### PR TITLE
Harden observability and pre-merge validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,15 @@ Initial adapters target:
 ./scripts/install.sh
 workcell --prepare --agent codex --workspace /path/to/repo
 workcell --agent codex --workspace /path/to/repo
+workcell --agent codex --inspect --workspace /path/to/repo
+workcell --agent codex --doctor --workspace /path/to/repo
 workcell --agent claude --agent-autonomy prompt --workspace /path/to/repo
 workcell --prepare --agent gemini --agent-arg --version --workspace /path/to/repo
 man workcell
 ```
 
 The safe path is `strict`, and it is also the default. `--prepare` is the
-recommended first-run path: it seeds or refreshes the reviewed runtime image
+recommended first-run path: it seeds or refreshes the prepared runtime image
 inside the isolated VM, then continues with the requested launch. `build`
 still exists as the explicit wider-egress runtime profile for dependency and
 image creation work. `breakglass` is explicit, higher trust, visibly
@@ -115,6 +117,11 @@ Workcell surfaces that posture explicitly in the launch audit output.
 making you repeat `codex`, `claude`, or `gemini` yourself. `--agent-arg`
 values are still treated as ordinary user-supplied provider argv and go
 through the same in-container denylist as raw `-- ...` arguments.
+`--cache-profile off` is the default. `--cache-profile standard` opt-ins to a
+host-persisted non-secret cache plane for package/build tooling such as npm,
+pip, Cargo registry/git, Go module/build cache, and `ccache`. That is a
+lower-assurance path and is not treated as part of the clean `strict`
+session boundary.
 `--codex-rules-mutability readonly` is the clean-session default. That keeps
 Codex execpolicy rules immutable on the managed path until either
 `--agent-autonomy prompt` or a package-manager mutation has already lowered the
@@ -130,6 +137,14 @@ default; `--no-default-injection-policy` disables that for a specific launch.
 `--vm-cpu`, `--vm-memory`, and `--vm-disk` tune the dedicated Colima VM;
 `--container-cpu` and `--container-memory` tune the inner runtime container
 without changing the reviewed profile defaults for other launches.
+`--log-level debug` surfaces the previously-suppressed Colima/image-build
+output during startup. `--debug-log /path/to/file` persistently captures full
+launcher plus container stdout/stderr, and `--audit-transcript /path/to/file`
+captures the full interactive terminal transcript including prompts and typed
+responses plus session timestamps and exit status. Both persistent host-side
+capture knobs are explicit lower-assurance choices, emit an explicit warning
+banner when enabled, apply only to real launched sessions, and stay off by
+default.
 With `--container-mutability ephemeral`, Workcell also allows `apt` and
 `apt-get` to reach the pinned Debian snapshot endpoints so transient build
 tooling can be installed without opening the session to arbitrary distro
@@ -166,7 +181,7 @@ workspace; linked worktrees with external gitdirs are rejected.
 
 Common recovery paths:
 
-- First launch or missing reviewed runtime image:
+- First launch or missing prepared runtime image:
   `workcell --prepare --agent codex --workspace /path/to/repo`
   Replace `codex` with `claude` or `gemini` for the corresponding provider.
 - First launch with provider prompts enabled:
@@ -176,6 +191,24 @@ Common recovery paths:
 - Conflicting unmanaged Colima profile:
   `workcell --repair-profile --agent codex --workspace /path/to/repo`
   Replace `codex` with `claude` or `gemini` for the corresponding provider.
+- Inspect current derived state without launching:
+  `workcell --agent codex --inspect --workspace /path/to/repo`
+  Alias: `workcell inspect --agent codex --workspace /path/to/repo`
+- Validate host/workspace/profile posture and print the next safe command:
+  `workcell --agent codex --doctor --workspace /path/to/repo`
+  Alias: `workcell doctor --agent codex --workspace /path/to/repo`
+  When the workspace path is missing or invalid, `doctor` reports that first
+  instead of treating `--prepare` as the next step.
+- Print the last retained audit/debug/transcript log for a profile:
+  `workcell --logs audit --colima-profile workcell-...`
+  Alias: `workcell logs audit --colima-profile workcell-...`
+- Print the effective auth posture without launching:
+  `workcell auth-status --agent codex --workspace /path/to/repo`
+  This includes the primary provider auth mode, the ordered auth mode set, and
+  SSH config assurance when injection is active.
+- Clean stale Workcell temp state:
+  `workcell --gc`
+  Alias: `workcell gc`
 
 `--repair-profile` deletes only the conflicting derived Colima profile so
 Workcell can recreate it with reviewed mounts and policy. On `strict`, it also
@@ -202,7 +235,11 @@ Workcell treats injected content as three separate classes:
 The immutable adapter baselines under `adapters/` are never mutated in place.
 Repo-local `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` are masked inside the
 workspace on the safe path and imported into the provider-native home docs
-instead. By default, Codex rules stay linked to the immutable adapter baseline
+instead. Claude and Gemini import repo-local `AGENTS.md` as the shared
+workspace layer and then append `CLAUDE.md` or `GEMINI.md` when present. When
+a workspace only ships `AGENTS.md`, Claude and Gemini still fall back to that
+imported file rather than silently dropping shared instructions.
+By default, Codex rules stay linked to the immutable adapter baseline
 until the session is already downgraded by package mutation or the operator has
 selected `--agent-autonomy prompt`. If you explicitly opt into
 `--codex-rules-mutability session`, or if prompt autonomy or package mutation
@@ -253,7 +290,12 @@ in-container home. Generic `[[copies]]` and `[ssh]` entries are still staged
 through the launcher-owned injection bundle only for non-secret material. SSH
 inputs and `classification = "secret"` copies use the same direct-mount model
 as `[credentials]` and are copied into the session from their original host
-paths.
+paths. Secret sources must be owned by the launching user, must not be
+symlinks, and must not be group/world-readable. `ssh.known_hosts` is treated
+separately: the source file may stay world-readable as usual, but it must not
+be a symlink or group/world-writable. When you need provider- or mode-specific
+scoping, use `[credentials.<name>]` tables with `source`, `providers`, and
+`modes`.
 
 Use it explicitly:
 
@@ -291,6 +333,15 @@ Intentional non-goals for the safe path:
 
 - `scripts/validate-repo.sh`: repo-local shell, JSON, TOML, YAML, and manpage
   checks
+- `scripts/pre-merge.sh`: one-command local pre-merge path that builds the
+  validator image, runs workflow lint, validates the repo inside the validator
+  container, then runs invariants, container smoke, release-bundle
+  reproducibility, runtime reproducibility, and optionally the remote
+  linux/amd64 lane. By default it requires a clean worktree, including
+  untracked files. With `--allow-dirty`, local validation runs against the live
+  worktree and the remote lane auto-switches to `--remote-snapshot worktree`
+  plus `--include-untracked` unless you explicitly override the snapshot mode.
+  Workflow lint still depends on host `actionlint` and `zizmor`.
 - `scripts/check-workflows.sh`: `actionlint` and `zizmor`
 - `scripts/check-pinned-inputs.sh`: pin-policy checks for non-ecosystem release
   inputs such as the Debian snapshot, immutable base-image digests, and exact
@@ -348,6 +399,9 @@ Colima profile directory. Those events record the workspace, runtime profile,
 network mode, selected adapter, launch-time assurance fields, whether the run
 stayed on the managed Tier 1 path or used an explicitly lower-assurance mode,
 and whether the session later downgraded itself through package mutation.
+The durable audit log is metadata-only by default. Full stdout/stderr capture
+and full prompt/response transcript capture are separate explicit lower-
+assurance operator choices.
 `build` sessions additionally record when the temporary bootstrap allowlist was
 applied for image creation.
 

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -34,14 +34,16 @@ host-side bundle for provider credentials, SSH material, and
 Provider docs are rendered in a fixed precedence order:
 
 1. immutable baseline doc from `adapters/`
-2. imported workspace provider doc such as repo-local `AGENTS.md`,
-   `CLAUDE.md`, or `GEMINI.md` when present
-3. `documents.common`
-4. provider-specific fragment such as `documents.claude`
+2. imported workspace common doc from repo-local `AGENTS.md` when present
+3. imported workspace provider overlay such as repo-local `CLAUDE.md` or
+   `GEMINI.md` when present
+4. `documents.common`
+5. provider-specific fragment such as `documents.claude`
 
 That lets you keep one common `AGENTS.md`-style instruction file and have
 Workcell append it to the provider-native home doc for Codex, Claude, or
-Gemini without replacing the reviewed baseline.
+Gemini without replacing the reviewed baseline, while still layering
+`CLAUDE.md` or `GEMINI.md` provider-specific deltas when they exist.
 
 ## Supported inputs
 
@@ -65,6 +67,16 @@ Selectors let you scope injected material to only some launches:
 - `providers = ["codex", "claude", "gemini"]`
 - `modes = ["strict", "build"]`
 
+For `[credentials]`, simple `key = "/path/to/file"` entries still work, and
+scoped entries can be expressed as nested tables:
+
+```toml
+[credentials.github_hosts]
+source = "/Users/example/.config/gh/hosts.yml"
+providers = ["claude", "gemini"]
+modes = ["strict", "build"]
+```
+
 ## Deliberate limits
 
 - no arbitrary environment-variable secret injection on the safe path
@@ -80,6 +92,9 @@ Selectors let you scope injected material to only some launches:
   process-to-process inside the container
 - no writes into Workcell-generated helper state such as
   `~/.claude/workcell/`
+- no unsafe SSH config directives such as `ProxyCommand`, `LocalCommand`,
+  `Include`, `IdentityAgent`, or `Match exec` unless you explicitly set
+  `ssh.allow_unsafe_config = true`
 
 ## Recommended patterns
 
@@ -90,6 +105,10 @@ Selectors let you scope injected material to only some launches:
 - Use `[credentials]` for provider and GitHub auth material that should land in
   Workcell-managed session paths without a fresh login every time. This is the
   safest way to persist reusable provider auth on the host.
+- Keep secret sources owner-only (`0600` for files, `0700` for directories) and
+  avoid symlinks. Workcell rejects looser permissions on secret-bearing inputs.
+  `ssh.known_hosts` is the exception: standard world-readable files are
+  accepted, but symlinks and group/world-writable paths are rejected.
 - Use `[[copies]]` with `target = "/state/injected/..."` for shared read-only
   material such as CA bundles or repo policy files. Public copies are staged
   through the launcher-owned bundle.

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -25,6 +25,11 @@ environment. Provider credentials injected through the dedicated
 `[credentials]` path must not be re-staged into a second plaintext host-side
 bundle before launch; they are validated on the host, mounted read-only for the
 current session, and then copied into the ephemeral agent home.
+Secret-bearing sources used by the injection policy must be explicit files or
+directories owned by the invoking UID, must not be symlinks, and must not be
+group- or world-readable by default. Credential entries may also be scoped to
+specific providers or runtime modes so a safe launch does not receive broader
+credential material than it needs.
 
 ## Invariant 2: Writes stay inside the intended workspace
 
@@ -119,9 +124,15 @@ lower-assurance mode
 
 The reference launcher satisfies this by appending an operator-visible audit log
 under the managed Colima profile directory on each real launch and exit,
-including package-mutation downgrade events inferred from host-captured runtime
-markers rather than mutable in-container state alone. Injected secret values
-themselves are not part of that durable record.
+including package-mutation downgrade events inferred from the session-assurance
+marker that the launcher copies out of the runtime after exit. Injected secret
+values themselves are not part of that durable record. By default, this durable
+audit is metadata-only. Full host-persisted stdout/stderr debug capture and
+full interactive transcript capture are explicit opt-in observability paths and
+are classified as lower-assurance because they can persist provider content
+outside the ephemeral runtime boundary. The transcript path retains terminal I/O
+plus session timestamps and the final exit code, but not the raw host launch
+command.
 
 ## Profile expectations
 
@@ -136,8 +147,12 @@ themselves are not part of that durable record.
 - allowlisted steady-state egress only
 - pinned Debian snapshot egress for `apt` and `apt-get` when the default
   `ephemeral` container mutability is active
-- requires a prebuilt reviewed runtime image; `strict` does not rebuild or
+- requires a prebuilt prepared runtime image; `strict` does not rebuild or
   cold-bootstrap that image
+- requires active Docker seccomp support in the managed runtime before launch
+- may mount an opt-in host-persisted non-secret cache plane for package
+  indexes and compiler caches when `cache_profile=standard`; this is a
+  lower-assurance path and is not part of the clean `strict` session boundary
 
 Assurance mapping within `strict`:
 
@@ -159,7 +174,7 @@ Assurance mapping within `strict`:
 - same VM and container boundary as `strict`
 - same secret and mount restrictions
 - broader network allowlist for dependency and build traffic
-- reviewed runtime-image creation and rebuilds happen here, with any temporary
+- prepared runtime-image creation and rebuilds happen here, with any temporary
   bootstrap allowlist logged separately and restored before the session starts
 - still no host credential or control-plane passthrough
 

--- a/docs/provider-matrix.md
+++ b/docs/provider-matrix.md
@@ -17,9 +17,9 @@ same runtime, not host-native executors.
 |---|---|---|---|---|
 | Codex | CLI | `~/.codex/config.toml`, `AGENTS.md`, `.rules`, MCP config | Clean | Best fit for runtime-plus-adapter design |
 | Codex | App / GUI | app plus `app-server` | Partial | Tier 2 only when execution stays in the bounded runtime |
-| Claude | Claude Code CLI | `~/.claude/settings.json`, imported `CLAUDE.md`, `.mcp.json`, hooks | Partial | Hooks are guardrails, not the boundary; reviewed `.mcp.json` and auth can be injected explicitly |
+| Claude | Claude Code CLI | `~/.claude/settings.json`, imported shared `AGENTS.md` plus `CLAUDE.md` overlay when present, `.mcp.json`, hooks | Partial | Hooks are guardrails, not the boundary; reviewed `.mcp.json` and auth can be injected explicitly |
 | Claude | IDE / GUI workflows | IDE and host integrations | Partial | Lower assurance unless attached to the same bounded workspace/runtime |
-| Gemini | Gemini CLI | `~/.gemini/settings.json`, imported `GEMINI.md`, injected `projects.json` | Partial | Internal sandbox is not the primary boundary here; repo `.gemini/` stays masked on the safe path |
+| Gemini | Gemini CLI | `~/.gemini/settings.json`, imported shared `AGENTS.md` plus `GEMINI.md` overlay when present, injected `projects.json` | Partial | Internal sandbox is not the primary boundary here; repo `.gemini/` stays masked on the safe path |
 | Gemini | IDE / GUI workflows | IDE integration and host UI surfaces | Partial | Tier 2 only if execution is still fully remote/containerized |
 
 ## Adapter rule

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -1,4 +1,4 @@
-.TH WORKCELL 1 "2026-03-22" "Workcell" "User Commands"
+.TH WORKCELL 1 "2026-03-24" "Workcell" "User Commands"
 .SH NAME
 workcell \- bounded runtime launcher for coding agents
 .SH SYNOPSIS
@@ -108,11 +108,49 @@ Set an explicit CPU limit for the inner runtime container.
 Set an explicit memory limit for the inner runtime container, for example
 .BR 4g .
 .TP
+.B --cache-profile off|standard
+Select whether Workcell mounts an opt-in host-persisted non-secret cache plane
+into the runtime. The default is
+.BR off .
+Using
+.BR standard
+persists package-index and compiler caches such as npm, pip, Cargo, Go, and
+.BR ccache ,
+but it is a lower-assurance path and is not treated as part of the clean
+.B strict
+session boundary.
+.TP
 .B --injection-policy PATH
 Use an explicit host-side injection policy for this launch. Workcell mounts
 credential sources read-only from their original host paths and stages the
 selected docs, copied files, and SSH material into per-session runtime state
 instead of passing through host homes or sockets directly.
+.TP
+.B --log-level normal|debug
+Select launch-time logging verbosity. The default is
+.BR normal .
+Use
+.BR debug
+to surface successful Colima and runtime-build output in addition to the normal
+high-signal launcher messages.
+.TP
+.B --debug-log PATH
+Persist the full launcher plus container stdout/stderr stream to
+.IR PATH .
+This is an explicit lower-assurance host logging path because provider output
+may be retained outside the ephemeral runtime, and Workcell prints an explicit
+warning banner when it is enabled. This flag is only valid for real launched
+sessions.
+.TP
+.B --audit-transcript PATH
+Persist a full interactive terminal transcript, including typed input and child
+output, to
+.IR PATH .
+The retained transcript also includes session start and end timestamps plus the
+final exit code.
+This requires an interactive terminal and is an explicit lower-assurance host
+logging path. Workcell prints an explicit warning banner when it is enabled.
+This flag is only valid for real launched sessions.
 .TP
 .B --no-default-injection-policy
 Ignore
@@ -129,7 +167,7 @@ Select the runtime profile. The default is
 .BR strict .
 .TP
 .B --prepare
-Seed or refresh the reviewed runtime image before continuing with the requested
+Seed or refresh the prepared runtime image before continuing with the requested
 launch. This is the recommended first-run path.
 .TP
 .B --repair-profile
@@ -186,6 +224,38 @@ is also set.
 .B --dry-run
 Print the selected runtime command and exit.
 .TP
+.B --doctor
+Print derived profile and workspace state, identify whether the managed profile
+or prepared image is missing, and emit the recommended next command without
+launching the runtime. Also available as
+.BR "workcell doctor" .
+When the workspace path is missing or invalid, this reports that first instead
+of recommending
+.BR --prepare .
+.TP
+.B --inspect
+Print the derived launch configuration, active assurance labels, injection
+metadata, and latest retained host-log pointers without launching the runtime.
+Also available as
+.BR "workcell inspect" .
+.TP
+.B --logs audit|debug|transcript
+Print the latest retained log of the selected type for the derived or explicit
+Colima profile and exit. Also available as
+.BR "workcell logs audit|debug|transcript" .
+.TP
+.B --auth-status
+Print the selected injection or credential posture derived from the rendered
+injection manifest, including the primary provider auth mode, the ordered
+provider auth mode set, and SSH config assurance, and exit. Also available as
+.BR "workcell auth-status" .
+.TP
+.B --gc
+Remove stale host-side session audit and injection-bundle directories plus
+broken latest-log pointers from managed profile state and exit. Also available
+as
+.BR "workcell gc" .
+.TP
 .B -h, --help
 Show usage information.
 .SH PROFILES
@@ -200,7 +270,7 @@ and
 .I /state
 paths is blocked, and mutable shebang scripts cannot target protected real
 runtimes directly.
-This profile requires a prebuilt reviewed runtime image and does not perform
+This profile requires a prebuilt prepared runtime image and does not perform
 cold builds or rebuilds unless
 .B --prepare
 explicitly tells Workcell to seed the image before continuing.
@@ -209,7 +279,7 @@ explicitly tells Workcell to seed the image before continuing.
 The same mount and secret restrictions as
 .BR strict ,
 with broader network access for dependency and build traffic.
-Reviewed runtime-image creation and rebuilds happen here.
+Prepared runtime-image creation and rebuilds happen here.
 .TP
 .B breakglass
 Still inside the Workcell VM plus container boundary, but with unrestricted
@@ -244,7 +314,8 @@ of its contents into per-session runtime state unless
 is set.
 .TP
 .I ~/.colima/PROFILE/workcell.audit.log
-Durable host-side audit log written by the managed launcher for real runs.
+Durable host-side metadata audit log written by the managed launcher for real
+runs.
 .SH SESSION INJECTIONS
 The safe path does not allow ambient host passthrough for secrets, SSH agents,
 or provider state. The supported way to place consistent material into every
@@ -270,6 +341,19 @@ SSH material copied into the ephemeral in-container
 .I ~/.ssh
 with strict permissions.
 .PP
+Secret-bearing injection sources must be owner-only host files or directories
+and must not be symlinks. Standard world-readable
+.I ssh known_hosts
+files are accepted, but they must not be symlinks or group/world-writable.
+Credential entries may be scoped to selected
+providers or runtime modes, and unsafe raw
+.I ssh_config
+directives such as
+.BR ProxyCommand
+or
+.BR Match\ exec
+are rejected unless the operator explicitly opts into them.
+.PP
 The immutable adapter baselines under
 .I adapters/
 are never mutated in place. Repo-local
@@ -278,7 +362,14 @@ are never mutated in place. Repo-local
 and
 .BR GEMINI.md
 are masked inside the workspace and imported into the provider home docs
-instead. By default, Codex rules stay linked to the immutable adapter baseline
+instead. Claude and Gemini import shared
+.BR AGENTS.md
+first and then append
+.BR CLAUDE.md
+or
+.BR GEMINI.md
+when present.
+By default, Codex rules stay linked to the immutable adapter baseline
 until prompt autonomy or package mutation has already downgraded the session.
 If you explicitly opt into
 .B --codex-rules-mutability session
@@ -305,10 +396,33 @@ or
 .B gemini
 for the corresponding provider.
 .PP
-Normal launch after the reviewed image already exists:
+Normal launch after the prepared image already exists:
 .IP
 .EX
 workcell --agent codex --workspace /path/to/repo
+.EE
+.PP
+Inspecting or diagnosing state without launching:
+.IP
+.EX
+workcell --agent codex --inspect --workspace /path/to/repo
+workcell --agent codex --doctor --workspace /path/to/repo
+.EE
+.PP
+Capturing lower-assurance host logs explicitly:
+.IP
+.EX
+workcell --agent codex --workspace /path/to/repo \\
+  --log-level debug --debug-log ~/logs/workcell-debug.log
+workcell --agent codex --workspace /path/to/repo \\
+  --audit-transcript ~/logs/workcell-transcript.log
+.EE
+.PP
+Viewing the latest retained host logs for a profile:
+.IP
+.EX
+workcell --agent codex --workspace /path/to/repo --logs audit
+workcell --agent codex --workspace /path/to/repo --logs debug
 .EE
 .PP
 Prompted launch for a selected provider:

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -21,9 +21,9 @@ providers.
 
 ## Profiles
 
-- `strict`: allowlisted runtime access only and requires a prebuilt reviewed
-  runtime image
-- `build`: broader registry allowlist for dependency installation, reviewed
+- `strict`: allowlisted runtime access only, requires a prebuilt prepared
+  runtime image, and refuses launch if Docker seccomp support is not active
+- `build`: broader registry allowlist for dependency installation, prepared
   image creation, and rebuilds
 - `breakglass`: unrestricted network plus the provider's highest-trust mode
   where one exists; Codex maps this to `danger-full-access`
@@ -37,8 +37,9 @@ the GUI is wired as a client to the same bounded runtime.
 
 - `scripts/workcell`: start the VM, build the runtime image, apply the selected
   network mode, and launch the selected agent inside the container; `strict`
-  refuses image rebuilds and requires the image to have been seeded through
-  `build`
+  refuses image rebuilds, requires the image to have been seeded through
+  `build`, and supports metadata-only audit by default plus explicit
+  lower-assurance debug or transcript capture when the operator opts in
 - `scripts/colima-egress-allowlist.sh`: apply or clear VM-level egress rules
 - `scripts/verify-invariants.sh`: run basic regression checks against the
   current runtime assumptions

--- a/runtime/container/bin/apt-helper.sh
+++ b/runtime/container/bin/apt-helper.sh
@@ -10,6 +10,7 @@ command_name="${1-}"
 shift || true
 WORKCELL_RUNTIME_STATE_DIR="/run/workcell"
 WORKCELL_RUNTIME_ASSURANCE_FILE="${WORKCELL_RUNTIME_STATE_DIR}/session-assurance"
+WORKCELL_PERSISTED_ASSURANCE_FILE="/opt/workcell/session-assurance"
 
 case "${command_name}" in
   apt | apt-get) ;;
@@ -81,6 +82,11 @@ workcell_mark_lower_assurance_session() {
   fi
   printf '%s\n' "lower-assurance-package-mutation" >"${WORKCELL_RUNTIME_ASSURANCE_FILE}"
   chmod 0444 "${WORKCELL_RUNTIME_ASSURANCE_FILE}"
+  if [[ -e "${WORKCELL_PERSISTED_ASSURANCE_FILE}" ]]; then
+    chmod u+w "${WORKCELL_PERSISTED_ASSURANCE_FILE}" 2>/dev/null || true
+  fi
+  printf '%s\n' "lower-assurance-package-mutation" >"${WORKCELL_PERSISTED_ASSURANCE_FILE}"
+  chmod 0444 "${WORKCELL_PERSISTED_ASSURANCE_FILE}" 2>/dev/null || true
 }
 
 mutability="${WORKCELL_CONTAINER_MUTABILITY:-}"

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -334,7 +334,8 @@ workcell_render_provider_doc() {
   local provider_key="$3"
   local common_rel=""
   local provider_rel=""
-  local workspace_doc=""
+  local workspace_common_doc=""
+  local workspace_provider_doc=""
 
   if workcell_manifest_active; then
     common_rel="$(workcell_manifest_string '.documents.common // empty')"
@@ -343,17 +344,20 @@ workcell_render_provider_doc() {
 
   case "${provider_key}" in
     codex)
-      workspace_doc="$(workcell_workspace_import_path 'AGENTS.md' || true)"
+      workspace_common_doc="$(workcell_workspace_import_path 'AGENTS.md' || true)"
       ;;
     claude)
-      workspace_doc="$(workcell_workspace_import_path 'CLAUDE.md' || true)"
+      workspace_common_doc="$(workcell_workspace_import_path 'AGENTS.md' || true)"
+      workspace_provider_doc="$(workcell_workspace_import_path 'CLAUDE.md' || true)"
       ;;
     gemini)
-      workspace_doc="$(workcell_workspace_import_path 'GEMINI.md' || true)"
+      workspace_common_doc="$(workcell_workspace_import_path 'AGENTS.md' || true)"
+      workspace_provider_doc="$(workcell_workspace_import_path 'GEMINI.md' || true)"
       ;;
   esac
 
-  if [[ -z "${workspace_doc}" ]] && [[ -z "${common_rel}" ]] && [[ -z "${provider_rel}" ]]; then
+  if [[ -z "${workspace_common_doc}" ]] && [[ -z "${workspace_provider_doc}" ]] &&
+    [[ -z "${common_rel}" ]] && [[ -z "${provider_rel}" ]]; then
     workcell_link_control_plane_path "${baseline_path}" "${target_path}"
     return 0
   fi
@@ -362,9 +366,13 @@ workcell_render_provider_doc() {
   rm -rf "${target_path}"
   {
     cat "${baseline_path}"
-    if [[ -n "${workspace_doc}" ]]; then
-      printf '\n\n<!-- Workcell imported workspace %s -->\n\n' "$(basename "${workspace_doc}")"
-      cat "${workspace_doc}"
+    if [[ -n "${workspace_common_doc}" ]]; then
+      printf '\n\n<!-- Workcell imported workspace %s -->\n\n' "$(basename "${workspace_common_doc}")"
+      cat "${workspace_common_doc}"
+    fi
+    if [[ -n "${workspace_provider_doc}" ]]; then
+      printf '\n\n<!-- Workcell imported workspace %s -->\n\n' "$(basename "${workspace_provider_doc}")"
+      cat "${workspace_provider_doc}"
     fi
     if [[ -n "${common_rel}" ]]; then
       printf '\n\n<!-- Workcell injected common instructions -->\n\n'

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -6,6 +6,7 @@ if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
     HOME=/tmp \
     TMPDIR="${TMPDIR:-/tmp}" \
     WORKCELL_CONTAINER_SMOKE_DOCKER_CONTEXT="${WORKCELL_CONTAINER_SMOKE_DOCKER_CONTEXT-}" \
+    WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
     WORKCELL_DOCKER_HOST_HOME_ROOT="${WORKCELL_DOCKER_HOST_HOME_ROOT-}" \
     WORKCELL_DOCKER_HOST_WORKSPACE_ROOT="${WORKCELL_DOCKER_HOST_WORKSPACE_ROOT-}" \
     WORKCELL_IMAGE_TAG="${WORKCELL_IMAGE_TAG-}" \
@@ -72,6 +73,15 @@ align_path_for_mapped_runtime_user() {
   chmod "${file_mode}" "${target_path}"
 }
 
+run_as_mapped_host_user() {
+  if [[ "$(id -u)" == "0" ]] && [[ "${HOST_UID}" != "$(id -u)" || "${HOST_GID}" != "$(id -g)" ]]; then
+    setpriv --reuid "${HOST_UID}" --regid "${HOST_GID}" --clear-groups "$@"
+    return
+  fi
+
+  "$@"
+}
+
 cleanup_workspace_scratch() {
   local workspace_root="${1:-${SMOKE_WORKSPACE:-${ROOT_DIR}}}"
 
@@ -93,8 +103,8 @@ prepare_smoke_workspace() {
   local path_list_filtered=""
 
   mkdir -p "${ROOT_DIR}/tmp"
-  chmod 0700 "${ROOT_DIR}/tmp"
-  SMOKE_WORKSPACE="$(mktemp -d "${ROOT_DIR}/tmp/workcell-smoke-workspace.XXXXXX")"
+  align_path_for_mapped_runtime_user "${ROOT_DIR}/tmp" 0644 0755
+  SMOKE_WORKSPACE="$(run_as_mapped_host_user mktemp -d "${ROOT_DIR}/tmp/workcell-smoke-workspace.XXXXXX")"
 
   if ! git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     echo "container-smoke requires a git checkout" >&2
@@ -256,6 +266,7 @@ run_container() {
     -e HOME=/state/agent-home \
     -e CODEX_HOME=/state/agent-home/.codex \
     -e TMPDIR=/state/tmp \
+    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
     -e WORKCELL_RUNTIME=1 \
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
@@ -291,6 +302,7 @@ run_container_with_mutability() {
     -e HOME=/state/agent-home \
     -e CODEX_HOME=/state/agent-home/.codex \
     -e TMPDIR=/state/tmp \
+    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
     -e WORKCELL_RUNTIME=1 \
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
@@ -325,6 +337,7 @@ run_entrypoint() {
     -e HOME=/state/agent-home \
     -e CODEX_HOME=/state/agent-home/.codex \
     -e TMPDIR=/state/tmp \
+    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
     -e WORKCELL_RUNTIME=1 \
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
@@ -360,6 +373,7 @@ run_entrypoint_with_profile() {
     -e HOME=/state/agent-home \
     -e CODEX_HOME=/state/agent-home/.codex \
     -e TMPDIR=/state/tmp \
+    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
     -e WORKCELL_RUNTIME=1 \
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
@@ -396,6 +410,7 @@ run_entrypoint_with_init_profile() {
     -e HOME=/state/agent-home \
     -e CODEX_HOME=/state/agent-home/.codex \
     -e TMPDIR=/state/tmp \
+    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
     -e WORKCELL_RUNTIME=1 \
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
@@ -431,6 +446,7 @@ run_entrypoint_with_autonomy() {
     -e HOME=/state/agent-home \
     -e CODEX_HOME=/state/agent-home/.codex \
     -e TMPDIR=/state/tmp \
+    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
     -e WORKCELL_RUNTIME=1 \
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
@@ -470,6 +486,7 @@ run_entrypoint_with_autonomy_and_bind() {
     -e HOME=/state/agent-home \
     -e CODEX_HOME=/state/agent-home/.codex \
     -e TMPDIR=/state/tmp \
+    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
     -e WORKCELL_RUNTIME=1 \
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
@@ -515,6 +532,7 @@ run_entrypoint_with_injection_bundle() {
     -e HOME=/state/agent-home \
     -e CODEX_HOME=/state/agent-home/.codex \
     -e TMPDIR=/state/tmp \
+    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
     -e WORKCELL_RUNTIME=1 \
     -e WORKSPACE=/workspace \
     -e WORKCELL_INJECTION_MANIFEST=/opt/workcell/host-injections/manifest.json \
@@ -645,14 +663,22 @@ SOURCE_DATE_EPOCH="${BUILD_SOURCE_DATE_EPOCH}" buildx_cmd build \
   "${ROOT_DIR}" >/dev/null
 
 mkdir -p "${ROOT_DIR}/tmp"
-INJECTION_FIXTURE_ROOT="$(mktemp -d "${ROOT_DIR}/tmp/workcell-injection-fixtures.XXXXXX")"
-INJECTION_BUNDLE_ROOT="$(mktemp -d "${ROOT_DIR}/tmp/workcell-injection-bundle.XXXXXX")"
+align_path_for_mapped_runtime_user "${ROOT_DIR}/tmp" 0644 0755
+INJECTION_FIXTURE_ROOT="$(run_as_mapped_host_user mktemp -d "${ROOT_DIR}/tmp/workcell-injection-fixtures.XXXXXX")"
+INJECTION_BUNDLE_ROOT="$(run_as_mapped_host_user mktemp -d "${ROOT_DIR}/tmp/workcell-injection-bundle.XXXXXX")"
 mkdir -p "${INJECTION_FIXTURE_ROOT}"
+align_path_for_mapped_runtime_user "${INJECTION_BUNDLE_ROOT}" 0644 0755
 cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/common.md"
 # Common Smoke Instructions
 EOF
 cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/codex.md"
 # Codex Smoke Instructions
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/claude.md"
+# Claude Smoke Instructions
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gemini.md"
+# Gemini Smoke Instructions
 EOF
 cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/public.txt"
 injected-public
@@ -702,6 +728,8 @@ version = 1
 [documents]
 common = "common.md"
 codex = "codex.md"
+claude = "claude.md"
+gemini = "gemini.md"
 
 [credentials]
 codex_auth = "codex-auth.json"
@@ -733,22 +761,33 @@ providers = ["codex"]
 EOF
 
 align_path_for_mapped_runtime_user "${INJECTION_FIXTURE_ROOT}" 0644 0755
+chmod 0600 \
+  "${INJECTION_FIXTURE_ROOT}/secret.txt" \
+  "${INJECTION_FIXTURE_ROOT}/codex-auth.json" \
+  "${INJECTION_FIXTURE_ROOT}/claude-auth.json" \
+  "${INJECTION_FIXTURE_ROOT}/claude-mcp.json" \
+  "${INJECTION_FIXTURE_ROOT}/gh-hosts.yml" \
+  "${INJECTION_FIXTURE_ROOT}/claude-api-key.txt" \
+  "${INJECTION_FIXTURE_ROOT}/gemini.env" \
+  "${INJECTION_FIXTURE_ROOT}/gemini-projects.json" \
+  "${INJECTION_FIXTURE_ROOT}/ssh-config" \
+  "${INJECTION_FIXTURE_ROOT}/id_smoke"
 
-python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
+run_as_mapped_host_user python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
   --policy "${INJECTION_FIXTURE_ROOT}/policy.toml" \
   --agent codex \
   --mode strict \
   --output-root "${INJECTION_BUNDLE_ROOT}/codex" >/dev/null
 prepare_direct_mount_spec_for_bundle "${INJECTION_BUNDLE_ROOT}/codex"
 
-python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
+run_as_mapped_host_user python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
   --policy "${INJECTION_FIXTURE_ROOT}/policy.toml" \
   --agent claude \
   --mode strict \
   --output-root "${INJECTION_BUNDLE_ROOT}/claude" >/dev/null
 prepare_direct_mount_spec_for_bundle "${INJECTION_BUNDLE_ROOT}/claude"
 
-python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
+run_as_mapped_host_user python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
   --policy "${INJECTION_FIXTURE_ROOT}/policy.toml" \
   --agent gemini \
   --mode strict \
@@ -796,10 +835,13 @@ run_container_with_injection_bundle codex "${INJECTION_BUNDLE_ROOT}/codex" bash 
 run_container_with_injection_bundle claude "${INJECTION_BUNDLE_ROOT}/claude" bash -lc '
   set -euo pipefail
   /usr/local/bin/workcell-entrypoint claude --version >/dev/null
-  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
-    set -euo pipefail
-    grep -q "Workspace Claude Instructions" "$HOME/.claude/CLAUDE.md"
-    grep -q "\"apiKeyHelper\"" "$HOME/.claude/settings.json"
+    setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+      set -euo pipefail
+      grep -q "Common Smoke Instructions" "$HOME/.claude/CLAUDE.md"
+      grep -q "Claude Smoke Instructions" "$HOME/.claude/CLAUDE.md"
+      grep -q "Workspace AGENTS Instructions" "$HOME/.claude/CLAUDE.md"
+      grep -q "Workspace Claude Instructions" "$HOME/.claude/CLAUDE.md"
+      grep -q "\"apiKeyHelper\"" "$HOME/.claude/settings.json"
     helper_path="$(jq -r ".apiKeyHelper" "$HOME/.claude/settings.json")"
     test ! -L "$HOME/.claude/settings.json"
     test -x "$helper_path"
@@ -824,14 +866,49 @@ run_container_with_injection_bundle claude "${INJECTION_BUNDLE_ROOT}/claude" bas
 run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini" bash -lc '
   set -euo pipefail
   /usr/local/bin/workcell-entrypoint gemini --version >/dev/null
-  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
-    set -euo pipefail
-    grep -q "Workspace Gemini Instructions" "$HOME/.gemini/GEMINI.md"
-    grep -q "GEMINI_API_KEY=smoke-gemini-key" "$HOME/.gemini/.env"
+    setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+      set -euo pipefail
+      grep -q "Common Smoke Instructions" "$HOME/.gemini/GEMINI.md"
+      grep -q "Gemini Smoke Instructions" "$HOME/.gemini/GEMINI.md"
+      grep -q "Workspace AGENTS Instructions" "$HOME/.gemini/GEMINI.md"
+      grep -q "Workspace Gemini Instructions" "$HOME/.gemini/GEMINI.md"
+      grep -q "GEMINI_API_KEY=smoke-gemini-key" "$HOME/.gemini/.env"
     grep -q "\"smoke\"" "$HOME/.gemini/projects.json"
     grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
   '"'"'
 '
+
+WORKSPACE_IMPORT_ROOT_FALLBACK="$(mktemp -d "${ROOT_DIR}/tmp/workcell-import-fallback.XXXXXX")"
+cat <<'EOF' >"${WORKSPACE_IMPORT_ROOT_FALLBACK}/AGENTS.md"
+<!-- Workcell imported workspace AGENTS.md -->
+
+# Workspace AGENTS Instructions
+EOF
+align_path_for_mapped_runtime_user "${WORKSPACE_IMPORT_ROOT_FALLBACK}" 0644 0755
+ORIGINAL_WORKSPACE_IMPORT_ROOT="${WORKSPACE_IMPORT_ROOT}"
+WORKSPACE_IMPORT_ROOT="${WORKSPACE_IMPORT_ROOT_FALLBACK}"
+
+# shellcheck disable=SC2016
+run_container claude bash -lc '
+  set -euo pipefail
+  /usr/local/bin/workcell-entrypoint claude --version >/dev/null
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    grep -q "Workspace AGENTS Instructions" "$HOME/.claude/CLAUDE.md"
+  '"'"'
+'
+
+# shellcheck disable=SC2016
+run_container gemini bash -lc '
+  set -euo pipefail
+  /usr/local/bin/workcell-entrypoint gemini --version >/dev/null
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    grep -q "Workspace AGENTS Instructions" "$HOME/.gemini/GEMINI.md"
+  '"'"'
+'
+
+WORKSPACE_IMPORT_ROOT="${ORIGINAL_WORKSPACE_IMPORT_ROOT}"
 
 if [[ "$(uname -s)" == "Linux" ]] && [[ -x /bin/echo ]]; then
   CODEX_YOLO_ARGS="$(
@@ -1049,9 +1126,14 @@ run_container claude bash -lc '
   AGENT_NAME=claude /usr/local/bin/workcell-entrypoint claude --version >/dev/null
   setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
     set -euo pipefail
+    grep -q "Workspace AGENTS Instructions" "$HOME/.claude/CLAUDE.md"
     grep -q "Workspace Claude Instructions" "$HOME/.claude/CLAUDE.md"
     if grep -q "Nested Workspace Claude Instructions" "$HOME/.claude/CLAUDE.md"; then
       echo "expected nested CLAUDE.md instructions to remain path-scoped in the workspace" >&2
+      exit 1
+    fi
+    if grep -q "Nested Workspace AGENTS Instructions" "$HOME/.claude/CLAUDE.md"; then
+      echo "expected nested AGENTS.md instructions to remain path-scoped in the workspace" >&2
       exit 1
     fi
     grep -q "Nested Workspace Claude Instructions" /workspace/nested/CLAUDE.md
@@ -1064,9 +1146,14 @@ run_container gemini bash -lc '
   AGENT_NAME=gemini /usr/local/bin/workcell-entrypoint gemini --version >/dev/null
   setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
     set -euo pipefail
+    grep -q "Workspace AGENTS Instructions" "$HOME/.gemini/GEMINI.md"
     grep -q "Workspace Gemini Instructions" "$HOME/.gemini/GEMINI.md"
     if grep -q "Nested Workspace Gemini Instructions" "$HOME/.gemini/GEMINI.md"; then
       echo "expected nested GEMINI.md instructions to remain path-scoped in the workspace" >&2
+      exit 1
+    fi
+    if grep -q "Nested Workspace AGENTS Instructions" "$HOME/.gemini/GEMINI.md"; then
+      echo "expected nested AGENTS.md instructions to remain path-scoped in the workspace" >&2
       exit 1
     fi
     grep -q "Nested Workspace Gemini Instructions" /workspace/nested/GEMINI.md
@@ -1454,8 +1541,11 @@ EOF
     exit 1
   fi
   grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/state-native-codex-profile-bypass.out
-  mkdir -p /workspace/tmp
-  workspace_provider_scratch=/workspace/tmp/workcell-provider-scratch
+  if [[ "${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC:-0}" != "1" ]]; then
+  workspace_exec_scratch=/workspace/.workcell-exec-scratch
+  rm -rf "${workspace_exec_scratch}"
+  mkdir -p "${workspace_exec_scratch}"
+  workspace_provider_scratch="${workspace_exec_scratch}/workcell-provider-scratch"
   workspace_provider_tampered="${workspace_provider_scratch}/tampered"
   workspace_provider_aggressive="${workspace_provider_scratch}/aggressive"
   workspace_provider_minimal="${workspace_provider_scratch}/minimal"
@@ -1465,17 +1555,17 @@ EOF
   workspace_provider_benign_marker="${workspace_provider_scratch}/benign-marker-package"
   rm -rf "${workspace_provider_scratch}"
   mkdir -p "${workspace_provider_scratch}"
-  cp /bin/true /workspace/tmp/.workcell-native-helper
-  chmod 0700 /workspace/tmp/.workcell-native-helper
-  if /workspace/tmp/.workcell-native-helper >/tmp/workspace-native.out 2>&1; then
+  cp /bin/true "${workspace_exec_scratch}/.workcell-native-helper"
+  chmod 0700 "${workspace_exec_scratch}/.workcell-native-helper"
+  if "${workspace_exec_scratch}/.workcell-native-helper" >/tmp/workspace-native.out 2>&1; then
     echo "expected strict profile to reject direct native executable launches from /workspace" >&2
     exit 1
   fi
   grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/workspace-native.out
-  cp /bin/true /workspace/tmp/.workcell-native-helper-deleted-fd
-  chmod 0700 /workspace/tmp/.workcell-native-helper-deleted-fd
-  exec 3</workspace/tmp/.workcell-native-helper-deleted-fd
-  rm -f /workspace/tmp/.workcell-native-helper-deleted-fd
+  cp /bin/true "${workspace_exec_scratch}/.workcell-native-helper-deleted-fd"
+  chmod 0700 "${workspace_exec_scratch}/.workcell-native-helper-deleted-fd"
+  exec 3<"${workspace_exec_scratch}/.workcell-native-helper-deleted-fd"
+  rm -f "${workspace_exec_scratch}/.workcell-native-helper-deleted-fd"
   if /proc/self/fd/3 >/tmp/workspace-native-deleted-fd.out 2>&1; then
     echo "expected strict profile to reject deleted-fd native executable launches from /workspace" >&2
     exec 3<&-
@@ -1513,22 +1603,22 @@ EOF
   grep -Eq "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile\\.|cannot execute: required file not found|No such file or directory" /tmp/workspace-native-deleted-threadself.out
   grep -Eq "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile\\.|cannot execute: required file not found|No such file or directory" /tmp/workspace-native-deleted-taskfd.out
   grep -Eq "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile\\.|cannot execute: required file not found|No such file or directory" /tmp/workspace-native-deleted-stdin.out
-  cp /bin/true /workspace/tmp/.workcell-native-helper-deleted-pidfd
-  chmod 0700 /workspace/tmp/.workcell-native-helper-deleted-pidfd
+  cp /bin/true "${workspace_exec_scratch}/.workcell-native-helper-deleted-pidfd"
+  chmod 0700 "${workspace_exec_scratch}/.workcell-native-helper-deleted-pidfd"
   if (
-    exec 5</workspace/tmp/.workcell-native-helper-deleted-pidfd
-    rm -f /workspace/tmp/.workcell-native-helper-deleted-pidfd
+    exec 5<"${workspace_exec_scratch}/.workcell-native-helper-deleted-pidfd"
+    rm -f "${workspace_exec_scratch}/.workcell-native-helper-deleted-pidfd"
     exec /proc/"$BASHPID"/fd/5
   ) >/tmp/workspace-native-deleted-pidfd.out 2>&1; then
     echo "expected strict profile to reject deleted-fd native executable launches via /proc/\$\$/fd from /workspace" >&2
     exit 1
   fi
   grep -Eq "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile\\.|cannot execute: required file not found|No such file or directory" /tmp/workspace-native-deleted-pidfd.out
-  cp /bin/true /workspace/tmp/.workcell-native-helper-deleted-stdout
-  chmod 0700 /workspace/tmp/.workcell-native-helper-deleted-stdout
+  cp /bin/true "${workspace_exec_scratch}/.workcell-native-helper-deleted-stdout"
+  chmod 0700 "${workspace_exec_scratch}/.workcell-native-helper-deleted-stdout"
   if (
-    exec 5</workspace/tmp/.workcell-native-helper-deleted-stdout
-    rm -f /workspace/tmp/.workcell-native-helper-deleted-stdout
+    exec 5<"${workspace_exec_scratch}/.workcell-native-helper-deleted-stdout"
+    rm -f "${workspace_exec_scratch}/.workcell-native-helper-deleted-stdout"
     exec 1<&5
     exec /dev/stdout
   ) >/tmp/workspace-native-deleted-stdout.out 2>/tmp/workspace-native-deleted-stdout.err; then
@@ -1536,39 +1626,39 @@ EOF
     exit 1
   fi
   grep -Eq "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile\\.|cannot execute: required file not found|No such file or directory" /tmp/workspace-native-deleted-stdout.err
-  cp /bin/true /workspace/tmp/.workcell-native-helper-deleted-stderr
-  chmod 0700 /workspace/tmp/.workcell-native-helper-deleted-stderr
+  cp /bin/true "${workspace_exec_scratch}/.workcell-native-helper-deleted-stderr"
+  chmod 0700 "${workspace_exec_scratch}/.workcell-native-helper-deleted-stderr"
   if (
-    exec 5</workspace/tmp/.workcell-native-helper-deleted-stderr
-    rm -f /workspace/tmp/.workcell-native-helper-deleted-stderr
+    exec 5<"${workspace_exec_scratch}/.workcell-native-helper-deleted-stderr"
+    rm -f "${workspace_exec_scratch}/.workcell-native-helper-deleted-stderr"
     exec 2<&5
     exec /dev/stderr
   ) >/tmp/workspace-native-deleted-stderr.out 2>&1; then
     echo "expected strict profile to reject deleted-fd native executable launches via /dev/stderr from /workspace" >&2
     exit 1
   fi
-  if env -u LD_PRELOAD "$LOADER" /workspace/tmp/.workcell-native-helper >/tmp/workspace-native-loader.out 2>&1; then
+  if env -u LD_PRELOAD "$LOADER" "${workspace_exec_scratch}/.workcell-native-helper" >/tmp/workspace-native-loader.out 2>&1; then
     echo "expected strict profile to reject loader-mediated native executable launches from /workspace" >&2
     exit 1
   fi
   grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/workspace-native-loader.out
-  cat >/workspace/tmp/.workcell-node-shebang <<EOF
+  cat >"${workspace_exec_scratch}/.workcell-node-shebang" <<EOF
 #!/usr/local/libexec/workcell/real/node
 console.log("workcell shebang bypass");
 EOF
-  chmod 0700 /workspace/tmp/.workcell-node-shebang
-  if /workspace/tmp/.workcell-node-shebang >/tmp/workspace-node-shebang.out 2>&1; then
+  chmod 0700 "${workspace_exec_scratch}/.workcell-node-shebang"
+  if "${workspace_exec_scratch}/.workcell-node-shebang" >/tmp/workspace-node-shebang.out 2>&1; then
     echo "expected strict profile to reject mutable shebang execution of the real Node payload" >&2
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-node-shebang.out
-  cat >/workspace/tmp/.workcell-node-shebang-deleted-fd <<EOF
+  cat >"${workspace_exec_scratch}/.workcell-node-shebang-deleted-fd" <<EOF
 #!/usr/local/libexec/workcell/real/node
 console.log("workcell deleted fd shebang bypass");
 EOF
-  chmod 0700 /workspace/tmp/.workcell-node-shebang-deleted-fd
-  exec 4</workspace/tmp/.workcell-node-shebang-deleted-fd
-  rm -f /workspace/tmp/.workcell-node-shebang-deleted-fd
+  chmod 0700 "${workspace_exec_scratch}/.workcell-node-shebang-deleted-fd"
+  exec 4<"${workspace_exec_scratch}/.workcell-node-shebang-deleted-fd"
+  rm -f "${workspace_exec_scratch}/.workcell-node-shebang-deleted-fd"
   if /proc/self/fd/4 >/tmp/workspace-node-shebang-deleted-fd.out 2>&1; then
     echo "expected strict profile to reject deleted-fd mutable shebang execution of the real Node payload" >&2
     exec 4<&-
@@ -1606,28 +1696,28 @@ EOF
   grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-threadself.out
   grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-taskfd.out
   grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-stdin.out
-  cat >/workspace/tmp/.workcell-node-shebang-deleted-pidfd <<EOF
+  cat >"${workspace_exec_scratch}/.workcell-node-shebang-deleted-pidfd" <<EOF
 #!/usr/local/libexec/workcell/real/node
 console.log("workcell pid fd deleted shebang bypass");
 EOF
-  chmod 0700 /workspace/tmp/.workcell-node-shebang-deleted-pidfd
+  chmod 0700 "${workspace_exec_scratch}/.workcell-node-shebang-deleted-pidfd"
   if (
-    exec 5</workspace/tmp/.workcell-node-shebang-deleted-pidfd
-    rm -f /workspace/tmp/.workcell-node-shebang-deleted-pidfd
+    exec 5<"${workspace_exec_scratch}/.workcell-node-shebang-deleted-pidfd"
+    rm -f "${workspace_exec_scratch}/.workcell-node-shebang-deleted-pidfd"
     exec /proc/"$BASHPID"/fd/5
   ) >/tmp/workspace-node-shebang-deleted-pidfd.out 2>&1; then
     echo "expected strict profile to reject deleted-fd mutable shebang execution via /proc/\$\$/fd of the real Node payload" >&2
     exit 1
   fi
   grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-pidfd.out
-  cat >/workspace/tmp/.workcell-node-shebang-deleted-stdout <<EOF
+  cat >"${workspace_exec_scratch}/.workcell-node-shebang-deleted-stdout" <<EOF
 #!/usr/local/libexec/workcell/real/node
 console.log("workcell stdout deleted shebang bypass");
 EOF
-  chmod 0700 /workspace/tmp/.workcell-node-shebang-deleted-stdout
+  chmod 0700 "${workspace_exec_scratch}/.workcell-node-shebang-deleted-stdout"
   if (
-    exec 5</workspace/tmp/.workcell-node-shebang-deleted-stdout
-    rm -f /workspace/tmp/.workcell-node-shebang-deleted-stdout
+    exec 5<"${workspace_exec_scratch}/.workcell-node-shebang-deleted-stdout"
+    rm -f "${workspace_exec_scratch}/.workcell-node-shebang-deleted-stdout"
     exec 1<&5
     exec /dev/stdout
   ) >/tmp/workspace-node-shebang-deleted-stdout.out 2>/tmp/workspace-node-shebang-deleted-stdout.err; then
@@ -1635,81 +1725,82 @@ EOF
     exit 1
   fi
   grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-stdout.err
-  cat >/workspace/tmp/.workcell-node-shebang-deleted-stderr <<EOF
+  cat >"${workspace_exec_scratch}/.workcell-node-shebang-deleted-stderr" <<EOF
 #!/usr/local/libexec/workcell/real/node
 console.log("workcell stderr deleted shebang bypass");
 EOF
-  chmod 0700 /workspace/tmp/.workcell-node-shebang-deleted-stderr
+  chmod 0700 "${workspace_exec_scratch}/.workcell-node-shebang-deleted-stderr"
   if (
-    exec 5</workspace/tmp/.workcell-node-shebang-deleted-stderr
-    rm -f /workspace/tmp/.workcell-node-shebang-deleted-stderr
+    exec 5<"${workspace_exec_scratch}/.workcell-node-shebang-deleted-stderr"
+    rm -f "${workspace_exec_scratch}/.workcell-node-shebang-deleted-stderr"
     exec 2<&5
     exec /dev/stderr
   ) >/tmp/workspace-node-shebang-deleted-stderr.out 2>&1; then
     echo "expected strict profile to reject deleted-fd mutable shebang execution via /dev/stderr of the real Node payload" >&2
     exit 1
   fi
-  cat >/workspace/tmp/.workcell-loader-node-shebang <<EOF
+  cat >"${workspace_exec_scratch}/.workcell-loader-node-shebang" <<EOF
 #!${LOADER} /usr/local/libexec/workcell/real/node
 console.log("workcell loader shebang bypass");
 EOF
-  chmod 0700 /workspace/tmp/.workcell-loader-node-shebang
-  if /workspace/tmp/.workcell-loader-node-shebang >/tmp/workspace-loader-node-shebang.out 2>&1; then
+  chmod 0700 "${workspace_exec_scratch}/.workcell-loader-node-shebang"
+  if "${workspace_exec_scratch}/.workcell-loader-node-shebang" >/tmp/workspace-loader-node-shebang.out 2>&1; then
     echo "expected strict profile to reject mutable loader shebang execution of the real Node payload" >&2
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-loader-node-shebang.out
-  cat >/workspace/tmp/.workcell-env-node-shebang <<EOF
+  cat >"${workspace_exec_scratch}/.workcell-env-node-shebang" <<EOF
 #!/usr/bin/env -S /usr/local/libexec/workcell/real/node
 console.log("workcell env shebang bypass");
 EOF
-  chmod 0700 /workspace/tmp/.workcell-env-node-shebang
-  if /workspace/tmp/.workcell-env-node-shebang >/tmp/workspace-env-node-shebang.out 2>&1; then
+  chmod 0700 "${workspace_exec_scratch}/.workcell-env-node-shebang"
+  if "${workspace_exec_scratch}/.workcell-env-node-shebang" >/tmp/workspace-env-node-shebang.out 2>&1; then
     echo "expected strict profile to reject env -S shebang execution of the real Node payload" >&2
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-node-shebang.out
-  cat >/workspace/tmp/.workcell-env-loader-node-shebang <<EOF
+  cat >"${workspace_exec_scratch}/.workcell-env-loader-node-shebang" <<EOF
 #!/usr/bin/env -S ${LOADER} /usr/local/libexec/workcell/real/node
 console.log("workcell env loader shebang bypass");
 EOF
-  chmod 0700 /workspace/tmp/.workcell-env-loader-node-shebang
-  if /workspace/tmp/.workcell-env-loader-node-shebang >/tmp/workspace-env-loader-node-shebang.out 2>&1; then
+  chmod 0700 "${workspace_exec_scratch}/.workcell-env-loader-node-shebang"
+  if "${workspace_exec_scratch}/.workcell-env-loader-node-shebang" >/tmp/workspace-env-loader-node-shebang.out 2>&1; then
     echo "expected strict profile to reject env -S loader shebang execution of the real Node payload" >&2
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-loader-node-shebang.out
-  cp /usr/local/libexec/workcell/real/node /workspace/tmp/node
-  chmod 0700 /workspace/tmp/node
-  cat >/workspace/tmp/.workcell-env-path-node-shebang <<EOF
-#!/usr/bin/env -S PATH=/workspace/tmp node --version
+  cp /usr/local/libexec/workcell/real/node "${workspace_exec_scratch}/node"
+  chmod 0700 "${workspace_exec_scratch}/node"
+  cat >"${workspace_exec_scratch}/.workcell-env-path-node-shebang" <<EOF
+#!/usr/bin/env -S PATH=${workspace_exec_scratch} node --version
 EOF
-  chmod 0700 /workspace/tmp/.workcell-env-path-node-shebang
-  if /workspace/tmp/.workcell-env-path-node-shebang >/tmp/workspace-env-path-node-shebang.out 2>&1; then
+  chmod 0700 "${workspace_exec_scratch}/.workcell-env-path-node-shebang"
+  if "${workspace_exec_scratch}/.workcell-env-path-node-shebang" >/tmp/workspace-env-path-node-shebang.out 2>&1; then
     echo "expected strict profile to reject env -S PATH-rebound execution of a protected Node copy" >&2
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-path-node-shebang.out
-  if env -i PATH=/workspace/tmp /usr/bin/env node --version >/tmp/env-path-node.out 2>&1; then
+  if env -i PATH="${workspace_exec_scratch}" /usr/bin/env node --version >/tmp/env-path-node.out 2>&1; then
     echo "expected strict profile to reject env basename resolution to a protected Node copy" >&2
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/env-path-node.out
-  cat <<'\''EOF'\'' >/workspace/tmp/workcell-child-envp-bypass.js
+  cat <<'\''EOF'\'' >"${workspace_exec_scratch}/workcell-child-envp-bypass.js"
 const fs = require("node:fs");
 const { spawnSync } = require("node:child_process");
+const scratch = process.env.WORKCELL_EXEC_SCRATCH;
 
-fs.copyFileSync("/usr/local/libexec/workcell/real/node", "/workspace/tmp/node");
-fs.chmodSync("/workspace/tmp/node", 0o700);
+fs.copyFileSync("/usr/local/libexec/workcell/real/node", `${scratch}/node`);
+fs.chmodSync(`${scratch}/node`, 0o700);
 fs.writeFileSync(
-  "/workspace/tmp/shebang-bypass",
-  "#!/usr/bin/env node\nconsole.log(\"bypass-ok\")\n",
+  `${scratch}/shebang-bypass`,
+  `#!/usr/bin/env -S PATH=${scratch} node --version\n`,
   { mode: 0o700 },
 );
 
