### PR TITLE
feat: add provider authenticated validation smoke

### DIFF
--- a/.github/workflows/provider-e2e.yml
+++ b/.github/workflows/provider-e2e.yml
@@ -1,0 +1,90 @@
+name: Provider Authenticated Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: Provider to exercise inside the managed runtime
+        required: true
+        type: choice
+        options:
+          - codex
+          - claude
+          - gemini
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.provider }}
+  cancel-in-progress: true
+
+jobs:
+  provider-e2e-guard:
+    name: Provider Authenticated Smoke Guard
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Enforce reviewed dispatch preconditions
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          WORKCELL_ENABLE_SELF_HOSTED_MACOS: ${{ vars.WORKCELL_ENABLE_SELF_HOSTED_MACOS }}
+        run: |
+          if [[ "${GITHUB_ACTOR}" != "${GITHUB_REPOSITORY_OWNER}" ]]; then
+            echo "Only the repository owner may dispatch provider-e2e." >&2
+            exit 1
+          fi
+          if [[ "${GITHUB_REF_NAME}" != "${DEFAULT_BRANCH}" ]]; then
+            echo "Provider-e2e may only run from the default branch (${DEFAULT_BRANCH})." >&2
+            exit 1
+          fi
+          if [[ "${WORKCELL_ENABLE_SELF_HOSTED_MACOS}" != "true" ]]; then
+            echo "Set WORKCELL_ENABLE_SELF_HOSTED_MACOS=true to enable provider-e2e." >&2
+            exit 1
+          fi
+
+  provider-e2e:
+    name: Provider Authenticated Smoke (${{ inputs.provider }})
+    needs: provider-e2e-guard
+    runs-on:
+      - self-hosted
+      - macOS
+    environment:
+      name: provider-e2e
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Derive managed Colima profile
+        run: |
+          echo "WORKCELL_MACOS_PROFILE=wc-pe2e-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "${GITHUB_ENV}"
+
+      - name: Run provider authenticated probe
+        env:
+          WORKCELL_E2E_CODEX_AUTH_JSON: ${{ secrets.WORKCELL_E2E_CODEX_AUTH_JSON }}
+          WORKCELL_E2E_CLAUDE_API_KEY: ${{ secrets.WORKCELL_E2E_CLAUDE_API_KEY }}
+          WORKCELL_E2E_CLAUDE_AUTH_JSON: ${{ secrets.WORKCELL_E2E_CLAUDE_AUTH_JSON }}
+          WORKCELL_E2E_CLAUDE_MCP_JSON: ${{ secrets.WORKCELL_E2E_CLAUDE_MCP_JSON }}
+          WORKCELL_E2E_GCLOUD_ADC_JSON: ${{ secrets.WORKCELL_E2E_GCLOUD_ADC_JSON }}
+          WORKCELL_E2E_GEMINI_ENV: ${{ secrets.WORKCELL_E2E_GEMINI_ENV }}
+          WORKCELL_E2E_GEMINI_OAUTH_JSON: ${{ secrets.WORKCELL_E2E_GEMINI_OAUTH_JSON }}
+          WORKCELL_E2E_GEMINI_PROJECTS_JSON: ${{ secrets.WORKCELL_E2E_GEMINI_PROJECTS_JSON }}
+          WORKCELL_E2E_GITHUB_CONFIG_YML: ${{ secrets.WORKCELL_E2E_GITHUB_CONFIG_YML }}
+          WORKCELL_E2E_GITHUB_HOSTS_YML: ${{ secrets.WORKCELL_E2E_GITHUB_HOSTS_YML }}
+        run: |
+          ./scripts/provider-e2e.sh \
+            --agent "${{ inputs.provider }}" \
+            --workspace "${GITHUB_WORKSPACE}" \
+            --require-injection \
+            --colima-profile "${WORKCELL_MACOS_PROFILE}"
+
+      - name: Clean up managed Colima profile
+        if: always()
+        run: |
+          if command -v colima >/dev/null 2>&1; then
+            COLIMA_HOME="${HOME}/.colima" colima delete --profile "${WORKCELL_MACOS_PROFILE}" --force >/dev/null 2>&1 || true
+          fi

--- a/.github/workflows/provider-e2e.yml
+++ b/.github/workflows/provider-e2e.yml
@@ -57,27 +57,46 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.sha }}
 
       - name: Derive managed Colima profile
         run: |
           echo "WORKCELL_MACOS_PROFILE=wc-pe2e-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "${GITHUB_ENV}"
 
-      - name: Run provider authenticated probe
+      - name: Run Codex authenticated probe
+        if: ${{ inputs.provider == 'codex' }}
         env:
           WORKCELL_E2E_CODEX_AUTH_JSON: ${{ secrets.WORKCELL_E2E_CODEX_AUTH_JSON }}
+        run: |
+          ./scripts/provider-e2e.sh \
+            --agent "codex" \
+            --workspace "${GITHUB_WORKSPACE}" \
+            --require-injection \
+            --colima-profile "${WORKCELL_MACOS_PROFILE}"
+
+      - name: Run Claude authenticated probe
+        if: ${{ inputs.provider == 'claude' }}
+        env:
           WORKCELL_E2E_CLAUDE_API_KEY: ${{ secrets.WORKCELL_E2E_CLAUDE_API_KEY }}
           WORKCELL_E2E_CLAUDE_AUTH_JSON: ${{ secrets.WORKCELL_E2E_CLAUDE_AUTH_JSON }}
           WORKCELL_E2E_CLAUDE_MCP_JSON: ${{ secrets.WORKCELL_E2E_CLAUDE_MCP_JSON }}
+        run: |
+          ./scripts/provider-e2e.sh \
+            --agent "claude" \
+            --workspace "${GITHUB_WORKSPACE}" \
+            --require-injection \
+            --colima-profile "${WORKCELL_MACOS_PROFILE}"
+
+      - name: Run Gemini authenticated probe
+        if: ${{ inputs.provider == 'gemini' }}
+        env:
           WORKCELL_E2E_GCLOUD_ADC_JSON: ${{ secrets.WORKCELL_E2E_GCLOUD_ADC_JSON }}
           WORKCELL_E2E_GEMINI_ENV: ${{ secrets.WORKCELL_E2E_GEMINI_ENV }}
           WORKCELL_E2E_GEMINI_OAUTH_JSON: ${{ secrets.WORKCELL_E2E_GEMINI_OAUTH_JSON }}
           WORKCELL_E2E_GEMINI_PROJECTS_JSON: ${{ secrets.WORKCELL_E2E_GEMINI_PROJECTS_JSON }}
-          WORKCELL_E2E_GITHUB_CONFIG_YML: ${{ secrets.WORKCELL_E2E_GITHUB_CONFIG_YML }}
-          WORKCELL_E2E_GITHUB_HOSTS_YML: ${{ secrets.WORKCELL_E2E_GITHUB_HOSTS_YML }}
         run: |
           ./scripts/provider-e2e.sh \
-            --agent "${{ inputs.provider }}" \
+            --agent "gemini" \
             --workspace "${GITHUB_WORKSPACE}" \
             --require-injection \
             --colima-profile "${WORKCELL_MACOS_PROFILE}"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ after the boundary and trust assumptions are fixed.
 | Threat model | [docs/threat-model.md](docs/threat-model.md) |
 | Security invariants | [docs/invariants.md](docs/invariants.md) |
 | Provider matrix | [docs/provider-matrix.md](docs/provider-matrix.md) |
+| Validation scenarios | [docs/validation-scenarios.md](docs/validation-scenarios.md) |
 | Injection policy | [docs/injection-policy.md](docs/injection-policy.md) |
 | Provenance & signing | [docs/provenance.md](docs/provenance.md) |
 | GitHub workflows | [docs/github-workflows.md](docs/github-workflows.md) |
@@ -215,6 +216,8 @@ Common recovery paths:
   `workcell --prepare --agent claude --agent-autonomy prompt --workspace /path/to/repo`
 - One-off provider flags without repeating the provider command:
   `workcell --agent gemini --agent-arg --version --workspace /path/to/repo`
+- Manual provider-authenticated smoke with explicit injected credentials:
+  `./scripts/provider-e2e.sh --agent codex --workspace /path/to/repo`
 - Conflicting unmanaged Colima profile:
   `workcell --repair-profile --agent codex --workspace /path/to/repo`
   Replace `codex` with `claude` or `gemini` for the corresponding provider.
@@ -361,7 +364,7 @@ Intentional non-goals for the safe path:
 - `policy/`: generic policy contracts and operator expectations
 - `adapters/`: thin provider mappings for Codex, Claude, and Gemini
 - `verify/`: invariant verification specs and harnesses
-- `docs/`: threat model, assurance tiers, and provider matrix
+- `docs/`: threat model, assurance tiers, provider matrix, and validation scenarios
 - `workflows/`: launch, migration, and downgrade-path notes
 - `scripts/`: installers, launchers, and verification entrypoints
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -213,7 +213,8 @@ path remains the standard repository gate. Keep the `provider-e2e`
 environment protected so only approved operators can access its secrets, and
 keep the owner-only plus default-branch job gate in place so a manual dispatch
 by another actor or from a non-default branch cannot consume those
