### PR TITLE
fix: trust release bundle archive workspace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
             -lc '
               set -euo pipefail
               bundle_tar="/dist/${BUNDLE_NAME%.tar.gz}.tar"
-              git archive \
+              git -c safe.directory=/workspace archive \
                 --format=tar \
                 --mtime="@${SOURCE_DATE_EPOCH}" \
                 --prefix="${BUNDLE_PREFIX}" \

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -676,6 +676,12 @@ require_contains(
 )
 require_contains(
     release_workflow,
+    "git -c safe.directory=/workspace archive \\",
+    "an explicit safe.directory override for release bundle archiving inside the validator container",
+    ".github/workflows/release.yml",
+)
+require_contains(
+    release_workflow,
     "docker buildx prune -af || true",
     "release-preflight Buildx cache cleanup before the reproducible image check",
     ".github/workflows/release.yml",


### PR DESCRIPTION
## Summary
- trust /workspace explicitly when archiving the release bundle inside the validator container
- lock that release-workflow behavior in the pinned-input invariant check

## Testing
- ./scripts/check-pinned-inputs.sh
- ./scripts/dev-quick-check.sh
- git diff --check