### PR TITLE
fix: make Codex config session-writable

### DIFF
--- a/docs/adapter-control-planes.md
+++ b/docs/adapter-control-planes.md
@@ -32,7 +32,7 @@ The following table covers all files seeded by `seed_codex_home()`,
 | File / Path | Provider | Safe path status | Breakglass status | Description |
 |---|---|---|---|---|
 | `~/.codex/AGENTS.md` | Codex | Rendered (baseline + workspace + injection layers) | Same | Provider instruction doc; workspace `AGENTS.md` is imported as a layer |
-| `~/.codex/config.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/.codex/config.toml`; disables analytics, history, web search; sets env exclusion list |
+| `~/.codex/config.toml` | Codex | Session-local writable copy of the baseline; reset on each launch | Same | Seeded from `adapters/codex/.codex/config.toml`; disables analytics, history, web search; sets env exclusion list while still allowing Codex to persist per-session preferences |
 | `~/.codex/managed_config.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/managed_config.toml`; admin-enforced allowed approval policies, sandbox modes, web search modes, and execpolicy rules |
 | `~/.codex/requirements.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/requirements.toml`; hard requirements for the adapter including forbidden command patterns |
 | `~/.codex/agents/` | Codex | Symlink → immutable baseline agents dir | Same | Linked to `adapters/codex/.codex/agents/` |

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -33,6 +33,7 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
   && install_runtime_packages() { \
        DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        bash \
+       bubblewrap \
        ca-certificates \
        curl \
        fd-find \

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -101,6 +101,16 @@ workcell_copy_control_plane_tree() {
   chmod "${dir_mode}" "${target_path}"
 }
 
+workcell_copy_control_plane_file() {
+  local source_path="$1"
+  local target_path="$2"
+  local file_mode="$3"
+
+  workcell_reset_session_target "${target_path}" "control-plane file"
+  cp "${source_path}" "${target_path}"
+  chmod "${file_mode}" "${target_path}"
+}
+
 WORKCELL_WORKSPACE_IMPORT_ROOT="${WORKCELL_WORKSPACE_IMPORT_ROOT:-/opt/workcell/workspace-control-plane}"
 WORKCELL_CODEX_RULES_MUTABILITY="${WORKCELL_CODEX_RULES_MUTABILITY:-readonly}"
 
@@ -952,7 +962,8 @@ seed_codex_home() {
   workcell_prepare_session_directory "${CODEX_HOME}" "Codex home"
   workcell_prepare_session_directory "${CODEX_HOME}/mcp" "Codex MCP directory"
   workcell_render_provider_doc "${ADAPTER_ROOT}/codex/.codex/AGENTS.md" "${CODEX_HOME}/AGENTS.md" codex
-  workcell_link_control_plane_path "${ADAPTER_ROOT}/codex/.codex/config.toml" "${CODEX_HOME}/config.toml"
+  workcell_copy_control_plane_file "${ADAPTER_ROOT}/codex/.codex/config.toml" "${CODEX_HOME}/config.toml" 0600
+  workcell_assert_session_regular_writable_file "${CODEX_HOME}/config.toml" "Codex config"
   workcell_link_control_plane_path "${ADAPTER_ROOT}/codex/managed_config.toml" "${CODEX_HOME}/managed_config.toml"
   workcell_link_control_plane_path "${ADAPTER_ROOT}/codex/requirements.toml" "${CODEX_HOME}/requirements.toml"
   workcell_link_control_plane_path "${ADAPTER_ROOT}/codex/.codex/agents" "${CODEX_HOME}/agents"

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -239,6 +239,7 @@ require_exact_packages(
     runtime_install_blocks[0],
     [
         "bash",
+        "bubblewrap",
         "ca-certificates",
         "curl",
         "fd-find",

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1762,6 +1762,15 @@ run_container codex bash -lc '
         exit 1
       fi
     }
+    assert_codex_feature_value() {
+      local expected_value="$1"
+      if grep -Eq "^\[profiles\.strict\.features\]$" "$CODEX_HOME/config.toml"; then
+        grep -q "^unified_exec = ${expected_value}$" "$CODEX_HOME/config.toml"
+        return 0
+      fi
+      grep -Eq "^\[features\]$" "$CODEX_HOME/config.toml"
+      grep -q "^unified_exec = ${expected_value}$" "$CODEX_HOME/config.toml"
+    }
     EXEC_TMP="$TMPDIR/workcell-exec"
     mkdir -p "$EXEC_TMP"
     codex --version >/tmp/codex-version.out 2>/tmp/codex-version.err
@@ -1837,16 +1846,22 @@ run_container codex bash -lc '
       exit 1
     fi
     grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-app-server.out
+    rm -f "$CODEX_HOME/config.toml"
+    printf "web_search = \"enabled\"\n" >"$CODEX_HOME/config.toml"
+    codex --version >/tmp/codex-version-after-tamper.out 2>/tmp/codex-version-after-tamper.err
+    grep -q "codex-cli" /tmp/codex-version-after-tamper.out
+    assert_codex_stderr_clean /tmp/codex-version-after-tamper.err
+    test ! -L "$CODEX_HOME/config.toml"
+    test -w "$CODEX_HOME/config.toml"
+    cmp "$CODEX_HOME/config.toml" /opt/workcell/adapters/codex/.codex/config.toml
     codex features disable unified_exec >/tmp/codex-features-disable.out 2>/tmp/codex-features-disable.err
     assert_codex_stderr_clean /tmp/codex-features-disable.err
     test ! -L "$CODEX_HOME/config.toml"
     test -w "$CODEX_HOME/config.toml"
-    grep -q "^\[profiles\.strict\.features\]$" "$CODEX_HOME/config.toml"
-    grep -q "^unified_exec = false$" "$CODEX_HOME/config.toml"
+    assert_codex_feature_value false
     codex features enable unified_exec >/tmp/codex-features-enable.out 2>/tmp/codex-features-enable.err
     assert_codex_stderr_clean /tmp/codex-features-enable.err
-    grep -q "^\[profiles\.strict\.features\]$" "$CODEX_HOME/config.toml"
-    grep -q "^unified_exec = true$" "$CODEX_HOME/config.toml"
+    assert_codex_feature_value true
   '"'"'
   if /usr/local/libexec/workcell/real/codex --version >/tmp/codex-real-path.out 2>&1; then
     echo "expected direct real Codex payload execution to fail" >&2

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1752,6 +1752,8 @@ run_container codex bash -lc '
     test "$TMPDIR" = "/state/tmp"
     mkdir -p "$TMPDIR"
     touch "$TMPDIR/workcell-tmpdir-ok"
+    test -x /usr/bin/bwrap
+    test ! -u /usr/bin/bwrap
     EXEC_TMP="$TMPDIR/workcell-exec"
     mkdir -p "$EXEC_TMP"
     codex --version | grep -q "codex-cli"
@@ -1760,8 +1762,9 @@ run_container codex bash -lc '
     LD_PRELOAD=/workspace/workcell-does-not-exist.so git --version | grep -q "git version"
     LD_PRELOAD=/workspace/workcell-does-not-exist.so node --version | grep -q "^v"
     test -f "$CODEX_HOME/config.toml"
-    test -L "$CODEX_HOME/config.toml"
-    test "$(readlink "$CODEX_HOME/config.toml")" = "/opt/workcell/adapters/codex/.codex/config.toml"
+    test ! -L "$CODEX_HOME/config.toml"
+    test -w "$CODEX_HOME/config.toml"
+    cmp "$CODEX_HOME/config.toml" /opt/workcell/adapters/codex/.codex/config.toml
     codex features list >/dev/null
     if command -v python3 >/tmp/python-which.out 2>&1; then
       echo "expected runtime image to omit python3 from the operator PATH" >&2
@@ -1826,8 +1829,9 @@ run_container codex bash -lc '
     rm -f "$CODEX_HOME/config.toml"
     printf "web_search = \"enabled\"\n" >"$CODEX_HOME/config.toml"
     codex --version >/dev/null
-    test -L "$CODEX_HOME/config.toml"
-    test "$(readlink "$CODEX_HOME/config.toml")" = "/opt/workcell/adapters/codex/.codex/config.toml"
+    test ! -L "$CODEX_HOME/config.toml"
+    test -w "$CODEX_HOME/config.toml"
+    cmp "$CODEX_HOME/config.toml" /opt/workcell/adapters/codex/.codex/config.toml
   '"'"'
   if /usr/local/libexec/workcell/real/codex --version >/tmp/codex-real-path.out 2>&1; then
     echo "expected direct real Codex payload execution to fail" >&2

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1754,9 +1754,19 @@ run_container codex bash -lc '
     touch "$TMPDIR/workcell-tmpdir-ok"
     test -x /usr/bin/bwrap
     test ! -u /usr/bin/bwrap
+    assert_codex_stderr_clean() {
+      local stderr_path="$1"
+      if grep -Eq "Codex could not find system bubblewrap|Failed to save model migration prompt preference|Failed to save model for profile|failed to persist config.toml" "$stderr_path"; then
+        echo "expected Codex startup to avoid bubblewrap/config persistence warnings" >&2
+        cat "$stderr_path" >&2
+        exit 1
+      fi
+    }
     EXEC_TMP="$TMPDIR/workcell-exec"
     mkdir -p "$EXEC_TMP"
-    codex --version | grep -q "codex-cli"
+    codex --version >/tmp/codex-version.out 2>/tmp/codex-version.err
+    grep -q "codex-cli" /tmp/codex-version.out
+    assert_codex_stderr_clean /tmp/codex-version.err
     LD_PRELOAD=/workspace/workcell-does-not-exist.so codex --version | grep -q "codex-cli"
     LD_PRELOAD=/workspace/workcell-does-not-exist.so claude --version >/dev/null
     LD_PRELOAD=/workspace/workcell-does-not-exist.so git --version | grep -q "git version"
@@ -1765,7 +1775,8 @@ run_container codex bash -lc '
     test ! -L "$CODEX_HOME/config.toml"
     test -w "$CODEX_HOME/config.toml"
     cmp "$CODEX_HOME/config.toml" /opt/workcell/adapters/codex/.codex/config.toml
-    codex features list >/dev/null
+    codex features list >/tmp/codex-features.out 2>/tmp/codex-features.err
+    assert_codex_stderr_clean /tmp/codex-features.err
     if command -v python3 >/tmp/python-which.out 2>&1; then
       echo "expected runtime image to omit python3 from the operator PATH" >&2
       exit 1
@@ -1826,12 +1837,16 @@ run_container codex bash -lc '
       exit 1
     fi
     grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-app-server.out
-    rm -f "$CODEX_HOME/config.toml"
-    printf "web_search = \"enabled\"\n" >"$CODEX_HOME/config.toml"
-    codex --version >/dev/null
+    codex features disable unified_exec >/tmp/codex-features-disable.out 2>/tmp/codex-features-disable.err
+    assert_codex_stderr_clean /tmp/codex-features-disable.err
     test ! -L "$CODEX_HOME/config.toml"
     test -w "$CODEX_HOME/config.toml"
-    cmp "$CODEX_HOME/config.toml" /opt/workcell/adapters/codex/.codex/config.toml
+    grep -q "^\[profiles\.strict\.features\]$" "$CODEX_HOME/config.toml"
+    grep -q "^unified_exec = false$" "$CODEX_HOME/config.toml"
+    codex features enable unified_exec >/tmp/codex-features-enable.out 2>/tmp/codex-features-enable.err
+    assert_codex_stderr_clean /tmp/codex-features-enable.err
+    grep -q "^\[profiles\.strict\.features\]$" "$CODEX_HOME/config.toml"
+    grep -q "^unified_exec = true$" "$CODEX_HOME/config.toml"
   '"'"'
   if /usr/local/libexec/workcell/real/codex --version >/tmp/codex-real-path.out 2>&1; then
     echo "expected direct real Codex payload execution to fail" >&2


### PR DESCRIPTION
## Summary
- seed `~/.codex/config.toml` as a session-local writable copy instead of an immutable symlink
- install non-setuid `/usr/bin/bwrap` in the runtime image so Codex no longer falls back with a missing-bubblewrap warning
- update smoke coverage and control-plane docs to match the new Codex startup contract

## Validation
- `git diff --check`
- `bash -n runtime/container/home-control-plane.sh scripts/container-smoke.sh`
- `shellcheck -x runtime/container/home-control-plane.sh scripts/container-smoke.sh`
- `./scripts/workcell --rebuild --prepare-only --agent codex --workspace "$PWD" --log-level debug`
- `WORKCELL_CONTAINER_SMOKE_DOCKER_CONTEXT=workcell-localtest WORKCELL_IMAGE_TAG=workcell:local ./scripts/container-smoke.sh`
- `./scripts/validate-repo.sh`
- `./scripts/verify-invariants.sh`
