### PR TITLE
ci: run arm reproducible build on native runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
   reproducible-build-platform:
     name: Reproducible build (${{ matrix.platform_name }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: validate
     strategy:
       fail-fast: false
@@ -95,18 +95,14 @@ jobs:
         include:
           - platform: linux/amd64
             platform_name: amd64
+            runner: ubuntu-latest
           - platform: linux/arm64
             platform_name: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
-      - if: ${{ matrix.platform == 'linux/arm64' }}
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-        with:
-          cache-image: true
-          image: ${{ env.WORKCELL_QEMU_IMAGE }}
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -373,8 +373,40 @@ if "driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}" not in release_workfl
     raise SystemExit(".github/workflows/release.yml must pin the BuildKit daemon image used by setup-buildx-action")
 if "cache-binary: true" not in ci_workflow:
     raise SystemExit("Pinned buildx binary caching must stay enabled in .github/workflows/ci.yml")
-if "cache-image: true" not in ci_workflow:
-    raise SystemExit("Pinned QEMU image caching must stay enabled in .github/workflows/ci.yml")
+ci_repro_build_job = require_regex(
+    ci_workflow,
+    r"^  reproducible-build-platform:\n(?P<body>[\s\S]*?)(?=^  reproducible-build:\n)",
+    "reproducible-build-platform job",
+    ".github/workflows/ci.yml",
+).group("body")
+if not re.search(r"^\s{4}runs-on:\s*\$\{\{\s*matrix\.runner\s*\}\}$", ci_repro_build_job, re.MULTILINE):
+    raise SystemExit(
+        ".github/workflows/ci.yml must route reproducible-build-platform through runs-on: ${{ matrix.runner }}"
+    )
+ci_repro_strategy_block = require_regex(
+    ci_repro_build_job,
+    r"^    strategy:\n(?P<body>[\s\S]*?)(?=^    steps:\n)",
+    "reproducible-build-platform strategy block",
+    ".github/workflows/ci.yml",
+).group(0)
+expected_ci_repro_strategy_block = (
+    "    strategy:\n"
+    "      fail-fast: false\n"
+    "      matrix:\n"
+    "        include:\n"
+    "          - platform: linux/amd64\n"
+    "            platform_name: amd64\n"
+    "            runner: ubuntu-latest\n"
+    "          - platform: linux/arm64\n"
+    "            platform_name: arm64\n"
+    "            runner: ubuntu-24.04-arm\n"
+)
+if ci_repro_strategy_block != expected_ci_repro_strategy_block:
+    raise SystemExit(
+        ".github/workflows/ci.yml must keep the reviewed reproducible-build matrix structure, including a single native ubuntu-24.04-arm lane for linux/arm64"
+    )
+if "docker/setup-qemu-action@" in ci_workflow:
+    raise SystemExit(".github/workflows/ci.yml must not configure QEMU in CI now that arm64 reproducible builds use a native runner")
 if "cache-binary: false" not in release_workflow:
     raise SystemExit("The publishing release workflow must not cache the Buildx binary")
 if "cache-image: false" not in release_workflow:

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -140,6 +140,20 @@ def walk_strings(value):
         for nested in value:
             yield from walk_strings(nested)
 
+def extract_repro_matrix_entries(strategy_block: str, path: str) -> list[tuple[str, str, str]]:
+    entries = re.findall(
+        r"^\s{10}- platform:\s*(\S+)\n"
+        r"^\s{12}platform_name:\s*(\S+)\n"
+        r"^\s{12}runner:\s*(\S+)$",
+        strategy_block,
+        re.MULTILINE,
+    )
+    if not entries:
+        raise SystemExit(
+            f"Unable to extract reproducible-build matrix entries from {path}"
+        )
+    return entries
+
 def require_no_registry_bootstrap_mcp(config: dict, path: str) -> None:
     disallowed_fragments = (
         "npx",
@@ -404,6 +418,18 @@ expected_ci_repro_strategy_block = (
 if ci_repro_strategy_block != expected_ci_repro_strategy_block:
     raise SystemExit(
         ".github/workflows/ci.yml must keep the reviewed reproducible-build matrix structure, including a single native ubuntu-24.04-arm lane for linux/arm64"
+    )
+ci_repro_matrix_entries = extract_repro_matrix_entries(
+    ci_repro_strategy_block,
+    ".github/workflows/ci.yml",
+)
+arm64_entries = [
+    entry for entry in ci_repro_matrix_entries
+    if entry[0] == "linux/arm64"
+]
+if arm64_entries != [("linux/arm64", "arm64", "ubuntu-24.04-arm")]:
+    raise SystemExit(
+        ".github/workflows/ci.yml must define exactly one linux/arm64 reproducible-build matrix entry and it must use runner ubuntu-24.04-arm"
     )
 if "docker/setup-qemu-action@" in ci_workflow:
     raise SystemExit(".github/workflows/ci.yml must not configure QEMU in CI now that arm64 reproducible builds use a native runner")


### PR DESCRIPTION
## Summary
- move the CI arm64 reproducible-build lane from x64+QEMU to the native `ubuntu-24.04-arm` hosted runner
- keep amd64 on `ubuntu-latest`
- tighten `scripts/check-pinned-inputs.sh` to pin the exact reviewed matrix structure for `reproducible-build-platform`

## Why
Recent successful CI runs show the arm64 reproducible-build lane is the dominant bottleneck:
- last 10 successful CI runs on March 26, 2026: arm64 averaged about `24m08s`
- the same runs: amd64 averaged about `6m13s`
- arm64 was about `3.89x` slower on average

The current workflow runs both lanes on `ubuntu-latest`, and only the arm64 lane turns on QEMU. This change targets that measured emulation overhead directly.

A bigger GitHub-hosted ARM runner is not a practical option on this repo as it stands: `omkhar/workcell` is a private user-owned repo, and GitHub larger runners are not available here. The realistic lever is native `ubuntu-24.04-arm`, not a bigger box.

## Validation
- `./scripts/check-pinned-inputs.sh`
- `./scripts/check-workflows.sh`
- `./scripts/validate-repo.sh`

## Rollout
If PR CI is green, compare the next few successful runs against the current arm64 baseline before changing anything else in the reproducible-build path.
