### PR TITLE
fix: ignore attestation manifests in release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -506,13 +506,18 @@ jobs:
           image_name = sys.argv[3]
           manifest = json.loads(os.environ["MANIFEST_JSON"])
 
+          image_manifests = [
+              entry
+              for entry in manifest.get("manifests", [])
+              if entry.get("annotations", {}).get("vnd.docker.reference.type") != "attestation-manifest"
+          ]
           platform_arches = [
               entry.get("platform", {}).get("architecture")
-              for entry in manifest.get("manifests", [])
+              for entry in image_manifests
           ]
           if platform_arches != ["amd64", "arm64"]:
               raise SystemExit(
-                  "Deterministic multi-arch manifest must contain exactly amd64 then arm64, "
+                  "Deterministic multi-arch image manifest must contain exactly amd64 then arm64, "
                   f"found {platform_arches!r}"
               )
 

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -544,6 +544,10 @@ if "{{json .manifest}}" in release_workflow:
     raise SystemExit(
         ".github/workflows/release.yml must not use the unsupported lowercase Buildx .manifest template field"
     )
+if "vnd.docker.reference.type" not in release_workflow:
+    raise SystemExit(
+        ".github/workflows/release.yml must ignore attestation manifests when validating published multi-arch image platforms"
+    )
 if "Verify release bundle matches preflight" not in release_workflow:
     raise SystemExit(
         ".github/workflows/release.yml must compare the published source bundle against the preflight manifest"


### PR DESCRIPTION
Summary:\n- ignore attestation-manifest entries when validating the published multi-arch manifest platform list\n- keep the deterministic amd64/arm64 ordering check on the actual image manifests\n- lock the behavior in the pinned-input invariant check\n\nTesting:\n- ./scripts/check-pinned-inputs.sh\n- ./scripts/dev-quick-check.sh\n- ./scripts/validate-repo.sh