-const result = spawnSync("/workspace/tmp/shebang-bypass", [], {
+const result = spawnSync(`${scratch}/shebang-bypass`, [], {
   encoding: "utf8",
-  env: { PATH: "/workspace/tmp" },
+  env: { PATH: scratch },
 });
 
 const blockedByRuntime =
@@ -1731,22 +1822,22 @@ if (
 
 console.log("child-envp-shebang-blocked");
 EOF
-  node /workspace/tmp/workcell-child-envp-bypass.js >/tmp/workspace-child-envp-bypass.out 2>/tmp/workspace-child-envp-bypass.err
+  WORKCELL_EXEC_SCRATCH="${workspace_exec_scratch}" node "${workspace_exec_scratch}/workcell-child-envp-bypass.js" >/tmp/workspace-child-envp-bypass.out 2>/tmp/workspace-child-envp-bypass.err
   grep -q "child-envp-shebang-blocked" /tmp/workspace-child-envp-bypass.out
-  cat >/workspace/tmp/.workcell-env-shell-node-shebang <<EOF
+  cat >"${workspace_exec_scratch}/.workcell-env-shell-node-shebang" <<EOF
 #!/usr/bin/env -S /bin/sh -c /usr/local/libexec/workcell/real/node
 EOF
-  chmod 0700 /workspace/tmp/.workcell-env-shell-node-shebang
-  if /workspace/tmp/.workcell-env-shell-node-shebang >/tmp/workspace-env-shell-node-shebang.out 2>&1; then
+  chmod 0700 "${workspace_exec_scratch}/.workcell-env-shell-node-shebang"
+  if "${workspace_exec_scratch}/.workcell-env-shell-node-shebang" >/tmp/workspace-env-shell-node-shebang.out 2>&1; then
     echo "expected strict profile to reject env -S shell trampoline execution of the real Node payload" >&2
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-shell-node-shebang.out
-  rm -f /workspace/tmp/.workcell-node-shebang /workspace/tmp/.workcell-loader-node-shebang
-  rm -f /workspace/tmp/.workcell-env-node-shebang /workspace/tmp/.workcell-env-loader-node-shebang /workspace/tmp/.workcell-env-path-node-shebang /workspace/tmp/.workcell-env-shell-node-shebang
-  rm -f /workspace/tmp/shebang-bypass /workspace/tmp/workcell-child-envp-bypass.js
-  rm -f /workspace/tmp/node
-  rm -f /workspace/tmp/.workcell-native-helper
+  rm -f "${workspace_exec_scratch}/.workcell-node-shebang" "${workspace_exec_scratch}/.workcell-loader-node-shebang"
+  rm -f "${workspace_exec_scratch}/.workcell-env-node-shebang" "${workspace_exec_scratch}/.workcell-env-loader-node-shebang" "${workspace_exec_scratch}/.workcell-env-path-node-shebang" "${workspace_exec_scratch}/.workcell-env-shell-node-shebang"
+  rm -f "${workspace_exec_scratch}/shebang-bypass" "${workspace_exec_scratch}/workcell-child-envp-bypass.js"
+  rm -f "${workspace_exec_scratch}/node"
+  rm -f "${workspace_exec_scratch}/.workcell-native-helper"
   cp /usr/local/libexec/workcell/real/node "$EXEC_TMP/workcell-node-real-copy"
   chmod 0700 "$EXEC_TMP/workcell-node-real-copy"
   if "$EXEC_TMP/workcell-node-real-copy" --version >/tmp/node-real-copy.out 2>&1; then
@@ -1800,10 +1891,12 @@ EOF
     exit 1
   fi
   grep -q "Workcell blocked direct provider script execution via node." /tmp/node-provider-env.out
-  cp /bin/true /workspace/tmp/not-an-addon.node
-  cat <<'\''EOF'\'' >/workspace/tmp/workcell-native-addon-require.js
+  cp /bin/true "${workspace_exec_scratch}/not-an-addon.node"
+  cat <<'\''EOF'\'' >"${workspace_exec_scratch}/workcell-native-addon-require.js"
+const scratch = process.env.WORKCELL_EXEC_SCRATCH;
+
 try {
-  require("/workspace/tmp/not-an-addon.node");
+  require(`${scratch}/not-an-addon.node`);
   console.error("expected Workcell to block native addon loading");
   process.exit(1);
 } catch (error) {
@@ -1813,7 +1906,7 @@ try {
   console.log("native-addon-load-blocked");
 }
 EOF
-  node /workspace/tmp/workcell-native-addon-require.js >/tmp/node-native-addon.out 2>&1
+  WORKCELL_EXEC_SCRATCH="${workspace_exec_scratch}" node "${workspace_exec_scratch}/workcell-native-addon-require.js" >/tmp/node-native-addon.out 2>&1
   grep -q "native-addon-load-blocked" /tmp/node-native-addon.out
   cp -R /opt/workcell/providers /tmp/workcell-provider-copy
   if node /tmp/workcell-provider-copy/node_modules/@anthropic-ai/claude-code/cli.js --version >/tmp/node-provider-copy-claude.out 2>&1; then
@@ -1990,12 +2083,12 @@ EOF
   fi
   grep -q "dangerously-skip-permissions" /tmp/node-provider-marker-benign.out
   rm -rf "${workspace_provider_benign_marker}"
-  rm -f /workspace/tmp/workcell-provider-copy-scrub.js
-  rm -f /workspace/tmp/workcell-provider-copy-minimalize.js
-  rm -f /workspace/tmp/workcell-provider-copy-split.js
-  rm -f /workspace/tmp/workcell-provider-copy-no-package.js
-  rm -f /workspace/tmp/workcell-provider-copy-no-package-split.js
-  rm -f /workspace/tmp/not-an-addon.node /workspace/tmp/workcell-native-addon-require.js
+  rm -f "${workspace_exec_scratch}/workcell-provider-copy-scrub.js"
+  rm -f "${workspace_exec_scratch}/workcell-provider-copy-minimalize.js"
+  rm -f "${workspace_exec_scratch}/workcell-provider-copy-split.js"
+  rm -f "${workspace_exec_scratch}/workcell-provider-copy-no-package.js"
+  rm -f "${workspace_exec_scratch}/workcell-provider-copy-no-package-split.js"
+  rm -f "${workspace_exec_scratch}/not-an-addon.node" "${workspace_exec_scratch}/workcell-native-addon-require.js"
   cat <<'\''EOF'\'' >/tmp/workcell-node-public-preload.js
 require("fs").writeFileSync("/tmp/workcell-node-public-preload-ran", "1")
 process.exit(99)
@@ -2008,16 +2101,16 @@ EOF
     exit 1
   fi
   test ! -e /tmp/workcell-node-public-preload-ran
-  cat <<'\''EOF'\'' >/workspace/tmp/git
+  cat <<'\''EOF'\'' >"${workspace_exec_scratch}/git"
 #!/bin/sh
 printf '\''path-bypass-git\n'\''
 EOF
-  cat <<'\''EOF'\'' >/workspace/tmp/node
+  cat <<'\''EOF'\'' >"${workspace_exec_scratch}/node"
 #!/bin/sh
 printf '\''path-bypass-node\n'\''
 EOF
-  chmod 0700 /workspace/tmp/git /workspace/tmp/node
-  cat <<'\''EOF'\'' >/workspace/tmp/workcell-path-sanitize.js
+  chmod 0700 "${workspace_exec_scratch}/git" "${workspace_exec_scratch}/node"
+  cat <<'\''EOF'\'' >"${workspace_exec_scratch}/workcell-path-sanitize.js"
 const { spawnSync } = require("node:child_process");
 
 const git = spawnSync("git", ["--version"], { encoding: "utf8" });
@@ -2038,13 +2131,17 @@ if (!node.stdout.trim().startsWith("v")) {
 
 console.log("trusted-path-preserved");
 EOF
-  env PATH=/workspace/tmp:$PATH /usr/local/bin/node /workspace/tmp/workcell-path-sanitize.js >/tmp/node-path-sanitize.out 2>&1
+  env PATH="${workspace_exec_scratch}:$PATH" /usr/local/bin/node "${workspace_exec_scratch}/workcell-path-sanitize.js" >/tmp/node-path-sanitize.out 2>&1
   grep -q "trusted-path-preserved" /tmp/node-path-sanitize.out
   if grep -q "path-bypass-" /tmp/node-path-sanitize.out; then
     echo "expected public node wrapper to sanitize PATH for child processes" >&2
     exit 1
   fi
-  rm -f /workspace/tmp/git /workspace/tmp/node /workspace/tmp/workcell-path-sanitize.js
+  rm -f "${workspace_exec_scratch}/git" "${workspace_exec_scratch}/node" "${workspace_exec_scratch}/workcell-path-sanitize.js"
+  rm -rf "${workspace_exec_scratch}"
+  else
+    echo "Skipping nested workspace mutable-exec smoke checks for the remote validator bind-mount path." >&2
+  fi
   if printf '\''console.log("workcell")\n'\'' | node >/tmp/node-stdin.out 2>&1; then
     echo "expected public node wrapper to reject stdin-driven execution" >&2
     exit 1

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1541,6 +1541,10 @@ EOF
     exit 1
   fi
   grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/state-native-codex-profile-bypass.out
+  if [[ "${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC:-0}" != "1" ]] && [[ ! -w /workspace ]]; then
+    echo "Workcell note: skipping workspace mutable execution smoke because /workspace is not writable for the runtime user." >&2
+    WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC=1
+  fi
   if [[ "${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC:-0}" != "1" ]]; then
   workspace_exec_scratch=/workspace/.workcell-exec-scratch
   rm -rf "${workspace_exec_scratch}"

--- a/scripts/dev-remote-validate.sh
+++ b/scripts/dev-remote-validate.sh
@@ -515,6 +515,13 @@ if [[ "${REMOTE_USE_SUDO}" == "1" ]]; then
   rsync_args=(--rsync-path="sudo -n rsync" --chown=0:0 "${rsync_args[@]}")
 fi
 rsync "${rsync_args[@]}"
+if [[ "${REMOTE_USE_SUDO}" == "1" ]]; then
+  remote_cmd install -d -m 0755 -o "${REMOTE_LOGIN_UID}" -g "${REMOTE_LOGIN_GID}" "${REMOTE_DIR}/repo/tmp"
+else
+  remote_cmd mkdir -p -- "${REMOTE_DIR}/repo/tmp"
+  remote_cmd chown "${REMOTE_LOGIN_UID}:${REMOTE_LOGIN_GID}" "${REMOTE_DIR}/repo/tmp"
+  remote_cmd chmod 0755 "${REMOTE_DIR}/repo/tmp"
+fi
 
 helper_rsync_args=(
   --archive
@@ -541,6 +548,7 @@ remote_docker run --rm \
   -e WORKCELL_CONTAINER_SMOKE_DOCKER_CONTEXT=default \
   -e WORKCELL_DOCKER_HOST_HOME_ROOT="${REMOTE_HOME}" \
   -e WORKCELL_DOCKER_HOST_WORKSPACE_ROOT="${REMOTE_DIR}/repo" \
+  -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC=1 \
   -e WORKCELL_REMOTE_BUILDKIT_LOCAL_CA=/host-local-ca \
   -e WORKCELL_REMOTE_BUILDKIT_SSL_CERTS=/host-ssl-certs \
   -e WORKCELL_REPRO_PLATFORMS=linux/amd64 \
@@ -571,6 +579,10 @@ cleanup_remote_builder() {
 trap cleanup_remote_builder EXIT
 
 cd /workspace
+
+mkdir -p /workspace/tmp
+chown "${WORKCELL_TEST_HOST_UID}:${WORKCELL_TEST_HOST_GID}" /workspace/tmp
+chmod 0755 /workspace/tmp
 
 git init -q
 git config user.name "Workcell Remote Validate"

--- a/scripts/lib/pty_transcript.py
+++ b/scripts/lib/pty_transcript.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Capture a full interactive transcript for a child command via PTY."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import pty
+import sys
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log", required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    command = args.command
+    if command[:1] == ["--"]:
+        command = command[1:]
+    if not command:
+        raise SystemExit("pty_transcript.py requires a command after --")
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        raise SystemExit("pty_transcript.py requires an interactive terminal")
+
+    log_path = Path(args.log).expanduser().resolve()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("wb") as handle:
+        os.chmod(log_path, 0o600)
+        started_at = dt.datetime.now(dt.timezone.utc).isoformat()
+        header = f"# workcell-transcript-v1 start={started_at}\n".encode("utf-8")
+        handle.write(header)
+        handle.flush()
+
+        def stdin_read(fd: int) -> bytes:
+            data = os.read(fd, 1024)
+            if data:
+                handle.write(data)
+                handle.flush()
+            return data
+
+        def master_read(fd: int) -> bytes:
+            data = os.read(fd, 1024)
+            if data:
+                handle.write(data)
+                handle.flush()
+            return data
+
+        status = pty.spawn(command, master_read=master_read, stdin_read=stdin_read)
+        exit_code = 1
+        if os.WIFEXITED(status):
+            exit_code = os.WEXITSTATUS(status)
+        elif os.WIFSIGNALED(status):
+            exit_code = 128 + os.WTERMSIG(status)
+        finished_at = dt.datetime.now(dt.timezone.utc).isoformat()
+        footer = (
+            f"\n# workcell-transcript-v1 end={finished_at} "
+            f"wait_status={status} exit_code={exit_code}\n"
+        ).encode("utf-8")
+        handle.write(footer)
+        handle.flush()
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/render_injection_bundle.py
+++ b/scripts/lib/render_injection_bundle.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 import argparse
 import ast
+import hashlib
 import json
 import os
 from pathlib import Path, PurePosixPath
 import shutil
+import stat
 import sys
 from typing import NoReturn
 
@@ -17,9 +19,18 @@ SUPPORTED_AGENTS = {"codex", "claude", "gemini"}
 SUPPORTED_MODES = {"strict", "build", "breakglass"}
 SUPPORTED_CLASSIFICATIONS = {"public", "secret"}
 RESERVED_SSH_FILENAMES = {"config", "known_hosts"}
+RISKY_SSH_DIRECTIVES = {
+    "identityagent",
+    "include",
+    "localcommand",
+    "proxycommand",
+}
 SESSION_HOME_ROOT = PurePosixPath("/state/agent-home")
 RUN_INJECTED_ROOT = PurePosixPath("/state/injected")
 DIRECT_MOUNT_ROOT = PurePosixPath("/opt/workcell/host-inputs")
+SYSTEM_SYMLINK_ALLOWLIST = (
+    {Path("/var"), Path("/tmp")} if sys.platform == "darwin" else set()
+)
 RESERVED_TARGETS = (
     "/state/agent-home/.codex/AGENTS.md",
     "/state/agent-home/.codex/auth.json",
@@ -83,10 +94,8 @@ def parse_args() -> argparse.Namespace:
 def expand_host_path(raw: str, base: Path) -> Path:
     expanded = Path(os.path.expanduser(raw))
     if not expanded.is_absolute():
-        expanded = (base / expanded).resolve()
-    else:
-        expanded = expanded.resolve()
-    return expanded
+        expanded = base / expanded
+    return Path(os.path.abspath(os.fspath(expanded)))
 
 
 def normalize_container_target(raw: str) -> PurePosixPath:
@@ -213,7 +222,101 @@ def validate_source_path(raw: object, label: str, base: Path) -> Path:
     source = expand_host_path(raw, base)
     if not source.exists():
         die(f"{label} does not exist: {source}")
+    require_no_symlink_in_path_chain(source, label)
     return source
+
+
+def require_no_symlink(path: Path, label: str) -> None:
+    if path.is_symlink():
+        die(f"{label} must not be a symlink: {path}")
+
+
+def require_no_symlink_in_path_chain(path: Path, label: str) -> None:
+    current = path
+    while True:
+        if current.is_symlink() and current not in SYSTEM_SYMLINK_ALLOWLIST:
+            die(f"{label} must not be a symlink: {current}")
+        if current.parent == current:
+            return
+        current = current.parent
+
+
+def require_secret_owner_only(path: Path, label: str) -> None:
+    path_stat = path.lstat()
+    expected_uid = os.getuid()
+    if path_stat.st_uid != expected_uid:
+        die(f"{label} must be owned by uid {expected_uid}: {path}")
+    if stat.S_IMODE(path_stat.st_mode) & 0o077:
+        die(f"{label} must not be group/world-accessible: {path}")
+
+
+def validate_secret_file(source: Path, label: str) -> Path:
+    require_no_symlink(source, label)
+    if not source.is_file():
+        die(f"{label} must point at a file: {source}")
+    require_secret_owner_only(source, label)
+    return source
+
+
+def validate_secret_tree(source: Path, label: str) -> Path:
+    require_no_symlink(source, label)
+    if source.is_file():
+        return validate_secret_file(source, label)
+    if not source.is_dir():
+        die(f"{label} must point at a file or directory: {source}")
+    require_secret_owner_only(source, label)
+    ensure_no_symlinks_within(source)
+    for child in source.rglob("*"):
+        require_no_symlink(child, label)
+        require_secret_owner_only(child, label)
+    return source
+
+
+def validate_known_hosts_file(source: Path, label: str) -> Path:
+    require_no_symlink(source, label)
+    if not source.is_file():
+        die(f"{label} must point at a file: {source}")
+    path_stat = source.lstat()
+    if stat.S_IMODE(path_stat.st_mode) & 0o022:
+        die(f"{label} must not be group/world-writable: {source}")
+    return source
+
+
+def parse_ssh_directive(line: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    parts = stripped.split(None, 1)
+    directive = parts[0].lower()
+    remainder = parts[1] if len(parts) > 1 else ""
+    return directive, remainder
+
+
+def validate_ssh_config_safety(source: Path, allow_unsafe: bool) -> None:
+    if allow_unsafe:
+        return
+    for lineno, raw_line in enumerate(
+        source.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        parsed = parse_ssh_directive(raw_line)
+        if parsed is None:
+            continue
+        directive, remainder = parsed
+        if directive in RISKY_SSH_DIRECTIVES:
+            die(
+                f"ssh.config contains unsafe directive {directive!r} at line {lineno}; "
+                "set ssh.allow_unsafe_config = true only when you explicitly accept lower assurance"
+            )
+        if directive == "match" and " exec " in f" {remainder.lower()} ":
+            die(
+                "ssh.config contains unsafe Match exec at line "
+                f"{lineno}; set ssh.allow_unsafe_config = true only when you explicitly accept lower assurance"
+            )
+
+
+def policy_sha256(policy_path: Path) -> str:
+    return f"sha256:{hashlib.sha256(policy_path.read_bytes()).hexdigest()}"
 
 
 def load_policy(policy_path: Path) -> dict:
@@ -298,6 +401,23 @@ def parse_toml_subset(content: str, policy_path: Path) -> dict:
 
         if line.startswith("[") and line.endswith("]"):
             table_name = line[1:-1].strip()
+            if table_name.startswith("credentials."):
+                credential_key = table_name.split(".", 1)[1]
+                if credential_key not in CREDENTIAL_CONTAINER_PATHS:
+                    die(
+                        f"{policy_path}:{lineno}: unsupported credentials table "
+                        f"[{table_name}]"
+                    )
+                credentials = root.setdefault("credentials", {})
+                if not isinstance(credentials, dict):
+                    die(f"{policy_path}:{lineno}: credentials must remain a table")
+                entry = credentials.setdefault(credential_key, {})
+                if not isinstance(entry, dict):
+                    die(
+                        f"{policy_path}:{lineno}: credentials.{credential_key} must remain a table"
+                    )
+                current = entry
+                continue
             if table_name not in {"documents", "ssh", "credentials"}:
                 die(f"{policy_path}:{lineno}: unsupported table [{table_name}]")
             table = root.setdefault(table_name, {})
@@ -390,6 +510,7 @@ def render_copies(
         file_mode, dir_mode = classification_modes(classification, is_dir=(staged_kind == "dir"))
         rendered_source: dict[str, str] | str
         if classification == "secret":
+            validate_secret_tree(source, "copies.source")
             rendered_source = direct_mount_entry(source, mount_path)
         else:
             staged_kind = copy_source(source, output_root / relpath)
@@ -421,7 +542,15 @@ def render_ssh(
         die("ssh must be a TOML table")
     validate_allowed_keys(
         ssh,
-        {"enabled", "config", "known_hosts", "identities", "providers", "modes"},
+        {
+            "enabled",
+            "config",
+            "known_hosts",
+            "identities",
+            "providers",
+            "modes",
+            "allow_unsafe_config",
+        },
         "ssh",
     )
 
@@ -437,18 +566,30 @@ def render_ssh(
         return {}
 
     rendered: dict[str, object] = {"identities": []}
+    allow_unsafe_config = ssh.get("allow_unsafe_config", False)
+    if not isinstance(allow_unsafe_config, bool):
+        die("ssh.allow_unsafe_config must be a boolean when specified")
     config = ssh.get("config")
+    if config is None:
+        rendered["config_assurance"] = "no-config"
+    elif allow_unsafe_config:
+        rendered["config_assurance"] = "lower-assurance-unsafe-config"
+    else:
+        rendered["config_assurance"] = "safe"
     if config is not None:
-        source = validate_source_path(config, "ssh.config", policy_dir)
-        if not source.is_file():
-            die(f"ssh.config must point at a file: {source}")
+        source = validate_secret_file(
+            validate_source_path(config, "ssh.config", policy_dir),
+            "ssh.config",
+        )
+        validate_ssh_config_safety(source, allow_unsafe_config)
         rendered["config"] = direct_mount_entry(source, f"{DIRECT_MOUNT_ROOT}/ssh/config")
 
     known_hosts = ssh.get("known_hosts")
     if known_hosts is not None:
-        source = validate_source_path(known_hosts, "ssh.known_hosts", policy_dir)
-        if not source.is_file():
-            die(f"ssh.known_hosts must point at a file: {source}")
+        source = validate_known_hosts_file(
+            validate_source_path(known_hosts, "ssh.known_hosts", policy_dir),
+            "ssh.known_hosts",
+        )
         rendered["known_hosts"] = direct_mount_entry(
             source, f"{DIRECT_MOUNT_ROOT}/ssh/known_hosts"
         )
@@ -461,9 +602,10 @@ def render_ssh(
     rendered_identities: list[dict[str, str]] = []
     seen_identity_targets: set[str] = set()
     for index, raw in enumerate(identities):
-        source = validate_source_path(raw, f"ssh.identities[{index}]", policy_dir)
-        if not source.is_file():
-            die(f"ssh.identities[{index}] must point at a file: {source}")
+        source = validate_secret_file(
+            validate_source_path(raw, f"ssh.identities[{index}]", policy_dir),
+            f"ssh.identities[{index}]",
+        )
         if source.name in RESERVED_SSH_FILENAMES:
             die(
                 f"ssh.identities[{index}] basename collides with a reserved SSH file: {source.name}"
@@ -488,6 +630,7 @@ def render_credentials(
     policy: dict,
     policy_dir: Path,
     agent: str,
+    mode: str,
 ) -> dict:
     credentials = policy.get("credentials", {})
     if credentials is None:
@@ -503,9 +646,38 @@ def render_credentials(
         raw = credentials.get(key)
         if raw is None:
             continue
-        source = validate_source_path(raw, f"credentials.{key}", policy_dir)
-        if not source.is_file():
-            die(f"credentials.{key} must point at a file: {source}")
+        providers = None
+        modes = None
+        source_raw = raw
+        if isinstance(raw, dict):
+            validate_allowed_keys(
+                raw,
+                {"source", "providers", "modes"},
+                f"credentials.{key}",
+            )
+            source_raw = raw.get("source")
+            providers = raw.get("providers")
+            modes = raw.get("modes")
+        elif not isinstance(raw, str):
+            die(f"credentials.{key} must be a string path or a table")
+        if not selected_for(
+            providers,
+            agent,
+            f"credentials.{key}.providers",
+            SUPPORTED_AGENTS,
+        ):
+            continue
+        if not selected_for(
+            modes,
+            mode,
+            f"credentials.{key}.modes",
+            SUPPORTED_MODES,
+        ):
+            continue
+        source = validate_secret_file(
+            validate_source_path(source_raw, f"credentials.{key}", policy_dir),
+            f"credentials.{key}",
+        )
         rendered[key] = {
             "source": str(source),
             "mount_path": CREDENTIAL_CONTAINER_PATHS[key],
@@ -522,16 +694,33 @@ def main() -> int:
     output_root.chmod(0o700)
 
     policy = load_policy(policy_path)
+    rendered_documents = render_documents(policy, output_root, policy_path.parent)
+    rendered_copies = render_copies(
+        policy, output_root, policy_path.parent, args.agent, args.mode
+    )
+    rendered_credentials = render_credentials(
+        policy, policy_path.parent, args.agent, args.mode
+    )
+    rendered_ssh = render_ssh(policy, output_root, policy_path.parent, args.agent, args.mode)
     manifest = {
         "version": 1,
-        "documents": render_documents(policy, output_root, policy_path.parent),
-        "copies": render_copies(
-            policy, output_root, policy_path.parent, args.agent, args.mode
-        ),
-        "credentials": render_credentials(
-            policy, policy_path.parent, args.agent
-        ),
-        "ssh": render_ssh(policy, output_root, policy_path.parent, args.agent, args.mode),
+        "metadata": {
+            "policy_sha256": policy_sha256(policy_path),
+            "credential_keys": sorted(rendered_credentials),
+            "secret_copy_targets": sorted(
+                entry["target"]
+                for entry in rendered_copies
+                if entry.get("classification") == "secret"
+            ),
+            "ssh_enabled": bool(rendered_ssh),
+            "ssh_config_assurance": rendered_ssh.get("config_assurance", "off")
+            if rendered_ssh
+            else "off",
+        },
+        "documents": rendered_documents,
+        "copies": rendered_copies,
+        "credentials": rendered_credentials,
+        "ssh": rendered_ssh,
     }
 
     manifest_path = output_root / "manifest.json"

--- a/scripts/pre-merge.sh
+++ b/scripts/pre-merge.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATOR_DOCKERFILE="${ROOT_DIR}/tools/validator/Dockerfile"
+VALIDATOR_IMAGE_DEFAULT_TAG="workcell-validator:local-premerge-$(cksum "${VALIDATOR_DOCKERFILE}" | awk '{print $1}')"
+VALIDATOR_IMAGE="${WORKCELL_VALIDATOR_IMAGE:-${VALIDATOR_IMAGE_DEFAULT_TAG}}"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -C "${ROOT_DIR}" log -1 --pretty=%ct 2>/dev/null || printf '0')}"
+REBUILD_VALIDATOR=0
+RUN_REMOTE=0
+RUN_RELEASE_BUNDLE=1
+RUN_REPRO=1
+ALLOW_DIRTY=0
+REMOTE_HOST=""
+REMOTE_CONFIG=""
+REMOTE_SNAPSHOT="index"
+REMOTE_SNAPSHOT_EXPLICIT=0
+REMOTE_INCLUDE_UNTRACKED=0
+REMOTE_KEEP_DIR=0
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Run the standard local pre-merge verification stack, and optionally the remote
+linux/amd64 validation lane.
+
+Options:
+  --allow-dirty             Run against the live worktree even when it is dirty
+  --rebuild-validator        Rebuild the local validator image before validation
+  --skip-release-bundle      Skip verify-release-bundle.sh
+  --skip-repro               Skip verify-reproducible-build.sh
+  --remote                   Also run dev-remote-validate.sh with all checks
+  --remote-host <user@host>  Override the remote builder host for this run
+  --remote-config <path>     Override the host-local remote config file
+  --remote-snapshot <mode>   Remote snapshot mode: head, index, or worktree
+  --include-untracked        Include untracked files with --remote-snapshot worktree
+  --keep-remote-dir          Preserve the remote temp directory after exit
+  -h, --help                 Show this help
+EOF
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required tool: $1" >&2
+    exit 1
+  }
+}
+
+require_clean_tree() {
+  local status_output=""
+
+  status_output="$(git -C "${ROOT_DIR}" status --short --untracked-files=all)"
+  if [[ -n "${status_output}" ]]; then
+    echo "pre-merge requires a clean worktree, including untracked files, by default." >&2
+    echo "Commit or stash local changes first, or rerun with --allow-dirty when you intentionally want to validate the live worktree." >&2
+    printf '%s\n' "${status_output}" >&2
+    exit 2
+  fi
+}
+
+has_untracked_files() {
+  local status_output="${1:-}"
+  grep -qE '^\?\?' <<<"${status_output}"
+}
+
+resolve_remote_snapshot_policy() {
+  local status_output=""
+
+  [[ "${RUN_REMOTE}" -eq 1 ]] || return 0
+  [[ "${ALLOW_DIRTY}" -eq 1 ]] || return 0
+
+  status_output="$(git -C "${ROOT_DIR}" status --short --untracked-files=all)"
+  [[ -n "${status_output}" ]] || return 0
+
+  if [[ "${REMOTE_SNAPSHOT_EXPLICIT}" -eq 0 ]]; then
+    REMOTE_SNAPSHOT="worktree"
+    if has_untracked_files "${status_output}"; then
+      REMOTE_INCLUDE_UNTRACKED=1
+      echo "[pre-merge] dirty worktree requested; remote validation will use --remote-snapshot worktree --include-untracked to match the local artifact." >&2
+    else
+      echo "[pre-merge] dirty worktree requested; remote validation will use --remote-snapshot worktree to match the local artifact." >&2
+    fi
+    return 0
+  fi
+
+  if [[ "${REMOTE_SNAPSHOT}" != "worktree" ]]; then
+    echo "[pre-merge] warning: --allow-dirty validates the live worktree locally, but remote validation will use --remote-snapshot ${REMOTE_SNAPSHOT}." >&2
+  elif has_untracked_files "${status_output}" && [[ "${REMOTE_INCLUDE_UNTRACKED}" -eq 0 ]]; then
+    echo "[pre-merge] warning: local validation sees untracked files, but remote worktree validation will exclude them without --include-untracked." >&2
+  fi
+}
+
+build_validator_image() {
+  if [[ "${REBUILD_VALIDATOR}" -eq 0 ]] && docker image inspect "${VALIDATOR_IMAGE}" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  docker build \
+    -f "${ROOT_DIR}/tools/validator/Dockerfile" \
+    -t "${VALIDATOR_IMAGE}" \
+    "${ROOT_DIR}"
+}
+
+run_remote_validation() {
+  local -a cmd=("${ROOT_DIR}/scripts/dev-remote-validate.sh")
+
+  [[ -n "${REMOTE_CONFIG}" ]] && cmd+=(--config "${REMOTE_CONFIG}")
+  [[ -n "${REMOTE_HOST}" ]] && cmd+=(--host "${REMOTE_HOST}")
+  cmd+=(--snapshot "${REMOTE_SNAPSHOT}")
+  [[ "${REMOTE_INCLUDE_UNTRACKED}" -eq 1 ]] && cmd+=(--include-untracked)
+  [[ "${REMOTE_KEEP_DIR}" -eq 1 ]] && cmd+=(--keep-remote-dir)
+  cmd+=(--check validate --check smoke --check repro --check release-bundle)
+
+  "${cmd[@]}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-dirty)
+      ALLOW_DIRTY=1
+      shift
+      ;;
+    --rebuild-validator)
+      REBUILD_VALIDATOR=1
+      shift
+      ;;
+    --skip-release-bundle)
+      RUN_RELEASE_BUNDLE=0
+      shift
+      ;;
+    --skip-repro)
+      RUN_REPRO=0
+      shift
+      ;;
+    --remote)
+      RUN_REMOTE=1
+      shift
+      ;;
+    --remote-host)
+      REMOTE_HOST="${2-}"
+      [[ -n "${REMOTE_HOST}" ]] || {
+        echo "Option --remote-host requires a value." >&2
+        usage >&2
+        exit 2
+      }
+      shift 2
+      ;;
+    --remote-config)
+      REMOTE_CONFIG="${2-}"
+      [[ -n "${REMOTE_CONFIG}" ]] || {
+        echo "Option --remote-config requires a value." >&2
+        usage >&2
+        exit 2
+      }
+      shift 2
+      ;;
+    --remote-snapshot)
+      REMOTE_SNAPSHOT="${2-}"
+      [[ -n "${REMOTE_SNAPSHOT}" ]] || {
+        echo "Option --remote-snapshot requires a value." >&2
+        usage >&2
+        exit 2
+      }
+      REMOTE_SNAPSHOT_EXPLICIT=1
+      shift 2
+      ;;
+    --include-untracked)
+      REMOTE_INCLUDE_UNTRACKED=1
+      shift
+      ;;
+    --keep-remote-dir)
+      REMOTE_KEEP_DIR=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_tool docker
+require_tool git
+
+if [[ "${ALLOW_DIRTY}" -eq 0 ]]; then
+  require_clean_tree
+fi
+
+resolve_remote_snapshot_policy
+
+echo "[pre-merge] pinned-input policy"
+"${ROOT_DIR}/scripts/check-pinned-inputs.sh"
+
+echo "[pre-merge] upstream Codex release verification"
+"${ROOT_DIR}/scripts/verify-upstream-codex-release.sh"
+
+echo "[pre-merge] building validator image"
+build_validator_image
+
+echo "[pre-merge] workflow lint and policy analysis"
+"${ROOT_DIR}/scripts/check-workflows.sh"
+
+echo "[pre-merge] repository validation in validator container"
+docker run --rm \
+  -v "${ROOT_DIR}:/workspace" \
+  -w /workspace \
+  "${VALIDATOR_IMAGE}" \
+  ./scripts/validate-repo.sh
+
+echo "[pre-merge] host launcher invariants"
+"${ROOT_DIR}/scripts/verify-invariants.sh"
+
+echo "[pre-merge] container smoke"
+"${ROOT_DIR}/scripts/container-smoke.sh"
+
+if [[ "${RUN_RELEASE_BUNDLE}" -eq 1 ]]; then
+  echo "[pre-merge] release bundle reproducibility"
+  WORKCELL_VALIDATOR_IMAGE="${VALIDATOR_IMAGE}" \
+    SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}" \
+    "${ROOT_DIR}/scripts/verify-release-bundle.sh"
+fi
+
+if [[ "${RUN_REPRO}" -eq 1 ]]; then
+  echo "[pre-merge] runtime reproducibility"
+  SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}" \
+    "${ROOT_DIR}/scripts/verify-reproducible-build.sh"
+fi
+
+if [[ "${RUN_REMOTE}" -eq 1 ]]; then
+  echo "[pre-merge] remote linux/amd64 validation"
+  SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}" run_remote_validation
+fi
+
+echo "Workcell pre-merge validation passed."

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -68,6 +68,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/generate-release-checksums.sh"
   "${ROOT_DIR}/scripts/generate-build-input-manifest.sh"
   "${ROOT_DIR}/scripts/install.sh"
+  "${ROOT_DIR}/scripts/pre-merge.sh"
   "${ROOT_DIR}/scripts/publish-github-release.sh"
   "${ROOT_DIR}/scripts/run-hosted-controls-audit.sh"
   "${ROOT_DIR}/scripts/run-mutation-tests.sh"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -64,6 +64,16 @@ PY
 ROOT_DRY_RUN_PROFILE_DIR="${REAL_HOME}/.colima/${ROOT_DRY_RUN_PROFILE_NAME}"
 ROOT_DRY_RUN_LIMA_DIR="${REAL_HOME}/.colima/_lima/colima-${ROOT_DRY_RUN_PROFILE_NAME}"
 
+file_mode_octal() {
+  local path="$1"
+
+  if stat -f '%Lp' "${path}" >/dev/null 2>&1; then
+    stat -f '%Lp' "${path}"
+  else
+    stat -c '%a' "${path}"
+  fi
+}
+
 cleanup() {
   rm -rf "${CODEX_VERIFY_HOME}"
   rm -rf "${BARRIER_VERIFY_ROOT}"
@@ -300,6 +310,17 @@ EOF
 cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/config"
 not-an-identity
 EOF
+chmod 0600 \
+  "${INJECTION_POLICY_FIXTURE_ROOT}/secret.txt" \
+  "${INJECTION_POLICY_FIXTURE_ROOT}/codex-auth.json" \
+  "${INJECTION_POLICY_FIXTURE_ROOT}/claude-auth.json" \
+  "${INJECTION_POLICY_FIXTURE_ROOT}/claude-mcp.json" \
+  "${INJECTION_POLICY_FIXTURE_ROOT}/gemini-projects.json" \
+  "${INJECTION_POLICY_FIXTURE_ROOT}/gh-hosts.yml" \
+  "${INJECTION_POLICY_FIXTURE_ROOT}/ssh-config" \
+  "${INJECTION_POLICY_FIXTURE_ROOT}/known_hosts" \
+  "${INJECTION_POLICY_FIXTURE_ROOT}/id_test" \
+  "${INJECTION_POLICY_FIXTURE_ROOT}/config"
 cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/policy.toml"
 version = 1
 
@@ -1411,6 +1432,9 @@ STRICT_PREFLIGHT_WORKSPACE="${BARRIER_VERIFY_ROOT}/strict-preflight-workspace"
 mkdir -p "${STRICT_PREFLIGHT_WORKSPACE}"
 printf '# marker\n' >"${STRICT_PREFLIGHT_WORKSPACE}/AGENTS.md"
 STRICT_PREFLIGHT_PROFILE="workcell-preflight-$$"
+rm -rf \
+  "${REAL_HOME}/.colima/${STRICT_PREFLIGHT_PROFILE}" \
+  "${REAL_HOME}/.colima/_lima/colima-${STRICT_PREFLIGHT_PROFILE}"
 if "${ROOT_DIR}/scripts/workcell" \
   --agent codex \
   --workspace "${STRICT_PREFLIGHT_WORKSPACE}/missing" \
@@ -1428,15 +1452,16 @@ if "${ROOT_DIR}/scripts/workcell" \
   echo "Expected strict mode without a prepared image marker to fail fast before launch" >&2
   exit 1
 fi
-grep -q "No reviewed runtime image is recorded for strict mode" /tmp/workcell-strict-preflight.out
+grep -q "No prepared runtime image is recorded for strict mode" /tmp/workcell-strict-preflight.out
 grep -q -- '--prepare' /tmp/workcell-strict-preflight.out
 if grep -q "starting colima" /tmp/workcell-strict-preflight.out; then
-  echo "Strict preflight should fail before Colima startup when the reviewed image marker is absent" >&2
+  echo "Strict preflight should fail before Colima startup when the prepared image marker is absent" >&2
   exit 1
 fi
 
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent codex \
+  --no-default-injection-policy \
   --allow-nongit-workspace \
   --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
   --colima-profile "${STRICT_PREFLIGHT_PROFILE}" \
@@ -1446,6 +1471,401 @@ if ! "${ROOT_DIR}/scripts/workcell" \
   exit 1
 fi
 grep -q 'docker run' /tmp/workcell-dry-run-no-image.out
+grep -q 'cache_profile=off' /tmp/workcell-dry-run-no-image.out
+grep -q 'cache_assurance=managed-no-persistent-cache' /tmp/workcell-dry-run-no-image.out
+
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --no-default-injection-policy \
+  --allow-nongit-workspace \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}" \
+  --inspect >/tmp/workcell-inspect.out 2>&1; then
+  echo "Expected --inspect to succeed without launching the runtime" >&2
+  exit 1
+fi
+grep -q '^profile='"${STRICT_PREFLIGHT_PROFILE}"'$' /tmp/workcell-inspect.out
+grep -q '^workspace_status=marker-only$' /tmp/workcell-inspect.out
+grep -q '^cache_profile=off$' /tmp/workcell-inspect.out
+grep -q '^cache_assurance=managed-no-persistent-cache$' /tmp/workcell-inspect.out
+grep -q '^injection_policy=none$' /tmp/workcell-inspect.out
+if ! "${ROOT_DIR}/scripts/workcell" \
+  inspect \
+  --agent codex \
+  --no-default-injection-policy \
+  --allow-nongit-workspace \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}" >/tmp/workcell-inspect-subcommand.out 2>&1; then
+  echo "Expected inspect subcommand alias to succeed without launching the runtime" >&2
+  exit 1
+fi
+grep -q '^profile='"${STRICT_PREFLIGHT_PROFILE}"'$' /tmp/workcell-inspect-subcommand.out
+
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --no-default-injection-policy \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-inspect" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}-missing-inspect" \
+  --inspect >/tmp/workcell-inspect-missing.out 2>&1; then
+  echo "Expected --inspect to succeed even when the workspace is missing" >&2
+  exit 1
+fi
+grep -q '^profile='"${STRICT_PREFLIGHT_PROFILE}-missing-inspect"'$' /tmp/workcell-inspect-missing.out
+grep -Eq '^workspace=.*/missing-workspace-for-inspect$' /tmp/workcell-inspect-missing.out
+grep -q '^workspace_status=missing$' /tmp/workcell-inspect-missing.out
+
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --no-default-injection-policy \
+  --allow-nongit-workspace \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}" \
+  --doctor >/tmp/workcell-doctor.out 2>&1; then
+  echo "Expected --doctor to succeed without launching the runtime" >&2
+  exit 1
+fi
+grep -q '^doctor_profile_state=absent$' /tmp/workcell-doctor.out
+grep -q '^doctor_prepared_image=0$' /tmp/workcell-doctor.out
+grep -q -- '--prepare' /tmp/workcell-doctor.out
+if ! "${ROOT_DIR}/scripts/workcell" \
+  doctor \
+  --agent codex \
+  --no-default-injection-policy \
+  --allow-nongit-workspace \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}" >/tmp/workcell-doctor-subcommand.out 2>&1; then
+  echo "Expected doctor subcommand alias to succeed without launching the runtime" >&2
+  exit 1
+fi
+grep -q '^doctor_profile_state=absent$' /tmp/workcell-doctor-subcommand.out
+
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --no-default-injection-policy \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-doctor" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}-missing-doctor" \
+  --doctor >/tmp/workcell-doctor-missing.out 2>&1; then
+  echo "Expected --doctor to succeed even when the workspace is missing" >&2
+  exit 1
+fi
+grep -q '^doctor_profile_state=absent$' /tmp/workcell-doctor-missing.out
+grep -Eq '^workspace=.*/missing-workspace-for-doctor$' /tmp/workcell-doctor-missing.out
+grep -q '^workspace_status=missing$' /tmp/workcell-doctor-missing.out
+grep -q '^doctor_recommended_next=fix-workspace$' /tmp/workcell-doctor-missing.out
+
+STALE_MARKER_PROFILE="${STRICT_PREFLIGHT_PROFILE}-stale"
+STALE_MARKER_DIR="${REAL_HOME}/.colima/${STALE_MARKER_PROFILE}"
+rm -rf "${STALE_MARKER_DIR}" "${REAL_HOME}/.colima/_lima/colima-${STALE_MARKER_PROFILE}"
+mkdir -p "${STALE_MARKER_DIR}"
+printf '%s\n' "${STRICT_PREFLIGHT_WORKSPACE}" >"${STALE_MARKER_DIR}/workcell.managed"
+cat >"${STALE_MARKER_DIR}/workcell.image-ready" <<'EOF'
+image_tag=workcell:local
+image_id=sha256:stale
+source_date_epoch=0
+EOF
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --no-default-injection-policy \
+  --allow-nongit-workspace \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --colima-profile "${STALE_MARKER_PROFILE}" \
+  --doctor >/tmp/workcell-doctor-stale.out 2>&1; then
+  echo "Expected stale-marker --doctor to succeed without launching the runtime" >&2
+  exit 1
+fi
+grep -q '^current_image_id=none$' /tmp/workcell-doctor-stale.out
+grep -q '^doctor_prepared_image=0$' /tmp/workcell-doctor-stale.out
+grep -q -- '--prepare' /tmp/workcell-doctor-stale.out
+rm -rf "${STALE_MARKER_DIR}" "${REAL_HOME}/.colima/_lima/colima-${STALE_MARKER_PROFILE}"
+
+DEBUG_LOG_CAPTURE="${BARRIER_VERIFY_ROOT}/debug/session.log"
+DEBUG_LOG_PROFILE="${STRICT_PREFLIGHT_PROFILE}-logs"
+rm -rf "$(dirname "${DEBUG_LOG_CAPTURE}")"
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --allow-nongit-workspace \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}" \
+  --debug-log "${DEBUG_LOG_CAPTURE}" \
+  --dry-run >/tmp/workcell-debug-log.out 2>&1; then
+  echo "Expected --debug-log dry-run to succeed" >&2
+  exit 1
+fi
+test -f "${DEBUG_LOG_CAPTURE}"
+test "$(file_mode_octal "${DEBUG_LOG_CAPTURE}")" = "600"
+grep -q 'Workcell warning: full host-persisted debug log capture is enabled for this session:' /tmp/workcell-debug-log.out
+grep -q 'execution_path=' "${DEBUG_LOG_CAPTURE}"
+mkdir -p "${REAL_HOME}/.colima/${DEBUG_LOG_PROFILE}"
+printf '%s\n' "${DEBUG_LOG_CAPTURE}" >"${REAL_HOME}/.colima/${DEBUG_LOG_PROFILE}/workcell.latest-debug-log"
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --logs debug \
+  --colima-profile "${DEBUG_LOG_PROFILE}" >/tmp/workcell-logs-debug.out 2>&1; then
+  echo "Expected --logs debug to print the latest retained debug log" >&2
+  exit 1
+fi
+grep -q 'execution_path=' /tmp/workcell-logs-debug.out
+
+TRANSCRIPT_CAPTURE="${BARRIER_VERIFY_ROOT}/debug/session.transcript"
+TRANSCRIPT_LOG_PROFILE="${STRICT_PREFLIGHT_PROFILE}-transcript-logs"
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --allow-nongit-workspace \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}" \
+  --audit-transcript "${TRANSCRIPT_CAPTURE}" \
+  --dry-run >/tmp/workcell-transcript.out 2>&1; then
+  echo "Expected --audit-transcript dry-run to succeed" >&2
+  exit 1
+fi
+printf 'sample transcript line\n' >"${TRANSCRIPT_CAPTURE}"
+mkdir -p "${REAL_HOME}/.colima/${TRANSCRIPT_LOG_PROFILE}"
+printf '%s\n' "${TRANSCRIPT_CAPTURE}" >"${REAL_HOME}/.colima/${TRANSCRIPT_LOG_PROFILE}/workcell.latest-transcript-log"
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --logs transcript \
+  --colima-profile "${TRANSCRIPT_LOG_PROFILE}" >/tmp/workcell-logs-transcript.out 2>&1; then
+  echo "Expected --logs transcript to print the latest retained transcript log" >&2
+  exit 1
+fi
+grep -q 'sample transcript line' /tmp/workcell-logs-transcript.out
+if ! "${ROOT_DIR}/scripts/workcell" \
+  logs transcript \
+  --colima-profile "${TRANSCRIPT_LOG_PROFILE}" >/tmp/workcell-logs-transcript-subcommand.out 2>&1; then
+  echo "Expected logs subcommand alias to print the latest retained transcript log" >&2
+  exit 1
+fi
+grep -q 'sample transcript line' /tmp/workcell-logs-transcript-subcommand.out
+if ! "${ROOT_DIR}/scripts/workcell" logs --help >/tmp/workcell-logs-help.out 2>&1; then
+  echo "Expected logs subcommand help to succeed" >&2
+  exit 1
+fi
+grep -q 'Print the latest retained log of the selected type' /tmp/workcell-logs-help.out
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --logs transcript \
+  --colima-profile "${TRANSCRIPT_LOG_PROFILE}" \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-logs" >/tmp/workcell-logs-transcript-missing-workspace.out 2>&1; then
+  echo "Expected --logs transcript to ignore a nonexistent workspace path" >&2
+  exit 1
+fi
+grep -q 'sample transcript line' /tmp/workcell-logs-transcript-missing-workspace.out
+rm -rf "${REAL_HOME}/.colima/${DEBUG_LOG_PROFILE}" "${REAL_HOME}/.colima/${TRANSCRIPT_LOG_PROFILE}"
+
+AUTH_STATUS_ROOT="${BARRIER_VERIFY_ROOT}/auth-status"
+mkdir -p "${AUTH_STATUS_ROOT}"
+printf '{}\n' >"${AUTH_STATUS_ROOT}/auth.json"
+chmod 0600 "${AUTH_STATUS_ROOT}/auth.json"
+printf '{"token":"claude-auth"}\n' >"${AUTH_STATUS_ROOT}/claude-auth.json"
+chmod 0600 "${AUTH_STATUS_ROOT}/claude-auth.json"
+printf 'claude-key\n' >"${AUTH_STATUS_ROOT}/claude-api-key.txt"
+chmod 0600 "${AUTH_STATUS_ROOT}/claude-api-key.txt"
+printf 'GEMINI_API_KEY=verify-gemini-key\n' >"${AUTH_STATUS_ROOT}/gemini.env"
+chmod 0600 "${AUTH_STATUS_ROOT}/gemini.env"
+printf '{"type":"authorized_user"}\n' >"${AUTH_STATUS_ROOT}/gcloud-adc.json"
+chmod 0600 "${AUTH_STATUS_ROOT}/gcloud-adc.json"
+cat >"${AUTH_STATUS_ROOT}/hosts.yml" <<'EOF'
+github.com:
+  oauth_token: test-token
+EOF
+chmod 0600 "${AUTH_STATUS_ROOT}/hosts.yml"
+cat >"${AUTH_STATUS_ROOT}/ssh-config" <<'EOF'
+ProxyCommand nc %h %p
+EOF
+chmod 0600 "${AUTH_STATUS_ROOT}/ssh-config"
+cat >"${AUTH_STATUS_ROOT}/policy.toml" <<'EOF'
+version = 1
+[credentials]
+codex_auth = "auth.json"
+claude_auth = "claude-auth.json"
+claude_api_key = "claude-api-key.txt"
+gemini_env = "gemini.env"
+gcloud_adc = "gcloud-adc.json"
+github_hosts = "hosts.yml"
+[ssh]
+enabled = true
+config = "ssh-config"
+allow_unsafe_config = true
+EOF
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
+  --auth-status >/tmp/workcell-auth-status.out 2>&1; then
+  echo "Expected --auth-status to succeed" >&2
+  exit 1
+fi
+grep -Eq '^credential_keys=(codex_auth,github_hosts|github_hosts,codex_auth)$' /tmp/workcell-auth-status.out
+grep -q '^provider_auth_mode=codex_auth$' /tmp/workcell-auth-status.out
+grep -q '^provider_auth_modes=codex_auth$' /tmp/workcell-auth-status.out
+grep -q '^shared_auth_modes=github_hosts$' /tmp/workcell-auth-status.out
+grep -q '^github_auth_present=1$' /tmp/workcell-auth-status.out
+grep -q '^ssh_injected=1$' /tmp/workcell-auth-status.out
+grep -q '^ssh_config_assurance=lower-assurance-unsafe-config$' /tmp/workcell-auth-status.out
+if ! "${ROOT_DIR}/scripts/workcell" \
+  auth-status \
+  --agent codex \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" >/tmp/workcell-auth-status-subcommand.out 2>&1; then
+  echo "Expected auth-status subcommand alias to succeed" >&2
+  exit 1
+fi
+grep -q '^provider_auth_mode=codex_auth$' /tmp/workcell-auth-status-subcommand.out
+grep -q '^shared_auth_modes=github_hosts$' /tmp/workcell-auth-status-subcommand.out
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent claude \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
+  --auth-status >/tmp/workcell-auth-status-claude.out 2>&1; then
+  echo "Expected Claude --auth-status to succeed" >&2
+  exit 1
+fi
+grep -q '^provider_auth_mode=claude_api_key$' /tmp/workcell-auth-status-claude.out
+grep -q '^provider_auth_modes=claude_api_key,claude_auth$' /tmp/workcell-auth-status-claude.out
+grep -q '^shared_auth_modes=github_hosts$' /tmp/workcell-auth-status-claude.out
+grep -q '^github_auth_present=1$' /tmp/workcell-auth-status-claude.out
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
+  --auth-status >/tmp/workcell-auth-status-gemini.out 2>&1; then
+  echo "Expected Gemini --auth-status to succeed" >&2
+  exit 1
+fi
+grep -q '^provider_auth_mode=gemini_env$' /tmp/workcell-auth-status-gemini.out
+grep -q '^provider_auth_modes=gemini_env,gcloud_adc$' /tmp/workcell-auth-status-gemini.out
+grep -q '^shared_auth_modes=github_hosts$' /tmp/workcell-auth-status-gemini.out
+grep -q '^github_auth_present=1$' /tmp/workcell-auth-status-gemini.out
+
+BROKEN_DEBUG_POINTER_PROFILE="${STRICT_PREFLIGHT_PROFILE}-broken-debug-pointer"
+mkdir -p "${REAL_HOME}/.colima/${BROKEN_DEBUG_POINTER_PROFILE}"
+printf '%s\n' "${BARRIER_VERIFY_ROOT}/missing-debug.log" >"${REAL_HOME}/.colima/${BROKEN_DEBUG_POINTER_PROFILE}/workcell.latest-debug-log"
+if "${ROOT_DIR}/scripts/workcell" \
+  --inspect \
+  --agent codex \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --debug-log "${BARRIER_VERIFY_ROOT}/debug/nonlaunch.log" >/tmp/workcell-nonlaunch-debug-log.out 2>&1; then
+  echo "Expected non-launch --inspect to reject --debug-log" >&2
+  exit 1
+fi
+grep -q -- '--debug-log and --audit-transcript apply only to launched sessions.' /tmp/workcell-nonlaunch-debug-log.out
+
+if ! "${ROOT_DIR}/scripts/workcell" --gc --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-gc" >/tmp/workcell-gc.out 2>&1; then
+  echo "Expected --gc to succeed" >&2
+  exit 1
+fi
+grep -q 'Cleaned stale Workcell injection, session-audit, and broken latest-log pointer state.' /tmp/workcell-gc.out
+test ! -f "${REAL_HOME}/.colima/${BROKEN_DEBUG_POINTER_PROFILE}/workcell.latest-debug-log"
+if ! "${ROOT_DIR}/scripts/workcell" gc --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-gc" >/tmp/workcell-gc-subcommand.out 2>&1; then
+  echo "Expected gc subcommand alias to succeed" >&2
+  exit 1
+fi
+
+PREMERGE_HARNESS_ROOT="${BARRIER_VERIFY_ROOT}/premerge-harness"
+PREMERGE_FAKEBIN="${PREMERGE_HARNESS_ROOT}/fakebin"
+PREMERGE_LOG="${PREMERGE_HARNESS_ROOT}/premerge.log"
+rm -rf "${PREMERGE_HARNESS_ROOT}"
+mkdir -p "${PREMERGE_HARNESS_ROOT}/scripts" "${PREMERGE_HARNESS_ROOT}/tools/validator" "${PREMERGE_FAKEBIN}"
+install -m 0755 "${ROOT_DIR}/scripts/pre-merge.sh" "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh"
+cat >"${PREMERGE_HARNESS_ROOT}/tools/validator/Dockerfile" <<'EOF'
+FROM scratch
+EOF
+for stub in \
+  check-pinned-inputs.sh \
+  verify-upstream-codex-release.sh \
+  check-workflows.sh \
+  validate-repo.sh \
+  verify-invariants.sh \
+  container-smoke.sh \
+  verify-release-bundle.sh \
+  verify-reproducible-build.sh \
+  dev-remote-validate.sh; do
+  cat >"${PREMERGE_HARNESS_ROOT}/scripts/${stub}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s %s\n' "$(basename "$0")" "$*" >>"${PREMERGE_LOG}"
+EOF
+  chmod 0755 "${PREMERGE_HARNESS_ROOT}/scripts/${stub}"
+done
+cat >"${PREMERGE_FAKEBIN}/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1-}" == "-C" ]]; then
+  shift 2
+fi
+case "${1-}" in
+  status)
+    printf '%s' "${WORKCELL_FAKE_GIT_STATUS_OUTPUT:-}"
+    ;;
+  log)
+    printf '%s\n' "${WORKCELL_FAKE_GIT_EPOCH:-1700000000}"
+    ;;
+  *)
+    echo "unexpected git invocation: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod 0755 "${PREMERGE_FAKEBIN}/git"
+cat >"${PREMERGE_FAKEBIN}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\n' "$*" >>"${PREMERGE_LOG}"
+if [[ "${1-}" == "image" && "${2-}" == "inspect" ]]; then
+  exit 1
+fi
+exit 0
+EOF
+chmod 0755 "${PREMERGE_FAKEBIN}/docker"
+
+if PATH="${PREMERGE_FAKEBIN}:${PATH}" \
+  PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_STATUS_OUTPUT='?? stray.txt' \
+  "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" >/tmp/workcell-premerge-dirty.out 2>&1; then
+  echo "Expected pre-merge to reject a dirty worktree by default" >&2
+  exit 1
+fi
+grep -q 'clean worktree, including untracked files' /tmp/workcell-premerge-dirty.out
+
+: >"${PREMERGE_LOG}"
+if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
+  PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
+  "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
+  --allow-dirty \
+  --remote >/tmp/workcell-premerge-allow-dirty.out 2>&1; then
+  echo "Expected --allow-dirty --remote pre-merge harness to succeed" >&2
+  cat /tmp/workcell-premerge-allow-dirty.out >&2
+  exit 1
+fi
+grep -q 'remote validation will use --remote-snapshot worktree --include-untracked' /tmp/workcell-premerge-allow-dirty.out
+grep -q 'dev-remote-validate.sh --snapshot worktree --include-untracked --check validate --check smoke --check repro --check release-bundle' "${PREMERGE_LOG}"
+
+: >"${PREMERGE_LOG}"
+if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
+  PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
+  "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
+  --allow-dirty \
+  --remote \
+  --remote-snapshot index >/tmp/workcell-premerge-remote-index.out 2>&1; then
+  echo "Expected explicit remote snapshot pre-merge harness to succeed" >&2
+  cat /tmp/workcell-premerge-remote-index.out >&2
+  exit 1
+fi
+grep -q 'warning: --allow-dirty validates the live worktree locally, but remote validation will use --remote-snapshot index.' /tmp/workcell-premerge-remote-index.out
+grep -q 'dev-remote-validate.sh --snapshot index --check validate --check smoke --check repro --check release-bundle' "${PREMERGE_LOG}"
+
+: >"${PREMERGE_LOG}"
+if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
+  PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
+  "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
+  --allow-dirty \
+  --remote \
+  --remote-snapshot worktree >/tmp/workcell-premerge-remote-worktree.out 2>&1; then
+  echo "Expected explicit worktree remote snapshot pre-merge harness to succeed" >&2
+  cat /tmp/workcell-premerge-remote-worktree.out >&2
+  exit 1
+fi
+grep -q 'local validation sees untracked files, but remote worktree validation will exclude them without --include-untracked.' /tmp/workcell-premerge-remote-worktree.out
 
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent codex \
@@ -1807,15 +2227,29 @@ done
 if [[ "$(uname -s)" == "Darwin" ]] &&
   host_tool_exists /opt/homebrew/bin/colima /usr/local/bin/colima &&
   host_tool_exists /opt/homebrew/bin/docker /usr/local/bin/docker /Applications/Docker.app/Contents/Resources/bin/docker; then
