### PR TITLE
Pin Codex strict profile in managed_config to enforce immutable sandbox and approval settings

### DIFF
--- a/adapters/codex/managed_config.toml
+++ b/adapters/codex/managed_config.toml
@@ -7,6 +7,7 @@
 analytics.enabled = false
 history.persistence = "none"
 web_search = "disabled"
+profile = "strict"
 
 [shell_environment_policy]
 inherit = "core"
@@ -37,6 +38,24 @@ network_access = false
 
 [features]
 unified_exec = true
+
+[profiles.strict]
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"
+web_search = "disabled"
+
+[profiles.build]
+sandbox_mode = "workspace-write"
+approval_policy = "never"
+web_search = "disabled"
+
+[profiles.build.sandbox_workspace_write]
+network_access = true
+
+[profiles.breakglass]
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
+web_search = "disabled"
 
 [[rules.prefix_rules]]
 pattern = [{ any_of = ["git", "/usr/bin/git", "/usr/local/libexec/workcell/git", "/usr/local/libexec/workcell/core/git", "/usr/local/libexec/workcell/real/git"] }, { token = "commit" }, { any_of = ["--no-verify", "-n"] }]

--- a/docs/adapter-control-planes.md
+++ b/docs/adapter-control-planes.md
@@ -32,8 +32,8 @@ The following table covers all files seeded by `seed_codex_home()`,
 | File / Path | Provider | Safe path status | Breakglass status | Description |
 |---|---|---|---|---|
 | `~/.codex/AGENTS.md` | Codex | Rendered (baseline + workspace + injection layers) | Same | Provider instruction doc; workspace `AGENTS.md` is imported as a layer |
-| `~/.codex/config.toml` | Codex | Session-local writable copy of the baseline; reset on each launch | Same | Seeded from `adapters/codex/.codex/config.toml`; disables analytics, history, web search; sets env exclusion list while still allowing Codex to persist per-session preferences |
-| `~/.codex/managed_config.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/managed_config.toml`; admin-enforced allowed approval policies, sandbox modes, web search modes, and execpolicy rules |
+| `~/.codex/config.toml` | Codex | Session-local writable copy of the baseline; reset on each launch | Same | Seeded from `adapters/codex/.codex/config.toml`; holds user/session-tunable defaults (analytics, history, project markers, etc.) |
+| `~/.codex/managed_config.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/managed_config.toml`; admin-enforced strict default profile plus pinned profile sandbox/approval settings, web search modes, and execpolicy rules |
 | `~/.codex/requirements.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/requirements.toml`; hard requirements for the adapter including forbidden command patterns |
 | `~/.codex/agents/` | Codex | Symlink → immutable baseline agents dir | Same | Linked to `adapters/codex/.codex/agents/` |
 | `~/.codex/rules/` | Codex | Symlink → immutable baseline (readonly) or session-local writable copy (session) | Same | Execpolicy rules; see rules mutability section below |

--- a/docs/adapter-control-planes.md
+++ b/docs/adapter-control-planes.md
@@ -32,7 +32,7 @@ The following table covers all files seeded by `seed_codex_home()`,
 | File / Path | Provider | Safe path status | Breakglass status | Description |
 |---|---|---|---|---|
 | `~/.codex/AGENTS.md` | Codex | Rendered (baseline + workspace + injection layers) | Same | Provider instruction doc; workspace `AGENTS.md` is imported as a layer |
-| `~/.codex/config.toml` | Codex | Session-local writable copy of the baseline; reset on each launch | Same | Seeded from `adapters/codex/.codex/config.toml`; holds user/session-tunable defaults (analytics, history, project markers, etc.) |
+| `~/.codex/config.toml` | Codex | Session-local writable copy of the baseline; reset on each launch | Same | Seeded from `adapters/codex/.codex/config.toml`; carries the baseline default profile and session-tunable defaults (analytics, history, project markers, etc.), while immutable `managed_config.toml` separately pins the reviewed policy overlay |
 | `~/.codex/managed_config.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/managed_config.toml`; admin-enforced strict default profile plus pinned profile sandbox/approval settings, web search modes, and execpolicy rules |
 | `~/.codex/requirements.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/requirements.toml`; hard requirements for the adapter including forbidden command patterns |
 | `~/.codex/agents/` | Codex | Symlink → immutable baseline agents dir | Same | Linked to `adapters/codex/.codex/agents/` |

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -94,7 +94,21 @@ ARG SOURCE_DATE_EPOCH
 COPY runtime/container/providers /opt/workcell/providers
 
 RUN cd /opt/workcell/providers \
-  && npm ci --omit=dev --ignore-scripts --no-audit --no-fund --no-update-notifier \
+  && install_provider_packages() { \
+       npm ci --omit=dev --ignore-scripts --no-audit --no-fund --no-update-notifier \
+       && return 0; \
+     } \
+  && for attempt in 1 2 3; do \
+       rm -rf /opt/workcell/providers/node_modules; \
+       if install_provider_packages; then \
+         break; \
+       fi; \
+       if [[ "${attempt}" -eq 3 ]]; then \
+         exit 1; \
+       fi; \
+       npm cache clean --force >/dev/null 2>&1 || true; \
+       sleep "$((attempt * 5))"; \
+     done \
   && npm cache clean --force \
   && tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner \
     -cf /tmp/workcell-providers.tar -C /opt/workcell/providers . \

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -389,10 +389,31 @@ toml_section_assignments() {
       return value
     }
 
