### PR TITLE
Improve startup feedback and Gemini launch flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ the runtime boundary or explicit security guarantees in the name of convenience.
 
 ## Mandatory rules
 
+- Sign every commit. Do not create or rewrite commits in this repository
+  without a verified signature from the maintainer identity.
 - Do not treat provider config, prompt files, or rules as the sole security
   boundary.
 - Preserve the dedicated VM plus container boundary as the Tier 1 design for

--- a/adapters/gemini/.gemini/settings.json
+++ b/adapters/gemini/.gemini/settings.json
@@ -33,7 +33,7 @@
   },
   "security": {
     "folderTrust": {
-      "enabled": true
+      "enabled": false
     }
   },
   "advanced": {

--- a/adapters/gemini/README.md
+++ b/adapters/gemini/README.md
@@ -16,6 +16,23 @@ Workcell injection policy inputs such as `documents.gemini` or
 `credentials.gemini_projects` when you want reviewed Gemini state or
 instructions to persist across launches.
 
+On the managed strict/build path, the adapter seeds Gemini's session-local
+trusted-folders registry for `/workspace` and disables Gemini CLI's own
+folder-trust gate in the managed baseline. Workcell already masks repo-local
+Gemini control files and seeds the only trusted Gemini home inside the bounded
+runtime, so surfacing Gemini's restart-based trust flow there would add friction
+without adding a stronger boundary. In `breakglass`, Workcell restores Gemini's
+own folder-trust prompt behavior because the workspace control plane is no
+longer masked.
+
+When Gemini auth is injected, Workcell also preselects the matching Gemini auth
+mode inside the session-local settings when it can do so unambiguously.
+`GEMINI_API_KEY` and Google-login flows can stand alone. Vertex flows must set
+`GOOGLE_GENAI_USE_VERTEXAI=true` and then provide either `GOOGLE_API_KEY` or
+both `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`. `gcloud_adc` is only a
+supplemental Vertex input and must be paired with explicit Vertex settings in
+`credentials.gemini_env`.
+
 Gemini CLI is Tier 1 when it runs fully inside the bounded runtime. GUI or IDE
 integration is lower assurance unless it is only a client to the same bounded
 executor.

--- a/docs/adapter-control-planes.md
+++ b/docs/adapter-control-planes.md
@@ -44,12 +44,13 @@ The following table covers all files seeded by `seed_codex_home()`,
 | `~/.claude/workcell/` | Claude | Created only when `claude_api_key` credential is injected | Same | Holds the session-local `api-key-helper.sh` script and secret file |
 | `~/.config/claude-code/auth.json` | Claude | Copied from injection credential `claude_auth` if present | Same | Session-local Claude CLI auth; not present if `credentials.claude_auth` is not configured |
 | `~/.mcp.json` | Claude | Symlink → immutable `mcp-template.json` (empty), or copied from `claude_mcp` credential if injected | Same | MCP server registry; ships empty by default |
-| `~/.gemini/settings.json` | Gemini | Copied (not symlinked) from immutable baseline; mode `0600` | Same | Copied from `adapters/gemini/.gemini/settings.json` |
+| `~/.gemini/settings.json` | Gemini | Copied (not symlinked) from immutable baseline; mode `0600` | Same, but `breakglass` re-enables Gemini folder trust before launch | Copied from `adapters/gemini/.gemini/settings.json` |
+| `~/.gemini/trustedFolders.json` | Gemini | Seeded session-local with `/workspace` trusted; mode `0600` | Same for strict/build; omitted in `breakglass` | Prevents Gemini's restart-only trust prompt inside masked ephemeral sessions while preserving Gemini's own prompt on `breakglass` |
 | `~/.gemini/GEMINI.md` | Gemini | Rendered (baseline + workspace + injection layers) | Same | Provider instruction doc; workspace `AGENTS.md` and `GEMINI.md` are imported as layers |
-| `~/.gemini/.env` | Gemini | Copied from injection credential `gemini_env` if present | Same | Provider-native env-file auth (API keys, Vertex project settings) |
+| `~/.gemini/.env` | Gemini | Copied from injection credential `gemini_env` if present | Same | Provider-native env-file auth (API keys, Vertex project settings); Workcell derives Gemini's selected auth type from this file when possible |
 | `~/.gemini/oauth_creds.json` | Gemini | Copied from injection credential `gemini_oauth` if present | Same | Cached Gemini OAuth credential |
 | `~/.gemini/projects.json` | Gemini | Copied from injection credential `gemini_projects` if present; otherwise seeded with empty `{"projects":{}}` | Same | Gemini CLI project registry |
-| `~/.config/gcloud/application_default_credentials.json` | Gemini | Copied from injection credential `gcloud_adc` if present | Same | Google ADC for Vertex flows |
+| `~/.config/gcloud/application_default_credentials.json` | Gemini | Copied from injection credential `gcloud_adc` if present | Same | Supplemental Google ADC for Vertex flows driven by `~/.gemini/.env`; not a standalone Gemini auth mode |
 | `~/.config/gh/config.yml` | All | Copied from injection credential `github_config` if present | Same | GitHub CLI config; shared across providers |
 | `~/.config/gh/hosts.yml` | All | Copied from injection credential `github_hosts` if present | Same | GitHub CLI auth; shared across providers |
 | `~/.ssh/` | All | Seeded from `[ssh]` injection section if configured | Same | SSH config, known_hosts, and identity files; `SSH_AUTH_SOCK` is never forwarded |

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -22,14 +22,16 @@ baseline. If you explicitly opt into
 session-local writable tree so provider-approved execpolicy amendments can
 persist for the life of the container, while the adapter baseline remains
 immutable. The staged host bundle lives in a launcher-owned state
-directory under `~/.local/state/workcell/tmp`, is mounted read-only into the
-runtime, and is cleaned up on exit with dead-owner stale
+directory under `~/Library/Caches/colima/workcell-host-inputs`, is mounted
+read-only into the runtime, and is cleaned up on exit with dead-owner stale
 bundle garbage collection on later launches. Secret-bearing inputs are treated
-more strictly: Workcell validates their host source files, mounts those sources
-read-only into the runtime for the current session, and only then copies them
-into the ephemeral session home. That avoids creating an extra plaintext
-host-side bundle for provider credentials, SSH material, and
-`classification = "secret"` copied files.
+more strictly: Workcell validates their host source files, restages those files
+under the same launcher-owned cache root with restrictive permissions so the
+managed Colima VM can bind-mount them read-only, and only then copies them into
+the ephemeral session home. That means provider credentials, SSH material, and
+`classification = "secret"` copied files do create a short-lived extra
+host-side plaintext staging copy, which later launches garbage-collect if a
+previous session crashes before cleanup.
 
 Provider docs are rendered in a fixed precedence order:
 
@@ -138,8 +140,10 @@ modes = ["strict", "build"]
 - `credentials.claude_mcp` mounts an approved Claude `.mcp.json` into the
   session without widening trust to the whole workspace copy.
 - `credentials.gemini_env` mounts a provider-native `~/.gemini/.env`.
-  This matches Gemini CLI's documented env-file auth flow for API keys,
-  Vertex project settings, and related variables. When the file includes
+  This matches Gemini CLI's documented env-file auth flow for `GEMINI_API_KEY`,
+  `GOOGLE_GENAI_USE_GCA=true`, or explicit Vertex settings such as
+  `GOOGLE_GENAI_USE_VERTEXAI=true` paired with either `GOOGLE_API_KEY` or both
+  `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`. When the file includes
   `GOOGLE_CLOUD_LOCATION`, `GOOGLE_CLOUD_REGION`, `CLOUD_ML_REGION`,
   `VERTEX_LOCATION`, or `VERTEX_AI_LOCATION`, Workcell also derives the
   corresponding regional `LOCATION-aiplatform.googleapis.com` allowlist entry
@@ -148,9 +152,12 @@ modes = ["strict", "build"]
   you already have one on the host.
 - `credentials.gemini_projects` mounts a persisted Gemini `projects.json`
   when you want Gemini CLI's project registry to survive across sessions.
+  Workcell validates that the file is a JSON object with an object-valued
+  `projects` field before launch.
 - `credentials.gcloud_adc` mounts Google ADC into
-  `~/.config/gcloud/application_default_credentials.json` for Gemini Vertex
-  flows.
+  `~/.config/gcloud/application_default_credentials.json` as a supplemental
+  input for Gemini Vertex flows that are explicitly configured through
+  `credentials.gemini_env`. It is not a standalone Gemini auth mode.
 - `credentials.github_hosts` and `credentials.github_config` mount GitHub CLI
   auth/config into `~/.config/gh/`. Because those credentials are shared across
   tools rather than provider-native, prefer `[credentials.github_hosts]` or

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -29,24 +29,37 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
   && printf 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/%s trixie main\n' "${DEBIAN_SNAPSHOT}" > /etc/apt/sources.list \
   && printf 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/%s trixie-updates main\n' "${DEBIAN_SNAPSHOT}" >> /etc/apt/sources.list \
   && printf 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/%s trixie-security main\n' "${DEBIAN_SNAPSHOT}" >> /etc/apt/sources.list \
-  && printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99workcell-snapshot \
-  && DEBIAN_FRONTEND=noninteractive apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-  bash \
-  ca-certificates \
-  curl \
-  fd-find \
-  git \
-  jq \
-  less \
-  openssh-client \
-  passwd \
-  procps \
-  ripgrep \
-  sudo \
-  unzip \
-  util-linux \
-  xz-utils \
+  && printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "5";\nAcquire::http::Timeout "30";\n' > /etc/apt/apt.conf.d/99workcell-snapshot \
+  && install_runtime_packages() { \
+       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       bash \
+       ca-certificates \
+       curl \
+       fd-find \
+       git \
+       jq \
+       less \
+       openssh-client \
+       passwd \
+       procps \
+       ripgrep \
+       sudo \
+       unzip \
+       util-linux \
+       xz-utils \
+       && return 0; \
+     } \
+  && for attempt in 1 2 3; do \
+       rm -rf /var/lib/apt/lists/*; \
+       if DEBIAN_FRONTEND=noninteractive apt-get update \
+         && install_runtime_packages; then \
+         break; \
+       fi; \
+       if [[ "${attempt}" -eq 3 ]]; then \
+         exit 1; \
+       fi; \
+       sleep "$((attempt * 5))"; \
+     done \
   && ln -sf /usr/bin/fdfind /usr/local/bin/fd \
   && mkdir -p \
     /etc/workcell/empty-xdg \
@@ -103,8 +116,23 @@ ARG TARGETARCH
 ARG BUILDKIT_MULTI_PLATFORM=1
 ARG SOURCE_DATE_EPOCH
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cargo rustc \
+RUN install_runtime_builder_packages() { \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      cargo \
+      rustc \
+      && return 0; \
+    } \
+  && for attempt in 1 2 3; do \
+       rm -rf /var/lib/apt/lists/*; \
+       if DEBIAN_FRONTEND=noninteractive apt-get update \
+         && install_runtime_builder_packages; then \
+         break; \
+       fi; \
+       if [[ "${attempt}" -eq 3 ]]; then \
+         exit 1; \
+       fi; \
+       sleep "$((attempt * 5))"; \
+     done \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /var/cache/debconf/*-old /var/cache/ldconfig/aux-cache \
   && rm -f /etc/ld.so.cache
 

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -282,6 +282,397 @@ workcell_copy_manifest_credential_file() {
   return 0
 }
 
+workcell_trim_leading_whitespace() {
+  local value="$1"
+
+  printf '%s' "${value#"${value%%[![:space:]]*}"}"
+}
+
+workcell_trim_trailing_whitespace() {
+  local value="$1"
+
+  printf '%s' "${value%"${value##*[![:space:]]}"}"
+}
+
+workcell_env_file_assignment_value() {
+  local env_path="$1"
+  local expected_key="$2"
+  local line=""
+  local parsed_key=""
+  local value=""
+
+  [[ -f "${env_path}" ]] || return 1
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line="${line%$'\r'}"
+    line="$(workcell_trim_leading_whitespace "${line}")"
+    [[ -n "${line}" ]] || continue
+    [[ "${line}" == \#* ]] && continue
+
+    if [[ "${line}" == export[[:space:]]* ]]; then
+      line="${line#export}"
+      line="$(workcell_trim_leading_whitespace "${line}")"
+    fi
+
+    if [[ "${line}" =~ ^([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*(.*)$ ]]; then
+      parsed_key="${BASH_REMATCH[1]}"
+      value="${BASH_REMATCH[2]}"
+      [[ "${parsed_key}" == "${expected_key}" ]] || continue
+
+      value="$(workcell_trim_trailing_whitespace "$(workcell_trim_leading_whitespace "${value}")")"
+
+      if [[ "${value}" =~ ^\"(.*)\"[[:space:]]*(#.*)?$ ]]; then
+        value="${BASH_REMATCH[1]}"
+      elif [[ "${value}" =~ ^\'(.*)\'[[:space:]]*(#.*)?$ ]]; then
+        value="${BASH_REMATCH[1]}"
+      else
+        value="${value%%#*}"
+        value="$(workcell_trim_trailing_whitespace "$(workcell_trim_leading_whitespace "${value}")")"
+      fi
+
+      printf '%s\n' "${value}"
+      return 0
+    fi
+  done <"${env_path}"
+
+  return 1
+}
+
+workcell_env_file_has_assignment_key() {
+  local env_path="$1"
+  local expected_key="$2"
+  local line=""
+  local parsed_key=""
+
+  [[ -f "${env_path}" ]] || return 1
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line="${line%$'\r'}"
+    line="$(workcell_trim_leading_whitespace "${line}")"
+    [[ -n "${line}" ]] || continue
+    [[ "${line}" == \#* ]] && continue
+
+    if [[ "${line}" == export[[:space:]]* ]]; then
+      line="${line#export}"
+      line="$(workcell_trim_leading_whitespace "${line}")"
+    fi
+
+    if [[ "${line}" =~ ^([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*= ]]; then
+      parsed_key="${BASH_REMATCH[1]}"
+      [[ "${parsed_key}" == "${expected_key}" ]] || continue
+      return 0
+    fi
+  done <"${env_path}"
+
+  return 1
+}
+
+workcell_env_file_boolean_value() {
+  local env_path="$1"
+  local expected_key="$2"
+  local value=""
+
+  value="$(workcell_env_file_assignment_value "${env_path}" "${expected_key}" || true)"
+  [[ -n "${value}" ]] || return 1
+  value="$(printf '%s' "${value}" | tr '[:upper:]' '[:lower:]')"
+
+  case "${value}" in
+    true | false)
+      printf '%s\n' "${value}"
+      return 0
+      ;;
+    *)
+      workcell_die "Invalid boolean in Gemini auth env file ${env_path}: ${expected_key}=${value}. Use true or false."
+      ;;
+  esac
+}
+
+workcell_gemini_env_has_project_config() {
+  local env_path="$1"
+  local env_value=""
+
+  env_value="$(workcell_env_file_assignment_value "${env_path}" "GOOGLE_CLOUD_PROJECT" || true)"
+  [[ -n "${env_value}" ]] && return 0
+  env_value="$(workcell_env_file_assignment_value "${env_path}" "GOOGLE_CLOUD_PROJECT_ID" || true)"
+  [[ -n "${env_value}" ]]
+}
+
+workcell_gemini_env_has_location_config() {
+  local env_path="$1"
+  local env_value=""
+
+  env_value="$(workcell_env_file_assignment_value "${env_path}" "GOOGLE_CLOUD_LOCATION" || true)"
+  [[ -n "${env_value}" ]] && return 0
+  env_value="$(workcell_env_file_assignment_value "${env_path}" "GOOGLE_CLOUD_REGION" || true)"
+  [[ -n "${env_value}" ]] && return 0
+  env_value="$(workcell_env_file_assignment_value "${env_path}" "CLOUD_ML_REGION" || true)"
+  [[ -n "${env_value}" ]] && return 0
+  env_value="$(workcell_env_file_assignment_value "${env_path}" "VERTEX_LOCATION" || true)"
+  [[ -n "${env_value}" ]] && return 0
+  env_value="$(workcell_env_file_assignment_value "${env_path}" "VERTEX_AI_LOCATION" || true)"
+  [[ -n "${env_value}" ]]
+}
+
+workcell_gemini_env_key_is_supported() {
+  case "$1" in
+    GEMINI_API_KEY | GOOGLE_API_KEY | GOOGLE_GENAI_USE_GCA | GOOGLE_GENAI_USE_VERTEXAI | GOOGLE_CLOUD_PROJECT | GOOGLE_CLOUD_PROJECT_ID | GOOGLE_CLOUD_LOCATION | GOOGLE_CLOUD_REGION | CLOUD_ML_REGION | VERTEX_LOCATION | VERTEX_AI_LOCATION)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+workcell_validate_gemini_env_file_syntax() {
+  local env_path="$1"
+  local line=""
+  local parsed_key=""
+  local value=""
+  local -A seen_keys=()
+
+  [[ -f "${env_path}" ]] || return 0
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line="${line%$'\r'}"
+    line="$(workcell_trim_leading_whitespace "${line}")"
+    [[ -n "${line}" ]] || continue
+    [[ "${line}" == \#* ]] && continue
+
+    if [[ "${line}" == export[[:space:]]* ]]; then
+      line="${line#export}"
+      line="$(workcell_trim_leading_whitespace "${line}")"
+    fi
+
+    if ! [[ "${line}" =~ ^([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*(.*)$ ]]; then
+      workcell_die "Malformed Gemini auth env file ${env_path}: ${line}. Use KEY=value assignments."
+    fi
+
+    parsed_key="${BASH_REMATCH[1]}"
+    value="${BASH_REMATCH[2]}"
+    if [[ -n "${seen_keys[${parsed_key}]:-}" ]]; then
+      workcell_die "Gemini auth env file ${env_path} configures ${parsed_key} more than once."
+    fi
+    seen_keys["${parsed_key}"]=1
+
+    if ! workcell_gemini_env_key_is_supported "${parsed_key}"; then
+      workcell_die "Unsupported key in Gemini auth env file ${env_path}: ${parsed_key}."
+    fi
+
+    value="$(workcell_trim_trailing_whitespace "$(workcell_trim_leading_whitespace "${value}")")"
+    if [[ "${value}" =~ ^\"(.*)\"[[:space:]]*(#.*)?$ ]]; then
+      value="${BASH_REMATCH[1]}"
+    elif [[ "${value}" =~ ^\'(.*)\'[[:space:]]*(#.*)?$ ]]; then
+      value="${BASH_REMATCH[1]}"
+    else
+      value="${value%%#*}"
+      value="$(workcell_trim_trailing_whitespace "$(workcell_trim_leading_whitespace "${value}")")"
+    fi
+
+    case "${parsed_key}" in
+      GEMINI_API_KEY | GOOGLE_API_KEY | GOOGLE_CLOUD_PROJECT | GOOGLE_CLOUD_PROJECT_ID | GOOGLE_CLOUD_LOCATION | GOOGLE_CLOUD_REGION | CLOUD_ML_REGION | VERTEX_LOCATION | VERTEX_AI_LOCATION)
+        if [[ -z "${value}" ]]; then
+          workcell_die "Gemini auth env file ${env_path} sets ${parsed_key} but leaves it empty."
+        fi
+        ;;
+    esac
+  done <"${env_path}"
+}
+
+workcell_validate_gemini_env_auth_config() {
+  local env_path="$1"
+  local gca_value=""
+  local vertex_value=""
+  local gemini_api_key=""
+  local google_api_key=""
+  local has_project=0
+  local has_location=0
+
+  [[ -f "${env_path}" ]] || return 0
+
+  workcell_validate_gemini_env_file_syntax "${env_path}"
+  gca_value="$(workcell_env_file_boolean_value "${env_path}" "GOOGLE_GENAI_USE_GCA" || true)"
+  vertex_value="$(workcell_env_file_boolean_value "${env_path}" "GOOGLE_GENAI_USE_VERTEXAI" || true)"
+  gemini_api_key="$(workcell_env_file_assignment_value "${env_path}" "GEMINI_API_KEY" || true)"
+  google_api_key="$(workcell_env_file_assignment_value "${env_path}" "GOOGLE_API_KEY" || true)"
+
+  if [[ "${gca_value}" == "true" ]] && [[ "${vertex_value}" == "true" ]]; then
+    workcell_die "Gemini auth env file ${env_path} enables both GOOGLE_GENAI_USE_GCA and GOOGLE_GENAI_USE_VERTEXAI. Choose exactly one auth selector."
+  fi
+
+  if workcell_gemini_env_has_project_config "${env_path}"; then
+    has_project=1
+  fi
+  if workcell_gemini_env_has_location_config "${env_path}"; then
+    has_location=1
+  fi
+
+  if [[ "${has_location}" == "1" ]] && [[ "${has_project}" != "1" ]]; then
+    workcell_die "Gemini auth env file ${env_path} sets a Google Cloud location without a project."
+  fi
+
+  if [[ "${vertex_value}" == "true" ]]; then
+    if [[ -n "${google_api_key}" ]] || { [[ "${has_project}" == "1" ]] && [[ "${has_location}" == "1" ]]; }; then
+      return 0
+    fi
+    workcell_die "Gemini auth env file ${env_path} enables GOOGLE_GENAI_USE_VERTEXAI=true without either GOOGLE_API_KEY or both GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION."
+  fi
+
+  if [[ -n "${google_api_key}" ]]; then
+    workcell_die "Gemini auth env file ${env_path} sets GOOGLE_API_KEY without GOOGLE_GENAI_USE_VERTEXAI=true."
+  fi
+
+  if [[ "${gca_value}" == "true" ]] || [[ -n "${gemini_api_key}" ]]; then
+    return 0
+  fi
+
+  workcell_die "Gemini auth env file ${env_path} does not configure a supported Gemini auth mode. Use GEMINI_API_KEY, GOOGLE_GENAI_USE_GCA=true, or GOOGLE_GENAI_USE_VERTEXAI=true with GOOGLE_API_KEY or both GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION."
+}
+
+workcell_validate_json_object_file() {
+  local json_path="$1"
+  local label="$2"
+
+  [[ -f "${json_path}" ]] || return 0
+
+  if ! jq -e 'type == "object"' "${json_path}" >/dev/null 2>&1; then
+    workcell_die "${label} must contain a JSON object: ${json_path}"
+  fi
+}
+
+workcell_validate_gemini_oauth_config() {
+  local oauth_path="$1"
+
+  workcell_validate_json_object_file "${oauth_path}" "Gemini OAuth config"
+}
+
+workcell_validate_gcloud_adc_config() {
+  local adc_path="$1"
+
+  [[ -f "${adc_path}" ]] || return 0
+
+  if ! jq -e 'type == "object" and (.type | type == "string") and (.type | length > 0)' "${adc_path}" >/dev/null 2>&1; then
+    workcell_die "Google ADC config must contain a JSON object with a non-empty string type: ${adc_path}"
+  fi
+}
+
+workcell_validate_gemini_projects_config() {
+  local projects_path="$1"
+
+  [[ -f "${projects_path}" ]] || return 0
+
+  if ! jq -e 'type == "object" and (.projects | type == "object")' "${projects_path}" >/dev/null 2>&1; then
+    workcell_die "Gemini projects config must contain a JSON object with an object-valued projects field: ${projects_path}"
+  fi
+}
+
+workcell_render_gemini_trusted_folders() {
+  local target_path="$1"
+  local workspace_root="$2"
+  local target_dir=""
+  local target_name=""
+  local rendered_path=""
+
+  target_dir="$(dirname "${target_path}")"
+  target_name="$(basename "${target_path}")"
+  rendered_path="$(mktemp "${target_dir}/${target_name}.tmp.XXXXXX")"
+
+  jq -n --arg workspace_root "${workspace_root}" \
+    '{($workspace_root): "TRUST_FOLDER"}' >"${rendered_path}" || {
+    rm -f "${rendered_path}"
+    return 1
+  }
+  mv "${rendered_path}" "${target_path}"
+
+  return 0
+}
+
+workcell_env_file_value_is_true() {
+  local env_path="$1"
+  local expected_key="$2"
+  local value=""
+
+  value="$(workcell_env_file_boolean_value "${env_path}" "${expected_key}" || true)"
+  [[ "${value}" == "true" ]]
+}
+
+workcell_gemini_selected_auth_type_from_env_file() {
+  local env_path="$1"
+  local env_value=""
+
+  [[ -f "${env_path}" ]] || return 1
+
+  if workcell_env_file_value_is_true "${env_path}" "GOOGLE_GENAI_USE_GCA"; then
+    printf 'oauth-personal\n'
+    return 0
+  fi
+  if workcell_env_file_value_is_true "${env_path}" "GOOGLE_GENAI_USE_VERTEXAI"; then
+    printf 'vertex-ai\n'
+    return 0
+  fi
+  env_value="$(workcell_env_file_assignment_value "${env_path}" "GEMINI_API_KEY" || true)"
+  if [[ -n "${env_value}" ]]; then
+    printf 'gemini-api-key\n'
+    return 0
+  fi
+
+  return 1
+}
+
+workcell_gemini_selected_auth_type() {
+  local env_path="$1"
+  local oauth_path="$2"
+  local selected_auth_type=""
+
+  selected_auth_type="$(workcell_gemini_selected_auth_type_from_env_file "${env_path}" || true)"
+  if [[ -z "${selected_auth_type}" ]] && [[ -f "${oauth_path}" ]]; then
+    selected_auth_type="oauth-personal"
+  fi
+  [[ -n "${selected_auth_type}" ]] || return 1
+  printf '%s\n' "${selected_auth_type}"
+}
+
+workcell_set_gemini_selected_auth_type() {
+  local settings_path="$1"
+  local selected_auth_type="$2"
+  local settings_dir=""
+  local settings_name=""
+  local rendered_path=""
+
+  [[ -n "${selected_auth_type}" ]] || return 0
+  settings_dir="$(dirname "${settings_path}")"
+  settings_name="$(basename "${settings_path}")"
+  rendered_path="$(mktemp "${settings_dir}/${settings_name}.tmp.XXXXXX")"
+  jq --arg selected_auth_type "${selected_auth_type}" \
+    '.security.auth.selectedType = $selected_auth_type' \
+    "${settings_path}" >"${rendered_path}" || {
+    rm -f "${rendered_path}"
+    return 1
+  }
+  mv "${rendered_path}" "${settings_path}"
+  chmod 0600 "${settings_path}"
+}
+
+workcell_set_gemini_folder_trust_enabled() {
+  local settings_path="$1"
+  local enabled="$2"
+  local settings_dir=""
+  local settings_name=""
+  local rendered_path=""
+
+  settings_dir="$(dirname "${settings_path}")"
+  settings_name="$(basename "${settings_path}")"
+  rendered_path="$(mktemp "${settings_dir}/${settings_name}.tmp.XXXXXX")"
+  jq --argjson enabled "${enabled}" \
+    '.security.folderTrust.enabled = $enabled' \
+    "${settings_path}" >"${rendered_path}" || {
+    rm -f "${rendered_path}"
+    return 1
+  }
+  mv "${rendered_path}" "${settings_path}"
+  chmod 0600 "${settings_path}"
+}
+
 workcell_workspace_import_path() {
   local relative_path="$1"
   local import_path="${WORKCELL_WORKSPACE_IMPORT_ROOT}/${relative_path}"
@@ -350,6 +741,7 @@ workcell_target_is_allowed() {
       /state/agent-home/.gemini/.env | \
       /state/agent-home/.gemini/oauth_creds.json | \
       /state/agent-home/.gemini/projects.json | \
+      /state/agent-home/.gemini/trustedFolders.json | \
       /state/agent-home/.config/gcloud/application_default_credentials.json | \
       /state/agent-home/.config/gh/config.yml | \
       /state/agent-home/.config/gh/hosts.yml | \
@@ -578,20 +970,41 @@ seed_claude_home() {
 }
 
 seed_gemini_home() {
+  local workspace_root="${WORKSPACE:-/workspace}"
+  local selected_auth_type=""
+
   workcell_prepare_session_directory "${HOME}/.gemini" "Gemini home"
   rm -f "${HOME}/.gemini/settings.json"
   cp "${ADAPTER_ROOT}/gemini/.gemini/settings.json" "${HOME}/.gemini/settings.json"
   chmod 0600 "${HOME}/.gemini/settings.json"
+  if [[ "${WORKCELL_MODE:-strict}" == "breakglass" ]]; then
+    workcell_set_gemini_folder_trust_enabled "${HOME}/.gemini/settings.json" true
+    workcell_reset_session_target "${HOME}/.gemini/trustedFolders.json" "Gemini trusted folders"
+    rm -f "${HOME}/.gemini/trustedFolders.json"
+  else
+    workcell_set_gemini_folder_trust_enabled "${HOME}/.gemini/settings.json" false
+    workcell_reset_session_target "${HOME}/.gemini/trustedFolders.json" "Gemini trusted folders"
+    workcell_render_gemini_trusted_folders "${HOME}/.gemini/trustedFolders.json" "${workspace_root}"
+    chmod 0600 "${HOME}/.gemini/trustedFolders.json"
+  fi
   workcell_render_provider_doc "${ADAPTER_ROOT}/gemini/GEMINI.md" "${HOME}/.gemini/GEMINI.md" gemini
   workcell_copy_manifest_credential_file gemini_env "${HOME}/.gemini/.env" || true
+  workcell_validate_gemini_env_auth_config "${HOME}/.gemini/.env"
   workcell_copy_manifest_credential_file gemini_oauth "${HOME}/.gemini/oauth_creds.json" || true
+  workcell_validate_gemini_oauth_config "${HOME}/.gemini/oauth_creds.json"
   workcell_prepare_session_directory "${HOME}/.config/gcloud" "Google ADC directory"
   workcell_copy_manifest_credential_file gcloud_adc "${HOME}/.config/gcloud/application_default_credentials.json" || true
+  workcell_validate_gcloud_adc_config "${HOME}/.config/gcloud/application_default_credentials.json"
+  selected_auth_type="$(workcell_gemini_selected_auth_type \
+    "${HOME}/.gemini/.env" \
+    "${HOME}/.gemini/oauth_creds.json" || true)"
+  workcell_set_gemini_selected_auth_type "${HOME}/.gemini/settings.json" "${selected_auth_type}"
   if ! workcell_copy_manifest_credential_file gemini_projects "${HOME}/.gemini/projects.json"; then
     workcell_reset_session_target "${HOME}/.gemini/projects.json" "Gemini projects"
     printf '{\n  "projects": {}\n}\n' >"${HOME}/.gemini/projects.json"
     chmod 0600 "${HOME}/.gemini/projects.json"
   fi
+  workcell_validate_gemini_projects_config "${HOME}/.gemini/projects.json"
 }
 
 workcell_seed_shared_credentials() {

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -191,7 +191,8 @@ case "${AGENT_NAME}" in
     ;;
   gemini)
     reject_unsafe_gemini_args "$@"
-    exec /usr/local/libexec/workcell/real/node \
+    # Gemini CLI self-relaunch conflicts with Workcell's protected exec boundary.
+    GEMINI_CLI_NO_RELAUNCH=1 exec /usr/local/libexec/workcell/real/node \
       /opt/workcell/providers/node_modules/@google/gemini-cli/dist/index.js \
       "${MANAGED_AUTONOMY_ARGS[@]}" \
       "$@"

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1103,7 +1103,7 @@ run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini" bas
       grep -q "GEMINI_API_KEY=smoke-gemini-key" "$HOME/.gemini/.env"
       jq -r ".security.auth.selectedType" "$HOME/.gemini/settings.json" | grep -q "^gemini-api-key$"
       jq -r ".security.folderTrust.enabled" "$HOME/.gemini/settings.json" | grep -q "^false$"
-      jq -e --arg workspace "/workspace" ". == {(\\$workspace): \"TRUST_FOLDER\"}" "$HOME/.gemini/trustedFolders.json" >/dev/null
+      jq -e --arg workspace "/workspace" ". == {(\$workspace): \"TRUST_FOLDER\"}" "$HOME/.gemini/trustedFolders.json" >/dev/null
       grep -q "\"smoke\"" "$HOME/.gemini/projects.json"
       grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
       mkdir -p /workspace/exfil

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1103,7 +1103,7 @@ run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini" bas
       grep -q "GEMINI_API_KEY=smoke-gemini-key" "$HOME/.gemini/.env"
       jq -r ".security.auth.selectedType" "$HOME/.gemini/settings.json" | grep -q "^gemini-api-key$"
       jq -r ".security.folderTrust.enabled" "$HOME/.gemini/settings.json" | grep -q "^false$"
-      jq -e --arg workspace "/workspace" '"'"'. == {($workspace): "TRUST_FOLDER"}'"'"' "$HOME/.gemini/trustedFolders.json" >/dev/null
+      jq -e --arg workspace "/workspace" ". == {(\\$workspace): \"TRUST_FOLDER\"}" "$HOME/.gemini/trustedFolders.json" >/dev/null
       grep -q "\"smoke\"" "$HOME/.gemini/projects.json"
       grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
       mkdir -p /workspace/exfil

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -988,6 +988,26 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ -x /bin/echo ]]; then
     exit 1
   fi
 
+  cat <<'EOF' >"${ROOT_DIR}/tmp/workcell-gemini-node-env.sh"
+#!/bin/sh
+printf 'GEMINI_CLI_NO_RELAUNCH=%s\n' "${GEMINI_CLI_NO_RELAUNCH-}"
+printf '%s\n' "$*"
+EOF
+  align_path_for_mapped_runtime_user "${ROOT_DIR}/tmp/workcell-gemini-node-env.sh" 0755 0755
+
+  GEMINI_NO_RELAUNCH_ENV="$(
+    run_entrypoint_with_autonomy_and_bind \
+      gemini \
+      yolo \
+      "${ROOT_DIR}/tmp/workcell-gemini-node-env.sh" \
+      /usr/local/libexec/workcell/real/node \
+      gemini --version
+  )"
+  if [[ "${GEMINI_NO_RELAUNCH_ENV}" != $'GEMINI_CLI_NO_RELAUNCH=1\n/opt/workcell/providers/node_modules/@google/gemini-cli/dist/index.js --approval-mode yolo --version' ]]; then
+    echo "unexpected Gemini relaunch env/argv: ${GEMINI_NO_RELAUNCH_ENV}" >&2
+    exit 1
+  fi
+
   GEMINI_PROMPT_ARGS="$(
     run_entrypoint_with_autonomy_and_bind \
       gemini \

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -209,6 +209,29 @@ prepare_direct_mount_spec_for_bundle() {
   align_path_for_mapped_runtime_user "${mount_spec_path}" 0644 0755
 }
 
+clone_bundle_with_credential_override() {
+  local source_bundle="$1"
+  local bundle_root="$2"
+  local credential_key="$3"
+  local override_source="$4"
+
+  rm -rf "${bundle_root}"
+  cp -R "${source_bundle}" "${bundle_root}"
+  python3 - "${bundle_root}/manifest.json" "${credential_key}" "${override_source}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+credential_key = sys.argv[2]
+override_source = sys.argv[3]
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+manifest["credentials"][credential_key]["source"] = override_source
+manifest_path.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+  prepare_direct_mount_spec_for_bundle "${bundle_root}"
+}
+
 direct_mount_specs_for_bundle() {
   local bundle_root="$1"
   local mount_spec_path="${bundle_root}.mounts.json"
@@ -707,8 +730,48 @@ EOF
 cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gemini.env"
 GEMINI_API_KEY=smoke-gemini-key
 EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gemini-invalid-bool.env"
+GOOGLE_GENAI_USE_GCA=maybe
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gemini-conflicting.env"
+GOOGLE_GENAI_USE_GCA=true
+GOOGLE_GENAI_USE_VERTEXAI=true
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gemini-partial-vertex.env"
+GOOGLE_CLOUD_PROJECT=smoke-project
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gemini-google-api-key-only.env"
+GOOGLE_API_KEY=smoke-google-key
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gemini-malformed.env"
+GOOGLE_GENAI_USE_VERTEXAI true
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gemini-vertex.env"
+GOOGLE_GENAI_USE_VERTEXAI=true
+GOOGLE_CLOUD_PROJECT=smoke-project
+GOOGLE_CLOUD_LOCATION=us-central1
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gemini-vertex-express.env"
+GOOGLE_GENAI_USE_VERTEXAI=true
+GOOGLE_API_KEY=smoke-google-key
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gcloud-adc.json"
+{"type":"authorized_user","client_id":"smoke-client","client_secret":"smoke-secret","refresh_token":"smoke-refresh"}
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gcloud-adc-invalid.json"
+{}
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gemini-oauth.json"
+{"token":"smoke-gemini-oauth"}
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gemini-invalid-oauth.json"
+[]
+EOF
 cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gemini-projects.json"
 {"projects":{"smoke":{"path":"/workspace"}}}
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/gemini-projects-invalid.json"
+{"projects":[]}
 EOF
 cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/ssh-config"
 Host smoke
@@ -762,6 +825,65 @@ target = "~/.config/workcell/token.txt"
 classification = "secret"
 providers = ["codex"]
 EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/policy-gemini-invalid-bool.toml"
+version = 1
+
+[credentials]
+gemini_env = "gemini-invalid-bool.env"
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/policy-gemini-conflicting.toml"
+version = 1
+
+[credentials]
+gemini_env = "gemini-conflicting.env"
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/policy-gemini-partial-vertex.toml"
+version = 1
+
+[credentials]
+gemini_env = "gemini-partial-vertex.env"
+gcloud_adc = "gcloud-adc.json"
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/policy-gemini-google-api-key-only-oauth.toml"
+version = 1
+
+[credentials]
+gemini_env = "gemini-google-api-key-only.env"
+gemini_oauth = "gemini-oauth.json"
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/policy-gemini-project-only-oauth.toml"
+version = 1
+
+[credentials]
+gemini_env = "gemini-partial-vertex.env"
+gemini_oauth = "gemini-oauth.json"
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/policy-gemini-malformed.toml"
+version = 1
+
+[credentials]
+gemini_env = "gemini-malformed.env"
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/policy-gemini-gcloud-adc.toml"
+version = 1
+
+[credentials]
+gemini_env = "gemini-vertex.env"
+gcloud_adc = "gcloud-adc.json"
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/policy-gemini-vertex-express.toml"
+version = 1
+
+[credentials]
+gemini_env = "gemini-vertex-express.env"
+EOF
+cat <<'EOF' >"${INJECTION_FIXTURE_ROOT}/policy-gemini-env-plus-oauth.toml"
+version = 1
+
+[credentials]
+gemini_env = "gemini-vertex-express.env"
+gemini_oauth = "gemini-oauth.json"
+EOF
 
 align_path_for_mapped_runtime_user "${INJECTION_FIXTURE_ROOT}" 0644 0755
 chmod 0600 \
@@ -772,7 +894,19 @@ chmod 0600 \
   "${INJECTION_FIXTURE_ROOT}/gh-hosts.yml" \
   "${INJECTION_FIXTURE_ROOT}/claude-api-key.txt" \
   "${INJECTION_FIXTURE_ROOT}/gemini.env" \
+  "${INJECTION_FIXTURE_ROOT}/gemini-invalid-bool.env" \
+  "${INJECTION_FIXTURE_ROOT}/gemini-conflicting.env" \
+  "${INJECTION_FIXTURE_ROOT}/gemini-partial-vertex.env" \
+  "${INJECTION_FIXTURE_ROOT}/gemini-google-api-key-only.env" \
+  "${INJECTION_FIXTURE_ROOT}/gemini-malformed.env" \
+  "${INJECTION_FIXTURE_ROOT}/gemini-vertex.env" \
+  "${INJECTION_FIXTURE_ROOT}/gemini-vertex-express.env" \
+  "${INJECTION_FIXTURE_ROOT}/gcloud-adc.json" \
+  "${INJECTION_FIXTURE_ROOT}/gcloud-adc-invalid.json" \
+  "${INJECTION_FIXTURE_ROOT}/gemini-oauth.json" \
+  "${INJECTION_FIXTURE_ROOT}/gemini-invalid-oauth.json" \
   "${INJECTION_FIXTURE_ROOT}/gemini-projects.json" \
+  "${INJECTION_FIXTURE_ROOT}/gemini-projects-invalid.json" \
   "${INJECTION_FIXTURE_ROOT}/ssh-config" \
   "${INJECTION_FIXTURE_ROOT}/id_smoke"
 
@@ -796,6 +930,73 @@ run_as_mapped_host_user python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle
   --mode strict \
   --output-root "${INJECTION_BUNDLE_ROOT}/gemini" >/dev/null
 prepare_direct_mount_spec_for_bundle "${INJECTION_BUNDLE_ROOT}/gemini"
+
+run_as_mapped_host_user python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
+  --policy "${INJECTION_FIXTURE_ROOT}/policy-gemini-gcloud-adc.toml" \
+  --agent gemini \
+  --mode strict \
+  --output-root "${INJECTION_BUNDLE_ROOT}/gemini-gcloud-adc" >/dev/null
+prepare_direct_mount_spec_for_bundle "${INJECTION_BUNDLE_ROOT}/gemini-gcloud-adc"
+
+run_as_mapped_host_user python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
+  --policy "${INJECTION_FIXTURE_ROOT}/policy-gemini-vertex-express.toml" \
+  --agent gemini \
+  --mode strict \
+  --output-root "${INJECTION_BUNDLE_ROOT}/gemini-vertex-express" >/dev/null
+prepare_direct_mount_spec_for_bundle "${INJECTION_BUNDLE_ROOT}/gemini-vertex-express"
+
+run_as_mapped_host_user python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
+  --policy "${INJECTION_FIXTURE_ROOT}/policy-gemini-env-plus-oauth.toml" \
+  --agent gemini \
+  --mode strict \
+  --output-root "${INJECTION_BUNDLE_ROOT}/gemini-env-plus-oauth" >/dev/null
+prepare_direct_mount_spec_for_bundle "${INJECTION_BUNDLE_ROOT}/gemini-env-plus-oauth"
+
+clone_bundle_with_credential_override \
+  "${INJECTION_BUNDLE_ROOT}/gemini-vertex-express" \
+  "${INJECTION_BUNDLE_ROOT}/gemini-invalid-bool" \
+  gemini_env \
+  "${INJECTION_FIXTURE_ROOT}/gemini-invalid-bool.env"
+clone_bundle_with_credential_override \
+  "${INJECTION_BUNDLE_ROOT}/gemini-vertex-express" \
+  "${INJECTION_BUNDLE_ROOT}/gemini-conflicting" \
+  gemini_env \
+  "${INJECTION_FIXTURE_ROOT}/gemini-conflicting.env"
+clone_bundle_with_credential_override \
+  "${INJECTION_BUNDLE_ROOT}/gemini-gcloud-adc" \
+  "${INJECTION_BUNDLE_ROOT}/gemini-partial-vertex" \
+  gemini_env \
+  "${INJECTION_FIXTURE_ROOT}/gemini-partial-vertex.env"
+clone_bundle_with_credential_override \
+  "${INJECTION_BUNDLE_ROOT}/gemini-env-plus-oauth" \
+  "${INJECTION_BUNDLE_ROOT}/gemini-google-api-key-only-oauth" \
+  gemini_env \
+  "${INJECTION_FIXTURE_ROOT}/gemini-google-api-key-only.env"
+clone_bundle_with_credential_override \
+  "${INJECTION_BUNDLE_ROOT}/gemini-env-plus-oauth" \
+  "${INJECTION_BUNDLE_ROOT}/gemini-project-only-oauth" \
+  gemini_env \
+  "${INJECTION_FIXTURE_ROOT}/gemini-partial-vertex.env"
+clone_bundle_with_credential_override \
+  "${INJECTION_BUNDLE_ROOT}/gemini-vertex-express" \
+  "${INJECTION_BUNDLE_ROOT}/gemini-malformed" \
+  gemini_env \
+  "${INJECTION_FIXTURE_ROOT}/gemini-malformed.env"
+clone_bundle_with_credential_override \
+  "${INJECTION_BUNDLE_ROOT}/gemini-env-plus-oauth" \
+  "${INJECTION_BUNDLE_ROOT}/gemini-invalid-oauth" \
+  gemini_oauth \
+  "${INJECTION_FIXTURE_ROOT}/gemini-invalid-oauth.json"
+clone_bundle_with_credential_override \
+  "${INJECTION_BUNDLE_ROOT}/gemini-gcloud-adc" \
+  "${INJECTION_BUNDLE_ROOT}/gemini-invalid-adc" \
+  gcloud_adc \
+  "${INJECTION_FIXTURE_ROOT}/gcloud-adc-invalid.json"
+clone_bundle_with_credential_override \
+  "${INJECTION_BUNDLE_ROOT}/gemini" \
+  "${INJECTION_BUNDLE_ROOT}/gemini-invalid-projects" \
+  gemini_projects \
+  "${INJECTION_FIXTURE_ROOT}/gemini-projects-invalid.json"
 
 run_entrypoint codex codex --version >/dev/null
 run_entrypoint_with_profile codex build codex --version >/dev/null
@@ -885,8 +1086,132 @@ run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini" bas
       grep -q "Workspace AGENTS Instructions" "$HOME/.gemini/GEMINI.md"
       grep -q "Workspace Gemini Instructions" "$HOME/.gemini/GEMINI.md"
       grep -q "GEMINI_API_KEY=smoke-gemini-key" "$HOME/.gemini/.env"
-    grep -q "\"smoke\"" "$HOME/.gemini/projects.json"
-    grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
+      jq -r ".security.auth.selectedType" "$HOME/.gemini/settings.json" | grep -q "^gemini-api-key$"
+      jq -r ".security.folderTrust.enabled" "$HOME/.gemini/settings.json" | grep -q "^false$"
+      jq -e --arg workspace "/workspace" '"'"'. == {($workspace): "TRUST_FOLDER"}'"'"' "$HOME/.gemini/trustedFolders.json" >/dev/null
+      grep -q "\"smoke\"" "$HOME/.gemini/projects.json"
+      grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
+      mkdir -p /workspace/exfil
+      rm -f "$HOME/.gemini/settings.json.tmp" "$HOME/.gemini/trustedFolders.json.tmp"
+      ln -s /workspace/exfil/settings-clobber "$HOME/.gemini/settings.json.tmp"
+      ln -s /workspace/exfil/trusted-clobber "$HOME/.gemini/trustedFolders.json.tmp"
+      gemini --version >/dev/null 2>&1
+      test ! -e /workspace/exfil/settings-clobber
+      test ! -e /workspace/exfil/trusted-clobber
+  '"'"'
+'
+
+# shellcheck disable=SC2016
+run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini-invalid-bool" bash -lc '
+  set -euo pipefail
+  if /usr/local/bin/workcell-entrypoint gemini --version >/tmp/gemini-invalid-bool.out 2>&1; then
+    echo "expected Gemini invalid boolean env config to fail fast" >&2
+    exit 1
+  fi
+  grep -q "Invalid boolean in Gemini auth env file" /tmp/gemini-invalid-bool.out
+'
+
+# shellcheck disable=SC2016
+run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini-conflicting" bash -lc '
+  set -euo pipefail
+  if /usr/local/bin/workcell-entrypoint gemini --version >/tmp/gemini-conflicting.out 2>&1; then
+    echo "expected Gemini conflicting auth selectors to fail fast" >&2
+    exit 1
+  fi
+  grep -q "enables both GOOGLE_GENAI_USE_GCA and GOOGLE_GENAI_USE_VERTEXAI" /tmp/gemini-conflicting.out
+'
+
+# shellcheck disable=SC2016
+run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini-partial-vertex" bash -lc '
+  set -euo pipefail
+  if /usr/local/bin/workcell-entrypoint gemini --version >/tmp/gemini-partial-vertex.out 2>&1; then
+    echo "expected Gemini partial Vertex config to fail fast" >&2
+    exit 1
+  fi
+  grep -q "does not configure a supported Gemini auth mode" /tmp/gemini-partial-vertex.out
+'
+
+# shellcheck disable=SC2016
+run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini-google-api-key-only-oauth" bash -lc '
+  set -euo pipefail
+  if /usr/local/bin/workcell-entrypoint gemini --version >/tmp/gemini-google-api-key-only-oauth.out 2>&1; then
+    echo "expected Gemini GOOGLE_API_KEY config without explicit Vertex selection to fail fast" >&2
+    exit 1
+  fi
+  grep -q "sets GOOGLE_API_KEY without GOOGLE_GENAI_USE_VERTEXAI=true" /tmp/gemini-google-api-key-only-oauth.out
+'
+
+# shellcheck disable=SC2016
+run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini-project-only-oauth" bash -lc '
+  set -euo pipefail
+  if /usr/local/bin/workcell-entrypoint gemini --version >/tmp/gemini-project-only-oauth.out 2>&1; then
+    echo "expected project-only Gemini env config to remain invalid even when gemini_oauth is present" >&2
+    exit 1
+  fi
+  grep -q "does not configure a supported Gemini auth mode" /tmp/gemini-project-only-oauth.out
+'
+
+# shellcheck disable=SC2016
+run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini-malformed" bash -lc '
+  set -euo pipefail
+  if /usr/local/bin/workcell-entrypoint gemini --version >/tmp/gemini-malformed.out 2>&1; then
+    echo "expected malformed Gemini env config to fail fast" >&2
+    exit 1
+  fi
+  grep -q "Malformed Gemini auth env file" /tmp/gemini-malformed.out
+'
+
+# shellcheck disable=SC2016
+run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini-gcloud-adc" bash -lc '
+  set -euo pipefail
+  /usr/local/bin/workcell-entrypoint gemini --version >/dev/null
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    jq -r ".security.auth.selectedType" "$HOME/.gemini/settings.json" | grep -q "^vertex-ai$"
+    grep -q "GOOGLE_CLOUD_PROJECT=smoke-project" "$HOME/.gemini/.env"
+    grep -q "\"authorized_user\"" "$HOME/.config/gcloud/application_default_credentials.json"
+  '"'"'
+'
+
+# shellcheck disable=SC2016
+run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini-invalid-oauth" bash -lc '
+  set -euo pipefail
+  if /usr/local/bin/workcell-entrypoint gemini --version >/tmp/gemini-invalid-oauth.out 2>&1; then
+    echo "expected malformed Gemini OAuth JSON to fail fast" >&2
+    exit 1
+  fi
+  grep -q "Gemini OAuth config must contain a JSON object" /tmp/gemini-invalid-oauth.out
+'
+
+# shellcheck disable=SC2016
+run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini-invalid-adc" bash -lc '
+  set -euo pipefail
+  if /usr/local/bin/workcell-entrypoint gemini --version >/tmp/gemini-invalid-adc.out 2>&1; then
+    echo "expected malformed Google ADC JSON to fail fast" >&2
+    exit 1
+  fi
+  grep -q "Google ADC config must contain a JSON object with a non-empty string type" /tmp/gemini-invalid-adc.out
+'
+
+# shellcheck disable=SC2016
+run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini-invalid-projects" bash -lc '
+  set -euo pipefail
+  if /usr/local/bin/workcell-entrypoint gemini --version >/tmp/gemini-invalid-projects.out 2>&1; then
+    echo "expected malformed Gemini projects JSON to fail fast" >&2
+    exit 1
+  fi
+  grep -q "Gemini projects config must contain a JSON object with an object-valued projects field" /tmp/gemini-invalid-projects.out
+'
+
+# shellcheck disable=SC2016
+run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini-vertex-express" bash -lc '
+  set -euo pipefail
+  /usr/local/bin/workcell-entrypoint gemini --version >/dev/null
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
+    set -euo pipefail
+    jq -r ".security.auth.selectedType" "$HOME/.gemini/settings.json" | grep -q "^vertex-ai$"
+    grep -q "GOOGLE_GENAI_USE_VERTEXAI=true" "$HOME/.gemini/.env"
+    grep -q "GOOGLE_API_KEY=smoke-google-key" "$HOME/.gemini/.env"
   '"'"'
 '
 

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -217,15 +217,30 @@ clone_bundle_with_credential_override() {
 
   rm -rf "${bundle_root}"
   cp -R "${source_bundle}" "${bundle_root}"
-  python3 - "${bundle_root}/manifest.json" "${credential_key}" "${override_source}" <<'PY'
+  python3 - "${bundle_root}/manifest.json" "${source_bundle}.mounts.json" "${credential_key}" "${override_source}" <<'PY'
 import json
 import sys
 from pathlib import Path
 
 manifest_path = Path(sys.argv[1])
-credential_key = sys.argv[2]
-override_source = sys.argv[3]
+mount_spec_path = Path(sys.argv[2])
+credential_key = sys.argv[3]
+override_source = sys.argv[4]
 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+mount_sources = {}
+
+if mount_spec_path.is_file():
+    for entry in json.loads(mount_spec_path.read_text(encoding="utf-8")):
+        mount_path = entry.get("mount_path")
+        source = entry.get("source")
+        if isinstance(mount_path, str) and mount_path and isinstance(source, str) and source:
+            mount_sources[mount_path] = source
+
+for entry in manifest.get("credentials", {}).values():
+    mount_path = entry.get("mount_path")
+    if "source" not in entry and isinstance(mount_path, str) and mount_path in mount_sources:
+        entry["source"] = mount_sources[mount_path]
+
 manifest["credentials"][credential_key]["source"] = override_source
 manifest_path.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY

--- a/scripts/lib/render_injection_bundle.py
+++ b/scripts/lib/render_injection_bundle.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import os
 from pathlib import Path, PurePosixPath
+import re
 import shutil
 import stat
 import sys
@@ -61,6 +62,7 @@ RESERVED_TARGETS = (
     "/state/agent-home/.gemini/.env",
     "/state/agent-home/.gemini/oauth_creds.json",
     "/state/agent-home/.gemini/projects.json",
+    "/state/agent-home/.gemini/trustedFolders.json",
     "/state/agent-home/.config/gcloud/application_default_credentials.json",
     "/state/agent-home/.config/gh/config.yml",
     "/state/agent-home/.config/gh/hosts.yml",
@@ -87,6 +89,13 @@ AGENT_SCOPED_CREDENTIAL_KEYS = {
 }
 
 SHARED_CREDENTIAL_KEYS = {"github_hosts", "github_config"}
+GOOGLE_AUTH_ENDPOINTS = (
+    "accounts.google.com:443",
+    "oauth2.googleapis.com:443",
+    "sts.googleapis.com:443",
+)
+VERTEX_ENDPOINT = "aiplatform.googleapis.com:443"
+GEMINI_PROJECT_KEYS = ("GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID")
 GEMINI_VERTEX_LOCATION_KEYS = (
     "GOOGLE_CLOUD_LOCATION",
     "GOOGLE_CLOUD_REGION",
@@ -94,6 +103,14 @@ GEMINI_VERTEX_LOCATION_KEYS = (
     "VERTEX_LOCATION",
     "VERTEX_AI_LOCATION",
 )
+GEMINI_SUPPORTED_ENV_KEYS = {
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GOOGLE_GENAI_USE_GCA",
+    "GOOGLE_GENAI_USE_VERTEXAI",
+    *GEMINI_PROJECT_KEYS,
+    *GEMINI_VERTEX_LOCATION_KEYS,
+}
 
 
 def die(message: str) -> NoReturn:
@@ -236,25 +253,29 @@ def direct_mount_entry(source: Path, mount_path: str) -> dict[str, str]:
 
 def parse_simple_env_file(source: Path) -> dict[str, str]:
     values: dict[str, str] = {}
-    for raw_line in source.read_text(encoding="utf-8").splitlines():
+    for lineno, raw_line in enumerate(source.read_text(encoding="utf-8").splitlines(), start=1):
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue
         if line.startswith("export "):
             line = line[len("export ") :].lstrip()
-        if "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        key = key.strip()
-        value = value.strip()
-        if not key or any(char.isspace() for char in key):
-            continue
+        match = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)", line)
+        if match is None:
+            die(f"Malformed Gemini auth env file {source}: {raw_line.strip()}. Use KEY=value assignments.")
+        key, value = match.groups()
+        if key in values:
+            die(f"Gemini auth env file {source} configures {key} more than once.")
+        value = strip_comment(value)
         if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-            try:
-                parsed = ast.literal_eval(value)
-            except (SyntaxError, ValueError):
+            if value[0] == '"':
+                try:
+                    parsed = ast.literal_eval(value)
+                except (SyntaxError, ValueError):
+                    parsed = value[1:-1]
+                value = parsed if isinstance(parsed, str) else str(parsed)
+            else:
                 parsed = value[1:-1]
-            value = parsed if isinstance(parsed, str) else str(parsed)
+                value = parsed if isinstance(parsed, str) else str(parsed)
         values[key] = value
     return values
 
@@ -273,15 +294,108 @@ def normalize_vertex_location(value: str | None) -> str | None:
     return candidate
 
 
+def validate_json_object_file(source: Path, label: str) -> dict[str, object]:
+    try:
+        parsed = json.loads(source.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        die(f"{label} must contain valid JSON: {source} ({exc.msg})")
+    if not isinstance(parsed, dict):
+        die(f"{label} must contain a JSON object: {source}")
+    return parsed
+
+
+def parse_env_boolean_value(values: dict[str, str], source: Path, key: str) -> bool | None:
+    raw = values.get(key)
+    if raw is None:
+        return None
+    normalized = raw.strip().lower()
+    if normalized not in {"true", "false"}:
+        die(f"Invalid boolean in Gemini auth env file {source}: {key}={raw}. Use true or false.")
+    return normalized == "true"
+
+
+def validate_gcloud_adc_file(source: Path, label: str) -> None:
+    parsed = validate_json_object_file(source, label)
+    adc_type = parsed.get("type")
+    if not isinstance(adc_type, str) or not adc_type.strip():
+        die(f"{label} must contain a non-empty JSON string field: type")
+
+
+def validate_gemini_projects_file(source: Path, label: str) -> None:
+    parsed = validate_json_object_file(source, label)
+    projects = parsed.get("projects")
+    if not isinstance(projects, dict):
+        die(f"{label} must contain a JSON object with an object-valued projects field")
+
+
+def validate_gemini_env_file(source: Path) -> dict[str, object]:
+    values = parse_simple_env_file(source)
+    for key, value in values.items():
+        if key not in GEMINI_SUPPORTED_ENV_KEYS:
+            die(f"Unsupported key in Gemini auth env file {source}: {key}.")
+        if key not in {"GOOGLE_GENAI_USE_GCA", "GOOGLE_GENAI_USE_VERTEXAI"} and not value.strip():
+            die(f"Gemini auth env file {source} sets {key} but leaves it empty.")
+
+    gca_enabled = parse_env_boolean_value(values, source, "GOOGLE_GENAI_USE_GCA")
+    vertex_enabled = parse_env_boolean_value(values, source, "GOOGLE_GENAI_USE_VERTEXAI")
+    gemini_api_key = values.get("GEMINI_API_KEY", "").strip()
+    google_api_key = values.get("GOOGLE_API_KEY", "").strip()
+    has_project = any(values.get(key, "").strip() for key in GEMINI_PROJECT_KEYS)
+    has_location = any(values.get(key, "").strip() for key in GEMINI_VERTEX_LOCATION_KEYS)
+
+    if gca_enabled and vertex_enabled:
+        die(
+            f"Gemini auth env file {source} enables both GOOGLE_GENAI_USE_GCA and "
+            "GOOGLE_GENAI_USE_VERTEXAI. Choose exactly one auth selector."
+        )
+    if has_location and not has_project:
+        die(f"Gemini auth env file {source} sets a Google Cloud location without a project.")
+
+    endpoints: set[str] = set()
+    if vertex_enabled:
+        if google_api_key or (has_project and has_location):
+            endpoints.add(VERTEX_ENDPOINT)
+            for key in GEMINI_VERTEX_LOCATION_KEYS:
+                location = normalize_vertex_location(values.get(key))
+                if location is not None:
+                    endpoints.add(f"{location}-aiplatform.googleapis.com:443")
+            return {
+                "selected_auth_type": "vertex-ai",
+                "extra_endpoints": sorted(endpoints),
+            }
+        die(
+            f"Gemini auth env file {source} enables GOOGLE_GENAI_USE_VERTEXAI=true without "
+            "either GOOGLE_API_KEY or both GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION."
+        )
+
+    if google_api_key:
+        die(f"Gemini auth env file {source} sets GOOGLE_API_KEY without GOOGLE_GENAI_USE_VERTEXAI=true.")
+
+    if gca_enabled:
+        return {
+            "selected_auth_type": "oauth-personal",
+            "extra_endpoints": list(GOOGLE_AUTH_ENDPOINTS),
+        }
+
+    if gemini_api_key:
+        return {
+            "selected_auth_type": "gemini-api-key",
+            "extra_endpoints": [],
+        }
+
+    die(
+        f"Gemini auth env file {source} does not configure a supported Gemini auth mode. "
+        "Use GEMINI_API_KEY, GOOGLE_GENAI_USE_GCA=true, or GOOGLE_GENAI_USE_VERTEXAI=true "
+        "with GOOGLE_API_KEY or both GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION."
+    )
+
+
 def derive_credential_extra_endpoints(rendered_credentials: dict[str, dict[str, str]]) -> list[str]:
     endpoints: set[str] = set()
     gemini_env = rendered_credentials.get("gemini_env")
     if gemini_env is not None:
-        env_values = parse_simple_env_file(Path(gemini_env["source"]))
-        for key in GEMINI_VERTEX_LOCATION_KEYS:
-            location = normalize_vertex_location(env_values.get(key))
-            if location is not None:
-                endpoints.add(f"{location}-aiplatform.googleapis.com:443")
+        metadata = validate_gemini_env_file(Path(gemini_env["source"]))
+        endpoints.update(metadata["extra_endpoints"])
     return sorted(endpoints)
 
 
@@ -403,7 +517,7 @@ def load_policy(policy_path: Path) -> dict:
 
 def strip_comment(line: str) -> str:
     escaped = False
-    in_string = False
+    quote_char = ""
     result = []
 
     for char in line:
@@ -411,15 +525,18 @@ def strip_comment(line: str) -> str:
             result.append(char)
             escaped = False
             continue
-        if char == "\\" and in_string:
+        if char == "\\" and quote_char == '"':
             result.append(char)
             escaped = True
             continue
-        if char == '"':
-            in_string = not in_string
+        if char in {'"', "'"}:
+            if not quote_char:
+                quote_char = char
+            elif quote_char == char:
+                quote_char = ""
             result.append(char)
             continue
-        if char == "#" and not in_string:
+        if char == "#" and not quote_char:
             break
         result.append(char)
     return "".join(result).strip()
@@ -450,6 +567,7 @@ def parse_value(raw: str, policy_path: Path, lineno: int) -> object:
 def parse_toml_subset(content: str, policy_path: Path) -> dict:
     root: dict[str, object] = {}
     current: dict[str, object] = root
+    seen_tables: set[str] = set()
 
     for lineno, raw_line in enumerate(content.splitlines(), start=1):
         line = strip_comment(raw_line)
@@ -470,6 +588,9 @@ def parse_toml_subset(content: str, policy_path: Path) -> dict:
 
         if line.startswith("[") and line.endswith("]"):
             table_name = line[1:-1].strip()
+            if table_name in seen_tables:
+                die(f"{policy_path}:{lineno}: duplicate table [{table_name}]")
+            seen_tables.add(table_name)
             if table_name.startswith("credentials."):
                 credential_key = table_name.split(".", 1)[1]
                 if credential_key not in CREDENTIAL_CONTAINER_PATHS:
@@ -502,6 +623,13 @@ def parse_toml_subset(content: str, policy_path: Path) -> dict:
         key = key.strip()
         if not key:
             die(f"{policy_path}:{lineno}: empty key")
+        if "." in key:
+            die(
+                f"{policy_path}:{lineno}: dotted TOML keys are not supported; "
+                "use explicit [table] headers instead"
+            )
+        if key in current:
+            die(f"{policy_path}:{lineno}: duplicate key: {key}")
         current[key] = parse_value(value, policy_path, lineno)
 
     return root
@@ -752,6 +880,14 @@ def render_credentials(
             validate_source_path(source_raw, f"credentials.{key}", policy_dir),
             f"credentials.{key}",
         )
+        if key == "gemini_env":
+            validate_gemini_env_file(source)
+        elif key == "gemini_oauth":
+            validate_json_object_file(source, "credentials.gemini_oauth")
+        elif key == "gcloud_adc":
+            validate_gcloud_adc_file(source, "credentials.gcloud_adc")
+        elif key == "gemini_projects":
+            validate_gemini_projects_file(source, "credentials.gemini_projects")
         rendered[key] = {
             "source": str(source),
             "mount_path": CREDENTIAL_CONTAINER_PATHS[key],

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1998,7 +1998,8 @@ WORKSPACE=/tmp/workcell-gemini-workspace
 INJECTION_CREDENTIAL_KEYS=github_hosts
 
 status=0
-if ( fail_fast_for_missing_gemini_auth ) >/tmp/workcell-gemini-auth-harness.stdout 2>/tmp/workcell-gemini-auth-harness.stderr; then
+set -- gemini
+if ( fail_fast_for_missing_gemini_auth "$@" ) >/tmp/workcell-gemini-auth-harness.stdout 2>/tmp/workcell-gemini-auth-harness.stderr; then
   echo "Expected Gemini missing-auth harness to fail fast" >&2
   exit 1
 else
@@ -2012,8 +2013,19 @@ grep -q 'Gemini auth is not configured for this session.' /tmp/workcell-gemini-a
 grep -q 'Update /tmp/no-gemini-policy.toml to include credentials.gemini_env, credentials.gemini_oauth, or credentials.gcloud_adc.' /tmp/workcell-gemini-auth-harness.stderr
 grep -q '^Next step: workcell --auth-status --agent gemini --workspace /tmp/workcell-gemini-workspace$' /tmp/workcell-gemini-auth-harness.stderr
 
+set -- gemini --version
+if ! ( fail_fast_for_missing_gemini_auth "$@" ) >/tmp/workcell-gemini-auth-version.stdout 2>/tmp/workcell-gemini-auth-version.stderr; then
+  echo "Expected Gemini --version harness to bypass missing-auth fail-fast" >&2
+  exit 1
+fi
+if [[ -s /tmp/workcell-gemini-auth-version.stderr ]]; then
+  echo "Expected Gemini --version harness to stay silent" >&2
+  exit 1
+fi
+
 DRY_RUN=1
-if ! ( fail_fast_for_missing_gemini_auth ) >/tmp/workcell-gemini-auth-dry-run.stdout 2>/tmp/workcell-gemini-auth-dry-run.stderr; then
+set -- gemini
+if ! ( fail_fast_for_missing_gemini_auth "$@" ) >/tmp/workcell-gemini-auth-dry-run.stdout 2>/tmp/workcell-gemini-auth-dry-run.stderr; then
   echo "Expected Gemini missing-auth harness to skip dry-run" >&2
   exit 1
 fi

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3484,7 +3484,8 @@ GEMINI_AUTH_SELECTION_HARNESS="$(mktemp)"
   printf '\n'
   extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_target_is_allowed
   cat <<'EOF'
-set -euo pipefail
+set -Eeuo pipefail
+trap 'echo "Gemini auth selection harness failed at line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3488,10 +3488,8 @@ GEMINI_AUTH_SELECTION_STDERR="$(mktemp)"
   cat <<'EOF'
 set -Eeuo pipefail
 trap 'echo "Gemini auth selection harness failed at line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
-if [[ "${CI:-}" == "true" ]] || [[ "${CI:-}" == "1" ]]; then
-  export PS4='+ gemini-harness:${LINENO}: '
-  set -x
-fi
+export PS4='+ gemini-harness:${LINENO}: '
+set -x
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3499,6 +3499,18 @@ workcell_die() {
   exit 1
 }
 
+expect_fatal_function_failure() {
+  local stdout_path="$1"
+  local stderr_path="$2"
+  shift 2
+
+  if ( "$@" ) >"${stdout_path}" 2>"${stderr_path}"; then
+    return 0
+  fi
+
+  return 1
+}
+
 expect_auth_type() {
   local env_contents="$1"
   local oauth_present="$2"
@@ -3543,28 +3555,32 @@ if workcell_gemini_selected_auth_type "${TMP_DIR}/missing.env" "${TMP_DIR}/missi
 fi
 
 printf 'GOOGLE_GENAI_USE_GCA=maybe\n' >"${TMP_DIR}/invalid-bool.env"
-if workcell_validate_gemini_env_auth_config "${TMP_DIR}/invalid-bool.env" >/tmp/gemini-invalid-bool.stdout 2>/tmp/gemini-invalid-bool.stderr; then
+if expect_fatal_function_failure /tmp/gemini-invalid-bool.stdout /tmp/gemini-invalid-bool.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/invalid-bool.env"; then
   echo "Expected invalid Gemini auth booleans to be rejected" >&2
   exit 1
 fi
 grep -q 'Invalid boolean in Gemini auth env file' /tmp/gemini-invalid-bool.stderr
 
 printf 'GOOGLE_GENAI_USE_VERTEXAI true\n' >"${TMP_DIR}/malformed.env"
-if workcell_validate_gemini_env_auth_config "${TMP_DIR}/malformed.env" >/tmp/gemini-malformed.stdout 2>/tmp/gemini-malformed.stderr; then
+if expect_fatal_function_failure /tmp/gemini-malformed.stdout /tmp/gemini-malformed.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/malformed.env"; then
   echo "Expected malformed Gemini auth env syntax to be rejected" >&2
   exit 1
 fi
 grep -q 'Malformed Gemini auth env file' /tmp/gemini-malformed.stderr
 
 printf 'UNSUPPORTED_KEY=test\n' >"${TMP_DIR}/unsupported.env"
-if workcell_validate_gemini_env_auth_config "${TMP_DIR}/unsupported.env" >/tmp/gemini-unsupported.stdout 2>/tmp/gemini-unsupported.stderr; then
+if expect_fatal_function_failure /tmp/gemini-unsupported.stdout /tmp/gemini-unsupported.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/unsupported.env"; then
   echo "Expected unsupported Gemini auth env keys to be rejected" >&2
   exit 1
 fi
 grep -q 'Unsupported key in Gemini auth env file' /tmp/gemini-unsupported.stderr
 
 printf 'GOOGLE_GENAI_USE_GCA=true\nGOOGLE_GENAI_USE_VERTEXAI=true\n' >"${TMP_DIR}/conflicting-selectors.env"
-if workcell_validate_gemini_env_auth_config "${TMP_DIR}/conflicting-selectors.env" >/tmp/gemini-conflicting.stdout 2>/tmp/gemini-conflicting.stderr; then
+if expect_fatal_function_failure /tmp/gemini-conflicting.stdout /tmp/gemini-conflicting.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/conflicting-selectors.env"; then
   echo "Expected contradictory Gemini auth selectors to be rejected" >&2
   exit 1
 fi
@@ -3578,21 +3594,24 @@ if ! workcell_validate_gemini_env_auth_config "${TMP_DIR}/vertex-express.env" >/
 fi
 
 printf 'GOOGLE_API_KEY=vertex-key\n' >"${TMP_DIR}/google-api-key-only.env"
-if workcell_validate_gemini_env_auth_config "${TMP_DIR}/google-api-key-only.env" >/tmp/gemini-google-api-key.stdout 2>/tmp/gemini-google-api-key.stderr; then
+if expect_fatal_function_failure /tmp/gemini-google-api-key.stdout /tmp/gemini-google-api-key.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/google-api-key-only.env"; then
   echo "Expected bare GOOGLE_API_KEY to be rejected without GOOGLE_GENAI_USE_VERTEXAI=true" >&2
   exit 1
 fi
 grep -q 'sets GOOGLE_API_KEY without GOOGLE_GENAI_USE_VERTEXAI=true' /tmp/gemini-google-api-key.stderr
 
 printf 'GOOGLE_CLOUD_LOCATION=us-central1\n' >"${TMP_DIR}/location-only.env"
-if workcell_validate_gemini_env_auth_config "${TMP_DIR}/location-only.env" >/tmp/gemini-location-only.stdout 2>/tmp/gemini-location-only.stderr; then
+if expect_fatal_function_failure /tmp/gemini-location-only.stdout /tmp/gemini-location-only.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/location-only.env"; then
   echo "Expected location-only Gemini env config to be rejected" >&2
   exit 1
 fi
 grep -q 'sets a Google Cloud location without a project' /tmp/gemini-location-only.stderr
 
 printf 'GOOGLE_CLOUD_PROJECT=my-proj\n' >"${TMP_DIR}/project-only.env"
-if workcell_validate_gemini_env_auth_config "${TMP_DIR}/project-only.env" >/tmp/gemini-project-only.stdout 2>/tmp/gemini-project-only.stderr; then
+if expect_fatal_function_failure /tmp/gemini-project-only.stdout /tmp/gemini-project-only.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/project-only.env"; then
   echo "Expected project-only Gemini env config to be rejected" >&2
   exit 1
 fi

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -74,6 +74,17 @@ file_mode_octal() {
   fi
 }
 
+extract_top_level_bash_function() {
+  local source_file="$1"
+  local function_name="$2"
+
+  awk -v function_name="${function_name}" '
+    $0 ~ "^" function_name "\\(\\) \\{" { capture = 1 }
+    capture { print }
+    capture && $0 == "}" { exit }
+  ' "${source_file}"
+}
+
 cleanup() {
   rm -rf "${CODEX_VERIFY_HOME}"
   rm -rf "${BARRIER_VERIFY_ROOT}"
@@ -1762,6 +1773,49 @@ test -f "${DEBUG_LOG_CAPTURE}"
 test "$(file_mode_octal "${DEBUG_LOG_CAPTURE}")" = "600"
 grep -q 'Workcell warning: full host-persisted debug log capture is enabled for this session:' /tmp/workcell-debug-log.out
 grep -q 'execution_path=' "${DEBUG_LOG_CAPTURE}"
+RUN_COMMAND_DEBUG_FAILURE_HARNESS="${BARRIER_VERIFY_ROOT}/debug/run-command-debug-failure.sh"
+RUN_COMMAND_DEBUG_FAILURE_LOG="${BARRIER_VERIFY_ROOT}/debug/run-command-debug-failure.log"
+extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" run_command_with_debug_log >"${RUN_COMMAND_DEBUG_FAILURE_HARNESS}"
+cat >>"${RUN_COMMAND_DEBUG_FAILURE_HARNESS}" <<EOF
+set -euo pipefail
+LOG_LEVEL=debug
+DEBUG_LOG_PATH=""
+COLIMA_PROFILE="${STRICT_PREFLIGHT_PROFILE}"
+PREPARE_ONLY=0
+AGENT=codex
+BUILD_STATUS=0
+run_command_with_debug_log runtime-build bash -lc 'echo debug-pipeline-failure >&2; exit 23' || BUILD_STATUS=\$?
+printf 'build_status=%s\n' "\${BUILD_STATUS}"
+EOF
+chmod +x "${RUN_COMMAND_DEBUG_FAILURE_HARNESS}"
+if ! bash "${RUN_COMMAND_DEBUG_FAILURE_HARNESS}" >"${RUN_COMMAND_DEBUG_FAILURE_LOG}" 2>&1; then
+  echo "Expected debug-mode command failures to return control to the caller" >&2
+  cat "${RUN_COMMAND_DEBUG_FAILURE_LOG}" >&2
+  exit 1
+fi
+grep -q '^build_status=23$' "${RUN_COMMAND_DEBUG_FAILURE_LOG}"
+grep -q 'Workcell runtime-build failed\.' "${RUN_COMMAND_DEBUG_FAILURE_LOG}"
+grep -q 'debug-pipeline-failure' "${RUN_COMMAND_DEBUG_FAILURE_LOG}"
+RUN_COMMAND_DEBUG_DUP_HARNESS="${BARRIER_VERIFY_ROOT}/debug/run-command-debug-dup.sh"
+RUN_COMMAND_DEBUG_DUP_LOG="${BARRIER_VERIFY_ROOT}/debug/run-command-debug-dup.log"
+extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" run_command_with_debug_log >"${RUN_COMMAND_DEBUG_DUP_HARNESS}"
+cat >>"${RUN_COMMAND_DEBUG_DUP_HARNESS}" <<EOF
+set -euo pipefail
+LOG_LEVEL=debug
+DEBUG_LOG_PATH="${RUN_COMMAND_DEBUG_DUP_LOG}"
+COLIMA_PROFILE="${STRICT_PREFLIGHT_PROFILE}"
+PREPARE_ONLY=0
+AGENT=codex
+exec > >(tee -a "${RUN_COMMAND_DEBUG_DUP_LOG}") 2>&1
+run_command_with_debug_log runtime-build bash -lc 'echo workcell-debug-unique-line >&2'
+EOF
+chmod +x "${RUN_COMMAND_DEBUG_DUP_HARNESS}"
+if ! bash "${RUN_COMMAND_DEBUG_DUP_HARNESS}" >/tmp/workcell-run-command-debug-dup.out 2>&1; then
+  echo "Expected debug-mode log duplication harness to succeed" >&2
+  cat /tmp/workcell-run-command-debug-dup.out >&2
+  exit 1
+fi
+test "$(grep -c '^workcell-debug-unique-line$' "${RUN_COMMAND_DEBUG_DUP_LOG}")" = "1"
 DEBUG_LOG_SYMLINK_TARGET="${BARRIER_VERIFY_ROOT}/debug/redirected.log"
 DEBUG_LOG_SYMLINK="${BARRIER_VERIFY_ROOT}/debug/symlink.log"
 rm -f "${DEBUG_LOG_SYMLINK_TARGET}" "${DEBUG_LOG_SYMLINK}"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env -S -i PATH=/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin BASH_ENV= ENV= /bin/bash
 # shellcheck shell=bash
-set -euo pipefail
+set -Eeuo pipefail
+
+report_verify_invariants_failure() {
+  local status="$1"
+  local line="$2"
+  local command="$3"
+  local caller_frame=""
+
+  if [[ "${FUNCNAME[1]:-}" == "rg" ]]; then
+    return 0
+  fi
+
+  trap - ERR
+  caller_frame="$(caller 0 2>/dev/null || true)"
+  if [[ -n "${caller_frame}" ]]; then
+    echo "verify-invariants failed with status ${status} at ${caller_frame}: ${command}" >&2
+  else
+    echo "verify-invariants failed with status ${status} at line ${line}: ${command}" >&2
+  fi
+}
+
+trap 'report_verify_invariants_failure "$?" "${LINENO}" "${BASH_COMMAND}"' ERR
 
 readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 export PATH="${TRUSTED_HOST_PATH}"
@@ -114,19 +135,36 @@ check_file() {
 }
 
 rg() {
+  local status=0
+
   if builtin type -P rg >/dev/null 2>&1; then
+    set +E
+    set +e
     command rg "$@"
-    return
+    status=$?
+    set -e
+    set -E
+    return "${status}"
   fi
 
   if [[ "${1:-}" == "-q" ]] && [[ "$#" -eq 3 ]]; then
+    set +E
+    set +e
     grep -Eq -- "$2" "$3"
-    return
+    status=$?
+    set -e
+    set -E
+    return "${status}"
   fi
 
   if [[ "${1:-}" == "-q" ]] && [[ "${2:-}" == "--" ]] && [[ "$#" -eq 4 ]]; then
+    set +E
+    set +e
     grep -Eq -- "$3" "$4"
-    return
+    status=$?
+    set -e
+    set -E
+    return "${status}"
   fi
 
   echo "rg fallback only supports 'rg -q PATTERN FILE' or 'rg -q -- PATTERN FILE'" >&2

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -318,6 +318,11 @@ if ! rg -q 'REAL_HOME=' "${ROOT_DIR}/scripts/workcell"; then
   exit 1
 fi
 
+if ! sed -n '/^run_host_colima()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq "HOME=\"\${REAL_HOME}\""; then
+  echo "Expected run_host_colima to restore the real host HOME instead of the Docker client sandbox home" >&2
+  exit 1
+fi
+
 if ! head -n 1 "${ROOT_DIR}/scripts/workcell" | grep -q '^#!/usr/bin/env -S -i PATH=.* BASH_ENV= ENV= /bin/bash$'; then
   echo "Expected scripts/workcell to use env -S -i with an absolute /bin/bash and cleared host environment" >&2
   exit 1
@@ -657,7 +662,7 @@ if [[ "${INJECTION_DRY_RUN_OUTPUT}" != *'WORKCELL_CONTAINER_MUTABILITY=ephemeral
   exit 1
 fi
 
-STALE_INJECTION_BUNDLE="${REAL_HOME}/.local/state/workcell/tmp/workcell-injections.verify-stale.$$"
+STALE_INJECTION_BUNDLE="${REAL_HOME}/Library/Caches/colima/workcell-host-inputs/workcell-injections.verify-stale.$$"
 STALE_INJECTION_SIDECAR="${STALE_INJECTION_BUNDLE}.mounts.json"
 mkdir -p "$(dirname "${STALE_INJECTION_BUNDLE}")"
 mkdir -p "${STALE_INJECTION_BUNDLE}"
@@ -752,6 +757,73 @@ if ! grep -q 'copies.classification is required' /tmp/workcell-injection-missing
   exit 1
 fi
 
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/bad-duplicate-key.toml"
+version = 1
+
+[credentials]
+gemini_env = "gemini.env"
+gemini_env = "gemini.env"
+EOF
+
+if "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${INJECTION_POLICY_FIXTURE_ROOT}/bad-duplicate-key.toml" \
+  --auth-status >/tmp/workcell-injection-bad-duplicate-key.out 2>&1; then
+  echo "Expected workcell --auth-status to reject duplicate keys in injection policies" >&2
+  exit 1
+fi
+
+if ! grep -q 'duplicate key: gemini_env' /tmp/workcell-injection-bad-duplicate-key.out; then
+  echo "Expected duplicate-key rejection to name the repeated key" >&2
+  cat /tmp/workcell-injection-bad-duplicate-key.out >&2
+  exit 1
+fi
+
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/bad-value.toml"
+version = 1
+
+[credentials]
+gemini_env = gemini.env
+EOF
+
+if "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${INJECTION_POLICY_FIXTURE_ROOT}/bad-value.toml" \
+  --auth-status >/tmp/workcell-injection-bad-value.out 2>&1; then
+  echo "Expected workcell --auth-status to reject unsupported TOML values in injection policies" >&2
+  exit 1
+fi
+
+if ! grep -q 'unsupported TOML value' /tmp/workcell-injection-bad-value.out; then
+  echo "Expected invalid-value rejection to explain the supported TOML subset" >&2
+  cat /tmp/workcell-injection-bad-value.out >&2
+  exit 1
+fi
+
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/bad-github-scope.toml"
+version = 1
+
+[credentials.github_hosts]
+source = "gh-hosts.yml"
+EOF
+
+if "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${INJECTION_POLICY_FIXTURE_ROOT}/bad-github-scope.toml" \
+  --auth-status >/tmp/workcell-injection-bad-github-scope.out 2>&1; then
+  echo "Expected workcell --auth-status to reject unscoped shared GitHub credentials" >&2
+  exit 1
+fi
+
+if ! grep -q 'providers is required' /tmp/workcell-injection-bad-github-scope.out; then
+  echo "Expected shared GitHub credential rejection to require explicit providers scoping" >&2
+  cat /tmp/workcell-injection-bad-github-scope.out >&2
+  exit 1
+fi
+
 cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/bad-ssh.toml"
 version = 1
 
@@ -792,6 +864,11 @@ fi
 
 if ! rg -q -- '--self-docker-probe' "${ROOT_DIR}/scripts/workcell"; then
   echo "Expected scripts/workcell to expose a hidden self-docker probe for invariant testing" >&2
+  exit 1
+fi
+
+if ! rg -q -- '--self-staging-probe' "${ROOT_DIR}/scripts/workcell"; then
+  echo "Expected scripts/workcell to expose a hidden staging probe for invariant testing" >&2
   exit 1
 fi
 
@@ -910,6 +987,25 @@ if ! rg -q 'snapshot\.debian\.org:80' "${ROOT_DIR}/scripts/workcell"; then
   echo "Expected scripts/workcell bootstrap endpoints to allow snapshot.debian.org" >&2
   exit 1
 fi
+
+if rg -q 'snapshot\.debian\.org:443' "${ROOT_DIR}/scripts/workcell"; then
+  echo "Expected scripts/workcell bootstrap endpoints to avoid unused snapshot.debian.org:443 egress" >&2
+  exit 1
+fi
+
+for dockerfile in \
+  "${ROOT_DIR}/runtime/container/Dockerfile" \
+  "${ROOT_DIR}/tools/validator/Dockerfile" \
+  "${ROOT_DIR}/tools/remote-validator/Dockerfile"; do
+  if ! rg -q 'Acquire::Retries "5";' "${dockerfile}"; then
+    echo "Expected ${dockerfile} to pin apt retry count for snapshot fetch resilience" >&2
+    exit 1
+  fi
+  if ! rg -q 'Acquire::http::Timeout "30";' "${dockerfile}"; then
+    echo "Expected ${dockerfile} to pin apt HTTP timeout for snapshot fetch resilience" >&2
+    exit 1
+  fi
+done
 
 if ! rg -q '"bootstrap_applied=\$\{BOOTSTRAP_APPLIED\}"' "${ROOT_DIR}/scripts/workcell" ||
   ! rg -q '"bootstrap_endpoints=\$\(\[\[ "\$\{BOOTSTRAP_APPLIED\}" -eq 1 \]\] && printf '\''%s'\'' "\$\{BOOTSTRAP_ENDPOINTS\}" \|\| printf '\'''\''\)"' "${ROOT_DIR}/scripts/workcell"; then
@@ -1901,6 +1997,24 @@ printf 'GEMINI_API_KEY=verify-gemini-key\n' >"${AUTH_STATUS_ROOT}/gemini.env"
 chmod 0600 "${AUTH_STATUS_ROOT}/gemini.env"
 printf '{"type":"authorized_user"}\n' >"${AUTH_STATUS_ROOT}/gcloud-adc.json"
 chmod 0600 "${AUTH_STATUS_ROOT}/gcloud-adc.json"
+printf '{"projects":{"verify":{"path":"/workspace"}}}\n' >"${AUTH_STATUS_ROOT}/gemini-projects.json"
+chmod 0600 "${AUTH_STATUS_ROOT}/gemini-projects.json"
+printf 'GOOGLE_GENAI_USE_VERTEXAI true\n' >"${AUTH_STATUS_ROOT}/gemini-invalid.env"
+chmod 0600 "${AUTH_STATUS_ROOT}/gemini-invalid.env"
+printf '[]\n' >"${AUTH_STATUS_ROOT}/gemini-invalid-oauth.json"
+chmod 0600 "${AUTH_STATUS_ROOT}/gemini-invalid-oauth.json"
+printf '{}\n' >"${AUTH_STATUS_ROOT}/gcloud-adc-invalid.json"
+chmod 0600 "${AUTH_STATUS_ROOT}/gcloud-adc-invalid.json"
+printf '{"projects":[]}\n' >"${AUTH_STATUS_ROOT}/gemini-projects-invalid.json"
+chmod 0600 "${AUTH_STATUS_ROOT}/gemini-projects-invalid.json"
+printf 'GOOGLE_GENAI_USE_GCA=true\n' >"${AUTH_STATUS_ROOT}/gemini-gca.env"
+chmod 0600 "${AUTH_STATUS_ROOT}/gemini-gca.env"
+cat >"${AUTH_STATUS_ROOT}/gemini-vertex-comment.env" <<'EOF'
+GOOGLE_GENAI_USE_VERTEXAI=true
+GOOGLE_CLOUD_PROJECT=verify-project
+GOOGLE_CLOUD_LOCATION="us-central1" # comment
+EOF
+chmod 0600 "${AUTH_STATUS_ROOT}/gemini-vertex-comment.env"
 cat >"${AUTH_STATUS_ROOT}/hosts.yml" <<'EOF'
 github.com:
   oauth_token: test-token
@@ -1917,6 +2031,7 @@ codex_auth = "auth.json"
 claude_auth = "claude-auth.json"
 claude_api_key = "claude-api-key.txt"
 gemini_env = "gemini.env"
+gemini_projects = "gemini-projects.json"
 gcloud_adc = "gcloud-adc.json"
 [credentials.github_hosts]
 source = "hosts.yml"
@@ -1927,7 +2042,8 @@ config = "ssh-config"
 allow_unsafe_config = true
 EOF
 cat >"${AUTH_STATUS_ROOT}/gemini.env" <<'EOF'
-GOOGLE_CLOUD_LOCATION=us-central1
+GOOGLE_GENAI_USE_VERTEXAI=true
+GOOGLE_API_KEY=verify-google-key
 EOF
 chmod 0600 "${AUTH_STATUS_ROOT}/gemini.env"
 if ! "${ROOT_DIR}/scripts/workcell" \
@@ -1976,9 +2092,222 @@ if ! "${ROOT_DIR}/scripts/workcell" \
   exit 1
 fi
 grep -q '^provider_auth_mode=gemini_env$' /tmp/workcell-auth-status-gemini.out
-grep -q '^provider_auth_modes=gemini_env,gcloud_adc$' /tmp/workcell-auth-status-gemini.out
+grep -q '^provider_auth_modes=gemini_env$' /tmp/workcell-auth-status-gemini.out
 grep -q '^shared_auth_modes=github_hosts$' /tmp/workcell-auth-status-gemini.out
 grep -q '^github_auth_present=1$' /tmp/workcell-auth-status-gemini.out
+
+cat >"${AUTH_STATUS_ROOT}/adc-only.toml" <<'EOF'
+version = 1
+
+[credentials]
+gcloud_adc = "gcloud-adc.json"
+EOF
+cat >"${AUTH_STATUS_ROOT}/invalid-gemini-env.toml" <<'EOF'
+version = 1
+
+[credentials]
+gemini_env = "gemini-invalid.env"
+EOF
+cat >"${AUTH_STATUS_ROOT}/invalid-gemini-oauth.toml" <<'EOF'
+version = 1
+
+[credentials]
+gemini_oauth = "gemini-invalid-oauth.json"
+EOF
+cat >"${AUTH_STATUS_ROOT}/invalid-gcloud-adc.toml" <<'EOF'
+version = 1
+
+[credentials]
+gcloud_adc = "gcloud-adc-invalid.json"
+EOF
+cat >"${AUTH_STATUS_ROOT}/invalid-gemini-projects.toml" <<'EOF'
+version = 1
+
+[credentials]
+gemini_projects = "gemini-projects-invalid.json"
+EOF
+cat >"${AUTH_STATUS_ROOT}/gca-only.toml" <<'EOF'
+version = 1
+
+[credentials]
+gemini_env = "gemini-gca.env"
+EOF
+cat >"${AUTH_STATUS_ROOT}/vertex-comment.toml" <<'EOF'
+version = 1
+
+[credentials]
+gemini_env = "gemini-vertex-comment.env"
+EOF
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${AUTH_STATUS_ROOT}/adc-only.toml" \
+  --auth-status >/tmp/workcell-auth-status-gemini-adc-only.out 2>&1; then
+  echo "Expected Gemini --auth-status to succeed for supplemental gcloud_adc inputs" >&2
+  exit 1
+fi
+grep -q '^provider_auth_mode=none$' /tmp/workcell-auth-status-gemini-adc-only.out
+grep -q '^provider_auth_modes=none$' /tmp/workcell-auth-status-gemini-adc-only.out
+
+if "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${AUTH_STATUS_ROOT}/invalid-gemini-env.toml" \
+  --auth-status >/tmp/workcell-auth-status-gemini-invalid-env.out 2>&1; then
+  echo "Expected Gemini --auth-status to reject malformed Gemini env auth" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/workcell-auth-status-gemini-invalid-env.out
+
+if "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${AUTH_STATUS_ROOT}/invalid-gemini-oauth.toml" \
+  --auth-status >/tmp/workcell-auth-status-gemini-invalid-oauth.out 2>&1; then
+  echo "Expected Gemini --auth-status to reject malformed Gemini OAuth JSON" >&2
+  exit 1
+fi
+grep -q 'credentials.gemini_oauth must contain a JSON object' /tmp/workcell-auth-status-gemini-invalid-oauth.out
+
+if "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${AUTH_STATUS_ROOT}/invalid-gcloud-adc.toml" \
+  --auth-status >/tmp/workcell-auth-status-gemini-invalid-adc.out 2>&1; then
+  echo "Expected Gemini --auth-status to reject malformed Google ADC JSON" >&2
+  exit 1
+fi
+grep -q 'credentials.gcloud_adc must contain a non-empty JSON string field: type' /tmp/workcell-auth-status-gemini-invalid-adc.out
+
+if "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${AUTH_STATUS_ROOT}/invalid-gemini-projects.toml" \
+  --auth-status >/tmp/workcell-auth-status-gemini-invalid-projects.out 2>&1; then
+  echo "Expected Gemini --auth-status to reject malformed Gemini projects JSON" >&2
+  exit 1
+fi
+grep -q 'credentials.gemini_projects must contain a JSON object with an object-valued projects field' /tmp/workcell-auth-status-gemini-invalid-projects.out
+
+cat >"${AUTH_STATUS_ROOT}/invalid-dotted.toml" <<'EOF'
+version = 1
+credentials.gemini_env = "gemini.env"
+EOF
+if "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${AUTH_STATUS_ROOT}/invalid-dotted.toml" \
+  --auth-status >/tmp/workcell-auth-status-invalid-dotted.out 2>&1; then
+  echo "Expected workcell to reject dotted injection-policy keys through the CLI path" >&2
+  exit 1
+fi
+grep -q 'dotted TOML keys are not supported' /tmp/workcell-auth-status-invalid-dotted.out
+
+cat >"${AUTH_STATUS_ROOT}/invalid-credential-key.toml" <<'EOF'
+version = 1
+[credentials]
+gemini = "gemini.env"
+EOF
+if "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${AUTH_STATUS_ROOT}/invalid-credential-key.toml" \
+  --auth-status >/tmp/workcell-auth-status-invalid-credential-key.out 2>&1; then
+  echo "Expected workcell to reject unsupported credential keys through the CLI path" >&2
+  exit 1
+fi
+grep -q 'credentials contains unsupported keys: gemini' /tmp/workcell-auth-status-invalid-credential-key.out
+
+cat >"${AUTH_STATUS_ROOT}/invalid-duplicate-table.toml" <<'EOF'
+version = 1
+
+[credentials]
+gemini_env = "gemini.env"
+
+[credentials]
+gcloud_adc = "adc.json"
+EOF
+if "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${AUTH_STATUS_ROOT}/invalid-duplicate-table.toml" \
+  --auth-status >/tmp/workcell-auth-status-invalid-duplicate-table.out 2>&1; then
+  echo "Expected workcell to reject duplicate top-level tables through the CLI path" >&2
+  exit 1
+fi
+grep -q 'duplicate table \[credentials\]' /tmp/workcell-auth-status-invalid-duplicate-table.out
+
+cat >"${AUTH_STATUS_ROOT}/invalid-duplicate-shared-credential-table.toml" <<'EOF'
+version = 1
+
+[credentials.github_hosts]
+source = "gh-hosts.yml"
+providers = ["gemini"]
+
+[credentials.github_hosts]
+source = "gh-hosts.yml"
+providers = ["codex"]
+EOF
+if "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${BARRIER_VERIFY_ROOT}/missing-workspace-for-auth-status" \
+  --injection-policy "${AUTH_STATUS_ROOT}/invalid-duplicate-shared-credential-table.toml" \
+  --auth-status >/tmp/workcell-auth-status-invalid-duplicate-shared-credential-table.out 2>&1; then
+  echo "Expected workcell to reject duplicate shared credential tables through the CLI path" >&2
+  exit 1
+fi
+grep -q 'duplicate table \[credentials.github_hosts\]' /tmp/workcell-auth-status-invalid-duplicate-shared-credential-table.out
+
+STAGING_PROBE_WORKSPACE="${AUTH_STATUS_ROOT}/staging-probe-workspace"
+mkdir -p "${STAGING_PROBE_WORKSPACE}"
+printf '# staging probe\n' >"${STAGING_PROBE_WORKSPACE}/AGENTS.md"
+STAGING_PROBE_OUTPUT="$("${ROOT_DIR}/scripts/workcell" \
+  --self-staging-probe \
+  gemini \
+  "${STAGING_PROBE_WORKSPACE}" \
+  "${AUTH_STATUS_ROOT}/policy.toml" \
+  strict)"
+if [[ "${STAGING_PROBE_OUTPUT}" != *"injection_bundle_root=${REAL_HOME}/Library/Caches/colima/workcell-host-inputs/workcell-injections."* ]]; then
+  echo "Expected staging probe to keep rendered injection bundles under the real Colima-visible cache root" >&2
+  printf '%s\n' "${STAGING_PROBE_OUTPUT}" >&2
+  exit 1
+fi
+if [[ "${STAGING_PROBE_OUTPUT}" != *"shadow_root=${REAL_HOME}/Library/Caches/colima/workcell-shadow/shadow."* ]]; then
+  echo "Expected staging probe to keep workspace control-plane shadows under the real Colima-visible cache root" >&2
+  printf '%s\n' "${STAGING_PROBE_OUTPUT}" >&2
+  exit 1
+fi
+if [[ "${STAGING_PROBE_OUTPUT}" != *'/opt/workcell/host-inputs/credentials/gemini.env:ro'* ]]; then
+  echo "Expected staging probe to include the rendered Gemini credential mount" >&2
+  printf '%s\n' "${STAGING_PROBE_OUTPUT}" >&2
+  exit 1
+fi
+if ! printf '%s\n' "${STAGING_PROBE_OUTPUT}" | grep -Eq "^direct_mount=${REAL_HOME}/Library/Caches/colima/workcell-host-inputs/workcell-injections\\.[^:]*/direct-mounts/[0-9a-f]{16}:/opt/workcell/host-inputs/credentials/gemini.env:ro$"; then
+  echo "Expected staging probe to restage direct credential mounts under the injection bundle root" >&2
+  printf '%s\n' "${STAGING_PROBE_OUTPUT}" >&2
+  exit 1
+fi
+if printf '%s\n' "${STAGING_PROBE_OUTPUT}" | grep -Fq "direct_mount=${AUTH_STATUS_ROOT}/gemini.env:/opt/workcell/host-inputs/credentials/gemini.env:ro"; then
+  echo "Expected staging probe to avoid binding the original host credential path directly into the runtime" >&2
+  printf '%s\n' "${STAGING_PROBE_OUTPUT}" >&2
+  exit 1
+fi
+if [[ "${STAGING_PROBE_OUTPUT}" != *'/workspace/AGENTS.md:ro'* ]]; then
+  echo "Expected staging probe to include the masked workspace AGENTS.md mount" >&2
+  printf '%s\n' "${STAGING_PROBE_OUTPUT}" >&2
+  exit 1
+fi
+if [[ "${STAGING_PROBE_OUTPUT}" != *'/opt/workcell/workspace-control-plane:ro'* ]]; then
+  echo "Expected staging probe to include the workspace import mount" >&2
+  printf '%s\n' "${STAGING_PROBE_OUTPUT}" >&2
+  exit 1
+fi
+if printf '%s\n' "${STAGING_PROBE_OUTPUT}" | grep -Eq '^(direct_mount|shadow_mount|workspace_import_mount)=/tmp/workcell-docker\.'; then
+  echo "Expected staging probe mount sources to avoid the temporary Docker client sandbox home" >&2
+  printf '%s\n' "${STAGING_PROBE_OUTPUT}" >&2
+  exit 1
+fi
+
 GEMINI_AUTH_FAILURE_HARNESS="$(mktemp)"
 {
   extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" csv_contains_value
@@ -2010,8 +2339,23 @@ if [[ "${status}" -ne 2 ]]; then
   exit 1
 fi
 grep -q 'Gemini auth is not configured for this session.' /tmp/workcell-gemini-auth-harness.stderr
-grep -q 'Update /tmp/no-gemini-policy.toml to include credentials.gemini_env, credentials.gemini_oauth, or credentials.gcloud_adc.' /tmp/workcell-gemini-auth-harness.stderr
+grep -q 'Update /tmp/no-gemini-policy.toml to include credentials.gemini_env or credentials.gemini_oauth.' /tmp/workcell-gemini-auth-harness.stderr
+grep -q 'credentials.gcloud_adc only supplements Gemini Vertex auth that is explicitly configured through credentials.gemini_env.' /tmp/workcell-gemini-auth-harness.stderr
 grep -q '^Next step: workcell --auth-status --agent gemini --workspace /tmp/workcell-gemini-workspace$' /tmp/workcell-gemini-auth-harness.stderr
+
+INJECTION_CREDENTIAL_KEYS=gcloud_adc
+set -- gemini
+if ( fail_fast_for_missing_gemini_auth "$@" ) >/tmp/workcell-gemini-auth-adc-only.stdout 2>/tmp/workcell-gemini-auth-adc-only.stderr; then
+  echo "Expected bare gcloud_adc to remain insufficient for Gemini fail-fast" >&2
+  exit 1
+else
+  status=$?
+fi
+if [[ "${status}" -ne 2 ]]; then
+  echo "Expected bare gcloud_adc fail-fast to exit 2, got ${status}" >&2
+  exit 1
+fi
+grep -q 'credentials.gcloud_adc only supplements Gemini Vertex auth' /tmp/workcell-gemini-auth-adc-only.stderr
 
 set -- gemini --version
 if ! ( fail_fast_for_missing_gemini_auth "$@" ) >/tmp/workcell-gemini-auth-version.stdout 2>/tmp/workcell-gemini-auth-version.stderr; then
@@ -2086,9 +2430,35 @@ if ! "${ROOT_DIR}/scripts/workcell" \
 fi
 grep -q 'accounts.google.com:443' /tmp/workcell-gemini-network.stderr
 grep -q 'api.github.com:443' /tmp/workcell-gemini-network.stderr
-grep -q 'us-central1-aiplatform.googleapis.com:443' /tmp/workcell-gemini-network.stderr
+grep -q 'aiplatform.googleapis.com:443' /tmp/workcell-gemini-network.stderr
 grep -q -- '--add-host accounts.google.com:' /tmp/workcell-gemini-network.stdout
-grep -q -- '--add-host us-central1-aiplatform.googleapis.com:' /tmp/workcell-gemini-network.stdout
+grep -q -- '--add-host aiplatform.googleapis.com:' /tmp/workcell-gemini-network.stdout
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${ROOT_DIR}" \
+  --injection-policy "${AUTH_STATUS_ROOT}/gca-only.toml" \
+  --dry-run >/tmp/workcell-gemini-gca-network.stdout 2>/tmp/workcell-gemini-gca-network.stderr; then
+  echo "Expected Gemini dry-run with GOOGLE_GENAI_USE_GCA=true auth to succeed" >&2
+  exit 1
+fi
+grep -q 'accounts.google.com:443' /tmp/workcell-gemini-gca-network.stderr
+grep -q 'oauth2.googleapis.com:443' /tmp/workcell-gemini-gca-network.stderr
+grep -q 'sts.googleapis.com:443' /tmp/workcell-gemini-gca-network.stderr
+grep -q -- '--add-host accounts.google.com:' /tmp/workcell-gemini-gca-network.stdout
+grep -q -- '--add-host oauth2.googleapis.com:' /tmp/workcell-gemini-gca-network.stdout
+grep -q -- '--add-host sts.googleapis.com:' /tmp/workcell-gemini-gca-network.stdout
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --workspace "${ROOT_DIR}" \
+  --injection-policy "${AUTH_STATUS_ROOT}/vertex-comment.toml" \
+  --dry-run >/tmp/workcell-gemini-vertex-comment.stdout 2>/tmp/workcell-gemini-vertex-comment.stderr; then
+  echo "Expected Gemini dry-run with commented Vertex location auth to succeed" >&2
+  exit 1
+fi
+grep -q 'aiplatform.googleapis.com:443' /tmp/workcell-gemini-vertex-comment.stderr
+grep -q 'us-central1-aiplatform.googleapis.com:443' /tmp/workcell-gemini-vertex-comment.stderr
+grep -q -- '--add-host aiplatform.googleapis.com:' /tmp/workcell-gemini-vertex-comment.stdout
+grep -q -- '--add-host us-central1-aiplatform.googleapis.com:' /tmp/workcell-gemini-vertex-comment.stdout
 
 BROKEN_DEBUG_POINTER_PROFILE="${STRICT_PREFLIGHT_PROFILE}-broken-debug-pointer"
 mkdir -p "${REAL_HOME}/.colima/${BROKEN_DEBUG_POINTER_PROFILE}"
@@ -2616,6 +2986,7 @@ if [[ "$(uname -s)" == "Darwin" ]] &&
     --prepare \
     --rebuild \
     --workspace "${ROOT_DIR}" \
+    --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
     --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
     --debug-log "${LIVE_DEBUG_LOG}" \
     --agent-arg --version >/tmp/workcell-audit-prepare.out 2>&1; then
@@ -2645,6 +3016,7 @@ if [[ "$(uname -s)" == "Darwin" ]] &&
     --agent codex \
     --mode build \
     --workspace "${ROOT_DIR}" \
+    --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
     --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
     --allow-arbitrary-command \
     --ack-arbitrary-command \
@@ -2661,6 +3033,18 @@ if [[ "$(uname -s)" == "Darwin" ]] &&
   grep -q 'session_assurance_final=lower-assurance-package-mutation' /tmp/workcell-audit-session.log
   grep -q 'event=exit' /tmp/workcell-audit-session.log
   grep -q 'package_mutation_downgraded=1' /tmp/workcell-audit-session.log
+  if ! "${ROOT_DIR}/scripts/workcell" \
+    --agent codex \
+    --mode build \
+    --workspace "${ROOT_DIR}" \
+    --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
+    --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
+    --allow-arbitrary-command \
+    --ack-arbitrary-command \
+    -- /bin/bash -lc 'test -f /opt/workcell/host-injections/manifest.json && grep -q "Workcell masks workspace control files inside the boundary." /workspace/AGENTS.md && test ! -d /workspace/AGENTS.md'; then
+    echo "Expected live launcher run to stage an injection manifest and mount /workspace/AGENTS.md as a file" >&2
+    exit 1
+  fi
   if [[ -x /opt/homebrew/bin/colima ]]; then
     /opt/homebrew/bin/colima delete --profile "${LIVE_DEBUG_PROFILE_NAME}" --force >/dev/null 2>&1 || true
   else
@@ -2700,6 +3084,70 @@ EOF
     /usr/local/bin/colima delete --profile "${AUDIT_RESTORE_PROFILE_NAME}" --force >/dev/null 2>&1 || true
   fi
   rm -rf "${REAL_HOME}/.colima/${AUDIT_RESTORE_PROFILE_NAME}" "${REAL_HOME}/.colima/_lima/colima-${AUDIT_RESTORE_PROFILE_NAME}"
+
+  STRICT_REFRESH_PROFILE_NAME="workcell-strict-refresh-$$"
+  STRICT_REFRESH_DIR="${REAL_HOME}/.colima/${STRICT_REFRESH_PROFILE_NAME}"
+  mkdir -p "${STRICT_REFRESH_DIR}"
+  printf '%s\n' "${NONGIT_WORKSPACE}" >"${STRICT_REFRESH_DIR}/workcell.managed"
+  cat >"${STRICT_REFRESH_DIR}/colima.yaml" <<'EOF'
+cpu: 4
+memory: 7
+disk: 60
+runtime: docker
+vmType: vz
+mountType: virtiofs
+EOF
+  printf 'image_id=stale-image\n' >"${STRICT_REFRESH_DIR}/workcell.image-ready"
+  printf 'timestamp=test event=launch workspace=%q\n' "${NONGIT_WORKSPACE}" >"${STRICT_REFRESH_DIR}/workcell.audit.log"
+  set +e
+  "${ROOT_DIR}/scripts/workcell" \
+    --test-fail-after-profile-refresh \
+    --agent codex \
+    --allow-nongit-workspace \
+    --workspace "${NONGIT_WORKSPACE}" \
+    --colima-profile "${STRICT_REFRESH_PROFILE_NAME}" \
+    --agent-arg --version >/tmp/workcell-strict-refresh-preflight.out 2>&1
+  strict_refresh_status=$?
+  set -e
+  if [[ "${strict_refresh_status}" -ne 2 ]]; then
+    echo "Expected strict-mode refresh preflight to fail with exit 2 before the test hook, got ${strict_refresh_status}" >&2
+    cat /tmp/workcell-strict-refresh-preflight.out >&2
+    exit 1
+  fi
+  grep -q "Refreshing managed Colima profile ${STRICT_REFRESH_PROFILE_NAME} to apply the requested reviewed VM resources." /tmp/workcell-strict-refresh-preflight.out
+  grep -q "No prepared runtime image is recorded for strict mode on profile ${STRICT_REFRESH_PROFILE_NAME}." /tmp/workcell-strict-refresh-preflight.out
+  grep -q "No VM or container was started." /tmp/workcell-strict-refresh-preflight.out
+  if grep -q 'Workcell test hook: forcing failure after managed profile refresh.' /tmp/workcell-strict-refresh-preflight.out; then
+    echo "Strict-mode refresh preflight should fail before the post-refresh test hook runs" >&2
+    exit 1
+  fi
+  set +e
+  "${ROOT_DIR}/scripts/workcell" \
+    --test-fail-after-profile-refresh \
+    --agent codex \
+    --prepare \
+    --allow-nongit-workspace \
+    --workspace "${NONGIT_WORKSPACE}" \
+    --colima-profile "${STRICT_REFRESH_PROFILE_NAME}" \
+    --agent-arg --version >/tmp/workcell-strict-refresh-prepare.out 2>&1
+  strict_refresh_prepare_status=$?
+  set -e
+  if [[ "${strict_refresh_prepare_status}" -ne 88 ]]; then
+    echo "Expected follow-up strict prepare to reach the post-refresh hook instead of tripping unmanaged-profile preflight, got ${strict_refresh_prepare_status}" >&2
+    cat /tmp/workcell-strict-refresh-prepare.out >&2
+    exit 1
+  fi
+  grep -q 'Workcell test hook: forcing failure after managed profile refresh.' /tmp/workcell-strict-refresh-prepare.out
+  if grep -q 'Refusing to reuse unmanaged Colima profile' /tmp/workcell-strict-refresh-prepare.out; then
+    echo "Strict-mode refresh preflight should leave the profile recoverable by --prepare" >&2
+    exit 1
+  fi
+  if [[ -x /opt/homebrew/bin/colima ]]; then
+    /opt/homebrew/bin/colima delete --profile "${STRICT_REFRESH_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+  else
+    /usr/local/bin/colima delete --profile "${STRICT_REFRESH_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+  fi
+  rm -rf "${REAL_HOME}/.colima/${STRICT_REFRESH_PROFILE_NAME}" "${REAL_HOME}/.colima/_lima/colima-${STRICT_REFRESH_PROFILE_NAME}"
 fi
 
 UNMANAGED_PROFILE_NAME="workcell-unmanaged-verify-$$"
@@ -2916,10 +3364,228 @@ if gemini_settings.get("tools", {}).get("allowed") != []:
     raise SystemExit("Gemini adapter must not seed allowed tools")
 if gemini_settings.get("mcp", {}).get("allowed") != []:
     raise SystemExit("Gemini adapter must not seed allowed MCP servers")
+if "selectedType" in gemini_settings.get("security", {}).get("auth", {}):
+    raise SystemExit("Gemini adapter baseline must not hardcode a selected auth type")
+if gemini_settings.get("security", {}).get("folderTrust", {}).get("enabled") is not False:
+    raise SystemExit("Gemini adapter must disable Gemini folder trust inside the managed runtime")
 if gemini_settings.get("tools", {}).get("shell", {}).get("enableInteractiveShell") is not False:
     raise SystemExit("Gemini adapter must disable interactive shell mode")
 if not isinstance(gemini_settings.get("advanced", {}).get("excludedEnvVars"), list):
     raise SystemExit("Gemini adapter must exclude sensitive environment variables")
 PY
+
+GEMINI_AUTH_SELECTION_HARNESS="$(mktemp)"
+{
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_trim_leading_whitespace
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_trim_trailing_whitespace
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_env_file_assignment_value
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_gemini_env_key_is_supported
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_validate_gemini_env_file_syntax
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_env_file_boolean_value
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_env_file_value_is_true
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_gemini_env_has_project_config
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_gemini_env_has_location_config
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_validate_gemini_env_auth_config
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_validate_json_object_file
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_validate_gemini_projects_config
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_gemini_selected_auth_type_from_env_file
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_gemini_selected_auth_type
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_set_gemini_selected_auth_type
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_set_gemini_folder_trust_enabled
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_render_gemini_trusted_folders
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_target_is_allowed
+  cat <<'EOF'
+set -euo pipefail
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+workcell_die() {
+  printf '%s\n' "$*" >&2
+  exit 1
+}
+
+expect_auth_type() {
+  local env_contents="$1"
+  local oauth_present="$2"
+  local expected="$3"
+  local env_path="${TMP_DIR}/gemini.env"
+  local oauth_path="${TMP_DIR}/oauth.json"
+  local selected=""
+
+  rm -f "${env_path}" "${oauth_path}"
+  if [[ -n "${env_contents}" ]]; then
+    printf '%s\n' "${env_contents}" >"${env_path}"
+  fi
+  if [[ "${oauth_present}" == "1" ]]; then
+    printf '{}\n' >"${oauth_path}"
+  fi
+
+  selected="$(workcell_gemini_selected_auth_type "${env_path}" "${oauth_path}")"
+  if [[ "${selected}" != "${expected}" ]]; then
+    echo "Expected Gemini auth type ${expected}, got ${selected}" >&2
+    exit 1
+  fi
+}
+
+expect_auth_type 'GEMINI_API_KEY=test-key' 0 'gemini-api-key'
+expect_auth_type ' export GEMINI_API_KEY = "quoted-key" # comment' 0 'gemini-api-key'
+expect_auth_type $'GOOGLE_GENAI_USE_GCA=true\nGEMINI_API_KEY=test-key' 0 'oauth-personal'
+expect_auth_type $'GOOGLE_GENAI_USE_GCA="true" # comment\nGOOGLE_CLOUD_PROJECT=my-proj' 0 'oauth-personal'
+expect_auth_type $'GOOGLE_GENAI_USE_VERTEXAI="true" # comment\nGOOGLE_CLOUD_PROJECT=my-proj\nGOOGLE_CLOUD_LOCATION="us-central1" # comment' 0 'vertex-ai'
+expect_auth_type $'GOOGLE_GENAI_USE_VERTEXAI=true\nGOOGLE_API_KEY=vertex-key' 0 'vertex-ai'
+expect_auth_type $'GEMINI_API_KEY=test-key\nGOOGLE_CLOUD_PROJECT=my-proj' 0 'gemini-api-key'
+expect_auth_type '' 1 'oauth-personal'
+
+printf 'GOOGLE_API_KEY=test-key\n' >"${TMP_DIR}/google-api-key-only.env"
+if workcell_gemini_selected_auth_type "${TMP_DIR}/google-api-key-only.env" "${TMP_DIR}/missing-oauth.json" >/dev/null 2>&1; then
+  echo "Expected bare GOOGLE_API_KEY to stay unset until Gemini Vertex auth is explicitly selected" >&2
+  exit 1
+fi
+
+if workcell_gemini_selected_auth_type "${TMP_DIR}/missing.env" "${TMP_DIR}/missing-oauth.json" >/dev/null 2>&1; then
+  echo "Expected Gemini auth selection to stay unset when no credential material is present" >&2
+  exit 1
+fi
+
+printf 'GOOGLE_GENAI_USE_GCA=maybe\n' >"${TMP_DIR}/invalid-bool.env"
+if workcell_validate_gemini_env_auth_config "${TMP_DIR}/invalid-bool.env" >/tmp/gemini-invalid-bool.stdout 2>/tmp/gemini-invalid-bool.stderr; then
+  echo "Expected invalid Gemini auth booleans to be rejected" >&2
+  exit 1
+fi
+grep -q 'Invalid boolean in Gemini auth env file' /tmp/gemini-invalid-bool.stderr
+
+printf 'GOOGLE_GENAI_USE_VERTEXAI true\n' >"${TMP_DIR}/malformed.env"
+if workcell_validate_gemini_env_auth_config "${TMP_DIR}/malformed.env" >/tmp/gemini-malformed.stdout 2>/tmp/gemini-malformed.stderr; then
+  echo "Expected malformed Gemini auth env syntax to be rejected" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-malformed.stderr
+
+printf 'UNSUPPORTED_KEY=test\n' >"${TMP_DIR}/unsupported.env"
+if workcell_validate_gemini_env_auth_config "${TMP_DIR}/unsupported.env" >/tmp/gemini-unsupported.stdout 2>/tmp/gemini-unsupported.stderr; then
+  echo "Expected unsupported Gemini auth env keys to be rejected" >&2
+  exit 1
+fi
+grep -q 'Unsupported key in Gemini auth env file' /tmp/gemini-unsupported.stderr
+
+printf 'GOOGLE_GENAI_USE_GCA=true\nGOOGLE_GENAI_USE_VERTEXAI=true\n' >"${TMP_DIR}/conflicting-selectors.env"
+if workcell_validate_gemini_env_auth_config "${TMP_DIR}/conflicting-selectors.env" >/tmp/gemini-conflicting.stdout 2>/tmp/gemini-conflicting.stderr; then
+  echo "Expected contradictory Gemini auth selectors to be rejected" >&2
+  exit 1
+fi
+grep -q 'enables both GOOGLE_GENAI_USE_GCA and GOOGLE_GENAI_USE_VERTEXAI' /tmp/gemini-conflicting.stderr
+
+printf 'GOOGLE_GENAI_USE_VERTEXAI=true\nGOOGLE_API_KEY=vertex-key\n' >"${TMP_DIR}/vertex-express.env"
+if ! workcell_validate_gemini_env_auth_config "${TMP_DIR}/vertex-express.env" >/tmp/gemini-vertex-express.stdout 2>/tmp/gemini-vertex-express.stderr; then
+  echo "Expected Gemini Vertex express-mode env config to validate" >&2
+  cat /tmp/gemini-vertex-express.stderr >&2
+  exit 1
+fi
+
+printf 'GOOGLE_API_KEY=vertex-key\n' >"${TMP_DIR}/google-api-key-only.env"
+if workcell_validate_gemini_env_auth_config "${TMP_DIR}/google-api-key-only.env" >/tmp/gemini-google-api-key.stdout 2>/tmp/gemini-google-api-key.stderr; then
+  echo "Expected bare GOOGLE_API_KEY to be rejected without GOOGLE_GENAI_USE_VERTEXAI=true" >&2
+  exit 1
+fi
+grep -q 'sets GOOGLE_API_KEY without GOOGLE_GENAI_USE_VERTEXAI=true' /tmp/gemini-google-api-key.stderr
+
+printf 'GOOGLE_CLOUD_LOCATION=us-central1\n' >"${TMP_DIR}/location-only.env"
+if workcell_validate_gemini_env_auth_config "${TMP_DIR}/location-only.env" >/tmp/gemini-location-only.stdout 2>/tmp/gemini-location-only.stderr; then
+  echo "Expected location-only Gemini env config to be rejected" >&2
+  exit 1
+fi
+grep -q 'sets a Google Cloud location without a project' /tmp/gemini-location-only.stderr
+
+printf 'GOOGLE_CLOUD_PROJECT=my-proj\n' >"${TMP_DIR}/project-only.env"
+if workcell_validate_gemini_env_auth_config "${TMP_DIR}/project-only.env" >/tmp/gemini-project-only.stdout 2>/tmp/gemini-project-only.stderr; then
+  echo "Expected project-only Gemini env config to be rejected" >&2
+  exit 1
+fi
+grep -q 'does not configure a supported Gemini auth mode' /tmp/gemini-project-only.stderr
+
+SETTINGS_PATH="${TMP_DIR}/settings.json"
+cat >"${SETTINGS_PATH}" <<'JSON'
+{"security":{"folderTrust":{"enabled":false}}}
+JSON
+workcell_set_gemini_selected_auth_type "${SETTINGS_PATH}" "gemini-api-key"
+python3 - "${SETTINGS_PATH}" <<'PY'
+import json
+import sys
+
+settings = json.load(open(sys.argv[1], encoding="utf-8"))
+if settings.get("security", {}).get("auth", {}).get("selectedType") != "gemini-api-key":
+    raise SystemExit("Gemini selected auth type should be persisted into the seeded settings")
+if settings.get("security", {}).get("folderTrust", {}).get("enabled") is not False:
+    raise SystemExit("Gemini selected auth type update should preserve existing settings")
+PY
+workcell_set_gemini_folder_trust_enabled "${SETTINGS_PATH}" true
+python3 - "${SETTINGS_PATH}" <<'PY'
+import json
+import sys
+
+settings = json.load(open(sys.argv[1], encoding="utf-8"))
+if settings.get("security", {}).get("folderTrust", {}).get("enabled") is not True:
+    raise SystemExit("Gemini folder-trust helper should restore trust prompts for breakglass sessions")
+PY
+workcell_set_gemini_folder_trust_enabled "${SETTINGS_PATH}" false
+
+TRUSTED_FOLDERS_PATH="${TMP_DIR}/trustedFolders.json"
+TRUSTED_WORKSPACE=$'/workspace/quoted"path\\segment'
+workcell_render_gemini_trusted_folders "${TRUSTED_FOLDERS_PATH}" "${TRUSTED_WORKSPACE}"
+python3 - "${TRUSTED_FOLDERS_PATH}" "${TRUSTED_WORKSPACE}" <<'PY'
+import json
+import sys
+
+trusted = json.load(open(sys.argv[1], encoding="utf-8"))
+expected = {sys.argv[2]: "TRUST_FOLDER"}
+if trusted != expected:
+    raise SystemExit(f"Expected trustedFolders.json to preserve the exact workspace path, got {trusted!r}")
+PY
+
+printf '{"projects":[]}\n' >"${TMP_DIR}/invalid-projects.json"
+if workcell_validate_gemini_projects_config "${TMP_DIR}/invalid-projects.json" >/tmp/gemini-invalid-projects.stdout 2>/tmp/gemini-invalid-projects.stderr; then
+  echo "Expected invalid Gemini projects config to be rejected" >&2
+  exit 1
+fi
+grep -q 'Gemini projects config must contain a JSON object with an object-valued projects field' /tmp/gemini-invalid-projects.stderr
+
+printf '{"projects":{}}\n' >"${TMP_DIR}/valid-projects.json"
+if ! workcell_validate_gemini_projects_config "${TMP_DIR}/valid-projects.json" >/tmp/gemini-valid-projects.stdout 2>/tmp/gemini-valid-projects.stderr; then
+  echo "Expected valid Gemini projects config to be accepted" >&2
+  cat /tmp/gemini-valid-projects.stderr >&2
+  exit 1
+fi
+
+if workcell_target_is_allowed '/state/agent-home/.gemini/trustedFolders.json'; then
+  echo "Expected runtime manifest guard to reserve Gemini trustedFolders.json" >&2
+  exit 1
+fi
+EOF
+} >"${GEMINI_AUTH_SELECTION_HARNESS}"
+/bin/bash "${GEMINI_AUTH_SELECTION_HARNESS}"
+rm -f "${GEMINI_AUTH_SELECTION_HARNESS}"
+
+if ! rg -q 'trustedFolders\.json' "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
+  echo "Expected Gemini home seeding to provision trustedFolders.json" >&2
+  exit 1
+fi
 
 echo "Workcell invariant verification passed."

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3657,7 +3657,8 @@ if trusted != expected:
 PY
 
 printf '{"projects":[]}\n' >"${TMP_DIR}/invalid-projects.json"
-if workcell_validate_gemini_projects_config "${TMP_DIR}/invalid-projects.json" >/tmp/gemini-invalid-projects.stdout 2>/tmp/gemini-invalid-projects.stderr; then
+if expect_fatal_function_failure /tmp/gemini-invalid-projects.stdout /tmp/gemini-invalid-projects.stderr \
+  workcell_validate_gemini_projects_config "${TMP_DIR}/invalid-projects.json"; then
   echo "Expected invalid Gemini projects config to be rejected" >&2
   exit 1
 fi

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -8,11 +8,10 @@ report_verify_invariants_failure() {
   local command="$3"
   local caller_frame=""
 
-  if [[ "${FUNCNAME[1]:-}" == "rg" ]]; then
+  if [[ "${FUNCNAME[1]:-}" == "rg" ]] || [[ "${VERIFY_INVARIANTS_EXPECTED_FAILURE:-0}" -eq 1 ]]; then
     return 0
   fi
 
-  trap - ERR
   caller_frame="$(caller 0 2>/dev/null || true)"
   if [[ -n "${caller_frame}" ]]; then
     echo "verify-invariants failed with status ${status} at ${caller_frame}: ${command}" >&2
@@ -22,6 +21,29 @@ report_verify_invariants_failure() {
 }
 
 trap 'report_verify_invariants_failure "$?" "${LINENO}" "${BASH_COMMAND}"' ERR
+
+assert_output_did_not_start_colima() {
+  local output_path="$1"
+  local context="$2"
+
+  if grep -Eq 'Starting managed Colima profile|starting colima' "${output_path}"; then
+    echo "${context}" >&2
+    cat "${output_path}" >&2
+    exit 1
+  fi
+}
+
+assert_output_contains() {
+  local needle="$1"
+  local output_path="$2"
+  local context="$3"
+
+  if ! grep -Fq -- "${needle}" "${output_path}"; then
+    echo "${context}" >&2
+    cat "${output_path}" >&2
+    exit 1
+  fi
+}
 
 readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 export PATH="${TRUSTED_HOST_PATH}"
@@ -1759,12 +1781,17 @@ if "${ROOT_DIR}/scripts/workcell" \
   echo "Expected strict mode without a prepared image marker to fail fast before launch" >&2
   exit 1
 fi
-grep -q "No prepared runtime image is recorded for strict mode" /tmp/workcell-strict-preflight.out
-grep -q -- '--prepare' /tmp/workcell-strict-preflight.out
-if grep -q "starting colima" /tmp/workcell-strict-preflight.out; then
-  echo "Strict preflight should fail before Colima startup when the prepared image marker is absent" >&2
-  exit 1
-fi
+assert_output_contains \
+  "No prepared runtime image is recorded for strict mode" \
+  /tmp/workcell-strict-preflight.out \
+  "Expected strict preflight output to explain that the prepared image marker is missing"
+assert_output_contains \
+  "--prepare" \
+  /tmp/workcell-strict-preflight.out \
+  "Expected strict preflight output to recommend a strict prepare command"
+assert_output_did_not_start_colima \
+  /tmp/workcell-strict-preflight.out \
+  "Strict preflight should fail before Colima startup when the prepared image marker is absent"
 
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent codex \
@@ -3137,6 +3164,7 @@ mountType: virtiofs
 EOF
   printf 'image_id=stale-image\n' >"${STRICT_REFRESH_DIR}/workcell.image-ready"
   printf 'timestamp=test event=launch workspace=%q\n' "${NONGIT_WORKSPACE}" >"${STRICT_REFRESH_DIR}/workcell.audit.log"
+  VERIFY_INVARIANTS_EXPECTED_FAILURE=1
   set +e
   "${ROOT_DIR}/scripts/workcell" \
     --test-fail-after-profile-refresh \
@@ -3147,6 +3175,7 @@ EOF
     --agent-arg --version >/tmp/workcell-strict-refresh-preflight.out 2>&1
   strict_refresh_status=$?
   set -e
+  VERIFY_INVARIANTS_EXPECTED_FAILURE=0
   if [[ "${strict_refresh_status}" -ne 2 ]]; then
     echo "Expected strict-mode refresh preflight to fail with exit 2 before the test hook, got ${strict_refresh_status}" >&2
     cat /tmp/workcell-strict-refresh-preflight.out >&2
@@ -3155,10 +3184,14 @@ EOF
   grep -q "Refreshing managed Colima profile ${STRICT_REFRESH_PROFILE_NAME} to apply the requested reviewed VM resources." /tmp/workcell-strict-refresh-preflight.out
   grep -q "No prepared runtime image is recorded for strict mode on profile ${STRICT_REFRESH_PROFILE_NAME}." /tmp/workcell-strict-refresh-preflight.out
   grep -q "No VM or container was started." /tmp/workcell-strict-refresh-preflight.out
+  assert_output_did_not_start_colima \
+    /tmp/workcell-strict-refresh-preflight.out \
+    "Strict-mode refresh preflight should fail before Colima startup when the prepared image marker is absent"
   if grep -q 'Workcell test hook: forcing failure after managed profile refresh.' /tmp/workcell-strict-refresh-preflight.out; then
     echo "Strict-mode refresh preflight should fail before the post-refresh test hook runs" >&2
     exit 1
   fi
+  VERIFY_INVARIANTS_EXPECTED_FAILURE=1
   set +e
   "${ROOT_DIR}/scripts/workcell" \
     --test-fail-after-profile-refresh \
@@ -3170,6 +3203,7 @@ EOF
     --agent-arg --version >/tmp/workcell-strict-refresh-prepare.out 2>&1
   strict_refresh_prepare_status=$?
   set -e
+  VERIFY_INVARIANTS_EXPECTED_FAILURE=0
   if [[ "${strict_refresh_prepare_status}" -ne 88 ]]; then
     echo "Expected follow-up strict prepare to reach the post-refresh hook instead of tripping unmanaged-profile preflight, got ${strict_refresh_prepare_status}" >&2
     cat /tmp/workcell-strict-refresh-prepare.out >&2

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1979,6 +1979,50 @@ grep -q '^provider_auth_mode=gemini_env$' /tmp/workcell-auth-status-gemini.out
 grep -q '^provider_auth_modes=gemini_env,gcloud_adc$' /tmp/workcell-auth-status-gemini.out
 grep -q '^shared_auth_modes=github_hosts$' /tmp/workcell-auth-status-gemini.out
 grep -q '^github_auth_present=1$' /tmp/workcell-auth-status-gemini.out
+GEMINI_AUTH_FAILURE_HARNESS="$(mktemp)"
+extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" csv_contains_value >"${GEMINI_AUTH_FAILURE_HARNESS}"
+printf '\n' >>"${GEMINI_AUTH_FAILURE_HARNESS}"
+extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" provider_auth_modes >>"${GEMINI_AUTH_FAILURE_HARNESS}"
+printf '\n' >>"${GEMINI_AUTH_FAILURE_HARNESS}"
+extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" selected_provider_auth_mode >>"${GEMINI_AUTH_FAILURE_HARNESS}"
+printf '\n' >>"${GEMINI_AUTH_FAILURE_HARNESS}"
+extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" fail_fast_for_missing_gemini_auth >>"${GEMINI_AUTH_FAILURE_HARNESS}"
+cat >>"${GEMINI_AUTH_FAILURE_HARNESS}" <<'EOF'
+AGENT=gemini
+PREPARE_ONLY=0
+ALLOW_ARBITRARY_COMMAND=0
+DRY_RUN=0
+INJECTION_POLICY=/tmp/no-gemini-policy.toml
+WORKSPACE=/tmp/workcell-gemini-workspace
+INJECTION_CREDENTIAL_KEYS=github_hosts
+
+status=0
+if ( fail_fast_for_missing_gemini_auth ) >/tmp/workcell-gemini-auth-harness.stdout 2>/tmp/workcell-gemini-auth-harness.stderr; then
+  echo "Expected Gemini missing-auth harness to fail fast" >&2
+  exit 1
+else
+  status=$?
+fi
+if [[ "${status}" -ne 2 ]]; then
+  echo "Expected Gemini missing-auth harness to exit 2, got ${status}" >&2
+  exit 1
+fi
+grep -q 'Gemini auth is not configured for this session.' /tmp/workcell-gemini-auth-harness.stderr
+grep -q 'Update /tmp/no-gemini-policy.toml to include credentials.gemini_env, credentials.gemini_oauth, or credentials.gcloud_adc.' /tmp/workcell-gemini-auth-harness.stderr
+grep -q '^Next step: workcell --auth-status --agent gemini --workspace /tmp/workcell-gemini-workspace$' /tmp/workcell-gemini-auth-harness.stderr
+
+DRY_RUN=1
+if ! ( fail_fast_for_missing_gemini_auth ) >/tmp/workcell-gemini-auth-dry-run.stdout 2>/tmp/workcell-gemini-auth-dry-run.stderr; then
+  echo "Expected Gemini missing-auth harness to skip dry-run" >&2
+  exit 1
+fi
+if [[ -s /tmp/workcell-gemini-auth-dry-run.stderr ]]; then
+  echo "Expected Gemini missing-auth dry-run harness to stay silent" >&2
+  exit 1
+fi
+EOF
+/bin/bash "${GEMINI_AUTH_FAILURE_HARNESS}"
+rm -f "${GEMINI_AUTH_FAILURE_HARNESS}"
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent gemini \
   --workspace "${ROOT_DIR}" \

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2037,6 +2037,45 @@ EOF
 } >"${GEMINI_AUTH_FAILURE_HARNESS}"
 /bin/bash "${GEMINI_AUTH_FAILURE_HARNESS}"
 rm -f "${GEMINI_AUTH_FAILURE_HARNESS}"
+PROFILE_PROCESS_MATCH_HARNESS="$(mktemp)"
+{
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" profile_process_pids
+  cat <<'EOF'
+set -euo pipefail
+
+HARNESS_BIN="$(mktemp -d)"
+trap 'rm -rf "${HARNESS_BIN}"' EXIT
+
+cat >"${HARNESS_BIN}/pgrep" <<'PGREP'
+#!/bin/sh
+printf '49909\n49991\n60000\n'
+PGREP
+cat >"${HARNESS_BIN}/ps" <<'PS'
+#!/bin/sh
+case "$2" in
+  49909)
+    printf '%s\n' '/opt/homebrew/bin/limactl hostagent --pidfile /Users/omkharanarasaratnam/.colima/_lima/colima-workcell-workcell-ac42b1dc/ha.pid --socket /Users/omkharanarasaratnam/.colima/_lima/colima-workcell-workcell-ac42b1dc/ha.sock --guestagent /opt/homebrew/share/lima/lima-guestagent.Linux-aarch64.gz colima-workcell-workcell-ac42b1dc'
+    ;;
+  49991)
+    printf '%s\n' 'ssh: /Users/omkharanarasaratnam/.colima/_lima/colima-workcell-workcell-ac42b1dc/ssh.sock [mux]'
+    ;;
+  60000)
+    printf '%s\n' '/opt/homebrew/bin/limactl hostagent --pidfile /Users/omkharanarasaratnam/.colima/_lima/colima-other/ha.pid --socket /Users/omkharanarasaratnam/.colima/_lima/colima-other/ha.sock colima-other'
+    ;;
+esac
+PS
+chmod +x "${HARNESS_BIN}/pgrep" "${HARNESS_BIN}/ps"
+
+PATH="${HARNESS_BIN}:${PATH}"
+matched="$(profile_process_pids workcell-workcell-ac42b1dc | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+if [[ "${matched}" != "49909 49991" ]]; then
+  echo "Expected profile_process_pids to return the stale hostagent and ssh mux, got: ${matched}" >&2
+  exit 1
+fi
+EOF
+} >"${PROFILE_PROCESS_MATCH_HARNESS}"
+/bin/bash "${PROFILE_PROCESS_MATCH_HARNESS}"
+rm -f "${PROFILE_PROCESS_MATCH_HARNESS}"
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent gemini \
   --workspace "${ROOT_DIR}" \

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1980,14 +1980,15 @@ grep -q '^provider_auth_modes=gemini_env,gcloud_adc$' /tmp/workcell-auth-status-
 grep -q '^shared_auth_modes=github_hosts$' /tmp/workcell-auth-status-gemini.out
 grep -q '^github_auth_present=1$' /tmp/workcell-auth-status-gemini.out
 GEMINI_AUTH_FAILURE_HARNESS="$(mktemp)"
-extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" csv_contains_value >"${GEMINI_AUTH_FAILURE_HARNESS}"
-printf '\n' >>"${GEMINI_AUTH_FAILURE_HARNESS}"
-extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" provider_auth_modes >>"${GEMINI_AUTH_FAILURE_HARNESS}"
-printf '\n' >>"${GEMINI_AUTH_FAILURE_HARNESS}"
-extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" selected_provider_auth_mode >>"${GEMINI_AUTH_FAILURE_HARNESS}"
-printf '\n' >>"${GEMINI_AUTH_FAILURE_HARNESS}"
-extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" fail_fast_for_missing_gemini_auth >>"${GEMINI_AUTH_FAILURE_HARNESS}"
-cat >>"${GEMINI_AUTH_FAILURE_HARNESS}" <<'EOF'
+{
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" csv_contains_value
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" provider_auth_modes
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" selected_provider_auth_mode
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" fail_fast_for_missing_gemini_auth
+  cat <<'EOF'
 AGENT=gemini
 PREPARE_ONLY=0
 ALLOW_ARBITRARY_COMMAND=0
@@ -2021,6 +2022,7 @@ if [[ -s /tmp/workcell-gemini-auth-dry-run.stderr ]]; then
   exit 1
 fi
 EOF
+} >"${GEMINI_AUTH_FAILURE_HARNESS}"
 /bin/bash "${GEMINI_AUTH_FAILURE_HARNESS}"
 rm -f "${GEMINI_AUTH_FAILURE_HARNESS}"
 if ! "${ROOT_DIR}/scripts/workcell" \

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3486,6 +3486,10 @@ GEMINI_AUTH_SELECTION_HARNESS="$(mktemp)"
   cat <<'EOF'
 set -Eeuo pipefail
 trap 'echo "Gemini auth selection harness failed at line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