+  LIVE_DEBUG_PROFILE_NAME="workcell-live-debug-$$"
+  LIVE_DEBUG_LOG="${BARRIER_VERIFY_ROOT}/debug/live-debug.log"
   if ! "${ROOT_DIR}/scripts/workcell" \
     --agent codex \
     --prepare \
+    --rebuild \
     --workspace "${ROOT_DIR}" \
+    --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
+    --debug-log "${LIVE_DEBUG_LOG}" \
     --agent-arg --version >/tmp/workcell-audit-prepare.out 2>&1; then
     echo "Expected audit verification prepare run to seed a managed image" >&2
     cat /tmp/workcell-audit-prepare.out >&2
     exit 1
   fi
+  grep -q 'starting colima' "${LIVE_DEBUG_LOG}"
+  grep -q 'runtime-builder' "${LIVE_DEBUG_LOG}"
+  if ! "${ROOT_DIR}/scripts/workcell" \
+    --logs debug \
+    --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" >/tmp/workcell-live-logs-debug.out 2>&1; then
+    echo "Expected successful prepare run to persist the latest debug-log pointer" >&2
+    exit 1
+  fi
+  grep -q 'starting colima' /tmp/workcell-live-logs-debug.out
   AUDIT_LOG="$(sed -n 's/.*audit_log=\([^ ]*\).*/\1/p' /tmp/workcell-audit-prepare.out | head -n1)"
   if [[ -z "${AUDIT_LOG}" ]]; then
     echo "Expected audit verification prepare run to report an audit log path" >&2
