### PR TITLE
Declare hosted branch integrity invariants

### DIFF
--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -81,8 +81,8 @@ automation.
 Workcell keeps several repository settings outside git, but they are still part
 of the reviewed control plane:
 
-- active rulesets on the default branch for signed commits and anti-rewrite
-  integrity
+- active rulesets on the default branch for signed commits, anti-rewrite
+  integrity, and branch-deletion protection
 - an active required-status-checks ruleset on the default branch for the core
   CI and GitHub workflow security checks
 - an active review ruleset on the default branch that requires pull requests;
@@ -123,14 +123,18 @@ the audit. Workflow jobs that can read that token run inside a dedicated
 jobs.
 
 The current repository policy uses
-`branch_review.mode = "single-owner-private-pr"` and
+`branch_integrity.require_signed_commits = true`,
+`branch_integrity.block_force_pushes = true`,
+`branch_integrity.block_deletions = true`,
+`branch_review.mode = "single-owner-private-pr"`, and
 `release_environment.mode = "single-owner-private"` because this is a private
 single-owner repository. The audit enforces that as a private user-owned
 repository whose only direct collaborator is the owner. In that mode, the
 audited expectation is:
 
-- `main` still requires pull requests and green required checks, but does not
-  require impossible third-party approvals, code-owner review, or review-thread
+- `main` requires signed commits, blocks force-push and deletion, and still
+  requires pull requests plus green required checks, but does not require
+  impossible third-party approvals, code-owner review, or review-thread
   resolution
 - the named `release` environment exists, but it is not treated as a
   multi-party human approval gate

--- a/policy/README.md
+++ b/policy/README.md
@@ -10,5 +10,7 @@ captures the shared rules that every adapter must preserve:
 - network modes are explicit
 - `breakglass` is named and narrow
 - lower-assurance GUI modes are clearly labeled
+- repository-hosted controls that live outside git still need explicit,
+  auditable policy declarations
 
 Provider-native config belongs under `adapters/`.

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -1,6 +1,15 @@
 # GitHub-hosted repository controls that live outside the git tree but remain
 # part of the reviewed Workcell control plane.
 
+[branch_integrity]
+# These integrity controls stay enabled regardless of repository size:
+# - require signed commits on the default branch
+# - block force-pushes on the default branch
+# - block deletion of the default branch
+require_signed_commits = true
+block_force_pushes = true
+block_deletions = true
+
 [branch_review]
 # Valid modes:
 # - "review-gated": require pull requests, at least one approving review,

--- a/scripts/verify-github-hosted-controls.sh
+++ b/scripts/verify-github-hosted-controls.sh
@@ -78,6 +78,16 @@ policy = tomllib.loads(policy_path.read_text(encoding="utf-8"))
 default_branch = repo_meta["default_branch"]
 owner_login = repo_meta["owner"]["login"]
 owner_type = repo_meta["owner"]["type"]
+branch_integrity_policy = policy.get("branch_integrity")
+if not isinstance(branch_integrity_policy, dict):
+    raise SystemExit(
+        f"{policy_path} must define branch_integrity as a table with explicit booleans"
+    )
+for key in ("require_signed_commits", "block_force_pushes", "block_deletions"):
+    if branch_integrity_policy.get(key) is not True:
+        raise SystemExit(
+            f"{policy_path} must set branch_integrity.{key} = true"
+        )
 branch_review_mode = policy.get("branch_review", {}).get("mode", "review-gated")
 if branch_review_mode not in {"review-gated", "single-owner-private-pr"}:
     raise SystemExit(
@@ -151,7 +161,8 @@ for ruleset in active_rulesets:
     if ruleset.get("target") == "branch" and has_ref_include(ruleset, "~DEFAULT_BRANCH"):
         signatures = has_rule(ruleset, "required_signatures")
         non_fast_forward = has_rule(ruleset, "non_fast_forward")
-        if signatures and non_fast_forward:
+        deletion = has_rule(ruleset, "deletion")
+        if signatures and non_fast_forward and deletion:
             branch_integrity = ruleset
         pull_request = has_rule(ruleset, "pull_request")
         if pull_request:
@@ -169,7 +180,7 @@ for ruleset in active_rulesets:
 if branch_integrity is None:
     raise SystemExit(
         f"Missing active default-branch integrity ruleset on {repo} "
-        f"with required_signatures and non_fast_forward"
+        f"with required_signatures, non_fast_forward, and deletion"
     )
 
 if branch_review is None:


### PR DESCRIPTION
## Summary
- declare default-branch signed-commit, force-push, and deletion protections explicitly in `policy/github-hosted-controls.toml`
- make `scripts/verify-github-hosted-controls.sh` enforce branch deletion protection instead of assuming it implicitly
- document the single-maintainer hosted-controls policy more explicitly
- audit prior closed security PRs and confirm #7 superseded #3, #4, and #5 with the protections present on `main`

## Validation
- `bash -n scripts/verify-github-hosted-controls.sh`
- `./scripts/verify-github-hosted-controls.sh omkhar/workcell`
- `./scripts/validate-repo.sh`