+if [[ "${CI:-}" == "true" ]] || [[ "${CI:-}" == "1" ]]; then
+  export PS4='+ gemini-harness:${LINENO}: '
+  set -x
+fi
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3447,6 +3447,8 @@ if not isinstance(gemini_settings.get("advanced", {}).get("excludedEnvVars"), li
 PY
 
 GEMINI_AUTH_SELECTION_HARNESS="$(mktemp)"
+GEMINI_AUTH_SELECTION_STDOUT="$(mktemp)"
+GEMINI_AUTH_SELECTION_STDERR="$(mktemp)"
 {
   extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_trim_leading_whitespace
   printf '\n'
@@ -3657,8 +3659,15 @@ if workcell_target_is_allowed '/state/agent-home/.gemini/trustedFolders.json'; t
 fi
 EOF
 } >"${GEMINI_AUTH_SELECTION_HARNESS}"
-/bin/bash "${GEMINI_AUTH_SELECTION_HARNESS}"
+/bin/bash "${GEMINI_AUTH_SELECTION_HARNESS}" >"${GEMINI_AUTH_SELECTION_STDOUT}" 2>"${GEMINI_AUTH_SELECTION_STDERR}" || {
+  echo "Gemini auth selection harness stdout (tail):" >&2
+  tail -n 200 "${GEMINI_AUTH_SELECTION_STDOUT}" >&2 || true
+  echo "Gemini auth selection harness stderr (tail):" >&2
+  tail -n 200 "${GEMINI_AUTH_SELECTION_STDERR}" >&2 || true
+  exit 1
+}
 rm -f "${GEMINI_AUTH_SELECTION_HARNESS}"
+rm -f "${GEMINI_AUTH_SELECTION_STDOUT}" "${GEMINI_AUTH_SELECTION_STDERR}"
 
 if ! rg -q 'trustedFolders\.json' "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
   echo "Expected Gemini home seeding to provision trustedFolders.json" >&2

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1774,28 +1774,31 @@ test "$(file_mode_octal "${DEBUG_LOG_CAPTURE}")" = "600"
 grep -q 'Workcell warning: full host-persisted debug log capture is enabled for this session:' /tmp/workcell-debug-log.out
 grep -q 'execution_path=' "${DEBUG_LOG_CAPTURE}"
 RUN_COMMAND_DEBUG_FAILURE_HARNESS="${BARRIER_VERIFY_ROOT}/debug/run-command-debug-failure.sh"
-RUN_COMMAND_DEBUG_FAILURE_LOG="${BARRIER_VERIFY_ROOT}/debug/run-command-debug-failure.log"
+RUN_COMMAND_DEBUG_FAILURE_CAPTURE="${BARRIER_VERIFY_ROOT}/debug/run-command-debug-failure.log"
+RUN_COMMAND_DEBUG_FAILURE_PERSISTED_LOG="${BARRIER_VERIFY_ROOT}/debug/run-command-debug-failure.persisted.log"
 extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" run_command_with_debug_log >"${RUN_COMMAND_DEBUG_FAILURE_HARNESS}"
 cat >>"${RUN_COMMAND_DEBUG_FAILURE_HARNESS}" <<EOF
 set -euo pipefail
 LOG_LEVEL=debug
-DEBUG_LOG_PATH=""
+DEBUG_LOG_PATH="${RUN_COMMAND_DEBUG_FAILURE_PERSISTED_LOG}"
 COLIMA_PROFILE="${STRICT_PREFLIGHT_PROFILE}"
 PREPARE_ONLY=0
 AGENT=codex
 BUILD_STATUS=0
-run_command_with_debug_log runtime-build bash -lc 'echo debug-pipeline-failure >&2; exit 23' || BUILD_STATUS=\$?
+exec > >(tee -a "${RUN_COMMAND_DEBUG_FAILURE_PERSISTED_LOG}") 2>&1
+run_command_with_debug_log runtime-build /bin/bash -lc 'echo debug-pipeline-failure >&2; exit 23' || BUILD_STATUS=\$?
 printf 'build_status=%s\n' "\${BUILD_STATUS}"
 EOF
 chmod +x "${RUN_COMMAND_DEBUG_FAILURE_HARNESS}"
-if ! bash "${RUN_COMMAND_DEBUG_FAILURE_HARNESS}" >"${RUN_COMMAND_DEBUG_FAILURE_LOG}" 2>&1; then
+if ! /bin/bash "${RUN_COMMAND_DEBUG_FAILURE_HARNESS}" >"${RUN_COMMAND_DEBUG_FAILURE_CAPTURE}" 2>&1; then
   echo "Expected debug-mode command failures to return control to the caller" >&2
-  cat "${RUN_COMMAND_DEBUG_FAILURE_LOG}" >&2
+  cat "${RUN_COMMAND_DEBUG_FAILURE_CAPTURE}" >&2
   exit 1
 fi
-grep -q '^build_status=23$' "${RUN_COMMAND_DEBUG_FAILURE_LOG}"
-grep -q 'Workcell runtime-build failed\.' "${RUN_COMMAND_DEBUG_FAILURE_LOG}"
-grep -q 'debug-pipeline-failure' "${RUN_COMMAND_DEBUG_FAILURE_LOG}"
+grep -q '^build_status=23$' "${RUN_COMMAND_DEBUG_FAILURE_CAPTURE}"
+grep -q 'Workcell runtime-build failed\.' "${RUN_COMMAND_DEBUG_FAILURE_CAPTURE}"
+grep -q 'debug-pipeline-failure' "${RUN_COMMAND_DEBUG_FAILURE_CAPTURE}"
+test "$(grep -c '^debug-pipeline-failure$' "${RUN_COMMAND_DEBUG_FAILURE_PERSISTED_LOG}")" = "1"
 RUN_COMMAND_DEBUG_DUP_HARNESS="${BARRIER_VERIFY_ROOT}/debug/run-command-debug-dup.sh"
 RUN_COMMAND_DEBUG_DUP_LOG="${BARRIER_VERIFY_ROOT}/debug/run-command-debug-dup.log"
 extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" run_command_with_debug_log >"${RUN_COMMAND_DEBUG_DUP_HARNESS}"
@@ -1807,10 +1810,10 @@ COLIMA_PROFILE="${STRICT_PREFLIGHT_PROFILE}"
 PREPARE_ONLY=0
 AGENT=codex
 exec > >(tee -a "${RUN_COMMAND_DEBUG_DUP_LOG}") 2>&1
-run_command_with_debug_log runtime-build bash -lc 'echo workcell-debug-unique-line >&2'
+run_command_with_debug_log runtime-build /bin/bash -lc 'echo workcell-debug-unique-line >&2'
 EOF
 chmod +x "${RUN_COMMAND_DEBUG_DUP_HARNESS}"
-if ! bash "${RUN_COMMAND_DEBUG_DUP_HARNESS}" >/tmp/workcell-run-command-debug-dup.out 2>&1; then
+if ! /bin/bash "${RUN_COMMAND_DEBUG_DUP_HARNESS}" >/tmp/workcell-run-command-debug-dup.out 2>&1; then
   echo "Expected debug-mode log duplication harness to succeed" >&2
   cat /tmp/workcell-run-command-debug-dup.out >&2
   exit 1

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1484,6 +1484,25 @@ selected_provider_auth_mode() {
   fi
 }
 
+fail_fast_for_missing_gemini_auth() {
+  if [[ "${AGENT}" != "gemini" ]] || [[ "${PREPARE_ONLY}" -eq 1 ]] || [[ "${ALLOW_ARBITRARY_COMMAND}" -eq 1 ]] || [[ "${DRY_RUN}" -eq 1 ]]; then
+    return 0
+  fi
+
+  if [[ "$(selected_provider_auth_mode)" != "none" ]]; then
+    return 0
+  fi
+
+  echo "Gemini auth is not configured for this session." >&2
+  if [[ -n "${INJECTION_POLICY}" ]]; then
+    echo "Update ${INJECTION_POLICY} to include credentials.gemini_env, credentials.gemini_oauth, or credentials.gcloud_adc." >&2
+  else
+    echo "Create $(default_injection_policy_path) or pass --injection-policy PATH with credentials.gemini_env, credentials.gemini_oauth, or credentials.gcloud_adc." >&2
+  fi
+  printf 'Next step: workcell --auth-status --agent gemini --workspace %q\n' "${WORKSPACE}" >&2
+  exit 2
+}
+
 print_injection_status() {
   if [[ -z "${INJECTION_POLICY_SHA256}" ]]; then
     printf 'injection_policy=none\n'
@@ -1951,7 +1970,7 @@ run_command_with_debug_log() {
       colima-start)
         case "${phase}" in
           start)
-            echo "Starting managed Colima profile ${COLIMA_PROFILE}. This can take a moment on first use." >&2
+            echo "Starting managed Colima profile ${COLIMA_PROFILE}. This can take a moment, especially on first use." >&2
             ;;
           heartbeat)
             echo "Workcell is still starting Colima for profile ${COLIMA_PROFILE} (${elapsed} elapsed)." >&2
