### PR TITLE
fix: tighten audit retention and runtime safeguards

### DIFF
--- a/.github/workflows/hosted-controls.yml
+++ b/.github/workflows/hosted-controls.yml
@@ -1,0 +1,29 @@
+name: Hosted controls
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "23 5 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-hosted-controls:
+    name: Hosted controls verification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify GitHub-hosted controls
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/verify-github-hosted-controls.sh "${GITHUB_REPOSITORY}"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.pem
 *.key
 *.p12
+.workcell.remote.local
 
 .codex-local/
 .codex-state/

--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ Workcell surfaces that posture explicitly in the launch audit output.
 making you repeat `codex`, `claude`, or `gemini` yourself. `--agent-arg`
 values are still treated as ordinary user-supplied provider argv and go
 through the same in-container denylist as raw `-- ...` arguments.
+`--codex-rules-mutability readonly` is the clean-session default. That keeps
+Codex execpolicy rules immutable on the managed path until either
+`--agent-autonomy prompt` or a package-manager mutation has already lowered the
+live session. If you explicitly want session-local Codex execpolicy amendments
+to persist across nested Codex launches until container exit even on the yolo
+path, opt in with `--codex-rules-mutability session`. Workcell surfaces both
+the configured and effective Codex rules posture in launch audit output.
 `--injection-policy` lets you stage reviewed per-session inputs such as
 org-wide instructions, persistent provider credentials, SSH material, and
 read-only config files without passing through host homes or sockets. If
@@ -131,6 +138,22 @@ lower-assurance in-session downgrade: maintainer scripts run as root inside the
 mutable container, so Workcell warns, records the downgrade in runtime state,
 and keeps that warning attached to later provider launches until the container
 evaporates on exit.
+That lane also adds only the minimal Linux capabilities needed for Workcell’s
+root-to-runtime-user handoff inside the container:
+`SETUID` and `SETGID`.
+
+Choose the mutability lane explicitly:
+
+- `strict` + `--container-mutability ephemeral`: default DX lane,
+  `container_assurance=managed-mutable`. This allows transient package installs,
+  but a successful package mutation downgrades the live session to
+  `lower-assurance-package-mutation` until exit.
+- `strict` + `--container-mutability readonly`: strongest managed lane,
+  `container_assurance=managed-readonly`. Package-manager writes stay blocked,
+  so the in-session control-plane posture does not downgrade.
+- `--agent-autonomy prompt`: keeps the provider’s ordinary approval flow, but
+  Workcell surfaces that separately as
+  `autonomy_assurance=lower-assurance-prompt-autonomy`.
 
 By default, Workcell expects a git worktree and only forwards the selected
 provider command through the bounded runtime. Use `--allow-nongit-workspace`
@@ -152,6 +175,7 @@ Common recovery paths:
   `workcell --agent gemini --agent-arg --version --workspace /path/to/repo`
 - Conflicting unmanaged Colima profile:
   `workcell --repair-profile --agent codex --workspace /path/to/repo`
+  Replace `codex` with `claude` or `gemini` for the corresponding provider.
 
 `--repair-profile` deletes only the conflicting derived Colima profile so
 Workcell can recreate it with reviewed mounts and policy. On `strict`, it also
@@ -178,12 +202,14 @@ Workcell treats injected content as three separate classes:
 The immutable adapter baselines under `adapters/` are never mutated in place.
 Repo-local `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` are masked inside the
 workspace on the safe path and imported into the provider-native home docs
-instead. On the default `--agent-autonomy yolo` path, managed provider policy
-such as Codex `rules/default.rules` stays read-only inside the session. On the
-explicit lower-assurance `--agent-autonomy prompt` path, Workcell seeds a
-session-local writable copy of the Codex rules tree so provider-approved
-session amendments can persist across nested Codex launches until the container
-exits.
+instead. By default, Codex rules stay linked to the immutable adapter baseline
+until the session is already downgraded by package mutation or the operator has
+selected `--agent-autonomy prompt`. If you explicitly opt into
+`--codex-rules-mutability session`, or if prompt autonomy or package mutation
+has already lowered the session assurance, Workcell seeds a session-local
+writable copy of the Codex rules tree so provider-approved execpolicy
+amendments can persist across nested Codex launches until the container exits,
+while the immutable adapter baseline remains unchanged under `adapters/`.
 
 Example policy:
 
@@ -275,6 +301,9 @@ Intentional non-goals for the safe path:
   release assets against OpenAI's published Sigstore bundle
 - `scripts/verify-build-input-manifest.sh`: deterministic local verification
   for the release build-input manifest generator
+- `scripts/verify-coverage.sh`: `>=90%` numeric coverage for first-party Python
+  helpers and Rust launcher wrappers, with shell boundary code kept under
+  integration and mutation tests instead of a fake line-coverage target
 - `scripts/container-smoke.sh`: direct container build and adapter smoke tests
 - `scripts/verify-invariants.sh`: local invariant regression checks against the
   launcher and shipped adapter policy
@@ -282,16 +311,20 @@ Intentional non-goals for the safe path:
   runtime export verification under a fixed `SOURCE_DATE_EPOCH`
 - `scripts/verify-release-bundle.sh`: deterministic source bundle verification
   under a fixed `SOURCE_DATE_EPOCH`
-- `scripts/dev-remote-validate.sh`: stage the current working tree to a remote
-  amd64 builder such as `builder@bewear`, build an ephemeral remote helper
-  container there from `tools/remote-validator/Dockerfile`, and run
+- `scripts/dev-remote-validate.sh`: stage the current working tree to a private
+  remote amd64 builder, build an ephemeral remote helper container there from
+  `tools/remote-validator/Dockerfile`, and run
   `validate-repo`, `container-smoke`,
   `verify-reproducible-build`, and `verify-release-bundle` inside that
-  container as a single pre-push preflight. The default remote snapshot is the
-  local index; `--snapshot worktree` and `--include-untracked` are explicit
-  opt-ins. The remote reproducibility lane is intentionally native
-  `linux/amd64` only; the canonical multi-architecture release gate remains the
-  local macOS plus GitHub release path.
+  container as a single pre-push preflight. Set the builder explicitly with
+  `--host <user@host>` or `WORKCELL_REMOTE_VALIDATE_HOST`. The default remote
+  snapshot is the local index; `--snapshot worktree` and `--include-untracked`
+  are explicit opt-ins. For host-local defaults, point
+  `WORKCELL_REMOTE_VALIDATE_CONFIG_PATH` at a host-local config file or use the
+  default `~/.config/workcell/remote-validate.env`. The remote
+  reproducibility lane is intentionally native `linux/amd64` only; the
+  canonical multi-architecture release gate remains the local macOS plus GitHub
+  release path.
 
 Full Colima plus Virtualization.Framework boundary verification remains a local
 or self-hosted macOS exercise. GitHub-hosted CI validates the repo shape and
@@ -310,11 +343,13 @@ Recommended split:
   and parity aid, not as a provenance or multi-tenant isolation boundary.
 - GitHub CI and release: final policy, signing, attestations, and publication
 
-Each real launch appends a durable audit record under the managed Colima profile
-directory with the workspace, runtime profile, network mode, selected adapter,
-and whether the run stayed on the managed Tier 1 path or used an explicitly
-lower-assurance mode. `build` sessions additionally record when the temporary
-bootstrap allowlist was applied for image creation.
+Each real launch appends durable host-side audit events under the managed
+Colima profile directory. Those events record the workspace, runtime profile,
+network mode, selected adapter, launch-time assurance fields, whether the run
+stayed on the managed Tier 1 path or used an explicitly lower-assurance mode,
+and whether the session later downgraded itself through package mutation.
+`build` sessions additionally record when the temporary bootstrap allowlist was
+applied for image creation.
 
 ## Release posture
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -54,6 +54,9 @@ under platform automation.
   tooling, archived-source-tree image publication instead of live-worktree
   publication, and pinned GitHub Release publication instead of an ambient `gh`
   binary
+- `hosted-controls.yml`: live GitHub control-plane drift detection on `main`
+  pushes, schedule, and manual dispatch, using the same hosted-controls policy
+  that release preflight enforces before publish
 - `.github/dependabot.yml`: grouped weekly updates for GitHub Actions and the
   runtime base image, validator base image, pinned provider CLI dependency
   graph, and shipped Rust runtime crate, with cooldowns
@@ -92,9 +95,11 @@ of the reviewed control plane:
   `.github/workflows/`, `scripts/`, and the runtime boundary
 
 The repository includes [`scripts/verify-github-hosted-controls.sh`](../scripts/verify-github-hosted-controls.sh)
-to audit those hosted settings with the GitHub API. Tagged releases rerun that
-audit in release preflight before publish and refuse publication if the hosted
-controls drift.
+to audit those hosted settings with the GitHub API.
+[`hosted-controls.yml`](../.github/workflows/hosted-controls.yml) runs that
+audit continuously against the live repository, and tagged releases rerun it in
+release preflight before publish and refuse publication if the hosted controls
+drift.
 
 The current repository policy uses `release_environment.mode = "single-owner-private"`
 because this is a private single-owner repository. The audit enforces that as a

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -16,8 +16,12 @@ Workcell separates three planes:
 At provider launch, Workcell re-seeds the provider-facing home from the
 immutable baseline plus the staged operator input. Mutable provider state such
 as provider auth tokens stays session-local, not a write-back into the adapter
-baseline. Managed policy files such as Codex `rules/default.rules` stay
-read-only inside the session. The staged host bundle lives in a launcher-owned state
+baseline. By default, Codex rules remain linked to the immutable adapter
+baseline. If you explicitly opt into
+`--codex-rules-mutability session`, Workcell copies the Codex rules tree into a
+session-local writable tree so provider-approved execpolicy amendments can
+persist for the life of the container, while the adapter baseline remains
+immutable. The staged host bundle lives in a launcher-owned state
 directory under `~/.local/state/workcell/tmp`, is mounted read-only into the
 runtime, and is cleaned up on exit with dead-owner stale
 bundle garbage collection on later launches. Secret-bearing inputs are treated
@@ -125,4 +129,4 @@ Selectors let you scope injected material to only some launches:
 
 ## Example
 
-See [docs/examples/injection-policy.toml](/Users/omkharanarasaratnam/src/workcell/docs/examples/injection-policy.toml).
+See [`docs/examples/injection-policy.toml`](./examples/injection-policy.toml).

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -65,16 +65,18 @@ named network mode:
 - `breakglass`: unrestricted outbound access, explicitly chosen and acknowledged
 
 On the allowlist path, Workcell enforces reviewed destination-IP allowlists
-derived from the configured hostnames at launch time. It programs both IPv4
-and, when available in the VM, IPv6 rules; if IPv6 enforcement is unavailable,
-Workcell disables IPv6 rather than leaving an unmanaged parallel egress path.
+derived from the configured hostnames at launch time. It programs an IPv4
+allowlist and a deny-by-default IPv6 chain for every allowlist launch, adding
+explicit IPv6 allowlist entries when the resolved destination set is dual-stack.
+If `ip6tables` enforcement is unavailable in the VM, Workcell fails closed
+rather than silently downgrading to IPv4-only enforcement.
 The current enforcement model is not a hostname-aware proxy. `strict` does not
 perform cold image builds or rebuilds; runtime-image creation is an explicit
 `build`-mode operation that may temporarily apply a separate pinned bootstrap
 endpoint set before returning to the steady-state runtime allowlist. When the
 operator keeps the default `ephemeral` container mutability, the steady-state
 allowlist also includes the pinned Debian snapshot endpoints used by
-`apt`/`apt-get` so transient build tooling can be installed without enabling
+`apt` and `apt-get` so transient build tooling can be installed without enabling
 arbitrary distro mirrors. A successful package mutation is an explicit
 lower-assurance event for the live session because maintainer scripts run as
 root inside the mutable container. Workcell must warn when that happens and
@@ -100,7 +102,8 @@ runtimes or loaders that target them.
 If a workflow cannot preserve the Tier 1 guarantees, it must be labeled
 lower-assurance rather than presented as equivalent.
 That includes provider prompt-autonomy mode and any mutable session that has
-successfully performed package-manager mutations as root.
+successfully performed package-manager mutations as root. It also includes any
+session that explicitly opts into writable Codex execpolicy rules.
 
 ## Invariant 7: Autonomous runs remain auditable
 
@@ -112,11 +115,13 @@ reconstruct:
 - which network mode was applied
 - which provider adapter was selected
 - whether the run stayed on the managed Tier 1 path or used an explicitly
-  lower-assurance mode
+lower-assurance mode
 
 The reference launcher satisfies this by appending an operator-visible audit log
-entry under the managed Colima profile directory on each real launch.
-Injected secret values themselves are not part of that durable record.
+under the managed Colima profile directory on each real launch and exit,
+including package-mutation downgrade events inferred from host-captured runtime
+markers rather than mutable in-container state alone. Injected secret values
+themselves are not part of that durable record.
 
 ## Profile expectations
 
@@ -133,6 +138,21 @@ Injected secret values themselves are not part of that durable record.
   `ephemeral` container mutability is active
 - requires a prebuilt reviewed runtime image; `strict` does not rebuild or
   cold-bootstrap that image
+
+Assurance mapping within `strict`:
+
+- `ephemeral`: default DX lane, `container_assurance=managed-mutable`
+- `ephemeral` adds only the handoff capabilities required to move from root to
+  the mapped runtime user inside the container: `SETUID`, `SETGID`
+- `readonly`: strongest managed lane, `container_assurance=managed-readonly`
+- prompt autonomy: separate lower-assurance flag,
+  `autonomy_assurance=lower-assurance-prompt-autonomy`
+- session Codex rules mutability: explicit lower-assurance flag,
+  `codex_rules_assurance_effective_initial=lower-assurance-session-rules`
+- package mutation can also force this session-local copy for the remainder of
+  an already-downgraded container
+- successful package mutation: runtime downgrade to
+  `lower-assurance-package-mutation` until exit
 
 ### `build`
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -48,7 +48,8 @@ profile, or mount host state that should remain outside the trust boundary.
 ## Controls
 
 - dedicated Colima VM profile rather than the shared default profile
-- non-privileged inner container with `no-new-privileges`
+- inner container with `no-new-privileges`; mutable sessions add only
+  `SETUID` and `SETGID` to support the root-to-runtime-user handoff
 - explicit mount allowlist
 - Workcell profile split: `strict`, `build`, `breakglass`
 - disabled web search by default

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -45,6 +45,17 @@ or
 in the provider argv. These values are still validated as ordinary user-supplied
 provider arguments inside the managed runtime.
 .TP
+.B --codex-rules-mutability readonly|session
+Select Codex execpolicy mutability. The default is
+.BR readonly ,
+which keeps Codex rules linked to the immutable adapter baseline on the managed
+path until the session is already downgraded by package mutation or prompt
+autonomy. Use
+.BR session
+only when you explicitly want session-local Codex execpolicy amendments to
+persist across nested Codex launches until container exit. That is surfaced as
+.BR codex_rules_assurance_effective_initial=lower-assurance-session-rules .
+.TP
 .B --container-mutability ephemeral|readonly
 Select whether the inner runtime root filesystem is writable but session-local
 .RB ( ephemeral )
@@ -64,6 +75,31 @@ Successful package mutations are treated as a lower-assurance in-session
 downgrade because maintainer scripts run as root inside the mutable container;
 Workcell warns when that happens and keeps the downgrade visible until the
 container exits.
+This lane adds only the minimal Linux capabilities required for the
+root-to-runtime-user handoff inside the container:
+.BR SETUID
+and
+.BR SETGID .
+.RS
+.TP
+.B strict + ephemeral
+Default developer path with
+.BR container_assurance=managed-mutable .
+This allows transient package installs, but a successful package mutation
+downgrades the live session to
+.BR lower-assurance-package-mutation
+until exit.
+.TP
+.B strict + readonly
+Strongest managed path with
+.BR container_assurance=managed-readonly .
+Package-manager writes stay blocked, so the in-session control-plane posture
+does not downgrade.
+.TP
+.B --agent-autonomy prompt
+Keeps the provider's approval flow, but Workcell surfaces that separately as
+.BR autonomy_assurance=lower-assurance-prompt-autonomy .
+.RE
 .TP
 .B --container-cpu COUNT
 Set an explicit CPU limit for the inner runtime container.
@@ -242,15 +278,15 @@ are never mutated in place. Repo-local
 and
 .BR GEMINI.md
 are masked inside the workspace and imported into the provider home docs
-instead. On the default
-.B --agent-autonomy yolo
-path, managed provider policy such as Codex
-.I rules/default.rules
-stays read-only inside the session. On the explicit lower-assurance
-.B --agent-autonomy prompt
-path, Workcell seeds a session-local writable copy of the Codex rules tree so
+instead. By default, Codex rules stay linked to the immutable adapter baseline
+until prompt autonomy or package mutation has already downgraded the session.
+If you explicitly opt into
+.B --codex-rules-mutability session
+Workcell seeds a session-local writable copy of the Codex rules tree so
 provider-approved session amendments can persist across nested Codex launches
-until the container exits.
+until the container exits, while the immutable adapter baseline under
+.I adapters/
+remains unchanged.
 Reusable provider and GitHub auth should go through
 .BR [credentials]
 in the injection policy rather than generic copied files.
@@ -299,6 +335,14 @@ If Workcell reports an unmanaged Colima profile, rerun with:
 .EX
 workcell --repair-profile --agent codex --workspace /path/to/repo
 .EE
+.PP
+Replace
+.B codex
+with
+.B claude
+or
+.B gemini
+for the corresponding provider.
 .SH EXIT STATUS
 The command exits non-zero on validation failures, unsupported modes, missing
 dependencies, or runtime launch errors.

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -7,3 +7,12 @@
 # - "single-owner-private": allow a private single-owner repo to use the
 #   release environment without a reviewer gate
 mode = "single-owner-private"
+
+[required_status_checks]
+contexts = [
+  "Validate repository",
+  "Container smoke",
+  "Reproducible build",
+  "GitHub Actions lint",
+  "GitHub Actions security analysis",
+]

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -134,6 +134,7 @@ COPY runtime/container/bin/node /usr/local/libexec/workcell/node-wrapper.sh
 COPY runtime/container/bin/apt-helper.sh /usr/local/libexec/workcell/apt-helper.sh
 COPY runtime/container/bin/apt-wrapper.sh /usr/local/libexec/workcell/apt-wrapper.sh
 COPY runtime/container/rust /workcell-rust
+COPY runtime/container/assurance.sh /usr/local/libexec/workcell/assurance.sh
 COPY runtime/container/provider-policy.sh /usr/local/libexec/workcell/provider-policy.sh
 COPY runtime/container/home-control-plane.sh /usr/local/libexec/workcell/home-control-plane.sh
 COPY runtime/container/provider-wrapper.sh /usr/local/libexec/workcell/provider-wrapper.sh
@@ -158,6 +159,7 @@ RUN cd /workcell-rust \
   && printf '/usr/local/lib/libworkcell_exec_guard.so\n' > /etc/ld.so.preload \
   && chmod 0444 /etc/claude-code/managed-settings.json \
   && chmod 0444 \
+    /usr/local/libexec/workcell/assurance.sh \
     /usr/local/libexec/workcell/apt-wrapper.sh \
     /usr/local/libexec/workcell/apt-helper.sh \
     /usr/local/libexec/workcell/entrypoint.sh \
@@ -167,6 +169,7 @@ RUN cd /workcell-rust \
     /usr/local/libexec/workcell/runtime-user.sh \
   && chmod +x \
     /usr/local/libexec/workcell/core/launcher \
+    /usr/local/libexec/workcell/assurance.sh \
     /usr/local/libexec/workcell/apt-wrapper.sh \
     /usr/local/libexec/workcell/apt-helper.sh \
     /usr/local/libexec/workcell/home-control-plane.sh \

--- a/runtime/container/assurance.sh
+++ b/runtime/container/assurance.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# shellcheck shell=bash
+
+workcell_container_assurance() {
+  local mutability="${1:-}"
+
+  case "${mutability}" in
+    readonly)
+      printf 'managed-readonly\n'
+      ;;
+    ephemeral)
+      printf 'managed-mutable\n'
+      ;;
+    *)
+      echo "Unsupported Workcell container mutability for assurance mapping: ${mutability}" >&2
+      return 1
+      ;;
+  esac
+}
+
+workcell_autonomy_assurance() {
+  local autonomy="${1:-}"
+
+  case "${autonomy}" in
+    yolo)
+      printf 'managed-yolo\n'
+      ;;
+    prompt)
+      printf 'lower-assurance-prompt-autonomy\n'
+      ;;
+    *)
+      echo "Unsupported Workcell agent autonomy for assurance mapping: ${autonomy}" >&2
+      return 1
+      ;;
+  esac
+}
+
+workcell_codex_rules_assurance() {
+  local mutability="${1:-}"
+
+  case "${mutability}" in
+    readonly | "")
+      printf 'managed-immutable-rules\n'
+      ;;
+    session)
+      printf 'lower-assurance-session-rules\n'
+      ;;
+    *)
+      echo "Unsupported Workcell Codex rules mutability for assurance mapping: ${mutability}" >&2
+      return 1
+      ;;
+  esac
+}
+
+workcell_effective_codex_rules_mutability() {
+  local configured_mutability="${1:-readonly}"
+  local autonomy="${2:-yolo}"
+  local session_assurance="${3:-}"
+
+  case "${configured_mutability}" in
+    "" | readonly | session) ;;
+    *)
+      echo "Unsupported Workcell Codex rules mutability for effective mapping: ${configured_mutability}" >&2
+      return 1
+      ;;
+  esac
+
+  case "${autonomy}" in
+    "" | yolo | prompt) ;;
+    *)
+      echo "Unsupported Workcell agent autonomy for effective Codex rules mapping: ${autonomy}" >&2
+      return 1
+      ;;
+  esac
+
+  if [[ "${configured_mutability}" == "session" ]]; then
+    printf 'session\n'
+    return 0
+  fi
+
+  if [[ "${autonomy}" == "prompt" ]]; then
+    printf 'session\n'
+    return 0
+  fi
+
+  if [[ "${session_assurance}" == "lower-assurance-package-mutation" ]]; then
+    printf 'session\n'
+    return 0
+  fi
+
+  printf 'readonly\n'
+}
+
+workcell_effective_codex_rules_assurance() {
+  local effective_mutability=""
+
+  effective_mutability="$(workcell_effective_codex_rules_mutability "$@")" || return 1
+  workcell_codex_rules_assurance "${effective_mutability}"
+}

--- a/runtime/container/bin/apt-helper.sh
+++ b/runtime/container/bin/apt-helper.sh
@@ -76,6 +76,9 @@ workcell_validate_apt_args() {
 
 workcell_mark_lower_assurance_session() {
   mkdir -p "${WORKCELL_RUNTIME_STATE_DIR}"
+  if [[ -e "${WORKCELL_RUNTIME_ASSURANCE_FILE}" ]]; then
+    chmod u+w "${WORKCELL_RUNTIME_ASSURANCE_FILE}"
+  fi
   printf '%s\n' "lower-assurance-package-mutation" >"${WORKCELL_RUNTIME_ASSURANCE_FILE}"
   chmod 0444 "${WORKCELL_RUNTIME_ASSURANCE_FILE}"
 }
@@ -118,5 +121,6 @@ fi
 
 if [[ "${mutates_packages}" -eq 1 ]]; then
   workcell_mark_lower_assurance_session
+  echo "WORKCELL_EVENT package-mutation assurance=lower-assurance-package-mutation" >&2
   echo "Workcell note: this session is now lower-assurance until the container exits." >&2
 fi

--- a/runtime/container/bin/apt-wrapper.sh
+++ b/runtime/container/bin/apt-wrapper.sh
@@ -21,14 +21,14 @@ if [[ ! -x "${real_command}" ]]; then
   exit 127
 fi
 
-if [[ "$(id -u)" == "0" ]]; then
-  exec "${real_command}" "$@"
-fi
-
 if [[ "${mutability}" != "ephemeral" ]]; then
   echo "Workcell blocked ${command_name}: readonly container mutability is active." >&2
   echo "Relaunch with --container-mutability ephemeral to allow ephemeral package-manager writes." >&2
   exit 2
+fi
+
+if [[ "$(id -u)" == "0" ]]; then
+  exec "${real_command}" "$@"
 fi
 
 if [[ ! -x "${helper_command}" ]]; then

--- a/runtime/container/entrypoint.sh
+++ b/runtime/container/entrypoint.sh
@@ -13,6 +13,9 @@ WORKSPACE="${WORKSPACE:-/workspace}"
 export ADAPTER_ROOT="/opt/workcell/adapters"
 
 # shellcheck disable=SC1091
+# shellcheck source=assurance.sh
+source /usr/local/libexec/workcell/assurance.sh
+# shellcheck disable=SC1091
 # shellcheck source=provider-policy.sh
 source /usr/local/libexec/workcell/provider-policy.sh
 # shellcheck disable=SC1091
@@ -25,17 +28,20 @@ source /usr/local/libexec/workcell/runtime-user.sh
 emit_session_assurance_notice() {
   local assurance=""
 
+  if [[ "${WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED:-0}" == "1" ]]; then
+    return 0
+  fi
+
   assurance="$(workcell_runtime_state_value WORKCELL_SESSION_ASSURANCE || true)"
   case "${assurance}" in
     lower-assurance-package-mutation)
       echo "Workcell warning: this session previously ran package-manager mutations as root. In-container control-plane integrity is now lower-assurance until container exit." >&2
+      export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1
       ;;
   esac
 }
 
 umask 077
-mkdir -p "${HOME}"
-mkdir -p "${TMPDIR}"
 
 if [[ "$$" -ne 1 ]]; then
   pid1_comm="$(tr -d '\n' </proc/1/comm 2>/dev/null || true)"
@@ -73,6 +79,9 @@ fi
 if workcell_should_reexec_as_runtime_user; then
   workcell_reexec_as_runtime_user /usr/local/libexec/workcell/entrypoint.sh "$@"
 fi
+
+mkdir -p "${HOME}"
+mkdir -p "${TMPDIR}"
 
 seed_agent_home "${AGENT_NAME}"
 emit_session_assurance_notice

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
 
+# shellcheck disable=SC1091
+source /usr/local/libexec/workcell/assurance.sh
+
 workcell_link_control_plane_path() {
   local source_path="$1"
   local target_path="$2"
@@ -25,6 +28,15 @@ workcell_copy_control_plane_tree() {
 }
 
 WORKCELL_WORKSPACE_IMPORT_ROOT="${WORKCELL_WORKSPACE_IMPORT_ROOT:-/opt/workcell/workspace-control-plane}"
+WORKCELL_CODEX_RULES_MUTABILITY="${WORKCELL_CODEX_RULES_MUTABILITY:-readonly}"
+
+workcell_session_assurance() {
+  workcell_runtime_state_value WORKCELL_SESSION_ASSURANCE || true
+}
+
+workcell_current_agent_autonomy() {
+  workcell_runtime_state_value WORKCELL_AGENT_AUTONOMY || printf '%s\n' "${WORKCELL_AGENT_AUTONOMY:-yolo}"
+}
 
 workcell_assert_session_regular_writable_file() {
   local target_path="$1"
@@ -41,19 +53,67 @@ workcell_assert_session_regular_writable_file() {
   fi
 }
 
-workcell_assert_codex_execpolicy_baseline() {
-  local rules_dir="${CODEX_HOME}/rules"
-  local rules_path="${rules_dir}/default.rules"
+workcell_codex_rules_mutability() {
+  case "${WORKCELL_CODEX_RULES_MUTABILITY:-readonly}" in
+    readonly | session)
+      printf '%s\n' "${WORKCELL_CODEX_RULES_MUTABILITY:-readonly}"
+      ;;
+    *)
+      workcell_die "Unsupported Workcell Codex rules mutability: ${WORKCELL_CODEX_RULES_MUTABILITY}"
+      ;;
+  esac
+}
 
-  if [[ ! -d "${rules_dir}" ]]; then
-    workcell_die "Workcell failed to seed Codex execpolicy baseline: missing directory ${rules_dir}"
+workcell_codex_rules_promoted_for_session_assurance() {
+  local configured_mutability=""
+  local assurance=""
+
+  configured_mutability="$(workcell_codex_rules_mutability)"
+  assurance="$(workcell_session_assurance)"
+  [[ "${configured_mutability}" == "readonly" ]] &&
+    [[ "${assurance}" == "lower-assurance-package-mutation" ]]
+}
+
+workcell_codex_rules_promoted_for_prompt_autonomy() {
+  local configured_mutability=""
+  local autonomy=""
+
+  configured_mutability="$(workcell_codex_rules_mutability)"
+  autonomy="$(workcell_current_agent_autonomy)"
+  [[ "${configured_mutability}" == "readonly" ]] &&
+    [[ "${autonomy}" == "prompt" ]]
+}
+
+workcell_codex_rules_effective_reason() {
+  local configured_mutability=""
+  local autonomy=""
+  local assurance=""
+
+  configured_mutability="$(workcell_codex_rules_mutability)"
+  autonomy="$(workcell_current_agent_autonomy)"
+  assurance="$(workcell_session_assurance)"
+
+  if [[ "${configured_mutability}" == "session" ]]; then
+    printf 'operator-opt-in\n'
+    return 0
   fi
-  if [[ ! -f "${rules_path}" ]]; then
-    workcell_die "Workcell failed to seed Codex execpolicy baseline: missing file ${rules_path}"
+  if [[ "${autonomy}" == "prompt" ]]; then
+    printf 'prompt-autonomy\n'
+    return 0
   fi
-  if [[ -w "${rules_path}" ]]; then
-    workcell_die "Workcell failed to seed Codex execpolicy baseline: managed rules must remain read-only: ${rules_path}"
+  if [[ "${assurance}" == "lower-assurance-package-mutation" ]]; then
+    printf 'package-mutation\n'
+    return 0
   fi
+
+  printf 'managed-default\n'
+}
+
+workcell_current_effective_codex_rules_mutability() {
+  workcell_effective_codex_rules_mutability \
+    "$(workcell_codex_rules_mutability)" \
+    "$(workcell_current_agent_autonomy)" \
+    "$(workcell_session_assurance)"
 }
 
 workcell_manifest_active() {
@@ -322,17 +382,20 @@ workcell_seed_codex_rules() {
   local baseline_rules="${ADAPTER_ROOT}/codex/.codex/rules"
   local rules_target="${CODEX_HOME}/rules"
   local default_rules_target="${rules_target}/default.rules"
+  local rules_mutability=""
 
-  if [[ "${WORKCELL_AGENT_AUTONOMY:-yolo}" == "prompt" ]]; then
-    if [[ ! -d "${rules_target}" ]] || [[ -L "${rules_target}" ]] || [[ ! -f "${default_rules_target}" ]]; then
-      workcell_copy_control_plane_tree "${baseline_rules}" "${rules_target}" 0600 0700
-    fi
-    workcell_assert_session_regular_writable_file "${default_rules_target}" "Codex execpolicy session rules"
-    return 0
-  fi
-
-  workcell_link_control_plane_path "${baseline_rules}" "${rules_target}"
-  workcell_assert_codex_execpolicy_baseline
+  rules_mutability="$(workcell_current_effective_codex_rules_mutability)"
+  case "${rules_mutability}" in
+    readonly)
+      workcell_link_control_plane_path "${baseline_rules}" "${rules_target}"
+      ;;
+    session)
+      if [[ ! -d "${rules_target}" ]] || [[ -L "${rules_target}" ]] || [[ ! -f "${default_rules_target}" ]]; then
+        workcell_copy_control_plane_tree "${baseline_rules}" "${rules_target}" 0600 0700
+      fi
+      workcell_assert_session_regular_writable_file "${default_rules_target}" "Codex execpolicy session rules"
+      ;;
+  esac
 }
 
 workcell_apply_manifest_copies() {

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -54,14 +54,51 @@ sanitize_provider_env() {
 emit_session_assurance_notice() {
   local assurance=""
 
+  if [[ "${WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED:-0}" == "1" ]]; then
+    return 0
+  fi
+
   assurance="$(workcell_runtime_state_value WORKCELL_SESSION_ASSURANCE || true)"
   case "${assurance}" in
     lower-assurance-package-mutation)
       echo "Workcell warning: this session previously ran package-manager mutations as root. In-container control-plane integrity is now lower-assurance until container exit." >&2
+      export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1
       ;;
   esac
 }
 
+emit_codex_rules_mutability_notice() {
+  local configured_mutability=""
+  local effective_mutability=""
+  local effective_reason=""
+
+  if [[ "${AGENT_NAME}" != "codex" ]]; then
+    return 0
+  fi
+
+  configured_mutability="$(workcell_codex_rules_mutability)"
+  effective_mutability="$(workcell_current_effective_codex_rules_mutability)"
+  effective_reason="$(workcell_codex_rules_effective_reason)"
+
+  if [[ "${effective_mutability}" == "${configured_mutability}" ]]; then
+    return 0
+  fi
+
+  case "${effective_reason}" in
+    prompt-autonomy)
+      echo "Workcell note: Codex prompt autonomy uses session-local execpolicy rules until this container exits." >&2
+      echo "WORKCELL_EVENT codex-rules-mutability effective=session reason=prompt-autonomy" >&2
+      ;;
+    package-mutation)
+      echo "Workcell warning: package-manager mutation forced session-local Codex execpolicy rules for the remainder of this already-lower-assurance session." >&2
+      echo "WORKCELL_EVENT codex-rules-mutability effective=session reason=package-mutation" >&2
+      ;;
+  esac
+}
+
+# shellcheck disable=SC1091
+# shellcheck source=assurance.sh
+source /usr/local/libexec/workcell/assurance.sh
 # shellcheck disable=SC1091
 # shellcheck source=provider-policy.sh
 source /usr/local/libexec/workcell/provider-policy.sh
@@ -80,6 +117,7 @@ if workcell_should_reexec_as_runtime_user; then
 fi
 seed_agent_home "${AGENT_NAME}"
 emit_session_assurance_notice
