### PR TITLE
chore: document required QA suppressions

### DIFF
--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "1d24b1a950256c6666209292b3d70ed2af8a7828dd7149b25522f80675d4b1f7"
+      "sha256": "90644f8fe93a529db14b08c37930dfcafaf4f7b1b69ffef2e77ca3d255511502"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts.py",

--- a/scripts/dev-remote-validate.sh
+++ b/scripts/dev-remote-validate.sh
@@ -301,6 +301,7 @@ remote_cmd() {
     return
   fi
 
+  # Intentionally forward a vetted local argv vector through ssh unchanged.
   # shellcheck disable=SC2029
   ssh "${REMOTE_HOST}" "$@"
 }
@@ -320,6 +321,7 @@ remote_docker() {
     return
   fi
 
+  # Intentionally forward a vetted local argv vector through ssh unchanged.
   # shellcheck disable=SC2029
   ssh "${REMOTE_HOST}" docker "$@"
 }

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -621,6 +621,8 @@ declare -a WORKSPACE_IMPORT_MOUNTS=()
 declare -a CACHE_MOUNTS=()
 declare -a RUNTIME_NETWORK_ARGS=()
 
+# cleanup is only reached through trap 'cleanup' EXIT; validator/CI ShellCheck
+# still misclassifies the trap-only body as unreachable.
 # shellcheck disable=SC2317,SC2329
 cleanup() {
   if [[ -n "${CONTROL_PLANE_SHADOW_ROOT}" ]] && [[ -e "${CONTROL_PLANE_SHADOW_ROOT}" ]]; then


### PR DESCRIPTION
## Summary
- document the remaining justified ShellCheck suppressions inline
- clarify that the ssh wrappers intentionally forward vetted argv vectors unchanged
- refresh the control-plane manifest for the updated scripts/workcell hash

## Validation
- shellcheck scripts/workcell scripts/dev-remote-validate.sh
- DOCKER_CONTEXT=colima ./scripts/pre-merge.sh --allow-dirty

## Review
- three independent peer reviews found no ship blockers; the remaining suppressions are justified by validator/CI behavior or required self-hosted coverage