### PR TITLE
chore: remediate provider dependency alert

### DIFF
--- a/runtime/container/providers/package-lock.json
+++ b/runtime/container/providers/package-lock.json
@@ -5809,9 +5809,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
## Summary
- update the provider lockfile to remediate the current transitive `path-to-regexp` alert
- keep the change lockfile-only with no manifest edits

## Verification
- npm audit --json (runtime/container/providers)
- npm ci (runtime/container/providers)
- ./scripts/validate-repo.sh

## Peer review
- Reviewed with no findings before commit