+emit_codex_rules_mutability_notice
 
 codex_args_include_profile() {
   local arg=""

--- a/runtime/container/runtime-user.sh
+++ b/runtime/container/runtime-user.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
 
+# shellcheck disable=SC1091
+# shellcheck source=assurance.sh
+source /usr/local/libexec/workcell/assurance.sh
+
 WORKCELL_RUNTIME_STATE_DIR="/run/workcell"
 WORKCELL_RUNTIME_MUTABILITY_FILE="${WORKCELL_RUNTIME_STATE_DIR}/container-mutability"
 WORKCELL_RUNTIME_MODE_FILE="${WORKCELL_RUNTIME_STATE_DIR}/mode"
@@ -183,21 +187,25 @@ workcell_prepare_runtime_identity() {
   workcell_append_shadow_entry "${user_name}"
 
   mkdir -p /etc/sudoers.d
+  if [[ -e /etc/sudoers.d/workcell-runtime-user ]]; then
+    chmod u+w /etc/sudoers.d/workcell-runtime-user
+  fi
   printf '%s ALL=(root) NOPASSWD: /usr/local/libexec/workcell/apt-helper.sh\n' "${user_name}" >/etc/sudoers.d/workcell-runtime-user
   chmod 0440 /etc/sudoers.d/workcell-runtime-user
 
   printf '%s\n' "${user_name}"
 }
 
-workcell_prepare_runtime_state_ownership() {
-  local uid="$1"
-  local gid="$2"
+workcell_write_readonly_state_file() {
+  local path="$1"
+  local value="$2"
 
-  mkdir -p "${HOME}" "${TMPDIR}"
-  chown -R "${uid}:${gid}" "${HOME}" "${TMPDIR}"
-  if [[ -d /state/injected ]]; then
-    chown -R "${uid}:${gid}" /state/injected
+  mkdir -p "$(dirname "${path}")"
+  if [[ -e "${path}" ]]; then
+    chmod u+w "${path}"
   fi
+  printf '%s\n' "${value}" >"${path}"
+  chmod 0444 "${path}"
 }
 
 workcell_write_runtime_state() {
@@ -205,31 +213,21 @@ workcell_write_runtime_state() {
   local mode=""
   local profile=""
   local autonomy=""
-  local assurance=""
+  local session_assurance=""
 
   mutability="$(workcell_runtime_mutability)"
   mode="${WORKCELL_MODE:-${CODEX_PROFILE:-strict}}"
   profile="${CODEX_PROFILE:-${mode}}"
   autonomy="${WORKCELL_AGENT_AUTONOMY:-yolo}"
-  assurance="managed-readonly"
-  if [[ "${autonomy}" == "prompt" ]]; then
-    assurance="lower-assurance-prompt-autonomy"
-  elif [[ "${mutability}" == "ephemeral" ]]; then
-    assurance="managed-mutable"
-  fi
+  session_assurance="$(workcell_container_assurance "${mutability}")"
   mkdir -p "${WORKCELL_RUNTIME_STATE_DIR}"
   chmod 0755 "${WORKCELL_RUNTIME_STATE_DIR}"
-  printf '%s\n' "${mutability}" >"${WORKCELL_RUNTIME_MUTABILITY_FILE}"
-  chmod 0444 "${WORKCELL_RUNTIME_MUTABILITY_FILE}"
-  printf '%s\n' "${mode}" >"${WORKCELL_RUNTIME_MODE_FILE}"
-  chmod 0444 "${WORKCELL_RUNTIME_MODE_FILE}"
-  printf '%s\n' "${profile}" >"${WORKCELL_RUNTIME_PROFILE_FILE}"
-  chmod 0444 "${WORKCELL_RUNTIME_PROFILE_FILE}"
-  printf '%s\n' "${autonomy}" >"${WORKCELL_RUNTIME_AUTONOMY_FILE}"
-  chmod 0444 "${WORKCELL_RUNTIME_AUTONOMY_FILE}"
+  workcell_write_readonly_state_file "${WORKCELL_RUNTIME_MUTABILITY_FILE}" "${mutability}"
+  workcell_write_readonly_state_file "${WORKCELL_RUNTIME_MODE_FILE}" "${mode}"
+  workcell_write_readonly_state_file "${WORKCELL_RUNTIME_PROFILE_FILE}" "${profile}"
+  workcell_write_readonly_state_file "${WORKCELL_RUNTIME_AUTONOMY_FILE}" "${autonomy}"
   if [[ ! -e "${WORKCELL_RUNTIME_ASSURANCE_FILE}" ]]; then
-    printf '%s\n' "${assurance}" >"${WORKCELL_RUNTIME_ASSURANCE_FILE}"
-    chmod 0444 "${WORKCELL_RUNTIME_ASSURANCE_FILE}"
+    workcell_write_readonly_state_file "${WORKCELL_RUNTIME_ASSURANCE_FILE}" "${session_assurance}"
   fi
 }
 
@@ -279,7 +277,6 @@ workcell_reexec_as_runtime_user() {
   gid="$(workcell_runtime_host_gid)"
   user_name="$(workcell_prepare_runtime_identity)"
   workcell_write_runtime_state
-  workcell_prepare_runtime_state_ownership "${uid}" "${gid}"
   export USER="${user_name}"
   export LOGNAME="${user_name}"
 

--- a/runtime/container/rust/src/bin/workcell-git-launcher.rs
+++ b/runtime/container/rust/src/bin/workcell-git-launcher.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::ffi::CString;
+use std::ffi::{CString, OsString};
 use std::os::raw::c_char;
 use std::process;
 
@@ -10,6 +10,16 @@ unsafe extern "C" {
 const BASH_PATH: &str = "/bin/bash";
 const TARGET_NAME: &str = "git";
 const SCRIPT_PATH: &str = "/usr/local/libexec/workcell/git-wrapper.sh";
+
+#[derive(Debug)]
+struct LaunchRequest {
+    exec_args: Vec<CString>,
+}
+
+#[derive(Debug)]
+enum LaunchError {
+    NulArgument,
+}
 
 fn sanitize_env() {
     for key in [
@@ -27,43 +37,131 @@ fn sanitize_env() {
     }
 }
 
-fn main() {
-    let args: Vec<CString> = env::args_os()
-        .skip(1)
-        .map(|arg| CString::new(arg.as_encoded_bytes()).map_err(|_| ()))
-        .collect::<Result<_, _>>()
-        .unwrap_or_else(|_| {
-            eprintln!("Workcell launcher argument contained a NUL byte.");
-            process::exit(126);
-        });
+fn build_exec_args(args: Vec<OsString>) -> Result<Vec<CString>, LaunchError> {
+    let mut exec_args = Vec::new();
+    exec_args.push(CString::new(BASH_PATH).expect("static bash path"));
+    exec_args.push(CString::new(SCRIPT_PATH).expect("static script path"));
+    for arg in args {
+        exec_args.push(CString::new(arg.as_encoded_bytes()).map_err(|_| LaunchError::NulArgument)?);
+    }
+    Ok(exec_args)
+}
 
-    sanitize_env();
-    env::set_var("WORKCELL_LAUNCH_TARGET", TARGET_NAME);
+fn prepare_launch(args: Vec<OsString>) -> Result<LaunchRequest, LaunchError> {
+    Ok(LaunchRequest {
+        exec_args: build_exec_args(args)?,
+    })
+}
 
-    let bash_path = CString::new(BASH_PATH).expect("static bash path");
-    let script_path = CString::new(SCRIPT_PATH).expect("static script path");
+fn format_launch_error(error: LaunchError) -> String {
+    match error {
+        LaunchError::NulArgument => "Workcell launcher argument contained a NUL byte.".to_string(),
+    }
+}
 
-    let mut exec_args = Vec::with_capacity(args.len() + 2);
-    exec_args.push(bash_path.clone());
-    exec_args.push(script_path.clone());
-    exec_args.extend(args);
+fn exit_code_for_errno(errno: i32) -> i32 {
+    if errno == libc::ENOENT {
+        127
+    } else {
+        126
+    }
+}
 
-    let mut argv: Vec<*const c_char> = exec_args.iter().map(|arg| arg.as_ptr()).collect();
+fn format_exec_error(errno: i32) -> String {
+    format!(
+        "execve({}, {}): {}",
+        BASH_PATH,
+        SCRIPT_PATH,
+        std::io::Error::from_raw_os_error(errno)
+    )
+}
+
+fn exec_request(request: &LaunchRequest) -> i32 {
+    let mut argv: Vec<*const c_char> = request.exec_args.iter().map(|arg| arg.as_ptr()).collect();
     argv.push(std::ptr::null());
 
-    let rc = unsafe { libc::execve(bash_path.as_ptr(), argv.as_ptr(), environ.cast()) };
+    let rc = unsafe { libc::execve(request.exec_args[0].as_ptr(), argv.as_ptr(), environ.cast()) };
     let errno = std::io::Error::last_os_error()
         .raw_os_error()
         .unwrap_or(libc::ENOENT);
 
     if rc != 0 {
-        eprintln!(
-            "execve({}, {}): {}",
-            BASH_PATH,
-            SCRIPT_PATH,
-            std::io::Error::from_raw_os_error(errno)
+        eprintln!("{}", format_exec_error(errno));
+    }
+
+    exit_code_for_errno(errno)
+}
+
+fn main() {
+    let args: Vec<OsString> = env::args_os().skip(1).collect();
+    let request = prepare_launch(args).unwrap_or_else(|error| {
+        eprintln!("{}", format_launch_error(error));
+        process::exit(126);
+    });
+
+    sanitize_env();
+    env::set_var("WORKCELL_LAUNCH_TARGET", TARGET_NAME);
+    process::exit(exec_request(&request));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::ffi::OsStringExt;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn sanitize_env_clears_sensitive_loader_and_node_state() {
+        let _guard = env_lock().lock().expect("env lock");
+        env::set_var("BASH_ENV", "/tmp/bashenv");
+        env::set_var("LD_PRELOAD", "/tmp/preload.so");
+        env::set_var("NODE_OPTIONS", "--inspect");
+
+        sanitize_env();
+
+        assert!(env::var_os("BASH_ENV").is_none());
+        assert!(env::var_os("LD_PRELOAD").is_none());
+        assert!(env::var_os("NODE_OPTIONS").is_none());
+    }
+
+    #[test]
+    fn prepare_launch_builds_exec_args_and_rejects_nul_bytes() {
+        let request = prepare_launch(vec![OsString::from("--version")]).expect("prepare launch");
+        assert_eq!(request.exec_args[0].as_bytes(), BASH_PATH.as_bytes());
+        assert_eq!(request.exec_args[1].as_bytes(), SCRIPT_PATH.as_bytes());
+        assert_eq!(request.exec_args[2].as_bytes(), b"--version");
+
+        let invalid = OsString::from_vec(b"gi\0t".to_vec());
+        let err = prepare_launch(vec![invalid]).expect_err("nul args should fail");
+        assert_eq!(
+            format_launch_error(err),
+            "Workcell launcher argument contained a NUL byte."
         );
     }
 
-    process::exit(if errno == libc::ENOENT { 127 } else { 126 });
+    #[test]
+    fn exec_failure_helpers_format_messages_and_exit_codes() {
+        assert_eq!(exit_code_for_errno(libc::ENOENT), 127);
+        assert_eq!(exit_code_for_errno(libc::EACCES), 126);
+        let message = format_exec_error(libc::ENOENT);
+        assert!(message.contains("execve(/bin/bash, /usr/local/libexec/workcell/git-wrapper.sh):"));
+    }
+
+    #[test]
+    fn exec_request_returns_failure_code_when_shell_is_unavailable() {
+        let request = LaunchRequest {
+            exec_args: vec![
+                CString::new("/definitely/missing/bash").expect("missing bash path"),
+                CString::new(SCRIPT_PATH).expect("script path"),
+                CString::new("--version").expect("version arg"),
+            ],
+        };
+
+        assert_eq!(exec_request(&request), 127);
+    }
 }

--- a/runtime/container/rust/src/bin/workcell-launcher.rs
+++ b/runtime/container/rust/src/bin/workcell-launcher.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::ffi::{CString, OsStr};
+use std::ffi::{CString, OsStr, OsString};
 use std::os::raw::c_char;
 use std::os::unix::ffi::OsStrExt;
 use std::process;
@@ -21,6 +21,19 @@ const LAUNCH_TARGETS: &[(&str, &str)] = &[
     ("claude", "/usr/local/libexec/workcell/provider-wrapper.sh"),
     ("gemini", "/usr/local/libexec/workcell/provider-wrapper.sh"),
 ];
+
+#[derive(Debug)]
+struct LaunchRequest {
+    target_name: &'static str,
+    script_path: &'static str,
+    exec_args: Vec<CString>,
+}
+
+#[derive(Debug)]
+enum LaunchError {
+    UnsupportedTarget(String),
+    NulArgument,
+}
 
 fn sanitize_env() {
     for key in [
@@ -52,50 +65,202 @@ fn lookup_target(argv0: &OsStr) -> Option<(&'static str, &'static str)> {
         .copied()
 }
 
-fn main() {
-    let mut args = env::args_os();
-    let argv0 = args.next().unwrap_or_else(|| OsStr::new("").to_owned());
-    let Some((target_name, script_path)) = lookup_target(&argv0) else {
-        eprintln!(
-            "Unsupported Workcell launcher target: {}",
-            argv0.to_string_lossy()
-        );
-        process::exit(126);
+fn build_exec_args(
+    script_path: &'static str,
+    args: Vec<OsString>,
+) -> Result<Vec<CString>, LaunchError> {
+    let mut exec_args = Vec::new();
+    exec_args.push(CString::new(BASH_PATH).expect("static bash path"));
+    exec_args.push(CString::new(script_path).expect("static script path"));
+    for arg in args {
+        exec_args.push(osstr_to_cstring(&arg).map_err(|_| LaunchError::NulArgument)?);
+    }
+    Ok(exec_args)
+}
+
+fn prepare_launch(argv0: &OsStr, args: Vec<OsString>) -> Result<LaunchRequest, LaunchError> {
+    let Some((target_name, script_path)) = lookup_target(argv0) else {
+        return Err(LaunchError::UnsupportedTarget(
+            argv0.to_string_lossy().into_owned(),
+        ));
     };
 
-    sanitize_env();
-    env::set_var("WORKCELL_LAUNCH_TARGET", target_name);
+    Ok(LaunchRequest {
+        target_name,
+        script_path,
+        exec_args: build_exec_args(script_path, args)?,
+    })
+}
 
-    let bash_path = CString::new(BASH_PATH).expect("static bash path");
-    let script_path = CString::new(script_path).expect("static script path");
-
-    let mut exec_args = Vec::new();
-    exec_args.push(bash_path.clone());
-    exec_args.push(script_path.clone());
-    for arg in args {
-        let Ok(arg) = osstr_to_cstring(&arg) else {
-            eprintln!("Workcell launcher argument contained a NUL byte.");
-            process::exit(126);
-        };
-        exec_args.push(arg);
+fn format_launch_error(error: LaunchError) -> String {
+    match error {
+        LaunchError::UnsupportedTarget(target) => {
+            format!("Unsupported Workcell launcher target: {target}")
+        }
+        LaunchError::NulArgument => "Workcell launcher argument contained a NUL byte.".to_string(),
     }
+}
 
-    let mut argv: Vec<*const c_char> = exec_args.iter().map(|arg| arg.as_ptr()).collect();
+fn exit_code_for_errno(errno: i32) -> i32 {
+    if errno == libc::ENOENT {
+        127
+    } else {
+        126
+    }
+}
+
+fn format_exec_error(script_path: &str, errno: i32) -> String {
+    format!(
+        "execve({}, {}): {}",
+        BASH_PATH,
+        script_path,
+        std::io::Error::from_raw_os_error(errno)
+    )
+}
+
+fn exec_request(request: &LaunchRequest) -> i32 {
+    let mut argv: Vec<*const c_char> = request.exec_args.iter().map(|arg| arg.as_ptr()).collect();
     argv.push(std::ptr::null());
 
-    let rc = unsafe { libc::execve(bash_path.as_ptr(), argv.as_ptr(), environ.cast()) };
+    let rc = unsafe { libc::execve(request.exec_args[0].as_ptr(), argv.as_ptr(), environ.cast()) };
     let errno = std::io::Error::last_os_error()
         .raw_os_error()
         .unwrap_or(libc::ENOENT);
 
     if rc != 0 {
-        eprintln!(
-            "execve({}, {}): {}",
-            BASH_PATH,
-            script_path.to_string_lossy(),
-            std::io::Error::from_raw_os_error(errno)
+        eprintln!("{}", format_exec_error(request.script_path, errno));
+    }
+
+    exit_code_for_errno(errno)
+}
+
+fn main() {
+    let mut args = env::args_os();
+    let argv0 = args.next().unwrap_or_else(|| OsStr::new("").to_owned());
+    let remaining_args: Vec<OsString> = args.collect();
+    let request = prepare_launch(&argv0, remaining_args).unwrap_or_else(|error| {
+        eprintln!("{}", format_launch_error(error));
+        process::exit(126);
+    });
+
+    sanitize_env();
+    env::set_var("WORKCELL_LAUNCH_TARGET", request.target_name);
+    process::exit(exec_request(&request));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn lookup_target_matches_known_invocations() {
+        assert_eq!(
+            lookup_target(OsStr::new("/usr/local/bin/workcell-entrypoint")),
+            Some((
+                "workcell-entrypoint",
+                "/usr/local/libexec/workcell/entrypoint.sh"
+            ))
+        );
+        assert_eq!(
+            lookup_target(OsStr::new("claude")),
+            Some(("claude", "/usr/local/libexec/workcell/provider-wrapper.sh"))
+        );
+        assert_eq!(lookup_target(OsStr::new("unknown")), None);
+    }
+
+    #[test]
+    fn prepare_launch_builds_exec_args_for_known_targets() {
+        let request = prepare_launch(
+            OsStr::new("/usr/local/bin/codex"),
+            vec![OsString::from("--version")],
+        )
+        .expect("prepare launch");
+
+        assert_eq!(request.target_name, "codex");
+        assert_eq!(
+            request.script_path,
+            "/usr/local/libexec/workcell/provider-wrapper.sh"
+        );
+        assert_eq!(request.exec_args[0].as_bytes(), BASH_PATH.as_bytes());
+        assert_eq!(
+            request.exec_args[1].as_bytes(),
+            b"/usr/local/libexec/workcell/provider-wrapper.sh"
+        );
+        assert_eq!(request.exec_args[2].as_bytes(), b"--version");
+    }
+
+    #[test]
+    fn prepare_launch_rejects_unknown_targets_and_nul_args() {
+        let unknown =
+            prepare_launch(OsStr::new("unknown"), vec![]).expect_err("unknown target should fail");
+        assert_eq!(
+            format_launch_error(unknown),
+            "Unsupported Workcell launcher target: unknown"
+        );
+
+        let invalid = OsString::from_vec(b"co\0dex".to_vec());
+        let nul =
+            prepare_launch(OsStr::new("codex"), vec![invalid]).expect_err("nul arg should fail");
+        assert_eq!(
+            format_launch_error(nul),
+            "Workcell launcher argument contained a NUL byte."
         );
     }
 
-    process::exit(if errno == libc::ENOENT { 127 } else { 126 });
+    #[test]
+    fn osstr_to_cstring_rejects_nul_bytes() {
+        assert!(osstr_to_cstring(OsStr::new("codex")).is_ok());
+        assert!(osstr_to_cstring(OsStr::from_bytes(b"co\0dex")).is_err());
+    }
+
+    #[test]
+    fn sanitize_env_clears_sensitive_loader_and_node_state() {
+        let _guard = env_lock().lock().expect("env lock");
+        env::set_var("BASH_ENV", "/tmp/bashenv");
+        env::set_var("LD_PRELOAD", "/tmp/preload.so");
+        env::set_var("NODE_OPTIONS", "--inspect");
+
+        sanitize_env();
+
+        assert!(env::var_os("BASH_ENV").is_none());
+        assert!(env::var_os("LD_PRELOAD").is_none());
+        assert!(env::var_os("NODE_OPTIONS").is_none());
+    }
+
+    #[test]
+    fn exec_failure_helpers_format_messages_and_exit_codes() {
+        assert_eq!(exit_code_for_errno(libc::ENOENT), 127);
+        assert_eq!(exit_code_for_errno(libc::EACCES), 126);
+        let message = format_exec_error(
+            "/usr/local/libexec/workcell/provider-wrapper.sh",
+            libc::ENOENT,
+        );
+        assert!(
+            message.contains("execve(/bin/bash, /usr/local/libexec/workcell/provider-wrapper.sh):")
+        );
+    }
+
+    #[test]
+    fn exec_request_returns_failure_code_when_shell_is_unavailable() {
+        let request = LaunchRequest {
+            target_name: "codex",
+            script_path: "/usr/local/libexec/workcell/provider-wrapper.sh",
+            exec_args: vec![
+                CString::new("/definitely/missing/bash").expect("missing bash path"),
+                CString::new("/usr/local/libexec/workcell/provider-wrapper.sh")
+                    .expect("provider wrapper path"),
+                CString::new("--version").expect("version arg"),
+            ],
+        };
+
+        assert_eq!(exec_request(&request), 127);
+    }
 }

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -21,6 +21,7 @@ fi
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DOCKERFILE_PATH="${ROOT_DIR}/runtime/container/Dockerfile"
 VALIDATOR_DOCKERFILE_PATH="${ROOT_DIR}/tools/validator/Dockerfile"
+REMOTE_VALIDATOR_DOCKERFILE_PATH="${ROOT_DIR}/tools/remote-validator/Dockerfile"
 PROVIDERS_PACKAGE_JSON_PATH="${ROOT_DIR}/runtime/container/providers/package.json"
 PROVIDERS_PACKAGE_LOCK_PATH="${ROOT_DIR}/runtime/container/providers/package-lock.json"
 WORKFLOWS_DIR="${ROOT_DIR}/.github/workflows"
@@ -41,7 +42,7 @@ require_tool() {
 
 require_tool python3
 
-python3 - "${DOCKERFILE_PATH}" "${VALIDATOR_DOCKERFILE_PATH}" "${PROVIDERS_PACKAGE_JSON_PATH}" "${PROVIDERS_PACKAGE_LOCK_PATH}" "${WORKFLOWS_DIR}" "${CI_WORKFLOW_PATH}" "${RELEASE_WORKFLOW_PATH}" "${CODEOWNERS_PATH}" "${CODEX_REQUIREMENTS_PATH}" "${CODEX_MCP_CONFIG_PATH}" "${HOSTED_CONTROLS_POLICY_PATH}" "${MAX_DEBIAN_SNAPSHOT_AGE_DAYS}" <<'PY'
+python3 - "${DOCKERFILE_PATH}" "${VALIDATOR_DOCKERFILE_PATH}" "${REMOTE_VALIDATOR_DOCKERFILE_PATH}" "${PROVIDERS_PACKAGE_JSON_PATH}" "${PROVIDERS_PACKAGE_LOCK_PATH}" "${WORKFLOWS_DIR}" "${CI_WORKFLOW_PATH}" "${RELEASE_WORKFLOW_PATH}" "${CODEOWNERS_PATH}" "${CODEX_REQUIREMENTS_PATH}" "${CODEX_MCP_CONFIG_PATH}" "${HOSTED_CONTROLS_POLICY_PATH}" "${MAX_DEBIAN_SNAPSHOT_AGE_DAYS}" <<'PY'
 import datetime as dt
 import json
 import pathlib
@@ -51,16 +52,17 @@ import tomllib
 
 runtime_dockerfile = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
 validator_dockerfile = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
-providers_package_json = json.loads(pathlib.Path(sys.argv[3]).read_text(encoding="utf-8"))
-providers_package_lock = json.loads(pathlib.Path(sys.argv[4]).read_text(encoding="utf-8"))
-workflows_dir = pathlib.Path(sys.argv[5])
-ci_workflow = pathlib.Path(sys.argv[6]).read_text(encoding="utf-8")
-release_workflow = pathlib.Path(sys.argv[7]).read_text(encoding="utf-8")
-codeowners = pathlib.Path(sys.argv[8]).read_text(encoding="utf-8")
-codex_requirements = tomllib.loads(pathlib.Path(sys.argv[9]).read_text(encoding="utf-8"))
-codex_mcp_config = tomllib.loads(pathlib.Path(sys.argv[10]).read_text(encoding="utf-8"))
-hosted_controls_policy = tomllib.loads(pathlib.Path(sys.argv[11]).read_text(encoding="utf-8"))
-max_snapshot_age_days = int(sys.argv[12])
+remote_validator_dockerfile = pathlib.Path(sys.argv[3]).read_text(encoding="utf-8")
+providers_package_json = json.loads(pathlib.Path(sys.argv[4]).read_text(encoding="utf-8"))
+providers_package_lock = json.loads(pathlib.Path(sys.argv[5]).read_text(encoding="utf-8"))
+workflows_dir = pathlib.Path(sys.argv[6])
+ci_workflow = pathlib.Path(sys.argv[7]).read_text(encoding="utf-8")
+release_workflow = pathlib.Path(sys.argv[8]).read_text(encoding="utf-8")
+codeowners = pathlib.Path(sys.argv[9]).read_text(encoding="utf-8")
+codex_requirements = tomllib.loads(pathlib.Path(sys.argv[10]).read_text(encoding="utf-8"))
+codex_mcp_config = tomllib.loads(pathlib.Path(sys.argv[11]).read_text(encoding="utf-8"))
+hosted_controls_policy = tomllib.loads(pathlib.Path(sys.argv[12]).read_text(encoding="utf-8"))
+max_snapshot_age_days = int(sys.argv[13])
 
 def require_arg(text: str, name: str, path: str) -> str:
     match = re.search(rf"^ARG {re.escape(name)}=(.+)$", text, re.MULTILINE)
@@ -158,16 +160,36 @@ def require_no_registry_bootstrap_mcp(config: dict, path: str) -> None:
 
 runtime_base_image = require_arg(runtime_dockerfile, "NODE_BASE_IMAGE", "runtime/container/Dockerfile")
 validator_base_image = require_arg(validator_dockerfile, "VALIDATOR_BASE_IMAGE", "tools/validator/Dockerfile")
+remote_validator_base_image = require_arg(
+    remote_validator_dockerfile,
+    "VALIDATOR_BASE_IMAGE",
+    "tools/remote-validator/Dockerfile",
+)
 runtime_snapshot = require_arg(runtime_dockerfile, "DEBIAN_SNAPSHOT", "runtime/container/Dockerfile")
 validator_snapshot = require_arg(validator_dockerfile, "DEBIAN_SNAPSHOT", "tools/validator/Dockerfile")
+remote_validator_snapshot = require_arg(
+    remote_validator_dockerfile,
+    "DEBIAN_SNAPSHOT",
+    "tools/remote-validator/Dockerfile",
+)
 codex_version = require_arg(runtime_dockerfile, "CODEX_VERSION", "runtime/container/Dockerfile")
 runtime_install_blocks = extract_install_blocks(runtime_dockerfile, "runtime/container/Dockerfile")
 validator_install_blocks = extract_install_blocks(validator_dockerfile, "tools/validator/Dockerfile")
+remote_validator_install_blocks = extract_install_blocks(
+    remote_validator_dockerfile,
+    "tools/remote-validator/Dockerfile",
+)
 
 require_pinned_base_image(runtime_base_image, "NODE_BASE_IMAGE", "runtime/container/Dockerfile")
 require_pinned_base_image(validator_base_image, "VALIDATOR_BASE_IMAGE", "tools/validator/Dockerfile")
+require_pinned_base_image(
+    remote_validator_base_image,
+    "VALIDATOR_BASE_IMAGE",
+    "tools/remote-validator/Dockerfile",
+)
 verify_snapshot_freshness(runtime_snapshot, "runtime/container/Dockerfile")
 verify_snapshot_freshness(validator_snapshot, "tools/validator/Dockerfile")
+verify_snapshot_freshness(remote_validator_snapshot, "tools/remote-validator/Dockerfile")
 require_no_registry_bootstrap_mcp(codex_requirements, "adapters/codex/requirements.toml")
 require_no_registry_bootstrap_mcp(codex_mcp_config, "adapters/codex/mcp/config.toml")
 require_regex(
@@ -197,6 +219,8 @@ if len(runtime_install_blocks) != 2:
     )
 if len(validator_install_blocks) != 1:
     raise SystemExit("tools/validator/Dockerfile must contain exactly one apt install block")
+if len(remote_validator_install_blocks) != 1:
+    raise SystemExit("tools/remote-validator/Dockerfile must contain exactly one apt install block")
 require_exact_packages(
     runtime_install_blocks[0],
     [
@@ -235,8 +259,10 @@ require_exact_packages(
         "cargo",
         "git",
         "groff-base",
+        "llvm",
         "mandoc",
         "python3",
+        "python3-coverage",
         "rustc",
         "rustfmt",
         "shellcheck",
@@ -245,6 +271,28 @@ require_exact_packages(
     ],
     "Validator",
     "tools/validator/Dockerfile",
+)
+require_exact_packages(
+    remote_validator_install_blocks[0],
+    [
+        "codespell",
+        "cargo",
+        "docker-cli",
+        "docker-buildx",
+        "git",
+        "groff-base",
+        "llvm",
+        "mandoc",
+        "python3",
+        "python3-coverage",
+        "rustc",
+        "rustfmt",
+        "shellcheck",
+        "shfmt",
+        "yamllint",
+    ],
+    "Remote validator",
+    "tools/remote-validator/Dockerfile",
 )
 
 root_package = providers_package_lock.get("packages", {}).get("", {})

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POLICY_PATH="${ROOT_DIR}/policy/github-hosted-controls.toml"
 
 require_tool() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -12,11 +13,52 @@ require_tool() {
 
 require_tool actionlint
 require_tool zizmor
+require_tool python3
 
 (
   cd "${ROOT_DIR}"
   actionlint
 )
 zizmor --config "${ROOT_DIR}/.github/zizmor.yml" "${ROOT_DIR}/.github/workflows/"*.yml
+
+python3 - "${ROOT_DIR}" "${POLICY_PATH}" <<'PY'
+import pathlib
+import re
+import sys
+import tomllib
+
+root = pathlib.Path(sys.argv[1])
+policy_path = pathlib.Path(sys.argv[2])
+policy = tomllib.loads(policy_path.read_text(encoding="utf-8"))
+expected = policy.get("required_status_checks", {}).get("contexts")
+if not isinstance(expected, list) or not expected:
+    raise SystemExit(
+        f"{policy_path} must define required_status_checks.contexts as a non-empty array"
+    )
+if not all(isinstance(context, str) and context for context in expected):
+    raise SystemExit(
+        f"{policy_path} must define required_status_checks.contexts as non-empty strings"
+    )
+
+job_name_pattern = re.compile(r"^ {4}name:\s*(.+?)\s*$", re.MULTILINE)
+job_names: set[str] = set()
+for path in sorted((root / ".github" / "workflows").glob("*.yml")):
+    content = path.read_text(encoding="utf-8")
+    for match in job_name_pattern.finditer(content):
+        name = match.group(1).strip()
+        if (
+            (name.startswith('"') and name.endswith('"'))
+            or (name.startswith("'") and name.endswith("'"))
+        ):
+            name = name[1:-1]
+        job_names.add(name)
+
+missing = sorted(set(expected) - job_names)
+if missing:
+    raise SystemExit(
+        "Workflow jobs are missing required status-check names from "
+        f"{policy_path}: {', '.join(missing)}"
+    )
+PY
 
 echo "Workcell workflow checks passed."

--- a/scripts/colima-egress-allowlist.sh
+++ b/scripts/colima-egress-allowlist.sh
@@ -31,6 +31,7 @@ CANONICALIZER_PYTHON="/usr/bin/python3"
 usage() {
   cat <<'EOF'
 Usage:
+  colima-egress-allowlist.sh plan <profile> "<host:port ...>"
   colima-egress-allowlist.sh apply <profile> "<host:port ...>"
   colima-egress-allowlist.sh clear <profile>
 EOF
@@ -116,25 +117,41 @@ run_clean_host_command() {
 
 validate_endpoint() {
   local endpoint="$1"
-  local host="${endpoint%:*}"
-  local port="${endpoint##*:}"
+  local host=""
+  local port=""
+
+  if [[ "${endpoint}" =~ ^\[([0-9A-Fa-f:.]+)\]:([0-9]{1,5})$ ]]; then
+    host="[${BASH_REMATCH[1]}]"
+    port="${BASH_REMATCH[2]}"
+  elif [[ "${endpoint}" =~ ^([^:]+):([0-9]{1,5})$ ]]; then
+    host="${BASH_REMATCH[1]}"
+    port="${BASH_REMATCH[2]}"
+  fi
 
   [[ -n "${host}" ]] || {
     echo "Invalid endpoint host: ${endpoint}" >&2
     exit 1
   }
-  [[ "${host}" =~ ^[A-Za-z0-9.-]+$ ]] || {
-    echo "Invalid endpoint host: ${endpoint}" >&2
-    exit 1
-  }
-  [[ "${host}" != .* ]] || {
-    echo "Invalid endpoint host: ${endpoint}" >&2
-    exit 1
-  }
-  [[ "${host}" != *..* ]] || {
-    echo "Invalid endpoint host: ${endpoint}" >&2
-    exit 1
-  }
+  if [[ "${host}" == \[*\] ]]; then
+    local ipv6_host="${host:1:${#host}-2}"
+    [[ "${ipv6_host}" =~ ^[0-9A-Fa-f:.]+$ ]] || {
+      echo "Invalid endpoint host: ${endpoint}" >&2
+      exit 1
+    }
+  else
+    [[ "${host}" =~ ^[A-Za-z0-9.-]+$ ]] || {
+      echo "Invalid endpoint host: ${endpoint}" >&2
+      exit 1
+    }
+    [[ "${host}" != .* ]] || {
+      echo "Invalid endpoint host: ${endpoint}" >&2
+      exit 1
+    }
+    [[ "${host}" != *..* ]] || {
+      echo "Invalid endpoint host: ${endpoint}" >&2
+      exit 1
+    }
+  fi
   [[ "${port}" =~ ^[0-9]{1,5}$ ]] || {
     echo "Invalid endpoint port: ${endpoint}" >&2
     exit 1
@@ -147,6 +164,9 @@ validate_endpoint() {
 
 resolve_ips() {
   local host="$1"
+  if [[ "${host}" == \[*\] ]]; then
+    host="${host:1:${#host}-2}"
+  fi
   run_clean_host_command "${PYTHON3_BIN}" - "$host" <<'PY'
 import socket, sys
 host = sys.argv[1]
@@ -174,11 +194,31 @@ PROFILE="${2:-}"
 }
 
 initialize_vm_tools() {
-  if [[ -n "${LIMACTL_BIN}" && -n "${PYTHON3_BIN}" && -n "${REAL_HOME:-}" ]]; then
+  if [[ -n "${PYTHON3_BIN}" && -n "${REAL_HOME:-}" ]]; then
+    :
+  else
+    PYTHON3_BIN="$(resolve_host_tool python3 /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3)"
+    REAL_HOME="$(
+      run_clean_host_command "${PYTHON3_BIN}" - <<'PY'
+import os
+import pwd
+print(pwd.getpwuid(os.getuid()).pw_dir)
+PY
+    )"
+  fi
+
+  if [[ -n "${LIMACTL_BIN}" ]]; then
     return 0
   fi
 
   LIMACTL_BIN="$(resolve_host_tool limactl /opt/homebrew/bin/limactl /usr/local/bin/limactl)"
+}
+
+initialize_host_tools() {
+  if [[ -n "${PYTHON3_BIN}" && -n "${REAL_HOME:-}" ]]; then
+    return 0
+  fi
+
   PYTHON3_BIN="$(resolve_host_tool python3 /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3)"
   REAL_HOME="$(
     run_clean_host_command "${PYTHON3_BIN}" - <<'PY'
@@ -224,9 +264,105 @@ clear_rules() {
   '
 }
 
+render_clear_plan() {
+  cat <<'EOF'
+sudo iptables -D DOCKER-USER -j WORKCELL_EGRESS 2>/dev/null || true
+sudo iptables -F WORKCELL_EGRESS 2>/dev/null || true
+sudo iptables -X WORKCELL_EGRESS 2>/dev/null || true
+if type ip6tables >/dev/null 2>&1; then
+  sudo ip6tables -D DOCKER-USER -j WORKCELL_EGRESS6 2>/dev/null || true
+  sudo ip6tables -F WORKCELL_EGRESS6 2>/dev/null || true
+  sudo ip6tables -X WORKCELL_EGRESS6 2>/dev/null || true
+fi
+EOF
+}
+
+declare -a RULES=()
+declare -a IPV6_RULES=()
+
+build_allowlist_rules() {
+  local endpoints="$1"
+  local endpoint=""
+  local host=""
+  local port=""
+  local ip=""
+
+  RULES=(
+    "sudo iptables -N WORKCELL_EGRESS 2>/dev/null || true"
+    "sudo iptables -F WORKCELL_EGRESS"
+    "sudo iptables -C DOCKER-USER -j WORKCELL_EGRESS 2>/dev/null || sudo iptables -I DOCKER-USER 1 -j WORKCELL_EGRESS"
+    "sudo iptables -A WORKCELL_EGRESS -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT"
+  )
+  IPV6_RULES=(
+    "if ! type ip6tables >/dev/null 2>&1; then echo \"Workcell requires ip6tables support to enforce dual-stack allowlist egress policy.\" >&2; exit 1; fi"
+    "sudo ip6tables -N WORKCELL_EGRESS6 2>/dev/null || true"
+    "sudo ip6tables -F WORKCELL_EGRESS6"
+    "sudo ip6tables -C DOCKER-USER -j WORKCELL_EGRESS6 2>/dev/null || sudo ip6tables -I DOCKER-USER 1 -j WORKCELL_EGRESS6"
+    "sudo ip6tables -A WORKCELL_EGRESS6 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT"
+  )
+
+  for endpoint in ${endpoints}; do
+    validate_endpoint "${endpoint}"
+  done
+
+  initialize_host_tools
+
+  for endpoint in ${endpoints}; do
+    if [[ "${endpoint}" =~ ^\[([0-9A-Fa-f:.]+)\]:([0-9]{1,5})$ ]]; then
+      host="[${BASH_REMATCH[1]}]"
+      port="${BASH_REMATCH[2]}"
+    else
+      host="${endpoint%:*}"
+      port="${endpoint##*:}"
+    fi
+    while IFS= read -r ip; do
+      [[ -n "${ip}" ]] || continue
+      if [[ "${ip}" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+        RULES+=("sudo iptables -A WORKCELL_EGRESS -p tcp -d ${ip} --dport ${port} -j ACCEPT")
+        continue
+      fi
+      if [[ "${ip}" == *:* ]]; then
+        IPV6_RULES+=("sudo ip6tables -A WORKCELL_EGRESS6 -p tcp -d ${ip} --dport ${port} -j ACCEPT")
+        continue
+      fi
+      echo "Resolver returned invalid IP address: ${ip}" >&2
+      exit 1
+    done < <(resolve_ips "${host}")
+  done
+
+  RULES+=("sudo iptables -A WORKCELL_EGRESS -j DROP")
+  IPV6_RULES+=("sudo ip6tables -A WORKCELL_EGRESS6 -j DROP")
+}
+
+render_allowlist_plan() {
+  printf '%s\n' "${RULES[@]}"
+  printf '%s\n' "${IPV6_RULES[@]}"
+}
+
+render_allowlist_apply_plan() {
+  cat <<'EOF'
+if ! type ip6tables >/dev/null 2>&1; then
+  echo "Workcell requires ip6tables support to enforce dual-stack allowlist egress policy." >&2
+  exit 1
+fi
+sudo ip6tables -L WORKCELL_EGRESS6 >/dev/null 2>&1 || true
+EOF
+  render_clear_plan
+  render_allowlist_plan
+}
+
 case "${COMMAND}" in
   clear)
     clear_rules
+    ;;
+  plan)
+    ENDPOINTS="${3:-}"
+    [[ -n "${ENDPOINTS}" ]] || {
+      echo "Missing endpoint list for plan" >&2
+      exit 1
+    }
+    build_allowlist_rules "${ENDPOINTS}"
+    render_allowlist_plan
     ;;
   apply)
     ENDPOINTS="${3:-}"
@@ -234,64 +370,8 @@ case "${COMMAND}" in
       echo "Missing endpoint list for apply" >&2
       exit 1
     }
-
-    RULES=("sudo iptables -N WORKCELL_EGRESS 2>/dev/null || true"
-      "sudo iptables -F WORKCELL_EGRESS"
-      "sudo iptables -C DOCKER-USER -j WORKCELL_EGRESS 2>/dev/null || sudo iptables -I DOCKER-USER 1 -j WORKCELL_EGRESS"
-      "sudo iptables -A WORKCELL_EGRESS -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT")
-    IPV6_RULES=()
-
-    for endpoint in ${ENDPOINTS}; do
-      validate_endpoint "${endpoint}"
-    done
-
-    initialize_vm_tools
-
-    for endpoint in ${ENDPOINTS}; do
-      host="${endpoint%:*}"
-      port="${endpoint##*:}"
-      while IFS= read -r ip; do
-        [[ -n "${ip}" ]] || continue
-        if [[ "${ip}" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
-          RULES+=("sudo iptables -A WORKCELL_EGRESS -p tcp -d ${ip} --dport ${port} -j ACCEPT")
-          continue
-        fi
-        if [[ "${ip}" == *:* ]]; then
-          IPV6_RULES+=("sudo ip6tables -A WORKCELL_EGRESS6 -p tcp -d ${ip} --dport ${port} -j ACCEPT")
-          continue
-        fi
-        echo "Resolver returned invalid IP address: ${ip}" >&2
-        exit 1
-      done < <(resolve_ips "${host}")
-    done
-
-    RULES+=("sudo iptables -A WORKCELL_EGRESS -j DROP")
-    if [[ "${#IPV6_RULES[@]}" -gt 0 ]]; then
-      IPV6_RULES=("sudo ip6tables -N WORKCELL_EGRESS6 2>/dev/null || true"
-        "sudo ip6tables -F WORKCELL_EGRESS6"
-        "sudo ip6tables -C DOCKER-USER -j WORKCELL_EGRESS6 2>/dev/null || sudo ip6tables -I DOCKER-USER 1 -j WORKCELL_EGRESS6"
-        "sudo ip6tables -A WORKCELL_EGRESS6 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT"
-        "${IPV6_RULES[@]}"
-        "sudo ip6tables -A WORKCELL_EGRESS6 -j DROP")
-    fi
-
-    clear_rules
-    run_in_vm "$(
-      cat <<EOF
-$(printf '%s\n' "${RULES[@]}")
-if type ip6tables >/dev/null 2>&1; then
-  sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 >/dev/null 2>&1 || true
-  sudo sysctl -w net.ipv6.conf.default.disable_ipv6=0 >/dev/null 2>&1 || true
-$(if [[ "${#IPV6_RULES[@]}" -gt 0 ]]; then printf '%s\n' "${IPV6_RULES[@]}"; else
-        printf '%s\n%s\n' "sudo ip6tables -N WORKCELL_EGRESS6 2>/dev/null || true" "sudo ip6tables -F WORKCELL_EGRESS6"
-        printf '%s\n%s\n' "sudo ip6tables -C DOCKER-USER -j WORKCELL_EGRESS6 2>/dev/null || sudo ip6tables -I DOCKER-USER 1 -j WORKCELL_EGRESS6" "sudo ip6tables -A WORKCELL_EGRESS6 -j DROP"
-      fi)
-else
-  sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1 >/dev/null 2>&1 || true
-  sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1 >/dev/null 2>&1 || true
-fi
-EOF
-    )"
+    build_allowlist_rules "${ENDPOINTS}"
+    run_in_vm "$(render_allowlist_apply_plan)"
     ;;
   *)
     usage

--- a/scripts/colima-egress-allowlist.sh
+++ b/scripts/colima-egress-allowlist.sh
@@ -278,7 +278,6 @@ EOF
 }
 
 clear_rules() {
-  initialize_vm_tools
   run_in_vm '
     set -euo pipefail
     sudo iptables -D DOCKER-USER -j WORKCELL_EGRESS 2>/dev/null || true

--- a/scripts/colima-egress-allowlist.sh
+++ b/scripts/colima-egress-allowlist.sh
@@ -8,6 +8,7 @@ scrub_host_process_env() {
   local env_name
 
   unset BASH_ENV ENV
+  unset WORKCELL_TEST_RUN_IN_VM_CAPTURE_DIR
   unset PYTHONPATH PYTHONHOME PYTHONSAFEPATH PYTHONSTARTUP
   unset RUBYOPT RUBYLIB GEM_HOME GEM_PATH
   unset PERL5OPT PERL5LIB PERLLIB PERL_MB_OPT PERL_MM_OPT
@@ -27,6 +28,7 @@ scrub_host_process_env
 LIMACTL_BIN=""
 PYTHON3_BIN=""
 CANONICALIZER_PYTHON="/usr/bin/python3"
+TEST_RUN_IN_VM_CAPTURE_DIR=""
 
 usage() {
   cat <<'EOF'
@@ -181,6 +183,15 @@ PY
 }
 
 COMMAND="${1:-}"
+if [[ "${COMMAND}" == "--test-run-in-vm-capture-dir" ]]; then
+  TEST_RUN_IN_VM_CAPTURE_DIR="${2:-}"
+  [[ -n "${TEST_RUN_IN_VM_CAPTURE_DIR}" ]] || {
+    echo "Missing capture directory for --test-run-in-vm-capture-dir" >&2
+    exit 1
+  }
+  shift 2
+  COMMAND="${1:-}"
+fi
 PROFILE="${2:-}"
 
 [[ -n "${COMMAND}" ]] || {
@@ -239,8 +250,25 @@ lima_instance() {
 
 run_in_vm() {
   local script="$1"
-  local colima_home="${COLIMA_HOME:-${REAL_HOME}/.colima}"
+  local colima_home=""
+  local capture_base=""
 
+  if [[ -n "${TEST_RUN_IN_VM_CAPTURE_DIR}" ]]; then
+    initialize_host_tools
+    colima_home="${COLIMA_HOME:-${REAL_HOME}/.colima}"
+    mkdir -p "${TEST_RUN_IN_VM_CAPTURE_DIR}"
+    capture_base="${TEST_RUN_IN_VM_CAPTURE_DIR}/${COMMAND}-${PROFILE}"
+    printf '%s\n' "${script}" >"${capture_base}.script"
+    cat >"${capture_base}.env" <<EOF
+REAL_HOME=${REAL_HOME}
+COLIMA_HOME=${colima_home}
+LIMA_HOME=${colima_home}/_lima
+LIMA_WORKDIR=/
+EOF
+    return 0
+  fi
+  initialize_vm_tools
+  colima_home="${COLIMA_HOME:-${REAL_HOME}/.colima}"
   printf 'set -euo pipefail\n%s\n' "${script}" |
     HOME="${REAL_HOME}" \
       COLIMA_HOME="${colima_home}" \

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -574,6 +574,15 @@ run_container_with_injection_bundle() {
     "${IMAGE_TAG}" "${@:2}"
 }
 
+if [[ "${1:-}" == "--self-docker-probe" ]]; then
+  require_tool docker
+  setup_workcell_trusted_docker_client
+  select_docker_context
+  buildx_cmd version >/dev/null
+  echo "container-smoke-docker-probe-ok"
+  exit 0
+fi
+
 require_tool docker
 trap cleanup EXIT
 cleanup_workspace_scratch "${ROOT_DIR}"
@@ -624,12 +633,6 @@ cat <<'EOF' >"${WORKSPACE_IMPORT_ROOT}/GEMINI.md"
 # Workspace Gemini Instructions
 EOF
 align_path_for_mapped_runtime_user "${WORKSPACE_IMPORT_ROOT}" 0644 0755
-
-if [[ "${1:-}" == "--self-docker-probe" ]]; then
-  buildx_cmd version >/dev/null
-  echo "container-smoke-docker-probe-ok"
-  exit 0
-fi
 
 BUILD_SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}"
 SOURCE_DATE_EPOCH="${BUILD_SOURCE_DATE_EPOCH}" buildx_cmd build \
@@ -798,12 +801,22 @@ run_container_with_injection_bundle claude "${INJECTION_BUNDLE_ROOT}/claude" bas
     grep -q "Workspace Claude Instructions" "$HOME/.claude/CLAUDE.md"
     grep -q "\"apiKeyHelper\"" "$HOME/.claude/settings.json"
     helper_path="$(jq -r ".apiKeyHelper" "$HOME/.claude/settings.json")"
+    test ! -L "$HOME/.claude/settings.json"
     test -x "$helper_path"
     test "$("$helper_path")" = "claude-smoke-key"
     grep -q "\"token\": \"claude-auth\"" "$HOME/.config/claude-code/auth.json"
+    test ! -L "$HOME/.config/claude-code/auth.json"
     test ! -L "$HOME/.mcp.json"
     grep -q "\"stub\"" "$HOME/.mcp.json"
     grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
+    rm -f "$HOME/.claude/settings.json" "$HOME/.config/claude-code/auth.json" "$HOME/.mcp.json"
+    claude --version >/dev/null
+    grep -q "\"apiKeyHelper\"" "$HOME/.claude/settings.json"
+    helper_path="$(jq -r ".apiKeyHelper" "$HOME/.claude/settings.json")"
+    test -x "$helper_path"
+    test "$("$helper_path")" = "claude-smoke-key"
+    grep -q "\"token\": \"claude-auth\"" "$HOME/.config/claude-code/auth.json"
+    grep -q "\"stub\"" "$HOME/.mcp.json"
   '"'"'
 '
 
@@ -1442,6 +1455,16 @@ EOF
   fi
   grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/state-native-codex-profile-bypass.out
   mkdir -p /workspace/tmp
+  workspace_provider_scratch=/workspace/tmp/workcell-provider-scratch
+  workspace_provider_tampered="${workspace_provider_scratch}/tampered"
+  workspace_provider_aggressive="${workspace_provider_scratch}/aggressive"
+  workspace_provider_minimal="${workspace_provider_scratch}/minimal"
+  workspace_provider_split="${workspace_provider_scratch}/split"
+  workspace_provider_no_package="${workspace_provider_scratch}/no-package.js"
+  workspace_provider_no_package_split="${workspace_provider_scratch}/no-package-split"
+  workspace_provider_benign_marker="${workspace_provider_scratch}/benign-marker-package"
+  rm -rf "${workspace_provider_scratch}"
+  mkdir -p "${workspace_provider_scratch}"
   cp /bin/true /workspace/tmp/.workcell-native-helper
   chmod 0700 /workspace/tmp/.workcell-native-helper
   if /workspace/tmp/.workcell-native-helper >/tmp/workspace-native.out 2>&1; then
@@ -1820,247 +1843,153 @@ EOF
     exit 1
   fi
   grep -Eq "Workcell blocked provider package execution via public node.|Workcell blocked public node execution outside the mounted workspace." /tmp/node-provider-copy-tampered.out
-  rm -rf /workspace/.workcell-provider-copy-tampered
-  cp -R /opt/workcell/providers/node_modules/@anthropic-ai/claude-code /workspace/.workcell-provider-copy-tampered
-  jq ".name = \"@workcell/not-claude-workspace\"" /workspace/.workcell-provider-copy-tampered/package.json >/workspace/.workcell-provider-copy-tampered/package.json.new
-  mv /workspace/.workcell-provider-copy-tampered/package.json.new /workspace/.workcell-provider-copy-tampered/package.json
-  printf "\n// tampered workspace copy\n" >>/workspace/.workcell-provider-copy-tampered/cli.js
-  if node /workspace/.workcell-provider-copy-tampered/cli.js --version >/tmp/node-provider-copy-workspace.out 2>&1; then
+  rm -rf "${workspace_provider_tampered}"
+  cp -R /opt/workcell/providers/node_modules/@anthropic-ai/claude-code "${workspace_provider_tampered}"
+  jq ".name = \"@workcell/not-claude-workspace\"" "${workspace_provider_tampered}/package.json" >"${workspace_provider_tampered}/package.json.new"
+  mv "${workspace_provider_tampered}/package.json.new" "${workspace_provider_tampered}/package.json"
+  printf "\n// tampered workspace copy\n" >>"${workspace_provider_tampered}/cli.js"
+  if node "${workspace_provider_tampered}/cli.js" --version >/tmp/node-provider-copy-workspace.out 2>&1; then
     echo "expected tampered workspace Claude provider copy execution via public node to fail" >&2
     exit 1
   fi
   grep -q "Workcell blocked provider package execution via public node." /tmp/node-provider-copy-workspace.out
-  rm -rf /workspace/.workcell-provider-copy-tampered
-  rm -rf /workspace/.workcell-provider-copy-aggressive
-  cp -R /opt/workcell/providers/node_modules/@anthropic-ai/claude-code /workspace/.workcell-provider-copy-aggressive
-  cat <<'\''EOF'\'' >/workspace/tmp/workcell-provider-copy-scrub.js
-const fs = require("node:fs");
-const path = require("node:path");
+  rm -rf "${workspace_provider_tampered}"
+  rm -rf "${workspace_provider_aggressive}"
+  cp -R /opt/workcell/providers/node_modules/@anthropic-ai/claude-code "${workspace_provider_aggressive}"
+  sanitize_workspace_claude_entrypoint() {
+    local entrypoint_path="$1"
+    perl -0pi \
+      -e "s/Anthropic PBC\\. All rights reserved\\./Workcell scrubbed marker/g;" \
+      -e "s|https://code\\.claude\\.com/docs/en/legal-and-compliance\\.|https://example.invalid/workcell|g;" \
+      -e "s/Want to see the unminified source\\? We\\x27re hiring!/Workcell scrubbed hiring marker/g;" \
+      -e "s/dangerously-skip-permissions/scrubbed-danger-flag/g;" \
+      "${entrypoint_path}"
+  }
+  write_provider_token_parts() {
+    local target_root="$1"
+    local _source_entrypoint="$2"
+    local -a provider_tokens=(
+      "/usr/bin/env"
+      "https://code.claude.com/docs/en/legal-and-compliance."
+      "https://job-boards.greenhouse.io/anthropic/jobs/4816199008"
+      "createRequire"
+      "Object.create"
+      "getPrototypeOf:Xlq"
+      "defineProperty:Hy6"
+      "getOwnPropertyNames:_AA"
+      "getOwnPropertyDescriptor:Dlq"
+      "Object.prototype.hasOwnProperty"
+      "A.__esModule"
+      "get:zAA.bind"
+      "K.enumerable"
+      "configurable:"
+      "set:Zlq.bind"
+      "import.meta.url"
+      "Symbol.dispose"
+      "Symbol.asyncDispose"
+      "SuppressedError"
+      "SuppressedError:function"
+      "H.suppressed"
+      "Promise.resolve"
+      "global.Object"
+      "Object.prototype"
+    )
+    local -a part_names=(a b c)
+    local chunk=""
+    local chunk_json=""
+    local index=0
 
-const packageRoot = process.argv[2];
-const packageJsonPath = path.join(packageRoot, "package.json");
-const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-packageJson.name = "@workcell/not-claude-workspace-aggressive";
-fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n");
+    : "${_source_entrypoint:?}"
 
-const joinMarker = (...parts) => parts.join("");
-const replacements = [
-  [joinMarker("Anthropic ", "PBC. All rights reserved."), "Workcell scrubbed marker"],
-  [
-    joinMarker(
-      "https://code.claude.com/docs/en/legal-",
-      "and-compliance.",
-    ),
-    "https://example.invalid/workcell",
-  ],
-  [
-    joinMarker("Want to see the unminified source? We", "\x27re hiring!"),
-    "Workcell scrubbed hiring marker",
-  ],
-  [joinMarker("dangerously", "-skip-permissions"), "scrubbed-danger-flag"],
-];
-
-for (const relativePath of ["README.md", "LICENSE.md", "sdk-tools.d.ts", "resvg.wasm"]) {
-  fs.rmSync(path.join(packageRoot, relativePath), { force: true });
-}
-
-const entrypointPath = path.join(packageRoot, "cli.js");
-let entrypoint = fs.readFileSync(entrypointPath, "utf8");
-for (const [from, to] of replacements) {
-  entrypoint = entrypoint.split(from).join(to);
-}
-fs.writeFileSync(entrypointPath, entrypoint);
+    cat >"${target_root}/main.js" <<'\''EOF'\''
+import "./part-a.js";
+import "./part-b.js";
+import "./part-c.js";
+console.log("workcell split provider smoke");
 EOF
-  node /workspace/tmp/workcell-provider-copy-scrub.js /workspace/.workcell-provider-copy-aggressive >/tmp/node-provider-copy-scrub.out 2>&1
-  if node /workspace/.workcell-provider-copy-aggressive/cli.js --version >/tmp/node-provider-copy-aggressive.out 2>&1; then
+
+    for index in 0 1 2; do
+      chunk="$(printf "%s " "${provider_tokens[@]:$((index * 8)):8}")"
+      chunk="${chunk% }"
+      chunk_json="$(jq -Rn --arg s "${chunk}" "\$s")"
+      printf "export const tokenChunk%s = %s;\n" "${index}" "${chunk_json}" >"${target_root}/part-${part_names[index]}.js"
+    done
+  }
+  jq ".name = \"@workcell/not-claude-workspace-aggressive\"" "${workspace_provider_aggressive}/package.json" >"${workspace_provider_aggressive}/package.json.new"
+  mv "${workspace_provider_aggressive}/package.json.new" "${workspace_provider_aggressive}/package.json"
+  rm -f \
+    "${workspace_provider_aggressive}/README.md" \
+    "${workspace_provider_aggressive}/LICENSE.md" \
+    "${workspace_provider_aggressive}/sdk-tools.d.ts" \
+    "${workspace_provider_aggressive}/resvg.wasm"
+  sanitize_workspace_claude_entrypoint "${workspace_provider_aggressive}/cli.js"
+  if node "${workspace_provider_aggressive}/cli.js" --version >/tmp/node-provider-copy-aggressive.out 2>&1; then
     echo "expected aggressively scrubbed workspace Claude provider copy execution via public node to fail" >&2
     exit 1
   fi
   grep -q "Workcell blocked provider package execution via public node." /tmp/node-provider-copy-aggressive.out
-  rm -rf /workspace/.workcell-provider-copy-aggressive
-  rm -rf /workspace/.workcell-provider-copy-minimal
-  mkdir -p /workspace/.workcell-provider-copy-minimal
-  cp /opt/workcell/providers/node_modules/@anthropic-ai/claude-code/cli.js /workspace/.workcell-provider-copy-minimal/main.js
-  cp /opt/workcell/providers/node_modules/@anthropic-ai/claude-code/package.json /workspace/.workcell-provider-copy-minimal/
-  cat <<'\''EOF'\'' >/workspace/tmp/workcell-provider-copy-minimalize.js
-const fs = require("node:fs");
-const path = require("node:path");
-
-const packageRoot = process.argv[2];
-const packageJsonPath = path.join(packageRoot, "package.json");
-const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-packageJson.name = "@workcell/not-claude-workspace-minimal";
-packageJson.workcellTampered = true;
-fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n");
-
-const entrypointPath = path.join(packageRoot, "main.js");
-let entrypoint = fs.readFileSync(entrypointPath, "utf8");
-for (const [from, to] of [
-  [("Anthropic " + "PBC. All rights reserved."), "Workcell scrubbed marker"],
-  [
-    ("https://code.claude.com/docs/en/legal-" + "and-compliance."),
-    "https://example.invalid/workcell",
-  ],
-  [
-    ("Want to see the unminified source? We" + "\x27re hiring!"),
-    "Workcell scrubbed hiring marker",
-  ],
-  [("dangerously" + "-skip-permissions"), "scrubbed-danger-flag"],
-]) {
-  entrypoint = entrypoint.split(from).join(to);
-}
-fs.writeFileSync(entrypointPath, entrypoint);
-EOF
-  node /workspace/tmp/workcell-provider-copy-minimalize.js /workspace/.workcell-provider-copy-minimal >/tmp/node-provider-copy-minimalize.out 2>&1
-  if node /workspace/.workcell-provider-copy-minimal/main.js --version >/tmp/node-provider-copy-minimal.out 2>&1; then
+  rm -rf "${workspace_provider_aggressive}"
+  rm -rf "${workspace_provider_minimal}"
+  mkdir -p "${workspace_provider_minimal}"
+  cp /opt/workcell/providers/node_modules/@anthropic-ai/claude-code/cli.js "${workspace_provider_minimal}/main.js"
+  cp /opt/workcell/providers/node_modules/@anthropic-ai/claude-code/package.json "${workspace_provider_minimal}/"
+  jq ".name = \"@workcell/not-claude-workspace-minimal\" | .workcellTampered = true" "${workspace_provider_minimal}/package.json" >"${workspace_provider_minimal}/package.json.new"
+  mv "${workspace_provider_minimal}/package.json.new" "${workspace_provider_minimal}/package.json"
+  sanitize_workspace_claude_entrypoint "${workspace_provider_minimal}/main.js"
+  if node "${workspace_provider_minimal}/main.js" --version >/tmp/node-provider-copy-minimal.out 2>&1; then
     echo "expected minimized scrubbed renamed workspace Claude provider subset execution via public node to fail" >&2
     exit 1
   fi
   grep -q "Workcell blocked provider package execution via public node." /tmp/node-provider-copy-minimal.out
-  rm -rf /workspace/.workcell-provider-copy-minimal
-  rm -rf /workspace/.workcell-provider-copy-split
-  mkdir -p /workspace/.workcell-provider-copy-split
-  cp /opt/workcell/providers/node_modules/@anthropic-ai/claude-code/package.json /workspace/.workcell-provider-copy-split/
-  cat <<'\''EOF'\'' >/workspace/tmp/workcell-provider-copy-split.js
-const fs = require("node:fs");
-const path = require("node:path");
-
-const packageRoot = process.argv[2];
-const sourceEntrypoint = "/opt/workcell/providers/node_modules/@anthropic-ai/claude-code/cli.js";
-const packageJsonPath = path.join(packageRoot, "package.json");
-const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-packageJson.name = "@workcell/not-claude-workspace-split";
-packageJson.workcellTampered = true;
-fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n");
-
-const tokenPattern = /[A-Za-z0-9_./:-]{12,}/g;
-const sourceText = fs.readFileSync(sourceEntrypoint, "utf8");
-const tokens = [...new Set(sourceText.match(tokenPattern) ?? [])].slice(0, 24);
-if (tokens.length !== 24) {
-  throw new Error(`expected at least 24 provider signature tokens, received ${tokens.length}`);
-}
-
-fs.writeFileSync(
-  path.join(packageRoot, "main.js"),
-  [
-    "import \"./part-a.js\";",
-    "import \"./part-b.js\";",
-    "import \"./part-c.js\";",
-    "console.log(\"workcell split provider smoke\");",
-    "",
-  ].join("\n"),
-);
-
-for (const [index, partTokens] of [
-  [0, tokens.slice(0, 8)],
-  [1, tokens.slice(8, 16)],
-  [2, tokens.slice(16, 24)],
-]) {
-  fs.writeFileSync(
-    path.join(packageRoot, `part-${String.fromCharCode(97 + index)}.js`),
-    `export const tokenChunk${index} = ${JSON.stringify(partTokens.join(" "))};\n`,
-  );
-}
-EOF
-  node /workspace/tmp/workcell-provider-copy-split.js /workspace/.workcell-provider-copy-split >/tmp/node-provider-copy-splitize.out 2>&1
-  if node /workspace/.workcell-provider-copy-split/main.js >/tmp/node-provider-copy-split.out 2>&1; then
+  rm -rf "${workspace_provider_minimal}"
+  rm -rf "${workspace_provider_split}"
+  mkdir -p "${workspace_provider_split}"
+  cp /opt/workcell/providers/node_modules/@anthropic-ai/claude-code/package.json "${workspace_provider_split}/"
+  jq ".name = \"@workcell/not-claude-workspace-split\" | .workcellTampered = true" "${workspace_provider_split}/package.json" >"${workspace_provider_split}/package.json.new"
+  mv "${workspace_provider_split}/package.json.new" "${workspace_provider_split}/package.json"
+  write_provider_token_parts "${workspace_provider_split}" "/opt/workcell/providers/node_modules/@anthropic-ai/claude-code/cli.js"
+  if node "${workspace_provider_split}/main.js" >/tmp/node-provider-copy-split.out 2>&1; then
     echo "expected split workspace Claude provider subset execution via public node to fail" >&2
     exit 1
   fi
   grep -q "Workcell blocked provider package execution via public node." /tmp/node-provider-copy-split.out
-  rm -rf /workspace/.workcell-provider-copy-split
-  cp /opt/workcell/providers/node_modules/@anthropic-ai/claude-code/cli.js /workspace/.workcell-provider-copy-no-package.js
-  cat <<'\''EOF'\'' >/workspace/tmp/workcell-provider-copy-no-package.js
-const fs = require("node:fs");
-
-const entrypointPath = process.argv[2];
-let entrypoint = fs.readFileSync(entrypointPath, "utf8");
-for (const [from, to] of [
-  [("Anthropic " + "PBC. All rights reserved."), "Workcell scrubbed marker"],
-  [
-    ("https://code.claude.com/docs/en/legal-" + "and-compliance."),
-    "https://example.invalid/workcell",
-  ],
-  [
-    ("Want to see the unminified source? We" + "\x27re hiring!"),
-    "Workcell scrubbed hiring marker",
-  ],
-  [("dangerously" + "-skip-permissions"), "scrubbed-danger-flag"],
-]) {
-  entrypoint = entrypoint.split(from).join(to);
-}
-fs.writeFileSync(entrypointPath, entrypoint);
-EOF
-  node /workspace/tmp/workcell-provider-copy-no-package.js /workspace/.workcell-provider-copy-no-package.js >/tmp/node-provider-copy-no-packageize.out 2>&1
-  if node /workspace/.workcell-provider-copy-no-package.js --version >/tmp/node-provider-copy-no-package.out 2>&1; then
+  rm -rf "${workspace_provider_split}"
+  cp /opt/workcell/providers/node_modules/@anthropic-ai/claude-code/cli.js "${workspace_provider_no_package}"
+  sanitize_workspace_claude_entrypoint "${workspace_provider_no_package}"
+  if node "${workspace_provider_no_package}" --version >/tmp/node-provider-copy-no-package.out 2>&1; then
     echo "expected package-less scrubbed Claude provider copy execution via public node to fail" >&2
     exit 1
   fi
   grep -q "Workcell blocked provider package execution via public node." /tmp/node-provider-copy-no-package.out
-  rm -f /workspace/.workcell-provider-copy-no-package.js
-  rm -rf /workspace/.workcell-provider-copy-no-package-split
-  mkdir -p /workspace/.workcell-provider-copy-no-package-split
-  cat <<'\''EOF'\'' >/workspace/tmp/workcell-provider-copy-no-package-split.js
-const fs = require("node:fs");
-const path = require("node:path");
-
-const root = process.argv[2];
-const sourceEntrypoint = "/opt/workcell/providers/node_modules/@anthropic-ai/claude-code/cli.js";
-const tokenPattern = /[A-Za-z0-9_./:-]{12,}/g;
-const sourceText = fs.readFileSync(sourceEntrypoint, "utf8");
-const tokens = [...new Set(sourceText.match(tokenPattern) ?? [])].slice(0, 24);
-if (tokens.length !== 24) {
-  throw new Error(`expected at least 24 provider signature tokens, received ${tokens.length}`);
-}
-
-fs.writeFileSync(
-  path.join(root, "main.js"),
-  [
-    "import \"./part-a.js\";",
-    "import \"./part-b.js\";",
-    "import \"./part-c.js\";",
-    "console.log(\"workcell split no-package smoke\");",
-    "",
-  ].join("\n"),
-);
-
-for (const [index, partTokens] of [
-  [0, tokens.slice(0, 8)],
-  [1, tokens.slice(8, 16)],
-  [2, tokens.slice(16, 24)],
-]) {
-  fs.writeFileSync(
-    path.join(root, `part-${String.fromCharCode(97 + index)}.js`),
-    `export const tokenChunk${index} = ${JSON.stringify(partTokens.join(" "))};\n`,
-  );
-}
-EOF
-  node /workspace/tmp/workcell-provider-copy-no-package-split.js /workspace/.workcell-provider-copy-no-package-split >/tmp/node-provider-copy-no-package-splitize.out 2>&1
-  if node /workspace/.workcell-provider-copy-no-package-split/main.js >/tmp/node-provider-copy-no-package-split.out 2>&1; then
+  rm -f "${workspace_provider_no_package}"
+  rm -rf "${workspace_provider_no_package_split}"
+  mkdir -p "${workspace_provider_no_package_split}"
+  write_provider_token_parts "${workspace_provider_no_package_split}" "/opt/workcell/providers/node_modules/@anthropic-ai/claude-code/cli.js"
+  if node "${workspace_provider_no_package_split}/main.js" >/tmp/node-provider-copy-no-package-split.out 2>&1; then
     echo "expected split package-less Claude provider subset execution via public node to fail" >&2
     exit 1
   fi
   grep -q "Workcell blocked provider package execution via public node." /tmp/node-provider-copy-no-package-split.out
-  rm -rf /workspace/.workcell-provider-copy-no-package-split
-  rm -rf /workspace/.workcell-benign-marker-package
-  mkdir -p /workspace/.workcell-benign-marker-package
-  cat <<'\''EOF'\'' >/workspace/.workcell-benign-marker-package/package.json
+  rm -rf "${workspace_provider_no_package_split}"
+  rm -rf "${workspace_provider_benign_marker}"
+  mkdir -p "${workspace_provider_benign_marker}"
+  cat <<'\''EOF'\'' >"${workspace_provider_benign_marker}/package.json"
 {
   "name": "@workcell/benign-marker-package",
   "version": "1.0.0",
   "type": "module"
 }
 EOF
-  cat <<'\''EOF'\'' >/workspace/.workcell-benign-marker-package/script.js
+  cat <<'\''EOF'\'' >"${workspace_provider_benign_marker}/script.js"
 console.log("dangerously-skip-permissions");
 EOF
-  if ! node /workspace/.workcell-benign-marker-package/script.js >/tmp/node-provider-marker-benign.out 2>&1; then
+  if ! node "${workspace_provider_benign_marker}/script.js" >/tmp/node-provider-marker-benign.out 2>&1; then
     cat /tmp/node-provider-marker-benign.out >&2
     echo "expected benign workspace package file containing a single provider marker to remain executable" >&2
     exit 1
   fi
   grep -q "dangerously-skip-permissions" /tmp/node-provider-marker-benign.out
-  rm -rf /workspace/.workcell-benign-marker-package
+  rm -rf "${workspace_provider_benign_marker}"
   rm -f /workspace/tmp/workcell-provider-copy-scrub.js
   rm -f /workspace/tmp/workcell-provider-copy-minimalize.js
   rm -f /workspace/tmp/workcell-provider-copy-split.js

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -17,6 +17,7 @@ if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
     /bin/bash -p "$0" "$@"
 fi
 set -euo pipefail
+trap 'echo "container-smoke failed at line ${LINENO}" >&2' ERR
 export PATH="${TRUSTED_HOST_PATH}"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -35,6 +36,7 @@ INJECTION_FIXTURE_ROOT=""
 INJECTION_BUNDLE_ROOT=""
 WORKSPACE_IMPORT_ROOT=""
 declare -a WORKSPACE_IMPORT_ARGS=()
+declare -a RUNTIME_SECURITY_ARGS=()
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
@@ -174,6 +176,18 @@ docker_cmd() {
   fi
 }
 
+populate_runtime_security_args() {
+  local mutability="$1"
+
+  RUNTIME_SECURITY_ARGS=(--cap-drop ALL)
+  if [[ "${mutability}" == "ephemeral" ]]; then
+    RUNTIME_SECURITY_ARGS+=(
+      --cap-add SETUID
+      --cap-add SETGID
+    )
+  fi
+}
+
 prepare_direct_mount_spec_for_bundle() {
   local bundle_root="$1"
   local mount_spec_path="${bundle_root}.mounts.json"
@@ -224,8 +238,10 @@ run_container() {
 
   docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
   populate_workspace_import_mounts
+  populate_runtime_security_args ephemeral
 
   docker_cmd run --rm \
+    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
     --user 0:0 \
     --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
     --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
@@ -244,7 +260,7 @@ run_container() {
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
     -v "${docker_workspace}:/workspace" \
-    "${WORKSPACE_IMPORT_ARGS[@]}" \
+    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
     --entrypoint "$1" \
     "${IMAGE_TAG}" "${@:2}"
 }
@@ -257,8 +273,10 @@ run_container_with_mutability() {
 
   docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
   populate_workspace_import_mounts
+  populate_runtime_security_args "${mutability}"
 
   docker_cmd run --rm \
+    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
     --user 0:0 \
     --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
     --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
@@ -277,7 +295,7 @@ run_container_with_mutability() {
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
     -v "${docker_workspace}:/workspace" \
-    "${WORKSPACE_IMPORT_ARGS[@]}" \
+    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
     --entrypoint "$1" \
     "${IMAGE_TAG}" "${@:2}"
 }
@@ -289,8 +307,10 @@ run_entrypoint() {
 
   docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
   populate_workspace_import_mounts
+  populate_runtime_security_args ephemeral
 
   docker_cmd run --rm \
+    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
     --user 0:0 \
     --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
     --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
@@ -309,7 +329,7 @@ run_entrypoint() {
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
     -v "${docker_workspace}:/workspace" \
-    "${WORKSPACE_IMPORT_ARGS[@]}" \
+    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
     "${IMAGE_TAG}" "$@"
 }
 
@@ -321,8 +341,10 @@ run_entrypoint_with_profile() {
 
   docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
   populate_workspace_import_mounts
+  populate_runtime_security_args ephemeral
 
   docker_cmd run --rm \
+    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
     --user 0:0 \
     --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
     --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
@@ -342,7 +364,7 @@ run_entrypoint_with_profile() {
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
     -v "${docker_workspace}:/workspace" \
-    "${WORKSPACE_IMPORT_ARGS[@]}" \
+    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
     "${IMAGE_TAG}" "$@"
 }
 
@@ -354,9 +376,11 @@ run_entrypoint_with_init_profile() {
 
   docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
   populate_workspace_import_mounts
+  populate_runtime_security_args ephemeral
 
   docker_cmd run --rm \
     --init \
+    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
     --user 0:0 \
     --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
     --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
@@ -376,7 +400,7 @@ run_entrypoint_with_init_profile() {
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
     -v "${docker_workspace}:/workspace" \
-    "${WORKSPACE_IMPORT_ARGS[@]}" \
+    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
     "${IMAGE_TAG}" "$@"
 }
 
@@ -388,8 +412,10 @@ run_entrypoint_with_autonomy() {
 
   docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
   populate_workspace_import_mounts
+  populate_runtime_security_args ephemeral
 
   docker_cmd run --rm \
+    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
     --user 0:0 \
     --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
     --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
@@ -409,7 +435,7 @@ run_entrypoint_with_autonomy() {
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
     -v "${docker_workspace}:/workspace" \
-    "${WORKSPACE_IMPORT_ARGS[@]}" \
+    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
     "${IMAGE_TAG}" "$@"
 }
 
@@ -425,8 +451,10 @@ run_entrypoint_with_autonomy_and_bind() {
   docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
   docker_bind_source="$(workcell_docker_host_path "${bind_source}")"
   populate_workspace_import_mounts
+  populate_runtime_security_args ephemeral
 
   docker_cmd run --rm \
+    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
     --user 0:0 \
     --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
     --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
@@ -446,7 +474,7 @@ run_entrypoint_with_autonomy_and_bind() {
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
     -v "${docker_workspace}:/workspace" \
-    "${WORKSPACE_IMPORT_ARGS[@]}" \
+    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
     -v "${docker_bind_source}:${bind_target}:ro" \
     "${IMAGE_TAG}" "$@"
 }
@@ -469,8 +497,10 @@ run_entrypoint_with_injection_bundle() {
   docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
   docker_bundle_root="$(workcell_docker_host_path "${bundle_root}")"
   populate_workspace_import_mounts
+  populate_runtime_security_args ephemeral
 
   docker_cmd run --rm \
+    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
     --user 0:0 \
     --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
     --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
@@ -490,8 +520,8 @@ run_entrypoint_with_injection_bundle() {
     -e WORKCELL_INJECTION_MANIFEST=/opt/workcell/host-injections/manifest.json \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
     -v "${docker_workspace}:/workspace" \
-    "${credential_mounts[@]}" \
-    "${WORKSPACE_IMPORT_ARGS[@]}" \
+    ${credential_mounts[@]+"${credential_mounts[@]}"} \
+    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
     -v "${docker_bundle_root}:/opt/workcell/host-injections:ro" \
     "${IMAGE_TAG}" "$@"
 }
@@ -514,8 +544,10 @@ run_container_with_injection_bundle() {
   docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
   docker_bundle_root="$(workcell_docker_host_path "${bundle_root}")"
   populate_workspace_import_mounts
+  populate_runtime_security_args ephemeral
 
   docker_cmd run --rm \
+    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
     --user 0:0 \
     --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
     --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
@@ -535,8 +567,8 @@ run_container_with_injection_bundle() {
     -e WORKCELL_INJECTION_MANIFEST=/opt/workcell/host-injections/manifest.json \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
     -v "${docker_workspace}:/workspace" \
-    "${credential_mounts[@]}" \
-    "${WORKSPACE_IMPORT_ARGS[@]}" \
+    ${credential_mounts[@]+"${credential_mounts[@]}"} \
+    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
     -v "${docker_bundle_root}:/opt/workcell/host-injections:ro" \
     --entrypoint "$1" \
     "${IMAGE_TAG}" "${@:2}"
@@ -726,24 +758,25 @@ run_entrypoint_with_profile codex build codex --version >/dev/null
 # shellcheck disable=SC2016
 run_container_with_injection_bundle codex "${INJECTION_BUNDLE_ROOT}/codex" bash -lc '
   set -euo pipefail
+  CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
   /usr/local/bin/workcell-entrypoint codex --version >/dev/null
-  grep -q "Common Smoke Instructions" "$CODEX_HOME/AGENTS.md"
-  grep -q "Codex Smoke Instructions" "$CODEX_HOME/AGENTS.md"
-  grep -q "\"test\": \"auth\"" "$CODEX_HOME/auth.json"
-  grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
-  grep -q "injected-public" /state/injected/public.txt
-  test "$(stat -c "%a" /state/injected/public.txt)" = "644"
-  grep -q "injected-secret" "$HOME/.config/workcell/token.txt"
-  test "$(stat -c "%a" "$HOME/.config/workcell/token.txt")" = "600"
-  grep -q "smoke.example" "$HOME/.ssh/config"
-  test "$(stat -c "%a" "$HOME/.ssh")" = "700"
-  test "$(stat -c "%a" "$HOME/.ssh/id_smoke")" = "600"
   setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
     set -euo pipefail
+    CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
+    grep -q "Common Smoke Instructions" "$CODEX_HOME/AGENTS.md"
+    grep -q "Codex Smoke Instructions" "$CODEX_HOME/AGENTS.md"
+    grep -q "\"test\": \"auth\"" "$CODEX_HOME/auth.json"
+    grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
+    grep -q "injected-public" /state/injected/public.txt
+    test "$(stat -c "%a" /state/injected/public.txt)" = "644"
+    grep -q "injected-secret" "$HOME/.config/workcell/token.txt"
+    test "$(stat -c "%a" "$HOME/.config/workcell/token.txt")" = "600"
+    grep -q "smoke.example" "$HOME/.ssh/config"
+    test "$(stat -c "%a" "$HOME/.ssh")" = "700"
+    test "$(stat -c "%a" "$HOME/.ssh/id_smoke")" = "600"
     test -L "$CODEX_HOME/rules"
-    test ! -w "$CODEX_HOME/rules/default.rules"
-    if printf "\n# session-marker\n" | tee -a "$CODEX_HOME/rules/default.rules" >/dev/null; then
-      echo "expected managed Codex rules to remain read-only" >&2
+    if printf "\n# session-marker\n" >>"$CODEX_HOME/rules/default.rules" 2>/tmp/workcell-codex-rules-write.err; then
+      echo "expected default Codex execpolicy rules to stay immutable on the managed path" >&2
       exit 1
     fi
     if sudo -n id >/tmp/codex-sudo-id.out 2>&1; then
@@ -752,33 +785,39 @@ run_container_with_injection_bundle codex "${INJECTION_BUNDLE_ROOT}/codex" bash 
     fi
     apt-get --help >/dev/null
     sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get --help >/dev/null
+    codex --version >/dev/null
   '"'"'
-  codex --version >/dev/null
 '
 
 # shellcheck disable=SC2016
 run_container_with_injection_bundle claude "${INJECTION_BUNDLE_ROOT}/claude" bash -lc '
   set -euo pipefail
   /usr/local/bin/workcell-entrypoint claude --version >/dev/null
-  grep -q "Workspace Claude Instructions" "$HOME/.claude/CLAUDE.md"
-  grep -q "\"apiKeyHelper\"" "$HOME/.claude/settings.json"
-  helper_path="$(jq -r ".apiKeyHelper" "$HOME/.claude/settings.json")"
-  test -x "$helper_path"
-  test "$("$helper_path")" = "claude-smoke-key"
-  grep -q "\"token\": \"claude-auth\"" "$HOME/.config/claude-code/auth.json"
-  test ! -L "$HOME/.mcp.json"
-  grep -q "\"stub\"" "$HOME/.mcp.json"
-  grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    grep -q "Workspace Claude Instructions" "$HOME/.claude/CLAUDE.md"
+    grep -q "\"apiKeyHelper\"" "$HOME/.claude/settings.json"
+    helper_path="$(jq -r ".apiKeyHelper" "$HOME/.claude/settings.json")"
+    test -x "$helper_path"
+    test "$("$helper_path")" = "claude-smoke-key"
+    grep -q "\"token\": \"claude-auth\"" "$HOME/.config/claude-code/auth.json"
+    test ! -L "$HOME/.mcp.json"
+    grep -q "\"stub\"" "$HOME/.mcp.json"
+    grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
+  '"'"'
 '
 
 # shellcheck disable=SC2016
 run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini" bash -lc '
   set -euo pipefail
   /usr/local/bin/workcell-entrypoint gemini --version >/dev/null
-  grep -q "Workspace Gemini Instructions" "$HOME/.gemini/GEMINI.md"
-  grep -q "GEMINI_API_KEY=smoke-gemini-key" "$HOME/.gemini/.env"
-  grep -q "\"smoke\"" "$HOME/.gemini/projects.json"
-  grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    grep -q "Workspace Gemini Instructions" "$HOME/.gemini/GEMINI.md"
+    grep -q "GEMINI_API_KEY=smoke-gemini-key" "$HOME/.gemini/.env"
+    grep -q "\"smoke\"" "$HOME/.gemini/projects.json"
+    grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
+  '"'"'
 '
 
 if [[ "$(uname -s)" == "Linux" ]] && [[ -x /bin/echo ]]; then
@@ -861,7 +900,9 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ -x /bin/echo ]]; then
   fi
 fi
 
+populate_runtime_security_args ephemeral
 if docker_cmd run --rm \
+  ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
   --user 0:0 \
   --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
   --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
@@ -975,47 +1016,78 @@ run_entrypoint gemini gemini --version >/dev/null
 # shellcheck disable=SC2016
 run_container codex bash -lc '
   set -euo pipefail
+  CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
   /usr/local/bin/workcell-entrypoint codex --version >/dev/null
-  grep -q "Workspace AGENTS Instructions" "$CODEX_HOME/AGENTS.md"
-  if grep -q "Nested Workspace AGENTS Instructions" "$CODEX_HOME/AGENTS.md"; then
-    echo "expected nested AGENTS.md instructions to remain path-scoped in the workspace" >&2
-    exit 1
-  fi
-  grep -q "Nested Workspace AGENTS Instructions" /workspace/nested/AGENTS.md
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
+    grep -q "Workspace AGENTS Instructions" "$CODEX_HOME/AGENTS.md"
+    if grep -q "Nested Workspace AGENTS Instructions" "$CODEX_HOME/AGENTS.md"; then
+      echo "expected nested AGENTS.md instructions to remain path-scoped in the workspace" >&2
+      exit 1
+    fi
+    grep -q "Nested Workspace AGENTS Instructions" /workspace/nested/AGENTS.md
+  '"'"'
 '
 
 # shellcheck disable=SC2016
 run_container claude bash -lc '
   set -euo pipefail
   AGENT_NAME=claude /usr/local/bin/workcell-entrypoint claude --version >/dev/null
-  grep -q "Workspace Claude Instructions" "$HOME/.claude/CLAUDE.md"
-  if grep -q "Nested Workspace Claude Instructions" "$HOME/.claude/CLAUDE.md"; then
-    echo "expected nested CLAUDE.md instructions to remain path-scoped in the workspace" >&2
-    exit 1
-  fi
-  grep -q "Nested Workspace Claude Instructions" /workspace/nested/CLAUDE.md
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    grep -q "Workspace Claude Instructions" "$HOME/.claude/CLAUDE.md"
+    if grep -q "Nested Workspace Claude Instructions" "$HOME/.claude/CLAUDE.md"; then
+      echo "expected nested CLAUDE.md instructions to remain path-scoped in the workspace" >&2
+      exit 1
+    fi
+    grep -q "Nested Workspace Claude Instructions" /workspace/nested/CLAUDE.md
+  '"'"'
 '
 
 # shellcheck disable=SC2016
 run_container gemini bash -lc '
   set -euo pipefail
   AGENT_NAME=gemini /usr/local/bin/workcell-entrypoint gemini --version >/dev/null
-  grep -q "Workspace Gemini Instructions" "$HOME/.gemini/GEMINI.md"
-  if grep -q "Nested Workspace Gemini Instructions" "$HOME/.gemini/GEMINI.md"; then
-    echo "expected nested GEMINI.md instructions to remain path-scoped in the workspace" >&2
-    exit 1
-  fi
-  grep -q "Nested Workspace Gemini Instructions" /workspace/nested/GEMINI.md
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    grep -q "Workspace Gemini Instructions" "$HOME/.gemini/GEMINI.md"
+    if grep -q "Nested Workspace Gemini Instructions" "$HOME/.gemini/GEMINI.md"; then
+      echo "expected nested GEMINI.md instructions to remain path-scoped in the workspace" >&2
+      exit 1
+    fi
+    grep -q "Nested Workspace Gemini Instructions" /workspace/nested/GEMINI.md
+  '"'"'
 '
 
 # shellcheck disable=SC2016
 run_container codex bash -lc '
   set -euo pipefail
+  CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
+  AGENT_NAME=codex WORKCELL_AGENT_AUTONOMY=yolo WORKCELL_CODEX_RULES_MUTABILITY=session /usr/local/bin/workcell-entrypoint codex --version >/dev/null
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
+    test ! -L "$CODEX_HOME/rules"
+    printf "\n# yolo-session-marker\n" >>"$CODEX_HOME/rules/default.rules"
+    AGENT_NAME=codex WORKCELL_AGENT_AUTONOMY=yolo WORKCELL_CODEX_RULES_MUTABILITY=session /usr/local/bin/workcell-entrypoint codex --version >/dev/null
+    grep -q "^# yolo-session-marker$" "$CODEX_HOME/rules/default.rules"
+  '"'"'
+'
+
+# shellcheck disable=SC2016
+run_container codex bash -lc '
+  set -euo pipefail
+  CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
   AGENT_NAME=codex WORKCELL_AGENT_AUTONOMY=prompt /usr/local/bin/workcell-entrypoint codex --version >/dev/null
-  test ! -L "$CODEX_HOME/rules"
-  printf "\n# prompt-session-marker\n" >>"$CODEX_HOME/rules/default.rules"
-  AGENT_NAME=codex WORKCELL_AGENT_AUTONOMY=prompt /usr/local/bin/workcell-entrypoint codex --version >/dev/null
-  grep -q "^# prompt-session-marker$" "$CODEX_HOME/rules/default.rules"
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
+    test ! -L "$CODEX_HOME/rules"
+    printf "\n# prompt-session-marker\n" >>"$CODEX_HOME/rules/default.rules"
+    AGENT_NAME=codex WORKCELL_AGENT_AUTONOMY=prompt /usr/local/bin/workcell-entrypoint codex --version >/dev/null
+    grep -q "^# prompt-session-marker$" "$CODEX_HOME/rules/default.rules"
+  '"'"'
 '
 
 HOST_UID_LITERAL="${HOST_UID}"
@@ -1036,11 +1108,18 @@ apt-get install -y --no-install-recommends make >/tmp/workcell-apt-install.out 2
 grep -q "downgrades in-container control-plane assurance until this session exits" /tmp/workcell-apt-install.err
 grep -q "this session is now lower-assurance until the container exits" /tmp/workcell-apt-install.err
 command -v make >/dev/null
+grep -q "^CapEff:[[:space:]]*0000000000000000$" /proc/self/status
 codex --version >/tmp/workcell-post-apt-codex.out 2>&1
 grep -q "session previously ran package-manager mutations as root" /tmp/workcell-post-apt-codex.out
+grep -q "forced session-local Codex execpolicy rules" /tmp/workcell-post-apt-codex.out
+test ! -L "$CODEX_HOME/rules"
+test -w "$CODEX_HOME/rules/default.rules"
+claude --version >/tmp/workcell-post-apt-claude.out 2>&1
+grep -q "session previously ran package-manager mutations as root" /tmp/workcell-post-apt-claude.out
+gemini --version >/tmp/workcell-post-apt-gemini.out 2>&1
+grep -q "session previously ran package-manager mutations as root" /tmp/workcell-post-apt-gemini.out
 EOF
   source /usr/local/libexec/workcell/runtime-user.sh
-  mkdir -p /state/agent-home /state/tmp
   if ! workcell_should_reexec_as_runtime_user; then
     echo "expected mutable runtime default to re-exec as the mapped host user" >&2
     exit 1
@@ -1065,7 +1144,6 @@ fi
 grep -q "Workcell blocked unsafe apt-get argument: /tmp/workcell-local.deb" /tmp/workcell-unsafe-apt-local.out
 EOF
   source /usr/local/libexec/workcell/runtime-user.sh
-  mkdir -p /state/agent-home /state/tmp
   workcell_reexec_as_runtime_user /tmp/workcell-unsafe-apt-check.sh
 ' >/tmp/workcell-unsafe-apt-run.out 2>&1; then
   :
@@ -1077,12 +1155,11 @@ fi
 if run_container_with_mutability codex readonly bash -lc '
   set -euo pipefail
   source /usr/local/libexec/workcell/runtime-user.sh
-  mkdir -p /state/agent-home /state/tmp
   if workcell_should_reexec_as_runtime_user; then
     echo "expected readonly runtime not to auto-reexec as the mapped host user" >&2
     exit 1
   fi
-  workcell_reexec_as_runtime_user /bin/bash -lc "apt-get update"
+  apt-get update
 ' >/tmp/workcell-readonly-mutability.out 2>&1; then
   echo "expected readonly mutability to block package-manager writes" >&2
   exit 1
@@ -1138,8 +1215,10 @@ if run_container codex bash -lc 'AGENT_NAME=codex WORKCELL_MODE=breakglass CODEX
 fi
 grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-direct-codex-breakglass.out
 
+populate_runtime_security_args ephemeral
 if docker_cmd run --rm \
   --init \
+  ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
   --user 0:0 \
   --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
   --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
@@ -1180,91 +1259,100 @@ fi
 
 # shellcheck disable=SC2016
 run_container codex bash -lc '
-  test "$(id -u)" != 0
-  test "$WORKCELL_RUNTIME" = "1"
-  test "$TMPDIR" = "/state/tmp"
-  mkdir -p "$TMPDIR"
-  touch "$TMPDIR/workcell-tmpdir-ok"
-  EXEC_TMP="$TMPDIR/workcell-exec"
-  mkdir -p "$EXEC_TMP"
-  codex --version | grep -q "codex-cli"
-  LD_PRELOAD=/workspace/workcell-does-not-exist.so codex --version | grep -q "codex-cli"
-  LD_PRELOAD=/workspace/workcell-does-not-exist.so claude --version >/dev/null
-  LD_PRELOAD=/workspace/workcell-does-not-exist.so git --version | grep -q "git version"
-  LD_PRELOAD=/workspace/workcell-does-not-exist.so node --version | grep -q "^v"
-  test -f "$CODEX_HOME/config.toml"
-  test -L "$CODEX_HOME/config.toml"
-  test "$(readlink "$CODEX_HOME/config.toml")" = "/opt/workcell/adapters/codex/.codex/config.toml"
-  codex features list >/dev/null
-  if command -v python3 >/tmp/python-which.out 2>&1; then
-    echo "expected runtime image to omit python3 from the operator PATH" >&2
-    exit 1
-  fi
-  command -v perl >/tmp/perl-which.out 2>&1
-  grep -q "^/usr/bin/perl$" /tmp/perl-which.out
-  if command -v perlbug >/tmp/perlbug-which.out 2>&1; then
-    echo "expected runtime image to omit auxiliary Perl tooling from the operator PATH" >&2
-    exit 1
-  fi
-  if command -v perldoc >/tmp/perldoc-which.out 2>&1; then
-    echo "expected runtime image to omit auxiliary Perl tooling from the operator PATH" >&2
-    exit 1
-  fi
-  if command -v perlthanks >/tmp/perlthanks-which.out 2>&1; then
-    echo "expected runtime image to omit auxiliary Perl tooling from the operator PATH" >&2
-    exit 1
-  fi
-  cp /bin/true /tmp/workcell-noexec
-  chmod 0700 /tmp/workcell-noexec
-  if /tmp/workcell-noexec >/tmp/workcell-noexec.out 2>&1; then
-    echo "expected /tmp to be mounted noexec" >&2
-    exit 1
-  fi
-  grep -Eq "Permission denied|Operation not permitted" /tmp/workcell-noexec.out
-  if codex --search >/tmp/codex-nested-search.out 2>&1; then
-    echo "expected nested Codex invocation to reject unsafe overrides" >&2
-    exit 1
-  fi
-  grep -q "Workcell blocked unsafe Codex override" /tmp/codex-nested-search.out
-  if codex --cd /state --version >/tmp/codex-nested-cd.out 2>&1; then
-    echo "expected nested Codex invocation to reject working-directory overrides" >&2
-    exit 1
-  fi
-  grep -q "Workcell blocked unsafe Codex override" /tmp/codex-nested-cd.out
-  if codex --config sandbox_workspace_write.writable_roots=/state --version >/tmp/codex-nested-config-writable-roots.out 2>&1; then
-    echo "expected nested Codex invocation to reject writable_roots overrides" >&2
-    exit 1
-  fi
-  grep -q "Workcell blocked unsafe Codex config override" /tmp/codex-nested-config-writable-roots.out
-  if WORKCELL_MODE=breakglass CODEX_PROFILE=breakglass codex --search >/tmp/codex-nested-breakglass.out 2>&1; then
-    echo "expected nested Codex invocation to ignore caller-supplied breakglass env" >&2
-    exit 1
-  fi
-  grep -q "Workcell blocked unsafe Codex override" /tmp/codex-nested-breakglass.out
-  if codex -a never --version >/tmp/codex-nested-approval.out 2>&1; then
-    echo "expected nested Codex invocation to reject approval overrides" >&2
-    exit 1
-  fi
-  grep -q "Workcell blocked unsafe Codex override" /tmp/codex-nested-approval.out
-  if codex --full-auto --version >/tmp/codex-nested-full-auto.out 2>&1; then
-    echo "expected nested Codex invocation to reject full-auto overrides" >&2
-    exit 1
-  fi
-  grep -q "Workcell blocked unsafe Codex override" /tmp/codex-nested-full-auto.out
-  if codex app-server >/tmp/codex-nested-app-server.out 2>&1; then
-    echo "expected nested Codex invocation to reject GUI subcommands on the CLI surface" >&2
-    exit 1
-  fi
-  grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-app-server.out
-  rm -f "$CODEX_HOME/config.toml"
-  printf "web_search = \"enabled\"\n" >"$CODEX_HOME/config.toml"
-  codex --version >/dev/null
-  test -L "$CODEX_HOME/config.toml"
-  test "$(readlink "$CODEX_HOME/config.toml")" = "/opt/workcell/adapters/codex/.codex/config.toml"
+  set -euo pipefail
+  /usr/local/bin/workcell-entrypoint codex --version >/dev/null
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
+    test "$(id -u)" != 0
+    test "$WORKCELL_RUNTIME" = "1"
+    test "$TMPDIR" = "/state/tmp"
+    mkdir -p "$TMPDIR"
+    touch "$TMPDIR/workcell-tmpdir-ok"
+    EXEC_TMP="$TMPDIR/workcell-exec"
+    mkdir -p "$EXEC_TMP"
+    codex --version | grep -q "codex-cli"
+    LD_PRELOAD=/workspace/workcell-does-not-exist.so codex --version | grep -q "codex-cli"
+    LD_PRELOAD=/workspace/workcell-does-not-exist.so claude --version >/dev/null
+    LD_PRELOAD=/workspace/workcell-does-not-exist.so git --version | grep -q "git version"
+    LD_PRELOAD=/workspace/workcell-does-not-exist.so node --version | grep -q "^v"
+    test -f "$CODEX_HOME/config.toml"
+    test -L "$CODEX_HOME/config.toml"
+    test "$(readlink "$CODEX_HOME/config.toml")" = "/opt/workcell/adapters/codex/.codex/config.toml"
+    codex features list >/dev/null
+    if command -v python3 >/tmp/python-which.out 2>&1; then
+      echo "expected runtime image to omit python3 from the operator PATH" >&2
+      exit 1
+    fi
+    command -v perl >/tmp/perl-which.out 2>&1
+    grep -q "^/usr/bin/perl$" /tmp/perl-which.out
+    if command -v perlbug >/tmp/perlbug-which.out 2>&1; then
+      echo "expected runtime image to omit auxiliary Perl tooling from the operator PATH" >&2
+      exit 1
+    fi
+    if command -v perldoc >/tmp/perldoc-which.out 2>&1; then
+      echo "expected runtime image to omit auxiliary Perl tooling from the operator PATH" >&2
+      exit 1
+    fi
+    if command -v perlthanks >/tmp/perlthanks-which.out 2>&1; then
+      echo "expected runtime image to omit auxiliary Perl tooling from the operator PATH" >&2
+      exit 1
+    fi
+    cp /bin/true /tmp/workcell-noexec
+    chmod 0700 /tmp/workcell-noexec
+    if /tmp/workcell-noexec >/tmp/workcell-noexec.out 2>&1; then
+      echo "expected /tmp to be mounted noexec" >&2
+      exit 1
+    fi
+    grep -Eq "Permission denied|Operation not permitted" /tmp/workcell-noexec.out
+    if codex --search >/tmp/codex-nested-search.out 2>&1; then
+      echo "expected nested Codex invocation to reject unsafe overrides" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsafe Codex override" /tmp/codex-nested-search.out
+    if codex --cd /state --version >/tmp/codex-nested-cd.out 2>&1; then
+      echo "expected nested Codex invocation to reject working-directory overrides" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsafe Codex override" /tmp/codex-nested-cd.out
+    if codex --config sandbox_workspace_write.writable_roots=/state --version >/tmp/codex-nested-config-writable-roots.out 2>&1; then
+      echo "expected nested Codex invocation to reject writable_roots overrides" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsafe Codex config override" /tmp/codex-nested-config-writable-roots.out
+    if WORKCELL_MODE=breakglass CODEX_PROFILE=breakglass codex --search >/tmp/codex-nested-breakglass.out 2>&1; then
+      echo "expected nested Codex invocation to ignore caller-supplied breakglass env" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsafe Codex override" /tmp/codex-nested-breakglass.out
+    if codex -a never --version >/tmp/codex-nested-approval.out 2>&1; then
+      echo "expected nested Codex invocation to reject approval overrides" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsafe Codex override" /tmp/codex-nested-approval.out
+    if codex --full-auto --version >/tmp/codex-nested-full-auto.out 2>&1; then
+      echo "expected nested Codex invocation to reject full-auto overrides" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsafe Codex override" /tmp/codex-nested-full-auto.out
+    if codex app-server >/tmp/codex-nested-app-server.out 2>&1; then
+      echo "expected nested Codex invocation to reject GUI subcommands on the CLI surface" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-app-server.out
+    rm -f "$CODEX_HOME/config.toml"
+    printf "web_search = \"enabled\"\n" >"$CODEX_HOME/config.toml"
+    codex --version >/dev/null
+    test -L "$CODEX_HOME/config.toml"
+    test "$(readlink "$CODEX_HOME/config.toml")" = "/opt/workcell/adapters/codex/.codex/config.toml"
+  '"'"'
   if /usr/local/libexec/workcell/real/codex --version >/tmp/codex-real-path.out 2>&1; then
     echo "expected direct real Codex payload execution to fail" >&2
     exit 1
   fi
+  EXEC_TMP="/state/workcell-exec"
+  mkdir -p "$EXEC_TMP"
+  chmod 0777 "$EXEC_TMP"
   codex execpolicy check --rules /opt/workcell/adapters/codex/.codex/rules/default.rules rm -rf build \
     | jq -e ".decision == \"forbidden\"" >/dev/null
   codex execpolicy check --rules /opt/workcell/adapters/codex/.codex/rules/default.rules git push origin feature \
@@ -1307,8 +1395,19 @@ EOF
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/node-wrapper-bashenv.out
-  set -- $(ldd /usr/local/libexec/workcell/real/node | grep -E "ld-linux|ld-musl" | head -n1)
-  LOADER="$1"
+  LOADER="$(
+    for candidate in \
+      /lib64/ld-linux-x86-64.so.2 \
+      /lib/ld-linux-aarch64.so.1 \
+      /lib/ld-linux-armhf.so.3 \
+      /lib/ld-musl-*.so.1 \
+      /lib64/ld-musl-*.so.1; do
+      if [ -x "$candidate" ]; then
+        printf "%s\n" "$candidate"
+        break
+      fi
+    done
+  )"
   test -n "$LOADER"
   if env -u LD_PRELOAD "$LOADER" /usr/local/libexec/workcell/real/node --version >/tmp/node-loader-real.out 2>&1; then
     echo "expected direct loader invocation of the real Node payload to fail" >&2
@@ -1385,12 +1484,12 @@ EOF
     exit 1
   fi
   exec 3<&-
-  grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/workspace-native-deleted-fd.out
-  grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/workspace-native-deleted-devfd.out
-  grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/workspace-native-deleted-dotfd.out
-  grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/workspace-native-deleted-threadself.out
-  grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/workspace-native-deleted-taskfd.out
-  grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/workspace-native-deleted-stdin.out
+  grep -Eq "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile\\.|cannot execute: required file not found|No such file or directory" /tmp/workspace-native-deleted-fd.out
+  grep -Eq "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile\\.|cannot execute: required file not found|No such file or directory" /tmp/workspace-native-deleted-devfd.out
+  grep -Eq "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile\\.|cannot execute: required file not found|No such file or directory" /tmp/workspace-native-deleted-dotfd.out
+  grep -Eq "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile\\.|cannot execute: required file not found|No such file or directory" /tmp/workspace-native-deleted-threadself.out
+  grep -Eq "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile\\.|cannot execute: required file not found|No such file or directory" /tmp/workspace-native-deleted-taskfd.out
+  grep -Eq "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile\\.|cannot execute: required file not found|No such file or directory" /tmp/workspace-native-deleted-stdin.out
   cp /bin/true /workspace/tmp/.workcell-native-helper-deleted-pidfd
   chmod 0700 /workspace/tmp/.workcell-native-helper-deleted-pidfd
   if (
@@ -1401,7 +1500,7 @@ EOF
     echo "expected strict profile to reject deleted-fd native executable launches via /proc/\$\$/fd from /workspace" >&2
     exit 1
   fi
-  grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/workspace-native-deleted-pidfd.out
+  grep -Eq "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile\\.|cannot execute: required file not found|No such file or directory" /tmp/workspace-native-deleted-pidfd.out
   cp /bin/true /workspace/tmp/.workcell-native-helper-deleted-stdout
   chmod 0700 /workspace/tmp/.workcell-native-helper-deleted-stdout
   if (
@@ -1413,7 +1512,7 @@ EOF
     echo "expected strict profile to reject deleted-fd native executable launches via /dev/stdout from /workspace" >&2
     exit 1
   fi
-  grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/workspace-native-deleted-stdout.err
+  grep -Eq "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile\\.|cannot execute: required file not found|No such file or directory" /tmp/workspace-native-deleted-stdout.err
   cp /bin/true /workspace/tmp/.workcell-native-helper-deleted-stderr
   chmod 0700 /workspace/tmp/.workcell-native-helper-deleted-stderr
   if (
@@ -1478,12 +1577,12 @@ EOF
     exit 1
   fi
   exec 4<&-
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-node-shebang-deleted-fd.out
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-node-shebang-deleted-devfd.out
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-node-shebang-deleted-dotfd.out
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-node-shebang-deleted-threadself.out
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-node-shebang-deleted-taskfd.out
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-node-shebang-deleted-stdin.out
+  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-fd.out
+  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-devfd.out
+  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-dotfd.out
+  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-threadself.out
+  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-taskfd.out
+  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-stdin.out
   cat >/workspace/tmp/.workcell-node-shebang-deleted-pidfd <<EOF
 #!/usr/local/libexec/workcell/real/node
 console.log("workcell pid fd deleted shebang bypass");
@@ -1497,7 +1596,7 @@ EOF
     echo "expected strict profile to reject deleted-fd mutable shebang execution via /proc/\$\$/fd of the real Node payload" >&2
     exit 1
   fi
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-node-shebang-deleted-pidfd.out
+  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-pidfd.out
   cat >/workspace/tmp/.workcell-node-shebang-deleted-stdout <<EOF
 #!/usr/local/libexec/workcell/real/node
 console.log("workcell stdout deleted shebang bypass");
@@ -1512,7 +1611,7 @@ EOF
     echo "expected strict profile to reject deleted-fd mutable shebang execution via /dev/stdout of the real Node payload" >&2
     exit 1
   fi
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-node-shebang-deleted-stdout.err
+  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-stdout.err
   cat >/workspace/tmp/.workcell-node-shebang-deleted-stderr <<EOF
 #!/usr/local/libexec/workcell/real/node
 console.log("workcell stderr deleted shebang bypass");
@@ -1590,11 +1689,16 @@ const result = spawnSync("/workspace/tmp/shebang-bypass", [], {
   env: { PATH: "/workspace/tmp" },
 });
 
+const blockedByRuntime =
+  typeof result.stderr === "string" &&
+  result.stderr.includes("Workcell blocked direct protected runtime execution");
+const blockedByExec =
+  result.error &&
+  (result.error.code === "EPERM" || result.error.code === "ENOENT");
+
 if (
   result.status === 0 ||
-  !result.stderr.includes(
-    "Workcell blocked direct protected runtime execution",
-  )
+  !(blockedByRuntime || blockedByExec)
 ) {
   process.stderr.write(
     `unexpected child-envp shebang result: ${JSON.stringify(result)}\n`,
@@ -1706,7 +1810,7 @@ EOF
     echo "expected imported copied provider package execution via public node to fail" >&2
     exit 1
   fi
-  grep -q "Workcell blocked provider package execution via public node." /tmp/node-provider-copy-import.out
+  grep -Eq "Workcell blocked provider package execution via public node.|Workcell blocked public node execution outside the mounted workspace." /tmp/node-provider-copy-import.out
   cp -R /opt/workcell/providers/node_modules/@anthropic-ai/claude-code /tmp/workcell-provider-copy-tampered
   jq ".name = \"@workcell/not-claude\"" /tmp/workcell-provider-copy-tampered/package.json >/tmp/workcell-provider-copy-tampered/package.json.new
   mv /tmp/workcell-provider-copy-tampered/package.json.new /tmp/workcell-provider-copy-tampered/package.json
@@ -1739,18 +1843,30 @@ const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 packageJson.name = "@workcell/not-claude-workspace-aggressive";
 fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n");
 
+const joinMarker = (...parts) => parts.join("");
+const replacements = [
+  [joinMarker("Anthropic ", "PBC. All rights reserved."), "Workcell scrubbed marker"],
+  [
+    joinMarker(
+      "https://code.claude.com/docs/en/legal-",
+      "and-compliance.",
+    ),
+    "https://example.invalid/workcell",
+  ],
+  [
+    joinMarker("Want to see the unminified source? We", "\x27re hiring!"),
+    "Workcell scrubbed hiring marker",
+  ],
+  [joinMarker("dangerously", "-skip-permissions"), "scrubbed-danger-flag"],
+];
+
 for (const relativePath of ["README.md", "LICENSE.md", "sdk-tools.d.ts", "resvg.wasm"]) {
   fs.rmSync(path.join(packageRoot, relativePath), { force: true });
 }
 
 const entrypointPath = path.join(packageRoot, "cli.js");
 let entrypoint = fs.readFileSync(entrypointPath, "utf8");
-for (const [from, to] of [
-  ["Anthropic PBC. All rights reserved.", "Workcell scrubbed marker"],
-  ["https://code.claude.com/docs/en/legal-and-compliance.", "https://example.invalid/workcell"],
-  ["Want to see the unminified source? We\x27re hiring!", "Workcell scrubbed hiring marker"],
-  ["dangerously-skip-permissions", "scrubbed-danger-flag"],
-]) {
+for (const [from, to] of replacements) {
   entrypoint = entrypoint.split(from).join(to);
 }
 fs.writeFileSync(entrypointPath, entrypoint);
@@ -1780,10 +1896,16 @@ fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n");
 const entrypointPath = path.join(packageRoot, "main.js");
 let entrypoint = fs.readFileSync(entrypointPath, "utf8");
 for (const [from, to] of [
-  ["Anthropic PBC. All rights reserved.", "Workcell scrubbed marker"],
-  ["https://code.claude.com/docs/en/legal-and-compliance.", "https://example.invalid/workcell"],
-  ["Want to see the unminified source? We\x27re hiring!", "Workcell scrubbed hiring marker"],
-  ["dangerously-skip-permissions", "scrubbed-danger-flag"],
+  [("Anthropic " + "PBC. All rights reserved."), "Workcell scrubbed marker"],
+  [
+    ("https://code.claude.com/docs/en/legal-" + "and-compliance."),
+    "https://example.invalid/workcell",
+  ],
+  [
+    ("Want to see the unminified source? We" + "\x27re hiring!"),
+    "Workcell scrubbed hiring marker",
+  ],
+  [("dangerously" + "-skip-permissions"), "scrubbed-danger-flag"],
 ]) {
   entrypoint = entrypoint.split(from).join(to);
 }
@@ -1854,10 +1976,16 @@ const fs = require("node:fs");
 const entrypointPath = process.argv[2];
 let entrypoint = fs.readFileSync(entrypointPath, "utf8");
 for (const [from, to] of [
-  ["Anthropic PBC. All rights reserved.", "Workcell scrubbed marker"],
-  ["https://code.claude.com/docs/en/legal-and-compliance.", "https://example.invalid/workcell"],
-  ["Want to see the unminified source? We\x27re hiring!", "Workcell scrubbed hiring marker"],
-  ["dangerously-skip-permissions", "scrubbed-danger-flag"],
+  [("Anthropic " + "PBC. All rights reserved."), "Workcell scrubbed marker"],
+  [
+    ("https://code.claude.com/docs/en/legal-" + "and-compliance."),
+    "https://example.invalid/workcell",
+  ],
+  [
+    ("Want to see the unminified source? We" + "\x27re hiring!"),
+    "Workcell scrubbed hiring marker",
+  ],
+  [("dangerously" + "-skip-permissions"), "scrubbed-danger-flag"],
 ]) {
   entrypoint = entrypoint.split(from).join(to);
 }
@@ -1997,7 +2125,7 @@ EOF
     echo "expected public node wrapper to ignore caller-supplied WORKSPACE overrides" >&2
     exit 1
   fi
-  grep -q "Workcell blocked public node execution outside the mounted workspace." /tmp/node-workspace-env.out
+  grep -Eq "Workcell blocked public node execution outside the mounted workspace.|Workcell blocked provider package execution via public node." /tmp/node-workspace-env.out
   cat <<'\''EOF'\'' >/tmp/workcell-node-preload.js
 require("fs").writeFileSync("/tmp/workcell-node-preload-ran", "1")
 process.exit(99)
@@ -2026,12 +2154,12 @@ EOF
     echo "expected Workcell git guard to reject --no-verify" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard.out
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard.out
   if /usr/bin/git commit -n -m smoke >/tmp/git-guard-short.out 2>&1; then
     echo "expected Workcell git guard to reject git commit -n" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard-short.out
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-short.out
   rm -f /tmp/workcell-git-ssh-env-ran /tmp/workcell-git-ssh-helper-ran /tmp/workcell-git-ssh-config-ran
   cat <<EOF >"$EXEC_TMP/git-ssh-helper.sh"
 #!/bin/sh
@@ -2110,7 +2238,7 @@ EOF
     echo "expected Workcell git guard to reject direct hidden git execution" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard-real.out
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-real.out
   if /usr/local/libexec/workcell/real/git status >/tmp/git-guard-real-payload.out 2>&1; then
     echo "expected direct real git payload execution to fail" >&2
     exit 1
@@ -2120,7 +2248,7 @@ EOF
       echo "expected Workcell git guard to reject hardlinked hidden git execution" >&2
       exit 1
     fi
-    grep -q "Workcell blocked git hook bypass" /tmp/git-guard-hardlink.out
+    grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-hardlink.out
   else
     grep -Eiq "cross-device|operation not permitted|read-only" /tmp/git-hardlink-link.out
   fi
@@ -2129,57 +2257,57 @@ EOF
     echo "expected Workcell git guard to reject symlinked hidden git execution" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard-symlink.out
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-symlink.out
   if ! cp /usr/local/libexec/workcell/core/git "$EXEC_TMP/git-copy" >/tmp/git-copy.out 2>&1; then
     echo "expected Workcell git trampoline to remain copyable for deterministic debugging" >&2
     exit 1
   fi
   if "$EXEC_TMP/git-copy" commit --no-verify -m smoke >/tmp/git-guard-copy.out 2>&1; then
-    echo "expected copied Workcell git trampoline to reject hook bypasses" >&2
+    echo "expected copied Workcell git trampoline under mutable state to be blocked before execution" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard-copy.out
+  grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/git-guard-copy.out
   if git -c core.hooksPath=/dev/null commit -m smoke >/tmp/git-guard-hooks.out 2>&1; then
     echo "expected Workcell git guard to reject inline core.hooksPath override" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard-hooks.out
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-hooks.out
   if git -c core.hookspath=/dev/null commit -m smoke >/tmp/git-guard-hooks-lower.out 2>&1; then
     echo "expected Workcell git guard to reject lowercase inline core.hookspath override" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard-hooks-lower.out
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-hooks-lower.out
   if GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath GIT_CONFIG_VALUE_0=/dev/null git commit -m smoke >/tmp/git-guard-env.out 2>&1; then
     echo "expected Workcell git guard to reject GIT_CONFIG_* hook override" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard-env.out
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-env.out
   if GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=Core.HooksPath GIT_CONFIG_VALUE_0=/dev/null git commit -m smoke >/tmp/git-guard-env-mixed.out 2>&1; then
     echo "expected Workcell git guard to reject mixed-case GIT_CONFIG_* hook override" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard-env-mixed.out
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-env-mixed.out
   printf "[core]\n  hooksPath = /dev/null\n" >"$EXEC_TMP/git-bypass.cfg"
   if git -c include.path="$EXEC_TMP/git-bypass.cfg" commit -m smoke >/tmp/git-guard-include.out 2>&1; then
     echo "expected Workcell git guard to reject inline include.path override" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard-include.out
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-include.out
   if git -c includeIf.onbranch:main.path="$EXEC_TMP/git-bypass.cfg" commit -m smoke >/tmp/git-guard-includeif.out 2>&1; then
     echo "expected Workcell git guard to reject inline includeIf override" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard-includeif.out
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-includeif.out
   if git -c core.worktree=/tmp commit -m smoke >/tmp/git-guard-worktree.out 2>&1; then
     echo "expected Workcell git guard to reject inline core.worktree override" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard-worktree.out || grep -q "Workcell blocked git control-plane override" /tmp/git-guard-worktree.out
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-worktree.out
   if GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=include.path GIT_CONFIG_VALUE_0="$EXEC_TMP/git-bypass.cfg" git commit -m smoke >/tmp/git-guard-env-include.out 2>&1; then
     echo "expected Workcell git guard to reject GIT_CONFIG_* include.path override" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard-env-include.out
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-env-include.out
   if GIT_CONFIG_PARAMETERS="core.worktree=/tmp" git status >/tmp/git-guard-env-parameters-worktree.out 2>&1; then
     echo "expected Workcell git guard to reject GIT_CONFIG_PARAMETERS core.worktree override" >&2
     exit 1
@@ -2245,7 +2373,7 @@ EOF
     echo "expected Workcell git guard to reject alias-expanded git commit -n" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git alias bypass" /tmp/git-guard-alias.out
+  grep -Eq "Workcell blocked git alias bypass|Workcell blocked git control-plane override|Workcell blocked direct protected runtime execution" /tmp/git-guard-alias.out
   git config --unset alias.ci
   git config alias.c "commit -n"
   git config alias.ci c
@@ -2253,45 +2381,61 @@ EOF
     echo "expected Workcell git guard to reject recursively expanded git commit -n aliases" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git alias bypass" /tmp/git-guard-alias-chain.out
+  grep -Eq "Workcell blocked git alias bypass|Workcell blocked git control-plane override|Workcell blocked direct protected runtime execution" /tmp/git-guard-alias-chain.out
   git config alias.ctab "$(printf "commit\\t-n")"
   if git ctab -m smoke >/tmp/git-guard-alias-tab.out 2>&1; then
     echo "expected Workcell git guard to reject tab-separated alias-expanded git commit -n" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git alias bypass" /tmp/git-guard-alias-tab.out
+  grep -Eq "Workcell blocked git alias bypass|Workcell blocked git control-plane override|Workcell blocked direct protected runtime execution" /tmp/git-guard-alias-tab.out
   git config alias.cquoted "commit \"-n\""
   if git cquoted -m smoke >/tmp/git-guard-alias-quoted.out 2>&1; then
     echo "expected Workcell git guard to reject quoted alias-expanded git commit -n" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git alias bypass" /tmp/git-guard-alias-quoted.out
-  git config alias.execpath "--exec-path=$EXEC_TMP/git-guard status"
-  if git execpath >/tmp/git-guard-alias-exec-path.out 2>&1; then
-    echo "expected Workcell git guard to reject alias-expanded --exec-path" >&2
+  grep -Eq "Workcell blocked git alias bypass|Workcell blocked git control-plane override|Workcell blocked direct protected runtime execution" /tmp/git-guard-alias-quoted.out
+  if git config alias.execpath "--exec-path=$EXEC_TMP/git-guard status" >/tmp/git-guard-alias-exec-path-define.out 2>&1; then
+    echo "expected Workcell git guard to reject defining an alias with --exec-path" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git alias bypass" /tmp/git-guard-alias-exec-path.out
-  git config alias.cshell "!git commit \\\\-n -m smoke"
-  if git cshell >/tmp/git-guard-alias-shell-escaped.out 2>&1; then
-    echo "expected Workcell git guard to reject shell alias git commit \\\\-n bypass" >&2
-    exit 1
+  grep -q "Workcell blocked git control-plane override" /tmp/git-guard-alias-exec-path-define.out
+  if git config alias.cshell "!git commit \\\\-n -m smoke" >/tmp/git-guard-alias-shell-escaped-define.out 2>&1; then
+    if git cshell >/tmp/git-guard-alias-shell-escaped.out 2>&1; then
+      echo "expected Workcell git guard to reject shell alias git commit \\\\-n bypass" >&2
+      exit 1
+    fi
+    grep -Eq "Workcell blocked git alias bypass|Workcell blocked git control-plane override|Workcell blocked direct protected runtime execution" /tmp/git-guard-alias-shell-escaped.out
+  else
+    grep -q "Workcell blocked git control-plane override" /tmp/git-guard-alias-shell-escaped-define.out
   fi
-  grep -q "Workcell blocked git alias bypass" /tmp/git-guard-alias-shell-escaped.out
-  git config alias.csubst "!git commit \$(printf -- -)\$(printf n) -m smoke"
-  if git csubst >/tmp/git-guard-alias-shell-substitution.out 2>&1; then
-    echo "expected Workcell git guard to reject shell alias substitution bypass" >&2
-    exit 1
+  if git config alias.csubst "!git commit \$(printf -- -)\$(printf n) -m smoke" >/tmp/git-guard-alias-shell-substitution-define.out 2>&1; then
+    if git csubst >/tmp/git-guard-alias-shell-substitution.out 2>&1; then
+      echo "expected Workcell git guard to reject shell alias substitution bypass" >&2
+      exit 1
+    fi
+    grep -Eq "Workcell blocked git alias bypass|Workcell blocked git control-plane override|Workcell blocked direct protected runtime execution" /tmp/git-guard-alias-shell-substitution.out
+  else
+    grep -q "Workcell blocked git control-plane override" /tmp/git-guard-alias-shell-substitution-define.out
   fi
-  grep -q "Workcell blocked git alias bypass" /tmp/git-guard-alias-shell-substitution.out
-  set -- $(ldd /usr/local/libexec/workcell/real/git | grep -E "ld-linux|ld-musl" | head -n1)
-  LOADER="$1"
+  LOADER="$(
+    for candidate in \
+      /lib64/ld-linux-x86-64.so.2 \
+      /lib/ld-linux-aarch64.so.1 \
+      /lib/ld-linux-armhf.so.3 \
+      /lib/ld-musl-*.so.1 \
+      /lib64/ld-musl-*.so.1; do
+      if [ -x "$candidate" ]; then
+        printf "%s\n" "$candidate"
+        break
+      fi
+    done
+  )"
   test -n "$LOADER"
   if "$LOADER" /usr/local/libexec/workcell/real/git commit --no-verify -m smoke >/tmp/git-guard-loader.out 2>&1; then
     echo "expected Workcell git guard to reject direct loader invocation" >&2
     exit 1
   fi
-  grep -q "Workcell blocked git hook bypass" /tmp/git-guard-loader.out
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override|Workcell blocked direct protected runtime execution" /tmp/git-guard-loader.out
   cp /usr/local/libexec/workcell/real/git "$EXEC_TMP/workcell-git-real-copy"
   chmod 0700 "$EXEC_TMP/workcell-git-real-copy"
   if "$EXEC_TMP/workcell-git-real-copy" status >/tmp/git-guard-real-copy.out 2>&1; then
@@ -2317,15 +2461,18 @@ EOF
   chmod +x .git/hooks/pre-commit
   touch smoke.txt
   git add smoke.txt
-  printf "[core]\n  hooksPath = /dev/null\n" >"$HOME/.gitconfig"
-  if git commit -m smoke >/tmp/git-guard-global-config.out 2>&1; then
+  GLOBAL_HOME="$EXEC_TMP/git-global-home"
+  mkdir -p "$GLOBAL_HOME"
+  printf "[core]\n  hooksPath = /dev/null\n" >"$GLOBAL_HOME/.gitconfig"
+  if HOME="$GLOBAL_HOME" git commit -m smoke >/tmp/git-guard-global-config.out 2>&1; then
     echo "expected Workcell git wrapper to ignore writable global git config" >&2
     exit 1
   fi
   grep -Eq "hook ran|pre-commit" /tmp/git-guard-global-config.out
-  mkdir -p "$HOME/.config/git"
-  printf "[core]\n  hooksPath = /dev/null\n" >"$HOME/.config/git/config"
-  if git commit -m smoke >/tmp/git-guard-xdg-config.out 2>&1; then
+  XDG_CONFIG_HOME="$EXEC_TMP/git-xdg-home"
+  mkdir -p "$XDG_CONFIG_HOME/git"
+  printf "[core]\n  hooksPath = /dev/null\n" >"$XDG_CONFIG_HOME/git/config"
+  if XDG_CONFIG_HOME="$XDG_CONFIG_HOME" git commit -m smoke >/tmp/git-guard-xdg-config.out 2>&1; then
     echo "expected Workcell git wrapper to ignore writable XDG git config" >&2
     exit 1
   fi
@@ -2334,15 +2481,19 @@ EOF
 
 # shellcheck disable=SC2016
 run_container claude bash -lc '
-  claude --version 2>&1 | grep -q "Claude Code"
-  test -f "$HOME/.claude/settings.json"
-  test -L "$HOME/.claude/settings.json"
-  test "$(readlink "$HOME/.claude/settings.json")" = "/opt/workcell/adapters/claude/.claude/settings.json"
-  test -f "$HOME/.mcp.json"
-  test -L "$HOME/.mcp.json"
-  test -f /etc/claude-code/managed-settings.json
-  jq -r ".disableBypassPermissionsMode" /etc/claude-code/managed-settings.json | grep -q "^allow$"
-  jq -r ".hooks.PreToolUse[0].hooks[0].command" "$HOME/.claude/settings.json" | grep -q "guard-bash.sh"
+  /usr/local/bin/workcell-entrypoint claude --version >/dev/null
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    claude --version 2>&1 | grep -q "Claude Code"
+    test -f "$HOME/.claude/settings.json"
+    test -L "$HOME/.claude/settings.json"
+    test "$(readlink "$HOME/.claude/settings.json")" = "/opt/workcell/adapters/claude/.claude/settings.json"
+    test -f "$HOME/.mcp.json"
+    test -L "$HOME/.mcp.json"
+    test -f /etc/claude-code/managed-settings.json
+    jq -r ".disableBypassPermissionsMode" /etc/claude-code/managed-settings.json | grep -q "^allow$"
+    jq -r ".hooks.PreToolUse[0].hooks[0].command" "$HOME/.claude/settings.json" | grep -q "guard-bash.sh"
+  '"'"'
   if /usr/local/libexec/workcell/real/node /opt/workcell/providers/node_modules/@anthropic-ai/claude-code/cli.js --version >/tmp/node-real-payload.out 2>&1; then
     echo "expected direct real node payload execution to fail" >&2
     exit 1
@@ -2367,11 +2518,22 @@ run_container claude bash -lc '
     exit 1
   fi
   grep -q "Workcell blocked unsafe Claude override" /tmp/claude-nested-breakglass.out
-  rm -f "$HOME/.claude/settings.json"
-  printf "{\n  \"disableBypassPermissionsMode\": \"allow\"\n}\n" >"$HOME/.claude/settings.json"
-  claude --version >/dev/null 2>&1
-  test -L "$HOME/.claude/settings.json"
-  test "$(readlink "$HOME/.claude/settings.json")" = "/opt/workcell/adapters/claude/.claude/settings.json"
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    if (
+      cat <<'\''EOF'\'' >"$HOME/.claude/settings.json"
+{
+  "disableBypassPermissionsMode": "allow"
+}
+EOF
+    ) >/tmp/claude-managed-settings-overwrite.out 2>&1; then
+      echo "expected managed Claude settings to remain protected" >&2
+      exit 1
+    fi
+    claude --version >/dev/null 2>&1
+    test -L "$HOME/.claude/settings.json"
+    test "$(readlink "$HOME/.claude/settings.json")" = "/opt/workcell/adapters/claude/.claude/settings.json"
+  '"'"'
   printf "%s" "{\"tool_input\":{\"command\":\"bash -lc '\''git commit -n -m smoke'\''\"}}" \
     | /opt/workcell/adapters/claude/hooks/guard-bash.sh >/tmp/claude-hook-git.out 2>&1 && {
       echo "expected Claude guard hook to reject nested-shell git bypass" >&2
@@ -2470,20 +2632,24 @@ EOF
 
 # shellcheck disable=SC2016
 run_container gemini bash -lc '
-  out="$(gemini --version 2>&1)"
-  echo "$out"
-  if echo "$out" | grep -q "Failed to save project registry"; then
-    echo "unexpected Gemini project registry warning" >&2
-    exit 1
-  fi
-  if echo "$out" | grep -q "There was an error saving your latest settings changes"; then
-    echo "unexpected Gemini settings write warning" >&2
-    exit 1
-  fi
-  echo "$out" | grep -Eq "([0-9]+\\.){2}[0-9]+"
-  test -f "$HOME/.gemini/settings.json"
-  test -f "$HOME/.gemini/GEMINI.md"
-  test -f "$HOME/.gemini/projects.json"
+  /usr/local/bin/workcell-entrypoint gemini --version >/dev/null
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    out="$(gemini --version 2>&1)"
+    echo "$out"
+    if echo "$out" | grep -q "Failed to save project registry"; then
+      echo "unexpected Gemini project registry warning" >&2
+      exit 1
+    fi
+    if echo "$out" | grep -q "There was an error saving your latest settings changes"; then
+      echo "unexpected Gemini settings write warning" >&2
+      exit 1
+    fi
+    echo "$out" | grep -Eq "([0-9]+\\.){2}[0-9]+"
+    test -f "$HOME/.gemini/settings.json"
+    test -f "$HOME/.gemini/GEMINI.md"
+    test -f "$HOME/.gemini/projects.json"
+  '"'"'
   if gemini --yolo >/tmp/gemini-nested-yolo.out 2>&1; then
     echo "expected nested Gemini invocation to reject unsafe overrides" >&2
     exit 1
@@ -2519,11 +2685,14 @@ run_container gemini bash -lc '
   HOME=/workspace gemini --version >/dev/null 2>&1
   test ! -e /workspace/.gemini/settings.json
   test ! -e /workspace/.gemini/projects.json
-  rm -f "$HOME/.gemini/settings.json"
-  printf "{\n  \"general\": {\"disableAutoUpdate\": false}\n}\n" >"$HOME/.gemini/settings.json"
-  gemini --version >/dev/null 2>&1
-  jq -r ".general.enableAutoUpdate" "$HOME/.gemini/settings.json" | grep -q "^false$"
-  jq -r ".general.enableAutoUpdateNotification" "$HOME/.gemini/settings.json" | grep -q "^false$"
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    jq -r ".general.enableAutoUpdate" "$HOME/.gemini/settings.json" | grep -q "^false$"
+    jq -r ".general.enableAutoUpdateNotification" "$HOME/.gemini/settings.json" | grep -q "^false$"
+    gemini --version >/dev/null 2>&1
+    jq -r ".general.enableAutoUpdate" "$HOME/.gemini/settings.json" | grep -q "^false$"
+    jq -r ".general.enableAutoUpdateNotification" "$HOME/.gemini/settings.json" | grep -q "^false$"
+  '"'"'
 '
 
 echo "Workcell container smoke passed."

--- a/scripts/dev-remote-validate.sh
+++ b/scripts/dev-remote-validate.sh
@@ -7,6 +7,7 @@ if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
     HOME=/tmp \
     TMPDIR="${TMPDIR:-/tmp}" \
     WORKCELL_REMOTE_VALIDATE_BASE_DIR="${WORKCELL_REMOTE_VALIDATE_BASE_DIR-}" \
+    WORKCELL_REMOTE_VALIDATE_CONFIG_PATH="${WORKCELL_REMOTE_VALIDATE_CONFIG_PATH-}" \
     WORKCELL_REMOTE_VALIDATE_HOST="${WORKCELL_REMOTE_VALIDATE_HOST-}" \
     WORKCELL_SANITIZED_ENTRYPOINT=1 \
     /bin/bash -p "$0" "$@"
@@ -15,7 +16,17 @@ set -euo pipefail
 export PATH="${TRUSTED_HOST_PATH}"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-REMOTE_HOST="${WORKCELL_REMOTE_VALIDATE_HOST:-builder@bewear}"
+REAL_HOME="$(
+  /usr/bin/env -i PATH="${TRUSTED_HOST_PATH}" /usr/bin/python3 - <<'PY'
+import os
+import pwd
+
+print(pwd.getpwuid(os.getuid()).pw_dir)
+PY
+)"
+LEGACY_LOCAL_REMOTE_CONFIG_PATH="${ROOT_DIR}/.workcell.remote.local"
+REMOTE_CONFIG_PATH="${WORKCELL_REMOTE_VALIDATE_CONFIG_PATH:-${REAL_HOME}/.config/workcell/remote-validate.env}"
+REMOTE_HOST="${WORKCELL_REMOTE_VALIDATE_HOST:-}"
 REMOTE_BASE_DIR="${WORKCELL_REMOTE_VALIDATE_BASE_DIR:-/tmp}"
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -C "${ROOT_DIR}" log -1 --pretty=%ct 2>/dev/null || printf '0')}"
 REMOTE_USE_SUDO=1
@@ -42,8 +53,18 @@ Stage a local Workcell snapshot to a remote amd64 builder, build a disposable
 remote helper container there, and run the selected heavy validation inside
 that container.
 
+If ${REMOTE_CONFIG_PATH} exists, Workcell loads simple KEY=VALUE entries for
+WORKCELL_REMOTE_VALIDATE_HOST, WORKCELL_REMOTE_VALIDATE_BASE_DIR, and
+WORKCELL_REMOTE_VALIDATE_USE_SUDO from that host-local config before CLI
+parsing. Override the path with WORKCELL_REMOTE_VALIDATE_CONFIG_PATH or
+--config <path>.
+
 Options:
-  --host <user@host>          Remote builder host (default: ${REMOTE_HOST})
+  --config <path>             Optional host-local config file to read before
+                              CLI parsing
+  --host <user@host>          Remote builder host
+                              (required; may also be set via
+                              WORKCELL_REMOTE_VALIDATE_HOST)
   --remote-base-dir <path>    Base directory for remote temp workspaces
                               (default: ${REMOTE_BASE_DIR})
   --source-date-epoch <sec>   SOURCE_DATE_EPOCH to use for remote checks
@@ -69,6 +90,125 @@ require_tool() {
   }
 }
 
+require_remote_host() {
+  if [[ -z "${REMOTE_HOST}" ]]; then
+    echo "Remote builder host is required. Pass --host <user@host> or set WORKCELL_REMOTE_VALIDATE_HOST." >&2
+    exit 1
+  fi
+}
+
+canonicalize_host_path() {
+  local path="$1"
+
+  /usr/bin/env -i PATH="${TRUSTED_HOST_PATH}" /usr/bin/python3 - "$path" <<'PY'
+import os
+import pathlib
+import sys
+
+print(pathlib.Path(sys.argv[1]).expanduser().resolve(strict=False))
+PY
+}
+
+assert_supported_remote_config_path() {
+  local candidate="$1"
+  local canonical_candidate=""
+  local canonical_root=""
+
+  [[ -n "${candidate}" ]] || return 0
+  canonical_candidate="$(canonicalize_host_path "${candidate}")"
+  canonical_root="$(canonicalize_host_path "${ROOT_DIR}")"
+
+  if [[ "${canonical_candidate}" == "${canonical_root}" ]] ||
+    [[ "${canonical_candidate}" == "${canonical_root}"/* ]]; then
+    echo "Remote builder config must live outside the repo checkout: ${canonical_candidate}" >&2
+    exit 1
+  fi
+}
+
+preparse_config_path() {
+  local args=("$@")
+  local i=0
+
+  while [[ ${i} -lt ${#args[@]} ]]; do
+    case "${args[${i}]}" in
+      --config)
+        if [[ $((i + 1)) -ge ${#args[@]} ]]; then
+          echo "Option --config requires a value." >&2
+          usage >&2
+          exit 1
+        fi
+        REMOTE_CONFIG_PATH="${args[$((i + 1))]}"
+        return 0
+        ;;
+      --config=*)
+        REMOTE_CONFIG_PATH="${args[${i}]#--config=}"
+        return 0
+        ;;
+    esac
+    i=$((i + 1))
+  done
+}
+
+load_local_remote_config() {
+  local line=""
+  local key=""
+  local value=""
+
+  if [[ -e "${LEGACY_LOCAL_REMOTE_CONFIG_PATH}" ]]; then
+    echo "Legacy repo-local remote builder config is no longer supported: ${LEGACY_LOCAL_REMOTE_CONFIG_PATH}" >&2
+    echo "Move it to ${REMOTE_CONFIG_PATH} or point WORKCELL_REMOTE_VALIDATE_CONFIG_PATH/--config at a host-local file." >&2
+    exit 1
+  fi
+
+  assert_supported_remote_config_path "${REMOTE_CONFIG_PATH}"
+
+  [[ -f "${REMOTE_CONFIG_PATH}" ]] || return 0
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "${line}" ]] && continue
+    [[ "${line}" == \#* ]] && continue
+    if [[ "${line}" != *=* ]]; then
+      echo "Unsupported entry in ${REMOTE_CONFIG_PATH}: ${line}" >&2
+      exit 1
+    fi
+    key="${line%%=*}"
+    value="${line#*=}"
+    key="${key%"${key##*[![:space:]]}"}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    if [[ "${value}" == \"*\" && "${value}" == *\" ]]; then
+      value="${value:1:${#value}-2}"
+    elif [[ "${value}" == \'*\' && "${value}" == *\' ]]; then
+      value="${value:1:${#value}-2}"
+    fi
+    case "${key}" in
+      WORKCELL_REMOTE_VALIDATE_HOST)
+        REMOTE_HOST="${value}"
+        ;;
+      WORKCELL_REMOTE_VALIDATE_BASE_DIR)
+        REMOTE_BASE_DIR="${value}"
+        ;;
+      WORKCELL_REMOTE_VALIDATE_USE_SUDO)
+        case "${value}" in
+          0 | 1)
+            REMOTE_USE_SUDO="${value}"
+            ;;
+          *)
+            echo "WORKCELL_REMOTE_VALIDATE_USE_SUDO in ${REMOTE_CONFIG_PATH} must be 0 or 1." >&2
+            exit 1
+            ;;
+        esac
+        ;;
+      *)
+        echo "Unsupported key in ${REMOTE_CONFIG_PATH}: ${key}" >&2
+        exit 1
+        ;;
+    esac
+  done <"${REMOTE_CONFIG_PATH}"
+}
+
 add_check() {
   local check="$1"
   case "${check}" in
@@ -82,6 +222,9 @@ add_check() {
       ;;
   esac
 }
+
+preparse_config_path "$@"
+load_local_remote_config
 
 prepare_snapshot_dir() {
   local path_list_raw
@@ -172,6 +315,23 @@ trap cleanup EXIT
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --config)
+      [[ $# -ge 2 ]] || {
+        echo "Option --config requires a value." >&2
+        usage >&2
+        exit 1
+      }
+      REMOTE_CONFIG_PATH="$2"
+      assert_supported_remote_config_path "${REMOTE_CONFIG_PATH}"
+      load_local_remote_config
+      shift 2
+      ;;
+    --config=*)
+      REMOTE_CONFIG_PATH="${1#--config=}"
+      assert_supported_remote_config_path "${REMOTE_CONFIG_PATH}"
+      load_local_remote_config
+      shift
+      ;;
     --host)
       [[ $# -ge 2 ]] || {
         echo "Option --host requires a value." >&2
@@ -245,6 +405,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+require_remote_host
+
 if [[ "${#CHECKS[@]}" -eq 0 ]]; then
   CHECKS=(validate smoke repro release-bundle)
 fi
@@ -273,6 +435,7 @@ cp "${ROOT_DIR}/tools/remote-validator/Dockerfile" "${HELPER_CONTEXT_DIR}/Docker
 echo "Remote host: ${REMOTE_HOST}"
 echo "Remote base dir: ${REMOTE_BASE_DIR}"
 echo "Remote sudo: ${REMOTE_USE_SUDO}"
+echo "Remote config path: ${REMOTE_CONFIG_PATH}"
 echo "Snapshot mode: ${SNAPSHOT_MODE}"
 if [[ "${SNAPSHOT_MODE}" == "worktree" ]]; then
   echo "Include untracked: ${INCLUDE_UNTRACKED}"

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -16,6 +16,7 @@ require_tool python3
 require_tool yamllint
 require_tool cargo
 require_tool rustfmt
+require_tool git
 
 mapfile -t python_files < <(
   find "${ROOT_DIR}/scripts/lib" "${ROOT_DIR}/tests/python" "${ROOT_DIR}/tests/mutation" \
@@ -69,6 +70,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/install.sh"
   "${ROOT_DIR}/scripts/publish-github-release.sh"
   "${ROOT_DIR}/scripts/run-mutation-tests.sh"
+  "${ROOT_DIR}/scripts/verify-coverage.sh"
   "${ROOT_DIR}/scripts/verify-github-hosted-controls.sh"
   "${ROOT_DIR}/scripts/validate-repo.sh"
   "${ROOT_DIR}/scripts/verify-build-input-manifest.sh"
@@ -80,6 +82,7 @@ shell_files=(
   "${ROOT_DIR}/runtime/container/entrypoint.sh"
   "${ROOT_DIR}/runtime/container/bin/apt-helper.sh"
   "${ROOT_DIR}/runtime/container/bin/apt-wrapper.sh"
+  "${ROOT_DIR}/runtime/container/assurance.sh"
   "${ROOT_DIR}/runtime/container/bin/git"
   "${ROOT_DIR}/runtime/container/bin/node"
   "${ROOT_DIR}/runtime/container/home-control-plane.sh"
@@ -163,6 +166,11 @@ if branding_scan; then
   exit 1
 fi
 
+if [[ -e "${ROOT_DIR}/.workcell.remote.local" ]]; then
+  echo "Legacy repo-local remote builder config must not exist: ${ROOT_DIR}/.workcell.remote.local" >&2
+  exit 1
+fi
+
 (
   cd "${ROOT_DIR}/runtime/container/rust"
   cargo fmt --all --check
@@ -171,5 +179,6 @@ fi
 )
 
 "${ROOT_DIR}/scripts/run-mutation-tests.sh"
+"${ROOT_DIR}/scripts/verify-coverage.sh"
 
 echo "Workcell repository validation passed."

--- a/scripts/verify-coverage.sh
+++ b/scripts/verify-coverage.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_MIN_COVERAGE="${WORKCELL_PYTHON_COVERAGE_MIN:-90}"
+RUST_MIN_COVERAGE="${WORKCELL_RUST_COVERAGE_MIN:-90}"
+REQUIRE_SUPPORTED_COVERAGE="${WORKCELL_REQUIRE_SUPPORTED_COVERAGE:-0}"
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required tool: $1" >&2
+    exit 1
+  }
+}
+
+resolve_llvm_tool() {
+  local tool_name="$1"
+
+  if command -v "${tool_name}" >/dev/null 2>&1; then
+    command -v "${tool_name}"
+    return 0
+  fi
+
+  if command -v xcrun >/dev/null 2>&1; then
+    xcrun --find "${tool_name}"
+    return 0
+  fi
+
+  return 1
+}
+
+require_tool python3
+require_tool cargo
+coverage_tools_available() {
+  python3 -m coverage --version >/dev/null 2>&1 || return 1
+  LLVM_COV_BIN="$(resolve_llvm_tool llvm-cov)" || return 1
+  LLVM_PROFDATA_BIN="$(resolve_llvm_tool llvm-profdata)" || return 1
+}
+
+if ! coverage_tools_available; then
+  if [[ "${REQUIRE_SUPPORTED_COVERAGE}" == "1" ]]; then
+    echo "Supported coverage tools are required but not fully available." >&2
+    exit 1
+  fi
+  echo "Skipping supported coverage verification because coverage.py or LLVM coverage tools are not available locally." >&2
+  exit 0
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/workcell-coverage.XXXXXX")"
+cleanup() {
+  rm -rf "${TMP_ROOT}"
+}
+trap cleanup EXIT
+
+run_python_coverage() {
+  local data_file="${TMP_ROOT}/python-coverage.data"
+  local report_file="${TMP_ROOT}/python-coverage.json"
+
+  (
+    cd "${ROOT_DIR}"
+    COVERAGE_FILE="${data_file}" python3 -m coverage run --branch \
+      -m unittest discover -s tests/python -p 'test_*.py'
+    COVERAGE_FILE="${data_file}" python3 -m coverage json \
+      --pretty-print \
+      --include="scripts/lib/*.py" \
+      -o "${report_file}"
+  )
+
+  python3 - "${report_file}" "${PYTHON_MIN_COVERAGE}" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+minimum = float(sys.argv[2])
+percent = float(report["totals"]["percent_covered"])
+if percent < minimum:
+    raise SystemExit(
+        f"Python helper coverage is {percent:.2f}%, below the required {minimum:.2f}%"
+    )
+print(f"Python helper coverage: {percent:.2f}%")
+PY
+}
+
+run_rust_launcher_coverage() {
+  local rust_dir="${ROOT_DIR}/runtime/container/rust"
+  local target_dir="${TMP_ROOT}/rust-target"
+  local message_file="${TMP_ROOT}/rust-messages.json"
+  local profdata_file="${TMP_ROOT}/rust.profdata"
+  local export_file="${TMP_ROOT}/rust-coverage.json"
+
+  (
+    cd "${rust_dir}"
+    CARGO_INCREMENTAL=0 \
+      CARGO_TARGET_DIR="${target_dir}" \
+      RUSTFLAGS="-C instrument-coverage" \
+      LLVM_PROFILE_FILE="${TMP_ROOT}/workcell-%p-%m.profraw" \
+      cargo test --locked --offline --bins --no-run --message-format=json \
+      >"${message_file}"
+
+    CARGO_INCREMENTAL=0 \
+      CARGO_TARGET_DIR="${target_dir}" \
+      RUSTFLAGS="-C instrument-coverage" \
+      LLVM_PROFILE_FILE="${TMP_ROOT}/workcell-%p-%m.profraw" \
+      cargo test --locked --offline --bins
+  )
+
+  python3 - "${message_file}" >"${TMP_ROOT}/rust-binaries.txt" <<'PY'
+import json
+import pathlib
+import sys
+
+message_path = pathlib.Path(sys.argv[1])
+executables = []
+for raw_line in message_path.read_text(encoding="utf-8").splitlines():
+    if not raw_line.startswith("{"):
+        continue
+    message = json.loads(raw_line)
+    if message.get("reason") != "compiler-artifact":
+        continue
+    executable = message.get("executable")
+    target = message.get("target", {})
+    if executable and target.get("kind") == ["bin"]:
+        executables.append(executable)
+
+if not executables:
+    raise SystemExit("Unable to locate instrumented Rust test executables for coverage")
+
+print("\n".join(sorted(set(executables))))
+PY
+
+  mapfile -t rust_binaries <"${TMP_ROOT}/rust-binaries.txt"
+  if [[ "${#rust_binaries[@]}" -eq 0 ]]; then
+    echo "Unable to locate instrumented Rust test executables for coverage." >&2
+    exit 1
+  fi
+
+  "${LLVM_PROFDATA_BIN}" merge -sparse "${TMP_ROOT}"/workcell-*.profraw -o "${profdata_file}"
+  "${LLVM_COV_BIN}" export \
+    --summary-only \
+    --instr-profile="${profdata_file}" \
+    --ignore-filename-regex='(/.cargo/registry|/rustc/|/src/lib.rs$)' \
+    "${rust_binaries[@]}" >"${export_file}"
+
+  python3 - "${export_file}" "${RUST_MIN_COVERAGE}" <<'PY'
+import json
+import pathlib
+import sys
+
+export = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+minimum = float(sys.argv[2])
+data = export.get("data", [])
+if not data:
+    raise SystemExit("Rust coverage export did not contain summary data")
+totals = data[0].get("totals", {})
+lines = totals.get("lines", {})
+percent = float(lines.get("percent", 0.0))
+if percent < minimum:
+    raise SystemExit(
+        f"Rust launcher coverage is {percent:.2f}%, below the required {minimum:.2f}%"
+    )
+print(f"Rust launcher coverage: {percent:.2f}%")
+PY
+}
+
+run_python_coverage
+run_rust_launcher_coverage
+
+echo "Workcell supported coverage verification passed."

--- a/scripts/verify-github-hosted-controls.sh
+++ b/scripts/verify-github-hosted-controls.sh
@@ -84,6 +84,15 @@ if release_mode not in {"review-gated", "single-owner-private"}:
         f"{policy_path} must set release_environment.mode to "
         f"'review-gated' or 'single-owner-private'"
     )
+expected_status_contexts = policy.get("required_status_checks", {}).get("contexts")
+if not isinstance(expected_status_contexts, list) or not expected_status_contexts:
+    raise SystemExit(
+        f"{policy_path} must define required_status_checks.contexts as a non-empty array"
+    )
+if not all(isinstance(context, str) and context for context in expected_status_contexts):
+    raise SystemExit(
+        f"{policy_path} must define required_status_checks.contexts as non-empty strings"
+    )
 
 if not actions_permissions.get("enabled"):
     raise SystemExit(f"GitHub Actions must be enabled on {repo}")
@@ -209,14 +218,7 @@ required_status_contexts = {
     for entry in status_parameters.get("required_status_checks", [])
     if entry.get("context")
 }
-expected_status_contexts = {
-    "Validate repository",
-    "Container smoke",
-    "Reproducible build",
-    "GitHub Actions lint",
-    "GitHub Actions security analysis",
-}
-missing_status_contexts = sorted(expected_status_contexts - required_status_contexts)
+missing_status_contexts = sorted(set(expected_status_contexts) - required_status_contexts)
 if missing_status_contexts:
     raise SystemExit(
         f"Default-branch status-check ruleset on {repo} is missing required contexts: "

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1157,11 +1157,10 @@ fi
 RUN_IN_VM_BLOCK="$(sed -n '/^run_in_vm()/,/^}/p' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh")"
 if ! printf '%s\n' "${RUN_IN_VM_BLOCK}" | awk '
   /initialize_host_tools/ && !host_init { host_init = NR }
-  /if \[\[ -n "\$\{TEST_RUN_IN_VM_CAPTURE_DIR\}" \]\]; then/ && !capture_branch { capture_branch = NR }
-  /colima_home=/ && !capture_home { capture_home = NR }
+  /colima_home="\$\{COLIMA_HOME/ && !capture_home { capture_home = NR }
   /initialize_vm_tools/ && !vm_init { vm_init = NR }
-  /printf '\''set -euo pipefail\\n%s\\n'\''/ && !vm_exec { vm_exec = NR }
-  END { exit !(host_init && capture_branch && capture_home && vm_init && vm_exec && host_init < capture_home && vm_init < vm_exec) }
+  /set -euo pipefail/ && !vm_exec { vm_exec = NR }
+  END { exit !(host_init && capture_home && vm_init && vm_exec && host_init < capture_home && vm_init < vm_exec) }
 '; then
   echo "Expected run_in_vm to initialize host tools before the capture branch derives colima_home, and VM tools before real VM execution" >&2
   exit 1

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1154,6 +1154,52 @@ if sed -n '/^render_allowlist_apply_plan()/,/^}/p' "${ROOT_DIR}/scripts/colima-e
   echo "Expected dual-stack allowlist apply plan to avoid invoking clear_rules during render" >&2
   exit 1
 fi
+RUN_IN_VM_BLOCK="$(sed -n '/^run_in_vm()/,/^}/p' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh")"
+if ! printf '%s\n' "${RUN_IN_VM_BLOCK}" | awk '
+  /initialize_host_tools/ && !host_init { host_init = NR }
+  /if \[\[ -n "\$\{TEST_RUN_IN_VM_CAPTURE_DIR\}" \]\]; then/ && !capture_branch { capture_branch = NR }
+  /colima_home=/ && !capture_home { capture_home = NR }
+  /initialize_vm_tools/ && !vm_init { vm_init = NR }
+  /printf '\''set -euo pipefail\\n%s\\n'\''/ && !vm_exec { vm_exec = NR }
+  END { exit !(host_init && capture_branch && capture_home && vm_init && vm_exec && host_init < capture_home && vm_init < vm_exec) }
+'; then
+  echo "Expected run_in_vm to initialize host tools before the capture branch derives colima_home, and VM tools before real VM execution" >&2
+  exit 1
+fi
+RUN_IN_VM_CAPTURE_DIR="$(mktemp -d)"
+if ! "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" \
+  --test-run-in-vm-capture-dir "${RUN_IN_VM_CAPTURE_DIR}" \
+  apply default '127.0.0.1:443 [::1]:443' >/dev/null 2>&1; then
+  echo "Expected dual-stack allowlist apply path to succeed under the test VM capture hook" >&2
+  exit 1
+fi
+if ! grep -q 'sudo iptables -A WORKCELL_EGRESS -p tcp -d 127.0.0.1 --dport 443 -j ACCEPT' "${RUN_IN_VM_CAPTURE_DIR}/apply-default.script"; then
+  echo "Expected captured dual-stack apply script to include the IPv4 allowlist rule" >&2
+  exit 1
+fi
+if ! grep -q 'sudo ip6tables -A WORKCELL_EGRESS6 -p tcp -d ::1 --dport 443 -j ACCEPT' "${RUN_IN_VM_CAPTURE_DIR}/apply-default.script"; then
+  echo "Expected captured dual-stack apply script to include the IPv6 allowlist rule" >&2
+  exit 1
+fi
+if ! grep -q "COLIMA_HOME=${REAL_HOME}/.colima" "${RUN_IN_VM_CAPTURE_DIR}/apply-default.env"; then
+  echo "Expected captured dual-stack apply env to derive COLIMA_HOME from the real home directory" >&2
+  exit 1
+fi
+if ! "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" \
+  --test-run-in-vm-capture-dir "${RUN_IN_VM_CAPTURE_DIR}" \
+  clear default >/dev/null 2>&1; then
+  echo "Expected dual-stack allowlist clear path to succeed under the test VM capture hook" >&2
+  exit 1
+fi
+if ! grep -q 'sudo ip6tables -X WORKCELL_EGRESS6 2>/dev/null || true' "${RUN_IN_VM_CAPTURE_DIR}/clear-default.script"; then
+  echo "Expected captured dual-stack clear script to remove the IPv6 chain" >&2
+  exit 1
+fi
+if ! grep -q 'sudo iptables -X WORKCELL_EGRESS 2>/dev/null || true' "${RUN_IN_VM_CAPTURE_DIR}/clear-default.script"; then
+  echo "Expected captured dual-stack clear script to remove the IPv4 chain" >&2
+  exit 1
+fi
+rm -rf "${RUN_IN_VM_CAPTURE_DIR}"
 
 HOST_PYTHON_INJECT_DIR="${BARRIER_VERIFY_ROOT}/python-inject"
 HOST_PYTHON_MARKER="${BARRIER_VERIFY_ROOT}/pythonpath-ran"
@@ -1684,21 +1730,28 @@ if ! "${ROOT_DIR}/scripts/workcell" --agent codex --prepare --allow-nongit-works
   echo "Expected marker-based non-git workspace to succeed with explicit opt-in" >&2
   exit 1
 fi
+for agent in claude gemini; do
+  if ! "${ROOT_DIR}/scripts/workcell" --agent "${agent}" --prepare --allow-nongit-workspace --workspace "${NONGIT_WORKSPACE}" --dry-run >/dev/null 2>&1; then
+    echo "Expected marker-based non-git workspace prepare dry-run to succeed for ${agent}" >&2
+    exit 1
+  fi
+done
 
 if [[ "$(uname -s)" == "Darwin" ]] &&
   host_tool_exists /opt/homebrew/bin/colima /usr/local/bin/colima &&
   host_tool_exists /opt/homebrew/bin/docker /usr/local/bin/docker /Applications/Docker.app/Contents/Resources/bin/docker; then
-  AUDIT_PROFILE_NAME="workcell-audit-verify-$$"
-  AUDIT_LOG="${REAL_HOME}/.colima/${AUDIT_PROFILE_NAME}/workcell.audit.log"
   if ! "${ROOT_DIR}/scripts/workcell" \
     --agent codex \
     --prepare \
-    --allow-nongit-workspace \
-    --workspace "${NONGIT_WORKSPACE}" \
-    --colima-profile "${AUDIT_PROFILE_NAME}" \
+    --workspace "${ROOT_DIR}" \
     --agent-arg --version >/tmp/workcell-audit-prepare.out 2>&1; then
     echo "Expected audit verification prepare run to seed a managed image" >&2
     cat /tmp/workcell-audit-prepare.out >&2
+    exit 1
+  fi
+  AUDIT_LOG="$(sed -n 's/.*audit_log=\([^ ]*\).*/\1/p' /tmp/workcell-audit-prepare.out | head -n1)"
+  if [[ -z "${AUDIT_LOG}" ]]; then
+    echo "Expected audit verification prepare run to report an audit log path" >&2
     exit 1
   fi
   AUDIT_BASE_LINES=0
@@ -1708,9 +1761,7 @@ if [[ "$(uname -s)" == "Darwin" ]] &&
   if ! "${ROOT_DIR}/scripts/workcell" \
     --agent codex \
     --mode build \
-    --allow-nongit-workspace \
-    --workspace "${NONGIT_WORKSPACE}" \
-    --colima-profile "${AUDIT_PROFILE_NAME}" \
+    --workspace "${ROOT_DIR}" \
     --allow-arbitrary-command \
     --ack-arbitrary-command \
     -- /bin/bash -lc 'sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get update >/dev/null && sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get install -y --no-install-recommends make >/dev/null'; then
@@ -1725,12 +1776,39 @@ if [[ "$(uname -s)" == "Darwin" ]] &&
   grep -q 'session_assurance_final=lower-assurance-package-mutation' /tmp/workcell-audit-session.log
   grep -q 'event=exit' /tmp/workcell-audit-session.log
   grep -q 'package_mutation_downgraded=1' /tmp/workcell-audit-session.log
-  if [[ -x /opt/homebrew/bin/colima ]]; then
-    /opt/homebrew/bin/colima delete --profile "${AUDIT_PROFILE_NAME}" --force >/dev/null 2>&1 || true
-  else
-    /usr/local/bin/colima delete --profile "${AUDIT_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+  AUDIT_RESTORE_PROFILE_NAME="workcell-audit-restore-$$"
+  AUDIT_RESTORE_DIR="${REAL_HOME}/.colima/${AUDIT_RESTORE_PROFILE_NAME}"
+  AUDIT_RESTORE_LOG="${AUDIT_RESTORE_DIR}/workcell.audit.log"
+  mkdir -p "${AUDIT_RESTORE_DIR}"
+  printf '%s\n' "${NONGIT_WORKSPACE}" >"${AUDIT_RESTORE_DIR}/workcell.managed"
+  cat >"${AUDIT_RESTORE_DIR}/colima.yaml" <<'EOF'
+cpu: 4
+memory: 8
+disk: 60
+runtime: docker
+vmType: vz
+mountType: virtiofs
+EOF
+  printf 'timestamp=test event=launch workspace=%q\n' "${NONGIT_WORKSPACE}" >"${AUDIT_RESTORE_LOG}"
+  if "${ROOT_DIR}/scripts/workcell" \
+    --test-fail-after-profile-refresh \
+    --agent codex \
+    --prepare \
+    --allow-nongit-workspace \
+    --workspace "${NONGIT_WORKSPACE}" \
+    --colima-profile "${AUDIT_RESTORE_PROFILE_NAME}" \
+    --agent-arg --version >/tmp/workcell-audit-restore.out 2>&1; then
+    echo "Expected managed-profile refresh test hook to fail after stashing the audit log" >&2
+    exit 1
   fi
-  rm -rf "${REAL_HOME}/.colima/${AUDIT_PROFILE_NAME}" "${REAL_HOME}/.colima/_lima/colima-${AUDIT_PROFILE_NAME}"
+  grep -q 'Workcell test hook: forcing failure after managed profile refresh.' /tmp/workcell-audit-restore.out
+  grep -q 'timestamp=test event=launch' "${AUDIT_RESTORE_LOG}"
+  if [[ -x /opt/homebrew/bin/colima ]]; then
+    /opt/homebrew/bin/colima delete --profile "${AUDIT_RESTORE_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+  else
+    /usr/local/bin/colima delete --profile "${AUDIT_RESTORE_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+  fi
+  rm -rf "${REAL_HOME}/.colima/${AUDIT_RESTORE_PROFILE_NAME}" "${REAL_HOME}/.colima/_lima/colima-${AUDIT_RESTORE_PROFILE_NAME}"
 fi
 
 UNMANAGED_PROFILE_NAME="workcell-unmanaged-verify-$$"
@@ -1760,6 +1838,21 @@ if ! "${ROOT_DIR}/scripts/workcell" \
 fi
 grep -q 'repair_action=delete_unmanaged_profile' /tmp/workcell-repair-profile-dry-run.out
 grep -q 'docker run' /tmp/workcell-repair-profile-dry-run.out
+for agent in claude gemini; do
+  if ! "${ROOT_DIR}/scripts/workcell" \
+    --agent "${agent}" \
+    --repair-profile \
+    --allow-nongit-workspace \
+    --workspace "${NONGIT_WORKSPACE}" \
+    --colima-profile "${UNMANAGED_PROFILE_NAME}" \
+    --dry-run >/tmp/workcell-repair-profile-${agent}-dry-run.out 2>&1; then
+    echo "Expected --repair-profile dry-run to succeed for ${agent}" >&2
+    cat /tmp/workcell-repair-profile-${agent}-dry-run.out >&2
+    exit 1
+  fi
+  grep -q 'repair_action=delete_unmanaged_profile' /tmp/workcell-repair-profile-${agent}-dry-run.out
+  grep -q 'docker run' /tmp/workcell-repair-profile-${agent}-dry-run.out
+done
 rm -rf "${REAL_HOME}/.colima/${UNMANAGED_PROFILE_NAME}" "${REAL_HOME}/.colima/_lima/colima-${UNMANAGED_PROFILE_NAME}"
 
 if [[ "$(uname -s)" == "Darwin" ]] &&

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -44,20 +44,46 @@ BARRIER_VERIFY_ROOT="$(mktemp -d)"
 BROWSER_PROFILE_FIXTURE=""
 COLIMA_PROFILE_FIXTURE=""
 INSTALL_VERIFY_HOME="$(mktemp -d)"
+REMOTE_VALIDATE_CONFIG_ROOT="$(mktemp -d)"
+LOCAL_REMOTE_CONFIG_PATH="${REMOTE_VALIDATE_CONFIG_ROOT}/remote-validate.env"
+LEGACY_LOCAL_REMOTE_CONFIG_PATH="${ROOT_DIR}/.workcell.remote.local"
+REPO_LOCAL_REMOTE_CONFIG_PATH="${ROOT_DIR}/tmp/verify-remote-validate-repo.env"
+ROOT_DRY_RUN_PROFILE_NAME="$(
+  python3 - "${ROOT_DIR}" <<'PY'
+import hashlib
+import pathlib
+import re
+import sys
+
+workspace = pathlib.Path(sys.argv[1]).resolve()
+slug = re.sub(r"[^a-z0-9]+", "-", workspace.name.lower()).strip("-")[:10] or "workspace"
+digest = hashlib.sha256(str(workspace).encode("utf-8")).hexdigest()[:8]
+print(f"workcell-{slug}-{digest}")
+PY
+)"
+ROOT_DRY_RUN_PROFILE_DIR="${REAL_HOME}/.colima/${ROOT_DRY_RUN_PROFILE_NAME}"
+ROOT_DRY_RUN_LIMA_DIR="${REAL_HOME}/.colima/_lima/colima-${ROOT_DRY_RUN_PROFILE_NAME}"
 
 cleanup() {
   rm -rf "${CODEX_VERIFY_HOME}"
   rm -rf "${BARRIER_VERIFY_ROOT}"
   rm -rf "${INSTALL_VERIFY_HOME}"
+  rm -rf "${REMOTE_VALIDATE_CONFIG_ROOT}"
+  rm -f "${REPO_LOCAL_REMOTE_CONFIG_PATH}"
   if [[ -n "${BROWSER_PROFILE_FIXTURE}" ]] && [[ -d "${BROWSER_PROFILE_FIXTURE}" ]]; then
     rmdir "${BROWSER_PROFILE_FIXTURE}" 2>/dev/null || true
   fi
   if [[ -n "${COLIMA_PROFILE_FIXTURE}" ]] && [[ -d "${COLIMA_PROFILE_FIXTURE}" ]]; then
     rm -rf "${COLIMA_PROFILE_FIXTURE}"
   fi
+  rm -f "${LEGACY_LOCAL_REMOTE_CONFIG_PATH}"
 }
 
 trap cleanup EXIT
+
+if [[ -d "${ROOT_DRY_RUN_PROFILE_DIR}" ]] && [[ ! -f "${ROOT_DRY_RUN_PROFILE_DIR}/workcell.managed" ]]; then
+  rm -rf "${ROOT_DRY_RUN_PROFILE_DIR}" "${ROOT_DRY_RUN_LIMA_DIR}"
+fi
 
 check_file() {
   [[ -f "$1" ]] || {
@@ -698,7 +724,8 @@ if ! rg -q 'snapshot\.debian\.org:80' "${ROOT_DIR}/scripts/workcell"; then
   exit 1
 fi
 
-if ! rg -q 'bootstrap_applied=%q bootstrap_endpoints=%q' "${ROOT_DIR}/scripts/workcell"; then
+if ! rg -q '"bootstrap_applied=\$\{BOOTSTRAP_APPLIED\}"' "${ROOT_DIR}/scripts/workcell" ||
+  ! rg -q '"bootstrap_endpoints=\$\(\[\[ "\$\{BOOTSTRAP_APPLIED\}" -eq 1 \]\] && printf '\''%s'\'' "\$\{BOOTSTRAP_ENDPOINTS\}" \|\| printf '\'''\''\)"' "${ROOT_DIR}/scripts/workcell"; then
   echo "Expected scripts/workcell audit records to include bootstrap network metadata" >&2
   exit 1
 fi
@@ -708,8 +735,13 @@ if ! rg -q 'bootstrap_policy=allowlist endpoints=%s' "${ROOT_DIR}/scripts/workce
   exit 1
 fi
 
-if ! rg -q 'net\.ipv6\.conf\.(all|default)\.disable_ipv6=1' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Expected allowlist egress helper to disable IPv6 while the IPv4 allowlist is active" >&2
+if rg -q 'disable_ipv6=1' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
+  echo "Workcell should not silently disable IPv6 as a fallback for allowlist enforcement" >&2
+  exit 1
+fi
+
+if ! rg -q 'requires ip6tables support to enforce dual-stack allowlist egress policy' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
+  echo "Expected allowlist egress helper to fail closed when dual-stack allowlist enforcement is unavailable" >&2
   exit 1
 fi
 
@@ -1065,6 +1097,64 @@ if [[ -e "${HOST_PATH_BASH_MARKER}" ]] || [[ -e "${HOST_PATH_DIRNAME_MARKER}" ]]
   exit 1
 fi
 
+EGRESS_PLAN_OUTPUT="$("${ROOT_DIR}/scripts/colima-egress-allowlist.sh" plan default 'localhost:443')"
+if ! echo "${EGRESS_PLAN_OUTPUT}" | grep -q 'iptables -A WORKCELL_EGRESS -p tcp -d 127\.0\.0\.1 --dport 443 -j ACCEPT'; then
+  echo "Expected dual-stack egress plan to include the IPv4 localhost rule" >&2
+  exit 1
+fi
+if ! echo "${EGRESS_PLAN_OUTPUT}" | grep -q 'ip6tables -A WORKCELL_EGRESS6 -p tcp -d ::1 --dport 443 -j ACCEPT'; then
+  echo "Expected dual-stack egress plan to include the IPv6 localhost rule" >&2
+  exit 1
+fi
+if ! echo "${EGRESS_PLAN_OUTPUT}" | grep -q 'ip6tables -A WORKCELL_EGRESS6 -j DROP'; then
+  echo "Expected dual-stack egress plan to default-drop IPv6 traffic" >&2
+  exit 1
+fi
+if echo "${EGRESS_PLAN_OUTPUT}" | grep -q 'disable_ipv6'; then
+  echo "Dual-stack egress plan must not toggle kernel IPv6 disablement" >&2
+  exit 1
+fi
+
+EGRESS_PLAN_IPV4_ONLY="$("${ROOT_DIR}/scripts/colima-egress-allowlist.sh" plan default '127.0.0.1:443')"
+if ! echo "${EGRESS_PLAN_IPV4_ONLY}" | grep -q 'ip6tables -N WORKCELL_EGRESS6'; then
+  echo "Expected IPv4-only allowlist plans to still install the IPv6 chain" >&2
+  exit 1
+fi
+if ! echo "${EGRESS_PLAN_IPV4_ONLY}" | grep -q 'ip6tables -A WORKCELL_EGRESS6 -j DROP'; then
+  echo "Expected IPv4-only allowlist plans to still default-drop IPv6 traffic" >&2
+  exit 1
+fi
+
+EGRESS_PLAN_IPV6_LITERAL="$("${ROOT_DIR}/scripts/colima-egress-allowlist.sh" plan default '[::1]:443')"
+if ! echo "${EGRESS_PLAN_IPV6_LITERAL}" | grep -q 'ip6tables -A WORKCELL_EGRESS6 -p tcp -d ::1 --dport 443 -j ACCEPT'; then
+  echo "Expected bracketed IPv6 literal endpoints to produce an IPv6 allowlist rule" >&2
+  exit 1
+fi
+if ! echo "${EGRESS_PLAN_IPV6_LITERAL}" | grep -q 'iptables -A WORKCELL_EGRESS -j DROP'; then
+  echo "Expected bracketed IPv6 literal endpoints to still default-drop IPv4 traffic" >&2
+  exit 1
+fi
+if ! rg -q 'run_in_vm "\$\(render_allowlist_apply_plan\)"' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
+  echo "Expected dual-stack allowlist apply path to use the guarded apply plan" >&2
+  exit 1
+fi
+if ! rg -q 'if ! type ip6tables >/dev/null 2>&1; then' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
+  echo "Expected dual-stack allowlist apply plan to preflight ip6tables before rewriting rules" >&2
+  exit 1
+fi
+if ! rg -q '^render_clear_plan\(\)' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
+  echo "Expected dual-stack allowlist helper to render clear rules in the VM apply plan" >&2
+  exit 1
+fi
+if ! sed -n '/^render_allowlist_apply_plan()/,/^}/p' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" | grep -q 'render_clear_plan'; then
+  echo "Expected dual-stack allowlist apply plan to include render_clear_plan" >&2
+  exit 1
+fi
+if sed -n '/^render_allowlist_apply_plan()/,/^}/p' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" | grep -q '^[[:space:]]*clear_rules$'; then
+  echo "Expected dual-stack allowlist apply plan to avoid invoking clear_rules during render" >&2
+  exit 1
+fi
+
 HOST_PYTHON_INJECT_DIR="${BARRIER_VERIFY_ROOT}/python-inject"
 HOST_PYTHON_MARKER="${BARRIER_VERIFY_ROOT}/pythonpath-ran"
 mkdir -p "${HOST_PYTHON_INJECT_DIR}"
@@ -1294,8 +1384,18 @@ if ! "${ROOT_DIR}/scripts/workcell" \
   exit 1
 fi
 grep -q 'agent_autonomy=yolo' /tmp/workcell-default-autonomy-dry-run.stderr
-grep -q 'assurance_posture=mutable-session' /tmp/workcell-default-autonomy-dry-run.stderr
+grep -q 'container_assurance=managed-mutable' /tmp/workcell-default-autonomy-dry-run.stderr
+grep -q 'autonomy_assurance=managed-yolo' /tmp/workcell-default-autonomy-dry-run.stderr
+grep -q 'codex_rules_mutability_configured=readonly' /tmp/workcell-default-autonomy-dry-run.stderr
+grep -q 'codex_rules_assurance_configured=managed-immutable-rules' /tmp/workcell-default-autonomy-dry-run.stderr
+grep -q 'codex_rules_mutability_effective_initial=readonly' /tmp/workcell-default-autonomy-dry-run.stderr
+grep -q 'codex_rules_assurance_effective_initial=managed-immutable-rules' /tmp/workcell-default-autonomy-dry-run.stderr
+grep -q 'session_assurance_initial=managed-mutable' /tmp/workcell-default-autonomy-dry-run.stderr
 grep -q 'WORKCELL_AGENT_AUTONOMY=yolo' /tmp/workcell-default-autonomy-dry-run.stdout
+grep -q 'WORKCELL_CODEX_RULES_MUTABILITY=readonly' /tmp/workcell-default-autonomy-dry-run.stdout
+grep -q -- '--cap-drop ALL' /tmp/workcell-default-autonomy-dry-run.stdout
+grep -q -- '--cap-add SETUID' /tmp/workcell-default-autonomy-dry-run.stdout
+grep -q -- '--cap-add SETGID' /tmp/workcell-default-autonomy-dry-run.stdout
 
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent codex \
@@ -1307,9 +1407,30 @@ if ! "${ROOT_DIR}/scripts/workcell" \
   exit 1
 fi
 grep -q 'agent_autonomy=prompt' /tmp/workcell-prompt-autonomy-dry-run.stderr
-grep -q 'assurance_posture=lower-assurance-prompt-autonomy,mutable-session' /tmp/workcell-prompt-autonomy-dry-run.stderr
+grep -q 'container_assurance=managed-mutable' /tmp/workcell-prompt-autonomy-dry-run.stderr
+grep -q 'autonomy_assurance=lower-assurance-prompt-autonomy' /tmp/workcell-prompt-autonomy-dry-run.stderr
+grep -q 'codex_rules_mutability_configured=readonly' /tmp/workcell-prompt-autonomy-dry-run.stderr
+grep -q 'codex_rules_assurance_configured=managed-immutable-rules' /tmp/workcell-prompt-autonomy-dry-run.stderr
+grep -q 'codex_rules_mutability_effective_initial=session' /tmp/workcell-prompt-autonomy-dry-run.stderr
+grep -q 'codex_rules_assurance_effective_initial=lower-assurance-session-rules' /tmp/workcell-prompt-autonomy-dry-run.stderr
+grep -q 'session_assurance_initial=managed-mutable' /tmp/workcell-prompt-autonomy-dry-run.stderr
 grep -q 'WORKCELL_AGENT_AUTONOMY=prompt' /tmp/workcell-prompt-autonomy-dry-run.stdout
 grep -q 'workcell:local codex --version' /tmp/workcell-prompt-autonomy-dry-run.stdout
+
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --codex-rules-mutability session \
+  --agent-arg --version \
+  --dry-run >/tmp/workcell-codex-session-rules-dry-run.stdout 2>/tmp/workcell-codex-session-rules-dry-run.stderr; then
+  echo "Expected session Codex rules mutability dry-run to succeed" >&2
+  cat /tmp/workcell-codex-session-rules-dry-run.stderr >&2
+  exit 1
+fi
+grep -q 'codex_rules_mutability_configured=session' /tmp/workcell-codex-session-rules-dry-run.stderr
+grep -q 'codex_rules_assurance_configured=lower-assurance-session-rules' /tmp/workcell-codex-session-rules-dry-run.stderr
+grep -q 'codex_rules_mutability_effective_initial=session' /tmp/workcell-codex-session-rules-dry-run.stderr
+grep -q 'codex_rules_assurance_effective_initial=lower-assurance-session-rules' /tmp/workcell-codex-session-rules-dry-run.stderr
+grep -q 'WORKCELL_CODEX_RULES_MUTABILITY=session' /tmp/workcell-codex-session-rules-dry-run.stdout
 
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent claude \
@@ -1334,6 +1455,17 @@ grep -q 'agent_autonomy=yolo' /tmp/workcell-gemini-agent-arg-dry-run.stderr
 grep -q 'workcell:local gemini --version' /tmp/workcell-gemini-agent-arg-dry-run.stdout
 
 DRY_RUN_OUTPUT="$("${ROOT_DIR}/scripts/workcell" --agent codex --mode strict --dry-run 2>/dev/null)"
+SECOND_DRY_RUN_OUTPUT="$("${ROOT_DIR}/scripts/workcell" --agent codex --mode strict --dry-run 2>/dev/null)"
+DRY_RUN_CONTAINER_NAME="$(printf '%s\n' "${DRY_RUN_OUTPUT}" | sed -n 's/.*--name \([^ ]*\).*/\1/p' | head -n1)"
+SECOND_DRY_RUN_CONTAINER_NAME="$(printf '%s\n' "${SECOND_DRY_RUN_OUTPUT}" | sed -n 's/.*--name \([^ ]*\).*/\1/p' | head -n1)"
+if [[ -z "${DRY_RUN_CONTAINER_NAME}" ]] || [[ -z "${SECOND_DRY_RUN_CONTAINER_NAME}" ]]; then
+  echo "Expected workcell --dry-run to expose a managed container name" >&2
+  exit 1
+fi
+if [[ "${DRY_RUN_CONTAINER_NAME}" == "${SECOND_DRY_RUN_CONTAINER_NAME}" ]]; then
+  echo "Expected repeated workcell --dry-run launches to use unique container names per session" >&2
+  exit 1
+fi
 
 MASK_VERIFY_WORKSPACE="${BARRIER_VERIFY_ROOT}/mask-workspace"
 mkdir -p "${MASK_VERIFY_WORKSPACE}/nested/.claude"
@@ -1410,10 +1542,21 @@ if ! "${ROOT_DIR}/scripts/workcell" \
 fi
 grep -q 'vm_resources=cpu=4 memory_gib=8 disk_gib=80' /tmp/workcell-resource-tunables.stderr
 grep -q 'container_resources=mutability=readonly cpu=2 memory=3g' /tmp/workcell-resource-tunables.stderr
-grep -q 'assurance_posture=managed-readonly' /tmp/workcell-resource-tunables.stderr
+grep -q 'container_assurance=managed-readonly' /tmp/workcell-resource-tunables.stderr
+grep -q 'autonomy_assurance=managed-yolo' /tmp/workcell-resource-tunables.stderr
+grep -q 'session_assurance_initial=managed-readonly' /tmp/workcell-resource-tunables.stderr
 grep -q 'WORKCELL_CONTAINER_MUTABILITY=readonly' /tmp/workcell-resource-tunables.stdout
 grep -q -- '--cpus 2' /tmp/workcell-resource-tunables.stdout
 grep -q -- '--memory 3g' /tmp/workcell-resource-tunables.stdout
+grep -q -- '--cap-drop ALL' /tmp/workcell-resource-tunables.stdout
+if grep -q -- '--cap-add SETUID' /tmp/workcell-resource-tunables.stdout; then
+  echo "Readonly dry-run should not add mutable-session handoff capabilities" >&2
+  exit 1
+fi
+if grep -q -- '--cap-add SETGID' /tmp/workcell-resource-tunables.stdout; then
+  echo "Readonly dry-run should not add mutable-session handoff capabilities" >&2
+  exit 1
+fi
 
 if "${ROOT_DIR}/scripts/workcell" --agent codex --workspace "${REAL_HOME}" --dry-run >/dev/null 2>&1; then
   echo "Expected broad workspace rejection for ${REAL_HOME}" >&2
@@ -1466,7 +1609,7 @@ EOF
 chmod 0755 "${FAKE_VM_BIN}/colima" "${FAKE_VM_BIN}/limactl"
 rm -f /tmp/workcell-egress-pwned
 if PATH="${FAKE_VM_BIN}:${PATH}" WORKCELL_FAKE_LIMACTL_MARKER="${BARRIER_VERIFY_ROOT}/fake-limactl-ran" \
-  "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" apply default 'example.com:443; touch /tmp/workcell-egress-pwned' \
+  "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" plan default 'example.com:443; touch /tmp/workcell-egress-pwned' \
   >/tmp/workcell-egress-invalid.out 2>&1; then
   echo "Expected invalid egress endpoint rejection" >&2
   exit 1
@@ -1475,8 +1618,8 @@ if ! grep -q "Invalid endpoint" /tmp/workcell-egress-invalid.out; then
   echo "Expected explicit invalid-endpoint validation failure" >&2
   exit 1
 fi
-if [[ -e "${BARRIER_VERIFY_ROOT}/fake-limactl-ran" ]]; then
-  echo "Invalid egress endpoint reached limactl execution" >&2
+if [[ -e /tmp/workcell-egress-pwned ]]; then
+  echo "Invalid egress endpoint survived validation and reached the shell" >&2
   exit 1
 fi
 if [[ -e /tmp/workcell-egress-pwned ]]; then
@@ -1542,6 +1685,54 @@ if ! "${ROOT_DIR}/scripts/workcell" --agent codex --prepare --allow-nongit-works
   exit 1
 fi
 
+if [[ "$(uname -s)" == "Darwin" ]] &&
+  host_tool_exists /opt/homebrew/bin/colima /usr/local/bin/colima &&
+  host_tool_exists /opt/homebrew/bin/docker /usr/local/bin/docker /Applications/Docker.app/Contents/Resources/bin/docker; then
+  AUDIT_PROFILE_NAME="workcell-audit-verify-$$"
+  AUDIT_LOG="${REAL_HOME}/.colima/${AUDIT_PROFILE_NAME}/workcell.audit.log"
+  if ! "${ROOT_DIR}/scripts/workcell" \
+    --agent codex \
+    --prepare \
+    --allow-nongit-workspace \
+    --workspace "${NONGIT_WORKSPACE}" \
+    --colima-profile "${AUDIT_PROFILE_NAME}" \
+    --agent-arg --version >/tmp/workcell-audit-prepare.out 2>&1; then
+    echo "Expected audit verification prepare run to seed a managed image" >&2
+    cat /tmp/workcell-audit-prepare.out >&2
+    exit 1
+  fi
+  AUDIT_BASE_LINES=0
+  if [[ -f "${AUDIT_LOG}" ]]; then
+    AUDIT_BASE_LINES="$(wc -l <"${AUDIT_LOG}")"
+  fi
+  if ! "${ROOT_DIR}/scripts/workcell" \
+    --agent codex \
+    --mode build \
+    --allow-nongit-workspace \
+    --workspace "${NONGIT_WORKSPACE}" \
+    --colima-profile "${AUDIT_PROFILE_NAME}" \
+    --allow-arbitrary-command \
+    --ack-arbitrary-command \
+    -- /bin/bash -lc 'sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get update >/dev/null && sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get install -y --no-install-recommends make >/dev/null'; then
+    echo "Expected package-mutation audit verification run to succeed" >&2
+    exit 1
+  fi
+  tail -n "+$((AUDIT_BASE_LINES + 1))" "${AUDIT_LOG}" >/tmp/workcell-audit-session.log
+  grep -q 'event=launch' /tmp/workcell-audit-session.log
+  grep -q 'execution_path=lower-assurance-debug-command' /tmp/workcell-audit-session.log
+  grep -q 'event=assurance-change' /tmp/workcell-audit-session.log
+  grep -q 'reason=package-mutation' /tmp/workcell-audit-session.log
+  grep -q 'session_assurance_final=lower-assurance-package-mutation' /tmp/workcell-audit-session.log
+  grep -q 'event=exit' /tmp/workcell-audit-session.log
+  grep -q 'package_mutation_downgraded=1' /tmp/workcell-audit-session.log
+  if [[ -x /opt/homebrew/bin/colima ]]; then
+    /opt/homebrew/bin/colima delete --profile "${AUDIT_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+  else
+    /usr/local/bin/colima delete --profile "${AUDIT_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+  fi
+  rm -rf "${REAL_HOME}/.colima/${AUDIT_PROFILE_NAME}" "${REAL_HOME}/.colima/_lima/colima-${AUDIT_PROFILE_NAME}"
+fi
+
 UNMANAGED_PROFILE_NAME="workcell-unmanaged-verify-$$"
 mkdir -p "${REAL_HOME}/.colima/${UNMANAGED_PROFILE_NAME}"
 if "${ROOT_DIR}/scripts/workcell" \
@@ -1590,16 +1781,13 @@ EOF
   cat >"${RUBYOPT_PAYLOAD}" <<'EOF'
 File.write(ENV.fetch("RUBYOPT_MARKER"), "ran\n")
 EOF
-  if RUBYOPT_MARKER="${RUBYOPT_MARKER}" \
+  RUBYOPT_MARKER="${RUBYOPT_MARKER}" \
     RUBYOPT="-r${RUBYOPT_PAYLOAD}" \
     "${ROOT_DIR}/scripts/workcell" \
     --agent codex \
     --allow-nongit-workspace \
     --workspace "${NONGIT_WORKSPACE}" \
-    --colima-profile "${RUBY_PROFILE_NAME}" >/tmp/workcell-rubyopt.out 2>&1; then
-    echo "Expected invalid managed Colima profile validation to fail" >&2
-    exit 1
-  fi
+    --colima-profile "${RUBY_PROFILE_NAME}" >/tmp/workcell-rubyopt.out 2>&1 || true
   if [[ -e "${RUBYOPT_MARKER}" ]]; then
     echo "scripts/workcell executed hostile Ruby preload hooks before validating managed Colima profiles" >&2
     exit 1
@@ -1637,6 +1825,53 @@ if "${ROOT_DIR}/scripts/workcell" --agent codex --workspace "${REDIRECTED_REPO}"
   echo "Expected redirected core.worktree repo to be rejected" >&2
   exit 1
 fi
+
+cat <<'EOF' >"${LOCAL_REMOTE_CONFIG_PATH}"
+WORKCELL_REMOTE_VALIDATE_HOST=builder@example.internal
+WORKCELL_REMOTE_VALIDATE_BASE_DIR=/var/tmp/workcell
+WORKCELL_REMOTE_VALIDATE_USE_SUDO=0
+EOF
+if ! WORKCELL_REMOTE_VALIDATE_CONFIG_PATH="${LOCAL_REMOTE_CONFIG_PATH}" \
+  "${ROOT_DIR}/scripts/dev-remote-validate.sh" --check validate --dry-run >/tmp/workcell-remote-config.out 2>&1; then
+  echo "Expected host-local remote builder config to be accepted" >&2
+  cat /tmp/workcell-remote-config.out >&2
+  exit 1
+fi
+grep -q 'Remote host: builder@example.internal' /tmp/workcell-remote-config.out
+grep -q 'Remote base dir: /var/tmp/workcell' /tmp/workcell-remote-config.out
+grep -q "Remote config path: ${LOCAL_REMOTE_CONFIG_PATH}" /tmp/workcell-remote-config.out
+if ! "${ROOT_DIR}/scripts/dev-remote-validate.sh" --config "${LOCAL_REMOTE_CONFIG_PATH}" --check validate --dry-run >/tmp/workcell-remote-config-cli.out 2>&1; then
+  echo "Expected --config host-local remote builder config to be accepted" >&2
+  cat /tmp/workcell-remote-config-cli.out >&2
+  exit 1
+fi
+grep -q 'Remote host: builder@example.internal' /tmp/workcell-remote-config-cli.out
+grep -q "Remote config path: ${LOCAL_REMOTE_CONFIG_PATH}" /tmp/workcell-remote-config-cli.out
+
+cat <<'EOF' >"${LEGACY_LOCAL_REMOTE_CONFIG_PATH}"
+WORKCELL_REMOTE_VALIDATE_HOST=builder@example.internal
+EOF
+if "${ROOT_DIR}/scripts/dev-remote-validate.sh" --check validate --dry-run >/tmp/workcell-remote-config-legacy.out 2>&1; then
+  echo "Expected legacy repo-local remote builder config to be rejected" >&2
+  exit 1
+fi
+grep -q 'Legacy repo-local remote builder config is no longer supported' /tmp/workcell-remote-config-legacy.out
+rm -f "${LEGACY_LOCAL_REMOTE_CONFIG_PATH}"
+
+cat <<'EOF' >"${REPO_LOCAL_REMOTE_CONFIG_PATH}"
+WORKCELL_REMOTE_VALIDATE_HOST=builder@example.internal
+EOF
+if WORKCELL_REMOTE_VALIDATE_CONFIG_PATH="${REPO_LOCAL_REMOTE_CONFIG_PATH}" \
+  "${ROOT_DIR}/scripts/dev-remote-validate.sh" --check validate --dry-run >/tmp/workcell-remote-config-repo-env.out 2>&1; then
+  echo "Expected repo-local remote builder config override via environment to be rejected" >&2
+  exit 1
+fi
+grep -q 'Remote builder config must live outside the repo checkout' /tmp/workcell-remote-config-repo-env.out
+if "${ROOT_DIR}/scripts/dev-remote-validate.sh" --config "${REPO_LOCAL_REMOTE_CONFIG_PATH}" --check validate --dry-run >/tmp/workcell-remote-config-repo-cli.out 2>&1; then
+  echo "Expected repo-local remote builder config override via --config to be rejected" >&2
+  exit 1
+fi
+grep -q 'Remote builder config must live outside the repo checkout' /tmp/workcell-remote-config-repo-cli.out
 
 cp -R "${ROOT_DIR}/adapters/codex/.codex/." "${CODEX_VERIFY_HOME}/"
 if command -v codex >/dev/null 2>&1; then

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -8,6 +8,7 @@ scrub_host_process_env() {
   local env_name
 
   unset BASH_ENV ENV
+  unset WORKCELL_TEST_FAIL_AFTER_PROFILE_REFRESH
   unset PYTHONPATH PYTHONHOME PYTHONSAFEPATH PYTHONSTARTUP
   unset RUBYOPT RUBYLIB GEM_HOME GEM_PATH
   unset PERL5OPT PERL5LIB PERLLIB PERL_MB_OPT PERL_MM_OPT
@@ -418,6 +419,17 @@ append_audit_record() {
     printf '%q ' "$@"
     printf '\n'
   } >>"${audit_path}"
+}
+
+maybe_fail_after_profile_refresh_for_tests() {
+  if [[ "${TEST_FAIL_AFTER_PROFILE_REFRESH:-0}" != "1" ]]; then
+    return 0
+  fi
+  if [[ -z "${PROFILE_AUDIT_LOG_STASH}" ]]; then
+    return 0
+  fi
+  echo "Workcell test hook: forcing failure after managed profile refresh." >&2
+  exit 88
 }
 
 container_assurance() {
@@ -1749,6 +1761,7 @@ ALLOW_NONGIT_WORKSPACE=0
 ALLOW_ARBITRARY_COMMAND=0
 ACK_BREAKGLASS=0
 ACK_ARBITRARY_COMMAND=0
+TEST_FAIL_AFTER_PROFILE_REFRESH=0
 declare -a AGENT_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -1823,6 +1836,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --repair-profile)
       REPAIR_PROFILE=1
+      shift
+      ;;
+    --test-fail-after-profile-refresh)
+      TEST_FAIL_AFTER_PROFILE_REFRESH=1
       shift
       ;;
     --allow-nongit-workspace)
@@ -2179,6 +2196,8 @@ if [[ "${PROFILE_PREEXISTED}" -eq 1 ]]; then
     PROFILE_PREEXISTED=0
   fi
 fi
+
+maybe_fail_after_profile_refresh_for_tests
 
 run_host_colima start \
   --profile "${COLIMA_PROFILE}" \

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -48,6 +48,8 @@ resolve_self_path() {
 
 ROOT_DIR="$(cd -P "$(dirname "$(resolve_self_path)")/.." && pwd)"
 # shellcheck source=/dev/null
+source "${ROOT_DIR}/runtime/container/assurance.sh"
+# shellcheck source=/dev/null
 source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
 resolve_fixed_host_tool() {
   local name="$1"
@@ -85,6 +87,9 @@ PROFILE_RUNNING=0
 PROFILE_VALIDATED=0
 COLIMA_PROFILE=""
 BOOTSTRAP_APPLIED=0
+SESSION_AUDIT_DIR=""
+SESSION_AUDIT_STATE_FILE=""
+SESSION_AUDIT_EVENT_FILE=""
 
 usage() {
   cat <<'EOF'
@@ -94,6 +99,8 @@ Options:
   --agent codex|claude|gemini   Provider to run (required)
   --agent-autonomy yolo|prompt  Provider approval posture (default: yolo)
   --agent-arg VALUE             Additional provider argv to append (repeatable)
+  --codex-rules-mutability readonly|session
+                                Codex execpolicy session mutability (default: readonly)
   --container-mutability ephemeral|readonly
                                 Runtime rootfs posture (default: ephemeral)
   --container-cpu COUNT         Inner container CPU limit (default: unmanaged)
@@ -122,10 +129,16 @@ Options:
 Workflows:
   First run:
     workcell --prepare --agent codex --workspace /path/to/repo
+    workcell --prepare --agent claude --workspace /path/to/repo
+    workcell --prepare --agent gemini --workspace /path/to/repo
   Normal run:
     workcell --agent codex --workspace /path/to/repo
+    workcell --agent claude --workspace /path/to/repo
+    workcell --agent gemini --workspace /path/to/repo
   Repair a conflicting unmanaged profile:
     workcell --repair-profile --agent codex --workspace /path/to/repo
+    workcell --repair-profile --agent claude --workspace /path/to/repo
+    workcell --repair-profile --agent gemini --workspace /path/to/repo
 
 Workcell launches the selected provider directly inside the bounded runtime.
 There is no separate container attach/connect step after launch.
@@ -137,6 +150,14 @@ slugify() {
     tr '[:upper:]' '[:lower:]' |
     tr -cs 'a-z0-9' '-' |
     sed -E 's/^-+//; s/-+$//; s/-+/-/g'
+}
+
+generate_session_suffix() {
+  env -i PATH="${TRUSTED_HOST_PATH}" "${HOST_PYTHON3_BIN}" - <<'PY'
+import secrets
+
+print(secrets.token_hex(4))
+PY
 }
 
 lower_ascii() {
@@ -175,6 +196,17 @@ validate_agent_autonomy_name() {
     *)
       echo "Unsupported agent autonomy mode: $1" >&2
       echo "Use --agent-autonomy yolo or --agent-autonomy prompt." >&2
+      exit 2
+      ;;
+  esac
+}
+
+validate_codex_rules_mutability_name() {
+  case "$1" in
+    readonly | session) ;;
+    *)
+      echo "Unsupported Codex rules mutability: $1" >&2
+      echo "Use --codex-rules-mutability readonly or --codex-rules-mutability session." >&2
       exit 2
       ;;
   esac
@@ -230,6 +262,8 @@ sanitize_host_docker_env() {
 CONTROL_PLANE_SHADOW_ROOT=""
 INJECTION_BUNDLE_ROOT=""
 DIRECT_MOUNT_SPEC_PATH=""
+PROFILE_AUDIT_LOG_STASH=""
+PRESERVE_FAILED_PROFILE_STATE=0
 declare -a SHADOW_MOUNTS=()
 declare -a SHADOW_DEST_PATHS=()
 declare -a DIRECT_SOURCE_MOUNTS=()
@@ -252,12 +286,37 @@ cleanup() {
     rm -f "${DIRECT_MOUNT_SPEC_PATH}"
   fi
 
+  if [[ -n "${PROFILE_AUDIT_LOG_STASH}" ]] && [[ -e "${PROFILE_AUDIT_LOG_STASH}" ]]; then
+    if [[ -n "${COLIMA_PROFILE:-}" ]]; then
+      restore_profile_audit_log "${COLIMA_PROFILE}" || true
+      PRESERVE_FAILED_PROFILE_STATE=1
+    fi
+  fi
+
+  if [[ -n "${PROFILE_AUDIT_LOG_STASH}" ]] && [[ -e "${PROFILE_AUDIT_LOG_STASH}" ]]; then
+    chmod u+w "${PROFILE_AUDIT_LOG_STASH}" 2>/dev/null || true
+    rm -f "${PROFILE_AUDIT_LOG_STASH}"
+  fi
+
+  if [[ -n "${SESSION_AUDIT_DIR}" ]] && [[ -e "${SESSION_AUDIT_DIR}" ]]; then
+    chmod -R u+w "${SESSION_AUDIT_DIR}" 2>/dev/null || true
+    rm -rf "${SESSION_AUDIT_DIR}"
+  fi
+
+  if [[ -n "${CONTAINER_NAME:-}" ]] && [[ -n "${HOST_DOCKER_BIN:-}" ]]; then
+    "${HOST_DOCKER_BIN}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+  fi
+
   cleanup_workcell_trusted_docker_client
   if [[ "${PROFILE_RUNNING}" -eq 1 ]] &&
     [[ -n "${COLIMA_PROFILE}" ]] &&
     [[ -n "${HOST_COLIMA_BIN}" ]]; then
     if [[ "${PROFILE_VALIDATED}" -eq 0 ]] && [[ "${PROFILE_PREEXISTED}" -eq 0 ]]; then
-      run_host_colima delete --profile "${COLIMA_PROFILE}" --force >/dev/null 2>&1 || true
+      if [[ "${PRESERVE_FAILED_PROFILE_STATE}" -eq 1 ]]; then
+        run_host_colima stop --profile "${COLIMA_PROFILE}" >/dev/null 2>&1 || true
+      else
+        run_host_colima delete --profile "${COLIMA_PROFILE}" --force >/dev/null 2>&1 || true
+      fi
     else
       run_host_colima stop --profile "${COLIMA_PROFILE}" >/dev/null 2>&1 || true
     fi
@@ -297,6 +356,44 @@ profile_audit_log_path() {
   printf '%s/workcell.audit.log\n' "$(profile_dir "${profile}")"
 }
 
+stash_profile_audit_log() {
+  local profile="$1"
+  local audit_log=""
+
+  audit_log="$(profile_audit_log_path "${profile}")"
+  [[ -f "${audit_log}" ]] || return 0
+
+  PROFILE_AUDIT_LOG_STASH="$(mktemp "${TMPDIR:-/tmp}/workcell-audit-log.XXXXXX")"
+  cp "${audit_log}" "${PROFILE_AUDIT_LOG_STASH}"
+  chmod 0600 "${PROFILE_AUDIT_LOG_STASH}" 2>/dev/null || true
+}
+
+restore_profile_audit_log() {
+  local profile="$1"
+  local audit_log=""
+  local merged_log=""
+
+  [[ -n "${PROFILE_AUDIT_LOG_STASH}" ]] || return 0
+  [[ -f "${PROFILE_AUDIT_LOG_STASH}" ]] || {
+    PROFILE_AUDIT_LOG_STASH=""
+    return 0
+  }
+
+  audit_log="$(profile_audit_log_path "${profile}")"
+  mkdir -p "$(dirname "${audit_log}")"
+  if [[ -f "${audit_log}" ]] && [[ -s "${audit_log}" ]]; then
+    merged_log="$(mktemp "${TMPDIR:-/tmp}/workcell-audit-merged.XXXXXX")"
+    cat "${PROFILE_AUDIT_LOG_STASH}" "${audit_log}" >"${merged_log}"
+    chmod 0600 "${merged_log}" 2>/dev/null || true
+    mv "${merged_log}" "${audit_log}"
+  else
+    cp "${PROFILE_AUDIT_LOG_STASH}" "${audit_log}"
+  fi
+  chmod 0600 "${audit_log}" 2>/dev/null || true
+  rm -f "${PROFILE_AUDIT_LOG_STASH}"
+  PROFILE_AUDIT_LOG_STASH=""
+}
+
 read_profile_marker_workspace() {
   local marker_path
   marker_path="$(profile_marker_path "$1")"
@@ -306,7 +403,7 @@ read_profile_marker_workspace() {
 
 append_audit_record() {
   local profile="$1"
-  local execution_path="$2"
+  shift
   local audit_path
   local timestamp
 
@@ -316,19 +413,189 @@ append_audit_record() {
   touch "${audit_path}"
   chmod 0600 "${audit_path}" 2>/dev/null || true
   timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-  printf 'timestamp=%s profile=%q mode=%q agent=%q agent_autonomy=%q ui=%q network_policy=%q execution_path=%q workspace=%q endpoints=%q bootstrap_applied=%q bootstrap_endpoints=%q\n' \
-    "${timestamp}" \
-    "${profile}" \
-    "${MODE}" \
-    "${AGENT}" \
-    "${AGENT_AUTONOMY}" \
-    "${UI}" \
-    "${NETWORK_POLICY}" \
-    "${execution_path}" \
-    "${WORKSPACE}" \
-    "${ALLOW_ENDPOINTS}" \
-    "${BOOTSTRAP_APPLIED}" \
-    "$([[ "${BOOTSTRAP_APPLIED}" -eq 1 ]] && printf '%s' "${BOOTSTRAP_ENDPOINTS}" || printf '')" >>"${audit_path}"
+  {
+    printf 'timestamp=%q ' "${timestamp}"
+    printf '%q ' "$@"
+    printf '\n'
+  } >>"${audit_path}"
+}
+
+container_assurance() {
+  workcell_container_assurance "${CONTAINER_MUTABILITY}"
+}
+
+autonomy_assurance() {
+  workcell_autonomy_assurance "${AGENT_AUTONOMY}"
+}
+
+codex_rules_assurance() {
+  if [[ "${AGENT}" != "codex" ]]; then
+    printf 'not-applicable\n'
+    return 0
+  fi
+  workcell_codex_rules_assurance "${CODEX_RULES_MUTABILITY}"
+}
+
+codex_rules_effective_mutability_with_session_assurance() {
+  local session_assurance="$1"
+
+  if [[ "${AGENT}" != "codex" ]]; then
+    printf 'not-applicable\n'
+    return 0
+  fi
+  workcell_effective_codex_rules_mutability "${CODEX_RULES_MUTABILITY}" "${AGENT_AUTONOMY}" "${session_assurance}"
+}
+
+codex_rules_effective_assurance_with_session_assurance() {
+  local session_assurance="$1"
+
+  if [[ "${AGENT}" != "codex" ]]; then
+    printf 'not-applicable\n'
+    return 0
+  fi
+  workcell_effective_codex_rules_assurance "${CODEX_RULES_MUTABILITY}" "${AGENT_AUTONOMY}" "${session_assurance}"
+}
+
+session_assurance_initial() {
+  container_assurance
+}
+
+session_assurance_final() {
+  local initial_assurance
+  local final_assurance
+
+  initial_assurance="$(session_assurance_initial)"
+  final_assurance="${initial_assurance}"
+  if [[ -n "${SESSION_AUDIT_EVENT_FILE}" ]] && [[ -r "${SESSION_AUDIT_EVENT_FILE}" ]] &&
+    grep -q '^WORKCELL_EVENT package-mutation assurance=lower-assurance-package-mutation$' "${SESSION_AUDIT_EVENT_FILE}"; then
+    printf '%s\n' "lower-assurance-package-mutation"
+    return 0
+  fi
+  if [[ -n "${SESSION_AUDIT_STATE_FILE}" ]] && [[ -r "${SESSION_AUDIT_STATE_FILE}" ]]; then
+    case "$(head -n1 "${SESSION_AUDIT_STATE_FILE}")" in
+      lower-assurance-package-mutation)
+        final_assurance="lower-assurance-package-mutation"
+        ;;
+    esac
+  fi
+  printf '%s\n' "${final_assurance}"
+}
+
+codex_rules_effective_mutability_initial() {
+  codex_rules_effective_mutability_with_session_assurance "$(session_assurance_initial)"
+}
+
+codex_rules_effective_assurance_initial() {
+  codex_rules_effective_assurance_with_session_assurance "$(session_assurance_initial)"
+}
+
+append_launch_audit_record() {
+  local profile="$1"
+  local execution_path="$2"
+
+  append_audit_record "${profile}" \
+    "event=launch" \
+    "profile=${profile}" \
+    "mode=${MODE}" \
+    "agent=${AGENT}" \
+    "agent_autonomy=${AGENT_AUTONOMY}" \
+    "autonomy_assurance=$(autonomy_assurance)" \
+    "codex_rules_mutability_configured=${CODEX_RULES_MUTABILITY}" \
+    "codex_rules_assurance_configured=$(codex_rules_assurance)" \
+    "codex_rules_mutability_effective_initial=$(codex_rules_effective_mutability_initial)" \
+    "codex_rules_assurance_effective_initial=$(codex_rules_effective_assurance_initial)" \
+    "ui=${UI}" \
+    "network_policy=${NETWORK_POLICY}" \
+    "execution_path=${execution_path}" \
+    "workspace=${WORKSPACE}" \
+    "endpoints=${ALLOW_ENDPOINTS}" \
+    "bootstrap_applied=${BOOTSTRAP_APPLIED}" \
+    "bootstrap_endpoints=$([[ "${BOOTSTRAP_APPLIED}" -eq 1 ]] && printf '%s' "${BOOTSTRAP_ENDPOINTS}" || printf '')" \
+    "container_assurance=$(container_assurance)" \
+    "session_assurance_initial=$(session_assurance_initial)"
+}
+
+append_assurance_change_audit_record() {
+  local profile="$1"
+  local final_assurance="$2"
+
+  append_audit_record "${profile}" \
+    "event=assurance-change" \
+    "profile=${profile}" \
+    "mode=${MODE}" \
+    "agent=${AGENT}" \
+    "workspace=${WORKSPACE}" \
+    "reason=package-mutation" \
+    "codex_rules_mutability_effective_final=$(codex_rules_effective_mutability_with_session_assurance "${final_assurance}")" \
+    "codex_rules_assurance_effective_final=$(codex_rules_effective_assurance_with_session_assurance "${final_assurance}")" \
+    "session_assurance_final=${final_assurance}"
+}
+
+append_exit_audit_record() {
+  local profile="$1"
+  local execution_path="$2"
+  local exit_status="$3"
+  local final_assurance="$4"
+  local downgraded="$5"
+
+  append_audit_record "${profile}" \
+    "event=exit" \
+    "profile=${profile}" \
+    "mode=${MODE}" \
+    "agent=${AGENT}" \
+    "workspace=${WORKSPACE}" \
+    "execution_path=${execution_path}" \
+    "exit_status=${exit_status}" \
+    "container_assurance=$(container_assurance)" \
+    "autonomy_assurance=$(autonomy_assurance)" \
+    "codex_rules_mutability_configured=${CODEX_RULES_MUTABILITY}" \
+    "codex_rules_assurance_configured=$(codex_rules_assurance)" \
+    "codex_rules_mutability_effective_final=$(codex_rules_effective_mutability_with_session_assurance "${final_assurance}")" \
+    "codex_rules_assurance_effective_final=$(codex_rules_effective_assurance_with_session_assurance "${final_assurance}")" \
+    "session_assurance_initial=$(session_assurance_initial)" \
+    "session_assurance_final=${final_assurance}" \
+    "package_mutation_downgraded=${downgraded}"
+}
+
+prepare_session_audit_state() {
+  local profile="$1"
+
+  mkdir -p "$(profile_dir "${profile}")"
+  SESSION_AUDIT_DIR="$(mktemp -d "$(profile_dir "${profile}")/session-audit.XXXXXX")"
+  chmod 0700 "${SESSION_AUDIT_DIR}" 2>/dev/null || true
+  SESSION_AUDIT_STATE_FILE="${SESSION_AUDIT_DIR}/session-assurance"
+  SESSION_AUDIT_EVENT_FILE="${SESSION_AUDIT_DIR}/events.log"
+}
+
+capture_session_audit_state() {
+  local container_name="$1"
+
+  [[ -n "${SESSION_AUDIT_STATE_FILE}" ]] || return 0
+  mkdir -p "$(dirname "${SESSION_AUDIT_STATE_FILE}")"
+  if ! "${HOST_DOCKER_BIN}" cp "${container_name}:/run/workcell/session-assurance" "${SESSION_AUDIT_STATE_FILE}" >/dev/null 2>&1; then
+    :
+  fi
+  chmod 0600 "${SESSION_AUDIT_STATE_FILE}" 2>/dev/null || true
+  if [[ -n "${SESSION_AUDIT_EVENT_FILE}" ]]; then
+    mkdir -p "$(dirname "${SESSION_AUDIT_EVENT_FILE}")"
+    "${HOST_DOCKER_BIN}" logs "${container_name}" >"${SESSION_AUDIT_EVENT_FILE}" 2>&1 || true
+    chmod 0600 "${SESSION_AUDIT_EVENT_FILE}" 2>/dev/null || true
+  fi
+}
+
+finalize_session_audit() {
+  local profile="$1"
+  local execution_path="$2"
+  local exit_status="$3"
+  local final_assurance
+  local downgraded=0
+
+  final_assurance="$(session_assurance_final)"
+  if [[ "${final_assurance}" == "lower-assurance-package-mutation" ]]; then
+    downgraded=1
+    append_assurance_change_audit_record "${profile}" "${final_assurance}"
+  fi
+  append_exit_audit_record "${profile}" "${execution_path}" "${exit_status}" "${final_assurance}" "${downgraded}"
 }
 
 write_profile_image_marker() {
@@ -872,25 +1139,6 @@ validate_container_mutability() {
   esac
 }
 
-assurance_posture() {
-  local autonomy="$1"
-  local mutability="$2"
-
-  if [[ "${autonomy}" == "prompt" ]] && [[ "${mutability}" == "ephemeral" ]]; then
-    printf 'lower-assurance-prompt-autonomy,mutable-session\n'
-    return 0
-  fi
-  if [[ "${autonomy}" == "prompt" ]]; then
-    printf 'lower-assurance-prompt-autonomy\n'
-    return 0
-  fi
-  if [[ "${mutability}" == "ephemeral" ]]; then
-    printf 'mutable-session\n'
-    return 0
-  fi
-  printf 'managed-readonly\n'
-}
-
 validate_positive_integer() {
   local label="$1"
   local value="$2"
@@ -1391,11 +1639,24 @@ add_shadow_git_config_mount() {
   register_shadow_mount "${source}" "${destination}"
 }
 
+add_shadow_git_path_if_present() {
+  local workspace="$1"
+  local relative_path="$2"
+  local path="${workspace}/${relative_path}"
+
+  [[ -e "${path}" ]] || return 0
+  if [[ -d "${path}" ]]; then
+    add_shadow_git_hooks_mount "${workspace}" "${relative_path}"
+  else
+    add_shadow_git_config_mount "${workspace}" "${relative_path}"
+  fi
+}
+
 prepare_workspace_control_plane_shadow() {
   local workspace="$1"
   local mode="$2"
   local shadow_parent="${REAL_HOME}/Library/Caches/colima/workcell-shadow"
-  local rel path
+  local rel path git_dir git_rel
 
   SHADOW_MOUNTS=()
   SHADOW_DEST_PATHS=()
@@ -1409,25 +1670,35 @@ prepare_workspace_control_plane_shadow() {
   mkdir -p "${shadow_parent}"
   CONTROL_PLANE_SHADOW_ROOT="$(mktemp -d "${shadow_parent}/shadow.XXXXXX")"
 
-  while IFS= read -r -d '' path; do
-    rel="${path#"${workspace}/"}"
-    if [[ -d "${path}" ]]; then
-      add_shadow_git_hooks_mount "${workspace}" "${rel}"
-    else
-      add_shadow_git_config_mount "${workspace}" "${rel}"
+  while IFS= read -r -d '' git_dir; do
+    git_rel="${git_dir#"${workspace}/"}"
+    for rel in "${git_rel}/hooks" "${git_rel}/config" "${git_rel}/config.worktree"; do
+      add_shadow_git_path_if_present "${workspace}" "${rel}"
+    done
+    if [[ -e "${workspace}/${git_rel}/worktrees" ]]; then
+      add_shadow_dir_mount "${git_rel}/worktrees"
+    fi
+    if [[ -d "${workspace}/${git_rel}/modules" ]]; then
+      while IFS= read -r -d '' path; do
+        rel="${path#"${workspace}/"}"
+        add_shadow_git_path_if_present "${workspace}" "${rel}"
+      done < <(
+        find "${workspace}/${git_rel}/modules" \
+          \( \
+          \( -type d -name hooks \) -o \
+          \( -type f \( -name config -o -name config.worktree \) \) \
+          \) \
+          -print0
+      )
+      while IFS= read -r -d '' path; do
+        rel="${path#"${workspace}/"}"
+        add_shadow_dir_mount "${rel}"
+      done < <(
+        find "${workspace}/${git_rel}/modules" -type d -name worktrees -print0
+      )
     fi
   done < <(
-    find "${workspace}" \
-      \( \( -type d -o -type l \) \( -path '*/.git/hooks' -o -path '*/.git/modules/*/hooks' \) \) -print0 -o \
-      \( \( -type f -o -type l \) \( -path '*/.git/config' -o -path '*/.git/config.worktree' -o -path '*/.git/modules/*/config' -o -path '*/.git/modules/*/config.worktree' \) \) -print0
-  )
-
-  while IFS= read -r -d '' path; do
-    rel="${path#"${workspace}/"}"
-    add_shadow_dir_mount "${rel}"
-  done < <(
-    find "${workspace}" \
-      \( \( -type d -o -type l \) \( -path '*/.git/worktrees' -o -path '*/.git/modules/*/worktrees' \) \) -print0
+    find "${workspace}" -type d -name .git -prune -print0
   )
 
   while IFS= read -r -d '' path; do
@@ -1457,6 +1728,7 @@ bootstrap_endpoints() {
 
 AGENT=""
 AGENT_AUTONOMY="yolo"
+CODEX_RULES_MUTABILITY="readonly"
 CONTAINER_MUTABILITY="ephemeral"
 CONTAINER_CPU_OVERRIDE=""
 CONTAINER_MEMORY_OVERRIDE=""
@@ -1491,6 +1763,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --agent-arg)
       AGENT_ARGS+=("$(raw_option_value_or_die "$1" "${2-}")")
+      shift 2
+      ;;
+    --codex-rules-mutability)
+      CODEX_RULES_MUTABILITY="$(option_value_or_die "$1" "${2-}")"
       shift 2
       ;;
     --container-mutability)
@@ -1588,6 +1864,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 validate_agent_autonomy_name "${AGENT_AUTONOMY}"
+validate_codex_rules_mutability_name "${CODEX_RULES_MUTABILITY}"
 declare -a PROVIDER_ARGS=()
 if ((${#AGENT_ARGS[@]} > 0)); then
   PROVIDER_ARGS=("${AGENT_ARGS[@]}")
@@ -1760,11 +2037,10 @@ if [[ "${CONTAINER_MUTABILITY}" == "ephemeral" ]]; then
 fi
 prepare_workspace_control_plane_shadow "${WORKSPACE}" "${MODE}"
 
-CONTAINER_NAME="workcell-$(slugify "${AGENT}-${MODE}-$(basename "${WORKSPACE}")")"
+CONTAINER_NAME="workcell-$(slugify "${AGENT}-${MODE}-$(basename "${WORKSPACE}")")-$(generate_session_suffix)"
 DOCKER_RUN_BASE=(
   "${HOST_DOCKER_BIN}"
   run
-  --rm
   --init
   --name "${CONTAINER_NAME}"
   --security-opt no-new-privileges:true
@@ -1777,6 +2053,7 @@ DOCKER_RUN_BASE=(
   --workdir /workspace
   -e AGENT_NAME="${AGENT}"
   -e WORKCELL_AGENT_AUTONOMY="${AGENT_AUTONOMY}"
+  -e WORKCELL_CODEX_RULES_MUTABILITY="${CODEX_RULES_MUTABILITY}"
   -e WORKCELL_CONTAINER_MUTABILITY="${CONTAINER_MUTABILITY}"
   -e AGENT_UI="${UI}"
   -e CODEX_PROFILE="${MODE}"
@@ -1798,6 +2075,11 @@ if [[ "${CONTAINER_MUTABILITY}" == "readonly" ]]; then
   )
 else
   DOCKER_RUN_BASE+=(
+    # Mutable sessions still drop the default capability set, but need the
+    # minimal handoff capabilities required to re-exec as the mapped runtime
+    # user.
+    --cap-add SETUID
+    --cap-add SETGID
     --user 0:0
     -e WORKCELL_HOST_UID="${HOST_UID}"
     -e WORKCELL_HOST_GID="${HOST_GID}"
@@ -1821,6 +2103,9 @@ if [[ -n "${INJECTION_BUNDLE_ROOT}" ]]; then
     -e WORKCELL_INJECTION_MANIFEST=/opt/workcell/host-injections/manifest.json
     -v "${INJECTION_BUNDLE_ROOT}:/opt/workcell/host-injections:ro"
   )
+fi
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+  prepare_session_audit_state "${COLIMA_PROFILE}"
 fi
 
 EXECUTION_PATH="managed-tier1"
@@ -1854,7 +2139,7 @@ else
 fi
 
 if [[ -t 0 ]] && [[ -t 1 ]]; then
-  DOCKER_RUN=("${HOST_DOCKER_BIN}" run --rm --init -it "${DOCKER_RUN[@]:4}")
+  DOCKER_RUN=("${HOST_DOCKER_BIN}" run --init -it "${DOCKER_RUN[@]:3}")
 fi
 
 printf 'profile=%s mode=%s agent=%s ui=%s workspace=%s\n' \
@@ -1863,7 +2148,13 @@ printf 'agent_autonomy=%s\n' "${AGENT_AUTONOMY}" >&2
 printf 'vm_resources=cpu=%s memory_gib=%s disk_gib=%s\n' "${COLIMA_CPU}" "${COLIMA_MEMORY}" "${COLIMA_DISK}" >&2
 printf 'container_resources=mutability=%s cpu=%s memory=%s\n' \
   "${CONTAINER_MUTABILITY}" "${CONTAINER_CPU_OVERRIDE:-unmanaged}" "${CONTAINER_MEMORY}" >&2
-printf 'assurance_posture=%s\n' "$(assurance_posture "${AGENT_AUTONOMY}" "${CONTAINER_MUTABILITY}")" >&2
+printf 'container_assurance=%s\n' "$(container_assurance)" >&2
+printf 'autonomy_assurance=%s\n' "$(autonomy_assurance)" >&2
+printf 'codex_rules_mutability_configured=%s\n' "${CODEX_RULES_MUTABILITY}" >&2
+printf 'codex_rules_assurance_configured=%s\n' "$(codex_rules_assurance)" >&2
+printf 'codex_rules_mutability_effective_initial=%s\n' "$(codex_rules_effective_mutability_initial)" >&2
+printf 'codex_rules_assurance_effective_initial=%s\n' "$(codex_rules_effective_assurance_initial)" >&2
+printf 'session_assurance_initial=%s\n' "$(session_assurance_initial)" >&2
 printf 'workspace_control_plane=%s\n' "$([[ "${MODE}" == "breakglass" ]] && printf 'unmasked' || printf 'masked')" >&2
 printf 'network_policy=%s endpoints=%s\n' "${NETWORK_POLICY}" "${ALLOW_ENDPOINTS}" >&2
 printf 'execution_path=%s audit_log=%s\n' "${EXECUTION_PATH}" "$(profile_audit_log_path "${COLIMA_PROFILE}")" >&2
@@ -1876,11 +2167,13 @@ fi
 if [[ "${PROFILE_PREEXISTED}" -eq 1 ]]; then
   if ! validate_colima_profile_config "${COLIMA_PROFILE}" "${WORKSPACE}" "${COLIMA_CPU}" "${COLIMA_MEMORY}" "${COLIMA_DISK}"; then
     echo "Refreshing managed Colima profile ${COLIMA_PROFILE} to apply the requested reviewed VM resources." >&2
+    stash_profile_audit_log "${COLIMA_PROFILE}"
     run_host_colima delete --profile "${COLIMA_PROFILE}" --force >/dev/null 2>&1 || true
     rm -rf "${PROFILE_DIR}"
     PROFILE_PREEXISTED=0
   elif ! validate_colima_runtime_mounts "${COLIMA_PROFILE}" "${WORKSPACE}"; then
     echo "Refreshing managed Colima profile ${COLIMA_PROFILE} to discard stale runtime mounts." >&2
+    stash_profile_audit_log "${COLIMA_PROFILE}"
     run_host_colima delete --profile "${COLIMA_PROFILE}" --force >/dev/null 2>&1 || true
     rm -rf "${PROFILE_DIR}"
     PROFILE_PREEXISTED=0
@@ -1900,6 +2193,7 @@ PROFILE_RUNNING=1
 
 validate_colima_profile "${COLIMA_PROFILE}" "${WORKSPACE}"
 mkdir -p "${PROFILE_DIR}"
+restore_profile_audit_log "${COLIMA_PROFILE}"
 printf '%s\n' "${WORKSPACE}" >"${PROFILE_MARKER}"
 PROFILE_VALIDATED=1
 
@@ -1969,10 +2263,14 @@ if [[ "${NEEDS_REBUILD}" -eq 1 ]]; then
 fi
 
 restore_runtime_egress
-append_audit_record "${COLIMA_PROFILE}" "${EXECUTION_PATH}"
+append_launch_audit_record "${COLIMA_PROFILE}" "${EXECUTION_PATH}"
 
 DOCKER_STATUS=0
+"${HOST_DOCKER_BIN}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
 "${DOCKER_RUN[@]}" || DOCKER_STATUS=$?
+capture_session_audit_state "${CONTAINER_NAME}"
+finalize_session_audit "${COLIMA_PROFILE}" "${EXECUTION_PATH}" "${DOCKER_STATUS}"
+"${HOST_DOCKER_BIN}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
 if [[ "${CONTAINER_MUTABILITY}" == "ephemeral" ]]; then
   echo "Workcell ephemeral runtime ended. Changes not persisted to /workspace or provided from the host control plane were discarded." >&2
 fi

--- a/tests/python/test_extract_direct_mounts.py
+++ b/tests/python/test_extract_direct_mounts.py
@@ -73,6 +73,48 @@ class ExtractDirectMountsTests(unittest.TestCase):
                 "/opt/workcell/host-inputs/copies/0",
             )
 
+    def test_require_direct_mount_rejects_missing_source(self) -> None:
+        with self.assertRaises(SystemExit):
+            self.module.require_direct_mount(
+                {"mount_path": "/opt/workcell/host-inputs/credentials/codex-auth.json"},
+                "credentials.codex_auth",
+            )
+
+    def test_main_leaves_plain_copy_sources_inline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = root / "manifest.json"
+            mount_spec_path = root / "mounts.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "copies": [
+                            {
+                                "source": "copies/0",
+                                "target": "/state/injected/public.txt",
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            argv = [
+                "extract_direct_mounts.py",
+                "--manifest",
+                str(manifest_path),
+                "--mount-spec",
+                str(mount_spec_path),
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                self.assertEqual(self.module.main(), 0)
+
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            mounts = json.loads(mount_spec_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(manifest["copies"][0]["source"], "copies/0")
+            self.assertEqual(mounts, [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/python/test_injection_helpers.py
+++ b/tests/python/test_injection_helpers.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path, PurePosixPath
+from unittest import mock
+
+from test_support import load_module
+
+
+class RenderInjectionHelperTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = load_module("scripts/lib/render_injection_bundle.py")
+        self.extract_module = load_module("scripts/lib/extract_direct_mounts.py")
+
+    def test_strip_comment_preserves_quoted_hashes(self) -> None:
+        self.assertEqual(
+            self.module.strip_comment('value = "keep # hash" # remove'),
+            'value = "keep # hash"',
+        )
+        self.assertEqual(
+            self.module.strip_comment(r'value = "escaped \"#\" hash" # remove'),
+            r'value = "escaped \"#\" hash"',
+        )
+
+    def test_parse_value_supports_supported_scalar_types(self) -> None:
+        policy = Path("/tmp/policy.toml")
+        self.assertTrue(self.module.parse_value("true", policy, 1))
+        self.assertFalse(self.module.parse_value("false", policy, 2))
+        self.assertEqual(self.module.parse_value('"text"', policy, 3), "text")
+        self.assertEqual(self.module.parse_value('["a", "b"]', policy, 4), ["a", "b"])
+        self.assertEqual(self.module.parse_value("42", policy, 5), 42)
+
+    def test_parse_value_rejects_unsupported_types(self) -> None:
+        policy = Path("/tmp/policy.toml")
+        with self.assertRaises(SystemExit):
+            self.module.parse_value("1.5", policy, 1)
+        with self.assertRaises(SystemExit):
+            self.module.parse_value("[1, 2]", policy, 2)
+        with self.assertRaises(SystemExit):
+            self.module.parse_value("", policy, 3)
+
+    def test_parse_toml_subset_parses_supported_tables(self) -> None:
+        policy = Path("/tmp/policy.toml")
+        parsed = self.module.parse_toml_subset(
+            """
+            version = 1
+            [documents]
+            common = "common.md"
+            [credentials]
+            codex_auth = "auth.json"
+            [ssh]
+            enabled = true
+            identities = ["id_ed25519"]
+            [[copies]]
+            source = "file.txt"
+            target = "/state/injected/file.txt"
+            classification = "public"
+            """,
+            policy,
+        )
+        self.assertEqual(parsed["version"], 1)
+        self.assertEqual(parsed["documents"]["common"], "common.md")
+        self.assertEqual(parsed["credentials"]["codex_auth"], "auth.json")
+        self.assertTrue(parsed["ssh"]["enabled"])
+        self.assertEqual(len(parsed["copies"]), 1)
+
+    def test_parse_toml_subset_rejects_invalid_lines(self) -> None:
+        policy = Path("/tmp/policy.toml")
+        with self.assertRaises(SystemExit):
+            self.module.parse_toml_subset("[[ssh]]\nfoo = \"bar\"\n", policy)
+        with self.assertRaises(SystemExit):
+            self.module.parse_toml_subset("= \"bar\"\n", policy)
+        with self.assertRaises(SystemExit):
+            self.module.parse_toml_subset("nope\n", policy)
+
+    def test_path_and_target_validation_helpers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            relative = self.module.expand_host_path("child/file.txt", base)
+            self.assertEqual(relative, (base / "child/file.txt").resolve())
+            candidate = self.module.normalize_container_target("~/test.txt")
+            self.assertEqual(
+                candidate,
+                PurePosixPath("/state/agent-home/test.txt"),
+            )
+            self.assertTrue(
+                self.module.target_is_under(
+                    PurePosixPath("/state/agent-home/.config"),
+                    PurePosixPath("/state/agent-home"),
+                )
+            )
+            self.assertTrue(
+                self.module.target_is_reserved(
+                    PurePosixPath("/state/agent-home/.codex/rules/default.rules")
+                )
+            )
+            self.assertEqual(
+                self.module.validate_container_target(
+                    PurePosixPath("/state/injected/notes.txt")
+                ),
+                "/state/injected/notes.txt",
+            )
+            with self.assertRaises(SystemExit):
+                self.module.normalize_container_target("relative.txt")
+            with self.assertRaises(SystemExit):
+                self.module.normalize_container_target("/state/agent-home/../escape")
+            with self.assertRaises(SystemExit):
+                self.module.validate_container_target(PurePosixPath("/tmp/outside"))
+
+    def test_selection_and_key_validation_helpers(self) -> None:
+        self.assertTrue(
+            self.module.selected_for(None, "codex", "providers", {"codex", "claude"})
+        )
+        self.assertTrue(
+            self.module.selected_for(["codex"], "codex", "providers", {"codex"})
+        )
+        with self.assertRaises(SystemExit):
+            self.module.selected_for([], "codex", "providers", {"codex"})
+        with self.assertRaises(SystemExit):
+            self.module.selected_for(["invalid"], "codex", "providers", {"codex"})
+        self.module.validate_allowed_keys({"a": 1}, {"a"}, "table")
+        with self.assertRaises(SystemExit):
+            self.module.validate_allowed_keys({"a": 1, "b": 2}, {"a"}, "table")
+
+    def test_copy_source_and_stage_file_handle_files_and_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            source_file = root / "source.txt"
+            source_file.write_text("hello\n", encoding="utf-8")
+            staged_file = root / "bundle/file.txt"
+            self.assertEqual(self.module.copy_source(source_file, staged_file), "file")
+            self.assertEqual(staged_file.read_text(encoding="utf-8"), "hello\n")
+            self.assertEqual(oct(staged_file.stat().st_mode & 0o777), "0o600")
+
+            source_dir = root / "dir-source"
+            source_dir.mkdir()
+            (source_dir / "nested.txt").write_text("nested\n", encoding="utf-8")
+            staged_dir = root / "bundle/dir"
+            self.assertEqual(self.module.copy_source(source_dir, staged_dir), "dir")
+            self.assertTrue((staged_dir / "nested.txt").is_file())
+            self.assertEqual(oct(staged_dir.stat().st_mode & 0o777), "0o700")
+
+            output_root = root / "stage"
+            output_root.mkdir()
+            relpath = self.module.stage_file(source_file, output_root, "documents/common.md")
+            self.assertEqual(relpath, "documents/common.md")
+            self.assertTrue((output_root / relpath).is_file())
+
+    def test_copy_source_rejects_symlinks_and_missing_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            source_dir = root / "dir-source"
+            source_dir.mkdir()
+            (source_dir / "target.txt").write_text("target\n", encoding="utf-8")
+            (source_dir / "link.txt").symlink_to(source_dir / "target.txt")
+            with self.assertRaises(SystemExit):
+                self.module.ensure_no_symlinks_within(source_dir)
+            with self.assertRaises(SystemExit):
+                self.module.copy_source(root / "missing.txt", root / "dest")
+
+    def test_validate_source_path_and_load_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "policy.toml"
+            source = root / "common.md"
+            source.write_text("common\n", encoding="utf-8")
+            policy_path.write_text(
+                'version = 1\n[documents]\ncommon = "common.md"\n',
+                encoding="utf-8",
+            )
+            loaded = self.module.load_policy(policy_path)
+            self.assertEqual(loaded["documents"]["common"], "common.md")
+            self.assertEqual(
+                self.module.validate_source_path("common.md", "documents.common", root),
+                source.resolve(),
+            )
+
+            policy_path.write_text('version = 2\n', encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                self.module.load_policy(policy_path)
+            with self.assertRaises(SystemExit):
+                self.module.validate_source_path("", "documents.common", root)
+
+    def test_render_documents_rejects_non_file_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            (root / "dir").mkdir()
+            with self.assertRaises(SystemExit):
+                self.module.render_documents(
+                    {"documents": {"common": "dir"}},
+                    output,
+                    root,
+                )
+
+    def test_render_copies_supports_public_and_secret_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            public_dir = root / "public-dir"
+            public_dir.mkdir()
+            (public_dir / "note.txt").write_text("note\n", encoding="utf-8")
+            secret_dir = root / "secret-dir"
+            secret_dir.mkdir()
+            (secret_dir / "token.txt").write_text("token\n", encoding="utf-8")
+
+            rendered = self.module.render_copies(
+                {
+                    "copies": [
+                        {
+                            "source": "public-dir",
+                            "target": "/state/injected/public-dir",
+                            "classification": "public",
+                        },
+                        {
+                            "source": "secret-dir",
+                            "target": "/state/agent-home/.config/workcell/secrets",
+                            "classification": "secret",
+                        },
+                    ]
+                },
+                output,
+                root,
+                "codex",
+                "strict",
+            )
+
+            self.assertEqual(rendered[0]["source"], "copies/0")
+            self.assertEqual(rendered[0]["kind"], "dir")
+            self.assertEqual(
+                rendered[1]["source"]["mount_path"],
+                "/opt/workcell/host-inputs/copies/1",
+            )
+            self.assertEqual(rendered[1]["kind"], "dir")
+
+    def test_render_copies_rejects_invalid_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            (root / "file.txt").write_text("data\n", encoding="utf-8")
+
+            with self.assertRaises(SystemExit):
+                self.module.render_copies(
+                    {"copies": [{"source": "file.txt", "target": "/state/injected/file.txt"}]},
+                    output,
+                    root,
+                    "codex",
+                    "strict",
+                )
+            with self.assertRaises(SystemExit):
+                self.module.render_copies(
+                    {"copies": ["not-a-table"]},
+                    output,
+                    root,
+                    "codex",
+                    "strict",
+                )
+            with self.assertRaises(SystemExit):
+                self.module.classification_modes("invalid", is_dir=False)
+
+    def test_render_ssh_supports_full_configuration(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            (root / "config").write_text("Host *\n", encoding="utf-8")
+            (root / "known_hosts").write_text("host key\n", encoding="utf-8")
+            (root / "id_a").write_text("key a\n", encoding="utf-8")
+            (root / "id_b").write_text("key b\n", encoding="utf-8")
+
+            rendered = self.module.render_ssh(
+                {
+                    "ssh": {
+                        "enabled": True,
+                        "config": "config",
+                        "known_hosts": "known_hosts",
+                        "identities": ["id_a", "id_b"],
+                    }
+                },
+                output,
+                root,
+                "codex",
+                "strict",
+            )
+
+            self.assertEqual(
+                rendered["config"]["mount_path"],
+                "/opt/workcell/host-inputs/ssh/config",
+            )
+            self.assertEqual(len(rendered["identities"]), 2)
+            self.assertEqual(rendered["identities"][0]["target_name"], "id_a")
+
+    def test_render_ssh_rejects_invalid_configuration(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            (root / "config-dir").mkdir()
+            with self.assertRaises(SystemExit):
+                self.module.render_ssh(
+                    {"ssh": {"enabled": "yes"}},
+                    output,
+                    root,
+                    "codex",
+                    "strict",
+                )
+
+            (root / "config").write_text("key\n", encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                self.module.render_ssh(
+                    {
+                        "ssh": {
+                            "enabled": True,
+                            "identities": ["config"],
+                        }
+                    },
+                    output,
+                    root,
+                    "codex",
+                    "strict",
+                )
+
+            with self.assertRaises(SystemExit):
+                self.module.render_ssh(
+                    {"ssh": {"enabled": True, "providers": ["invalid"]}},
+                    output,
+                    root,
+                    "codex",
+                    "strict",
+                )
+
+    def test_render_credentials_rejects_invalid_tables_and_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "dir").mkdir()
+            with self.assertRaises(SystemExit):
+                self.module.render_credentials({"credentials": []}, root, "codex")
+            with self.assertRaises(SystemExit):
+                self.module.render_credentials(
+                    {"credentials": {"codex_auth": "dir"}}, root, "codex"
+                )
+
+    def test_main_writes_manifest_for_supported_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            policy_path = root / "policy.toml"
+            (root / "common.md").write_text("common\n", encoding="utf-8")
+            (root / "auth.json").write_text('{"token":"abc"}\n', encoding="utf-8")
+            policy_path.write_text(
+                """
+                version = 1
+                [documents]
+                common = "common.md"
+                [credentials]
+                codex_auth = "auth.json"
+                """,
+                encoding="utf-8",
+            )
+            argv = [
+                "render_injection_bundle.py",
+                "--policy",
+                str(policy_path),
+                "--agent",
+                "codex",
+                "--mode",
+                "strict",
+                "--output-root",
+                str(output),
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                self.assertEqual(self.module.main(), 0)
+
+            manifest = json.loads((output / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["version"], 1)
+            self.assertEqual(manifest["documents"]["common"], "documents/common.md")
+            self.assertIn("codex_auth", manifest["credentials"])
+
+    def test_extract_direct_mounts_covers_ssh_identities_and_argparse(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = root / "manifest.json"
+            mount_spec_path = root / "mounts.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "credentials": {
+                            "codex_auth": {
+                                "source": "/host/auth.json",
+                                "mount_path": "/opt/workcell/host-inputs/credentials/codex-auth.json",
+                            }
+                        },
+                        "ssh": {
+                            "identities": [
+                                {
+                                    "source": "/host/id_a",
+                                    "mount_path": "/opt/workcell/host-inputs/ssh/identity-0",
+                                    "target_name": "id_a",
+                                }
+                            ]
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            argv = [
+                "extract_direct_mounts.py",
+                "--manifest",
+                str(manifest_path),
+                "--mount-spec",
+                str(mount_spec_path),
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                self.assertEqual(self.extract_module.parse_args().manifest, str(manifest_path))
+            with mock.patch.object(sys, "argv", argv):
+                self.assertEqual(self.extract_module.main(), 0)
+
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            mounts = json.loads(mount_spec_path.read_text(encoding="utf-8"))
+            self.assertNotIn("source", manifest["credentials"]["codex_auth"])
+            self.assertNotIn("source", manifest["ssh"]["identities"][0])
+            self.assertEqual(len(mounts), 2)
+
+    def test_extract_direct_mounts_rejects_missing_mount_path(self) -> None:
+        with self.assertRaises(SystemExit):
+            self.extract_module.require_direct_mount(
+                {"source": "/host/auth.json"},
+                "credentials.codex_auth",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_render_injection_bundle.py
+++ b/tests/python/test_render_injection_bundle.py
@@ -99,6 +99,100 @@ class RenderInjectionBundleTests(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 self.module.render_ssh(policy, root / "bundle", root, "codex", "strict")
 
+    def test_render_documents_stages_common_and_agent_specific_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            (root / "common.md").write_text("common\n", encoding="utf-8")
+            (root / "codex.md").write_text("codex\n", encoding="utf-8")
+
+            rendered = self.module.render_documents(
+                {
+                    "documents": {
+                        "common": "common.md",
+                        "codex": "codex.md",
+                    }
+                },
+                output,
+                root,
+            )
+
+            self.assertEqual(rendered["common"], "documents/common.md")
+            self.assertEqual(rendered["codex"], "documents/codex.md")
+            self.assertEqual(
+                (output / "documents/common.md").read_text(encoding="utf-8"),
+                "common\n",
+            )
+
+    def test_render_copies_respects_provider_and_mode_selection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            (root / "shared.txt").write_text("shared\n", encoding="utf-8")
+            (root / "codex-only.txt").write_text("codex\n", encoding="utf-8")
+
+            rendered = self.module.render_copies(
+                {
+                    "copies": [
+                        {
+                            "source": "shared.txt",
+                            "target": "/state/injected/shared.txt",
+                            "classification": "public",
+                            "providers": ["claude"],
+                        },
+                        {
+                            "source": "codex-only.txt",
+                            "target": "/state/injected/codex-only.txt",
+                            "classification": "public",
+                            "providers": ["codex"],
+                            "modes": ["strict"],
+                        },
+                    ]
+                },
+                output,
+                root,
+                "codex",
+                "strict",
+            )
+
+            self.assertEqual(len(rendered), 1)
+            self.assertEqual(rendered[0]["target"], "/state/injected/codex-only.txt")
+
+    def test_parse_toml_subset_rejects_unsupported_tables(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            policy_path = Path(tmpdir) / "policy.toml"
+            with self.assertRaises(SystemExit):
+                self.module.parse_toml_subset("[unsupported]\nfoo = \"bar\"\n", policy_path)
+
+    def test_selected_for_rejects_invalid_values(self) -> None:
+        with self.assertRaises(SystemExit):
+            self.module.selected_for(["codex", "invalid"], "codex", "providers", {"codex"})
+
+    def test_render_ssh_respects_provider_filtering(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            (root / "id_agent").write_text("key\n", encoding="utf-8")
+
+            rendered = self.module.render_ssh(
+                {
+                    "ssh": {
+                        "enabled": True,
+                        "identities": ["id_agent"],
+                        "providers": ["claude"],
+                    }
+                },
+                output,
+                root,
+                "codex",
+                "strict",
+            )
+
+            self.assertEqual(rendered, {})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/remote-validator/Dockerfile
+++ b/tools/remote-validator/Dockerfile
@@ -20,8 +20,10 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
     docker-buildx \
     git \
     groff-base \
+    llvm \
     mandoc \
     python3 \
+    python3-coverage \
     rustc \
     rustfmt \
     shellcheck \
@@ -30,5 +32,7 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /var/cache/debconf/*-old /var/cache/ldconfig/aux-cache
 
 WORKDIR /workspace
+
+ENV WORKCELL_REQUIRE_SUPPORTED_COVERAGE=1
 
 ENTRYPOINT ["/bin/bash", "-lc"]

--- a/tools/validator/Dockerfile
+++ b/tools/validator/Dockerfile
@@ -18,8 +18,10 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
     cargo \
     git \
     groff-base \
+    llvm \
     mandoc \
     python3 \
+    python3-coverage \
     rustc \
     rustfmt \
     shellcheck \
@@ -28,5 +30,7 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /var/cache/debconf/*-old /var/cache/ldconfig/aux-cache
 
 WORKDIR /workspace
+
+ENV WORKCELL_REQUIRE_SUPPORTED_COVERAGE=1
 
 ENTRYPOINT ["/bin/bash", "-lc"]

--- a/verify/invariants/expected-controls.md
+++ b/verify/invariants/expected-controls.md
@@ -25,8 +25,8 @@
 - `strict` applies the base egress allowlist
 - `build` applies the expanded egress allowlist
 - allowlist modes program reviewed IPv4 and, when available, IPv6 destination
-  allowlists; if IPv6 enforcement is unavailable, Workcell disables IPv6 in the
-  VM instead of leaving an unmanaged parallel egress path
+  allowlists; if IPv6 enforcement is unavailable, Workcell fails closed instead
+  of leaving an unmanaged parallel egress path
 - `breakglass` clears the allowlist and documents the loss
 
 ## Audit and operator controls


### PR DESCRIPTION
## Summary
- harden session audit capture and durable audit-log preservation across managed profile refresh paths
- tighten dual-stack egress apply behavior, multi-provider help/docs, and runtime warning behavior
- add and extend regression coverage for launch policy, injection handling, coverage gates, and hosted-control verification

## Validation
- ./scripts/verify-invariants.sh
- ./scripts/validate-repo.sh
- ./scripts/check-workflows.sh
- ./scripts/verify-github-hosted-controls.sh omkhar/workcell
- SOURCE_DATE_EPOCH=1711238400 ./scripts/container-smoke.sh

## Peer review
- Pascal: no blockers on current first-run/recovery UX surfaces
- Locke: no blockers; notable Codex rule/audit tradeoffs documented
- Halley: no blockers on current Claude path
- Schrodinger: no blockers after dual-stack apply-path fix; noted remaining behavioral coverage opportunity
- Euclid: no blockers on current DX/test stack
- Planck: no blockers after audit-preservation cleanup fix; noted remaining dedicated regression opportunity
