### PR TITLE
Harden checkout-index, git env, and publish-pr against known vuln classes

### DIFF
--- a/runtime/container/bin/git
+++ b/runtime/container/bin/git
@@ -214,7 +214,10 @@ has_unsafe_git_env() {
     [[ -n "${EDITOR:-}" ]] ||
     [[ -n "${PAGER:-}" ]] ||
     [[ -n "${VISUAL:-}" ]] ||
-    [[ -n "${GIT_CONFIG_NOSYSTEM:-}" && "${GIT_CONFIG_NOSYSTEM}" != "1" ]]; then
+    [[ -n "${GIT_CONFIG_NOSYSTEM:-}" && "${GIT_CONFIG_NOSYSTEM}" != "1" ]] ||
+    [[ -n "${GIT_OBJECT_DIRECTORY:-}" ]] ||
+    [[ -n "${GIT_ALTERNATE_OBJECT_DIRECTORIES:-}" ]] ||
+    [[ -n "${GIT_INDEX_FILE:-}" ]]; then
     return 0
   fi
 
@@ -340,7 +343,7 @@ if [[ "${hooks_path_bypass}" -eq 1 ]]; then
 fi
 
 if [[ "${env_config_bypass}" -eq 1 ]]; then
-  echo "Workcell blocked git control-plane override: remove GIT_CONFIG_*, GIT_CONFIG_GLOBAL, GIT_CONFIG_SYSTEM, GIT_DIR, GIT_WORK_TREE, GIT_COMMON_DIR, GIT_EXEC_PATH, askpass/editor overrides, GIT_SSH, or GIT_SSH_COMMAND overrides." >&2
+  echo "Workcell blocked git control-plane override: remove GIT_CONFIG_*, GIT_CONFIG_GLOBAL, GIT_CONFIG_SYSTEM, GIT_DIR, GIT_WORK_TREE, GIT_COMMON_DIR, GIT_EXEC_PATH, GIT_OBJECT_DIRECTORY, GIT_ALTERNATE_OBJECT_DIRECTORIES, GIT_INDEX_FILE, askpass/editor overrides, GIT_SSH, or GIT_SSH_COMMAND overrides." >&2
   exit 2
 fi
 

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "54ff83335cc3b4627a09dbd7b16874d816d2efc0deacf5b2ba4f71051cd54f1d"
+      "sha256": "e580cc17df1f4a414249c2cc1b4c60261812557acfc0d270fa1c2f1ab2be156f"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts.py",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "d249ae338f0001cdb4101a8161369edf5fc808e53c2ed9e3bc84d4f4dcd3150c"
+      "sha256": "df52943f51dbfd1d57e4ed8befca9e653f6705d45025993002d0152dee158791"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts.py",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "90644f8fe93a529db14b08c37930dfcafaf4f7b1b69ffef2e77ca3d255511502"
+      "sha256": "d249ae338f0001cdb4101a8161369edf5fc808e53c2ed9e3bc84d4f4dcd3150c"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts.py",
@@ -148,7 +148,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/bin/git",
       "runtime_path": "/usr/local/libexec/workcell/git-wrapper.sh",
-      "sha256": "490e2c8be98ab5a2612fc7317ff3d7ddfe12ddbf503271cf0fa717c06372944d"
+      "sha256": "2102d42e9c2119982fff5ee72cb763bf19c302f8e5a2b3888caac54c6f8196ec"
     },
     {
       "kind": "runtime-control-plane",
@@ -184,7 +184,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/runtime-user.sh",
       "runtime_path": "/usr/local/libexec/workcell/runtime-user.sh",
-      "sha256": "f7dbd0bfcb13ac35353594aefe216f029e12084bf740ca20b6d16f784e343289"
+      "sha256": "96f00a19840b43bddf49d5b341fd12d02eeb17d40878ff4fcb8a37d73ad5adfb"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "df52943f51dbfd1d57e4ed8befca9e653f6705d45025993002d0152dee158791"
+      "sha256": "54ff83335cc3b4627a09dbd7b16874d816d2efc0deacf5b2ba4f71051cd54f1d"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts.py",
@@ -154,7 +154,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/home-control-plane.sh",
       "runtime_path": "/usr/local/libexec/workcell/home-control-plane.sh",
-      "sha256": "93d571891e67ff872e419729d40a07f2900c7c2d37bc934216380d3e21111298"
+      "sha256": "037598825db0939d33c724b9337cf925e3487429c0d9bebd82365df87fce90ad"
     },
     {
       "kind": "runtime-control-plane",
@@ -172,7 +172,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-wrapper.sh",
-      "sha256": "e0461edeb02105a26cecf3ce28366cbbfc7a63b299508767fa68480946b0c9c3"
+      "sha256": "ed7a5eaacb73a42e8919e5a3466c7691ffd8d98a711f47c3596db06563f516b1"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -1042,6 +1042,26 @@ workcell_set_gemini_folder_trust_enabled() {
   chmod 0600 "${settings_path}"
 }
 
+workcell_set_gemini_tool_sandbox() {
+  local settings_path="$1"
+  local enabled="$2"
+  local settings_dir=""
+  local settings_name=""
+  local rendered_path=""
+
+  settings_dir="$(dirname "${settings_path}")"
+  settings_name="$(basename "${settings_path}")"
+  rendered_path="$(mktemp "${settings_dir}/${settings_name}.tmp.XXXXXX")"
+  jq --argjson enabled "${enabled}" \
+    '.tools.sandbox = $enabled' \
+    "${settings_path}" >"${rendered_path}" || {
+    rm -f "${rendered_path}"
+    return 1
+  }
+  mv "${rendered_path}" "${settings_path}"
+  chmod 0600 "${settings_path}"
+}
+
 workcell_workspace_import_path() {
   local relative_path="$1"
   local import_path="${WORKCELL_WORKSPACE_IMPORT_ROOT}/${relative_path}"
@@ -1357,6 +1377,9 @@ seed_gemini_home() {
   workcell_reset_session_target "${HOME}/.gemini/settings.json" "Gemini settings"
   cp "${ADAPTER_ROOT}/gemini/.gemini/settings.json" "${HOME}/.gemini/settings.json"
   chmod 0600 "${HOME}/.gemini/settings.json"
+  # Keep Gemini's nested sandbox explicitly off until Workcell validates a
+  # stronger managed posture for it inside the existing runtime boundary.
+  workcell_set_gemini_tool_sandbox "${HOME}/.gemini/settings.json" false
   if [[ "${WORKCELL_MODE:-strict}" == "breakglass" ]]; then
     workcell_set_gemini_folder_trust_enabled "${HOME}/.gemini/settings.json" true
     workcell_reset_session_target "${HOME}/.gemini/trustedFolders.json" "Gemini trusted folders"

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -142,6 +142,21 @@ codex_args_include_profile() {
   return 1
 }
 
+sanitize_gemini_sandbox_env() {
+  unset GEMINI_SANDBOX
+  unset GEMINI_SANDBOX_IMAGE
+  unset GEMINI_SANDBOX_IMAGE_DEFAULT
+  unset GEMINI_SANDBOX_PROXY_COMMAND
+  unset BUILD_SANDBOX
+  unset SANDBOX
+  unset SANDBOX_FLAGS
+  unset SANDBOX_MOUNTS
+  unset SANDBOX_ENV
+  unset SANDBOX_PORTS
+  unset SANDBOX_SET_UID_GID
+  unset SEATBELT_PROFILE
+}
+
 case "${WORKCELL_AGENT_AUTONOMY}" in
   yolo | prompt) ;;
   *)
@@ -191,9 +206,10 @@ case "${AGENT_NAME}" in
       "$@"
     ;;
   gemini)
