### PR TITLE
Reduce CI wall clock for reproducible builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,16 +85,25 @@ jobs:
       - name: Run Workcell container smoke
         run: ./scripts/container-smoke.sh
 
-  reproducible-build:
-    name: Reproducible build
+  reproducible-build-platform:
+    name: Reproducible build (${{ matrix.platform_name }})
     runs-on: ubuntu-latest
     needs: validate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            platform_name: amd64
+          - platform: linux/arm64
+            platform_name: arm64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - if: ${{ matrix.platform == 'linux/arm64' }}
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
           cache-image: true
           image: ${{ env.WORKCELL_QEMU_IMAGE }}
@@ -106,4 +115,14 @@ jobs:
           version: ${{ env.WORKCELL_BUILDX_VERSION }}
 
       - name: Verify reproducible runtime build
+        env:
+          WORKCELL_REPRO_PLATFORMS: ${{ matrix.platform }}
         run: ./scripts/verify-reproducible-build.sh
+
+  reproducible-build:
+    name: Reproducible build
+    runs-on: ubuntu-latest
+    needs: reproducible-build-platform
+    steps:
+      - name: Confirm per-platform reproducible builds passed
+        run: true

--- a/README.md
+++ b/README.md
@@ -379,8 +379,9 @@ Intentional non-goals for the safe path:
 - `scripts/container-smoke.sh`: direct container build and adapter smoke tests
 - `scripts/verify-invariants.sh`: local invariant regression checks against the
   launcher and shipped adapter policy
-- `scripts/verify-reproducible-build.sh`: deterministic per-platform OCI
-  runtime export verification under a fixed `SOURCE_DATE_EPOCH`
+- `scripts/verify-reproducible-build.sh`: deterministic paired multi-platform
+  OCI runtime image verification under a fixed `SOURCE_DATE_EPOCH`, with a
+  stable OCI subject digest plus per-platform digest binding for release preflight
 - `scripts/verify-release-bundle.sh`: deterministic source bundle verification
   under a fixed `SOURCE_DATE_EPOCH`
 - `scripts/dev-remote-validate.sh`: stage the current working tree to a private

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -8,8 +8,9 @@ under platform automation.
 
 - `ci.yml`: repo validation and direct container smoke on every pull request and
   push to `main`
-- `ci.yml`: also verifies that two OCI exports of each supported pinned runtime
-  platform are byte-for-byte identical when built with the same
+- `ci.yml`: also verifies that two multi-platform OCI exports covering every
+  supported pinned runtime platform produce the same stable OCI subject digest and the
+  same reviewed per-platform digests when built with the same
   `SOURCE_DATE_EPOCH`
 - `ci.yml`: caches only exact pinned QEMU and Buildx helper artifacts; it does
   not add layer caching to the reviewed runtime build path

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -8,10 +8,9 @@ under platform automation.
 
 - `ci.yml`: repo validation and direct container smoke on every pull request and
   push to `main`
-- `ci.yml`: also verifies that two multi-platform OCI exports covering every
-  supported pinned runtime platform produce the same stable OCI subject digest and the
-  same reviewed per-platform digests when built with the same
-  `SOURCE_DATE_EPOCH`
+- `ci.yml`: also verifies each supported pinned runtime platform
+  reproducibly under the same `SOURCE_DATE_EPOCH` in parallel, while keeping a
+  single required `Reproducible build` status for branch protection
 - `ci.yml`: caches only exact pinned QEMU and Buildx helper artifacts; it does
   not add layer caching to the reviewed runtime build path
 - `ci.yml`: also verifies that the release source bundle is reproducible with a

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -81,17 +81,18 @@ release workflow additionally requires the tagged commit to be reachable from
 `main`, but consumers should still verify branch protection and review policy in
 the repository itself.
 
