### PR TITLE
Fix Gemini startup regression follow-ups

### DIFF
--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1113,6 +1113,30 @@ run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini" bas
       gemini --version >/dev/null 2>&1
       test ! -e /workspace/exfil/settings-clobber
       test ! -e /workspace/exfil/trusted-clobber
+      interactive_status=0
+      if timeout 20 script -qefc "gemini" /tmp/workcell-gemini-interactive.typescript </dev/null >/dev/null 2>&1; then
+        interactive_status=0
+      else
+        interactive_status=$?
+      fi
+      if [[ "${interactive_status}" != "0" ]] && [[ "${interactive_status}" != "124" ]]; then
+        echo "Gemini interactive startup probe failed; transcript follows:" >&2
+        tail -n 80 /tmp/workcell-gemini-interactive.typescript >&2 || true
+        exit 1
+      fi
+      grep -q "Gemini CLI v" /tmp/workcell-gemini-interactive.typescript
+      if grep -q "Do you trust the files in this folder\\?" /tmp/workcell-gemini-interactive.typescript; then
+        echo "expected seeded Gemini trustedFolders.json to suppress the trust prompt" >&2
+        exit 1
+      fi
+      if grep -q "Gemini CLI is restarting to apply the trust changes" /tmp/workcell-gemini-interactive.typescript; then
+        echo "expected Gemini startup not to restart when the workspace is already trusted" >&2
+        exit 1
+      fi
+      if grep -q "Failed to relaunch the CLI process" /tmp/workcell-gemini-interactive.typescript; then
+        echo "expected Gemini startup not to hit the relaunch failure path" >&2
+        exit 1
+      fi
   '"'"'
 '
 

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2485,6 +2485,92 @@ EOF
 } >"${PROFILE_PROCESS_MATCH_HARNESS}"
 /bin/bash "${PROFILE_PROCESS_MATCH_HARNESS}"
 rm -f "${PROFILE_PROCESS_MATCH_HARNESS}"
+COLIMA_PROFILE_STATUS_HARNESS="$(mktemp)"
+{
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" colima_profile_status
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" maybe_reap_stale_profile_processes
+  cat <<'EOF'
+set -euo pipefail
+
+HOST_PYTHON3_BIN="$(command -v python3)"
+TRUSTED_HOST_PATH="${PATH}"
+
+run_host_colima() {
+  cat <<'JSON'
+{"name":"default","status":"Running"}
+{"name":"workcell-workcell-ac42b1dc","status":"Stopped"}
+{"name":"workcell-other","status":"Running"}
+JSON
+}
+
+reap_stale_profile_processes() {
+  printf 'reaped:%s\n' "$1"
+}
+
+profile_process_pids() {
+  case "$1" in
+    workcell-stale)
+      printf '%s\n' 49909
+      ;;
+    workcell-parse-failure)
+      printf '%s\n' 49991
+      ;;
+  esac
+}
+
+status="$(colima_profile_status workcell-workcell-ac42b1dc)"
+if [[ "${status}" != "Stopped" ]]; then
+  echo "Expected colima_profile_status to return Stopped for the matching profile, got: ${status}" >&2
+  exit 1
+fi
+
+status="$(colima_profile_status workcell-other)"
+if [[ "${status}" != "Running" ]]; then
+  echo "Expected colima_profile_status to return Running for the matching profile, got: ${status}" >&2
+  exit 1
+fi
+
+missing_status_rc=0
+if colima_profile_status does-not-exist >/tmp/workcell-colima-profile-status-missing.out 2>&1; then
+  echo "Expected colima_profile_status to fail for a missing profile" >&2
+  exit 1
+else
+  missing_status_rc=$?
+fi
+if ((missing_status_rc != 3)); then
+  echo "Expected colima_profile_status to return exit status 3 for a missing profile, got: ${missing_status_rc}" >&2
+  exit 1
+fi
+
+reaped="$(maybe_reap_stale_profile_processes workcell-workcell-ac42b1dc)"
+if [[ "${reaped}" != "reaped:workcell-workcell-ac42b1dc" ]]; then
+  echo "Expected maybe_reap_stale_profile_processes to reap only explicit Stopped profiles, got: ${reaped}" >&2
+  exit 1
+fi
+
+if [[ -n "$(maybe_reap_stale_profile_processes workcell-other)" ]]; then
+  echo "Expected maybe_reap_stale_profile_processes to ignore Running profiles" >&2
+  exit 1
+fi
+
+reaped="$(maybe_reap_stale_profile_processes workcell-stale)"
+if [[ "${reaped}" != "reaped:workcell-stale" ]]; then
+  echo "Expected maybe_reap_stale_profile_processes to reap missing profiles that still have orphaned processes, got: ${reaped}" >&2
+  exit 1
+fi
+
+run_host_colima() {
+  printf '%s\n' '{not-json'
+}
+
+if [[ -n "$(maybe_reap_stale_profile_processes workcell-parse-failure)" ]]; then
+  echo "Expected maybe_reap_stale_profile_processes to ignore parse failures instead of reaping live profiles blindly" >&2
+  exit 1
+fi
+EOF
+} >"${COLIMA_PROFILE_STATUS_HARNESS}"
+/bin/bash "${COLIMA_PROFILE_STATUS_HARNESS}"
+rm -f "${COLIMA_PROFILE_STATUS_HARNESS}"
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent gemini \
   --workspace "${ROOT_DIR}" \

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2512,6 +2512,9 @@ profile_process_pids() {
     workcell-stale)
       printf '%s\n' 49909
       ;;