+    sanitize_gemini_sandbox_env
     reject_unsafe_gemini_args "$@"
     # Gemini CLI self-relaunch conflicts with Workcell's protected exec boundary.
-    GEMINI_CLI_NO_RELAUNCH=1 exec /usr/local/libexec/workcell/real/node \
+    GEMINI_CLI_NO_RELAUNCH=1 GEMINI_SANDBOX=false exec /usr/local/libexec/workcell/real/node \
       /opt/workcell/providers/node_modules/@google/gemini-cli/dist/index.js \
       "${MANAGED_AUTONOMY_ARGS[@]}" \
       "$@"

--- a/runtime/container/runtime-user.sh
+++ b/runtime/container/runtime-user.sh
@@ -18,6 +18,15 @@ workcell_runtime_user_die() {
 workcell_pid1_env_value() {
   local key="$1"
 
+  case "${key}" in
+    WORKCELL_CONTAINER_MUTABILITY | WORKCELL_MODE | CODEX_PROFILE | \
+      WORKCELL_AGENT_AUTONOMY | WORKCELL_SESSION_ASSURANCE | \
+      WORKCELL_HOST_UID | WORKCELL_HOST_GID | WORKCELL_HOST_USER) ;;
+    *)
+      echo "Workcell internal error: unexpected key for pid1 env lookup: ${key}" >&2
+      return 1
+      ;;
+  esac
   [[ -r /proc/1/environ ]] || return 1
   tr '\0' '\n' </proc/1/environ | sed -n "s/^${key}=//p" | head -n1
 }

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1189,6 +1189,7 @@ run_container_with_injection_bundle_stdin gemini "${INJECTION_BUNDLE_ROOT}/gemin
     grep -q "GEMINI_API_KEY=smoke-gemini-key" "$HOME/.gemini/.env"
     jq -r ".security.auth.selectedType" "$HOME/.gemini/settings.json" | grep -q "^gemini-api-key$"
     jq -r ".security.folderTrust.enabled" "$HOME/.gemini/settings.json" | grep -q "^false$"
+    jq -r ".tools.sandbox" "$HOME/.gemini/settings.json" | grep -q "^false$"
     jq -e --arg workspace "/workspace" ". == {(\$workspace): \"TRUST_FOLDER\"}" "$HOME/.gemini/trustedFolders.json" >/dev/null
     grep -q "\"smoke\"" "$HOME/.gemini/projects.json"
     grep -q "github.com:" "$HOME/.config/gh/hosts.yml"
@@ -1479,11 +1480,18 @@ EOF
     exit 1
   fi
 
-  cat <<'EOF' >"${ROOT_DIR}/tmp/workcell-gemini-node-env.sh"
+cat <<'EOF' >"${ROOT_DIR}/tmp/workcell-gemini-node-env.sh"
 #!/bin/sh
-printf '{"claude_config":"%s","relaunch":"%s","aws":"%s","gh":"%s","ssh":"%s","args":"%s"}\n' \
+printf '{"claude_config":"%s","relaunch":"%s","gemini_sandbox":"%s","sandbox":"%s","sandbox_flags":"%s","sandbox_set_uid_gid":"%s","seatbelt":"%s","sandbox_mounts":"%s","sandbox_env":"%s","aws":"%s","gh":"%s","ssh":"%s","args":"%s"}\n' \
   "${CLAUDE_CONFIG_DIR-}" \
   "${GEMINI_CLI_NO_RELAUNCH-}" \
+  "${GEMINI_SANDBOX-}" \
+  "${SANDBOX-}" \
+  "${SANDBOX_FLAGS-}" \
+  "${SANDBOX_SET_UID_GID-}" \
+  "${SEATBELT_PROFILE-}" \
+  "${SANDBOX_MOUNTS-}" \
+  "${SANDBOX_ENV-}" \
   "${AWS_SECRET_ACCESS_KEY-}" \
   "${GITHUB_TOKEN-}" \
   "${SSH_AUTH_SOCK-}" \
@@ -1492,7 +1500,14 @@ EOF
   align_path_for_mapped_runtime_user "${ROOT_DIR}/tmp/workcell-gemini-node-env.sh" 0755 0755
 
   GEMINI_NO_RELAUNCH_ENV="$(
-    AWS_SECRET_ACCESS_KEY='verify-aws-secret' \
+    GEMINI_SANDBOX='docker' \
+      SANDBOX='host-sandbox' \
+      SANDBOX_FLAGS='--privileged' \
+      SANDBOX_SET_UID_GID='1' \
+      SEATBELT_PROFILE='permissive-open' \
+      SANDBOX_MOUNTS='/tmp:/sandbox:rw' \
+      SANDBOX_ENV='FOO=bar' \
+      AWS_SECRET_ACCESS_KEY='verify-aws-secret' \
       GITHUB_TOKEN='verify-gh-token' \
       SSH_AUTH_SOCK='/tmp/workcell-secret-sock' \
       run_entrypoint_with_autonomy_and_bind \
@@ -1502,7 +1517,7 @@ EOF
       /usr/local/libexec/workcell/real/node \
       gemini --version
   )"