@@ -3269,6 +3288,8 @@ if [[ "${DOCTOR}" -eq 1 ]]; then
   fi
   exit 0
 fi
+
+fail_fast_for_missing_gemini_auth
 
 if [[ "${DRY_RUN}" -eq 0 ]]; then
   acquire_profile_lock "${COLIMA_PROFILE}"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -305,7 +305,7 @@ profile_lima_dir() {
 }
 
 run_host_colima() {
-  COLIMA_HOME="${COLIMA_STATE_ROOT}" "${HOST_COLIMA_BIN}" "$@"
+  HOME="${REAL_HOME}" COLIMA_HOME="${COLIMA_STATE_ROOT}" "${HOST_COLIMA_BIN}" "$@"
 }
 
 profile_process_pids() {
@@ -393,6 +393,7 @@ CONTROL_PLANE_SHADOW_ROOT=""
 INJECTION_BUNDLE_ROOT=""
 DIRECT_MOUNT_SPEC_PATH=""
 PROFILE_AUDIT_LOG_STASH=""
+PROFILE_WAS_REFRESHED=0
 PRESERVE_FAILED_PROFILE_STATE=0
 declare -a SHADOW_MOUNTS=()
 declare -a SHADOW_DEST_PATHS=()
@@ -782,6 +783,20 @@ maybe_fail_after_profile_refresh_for_tests() {
   exit 88
 }
 
+fail_missing_strict_prepared_image_prelaunch() {
+  if [[ "${PROFILE_WAS_REFRESHED:-0}" -eq 1 ]]; then
+    mkdir -p "${PROFILE_DIR}"
+    printf '%s\n' "${WORKSPACE}" >"${PROFILE_MARKER}"
+  fi
+  echo "No prepared runtime image is recorded for strict mode on profile ${COLIMA_PROFILE}." >&2
+  echo "This is expected on the first launch for a workspace or after profile cleanup." >&2
+  echo "Next step:" >&2
+  build_recommended_command 1 0 "${MODE}"
+  echo "That command seeds the prepared runtime image inside the isolated VM and then launches ${AGENT} in strict mode." >&2
+  echo "No VM or container was started." >&2
+  exit 2
+}
+
 container_assurance() {
   workcell_container_assurance "${CONTAINER_MUTABILITY}"
 }
@@ -1117,7 +1132,7 @@ default_injection_policy_path() {
 }
 
 default_injection_bundle_parent() {
-  resolve_host_path "${XDG_STATE_HOME:-${REAL_HOME}/.local/state}/workcell/tmp"
+  resolve_host_path "${REAL_HOME}/Library/Caches/colima/workcell-host-inputs"
 }
 
 cleanup_stale_injection_bundles() {
@@ -1179,7 +1194,10 @@ for candidate in root.iterdir():
             continue
     elif stat.st_mtime > cutoff:
         continue
-    shutil.rmtree(candidate, ignore_errors=False)
+    try:
+        shutil.rmtree(candidate, ignore_errors=False)
+    except FileNotFoundError:
+        continue
     try:
         sidecar = sidecar_path(candidate)
         if sidecar.is_file():
@@ -1206,9 +1224,18 @@ prepare_injection_direct_mounts() {
   local mount_spec_path="$1"
   local host_source=""
   local mount_path=""
+  local staged_root=""
+  local staged_source=""
+  local entry_hash=""
 
   DIRECT_SOURCE_MOUNTS=()
   [[ -f "${mount_spec_path}" ]] || return 0
+  [[ -n "${INJECTION_BUNDLE_ROOT}" ]] || {
+    echo "Direct input staging requires an injection bundle root." >&2
+    exit 2
+  }
+  staged_root="${INJECTION_BUNDLE_ROOT}/direct-mounts"
+  mkdir -p "${staged_root}"
 
   while IFS=$'\t' read -r host_source mount_path; do
     [[ -n "${host_source}" ]] || continue
@@ -1227,7 +1254,30 @@ prepare_injection_direct_mounts() {
         ;;
     esac
 
-    DIRECT_SOURCE_MOUNTS+=(-v "${host_source}:${mount_path}:ro")
+    entry_hash="$(
+      run_clean_host_command "${HOST_PYTHON3_BIN}" - "${host_source}" "${mount_path}" <<'PY'
+import hashlib
+import sys
+
+digest = hashlib.sha256()
+for value in sys.argv[1:]:
+    digest.update(value.encode("utf-8"))
+    digest.update(b"\0")
+print(digest.hexdigest()[:16])
+PY
+    )"
+    staged_source="${staged_root}/${entry_hash}"
+    rm -rf "${staged_source}"
+    if [[ -d "${host_source}" ]]; then
+      mkdir -p "${staged_source}"
+      cp -R "${host_source}/." "${staged_source}"
+    else
+      mkdir -p "$(dirname "${staged_source}")"
+      cp -f "${host_source}" "${staged_source}"
+    fi
+    chmod -R go-rwx "${staged_source}" 2>/dev/null || true
+
+    DIRECT_SOURCE_MOUNTS+=(-v "${staged_source}:${mount_path}:ro")
   done < <(
     run_clean_host_command "${HOST_PYTHON3_BIN}" - "${mount_spec_path}" <<'PY'
 import json
@@ -1502,9 +1552,6 @@ provider_auth_modes() {
       if csv_contains_value "${credential_keys}" "gemini_oauth"; then
         modes+=(gemini_oauth)
       fi
-      if csv_contains_value "${credential_keys}" "gcloud_adc"; then
-        modes+=(gcloud_adc)
-      fi
       ;;
   esac
 
@@ -1544,6 +1591,20 @@ github_auth_present() {
 
 selected_provider_auth_mode() {
   local auth_modes=""
+  local credential_keys="${INJECTION_CREDENTIAL_KEYS:-}"
+
+  if [[ "${AGENT:-}" == "gemini" ]]; then
+    if csv_contains_value "${credential_keys}" "gemini_env"; then
+      printf 'gemini_env\n'
+      return 0
+    fi
+    if csv_contains_value "${credential_keys}" "gemini_oauth"; then
+      printf 'gemini_oauth\n'
+      return 0
+    fi
+    printf 'none\n'
+    return 0
+  fi
 
   auth_modes="$(provider_auth_modes)"
   if [[ "${auth_modes}" == "none" ]]; then
@@ -1568,9 +1629,11 @@ fail_fast_for_missing_gemini_auth() {
 
   echo "Gemini auth is not configured for this session." >&2
   if [[ -n "${INJECTION_POLICY}" ]]; then
-    echo "Update ${INJECTION_POLICY} to include credentials.gemini_env, credentials.gemini_oauth, or credentials.gcloud_adc." >&2
+    echo "Update ${INJECTION_POLICY} to include credentials.gemini_env or credentials.gemini_oauth." >&2
+    echo "credentials.gcloud_adc only supplements Gemini Vertex auth that is explicitly configured through credentials.gemini_env." >&2
   else
-    echo "Create $(default_injection_policy_path) or pass --injection-policy PATH with credentials.gemini_env, credentials.gemini_oauth, or credentials.gcloud_adc." >&2
+    echo "Create $(default_injection_policy_path) or pass --injection-policy PATH with credentials.gemini_env or credentials.gemini_oauth." >&2
+    echo "credentials.gcloud_adc only supplements Gemini Vertex auth that is explicitly configured through credentials.gemini_env." >&2
   fi
   printf 'Next step: workcell --auth-status --agent gemini --workspace %q\n' "${WORKSPACE}" >&2
   exit 2
@@ -2206,7 +2269,6 @@ validate_colima_runtime_mounts() {
     expected = ARGV[1].sub(%r{/$}, "")
     profile = ARGV[2]
     home = File.expand_path(ENV.fetch("HOME"))
-    sandbox_home = ARGV[3].to_s.empty? ? nil : File.expand_path(ARGV[3])
 
     def canonicalize(path)
       expanded = File.expand_path(path)
@@ -2215,9 +2277,6 @@ validate_colima_runtime_mounts() {
 
     expected = canonicalize(expected)
     cache_roots = [canonicalize(File.join(home, "Library", "Caches", "colima"))]
-    if sandbox_home
-      cache_roots << canonicalize(File.join(sandbox_home, "Library", "Caches", "colima"))
-    end
     lima_mounts = lima["mounts"] || []
     writable_mounts = lima_mounts.select { |mount| mount["writable"] == true }
 
@@ -2243,7 +2302,7 @@ validate_colima_runtime_mounts() {
       warn "Colima profile #{profile} has an unexpected host mount: #{bad_mount["location"]}"
       exit 2
     end
-  ' "${lima_path}" "${workspace}" "${profile}" "${WORKCELL_DOCKER_HOME:-}"
+  ' "${lima_path}" "${workspace}" "${profile}"
 }
 
 validate_colima_profile_config() {
@@ -2869,10 +2928,6 @@ prepare_workspace_control_plane_shadow() {
   WORKSPACE_IMPORT_MOUNTS=()
   [[ "${mode}" == "breakglass" ]] && return 0
 
-  if [[ -n "${WORKCELL_DOCKER_HOME:-}" ]]; then
-    shadow_parent="${WORKCELL_DOCKER_HOME}/Library/Caches/colima/workcell-shadow"
-  fi
-
   mkdir -p "${shadow_parent}"
   CONTROL_PLANE_SHADOW_ROOT="$(mktemp -d "${shadow_parent}/shadow.XXXXXX")"
 
@@ -2930,7 +2985,7 @@ prepare_workspace_control_plane_shadow() {
 }
 
 bootstrap_endpoints() {
-  echo "auth.docker.io:443 docker.io:443 index.docker.io:443 registry-1.docker.io:443 production.cloudflare.docker.com:443 github.com:443 objects.githubusercontent.com:443 release-assets.githubusercontent.com:443 registry.npmjs.org:443 snapshot.debian.org:80 snapshot.debian.org:443"
+  echo "auth.docker.io:443 docker.io:443 index.docker.io:443 registry-1.docker.io:443 production.cloudflare.docker.com:443 github.com:443 objects.githubusercontent.com:443 release-assets.githubusercontent.com:443 registry.npmjs.org:443 snapshot.debian.org:80"
 }
 
 AGENT=""
@@ -2970,6 +3025,49 @@ ACK_ARBITRARY_COMMAND=0
 TEST_FAIL_AFTER_PROFILE_REFRESH=0
 declare -a AGENT_ARGS=()
 declare -a NORMALIZED_ARGS=()
+
+if [[ "${1:-}" == "--self-staging-probe" ]]; then
+  shift
+  AGENT="${1:-}"
+  WORKSPACE="${2:-}"
+  INJECTION_POLICY="${3:-}"
+  MODE="${4:-strict}"
+
+  [[ -n "${AGENT}" ]] || {
+    echo "--self-staging-probe requires AGENT WORKSPACE INJECTION_POLICY [MODE]" >&2
+    exit 2
+  }
+  [[ -n "${WORKSPACE}" ]] || {
+    echo "--self-staging-probe requires AGENT WORKSPACE INJECTION_POLICY [MODE]" >&2
+    exit 2
+  }
+  [[ -n "${INJECTION_POLICY}" ]] || {
+    echo "--self-staging-probe requires AGENT WORKSPACE INJECTION_POLICY [MODE]" >&2
+    exit 2
+  }
+
+  sanitize_host_docker_env
+  WORKSPACE="$(resolve_existing_directory_or_die "${WORKSPACE}")"
+  INJECTION_POLICY="$(resolve_host_path "${INJECTION_POLICY}")"
+  USE_DEFAULT_INJECTION_POLICY=0
+  prepare_injection_bundle "${AGENT}" "${MODE}"
+  prepare_workspace_control_plane_shadow "${WORKSPACE}" "${MODE}"
+
+  printf 'workcell_docker_home=%s\n' "${WORKCELL_DOCKER_HOME:-}"
+  printf 'injection_bundle_root=%s\n' "${INJECTION_BUNDLE_ROOT}"
+  printf 'shadow_root=%s\n' "${CONTROL_PLANE_SHADOW_ROOT}"
+  printf 'workspace=%s\n' "${WORKSPACE}"
+  for ((i = 0; i < ${#DIRECT_SOURCE_MOUNTS[@]}; i += 2)); do
+    printf 'direct_mount=%s\n' "${DIRECT_SOURCE_MOUNTS[i+1]}"
+  done
+  for ((i = 0; i < ${#SHADOW_MOUNTS[@]}; i += 2)); do
+    printf 'shadow_mount=%s\n' "${SHADOW_MOUNTS[i+1]}"
+  done
+  for ((i = 0; i < ${#WORKSPACE_IMPORT_MOUNTS[@]}; i += 2)); do
+    printf 'workspace_import_mount=%s\n' "${WORKSPACE_IMPORT_MOUNTS[i+1]}"
+  done
+  exit 0
+fi
 
 if [[ $# -gt 0 ]]; then
   normalize_cli_aliases "$@"
@@ -3405,13 +3503,7 @@ if [[ -n "${PROFILE_MARKER_WORKSPACE}" ]] && [[ "${PROFILE_MARKER_WORKSPACE}" !=
 fi
 
 if [[ "${DRY_RUN}" -eq 0 ]] && [[ "${MODE}" == "strict" ]] && [[ "${PREPARE}" -eq 0 ]] && [[ ! -f "${PROFILE_IMAGE_MARKER}" ]]; then
-  echo "No prepared runtime image is recorded for strict mode on profile ${COLIMA_PROFILE}." >&2
-  echo "This is expected on the first launch for a workspace or after profile cleanup." >&2
-  echo "Next step:" >&2
-  build_recommended_command 1 0 "${MODE}"
-  echo "That command seeds the prepared runtime image inside the isolated VM and then launches ${AGENT} in strict mode." >&2
-  echo "No VM or container was started." >&2
-  exit 2
+  fail_missing_strict_prepared_image_prelaunch
 fi
 
 if [[ "${DRY_RUN}" -eq 0 ]]; then
@@ -3422,7 +3514,7 @@ fi
 
 ALLOW_ENDPOINTS="$(dedupe_endpoint_list "$(provider_endpoints "${AGENT}") $(credential_extra_endpoints) ${INJECTION_EXTRA_ENDPOINTS} ${EXTRA_ENDPOINTS}")"
 if [[ "${CONTAINER_MUTABILITY}" == "ephemeral" ]]; then
-  ALLOW_ENDPOINTS="$(dedupe_endpoint_list "${ALLOW_ENDPOINTS} snapshot.debian.org:80 snapshot.debian.org:443")"
+  ALLOW_ENDPOINTS="$(dedupe_endpoint_list "${ALLOW_ENDPOINTS} snapshot.debian.org:80")"
 fi
 prepare_workspace_control_plane_shadow "${WORKSPACE}" "${MODE}"
 prepare_cache_mounts "${AGENT}" "${CACHE_PROFILE}" "${WORKSPACE}"
@@ -3575,19 +3667,29 @@ if [[ "${DRY_RUN}" -eq 1 ]]; then
 fi
 
 if [[ "${PROFILE_PREEXISTED}" -eq 1 ]]; then
-  if ! validate_colima_profile_config "${COLIMA_PROFILE}" "${WORKSPACE}" "${COLIMA_CPU}" "${COLIMA_MEMORY}" "${COLIMA_DISK}"; then
+  profile_config_path="${COLIMA_STATE_ROOT}/${COLIMA_PROFILE}/colima.yaml"
+  lima_config_path="${COLIMA_STATE_ROOT}/_lima/colima-${COLIMA_PROFILE}/lima.yaml"
+  if [[ ! -f "${profile_config_path}" ]] ||
+    ! validate_colima_profile_config "${COLIMA_PROFILE}" "${WORKSPACE}" "${COLIMA_CPU}" "${COLIMA_MEMORY}" "${COLIMA_DISK}"; then
     echo "Refreshing managed Colima profile ${COLIMA_PROFILE} to apply the requested reviewed VM resources." >&2
     stash_profile_audit_log "${COLIMA_PROFILE}"
     run_host_colima delete --profile "${COLIMA_PROFILE}" --force >/dev/null 2>&1 || true
     rm -rf "${PROFILE_DIR}"
+    PROFILE_WAS_REFRESHED=1
     PROFILE_PREEXISTED=0
-  elif ! validate_colima_runtime_mounts "${COLIMA_PROFILE}" "${WORKSPACE}"; then
+  elif [[ ! -f "${lima_config_path}" ]] ||
+    ! validate_colima_runtime_mounts "${COLIMA_PROFILE}" "${WORKSPACE}"; then
     echo "Refreshing managed Colima profile ${COLIMA_PROFILE} to discard stale runtime mounts." >&2
     stash_profile_audit_log "${COLIMA_PROFILE}"
     run_host_colima delete --profile "${COLIMA_PROFILE}" --force >/dev/null 2>&1 || true
     rm -rf "${PROFILE_DIR}"
+    PROFILE_WAS_REFRESHED=1
     PROFILE_PREEXISTED=0
   fi
+fi
+
+if [[ "${MODE}" == "strict" ]] && [[ "${PREPARE}" -eq 0 ]] && [[ ! -f "${PROFILE_IMAGE_MARKER}" ]]; then
+  fail_missing_strict_prepared_image_prelaunch
 fi
 
 maybe_fail_after_profile_refresh_for_tests

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1925,17 +1925,103 @@ run_command_with_debug_log() {
   local label="$1"
   shift
   local log_path=""
+  local heartbeat_pid=""
+  local start_seconds=0
+  local pid=""
   local status=0
 
+  format_elapsed_compact() {
+    local total_seconds="$1"
+    local minutes=$((total_seconds / 60))
+    local seconds=$((total_seconds % 60))
+
+    if ((minutes > 0)); then
+      printf '%dm%02ds' "${minutes}" "${seconds}"
+    else
+      printf '%ds' "${seconds}"
+    fi
+  }
+
+  maybe_print_progress_update() {
+    local phase="$1"
+    local elapsed="$2"
+
+    case "${label}" in
+      colima-start)
+        case "${phase}" in
+          start)
+            echo "Starting managed Colima profile ${COLIMA_PROFILE}. This can take a moment on first use." >&2
+            ;;
+          heartbeat)
+            echo "Workcell is still starting Colima for profile ${COLIMA_PROFILE} (${elapsed} elapsed)." >&2
+            ;;
+          success)
+            echo "Managed Colima profile ${COLIMA_PROFILE} is ready (${elapsed})." >&2
+            ;;
+        esac
+        ;;
+      runtime-build)
+        case "${phase}" in
+          start)
+            echo "Preparing the runtime image for profile ${COLIMA_PROFILE}. First-time prepares can take several minutes; reruns are usually faster." >&2
+            if [[ "${LOG_LEVEL}" != "debug" ]]; then
+              echo "Use --log-level debug for live Docker build output." >&2
+            fi
+            ;;
+          heartbeat)
+            echo "Workcell is still preparing the runtime image for profile ${COLIMA_PROFILE} (${elapsed} elapsed)." >&2
+            ;;
+          success)
+            if [[ "${PREPARE_ONLY}" -eq 1 ]]; then
+              echo "Prepared runtime image is ready for profile ${COLIMA_PROFILE} (${elapsed})." >&2
+            else
+              echo "Prepared runtime image is ready for profile ${COLIMA_PROFILE} (${elapsed}). Launching ${AGENT}." >&2
+            fi
+            ;;
+        esac
+        ;;
+    esac
+  }
+
   log_path="$(mktemp "${TMPDIR:-/tmp}/workcell-${label}.log.XXXXXX")"
-  if "$@" >"${log_path}" 2>&1; then
-    if [[ "${LOG_LEVEL}" == "debug" ]]; then
-      cat "${log_path}" >&2
-    elif [[ -n "${DEBUG_LOG_PATH}" ]]; then
+  start_seconds="${SECONDS}"
+  maybe_print_progress_update start "0s"
+  if [[ "${LOG_LEVEL}" == "debug" ]]; then
+    if [[ -n "${DEBUG_LOG_PATH}" ]]; then
+      "$@" 2>&1 | tee -a "${DEBUG_LOG_PATH}" "${log_path}" >&2
+    else
+      "$@" 2>&1 | tee "${log_path}" >&2
+    fi
+    status="${PIPESTATUS[0]}"
+  else
+    "$@" >"${log_path}" 2>&1 &
+    pid=$!
+    (
+      while kill -0 "${pid}" >/dev/null 2>&1; do
+        sleep 30
+        if ! kill -0 "${pid}" >/dev/null 2>&1; then
+          break
+        fi
+        maybe_print_progress_update heartbeat "$(format_elapsed_compact "$((SECONDS - start_seconds))")"
+      done
+    ) &
+    heartbeat_pid=$!
+    if wait "${pid}"; then
+      :
+    else
+      status=$?
+    fi
+    if [[ -n "${heartbeat_pid}" ]]; then
+      kill "${heartbeat_pid}" >/dev/null 2>&1 || true
+      wait "${heartbeat_pid}" 2>/dev/null || true
+    fi
+    if [[ "${status}" -eq 0 ]] && [[ -n "${DEBUG_LOG_PATH}" ]]; then
       cat "${log_path}" >>"${DEBUG_LOG_PATH}"
     fi
+  fi
+  if [[ "${status}" -eq 0 ]]; then
+    maybe_print_progress_update success "$(format_elapsed_compact "$((SECONDS - start_seconds))")"
   else
-    status=$?
     echo "Workcell ${label} failed." >&2
     cat "${log_path}" >&2
   fi

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -3057,14 +3057,14 @@ if [[ "${1:-}" == "--self-staging-probe" ]]; then
   printf 'injection_bundle_root=%s\n' "${INJECTION_BUNDLE_ROOT}"
   printf 'shadow_root=%s\n' "${CONTROL_PLANE_SHADOW_ROOT}"
   printf 'workspace=%s\n' "${WORKSPACE}"
-  for ((i = 0; i < ${#DIRECT_SOURCE_MOUNTS[@]}; i += 2)); do
-    printf 'direct_mount=%s\n' "${DIRECT_SOURCE_MOUNTS[i+1]}"
+  for ((i = 1; i < ${#DIRECT_SOURCE_MOUNTS[@]}; i += 2)); do
+    printf 'direct_mount=%s\n' "${DIRECT_SOURCE_MOUNTS[i]}"
   done
-  for ((i = 0; i < ${#SHADOW_MOUNTS[@]}; i += 2)); do
-    printf 'shadow_mount=%s\n' "${SHADOW_MOUNTS[i+1]}"
+  for ((i = 1; i < ${#SHADOW_MOUNTS[@]}; i += 2)); do
+    printf 'shadow_mount=%s\n' "${SHADOW_MOUNTS[i]}"
   done
-  for ((i = 0; i < ${#WORKSPACE_IMPORT_MOUNTS[@]}; i += 2)); do
-    printf 'workspace_import_mount=%s\n' "${WORKSPACE_IMPORT_MOUNTS[i+1]}"
+  for ((i = 1; i < ${#WORKSPACE_IMPORT_MOUNTS[@]}; i += 2)); do
+    printf 'workspace_import_mount=%s\n' "${WORKSPACE_IMPORT_MOUNTS[i]}"
   done
   exit 0
 fi

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -305,6 +305,9 @@ profile_lima_dir() {
 }
 
 run_host_colima() {
+  if [[ -z "${HOST_COLIMA_BIN}" ]]; then
+    HOST_COLIMA_BIN="$(resolve_host_tool colima /opt/homebrew/bin/colima /usr/local/bin/colima)"
+  fi
   HOME="${REAL_HOME}" COLIMA_HOME="${COLIMA_STATE_ROOT}" "${HOST_COLIMA_BIN}" "$@"
 }
 
@@ -3464,7 +3467,6 @@ fi
 fail_fast_for_missing_gemini_auth "$@"
 
 if [[ "${DRY_RUN}" -eq 0 ]]; then
-  HOST_COLIMA_BIN="$(resolve_host_tool colima /opt/homebrew/bin/colima /usr/local/bin/colima)"
   export COLIMA_HOME="${COLIMA_STATE_ROOT}"
   acquire_profile_lock "${COLIMA_PROFILE}"
 fi

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -308,6 +308,75 @@ run_host_colima() {
   COLIMA_HOME="${COLIMA_STATE_ROOT}" "${HOST_COLIMA_BIN}" "$@"
 }
 
+profile_process_pids() {
+  local profile="$1"
+  local instance_name
+  local pid=""
+  local command=""
+
+  instance_name="colima-${profile}"
+  pgrep -f "${instance_name}" 2>/dev/null | while IFS= read -r pid; do
+    [[ -n "${pid}" ]] || continue
+    command="$(ps -p "${pid}" -o command= 2>/dev/null || true)"
+    case "${command}" in
+      */limactl\ hostagent*"${instance_name}")
+        printf '%s\n' "${pid}"
+        ;;
+      ssh:\ *"${instance_name}"/ssh.sock\ \[mux\])
+        printf '%s\n' "${pid}"
+        ;;
+    esac
+  done | sort -u
+}
+
+reap_stale_profile_processes() {
+  local profile="$1"
+  local -a pids=()
+  local -a remaining=()
+  local pid=""
+  local deadline=0
+
+  while IFS= read -r pid; do
+    [[ -n "${pid}" ]] && pids+=("${pid}")
+  done < <(profile_process_pids "${profile}")
+
+  if ((${#pids[@]} == 0)); then
+    return 0
+  fi
+
+  echo "Stopping stale Lima processes for profile ${profile}." >&2
+  kill "${pids[@]}" >/dev/null 2>&1 || true
+  deadline=$((SECONDS + 5))
+
+  while :; do
+    remaining=()
+    for pid in "${pids[@]}"; do
+      if kill -0 "${pid}" >/dev/null 2>&1; then
+        remaining+=("${pid}")
+      fi
+    done
+    if ((${#remaining[@]} == 0)); then
+      return 0
+    fi
+    if ((SECONDS >= deadline)); then
+      break
+    fi
+    sleep 1
+    pids=("${remaining[@]}")
+  done
+
+  kill -9 "${remaining[@]}" >/dev/null 2>&1 || true
+}
+
+maybe_reap_stale_profile_processes() {
+  local profile="$1"
+
+  if run_host_colima status --profile "${profile}" >/dev/null 2>&1; then
+    return 0
+  fi
+  reap_stale_profile_processes "${profile}"
+}
+
 sanitize_host_docker_env() {
   unset DOCKER_CONTEXT
   unset DOCKER_HOST
@@ -1595,6 +1664,7 @@ delete_unmanaged_profile() {
 
   HOST_COLIMA_BIN="${HOST_COLIMA_BIN:-$(resolve_host_tool colima /opt/homebrew/bin/colima /usr/local/bin/colima)}"
   export COLIMA_HOME="${COLIMA_STATE_ROOT}"
+  maybe_reap_stale_profile_processes "${profile}"
   run_host_colima delete --profile "${profile}" --force >/dev/null 2>&1 || true
   rm -rf "${state_dir}" "${lima_dir}"
 
@@ -3296,6 +3366,8 @@ fi
 fail_fast_for_missing_gemini_auth "$@"
 
 if [[ "${DRY_RUN}" -eq 0 ]]; then
+  HOST_COLIMA_BIN="$(resolve_host_tool colima /opt/homebrew/bin/colima /usr/local/bin/colima)"
+  export COLIMA_HOME="${COLIMA_STATE_ROOT}"
   acquire_profile_lock "${COLIMA_PROFILE}"
 fi
 
@@ -3343,11 +3415,9 @@ if [[ "${DRY_RUN}" -eq 0 ]] && [[ "${MODE}" == "strict" ]] && [[ "${PREPARE}" -e
 fi
 
 if [[ "${DRY_RUN}" -eq 0 ]]; then
-  HOST_COLIMA_BIN="$(resolve_host_tool colima /opt/homebrew/bin/colima /usr/local/bin/colima)"
   HOST_DOCKER_BIN="$(resolve_host_tool docker /opt/homebrew/bin/docker /usr/local/bin/docker /Applications/Docker.app/Contents/Resources/bin/docker)"
   HOST_RUBY_BIN="$(resolve_host_tool ruby /usr/bin/ruby /opt/homebrew/bin/ruby /usr/local/bin/ruby)"
   sanitize_host_docker_env
-  export COLIMA_HOME="${COLIMA_STATE_ROOT}"
 fi
 
 ALLOW_ENDPOINTS="$(dedupe_endpoint_list "$(provider_endpoints "${AGENT}") $(credential_extra_endpoints) ${INJECTION_EXTRA_ENDPOINTS} ${EXTRA_ENDPOINTS}")"
@@ -3522,6 +3592,7 @@ fi
 
 maybe_fail_after_profile_refresh_for_tests
 
+maybe_reap_stale_profile_processes "${COLIMA_PROFILE}"
 run_command_with_debug_log colima-start \
   run_host_colima start \
   --profile "${COLIMA_PROFILE}" \

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1924,6 +1924,7 @@ PY
 run_command_with_debug_log() {
   local label="$1"
   shift
+  local -a debug_pipe_status=()
   local log_path=""
   local heartbeat_pid=""
   local start_seconds=0
@@ -1987,12 +1988,15 @@ run_command_with_debug_log() {
   start_seconds="${SECONDS}"
   maybe_print_progress_update start "0s"
   if [[ "${LOG_LEVEL}" == "debug" ]]; then
-    if [[ -n "${DEBUG_LOG_PATH}" ]]; then
-      "$@" 2>&1 | tee -a "${DEBUG_LOG_PATH}" "${log_path}" >&2
-    else
-      "$@" 2>&1 | tee "${log_path}" >&2
+    set +e
+    "$@" 2>&1 | tee "${log_path}" >&2
+    debug_pipe_status=("${PIPESTATUS[@]}")
+    set -e
+    if [[ "${debug_pipe_status[0]}" -ne 0 ]]; then
+      status="${debug_pipe_status[0]}"
+    elif [[ "${debug_pipe_status[1]}" -ne 0 ]]; then
+      status="${debug_pipe_status[1]}"
     fi
-    status="${PIPESTATUS[0]}"
   else
     "$@" >"${log_path}" 2>&1 &
     pid=$!

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1489,6 +1489,10 @@ fail_fast_for_missing_gemini_auth() {
     return 0
   fi
 
+  if [[ "$#" -eq 2 ]] && [[ "$1" == "gemini" ]] && [[ "$2" == "--version" ]]; then
+    return 0
+  fi
+
   if [[ "$(selected_provider_auth_mode)" != "none" ]]; then
     return 0
   fi
@@ -3289,7 +3293,7 @@ if [[ "${DOCTOR}" -eq 1 ]]; then
   exit 0
 fi
 
-fail_fast_for_missing_gemini_auth
+fail_fast_for_missing_gemini_auth "$@"
 
 if [[ "${DRY_RUN}" -eq 0 ]]; then
   acquire_profile_lock "${COLIMA_PROFILE}"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -2027,7 +2027,9 @@ run_command_with_debug_log() {
     maybe_print_progress_update success "$(format_elapsed_compact "$((SECONDS - start_seconds))")"
   else
     echo "Workcell ${label} failed." >&2
-    cat "${log_path}" >&2
+    if [[ "${LOG_LEVEL}" != "debug" ]]; then
+      cat "${log_path}" >&2
+    fi
   fi
   rm -f "${log_path}"
   return "${status}"

--- a/tests/python/test_injection_helpers.py
+++ b/tests/python/test_injection_helpers.py
@@ -22,6 +22,10 @@ class RenderInjectionHelperTests(unittest.TestCase):
             'value = "keep # hash"',
         )
         self.assertEqual(
+            self.module.strip_comment("value = 'keep # hash' # remove"),
+            "value = 'keep # hash'",
+        )
+        self.assertEqual(
             self.module.strip_comment(r'value = "escaped \"#\" hash" # remove'),
             r'value = "escaped \"#\" hash"',
         )
@@ -42,6 +46,68 @@ class RenderInjectionHelperTests(unittest.TestCase):
             self.module.parse_value("[1, 2]", policy, 2)
         with self.assertRaises(SystemExit):
             self.module.parse_value("", policy, 3)
+
+    def test_validate_gemini_env_file_accepts_gca_and_commented_vertex_location(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            gca_env = root / "gemini-gca.env"
+            gca_env.write_text("GOOGLE_GENAI_USE_GCA=true\n", encoding="utf-8")
+            vertex_env = root / "gemini-vertex.env"
+            vertex_env.write_text(
+                'GOOGLE_GENAI_USE_VERTEXAI=true\n'
+                'GOOGLE_CLOUD_PROJECT=test-project\n'
+                'GOOGLE_CLOUD_LOCATION="us-central1" # comment\n',
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                self.module.validate_gemini_env_file(gca_env)["selected_auth_type"],
+                "oauth-personal",
+            )
+            self.assertEqual(
+                self.module.validate_gemini_env_file(vertex_env)["extra_endpoints"],
+                ["aiplatform.googleapis.com:443", "us-central1-aiplatform.googleapis.com:443"],
+            )
+
+    def test_validate_gemini_env_file_rejects_malformed_and_duplicate_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            malformed_env = root / "gemini-malformed.env"
+            malformed_env.write_text("GOOGLE_GENAI_USE_VERTEXAI true\n", encoding="utf-8")
+            duplicate_env = root / "gemini-duplicate.env"
+            duplicate_env.write_text(
+                "GOOGLE_GENAI_USE_GCA=true\nGOOGLE_GENAI_USE_GCA=false\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(SystemExit):
+                self.module.validate_gemini_env_file(malformed_env)
+            with self.assertRaises(SystemExit):
+                self.module.validate_gemini_env_file(duplicate_env)
+
+    def test_validate_json_helpers_reject_invalid_gemini_oauth_and_adc(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            invalid_oauth = root / "gemini-oauth.json"
+            invalid_oauth.write_text("[]\n", encoding="utf-8")
+            invalid_adc = root / "gcloud-adc.json"
+            invalid_adc.write_text("{}\n", encoding="utf-8")
+            invalid_projects = root / "gemini-projects.json"
+            invalid_projects.write_text('{"projects":[]}\n', encoding="utf-8")
+            valid_projects = root / "gemini-projects-valid.json"
+            valid_projects.write_text('{"projects":{}}\n', encoding="utf-8")
+
+            with self.assertRaises(SystemExit):
+                self.module.validate_json_object_file(invalid_oauth, "credentials.gemini_oauth")
+            with self.assertRaises(SystemExit):
+                self.module.validate_gcloud_adc_file(invalid_adc, "credentials.gcloud_adc")
+            with self.assertRaises(SystemExit):
+                self.module.validate_gemini_projects_file(
+                    invalid_projects, "credentials.gemini_projects"
+                )
+            self.module.validate_gemini_projects_file(
+                valid_projects, "credentials.gemini_projects"
+            )
 
     def test_parse_toml_subset_parses_supported_tables(self) -> None:
         policy = Path("/tmp/policy.toml")
@@ -90,6 +156,25 @@ class RenderInjectionHelperTests(unittest.TestCase):
             self.module.parse_toml_subset("= \"bar\"\n", policy)
         with self.assertRaises(SystemExit):
             self.module.parse_toml_subset("nope\n", policy)
+        with self.assertRaises(SystemExit) as excinfo:
+            self.module.parse_toml_subset('credentials.gemini_env = "gemini.env"\n', policy)
+        self.assertIn("dotted TOML keys are not supported", str(excinfo.exception))
+
+    def test_parse_toml_subset_rejects_duplicate_keys_and_tables(self) -> None:
+        policy = Path("/tmp/policy.toml")
+        with self.assertRaises(SystemExit) as excinfo:
+            self.module.parse_toml_subset(
+                '[credentials]\ngemini_env = "a"\ngemini_env = "b"\n',
+                policy,
+            )
+        self.assertIn("duplicate key: gemini_env", str(excinfo.exception))
+
+        with self.assertRaises(SystemExit) as excinfo:
+            self.module.parse_toml_subset(
+                '[credentials]\n[credentials]\n',
+                policy,
+            )
+        self.assertIn("duplicate table [credentials]", str(excinfo.exception))
 
     def test_path_and_target_validation_helpers(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/python/test_render_injection_bundle.py
+++ b/tests/python/test_render_injection_bundle.py
@@ -46,7 +46,12 @@ class RenderInjectionBundleTests(unittest.TestCase):
             )
 
     def test_reserved_targets_cover_managed_provider_state(self) -> None:
-        for target in ("~/.mcp.json", "~/.gemini/projects.json", "~/.config/claude-code/auth.json"):
+        for target in (
+            "~/.mcp.json",
+            "~/.gemini/projects.json",
+            "~/.gemini/trustedFolders.json",
+            "~/.config/claude-code/auth.json",
+        ):
             with self.assertRaises(SystemExit):
                 candidate = self.module.normalize_container_target(target)
                 self.module.validate_container_target(candidate)
@@ -258,7 +263,12 @@ class RenderInjectionBundleTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             env_file = root / "gemini.env"
-            env_file.write_text('export GOOGLE_CLOUD_LOCATION="us-central1"\n', encoding="utf-8")
+            env_file.write_text(
+                'export GOOGLE_GENAI_USE_VERTEXAI=true\n'
+                'GOOGLE_CLOUD_PROJECT=test-project\n'
+                'GOOGLE_CLOUD_LOCATION="us-central1" # comment\n',
+                encoding="utf-8",
+            )
             env_file.chmod(0o600)
 
             rendered = self.module.render_credentials(
@@ -270,8 +280,76 @@ class RenderInjectionBundleTests(unittest.TestCase):
 
             self.assertEqual(
                 self.module.derive_credential_extra_endpoints(rendered),
-                ["us-central1-aiplatform.googleapis.com:443"],
+                ["aiplatform.googleapis.com:443", "us-central1-aiplatform.googleapis.com:443"],
             )
+
+    def test_derive_credential_extra_endpoints_adds_google_auth_endpoints_for_gca(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            env_file = root / "gemini.env"
+            env_file.write_text("GOOGLE_GENAI_USE_GCA=true\n", encoding="utf-8")
+            env_file.chmod(0o600)
+
+            rendered = self.module.render_credentials(
+                {"credentials": {"gemini_env": "gemini.env"}},
+                root,
+                "gemini",
+                "strict",
+            )
+
+            self.assertEqual(
+                self.module.derive_credential_extra_endpoints(rendered),
+                [
+                    "accounts.google.com:443",
+                    "oauth2.googleapis.com:443",
+                    "sts.googleapis.com:443",
+                ],
+            )
+
+    def test_render_credentials_rejects_invalid_gemini_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            invalid_env = root / "gemini.env"
+            invalid_env.write_text("GOOGLE_GENAI_USE_VERTEXAI true\n", encoding="utf-8")
+            invalid_env.chmod(0o600)
+            invalid_oauth = root / "gemini-oauth.json"
+            invalid_oauth.write_text("[]\n", encoding="utf-8")
+            invalid_oauth.chmod(0o600)
+            invalid_adc = root / "gcloud-adc.json"
+            invalid_adc.write_text("{}\n", encoding="utf-8")
+            invalid_adc.chmod(0o600)
+            invalid_projects = root / "gemini-projects.json"
+            invalid_projects.write_text('{"projects":[]}\n', encoding="utf-8")
+            invalid_projects.chmod(0o600)
+
+            with self.assertRaises(SystemExit):
+                self.module.render_credentials(
+                    {"credentials": {"gemini_env": "gemini.env"}},
+                    root,
+                    "gemini",
+                    "strict",
+                )
+            with self.assertRaises(SystemExit):
+                self.module.render_credentials(
+                    {"credentials": {"gemini_oauth": "gemini-oauth.json"}},
+                    root,
+                    "gemini",
+                    "strict",
+                )
+            with self.assertRaises(SystemExit):
+                self.module.render_credentials(
+                    {"credentials": {"gcloud_adc": "gcloud-adc.json"}},
+                    root,
+                    "gemini",
+                    "strict",
+                )
+            with self.assertRaises(SystemExit):
+                self.module.render_credentials(
+                    {"credentials": {"gemini_projects": "gemini-projects.json"}},
+                    root,
+                    "gemini",
+                    "strict",
+                )
 
     def test_render_ssh_rejects_unsafe_config_without_opt_in(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tools/remote-validator/Dockerfile
+++ b/tools/remote-validator/Dockerfile
@@ -11,24 +11,37 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
   && printf 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/%s trixie main\n' "${DEBIAN_SNAPSHOT}" > /etc/apt/sources.list \
   && printf 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/%s trixie-updates main\n' "${DEBIAN_SNAPSHOT}" >> /etc/apt/sources.list \
   && printf 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/%s trixie-security main\n' "${DEBIAN_SNAPSHOT}" >> /etc/apt/sources.list \
-  && printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99workcell-remote-validator-snapshot \
-  && DEBIAN_FRONTEND=noninteractive apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    codespell \
-    cargo \
-    docker-cli \
-    docker-buildx \
-    git \
-    groff-base \
-    llvm \
-    mandoc \
-    python3 \
-    python3-coverage \
-    rustc \
-    rustfmt \
-    shellcheck \
-    shfmt \
-    yamllint \
+  && printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "5";\nAcquire::http::Timeout "30";\n' > /etc/apt/apt.conf.d/99workcell-remote-validator-snapshot \
+  && install_remote_validator_packages() { \
+       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+         codespell \
+         cargo \
+         docker-cli \
+         docker-buildx \
+         git \
+         groff-base \
+         llvm \
+         mandoc \
+         python3 \
+         python3-coverage \
+         rustc \
+         rustfmt \
+         shellcheck \
+         shfmt \
+         yamllint \
+       && return 0; \
+     } \
+  && for attempt in 1 2 3; do \
+       rm -rf /var/lib/apt/lists/*; \
+       if DEBIAN_FRONTEND=noninteractive apt-get update \
+         && install_remote_validator_packages; then \
+         break; \
+       fi; \
+       if [[ "${attempt}" -eq 3 ]]; then \
+         exit 1; \
+       fi; \
+       sleep "$((attempt * 5))"; \
+     done \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /var/cache/debconf/*-old /var/cache/ldconfig/aux-cache
 
 WORKDIR /workspace

--- a/tools/validator/Dockerfile
+++ b/tools/validator/Dockerfile
@@ -11,22 +11,35 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
   && printf 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/%s trixie main\n' "${DEBIAN_SNAPSHOT}" > /etc/apt/sources.list \
   && printf 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/%s trixie-updates main\n' "${DEBIAN_SNAPSHOT}" >> /etc/apt/sources.list \
   && printf 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/%s trixie-security main\n' "${DEBIAN_SNAPSHOT}" >> /etc/apt/sources.list \
-  && printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99workcell-validator-snapshot \
-  && DEBIAN_FRONTEND=noninteractive apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    codespell \
-    cargo \
-    git \
-    groff-base \
-    llvm \
-    mandoc \
-    python3 \
-    python3-coverage \
-    rustc \
-    rustfmt \
-    shellcheck \
-    shfmt \
-    yamllint \
+  && printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "5";\nAcquire::http::Timeout "30";\n' > /etc/apt/apt.conf.d/99workcell-validator-snapshot \
+  && install_validator_packages() { \
+       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+         codespell \
+         cargo \
+         git \
+         groff-base \
+         llvm \
+         mandoc \
+         python3 \
+         python3-coverage \
+         rustc \
+         rustfmt \
+         shellcheck \
+         shfmt \
+         yamllint \
+       && return 0; \
+     } \
+  && for attempt in 1 2 3; do \
+       rm -rf /var/lib/apt/lists/*; \
+       if DEBIAN_FRONTEND=noninteractive apt-get update \
+         && install_validator_packages; then \
+         break; \
+       fi; \
+       if [[ "${attempt}" -eq 3 ]]; then \
+         exit 1; \
+       fi; \
+       sleep "$((attempt * 5))"; \
+     done \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /var/cache/debconf/*-old /var/cache/ldconfig/aux-cache
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary
- add explicit phase-start, heartbeat, and success messages for long startup/build operations
- keep live Docker output available behind `--log-level debug`
- avoid completion lag by running the heartbeat loop in parallel with the build wait

## Validation
- bash -n scripts/workcell
- ./scripts/workcell --help
- ./scripts/validate-repo.sh
- synthetic 31s runtime-build harness exercising run_command_with_debug_log