### PR TITLE
Tighten runtime guard coverage and docs

### DIFF
--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -9,6 +9,15 @@ controls:
 - managed configuration
 - MCP policy/templates with no live defaults
 
+Workcell re-seeds these controls into the session-local Codex home on each
+launch. Use the host `workcell` launcher to select the runtime profile,
+autonomy mode, and injection policy; provider-native overrides that widen trust
+are blocked inside the container rather than delegated to repo-local state.
+
+For first-run and operator flows, start with the top-level `README.md` quick
+start. For the full control-plane mapping, see
+`docs/adapter-control-planes.md`.
+
 CLI is Tier 1 when it runs fully inside the bounded runtime.
 
 Codex app support is planned Tier 2 work. It is only valid once the app is

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -162,9 +162,16 @@ Assurance mapping within `strict`:
   the mapped runtime user inside the container: `SETUID`, `SETGID`
 - `readonly`: strongest managed lane for `strict`,
   `container_assurance=managed-readonly`
+- default managed autonomy: `autonomy_assurance=managed-yolo`
 - prompt autonomy: separate lower-assurance flag,
   `autonomy_assurance=lower-assurance-prompt-autonomy`
+- default configured Codex rules posture:
+  `codex_rules_assurance_configured=managed-immutable-rules`
+- default effective Codex rules posture:
+  `codex_rules_assurance_effective_initial=managed-immutable-rules`
 - session Codex rules mutability: explicit lower-assurance flag,
+  `codex_rules_assurance_configured=lower-assurance-session-rules`
+- prompt autonomy can also force the initial effective Codex rules posture to
   `codex_rules_assurance_effective_initial=lower-assurance-session-rules`
 - package mutation can also force this session-local copy for the remainder of
   an already-downgraded container

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -43,3 +43,7 @@ the GUI is wired as a client to the same bounded runtime.
 - `scripts/colima-egress-allowlist.sh`: apply or clear VM-level egress rules
 - `scripts/verify-invariants.sh`: run basic regression checks against the
   current runtime assumptions
+- `scripts/container-smoke.sh`: exercise generic container-local runtime and
+  provider-wrapper behavior under Docker
+- `scripts/validate-repo.sh`: run the local repository validation suite,
+  including shell, Python, Rust, manifest, mutation, and invariant checks

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -166,7 +166,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "1009fad1240009b44a434cb7b7aed6fa6b931cbaa53b04794dcf7e7d08562b45"
+      "sha256": "f287aaa2cf9a0eb75c7e5efdc2bed71441ebb91c2607161851be338bd11b5447"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -154,7 +154,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/home-control-plane.sh",
       "runtime_path": "/usr/local/libexec/workcell/home-control-plane.sh",
