### PR TITLE
feat: harden control-plane provenance and validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,26 @@ updates:
         patterns:
           - "*"
 
+  - package-ecosystem: "docker"
+    directory: "/tools/remote-validator"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:50"
+      timezone: "America/Toronto"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+      - "docker"
+    groups:
+      remote-validator-image:
+        patterns:
+          - "*"
+
   - package-ecosystem: "npm"
     directory: "/runtime/container/providers"
     schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
           WORKCELL_BUILD_INPUT_REF: ${{ github.sha }}
         run: ./scripts/verify-build-input-manifest.sh
 
+      - name: Verify control-plane manifest
+        run: ./scripts/verify-control-plane-manifest.sh
+
       - name: Generate preflight build input manifest
         env:
           SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
@@ -75,6 +78,11 @@ jobs:
         run: |
           mkdir -p dist
           ./scripts/generate-build-input-manifest.sh dist/workcell-build-inputs-preflight.json
+
+      - name: Generate preflight control-plane manifest
+        run: |
+          mkdir -p dist
+          ./scripts/generate-control-plane-manifest.sh dist/workcell-control-plane-preflight.json
 
       - name: Install actionlint
         env:
@@ -173,6 +181,7 @@ jobs:
           name: workcell-release-preflight
           path: |
             dist/workcell-build-inputs-preflight.json
+            dist/workcell-control-plane-preflight.json
             dist/workcell-release-bundle-preflight.json
             dist/workcell-runtime-preflight.json
           retention-days: 7
@@ -315,11 +324,22 @@ jobs:
           SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
         run: ./scripts/generate-build-input-manifest.sh dist/workcell-build-inputs.json
 
+      - name: Regenerate control-plane manifest from archived source tree
+        env:
+          WORKCELL_CONTROL_PLANE_ROOT: ${{ github.workspace }}/dist/release-source
+        run: ./scripts/generate-control-plane-manifest.sh dist/workcell-control-plane.json
+
       - name: Verify build input manifest matches preflight
         run: |
           cmp -s \
             dist/workcell-build-inputs.json \
             dist/preflight/workcell-build-inputs-preflight.json
+
+      - name: Verify control-plane manifest matches preflight
+        run: |
+          cmp -s \
+            dist/workcell-control-plane.json \
+            dist/preflight/workcell-control-plane-preflight.json
 
       - id: build_amd64
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -452,6 +472,7 @@ jobs:
             "dist/${BUNDLE_NAME}" \
             dist/workcell-image.digest \
             dist/workcell-build-inputs.json \
+            dist/workcell-control-plane.json \
             dist/workcell-builder-environment.json \
             dist/workcell-source.spdx.json \
             dist/workcell-image.spdx.json
@@ -486,6 +507,14 @@ jobs:
           cosign sign-blob \
             --bundle dist/workcell-build-inputs.sigstore.json \
             dist/workcell-build-inputs.json
+
+      - name: Sign control-plane manifest
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign-blob \
+            --bundle dist/workcell-control-plane.sigstore.json \
+            dist/workcell-control-plane.json
 
       - name: Sign builder environment manifest
         env:
@@ -547,6 +576,8 @@ jobs:
             dist/workcell-image.digest
             dist/workcell-build-inputs.json
             dist/workcell-build-inputs.sigstore.json
+            dist/workcell-control-plane.json
+            dist/workcell-control-plane.sigstore.json
             dist/workcell-builder-environment.json
             dist/workcell-builder-environment.sigstore.json
             dist/SHA256SUMS
@@ -567,6 +598,8 @@ jobs:
             dist/workcell-image.digest \
             dist/workcell-build-inputs.json \
             dist/workcell-build-inputs.sigstore.json \
+            dist/workcell-control-plane.json \
+            dist/workcell-control-plane.sigstore.json \
             dist/workcell-builder-environment.json \
             dist/workcell-builder-environment.sigstore.json \
             dist/SHA256SUMS \

--- a/docs/adapter-control-planes.md
+++ b/docs/adapter-control-planes.md
@@ -21,6 +21,17 @@ home and is never written back to the adapter baseline. On each new provider
 launch within the same container session, the home is re-seeded from the same
 immutable sources.
 
+Before seeding adapter-managed files, `runtime/container/home-control-plane.sh`
+verifies the relevant adapter baseline hashes against the `runtime_artifacts`
+section of the committed `runtime/container/control-plane-manifest.json` that
+is baked into the image. The same published manifest also carries a separate
+`host_artifacts` section for reviewed host-side launcher inputs such as
+`scripts/workcell` and `scripts/lib/render_injection_bundle.py`, but those
+entries are release-provenance only and are not runtime-hash-checked inside the
+container. Release publication signs and publishes the full manifest so
+consumers can audit the reviewed control-plane inputs separately from the
+broader build-input manifest.
+
 ---
 
 ## Control file matrix
@@ -39,9 +50,9 @@ The following table covers all files seeded by `seed_codex_home()`,
 | `~/.codex/rules/` | Codex | Symlink → immutable baseline (readonly) or session-local writable copy (session) | Same | Execpolicy rules; see rules mutability section below |
 | `~/.codex/mcp/config.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/mcp/config.toml`; ships no live MCP defaults |
 | `~/.codex/auth.json` | Codex | Copied from injection credential `codex_auth` if present | Same | Session-local Codex auth; not present if `credentials.codex_auth` is not configured |
-| `~/.claude/settings.json` | Claude | Symlink → immutable baseline, or session-local copy with `apiKeyHelper` if `claude_api_key` is injected | Same | Linked to `adapters/claude/managed-settings.json`; contains deny-list permissions and the `PreToolUse` Bash hook |
+| `~/.claude/settings.json` | Claude | Symlink → immutable baseline, or session-local copy with `apiKeyHelper` if `claude_api_key` is injected | Same | Linked to `adapters/claude/managed-settings.json`; contains deny-list permissions and the `PreToolUse` Bash hook. When `claude_api_key` is present, the helper reads the reviewed direct-mounted credential path instead of creating a second session-local key copy. |
 | `~/.claude/CLAUDE.md` | Claude | Rendered (baseline + workspace + injection layers) | Same | Provider instruction doc; workspace `AGENTS.md` and `CLAUDE.md` are imported as layers |
-| `~/.claude/workcell/` | Claude | Created only when `claude_api_key` credential is injected | Same | Holds the session-local `api-key-helper.sh` script and secret file |
+| `~/.claude/workcell/` | Claude | Created only when `claude_api_key` credential is injected | Same | Holds the session-local `api-key-helper.sh` script. The helper reads the mounted key file directly, so Workcell no longer drops a second plaintext copy under this directory. |
 | `~/.config/claude-code/auth.json` | Claude | Copied from injection credential `claude_auth` if present | Same | Session-local Claude CLI auth; not present if `credentials.claude_auth` is not configured |
 | `~/.mcp.json` | Claude | Symlink → immutable `mcp-template.json` (empty), or copied from `claude_mcp` credential if injected | Same | MCP server registry; ships empty by default |
 | `~/.gemini/settings.json` | Gemini | Copied (not symlinked) from immutable baseline; mode `0600` | Same, but `breakglass` re-enables Gemini folder trust before launch | Copied from `adapters/gemini/.gemini/settings.json` |

--- a/docs/adapter-control-planes.md
+++ b/docs/adapter-control-planes.md
@@ -26,11 +26,13 @@ verifies the relevant adapter baseline hashes against the `runtime_artifacts`
 section of the committed `runtime/container/control-plane-manifest.json` that
 is baked into the image. The same published manifest also carries a separate
 `host_artifacts` section for reviewed host-side launcher inputs such as
-`scripts/workcell` and `scripts/lib/render_injection_bundle.py`, but those
-entries are release-provenance only and are not runtime-hash-checked inside the
-container. Release publication signs and publishes the full manifest so
-consumers can audit the reviewed control-plane inputs separately from the
-broader build-input manifest.
+`scripts/workcell`, `scripts/lib/trusted-docker-client.sh`,
+`scripts/lib/extract_direct_mounts.py`, and
+`scripts/lib/render_injection_bundle.py`, but those entries are
+release-provenance only and are not runtime-hash-checked inside the container.
+Release publication signs and publishes the full manifest so consumers can
+audit the reviewed control-plane inputs separately from the broader
+build-input manifest.
 
 ---
 

--- a/docs/examples/injection-policy.toml
+++ b/docs/examples/injection-policy.toml
@@ -1,4 +1,5 @@
 version = 1
+includes = ["shared-documents.toml"]
 
 [documents]
 common = "/Users/example/.config/workcell/common-agent.md"

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -53,10 +53,11 @@ under platform automation.
   attestations on tagged releases, deterministic fixed-order multi-arch
   manifest assembly, preflight-to-publish digest binding for the source bundle
   and both per-platform image manifests, byte-for-byte preflight binding for
-  the build-input manifest and control-plane manifest, including the host-side
-  launcher and injection-policy renderer entries that stage the reviewed
-  provider homes, a conditional release-preflight CodeQL rerun when repository
-  settings enable private code scanning or the repository is public, a
+  the build-input manifest and control-plane manifest, including the
+  host-side launcher, Docker-context guard, direct-mount extractor, and
+  injection-policy renderer entries that stage the reviewed provider homes, a
+  conditional release-preflight CodeQL rerun when repository settings enable
+  private code scanning or the repository is public, a
   protected `release` environment with a human approval gate before publish
   when the repository visibility and billing plan support required reviewers,
   an explicit release-asset allowlist, exact pinned BuildKit, Cosign, and Syft

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -47,19 +47,22 @@ under platform automation.
   runs only on `main` pushes and manual dispatches so untrusted pull request
   code never lands on a self-hosted runner
 - `release.yml`: multi-arch image publish, a directly signed build-input
-  manifest, a signed builder-environment manifest, direct signing for the
-  source bundle and both published SBOMs, SBOM generation, checksums,
+  manifest, a directly signed control-plane manifest, a signed
+  builder-environment manifest, direct signing for the source bundle and both
+  published SBOMs, SBOM generation, checksums,
   attestations on tagged releases, deterministic fixed-order multi-arch
   manifest assembly, preflight-to-publish digest binding for the source bundle
   and both per-platform image manifests, byte-for-byte preflight binding for
-  the build-input manifest, a conditional release-preflight CodeQL rerun when
-  repository settings enable private code scanning or the repository is public,
-  a protected `release` environment with a human approval gate before publish
+  the build-input manifest and control-plane manifest, including the host-side
+  launcher and injection-policy renderer entries that stage the reviewed
+  provider homes, a conditional release-preflight CodeQL rerun when repository
+  settings enable private code scanning or the repository is public, a
+  protected `release` environment with a human approval gate before publish
   when the repository visibility and billing plan support required reviewers,
   an explicit release-asset allowlist, exact pinned BuildKit, Cosign, and Syft
   tooling, archived-source-tree image publication instead of live-worktree
-  publication, and pinned GitHub Release publication instead of an ambient `gh`
-  binary
+  publication, and pinned GitHub Release publication instead of an ambient
+  `gh` binary
 - `hosted-controls.yml`: live GitHub control-plane drift detection on `main`
   pushes, schedule, and manual dispatch, using the same hosted-controls policy
   that release preflight enforces before publish; on private repositories it
@@ -102,6 +105,12 @@ of the reviewed control plane:
   in [`policy/github-hosted-controls.toml`](../policy/github-hosted-controls.toml)
 - explicit CODEOWNERS entries for high-risk paths such as
   `.github/workflows/`, `scripts/`, and the runtime boundary
+
+Tagged release preflight also regenerates the deterministic control-plane
+manifest, compares it against the committed copy and archived-source rebuild,
+then signs and publishes it. That manifest separates runtime-enforced
+`runtime_artifacts` from release-provenance-only `host_artifacts` so the
+workflow does not overstate what the runtime itself verifies.
 
 The repository includes [`scripts/verify-github-hosted-controls.sh`](../scripts/verify-github-hosted-controls.sh)
 to audit those hosted settings with the GitHub API.
@@ -175,6 +184,7 @@ Dependabot currently covers:
 - GitHub Actions
 - the runtime Dockerfile base image
 - the validator Dockerfile base image
+- the remote-validator Dockerfile base image
 - the pinned provider CLI lockfile in `runtime/container/providers`
 - the vendored Rust runtime crate in `runtime/container/rust`
 

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -69,6 +69,16 @@ Selectors let you scope injected material to only some launches:
 - `providers = ["codex", "claude", "gemini"]`
 - `modes = ["strict", "build"]`
 
+For larger setups, policies can be composed from smaller operator-owned files:
+
+- `includes = ["shared-docs.toml", "provider-auth.toml"]`
+
+Includes are loaded relative to the current policy file, must stay within the
+entrypoint policy tree, are merged in the listed order, and fail closed on
+cycles or duplicate settings. `[[copies]]` entries append in include order;
+duplicate `documents.*`, `ssh.*`, or `credentials.*` settings are rejected so
+one fragment cannot silently override another.
+
 For `[credentials]`, simple `key = "/path/to/file"` entries still work for
 provider-native credentials. Shared GitHub CLI credentials should use scoped
 nested tables so you explicitly choose which provider sessions receive them.
@@ -132,8 +142,9 @@ modes = ["strict", "build"]
 - `credentials.codex_auth` mounts a host `auth.json` read-only and copies it into
   `~/.codex/auth.json` for session-local Codex auth reuse.
 - `credentials.claude_api_key` mounts a secret file read-only and generates a
-  session-local Claude `apiKeyHelper` so Claude can reuse an API key without
-  mutating the reviewed baseline settings.
+  session-local Claude `apiKeyHelper` that reads the reviewed direct-mounted
+  credential path, so Claude can reuse an API key without mutating the
+  reviewed baseline settings or creating an extra session-local secret copy.
 - `credentials.claude_auth` mounts persisted Claude CLI auth into
   `~/.config/claude-code/auth.json` when you already have reviewed host-side
   Claude login state.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -16,6 +16,8 @@ Tagged releases publish:
 - a published image digest file
 - a machine-readable build input manifest
 - a keyless Sigstore bundle for the build input manifest
+- a machine-readable control-plane manifest
+- a keyless Sigstore bundle for the control-plane manifest
 - a machine-readable builder environment manifest
 - a keyless Sigstore bundle for the builder environment manifest
 - `SHA256SUMS`
@@ -25,8 +27,8 @@ Tagged releases publish:
 - a keyless Sigstore bundle for the image SBOM
 - keyless Sigstore signatures for the published image
 - a keyless Sigstore bundle for `SHA256SUMS`, which covers the source bundle,
-  published image digest, build input manifest, builder environment manifest,
-  and both SBOM files
+  published image digest, build input manifest, control-plane manifest, builder
+  environment manifest, and both SBOM files
 - GitHub attestations when `WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true` is set on
   a repository and plan that support them
 
@@ -57,6 +59,12 @@ The release workflow uses:
   sources, and runtime enforcement code, plus the rest of the tracked
   repository inputs that control release publication, and is itself directly
   signed and also covered by the signed checksum set
+- a deterministic control-plane manifest that records the reviewed adapter
+  baselines, runtime control-plane scripts that seed provider-facing homes,
+  and the host-side launcher and injection-policy renderer that stage those
+  homes, is copied into the runtime image, drives runtime hash checks for the
+  adapter baselines and selected seeding inputs, is directly signed at release
+  time, and is also bound into the signed checksum set
 - host-side pin-hygiene checks that run before rebuilding the validator image
   in CI and release preflight, including exact package-set checks for both the
   runtime and validator Dockerfiles, pinned workflow-side BuildKit and signing
@@ -139,7 +147,17 @@ gh attestation verify oci://ghcr.io/OWNER/workcell@sha256:DIGEST \
    Cosign.
 3. Verify the checksum file bundle with Cosign.
 4. Verify the tarball, image digest file, build input manifest, builder
-   environment manifest, and SBOM digests against `SHA256SUMS`.
+  environment manifest, control-plane manifest, and SBOM digests against
+  `SHA256SUMS`.
+
+The control-plane manifest publishes two reviewed domains in one deterministic
+artifact:
+
+- `runtime_artifacts`: reviewed files baked into the runtime image; current
+  runtime hash checks cover the adapter baselines and selected seeding inputs
+- `host_artifacts`: reviewed host-side launcher and injection-renderer inputs
+  that are signed and published for release provenance, but not verified inside
+  the runtime
 
 ```bash
 cosign verify-blob SHA256SUMS \
@@ -149,6 +167,11 @@ cosign verify-blob SHA256SUMS \
 
 cosign verify-blob workcell-build-inputs.json \
   --bundle workcell-build-inputs.sigstore.json \
+  --certificate-identity-regexp 'https://github.com/OWNER/workcell/.github/workflows/release.yml@refs/tags/.+' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+cosign verify-blob workcell-control-plane.json \
+  --bundle workcell-control-plane.sigstore.json \
   --certificate-identity-regexp 'https://github.com/OWNER/workcell/.github/workflows/release.yml@refs/tags/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -61,10 +61,11 @@ The release workflow uses:
   signed and also covered by the signed checksum set
 - a deterministic control-plane manifest that records the reviewed adapter
   baselines, runtime control-plane scripts that seed provider-facing homes,
-  and the host-side launcher and injection-policy renderer that stage those
-  homes, is copied into the runtime image, drives runtime hash checks for the
-  adapter baselines and selected seeding inputs, is directly signed at release
-  time, and is also bound into the signed checksum set
+  and the host-side launcher, Docker-context guard, direct-mount extractor,
+  and injection-policy renderer that stage those homes, is copied into the
+  runtime image, drives runtime hash checks for the adapter baselines and
+  selected seeding inputs, is directly signed at release time, and is also
+  bound into the signed checksum set
 - host-side pin-hygiene checks that run before rebuilding the validator image
   in CI and release preflight, including exact package-set checks for both the
   runtime and validator Dockerfiles, pinned workflow-side BuildKit and signing
@@ -155,9 +156,9 @@ artifact:
 
 - `runtime_artifacts`: reviewed files baked into the runtime image; current
   runtime hash checks cover the adapter baselines and selected seeding inputs
-- `host_artifacts`: reviewed host-side launcher and injection-renderer inputs
-  that are signed and published for release provenance, but not verified inside
-  the runtime
+- `host_artifacts`: reviewed host-side launcher, Docker-context guard,
+  direct-mount extractor, and injection-renderer inputs that are signed and
+  published for release provenance, but not verified inside the runtime
 
 ```bash
 cosign verify-blob SHA256SUMS \

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -21,6 +21,15 @@ Recommended commands:
 - `./scripts/container-smoke.sh`
 - `./scripts/pre-merge.sh`
 
+If you want the broader local validation stack to run against a disposable
+snapshot instead of the live worktree, use the reviewed pre-merge flags:
+
+- `./scripts/pre-merge.sh --local-snapshot worktree --local-include-untracked`
+- `./scripts/pre-merge.sh --local-snapshot head`
+
+The snapshot mode is intentionally scoped to `pre-merge.sh` today. Provider
+authenticated smoke remains an explicit live-worktree lane.
+
 ## Local Provider Authenticated Smoke
 
 Use this lane when you need to validate that Workcell stages real provider

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -95,7 +95,7 @@ COPY runtime/container/providers /opt/workcell/providers
 
 RUN cd /opt/workcell/providers \
   && install_provider_packages() { \
-       npm ci --omit=dev --ignore-scripts --no-audit --no-fund --no-update-notifier \
+       npm ci --omit=dev --ignore-scripts --no-audit --no-fund \
        && return 0; \
      } \
   && for attempt in 1 2 3; do \
@@ -110,14 +110,10 @@ RUN cd /opt/workcell/providers \
        sleep "$((attempt * 5))"; \
      done \
   && npm cache clean --force \
-  && tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner \
-    -cf /tmp/workcell-providers.tar -C /opt/workcell/providers . \
-  && cd / \
-  && rm -rf /opt/workcell/providers \
-  && mkdir -p /opt/workcell/providers \
-  && tar -xf /tmp/workcell-providers.tar -C /opt/workcell/providers \
-  && rm -f /tmp/workcell-providers.tar \
   && find /opt/workcell/providers -print0 | LC_ALL=C sort -z | xargs -0 touch -h -d "@${SOURCE_DATE_EPOCH}" \
+  && tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner \
+    -cf /opt/workcell/providers.tar -C /opt/workcell/providers . \
+  && rm -rf /opt/workcell/providers \
   && rm -rf /root/.npm /root/.cache
 
 FROM runtime-base AS runtime-builder
@@ -214,7 +210,8 @@ RUN cd /workcell-rust \
   && cp /opt/workcell/adapters/claude/managed-settings.json /etc/claude-code/managed-settings.json \
   && rm -rf /tmp/workcell-rust-target /workcell-rust \
   && printf '/usr/local/lib/libworkcell_exec_guard.so\n' > /etc/ld.so.preload \
-  && chmod 0444 /etc/claude-code/managed-settings.json \
+  && chmod 0444 \
+    /etc/claude-code/managed-settings.json \
   && chmod 0444 \
     /usr/local/libexec/workcell/assurance.sh \
     /usr/local/libexec/workcell/apt-wrapper.sh \
@@ -244,14 +241,18 @@ FROM runtime-base AS runtime
 
 ARG SOURCE_DATE_EPOCH
 
-COPY --from=provider-builder /opt/workcell/providers /opt/workcell/providers
+COPY --from=provider-builder /opt/workcell/providers.tar /tmp/workcell-providers.tar
 COPY --from=runtime-builder /etc/claude-code/managed-settings.json /etc/claude-code/managed-settings.json
 COPY --from=runtime-builder /etc/ld.so.preload /etc/ld.so.preload
 COPY --from=runtime-builder /opt/workcell/adapters /opt/workcell/adapters
 COPY --from=runtime-builder /usr/local/lib/libworkcell_exec_guard.so /usr/local/lib/libworkcell_exec_guard.so
 COPY --from=runtime-builder /usr/local/libexec/workcell /usr/local/libexec/workcell
+COPY runtime/container/control-plane-manifest.json /usr/local/libexec/workcell/control-plane-manifest.json
 
 RUN mv /usr/bin/git /usr/local/libexec/workcell/real/git \
+  && mkdir -p /opt/workcell/providers \
+  && tar -xf /tmp/workcell-providers.tar -C /opt/workcell/providers \
+  && rm -f /tmp/workcell-providers.tar \
   && chmod 0644 /usr/local/libexec/workcell/real/git \
   && mv /usr/local/bin/node /usr/local/libexec/workcell/real/node \
   && chmod 0755 /usr/local/libexec/workcell/real/node \
@@ -268,7 +269,9 @@ RUN mv /usr/bin/git /usr/local/libexec/workcell/real/git \
   && ln -sf /usr/local/libexec/workcell/core/launcher /usr/local/bin/gemini \
   && ln -sf /usr/local/libexec/workcell/core/git /usr/local/bin/git \
   && ln -sf /usr/local/libexec/workcell/core/git /usr/bin/git \
-  && chmod 0444 /etc/claude-code/managed-settings.json \
+  && chmod 0444 \
+    /etc/claude-code/managed-settings.json \
+    /usr/local/libexec/workcell/control-plane-manifest.json \
   && chmod 0644 \
     /opt/workcell/providers/node_modules/@anthropic-ai/claude-code/cli.js \
     /opt/workcell/providers/node_modules/@google/gemini-cli/dist/index.js \