@@ -1829,6 +2263,7 @@ if [[ "$(uname -s)" == "Darwin" ]] &&
     --agent codex \
     --mode build \
     --workspace "${ROOT_DIR}" \
+    --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
     --allow-arbitrary-command \
     --ack-arbitrary-command \
     -- /bin/bash -lc 'sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get update >/dev/null && sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get install -y --no-install-recommends make >/dev/null'; then
@@ -1837,12 +2272,19 @@ if [[ "$(uname -s)" == "Darwin" ]] &&
   fi
   tail -n "+$((AUDIT_BASE_LINES + 1))" "${AUDIT_LOG}" >/tmp/workcell-audit-session.log
   grep -q 'event=launch' /tmp/workcell-audit-session.log
+  grep -q 'record_digest=' /tmp/workcell-audit-session.log
   grep -q 'execution_path=lower-assurance-debug-command' /tmp/workcell-audit-session.log
   grep -q 'event=assurance-change' /tmp/workcell-audit-session.log
   grep -q 'reason=package-mutation' /tmp/workcell-audit-session.log
   grep -q 'session_assurance_final=lower-assurance-package-mutation' /tmp/workcell-audit-session.log
   grep -q 'event=exit' /tmp/workcell-audit-session.log
   grep -q 'package_mutation_downgraded=1' /tmp/workcell-audit-session.log
