### PR TITLE
Fix hosted-controls workflow token handling

### DIFF
--- a/.github/workflows/hosted-controls.yml
+++ b/.github/workflows/hosted-controls.yml
@@ -18,6 +18,8 @@ jobs:
   verify-hosted-controls:
     name: Hosted controls verification
     runs-on: ubuntu-latest
+    environment:
+      name: hosted-controls-audit
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -25,5 +27,5 @@ jobs:
 
       - name: Verify GitHub-hosted controls
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: ./scripts/verify-github-hosted-controls.sh "${GITHUB_REPOSITORY}"
+          WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}
+        run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
   preflight:
     name: Release preflight
     runs-on: ubuntu-latest
+    environment:
+      name: hosted-controls-audit
     permissions:
       contents: read
       security-events: write
@@ -52,8 +54,9 @@ jobs:
 
       - name: Verify GitHub-hosted controls
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: ./scripts/verify-github-hosted-controls.sh "${GITHUB_REPOSITORY}"
+          WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"
+          WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}
+        run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"
 
       - name: Check pinned input policy
         run: ./scripts/check-pinned-inputs.sh

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -56,7 +56,10 @@ under platform automation.
   binary
 - `hosted-controls.yml`: live GitHub control-plane drift detection on `main`
   pushes, schedule, and manual dispatch, using the same hosted-controls policy
-  that release preflight enforces before publish
+  that release preflight enforces before publish; on private repositories it
+  uses an optional dedicated `WORKCELL_HOSTED_CONTROLS_TOKEN` because the
+  default workflow token cannot read rulesets/collaborator/environment
+  metadata for this audit
 - `.github/dependabot.yml`: grouped weekly updates for GitHub Actions and the
   runtime base image, validator base image, pinned provider CLI dependency
   graph, and shipped Rust runtime crate, with cooldowns
@@ -100,6 +103,19 @@ to audit those hosted settings with the GitHub API.
 audit continuously against the live repository, and tagged releases rerun it in
 release preflight before publish and refuse publication if the hosted controls
 drift.
+
+For private repositories, GitHub's default workflow token does not have enough
+access to read the rulesets, direct collaborators, and protected environment
+metadata that the hosted-controls audit requires. Workcell therefore uses a
+dedicated `WORKCELL_HOSTED_CONTROLS_TOKEN` secret for workflow-based audits.
+The continuous `hosted-controls.yml` workflow skips cleanly when that secret is
+absent so `main` does not stay red on a known GitHub token limitation, but the
+tagged `release.yml` preflight fails closed unless the secret is configured.
+That token should be a fine-grained token or GitHub App token scoped only to
+this repository and only to the repository-administration metadata needed for
+the audit. Workflow jobs that can read that token run inside a dedicated
+`hosted-controls-audit` environment so the secret is not exposed to unrelated
+jobs.
 
 The current repository policy uses
 `branch_review.mode = "single-owner-private-pr"` and

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -465,9 +465,28 @@ if "./scripts/publish-github-release.sh" not in release_workflow:
     )
 require_contains(
     release_workflow,
-    'run: ./scripts/verify-github-hosted-controls.sh "${GITHUB_REPOSITORY}"',
+    'run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"',
     "a hosted-controls audit in release preflight",
     ".github/workflows/release.yml",
+)
+require_contains(
+    release_workflow,
+    'WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"',
+    "a fail-closed hosted-controls requirement in release preflight",
+    ".github/workflows/release.yml",
+)
+hosted_controls_workflow = (workflows_dir / "hosted-controls.yml").read_text(encoding="utf-8")
+require_contains(
+    hosted_controls_workflow,
+    'run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"',
+    "the hosted-controls workflow wrapper",
+    ".github/workflows/hosted-controls.yml",
+)
+require_contains(
+    hosted_controls_workflow,
+    'WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}',
+    "the hosted-controls workflow token injection",
+    ".github/workflows/hosted-controls.yml",
 )
 require_contains(
     release_workflow,

--- a/scripts/run-hosted-controls-audit.sh
+++ b/scripts/run-hosted-controls-audit.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO="${1:-}"
+REQUIRED_MODE="${WORKCELL_HOSTED_CONTROLS_REQUIRED:-0}"
+WORKFLOW_TOKEN="${WORKCELL_HOSTED_CONTROLS_TOKEN:-}"
+
+if [[ "${REQUIRED_MODE}" != "0" && "${REQUIRED_MODE}" != "1" ]]; then
+  echo "WORKCELL_HOSTED_CONTROLS_REQUIRED must be 0 or 1." >&2
+  exit 1
+fi
+
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  if [[ -n "${WORKFLOW_TOKEN}" ]]; then
+    GH_TOKEN="${WORKFLOW_TOKEN}" \
+      "${ROOT_DIR}/scripts/verify-github-hosted-controls.sh" "${REPO}"
+    exit 0
+  fi
+
+  if [[ "${REQUIRED_MODE}" == "1" ]]; then
+    echo "Hosted-controls verification requires WORKCELL_HOSTED_CONTROLS_TOKEN in GitHub Actions." >&2
+    echo "Configure a fine-grained token or GitHub App token that can read repository administration metadata for this repository." >&2
+    exit 1
+  fi
+
+  echo "Skipping hosted-controls verification in GitHub Actions because WORKCELL_HOSTED_CONTROLS_TOKEN is not configured." >&2
+  echo "github.token cannot read the rulesets/collaborators/environment metadata this audit requires on this repository." >&2
+  exit 0
+fi
+
+"${ROOT_DIR}/scripts/verify-github-hosted-controls.sh" "${REPO}"

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -69,6 +69,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/generate-build-input-manifest.sh"
   "${ROOT_DIR}/scripts/install.sh"
   "${ROOT_DIR}/scripts/publish-github-release.sh"
+  "${ROOT_DIR}/scripts/run-hosted-controls-audit.sh"
   "${ROOT_DIR}/scripts/run-mutation-tests.sh"
   "${ROOT_DIR}/scripts/verify-coverage.sh"
   "${ROOT_DIR}/scripts/verify-github-hosted-controls.sh"


### PR DESCRIPTION
## Summary
- route hosted-controls verification through a dedicated workflow wrapper
- skip the continuous hosted-controls workflow cleanly when no dedicated audit token is configured
- require a dedicated hosted-controls token in release preflight and document the environment/token model

## Validation
- ./scripts/check-workflows.sh
- ./scripts/validate-repo.sh
- GITHUB_ACTIONS=true ./scripts/run-hosted-controls-audit.sh omkhar/workcell
- ./scripts/run-hosted-controls-audit.sh omkhar/workcell