### PR TITLE
fix: use supported buildx manifest template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -494,7 +494,7 @@ jobs:
             -t "${IMAGE_NAME}:${GITHUB_REF_NAME}" \
             -t "${IMAGE_NAME}:sha-${GITHUB_SHA}" \
             "${refs[@]}"
-          manifest_json="$(docker buildx imagetools inspect "${IMAGE_NAME}:${GITHUB_REF_NAME}" --format '{{json .manifest}}')"
+          manifest_json="$(docker buildx imagetools inspect "${IMAGE_NAME}:${GITHUB_REF_NAME}" --format '{{json .Manifest}}')"
           MANIFEST_JSON="${manifest_json}" python3 - "${GITHUB_OUTPUT}" "dist/workcell-image.digest" "${IMAGE_NAME}" <<'PY'
           import json
           import os

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -536,6 +536,14 @@ if '"imagetools", "inspect", "--raw"' not in release_workflow:
     raise SystemExit(
         ".github/workflows/release.yml must normalize attested published platform digests before comparing them against the preflight manifest"
     )
+if "{{json .Manifest}}" not in release_workflow:
+    raise SystemExit(
+        ".github/workflows/release.yml must use the supported Buildx .Manifest template field when reading the published multi-arch manifest"
+    )
+if "{{json .manifest}}" in release_workflow:
+    raise SystemExit(
+        ".github/workflows/release.yml must not use the unsupported lowercase Buildx .manifest template field"
+    )
 if "Verify release bundle matches preflight" not in release_workflow:
     raise SystemExit(
         ".github/workflows/release.yml must compare the published source bundle against the preflight manifest"


### PR DESCRIPTION
## Summary\n- switch the release publish step to the supported  template field \n- add invariant checks so the workflow cannot regress back to the unsupported lowercase field\n\n## Testing\n- docker buildx imagetools inspect alpine:latest --format '{{json .Manifest}}'\n- ./scripts/check-pinned-inputs.sh\n- ./scripts/dev-quick-check.sh\n- ./scripts/validate-repo.sh