-  if [[ "${GEMINI_NO_RELAUNCH_ENV}" != '{"claude_config":"","relaunch":"1","aws":"","gh":"","ssh":"","args":"/opt/workcell/providers/node_modules/@google/gemini-cli/dist/index.js --approval-mode yolo --version"}' ]]; then
+  if [[ "${GEMINI_NO_RELAUNCH_ENV}" != '{"claude_config":"","relaunch":"1","gemini_sandbox":"false","sandbox":"","sandbox_flags":"","sandbox_set_uid_gid":"","seatbelt":"","sandbox_mounts":"","sandbox_env":"","aws":"","gh":"","ssh":"","args":"/opt/workcell/providers/node_modules/@google/gemini-cli/dist/index.js --approval-mode yolo --version"}' ]]; then
     echo "unexpected Gemini relaunch env/argv: ${GEMINI_NO_RELAUNCH_ENV}" >&2
     exit 1
   fi
@@ -1517,6 +1532,26 @@ EOF
   )"
   if [[ "${GEMINI_PROMPT_ARGS}" != "/opt/workcell/providers/node_modules/@google/gemini-cli/dist/index.js --approval-mode default --version" ]]; then
     echo "unexpected Gemini prompt argv: ${GEMINI_PROMPT_ARGS}" >&2
+    exit 1
+  fi
+
+  GEMINI_PROMPT_ENV="$(
+    GEMINI_SANDBOX='docker' \
+      SANDBOX='host-sandbox' \
+      SANDBOX_FLAGS='--privileged' \
+      SANDBOX_SET_UID_GID='1' \
+      SEATBELT_PROFILE='permissive-open' \
+      SANDBOX_MOUNTS='/tmp:/sandbox:rw' \
+      SANDBOX_ENV='FOO=bar' \
+      run_entrypoint_with_autonomy_and_bind \
+      gemini \
+      prompt \
+      "${ROOT_DIR}/tmp/workcell-gemini-node-env.sh" \
+      /usr/local/libexec/workcell/real/node \
+      gemini --version
+  )"
+  if [[ "${GEMINI_PROMPT_ENV}" != '{"claude_config":"","relaunch":"1","gemini_sandbox":"false","sandbox":"","sandbox_flags":"","sandbox_set_uid_gid":"","seatbelt":"","sandbox_mounts":"","sandbox_env":"","aws":"","gh":"","ssh":"","args":"/opt/workcell/providers/node_modules/@google/gemini-cli/dist/index.js --approval-mode default --version"}' ]]; then
+    echo "unexpected Gemini prompt env/argv: ${GEMINI_PROMPT_ENV}" >&2
     exit 1
   fi
 fi

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1480,7 +1480,7 @@ EOF
     exit 1
   fi
 
-cat <<'EOF' >"${ROOT_DIR}/tmp/workcell-gemini-node-env.sh"
+  cat <<'EOF' >"${ROOT_DIR}/tmp/workcell-gemini-node-env.sh"
 #!/bin/sh
 printf '{"claude_config":"%s","relaunch":"%s","gemini_sandbox":"%s","sandbox":"%s","sandbox_flags":"%s","sandbox_set_uid_gid":"%s","seatbelt":"%s","sandbox_mounts":"%s","sandbox_env":"%s","aws":"%s","gh":"%s","ssh":"%s","args":"%s"}\n' \
   "${CLAUDE_CONFIG_DIR-}" \

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -4786,7 +4786,7 @@ PUBLISH_PR_DRY_RUN="$("${ROOT_DIR}/scripts/workcell" publish-pr \
 grep -q '^publish_snapshot=worktree$' <<<"${PUBLISH_PR_DRY_RUN}"
 grep -q '^publish_branch=feature/publish-fixture$' <<<"${PUBLISH_PR_DRY_RUN}"
 grep -q -- ' -c core.hooksPath=/dev/null -C ' <<<"${PUBLISH_PR_DRY_RUN}"
-grep -q -- 'switch -c --no-guess feature/publish-fixture' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q -- 'switch --no-guess -c feature/publish-fixture' <<<"${PUBLISH_PR_DRY_RUN}"
 grep -q -- ' add -A ' <<<"${PUBLISH_PR_DRY_RUN}"
 grep -q -- ' commit --no-verify -S -F ' <<<"${PUBLISH_PR_DRY_RUN}"
 grep -q -- ' push --no-verify -u origin feature/publish-fixture ' <<<"${PUBLISH_PR_DRY_RUN}"
@@ -4806,7 +4806,7 @@ if grep -q -- ' add -A ' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"; then
   exit 1
 fi
 grep -q -- ' -c core.hooksPath=/dev/null -C ' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"
-grep -q -- 'switch -c --no-guess feature/publish-index' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"
+grep -q -- 'switch --no-guess -c feature/publish-index' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"
 grep -q -- ' commit --no-verify -S -F ' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"
 
 if "${ROOT_DIR}/scripts/workcell" publish-pr \

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2413,6 +2413,29 @@ if ! sed -n '/^git_alias_value_is_blocked()/,/^}/p' "${ROOT_DIR}/scripts/workcel
   exit 1
 fi
 
+for _git_env_var in GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_INDEX_FILE; do
+  printf -v _git_env_literal '"${%s:-}"' "${_git_env_var}"
+  if ! grep -Fq "${_git_env_literal}" "${ROOT_DIR}/runtime/container/bin/git"; then
+    echo "Expected runtime/container/bin/git to block ${_git_env_var} to prevent object-store redirection" >&2
+    exit 1
+  fi
+done
+
+if ! sed -n '/^checkout_git_index_paths_to_prefix()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'CONTROL_PLANE_SHADOW_ROOT'; then
+  echo "Expected checkout_git_index_paths_to_prefix to validate prefix is inside CONTROL_PLANE_SHADOW_ROOT" >&2
+  exit 1
+fi
+
+if ! sed -n '/^git_index_populate_shadow_dir()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'sanitized_paths_file'; then
+  echo "Expected git_index_populate_shadow_dir to sanitize index paths before checkout-index to prevent path traversal" >&2
+  exit 1
+fi
+
+if ! sed -n '/^validate_publish_base_name()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'check-ref-format'; then
+  echo "Expected validate_publish_base_name to validate the publish-pr --base branch name" >&2
+  exit 1
+fi
+
 if ! sed -n '/^add_shadow_git_hooks_mount()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq "copy_tree_without_symlinks"; then
   echo "Expected add_shadow_git_hooks_mount to avoid copying symlinked hook content into the readonly shadow" >&2
   exit 1

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3437,6 +3437,9 @@ grep -q '^profile='"${STRICT_PREFLIGHT_PROFILE}"'$' /tmp/workcell-inspect.out
 grep -q '^workspace_status=marker-only$' /tmp/workcell-inspect.out
 grep -q '^cache_profile=off$' /tmp/workcell-inspect.out
 grep -q '^cache_assurance=managed-no-persistent-cache$' /tmp/workcell-inspect.out
