### PR TITLE
Add host-side publish-pr workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,10 @@ the runtime boundary or explicit security guarantees in the name of convenience.
 
 - Sign every commit. Do not create or rewrite commits in this repository
   without a verified signature from the maintainer identity.
+- Treat final GitHub publication as a host-side action. Prepare branch,
+  signed commit message, and PR metadata inside Workcell, then use
+  `workcell publish-pr` on the host rather than publishing directly from the
+  Tier 1 in-container session.
 - Do not treat provider config, prompt files, or rules as the sole security
   boundary.
 - Preserve the dedicated VM plus container boundary as the Tier 1 design for

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ The design explicitly avoids common boundary punctures:
   `/workspace` and `/state` paths is blocked, and mutable shebang scripts
   cannot point straight at protected real runtimes or loaders that target them
 - nested coding-agent CLI launches are blocked or mediated on the safe path,
-  and the public `node` surface blocks direct execution of the shipped provider
-  entrypoints, repackaged workspace copies of the shipped provider package
-  trees, and native addon loading instead of treating them as ordinary
-  workspace code
+  and the public `node` surface blocks direct execution of the shipped npm
+  provider entrypoints, repackaged workspace copies of the shipped npm
+  provider package trees, and native addon loading instead of treating them as
+  ordinary workspace code
 
 ## Scope
 
@@ -211,6 +211,12 @@ exists only for lower-assurance boundary debugging with
 is recorded in the host audit log as a downgraded path.
 The safe path requires self-contained git admin state inside the mounted
 workspace; linked worktrees with external gitdirs are rejected.
+The mounted workspace remains the durable source of truth across container
+exit, so agent-authored code already survives locally on the host. Final
+branch publication stays host-side: use `workcell publish-pr` to create or
+switch a feature branch, make a signed commit, push it, and open a draft PR
+with agent-prepared metadata instead of attempting final GitHub publication
+from inside the Tier 1 session.
 
 Common recovery paths:
 
@@ -219,6 +225,8 @@ Common recovery paths:
   Replace `codex` with `claude` or `gemini` for the corresponding provider.
 - Prewarm the runtime image without launching:
   `workcell --prepare-only --agent codex --workspace /path/to/repo`
+- Publish the current workspace snapshot to a draft PR on a feature branch:
+  `workcell publish-pr --workspace /path/to/repo --branch feature/name --title-file /tmp/pr-title.txt --body-file /tmp/pr-body.md --commit-message-file /tmp/commit-message.txt`
 - First launch with provider prompts enabled:
   `workcell --prepare --agent claude --agent-autonomy prompt --workspace /path/to/repo`
 - One-off provider flags without repeating the provider command:
@@ -309,7 +317,7 @@ claude = "/Users/example/.config/workcell/claude-extra.md"
 
 [credentials]
 codex_auth = "/Users/example/.codex/auth.json"
-claude_auth = "/Users/example/.config/claude-code/auth.json"
+claude_auth = "/Users/example/.claude/.credentials.json"
 claude_api_key = "/Users/example/.config/workcell/claude-api-key.txt"
 claude_mcp = "/Users/example/.config/workcell/claude-mcp.json"
 gemini_env = "/Users/example/.config/workcell/gemini.env"
@@ -410,6 +418,8 @@ Intentional non-goals for the safe path:
   lockfile graph
 - `scripts/verify-upstream-codex-release.sh`: re-verifies the pinned Codex
   release assets against OpenAI's published Sigstore bundle
+- `scripts/verify-upstream-claude-release.sh`: re-verifies the pinned Claude
+  native release assets against Anthropic's published release manifest
 - `scripts/verify-build-input-manifest.sh`: deterministic local verification
   for the release build-input manifest generator
 - `scripts/verify-coverage.sh`: `>=90%` numeric coverage for first-party Python

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -13,6 +13,10 @@ Workcell re-seeds these controls into the session-local Codex home on each
 launch. Use the host `workcell` launcher to select the runtime profile,
 autonomy mode, and injection policy; provider-native overrides that widen trust
 are blocked inside the container rather than delegated to repo-local state.