-The reproducibility check compares two OCI layout exports of each supported
-runtime platform that are built with the same `SOURCE_DATE_EPOCH` and without
-attached attestations. This is intentional: BuildKit attestations are
-separately signed and verified release metadata, while the reproducibility gate
-measures the image contents themselves. Release publication then assembles the
-final multi-architecture manifest list in a fixed platform order from those
-reviewed per-platform outputs and requires the pushed per-platform digests to
-match the preflight manifest before the final multi-architecture manifest is
-published. The release preflight also verifies deterministic source bundle
-generation, records the expected tarball digest for the tag-specific prefix and
-ref, and requires the published source bundle to match that preflight digest.
+The reproducibility check compares two multi-platform OCI layout exports that
+cover every supported runtime platform, built with the same
+`SOURCE_DATE_EPOCH` and without attached attestations. This is intentional:
+BuildKit attestations are separately signed and verified release metadata,
+while the reproducibility gate measures the image contents themselves. The
+check compares the stable OCI subject digest from those exports and still
+records reviewed per-platform manifest and config digests, and release
+publication requires the pushed per-platform digests to match the preflight
+manifest before the final multi-architecture manifest is published. The release
+preflight also verifies deterministic source bundle generation, records the
+expected tarball digest for the tag-specific prefix and ref, and requires the
+published source bundle to match that preflight digest.
 The publish job then rebuilds the signed build-input manifest and the published
 runtime image from the extracted signed source bundle tree, not from the live
 checkout, so the signed tarball is the authoritative source for the shipped

--- a/scripts/verify-reproducible-build.sh
+++ b/scripts/verify-reproducible-build.sh
@@ -27,9 +27,8 @@ REPRO_PLATFORMS="${WORKCELL_REPRO_PLATFORMS:-linux/amd64,linux/arm64}"
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -C "${ROOT_DIR}" log -1 --pretty=%ct 2>/dev/null || printf '0')}"
 REPRO_MANIFEST_PATH="${WORKCELL_REPRO_MANIFEST_PATH:-}"
 OCI_EXPORT_ROOT=""
-OCI_EXPORT_A=()
-OCI_EXPORT_B=()
-LAYOUT_DIGESTS=()
+OCI_EXPORT_A=""
+OCI_EXPORT_B=""
 MANIFEST_DIGESTS=()
 CONFIG_DIGESTS=()
 WORKCELL_DOCKER_SANDBOX_ROOT=""
@@ -79,12 +78,8 @@ if [[ "${1:-}" == "--self-docker-probe" ]]; then
   exit 0
 fi
 
