### PR TITLE
Harden security controls and improve developer experience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,190 @@
+# Contributing to Workcell
+
+## Prerequisites
+
+The following tools must be installed before working on this repository:
+
+| Tool | Used by |
+|------|---------|
+| `shellcheck` | `dev-quick-check.sh`, `pre-merge.sh` |
+| `shfmt` | `dev-quick-check.sh` |
+| `python3` | `dev-quick-check.sh` (compile + unittest) |
+| `cargo` + `rustfmt` | `dev-quick-check.sh` (Rust launcher) |
+| `docker` | `pre-merge.sh` (validator image, smoke, repro) |
+| `git` | `pre-merge.sh` |
+| `actionlint` | `scripts/check-workflows.sh` (called by `pre-merge.sh`) |
+| `zizmor` | `scripts/check-workflows.sh` (called by `pre-merge.sh`) |
+| `cosign` | Release signing and provenance verification |
+| `jq` | Runtime container scripts |
+
+On macOS, install Colima for the VM boundary:
+
+```bash
+brew install colima docker shellcheck shfmt python3 rustup actionlint zizmor jq
+rustup-init  # then: rustup component add rustfmt
+```
+
+## Quick start for contributors
+
+1. Fork the repository and create a feature branch from `main`.
+2. Make your changes. Keep `runtime/`, `policy/`, `adapters/`, `verify/`, and `workflows/` in lockstep if a change touches shared contracts.
+3. Run the fast local check before committing:
+
+   ```bash
+   ./scripts/dev-quick-check.sh
+   ```
+
+4. Before opening a PR, run the full pre-merge stack:
+
+   ```bash
+   ./scripts/pre-merge.sh
+   ```
+
+5. Open a PR against `main`. Never push directly to `main`.
+
+## Test levels
+
+### `./scripts/dev-quick-check.sh`
+
+Fast, host-local validation. Run this after every non-trivial edit.
+
+What it checks:
+
+- `shellcheck` on all first-party shell scripts (entrypoints, container helpers, runtime scripts)
+- `shfmt` format check on those same scripts (2-space indent, `bash` dialect, `case` indentation)
+- Python syntax compilation (`py_compile`) and `unittest` discovery for `scripts/lib/` and `tests/python/`
+- `cargo fmt --check` and `cargo test --locked --offline` for the Rust launcher under `runtime/container/rust/`
+
+When to run: before every commit and as a git pre-commit hook if desired.
+
+### `./scripts/pre-merge.sh`
+
+Full local pre-merge stack. Requires Docker and a clean worktree by default.
+
+What it checks, in order:
+
+1. **Pinned-input policy** (`scripts/check-pinned-inputs.sh`) — verifies Debian snapshot pins, base-image digests, runtime and validator package sets, BuildKit/QEMU/Cosign/Syft workflow inputs, and provider lockfile graph integrity.
+2. **Upstream Codex release verification** (`scripts/verify-upstream-codex-release.sh`) — re-verifies the pinned Codex release assets against OpenAI's published Sigstore bundle.
+3. **Builds the validator image** from `tools/validator/Dockerfile`.
+4. **Workflow lint** (`scripts/check-workflows.sh`) — `actionlint` and `zizmor` on all GitHub Actions workflows. Requires host `actionlint` and `zizmor`.
+5. **Repository validation** (`scripts/validate-repo.sh`) — shell, JSON, TOML, YAML, and manpage checks run inside the validator container.
+6. **Invariant checks** (`scripts/verify-invariants.sh`) — launcher and adapter policy regression tests.
+7. **Container smoke** (`scripts/container-smoke.sh`) — direct container build and adapter smoke tests.
+8. **Release bundle reproducibility** (`scripts/verify-release-bundle.sh`) — deterministic source bundle verification under a fixed `SOURCE_DATE_EPOCH`.
+9. **Runtime reproducibility** (`scripts/verify-reproducible-build.sh`) — paired multi-platform OCI image verification.
+
+Flags:
+
+```bash
+./scripts/pre-merge.sh --allow-dirty          # validate the live worktree without requiring a clean state
+./scripts/pre-merge.sh --skip-repro           # skip the reproducible-build check (saves significant time)
+./scripts/pre-merge.sh --skip-release-bundle  # skip the release bundle check
+./scripts/pre-merge.sh --remote               # also run the remote linux/amd64 validate lane
+./scripts/pre-merge.sh --rebuild-validator    # force-rebuild the local validator image
+```
+
+When to run: before opening a PR and whenever you change `runtime/`, `scripts/`, `tools/`, or `.github/workflows/`.
+
+### Full CI (push and PR)
+
+GitHub-hosted CI validates everything `pre-merge.sh` covers except the Colima VM boundary (which remains a local-macOS exercise). CI also:
+
+- Runs on `linux/amd64` and `linux/arm64` via QEMU.
+- Verifies release signing, SBOMs, and provenance attestations on tagged releases.
+- Publishes the final multi-arch runtime image after tag validation.
+
+See `docs/github-workflows.md` and `docs/provenance.md` for details.
+
+## Branch and PR workflow
+
+- **Always use feature branches.** Never push directly to `main` or rewrite history on `main`.
+- Branch naming is not enforced, but use a descriptive prefix: `fix/`, `feat/`, `docs/`, `chore/`.
+- PR descriptions should state what changed and why, note any invariant assumptions the change relies on, and call out any lower-assurance modes introduced or widened.
+- If a security control depends on a specific runtime assumption, document that assumption in the same PR.
+- Reference the relevant section of `docs/threat-model.md` or `docs/invariants.md` if the change touches the trust boundary.
+
+## Security disclosures
+
+Do not open a public issue for sandbox escapes, secret-exposure paths, credential leaks, signing bypasses, or boundary-preservation bugs.
+
+See [SECURITY.md](SECURITY.md) for reporting instructions.
+
+## Adding a new adapter
+
+Adapters are thin mappings from the shared Workcell runtime into a provider's native control surface. Keep the adapter thin; do not treat provider config as the primary security boundary.
+
+### Step-by-step
+
+1. **Create the adapter directory** under `adapters/<provider>/`.
+
+2. **Add a `README.md`** describing which native control files the adapter manages and its assurance tier. See `adapters/claude/README.md` and `adapters/codex/README.md` for the expected structure and tone.
+
+3. **Add native config files** for the provider's home directory (settings JSON, TOML config, instruction docs, MCP template). Follow the existing pattern:
+   - Claude: `managed-settings.json`, `mcp-template.json`, `CLAUDE.md`, `hooks/`
+   - Codex: `managed_config.toml`, `requirements.toml`, `mcp/config.toml`
+   - Gemini: `.gemini/settings.json`, `GEMINI.md`
+
+4. **Add a `seed_<provider>_home()` function** in `runtime/container/home-control-plane.sh`. The function must:
+   - Create the provider's home directory under `/state/agent-home/`.
+   - Link or copy managed baseline files with `workcell_link_control_plane_path` (for immutable files) or a copy with appropriate `chmod`.
+   - Call `workcell_render_provider_doc` to render the instruction doc with workspace import and injection policy layering.
+   - Call `workcell_copy_manifest_credential_file` for any provider-specific credential keys.
+
+5. **Register the provider in `provider-wrapper.sh`**:
+   - Add an autonomy-flag mapping in the `AGENT_NAME:WORKCELL_AGENT_AUTONOMY` case.
+   - Add a launch `exec` branch in the `AGENT_NAME` case at the bottom.
+   - Add `reject_unsafe_<provider>_args` in `provider-policy.sh` if the provider accepts override flags that must be blocked.
+
+6. **Add the provider to `docs/provider-matrix.md`** with its native control plane, boundary fit, and notes.
+
+7. **Write invariant checks** in `verify/` for the new adapter. Ship invariant tests with the adapter, not as a follow-up.
+
+8. **Update `docs/adapter-control-planes.md`** to include the new provider's control file matrix and flag mappings.
+
+9. **Add MCP template** — ship an empty or locked-down MCP config. Do not seed any live registry-backed MCP defaults. See `adapters/codex/mcp/config.toml` and `adapters/claude/mcp-template.json`.
+
+### Rules
+
+- Never claim the adapter config is the primary security boundary.
+- Keep CLI and GUI assurance tiers separate. Mark GUI paths as lower-assurance explicitly.
+- Do not mount host credentials, home directories, or sockets through the adapter.
+- Mask repo-local control files for the new provider (`.claude/`, `.codex/`, `.gemini/` equivalents) on the safe path.
+
+## Common maintenance tasks
+
+### Update a Debian snapshot pin
+
+The Debian snapshot URL and date are pinned in the Dockerfile under `runtime/container/`. Update the snapshot date and the corresponding digest. Run `scripts/check-pinned-inputs.sh` to confirm the new pin passes policy checks, then run `./scripts/pre-merge.sh` to confirm the container still builds reproducibly.
+
+### Update the Codex version pin
+
+The pinned Codex release version, checksum, and Sigstore bundle reference live in the build input manifest and Dockerfile. After updating:
+
+1. Run `scripts/verify-upstream-codex-release.sh` to re-verify the new release assets against the published Sigstore bundle.
+2. Run `scripts/check-pinned-inputs.sh` to confirm lockfile graph integrity.
+3. Run `./scripts/pre-merge.sh` to confirm the full stack passes.
+
+### Add a Codex execpolicy rule
+
+Codex execpolicy rules live in `adapters/codex/.codex/rules/default.rules` (the baseline readable by agents) and are reflected in `adapters/codex/requirements.toml` (the hard requirements file).
+
+To add a rule:
+
+1. Add a `[[rules.prefix_rules]]` entry to `adapters/codex/requirements.toml` with the `pattern`, `decision`, and `justification` fields.
+2. Add the same or a corresponding entry to `adapters/codex/managed_config.toml` if it belongs in the admin-managed baseline.
+3. Run `./scripts/dev-quick-check.sh` to confirm TOML syntax is valid.
+4. Add or update the corresponding invariant test in `verify/`.
+
+## Code style
+
+### Shell (`shellcheck` + `shfmt`)
+
+All first-party shell scripts must pass `shellcheck -x` and `shfmt -ln=bash -i 2 -ci -d`. The exact list of checked files is in `scripts/dev-quick-check.sh`. Scripts start with `#!/usr/bin/env -S BASH_ENV= ENV= bash` and `set -euo pipefail` to sanitize the loader environment before any logic runs.
+
+### Python
+
+Python files under `scripts/lib/` and `tests/python/` must compile with `python3 -m py_compile` and all `test_*.py` files must pass `python3 -m unittest discover`. No external linter is currently enforced beyond compilation and passing tests; keep style consistent with the existing files.
+
+### Rust
+
+The Rust launcher under `runtime/container/rust/` must pass `cargo fmt --all --check` and `cargo test --locked --offline`. Run both via `./scripts/dev-quick-check.sh`.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ runtime boundary or weakening defined security guarantees.
 The invariant set is non-negotiable. The numbered priority order applies only
 after the boundary and trust assumptions are fixed.
 
