### PR TITLE
Harden workcell validation and session safeguards

### DIFF
--- a/.github/workflows/hosted-controls.yml
+++ b/.github/workflows/hosted-controls.yml
@@ -27,5 +27,6 @@ jobs:
 
       - name: Verify GitHub-hosted controls
         env:
+          WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"
           WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}
         run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ Initial adapters target:
 ```bash
 ./scripts/install.sh
 workcell --prepare --agent codex --workspace /path/to/repo
+workcell --prepare-only --agent codex --workspace /path/to/repo
 workcell --agent codex --workspace /path/to/repo
 workcell --agent codex --inspect --workspace /path/to/repo
 workcell --agent codex --doctor --workspace /path/to/repo
-workcell --agent claude --agent-autonomy prompt --workspace /path/to/repo
+workcell --agent claude --workspace /path/to/repo
 workcell --prepare --agent gemini --agent-arg --version --workspace /path/to/repo
 man workcell
 ```
@@ -117,9 +118,14 @@ Workcell surfaces that posture explicitly in the launch audit output.
 making you repeat `codex`, `claude`, or `gemini` yourself. `--agent-arg`
 values are still treated as ordinary user-supplied provider argv and go
 through the same in-container denylist as raw `-- ...` arguments.
+`--prepare-only` is the prewarm path when you want to seed or refresh the
+reviewed runtime image without launching an agent session yet.
 `--cache-profile off` is the default. `--cache-profile standard` opt-ins to a
 host-persisted non-secret cache plane for package/build tooling such as npm,
-pip, Cargo registry/git, Go module/build cache, and `ccache`. That is a
+pnpm, pip, uv, Poetry, Cargo registry/git, Go module/build cache, `ccache`,
+`bun`, and XDG-cache-backed tooling. The persistent cache plane is scoped to
+the current workspace by default so one repo does not silently seed tool caches
+for another. That is a
 lower-assurance path and is not treated as part of the clean `strict`
 session boundary.
 `--codex-rules-mutability readonly` is the clean-session default. That keeps
@@ -159,13 +165,14 @@ root-to-runtime-user handoff inside the container:
 
 Choose the mutability lane explicitly:
 
-- `strict` + `--container-mutability ephemeral`: default DX lane,
-  `container_assurance=managed-mutable`. This allows transient package installs,
-  but a successful package mutation downgrades the live session to
-  `lower-assurance-package-mutation` until exit.
+- `strict`: default developer lane, `container_assurance=managed-mutable`.
+  This allows transient package installs, but a successful package mutation
+  downgrades the live session to `lower-assurance-package-mutation` until exit.
 - `strict` + `--container-mutability readonly`: strongest managed lane,
   `container_assurance=managed-readonly`. Package-manager writes stay blocked,
   so the in-session control-plane posture does not downgrade.
+- `build`: explicit mutable preparation lane with broader egress for dependency
+  and image creation work.
 - `--agent-autonomy prompt`: keeps the provider’s ordinary approval flow, but
   Workcell surfaces that separately as
   `autonomy_assurance=lower-assurance-prompt-autonomy`.
@@ -184,6 +191,8 @@ Common recovery paths:
 - First launch or missing prepared runtime image:
   `workcell --prepare --agent codex --workspace /path/to/repo`
   Replace `codex` with `claude` or `gemini` for the corresponding provider.
+- Prewarm the runtime image without launching:
+  `workcell --prepare-only --agent codex --workspace /path/to/repo`
 - First launch with provider prompts enabled:
   `workcell --prepare --agent claude --agent-autonomy prompt --workspace /path/to/repo`
 - One-off provider flags without repeating the provider command:
@@ -206,6 +215,8 @@ Common recovery paths:
   `workcell auth-status --agent codex --workspace /path/to/repo`
   This includes the primary provider auth mode, the ordered auth mode set, and
   SSH config assurance when injection is active.
+- Fast local validation during normal editing:
+  `./scripts/dev-quick-check.sh`
 - Clean stale Workcell temp state:
   `workcell --gc`
   Alias: `workcell gc`
@@ -264,7 +275,10 @@ claude_api_key = "/Users/example/.config/workcell/claude-api-key.txt"
 claude_mcp = "/Users/example/.config/workcell/claude-mcp.json"
 gemini_env = "/Users/example/.config/workcell/gemini.env"
 gemini_projects = "/Users/example/.config/workcell/gemini-projects.json"
-github_hosts = "/Users/example/.config/gh/hosts.yml"
+
+[credentials.github_hosts]
+source = "/Users/example/.config/gh/hosts.yml"
+providers = ["codex", "claude", "gemini"]
 
 [ssh]
 enabled = true
@@ -293,7 +307,11 @@ as `[credentials]` and are copied into the session from their original host
 paths. Secret sources must be owned by the launching user, must not be
 symlinks, and must not be group/world-readable. `ssh.known_hosts` is treated
 separately: the source file may stay world-readable as usual, but it must not
-be a symlink or group/world-writable. When you need provider- or mode-specific
+be a symlink or group/world-writable. Shared GitHub CLI credentials must use
+`[credentials.github_hosts]` or `[credentials.github_config]` tables with
+explicit `providers = [...]` selection. Legacy scalar shared GitHub credential
+entries still work as an all-provider shorthand for existing local policies.
+When you need provider- or mode-specific
 scoping, use `[credentials.<name>]` tables with `source`, `providers`, and
 `modes`.
 
@@ -337,11 +355,14 @@ Intentional non-goals for the safe path:
   validator image, runs workflow lint, validates the repo inside the validator
   container, then runs invariants, container smoke, release-bundle
   reproducibility, runtime reproducibility, and optionally the remote
-  linux/amd64 lane. By default it requires a clean worktree, including
-  untracked files. With `--allow-dirty`, local validation runs against the live
-  worktree and the remote lane auto-switches to `--remote-snapshot worktree`
-  plus `--include-untracked` unless you explicitly override the snapshot mode.
-  Workflow lint still depends on host `actionlint` and `zizmor`.
+  linux/amd64 lane. `--remote` runs the safe remote `validate` lane only;
+  `--remote-heavy` is the explicit shared-daemon escape hatch for remote
+  `smoke` / `repro` / `release-bundle` checks. By default it requires a clean
+  worktree, including untracked files. With `--allow-dirty`, local validation
+  runs against the live worktree and the remote lane auto-switches to
+  `--remote-snapshot worktree` plus `--include-untracked` unless you explicitly
+  override the snapshot mode. Workflow lint still depends on host `actionlint`
+  and `zizmor`.
 - `scripts/check-workflows.sh`: `actionlint` and `zizmor`
 - `scripts/check-pinned-inputs.sh`: pin-policy checks for non-ecosystem release
   inputs such as the Debian snapshot, immutable base-image digests, and exact
@@ -364,18 +385,18 @@ Intentional non-goals for the safe path:
   under a fixed `SOURCE_DATE_EPOCH`
 - `scripts/dev-remote-validate.sh`: stage the current working tree to a private
   remote amd64 builder, build an ephemeral remote helper container there from
-  `tools/remote-validator/Dockerfile`, and run
-  `validate-repo`, `container-smoke`,
-  `verify-reproducible-build`, and `verify-release-bundle` inside that
-  container as a single pre-push preflight. Set the builder explicitly with
-  `--host <user@host>` or `WORKCELL_REMOTE_VALIDATE_HOST`. The default remote
-  snapshot is the local index; `--snapshot worktree` and `--include-untracked`
-  are explicit opt-ins. For host-local defaults, point
-  `WORKCELL_REMOTE_VALIDATE_CONFIG_PATH` at a host-local config file or use the
-  default `~/.config/workcell/remote-validate.env`. The remote
-  reproducibility lane is intentionally native `linux/amd64` only; the
-  canonical multi-architecture release gate remains the local macOS plus GitHub
-  release path.
+  `tools/remote-validator/Dockerfile`. The default remote run is the safe
+  `validate` check only. Heavy shared-daemon checks such as `smoke`, `repro`,
+  and `release-bundle` require explicit `--check ...` selection plus
+  `--allow-shared-daemon-heavy-checks` or the corresponding host-local config
+  toggle. Set the builder explicitly with `--host <user@host>` or
+  `WORKCELL_REMOTE_VALIDATE_HOST`. The default remote snapshot is the local
+  index; `--snapshot worktree` and `--include-untracked` are explicit opt-ins.
+  For host-local defaults, point `WORKCELL_REMOTE_VALIDATE_CONFIG_PATH` at a
+  host-local config file or use the default
+  `~/.config/workcell/remote-validate.env`. The remote reproducibility lane is
+  intentionally native `linux/amd64` only; the canonical multi-architecture
+  release gate remains the local macOS plus GitHub release path.
 
 Full Colima plus Virtualization.Framework boundary verification remains a local
 or self-hosted macOS exercise. GitHub-hosted CI validates the repo shape and

--- a/docs/examples/injection-policy.toml
+++ b/docs/examples/injection-policy.toml
@@ -14,8 +14,14 @@ claude_mcp = "/Users/example/.config/workcell/claude-mcp.json"
 gemini_env = "/Users/example/.config/workcell/gemini.env"
 gemini_projects = "/Users/example/.config/workcell/gemini-projects.json"
 gcloud_adc = "/Users/example/.config/gcloud/application_default_credentials.json"
-github_hosts = "/Users/example/.config/gh/hosts.yml"
-github_config = "/Users/example/.config/gh/config.yml"
+
+[credentials.github_hosts]
+source = "/Users/example/.config/gh/hosts.yml"
+providers = ["codex", "claude", "gemini"]
+
+[credentials.github_config]
+source = "/Users/example/.config/gh/config.yml"
+providers = ["codex", "claude", "gemini"]
 
 [ssh]
 enabled = true

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -67,8 +67,11 @@ Selectors let you scope injected material to only some launches:
 - `providers = ["codex", "claude", "gemini"]`
 - `modes = ["strict", "build"]`
 
