### PR TITLE
feat: add local uninstall helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Initial adapters target:
 
 ```bash
 ./scripts/install.sh
+./scripts/uninstall.sh
 workcell --prepare --agent codex --workspace /path/to/repo
 workcell --prepare-only --agent codex --workspace /path/to/repo
 workcell --agent codex --workspace /path/to/repo
@@ -241,6 +242,10 @@ Common recovery paths:
 - Clean stale Workcell temp state:
   `workcell --gc`
   Alias: `workcell gc`
+- Reset all local Workcell install links, managed profiles, and Workcell-owned
+  host cache/temp state before testing a new build:
+  `./scripts/uninstall.sh`
+  Use `./scripts/uninstall.sh --dry-run` to preview removals.
 
 `--repair-profile` deletes only the conflicting derived Colima profile so
 Workcell can recreate it with reviewed mounts and policy. On `strict`, it also

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -312,6 +312,12 @@ Installed launcher path used by
 Installed man page path used by
 .BR scripts/install.sh .
 .TP
+.I scripts/uninstall.sh
+Repository helper that removes Workcell-owned install links, managed Colima
+profiles, Workcell cache roots, and known Workcell temp artifacts without
+touching
+.IR ~/.config/workcell .
+.TP
 .I ~/.config/workcell/injection-policy.toml
 Default optional host-side injection policy. If present, Workcell mounts
 credential sources read-only from their original host paths and stages the rest

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+readonly TRUSTED_HOST_PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+export PATH="${TRUSTED_HOST_PATH}"
+
+DRY_RUN=0
+
+usage() {
+  cat <<'EOF'
+Usage: uninstall.sh [--dry-run]
+
+Remove Workcell-owned local install links and managed host state:
+  - ~/.local/bin/workcell
+  - ~/.local/share/man/man1/workcell.1
+  - ~/.colima/workcell-* profiles, matching _lima dirs, and Workcell locks
+  - ~/Library/Caches/colima/workcell-host-inputs
+  - ~/Library/Caches/colima/workcell-shadow
+  - /tmp/workcell-docker.* and /tmp/workcell-*.log.*
+
+Preserved on purpose:
+  - ~/.config/workcell/*
+  - user-specified debug log and transcript files
+  - unrelated Colima profiles and caches
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unsupported uninstall option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+REAL_HOME="${HOME:-}"
+if [[ -z "${REAL_HOME}" ]]; then
+  REAL_HOME="$(
+    /usr/bin/python3 - <<'PY'
+import os
+import pwd
+
+print(pwd.getpwuid(os.getuid()).pw_dir)
+PY
+  )"
+fi
+REAL_HOME="$(
+  /usr/bin/python3 - "${REAL_HOME}" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(os.path.expanduser(sys.argv[1])))
+PY
+)"
+COLIMA_HOME="${REAL_HOME}/.colima"
+INSTALL_PATH="${REAL_HOME}/.local/bin/workcell"
+MAN_PATH="${REAL_HOME}/.local/share/man/man1/workcell.1"
+INJECTION_ROOT="${REAL_HOME}/Library/Caches/colima/workcell-host-inputs"
+SHADOW_ROOT="${REAL_HOME}/Library/Caches/colima/workcell-shadow"
+
+declare -a PROFILE_NAMES=()
+declare -a TEMP_ROOTS=()
+REMOVED_COUNT=0
+
+append_unique_value() {
+  local value="$1"
+  local existing=""
+
+  [[ -n "${value}" ]] || return 0
+  for existing in "${PROFILE_NAMES[@]}"; do
+    if [[ "${existing}" == "${value}" ]]; then
+      return 0
+    fi
+  done
+  PROFILE_NAMES+=("${value}")
+}
+
+append_unique_temp_root() {
+  local value="$1"
+  local existing=""
+
+  [[ -n "${value}" ]] || return 0
+  for existing in "${TEMP_ROOTS[@]}"; do
+    if [[ "${existing}" == "${value}" ]]; then
+      return 0
+    fi
+  done
+  TEMP_ROOTS+=("${value}")
+}
+
+validate_profile_name() {
+  local profile="$1"
+
+  [[ "${profile}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]] || return 1
+  case "${profile}" in
+    . | ..)
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+log_action() {
+  local action="$1"
+  local target="$2"
+
+  printf '%s %s\n' "${action}" "${target}"
+}
+
+remove_path() {
+  local target="$1"
+
+  [[ -e "${target}" || -L "${target}" ]] || return 0
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    log_action "Would remove" "${target}"
+  else
+    if [[ -d "${target}" ]] && [[ ! -L "${target}" ]]; then
+      chmod -R u+w "${target}" 2>/dev/null || true
+    fi
+    rm -rf "${target}"
+    log_action "Removed" "${target}"
+  fi
+  REMOVED_COUNT=$((REMOVED_COUNT + 1))
+}
+
+preserve_path() {
+  local label="$1"
+  local target="$2"
+
+  printf 'Preserved %s %s\n' "${label}" "${target}"
+}
+
+remove_workcell_symlink() {
+  local path="$1"
+  local expected_suffix="$2"
+  local label="$3"
+  local target=""
+
+  if [[ ! -L "${path}" ]]; then
+    if [[ -e "${path}" ]]; then
+      preserve_path "non-symlink ${label}" "${path}"
+    fi
+    return 0
+  fi
+
+  target="$(readlink "${path}" || true)"
+  case "${target}" in
+    */"${expected_suffix}")
+      remove_path "${path}"
+      ;;
+    *)
+      preserve_path "${label} symlink not owned by Workcell (${target})" "${path}"
+      ;;
+  esac
+}
+
+resolve_host_tool_optional() {
+  local name="$1"
+  shift
+  local candidate=""
+
+  for candidate in "$@"; do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+delete_managed_profile() {
+  local profile="$1"
+  local colima_bin="$2"
+  local profile_root="${COLIMA_HOME}/${profile}"
+  local lima_root="${COLIMA_HOME}/_lima/colima-${profile}"
+
+  validate_profile_name "${profile}" || {
+    preserve_path "unsafe profile name" "${profile}"
+    return 0
+  }
+
+  if [[ -n "${colima_bin}" ]] &&
+    { [[ -f "${profile_root}/colima.yaml" ]] || [[ -f "${lima_root}/lima.yaml" ]]; }; then
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+      log_action "Would run" "${colima_bin} delete --profile ${profile} --force"
+    else
+      env -i \
+        PATH="${TRUSTED_HOST_PATH}" \
+        HOME="${REAL_HOME}" \
+        COLIMA_HOME="${COLIMA_HOME}" \
+        "${colima_bin}" delete --profile "${profile}" --force >/dev/null 2>&1 || true
+    fi
+  fi
+
+  remove_path "${profile_root}"
+  remove_path "${lima_root}"
+  remove_path "${COLIMA_HOME}/locks/${profile}.lock"
+}
+
+collect_profiles() {
+  local candidate=""
+  local name=""
+
+  if [[ -d "${COLIMA_HOME}" ]]; then
+    while IFS= read -r -d '' candidate; do
+      name="$(basename "${candidate}")"
+      case "${name}" in
+        _lima | locks)
+          continue
+          ;;
+      esac
+      if [[ -f "${candidate}/workcell.managed" ]] || [[ "${name}" == workcell-* ]]; then
+        append_unique_value "${name}"
+      fi
+    done < <(find "${COLIMA_HOME}" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+
+    if [[ -d "${COLIMA_HOME}/_lima" ]]; then
+      while IFS= read -r -d '' candidate; do
+        name="$(basename "${candidate}")"
+        case "${name}" in
+          colima-workcell-*)
+            append_unique_value "${name#colima-}"
+            ;;
+        esac
+      done < <(find "${COLIMA_HOME}/_lima" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+    fi
+
+    if [[ -d "${COLIMA_HOME}/locks" ]]; then
+      while IFS= read -r -d '' candidate; do
+        name="$(basename "${candidate}")"
+        case "${name}" in
+          workcell-*.lock)
+            append_unique_value "${name%.lock}"
+            ;;
+        esac
+      done < <(find "${COLIMA_HOME}/locks" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+    fi
+  fi
+}
+
+cleanup_temp_root() {
+  local temp_root="$1"
+  local candidate=""
+  local -a patterns=(
+    "workcell-docker.*"
+    "workcell-audit-log.*"
+    "workcell-audit-merged.*"
+    "workcell-*.log.*"
+  )
+  local pattern=""
+  local nullglob_was_set=0
+
+  [[ -d "${temp_root}" ]] || return 0
+
+  if shopt -q nullglob; then
+    nullglob_was_set=1
+  fi
+  shopt -s nullglob
+
+  for pattern in "${patterns[@]}"; do
+    for candidate in "${temp_root}"/${pattern}; do
+      [[ -O "${candidate}" ]] || continue
+      remove_path "${candidate}"
+    done
+  done
+
+  if [[ "${nullglob_was_set}" -eq 0 ]]; then
+    shopt -u nullglob
+  fi
+}
+
+COLIMA_BIN="$(resolve_host_tool_optional colima /opt/homebrew/bin/colima /usr/local/bin/colima || true)"
+
+collect_profiles
+
+for profile in "${PROFILE_NAMES[@]}"; do
+  delete_managed_profile "${profile}" "${COLIMA_BIN}"
+done
+
+remove_workcell_symlink "${INSTALL_PATH}" "scripts/workcell" "launcher"
+remove_workcell_symlink "${MAN_PATH}" "man/workcell.1" "man page"
+
+remove_path "${INJECTION_ROOT}"
+remove_path "${SHADOW_ROOT}"
+
+append_unique_temp_root "/tmp"
+append_unique_temp_root "${TMPDIR:-}"
+for temp_root in "${TEMP_ROOTS[@]}"; do
+  cleanup_temp_root "${temp_root}"
+done
+
+if [[ "${REMOVED_COUNT}" -eq 0 ]]; then
+  echo "No Workcell-owned install links or managed host state found."
+else
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    echo "Dry run completed. No files were removed."
+  else
+    printf 'Removed %d Workcell path(s).\n' "${REMOVED_COUNT}"
+  fi
+fi
+
+echo "Preserved ~/.config/workcell and any user-specified debug/transcript files."

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -78,6 +78,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/generate-release-checksums.sh"
   "${ROOT_DIR}/scripts/generate-build-input-manifest.sh"
   "${ROOT_DIR}/scripts/install.sh"
+  "${ROOT_DIR}/scripts/uninstall.sh"
   "${ROOT_DIR}/scripts/pre-merge.sh"
   "${ROOT_DIR}/scripts/publish-github-release.sh"
   "${ROOT_DIR}/scripts/run-hosted-controls-audit.sh"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1044,6 +1044,41 @@ if ! grep -q 'Provider to run (required)' /tmp/workcell-installed-help.out; then
   exit 1
 fi
 
+mkdir -p "${INSTALL_VERIFY_HOME}/.config/workcell"
+printf 'version = 1\n' >"${INSTALL_VERIFY_HOME}/.config/workcell/injection-policy.toml"
+mkdir -p \
+  "${INSTALL_VERIFY_HOME}/.colima/workcell-verify-profile" \
+  "${INSTALL_VERIFY_HOME}/.colima/_lima/colima-workcell-verify-profile" \
+  "${INSTALL_VERIFY_HOME}/.colima/locks/workcell-verify-profile.lock" \
+  "${INSTALL_VERIFY_HOME}/Library/Caches/colima/workcell-host-inputs" \
+  "${INSTALL_VERIFY_HOME}/Library/Caches/colima/workcell-shadow"
+mkdir -p "${INSTALL_VERIFY_HOME}/Library/Caches/colima/workcell-shadow/shadow.readonly/git/.git/hooks"
+printf '#!/bin/sh\n' >"${INSTALL_VERIFY_HOME}/Library/Caches/colima/workcell-shadow/shadow.readonly/git/.git/hooks/pre-commit"
+chmod 0555 "${INSTALL_VERIFY_HOME}/Library/Caches/colima/workcell-shadow/shadow.readonly/git/.git/hooks"
+chmod 0444 "${INSTALL_VERIFY_HOME}/Library/Caches/colima/workcell-shadow/shadow.readonly/git/.git/hooks/pre-commit"
+printf '%s\n' "${ROOT_DIR}" >"${INSTALL_VERIFY_HOME}/.colima/workcell-verify-profile/workcell.managed"
+printf 'image_tag=workcell:local\nimage_id=sha256:test\nsource_date_epoch=0\n' >"${INSTALL_VERIFY_HOME}/.colima/workcell-verify-profile/workcell.image-ready"
+printf 'tmp\n' >"/tmp/workcell-uninstall-verify.log.$$"
+mkdir -p "/tmp/workcell-docker.verify-uninstall.$$"
+
+if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" "${ROOT_DIR}/scripts/uninstall.sh" >/tmp/workcell-uninstall.out 2>&1; then
+  echo "Expected scripts/uninstall.sh to succeed in a clean temporary HOME" >&2
+  cat /tmp/workcell-uninstall.out >&2
+  exit 1
+fi
+
+test ! -e "${INSTALL_VERIFY_HOME}/.local/bin/workcell"
+test ! -e "${INSTALL_VERIFY_HOME}/.local/share/man/man1/workcell.1"
+test ! -e "${INSTALL_VERIFY_HOME}/.colima/workcell-verify-profile"
+test ! -e "${INSTALL_VERIFY_HOME}/.colima/_lima/colima-workcell-verify-profile"
+test ! -e "${INSTALL_VERIFY_HOME}/.colima/locks/workcell-verify-profile.lock"
+test ! -e "${INSTALL_VERIFY_HOME}/Library/Caches/colima/workcell-host-inputs"
+test ! -e "${INSTALL_VERIFY_HOME}/Library/Caches/colima/workcell-shadow"
+test -e "${INSTALL_VERIFY_HOME}/.config/workcell/injection-policy.toml"
+test ! -e "/tmp/workcell-uninstall-verify.log.$$"
+test ! -e "/tmp/workcell-docker.verify-uninstall.$$"
+grep -q 'Preserved ~/.config/workcell and any user-specified debug/transcript files.' /tmp/workcell-uninstall.out
+
 INJECTION_POLICY_FIXTURE_ROOT="${BARRIER_VERIFY_ROOT}/injection-policy"
 INJECTION_STATE_ROOT="${INJECTION_POLICY_FIXTURE_ROOT}/xdg-state"
 mkdir -p "${INJECTION_POLICY_FIXTURE_ROOT}" "${INJECTION_STATE_ROOT}/workcell/tmp"


### PR DESCRIPTION
## Summary
- add a repository uninstall helper that removes Workcell-owned install links and managed local runtime state
- document the helper in the README and man page
- cover the helper in repo validation and install/uninstall invariant checks

## Validation
- ./scripts/validate-repo.sh
- ./scripts/verify-invariants.sh (local run blocked in a Colima boot path after validate passed)