### PR TITLE
Add explicit control-plane VCS lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ values are still treated as ordinary user-supplied provider argv and go
 through the same in-container denylist as raw `-- ...` arguments.
 `--prepare-only` is the prewarm path when you want to seed or refresh the
 reviewed runtime image without launching an agent session yet.
+`--allow-control-plane-vcs` is the narrow, explicitly acknowledged escape hatch
+for Workcell-maintainer workflows that need Git status, diff, or staging
+visibility on otherwise masked repo control-plane paths. It requires
+`--ack-control-plane-vcs`, keeps those paths mounted read-only, and surfaces
+the session as `workspace_control_plane=readonly-vcs` with
+`session_assurance_initial=lower-assurance-control-plane-vcs`.
 `--cache-profile off` is the default. `--cache-profile standard` opt-ins to a
 host-persisted non-secret cache plane for package/build tooling such as npm,
 pnpm, pip, uv, Poetry, Cargo registry/git, Go module/build cache, `ccache`,
@@ -276,6 +282,13 @@ instead. Claude and Gemini import repo-local `AGENTS.md` as the shared
 workspace layer and then append `CLAUDE.md` or `GEMINI.md` when present. When
 a workspace only ships `AGENTS.md`, Claude and Gemini still fall back to that
 imported file rather than silently dropping shared instructions.
+When those control-plane files or directories are tracked in git, the safe path
+masks them with a read-only snapshot from the git index so ordinary `git status`
+and `git add -A` flows do not get polluted by synthetic placeholder diffs.
+If you intentionally need to stage or diff real control-plane changes from
+inside Workcell, use `--allow-control-plane-vcs --ack-control-plane-vcs`; that
+switches the workspace posture to a visibly lower-assurance, read-only VCS lane
+rather than silently exposing the live control plane on the default path.
 By default, Codex rules stay linked to the immutable adapter baseline
 until the session is already downgraded by package mutation or the operator has
 selected `--agent-autonomy prompt`. If you explicitly opt into

--- a/adapters/claude/hooks/guard-bash.sh
+++ b/adapters/claude/hooks/guard-bash.sh
@@ -23,6 +23,15 @@ grep_deescaped_command() {
   printf '%s\n' "${command_lower_deescaped}" | grep -Eq -- "${pattern}"
 }
 