-platform_slug() {
-  printf '%s\n' "$1" | tr '/,' '__'
-}
-
 build_oci_layout() {
-  local platform="$1"
+  local platforms="$1"
   local dest="$2"
   local build_source_date_epoch="${SOURCE_DATE_EPOCH}"
 
@@ -92,7 +87,7 @@ build_oci_layout() {
   mkdir -p "$(dirname "${dest}")"
   SOURCE_DATE_EPOCH="${build_source_date_epoch}" buildx_cmd build \
     --no-cache \
-    --platform "${platform}" \
+    --platform "${platforms}" \
     --build-arg "BUILDKIT_MULTI_PLATFORM=1" \
     --build-arg "SOURCE_DATE_EPOCH=${build_source_date_epoch}" \
     --provenance=false \
@@ -102,27 +97,111 @@ build_oci_layout() {
     "${ROOT_DIR}" >/dev/null
 }
 
-layout_digest() {
+oci_subject_digest() {
   local dir="$1"
 
-  (
-    cd "${dir}"
-    find . -type f | LC_ALL=C sort | while IFS= read -r file; do
-      shasum -a 256 "${file}"
-    done
-  ) | shasum -a 256 | awk '{print $1}'
+  python3 - "${dir}" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+layout_dir = pathlib.Path(sys.argv[1])
+index_path = layout_dir / "index.json"
+index_bytes = index_path.read_bytes()
+index = json.loads(index_bytes)
+manifests = index.get("manifests", [])
+
+if not manifests:
+    raise SystemExit("OCI export index does not contain any manifests")
+
+if manifests and all("platform" not in entry for entry in manifests):
+    if len(manifests) != 1:
+        raise SystemExit(
+            "Expected a single top-level OCI index wrapper entry for multi-platform export"
+        )
+    digest = manifests[0].get("digest")
+    if not isinstance(digest, str) or not digest.startswith("sha256:"):
+        raise SystemExit(f"Malformed wrapped OCI index digest: {digest!r}")
+    print(digest)
+elif len(manifests) == 1:
+    digest = manifests[0].get("digest")
+    if not isinstance(digest, str) or not digest.startswith("sha256:"):
+        raise SystemExit(f"Malformed OCI subject digest: {digest!r}")
+    print(digest)
+else:
+    def strip_annotations(value):
+        if isinstance(value, dict):
+            return {
+                key: strip_annotations(item)
+                for key, item in value.items()
+                if key != "annotations"
+            }
+        if isinstance(value, list):
+            return [strip_annotations(item) for item in value]
+        return value
+
+    canonical = json.dumps(
+        strip_annotations(index),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    print(f"sha256:{hashlib.sha256(canonical).hexdigest()}")
+PY
 }
 
 manifest_digest() {
   local dir="$1"
+  local platform="$2"
 
-  python3 - "${dir}/index.json" <<'PY'
+  python3 - "${dir}" "${platform}" <<'PY'
 import json
+import pathlib
 import sys
 
-with open(sys.argv[1], "r", encoding="utf-8") as handle:
+platform_parts = sys.argv[2].split("/")
+if len(platform_parts) not in (2, 3):
+    raise SystemExit(f"Unsupported platform selector: {sys.argv[2]!r}")
+
+layout_dir = pathlib.Path(sys.argv[1])
+with (layout_dir / "index.json").open("r", encoding="utf-8") as handle:
     index = json.load(handle)
-print(index["manifests"][0]["digest"])
+
+manifests = index.get("manifests", [])
+if manifests and all("platform" not in entry for entry in manifests):
+    if len(manifests) != 1:
+        raise SystemExit(
+            "Expected a single top-level OCI index wrapper entry for multi-platform export"
+        )
+    digest = manifests[0].get("digest")
+    if not isinstance(digest, str) or not digest.startswith("sha256:"):
+        raise SystemExit(f"Malformed wrapped OCI index digest: {digest!r}")
+    nested_index_path = layout_dir / "blobs" / "sha256" / digest.split(":", 1)[1]
+    with nested_index_path.open("r", encoding="utf-8") as handle:
+        index = json.load(handle)
+    manifests = index.get("manifests", [])
+
+requested_os = platform_parts[0]
+requested_arch = platform_parts[1]
+requested_variant = platform_parts[2] if len(platform_parts) == 3 else None
+matches = []
+
+for manifest in manifests:
+    candidate = manifest.get("platform", {})
+    if candidate.get("os") != requested_os:
+        continue
+    if candidate.get("architecture") != requested_arch:
+        continue
+    if candidate.get("variant") != requested_variant:
+        continue
+    matches.append(manifest["digest"])
+
+if len(matches) != 1:
+    raise SystemExit(
+        f"Expected exactly one manifest for {sys.argv[2]!r}, found {len(matches)}"
+    )
+
+print(matches[0])
 PY
 }
 
@@ -170,46 +249,57 @@ else
   OCI_EXPORT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/workcell-repro.XXXXXX")"
 fi
 IFS=',' read -r -a platform_list <<<"${REPRO_PLATFORMS}"
-for index in "${!platform_list[@]}"; do
-  platform="${platform_list[${index}]}"
-  slug="$(platform_slug "${platform}")"
-  OCI_EXPORT_A[index]="${OCI_EXPORT_ROOT}/a-${slug}"
-  OCI_EXPORT_B[index]="${OCI_EXPORT_ROOT}/b-${slug}"
-  build_oci_layout "${platform}" "${OCI_EXPORT_A[${index}]}"
-  build_oci_layout "${platform}" "${OCI_EXPORT_B[${index}]}"
-done
+
+OCI_EXPORT_A="${OCI_EXPORT_ROOT}/a"
+OCI_EXPORT_B="${OCI_EXPORT_ROOT}/b"
+build_oci_layout "${REPRO_PLATFORMS}" "${OCI_EXPORT_A}"
+build_oci_layout "${REPRO_PLATFORMS}" "${OCI_EXPORT_B}"
+
+subject_digest_a="$(oci_subject_digest "${OCI_EXPORT_A}")"
+subject_digest_b="$(oci_subject_digest "${OCI_EXPORT_B}")"
+repro_failed=0
 
 for index in "${!platform_list[@]}"; do
   platform="${platform_list[${index}]}"
-  digest_a="$(layout_digest "${OCI_EXPORT_A[${index}]}")"
-  digest_b="$(layout_digest "${OCI_EXPORT_B[${index}]}")"
-  manifest_a="$(manifest_digest "${OCI_EXPORT_A[${index}]}")"
-  manifest_b="$(manifest_digest "${OCI_EXPORT_B[${index}]}")"
-  config_a="$(config_digest "${OCI_EXPORT_A[${index}]}" "${manifest_a}")"
-  config_b="$(config_digest "${OCI_EXPORT_B[${index}]}" "${manifest_b}")"
+  manifest_a="$(manifest_digest "${OCI_EXPORT_A}" "${platform}")"
+  manifest_b="$(manifest_digest "${OCI_EXPORT_B}" "${platform}")"
+  config_a="$(config_digest "${OCI_EXPORT_A}" "${manifest_a}")"
+  config_b="$(config_digest "${OCI_EXPORT_B}" "${manifest_b}")"
 
-  if [[ "${digest_a}" != "${digest_b}" ]]; then
-    echo "Non-reproducible OCI export for ${platform}: ${digest_a} != ${digest_b}" >&2
+  if [[ "${manifest_a}" != "${manifest_b}" ]]; then
     echo "Manifest digests (${platform}): ${manifest_a} != ${manifest_b}" >&2
-    echo "Config digests (${platform}): ${config_a} != ${config_b}" >&2
-    exit 1
+    repro_failed=1
   fi
 
-  LAYOUT_DIGESTS[index]="${digest_a}"
+  if [[ "${config_a}" != "${config_b}" ]]; then
+    echo "Config digests (${platform}): ${config_a} != ${config_b}" >&2
+    repro_failed=1
+  fi
+
   MANIFEST_DIGESTS[index]="${manifest_a}"
   CONFIG_DIGESTS[index]="${config_a}"
 done
 
+if [[ "${subject_digest_a}" != "${subject_digest_b}" ]]; then
+  echo "Non-reproducible OCI export subject digest: ${subject_digest_a} != ${subject_digest_b}" >&2
+  repro_failed=1
+fi
+
+if [[ "${repro_failed}" -ne 0 ]]; then
+  exit 1
+fi
+
 if [[ -n "${REPRO_MANIFEST_PATH}" ]]; then
-  python3 - "${REPRO_MANIFEST_PATH}" "${SOURCE_DATE_EPOCH}" "${#platform_list[@]}" "${platform_list[@]}" "${LAYOUT_DIGESTS[@]}" -- "${MANIFEST_DIGESTS[@]}" -- "${CONFIG_DIGESTS[@]}" <<'PY'
+  python3 - "${REPRO_MANIFEST_PATH}" "${SOURCE_DATE_EPOCH}" "${subject_digest_a}" "${#platform_list[@]}" "${platform_list[@]}" "${MANIFEST_DIGESTS[@]}" -- "${CONFIG_DIGESTS[@]}" <<'PY'
 import json
 import pathlib
 import sys
 
 manifest_path = pathlib.Path(sys.argv[1])
 source_date_epoch = int(sys.argv[2])
-count = int(sys.argv[3])
-argv = list(sys.argv[4:])
+oci_subject_digest = sys.argv[3]
+count = int(sys.argv[4])
+argv = list(sys.argv[5:])
 
 platforms = argv[:count]
 argv = argv[count:]
@@ -223,23 +313,22 @@ def take_until_separator(items):
     items.pop(0)
     return values
 
-layouts = take_until_separator(argv)
 manifests = take_until_separator(argv)
 configs = argv
 
-if not (len(platforms) == len(layouts) == len(manifests) == len(configs) == count):
+if not (len(platforms) == len(manifests) == len(configs) == count):
     raise SystemExit("Reproducibility manifest argument lengths do not match")
 
 manifest = {
+    "oci_subject_digest": oci_subject_digest,
     "source_date_epoch": source_date_epoch,
     "platforms": {
         platform: {
-            "layout_sha256": layout,
             "image_manifest_digest": manifest_digest,
             "config_digest": config_digest,
         }
-        for platform, layout, manifest_digest, config_digest in zip(
-            platforms, layouts, manifests, configs, strict=True
+        for platform, manifest_digest, config_digest in zip(
+            platforms, manifests, configs, strict=True
         )
     },
 }


### PR DESCRIPTION
## Summary
- optimize `scripts/verify-reproducible-build.sh` so it records stable OCI subject digests and per-platform digests for multi-platform and single-platform exports
- split CI reproducible-build verification into parallel amd64 and arm64 jobs while preserving one required `Reproducible build` status
- update workflow/provenance docs to match the reviewed verification shape

## Empirical result
- recent CI baseline: ~33m total wall clock, with `Reproducible build` around ~30m
- branch run `23556364414` (script-only change): ~32m32s total, not enough on its own
- branch run `23557965612` (with parallel per-platform CI): ~27m08s total
- net improvement versus the recent baseline: about 6 minutes, without adding layer caching or weakening reproducibility checks