-credentials.
+credentials. Keep its checkout pinned to the dispatched SHA so the reviewed
+workflow run cannot drift to newer default-branch code after dispatch.
 
 ## Review standard
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -26,6 +26,12 @@ under platform automation.
   image so release gating does not trust mutable runner apt packages
 - `docs.yml`: fast spelling and manpage feedback for documentation-only changes,
   including runtime documentation under `runtime/**`
+- `provider-e2e.yml`: manual `workflow_dispatch` provider-authenticated smoke
+  on the self-hosted macOS boundary path, with explicit provider selection,
+  explicit injection required, an owner-only plus default-branch job gate, and
+  credentials supplied only through the dedicated `provider-e2e` environment;
+  it stays separate from default CI so the secretless path remains the normal
+  gate
 - `security.yml`: GitHub Actions linting, dependency review on pull requests,
   and `zizmor`
 - `codeql.yml`: code scanning for the shipped Rust and JavaScript surfaces on
@@ -154,13 +160,13 @@ review through `WORKCELL_ENABLE_PRIVATE_DEPENDENCY_REVIEW=true`. Public
 repositories upload both SARIF result sets into the GitHub Security tab by
 default and run dependency review on pull requests without extra flags.
 
-Every workflow sets `permissions: read-all` at the workflow level and then
-elevates only the specific jobs that need write access, such as CodeQL SARIF
-upload, Scorecard SARIF upload, or tagged release publication. Workcell also
-forbids `pull_request_target` and disallows long-lived PAT-style workflow
-credentials in the reviewed workflow set. Release publication uses OIDC-backed
-ephemeral credentials for signing and attestations instead of long-lived cloud
-keys.
+Workcell now defaults workflows to `permissions: {}` or other minimal
+read-only scopes, and elevates only the specific jobs that need write access,
+such as CodeQL SARIF upload, Scorecard SARIF upload, or tagged release
+publication. Workcell also forbids `pull_request_target` and disallows
+long-lived PAT-style workflow credentials in the reviewed workflow set.
+Release publication uses OIDC-backed ephemeral credentials for signing and
+attestations instead of long-lived cloud keys.
 
 ## Dependency update scope
 
@@ -199,6 +205,15 @@ These are omitted on purpose:
 The small exception is `docs.yml`, which exists only to give faster spelling
 and manpage feedback on documentation-only changes. It does not replace the
 full validation and release gates in `ci.yml`.
+
+The manual provider-e2e workflow is not a default CI replacement. It is a
+separate dispatch-only lane for credential detection, control-plane seeding,
+and a small authenticated provider probe, kept narrow so the secretless CI
+path remains the standard repository gate. Keep the `provider-e2e`
+environment protected so only approved operators can access its secrets, and
+keep the owner-only plus default-branch job gate in place so a manual dispatch
+by another actor or from a non-default branch cannot consume those
+credentials.
 
 ## Review standard
 

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -1,0 +1,112 @@
+# Validation Scenarios
+
+This page groups the validation paths used by the provider validation plan.
+The split is intentional: secretless tests stay default, provider e2e stays
+explicit, and breakglass remains outside the normal workflow.
+
+## Local Secretless Tests
+
+Use this lane when you want fast validation without provider credentials.
+It should exercise repository shape, launcher behavior, invariant checks, and
+container smoke that does not depend on provider auth.
+
+Recommended entry points are the normal local validation commands already
+documented in the README, such as `./scripts/dev-quick-check.sh` and the
+broader pre-merge path when you need full local coverage.
+
+Recommended commands:
+
+- `./scripts/validate-repo.sh`
+- `./scripts/verify-invariants.sh`
+- `./scripts/container-smoke.sh`
+- `./scripts/pre-merge.sh`
+
+## Local Provider Authenticated Smoke
+
+Use this lane when you need to validate that Workcell stages real provider
+credentials and completes a small authenticated provider probe inside the
+Workcell boundary.
+The credential source must be explicit and operator-owned.
+
+Place provider credentials in the dedicated injection path, not in repo files,
+shell history, host homes, or ambient environment variables. This lane proves
+credential detection, control-plane seeding, strict launch, and a minimal
+provider-authenticated round trip. It is still an owner-triggered smoke lane,
+not a high-volume integration test.
+
+The reviewed entry point is:
+
+- `./scripts/provider-e2e.sh --agent codex --workspace "$PWD"`
+- `./scripts/provider-e2e.sh --agent claude --workspace "$PWD"`
+- `./scripts/provider-e2e.sh --agent gemini --workspace "$PWD"`
+
+That helper first runs `workcell --auth-status`, then `--prepare-only`, then a
+provider-specific non-interactive prompt that must emit the exact token
+`WORKCELL_PROVIDER_E2E_OK`.
+
+## GitHub CI Versus Manual Provider Authenticated Smoke
+
+GitHub default CI should stay secretless and deterministic. It is the lane for
+repo validation, workflow lint, pinned-input checks, and other checks that do
+not require provider credentials.
+
+The manual provider-e2e workflow is a separate `workflow_dispatch` lane. It
+should stay narrow, require explicit operator selection of the provider, pull
+any needed credentials from a dedicated secret-backed environment on the
+self-hosted macOS path, stay limited to the default branch, and only execute
+for the repository owner. A non-secret guard job should fail fast before the
+self-hosted secret-bearing job starts when those preconditions are not met. It
+should not run on pull requests.
+
+## Credential Placement
+
+Use the least-broad credential location that can support the test:
+
+- Local runs: `~/.config/workcell/injection-policy.toml` or another
+  operator-owned secret source that feeds that policy
+- GitHub manual provider-e2e runs: environment-scoped secrets for
+  `provider-e2e.yml` only, with environment protection rules enabled
+- Default CI: no provider credentials
+
+Never place provider secrets in committed files, default CI variables, host
+home directories, git config, or socket passthrough paths.
+
+Recommended local credential files:
+
+- Codex: `credentials.codex_auth = "~/.codex/auth.json"`
+- Claude: `credentials.claude_auth = "~/.config/claude-code/auth.json"` or
+  `credentials.claude_api_key = "~/.config/workcell/claude-api-key.txt"`
+- Gemini: `credentials.gemini_env = "~/.config/workcell/gemini.env"` or
+  `credentials.gemini_oauth = "~/.config/workcell/gemini-oauth.json"`
+- Gemini Vertex supplement: `credentials.gcloud_adc =
+  "~/.config/gcloud/application_default_credentials.json"`
+- Shared GitHub CLI auth when needed:
+  `credentials.github_hosts` / `credentials.github_config`
+
+Recommended GitHub environment secret names:
+
+- `WORKCELL_E2E_CODEX_AUTH_JSON`
+- `WORKCELL_E2E_CLAUDE_AUTH_JSON`
+- `WORKCELL_E2E_CLAUDE_API_KEY`
+- `WORKCELL_E2E_CLAUDE_MCP_JSON`
+- `WORKCELL_E2E_GEMINI_ENV`
+- `WORKCELL_E2E_GEMINI_OAUTH_JSON`
+- `WORKCELL_E2E_GEMINI_PROJECTS_JSON`
+- `WORKCELL_E2E_GCLOUD_ADC_JSON`
+- `WORKCELL_E2E_GITHUB_HOSTS_YML`
+- `WORKCELL_E2E_GITHUB_CONFIG_YML`
+
+## Out Of Scope And Breakglass
+
+These scenarios are intentionally out of scope for the normal validation plan:
+
+- host-native GUI or browser-only provider validation
+- unrestricted network or provider overrides that would require
+  `breakglass`
+- broad arbitrary-command debugging paths
+- any workflow that assumes host credential passthrough or ambient auth state
+- PR-triggered self-hosted runs that could expose provider-backed secrets to
+  untrusted code
+
+If a check needs any of those conditions, label it as `breakglass` explicitly
+and require the separate acknowledged path described elsewhere in the docs.

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -93,8 +93,11 @@ Recommended GitHub environment secret names:
 - `WORKCELL_E2E_GEMINI_OAUTH_JSON`
 - `WORKCELL_E2E_GEMINI_PROJECTS_JSON`
 - `WORKCELL_E2E_GCLOUD_ADC_JSON`
-- `WORKCELL_E2E_GITHUB_HOSTS_YML`
-- `WORKCELL_E2E_GITHUB_CONFIG_YML`
+
+The `provider-e2e.sh` helper intentionally limits its generated env-backed
+policy to the selected provider's credentials. If a future scenario needs
+shared GitHub CLI auth, pass an explicit injection policy instead of expanding
+the `WORKCELL_E2E_*` environment surface for this smoke lane.
 
 ## Out Of Scope And Breakglass
 