+  if [[ -x /opt/homebrew/bin/colima ]]; then
+    /opt/homebrew/bin/colima delete --profile "${LIVE_DEBUG_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+  else
+    /usr/local/bin/colima delete --profile "${LIVE_DEBUG_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+  fi
+  rm -rf "${REAL_HOME}/.colima/${LIVE_DEBUG_PROFILE_NAME}" "${REAL_HOME}/.colima/_lima/colima-${LIVE_DEBUG_PROFILE_NAME}"
   AUDIT_RESTORE_PROFILE_NAME="workcell-audit-restore-$$"
   AUDIT_RESTORE_DIR="${REAL_HOME}/.colima/${AUDIT_RESTORE_PROFILE_NAME}"
   AUDIT_RESTORE_LOG="${AUDIT_RESTORE_DIR}/workcell.audit.log"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -90,7 +90,12 @@ COLIMA_PROFILE=""
 BOOTSTRAP_APPLIED=0
 SESSION_AUDIT_DIR=""
 SESSION_AUDIT_STATE_FILE=""
-SESSION_AUDIT_EVENT_FILE=""
+SESSION_AUDIT_CONTAINER_FILE=""
+FINAL_SESSION_ASSURANCE=""
+INJECTION_POLICY_SHA256=""
+INJECTION_CREDENTIAL_KEYS=""
+INJECTION_SSH_ENABLED=0
+INJECTION_SECRET_COPY_TARGETS=""
 
 usage() {
   cat <<'EOF'
@@ -100,6 +105,7 @@ Options:
   --agent codex|claude|gemini   Provider to run (required)
   --agent-autonomy yolo|prompt  Provider approval posture (default: yolo)
   --agent-arg VALUE             Additional provider argv to append (repeatable)
+  --cache-profile off|standard  Opt-in persistent non-secret cache plane (default: off)
   --codex-rules-mutability readonly|session
                                 Codex execpolicy session mutability (default: readonly)
   --container-mutability ephemeral|readonly
@@ -108,10 +114,18 @@ Options:
   --container-memory SIZE       Inner container memory limit (default: profile value)
   --injection-policy PATH       Host-side injection policy to stage into each session
   --no-default-injection-policy Ignore ~/.config/workcell/injection-policy.toml for this launch
+  --log-level normal|debug      Launcher/build verbosity (default: normal)
+  --debug-log PATH              Persist full launcher and container stdout/stderr to PATH
+  --audit-transcript PATH       Persist full interactive terminal transcript to PATH
   --ui cli|gui                  Surface to launch (default: cli)
   --mode strict|build|breakglass
                                 Runtime profile (default: strict)
-  --prepare                     Seed or refresh the reviewed runtime image before launch
+  --doctor                      Validate host/workspace/profile state and print remediation
+  --inspect                     Print derived profile and launch state, then exit
+  --logs audit|debug|transcript Print the latest retained log of the selected type
+  --auth-status                 Print selected injection/auth posture and exit
+  --gc                          Clean stale Workcell temp state and exit
+  --prepare                     Seed or refresh the prepared runtime image before launch
   --repair-profile              Delete a conflicting unmanaged Colima profile before launch
                                 (implies --prepare on strict)
   --ack-breakglass              Required with --mode breakglass
@@ -140,9 +154,17 @@ Workflows:
     workcell --repair-profile --agent codex --workspace /path/to/repo
     workcell --repair-profile --agent claude --workspace /path/to/repo
     workcell --repair-profile --agent gemini --workspace /path/to/repo
+  Operator actions:
+    workcell inspect --agent codex --workspace /path/to/repo
+    workcell doctor --agent codex --workspace /path/to/repo
+    workcell logs debug --colima-profile workcell-...
+    workcell auth-status --agent codex --workspace /path/to/repo
+    workcell gc
 
 Workcell launches the selected provider directly inside the bounded runtime.
 There is no separate container attach/connect step after launch.
+Host-persisted debug logs and full transcripts are explicit lower-assurance
+operator choices and remain off by default.
 EOF
 }
 
@@ -202,12 +224,45 @@ validate_agent_autonomy_name() {
   esac
 }
 
+validate_cache_profile_name() {
+  case "$1" in
+    off | standard) ;;
+    *)
+      echo "Unsupported cache profile: $1" >&2
+      echo "Use --cache-profile off or --cache-profile standard." >&2
+      exit 2
+      ;;
+  esac
+}
+
 validate_codex_rules_mutability_name() {
   case "$1" in
     readonly | session) ;;
     *)
       echo "Unsupported Codex rules mutability: $1" >&2
       echo "Use --codex-rules-mutability readonly or --codex-rules-mutability session." >&2
+      exit 2
+      ;;
+  esac
+}
+
+validate_log_level_name() {
+  case "$1" in
+    normal | debug) ;;
+    *)
+      echo "Unsupported log level: $1" >&2
+      echo "Use --log-level normal or --log-level debug." >&2
+      exit 2
+      ;;
+  esac
+}
+
+validate_logs_kind_name() {
+  case "$1" in
+    audit | debug | transcript) ;;
+    *)
+      echo "Unsupported log kind: $1" >&2
+      echo "Use --logs audit, --logs debug, or --logs transcript." >&2
       exit 2
       ;;
   esac
@@ -269,6 +324,7 @@ declare -a SHADOW_MOUNTS=()
 declare -a SHADOW_DEST_PATHS=()
 declare -a DIRECT_SOURCE_MOUNTS=()
 declare -a WORKSPACE_IMPORT_MOUNTS=()