+    workcell-empty-list)
+      printf '%s\n' 49919
+      ;;
     workcell-parse-failure)
       printf '%s\n' 49991
       ;;
@@ -2556,6 +2559,16 @@ fi
 reaped="$(maybe_reap_stale_profile_processes workcell-stale)"
 if [[ "${reaped}" != "reaped:workcell-stale" ]]; then
   echo "Expected maybe_reap_stale_profile_processes to reap missing profiles that still have orphaned processes, got: ${reaped}" >&2
+  exit 1
+fi
+
+run_host_colima() {
+  return 0
+}
+
+reaped="$(maybe_reap_stale_profile_processes workcell-empty-list)"
+if [[ "${reaped}" != "reaped:workcell-empty-list" ]]; then
+  echo "Expected maybe_reap_stale_profile_processes to reap orphaned processes when colima list returns an empty profile set, got: ${reaped}" >&2
   exit 1
 fi
 

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -311,6 +311,43 @@ run_host_colima() {
   HOME="${REAL_HOME}" COLIMA_HOME="${COLIMA_STATE_ROOT}" "${HOST_COLIMA_BIN}" "$@"
 }
 
+colima_profile_status() {
+  local profile="$1"
+  local list_output=""
+
+  list_output="$(run_host_colima list --json 2>/dev/null || true)"
+  [[ -n "${list_output}" ]] || return 1
+
+  env -i \
+    PATH="${TRUSTED_HOST_PATH}" \
+    PROFILE_NAME="${profile}" \
+    COLIMA_LIST_JSON="${list_output}" \
+    "${HOST_PYTHON3_BIN}" - <<'PY'
+import json
+import os
+import sys
+
+profile_name = os.environ.get("PROFILE_NAME", "")
+for line in os.environ.get("COLIMA_LIST_JSON", "").splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        record = json.loads(line)
+    except json.JSONDecodeError:
+        sys.exit(1)
+    if record.get("name") != profile_name:
+        continue
+    status = record.get("status")
+    if isinstance(status, str) and status:
+        print(status)
+        sys.exit(0)
+    sys.exit(1)
+
+sys.exit(3)
+PY
+}
+
 profile_process_pids() {
   local profile="$1"
   local instance_name
@@ -373,11 +410,28 @@ reap_stale_profile_processes() {
 
 maybe_reap_stale_profile_processes() {
   local profile="$1"
+  local status=""
+  local status_rc=0
 
-  if run_host_colima status --profile "${profile}" >/dev/null 2>&1; then
-    return 0
+  if status="$(colima_profile_status "${profile}")"; then
+    status_rc=0
+  else
+    status_rc=$?
   fi
-  reap_stale_profile_processes "${profile}"
+
+  case "${status}" in
+    Running)
+      return 0
+      ;;
+    Stopped)
+      reap_stale_profile_processes "${profile}"
+      return 0
+      ;;
+  esac
+
+  if ((status_rc == 3)) && profile_process_pids "${profile}" | grep -q .; then
+    reap_stale_profile_processes "${profile}"
+  fi
 }
 
 sanitize_host_docker_env() {

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -315,8 +315,10 @@ colima_profile_status() {
   local profile="$1"
   local list_output=""
 
-  list_output="$(run_host_colima list --json 2>/dev/null || true)"
-  [[ -n "${list_output}" ]] || return 1
+  if ! list_output="$(run_host_colima list --json 2>/dev/null)"; then
+    return 1
+  fi
+  [[ -n "${list_output}" ]] || return 3
 
   env -i \
     PATH="${TRUSTED_HOST_PATH}" \


### PR DESCRIPTION
## Summary
- reap stale Colima processes only when the profile is explicitly stopped or truly missing with orphaned PIDs
- add regression coverage for Colima status parsing and empty-profile-list handling
- harden the Gemini startup smoke to assert no trust prompt, no restart loop, and no relaunch failure

## Why
PR #15 merged before the final two signed fixes on the source branch were re-landed. This follow-up carries only the validated delta still missing from `main`.

## Validation
- `bash -n scripts/workcell scripts/verify-invariants.sh scripts/container-smoke.sh`
- `./scripts/validate-repo.sh`