@@ -284,7 +287,7 @@ RUN mv /usr/bin/git /usr/local/libexec/workcell/real/git \
   && rm -rf /tmp/* /var/tmp/* /root/.npm /root/.cache /var/lib/apt/lists/* /var/cache/apt/* /var/cache/debconf/*-old /var/cache/ldconfig/aux-cache \
   && rm -f /etc/ld.so.cache \
   && find \
-      /opt/workcell \
+      /opt/workcell/adapters \
       /etc/claude-code \
       /etc/ld.so.preload \
       /usr/local/bin \

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -5,8 +5,16 @@
       "sha256": "3b71f6ce278568f92cc7bca664b6f5164bda4e53653f4b4254a84479372424df"
     },
     {
+      "repo_path": "scripts/lib/extract_direct_mounts.py",
+      "sha256": "66f9042444a3852a8155eb1d8c100fb026ac968b242573c62f34b536d2fab5fa"
+    },
+    {
       "repo_path": "scripts/lib/render_injection_bundle.py",
       "sha256": "848dbe2b708e6d2e4c59ba200ee57554366c63bf65bd253effb1a69befd908b5"
+    },
+    {
+      "repo_path": "scripts/lib/trusted-docker-client.sh",
+      "sha256": "66384bd55c487dc25fea52c6872ed4ddc5b190a97a47ff6a7b967a6e87244981"
     }
   ],
   "runtime_artifacts": [

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -1,0 +1,189 @@
+{
+  "host_artifacts": [
+    {
+      "repo_path": "scripts/workcell",
+      "sha256": "3b71f6ce278568f92cc7bca664b6f5164bda4e53653f4b4254a84479372424df"
+    },
+    {
+      "repo_path": "scripts/lib/render_injection_bundle.py",
+      "sha256": "848dbe2b708e6d2e4c59ba200ee57554366c63bf65bd253effb1a69befd908b5"
+    }
+  ],
+  "runtime_artifacts": [
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/claude/.claude/settings.json",
+      "runtime_path": "/opt/workcell/adapters/claude/.claude/settings.json",
+      "sha256": "61d55ea87682dce016c3bd4ede120863b8718db65e7309db5c0c4a41deb88629"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/claude/CLAUDE.md",
+      "runtime_path": "/opt/workcell/adapters/claude/CLAUDE.md",
+      "sha256": "57ebc2c1f55c1e537f14db0a843f24e1273a016c184d4fae5e5ff5c6e673c8a5"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/claude/hooks/guard-bash.sh",
+      "runtime_path": "/opt/workcell/adapters/claude/hooks/guard-bash.sh",
+      "sha256": "d8f1528b8d4eac4d73c362e6743d736f390ef70dc9c129a26f89e84d65695b72"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/claude/managed-settings.json",
+      "runtime_path": "/opt/workcell/adapters/claude/managed-settings.json",
+      "sha256": "977745dc9b4071011de5966aac596f89fa225bebb17306a4917238e7eff427d8"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/claude/mcp-template.json",
+      "runtime_path": "/opt/workcell/adapters/claude/mcp-template.json",
+      "sha256": "d8e397af03b5b032f21d0aa967086f0c78b33c87b76f2e9898ae0a144df7de02"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/.codex/AGENTS.md",
+      "runtime_path": "/opt/workcell/adapters/codex/.codex/AGENTS.md",
+      "sha256": "1ac10f9a44e3b23bdc9726f23c8138f79000649617ea7833572a6e1215489b6e"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/.codex/agents/anthropic_claude_compat.md",
+      "runtime_path": "/opt/workcell/adapters/codex/.codex/agents/anthropic_claude_compat.md",
+      "sha256": "b685cd6881676ef12a87cf5e3cc3c1f2abda30b9e3bb2ffc51f5b0e4fad0f9b1"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/.codex/agents/apple_platform_boundary.md",
+      "runtime_path": "/opt/workcell/adapters/codex/.codex/agents/apple_platform_boundary.md",
+      "sha256": "19f6e07bc4c516a22284f5853152b3ffbabbe32241335686ba5b0a1bed8511d8"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/.codex/agents/distinguished_security.md",
+      "runtime_path": "/opt/workcell/adapters/codex/.codex/agents/distinguished_security.md",
+      "sha256": "e9c1ded048aea209491c7d5c7c792030b31be8582f424d25d8e6d80e1e740e49"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/.codex/agents/openai_codex_platform.md",
+      "runtime_path": "/opt/workcell/adapters/codex/.codex/agents/openai_codex_platform.md",
+      "sha256": "83962765347a28cec878697e3a4e44a5ecda3e30a5daa9ff721f7e1c426ac318"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/.codex/config.toml",
+      "runtime_path": "/opt/workcell/adapters/codex/.codex/config.toml",
+      "sha256": "26e5b940ea519689e594d83018760317eeb0108833bd69b4a1071171f95a3c96"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/.codex/rules/default.rules",
+      "runtime_path": "/opt/workcell/adapters/codex/.codex/rules/default.rules",
+      "sha256": "094b8fe94dccb3c98000cd35ae1905bf804c03aa5d0e1e37cf80b25aa3fec688"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/managed_config.toml",
+      "runtime_path": "/opt/workcell/adapters/codex/managed_config.toml",
+      "sha256": "e281425eef791ce8fb1b6a7efcea68aa0cb2bf96e7c780b4f2c2af32658a0e3a"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/mcp/config.toml",
+      "runtime_path": "/opt/workcell/adapters/codex/mcp/config.toml",
+      "sha256": "28e70cdc32c22b7bcf51ed4b3ed5bec9686132ac9034500c3952bb3f6ac30856"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/requirements.toml",
+      "runtime_path": "/opt/workcell/adapters/codex/requirements.toml",
+      "sha256": "ff19c1f5942abd8479c0a740e9c38dd81c4ad483d4773aca4546a54a95a446cc"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/gemini/.gemini/settings.json",
+      "runtime_path": "/opt/workcell/adapters/gemini/.gemini/settings.json",
+      "sha256": "588a5edec5da4165d108f7da77ad268c7d3b4e2a66bd3b5044c30604d56911ec"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/gemini/GEMINI.md",
+      "runtime_path": "/opt/workcell/adapters/gemini/GEMINI.md",
+      "sha256": "a06f4999ace204e3a1f1236c98a777d18e9eba24df8fbe0ddd623bd0fccc8cb9"
+    },
+    {
+      "kind": "runtime-control-plane",
+      "repo_path": "runtime/container/assurance.sh",
+      "runtime_path": "/usr/local/libexec/workcell/assurance.sh",
+      "sha256": "e4acc20f65d4b98ae1ccc8b04a6a2ba9eae7cbf6fba500f640ce2b1328bdafa0"
+    },
+    {
+      "kind": "runtime-control-plane",
+      "repo_path": "runtime/container/bin/apt-helper.sh",
+      "runtime_path": "/usr/local/libexec/workcell/apt-helper.sh",
+      "sha256": "96237b87fd48a0eb723dfbc2be57403f69f1618c12b0d38f66c80c7d0e3a049b"
+    },
+    {
+      "kind": "runtime-control-plane",
+      "repo_path": "runtime/container/bin/apt-wrapper.sh",
+      "runtime_path": "/usr/local/libexec/workcell/apt-wrapper.sh",
+      "sha256": "7f69b164e6440e6082fac91e6fca9d992bdba2053af4a6c113630b251d41dc4e"
+    },
+    {
+      "kind": "runtime-control-plane",
+      "repo_path": "runtime/container/entrypoint.sh",
+      "runtime_path": "/usr/local/libexec/workcell/entrypoint.sh",
+      "sha256": "e3df912ebe11f103fcf4cf11befa1729764b3a887aeea2bd32ce1369b984f906"
+    },
+    {
+      "kind": "runtime-control-plane",
+      "repo_path": "runtime/container/bin/git",
+      "runtime_path": "/usr/local/libexec/workcell/git-wrapper.sh",
+      "sha256": "490e2c8be98ab5a2612fc7317ff3d7ddfe12ddbf503271cf0fa717c06372944d"
+    },
+    {
+      "kind": "runtime-control-plane",
+      "repo_path": "runtime/container/home-control-plane.sh",
+      "runtime_path": "/usr/local/libexec/workcell/home-control-plane.sh",
+      "sha256": "ef7db5a46f7bf21cd5cc2f7a3896e63f1711626905df9293902f3270311ff77e"
+    },
+    {
+      "kind": "runtime-control-plane",
+      "repo_path": "runtime/container/bin/node",
+      "runtime_path": "/usr/local/libexec/workcell/node-wrapper.sh",
+      "sha256": "e4c7691b547c777eda01f8475e0b6864278010ad561be9df5235079ec7a40d80"
+    },
+    {
+      "kind": "runtime-control-plane",
+      "repo_path": "runtime/container/provider-policy.sh",
+      "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
+      "sha256": "4c927c38806712648da566fa56b092a07f2c1829d90ce0b9c3a6ae9dfcc91963"
+    },
+    {
+      "kind": "runtime-control-plane",
+      "repo_path": "runtime/container/provider-wrapper.sh",
+      "runtime_path": "/usr/local/libexec/workcell/provider-wrapper.sh",
+      "sha256": "1f12566c8b7d5c198f7658c7d375f45f6f490153aa4e94fa7c3626db1a6a4fd5"
+    },
+    {
+      "kind": "runtime-control-plane",
+      "repo_path": "runtime/container/public-node-guard.mjs",
+      "runtime_path": "/usr/local/libexec/workcell/public-node-guard.mjs",
+      "sha256": "daab1332b6e21abe83ca92370db0714a3fb681b64100c6cf96ae9b9dba2ea659"
+    },
+    {
+      "kind": "runtime-control-plane",
+      "repo_path": "runtime/container/runtime-user.sh",
+      "runtime_path": "/usr/local/libexec/workcell/runtime-user.sh",
+      "sha256": "219a7defbabba9f312b3f331eebff1ab0bae7cbaa24fcbe424057e5c1f1a38e9"
+    },
+    {
+      "kind": "runtime-control-plane",
+      "repo_path": "adapters/claude/managed-settings.json",
+      "runtime_path": "/etc/claude-code/managed-settings.json",
+      "sha256": "977745dc9b4071011de5966aac596f89fa225bebb17306a4917238e7eff427d8"
+    }
+  ],
+  "schema_version": 2
+}

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -113,6 +113,7 @@ workcell_copy_control_plane_file() {
 
 WORKCELL_WORKSPACE_IMPORT_ROOT="${WORKCELL_WORKSPACE_IMPORT_ROOT:-/opt/workcell/workspace-control-plane}"
 WORKCELL_CODEX_RULES_MUTABILITY="${WORKCELL_CODEX_RULES_MUTABILITY:-readonly}"
+WORKCELL_CONTROL_PLANE_MANIFEST="${WORKCELL_CONTROL_PLANE_MANIFEST:-/usr/local/libexec/workcell/control-plane-manifest.json}"
 
 workcell_session_assurance() {
   workcell_runtime_state_value WORKCELL_SESSION_ASSURANCE || true
@@ -210,6 +211,89 @@ workcell_manifest_path() {
 
 workcell_manifest_root() {
   dirname "$(workcell_manifest_path)"
+}
+
+workcell_control_plane_manifest_path() {
+  printf '%s\n' "${WORKCELL_CONTROL_PLANE_MANIFEST}"
+}
+
+workcell_ensure_control_plane_manifest() {
+  if [[ ! -f "$(workcell_control_plane_manifest_path)" ]]; then
+    workcell_die "Workcell control-plane manifest is missing: $(workcell_control_plane_manifest_path)"
+  fi
+}
+
+workcell_control_plane_expected_sha() {
+  local runtime_path="$1"
+
+  workcell_ensure_control_plane_manifest
+  jq -r --arg runtime_path "${runtime_path}" \
+    '.runtime_artifacts[] | select(.runtime_path == $runtime_path) | .sha256' \
+    "$(workcell_control_plane_manifest_path)" | head -n 1
+}
+
+workcell_verify_control_plane_parent_paths() {
+  local runtime_path="$1"
+  local current_path="/"
+  local parent_path=""
+  local component=""
+  local -a path_components=()
+
+  parent_path="$(dirname "${runtime_path}")"
+  if [[ "${parent_path}" == "/" ]]; then
+    return 0
+  fi
+
+  IFS='/' read -r -a path_components <<<"${parent_path#/}"
+  for component in "${path_components[@]}"; do
+    [[ -n "${component}" ]] || continue
+    current_path="${current_path%/}/${component}"
+    if [[ -L "${current_path}" ]]; then
+      workcell_die "Workcell control-plane artifact parent must not be a symlink: ${current_path}"
+    fi
+  done
+}
+
+workcell_verify_control_plane_path() {
+  local runtime_path="$1"
+  local expected_sha=""
+  local actual_sha=""
+
+  expected_sha="$(workcell_control_plane_expected_sha "${runtime_path}")"
+  if [[ -z "${expected_sha}" ]] || [[ "${expected_sha}" == "null" ]]; then
+    workcell_die "Workcell control-plane manifest has no entry for ${runtime_path}"
+  fi
+  workcell_verify_control_plane_parent_paths "${runtime_path}"
+  if [[ -L "${runtime_path}" ]]; then
+    workcell_die "Workcell control-plane artifact must not be a symlink: ${runtime_path}"
+  fi
+  if [[ ! -f "${runtime_path}" ]]; then
+    workcell_die "Workcell control-plane artifact is missing: ${runtime_path}"
+  fi
+  actual_sha="$(sha256sum "${runtime_path}" | awk '{print $1}')"
+  if [[ "${actual_sha}" != "${expected_sha}" ]]; then
+    workcell_die "Workcell control-plane manifest mismatch for ${runtime_path}: ${actual_sha} != ${expected_sha}"
+  fi
+}
+
+workcell_verify_control_plane_prefix() {
+  local runtime_prefix="$1"
+  local runtime_path=""
+  local matched=0
+
+  workcell_ensure_control_plane_manifest
+  while IFS= read -r runtime_path; do
+    [[ -n "${runtime_path}" ]] || continue
+    matched=1
+    workcell_verify_control_plane_path "${runtime_path}"
+  done < <(
+    jq -r --arg runtime_prefix "${runtime_prefix}" \
+      '.runtime_artifacts[] | select(.runtime_path | startswith($runtime_prefix)) | .runtime_path' \
+      "$(workcell_control_plane_manifest_path)"
+  )
+  if [[ "${matched}" -eq 0 ]]; then
+    workcell_die "Workcell control-plane manifest has no entries for prefix ${runtime_prefix}"
+  fi
 }
 
 workcell_ensure_manifest() {
@@ -699,7 +783,6 @@ workcell_render_claude_settings() {
   local target_path="${HOME}/.claude/settings.json"
   local api_key_source=""
   local helper_dir=""
-  local helper_secret=""
   local helper_script=""
 
   api_key_source="$(workcell_manifest_direct_mount_path '.credentials["claude_api_key"].mount_path // empty' || true)"
@@ -709,18 +792,14 @@ workcell_render_claude_settings() {
   fi
 
   helper_dir="${HOME}/.claude/workcell"
-  helper_secret="${helper_dir}/claude-api-key"
   helper_script="${helper_dir}/api-key-helper.sh"
 
   workcell_prepare_session_directory "${helper_dir}" "Claude helper directory"
   if [[ ! -f "${api_key_source}" ]]; then
     workcell_die "Workcell expected mounted credential file for claude_api_key: ${api_key_source}"
   fi
-  workcell_reset_session_target "${helper_secret}" "Claude helper secret"
-  cp "${api_key_source}" "${helper_secret}"
-  chmod 0600 "${helper_secret}"
   workcell_reset_session_target "${helper_script}" "Claude helper script"
-  printf '#!/bin/sh\nset -eu\ncat %s\n' "${helper_secret@Q}" >"${helper_script}"
+  printf '#!/bin/sh\nset -eu\ncat %s\n' "${api_key_source@Q}" >"${helper_script}"
   chmod 0700 "${helper_script}"
   workcell_reset_session_target "${target_path}" "Claude settings"
   jq --arg helper "${helper_script}" '.apiKeyHelper = $helper' "${baseline_path}" >"${target_path}"
@@ -959,6 +1038,7 @@ workcell_apply_manifest_ssh() {
 }
 
 seed_codex_home() {
+  workcell_verify_control_plane_prefix "${ADAPTER_ROOT}/codex/"
   workcell_prepare_session_directory "${CODEX_HOME}" "Codex home"
   workcell_prepare_session_directory "${CODEX_HOME}/mcp" "Codex MCP directory"
   workcell_render_provider_doc "${ADAPTER_ROOT}/codex/.codex/AGENTS.md" "${CODEX_HOME}/AGENTS.md" codex
@@ -973,6 +1053,8 @@ seed_codex_home() {
 }
 
 seed_claude_home() {
+  workcell_verify_control_plane_prefix "${ADAPTER_ROOT}/claude/"
+  workcell_verify_control_plane_path "/etc/claude-code/managed-settings.json"
   workcell_prepare_session_directory "${HOME}/.claude" "Claude home"
   workcell_render_claude_settings
   workcell_render_provider_doc "${ADAPTER_ROOT}/claude/CLAUDE.md" "${HOME}/.claude/CLAUDE.md" claude
@@ -987,6 +1069,7 @@ seed_gemini_home() {
   local workspace_root="${WORKSPACE:-/workspace}"
   local selected_auth_type=""
 
+  workcell_verify_control_plane_prefix "${ADAPTER_ROOT}/gemini/"
   workcell_prepare_session_directory "${HOME}/.gemini" "Gemini home"
   rm -f "${HOME}/.gemini/settings.json"
   cp "${ADAPTER_ROOT}/gemini/.gemini/settings.json" "${HOME}/.gemini/settings.json"

--- a/runtime/container/providers/package-lock.json
+++ b/runtime/container/providers/package-lock.json
@@ -2883,9 +2883,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6168,9 +6168,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/runtime/container/providers/package.json
+++ b/runtime/container/providers/package.json
@@ -9,6 +9,8 @@
     "@google/gemini-cli": "0.34.0"
   },
   "overrides": {
-    "@tootallnate/once": "3.0.1"
+    "@tootallnate/once": "3.0.1",
+    "brace-expansion": "5.0.5",
+    "picomatch": "4.0.4"
   }
 }

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -463,6 +463,10 @@ if "COPY runtime/container/rust /workcell-rust" not in runtime_dockerfile:
     raise SystemExit(
         "runtime/container/Dockerfile must vendor the reviewed Rust runtime sources into the builder stage"
     )
+if "COPY runtime/container/control-plane-manifest.json /usr/local/libexec/workcell/control-plane-manifest.json" not in runtime_dockerfile:
+    raise SystemExit(
+        "runtime/container/Dockerfile must copy the reviewed control-plane manifest into the runtime image"
+    )
 if "cargo build \\" not in runtime_dockerfile or "--locked \\" not in runtime_dockerfile or "--offline \\" not in runtime_dockerfile:
     raise SystemExit(
         "runtime/container/Dockerfile must build the shipped Rust launcher artifacts with cargo --locked --offline"
@@ -487,6 +491,10 @@ if "WORKCELL_BUILD_INPUT_ROOT: ${{ github.workspace }}/dist/release-source" not 
     raise SystemExit(
         ".github/workflows/release.yml must generate the signed build input manifest from the archived release source tree"
     )
+if "WORKCELL_CONTROL_PLANE_ROOT: ${{ github.workspace }}/dist/release-source" not in release_workflow:
+    raise SystemExit(
+        ".github/workflows/release.yml must generate the signed control-plane manifest from the archived release source tree"
+    )
 if "Verify published platform digests match preflight" not in release_workflow:
     raise SystemExit(
         ".github/workflows/release.yml must compare published per-platform image digests against the preflight manifest"
@@ -494,6 +502,10 @@ if "Verify published platform digests match preflight" not in release_workflow:
 if "Verify release bundle matches preflight" not in release_workflow:
     raise SystemExit(
         ".github/workflows/release.yml must compare the published source bundle against the preflight manifest"
+    )
+if "Verify control-plane manifest matches preflight" not in release_workflow:
+    raise SystemExit(
+        ".github/workflows/release.yml must compare the published control-plane manifest against the preflight manifest"
     )
 if "github/codeql-action/init@" not in release_workflow or "github/codeql-action/analyze@" not in release_workflow:
     raise SystemExit(
@@ -503,12 +515,21 @@ if "language: rust" not in (workflows_dir / "codeql.yml").read_text(encoding="ut
     raise SystemExit(".github/workflows/codeql.yml must analyze the shipped Rust boundary code")
 for required_release_asset in (
     'dist/${{ env.BUNDLE_NAME }}.sigstore.json',
+    'dist/workcell-control-plane.sigstore.json',
     'dist/workcell-source.spdx.sigstore.json',
     'dist/workcell-image.spdx.sigstore.json',
 ):
     if required_release_asset not in release_workflow:
         raise SystemExit(
             f".github/workflows/release.yml must publish direct signature bundles for release artifacts: missing {required_release_asset!r}"
+        )
+for required_release_manifest in (
+    "dist/workcell-control-plane-preflight.json",
+    "dist/workcell-control-plane.json",
+):
+    if required_release_manifest not in release_workflow:
+        raise SystemExit(
+            f".github/workflows/release.yml must keep the reviewed control-plane manifest flow: missing {required_release_manifest!r}"
         )
 if "steps.build.outputs.digest" in release_workflow:
     raise SystemExit(

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -617,6 +617,54 @@ run_container_with_injection_bundle() {
     "${IMAGE_TAG}" "${@:2}"
 }
 
+run_container_with_injection_bundle_stdin() {
+  local agent="$1"
+  local bundle_root="$2"
+  shift 2
+  local -a credential_mounts=()
+  local docker_workspace=""
+  local docker_bundle_root=""
+  local host_source=""
+  local mount_path=""
+
+  while IFS=$'\t' read -r host_source mount_path; do
+    [[ -n "${host_source}" ]] || continue
+    credential_mounts+=(-v "$(workcell_docker_host_path "${host_source}"):${mount_path}:ro")
+  done < <(direct_mount_specs_for_bundle "${bundle_root}")
+
+  docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
+  docker_bundle_root="$(workcell_docker_host_path "${bundle_root}")"
+  populate_workspace_import_mounts
+  populate_runtime_security_args ephemeral
+
+  docker_cmd run --rm -i \
+    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
+    --user 0:0 \
+    --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
+    --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
+    --tmpfs "/state:exec,nosuid,nodev,size=1g,mode=1777" \
+    -e AGENT_NAME="${agent}" \
+    -e AGENT_UI=cli \
+    -e WORKCELL_CONTAINER_MUTABILITY=ephemeral \
+    -e WORKCELL_HOST_UID="${HOST_UID}" \
+    -e WORKCELL_HOST_GID="${HOST_GID}" \
+    -e WORKCELL_HOST_USER="${HOST_USER}" \
+    -e CODEX_PROFILE=strict \
+    -e HOME=/state/agent-home \
+    -e CODEX_HOME=/state/agent-home/.codex \
+    -e TMPDIR=/state/tmp \
+    -e WORKCELL_RUNTIME=1 \
+    -e WORKSPACE=/workspace \
+    -e WORKCELL_INJECTION_MANIFEST=/opt/workcell/host-injections/manifest.json \
+    -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
+    -v "${docker_workspace}:/workspace" \
+    ${credential_mounts[@]+"${credential_mounts[@]}"} \
+    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
+    -v "${docker_bundle_root}:/opt/workcell/host-injections:ro" \
+    --entrypoint "$1" \
+    "${IMAGE_TAG}" "${@:2}"
+}
+
 if [[ "${1:-}" == "--self-docker-probe" ]]; then
   require_tool docker
   setup_workcell_trusted_docker_client
@@ -1003,79 +1051,85 @@ clone_bundle_with_credential_override \
 run_entrypoint codex codex --version >/dev/null
 run_entrypoint_with_profile codex build codex --version >/dev/null
 
-# shellcheck disable=SC2016
-run_container_with_injection_bundle codex "${INJECTION_BUNDLE_ROOT}/codex" bash -lc '
-  set -euo pipefail
-  CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
-  /usr/local/bin/workcell-entrypoint codex --version >/dev/null
-  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
-    set -euo pipefail
-    CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
-    grep -q "Common Smoke Instructions" "$CODEX_HOME/AGENTS.md"
-    grep -q "Codex Smoke Instructions" "$CODEX_HOME/AGENTS.md"
-    grep -q "\"test\": \"auth\"" "$CODEX_HOME/auth.json"
-    grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
-    grep -q "injected-public" /state/injected/public.txt
-    test "$(stat -c "%a" /state/injected/public.txt)" = "644"
-    grep -q "injected-secret" "$HOME/.config/workcell/token.txt"
-    test "$(stat -c "%a" "$HOME/.config/workcell/token.txt")" = "600"
-    grep -q "smoke.example" "$HOME/.ssh/config"
-    test "$(stat -c "%a" "$HOME/.ssh")" = "700"
-    test "$(stat -c "%a" "$HOME/.ssh/id_smoke")" = "600"
-    test -L "$CODEX_HOME/rules"
-    if printf "\n# session-marker\n" >>"$CODEX_HOME/rules/default.rules" 2>/tmp/workcell-codex-rules-write.err; then
-      echo "expected default Codex execpolicy rules to stay immutable on the managed path" >&2
-      exit 1
-    fi
-    if sudo -n id >/tmp/codex-sudo-id.out 2>&1; then
-      echo "expected unrestricted sudo to stay blocked for the runtime user" >&2
-      exit 1
-    fi
-    apt-get --help >/dev/null
-    sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get --help >/dev/null
-    codex --version >/dev/null
-    mkdir -p /workspace/exfil
-    rm -rf "$HOME/.config/workcell"
-    ln -s /workspace/exfil "$HOME/.config/workcell"
-    if codex --version >/tmp/codex-injected-copy-symlink.out 2>&1; then
-      echo "expected nested Codex launch to reject symlinked injected-copy parents" >&2
-      exit 1
-    fi
-    grep -q "symlinked session path component" /tmp/codex-injected-copy-symlink.out
-    test ! -e /workspace/exfil/token.txt
-  '"'"'
-'
+run_container_with_injection_bundle_stdin codex "${INJECTION_BUNDLE_ROOT}/codex" bash -s <<'SCRIPT'
+set -euo pipefail
+CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
+/usr/local/bin/workcell-entrypoint codex --version >/dev/null
+setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -s <<'INNER'
+set -euo pipefail
+CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
+grep -q "Common Smoke Instructions" "$CODEX_HOME/AGENTS.md"
+grep -q "Codex Smoke Instructions" "$CODEX_HOME/AGENTS.md"
+grep -q "\"test\": \"auth\"" "$CODEX_HOME/auth.json"
+grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
+grep -q "injected-public" /state/injected/public.txt
+test "$(stat -c "%a" /state/injected/public.txt)" = "644"
+grep -q "injected-secret" "$HOME/.config/workcell/token.txt"
+test "$(stat -c "%a" "$HOME/.config/workcell/token.txt")" = "600"
+grep -q "smoke.example" "$HOME/.ssh/config"
+test "$(stat -c "%a" "$HOME/.ssh")" = "700"
+test "$(stat -c "%a" "$HOME/.ssh/id_smoke")" = "600"
+test -L "$CODEX_HOME/rules"
+if (printf "\n# session-marker\n" >>"$CODEX_HOME/rules/default.rules") 2>/tmp/workcell-codex-rules-write.err; then
+  echo "expected default Codex execpolicy rules to stay immutable on the managed path" >&2
+  exit 1
+fi
+grep -Eq "Permission denied|Read-only file system" /tmp/workcell-codex-rules-write.err
+if sudo -n id >/tmp/codex-sudo-id.out 2>&1; then
+  echo "expected unrestricted sudo to stay blocked for the runtime user" >&2
+  exit 1
+fi
+apt-get --help >/dev/null
+sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get --help >/dev/null
+codex --version >/dev/null
+mkdir -p /workspace/exfil
+rm -rf "$HOME/.config/workcell"
+ln -s /workspace/exfil "$HOME/.config/workcell"
+if codex --version >/tmp/codex-injected-copy-symlink.out 2>&1; then
+  echo "expected nested Codex launch to reject symlinked injected-copy parents" >&2
+  exit 1
+fi
+grep -q "symlinked session path component" /tmp/codex-injected-copy-symlink.out
+test ! -e /workspace/exfil/token.txt
+INNER
+SCRIPT
 
-# shellcheck disable=SC2016
-run_container_with_injection_bundle claude "${INJECTION_BUNDLE_ROOT}/claude" bash -lc '
-  set -euo pipefail
-  /usr/local/bin/workcell-entrypoint claude --version >/dev/null
-    setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '"'"'
-      set -euo pipefail
-      grep -q "Common Smoke Instructions" "$HOME/.claude/CLAUDE.md"
-      grep -q "Claude Smoke Instructions" "$HOME/.claude/CLAUDE.md"
-      grep -q "Workspace AGENTS Instructions" "$HOME/.claude/CLAUDE.md"
-      grep -q "Workspace Claude Instructions" "$HOME/.claude/CLAUDE.md"
-      grep -q "\"apiKeyHelper\"" "$HOME/.claude/settings.json"
-    helper_path="$(jq -r ".apiKeyHelper" "$HOME/.claude/settings.json")"
-    test ! -L "$HOME/.claude/settings.json"
-    test -x "$helper_path"
-    test "$("$helper_path")" = "claude-smoke-key"
-    grep -q "\"token\": \"claude-auth\"" "$HOME/.config/claude-code/auth.json"
-    test ! -L "$HOME/.config/claude-code/auth.json"
-    test ! -L "$HOME/.mcp.json"
-    grep -q "\"stub\"" "$HOME/.mcp.json"
-    grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
-    rm -f "$HOME/.claude/settings.json" "$HOME/.config/claude-code/auth.json" "$HOME/.mcp.json"
-    claude --version >/dev/null
-    grep -q "\"apiKeyHelper\"" "$HOME/.claude/settings.json"
-    helper_path="$(jq -r ".apiKeyHelper" "$HOME/.claude/settings.json")"
-    test -x "$helper_path"
-    test "$("$helper_path")" = "claude-smoke-key"
-    grep -q "\"token\": \"claude-auth\"" "$HOME/.config/claude-code/auth.json"
-    grep -q "\"stub\"" "$HOME/.mcp.json"
-  '"'"'
-'
+run_container_with_injection_bundle_stdin claude "${INJECTION_BUNDLE_ROOT}/claude" bash -s <<'SCRIPT'
+set -euo pipefail
+/usr/local/bin/workcell-entrypoint claude --version >/dev/null
+setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -s <<'INNER'
+set -euo pipefail
+test -f /usr/local/libexec/workcell/control-plane-manifest.json
+jq -e '.runtime_artifacts[] | select(.runtime_path == "/usr/local/libexec/workcell/home-control-plane.sh")' \
+  /usr/local/libexec/workcell/control-plane-manifest.json >/dev/null
+grep -q "Common Smoke Instructions" "$HOME/.claude/CLAUDE.md"
+grep -q "Claude Smoke Instructions" "$HOME/.claude/CLAUDE.md"
+grep -q "Workspace AGENTS Instructions" "$HOME/.claude/CLAUDE.md"
+grep -q "Workspace Claude Instructions" "$HOME/.claude/CLAUDE.md"
+grep -q "\"apiKeyHelper\"" "$HOME/.claude/settings.json"
+helper_path="$(jq -r '.apiKeyHelper' "$HOME/.claude/settings.json")"
+test ! -L "$HOME/.claude/settings.json"
+test -x "$helper_path"
+grep -q "/opt/workcell/host-inputs/credentials/claude-api-key.txt" "$helper_path"
+test ! -e "$HOME/.claude/workcell/claude-api-key"
+test "$("$helper_path")" = "claude-smoke-key"
+grep -q "\"token\": \"claude-auth\"" "$HOME/.config/claude-code/auth.json"
+test ! -L "$HOME/.config/claude-code/auth.json"
+test ! -L "$HOME/.mcp.json"
+grep -q "\"stub\"" "$HOME/.mcp.json"
+grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
+rm -f "$HOME/.claude/settings.json" "$HOME/.config/claude-code/auth.json" "$HOME/.mcp.json"
+claude --version >/dev/null
+grep -q "\"apiKeyHelper\"" "$HOME/.claude/settings.json"
+helper_path="$(jq -r '.apiKeyHelper' "$HOME/.claude/settings.json")"
+test -x "$helper_path"
+grep -q "/opt/workcell/host-inputs/credentials/claude-api-key.txt" "$helper_path"
+test ! -e "$HOME/.claude/workcell/claude-api-key"
+test "$("$helper_path")" = "claude-smoke-key"
+grep -q "\"token\": \"claude-auth\"" "$HOME/.config/claude-code/auth.json"
+grep -q "\"stub\"" "$HOME/.mcp.json"
+INNER
+SCRIPT
 
 # shellcheck disable=SC2016
 run_container_with_injection_bundle gemini "${INJECTION_BUNDLE_ROOT}/gemini" bash -lc '
@@ -1739,6 +1793,74 @@ else
   cat /tmp/workcell-entrypoint-init-nested-run.out >&2
   exit 1
 fi
+
+# shellcheck disable=SC2016
+run_container codex bash -lc '
+  set -euo pipefail
+  test -f /usr/local/libexec/workcell/control-plane-manifest.json
+  jq -e ".schema_version == 2" /usr/local/libexec/workcell/control-plane-manifest.json >/dev/null
+  printf "\n# tampered during smoke\n" >>/opt/workcell/adapters/codex/.codex/config.toml
+  if /usr/local/bin/workcell-entrypoint codex --version >/tmp/workcell-control-plane-tamper.out 2>&1; then
+    echo "expected tampered Codex adapter baseline to fail control-plane verification" >&2
+    exit 1
+  fi
+  grep -q "Workcell control-plane manifest mismatch for /opt/workcell/adapters/codex/.codex/config.toml" /tmp/workcell-control-plane-tamper.out
+'
+
+# shellcheck disable=SC2016
+run_container claude bash -lc '
+  set -euo pipefail
+  if (printf "\n# tampered during smoke\n" >>/etc/claude-code/managed-settings.json) \
+      >/tmp/workcell-control-plane-claude-write.out 2>&1; then
+    if /usr/local/bin/workcell-entrypoint claude --version >/tmp/workcell-control-plane-claude-tamper.out 2>&1; then
+      echo "expected tampered Claude managed settings to fail control-plane verification" >&2
+      exit 1
+    fi
+    grep -q "Workcell control-plane manifest mismatch for /etc/claude-code/managed-settings.json" \
+      /tmp/workcell-control-plane-claude-tamper.out
+  else
+    grep -Eq "Permission denied|Read-only file system" /tmp/workcell-control-plane-claude-write.out
+  fi
+'
+
+# shellcheck disable=SC2016
+run_container claude bash -lc '
+  set -euo pipefail
+  rm -f /etc/claude-code/managed-settings.json
+  ln -s /opt/workcell/adapters/claude/managed-settings.json /etc/claude-code/managed-settings.json
+  if /usr/local/bin/workcell-entrypoint claude --version >/tmp/workcell-control-plane-claude-symlink.out 2>&1; then
+    echo "expected symlinked Claude managed settings to fail control-plane verification" >&2
+    exit 1
+  fi
+  grep -q "Workcell control-plane artifact must not be a symlink: /etc/claude-code/managed-settings.json" \
+    /tmp/workcell-control-plane-claude-symlink.out
+'
+
+# shellcheck disable=SC2016
+run_container codex bash -lc '
+  set -euo pipefail
+  mkdir -p /tmp/workcell-control-plane-codex-parent
+  cp /opt/workcell/adapters/codex/.codex/config.toml /tmp/workcell-control-plane-codex-parent/config.toml
+  rm -rf /opt/workcell/adapters/codex/.codex
+  ln -s /tmp/workcell-control-plane-codex-parent /opt/workcell/adapters/codex/.codex
+  if /usr/local/bin/workcell-entrypoint codex --version >/tmp/workcell-control-plane-codex-parent-symlink.out 2>&1; then
+    echo "expected symlinked Codex control-plane parent to fail verification" >&2
+    exit 1
+  fi
+  grep -q "Workcell control-plane artifact parent must not be a symlink: /opt/workcell/adapters/codex/.codex" \
+    /tmp/workcell-control-plane-codex-parent-symlink.out
+'
+
+# shellcheck disable=SC2016
+run_container gemini bash -lc '
+  set -euo pipefail
+  printf "\n# tampered during smoke\n" >>/opt/workcell/adapters/gemini/.gemini/settings.json
+  if /usr/local/bin/workcell-entrypoint gemini --version >/tmp/workcell-control-plane-gemini-tamper.out 2>&1; then
+    echo "expected tampered Gemini adapter baseline to fail control-plane verification" >&2
+    exit 1
+  fi
+  grep -q "Workcell control-plane manifest mismatch for /opt/workcell/adapters/gemini/.gemini/settings.json" /tmp/workcell-control-plane-gemini-tamper.out
+'
 
 # shellcheck disable=SC2016
 run_container codex bash -lc '

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1070,7 +1070,8 @@ grep -q "smoke.example" "$HOME/.ssh/config"
 test "$(stat -c "%a" "$HOME/.ssh")" = "700"
 test "$(stat -c "%a" "$HOME/.ssh/id_smoke")" = "600"
 test -L "$CODEX_HOME/rules"
-if (printf "\n# session-marker\n" >>"$CODEX_HOME/rules/default.rules") 2>/tmp/workcell-codex-rules-write.err; then
+if bash -c 'printf "\n# session-marker\n" >>"$1"' bash "$CODEX_HOME/rules/default.rules" \
+  2>/tmp/workcell-codex-rules-write.err; then
   echo "expected default Codex execpolicy rules to stay immutable on the managed path" >&2
   exit 1
 fi

--- a/scripts/generate-control-plane-manifest.sh
+++ b/scripts/generate-control-plane-manifest.sh
@@ -1,0 +1,123 @@
+#!/bin/bash -p
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
+  exec /usr/bin/env -i \
+    PATH="${TRUSTED_HOST_PATH}" \
+    HOME="${HOME:-/tmp}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    WORKCELL_CONTROL_PLANE_ROOT="${WORKCELL_CONTROL_PLANE_ROOT-}" \
+    WORKCELL_SANITIZED_ENTRYPOINT=1 \
+    /bin/bash -p "$0" "$@"
+fi
+set -euo pipefail
+export PATH="${TRUSTED_HOST_PATH}"
+
+if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
+  head -n 1 "$0" >/dev/null
+  echo "generate-control-plane-manifest-entrypoint-ok"
+  exit 0
+fi
+
+ROOT_DIR="${WORKCELL_CONTROL_PLANE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+OUTPUT_PATH="${1:-}"
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required tool: $1" >&2
+    exit 1
+  }
+}
+
+[[ -n "${OUTPUT_PATH}" ]] || {
+  echo "usage: $0 OUTPUT_PATH" >&2
+  exit 64
+}
+
+require_tool python3
+
+python3 - "${ROOT_DIR}" "${OUTPUT_PATH}" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+root_dir = pathlib.Path(sys.argv[1]).resolve()
+output_path = pathlib.Path(sys.argv[2])
+
+host_artifacts = [
+    "scripts/workcell",
+    "scripts/lib/render_injection_bundle.py",
+]
+
+runtime_artifacts = [
+    ("adapter-baseline", "adapters/claude/.claude/settings.json", "/opt/workcell/adapters/claude/.claude/settings.json"),
+    ("adapter-baseline", "adapters/claude/CLAUDE.md", "/opt/workcell/adapters/claude/CLAUDE.md"),
+    ("adapter-baseline", "adapters/claude/hooks/guard-bash.sh", "/opt/workcell/adapters/claude/hooks/guard-bash.sh"),
+    ("adapter-baseline", "adapters/claude/managed-settings.json", "/opt/workcell/adapters/claude/managed-settings.json"),
+    ("adapter-baseline", "adapters/claude/mcp-template.json", "/opt/workcell/adapters/claude/mcp-template.json"),
+    ("adapter-baseline", "adapters/codex/.codex/AGENTS.md", "/opt/workcell/adapters/codex/.codex/AGENTS.md"),
+    ("adapter-baseline", "adapters/codex/.codex/agents/anthropic_claude_compat.md", "/opt/workcell/adapters/codex/.codex/agents/anthropic_claude_compat.md"),
+    ("adapter-baseline", "adapters/codex/.codex/agents/apple_platform_boundary.md", "/opt/workcell/adapters/codex/.codex/agents/apple_platform_boundary.md"),
+    ("adapter-baseline", "adapters/codex/.codex/agents/distinguished_security.md", "/opt/workcell/adapters/codex/.codex/agents/distinguished_security.md"),
+    ("adapter-baseline", "adapters/codex/.codex/agents/openai_codex_platform.md", "/opt/workcell/adapters/codex/.codex/agents/openai_codex_platform.md"),
+    ("adapter-baseline", "adapters/codex/.codex/config.toml", "/opt/workcell/adapters/codex/.codex/config.toml"),
+    ("adapter-baseline", "adapters/codex/.codex/rules/default.rules", "/opt/workcell/adapters/codex/.codex/rules/default.rules"),
+    ("adapter-baseline", "adapters/codex/managed_config.toml", "/opt/workcell/adapters/codex/managed_config.toml"),
+    ("adapter-baseline", "adapters/codex/mcp/config.toml", "/opt/workcell/adapters/codex/mcp/config.toml"),
+    ("adapter-baseline", "adapters/codex/requirements.toml", "/opt/workcell/adapters/codex/requirements.toml"),
+    ("adapter-baseline", "adapters/gemini/.gemini/settings.json", "/opt/workcell/adapters/gemini/.gemini/settings.json"),
+    ("adapter-baseline", "adapters/gemini/GEMINI.md", "/opt/workcell/adapters/gemini/GEMINI.md"),
+    ("runtime-control-plane", "runtime/container/assurance.sh", "/usr/local/libexec/workcell/assurance.sh"),
+    ("runtime-control-plane", "runtime/container/bin/apt-helper.sh", "/usr/local/libexec/workcell/apt-helper.sh"),
+    ("runtime-control-plane", "runtime/container/bin/apt-wrapper.sh", "/usr/local/libexec/workcell/apt-wrapper.sh"),
+    ("runtime-control-plane", "runtime/container/entrypoint.sh", "/usr/local/libexec/workcell/entrypoint.sh"),
+    ("runtime-control-plane", "runtime/container/bin/git", "/usr/local/libexec/workcell/git-wrapper.sh"),
+    ("runtime-control-plane", "runtime/container/home-control-plane.sh", "/usr/local/libexec/workcell/home-control-plane.sh"),
+    ("runtime-control-plane", "runtime/container/bin/node", "/usr/local/libexec/workcell/node-wrapper.sh"),
+    ("runtime-control-plane", "runtime/container/provider-policy.sh", "/usr/local/libexec/workcell/provider-policy.sh"),
+    ("runtime-control-plane", "runtime/container/provider-wrapper.sh", "/usr/local/libexec/workcell/provider-wrapper.sh"),
+    ("runtime-control-plane", "runtime/container/public-node-guard.mjs", "/usr/local/libexec/workcell/public-node-guard.mjs"),
+    ("runtime-control-plane", "runtime/container/runtime-user.sh", "/usr/local/libexec/workcell/runtime-user.sh"),
+    ("runtime-control-plane", "adapters/claude/managed-settings.json", "/etc/claude-code/managed-settings.json"),
+]
+
+
+def digest(path: pathlib.Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+rendered_host = []
+for repo_path in host_artifacts:
+    source_path = root_dir / repo_path
+    if not source_path.is_file():
+        raise SystemExit(f"Missing control-plane artifact: {repo_path}")
+    rendered_host.append(
+        {
+            "repo_path": repo_path,
+            "sha256": digest(source_path),
+        }
+    )
+
+rendered_runtime = []
+for kind, repo_path, runtime_path in runtime_artifacts:
+    source_path = root_dir / repo_path
+    if not source_path.is_file():
+        raise SystemExit(f"Missing control-plane artifact: {repo_path}")
+    rendered_runtime.append(
+        {
+            "kind": kind,
+            "repo_path": repo_path,
+            "runtime_path": runtime_path,
+            "sha256": digest(source_path),
+        }
+    )
+
+manifest = {
+    "schema_version": 2,
+    "host_artifacts": rendered_host,
+    "runtime_artifacts": rendered_runtime,
+}
+
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY

--- a/scripts/generate-control-plane-manifest.sh
+++ b/scripts/generate-control-plane-manifest.sh
@@ -46,7 +46,9 @@ output_path = pathlib.Path(sys.argv[2])
 
 host_artifacts = [
     "scripts/workcell",
+    "scripts/lib/extract_direct_mounts.py",
     "scripts/lib/render_injection_bundle.py",
+    "scripts/lib/trusted-docker-client.sh",
 ]
 
 runtime_artifacts = [
@@ -82,33 +84,43 @@ runtime_artifacts = [
 ]
 
 
-def digest(path: pathlib.Path) -> str:
+def require_tracked_regular_file(path: pathlib.Path, repo_path: str) -> None:
+    relative_parts = path.relative_to(root_dir).parts
+    current = root_dir
+    for part in relative_parts:
+        current = current / part
+        if current.is_symlink():
+            raise SystemExit(f"Control-plane artifact must not be a symlink: {repo_path}")
+    if not path.exists():
+        raise SystemExit(f"Missing control-plane artifact: {repo_path}")
+    if not path.is_file():
+        raise SystemExit(f"Control-plane artifact must be a regular file: {repo_path}")
+
+
+def digest(path: pathlib.Path, repo_path: str) -> str:
+    require_tracked_regular_file(path, repo_path)
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 rendered_host = []
 for repo_path in host_artifacts:
     source_path = root_dir / repo_path
-    if not source_path.is_file():
-        raise SystemExit(f"Missing control-plane artifact: {repo_path}")
     rendered_host.append(
         {
             "repo_path": repo_path,
-            "sha256": digest(source_path),
+            "sha256": digest(source_path, repo_path),
         }
     )
 
 rendered_runtime = []
 for kind, repo_path, runtime_path in runtime_artifacts:
     source_path = root_dir / repo_path
-    if not source_path.is_file():
-        raise SystemExit(f"Missing control-plane artifact: {repo_path}")
     rendered_runtime.append(
         {
             "kind": kind,
             "repo_path": repo_path,
             "runtime_path": runtime_path,
-            "sha256": digest(source_path),
+            "sha256": digest(source_path, repo_path),
         }
     )
 

--- a/scripts/lib/render_injection_bundle.py
+++ b/scripts/lib/render_injection_bundle.py
@@ -111,6 +111,14 @@ GEMINI_SUPPORTED_ENV_KEYS = {
     *GEMINI_PROJECT_KEYS,
     *GEMINI_VERTEX_LOCATION_KEYS,
 }
+ALLOWED_ROOT_POLICY_KEYS = {
+    "version",
+    "includes",
+    "documents",
+    "ssh",
+    "copies",
+    "credentials",
+}
 
 
 def die(message: str) -> NoReturn:
@@ -266,16 +274,27 @@ def parse_simple_env_file(source: Path) -> dict[str, str]:
         if key in values:
             die(f"Gemini auth env file {source} configures {key} more than once.")
         value = strip_comment(value)
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        if value and value[0] in {"'", '"'}:
+            if len(value) < 2 or value[-1] != value[0]:
+                die(
+                    f"Malformed Gemini auth env file {source}: {key} has an unterminated quoted value."
+                )
             if value[0] == '"':
                 try:
                     parsed = ast.literal_eval(value)
-                except (SyntaxError, ValueError):
-                    parsed = value[1:-1]
+                except (SyntaxError, ValueError) as exc:
+                    die(
+                        f"Malformed Gemini auth env file {source}: {key} has an invalid double-quoted value "
+                        f"({exc})."
+                    )
                 value = parsed if isinstance(parsed, str) else str(parsed)
             else:
                 parsed = value[1:-1]
                 value = parsed if isinstance(parsed, str) else str(parsed)
+        elif value and value[-1] in {"'", '"'}:
+            die(
+                f"Malformed Gemini auth env file {source}: {key} has an unmatched trailing quote."
+            )
         values[key] = value
     return values
 
@@ -409,6 +428,15 @@ def validate_source_path(raw: object, label: str, base: Path) -> Path:
     return source
 
 
+def require_path_within(root: Path, candidate: Path, label: str) -> None:
+    resolved_root = root.resolve()
+    resolved_candidate = candidate.resolve()
+    try:
+        resolved_candidate.relative_to(resolved_root)
+    except ValueError:
+        die(f"{label} must stay within {resolved_root}: {resolved_candidate}")
+
+
 def require_no_symlink(path: Path, label: str) -> None:
     if path.is_symlink():
         die(f"{label} must not be a symlink: {path}")
@@ -502,17 +530,300 @@ def policy_sha256(policy_path: Path) -> str:
     return f"sha256:{hashlib.sha256(policy_path.read_bytes()).hexdigest()}"
 
 
-def load_policy(policy_path: Path) -> dict:
-    loaded = parse_toml_subset(policy_path.read_text(encoding="utf-8"), policy_path)
-    if not isinstance(loaded, dict):
-        die(f"injection policy must decode to a TOML table: {policy_path}")
-    validate_allowed_keys(
-        loaded, {"version", "documents", "ssh", "copies", "credentials"}, "root policy"
+def composite_policy_sha256(policy_sources: list[dict[str, str]]) -> str:
+    canonical = json.dumps(
+        policy_sources,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+def path_material_sha256(path: Path) -> str:
+    if path.is_symlink():
+        target = os.readlink(path)
+        return hashlib.sha256(f"symlink:{target}".encode("utf-8")).hexdigest()
+    if path.is_file():
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    if path.is_dir():
+        digest = hashlib.sha256()
+        digest.update(b"dir\n")
+        for child in sorted(path.rglob("*"), key=lambda entry: entry.relative_to(path).as_posix()):
+            relative = child.relative_to(path).as_posix()
+            if child.is_symlink():
+                digest.update(f"symlink:{relative}:{os.readlink(child)}\n".encode("utf-8"))
+            elif child.is_dir():
+                digest.update(f"dir:{relative}\n".encode("utf-8"))
+            elif child.is_file():
+                digest.update(f"file:{relative}\n".encode("utf-8"))
+                digest.update(child.read_bytes())
+                digest.update(b"\n")
+            else:
+                die(f"unsupported path type while hashing {path}: {child}")
+        return digest.hexdigest()
+    die(f"unsupported path type while hashing {path}")
+
+
+def effective_policy_sha256(
+    policy_sources: list[dict[str, str]],
+    output_root: Path,
+    rendered_documents: dict[str, str],
+    rendered_copies: list[dict[str, object]],
+    rendered_credentials: dict[str, dict[str, str]],
+    rendered_ssh: dict[str, object],
+) -> str:
+    documents = {
+        key: path_material_sha256(output_root / relative_path)
+        for key, relative_path in sorted(rendered_documents.items())
+    }
+    copies: list[dict[str, object]] = []
+    for entry in rendered_copies:
+        rendered_source = entry["source"]
+        if isinstance(rendered_source, str):
+            source_path = output_root / rendered_source
+        elif isinstance(rendered_source, dict) and isinstance(rendered_source.get("source"), str):
+            source_path = Path(rendered_source["source"])
+        else:
+            die(f"unsupported rendered copy source while hashing effective policy: {rendered_source!r}")
+        copies.append(
+            {
+                "classification": entry["classification"],
+                "dir_mode": entry["dir_mode"],
+                "file_mode": entry["file_mode"],
+                "kind": entry["kind"],
+                "sha256": path_material_sha256(source_path),
+                "target": entry["target"],
+            }
+        )
+    credentials = {
+        key: {
+            "mount_path": value["mount_path"],
+            "sha256": path_material_sha256(Path(value["source"])),
+        }
+        for key, value in sorted(rendered_credentials.items())
+    }
+    ssh: dict[str, object] = {}
+    if rendered_ssh:
+        ssh["config_assurance"] = rendered_ssh.get("config_assurance", "off")
+        config = rendered_ssh.get("config")
+        if isinstance(config, dict) and isinstance(config.get("source"), str):
+            ssh["config"] = {
+                "mount_path": config["mount_path"],
+                "sha256": path_material_sha256(Path(config["source"])),
+            }
+        known_hosts = rendered_ssh.get("known_hosts")
+        if isinstance(known_hosts, dict) and isinstance(known_hosts.get("source"), str):
+            ssh["known_hosts"] = {
+                "mount_path": known_hosts["mount_path"],
+                "sha256": path_material_sha256(Path(known_hosts["source"])),
+            }
+        identities = rendered_ssh.get("identities")
+        if isinstance(identities, list):
+            ssh["identities"] = [
+                {
+                    "mount_path": entry["mount_path"],
+                    "sha256": path_material_sha256(Path(entry["source"])),
+                    "target_name": entry["target_name"],
+                }
+                for entry in identities
+            ]
+    canonical = json.dumps(
+        {
+            "credentials": credentials,
+            "copies": copies,
+            "documents": documents,
+            "policy_sources": policy_sources,
+            "ssh": ssh,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+def logical_policy_path(policy_path: Path, entrypoint_root: Path) -> str:
+    relative_path = os.path.relpath(policy_path, entrypoint_root)
+    return relative_path.replace(os.sep, "/")
+
+
+def rebase_fragment_path(raw: object, fragment_dir: Path) -> object:
+    if not isinstance(raw, str) or not raw:
+        return raw
+    return str(expand_host_path(raw, fragment_dir))
+
+
+def rebase_policy_fragment(policy: dict[str, object], fragment_dir: Path) -> dict[str, object]:
+    rebased: dict[str, object] = {}
+    for key, value in policy.items():
+        if key == "documents" and isinstance(value, dict):
+            rebased[key] = {
+                document_key: rebase_fragment_path(document_value, fragment_dir)
+                for document_key, document_value in value.items()
+            }
+            continue
+        if key == "copies" and isinstance(value, list):
+            rebased_copies: list[object] = []
+            for entry in value:
+                if not isinstance(entry, dict):
+                    rebased_copies.append(entry)
+                    continue
+                rebased_entry = dict(entry)
+                if "source" in rebased_entry:
+                    rebased_entry["source"] = rebase_fragment_path(
+                        rebased_entry["source"], fragment_dir
+                    )
+                rebased_copies.append(rebased_entry)
+            rebased[key] = rebased_copies
+            continue
+        if key == "ssh" and isinstance(value, dict):
+            rebased_ssh = dict(value)
+            for ssh_key in ("config", "known_hosts"):
+                if ssh_key in rebased_ssh:
+                    rebased_ssh[ssh_key] = rebase_fragment_path(rebased_ssh[ssh_key], fragment_dir)
+            identities = rebased_ssh.get("identities")
+            if isinstance(identities, list):
+                rebased_ssh["identities"] = [
+                    rebase_fragment_path(identity, fragment_dir) for identity in identities
+                ]
+            rebased[key] = rebased_ssh
+            continue
+        if key == "credentials" and isinstance(value, dict):
+            rebased_credentials: dict[str, object] = {}
+            for credential_key, credential_value in value.items():
+                if isinstance(credential_value, dict):
+                    rebased_credential = dict(credential_value)
+                    if "source" in rebased_credential:
+                        rebased_credential["source"] = rebase_fragment_path(
+                            rebased_credential["source"], fragment_dir
+                        )
+                    rebased_credentials[credential_key] = rebased_credential
+                else:
+                    rebased_credentials[credential_key] = rebase_fragment_path(
+                        credential_value, fragment_dir
+                    )
+            rebased[key] = rebased_credentials
+            continue
+        rebased[key] = value
+    return rebased
+
+
+def validate_policy_include(raw: object, label: str, base: Path, entrypoint_root: Path) -> Path:
+    source = validate_source_path(raw, label, base)
+    if not source.is_file():
+        die(f"{label} must point at a file: {source}")
+    resolved_source = source.resolve()
+    require_path_within(entrypoint_root, resolved_source, label)
+    return resolved_source
+
+
+def merge_policy_fragment(base: dict[str, object], addition: dict[str, object], source_path: Path) -> None:
+    version = addition.get("version", 1)
+    if version != 1:
+        die(f"unsupported injection policy version: {version}")
+
+    for table_name in ("documents", "ssh", "credentials"):
+        table = addition.get(table_name)
+        if table is None:
+            continue
+        if not isinstance(table, dict):
+            die(f"injection policy fragment must keep {table_name} as a table: {source_path}")
+        destination = base.setdefault(table_name, {})
+        if not isinstance(destination, dict):
+            die(f"injection policy merge corrupted {table_name}: {source_path}")
+        for key, value in table.items():
+            if key in destination:
+                die(
+                    "injection policy fragments declare the same setting more than once: "
+                    f"{table_name}.{key} ({source_path})"
+                )
+            destination[key] = value
+
+    copies = addition.get("copies")
+    if copies is None:
+        return
+    if not isinstance(copies, list):
+        die(f"injection policy fragment must keep copies as an array of tables: {source_path}")
+    destination_copies = base.setdefault("copies", [])
+    if not isinstance(destination_copies, list):
+        die(f"injection policy merge corrupted copies: {source_path}")
+    destination_copies.extend(copies)
+
+
+def load_policy_bundle(
+    policy_path: Path,
+    *,
+    entrypoint_root: Path | None = None,
+    active_stack: tuple[Path, ...] | None = None,
+    loaded_paths: set[Path] | None = None,
+) -> tuple[dict, list[dict[str, str]]]:
+    resolved_policy_path = policy_path.expanduser().resolve()
+    entrypoint_root = (
+        entrypoint_root.resolve() if entrypoint_root is not None else resolved_policy_path.parent
     )
+    active_stack = active_stack or ()
+    loaded_paths = loaded_paths if loaded_paths is not None else set()
+
+    if resolved_policy_path in active_stack:
+        cycle = " -> ".join(str(path) for path in (*active_stack, resolved_policy_path))
+        die(f"injection policy include cycle detected: {cycle}")
+    if resolved_policy_path in loaded_paths:
+        die(f"injection policy includes the same file more than once: {resolved_policy_path}")
+    loaded_paths.add(resolved_policy_path)
+
+    loaded = parse_toml_subset(
+        resolved_policy_path.read_text(encoding="utf-8"),
+        resolved_policy_path,
+    )
+    if not isinstance(loaded, dict):
+        die(f"injection policy must decode to a TOML table: {resolved_policy_path}")
+    validate_allowed_keys(loaded, ALLOWED_ROOT_POLICY_KEYS, "root policy")
+
     version = loaded.get("version", 1)
     if version != 1:
         die(f"unsupported injection policy version: {version}")
-    return loaded
+
+    includes = loaded.get("includes", [])
+    if includes is None:
+        includes = []
+    if not isinstance(includes, list):
+        die("includes must be an array of strings when specified")
+
+    merged: dict[str, object] = {"version": 1}
+    policy_sources: list[dict[str, str]] = []
+    next_stack = (*active_stack, resolved_policy_path)
+    for index, include in enumerate(includes):
+        include_path = validate_policy_include(
+            include,
+            f"includes[{index}]",
+            resolved_policy_path.parent,
+            entrypoint_root,
+        )
+        included_policy, included_sources = load_policy_bundle(
+            include_path,
+            entrypoint_root=entrypoint_root,
+            active_stack=next_stack,
+            loaded_paths=loaded_paths,
+        )
+        merge_policy_fragment(merged, included_policy, include_path)
+        policy_sources.extend(included_sources)
+
+    current_policy = dict(loaded)
+    current_policy.pop("includes", None)
+    if active_stack:
+        current_policy = rebase_policy_fragment(current_policy, resolved_policy_path.parent)
+    merge_policy_fragment(merged, current_policy, resolved_policy_path)
+    policy_sources.append(
+        {
+            "path": logical_policy_path(resolved_policy_path, entrypoint_root),
+            "sha256": policy_sha256(resolved_policy_path),
+        }
+    )
+    return merged, policy_sources
+
+
+def load_policy(policy_path: Path) -> dict:
+    policy, _ = load_policy_bundle(policy_path)
+    return policy
 
 
 def strip_comment(line: str) -> str:
@@ -903,7 +1214,7 @@ def main() -> int:
     output_root.mkdir(parents=True, exist_ok=True)
     output_root.chmod(0o700)
 
-    policy = load_policy(policy_path)
+    policy, policy_sources = load_policy_bundle(policy_path)
     rendered_documents = render_documents(policy, output_root, policy_path.parent)
     rendered_copies = render_copies(
         policy, output_root, policy_path.parent, args.agent, args.mode
@@ -916,7 +1227,16 @@ def main() -> int:
     manifest = {
         "version": 1,
         "metadata": {
-            "policy_sha256": policy_sha256(policy_path),
+            "policy_entrypoint": logical_policy_path(policy_path.resolve(), policy_path.parent.resolve()),
+            "policy_sha256": effective_policy_sha256(
+                policy_sources,
+                output_root,
+                rendered_documents,
+                rendered_copies,
+                rendered_credentials,
+                rendered_ssh,
+            ),
+            "policy_sources": policy_sources,
             "credential_keys": sorted(rendered_credentials),
             "extra_endpoints": extra_endpoints,
             "secret_copy_targets": sorted(

--- a/scripts/pre-merge.sh
+++ b/scripts/pre-merge.sh
@@ -6,6 +6,7 @@ VALIDATOR_DOCKERFILE="${ROOT_DIR}/tools/validator/Dockerfile"
 VALIDATOR_IMAGE_DEFAULT_TAG="workcell-validator:local-premerge-$(cksum "${VALIDATOR_DOCKERFILE}" | awk '{print $1}')"
 VALIDATOR_IMAGE="${WORKCELL_VALIDATOR_IMAGE:-${VALIDATOR_IMAGE_DEFAULT_TAG}}"
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -C "${ROOT_DIR}" log -1 --pretty=%ct 2>/dev/null || printf '0')}"
+LOCAL_SNAPSHOT_ACTIVE="${WORKCELL_PREMERGE_LOCAL_SNAPSHOT_ACTIVE:-0}"
 REBUILD_VALIDATOR=0
 RUN_REMOTE=0
 RUN_REMOTE_HEAVY=0
@@ -18,6 +19,10 @@ REMOTE_SNAPSHOT="index"
 REMOTE_SNAPSHOT_EXPLICIT=0
 REMOTE_INCLUDE_UNTRACKED=0
 REMOTE_KEEP_DIR=0
+LOCAL_SNAPSHOT_MODE=""
+LOCAL_INCLUDE_UNTRACKED=0
+LOCAL_KEEP_DIR=0
+ORIGINAL_ARGS=("$@")
 
 usage() {
   cat <<EOF
@@ -28,6 +33,11 @@ linux/amd64 validation lane.
 
 Options:
   --allow-dirty             Run against the live worktree even when it is dirty
+  --local-snapshot <mode>   Run the local validation stack from a disposable
+                            snapshot: head, index, or worktree
+  --local-include-untracked Include untracked files with
+                            --local-snapshot worktree
+  --keep-local-dir          Preserve the local snapshot directory after exit
   --rebuild-validator        Rebuild the local validator image before validation
   --skip-release-bundle      Skip verify-release-bundle.sh
   --skip-repro               Skip verify-reproducible-build.sh
@@ -66,6 +76,37 @@ require_clean_tree() {
 has_untracked_files() {
   local status_output="${1:-}"
   grep -qE '^\?\?' <<<"${status_output}"
+}
+
+run_from_local_snapshot() {
+  local -a snapshot_cmd=()
+  local status=0
+
+  [[ -n "${LOCAL_SNAPSHOT_MODE}" ]] || return 0
+  [[ "${LOCAL_SNAPSHOT_ACTIVE}" == "1" ]] && return 0
+
+  echo "[pre-merge] local validation will run from snapshot (${LOCAL_SNAPSHOT_MODE})." >&2
+  snapshot_cmd=(
+    "${ROOT_DIR}/scripts/with-validation-snapshot.sh"
+    --repo "${ROOT_DIR}"
+    --mode "${LOCAL_SNAPSHOT_MODE}"
+  )
+  if [[ "${LOCAL_INCLUDE_UNTRACKED}" -eq 1 ]]; then
+    snapshot_cmd+=(--include-untracked)
+  fi
+  if [[ "${LOCAL_KEEP_DIR}" -eq 1 ]]; then
+    snapshot_cmd+=(--keep-snapshot)
+  fi
+  snapshot_cmd+=(
+    --
+    env
+    WORKCELL_PREMERGE_LOCAL_SNAPSHOT_ACTIVE=1
+    ./scripts/pre-merge.sh
+    "${ORIGINAL_ARGS[@]}"
+  )
+
+  "${snapshot_cmd[@]}" || status=$?
+  exit "${status}"
 }
 
 resolve_remote_snapshot_policy() {
@@ -128,6 +169,23 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --allow-dirty)
       ALLOW_DIRTY=1
+      shift
+      ;;
+    --local-snapshot)
+      LOCAL_SNAPSHOT_MODE="${2-}"
+      [[ -n "${LOCAL_SNAPSHOT_MODE}" ]] || {
+        echo "Option --local-snapshot requires a value." >&2
+        usage >&2
+        exit 2
+      }
+      shift 2
+      ;;
+    --local-include-untracked)
+      LOCAL_INCLUDE_UNTRACKED=1
+      shift
+      ;;
+    --keep-local-dir)
+      LOCAL_KEEP_DIR=1
       shift
       ;;
     --rebuild-validator)
@@ -202,8 +260,17 @@ done
 require_tool docker
 require_tool git
 
+if [[ "${LOCAL_INCLUDE_UNTRACKED}" -eq 1 ]] && [[ "${LOCAL_SNAPSHOT_MODE}" != "worktree" ]]; then
+  echo "--local-include-untracked requires --local-snapshot worktree." >&2
+  exit 2
+fi
+
+run_from_local_snapshot
+
 if [[ "${ALLOW_DIRTY}" -eq 0 ]]; then
-  require_clean_tree
+  if [[ -z "${LOCAL_SNAPSHOT_MODE}" ]]; then
+    require_clean_tree
+  fi
 fi
 
 resolve_remote_snapshot_policy

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -65,6 +65,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/container-smoke.sh"
   "${ROOT_DIR}/scripts/dev-quick-check.sh"
   "${ROOT_DIR}/scripts/dev-remote-validate.sh"
+  "${ROOT_DIR}/scripts/generate-control-plane-manifest.sh"
   "${ROOT_DIR}/scripts/generate-builder-environment-manifest.sh"
   "${ROOT_DIR}/scripts/generate-release-checksums.sh"
   "${ROOT_DIR}/scripts/generate-build-input-manifest.sh"
@@ -77,10 +78,12 @@ shell_files=(
   "${ROOT_DIR}/scripts/verify-github-hosted-controls.sh"
   "${ROOT_DIR}/scripts/validate-repo.sh"
   "${ROOT_DIR}/scripts/verify-build-input-manifest.sh"
+  "${ROOT_DIR}/scripts/verify-control-plane-manifest.sh"
   "${ROOT_DIR}/scripts/verify-release-bundle.sh"
   "${ROOT_DIR}/scripts/verify-invariants.sh"
   "${ROOT_DIR}/scripts/verify-reproducible-build.sh"
   "${ROOT_DIR}/scripts/verify-upstream-codex-release.sh"
+  "${ROOT_DIR}/scripts/with-validation-snapshot.sh"
   "${ROOT_DIR}/adapters/claude/hooks/guard-bash.sh"
   "${ROOT_DIR}/runtime/container/entrypoint.sh"
   "${ROOT_DIR}/runtime/container/bin/apt-helper.sh"
@@ -143,6 +146,7 @@ yamllint -d "{extends: default, rules: {comments: disable, document-start: disab
   "${ROOT_DIR}/.github/workflows"
 
 "${ROOT_DIR}/scripts/verify-build-input-manifest.sh"
+"${ROOT_DIR}/scripts/verify-control-plane-manifest.sh"
 
 doc_files=()
 while IFS= read -r -d '' file; do

--- a/scripts/verify-control-plane-manifest.sh
+++ b/scripts/verify-control-plane-manifest.sh
@@ -86,10 +86,15 @@ if not isinstance(runtime_artifacts, list) or not runtime_artifacts:
     raise SystemExit("control-plane manifest must include non-empty runtime_artifacts")
 
 seen_runtime_paths: set[str] = set()
+seen_host_paths: set[str] = set()
 for entry in host_artifacts:
     if sorted(entry.keys()) != ["repo_path", "sha256"]:
         raise SystemExit(f"unexpected host artifact shape: {entry!r}")
-    if len(entry["sha256"]) != 64:
+    repo_path = entry["repo_path"]
+    if not isinstance(repo_path, str) or repo_path in seen_host_paths:
+        raise SystemExit(f"duplicate or invalid host artifact path: {entry!r}")
+    seen_host_paths.add(repo_path)
+    if len(entry["sha256"]) != 64 or any(ch not in "0123456789abcdef" for ch in entry["sha256"]):
         raise SystemExit(f"invalid host artifact digest: {entry!r}")
 
 for entry in runtime_artifacts:
@@ -102,7 +107,7 @@ for entry in runtime_artifacts:
     if runtime_path in seen_runtime_paths:
         raise SystemExit(f"duplicate runtime artifact path: {runtime_path}")
     seen_runtime_paths.add(runtime_path)
-    if len(entry["sha256"]) != 64:
+    if len(entry["sha256"]) != 64 or any(ch not in "0123456789abcdef" for ch in entry["sha256"]):
         raise SystemExit(f"invalid runtime artifact digest: {entry!r}")
 PY
 
@@ -128,6 +133,21 @@ if git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   if [[ "${digest_archive_outside}" != "${digest_archive_nested}" ]]; then
     echo "Nested archived-source control-plane manifest diverged from standalone archived-source manifest: ${digest_archive_nested} != ${digest_archive_outside}" >&2
     diff -u "${TMP_ROOT}/archive-outside.json" "${TMP_ROOT}/archive-nested.json" || true
+    exit 1
+  fi
+
+  cp -R "${ARCHIVE_ROOT}" "${TMP_ROOT}/symlink-artifact"
+  ln -sf "${TMP_ROOT}/a.json" "${TMP_ROOT}/symlink-artifact/scripts/workcell"
+  SYMLINK_LOG="${TMP_ROOT}/symlink-out.log"
+  if WORKCELL_CONTROL_PLANE_ROOT="${TMP_ROOT}/symlink-artifact" \
+    "${ROOT_DIR}/scripts/generate-control-plane-manifest.sh" "${TMP_ROOT}/symlink-out.json" \
+    >"${SYMLINK_LOG}" 2>&1; then
+    echo "Expected control-plane manifest generation to reject symlinked tracked artifacts" >&2
+    exit 1
+  fi
+  if ! grep -q "must not be a symlink" "${SYMLINK_LOG}"; then
+    echo "Expected symlinked tracked artifacts to fail with an explicit manifest error" >&2
+    cat "${SYMLINK_LOG}" >&2
     exit 1
   fi
 fi

--- a/scripts/verify-control-plane-manifest.sh
+++ b/scripts/verify-control-plane-manifest.sh
@@ -1,0 +1,135 @@
+#!/bin/bash -p
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
+  exec /usr/bin/env -i \
+    PATH="${TRUSTED_HOST_PATH}" \
+    HOME="${HOME:-/tmp}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    WORKCELL_SANITIZED_ENTRYPOINT=1 \
+    /bin/bash -p "$0" "$@"
+fi
+set -euo pipefail
+export PATH="${TRUSTED_HOST_PATH}"
+
+if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
+  head -n 1 "$0" >/dev/null
+  echo "verify-control-plane-manifest-entrypoint-ok"
+  exit 0
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMMITTED_MANIFEST="${ROOT_DIR}/runtime/container/control-plane-manifest.json"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/workcell-control-plane.XXXXXX")"
+NESTED_ROOT=""
+
+cleanup() {
+  rm -rf "${TMP_ROOT}"
+  if [[ -n "${NESTED_ROOT}" ]]; then
+    rm -rf "${NESTED_ROOT}"
+  fi
+}
+
+trap cleanup EXIT
+
+copy_tracked_worktree() {
+  local destination="$1"
+  local path=""
+  local source_path=""
+  local destination_path=""
+
+  mkdir -p "${destination}"
+  while IFS= read -r -d '' path; do
+    source_path="${ROOT_DIR}/${path}"
+    destination_path="${destination}/${path}"
+    if [[ ! -e "${source_path}" ]]; then
+      echo "Tracked control-plane input is missing from the working tree during archived-source verification: ${path}" >&2
+      exit 1
+    fi
+    mkdir -p "$(dirname "${destination_path}")"
+    cp -pP "${source_path}" "${destination_path}"
+  done < <(git -C "${ROOT_DIR}" ls-files -z)
+}
+
+"${ROOT_DIR}/scripts/generate-control-plane-manifest.sh" "${TMP_ROOT}/a.json"
+"${ROOT_DIR}/scripts/generate-control-plane-manifest.sh" "${TMP_ROOT}/b.json"
+
+digest_a="$(shasum -a 256 "${TMP_ROOT}/a.json" | awk '{print $1}')"
+digest_b="$(shasum -a 256 "${TMP_ROOT}/b.json" | awk '{print $1}')"
+
+if [[ "${digest_a}" != "${digest_b}" ]]; then
+  echo "Non-deterministic control-plane manifest: ${digest_a} != ${digest_b}" >&2
+  diff -u "${TMP_ROOT}/a.json" "${TMP_ROOT}/b.json" || true
+  exit 1
+fi
+
+committed_digest="$(shasum -a 256 "${COMMITTED_MANIFEST}" | awk '{print $1}')"
+if [[ "${digest_a}" != "${committed_digest}" ]]; then
+  echo "Committed control-plane manifest diverged from the generated manifest: ${committed_digest} != ${digest_a}" >&2
+  diff -u "${COMMITTED_MANIFEST}" "${TMP_ROOT}/a.json" || true
+  exit 1
+fi
+
+python3 - "${TMP_ROOT}/a.json" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if manifest.get("schema_version") != 2:
+    raise SystemExit("control-plane manifest must use schema_version 2")
+
+host_artifacts = manifest.get("host_artifacts")
+runtime_artifacts = manifest.get("runtime_artifacts")
+if not isinstance(host_artifacts, list) or not host_artifacts:
+    raise SystemExit("control-plane manifest must include non-empty host_artifacts")
+if not isinstance(runtime_artifacts, list) or not runtime_artifacts:
+    raise SystemExit("control-plane manifest must include non-empty runtime_artifacts")
+
+seen_runtime_paths: set[str] = set()
+for entry in host_artifacts:
+    if sorted(entry.keys()) != ["repo_path", "sha256"]:
+        raise SystemExit(f"unexpected host artifact shape: {entry!r}")
+    if len(entry["sha256"]) != 64:
+        raise SystemExit(f"invalid host artifact digest: {entry!r}")
+
+for entry in runtime_artifacts:
+    for key in ("kind", "repo_path", "runtime_path", "sha256"):
+        if key not in entry:
+            raise SystemExit(f"runtime artifact is missing {key}: {entry!r}")
+    runtime_path = entry["runtime_path"]
+    if not isinstance(runtime_path, str) or not runtime_path.startswith("/"):
+        raise SystemExit(f"runtime artifact path must be absolute: {entry!r}")
+    if runtime_path in seen_runtime_paths:
+        raise SystemExit(f"duplicate runtime artifact path: {runtime_path}")
+    seen_runtime_paths.add(runtime_path)
+    if len(entry["sha256"]) != 64:
+        raise SystemExit(f"invalid runtime artifact digest: {entry!r}")
+PY
+
+if git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  mkdir -p "${ROOT_DIR}/tmp"
+  NESTED_ROOT="$(mktemp -d "${ROOT_DIR}/tmp/workcell-control-plane-nested.XXXXXX")"
+  ARCHIVE_ROOT="${TMP_ROOT}/archived-source"
+  copy_tracked_worktree "${ARCHIVE_ROOT}"
+  copy_tracked_worktree "${NESTED_ROOT}"
+
+  WORKCELL_CONTROL_PLANE_ROOT="${ARCHIVE_ROOT}" \
+    "${ROOT_DIR}/scripts/generate-control-plane-manifest.sh" "${TMP_ROOT}/archive-outside.json"
+  WORKCELL_CONTROL_PLANE_ROOT="${NESTED_ROOT}" \
+    "${ROOT_DIR}/scripts/generate-control-plane-manifest.sh" "${TMP_ROOT}/archive-nested.json"
+
+  digest_archive_outside="$(shasum -a 256 "${TMP_ROOT}/archive-outside.json" | awk '{print $1}')"
+  digest_archive_nested="$(shasum -a 256 "${TMP_ROOT}/archive-nested.json" | awk '{print $1}')"
+  if [[ "${digest_a}" != "${digest_archive_outside}" ]]; then
+    echo "Archived-source control-plane manifest diverged from the tracked working-tree manifest: ${digest_archive_outside} != ${digest_a}" >&2
+    diff -u "${TMP_ROOT}/a.json" "${TMP_ROOT}/archive-outside.json" || true
+    exit 1
+  fi
+  if [[ "${digest_archive_outside}" != "${digest_archive_nested}" ]]; then
+    echo "Nested archived-source control-plane manifest diverged from standalone archived-source manifest: ${digest_archive_nested} != ${digest_archive_outside}" >&2
+    diff -u "${TMP_ROOT}/archive-outside.json" "${TMP_ROOT}/archive-nested.json" || true
+    exit 1
+  fi
+fi
+
+echo "Workcell control-plane manifest verification passed."

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -45,6 +45,11 @@ assert_output_contains() {
   fi
 }
 
+free_bytes_for_path() {
+  local target_path="$1"
+  /bin/df -Pk "${target_path}" | awk 'NR==2 {print $4 * 1024}'
+}
+
 readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 export PATH="${TRUSTED_HOST_PATH}"
 
@@ -53,10 +58,12 @@ HOST_GATE_SCRIPTS=(
   "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
   "${ROOT_DIR}/scripts/container-smoke.sh"
   "${ROOT_DIR}/scripts/generate-build-input-manifest.sh"
+  "${ROOT_DIR}/scripts/generate-control-plane-manifest.sh"
   "${ROOT_DIR}/scripts/generate-builder-environment-manifest.sh"
   "${ROOT_DIR}/scripts/generate-release-checksums.sh"
   "${ROOT_DIR}/scripts/publish-github-release.sh"
   "${ROOT_DIR}/scripts/verify-build-input-manifest.sh"
+  "${ROOT_DIR}/scripts/verify-control-plane-manifest.sh"
   "${ROOT_DIR}/scripts/verify-release-bundle.sh"
   "${ROOT_DIR}/scripts/verify-reproducible-build.sh"
   "${ROOT_DIR}/scripts/verify-upstream-codex-release.sh"
@@ -1237,6 +1244,97 @@ if gemini_manifest["credentials"]["gemini_projects"]["mount_path"] != "/opt/work
     raise SystemExit("expected Gemini projects credential to use the managed credential mount path")
 PY
 
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/fragment-docs.toml"
+[documents]
+common = "common.md"
+EOF
+
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/fragment-credentials.toml"
+[credentials]
+codex_auth = "codex-auth.json"
+EOF
+
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/policy-with-includes.toml"
+version = 1
+includes = ["fragment-docs.toml", "fragment-credentials.toml"]
+
+[credentials.github_hosts]
+source = "gh-hosts.yml"
+providers = ["codex"]
+EOF
+
+python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
+  --policy "${INJECTION_POLICY_FIXTURE_ROOT}/policy-with-includes.toml" \
+  --agent codex \
+  --mode strict \
+  --output-root "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes" >/dev/null
+
+python3 - "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes/manifest.json" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+metadata = manifest["metadata"]
+
+if manifest["documents"]["common"] != "documents/common.md":
+    raise SystemExit("expected included policy fragment to contribute documents.common")
+if manifest["credentials"]["codex_auth"]["mount_path"] != "/opt/workcell/host-inputs/credentials/codex-auth.json":
+    raise SystemExit("expected included policy fragment to contribute credentials.codex_auth")
+if not metadata["policy_sha256"].startswith("sha256:"):
+    raise SystemExit("expected composite policy metadata to expose a sha256 digest")
+source_names = [pathlib.Path(entry["path"]).name for entry in metadata["policy_sources"]]
+if source_names != ["fragment-docs.toml", "fragment-credentials.toml", "policy-with-includes.toml"]:
+    raise SystemExit(f"unexpected included policy source order: {source_names!r}")
+if metadata["policy_entrypoint"] != "policy-with-includes.toml":
+    raise SystemExit(f"expected relative policy entrypoint, found {metadata['policy_entrypoint']!r}")
+for entry in metadata["policy_sources"]:
+    if entry["path"].startswith("/"):
+        raise SystemExit(f"policy source leaked an absolute host path: {entry['path']!r}")
+PY
+
+mkdir -p "${INJECTION_POLICY_FIXTURE_ROOT}/fragments"
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/fragments/common-fragment.md"
+fragment common
+EOF
+printf '{}\n' >"${INJECTION_POLICY_FIXTURE_ROOT}/fragments/fragment-auth.json"
+chmod 0600 "${INJECTION_POLICY_FIXTURE_ROOT}/fragments/fragment-auth.json"
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/fragments/fragment-relative.toml"
+[documents]
+common = "common-fragment.md"
+
+[credentials]
+codex_auth = "fragment-auth.json"
+EOF
+
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/policy-with-nested-includes.toml"
+version = 1
+includes = ["fragments/fragment-relative.toml"]
+EOF
+
+python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
+  --policy "${INJECTION_POLICY_FIXTURE_ROOT}/policy-with-nested-includes.toml" \
+  --agent codex \
+  --mode strict \
+  --output-root "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-nested-includes" >/dev/null
+
+python3 - "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-nested-includes/manifest.json" "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-nested-includes/documents/common.md" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+document = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+expected_auth = pathlib.Path(sys.argv[1]).parent.parent / "fragments" / "fragment-auth.json"
+
+if manifest["documents"]["common"] != "documents/common.md":
+    raise SystemExit("expected nested include fragment to contribute documents.common")
+if document != "fragment common\n":
+    raise SystemExit(f"expected nested include document content, found {document!r}")
+if manifest["credentials"]["codex_auth"]["source"] != str(expected_auth.resolve()):
+    raise SystemExit("expected nested include credential path to resolve relative to the fragment file")
+PY
+
 INJECTION_DRY_RUN_OUTPUT="$("${ROOT_DIR}/scripts/workcell" \
   --agent codex \
   --workspace "${ROOT_DIR}" \
@@ -1258,6 +1356,38 @@ if [[ "${INJECTION_DRY_RUN_OUTPUT}" != *'/opt/workcell/host-inputs/credentials/c
   echo "Expected workcell --dry-run to mount validated credential sources directly into the runtime" >&2
   exit 1
 fi
+
+"${ROOT_DIR}/scripts/verify-control-plane-manifest.sh"
+
+python3 - "${ROOT_DIR}/runtime/container/control-plane-manifest.json" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if manifest.get("schema_version") != 2:
+    raise SystemExit("expected control-plane manifest schema_version 2")
+runtime_artifacts = {entry["runtime_path"]: entry for entry in manifest.get("runtime_artifacts", [])}
+host_repo_paths = {entry["repo_path"] for entry in manifest.get("host_artifacts", [])}
+for required in (
+    "/opt/workcell/adapters/codex/.codex/config.toml",
+    "/opt/workcell/adapters/claude/.claude/settings.json",
+    "/opt/workcell/adapters/gemini/.gemini/settings.json",
+    "/usr/local/libexec/workcell/home-control-plane.sh",
+    "/usr/local/libexec/workcell/provider-wrapper.sh",
+    "/etc/claude-code/managed-settings.json",
+):
+    if required not in runtime_artifacts:
+        raise SystemExit(f"missing control-plane manifest runtime path: {required}")
+    if len(runtime_artifacts[required].get("sha256", "")) != 64:
+        raise SystemExit(f"expected sha256 for {required}")
+for required_repo_path in (
+    "scripts/workcell",
+    "scripts/lib/render_injection_bundle.py",
+):
+    if required_repo_path not in host_repo_paths:
+        raise SystemExit(f"missing host control-plane manifest repo path: {required_repo_path}")
+PY
 
 if [[ "${INJECTION_DRY_RUN_OUTPUT}" == *"${INJECTION_POLICY_FIXTURE_ROOT}/codex-auth.json"* ]]; then
   echo "Expected workcell --dry-run to redact host credential source paths" >&2
@@ -1406,6 +1536,288 @@ fi
 if ! grep -q 'unsupported TOML value' /tmp/workcell-injection-bad-value.out; then
   echo "Expected invalid-value rejection to explain the supported TOML subset" >&2
   cat /tmp/workcell-injection-bad-value.out >&2
+  exit 1
+fi
+
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/duplicate-fragment.toml"
+[credentials]
+codex_auth = "codex-auth.json"
+EOF
+
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/duplicate-fragment-root.toml"
+version = 1
+includes = ["duplicate-fragment.toml"]
+
+[credentials]
+codex_auth = "codex-auth.json"
+EOF
+
+if python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
+  --policy "${INJECTION_POLICY_FIXTURE_ROOT}/duplicate-fragment-root.toml" \
+  --agent codex \
+  --mode strict \
+  --output-root "${INJECTION_POLICY_FIXTURE_ROOT}/duplicate-fragment-bundle" >/tmp/workcell-injection-duplicate-fragment.out 2>&1; then
+  echo "Expected injection policy renderer to reject duplicate settings across fragments" >&2
+  exit 1
+fi
+
+if ! grep -q 'credentials.codex_auth' /tmp/workcell-injection-duplicate-fragment.out; then
+  echo "Expected duplicate-fragment rejection to name the duplicated setting" >&2
+  cat /tmp/workcell-injection-duplicate-fragment.out >&2
+  exit 1
+fi
+
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/cycle-a.toml"
+version = 1
+includes = ["cycle-b.toml"]
+EOF
+
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/cycle-b.toml"
+includes = ["cycle-a.toml"]
+EOF
+
+if python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
+  --policy "${INJECTION_POLICY_FIXTURE_ROOT}/cycle-a.toml" \
+  --agent codex \
+  --mode strict \
+  --output-root "${INJECTION_POLICY_FIXTURE_ROOT}/cycle-bundle" >/tmp/workcell-injection-cycle.out 2>&1; then
+  echo "Expected injection policy renderer to reject include cycles" >&2
+  exit 1
+fi
+
+if ! grep -q 'include cycle detected' /tmp/workcell-injection-cycle.out; then
+  echo "Expected include-cycle rejection to explain the cycle" >&2
+  cat /tmp/workcell-injection-cycle.out >&2
+  exit 1
+fi
+
+mkdir -p "${INJECTION_POLICY_FIXTURE_ROOT}/subdir"
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/outside.toml"
+[documents]
+common = "common.md"
+EOF
+
+cat <<'EOF' >"${INJECTION_POLICY_FIXTURE_ROOT}/subdir/escape-root.toml"
+version = 1
+includes = ["../outside.toml"]
+EOF
+
+if python3 "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
+  --policy "${INJECTION_POLICY_FIXTURE_ROOT}/subdir/escape-root.toml" \
+  --agent codex \
+  --mode strict \
+  --output-root "${INJECTION_POLICY_FIXTURE_ROOT}/escape-root-bundle" >/tmp/workcell-injection-escape-root.out 2>&1; then
+  echo "Expected injection policy renderer to reject includes that escape the entrypoint root" >&2
+  exit 1
+fi
+
+if ! grep -q 'must stay within' /tmp/workcell-injection-escape-root.out; then
+  echo "Expected escaped-include rejection to explain the entrypoint root boundary" >&2
+  cat /tmp/workcell-injection-escape-root.out >&2
+  exit 1
+fi
+
+VALIDATION_SNAPSHOT_FIXTURE_ROOT="$(mktemp -d)"
+git -C "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" init -q
+git -C "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" config user.email "verify@example.com"
+git -C "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" config user.name "Workcell Verify"
+printf 'head\n' >"${VALIDATION_SNAPSHOT_FIXTURE_ROOT}/tracked.txt"
+cat <<'EOF' >"${VALIDATION_SNAPSHOT_FIXTURE_ROOT}/snapshot-probe.sh"
+#!/bin/bash
+set -euo pipefail
+printf 'tracked=%s\n' "$(cat tracked.txt)"
+if [[ -e untracked.txt ]]; then
+  printf 'untracked=%s\n' "$(cat untracked.txt)"
+fi
+EOF
+chmod 0700 "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}/snapshot-probe.sh"
+git -C "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" add tracked.txt
+git -C "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" add snapshot-probe.sh
+git -C "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" commit -qm "initial"
+printf 'index\n' >"${VALIDATION_SNAPSHOT_FIXTURE_ROOT}/tracked.txt"
+git -C "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" add tracked.txt
+printf 'worktree\n' >"${VALIDATION_SNAPSHOT_FIXTURE_ROOT}/tracked.txt"
+printf 'untracked\n' >"${VALIDATION_SNAPSHOT_FIXTURE_ROOT}/untracked.txt"
+
+SNAPSHOT_HEAD_OUTPUT="$("${ROOT_DIR}/scripts/with-validation-snapshot.sh" \
+  --repo "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" \
+  --mode head \
+  -- ./snapshot-probe.sh)"
+if [[ "${SNAPSHOT_HEAD_OUTPUT}" != *'tracked=head'* ]]; then
+  echo "Expected head validation snapshot to preserve committed tracked content" >&2
+  printf '%s\n' "${SNAPSHOT_HEAD_OUTPUT}" >&2
+  exit 1
+fi
+if [[ "${SNAPSHOT_HEAD_OUTPUT}" == *'untracked='* ]]; then
+  echo "Expected head validation snapshot to exclude untracked files" >&2
+  printf '%s\n' "${SNAPSHOT_HEAD_OUTPUT}" >&2
+  exit 1
+fi
+
+SNAPSHOT_INDEX_OUTPUT="$("${ROOT_DIR}/scripts/with-validation-snapshot.sh" \
+  --repo "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" \
+  --mode index \
+  -- ./snapshot-probe.sh)"
+if [[ "${SNAPSHOT_INDEX_OUTPUT}" != *'tracked=index'* ]]; then
+  echo "Expected index validation snapshot to preserve staged tracked content" >&2
+  printf '%s\n' "${SNAPSHOT_INDEX_OUTPUT}" >&2
+  exit 1
+fi
+if [[ "${SNAPSHOT_INDEX_OUTPUT}" == *'untracked='* ]]; then
+  echo "Expected index validation snapshot to exclude untracked files" >&2
+  printf '%s\n' "${SNAPSHOT_INDEX_OUTPUT}" >&2
+  exit 1
+fi
+
+VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT="$(mktemp -d)"
+git -C "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}" init -q
+git -C "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}" config user.email "verify@example.com"
+git -C "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}" config user.name "Workcell Verify"
+cat <<'EOF' >"${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}/snapshot-kind-probe.sh"
+#!/bin/bash
+set -euo pipefail
+if [[ -d kind ]]; then
+  printf 'kind=dir\n'
+  printf 'payload=%s\n' "$(cat kind/payload.txt)"
+else
+  printf 'kind=file\n'
+  printf 'payload=%s\n' "$(cat kind)"
+fi
+EOF
+chmod 0700 "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}/snapshot-kind-probe.sh"
+printf 'file\n' >"${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}/kind"
+git -C "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}" add kind snapshot-kind-probe.sh
+git -C "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}" commit -qm "initial"
+rm -f "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}/kind"
+mkdir -p "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}/kind"
+printf 'staged-nested\n' >"${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}/kind/payload.txt"
+git -C "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}" add -A kind
+
+SNAPSHOT_INDEX_FILE_TO_DIR_OUTPUT="$("${ROOT_DIR}/scripts/with-validation-snapshot.sh" \
+  --repo "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}" \
+  --mode index \
+  -- ./snapshot-kind-probe.sh)"
+if [[ "${SNAPSHOT_INDEX_FILE_TO_DIR_OUTPUT}" != *'kind=dir'* ]] || [[ "${SNAPSHOT_INDEX_FILE_TO_DIR_OUTPUT}" != *'payload=staged-nested'* ]]; then
+  echo "Expected index validation snapshot to preserve staged tracked file-to-directory type changes" >&2
+  printf '%s\n' "${SNAPSHOT_INDEX_FILE_TO_DIR_OUTPUT}" >&2
+  exit 1
+fi
+
+VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT="$(mktemp -d)"
+git -C "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}" init -q
+git -C "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}" config user.email "verify@example.com"
+git -C "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}" config user.name "Workcell Verify"
+cat <<'EOF' >"${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}/snapshot-kind-probe.sh"
+#!/bin/bash
+set -euo pipefail
+if [[ -d kind ]]; then
+  printf 'kind=dir\n'
+  printf 'payload=%s\n' "$(cat kind/payload.txt)"
+else
+  printf 'kind=file\n'
+  printf 'payload=%s\n' "$(cat kind)"
+fi
+EOF
+chmod 0700 "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}/snapshot-kind-probe.sh"
+mkdir -p "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}/kind"
+printf 'nested\n' >"${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}/kind/payload.txt"
+git -C "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}" add kind/payload.txt snapshot-kind-probe.sh
+git -C "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}" commit -qm "initial"
+rm -rf "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}/kind"
+printf 'staged-flattened\n' >"${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}/kind"
+git -C "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}" add -A kind
+
+SNAPSHOT_INDEX_DIR_TO_FILE_OUTPUT="$("${ROOT_DIR}/scripts/with-validation-snapshot.sh" \
+  --repo "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}" \
+  --mode index \
+  -- ./snapshot-kind-probe.sh)"
+if [[ "${SNAPSHOT_INDEX_DIR_TO_FILE_OUTPUT}" != *'kind=file'* ]] || [[ "${SNAPSHOT_INDEX_DIR_TO_FILE_OUTPUT}" != *'payload=staged-flattened'* ]]; then
+  echo "Expected index validation snapshot to preserve staged tracked directory-to-file type changes" >&2
+  printf '%s\n' "${SNAPSHOT_INDEX_DIR_TO_FILE_OUTPUT}" >&2
+  exit 1
+fi
+
+SNAPSHOT_WORKTREE_OUTPUT="$("${ROOT_DIR}/scripts/with-validation-snapshot.sh" \
+  --repo "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" \
+  --mode worktree \
+  --include-untracked \
+  -- ./snapshot-probe.sh)"
+if [[ "${SNAPSHOT_WORKTREE_OUTPUT}" != *'tracked=worktree'* ]]; then
+  echo "Expected worktree validation snapshot to preserve live tracked content" >&2
+  printf '%s\n' "${SNAPSHOT_WORKTREE_OUTPUT}" >&2
+  exit 1
+fi
+if [[ "${SNAPSHOT_WORKTREE_OUTPUT}" != *'untracked=untracked'* ]]; then
+  echo "Expected worktree validation snapshot to include untracked files when requested" >&2
+  printf '%s\n' "${SNAPSHOT_WORKTREE_OUTPUT}" >&2
+  exit 1
+fi
+
+VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT="$(mktemp -d)"
+git -C "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}" init -q
+git -C "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}" config user.email "verify@example.com"
+git -C "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}" config user.name "Workcell Verify"
+cat <<'EOF' >"${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}/snapshot-kind-probe.sh"
+#!/bin/bash
+set -euo pipefail
+if [[ -d kind ]]; then
+  printf 'kind=dir\n'
+  printf 'payload=%s\n' "$(cat kind/payload.txt)"
+else
+  printf 'kind=file\n'
+  printf 'payload=%s\n' "$(cat kind)"
+fi
+EOF
+chmod 0700 "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}/snapshot-kind-probe.sh"
+printf 'file\n' >"${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}/kind"
+git -C "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}" add kind snapshot-kind-probe.sh
+git -C "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}" commit -qm "initial"
+rm -f "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}/kind"
+mkdir -p "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}/kind"
+printf 'nested\n' >"${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}/kind/payload.txt"
+
+SNAPSHOT_FILE_TO_DIR_OUTPUT="$("${ROOT_DIR}/scripts/with-validation-snapshot.sh" \
+  --repo "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}" \
+  --mode worktree \
+  --include-untracked \
+  -- ./snapshot-kind-probe.sh)"
+if [[ "${SNAPSHOT_FILE_TO_DIR_OUTPUT}" != *'kind=dir'* ]] || [[ "${SNAPSHOT_FILE_TO_DIR_OUTPUT}" != *'payload=nested'* ]]; then
+  echo "Expected worktree validation snapshot to preserve tracked file-to-directory type changes" >&2
+  printf '%s\n' "${SNAPSHOT_FILE_TO_DIR_OUTPUT}" >&2
+  exit 1
+fi
+
+VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT="$(mktemp -d)"
+git -C "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}" init -q
+git -C "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}" config user.email "verify@example.com"
+git -C "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}" config user.name "Workcell Verify"
+cat <<'EOF' >"${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}/snapshot-kind-probe.sh"
+#!/bin/bash
+set -euo pipefail
+if [[ -d kind ]]; then
+  printf 'kind=dir\n'
+  printf 'payload=%s\n' "$(cat kind/payload.txt)"
+else
+  printf 'kind=file\n'
+  printf 'payload=%s\n' "$(cat kind)"
+fi
+EOF
+chmod 0700 "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}/snapshot-kind-probe.sh"
+mkdir -p "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}/kind"
+printf 'nested\n' >"${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}/kind/payload.txt"
+git -C "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}" add kind/payload.txt snapshot-kind-probe.sh
+git -C "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}" commit -qm "initial"
+rm -rf "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}/kind"
+printf 'flattened\n' >"${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}/kind"
+
+SNAPSHOT_DIR_TO_FILE_OUTPUT="$("${ROOT_DIR}/scripts/with-validation-snapshot.sh" \
+  --repo "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}" \
+  --mode worktree \
+  --include-untracked \
+  -- ./snapshot-kind-probe.sh)"
+if [[ "${SNAPSHOT_DIR_TO_FILE_OUTPUT}" != *'kind=file'* ]] || [[ "${SNAPSHOT_DIR_TO_FILE_OUTPUT}" != *'payload=flattened'* ]]; then
+  echo "Expected worktree validation snapshot to preserve tracked directory-to-file type changes" >&2
+  printf '%s\n' "${SNAPSHOT_DIR_TO_FILE_OUTPUT}" >&2
   exit 1
 fi
 
@@ -3284,6 +3696,21 @@ PREMERGE_LOG="${PREMERGE_HARNESS_ROOT}/premerge.log"
 rm -rf "${PREMERGE_HARNESS_ROOT}"
 mkdir -p "${PREMERGE_HARNESS_ROOT}/scripts" "${PREMERGE_HARNESS_ROOT}/tools/validator" "${PREMERGE_FAKEBIN}"
 install -m 0755 "${ROOT_DIR}/scripts/pre-merge.sh" "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh"
+cat >"${PREMERGE_HARNESS_ROOT}/scripts/with-validation-snapshot.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'with-validation-snapshot.sh %s\n' "$*" >>"${PREMERGE_LOG}"
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--" ]]; then
+    shift
+    break
+  fi
+  shift
+done
+cd "${WORKCELL_FAKE_GIT_ROOT}"
+"$@"
+EOF
+chmod 0755 "${PREMERGE_HARNESS_ROOT}/scripts/with-validation-snapshot.sh"
 cat >"${PREMERGE_HARNESS_ROOT}/tools/validator/Dockerfile" <<'EOF'
 FROM scratch
 EOF
@@ -3307,6 +3734,7 @@ done
 cat >"${PREMERGE_FAKEBIN}/git" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+printf 'git %s\n' "$*" >>"${PREMERGE_LOG}"
 if [[ "${1-}" == "-C" ]]; then
   shift 2
 fi
@@ -3316,6 +3744,35 @@ case "${1-}" in
     ;;
   log)
     printf '%s\n' "${WORKCELL_FAKE_GIT_EPOCH:-1700000000}"
+    ;;
+  archive)
+    tar -C "${WORKCELL_FAKE_GIT_ROOT}" -cf - scripts tools
+    ;;
+  checkout-index)
+    prefix=""
+    for arg in "$@"; do
+      case "${arg}" in
+        --prefix=*)
+          prefix="${arg#--prefix=}"
+          ;;
+      esac
+    done
+    [[ -n "${prefix}" ]] || {
+      echo "missing checkout-index prefix" >&2
+      exit 1
+    }
+    mkdir -p "${prefix}"
+    cp -R "${WORKCELL_FAKE_GIT_ROOT}/scripts" "${prefix}/scripts"
+    mkdir -p "${prefix}/tools"
+    cp -R "${WORKCELL_FAKE_GIT_ROOT}/tools/validator" "${prefix}/tools/validator"
+    ;;
+  ls-files)
+    (
+      cd "${WORKCELL_FAKE_GIT_ROOT}"
+      find scripts tools -type f -print0 | LC_ALL=C sort -z
+    )
+    ;;
+  init|config|add|commit)
     ;;
   *)
     echo "unexpected git invocation: $*" >&2
@@ -3337,6 +3794,7 @@ chmod 0755 "${PREMERGE_FAKEBIN}/docker"
 
 if PATH="${PREMERGE_FAKEBIN}:${PATH}" \
   PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
   WORKCELL_FAKE_GIT_STATUS_OUTPUT='?? stray.txt' \
   "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" >/tmp/workcell-premerge-dirty.out 2>&1; then
   echo "Expected pre-merge to reject a dirty worktree by default" >&2
@@ -3344,9 +3802,35 @@ if PATH="${PREMERGE_FAKEBIN}:${PATH}" \
 fi
 grep -q 'clean worktree, including untracked files' /tmp/workcell-premerge-dirty.out
 
+if PATH="${PREMERGE_FAKEBIN}:${PATH}" \
+  PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
+  WORKCELL_FAKE_GIT_STATUS_OUTPUT='?? stray.txt' \
+  "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
+  --local-include-untracked >/tmp/workcell-premerge-local-include.out 2>&1; then
+  echo "Expected --local-include-untracked without --local-snapshot worktree to fail" >&2
+  exit 1
+fi
+grep -q -- '--local-include-untracked requires --local-snapshot worktree.' /tmp/workcell-premerge-local-include.out
+
 : >"${PREMERGE_LOG}"
 if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
   PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
+  WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
+  "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
+  --local-snapshot head >/tmp/workcell-premerge-local-snapshot.out 2>&1; then
+  echo "Expected --local-snapshot head pre-merge harness to succeed on a dirty worktree" >&2
+  cat /tmp/workcell-premerge-local-snapshot.out >&2
+  exit 1
+fi
+grep -q 'local validation will run from snapshot (head).' /tmp/workcell-premerge-local-snapshot.out
+grep -q 'check-pinned-inputs.sh ' "${PREMERGE_LOG}"
+
+: >"${PREMERGE_LOG}"
+if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
+  PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
   WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
   "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
   --allow-dirty \
@@ -3361,6 +3845,7 @@ grep -q 'dev-remote-validate.sh --snapshot worktree --include-untracked --check 
 : >"${PREMERGE_LOG}"
 if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
   PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
   WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
   "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
   --allow-dirty \
@@ -3376,6 +3861,7 @@ grep -q 'dev-remote-validate.sh --snapshot index --check validate' "${PREMERGE_L
 : >"${PREMERGE_LOG}"
 if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
   PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
   WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
   "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
   --allow-dirty \
@@ -3390,6 +3876,7 @@ grep -q 'local validation sees untracked files, but remote worktree validation w
 : >"${PREMERGE_LOG}"
 if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
   PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
   WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
   "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
   --allow-dirty \
@@ -3399,6 +3886,34 @@ if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
   exit 1
 fi
 grep -q 'dev-remote-validate.sh --snapshot worktree --include-untracked --check validate --allow-shared-daemon-heavy-checks --check smoke --check repro --check release-bundle' "${PREMERGE_LOG}"
+
+: >"${PREMERGE_LOG}"
+if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
+  PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
+  WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
+  "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
+  --local-snapshot worktree \
+  --local-include-untracked >/tmp/workcell-premerge-local-snapshot.out 2>&1; then
+  echo "Expected local snapshot pre-merge harness to succeed" >&2
+  cat /tmp/workcell-premerge-local-snapshot.out >&2
+  exit 1
+fi
+grep -q 'local validation will run from snapshot (worktree).' /tmp/workcell-premerge-local-snapshot.out
+grep -q 'with-validation-snapshot.sh --repo ' "${PREMERGE_LOG}"
+grep -q -- '--mode worktree --include-untracked -- env WORKCELL_PREMERGE_LOCAL_SNAPSHOT_ACTIVE=1 ./scripts/pre-merge.sh --local-snapshot worktree --local-include-untracked' "${PREMERGE_LOG}"
+grep -q 'check-pinned-inputs.sh ' "${PREMERGE_LOG}"
+
+if PATH="${PREMERGE_FAKEBIN}:${PATH}" \
+  PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
+  "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
+  --local-snapshot head \
+  --local-include-untracked >/tmp/workcell-premerge-local-snapshot-invalid.out 2>&1; then
+  echo "Expected --local-include-untracked without worktree snapshot to fail" >&2
+  exit 1
+fi
+grep -q -- '--local-include-untracked requires --local-snapshot worktree.' /tmp/workcell-premerge-local-snapshot-invalid.out
 
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent codex \
@@ -3773,84 +4288,87 @@ done
 if [[ "$(uname -s)" == "Darwin" ]] &&
   host_tool_exists /opt/homebrew/bin/colima /usr/local/bin/colima &&
   host_tool_exists /opt/homebrew/bin/docker /usr/local/bin/docker /Applications/Docker.app/Contents/Resources/bin/docker; then
-  LIVE_DEBUG_PROFILE_NAME="workcell-live-debug-$$"
-  LIVE_DEBUG_LOG="${BARRIER_VERIFY_ROOT}/debug/live-debug.log"
-  if ! "${ROOT_DIR}/scripts/workcell" \
-    --agent codex \
-    --prepare \
-    --rebuild \
-    --workspace "${ROOT_DIR}" \
-    --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
-    --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
-    --debug-log "${LIVE_DEBUG_LOG}" \
-    --agent-arg --version >/tmp/workcell-audit-prepare.out 2>&1; then
-    echo "Expected audit verification prepare run to seed a managed image" >&2
-    cat /tmp/workcell-audit-prepare.out >&2
+  if [[ "$(free_bytes_for_path "${ROOT_DIR}")" -lt $((5 * 1024 * 1024 * 1024)) ]]; then
+    echo "Cannot run live-debug audit verification on Darwin: host filesystem has less than 5 GiB free." >&2
     exit 1
-  fi
-  grep -q 'starting colima' "${LIVE_DEBUG_LOG}"
-  grep -q 'runtime-builder' "${LIVE_DEBUG_LOG}"
-  if ! "${ROOT_DIR}/scripts/workcell" \
-    --logs debug \
-    --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" >/tmp/workcell-live-logs-debug.out 2>&1; then
-    echo "Expected successful prepare run to persist the latest debug-log pointer" >&2
-    exit 1
-  fi
-  grep -q 'starting colima' /tmp/workcell-live-logs-debug.out
-  AUDIT_LOG="$(sed -n 's/.*audit_log=\([^ ]*\).*/\1/p' /tmp/workcell-audit-prepare.out | head -n1)"
-  if [[ -z "${AUDIT_LOG}" ]]; then
-    echo "Expected audit verification prepare run to report an audit log path" >&2
-    exit 1
-  fi
-  AUDIT_BASE_LINES=0
-  if [[ -f "${AUDIT_LOG}" ]]; then
-    AUDIT_BASE_LINES="$(wc -l <"${AUDIT_LOG}")"
-  fi
-  if ! "${ROOT_DIR}/scripts/workcell" \
-    --agent codex \
-    --mode build \
-    --workspace "${ROOT_DIR}" \
-    --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
-    --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
-    --allow-arbitrary-command \
-    --ack-arbitrary-command \
-    -- /bin/bash -lc 'sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get update >/dev/null && sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get install -y --no-install-recommends make >/dev/null'; then
-    echo "Expected package-mutation audit verification run to succeed" >&2
-    exit 1
-  fi
-  tail -n "+$((AUDIT_BASE_LINES + 1))" "${AUDIT_LOG}" >/tmp/workcell-audit-session.log
-  grep -q 'event=launch' /tmp/workcell-audit-session.log
-  grep -q 'record_digest=' /tmp/workcell-audit-session.log
-  grep -q 'execution_path=lower-assurance-debug-command' /tmp/workcell-audit-session.log
-  grep -q 'event=assurance-change' /tmp/workcell-audit-session.log
-  grep -q 'reason=package-mutation' /tmp/workcell-audit-session.log
-  grep -q 'session_assurance_final=lower-assurance-package-mutation' /tmp/workcell-audit-session.log
-  grep -q 'event=exit' /tmp/workcell-audit-session.log
-  grep -q 'package_mutation_downgraded=1' /tmp/workcell-audit-session.log
-  if ! "${ROOT_DIR}/scripts/workcell" \
-    --agent codex \
-    --mode build \
-    --workspace "${ROOT_DIR}" \
-    --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
-    --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
-    --allow-arbitrary-command \
-    --ack-arbitrary-command \
-    -- /bin/bash -lc 'test -f /opt/workcell/host-injections/manifest.json && grep -q "Workcell masks workspace control files inside the boundary." /workspace/AGENTS.md && test ! -d /workspace/AGENTS.md'; then
-    echo "Expected live launcher run to stage an injection manifest and mount /workspace/AGENTS.md as a file" >&2
-    exit 1
-  fi
-  if [[ -x /opt/homebrew/bin/colima ]]; then
-    /opt/homebrew/bin/colima delete --profile "${LIVE_DEBUG_PROFILE_NAME}" --force >/dev/null 2>&1 || true
   else
