### PR TITLE
docs: rewrite public docs and enforce GitHub attestations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,190 +1,116 @@
 # Contributing to Workcell
 
+Workcell changes should preserve the runtime boundary first and developer
+ergonomics second.
+
+## Ground rules
+
+- keep `runtime/`, `policy/`, `adapters/`, `verify/`, and `workflows/` in
+  sync when a change touches shared contracts
+- do not widen trust silently
+- document lower-assurance paths instead of implying parity
+- sign every commit
+- use feature branches and pull requests; do not push directly to `main`
+
 ## Prerequisites
 
-The following tools must be installed before working on this repository:
+Local development expects:
 
-| Tool | Used by |
-|------|---------|
-| `shellcheck` | `dev-quick-check.sh`, `pre-merge.sh` |
-| `shfmt` | `dev-quick-check.sh` |
-| `python3` | `dev-quick-check.sh` (compile + unittest) |
-| `cargo` + `rustfmt` + Clippy | `dev-quick-check.sh` (Rust launcher) |
-| `docker` | `pre-merge.sh` (validator image, smoke, repro) |
-| `git` | `pre-merge.sh` |
-| `actionlint` | `scripts/check-workflows.sh` (called by `pre-merge.sh`) |
-| `zizmor` | `scripts/check-workflows.sh` (called by `pre-merge.sh`) |
-| `cosign` | Release signing and provenance verification |
-| `jq` | Runtime container scripts |
+- `git`
+- `docker`
+- `python3`
+- `shellcheck`
+- `shfmt`
+- `cargo`, `rustfmt`, and `clippy`
+- `actionlint`
+- `zizmor`
+- `jq`
 
-On macOS, install Colima for the VM boundary:
+On macOS, also install Colima for the real VM boundary path.
 
-```bash
-brew install colima docker shellcheck shfmt python3 rustup actionlint zizmor jq
-rustup-init  # then: rustup component add rustfmt clippy
-```
+## Recommended workflow
 
-## Quick start for contributors
-
-1. Fork the repository and create a feature branch from `main`.
-2. Make your changes. Keep `runtime/`, `policy/`, `adapters/`, `verify/`, and `workflows/` in lockstep if a change touches shared contracts.
-3. Run the fast local check before committing:
+1. Create a feature branch from `main`.
+2. Make the change.
+3. Run the fast local gate:
 
    ```bash
    ./scripts/dev-quick-check.sh
    ```
 
-4. Before opening a PR, run the full pre-merge stack:
+4. Before opening a PR, run the full local gate:
 
    ```bash
    ./scripts/pre-merge.sh
    ```
 
-5. Open a PR against `main`. Never push directly to `main`.
+5. Open a PR against `main`.
 
-## Test levels
+## Validation levels
 
-### `./scripts/dev-quick-check.sh`
+### Fast local gate
 
-Fast, host-local validation. Run this after every non-trivial edit.
+`./scripts/dev-quick-check.sh` is the normal edit loop. It covers:
 
-What it checks:
+- shell lint and format checks
+- Python compile and unit tests
+- Rust fmt, clippy, and tests
 
-- `shellcheck` on all first-party shell scripts (entrypoints, container helpers, runtime scripts)
-- `shfmt` format check on those same scripts (2-space indent, `bash` dialect, `case` indentation)
-- Python syntax compilation (`py_compile`) and `unittest` discovery for `scripts/lib/` and `tests/python/`
-- `cargo fmt --check`, `cargo clippy --all-targets --locked --offline -- -D warnings`, and `cargo test --locked --offline` for the Rust launcher under `runtime/container/rust/`
+### Full local gate
 
-When to run: before every commit and as a git pre-commit hook if desired.
+`./scripts/pre-merge.sh` is the normal pre-PR gate. It covers:
 
-### `./scripts/pre-merge.sh`
+- pinned-input checks
+- upstream release verification for pinned provider artifacts
+- validator-image rebuild
+- workflow lint
+- repo validation
+- invariant checks
+- container smoke
+- source-bundle reproducibility
+- runtime-image reproducibility
 
-Full local pre-merge stack. Requires Docker and a clean worktree by default.
-
-What it checks, in order:
-
-1. **Pinned-input policy** (`scripts/check-pinned-inputs.sh`) — verifies Debian snapshot pins, base-image digests, runtime and validator package sets, BuildKit/QEMU/Cosign/Syft workflow inputs, and provider lockfile graph integrity.
-2. **Upstream Codex release verification** (`scripts/verify-upstream-codex-release.sh`) — re-verifies the pinned Codex release assets against OpenAI's published Sigstore bundle.
-3. **Builds the validator image** from `tools/validator/Dockerfile`.
-4. **Workflow lint** (`scripts/check-workflows.sh`) — `actionlint` and `zizmor` on all GitHub Actions workflows. Requires host `actionlint` and `zizmor`.
-5. **Repository validation** (`scripts/validate-repo.sh`) — shell, JSON, TOML, YAML, and manpage checks run inside the validator container.
-6. **Invariant checks** (`scripts/verify-invariants.sh`) — launcher and adapter policy regression tests.
-7. **Container smoke** (`scripts/container-smoke.sh`) — direct container build and adapter smoke tests.
-8. **Release bundle reproducibility** (`scripts/verify-release-bundle.sh`) — deterministic source bundle verification under a fixed `SOURCE_DATE_EPOCH`.
-9. **Runtime reproducibility** (`scripts/verify-reproducible-build.sh`) — paired multi-platform OCI image verification.
-
-Flags:
+Helpful flags:
 
 ```bash
-./scripts/pre-merge.sh --allow-dirty          # validate the live worktree without requiring a clean state
-./scripts/pre-merge.sh --skip-repro           # skip the reproducible-build check (saves significant time)
-./scripts/pre-merge.sh --skip-release-bundle  # skip the release bundle check
-./scripts/pre-merge.sh --remote               # also run the remote linux/amd64 validate lane
-./scripts/pre-merge.sh --rebuild-validator    # force-rebuild the local validator image
+./scripts/pre-merge.sh --allow-dirty
+./scripts/pre-merge.sh --skip-repro
+./scripts/pre-merge.sh --skip-release-bundle
+./scripts/pre-merge.sh --remote
+./scripts/pre-merge.sh --rebuild-validator
 ```
 
-When to run: before opening a PR and whenever you change `runtime/`, `scripts/`, `tools/`, or `.github/workflows/`.
+## Pull requests
 
-### Full CI (push and PR)
+A good PR should:
 
-GitHub-hosted CI validates everything `pre-merge.sh` covers except the Colima VM boundary (which remains a local-macOS exercise). CI also:
+- explain what changed and why
+- call out any runtime or trust assumptions the change depends on
+- note any lower-assurance modes introduced or widened
+- update docs in the same change when behavior changes
 
-- Runs on `linux/amd64` and `linux/arm64` via QEMU.
-- Verifies release signing, SBOMs, and provenance attestations on tagged releases.
-- Publishes the final multi-arch runtime image after tag validation.
+If you touch the boundary or policy model, link the relevant invariant or
+threat-model section in the PR description.
 
-See `docs/github-workflows.md` and `docs/provenance.md` for details.
+## Security-sensitive issues
 
-## Branch and PR workflow
+Do not open a public issue for:
 
-- **Always use feature branches.** Never push directly to `main` or rewrite history on `main`.
-- Branch naming is not enforced, but use a descriptive prefix: `fix/`, `feat/`, `docs/`, `chore/`.
-- PR descriptions should state what changed and why, note any invariant assumptions the change relies on, and call out any lower-assurance modes introduced or widened.
-- If a security control depends on a specific runtime assumption, document that assumption in the same PR.
-- Reference the relevant section of `docs/threat-model.md` or `docs/invariants.md` if the change touches the trust boundary.
+- sandbox escapes
+- secret exposure
+- signing or provenance bypasses
+- unexpected trust widening
 
-## Security disclosures
+Use the process in [SECURITY.md](SECURITY.md).
 
-Do not open a public issue for sandbox escapes, secret-exposure paths, credential leaks, signing bypasses, or boundary-preservation bugs.
+## Adding or changing adapters
 
-See [SECURITY.md](SECURITY.md) for reporting instructions.
+Adapters should stay thin. A new or changed adapter should:
 
-## Adding a new adapter
+1. map into the provider's native control plane
+2. avoid treating provider config as the primary boundary
+3. ship invariant checks with the adapter change
+4. update the provider matrix and adapter-control-plane docs
 
-Adapters are thin mappings from the shared Workcell runtime into a provider's native control surface. Keep the adapter thin; do not treat provider config as the primary security boundary.
-
-### Step-by-step
-
-1. **Create the adapter directory** under `adapters/<provider>/`.
-
-2. **Add a `README.md`** describing which native control files the adapter manages and its assurance tier. See `adapters/claude/README.md` and `adapters/codex/README.md` for the expected structure and tone.
-
-3. **Add native config files** for the provider's home directory (settings JSON, TOML config, instruction docs, MCP template). Follow the existing pattern:
-   - Claude: `managed-settings.json`, `mcp-template.json`, `CLAUDE.md`, `hooks/`
-   - Codex: `managed_config.toml`, `requirements.toml`, `mcp/config.toml`
-   - Gemini: `.gemini/settings.json`, `GEMINI.md`
-
-4. **Add a `seed_<provider>_home()` function** in `runtime/container/home-control-plane.sh`. The function must:
-   - Create the provider's home directory under `/state/agent-home/`.
-   - Link or copy managed baseline files with `workcell_link_control_plane_path` (for immutable files) or a copy with appropriate `chmod`.
-   - Call `workcell_render_provider_doc` to render the instruction doc with workspace import and injection policy layering.
-   - Call `workcell_copy_manifest_credential_file` for any provider-specific credential keys.
-
-5. **Register the provider in `provider-wrapper.sh`**:
-   - Add an autonomy-flag mapping in the `AGENT_NAME:WORKCELL_AGENT_AUTONOMY` case.
-   - Add a launch `exec` branch in the `AGENT_NAME` case at the bottom.
-   - Add `reject_unsafe_<provider>_args` in `provider-policy.sh` if the provider accepts override flags that must be blocked.
-
-6. **Add the provider to `docs/provider-matrix.md`** with its native control plane, boundary fit, and notes.
-
-7. **Write invariant checks** in `verify/` for the new adapter. Ship invariant tests with the adapter, not as a follow-up.
-
-8. **Update `docs/adapter-control-planes.md`** to include the new provider's control file matrix and flag mappings.
-
-9. **Add MCP template** — ship an empty or locked-down MCP config. Do not seed any live registry-backed MCP defaults. See `adapters/codex/mcp/config.toml` and `adapters/claude/mcp-template.json`.
-
-### Rules
-
-- Never claim the adapter config is the primary security boundary.
-- Keep CLI and GUI assurance tiers separate. Mark GUI paths as lower-assurance explicitly.
-- Do not mount host credentials, home directories, or sockets through the adapter.
-- Mask repo-local control files for the new provider (`.claude/`, `.codex/`, `.gemini/` equivalents) on the safe path.
-
-## Common maintenance tasks
-
-### Update a Debian snapshot pin
-
-The Debian snapshot URL and date are pinned in the Dockerfile under `runtime/container/`. Update the snapshot date and the corresponding digest. Run `scripts/check-pinned-inputs.sh` to confirm the new pin passes policy checks, then run `./scripts/pre-merge.sh` to confirm the container still builds reproducibly.
-
-### Update the Codex version pin
-
-The pinned Codex release version, checksum, and Sigstore bundle reference live in the build input manifest and Dockerfile. After updating:
-
-1. Run `scripts/verify-upstream-codex-release.sh` to re-verify the new release assets against the published Sigstore bundle.
-2. Run `scripts/check-pinned-inputs.sh` to confirm lockfile graph integrity.
-3. Run `./scripts/pre-merge.sh` to confirm the full stack passes.
-
-### Add a Codex execpolicy rule
-
-Codex execpolicy rules live in `adapters/codex/.codex/rules/default.rules` (the baseline readable by agents) and are reflected in `adapters/codex/requirements.toml` (the hard requirements file).
-
-To add a rule:
-
-1. Add a `[[rules.prefix_rules]]` entry to `adapters/codex/requirements.toml` with the `pattern`, `decision`, and `justification` fields.
-2. Add the same or a corresponding entry to `adapters/codex/managed_config.toml` if it belongs in the admin-managed baseline.
-3. Run `./scripts/dev-quick-check.sh` to confirm TOML syntax is valid.
-4. Add or update the corresponding invariant test in `verify/`.
-
-## Code style
-
-### Shell (`shellcheck` + `shfmt`)
-
-All first-party shell scripts must pass `shellcheck -x` and `shfmt -ln=bash -i 2 -ci -d`. The exact list of checked files is in `scripts/dev-quick-check.sh`. Scripts start with `#!/usr/bin/env -S BASH_ENV= ENV= bash` and `set -euo pipefail` to sanitize the loader environment before any logic runs.
-
-### Python
-
-Python files under `scripts/lib/` and `tests/python/` must compile with `python3 -m py_compile` and all `test_*.py` files must pass `python3 -m unittest discover`. No external linter is currently enforced beyond compilation and passing tests; keep style consistent with the existing files.
-
-### Rust
-
-The Rust launcher under `runtime/container/rust/` must pass `cargo fmt --all --check`, `cargo clippy --all-targets --locked --offline -- -D warnings`, and `cargo test --locked --offline`. Run all three via `./scripts/dev-quick-check.sh`.
+See [workflows/adapter-porting.md](workflows/adapter-porting.md) for the
+porting checklist.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Workcell
 
-`Workcell` provides a bounded local runtime with explicit isolation and policy
-controls for coding agents, including Codex, Claude, and Gemini. It keeps the
-active agent inside a dedicated VM plus hardened container boundary and exposes
-thin provider adapters instead of pretending every agent product shares one
-control plane.
+Workcell runs coding agents inside a bounded local runtime on macOS: a
+dedicated Colima VM plus a hardened container inside that VM. It supports
+Codex, Claude Code, and Gemini through thin provider adapters that seed each
+provider's native control plane without pretending the provider config itself
+is the security boundary.
 
-This project is organized around these priorities, in order:
+## Priorities
 
 1. Developer experience
 2. Simplicity
@@ -14,498 +14,175 @@ This project is organized around these priorities, in order:
 4. Performance
 5. Idiomatic correctness
 