+control_plane_vcs_git_command_allowed() {
+  [[ "${WORKCELL_ALLOW_CONTROL_PLANE_VCS:-0}" == "1" ]] || return 1
+  if [[ "${command}" == *";"* ]] || [[ "${command}" == *"&&"* ]] || [[ "${command}" == *"||"* ]] || [[ "${command}" == *"|"* ]]; then
+    return 1
+  fi
+  grep_command '(^|[^[:alnum:]_./-])(git|/usr/bin/git|/usr/local/libexec/workcell/git|/usr/local/libexec/workcell/core/git|/usr/local/libexec/workcell/real/git)([^[:alnum:]_./-]|$)' || return 1
+  grep_command '(^|[[:space:]'"'"'";])((status|diff|add|restore|reset|rm)([[:space:]'"'"'";]|$))' || return 1
+}
+
 token_is_assignment_word() {
   local token="$1"
   [[ "${token}" =~ ^[[:alpha:]_][[:alnum:]_]*=.*$ ]]
@@ -353,11 +362,13 @@ if grep_command 'git.*push.*(main|master)([[:space:]'"'"'";|&]|$)'; then
   fail "Use a feature branch, not a direct push to main or master."
 fi
 
-if grep_command '(^|[[:space:]'"'"'";|&])([^[:space:]'"'"'";|&]+/)?(agents\.md|claude\.md|gemini\.md|\.mcp\.json)([[:space:]'"'"'";|&]|$)'; then
+if grep_command '(^|[[:space:]'"'"'";|&])([^[:space:]'"'"'";|&]+/)?(agents\.md|claude\.md|gemini\.md|\.mcp\.json)([[:space:]'"'"'";|&]|$)' &&
+  ! control_plane_vcs_git_command_allowed; then
   fail "Do not read or modify workspace control files from Bash."
 fi
 
-if grep_command '(^|[[:space:]'"'"'";|&])([^[:space:]'"'"'";|&]+/)?(\.claude|\.codex|\.gemini|\.cursor|\.idea|\.vscode|\.zed)(/|[[:space:]'"'"'";|&]|$)'; then
+if grep_command '(^|[[:space:]'"'"'";|&])([^[:space:]'"'"'";|&]+/)?(\.claude|\.codex|\.gemini|\.cursor|\.idea|\.vscode|\.zed)(/|[[:space:]'"'"'";|&]|$)' &&
+  ! control_plane_vcs_git_command_allowed; then
   fail "Do not read or modify workspace control directories from Bash."
 fi
 

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -194,12 +194,24 @@ Required with
 .B --allow-arbitrary-command
 to make lower-assurance boundary-debugging command passthrough explicit.
 .TP
+.B --ack-control-plane-vcs
+Required with
+.B --allow-control-plane-vcs
+to make the lower-assurance control-plane Git lane explicit.
+.TP
 .B --workspace PATH
 Select the workspace to mount inside the runtime. The default is the current
 directory.
 .TP
 .B --allow-nongit-workspace
 Allow a non-git workspace that contains an explicit agent marker file.
+.TP
+.B --allow-control-plane-vcs
+Allow read-only Git status, diff, and staging visibility for otherwise masked
+workspace control-plane paths. Workcell records this as
+.BR workspace_control_plane=readonly-vcs
+with
+.BR session_assurance_initial=lower-assurance-control-plane-vcs .
 .TP
 .B --allow-arbitrary-command
 Launch the runtime image with a direct container entrypoint after
@@ -381,6 +393,16 @@ first and then append
 or
 .BR GEMINI.md
 when present.
+When those control-plane files or directories are tracked in git, Workcell
+masks them with a read-only git-index snapshot so ordinary git status and
+staging flows are not polluted by placeholder diffs.
+If an operator intentionally needs to diff or stage live control-plane changes
+inside Workcell, they must opt into
+.B --allow-control-plane-vcs
+and
+.BR --ack-control-plane-vcs ,
+which exposes those workspace paths read-only and lowers the reported session
+assurance accordingly.
 By default, Codex rules stay linked to the immutable adapter baseline
 until prompt autonomy or package mutation has already downgraded the session.
 If you explicitly opt into

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "355dbb40d5ee57c8d0081481035aa6ade5d4362942a3c07a210411fdb80ab2b7"
+      "sha256": "f6235de1aac1b658b5c6f606906e698060ae9c0561a768ddb87e1f22c1c0be06"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts.py",
@@ -34,7 +34,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/claude/hooks/guard-bash.sh",
       "runtime_path": "/opt/workcell/adapters/claude/hooks/guard-bash.sh",
-      "sha256": "d8f1528b8d4eac4d73c362e6743d736f390ef70dc9c129a26f89e84d65695b72"
+      "sha256": "f5a6bc9d318fe59bef0024ad36c6c043fc782f93ca28b137dc1ae614741a0660"
     },
     {
       "kind": "adapter-baseline",
@@ -142,7 +142,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/entrypoint.sh",
       "runtime_path": "/usr/local/libexec/workcell/entrypoint.sh",
-      "sha256": "e3df912ebe11f103fcf4cf11befa1729764b3a887aeea2bd32ce1369b984f906"
+      "sha256": "733f2b5cebdf982eb82d4b00cc559fb235abbd6fb7396fe46f9e44041293f9f1"
     },
     {
       "kind": "runtime-control-plane",
@@ -172,7 +172,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-wrapper.sh",
-      "sha256": "1f12566c8b7d5c198f7658c7d375f45f6f490153aa4e94fa7c3626db1a6a4fd5"
+      "sha256": "5e48502930e49a4317e98d126f2f044c46cb304f4c6289a78c767946a5bddf8f"
     },
     {
       "kind": "runtime-control-plane",
@@ -184,7 +184,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/runtime-user.sh",
       "runtime_path": "/usr/local/libexec/workcell/runtime-user.sh",
-      "sha256": "4e76f9c782dda7e208d7d4fa0cb1f9d3042a5e98fcc24102726bd78df730d072"
+      "sha256": "f7dbd0bfcb13ac35353594aefe216f029e12084bf740ca20b6d16f784e343289"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/entrypoint.sh
+++ b/runtime/container/entrypoint.sh
@@ -30,6 +30,10 @@ emit_session_assurance_notice() {
 
   assurance="$(workcell_runtime_state_value WORKCELL_SESSION_ASSURANCE || true)"
   case "${assurance}" in
+    lower-assurance-control-plane-vcs)
+      echo "Workcell warning: this session intentionally exposed readonly workspace control-plane paths for Git VCS operations. Treat workspace control-plane contents as lower-assurance until container exit." >&2
+      export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1
+      ;;
     lower-assurance-package-mutation)
       echo "Workcell warning: this session previously ran package-manager mutations as root. In-container control-plane integrity is now lower-assurance until container exit." >&2
       export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -60,6 +60,10 @@ emit_session_assurance_notice() {
 
   assurance="$(workcell_runtime_state_value WORKCELL_SESSION_ASSURANCE || true)"
   case "${assurance}" in
+    lower-assurance-control-plane-vcs)
+      echo "Workcell warning: this session intentionally exposed readonly workspace control-plane paths for Git VCS operations. Treat workspace control-plane contents as lower-assurance until container exit." >&2
+      export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1
+      ;;
     lower-assurance-package-mutation)
       echo "Workcell warning: this session previously ran package-manager mutations as root. In-container control-plane integrity is now lower-assurance until container exit." >&2
       export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1

--- a/runtime/container/runtime-user.sh
+++ b/runtime/container/runtime-user.sh
@@ -219,12 +219,18 @@ workcell_write_runtime_state() {
   local profile=""
   local autonomy=""
   local session_assurance=""
+  local session_assurance_override=""
 
   mutability="$(workcell_runtime_mutability)"
   mode="${WORKCELL_MODE:-${CODEX_PROFILE:-strict}}"
   profile="${CODEX_PROFILE:-${mode}}"
   autonomy="${WORKCELL_AGENT_AUTONOMY:-yolo}"
-  session_assurance="$(workcell_container_assurance "${mutability}")"
+  session_assurance_override="${WORKCELL_SESSION_ASSURANCE_INITIAL:-}"
+  if [[ -n "${session_assurance_override}" ]]; then
+    session_assurance="${session_assurance_override}"
+  else
+    session_assurance="$(workcell_container_assurance "${mutability}")"
+  fi
   mkdir -p "${WORKCELL_RUNTIME_STATE_DIR}"
   chmod 0755 "${WORKCELL_RUNTIME_STATE_DIR}"
   workcell_write_readonly_state_file "${WORKCELL_RUNTIME_MUTABILITY_FILE}" "${mutability}"

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -3279,6 +3279,30 @@ EOF
       exit 1
     }
   grep -q "BLOCKED:" /tmp/claude-hook-control-plane.out