-    /usr/local/bin/colima delete --profile "${LIVE_DEBUG_PROFILE_NAME}" --force >/dev/null 2>&1 || true
-  fi
-  rm -rf "${REAL_HOME}/.colima/${LIVE_DEBUG_PROFILE_NAME}" "${REAL_HOME}/.colima/_lima/colima-${LIVE_DEBUG_PROFILE_NAME}"
-  AUDIT_RESTORE_PROFILE_NAME="workcell-audit-restore-$$"
-  AUDIT_RESTORE_DIR="${REAL_HOME}/.colima/${AUDIT_RESTORE_PROFILE_NAME}"
-  AUDIT_RESTORE_LOG="${AUDIT_RESTORE_DIR}/workcell.audit.log"
-  mkdir -p "${AUDIT_RESTORE_DIR}"
-  printf '%s\n' "${NONGIT_WORKSPACE}" >"${AUDIT_RESTORE_DIR}/workcell.managed"
-  cat >"${AUDIT_RESTORE_DIR}/colima.yaml" <<'EOF'
+    LIVE_DEBUG_PROFILE_NAME="workcell-live-debug-$$"
+    LIVE_DEBUG_LOG="${BARRIER_VERIFY_ROOT}/debug/live-debug.log"
+    if ! "${ROOT_DIR}/scripts/workcell" \
+      --agent codex \
+      --prepare-only \
+      --rebuild \
+      --workspace "${ROOT_DIR}" \
+      --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
+      --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
+      --debug-log "${LIVE_DEBUG_LOG}" >/tmp/workcell-audit-prepare.out 2>&1; then
+      echo "Expected audit verification prepare run to seed a managed image" >&2
+      cat /tmp/workcell-audit-prepare.out >&2
+      exit 1
+    fi
+    grep -q 'starting colima' "${LIVE_DEBUG_LOG}"
+    grep -q 'runtime-builder' "${LIVE_DEBUG_LOG}"
+    if ! "${ROOT_DIR}/scripts/workcell" \
+      --logs debug \
+      --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" >/tmp/workcell-live-logs-debug.out 2>&1; then
+      echo "Expected successful prepare run to persist the latest debug-log pointer" >&2
+      exit 1
+    fi
+    grep -q 'starting colima' /tmp/workcell-live-logs-debug.out
+    AUDIT_LOG="$(sed -n 's/.*audit_log=\([^ ]*\).*/\1/p' /tmp/workcell-audit-prepare.out | head -n1)"
+    if [[ -z "${AUDIT_LOG}" ]]; then
+      echo "Expected audit verification prepare run to report an audit log path" >&2
+      exit 1
+    fi
+    AUDIT_BASE_LINES=0
+    if [[ -f "${AUDIT_LOG}" ]]; then
+      AUDIT_BASE_LINES="$(wc -l <"${AUDIT_LOG}")"
+    fi
+    if ! "${ROOT_DIR}/scripts/workcell" \
+      --agent codex \
+      --mode build \
+      --workspace "${ROOT_DIR}" \
+      --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
+      --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
+      --allow-arbitrary-command \
+      --ack-arbitrary-command \
+      -- /bin/bash -lc 'sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get update >/dev/null && sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get install -y --no-install-recommends make >/dev/null'; then
+      echo "Expected package-mutation audit verification run to succeed" >&2
+      exit 1
+    fi
+    tail -n "+$((AUDIT_BASE_LINES + 1))" "${AUDIT_LOG}" >/tmp/workcell-audit-session.log
+    grep -q 'event=launch' /tmp/workcell-audit-session.log
+    grep -q 'record_digest=' /tmp/workcell-audit-session.log
+    grep -q 'execution_path=lower-assurance-debug-command' /tmp/workcell-audit-session.log
+    grep -q 'event=assurance-change' /tmp/workcell-audit-session.log
+    grep -q 'reason=package-mutation' /tmp/workcell-audit-session.log
+    grep -q 'session_assurance_final=lower-assurance-package-mutation' /tmp/workcell-audit-session.log
+    grep -q 'event=exit' /tmp/workcell-audit-session.log
+    grep -q 'package_mutation_downgraded=1' /tmp/workcell-audit-session.log
+    if ! "${ROOT_DIR}/scripts/workcell" \
+      --agent codex \
+      --mode build \
+      --workspace "${ROOT_DIR}" \
+      --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
+      --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
+      --allow-arbitrary-command \
+      --ack-arbitrary-command \
+      -- /bin/bash -lc 'test -f /opt/workcell/host-injections/manifest.json && grep -q "Workcell masks workspace control files inside the boundary." /workspace/AGENTS.md && test ! -d /workspace/AGENTS.md'; then
+      echo "Expected live launcher run to stage an injection manifest and mount /workspace/AGENTS.md as a file" >&2
+      exit 1
+    fi
+    if [[ -x /opt/homebrew/bin/colima ]]; then
+      /opt/homebrew/bin/colima delete --profile "${LIVE_DEBUG_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+    else
+      /usr/local/bin/colima delete --profile "${LIVE_DEBUG_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+    fi
+    rm -rf "${REAL_HOME}/.colima/${LIVE_DEBUG_PROFILE_NAME}" "${REAL_HOME}/.colima/_lima/colima-${LIVE_DEBUG_PROFILE_NAME}"
+    AUDIT_RESTORE_PROFILE_NAME="workcell-audit-restore-$$"
+    AUDIT_RESTORE_DIR="${REAL_HOME}/.colima/${AUDIT_RESTORE_PROFILE_NAME}"
+    AUDIT_RESTORE_LOG="${AUDIT_RESTORE_DIR}/workcell.audit.log"
+    mkdir -p "${AUDIT_RESTORE_DIR}"
+    printf '%s\n' "${NONGIT_WORKSPACE}" >"${AUDIT_RESTORE_DIR}/workcell.managed"
+    cat >"${AUDIT_RESTORE_DIR}/colima.yaml" <<'EOF'
 cpu: 4
 memory: 8
 disk: 60
