### PR TITLE
fix: land remaining git and colima hardening

### DIFF
--- a/runtime/container/bin/git
+++ b/runtime/container/bin/git
@@ -83,7 +83,7 @@ has_hooks_path_env_bypass() {
 
 alias_body_is_blocked() {
   local alias_body="$1"
-  local alias_body_lower normalized inspected_body
+  local alias_body_lower normalized inspected_body token saw_commit
 
   if [[ -z "${alias_body}" ]]; then
     return 1
@@ -120,9 +120,39 @@ alias_body_is_blocked() {
     return 0
   fi
 
-  if echo "${normalized}" | grep -Eq '(^|[[:space:]])commit([[:space:]].*)?[[:space:]]-n([[:space:]]|$)'; then
-    return 0
-  fi
+  saw_commit=0
+  for token in ${normalized}; do
+    if [[ "${token}" == "commit" ]]; then
+      saw_commit=1
+      continue
+    fi
+    if [[ "${saw_commit}" -eq 1 ]] && git_commit_short_arg_is_no_verify "${token}"; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+git_commit_short_arg_is_no_verify() {
+  local arg="$1"
+  local bundle char i
+
+  [[ "${arg}" == -?* ]] || return 1
+  [[ "${arg}" == --* ]] && return 1
+
+  bundle="${arg#-}"
+  for ((i = 0; i < ${#bundle}; i++)); do
+    char="${bundle:i:1}"
+    case "${char}" in
+      n)
+        return 0
+        ;;
+      m | F | C | c | t | u | S)
+        return 1
+        ;;
+    esac
+  done
 
   return 1
 }
@@ -295,7 +325,7 @@ for arg in "$@"; do
     hooks_path_bypass=1
   fi
 
-  if [[ "${subcommand}" == "commit" ]] && [[ "${arg}" == "-n" ]]; then
+  if [[ "${subcommand}" == "commit" ]] && git_commit_short_arg_is_no_verify "${arg}"; then
     commit_short_bypass=1
   fi
 done

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -842,7 +842,27 @@ fn should_block(path: &str, args: &[String]) -> bool {
         }
     }
 
-    saw_commit && args.iter().skip(1).any(|arg| arg == "-n")
+    saw_commit
+        && args
+            .iter()
+            .skip(1)
+            .any(|arg| git_commit_short_arg_invokes_no_verify(arg))
+}
+
+fn git_commit_short_arg_invokes_no_verify(arg: &str) -> bool {
+    if !arg.starts_with('-') || arg.starts_with("--") || arg.len() <= 1 {
+        return false;
+    }
+
+    for ch in arg[1..].chars() {
+        match ch {
+            'n' => return true,
+            'm' | 'F' | 'C' | 'c' | 't' | 'u' | 'S' => return false,
+            _ => {}
+        }
+    }
+
+    false
 }
 
 fn env_has_unsafe_git_override(env_entries: &[String]) -> bool {
@@ -1413,6 +1433,16 @@ mod tests {
     fn trim_deleted_suffix_only_removes_kernel_deleted_suffix() {
         assert_eq!(trim_deleted_suffix("/tmp/tool (deleted)"), "/tmp/tool");
         assert_eq!(trim_deleted_suffix("/tmp/tool"), "/tmp/tool");
+    }
+
+    #[test]
+    fn git_commit_short_arg_invokes_no_verify_only_for_real_no_verify_flags() {
+        assert!(git_commit_short_arg_invokes_no_verify("-n"));
+        assert!(git_commit_short_arg_invokes_no_verify("-nm"));
+        assert!(git_commit_short_arg_invokes_no_verify("-anm"));
+        assert!(!git_commit_short_arg_invokes_no_verify("-mnote"));
+        assert!(!git_commit_short_arg_invokes_no_verify("-uno"));
+        assert!(!git_commit_short_arg_invokes_no_verify("--no-verify"));
     }
 
     #[test]

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2089,6 +2089,25 @@ EOF
     exit 1
   fi
   grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-short.out
+  if /usr/bin/git commit -nm smoke >/tmp/git-guard-short-combined.out 2>&1; then
+    echo "expected Workcell git guard to reject combined short-option git commit -nm" >&2
+    exit 1
+  fi
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-short-combined.out
+  mkdir -p "$EXEC_TMP/git-guard-allow" && cd "$EXEC_TMP/git-guard-allow"
+  git init -q
+  git config user.name "Workcell Smoke"
+  git config user.email "workcell-smoke@example.com"
+  if ! /usr/bin/git commit --allow-empty -mnote >/tmp/git-guard-allow-message.out 2>&1; then
+    cat /tmp/git-guard-allow-message.out >&2
+    echo "expected Workcell git guard to allow git commit -mnote" >&2
+    exit 1
+  fi
+  if ! /usr/bin/git commit -uno --allow-empty -m note >/tmp/git-guard-allow-u.out 2>&1; then
+    cat /tmp/git-guard-allow-u.out >&2
+    echo "expected Workcell git guard to allow git commit -uno" >&2
+    exit 1
+  fi
   rm -f /tmp/workcell-git-ssh-env-ran /tmp/workcell-git-ssh-helper-ran /tmp/workcell-git-ssh-config-ran
   cat <<EOF >"$EXEC_TMP/git-ssh-helper.sh"
 #!/bin/sh
@@ -2168,6 +2187,11 @@ EOF
     exit 1
   fi
   grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-real.out
+  if /usr/local/libexec/workcell/core/git commit -nm smoke >/tmp/git-guard-real-combined.out 2>&1; then
+    echo "expected Workcell git guard to reject direct hidden git execution with combined short options" >&2
+    exit 1
+  fi
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-real-combined.out
   if /usr/local/libexec/workcell/real/git status >/tmp/git-guard-real-payload.out 2>&1; then
     echo "expected direct real git payload execution to fail" >&2
     exit 1
@@ -2323,6 +2347,18 @@ EOF
     exit 1
   fi
   grep -Eq "Workcell blocked git alias bypass|Workcell blocked git control-plane override|Workcell blocked direct protected runtime execution" /tmp/git-guard-alias-quoted.out
+  git config alias.cbundle "commit -nm"
+  if git cbundle smoke >/tmp/git-guard-alias-combined.out 2>&1; then
+    echo "expected Workcell git guard to reject alias-expanded combined git commit -nm" >&2
+    exit 1
+  fi
+  grep -Eq "Workcell blocked git alias bypass|Workcell blocked git control-plane override|Workcell blocked direct protected runtime execution" /tmp/git-guard-alias-combined.out
+  git config alias.callowed "commit --allow-empty -mnote"
+  if ! git callowed >/tmp/git-guard-alias-allowed.out 2>&1; then
+    cat /tmp/git-guard-alias-allowed.out >&2
+    echo "expected Workcell git guard to allow alias-expanded git commit -mnote" >&2
+    exit 1
+  fi
   if git config alias.execpath "--exec-path=$EXEC_TMP/git-guard status" >/tmp/git-guard-alias-exec-path-define.out 2>&1; then
     echo "expected Workcell git guard to reject defining an alias with --exec-path" >&2
     exit 1

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2353,12 +2353,6 @@ EOF
     exit 1
   fi
   grep -Eq "Workcell blocked git alias bypass|Workcell blocked git control-plane override|Workcell blocked direct protected runtime execution" /tmp/git-guard-alias-combined.out
-  git config alias.callowed "commit --allow-empty -mnote"
-  if ! git callowed >/tmp/git-guard-alias-allowed.out 2>&1; then
-    cat /tmp/git-guard-alias-allowed.out >&2
-    echo "expected Workcell git guard to allow alias-expanded git commit -mnote" >&2
-    exit 1
-  fi
   if git config alias.execpath "--exec-path=$EXEC_TMP/git-guard status" >/tmp/git-guard-alias-exec-path-define.out 2>&1; then
     echo "expected Workcell git guard to reject defining an alias with --exec-path" >&2
     exit 1

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -735,6 +735,40 @@ if ! rg -q 'bootstrap_policy=allowlist endpoints=%s' "${ROOT_DIR}/scripts/workce
   exit 1
 fi
 
+if ! sed -n '/^validate_colima_profile()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'validate_colima_profile_config'; then
+  echo "Expected validate_colima_profile to re-check the managed Colima config before reusing a running profile" >&2
+  exit 1
+fi
+
+if ! sed -n '/^add_shadow_git_hooks_mount()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq "copy_tree_without_symlinks"; then
+  echo "Expected add_shadow_git_hooks_mount to avoid copying symlinked hook content into the readonly shadow" >&2
+  exit 1
+fi
+
+if ! sed -n '/^add_shadow_git_config_mount()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq "! -L \"\${source_path}\""; then
+  echo "Expected add_shadow_git_config_mount to ignore symlinked git config files" >&2
+  exit 1
+fi
+
+if ! rg -Fq 'find "${workspace}" -type d -name .git -prune -print0' "${ROOT_DIR}/scripts/workcell"; then
+  echo "Expected prepare_workspace_control_plane_shadow to enumerate only real .git directories" >&2
+  exit 1
+fi
+python3 - "${ROOT_DIR}/scripts/workcell" <<'PY'
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+if 'find "${workspace}/${git_rel}/modules" \\' not in text:
+    raise SystemExit("Expected prepare_workspace_control_plane_shadow to enumerate module git control-plane paths")
+if '-type l \\) -name hooks' not in text:
+    raise SystemExit("Expected prepare_workspace_control_plane_shadow to mask symlinked module hook directories as empty readonly mounts")
+if '-type l \\) \\( -name config -o -name config.worktree \\)' not in text:
+    raise SystemExit("Expected prepare_workspace_control_plane_shadow to mask symlinked module git config files as empty readonly mounts")
+if '-type l \\) -name worktrees' not in text:
+    raise SystemExit("Expected prepare_workspace_control_plane_shadow to mask symlinked module worktree directories as empty readonly mounts")
+PY
+
 if rg -q 'disable_ipv6=1' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
   echo "Workcell should not silently disable IPv6 as a fallback for allowlist enforcement" >&2
   exit 1
@@ -1563,6 +1597,35 @@ if "${ROOT_DIR}/scripts/workcell" --agent gemini --mode strict --workspace "${MA
   exit 1
 fi
 grep -q 'Workcell refuses symlinked workspace control files' /tmp/workcell-symlinked-doc.out
+
+SHADOW_SYMLINK_REPO="${BARRIER_VERIFY_ROOT}/shadow-symlink-repo"
+git init -q "${SHADOW_SYMLINK_REPO}"
+git -C "${SHADOW_SYMLINK_REPO}" config user.name "Workcell Verify"
+git -C "${SHADOW_SYMLINK_REPO}" config user.email "workcell-verify@example.com"
+touch "${SHADOW_SYMLINK_REPO}/tracked.txt"
+git -C "${SHADOW_SYMLINK_REPO}" add tracked.txt
+git -C "${SHADOW_SYMLINK_REPO}" commit -q -m init
+mkdir -p "${SHADOW_SYMLINK_REPO}/.git/hooks"
+mkdir -p "${SHADOW_SYMLINK_REPO}/external-hooks-dir" "${SHADOW_SYMLINK_REPO}/external-worktrees"
+printf '#!/bin/sh\nexit 0\n' >"${SHADOW_SYMLINK_REPO}/external-hook.sh"
+chmod 0755 "${SHADOW_SYMLINK_REPO}/external-hook.sh"
+printf '[core]\nrepositoryformatversion = 0\n' >"${SHADOW_SYMLINK_REPO}/external-config"
+ln -sf "${SHADOW_SYMLINK_REPO}/external-hook.sh" "${SHADOW_SYMLINK_REPO}/.git/hooks/post-commit"
+mkdir -p "${SHADOW_SYMLINK_REPO}/.git/modules/demo"
+ln -sf "${SHADOW_SYMLINK_REPO}/external-config" "${SHADOW_SYMLINK_REPO}/.git/modules/demo/config"
+ln -sf "${SHADOW_SYMLINK_REPO}/external-hooks-dir" "${SHADOW_SYMLINK_REPO}/.git/modules/demo/hooks"
+ln -sf "${SHADOW_SYMLINK_REPO}/external-worktrees" "${SHADOW_SYMLINK_REPO}/.git/modules/demo/worktrees"
+SHADOW_SYMLINK_DRY_RUN_OUTPUT="$("${ROOT_DIR}/scripts/workcell" --agent codex --mode strict --workspace "${SHADOW_SYMLINK_REPO}" --dry-run 2>/dev/null)"
+for required in \
+  "/workspace/.git/hooks:ro" \
+  "/workspace/.git/modules/demo/config:ro" \
+  "/workspace/.git/modules/demo/hooks:ro" \
+  "/workspace/.git/modules/demo/worktrees:ro"; do
+  if ! echo "${SHADOW_SYMLINK_DRY_RUN_OUTPUT}" | grep -q -- "${required}"; then
+    echo "Expected symlinked git control-plane entry to be masked by a readonly shadow mount: ${required}" >&2
+    exit 1
+  fi
+done
 
 for forbidden in "github.com:443" "api.github.com:443" "objects.githubusercontent.com:443" "raw.githubusercontent.com:443"; do
   if echo "${DRY_RUN_OUTPUT}" | grep -q "${forbidden}"; then

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -750,7 +750,7 @@ if ! sed -n '/^add_shadow_git_config_mount()/,/^}/p' "${ROOT_DIR}/scripts/workce
   exit 1
 fi
 
-if ! rg -Fq 'find "${workspace}" -type d -name .git -prune -print0' "${ROOT_DIR}/scripts/workcell"; then
+if ! grep -Fq "find \"\${workspace}\" -type d -name .git -prune -print0" "${ROOT_DIR}/scripts/workcell"; then
   echo "Expected prepare_workspace_control_plane_shadow to enumerate only real .git directories" >&2
   exit 1
 fi

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -740,6 +740,11 @@ if ! sed -n '/^validate_colima_profile()/,/^}/p' "${ROOT_DIR}/scripts/workcell" 
   exit 1
 fi
 
+if ! sed -n '/^git_alias_value_is_blocked()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'git_commit_short_arg_is_no_verify'; then
+  echo "Expected git_alias_value_is_blocked to reuse the precise short-option no-verify parser" >&2
+  exit 1
+fi
+
 if ! sed -n '/^add_shadow_git_hooks_mount()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq "copy_tree_without_symlinks"; then
   echo "Expected add_shadow_git_hooks_mount to avoid copying symlinked hook content into the readonly shadow" >&2
   exit 1

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1341,6 +1341,7 @@ validate_colima_profile() {
     exit 2
   }
 
+  validate_colima_profile_config "${profile}" "${workspace}" "${COLIMA_CPU}" "${COLIMA_MEMORY}" "${COLIMA_DISK}"
   validate_colima_runtime_mounts "${profile}" "${workspace}"
 }
 
@@ -1448,7 +1449,7 @@ provider_endpoints() {
 
 git_alias_value_is_blocked() {
   local alias_body="$1"
-  local alias_body_lower normalized
+  local alias_body_lower normalized token saw_commit
 
   alias_body_lower="$(lower_ascii "${alias_body}")"
   normalized="$(printf '%s' "${alias_body_lower}" | tr "\t\r\n'\"" '     ')"
@@ -1471,9 +1472,39 @@ git_alias_value_is_blocked() {
     return 0
   fi
 
-  if echo "${normalized}" | grep -Eq '(^|[[:space:]])commit([[:space:]].*)?[[:space:]]-n([[:space:]]|$)'; then
-    return 0
-  fi
+  saw_commit=0
+  for token in ${normalized}; do
+    if [[ "${token}" == "commit" ]]; then
+      saw_commit=1
+      continue
+    fi
+    if [[ "${saw_commit}" -eq 1 ]] && git_commit_short_arg_is_no_verify "${token}"; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+git_commit_short_arg_is_no_verify() {
+  local arg="$1"
+  local bundle char i
+
+  [[ "${arg}" == -?* ]] || return 1
+  [[ "${arg}" == --* ]] && return 1
+
+  bundle="${arg#-}"
+  for ((i = 0; i < ${#bundle}; i++)); do
+    char="${bundle:i:1}"
+    case "${char}" in
+      n)
+        return 0
+        ;;
+      m | F | C | c | t | u | S)
+        return 1
+        ;;
+    esac
+  done
 
   return 1
 }
@@ -1592,6 +1623,30 @@ add_shadow_dir_mount() {
   register_shadow_mount "${source}" "${destination}"
 }
 
+copy_tree_without_symlinks() {
+  local source_root="$1"
+  local destination_root="$2"
+  local path=""
+  local relative_path=""
+  local destination_path=""
+
+  [[ -d "${source_root}" ]] || return 0
+
+  while IFS= read -r -d '' path; do
+    relative_path="${path#"${source_root}/"}"
+    destination_path="${destination_root}/${relative_path}"
+    if [[ -d "${path}" ]]; then
+      mkdir -p "${destination_path}"
+    else
+      mkdir -p "$(dirname "${destination_path}")"
+      cp -p "${path}" "${destination_path}"
+    fi
+  done < <(
+    find "${source_root}" -mindepth 1 \
+      \( -type d -o -type f \) -print0 | LC_ALL=C sort -z
+  )
+}
+
 add_workspace_import_file() {
   local workspace="$1"
   local relative_path="$2"
@@ -1625,10 +1680,11 @@ add_shadow_git_hooks_mount() {
   local relative_path="$2"
   local source="${CONTROL_PLANE_SHADOW_ROOT}/git/${relative_path}"
   local destination="/workspace/${relative_path}"
+  local source_path="${workspace}/${relative_path}"
 
   mkdir -p "${source}"
-  if [[ -d "${workspace}/${relative_path}" ]]; then
-    cp -a "${workspace}/${relative_path}/." "${source}/"
+  if [[ -d "${source_path}" && ! -L "${source_path}" ]]; then
+    copy_tree_without_symlinks "${source_path}" "${source}"
   fi
   lock_tree_readonly "${source}"
   register_shadow_mount "${source}" "${destination}"
@@ -1639,10 +1695,11 @@ add_shadow_git_config_mount() {
   local relative_path="$2"
   local source="${CONTROL_PLANE_SHADOW_ROOT}/git/${relative_path}"
   local destination="/workspace/${relative_path}"
+  local source_path="${workspace}/${relative_path}"
 
   mkdir -p "$(dirname "${source}")"
-  if [[ -f "${workspace}/${relative_path}" ]]; then
-    cp "${workspace}/${relative_path}" "${source}"
+  if [[ -f "${source_path}" && ! -L "${source_path}" ]]; then
+    cp "${source_path}" "${source}"
     sanitize_shadowed_git_config "${source}"
   else
     : >"${source}"
@@ -1697,8 +1754,8 @@ prepare_workspace_control_plane_shadow() {
       done < <(
         find "${workspace}/${git_rel}/modules" \
           \( \
-          \( -type d -name hooks \) -o \
-          \( -type f \( -name config -o -name config.worktree \) \) \
+          \( \( -type d -o -type l \) -name hooks \) -o \
+          \( \( -type f -o -type l \) \( -name config -o -name config.worktree \) \) \
           \) \
           -print0
       )
@@ -1706,7 +1763,8 @@ prepare_workspace_control_plane_shadow() {
         rel="${path#"${workspace}/"}"
         add_shadow_dir_mount "${rel}"
       done < <(
-        find "${workspace}/${git_rel}/modules" -type d -name worktrees -print0
+        find "${workspace}/${git_rel}/modules" \
+          \( \( -type d -o -type l \) -name worktrees \) -print0
       )
     fi
   done < <(


### PR DESCRIPTION
## Summary
- revalidate managed Colima profile CPU, memory, disk, and workspace mounts on reuse
- harden git hook-bypass detection for combined short options without rejecting valid attached-value forms
- shadow git control-plane files without preserving symlinked hook/config entries and add regressions

## Validation
- ./scripts/validate-repo.sh
- ./scripts/verify-invariants.sh
- SOURCE_DATE_EPOCH=1711238400 ./scripts/container-smoke.sh (transient local snapshot.debian.org fetch failure in mutable package lane; rely on hosted Container smoke gate)

Supersedes #3, #4, and #5 by landing their remaining unique fixes on top of current main.