### PR TITLE
fix: block combined git commit short options for no-verify

### DIFF
--- a/runtime/container/bin/git
+++ b/runtime/container/bin/git
@@ -295,7 +295,7 @@ for arg in "$@"; do
     hooks_path_bypass=1
   fi
 
-  if [[ "${subcommand}" == "commit" ]] && [[ "${arg}" == "-n" ]]; then
+  if [[ "${subcommand}" == "commit" ]] && [[ "${arg}" == -?* ]] && [[ "${arg}" != --* ]] && [[ "${arg#-}" == *n* ]]; then
     commit_short_bypass=1
   fi
 done

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -842,7 +842,11 @@ fn should_block(path: &str, args: &[String]) -> bool {
         }
     }
 
-    saw_commit && args.iter().skip(1).any(|arg| arg == "-n")
+    saw_commit
+        && args
+            .iter()
+            .skip(1)
+            .any(|arg| arg.starts_with('-') && !arg.starts_with("--") && arg[1..].contains('n'))
 }
 
 fn env_has_unsafe_git_override(env_entries: &[String]) -> bool {


### PR DESCRIPTION
### Motivation
- The git hook bypass guards only matched an exact `-n` token, allowing combined short-option bundles like `-nm` or `-anm` to bypass hook enforcement for `git commit`.
- Harden the wrapper and exec-guard logic to preserve the invariant that any single-dash option group containing `n` used with `commit` is treated as a hook-bypass attempt.

### Description
- Updated the Bash git wrapper to mark a `commit` argument as a bypass when an argument is a single-dash option group (matches `-?*`), is not a long option (`--*`), and the characters after the leading dash contain `n` (the check implemented as `[[ "${arg}" == -?* ]] && [[ "${arg}" != --* ]] && [[ "${arg#-}" == *n* ]]`).
- Updated the Rust exec guard's `should_block` logic to mirror the same behavior by checking for any `arg` that `starts_with('-') && !arg.starts_with("--") && arg[1..].contains('n')` when a `commit` subcommand was seen.

### Testing
- Ran shell syntax check with `bash -n runtime/container/bin/git`, which succeeded. 
- Ran the Rust library tests with `cd runtime/container/rust && cargo test --lib`, which completed successfully (no failing tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1e241539c8329ad4882173cba13c5)