### PR TITLE
Skip hosted-controls audit when token is absent on main

### DIFF
--- a/.github/workflows/hosted-controls.yml
+++ b/.github/workflows/hosted-controls.yml
@@ -27,6 +27,6 @@ jobs:
 
       - name: Verify GitHub-hosted controls
         env:
-          WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"
+          WORKCELL_HOSTED_CONTROLS_REQUIRED: "0"
           WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}
         run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -111,6 +111,11 @@ dedicated `WORKCELL_HOSTED_CONTROLS_TOKEN` secret for workflow-based audits.
 The continuous `hosted-controls.yml` workflow skips cleanly when that secret is
 absent so `main` does not stay red on a known GitHub token limitation, but the
 tagged `release.yml` preflight fails closed unless the secret is configured.
+The workflow enforces that split explicitly with
+`WORKCELL_HOSTED_CONTROLS_REQUIRED="0"` in
+[`hosted-controls.yml`](../.github/workflows/hosted-controls.yml) and
+`WORKCELL_HOSTED_CONTROLS_REQUIRED="1"` in
+[`release.yml`](../.github/workflows/release.yml).
 That token should be a fine-grained token or GitHub App token scoped only to
 this repository and only to the repository-administration metadata needed for
 the audit. Workflow jobs that can read that token run inside a dedicated

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -489,6 +489,12 @@ require_contains(
     ".github/workflows/hosted-controls.yml",
 )
 require_contains(
+    hosted_controls_workflow,
+    'WORKCELL_HOSTED_CONTROLS_REQUIRED: "0"',
+    "a non-blocking hosted-controls audit mode for continuous drift detection",
+    ".github/workflows/hosted-controls.yml",
+)
+require_contains(
     release_workflow,
     "environment:\n      name: release",
     "a protected release environment gate",


### PR DESCRIPTION
## Summary
- make the continuous hosted-controls workflow explicitly non-blocking when the dedicated audit token is absent
- keep release preflight fail-closed and document the split
- enforce the workflow contract in the pinned-input policy check

## Validation
- ./scripts/check-pinned-inputs.sh
- ./scripts/check-workflows.sh