@@ -3858,32 +4376,32 @@ runtime: docker
 vmType: vz
 mountType: virtiofs
 EOF
-  printf 'timestamp=test event=launch workspace=%q\n' "${NONGIT_WORKSPACE}" >"${AUDIT_RESTORE_LOG}"
-  if "${ROOT_DIR}/scripts/workcell" \
-    --test-fail-after-profile-refresh \
-    --agent codex \
-    --prepare \
-    --allow-nongit-workspace \
-    --workspace "${NONGIT_WORKSPACE}" \
-    --colima-profile "${AUDIT_RESTORE_PROFILE_NAME}" \
-    --agent-arg --version >/tmp/workcell-audit-restore.out 2>&1; then
-    echo "Expected managed-profile refresh test hook to fail after stashing the audit log" >&2
-    exit 1
-  fi
-  grep -q 'Workcell test hook: forcing failure after managed profile refresh.' /tmp/workcell-audit-restore.out
-  grep -q 'timestamp=test event=launch' "${AUDIT_RESTORE_LOG}"
-  if [[ -x /opt/homebrew/bin/colima ]]; then
-    /opt/homebrew/bin/colima delete --profile "${AUDIT_RESTORE_PROFILE_NAME}" --force >/dev/null 2>&1 || true
-  else
-    /usr/local/bin/colima delete --profile "${AUDIT_RESTORE_PROFILE_NAME}" --force >/dev/null 2>&1 || true
-  fi
-  rm -rf "${REAL_HOME}/.colima/${AUDIT_RESTORE_PROFILE_NAME}" "${REAL_HOME}/.colima/_lima/colima-${AUDIT_RESTORE_PROFILE_NAME}"
+    printf 'timestamp=test event=launch workspace=%q\n' "${NONGIT_WORKSPACE}" >"${AUDIT_RESTORE_LOG}"
+    if "${ROOT_DIR}/scripts/workcell" \
+      --test-fail-after-profile-refresh \
+      --agent codex \
+      --prepare \
+      --allow-nongit-workspace \
+      --workspace "${NONGIT_WORKSPACE}" \
+      --colima-profile "${AUDIT_RESTORE_PROFILE_NAME}" \
+      --agent-arg --version >/tmp/workcell-audit-restore.out 2>&1; then
+      echo "Expected managed-profile refresh test hook to fail after stashing the audit log" >&2
+      exit 1
+    fi
+    grep -q 'Workcell test hook: forcing failure after managed profile refresh.' /tmp/workcell-audit-restore.out
+    grep -q 'timestamp=test event=launch' "${AUDIT_RESTORE_LOG}"
+    if [[ -x /opt/homebrew/bin/colima ]]; then
+      /opt/homebrew/bin/colima delete --profile "${AUDIT_RESTORE_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+    else
+      /usr/local/bin/colima delete --profile "${AUDIT_RESTORE_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+    fi
+    rm -rf "${REAL_HOME}/.colima/${AUDIT_RESTORE_PROFILE_NAME}" "${REAL_HOME}/.colima/_lima/colima-${AUDIT_RESTORE_PROFILE_NAME}"
 
