### PR TITLE
fix: support Gemini auth parsing on Bash 3.2

### DIFF
--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -429,7 +429,8 @@ workcell_validate_gemini_env_file_syntax() {
   local line=""
   local parsed_key=""
   local value=""
-  local -A seen_keys=()
+  # Keep duplicate-key tracking compatible with host-side Bash 3.2 invariant runs.
+  local seen_keys=$'\n'
 
   [[ -f "${env_path}" ]] || return 0
 
@@ -450,10 +451,12 @@ workcell_validate_gemini_env_file_syntax() {
 
     parsed_key="${BASH_REMATCH[1]}"
     value="${BASH_REMATCH[2]}"
-    if [[ -n "${seen_keys[${parsed_key}]:-}" ]]; then
-      workcell_die "Gemini auth env file ${env_path} configures ${parsed_key} more than once."
-    fi
-    seen_keys["${parsed_key}"]=1
+    case "${seen_keys}" in
+      *$'\n'"${parsed_key}"$'\n'*)
+        workcell_die "Gemini auth env file ${env_path} configures ${parsed_key} more than once."
+        ;;
+    esac
+    seen_keys+="${parsed_key}"$'\n'
 
     if ! workcell_gemini_env_key_is_supported "${parsed_key}"; then
       workcell_die "Unsupported key in Gemini auth env file ${env_path}: ${parsed_key}."

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3760,6 +3760,22 @@ if expect_fatal_function_failure /tmp/gemini-unsupported.stdout /tmp/gemini-unsu
 fi
 grep -q 'Unsupported key in Gemini auth env file' /tmp/gemini-unsupported.stderr
 
+printf 'GEMINI_API_KEY=one\nGEMINI_API_KEY=two\n' >"${TMP_DIR}/duplicate-api-key.env"
+if expect_fatal_function_failure /tmp/gemini-duplicate-api-key.stdout /tmp/gemini-duplicate-api-key.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/duplicate-api-key.env"; then
+  echo "Expected duplicate GEMINI_API_KEY assignments to be rejected" >&2
+  exit 1
+fi
+grep -q 'configures GEMINI_API_KEY more than once' /tmp/gemini-duplicate-api-key.stderr
+
+printf ' export GOOGLE_GENAI_USE_GCA=true\nGOOGLE_GENAI_USE_GCA=false\n' >"${TMP_DIR}/duplicate-exported-bool.env"
+if expect_fatal_function_failure /tmp/gemini-duplicate-exported-bool.stdout /tmp/gemini-duplicate-exported-bool.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/duplicate-exported-bool.env"; then
+  echo "Expected duplicate exported Gemini auth selectors to be rejected" >&2
+  exit 1
+fi
+grep -q 'configures GOOGLE_GENAI_USE_GCA more than once' /tmp/gemini-duplicate-exported-bool.stderr
+
 printf 'GOOGLE_GENAI_USE_GCA=true\nGOOGLE_GENAI_USE_VERTEXAI=true\n' >"${TMP_DIR}/conflicting-selectors.env"
 if expect_fatal_function_failure /tmp/gemini-conflicting.stdout /tmp/gemini-conflicting.stderr \
   workcell_validate_gemini_env_auth_config "${TMP_DIR}/conflicting-selectors.env"; then


### PR DESCRIPTION
## Summary
- replace Bash 4 associative-array duplicate tracking in Gemini env validation with a Bash 3.2-compatible sentinel set
- add explicit duplicate-key regressions to the Gemini auth invariant harness
- preserve the existing Gemini auth validation behavior while unblocking macOS host-side invariant runs

## Testing
- git diff --check
- /bin/bash -n runtime/container/home-control-plane.sh scripts/verify-invariants.sh
- shellcheck -x runtime/container/home-control-plane.sh scripts/verify-invariants.sh
- extracted Gemini auth harness under /bin/bash
- ./scripts/validate-repo.sh
- plain-clone ./scripts/verify-invariants.sh