+grep -q '^provider_native_sandbox_configured=workspace-write$' /tmp/workcell-inspect.out
+grep -q '^provider_native_sandbox_effective=workspace-write$' /tmp/workcell-inspect.out
+grep -q '^provider_native_sandbox_reason=managed-profile-strict$' /tmp/workcell-inspect.out
 grep -q '^injection_policy=none$' /tmp/workcell-inspect.out
 if ! "${ROOT_DIR}/scripts/workcell" \
   inspect \
@@ -3449,6 +3452,34 @@ if ! "${ROOT_DIR}/scripts/workcell" \
   exit 1
 fi
 grep -q '^profile='"${STRICT_PREFLIGHT_PROFILE}"'$' /tmp/workcell-inspect-subcommand.out
+
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent claude \
+  --no-default-injection-policy \
+  --allow-nongit-workspace \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}-claude-inspect" \
+  --inspect >/tmp/workcell-inspect-claude.out 2>&1; then
+  echo "Expected Claude --inspect to succeed without launching the runtime" >&2
+  exit 1
+fi
+grep -q '^provider_native_sandbox_configured=deferred$' /tmp/workcell-inspect-claude.out
+grep -q '^provider_native_sandbox_effective=disabled$' /tmp/workcell-inspect-claude.out
+grep -q '^provider_native_sandbox_reason=deferred-until-runtime-prereqs-and-validation$' /tmp/workcell-inspect-claude.out
+
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent gemini \
+  --no-default-injection-policy \
+  --allow-nongit-workspace \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}-gemini-inspect" \
+  --inspect >/tmp/workcell-inspect-gemini.out 2>&1; then
+  echo "Expected Gemini --inspect to succeed without launching the runtime" >&2
+  exit 1
+fi
+grep -q '^provider_native_sandbox_configured=disabled$' /tmp/workcell-inspect-gemini.out
+grep -q '^provider_native_sandbox_effective=disabled$' /tmp/workcell-inspect-gemini.out
+grep -q '^provider_native_sandbox_reason=workcell-pinned-off-until-validated$' /tmp/workcell-inspect-gemini.out
 
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent codex \
@@ -5177,6 +5208,9 @@ EOF
     grep -q 'event=launch' "${AUDIT_SESSION_LOG}"
     grep -q 'record_digest=' "${AUDIT_SESSION_LOG}"
     grep -q 'execution_path=lower-assurance-debug-command' "${AUDIT_SESSION_LOG}"
+    grep -q 'provider_native_sandbox_configured=workspace-write' "${AUDIT_SESSION_LOG}"
+    grep -q 'provider_native_sandbox_effective=workspace-write' "${AUDIT_SESSION_LOG}"
+    grep -q 'provider_native_sandbox_reason=managed-profile-build' "${AUDIT_SESSION_LOG}"
     grep -q 'event=assurance-change' "${AUDIT_SESSION_LOG}"
     grep -q 'reason=package-mutation' "${AUDIT_SESSION_LOG}"
     grep -q 'session_assurance_final=lower-assurance-package-mutation' "${AUDIT_SESSION_LOG}"
@@ -6259,6 +6293,10 @@ if ! grep -Fq "workcell_reset_session_target \"\${HOME}/.gemini/settings.json\" 
   echo "Expected Gemini home seeding to reset settings.json through workcell_reset_session_target" >&2
   exit 1
 fi
+if ! grep -Fq "workcell_set_gemini_tool_sandbox \"\${HOME}/.gemini/settings.json\" false" "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
+  echo "Expected Gemini home seeding to pin the nested sandbox setting explicitly" >&2
+  exit 1
+fi
 if ! grep -Fq "workcell_copy_manifest_credential_file claude_auth \"\${HOME}/.claude/.credentials.json\" || true" "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
   echo "Expected Claude home seeding to copy auth into .claude/.credentials.json" >&2
   exit 1
@@ -6283,8 +6321,30 @@ if ! grep -Fq 'unset DISABLE_AUTOUPDATER' "${ROOT_DIR}/runtime/container/provide
   echo "Expected provider wrapper to discard caller-supplied DISABLE_AUTOUPDATER" >&2
   exit 1
 fi
+for gemini_sandbox_env in \
+  'unset GEMINI_SANDBOX' \
+  'unset GEMINI_SANDBOX_IMAGE' \
+  'unset GEMINI_SANDBOX_IMAGE_DEFAULT' \
+  'unset GEMINI_SANDBOX_PROXY_COMMAND' \
+  'unset BUILD_SANDBOX' \
+  'unset SANDBOX' \
+  'unset SANDBOX_FLAGS' \
+  'unset SANDBOX_MOUNTS' \
+  'unset SANDBOX_ENV' \
+  'unset SANDBOX_PORTS' \
+  'unset SANDBOX_SET_UID_GID' \
+  'unset SEATBELT_PROFILE'; do
+  if ! grep -Fq "${gemini_sandbox_env}" "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
+    echo "Expected provider wrapper to scrub Gemini sandbox env knob: ${gemini_sandbox_env}" >&2
+    exit 1
+  fi
+done
 if ! grep -Fq "DISABLE_AUTOUPDATER=1 CLAUDE_CONFIG_DIR=\"\${HOME}/.claude\" exec /usr/local/libexec/workcell/real/claude \\" "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
   echo "Expected provider wrapper to launch the pinned native Claude binary with managed env" >&2
+  exit 1
+fi
+if ! grep -Fq "GEMINI_CLI_NO_RELAUNCH=1 GEMINI_SANDBOX=false exec /usr/local/libexec/workcell/real/node \\" "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
+  echo "Expected provider wrapper to pin Gemini native sandbox off on the managed path" >&2
   exit 1
 fi
 if ! grep -Fq "Workcell blocked Claude lifecycle command: \${arg}" "${ROOT_DIR}/runtime/container/provider-policy.sh"; then
@@ -6360,7 +6420,16 @@ import sys
 from pathlib import Path
 
 text = Path(sys.argv[1]).read_text(encoding="utf-8")
-required = ["--inspect", "print_inspect_state", "codex", "claude", "gemini"]
+required = [
+    "--inspect",
+    "print_inspect_state",
+    "provider_native_sandbox_configured",
+    "provider_native_sandbox_effective",
+    "provider_native_sandbox_reason",
+    "codex",
+    "claude",
+    "gemini",
+]
 for token in required:
     if token not in text:
         raise SystemExit(f"Expected workcell to contain --inspect contract token: {token}")