-  STRICT_REFRESH_PROFILE_NAME="workcell-strict-refresh-$$"
-  STRICT_REFRESH_DIR="${REAL_HOME}/.colima/${STRICT_REFRESH_PROFILE_NAME}"
-  mkdir -p "${STRICT_REFRESH_DIR}"
-  printf '%s\n' "${NONGIT_WORKSPACE}" >"${STRICT_REFRESH_DIR}/workcell.managed"
-  cat >"${STRICT_REFRESH_DIR}/colima.yaml" <<'EOF'
+    STRICT_REFRESH_PROFILE_NAME="workcell-strict-refresh-$$"
+    STRICT_REFRESH_DIR="${REAL_HOME}/.colima/${STRICT_REFRESH_PROFILE_NAME}"
+    mkdir -p "${STRICT_REFRESH_DIR}"
+    printf '%s\n' "${NONGIT_WORKSPACE}" >"${STRICT_REFRESH_DIR}/workcell.managed"
+    cat >"${STRICT_REFRESH_DIR}/colima.yaml" <<'EOF'
 cpu: 4
 memory: 7
 disk: 60
@@ -3891,64 +4409,65 @@ runtime: docker
 vmType: vz
 mountType: virtiofs
 EOF
-  printf 'image_id=stale-image\n' >"${STRICT_REFRESH_DIR}/workcell.image-ready"
-  printf 'timestamp=test event=launch workspace=%q\n' "${NONGIT_WORKSPACE}" >"${STRICT_REFRESH_DIR}/workcell.audit.log"
-  VERIFY_INVARIANTS_EXPECTED_FAILURE=1
-  set +e
-  "${ROOT_DIR}/scripts/workcell" \
-    --test-fail-after-profile-refresh \
-    --agent codex \
-    --allow-nongit-workspace \
-    --workspace "${NONGIT_WORKSPACE}" \
-    --colima-profile "${STRICT_REFRESH_PROFILE_NAME}" \
-    --agent-arg --version >/tmp/workcell-strict-refresh-preflight.out 2>&1
-  strict_refresh_status=$?
-  set -e
-  VERIFY_INVARIANTS_EXPECTED_FAILURE=0
-  if [[ "${strict_refresh_status}" -ne 2 ]]; then
-    echo "Expected strict-mode refresh preflight to fail with exit 2 before the test hook, got ${strict_refresh_status}" >&2
-    cat /tmp/workcell-strict-refresh-preflight.out >&2
-    exit 1
+    printf 'image_id=stale-image\n' >"${STRICT_REFRESH_DIR}/workcell.image-ready"
+    printf 'timestamp=test event=launch workspace=%q\n' "${NONGIT_WORKSPACE}" >"${STRICT_REFRESH_DIR}/workcell.audit.log"
+    VERIFY_INVARIANTS_EXPECTED_FAILURE=1
+    set +e
+    "${ROOT_DIR}/scripts/workcell" \
+      --test-fail-after-profile-refresh \
+      --agent codex \
+      --allow-nongit-workspace \
+      --workspace "${NONGIT_WORKSPACE}" \
+      --colima-profile "${STRICT_REFRESH_PROFILE_NAME}" \
+      --agent-arg --version >/tmp/workcell-strict-refresh-preflight.out 2>&1
+    strict_refresh_status=$?
+    set -e
+    VERIFY_INVARIANTS_EXPECTED_FAILURE=0
+    if [[ "${strict_refresh_status}" -ne 2 ]]; then
+      echo "Expected strict-mode refresh preflight to fail with exit 2 before the test hook, got ${strict_refresh_status}" >&2
+      cat /tmp/workcell-strict-refresh-preflight.out >&2
+      exit 1
+    fi
+    grep -q "Refreshing managed Colima profile ${STRICT_REFRESH_PROFILE_NAME} to apply the requested reviewed VM resources." /tmp/workcell-strict-refresh-preflight.out
+    grep -q "No prepared runtime image is recorded for strict mode on profile ${STRICT_REFRESH_PROFILE_NAME}." /tmp/workcell-strict-refresh-preflight.out
+    grep -q "No VM or container was started." /tmp/workcell-strict-refresh-preflight.out
+    assert_output_did_not_start_colima \
+      /tmp/workcell-strict-refresh-preflight.out \
+      "Strict-mode refresh preflight should fail before Colima startup when the prepared image marker is absent"
+    if grep -q 'Workcell test hook: forcing failure after managed profile refresh.' /tmp/workcell-strict-refresh-preflight.out; then
+      echo "Strict-mode refresh preflight should fail before the post-refresh test hook runs" >&2
+      exit 1
+    fi
+    VERIFY_INVARIANTS_EXPECTED_FAILURE=1
+    set +e
+    "${ROOT_DIR}/scripts/workcell" \
+      --test-fail-after-profile-refresh \
+      --agent codex \
+      --prepare \
+      --allow-nongit-workspace \
+      --workspace "${NONGIT_WORKSPACE}" \
+      --colima-profile "${STRICT_REFRESH_PROFILE_NAME}" \
+      --agent-arg --version >/tmp/workcell-strict-refresh-prepare.out 2>&1
+    strict_refresh_prepare_status=$?
+    set -e
+    VERIFY_INVARIANTS_EXPECTED_FAILURE=0
+    if [[ "${strict_refresh_prepare_status}" -ne 88 ]]; then
+      echo "Expected follow-up strict prepare to reach the post-refresh hook instead of tripping unmanaged-profile preflight, got ${strict_refresh_prepare_status}" >&2
+      cat /tmp/workcell-strict-refresh-prepare.out >&2
+      exit 1
+    fi
+    grep -q 'Workcell test hook: forcing failure after managed profile refresh.' /tmp/workcell-strict-refresh-prepare.out
+    if grep -q 'Refusing to reuse unmanaged Colima profile' /tmp/workcell-strict-refresh-prepare.out; then
+      echo "Strict-mode refresh preflight should leave the profile recoverable by --prepare" >&2
+      exit 1
+    fi
+    if [[ -x /opt/homebrew/bin/colima ]]; then
+      /opt/homebrew/bin/colima delete --profile "${STRICT_REFRESH_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+    else
+      /usr/local/bin/colima delete --profile "${STRICT_REFRESH_PROFILE_NAME}" --force >/dev/null 2>&1 || true
+    fi
+    rm -rf "${REAL_HOME}/.colima/${STRICT_REFRESH_PROFILE_NAME}" "${REAL_HOME}/.colima/_lima/colima-${STRICT_REFRESH_PROFILE_NAME}"
   fi