-      "sha256": "ef7db5a46f7bf21cd5cc2f7a3896e63f1711626905df9293902f3270311ff77e"
+      "sha256": "2e620ae880e20e455668d0ebf784c5c6a5a805bee67f850a4cf75043e1ea54a7"
     },
     {
       "kind": "runtime-control-plane",
@@ -166,7 +166,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "753d6af60025f2cfb14bec7a886a7c2eb42f9d7666b07c6166f98dbc87d97195"
+      "sha256": "1009fad1240009b44a434cb7b7aed6fa6b931cbaa53b04794dcf7e7d08562b45"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -1071,7 +1071,7 @@ seed_gemini_home() {
 
   workcell_verify_control_plane_prefix "${ADAPTER_ROOT}/gemini/"
   workcell_prepare_session_directory "${HOME}/.gemini" "Gemini home"
-  rm -f "${HOME}/.gemini/settings.json"
+  workcell_reset_session_target "${HOME}/.gemini/settings.json" "Gemini settings"
   cp "${ADAPTER_ROOT}/gemini/.gemini/settings.json" "${HOME}/.gemini/settings.json"
   chmod 0600 "${HOME}/.gemini/settings.json"
   if [[ "${WORKCELL_MODE:-strict}" == "breakglass" ]]; then

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -5,6 +5,9 @@ workcell_die() {
   exit 2
 }
 
+# Only the PID 1 entrypoint path may honor breakglass-style provider flags.
+# provider-wrapper.sh always exports WORKCELL_WRAPPER_CONTEXT=1 so nested
+# launches cannot re-enable those overrides after the entrypoint policy check.
 provider_policy_allows_breakglass() {
   [[ "${WORKCELL_WRAPPER_CONTEXT:-0}" != "1" ]] &&
     [[ "$$" -eq 1 ]] &&
@@ -141,6 +144,7 @@ reject_unsafe_claude_args() {
 reject_unsafe_gemini_args() {
   local expect_value=""
   local arg
+  local arg_lower=""
 
   provider_policy_allows_breakglass && return 0
 
@@ -155,8 +159,9 @@ reject_unsafe_gemini_args() {
       continue
     fi
 
-    case "${arg}" in
-      *dangerously* | *bypass*permission* | --sandbox | --sandbox=* | --add-dir | --add-dir=* | -y | --yolo)
+    arg_lower="${arg,,}"
+    case "${arg_lower}" in
+      --*dangerously* | --*bypass*permission* | --sandbox | --sandbox=* | --add-dir | --add-dir=* | -y | --yolo)
         workcell_die "Workcell blocked unsafe Gemini override: ${arg}"
         ;;
       --approval-mode)
@@ -169,6 +174,9 @@ reject_unsafe_gemini_args() {
   done
 }
 
+# entrypoint.sh validates the full provider command before launch. After that,
+# provider-wrapper.sh calls the per-provider reject helpers directly because it
+# has already fixed the launch target and only needs to re-check user argv.
 validate_command_args() {
   local expected_command="$1"
 

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1342,6 +1342,28 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ -x /bin/echo ]]; then
     exit 1
   fi
 
+  cat <<'EOF' >"${ROOT_DIR}/tmp/workcell-codex-env-check.sh"
+#!/bin/sh
+printf '{"aws":"%s","gh":"%s","ssh":"%s"}\n' \
+  "${AWS_SECRET_ACCESS_KEY-}" \
+  "${GITHUB_TOKEN-}" \
+  "${SSH_AUTH_SOCK-}"
+EOF
+  align_path_for_mapped_runtime_user "${ROOT_DIR}/tmp/workcell-codex-env-check.sh" 0755 0755
+
+  CODEX_SECRET_ENV="$(
+    run_entrypoint_with_autonomy_and_bind \
+      codex \
+      yolo \
+      "${ROOT_DIR}/tmp/workcell-codex-env-check.sh" \
+      /usr/local/libexec/workcell/real/codex \
+      codex --version
+  )"
+  if [[ "${CODEX_SECRET_ENV}" != '{"aws":"","gh":"","ssh":""}' ]]; then
+    echo "unexpected Codex provider environment exposure: ${CODEX_SECRET_ENV}" >&2
+    exit 1
+  fi
+
   CODEX_PROMPT_ARGS="$(
     run_entrypoint_with_autonomy_and_bind \
       codex \
@@ -1754,6 +1776,18 @@ if run_entrypoint gemini gemini --approval-mode default --version >/tmp/workcell
   exit 1
 fi
 grep -q "Workcell blocked Gemini autonomy override" /tmp/workcell-entrypoint-gemini-approval-mode.out
+
+if run_entrypoint gemini gemini --bypassPermissions --version >/tmp/workcell-entrypoint-gemini-bypass-camel.out 2>&1; then
+  echo "expected Workcell entrypoint to reject Gemini bypassPermissions-style overrides" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Gemini override" /tmp/workcell-entrypoint-gemini-bypass-camel.out
+
+if run_entrypoint gemini gemini --bypass-permissions --version >/tmp/workcell-entrypoint-gemini-bypass-kebab.out 2>&1; then
+  echo "expected Workcell entrypoint to reject Gemini bypass-permissions-style overrides" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Gemini override" /tmp/workcell-entrypoint-gemini-bypass-kebab.out
 
 if run_entrypoint gemini gemini -y --version >/tmp/workcell-entrypoint-gemini-yolo-short.out 2>&1; then
   echo "expected Workcell entrypoint to reject Gemini short yolo overrides outside host policy" >&2
@@ -3341,6 +3375,16 @@ run_container gemini bash -lc '
     exit 1
   fi
   grep -q "Workcell blocked unsafe Gemini override" /tmp/gemini-nested-yolo-short.out
+  if gemini --bypassPermissions --version >/tmp/gemini-nested-bypass-camel.out 2>&1; then
+    echo "expected nested Gemini invocation to reject bypassPermissions-style overrides" >&2
+    exit 1
+  fi
+  grep -q "Workcell blocked unsafe Gemini override" /tmp/gemini-nested-bypass-camel.out
+  if gemini --bypass-permissions --version >/tmp/gemini-nested-bypass-dashed.out 2>&1; then
+    echo "expected nested Gemini invocation to reject bypass-permissions-style overrides" >&2
+    exit 1
+  fi
+  grep -q "Workcell blocked unsafe Gemini override" /tmp/gemini-nested-bypass-dashed.out
   if gemini --add-dir=/state --version >/tmp/gemini-nested-add-dir.out 2>&1; then
     echo "expected nested Gemini invocation to reject add-dir overrides" >&2
     exit 1

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1352,7 +1352,10 @@ EOF
   align_path_for_mapped_runtime_user "${ROOT_DIR}/tmp/workcell-codex-env-check.sh" 0755 0755
 
   CODEX_SECRET_ENV="$(
-    run_entrypoint_with_autonomy_and_bind \
+    AWS_SECRET_ACCESS_KEY='verify-aws-secret' \
+      GITHUB_TOKEN='verify-gh-token' \
+      SSH_AUTH_SOCK='/tmp/workcell-secret-sock' \
+      run_entrypoint_with_autonomy_and_bind \
       codex \
       yolo \
       "${ROOT_DIR}/tmp/workcell-codex-env-check.sh" \

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -5597,7 +5597,7 @@ if ! rg -q 'trustedFolders\.json' "${ROOT_DIR}/runtime/container/home-control-pl
   echo "Expected Gemini home seeding to provision trustedFolders.json" >&2
   exit 1
 fi
-if ! rg -Fq 'workcell_reset_session_target "${HOME}/.gemini/settings.json" "Gemini settings"' "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
+if ! grep -Fq 'workcell_reset_session_target "${HOME}/.gemini/settings.json" "Gemini settings"' "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
   echo "Expected Gemini home seeding to reset settings.json through workcell_reset_session_target" >&2
   exit 1
 fi

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -4157,10 +4157,27 @@ printf '# nested agent marker\n' >"${MASK_VERIFY_WORKSPACE}/nested/AGENTS.md"
 printf '{\n  "masked": true\n}\n' >"${MASK_VERIFY_WORKSPACE}/nested/.claude/settings.json"
 git init -q "${MASK_VERIFY_WORKSPACE}/.alt"
 MASK_DRY_RUN_OUTPUT="$("${ROOT_DIR}/scripts/workcell" --agent codex --mode strict --workspace "${MASK_VERIFY_WORKSPACE}" --dry-run 2>/dev/null)"
+SECRET_DRY_RUN_OUTPUT="$(
+  AWS_SECRET_ACCESS_KEY='verify-aws-secret' \
+    GITHUB_TOKEN='verify-gh-token' \
+    SSH_AUTH_SOCK='/tmp/workcell-secret-sock' \
+    "${ROOT_DIR}/scripts/workcell" \
+    --agent codex \
+    --mode strict \
+    --workspace "${MASK_VERIFY_WORKSPACE}" \
+    --dry-run 2>/dev/null
+)"
 
 for forbidden in "docker.sock" "SSH_AUTH_SOCK" "/.ssh" "/.aws" "Library/Keychains" ".gnupg"; do
   if echo "${DRY_RUN_OUTPUT}" | grep -q "${forbidden}"; then
     echo "Unexpected host exposure in dry-run output: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+for forbidden in "verify-aws-secret" "verify-gh-token" "/tmp/workcell-secret-sock"; do
