### PR TITLE
ci: narrow workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 env:
   WORKCELL_BUILDKIT_IMAGE: moby/buildkit:buildx-stable-1@sha256:37539dd4d60fc70968d164d3850d903a2c56f6402214a1953fbf9fcb81ada731
@@ -25,6 +25,8 @@ jobs:
   validate:
     name: Validate repository
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -77,6 +79,8 @@ jobs:
     name: Container smoke
     runs-on: ubuntu-latest
     needs: validate
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -89,6 +93,8 @@ jobs:
     name: Reproducible build (${{ matrix.platform_name }})
     runs-on: ${{ matrix.runner }}
     needs: validate
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
     - cron: "15 2 * * 3"
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ on:
       - "workflows/**"
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -43,6 +43,8 @@ jobs:
   spelling-and-manpage:
     name: Spelling and manpage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/hosted-controls.yml
+++ b/.github/workflows/hosted-controls.yml
@@ -8,7 +8,7 @@ on:
     - cron: "23 5 * * 1"
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: hosted-controls-audit
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/macos-boundary.yml
+++ b/.github/workflows/macos-boundary.yml
@@ -6,7 +6,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,6 +19,8 @@ jobs:
     runs-on:
       - self-hosted
       - macOS
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/pin-hygiene.yml
+++ b/.github/workflows/pin-hygiene.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 14 * * 2"
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 env:
   WORKCELL_COSIGN_VERSION: v3.0.5
@@ -18,6 +18,8 @@ jobs:
   pinned-inputs:
     name: Check pinned inputs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v*"
 
-permissions: read-all
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,6 +27,7 @@ jobs:
     environment:
       name: hosted-controls-audit
     permissions:
+      actions: read
       contents: read
       security-events: write
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,7 +8,7 @@ on:
     - cron: "30 1 * * 6"
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +20,8 @@ jobs:
     name: Dependency review
     if: ${{ github.event_name == 'pull_request' && (!github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_DEPENDENCY_REVIEW == 'true') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -32,6 +34,8 @@ jobs:
   actionlint:
     name: GitHub Actions lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,1 @@
-rules:
-  excessive-permissions:
-    ignore:
-      - ci.yml:12
-      - security.yml:12
+rules: {}

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -574,8 +574,8 @@ for workflow_path in sorted(workflows_dir.glob("*.yml")):
     workflow_text = workflow_path.read_text(encoding="utf-8")
     require_regex(
         workflow_text,
-        r"^permissions:\s+read-all$",
-        "workflow-level read-all permissions",
+        r"^permissions:\s+\{\}$",
+        "workflow-level empty permissions declaration",
         str(workflow_path.relative_to(workflows_dir.parent.parent)),
     )
     require_not_regex(


### PR DESCRIPTION
## Summary
- remove the explicit `zizmor` excessive-permissions ignores by tightening `CI` and `Security` to workflow-level `permissions: {}` with per-job minima
- narrow the rest of the workflow fleet away from redundant top-level `permissions: read-all`
- keep explicit higher-scope jobs only where they are still required, including `release` preflight `actions: read` for `zizmor-action`

## Local validation
- `./scripts/check-workflows.sh`
- `actionlint .github/workflows/*.yml`
- `zizmor .github/workflows`

## Peer review
- permissions-focused review found one real regression in `release.yml` (`zizmor-action` still needed `actions: read` in private-repo preflight); fixed in follow-up commit
- final reviewed worktree returned no findings and is merge-ready pending PR CI