-  grep -q "Refreshing managed Colima profile ${STRICT_REFRESH_PROFILE_NAME} to apply the requested reviewed VM resources." /tmp/workcell-strict-refresh-preflight.out
-  grep -q "No prepared runtime image is recorded for strict mode on profile ${STRICT_REFRESH_PROFILE_NAME}." /tmp/workcell-strict-refresh-preflight.out
-  grep -q "No VM or container was started." /tmp/workcell-strict-refresh-preflight.out
-  assert_output_did_not_start_colima \
-    /tmp/workcell-strict-refresh-preflight.out \
-    "Strict-mode refresh preflight should fail before Colima startup when the prepared image marker is absent"
-  if grep -q 'Workcell test hook: forcing failure after managed profile refresh.' /tmp/workcell-strict-refresh-preflight.out; then
-    echo "Strict-mode refresh preflight should fail before the post-refresh test hook runs" >&2
-    exit 1
-  fi
-  VERIFY_INVARIANTS_EXPECTED_FAILURE=1
-  set +e
-  "${ROOT_DIR}/scripts/workcell" \
-    --test-fail-after-profile-refresh \
-    --agent codex \
-    --prepare \
-    --allow-nongit-workspace \
-    --workspace "${NONGIT_WORKSPACE}" \
-    --colima-profile "${STRICT_REFRESH_PROFILE_NAME}" \
-    --agent-arg --version >/tmp/workcell-strict-refresh-prepare.out 2>&1
-  strict_refresh_prepare_status=$?
-  set -e
-  VERIFY_INVARIANTS_EXPECTED_FAILURE=0
-  if [[ "${strict_refresh_prepare_status}" -ne 88 ]]; then
-    echo "Expected follow-up strict prepare to reach the post-refresh hook instead of tripping unmanaged-profile preflight, got ${strict_refresh_prepare_status}" >&2
-    cat /tmp/workcell-strict-refresh-prepare.out >&2
-    exit 1
-  fi
-  grep -q 'Workcell test hook: forcing failure after managed profile refresh.' /tmp/workcell-strict-refresh-prepare.out
-  if grep -q 'Refusing to reuse unmanaged Colima profile' /tmp/workcell-strict-refresh-prepare.out; then
-    echo "Strict-mode refresh preflight should leave the profile recoverable by --prepare" >&2
-    exit 1
-  fi
-  if [[ -x /opt/homebrew/bin/colima ]]; then
-    /opt/homebrew/bin/colima delete --profile "${STRICT_REFRESH_PROFILE_NAME}" --force >/dev/null 2>&1 || true
-  else
-    /usr/local/bin/colima delete --profile "${STRICT_REFRESH_PROFILE_NAME}" --force >/dev/null 2>&1 || true
-  fi
-  rm -rf "${REAL_HOME}/.colima/${STRICT_REFRESH_PROFILE_NAME}" "${REAL_HOME}/.colima/_lima/colima-${STRICT_REFRESH_PROFILE_NAME}"
 fi
 
 UNMANAGED_PROFILE_NAME="workcell-unmanaged-verify-$$"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1382,6 +1382,8 @@ for required in (
     if len(runtime_artifacts[required].get("sha256", "")) != 64:
         raise SystemExit(f"expected sha256 for {required}")
 for required_repo_path in (
+    "scripts/lib/extract_direct_mounts.py",
+    "scripts/lib/trusted-docker-client.sh",
     "scripts/workcell",
     "scripts/lib/render_injection_bundle.py",
 ):

--- a/scripts/verify-reproducible-build.sh
+++ b/scripts/verify-reproducible-build.sh
@@ -11,6 +11,7 @@ if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
     WORKCELL_REMOTE_BUILDKIT_SSL_CERTS="${WORKCELL_REMOTE_BUILDKIT_SSL_CERTS-}" \
     WORKCELL_DOCKER_HOST_HOME_ROOT="${WORKCELL_DOCKER_HOST_HOME_ROOT-}" \
     WORKCELL_DOCKER_HOST_WORKSPACE_ROOT="${WORKCELL_DOCKER_HOST_WORKSPACE_ROOT-}" \
+    WORKCELL_REPRO_BUILD_MODE="${WORKCELL_REPRO_BUILD_MODE-}" \
     WORKCELL_REPRO_DOCKER_CONTEXT="${WORKCELL_REPRO_DOCKER_CONTEXT-}" \
     WORKCELL_REPRO_MANIFEST_PATH="${WORKCELL_REPRO_MANIFEST_PATH-}" \
     WORKCELL_REPRO_PLATFORMS="${WORKCELL_REPRO_PLATFORMS-}" \
@@ -24,6 +25,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
 DOCKER_CONTEXT_NAME="${WORKCELL_REPRO_DOCKER_CONTEXT:-}"
 REPRO_PLATFORMS="${WORKCELL_REPRO_PLATFORMS:-linux/amd64,linux/arm64}"
+REPRO_BUILD_MODE="${WORKCELL_REPRO_BUILD_MODE:-serial}"
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -C "${ROOT_DIR}" log -1 --pretty=%ct 2>/dev/null || printf '0')}"
 REPRO_MANIFEST_PATH="${WORKCELL_REPRO_MANIFEST_PATH:-}"
 OCI_EXPORT_ROOT=""