+  if echo "${SECRET_DRY_RUN_OUTPUT}" | grep -Fq -- "${forbidden}"; then
+    echo "Unexpected host secret forwarding in dry-run output: ${forbidden}" >&2
     exit 1
   fi
 done
@@ -5544,6 +5561,26 @@ if workcell_target_is_allowed '/state/agent-home/.gemini/trustedFolders.json'; t
   echo "Expected runtime manifest guard to reserve Gemini trustedFolders.json" >&2
   exit 1
 fi
+if workcell_target_is_allowed '/state/agent-home/.gemini/settings.json'; then
+  echo "Expected runtime manifest guard to reserve Gemini settings.json" >&2
+  exit 1
+fi
+if workcell_target_is_allowed '/state/agent-home/.ssh/config'; then
+  echo "Expected runtime manifest guard to reserve seeded SSH config paths" >&2
+  exit 1
+fi
+if ! workcell_target_is_allowed '/state/agent-home/workcell-benign-note.txt'; then
+  echo "Expected runtime manifest guard to allow benign session-local targets under /state/agent-home" >&2
+  exit 1
+fi
+if ! workcell_target_is_allowed '/state/injected/documents/org-policy.md'; then
+  echo "Expected runtime manifest guard to allow staged injected documents under /state/injected" >&2
+  exit 1
+fi
+if workcell_target_is_allowed '/workspace/not-allowed.txt'; then
+  echo "Expected runtime manifest guard to reject targets outside managed session roots" >&2
+  exit 1
+fi
 EOF
 } >"${GEMINI_AUTH_SELECTION_HARNESS}"
 /bin/bash "${GEMINI_AUTH_SELECTION_HARNESS}" >"${GEMINI_AUTH_SELECTION_STDOUT}" 2>"${GEMINI_AUTH_SELECTION_STDERR}" || {
@@ -5558,6 +5595,10 @@ rm -f "${GEMINI_AUTH_SELECTION_STDOUT}" "${GEMINI_AUTH_SELECTION_STDERR}"
 
 if ! rg -q 'trustedFolders\.json' "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
   echo "Expected Gemini home seeding to provision trustedFolders.json" >&2
+  exit 1
+fi
+if ! rg -Fq 'workcell_reset_session_target "${HOME}/.gemini/settings.json" "Gemini settings"' "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
+  echo "Expected Gemini home seeding to reset settings.json through workcell_reset_session_target" >&2
   exit 1
 fi
 

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -5597,7 +5597,7 @@ if ! rg -q 'trustedFolders\.json' "${ROOT_DIR}/runtime/container/home-control-pl
   echo "Expected Gemini home seeding to provision trustedFolders.json" >&2
   exit 1
 fi
-if ! grep -Fq 'workcell_reset_session_target "${HOME}/.gemini/settings.json" "Gemini settings"' "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
+if ! grep -Fq "workcell_reset_session_target \"\${HOME}/.gemini/settings.json\" \"Gemini settings\"" "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
   echo "Expected Gemini home seeding to reset settings.json through workcell_reset_session_target" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- harden Gemini argument rejection without broadening prompt-text false positives
- make Gemini settings seeding use the same session-target reset path as other control-plane writes
- expand runtime/Codex docs and add focused invariant and smoke coverage for target confinement and secret forwarding

## Testing
- ./scripts/validate-repo.sh
- ./scripts/container-smoke.sh