+  printf "%s" "{\"tool_input\":{\"command\":\"git add AGENTS.md\"}}" \
+    | /opt/workcell/adapters/claude/hooks/guard-bash.sh >/tmp/claude-hook-control-plane-git-default.out 2>&1 && {
+      echo "expected Claude guard hook to reject control-plane git staging without explicit opt-in" >&2
+      exit 1
+    }
+  grep -q "BLOCKED:" /tmp/claude-hook-control-plane-git-default.out
+  printf "%s" "{\"tool_input\":{\"command\":\"git add AGENTS.md\"}}" \
+    | WORKCELL_ALLOW_CONTROL_PLANE_VCS=1 /opt/workcell/adapters/claude/hooks/guard-bash.sh >/tmp/claude-hook-control-plane-git-allowed.out 2>&1 || {
+      echo "expected Claude guard hook to allow acknowledged control-plane git staging" >&2
+      cat /tmp/claude-hook-control-plane-git-allowed.out >&2
+      exit 1
+    }
+  printf "%s" "{\"tool_input\":{\"command\":\"cat AGENTS.md\"}}" \
+    | WORKCELL_ALLOW_CONTROL_PLANE_VCS=1 /opt/workcell/adapters/claude/hooks/guard-bash.sh >/tmp/claude-hook-control-plane-read-still-blocked.out 2>&1 && {
+      echo "expected Claude guard hook to keep plain control-plane reads blocked even with Git opt-in" >&2
+      exit 1
+    }
+  grep -q "BLOCKED:" /tmp/claude-hook-control-plane-read-still-blocked.out
+  printf "%s" "{\"tool_input\":{\"command\":\"git add AGENTS.md && cat AGENTS.md\"}}" \
+    | WORKCELL_ALLOW_CONTROL_PLANE_VCS=1 /opt/workcell/adapters/claude/hooks/guard-bash.sh >/tmp/claude-hook-control-plane-compound.out 2>&1 && {
+      echo "expected Claude guard hook to reject compound control-plane commands" >&2
+      exit 1
+    }
+  grep -q "BLOCKED:" /tmp/claude-hook-control-plane-compound.out
   printf "%s" "{\"tool_input\":{\"command\":\"cat ~/.claude/settings.json\"}}" \
     | /opt/workcell/adapters/claude/hooks/guard-bash.sh >/tmp/claude-hook-home-control-plane.out 2>&1 && {
       echo "expected Claude guard hook to reject home control-plane access" >&2

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2894,6 +2894,12 @@ fi
 grep -q "Option --agent-arg requires a value." /tmp/workcell-missing-agent-arg.out
 grep -q '^Usage: workcell' /tmp/workcell-missing-agent-arg.out
 
+if "${ROOT_DIR}/scripts/workcell" --agent codex --allow-control-plane-vcs --dry-run >/tmp/workcell-missing-control-plane-vcs-ack.out 2>&1; then
+  echo "Expected --allow-control-plane-vcs without acknowledgement to fail cleanly" >&2
+  exit 1
+fi
+grep -q "control-plane VCS mode requires --ack-control-plane-vcs." /tmp/workcell-missing-control-plane-vcs-ack.out
+
 if "${ROOT_DIR}/scripts/workcell" --dry-run >/tmp/workcell-missing-agent.out 2>&1; then
   echo "Expected workcell without --agent to fail cleanly" >&2
   exit 1
@@ -4185,6 +4191,63 @@ if echo "${MASK_DRY_RUN_OUTPUT}" | grep -q -- "/workspace/nested/AGENTS.md:ro"; 
   exit 1
 fi
 
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --mode strict \
+  --workspace "${MASK_VERIFY_WORKSPACE}" \
+  --allow-control-plane-vcs \
+  --ack-control-plane-vcs \
+  --dry-run >/tmp/workcell-control-plane-vcs.stdout 2>/tmp/workcell-control-plane-vcs.stderr; then
+  echo "Expected acknowledged control-plane VCS dry-run to succeed" >&2
+  cat /tmp/workcell-control-plane-vcs.stderr >&2
+  exit 1
+fi
+grep -q 'session_assurance_initial=lower-assurance-control-plane-vcs' /tmp/workcell-control-plane-vcs.stderr
+grep -q 'workspace_control_plane=readonly-vcs' /tmp/workcell-control-plane-vcs.stderr
+grep -q 'execution_path=lower-assurance-control-plane-vcs' /tmp/workcell-control-plane-vcs.stderr
+grep -q 'WORKCELL_ALLOW_CONTROL_PLANE_VCS=1' /tmp/workcell-control-plane-vcs.stdout
+grep -q -- "${MASK_VERIFY_WORKSPACE}/AGENTS.md:/workspace/AGENTS.md:ro" /tmp/workcell-control-plane-vcs.stdout
+
+MASK_SNAPSHOT_WORKSPACE="${BARRIER_VERIFY_ROOT}/mask-snapshot-workspace"
+mkdir -p "${MASK_SNAPSHOT_WORKSPACE}/.claude"
+git init -q "${MASK_SNAPSHOT_WORKSPACE}"
+git -C "${MASK_SNAPSHOT_WORKSPACE}" config user.name "Workcell Verify"
+git -C "${MASK_SNAPSHOT_WORKSPACE}" config user.email "workcell-verify@example.com"
+cat <<'EOF' >"${MASK_SNAPSHOT_WORKSPACE}/AGENTS.md"
+# committed instructions
+EOF
+cat <<'EOF' >"${MASK_SNAPSHOT_WORKSPACE}/.claude/settings.json"
+{"tracked": true}
+EOF
+git -C "${MASK_SNAPSHOT_WORKSPACE}" add AGENTS.md .claude/settings.json
+git -C "${MASK_SNAPSHOT_WORKSPACE}" commit -q -m init
+cat <<'EOF' >"${MASK_SNAPSHOT_WORKSPACE}/AGENTS.md"
+# modified instructions
+EOF
+rm -f "${MASK_SNAPSHOT_WORKSPACE}/.claude/settings.json"
+MASK_SNAPSHOT_OUTPUT="$("${ROOT_DIR}/scripts/workcell" \
+  --self-staging-probe \
+  codex \
+  "${MASK_SNAPSHOT_WORKSPACE}" \
+  "${AUTH_STATUS_ROOT}/policy.toml" \
+  strict \
+  0 \
+  1)"
+MASK_SNAPSHOT_ROOT="$(printf '%s\n' "${MASK_SNAPSHOT_OUTPUT}" | sed -n 's/^shadow_root=//p' | head -n1)"
+if [[ -z "${MASK_SNAPSHOT_ROOT}" ]] || [[ ! -d "${MASK_SNAPSHOT_ROOT}" ]]; then
+  echo "Expected staging probe to expose a shadow root for tracked control-plane snapshots" >&2
+  printf '%s\n' "${MASK_SNAPSHOT_OUTPUT}" >&2
+  exit 1
+fi
+grep -q '^# committed instructions$' "${MASK_SNAPSHOT_ROOT}/files/AGENTS.md"
+if grep -q '^# modified instructions$' "${MASK_SNAPSHOT_ROOT}/files/AGENTS.md"; then
+  echo "Expected masked root control files to reflect the git index snapshot, not modified workspace contents" >&2
+  exit 1
+fi
+grep -q '"tracked": true' "${MASK_SNAPSHOT_ROOT}/dirs/.claude/settings.json"
+chmod -R u+w "${MASK_SNAPSHOT_ROOT}" 2>/dev/null || true
+rm -rf "${MASK_SNAPSHOT_ROOT}"
+
 mkdir -p "${MASK_VERIFY_WORKSPACE}/symlinked"
 ln -s "${REAL_HOME}/.ssh/config" "${MASK_VERIFY_WORKSPACE}/symlinked/GEMINI.md"
 if "${ROOT_DIR}/scripts/workcell" --agent gemini --mode strict --workspace "${MASK_VERIFY_WORKSPACE}" --dry-run >/tmp/workcell-symlinked-doc.out 2>&1; then
@@ -4462,8 +4525,8 @@ if [[ "$(uname -s)" == "Darwin" ]] &&
       --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
       --allow-arbitrary-command \
       --ack-arbitrary-command \
-      -- /bin/bash -lc 'test -f /opt/workcell/host-injections/manifest.json && grep -q "Workcell masks workspace control files inside the boundary." /workspace/AGENTS.md && test ! -d /workspace/AGENTS.md'; then
-      echo "Expected live launcher run to stage an injection manifest and mount /workspace/AGENTS.md as a file" >&2
+      -- /bin/bash -lc 'test -f /opt/workcell/host-injections/manifest.json && grep -q "Repository Working Agreement" /workspace/AGENTS.md && test ! -d /workspace/AGENTS.md'; then
+      echo "Expected live launcher run to stage an injection manifest and mount the tracked workspace AGENTS.md snapshot as a file" >&2
       exit 1
     fi
     if [[ -x /opt/homebrew/bin/colima ]]; then

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -133,6 +133,7 @@ Options:
   --ack-arbitrary-command       Required with --allow-arbitrary-command
   --workspace PATH              Workspace to mount (default: current directory)
   --allow-nongit-workspace      Allow a non-git workspace only when it contains an explicit agent marker
+  --allow-control-plane-vcs     Allow readonly Git VCS visibility for masked workspace control-plane paths
   --allow-arbitrary-command     Launch the runtime image with a direct container entrypoint after --
   --colima-profile NAME         Override derived Colima profile name
   --vm-cpu COUNT                Colima VM CPU count (default: profile value)
@@ -141,6 +142,7 @@ Options:
   --rebuild                     Rebuild the runtime image before launch
   --dry-run                     Print the selected runtime command and exit
   -h, --help                    Show this help text
+  --ack-control-plane-vcs       Required with --allow-control-plane-vcs
 
 Workflows:
   First run:
@@ -931,11 +933,27 @@ codex_rules_effective_assurance_with_session_assurance() {
 }
 
 session_assurance_initial() {
+  if [[ "${ALLOW_CONTROL_PLANE_VCS}" -eq 1 ]]; then
+    printf 'lower-assurance-control-plane-vcs\n'
+    return 0
+  fi
   if [[ "${CACHE_PROFILE}" == "standard" ]]; then
     printf 'lower-assurance-persistent-cache\n'
     return 0
   fi
   container_assurance
+}
+
+workspace_control_plane_state() {
+  if [[ "${MODE}" == "breakglass" ]]; then
+    printf 'unmasked\n'
+    return 0
+  fi
+  if [[ "${ALLOW_CONTROL_PLANE_VCS}" -eq 1 ]]; then
+    printf 'readonly-vcs\n'
+    return 0
+  fi
+  printf 'masked\n'
 }
 
 session_assurance_final() {
@@ -996,6 +1014,7 @@ append_launch_audit_record() {
     "network_policy=${NETWORK_POLICY}" \
     "execution_path=${execution_path}" \
     "workspace=${WORKSPACE}" \
+    "workspace_control_plane=$(workspace_control_plane_state)" \
     "endpoints=${ALLOW_ENDPOINTS}" \
     "bootstrap_applied=${BOOTSTRAP_APPLIED}" \
     "bootstrap_endpoints=$([[ "${BOOTSTRAP_APPLIED}" -eq 1 ]] && printf '%s' "${BOOTSTRAP_ENDPOINTS}" || printf '')" \
@@ -1033,6 +1052,7 @@ append_exit_audit_record() {
     "agent=${AGENT}" \
     "workspace=${WORKSPACE}" \
     "execution_path=${execution_path}" \
+    "workspace_control_plane=$(workspace_control_plane_state)" \
     "exit_status=${exit_status}" \
     "cache_profile=${CACHE_PROFILE}" \
     "cache_assurance=$(cache_assurance)" \
@@ -1531,6 +1551,9 @@ build_recommended_command() {
   fi
   cmd+=(--workspace "${WORKSPACE}")
   [[ "${ALLOW_NONGIT_WORKSPACE}" -eq 1 ]] && cmd+=(--allow-nongit-workspace)
+  if [[ "${ALLOW_CONTROL_PLANE_VCS}" -eq 1 ]]; then
+    cmd+=(--allow-control-plane-vcs --ack-control-plane-vcs)
+  fi
   [[ "${COLIMA_PROFILE_EXPLICIT:-0}" -eq 1 ]] && [[ -n "${COLIMA_PROFILE}" ]] && cmd+=(--colima-profile "${COLIMA_PROFILE}")
   [[ -n "${VM_CPU_OVERRIDE}" ]] && cmd+=(--vm-cpu "${VM_CPU_OVERRIDE}")
   [[ -n "${VM_MEMORY_OVERRIDE}" ]] && cmd+=(--vm-memory "${VM_MEMORY_OVERRIDE}")
@@ -2013,8 +2036,10 @@ validate_mode_requirements() {
   local ack_breakglass="$2"
   local allow_arbitrary_command="$3"
   local ack_arbitrary_command="$4"
-  local rebuild="$5"
-  local prepare="$6"
+  local allow_control_plane_vcs="$5"
+  local ack_control_plane_vcs="$6"
+  local rebuild="$7"
+  local prepare="$8"
 
   if [[ "${mode}" == "breakglass" ]] && [[ "${ack_breakglass}" -eq 0 ]]; then
     echo "breakglass mode requires --ack-breakglass." >&2
@@ -2025,6 +2050,17 @@ validate_mode_requirements() {
   if [[ "${allow_arbitrary_command}" -eq 1 ]] && [[ "${ack_arbitrary_command}" -eq 0 ]]; then
     echo "arbitrary command mode requires --ack-arbitrary-command." >&2
     echo "Use it only for lower-assurance boundary debugging when you intentionally want to bypass provider command mediation." >&2
+    exit 2
+  fi
+
+  if [[ "${allow_control_plane_vcs}" -eq 1 ]] && [[ "${ack_control_plane_vcs}" -eq 0 ]]; then
+    echo "control-plane VCS mode requires --ack-control-plane-vcs." >&2
+    echo "Use it only when you intentionally want readonly Git visibility for masked workspace control-plane paths." >&2
+    exit 2
+  fi
+
+  if [[ "${mode}" == "breakglass" ]] && [[ "${allow_control_plane_vcs}" -eq 1 ]]; then
+    echo "--allow-control-plane-vcs is redundant in breakglass mode." >&2
     exit 2
   fi
 
@@ -2956,25 +2992,178 @@ register_workspace_import_root_mount() {
 }
 
 add_shadow_file_mount() {
-  local relative_path="$1"
+  local workspace="$1"
+  local relative_path="$2"
   local source="${CONTROL_PLANE_SHADOW_ROOT}/files/${relative_path}"
   local destination="/workspace/${relative_path}"
   local placeholder_message="# Workcell masks workspace control files inside the boundary."
 
   mkdir -p "$(dirname "${source}")"
-  printf '%s\n' "${placeholder_message}" >"${source}"
+  rm -f "${source}"
+  if git_index_has_path "${workspace}" "${relative_path}"; then
+    checkout_git_index_paths_to_prefix "${workspace}" "${CONTROL_PLANE_SHADOW_ROOT}/files/" "${relative_path}"
+  fi
+  if [[ -L "${source}" ]] || [[ ! -f "${source}" ]]; then
+    rm -f "${source}"
+    printf '%s\n' "${placeholder_message}" >"${source}"
+  fi
   chmod 0444 "${source}"
   register_shadow_mount "${source}" "${destination}"
 }
 
 add_shadow_dir_mount() {
-  local relative_path="$1"
+  local workspace="$1"
+  local relative_path="$2"
   local source="${CONTROL_PLANE_SHADOW_ROOT}/dirs/${relative_path}"
   local destination="/workspace/${relative_path}"
 
+  chmod -R u+w "${source}" 2>/dev/null || true
+  rm -rf "${source}"
   mkdir -p "${source}"
+  if git_index_populate_shadow_dir "${workspace}" "${relative_path}" "${source}"; then
+    replace_shadow_symlinks_with_placeholder "${source}"
+  fi
   chmod 0555 "${source}"
   register_shadow_mount "${source}" "${destination}"
+}
+
+workspace_is_git_worktree() {
+  local workspace="$1"
+
+  run_clean_host_command git -C "${workspace}" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+git_index_has_path() {
+  local workspace="$1"
+  local relative_path="$2"
+
+  workspace_is_git_worktree "${workspace}" || return 1
+  run_clean_host_command git -C "${workspace}" ls-files --error-unmatch -- "${relative_path}" >/dev/null 2>&1
+}
+
+checkout_git_index_paths_to_prefix() {
+  local workspace="$1"
+  local prefix="$2"
+  shift 2 || true
+
+  [[ "$#" -gt 0 ]] || return 1
+  workspace_is_git_worktree "${workspace}" || return 1
+  run_clean_host_command git -C "${workspace}" checkout-index --prefix="${prefix}" -- "$@"
+}
+
+git_index_populate_shadow_dir() {
+  local workspace="$1"
+  local relative_path="$2"
+  local source_root="$3"
+  local tracked_paths_file=""
+
+  workspace_is_git_worktree "${workspace}" || return 1
+  tracked_paths_file="$(mktemp "${CONTROL_PLANE_SHADOW_ROOT}/index-paths.XXXXXX")"
+  run_clean_host_command git -C "${workspace}" ls-files -z --cached -- "${relative_path}" >"${tracked_paths_file}"
+  if [[ ! -s "${tracked_paths_file}" ]]; then
+    rm -f "${tracked_paths_file}"
+    return 1
+  fi
+  run_clean_host_command git -C "${workspace}" checkout-index --stdin -z --prefix="${CONTROL_PLANE_SHADOW_ROOT}/dirs/" <"${tracked_paths_file}"
+  rm -f "${tracked_paths_file}"
+  [[ -d "${source_root}" ]]
+}
+
+replace_shadow_symlinks_with_placeholder() {
+  local source_root="$1"
+  local path=""
+  local placeholder_message="# Workcell masks workspace control files inside the boundary."
+
+  [[ -d "${source_root}" ]] || return 0
+  while IFS= read -r -d '' path; do
+    rm -f "${path}"
+    printf '%s\n' "${placeholder_message}" >"${path}"
+    chmod 0444 "${path}"
+  done < <(find "${source_root}" -type l -print0)
+  lock_tree_readonly "${source_root}"
+}
+
+git_index_control_plane_dir_roots() {
+  local workspace="$1"
+  local path=""
+
+  workspace_is_git_worktree "${workspace}" || return 0
+  while IFS= read -r -d '' path; do
+    case "${path}" in
+      .codex/*)
+        printf '%s\0' ".codex"
+        ;;
+      .claude/*)
+        printf '%s\0' ".claude"
+        ;;
+      .gemini/*)
+        printf '%s\0' ".gemini"
+        ;;
+      .vscode/*)
+        printf '%s\0' ".vscode"
+        ;;
+      .idea/*)
+        printf '%s\0' ".idea"
+        ;;
+      .cursor/*)
+        printf '%s\0' ".cursor"
+        ;;
+      .zed/*)
+        printf '%s\0' ".zed"
+        ;;
+      */.codex/*)
+        printf '%s\0' "${path%%/.codex/*}/.codex"
+        ;;
+      */.claude/*)
+        printf '%s\0' "${path%%/.claude/*}/.claude"
+        ;;
+      */.gemini/*)
+        printf '%s\0' "${path%%/.gemini/*}/.gemini"
+        ;;
+      */.vscode/*)
+        printf '%s\0' "${path%%/.vscode/*}/.vscode"
+        ;;
+      */.idea/*)
+        printf '%s\0' "${path%%/.idea/*}/.idea"
+        ;;
+      */.cursor/*)
+        printf '%s\0' "${path%%/.cursor/*}/.cursor"
+        ;;
+      */.zed/*)
+        printf '%s\0' "${path%%/.zed/*}/.zed"
+        ;;
+    esac
+  done < <(run_clean_host_command git -C "${workspace}" ls-files -z --cached)
+}
+
+register_workspace_control_plane_file_mount() {
+  local workspace="$1"
+  local relative_path="$2"
+  local source_path="${workspace}/${relative_path}"
+  local destination="/workspace/${relative_path}"
+
+  [[ -e "${source_path}" ]] || return 0
+  if [[ -L "${source_path}" ]]; then
+    echo "Workcell refuses symlinked workspace control files even with --allow-control-plane-vcs: ${source_path}" >&2
+    exit 2
+  fi
+  [[ -f "${source_path}" ]] || return 0
+  register_shadow_mount "${source_path}" "${destination}"
+}
+
+register_workspace_control_plane_dir_mount() {
+  local workspace="$1"
+  local relative_path="$2"
+  local source_path="${workspace}/${relative_path}"
+  local destination="/workspace/${relative_path}"
+
+  [[ -e "${source_path}" ]] || return 0
+  if [[ -L "${source_path}" ]]; then
+    echo "Workcell refuses symlinked workspace control directories even with --allow-control-plane-vcs: ${source_path}" >&2
+    exit 2
+  fi
+  [[ -d "${source_path}" ]] || return 0
+  register_shadow_mount "${source_path}" "${destination}"
 }
 
 copy_tree_without_symlinks() {
@@ -3095,7 +3284,7 @@ prepare_workspace_control_plane_shadow() {
       add_shadow_git_path_if_present "${workspace}" "${rel}"
     done
     if [[ -e "${workspace}/${git_rel}/worktrees" ]]; then
-      add_shadow_dir_mount "${git_rel}/worktrees"
+      add_shadow_dir_mount "${workspace}" "${git_rel}/worktrees"
     fi
     if [[ -d "${workspace}/${git_rel}/modules" ]]; then
       while IFS= read -r -d '' path; do
@@ -3111,7 +3300,7 @@ prepare_workspace_control_plane_shadow() {
       )
       while IFS= read -r -d '' path; do
         rel="${path#"${workspace}/"}"
-        add_shadow_dir_mount "${rel}"
+        add_shadow_dir_mount "${workspace}" "${rel}"
       done < <(
         find "${workspace}/${git_rel}/modules" \
           \( \( -type d -o -type l \) -name worktrees \) -print0
@@ -3121,20 +3310,38 @@ prepare_workspace_control_plane_shadow() {
     find "${workspace}" -type d -name .git -prune -print0
   )
 
-  while IFS= read -r -d '' path; do
-    rel="${path#"${workspace}/"}"
-    add_shadow_dir_mount "${rel}"
-  done < <(
-    find "${workspace}" \
-      \( -name .git -type d -prune \) -o \
-      \( \( -type d -o -type l \) \( -name .codex -o -name .claude -o -name .gemini -o -name .vscode -o -name .idea -o -name .cursor -o -name .zed \) \) -print0
-  )
+  if [[ "${ALLOW_CONTROL_PLANE_VCS}" -eq 1 ]]; then
+    while IFS= read -r -d '' path; do
+      rel="${path#"${workspace}/"}"
+      register_workspace_control_plane_dir_mount "${workspace}" "${rel}"
+    done < <(
+      find "${workspace}" \
+        \( -name .git -type d -prune \) -o \
+        \( \( -type d -o -type l \) \( -name .codex -o -name .claude -o -name .gemini -o -name .vscode -o -name .idea -o -name .cursor -o -name .zed \) \) -print0
+    )
 
-  for rel in AGENTS.md CLAUDE.md GEMINI.md .mcp.json; do
-    if [[ -f "${workspace}/${rel}" ]] || [[ -L "${workspace}/${rel}" ]]; then
-      add_shadow_file_mount "${rel}"
-    fi
-  done
+    for rel in AGENTS.md CLAUDE.md GEMINI.md .mcp.json; do
+      register_workspace_control_plane_file_mount "${workspace}" "${rel}"
+    done
+  else
+    while IFS= read -r -d '' path; do
+      rel="${path#"${workspace}/"}"
+      add_shadow_dir_mount "${workspace}" "${rel}"
+    done < <(
+      find "${workspace}" \
+        \( -name .git -type d -prune \) -o \
+        \( \( -type d -o -type l \) \( -name .codex -o -name .claude -o -name .gemini -o -name .vscode -o -name .idea -o -name .cursor -o -name .zed \) \) -print0
+    )
+    while IFS= read -r -d '' rel; do
+      add_shadow_dir_mount "${workspace}" "${rel}"
+    done < <(git_index_control_plane_dir_roots "${workspace}" | LC_ALL=C sort -zu)
+
+    for rel in AGENTS.md CLAUDE.md GEMINI.md .mcp.json; do
+      if [[ -f "${workspace}/${rel}" ]] || [[ -L "${workspace}/${rel}" ]] || git_index_has_path "${workspace}" "${rel}"; then
+        add_shadow_file_mount "${workspace}" "${rel}"
+      fi
+    done
+  fi
 
   add_workspace_import_file "${workspace}" "AGENTS.md"
   add_workspace_import_file "${workspace}" "CLAUDE.md"
@@ -3177,8 +3384,10 @@ GC=0
 AUTH_STATUS=0
 LOGS_KIND=""
 ALLOW_NONGIT_WORKSPACE=0
+ALLOW_CONTROL_PLANE_VCS=0
 ALLOW_ARBITRARY_COMMAND=0
 ACK_BREAKGLASS=0
+ACK_CONTROL_PLANE_VCS=0
 ACK_ARBITRARY_COMMAND=0
 TEST_FAIL_AFTER_PROFILE_REFRESH=0
 declare -a AGENT_ARGS=()
@@ -3190,6 +3399,8 @@ if [[ "${1:-}" == "--self-staging-probe" ]]; then
   WORKSPACE="${2:-}"
   INJECTION_POLICY="${3:-}"
   MODE="${4:-strict}"
+  ALLOW_CONTROL_PLANE_VCS="${5:-0}"
+  PRESERVE_STAGING_PROBE_ARTIFACTS="${6:-0}"
 
   [[ -n "${AGENT}" ]] || {
     echo "--self-staging-probe requires AGENT WORKSPACE INJECTION_POLICY [MODE]" >&2
@@ -3224,6 +3435,9 @@ if [[ "${1:-}" == "--self-staging-probe" ]]; then
   for ((i = 1; i < ${#WORKSPACE_IMPORT_MOUNTS[@]}; i += 2)); do
     printf 'workspace_import_mount=%s\n' "${WORKSPACE_IMPORT_MOUNTS[i]}"
   done
+  if [[ "${PRESERVE_STAGING_PROBE_ARTIFACTS}" == "1" ]]; then
+    trap - EXIT
+  fi
   exit 0
 fi
 
@@ -3356,12 +3570,20 @@ while [[ $# -gt 0 ]]; do
       ALLOW_NONGIT_WORKSPACE=1
       shift
       ;;
+    --allow-control-plane-vcs)
+      ALLOW_CONTROL_PLANE_VCS=1
+      shift
+      ;;
     --allow-arbitrary-command)
       ALLOW_ARBITRARY_COMMAND=1
       shift
       ;;
     --ack-breakglass)
       ACK_BREAKGLASS=1
+      shift
+      ;;
+    --ack-control-plane-vcs)
+      ACK_CONTROL_PLANE_VCS=1
       shift
       ;;
     --ack-arbitrary-command)
@@ -3531,7 +3753,7 @@ if [[ -n "${LOGS_KIND}" ]]; then
   show_requested_logs
   exit 0
 fi
-validate_mode_requirements "${MODE}" "${ACK_BREAKGLASS}" "${ALLOW_ARBITRARY_COMMAND}" "${ACK_ARBITRARY_COMMAND}" "${REBUILD}" "${PREPARE}"
+validate_mode_requirements "${MODE}" "${ACK_BREAKGLASS}" "${ALLOW_ARBITRARY_COMMAND}" "${ACK_ARBITRARY_COMMAND}" "${ALLOW_CONTROL_PLANE_VCS}" "${ACK_CONTROL_PLANE_VCS}" "${REBUILD}" "${PREPARE}"
 cleanup_stale_injection_bundles "$(default_injection_bundle_parent)"
 prepare_injection_bundle "${AGENT}" "${MODE}"
 
@@ -3695,6 +3917,9 @@ DOCKER_RUN_BASE=(
   -e WORKCELL_CODEX_RULES_MUTABILITY="${CODEX_RULES_MUTABILITY}"
   -e WORKCELL_CACHE_PROFILE="${CACHE_PROFILE}"
   -e WORKCELL_CONTAINER_MUTABILITY="${CONTAINER_MUTABILITY}"
+  -e WORKCELL_SESSION_ASSURANCE_INITIAL="$(session_assurance_initial)"
+  -e WORKCELL_ALLOW_CONTROL_PLANE_VCS="${ALLOW_CONTROL_PLANE_VCS}"
+  -e WORKCELL_WORKSPACE_CONTROL_PLANE_STATE="$(workspace_control_plane_state)"
   -e AGENT_UI="${UI}"
   -e CODEX_PROFILE="${MODE}"
   -e WORKCELL_MODE="${MODE}"
@@ -3753,6 +3978,8 @@ fi
 EXECUTION_PATH="managed-tier1"
 if [[ "${MODE}" == "breakglass" ]]; then
   EXECUTION_PATH="lower-assurance-breakglass"
+elif [[ "${ALLOW_CONTROL_PLANE_VCS}" -eq 1 ]]; then
+  EXECUTION_PATH="lower-assurance-control-plane-vcs"
 fi
 
 if [[ "${ALLOW_ARBITRARY_COMMAND}" -eq 1 ]]; then
@@ -3806,7 +4033,7 @@ if [[ -n "${INJECTION_POLICY_SHA256}" ]]; then
   printf 'injection_policy_sha256=%s credential_keys=%s ssh_injected=%s\n' \
     "${INJECTION_POLICY_SHA256}" "${INJECTION_CREDENTIAL_KEYS:-none}" "${INJECTION_SSH_ENABLED}" >&2
 fi
-printf 'workspace_control_plane=%s\n' "$([[ "${MODE}" == "breakglass" ]] && printf 'unmasked' || printf 'masked')" >&2
+printf 'workspace_control_plane=%s\n' "$(workspace_control_plane_state)" >&2
 printf 'network_policy=%s endpoints=%s\n' "${NETWORK_POLICY}" "${ALLOW_ENDPOINTS}" >&2
 printf 'execution_path=%s audit_log=%s\n' "${EXECUTION_PATH}" "$(profile_audit_log_path "${COLIMA_PROFILE}")" >&2
 


### PR DESCRIPTION
## Summary
- keep strict/build control-plane masking clean for ordinary git flows by mounting tracked control-plane paths from the git index snapshot
- add an explicit acknowledged readonly control-plane VCS lane for maintainers who need to diff or stage live control-plane changes
- extend invariant, smoke, manifest, and docs coverage for the new behavior

## Testing
- shellcheck -x scripts/workcell runtime/container/runtime-user.sh runtime/container/entrypoint.sh runtime/container/provider-wrapper.sh adapters/claude/hooks/guard-bash.sh scripts/verify-invariants.sh scripts/container-smoke.sh
- bash -n scripts/workcell runtime/container/runtime-user.sh runtime/container/entrypoint.sh runtime/container/provider-wrapper.sh adapters/claude/hooks/guard-bash.sh scripts/verify-invariants.sh scripts/container-smoke.sh
- mandoc -Tlint man/workcell.1
- ./scripts/verify-control-plane-manifest.sh
- targeted dry-run/probe validation for git-index control-plane snapshots and acknowledged readonly-vcs sessions
- targeted Claude guard validation for the narrow control-plane Git exception
- live build-mode arbitrary-command check confirming /workspace control-plane mounts use the tracked snapshot