@@ -84,6 +86,35 @@ build_oci_layout() {
     --output "type=oci,dest=${dest},tar=false,oci-mediatypes=true,rewrite-timestamp=true" \
     -f "${ROOT_DIR}/runtime/container/Dockerfile" \
     "${ROOT_DIR}" >/dev/null
+}
+
+build_oci_layout_pair() {
+  local platforms="$1"
+  local dest_a="$2"
+  local dest_b="$3"
+  local pid_a=""
+  local pid_b=""
+  local status=0
+
+  case "${REPRO_BUILD_MODE}" in
+    parallel)
+      build_oci_layout "${platforms}" "${dest_a}" &
+      pid_a=$!
+      build_oci_layout "${platforms}" "${dest_b}" &
+      pid_b=$!
+      wait "${pid_a}" || status=1
+      wait "${pid_b}" || status=1
+      return "${status}"
+      ;;
+    serial)
+      build_oci_layout "${platforms}" "${dest_a}"
+      build_oci_layout "${platforms}" "${dest_b}"
+      ;;
+    *)
+      echo "Unsupported WORKCELL_REPRO_BUILD_MODE: ${REPRO_BUILD_MODE}" >&2
+      exit 2
+      ;;
+  esac
 }
 
 oci_subject_digest() {
@@ -241,8 +272,7 @@ IFS=',' read -r -a platform_list <<<"${REPRO_PLATFORMS}"
 
 OCI_EXPORT_A="${OCI_EXPORT_ROOT}/a"
 OCI_EXPORT_B="${OCI_EXPORT_ROOT}/b"
-build_oci_layout "${REPRO_PLATFORMS}" "${OCI_EXPORT_A}"
-build_oci_layout "${REPRO_PLATFORMS}" "${OCI_EXPORT_B}"
+build_oci_layout_pair "${REPRO_PLATFORMS}" "${OCI_EXPORT_A}" "${OCI_EXPORT_B}"
 
 subject_digest_a="$(oci_subject_digest "${OCI_EXPORT_A}")"
 subject_digest_b="$(oci_subject_digest "${OCI_EXPORT_B}")"

--- a/scripts/with-validation-snapshot.sh
+++ b/scripts/with-validation-snapshot.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+REPO_ROOT=""
+SNAPSHOT_MODE=""
+INCLUDE_UNTRACKED=0
+KEEP_SNAPSHOT=0
+SNAPSHOT_DIR=""
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --mode head|index|worktree [options] -- command [args...]
+
+Create a disposable git-backed snapshot of a repository, run a validation
+command inside that snapshot, then discard the snapshot on exit unless
+--keep-snapshot is set.
+
+Options:
+  --repo <path>                Repository to snapshot (default: current directory)
+  --mode <head|index|worktree> Snapshot mode to materialize
+  --include-untracked          Include untracked files with --mode worktree
+  --keep-snapshot              Preserve the snapshot worktree after the command
+  -h, --help                   Show this help
+EOF
+}
+
+die() {
+  echo "$*" >&2
+  exit 2
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required tool: $1"
+}
+
+copy_path_into_snapshot() {
+  local relative_path="$1"
+  local source_path="${REPO_ROOT}/${relative_path}"
+  local target_path="${SNAPSHOT_DIR}/${relative_path}"
+
+  remove_path_from_snapshot "${relative_path}"
+  if [[ ! -e "${source_path}" && ! -L "${source_path}" ]]; then
+    return 0
+  fi
+  mkdir -p "$(dirname "${target_path}")"
+  cp -pPR "${source_path}" "${target_path}"
+}
+
+remove_path_from_snapshot() {
+  local relative_path="$1"
+  local target_path="${SNAPSHOT_DIR}/${relative_path}"
+
+  rm -rf "${target_path}"
+}
+
+overlay_index_state() {
+  local tracked_path=""
+
+  while IFS= read -r -d '' tracked_path; do
+    remove_path_from_snapshot "${tracked_path}"
+  done < <(git -C "${SNAPSHOT_DIR}" ls-files -z)
+  git -C "${REPO_ROOT}" checkout-index -a -f --prefix="${SNAPSHOT_DIR}/"
+}
+
+overlay_worktree_state() {
+  local modified_path=""
+  local deleted_path=""
+  local untracked_path=""
+
+  while IFS= read -r -d '' deleted_path; do
+    remove_path_from_snapshot "${deleted_path}"
+  done < <(git -C "${REPO_ROOT}" ls-files -z --deleted)
+
+  while IFS= read -r -d '' modified_path; do
+    copy_path_into_snapshot "${modified_path}"
+  done < <(git -C "${REPO_ROOT}" ls-files -z -m)
+
+  if [[ "${INCLUDE_UNTRACKED}" -eq 1 ]]; then
+    while IFS= read -r -d '' untracked_path; do
+      copy_path_into_snapshot "${untracked_path}"
+    done < <(git -C "${REPO_ROOT}" ls-files -z --others --exclude-standard)
+  fi
+}
+
+cleanup() {
+  if [[ -z "${SNAPSHOT_DIR}" ]] || [[ ! -d "${SNAPSHOT_DIR}" ]]; then
+    return 0
+  fi
+  if [[ "${KEEP_SNAPSHOT}" -eq 1 ]]; then
+    echo "Preserved validation snapshot at ${SNAPSHOT_DIR}" >&2
+    return 0
+  fi
+  git -C "${REPO_ROOT}" worktree remove --force "${SNAPSHOT_DIR}" >/dev/null 2>&1 || true
+  rm -rf "${SNAPSHOT_DIR}"
+}
+
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || die "Option --repo requires a value."
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --mode)
+      [[ $# -ge 2 ]] || die "Option --mode requires a value."
+      SNAPSHOT_MODE="$2"
+      shift 2
+      ;;
+    --include-untracked)
+      INCLUDE_UNTRACKED=1
+      shift
+      ;;
+    --keep-snapshot)
+      KEEP_SNAPSHOT=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      die "Unknown option: $1"
+      ;;
+  esac
+done
+
+[[ $# -gt 0 ]] || die "Pass the validation command after --."
+[[ -n "${SNAPSHOT_MODE}" ]] || die "Option --mode is required."
+
+case "${SNAPSHOT_MODE}" in
+  head | index | worktree) ;;
+  *)
+    die "Unsupported snapshot mode: ${SNAPSHOT_MODE}"
+    ;;
+esac
+
+if [[ -z "${REPO_ROOT}" ]]; then
+  REPO_ROOT="$(pwd)"
+fi
+REPO_ROOT="$(cd "${REPO_ROOT}" && pwd)"
+
+require_tool git
+require_tool mktemp
+require_tool cp
+
+git -C "${REPO_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
+  die "Repository is not inside a git worktree: ${REPO_ROOT}"
+REPO_ROOT="$(git -C "${REPO_ROOT}" rev-parse --show-toplevel)"
+
+SNAPSHOT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-validation-snapshot.XXXXXX")"
+git -C "${REPO_ROOT}" worktree add --detach "${SNAPSHOT_DIR}" HEAD >/dev/null
+
+case "${SNAPSHOT_MODE}" in
+  index)
+    overlay_index_state
+    ;;
+  worktree)
+    overlay_index_state
+    overlay_worktree_state
+    ;;
+esac
+
+(
+  cd "${SNAPSHOT_DIR}"
+  WORKCELL_VALIDATION_SNAPSHOT_ACTIVE=1 \
+    WORKCELL_VALIDATION_SNAPSHOT_DIR="${SNAPSHOT_DIR}" \
+    "$@"
+)

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -620,7 +620,10 @@ for profile_dir in root.iterdir():
             continue
         if stat_result.st_uid != uid or pointer_path.is_symlink():
             continue
-        lines = pointer_path.read_text(encoding="utf-8").splitlines()
+        try:
+            lines = pointer_path.read_text(encoding="utf-8").splitlines()
+        except FileNotFoundError:
+            continue
         target_path = Path(lines[0]).expanduser() if lines else None
         if target_path is None or not target_path.exists():
             pointer_path.unlink(missing_ok=True)