-For `[credentials]`, simple `key = "/path/to/file"` entries still work, and
-scoped entries can be expressed as nested tables:
+For `[credentials]`, simple `key = "/path/to/file"` entries still work for
+provider-native credentials. Shared GitHub CLI credentials should use scoped
+nested tables so you explicitly choose which provider sessions receive them.
+Legacy scalar shared GitHub entries still work as an all-provider shorthand for
+existing local policies:
 
 ```toml
 [credentials.github_hosts]
@@ -93,7 +96,8 @@ modes = ["strict", "build"]
 - no writes into Workcell-generated helper state such as
   `~/.claude/workcell/`
 - no unsafe SSH config directives such as `ProxyCommand`, `LocalCommand`,
-  `Include`, `IdentityAgent`, or `Match exec` unless you explicitly set
+  `Include`, `IdentityAgent`, `KnownHostsCommand`, `PKCS11Provider`,
+  `SecurityKeyProvider`, or `Match exec` unless you explicitly set
   `ssh.allow_unsafe_config = true`
 
 ## Recommended patterns
@@ -135,7 +139,11 @@ modes = ["strict", "build"]
   session without widening trust to the whole workspace copy.
 - `credentials.gemini_env` mounts a provider-native `~/.gemini/.env`.
   This matches Gemini CLI's documented env-file auth flow for API keys,
-  Vertex project settings, and related variables.
+  Vertex project settings, and related variables. When the file includes
+  `GOOGLE_CLOUD_LOCATION`, `GOOGLE_CLOUD_REGION`, `CLOUD_ML_REGION`,
+  `VERTEX_LOCATION`, or `VERTEX_AI_LOCATION`, Workcell also derives the
+  corresponding regional `LOCATION-aiplatform.googleapis.com` allowlist entry
+  for strict-mode Vertex sessions.
 - `credentials.gemini_oauth` mounts a cached Gemini OAuth credential file when
   you already have one on the host.
 - `credentials.gemini_projects` mounts a persisted Gemini `projects.json`
@@ -144,7 +152,10 @@ modes = ["strict", "build"]
   `~/.config/gcloud/application_default_credentials.json` for Gemini Vertex
   flows.
 - `credentials.github_hosts` and `credentials.github_config` mount GitHub CLI
-  auth/config into `~/.config/gh/`.
+  auth/config into `~/.config/gh/`. Because those credentials are shared across
+  tools rather than provider-native, prefer `[credentials.github_hosts]` or
+  `[credentials.github_config]` tables with explicit `providers = [...]`
+  selection over the legacy scalar shorthand.
 
 ## Example
 

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -79,7 +79,7 @@ The current enforcement model is not a hostname-aware proxy. `strict` does not
 perform cold image builds or rebuilds; runtime-image creation is an explicit
 `build`-mode operation that may temporarily apply a separate pinned bootstrap
 endpoint set before returning to the steady-state runtime allowlist. When the
-operator keeps the default `ephemeral` container mutability, the steady-state
+operator explicitly opts into `ephemeral` container mutability, the steady-state
 allowlist also includes the pinned Debian snapshot endpoints used by
 `apt` and `apt-get` so transient build tooling can be installed without enabling
 arbitrary distro mirrors. A successful package mutation is an explicit
@@ -145,21 +145,23 @@ command.
 - provider-native bounded or constrained mode only where the provider offers
   one, with the shared Workcell runtime remaining the primary boundary
 - allowlisted steady-state egress only
-- pinned Debian snapshot egress for `apt` and `apt-get` when the default
+- pinned Debian snapshot egress for `apt` and `apt-get` when explicit
   `ephemeral` container mutability is active
 - requires a prebuilt prepared runtime image; `strict` does not rebuild or
   cold-bootstrap that image
 - requires active Docker seccomp support in the managed runtime before launch
 - may mount an opt-in host-persisted non-secret cache plane for package
-  indexes and compiler caches when `cache_profile=standard`; this is a
+  indexes and compiler caches when `cache_profile=standard`; the default cache
+  namespace is scoped to the current workspace, and this is still a
   lower-assurance path and is not part of the clean `strict` session boundary
 
 Assurance mapping within `strict`:
 
-- `ephemeral`: default DX lane, `container_assurance=managed-mutable`
+- `ephemeral`: default developer lane, `container_assurance=managed-mutable`
 - `ephemeral` adds only the handoff capabilities required to move from root to
   the mapped runtime user inside the container: `SETUID`, `SETGID`
-- `readonly`: strongest managed lane, `container_assurance=managed-readonly`
+- `readonly`: strongest managed lane for `strict`,
+  `container_assurance=managed-readonly`
 - prompt autonomy: separate lower-assurance flag,
   `autonomy_assurance=lower-assurance-prompt-autonomy`
 - session Codex rules mutability: explicit lower-assurance flag,

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -116,7 +116,8 @@ Using
 .BR standard
 persists package-index and compiler caches such as npm, pip, Cargo, Go, and
 .BR ccache ,
-but it is a lower-assurance path and is not treated as part of the clean
+scoped to the current workspace by default, but it is still a lower-assurance
+path and is not treated as part of the clean
 .B strict
 session boundary.
 .TP
@@ -169,6 +170,11 @@ Select the runtime profile. The default is
 .B --prepare
 Seed or refresh the prepared runtime image before continuing with the requested
 launch. This is the recommended first-run path.
+.TP
+.B --prepare-only
+Seed or refresh the prepared runtime image and then exit without launching a
+session. This is the recommended prewarm path when you want to remove the cold
+build cost ahead of time.
 .TP
 .B --repair-profile
 Delete a conflicting unmanaged Colima profile before launch so Workcell can
@@ -386,6 +392,12 @@ Recommended first launch:
 .IP
 .EX
 workcell --prepare --agent codex --workspace /path/to/repo
+.EE
+.PP
+Prewarm the prepared runtime image without launching:
+.IP
+.EX
+workcell --prepare-only --agent codex --workspace /path/to/repo
 .EE
 .PP
 Replace

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -3,12 +3,87 @@
 # shellcheck disable=SC1091
 source /usr/local/libexec/workcell/assurance.sh
 
+workcell_managed_session_root_for_path() {
+  local path="$1"
+
+  case "${path}" in
+    /state/agent-home | /state/agent-home/*)
+      printf '/state/agent-home\n'
+      ;;
+    /state/injected | /state/injected/*)
+      printf '/state/injected\n'
+      ;;
+    *)
+      workcell_die "Workcell session target is outside the managed session roots: ${path}"
+      ;;
+  esac
+}
+
+workcell_assert_no_symlink_path_components() {
+  local path="$1"
+  local label="$2"
+  local include_target="${3:-1}"
+  local root=""
+  local current=""
+
+  root="$(workcell_managed_session_root_for_path "${path}")"
+  if [[ "${include_target}" == "1" ]]; then
+    current="${path}"
+  else
+    current="$(dirname "${path}")"
+  fi
+  while :; do
+    if [[ -L "${current}" ]]; then
+      workcell_die "Workcell refused ${label}: symlinked session path component ${current}"
+    fi
+    if [[ "${current}" == "${root}" ]]; then
+      return 0
+    fi
+    current="$(dirname "${current}")"
+  done
+}
+
+workcell_prepare_session_parent() {
+  local target_path="$1"
+  local label="$2"
+  local parent_path=""
+
+  workcell_assert_no_symlink_path_components "${target_path}" "${label}" 0
+  parent_path="$(dirname "${target_path}")"
+  mkdir -p "${parent_path}"
+  workcell_assert_no_symlink_path_components "${target_path}" "${label}" 0
+}
+
+workcell_prepare_session_directory() {
+  local target_path="$1"
+  local label="$2"
+
+  workcell_prepare_session_parent "${target_path}" "${label}"
+  if [[ -e "${target_path}" ]] && [[ ! -d "${target_path}" ]]; then
+    rm -rf "${target_path}"
+  fi
+  mkdir -p "${target_path}"
+  workcell_assert_no_symlink_path_components "${target_path}" "${label}"
+}
+
+workcell_reset_session_target() {
+  local target_path="$1"
+  local label="$2"
+
+  workcell_prepare_session_parent "${target_path}" "${label}"
+  if [[ -L "${target_path}" ]]; then
+    rm -f "${target_path}"
+  elif [[ -e "${target_path}" ]]; then
+    rm -rf "${target_path}"
+  fi
+  workcell_assert_no_symlink_path_components "${target_path}" "${label}"
+}
+
 workcell_link_control_plane_path() {
   local source_path="$1"
   local target_path="$2"
 
-  mkdir -p "$(dirname "${target_path}")"
-  rm -rf "${target_path}"
+  workcell_reset_session_target "${target_path}" "control-plane link"
   ln -s "${source_path}" "${target_path}"
 }
 
@@ -18,8 +93,7 @@ workcell_copy_control_plane_tree() {
   local file_mode="$3"
   local dir_mode="$4"
 
-  mkdir -p "$(dirname "${target_path}")"
-  rm -rf "${target_path}"
+  workcell_reset_session_target "${target_path}" "control-plane tree"
   mkdir -p "${target_path}"
   cp -R "${source_path}/." "${target_path}"
   find "${target_path}" -type d -exec chmod "${dir_mode}" {} +
@@ -199,7 +273,7 @@ workcell_copy_manifest_credential_file() {
   source_path="$(workcell_manifest_direct_mount_path ".credentials[\"${key}\"].mount_path // empty" || true)"
   [[ -n "${source_path}" ]] || return 1
 
-  mkdir -p "$(dirname "${target_path}")"
+  workcell_reset_session_target "${target_path}" "credential copy"
   if [[ ! -f "${source_path}" ]]; then
     workcell_die "Workcell expected mounted credential file for ${key}: ${source_path}"
   fi
@@ -234,18 +308,21 @@ workcell_render_claude_settings() {
   helper_secret="${helper_dir}/claude-api-key"
   helper_script="${helper_dir}/api-key-helper.sh"
 
-  mkdir -p "${helper_dir}"
+  workcell_prepare_session_directory "${helper_dir}" "Claude helper directory"
   if [[ ! -f "${api_key_source}" ]]; then
     workcell_die "Workcell expected mounted credential file for claude_api_key: ${api_key_source}"
   fi
+  workcell_reset_session_target "${helper_secret}" "Claude helper secret"
   cp "${api_key_source}" "${helper_secret}"
   chmod 0600 "${helper_secret}"
+  workcell_reset_session_target "${helper_script}" "Claude helper script"
   cat >"${helper_script}" <<EOF
 #!/bin/sh
 set -eu
 cat "${helper_secret}"
 EOF
   chmod 0700 "${helper_script}"
+  workcell_reset_session_target "${target_path}" "Claude settings"
   jq --arg helper "${helper_script}" '.apiKeyHelper = $helper' "${baseline_path}" >"${target_path}"
   chmod 0600 "${target_path}"
 }
@@ -308,14 +385,12 @@ workcell_copy_manifest_entry() {
 
   case "${kind}" in
     file)
-      mkdir -p "$(dirname "${target_path}")"
-      rm -rf "${target_path}"
+      workcell_reset_session_target "${target_path}" "injected copy"
       cp "${source_path}" "${target_path}"
       chmod "${file_mode}" "${target_path}"
       ;;
     dir)
-      mkdir -p "$(dirname "${target_path}")"
-      rm -rf "${target_path}"
+      workcell_reset_session_target "${target_path}" "injected copy"
       mkdir -p "${target_path}"
       cp -R "${source_path}/." "${target_path}"
       find "${target_path}" -type d -exec chmod "${dir_mode}" {} +
@@ -362,8 +437,7 @@ workcell_render_provider_doc() {
     return 0
   fi
 
-  mkdir -p "$(dirname "${target_path}")"
-  rm -rf "${target_path}"
+  workcell_reset_session_target "${target_path}" "provider document"
   {
     cat "${baseline_path}"
     if [[ -n "${workspace_common_doc}" ]]; then
@@ -455,15 +529,17 @@ workcell_apply_manifest_ssh() {
     return 0
   fi
 
-  mkdir -p "${HOME}/.ssh"
+  workcell_prepare_session_directory "${HOME}/.ssh" "SSH home"
   chmod 0700 "${HOME}/.ssh"
 
   if [[ -n "${config_source}${config_mount_path}" ]]; then
+    workcell_reset_session_target "${HOME}/.ssh/config" "SSH config"
     cp "$(workcell_resolve_manifest_input_path "${config_source}" "${config_mount_path}")" "${HOME}/.ssh/config"
     chmod 0600 "${HOME}/.ssh/config"
   fi
 
   if [[ -n "${known_hosts_source}${known_hosts_mount_path}" ]]; then
+    workcell_reset_session_target "${HOME}/.ssh/known_hosts" "known_hosts"
     cp "$(workcell_resolve_manifest_input_path "${known_hosts_source}" "${known_hosts_mount_path}")" "${HOME}/.ssh/known_hosts"
     chmod 0600 "${HOME}/.ssh/known_hosts"
   fi
@@ -473,13 +549,15 @@ workcell_apply_manifest_ssh() {
     identity_mount_path="$(jq -r '.mount_path // ""' <<<"${entry_json}")"
     identity_name="$(jq -r '.target_name' <<<"${entry_json}")"
     [[ -n "${identity_source}${identity_mount_path}" ]] || continue
+    workcell_reset_session_target "${HOME}/.ssh/${identity_name}" "SSH identity"
     cp "$(workcell_resolve_manifest_input_path "${identity_source}" "${identity_mount_path}")" "${HOME}/.ssh/${identity_name}"
     chmod 0600 "${HOME}/.ssh/${identity_name}"
   done < <(jq -c '.ssh.identities[]?' "$(workcell_manifest_path)")
 }
 
 seed_codex_home() {
-  mkdir -p "${CODEX_HOME}" "${CODEX_HOME}/mcp"
+  workcell_prepare_session_directory "${CODEX_HOME}" "Codex home"
+  workcell_prepare_session_directory "${CODEX_HOME}/mcp" "Codex MCP directory"
   workcell_render_provider_doc "${ADAPTER_ROOT}/codex/.codex/AGENTS.md" "${CODEX_HOME}/AGENTS.md" codex
   workcell_link_control_plane_path "${ADAPTER_ROOT}/codex/.codex/config.toml" "${CODEX_HOME}/config.toml"
   workcell_link_control_plane_path "${ADAPTER_ROOT}/codex/managed_config.toml" "${CODEX_HOME}/managed_config.toml"
@@ -491,10 +569,10 @@ seed_codex_home() {
 }
 
 seed_claude_home() {
-  mkdir -p "${HOME}/.claude"
+  workcell_prepare_session_directory "${HOME}/.claude" "Claude home"
   workcell_render_claude_settings
   workcell_render_provider_doc "${ADAPTER_ROOT}/claude/CLAUDE.md" "${HOME}/.claude/CLAUDE.md" claude
-  mkdir -p "${HOME}/.config/claude-code"
+  workcell_prepare_session_directory "${HOME}/.config/claude-code" "Claude auth directory"
   workcell_copy_manifest_credential_file claude_auth "${HOME}/.config/claude-code/auth.json" || true
   if ! workcell_copy_manifest_credential_file claude_mcp "${HOME}/.mcp.json"; then
     workcell_link_control_plane_path "${ADAPTER_ROOT}/claude/mcp-template.json" "${HOME}/.mcp.json"
@@ -502,21 +580,24 @@ seed_claude_home() {
 }
 
 seed_gemini_home() {
-  mkdir -p "${HOME}/.gemini"
+  workcell_prepare_session_directory "${HOME}/.gemini" "Gemini home"
   rm -f "${HOME}/.gemini/settings.json"
   cp "${ADAPTER_ROOT}/gemini/.gemini/settings.json" "${HOME}/.gemini/settings.json"
   chmod 0600 "${HOME}/.gemini/settings.json"
   workcell_render_provider_doc "${ADAPTER_ROOT}/gemini/GEMINI.md" "${HOME}/.gemini/GEMINI.md" gemini
   workcell_copy_manifest_credential_file gemini_env "${HOME}/.gemini/.env" || true
   workcell_copy_manifest_credential_file gemini_oauth "${HOME}/.gemini/oauth_creds.json" || true
+  workcell_prepare_session_directory "${HOME}/.config/gcloud" "Google ADC directory"
   workcell_copy_manifest_credential_file gcloud_adc "${HOME}/.config/gcloud/application_default_credentials.json" || true
   if ! workcell_copy_manifest_credential_file gemini_projects "${HOME}/.gemini/projects.json"; then
+    workcell_reset_session_target "${HOME}/.gemini/projects.json" "Gemini projects"
     printf '{\n  "projects": {}\n}\n' >"${HOME}/.gemini/projects.json"
     chmod 0600 "${HOME}/.gemini/projects.json"
   fi
 }
 
 workcell_seed_shared_credentials() {
+  workcell_prepare_session_directory "${HOME}/.config/gh" "GitHub CLI config directory"
   workcell_copy_manifest_credential_file github_config "${HOME}/.config/gh/config.yml" || true
   workcell_copy_manifest_credential_file github_hosts "${HOME}/.config/gh/hosts.yml" || true
 }

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -738,7 +738,10 @@ claude_api_key = "claude-api-key.txt"
 claude_mcp = "claude-mcp.json"
 gemini_env = "gemini.env"
 gemini_projects = "gemini-projects.json"
-github_hosts = "gh-hosts.yml"
+
+[credentials.github_hosts]
+source = "gh-hosts.yml"
+providers = ["codex", "claude", "gemini"]
 
 [ssh]
 enabled = true
@@ -828,6 +831,15 @@ run_container_with_injection_bundle codex "${INJECTION_BUNDLE_ROOT}/codex" bash 
     apt-get --help >/dev/null
     sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get --help >/dev/null
     codex --version >/dev/null
+    mkdir -p /workspace/exfil
+    rm -rf "$HOME/.config/workcell"
+    ln -s /workspace/exfil "$HOME/.config/workcell"
+    if codex --version >/tmp/codex-injected-copy-symlink.out 2>&1; then
+      echo "expected nested Codex launch to reject symlinked injected-copy parents" >&2
+      exit 1
+    fi
+    grep -q "symlinked session path component" /tmp/codex-injected-copy-symlink.out
+    test ! -e /workspace/exfil/token.txt
   '"'"'
 '
 

--- a/scripts/dev-quick-check.sh
+++ b/scripts/dev-quick-check.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required tool: $1" >&2
+    exit 1
+  }
+}
+
+require_tool shellcheck
+require_tool shfmt
+require_tool python3
+require_tool cargo
+require_tool rustfmt
+
+shell_files=(
+  "${ROOT_DIR}/scripts/dev-quick-check.sh"
+  "${ROOT_DIR}/scripts/workcell"
+  "${ROOT_DIR}/scripts/dev-remote-validate.sh"
+  "${ROOT_DIR}/runtime/container/bin/apt-helper.sh"
+  "${ROOT_DIR}/runtime/container/bin/apt-wrapper.sh"
+  "${ROOT_DIR}/runtime/container/home-control-plane.sh"
+  "${ROOT_DIR}/runtime/container/provider-wrapper.sh"
+  "${ROOT_DIR}/runtime/container/runtime-user.sh"
+)
+
+mapfile -t python_files < <(
+  find "${ROOT_DIR}/scripts/lib" "${ROOT_DIR}/tests/python" \
+    -type f -name '*.py' -print | sort
+)
+
+shellcheck -x "${shell_files[@]}"
+shfmt -ln=bash -i 2 -ci -d "${shell_files[@]}"
+python3 -m py_compile "${python_files[@]}"
+python3 -m unittest discover -s "${ROOT_DIR}/tests/python" -p 'test_*.py'
+
+(
+  cd "${ROOT_DIR}/runtime/container/rust"
+  cargo fmt --all --check
+  cargo test --locked --offline
+)
+
+echo "Workcell quick validation passed."

--- a/scripts/dev-remote-validate.sh
+++ b/scripts/dev-remote-validate.sh
@@ -6,6 +6,7 @@ if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
     PATH="${TRUSTED_HOST_PATH}" \
     HOME=/tmp \
     TMPDIR="${TMPDIR:-/tmp}" \
+    WORKCELL_REMOTE_VALIDATE_ALLOW_SHARED_DAEMON_HEAVY_CHECKS="${WORKCELL_REMOTE_VALIDATE_ALLOW_SHARED_DAEMON_HEAVY_CHECKS-}" \
     WORKCELL_REMOTE_VALIDATE_BASE_DIR="${WORKCELL_REMOTE_VALIDATE_BASE_DIR-}" \
     WORKCELL_REMOTE_VALIDATE_CONFIG_PATH="${WORKCELL_REMOTE_VALIDATE_CONFIG_PATH-}" \
     WORKCELL_REMOTE_VALIDATE_HOST="${WORKCELL_REMOTE_VALIDATE_HOST-}" \
@@ -28,6 +29,7 @@ LEGACY_LOCAL_REMOTE_CONFIG_PATH="${ROOT_DIR}/.workcell.remote.local"
 REMOTE_CONFIG_PATH="${WORKCELL_REMOTE_VALIDATE_CONFIG_PATH:-${REAL_HOME}/.config/workcell/remote-validate.env}"
 REMOTE_HOST="${WORKCELL_REMOTE_VALIDATE_HOST:-}"
 REMOTE_BASE_DIR="${WORKCELL_REMOTE_VALIDATE_BASE_DIR:-/tmp}"
+ALLOW_SHARED_DAEMON_HEAVY_CHECKS="${WORKCELL_REMOTE_VALIDATE_ALLOW_SHARED_DAEMON_HEAVY_CHECKS:-0}"
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -C "${ROOT_DIR}" log -1 --pretty=%ct 2>/dev/null || printf '0')}"
 REMOTE_USE_SUDO=1
 KEEP_REMOTE_DIR=0
@@ -56,7 +58,10 @@ that container.
 If ${REMOTE_CONFIG_PATH} exists, Workcell loads simple KEY=VALUE entries for
 WORKCELL_REMOTE_VALIDATE_HOST, WORKCELL_REMOTE_VALIDATE_BASE_DIR, and
 WORKCELL_REMOTE_VALIDATE_USE_SUDO from that host-local config before CLI
-parsing. Override the path with WORKCELL_REMOTE_VALIDATE_CONFIG_PATH or
+parsing. It also honors
+WORKCELL_REMOTE_VALIDATE_ALLOW_SHARED_DAEMON_HEAVY_CHECKS=1 there when you
+explicitly accept lower-assurance heavy checks on a shared remote Docker
+daemon. Override the path with WORKCELL_REMOTE_VALIDATE_CONFIG_PATH or
 --config <path>.
 
 Options:
@@ -76,7 +81,12 @@ Options:
                               remote docker commands
   --check <name>              One or more checks to run. Valid values:
                               validate, smoke, repro, release-bundle
-                              Default: all
+                              Default: validate
+  --allow-shared-daemon-heavy-checks
+                              Allow heavy remote checks that mount the shared
+                              remote Docker daemon into the helper container.
+                              This is lower-assurance and should be enabled
+                              only on a reviewed builder.
   --keep-remote-dir           Preserve the remote temp directory after exit
   --dry-run                   Print the plan without staging or executing
   -h, --help                  Show this help
@@ -163,6 +173,7 @@ load_local_remote_config() {
   assert_supported_remote_config_path "${REMOTE_CONFIG_PATH}"
 
   [[ -f "${REMOTE_CONFIG_PATH}" ]] || return 0
+  ALLOW_SHARED_DAEMON_HEAVY_CHECKS=0
 
   while IFS= read -r line || [[ -n "${line}" ]]; do
     line="${line#"${line%%[![:space:]]*}"}"
@@ -197,6 +208,17 @@ load_local_remote_config() {
             ;;
           *)
             echo "WORKCELL_REMOTE_VALIDATE_USE_SUDO in ${REMOTE_CONFIG_PATH} must be 0 or 1." >&2
+            exit 1
+            ;;
+        esac
+        ;;
+      WORKCELL_REMOTE_VALIDATE_ALLOW_SHARED_DAEMON_HEAVY_CHECKS)
+        case "${value}" in
+          0 | 1)
+            ALLOW_SHARED_DAEMON_HEAVY_CHECKS="${value}"
+            ;;
+          *)
+            echo "WORKCELL_REMOTE_VALIDATE_ALLOW_SHARED_DAEMON_HEAVY_CHECKS in ${REMOTE_CONFIG_PATH} must be 0 or 1." >&2
             exit 1
             ;;
         esac
@@ -385,6 +407,10 @@ while [[ $# -gt 0 ]]; do
       add_check "$2"
       shift 2
       ;;
+    --allow-shared-daemon-heavy-checks)
+      ALLOW_SHARED_DAEMON_HEAVY_CHECKS=1
+      shift
+      ;;
     --keep-remote-dir)
       KEEP_REMOTE_DIR=1
       shift
@@ -408,7 +434,7 @@ done
 require_remote_host
 
 if [[ "${#CHECKS[@]}" -eq 0 ]]; then
-  CHECKS=(validate smoke repro release-bundle)
+  CHECKS=(validate)
 fi
 
 if [[ "${SNAPSHOT_MODE}" != "worktree" ]] && [[ "${INCLUDE_UNTRACKED}" == "1" ]]; then
@@ -441,7 +467,27 @@ if [[ "${SNAPSHOT_MODE}" == "worktree" ]]; then
   echo "Include untracked: ${INCLUDE_UNTRACKED}"
 fi
 echo "Checks: ${CHECKS[*]}"
+echo "Allow shared-daemon heavy checks: ${ALLOW_SHARED_DAEMON_HEAVY_CHECKS}"
 echo "SOURCE_DATE_EPOCH: ${SOURCE_DATE_EPOCH}"
+
+LIGHT_CHECKS=()
+HEAVY_CHECKS=()
+for check in "${CHECKS[@]}"; do
+  case "${check}" in
+    validate)
+      LIGHT_CHECKS+=("${check}")
+      ;;
+    smoke | repro | release-bundle)
+      HEAVY_CHECKS+=("${check}")
+      ;;
+  esac
+done
+
+if ((${#HEAVY_CHECKS[@]} > 0)) && [[ "${ALLOW_SHARED_DAEMON_HEAVY_CHECKS}" != "1" ]]; then
+  echo "Heavy remote checks require --allow-shared-daemon-heavy-checks or WORKCELL_REMOTE_VALIDATE_ALLOW_SHARED_DAEMON_HEAVY_CHECKS=1 in the host-local config." >&2
+  echo "Those checks mount the shared remote Docker daemon into the helper container and are lower-assurance on a shared builder." >&2
+  exit 1
+fi
 
 if [[ "${DRY_RUN}" == "1" ]]; then
   echo "Dry run only; no files were staged to the remote builder."
@@ -539,33 +585,46 @@ remote_docker build \
   -f "${REMOTE_DIR}/helper/Dockerfile" \
   "${REMOTE_DIR}/helper" >/dev/null
 
-remote_docker run --rm \
-  -i \
-  -e HOME=/tmp/workcell-home \
-  -e SSL_CERT_DIR=/etc/ssl/certs \
-  -e SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
-  -e SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}" \
-  -e WORKCELL_CONTAINER_SMOKE_DOCKER_CONTEXT=default \
-  -e WORKCELL_DOCKER_HOST_HOME_ROOT="${REMOTE_HOME}" \
-  -e WORKCELL_DOCKER_HOST_WORKSPACE_ROOT="${REMOTE_DIR}/repo" \
-  -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC=1 \
-  -e WORKCELL_REMOTE_BUILDKIT_LOCAL_CA=/host-local-ca \
-  -e WORKCELL_REMOTE_BUILDKIT_SSL_CERTS=/host-ssl-certs \
-  -e WORKCELL_REPRO_PLATFORMS=linux/amd64 \
-  -e WORKCELL_RELEASE_BUNDLE_DOCKER_CONTEXT=default \
-  -e WORKCELL_REPRO_DOCKER_CONTEXT=default \
-  -e WORKCELL_TEST_HOST_GID="${REMOTE_LOGIN_GID}" \
-  -e WORKCELL_TEST_HOST_UID="${REMOTE_LOGIN_UID}" \
-  -e WORKCELL_TEST_HOST_USER="${REMOTE_LOGIN_USER}" \
-  -v /etc/ssl/certs:/host-ssl-certs:ro \
-  -v /etc/ssl/certs:/etc/ssl/certs:ro \
-  -v /usr/local/share/ca-certificates:/host-local-ca:ro \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v "${REMOTE_DIR}/repo:/workspace" \
-  -v "${REMOTE_HOME}:/tmp/workcell-home" \
-  --entrypoint /bin/bash \
-  "${REMOTE_VALIDATOR_IMAGE}" \
-  -s -- "${CHECKS[@]}" <<'EOF'
+run_remote_validator_container() {
+  local needs_docker="$1"
+  shift
+  local -a selected_checks=("$@")
+  local -a docker_args=(
+    run --rm
+    -i
+    -e HOME=/tmp/workcell-home
+    -e SSL_CERT_DIR=/etc/ssl/certs
+    -e SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+    -e SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}"
+    -e WORKCELL_TEST_HOST_GID="${REMOTE_LOGIN_GID}"
+    -e WORKCELL_TEST_HOST_UID="${REMOTE_LOGIN_UID}"
+    -e WORKCELL_TEST_HOST_USER="${REMOTE_LOGIN_USER}"
+    -v /etc/ssl/certs:/etc/ssl/certs:ro
+    -v "${REMOTE_DIR}/repo:/workspace"
+  )
+
+  if [[ "${needs_docker}" == "1" ]]; then
+    docker_args+=(
+      -e WORKCELL_CONTAINER_SMOKE_DOCKER_CONTEXT=default
+      -e WORKCELL_DOCKER_HOST_HOME_ROOT="${REMOTE_HOME}"
+      -e WORKCELL_DOCKER_HOST_WORKSPACE_ROOT="${REMOTE_DIR}/repo"
+      -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC=1
+      -e WORKCELL_REMOTE_BUILDKIT_LOCAL_CA=/host-local-ca
+      -e WORKCELL_REMOTE_BUILDKIT_SSL_CERTS=/host-ssl-certs
+      -e WORKCELL_REPRO_PLATFORMS=linux/amd64
+      -e WORKCELL_RELEASE_BUNDLE_DOCKER_CONTEXT=default
+      -e WORKCELL_REPRO_DOCKER_CONTEXT=default
+      -v /etc/ssl/certs:/host-ssl-certs:ro
+      -v /usr/local/share/ca-certificates:/host-local-ca:ro
+      -v "${REMOTE_HOME}:/tmp/workcell-home"
+      -v /var/run/docker.sock:/var/run/docker.sock
+    )
+  fi
+
+  remote_docker "${docker_args[@]}" \
+    --entrypoint /bin/bash \
+    "${REMOTE_VALIDATOR_IMAGE}" \
+    -s -- "${selected_checks[@]}" <<'EOF'
 set -euo pipefail
 
 REMOTE_BUILDER_NAME=""
@@ -584,6 +643,7 @@ mkdir -p /workspace/tmp
 chown "${WORKCELL_TEST_HOST_UID}:${WORKCELL_TEST_HOST_GID}" /workspace/tmp
 chmod 0755 /workspace/tmp
 
+rm -rf /workspace/.git
 git init -q
 git config user.name "Workcell Remote Validate"
 git config user.email "workcell@example.invalid"
@@ -632,6 +692,15 @@ for check in "$@"; do
   esac
 done
 EOF
+}
+
+if ((${#LIGHT_CHECKS[@]} > 0)); then
+  run_remote_validator_container 0 "${LIGHT_CHECKS[@]}"
+fi
+
+if ((${#HEAVY_CHECKS[@]} > 0)); then
+  run_remote_validator_container 1 "${HEAVY_CHECKS[@]}"
+fi
 
 if [[ "${KEEP_REMOTE_DIR}" == "1" ]]; then
   echo "Remote validation finished. Preserved workspace: ${REMOTE_DIR}"

--- a/scripts/lib/render_injection_bundle.py
+++ b/scripts/lib/render_injection_bundle.py
@@ -22,8 +22,11 @@ RESERVED_SSH_FILENAMES = {"config", "known_hosts"}
 RISKY_SSH_DIRECTIVES = {
     "identityagent",
     "include",
+    "knownhostscommand",
     "localcommand",
+    "pkcs11provider",
     "proxycommand",
+    "securitykeyprovider",
 }
 SESSION_HOME_ROOT = PurePosixPath("/state/agent-home")
 RUN_INJECTED_ROOT = PurePosixPath("/state/injected")
@@ -76,6 +79,13 @@ AGENT_SCOPED_CREDENTIAL_KEYS = {
 }
 
 SHARED_CREDENTIAL_KEYS = {"github_hosts", "github_config"}
+GEMINI_VERTEX_LOCATION_KEYS = (
+    "GOOGLE_CLOUD_LOCATION",
+    "GOOGLE_CLOUD_REGION",
+    "CLOUD_ML_REGION",
+    "VERTEX_LOCATION",
+    "VERTEX_AI_LOCATION",
+)
 
 
 def die(message: str) -> NoReturn:
@@ -214,6 +224,57 @@ def direct_mount_entry(source: Path, mount_path: str) -> dict[str, str]:
         "source": str(source),
         "mount_path": mount_path,
     }
+
+
+def parse_simple_env_file(source: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in source.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or any(char.isspace() for char in key):
+            continue
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            try:
+                parsed = ast.literal_eval(value)
+            except (SyntaxError, ValueError):
+                parsed = value[1:-1]
+            value = parsed if isinstance(parsed, str) else str(parsed)
+        values[key] = value
+    return values
+
+
+def normalize_vertex_location(value: str | None) -> str | None:
+    if value is None:
+        return None
+    candidate = value.strip().lower()
+    if not candidate:
+        return None
+    allowed = set("abcdefghijklmnopqrstuvwxyz0123456789-")
+    if any(char not in allowed for char in candidate):
+        return None
+    if candidate.startswith("-") or candidate.endswith("-") or "--" in candidate:
+        return None
+    return candidate
+
+
+def derive_credential_extra_endpoints(rendered_credentials: dict[str, dict[str, str]]) -> list[str]:
+    endpoints: set[str] = set()
+    gemini_env = rendered_credentials.get("gemini_env")
+    if gemini_env is not None:
+        env_values = parse_simple_env_file(Path(gemini_env["source"]))
+        for key in GEMINI_VERTEX_LOCATION_KEYS:
+            location = normalize_vertex_location(env_values.get(key))
+            if location is not None:
+                endpoints.add(f"{location}-aiplatform.googleapis.com:443")
+    return sorted(endpoints)
 
 
 def validate_source_path(raw: object, label: str, base: Path) -> Path:
@@ -660,6 +721,11 @@ def render_credentials(
             modes = raw.get("modes")
         elif not isinstance(raw, str):
             die(f"credentials.{key} must be a string path or a table")
+        if key in SHARED_CREDENTIAL_KEYS and isinstance(raw, dict) and providers is None:
+            die(
+                f"credentials.{key}.providers is required so shared GitHub credentials "
+                "stay least-privilege"
+            )
         if not selected_for(
             providers,
             agent,
@@ -702,11 +768,13 @@ def main() -> int:
         policy, policy_path.parent, args.agent, args.mode
     )
     rendered_ssh = render_ssh(policy, output_root, policy_path.parent, args.agent, args.mode)
+    extra_endpoints = derive_credential_extra_endpoints(rendered_credentials)
     manifest = {
         "version": 1,
         "metadata": {
             "policy_sha256": policy_sha256(policy_path),
             "credential_keys": sorted(rendered_credentials),
+            "extra_endpoints": extra_endpoints,
             "secret_copy_targets": sorted(
                 entry["target"]
                 for entry in rendered_copies

--- a/scripts/pre-merge.sh
+++ b/scripts/pre-merge.sh
@@ -8,6 +8,7 @@ VALIDATOR_IMAGE="${WORKCELL_VALIDATOR_IMAGE:-${VALIDATOR_IMAGE_DEFAULT_TAG}}"
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -C "${ROOT_DIR}" log -1 --pretty=%ct 2>/dev/null || printf '0')}"
 REBUILD_VALIDATOR=0
 RUN_REMOTE=0
+RUN_REMOTE_HEAVY=0
 RUN_RELEASE_BUNDLE=1
 RUN_REPRO=1
 ALLOW_DIRTY=0
@@ -30,7 +31,10 @@ Options:
   --rebuild-validator        Rebuild the local validator image before validation
   --skip-release-bundle      Skip verify-release-bundle.sh
   --skip-repro               Skip verify-reproducible-build.sh
-  --remote                   Also run dev-remote-validate.sh with all checks
+  --remote                   Also run dev-remote-validate.sh with the safe
+                             remote validate-only lane
+  --remote-heavy             Extend --remote with explicit shared-daemon
+                             heavy checks (smoke/repro/release-bundle)
   --remote-host <user@host>  Override the remote builder host for this run
   --remote-config <path>     Override the host-local remote config file
   --remote-snapshot <mode>   Remote snapshot mode: head, index, or worktree
@@ -110,7 +114,12 @@ run_remote_validation() {
   cmd+=(--snapshot "${REMOTE_SNAPSHOT}")
   [[ "${REMOTE_INCLUDE_UNTRACKED}" -eq 1 ]] && cmd+=(--include-untracked)
   [[ "${REMOTE_KEEP_DIR}" -eq 1 ]] && cmd+=(--keep-remote-dir)
-  cmd+=(--check validate --check smoke --check repro --check release-bundle)
+  cmd+=(--check validate)
+  if [[ "${RUN_REMOTE_HEAVY}" -eq 1 ]]; then
+    cmd+=(--allow-shared-daemon-heavy-checks --check smoke)
+    [[ "${RUN_REPRO}" -eq 1 ]] && cmd+=(--check repro)
+    [[ "${RUN_RELEASE_BUNDLE}" -eq 1 ]] && cmd+=(--check release-bundle)
+  fi
 
   "${cmd[@]}"
 }
@@ -135,6 +144,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     --remote)
       RUN_REMOTE=1
+      shift
+      ;;
+    --remote-heavy)
+      RUN_REMOTE=1
+      RUN_REMOTE_HEAVY=1
       shift
       ;;
     --remote-host)

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -63,6 +63,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/check-workflows.sh"
   "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"
   "${ROOT_DIR}/scripts/container-smoke.sh"
+  "${ROOT_DIR}/scripts/dev-quick-check.sh"
   "${ROOT_DIR}/scripts/dev-remote-validate.sh"
   "${ROOT_DIR}/scripts/generate-builder-environment-manifest.sh"
   "${ROOT_DIR}/scripts/generate-release-checksums.sh"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -222,6 +222,11 @@ if ! grep -q -- '--prepare' /tmp/workcell-installed-help.out; then
   exit 1
 fi
 
+if ! grep -q -- '--prepare-only' /tmp/workcell-installed-help.out; then
+  echo "Expected installed ~/.local/bin/workcell --help to describe --prepare-only" >&2
+  exit 1
+fi
+
 if ! grep -q -- '--repair-profile' /tmp/workcell-installed-help.out; then
   echo "Expected installed ~/.local/bin/workcell --help to describe --repair-profile" >&2
   exit 1
@@ -333,7 +338,10 @@ codex_auth = "codex-auth.json"
 claude_auth = "claude-auth.json"
 claude_mcp = "claude-mcp.json"
 gemini_projects = "gemini-projects.json"
-github_hosts = "gh-hosts.yml"
+
+[credentials.github_hosts]
+source = "gh-hosts.yml"
+providers = ["codex"]
 
 [ssh]
 enabled = true
@@ -487,7 +495,7 @@ if [[ "${INJECTION_DRY_RUN_OUTPUT}" == *"${INJECTION_POLICY_FIXTURE_ROOT}/codex-
 fi
 
 if [[ "${INJECTION_DRY_RUN_OUTPUT}" != *'WORKCELL_CONTAINER_MUTABILITY=ephemeral'* ]]; then
-  echo "Expected workcell --dry-run to default the runtime to ephemeral container mutability" >&2
+  echo "Expected workcell --dry-run to default strict mode to ephemeral container mutability" >&2
   exit 1
 fi
 
@@ -1525,6 +1533,7 @@ if ! "${ROOT_DIR}/scripts/workcell" \
   exit 1
 fi
 grep -q '^doctor_profile_state=absent$' /tmp/workcell-doctor.out
+grep -q '^doctor_missing_host_tools=none$' /tmp/workcell-doctor.out
 grep -q '^doctor_prepared_image=0$' /tmp/workcell-doctor.out
 grep -q -- '--prepare' /tmp/workcell-doctor.out
 if ! "${ROOT_DIR}/scripts/workcell" \
@@ -1595,6 +1604,22 @@ test -f "${DEBUG_LOG_CAPTURE}"
 test "$(file_mode_octal "${DEBUG_LOG_CAPTURE}")" = "600"
 grep -q 'Workcell warning: full host-persisted debug log capture is enabled for this session:' /tmp/workcell-debug-log.out
 grep -q 'execution_path=' "${DEBUG_LOG_CAPTURE}"
+DEBUG_LOG_SYMLINK_TARGET="${BARRIER_VERIFY_ROOT}/debug/redirected.log"
+DEBUG_LOG_SYMLINK="${BARRIER_VERIFY_ROOT}/debug/symlink.log"
+rm -f "${DEBUG_LOG_SYMLINK_TARGET}" "${DEBUG_LOG_SYMLINK}"
+printf 'seed\n' >"${DEBUG_LOG_SYMLINK_TARGET}"
+ln -s "${DEBUG_LOG_SYMLINK_TARGET}" "${DEBUG_LOG_SYMLINK}"
+if "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --allow-nongit-workspace \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}" \
+  --debug-log "${DEBUG_LOG_SYMLINK}" \
+  --dry-run >/tmp/workcell-debug-log-symlink.out 2>&1; then
+  echo "Expected --debug-log to reject symlinked host output paths" >&2
+  exit 1
+fi
+grep -q 'Refusing symlinked host output path component:' /tmp/workcell-debug-log-symlink.out
 mkdir -p "${REAL_HOME}/.colima/${DEBUG_LOG_PROFILE}"
 printf '%s\n' "${DEBUG_LOG_CAPTURE}" >"${REAL_HOME}/.colima/${DEBUG_LOG_PROFILE}/workcell.latest-debug-log"
 if ! "${ROOT_DIR}/scripts/workcell" \
@@ -1678,12 +1703,18 @@ claude_auth = "claude-auth.json"
 claude_api_key = "claude-api-key.txt"
 gemini_env = "gemini.env"
 gcloud_adc = "gcloud-adc.json"
-github_hosts = "hosts.yml"
+[credentials.github_hosts]
+source = "hosts.yml"
+providers = ["codex", "claude", "gemini"]
 [ssh]
 enabled = true
 config = "ssh-config"
 allow_unsafe_config = true
 EOF
+cat >"${AUTH_STATUS_ROOT}/gemini.env" <<'EOF'
+GOOGLE_CLOUD_LOCATION=us-central1
+EOF
+chmod 0600 "${AUTH_STATUS_ROOT}/gemini.env"
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent codex \
   --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
@@ -1733,6 +1764,19 @@ grep -q '^provider_auth_mode=gemini_env$' /tmp/workcell-auth-status-gemini.out
 grep -q '^provider_auth_modes=gemini_env,gcloud_adc$' /tmp/workcell-auth-status-gemini.out
 grep -q '^shared_auth_modes=github_hosts$' /tmp/workcell-auth-status-gemini.out
 grep -q '^github_auth_present=1$' /tmp/workcell-auth-status-gemini.out
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${ROOT_DIR}" \
+  --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
+  --dry-run >/tmp/workcell-gemini-network.stdout 2>/tmp/workcell-gemini-network.stderr; then
+  echo "Expected Gemini dry-run with scoped auth policy to succeed" >&2
+  exit 1
+fi
+grep -q 'accounts.google.com:443' /tmp/workcell-gemini-network.stderr
+grep -q 'api.github.com:443' /tmp/workcell-gemini-network.stderr
+grep -q 'us-central1-aiplatform.googleapis.com:443' /tmp/workcell-gemini-network.stderr
+grep -q -- '--add-host accounts.google.com:' /tmp/workcell-gemini-network.stdout
+grep -q -- '--add-host us-central1-aiplatform.googleapis.com:' /tmp/workcell-gemini-network.stdout
 
 BROKEN_DEBUG_POINTER_PROFILE="${STRICT_PREFLIGHT_PROFILE}-broken-debug-pointer"
 mkdir -p "${REAL_HOME}/.colima/${BROKEN_DEBUG_POINTER_PROFILE}"
@@ -1836,7 +1880,7 @@ if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
   exit 1
 fi
 grep -q 'remote validation will use --remote-snapshot worktree --include-untracked' /tmp/workcell-premerge-allow-dirty.out
-grep -q 'dev-remote-validate.sh --snapshot worktree --include-untracked --check validate --check smoke --check repro --check release-bundle' "${PREMERGE_LOG}"
+grep -q 'dev-remote-validate.sh --snapshot worktree --include-untracked --check validate' "${PREMERGE_LOG}"
 
 : >"${PREMERGE_LOG}"
 if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
@@ -1851,7 +1895,7 @@ if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
   exit 1
 fi
 grep -q 'warning: --allow-dirty validates the live worktree locally, but remote validation will use --remote-snapshot index.' /tmp/workcell-premerge-remote-index.out
-grep -q 'dev-remote-validate.sh --snapshot index --check validate --check smoke --check repro --check release-bundle' "${PREMERGE_LOG}"
+grep -q 'dev-remote-validate.sh --snapshot index --check validate' "${PREMERGE_LOG}"
 
 : >"${PREMERGE_LOG}"
 if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
@@ -1867,6 +1911,19 @@ if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
 fi
 grep -q 'local validation sees untracked files, but remote worktree validation will exclude them without --include-untracked.' /tmp/workcell-premerge-remote-worktree.out
 
+: >"${PREMERGE_LOG}"
+if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
+  PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
+  "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
+  --allow-dirty \
+  --remote-heavy >/tmp/workcell-premerge-remote-heavy.out 2>&1; then
+  echo "Expected explicit heavy remote pre-merge harness to succeed" >&2
+  cat /tmp/workcell-premerge-remote-heavy.out >&2
+  exit 1
+fi
+grep -q 'dev-remote-validate.sh --snapshot worktree --include-untracked --check validate --allow-shared-daemon-heavy-checks --check smoke --check repro --check release-bundle' "${PREMERGE_LOG}"
+
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent codex \
   --prepare \
@@ -1879,6 +1936,19 @@ if ! "${ROOT_DIR}/scripts/workcell" \
   exit 1
 fi
 grep -q 'docker run' /tmp/workcell-prepare-dry-run.out
+
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --prepare-only \
+  --allow-nongit-workspace \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}" \
+  --dry-run >/tmp/workcell-prepare-only-dry-run.out 2>&1; then
+  echo "Expected --prepare-only dry-run to succeed" >&2
+  cat /tmp/workcell-prepare-only-dry-run.out >&2
+  exit 1
+fi
+grep -q '^prepare_only=1 no_session_launch=1$' /tmp/workcell-prepare-only-dry-run.out
 
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent codex \
@@ -2449,6 +2519,25 @@ if ! "${ROOT_DIR}/scripts/dev-remote-validate.sh" --config "${LOCAL_REMOTE_CONFI
 fi
 grep -q 'Remote host: builder@example.internal' /tmp/workcell-remote-config-cli.out
 grep -q "Remote config path: ${LOCAL_REMOTE_CONFIG_PATH}" /tmp/workcell-remote-config-cli.out
+
+if "${ROOT_DIR}/scripts/dev-remote-validate.sh" --config "${LOCAL_REMOTE_CONFIG_PATH}" --check smoke --dry-run >/tmp/workcell-remote-heavy-no-ack.out 2>&1; then
+  echo "Expected heavy remote validation without an explicit shared-daemon acknowledgement to be rejected" >&2
+  exit 1
+fi
+grep -q 'Heavy remote checks require --allow-shared-daemon-heavy-checks' /tmp/workcell-remote-heavy-no-ack.out
+
+cat <<'EOF' >"${LOCAL_REMOTE_CONFIG_PATH}"
+WORKCELL_REMOTE_VALIDATE_HOST=builder@example.internal
+WORKCELL_REMOTE_VALIDATE_BASE_DIR=/var/tmp/workcell
+WORKCELL_REMOTE_VALIDATE_USE_SUDO=0
+WORKCELL_REMOTE_VALIDATE_ALLOW_SHARED_DAEMON_HEAVY_CHECKS=1
+EOF
+if ! "${ROOT_DIR}/scripts/dev-remote-validate.sh" --config "${LOCAL_REMOTE_CONFIG_PATH}" --check smoke --dry-run >/tmp/workcell-remote-heavy-ack.out 2>&1; then
+  echo "Expected heavy remote validation with an explicit shared-daemon acknowledgement to be accepted" >&2
+  cat /tmp/workcell-remote-heavy-ack.out >&2
+  exit 1
+fi
+grep -q 'Allow shared-daemon heavy checks: 1' /tmp/workcell-remote-heavy-ack.out
 
 cat <<'EOF' >"${LEGACY_LOCAL_REMOTE_CONFIG_PATH}"
 WORKCELL_REMOTE_VALIDATE_HOST=builder@example.internal

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -122,6 +122,153 @@ rg() {
   return 127
 }
 
+canonicalize_verify_tool_path() {
+  local candidate="$1"
+
+  python3 - "${candidate}" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))
+PY
+}
+
+verify_tool_path_is_trusted() {
+  local candidate="$1"
+  local workspace_root="${2:-}"
+  local trusted_prefixes=(
+    /usr/bin
+    /bin
+    /usr/sbin
+    /sbin
+    /usr/local/bin
+    /usr/local/Cellar
+    /opt/homebrew/bin
+    /opt/homebrew/Cellar
+    /Applications/Docker.app/Contents/Resources/bin
+  )
+  local prefix=""
+
+  [[ "${candidate}" = /* ]] || return 1
+  case "${candidate}" in
+    "${ROOT_DIR}" | "${ROOT_DIR}"/*)
+      return 1
+      ;;
+  esac
+  if [[ -n "${workspace_root}" ]]; then
+    case "${candidate}" in
+      "${workspace_root}" | "${workspace_root}"/*)
+        return 1
+        ;;
+    esac
+  fi
+  for prefix in "${trusted_prefixes[@]}"; do
+    case "${candidate}" in
+      "${prefix}" | "${prefix}"/*)
+        return 0
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+doctor_tool_is_available() {
+  local workspace_root="$1"
+  shift
+  local name="$1"
+  shift
+  local candidate=""
+  local canonical_candidate=""
+
+  for candidate in "$@"; do
+    canonical_candidate="$(canonicalize_verify_tool_path "${candidate}")"
+    if [[ -x "${candidate}" ]] &&
+      verify_tool_path_is_trusted "${candidate}" "${workspace_root}" &&
+      verify_tool_path_is_trusted "${canonical_candidate}" "${workspace_root}"; then
+      return 0
+    fi
+  done
+
+  candidate="$(type -P "${name}" || true)"
+  canonical_candidate="$(canonicalize_verify_tool_path "${candidate}")"
+  if [[ -n "${candidate}" ]] &&
+    verify_tool_path_is_trusted "${candidate}" "${workspace_root}" &&
+    verify_tool_path_is_trusted "${canonical_candidate}" "${workspace_root}"; then
+    return 0
+  fi
+
+  return 1
+}
+
+expected_doctor_missing_host_tools_csv_for_workspace() {
+  local workspace_root="$1"
+  local -a missing=()
+
+  doctor_tool_is_available "${workspace_root}" colima /opt/homebrew/bin/colima /usr/local/bin/colima || missing+=(colima)
+  doctor_tool_is_available "${workspace_root}" docker /opt/homebrew/bin/docker /usr/local/bin/docker /Applications/Docker.app/Contents/Resources/bin/docker || missing+=(docker)
+  doctor_tool_is_available "${workspace_root}" ruby /usr/bin/ruby /opt/homebrew/bin/ruby /usr/local/bin/ruby || missing+=(ruby)
+
+  if ((${#missing[@]} == 0)); then
+    printf 'none\n'
+    return 0
+  fi
+
+  local IFS=','
+  printf '%s\n' "${missing[*]}"
+}
+
+assert_doctor_missing_host_tools() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -q "^doctor_missing_host_tools=${expected}$" "${file}"; then
+    echo "Expected ${file} to report doctor_missing_host_tools=${expected}" >&2
+    cat "${file}" >&2
+    exit 1
+  fi
+}
+
+assert_doctor_next_for_prepare() {
+  local file="$1"
+  local expected_missing="$2"
+
+  if [[ "${expected_missing}" == "none" ]]; then
+    if ! grep -q -- '--prepare' "${file}"; then
+      echo "Expected ${file} to recommend --prepare when required host tools are present" >&2
+      cat "${file}" >&2
+      exit 1
+    fi
+    return 0
+  fi
+
+  if ! grep -q '^doctor_recommended_next=install-host-tools$' "${file}"; then
+    echo "Expected ${file} to recommend installing missing host tools before prepare" >&2
+    cat "${file}" >&2
+    exit 1
+  fi
+}
+
+assert_doctor_next_for_missing_workspace() {
+  local file="$1"
+  local expected_missing="$2"
+
+  if [[ "${expected_missing}" == "none" ]]; then
+    if ! grep -q '^doctor_recommended_next=fix-workspace$' "${file}"; then
+      echo "Expected ${file} to recommend fixing the missing workspace when required host tools are present" >&2
+      cat "${file}" >&2
+      exit 1
+    fi
+    return 0
+  fi
+
+  if ! grep -q '^doctor_recommended_next=install-host-tools$' "${file}"; then
+    echo "Expected ${file} to prioritize installing missing host tools before fixing the workspace" >&2
+    cat "${file}" >&2
+    exit 1
+  fi
+}
+
 for file in \
   "${ROOT_DIR}/adapters/codex/.codex/config.toml" \
   "${ROOT_DIR}/adapters/claude/.claude/settings.json" \
@@ -1439,6 +1586,13 @@ grep -q '^Usage: workcell' /tmp/workcell-missing-agent.out
 STRICT_PREFLIGHT_WORKSPACE="${BARRIER_VERIFY_ROOT}/strict-preflight-workspace"
 mkdir -p "${STRICT_PREFLIGHT_WORKSPACE}"
 printf '# marker\n' >"${STRICT_PREFLIGHT_WORKSPACE}/AGENTS.md"
+MISSING_DOCTOR_WORKSPACE="${BARRIER_VERIFY_ROOT}/missing-workspace-for-doctor"
+EXPECTED_STRICT_DOCTOR_MISSING_HOST_TOOLS="$(
+  expected_doctor_missing_host_tools_csv_for_workspace "${STRICT_PREFLIGHT_WORKSPACE}"
+)"
+EXPECTED_MISSING_DOCTOR_MISSING_HOST_TOOLS="$(
+  expected_doctor_missing_host_tools_csv_for_workspace "${MISSING_DOCTOR_WORKSPACE}"
+)"
 STRICT_PREFLIGHT_PROFILE="workcell-preflight-$$"
 rm -rf \
   "${REAL_HOME}/.colima/${STRICT_PREFLIGHT_PROFILE}" \
@@ -1533,9 +1687,9 @@ if ! "${ROOT_DIR}/scripts/workcell" \
   exit 1
 fi
 grep -q '^doctor_profile_state=absent$' /tmp/workcell-doctor.out
-grep -q '^doctor_missing_host_tools=none$' /tmp/workcell-doctor.out
+assert_doctor_missing_host_tools /tmp/workcell-doctor.out "${EXPECTED_STRICT_DOCTOR_MISSING_HOST_TOOLS}"
 grep -q '^doctor_prepared_image=0$' /tmp/workcell-doctor.out
-grep -q -- '--prepare' /tmp/workcell-doctor.out
+assert_doctor_next_for_prepare /tmp/workcell-doctor.out "${EXPECTED_STRICT_DOCTOR_MISSING_HOST_TOOLS}"
 if ! "${ROOT_DIR}/scripts/workcell" \
   doctor \
   --agent codex \
@@ -1547,20 +1701,23 @@ if ! "${ROOT_DIR}/scripts/workcell" \
   exit 1
 fi
 grep -q '^doctor_profile_state=absent$' /tmp/workcell-doctor-subcommand.out
+assert_doctor_missing_host_tools /tmp/workcell-doctor-subcommand.out "${EXPECTED_STRICT_DOCTOR_MISSING_HOST_TOOLS}"
+assert_doctor_next_for_prepare /tmp/workcell-doctor-subcommand.out "${EXPECTED_STRICT_DOCTOR_MISSING_HOST_TOOLS}"
 
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent codex \
   --no-default-injection-policy \
-  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-doctor" \
+  --workspace "${MISSING_DOCTOR_WORKSPACE}" \
   --colima-profile "${STRICT_PREFLIGHT_PROFILE}-missing-doctor" \
   --doctor >/tmp/workcell-doctor-missing.out 2>&1; then
   echo "Expected --doctor to succeed even when the workspace is missing" >&2
   exit 1
 fi
 grep -q '^doctor_profile_state=absent$' /tmp/workcell-doctor-missing.out
+assert_doctor_missing_host_tools /tmp/workcell-doctor-missing.out "${EXPECTED_MISSING_DOCTOR_MISSING_HOST_TOOLS}"
 grep -Eq '^workspace=.*/missing-workspace-for-doctor$' /tmp/workcell-doctor-missing.out
 grep -q '^workspace_status=missing$' /tmp/workcell-doctor-missing.out
-grep -q '^doctor_recommended_next=fix-workspace$' /tmp/workcell-doctor-missing.out
+assert_doctor_next_for_missing_workspace /tmp/workcell-doctor-missing.out "${EXPECTED_MISSING_DOCTOR_MISSING_HOST_TOOLS}"
 
 STALE_MARKER_PROFILE="${STRICT_PREFLIGHT_PROFILE}-stale"
 STALE_MARKER_DIR="${REAL_HOME}/.colima/${STALE_MARKER_PROFILE}"
@@ -1583,8 +1740,9 @@ if ! "${ROOT_DIR}/scripts/workcell" \
   exit 1
 fi
 grep -q '^current_image_id=none$' /tmp/workcell-doctor-stale.out
+assert_doctor_missing_host_tools /tmp/workcell-doctor-stale.out "${EXPECTED_STRICT_DOCTOR_MISSING_HOST_TOOLS}"
 grep -q '^doctor_prepared_image=0$' /tmp/workcell-doctor-stale.out
-grep -q -- '--prepare' /tmp/workcell-doctor-stale.out
+assert_doctor_next_for_prepare /tmp/workcell-doctor-stale.out "${EXPECTED_STRICT_DOCTOR_MISSING_HOST_TOOLS}"
 rm -rf "${STALE_MARKER_DIR}" "${REAL_HOME}/.colima/_lima/colima-${STALE_MARKER_PROFILE}"
 
 DEBUG_LOG_CAPTURE="${BARRIER_VERIFY_ROOT}/debug/session.log"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -94,8 +94,10 @@ SESSION_AUDIT_CONTAINER_FILE=""
 FINAL_SESSION_ASSURANCE=""
 INJECTION_POLICY_SHA256=""
 INJECTION_CREDENTIAL_KEYS=""
+INJECTION_EXTRA_ENDPOINTS=""
 INJECTION_SSH_ENABLED=0
 INJECTION_SECRET_COPY_TARGETS=""
+PROFILE_LOCK_DIR=""
 
 usage() {
   cat <<'EOF'
@@ -109,7 +111,7 @@ Options:
   --codex-rules-mutability readonly|session
                                 Codex execpolicy session mutability (default: readonly)
   --container-mutability ephemeral|readonly
-                                Runtime rootfs posture (default: ephemeral)
+                                Runtime rootfs posture (default: ephemeral on strict/build/breakglass)
   --container-cpu COUNT         Inner container CPU limit (default: unmanaged)
   --container-memory SIZE       Inner container memory limit (default: profile value)
   --injection-policy PATH       Host-side injection policy to stage into each session
@@ -126,6 +128,7 @@ Options:
   --auth-status                 Print selected injection/auth posture and exit
   --gc                          Clean stale Workcell temp state and exit
   --prepare                     Seed or refresh the prepared runtime image before launch
+  --prepare-only                Seed or refresh the prepared runtime image, then exit without launching
   --repair-profile              Delete a conflicting unmanaged Colima profile before launch
                                 (implies --prepare on strict)
   --ack-breakglass              Required with --mode breakglass
@@ -146,6 +149,8 @@ Workflows:
     workcell --prepare --agent codex --workspace /path/to/repo
     workcell --prepare --agent claude --workspace /path/to/repo
     workcell --prepare --agent gemini --workspace /path/to/repo
+  Prewarm only:
+    workcell --prepare-only --agent codex --workspace /path/to/repo
   Normal run:
     workcell --agent codex --workspace /path/to/repo
     workcell --agent claude --workspace /path/to/repo
@@ -325,6 +330,7 @@ declare -a SHADOW_DEST_PATHS=()
 declare -a DIRECT_SOURCE_MOUNTS=()
 declare -a WORKSPACE_IMPORT_MOUNTS=()
 declare -a CACHE_MOUNTS=()
+declare -a RUNTIME_NETWORK_ARGS=()
 
 # shellcheck disable=SC2317,SC2329
 cleanup() {
@@ -362,6 +368,10 @@ cleanup() {
 
   if [[ -n "${CONTAINER_NAME:-}" ]] && [[ -n "${HOST_DOCKER_BIN:-}" ]]; then
     "${HOST_DOCKER_BIN}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+  fi
+
+  if [[ -n "${PROFILE_LOCK_DIR}" ]] && [[ -d "${PROFILE_LOCK_DIR}" ]]; then
+    rm -rf "${PROFILE_LOCK_DIR}"
   fi
 
   cleanup_workcell_trusted_docker_client
@@ -411,6 +421,13 @@ profile_audit_log_path() {
 
   validate_colima_profile_name "${profile}"
   printf '%s/workcell.audit.log\n' "$(profile_dir "${profile}")"
+}
+
+profile_lock_dir_path() {
+  local profile="$1"
+
+  validate_colima_profile_name "${profile}"
+  printf '%s/locks/%s.lock\n' "${COLIMA_STATE_ROOT}" "${profile}"
 }
 
 profile_latest_log_pointer_path() {
@@ -481,6 +498,88 @@ for profile_dir in root.iterdir():
         if target_path is None or not target_path.exists():
             pointer_path.unlink(missing_ok=True)
 PY
+}
+
+profile_lock_is_stale() {
+  local lock_dir="$1"
+
+  run_clean_host_command "${HOST_PYTHON3_BIN}" - "${lock_dir}" <<'PY'
+import json
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+lock_dir = Path(sys.argv[1])
+owner_path = lock_dir / "owner.json"
+if not owner_path.is_file():
+    print("1")
+    raise SystemExit(0)
+
+try:
+    owner = json.loads(owner_path.read_text(encoding="utf-8"))
+    pid = int(owner["pid"])
+    started = str(owner["started"])
+except Exception:
+    print("1")
+    raise SystemExit(0)
+
+try:
+    os.kill(pid, 0)
+except OSError:
+    print("1")
+    raise SystemExit(0)
+
+observed = subprocess.check_output(
+    ["ps", "-o", "lstart=", "-p", str(pid)],
+    text=True,
+    stderr=subprocess.DEVNULL,
+).strip()
+print("0" if observed == started else "1")
+PY
+}
+
+acquire_profile_lock() {
+  local profile="$1"
+  local lock_dir=""
+  local lock_parent=""
+  local attempts=0
+
+  lock_dir="$(profile_lock_dir_path "${profile}")"
+  lock_parent="$(dirname "${lock_dir}")"
+  mkdir -p "${lock_parent}"
+
+  while ! mkdir "${lock_dir}" 2>/dev/null; do
+    if [[ "$(profile_lock_is_stale "${lock_dir}")" == "1" ]]; then
+      rm -rf "${lock_dir}"
+      continue
+    fi
+    attempts=$((attempts + 1))
+    if [[ "${attempts}" -eq 1 ]]; then
+      echo "Waiting for the active Workcell session on profile ${profile} to release the managed runtime lock." >&2
+    fi
+    sleep 1
+  done
+
+  PROFILE_LOCK_DIR="${lock_dir}"
+  run_clean_host_command "${HOST_PYTHON3_BIN}" - "${lock_dir}/owner.json" "$$" <<'PY'
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+started = subprocess.check_output(
+    ["ps", "-o", "lstart=", "-p", sys.argv[2]],
+    text=True,
+    stderr=subprocess.DEVNULL,
+).strip()
+Path(sys.argv[1]).write_text(
+    json.dumps({"pid": int(sys.argv[2]), "started": started}, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PY
+  chmod 0600 "${lock_dir}/owner.json" 2>/dev/null || true
 }
 
 cleanup_stale_session_audit_dirs() {
@@ -891,6 +990,41 @@ print(os.path.realpath(os.path.expanduser(sys.argv[1])))
 PY
 }
 
+resolve_host_output_candidate() {
+  env -i PATH="${TRUSTED_HOST_PATH}" "${HOST_PYTHON3_BIN}" - "$1" <<'PY'
+import os
+import stat
+import sys
+from pathlib import Path
+
+target = Path(os.path.abspath(os.path.expanduser(sys.argv[1])))
+allowed_symlink_roots = {Path("/var"), Path("/tmp")} if sys.platform == "darwin" else set()
+
+current = target
+while True:
+    try:
+        path_stat = current.lstat()
+    except FileNotFoundError:
+        pass
+    else:
+        if stat.S_ISLNK(path_stat.st_mode):
+            if current in allowed_symlink_roots:
+                if current == current.parent:
+                    break
+                current = current.parent
+                continue
+            raise SystemExit(f"Refusing symlinked host output path component: {current}")
+    if current == current.parent:
+        break
+    current = current.parent
+
+if target.exists() and not target.is_file():
+    raise SystemExit(f"Host output path must be a regular file or a new file path: {target}")
+
+print(target)
+PY
+}
+
 resolve_existing_directory_or_die() {
   local raw_path="$1"
   local resolved_path=""
@@ -1059,6 +1193,7 @@ prepare_injection_bundle() {
   if [[ -z "${policy_path}" ]]; then
     INJECTION_POLICY_SHA256=""
     INJECTION_CREDENTIAL_KEYS=""
+    INJECTION_EXTRA_ENDPOINTS=""
     INJECTION_SSH_ENABLED=0
     INJECTION_SSH_CONFIG_ASSURANCE="off"
     INJECTION_SECRET_COPY_TARGETS=""
@@ -1134,6 +1269,7 @@ manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 metadata = manifest.get("metadata", {})
 print(metadata.get("policy_sha256", ""))
 print(",".join(metadata.get("credential_keys", [])))
+print(" ".join(metadata.get("extra_endpoints", [])))
 print("1" if metadata.get("ssh_enabled") else "0")
 print(metadata.get("ssh_config_assurance", "off"))
 print(",".join(metadata.get("secret_copy_targets", [])))
@@ -1141,9 +1277,10 @@ PY
   )"
   INJECTION_POLICY_SHA256="$(printf '%s\n' "${metadata}" | sed -n '1p')"
   INJECTION_CREDENTIAL_KEYS="$(printf '%s\n' "${metadata}" | sed -n '2p')"
-  INJECTION_SSH_ENABLED="$(printf '%s\n' "${metadata}" | sed -n '3p')"
-  INJECTION_SSH_CONFIG_ASSURANCE="$(printf '%s\n' "${metadata}" | sed -n '4p')"
-  INJECTION_SECRET_COPY_TARGETS="$(printf '%s\n' "${metadata}" | sed -n '5p')"
+  INJECTION_EXTRA_ENDPOINTS="$(printf '%s\n' "${metadata}" | sed -n '3p')"
+  INJECTION_SSH_ENABLED="$(printf '%s\n' "${metadata}" | sed -n '4p')"
+  INJECTION_SSH_CONFIG_ASSURANCE="$(printf '%s\n' "${metadata}" | sed -n '5p')"
+  INJECTION_SECRET_COPY_TARGETS="$(printf '%s\n' "${metadata}" | sed -n '6p')"
 }
 
 build_recommended_command() {
@@ -1151,16 +1288,20 @@ build_recommended_command() {
   local include_repair="$2"
   local target_mode="${3}"
   local -a cmd=("workcell")
+  local target_mutability=""
 
   if [[ "${include_repair}" -eq 1 ]] && [[ "${target_mode}" == "strict" ]]; then
     include_prepare=0
   fi
+  target_mutability="${CONTAINER_MUTABILITY:-$(default_container_mutability_for_mode "${target_mode}")}"
   [[ "${include_prepare}" -eq 1 ]] && cmd+=(--prepare)
   [[ "${include_repair}" -eq 1 ]] && cmd+=(--repair-profile)
   cmd+=(--agent "${AGENT}")
   [[ "${AGENT_AUTONOMY}" != "yolo" ]] && cmd+=(--agent-autonomy "${AGENT_AUTONOMY}")
   [[ "${CACHE_PROFILE}" != "off" ]] && cmd+=(--cache-profile "${CACHE_PROFILE}")
-  [[ "${CONTAINER_MUTABILITY}" != "ephemeral" ]] && cmd+=(--container-mutability "${CONTAINER_MUTABILITY}")
+  if ! container_mutability_is_default_for_mode "${target_mutability}" "${target_mode}"; then
+    cmd+=(--container-mutability "${target_mutability}")
+  fi
   [[ -n "${CONTAINER_CPU_OVERRIDE}" ]] && cmd+=(--container-cpu "${CONTAINER_CPU_OVERRIDE}")
   [[ -n "${CONTAINER_MEMORY_OVERRIDE}" ]] && cmd+=(--container-memory "${CONTAINER_MEMORY_OVERRIDE}")
   [[ "${USE_DEFAULT_INJECTION_POLICY}" -eq 0 ]] && cmd+=(--no-default-injection-policy)
@@ -1169,9 +1310,12 @@ build_recommended_command() {
   [[ -n "${DEBUG_LOG_PATH}" ]] && cmd+=(--debug-log "${DEBUG_LOG_PATH}")
   [[ -n "${AUDIT_TRANSCRIPT_PATH}" ]] && cmd+=(--audit-transcript "${AUDIT_TRANSCRIPT_PATH}")
   [[ "${UI}" != "cli" ]] && cmd+=(--ui "${UI}")
-  cmd+=(--mode "${target_mode}" --workspace "${WORKSPACE}")
+  if [[ "${target_mode}" != "strict" ]]; then
+    cmd+=(--mode "${target_mode}")
+  fi
+  cmd+=(--workspace "${WORKSPACE}")
   [[ "${ALLOW_NONGIT_WORKSPACE}" -eq 1 ]] && cmd+=(--allow-nongit-workspace)
-  [[ -n "${COLIMA_PROFILE}" ]] && cmd+=(--colima-profile "${COLIMA_PROFILE}")
+  [[ "${COLIMA_PROFILE_EXPLICIT:-0}" -eq 1 ]] && [[ -n "${COLIMA_PROFILE}" ]] && cmd+=(--colima-profile "${COLIMA_PROFILE}")
   [[ -n "${VM_CPU_OVERRIDE}" ]] && cmd+=(--vm-cpu "${VM_CPU_OVERRIDE}")
   [[ -n "${VM_MEMORY_OVERRIDE}" ]] && cmd+=(--vm-memory "${VM_MEMORY_OVERRIDE}")
   [[ -n "${VM_DISK_OVERRIDE}" ]] && cmd+=(--vm-disk "${VM_DISK_OVERRIDE}")
@@ -1228,9 +1372,14 @@ prepare_host_output_path() {
   local resolved_path=""
   local parent_dir=""
 
-  resolved_path="$(resolve_host_path "${raw_path}")"
+  if ! resolved_path="$(resolve_host_output_candidate "${raw_path}")"; then
+    exit 2
+  fi
   parent_dir="$(dirname "${resolved_path}")"
   mkdir -p "${parent_dir}"
+  if ! resolved_path="$(resolve_host_output_candidate "${resolved_path}")"; then
+    exit 2
+  fi
   chmod 0700 "${parent_dir}" 2>/dev/null || true
   : >"${resolved_path}"
   chmod 0600 "${resolved_path}" 2>/dev/null || true
@@ -1246,9 +1395,10 @@ csv_contains_value() {
   local csv="${1:-}"
   local needle="$2"
   local item=""
+  local IFS=','
 
-  IFS=',' read -r -a _csv_items <<<"${csv}"
-  for item in "${_csv_items[@]}"; do
+  [[ -n "${csv}" ]] || return 1
+  for item in ${csv}; do
     [[ -n "${item}" ]] || continue
     if [[ "${item}" == "${needle}" ]]; then
       return 0
@@ -1337,6 +1487,8 @@ selected_provider_auth_mode() {
 print_injection_status() {
   if [[ -z "${INJECTION_POLICY_SHA256}" ]]; then
     printf 'injection_policy=none\n'
+    printf 'default_injection_policy_path=%s\n' "$(default_injection_policy_path)"
+    printf 'supported_credential_keys=codex_auth,claude_api_key,claude_auth,claude_mcp,gemini_env,gemini_oauth,gemini_projects,gcloud_adc,github_config,github_hosts\n'
     return 0
   fi
   printf 'injection_policy_sha256=%s\n' "${INJECTION_POLICY_SHA256}"
@@ -1634,12 +1786,34 @@ validate_mode_name() {
 
 validate_container_mutability() {
   case "$1" in
-    ephemeral | readonly) ;;
+    "" | ephemeral | readonly) ;;
     *)
       echo "Unsupported container mutability: $1" >&2
       exit 2
       ;;
   esac
+}
+
+default_container_mutability_for_mode() {
+  case "$1" in
+    strict)
+      printf 'ephemeral\n'
+      ;;
+    build | breakglass)
+      printf 'ephemeral\n'
+      ;;
+    *)
+      echo "Unsupported mode for container mutability defaults: $1" >&2
+      exit 2
+      ;;
+  esac
+}
+
+container_mutability_is_default_for_mode() {
+  local mutability="$1"
+  local mode="$2"
+
+  [[ "${mutability}" == "$(default_container_mutability_for_mode "${mode}")" ]]
 }
 
 normalize_cli_aliases() {
@@ -1674,9 +1848,11 @@ normalize_cli_aliases() {
 }
 
 prepare_cache_mounts() {
-  local profile="$1"
+  local agent="$1"
   local cache_profile="$2"
+  local workspace="$3"
   local cache_root=""
+  local workspace_cache_key=""
 
   CACHE_MOUNTS=()
   case "${cache_profile}" in
@@ -1690,32 +1866,58 @@ prepare_cache_mounts() {
       ;;
   esac
 
-  cache_root="$(profile_dir "${profile}")/cache"
+  workspace_cache_key="$(
+    run_clean_host_command "${HOST_PYTHON3_BIN}" - "${workspace}" <<'PY'
+import hashlib
+import os
+import pathlib
+import sys
+
+workspace = pathlib.Path(os.path.realpath(os.path.expanduser(sys.argv[1])))
+print(hashlib.sha256(os.fspath(workspace).encode("utf-8")).hexdigest()[:16])
+PY
+  )"
+  cache_root="$(resolve_host_path "${XDG_STATE_HOME:-${REAL_HOME}/.local/state}/workcell/cache/${agent}/${workspace_cache_key}")"
   if [[ "${DRY_RUN}" -eq 0 ]]; then
     mkdir -p \
       "${cache_root}/npm" \
+      "${cache_root}/pnpm" \
       "${cache_root}/pip" \
+      "${cache_root}/uv" \
+      "${cache_root}/poetry" \
       "${cache_root}/cargo-registry" \
       "${cache_root}/cargo-git" \
       "${cache_root}/go-mod" \
       "${cache_root}/go-build" \
-      "${cache_root}/ccache"
+      "${cache_root}/ccache" \
+      "${cache_root}/bun" \
+      "${cache_root}/xdg"
     chmod 0700 "${cache_root}" 2>/dev/null || true
   fi
   CACHE_MOUNTS=(
     -e npm_config_cache=/state/cache/npm
+    -e PNPM_STORE_DIR=/state/cache/pnpm
     -e PIP_CACHE_DIR=/state/cache/pip
+    -e UV_CACHE_DIR=/state/cache/uv
+    -e POETRY_CACHE_DIR=/state/cache/poetry
     -e CARGO_HOME=/state/cache/cargo-home
     -e GOMODCACHE=/state/cache/go-mod
     -e GOCACHE=/state/cache/go-build
     -e CCACHE_DIR=/state/cache/ccache
+    -e BUN_INSTALL_CACHE_DIR=/state/cache/bun
+    -e XDG_CACHE_HOME=/state/cache/xdg
     -v "${cache_root}/npm:/state/cache/npm"
+    -v "${cache_root}/pnpm:/state/cache/pnpm"
     -v "${cache_root}/pip:/state/cache/pip"
+    -v "${cache_root}/uv:/state/cache/uv"
+    -v "${cache_root}/poetry:/state/cache/poetry"
     -v "${cache_root}/cargo-registry:/state/cache/cargo-home/registry"
     -v "${cache_root}/cargo-git:/state/cache/cargo-home/git"
     -v "${cache_root}/go-mod:/state/cache/go-mod"
     -v "${cache_root}/go-build:/state/cache/go-build"
     -v "${cache_root}/ccache:/state/cache/ccache"
+    -v "${cache_root}/bun:/state/cache/bun"
+    -v "${cache_root}/xdg:/state/cache/xdg"
   )
 }
 
@@ -1725,7 +1927,7 @@ run_command_with_debug_log() {
   local log_path=""
   local status=0
 
-  log_path="$(mktemp "${TMPDIR:-/tmp}/workcell-${label}.XXXXXX.log")"
+  log_path="$(mktemp "${TMPDIR:-/tmp}/workcell-${label}.log.XXXXXX")"
   if "$@" >"${log_path}" 2>&1; then
     if [[ "${LOG_LEVEL}" == "debug" ]]; then
       cat "${log_path}" >&2
@@ -2034,6 +2236,50 @@ resolve_host_tool() {
   exit 1
 }
 
+resolve_host_tool_optional() {
+  local name="$1"
+  shift
+  local candidate=""
+  local canonical_candidate=""
+
+  for candidate in "$@"; do
+    canonical_candidate="$(canonicalize_host_tool_path "${candidate}")"
+    if [[ -x "${candidate}" ]] &&
+      is_trusted_host_tool_path "${candidate}" &&
+      is_trusted_host_tool_path "${canonical_candidate}"; then
+      printf '%s\n' "${canonical_candidate}"
+      return 0
+    fi
+  done
+
+  candidate="$(type -P "${name}" || true)"
+  canonical_candidate="$(canonicalize_host_tool_path "${candidate}")"
+  if [[ -n "${candidate}" ]] &&
+    is_trusted_host_tool_path "${candidate}" &&
+    is_trusted_host_tool_path "${canonical_candidate}"; then
+    printf '%s\n' "${canonical_candidate}"
+    return 0
+  fi
+
+  return 1
+}
+
+missing_launch_host_tools_csv() {
+  local -a missing=()
+
+  resolve_host_tool_optional colima /opt/homebrew/bin/colima /usr/local/bin/colima >/dev/null || missing+=(colima)
+  resolve_host_tool_optional docker /opt/homebrew/bin/docker /usr/local/bin/docker /Applications/Docker.app/Contents/Resources/bin/docker >/dev/null || missing+=(docker)
+  resolve_host_tool_optional ruby /usr/bin/ruby /opt/homebrew/bin/ruby /usr/local/bin/ruby >/dev/null || missing+=(ruby)
+
+  if ((${#missing[@]} == 0)); then
+    printf 'none\n'
+    return 0
+  fi
+
+  local IFS=','
+  printf '%s\n' "${missing[*]}"
+}
+
 if [[ "${1:-}" == "--self-docker-probe" ]]; then
   sanitize_host_docker_env
   buildx_cmd version >/dev/null
@@ -2056,6 +2302,101 @@ provider_endpoints() {
       return 1
       ;;
   esac
+}
+
+credential_extra_endpoints() {
+  local credential_keys="${INJECTION_CREDENTIAL_KEYS:-}"
+  local -a endpoints=()
+
+  if csv_contains_value "${credential_keys}" "github_hosts" || csv_contains_value "${credential_keys}" "github_config"; then
+    endpoints+=(
+      github.com:443
+      api.github.com:443
+      objects.githubusercontent.com:443
+      raw.githubusercontent.com:443
+    )
+  fi
+
+  if [[ "${AGENT}" == "gemini" ]]; then
+    if csv_contains_value "${credential_keys}" "gemini_oauth" || csv_contains_value "${credential_keys}" "gcloud_adc"; then
+      endpoints+=(
+        accounts.google.com:443
+        oauth2.googleapis.com:443
+        sts.googleapis.com:443
+        aiplatform.googleapis.com:443
+      )
+    fi
+  fi
+
+  if ((${#endpoints[@]} == 0)); then
+    return 0
+  fi
+
+  printf '%s\n' "${endpoints[*]}"
+}
+
+dedupe_endpoint_list() {
+  run_clean_host_command "${HOST_PYTHON3_BIN}" - "$1" <<'PY'
+import sys
+
+seen = set()
+ordered = []
+for entry in sys.argv[1].split():
+    if entry and entry not in seen:
+        seen.add(entry)
+        ordered.append(entry)
+print(" ".join(ordered))
+PY
+}
+
+build_runtime_host_aliases() {
+  local endpoint_list="$1"
+  local host=""
+  local ip=""
+
+  RUNTIME_NETWORK_ARGS=()
+  [[ "${NETWORK_POLICY}" == "allowlist" ]] || return 0
+
+  while IFS=$'\t' read -r host ip; do
+    [[ -n "${host}" ]] || continue
+    if [[ "${ip}" == *:* ]]; then
+      RUNTIME_NETWORK_ARGS+=(--add-host "${host}:[${ip}]")
+    else
+      RUNTIME_NETWORK_ARGS+=(--add-host "${host}:${ip}")
+    fi
+  done < <(
+    run_clean_host_command "${HOST_PYTHON3_BIN}" - "${endpoint_list}" <<'PY'
+import socket
+import sys
+
+for endpoint in sys.argv[1].split():
+    host, _, _port = endpoint.rpartition(":")
+    if host.startswith("[") and host.endswith("]"):
+        continue
+    if host.replace(".", "").isdigit():
+        continue
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        continue
+    seen = set()
+    ipv4_addrs = []
+    ipv6_addrs = []
+    for family, _socktype, _proto, _canonname, sockaddr in infos:
+        ip = sockaddr[0]
+        key = (host, ip)
+        if key in seen:
+            continue
+        seen.add(key)
+        if family == socket.AF_INET6:
+            ipv6_addrs.append(ip)
+        else:
+            ipv4_addrs.append(ip)
+    for ip in ipv4_addrs + ipv6_addrs:
+        print(f"{host}\t{ip}")
+PY
+  )
+
 }
 
 git_alias_value_is_blocked() {
@@ -2411,7 +2752,7 @@ AGENT=""
 AGENT_AUTONOMY="yolo"
 CACHE_PROFILE="off"
 CODEX_RULES_MUTABILITY="readonly"
-CONTAINER_MUTABILITY="ephemeral"
+CONTAINER_MUTABILITY=""
 CONTAINER_CPU_OVERRIDE=""
 CONTAINER_MEMORY_OVERRIDE=""
 UI="cli"
@@ -2421,6 +2762,7 @@ DEBUG_LOG_PATH=""
 AUDIT_TRANSCRIPT_PATH=""
 WORKSPACE="$(pwd -P)"
 COLIMA_PROFILE=""
+COLIMA_PROFILE_EXPLICIT=0
 INJECTION_POLICY=""
 USE_DEFAULT_INJECTION_POLICY=1
 VM_CPU_OVERRIDE=""
@@ -2429,6 +2771,7 @@ VM_DISK_OVERRIDE=""
 REBUILD=0
 DRY_RUN=0
 PREPARE=0
+PREPARE_ONLY=0
 REPAIR_PROFILE=0
 DOCTOR=0
 INSPECT=0
@@ -2516,6 +2859,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --colima-profile)
       COLIMA_PROFILE="$(option_value_or_die "$1" "${2-}")"
+      COLIMA_PROFILE_EXPLICIT=1
       shift 2
       ;;
     --vm-cpu)
@@ -2532,6 +2876,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     --prepare)
       PREPARE=1
+      shift
+      ;;
+    --prepare-only)
+      PREPARE=1
+      PREPARE_ONLY=1
       shift
       ;;
     --repair-profile)
@@ -2699,6 +3048,9 @@ if [[ "${REPAIR_PROFILE}" -eq 1 ]] && [[ "${MODE}" == "strict" ]]; then
 fi
 
 validate_mode_name "${MODE}"
+if [[ -z "${CONTAINER_MUTABILITY}" ]]; then
+  CONTAINER_MUTABILITY="$(default_container_mutability_for_mode "${MODE}")"
+fi
 validate_container_mutability "${CONTAINER_MUTABILITY}"
 PROFILE_ENV="$(profile_env_path "${MODE}")"
 [[ -f "${PROFILE_ENV}" ]] || {
@@ -2727,6 +3079,7 @@ validate_container_memory_value "${CONTAINER_MEMORY}"
 if [[ -n "${CONTAINER_CPU_OVERRIDE}" ]]; then
   validate_positive_decimal "container CPU limit" "${CONTAINER_CPU_OVERRIDE}"
 fi
+HOST_TOOL_MISSING_CSV="$(missing_launch_host_tools_csv)"
 HOST_GIT_BIN="$(resolve_host_tool git /usr/bin/git /opt/homebrew/bin/git /usr/local/bin/git)"
 HOST_DOCKER_BIN="docker"
 if [[ -z "${COLIMA_PROFILE}" ]]; then
@@ -2801,10 +3154,13 @@ if [[ "${DOCTOR}" -eq 1 ]]; then
     prepared_image=1
   fi
   print_inspect_state "${recorded_image_id}" "${local_current_image_id}"
+  printf 'doctor_missing_host_tools=%s\n' "${HOST_TOOL_MISSING_CSV}"
   printf 'doctor_profile_state=%s\n' "${profile_state}"
   printf 'doctor_workspace_binding=%s\n' "${PROFILE_MARKER_WORKSPACE:-none}"
   printf 'doctor_prepared_image=%s\n' "${prepared_image}"
-  if [[ "${workspace_state}" == "missing" ]] || [[ "${workspace_state}" == "not-directory" ]]; then
+  if [[ "${HOST_TOOL_MISSING_CSV}" != "none" ]]; then
+    printf 'doctor_recommended_next=install-host-tools\n'
+  elif [[ "${workspace_state}" == "missing" ]] || [[ "${workspace_state}" == "not-directory" ]]; then
     printf 'doctor_recommended_next=fix-workspace\n'
   elif [[ "${profile_state}" == "unmanaged" ]]; then
     printf 'doctor_recommended_next='
@@ -2820,6 +3176,10 @@ if [[ "${DOCTOR}" -eq 1 ]]; then
     printf 'doctor_recommended_next=none\n'
   fi
   exit 0
+fi
+
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+  acquire_profile_lock "${COLIMA_PROFILE}"
 fi
 
 if [[ "${PROFILE_PREEXISTED}" -eq 1 ]] && [[ ! -f "${PROFILE_MARKER}" ]]; then
@@ -2873,12 +3233,13 @@ if [[ "${DRY_RUN}" -eq 0 ]]; then
   export COLIMA_HOME="${COLIMA_STATE_ROOT}"
 fi
 
-ALLOW_ENDPOINTS="$(provider_endpoints "${AGENT}") ${EXTRA_ENDPOINTS}"
+ALLOW_ENDPOINTS="$(dedupe_endpoint_list "$(provider_endpoints "${AGENT}") $(credential_extra_endpoints) ${INJECTION_EXTRA_ENDPOINTS} ${EXTRA_ENDPOINTS}")"
 if [[ "${CONTAINER_MUTABILITY}" == "ephemeral" ]]; then
-  ALLOW_ENDPOINTS="${ALLOW_ENDPOINTS} snapshot.debian.org:80 snapshot.debian.org:443"
+  ALLOW_ENDPOINTS="$(dedupe_endpoint_list "${ALLOW_ENDPOINTS} snapshot.debian.org:80 snapshot.debian.org:443")"
 fi
 prepare_workspace_control_plane_shadow "${WORKSPACE}" "${MODE}"
-prepare_cache_mounts "${COLIMA_PROFILE}" "${CACHE_PROFILE}"
+prepare_cache_mounts "${AGENT}" "${CACHE_PROFILE}" "${WORKSPACE}"
+build_runtime_host_aliases "${ALLOW_ENDPOINTS}"
 if [[ "${DRY_RUN}" -eq 0 ]]; then
   prepare_session_audit_state "${COLIMA_PROFILE}"
 fi
@@ -2941,6 +3302,9 @@ if ((${#SHADOW_MOUNTS[@]} > 0)); then
 fi
 if ((${#WORKSPACE_IMPORT_MOUNTS[@]} > 0)); then
   DOCKER_RUN_BASE+=("${WORKSPACE_IMPORT_MOUNTS[@]}")
+fi
+if ((${#RUNTIME_NETWORK_ARGS[@]} > 0)); then
+  DOCKER_RUN_BASE+=("${RUNTIME_NETWORK_ARGS[@]}")
 fi
 if ((${#DIRECT_SOURCE_MOUNTS[@]} > 0)); then
   DOCKER_RUN_BASE+=("${DIRECT_SOURCE_MOUNTS[@]}")
@@ -3015,6 +3379,10 @@ printf 'network_policy=%s endpoints=%s\n' "${NETWORK_POLICY}" "${ALLOW_ENDPOINTS
 printf 'execution_path=%s audit_log=%s\n' "${EXECUTION_PATH}" "$(profile_audit_log_path "${COLIMA_PROFILE}")" >&2
 
 if [[ "${DRY_RUN}" -eq 1 ]]; then
+  if [[ "${PREPARE_ONLY}" -eq 1 ]]; then
+    printf 'prepare_only=1 no_session_launch=1\n'
+    exit 0
+  fi
   emit_redacted_command "${DOCKER_RUN[@]}"
   exit 0
 fi
@@ -3126,6 +3494,10 @@ if [[ "${NEEDS_REBUILD}" -eq 1 ]]; then
 fi
 
 restore_runtime_egress
+if [[ "${PREPARE_ONLY}" -eq 1 ]]; then
+  echo "Prepared runtime image recorded for profile ${COLIMA_PROFILE}. No session launched because --prepare-only was requested." >&2
+  exit 0
+fi
 append_launch_audit_record "${COLIMA_PROFILE}" "${EXECUTION_PATH}"
 
 DOCKER_STATUS=0

--- a/tests/python/test_render_injection_bundle.py
+++ b/tests/python/test_render_injection_bundle.py
@@ -222,6 +222,57 @@ class RenderInjectionBundleTests(unittest.TestCase):
 
             self.assertEqual(rendered, {})
 
+    def test_render_credentials_accepts_legacy_scalar_github_auth_and_requires_providers_for_tables(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            auth = root / "github-hosts.yml"
+            auth.write_text("github.com:\n", encoding="utf-8")
+            auth.chmod(0o600)
+
+            rendered = self.module.render_credentials(
+                {"credentials": {"github_hosts": "github-hosts.yml"}},
+                root,
+                "codex",
+                "strict",
+            )
+            self.assertEqual(
+                rendered["github_hosts"]["mount_path"],
+                "/opt/workcell/host-inputs/credentials/github-hosts.yml",
+            )
+
+            with self.assertRaises(SystemExit):
+                self.module.render_credentials(
+                    {
+                        "credentials": {
+                            "github_hosts": {
+                                "source": "github-hosts.yml",
+                            }
+                        }
+                    },
+                    root,
+                    "codex",
+                    "strict",
+                )
+
+    def test_derive_credential_extra_endpoints_adds_vertex_region_from_gemini_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            env_file = root / "gemini.env"
+            env_file.write_text('export GOOGLE_CLOUD_LOCATION="us-central1"\n', encoding="utf-8")
+            env_file.chmod(0o600)
+
+            rendered = self.module.render_credentials(
+                {"credentials": {"gemini_env": "gemini.env"}},
+                root,
+                "gemini",
+                "strict",
+            )
+
+            self.assertEqual(
+                self.module.derive_credential_extra_endpoints(rendered),
+                ["us-central1-aiplatform.googleapis.com:443"],
+            )
+
     def test_render_ssh_rejects_unsafe_config_without_opt_in(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -229,6 +280,24 @@ class RenderInjectionBundleTests(unittest.TestCase):
             output.mkdir()
             config = root / "ssh-config"
             config.write_text("ProxyCommand nc %h %p\n", encoding="utf-8")
+            config.chmod(0o600)
+
+            with self.assertRaises(SystemExit):
+                self.module.render_ssh(
+                    {"ssh": {"enabled": True, "config": "ssh-config"}},
+                    output,
+                    root,
+                    "codex",
+                    "strict",
+                )
+
+    def test_render_ssh_rejects_other_exec_capable_directives_without_opt_in(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            config = root / "ssh-config"
+            config.write_text("KnownHostsCommand /bin/true\n", encoding="utf-8")
             config.chmod(0o600)
 
             with self.assertRaises(SystemExit):


### PR DESCRIPTION
## Summary
- harden session replay paths, injection metadata, and runtime host alias handling
- split safe vs heavy remote pre-merge validation and tighten remote validator fail-closed behavior
- extend validation/docs/tests for Gemini Vertex regional endpoints, symlink-safe copy replay, and launcher UX

## Validation
- ./scripts/dev-quick-check.sh
- ./scripts/verify-invariants.sh
- ./scripts/validate-repo.sh
- ./scripts/dev-remote-validate.sh --host <configured internal builder> --check validate --check smoke --allow-shared-daemon-heavy-checks

## Review
- six blocker-only reviewer passes: ethical hacker, penetration tester, reverse engineer, Claude SWE, OpenAI SWE, Gemini SWE