-These priorities apply only inside a fixed invariant set. Developer experience
-and simplicity can shape the safe path, but they do not justify puncturing the
-runtime boundary or weakening defined security guarantees.
-
-The invariant set is non-negotiable. The numbered priority order applies only
-after the boundary and trust assumptions are fixed.
-
-## Documentation index
-
-| Topic | File |
-|-------|------|
-| Getting started | [Quick start](#quick-start) (below) |
-| Threat model | [docs/threat-model.md](docs/threat-model.md) |
-| Security invariants | [docs/invariants.md](docs/invariants.md) |
-| Provider matrix | [docs/provider-matrix.md](docs/provider-matrix.md) |
-| Validation scenarios | [docs/validation-scenarios.md](docs/validation-scenarios.md) |
-| Injection policy | [docs/injection-policy.md](docs/injection-policy.md) |
-| Provenance & signing | [docs/provenance.md](docs/provenance.md) |
-| GitHub workflows | [docs/github-workflows.md](docs/github-workflows.md) |
-| Adapter control planes | [docs/adapter-control-planes.md](docs/adapter-control-planes.md) |
-| Claude adapter | [adapters/claude/README.md](adapters/claude/README.md) |
-| Codex adapter | [adapters/codex/README.md](adapters/codex/README.md) |
-| Gemini adapter | [adapters/gemini/README.md](adapters/gemini/README.md) |
-| Contributing | [CONTRIBUTING.md](CONTRIBUTING.md) |
-| Security policy | [SECURITY.md](SECURITY.md) |
+Those priorities apply only after the boundary and invariants are fixed.
+Workcell does not trade away the VM-plus-container boundary for convenience.
 
 ## Design stance
 
-This repository does not treat prompts, provider config files, or IDE settings
-as the main security boundary. The primary boundary is an external runtime:
+Workcell treats the external runtime as primary:
 
-- a dedicated Colima VM profile on macOS
-- a hardened inner container that runs the selected agent
-- each provider's native policy surface inside that container
+- the selected workspace is the only intended writable host mount
+- host homes, keychains, credential helpers, and agent sockets stay out
+- `docker.sock`, `ssh-agent`, GPG agent sockets, and provider state are not
+  passed through on the safe path
+- repo-local control-plane files such as `AGENTS.md`, `CLAUDE.md`,
+  `GEMINI.md`, `.codex/`, `.claude/`, and `.gemini/` are masked inside the
+  mounted workspace and imported into provider homes instead
+- lower-assurance paths are explicit, acknowledged, and surfaced in audit
+  output
 
-That layered design exists because the strongest practical local boundary on
-this host is the VM. The inner container is the packaging and workflow layer,
-not the only wall.
+The result is one shared boundary with provider-native adapters on top, not a
+fake universal agent abstraction.
 
-The design explicitly avoids common boundary punctures:
+## Start here
 
-- no host home directory mount
-- no host `docker.sock`
-- no SSH, GPG, or other agent socket passthrough
-- no host `~/.codex` or similar persistent auth and state passthrough
-- no host credential helper, keychain, or browser-profile passthrough
-- no ambient secret or SSH-agent passthrough; host-side docs, config, and
-  secret material may enter the session only through an explicit Workcell
-  injection policy that stages them into per-session runtime state
-- public in-container `/usr/local/bin` launch surfaces sanitize hostile loader
-  environment variables before bash or provider wrapper logic begins; internal
-  `/usr/local/libexec/workcell/*.sh` support scripts are not supported operator
-  entrypoints
-- common git hook-bypass flags and inline hook-path overrides are blocked on the Tier 1 path
-- repo-local control-plane files such as `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`,
-  `.codex/`, `.claude/`, `.gemini/`, and mutable git hook/config paths are
-  masked read-only on the safe path
-- per-session home control-plane files are re-seeded on each provider launch
-- `/tmp` is mounted `noexec`; `TMPDIR` points at ephemeral exec-capable state
-  under `/state/tmp`
-- on the `strict` profile, direct native ELF execution from mutable
-  `/workspace` and `/state` paths is blocked, and mutable shebang scripts
-  cannot point straight at protected real runtimes or loaders that target them
-- nested coding-agent CLI launches are blocked or mediated on the safe path,
-  and the public `node` surface blocks direct execution of Gemini's shipped
-  npm entrypoint, repackaged workspace copies of Gemini's shipped npm package
-  tree, and native addon loading instead of treating them as ordinary
-  workspace code
+Read the repo in this order:
 
-## Scope
+1. start with the quick start below
+2. use [docs/invariants.md](docs/invariants.md) for the contract
+3. use the provider quickstarts for provider-specific setup
+4. use [docs/provenance.md](docs/provenance.md) and
+   [docs/github-workflows.md](docs/github-workflows.md) for release and
+   maintainer details
 
-Supported tiers:
+Workcell uses two terms that matter throughout the docs:
 
-- Tier 1: CLI agents fully inside the dedicated runtime boundary
-- Tier 2: GUI variants only when the GUI is a client to that same bounded
-  runtime
-- Tier 3: host-native GUI, cloud, or web guidance only; no claim of equivalent
-  host-bound guarantees
+- `Tier 1`: a provider CLI running fully inside the bounded Workcell runtime
+- `strict`: the default managed Tier 1 runtime mode
 
-Initial adapters target:
+## Mode map
 
-- Codex CLI now, with Codex app integration planned only after a bounded client
-  path is implemented
-- Claude Code CLI
-- Gemini CLI
-- GUI variants only with explicit downgrade notes when the boundary is weaker
+| Path | Intended use | Key properties |
+|---|---|---|
+| `strict` | default developer lane | bounded VM plus container, reviewed network posture, repo control-plane masking, `--agent-autonomy yolo` by default |
+| `strict --container-mutability readonly` | strongest managed lane | package-manager writes blocked; no package-mutation downgrade |
+| `build` | image preparation and dependency refresh | broader egress for rebuild and preparation work |
+| `breakglass` | explicit higher-trust debugging path | requires `--ack-breakglass`; visibly lower assurance |
+
+Other defaults that matter:
+
+- `--agent` is always required; there is no default provider
+- `--agent-autonomy yolo` is the default; `--agent-autonomy prompt` is the
+  explicit lower-assurance opt-out
+- `--cache-profile off` is the default
+- `--prepare` is the recommended first-run path
 
 ## Quick start
 
+Install the launcher symlink and verify the host prerequisites:
+
 ```bash
 ./scripts/install.sh
-./scripts/uninstall.sh
 workcell --prepare --agent codex --workspace /path/to/repo
-workcell --prepare-only --agent codex --workspace /path/to/repo
+```
+
+Launch a provider inside the bounded runtime:
+
+```bash
 workcell --agent codex --workspace /path/to/repo
-workcell --agent codex --inspect --workspace /path/to/repo
-workcell --agent codex --doctor --workspace /path/to/repo
 workcell --agent claude --workspace /path/to/repo
-workcell --prepare --agent gemini --agent-arg --version --workspace /path/to/repo
-man workcell
+workcell --agent gemini --workspace /path/to/repo
 ```
 
-The safe path is `strict`, and it is also the default. `--prepare` is the
-recommended first-run path: it seeds or refreshes the prepared runtime image
-inside the isolated VM, then continues with the requested launch. `build`
-still exists as the explicit wider-egress runtime profile for dependency and
-image creation work. `breakglass` is explicit, higher trust, visibly
-different, and requires `--ack-breakglass`, but the managed in-container
-entrypoint still does not auto-inject unsafe provider flags.
-There is no default agent; pass `--agent codex`, `--agent claude`, or
-`--agent gemini` explicitly on every launch.
-Workcell launches the selected provider directly inside the bounded runtime.
-There is no separate container attach or “start Codex and then connect to it”
-step on the safe path.
-Workcell does default the selected provider to no-prompt autonomy:
-`--agent-autonomy yolo` is the default, and `--agent-autonomy prompt` is the
-explicit opt-out when you want the provider’s ordinary approval flow.
-Prompt autonomy is also a lower-assurance choice: provider-native approval
-state or session-local policy amendments can change during the live session, so
-Workcell surfaces that posture explicitly in the launch audit output.
-`--agent-arg` is repeatable and appends provider-native argv at launch without
-making you repeat `codex`, `claude`, or `gemini` yourself. `--agent-arg`
-values are still treated as ordinary user-supplied provider argv and go
-through the same in-container denylist as raw `-- ...` arguments.
-`--prepare-only` is the prewarm path when you want to seed or refresh the
-reviewed runtime image without launching an agent session yet.
-`--allow-control-plane-vcs` is the narrow, explicitly acknowledged escape hatch
-for Workcell-maintainer workflows that need Git status, diff, or staging
-visibility on otherwise masked repo control-plane paths. It requires
-`--ack-control-plane-vcs`, keeps those paths mounted read-only, and surfaces
-the session as `workspace_control_plane=readonly-vcs` with
-`session_assurance_initial=lower-assurance-control-plane-vcs`.
-`--cache-profile off` is the default. `--cache-profile standard` opt-ins to a
-host-persisted non-secret cache plane for package/build tooling such as npm,
-pnpm, pip, uv, Poetry, Cargo registry/git, Go module/build cache, `ccache`,
-`bun`, and XDG-cache-backed tooling. The persistent cache plane is scoped to
-the current workspace by default so one repo does not silently seed tool caches
-for another. That is a
-lower-assurance path and is not treated as part of the clean `strict`
-session boundary.
-`--codex-rules-mutability readonly` is the clean-session default. That keeps
-Codex execpolicy rules immutable on the managed path until either
-`--agent-autonomy prompt` or a package-manager mutation has already lowered the
-live session. If you explicitly want session-local Codex execpolicy amendments
-to persist across nested Codex launches until container exit even on the yolo
-path, opt in with `--codex-rules-mutability session`. Workcell surfaces both
-the configured and effective Codex rules posture in launch audit output.
-`--injection-policy` lets you stage reviewed per-session inputs such as
-org-wide instructions, persistent provider credentials, SSH material, and
-read-only config files without passing through host homes or sockets. If
-`~/.config/workcell/injection-policy.toml` exists, Workcell uses it by
-default; `--no-default-injection-policy` disables that for a specific launch.
-`--vm-cpu`, `--vm-memory`, and `--vm-disk` tune the dedicated Colima VM;
-`--container-cpu` and `--container-memory` tune the inner runtime container
-without changing the reviewed profile defaults for other launches.
-`--log-level debug` surfaces the previously-suppressed Colima/image-build
-output during startup. `--debug-log /path/to/file` persistently captures
-launcher stderr plus any build/output streams that Workcell explicitly forwards
-through the launcher, `--file-trace-log /path/to/file` retains a session-home
-file transaction trace on the host, and `--audit-transcript /path/to/file`
-captures the full interactive terminal transcript including prompts and typed
-responses plus session timestamps and exit status. All three persistent
-host-side capture knobs are explicit lower-assurance choices, emit an explicit
-warning banner when enabled, apply only to real launched sessions, and stay
-off by default.
-With `--container-mutability ephemeral`, Workcell also allows `apt` and
-`apt-get` to reach the pinned Debian snapshot endpoints so transient build
-tooling can be installed without opening the session to arbitrary distro
-mirrors. Successful package mutations are explicitly treated as a
-lower-assurance in-session downgrade: maintainer scripts run as root inside the
-mutable container, so Workcell warns, records the downgrade in runtime state,
-and keeps that warning attached to later provider launches until the container
-evaporates on exit.
-That lane also adds only the minimal Linux capabilities needed for Workcell’s
-root-to-runtime-user handoff inside the container:
-`SETUID` and `SETGID`.
-
-Choose the mutability lane explicitly:
-
-- `strict`: default developer lane, `container_assurance=managed-mutable`.
-  This allows transient package installs, but a successful package mutation
-  downgrades the live session to `lower-assurance-package-mutation` until exit.
-- `strict` + `--container-mutability readonly`: strongest managed lane,
-  `container_assurance=managed-readonly`. Package-manager writes stay blocked,
-  so the in-session control-plane posture does not downgrade.
-- `build`: explicit mutable preparation lane with broader egress for dependency
-  and image creation work.
-- `--agent-autonomy prompt`: keeps the provider’s ordinary approval flow, but
-  Workcell surfaces that separately as
-  `autonomy_assurance=lower-assurance-prompt-autonomy`.
-
-By default, Workcell expects a git worktree and only forwards the selected
-provider command through the bounded runtime. Use `--allow-nongit-workspace`
-only for an intentional marker-based workspace. `--allow-arbitrary-command`
-exists only for lower-assurance boundary debugging with
-`--ack-arbitrary-command`; it bypasses the managed in-container entrypoint and
-is recorded in the host audit log as a downgraded path.
-The safe path requires self-contained git admin state inside the mounted
-workspace; linked worktrees with external gitdirs are rejected.
-The mounted workspace remains the durable source of truth across container
-exit, so agent-authored code already survives locally on the host. Final
-branch publication stays host-side: use `workcell publish-pr` to create or
-switch a feature branch, make a signed commit, push it, and open a draft PR
-with agent-prepared metadata instead of attempting final GitHub publication
-from inside the Tier 1 session.
-
-Common recovery paths:
-
-- First launch or missing prepared runtime image:
-  `workcell --prepare --agent codex --workspace /path/to/repo`
-  Replace `codex` with `claude` or `gemini` for the corresponding provider.
-- Prewarm the runtime image without launching:
-  `workcell --prepare-only --agent codex --workspace /path/to/repo`
-- Publish the current workspace snapshot to a draft PR on a feature branch:
-  `workcell publish-pr --workspace /path/to/repo --branch feature/name --title-file /tmp/pr-title.txt --body-file /tmp/pr-body.md --commit-message-file /tmp/commit-message.txt`
-- First launch with provider prompts enabled:
-  `workcell --prepare --agent claude --agent-autonomy prompt --workspace /path/to/repo`
-- One-off provider flags without repeating the provider command:
-  `workcell --agent gemini --agent-arg --version --workspace /path/to/repo`
-- Manual provider-authenticated smoke with explicit injected credentials:
-  `./scripts/provider-e2e.sh --agent codex --workspace /path/to/repo`
-- Conflicting unmanaged Colima profile:
-  `workcell --repair-profile --agent codex --workspace /path/to/repo`
-  Replace `codex` with `claude` or `gemini` for the corresponding provider.
-- Inspect current derived state without launching:
-  `workcell --agent codex --inspect --workspace /path/to/repo`
-  Alias: `workcell inspect --agent codex --workspace /path/to/repo`
-- Validate host/workspace/profile posture and print the next safe command:
-  `workcell --agent codex --doctor --workspace /path/to/repo`
-  Alias: `workcell doctor --agent codex --workspace /path/to/repo`
-  When the workspace path is missing or invalid, `doctor` reports that first
-  instead of treating `--prepare` as the next step.
-- Print the last retained audit/debug/transcript log for a profile:
-  `workcell --logs audit --colima-profile workcell-...`
-  Alias: `workcell logs audit --colima-profile workcell-...`
-- Print the last retained file transaction trace for a profile:
-  `workcell --logs file-trace --colima-profile workcell-...`
-  Alias: `workcell logs file-trace --colima-profile workcell-...`
-- Print the effective auth posture without launching:
-  `workcell auth-status --agent codex --workspace /path/to/repo`
-  This includes the primary provider auth mode, the ordered auth mode set, and
-  SSH config assurance when injection is active.
-- Fast local validation during normal editing:
-  `./scripts/dev-quick-check.sh`
-- Clean stale Workcell temp state:
-  `workcell --gc`
-  Alias: `workcell gc`
-- Reset all local Workcell install links, managed profiles, and Workcell-owned
-  host cache/temp state before testing a new build:
-  `./scripts/uninstall.sh`
-  Use `./scripts/uninstall.sh --dry-run` to preview removals.
-
-`--repair-profile` deletes only the conflicting derived Colima profile so
-Workcell can recreate it with reviewed mounts and policy. On `strict`, it also
-acts like `--prepare`, because the recreated profile starts empty.
-
-## Session injections
-
-The supported way to place consistent material into every session is an
-operator-owned injection policy, not ad hoc host passthrough.
-
-Workcell treats injected content as three separate classes:
-
-- common or provider-specific non-secret instructions that are rendered into
-  provider-native home docs like `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`
-- provider-native credentials mounted read-only from their original host paths
-  and copied into the ephemeral session home at launch time
-- copied files or directories placed into either `/state/injected/...` or a
-  non-reserved path under the ephemeral session home. Public copies are staged
-  through the launcher-owned bundle; secret copies are mounted read-only from
-  their original host paths and copied in-session.
-- SSH material mounted read-only from its original host paths and copied into
-  the ephemeral in-container `~/.ssh` with strict permissions
-
-The immutable adapter baselines under `adapters/` are never mutated in place.
-Repo-local `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` are masked inside the
-workspace on the safe path and imported into the provider-native home docs
-instead. Claude and Gemini import repo-local `AGENTS.md` as the shared
-workspace layer and then append `CLAUDE.md` or `GEMINI.md` when present. When
-a workspace only ships `AGENTS.md`, Claude and Gemini still fall back to that
-imported file rather than silently dropping shared instructions.
-When those control-plane files or directories are tracked in git, the safe path
-masks them with a read-only snapshot from the git index so ordinary `git status`
-and `git add -A` flows do not get polluted by synthetic placeholder diffs.
-If you intentionally need to stage or diff real control-plane changes from
-inside Workcell, use `--allow-control-plane-vcs --ack-control-plane-vcs`; that
-switches the workspace posture to a visibly lower-assurance, read-only VCS lane
-rather than silently exposing the live control plane on the default path.
-By default, Codex rules stay linked to the immutable adapter baseline
-until the session is already downgraded by package mutation or the operator has
-selected `--agent-autonomy prompt`. If you explicitly opt into
-`--codex-rules-mutability session`, or if prompt autonomy or package mutation
-has already lowered the session assurance, Workcell seeds a session-local
-writable copy of the Codex rules tree so provider-approved execpolicy
-amendments can persist across nested Codex launches until the container exits,
-while the immutable adapter baseline remains unchanged under `adapters/`.
-
-Example policy:
-
-```toml
-version = 1
-
-[documents]
-common = "/Users/example/.config/workcell/common-agent.md"
-claude = "/Users/example/.config/workcell/claude-extra.md"
-
-[credentials]
-codex_auth = "/Users/example/.codex/auth.json"
-claude_auth = "/Users/example/.claude.json"
-claude_api_key = "/Users/example/.config/workcell/claude-api-key.txt"
-claude_mcp = "/Users/example/.config/workcell/claude-mcp.json"
-gemini_env = "/Users/example/.config/workcell/gemini.env"
-gemini_projects = "/Users/example/.config/workcell/gemini-projects.json"
-
-[credentials.github_hosts]
-source = "/Users/example/.config/gh/hosts.yml"
-providers = ["codex", "claude", "gemini"]
-
-[ssh]
-enabled = true
-config = "/Users/example/.ssh/config"
-known_hosts = "/Users/example/.ssh/known_hosts"
-identities = ["/Users/example/.ssh/id_workcell"]
-
-[[copies]]
-source = "/Users/example/.config/corp-ca.pem"
-target = "/state/injected/corp-ca.pem"
-classification = "public"
-
-[[copies]]
-source = "/Users/example/.config/workcell/repo-token.txt"
-target = "~/.config/workcell/token.txt"
-classification = "secret"
-```
-
-Use `[credentials]` for reusable provider or GitHub auth when you do not want
-to log in on every launch. Workcell validates those host files, mounts them
-read-only for the current session, and then copies them into the ephemeral
-in-container home. Generic `[[copies]]` and `[ssh]` entries are still staged
-through the launcher-owned injection bundle only for non-secret material. SSH
-inputs and `classification = "secret"` copies use the same direct-mount model
-as `[credentials]` and are copied into the session from their original host
-paths. Secret sources must be owned by the launching user, must not be
-symlinks, and must not be group/world-readable. `ssh.known_hosts` is treated
-separately: the source file may stay world-readable as usual, but it must not
-be a symlink or group/world-writable. Shared GitHub CLI credentials must use
-`[credentials.github_hosts]` or `[credentials.github_config]` tables with
-explicit `providers = [...]` selection. Legacy scalar shared GitHub credential
-entries still work as an all-provider shorthand for existing local policies.
-When you need provider- or mode-specific
-scoping, use `[credentials.<name>]` tables with `source`, `providers`, and
-`modes`.
-
-Use it explicitly:
+Useful operator flows:
 
 ```bash
-workcell --prepare --agent codex --workspace /path/to/repo \
-  --injection-policy ~/.config/workcell/injection-policy.toml
+workcell --prepare-only --agent codex --workspace /path/to/repo
+workcell --inspect --agent codex --workspace /path/to/repo
+workcell --doctor --agent codex --workspace /path/to/repo
+workcell --auth-status --agent codex --workspace /path/to/repo
+workcell --logs audit --colima-profile workcell-...
+workcell publish-pr --workspace /path/to/repo --branch feature/name \
+  --title-file /tmp/pr-title.txt \
+  --body-file /tmp/pr-body.md \
+  --commit-message-file /tmp/commit-message.txt
 ```
 
-Or keep it as the default:
+What to expect from the safe path:
 
-```bash
-mkdir -p ~/.config/workcell
-$EDITOR ~/.config/workcell/injection-policy.toml
-workcell --agent codex --workspace /path/to/repo
-```
+- Workcell launches the selected provider directly inside the bounded runtime
+- there is no separate "start a container, then attach the agent" step
+- `publish-pr` runs on the host so signed commits and GitHub publication stay
+  outside the Tier 1 container
+- `--debug-log`, `--file-trace-log`, and `--audit-transcript` are explicit
+  lower-assurance operator choices and are off by default
 
-Intentional non-goals for the safe path:
+## Session inputs
 
-- no host `SSH_AUTH_SOCK` forwarding
-- no whole-home or provider-state passthrough
-- no arbitrary environment-variable secret injection
-- no writes back into the staged host bundle or immutable adapter baselines
+The supported way to feed stable inputs into sessions is an explicit injection
+policy, usually at `~/.config/workcell/injection-policy.toml`.
 
-## Repository layout
+Workcell can stage:
 
-- `runtime/`: shared VM plus container boundary
-- `policy/`: generic policy contracts and operator expectations
-- `adapters/`: thin provider mappings for Codex, Claude, and Gemini
-- `verify/`: invariant verification specs and harnesses
-- `docs/`: threat model, assurance tiers, provider matrix, and validation scenarios
-- `workflows/`: launch, migration, and downgrade-path notes
-- `scripts/`: installers, launchers, and verification entrypoints
+- common or provider-specific instruction fragments
+- provider-native credentials such as `codex_auth`, `claude_auth`,
+  `claude_api_key`, `claude_mcp`, `gemini_env`, `gemini_oauth`,
+  `gemini_projects`, and `gcloud_adc`
+- scoped GitHub CLI credentials through `github_hosts` and `github_config`
+- SSH config, known hosts, and identities
+- explicit copied files or directories for non-reserved paths
 
-## Verification
+It does not support whole-home passthrough, arbitrary environment-variable
+secret injection, or host socket forwarding on the safe path.
 
-- `scripts/validate-repo.sh`: repo-local shell, JSON, TOML, YAML, and manpage
-  checks
-- `scripts/pre-merge.sh`: one-command local pre-merge path that builds the
-  validator image, runs workflow lint, validates the repo inside the validator
-  container, then runs invariants, container smoke, release-bundle
-  reproducibility, host-native runtime reproducibility, and optionally the
-  remote linux/amd64 lane. The shared `scripts/verify-reproducible-build.sh`
-  entrypoint remains multi-platform by default; CI and release preflight keep
-  the cross-platform reproducibility gate. `--remote` runs the safe remote
-  `validate` lane only;
-  `--remote-heavy` is the explicit shared-daemon escape hatch for remote
-  `smoke` / `repro` / `release-bundle` checks. By default it requires a clean
-  worktree, including untracked files. With `--allow-dirty`, local validation
-  runs against the live worktree and the remote lane auto-switches to
-  `--remote-snapshot worktree` plus `--include-untracked` unless you explicitly
-  override the snapshot mode. Workflow lint still depends on host `actionlint`
-  and `zizmor`.
-- `scripts/check-workflows.sh`: `actionlint` and `zizmor`
-- `scripts/check-pinned-inputs.sh`: pin-policy checks for non-ecosystem release
-  inputs such as the Debian snapshot, immutable base-image digests, and exact
-  runtime and validator package sets, pinned BuildKit, QEMU, Cosign, and Syft
-  workflow inputs, plus integrity validation for the committed provider
-  lockfile graph
-- `scripts/verify-upstream-codex-release.sh`: re-verifies the pinned Codex
-  release assets against OpenAI's published Sigstore bundle
-- `scripts/verify-upstream-claude-release.sh`: re-verifies the pinned Claude
-  native release assets against Anthropic's published release manifest
-- `scripts/verify-build-input-manifest.sh`: deterministic local verification
-  for the release build-input manifest generator
-- `scripts/verify-coverage.sh`: `>=90%` numeric coverage for first-party Python
-  helpers and Rust launcher wrappers, with shell boundary code kept under
-  integration and mutation tests instead of a fake line-coverage target
-- `scripts/container-smoke.sh`: direct container build and adapter smoke tests
-- `scripts/verify-invariants.sh`: local invariant regression checks against the
-  launcher and shipped adapter policy
-- `scripts/verify-reproducible-build.sh`: deterministic paired multi-platform
-  OCI runtime image verification under a fixed `SOURCE_DATE_EPOCH`, with a
-  stable OCI subject digest plus per-platform digest binding for release preflight
-- `scripts/verify-release-bundle.sh`: deterministic source bundle verification
-  under a fixed `SOURCE_DATE_EPOCH`
-- `scripts/dev-remote-validate.sh`: stage the current working tree to a private
-  remote amd64 builder, build an ephemeral remote helper container there from
-  `tools/remote-validator/Dockerfile`. The default remote run is the safe
-  `validate` check only. Heavy shared-daemon checks such as `smoke`, `repro`,
-  and `release-bundle` require explicit `--check ...` selection plus
-  `--allow-shared-daemon-heavy-checks` or the corresponding host-local config
-  toggle. Set the builder explicitly with `--host <user@host>` or
-  `WORKCELL_REMOTE_VALIDATE_HOST`. The default remote snapshot is the local
-  index; `--snapshot worktree` and `--include-untracked` are explicit opt-ins.
-  For host-local defaults, point `WORKCELL_REMOTE_VALIDATE_CONFIG_PATH` at a
-  host-local config file or use the default
-  `~/.config/workcell/remote-validate.env`. The remote reproducibility lane is
-  intentionally native `linux/amd64` only; the canonical multi-architecture
-  release gate remains the local macOS plus GitHub release path.
+See [docs/injection-policy.md](docs/injection-policy.md) and
+[docs/examples/injection-policy.toml](docs/examples/injection-policy.toml).
 
-Full Colima plus Virtualization.Framework boundary verification remains a local
-or self-hosted macOS exercise. GitHub-hosted CI validates the repo shape and
-container path, not the full host boundary.
+## Provider support
 
-Recommended split:
+| Provider | Tier 1 surface today | Native control plane | Quickstart |
+|---|---|---|---|
+| Codex | CLI | `~/.codex/config.toml`, `AGENTS.md`, rules, MCP config | [docs/examples/quickstart-codex.md](docs/examples/quickstart-codex.md) |
+| Claude | Claude Code CLI | `~/.claude/settings.json`, `CLAUDE.md`, `.mcp.json`, auth mirrors, hooks | [docs/examples/quickstart-claude.md](docs/examples/quickstart-claude.md) |
+| Gemini | Gemini CLI | `~/.gemini/settings.json`, `GEMINI.md`, `.env`, `projects.json` | [docs/examples/quickstart-gemini.md](docs/examples/quickstart-gemini.md) |
 
-- local macOS: `scripts/verify-invariants.sh`, launcher UX work, and any
-  Colima or Virtualization.Framework debugging
-- remote amd64 builder: `./scripts/dev-remote-validate.sh`
-  This path stages the selected snapshot to a root-owned remote temp workspace
-  when `sudo` is available, then runs the heavy checks inside an ephemeral
-  helper container on that host.
-  This is still a lower-assurance trusted-builder path because the helper
-  container talks to the remote host Docker daemon. Treat it as a performance
-  and parity aid, not as a provenance or multi-tenant isolation boundary.
-- GitHub CI and release: final policy, signing, attestations, and publication
-
-Each real launch appends durable host-side audit events under the managed
-Colima profile directory. Those events record the workspace, runtime profile,
-network mode, selected adapter, launch-time assurance fields, whether the run
-stayed on the managed Tier 1 path or used an explicitly lower-assurance mode,
-and whether the session later downgraded itself through package mutation.
-The durable audit log is metadata-only by default. Full stdout/stderr capture
-and full prompt/response transcript capture are separate explicit lower-
-assurance operator choices.
-`build` sessions additionally record when the temporary bootstrap allowlist was
-applied for image creation.
+GUI and IDE surfaces are lower assurance unless they act only as clients to
+the same bounded runtime.
 
 ## Release posture
 
-Release automation publishes a multi-arch runtime image, SBOMs, checksums, and
-signed provenance materials. Tagged releases are revalidated before signing and
-publishing. Releases publish the final multi-arch image by first pushing pinned
-single-platform manifests, then assembling the published manifest list in a
-fixed `amd64` then `arm64` order. Releases also publish directly signed source
-bundle, build-input, builder-environment, and SBOM artifacts. The signed
-checksum manifest additionally covers the source bundle, published image digest,
-build input manifest, builder environment manifest, and both release SBOMs even
-when GitHub attestations are not enabled. The build-input manifest covers the
-runtime image build context that the Dockerfile actually consumes, plus the
-release and verification inputs that gate publication. See
-`docs/github-workflows.md` and `docs/provenance.md`.
+Tagged releases are rebuilt and verified before publication. The release path:
 
-## Implementation goals
+- reruns validation, smoke, and reproducibility checks
+- publishes from the archived source bundle rather than the live checkout
+- signs the image, source bundle, checksums, build-input manifest,
+  control-plane manifest, builder-environment manifest, and both SBOMs with
+  keyless Sigstore/Cosign
+- publishes GitHub-native attestations in the canonical upstream repository as
+  an additional verification surface, not a replacement for Sigstore
 
-- make the safe path the default path
-- preserve normal coding ergonomics across supported providers
-- make `breakglass` mode explicit, acknowledged, and externally sandboxed
-- ship invariant tests with the runtime, not as a follow-up
-- document any lower-assurance modes rather than implying parity
+Forks can keep the GitHub attestation gate off. The upstream repo treats that
+setting as hosted control-plane state and audits it accordingly.
+
+See [docs/provenance.md](docs/provenance.md) and
+[docs/github-workflows.md](docs/github-workflows.md).
+
+## Documentation map
+
+| Topic | File |
+|---|---|
+| Security invariants | [docs/invariants.md](docs/invariants.md) |
+| Threat model | [docs/threat-model.md](docs/threat-model.md) |
+| Provider matrix | [docs/provider-matrix.md](docs/provider-matrix.md) |
+| Adapter control planes | [docs/adapter-control-planes.md](docs/adapter-control-planes.md) |
+| Injection policy | [docs/injection-policy.md](docs/injection-policy.md) |
+| Validation coverage | [docs/validation-scenarios.md](docs/validation-scenarios.md) |
+| Scenario gaps | [docs/scenario-gaps.md](docs/scenario-gaps.md) |
+| Use-case coverage | [docs/use-case-matrix.md](docs/use-case-matrix.md) |
+| Provenance and signing | [docs/provenance.md](docs/provenance.md) |
+| GitHub automation | [docs/github-workflows.md](docs/github-workflows.md) |
+| Contributor workflow | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Security reporting | [SECURITY.md](SECURITY.md) |
+
+## Repository layout
+
+- `runtime/`: VM and container boundary implementation
+- `policy/`: shared contract layer and hosted-control policy
+- `adapters/`: provider-native baselines for Codex, Claude, and Gemini
+- `scripts/`: launcher, validation, release, and audit entrypoints
+- `verify/`: invariant-oriented verification material
+- `docs/`: user-facing design, quickstarts, and release docs
+- `workflows/`: implementation notes such as adapter porting guidance
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,24 +2,23 @@
 
 ## Reporting
 
-Do not open a public issue for a new sandbox escape, secret-exposure path,
-credential leak, signing bypass, or boundary-preservation bug.
+Do not disclose new sandbox escapes, credential leaks, signing bypasses, or
+boundary-preservation bugs in a public issue.
 
 Use GitHub Private Vulnerability Reporting or a GitHub security advisory for
 this repository. If that is unavailable, contact the repository owner privately
-through GitHub before disclosing details.
+through GitHub first.
 
-## Scope
+## In scope
 
-High-priority issues include:
+High-priority reports include:
 
-- reads of host secrets outside the documented trust boundary
+- reads of host secrets outside the documented boundary
 - writes outside the intended workspace without explicit `breakglass`
-- ambient network access in `strict`
 - unmanaged host socket or credential passthrough
+- silent trust widening through repo content or workflow changes
 - release signing, SBOM, or provenance regressions
-- workflow changes that widen trust unexpectedly
 
 ## Supported branch
 
-- `main`
+Security fixes are expected on `main`.

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -1,9 +1,9 @@
 # Provider Adapters
 
-Each adapter maps the shared runtime and invariant model into a provider's
-native control surface.
+Each adapter maps the shared Workcell runtime into one provider's native
+control plane.
 
-Current targets:
+Current adapters:
 
 - `codex/`
 - `claude/`
@@ -12,6 +12,6 @@ Current targets:
 Adapter rules:
 
 - keep the adapter thin
-- prefer native provider configuration over wrapper-only policy
-- never claim the adapter is the primary boundary
-- keep CLI and GUI assurance tiers separate
+- prefer native provider config over wrapper-only policy
+- do not claim the adapter is the primary boundary
+- keep lower-assurance GUI or IDE paths clearly separate from Tier 1 CLI paths

--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -1,20 +1,21 @@
 # Claude Adapter
 
-This adapter maps the shared Workcell runtime boundary into Claude Code's
-native control surface:
+The Claude adapter maps the shared Workcell runtime into Claude Code's native
+files and guardrails.
+
+Managed surfaces:
 
 - `~/.claude/settings.json`
-- `CLAUDE.md`
-- `.mcp.json`
-- optional hooks as guardrails
+- rendered `~/.claude/CLAUDE.md`
+- `~/.mcp.json`
+- Claude auth compatibility files when injected
+- a reviewed `PreToolUse` Bash hook as defense in depth
 
-Claude hooks are defense in depth, not the security boundary.
+Key points:
 
-The strict baseline seeds an empty `.mcp.json`. Networked or package-fetching
-MCP servers must be opted into explicitly in a broader runtime mode.
-Reviewed Claude auth and MCP state can be injected explicitly with
-`credentials.claude_auth` and `credentials.claude_mcp`.
-
-Claude CLI is Tier 1 when it runs inside the shared bounded runtime. GUI or IDE
-surfaces are lower assurance unless they are attached to that same bounded
-runtime rather than executing on the host.
+- hooks are guardrails, not the security boundary
+- the default MCP template is empty
+- `claude_api_key`, `claude_auth`, and `claude_mcp` are the supported
+  credential/injection paths
+- GUI or IDE use is lower assurance unless it is only a client to the same
+  bounded runtime

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,29 +1,20 @@
 # Codex Adapter
 
-This adapter maps the shared Workcell runtime boundary into Codex-native
-controls:
+The Codex adapter maps the shared Workcell boundary into Codex-native controls:
 
 - `~/.codex/config.toml`
+- `managed_config.toml`
+- `requirements.toml`
 - `AGENTS.md`
-- `.rules`
-- managed configuration
-- MCP policy/templates with no live defaults
+- rules
+- MCP config
 
-Workcell re-seeds these controls into the session-local Codex home on each
-launch. Use the host `workcell` launcher to select the runtime profile,
-autonomy mode, and injection policy; provider-native overrides that widen trust
-are blocked inside the container rather than delegated to repo-local state.
-Final branch publication remains a host-side flow: the in-container Codex
-session should prepare branch, commit, and PR metadata, then the operator uses
-`workcell publish-pr` on the host to perform the signed commit, push, and PR
-creation.
+Workcell re-seeds this state into the session-local Codex home on launch.
+Repo-local control files stay masked on the safe path and are imported only as
+reviewed layers.
 
-For first-run and operator flows, start with the top-level `README.md` quick
-start. For the full control-plane mapping, see
-`docs/adapter-control-planes.md`.
+Final branch publication stays on the host through `workcell publish-pr`, not
+from inside the container session.
 
-CLI is Tier 1 when it runs fully inside the bounded runtime.
-
-Codex app support is planned Tier 2 work. It is only valid once the app is
-acting as a client to the same bounded executor rather than running on the
-host.
+Codex CLI is Tier 1 when it runs fully inside the bounded runtime. App support
+is only valid once it becomes a client of the same bounded executor.

--- a/adapters/gemini/README.md
+++ b/adapters/gemini/README.md
@@ -1,38 +1,22 @@
 # Gemini Adapter
 
-This adapter maps the shared Workcell runtime boundary into Gemini CLI's native
-control surface:
+The Gemini adapter seeds Gemini CLI's session-local home from reviewed
+baselines and explicit injection inputs.
+
+Managed surfaces:
 
 - `~/.gemini/settings.json`
-- `GEMINI.md`
-- optional injected `projects.json`
+- rendered `~/.gemini/GEMINI.md`
+- `~/.gemini/.env`
+- `~/.gemini/oauth_creds.json`
+- `~/.gemini/projects.json`
+- `~/.gemini/trustedFolders.json`
 
-Gemini CLI exposes its own sandbox setting, but the shared external runtime is
-the primary boundary here. Nested sandboxing is optional and not required for
-Tier 1.
+Key points:
 
-On the safe path, repo-local `.gemini/` workspace files stay masked. Use
-Workcell injection policy inputs such as `documents.gemini` or
-`credentials.gemini_projects` when you want reviewed Gemini state or
-instructions to persist across launches.
-
-On the managed strict/build path, the adapter seeds Gemini's session-local
-trusted-folders registry for `/workspace` and disables Gemini CLI's own
-folder-trust gate in the managed baseline. Workcell already masks repo-local
-Gemini control files and seeds the only trusted Gemini home inside the bounded
-runtime, so surfacing Gemini's restart-based trust flow there would add friction
-without adding a stronger boundary. In `breakglass`, Workcell restores Gemini's
-own folder-trust prompt behavior because the workspace control plane is no
-longer masked.
-
-When Gemini auth is injected, Workcell also preselects the matching Gemini auth
-mode inside the session-local settings when it can do so unambiguously.
-`GEMINI_API_KEY` and Google-login flows can stand alone. Vertex flows must set
-`GOOGLE_GENAI_USE_VERTEXAI=true` and then provide either `GOOGLE_API_KEY` or
-both `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`. `gcloud_adc` is only a
-supplemental Vertex input and must be paired with explicit Vertex settings in
-`credentials.gemini_env`.
-
-Gemini CLI is Tier 1 when it runs fully inside the bounded runtime. GUI or IDE
-integration is lower assurance unless it is only a client to the same bounded
-executor.
+- Workcell's external VM-plus-container boundary is primary; Gemini's own
+  sandbox is optional and not the Tier 1 boundary here
+- repo-local `.gemini/` content stays masked on the safe path
+- `gemini_env`, `gemini_oauth`, `gemini_projects`, and `gcloud_adc` cover the
+  supported long-lived auth and project-state paths
+- `breakglass` restores Gemini's own folder-trust prompt behavior

--- a/docs/adapter-control-planes.md
+++ b/docs/adapter-control-planes.md
@@ -1,168 +1,92 @@
 # Adapter Control Planes
 
-## Overview
+Workcell keeps one shared boundary and several thin adapters. Each adapter
+seeds a session-local provider home from reviewed baselines under `adapters/`
+plus explicit injection inputs.
 
-Workcell keeps one shared runtime boundary (dedicated Colima VM plus hardened
-inner container) and exposes thin provider adapters instead of pretending every
-agent product shares one control plane. Each adapter manages a small set of
-files inside the per-session ephemeral home (`/state/agent-home`) that map
-Workcell's policy model into the provider's native configuration surface.
+## How adapter seeding works
 
-At provider launch, `runtime/container/home-control-plane.sh` re-seeds the
-provider-facing home from two sources:
+At launch, `runtime/container/home-control-plane.sh` rebuilds the provider home
+from:
 
-- the **immutable adapter baseline** under `/opt/workcell/adapters/` (a
-  read-only copy of `adapters/` baked into the container image)
-- the **staged operator injection bundle** mounted read-only at
-  `/opt/workcell/host-injections` (from an explicit `--injection-policy`)
+1. immutable adapter baselines baked into the image
+2. explicit injection-policy inputs staged read-only for the session
+3. selected workspace instruction imports such as repo-local `AGENTS.md`
 
-Mutable provider state such as auth tokens is copied into the ephemeral session
-home and is never written back to the adapter baseline. On each new provider
-launch within the same container session, the home is re-seeded from the same
-immutable sources.
+Mutable provider state stays session-local. It is not written back into the
+adapter baseline.
 
-Before seeding adapter-managed files, `runtime/container/home-control-plane.sh`
-verifies the relevant adapter baseline hashes against the `runtime_artifacts`
-section of the committed `runtime/container/control-plane-manifest.json` that
-is baked into the image. The same published manifest also carries a separate
-`host_artifacts` section for reviewed host-side launcher inputs such as
-`scripts/workcell`, `scripts/lib/trusted-docker-client.sh`,
-`scripts/lib/extract_direct_mounts.py`, and
-`scripts/lib/render_injection_bundle.py`, but those entries are
-release-provenance only and are not runtime-hash-checked inside the container.
-Release publication signs and publishes the full manifest so consumers can
-audit the reviewed control-plane inputs separately from the broader
-build-input manifest.
+## Per-provider mapping
 
----
+| Provider | Main managed files | Notable behavior |
+|---|---|---|
+| Codex | `config.toml`, `managed_config.toml`, `requirements.toml`, `rules/`, `mcp/config.toml`, rendered `AGENTS.md`, optional `auth.json` | rules are immutable by default and can become session-local writable only in explicit lower-assurance cases |
+| Claude | `settings.json`, rendered `CLAUDE.md`, `.mcp.json`, auth mirrors, optional API key helper | the reviewed Bash hook is defense in depth; MCP defaults are empty |
+| Gemini | `settings.json`, rendered `GEMINI.md`, `.env`, `oauth_creds.json`, `projects.json`, `trustedFolders.json` | `breakglass` restores Gemini's own folder-trust prompt; `gcloud_adc` is supplemental to Vertex config in `gemini_env` |
 
-## Control file matrix
+Shared cross-provider state can also seed:
 
-The following table covers all files seeded by `seed_codex_home()`,
-`seed_claude_home()`, and `seed_gemini_home()` in
-`runtime/container/home-control-plane.sh`.
+- `~/.config/gh/config.yml`
+- `~/.config/gh/hosts.yml`
+- `~/.ssh/*`
 
-| File / Path | Provider | Safe path status | Breakglass status | Description |
-|---|---|---|---|---|
-| `~/.codex/AGENTS.md` | Codex | Rendered (baseline + workspace + injection layers) | Same | Provider instruction doc; workspace `AGENTS.md` is imported as a layer |
-| `~/.codex/config.toml` | Codex | Session-local writable copy of the baseline; reset on each launch | Same | Seeded from `adapters/codex/.codex/config.toml`; carries the baseline default profile and session-tunable defaults (analytics, history, project markers, etc.), while immutable `managed_config.toml` separately pins the reviewed policy overlay |
-| `~/.codex/managed_config.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/managed_config.toml`; admin-enforced strict default profile plus pinned profile sandbox/approval settings, web search modes, and execpolicy rules |
-| `~/.codex/requirements.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/requirements.toml`; hard requirements for the adapter including forbidden command patterns |
-| `~/.codex/agents/` | Codex | Symlink → immutable baseline agents dir | Same | Linked to `adapters/codex/.codex/agents/` |
-| `~/.codex/rules/` | Codex | Symlink → immutable baseline (readonly) or session-local writable copy (session) | Same | Execpolicy rules; see rules mutability section below |
-| `~/.codex/mcp/config.toml` | Codex | Symlink → immutable baseline | Same | Linked to `adapters/codex/mcp/config.toml`; ships no live MCP defaults |
-| `~/.codex/auth.json` | Codex | Copied from injection credential `codex_auth` if present | Same | Session-local Codex auth; not present if `credentials.codex_auth` is not configured |
-| `~/.claude/settings.json` | Claude | Symlink → immutable baseline, or session-local copy with `apiKeyHelper` if `claude_api_key` is injected | Same | Linked to `adapters/claude/.claude/settings.json`; carries the adapter defaults, deny-list permissions, and the `PreToolUse` Bash hook. When `claude_api_key` is present, the helper reads the reviewed direct-mounted credential path instead of creating a second session-local key copy. Native Claude also loads the separately managed `/etc/claude-code/managed-settings.json` overlay. |
-| `~/.claude/CLAUDE.md` | Claude | Rendered (baseline + workspace + injection layers) | Same | Provider instruction doc; workspace `AGENTS.md` and `CLAUDE.md` are imported as layers |
-| `~/.claude/.claude.json` | Claude | Copied from injection credential `claude_auth` if present | Same | Current Claude session auth/config artifact when `CLAUDE_CONFIG_DIR=~/.claude` |
-| `~/.claude.json` | Claude | Copied from injection credential `claude_auth` if present | Same | Host-style Claude global auth/config compatibility mirror |
-| `~/.claude/.credentials.json` | Claude | Copied from injection credential `claude_auth` if present | Same | Session-local native Claude auth on Linux for Claude builds that still consult the legacy home-local credential path |
-| `~/.claude/workcell/` | Claude | Created only when `claude_api_key` credential is injected | Same | Holds the session-local `api-key-helper.sh` script. The helper reads the mounted key file directly, so Workcell no longer drops a second plaintext copy under this directory. |
-| `~/.config/claude-code/auth.json` | Claude | Copied from injection credential `claude_auth` if present | Same | Session-local Claude CLI auth compatibility path |
-| `~/.mcp.json` | Claude | Symlink → immutable `mcp-template.json` (empty), or copied from `claude_mcp` credential if injected | Same | MCP server registry; ships empty by default |
-| `~/.gemini/settings.json` | Gemini | Copied (not symlinked) from immutable baseline; mode `0600` | Same, but `breakglass` re-enables Gemini folder trust before launch | Copied from `adapters/gemini/.gemini/settings.json` |
-| `~/.gemini/trustedFolders.json` | Gemini | Seeded session-local with `/workspace` trusted; mode `0600` | Same for strict/build; omitted in `breakglass` | Prevents Gemini's restart-only trust prompt inside masked ephemeral sessions while preserving Gemini's own prompt on `breakglass` |
-| `~/.gemini/GEMINI.md` | Gemini | Rendered (baseline + workspace + injection layers) | Same | Provider instruction doc; workspace `AGENTS.md` and `GEMINI.md` are imported as layers |
-| `~/.gemini/.env` | Gemini | Copied from injection credential `gemini_env` if present | Same | Provider-native env-file auth (API keys, Vertex project settings); Workcell derives Gemini's selected auth type from this file when possible |
-| `~/.gemini/oauth_creds.json` | Gemini | Copied from injection credential `gemini_oauth` if present | Same | Cached Gemini OAuth credential |
-| `~/.gemini/projects.json` | Gemini | Copied from injection credential `gemini_projects` if present; otherwise seeded with empty `{"projects":{}}` | Same | Gemini CLI project registry |
-| `~/.config/gcloud/application_default_credentials.json` | Gemini | Copied from injection credential `gcloud_adc` if present | Same | Supplemental Google ADC for Vertex flows driven by `~/.gemini/.env`; not a standalone Gemini auth mode |
-| `~/.config/gh/config.yml` | All | Copied from injection credential `github_config` if present | Same | GitHub CLI config; shared across providers |
-| `~/.config/gh/hosts.yml` | All | Copied from injection credential `github_hosts` if present | Same | GitHub CLI auth; shared across providers |
-| `~/.ssh/` | All | Seeded from `[ssh]` injection section if configured | Same | SSH config, known_hosts, and identity files; `SSH_AUTH_SOCK` is never forwarded |
+## Instruction layering
+
+Provider docs are rendered in this order:
+
+1. adapter baseline doc
+2. workspace `AGENTS.md` when present
+3. workspace provider overlay such as `CLAUDE.md` or `GEMINI.md`
+4. `documents.common`
+5. provider-specific document fragment such as `documents.claude`
+
+That gives the provider a native home document while keeping the workspace
+control plane masked on the safe path.
+
+## Autonomy mapping
+
+| Workcell setting | Codex | Claude | Gemini |
+|---|---|---|---|
+| `--agent-autonomy yolo` | `--ask-for-approval never` | `--permission-mode bypassPermissions` | `--approval-mode yolo` |
+| `--agent-autonomy prompt` | `--ask-for-approval on-request` | `--permission-mode default` | `--approval-mode default` |
+
+Unsafe provider-native attempts to override those managed flags are blocked on
+the managed path.
+
+## Runtime-profile effect
+
+`--mode` changes the runtime posture, not just provider argv:
+
+- `strict`: default managed lane
+- `strict --container-mutability readonly`: strongest managed lane
+- `build`: broader egress for preparation and rebuild work
+- `breakglass`: explicit higher-trust path requiring acknowledgement
+
+## Special cases
 
 ### Codex rules mutability
 
-By default (`--codex-rules-mutability readonly`), `~/.codex/rules/` is a
-symlink to the immutable adapter baseline. This means execpolicy rules cannot
-be amended by the running session.
+`~/.codex/rules/` is read-only by default. It becomes a session-local writable
+copy only when:
 
-The rules become session-local writable (a copy, not a symlink) in three cases:
+- `--codex-rules-mutability session` is selected
+- prompt autonomy is active
+- the session has already been downgraded by package mutation
 
-1. The operator explicitly passes `--codex-rules-mutability session`.
-2. `--agent-autonomy prompt` is active (promoted automatically).
-3. The session has already been downgraded by a package-manager mutation
-   (promoted automatically).
+### Claude hook coverage
 
-In all three cases, the immutable adapter baseline under `adapters/` remains
-unchanged. The session-local copy persists only until container exit.
+The Claude adapter installs a reviewed `PreToolUse` Bash hook that blocks
+common trust-widening shell patterns. It does not replace the external runtime
+boundary and does not cover non-Bash Claude tools.
 
----
+### Gemini folder trust
 
-## How Workcell flags map to provider behavior
+Workcell seeds Gemini's trusted-folders state for `/workspace` on the managed
+path so masked ephemeral sessions do not force a restart-based trust prompt.
+`breakglass` restores Gemini's own folder-trust flow.
 
-The mapping is applied by `runtime/container/provider-wrapper.sh` before
-`exec`-ing the pinned provider runtime: the native provider binary for Codex
-and Claude, and the real Node runtime plus the pinned Gemini entrypoint script
-for Gemini.
+## MCP posture
 
-### `--agent-autonomy` flag
-
-| Workcell flag | Codex flag | Claude flag | Gemini flag |
-|---|---|---|---|
-| `--agent-autonomy yolo` (default) | `--ask-for-approval never` | `--permission-mode bypassPermissions` | `--approval-mode yolo` |
-| `--agent-autonomy prompt` | `--ask-for-approval on-request` | `--permission-mode default` | `--approval-mode default` |
-
-Autonomy flags are injected ahead of any user-supplied `--agent-arg` values.
-Attempts by the agent to override autonomy flags through provider-native argv
-are blocked by `reject_unsafe_<provider>_args` in `provider-policy.sh` before
-the exec.
-
-### `--mode` flag (Workcell runtime profile)
-
-The `--mode` flag selects the Workcell runtime profile. It affects the
-container and VM posture, not directly the provider binary flags. The profile
-is recorded in runtime state and surfaced in the launch audit output.
-
-| Workcell mode | Behavior |
-|---|---|
-| `strict` (default) | Default developer lane. Direct native ELF execution from `/workspace` and `/state` is blocked. Mutable shebang scripts cannot target protected runtimes. Package mutations are allowed but downgrade the session assurance to `lower-assurance-package-mutation`. |
-| `strict` + `--container-mutability readonly` | Strongest managed lane. Package-manager writes stay blocked; control-plane posture does not downgrade. |
-| `build` | Explicit mutable preparation lane with broader egress for dependency and image creation. |
-| `breakglass` | Requires `--ack-breakglass`. Explicit higher-trust path. Visibly different. The managed in-container entrypoint still does not auto-inject unsafe provider flags. |
-
----
-
-## MCP configuration
-
-Workcell ships intentionally empty MCP templates for all providers:
-
-- **Claude**: `adapters/claude/mcp-template.json` — contains `{"mcpServers": {}}`. On the safe path this is symlinked to `~/.mcp.json`. It can be replaced by an operator-reviewed file via `credentials.claude_mcp` in the injection policy.
-- **Codex**: `adapters/codex/mcp/config.toml` — contains only a comment stating that no registry-backed MCP defaults are seeded. Linked to `~/.codex/mcp/config.toml`.
-
-**Do not add live MCP server entries to either file.** The safe path disables all project MCP servers (`enableAllProjectMcpServers: false` in Claude settings). MCP servers with network access or package-fetching behavior must be explicitly opted into in a broader runtime mode and supplied through the injection policy, not committed to the adapter baseline.
-
----
-
-## Hook coverage
-
-The Claude adapter installs a `PreToolUse` hook for the `Bash` tool via
-the seeded `~/.claude/settings.json` baseline (`adapters/claude/.claude/settings.json`).
-The hook script is
-`adapters/claude/hooks/guard-bash.sh`.
-
-### What the hook covers
-
-The `guard-bash.sh` hook intercepts Bash tool invocations and blocks:
-
-- `git` calls with `--no-verify`, inline hook-path overrides (`-c core.hookspath=...`), or `--git-dir`/`--work-tree` overrides
-- Nested `claude` subprocess calls with unsafe override flags (`--dangerously-skip-permissions`, `--mcp-config`, `--settings`, `--system-prompt`, etc.)
-- Shell expansion syntax: command substitution `$(...)`, backticks, parameter expansion `${...}`, ANSI-C quoting `$'...'`, process substitution `<(...)` / `>(...)`
-- `eval` and shell variable expansion (`$VAR`)
-- Nested coding-agent CLI invocations (`codex`, `claude`, `gemini` by path or name)
-- `source` and `.` (script sourcing)
-- Nested shell interpreter invocations (`bash script.sh`, `sh script.sh`, etc.) — `bash -c '...'` is permitted
-- `rm -rf` / `rm -fr` patterns
-- Direct pushes to `main` or `master`
-- Reads or writes to workspace control files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.mcp.json`) and control directories (`.claude/`, `.codex/`, `.gemini/`, `.cursor/`, `.idea/`, `.vscode/`, `.zed/`)
-- Reads or writes to Workcell home control-plane paths (`~/.claude`, `~/.codex`, `~/.gemini`, `/state/agent-home/.claude`, etc.)
-
-### What the hook does NOT cover
-
-- **Non-Bash tool use**: the hook is a `PreToolUse` matcher scoped to `Bash`. It does not intercept `Read`, `Edit`, `Write`, `Glob`, `Grep`, or any other Claude tool.
-- **Read/Edit/Write tool path restrictions**: those are handled by the `permissions.deny` list in Claude's reviewed settings overlays, not by the hook.
-- **Codex**: Codex uses its own execpolicy rules (`.codex/rules/`) rather than hooks. There is no equivalent Bash hook for Codex.
-- **Gemini**: Gemini CLI does not expose a hook interface equivalent to Claude's `PreToolUse`. Workcell relies on the shared runtime boundary and Gemini's native approval mode.
-- **Multi-step or indirect execution**: the hook inspects the literal Bash command string. Sufficiently indirect invocations may not be caught by static pattern matching. The hook is defense in depth, not the primary boundary.
-
-The primary security boundary is always the external runtime (dedicated Colima VM plus hardened inner container), not the hook layer.
+Workcell ships no live MCP defaults in the adapter baselines. Reviewed MCP
+state must arrive through explicit operator inputs, not ambient workspace
+content.

--- a/docs/examples/enterprise-claude-setup.md
+++ b/docs/examples/enterprise-claude-setup.md
@@ -1,176 +1,50 @@
 # Enterprise Claude Setup with Workcell
 
-This guide covers deploying Claude Code inside Workcell for organizations
-where multiple engineers share a common policy structure.
+This pattern is for teams that want a shared Claude baseline without mounting
+whole host homes into the runtime.
 
-## How the injection policy works at org scale
+## Recommended split
 
-Each engineer owns their own injection policy file on their host machine.
-Workcell reads it at launch time, validates the declared sources, and stages
-them into the ephemeral per-session container home. The policy file never
-leaves the host; secrets are mounted read-only from their original paths and
-then copied into the session.
+Keep these concerns separate:
 
-For org-wide deployment, the pattern is:
+- org-wide instructions in `documents.common` or `documents.claude`
+- reviewed persisted Claude auth in `credentials.claude_auth`
+- reviewed MCP state in `credentials.claude_mcp`
+- optional API-key fallback in `credentials.claude_api_key`
 
-1. Maintain a canonical policy template in a shared (non-secret) location such
-   as a company config repo or a managed MDM-deployed file.
-2. Each engineer copies or symlinks (at the file level, not for secret sources)
-   the shared non-secret fragments and supplies their own credential paths.
-3. Secrets remain on each engineer's machine at operator-owned paths and are
-   never shared.
-
-## 1. Common CLAUDE.md overlay via injection policy
-
-The `documents.claude` key appends a provider-specific instruction fragment
-to the rendered `~/.claude/CLAUDE.md` inside every session. This is the
-supported way to distribute org-wide Claude instructions without replacing
-the reviewed adapter baseline.
-
-Example policy entry:
+## Example policy
 
 ```toml
 version = 1
-
-providers = ["claude"]
 
 [documents]
-claude = "/Users/example/.config/workcell/org-claude-overlay.md"
-```
-
-The `providers = ["claude"]` scoping ensures this fragment is only applied
-to Claude sessions, not Codex or Gemini sessions launched from the same
-policy file.
-
-Rendering order inside `~/.claude/CLAUDE.md`:
-
-1. Immutable baseline from `adapters/claude/CLAUDE.md`
-2. Workspace `AGENTS.md` (imported from a read-only masked snapshot, if present)
-3. Workspace `CLAUDE.md` (imported from a read-only masked snapshot, if present)
-4. `documents.common` (if configured)
-5. `documents.claude` (the org overlay, if configured)
-
-The org overlay appends at the end. It does not replace or override the
-reviewed adapter baseline.
-
-## 2. managed-settings.json as the immutable baseline
-
-`adapters/claude/managed-settings.json` is baked into the container image and
-symlinked to `~/.claude/settings.json` inside each session. It contains the
-deny-list permissions and the `PreToolUse` Bash hook registration.
-
-This file is not replaceable by workspace content or injection policy entries.
-Writing to `.claude/settings.json` or `CLAUDE.md` through workspace files has
-no effect because those workspace paths are masked on the safe path and the
-session home is re-seeded from the immutable adapter baseline on each provider
-launch.
-
-If your org needs to adjust the deny list or hooks, that requires a reviewed
-change to the adapter baseline and a new container image build, not a
-per-engineer policy override.
-
-## 3. apiKeyHelper pattern
-
-When `credentials.claude_api_key` is configured, Workcell generates a
-session-local `apiKeyHelper` script at `~/.claude/workcell/api-key-helper.sh`.
-This script reads the mounted credential path directly rather than copying
-the key to a second location.
-
-Claude Code reads the `apiKeyHelper` field from `~/.claude/settings.json` and
-calls the helper at auth time. Because the helper reads the mounted file, the
-key is never duplicated into a second plaintext session-local copy.
-
-Policy entry:
-
-```toml
-version = 1
+common = "/Users/example/.config/workcell/org-agent.md"
+claude = "/Users/example/.config/workcell/claude-overlay.md"
 
 [credentials]
-claude_api_key = "/Users/example/.config/workcell/claude-api-key.txt"
-```
-
-The source file must be mode `0600`, owned by the launching user, and must not
-be a symlink.
-
-## 4. Org-wide policy example
-
-The following example shows a policy structure suitable for a team where
-engineers share common documents and each has their own API key.
-
-`~/.config/workcell/injection-policy.toml` (per-engineer, references shared
-and personal paths):
-
-```toml
-version = 1
-
-# Include shared non-secret fragments managed by the org
-includes = ["/opt/corp/workcell/shared-docs.toml"]
-
-[credentials]
-# Personal API key — owned by each engineer, never shared
-claude_api_key = "/Users/example/.config/workcell/claude-api-key.txt"
-
-# Shared GitHub CLI auth scoped to Claude sessions
-[credentials.github_hosts]
-source = "/Users/example/.config/gh/hosts.yml"
-providers = ["claude"]
-modes = ["strict", "build"]
-```
-
-`/opt/corp/workcell/shared-docs.toml` (org-managed, non-secret):
-
-```toml
-version = 1
-
-providers = ["claude"]
-
-[documents]
-common = "/opt/corp/workcell/org-agent-instructions.md"
-claude = "/opt/corp/workcell/org-claude-overlay.md"
-```
-
-The `includes` field loads `shared-docs.toml` relative to the entrypoint
-policy. Include files must stay within the entrypoint policy tree.
-Duplicate `documents.*` entries across includes are rejected so one fragment
-cannot silently override another.
-
-## 5. Scoping credentials to specific providers and modes
-
-Use `providers` and `modes` fields to limit which sessions receive which
-credentials:
-
-```toml
-version = 1
+claude_auth = "/Users/example/.claude.json"
+claude_mcp = "/Users/example/.config/workcell/claude-mcp.json"
 
 [credentials.github_hosts]
 source = "/Users/example/.config/gh/hosts.yml"
 providers = ["claude"]
-modes = ["strict", "build"]
 ```
 
-This ensures that GitHub CLI credentials are only injected into Claude sessions
-running in `strict` or `build` mode, not into Codex or Gemini sessions or
-`breakglass` sessions.
+## Why this pattern works
 
-## 6. Launch
+- the reviewed adapter baseline still controls Claude's default settings
+- workspace `CLAUDE.md` is imported as a layer instead of becoming the live
+  control plane
+- the session gets only the reviewed credentials it needs
+- final publication still stays on the host with `workcell publish-pr`
 
-Each engineer launches with their personal policy:
+## Launch
 
 ```bash
-workcell --agent claude --workspace /path/to/repo
+workcell --prepare --agent claude --workspace /path/to/repo
 ```
 
-If `~/.config/workcell/injection-policy.toml` exists, Workcell uses it
-automatically. To use an explicit path:
+## Related docs
 
-```bash
-workcell --agent claude --workspace /path/to/repo \
-  --injection-policy ~/.config/workcell/injection-policy.toml
-```
-
-## Further reading
-
-- `docs/injection-policy.md` — full injection policy reference
-- `docs/examples/quickstart-claude.md` — Claude quickstart
-- `docs/adapter-control-planes.md` — how settings.json and hooks are seeded
-- `docs/invariants.md` — the seven security invariants
+- [docs/injection-policy.md](../injection-policy.md)
+- [docs/adapter-control-planes.md](../adapter-control-planes.md)

--- a/docs/examples/gemini-vertex-setup.md
+++ b/docs/examples/gemini-vertex-setup.md
@@ -1,66 +1,19 @@
 # Gemini Vertex AI Setup with Workcell
 
-This guide covers configuring Google Vertex AI as the backend for Gemini CLI
-inside Workcell.
+Use this pattern when Gemini should authenticate through Vertex instead of a
+plain Gemini API key.
 
-## When to use Vertex vs API key
+## 1. Create the Gemini env file
 
-| Scenario | Recommended auth |
-|---|---|
-| Individual developer, personal quota | `GEMINI_API_KEY` via `gemini_env` |
-| Enterprise org, GCP project billing | Vertex AI via `gemini_env` |
-| Google Cloud Application Default Credentials already provisioned | `gcloud_adc` (supplemental, paired with Vertex env settings) |
-| Interactive personal use, no credential file | OAuth interactive login |
-
-Use Vertex when your organization bills Gemini usage through a GCP project,
-needs access to region-specific model endpoints, or requires Vertex-specific
-governance controls.
-
-## 1. Create the gemini_env file for Vertex
-
-Create a plain text env file with owner-only permissions:
-
-```bash
-mkdir -p ~/.config/workcell
-install -m 0600 /dev/null ~/.config/workcell/gemini-vertex.env
-```
-
-Populate it with Vertex settings:
-
-```
+```dotenv
 GOOGLE_GENAI_USE_VERTEXAI=true
-GOOGLE_CLOUD_PROJECT=your-project-id
+GOOGLE_CLOUD_PROJECT=my-project
 GOOGLE_CLOUD_LOCATION=us-central1
 ```
 
-Replace `your-project-id` with your actual GCP project ID and `us-central1`
-with the region where your Vertex endpoint is provisioned. Never substitute a
-real API key or service account key inline here unless your Vertex flow
-requires `GOOGLE_API_KEY` in addition to the project/location pair.
+If your flow also needs ADC, keep it as a separate reviewed credential file.
 
-If your Vertex flow uses `GOOGLE_API_KEY` instead of project/location:
-
-```
-GOOGLE_GENAI_USE_VERTEXAI=true
-GOOGLE_API_KEY=FIXTURE_FAKE_KEY_DO_NOT_USE
-```
-
-> **Note:** `FIXTURE_FAKE_KEY_DO_NOT_USE` is a placeholder. Replace it with
-> your actual key. Never commit real keys to files tracked by git.
-
-## 2. Injection policy TOML
-
-Reference the env file in your injection policy:
-
-```toml
-version = 1
-
-[credentials]
-gemini_env = "/Users/example/.config/workcell/gemini-vertex.env"
-```
-
-For supplemental Google ADC (only if your Vertex flow requires it alongside
-the `gemini_env` settings):
+## 2. Create the injection policy
 
 ```toml
 version = 1
@@ -70,74 +23,20 @@ gemini_env = "/Users/example/.config/workcell/gemini-vertex.env"
 gcloud_adc = "/Users/example/.config/gcloud/application_default_credentials.json"
 ```
 
-`gcloud_adc` mounts the ADC file to
-`~/.config/gcloud/application_default_credentials.json` inside the session.
-It is a supplemental input only; it does not activate Vertex mode by itself.
-The `gemini_env` entry with `GOOGLE_GENAI_USE_VERTEXAI=true` must also be
-present.
+## 3. What Workcell does with this
 
-## 3. Egress allowlist expansion
+- seeds `~/.gemini/.env` inside the session
+- treats ADC as a supplemental input rather than a standalone auth mode
+- derives the matching regional `aiplatform.googleapis.com` allowlist entry for
+  strict-mode launches when a location is present
 
-When `GOOGLE_CLOUD_LOCATION` (or `GOOGLE_CLOUD_REGION`, `CLOUD_ML_REGION`,
-`VERTEX_LOCATION`, or `VERTEX_AI_LOCATION`) is present in the env file,
-Workcell derives the corresponding regional allowlist entry at launch time.
-
-For `GOOGLE_CLOUD_LOCATION=us-central1`, Workcell adds:
-
-```
-us-central1-aiplatform.googleapis.com:443
-```
-
-For `GOOGLE_CLOUD_LOCATION=europe-west4`:
-
-```
-europe-west4-aiplatform.googleapis.com:443
-```
-
-This allowlist expansion applies to `strict` and `build` mode sessions. The
-derived hostname is added alongside the standard Gemini API endpoints. You do
-not need to configure it manually.
-
-## 4. Expected endpoints
-
-On a Vertex session with `us-central1`, the effective allowlisted egress set
-includes (among other entries):
-
-```
-aiplatform.googleapis.com:443
-us-central1-aiplatform.googleapis.com:443
-```
-
-These endpoints are where Gemini CLI sends model requests when
-`GOOGLE_GENAI_USE_VERTEXAI=true` is active.
-
-## 5. Launch with Vertex credentials
+## 4. Launch
 
 ```bash
-workcell --prepare --agent gemini --workspace /path/to/repo \
-  --injection-policy ~/.config/workcell/injection-policy.toml
+workcell --prepare --agent gemini --workspace /path/to/repo
 ```
 
-After the image is prepared:
+## Related docs
 
-```bash
-workcell --agent gemini --workspace /path/to/repo
-```
-
-Workcell reads the injection policy from the default location
-(`~/.config/workcell/injection-policy.toml`) automatically if it exists.
-
-Confirm the auth mode before launch:
-
-```bash
-workcell auth-status --agent gemini --workspace /path/to/repo
-```
-
-This prints the primary provider auth mode and the ordered auth mode set
-resolved from the injected `gemini_env` content.
-
-## Further reading
-
-- `docs/examples/quickstart-gemini.md` — Gemini quickstart
-- `docs/injection-policy.md` — full injection policy reference
-- `adapters/gemini/README.md` — Gemini adapter and auth mode details
+- [docs/injection-policy.md](../injection-policy.md)
+- [docs/examples/quickstart-gemini.md](quickstart-gemini.md)

--- a/docs/examples/quickstart-claude.md
+++ b/docs/examples/quickstart-claude.md
@@ -1,55 +1,14 @@
-# Quickstart: Anthropic Claude in Workcell
-
-This guide walks through running Anthropic Claude Code inside the Workcell
-bounded runtime. All commands are copy-pasteable.
+# Quickstart: Claude in Workcell
 
 ## Prerequisites
 
-- macOS (the host launcher is macOS only)
-- [Colima](https://github.com/abiosoft/colima) installed (`brew install colima`)
-- Docker CLI installed (`brew install docker`)
-- Workcell installed (`./scripts/install.sh` from the repo root)
+- Workcell installed with `./scripts/install.sh`
+- a repo you want to mount as the workspace
+- either reviewed Claude login state or a reviewed API key file
 
-Verify the install:
+## 1. Create an injection policy
 
-```bash
-workcell --version
-```
-
-## 1. Credential setup
-
-Workcell does not forward host environment variables or the host home directory
-into the session. The supported method is an explicit injection policy.
-
-### Option A: API key injection
-
-Create the API key file with owner-only permissions:
-
-```bash
-mkdir -p ~/.config/workcell
-install -m 0600 /dev/null ~/.config/workcell/claude-api-key.txt
-# Write your actual key into that file (not FIXTURE_FAKE_KEY_DO_NOT_USE)
-```
-
-Create `~/.config/workcell/injection-policy.toml`:
-
-```toml
-version = 1
-
-[credentials]
-claude_api_key = "/Users/example/.config/workcell/claude-api-key.txt"
-```
-
-The `claude_api_key` key mounts the file read-only and generates a
-session-local `apiKeyHelper` script inside `~/.claude/workcell/` that reads
-the mounted credential path directly. This means Claude can reuse the key
-without creating a second plaintext copy and without mutating the reviewed
-`~/.claude/settings.json` baseline.
-
-### Option B: Persisted CLI auth
-
-If you have already authenticated via `claude login` and want to reuse the
-resulting session file:
+Persisted Claude login:
 
 ```toml
 version = 1
@@ -58,158 +17,60 @@ version = 1
 claude_auth = "/Users/example/.claude.json"
 ```
 
-On the host, `claude_auth` can point at your reviewed Claude login artifact,
-commonly `~/.claude.json`. Inside Workcell, current Claude releases persist
-session state under `~/.claude/.claude.json` when `CLAUDE_CONFIG_DIR=~/.claude`.
-If your host still writes `~/.claude/.credentials.json` or
-`~/.config/claude-code/auth.json`, you can point `claude_auth` at that legacy
-path instead. Workcell seeds the current session path plus the legacy mirrors
-for compatibility.
-
-Only one of `claude_api_key` or `claude_auth` is needed for most workflows.
-
-> **Note:** Never store credentials in environment variables, shell history,
-> or committed files. `FIXTURE_FAKE_KEY_DO_NOT_USE` is used as a placeholder
-> in examples and must never appear in real config.
-
-## 2. Prepare the runtime image
-
-The `strict` profile requires a prebuilt runtime image. Run `--prepare` on
-first launch or after a Workcell update:
-
-```bash
-workcell --prepare --agent claude --workspace /path/to/repo
-```
-
-## 3. Basic launch
-
-```bash
-workcell --agent claude --workspace /path/to/repo
-```
-
-Workcell starts the dedicated Colima VM profile and launches Claude Code
-inside the hardened inner container. The workspace mounts at `/workspace`.
-
-The default autonomy mode is `yolo` (`--permission-mode bypassPermissions`).
-Claude proceeds without per-action approval prompts.
-
-## 4. Autonomy mode: prompt
-
-> **Note (lower-assurance):** Enabling prompt autonomy keeps Claude's ordinary
-> per-action approval flow but marks the session as
-> `autonomy_assurance=lower-assurance-prompt-autonomy`. Provider-native
-> approval state or session-local policy amendments can change during the live
-> session, so Workcell surfaces this posture explicitly in the launch audit
-> output. Use it only when you need interactive oversight.
-
-```bash
-workcell --agent claude --agent-autonomy prompt --workspace /path/to/repo
-```
-
-## 5. managed-settings.json: the immutable baseline
-
-Claude's session home is seeded from `adapters/claude/managed-settings.json`
-on every provider launch. The file contains:
-
-- a deny list covering `rm -rf`, `sudo`, force pushes, and reads of host
-  credential paths such as `~/.ssh/`, `~/.aws/`, `~/.kube/`, and
-  `~/.config/gh/`
-- `enableAllProjectMcpServers: false` to block automatic project MCP server
-  activation
-- the `PreToolUse` Bash hook registration pointing to `guard-bash.sh`
-
-This file is symlinked from the immutable adapter baseline, not copied into a
-location the workspace can replace. Workspace-visible `CLAUDE.md` and
-`.claude/` paths are masked on the safe path; the agent cannot silently
-override `managed-settings.json` by writing control files into the workspace.
-
-## 6. guard-bash.sh: what it blocks and why
-
-The `guard-bash.sh` hook runs as a `PreToolUse` filter on every Bash tool
-invocation. It blocks:
-
-- `git` calls that bypass hooks (`--no-verify`, `commit -n`, inline
-  `-c core.hookspath=...`, `--git-dir`, `--work-tree` overrides)
-- Nested `claude` subprocess calls with unsafe flags such as
-  `--dangerously-skip-permissions`, `--mcp-config`, `--settings`, or
-  `--system-prompt`
-- Shell expansion syntax: command substitution `$(...)`, backticks,
-  parameter expansion `${...}`, process substitution `<(...)` / `>(...)`
-- `eval` and shell variable expansion (`$VAR`, `${VAR}`)
-- Nested coding-agent CLI launches (`codex`, `claude`, `gemini`)
-- `source` and `.` (shell script sourcing)
-- Nested shell interpreter calls (`bash script.sh`) — `bash -c '...'` is
-  allowed
-- `rm -rf` and `rm -fr`
-- Direct pushes to `main` or `master`
-- Reads or writes to workspace control files and directories (`AGENTS.md`,
-  `CLAUDE.md`, `GEMINI.md`, `.mcp.json`, `.claude/`, `.codex/`, `.gemini/`)
-- Reads or writes to Workcell home control-plane paths
-
-The hook is defense in depth. The primary boundary is always the external
-runtime (dedicated Colima VM plus hardened inner container), not the hook.
-The hook does not cover non-Bash tools (`Read`, `Edit`, `Write`, etc.); those
-are constrained by the `permissions.deny` list in `managed-settings.json`.
-
-## 7. MCP setup
-
-MCP servers are disabled by default. The safe path symlinks an empty
-`~/.mcp.json` from `adapters/claude/mcp-template.json`.
-
-To inject a reviewed MCP configuration:
+API key helper path:
 
 ```toml
 version = 1
 
 [credentials]
+claude_api_key = "/Users/example/.config/workcell/claude-api-key.txt"
+```
+
+## 2. Prepare the runtime image
+
+```bash
+workcell --prepare-only --agent claude --workspace /path/to/repo
+```
+
+## 3. Check the derived state
+
+```bash
+workcell --agent claude --inspect --workspace /path/to/repo
+workcell --agent claude --auth-status --workspace /path/to/repo
+```
+
+## 4. Launch Claude
+
+```bash
+workcell --agent claude --workspace /path/to/repo
+```
+
+Prompt-mode autonomy:
+
+```bash
+workcell --agent claude --agent-autonomy prompt --workspace /path/to/repo
+```
+
+## 5. Optional reviewed MCP state
+
+If you want Claude to use a reviewed MCP registry instead of the empty safe
+baseline:
+
+```toml
+[credentials]
 claude_mcp = "/Users/example/.config/workcell/claude-mcp.json"
 ```
 
-The file at that path replaces the empty template for the session. It must be
-operator-reviewed and owned by the launching user with mode `0600`.
-
-> **Note (lower-assurance):** MCP servers with network access or
-> package-fetching behavior require a broader runtime mode such as `build`.
-> Enabling such servers inside `strict` is possible but counts as a
-> lower-assurance configuration. Do not commit live MCP server entries to the
-> adapter baseline.
-
-## 8. Publish a PR after work is done
-
-Final branch publication is a host-side action.
-
-Prepare the PR metadata (the agent or operator fills these in):
+## 6. Publish the result on the host
 
 ```bash
-echo "Add feature X" > /tmp/pr-title.txt
-cat > /tmp/pr-body.md <<'EOF'
-## Summary
-
-- Implements feature X
-
-## Test plan
-
-- [ ] Tests pass
-EOF
+workcell publish-pr --workspace /path/to/repo --branch feature/my-change \
+  --title-file /tmp/pr-title.txt --body-file /tmp/pr-body.md \
+  --commit-message-file /tmp/commit-message.txt
 ```
-
-Then publish from the host:
-
-```bash
-workcell publish-pr \
-  --branch feature-branch \
-  --title-file /tmp/pr-title.txt \
-  --body-file /tmp/pr-body.md \
-  --workspace /path/to/repo
-```
-
-`publish-pr` creates or switches to the named branch, makes a signed commit
-using the operator's host identity, pushes it, and opens a draft PR.
 
 ## Further reading
 
-- `docs/injection-policy.md` — full injection policy reference
-- `docs/invariants.md` — the seven security invariants
-- `adapters/claude/README.md` — Claude adapter overview
-- `docs/adapter-control-planes.md` — full control file matrix and hook
-  coverage
+- [docs/injection-policy.md](../injection-policy.md)
+- [docs/adapter-control-planes.md](../adapter-control-planes.md)
+- [docs/validation-scenarios.md](../validation-scenarios.md)

--- a/docs/examples/quickstart-codex.md
+++ b/docs/examples/quickstart-codex.md
@@ -1,35 +1,23 @@
-# Quickstart: OpenAI Codex in Workcell
+# Quickstart: Codex in Workcell
 
-This guide walks through running OpenAI Codex inside the Workcell bounded
-runtime. All commands are copy-pasteable. Use fake credentials in examples;
-never substitute real keys.
+This guide walks through the normal Codex path inside Workcell's bounded
+runtime.
 
 ## Prerequisites
 
-- macOS (the host launcher is macOS only)
-- [Colima](https://github.com/abiosoft/colima) installed (`brew install colima`)
-- Docker CLI installed (`brew install docker`)
-- Workcell installed (`./scripts/install.sh` from the repo root)
+- macOS
+- Colima
+- Docker CLI
+- Workcell installed from the repo root with `./scripts/install.sh`
 
-Verify the install:
+## 1. Create a reviewed auth file
 
-```bash
-workcell --version
-```
-
-## 1. Credential setup
-
-Workcell does not forward host environment variables or host home directories
-into the session. Credentials reach the agent only through an explicit
-injection policy.
-
-Create the API key file with owner-only permissions:
+Workcell does not pass host environment variables or provider homes through to
+the session. Use an injection policy instead.
 
 ```bash
 mkdir -p ~/.config/workcell
-# Write your actual key here; the file must be mode 0600
 install -m 0600 /dev/null ~/.config/workcell/codex-auth.json
-# Populate the file with your reviewed Codex auth.json content
 ```
 
 Create `~/.config/workcell/injection-policy.toml`:
@@ -41,149 +29,79 @@ version = 1
 codex_auth = "/Users/example/.config/workcell/codex-auth.json"
 ```
 
-Replace `/Users/example` with your actual home path. The `codex_auth` key
-mounts the file read-only into the session and copies it to
-`~/.codex/auth.json` inside the container.
-
-> **Note:** Never store credentials in environment variables, shell history,
-> or committed files. `FIXTURE_FAKE_KEY_DO_NOT_USE` is used as a placeholder
-> in examples throughout this document and must never appear in real config.
-
-## 2. Prepare the runtime image
-
-The `strict` profile (the default) requires a prebuilt runtime image. Run
-`--prepare` on first launch or after a Workcell update:
+## 2. Prepare the runtime
 
 ```bash
 workcell --prepare --agent codex --workspace /path/to/repo
 ```
 
-To preload the image without starting a session:
+To prewarm without launching:
 
 ```bash
 workcell --prepare-only --agent codex --workspace /path/to/repo
 ```
 
-## 3. Check preconditions
-
-Before launching a session, verify host, workspace, and profile posture:
+## 3. Check the derived state
 
 ```bash
 workcell doctor --agent codex --workspace /path/to/repo
+workcell inspect --agent codex --workspace /path/to/repo
 ```
 
-`doctor` reports the first blocking issue and prints the next safe command.
-Run it whenever a launch fails unexpectedly.
-
-## 4. Basic launch
+## 4. Launch Codex
 
 ```bash
 workcell --agent codex --workspace /path/to/repo
 ```
 
-Workcell starts the dedicated Colima VM profile, builds or reuses the
-prepared runtime image, and launches Codex inside the hardened inner
-container. The workspace is mounted at `/workspace` inside the container.
+Important defaults:
 
-The default autonomy mode is `yolo` (`--ask-for-approval never`). Codex
-proceeds without per-action approval prompts.
+- `strict` is the default mode
+- `yolo` is the default autonomy posture
+- the injection policy at `~/.config/workcell/injection-policy.toml` is used
+  automatically if present
 
-With an explicit injection policy:
+## 5. Optional lower-assurance paths
 
-```bash
-workcell --agent codex --workspace /path/to/repo \
-  --injection-policy ~/.config/workcell/injection-policy.toml
-```
-
-If `~/.config/workcell/injection-policy.toml` exists, Workcell uses it
-automatically without `--injection-policy`.
-
-## 5. Inspect derived session state
-
-To see the full derived configuration without launching a session:
-
-```bash
-workcell --agent codex --inspect --workspace /path/to/repo
-```
-
-This prints the resolved profile, network mode, injection inputs, and
-assurance fields. Use it to confirm credentials will be injected correctly
-before a real launch.
-
-## 6. Publish a PR after work is done
-
-Final branch publication is a host-side action. The agent prepares a branch
-and commit message inside the session; the operator runs `publish-pr` on the
-host to sign the commit, push, and open a draft PR.
-
-Prepare the PR metadata files (the agent or operator fills these in):
-
-```bash
-echo "Add feature X" > /tmp/pr-title.txt
-cat > /tmp/pr-body.md <<'EOF'
-## Summary
-
-- Implements feature X
-- Adds tests
-
-## Test plan
-
-- [ ] Unit tests pass
-EOF
-```
-
-Then publish from the host:
-
-```bash
-workcell publish-pr \
-  --branch feature-branch \
-  --title-file /tmp/pr-title.txt \
-  --body-file /tmp/pr-body.md \
-  --workspace /path/to/repo
-```
-
-`publish-pr` creates or switches to the named branch, makes a signed commit
-using the operator's host identity, pushes it, and opens a draft PR. It does
-not run inside the container.
-
-## 7. Lower-assurance options
-
-> **Note (lower-assurance):** The options below reduce session integrity
-> guarantees. They are explicitly surfaced in the launch audit output and
-> should only be used when you understand the tradeoff.
-
-**Prompt autonomy** keeps Codex's ordinary per-action approval flow but marks
-the session as `autonomy_assurance=lower-assurance-prompt-autonomy`:
+Prompt mode:
 
 ```bash
 workcell --agent codex --agent-autonomy prompt --workspace /path/to/repo
 ```
 
-**Session-writable Codex rules** allow execpolicy amendments to persist
-across nested Codex launches until container exit:
+Session-local writable rules:
 
 ```bash
 workcell --agent codex --codex-rules-mutability session --workspace /path/to/repo
 ```
 
-**Build mode** opens a broader egress allowlist for package registries and
-dependency fetching. Use this for image preparation and build work:
+Build lane:
 
 ```bash
 workcell --agent codex --mode build --workspace /path/to/repo
 ```
 
-**Breakglass** requires an explicit acknowledgement flag and gives
-unrestricted network access. The managed in-container entrypoint still does
-not auto-inject unsafe provider flags:
+Breakglass:
 
 ```bash
 workcell --agent codex --mode breakglass --ack-breakglass --workspace /path/to/repo
 ```
 
+## 6. Publish on the host
+
+Prepare the PR metadata, then publish from the host:
+
+```bash
+workcell publish-pr \
+  --workspace /path/to/repo \
+  --branch feature/name \
+  --title-file /tmp/pr-title.txt \
+  --body-file /tmp/pr-body.md \
+  --commit-message-file /tmp/commit-message.txt
+```
+
 ## Further reading
 
-- `docs/injection-policy.md` — full injection policy reference
-- `docs/invariants.md` — the seven security invariants
-- `adapters/codex/README.md` — Codex adapter control-plane details
-- `docs/adapter-control-planes.md` — full control file matrix
+- [Injection policy](../injection-policy.md)
+- [Codex adapter](../../adapters/codex/README.md)
+- [Adapter control planes](../adapter-control-planes.md)

--- a/docs/examples/quickstart-gemini.md
+++ b/docs/examples/quickstart-gemini.md
@@ -1,44 +1,14 @@
-# Quickstart: Google Gemini in Workcell
-
-This guide walks through running Google Gemini CLI inside the Workcell bounded
-runtime. All commands are copy-pasteable.
+# Quickstart: Gemini in Workcell
 
 ## Prerequisites
 
-- macOS (the host launcher is macOS only)
-- [Colima](https://github.com/abiosoft/colima) installed (`brew install colima`)
-- Docker CLI installed (`brew install docker`)
-- Workcell installed (`./scripts/install.sh` from the repo root)
+- Workcell installed with `./scripts/install.sh`
+- a repo you want to mount as the workspace
+- either a reviewed Gemini env file or reviewed cached OAuth material
 
-Verify the install:
+## 1. Create an injection policy
 
-```bash
-workcell --version
-```
-
-## 1. Credential setup
-
-Workcell does not forward host environment variables or the host home directory
-into the session. Credentials reach the agent only through an explicit
-injection policy. Three auth modes are supported.
-
-### Option A: API key via gemini_env
-
-The Gemini CLI reads credentials from `~/.gemini/.env` inside the session.
-Workcell populates this file from the `credentials.gemini_env` injection
-policy key.
-
-Create the env file with owner-only permissions:
-
-```bash
-mkdir -p ~/.config/workcell
-install -m 0600 /dev/null ~/.config/workcell/gemini.env
-# Write the following line (replace with your actual key, not the placeholder)
-echo 'GEMINI_API_KEY=FIXTURE_FAKE_KEY_DO_NOT_USE' > ~/.config/workcell/gemini.env
-chmod 0600 ~/.config/workcell/gemini.env
-```
-
-Create `~/.config/workcell/injection-policy.toml`:
+API key or Vertex env-file path:
 
 ```toml
 version = 1
@@ -47,12 +17,7 @@ version = 1
 gemini_env = "/Users/example/.config/workcell/gemini.env"
 ```
 
-> **Note:** `FIXTURE_FAKE_KEY_DO_NOT_USE` is a placeholder. Replace it with
-> your actual key. Never commit real keys to files tracked by git.
-
-### Option B: Persisted OAuth credential
-
-If you have an existing Gemini OAuth credential file on the host:
+Cached OAuth path:
 
 ```toml
 version = 1
@@ -61,104 +26,48 @@ version = 1
 gemini_oauth = "/Users/example/.config/workcell/gemini-oauth.json"
 ```
 
-Workcell copies this file to `~/.gemini/oauth_creds.json` inside the session.
-
-### Option C: Interactive OAuth login (no credential file needed)
-
-> **Note (lower-assurance):** Interactive OAuth requires network access to
-> Google login endpoints. On `strict`, this is within the allowlisted egress
-> set for Google auth. No credential file is required on the host, but the
-> login flow opens a browser on the host. This gives less reproducibility than
-> a pre-provisioned credential file.
-
-Launch without a `gemini_env` or `gemini_oauth` entry; Gemini CLI will prompt
-for login interactively on first use.
-
 ## 2. Prepare the runtime image
 
-The `strict` profile requires a prebuilt runtime image. Run `--prepare` on
-first launch or after a Workcell update:
-
 ```bash
-workcell --prepare --agent gemini --workspace /path/to/repo
+workcell --prepare-only --agent gemini --workspace /path/to/repo
 ```
 
-## 3. Basic launch
+## 3. Inspect the derived posture
+
+```bash
+workcell --agent gemini --inspect --workspace /path/to/repo
+workcell --agent gemini --auth-status --workspace /path/to/repo
+```
+
+## 4. Launch Gemini
 
 ```bash
 workcell --agent gemini --workspace /path/to/repo
 ```
 
-Workcell starts the dedicated Colima VM profile and launches Gemini CLI inside
-the hardened inner container. The workspace mounts at `/workspace`.
+Gemini's trusted-folders registry is seeded on the managed path so `/workspace`
+is already trusted inside the ephemeral session home.
 
-The default autonomy mode is `yolo` (`--approval-mode yolo`). Gemini proceeds
-without per-action approval prompts.
+## 5. Vertex supplement
 
-## 4. trustedFolders.json is auto-seeded
+If the env file configures Vertex and you need ADC as a supplemental input:
 
-On the safe path (`strict` and `build`), Workcell seeds
-`~/.gemini/trustedFolders.json` with `/workspace` as a trusted folder before
-each provider launch. You will not see Gemini's restart-based folder-trust
-prompt inside managed sessions because the trust registry is already correct
-at startup.
-
-In `breakglass` mode, the `trustedFolders.json` seeding is omitted so Gemini's
-own folder-trust prompt behavior is preserved.
-
-## 5. Vertex AI setup
-
-For Vertex AI, see the dedicated guide at
-[`docs/examples/gemini-vertex-setup.md`](./gemini-vertex-setup.md).
-
-A minimal Vertex `gemini.env` file looks like:
-
-```
-GOOGLE_GENAI_USE_VERTEXAI=true
-GOOGLE_CLOUD_PROJECT=your-project-id
-GOOGLE_CLOUD_LOCATION=us-central1
+```toml
+[credentials]
+gemini_env = "/Users/example/.config/workcell/gemini.env"
+gcloud_adc = "/Users/example/.config/gcloud/application_default_credentials.json"
 ```
 
-When `GOOGLE_CLOUD_LOCATION` is present in the env file, Workcell
-automatically derives the regional `us-central1-aiplatform.googleapis.com:443`
-entry and adds it to the egress allowlist for strict-mode sessions.
-
-## 6. Publish a PR after work is done
-
-Final branch publication is a host-side action.
-
-Prepare the PR metadata:
+## 6. Publish the result on the host
 
 ```bash
-echo "Add feature X" > /tmp/pr-title.txt
-cat > /tmp/pr-body.md <<'EOF'
-## Summary
-
-- Implements feature X
-
-## Test plan
-
-- [ ] Tests pass
-EOF
+workcell publish-pr --workspace /path/to/repo --branch feature/my-change \
+  --title-file /tmp/pr-title.txt --body-file /tmp/pr-body.md \
+  --commit-message-file /tmp/commit-message.txt
 ```
-
-Then publish from the host:
-
-```bash
-workcell publish-pr \
-  --branch feature-branch \
-  --title-file /tmp/pr-title.txt \
-  --body-file /tmp/pr-body.md \
-  --workspace /path/to/repo
-```
-
-`publish-pr` creates or switches to the named branch, makes a signed commit
-using the operator's host identity, pushes it, and opens a draft PR.
 
 ## Further reading
 
-- `docs/examples/gemini-vertex-setup.md` — Vertex AI setup guide
-- `docs/injection-policy.md` — full injection policy reference
-- `docs/invariants.md` — the seven security invariants
-- `adapters/gemini/README.md` — Gemini adapter overview
-- `docs/adapter-control-planes.md` — full control file matrix
+- [docs/injection-policy.md](../injection-policy.md)
+- [docs/examples/gemini-vertex-setup.md](gemini-vertex-setup.md)
+- [docs/adapter-control-planes.md](../adapter-control-planes.md)

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -1,240 +1,70 @@
 # GitHub Workflow Design
 
-Workcell keeps its GitHub automation intentionally small. The workflow surface
-should reinforce the runtime boundary and release posture, not bury the project
-under platform automation.
+Workcell keeps the workflow set narrow and reviewable. GitHub automation should
+reinforce the runtime boundary and release posture, not replace them.
 
-## Current workflow set
+## Workflow inventory
 
-- `ci.yml`: repo validation and direct container smoke on every pull request and
-  push to `main`
-- `ci.yml`: also verifies each supported pinned runtime platform
-  reproducibly under the same `SOURCE_DATE_EPOCH` in parallel, while keeping a
-  single required `Reproducible build` status for branch protection
-- `ci.yml`: caches only exact pinned QEMU and Buildx helper artifacts; it does
-  not add layer caching to the reviewed runtime build path
-- `ci.yml`: also verifies that the release source bundle is reproducible with a
-  fixed `SOURCE_DATE_EPOCH`
-- `ci.yml`: also enforces the reviewed pin policy for non-ecosystem inputs such
-  as the Debian snapshot, immutable base-image digests, and exact runtime and
-  validator package sets
-- `ci.yml`: also verifies the pinned upstream Codex Linux assets against
-  OpenAI's published Sigstore bundle and the pinned upstream Claude Linux
-  assets against Anthropic's published release manifest
-- `ci.yml`: also verifies the determinism of the release build-input manifest
-- `ci.yml`: first runs host-side pin-hygiene checks for the runtime and
-  validator Dockerfiles, then runs repo validation inside a pinned validator
-  image so release gating does not trust mutable runner apt packages
-- `docs.yml`: fast spelling and manpage feedback for documentation-only changes,
-  including runtime documentation under `runtime/**`
-- `provider-e2e.yml`: manual `workflow_dispatch` provider-authenticated smoke
-  on the self-hosted macOS boundary path, with explicit provider selection,
-  explicit injection required, an owner-only plus default-branch job gate, and
-  credentials supplied only through the dedicated `provider-e2e` environment;
-  it stays separate from default CI so the secretless path remains the normal
-  gate
-- `security.yml`: GitHub Actions linting, dependency review on pull requests,
-  and `zizmor`
-- `codeql.yml`: code scanning for the shipped Rust, JavaScript, and Python surfaces on
-  public repositories by default, or on private repositories when
-  `WORKCELL_ENABLE_PRIVATE_CODE_SCANNING=true`
-- `scorecard.yml`: weekly and default-branch OpenSSF Scorecard analysis
-- `pin-hygiene.yml`: weekly re-validation of pinned non-ecosystem inputs and
-  re-verification of the pinned upstream Codex and Claude releases
-- `macos-boundary.yml`: optional self-hosted macOS launch verification for the
-  real Colima plus Virtualization.Framework path when
-  `WORKCELL_ENABLE_SELF_HOSTED_MACOS=true`; it first seeds the reviewed runtime
-  image in `build` mode and then verifies the managed `strict` launch path; it
-  runs only on `main` pushes and manual dispatches so untrusted pull request
-  code never lands on a self-hosted runner
-- `release.yml`: multi-arch image publish, a directly signed build-input
-  manifest, a directly signed control-plane manifest, a signed
-  builder-environment manifest, direct signing for the source bundle and both
-  published SBOMs, SBOM generation, checksums,
-  attestations on tagged releases, deterministic fixed-order multi-arch
-  manifest assembly, preflight-to-publish digest binding for the source bundle
-  and both per-platform image manifests, byte-for-byte preflight binding for
-  the build-input manifest and control-plane manifest, including the
-  host-side launcher, Docker-context guard, direct-mount extractor, and
-  injection-policy renderer entries that stage the reviewed provider homes, a
-  conditional release-preflight CodeQL rerun when repository settings enable
-  private code scanning or the repository is public, a
-  protected `release` environment with a human approval gate before publish
-  when the repository visibility and billing plan support required reviewers,
-  an explicit release-asset allowlist, exact pinned BuildKit, Cosign, and Syft
-  tooling, archived-source-tree image publication instead of live-worktree
-  publication, and pinned GitHub Release publication instead of an ambient
-  `gh` binary
-- `hosted-controls.yml`: live GitHub control-plane drift detection on `main`
-  pushes, schedule, and manual dispatch, using the same hosted-controls policy
-  that release preflight enforces before publish; on private repositories it
-  uses an optional dedicated `WORKCELL_HOSTED_CONTROLS_TOKEN` because the
-  default workflow token cannot read rulesets/collaborator/environment
-  metadata for this audit
-- `.github/dependabot.yml`: grouped weekly updates for GitHub Actions and the
-  runtime base image, validator base image, remote-validator base image,
-  pinned Gemini CLI dependency graph, and shipped Rust runtime crate, with
-  cooldowns
+| Workflow | Purpose |
+|---|---|
+| `ci.yml` | repository validation, smoke, reproducibility, pin verification, and upstream release re-verification on pushes and PRs |
+| `docs.yml` | fast spelling and manpage feedback for docs-only changes |
+| `security.yml` | workflow lint, dependency review, and `zizmor` |
+| `codeql.yml` | code scanning for shipped Rust, Python, and JavaScript surfaces |
+| `scorecard.yml` | OpenSSF Scorecard analysis |
+| `pin-hygiene.yml` | scheduled re-validation of pinned inputs and upstream release pins |
+| `hosted-controls.yml` | drift detection for GitHub-hosted controls that live outside git |
+| `provider-e2e.yml` | manual provider-authenticated smoke on the self-hosted macOS boundary path |
+| `macos-boundary.yml` | optional self-hosted verification of the real Colima boundary |
+| `release.yml` | tagged release preflight, publication, signatures, SBOMs, manifests, and attestations |
 
-## Source influence
+## Release workflow posture
 
-The original `trailofbits/claude-code-config` repository did not ship GitHub
-workflow files. The linked Trail of Bits repos that informed the posture did:
+`release.yml` is intentionally strict:
 
-- `trailofbits/skills`: `lint` and `validate`
-- `trailofbits/skills-curated`: `lint`, `validate`, and a focused security scan
-- `trailofbits/dropkit`: one CI workflow
+- it publishes from the archived source bundle, not the live checkout
+- it binds publish outputs to preflight results before signing
+- it signs release assets with keyless Sigstore/Cosign
+- it publishes GitHub attestations in the canonical repo as an additional
+  surface, not a replacement
+- it uses pinned GitHub Actions and pinned Buildx, QEMU, Cosign, and Syft
+  versions
+- it runs with minimal workflow-level permissions and only elevates the publish
+  job for package publication, OIDC, attestations, and release asset upload
 
-Workcell follows that smaller pattern instead of adding a wide spray of generic
-automation.
+## Hosted controls
 
-## Repository-hosted controls
+Some release-relevant controls live outside git. Workcell still treats them as
+reviewed inputs:
 
-Workcell keeps several repository settings outside git, but they are still part
-of the reviewed control plane:
+- branch rulesets for signed commits, anti-rewrite protection, PR gating, and
+  required checks
+- tag rulesets for `refs/tags/v*`
+- the protected `release` environment
+- GitHub Actions SHA pinning
+- canonical repository variables such as
+  `WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true`
 
-- active rulesets on the default branch for signed commits, anti-rewrite
-  integrity, and branch-deletion protection
-- an active required-status-checks ruleset on the default branch for the core
-  CI and GitHub workflow security checks
-- an active review ruleset on the default branch that requires pull requests;
-  in the current single-owner-private mode it requires zero approvals and no
-  code-owner/thread gate, while multi-maintainer mode raises that back to
-  human-reviewed approval plus review resolution
-- an active ruleset on `refs/tags/v*` that blocks tag creation, updates, and
-  deletion except for explicit repository-role bypass actors
-- GitHub Actions SHA pinning required at the repository level
-- a protected `release` environment whose expected protection mode is declared
-  in [`policy/github-hosted-controls.toml`](../policy/github-hosted-controls.toml)
-- explicit CODEOWNERS entries for high-risk paths such as
-  `.github/workflows/`, `scripts/`, and the runtime boundary
+`scripts/verify-github-hosted-controls.sh` audits those settings against
+`policy/github-hosted-controls.toml`.
 
-Tagged release preflight also regenerates the deterministic control-plane
-manifest, compares it against the committed copy and archived-source rebuild,
-then signs and publishes it. That manifest separates runtime-enforced
-`runtime_artifacts` from release-provenance-only `host_artifacts` so the
-workflow does not overstate what the runtime itself verifies.
+## Public vs private behavior
 
-The repository includes [`scripts/verify-github-hosted-controls.sh`](../scripts/verify-github-hosted-controls.sh)
-to audit those hosted settings with the GitHub API.
-[`hosted-controls.yml`](../.github/workflows/hosted-controls.yml) runs that
-audit continuously against the live repository, and tagged releases rerun it in
-release preflight before publish and refuse publication if the hosted controls
-drift.
+The workflow set supports both public and private repos, but some features are
+conditional:
 
-For private repositories, GitHub's default workflow token does not have enough
-access to read the rulesets, direct collaborators, and protected environment
-metadata that the hosted-controls audit requires. Workcell therefore uses a
-dedicated `WORKCELL_HOSTED_CONTROLS_TOKEN` secret for workflow-based audits.
-The continuous `hosted-controls.yml` workflow skips cleanly when that secret is
-absent so `main` does not stay red on a known GitHub token limitation, but the
-tagged `release.yml` preflight fails closed unless the secret is configured.
-The workflow enforces that split explicitly with
-`WORKCELL_HOSTED_CONTROLS_REQUIRED="0"` in
-[`hosted-controls.yml`](../.github/workflows/hosted-controls.yml) and
-`WORKCELL_HOSTED_CONTROLS_REQUIRED="1"` in
-[`release.yml`](../.github/workflows/release.yml).
-That token should be a fine-grained token or GitHub App token scoped only to
-this repository and only to the repository-administration metadata needed for
-the audit. Workflow jobs that can read that token run inside a dedicated
-`hosted-controls-audit` environment so the secret is not exposed to unrelated
-jobs.
-
-The current repository policy uses
-`branch_integrity.require_signed_commits = true`,
-`branch_integrity.block_force_pushes = true`,
-`branch_integrity.block_deletions = true`,
-`branch_review.mode = "single-owner-private-pr"`, and
-`release_environment.mode = "single-owner-private"` because this is a private
-single-owner repository. The audit enforces that as a private user-owned
-repository whose only direct collaborator is the owner. In that mode, the
-audited expectation is:
-
-- `main` requires signed commits, blocks force-push and deletion, and still
-  requires pull requests plus green required checks, but does not require
-  impossible third-party approvals, code-owner review, or review-thread
-  resolution
-- the named `release` environment exists, but it is not treated as a
-  multi-party human approval gate
-
-If the repository later moves to a multi-maintainer or public operating model,
-flip those policies back to `review-gated` and Workcell will require at least
-one human reviewer and no administrator bypass before protected-branch merges
-or tagged publication.
-
-For private repositories, `codeql.yml` is opt-in through
-`WORKCELL_ENABLE_PRIVATE_CODE_SCANNING=true` because GitHub code scanning is
-not universally available on private repositories. The Scorecard run still
-executes and uploads its artifact, but SARIF upload is opt-in through
-`WORKCELL_ENABLE_PRIVATE_SCORECARD_SARIF=true`. The same pattern applies to
-`zizmor` through `WORKCELL_ENABLE_PRIVATE_ZIZMOR_SARIF=true`, and to dependency
-review through `WORKCELL_ENABLE_PRIVATE_DEPENDENCY_REVIEW=true`. Public
-repositories upload both SARIF result sets into the GitHub Security tab by
-default and run dependency review on pull requests without extra flags.
-
-Workcell now defaults workflows to `permissions: {}` or other minimal
-read-only scopes, and elevates only the specific jobs that need write access,
-such as CodeQL SARIF upload, Scorecard SARIF upload, or tagged release
-publication. Workcell also forbids `pull_request_target` and disallows
-long-lived PAT-style workflow credentials in the reviewed workflow set.
-Release publication uses OIDC-backed ephemeral credentials for signing and
-attestations instead of long-lived cloud keys.
-
-## Dependency update scope
-
-Dependabot currently covers:
-
-- GitHub Actions
-- the runtime Dockerfile base image
-- the validator Dockerfile base image
-- the remote-validator Dockerfile base image
-- the pinned Gemini CLI lockfile in `runtime/container/providers`
-- the vendored Rust runtime crate in `runtime/container/rust`
-
-Non-ecosystem pinned inputs such as the Codex and Claude release bundles and
-the Debian snapshot are checked by CI, release preflight, and the scheduled
-`pin-hygiene.yml` workflow rather than Dependabot.
-
-Dependency diffs on pull requests are additionally screened with
-`actions/dependency-review-action` using
-[`../.github/dependency-review-config.yml`](../.github/dependency-review-config.yml).
+- private repos may need `WORKCELL_HOSTED_CONTROLS_TOKEN` for hosted-control
+  auditing
+- private code scanning and some SARIF uploads are opt-in because GitHub plan
+  support varies
+- the canonical upstream repository enables GitHub attestations through the
+  reviewed repository-variable policy
 
 ## Deliberate omissions
 
-These are omitted on purpose:
+Workcell does not use:
 
-- A GitHub-hosted macOS boundary workflow. Hosted runners cannot prove the full
-  Colima plus Virtualization.Framework boundary, so Workcell does not pretend
-  they can.
-- Mandatory self-hosted macOS gating for every repo. Workcell ships an opt-in
-  `macos-boundary.yml` workflow for repos that actually have the runner and
-  host prerequisites, but it does not make unverifiable promises for repos that
-  do not.
-- `pull_request_target`. This repo treats untrusted pull request code as
-  untrusted.
-- Bot churn such as stale-issue automation. It does not improve the boundary or
-  developer workflow.
-
-The small exception is `docs.yml`, which exists only to give faster spelling
-and manpage feedback on documentation-only changes. It does not replace the
-full validation and release gates in `ci.yml`.
-
-The manual provider-e2e workflow is not a default CI replacement. It is a
-separate dispatch-only lane for credential detection, control-plane seeding,
-and a small authenticated provider probe, kept narrow so the secretless CI
-path remains the standard repository gate. Keep the `provider-e2e`
-environment protected so only approved operators can access its secrets, and
-keep the owner-only plus default-branch job gate in place so a manual dispatch
-by another actor or from a non-default branch cannot consume those
-credentials. Keep its checkout pinned to the dispatched SHA so the reviewed
-workflow run cannot drift to newer default-branch code after dispatch.
-
-## Review standard
-
-Every workflow should pass the same review gate:
-
-1. Does it improve contributor experience or just add ceremony?
-2. Does it validate a real Workcell invariant?
-3. Is the same check already covered elsewhere?
-4. Are action permissions and refs minimal?
-5. Does it avoid implying assurance we do not actually have?
+- `pull_request_target`
+- ambient PAT-style workflow credentials
+- GitHub-hosted macOS claims for the full Colima boundary
+- stale-issue or other bot churn unrelated to the runtime or release posture

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -1,184 +1,83 @@
 # Injection Policy
 
-Workcell's safe path does not forward host homes, `SSH_AUTH_SOCK`, keychains,
-browser profiles, or provider state by default. The supported way to place
-consistent material into every session is an operator-owned injection policy.
+The safe path does not forward host homes, sockets, or provider state by
+default. The supported way to place stable material into Workcell sessions is
+an explicit operator-owned injection policy.
 
-## Design
+## How it works
 
-Workcell separates three planes:
+Each launch rebuilds the provider-facing home from:
 
-- immutable adapter baseline under `adapters/`
-- per-session writable runtime state under `/state/agent-home`
-- explicit staged operator input mounted read-only under
-  `/opt/workcell/host-injections`
+1. immutable adapter baselines
+2. workspace instruction imports
+3. explicit injected documents, credentials, copies, and SSH material
 
-At provider launch, Workcell re-seeds the provider-facing home from the
-immutable baseline plus the staged operator input. Mutable provider state such
-as provider auth tokens stays session-local, not a write-back into the adapter
-baseline. By default, Codex rules remain linked to the immutable adapter
-baseline. If you explicitly opt into
-`--codex-rules-mutability session`, Workcell copies the Codex rules tree into a
-session-local writable tree so provider-approved execpolicy amendments can
-persist for the life of the container, while the adapter baseline remains
-immutable. The staged host bundle lives in a launcher-owned state
-directory under `~/Library/Caches/colima/workcell-host-inputs`, is mounted
-read-only into the runtime, and is cleaned up on exit with dead-owner stale
-bundle garbage collection on later launches. Secret-bearing inputs are treated
-more strictly: Workcell validates their host source files, restages those files
-under the same launcher-owned cache root with restrictive permissions so the
-managed Colima VM can bind-mount them read-only, and only then copies them into
-the ephemeral session home. That means provider credentials, SSH material, and
-`classification = "secret"` copied files do create a short-lived extra
-host-side plaintext staging copy, which later launches garbage-collect if a
-previous session crashes before cleanup.
+Secret-bearing inputs are handled more carefully than public inputs:
 
-Provider docs are rendered in a fixed precedence order:
+- provider credentials, SSH identities, and `classification = "secret"` copies
+  are validated on the host
+- they are mounted read-only into the runtime from launcher-owned staging
+  state, then copied into the ephemeral session home
+- a crash can leave short-lived staged plaintext behind until later cleanup
 
-1. immutable baseline doc from `adapters/`
-2. imported workspace common doc from repo-local `AGENTS.md` when present
-3. imported workspace provider overlay such as repo-local `CLAUDE.md` or
-   `GEMINI.md` when present
-4. `documents.common`
-5. provider-specific fragment such as `documents.claude`
+## Supported sections
 
-That lets you keep one common `AGENTS.md`-style instruction file and have
-Workcell append it to the provider-native home doc for Codex, Claude, or
-Gemini without replacing the reviewed baseline, while still layering
-`CLAUDE.md` or `GEMINI.md` provider-specific deltas when they exist.
+| Section | Purpose |
+|---|---|
+| `[documents]` | common or provider-specific instruction fragments |
+| `[credentials]` | provider-native auth, MCP, and shared GitHub CLI state |
+| `[ssh]` | SSH config, known hosts, and identity files |
+| `[[copies]]` | explicit copied files or directories for non-reserved targets |
+| `includes = [...]` | compose a policy from smaller operator-owned fragments |
 
-## Supported inputs
-
-- `documents.common`: common non-secret instructions rendered into every
-  provider's home doc
-- `documents.codex`, `documents.claude`, `documents.gemini`: provider-specific
-  instruction fragments
-- `[credentials]`: provider-native credential files mounted read-only from
-  their original host paths and then copied into the correct per-session home
-  paths for Codex, Claude, Gemini, and GitHub CLI
-- `[ssh]`: optional SSH config, known hosts, and identity files mounted
-  read-only from their original host paths and copied into the ephemeral
-  in-container `~/.ssh`
-- `[[copies]]`: explicit copied files or directories staged into either
-  `/state/injected/...` or a non-reserved target under
-  `/state/agent-home/...`. `classification = "secret"` entries use the same
-  direct-mount model as `[credentials]`.
-
-Selectors let you scope injected material to only some launches:
+Selectors let you scope entries to only some launches:
 
 - `providers = ["codex", "claude", "gemini"]`
 - `modes = ["strict", "build"]`
 
-For larger setups, policies can be composed from smaller operator-owned files:
+## Credential keys
 
-- `includes = ["shared-docs.toml", "provider-auth.toml"]`
+| Key | Session target | Notes |
+|---|---|---|
+| `codex_auth` | `~/.codex/auth.json` | persisted Codex auth |
+| `claude_auth` | Claude auth mirrors under `~/.claude/`, `~/.claude.json`, and `~/.config/claude-code/` | compatibility-friendly Claude login reuse |
+| `claude_api_key` | helper-backed Claude API key access | avoids seeding a second plaintext key copy into the session |
+| `claude_mcp` | `~/.mcp.json` | reviewed Claude MCP config |
+| `gemini_env` | `~/.gemini/.env` | API key, GCA, or Vertex configuration |
+| `gemini_oauth` | `~/.gemini/oauth_creds.json` | cached Gemini OAuth state |
+| `gemini_projects` | `~/.gemini/projects.json` | persisted Gemini project registry |
+| `gcloud_adc` | `~/.config/gcloud/application_default_credentials.json` | supplemental Vertex credential, not a standalone Gemini auth mode |
+| `github_hosts` | `~/.config/gh/hosts.yml` | shared GitHub CLI auth; prefer scoped nested tables |
+| `github_config` | `~/.config/gh/config.yml` | shared GitHub CLI config; prefer scoped nested tables |
 
-Includes are loaded relative to the current policy file, must stay within the
-entrypoint policy tree, are merged in the listed order, and fail closed on
-cycles or duplicate settings. `[[copies]]` entries append in include order;
-duplicate `documents.*`, `ssh.*`, or `credentials.*` settings are rejected so
-one fragment cannot silently override another.
+## Instruction precedence
 
-For `[credentials]`, simple `key = "/path/to/file"` entries still work for
-provider-native credentials. Shared GitHub CLI credentials should use scoped
-nested tables so you explicitly choose which provider sessions receive them.
-Legacy scalar shared GitHub entries still work as an all-provider shorthand for
-existing local policies:
+Provider docs are rendered in this order:
 
-```toml
-[credentials.github_hosts]
-source = "/Users/example/.config/gh/hosts.yml"
-providers = ["claude", "gemini"]
-modes = ["strict", "build"]
-```
+1. adapter baseline doc
+2. repo-local `AGENTS.md`
+3. repo-local provider overlay such as `CLAUDE.md` or `GEMINI.md`
+4. `documents.common`
+5. provider-specific document fragment
 
 ## Deliberate limits
 
 - no arbitrary environment-variable secret injection on the safe path
 - no whole-home passthrough
-- no writes into reserved Workcell-managed control-plane files such as
-  `.codex/config.toml`, `.codex/auth.json`, `.codex/rules/`,
-  `.claude/settings.json`, `.gemini/settings.json`, `.gemini/.env`, or
-  `.config/gh/hosts.yml`
-- no generic `.ssh` target writes through `[[copies]]`; use the dedicated
-  `[ssh]` section
-- no expectation that injected secrets stay hidden from processes already
-  running inside the same session; the boundary is host-to-session, not
-  process-to-process inside the container
-- no writes into Workcell-generated helper state such as
-  `~/.claude/workcell/`
-- no unsafe SSH config directives such as `ProxyCommand`, `LocalCommand`,
-  `Include`, `IdentityAgent`, `KnownHostsCommand`, `PKCS11Provider`,
-  `SecurityKeyProvider`, or `Match exec` unless you explicitly set
-  `ssh.allow_unsafe_config = true`
+- no writes into Workcell-managed control-plane paths through `[[copies]]`
+- no `SSH_AUTH_SOCK` forwarding
+- no assumption that one process inside the session is isolated from another
+  process in the same session
 
-## Recommended patterns
+## Recommended usage
 
-- Use `documents.common` for organization-wide instructions that should appear
-  in every agent session.
-- Use `documents.codex`, `documents.claude`, or `documents.gemini` only for
-  provider-specific deltas.
-- Use `[credentials]` for provider and GitHub auth material that should land in
-  Workcell-managed session paths without a fresh login every time. This is the
-  safest way to persist reusable provider auth on the host.
-- Keep secret sources owner-only (`0600` for files, `0700` for directories) and
-  avoid symlinks. Workcell rejects looser permissions on secret-bearing inputs.
-  `ssh.known_hosts` is the exception: standard world-readable files are
-  accepted, but symlinks and group/world-writable paths are rejected.
-- Use `[[copies]]` with `target = "/state/injected/..."` for shared read-only
-  material such as CA bundles or repo policy files. Public copies are staged
-  through the launcher-owned bundle.
-- Use `[[copies]]` with `target = "~/.config/..."` for per-session config files
-  that are not already covered by Workcell-managed credential or control-plane
-  paths. Secret copies are mounted read-only from their original host paths and
-  copied in-session.
-- Use `[ssh]` for SSH config and identity files. Do not forward host
-  `SSH_AUTH_SOCK`.
-- Do not use `[[copies]]` for long-lived API keys or provider login material
-  when `[credentials]` already covers that provider.
-
-## Credential guidance
-
-- `credentials.codex_auth` mounts a host `auth.json` read-only and copies it into
-  `~/.codex/auth.json` for session-local Codex auth reuse.
-- `credentials.claude_api_key` mounts a secret file read-only and generates a
-  session-local Claude `apiKeyHelper` that reads the reviewed direct-mounted
-  credential path, so Claude can reuse an API key without mutating the
-  reviewed baseline settings or creating an extra session-local secret copy.
-- `credentials.claude_auth` mounts persisted Claude auth into
-  `~/.claude/.claude.json` inside the session and mirrors the same reviewed
-  artifact into `~/.claude.json`, `~/.claude/.credentials.json`, plus
-  `~/.config/claude-code/auth.json` for compatibility when you already have
-  reviewed host-side Claude login state. If your host still writes one of the
-  legacy Claude auth files, you can point the injection policy there and
-  Workcell will seed all supported session-local Claude auth paths.
-- `credentials.claude_mcp` mounts an approved Claude `.mcp.json` into the
-  session without widening trust to the whole workspace copy.
-- `credentials.gemini_env` mounts a provider-native `~/.gemini/.env`.
-  This matches Gemini CLI's documented env-file auth flow for `GEMINI_API_KEY`,
-  `GOOGLE_GENAI_USE_GCA=true`, or explicit Vertex settings such as
-  `GOOGLE_GENAI_USE_VERTEXAI=true` paired with either `GOOGLE_API_KEY` or both
-  `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`. When the file includes
-  `GOOGLE_CLOUD_LOCATION`, `GOOGLE_CLOUD_REGION`, `CLOUD_ML_REGION`,
-  `VERTEX_LOCATION`, or `VERTEX_AI_LOCATION`, Workcell also derives the
-  corresponding regional `LOCATION-aiplatform.googleapis.com` allowlist entry
-  for strict-mode Vertex sessions.
-- `credentials.gemini_oauth` mounts a cached Gemini OAuth credential file when
-  you already have one on the host.
-- `credentials.gemini_projects` mounts a persisted Gemini `projects.json`
-  when you want Gemini CLI's project registry to survive across sessions.
-  Workcell validates that the file is a JSON object with an object-valued
-  `projects` field before launch.
-- `credentials.gcloud_adc` mounts Google ADC into
-  `~/.config/gcloud/application_default_credentials.json` as a supplemental
-  input for Gemini Vertex flows that are explicitly configured through
-  `credentials.gemini_env`. It is not a standalone Gemini auth mode.
-- `credentials.github_hosts` and `credentials.github_config` mount GitHub CLI
-  auth/config into `~/.config/gh/`. Because those credentials are shared across
-  tools rather than provider-native, prefer `[credentials.github_hosts]` or
-  `[credentials.github_config]` tables with explicit `providers = [...]`
-  selection over the legacy scalar shorthand.
+- put org-wide guidance in `documents.common`
+- keep provider deltas in `documents.codex`, `documents.claude`, or
+  `documents.gemini`
+- use `[credentials]` for reusable auth, not `[[copies]]`
+- scope shared GitHub credentials with `providers = [...]`
+- keep secret inputs owner-only and avoid symlinks
 
 ## Example
 
-See [`docs/examples/injection-policy.toml`](./examples/injection-policy.toml).
+See [docs/examples/injection-policy.toml](./examples/injection-policy.toml).

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -1,206 +1,84 @@
 # Security Invariants
 
-These invariants are the contract for this repository. Everything else,
-including the priority order and provider adapter behavior, is subordinate to
-them.
+These invariants define the safe path. The priority order in the repository
+only applies after these constraints are satisfied.
 
-## Invariant 1: Host secrets stay outside the default trust boundary
+## 1. Host secrets stay outside the default trust boundary
 
-Tier 1 must not expose host secrets to the active provider by default. That
-includes:
+On the managed path, Workcell does not pass through:
 
 - host home directories
-- host provider state directories
-- keychains and browser profiles
-- SSH, GPG, and similar agent sockets
-- cloud credentials and git credential helper state
-- container or VM control sockets such as `docker.sock`
-- split git-admin directories outside the mounted workspace
+- keychains or browser profiles
+- git credential helpers
+- `docker.sock`
+- SSH, GPG, or provider agent sockets
+- host provider-home state such as `~/.codex`, `~/.claude`, or `~/.gemini`
 
-Explicit operator-owned injection is a separate path, not a default exception.
-When an operator chooses to inject docs, config, or secrets, Workcell must
-copy or mount them into per-session runtime state and keep them out of the
-immutable adapter baseline, workspace mount, durable host logs, and ambient
-environment. Provider credentials injected through the dedicated
-`[credentials]` path must not be re-staged into a second plaintext host-side
-bundle before launch; they are validated on the host, mounted read-only for the
-current session, and then copied into the ephemeral agent home.
-Secret-bearing sources used by the injection policy must be explicit files or
-directories owned by the invoking UID, must not be symlinks, and must not be
-group- or world-readable by default. Credential entries may also be scoped to
-specific providers or runtime modes so a safe launch does not receive broader
-credential material than it needs.
+Reusable auth enters the session only through explicit injection-policy inputs.
 
-## Invariant 2: Writes stay inside the intended workspace
+## 2. Writes stay inside the intended workspace
 
-The active provider must not be able to modify files outside the chosen task
-workspace unless the operator enters an explicit `breakglass` path.
+The selected workspace is the durable writable mount. Provider homes are
+session-local state inside the runtime. Host-side publication remains a
+separate action.
 
-## Invariant 3: Repo policy must not silently widen trust
+## 3. Repo policy must not silently widen trust
 
-The repository must not auto-enable project MCP servers, arbitrary networked
-tools, or higher-trust profiles just because the files exist.
-It should also refuse broad non-git workspace mounts and unsafe provider
-command overrides unless the operator opts into them explicitly.
-On the safe path it should also mask repo-local provider control files and
-mutable git hook/config paths so workspace content cannot silently retake the
-control plane between runs. Repo-local `AGENTS.md`, `CLAUDE.md`, and
-`GEMINI.md` may be imported into provider-native home docs from hidden
-read-only copies, but the workspace-visible files remain masked. Home-scoped
-provider control files must be re-seeded on provider launch, and nested
-coding-agent CLI launches must not be an unmediated escape hatch. Public
-in-container launch surfaces must also
-sanitize hostile loader environment variables before shell or provider wrapper
-logic starts. This claim applies to the public launcher surface under
-`/usr/local/bin`, not
-to internal support scripts under `/usr/local/libexec/workcell/*.sh`. For
-Gemini's shipped npm entrypoint and repackaged workspace copies of Gemini's
-shipped package tree are blocked on the public `node` surface, and the public
-`node` surface also blocks native addon loading so workspace JS cannot retake
-native code execution. Workcell still does not claim to classify arbitrarily
-rewritten workspace JavaScript as vendor code.
+Repo-local control-plane files such as `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`,
+`.codex/`, `.claude/`, and `.gemini/` are masked on the safe path and imported
+into provider homes as reviewed inputs. The workspace should not be able to
+quietly take over the runtime control plane.
 
-## Invariant 4: Network egress is explicit
+## 4. Network posture is explicit
 
-Ambient outbound network access is not an acceptable default. Tier 1 must use a
-named network mode:
+`strict`, `build`, and `breakglass` are distinct runtime profiles. Workcell
+does not rely on provider prompts to describe network posture after the fact.
 
-- `strict`: allowlisted runtime endpoint access only
-- `build`: expanded allowlist for package registries and build tooling
-- `breakglass`: unrestricted outbound access, explicitly chosen and acknowledged
+## 5. Destructive or trust-widening actions need defense in depth
 
-On the allowlist path, Workcell enforces reviewed destination-IP allowlists
-derived from the configured hostnames at launch time. It programs an IPv4
-allowlist and a deny-by-default IPv6 chain for every allowlist launch, adding
-explicit IPv6 allowlist entries when the resolved destination set is dual-stack.
-If `ip6tables` enforcement is unavailable in the VM, Workcell fails closed
-rather than silently downgrading to IPv4-only enforcement.
-The current enforcement model is not a hostname-aware proxy. `strict` does not
-perform cold image builds or rebuilds; runtime-image creation is an explicit
-`build`-mode operation that may temporarily apply a separate pinned bootstrap
-endpoint set before returning to the steady-state runtime allowlist. When the
-operator explicitly opts into `ephemeral` container mutability, the steady-state
-allowlist also includes the pinned Debian snapshot endpoints used by
-`apt` and `apt-get` so transient build tooling can be installed without enabling
-arbitrary distro mirrors. A successful package mutation is an explicit
-lower-assurance event for the live session because maintainer scripts run as
-root inside the mutable container. Workcell must warn when that happens and
-must not imply that the rest of the session preserves the same in-container
-control-plane integrity as a readonly launch.
+The runtime boundary is primary, but Workcell also uses provider-side defenses
+where they help:
 
-## Invariant 5: Destructive command paths have defense in depth
+- Codex requirements and rules
+- Claude reviewed settings and Bash hook
+- Gemini managed settings and trusted-folder seeding
 
-Recursive deletion, raw block writes, privileged host mutation, and history
-rewrites must not depend on prompt quality alone. They need policy controls plus
-the outer runtime boundary.
-Common git hook-bypass flags such as `--no-verify`, `git commit -n`, and inline
-`core.hooksPath` overrides are part of the same class and are not allowed on
-the Tier 1 path. The runtime should also prefer `noexec` scratch space by
-default and reserve exec-capable temporary storage for the explicit per-session
-state area. On `strict`, direct native ELF launches from mutable `/workspace`
-and `/state` paths are blocked so helper binaries cannot bypass the managed
-launcher, and mutable shebang scripts cannot jump straight to protected real
-runtimes or loaders that target them.
+These are guardrails, not substitutes for the runtime boundary.
 
-## Invariant 6: Lower-assurance modes are explicit
+## 6. Lower-assurance paths are labeled
 
-If a workflow cannot preserve the Tier 1 guarantees, it must be labeled
-lower-assurance rather than presented as equivalent.
-That includes provider prompt-autonomy mode and any mutable session that has
-successfully performed package-manager mutations as root. It also includes any
-session that explicitly opts into writable Codex execpolicy rules.
+Examples:
 
-## Invariant 7: Autonomous runs remain auditable
+- `--agent-autonomy prompt`
+- `--cache-profile standard`
+- package mutation inside a mutable container
+- `--allow-control-plane-vcs`
+- `--allow-arbitrary-command`
+- `breakglass`
+- host-side debug or transcript capture
 
-The secure path must preserve enough durable host-side information to
-reconstruct:
+Workcell records those choices in launch or runtime state instead of implying
+they are equivalent to the default path.
 
-- which workspace was used
-- which runtime profile was active
-- which network mode was applied
-- which provider adapter was selected
-- whether the run stayed on the managed Tier 1 path or used an explicitly
-lower-assurance mode
+## 7. Autonomous runs remain auditable
 
-The reference launcher satisfies this by appending an operator-visible audit log
-under the managed Colima profile directory on each real launch and exit,
-including package-mutation downgrade events inferred from a host-visible
-session-assurance marker path that the launcher provides to the runtime during
-the session and, when needed, copies out after exit as a fallback. Injected
-secret values themselves are not part of that durable record. By default, this
-durable audit is metadata-only. Full host-persisted stdout/stderr debug capture
-and session-home file transaction trace capture plus full interactive
-transcript capture are explicit opt-in observability paths and are classified
-as lower-assurance because they can persist provider content or host-retained
-session metadata outside the ephemeral runtime boundary. The transcript path
-retains terminal I/O plus session timestamps and the final exit code, but not
-the raw host launch command.
+The launcher keeps durable host-side audit metadata for real sessions. Full
+debug logs, file traces, and transcripts are separate explicit choices rather
+than ambient defaults.
 
 ## Profile expectations
 
-### `strict`
-
-- dedicated Colima VM profile
-- hardened inner container
-- ephemeral in-container home
-- no host credential or socket passthrough
-- provider-native bounded or constrained mode only where the provider offers
-  one, with the shared Workcell runtime remaining the primary boundary
-- allowlisted steady-state egress only
-- pinned Debian snapshot egress for `apt` and `apt-get` when explicit
-  `ephemeral` container mutability is active
-- requires a prebuilt prepared runtime image; `strict` does not rebuild or
-  cold-bootstrap that image
-- requires active Docker seccomp support in the managed runtime before launch
-- may mount an opt-in host-persisted non-secret cache plane for package
-  indexes and compiler caches when `cache_profile=standard`; the default cache
-  namespace is scoped to the current workspace, and this is still a
-  lower-assurance path and is not part of the clean `strict` session boundary
-
-Assurance mapping within `strict`:
-
-- `ephemeral`: default developer lane, `container_assurance=managed-mutable`
-- `ephemeral` adds only the handoff capabilities required to move from root to
-  the mapped runtime user inside the container: `SETUID`, `SETGID`
-- `readonly`: strongest managed lane for `strict`,
-  `container_assurance=managed-readonly`
-- default managed autonomy: `autonomy_assurance=managed-yolo`
-- prompt autonomy: separate lower-assurance flag,
-  `autonomy_assurance=lower-assurance-prompt-autonomy`
-- default configured Codex rules posture:
-  `codex_rules_assurance_configured=managed-immutable-rules`
-- default effective Codex rules posture:
-  `codex_rules_assurance_effective_initial=managed-immutable-rules`
-- session Codex rules mutability: explicit lower-assurance flag,
-  `codex_rules_assurance_configured=lower-assurance-session-rules`
-- prompt autonomy can also force the initial effective Codex rules posture to
-  `codex_rules_assurance_effective_initial=lower-assurance-session-rules`
-- package mutation can also force this session-local copy for the remainder of
-  an already-downgraded container
-- successful package mutation: runtime downgrade to
-  `lower-assurance-package-mutation` until exit
-
-### `build`
-
-- same VM and container boundary as `strict`
-- same secret and mount restrictions
-- broader network allowlist for dependency and build traffic
-- prepared runtime-image creation and rebuilds happen here, with any temporary
-  bootstrap allowlist logged separately and restored before the session starts
-- still no host credential or control-plane passthrough
-
-### `breakglass`
-
-- still inside the dedicated VM plus container boundary
-- unrestricted network, with any adapter-specific unsafe provider mode selected
-  only through an explicitly lower-assurance direct provider path rather than
-  auto-injected by the managed entrypoint
-- explicitly selected, acknowledged, and visibly different from the safe path
+| Profile | Expected posture |
+|---|---|
+| `strict` | default developer lane; reviewed mounts, explicit network posture, repo control-plane masking |
+| `strict --container-mutability readonly` | strongest managed lane; package-manager writes blocked |
+| `build` | broader egress for image preparation and dependency refresh |
+| `breakglass` | explicit higher-trust lane requiring acknowledgement |
 
 ## Non-goals
 
-This repository does not claim:
+Workcell does not claim:
 
-- equivalent guarantees for host-native GUI, web, or cloud surfaces
-- protection from a compromised host administrator
-- perfect network isolation when the operator bypasses the wrapper
+- that provider hooks or rules are the primary boundary
+- that host-native GUIs are equivalent to Tier 1
+- that release provenance proves the full local macOS boundary on its own

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -1,135 +1,76 @@
 # Provenance, Signing, and SBOMs
 
-Workcell release artifacts are published with verifiable metadata, not just as
-opaque downloads. Signed release publication is gated by a release preflight
-that reruns repo validation, container smoke checks, a reproducible
-runtime-image check, and a reproducible source-bundle check on the tagged
-commit.
+Workcell releases publish verifiable artifacts, not just opaque downloads.
+The canonical release posture uses two verification surfaces:
 
-## Release outputs
+1. always-on keyless Sigstore/Cosign signing
+2. GitHub-native attestations as an additional publication surface
+
+Sigstore is the portable baseline. GitHub attestations are additive.
+
+## What tagged releases publish
 
 Tagged releases publish:
 
-- a multi-architecture container image to GHCR
+- a multi-architecture runtime image to GHCR
 - a source bundle tarball
-- a keyless Sigstore bundle for the source bundle
-- a published image digest file
-- a machine-readable build input manifest
-- a keyless Sigstore bundle for the build input manifest
-- a machine-readable control-plane manifest
-- a keyless Sigstore bundle for the control-plane manifest
-- a machine-readable builder environment manifest
-- a keyless Sigstore bundle for the builder environment manifest
 - `SHA256SUMS`
-- a source SBOM in SPDX JSON
-- a keyless Sigstore bundle for the source SBOM
-- an image SBOM in SPDX JSON
-- a keyless Sigstore bundle for the image SBOM
+- a published image digest file
+- a deterministic build-input manifest
+- a deterministic control-plane manifest
+- a deterministic builder-environment manifest
+- source and image SBOMs in SPDX JSON
+- Sigstore bundles for the source bundle, checksums, build-input manifest,
+  control-plane manifest, builder-environment manifest, and both SBOMs
 - keyless Sigstore signatures for the published image
-- a keyless Sigstore bundle for `SHA256SUMS`, which covers the source bundle,
-  published image digest, build input manifest, control-plane manifest, builder
-  environment manifest, and both SBOM files
-- GitHub attestations when `WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true` is set on
-  a repository and plan that support them
+- GitHub attestations for the published image, image SBOM, source bundle, and
+  source SBOM in the canonical upstream repository
 
-## Trusted builder posture
+## What the release workflow proves
 
-The release workflow uses:
+Before publish, release preflight reruns:
 
-- pinned GitHub Actions refs
-- GitHub-hosted runners
-- GitHub OIDC for short-lived signing identity
-- Docker Buildx provenance and SBOM generation
-- Sigstore keyless signing
-- exact pinned Cosign releases in CI and release workflows, plus an exact
-  pinned Syft release in the publishing workflow
-- a digest-pinned base image
-- a digest-pinned BuildKit daemon image for GitHub-hosted builder jobs
-- fixed Debian snapshot archives
-- a vendored, locked, offline Rust build for the shipped launcher and exec
-  guard artifacts, rebuilt inside the runtime image with a fixed
-  `SOURCE_DATE_EPOCH`
-- a committed provider CLI lockfile with integrity-pinned transitive npm inputs
-  for the shipped Gemini CLI, installed with `npm ci --ignore-scripts` and
-  validated in CI for source, version, and integrity coverage
-- a pinned native Claude Linux release with explicit version and per-arch
-  SHA256 checksums, re-verified in CI against Anthropic's published release
-  manifest
-- a deterministic build input manifest that records the pinned runtime base
-  image, full runtime Dockerfile digest, Debian snapshot, Codex release assets,
-  Claude release assets, Gemini provider lockfile digests, the actual runtime
-  build-context inputs consumed by the Dockerfile including `.dockerignore`,
-  adapters, vendored Rust runtime sources, and runtime enforcement code, plus
-  the rest of the tracked repository inputs that control release publication,
-  and is itself directly signed and also covered by the signed checksum set
-- a deterministic control-plane manifest that records the reviewed adapter
-  baselines, runtime control-plane scripts that seed provider-facing homes,
-  and the host-side launcher, Docker-context guard, direct-mount extractor,
-  and injection-policy renderer that stage those homes, is copied into the
-  runtime image, drives runtime hash checks for the adapter baselines and
-  selected seeding inputs, is directly signed at release time, and is also
-  bound into the signed checksum set
-- host-side pin-hygiene checks that run before rebuilding the validator image
-  in CI and release preflight, including exact package-set checks for both the
-  runtime and validator Dockerfiles, pinned workflow-side BuildKit and signing
-  tool releases, and rejection of ambient `gh release` publication paths
-- release-preflight verification of the pinned Codex Linux assets against
-  OpenAI's published Sigstore bundle and the pinned Claude Linux assets against
-  Anthropic's published release manifest
-- scheduled re-verification of pinned non-Dependabot inputs such as the
-  Debian snapshot policy and the pinned Codex and Claude release artifacts
-- a fixed source bundle mtime plus `gzip -n` for reproducible source archives
-- fixed-order multi-architecture publication, where the final manifest list is
-  assembled from independently published `linux/amd64` and `linux/arm64`
-  manifests in a reviewed order rather than emitted by one opaque multi-platform
-  push step
+- repository validation
+- container smoke
+- release-bundle reproducibility
+- runtime-image reproducibility
+- hosted-control auditing
+- upstream pinned Codex and Claude release verification
 
-This gives consumers one always-on verification path and one optional one:
+The publish job then rebuilds from the archived source bundle, not the live
+checkout. It binds the published per-platform image digests, source bundle,
+build-input manifest, and control-plane manifest back to preflight results
+before signing and publication.
 
-1. Sigstore and Cosign verification
-2. GitHub attestation verification when repository settings enable it
+## Sigstore path
 
-The builder proves that GitHub Actions produced the published artifacts. The
-release workflow additionally requires the tagged commit to be reachable from
-`main`, but consumers should still verify branch protection and review policy in
-the repository itself.
+The always-on path is:
 
-The reproducibility check compares two multi-platform OCI layout exports that
-cover every supported runtime platform, built with the same
-`SOURCE_DATE_EPOCH` and without attached attestations. This is intentional:
-BuildKit attestations are separately signed and verified release metadata,
-while the reproducibility gate measures the image contents themselves. The
-check compares the stable OCI subject digest from those exports and still
-records reviewed per-platform manifest and config digests, and release
-publication requires the pushed per-platform digests to match the preflight
-manifest before the final multi-architecture manifest is published. The release
-preflight also verifies deterministic source bundle generation, records the
-expected tarball digest for the tag-specific prefix and ref, and requires the
-published source bundle to match that preflight digest.
-The publish job then rebuilds the signed build-input manifest and the published
-runtime image from the extracted signed source bundle tree, not from the live
-checkout, so the signed tarball is the authoritative source for the shipped
-runtime contents. Release preflight also generates the exact expected
-build-input manifest and publish requires the manifest regenerated from the
-archived source tree to match it byte-for-byte before signing. Local
-verification also requires release-critical manifest inputs to be tracked in
-git before the repo validation or release preflight passes, so newly added
-workflow, script, docs, policy, or runtime files cannot silently fall outside
-the signed input set.
+- GitHub OIDC identity
+- keyless Cosign signing
+- Rekor-backed Sigstore bundles published with the release assets
 
-Those checks prove that Workcell can rebuild the OCI runtime image and the
-published source bundle deterministically when the same pinned upstream
-artifacts are still available. They do not make the build hermetic or
-independent of upstream artifact availability, and they do not claim
-byte-for-byte reproducibility for generated SBOM or attestation metadata. The
-published SBOMs are directly signed and are also bound into the always-on
-signed checksum manifest. The runtime also removes general-purpose Perl
-entrypoints from the final image,
-mounts `/tmp` as `noexec`, and uses `/state/tmp` as the exec-capable temporary
-area so the shipped runtime shape matches the invariants the verification suite
-expects.
+This path is the recommended verifier for consumers who want a portable,
+GitHub-independent check.
 
-## Verifying a release image
+## GitHub attestation path
+
+The canonical upstream repo also publishes GitHub attestations. That posture is
+treated as part of the reviewed hosted control plane through the
+`WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true` repository variable.
+
+This does not replace Sigstore. It adds:
+
+- GitHub-native attestation UX and policy integration
+- subject-linked attestations for the image and selected release artifacts
+
+Because GitHub attestations can add extra OCI attestation manifests next to the
+published image, Workcell validates multi-arch platform ordering separately
+from those attestation entries.
+
+## Verifying the image
+
+Verify the image with Cosign:
 
 ```bash
 cosign verify ghcr.io/OWNER/workcell@sha256:DIGEST \
@@ -137,32 +78,23 @@ cosign verify ghcr.io/OWNER/workcell@sha256:DIGEST \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
-If GitHub attestations are available for the repository:
+Verify the same image with GitHub attestation tooling:
 
 ```bash
 gh attestation verify oci://ghcr.io/OWNER/workcell@sha256:DIGEST \
   --repo OWNER/workcell
 ```
 
-## Verifying the source bundle
+## Verifying release assets
 
-1. Download `SHA256SUMS`, `SHA256SUMS.sigstore.json`, and the release assets you
-   want to verify.
-2. Optionally verify the directly signed source bundle and SBOM bundles with
-   Cosign.
-3. Verify the checksum file bundle with Cosign.
-4. Verify the tarball, image digest file, build input manifest, builder
-  environment manifest, control-plane manifest, and SBOM digests against
-  `SHA256SUMS`.
+1. Download `SHA256SUMS`, `SHA256SUMS.sigstore.json`, and the assets you want
+   to verify.
+2. Verify the signed checksum file with Cosign.
+3. Verify the asset digests against `SHA256SUMS`.
+4. Optionally verify the directly signed JSON manifests or SBOMs with their own
+   Sigstore bundles.
 
-The control-plane manifest publishes two reviewed domains in one deterministic
-artifact:
-
-- `runtime_artifacts`: reviewed files baked into the runtime image; current
-  runtime hash checks cover the adapter baselines and selected seeding inputs
-- `host_artifacts`: reviewed host-side launcher, Docker-context guard,
-  direct-mount extractor, and injection-renderer inputs that are signed and
-  published for release provenance, but not verified inside the runtime
+Example:
 
 ```bash
 cosign verify-blob SHA256SUMS \
@@ -170,38 +102,10 @@ cosign verify-blob SHA256SUMS \
   --certificate-identity-regexp 'https://github.com/OWNER/workcell/.github/workflows/release.yml@refs/tags/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
-cosign verify-blob workcell-build-inputs.json \
-  --bundle workcell-build-inputs.sigstore.json \
-  --certificate-identity-regexp 'https://github.com/OWNER/workcell/.github/workflows/release.yml@refs/tags/.+' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com
-
-cosign verify-blob workcell-control-plane.json \
-  --bundle workcell-control-plane.sigstore.json \
-  --certificate-identity-regexp 'https://github.com/OWNER/workcell/.github/workflows/release.yml@refs/tags/.+' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com
-
-cosign verify-blob workcell-VERSION.tar.gz \
-  --bundle workcell-VERSION.tar.gz.sigstore.json \
-  --certificate-identity-regexp 'https://github.com/OWNER/workcell/.github/workflows/release.yml@refs/tags/.+' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com
-
-cosign verify-blob workcell-source.spdx.json \
-  --bundle workcell-source.spdx.sigstore.json \
-  --certificate-identity-regexp 'https://github.com/OWNER/workcell/.github/workflows/release.yml@refs/tags/.+' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com
-
-cosign verify-blob workcell-image.spdx.json \
-  --bundle workcell-image.spdx.sigstore.json \
-  --certificate-identity-regexp 'https://github.com/OWNER/workcell/.github/workflows/release.yml@refs/tags/.+' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com
-
-cosign verify-blob workcell-builder-environment.json \
-  --bundle workcell-builder-environment.sigstore.json \
-  --certificate-identity-regexp 'https://github.com/OWNER/workcell/.github/workflows/release.yml@refs/tags/.+' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+sha256sum -c SHA256SUMS
 ```
 
-If GitHub attestations are available:
+If you want GitHub's attestation view for the source bundle:
 
 ```bash
 gh attestation verify workcell-VERSION.tar.gz --repo OWNER/workcell
@@ -209,6 +113,7 @@ gh attestation verify workcell-VERSION.tar.gz --repo OWNER/workcell
 
 ## Scope note
 
-These release materials prove how the published artifacts were built. They do
-not, by themselves, prove the full local macOS runtime boundary. That assurance
-still depends on Workcell's local runtime verification and operator discipline.
+Release provenance proves how the published artifacts were built and signed. It
+does not, by itself, prove the entire local macOS runtime boundary. That still
+depends on Workcell's local runtime controls, local validation, and operator
+discipline.

--- a/docs/provider-matrix.md
+++ b/docs/provider-matrix.md
@@ -1,31 +1,22 @@
 # Provider Matrix
 
-`Workcell` keeps one shared runtime boundary and exposes thin adapters for
-provider-native control planes.
+Workcell keeps one shared runtime boundary and adapts each provider into it
+through a native control-plane mapping.
 
-## Summary
+## Current support
 
-The runtime boundary is shared. The adapter layer changes by provider.
-
-CLI adapters are the primary Tier 1 target because they can stay fully inside
-the bounded runtime. GUI adapters are Tier 2 only when they are clients to that
-same runtime, not host-native executors.
-
-## Matrix
-
-| Provider | Primary Tier 1 surface | Native control plane | Boundary fit | Notes |
+| Provider | Tier 1 surface today | Managed control plane | Long-lived auth inputs | Notes |
 |---|---|---|---|---|
-| Codex | CLI | `~/.codex/config.toml`, `AGENTS.md`, `.rules`, MCP config | Clean | Best fit for runtime-plus-adapter design |
-| Codex | App / GUI | app plus `app-server` | Partial | Tier 2 only when execution stays in the bounded runtime |
-| Claude | Claude Code CLI | `~/.claude/settings.json`, `~/.claude/.claude.json`, compatibility mirror `~/.claude.json`, `/etc/claude-code/managed-settings.json`, legacy mirrors under `~/.claude/.credentials.json` and `~/.config/claude-code/auth.json`, imported shared `AGENTS.md` plus `CLAUDE.md` overlay when present, `.mcp.json`, hooks | Partial | Hooks are guardrails, not the boundary; reviewed `managed-settings.json`, `.mcp.json`, and auth can be injected explicitly |
-| Claude | IDE / GUI workflows | IDE and host integrations | Partial | Lower assurance unless attached to the same bounded workspace/runtime |
-| Gemini | Gemini CLI | `~/.gemini/settings.json`, imported shared `AGENTS.md` plus `GEMINI.md` overlay when present, injected `projects.json` | Partial | Internal sandbox is not the primary boundary here; repo `.gemini/` stays masked on the safe path |
-| Gemini | IDE / GUI workflows | IDE integration and host UI surfaces | Partial | Tier 2 only if execution is still fully remote/containerized |
+| Codex | CLI | `~/.codex/config.toml`, `managed_config.toml`, `requirements.toml`, rules, MCP config, rendered `AGENTS.md` | `codex_auth` | best fit for the shared boundary model |
+| Claude | Claude Code CLI | `~/.claude/settings.json`, rendered `CLAUDE.md`, `.mcp.json`, auth mirrors, reviewed Bash hook | `claude_auth`, `claude_api_key`, `claude_mcp` | hooks are defense in depth, not the primary boundary |
+| Gemini | Gemini CLI | `~/.gemini/settings.json`, rendered `GEMINI.md`, `.env`, OAuth creds, `projects.json`, trusted folders | `gemini_env`, `gemini_oauth`, `gemini_projects`, `gcloud_adc` | Gemini's own sandbox is not the Tier 1 boundary here |
 
-## Adapter rule
+## Tiering rule
 
-Do not force one provider's control model onto another. Keep:
+- Tier 1: provider CLI runs fully inside the bounded runtime
+- Tier 2: GUI or IDE surface is only a client to that same bounded runtime
+- Tier 3: host-native GUI, cloud, or web-only guidance with no claim of
+  equivalent local isolation
 
-1. one shared runtime boundary
-2. one shared invariant set
-3. one provider adapter per product
+Do not force one provider's control model onto another. Keep one shared
+boundary and one thin adapter per product.

--- a/docs/scenario-gaps.md
+++ b/docs/scenario-gaps.md
@@ -1,175 +1,51 @@
 # Scenario Test Coverage Gaps
 
-This document lists known gaps in scenario test coverage. Each gap is marked
-with the reason it is not yet tested and the path to add a test when the
-constraint is lifted.
+This file tracks the main places where Workcell is documented or designed but
+not yet covered as deeply as the core secretless validation path.
 
-Scenarios marked `aspirational` in `docs/use-case-matrix.md` correspond to
-entries here.
+## Highest-value gaps
 
----
+### Full macOS boundary proof
 
-## Codex gaps
+The strongest local claim depends on the actual Colima plus
+Virtualization.Framework boundary. GitHub-hosted runners cannot prove that, so
+the best evidence today is local or self-hosted macOS verification.
 
-### codex-auth injection end-to-end
+### End-to-end authenticated coverage for every provider
 
-**Description:** Verify that a `codex_auth` injection policy entry correctly
-places `auth.json` at `~/.codex/auth.json` inside the session and that Codex
-CLI can authenticate against the OpenAI API.
+Manual provider-authenticated smoke exists, but not every documented auth path
+has full automated end-to-end coverage across all providers.
 
-**Why not tested yet:** Requires live Codex/OpenAI credentials. The secretless
-CI lane cannot execute this without real auth material.
+### Lower-assurance transition coverage
 
-**Path to add:** Add a scenario under `tests/scenarios/codex-auth/` that
-checks the injected file path inside the container using the provider-e2e
-smoke harness (`scripts/provider-e2e.sh`). Gate it behind
-`requires_credentials: true` in the manifest and wire it to the
-`provider-e2e.yml` workflow dispatch lane.
+Some downgrade paths are validated statically or by smoke tests but still need
+more explicit end-to-end scenarios, especially:
 
-### codex-rules-mutability session vs readonly
+- prompt autonomy audit fields
+- package-mutation downgrade behavior
+- `breakglass` posture and audit output
 
-**Description:** Verify that `--codex-rules-mutability session` seeds a
-writable rules copy and that the adapter baseline under `adapters/` is
-unchanged after the session.
+## Provider-specific gaps
 
-**Why not tested yet:** Requires a running container session. The current
-secretless lane validates the static adapter files but does not run a full
-session lifecycle.
+### Codex
 
-**Path to add:** Add a scenario under `tests/scenarios/codex-rules/` that
-mounts a test workspace, launches a minimal Codex session in readonly mode,
-attempts an execpolicy amendment, and verifies the adapter baseline is
-unmodified. Can run secretless if Codex is invoked with a fixture command that
-does not require network auth.
+- more end-to-end coverage around rule mutability transitions
+- more explicit live coverage of host-side publication handoff
 
----
+### Claude
 
-## Claude gaps
+- deeper authenticated coverage for imported MCP state and prompt-autonomy
+  downgrade labeling
 
-### claude prompt autonomy audit field
+### Gemini
 
-**Description:** Verify that launching Claude with `--agent-autonomy prompt`
-produces an audit log entry with
-`autonomy_assurance=lower-assurance-prompt-autonomy`.
+- more end-to-end coverage for Gemini OAuth reuse
+- more end-to-end coverage for Vertex plus `gcloud_adc`
+- more coverage for `breakglass` folder-trust restoration
 
-**Why not tested yet:** Requires a running container session that reaches the
-audit log write path. The hook-parametric test covers the hook layer but not
-the audit log schema for autonomy mode.
+## Why these gaps remain acceptable for now
 
-**Path to add:** Add a scenario under `tests/scenarios/claude-audit/` that
-checks the audit log entry fields after a minimal prompt-autonomy session.
-Can reuse the existing audit-field contract checks in
-`scripts/verify-invariants.sh` as a baseline, then graduate them into a
-dedicated runnable scenario for prompt autonomy.
-
-### claude MCP injection replaces empty template
-
-**Description:** Verify that `credentials.claude_mcp` replaces the symlinked
-empty `mcp-template.json` with the operator-provided file and that
-`~/.mcp.json` inside the session reflects the injected content.
-
-**Why not tested yet:** Requires a fixture MCP config and a running session
-that can inspect the seeded home. The injection helper tests cover the
-rendering step but not the final in-container file.
-
-**Path to add:** Add a scenario under `tests/scenarios/claude-mcp/` using a
-fixture `.mcp.json` with no live server entries. Run secretless.
-
----
-
-## Gemini gaps
-
-### gemini OAuth interactive login
-
-**Description:** Verify that Gemini CLI completes the OAuth browser login flow
-inside a managed Workcell session and that the resulting `oauth_creds.json` is
-session-local only.
-
-**Why not tested yet:** Requires a live browser interaction on the host.
-There is no headless path for this flow. It cannot run in CI without a
-self-hosted macOS runner with an active desktop session.
-
-**Path to add:** Document as a manual validation step in
-`docs/validation-scenarios.md`. A fully automated test is only feasible if
-Gemini CLI exposes a headless OAuth code-exchange path.
-
-### gemini GCA (Google Cloud Application Default Credentials)
-
-**Description:** Verify that `GOOGLE_GENAI_USE_GCA=true` in `gemini_env`
-correctly activates GCA mode and that the session can reach Gemini through
-ADC without a separate API key.
-
-**Why not tested yet:** Requires a live GCP project with ADC provisioned on
-the self-hosted macOS runner. This is an infrastructure dependency that the
-default CI lane cannot satisfy.
-
-**Path to add:** Wire to the `provider-e2e.yml` workflow dispatch lane on the
-self-hosted macOS path with `WORKCELL_E2E_GCLOUD_ADC_JSON` as the environment
-secret. Add a scenario under `tests/scenarios/gemini-gca/` gated behind
-`requires_credentials: true`.
-
-### gemini Vertex regional allowlist expansion
-
-**Description:** Verify that a `gemini_env` file containing
-`GOOGLE_CLOUD_LOCATION=us-central1` causes Workcell to add
-`us-central1-aiplatform.googleapis.com:443` to the active egress allowlist
-before launch.
-
-**Why not tested yet:** The injection helper unit tests cover env-file parsing.
-The allowlist expansion step happens in the host launcher and requires a
-running Colima VM to observe the resulting iptables rules. This is a macOS
-local or self-hosted test.
-
-**Path to add:** Add an invariant check to `scripts/verify-invariants.sh` that
-parses the launcher output for a Vertex-env fixture and confirms the derived
-allowlist entry. No live network required; the check is on the derived
-hostname, not the live endpoint.
-
----
-
-## Cross-provider gaps
-
-### Full VM boundary test
-
-**Description:** Verify that the Colima VM plus container boundary prevents the
-agent from reading host home directories, keychains, and credential paths.
-
-**Why not tested yet:** Requires Colima and the Virtualization.Framework on a
-macOS host. This test cannot run on GitHub-hosted ubuntu runners.
-
-**Path to add:** The `macos-boundary.yml` workflow (`workflows/macos-boundary.yml`)
-is the designated lane for this test on a self-hosted macOS runner. Extend it
-with an explicit host-secret-isolation scenario once a self-hosted macOS runner
-is provisioned with `WORKCELL_ENABLE_SELF_HOSTED_MACOS=true`.
-
-### breakglass mode audit and posture
-
-**Description:** Verify that a `breakglass` session produces an audit log entry
-recording the explicit acknowledgement and that the session posture fields
-reflect the lower-assurance downgrade.
-
-**Why not tested yet:** `breakglass` requires `--ack-breakglass` and a running
-Colima VM. It is intentionally local macOS only; running it in default CI would
-require the full VM boundary.
-
-**Path to add:** Add a manual scenario under `tests/scenarios/breakglass/`
-with a fixture `--ack-breakglass` launch that checks the audit log fields.
-Gate it behind a local-only flag so it does not run in the default CI lane.
-Document it in `docs/validation-scenarios.md` under "Out Of Scope And
-Breakglass".
-
-### Live provider end-to-end for all three providers
-
-**Description:** Full round-trip test: inject real credentials, prepare image,
-launch provider inside Workcell, run a minimal authenticated probe, verify
-`WORKCELL_PROVIDER_E2E_OK` in output.
-
-**Why not tested yet:** Requires live provider credentials. The
-`provider-e2e.yml` workflow is `workflow_dispatch` only and requires a
-self-hosted macOS runner with environment-scoped secrets.
-
-**Path to add:** All three providers are already scaffolded in
-`scripts/provider-e2e.sh`. Wire each to a scenario under
-`tests/scenarios/<provider>-e2e/` gated behind `requires_credentials: true`
-and `workflow_dispatch` in `provider-e2e.yml`. This is the lane described in
-`docs/validation-scenarios.md`.
+The core secretless path is covered by invariants, smoke tests, repo
+validation, reproducibility checks, and tagged release preflight. The open
+gaps are mostly at the edges: live-provider auth, local macOS proof, and
+explicit lower-assurance transitions.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -2,66 +2,64 @@
 
 ## Assets
 
-- host credentials and long-lived tokens
-- host filesystem outside the task workspace
-- git history and remote branch integrity
-- Workcell policy, runtime, and reviewer configuration
-- autonomous-run audit metadata
+- the host's credentials, homes, keychains, and agent sockets
+- the selected workspace and git history
+- the reviewed runtime and adapter baselines
+- release materials: image, source bundle, SBOMs, signatures, and manifests
 
 ## Trust boundaries
 
-1. macOS host
-2. dedicated Colima VM profile
-3. hardened inner container
-4. active provider process and provider-managed shell commands
-5. mounted task workspace
-6. explicitly enabled MCP servers and outbound network destinations
+1. host OS
+2. dedicated Colima VM
+3. hardened runtime container
+4. provider-native process inside the container
+5. explicit injected material staged for the session
+6. repository-hosted GitHub controls used for release and branch protection
 
 ## Main attacker models
 
 ### Malicious repository content
 
-The repository being analyzed may contain prompt injection, dangerous scripts,
-malicious dependency metadata, and files intended to exfiltrate secrets or push
-the agent into destructive actions.
+Untrusted workspace files try to change provider behavior, steal secrets, or
+influence host publication flows.
 
 ### Malicious or compromised MCP server
 
-An MCP server may try to widen trust, obtain credentials, or cause unexpected
-mutations.
+An MCP server or related config attempts to widen network or filesystem access
+from inside the session.
 
 ### Mis-scoped operator trust
 
-An operator may accidentally run the tool outside the wrapper, use the wrong
-profile, or mount host state that should remain outside the trust boundary.
+An operator accidentally chooses a lower-assurance mode and assumes it is
+equivalent to the default path.
+
+### Supply-chain or release tampering
+
+A workflow, hosted control, or release input changes in a way that weakens the
+published provenance story.
 
 ## Primary abuse paths
 
-1. Read host secrets through ambient mounts or inherited environment.
-2. Escape the intended workspace by using broad writable roots or host
-   passthrough.
-3. Use ambient network access to exfiltrate code or pull malicious tooling.
-4. Rewrite git history or mutate shared branches from an autonomous workflow.
-5. Expand tool reach by enabling project MCP servers, dangerous profiles, or
-   weaker host-native GUI paths.
+- repo-local control-plane files replacing reviewed provider baselines
+- host socket or credential passthrough through the runtime boundary
+- uncontrolled egress on the managed path
+- unsafe provider-native flag overrides
+- unsigned or weakly attested release publication
 
 ## Controls
 
-- dedicated Colima VM profile rather than the shared default profile
-- inner container with `no-new-privileges`; mutable sessions add only
-  `SETUID` and `SETGID` to support the root-to-runtime-user handoff
-- explicit mount allowlist
-- Workcell profile split: `strict`, `build`, `breakglass`
-- disabled web search by default
-- explicit MCP definitions and disabled-by-default posture
-- command guardrails in `.rules`
-- VM-level egress policy rather than extra container capabilities
+- dedicated VM plus container boundary
+- explicit runtime profiles with separate assurance labels
+- masking and re-seeding of provider control-plane files
+- explicit injection-policy inputs instead of ambient host passthrough
+- invariant tests and container smoke checks
+- signed commits, branch rulesets, and hosted-control audits
+- Sigstore-based release signing plus GitHub attestations in the canonical repo
 
 ## Residual risks
 
-- If the operator bypasses the wrapper and runs Codex on the host, Tier 1 is
-  lost.
-- Bind mounts remain the main path from the VM into host-controlled data.
-- Network allowlists based on resolved IPs are best-effort and must be refreshed
-  when endpoints change.
-- Lower-assurance app and IDE flows may remain necessary for some workflows.
+- the full macOS boundary is still a local or self-hosted exercise, not a
+  GitHub-hosted guarantee
+- `breakglass`, prompt autonomy, and other explicit downgrades remain
+  operator-controlled trust decisions
+- MCP servers remain extension points and need deliberate operator review

--- a/docs/use-case-matrix.md
+++ b/docs/use-case-matrix.md
@@ -1,78 +1,32 @@
 # Use Case Coverage Matrix
 
-This matrix maps providers, personas, and use cases to their current test
-coverage status.
+This matrix summarizes how well the current repo validates the most important
+Workcell workflows.
 
-Test status values:
+## Coverage scale
 
-- `tested` — automated coverage exists (scenario test, unit test, or
-  invariant check)
-- `doc-only` — documented and manually verified, but no automated scenario
-  test yet
-- `aspirational` — identified as a target scenario, not yet tested or
-  documented in detail
-
-Some `tested` rows are static contract checks rather than end-to-end runtime
-scenarios. The `Coverage Source` column shows where the current automated
-coverage lives.
+- `tested`: covered by repo validation, invariants, smoke, or scenario tests
+- `doc-only`: documented and intentionally supported, but not deeply automated
+- `gap`: recognized coverage gap tracked in `docs/scenario-gaps.md`
 
 ## Matrix
 
-| Provider | Persona | Use Case | Test Status | Coverage Source |
-|---|---|---|---|---|
-| Codex | SWE | `--inspect` contract retains required keys | tested | `scripts/verify-invariants.sh` |
-| Codex | SWE | audit record contract retains required fields | tested | `scripts/verify-invariants.sh` |
-| Codex | SWE | launch with codex_auth injection policy credential | tested | `scripts/container-smoke.sh` |
-| Codex | SWE | session-local Codex rules mutability does not affect adapter baseline | tested | `scripts/container-smoke.sh`, `scripts/verify-invariants.sh` |
-| Codex | Developer | first-run --prepare flow seeds runtime image | doc-only | — |
-| Codex | Developer | doctor reports missing workspace before suggesting --prepare | tested | `scripts/verify-invariants.sh` |
-| Codex | Developer | --injection-policy default path auto-picked from ~/.config/workcell | doc-only | — |
-| Codex | DevRel | publish-pr creates signed commit and draft PR on host | tested | `tests/scenarios/shared/test-publish-pr-dry-run.sh`, `scripts/verify-invariants.sh` |
-| Codex | DevRel | auth-status prints primary auth mode from injected codex_auth | tested | `tests/scenarios/shared/test-auth-status.sh`, `scripts/verify-invariants.sh` |
-| Codex | PM | yolo autonomy mode launches with --ask-for-approval never | tested | `scripts/container-smoke.sh` |
-| Codex | PM | prompt autonomy mode marked lower-assurance in audit output | tested | `scripts/verify-invariants.sh` |
-| Codex | NaiveCoder | nested coding-agent CLI launch blocked by provider-policy.sh | doc-only | — |
-| Codex | NaiveCoder | git hook-bypass flags rejected on Tier 1 path | doc-only | — |
-| Codex | NaiveCoder | direct push to main blocked | doc-only | — |
-| Codex | NaiveCoder | host home not reachable from inside session | doc-only | — |
-| Claude | SWE | guard-bash.sh blocks unsafe git commands | tested | `tests/scenarios/claude-swe/test-hook-parametric.sh` |
-| Claude | SWE | `--inspect` contract retains required keys | tested | `scripts/verify-invariants.sh` |
-| Claude | SWE | audit record contract retains required fields | tested | `scripts/verify-invariants.sh` |
-| Claude | SWE | managed-settings.json is not replaceable by workspace files | doc-only | — |
-| Claude | Developer | claude_api_key generates apiKeyHelper without second plaintext copy | tested | `scripts/container-smoke.sh` |
-| Claude | Developer | claude_mcp injects reviewed MCP config replacing empty template | tested | `scripts/container-smoke.sh` |
-| Claude | Developer | enableAllProjectMcpServers remains false after workspace launch | tested | `scripts/container-smoke.sh`, `scripts/verify-invariants.sh` |
-| Claude | DevRel | publish-pr creates signed commit and draft PR on host | tested | `tests/scenarios/shared/test-publish-pr-dry-run.sh`, `scripts/verify-invariants.sh` |
-| Claude | DevRel | org CLAUDE.md overlay appended via documents.claude in policy | doc-only | — |
-| Claude | PM | yolo autonomy mode launches with --permission-mode bypassPermissions | tested | `scripts/container-smoke.sh` |
-| Claude | PM | prompt autonomy mode marked lower-assurance in audit output | aspirational | — |
-| Claude | NaiveCoder | nested claude subprocess with unsafe flags blocked by guard-bash.sh | tested | `tests/scenarios/claude-swe/test-hook-parametric.sh` |
-| Claude | NaiveCoder | rm -rf blocked by guard-bash.sh | tested | `tests/scenarios/claude-swe/test-hook-parametric.sh` |
-| Claude | NaiveCoder | shell expansion syntax blocked by guard-bash.sh | tested | `tests/scenarios/claude-swe/test-hook-parametric.sh` |
-| Claude | NaiveCoder | workspace control file reads blocked by guard-bash.sh | tested | `tests/scenarios/claude-swe/test-hook-parametric.sh` |
-| Gemini | SWE | auth modes correctly parsed from `gemini_env` injection | tested | `tests/python/test_injection_helpers.py` |
-| Gemini | SWE | `--inspect` contract retains required keys | tested | `scripts/verify-invariants.sh` |
-| Gemini | SWE | audit record contract retains required fields | tested | `scripts/verify-invariants.sh` |
-| Gemini | SWE | trustedFolders.json seeded with /workspace before launch | tested | `scripts/container-smoke.sh`, `scripts/verify-invariants.sh` |
-| Gemini | Developer | Vertex env derives regional aiplatform allowlist entry | doc-only | — |
-| Gemini | Developer | gcloud_adc supplemental only, not standalone Gemini auth | tested | `tests/scenarios/shared/test-auth-status.sh`, `scripts/verify-invariants.sh` |
-| Gemini | Developer | gemini_oauth credential copied to ~/.gemini/oauth_creds.json | doc-only | — |
-| Gemini | DevRel | publish-pr creates signed commit and draft PR on host | tested | `tests/scenarios/shared/test-publish-pr-dry-run.sh`, `scripts/verify-invariants.sh` |
-| Gemini | DevRel | gemini_projects credential seeded into ~/.gemini/projects.json | tested | `scripts/container-smoke.sh` |
-| Gemini | PM | yolo autonomy mode launches with --approval-mode yolo | tested | `scripts/container-smoke.sh` |
-| Gemini | PM | prompt autonomy mode marked lower-assurance in audit output | aspirational | — |
-| Gemini | NaiveCoder | workspace .gemini/ masked on safe path | doc-only | — |
-| Gemini | NaiveCoder | nested coding-agent CLI launch blocked | doc-only | — |
-| Gemini | NaiveCoder | breakglass restores Gemini folder-trust prompt, omits trustedFolders seed | doc-only | — |
-| Gemini | NaiveCoder | host home not reachable from inside session | doc-only | — |
+| Use case | Status | Primary evidence |
+|---|---|---|
+| secretless provider launch on the managed path | tested | `scripts/container-smoke.sh`, `scripts/verify-invariants.sh` |
+| provider auth injected through the reviewed policy model | tested | container smoke, auth-status tests, provider-specific helpers |
+| host-side signed `publish-pr` handoff | tested | shared scenario tests and invariant checks |
+| repo control-plane masking and provider-home re-seeding | tested | invariants and smoke |
+| prompt-autonomy downgrade labeling | tested for Codex, partial elsewhere | invariants plus provider-specific coverage |
+| release-bundle reproducibility | tested | `scripts/verify-release-bundle.sh`, tagged release preflight |
+| runtime-image reproducibility | tested | `scripts/verify-reproducible-build.sh`, CI, tagged release preflight |
+| Sigstore signing and SBOM publication | tested | successful tagged release workflow |
+| GitHub attestations on tagged releases | tested at release time | `release.yml` publish job |
+| full macOS Colima boundary proof | gap | local or self-hosted exercise only |
+| exhaustive live-provider auth UX across all providers | gap | manual provider-e2e path exists, but automation is partial |
 
-## Notes on coverage sources
+## Notes
 
-Scenario tests are declared in `tests/scenarios/manifest.json`, including the
-lane and platform metadata that determines whether they run in the default
-secretless path. Their scripts live under `tests/scenarios/`. Static
-invariant checks live in `scripts/verify-invariants.sh`, container/runtime
-coverage lives in `scripts/container-smoke.sh`, and unit tests live under
-`tests/python/`.
-
-For gaps and aspirational scenarios, see `docs/scenario-gaps.md`.
+The most heavily tested paths are the secretless runtime boundary, release
+preflight, reproducibility, and signed publication. The biggest remaining gaps
+are local macOS boundary proof and deeper end-to-end live-provider coverage.

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -1,137 +1,70 @@
 # Validation Scenarios
 
-This page groups the validation paths used by the provider validation plan.
-The split is intentional: secretless tests stay default, provider e2e stays
-explicit, and breakglass remains outside the normal workflow.
+Workcell uses several validation layers. No single test proves the full
+boundary or release story by itself.
 
-## Local Secretless Tests
+Use this page with:
 
-Use this lane when you want fast validation without provider credentials.
-It should exercise repository shape, launcher behavior, invariant checks, and
-container smoke that does not depend on provider auth.
+- [docs/use-case-matrix.md](use-case-matrix.md) for what is currently covered
+- [docs/scenario-gaps.md](scenario-gaps.md) for what is still missing
 
-Recommended entry points are the normal local validation commands already
-documented in the README, such as `./scripts/dev-quick-check.sh` and the
-broader pre-merge path when you need the standard local developer gate. That
-path keeps repository validation, invariants, smoke, release-bundle checks, and
-host-native runtime reproducibility local; CI and release preflight remain the
-cross-platform reproducibility authority.
+## Local secretless checks
 
-Recommended commands:
+These run without provider credentials:
 
+- `./scripts/dev-quick-check.sh`
 - `./scripts/validate-repo.sh`
-- `./scripts/run-scenario-tests.sh --secretless-only`
-- `./scripts/verify-invariants.sh`
 - `./scripts/container-smoke.sh`
+- `./scripts/verify-invariants.sh`
+- `./scripts/verify-release-bundle.sh`
+- `./scripts/verify-reproducible-build.sh`
 - `./scripts/pre-merge.sh`
 
-If you want the broader local validation stack to run against a disposable
-snapshot instead of the live worktree, use the reviewed pre-merge flags:
+They cover repo shape, runtime contracts, smoke behavior, and reproducibility.
 
-- `./scripts/pre-merge.sh --local-snapshot worktree --local-include-untracked`
-- `./scripts/pre-merge.sh --local-snapshot head`
+## Manual authenticated smoke
 
-The snapshot mode is intentionally scoped to `pre-merge.sh` today. Provider
-authenticated smoke remains an explicit live-worktree lane.
+`./scripts/provider-e2e.sh` is the reviewed path for provider-authenticated
+checks. It is deliberately separate from default CI so the default path stays
+secretless.
 
-Scenario metadata lives in `tests/scenarios/manifest.json`. Each entry can
-declare a `lane`, `platform`, and `manual` flag so the local runner can skip
-non-secretless, platform-specific, or operator-only scenarios with an explicit
-reason instead of pretending they belong in the default lane.
+Use it when you need to verify:
 
-## Local Provider Authenticated Smoke
+- real provider login reuse
+- provider-specific auth selection
+- injected MCP or project-registry behavior
+- provider UX that only shows up with a live account
 
-Use this lane when you need to validate that Workcell stages real provider
-credentials and completes a small authenticated provider probe inside the
-Workcell boundary.
-The credential source must be explicit and operator-owned.
+## Remote heavy validation
 
-Place provider credentials in the dedicated injection path, not in repo files,
-shell history, host homes, or ambient environment variables. This lane proves
-credential detection, control-plane seeding, strict launch, and a minimal
-provider-authenticated round trip. It is still an owner-triggered smoke lane,
-not a high-volume integration test.
+`./scripts/dev-remote-validate.sh` stages the selected snapshot to a trusted
+remote `linux/amd64` host and runs validation there. This is useful when local
+heavy checks are too slow, but it is still a lower-assurance trusted-builder
+path because the helper container talks to the remote host's Docker daemon.
 
-The reviewed entry point is:
+## GitHub CI vs local boundary proof
 
-- `./scripts/provider-e2e.sh --agent codex --workspace "$PWD"`
-- `./scripts/provider-e2e.sh --agent claude --workspace "$PWD"`
-- `./scripts/provider-e2e.sh --agent gemini --workspace "$PWD"`
+GitHub-hosted CI proves:
 
-That helper first runs `workcell --auth-status`, then `--prepare-only`, then a
-provider-specific non-interactive prompt that must emit the exact token
-`WORKCELL_PROVIDER_E2E_OK`.
+- repo validation and workflow hygiene
+- smoke behavior in the reviewed runtime image
+- reproducibility and release-preflight logic
+- signing and attestation logic on tagged releases
 
-## GitHub CI Versus Manual Provider Authenticated Smoke
+GitHub-hosted CI does not prove the full macOS Colima boundary. That remains a
+local or self-hosted exercise.
 
-GitHub default CI should stay secretless and deterministic. It is the lane for
-repo validation, workflow lint, pinned-input checks, and other checks that do
-not require provider credentials.
+## Credential placement rule
 
-The manual provider-e2e workflow is a separate `workflow_dispatch` lane. It
-should stay narrow, require explicit operator selection of the provider, pull
-any needed credentials from a dedicated secret-backed environment on the
-self-hosted macOS path, stay limited to the default branch, and only execute
-for the repository owner. A non-secret guard job should fail fast before the
-self-hosted secret-bearing job starts when those preconditions are not met. It
-should not run on pull requests.
+Provider credentials belong in the injection policy or the reviewed manual
+provider-e2e path. They do not belong in the workspace, repo config, or
+ambient host passthrough.
 
-## Credential Placement
+## Out of scope
 
-Use the least-broad credential location that can support the test:
+These are not treated as equivalent to the default path:
 
-- Local runs: `~/.config/workcell/injection-policy.toml` or another
-  operator-owned secret source that feeds that policy
-- GitHub manual provider-e2e runs: environment-scoped secrets for
-  `provider-e2e.yml` only, with environment protection rules enabled
-- Default CI: no provider credentials
-
-Never place provider secrets in committed files, default CI variables, host
-home directories, git config, or socket passthrough paths.
-
-Recommended local credential files:
-
-- Codex: `credentials.codex_auth = "~/.codex/auth.json"`
-- Claude: `credentials.claude_auth = "~/.claude.json"` or
-  `credentials.claude_api_key = "~/.config/workcell/claude-api-key.txt"`
-- Gemini: `credentials.gemini_env = "~/.config/workcell/gemini.env"` or
-  `credentials.gemini_oauth = "~/.config/workcell/gemini-oauth.json"`
-- Gemini Vertex supplement: `credentials.gcloud_adc =
-  "~/.config/gcloud/application_default_credentials.json"`
-- Shared GitHub CLI auth when needed:
-  `credentials.github_hosts` / `credentials.github_config`
-
-For Claude, Workcell currently seeds the reviewed `claude_auth` artifact into
-the session-local `~/.claude/.claude.json` path and mirrors it into the older
-Claude auth locations for compatibility.
-
-Recommended GitHub environment secret names:
-
-- `WORKCELL_E2E_CODEX_AUTH_JSON`
-- `WORKCELL_E2E_CLAUDE_AUTH_JSON`
-- `WORKCELL_E2E_CLAUDE_API_KEY`
-- `WORKCELL_E2E_CLAUDE_MCP_JSON`
-- `WORKCELL_E2E_GEMINI_ENV`
-- `WORKCELL_E2E_GEMINI_OAUTH_JSON`
-- `WORKCELL_E2E_GEMINI_PROJECTS_JSON`
-- `WORKCELL_E2E_GCLOUD_ADC_JSON`
-
-The `provider-e2e.sh` helper intentionally limits its generated env-backed
-policy to the selected provider's credentials. If a future scenario needs
-shared GitHub CLI auth, pass an explicit injection policy instead of expanding
-the `WORKCELL_E2E_*` environment surface for this smoke lane.
-
-## Out Of Scope And Breakglass
-
-These scenarios are intentionally out of scope for the normal validation plan:
-
-- host-native GUI or browser-only provider validation
-- unrestricted network or provider overrides that would require
-  `breakglass`
-- broad arbitrary-command debugging paths
-- any workflow that assumes host credential passthrough or ambient auth state
-- PR-triggered self-hosted runs that could expose provider-backed secrets to
-  untrusted code
-
-If a check needs any of those conditions, label it as `breakglass` explicitly
-and require the separate acknowledged path described elsewhere in the docs.
+- host-native GUI execution
+- arbitrary container commands through the managed runtime image
+- `breakglass`
+- whole-home or socket passthrough

--- a/policy/README.md
+++ b/policy/README.md
@@ -1,16 +1,13 @@
 # Policy Core
 
-`policy/` is the generic contract layer for `Workcell`.
+`policy/` holds the shared contract layer for Workcell.
 
-It does not try to define one universal provider config format. Instead it
-captures the shared rules that every adapter must preserve:
+It exists to define what every adapter and workflow must preserve:
 
 - the runtime boundary is primary
-- host secrets and control sockets stay out
+- host secrets and control sockets stay out by default
 - network modes are explicit
-- `breakglass` is named and narrow
-- lower-assurance GUI modes are clearly labeled
-- repository-hosted controls that live outside git still need explicit,
-  auditable policy declarations
+- `breakglass` is narrow and visibly lower assurance
+- hosted controls outside git still require explicit policy
 
-Provider-native config belongs under `adapters/`.
+Provider-native config does not live here. That belongs in `adapters/`.

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -34,3 +34,10 @@ contexts = [
   "GitHub Actions lint",
   "GitHub Actions security analysis",
 ]
+
+[repository_variables]
+# The canonical Workcell repository publishes both Sigstore materials and
+# GitHub-native attestations on tagged releases. Forks can loosen this policy,
+# but the upstream repo treats the variable as part of the reviewed control
+# plane so publication posture cannot silently drift.
+WORKCELL_ENABLE_GITHUB_ATTESTATIONS = "true"

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,49 +1,40 @@
 # Runtime Boundary
 
-Tier 1 uses two layers:
+Tier 1 is a two-layer boundary:
 
 1. a dedicated Colima VM profile on macOS
-2. a hardened Docker container inside that VM
+2. a hardened inner container inside that VM
 
-The VM is the strongest practical local boundary available on this host. The
-container keeps the environment reproducible and usable across multiple agent
-providers.
+The VM is the main local isolation boundary. The container provides a reviewed,
+reproducible runtime for the supported providers.
 
-## Design goals
+## Goals
 
 - keep the safe path one command away
-- keep the selected agent inside the boundary, not on the host
-- keep the VM mount set to the selected workspace only
+- run the provider inside the boundary, not on the host
+- mount only the selected workspace
 - keep the container unprivileged
-- keep common git hook-bypass flags and inline hook-path overrides blocked on
-  the safe path
-- push network enforcement to the VM layer
+- enforce network posture at the VM layer
+- block common control-plane escape hatches on the managed path
 
-## Profiles
+## Runtime profiles
 
-- `strict`: allowlisted runtime access only, requires a prebuilt prepared
-  runtime image, and refuses launch if Docker seccomp support is not active
-- `build`: broader registry allowlist for dependency installation, prepared
-  image creation, and rebuilds
-- `breakglass`: unrestricted network plus the provider's highest-trust mode
-  where one exists; Codex maps this to `danger-full-access`
+- `strict`: default developer lane
+- `build`: explicit build and image-preparation lane
+- `breakglass`: explicit higher-trust lane
 
-## GUI status
-
-CLI is the only implemented Tier 1 path today. GUI support is not claimed until
-the GUI is wired as a client to the same bounded runtime.
+`strict` expects a prepared runtime image. Image creation and rebuild belong to
+`build`.
 
 ## Main entrypoints
 
-- `scripts/workcell`: start the VM, build the runtime image, apply the selected
-  network mode, and launch the selected agent inside the container; `strict`
-  refuses image rebuilds, requires the image to have been seeded through
-  `build`, and supports metadata-only audit by default plus explicit
-  lower-assurance debug or transcript capture when the operator opts in
-- `scripts/colima-egress-allowlist.sh`: apply or clear VM-level egress rules
-- `scripts/verify-invariants.sh`: run basic regression checks against the
-  current runtime assumptions
-- `scripts/container-smoke.sh`: exercise generic container-local runtime and
-  provider-wrapper behavior under Docker
-- `scripts/validate-repo.sh`: run the local repository validation suite,
-  including shell, Python, Rust, manifest, mutation, and invariant checks
+- `scripts/workcell`: host launcher and operator entrypoint
+- `scripts/colima-egress-allowlist.sh`: VM-level network posture helper
+- `scripts/container-smoke.sh`: direct container smoke coverage
+- `scripts/verify-invariants.sh`: invariant checks
+- `scripts/validate-repo.sh`: repo-wide validation
+
+## GUI status
+
+CLI is the implemented Tier 1 path today. GUI or IDE surfaces are lower
+assurance unless they become clients of the same bounded runtime.

--- a/runtime/colima/README.md
+++ b/runtime/colima/README.md
@@ -1,34 +1,26 @@
 # Colima Design
 
-## Why Colima
-
-On this machine, Colima backed by Apple Virtualization.Framework is the
-strongest practical deployable boundary available today. There is no verified
-Kata-class runtime in the active stack, so the VM is the hard wall.
+Workcell uses a dedicated Colima VM profile because that is the strongest
+practical local boundary available in the current macOS stack.
 
 ## Boundary rules
 
-- use a dedicated Colima profile per bounded workspace
-- do not reuse the shared default developer profile when stronger isolation is
-  required
-- disable Colima's default home-directory mount by supplying an explicit mount
-  list
-- keep the task workspace as the only writable host mount
-- enforce network policy at the VM layer instead of granting container network
-  capabilities
+- use a dedicated profile per workspace by default
+- do not rely on Colima's shared `default` profile for Tier 1
+- mount only the selected workspace as writable host state
+- do not mount host homes, sockets, or broad source trees
+- enforce network posture at the VM layer
 
 ## Operational stance
 
-The wrapper derives a unique Colima profile name from the full target workspace
-path by default, starts the VM with `--mount <workspace>:w`, and validates the
-saved Lima config after startup. The secure path expects exactly one writable
-host mount: the selected workspace. Operators can override the name, but the
-secure path should not depend on the shared `default` profile.
+The host launcher derives a profile name from the workspace path unless the
+operator overrides it. The managed path validates the resulting Lima config and
+expects exactly one writable host mount: the selected workspace.
 
 ## What stays out
 
 - host home directories
 - host auth and agent sockets
-- keychain or browser-profile passthrough
+- keychain and browser-profile passthrough
 - host Docker control sockets
-- broad source-tree mounts unrelated to the task workspace
+- unrelated source trees

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -31,6 +31,7 @@ CODEOWNERS_PATH="${ROOT_DIR}/.github/CODEOWNERS"
 CODEX_REQUIREMENTS_PATH="${ROOT_DIR}/adapters/codex/requirements.toml"
 CODEX_MCP_CONFIG_PATH="${ROOT_DIR}/adapters/codex/mcp/config.toml"
 HOSTED_CONTROLS_POLICY_PATH="${ROOT_DIR}/policy/github-hosted-controls.toml"
+HOSTED_CONTROLS_SCRIPT_PATH="${ROOT_DIR}/scripts/verify-github-hosted-controls.sh"
 MAX_DEBIAN_SNAPSHOT_AGE_DAYS="${WORKCELL_MAX_DEBIAN_SNAPSHOT_AGE_DAYS:-45}"
 
 require_tool() {
@@ -42,7 +43,7 @@ require_tool() {
 
 require_tool python3
 
-python3 - "${DOCKERFILE_PATH}" "${VALIDATOR_DOCKERFILE_PATH}" "${REMOTE_VALIDATOR_DOCKERFILE_PATH}" "${PROVIDERS_PACKAGE_JSON_PATH}" "${PROVIDERS_PACKAGE_LOCK_PATH}" "${WORKFLOWS_DIR}" "${CI_WORKFLOW_PATH}" "${RELEASE_WORKFLOW_PATH}" "${CODEOWNERS_PATH}" "${CODEX_REQUIREMENTS_PATH}" "${CODEX_MCP_CONFIG_PATH}" "${HOSTED_CONTROLS_POLICY_PATH}" "${MAX_DEBIAN_SNAPSHOT_AGE_DAYS}" <<'PY'
+python3 - "${DOCKERFILE_PATH}" "${VALIDATOR_DOCKERFILE_PATH}" "${REMOTE_VALIDATOR_DOCKERFILE_PATH}" "${PROVIDERS_PACKAGE_JSON_PATH}" "${PROVIDERS_PACKAGE_LOCK_PATH}" "${WORKFLOWS_DIR}" "${CI_WORKFLOW_PATH}" "${RELEASE_WORKFLOW_PATH}" "${CODEOWNERS_PATH}" "${CODEX_REQUIREMENTS_PATH}" "${CODEX_MCP_CONFIG_PATH}" "${HOSTED_CONTROLS_POLICY_PATH}" "${HOSTED_CONTROLS_SCRIPT_PATH}" "${MAX_DEBIAN_SNAPSHOT_AGE_DAYS}" <<'PY'
 import datetime as dt
 import json
 import pathlib
@@ -62,7 +63,8 @@ codeowners = pathlib.Path(sys.argv[9]).read_text(encoding="utf-8")
 codex_requirements = tomllib.loads(pathlib.Path(sys.argv[10]).read_text(encoding="utf-8"))
 codex_mcp_config = tomllib.loads(pathlib.Path(sys.argv[11]).read_text(encoding="utf-8"))
 hosted_controls_policy = tomllib.loads(pathlib.Path(sys.argv[12]).read_text(encoding="utf-8"))
-max_snapshot_age_days = int(sys.argv[13])
+hosted_controls_script = pathlib.Path(sys.argv[13]).read_text(encoding="utf-8")
+max_snapshot_age_days = int(sys.argv[14])
 
 def require_arg(text: str, name: str, path: str) -> str:
     match = re.search(rf"^ARG {re.escape(name)}=(.+)$", text, re.MULTILINE)
@@ -548,6 +550,14 @@ if "vnd.docker.reference.type" not in release_workflow:
     raise SystemExit(
         ".github/workflows/release.yml must ignore attestation manifests when validating published multi-arch image platforms"
     )
+if "ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}" not in release_workflow:
+    raise SystemExit(
+        ".github/workflows/release.yml must derive GitHub attestation enablement from the reviewed repository variable"
+    )
+if "actions/attest@" not in release_workflow:
+    raise SystemExit(
+        ".github/workflows/release.yml must retain GitHub attestation publication steps"
+    )
 if "Verify release bundle matches preflight" not in release_workflow:
     raise SystemExit(
         ".github/workflows/release.yml must compare the published source bundle against the preflight manifest"
@@ -745,6 +755,27 @@ if release_mode not in {"review-gated", "single-owner-private"}:
         "policy/github-hosted-controls.toml must set release_environment.mode "
         "to 'review-gated' or 'single-owner-private'"
     )
+repository_variables = hosted_controls_policy.get("repository_variables")
+if not isinstance(repository_variables, dict) or not repository_variables:
+    raise SystemExit(
+        "policy/github-hosted-controls.toml must declare canonical repository variables"
+    )
+if repository_variables.get("WORKCELL_ENABLE_GITHUB_ATTESTATIONS") != "true":
+    raise SystemExit(
+        "policy/github-hosted-controls.toml must require WORKCELL_ENABLE_GITHUB_ATTESTATIONS = \"true\""
+    )
+require_contains(
+    hosted_controls_script,
+    'actions/variables?per_page=100',
+    "repository variable auditing in the hosted-controls audit",
+    "scripts/verify-github-hosted-controls.sh",
+)
+require_contains(
+    hosted_controls_script,
+    "WORKCELL_ENABLE_GITHUB_ATTESTATIONS",
+    "GitHub attestation repository variable enforcement in the hosted-controls audit",
+    "scripts/verify-github-hosted-controls.sh",
+)
 
 print("Workcell pinned input policy check passed.")
 PY

--- a/scripts/verify-github-hosted-controls.sh
+++ b/scripts/verify-github-hosted-controls.sh
@@ -27,6 +27,7 @@ trap cleanup EXIT
 
 gh api "repos/${REPO}" >"${TMP_DIR}/repo.json"
 gh api "repos/${REPO}/actions/permissions" >"${TMP_DIR}/actions-permissions.json"
+gh api "repos/${REPO}/actions/variables?per_page=100" >"${TMP_DIR}/actions-variables.json"
 gh api "repos/${REPO}/collaborators?affiliation=direct&per_page=100" >"${TMP_DIR}/collaborators-direct.json"
 gh api "repos/${REPO}/rulesets" >"${TMP_DIR}/rulesets-summary.json"
 python3 - "${TMP_DIR}" "${REPO}" <<'PY'
@@ -70,6 +71,7 @@ policy_path = pathlib.Path(sys.argv[3])
 
 repo_meta = json.loads((tmp_dir / "repo.json").read_text(encoding="utf-8"))
 actions_permissions = json.loads((tmp_dir / "actions-permissions.json").read_text(encoding="utf-8"))
+actions_variables = json.loads((tmp_dir / "actions-variables.json").read_text(encoding="utf-8"))
 direct_collaborators = json.loads((tmp_dir / "collaborators-direct.json").read_text(encoding="utf-8"))
 rulesets = json.loads((tmp_dir / "rulesets.json").read_text(encoding="utf-8"))
 release_env = json.loads((tmp_dir / "environment-release.json").read_text(encoding="utf-8"))
@@ -108,6 +110,25 @@ if not isinstance(expected_status_contexts, list) or not expected_status_context
 if not all(isinstance(context, str) and context for context in expected_status_contexts):
     raise SystemExit(
         f"{policy_path} must define required_status_checks.contexts as non-empty strings"
+    )
+expected_repo_variables = policy.get("repository_variables", {})
+if not isinstance(expected_repo_variables, dict):
+    raise SystemExit(
+        f"{policy_path} must define repository_variables as a table of exact expected values"
+    )
+required_attestation_variable = "WORKCELL_ENABLE_GITHUB_ATTESTATIONS"
+if not all(
+    isinstance(name, str)
+    and name
+    and isinstance(value, str)
+    for name, value in expected_repo_variables.items()
+):
+    raise SystemExit(
+        f"{policy_path} repository_variables entries must map non-empty names to exact string values"
+    )
+if required_attestation_variable not in expected_repo_variables:
+    raise SystemExit(
+        f"{policy_path} must declare {required_attestation_variable} in repository_variables"
     )
 
 if not actions_permissions.get("enabled"):
@@ -274,6 +295,32 @@ if missing_status_contexts:
     raise SystemExit(
         f"Default-branch status-check ruleset on {repo} is missing required contexts: "
         + ", ".join(missing_status_contexts)
+    )
+
+actual_repo_variables = {
+    entry.get("name"): entry.get("value")
+    for entry in actions_variables.get("variables", [])
+    if entry.get("name")
+}
+missing_repo_variables = sorted(
+    name for name in expected_repo_variables if name not in actual_repo_variables
+)
+if missing_repo_variables:
+    raise SystemExit(
+        f"Repository variables missing on {repo}: " + ", ".join(missing_repo_variables)
+    )
+wrong_repo_variables = sorted(
+    name
+    for name, expected_value in expected_repo_variables.items()
+    if actual_repo_variables.get(name) != expected_value
+)
+if wrong_repo_variables:
+    details = ", ".join(
+        f"{name}={actual_repo_variables.get(name)!r} (expected {expected_repo_variables[name]!r})"
+        for name in wrong_repo_variables
+    )
+    raise SystemExit(
+        f"Repository variables on {repo} do not match policy: {details}"
     )
 
 protection_rules = release_env.get("protection_rules", [])

--- a/verify/invariants/README.md
+++ b/verify/invariants/README.md
@@ -1,26 +1,28 @@
 # Invariant Test Plan
 
-The verification harness should answer one question: does the current runtime
-still satisfy the documented invariants?
+The invariant suite answers one question: does the current implementation still
+match the documented security and control-plane contract?
 
 ## Minimum checks
 
-1. `strict` starts the selected agent inside the container and not on the host.
-2. The container does not receive host auth or control-plane mounts.
-3. The Codex profile inside the container defaults to `strict`.
-4. The wrapper mounts only the selected workspace.
-5. The VM egress policy is applied for `strict` and `build`.
-6. `breakglass` is visibly different and must be explicitly selected.
-7. Policy files exist and are loadable by the local Codex binary.
-8. Broad workspaces such as `/` and `$HOME` are rejected by default.
+The suite should keep verifying that:
+
+1. the provider launches inside the container, not on the host
+2. the runtime receives only the reviewed host mounts
+3. host auth state and sockets stay out by default
+4. the selected workspace is the only writable host mount
+5. network posture is applied for the managed modes
+6. `breakglass` is explicit and visibly different
+7. provider control-plane files are present and loadable
+8. unsafe broad workspaces are rejected
 
 ## Negative checks
 
-The harness should fail if it detects:
+The suite should fail if it finds:
 
 - `docker.sock` passthrough
-- host `~/.codex` passthrough
+- host home passthrough
+- host provider-state passthrough
 - SSH or GPG agent socket passthrough
-- host home directory passthrough
-- missing egress policy when `strict` is requested
-- `breakglass` defaults
+- missing egress controls on the managed path
+- silent defaulting into `breakglass`

--- a/workflows/adapter-porting.md
+++ b/workflows/adapter-porting.md
@@ -1,95 +1,78 @@
 # Adapter Porting Workflow
 
-This workflow turns the provider matrix into an implementation sequence. It
-assumes the secure boundary is a dedicated Colima VM profile plus a hardened
-container inside it.
+Use this checklist when adding or refactoring a provider adapter.
 
-## Objectives
+## Goal
 
-Preserve the useful parts of each provider's workflow surface without carrying
-over provider-specific coupling into the shared boundary.
+Preserve the shared Workcell boundary while mapping into the provider's native
+control plane. Do not blur the boundary and the adapter into one layer.
 
-The output should optimize for:
+## Design order
+
+Optimize in this order:
+
 1. Developer experience
 2. Simplicity
 3. Security invariant preservation
 4. Performance
 5. Idiomatic correctness
 
-That optimization order only applies after the runtime boundary and invariants
-are fixed. Do not trade them away for ergonomics.
+That order only applies after the runtime boundary is fixed.
 
-## Operating Rules
+## Porting sequence
 
-1. Keep the policy layer and runtime boundary separate.
-2. Prefer one clear mechanism over multiple overlapping ones.
-3. Treat hooks and rules as guardrails, not as the boundary.
-4. Keep high-autonomy execution inside the strongest available runtime boundary only.
-5. Make every workflow reproducible from files in the repo.
+### 1. Lock the shared boundary first
 
-## Migration Sequence
+Before touching provider specifics, confirm that the shared runtime still
+guarantees:
 
-### 1. Lock the boundary
+- dedicated VM profile
+- hardened inner container
+- narrow mount set
+- explicit network posture
+- no host home, sockets, or ambient credential passthrough
 
-Start by implementing and documenting the Tier 1 runtime:
+### 2. Define the native control plane
 
-1. Dedicated Colima VM profile for the selected Workcell task.
-2. Hardened container inside that VM.
-3. Only the task workspace mounted.
-4. No host home, no agent socket, no Docker socket, no keychain passthrough.
-5. Network off by default.
+Document exactly which provider files Workcell owns, seeds, links, or masks.
+Keep the list small and auditable.
 
-Do not let the policy layer expand trust before this boundary exists.
+### 3. Keep the adapter thin
 
-### 2. Establish the generic core and adapter split
+Use the provider's native config surfaces where possible. Do not invent a fake
+universal provider config layer.
 
-Create the shared core first, then the provider adapters:
+### 4. Add the runtime seeding path
 
-1. shared invariants and threat model
-2. one provider adapter directory per product
-3. native config for each provider
-4. explicit MCP allowlists or deny-by-default posture
-5. provider-specific downgrade notes for GUI surfaces
+Update the home-control-plane logic so the provider-facing home is rebuilt from:
 
-### 3. Port workflows, not syntax
+- the immutable adapter baseline
+- imported workspace docs
+- explicit injection-policy input
 
-Rewrite useful provider workflows as generic bounded workflows:
+### 5. Add deny-list and downgrade logic
 
-1. review workflows become provider-specific review commands plus peer-review gates
-2. fix workflows become bounded execution plus plan/implement/test/review steps
-3. bootstrap/install becomes pinned adapter installation
-4. hook-based logging becomes wrapper-script logging or Git-based auditing
+Block provider-native flags or workflows that would silently widen trust, and
+document any lower-assurance paths explicitly.
 
-### 4. Add subagent reviews
+### 6. Add validation with the adapter
 
-Use subagents as the peer-review ring before merging any parity change:
+No adapter change is complete without matching invariant or smoke coverage.
 
-1. Architecture and portability review.
-2. Security boundary review.
-3. macOS and container boundary review.
-4. Provider-native config consistency review.
+### 7. Update the docs in the same change
 
-No change should land until the subagent consensus is clear or the disagreement is documented.
+At minimum, update:
 
-### 5. Verify the invariants
+- `docs/provider-matrix.md`
+- `docs/adapter-control-planes.md`
+- provider-specific quickstart or adapter README material if behavior changed
 
-Every implementation slice should be checked against the same tests:
+## Review questions
 
-1. Host secret reads are blocked.
-2. Writes outside the workspace are blocked.
-3. Unapproved MCP access is blocked.
-4. Network egress is controlled.
-5. Destructive shell patterns are blocked or escalated.
-6. Workflow wrappers still work end-to-end.
+Before merging an adapter change, ask:
 
-## Review Gate
-
-Before merging any doc or runtime change, ask:
-
-1. Did this improve developer experience or just add indirection?
-2. Is there a simpler way to express the same invariant?
-3. Does the control survive prompt injection and agent drift?
-4. Does the control live in the runtime boundary, not only in text?
-5. Is the performance cost justified by the security gain?
-
-If the answer to any of those is no, simplify before proceeding.
+1. Did this improve the workflow, or just add indirection?
+2. Is the provider config being mistaken for the primary boundary?
+3. Can repo content retake the control plane after this change?
+4. Are any lower-assurance paths clearly labeled?
+5. Is the new behavior covered by validation?


### PR DESCRIPTION
## Summary
- rewrite the public docs around the current runtime, validation, and release behavior
- normalize the quickstarts and reference pages so the docs read as one system
- enforce `WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true` as reviewed hosted-control state for the upstream repo
- keep GitHub attestations additive to the always-on Sigstore/Cosign path

## What changed
- rewrote the top-level docs set across the README, reference docs, quickstarts, contributor docs, and runtime/policy notes for clarity and current behavior
- updated provenance and workflow docs to say exactly how dual-signing works: Sigstore is always on, GitHub attestations are additive, and the upstream repo enables both while forks may keep the gate off
- added the canonical repo variable to `policy/github-hosted-controls.toml`
- tightened `scripts/verify-github-hosted-controls.sh` so the hosted-controls audit verifies reviewed repository variables
- tightened `scripts/check-pinned-inputs.sh` so future workflow refactors cannot silently remove GitHub attestation support or the reviewed variable gate

## Reviews incorporated
- technical writing review: tighten structure, reduce repeated boundary language, keep quickstarts procedural
- editorial review: lead with operational guidance, move theory to reference pages, simplify dense phrasing
- Distinguished Engineer review: keep Sigstore as the portable baseline, enforce the GitHub attestation variable as hosted control-plane state, preserve attestation-manifest filtering in release publication
- Tech Fellow review: define terms consistently, separate upstream posture from fork posture, keep host-side publication explicit

## Validation
- `./scripts/check-pinned-inputs.sh`
- `./scripts/dev-quick-check.sh`
- `git diff --check`
- `./scripts/run-hosted-controls-audit.sh omkhar/workcell`
- `./scripts/validate-repo.sh`
