### PR TITLE
Harden provider session launch and profile recovery

### DIFF
--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "3b71f6ce278568f92cc7bca664b6f5164bda4e53653f4b4254a84479372424df"
+      "sha256": "355dbb40d5ee57c8d0081481035aa6ade5d4362942a3c07a210411fdb80ab2b7"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts.py",
@@ -14,7 +14,7 @@
     },
     {
       "repo_path": "scripts/lib/trusted-docker-client.sh",
-      "sha256": "66384bd55c487dc25fea52c6872ed4ddc5b190a97a47ff6a7b967a6e87244981"
+      "sha256": "826a61b2b5584d1911a68cfe8f6c9107abc982c5a3ec2de0b209984ba10dcbf8"
     }
   ],
   "runtime_artifacts": [

--- a/scripts/colima-egress-allowlist.sh
+++ b/scripts/colima-egress-allowlist.sh
@@ -109,12 +109,20 @@ PY
 run_clean_host_command() {
   local home="${REAL_HOME:-/}"
 
-  env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${home}" \
-    LC_ALL=C \
-    LANG=C \
-    "$@"
+  [[ "$#" -gt 0 ]] || return 0
+  if [[ ! -d "${home}" ]]; then
+    home="/"
+  fi
+
+  (
+    cd "${home}" &&
+      env -i \
+        PATH="${TRUSTED_HOST_PATH}" \
+        HOME="${home}" \
+        LC_ALL=C \
+        LANG=C \
+        "$@"
+  )
 }
 
 validate_endpoint() {
@@ -269,12 +277,15 @@ EOF
   fi
   initialize_vm_tools
   colima_home="${COLIMA_HOME:-${REAL_HOME}/.colima}"
-  printf 'set -euo pipefail\n%s\n' "${script}" |
-    HOME="${REAL_HOME}" \
-      COLIMA_HOME="${colima_home}" \
-      LIMA_HOME="${colima_home}/_lima" \
-      LIMA_WORKDIR=/ \
-      "${LIMACTL_BIN}" shell "$(lima_instance)" -- bash -s --
+  (
+    cd / &&
+      printf 'set -euo pipefail\n%s\n' "${script}" |
+        HOME="${REAL_HOME}" \
+          COLIMA_HOME="${colima_home}" \
+          LIMA_HOME="${colima_home}/_lima" \
+          LIMA_WORKDIR=/ \
+          "${LIMACTL_BIN}" shell "$(lima_instance)" -- bash -s --
+  )
 }
 
 clear_rules() {

--- a/scripts/colima-egress-allowlist.sh
+++ b/scripts/colima-egress-allowlist.sh
@@ -280,11 +280,11 @@ EOF
   (
     cd / &&
       printf 'set -euo pipefail\n%s\n' "${script}" |
-        HOME="${REAL_HOME}" \
-          COLIMA_HOME="${colima_home}" \
-          LIMA_HOME="${colima_home}/_lima" \
-          LIMA_WORKDIR=/ \
-          "${LIMACTL_BIN}" shell "$(lima_instance)" -- bash -s --
+      HOME="${REAL_HOME}" \
+        COLIMA_HOME="${colima_home}" \
+        LIMA_HOME="${colima_home}/_lima" \
+        LIMA_WORKDIR=/ \
+        "${LIMACTL_BIN}" shell "$(lima_instance)" -- bash -s --
   )
 }
 

--- a/scripts/lib/trusted-docker-client.sh
+++ b/scripts/lib/trusted-docker-client.sh
@@ -28,6 +28,30 @@ copy_workcell_docker_state_tree() {
   cp -R "${source_dir}/." "${destination_dir}/"
 }
 
+sanitize_workcell_docker_buildx_state() {
+  local buildx_dir="$1"
+
+  [[ -d "${buildx_dir}" ]] || return 0
+  # Buildx refs cache prior local build roots and Dockerfile paths. Reusing
+  # them inside a remapped Docker/Colima context can emit stale host-path cd
+  # failures before the real build starts.
+  rm -rf "${buildx_dir}/refs"
+}
+
+run_workcell_docker_client_command() {
+  local safe_cwd="${WORKCELL_DOCKER_CLIENT_CWD:-${HOME:-/}}"
+
+  [[ "$#" -gt 0 ]] || return 0
+  if [[ ! -d "${safe_cwd}" ]]; then
+    safe_cwd="/"
+  fi
+
+  (
+    cd "${safe_cwd}" &&
+      "$@"
+  )
+}
+
 select_workcell_trusted_buildx() {
   local candidate
 
@@ -58,6 +82,7 @@ setup_workcell_trusted_docker_client() {
 
   copy_workcell_docker_state_tree "${real_home}/.docker/contexts" "${WORKCELL_DOCKER_CONFIG}/contexts"
   copy_workcell_docker_state_tree "${real_home}/.docker/buildx" "${WORKCELL_DOCKER_CONFIG}/buildx"
+  sanitize_workcell_docker_buildx_state "${WORKCELL_DOCKER_CONFIG}/buildx"
   rm -rf "${WORKCELL_DOCKER_CONFIG}/cli-plugins"
 
   export HOME="${WORKCELL_DOCKER_HOME}"
@@ -84,12 +109,12 @@ ensure_workcell_trusted_buildx() {
 
 docker_context_exists() {
   local context_name="$1"
-  docker context inspect "${context_name}" >/dev/null 2>&1
+  run_workcell_docker_client_command docker context inspect "${context_name}" >/dev/null 2>&1
 }
 
 docker_context_is_healthy() {
   local context_name="$1"
-  docker --context "${context_name}" info >/dev/null 2>&1
+  run_workcell_docker_client_command docker --context "${context_name}" info >/dev/null 2>&1
 }
 
 select_workcell_docker_context() {
@@ -132,9 +157,9 @@ select_workcell_docker_context() {
 buildx_cmd() {
   ensure_workcell_trusted_buildx
   if [[ -n "${DOCKER_CONTEXT_NAME:-}" ]]; then
-    DOCKER_CONTEXT="${DOCKER_CONTEXT_NAME}" "${WORKCELL_TRUSTED_BUILDX_BIN}" "$@"
+    run_workcell_docker_client_command env DOCKER_CONTEXT="${DOCKER_CONTEXT_NAME}" "${WORKCELL_TRUSTED_BUILDX_BIN}" "$@"
   else
-    "${WORKCELL_TRUSTED_BUILDX_BIN}" "$@"
+    run_workcell_docker_client_command "${WORKCELL_TRUSTED_BUILDX_BIN}" "$@"
   fi
 }
 

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2454,6 +2454,78 @@ DOCKER_CONTEXT_SELECTOR_FAKEBIN="${DOCKER_CONTEXT_SELECTOR_FAKEBIN}" \
   PATH="${DOCKER_CONTEXT_SELECTOR_PATH}" ROOT_DIR="${ROOT_DIR}" BARRIER_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}" \
   /bin/bash "${DOCKER_CONTEXT_SELECTOR_HARNESS}"
 
+DOCKER_BUILDX_REF_SANITIZE_HARNESS="${BARRIER_VERIFY_ROOT}/docker-buildx-ref-sanitize.sh"
+cat >"${DOCKER_BUILDX_REF_SANITIZE_HARNESS}" <<'EOF'
+set -euo pipefail
+
+buildx_root="${BARRIER_VERIFY_ROOT}/docker-buildx-ref-sanitize"
+mkdir -p "${buildx_root}/refs/default/default"
+printf '{"LocalPath":"/tmp/stale","DockerfilePath":"/tmp/stale/Dockerfile"}\n' >"${buildx_root}/refs/default/default/ref.json"
+printf '{"Key":"default","Name":"","Global":false}\n' >"${buildx_root}/current"
+
+ROOT_DIR="${ROOT_DIR}" BARRIER_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}" /bin/bash -lc '
+  set -euo pipefail
+  source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
+  sanitize_workcell_docker_buildx_state "'"${buildx_root}"'"
+'
+
+if [[ -e "${buildx_root}/refs/default/default/ref.json" ]]; then
+  echo "Expected trusted Docker setup to drop stale buildx refs" >&2
+  exit 1
+fi
+if [[ ! -f "${buildx_root}/current" ]]; then
+  echo "Expected trusted Docker buildx sanitization to preserve current builder selection" >&2
+  exit 1
+fi
+EOF
+chmod 0755 "${DOCKER_BUILDX_REF_SANITIZE_HARNESS}"
+ROOT_DIR="${ROOT_DIR}" BARRIER_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}" /bin/bash "${DOCKER_BUILDX_REF_SANITIZE_HARNESS}"
+
+DOCKER_CLIENT_CWD_HARNESS="${BARRIER_VERIFY_ROOT}/docker-client-cwd.sh"
+cat >"${DOCKER_CLIENT_CWD_HARNESS}" <<'EOF'
+set -euo pipefail
+
+FAKE_DOCKER_BIN="${BARRIER_VERIFY_ROOT}/docker-client-cwd-bin"
+WORKTREE_CWD="${BARRIER_VERIFY_ROOT}/missing-cwd"
+mkdir -p "${FAKE_DOCKER_BIN}"
+rm -rf "${WORKTREE_CWD}"
+
+cat >"${FAKE_DOCKER_BIN}/docker" <<'EOS'
+#!/bin/sh
+printf '%s\n' "$PWD"
+EOS
+chmod 0755 "${FAKE_DOCKER_BIN}/docker"
+
+ROOT_DIR="${ROOT_DIR}" PATH="${FAKE_DOCKER_BIN}:${PATH}" /bin/bash -lc '
+  set -euo pipefail
+  source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
+  export HOME="${BARRIER_VERIFY_ROOT}/docker-client-home"
+  mkdir -p "${HOME}"
+  export WORKCELL_DOCKER_CLIENT_CWD="${HOME}"
+  cd "'"${WORKTREE_CWD}"'" 2>/dev/null || true
+  output="$(run_workcell_docker_client_command docker context inspect default)"
+  if [[ "${output}" != "${HOME}" ]]; then
+    echo "Expected Docker client commands to run from the configured safe cwd, got: ${output}" >&2
+    exit 1
+  fi
+'
+EOF
+chmod 0755 "${DOCKER_CLIENT_CWD_HARNESS}"
+ROOT_DIR="${ROOT_DIR}" BARRIER_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}" /bin/bash "${DOCKER_CLIENT_CWD_HARNESS}"
+
+DOCKER_CLIENT_EMPTY_ARGV_HARNESS="${BARRIER_VERIFY_ROOT}/docker-client-empty-argv.sh"
+cat >"${DOCKER_CLIENT_EMPTY_ARGV_HARNESS}" <<'EOF'
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR}" /bin/bash -lc '
+  set -euo pipefail
+  source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
+  run_workcell_docker_client_command
+'
+EOF
+chmod 0755 "${DOCKER_CLIENT_EMPTY_ARGV_HARNESS}"
+ROOT_DIR="${ROOT_DIR}" /bin/bash "${DOCKER_CLIENT_EMPTY_ARGV_HARNESS}"
+
 CONTAINER_SMOKE_PATH_OVERRIDE_DIR="${BARRIER_VERIFY_ROOT}/container-smoke-path-override-bin"
 CONTAINER_SMOKE_PATH_MARKER="${BARRIER_VERIFY_ROOT}/container-smoke-path-ran"
 mkdir -p "${CONTAINER_SMOKE_PATH_OVERRIDE_DIR}"
@@ -5390,5 +5462,47 @@ if ! rg -q 'trustedFolders\.json' "${ROOT_DIR}/runtime/container/home-control-pl
   echo "Expected Gemini home seeding to provision trustedFolders.json" >&2
   exit 1
 fi
+
+python3 - "${ROOT_DIR}/scripts/workcell" <<'PY'
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+needle = 'acquire_profile_lock "${COLIMA_PROFILE}"\n  # Another launch may have created or repaired the profile while we waited.\n  refresh_profile_state "${COLIMA_PROFILE}"'
+if needle not in text:
+    raise SystemExit("Expected workcell to refresh profile state immediately after taking the profile lock")
+PY
+
+python3 - "${ROOT_DIR}/scripts/workcell" <<'PY'
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+required = [
+    'workspace_runtime_probe_path()',
+    'validate_colima_runtime_workspace_view()',
+    'validate_colima_runtime_workspace_view "${profile}" "${workspace}"',
+    'Refreshing managed Colima profile ${COLIMA_PROFILE} because the running VM is not exposing the expected workspace contents.',
+    'Refreshing managed Colima profile ${COLIMA_PROFILE} because the started VM did not expose the expected workspace view.',
+]
+for needle in required:
+    if needle not in text:
+        raise SystemExit(f"Expected workcell mount-view validation snippet missing: {needle}")
+PY
+
+python3 - "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" <<'PY'
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+required = [
+    'cd "${home}" &&',
+    'cd / &&',
+    'LIMA_WORKDIR=/',
+]
+for needle in required:
+    if needle not in text:
+        raise SystemExit(f"Expected egress helper safe-cwd snippet missing: {needle}")
+PY
 
 echo "Workcell invariant verification passed."

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -303,10 +303,19 @@ profile_lima_dir() {
 }
 
 run_host_colima() {
+  local safe_cwd="${WORKCELL_HOST_COMMAND_CWD:-${REAL_HOME:-/}}"
+
+  [[ "$#" -gt 0 ]] || return 0
   if [[ -z "${HOST_COLIMA_BIN}" ]]; then
     HOST_COLIMA_BIN="$(resolve_host_tool colima /opt/homebrew/bin/colima /usr/local/bin/colima)"
   fi
-  HOME="${REAL_HOME}" COLIMA_HOME="${COLIMA_STATE_ROOT}" "${HOST_COLIMA_BIN}" "$@"
+  if [[ ! -d "${safe_cwd}" ]]; then
+    safe_cwd="/"
+  fi
+  (
+    cd "${safe_cwd}" &&
+      HOME="${REAL_HOME}" COLIMA_HOME="${COLIMA_STATE_ROOT}" "${HOST_COLIMA_BIN}" "$@"
+  )
 }
 
 colima_profile_status() {
@@ -434,6 +443,19 @@ maybe_reap_stale_profile_processes() {
   fi
 }
 
+refresh_managed_profile() {
+  local message="$1"
+
+  echo "${message}" >&2
+  stash_profile_audit_log "${COLIMA_PROFILE}"
+  run_host_colima delete --profile "${COLIMA_PROFILE}" --force >/dev/null 2>&1 || true
+  rm -rf "${PROFILE_DIR}"
+  PROFILE_WAS_REFRESHED=1
+  PROFILE_PREEXISTED=0
+  PROFILE_MARKER_WORKSPACE=""
+  PROFILE_RUNNING=0
+}
+
 sanitize_host_docker_env() {
   unset DOCKER_CONTEXT
   unset DOCKER_HOST
@@ -494,7 +516,7 @@ cleanup() {
   fi
 
   if [[ -n "${CONTAINER_NAME:-}" ]] && [[ -n "${HOST_DOCKER_BIN:-}" ]]; then
-    "${HOST_DOCKER_BIN}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+    run_workcell_docker_client_command "${HOST_DOCKER_BIN}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
   fi
 
   if [[ -n "${PROFILE_LOCK_DIR}" ]] && [[ -d "${PROFILE_LOCK_DIR}" ]]; then
@@ -531,6 +553,21 @@ profile_image_marker_path() {
 
   validate_colima_profile_name "${profile}"
   printf '%s/workcell.image-ready\n' "$(profile_dir "${profile}")"
+}
+
+refresh_profile_state() {
+  local profile="$1"
+
+  PROFILE_PREEXISTED=0
+  PROFILE_MARKER_WORKSPACE=""
+
+  if [[ -d "$(profile_dir "${profile}")" ]]; then
+    PROFILE_PREEXISTED=1
+  fi
+
+  if [[ -f "$(profile_marker_path "${profile}")" ]]; then
+    PROFILE_MARKER_WORKSPACE="$(read_profile_marker_workspace "${profile}" || true)"
+  fi
 }
 
 profile_image_marker_value() {
@@ -1050,8 +1087,8 @@ capture_session_audit_state() {
     return 0
   fi
   mkdir -p "$(dirname "${SESSION_AUDIT_STATE_FILE}")"
-  if ! "${HOST_DOCKER_BIN}" cp "${container_name}:${SESSION_AUDIT_CONTAINER_FILE}" "${SESSION_AUDIT_STATE_FILE}" >/dev/null 2>&1; then
-    if ! "${HOST_DOCKER_BIN}" cp "${container_name}:/run/workcell/session-assurance" "${SESSION_AUDIT_STATE_FILE}" >/dev/null 2>&1; then
+  if ! run_workcell_docker_client_command "${HOST_DOCKER_BIN}" cp "${container_name}:${SESSION_AUDIT_CONTAINER_FILE}" "${SESSION_AUDIT_STATE_FILE}" >/dev/null 2>&1; then
+    if ! run_workcell_docker_client_command "${HOST_DOCKER_BIN}" cp "${container_name}:/run/workcell/session-assurance" "${SESSION_AUDIT_STATE_FILE}" >/dev/null 2>&1; then
       :
     fi
   fi
@@ -1087,7 +1124,7 @@ write_profile_image_marker() {
 }
 
 current_image_id() {
-  "${HOST_DOCKER_BIN}" image inspect "${IMAGE_TAG}" --format '{{.Id}}' 2>/dev/null || true
+  run_workcell_docker_client_command "${HOST_DOCKER_BIN}" image inspect "${IMAGE_TAG}" --format '{{.Id}}' 2>/dev/null || true
 }
 
 current_profile_image_id() {
@@ -1096,7 +1133,7 @@ current_profile_image_id() {
 
   socket_path="${COLIMA_STATE_ROOT}/${profile}/docker.sock"
   [[ -S "${socket_path}" ]] || return 0
-  DOCKER_HOST="unix://${socket_path}" "${HOST_DOCKER_BIN}" image inspect "${IMAGE_TAG}" --format '{{.Id}}' 2>/dev/null || true
+  run_workcell_docker_client_command env DOCKER_HOST="unix://${socket_path}" "${HOST_DOCKER_BIN}" image inspect "${IMAGE_TAG}" --format '{{.Id}}' 2>/dev/null || true
 }
 
 emit_command() {
@@ -1955,12 +1992,20 @@ validate_workspace() {
 run_clean_host_command() {
   local home="${REAL_HOME:-/}"
 
-  env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${home}" \
-    LC_ALL=C \
-    LANG=C \
-    "$@"
+  [[ "$#" -gt 0 ]] || return 0
+  if [[ ! -d "${home}" ]]; then
+    home="/"
+  fi
+
+  (
+    cd "${home}" &&
+      env -i \
+        PATH="${TRUSTED_HOST_PATH}" \
+        HOME="${home}" \
+        LC_ALL=C \
+        LANG=C \
+        "$@"
+  )
 }
 
 validate_mode_requirements() {
@@ -2365,6 +2410,39 @@ validate_colima_runtime_mounts() {
   ' "${lima_path}" "${workspace}" "${profile}"
 }
 
+workspace_runtime_probe_path() {
+  local workspace="$1"
+  local marker=""
+
+  if [[ -e "${workspace}/.git" ]]; then
+    printf '%s/.git\n' "${workspace}"
+    return 0
+  fi
+
+  for marker in AGENTS.md CLAUDE.md GEMINI.md; do
+    if [[ -e "${workspace}/${marker}" ]]; then
+      printf '%s/%s\n' "${workspace}" "${marker}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+validate_colima_runtime_workspace_view() {
+  local profile="$1"
+  local workspace="$2"
+  local probe_path=""
+
+  probe_path="$(workspace_runtime_probe_path "${workspace}" || true)"
+  [[ -n "${probe_path}" ]] || return 0
+
+  if ! run_host_colima ssh --profile "${profile}" -- test -e "${probe_path}" >/dev/null 2>&1; then
+    echo "Managed Colima profile ${profile} does not expose expected workspace content inside the VM: ${probe_path}" >&2
+    return 1
+  fi
+}
+
 validate_colima_profile_config() {
   local profile="$1"
   local workspace="$2"
@@ -2426,25 +2504,45 @@ validate_colima_profile() {
   status="$(run_host_colima status --profile "${profile}" 2>&1)"
   echo "${status}" | grep -q "Virtualization.Framework" || {
     echo "Colima profile ${profile} is not using Virtualization.Framework." >&2
-    exit 2
+    return 1
   }
   echo "${status}" | grep -q "mountType: virtiofs" || {
     echo "Colima profile ${profile} is not using virtiofs." >&2
-    exit 2
+    return 1
   }
   echo "${status}" | grep -q "runtime: docker" || {
     echo "Colima profile ${profile} is not using Docker runtime." >&2
-    exit 2
+    return 1
   }
 
-  validate_colima_profile_config "${profile}" "${workspace}" "${COLIMA_CPU}" "${COLIMA_MEMORY}" "${COLIMA_DISK}"
-  validate_colima_runtime_mounts "${profile}" "${workspace}"
+  if ! validate_colima_profile_config "${profile}" "${workspace}" "${COLIMA_CPU}" "${COLIMA_MEMORY}" "${COLIMA_DISK}"; then
+    return 1
+  fi
+  if ! validate_colima_runtime_mounts "${profile}" "${workspace}"; then
+    return 1
+  fi
+  validate_colima_runtime_workspace_view "${profile}" "${workspace}"
+}
+
+start_managed_profile() {
+  maybe_reap_stale_profile_processes "${COLIMA_PROFILE}"
+  run_command_with_debug_log colima-start \
+    run_host_colima start \
+    --profile "${COLIMA_PROFILE}" \
+    --vm-type vz \
+    --mount "${WORKSPACE}:w" \
+    --mount-type virtiofs \
+    --runtime docker \
+    --cpu "${COLIMA_CPU}" \
+    --memory "${COLIMA_MEMORY}" \
+    --disk "${COLIMA_DISK}"
+  PROFILE_RUNNING=1
 }
 
 validate_runtime_security_posture() {
   local security_options_json=""
 
-  security_options_json="$("${HOST_DOCKER_BIN}" info --format '{{json .SecurityOptions}}' 2>/dev/null || true)"
+  security_options_json="$(run_workcell_docker_client_command "${HOST_DOCKER_BIN}" info --format '{{json .SecurityOptions}}' 2>/dev/null || true)"
   [[ -n "${security_options_json}" ]] || {
     echo "Workcell could not inspect Docker security options for the managed runtime." >&2
     exit 2
@@ -3456,13 +3554,7 @@ if [[ -n "${WORKCELL_EGRESS_HELPER:-}" ]]; then
   exit 2
 fi
 
-if [[ -d "${PROFILE_DIR}" ]]; then
-  PROFILE_PREEXISTED=1
-fi
-
-if [[ -f "${PROFILE_MARKER}" ]]; then
-  PROFILE_MARKER_WORKSPACE="$(read_profile_marker_workspace "${COLIMA_PROFILE}" || true)"
-fi
+refresh_profile_state "${COLIMA_PROFILE}"
 
 if [[ "${AUTH_STATUS}" -eq 1 ]]; then
   print_injection_status
@@ -3526,6 +3618,8 @@ fail_fast_for_missing_gemini_auth "$@"
 if [[ "${DRY_RUN}" -eq 0 ]]; then
   export COLIMA_HOME="${COLIMA_STATE_ROOT}"
   acquire_profile_lock "${COLIMA_PROFILE}"
+  # Another launch may have created or repaired the profile while we waited.
+  refresh_profile_state "${COLIMA_PROFILE}"
 fi
 
 if [[ "${PROFILE_PREEXISTED}" -eq 1 ]] && [[ ! -f "${PROFILE_MARKER}" ]]; then
@@ -3728,22 +3822,19 @@ fi
 if [[ "${PROFILE_PREEXISTED}" -eq 1 ]]; then
   profile_config_path="${COLIMA_STATE_ROOT}/${COLIMA_PROFILE}/colima.yaml"
   lima_config_path="${COLIMA_STATE_ROOT}/_lima/colima-${COLIMA_PROFILE}/lima.yaml"
+  profile_status=""
   if [[ ! -f "${profile_config_path}" ]] ||
     ! validate_colima_profile_config "${COLIMA_PROFILE}" "${WORKSPACE}" "${COLIMA_CPU}" "${COLIMA_MEMORY}" "${COLIMA_DISK}"; then
-    echo "Refreshing managed Colima profile ${COLIMA_PROFILE} to apply the requested reviewed VM resources." >&2
-    stash_profile_audit_log "${COLIMA_PROFILE}"
-    run_host_colima delete --profile "${COLIMA_PROFILE}" --force >/dev/null 2>&1 || true
-    rm -rf "${PROFILE_DIR}"
-    PROFILE_WAS_REFRESHED=1
-    PROFILE_PREEXISTED=0
+    refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} to apply the requested reviewed VM resources."
   elif [[ ! -f "${lima_config_path}" ]] ||
     ! validate_colima_runtime_mounts "${COLIMA_PROFILE}" "${WORKSPACE}"; then
-    echo "Refreshing managed Colima profile ${COLIMA_PROFILE} to discard stale runtime mounts." >&2
-    stash_profile_audit_log "${COLIMA_PROFILE}"
-    run_host_colima delete --profile "${COLIMA_PROFILE}" --force >/dev/null 2>&1 || true
-    rm -rf "${PROFILE_DIR}"
-    PROFILE_WAS_REFRESHED=1
-    PROFILE_PREEXISTED=0
+    refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} to discard stale runtime mounts."
+  else
+    profile_status="$(colima_profile_status "${COLIMA_PROFILE}" || true)"
+    if [[ "${profile_status}" == "Running" ]] &&
+      ! validate_colima_runtime_workspace_view "${COLIMA_PROFILE}" "${WORKSPACE}"; then
+      refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} because the running VM is not exposing the expected workspace contents."
+    fi
   fi
 fi
 
@@ -3753,20 +3844,16 @@ fi
 
 maybe_fail_after_profile_refresh_for_tests
 
-maybe_reap_stale_profile_processes "${COLIMA_PROFILE}"
-run_command_with_debug_log colima-start \
-  run_host_colima start \
-  --profile "${COLIMA_PROFILE}" \
-  --vm-type vz \
-  --mount "${WORKSPACE}:w" \
-  --mount-type virtiofs \
-  --runtime docker \
-  --cpu "${COLIMA_CPU}" \
-  --memory "${COLIMA_MEMORY}" \
-  --disk "${COLIMA_DISK}"
-PROFILE_RUNNING=1
-
-validate_colima_profile "${COLIMA_PROFILE}" "${WORKSPACE}"
+start_managed_profile
+if ! validate_colima_profile "${COLIMA_PROFILE}" "${WORKSPACE}"; then
+  if [[ "${PROFILE_PREEXISTED}" -eq 1 ]] && [[ "${PROFILE_WAS_REFRESHED}" -eq 0 ]]; then
+    refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} because the started VM did not expose the expected workspace view."
+    start_managed_profile
+    validate_colima_profile "${COLIMA_PROFILE}" "${WORKSPACE}" || exit 2
+  else
+    exit 2
+  fi
+fi
 mkdir -p "${PROFILE_DIR}"
 restore_profile_audit_log "${COLIMA_PROFILE}"
 ensure_session_audit_state
@@ -3850,7 +3937,7 @@ fi
 append_launch_audit_record "${COLIMA_PROFILE}" "${EXECUTION_PATH}"
 
 DOCKER_STATUS=0
-"${HOST_DOCKER_BIN}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+run_workcell_docker_client_command "${HOST_DOCKER_BIN}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
 if [[ -n "${AUDIT_TRANSCRIPT_PATH}" ]]; then
   if [[ ! -t 0 ]] || [[ ! -t 1 ]]; then
     echo "Full transcript capture requires an interactive terminal." >&2
@@ -3863,7 +3950,7 @@ else
 fi
 capture_session_audit_state "${CONTAINER_NAME}"
 finalize_session_audit "${COLIMA_PROFILE}" "${EXECUTION_PATH}" "${DOCKER_STATUS}"
-"${HOST_DOCKER_BIN}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+run_workcell_docker_client_command "${HOST_DOCKER_BIN}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
 if [[ "${FINAL_SESSION_ASSURANCE:-}" == "lower-assurance-package-mutation" ]]; then
   echo "Workcell warning: this session ended lower-assurance because package-manager mutations ran as root inside the container." >&2
 fi


### PR DESCRIPTION
## Summary
- harden host/docker helper execution so provider session cleanup and egress updates do not inherit invalid host cwd state
- detect stale managed Colima workspace views and refresh managed profiles when the VM no longer exposes the expected mounted workspace contents
- expand invariant coverage for trusted Docker client handling, helper safe-cwd behavior, and the new mount-view validation path

## Provider Exercise
- `codex`: authenticated prepare + live probe passed; substantive no-push SWE session launched but repo inspection was blocked by the inner execution boundary, not by Workcell launch
- `gemini`: authenticated prepare + live probe passed after fixing stale profile/workspace visibility; substantive SWE session hit provider quota exhaustion after launch
- `claude`: container prepare path passed; live prompt reached provider auth gate and failed with `Not logged in · Please run /login` because no Claude auth is injected in this environment

## Validation
- `bash -n scripts/workcell scripts/lib/trusted-docker-client.sh scripts/colima-egress-allowlist.sh`
- `shellcheck -x scripts/workcell scripts/lib/trusted-docker-client.sh scripts/colima-egress-allowlist.sh`
- `./scripts/verify-invariants.sh`
- `./scripts/provider-e2e.sh --agent codex --workspace /tmp/workcell-run-codex`
- `./scripts/provider-e2e.sh --agent gemini --workspace /tmp/workcell-run-gemini`

## Notes
- The distinguished-engineer review found no remaining approval blockers in the final diff.
- The temp SWE workspaces had push disabled via `push.default=nothing` and invalid `origin` push URLs, and no GitHub auth or SSH forwarding was injected into the sessions.