@@ -6371,7 +6440,17 @@ import sys
 from pathlib import Path
 
 content = "".join(Path(p).read_text(encoding="utf-8") for p in sys.argv[1:])
-required = ["workspace", "network_policy", "session_assurance_initial", "codex", "claude", "gemini"]
+required = [
+    "workspace",
+    "network_policy",
+    "session_assurance_initial",
+    "provider_native_sandbox_configured",
+    "provider_native_sandbox_effective",
+    "provider_native_sandbox_reason",
+    "codex",
+    "claude",
+    "gemini",
+]
 for field in required:
     if field not in content:
         raise SystemExit(f"Expected audit log field referenced in control scripts: {field}")

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2414,6 +2414,7 @@ if ! sed -n '/^git_alias_value_is_blocked()/,/^}/p' "${ROOT_DIR}/scripts/workcel
 fi
 
 for _git_env_var in GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_INDEX_FILE; do
+  # shellcheck disable=SC2016
   printf -v _git_env_literal '"${%s:-}"' "${_git_env_var}"
   if ! grep -Fq "${_git_env_literal}" "${ROOT_DIR}/runtime/container/bin/git"; then
     echo "Expected runtime/container/bin/git to block ${_git_env_var} to prevent object-store redirection" >&2

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2437,6 +2437,16 @@ if ! sed -n '/^validate_publish_base_name()/,/^}/p' "${ROOT_DIR}/scripts/workcel
   exit 1
 fi
 
+if ! sed -n '/^publish_pr_main()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'core.hooksPath=/dev/null'; then
+  echo "Expected publish_pr_main to disable repo hooks for host-side publish git commands" >&2
+  exit 1
+fi
+
+if ! sed -n '/^publish_pr_main()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q -- '--no-verify'; then
+  echo "Expected publish_pr_main to bypass repo hooks explicitly on host-side commit and push" >&2
+  exit 1
+fi
+
 if ! sed -n '/^add_shadow_git_hooks_mount()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq "copy_tree_without_symlinks"; then
   echo "Expected add_shadow_git_hooks_mount to avoid copying symlinked hook content into the readonly shadow" >&2
   exit 1
@@ -4744,10 +4754,11 @@ PUBLISH_PR_DRY_RUN="$("${ROOT_DIR}/scripts/workcell" publish-pr \
   --dry-run)"
 grep -q '^publish_snapshot=worktree$' <<<"${PUBLISH_PR_DRY_RUN}"
 grep -q '^publish_branch=feature/publish-fixture$' <<<"${PUBLISH_PR_DRY_RUN}"
-grep -q -- 'switch -c feature/publish-fixture' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q -- ' -c core.hooksPath=/dev/null -C ' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q -- 'switch -c --no-guess feature/publish-fixture' <<<"${PUBLISH_PR_DRY_RUN}"
 grep -q -- ' add -A ' <<<"${PUBLISH_PR_DRY_RUN}"
-grep -q -- ' commit -S -F ' <<<"${PUBLISH_PR_DRY_RUN}"
-grep -q -- ' push -u origin feature/publish-fixture ' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q -- ' commit --no-verify -S -F ' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q -- ' push --no-verify -u origin feature/publish-fixture ' <<<"${PUBLISH_PR_DRY_RUN}"
 grep -q -- 'gh pr create --base main --head feature/publish-fixture --title Verify\\ PR\\ title --draft --body-file' <<<"${PUBLISH_PR_DRY_RUN}"
 
 git -C "${PUBLISH_PR_FIXTURE}" add tracked.txt
@@ -4763,8 +4774,9 @@ if grep -q -- ' add -A ' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"; then
   echo "publish-pr index snapshot should not auto-stage the worktree" >&2
   exit 1
 fi
-grep -q -- 'switch -c feature/publish-index' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"
-grep -q -- ' commit -S -F ' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"
+grep -q -- ' -c core.hooksPath=/dev/null -C ' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"
+grep -q -- 'switch -c --no-guess feature/publish-index' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"
+grep -q -- ' commit --no-verify -S -F ' <<<"${PUBLISH_PR_INDEX_DRY_RUN}"
 
 if "${ROOT_DIR}/scripts/workcell" publish-pr \
   --workspace "${PUBLISH_PR_FIXTURE}" \

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1423,6 +1423,9 @@ Notes:
   - publish-pr runs on the host, not inside the Workcell container.
   - It uses the host Git and GitHub CLI configuration so maintainer signing
     and publication stay outside the Tier 1 container boundary.
+  - Host-side git commands explicitly bypass repo hooks during publication
+    because workspace hook content is untrusted; signed commits remain
+    mandatory.
   - The default snapshot is worktree, which stages the current tracked and
     untracked workspace changes with `git add -A` before committing.
 EOF