+    function strip_wrapping_quotes(value, first, last) {
+      value = trim(value)
+      first = substr(value, 1, 1)
+      last = substr(value, length(value), 1)
+
+      if ((first == "\"" && last == "\"") || (first == "'"'"'" && last == "'"'"'")) {
+        return substr(value, 2, length(value) - 2)
+      }
+
+      return value
+    }
+
+    function normalize_toml_name(value) {
+      value = trim(value)
+      gsub(/[[:space:]]*\.[[:space:]]*/, ".", value)
+      value = strip_wrapping_quotes(value)
+      return value
+    }
+
     BEGIN {
       current = "__top__"
       if (want == "") {
         want = "__top__"
+      } else {
+        want = normalize_toml_name(want)
       }
     }
 
@@ -408,6 +429,7 @@ toml_section_assignments() {
         current = line
         gsub(/^[[:space:]]*\[/, "", current)
         gsub(/\][[:space:]]*$/, "", current)
+        current = normalize_toml_name(current)
         next
       }
 
@@ -420,9 +442,54 @@ toml_section_assignments() {
       }
 
       split(line, parts, "=")
-      key = trim(parts[1])
+      key = normalize_toml_name(parts[1])
       value = trim(substr(line, index(line, "=") + 1))
       print key "=" value
+    }
+  ' "${file}"
+}
+
+toml_section_names() {
+  local file="$1"
+
+  awk '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+
+    function strip_wrapping_quotes(value, first, last) {
+      value = trim(value)
+      first = substr(value, 1, 1)
+      last = substr(value, length(value), 1)
+
+      if ((first == "\"" && last == "\"") || (first == "'"'"'" && last == "'"'"'")) {
+        return substr(value, 2, length(value) - 2)
+      }
+
+      return value
+    }
+
+    function normalize_toml_name(value) {
+      value = trim(value)
+      gsub(/[[:space:]]*\.[[:space:]]*/, ".", value)
+      value = strip_wrapping_quotes(value)
+      return value
+    }
+
+    {
+      line = $0
+      sub(/[[:space:]]+#.*$/, "", line)
+
+      if (line !~ /^[[:space:]]*\[/) {
+        next
+      }
+
+      section = line
+      gsub(/^[[:space:]]*\[/, "", section)
+      gsub(/\][[:space:]]*$/, "", section)
+      print normalize_toml_name(section)
     }
   ' "${file}"
 }
@@ -449,12 +516,12 @@ require_toml_assignment() {
     '
   )" || {
     echo "Expected ${file} section [${section:-top-level}] to define ${key}" >&2
-    exit 1
+    return 1
   }
 
   if [[ "${actual}" != "${expected}" ]]; then
     echo "Expected ${file} section [${section:-top-level}] to set ${key}=${expected}, got ${actual}" >&2
-    exit 1
+    return 1
   fi
 }
 
@@ -465,7 +532,7 @@ require_toml_key_absent() {
 
   if toml_section_assignments "${file}" "${section}" | cut -d= -f1 | grep -Fxq -- "${key}"; then
     echo "Expected ${file} section [${section:-top-level}] not to define ${key}" >&2
-    exit 1
+    return 1
   fi
 }
 