+Final branch publication remains a host-side flow: the in-container Codex
+session should prepare branch, commit, and PR metadata, then the operator uses
+`workcell publish-pr` on the host to perform the signed commit, push, and PR
+creation.
 
 For first-run and operator flows, start with the top-level `README.md` quick
 start. For the full control-plane mapping, see

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "f6235de1aac1b658b5c6f606906e698060ae9c0561a768ddb87e1f22c1c0be06"
+      "sha256": "3ebda8623a836d7092d1caf1a231ef998e5c3fd3cfb3371c8dfa6ad612be9b1d"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts.py",

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -4225,6 +4225,107 @@ grep -q 'execution_path=lower-assurance-control-plane-vcs' /tmp/workcell-control
 grep -q 'WORKCELL_ALLOW_CONTROL_PLANE_VCS=1' /tmp/workcell-control-plane-vcs.stdout
 grep -q -- "${MASK_VERIFY_WORKSPACE}/AGENTS.md:/workspace/AGENTS.md:ro" /tmp/workcell-control-plane-vcs.stdout
 
+PUBLISH_PR_FIXTURE="${BARRIER_VERIFY_ROOT}/publish-pr-fixture"
+mkdir -p "${PUBLISH_PR_FIXTURE}"
+git init -q "${PUBLISH_PR_FIXTURE}"
+git -C "${PUBLISH_PR_FIXTURE}" config user.name "Workcell Verify"
+git -C "${PUBLISH_PR_FIXTURE}" config user.email "workcell-verify@example.com"
+git -C "${PUBLISH_PR_FIXTURE}" remote add origin https://github.com/example/workcell-publish-fixture.git
+printf 'base\n' >"${PUBLISH_PR_FIXTURE}/tracked.txt"
+git -C "${PUBLISH_PR_FIXTURE}" add tracked.txt
+git -C "${PUBLISH_PR_FIXTURE}" commit -q -m init
+printf 'worktree\n' >"${PUBLISH_PR_FIXTURE}/tracked.txt"
+cat <<'EOF' >"${PUBLISH_PR_FIXTURE}/pr-title.txt"
+Verify PR title
+EOF
+cat <<'EOF' >"${PUBLISH_PR_FIXTURE}/pr-body.md"
+Verify PR body
+EOF
+cat <<'EOF' >"${PUBLISH_PR_FIXTURE}/commit-message.txt"
+Verify publish-pr commit
+
+- include staged workspace changes
+EOF
+PUBLISH_PR_DRY_RUN="$("${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${PUBLISH_PR_FIXTURE}" \
+  --branch feature/publish-fixture \
+  --title-file "${PUBLISH_PR_FIXTURE}/pr-title.txt" \
+  --body-file "${PUBLISH_PR_FIXTURE}/pr-body.md" \
+  --commit-message-file "${PUBLISH_PR_FIXTURE}/commit-message.txt" \
+  --snapshot worktree \
+  --dry-run)"
+grep -q '^publish_snapshot=worktree$' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q '^publish_branch=feature/publish-fixture$' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q -- 'switch -c feature/publish-fixture' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q -- ' add -A ' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q -- ' commit -S -F ' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q -- ' push -u origin feature/publish-fixture ' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q -- 'gh pr create --base main --head feature/publish-fixture --title Verify\\ PR\\ title --draft --body-file' <<<"${PUBLISH_PR_DRY_RUN}"
+
+git -C "${PUBLISH_PR_FIXTURE}" add tracked.txt
+PUBLISH_PR_INDEX_DRY_RUN="$("${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${PUBLISH_PR_FIXTURE}" \
+  --branch feature/publish-index \
+  --title "Index publish title" \
+  --commit-message "Index publish commit" \
+  --snapshot index \
+  --dry-run)"
+grep -q '^publish_snapshot=index$' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"
+if grep -q -- ' add -A ' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"; then
+  echo "publish-pr index snapshot should not auto-stage the worktree" >&2
+  exit 1
+fi
+grep -q -- 'switch -c feature/publish-index' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"
+grep -q -- ' commit -S -F ' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"
+
+if "${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${PUBLISH_PR_FIXTURE}" \
+  --branch main \
+  --title "Bad branch" \
+  --commit-message "Bad branch commit" \
+  --dry-run >/tmp/workcell-publish-pr-main.out 2>&1; then
+  echo "Expected publish-pr to reject the default branch" >&2
+  exit 1
+fi
+grep -q 'publish-pr refuses the default branch' /tmp/workcell-publish-pr-main.out
+
+if "${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${PUBLISH_PR_FIXTURE}" \
+  --branch topic.lock \
+  --title "Bad branch format" \
+  --commit-message "Bad branch format commit" \
+  --dry-run >/tmp/workcell-publish-pr-invalid-branch.out 2>&1; then
+  echo "Expected publish-pr to reject an invalid branch name" >&2
+  exit 1
+fi
+grep -q 'Invalid publish branch name: topic.lock' /tmp/workcell-publish-pr-invalid-branch.out
+
+if "${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${PUBLISH_PR_FIXTURE}" \
+  --branch feature/publish-invalid-base \
+  --base topic.lock \
+  --title "Bad base branch format" \
+  --commit-message "Bad base branch format commit" \
+  --dry-run >/tmp/workcell-publish-pr-invalid-base.out 2>&1; then
+  echo "Expected publish-pr to reject an invalid base branch name" >&2
+  exit 1
+fi
+grep -q 'Invalid publish base branch name: topic.lock' /tmp/workcell-publish-pr-invalid-base.out
+
+git -C "${PUBLISH_PR_FIXTURE}" reset -q --hard HEAD
+git -C "${PUBLISH_PR_FIXTURE}" clean -fdq
+if "${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${PUBLISH_PR_FIXTURE}" \
+  --branch feature/publish-noop \
+  --title "No changes" \
+  --commit-message "No changes commit" \
+  --snapshot worktree \
+  --dry-run >/tmp/workcell-publish-pr-noop.out 2>&1; then
+  echo "Expected publish-pr to reject an empty worktree snapshot" >&2
+  exit 1
+fi
+grep -q 'publish-pr found no workspace changes to publish' /tmp/workcell-publish-pr-noop.out
+
 MASK_SNAPSHOT_WORKSPACE="${BARRIER_VERIFY_ROOT}/mask-snapshot-workspace"
 mkdir -p "${MASK_SNAPSHOT_WORKSPACE}/.claude"
 git init -q "${MASK_SNAPSHOT_WORKSPACE}"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -100,6 +100,7 @@ PROFILE_LOCK_DIR=""
 usage() {
   cat <<'EOF'
 Usage: workcell [options] [-- provider-args...]
+       workcell publish-pr [options]
 
 Options:
   --agent codex|claude|gemini   Provider to run (required)
@@ -164,6 +165,9 @@ Workflows:
     workcell doctor --agent codex --workspace /path/to/repo
     workcell logs debug --colima-profile workcell-...
     workcell auth-status --agent codex --workspace /path/to/repo
+    workcell publish-pr --workspace /path/to/repo --branch feature/name \
+      --title-file /path/to/pr-title.txt --body-file /path/to/pr-body.md \
+      --commit-message-file /path/to/commit-message.txt
     workcell gc
 
 Workcell launches the selected provider directly inside the bounded runtime.
@@ -1242,6 +1246,419 @@ resolve_existing_directory_or_die() {
   fi
 
   printf '%s\n' "${resolved_path}"
+}
+
+publish_pr_usage() {
+  cat <<'EOF'
+Usage: workcell publish-pr [options]
+
+Options:
+  --workspace PATH              Workspace to publish (default: current directory)
+  --branch NAME                 Feature branch to create or switch to (required)
+  --base NAME                   Base branch for the PR (default: main)
+  --snapshot index|worktree     Publish the current index or stage the worktree (default: worktree)
+  --title TEXT                  PR title
+  --title-file PATH             Read the PR title from PATH
+  --body TEXT                   PR body (default: empty)
+  --body-file PATH              Read the PR body from PATH
+  --commit-message TEXT         Commit message to sign and publish
+  --commit-message-file PATH    Read the commit message from PATH
+  --ready                       Create a ready PR instead of a draft PR
+  --dry-run                     Print the planned host commands and exit
+  -h, --help                    Show this help text
+
+Notes:
+  - publish-pr runs on the host, not inside the Workcell container.
+  - It uses the host Git and GitHub CLI configuration so maintainer signing
+    and publication stay outside the Tier 1 container boundary.
+  - The default snapshot is worktree, which stages the current tracked and
+    untracked workspace changes with `git add -A` before committing.
+EOF
+}
+
+resolve_existing_file_or_die() {
+  local raw_path="$1"
+  local label="$2"
+  local resolved_path=""
+
+  resolved_path="$(resolve_host_path "${raw_path}")"
+  if [[ ! -f "${resolved_path}" ]]; then
+    echo "${label} file does not exist: ${raw_path}" >&2
+    exit 2
+  fi
+
+  printf '%s\n' "${resolved_path}"
+}
+
+run_clean_host_command_in_dir() {
+  local dir="$1"
+  local home="${REAL_HOME:-/}"
+
+  shift
+  [[ "$#" -gt 0 ]] || return 0
+  if [[ ! -d "${dir}" ]]; then
+    echo "Missing host working directory: ${dir}" >&2
+    exit 2
+  fi
+  if [[ ! -d "${home}" ]]; then
+    home="/"
+  fi
+
+  (
+    cd "${dir}" &&
+      env -i \
+        PATH="${TRUSTED_HOST_PATH}" \
+        HOME="${home}" \
+        LC_ALL=C \
+        LANG=C \
+        "$@"
+  )
+}
+
+run_publish_host_command_in_dir() {
+  local dir="$1"
+  local home="${REAL_HOME:-/}"
+  local -a env_args=()
+
+  shift
+  [[ "$#" -gt 0 ]] || return 0
+  if [[ ! -d "${dir}" ]]; then
+    echo "Missing host working directory: ${dir}" >&2
+    exit 2
+  fi
+  if [[ ! -d "${home}" ]]; then
+    home="/"
+  fi
+
+  env_args=(
+    PATH="${TRUSTED_HOST_PATH}"
+    HOME="${home}"
+    LC_ALL=C
+    LANG=C
+  )
+
+  [[ -n "${TERM:-}" ]] && env_args+=("TERM=${TERM}")
+  [[ -n "${GPG_TTY:-}" ]] && env_args+=("GPG_TTY=${GPG_TTY}")
+  [[ -n "${GNUPGHOME:-}" ]] && env_args+=("GNUPGHOME=${GNUPGHOME}")
+  [[ -n "${SSH_AUTH_SOCK:-}" ]] && env_args+=("SSH_AUTH_SOCK=${SSH_AUTH_SOCK}")
+  [[ -n "${SSH_AGENT_PID:-}" ]] && env_args+=("SSH_AGENT_PID=${SSH_AGENT_PID}")
+  [[ -n "${SSH_ASKPASS:-}" ]] && env_args+=("SSH_ASKPASS=${SSH_ASKPASS}")
+  [[ -n "${GIT_ASKPASS:-}" ]] && env_args+=("GIT_ASKPASS=${GIT_ASKPASS}")
+  [[ -n "${XDG_CONFIG_HOME:-}" ]] && env_args+=("XDG_CONFIG_HOME=${XDG_CONFIG_HOME}")
+  [[ -n "${XDG_STATE_HOME:-}" ]] && env_args+=("XDG_STATE_HOME=${XDG_STATE_HOME}")
+  [[ -n "${XDG_CACHE_HOME:-}" ]] && env_args+=("XDG_CACHE_HOME=${XDG_CACHE_HOME}")
+  [[ -n "${XDG_DATA_HOME:-}" ]] && env_args+=("XDG_DATA_HOME=${XDG_DATA_HOME}")
+  [[ -n "${XDG_RUNTIME_DIR:-}" ]] && env_args+=("XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}")
+  [[ -n "${GH_TOKEN:-}" ]] && env_args+=("GH_TOKEN=${GH_TOKEN}")
+  [[ -n "${GITHUB_TOKEN:-}" ]] && env_args+=("GITHUB_TOKEN=${GITHUB_TOKEN}")
+  [[ -n "${GH_HOST:-}" ]] && env_args+=("GH_HOST=${GH_HOST}")
+  [[ -n "${GH_CONFIG_DIR:-}" ]] && env_args+=("GH_CONFIG_DIR=${GH_CONFIG_DIR}")
+
+  (
+    cd "${dir}" &&
+      env -i \
+        "${env_args[@]}" \
+        "$@"
+  )
+}
+
+validate_publish_snapshot_name() {
+  case "$1" in
+    index | worktree) ;;
+    *)
+      echo "Unsupported publish snapshot: $1" >&2
+      echo "Use --snapshot index or --snapshot worktree." >&2
+      exit 2
+      ;;
+  esac
+}
+
+validate_publish_branch_name() {
+  local branch="$1"
+
+  if [[ -z "${branch}" ]]; then
+    echo "publish-pr requires --branch." >&2
+    exit 2
+  fi
+  if [[ "${branch}" == "main" ]] || [[ "${branch}" == "master" ]]; then
+    echo "publish-pr refuses the default branch. Use a feature branch instead." >&2
+    exit 2
+  fi
+  if ! "${HOST_GIT_BIN}" check-ref-format --branch "${branch}" >/dev/null 2>&1; then
+    echo "Invalid publish branch name: ${branch}" >&2
+    exit 2
+  fi
+}
+
+validate_publish_base_name() {
+  local base="$1"
+
+  if [[ -z "${base}" ]]; then
+    echo "publish-pr requires --base." >&2
+    exit 2
+  fi
+  if ! "${HOST_GIT_BIN}" check-ref-format --branch "${base}" >/dev/null 2>&1; then
+    echo "Invalid publish base branch name: ${base}" >&2
+    exit 2
+  fi
+}
+
+publish_pr_load_text_arg() {
+  local inline_value="$1"
+  local file_value="$2"
+  local label="$3"
+  local required="$4"
+  local resolved_file=""
+
+  if [[ -n "${inline_value}" ]] && [[ -n "${file_value}" ]]; then
+    echo "Use only one of --${label} or --${label}-file." >&2
+    exit 2
+  fi
+
+  if [[ -n "${file_value}" ]]; then
+    resolved_file="$(resolve_existing_file_or_die "${file_value}" "${label}")"
+    cat "${resolved_file}"
+    return 0
+  fi
+
+  if [[ -n "${inline_value}" ]]; then
+    printf '%s' "${inline_value}"
+    return 0
+  fi
+
+  if [[ "${required}" == "1" ]]; then
+    echo "publish-pr requires --${label} or --${label}-file." >&2
+    exit 2
+  fi
+
+  printf ''
+}
+
+publish_pr_branch_exists() {
+  local workspace="$1"
+  local branch="$2"
+
+  run_clean_host_command_in_dir "${workspace}" "${HOST_GIT_BIN}" show-ref --verify --quiet "refs/heads/${branch}"
+}
+
+publish_pr_current_branch() {
+  local workspace="$1"
+
+  run_clean_host_command_in_dir "${workspace}" "${HOST_GIT_BIN}" branch --show-current
+}
+
+publish_pr_has_remote_origin() {
+  local workspace="$1"
+
+  run_clean_host_command_in_dir "${workspace}" "${HOST_GIT_BIN}" remote get-url origin >/dev/null 2>&1
+}
+
+publish_pr_has_worktree_changes() {
+  local workspace="$1"
+
+  [[ -n "$(run_clean_host_command_in_dir "${workspace}" "${HOST_GIT_BIN}" status --short --untracked-files=all)" ]]
+}
+
+publish_pr_has_staged_changes() {
+  local workspace="$1"
+
+  ! run_clean_host_command_in_dir "${workspace}" "${HOST_GIT_BIN}" diff --cached --quiet --exit-code
+}
+
+publish_pr_main() {
+  local workspace="${PWD}"
+  local branch=""
+  local base="main"
+  local snapshot="worktree"
+  local title=""
+  local title_file=""
+  local body=""
+  local body_file=""
+  local commit_message=""
+  local commit_message_file=""
+  local ready=0
+  local dry_run=0
+  local resolved_workspace=""
+  local current_branch=""
+  local title_text=""
+  local body_text=""
+  local commit_message_text=""
+  local resolved_commit_message_file=""
+  local pr_url=""
+  local -a cleanup_files=()
+  local -a branch_cmd=()
+  local -a commit_cmd=()
+  local -a push_cmd=()
+  local -a pr_cmd=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --workspace)
+        workspace="$(option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      --branch)
+        branch="$(option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      --base)
+        base="$(option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      --snapshot)
+        snapshot="$(option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      --title)
+        title="$(raw_option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      --title-file)
+        title_file="$(option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      --body)
+        body="$(raw_option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      --body-file)
+        body_file="$(option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      --commit-message)
+        commit_message="$(raw_option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      --commit-message-file)
+        commit_message_file="$(option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      --ready)
+        ready=1
+        shift
+        ;;
+      --dry-run)
+        dry_run=1
+        shift
+        ;;
+      -h | --help)
+        publish_pr_usage
+        exit 0
+        ;;
+      *)
+        echo "Unsupported publish-pr option: $1" >&2
+        publish_pr_usage >&2
+        exit 2
+        ;;
+    esac
+  done
+
+  resolved_workspace="$(resolve_existing_directory_or_die "${workspace}")"
+  HOST_GIT_BIN="${HOST_GIT_BIN:-$(resolve_host_tool git /usr/bin/git /opt/homebrew/bin/git /usr/local/bin/git)}"
+  validate_publish_snapshot_name "${snapshot}"
+  validate_publish_branch_name "${branch}"
+  validate_publish_base_name "${base}"
+  if [[ "${dry_run}" -eq 1 ]]; then
+    HOST_GH_BIN="${HOST_GH_BIN:-$(resolve_host_tool_optional gh /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh || true)}"
+    [[ -n "${HOST_GH_BIN}" ]] || HOST_GH_BIN="gh"
+  else
+    HOST_GH_BIN="${HOST_GH_BIN:-$(resolve_host_tool gh /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh)}"
+  fi
+
+  if ! workspace_has_markers "${resolved_workspace}"; then
+    echo "publish-pr requires a git worktree: ${resolved_workspace}" >&2
+    exit 2
+  fi
+  if ! publish_pr_has_remote_origin "${resolved_workspace}"; then
+    echo "publish-pr requires an origin remote in ${resolved_workspace}." >&2
+    exit 2
+  fi
+
+  title_text="$(publish_pr_load_text_arg "${title}" "${title_file}" "title" 1)"
+  body_text="$(publish_pr_load_text_arg "${body}" "${body_file}" "body" 0)"
+  commit_message_text="$(publish_pr_load_text_arg "${commit_message}" "${commit_message_file}" "commit-message" 1)"
+  if [[ -z "${title_text}" ]]; then
+    echo "publish-pr requires a non-empty PR title." >&2
+    exit 2
+  fi
+  if [[ -z "${commit_message_text}" ]]; then
+    echo "publish-pr requires a non-empty commit message." >&2
+    exit 2
+  fi
+
+  if [[ "${snapshot}" == "worktree" ]]; then
+    if ! publish_pr_has_worktree_changes "${resolved_workspace}"; then
+      echo "publish-pr found no workspace changes to publish in ${resolved_workspace}." >&2
+      exit 2
+    fi
+  elif ! publish_pr_has_staged_changes "${resolved_workspace}"; then
+    echo "publish-pr found no staged changes to publish in ${resolved_workspace}." >&2
+    exit 2
+  fi
+
+  if [[ -n "${commit_message_file}" ]]; then
+    resolved_commit_message_file="$(resolve_existing_file_or_die "${commit_message_file}" "commit-message")"
+  else
+    resolved_commit_message_file="$(mktemp "${TMPDIR:-/tmp}/workcell-publish-commit.XXXXXX")"
+    cleanup_files+=("${resolved_commit_message_file}")
+    printf '%s' "${commit_message_text}" >"${resolved_commit_message_file}"
+    chmod 0600 "${resolved_commit_message_file}" 2>/dev/null || true
+  fi
+  trap 'if ((${#cleanup_files[@]} > 0)); then rm -f "${cleanup_files[@]}"; fi' RETURN
+
+  current_branch="$(publish_pr_current_branch "${resolved_workspace}")"
+  if [[ "${current_branch}" == "${branch}" ]]; then
+    branch_cmd=("${HOST_GIT_BIN}" -C "${resolved_workspace}" switch "${branch}")
+  elif publish_pr_branch_exists "${resolved_workspace}" "${branch}"; then
+    branch_cmd=("${HOST_GIT_BIN}" -C "${resolved_workspace}" switch "${branch}")
+  else
+    branch_cmd=("${HOST_GIT_BIN}" -C "${resolved_workspace}" switch -c "${branch}")
+  fi
+
+  commit_cmd=("${HOST_GIT_BIN}" -C "${resolved_workspace}" commit -S -F "${resolved_commit_message_file}")
+  push_cmd=("${HOST_GIT_BIN}" -C "${resolved_workspace}" push -u origin "${branch}")
+  pr_cmd=("${HOST_GH_BIN}" pr create --base "${base}" --head "${branch}" --title "${title_text}")
+  if [[ "${ready}" -eq 0 ]]; then
+    pr_cmd+=(--draft)
+  fi
+  if [[ -n "${body_file}" ]]; then
+    pr_cmd+=(--body-file "$(resolve_existing_file_or_die "${body_file}" "body")")
+  else
+    pr_cmd+=(--body "${body_text}")
+  fi
+
+  if [[ "${dry_run}" -eq 1 ]]; then
+    printf 'publish_workspace=%s\n' "${resolved_workspace}"
+    printf 'publish_snapshot=%s\n' "${snapshot}"
+    printf 'publish_branch=%s\n' "${branch}"
+    printf 'publish_base=%s\n' "${base}"
+    printf 'publish_draft=%s\n' "$([[ "${ready}" -eq 0 ]] && printf '1' || printf '0')"
+    emit_command "${branch_cmd[@]}"
+    if [[ "${snapshot}" == "worktree" ]]; then
+      emit_command "${HOST_GIT_BIN}" -C "${resolved_workspace}" add -A
+    fi
+    emit_command "${commit_cmd[@]}"
+    emit_command "${push_cmd[@]}"
+    emit_command "${pr_cmd[@]}"
+    exit 0
+  fi
+
+  run_publish_host_command_in_dir "${resolved_workspace}" "${branch_cmd[@]}"
+  if [[ "${snapshot}" == "worktree" ]]; then
+    run_publish_host_command_in_dir "${resolved_workspace}" "${HOST_GIT_BIN}" -C "${resolved_workspace}" add -A
+  fi
+  if ! publish_pr_has_staged_changes "${resolved_workspace}"; then
+    echo "publish-pr found no staged changes to commit in ${resolved_workspace}." >&2
+    exit 2
+  fi
+  run_publish_host_command_in_dir "${resolved_workspace}" "${commit_cmd[@]}"
+  run_publish_host_command_in_dir "${resolved_workspace}" "${push_cmd[@]}"
+  pr_url="$(run_publish_host_command_in_dir "${resolved_workspace}" "${pr_cmd[@]}")"
+  printf 'publish_branch=%s\n' "${branch}"
+  printf 'publish_base=%s\n' "${base}"
+  printf 'publish_pr_url=%s\n' "${pr_url}"
+  printf 'publish_snapshot=%s\n' "${snapshot}"
+  exit 0
 }
 
 default_injection_policy_path() {
@@ -3439,6 +3856,11 @@ if [[ "${1:-}" == "--self-staging-probe" ]]; then
     trap - EXIT
   fi
   exit 0
+fi
+
+if [[ "${1:-}" == "publish-pr" ]]; then
+  shift
+  publish_pr_main "$@"
 fi
 
 if [[ $# -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- add a host-side `workcell publish-pr` workflow for signed commit, push, and PR creation
- document that Tier 1 sessions prepare publish metadata but final GitHub publication happens on the host
- cover worktree and index dry runs, invalid refs, and empty snapshots in invariant checks
- regenerate the committed control-plane manifest for the new launcher entrypoint

## Validation

- [x] `bash -n scripts/workcell`
- [x] `bash -n scripts/verify-invariants.sh`
- [x] `./scripts/verify-control-plane-manifest.sh`
- [x] `./scripts/workcell publish-pr --workspace /tmp/workcell-publish-clone.kftSG7 --branch codex/publish-pr-flow --title 'Add host-side publish-pr workflow' --commit-message 'Add host-side publish-pr workflow' --snapshot worktree --dry-run`
- [ ] `./scripts/verify-invariants.sh` on macOS host still stops in the existing live-debug audit check looking for `runtime-builder` in `LIVE_DEBUG_LOG`