@@ -1636,9 +1639,11 @@ publish_pr_main() {
   local pr_url=""
   local -a cleanup_files=()
   local -a branch_cmd=()
+  local -a add_cmd=()
   local -a commit_cmd=()
   local -a push_cmd=()
   local -a pr_cmd=()
+  local -a publish_git_cmd=()
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -1755,16 +1760,18 @@ publish_pr_main() {
   trap 'if ((${#cleanup_files[@]} > 0)); then rm -f "${cleanup_files[@]}"; fi' RETURN
 
   current_branch="$(publish_pr_current_branch "${resolved_workspace}")"
+  publish_git_cmd=("${HOST_GIT_BIN}" -c core.hooksPath=/dev/null -C "${resolved_workspace}")
   if [[ "${current_branch}" == "${branch}" ]]; then
-    branch_cmd=("${HOST_GIT_BIN}" -C "${resolved_workspace}" switch "${branch}")
+    branch_cmd=("${publish_git_cmd[@]}" switch --no-guess "${branch}")
   elif publish_pr_branch_exists "${resolved_workspace}" "${branch}"; then
-    branch_cmd=("${HOST_GIT_BIN}" -C "${resolved_workspace}" switch "${branch}")
+    branch_cmd=("${publish_git_cmd[@]}" switch --no-guess "${branch}")
   else
-    branch_cmd=("${HOST_GIT_BIN}" -C "${resolved_workspace}" switch -c "${branch}")
+    branch_cmd=("${publish_git_cmd[@]}" switch -c --no-guess "${branch}")
   fi
 
-  commit_cmd=("${HOST_GIT_BIN}" -C "${resolved_workspace}" commit -S -F "${resolved_commit_message_file}")
-  push_cmd=("${HOST_GIT_BIN}" -C "${resolved_workspace}" push -u origin "${branch}")
+  add_cmd=("${publish_git_cmd[@]}" add -A)
+  commit_cmd=("${publish_git_cmd[@]}" commit --no-verify -S -F "${resolved_commit_message_file}")
+  push_cmd=("${publish_git_cmd[@]}" push --no-verify -u origin "${branch}")
   pr_cmd=("${HOST_GH_BIN}" pr create --base "${base}" --head "${branch}" --title "${title_text}")
   if [[ "${ready}" -eq 0 ]]; then
     pr_cmd+=(--draft)
@@ -1783,7 +1790,7 @@ publish_pr_main() {
     printf 'publish_draft=%s\n' "$([[ "${ready}" -eq 0 ]] && printf '1' || printf '0')"
     emit_command "${branch_cmd[@]}"
     if [[ "${snapshot}" == "worktree" ]]; then
-      emit_command "${HOST_GIT_BIN}" -C "${resolved_workspace}" add -A
+      emit_command "${add_cmd[@]}"
     fi
     emit_command "${commit_cmd[@]}"
     emit_command "${push_cmd[@]}"
@@ -1793,7 +1800,7 @@ publish_pr_main() {
 
   run_publish_host_command_in_dir "${resolved_workspace}" "${branch_cmd[@]}"
   if [[ "${snapshot}" == "worktree" ]]; then
-    run_publish_host_command_in_dir "${resolved_workspace}" "${HOST_GIT_BIN}" -C "${resolved_workspace}" add -A
+    run_publish_host_command_in_dir "${resolved_workspace}" "${add_cmd[@]}"
   fi
   if ! publish_pr_has_staged_changes "${resolved_workspace}"; then
     echo "publish-pr found no staged changes to commit in ${resolved_workspace}." >&2

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1125,6 +1125,77 @@ codex_rules_effective_assurance_initial() {
   codex_rules_effective_assurance_with_session_assurance "$(session_assurance_initial)"
 }
 
+provider_native_sandbox_configured() {
+  case "${AGENT:-}" in
+    codex)
+      case "${MODE}" in
+        strict | build)
+          printf 'workspace-write\n'
+          ;;
+        breakglass)
+          printf 'danger-full-access\n'
+          ;;
+        *)
+          printf 'disabled\n'
+          ;;
+      esac
+      ;;
+    claude)
+      printf 'deferred\n'
+      ;;
+    gemini)
+      printf 'disabled\n'
+      ;;
+    *)
+      printf 'not-applicable\n'
+      ;;
+  esac
+}
+
+provider_native_sandbox_effective() {
+  case "${AGENT:-}" in
+    codex)
+      provider_native_sandbox_configured
+      ;;
+    claude | gemini)
+      printf 'disabled\n'
+      ;;
+    *)
+      printf 'not-applicable\n'
+      ;;
+  esac
+}
+
+provider_native_sandbox_reason() {
+  case "${AGENT:-}" in
+    codex)
+      case "${MODE}" in
+        strict)
+          printf 'managed-profile-strict\n'
+          ;;
+        build)
+          printf 'managed-profile-build\n'
+          ;;
+        breakglass)
+          printf 'managed-profile-breakglass\n'
+          ;;
+        *)
+          printf 'unmanaged-mode\n'
+          ;;
+      esac
+      ;;
+    claude)
+      printf 'deferred-until-runtime-prereqs-and-validation\n'
+      ;;
+    gemini)
+      printf 'workcell-pinned-off-until-validated\n'
+      ;;
+    *)
+      printf 'not-applicable\n'
+      ;;
+  esac
+}
+
 append_launch_audit_record() {
   local profile="$1"
   local execution_path="$2"
@@ -1142,6 +1213,9 @@ append_launch_audit_record() {
     "codex_rules_assurance_configured=$(codex_rules_assurance)" \
     "codex_rules_mutability_effective_initial=$(codex_rules_effective_mutability_initial)" \
     "codex_rules_assurance_effective_initial=$(codex_rules_effective_assurance_initial)" \
+    "provider_native_sandbox_configured=$(provider_native_sandbox_configured)" \
+    "provider_native_sandbox_effective=$(provider_native_sandbox_effective)" \
+    "provider_native_sandbox_reason=$(provider_native_sandbox_reason)" \
     "observability_assurance=$(observability_assurance)" \
     "log_level=${LOG_LEVEL}" \
     "debug_log_enabled=$([[ -n "${DEBUG_LOG_PATH}" ]] && printf '1' || printf '0')" \
@@ -1219,6 +1293,9 @@ append_exit_audit_record() {
     "codex_rules_assurance_configured=$(codex_rules_assurance)" \
     "codex_rules_mutability_effective_final=$(codex_rules_effective_mutability_with_session_assurance "${final_assurance}")" \
     "codex_rules_assurance_effective_final=$(codex_rules_effective_assurance_with_session_assurance "${final_assurance}")" \
+    "provider_native_sandbox_configured=$(provider_native_sandbox_configured)" \
+    "provider_native_sandbox_effective=$(provider_native_sandbox_effective)" \
+    "provider_native_sandbox_reason=$(provider_native_sandbox_reason)" \
     "session_assurance_initial=$(session_assurance_initial)" \
     "session_assurance_final=${final_assurance}" \
     "package_mutation_downgraded=${downgraded}"
@@ -2408,6 +2485,9 @@ print_inspect_state() {
   printf 'container_assurance=%s\n' "$(container_assurance)"
   printf 'autonomy_assurance=%s\n' "$(autonomy_assurance)"
   printf 'observability_assurance=%s\n' "$(observability_assurance)"
+  printf 'provider_native_sandbox_configured=%s\n' "$(provider_native_sandbox_configured)"
+  printf 'provider_native_sandbox_effective=%s\n' "$(provider_native_sandbox_effective)"
+  printf 'provider_native_sandbox_reason=%s\n' "$(provider_native_sandbox_reason)"
   printf 'log_level=%s\n' "${LOG_LEVEL}"
   printf 'profile_dir=%s\n' "$(profile_dir "${COLIMA_PROFILE}")"
   printf 'profile_marker=%s\n' "$(profile_marker_path "${COLIMA_PROFILE}")"
@@ -4869,6 +4949,10 @@ printf 'codex_rules_mutability_configured=%s\n' "${CODEX_RULES_MUTABILITY}" >&2
 printf 'codex_rules_assurance_configured=%s\n' "$(codex_rules_assurance)" >&2
 printf 'codex_rules_mutability_effective_initial=%s\n' "$(codex_rules_effective_mutability_initial)" >&2
 printf 'codex_rules_assurance_effective_initial=%s\n' "$(codex_rules_effective_assurance_initial)" >&2
+printf 'provider_native_sandbox_configured=%s effective=%s reason=%s\n' \
+  "$(provider_native_sandbox_configured)" \
+  "$(provider_native_sandbox_effective)" \
+  "$(provider_native_sandbox_reason)" >&2
 printf 'session_assurance_initial=%s\n' "$(session_assurance_initial)" >&2
 if [[ -n "${INJECTION_POLICY_SHA256}" ]]; then
   printf 'injection_policy_sha256=%s credential_keys=%s ssh_injected=%s\n' \

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1545,7 +1545,7 @@ validate_publish_base_name() {
   local base="$1"
 
   if [[ -z "${base}" ]]; then
-    echo "publish-pr requires --base." >&2
+    echo "publish-pr requires a non-empty --base branch name." >&2
     exit 2
   fi
   if ! "${HOST_GIT_BIN}" check-ref-format --branch "${base}" >/dev/null 2>&1; then
@@ -3807,6 +3807,12 @@ checkout_git_index_paths_to_prefix() {
 
   [[ "$#" -gt 0 ]] || return 1
   workspace_is_git_worktree "${workspace}" || return 1
+  # Prefix must be absolute, end with /, and remain inside the shadow root so
+  # that a crafted git index cannot write files outside the controlled area.
+  if [[ "${prefix}" != /* ]] || [[ "${prefix}" != */ ]] || [[ "${prefix}" != "${CONTROL_PLANE_SHADOW_ROOT}/"* ]]; then
+    echo "Workcell internal error: unsafe checkout-index prefix rejected: ${prefix}" >&2
+    return 2
+  fi
   run_clean_host_command git -C "${workspace}" checkout-index --prefix="${prefix}" -- "$@"
 }
 
@@ -3815,6 +3821,8 @@ git_index_populate_shadow_dir() {
   local relative_path="$2"
   local source_root="$3"
   local tracked_paths_file=""
+  local sanitized_paths_file=""
+  local entry=""
 
   workspace_is_git_worktree "${workspace}" || return 1
   tracked_paths_file="$(mktemp "${CONTROL_PLANE_SHADOW_ROOT}/index-paths.XXXXXX")"
@@ -3823,8 +3831,33 @@ git_index_populate_shadow_dir() {
     rm -f "${tracked_paths_file}"
     return 1
   fi
-  run_clean_host_command git -C "${workspace}" checkout-index --stdin -z --prefix="${CONTROL_PLANE_SHADOW_ROOT}/dirs/" <"${tracked_paths_file}"
+  # Reject any path that could escape the shadow prefix via traversal segments
+  # or absolute references.  Such entries indicate a malicious or corrupted
+  # repository and must not reach checkout-index.
+  sanitized_paths_file="$(mktemp "${CONTROL_PLANE_SHADOW_ROOT}/index-safe.XXXXXX")"
+  exec 3<"${tracked_paths_file}"
+  exec 4>"${sanitized_paths_file}"
+  while IFS= read -r -d '' entry <&3; do
+    case "${entry}" in
+      '' | /* | */../* | ../* | */..)
+        echo "Workcell blocked checkout-index: unsafe path in git index rejected: ${entry}" >&2
+        exec 3<&-
+        exec 4>&-
+        rm -f "${tracked_paths_file}" "${sanitized_paths_file}"
+        return 2
+        ;;
+    esac
+    printf '%s\0' "${entry}" >&4
+  done
+  exec 3<&-
+  exec 4>&-
   rm -f "${tracked_paths_file}"
+  if [[ ! -s "${sanitized_paths_file}" ]]; then
+    rm -f "${sanitized_paths_file}"
+    return 1
+  fi
+  run_clean_host_command git -C "${workspace}" checkout-index --stdin -z --prefix="${CONTROL_PLANE_SHADOW_ROOT}/dirs/" <"${sanitized_paths_file}"
+  rm -f "${sanitized_paths_file}"
   [[ -d "${source_root}" ]]
 }
 

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1843,7 +1843,7 @@ publish_pr_main() {
   elif publish_pr_branch_exists "${resolved_workspace}" "${branch}"; then
     branch_cmd=("${publish_git_cmd[@]}" switch --no-guess "${branch}")
   else
-    branch_cmd=("${publish_git_cmd[@]}" switch -c --no-guess "${branch}")
+    branch_cmd=("${publish_git_cmd[@]}" switch --no-guess -c "${branch}")
   fi
 
   add_cmd=("${publish_git_cmd[@]}" add -A)

--- a/tests/scenarios/shared/test-publish-pr-dry-run.sh
+++ b/tests/scenarios/shared/test-publish-pr-dry-run.sh
@@ -47,7 +47,7 @@ grep -q '^publish_branch=feature/publish-scenario$' <<<"${worktree_dry_run}"
 grep -q '^publish_base=main$' <<<"${worktree_dry_run}"
 grep -q '^publish_draft=1$' <<<"${worktree_dry_run}"
 grep -q -- ' -c core.hooksPath=/dev/null -C ' <<<"${worktree_dry_run}"
-grep -q -- 'switch -c --no-guess feature/publish-scenario' <<<"${worktree_dry_run}"
+grep -q -- 'switch --no-guess -c feature/publish-scenario' <<<"${worktree_dry_run}"
 grep -q -- ' add -A ' <<<"${worktree_dry_run}"
 grep -q -- ' commit --no-verify -S -F ' <<<"${worktree_dry_run}"
 grep -q -- ' push --no-verify -u origin feature/publish-scenario ' <<<"${worktree_dry_run}"
@@ -65,7 +65,7 @@ index_dry_run="$("${ROOT_DIR}/scripts/workcell" publish-pr \
 grep -q '^publish_snapshot=index$' <<<"${index_dry_run}"
 grep -q '^publish_branch=feature/publish-index$' <<<"${index_dry_run}"
 grep -q -- ' -c core.hooksPath=/dev/null -C ' <<<"${index_dry_run}"
-grep -q -- 'switch -c --no-guess feature/publish-index' <<<"${index_dry_run}"
+grep -q -- 'switch --no-guess -c feature/publish-index' <<<"${index_dry_run}"
 grep -q -- ' commit --no-verify -S -F ' <<<"${index_dry_run}"
 if grep -q -- ' add -A ' <<<"${index_dry_run}"; then
   echo "publish-pr index snapshot should not auto-stage the worktree" >&2

--- a/tests/scenarios/shared/test-publish-pr-dry-run.sh
+++ b/tests/scenarios/shared/test-publish-pr-dry-run.sh
@@ -46,10 +46,11 @@ grep -q '^publish_snapshot=worktree$' <<<"${worktree_dry_run}"
 grep -q '^publish_branch=feature/publish-scenario$' <<<"${worktree_dry_run}"
 grep -q '^publish_base=main$' <<<"${worktree_dry_run}"
 grep -q '^publish_draft=1$' <<<"${worktree_dry_run}"
-grep -q -- 'switch -c feature/publish-scenario' <<<"${worktree_dry_run}"
+grep -q -- ' -c core.hooksPath=/dev/null -C ' <<<"${worktree_dry_run}"
+grep -q -- 'switch -c --no-guess feature/publish-scenario' <<<"${worktree_dry_run}"
 grep -q -- ' add -A ' <<<"${worktree_dry_run}"
-grep -q -- ' commit -S -F ' <<<"${worktree_dry_run}"
-grep -q -- ' push -u origin feature/publish-scenario ' <<<"${worktree_dry_run}"
+grep -q -- ' commit --no-verify -S -F ' <<<"${worktree_dry_run}"
+grep -q -- ' push --no-verify -u origin feature/publish-scenario ' <<<"${worktree_dry_run}"
 grep -q -- 'gh pr create --base main --head feature/publish-scenario --title Scenario\\ PR\\ title --draft --body-file' <<<"${worktree_dry_run}"
 
 git -C "${FIXTURE}" add tracked.txt
@@ -63,8 +64,9 @@ index_dry_run="$("${ROOT_DIR}/scripts/workcell" publish-pr \
 
 grep -q '^publish_snapshot=index$' <<<"${index_dry_run}"
 grep -q '^publish_branch=feature/publish-index$' <<<"${index_dry_run}"
-grep -q -- 'switch -c feature/publish-index' <<<"${index_dry_run}"
-grep -q -- ' commit -S -F ' <<<"${index_dry_run}"
+grep -q -- ' -c core.hooksPath=/dev/null -C ' <<<"${index_dry_run}"
+grep -q -- 'switch -c --no-guess feature/publish-index' <<<"${index_dry_run}"
+grep -q -- ' commit --no-verify -S -F ' <<<"${index_dry_run}"
 if grep -q -- ' add -A ' <<<"${index_dry_run}"; then
   echo "publish-pr index snapshot should not auto-stage the worktree" >&2
   exit 1


### PR DESCRIPTION
## Summary

This PR keeps the hardening-only scope on `fix/code-review-findings` and now lands five boundary-focused changes:

### Fixes included

| Fix | File | Invariant |
|-----|------|-----------|
| **C1** — git `checkout-index` path traversal hardening | `scripts/workcell` | Inv. 2 |
| **C2** — git object-store/index env redirection blocking | `runtime/container/bin/git` | Inv. 3 |
| **C3** — `publish-pr --base` branch validation | `scripts/workcell` | Inv. 2 / host publication integrity |
| **C4** — host-side `publish-pr` hook suppression | `scripts/workcell` | Inv. 3 / host publication integrity |
| **C5** — provider-native sandbox posture visibility plus Gemini safe-path pinning | `scripts/workcell`, `runtime/container/provider-wrapper.sh`, `runtime/container/home-control-plane.sh` | Inv. 1 / provider backstop visibility |

### C1 — checkout-index path traversal

`checkout_git_index_paths_to_prefix` now rejects unsafe prefixes unless they are absolute, slash-terminated, and rooted under `CONTROL_PLANE_SHADOW_ROOT`. `git_index_populate_shadow_dir` now validates every NUL-delimited path from `git ls-files` before piping it to `checkout-index --stdin`, rejecting empty, absolute, and traversal-style entries.

### C2 — git env object-store/index redirection

`runtime/container/bin/git` now blocks `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`, and `GIT_INDEX_FILE` in the same unsafe-env gate that already blocked git control-plane override env vars.

### C3 — publish-pr base branch validation

`publish_pr_main` now validates `--base` with `git check-ref-format --branch` before forwarding it to `gh pr create --base`.

### C4 — host-side publish-pr hook suppression

`publish-pr` is intentionally a host-side path. The publication git commands now run through:

- `git -c core.hooksPath=/dev/null`
- `commit --no-verify -S`
- `push --no-verify`

This keeps repo-local hook content from silently taking over the host publication path while preserving signed commits. The usage text now states that this bypass is intentional on the host publication path only.

### C5 — native sandbox posture and Gemini pinning

Workcell now reports provider-native sandbox posture in `--inspect`, launch stderr, and the audit log using:

- `provider_native_sandbox_configured`
- `provider_native_sandbox_effective`
- `provider_native_sandbox_reason`

For the current scope:

- Codex reports the managed profile-derived posture already in use.
- Claude remains explicitly deferred until runtime prerequisites and validation exist.
- Gemini is pinned off for now through both seeded session settings and wrapper-managed env, and Gemini sandbox override env channels are scrubbed on the Gemini launch path.

This keeps Workcell as the primary boundary while making provider-native posture visible and backstopped instead of implicit.

### Superseded remote work

The older diverged `codex/*` branches are treated as patch sources, not merge targets. Their relevant hardening is now represented here in current history.

### Manifest

`runtime/container/control-plane-manifest.json` was refreshed for the updated control-plane hashes.

### Validation

Local validation run:

- [x] `bash -n scripts/workcell runtime/container/provider-wrapper.sh runtime/container/home-control-plane.sh scripts/verify-invariants.sh scripts/container-smoke.sh`
- [x] `git diff --check`
- [x] `./scripts/workcell --agent codex --no-default-injection-policy --allow-nongit-workspace --workspace /tmp --colima-profile workcell-inspect-codex --inspect`
- [x] `./scripts/workcell --agent claude --no-default-injection-policy --allow-nongit-workspace --workspace /tmp --colima-profile workcell-inspect-claude --inspect`
- [x] `./scripts/workcell --agent gemini --no-default-injection-policy --allow-nongit-workspace --workspace /tmp --colima-profile workcell-inspect-gemini --inspect`
- [x] `./scripts/verify-control-plane-manifest.sh`
- [x] `./scripts/verify-scenario-coverage.sh`
- [x] `./scripts/run-scenario-tests.sh --secretless-only`

Deferred to CI / longer host validation:

- [ ] `./scripts/verify-invariants.sh`
- [ ] Full CI `Validate repository`

### Peer review

This branch was reviewed with both:

- security review focused on boundary preservation, native-sandbox backstops, and confinement of the host-side exception
- development/maintainability review focused on correctness, operator-facing posture, and targeted test coverage