--- a/scripts/provider-e2e.sh
+++ b/scripts/provider-e2e.sh
@@ -1,0 +1,426 @@
+#!/bin/bash -p
+
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
+  exec /usr/bin/env -i \
+    PATH="${TRUSTED_HOST_PATH}" \
+    HOME=/tmp \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    WORKCELL_E2E_CLAUDE_API_KEY="${WORKCELL_E2E_CLAUDE_API_KEY-}" \
+    WORKCELL_E2E_CLAUDE_AUTH_JSON="${WORKCELL_E2E_CLAUDE_AUTH_JSON-}" \
+    WORKCELL_E2E_CLAUDE_MCP_JSON="${WORKCELL_E2E_CLAUDE_MCP_JSON-}" \
+    WORKCELL_E2E_CODEX_AUTH_JSON="${WORKCELL_E2E_CODEX_AUTH_JSON-}" \
+    WORKCELL_E2E_GCLOUD_ADC_JSON="${WORKCELL_E2E_GCLOUD_ADC_JSON-}" \
+    WORKCELL_E2E_GEMINI_ENV="${WORKCELL_E2E_GEMINI_ENV-}" \
+    WORKCELL_E2E_GEMINI_OAUTH_JSON="${WORKCELL_E2E_GEMINI_OAUTH_JSON-}" \
+    WORKCELL_E2E_GEMINI_PROJECTS_JSON="${WORKCELL_E2E_GEMINI_PROJECTS_JSON-}" \
+    WORKCELL_E2E_GITHUB_CONFIG_YML="${WORKCELL_E2E_GITHUB_CONFIG_YML-}" \
+    WORKCELL_E2E_GITHUB_HOSTS_YML="${WORKCELL_E2E_GITHUB_HOSTS_YML-}" \
+    WORKCELL_PROVIDER_E2E_WORKCELL_SCRIPT="${WORKCELL_PROVIDER_E2E_WORKCELL_SCRIPT-}" \
+    WORKCELL_SANITIZED_ENTRYPOINT=1 \
+    /bin/bash -p "$0" "$@"
+fi
+
+set -euo pipefail
+export PATH="${TRUSTED_HOST_PATH}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKCELL_SCRIPT="${WORKCELL_PROVIDER_E2E_WORKCELL_SCRIPT:-${ROOT_DIR}/scripts/workcell}"
+WORKSPACE=""
+AGENT=""
+COLIMA_PROFILE=""
+INJECTION_POLICY=""
+readonly PROBE_RESPONSE_TOKEN="WORKCELL_PROVIDER_E2E_OK"
+DRY_RUN=0
+REQUIRE_INJECTION=0
+GENERATED_POLICY=""
+INJECTION_SOURCE="default-workcell-resolution"
+TMP_ROOT=""
+declare -a GENERATED_CREDENTIAL_KEYS=()
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --agent codex|claude|gemini --workspace PATH [options]
+
+Run a small provider-focused Workcell credential and launch sequence:
+
+1. Print Workcell auth status for the selected agent
+2. Seed or refresh the prepared runtime image with --prepare-only
+3. Run a small provider-specific authenticated probe inside the strict runtime
+
+Options:
+  --agent <name>              Provider to exercise: codex, claude, or gemini
+  --workspace <path>          Workspace to run against
+  --injection-policy <path>   Optional explicit injection policy
+  --colima-profile <name>     Optional managed Colima profile name
+  --require-injection         Fail unless an explicit or generated injection
+                              policy is available
+  --dry-run                   Print the planned commands and exit
+  -h, --help                  Show this help
+
+If --injection-policy is omitted, the script will generate a temporary policy
+from WORKCELL_E2E_* environment variables when they are present. Otherwise it
+falls back to Workcell's ordinary default injection-policy resolution unless
+--require-injection is set.
+EOF
+}
+
+die() {
+  echo "$*" >&2
+  exit 2
+}
+
+cleanup() {
+  if [[ -n "${TMP_ROOT}" ]] && [[ -d "${TMP_ROOT}" ]]; then
+    rm -rf "${TMP_ROOT}"
+  fi
+}
+trap cleanup EXIT
+
+ensure_tmp_root() {
+  if [[ -z "${TMP_ROOT}" ]]; then
+    TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/workcell-provider-e2e.XXXXXX")"
+  fi
+}
+
+toml_quote() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '"%s"' "${value}"
+}
+
+write_secret_file() {
+  local env_name="$1"
+  local filename="$2"
+  local required="${3:-0}"
+  local value="${!env_name-}"
+  local path=""
+
+  if [[ -z "${value}" ]]; then
+    if [[ "${required}" -eq 1 ]]; then
+      die "Missing required provider E2E secret: ${env_name}"
+    fi
+    return 1
+  fi
+
+  path="${TMP_ROOT}/${filename}"
+  printf '%s' "${value}" >"${path}"
+  chmod 0600 "${path}"
+  printf '%s\n' "${path}"
+}
+
+append_shared_github_credentials() {
+  local policy_path="$1"
+  local provider="$2"
+  local hosts_path="$3"
+  local config_path="$4"
+
+  if [[ -n "${hosts_path}" ]]; then
+    {
+      printf '\n[credentials.github_hosts]\n'
+      printf 'source = %s\n' "$(toml_quote "${hosts_path}")"
+      printf 'providers = [%s]\n' "$(toml_quote "${provider}")"
+    } >>"${policy_path}"
+  fi
+
+  if [[ -n "${config_path}" ]]; then
+    {
+      printf '\n[credentials.github_config]\n'
+      printf 'source = %s\n' "$(toml_quote "${config_path}")"
+      printf 'providers = [%s]\n' "$(toml_quote "${provider}")"
+    } >>"${policy_path}"
+  fi
+}
+
+generate_policy_from_env() {
+  local policy_path=""
+  local codex_auth_path=""
+  local claude_auth_path=""
+  local claude_api_key_path=""
+  local claude_mcp_path=""
+  local gemini_env_path=""
+  local gemini_oauth_path=""
+  local gemini_projects_path=""
+  local gcloud_adc_path=""
+  local github_hosts_path=""
+  local github_config_path=""
+
+  if [[ -n "${INJECTION_POLICY}" ]]; then
+    GENERATED_POLICY=""
+    INJECTION_SOURCE="explicit"
+    return 0
+  fi
+
+  TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/workcell-provider-e2e.XXXXXX")"
+  policy_path="${TMP_ROOT}/policy.toml"
+  GENERATED_CREDENTIAL_KEYS=()
+
+  codex_auth_path="$(write_secret_file WORKCELL_E2E_CODEX_AUTH_JSON codex-auth.json 0 || true)"
+  claude_auth_path="$(write_secret_file WORKCELL_E2E_CLAUDE_AUTH_JSON claude-auth.json 0 || true)"
+  claude_api_key_path="$(write_secret_file WORKCELL_E2E_CLAUDE_API_KEY claude-api-key.txt 0 || true)"
+  claude_mcp_path="$(write_secret_file WORKCELL_E2E_CLAUDE_MCP_JSON claude-mcp.json 0 || true)"
+  gemini_env_path="$(write_secret_file WORKCELL_E2E_GEMINI_ENV gemini.env 0 || true)"
+  gemini_oauth_path="$(write_secret_file WORKCELL_E2E_GEMINI_OAUTH_JSON gemini-oauth.json 0 || true)"
+  gemini_projects_path="$(write_secret_file WORKCELL_E2E_GEMINI_PROJECTS_JSON gemini-projects.json 0 || true)"
+  gcloud_adc_path="$(write_secret_file WORKCELL_E2E_GCLOUD_ADC_JSON gcloud-adc.json 0 || true)"
+  github_hosts_path="$(write_secret_file WORKCELL_E2E_GITHUB_HOSTS_YML gh-hosts.yml 0 || true)"
+  github_config_path="$(write_secret_file WORKCELL_E2E_GITHUB_CONFIG_YML gh-config.yml 0 || true)"
+  [[ -n "${codex_auth_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("codex_auth")
+  [[ -n "${claude_auth_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("claude_auth")
+  [[ -n "${claude_api_key_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("claude_api_key")
+  [[ -n "${claude_mcp_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("claude_mcp")
+  [[ -n "${gemini_env_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("gemini_env")
+  [[ -n "${gemini_oauth_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("gemini_oauth")
+  [[ -n "${gemini_projects_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("gemini_projects")
+  [[ -n "${gcloud_adc_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("gcloud_adc")
+  [[ -n "${github_hosts_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("github_hosts")
+  [[ -n "${github_config_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("github_config")
+
+  case "${AGENT}" in
+    codex)
+      [[ -n "${codex_auth_path}" ]] || return 0
+      ;;
+    claude)
+      if [[ -z "${claude_auth_path}" ]] && [[ -z "${claude_api_key_path}" ]]; then
+        return 0
+      fi
+      ;;
+    gemini)
+      if [[ -z "${gemini_env_path}" ]] && [[ -z "${gemini_oauth_path}" ]]; then
+        return 0
+      fi
+      ;;
+  esac
+
+  printf 'version = 1\n\n[credentials]\n' >"${policy_path}"
+  case "${AGENT}" in
+    codex)
+      printf 'codex_auth = %s\n' "$(toml_quote "${codex_auth_path}")" >>"${policy_path}"
+      ;;
+    claude)
+      if [[ -n "${claude_auth_path}" ]]; then
+        printf 'claude_auth = %s\n' "$(toml_quote "${claude_auth_path}")" >>"${policy_path}"
+      fi
+      if [[ -n "${claude_api_key_path}" ]]; then
+        printf 'claude_api_key = %s\n' "$(toml_quote "${claude_api_key_path}")" >>"${policy_path}"
+      fi
+      if [[ -n "${claude_mcp_path}" ]]; then
+        printf 'claude_mcp = %s\n' "$(toml_quote "${claude_mcp_path}")" >>"${policy_path}"
+      fi
+      ;;
+    gemini)
+      if [[ -n "${gemini_env_path}" ]]; then
+        printf 'gemini_env = %s\n' "$(toml_quote "${gemini_env_path}")" >>"${policy_path}"
+      fi
+      if [[ -n "${gemini_oauth_path}" ]]; then
+        printf 'gemini_oauth = %s\n' "$(toml_quote "${gemini_oauth_path}")" >>"${policy_path}"
+      fi
+      if [[ -n "${gemini_projects_path}" ]]; then
+        printf 'gemini_projects = %s\n' "$(toml_quote "${gemini_projects_path}")" >>"${policy_path}"
+      fi
+      if [[ -n "${gcloud_adc_path}" ]]; then
+        printf 'gcloud_adc = %s\n' "$(toml_quote "${gcloud_adc_path}")" >>"${policy_path}"
+      fi
+      ;;
+  esac
+
+  append_shared_github_credentials "${policy_path}" "${AGENT}" "${github_hosts_path}" "${github_config_path}"
+
+  GENERATED_POLICY="${policy_path}"
+  INJECTION_SOURCE="generated-env"
+}
+
+print_command() {
+  local label="$1"
+  shift
+
+  printf '%s=' "${label}"
+  printf '%q ' "$@"
+  printf '\n'
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required tool: $1"
+}
+
+build_probe_prompt() {
+  printf 'Reply with exactly the single token %s and nothing else.' "${PROBE_RESPONSE_TOKEN}"
+}
+
+probe_output_matches_expected_token() {
+  local output="$1"
+
+  case "${AGENT}" in
+    codex)
+      grep -Eq "\"text\"[[:space:]]*:[[:space:]]*\"${PROBE_RESPONSE_TOKEN}\"" <<<"${output}" ||
+        grep -qxF "${PROBE_RESPONSE_TOKEN}" <<<"${output}"
+      ;;
+    claude)
+      grep -Eq "\"(result|response|text)\"[[:space:]]*:[[:space:]]*\"${PROBE_RESPONSE_TOKEN}\"" <<<"${output}" ||
+        grep -qxF "${PROBE_RESPONSE_TOKEN}" <<<"${output}"
+      ;;
+    gemini)
+      grep -Eq "\"response\"[[:space:]]*:[[:space:]]*\"${PROBE_RESPONSE_TOKEN}\"" <<<"${output}" ||
+        grep -qxF "${PROBE_RESPONSE_TOKEN}" <<<"${output}"
+      ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent)
+      [[ $# -ge 2 ]] || die "Option --agent requires a value."
+      AGENT="$2"
+      shift 2
+      ;;
+    --workspace)
+      [[ $# -ge 2 ]] || die "Option --workspace requires a value."
+      WORKSPACE="$2"
+      shift 2
+      ;;
+    --injection-policy)
+      [[ $# -ge 2 ]] || die "Option --injection-policy requires a value."
+      INJECTION_POLICY="$2"
+      shift 2
+      ;;
+    --colima-profile)
+      [[ $# -ge 2 ]] || die "Option --colima-profile requires a value."
+      COLIMA_PROFILE="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --require-injection)
+      REQUIRE_INJECTION=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unsupported option: $1"
+      ;;
+  esac
+done
+
+[[ -n "${AGENT}" ]] || die "Option --agent is required."
+[[ -n "${WORKSPACE}" ]] || die "Option --workspace is required."
+case "${AGENT}" in
+  codex | claude | gemini) ;;
+  *)
+    die "Unsupported agent: ${AGENT}"
+    ;;
+esac
+
+require_tool /usr/bin/env
+[[ -x "${WORKCELL_SCRIPT}" ]] || die "Workcell launcher is missing or not executable: ${WORKCELL_SCRIPT}"
+
+generate_policy_from_env
+if [[ "${REQUIRE_INJECTION}" -eq 1 ]] && [[ -z "${INJECTION_POLICY}" ]] && [[ -z "${GENERATED_POLICY}" ]]; then
+  die "No injection policy is available. Pass --injection-policy or populate the required WORKCELL_E2E_* environment variables."
+fi
+
+declare -a common_args=("${WORKCELL_SCRIPT}" "--agent" "${AGENT}" "--workspace" "${WORKSPACE}")
+if [[ -n "${COLIMA_PROFILE}" ]]; then
+  common_args+=("--colima-profile" "${COLIMA_PROFILE}")
+fi
+if [[ -n "${INJECTION_POLICY}" ]]; then
+  common_args+=("--injection-policy" "${INJECTION_POLICY}")
+elif [[ -n "${GENERATED_POLICY}" ]]; then
+  common_args+=("--injection-policy" "${GENERATED_POLICY}")
+fi
+
+declare -a auth_status_cmd=("${common_args[@]}" "--auth-status")
+declare -a prepare_only_cmd=("${WORKCELL_SCRIPT}" "--prepare-only" "--agent" "${AGENT}" "--workspace" "${WORKSPACE}")
+declare -a probe_cmd=("${WORKCELL_SCRIPT}" "--agent" "${AGENT}" "--workspace" "${WORKSPACE}")
+auth_status_output=""
+probe_output=""
+probe_output_path=""
+if [[ -n "${COLIMA_PROFILE}" ]]; then
+  prepare_only_cmd+=("--colima-profile" "${COLIMA_PROFILE}")
+  probe_cmd+=("--colima-profile" "${COLIMA_PROFILE}")
+fi
+if [[ -n "${INJECTION_POLICY}" ]]; then
+  prepare_only_cmd+=("--injection-policy" "${INJECTION_POLICY}")
+  probe_cmd+=("--injection-policy" "${INJECTION_POLICY}")
+elif [[ -n "${GENERATED_POLICY}" ]]; then
+  prepare_only_cmd+=("--injection-policy" "${GENERATED_POLICY}")
+  probe_cmd+=("--injection-policy" "${GENERATED_POLICY}")
+fi
+case "${AGENT}" in
+  codex)
+    probe_cmd+=(
+      "--agent-arg" "exec"
+      "--agent-arg" "--json"
+      "--agent-arg" "$(build_probe_prompt)"
+    )
+    ;;
+  claude)
+    probe_cmd+=(
+      "--agent-arg" "-p"
+      "--agent-arg" "--output-format"
+      "--agent-arg" "json"
+      "--agent-arg" "--no-session-persistence"
+      "--agent-arg" "--max-budget-usd"
+      "--agent-arg" "0.10"
+      "--agent-arg" "--tools"
+      "--agent-arg" ""
+      "--agent-arg" "$(build_probe_prompt)"
+    )
+    ;;
+  gemini)
+    probe_cmd+=(
+      "--agent-arg" "-p"
+      "--agent-arg" "$(build_probe_prompt)"
+      "--agent-arg" "--output-format"
+      "--agent-arg" "json"
+    )
+    ;;
+esac
+
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  printf 'provider_e2e_agent=%s\n' "${AGENT}"
+  printf 'provider_e2e_workspace=%s\n' "${WORKSPACE}"
+  printf 'provider_e2e_injection_source=%s\n' "${INJECTION_SOURCE}"
+  if ((${#GENERATED_CREDENTIAL_KEYS[@]} > 0)); then
+    printf 'provider_e2e_credential_keys=%s\n' "$(IFS=,; printf '%s' "${GENERATED_CREDENTIAL_KEYS[*]}")"
+  else
+    printf 'provider_e2e_credential_keys=\n'
+  fi
+  printf 'provider_e2e_steps=auth-status,prepare-only,live-probe\n'
+  print_command provider_e2e_auth_status_cmd "${auth_status_cmd[@]}"
+  print_command provider_e2e_prepare_only_cmd "${prepare_only_cmd[@]}"
+  print_command provider_e2e_probe_cmd "${probe_cmd[@]}"
+  exit 0
+fi
+
+printf '[provider-e2e] auth-status (%s)\n' "${AGENT}"
+if ! auth_status_output="$("${auth_status_cmd[@]}" 2>&1)"; then
+  printf '%s\n' "${auth_status_output}" >&2
+  exit 1
+fi
+printf '%s\n' "${auth_status_output}"
+if ! grep -q '^provider_auth_mode=' <<<"${auth_status_output}"; then
+  die "Workcell auth-status did not report provider_auth_mode for ${AGENT}."
+fi
+if grep -q '^provider_auth_mode=none$' <<<"${auth_status_output}"; then
+  die "Workcell did not detect provider auth for ${AGENT}."
+fi
+printf '[provider-e2e] prepare-only (%s)\n' "${AGENT}"
+"${prepare_only_cmd[@]}"
+printf '[provider-e2e] live-probe (%s)\n' "${AGENT}"
+ensure_tmp_root
+probe_output_path="${TMP_ROOT}/${AGENT}-probe.out"
+if ! "${probe_cmd[@]}" >"${probe_output_path}" 2>&1; then
+  cat "${probe_output_path}" >&2
+  exit 1
+fi
+probe_output="$(cat "${probe_output_path}")"
+printf '%s\n' "${probe_output}"
+if ! probe_output_matches_expected_token "${probe_output}"; then
+  die "Provider probe did not emit the expected token for ${AGENT}."
+fi

--- a/scripts/provider-e2e.sh
+++ b/scripts/provider-e2e.sh
@@ -14,8 +14,6 @@ if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
     WORKCELL_E2E_GEMINI_ENV="${WORKCELL_E2E_GEMINI_ENV-}" \
     WORKCELL_E2E_GEMINI_OAUTH_JSON="${WORKCELL_E2E_GEMINI_OAUTH_JSON-}" \
     WORKCELL_E2E_GEMINI_PROJECTS_JSON="${WORKCELL_E2E_GEMINI_PROJECTS_JSON-}" \
-    WORKCELL_E2E_GITHUB_CONFIG_YML="${WORKCELL_E2E_GITHUB_CONFIG_YML-}" \
-    WORKCELL_E2E_GITHUB_HOSTS_YML="${WORKCELL_E2E_GITHUB_HOSTS_YML-}" \
     WORKCELL_PROVIDER_E2E_WORKCELL_SCRIPT="${WORKCELL_PROVIDER_E2E_WORKCELL_SCRIPT-}" \
     WORKCELL_SANITIZED_ENTRYPOINT=1 \
     /bin/bash -p "$0" "$@"
@@ -110,29 +108,6 @@ write_secret_file() {
   printf '%s\n' "${path}"
 }
 
-append_shared_github_credentials() {
-  local policy_path="$1"
-  local provider="$2"
-  local hosts_path="$3"
-  local config_path="$4"
-
-  if [[ -n "${hosts_path}" ]]; then
-    {
-      printf '\n[credentials.github_hosts]\n'
-      printf 'source = %s\n' "$(toml_quote "${hosts_path}")"
-      printf 'providers = [%s]\n' "$(toml_quote "${provider}")"
-    } >>"${policy_path}"
-  fi
-
-  if [[ -n "${config_path}" ]]; then
-    {
-      printf '\n[credentials.github_config]\n'
-      printf 'source = %s\n' "$(toml_quote "${config_path}")"
-      printf 'providers = [%s]\n' "$(toml_quote "${provider}")"
-    } >>"${policy_path}"
-  fi
-}
-
 generate_policy_from_env() {
   local policy_path=""
   local codex_auth_path=""
@@ -143,8 +118,6 @@ generate_policy_from_env() {
   local gemini_oauth_path=""
   local gemini_projects_path=""
   local gcloud_adc_path=""
-  local github_hosts_path=""
-  local github_config_path=""
 
   if [[ -n "${INJECTION_POLICY}" ]]; then
     GENERATED_POLICY=""
@@ -152,44 +125,43 @@ generate_policy_from_env() {
     return 0
   fi
 
-  TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/workcell-provider-e2e.XXXXXX")"
-  policy_path="${TMP_ROOT}/policy.toml"
   GENERATED_CREDENTIAL_KEYS=()
-
-  codex_auth_path="$(write_secret_file WORKCELL_E2E_CODEX_AUTH_JSON codex-auth.json 0 || true)"
-  claude_auth_path="$(write_secret_file WORKCELL_E2E_CLAUDE_AUTH_JSON claude-auth.json 0 || true)"
-  claude_api_key_path="$(write_secret_file WORKCELL_E2E_CLAUDE_API_KEY claude-api-key.txt 0 || true)"
-  claude_mcp_path="$(write_secret_file WORKCELL_E2E_CLAUDE_MCP_JSON claude-mcp.json 0 || true)"
-  gemini_env_path="$(write_secret_file WORKCELL_E2E_GEMINI_ENV gemini.env 0 || true)"
-  gemini_oauth_path="$(write_secret_file WORKCELL_E2E_GEMINI_OAUTH_JSON gemini-oauth.json 0 || true)"
-  gemini_projects_path="$(write_secret_file WORKCELL_E2E_GEMINI_PROJECTS_JSON gemini-projects.json 0 || true)"
-  gcloud_adc_path="$(write_secret_file WORKCELL_E2E_GCLOUD_ADC_JSON gcloud-adc.json 0 || true)"
-  github_hosts_path="$(write_secret_file WORKCELL_E2E_GITHUB_HOSTS_YML gh-hosts.yml 0 || true)"
-  github_config_path="$(write_secret_file WORKCELL_E2E_GITHUB_CONFIG_YML gh-config.yml 0 || true)"
-  [[ -n "${codex_auth_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("codex_auth")
-  [[ -n "${claude_auth_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("claude_auth")
-  [[ -n "${claude_api_key_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("claude_api_key")
-  [[ -n "${claude_mcp_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("claude_mcp")
-  [[ -n "${gemini_env_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("gemini_env")
-  [[ -n "${gemini_oauth_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("gemini_oauth")
-  [[ -n "${gemini_projects_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("gemini_projects")
-  [[ -n "${gcloud_adc_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("gcloud_adc")
-  [[ -n "${github_hosts_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("github_hosts")
-  [[ -n "${github_config_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("github_config")
 
   case "${AGENT}" in
     codex)
-      [[ -n "${codex_auth_path}" ]] || return 0
+      [[ -n "${WORKCELL_E2E_CODEX_AUTH_JSON-}" ]] || return 0
+      ensure_tmp_root
+      policy_path="${TMP_ROOT}/policy.toml"
+      codex_auth_path="$(write_secret_file WORKCELL_E2E_CODEX_AUTH_JSON codex-auth.json 1)"
+      GENERATED_CREDENTIAL_KEYS+=("codex_auth")
       ;;
     claude)
-      if [[ -z "${claude_auth_path}" ]] && [[ -z "${claude_api_key_path}" ]]; then
+      if [[ -z "${WORKCELL_E2E_CLAUDE_AUTH_JSON-}" ]] && [[ -z "${WORKCELL_E2E_CLAUDE_API_KEY-}" ]]; then
         return 0
       fi
+      ensure_tmp_root
+      policy_path="${TMP_ROOT}/policy.toml"
+      claude_auth_path="$(write_secret_file WORKCELL_E2E_CLAUDE_AUTH_JSON claude-auth.json 0 || true)"
+      claude_api_key_path="$(write_secret_file WORKCELL_E2E_CLAUDE_API_KEY claude-api-key.txt 0 || true)"
+      claude_mcp_path="$(write_secret_file WORKCELL_E2E_CLAUDE_MCP_JSON claude-mcp.json 0 || true)"
+      [[ -n "${claude_auth_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("claude_auth")
+      [[ -n "${claude_api_key_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("claude_api_key")
+      [[ -n "${claude_mcp_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("claude_mcp")
       ;;
     gemini)
-      if [[ -z "${gemini_env_path}" ]] && [[ -z "${gemini_oauth_path}" ]]; then
+      if [[ -z "${WORKCELL_E2E_GEMINI_ENV-}" ]] && [[ -z "${WORKCELL_E2E_GEMINI_OAUTH_JSON-}" ]]; then
         return 0
       fi
+      ensure_tmp_root
+      policy_path="${TMP_ROOT}/policy.toml"
+      gemini_env_path="$(write_secret_file WORKCELL_E2E_GEMINI_ENV gemini.env 0 || true)"
+      gemini_oauth_path="$(write_secret_file WORKCELL_E2E_GEMINI_OAUTH_JSON gemini-oauth.json 0 || true)"
+      gemini_projects_path="$(write_secret_file WORKCELL_E2E_GEMINI_PROJECTS_JSON gemini-projects.json 0 || true)"
+      gcloud_adc_path="$(write_secret_file WORKCELL_E2E_GCLOUD_ADC_JSON gcloud-adc.json 0 || true)"
+      [[ -n "${gemini_env_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("gemini_env")
+      [[ -n "${gemini_oauth_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("gemini_oauth")
+      [[ -n "${gemini_projects_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("gemini_projects")
+      [[ -n "${gcloud_adc_path}" ]] && GENERATED_CREDENTIAL_KEYS+=("gcloud_adc")
       ;;
   esac
 
@@ -224,8 +196,6 @@ generate_policy_from_env() {
       fi
       ;;
   esac
-
-  append_shared_github_credentials "${policy_path}" "${AGENT}" "${github_hosts_path}" "${github_config_path}"
 
   GENERATED_POLICY="${policy_path}"
   INJECTION_SOURCE="generated-env"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3496,10 +3496,11 @@ touch "${WORKTREE_MAIN}/tracked.txt"
 git -C "${WORKTREE_MAIN}" add tracked.txt
 git -C "${WORKTREE_MAIN}" commit -q -m init
 git -C "${WORKTREE_MAIN}" worktree add -q -b linked "${WORKTREE_LINKED}"
-if "${ROOT_DIR}/scripts/workcell" --agent codex --workspace "${WORKTREE_LINKED}" --dry-run >/dev/null 2>&1; then
+if "${ROOT_DIR}/scripts/workcell" --agent codex --workspace "${WORKTREE_LINKED}" --dry-run >/tmp/workcell-linked-worktree.out 2>&1; then
   echo "Expected linked git worktree with external admin state to be rejected" >&2
   exit 1
 fi
+grep -q 'linked worktrees require breakglass or a different clone' /tmp/workcell-linked-worktree.out
 
 REDIRECTED_ROOT="${BARRIER_VERIFY_ROOT}/redirected-root"
 REDIRECTED_REPO="${REDIRECTED_ROOT}/repo"
@@ -3523,6 +3524,217 @@ if ! WORKCELL_REMOTE_VALIDATE_CONFIG_PATH="${LOCAL_REMOTE_CONFIG_PATH}" \
   cat /tmp/workcell-remote-config.out >&2
   exit 1
 fi
+
+if ! WORKCELL_E2E_CODEX_AUTH_JSON='{"token":"codex-smoke"}' \
+  WORKCELL_E2E_GITHUB_HOSTS_YML=$'github.com:\n  user: smoke\n' \
+  "${ROOT_DIR}/scripts/provider-e2e.sh" \
+  --agent codex \
+  --workspace "${ROOT_DIR}" \
+  --dry-run >/tmp/workcell-provider-e2e-codex.out 2>&1; then
+  echo "Expected provider-e2e codex dry-run to succeed with generated env credentials" >&2
+  cat /tmp/workcell-provider-e2e-codex.out >&2
+  exit 1
+fi
+grep -q '^provider_e2e_agent=codex$' /tmp/workcell-provider-e2e-codex.out
+grep -q '^provider_e2e_injection_source=generated-env$' /tmp/workcell-provider-e2e-codex.out
+grep -q '^provider_e2e_steps=auth-status,prepare-only,live-probe$' /tmp/workcell-provider-e2e-codex.out
+grep -q 'codex_auth' /tmp/workcell-provider-e2e-codex.out
+grep -q 'provider_e2e_auth_status_cmd=.*--auth-status' /tmp/workcell-provider-e2e-codex.out
+grep -q 'provider_e2e_prepare_only_cmd=.*--prepare-only' /tmp/workcell-provider-e2e-codex.out
+grep -q 'provider_e2e_probe_cmd=.*--agent-arg exec' /tmp/workcell-provider-e2e-codex.out
+grep -q 'provider_e2e_probe_cmd=.*--agent-arg --json' /tmp/workcell-provider-e2e-codex.out
+grep -q 'provider_e2e_probe_cmd=.*WORKCELL_PROVIDER_E2E_OK' /tmp/workcell-provider-e2e-codex.out
+
+if ! WORKCELL_E2E_CLAUDE_API_KEY='smoke-api-key' \
+  "${ROOT_DIR}/scripts/provider-e2e.sh" \
+  --agent claude \
+  --workspace "${ROOT_DIR}" \
+  --dry-run >/tmp/workcell-provider-e2e-claude.out 2>&1; then
+  echo "Expected provider-e2e claude dry-run to succeed with generated env credentials" >&2
+  cat /tmp/workcell-provider-e2e-claude.out >&2
+  exit 1
+fi
+grep -q '^provider_e2e_agent=claude$' /tmp/workcell-provider-e2e-claude.out
+grep -q '^provider_e2e_injection_source=generated-env$' /tmp/workcell-provider-e2e-claude.out
+grep -q 'claude_api_key' /tmp/workcell-provider-e2e-claude.out
+grep -q 'provider_e2e_probe_cmd=.*--agent-arg -p' /tmp/workcell-provider-e2e-claude.out
+grep -q 'provider_e2e_probe_cmd=.*--agent-arg json' /tmp/workcell-provider-e2e-claude.out
+grep -q 'provider_e2e_probe_cmd=.*--agent-arg --no-session-persistence' /tmp/workcell-provider-e2e-claude.out
+grep -q 'provider_e2e_probe_cmd=.*WORKCELL_PROVIDER_E2E_OK' /tmp/workcell-provider-e2e-claude.out
+
+if ! WORKCELL_E2E_GEMINI_ENV=$'GOOGLE_GENAI_USE_VERTEXAI=true\nGOOGLE_CLOUD_PROJECT=smoke-project\nGOOGLE_CLOUD_LOCATION=us-central1\n' \
+  WORKCELL_E2E_GCLOUD_ADC_JSON='{"type":"authorized_user","client_id":"smoke-client","client_secret":"smoke-secret","refresh_token":"smoke-refresh"}' \
+  "${ROOT_DIR}/scripts/provider-e2e.sh" \
+  --agent gemini \
+  --workspace "${ROOT_DIR}" \
+  --dry-run >/tmp/workcell-provider-e2e-gemini.out 2>&1; then
+  echo "Expected provider-e2e gemini dry-run to succeed with generated env credentials" >&2
+  cat /tmp/workcell-provider-e2e-gemini.out >&2
+  exit 1
+fi
+grep -q '^provider_e2e_agent=gemini$' /tmp/workcell-provider-e2e-gemini.out
+grep -q '^provider_e2e_injection_source=generated-env$' /tmp/workcell-provider-e2e-gemini.out
+grep -q 'gemini_env' /tmp/workcell-provider-e2e-gemini.out
+grep -q 'gcloud_adc' /tmp/workcell-provider-e2e-gemini.out
+grep -q 'provider_e2e_probe_cmd=.*--agent-arg -p' /tmp/workcell-provider-e2e-gemini.out
+grep -q 'provider_e2e_probe_cmd=.*--agent-arg json' /tmp/workcell-provider-e2e-gemini.out
+grep -q 'provider_e2e_probe_cmd=.*WORKCELL_PROVIDER_E2E_OK' /tmp/workcell-provider-e2e-gemini.out
+
+FAKE_PROVIDER_E2E_WORKCELL_OK="${BARRIER_VERIFY_ROOT}/provider-e2e-fake-workcell-ok.sh"
+cat >"${FAKE_PROVIDER_E2E_WORKCELL_OK}" <<'EOF_FAKE_PROVIDER_E2E_OK'
+#!/bin/bash
+set -euo pipefail
+
+for arg in "$@"; do
+  if [[ "${arg}" == "--auth-status" ]]; then
+    cat <<'STATUS'
+credential_keys=codex_auth
+provider_auth_mode=codex_auth
+provider_auth_modes=codex_auth
+shared_auth_modes=none
+github_auth_present=0
+ssh_injected=0
+ssh_config_assurance=off
+secret_copy_targets=none
+STATUS
+    exit 0
+  fi
+done
+
+if [[ "${1:-}" == "--prepare-only" ]]; then
+  exit 0
+fi
+
+case " $* " in
+  *" --agent-arg exec "* ) ;;
+  * )
+    echo "missing codex exec probe args: $*" >&2
+    exit 98
+    ;;
+esac
+case " $* " in
+  *" --agent-arg --json "* ) ;;
+  * )
+    echo "missing codex json probe args: $*" >&2
+    exit 97
+    ;;
+esac
+
+printf '{"type":"item.completed","item":{"type":"agent_message","text":"WORKCELL_PROVIDER_E2E_OK"}}\n'
+EOF_FAKE_PROVIDER_E2E_OK
+chmod +x "${FAKE_PROVIDER_E2E_WORKCELL_OK}"
+
+if ! WORKCELL_PROVIDER_E2E_WORKCELL_SCRIPT="${FAKE_PROVIDER_E2E_WORKCELL_OK}" \
+  WORKCELL_E2E_CODEX_AUTH_JSON='{"token":"codex-smoke"}' \
+  "${ROOT_DIR}/scripts/provider-e2e.sh" \
+  --agent codex \
+  --workspace "${ROOT_DIR}" \
+  --require-injection >/tmp/workcell-provider-e2e-live-probe.out 2>&1; then
+  echo "Expected provider-e2e live probe to succeed against the fake Workcell shim" >&2
+  cat /tmp/workcell-provider-e2e-live-probe.out >&2
+  exit 1
+fi
+grep -q '\[provider-e2e\] auth-status (codex)' /tmp/workcell-provider-e2e-live-probe.out
+grep -q '\[provider-e2e\] prepare-only (codex)' /tmp/workcell-provider-e2e-live-probe.out
+grep -q '\[provider-e2e\] live-probe (codex)' /tmp/workcell-provider-e2e-live-probe.out
+grep -q '"text":"WORKCELL_PROVIDER_E2E_OK"' /tmp/workcell-provider-e2e-live-probe.out
+
+FAKE_PROVIDER_E2E_WORKCELL_GEMINI="${BARRIER_VERIFY_ROOT}/provider-e2e-fake-workcell-gemini.sh"
+cat >"${FAKE_PROVIDER_E2E_WORKCELL_GEMINI}" <<'EOF_FAKE_PROVIDER_E2E_GEMINI'
+#!/bin/bash
+set -euo pipefail
+
+for arg in "$@"; do
+  if [[ "${arg}" == "--auth-status" ]]; then
+    cat <<'STATUS'
+credential_keys=gemini_env
+provider_auth_mode=gemini_env
+provider_auth_modes=gemini_env
+shared_auth_modes=none
+github_auth_present=0
+ssh_injected=0
+ssh_config_assurance=off
+secret_copy_targets=none
+STATUS
+    exit 0
+  fi
+done
+
+if [[ "${1:-}" == "--prepare-only" ]]; then
+  exit 0
+fi
+
+case " $* " in
+  *" --agent-arg -p "* ) ;;
+  * )
+    echo "missing gemini prompt probe args: $*" >&2
+    exit 96
+    ;;
+esac
+case " $* " in
+  *" --agent-arg --output-format "* ) ;;
+  * )
+    echo "missing gemini output-format probe args: $*" >&2
+    exit 95
+    ;;
+esac
+
+printf '{\n  "response": "WORKCELL_PROVIDER_E2E_OK"\n}\n'
+EOF_FAKE_PROVIDER_E2E_GEMINI
+chmod +x "${FAKE_PROVIDER_E2E_WORKCELL_GEMINI}"
+
+if ! WORKCELL_PROVIDER_E2E_WORKCELL_SCRIPT="${FAKE_PROVIDER_E2E_WORKCELL_GEMINI}" \
+  WORKCELL_E2E_GEMINI_ENV=$'GOOGLE_GENAI_USE_VERTEXAI=true\nGOOGLE_CLOUD_PROJECT=smoke-project\nGOOGLE_CLOUD_LOCATION=us-central1\n' \
+  "${ROOT_DIR}/scripts/provider-e2e.sh" \
+  --agent gemini \
+  --workspace "${ROOT_DIR}" \
+  --require-injection >/tmp/workcell-provider-e2e-live-probe-gemini.out 2>&1; then
+  echo "Expected provider-e2e Gemini probe to succeed against the fake Workcell shim" >&2
+  cat /tmp/workcell-provider-e2e-live-probe-gemini.out >&2
+  exit 1
+fi
+grep -q '\[provider-e2e\] auth-status (gemini)' /tmp/workcell-provider-e2e-live-probe-gemini.out
+grep -q '\[provider-e2e\] prepare-only (gemini)' /tmp/workcell-provider-e2e-live-probe-gemini.out
+grep -q '\[provider-e2e\] live-probe (gemini)' /tmp/workcell-provider-e2e-live-probe-gemini.out
+grep -q '"response": "WORKCELL_PROVIDER_E2E_OK"' /tmp/workcell-provider-e2e-live-probe-gemini.out
+
+FAKE_PROVIDER_E2E_WORKCELL_NONE="${BARRIER_VERIFY_ROOT}/provider-e2e-fake-workcell-none.sh"
+cat >"${FAKE_PROVIDER_E2E_WORKCELL_NONE}" <<'EOF_FAKE_PROVIDER_E2E_NONE'
+#!/bin/bash
+set -euo pipefail
+
+for arg in "$@"; do
+  if [[ "${arg}" == "--auth-status" ]]; then
+    printf 'provider_auth_mode=none\n'
+    exit 0
+  fi
+done
+
+echo "unexpected fake provider-e2e workcell invocation: $*" >&2
+exit 99
+EOF_FAKE_PROVIDER_E2E_NONE
+chmod +x "${FAKE_PROVIDER_E2E_WORKCELL_NONE}"
+
+if WORKCELL_PROVIDER_E2E_WORKCELL_SCRIPT="${FAKE_PROVIDER_E2E_WORKCELL_NONE}" \
+  WORKCELL_E2E_CODEX_AUTH_JSON='{"token":"codex-smoke"}' \
+  "${ROOT_DIR}/scripts/provider-e2e.sh" \
+  --agent codex \
+  --workspace "${ROOT_DIR}" >/tmp/workcell-provider-e2e-auth-guard.out 2>&1; then
+  echo "Expected provider-e2e auth guard to fail when injected credentials are not recognized" >&2
+  exit 1
+fi
+grep -q 'Workcell did not detect provider auth for codex' /tmp/workcell-provider-e2e-auth-guard.out
+
+if "${ROOT_DIR}/scripts/provider-e2e.sh" \
+  --agent claude \
+  --workspace "${ROOT_DIR}" \
+  --require-injection \
+  --dry-run >/tmp/workcell-provider-e2e-missing-injection.out 2>&1; then
+  echo "Expected provider-e2e require-injection mode to fail without explicit or generated credentials" >&2
+  exit 1
+fi
+grep -q 'No injection policy is available' /tmp/workcell-provider-e2e-missing-injection.out
+grep -q -- '--require-injection' "${ROOT_DIR}/.github/workflows/provider-e2e.yml"
 grep -q 'Remote host: builder@example.internal' /tmp/workcell-remote-config.out
 grep -q 'Remote base dir: /var/tmp/workcell' /tmp/workcell-remote-config.out
 grep -q "Remote config path: ${LOCAL_REMOTE_CONFIG_PATH}" /tmp/workcell-remote-config.out

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3539,6 +3539,10 @@ grep -q '^provider_e2e_agent=codex$' /tmp/workcell-provider-e2e-codex.out
 grep -q '^provider_e2e_injection_source=generated-env$' /tmp/workcell-provider-e2e-codex.out
 grep -q '^provider_e2e_steps=auth-status,prepare-only,live-probe$' /tmp/workcell-provider-e2e-codex.out
 grep -q 'codex_auth' /tmp/workcell-provider-e2e-codex.out
+if grep -q 'github_hosts' /tmp/workcell-provider-e2e-codex.out; then
+  echo "Expected provider-e2e codex dry-run to omit unrelated shared GitHub credentials" >&2
+  exit 1
+fi
 grep -q 'provider_e2e_auth_status_cmd=.*--auth-status' /tmp/workcell-provider-e2e-codex.out
 grep -q 'provider_e2e_prepare_only_cmd=.*--prepare-only' /tmp/workcell-provider-e2e-codex.out
 grep -q 'provider_e2e_probe_cmd=.*--agent-arg exec' /tmp/workcell-provider-e2e-codex.out
@@ -3561,6 +3565,10 @@ grep -q 'provider_e2e_probe_cmd=.*--agent-arg -p' /tmp/workcell-provider-e2e-cla
 grep -q 'provider_e2e_probe_cmd=.*--agent-arg json' /tmp/workcell-provider-e2e-claude.out
 grep -q 'provider_e2e_probe_cmd=.*--agent-arg --no-session-persistence' /tmp/workcell-provider-e2e-claude.out
 grep -q 'provider_e2e_probe_cmd=.*WORKCELL_PROVIDER_E2E_OK' /tmp/workcell-provider-e2e-claude.out
+if grep -q 'github_hosts' /tmp/workcell-provider-e2e-claude.out; then
+  echo "Expected provider-e2e claude dry-run to omit unrelated shared GitHub credentials" >&2
+  exit 1
+fi
 
 if ! WORKCELL_E2E_GEMINI_ENV=$'GOOGLE_GENAI_USE_VERTEXAI=true\nGOOGLE_CLOUD_PROJECT=smoke-project\nGOOGLE_CLOUD_LOCATION=us-central1\n' \
   WORKCELL_E2E_GCLOUD_ADC_JSON='{"type":"authorized_user","client_id":"smoke-client","client_secret":"smoke-secret","refresh_token":"smoke-refresh"}' \
@@ -3579,6 +3587,111 @@ grep -q 'gcloud_adc' /tmp/workcell-provider-e2e-gemini.out
 grep -q 'provider_e2e_probe_cmd=.*--agent-arg -p' /tmp/workcell-provider-e2e-gemini.out
 grep -q 'provider_e2e_probe_cmd=.*--agent-arg json' /tmp/workcell-provider-e2e-gemini.out
 grep -q 'provider_e2e_probe_cmd=.*WORKCELL_PROVIDER_E2E_OK' /tmp/workcell-provider-e2e-gemini.out
+
+python3 - "${ROOT_DIR}/.github/workflows/provider-e2e.yml" <<'EOF_PROVIDER_E2E_WORKFLOW'
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text()
+on_block = text.split("\npermissions:", 1)[0]
+if "workflow_dispatch:" not in on_block:
+    raise SystemExit("Expected provider-e2e workflow to remain workflow_dispatch-only")
+for forbidden in ("push:", "pull_request:", "pull_request_target:", "schedule:"):
+    if forbidden in on_block:
+        raise SystemExit(f"Unexpected provider-e2e workflow trigger: {forbidden}")
+if text.count("permissions: {}") < 2:
+    raise SystemExit("Expected provider-e2e workflow to keep top-level and guard-job permissions: {}")
+required_global = (
+    "Only the repository owner may dispatch provider-e2e.",
+    "Provider-e2e may only run from the default branch",
+    "needs: provider-e2e-guard",
+    "environment:\n      name: provider-e2e",
+    "permissions:\n      contents: read",
+    "persist-credentials: false",
+    "ref: ${{ github.sha }}",
+)
+for needle in required_global:
+    if needle not in text:
+        raise SystemExit(f"Missing provider-e2e workflow invariant: {needle}")
+
+def step_block(name: str) -> str:
+    marker = f"      - name: {name}\n"
+    start = text.find(marker)
+    if start == -1:
+        raise SystemExit(f"Missing workflow step: {name}")
+    next_step = text.find("\n      - name:", start + len(marker))
+    if next_step == -1:
+        next_step = len(text)
+    return text[start:next_step]
+
+step_expectations = {
+    "Run Codex authenticated probe": {
+        "if": "if: ${{ inputs.provider == 'codex' }}",
+        "agent": '--agent "codex"',
+        "required": ("WORKCELL_E2E_CODEX_AUTH_JSON",),
+        "forbidden": (
+            "WORKCELL_E2E_CLAUDE_API_KEY",
+            "WORKCELL_E2E_CLAUDE_AUTH_JSON",
+            "WORKCELL_E2E_CLAUDE_MCP_JSON",
+            "WORKCELL_E2E_GCLOUD_ADC_JSON",
+            "WORKCELL_E2E_GEMINI_ENV",
+            "WORKCELL_E2E_GEMINI_OAUTH_JSON",
+            "WORKCELL_E2E_GEMINI_PROJECTS_JSON",
+            "WORKCELL_E2E_GITHUB_CONFIG_YML",
+            "WORKCELL_E2E_GITHUB_HOSTS_YML",
+        ),
+    },
+    "Run Claude authenticated probe": {
+        "if": "if: ${{ inputs.provider == 'claude' }}",
+        "agent": '--agent "claude"',
+        "required": (
+            "WORKCELL_E2E_CLAUDE_API_KEY",
+            "WORKCELL_E2E_CLAUDE_AUTH_JSON",
+            "WORKCELL_E2E_CLAUDE_MCP_JSON",
+        ),
+        "forbidden": (
+            "WORKCELL_E2E_CODEX_AUTH_JSON",
+            "WORKCELL_E2E_GCLOUD_ADC_JSON",
+            "WORKCELL_E2E_GEMINI_ENV",
+            "WORKCELL_E2E_GEMINI_OAUTH_JSON",
+            "WORKCELL_E2E_GEMINI_PROJECTS_JSON",
+            "WORKCELL_E2E_GITHUB_CONFIG_YML",
+            "WORKCELL_E2E_GITHUB_HOSTS_YML",
+        ),
+    },
+    "Run Gemini authenticated probe": {
+        "if": "if: ${{ inputs.provider == 'gemini' }}",
+        "agent": '--agent "gemini"',
+        "required": (
+            "WORKCELL_E2E_GCLOUD_ADC_JSON",
+            "WORKCELL_E2E_GEMINI_ENV",
+            "WORKCELL_E2E_GEMINI_OAUTH_JSON",
+            "WORKCELL_E2E_GEMINI_PROJECTS_JSON",
+        ),
+        "forbidden": (
+            "WORKCELL_E2E_CODEX_AUTH_JSON",
+            "WORKCELL_E2E_CLAUDE_API_KEY",
+            "WORKCELL_E2E_CLAUDE_AUTH_JSON",
+            "WORKCELL_E2E_CLAUDE_MCP_JSON",
+            "WORKCELL_E2E_GITHUB_CONFIG_YML",
+            "WORKCELL_E2E_GITHUB_HOSTS_YML",
+        ),
+    },
+}
+
+for step_name, expectation in step_expectations.items():
+    block = step_block(step_name)
+    if expectation["if"] not in block:
+        raise SystemExit(f"Missing provider selector in {step_name}")
+    if expectation["agent"] not in block:
+        raise SystemExit(f"Missing pinned agent launch in {step_name}")
+    for needle in expectation["required"]:
+        if needle not in block:
+            raise SystemExit(f"Missing required env {needle} in {step_name}")
+    for needle in expectation["forbidden"]:
+        if needle in block:
+            raise SystemExit(f"Unexpected env {needle} in {step_name}")
+EOF_PROVIDER_E2E_WORKFLOW
 
 FAKE_PROVIDER_E2E_WORKCELL_OK="${BARRIER_VERIFY_ROOT}/provider-e2e-fake-workcell-ok.sh"
 cat >"${FAKE_PROVIDER_E2E_WORKCELL_OK}" <<'EOF_FAKE_PROVIDER_E2E_OK'
@@ -3638,6 +3751,104 @@ grep -q '\[provider-e2e\] auth-status (codex)' /tmp/workcell-provider-e2e-live-p
 grep -q '\[provider-e2e\] prepare-only (codex)' /tmp/workcell-provider-e2e-live-probe.out
 grep -q '\[provider-e2e\] live-probe (codex)' /tmp/workcell-provider-e2e-live-probe.out
 grep -q '"text":"WORKCELL_PROVIDER_E2E_OK"' /tmp/workcell-provider-e2e-live-probe.out
+
+FAKE_PROVIDER_E2E_WORKCELL_CLAUDE="${BARRIER_VERIFY_ROOT}/provider-e2e-fake-workcell-claude.sh"
+cat >"${FAKE_PROVIDER_E2E_WORKCELL_CLAUDE}" <<'EOF_FAKE_PROVIDER_E2E_CLAUDE'
+#!/bin/bash
+set -euo pipefail
+
+for arg in "$@"; do
+  if [[ "${arg}" == "--auth-status" ]]; then
+    cat <<'STATUS'
+credential_keys=claude_api_key
+provider_auth_mode=claude_api_key
+provider_auth_modes=claude_api_key
+shared_auth_modes=none
+github_auth_present=0
+ssh_injected=0
+ssh_config_assurance=off
+secret_copy_targets=none
+STATUS
+    exit 0
+  fi
+done
+
+if [[ "${1:-}" == "--prepare-only" ]]; then
+  exit 0
+fi
+
+case " $* " in
+  *" --agent-arg -p "* ) ;;
+  * )
+    echo "missing claude prompt probe args: $*" >&2
+    exit 94
+    ;;
+esac
+case " $* " in
+  *" --agent-arg --output-format "* ) ;;
+  * )
+    echo "missing claude output-format probe args: $*" >&2
+    exit 93
+    ;;
+esac
+case " $* " in
+  *" --agent-arg --no-session-persistence "* ) ;;
+  * )
+    echo "missing claude session-persistence probe args: $*" >&2
+    exit 92
+    ;;
+esac
+case " $* " in
+  *" --agent-arg --max-budget-usd "* ) ;;
+  * )
+    echo "missing claude budget probe args: $*" >&2
+    exit 91
+    ;;
+esac
+case " $* " in
+  *" --agent-arg --tools "* ) ;;
+  * )
+    echo "missing claude tools probe args: $*" >&2
+    exit 90
+    ;;
+esac
+if ! python3 - "$@" <<'EOF_FAKE_PROVIDER_E2E_CLAUDE_TOOLS'
+import sys
+
+args = sys.argv[1:]
+for index in range(len(args) - 3):
+    if (
+        args[index] == "--agent-arg"
+        and args[index + 1] == "--tools"
+        and args[index + 2] == "--agent-arg"
+        and args[index + 3] == ""
+    ):
+        raise SystemExit(0)
+raise SystemExit(1)
+EOF_FAKE_PROVIDER_E2E_CLAUDE_TOOLS
+then
+  echo "missing claude empty tools probe value: $*" >&2
+  exit 89
+fi
+
+printf '{"result":"WORKCELL_PROVIDER_E2E_OK"}\n'
+EOF_FAKE_PROVIDER_E2E_CLAUDE
+chmod +x "${FAKE_PROVIDER_E2E_WORKCELL_CLAUDE}"
+
+if ! WORKCELL_PROVIDER_E2E_WORKCELL_SCRIPT="${FAKE_PROVIDER_E2E_WORKCELL_CLAUDE}" \
+  WORKCELL_E2E_CLAUDE_API_KEY='smoke-api-key' \
+  "${ROOT_DIR}/scripts/provider-e2e.sh" \
+  --agent claude \
+  --workspace "${ROOT_DIR}" \
+  --require-injection >/tmp/workcell-provider-e2e-live-probe-claude.out 2>&1; then
+  echo "Expected provider-e2e Claude probe to succeed against the fake Workcell shim" >&2
+  cat /tmp/workcell-provider-e2e-live-probe-claude.out >&2
+  exit 1
+fi
+grep -q '\[provider-e2e\] auth-status (claude)' /tmp/workcell-provider-e2e-live-probe-claude.out
+grep -q '\[provider-e2e\] prepare-only (claude)' /tmp/workcell-provider-e2e-live-probe-claude.out
+grep -q '\[provider-e2e\] live-probe (claude)' /tmp/workcell-provider-e2e-live-probe-claude.out
+grep -q '"result":"WORKCELL_PROVIDER_E2E_OK"' /tmp/workcell-provider-e2e-live-probe-claude.out
 
 FAKE_PROVIDER_E2E_WORKCELL_GEMINI="${BARRIER_VERIFY_ROOT}/provider-e2e-fake-workcell-gemini.sh"
 cat >"${FAKE_PROVIDER_E2E_WORKCELL_GEMINI}" <<'EOF_FAKE_PROVIDER_E2E_GEMINI'
@@ -3724,6 +3935,16 @@ if WORKCELL_PROVIDER_E2E_WORKCELL_SCRIPT="${FAKE_PROVIDER_E2E_WORKCELL_NONE}" \
   exit 1
 fi
 grep -q 'Workcell did not detect provider auth for codex' /tmp/workcell-provider-e2e-auth-guard.out
+
+if WORKCELL_PROVIDER_E2E_WORKCELL_SCRIPT="${FAKE_PROVIDER_E2E_WORKCELL_NONE}" \
+  WORKCELL_E2E_CLAUDE_API_KEY='smoke-api-key' \
+  "${ROOT_DIR}/scripts/provider-e2e.sh" \
+  --agent claude \
+  --workspace "${ROOT_DIR}" >/tmp/workcell-provider-e2e-auth-guard-claude.out 2>&1; then
+  echo "Expected provider-e2e auth guard to fail for Claude when injected credentials are not recognized" >&2
+  exit 1
+fi
+grep -q 'Workcell did not detect provider auth for claude' /tmp/workcell-provider-e2e-auth-guard-claude.out
 
 if "${ROOT_DIR}/scripts/provider-e2e.sh" \
   --agent claude \


### PR DESCRIPTION
## Summary
- add a manual owner-gated provider-authenticated smoke workflow for Codex, Claude, and Gemini
- add a provider-e2e helper that stages reviewed credentials, checks auth posture, prepares the runtime, and runs a minimal authenticated probe
- document the new validation lane and cover it in `verify-invariants.sh`, including non-dry-run shim coverage for auth-detection failures

## Validation
- `git diff --check`
- `bash -n scripts/provider-e2e.sh scripts/verify-invariants.sh`
- `shellcheck -x scripts/provider-e2e.sh scripts/verify-invariants.sh`
- `actionlint .github/workflows/provider-e2e.yml`
- `./scripts/validate-repo.sh`
- `./scripts/verify-invariants.sh`
- `./scripts/provider-e2e.sh --agent codex --workspace "$PWD"`
- `./scripts/provider-e2e.sh --agent gemini --workspace "$PWD"`