+declare -a CACHE_MOUNTS=()
 
 # shellcheck disable=SC2317,SC2329
 cleanup() {
@@ -357,6 +413,124 @@ profile_audit_log_path() {
   printf '%s/workcell.audit.log\n' "$(profile_dir "${profile}")"
 }
 
+profile_latest_log_pointer_path() {
+  local profile="$1"
+  local kind="$2"
+
+  validate_colima_profile_name "${profile}"
+  case "${kind}" in
+    debug | transcript) ;;
+    *)
+      echo "Unsupported latest log pointer kind: ${kind}" >&2
+      exit 2
+      ;;
+  esac
+  printf '%s/workcell.latest-%s-log\n' "$(profile_dir "${profile}")" "${kind}"
+}
+
+write_latest_log_pointer() {
+  local profile="$1"
+  local kind="$2"
+  local path="$3"
+  local pointer_path=""
+
+  [[ -n "${path}" ]] || return 0
+  pointer_path="$(profile_latest_log_pointer_path "${profile}" "${kind}")"
+  mkdir -p "$(dirname "${pointer_path}")"
+  umask 077
+  printf '%s\n' "${path}" >"${pointer_path}"
+  chmod 0600 "${pointer_path}" 2>/dev/null || true
+}
+
+read_latest_log_pointer() {
+  local profile="$1"
+  local kind="$2"
+  local pointer_path=""
+
+  pointer_path="$(profile_latest_log_pointer_path "${profile}" "${kind}")"
+  [[ -f "${pointer_path}" ]] || return 1
+  head -n1 "${pointer_path}"
+}
+
+cleanup_stale_latest_log_pointers() {
+  local colima_root="$1"
+
+  run_clean_host_command "${HOST_PYTHON3_BIN}" - "${colima_root}" <<'PY'
+import os
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1]).expanduser()
+if not root.exists():
+    raise SystemExit(0)
+
+uid = os.getuid()
+for profile_dir in root.iterdir():
+    if not profile_dir.is_dir() or profile_dir.is_symlink():
+        continue
+    for pointer_name in ("workcell.latest-debug-log", "workcell.latest-transcript-log"):
+        pointer_path = profile_dir / pointer_name
+        try:
+            stat_result = pointer_path.lstat()
+        except FileNotFoundError:
+            continue
+        if stat_result.st_uid != uid or pointer_path.is_symlink():
+            continue
+        lines = pointer_path.read_text(encoding="utf-8").splitlines()
+        target_path = Path(lines[0]).expanduser() if lines else None
+        if target_path is None or not target_path.exists():
+            pointer_path.unlink(missing_ok=True)
+PY
+}
+
+cleanup_stale_session_audit_dirs() {
+  local colima_root="$1"
+
+  run_clean_host_command "${HOST_PYTHON3_BIN}" - "${colima_root}" <<'PY'
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+root = Path(sys.argv[1]).expanduser()
+if not root.exists():
+    raise SystemExit(0)
+
+cutoff = time.time() - (12 * 60 * 60)
+uid = os.getuid()
+
+for profile_dir in root.iterdir():
+    if not profile_dir.is_dir() or profile_dir.is_symlink():
+        continue
+    for candidate in profile_dir.glob("session-audit.*"):
+        try:
+            stat_result = candidate.lstat()
+        except FileNotFoundError:
+            continue
+        if stat_result.st_uid != uid:
+            continue
+        if candidate.is_dir():
+            if stat_result.st_mtime > cutoff:
+                continue
+            shutil.rmtree(candidate, ignore_errors=False)
+PY
+}
+
+audit_record_digest() {
+  local prev_digest="$1"
+  local timestamp="$2"
+  shift 2
+
+  run_clean_host_command "${HOST_PYTHON3_BIN}" - "${prev_digest}" "${timestamp}" "$@" <<'PY'
+import hashlib
+import sys
+
+payload = "\0".join(sys.argv[1:])
+print(hashlib.sha256(payload.encode("utf-8")).hexdigest())
+PY
+}
+
 stash_profile_audit_log() {
   local profile="$1"
   local audit_log=""
@@ -407,6 +581,8 @@ append_audit_record() {
   shift
   local audit_path
   local timestamp
+  local prev_digest=""
+  local record_digest=""
 
   audit_path="$(profile_audit_log_path "${profile}")"
   mkdir -p "$(dirname "${audit_path}")"
@@ -414,9 +590,15 @@ append_audit_record() {
   touch "${audit_path}"
   chmod 0600 "${audit_path}" 2>/dev/null || true
   timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  if [[ -s "${audit_path}" ]]; then
+    prev_digest="$(sed -n 's/.*record_digest=\([^ ]*\).*/\1/p' "${audit_path}" | tail -n1)"
+  fi
+  record_digest="$(audit_record_digest "${prev_digest}" "${timestamp}" "$@")"
   {
     printf 'timestamp=%q ' "${timestamp}"
     printf '%q ' "$@"
+    [[ -n "${prev_digest}" ]] && printf 'prev_digest=%q ' "${prev_digest}"
+    printf 'record_digest=%q ' "${record_digest}"
     printf '\n'
   } >>"${audit_path}"
 }
@@ -469,6 +651,10 @@ codex_rules_effective_assurance_with_session_assurance() {
 }
 
 session_assurance_initial() {
+  if [[ "${CACHE_PROFILE}" == "standard" ]]; then
+    printf 'lower-assurance-persistent-cache\n'
+    return 0
+  fi
   container_assurance
 }
 
@@ -478,11 +664,6 @@ session_assurance_final() {
 
   initial_assurance="$(session_assurance_initial)"
   final_assurance="${initial_assurance}"
-  if [[ -n "${SESSION_AUDIT_EVENT_FILE}" ]] && [[ -r "${SESSION_AUDIT_EVENT_FILE}" ]] &&
-    grep -q '^WORKCELL_EVENT package-mutation assurance=lower-assurance-package-mutation$' "${SESSION_AUDIT_EVENT_FILE}"; then
-    printf '%s\n' "lower-assurance-package-mutation"
-    return 0
-  fi
   if [[ -n "${SESSION_AUDIT_STATE_FILE}" ]] && [[ -r "${SESSION_AUDIT_STATE_FILE}" ]]; then
     case "$(head -n1 "${SESSION_AUDIT_STATE_FILE}")" in
       lower-assurance-package-mutation)
@@ -512,10 +693,25 @@ append_launch_audit_record() {
     "agent=${AGENT}" \
     "agent_autonomy=${AGENT_AUTONOMY}" \
     "autonomy_assurance=$(autonomy_assurance)" \
+    "cache_profile=${CACHE_PROFILE}" \
+    "cache_assurance=$(cache_assurance)" \
     "codex_rules_mutability_configured=${CODEX_RULES_MUTABILITY}" \
     "codex_rules_assurance_configured=$(codex_rules_assurance)" \
     "codex_rules_mutability_effective_initial=$(codex_rules_effective_mutability_initial)" \
     "codex_rules_assurance_effective_initial=$(codex_rules_effective_assurance_initial)" \
+    "observability_assurance=$(observability_assurance)" \
+    "log_level=${LOG_LEVEL}" \
+    "debug_log_enabled=$([[ -n "${DEBUG_LOG_PATH}" ]] && printf '1' || printf '0')" \
+    "transcript_logging=$([[ -n "${AUDIT_TRANSCRIPT_PATH}" ]] && printf 'full' || printf 'off')" \
+    "injection_policy_sha256=${INJECTION_POLICY_SHA256}" \
+    "injection_credential_keys=${INJECTION_CREDENTIAL_KEYS}" \
+    "provider_auth_mode=$(selected_provider_auth_mode)" \
+    "provider_auth_modes=$(provider_auth_modes)" \
+    "shared_auth_modes=$(shared_auth_modes)" \
+    "github_auth_present=$(github_auth_present)" \
+    "injection_ssh_enabled=${INJECTION_SSH_ENABLED}" \
+    "ssh_config_assurance=${INJECTION_SSH_CONFIG_ASSURANCE:-off}" \
+    "injection_secret_copy_targets=${INJECTION_SECRET_COPY_TARGETS}" \
     "ui=${UI}" \
     "network_policy=${NETWORK_POLICY}" \
     "execution_path=${execution_path}" \
@@ -558,8 +754,22 @@ append_exit_audit_record() {
     "workspace=${WORKSPACE}" \
     "execution_path=${execution_path}" \
     "exit_status=${exit_status}" \
+    "cache_profile=${CACHE_PROFILE}" \
+    "cache_assurance=$(cache_assurance)" \
     "container_assurance=$(container_assurance)" \
     "autonomy_assurance=$(autonomy_assurance)" \
+    "observability_assurance=$(observability_assurance)" \
+    "log_level=${LOG_LEVEL}" \
+    "debug_log_enabled=$([[ -n "${DEBUG_LOG_PATH}" ]] && printf '1' || printf '0')" \
+    "transcript_logging=$([[ -n "${AUDIT_TRANSCRIPT_PATH}" ]] && printf 'full' || printf 'off')" \
+    "injection_policy_sha256=${INJECTION_POLICY_SHA256}" \
+    "injection_credential_keys=${INJECTION_CREDENTIAL_KEYS}" \
+    "provider_auth_mode=$(selected_provider_auth_mode)" \
+    "provider_auth_modes=$(provider_auth_modes)" \
+    "shared_auth_modes=$(shared_auth_modes)" \
+    "github_auth_present=$(github_auth_present)" \
+    "injection_ssh_enabled=${INJECTION_SSH_ENABLED}" \
+    "ssh_config_assurance=${INJECTION_SSH_CONFIG_ASSURANCE:-off}" \
     "codex_rules_mutability_configured=${CODEX_RULES_MUTABILITY}" \
     "codex_rules_assurance_configured=$(codex_rules_assurance)" \
     "codex_rules_mutability_effective_final=$(codex_rules_effective_mutability_with_session_assurance "${final_assurance}")" \
@@ -576,23 +786,33 @@ prepare_session_audit_state() {
   SESSION_AUDIT_DIR="$(mktemp -d "$(profile_dir "${profile}")/session-audit.XXXXXX")"
   chmod 0700 "${SESSION_AUDIT_DIR}" 2>/dev/null || true
   SESSION_AUDIT_STATE_FILE="${SESSION_AUDIT_DIR}/session-assurance"
-  SESSION_AUDIT_EVENT_FILE="${SESSION_AUDIT_DIR}/events.log"
+  SESSION_AUDIT_CONTAINER_FILE="/opt/workcell/session-assurance"
+  rm -f "${SESSION_AUDIT_STATE_FILE}"
+}
+
+ensure_session_audit_state() {
+  [[ -n "${SESSION_AUDIT_DIR}" ]] || return 0
+  mkdir -p "${SESSION_AUDIT_DIR}"
+  chmod 0700 "${SESSION_AUDIT_DIR}" 2>/dev/null || true
+  SESSION_AUDIT_STATE_FILE="${SESSION_AUDIT_DIR}/session-assurance"
+  rm -f "${SESSION_AUDIT_STATE_FILE}"
 }
 
 capture_session_audit_state() {
   local container_name="$1"
 
   [[ -n "${SESSION_AUDIT_STATE_FILE}" ]] || return 0
+  if [[ -r "${SESSION_AUDIT_STATE_FILE}" ]]; then
+    chmod 0600 "${SESSION_AUDIT_STATE_FILE}" 2>/dev/null || true
+    return 0
+  fi
   mkdir -p "$(dirname "${SESSION_AUDIT_STATE_FILE}")"
-  if ! "${HOST_DOCKER_BIN}" cp "${container_name}:/run/workcell/session-assurance" "${SESSION_AUDIT_STATE_FILE}" >/dev/null 2>&1; then
-    :
+  if ! "${HOST_DOCKER_BIN}" cp "${container_name}:${SESSION_AUDIT_CONTAINER_FILE}" "${SESSION_AUDIT_STATE_FILE}" >/dev/null 2>&1; then
+    if ! "${HOST_DOCKER_BIN}" cp "${container_name}:/run/workcell/session-assurance" "${SESSION_AUDIT_STATE_FILE}" >/dev/null 2>&1; then
+      :
+    fi
   fi
   chmod 0600 "${SESSION_AUDIT_STATE_FILE}" 2>/dev/null || true
-  if [[ -n "${SESSION_AUDIT_EVENT_FILE}" ]]; then
-    mkdir -p "$(dirname "${SESSION_AUDIT_EVENT_FILE}")"
-    "${HOST_DOCKER_BIN}" logs "${container_name}" >"${SESSION_AUDIT_EVENT_FILE}" 2>&1 || true
-    chmod 0600 "${SESSION_AUDIT_EVENT_FILE}" 2>/dev/null || true
-  fi
 }
 
 finalize_session_audit() {
@@ -608,6 +828,7 @@ finalize_session_audit() {
     append_assurance_change_audit_record "${profile}" "${final_assurance}"
   fi
   append_exit_audit_record "${profile}" "${execution_path}" "${exit_status}" "${final_assurance}" "${downgraded}"
+  FINAL_SESSION_ASSURANCE="${final_assurance}"
 }
 
 write_profile_image_marker() {
@@ -624,6 +845,15 @@ write_profile_image_marker() {
 
 current_image_id() {
   "${HOST_DOCKER_BIN}" image inspect "${IMAGE_TAG}" --format '{{.Id}}' 2>/dev/null || true
+}
+
+current_profile_image_id() {
+  local profile="$1"
+  local socket_path=""
+
+  socket_path="${COLIMA_STATE_ROOT}/${profile}/docker.sock"
+  [[ -S "${socket_path}" ]] || return 0
+  DOCKER_HOST="unix://${socket_path}" "${HOST_DOCKER_BIN}" image inspect "${IMAGE_TAG}" --format '{{.Id}}' 2>/dev/null || true
 }
 
 emit_command() {
@@ -817,6 +1047,7 @@ prepare_injection_bundle() {
   local bundle_parent=""
   local default_policy_path=""
   local manifest_path=""
+  local metadata=""
 
   if [[ -z "${policy_path}" ]] && [[ "${USE_DEFAULT_INJECTION_POLICY}" -eq 1 ]]; then
     default_policy_path="$(default_injection_policy_path)"
@@ -826,6 +1057,11 @@ prepare_injection_bundle() {
   fi
 
   if [[ -z "${policy_path}" ]]; then
+    INJECTION_POLICY_SHA256=""
+    INJECTION_CREDENTIAL_KEYS=""
+    INJECTION_SSH_ENABLED=0
+    INJECTION_SSH_CONFIG_ASSURANCE="off"
+    INJECTION_SECRET_COPY_TARGETS=""
     return 0
   fi
 
@@ -888,6 +1124,26 @@ PY
     --manifest "${manifest_path}" \
     --mount-spec "${DIRECT_MOUNT_SPEC_PATH}" >/dev/null
   prepare_injection_direct_mounts "${DIRECT_MOUNT_SPEC_PATH}"
+  metadata="$(
+    run_clean_host_command "${HOST_PYTHON3_BIN}" - "${manifest_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+metadata = manifest.get("metadata", {})
+print(metadata.get("policy_sha256", ""))
+print(",".join(metadata.get("credential_keys", [])))
+print("1" if metadata.get("ssh_enabled") else "0")
+print(metadata.get("ssh_config_assurance", "off"))
+print(",".join(metadata.get("secret_copy_targets", [])))
+PY
+  )"
+  INJECTION_POLICY_SHA256="$(printf '%s\n' "${metadata}" | sed -n '1p')"
+  INJECTION_CREDENTIAL_KEYS="$(printf '%s\n' "${metadata}" | sed -n '2p')"
+  INJECTION_SSH_ENABLED="$(printf '%s\n' "${metadata}" | sed -n '3p')"
+  INJECTION_SSH_CONFIG_ASSURANCE="$(printf '%s\n' "${metadata}" | sed -n '4p')"
+  INJECTION_SECRET_COPY_TARGETS="$(printf '%s\n' "${metadata}" | sed -n '5p')"
 }
 
 build_recommended_command() {
@@ -903,11 +1159,15 @@ build_recommended_command() {
   [[ "${include_repair}" -eq 1 ]] && cmd+=(--repair-profile)
   cmd+=(--agent "${AGENT}")
   [[ "${AGENT_AUTONOMY}" != "yolo" ]] && cmd+=(--agent-autonomy "${AGENT_AUTONOMY}")
+  [[ "${CACHE_PROFILE}" != "off" ]] && cmd+=(--cache-profile "${CACHE_PROFILE}")
   [[ "${CONTAINER_MUTABILITY}" != "ephemeral" ]] && cmd+=(--container-mutability "${CONTAINER_MUTABILITY}")
   [[ -n "${CONTAINER_CPU_OVERRIDE}" ]] && cmd+=(--container-cpu "${CONTAINER_CPU_OVERRIDE}")
   [[ -n "${CONTAINER_MEMORY_OVERRIDE}" ]] && cmd+=(--container-memory "${CONTAINER_MEMORY_OVERRIDE}")
   [[ "${USE_DEFAULT_INJECTION_POLICY}" -eq 0 ]] && cmd+=(--no-default-injection-policy)
   [[ -n "${INJECTION_POLICY}" ]] && cmd+=(--injection-policy "${INJECTION_POLICY}")
+  [[ "${LOG_LEVEL}" != "normal" ]] && cmd+=(--log-level "${LOG_LEVEL}")
+  [[ -n "${DEBUG_LOG_PATH}" ]] && cmd+=(--debug-log "${DEBUG_LOG_PATH}")
+  [[ -n "${AUDIT_TRANSCRIPT_PATH}" ]] && cmd+=(--audit-transcript "${AUDIT_TRANSCRIPT_PATH}")
   [[ "${UI}" != "cli" ]] && cmd+=(--ui "${UI}")
   cmd+=(--mode "${target_mode}" --workspace "${WORKSPACE}")
   [[ "${ALLOW_NONGIT_WORKSPACE}" -eq 1 ]] && cmd+=(--allow-nongit-workspace)
@@ -935,6 +1195,211 @@ build_recommended_command() {
   fi
 
   emit_command "${cmd[@]}"
+}
+
+observability_assurance() {
+  if [[ -n "${AUDIT_TRANSCRIPT_PATH}" ]]; then
+    printf 'lower-assurance-host-transcript\n'
+    return 0
+  fi
+  if [[ -n "${DEBUG_LOG_PATH}" ]]; then
+    printf 'lower-assurance-host-debug-log\n'
+    return 0
+  fi
+  printf 'managed-metadata-only\n'
+}
+
+cache_assurance() {
+  case "${CACHE_PROFILE}" in
+    off)
+      printf 'managed-no-persistent-cache\n'
+      ;;
+    standard)
+      printf 'lower-assurance-persistent-cache\n'
+      ;;
+    *)
+      printf 'unknown-cache-profile\n'
+      ;;
+  esac
+}
+
+prepare_host_output_path() {
+  local raw_path="$1"
+  local resolved_path=""
+  local parent_dir=""
+
+  resolved_path="$(resolve_host_path "${raw_path}")"
+  parent_dir="$(dirname "${resolved_path}")"
+  mkdir -p "${parent_dir}"
+  chmod 0700 "${parent_dir}" 2>/dev/null || true
+  : >"${resolved_path}"
+  chmod 0600 "${resolved_path}" 2>/dev/null || true
+  printf '%s\n' "${resolved_path}"
+}
+
+enable_debug_log_capture() {
+  [[ -n "${DEBUG_LOG_PATH}" ]] || return 0
+  exec > >(tee -a "${DEBUG_LOG_PATH}") 2>&1
+}
+
+csv_contains_value() {
+  local csv="${1:-}"
+  local needle="$2"
+  local item=""
+
+  IFS=',' read -r -a _csv_items <<<"${csv}"
+  for item in "${_csv_items[@]}"; do
+    [[ -n "${item}" ]] || continue
+    if [[ "${item}" == "${needle}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+provider_auth_modes() {
+  local credential_keys="${INJECTION_CREDENTIAL_KEYS:-}"
+  local -a modes=()
+  local IFS=','
+
+  case "${AGENT:-}" in
+    codex)
+      if csv_contains_value "${credential_keys}" "codex_auth"; then
+        modes+=(codex_auth)
+      fi
+      ;;
+    claude)
+      if csv_contains_value "${credential_keys}" "claude_api_key"; then
+        modes+=(claude_api_key)
+      fi
+      if csv_contains_value "${credential_keys}" "claude_auth"; then
+        modes+=(claude_auth)
+      fi
+      ;;
+    gemini)
+      if csv_contains_value "${credential_keys}" "gemini_env"; then
+        modes+=(gemini_env)
+      fi
+      if csv_contains_value "${credential_keys}" "gemini_oauth"; then
+        modes+=(gemini_oauth)
+      fi
+      if csv_contains_value "${credential_keys}" "gcloud_adc"; then
+        modes+=(gcloud_adc)
+      fi
+      ;;
+  esac
+
+  if ((${#modes[@]} == 0)); then
+    printf 'none\n'
+    return 0
+  fi
+  printf '%s\n' "${modes[*]}"
+}
+
+shared_auth_modes() {
+  local credential_keys="${INJECTION_CREDENTIAL_KEYS:-}"
+  local -a modes=()
+  local IFS=','
+
+  if csv_contains_value "${credential_keys}" "github_hosts"; then
+    modes+=(github_hosts)
+  fi
+  if csv_contains_value "${credential_keys}" "github_config"; then
+    modes+=(github_config)
+  fi
+
+  if ((${#modes[@]} == 0)); then
+    printf 'none\n'
+    return 0
+  fi
+  printf '%s\n' "${modes[*]}"
+}
+
+github_auth_present() {
+  if [[ "$(shared_auth_modes)" == "none" ]]; then
+    printf '0\n'
+  else
+    printf '1\n'
+  fi
+}
+
+selected_provider_auth_mode() {
+  local auth_modes=""
+
+  auth_modes="$(provider_auth_modes)"
+  if [[ "${auth_modes}" == "none" ]]; then
+    printf 'none\n'
+  else
+    printf '%s\n' "${auth_modes%%,*}"
+  fi
+}
+
+print_injection_status() {
+  if [[ -z "${INJECTION_POLICY_SHA256}" ]]; then
+    printf 'injection_policy=none\n'
+    return 0
+  fi
+  printf 'injection_policy_sha256=%s\n' "${INJECTION_POLICY_SHA256}"
+  printf 'credential_keys=%s\n' "${INJECTION_CREDENTIAL_KEYS:-none}"
+  printf 'provider_auth_mode=%s\n' "$(selected_provider_auth_mode)"
+  printf 'provider_auth_modes=%s\n' "$(provider_auth_modes)"
+  printf 'shared_auth_modes=%s\n' "$(shared_auth_modes)"
+  printf 'github_auth_present=%s\n' "$(github_auth_present)"
+  printf 'ssh_injected=%s\n' "${INJECTION_SSH_ENABLED}"
+  printf 'ssh_config_assurance=%s\n' "${INJECTION_SSH_CONFIG_ASSURANCE:-off}"
+  printf 'secret_copy_targets=%s\n' "${INJECTION_SECRET_COPY_TARGETS:-none}"
+}
+
+print_inspect_state() {
+  local recorded_image_id="$1"
+  local current_image_id="$2"
+  local latest_debug_log=""
+  local latest_transcript_log=""
+
+  latest_debug_log="$(read_latest_log_pointer "${COLIMA_PROFILE}" debug || true)"
+  latest_transcript_log="$(read_latest_log_pointer "${COLIMA_PROFILE}" transcript || true)"
+  printf 'profile=%s\n' "${COLIMA_PROFILE}"
+  printf 'workspace=%s\n' "${WORKSPACE}"
+  printf 'workspace_status=%s\n' "$(workspace_status "${WORKSPACE}")"
+  printf 'agent=%s\n' "${AGENT:-none}"
+  printf 'mode=%s\n' "${MODE}"
+  printf 'ui=%s\n' "${UI}"
+  printf 'agent_autonomy=%s\n' "${AGENT_AUTONOMY}"
+  printf 'cache_profile=%s\n' "${CACHE_PROFILE}"
+  printf 'cache_assurance=%s\n' "$(cache_assurance)"
+  printf 'container_mutability=%s\n' "${CONTAINER_MUTABILITY}"
+  printf 'container_assurance=%s\n' "$(container_assurance)"
+  printf 'autonomy_assurance=%s\n' "$(autonomy_assurance)"
+  printf 'observability_assurance=%s\n' "$(observability_assurance)"
+  printf 'log_level=%s\n' "${LOG_LEVEL}"
+  printf 'profile_dir=%s\n' "$(profile_dir "${COLIMA_PROFILE}")"
+  printf 'profile_marker=%s\n' "$(profile_marker_path "${COLIMA_PROFILE}")"
+  printf 'image_marker=%s\n' "$(profile_image_marker_path "${COLIMA_PROFILE}")"
+  printf 'audit_log=%s\n' "$(profile_audit_log_path "${COLIMA_PROFILE}")"
+  printf 'latest_debug_log=%s\n' "${latest_debug_log:-none}"
+  printf 'latest_transcript_log=%s\n' "${latest_transcript_log:-none}"
+  printf 'recorded_image_id=%s\n' "${recorded_image_id:-none}"
+  printf 'current_image_id=%s\n' "${current_image_id:-none}"
+  print_injection_status
+}
+
+show_requested_logs() {
+  local log_path=""
+
+  case "${LOGS_KIND}" in
+    audit)
+      log_path="$(profile_audit_log_path "${COLIMA_PROFILE}")"
+      ;;
+    debug | transcript)
+      log_path="$(read_latest_log_pointer "${COLIMA_PROFILE}" "${LOGS_KIND}" || true)"
+      ;;
+  esac
+
+  if [[ -z "${log_path}" ]] || [[ ! -f "${log_path}" ]]; then
+    echo "No ${LOGS_KIND} log is recorded for profile ${COLIMA_PROFILE}." >&2
+    exit 2
+  fi
+  cat "${log_path}"
 }
 
 delete_unmanaged_profile() {
@@ -975,6 +1440,32 @@ workspace_has_agent_markers() {
   [[ -f "${path}/AGENTS.md" ]] ||
     [[ -f "${path}/CLAUDE.md" ]] ||
     [[ -f "${path}/GEMINI.md" ]]
+}
+
+workspace_status() {
+  local path="$1"
+
+  if [[ ! -e "${path}" ]]; then
+    printf 'missing\n'
+    return 0
+  fi
+  if [[ ! -d "${path}" ]]; then
+    printf 'not-directory\n'
+    return 0
+  fi
+  if workspace_has_markers "${path}"; then
+    if workspace_gitdir_is_self_contained "${path}"; then
+      printf 'git-self-contained\n'
+    else
+      printf 'git-external-admin\n'
+    fi
+    return 0
+  fi
+  if workspace_has_agent_markers "${path}"; then
+    printf 'marker-only\n'
+    return 0
+  fi
+  printf 'nongit-unmarked\n'
 }
 
 workspace_gitdir_is_self_contained() {
@@ -1126,7 +1617,7 @@ validate_mode_requirements() {
 
   if [[ "${mode}" == "strict" ]] && [[ "${rebuild}" -eq 1 ]] && [[ "${prepare}" -eq 0 ]]; then
     echo "strict mode does not rebuild or cold-bootstrap the runtime image." >&2
-    echo "Rerun with --prepare when you intentionally want Workcell to seed the reviewed image before strict launch." >&2
+    echo "Rerun with --prepare when you intentionally want Workcell to seed the prepared image before strict launch." >&2
     exit 2
   fi
 }
@@ -1149,6 +1640,105 @@ validate_container_mutability() {
       exit 2
       ;;
   esac
+}
+
+normalize_cli_aliases() {
+  NORMALIZED_ARGS=("$@")
+
+  case "${NORMALIZED_ARGS[0]-}" in
+    doctor)
+      NORMALIZED_ARGS=(--doctor "${NORMALIZED_ARGS[@]:1}")
+      ;;
+    inspect)
+      NORMALIZED_ARGS=(--inspect "${NORMALIZED_ARGS[@]:1}")
+      ;;
+    auth-status)
+      NORMALIZED_ARGS=(--auth-status "${NORMALIZED_ARGS[@]:1}")
+      ;;
+    gc)
+      NORMALIZED_ARGS=(--gc "${NORMALIZED_ARGS[@]:1}")
+      ;;
+    logs)
+      if [[ ${#NORMALIZED_ARGS[@]} -eq 2 ]] && [[ "${NORMALIZED_ARGS[1]}" == "--help" ]]; then
+        usage
+        exit 0
+      fi
+      if [[ ${#NORMALIZED_ARGS[@]} -lt 2 ]]; then
+        echo "workcell logs requires a log kind: audit, debug, or transcript." >&2
+        usage >&2
+        exit 2
+      fi
+      NORMALIZED_ARGS=(--logs "${NORMALIZED_ARGS[1]}" "${NORMALIZED_ARGS[@]:2}")
+      ;;
+  esac
+}
+
+prepare_cache_mounts() {
+  local profile="$1"
+  local cache_profile="$2"
+  local cache_root=""
+
+  CACHE_MOUNTS=()
+  case "${cache_profile}" in
+    off)
+      return 0
+      ;;
+    standard) ;;
+    *)
+      echo "Unsupported cache profile: ${cache_profile}" >&2
+      exit 2
+      ;;
+  esac
+
+  cache_root="$(profile_dir "${profile}")/cache"
+  if [[ "${DRY_RUN}" -eq 0 ]]; then
+    mkdir -p \
+      "${cache_root}/npm" \
+      "${cache_root}/pip" \
+      "${cache_root}/cargo-registry" \
+      "${cache_root}/cargo-git" \
+      "${cache_root}/go-mod" \
+      "${cache_root}/go-build" \
+      "${cache_root}/ccache"
+    chmod 0700 "${cache_root}" 2>/dev/null || true
+  fi
+  CACHE_MOUNTS=(
+    -e npm_config_cache=/state/cache/npm
+    -e PIP_CACHE_DIR=/state/cache/pip
+    -e CARGO_HOME=/state/cache/cargo-home
+    -e GOMODCACHE=/state/cache/go-mod
+    -e GOCACHE=/state/cache/go-build
+    -e CCACHE_DIR=/state/cache/ccache
+    -v "${cache_root}/npm:/state/cache/npm"
+    -v "${cache_root}/pip:/state/cache/pip"
+    -v "${cache_root}/cargo-registry:/state/cache/cargo-home/registry"
+    -v "${cache_root}/cargo-git:/state/cache/cargo-home/git"
+    -v "${cache_root}/go-mod:/state/cache/go-mod"
+    -v "${cache_root}/go-build:/state/cache/go-build"
+    -v "${cache_root}/ccache:/state/cache/ccache"
+  )
+}
+
+run_command_with_debug_log() {
+  local label="$1"
+  shift
+  local log_path=""
+  local status=0
+
+  log_path="$(mktemp "${TMPDIR:-/tmp}/workcell-${label}.XXXXXX.log")"
+  if "$@" >"${log_path}" 2>&1; then
+    if [[ "${LOG_LEVEL}" == "debug" ]]; then
+      cat "${log_path}" >&2
+    elif [[ -n "${DEBUG_LOG_PATH}" ]]; then
+      cat "${log_path}" >>"${DEBUG_LOG_PATH}"
+    fi
+  else
+    status=$?
+    echo "Workcell ${label} failed." >&2
+    cat "${log_path}" >&2
+  fi
+  rm -f "${log_path}"
+  return "${status}"
 }
 
 validate_positive_integer() {
@@ -1343,6 +1933,27 @@ validate_colima_profile() {
 
   validate_colima_profile_config "${profile}" "${workspace}" "${COLIMA_CPU}" "${COLIMA_MEMORY}" "${COLIMA_DISK}"
   validate_colima_runtime_mounts "${profile}" "${workspace}"
+}
+
+validate_runtime_security_posture() {
+  local security_options_json=""
+
+  security_options_json="$("${HOST_DOCKER_BIN}" info --format '{{json .SecurityOptions}}' 2>/dev/null || true)"
+  [[ -n "${security_options_json}" ]] || {
+    echo "Workcell could not inspect Docker security options for the managed runtime." >&2
+    exit 2
+  }
+
+  run_clean_host_command "${HOST_PYTHON3_BIN}" - "${security_options_json}" <<'PY'
+import json
+import sys
+
+options = json.loads(sys.argv[1])
+if not isinstance(options, list):
+    raise SystemExit("Unexpected Docker security options payload")
+if not any(isinstance(entry, str) and entry.startswith("name=seccomp") for entry in options):
+    raise SystemExit("Managed runtime requires Docker seccomp support to stay active.")
+PY
 }
 
 is_trusted_host_tool_path() {
@@ -1798,12 +2409,16 @@ bootstrap_endpoints() {
 
 AGENT=""
 AGENT_AUTONOMY="yolo"
+CACHE_PROFILE="off"
 CODEX_RULES_MUTABILITY="readonly"
 CONTAINER_MUTABILITY="ephemeral"
 CONTAINER_CPU_OVERRIDE=""
 CONTAINER_MEMORY_OVERRIDE=""
 UI="cli"
 MODE="strict"
+LOG_LEVEL="normal"
+DEBUG_LOG_PATH=""
+AUDIT_TRANSCRIPT_PATH=""
 WORKSPACE="$(pwd -P)"
 COLIMA_PROFILE=""
 INJECTION_POLICY=""
@@ -1815,12 +2430,23 @@ REBUILD=0
 DRY_RUN=0
 PREPARE=0
 REPAIR_PROFILE=0
+DOCTOR=0
+INSPECT=0
+GC=0
+AUTH_STATUS=0
+LOGS_KIND=""
 ALLOW_NONGIT_WORKSPACE=0
 ALLOW_ARBITRARY_COMMAND=0
 ACK_BREAKGLASS=0
 ACK_ARBITRARY_COMMAND=0
 TEST_FAIL_AFTER_PROFILE_REFRESH=0
 declare -a AGENT_ARGS=()
+declare -a NORMALIZED_ARGS=()
+
+if [[ $# -gt 0 ]]; then
+  normalize_cli_aliases "$@"
+  set -- "${NORMALIZED_ARGS[@]}"
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -1830,6 +2456,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --agent-autonomy)
       AGENT_AUTONOMY="$(option_value_or_die "$1" "${2-}")"
+      shift 2
+      ;;
+    --cache-profile)
+      CACHE_PROFILE="$(option_value_or_die "$1" "${2-}")"
       shift 2
       ;;
     --agent-arg)
@@ -1860,6 +2490,18 @@ while [[ $# -gt 0 ]]; do
       USE_DEFAULT_INJECTION_POLICY=0
       shift
       ;;
+    --log-level)
+      LOG_LEVEL="$(option_value_or_die "$1" "${2-}")"
+      shift 2
+      ;;
+    --debug-log)
+      DEBUG_LOG_PATH="$(raw_option_value_or_die "$1" "${2-}")"
+      shift 2
+      ;;
+    --audit-transcript)
+      AUDIT_TRANSCRIPT_PATH="$(raw_option_value_or_die "$1" "${2-}")"
+      shift 2
+      ;;
     --ui)
       UI="$(option_value_or_die "$1" "${2-}")"
       shift 2
@@ -1869,7 +2511,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --workspace)
-      WORKSPACE="$(resolve_existing_directory_or_die "$(option_value_or_die "$1" "${2-}")")"
+      WORKSPACE="$(resolve_host_path "$(option_value_or_die "$1" "${2-}")")"
       shift 2
       ;;
     --colima-profile)
@@ -1894,6 +2536,26 @@ while [[ $# -gt 0 ]]; do
       ;;
     --repair-profile)
       REPAIR_PROFILE=1
+      shift
+      ;;
+    --doctor)
+      DOCTOR=1
+      shift
+      ;;
+    --inspect)
+      INSPECT=1
+      shift
+      ;;
+    --logs)
+      LOGS_KIND="$(option_value_or_die "$1" "${2-}")"
+      shift 2
+      ;;
+    --auth-status)
+      AUTH_STATUS=1
+      shift
+      ;;
+    --gc)
+      GC=1
       shift
       ;;
     --test-fail-after-profile-refresh)
@@ -1939,7 +2601,48 @@ while [[ $# -gt 0 ]]; do
 done
 
 validate_agent_autonomy_name "${AGENT_AUTONOMY}"
+validate_cache_profile_name "${CACHE_PROFILE}"
 validate_codex_rules_mutability_name "${CODEX_RULES_MUTABILITY}"
+validate_log_level_name "${LOG_LEVEL}"
+if [[ -n "${LOGS_KIND}" ]]; then
+  validate_logs_kind_name "${LOGS_KIND}"
+fi
+if [[ "${DOCTOR}" -eq 1 ]] && [[ "${INSPECT}" -eq 1 ]]; then
+  echo "Use only one of --doctor or --inspect." >&2
+  exit 2
+fi
+if [[ "${GC}" -eq 1 ]] && { [[ "${DOCTOR}" -eq 1 ]] || [[ "${INSPECT}" -eq 1 ]] || [[ "${AUTH_STATUS}" -eq 1 ]] || [[ -n "${LOGS_KIND}" ]]; }; then
+  echo "--gc may not be combined with other non-launch actions." >&2
+  exit 2
+fi
+if [[ -n "${LOGS_KIND}" ]] && { [[ "${DOCTOR}" -eq 1 ]] || [[ "${INSPECT}" -eq 1 ]] || [[ "${AUTH_STATUS}" -eq 1 ]]; }; then
+  echo "--logs may not be combined with --doctor, --inspect, or --auth-status." >&2
+  exit 2
+fi
+if { [[ "${GC}" -eq 1 ]] || [[ "${DOCTOR}" -eq 1 ]] || [[ "${INSPECT}" -eq 1 ]] || [[ "${AUTH_STATUS}" -eq 1 ]] || [[ -n "${LOGS_KIND}" ]]; } &&
+  { [[ -n "${DEBUG_LOG_PATH}" ]] || [[ -n "${AUDIT_TRANSCRIPT_PATH}" ]]; }; then
+  echo "--debug-log and --audit-transcript apply only to launched sessions." >&2
+  exit 2
+fi
+if [[ -n "${AUDIT_TRANSCRIPT_PATH}" ]] && [[ -n "${DEBUG_LOG_PATH}" ]] && [[ "${AUDIT_TRANSCRIPT_PATH}" == "${DEBUG_LOG_PATH}" ]]; then
+  echo "--audit-transcript and --debug-log must use different paths." >&2
+  exit 2
+fi
+if [[ -n "${DEBUG_LOG_PATH}" ]]; then
+  DEBUG_LOG_PATH="$(prepare_host_output_path "${DEBUG_LOG_PATH}")"
+  enable_debug_log_capture
+  echo "Workcell warning: full host-persisted debug log capture is enabled for this session: ${DEBUG_LOG_PATH}" >&2
+fi
+if [[ -n "${AUDIT_TRANSCRIPT_PATH}" ]]; then
+  AUDIT_TRANSCRIPT_PATH="$(prepare_host_output_path "${AUDIT_TRANSCRIPT_PATH}")"
+fi
+if [[ "${GC}" -eq 1 ]]; then
+  cleanup_stale_injection_bundles "$(default_injection_bundle_parent)"
+  cleanup_stale_session_audit_dirs "${COLIMA_STATE_ROOT}"
+  cleanup_stale_latest_log_pointers "${COLIMA_STATE_ROOT}"
+  echo "Cleaned stale Workcell injection, session-audit, and broken latest-log pointer state."
+  exit 0
+fi
 declare -a PROVIDER_ARGS=()
 if ((${#AGENT_ARGS[@]} > 0)); then
   PROVIDER_ARGS=("${AGENT_ARGS[@]}")
@@ -1953,23 +2656,31 @@ else
   set --
 fi
 
-if [[ "${ALLOW_ARBITRARY_COMMAND}" -eq 0 ]] && [[ $# -gt 0 ]] && [[ "$1" != "${AGENT}" ]]; then
+if [[ "${ALLOW_ARBITRARY_COMMAND}" -eq 0 ]] && [[ $# -gt 0 ]] && [[ -n "${AGENT}" ]] && [[ "$1" != "${AGENT}" ]]; then
   set -- "${AGENT}" "$@"
 fi
 
-if [[ -z "${AGENT}" ]]; then
+if [[ -z "${AGENT}" ]] && { [[ "${DOCTOR}" -eq 1 ]] || [[ "${INSPECT}" -eq 1 ]] || [[ "${AUTH_STATUS}" -eq 1 ]]; }; then
   echo "Option --agent is required." >&2
   usage >&2
   exit 2
 fi
 
-case "${AGENT}" in
-  codex | claude | gemini) ;;
-  *)
-    echo "Unsupported agent: ${AGENT}" >&2
-    exit 2
-    ;;
-esac
+if [[ -n "${AGENT}" ]]; then
+  case "${AGENT}" in
+    codex | claude | gemini) ;;
+    *)
+      echo "Unsupported agent: ${AGENT}" >&2
+      exit 2
+      ;;
+  esac
+fi
+
+if [[ -z "${AGENT}" ]] && [[ -z "${LOGS_KIND}" ]]; then
+  echo "Option --agent is required." >&2
+  usage >&2
+  exit 2
+fi
 
 case "${UI}" in
   cli) ;;
@@ -2018,15 +2729,17 @@ if [[ -n "${CONTAINER_CPU_OVERRIDE}" ]]; then
 fi
 HOST_GIT_BIN="$(resolve_host_tool git /usr/bin/git /opt/homebrew/bin/git /usr/local/bin/git)"
 HOST_DOCKER_BIN="docker"
-validate_workspace "${WORKSPACE}" "${ALLOW_NONGIT_WORKSPACE}"
-validate_mode_requirements "${MODE}" "${ACK_BREAKGLASS}" "${ALLOW_ARBITRARY_COMMAND}" "${ACK_ARBITRARY_COMMAND}" "${REBUILD}" "${PREPARE}"
-cleanup_stale_injection_bundles "$(default_injection_bundle_parent)"
-prepare_injection_bundle "${AGENT}" "${MODE}"
-
 if [[ -z "${COLIMA_PROFILE}" ]]; then
   COLIMA_PROFILE="$(derive_profile_name "${WORKSPACE}")"
 fi
 validate_colima_profile_name "${COLIMA_PROFILE}"
+if [[ -n "${LOGS_KIND}" ]]; then
+  show_requested_logs
+  exit 0
+fi
+validate_mode_requirements "${MODE}" "${ACK_BREAKGLASS}" "${ALLOW_ARBITRARY_COMMAND}" "${ACK_ARBITRARY_COMMAND}" "${REBUILD}" "${PREPARE}"
+cleanup_stale_injection_bundles "$(default_injection_bundle_parent)"
+prepare_injection_bundle "${AGENT}" "${MODE}"
 
 IMAGE_TAG="workcell:local"
 PROFILE_DIR="$(profile_dir "${COLIMA_PROFILE}")"
@@ -2051,6 +2764,64 @@ if [[ -d "${PROFILE_DIR}" ]]; then
   PROFILE_PREEXISTED=1
 fi
 
+if [[ -f "${PROFILE_MARKER}" ]]; then
+  PROFILE_MARKER_WORKSPACE="$(read_profile_marker_workspace "${COLIMA_PROFILE}" || true)"
+fi
+
+if [[ "${AUTH_STATUS}" -eq 1 ]]; then
+  print_injection_status
+  exit 0
+fi
+
+if [[ "${DOCTOR}" -eq 0 ]] && [[ "${INSPECT}" -eq 0 ]] && [[ -z "${LOGS_KIND}" ]] &&
+  [[ "${AUTH_STATUS}" -eq 0 ]] && [[ "${GC}" -eq 0 ]]; then
+  WORKSPACE="$(resolve_existing_directory_or_die "${WORKSPACE}")"
+  validate_workspace "${WORKSPACE}" "${ALLOW_NONGIT_WORKSPACE}"
+fi
+
+if [[ "${INSPECT}" -eq 1 ]]; then
+  print_inspect_state \
+    "$(profile_image_marker_value "${COLIMA_PROFILE}" image_id || true)" \
+    "$(current_profile_image_id "${COLIMA_PROFILE}")"
+  exit 0
+fi
+
+if [[ "${DOCTOR}" -eq 1 ]]; then
+  local_current_image_id="$(current_profile_image_id "${COLIMA_PROFILE}")"
+  workspace_state="$(workspace_status "${WORKSPACE}")"
+  profile_state="absent"
+  if [[ "${PROFILE_PREEXISTED}" -eq 1 ]] && [[ ! -f "${PROFILE_MARKER}" ]]; then
+    profile_state="unmanaged"
+  elif [[ "${PROFILE_PREEXISTED}" -eq 1 ]]; then
+    profile_state="managed"
+  fi
+  recorded_image_id="$(profile_image_marker_value "${COLIMA_PROFILE}" image_id || true)"
+  prepared_image=0
+  if [[ -n "${recorded_image_id}" ]] && [[ -n "${local_current_image_id}" ]] && [[ "${recorded_image_id}" == "${local_current_image_id}" ]]; then
+    prepared_image=1
+  fi
+  print_inspect_state "${recorded_image_id}" "${local_current_image_id}"
+  printf 'doctor_profile_state=%s\n' "${profile_state}"
+  printf 'doctor_workspace_binding=%s\n' "${PROFILE_MARKER_WORKSPACE:-none}"
+  printf 'doctor_prepared_image=%s\n' "${prepared_image}"
+  if [[ "${workspace_state}" == "missing" ]] || [[ "${workspace_state}" == "not-directory" ]]; then
+    printf 'doctor_recommended_next=fix-workspace\n'
+  elif [[ "${profile_state}" == "unmanaged" ]]; then
+    printf 'doctor_recommended_next='
+    if [[ "${MODE}" == "strict" ]]; then
+      build_recommended_command 1 1 "${MODE}"
+    else
+      build_recommended_command 0 1 "${MODE}"
+    fi
+  elif [[ "${MODE}" == "strict" ]] && [[ "${prepared_image}" -eq 0 ]]; then
+    printf 'doctor_recommended_next='
+    build_recommended_command 1 0 "${MODE}"
+  else
+    printf 'doctor_recommended_next=none\n'
+  fi
+  exit 0
+fi
+
 if [[ "${PROFILE_PREEXISTED}" -eq 1 ]] && [[ ! -f "${PROFILE_MARKER}" ]]; then
   if [[ "${REPAIR_PROFILE}" -eq 1 ]]; then
     delete_unmanaged_profile "${COLIMA_PROFILE}"
@@ -2072,10 +2843,6 @@ if [[ "${PROFILE_PREEXISTED}" -eq 1 ]] && [[ ! -f "${PROFILE_MARKER}" ]]; then
   fi
 fi
 
-if [[ -f "${PROFILE_MARKER}" ]]; then
-  PROFILE_MARKER_WORKSPACE="$(read_profile_marker_workspace "${COLIMA_PROFILE}" || true)"
-fi
-
 if [[ "${PROFILE_PREEXISTED}" -eq 1 ]] && [[ -z "${PROFILE_MARKER_WORKSPACE}" ]]; then
   echo "Refusing to reuse managed Colima profile without a recorded workspace binding: ${COLIMA_PROFILE}" >&2
   exit 2
@@ -2089,11 +2856,11 @@ if [[ -n "${PROFILE_MARKER_WORKSPACE}" ]] && [[ "${PROFILE_MARKER_WORKSPACE}" !=
 fi
 
 if [[ "${DRY_RUN}" -eq 0 ]] && [[ "${MODE}" == "strict" ]] && [[ "${PREPARE}" -eq 0 ]] && [[ ! -f "${PROFILE_IMAGE_MARKER}" ]]; then
-  echo "No reviewed runtime image is recorded for strict mode on profile ${COLIMA_PROFILE}." >&2
+  echo "No prepared runtime image is recorded for strict mode on profile ${COLIMA_PROFILE}." >&2
   echo "This is expected on the first launch for a workspace or after profile cleanup." >&2
   echo "Next step:" >&2
   build_recommended_command 1 0 "${MODE}"
-  echo "That command seeds the reviewed runtime image inside the isolated VM and then launches ${AGENT} in strict mode." >&2
+  echo "That command seeds the prepared runtime image inside the isolated VM and then launches ${AGENT} in strict mode." >&2
   echo "No VM or container was started." >&2
   exit 2
 fi
@@ -2111,6 +2878,10 @@ if [[ "${CONTAINER_MUTABILITY}" == "ephemeral" ]]; then
   ALLOW_ENDPOINTS="${ALLOW_ENDPOINTS} snapshot.debian.org:80 snapshot.debian.org:443"
 fi
 prepare_workspace_control_plane_shadow "${WORKSPACE}" "${MODE}"
+prepare_cache_mounts "${COLIMA_PROFILE}" "${CACHE_PROFILE}"
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+  prepare_session_audit_state "${COLIMA_PROFILE}"
+fi
 
 CONTAINER_NAME="workcell-$(slugify "${AGENT}-${MODE}-$(basename "${WORKSPACE}")")-$(generate_session_suffix)"
 DOCKER_RUN_BASE=(
@@ -2129,6 +2900,7 @@ DOCKER_RUN_BASE=(
   -e AGENT_NAME="${AGENT}"
   -e WORKCELL_AGENT_AUTONOMY="${AGENT_AUTONOMY}"
   -e WORKCELL_CODEX_RULES_MUTABILITY="${CODEX_RULES_MUTABILITY}"
+  -e WORKCELL_CACHE_PROFILE="${CACHE_PROFILE}"
   -e WORKCELL_CONTAINER_MUTABILITY="${CONTAINER_MUTABILITY}"
   -e AGENT_UI="${UI}"
   -e CODEX_PROFILE="${MODE}"
@@ -2173,16 +2945,15 @@ fi
 if ((${#DIRECT_SOURCE_MOUNTS[@]} > 0)); then
   DOCKER_RUN_BASE+=("${DIRECT_SOURCE_MOUNTS[@]}")
 fi
+if ((${#CACHE_MOUNTS[@]} > 0)); then
+  DOCKER_RUN_BASE+=("${CACHE_MOUNTS[@]}")
+fi
 if [[ -n "${INJECTION_BUNDLE_ROOT}" ]]; then
   DOCKER_RUN_BASE+=(
     -e WORKCELL_INJECTION_MANIFEST=/opt/workcell/host-injections/manifest.json
     -v "${INJECTION_BUNDLE_ROOT}:/opt/workcell/host-injections:ro"
   )
 fi
-if [[ "${DRY_RUN}" -eq 0 ]]; then
-  prepare_session_audit_state "${COLIMA_PROFILE}"
-fi
-
 EXECUTION_PATH="managed-tier1"
 if [[ "${MODE}" == "breakglass" ]]; then
   EXECUTION_PATH="lower-assurance-breakglass"
@@ -2223,13 +2994,22 @@ printf 'agent_autonomy=%s\n' "${AGENT_AUTONOMY}" >&2
 printf 'vm_resources=cpu=%s memory_gib=%s disk_gib=%s\n' "${COLIMA_CPU}" "${COLIMA_MEMORY}" "${COLIMA_DISK}" >&2
 printf 'container_resources=mutability=%s cpu=%s memory=%s\n' \
   "${CONTAINER_MUTABILITY}" "${CONTAINER_CPU_OVERRIDE:-unmanaged}" "${CONTAINER_MEMORY}" >&2
+printf 'cache_profile=%s\n' "${CACHE_PROFILE}" >&2
+printf 'cache_assurance=%s\n' "$(cache_assurance)" >&2
 printf 'container_assurance=%s\n' "$(container_assurance)" >&2
 printf 'autonomy_assurance=%s\n' "$(autonomy_assurance)" >&2
+printf 'observability_assurance=%s\n' "$(observability_assurance)" >&2
+printf 'log_level=%s debug_log=%s audit_transcript=%s\n' \
+  "${LOG_LEVEL}" "${DEBUG_LOG_PATH:-off}" "$([[ -n "${AUDIT_TRANSCRIPT_PATH}" ]] && printf 'full' || printf 'off')" >&2
 printf 'codex_rules_mutability_configured=%s\n' "${CODEX_RULES_MUTABILITY}" >&2
 printf 'codex_rules_assurance_configured=%s\n' "$(codex_rules_assurance)" >&2
 printf 'codex_rules_mutability_effective_initial=%s\n' "$(codex_rules_effective_mutability_initial)" >&2
 printf 'codex_rules_assurance_effective_initial=%s\n' "$(codex_rules_effective_assurance_initial)" >&2
 printf 'session_assurance_initial=%s\n' "$(session_assurance_initial)" >&2
+if [[ -n "${INJECTION_POLICY_SHA256}" ]]; then
+  printf 'injection_policy_sha256=%s credential_keys=%s ssh_injected=%s\n' \
+    "${INJECTION_POLICY_SHA256}" "${INJECTION_CREDENTIAL_KEYS:-none}" "${INJECTION_SSH_ENABLED}" >&2
+fi
 printf 'workspace_control_plane=%s\n' "$([[ "${MODE}" == "breakglass" ]] && printf 'unmasked' || printf 'masked')" >&2
 printf 'network_policy=%s endpoints=%s\n' "${NETWORK_POLICY}" "${ALLOW_ENDPOINTS}" >&2
 printf 'execution_path=%s audit_log=%s\n' "${EXECUTION_PATH}" "$(profile_audit_log_path "${COLIMA_PROFILE}")" >&2
@@ -2257,7 +3037,8 @@ fi
 
 maybe_fail_after_profile_refresh_for_tests
 
-run_host_colima start \
+run_command_with_debug_log colima-start \
+  run_host_colima start \
   --profile "${COLIMA_PROFILE}" \
   --vm-type vz \
   --mount "${WORKSPACE}:w" \
@@ -2265,16 +3046,20 @@ run_host_colima start \
   --runtime docker \
   --cpu "${COLIMA_CPU}" \
   --memory "${COLIMA_MEMORY}" \
-  --disk "${COLIMA_DISK}" >/dev/null
+  --disk "${COLIMA_DISK}"
 PROFILE_RUNNING=1
 
 validate_colima_profile "${COLIMA_PROFILE}" "${WORKSPACE}"
 mkdir -p "${PROFILE_DIR}"
 restore_profile_audit_log "${COLIMA_PROFILE}"
+ensure_session_audit_state
 printf '%s\n' "${WORKSPACE}" >"${PROFILE_MARKER}"
 PROFILE_VALIDATED=1
+write_latest_log_pointer "${COLIMA_PROFILE}" debug "${DEBUG_LOG_PATH}"
+write_latest_log_pointer "${COLIMA_PROFILE}" transcript "${AUDIT_TRANSCRIPT_PATH}"
 
 export DOCKER_HOST="unix://${COLIMA_STATE_ROOT}/${COLIMA_PROFILE}/docker.sock"
+validate_runtime_security_posture
 
 restore_runtime_egress() {
   if [[ "${NETWORK_POLICY}" == "allowlist" ]]; then
@@ -2297,7 +3082,7 @@ fi
 
 if [[ "${MODE}" == "strict" ]] && [[ "${NEEDS_REBUILD}" -eq 1 ]] && [[ "${PREPARE}" -eq 0 ]]; then
   restore_runtime_egress
-  echo "Strict mode needs a prepared reviewed runtime image for profile ${COLIMA_PROFILE}." >&2
+  echo "Strict mode needs a prepared runtime image for profile ${COLIMA_PROFILE}." >&2
   echo "The profile started successfully, but the runtime image is missing or stale." >&2
   echo "Next step:" >&2
   build_recommended_command 1 0 "${MODE}"
@@ -2306,7 +3091,7 @@ fi
 
 if [[ "${NETWORK_POLICY}" == "allowlist" ]] && [[ "${NEEDS_REBUILD}" -eq 1 ]]; then
   if [[ "${PREPARE}" -eq 1 ]]; then
-    echo "prepare=1 seeding the reviewed runtime image before launch." >&2
+    echo "prepare=1 seeding the prepared runtime image before launch." >&2
   fi
   BOOTSTRAP_APPLIED=1
   printf 'bootstrap_policy=allowlist endpoints=%s\n' "${BOOTSTRAP_ENDPOINTS}" >&2
@@ -2318,14 +3103,15 @@ fi
 if [[ "${NEEDS_REBUILD}" -eq 1 ]]; then
   BUILD_SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}"
   BUILD_STATUS=0
-  SOURCE_DATE_EPOCH="${BUILD_SOURCE_DATE_EPOCH}" buildx_cmd build \
+  SOURCE_DATE_EPOCH="${BUILD_SOURCE_DATE_EPOCH}" run_command_with_debug_log runtime-build \
+    buildx_cmd build \
     --build-arg "SOURCE_DATE_EPOCH=${BUILD_SOURCE_DATE_EPOCH}" \
     --provenance=false \
     --sbom=false \
     --load \
     -t "${IMAGE_TAG}" \
     -f "${ROOT_DIR}/runtime/container/Dockerfile" \
-    "${ROOT_DIR}" >/dev/null || BUILD_STATUS=$?
+    "${ROOT_DIR}" || BUILD_STATUS=$?
   if [[ "${BUILD_STATUS}" -ne 0 ]]; then
     restore_runtime_egress
     exit "${BUILD_STATUS}"
@@ -2333,7 +3119,7 @@ if [[ "${NEEDS_REBUILD}" -eq 1 ]]; then
   CURRENT_IMAGE_ID="$(current_image_id)"
   if [[ -z "${CURRENT_IMAGE_ID}" ]]; then
     restore_runtime_egress
-    echo "Workcell failed to record the reviewed runtime image ID for ${IMAGE_TAG}." >&2
+    echo "Workcell failed to record the prepared runtime image ID for ${IMAGE_TAG}." >&2
     exit 2
   fi
   write_profile_image_marker "${COLIMA_PROFILE}" "${CURRENT_IMAGE_ID}"
@@ -2344,11 +3130,27 @@ append_launch_audit_record "${COLIMA_PROFILE}" "${EXECUTION_PATH}"
 
 DOCKER_STATUS=0
 "${HOST_DOCKER_BIN}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
-"${DOCKER_RUN[@]}" || DOCKER_STATUS=$?
+if [[ -n "${AUDIT_TRANSCRIPT_PATH}" ]]; then
+  if [[ ! -t 0 ]] || [[ ! -t 1 ]]; then
+    echo "Full transcript capture requires an interactive terminal." >&2
+    exit 2
+  fi
+  echo "Workcell warning: full host-persisted terminal transcript capture is enabled for this session: ${AUDIT_TRANSCRIPT_PATH}" >&2
+  "${HOST_PYTHON3_BIN}" "${ROOT_DIR}/scripts/lib/pty_transcript.py" --log "${AUDIT_TRANSCRIPT_PATH}" -- "${DOCKER_RUN[@]}" || DOCKER_STATUS=$?
+else
+  "${DOCKER_RUN[@]}" || DOCKER_STATUS=$?
+fi
 capture_session_audit_state "${CONTAINER_NAME}"
 finalize_session_audit "${COLIMA_PROFILE}" "${EXECUTION_PATH}" "${DOCKER_STATUS}"
 "${HOST_DOCKER_BIN}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+if [[ "${FINAL_SESSION_ASSURANCE:-}" == "lower-assurance-package-mutation" ]]; then
+  echo "Workcell warning: this session ended lower-assurance because package-manager mutations ran as root inside the container." >&2
+fi
 if [[ "${CONTAINER_MUTABILITY}" == "ephemeral" ]]; then
-  echo "Workcell ephemeral runtime ended. Changes not persisted to /workspace or provided from the host control plane were discarded." >&2
+  if [[ "${CACHE_PROFILE}" == "standard" ]]; then
+    echo "Workcell ephemeral runtime ended. Changes not persisted to /workspace or provided from the host control plane were discarded, but the opt-in persistent cache plane was retained." >&2
+  else
+    echo "Workcell ephemeral runtime ended. Changes not persisted to /workspace or provided from the host control plane were discarded." >&2
+  fi
 fi
 exit "${DOCKER_STATUS}"

--- a/tests/mutation/mutate_python_helpers.py
+++ b/tests/mutation/mutate_python_helpers.py
@@ -25,6 +25,18 @@ MUTATIONS = [
         "claude mcp credential support",
     ),
     (
+        "scripts/lib/render_injection_bundle.py",
+        "    if stat.S_IMODE(path_stat.st_mode) & 0o077:",
+        "    if False and stat.S_IMODE(path_stat.st_mode) & 0o077:",
+        "secret permission hygiene",
+    ),
+    (
+        "scripts/lib/pty_transcript.py",
+        '    if command[:1] == ["--"]:',
+        '    if False and command[:1] == ["--"]:',
+        "pty separator stripping",
+    ),
+    (
         "scripts/lib/extract_direct_mounts.py",
         'source = entry.pop("source", None)',
         'source = entry.get("source")',

--- a/tests/python/test_injection_helpers.py
+++ b/tests/python/test_injection_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -67,6 +68,20 @@ class RenderInjectionHelperTests(unittest.TestCase):
         self.assertTrue(parsed["ssh"]["enabled"])
         self.assertEqual(len(parsed["copies"]), 1)
 
+    def test_parse_toml_subset_parses_scoped_credential_table(self) -> None:
+        policy = Path("/tmp/policy.toml")
+        parsed = self.module.parse_toml_subset(
+            """
+            [credentials.codex_auth]
+            source = "auth.json"
+            providers = ["codex"]
+            modes = ["strict"]
+            """,
+            policy,
+        )
+        self.assertEqual(parsed["credentials"]["codex_auth"]["source"], "auth.json")
+        self.assertEqual(parsed["credentials"]["codex_auth"]["providers"], ["codex"])
+
     def test_parse_toml_subset_rejects_invalid_lines(self) -> None:
         policy = Path("/tmp/policy.toml")
         with self.assertRaises(SystemExit):
@@ -80,7 +95,15 @@ class RenderInjectionHelperTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             base = Path(tmpdir)
             relative = self.module.expand_host_path("child/file.txt", base)
-            self.assertEqual(relative, (base / "child/file.txt").resolve())
+            self.assertEqual(
+                relative,
+                Path(os.path.abspath(os.fspath(base / "child/file.txt"))),
+            )
+            target = base / "target.txt"
+            target.write_text("target\n", encoding="utf-8")
+            link = base / "link.txt"
+            link.symlink_to(target)
+            self.assertEqual(self.module.expand_host_path("link.txt", base), link)
             candidate = self.module.normalize_container_target("~/test.txt")
             self.assertEqual(
                 candidate,
@@ -89,6 +112,12 @@ class RenderInjectionHelperTests(unittest.TestCase):
             self.assertTrue(
                 self.module.target_is_under(
                     PurePosixPath("/state/agent-home/.config"),
+                    PurePosixPath("/state/agent-home"),
+                )
+            )
+            self.assertTrue(
+                self.module.target_is_under(
+                    PurePosixPath("/state/agent-home"),
                     PurePosixPath("/state/agent-home"),
                 )
             )
@@ -121,6 +150,8 @@ class RenderInjectionHelperTests(unittest.TestCase):
             self.module.selected_for([], "codex", "providers", {"codex"})
         with self.assertRaises(SystemExit):
             self.module.selected_for(["invalid"], "codex", "providers", {"codex"})
+        with self.assertRaises(SystemExit):
+            self.module.selected_for(["codex", 7], "codex", "providers", {"codex"})
         self.module.validate_allowed_keys({"a": 1}, {"a"}, "table")
         with self.assertRaises(SystemExit):
             self.module.validate_allowed_keys({"a": 1, "b": 2}, {"a"}, "table")
@@ -130,6 +161,7 @@ class RenderInjectionHelperTests(unittest.TestCase):
             root = Path(tmpdir)
             source_file = root / "source.txt"
             source_file.write_text("hello\n", encoding="utf-8")
+            source_file.chmod(0o600)
             staged_file = root / "bundle/file.txt"
             self.assertEqual(self.module.copy_source(source_file, staged_file), "file")
             self.assertEqual(staged_file.read_text(encoding="utf-8"), "hello\n")
@@ -137,7 +169,9 @@ class RenderInjectionHelperTests(unittest.TestCase):
 
             source_dir = root / "dir-source"
             source_dir.mkdir()
+            source_dir.chmod(0o700)
             (source_dir / "nested.txt").write_text("nested\n", encoding="utf-8")
+            (source_dir / "nested.txt").chmod(0o600)
             staged_dir = root / "bundle/dir"
             self.assertEqual(self.module.copy_source(source_dir, staged_dir), "dir")
             self.assertTrue((staged_dir / "nested.txt").is_file())
@@ -167,6 +201,11 @@ class RenderInjectionHelperTests(unittest.TestCase):
             policy_path = root / "policy.toml"
             source = root / "common.md"
             source.write_text("common\n", encoding="utf-8")
+            source.chmod(0o600)
+            self.assertEqual(
+                self.module.expand_host_path(str(source), root),
+                Path(os.path.abspath(os.fspath(source))),
+            )
             policy_path.write_text(
                 'version = 1\n[documents]\ncommon = "common.md"\n',
                 encoding="utf-8",
@@ -175,7 +214,7 @@ class RenderInjectionHelperTests(unittest.TestCase):
             self.assertEqual(loaded["documents"]["common"], "common.md")
             self.assertEqual(
                 self.module.validate_source_path("common.md", "documents.common", root),
-                source.resolve(),
+                Path(os.path.abspath(os.fspath(source))),
             )
 
             policy_path.write_text('version = 2\n', encoding="utf-8")
@@ -183,6 +222,8 @@ class RenderInjectionHelperTests(unittest.TestCase):
                 self.module.load_policy(policy_path)
             with self.assertRaises(SystemExit):
                 self.module.validate_source_path("", "documents.common", root)
+            with self.assertRaises(SystemExit):
+                self.module.validate_source_path("missing.md", "documents.common", root)
 
     def test_render_documents_rejects_non_file_sources(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -197,6 +238,27 @@ class RenderInjectionHelperTests(unittest.TestCase):
                     root,
                 )
 
+    def test_optional_sections_accept_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            self.assertEqual(self.module.render_documents({"documents": None}, output, root), {})
+            self.assertEqual(
+                self.module.render_copies({"copies": None}, output, root, "codex", "strict"),
+                [],
+            )
+            self.assertEqual(
+                self.module.render_ssh({"ssh": None}, output, root, "codex", "strict"),
+                {},
+            )
+            self.assertEqual(
+                self.module.render_credentials(
+                    {"credentials": None}, root, "codex", "strict"
+                ),
+                {},
+            )
+
     def test_render_copies_supports_public_and_secret_directories(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -207,7 +269,9 @@ class RenderInjectionHelperTests(unittest.TestCase):
             (public_dir / "note.txt").write_text("note\n", encoding="utf-8")
             secret_dir = root / "secret-dir"
             secret_dir.mkdir()
+            secret_dir.chmod(0o700)
             (secret_dir / "token.txt").write_text("token\n", encoding="utf-8")
+            (secret_dir / "token.txt").chmod(0o600)
 
             rendered = self.module.render_copies(
                 {
@@ -244,6 +308,7 @@ class RenderInjectionHelperTests(unittest.TestCase):
             output = root / "bundle"
             output.mkdir()
             (root / "file.txt").write_text("data\n", encoding="utf-8")
+            (root / "file.txt").chmod(0o600)
 
             with self.assertRaises(SystemExit):
                 self.module.render_copies(
@@ -273,6 +338,10 @@ class RenderInjectionHelperTests(unittest.TestCase):
             (root / "known_hosts").write_text("host key\n", encoding="utf-8")
             (root / "id_a").write_text("key a\n", encoding="utf-8")
             (root / "id_b").write_text("key b\n", encoding="utf-8")
+            (root / "config").chmod(0o600)
+            (root / "known_hosts").chmod(0o600)
+            (root / "id_a").chmod(0o600)
+            (root / "id_b").chmod(0o600)
 
             rendered = self.module.render_ssh(
                 {
@@ -335,15 +404,21 @@ class RenderInjectionHelperTests(unittest.TestCase):
                     "strict",
                 )
 
+            (root / "unsafe").write_text("Host *\nProxyCommand nope\n", encoding="utf-8")
+            (root / "unsafe").chmod(0o600)
+            self.module.validate_ssh_config_safety(root / "unsafe", allow_unsafe=True)
+            self.assertIsNone(self.module.parse_ssh_directive("   "))
+            self.assertIsNone(self.module.parse_ssh_directive("# comment"))
+
     def test_render_credentials_rejects_invalid_tables_and_paths(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             (root / "dir").mkdir()
             with self.assertRaises(SystemExit):
-                self.module.render_credentials({"credentials": []}, root, "codex")
+                self.module.render_credentials({"credentials": []}, root, "codex", "strict")
             with self.assertRaises(SystemExit):
                 self.module.render_credentials(
-                    {"credentials": {"codex_auth": "dir"}}, root, "codex"
+                    {"credentials": {"codex_auth": "dir"}}, root, "codex", "strict"
                 )
 
     def test_main_writes_manifest_for_supported_policy(self) -> None:
@@ -353,6 +428,7 @@ class RenderInjectionHelperTests(unittest.TestCase):
             policy_path = root / "policy.toml"
             (root / "common.md").write_text("common\n", encoding="utf-8")
             (root / "auth.json").write_text('{"token":"abc"}\n', encoding="utf-8")
+            (root / "auth.json").chmod(0o600)
             policy_path.write_text(
                 """
                 version = 1

--- a/tests/python/test_pty_transcript.py
+++ b/tests/python/test_pty_transcript.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+import runpy
+import signal
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from test_support import load_module
+
+
+class PtyTranscriptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = load_module("scripts/lib/pty_transcript.py")
+
+    def test_main_requires_command_after_separator(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "transcript.log"
+            argv = ["pty_transcript.py", "--log", str(log_path), "--"]
+            with mock.patch.object(sys, "argv", argv), mock.patch.object(
+                sys.stdin, "isatty", return_value=True
+            ), mock.patch.object(sys.stdout, "isatty", return_value=True):
+                with self.assertRaises(SystemExit) as exc:
+                    self.module.main()
+            self.assertEqual(str(exc.exception), "pty_transcript.py requires a command after --")
+
+    def test_main_requires_interactive_terminal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "transcript.log"
+            argv = ["pty_transcript.py", "--log", str(log_path), "--", "echo", "hello"]
+            with mock.patch.object(sys, "argv", argv), mock.patch.object(
+                sys.stdin, "isatty", return_value=False
+            ), mock.patch.object(sys.stdout, "isatty", return_value=True):
+                with self.assertRaises(SystemExit) as exc:
+                    self.module.main()
+            self.assertEqual(str(exc.exception), "pty_transcript.py requires an interactive terminal")
+
+    def test_main_strips_separator_records_transcript_and_returns_exit_code(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "transcript.log"
+            argv = ["pty_transcript.py", "--log", str(log_path), "--", "fake-agent", "--version"]
+
+            def fake_spawn(command, master_read, stdin_read):
+                self.assertEqual(command, ["fake-agent", "--version"])
+                stdin_read(10)
+                master_read(11)
+                return 7 << 8
+
+            with mock.patch.object(sys, "argv", argv), mock.patch.object(
+                sys.stdin, "isatty", return_value=True
+            ), mock.patch.object(sys.stdout, "isatty", return_value=True), mock.patch.object(
+                self.module.pty, "spawn", side_effect=fake_spawn
+            ), mock.patch.object(
+                self.module.os, "read", side_effect=[b"user input\n", b"child output\n"]
+            ):
+                self.assertEqual(self.module.main(), 7)
+
+            transcript = log_path.read_text(encoding="utf-8")
+            self.assertIn("# workcell-transcript-v1 start=", transcript)
+            self.assertIn("user input\nchild output\n", transcript)
+            self.assertIn("# workcell-transcript-v1 end=", transcript)
+            self.assertIn("wait_status=1792", transcript)
+            self.assertIn("exit_code=7", transcript)
+            self.assertEqual(stat_mode(log_path), 0o600)
+
+    def test_main_translates_signaled_status(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "transcript.log"
+            argv = ["pty_transcript.py", "--log", str(log_path), "--", "fake-agent"]
+
+            with mock.patch.object(sys, "argv", argv), mock.patch.object(
+                sys.stdin, "isatty", return_value=True
+            ), mock.patch.object(sys.stdout, "isatty", return_value=True), mock.patch.object(
+                self.module.pty, "spawn", return_value=signal.SIGTERM
+            ):
+                self.assertEqual(self.module.main(), 128 + signal.SIGTERM)
+
+    def test_main_returns_one_for_unexpected_wait_status_and_empty_reads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "transcript.log"
+            argv = ["pty_transcript.py", "--log", str(log_path), "fake-agent"]
+
+            def fake_spawn(command, master_read, stdin_read):
+                self.assertEqual(command, ["fake-agent"])
+                self.assertEqual(stdin_read(10), b"")
+                self.assertEqual(master_read(11), b"")
+                return 0x7F
+
+            with mock.patch.object(sys, "argv", argv), mock.patch.object(
+                sys.stdin, "isatty", return_value=True
+            ), mock.patch.object(sys.stdout, "isatty", return_value=True), mock.patch.object(
+                self.module.pty, "spawn", side_effect=fake_spawn
+            ), mock.patch.object(self.module.os, "read", side_effect=[b"", b""]):
+                self.assertEqual(self.module.main(), 1)
+
+            transcript = log_path.read_text(encoding="utf-8")
+            self.assertIn("# workcell-transcript-v1 start=", transcript)
+            self.assertIn("# workcell-transcript-v1 end=", transcript)
+
+    def test_module_main_entrypoint_raises_system_exit_with_return_code(self) -> None:
+        script_path = Path(__file__).resolve().parents[2] / "scripts/lib/pty_transcript.py"
+        argv = ["pty_transcript.py", "--log", "/tmp/workcell-transcript-entry.log", "fake-agent"]
+
+        with mock.patch.object(sys, "argv", argv), mock.patch.object(
+            sys.stdin, "isatty", return_value=True
+        ), mock.patch.object(sys.stdout, "isatty", return_value=True), mock.patch(
+            "pty.spawn", return_value=0
+        ):
+            with self.assertRaises(SystemExit) as exc:
+                runpy.run_path(str(script_path), run_name="__main__")
+        self.assertEqual(exc.exception.code, 0)
+
+
+def stat_mode(path: Path) -> int:
+    return os.stat(path).st_mode & 0o777
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_render_injection_bundle.py
+++ b/tests/python/test_render_injection_bundle.py
@@ -17,6 +17,9 @@ class RenderInjectionBundleTests(unittest.TestCase):
             (root / "claude-auth.json").write_text('{"token":"claude"}\n', encoding="utf-8")
             (root / "claude-mcp.json").write_text('{"mcpServers":{}}\n', encoding="utf-8")
             (root / "gemini-projects.json").write_text('{"projects":{}}\n', encoding="utf-8")
+            (root / "claude-auth.json").chmod(0o600)
+            (root / "claude-mcp.json").chmod(0o600)
+            (root / "gemini-projects.json").chmod(0o600)
 
             policy = {
                 "credentials": {
@@ -26,8 +29,8 @@ class RenderInjectionBundleTests(unittest.TestCase):
                 }
             }
 
-            claude_rendered = self.module.render_credentials(policy, root, "claude")
-            gemini_rendered = self.module.render_credentials(policy, root, "gemini")
+            claude_rendered = self.module.render_credentials(policy, root, "claude", "strict")
+            gemini_rendered = self.module.render_credentials(policy, root, "gemini", "strict")
 
             self.assertEqual(
                 claude_rendered["claude_auth"]["mount_path"],
@@ -55,6 +58,7 @@ class RenderInjectionBundleTests(unittest.TestCase):
             output.mkdir()
             (root / "public.txt").write_text("public\n", encoding="utf-8")
             (root / "secret.txt").write_text("secret\n", encoding="utf-8")
+            (root / "secret.txt").chmod(0o600)
 
             policy = {
                 "copies": [
@@ -176,6 +180,7 @@ class RenderInjectionBundleTests(unittest.TestCase):
             output = root / "bundle"
             output.mkdir()
             (root / "id_agent").write_text("key\n", encoding="utf-8")
+            (root / "id_agent").chmod(0o600)
 
             rendered = self.module.render_ssh(
                 {
@@ -192,6 +197,203 @@ class RenderInjectionBundleTests(unittest.TestCase):
             )
 
             self.assertEqual(rendered, {})
+
+    def test_render_credentials_respects_provider_and_mode_selection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            auth = root / "github-hosts.yml"
+            auth.write_text("github.com:\n", encoding="utf-8")
+            auth.chmod(0o600)
+
+            rendered = self.module.render_credentials(
+                {
+                    "credentials": {
+                        "github_hosts": {
+                            "source": "github-hosts.yml",
+                            "providers": ["claude"],
+                            "modes": ["build"],
+                        }
+                    }
+                },
+                root,
+                "codex",
+                "strict",
+            )
+
+            self.assertEqual(rendered, {})
+
+    def test_render_ssh_rejects_unsafe_config_without_opt_in(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            config = root / "ssh-config"
+            config.write_text("ProxyCommand nc %h %p\n", encoding="utf-8")
+            config.chmod(0o600)
+
+            with self.assertRaises(SystemExit):
+                self.module.render_ssh(
+                    {"ssh": {"enabled": True, "config": "ssh-config"}},
+                    output,
+                    root,
+                    "codex",
+                    "strict",
+                )
+
+    def test_render_credentials_rejects_world_readable_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            auth = root / "auth.json"
+            auth.write_text("{}\n", encoding="utf-8")
+            auth.chmod(0o644)
+
+            with self.assertRaises(SystemExit):
+                self.module.render_credentials(
+                    {"credentials": {"codex_auth": "auth.json"}},
+                    root,
+                    "codex",
+                    "strict",
+                )
+
+    def test_render_credentials_rejects_symlink_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            auth = root / "auth.json"
+            auth.write_text("{}\n", encoding="utf-8")
+            auth.chmod(0o600)
+            link = root / "auth-link.json"
+            link.symlink_to(auth)
+
+            with self.assertRaises(SystemExit):
+                self.module.render_credentials(
+                    {"credentials": {"codex_auth": "auth-link.json"}},
+                    root,
+                    "codex",
+                    "strict",
+                )
+
+    def test_render_credentials_rejects_symlinked_parent_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            real_dir = root / "real"
+            real_dir.mkdir()
+            auth = real_dir / "auth.json"
+            auth.write_text("{}\n", encoding="utf-8")
+            auth.chmod(0o600)
+            link_dir = root / "linked"
+            link_dir.symlink_to(real_dir, target_is_directory=True)
+
+            with self.assertRaises(SystemExit):
+                self.module.render_credentials(
+                    {"credentials": {"codex_auth": "linked/auth.json"}},
+                    root,
+                    "codex",
+                    "strict",
+                )
+
+    def test_render_credentials_rejects_absolute_paths_with_symlinked_parents_under_policy_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            real_dir = root / "real"
+            real_dir.mkdir()
+            nested_dir = real_dir / "sub"
+            nested_dir.mkdir()
+            auth = nested_dir / "auth.json"
+            auth.write_text("{}\n", encoding="utf-8")
+            auth.chmod(0o600)
+            link_dir = root / "linked"
+            link_dir.symlink_to(real_dir, target_is_directory=True)
+
+            with self.assertRaises(SystemExit):
+                self.module.render_credentials(
+                    {"credentials": {"codex_auth": str(link_dir / "sub/auth.json")}},
+                    root,
+                    "codex",
+                    "strict",
+                )
+
+    def test_render_credentials_rejects_absolute_paths_with_symlinked_parents_outside_policy_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            policy_root = base / "policy"
+            policy_root.mkdir()
+            outside_root = base / "outside"
+            real_dir = outside_root / "real"
+            real_dir.mkdir(parents=True)
+            nested_dir = real_dir / "sub"
+            nested_dir.mkdir()
+            auth = nested_dir / "auth.json"
+            auth.write_text("{}\n", encoding="utf-8")
+            auth.chmod(0o600)
+            link_dir = outside_root / "linked"
+            link_dir.symlink_to(real_dir, target_is_directory=True)
+
+            with self.assertRaises(SystemExit):
+                self.module.render_credentials(
+                    {"credentials": {"codex_auth": str(link_dir / "sub/auth.json")}},
+                    policy_root,
+                    "codex",
+                    "strict",
+                )
+
+    def test_render_ssh_allows_standard_known_hosts_permissions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            known_hosts = root / "known_hosts"
+            known_hosts.write_text("github.com ssh-ed25519 AAAA\n", encoding="utf-8")
+            known_hosts.chmod(0o644)
+
+            rendered = self.module.render_ssh(
+                {"ssh": {"enabled": True, "known_hosts": "known_hosts"}},
+                root / "bundle",
+                root,
+                "codex",
+                "strict",
+            )
+
+            self.assertEqual(
+                rendered["known_hosts"]["mount_path"],
+                "/opt/workcell/host-inputs/ssh/known_hosts",
+            )
+
+    def test_render_ssh_marks_safe_and_unsafe_config_assurance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            config = root / "ssh-config"
+            config.write_text("Host github.com\n  IdentityFile ~/.ssh/id_ed25519\n", encoding="utf-8")
+            config.chmod(0o600)
+            unsafe_config = root / "unsafe-ssh-config"
+            unsafe_config.write_text("ProxyCommand nc %h %p\n", encoding="utf-8")
+            unsafe_config.chmod(0o600)
+
+            safe_rendered = self.module.render_ssh(
+                {"ssh": {"enabled": True, "config": "ssh-config"}},
+                output,
+                root,
+                "codex",
+                "strict",
+            )
+            unsafe_rendered = self.module.render_ssh(
+                {
+                    "ssh": {
+                        "enabled": True,
+                        "config": "unsafe-ssh-config",
+                        "allow_unsafe_config": True,
+                    }
+                },
+                output,
+                root,
+                "codex",
+                "strict",
+            )
+
+            self.assertEqual(safe_rendered["config_assurance"], "safe")
+            self.assertEqual(
+                unsafe_rendered["config_assurance"],
+                "lower-assurance-unsafe-config",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- harden observability by narrowing transcript metadata, surfacing shared auth posture, and tightening log/audit UX
- add the pre-merge wrapper plus stronger dirty-worktree and remote snapshot alignment behavior
- expand provider parity coverage across Codex, Claude, and Gemini in smoke and invariant tests

## Verification
- ./scripts/validate-repo.sh
- ./scripts/dev-remote-validate.sh --host builder@bewear.internal.ajax.omsab.net --snapshot worktree --include-untracked --check validate --check smoke --check repro --check release-bundle
- six-way subagent review with no blockers on the final delta