--- a/tests/python/test_injection_helpers.py
+++ b/tests/python/test_injection_helpers.py
@@ -85,6 +85,81 @@ class RenderInjectionHelperTests(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 self.module.validate_gemini_env_file(duplicate_env)
 
+    def test_parse_simple_env_file_supports_export_comments_and_quoted_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            env_file = root / "gemini.env"
+            env_file.write_text(
+                'export GEMINI_API_KEY="abc#123" # trailing comment\n'
+                "GOOGLE_CLOUD_LOCATION='us-central1'\n"
+                'GOOGLE_CLOUD_PROJECT="test-project"\n',
+                encoding="utf-8",
+            )
+
+            parsed = self.module.parse_simple_env_file(env_file)
+            self.assertEqual(parsed["GEMINI_API_KEY"], "abc#123")
+            self.assertEqual(parsed["GOOGLE_CLOUD_LOCATION"], "us-central1")
+            self.assertEqual(parsed["GOOGLE_CLOUD_PROJECT"], "test-project")
+
+    def test_parse_simple_env_file_rejects_malformed_quoted_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            env_file = root / "gemini.env"
+            env_file.write_text(
+                'GOOGLE_CLOUD_PROJECT="unterminated\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(SystemExit):
+                self.module.parse_simple_env_file(env_file)
+
+    def test_validate_gemini_env_file_rejects_conflicting_empty_and_unsupported_modes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            conflicting = root / "conflicting.env"
+            conflicting.write_text(
+                "GOOGLE_GENAI_USE_GCA=true\nGOOGLE_GENAI_USE_VERTEXAI=true\n",
+                encoding="utf-8",
+            )
+            missing_project = root / "missing-project.env"
+            missing_project.write_text(
+                "GOOGLE_GENAI_USE_VERTEXAI=true\nGOOGLE_CLOUD_LOCATION=us-central1\n",
+                encoding="utf-8",
+            )
+            google_without_vertex = root / "google-without-vertex.env"
+            google_without_vertex.write_text("GOOGLE_API_KEY=test\n", encoding="utf-8")
+            empty_value = root / "empty.env"
+            empty_value.write_text("GEMINI_API_KEY=\n", encoding="utf-8")
+            invalid_bool = root / "invalid-bool.env"
+            invalid_bool.write_text("GOOGLE_GENAI_USE_GCA=maybe\n", encoding="utf-8")
+            unsupported_key = root / "unsupported.env"
+            unsupported_key.write_text("UNSUPPORTED_KEY=value\n", encoding="utf-8")
+            malformed_quoted = root / "malformed-quoted.env"
+            malformed_quoted.write_text(
+                'GOOGLE_GENAI_USE_VERTEXAI=true\n'
+                'GOOGLE_CLOUD_PROJECT="unterminated\n'
+                "GOOGLE_CLOUD_LOCATION=us-central1\n",
+                encoding="utf-8",
+            )
+            api_key = root / "api-key.env"
+            api_key.write_text("GEMINI_API_KEY=secret\n", encoding="utf-8")
+
+            for candidate in (
+                conflicting,
+                missing_project,
+                google_without_vertex,
+                empty_value,
+                invalid_bool,
+                unsupported_key,
+                malformed_quoted,
+            ):
+                with self.assertRaises(SystemExit):
+                    self.module.validate_gemini_env_file(candidate)
+
+            metadata = self.module.validate_gemini_env_file(api_key)
+            self.assertEqual(metadata["selected_auth_type"], "gemini-api-key")
+            self.assertEqual(metadata["extra_endpoints"], [])
+
     def test_validate_json_helpers_reject_invalid_gemini_oauth_and_adc(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -109,11 +184,34 @@ class RenderInjectionHelperTests(unittest.TestCase):
                 valid_projects, "credentials.gemini_projects"
             )
 
+    def test_validation_helpers_reject_unsafe_paths_and_permissions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            file_path = root / "file.txt"
+            file_path.write_text("content\n", encoding="utf-8")
+            file_path.chmod(0o600)
+            symlink = root / "link.txt"
+            symlink.symlink_to(file_path)
+            directory = root / "directory"
+            directory.mkdir()
+            known_hosts = root / "known_hosts"
+            known_hosts.write_text("github.com ssh-ed25519 AAAA\n", encoding="utf-8")
+            known_hosts.chmod(0o666)
+
+            self.module.require_path_within(root, file_path, "file")
+            with self.assertRaises(SystemExit):
+                self.module.require_no_symlink(symlink, "link")
+            with self.assertRaises(SystemExit):
+                self.module.validate_secret_tree(directory, "directory")
+            with self.assertRaises(SystemExit):
+                self.module.validate_known_hosts_file(known_hosts, "known_hosts")
+
     def test_parse_toml_subset_parses_supported_tables(self) -> None:
         policy = Path("/tmp/policy.toml")
         parsed = self.module.parse_toml_subset(
             """
             version = 1
+            includes = ["shared.toml"]
             [documents]
             common = "common.md"
             [credentials]
@@ -129,6 +227,7 @@ class RenderInjectionHelperTests(unittest.TestCase):
             policy,
         )
         self.assertEqual(parsed["version"], 1)
+        self.assertEqual(parsed["includes"], ["shared.toml"])
         self.assertEqual(parsed["documents"]["common"], "common.md")
         self.assertEqual(parsed["credentials"]["codex_auth"], "auth.json")
         self.assertTrue(parsed["ssh"]["enabled"])
@@ -284,22 +383,41 @@ class RenderInjectionHelperTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             policy_path = root / "policy.toml"
+            included_path = root / "shared.toml"
             source = root / "common.md"
+            codex_auth = root / "auth.json"
             source.write_text("common\n", encoding="utf-8")
+            codex_auth.write_text("{}\n", encoding="utf-8")
             source.chmod(0o600)
+            codex_auth.chmod(0o600)
             self.assertEqual(
                 self.module.expand_host_path(str(source), root),
                 Path(os.path.abspath(os.fspath(source))),
             )
+            included_path.write_text(
+                '[documents]\ncommon = "common.md"\n',
+                encoding="utf-8",
+            )
             policy_path.write_text(
-                'version = 1\n[documents]\ncommon = "common.md"\n',
+                'version = 1\nincludes = ["shared.toml"]\n[credentials]\ncodex_auth = "auth.json"\n',
                 encoding="utf-8",
             )
             loaded = self.module.load_policy(policy_path)
-            self.assertEqual(loaded["documents"]["common"], "common.md")
+            self.assertEqual(loaded["documents"]["common"], str(source.resolve()))
+            self.assertEqual(loaded["credentials"]["codex_auth"], "auth.json")
             self.assertEqual(
                 self.module.validate_source_path("common.md", "documents.common", root),
                 Path(os.path.abspath(os.fspath(source))),
+            )
+
+            loaded_bundle, policy_sources = self.module.load_policy_bundle(policy_path)
+            self.assertEqual(loaded_bundle["documents"]["common"], str(source.resolve()))
+            self.assertEqual(
+                [entry["path"] for entry in policy_sources],
+                ["shared.toml", "policy.toml"],
+            )
+            self.assertTrue(
+                self.module.composite_policy_sha256(policy_sources).startswith("sha256:")
             )
 
             policy_path.write_text('version = 2\n', encoding="utf-8")
@@ -309,6 +427,56 @@ class RenderInjectionHelperTests(unittest.TestCase):
                 self.module.validate_source_path("", "documents.common", root)
             with self.assertRaises(SystemExit):
                 self.module.validate_source_path("missing.md", "documents.common", root)
+
+    def test_load_policy_bundle_rejects_duplicate_fragment_settings_and_cycles(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "common.md").write_text("common\n", encoding="utf-8")
+            (root / "common.md").chmod(0o600)
+            (root / "a.toml").write_text(
+                'includes = ["b.toml"]\n[documents]\ncommon = "common.md"\n',
+                encoding="utf-8",
+            )
+            (root / "b.toml").write_text(
+                'includes = ["a.toml"]\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(SystemExit) as excinfo:
+                self.module.load_policy_bundle(root / "a.toml")
+            self.assertIn("include cycle detected", str(excinfo.exception))
+
+            (root / "shared.toml").write_text(
+                '[credentials]\ncodex_auth = "auth-a.json"\n',
+                encoding="utf-8",
+            )
+            (root / "root.toml").write_text(
+                'includes = ["shared.toml"]\n[credentials]\ncodex_auth = "auth-b.json"\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(SystemExit) as duplicate_excinfo:
+                self.module.load_policy_bundle(root / "root.toml")
+            self.assertIn(
+                "credentials.codex_auth",
+                str(duplicate_excinfo.exception),
+            )
+
+    def test_load_policy_bundle_rejects_includes_outside_entrypoint_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            outside = root / "outside.toml"
+            subdir = root / "subdir"
+            subdir.mkdir()
+            outside.write_text('[documents]\ncommon = "common.md"\n', encoding="utf-8")
+            (subdir / "policy.toml").write_text(
+                'version = 1\nincludes = ["../outside.toml"]\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(SystemExit) as excinfo:
+                self.module.load_policy_bundle(subdir / "policy.toml")
+            self.assertIn("must stay within", str(excinfo.exception))
 
     def test_render_documents_rejects_non_file_sources(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -321,6 +489,34 @@ class RenderInjectionHelperTests(unittest.TestCase):
                     {"documents": {"common": "dir"}},
                     output,
                     root,
+                )
+
+    def test_render_ssh_rejects_invalid_table_and_option_types(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            key = root / "id_ed25519"
+            key.write_text("secret\n", encoding="utf-8")
+            key.chmod(0o600)
+
+            with self.assertRaises(SystemExit):
+                self.module.render_ssh({"ssh": []}, output, root, "codex", "strict")
+            with self.assertRaises(SystemExit):
+                self.module.render_ssh(
+                    {"ssh": {"enabled": True, "allow_unsafe_config": "yes"}},
+                    output,
+                    root,
+                    "codex",
+                    "strict",
+                )
+            with self.assertRaises(SystemExit):
+                self.module.render_ssh(
+                    {"ssh": {"enabled": True, "identities": "id_ed25519"}},
+                    output,
+                    root,
+                    "codex",
+                    "strict",
                 )
 
     def test_optional_sections_accept_none(self) -> None:

--- a/tests/python/test_render_injection_bundle.py
+++ b/tests/python/test_render_injection_bundle.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -44,6 +47,388 @@ class RenderInjectionBundleTests(unittest.TestCase):
                 gemini_rendered["gemini_projects"]["mount_path"],
                 "/opt/workcell/host-inputs/credentials/gemini-projects.json",
             )
+
+    def test_load_policy_bundle_merges_includes_and_tracks_source_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "common.md").write_text("common\n", encoding="utf-8")
+            (root / "auth.json").write_text("{}\n", encoding="utf-8")
+            (root / "common.md").chmod(0o600)
+            (root / "auth.json").chmod(0o600)
+            (root / "shared.toml").write_text(
+                '[documents]\ncommon = "common.md"\n',
+                encoding="utf-8",
+            )
+            root_policy = root / "policy.toml"
+            root_policy.write_text(
+                'version = 1\nincludes = ["shared.toml"]\n[credentials]\ncodex_auth = "auth.json"\n',
+                encoding="utf-8",
+            )
+
+            merged_policy, policy_sources = self.module.load_policy_bundle(root_policy)
+
+            self.assertEqual(
+                merged_policy["documents"]["common"],
+                str((root / "common.md").resolve()),
+            )
+            self.assertEqual(merged_policy["credentials"]["codex_auth"], "auth.json")
+            self.assertEqual(
+                [entry["path"] for entry in policy_sources],
+                ["shared.toml", "policy.toml"],
+            )
+            self.assertTrue(
+                self.module.composite_policy_sha256(policy_sources).startswith("sha256:")
+            )
+
+    def test_policy_sha256_tracks_effective_injected_material(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "policy.toml"
+            bundle_a = root / "bundle-a"
+            bundle_b = root / "bundle-b"
+            (root / "common.md").write_text("common\n", encoding="utf-8")
+            (root / "auth.json").write_text('{"token":"one"}\n', encoding="utf-8")
+            (root / "auth.json").chmod(0o600)
+            policy_path.write_text(
+                'version = 1\n[documents]\ncommon = "common.md"\n[credentials]\ncodex_auth = "auth.json"\n',
+                encoding="utf-8",
+            )
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(self.module.__file__).resolve()),
+                    "--policy",
+                    str(policy_path),
+                    "--agent",
+                    "codex",
+                    "--mode",
+                    "strict",
+                    "--output-root",
+                    str(bundle_a),
+                ],
+                check=True,
+            )
+            manifest_a = json.loads((bundle_a / "manifest.json").read_text(encoding="utf-8"))
+
+            (root / "auth.json").write_text('{"token":"two"}\n', encoding="utf-8")
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(self.module.__file__).resolve()),
+                    "--policy",
+                    str(policy_path),
+                    "--agent",
+                    "codex",
+                    "--mode",
+                    "strict",
+                    "--output-root",
+                    str(bundle_b),
+                ],
+                check=True,
+            )
+            manifest_b = json.loads((bundle_b / "manifest.json").read_text(encoding="utf-8"))
+
+            self.assertNotEqual(
+                manifest_a["metadata"]["policy_sha256"],
+                manifest_b["metadata"]["policy_sha256"],
+            )
+
+    def test_load_policy_bundle_rejects_parent_escape_includes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            nested = root / "nested"
+            nested.mkdir()
+            (root / "outside.toml").write_text('[documents]\ncommon = "common.md"\n', encoding="utf-8")
+            (nested / "policy.toml").write_text(
+                'version = 1\nincludes = ["../outside.toml"]\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(SystemExit) as excinfo:
+                self.module.load_policy_bundle(nested / "policy.toml")
+            self.assertIn("must stay within", str(excinfo.exception))
+
+    def test_load_policy_bundle_rejects_non_list_and_duplicate_includes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "shared.toml").write_text('[documents]\ncommon = "common.md"\n', encoding="utf-8")
+            (root / "common.md").write_text("common\n", encoding="utf-8")
+            (root / "policy-invalid.toml").write_text(
+                'version = 1\nincludes = "shared.toml"\n',
+                encoding="utf-8",
+            )
+            (root / "policy-duplicate.toml").write_text(
+                'version = 1\nincludes = ["shared.toml", "shared.toml"]\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(SystemExit) as excinfo:
+                self.module.load_policy_bundle(root / "policy-invalid.toml")
+            self.assertIn("includes must be an array of strings", str(excinfo.exception))
+
+            with self.assertRaises(SystemExit) as excinfo:
+                self.module.load_policy_bundle(root / "policy-duplicate.toml")
+            self.assertIn("includes the same file more than once", str(excinfo.exception))
+
+    def test_load_policy_bundle_rebases_included_fragment_paths_to_fragment_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            fragments = root / "fragments"
+            fragments.mkdir()
+            (fragments / "common.md").write_text("common\n", encoding="utf-8")
+            (fragments / "copy.txt").write_text("copy\n", encoding="utf-8")
+            (fragments / "auth.json").write_text("{}\n", encoding="utf-8")
+            (fragments / "ssh_config").write_text("Host github.com\n", encoding="utf-8")
+            (fragments / "id_workcell").write_text("private\n", encoding="utf-8")
+            (fragments / "id_workcell").chmod(0o600)
+            (fragments / "fragment.toml").write_text(
+                '[documents]\n'
+                'common = "common.md"\n'
+                '[[copies]]\n'
+                'source = "copy.txt"\n'
+                'target = "/state/injected/copy.txt"\n'
+                'classification = "public"\n'
+                '[ssh]\n'
+                'enabled = true\n'
+                'config = "ssh_config"\n'
+                'identities = ["id_workcell"]\n'
+                '[credentials]\n'
+                'codex_auth = "auth.json"\n',
+                encoding="utf-8",
+            )
+            root_policy = root / "policy.toml"
+            root_policy.write_text(
+                'version = 1\nincludes = ["fragments/fragment.toml"]\n',
+                encoding="utf-8",
+            )
+
+            merged_policy, _ = self.module.load_policy_bundle(root_policy)
+
+            self.assertEqual(
+                merged_policy["documents"]["common"],
+                str((fragments / "common.md").resolve()),
+            )
+            self.assertEqual(
+                merged_policy["copies"][0]["source"],
+                str((fragments / "copy.txt").resolve()),
+            )
+            self.assertEqual(
+                merged_policy["ssh"]["config"],
+                str((fragments / "ssh_config").resolve()),
+            )
+            self.assertEqual(
+                merged_policy["ssh"]["identities"][0],
+                str((fragments / "id_workcell").resolve()),
+            )
+            self.assertEqual(
+                merged_policy["credentials"]["codex_auth"],
+                str((fragments / "auth.json").resolve()),
+            )
+
+    def test_rebase_policy_fragment_rebases_all_supported_path_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            fragment_dir = root / "fragment"
+            fragment_dir.mkdir()
+
+            rebased = self.module.rebase_policy_fragment(
+                {
+                    "documents": {"common": "common.md"},
+                    "copies": [{"source": "copy.txt", "target": "/state/injected/copy.txt"}, "literal"],
+                    "ssh": {
+                        "config": "ssh_config",
+                        "known_hosts": "known_hosts",
+                        "identities": ["id_workcell"],
+                    },
+                    "credentials": {
+                        "codex_auth": "auth.json",
+                        "github_hosts": {"source": "hosts.yml", "providers": ["codex"]},
+                    },
+                    "version": 1,
+                },
+                fragment_dir,
+            )
+            expected = lambda value: str(self.module.expand_host_path(value, fragment_dir))
+
+            self.assertEqual(
+                rebased["documents"]["common"],
+                expected("common.md"),
+            )
+            self.assertEqual(
+                rebased["copies"][0]["source"],
+                expected("copy.txt"),
+            )
+            self.assertEqual(rebased["copies"][1], "literal")
+            self.assertEqual(
+                rebased["ssh"]["config"],
+                expected("ssh_config"),
+            )
+            self.assertEqual(
+                rebased["ssh"]["known_hosts"],
+                expected("known_hosts"),
+            )
+            self.assertEqual(
+                rebased["ssh"]["identities"][0],
+                expected("id_workcell"),
+            )
+            self.assertEqual(
+                rebased["credentials"]["codex_auth"],
+                expected("auth.json"),
+            )
+            self.assertEqual(
+                rebased["credentials"]["github_hosts"]["source"],
+                expected("hosts.yml"),
+            )
+
+    def test_path_material_sha256_covers_file_directory_and_symlink_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            file_path = root / "file.txt"
+            dir_path = root / "tree"
+            symlink_path = root / "link.txt"
+            file_path.write_text("file\n", encoding="utf-8")
+            dir_path.mkdir()
+            (dir_path / "nested.txt").write_text("nested\n", encoding="utf-8")
+            symlink_path.symlink_to(file_path.name)
+
+            file_digest = self.module.path_material_sha256(file_path)
+            dir_digest = self.module.path_material_sha256(dir_path)
+            symlink_digest = self.module.path_material_sha256(symlink_path)
+
+            self.assertEqual(file_digest, self.module.path_material_sha256(file_path))
+            self.assertEqual(dir_digest, self.module.path_material_sha256(dir_path))
+            self.assertEqual(symlink_digest, self.module.path_material_sha256(symlink_path))
+            self.assertNotEqual(file_digest, dir_digest)
+            self.assertNotEqual(file_digest, symlink_digest)
+
+    def test_effective_policy_sha256_tracks_documents_copies_credentials_and_ssh(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "bundle"
+            output.mkdir()
+            (output / "documents").mkdir()
+            (output / "copies").mkdir()
+            (output / "documents/common.md").write_text("common\n", encoding="utf-8")
+            (output / "copies/0").write_text("public\n", encoding="utf-8")
+            secret_copy = root / "secret-copy.txt"
+            credential = root / "auth.json"
+            ssh_config = root / "ssh_config"
+            known_hosts = root / "known_hosts"
+            identity = root / "id_workcell"
+            secret_copy.write_text("secret\n", encoding="utf-8")
+            credential.write_text('{"token":"one"}\n', encoding="utf-8")
+            ssh_config.write_text("Host github.com\n", encoding="utf-8")
+            known_hosts.write_text("github.com ssh-ed25519 AAAA\n", encoding="utf-8")
+            identity.write_text("private\n", encoding="utf-8")
+            credential.chmod(0o600)
+            ssh_config.chmod(0o600)
+            identity.chmod(0o600)
+
+            digest_before = self.module.effective_policy_sha256(
+                [{"path": "policy.toml", "sha256": "sha256:policy"}],
+                output,
+                {"common": "documents/common.md"},
+                [
+                    {
+                        "source": "copies/0",
+                        "target": "/state/injected/public.txt",
+                        "kind": "file",
+                        "file_mode": "0644",
+                        "dir_mode": "0755",
+                        "classification": "public",
+                    },
+                    {
+                        "source": {
+                            "source": str(secret_copy),
+                            "mount_path": "/opt/workcell/host-inputs/copies/1",
+                        },
+                        "target": "~/.config/workcell/token.txt",
+                        "kind": "file",
+                        "file_mode": "0600",
+                        "dir_mode": "0700",
+                        "classification": "secret",
+                    },
+                ],
+                {
+                    "codex_auth": {
+                        "source": str(credential),
+                        "mount_path": "/opt/workcell/host-inputs/credentials/codex-auth.json",
+                    }
+                },
+                {
+                    "config_assurance": "safe",
+                    "config": {
+                        "source": str(ssh_config),
+                        "mount_path": "/opt/workcell/host-inputs/ssh/config",
+                    },
+                    "known_hosts": {
+                        "source": str(known_hosts),
+                        "mount_path": "/opt/workcell/host-inputs/ssh/known_hosts",
+                    },
+                    "identities": [
+                        {
+                            "source": str(identity),
+                            "mount_path": "/opt/workcell/host-inputs/ssh/identity-0",
+                            "target_name": "id_workcell",
+                        }
+                    ],
+                },
+            )
+
+            secret_copy.write_text("secret-two\n", encoding="utf-8")
+            digest_after = self.module.effective_policy_sha256(
+                [{"path": "policy.toml", "sha256": "sha256:policy"}],
+                output,
+                {"common": "documents/common.md"},
+                [
+                    {
+                        "source": "copies/0",
+                        "target": "/state/injected/public.txt",
+                        "kind": "file",
+                        "file_mode": "0644",
+                        "dir_mode": "0755",
+                        "classification": "public",
+                    },
+                    {
+                        "source": {
+                            "source": str(secret_copy),
+                            "mount_path": "/opt/workcell/host-inputs/copies/1",
+                        },
+                        "target": "~/.config/workcell/token.txt",
+                        "kind": "file",
+                        "file_mode": "0600",
+                        "dir_mode": "0700",
+                        "classification": "secret",
+                    },
+                ],
+                {
+                    "codex_auth": {
+                        "source": str(credential),
+                        "mount_path": "/opt/workcell/host-inputs/credentials/codex-auth.json",
+                    }
+                },
+                {
+                    "config_assurance": "safe",
+                    "config": {
+                        "source": str(ssh_config),
+                        "mount_path": "/opt/workcell/host-inputs/ssh/config",
+                    },
+                    "known_hosts": {
+                        "source": str(known_hosts),
+                        "mount_path": "/opt/workcell/host-inputs/ssh/known_hosts",
+                    },
+                    "identities": [
+                        {
+                            "source": str(identity),
+                            "mount_path": "/opt/workcell/host-inputs/ssh/identity-0",
+                            "target_name": "id_workcell",
+                        }
+                    ],
+                },
+            )
+
+            self.assertNotEqual(digest_before, digest_after)
 
     def test_reserved_targets_cover_managed_provider_state(self) -> None:
         for target in (


### PR DESCRIPTION
## Summary
- add signed control-plane manifest generation and verification, and tighten runtime control-plane integrity checks
- add composable injection-policy fragments, stronger effective policy provenance hashing, and validation snapshot support for local pre-merge workflows
- tighten provider smoke/invariant coverage, improve arm64 reproducible-build caching behavior, and expand Dependabot coverage to the remaining Docker ecosystem

## Local validation
- `git diff --check`
- `python3 -m unittest discover -s tests/python -p 'test_*.py'`
- `./scripts/verify-control-plane-manifest.sh`
- `WORKCELL_CONTAINER_SMOKE_DOCKER_CONTEXT=colima ./scripts/container-smoke.sh`
- `./scripts/verify-invariants.sh`
- `./scripts/validate-repo.sh`
- local arm64 reproducible-build verification and cache-behavior probes on the updated Dockerfile path

## Peer review
- security/provenance review: no findings on final tree
- snapshot/invariant review: no findings on final tree
