### PR TITLE
Align single-maintainer branch review policy

### DIFF
--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -82,10 +82,10 @@ of the reviewed control plane:
   integrity
 - an active required-status-checks ruleset on the default branch for the core
   CI and GitHub workflow security checks
-- an active review ruleset on the default branch that requires pull requests,
-  at least one approval, code owner review, and resolved review threads, with
-  only an explicit repository-role pull-request-only bypass to preserve a
-  workable single-maintainer path
+- an active review ruleset on the default branch that requires pull requests;
+  in the current single-owner-private mode it requires zero approvals and no
+  code-owner/thread gate, while multi-maintainer mode raises that back to
+  human-reviewed approval plus review resolution
 - an active ruleset on `refs/tags/v*` that blocks tag creation, updates, and
   deletion except for explicit repository-role bypass actors
 - GitHub Actions SHA pinning required at the repository level
@@ -101,14 +101,23 @@ audit continuously against the live repository, and tagged releases rerun it in
 release preflight before publish and refuse publication if the hosted controls
 drift.
 
-The current repository policy uses `release_environment.mode = "single-owner-private"`
-because this is a private single-owner repository. The audit enforces that as a
-private user-owned repository whose only direct collaborator is the owner. In
-that mode, the audited expectation is a named `release` environment, not a
-multi-party human approval gate. If the repository later moves to a
-multi-maintainer or public operating model, flip that policy to `review-gated`
-and Workcell will require at least one human reviewer and no administrator
-bypass before tagged publication.
+The current repository policy uses
+`branch_review.mode = "single-owner-private-pr"` and
+`release_environment.mode = "single-owner-private"` because this is a private
+single-owner repository. The audit enforces that as a private user-owned
+repository whose only direct collaborator is the owner. In that mode, the
+audited expectation is:
+
+- `main` still requires pull requests and green required checks, but does not
+  require impossible third-party approvals, code-owner review, or review-thread
+  resolution
+- the named `release` environment exists, but it is not treated as a
+  multi-party human approval gate
+
+If the repository later moves to a multi-maintainer or public operating model,
+flip those policies back to `review-gated` and Workcell will require at least
+one human reviewer and no administrator bypass before protected-branch merges
+or tagged publication.
 
 For private repositories, `codeql.yml` is opt-in through
 `WORKCELL_ENABLE_PRIVATE_CODE_SCANNING=true` because GitHub code scanning is

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -1,6 +1,15 @@
 # GitHub-hosted repository controls that live outside the git tree but remain
 # part of the reviewed Workcell control plane.
 
+[branch_review]
+# Valid modes:
+# - "review-gated": require pull requests, at least one approving review,
+#   code owner review, and resolved review threads
+# - "single-owner-private-pr": require pull requests on a private user-owned
+#   single-owner repository, but allow zero required approvals and no code
+#   owner/thread gate so merges remain workable without an admin bypass
+mode = "single-owner-private-pr"
+
 [release_environment]
 # Valid modes:
 # - "review-gated": require at least one human reviewer and no admin bypass

--- a/scripts/verify-github-hosted-controls.sh
+++ b/scripts/verify-github-hosted-controls.sh
@@ -78,6 +78,12 @@ policy = tomllib.loads(policy_path.read_text(encoding="utf-8"))
 default_branch = repo_meta["default_branch"]
 owner_login = repo_meta["owner"]["login"]
 owner_type = repo_meta["owner"]["type"]
+branch_review_mode = policy.get("branch_review", {}).get("mode", "review-gated")
+if branch_review_mode not in {"review-gated", "single-owner-private-pr"}:
+    raise SystemExit(
+        f"{policy_path} must set branch_review.mode to "
+        f"'review-gated' or 'single-owner-private-pr'"
+    )
 release_mode = policy.get("release_environment", {}).get("mode", "review-gated")
 if release_mode not in {"review-gated", "single-owner-private"}:
     raise SystemExit(
@@ -194,18 +200,52 @@ require_bypass_shape(
 
 pull_request_rule = has_rule(branch_review, "pull_request")
 parameters = pull_request_rule.get("parameters", {})
-if parameters.get("required_approving_review_count", 0) < 1:
-    raise SystemExit(
-        f"Default-branch review ruleset on {repo} must require at least one approving review"
-    )
-if not parameters.get("require_code_owner_review"):
-    raise SystemExit(
-        f"Default-branch review ruleset on {repo} must require code owner review"
-    )
-if not parameters.get("required_review_thread_resolution"):
-    raise SystemExit(
-        f"Default-branch review ruleset on {repo} must require resolved review threads"
-    )
+if branch_review_mode == "review-gated":
+    if parameters.get("required_approving_review_count", 0) < 1:
+        raise SystemExit(
+            f"Default-branch review ruleset on {repo} must require at least one approving review"
+        )
+    if not parameters.get("require_code_owner_review"):
+        raise SystemExit(
+            f"Default-branch review ruleset on {repo} must require code owner review"
+        )
+    if not parameters.get("required_review_thread_resolution"):
+        raise SystemExit(
+            f"Default-branch review ruleset on {repo} must require resolved review threads"
+        )
+else:
+    if not repo_meta.get("private"):
+        raise SystemExit(
+            f"Branch review mode 'single-owner-private-pr' on {repo} is only valid for private repositories"
+        )
+    if owner_type != "User":
+        raise SystemExit(
+            f"Branch review mode 'single-owner-private-pr' on {repo} is only valid for user-owned repositories"
+        )
+    if len(direct_collaborators) != 1:
+        raise SystemExit(
+            f"Branch review mode 'single-owner-private-pr' on {repo} requires exactly one direct collaborator"
+        )
+    if direct_collaborators[0].get("login") != owner_login:
+        raise SystemExit(
+            f"Branch review mode 'single-owner-private-pr' on {repo} requires the owner to be the only direct collaborator"
+        )
+    if not direct_collaborators[0].get("permissions", {}).get("admin"):
+        raise SystemExit(
+            f"Branch review mode 'single-owner-private-pr' on {repo} requires the owner to retain admin permission"
+        )
+    if parameters.get("required_approving_review_count", 0) != 0:
+        raise SystemExit(
+            f"Default-branch review ruleset on {repo} must require zero approving reviews in single-owner-private-pr mode"
+        )
+    if parameters.get("require_code_owner_review"):
+        raise SystemExit(
+            f"Default-branch review ruleset on {repo} must not require code owner review in single-owner-private-pr mode"
+        )
+    if parameters.get("required_review_thread_resolution"):
+        raise SystemExit(
+            f"Default-branch review ruleset on {repo} must not require resolved review threads in single-owner-private-pr mode"
+        )
 
 status_rule = has_rule(branch_status_checks, "required_status_checks")
 status_parameters = status_rule.get("parameters", {})


### PR DESCRIPTION
## Summary
- align the hosted-controls policy with the live single-maintainer branch review ruleset
- teach the GitHub control verifier to enforce the private single-owner PR-required mode
- update the GitHub workflow docs to describe the secure single-maintainer operating model

## Validation
- ./scripts/validate-repo.sh
- ./scripts/check-workflows.sh
- ./scripts/verify-github-hosted-controls.sh omkhar/workcell