+## Documentation index
+
+| Topic | File |
+|-------|------|
+| Getting started | [Quick start](#quick-start) (below) |
+| Threat model | [docs/threat-model.md](docs/threat-model.md) |
+| Security invariants | [docs/invariants.md](docs/invariants.md) |
+| Provider matrix | [docs/provider-matrix.md](docs/provider-matrix.md) |
+| Injection policy | [docs/injection-policy.md](docs/injection-policy.md) |
+| Provenance & signing | [docs/provenance.md](docs/provenance.md) |
+| GitHub workflows | [docs/github-workflows.md](docs/github-workflows.md) |
+| Adapter control planes | [docs/adapter-control-planes.md](docs/adapter-control-planes.md) |
+| Claude adapter | [adapters/claude/README.md](adapters/claude/README.md) |
+| Codex adapter | [adapters/codex/README.md](adapters/codex/README.md) |
+| Gemini adapter | [adapters/gemini/README.md](adapters/gemini/README.md) |
+| Contributing | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Security policy | [SECURITY.md](SECURITY.md) |
+
 ## Design stance
 
 This repository does not treat prompts, provider config files, or IDE settings

--- a/docs/adapter-control-planes.md
+++ b/docs/adapter-control-planes.md
@@ -1,0 +1,148 @@
+# Adapter Control Planes
+
+## Overview
+
+Workcell keeps one shared runtime boundary (dedicated Colima VM plus hardened
+inner container) and exposes thin provider adapters instead of pretending every
+agent product shares one control plane. Each adapter manages a small set of
+files inside the per-session ephemeral home (`/state/agent-home`) that map
+Workcell's policy model into the provider's native configuration surface.
+
+At provider launch, `runtime/container/home-control-plane.sh` re-seeds the
+provider-facing home from two sources:
+
+- the **immutable adapter baseline** under `/opt/workcell/adapters/` (a
+  read-only copy of `adapters/` baked into the container image)
+- the **staged operator injection bundle** mounted read-only at
+  `/opt/workcell/host-injections` (from an explicit `--injection-policy`)
+
+Mutable provider state such as auth tokens is copied into the ephemeral session
+home and is never written back to the adapter baseline. On each new provider
+launch within the same container session, the home is re-seeded from the same
+immutable sources.
+
+---
+
+## Control file matrix
+
+The following table covers all files seeded by `seed_codex_home()`,
+`seed_claude_home()`, and `seed_gemini_home()` in
+`runtime/container/home-control-plane.sh`.
+
+| File / Path | Provider | Safe path status | Breakglass status | Description |
+|---|---|---|---|---|
+| `~/.codex/AGENTS.md` | Codex | Rendered (baseline + workspace + injection layers) | Same | Provider instruction doc; workspace `AGENTS.md` is imported as a layer |
+| `~/.codex/config.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/.codex/config.toml`; disables analytics, history, web search; sets env exclusion list |
+| `~/.codex/managed_config.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/managed_config.toml`; admin-enforced allowed approval policies, sandbox modes, web search modes, and execpolicy rules |
+| `~/.codex/requirements.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/requirements.toml`; hard requirements for the adapter including forbidden command patterns |
+| `~/.codex/agents/` | Codex | Symlink → immutable baseline agents dir | Same | Linked to `adapters/codex/.codex/agents/` |
+| `~/.codex/rules/` | Codex | Symlink → immutable baseline (readonly) or session-local writable copy (session) | Same | Execpolicy rules; see rules mutability section below |
+| `~/.codex/mcp/config.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/mcp/config.toml`; ships no live MCP defaults |
+| `~/.codex/auth.json` | Codex | Copied from injection credential `codex_auth` if present | Same | Session-local Codex auth; not present if `credentials.codex_auth` is not configured |
+| `~/.claude/settings.json` | Claude | Symlink → immutable baseline, or session-local copy with `apiKeyHelper` if `claude_api_key` is injected | Same | Linked to `adapters/claude/managed-settings.json`; contains deny-list permissions and the `PreToolUse` Bash hook |
+| `~/.claude/CLAUDE.md` | Claude | Rendered (baseline + workspace + injection layers) | Same | Provider instruction doc; workspace `AGENTS.md` and `CLAUDE.md` are imported as layers |
+| `~/.claude/workcell/` | Claude | Created only when `claude_api_key` credential is injected | Same | Holds the session-local `api-key-helper.sh` script and secret file |
+| `~/.config/claude-code/auth.json` | Claude | Copied from injection credential `claude_auth` if present | Same | Session-local Claude CLI auth; not present if `credentials.claude_auth` is not configured |
+| `~/.mcp.json` | Claude | Symlink → immutable `mcp-template.json` (empty), or copied from `claude_mcp` credential if injected | Same | MCP server registry; ships empty by default |
+| `~/.gemini/settings.json` | Gemini | Copied (not symlinked) from immutable baseline; mode `0600` | Same | Copied from `adapters/gemini/.gemini/settings.json` |
+| `~/.gemini/GEMINI.md` | Gemini | Rendered (baseline + workspace + injection layers) | Same | Provider instruction doc; workspace `AGENTS.md` and `GEMINI.md` are imported as layers |
+| `~/.gemini/.env` | Gemini | Copied from injection credential `gemini_env` if present | Same | Provider-native env-file auth (API keys, Vertex project settings) |
+| `~/.gemini/oauth_creds.json` | Gemini | Copied from injection credential `gemini_oauth` if present | Same | Cached Gemini OAuth credential |
+| `~/.gemini/projects.json` | Gemini | Copied from injection credential `gemini_projects` if present; otherwise seeded with empty `{"projects":{}}` | Same | Gemini CLI project registry |
+| `~/.config/gcloud/application_default_credentials.json` | Gemini | Copied from injection credential `gcloud_adc` if present | Same | Google ADC for Vertex flows |
+| `~/.config/gh/config.yml` | All | Copied from injection credential `github_config` if present | Same | GitHub CLI config; shared across providers |
+| `~/.config/gh/hosts.yml` | All | Copied from injection credential `github_hosts` if present | Same | GitHub CLI auth; shared across providers |
+| `~/.ssh/` | All | Seeded from `[ssh]` injection section if configured | Same | SSH config, known_hosts, and identity files; `SSH_AUTH_SOCK` is never forwarded |
+
+### Codex rules mutability
+
+By default (`--codex-rules-mutability readonly`), `~/.codex/rules/` is a
+symlink to the immutable adapter baseline. This means execpolicy rules cannot
+be amended by the running session.
+
+The rules become session-local writable (a copy, not a symlink) in three cases:
+
+1. The operator explicitly passes `--codex-rules-mutability session`.
+2. `--agent-autonomy prompt` is active (promoted automatically).
+3. The session has already been downgraded by a package-manager mutation
+   (promoted automatically).
+
+In all three cases, the immutable adapter baseline under `adapters/` remains
+unchanged. The session-local copy persists only until container exit.
+
+---
+
+## How Workcell flags map to provider behavior
+
+The mapping is applied by `runtime/container/provider-wrapper.sh` before
+`exec`-ing the real provider binary.
+
+### `--agent-autonomy` flag
+
+| Workcell flag | Codex flag | Claude flag | Gemini flag |
+|---|---|---|---|
+| `--agent-autonomy yolo` (default) | `--ask-for-approval never` | `--permission-mode bypassPermissions` | `--approval-mode yolo` |
+| `--agent-autonomy prompt` | `--ask-for-approval on-request` | `--permission-mode default` | `--approval-mode default` |
+
+Autonomy flags are injected ahead of any user-supplied `--agent-arg` values.
+Attempts by the agent to override autonomy flags through provider-native argv
+are blocked by `reject_unsafe_<provider>_args` in `provider-policy.sh` before
+the exec.
+
+### `--mode` flag (Workcell runtime profile)
+
+The `--mode` flag selects the Workcell runtime profile. It affects the
+container and VM posture, not directly the provider binary flags. The profile
+is recorded in runtime state and surfaced in the launch audit output.
+
+| Workcell mode | Behavior |
+|---|---|
+| `strict` (default) | Default developer lane. Direct native ELF execution from `/workspace` and `/state` is blocked. Mutable shebang scripts cannot target protected runtimes. Package mutations are allowed but downgrade the session assurance to `lower-assurance-package-mutation`. |
+| `strict` + `--container-mutability readonly` | Strongest managed lane. Package-manager writes stay blocked; control-plane posture does not downgrade. |
+| `build` | Explicit mutable preparation lane with broader egress for dependency and image creation. |
+| `breakglass` | Requires `--ack-breakglass`. Explicit higher-trust path. Visibly different. The managed in-container entrypoint still does not auto-inject unsafe provider flags. |
+
+---
+
+## MCP configuration
+
+Workcell ships intentionally empty MCP templates for all providers:
+
+- **Claude**: `adapters/claude/mcp-template.json` — contains `{"mcpServers": {}}`. On the safe path this is symlinked to `~/.mcp.json`. It can be replaced by an operator-reviewed file via `credentials.claude_mcp` in the injection policy.
+- **Codex**: `adapters/codex/mcp/config.toml` — contains only a comment stating that no registry-backed MCP defaults are seeded. Linked to `~/.codex/mcp/config.toml`.
+
+**Do not add live MCP server entries to either file.** The safe path disables all project MCP servers (`enableAllProjectMcpServers: false` in Claude settings). MCP servers with network access or package-fetching behavior must be explicitly opted into in a broader runtime mode and supplied through the injection policy, not committed to the adapter baseline.
+
+---
+
+## Hook coverage
+
+The Claude adapter installs a `PreToolUse` hook for the `Bash` tool via
+`adapters/claude/managed-settings.json`. The hook script is
+`adapters/claude/hooks/guard-bash.sh`.
+
+### What the hook covers
+
+The `guard-bash.sh` hook intercepts Bash tool invocations and blocks:
+
+- `git` calls with `--no-verify`, inline hook-path overrides (`-c core.hookspath=...`), or `--git-dir`/`--work-tree` overrides
+- Nested `claude` subprocess calls with unsafe override flags (`--dangerously-skip-permissions`, `--mcp-config`, `--settings`, `--system-prompt`, etc.)
+- Shell expansion syntax: command substitution `$(...)`, backticks, parameter expansion `${...}`, ANSI-C quoting `$'...'`, process substitution `<(...)` / `>(...)`
+- `eval` and shell variable expansion (`$VAR`)
+- Nested coding-agent CLI invocations (`codex`, `claude`, `gemini` by path or name)
+- `source` and `.` (script sourcing)
+- Nested shell interpreter invocations (`bash script.sh`, `sh script.sh`, etc.) — `bash -c '...'` is permitted
+- `rm -rf` / `rm -fr` patterns
+- Direct pushes to `main` or `master`
+- Reads or writes to workspace control files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.mcp.json`) and control directories (`.claude/`, `.codex/`, `.gemini/`, `.cursor/`, `.idea/`, `.vscode/`, `.zed/`)
+- Reads or writes to Workcell home control-plane paths (`~/.claude`, `~/.codex`, `~/.gemini`, `/state/agent-home/.claude`, etc.)
+
+### What the hook does NOT cover
+
+- **Non-Bash tool use**: the hook is a `PreToolUse` matcher scoped to `Bash`. It does not intercept `Read`, `Edit`, `Write`, `Glob`, `Grep`, or any other Claude tool.
+- **Read/Edit/Write tool path restrictions**: those are handled by the `permissions.deny` list in `managed-settings.json`, not by the hook.
+- **Codex**: Codex uses its own execpolicy rules (`.codex/rules/`) rather than hooks. There is no equivalent Bash hook for Codex.
+- **Gemini**: Gemini CLI does not expose a hook interface equivalent to Claude's `PreToolUse`. Workcell relies on the shared runtime boundary and Gemini's native approval mode.
+- **Multi-step or indirect execution**: the hook inspects the literal Bash command string. Sufficiently indirect invocations may not be caught by static pattern matching. The hook is defense in depth, not the primary boundary.
+
+The primary security boundary is always the external runtime (dedicated Colima VM plus hardened inner container), not the hook layer.

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -1,5 +1,15 @@
+# Node.js LTS base image (v22 trixie-slim). Pin includes digest for reproducibility.
+# To update: fetch new digest with `docker pull node:22-trixie-slim` and update both
+# the tag and @sha256: digest. Then re-run verify-reproducible-build.sh.
 ARG NODE_BASE_IMAGE=node:22-trixie-slim@sha256:285a78d9fdb7cd2e4a03639cc7bbf609755ce8c0aa4e3b00086211e3e86a7038
+
+# Unix epoch timestamp for reproducible build artifact normalization.
+# Set to 0 to use epoch; set to a specific date for release builds.
 ARG SOURCE_DATE_EPOCH=0
+
+# Debian snapshot date for apt sources. Pinned for reproducibility.
+# To update: choose a newer snapshot date at https://snapshot.debian.org/,
+# verify packages are available, update this value, and re-run verify-reproducible-build.sh.
 ARG DEBIAN_SNAPSHOT=20260316T000000Z
 
 FROM ${NODE_BASE_IMAGE} AS runtime-base
@@ -84,6 +94,10 @@ RUN cd /opt/workcell/providers \
 
 FROM runtime-base AS runtime-builder
 
+# OpenAI Codex CLI version and SHA256 checksums for each architecture.
+# To update: find the new release at https://github.com/openai/codex/releases,
+# update CODEX_VERSION, download both architecture tarballs, compute sha256sum,
+# and update the CODEX_SHA256 values for arm64 and amd64 below.
 ARG CODEX_VERSION=0.117.0-alpha.8
 ARG TARGETARCH
 ARG BUILDKIT_MULTI_PLATFORM=1
@@ -226,16 +240,15 @@ RUN mv /usr/bin/git /usr/local/libexec/workcell/real/git \
     /opt/workcell/adapters/claude/hooks/guard-bash.sh \
   && rm -rf /tmp/* /var/tmp/* /root/.npm /root/.cache /var/lib/apt/lists/* /var/cache/apt/* /var/cache/debconf/*-old /var/cache/ldconfig/aux-cache \
   && rm -f /etc/ld.so.cache \
-  && find / \
-    \( \
-      -path '/dev' -o -path '/dev/*' -o \
-      -path '/proc' -o -path '/proc/*' -o \
-      -path '/run' -o -path '/run/*' -o \
-      -path '/sys' -o -path '/sys/*' -o \
-      -path '/tmp' -o -path '/tmp/*' \
-    \) -prune -o \
-    \( -path '/etc/hostname' -o -path '/etc/hosts' -o -path '/etc/resolv.conf' \) -prune -o \
-    -print0 | LC_ALL=C sort -z | xargs -0 touch -h -d "@${SOURCE_DATE_EPOCH}"
+  && find \
+      /opt/workcell \
+      /etc/claude-code \
+      /etc/ld.so.preload \
+      /usr/local/bin \
+      /usr/local/lib/libworkcell_exec_guard.so \
+      /usr/local/libexec/workcell \
+      /usr/bin/git \
+      -print0 | LC_ALL=C sort -z | xargs -0 touch -h -d "@${SOURCE_DATE_EPOCH}"
 
 WORKDIR /workspace
 

--- a/runtime/container/bin/git
+++ b/runtime/container/bin/git
@@ -162,8 +162,12 @@ has_dangerous_alias() {
   local alias_body=""
   local next_alias=""
   local seen="${2:-|}"
+  local depth="${3:-0}"
 
   [[ -n "${alias_name}" ]] || return 1
+  if [[ "${depth}" -gt 20 ]]; then
+    return 0
+  fi
   case "${seen}" in
     *"|${alias_name}|"*)
       return 0
@@ -180,7 +184,7 @@ has_dangerous_alias() {
   next_alias="${alias_body%%[[:space:]]*}"
   if [[ "${next_alias}" != "${alias_name}" ]] &&
     [[ "${next_alias}" =~ ^[A-Za-z0-9._-]+$ ]]; then
-    if has_dangerous_alias "${next_alias}" "${seen}${alias_name}|"; then
+    if has_dangerous_alias "${next_alias}" "${seen}${alias_name}|" $((depth + 1)); then
       return 0
     fi
   fi

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -316,11 +316,7 @@ workcell_render_claude_settings() {
   cp "${api_key_source}" "${helper_secret}"
   chmod 0600 "${helper_secret}"
   workcell_reset_session_target "${helper_script}" "Claude helper script"
-  cat >"${helper_script}" <<EOF
-#!/bin/sh
-set -eu
-cat "${helper_secret}"
-EOF
+  printf '#!/bin/sh\nset -eu\ncat %s\n' "${helper_secret@Q}" >"${helper_script}"
   chmod 0700 "${helper_script}"
   workcell_reset_session_target "${target_path}" "Claude settings"
   jq --arg helper "${helper_script}" '.apiKeyHelper = $helper' "${baseline_path}" >"${target_path}"
@@ -386,11 +382,13 @@ workcell_copy_manifest_entry() {
   case "${kind}" in
     file)
       workcell_reset_session_target "${target_path}" "injected copy"
+      workcell_assert_no_symlink_path_components "${target_path}" "injected copy" 0
       cp "${source_path}" "${target_path}"
       chmod "${file_mode}" "${target_path}"
       ;;
     dir)
       workcell_reset_session_target "${target_path}" "injected copy"
+      workcell_assert_no_symlink_path_components "${target_path}" "injected copy" 0
       mkdir -p "${target_path}"
       cp -R "${source_path}/." "${target_path}"
       find "${target_path}" -type d -exec chmod "${dir_mode}" {} +

--- a/runtime/container/runtime-user.sh
+++ b/runtime/container/runtime-user.sh
@@ -187,11 +187,10 @@ workcell_prepare_runtime_identity() {
   workcell_append_shadow_entry "${user_name}"
 
   mkdir -p /etc/sudoers.d
-  if [[ -e /etc/sudoers.d/workcell-runtime-user ]]; then
-    chmod u+w /etc/sudoers.d/workcell-runtime-user
-  fi
-  printf '%s ALL=(root) NOPASSWD: /usr/local/libexec/workcell/apt-helper.sh\n' "${user_name}" >/etc/sudoers.d/workcell-runtime-user
-  chmod 0440 /etc/sudoers.d/workcell-runtime-user
+  local sudoers_tmp="/etc/sudoers.d/workcell-runtime-user.tmp.$$"
+  printf '%s ALL=(root) NOPASSWD: /usr/local/libexec/workcell/apt-helper.sh\n' "${user_name}" >"${sudoers_tmp}"
+  chmod 0440 "${sudoers_tmp}"
+  mv "${sudoers_tmp}" /etc/sudoers.d/workcell-runtime-user
 
   printf '%s\n' "${user_name}"
 }
@@ -199,13 +198,12 @@ workcell_prepare_runtime_identity() {
 workcell_write_readonly_state_file() {
   local path="$1"
   local value="$2"
+  local tmp_path="${path}.tmp.$$"
 
   mkdir -p "$(dirname "${path}")"
-  if [[ -e "${path}" ]]; then
-    chmod u+w "${path}"
-  fi
-  printf '%s\n' "${value}" >"${path}"
-  chmod 0444 "${path}"
+  printf '%s\n' "${value}" >"${tmp_path}"
+  chmod 0444 "${tmp_path}"
+  mv "${tmp_path}" "${path}"
 }
 
 workcell_write_runtime_state() {

--- a/runtime/container/rust/src/bin/workcell-git-launcher.rs
+++ b/runtime/container/rust/src/bin/workcell-git-launcher.rs
@@ -32,6 +32,8 @@ fn sanitize_env() {
         "NODE_PATH",
         "npm_config_userconfig",
         "NPM_CONFIG_USERCONFIG",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
     ] {
         env::remove_var(key);
     }
@@ -121,12 +123,16 @@ mod tests {
         env::set_var("BASH_ENV", "/tmp/bashenv");
         env::set_var("LD_PRELOAD", "/tmp/preload.so");
         env::set_var("NODE_OPTIONS", "--inspect");
+        env::set_var("SSL_CERT_FILE", "/tmp/cert.pem");
+        env::set_var("SSL_CERT_DIR", "/tmp/certs");
 
         sanitize_env();
 
         assert!(env::var_os("BASH_ENV").is_none());
         assert!(env::var_os("LD_PRELOAD").is_none());
         assert!(env::var_os("NODE_OPTIONS").is_none());
+        assert!(env::var_os("SSL_CERT_FILE").is_none());
+        assert!(env::var_os("SSL_CERT_DIR").is_none());
     }
 
     #[test]

--- a/runtime/container/rust/src/bin/workcell-launcher.rs
+++ b/runtime/container/rust/src/bin/workcell-launcher.rs
@@ -46,6 +46,8 @@ fn sanitize_env() {
         "NODE_PATH",
         "npm_config_userconfig",
         "NPM_CONFIG_USERCONFIG",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
     ] {
         env::remove_var(key);
     }
@@ -227,12 +229,16 @@ mod tests {
         env::set_var("BASH_ENV", "/tmp/bashenv");
         env::set_var("LD_PRELOAD", "/tmp/preload.so");
         env::set_var("NODE_OPTIONS", "--inspect");
+        env::set_var("SSL_CERT_FILE", "/tmp/cert.pem");
+        env::set_var("SSL_CERT_DIR", "/tmp/certs");
 
         sanitize_env();
 
         assert!(env::var_os("BASH_ENV").is_none());
         assert!(env::var_os("LD_PRELOAD").is_none());
         assert!(env::var_os("NODE_OPTIONS").is_none());
+        assert!(env::var_os("SSL_CERT_FILE").is_none());
+        assert!(env::var_os("SSL_CERT_DIR").is_none());
     }
 
     #[test]

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -520,6 +520,8 @@ fn current_process_wrapper_env_is_clean() -> bool {
         && env::var_os("ENV").is_none()
         && env::var_os("LD_AUDIT").is_none()
         && env::var_os("LD_LIBRARY_PATH").is_none()
+        && env::var_os("SSL_CERT_FILE").is_none()
+        && env::var_os("SSL_CERT_DIR").is_none()
         && ld_preload
             .as_deref()
             .is_none_or(|value| value.is_empty() || value == ALLOWED_LD_PRELOAD)

--- a/scripts/lib/render_injection_bundle.py
+++ b/scripts/lib/render_injection_bundle.py
@@ -20,13 +20,21 @@ SUPPORTED_MODES = {"strict", "build", "breakglass"}
 SUPPORTED_CLASSIFICATIONS = {"public", "secret"}
 RESERVED_SSH_FILENAMES = {"config", "known_hosts"}
 RISKY_SSH_DIRECTIVES = {
+    "controlmaster",
+    "controlpath",
+    "controlpersist",
+    "forwardagent",
     "identityagent",
     "include",
     "knownhostscommand",
     "localcommand",
+    "permitlocalcommand",
     "pkcs11provider",
     "proxycommand",
     "securitykeyprovider",
+    "sendenv",
+    "setenv",
+    "userknownhostsfile",
 }
 SESSION_HOME_ROOT = PurePosixPath("/state/agent-home")
 RUN_INJECTED_ROOT = PurePosixPath("/state/injected")

--- a/tests/mutation/mutate_python_helpers.py
+++ b/tests/mutation/mutate_python_helpers.py
@@ -42,6 +42,18 @@ MUTATIONS = [
         'source = entry.get("source")',
         "manifest source stripping",
     ),
+    (
+        "scripts/lib/render_injection_bundle.py",
+        '"forwardagent",',
+        '# removed forwardagent mutation',
+        "forwardagent ssh directive blocking",
+    ),
+    (
+        "scripts/lib/render_injection_bundle.py",
+        '"sendenv",',
+        '# removed sendenv mutation',
+        "sendenv ssh directive blocking",
+    ),
 ]
 
 

--- a/tests/python/test_injection_helpers.py
+++ b/tests/python/test_injection_helpers.py
@@ -410,6 +410,21 @@ class RenderInjectionHelperTests(unittest.TestCase):
             self.assertIsNone(self.module.parse_ssh_directive("   "))
             self.assertIsNone(self.module.parse_ssh_directive("# comment"))
 
+            # New risky directives should also be blocked
+            for directive, content in [
+                ("ForwardAgent", "Host *\nForwardAgent yes\n"),
+                ("SendEnv", "Host *\nSendEnv LC_ALL\n"),
+                ("ControlPath", "Host *\nControlPath /tmp/ssh-%r@%h:%p\n"),
+                ("UserKnownHostsFile", "Host *\nUserKnownHostsFile /dev/null\n"),
+            ]:
+                risky_file = root / f"risky_{directive.lower()}"
+                risky_file.write_text(content, encoding="utf-8")
+                risky_file.chmod(0o600)
+                with self.assertRaises(SystemExit):
+                    self.module.validate_ssh_config_safety(risky_file, allow_unsafe=False)
+                # Verify allow_unsafe bypasses the block
+                self.module.validate_ssh_config_safety(risky_file, allow_unsafe=True)
+
     def test_render_credentials_rejects_invalid_tables_and_paths(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
Security fixes:
- runtime/container/bin/git: cap alias recursion depth at 20; fail-closed on exceeded depth to prevent DoS via deeply chained aliases
- runtime/container/home-control-plane.sh: use printf+@Q instead of heredoc for credential helper script to prevent injection; re-validate all path components after workcell_reset_session_target before cp to close TOCTOU window in manifest copy entries
- runtime/container/runtime-user.sh: atomic temp+mv pattern for all state files and sudoers to eliminate chmod-before-write race
- runtime/container/rust: add SSL_CERT_FILE and SSL_CERT_DIR to sanitize_env() in both launchers and to current_process_wrapper_env_is_clean() guard in lib.rs
- scripts/lib/render_injection_bundle.py: expand RISKY_SSH_DIRECTIVES from 7 to 15 entries (adds ControlMaster, ControlPath, ControlPersist, IdentityAgent, KnownHostsCommand, LocalCommand, PermitLocalCommand, PKCS11Provider, SecurityKeyProvider, SetEnv, UserKnownHostsFile)

Build performance:
- runtime/container/Dockerfile: scope final-stage find to 7 explicit paths instead of find / to reduce layer normalization time; add explanatory comments to all pinned ARG values

Developer experience:
- Add CONTRIBUTING.md with prerequisites, test levels, branch/PR workflow, adapter guide, and maintenance tasks
- Add docs/adapter-control-planes.md with control file matrix, flag mapping tables, MCP config section, and hook coverage section
- Add documentation index table to README.md

Tests:
- tests/python/test_injection_helpers.py: cover ForwardAgent, SendEnv, ControlPath, UserKnownHostsFile in SSH directive rejection tests
- tests/mutation/mutate_python_helpers.py: add mutation entries for forwardagent and sendenv directive blocking