@@ -488,7 +555,7 @@ require_toml_exact_keys() {
     echo "Expected ${file} section [${section:-top-level}] to contain the exact reviewed key set" >&2
     diff -u "${expected_keys}" "${actual_keys}" >&2 || true
     rm -rf "${tmpdir}"
-    exit 1
+    return 1
   fi
 
   rm -rf "${tmpdir}"
@@ -498,55 +565,89 @@ require_toml_section_absent() {
   local file="$1"
   local section="$2"
 
-  if grep -Fxq -- "[${section}]" "${file}"; then
+  if toml_section_names "${file}" | grep -Fxq -- "${section}"; then
     echo "Expected ${file} not to define [${section}]" >&2
-    exit 1
+    return 1
+  fi
+}
+
+verify_codex_managed_config_invariants() {
+  local file="$1"
+
+  require_toml_assignment "${file}" "" "profile" '"strict"' || return 1
+  require_toml_key_absent "${file}" "" "sandbox" || return 1
+  require_toml_key_absent "${file}" "" "sandbox_mode" || return 1
+  require_toml_key_absent "${file}" "" "sandbox_permissions" || return 1
+  require_toml_key_absent "${file}" "" "approval_policy" || return 1
+
+  require_toml_exact_keys "${file}" "sandbox_workspace_write" \
+    "exclude_slash_tmp" \
+    "exclude_tmpdir_env_var" \
+    "network_access" || return 1
+  require_toml_assignment "${file}" "sandbox_workspace_write" "exclude_slash_tmp" "true" || return 1
+  require_toml_assignment "${file}" "sandbox_workspace_write" "exclude_tmpdir_env_var" "true" || return 1
+  require_toml_assignment "${file}" "sandbox_workspace_write" "network_access" "false" || return 1
+
+  require_toml_exact_keys "${file}" "profiles.strict" \
+    "approval_policy" \
+    "sandbox_mode" \
+    "web_search" || return 1
+  require_toml_assignment "${file}" "profiles.strict" "sandbox_mode" '"workspace-write"' || return 1
+  require_toml_assignment "${file}" "profiles.strict" "approval_policy" '"on-request"' || return 1
+  require_toml_assignment "${file}" "profiles.strict" "web_search" '"disabled"' || return 1
+  require_toml_section_absent "${file}" "profiles.strict.sandbox_workspace_write" || return 1
+
+  require_toml_exact_keys "${file}" "profiles.build" \
+    "approval_policy" \
+    "sandbox_mode" \
+    "web_search" || return 1
+  require_toml_assignment "${file}" "profiles.build" "sandbox_mode" '"workspace-write"' || return 1
+  require_toml_assignment "${file}" "profiles.build" "approval_policy" '"never"' || return 1
+  require_toml_assignment "${file}" "profiles.build" "web_search" '"disabled"' || return 1
+
+  require_toml_exact_keys "${file}" "profiles.build.sandbox_workspace_write" "network_access" || return 1
+  require_toml_assignment "${file}" "profiles.build.sandbox_workspace_write" "network_access" "true" || return 1
+
+  require_toml_exact_keys "${file}" "profiles.breakglass" \
+    "approval_policy" \
+    "sandbox_mode" \
+    "web_search" || return 1
+  require_toml_assignment "${file}" "profiles.breakglass" "sandbox_mode" '"danger-full-access"' || return 1
+  require_toml_assignment "${file}" "profiles.breakglass" "approval_policy" '"never"' || return 1
+  require_toml_assignment "${file}" "profiles.breakglass" "web_search" '"disabled"' || return 1
+}
+
+assert_codex_managed_config_rejected() {
+  local file="$1"
+  local reason="$2"
+
+  if verify_codex_managed_config_invariants "${file}" >/dev/null 2>&1; then
+    echo "Expected Codex managed config invariant to reject ${reason}" >&2
+    return 1
   fi
 }
 
 CODEX_MANAGED_CONFIG="${ROOT_DIR}/adapters/codex/managed_config.toml"
+verify_codex_managed_config_invariants "${CODEX_MANAGED_CONFIG}" || exit 1
 
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "" "profile" '"strict"'
-require_toml_key_absent "${CODEX_MANAGED_CONFIG}" "" "sandbox"
-require_toml_key_absent "${CODEX_MANAGED_CONFIG}" "" "sandbox_mode"
-require_toml_key_absent "${CODEX_MANAGED_CONFIG}" "" "sandbox_permissions"
-require_toml_key_absent "${CODEX_MANAGED_CONFIG}" "" "approval_policy"
+codex_managed_config_tmpdir="$(mktemp -d)"
 
-require_toml_exact_keys "${CODEX_MANAGED_CONFIG}" "sandbox_workspace_write" \
-  "exclude_slash_tmp" \
-  "exclude_tmpdir_env_var" \
-  "network_access"
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "sandbox_workspace_write" "exclude_slash_tmp" "true"
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "sandbox_workspace_write" "exclude_tmpdir_env_var" "true"
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "sandbox_workspace_write" "network_access" "false"
+quoted_key_config="${codex_managed_config_tmpdir}/quoted-key.toml"
+awk '
+  {
+    print
+    if ($0 == "profile = \"strict\"") {
+      print "\"approval_policy\" = \"never\""
+    }
+  }
+' "${CODEX_MANAGED_CONFIG}" >"${quoted_key_config}"
+assert_codex_managed_config_rejected "${quoted_key_config}" 'quoted top-level approval_policy override' || exit 1
 
-require_toml_exact_keys "${CODEX_MANAGED_CONFIG}" "profiles.strict" \
-  "approval_policy" \
-  "sandbox_mode" \
-  "web_search"
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.strict" "sandbox_mode" '"workspace-write"'
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.strict" "approval_policy" '"on-request"'
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.strict" "web_search" '"disabled"'
-require_toml_section_absent "${CODEX_MANAGED_CONFIG}" "profiles.strict.sandbox_workspace_write"
-
-require_toml_exact_keys "${CODEX_MANAGED_CONFIG}" "profiles.build" \
-  "approval_policy" \
-  "sandbox_mode" \
-  "web_search"
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.build" "sandbox_mode" '"workspace-write"'
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.build" "approval_policy" '"never"'
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.build" "web_search" '"disabled"'
-
-require_toml_exact_keys "${CODEX_MANAGED_CONFIG}" "profiles.build.sandbox_workspace_write" "network_access"
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.build.sandbox_workspace_write" "network_access" "true"
-
-require_toml_exact_keys "${CODEX_MANAGED_CONFIG}" "profiles.breakglass" \
-  "approval_policy" \
-  "sandbox_mode" \
-  "web_search"
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.breakglass" "sandbox_mode" '"danger-full-access"'
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.breakglass" "approval_policy" '"never"'
-require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.breakglass" "web_search" '"disabled"'
+spaced_section_config="${codex_managed_config_tmpdir}/spaced-section.toml"
+cp "${CODEX_MANAGED_CONFIG}" "${spaced_section_config}"
+printf '\n[ profiles.strict.sandbox_workspace_write ]\nnetwork_access = true\n' >>"${spaced_section_config}"
+assert_codex_managed_config_rejected "${spaced_section_config}" 'whitespace-padded strict sandbox override section' || exit 1
+rm -rf "${codex_managed_config_tmpdir}"
 
 if ! sed -n '/^run_host_colima()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq "HOME=\"\${REAL_HOME}\""; then
   echo "Expected run_host_colima to restore the real host HOME instead of the Docker client sandbox home" >&2

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -378,15 +378,175 @@ if ! rg -q 'REAL_HOME=' "${ROOT_DIR}/scripts/workcell"; then
   exit 1
 fi
 
-if ! rg -q '^\[profiles\.strict\]$' "${ROOT_DIR}/adapters/codex/managed_config.toml"; then
-  echo "Expected adapters/codex/managed_config.toml to pin the strict profile block" >&2
-  exit 1
-fi
+toml_section_assignments() {
+  local file="$1"
+  local section="$2"
 
-if ! rg -q '^profile = "strict"$' "${ROOT_DIR}/adapters/codex/managed_config.toml"; then
-  echo "Expected adapters/codex/managed_config.toml to pin the default profile to strict" >&2
-  exit 1
-fi
+  awk -v want="${section}" '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+
+    BEGIN {
+      current = "__top__"
+      if (want == "") {
+        want = "__top__"
+      }
+    }
+
+    {
+      line = $0
+      sub(/[[:space:]]+#.*$/, "", line)
+
+      if (line ~ /^[[:space:]]*$/) {
+        next
+      }
+
+      if (line ~ /^[[:space:]]*\[/) {
+        current = line
+        gsub(/^[[:space:]]*\[/, "", current)
+        gsub(/\][[:space:]]*$/, "", current)
+        next
+      }
+
+      if (current != want) {
+        next
+      }
+
+      if (line !~ /=/) {
+        next
+      }
+
+      split(line, parts, "=")
+      key = trim(parts[1])
+      value = trim(substr(line, index(line, "=") + 1))
+      print key "=" value
+    }
+  ' "${file}"
+}
+
+require_toml_assignment() {
+  local file="$1"
+  local section="$2"
+  local key="$3"
+  local expected="$4"
+  local actual=""
+
+  actual="$(
+    toml_section_assignments "${file}" "${section}" | awk -F= -v want="${key}" '
+      $1 == want {
+        print substr($0, length($1) + 2)
+        found = 1
+        exit
+      }
+      END {
+        if (!found) {
+          exit 1
+        }
+      }
+    '
+  )" || {
+    echo "Expected ${file} section [${section:-top-level}] to define ${key}" >&2
+    exit 1
+  }
+
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "Expected ${file} section [${section:-top-level}] to set ${key}=${expected}, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+require_toml_key_absent() {
+  local file="$1"
+  local section="$2"
+  local key="$3"
+
+  if toml_section_assignments "${file}" "${section}" | cut -d= -f1 | grep -Fxq -- "${key}"; then
+    echo "Expected ${file} section [${section:-top-level}] not to define ${key}" >&2
+    exit 1
+  fi
+}
+
+require_toml_exact_keys() {
+  local file="$1"
+  local section="$2"
+  local tmpdir=""
+  local expected_keys=""
+  local actual_keys=""
+  shift 2
+
+  tmpdir="$(mktemp -d)"
+  expected_keys="${tmpdir}/expected"
+  actual_keys="${tmpdir}/actual"
+
+  printf '%s\n' "$@" | sort >"${expected_keys}"
+  toml_section_assignments "${file}" "${section}" | cut -d= -f1 | sort >"${actual_keys}"
+
+  if ! diff -u "${expected_keys}" "${actual_keys}" >/dev/null; then
+    echo "Expected ${file} section [${section:-top-level}] to contain the exact reviewed key set" >&2
+    diff -u "${expected_keys}" "${actual_keys}" >&2 || true
+    rm -rf "${tmpdir}"
+    exit 1
+  fi
+
+  rm -rf "${tmpdir}"
+}
+
+require_toml_section_absent() {
+  local file="$1"
+  local section="$2"
+
+  if grep -Fxq -- "[${section}]" "${file}"; then
+    echo "Expected ${file} not to define [${section}]" >&2
+    exit 1
+  fi
+}
+
+CODEX_MANAGED_CONFIG="${ROOT_DIR}/adapters/codex/managed_config.toml"
+
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "" "profile" '"strict"'
+require_toml_key_absent "${CODEX_MANAGED_CONFIG}" "" "sandbox"
+require_toml_key_absent "${CODEX_MANAGED_CONFIG}" "" "sandbox_mode"
+require_toml_key_absent "${CODEX_MANAGED_CONFIG}" "" "sandbox_permissions"
+require_toml_key_absent "${CODEX_MANAGED_CONFIG}" "" "approval_policy"
+
+require_toml_exact_keys "${CODEX_MANAGED_CONFIG}" "sandbox_workspace_write" \
+  "exclude_slash_tmp" \
+  "exclude_tmpdir_env_var" \
+  "network_access"
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "sandbox_workspace_write" "exclude_slash_tmp" "true"
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "sandbox_workspace_write" "exclude_tmpdir_env_var" "true"
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "sandbox_workspace_write" "network_access" "false"
+
+require_toml_exact_keys "${CODEX_MANAGED_CONFIG}" "profiles.strict" \
+  "approval_policy" \
+  "sandbox_mode" \
+  "web_search"
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.strict" "sandbox_mode" '"workspace-write"'
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.strict" "approval_policy" '"on-request"'
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.strict" "web_search" '"disabled"'
+require_toml_section_absent "${CODEX_MANAGED_CONFIG}" "profiles.strict.sandbox_workspace_write"
+
+require_toml_exact_keys "${CODEX_MANAGED_CONFIG}" "profiles.build" \
+  "approval_policy" \
+  "sandbox_mode" \
+  "web_search"
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.build" "sandbox_mode" '"workspace-write"'
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.build" "approval_policy" '"never"'
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.build" "web_search" '"disabled"'
+
+require_toml_exact_keys "${CODEX_MANAGED_CONFIG}" "profiles.build.sandbox_workspace_write" "network_access"
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.build.sandbox_workspace_write" "network_access" "true"
+
+require_toml_exact_keys "${CODEX_MANAGED_CONFIG}" "profiles.breakglass" \
+  "approval_policy" \
+  "sandbox_mode" \
+  "web_search"
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.breakglass" "sandbox_mode" '"danger-full-access"'
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.breakglass" "approval_policy" '"never"'
+require_toml_assignment "${CODEX_MANAGED_CONFIG}" "profiles.breakglass" "web_search" '"disabled"'
 
 if ! sed -n '/^run_host_colima()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq "HOME=\"\${REAL_HOME}\""; then
   echo "Expected run_host_colima to restore the real host HOME instead of the Docker client sandbox home" >&2

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -389,23 +389,117 @@ toml_section_assignments() {
       return value
     }
 
-    function strip_wrapping_quotes(value, first, last) {
+    function hex_value(ch) {
+      if (ch >= "0" && ch <= "9") {
+        return ch + 0
+      }
+      ch = tolower(ch)
+      if (ch >= "a" && ch <= "f") {
+        return index("abcdef", ch) + 9
+      }
+      return -1
+    }
+
+    function decode_toml_basic_string(value, i, ch, escaped, hex, code, j) {
+      escaped = ""
+
+      for (i = 1; i <= length(value); i++) {
+        ch = substr(value, i, 1)
+        if (ch != "\\") {
+          escaped = escaped ch
+          continue
+        }
+
+        i++
+        ch = substr(value, i, 1)
+
+        if (ch == "b") {
+          escaped = escaped sprintf("%c", 8)
+        } else if (ch == "t") {
+          escaped = escaped sprintf("%c", 9)
+        } else if (ch == "n") {
+          escaped = escaped sprintf("%c", 10)
+        } else if (ch == "f") {
+          escaped = escaped sprintf("%c", 12)
+        } else if (ch == "r") {
+          escaped = escaped sprintf("%c", 13)
+        } else if (ch == "\"" || ch == "\\") {
+          escaped = escaped ch
+        } else if (ch == "u" || ch == "U") {
+          hex = substr(value, i + 1, (ch == "u" ? 4 : 8))
+          code = 0
+          for (j = 1; j <= length(hex); j++) {
+            code = (code * 16) + hex_value(substr(hex, j, 1))
+          }
+          escaped = escaped sprintf("%c", code)
+          i += length(hex)
+        } else {
+          escaped = escaped ch
+        }
+      }
+
+      return escaped
+    }
+
+    function normalize_toml_segment(value, first, last) {
       value = trim(value)
       first = substr(value, 1, 1)
       last = substr(value, length(value), 1)
 
-      if ((first == "\"" && last == "\"") || (first == "'"'"'" && last == "'"'"'")) {
+      if (first == "\"" && last == "\"") {
+        return decode_toml_basic_string(substr(value, 2, length(value) - 2))
+      }
+
+      if (first == "'"'"'" && last == "'"'"'") {
         return substr(value, 2, length(value) - 2)
       }
 
       return value
     }
 
-    function normalize_toml_name(value) {
+    function normalize_toml_name(value, i, ch, prev, quote, segment, normalized) {
       value = trim(value)
-      gsub(/[[:space:]]*\.[[:space:]]*/, ".", value)
-      value = strip_wrapping_quotes(value)
-      return value
+      quote = ""
+      segment = ""
+      normalized = ""
+
+      for (i = 1; i <= length(value); i++) {
+        ch = substr(value, i, 1)
+        prev = (i > 1 ? substr(value, i - 1, 1) : "")
+
+        if (quote != "") {
+          segment = segment ch
+          if (ch == quote && prev != "\\") {
+            quote = ""
+          }
+          continue
+        }
+
+        if (ch == "\"" || ch == "'"'"'" ) {
+          quote = ch
+          segment = segment ch
+          continue
+        }
+
+        if (ch == ".") {
+          segment = normalize_toml_segment(segment)
+          if (normalized != "") {
+            normalized = normalized "."
+          }
+          normalized = normalized segment
+          segment = ""
+          continue
+        }
+
+        segment = segment ch
+      }
+
+      segment = normalize_toml_segment(segment)
+      if (normalized != "") {
+        normalized = normalized "."
+      }
+      normalized = normalized segment
+      return normalized
     }
 
     BEGIN {
@@ -459,23 +553,117 @@ toml_section_names() {
       return value
     }
 
-    function strip_wrapping_quotes(value, first, last) {
+    function hex_value(ch) {
+      if (ch >= "0" && ch <= "9") {
+        return ch + 0
+      }
+      ch = tolower(ch)
+      if (ch >= "a" && ch <= "f") {
+        return index("abcdef", ch) + 9
+      }
+      return -1
+    }
+
+    function decode_toml_basic_string(value, i, ch, escaped, hex, code, j) {
+      escaped = ""
+
+      for (i = 1; i <= length(value); i++) {
+        ch = substr(value, i, 1)
+        if (ch != "\\") {
+          escaped = escaped ch
+          continue
+        }
+
+        i++
+        ch = substr(value, i, 1)
+
+        if (ch == "b") {
+          escaped = escaped sprintf("%c", 8)
+        } else if (ch == "t") {
+          escaped = escaped sprintf("%c", 9)
+        } else if (ch == "n") {
+          escaped = escaped sprintf("%c", 10)
+        } else if (ch == "f") {
+          escaped = escaped sprintf("%c", 12)
+        } else if (ch == "r") {
+          escaped = escaped sprintf("%c", 13)
+        } else if (ch == "\"" || ch == "\\") {
+          escaped = escaped ch
+        } else if (ch == "u" || ch == "U") {
+          hex = substr(value, i + 1, (ch == "u" ? 4 : 8))
+          code = 0
+          for (j = 1; j <= length(hex); j++) {
+            code = (code * 16) + hex_value(substr(hex, j, 1))
+          }
+          escaped = escaped sprintf("%c", code)
+          i += length(hex)
+        } else {
+          escaped = escaped ch
+        }
+      }
+
+      return escaped
+    }
+
+    function normalize_toml_segment(value, first, last) {
       value = trim(value)
       first = substr(value, 1, 1)
       last = substr(value, length(value), 1)
 
-      if ((first == "\"" && last == "\"") || (first == "'"'"'" && last == "'"'"'")) {
+      if (first == "\"" && last == "\"") {
+        return decode_toml_basic_string(substr(value, 2, length(value) - 2))
+      }
+
+      if (first == "'"'"'" && last == "'"'"'") {
         return substr(value, 2, length(value) - 2)
       }
 
       return value
     }
 
-    function normalize_toml_name(value) {
+    function normalize_toml_name(value, i, ch, prev, quote, segment, normalized) {
       value = trim(value)
-      gsub(/[[:space:]]*\.[[:space:]]*/, ".", value)
-      value = strip_wrapping_quotes(value)
-      return value
+      quote = ""
+      segment = ""
+      normalized = ""
+
+      for (i = 1; i <= length(value); i++) {
+        ch = substr(value, i, 1)
+        prev = (i > 1 ? substr(value, i - 1, 1) : "")
+
+        if (quote != "") {
+          segment = segment ch
+          if (ch == quote && prev != "\\") {
+            quote = ""
+          }
+          continue
+        }
+
+        if (ch == "\"" || ch == "'"'"'" ) {
+          quote = ch
+          segment = segment ch
+          continue
+        }
+
+        if (ch == ".") {
+          segment = normalize_toml_segment(segment)
+          if (normalized != "") {
+            normalized = normalized "."
+          }
+          normalized = normalized segment
+          segment = ""
+          continue
+        }
+
+        segment = segment ch
+      }
+
+      segment = normalize_toml_segment(segment)
+      if (normalized != "") {
+        normalized = normalized "."
+      }
+      normalized = normalized segment
+      return normalized
     }
 
     {
@@ -643,10 +831,27 @@ awk '
 ' "${CODEX_MANAGED_CONFIG}" >"${quoted_key_config}"
 assert_codex_managed_config_rejected "${quoted_key_config}" 'quoted top-level approval_policy override' || exit 1
 
+escaped_key_config="${codex_managed_config_tmpdir}/escaped-key.toml"
+awk '
+  {
+    print
+    if ($0 == "profile = \"strict\"") {
+      print "\"approval\\u005fpolicy\" = \"never\""
+    }
+  }
+' "${CODEX_MANAGED_CONFIG}" >"${escaped_key_config}"
+assert_codex_managed_config_rejected "${escaped_key_config}" 'escaped top-level approval_policy override' || exit 1
+
 spaced_section_config="${codex_managed_config_tmpdir}/spaced-section.toml"
 cp "${CODEX_MANAGED_CONFIG}" "${spaced_section_config}"
 printf '\n[ profiles.strict.sandbox_workspace_write ]\nnetwork_access = true\n' >>"${spaced_section_config}"
 assert_codex_managed_config_rejected "${spaced_section_config}" 'whitespace-padded strict sandbox override section' || exit 1
+
+quoted_segment_section_config="${codex_managed_config_tmpdir}/quoted-segment-section.toml"
+cp "${CODEX_MANAGED_CONFIG}" "${quoted_segment_section_config}"
+printf '\n[ "profiles" . "strict" . "sandbox_workspace_write" ]\nnetwork_access = true\n' >>"${quoted_segment_section_config}"
+assert_codex_managed_config_rejected "${quoted_segment_section_config}" 'quoted strict segment sandbox override section' || exit 1
+
 rm -rf "${codex_managed_config_tmpdir}"
 
 if ! sed -n '/^run_host_colima()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq "HOME=\"\${REAL_HOME}\""; then

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -378,6 +378,16 @@ if ! rg -q 'REAL_HOME=' "${ROOT_DIR}/scripts/workcell"; then
   exit 1
 fi
 
+if ! rg -q '^\[profiles\.strict\]$' "${ROOT_DIR}/adapters/codex/managed_config.toml"; then
+  echo "Expected adapters/codex/managed_config.toml to pin the strict profile block" >&2
+  exit 1
+fi
+
+if ! rg -q '^profile = "strict"$' "${ROOT_DIR}/adapters/codex/managed_config.toml"; then
+  echo "Expected adapters/codex/managed_config.toml to pin the default profile to strict" >&2
+  exit 1
+fi
+
 if ! sed -n '/^run_host_colima()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq "HOME=\"\${REAL_HOME}\""; then
   echo "Expected run_host_colima to restore the real host HOME instead of the Docker client sandbox home" >&2
   exit 1

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -400,7 +400,7 @@ toml_section_assignments() {
       return -1
     }
 
-    function decode_toml_basic_string(value, i, ch, escaped, hex, code, j) {
+    function decode_toml_basic_string(value, i, ch, escaped, hex, code, digit, j) {
       escaped = ""
 
       for (i = 1; i <= length(value); i++) {
@@ -411,6 +411,10 @@ toml_section_assignments() {
         }
 
         i++
+        if (i > length(value)) {
+          parse_error = 1
+          return value
+        }
         ch = substr(value, i, 1)
 
         if (ch == "b") {
@@ -427,14 +431,24 @@ toml_section_assignments() {
           escaped = escaped ch
         } else if (ch == "u" || ch == "U") {
           hex = substr(value, i + 1, (ch == "u" ? 4 : 8))
+          if (length(hex) != (ch == "u" ? 4 : 8)) {
+            parse_error = 1
+            return value
+          }
           code = 0
           for (j = 1; j <= length(hex); j++) {
-            code = (code * 16) + hex_value(substr(hex, j, 1))
+            digit = hex_value(substr(hex, j, 1))
+            if (digit < 0) {
+              parse_error = 1
+              return value
+            }
+            code = (code * 16) + digit
           }
           escaped = escaped sprintf("%c", code)
           i += length(hex)
         } else {
-          escaped = escaped ch
+          parse_error = 1
+          return value
         }
       }
 
@@ -447,13 +461,13 @@ toml_section_assignments() {
       last = substr(value, length(value), 1)
 
       if (first == "\"" && last == "\"") {
-        return decode_toml_basic_string(substr(value, 2, length(value) - 2))
+        value = decode_toml_basic_string(substr(value, 2, length(value) - 2))
+      } else if (first == "'"'"'" && last == "'"'"'") {
+        value = substr(value, 2, length(value) - 2)
       }
 
-      if (first == "'"'"'" && last == "'"'"'") {
-        return substr(value, 2, length(value) - 2)
-      }
-
+      gsub(/\\/, "\\\\", value)
+      gsub(/\./, "\\.", value)
       return value
     }
 
@@ -503,6 +517,7 @@ toml_section_assignments() {
     }
 
     BEGIN {
+      parse_error = 0
       current = "__top__"
       if (want == "") {
         want = "__top__"
@@ -540,6 +555,11 @@ toml_section_assignments() {
       value = trim(substr(line, index(line, "=") + 1))
       print key "=" value
     }
+    END {
+      if (parse_error) {
+        exit 2
+      }
+    }
   ' "${file}"
 }
 
@@ -564,7 +584,7 @@ toml_section_names() {
       return -1
     }
 
-    function decode_toml_basic_string(value, i, ch, escaped, hex, code, j) {
+    function decode_toml_basic_string(value, i, ch, escaped, hex, code, digit, j) {
       escaped = ""
 
       for (i = 1; i <= length(value); i++) {
@@ -575,6 +595,10 @@ toml_section_names() {
         }
 
         i++
+        if (i > length(value)) {
+          parse_error = 1
+          return value
+        }
         ch = substr(value, i, 1)
 
         if (ch == "b") {
@@ -591,14 +615,24 @@ toml_section_names() {
           escaped = escaped ch
         } else if (ch == "u" || ch == "U") {
           hex = substr(value, i + 1, (ch == "u" ? 4 : 8))
+          if (length(hex) != (ch == "u" ? 4 : 8)) {
+            parse_error = 1
+            return value
+          }
           code = 0
           for (j = 1; j <= length(hex); j++) {
-            code = (code * 16) + hex_value(substr(hex, j, 1))
+            digit = hex_value(substr(hex, j, 1))
+            if (digit < 0) {
+              parse_error = 1
+              return value
+            }
+            code = (code * 16) + digit
           }
           escaped = escaped sprintf("%c", code)
           i += length(hex)
         } else {
-          escaped = escaped ch
+          parse_error = 1
+          return value
         }
       }
 
@@ -611,13 +645,13 @@ toml_section_names() {
       last = substr(value, length(value), 1)
 
       if (first == "\"" && last == "\"") {
-        return decode_toml_basic_string(substr(value, 2, length(value) - 2))
+        value = decode_toml_basic_string(substr(value, 2, length(value) - 2))
+      } else if (first == "'"'"'" && last == "'"'"'") {
+        value = substr(value, 2, length(value) - 2)
       }
 
-      if (first == "'"'"'" && last == "'"'"'") {
-        return substr(value, 2, length(value) - 2)
-      }
-
+      gsub(/\\/, "\\\\", value)
+      gsub(/\./, "\\.", value)
       return value
     }
 
@@ -666,6 +700,10 @@ toml_section_names() {
       return normalized
     }
 
+    BEGIN {
+      parse_error = 0
+    }
+
     {
       line = $0
       sub(/[[:space:]]+#.*$/, "", line)
@@ -678,6 +716,11 @@ toml_section_names() {
       gsub(/^[[:space:]]*\[/, "", section)
       gsub(/\][[:space:]]*$/, "", section)
       print normalize_toml_name(section)
+    }
+    END {
+      if (parse_error) {
+        exit 2
+      }
     }
   ' "${file}"
 }
@@ -717,8 +760,11 @@ require_toml_key_absent() {
   local file="$1"
   local section="$2"
   local key="$3"
+  local actual_keys=""
 
-  if toml_section_assignments "${file}" "${section}" | cut -d= -f1 | grep -Fxq -- "${key}"; then
+  actual_keys="$(toml_section_assignments "${file}" "${section}" | cut -d= -f1)" || return 1
+
+  if printf '%s\n' "${actual_keys}" | grep -Fxq -- "${key}"; then
     echo "Expected ${file} section [${section:-top-level}] not to define ${key}" >&2
     return 1
   fi
@@ -737,7 +783,10 @@ require_toml_exact_keys() {
   actual_keys="${tmpdir}/actual"
 
   printf '%s\n' "$@" | sort >"${expected_keys}"
-  toml_section_assignments "${file}" "${section}" | cut -d= -f1 | sort >"${actual_keys}"
+  if ! toml_section_assignments "${file}" "${section}" | cut -d= -f1 | sort >"${actual_keys}"; then
+    rm -rf "${tmpdir}"
+    return 1
+  fi
 
   if ! diff -u "${expected_keys}" "${actual_keys}" >/dev/null; then
     echo "Expected ${file} section [${section:-top-level}] to contain the exact reviewed key set" >&2
@@ -752,8 +801,11 @@ require_toml_exact_keys() {
 require_toml_section_absent() {
   local file="$1"
   local section="$2"
+  local sections=""
 
-  if toml_section_names "${file}" | grep -Fxq -- "${section}"; then
+  sections="$(toml_section_names "${file}")" || return 1
+
+  if printf '%s\n' "${sections}" | grep -Fxq -- "${section}"; then
     echo "Expected ${file} not to define [${section}]" >&2
     return 1
   fi
@@ -851,6 +903,25 @@ quoted_segment_section_config="${codex_managed_config_tmpdir}/quoted-segment-sec
 cp "${CODEX_MANAGED_CONFIG}" "${quoted_segment_section_config}"
 printf '\n[ "profiles" . "strict" . "sandbox_workspace_write" ]\nnetwork_access = true\n' >>"${quoted_segment_section_config}"
 assert_codex_managed_config_rejected "${quoted_segment_section_config}" 'quoted strict segment sandbox override section' || exit 1
+
+invalid_escape_key_config="${codex_managed_config_tmpdir}/invalid-escape-key.toml"
+awk '
+  {
+    print
+    if ($0 == "profile = \"strict\"") {
+      print "\"approval\\u00ZZpolicy\" = \"never\""
+    }
+  }
+' "${CODEX_MANAGED_CONFIG}" >"${invalid_escape_key_config}"
+assert_codex_managed_config_rejected "${invalid_escape_key_config}" 'malformed escaped approval_policy override' || exit 1
+
+literal_dot_section_config="${codex_managed_config_tmpdir}/literal-dot-section.toml"
+cp "${CODEX_MANAGED_CONFIG}" "${literal_dot_section_config}"
+printf '\n["profiles.strict.sandbox_workspace_write"]\nnetwork_access = true\n' >>"${literal_dot_section_config}"
+if ! verify_codex_managed_config_invariants "${literal_dot_section_config}" >/dev/null 2>&1; then
+  echo 'Expected quoted single-segment section names with literal dots to remain distinct from forbidden dotted paths' >&2
+  exit 1
+fi
 
 rm -rf "${codex_managed_config_tmpdir}"
 


### PR DESCRIPTION
### Motivation
- A writable session copy of `~/.codex/config.toml` allowed local processes to alter security‑critical profile settings (sandbox mode and approval policy) and thus bypass intended safe-path restrictions. 
- The admin-managed `managed_config.toml` did not previously pin the default profile or profile blocks, so enforcement relied on the mutable session copy instead of an immutable baseline.

### Description
- Add `profile = "strict"` and pin the `[profiles.strict]`, `[profiles.build]`, and `[profiles.breakglass]` blocks in `adapters/codex/managed_config.toml` so sandbox modes and approval policies are enforced from the immutable managed config.
- Add invariant checks to `scripts/verify-invariants.sh` to require `profile = "strict"` and the `[profiles.strict]` block in the managed config to prevent regressions.
- Update `docs/adapter-control-planes.md` to clarify that `~/.codex/config.toml` is for session-tunable defaults while security-critical profile policy is enforced by the immutable `managed_config.toml`.

### Testing
- Ran a syntax check with `bash -n scripts/verify-invariants.sh`, which succeeded and confirms the script changes are syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58479ed688329a03262f5c6162bec)