### PR TITLE
fix: enforce Colima config validation for newly created profiles

### DIFF
--- a/scripts/workcell
+++ b/scripts/workcell
@@ -530,6 +530,7 @@ validate_colima_profile() {
     exit 2
   }
 
+  validate_colima_profile_config "${profile}" "${workspace}"
   validate_colima_runtime_mounts "${profile}" "${workspace}"
 }
 


### PR DESCRIPTION
### Motivation

- A recent refactor made `validate_colima_profile_config()` (which rejects `forwardAgent: true`) only run for preexisting Colima profiles, allowing newly created profiles to inherit `forwardAgent: true` from host defaults and expose SSH agent sockets across the VM/container boundary. 
- The change aims to ensure the SSH agent forwarding guardrail is enforced for every managed profile, including freshly created ones.

### Description

- Call `validate_colima_profile_config` from within `validate_colima_profile` so config-level checks (including the `forwardAgent` rejection) run for every started profile. 
- The insertion occurs before the runtime mount validation call in `validate_colima_profile`, ensuring config assertions are evaluated after `colima start` and before runtime mounts are inspected. 
- This is a minimal, behavior-preserving change that does not alter the existing stale-mount refresh or pre-start validation flow.

### Testing

- Ran `bash -n scripts/workcell` to verify the script parses without syntax errors and the change is syntactically valid (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1e1f52e7c8329b7f0c1746d9aa865)