### PR TITLE
Add host-side auth management and Claude resolver staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ What to expect from the safe path:
 The supported way to feed stable inputs into sessions is an explicit injection
 policy, usually at `~/.config/workcell/injection-policy.toml`.
 
+For host-side setup, Workcell also ships `workcell auth init|set|unset|status`
+to manage explicit policy-backed credentials without widening the runtime
+boundary.
+
 Workcell can stage:
 
 - common or provider-specific instruction fragments
@@ -133,7 +137,7 @@ See [docs/injection-policy.md](docs/injection-policy.md) and
 | Provider | Tier 1 surface today | Native control plane | Quickstart |
 |---|---|---|---|
 | Codex | CLI | `~/.codex/config.toml`, `AGENTS.md`, rules, MCP config | [docs/examples/quickstart-codex.md](docs/examples/quickstart-codex.md) |
-| Claude | Claude Code CLI | `~/.claude/settings.json`, `CLAUDE.md`, `.mcp.json`, auth mirrors, hooks | [docs/examples/quickstart-claude.md](docs/examples/quickstart-claude.md) |
+| Claude | Claude Code CLI | `~/.claude/settings.json`, `CLAUDE.md`, `.mcp.json`, auth mirrors, hooks, host-side macOS auth resolver scaffold | [docs/examples/quickstart-claude.md](docs/examples/quickstart-claude.md) |
 | Gemini | Gemini CLI | `~/.gemini/settings.json`, `GEMINI.md`, `.env`, `projects.json` | [docs/examples/quickstart-gemini.md](docs/examples/quickstart-gemini.md) |
 
 GUI and IDE surfaces are lower assurance unless they act only as clients to

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ policy, usually at `~/.config/workcell/injection-policy.toml`.
 
 For host-side setup, Workcell also ships `workcell auth init|set|unset|status`
 to manage explicit policy-backed credentials without widening the runtime
-boundary.
+boundary. Those host-side auth commands only rewrite the entrypoint policy
+file, so credentials declared through `includes = [...]` must still be updated
+in the owning fragment.
 
 Workcell can stage:
 

--- a/docs/examples/enterprise-claude-setup.md
+++ b/docs/examples/enterprise-claude-setup.md
@@ -8,9 +8,9 @@ whole host homes into the runtime.
 Keep these concerns separate:
 
 - org-wide instructions in `documents.common` or `documents.claude`
-- reviewed persisted Claude auth in `credentials.claude_auth`
+- reviewed Claude API-key access in `credentials.claude_api_key`
 - reviewed MCP state in `credentials.claude_mcp`
-- optional API-key fallback in `credentials.claude_api_key`
+- optional fail-closed macOS resolver scaffold in `credentials.claude_auth`
 
 ## Example policy
 
@@ -21,9 +21,11 @@ version = 1
 common = "/Users/example/.config/workcell/org-agent.md"
 claude = "/Users/example/.config/workcell/claude-overlay.md"
 
-[credentials]
-claude_auth = "/Users/example/.claude.json"
-claude_mcp = "/Users/example/.config/workcell/claude-mcp.json"
+[credentials.claude_api_key]
+source = "/Users/example/.config/workcell/claude-api-key.txt"
+
+[credentials.claude_mcp]
+source = "/Users/example/.config/workcell/claude-mcp.json"
 
 [credentials.github_hosts]
 source = "/Users/example/.config/gh/hosts.yml"
@@ -36,6 +38,8 @@ providers = ["claude"]
 - workspace `CLAUDE.md` is imported as a layer instead of becoming the live
   control plane
 - the session gets only the reviewed credentials it needs
+- the macOS Claude resolver can still be recorded separately, but it is
+  currently fail-closed until a supported export path exists
 - final publication still stays on the host with `workcell publish-pr`
 
 ## Launch

--- a/docs/examples/injection-policy.toml
+++ b/docs/examples/injection-policy.toml
@@ -9,12 +9,17 @@ gemini = "/Users/example/.config/workcell/gemini-extra.md"
 
 [credentials]
 codex_auth = "/Users/example/.codex/auth.json"
-claude_auth = "/Users/example/.claude.json"
 claude_api_key = "/Users/example/.config/workcell/claude-api-key.txt"
 claude_mcp = "/Users/example/.config/workcell/claude-mcp.json"
 gemini_env = "/Users/example/.config/workcell/gemini.env"
 gemini_projects = "/Users/example/.config/workcell/gemini-projects.json"
 gcloud_adc = "/Users/example/.config/gcloud/application_default_credentials.json"
+
+[credentials.claude_auth]
+# Records the intended macOS Claude auth source. Current Workcell releases
+# still fail closed unless a supported export path exists.
+resolver = "claude-macos-keychain"
+materialization = "ephemeral"
 
 [credentials.github_hosts]
 source = "/Users/example/.config/gh/hosts.yml"

--- a/docs/examples/quickstart-claude.md
+++ b/docs/examples/quickstart-claude.md
@@ -4,29 +4,39 @@
 
 - Workcell installed with `./scripts/install.sh`
 - a repo you want to mount as the workspace
-- either reviewed Claude login state or a reviewed API key file
+- a reviewed Claude API key file, or an experimental macOS resolver config
 
-## 1. Create an injection policy
+## 1. Create or update the injection policy
 
-Persisted Claude login:
+Supported flow today: API key helper path
 
-```toml
-version = 1
-
-[credentials]
-claude_auth = "/Users/example/.claude.json"
+```bash
+workcell auth init
+workcell auth set \
+  --agent claude \
+  --credential claude_api_key \
+  --source /Users/example/.config/workcell/claude-api-key.txt
 ```
 
-API key helper path:
+Optional fail-closed macOS resolver scaffold:
 
-```toml
-version = 1
-
-[credentials]
-claude_api_key = "/Users/example/.config/workcell/claude-api-key.txt"
+```bash
+workcell auth set \
+  --agent claude \
+  --credential claude_auth \
+  --resolver claude-macos-keychain \
+  --ack-host-resolver
 ```
+
+That resolver records the intended host-side auth source in policy, but the
+current Workcell implementation still aborts `--prepare-only` and launch flows
+unless a supported export path exists. Use it only to record intent for a
+future supported export and verify the configured-only state with
+`workcell auth status --agent claude`.
 
 ## 2. Prepare the runtime image
+
+If you configured `claude_api_key`, prepare the runtime image:
 
 ```bash
 workcell --prepare-only --agent claude --workspace /path/to/repo
@@ -36,8 +46,16 @@ workcell --prepare-only --agent claude --workspace /path/to/repo
 
 ```bash
 workcell --agent claude --inspect --workspace /path/to/repo
+workcell auth status --agent claude
 workcell --agent claude --auth-status --workspace /path/to/repo
 ```
+
+`workcell auth status` reports the host policy view. `--auth-status` reports the
+staged launch view after selector evaluation and resolver preprocessing.
+
+If you configured only `claude_auth` via the experimental macOS resolver, expect
+`credential_resolution_states=claude_auth:configured-only` and
+`provider_auth_mode=none` until a supported export path exists.
 
 ## 4. Launch Claude
 
@@ -57,8 +75,8 @@ If you want Claude to use a reviewed MCP registry instead of the empty safe
 baseline:
 
 ```toml
-[credentials]
-claude_mcp = "/Users/example/.config/workcell/claude-mcp.json"
+[credentials.claude_mcp]
+source = "/Users/example/.config/workcell/claude-mcp.json"
 ```
 
 ## 6. Publish the result on the host

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -30,6 +30,10 @@ Secret-bearing inputs are handled more carefully than public inputs:
 | `[[copies]]` | explicit copied files or directories for non-reserved targets |
 | `includes = [...]` | compose a policy from smaller operator-owned fragments |
 
+`workcell auth init|set|unset|status` manages the entrypoint policy file only.
+If a credential is declared by an included fragment, update that fragment
+directly.
+
 Selectors let you scope entries to only some launches:
 
 - `providers = ["codex", "claude", "gemini"]`

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -35,12 +35,26 @@ Selectors let you scope entries to only some launches:
 - `providers = ["codex", "claude", "gemini"]`
 - `modes = ["strict", "build"]`
 
+Credential entries can be either direct file sources or built-in host
+resolvers:
+
+- `credentials.codex_auth = "/abs/path"`
+- `[credentials.claude_auth] resolver = "claude-macos-keychain"`
+
+Resolver-backed credentials are still host-side preprocessing only. Workcell
+materializes them into ordinary files under the per-launch injection bundle; it
+does not pass Keychain access into the runtime.
+
+Today, `claude-macos-keychain` is a fail-closed resolver scaffold: it lets you
+record the intended host-side auth source in policy, but Workcell still aborts
+launch unless a supported export path exists.
+
 ## Credential keys
 
 | Key | Session target | Notes |
 |---|---|---|
 | `codex_auth` | `~/.codex/auth.json` | persisted Codex auth |
-| `claude_auth` | Claude auth mirrors under `~/.claude/`, `~/.claude.json`, and `~/.config/claude-code/` | compatibility-friendly Claude login reuse |
+| `claude_auth` | Claude auth mirrors under `~/.claude/`, `~/.claude.json`, and `~/.config/claude-code/` | on macOS, prefer the built-in `claude-macos-keychain` host resolver |
 | `claude_api_key` | helper-backed Claude API key access | avoids seeding a second plaintext key copy into the session |
 | `claude_mcp` | `~/.mcp.json` | reviewed Claude MCP config |
 | `gemini_env` | `~/.gemini/.env` | API key, GCA, or Vertex configuration |

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -7,6 +7,9 @@ workcell \- bounded runtime launcher for coding agents
 .br
 .B workcell publish-pr
 [\fIoptions\fR]
+.br
+.B workcell auth
+\fIinit|set|unset|status\fR [\fIoptions\fR]
 .SH DESCRIPTION
 .B workcell
 starts the selected coding agent inside a bounded local runtime with explicit
@@ -129,6 +132,11 @@ Use an explicit host-side injection policy for this launch. Workcell mounts
 credential sources read-only from their original host paths and stages the
 selected docs, copied files, and SSH material into per-session runtime state
 instead of passing through host homes or sockets directly.
+.TP
+.B workcell auth init|set|unset|status
+Manage explicit host-side credential policy state without starting the Workcell
+runtime. Resolver-backed credentials are still host-only preprocessing and do
+not pass Keychain or provider-home access into Tier 1.
 .TP
 .B --log-level normal|debug
 Select launch-time logging verbosity. The default is

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -169,14 +169,10 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
     arm64) \
       CLAUDE_PLATFORM="linux-arm64"; \
       CLAUDE_SHA256="c04aebe3de140679b4cce158812d6f011b7e9c483496ccb0472cf38cc1714afe"; \
-      CODEX_ARCH="aarch64-unknown-linux-gnu"; \
-      CODEX_SHA256="120b8bd6ececc125198de3fbce896da98a4795b449a4c78d516534e08a63ab14"; \
       ;; \
     amd64) \
       CLAUDE_PLATFORM="linux-x64"; \
       CLAUDE_SHA256="adce02c5f94a85b6ca231c8aeef533707597cd387e8934776455b87d10a3051b"; \
-      CODEX_ARCH="x86_64-unknown-linux-gnu"; \
-      CODEX_SHA256="1d65d8aa80847ac771487d74cb2a63c86ef23479636aa1c1b3d051c9931d314b"; \
       ;; \
     *) \
       echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; \
@@ -192,7 +188,33 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
   && echo "${CLAUDE_SHA256}  /tmp/claude" | sha256sum -c - \
   && install -m 0755 /tmp/claude /usr/local/libexec/workcell/real/claude \
   && touch -d "@${SOURCE_DATE_EPOCH}" /usr/local/libexec/workcell/real/claude \
-  && rm -f /tmp/claude \
+  && rm -f /tmp/claude
+
+RUN TARGET_ARCH="${TARGETARCH:-}" \
+  && if [[ -z "${TARGET_ARCH}" ]]; then \
+       case "$(dpkg --print-architecture)" in \
+         arm64) TARGET_ARCH="arm64" ;; \
+         amd64) TARGET_ARCH="amd64" ;; \
+         *) \
+           echo "Unsupported dpkg architecture: $(dpkg --print-architecture)" >&2; \
+           exit 1; \
+           ;; \
+       esac; \
+     fi \
+  && case "${TARGET_ARCH}" in \
+    arm64) \
+      CODEX_ARCH="aarch64-unknown-linux-gnu"; \
+      CODEX_SHA256="120b8bd6ececc125198de3fbce896da98a4795b449a4c78d516534e08a63ab14"; \
+      ;; \
+    amd64) \
+      CODEX_ARCH="x86_64-unknown-linux-gnu"; \
+      CODEX_SHA256="1d65d8aa80847ac771487d74cb2a63c86ef23479636aa1c1b3d051c9931d314b"; \
+      ;; \
+    *) \
+      echo "Unsupported TARGETARCH: ${TARGET_ARCH}" >&2; \
+      exit 1; \
+      ;; \
+  esac \
   && if [[ -n "${CODEX_RELEASE_URL}" ]]; then \
        curl -fsSL "${CODEX_RELEASE_URL}" \
          --retry 5 \

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -129,6 +129,7 @@ ARG CLAUDE_VERSION=2.1.86
 # update CODEX_VERSION, download both architecture tarballs, compute sha256sum,
 # and update the CODEX_SHA256 values for arm64 and amd64 below.
 ARG CODEX_VERSION=0.117.0-alpha.8
+ARG CODEX_RELEASE_URL=
 ARG TARGETARCH
 ARG BUILDKIT_MULTI_PLATFORM=1
 ARG SOURCE_DATE_EPOCH
@@ -192,12 +193,21 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
   && install -m 0755 /tmp/claude /usr/local/libexec/workcell/real/claude \
   && touch -d "@${SOURCE_DATE_EPOCH}" /usr/local/libexec/workcell/real/claude \
   && rm -f /tmp/claude \
-  && curl -fsSL "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-${CODEX_ARCH}.tar.gz" \
-    --retry 5 \
-    --retry-all-errors \
-    --retry-delay 5 \
-    --connect-timeout 20 \
-    -o /tmp/codex.tar.gz \
+  && if [[ -n "${CODEX_RELEASE_URL}" ]]; then \
+       curl -fsSL "${CODEX_RELEASE_URL}" \
+         --retry 5 \
+         --retry-all-errors \
+         --retry-delay 5 \
+         --connect-timeout 20 \
+         -o /tmp/codex.tar.gz; \
+     else \
+       curl -fsSL "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-${CODEX_ARCH}.tar.gz" \
+         --retry 5 \
+         --retry-all-errors \
+         --retry-delay 5 \
+         --connect-timeout 20 \
+         -o /tmp/codex.tar.gz; \
+     fi \
   && echo "${CODEX_SHA256}  /tmp/codex.tar.gz" | sha256sum -c - \
   && tar -xzf /tmp/codex.tar.gz -C /tmp \
   && mv "/tmp/codex-${CODEX_ARCH}" /usr/local/libexec/workcell/real/codex \

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "4873ff0c817a1eea21003d333a6ae96d9ec6fdb8475fdb7ba50d42a72aa509e0"
+      "sha256": "07bd2243c366b9fde4960d0908c5667470da8bafdaddff658ec491399cd0f224"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts.py",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "e580cc17df1f4a414249c2cc1b4c60261812557acfc0d270fa1c2f1ab2be156f"
+      "sha256": "4873ff0c817a1eea21003d333a6ae96d9ec6fdb8475fdb7ba50d42a72aa509e0"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts.py",
@@ -10,7 +10,7 @@
     },
     {
       "repo_path": "scripts/lib/render_injection_bundle.py",
-      "sha256": "ee0fd7d117ec558b1f53433a2f9fae2dfdd50561ff613a5827c1821d4f0d701f"
+      "sha256": "2722a0680c5db9b56fe65f63a590b286c391086d559028585ef03a749572e882"
     },
     {
       "repo_path": "scripts/lib/trusted-docker-client.sh",

--- a/scripts/lib/manage_injection_policy.py
+++ b/scripts/lib/manage_injection_policy.py
@@ -1,0 +1,652 @@
+#!/usr/bin/env python3
+"""Manage Workcell injection policy files for host-side auth commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from policy_bundle import (  # noqa: E402
+    AGENT_SCOPED_CREDENTIAL_KEYS,
+    CREDENTIAL_KEYS,
+    SHARED_CREDENTIAL_KEYS,
+    SUPPORTED_AGENTS,
+    SUPPORTED_MODES,
+    composite_policy_sha256,
+    die,
+    load_policy_bundle,
+    load_raw_policy,
+    require_no_symlink_in_path_chain,
+    require_path_within,
+    require_secret_file,
+    selected_for,
+    validate_allowed_keys,
+    validate_source_path,
+    write_policy_file,
+)
+
+
+CANONICAL_CREDENTIAL_DESTINATIONS = {
+    "codex_auth": ("codex", "auth.json"),
+    "claude_api_key": ("claude", "api-key.txt"),
+    "claude_mcp": ("claude", "mcp.json"),
+    "gemini_env": ("gemini", "gemini.env"),
+    "gemini_oauth": ("gemini", "oauth_creds.json"),
+    "gemini_projects": ("gemini", "projects.json"),
+    "gcloud_adc": ("gemini", "gcloud-adc.json"),
+    "github_hosts": ("shared", "github-hosts.yml"),
+    "github_config": ("shared", "github-config.yml"),
+}
+ALLOWED_RESOLVERS = {
+    "claude_auth": {"claude-macos-keychain"},
+}
+STATUS_ORDER = {
+    "codex": ["codex_auth"],
+    "claude": ["claude_api_key", "claude_auth"],
+    "gemini": ["gemini_env", "gemini_oauth"],
+}
+ENTRY_ALLOWED_KEYS = {"source", "resolver", "materialization", "providers", "modes"}
+MANAGED_ROOT_MARKER = ".workcell-managed-root"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init")
+    init_parser.add_argument("--policy", required=True)
+    init_parser.add_argument("--managed-root", required=True)
+
+    set_parser = subparsers.add_parser("set")
+    set_parser.add_argument("--policy", required=True)
+    set_parser.add_argument("--managed-root", required=True)
+    set_parser.add_argument("--agent", required=True, choices=sorted(SUPPORTED_AGENTS))
+    set_parser.add_argument("--credential", required=True, choices=sorted(CREDENTIAL_KEYS))
+    set_parser.add_argument("--source")
+    set_parser.add_argument("--source-base")
+    set_parser.add_argument("--resolver")
+    set_parser.add_argument("--ack-host-resolver", action="store_true")
+
+    unset_parser = subparsers.add_parser("unset")
+    unset_parser.add_argument("--policy", required=True)
+    unset_parser.add_argument("--managed-root", required=True)
+    unset_parser.add_argument("--credential", required=True, choices=sorted(CREDENTIAL_KEYS))
+
+    status_parser = subparsers.add_parser("status")
+    status_parser.add_argument("--policy", required=True)
+    status_parser.add_argument("--agent", choices=sorted(SUPPORTED_AGENTS))
+    status_parser.add_argument("--mode", default="strict", choices=sorted(SUPPORTED_MODES))
+    return parser.parse_args()
+
+
+def ensure_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    path.chmod(0o700)
+
+
+def validate_managed_path(managed_root: Path, path: Path, label: str) -> None:
+    require_no_symlink_in_path_chain(path, label)
+    require_path_within(managed_root, path, label)
+
+
+def write_managed_root_marker(managed_root: Path) -> None:
+    ensure_directory(managed_root)
+    marker_path = managed_root / MANAGED_ROOT_MARKER
+    with tempfile.NamedTemporaryFile(
+        dir=managed_root,
+        prefix=f"{MANAGED_ROOT_MARKER}.",
+        suffix=".tmp",
+        delete=False,
+        mode="w",
+        encoding="utf-8",
+    ) as handle:
+        temp_path = Path(handle.name)
+        handle.write("managed_by=workcell\n")
+    try:
+        temp_path.chmod(0o600)
+        temp_path.replace(marker_path)
+        marker_path.chmod(0o600)
+    finally:
+        cleanup_staged_file(temp_path)
+
+
+def is_workcell_managed_root(path: Path) -> bool:
+    return (path / MANAGED_ROOT_MARKER).is_file()
+
+
+def stage_file_copy(source: Path, destination: Path) -> Path:
+    ensure_directory(destination.parent)
+    with tempfile.NamedTemporaryFile(dir=destination.parent, delete=False) as handle:
+        temp_path = Path(handle.name)
+    try:
+        shutil.copyfile(source, temp_path)
+        temp_path.chmod(0o600)
+    except Exception:
+        cleanup_staged_file(temp_path)
+        raise
+    return temp_path
+
+
+def install_staged_file(staged_path: Path, destination: Path) -> None:
+    staged_path.replace(destination)
+    destination.chmod(0o600)
+
+
+def cleanup_staged_file(path: Path | None) -> None:
+    if path is None:
+        return
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def stage_existing_file(path: Path | None) -> Path | None:
+    if path is None or not path.exists():
+        return None
+    with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as handle:
+        backup_path = Path(handle.name)
+    cleanup_staged_file(backup_path)
+    path.replace(backup_path)
+    return backup_path
+
+
+def restore_staged_file(staged_path: Path | None, destination: Path | None) -> None:
+    if staged_path is None or destination is None:
+        return
+    staged_path.replace(destination)
+    destination.chmod(0o600)
+
+
+def canonical_destination_path(managed_root: Path, credential: str) -> Path:
+    if credential not in CANONICAL_CREDENTIAL_DESTINATIONS:
+        die(f"workcell auth set does not manage {credential} automatically")
+    provider_dir, filename = CANONICAL_CREDENTIAL_DESTINATIONS[credential]
+    return managed_root / provider_dir / filename
+
+
+def load_mutable_policy(policy_path: Path) -> dict[str, object]:
+    policy = load_raw_policy(policy_path)
+    if "version" not in policy:
+        policy["version"] = 1
+    return policy
+
+
+def ensure_credential_not_only_in_includes(
+    policy_path: Path,
+    credentials: dict[str, object],
+    credential: str,
+    command: str,
+) -> None:
+    if credential in credentials or not policy_path.exists():
+        return
+    merged_policy, _ = load_policy_bundle(policy_path)
+    merged_credentials = merged_policy.get("credentials", {})
+    if isinstance(merged_credentials, dict) and credential in merged_credentials:
+        die(
+            f"credentials.{credential} is declared by an included policy fragment; "
+            f"update that fragment directly before using workcell auth {command}"
+        )
+
+
+def desired_selectors(
+    credentials: dict[str, object],
+    credential: str,
+    agent: str,
+) -> dict[str, object]:
+    existing = credentials.get(credential)
+    if not isinstance(existing, dict):
+        if credential in SHARED_CREDENTIAL_KEYS:
+            return {"providers": [agent]}
+        return {}
+    validate_allowed_keys(existing, ENTRY_ALLOWED_KEYS, f"credentials.{credential}")
+    selectors: dict[str, object] = {}
+    if "modes" in existing:
+        selectors["modes"] = existing["modes"]
+    if credential in SHARED_CREDENTIAL_KEYS:
+        if "providers" in existing:
+            selectors["providers"] = existing["providers"]
+        else:
+            selectors["providers"] = [agent]
+    elif "providers" in existing:
+        selectors["providers"] = existing["providers"]
+    return selectors
+
+
+def managed_source_path_for_entry(
+    managed_root: Path,
+    credential: str,
+    existing_entry: object,
+) -> Path | None:
+    if credential not in CANONICAL_CREDENTIAL_DESTINATIONS:
+        return None
+    provider_dir, filename = CANONICAL_CREDENTIAL_DESTINATIONS[credential]
+    candidate = canonical_destination_path(managed_root, credential)
+    existing_source = None
+    if isinstance(existing_entry, dict):
+        existing_source = existing_entry.get("source")
+    elif isinstance(existing_entry, str):
+        existing_source = existing_entry
+    if isinstance(existing_source, str) and existing_source == str(candidate):
+        return candidate
+    if not isinstance(existing_source, str):
+        return None
+    existing_path = Path(existing_source).expanduser()
+    if existing_path.name != filename or existing_path.parent.name != provider_dir:
+        return None
+    root_candidate = existing_path.parent.parent
+    if is_workcell_managed_root(root_candidate):
+        return existing_path
+    return None
+
+
+def validate_agent_credential(agent: str, credential: str) -> None:
+    allowed = AGENT_SCOPED_CREDENTIAL_KEYS.get(agent, set()) | SHARED_CREDENTIAL_KEYS
+    if credential not in allowed:
+        die(f"{credential} is not valid for agent {agent}")
+
+
+def write_verified_policy(policy_path: Path, policy: dict[str, object]) -> None:
+    ensure_directory(policy_path.parent)
+    with tempfile.NamedTemporaryFile(
+        dir=policy_path.parent,
+        prefix=f"{policy_path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        temp_path = Path(handle.name)
+    try:
+        write_policy_file(temp_path, policy)
+        load_policy_bundle(temp_path)
+        temp_path.replace(policy_path)
+        policy_path.chmod(0o600)
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def command_init(policy_path: Path, managed_root: Path) -> int:
+    validate_managed_path(managed_root, managed_root, "managed_root")
+    if not policy_path.exists():
+        write_verified_policy(policy_path, {"version": 1})
+    else:
+        load_policy_bundle(policy_path)
+    ensure_directory(managed_root)
+    write_managed_root_marker(managed_root)
+    for name in ("codex", "claude", "gemini", "shared"):
+        validate_managed_path(managed_root, managed_root / name, f"managed_root/{name}")
+        ensure_directory(managed_root / name)
+    print(f"policy_path={policy_path}")
+    print(f"managed_root={managed_root}")
+    return 0
+
+
+def command_set(
+    policy_path: Path,
+    managed_root: Path,
+    agent: str,
+    credential: str,
+    source_raw: str | None,
+    source_base_raw: str | None,
+    resolver: str | None,
+    ack_host_resolver: bool,
+) -> int:
+    validate_agent_credential(agent, credential)
+    if bool(source_raw) == bool(resolver):
+        die("Specify exactly one of --source or --resolver")
+    validate_managed_path(managed_root, managed_root, "managed_root")
+
+    policy = load_mutable_policy(policy_path)
+    credentials = policy.setdefault("credentials", {})
+    if not isinstance(credentials, dict):
+        die("credentials must remain a TOML table")
+    ensure_credential_not_only_in_includes(policy_path, credentials, credential, "set")
+    existing_entry = credentials.get(credential)
+    selectors = desired_selectors(credentials, credential, agent)
+
+    if source_raw is not None:
+        source_base = Path(source_base_raw).expanduser().resolve() if source_base_raw else Path.cwd()
+        source = require_secret_file(
+            validate_source_path(source_raw, f"credentials.{credential}", source_base),
+            f"credentials.{credential}",
+        )
+        destination = canonical_destination_path(managed_root, credential)
+        validate_managed_path(
+            managed_root,
+            destination,
+            f"managed credential path for {credential}",
+        )
+        prior_managed_path = managed_source_path_for_entry(managed_root, credential, existing_entry)
+        if prior_managed_path is not None and prior_managed_path != destination:
+            require_no_symlink_in_path_chain(
+                prior_managed_path,
+                f"managed credential path for {credential}",
+            )
+        previous_destination = stage_existing_file(destination)
+        prior_managed_backup = None
+        if prior_managed_path is not None and prior_managed_path != destination:
+            prior_managed_backup = stage_existing_file(prior_managed_path)
+        staged_destination = None
+        credentials[credential] = {
+            **selectors,
+            "source": str(destination),
+        }
+        try:
+            staged_destination = stage_file_copy(source, destination)
+            install_staged_file(staged_destination, destination)
+            write_verified_policy(policy_path, policy)
+            try:
+                write_managed_root_marker(managed_root)
+            except OSError:
+                pass
+        except BaseException:
+            cleanup_staged_file(staged_destination)
+            cleanup_staged_file(destination if destination.exists() else None)
+            restore_staged_file(previous_destination, destination)
+            restore_staged_file(prior_managed_backup, prior_managed_path)
+            raise
+        cleanup_staged_file(previous_destination)
+        cleanup_staged_file(prior_managed_backup)
+        print(f"policy_path={policy_path}")
+        print(f"credential={credential}")
+        print(f"source={source.resolve()}")
+        print(f"managed_source={destination}")
+        if isinstance(selectors.get("providers"), list):
+            print(f"providers={','.join(selectors['providers'])}")
+        if isinstance(selectors.get("modes"), list):
+            print(f"modes={','.join(selectors['modes'])}")
+        return 0
+
+    if credential not in ALLOWED_RESOLVERS or resolver not in ALLOWED_RESOLVERS[credential]:
+        die(f"{credential} does not support resolver {resolver}")
+    if not ack_host_resolver:
+        die("set --resolver requires --ack-host-resolver")
+    managed_path = managed_source_path_for_entry(managed_root, credential, existing_entry)
+    if managed_path is not None:
+        require_no_symlink_in_path_chain(
+            managed_path,
+            f"managed credential path for {credential}",
+        )
+    staged_managed_path = stage_existing_file(managed_path)
+    credentials[credential] = {
+        **selectors,
+        "resolver": resolver,
+        "materialization": "ephemeral",
+    }
+    try:
+        write_verified_policy(policy_path, policy)
+    except BaseException:
+        restore_staged_file(staged_managed_path, managed_path)
+        raise
+    cleanup_staged_file(staged_managed_path)
+    print(f"policy_path={policy_path}")
+    print(f"credential={credential}")
+    print(f"resolver={resolver}")
+    print("materialization=ephemeral")
+    print("resolver_status=configured-fail-closed")
+    if isinstance(selectors.get("providers"), list):
+        print(f"providers={','.join(selectors['providers'])}")
+    if isinstance(selectors.get("modes"), list):
+        print(f"modes={','.join(selectors['modes'])}")
+    return 0
+
+
+def command_unset(policy_path: Path, managed_root: Path, credential: str) -> int:
+    validate_managed_path(managed_root, managed_root, "managed_root")
+    policy = load_mutable_policy(policy_path)
+    credentials = policy.get("credentials")
+    ensure_credential_not_only_in_includes(
+        policy_path,
+        credentials if isinstance(credentials, dict) else {},
+        credential,
+        "unset",
+    )
+    existing_entry = credentials.get(credential) if isinstance(credentials, dict) else None
+    if not isinstance(credentials, dict) or credential not in credentials:
+        print(f"policy_path={policy_path}")
+        print(f"credential={credential}")
+        print("removed=0")
+        return 0
+    del credentials[credential]
+    if not credentials:
+        policy.pop("credentials", None)
+    managed_path = managed_source_path_for_entry(managed_root, credential, existing_entry)
+    if managed_path is not None:
+        require_no_symlink_in_path_chain(
+            managed_path,
+            f"managed credential path for {credential}",
+        )
+    staged_managed_path = stage_existing_file(managed_path)
+    try:
+        write_verified_policy(policy_path, policy)
+    except BaseException:
+        restore_staged_file(staged_managed_path, managed_path)
+        raise
+    cleanup_staged_file(staged_managed_path)
+    print(f"policy_path={policy_path}")
+    print(f"credential={credential}")
+    print("removed=1")
+    return 0
+
+
+def selected_credentials(policy: dict, agent: str | None, mode: str) -> dict[str, object]:
+    credentials = policy.get("credentials", {})
+    if not isinstance(credentials, dict):
+        return {}
+    if agent is None:
+        selected: dict[str, object] = {}
+        for key, raw in credentials.items():
+            if isinstance(raw, dict):
+                validate_status_credential_entry(key, raw)
+                validate_selector_values(
+                    raw.get("providers"),
+                    f"credentials.{key}.providers",
+                    SUPPORTED_AGENTS,
+                )
+                if not selected_for(
+                    raw.get("modes"),
+                    mode,
+                    f"credentials.{key}.modes",
+                    SUPPORTED_MODES,
+                ):
+                    continue
+            selected[key] = raw
+        return selected
+
+    relevant = SHARED_CREDENTIAL_KEYS | AGENT_SCOPED_CREDENTIAL_KEYS.get(agent, set())
+    selected: dict[str, object] = {}
+    for key in sorted(relevant):
+        raw = credentials.get(key)
+        if raw is None:
+            continue
+        if isinstance(raw, dict):
+            validate_status_credential_entry(key, raw)
+            if not selected_for(
+                raw.get("providers"),
+                agent,
+                f"credentials.{key}.providers",
+                SUPPORTED_AGENTS,
+            ):
+                continue
+            if not selected_for(
+                raw.get("modes"),
+                mode,
+                f"credentials.{key}.modes",
+                SUPPORTED_MODES,
+            ):
+                continue
+        selected[key] = raw
+    return selected
+
+
+def credential_input_kind(raw: object) -> str:
+    if isinstance(raw, dict) and raw.get("resolver") is not None:
+        return "resolver"
+    return "source"
+
+
+def validate_status_credential_entry(key: str, raw: object) -> None:
+    if not isinstance(raw, dict):
+        return
+    validate_allowed_keys(raw, ENTRY_ALLOWED_KEYS, f"credentials.{key}")
+    source_raw = raw.get("source")
+    resolver = raw.get("resolver")
+    providers = raw.get("providers")
+    materialization = raw.get("materialization")
+    if key in SHARED_CREDENTIAL_KEYS and providers is None:
+        die(
+            f"credentials.{key}.providers is required so shared GitHub credentials "
+            "stay least-privilege"
+        )
+    if source_raw is not None and resolver is not None:
+        die(f"credentials.{key} must not declare both source and resolver")
+    if resolver is None:
+        if materialization is not None:
+            die(
+                f"credentials.{key}.materialization is only valid for resolver-backed auth"
+            )
+        if source_raw is None:
+            die(f"credentials.{key} must declare source or resolver")
+        return
+    if key not in ALLOWED_RESOLVERS or resolver not in ALLOWED_RESOLVERS[key]:
+        die(f"credentials.{key}.resolver is unsupported: {resolver}")
+    if materialization not in (None, "ephemeral"):
+        die(
+            f"credentials.{key}.materialization must stay ephemeral for resolver-backed auth"
+        )
+
+
+def validate_selector_values(values: object, label: str, allowed_values: set[str]) -> None:
+    if values is None:
+        return
+    if not isinstance(values, list) or not values:
+        die(f"{label} must be a non-empty array when specified")
+    for value in values:
+        if not isinstance(value, str):
+            die(f"{label} values must be strings")
+        if value not in allowed_values:
+            die(f"{label} contains unsupported value: {value}")
+
+
+def validate_status_credential_source(key: str, raw: object, policy_base: Path) -> None:
+    source_raw = raw
+    if isinstance(raw, dict):
+        source_raw = raw.get("source")
+    if source_raw is None:
+        return
+    source = validate_source_path(source_raw, f"credentials.{key}", policy_base)
+    require_secret_file(source, f"credentials.{key}")
+
+
+def render_map(value: dict[str, str]) -> str:
+    if not value:
+        return "none"
+    return ",".join(f"{key}:{value[key]}" for key in sorted(value))
+
+
+def render_modes(keys: list[str]) -> str:
+    return ",".join(keys) if keys else "none"
+
+
+def command_status(policy_path: Path, agent: str | None, mode: str) -> int:
+    if not policy_path.exists():
+        print("injection_policy=none")
+        print(f"default_injection_policy_path={policy_path}")
+        print("credential_keys=none")
+        print("credential_input_kinds=none")
+        print("credential_resolvers=none")
+        print("credential_materialization=none")
+        print("credential_resolution_states=none")
+        if agent is not None:
+            print("provider_auth_mode=none")
+            print("provider_auth_modes=none")
+            print("shared_auth_modes=none")
+            print("github_auth_present=0")
+        return 0
+
+    policy, policy_sources = load_policy_bundle(policy_path)
+    selected = selected_credentials(policy, agent, mode)
+    for key, raw in selected.items():
+        validate_status_credential_source(key, raw, policy_path.parent)
+    input_kinds = {key: credential_input_kind(raw) for key, raw in selected.items()}
+    resolvers = {
+        key: raw["resolver"]
+        for key, raw in selected.items()
+        if isinstance(raw, dict) and isinstance(raw.get("resolver"), str)
+    }
+    materialization = {
+        key: raw["materialization"]
+        for key, raw in selected.items()
+        if isinstance(raw, dict) and isinstance(raw.get("materialization"), str)
+    }
+    resolution_states = {
+        key: ("configured-only" if input_kinds[key] == "resolver" else "source")
+        for key in selected
+    }
+
+    print(f"policy_source_sha256={composite_policy_sha256(policy_sources)}")
+    print(f"credential_keys={render_modes(sorted(selected))}")
+    print(f"credential_input_kinds={render_map(input_kinds)}")
+    print(f"credential_resolvers={render_map(resolvers)}")
+    print(f"credential_materialization={render_map(materialization)}")
+    print(f"credential_resolution_states={render_map(resolution_states)}")
+
+    if agent is not None:
+        provider_auth_modes = [
+            key
+            for key in STATUS_ORDER.get(agent, [])
+            if key in selected and resolution_states.get(key) != "configured-only"
+        ]
+        shared_auth_modes = [
+            key
+            for key in ("github_hosts", "github_config")
+            if key in selected and resolution_states.get(key) != "configured-only"
+        ]
+        provider_auth_mode = provider_auth_modes[0] if provider_auth_modes else "none"
+        print(f"provider_auth_mode={provider_auth_mode}")
+        print(f"provider_auth_modes={render_modes(provider_auth_modes)}")
+        print(f"shared_auth_modes={render_modes(shared_auth_modes)}")
+        print(f"github_auth_present={1 if shared_auth_modes else 0}")
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    policy_path = Path(args.policy).expanduser().resolve()
+
+    if args.command == "init":
+        managed_root = Path(args.managed_root).expanduser().resolve()
+        return command_init(policy_path, managed_root)
+    if args.command == "set":
+        managed_root = Path(args.managed_root).expanduser().resolve()
+        return command_set(
+            policy_path,
+            managed_root,
+            args.agent,
+            args.credential,
+            args.source,
+            args.source_base,
+            args.resolver,
+            args.ack_host_resolver,
+        )
+    if args.command == "unset":
+        managed_root = Path(args.managed_root).expanduser().resolve()
+        return command_unset(policy_path, managed_root, args.credential)
+    if args.command == "status":
+        return command_status(policy_path, args.agent, args.mode)
+    die(f"unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/manage_injection_policy.py
+++ b/scripts/lib/manage_injection_policy.py
@@ -23,6 +23,7 @@ from policy_bundle import (  # noqa: E402
     SUPPORTED_MODES,
     composite_policy_sha256,
     die,
+    expand_host_path,
     load_policy_bundle,
     load_raw_policy,
     require_no_symlink_in_path_chain,
@@ -189,12 +190,22 @@ def ensure_credential_not_only_in_includes(
 ) -> None:
     if credential in credentials or not policy_path.exists():
         return
-    merged_policy, _ = load_policy_bundle(policy_path)
+    merged_policy, policy_sources = load_policy_bundle(policy_path)
     merged_credentials = merged_policy.get("credentials", {})
     if isinstance(merged_credentials, dict) and credential in merged_credentials:
+        fragment_path = ""
+        for source in policy_sources:
+            source_path = Path(source["path"])
+            source_policy = load_raw_policy(source_path)
+            source_credentials = source_policy.get("credentials", {})
+            if isinstance(source_credentials, dict) and credential in source_credentials:
+                fragment_path = str(source_path)
+                break
+        fragment_hint = f": {fragment_path}" if fragment_path else ""
         die(
             f"credentials.{credential} is declared by an included policy fragment; "
             f"update that fragment directly before using workcell auth {command}"
+            f"{fragment_hint}"
         )
 
 
@@ -222,7 +233,43 @@ def desired_selectors(
     return selectors
 
 
+def paths_equivalent(left: Path, right: Path) -> bool:
+    try:
+        return left.resolve(strict=False) == right.resolve(strict=False)
+    except OSError:
+        return left == right
+
+
+def entry_source_path(policy_path: Path, existing_source: str) -> Path:
+    return expand_host_path(existing_source, policy_path.parent)
+
+
 def managed_source_path_for_entry(
+    policy_path: Path,
+    managed_root: Path,
+    credential: str,
+    existing_entry: object,
+) -> Path | None:
+    if credential not in CANONICAL_CREDENTIAL_DESTINATIONS:
+        return None
+    candidate = canonical_destination_path(managed_root, credential)
+    existing_source = None
+    if isinstance(existing_entry, dict):
+        existing_source = existing_entry.get("source")
+    elif isinstance(existing_entry, str):
+        existing_source = existing_entry
+    if isinstance(existing_source, str) and existing_source == str(candidate):
+        return candidate
+    if not isinstance(existing_source, str):
+        return None
+    existing_path = entry_source_path(policy_path, existing_source)
+    if paths_equivalent(existing_path, candidate):
+        return candidate
+    return None
+
+
+def foreign_managed_source_path_for_entry(
+    policy_path: Path,
     managed_root: Path,
     credential: str,
     existing_entry: object,
@@ -236,17 +283,39 @@ def managed_source_path_for_entry(
         existing_source = existing_entry.get("source")
     elif isinstance(existing_entry, str):
         existing_source = existing_entry
-    if isinstance(existing_source, str) and existing_source == str(candidate):
-        return candidate
     if not isinstance(existing_source, str):
         return None
-    existing_path = Path(existing_source).expanduser()
+    existing_path = entry_source_path(policy_path, existing_source)
+    if paths_equivalent(existing_path, candidate):
+        return None
     if existing_path.name != filename or existing_path.parent.name != provider_dir:
         return None
     root_candidate = existing_path.parent.parent
     if is_workcell_managed_root(root_candidate):
         return existing_path
     return None
+
+
+def ensure_no_foreign_managed_source(
+    policy_path: Path,
+    managed_root: Path,
+    credential: str,
+    existing_entry: object,
+    command: str,
+) -> None:
+    foreign_path = foreign_managed_source_path_for_entry(
+        policy_path,
+        managed_root,
+        credential,
+        existing_entry,
+    )
+    if foreign_path is None:
+        return
+    die(
+        f"credentials.{credential} is already managed under a different --managed-root "
+        f"({foreign_path.parent.parent}); run workcell auth {command} with that "
+        f"--managed-root before switching roots"
+    )
 
 
 def validate_agent_credential(agent: str, credential: str) -> None:
@@ -313,6 +382,13 @@ def command_set(
         die("credentials must remain a TOML table")
     ensure_credential_not_only_in_includes(policy_path, credentials, credential, "set")
     existing_entry = credentials.get(credential)
+    ensure_no_foreign_managed_source(
+        policy_path,
+        managed_root,
+        credential,
+        existing_entry,
+        "set",
+    )
     selectors = desired_selectors(credentials, credential, agent)
 
     if source_raw is not None:
@@ -327,7 +403,12 @@ def command_set(
             destination,
             f"managed credential path for {credential}",
         )
-        prior_managed_path = managed_source_path_for_entry(managed_root, credential, existing_entry)
+        prior_managed_path = managed_source_path_for_entry(
+            policy_path,
+            managed_root,
+            credential,
+            existing_entry,
+        )
         if prior_managed_path is not None and prior_managed_path != destination:
             require_no_symlink_in_path_chain(
                 prior_managed_path,
@@ -372,7 +453,12 @@ def command_set(
         die(f"{credential} does not support resolver {resolver}")
     if not ack_host_resolver:
         die("set --resolver requires --ack-host-resolver")
-    managed_path = managed_source_path_for_entry(managed_root, credential, existing_entry)
+    managed_path = managed_source_path_for_entry(
+        policy_path,
+        managed_root,
+        credential,
+        existing_entry,
+    )
     if managed_path is not None:
         require_no_symlink_in_path_chain(
             managed_path,
@@ -413,6 +499,13 @@ def command_unset(policy_path: Path, managed_root: Path, credential: str) -> int
         "unset",
     )
     existing_entry = credentials.get(credential) if isinstance(credentials, dict) else None
+    ensure_no_foreign_managed_source(
+        policy_path,
+        managed_root,
+        credential,
+        existing_entry,
+        "unset",
+    )
     if not isinstance(credentials, dict) or credential not in credentials:
         print(f"policy_path={policy_path}")
         print(f"credential={credential}")
@@ -421,7 +514,12 @@ def command_unset(policy_path: Path, managed_root: Path, credential: str) -> int
     del credentials[credential]
     if not credentials:
         policy.pop("credentials", None)
-    managed_path = managed_source_path_for_entry(managed_root, credential, existing_entry)
+    managed_path = managed_source_path_for_entry(
+        policy_path,
+        managed_root,
+        credential,
+        existing_entry,
+    )
     if managed_path is not None:
         require_no_symlink_in_path_chain(
             managed_path,

--- a/scripts/lib/policy_bundle.py
+++ b/scripts/lib/policy_bundle.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""Shared helpers for Workcell injection policy parsing and rendering."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import os
+from pathlib import Path
+import stat
+import sys
+from typing import NoReturn
+
+
+SUPPORTED_AGENTS = {"codex", "claude", "gemini"}
+SUPPORTED_MODES = {"strict", "build", "breakglass"}
+CREDENTIAL_KEYS = {
+    "codex_auth",
+    "claude_auth",
+    "claude_api_key",
+    "claude_mcp",
+    "gemini_env",
+    "gemini_oauth",
+    "gemini_projects",
+    "gcloud_adc",
+    "github_hosts",
+    "github_config",
+}
+AGENT_SCOPED_CREDENTIAL_KEYS = {
+    "codex": {"codex_auth"},
+    "claude": {"claude_api_key", "claude_auth", "claude_mcp"},
+    "gemini": {"gemini_env", "gemini_oauth", "gemini_projects", "gcloud_adc"},
+}
+SHARED_CREDENTIAL_KEYS = {"github_hosts", "github_config"}
+ALLOWED_ROOT_POLICY_KEYS = {
+    "version",
+    "includes",
+    "documents",
+    "ssh",
+    "copies",
+    "credentials",
+}
+SYSTEM_SYMLINK_ALLOWLIST = (
+    {Path("/var"), Path("/tmp")} if sys.platform == "darwin" else set()
+)
+
+
+def die(message: str) -> NoReturn:
+    raise SystemExit(message)
+
+
+def expand_host_path(raw: str, base: Path) -> Path:
+    expanded = Path(os.path.expanduser(raw))
+    if not expanded.is_absolute():
+        expanded = base / expanded
+    return Path(os.path.abspath(os.fspath(expanded)))
+
+
+def require_path_within(root: Path, candidate: Path, label: str) -> None:
+    resolved_root = root.resolve()
+    resolved_candidate = candidate.resolve()
+    try:
+        resolved_candidate.relative_to(resolved_root)
+    except ValueError:
+        die(f"{label} must stay within {resolved_root}: {resolved_candidate}")
+
+
+def require_no_symlink_in_path_chain(path: Path, label: str) -> None:
+    current = path
+    while True:
+        if current.is_symlink() and current not in SYSTEM_SYMLINK_ALLOWLIST:
+            die(f"{label} must not be a symlink: {current}")
+        if current.parent == current:
+            return
+        current = current.parent
+
+
+def validate_source_path(raw: object, label: str, base: Path) -> Path:
+    if not isinstance(raw, str) or not raw:
+        die(f"{label} must be a non-empty string path")
+    source = expand_host_path(raw, base)
+    if not source.exists():
+        die(f"{label} does not exist: {source}")
+    require_no_symlink_in_path_chain(source, label)
+    return source
+
+
+def validate_allowed_keys(table: dict, allowed_keys: set[str], label: str) -> None:
+    unknown = sorted(set(table) - allowed_keys)
+    if unknown:
+        die(f"{label} contains unsupported keys: {', '.join(unknown)}")
+
+
+def selected_for(
+    values: object, current: str, label: str, allowed_values: set[str]
+) -> bool:
+    if values is None:
+        return True
+    if not isinstance(values, list) or not values:
+        die(f"{label} must be a non-empty array when specified")
+    for value in values:
+        if not isinstance(value, str):
+            die(f"{label} values must be strings")
+        if value not in allowed_values:
+            die(f"{label} contains unsupported value: {value}")
+    return current in values
+
+
+def strip_comment(line: str) -> str:
+    escaped = False
+    quote_char = ""
+    result = []
+
+    for char in line:
+        if escaped:
+            result.append(char)
+            escaped = False
+            continue
+        if char == "\\" and quote_char == '"':
+            result.append(char)
+            escaped = True
+            continue
+        if char in {'"', "'"}:
+            if not quote_char:
+                quote_char = char
+            elif quote_char == char:
+                quote_char = ""
+            result.append(char)
+            continue
+        if char == "#" and not quote_char:
+            break
+        result.append(char)
+    return "".join(result).strip()
+
+
+def parse_value(raw: str, policy_path: Path, lineno: int) -> object:
+    value = raw.strip()
+    if not value:
+        die(f"{policy_path}:{lineno}: expected a value")
+    if value in ("true", "false"):
+        return value == "true"
+    if value.startswith('"') and value.endswith('"'):
+        return ast.literal_eval(value)
+    if value.startswith("[") and value.endswith("]"):
+        parsed = ast.literal_eval(value)
+        if not isinstance(parsed, list):
+            die(f"{policy_path}:{lineno}: expected an array value")
+        if not all(isinstance(item, str) for item in parsed):
+            die(f"{policy_path}:{lineno}: only arrays of strings are supported")
+        return parsed
+    if value.isdigit():
+        return int(value)
+    die(
+        f"{policy_path}:{lineno}: unsupported TOML value; use quoted strings, "
+        "booleans, integers, or arrays of strings"
+    )
+
+
+def parse_toml_subset(content: str, policy_path: Path) -> dict:
+    root: dict[str, object] = {}
+    current: dict[str, object] = root
+    seen_tables: set[str] = set()
+
+    for lineno, raw_line in enumerate(content.splitlines(), start=1):
+        line = strip_comment(raw_line)
+        if not line:
+            continue
+
+        if line.startswith("[[") and line.endswith("]]"):
+            table_name = line[2:-2].strip()
+            if table_name != "copies":
+                die(f"{policy_path}:{lineno}: unsupported array-of-table [{table_name}]")
+            copies = root.setdefault("copies", [])
+            if not isinstance(copies, list):
+                die(f"{policy_path}:{lineno}: copies must remain an array of tables")
+            entry: dict[str, object] = {}
+            copies.append(entry)
+            current = entry
+            continue
+
+        if line.startswith("[") and line.endswith("]"):
+            table_name = line[1:-1].strip()
+            if table_name in seen_tables:
+                die(f"{policy_path}:{lineno}: duplicate table [{table_name}]")
+            seen_tables.add(table_name)
+            if table_name.startswith("credentials."):
+                credential_key = table_name.split(".", 1)[1]
+                if credential_key not in CREDENTIAL_KEYS:
+                    die(
+                        f"{policy_path}:{lineno}: unsupported credentials table "
+                        f"[{table_name}]"
+                    )
+                credentials = root.setdefault("credentials", {})
+                if not isinstance(credentials, dict):
+                    die(f"{policy_path}:{lineno}: credentials must remain a table")
+                entry = credentials.setdefault(credential_key, {})
+                if not isinstance(entry, dict):
+                    die(
+                        f"{policy_path}:{lineno}: credentials.{credential_key} must remain a table"
+                    )
+                current = entry
+                continue
+            if table_name not in {"documents", "ssh", "credentials"}:
+                die(f"{policy_path}:{lineno}: unsupported table [{table_name}]")
+            table = root.setdefault(table_name, {})
+            if not isinstance(table, dict):
+                die(f"{policy_path}:{lineno}: {table_name} must remain a table")
+            current = table
+            continue
+
+        if "=" not in line:
+            die(f"{policy_path}:{lineno}: expected key = value")
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not key:
+            die(f"{policy_path}:{lineno}: empty key")
+        if "." in key:
+            die(
+                f"{policy_path}:{lineno}: dotted TOML keys are not supported; "
+                "use explicit [table] headers instead"
+            )
+        if key in current:
+            die(f"{policy_path}:{lineno}: duplicate key: {key}")
+        current[key] = parse_value(value, policy_path, lineno)
+
+    return root
+
+
+def policy_sha256(policy_path: Path) -> str:
+    return f"sha256:{hashlib.sha256(policy_path.read_bytes()).hexdigest()}"
+
+
+def composite_policy_sha256(policy_sources: list[dict[str, str]]) -> str:
+    canonical = repr(sorted(policy_sources, key=lambda entry: entry["path"])).encode("utf-8")
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+def logical_policy_path(policy_path: Path, entrypoint_root: Path) -> str:
+    relative_path = os.path.relpath(policy_path, entrypoint_root)
+    return relative_path.replace(os.sep, "/")
+
+
+def rebase_fragment_path(raw: object, fragment_dir: Path) -> object:
+    if not isinstance(raw, str) or not raw:
+        return raw
+    return str(expand_host_path(raw, fragment_dir))
+
+
+def rebase_policy_fragment(policy: dict[str, object], fragment_dir: Path) -> dict[str, object]:
+    rebased: dict[str, object] = {}
+    for key, value in policy.items():
+        if key == "documents" and isinstance(value, dict):
+            rebased[key] = {
+                document_key: rebase_fragment_path(document_value, fragment_dir)
+                for document_key, document_value in value.items()
+            }
+            continue
+        if key == "copies" and isinstance(value, list):
+            rebased_copies: list[object] = []
+            for entry in value:
+                if not isinstance(entry, dict):
+                    rebased_copies.append(entry)
+                    continue
+                rebased_entry = dict(entry)
+                if "source" in rebased_entry:
+                    rebased_entry["source"] = rebase_fragment_path(
+                        rebased_entry["source"], fragment_dir
+                    )
+                rebased_copies.append(rebased_entry)
+            rebased[key] = rebased_copies
+            continue
+        if key == "ssh" and isinstance(value, dict):
+            rebased_ssh = dict(value)
+            for ssh_key in ("config", "known_hosts"):
+                if ssh_key in rebased_ssh:
+                    rebased_ssh[ssh_key] = rebase_fragment_path(rebased_ssh[ssh_key], fragment_dir)
+            identities = rebased_ssh.get("identities")
+            if isinstance(identities, list):
+                rebased_ssh["identities"] = [
+                    rebase_fragment_path(identity, fragment_dir) for identity in identities
+                ]
+            rebased[key] = rebased_ssh
+            continue
+        if key == "credentials" and isinstance(value, dict):
+            rebased_credentials: dict[str, object] = {}
+            for credential_key, credential_value in value.items():
+                if isinstance(credential_value, dict):
+                    rebased_credential = dict(credential_value)
+                    if "source" in rebased_credential:
+                        rebased_credential["source"] = rebase_fragment_path(
+                            rebased_credential["source"], fragment_dir
+                        )
+                    rebased_credentials[credential_key] = rebased_credential
+                else:
+                    rebased_credentials[credential_key] = rebase_fragment_path(
+                        credential_value, fragment_dir
+                    )
+            rebased[key] = rebased_credentials
+            continue
+        rebased[key] = value
+    return rebased
+
+
+def validate_policy_include(raw: object, label: str, base: Path, entrypoint_root: Path) -> Path:
+    source = validate_source_path(raw, label, base)
+    if not source.is_file():
+        die(f"{label} must point at a file: {source}")
+    resolved_source = source.resolve()
+    require_path_within(entrypoint_root, resolved_source, label)
+    return resolved_source
+
+
+def merge_policy_fragment(base: dict[str, object], addition: dict[str, object], source_path: Path) -> None:
+    version = addition.get("version", 1)
+    if version != 1:
+        die(f"unsupported injection policy version: {version}")
+
+    for table_name in ("documents", "ssh", "credentials"):
+        table = addition.get(table_name)
+        if table is None:
+            continue
+        if not isinstance(table, dict):
+            die(f"injection policy fragment must keep {table_name} as a table: {source_path}")
+        destination = base.setdefault(table_name, {})
+        if not isinstance(destination, dict):
+            die(f"injection policy merge corrupted {table_name}: {source_path}")
+        for key, value in table.items():
+            if key in destination:
+                die(
+                    "injection policy fragments declare the same setting more than once: "
+                    f"{table_name}.{key} ({source_path})"
+                )
+            destination[key] = value
+
+    copies = addition.get("copies")
+    if copies is None:
+        return
+    if not isinstance(copies, list):
+        die(f"injection policy fragment must keep copies as an array of tables: {source_path}")
+    destination_copies = base.setdefault("copies", [])
+    if not isinstance(destination_copies, list):
+        die(f"injection policy merge corrupted copies: {source_path}")
+    destination_copies.extend(copies)
+
+
+def load_policy_bundle(
+    policy_path: Path,
+    *,
+    entrypoint_root: Path | None = None,
+    active_stack: tuple[Path, ...] | None = None,
+    loaded_paths: set[Path] | None = None,
+) -> tuple[dict, list[dict[str, str]]]:
+    resolved_policy_path = policy_path.expanduser().resolve()
+    entrypoint_root = (
+        entrypoint_root.resolve() if entrypoint_root is not None else resolved_policy_path.parent
+    )
+    active_stack = active_stack or ()
+    loaded_paths = loaded_paths if loaded_paths is not None else set()
+
+    if resolved_policy_path in active_stack:
+        cycle = " -> ".join(str(path) for path in (*active_stack, resolved_policy_path))
+        die(f"injection policy include cycle detected: {cycle}")
+    if resolved_policy_path in loaded_paths:
+        die(f"injection policy includes the same file more than once: {resolved_policy_path}")
+    loaded_paths.add(resolved_policy_path)
+
+    loaded = parse_toml_subset(
+        resolved_policy_path.read_text(encoding="utf-8"),
+        resolved_policy_path,
+    )
+    if not isinstance(loaded, dict):
+        die(f"injection policy must decode to a TOML table: {resolved_policy_path}")
+    validate_allowed_keys(loaded, ALLOWED_ROOT_POLICY_KEYS, "root policy")
+
+    version = loaded.get("version", 1)
+    if version != 1:
+        die(f"unsupported injection policy version: {version}")
+
+    includes = loaded.get("includes", [])
+    if includes is None:
+        includes = []
+    if not isinstance(includes, list):
+        die("includes must be an array of strings when specified")
+
+    merged: dict[str, object] = {"version": 1}
+    policy_sources: list[dict[str, str]] = []
+    next_stack = (*active_stack, resolved_policy_path)
+    for index, include in enumerate(includes):
+        include_path = validate_policy_include(
+            include,
+            f"includes[{index}]",
+            resolved_policy_path.parent,
+            entrypoint_root,
+        )
+        included_policy, included_sources = load_policy_bundle(
+            include_path,
+            entrypoint_root=entrypoint_root,
+            active_stack=next_stack,
+            loaded_paths=loaded_paths,
+        )
+        merge_policy_fragment(merged, included_policy, include_path)
+        policy_sources.extend(included_sources)
+
+    current_policy = dict(loaded)
+    current_policy.pop("includes", None)
+    if active_stack:
+        current_policy = rebase_policy_fragment(current_policy, resolved_policy_path.parent)
+    merge_policy_fragment(merged, current_policy, resolved_policy_path)
+    policy_sources.append(
+        {
+            "path": logical_policy_path(resolved_policy_path, entrypoint_root),
+            "sha256": policy_sha256(resolved_policy_path),
+        }
+    )
+    return merged, policy_sources
+
+
+def load_raw_policy(policy_path: Path) -> dict:
+    if not policy_path.exists():
+        return {"version": 1}
+    loaded = parse_toml_subset(policy_path.read_text(encoding="utf-8"), policy_path)
+    if not isinstance(loaded, dict):
+        die(f"injection policy must decode to a TOML table: {policy_path}")
+    validate_allowed_keys(loaded, ALLOWED_ROOT_POLICY_KEYS, "root policy")
+    version = loaded.get("version", 1)
+    if version != 1:
+        die(f"unsupported injection policy version: {version}")
+    if "version" not in loaded:
+        loaded["version"] = 1
+    return loaded
+
+
+def quote_string(value: str) -> str:
+    return json_quote(value)
+
+
+def json_quote(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    escaped = escaped.replace("\n", "\\n")
+    return f'"{escaped}"'
+
+
+def render_toml_value(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        return json_quote(value)
+    if isinstance(value, list):
+        if not all(isinstance(item, str) for item in value):
+            die("only arrays of strings are supported in rendered policy output")
+        return "[" + ", ".join(json_quote(item) for item in value) + "]"
+    die(f"unsupported TOML value type: {type(value).__name__}")
+
+
+def render_policy_toml(policy: dict[str, object]) -> str:
+    lines: list[str] = []
+    version = policy.get("version", 1)
+    lines.append(f"version = {render_toml_value(version)}")
+
+    includes = policy.get("includes")
+    if isinstance(includes, list) and includes:
+        lines.append(f"includes = {render_toml_value(includes)}")
+
+    documents = policy.get("documents")
+    if isinstance(documents, dict) and documents:
+        lines.append("")
+        lines.append("[documents]")
+        for key in ("common", "codex", "claude", "gemini"):
+            if key in documents:
+                lines.append(f"{key} = {render_toml_value(documents[key])}")
+
+    credentials = policy.get("credentials")
+    if isinstance(credentials, dict) and credentials:
+        scalar_entries = {
+            key: value for key, value in credentials.items() if not isinstance(value, dict)
+        }
+        if scalar_entries:
+            lines.append("")
+            lines.append("[credentials]")
+            for key in sorted(scalar_entries):
+                lines.append(f"{key} = {render_toml_value(scalar_entries[key])}")
+        for key in sorted(credentials):
+            value = credentials[key]
+            if not isinstance(value, dict):
+                continue
+            lines.append("")
+            lines.append(f"[credentials.{key}]")
+            for field in sorted(value):
+                lines.append(f"{field} = {render_toml_value(value[field])}")
+
+    ssh = policy.get("ssh")
+    if isinstance(ssh, dict) and ssh:
+        lines.append("")
+        lines.append("[ssh]")
+        ordered = ("enabled", "config", "known_hosts", "identities", "providers", "modes", "allow_unsafe_config")
+        for key in ordered:
+            if key in ssh:
+                lines.append(f"{key} = {render_toml_value(ssh[key])}")
+        for key in sorted(set(ssh) - set(ordered)):
+            lines.append(f"{key} = {render_toml_value(ssh[key])}")
+
+    copies = policy.get("copies")
+    if isinstance(copies, list) and copies:
+        for entry in copies:
+            if not isinstance(entry, dict):
+                die("copies entries must be TOML tables when rendering policy output")
+            lines.append("")
+            lines.append("[[copies]]")
+            for key in ("source", "target", "classification", "providers", "modes"):
+                if key in entry:
+                    lines.append(f"{key} = {render_toml_value(entry[key])}")
+            for key in sorted(set(entry) - {"source", "target", "classification", "providers", "modes"}):
+                lines.append(f"{key} = {render_toml_value(entry[key])}")
+
+    return "\n".join(lines) + "\n"
+
+
+def write_policy_file(policy_path: Path, policy: dict[str, object]) -> None:
+    policy_path.parent.mkdir(parents=True, exist_ok=True)
+    policy_path.write_text(render_policy_toml(policy), encoding="utf-8")
+    policy_path.chmod(0o600)
+
+
+def require_secret_file(source: Path, label: str) -> Path:
+    if source.is_symlink():
+        die(f"{label} must not be a symlink: {source}")
+    if not source.is_file():
+        die(f"{label} must point at a file: {source}")
+    path_stat = source.lstat()
+    if path_stat.st_uid != os.getuid():
+        die(f"{label} must be owned by uid {os.getuid()}: {source}")
+    if stat.S_IMODE(path_stat.st_mode) & 0o077:
+        die(f"{label} must not be group/world-accessible: {source}")
+    return source

--- a/scripts/lib/render_injection_bundle.py
+++ b/scripts/lib/render_injection_bundle.py
@@ -134,6 +134,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--agent", required=True, choices=sorted(SUPPORTED_AGENTS))
     parser.add_argument("--mode", required=True, choices=sorted(SUPPORTED_MODES))
     parser.add_argument("--output-root", required=True)
+    parser.add_argument("--policy-metadata", help=argparse.SUPPRESS)
     return parser.parse_args()
 
 
@@ -642,6 +643,36 @@ def effective_policy_sha256(
         separators=(",", ":"),
     ).encode("utf-8")
     return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+def load_policy_metadata_override(path: Path) -> tuple[str, list[dict[str, str]]]:
+    try:
+        metadata = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        die(f"policy metadata override must be valid JSON: {path} ({exc.msg})")
+    if not isinstance(metadata, dict):
+        die(f"policy metadata override must be a JSON object: {path}")
+
+    entrypoint = metadata.get("policy_entrypoint")
+    if not isinstance(entrypoint, str) or not entrypoint:
+        die(f"policy metadata override must include policy_entrypoint: {path}")
+
+    raw_sources = metadata.get("policy_sources")
+    if not isinstance(raw_sources, list) or not raw_sources:
+        die(f"policy metadata override must include policy_sources: {path}")
+
+    sources: list[dict[str, str]] = []
+    for entry in raw_sources:
+        if not isinstance(entry, dict):
+            die(f"policy metadata override sources must be objects: {path}")
+        source_path = entry.get("path")
+        source_sha = entry.get("sha256")
+        if not isinstance(source_path, str) or not source_path:
+            die(f"policy metadata override source path must be a string: {path}")
+        if not isinstance(source_sha, str) or not source_sha:
+            die(f"policy metadata override source sha256 must be a string: {path}")
+        sources.append({"path": source_path, "sha256": source_sha})
+    return entrypoint, sources
 
 
 def logical_policy_path(policy_path: Path, entrypoint_root: Path) -> str:
@@ -1218,6 +1249,14 @@ def main() -> int:
     output_root.chmod(0o700)
 
     policy, policy_sources = load_policy_bundle(policy_path)
+    policy_entrypoint = logical_policy_path(
+        policy_path.resolve(),
+        policy_path.parent.resolve(),
+    )
+    if args.policy_metadata:
+        policy_entrypoint, policy_sources = load_policy_metadata_override(
+            Path(args.policy_metadata).expanduser().resolve()
+        )
     rendered_documents = render_documents(policy, output_root, policy_path.parent)
     rendered_copies = render_copies(
         policy, output_root, policy_path.parent, args.agent, args.mode
@@ -1230,7 +1269,7 @@ def main() -> int:
     manifest = {
         "version": 1,
         "metadata": {
-            "policy_entrypoint": logical_policy_path(policy_path.resolve(), policy_path.parent.resolve()),
+            "policy_entrypoint": policy_entrypoint,
             "policy_sha256": effective_policy_sha256(
                 policy_sources,
                 output_root,

--- a/scripts/lib/resolve_credential_sources.py
+++ b/scripts/lib/resolve_credential_sources.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Resolve host-side credential inputs into concrete files before rendering."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from policy_bundle import (  # noqa: E402
+    AGENT_SCOPED_CREDENTIAL_KEYS,
+    SHARED_CREDENTIAL_KEYS,
+    SUPPORTED_AGENTS,
+    SUPPORTED_MODES,
+    die,
+    logical_policy_path,
+    load_policy_bundle,
+    require_secret_file,
+    rebase_policy_fragment,
+    render_policy_toml,
+    selected_for,
+    validate_allowed_keys,
+    validate_source_path,
+)
+
+
+RESOLVER_ALLOWED_KEYS = {"source", "resolver", "materialization", "providers", "modes"}
+SUPPORTED_MATERIALIZATION = {"ephemeral", "persistent"}
+ALLOWED_RESOLVERS = {
+    "claude_auth": {"claude-macos-keychain"},
+}
+TEST_CLAUDE_EXPORT_ENV = "WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--policy", required=True)
+    parser.add_argument("--agent", required=True, choices=sorted(SUPPORTED_AGENTS))
+    parser.add_argument("--mode", required=True, choices=sorted(SUPPORTED_MODES))
+    parser.add_argument(
+        "--resolution-mode",
+        required=True,
+        choices=("launch", "metadata"),
+    )
+    parser.add_argument("--output-policy", required=True)
+    parser.add_argument("--output-metadata", required=True)
+    parser.add_argument("--output-root", required=True)
+    return parser.parse_args()
+
+
+def materialize_file(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=destination.parent, delete=False) as handle:
+        temp_path = Path(handle.name)
+    try:
+        shutil.copyfile(source, temp_path)
+        temp_path.chmod(0o600)
+        temp_path.replace(destination)
+        destination.chmod(0o600)
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def write_placeholder(destination: Path, resolver: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        dir=destination.parent,
+        delete=False,
+        mode="w",
+        encoding="utf-8",
+    ) as handle:
+        temp_path = Path(handle.name)
+        handle.write(
+            json.dumps(
+                {
+                    "workcell": "metadata-only",
+                    "resolver": resolver,
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    try:
+        temp_path.chmod(0o600)
+        temp_path.replace(destination)
+        destination.chmod(0o600)
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def atomic_write_text(destination: Path, content: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        dir=destination.parent,
+        delete=False,
+        mode="w",
+        encoding="utf-8",
+    ) as handle:
+        temp_path = Path(handle.name)
+        handle.write(content)
+    try:
+        temp_path.chmod(0o600)
+        temp_path.replace(destination)
+        destination.chmod(0o600)
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def resolve_claude_macos_keychain(
+    destination: Path,
+    resolution_mode: str,
+) -> str:
+    test_export_path = os.environ.get(TEST_CLAUDE_EXPORT_ENV, "")
+    if test_export_path:
+        source = require_secret_file(
+            validate_source_path(
+                test_export_path,
+                TEST_CLAUDE_EXPORT_ENV,
+                Path.cwd(),
+            ),
+            TEST_CLAUDE_EXPORT_ENV,
+        )
+        materialize_file(source, destination)
+        return "resolved"
+    if resolution_mode == "metadata":
+        write_placeholder(destination, "claude-macos-keychain")
+        return "configured-only"
+    die(
+        "Claude macOS login reuse is configured but no supported export path is "
+        "available. Use claude_api_key or remove credentials.claude_auth."
+    )
+
+
+def resolve_credential(
+    key: str,
+    resolver_name: str,
+    destination: Path,
+    resolution_mode: str,
+) -> str:
+    if key == "claude_auth" and resolver_name == "claude-macos-keychain":
+        return resolve_claude_macos_keychain(destination, resolution_mode)
+    die(f"unsupported credential resolver: {resolver_name}")
+
+
+def main() -> int:
+    args = parse_args()
+    policy_path = Path(args.policy).expanduser().resolve()
+    output_policy_path = Path(args.output_policy).expanduser().resolve()
+    output_metadata_path = Path(args.output_metadata).expanduser().resolve()
+    output_root = Path(args.output_root).expanduser().resolve()
+
+    policy, policy_sources = load_policy_bundle(policy_path)
+    policy = rebase_policy_fragment(policy, policy_path.parent)
+    credentials = policy.get("credentials", {})
+    if credentials is None:
+        credentials = {}
+    if not isinstance(credentials, dict):
+        die("credentials must be a TOML table")
+
+    relevant_keys = SHARED_CREDENTIAL_KEYS | AGENT_SCOPED_CREDENTIAL_KEYS.get(args.agent, set())
+    metadata = {
+        "policy_entrypoint": logical_policy_path(policy_path, policy_path.parent),
+        "policy_sources": policy_sources,
+        "credential_input_kinds": {},
+        "credential_resolvers": {},
+        "credential_materialization": {},
+        "credential_resolution_states": {},
+    }
+
+    for key in sorted(relevant_keys):
+        raw = credentials.get(key)
+        if raw is None:
+            continue
+        if not isinstance(raw, dict):
+            metadata["credential_input_kinds"][key] = "source"
+            metadata["credential_resolution_states"][key] = "source"
+            continue
+
+        validate_allowed_keys(raw, RESOLVER_ALLOWED_KEYS, f"credentials.{key}")
+        resolver_name = raw.get("resolver")
+        providers = raw.get("providers")
+        modes = raw.get("modes")
+        if not selected_for(
+            providers,
+            args.agent,
+            f"credentials.{key}.providers",
+            SUPPORTED_AGENTS,
+        ):
+            if resolver_name is not None:
+                credentials.pop(key, None)
+            continue
+        if not selected_for(
+            modes,
+            args.mode,
+            f"credentials.{key}.modes",
+            SUPPORTED_MODES,
+        ):
+            if resolver_name is not None:
+                credentials.pop(key, None)
+            continue
+
+        source_raw = raw.get("source")
+        if source_raw is not None and resolver_name is not None:
+            die(f"credentials.{key} must not declare both source and resolver")
+        if source_raw is None and resolver_name is None:
+            die(f"credentials.{key} must declare source or resolver")
+        if resolver_name is None:
+            metadata["credential_input_kinds"][key] = "source"
+            metadata["credential_resolution_states"][key] = "source"
+            continue
+        if key not in ALLOWED_RESOLVERS or resolver_name not in ALLOWED_RESOLVERS[key]:
+            die(f"credentials.{key}.resolver is unsupported: {resolver_name}")
+        materialization = raw.get("materialization", "ephemeral")
+        if materialization not in SUPPORTED_MATERIALIZATION:
+            die(
+                f"credentials.{key}.materialization must be one of: "
+                f"{', '.join(sorted(SUPPORTED_MATERIALIZATION))}"
+            )
+        if materialization != "ephemeral":
+            die(
+                f"credentials.{key}.materialization must stay ephemeral for resolver-backed auth"
+            )
+
+        destination = output_root / "resolved" / "credentials" / f"{key}.json"
+        state = resolve_credential(key, resolver_name, destination, args.resolution_mode)
+        rewritten = dict(raw)
+        rewritten.pop("resolver", None)
+        rewritten.pop("materialization", None)
+        rewritten["source"] = str(destination)
+        credentials[key] = rewritten
+
+        metadata["credential_input_kinds"][key] = "resolver"
+        metadata["credential_resolvers"][key] = resolver_name
+        metadata["credential_materialization"][key] = materialization
+        metadata["credential_resolution_states"][key] = state
+
+    atomic_write_text(output_policy_path, render_policy_toml(policy))
+    atomic_write_text(
+        output_metadata_path,
+        json.dumps(metadata, sort_keys=True, indent=2) + "\n",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1922,11 +1922,11 @@ Usage: workcell auth init [options]
 
 Commands:
   init
-    --injection-policy PATH     Policy file to create or validate
+    --injection-policy PATH     Policy file to create or validate (default: ~/.config/workcell/injection-policy.toml)
     --managed-root PATH         Managed credential root (default: ~/.config/workcell/credentials)
 
   set
-    --injection-policy PATH     Policy file to update
+    --injection-policy PATH     Policy file to update (default: ~/.config/workcell/injection-policy.toml)
     --managed-root PATH         Managed credential root (default: ~/.config/workcell/credentials)
     --agent codex|claude|gemini Agent used for validation and default shared-credential scoping
     --credential KEY            Credential key to configure
@@ -1935,18 +1935,20 @@ Commands:
     --ack-host-resolver         Required with --resolver
 
   unset
-    --injection-policy PATH     Policy file to update
+    --injection-policy PATH     Policy file to update (default: ~/.config/workcell/injection-policy.toml)
     --managed-root PATH         Managed credential root (default: ~/.config/workcell/credentials)
     --credential KEY            Credential key to remove
 
   status
-    --injection-policy PATH     Policy file to inspect
+    --injection-policy PATH     Policy file to inspect (default: ~/.config/workcell/injection-policy.toml)
     --agent codex|claude|gemini Filter to the selected agent
     --mode strict|build|breakglass
     --workspace PATH            Accepted for CLI symmetry; ignored by host status
 
 Notes:
   - auth commands run on the host and do not start the Workcell runtime.
+  - auth set/unset rewrite only the entrypoint policy file; if a credential is
+    declared by an included fragment, update that fragment directly.
   - resolver-backed credentials remain host-side preprocessing and do not
     grant Keychain or provider-home access inside Tier 1.
 EOF
@@ -2444,10 +2446,13 @@ PY
     --output-metadata "${resolver_metadata_path}"
     --output-root "${INJECTION_BUNDLE_ROOT}"
   )
-  if [[ -n "${SELF_STAGING_PROBE_CLAUDE_EXPORT_FILE:-}" ]]; then
+  if [[ "${SELF_STAGING_PROBE_SYNTHETIC_CLAUDE_EXPORT}" == "1" ]]; then
+    synthetic_claude_export="${INJECTION_BUNDLE_ROOT}/self-staging-probe-claude-export.json"
+    umask 077
+    printf '{"token":"claude"}\n' >"${synthetic_claude_export}"
     run_clean_host_command \
       env \
-      "WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE=${SELF_STAGING_PROBE_CLAUDE_EXPORT_FILE}" \
+      "WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE=${synthetic_claude_export}" \
       "${resolver_cmd[@]}" >/dev/null
   else
     run_clean_host_command "${resolver_cmd[@]}" >/dev/null
@@ -3547,10 +3552,10 @@ run_runtime_image_build_with_retries() {
     safe_builder_context="${COLIMA_PROFILE//[^[:alnum:]_.-]/-}"
     BUILDX_BUILDER="workcell-runtime-${safe_builder_context}"
   fi
-  codex_release_url="$(resolve_codex_release_url || true)"
 
   while :; do
     build_status=0
+    codex_release_url="$(resolve_codex_release_url || true)"
     if [[ "${attempt}" -gt 1 ]]; then
       echo "Retrying the runtime image build for profile ${COLIMA_PROFILE} (attempt ${attempt}/${max_attempts})." >&2
       start_managed_profile || build_status=$?
@@ -4732,7 +4737,7 @@ ACK_BREAKGLASS=0
 ACK_CONTROL_PLANE_VCS=0
 ACK_ARBITRARY_COMMAND=0
 TEST_FAIL_AFTER_PROFILE_REFRESH=0
-SELF_STAGING_PROBE_CLAUDE_EXPORT_FILE=""
+SELF_STAGING_PROBE_SYNTHETIC_CLAUDE_EXPORT=0
 declare -a AGENT_ARGS=()
 declare -a NORMALIZED_ARGS=()
 
@@ -4744,7 +4749,7 @@ if [[ "${1:-}" == "--self-staging-probe" ]]; then
   MODE="${4:-strict}"
   ALLOW_CONTROL_PLANE_VCS="${5:-0}"
   PRESERVE_STAGING_PROBE_ARTIFACTS="${6:-0}"
-  SELF_STAGING_PROBE_CLAUDE_EXPORT_FILE="${7:-}"
+  SELF_STAGING_PROBE_SYNTHETIC_CLAUDE_EXPORT="${7:-0}"
 
   [[ -n "${AGENT}" ]] || {
     echo "--self-staging-probe requires AGENT WORKSPACE INJECTION_POLICY [MODE]" >&2
@@ -4763,6 +4768,13 @@ if [[ "${1:-}" == "--self-staging-probe" ]]; then
   WORKSPACE="$(resolve_existing_directory_or_die "${WORKSPACE}")"
   INJECTION_POLICY="$(resolve_host_path "${INJECTION_POLICY}")"
   USE_DEFAULT_INJECTION_POLICY=0
+  case "${SELF_STAGING_PROBE_SYNTHETIC_CLAUDE_EXPORT}" in
+    0 | 1) ;;
+    *)
+      echo "--self-staging-probe synthetic Claude export flag must be 0 or 1" >&2
+      exit 2
+      ;;
+  esac
   prepare_injection_bundle "${AGENT}" "${MODE}"
   prepare_workspace_control_plane_shadow "${WORKSPACE}" "${MODE}"
 

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -93,6 +93,10 @@ SESSION_FILE_TRACE_CONTAINER_FILE="/var/tmp/workcell-file-trace.log"
 FINAL_SESSION_ASSURANCE=""
 INJECTION_POLICY_SHA256=""
 INJECTION_CREDENTIAL_KEYS=""
+INJECTION_CREDENTIAL_INPUT_KINDS=""
+INJECTION_CREDENTIAL_RESOLVERS=""
+INJECTION_CREDENTIAL_MATERIALIZATION=""
+INJECTION_CREDENTIAL_RESOLUTION_STATES=""
 INJECTION_EXTRA_ENDPOINTS=""
 INJECTION_SSH_ENABLED=0
 INJECTION_SECRET_COPY_TARGETS=""
@@ -102,6 +106,7 @@ usage() {
   cat <<'EOF'
 Usage: workcell [options] [-- provider-args...]
        workcell publish-pr [options]
+       workcell auth <init|set|unset|status> [options]
 
 Options:
   --agent codex|claude|gemini   Provider to run (required)
@@ -164,6 +169,10 @@ Workflows:
     workcell --repair-profile --agent claude --workspace /path/to/repo
     workcell --repair-profile --agent gemini --workspace /path/to/repo
   Operator actions:
+    workcell auth init
+    workcell auth set --agent codex --credential codex_auth --source /path/to/auth.json
+    workcell auth set --agent claude --credential claude_auth --resolver claude-macos-keychain --ack-host-resolver
+    workcell auth status --agent codex
     workcell inspect --agent codex --workspace /path/to/repo
     workcell doctor --agent codex --workspace /path/to/repo
     workcell logs debug --colima-profile workcell-...
@@ -621,6 +630,16 @@ declare -a WORKSPACE_IMPORT_MOUNTS=()
 declare -a CACHE_MOUNTS=()
 declare -a RUNTIME_NETWORK_ARGS=()
 
+restore_interactive_host_terminal() {
+  [[ -t 0 ]] && [[ -t 1 ]] || return 0
+  [[ -r /dev/tty ]] && [[ -w /dev/tty ]] || return 0
+
+  # Some interactive provider exits leave the host tty in an alternate-screen
+  # or bracketed-paste mode. Reset it before handing control back to the shell.
+  stty sane </dev/tty >/dev/tty 2>/dev/null || true
+  printf '\033[0m\033[?25h\033[?2004l\033[?1004l\033[?1000l\033[?1002l\033[?1003l\033[?1006l\033[?1049l' >/dev/tty 2>/dev/null || true
+}
+
 # cleanup is only reached through trap 'cleanup' EXIT; validator/CI ShellCheck
 # still misclassifies the trap-only body as unreachable.
 # shellcheck disable=SC2317,SC2329
@@ -680,6 +699,7 @@ cleanup() {
       run_host_colima stop --profile "${COLIMA_PROFILE}" >/dev/null 2>&1 || true
     fi
   fi
+  restore_interactive_host_terminal
 }
 
 trap 'cleanup' EXIT
@@ -1893,8 +1913,290 @@ publish_pr_main() {
   exit 0
 }
 
+auth_usage() {
+  cat <<'EOF'
+Usage: workcell auth init [options]
+       workcell auth set [options]
+       workcell auth unset [options]
+       workcell auth status [options]
+
+Commands:
+  init
+    --injection-policy PATH     Policy file to create or validate
+    --managed-root PATH         Managed credential root (default: ~/.config/workcell/credentials)
+
+  set
+    --injection-policy PATH     Policy file to update
+    --managed-root PATH         Managed credential root (default: ~/.config/workcell/credentials)
+    --agent codex|claude|gemini Agent used for validation and default shared-credential scoping
+    --credential KEY            Credential key to configure
+    --source PATH               Copy PATH into the managed Workcell credential store
+    --resolver NAME             Configure a built-in host resolver
+    --ack-host-resolver         Required with --resolver
+
+  unset
+    --injection-policy PATH     Policy file to update
+    --managed-root PATH         Managed credential root (default: ~/.config/workcell/credentials)
+    --credential KEY            Credential key to remove
+
+  status
+    --injection-policy PATH     Policy file to inspect
+    --agent codex|claude|gemini Filter to the selected agent
+    --mode strict|build|breakglass
+    --workspace PATH            Accepted for CLI symmetry; ignored by host status
+
+Notes:
+  - auth commands run on the host and do not start the Workcell runtime.
+  - resolver-backed credentials remain host-side preprocessing and do not
+    grant Keychain or provider-home access inside Tier 1.
+EOF
+}
+
 default_injection_policy_path() {
   printf '%s/.config/workcell/injection-policy.toml\n' "${REAL_HOME}"
+}
+
+default_managed_credentials_root() {
+  printf '%s/.config/workcell/credentials\n' "${REAL_HOME}"
+}
+
+auth_main() {
+  local subcommand="${1:-}"
+  local policy_path=""
+  local policy_path_explicit=0
+  local managed_root=""
+  local agent=""
+  local credential=""
+  local source_path=""
+  local source_base=""
+  local resolver_name=""
+  local mode="strict"
+  local ack_host_resolver=0
+  local -a auth_cmd=()
+
+  if [[ "${subcommand}" == "-h" ]] || [[ "${subcommand}" == "--help" ]] || [[ "${subcommand}" == "help" ]]; then
+    auth_usage
+    exit 0
+  fi
+  [[ -n "${subcommand}" ]] || {
+    auth_usage >&2
+    exit 2
+  }
+  shift
+
+  policy_path="$(default_injection_policy_path)"
+  managed_root="$(default_managed_credentials_root)"
+
+  case "${subcommand}" in
+    init)
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --injection-policy)
+            policy_path="$(raw_option_value_or_die "$1" "${2-}")"
+            policy_path_explicit=1
+            shift 2
+            ;;
+          --managed-root)
+            managed_root="$(raw_option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          -h | --help)
+            auth_usage
+            exit 0
+            ;;
+          *)
+            echo "Unsupported workcell auth init option: $1" >&2
+            auth_usage >&2
+            exit 2
+            ;;
+        esac
+      done
+      policy_path="$(resolve_host_path "${policy_path}")"
+      managed_root="$(resolve_host_path "${managed_root}")"
+      auth_cmd=(
+        "${HOST_PYTHON3_BIN}"
+        "${ROOT_DIR}/scripts/lib/manage_injection_policy.py"
+        init
+        --policy "${policy_path}"
+        --managed-root "${managed_root}"
+      )
+      run_clean_host_command "${auth_cmd[@]}"
+      exit 0
+      ;;
+    set)
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --injection-policy)
+            policy_path="$(raw_option_value_or_die "$1" "${2-}")"
+            policy_path_explicit=1
+            shift 2
+            ;;
+          --managed-root)
+            managed_root="$(raw_option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          --agent)
+            agent="$(option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          --credential)
+            credential="$(option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          --source)
+            source_path="$(raw_option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          --resolver)
+            resolver_name="$(option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          --ack-host-resolver)
+            ack_host_resolver=1
+            shift
+            ;;
+          -h | --help)
+            auth_usage
+            exit 0
+            ;;
+          *)
+            echo "Unsupported workcell auth set option: $1" >&2
+            auth_usage >&2
+            exit 2
+            ;;
+        esac
+      done
+      [[ -n "${agent}" ]] || {
+        echo "workcell auth set requires --agent." >&2
+        exit 2
+      }
+      [[ -n "${credential}" ]] || {
+        echo "workcell auth set requires --credential." >&2
+        exit 2
+      }
+      if [[ -n "${resolver_name}" ]] && [[ "${ack_host_resolver}" -ne 1 ]]; then
+        echo "workcell auth set requires --ack-host-resolver with --resolver." >&2
+        exit 2
+      fi
+      policy_path="$(resolve_host_path "${policy_path}")"
+      managed_root="$(resolve_host_path "${managed_root}")"
+      auth_cmd=(
+        "${HOST_PYTHON3_BIN}"
+        "${ROOT_DIR}/scripts/lib/manage_injection_policy.py"
+        set
+        --policy "${policy_path}"
+        --managed-root "${managed_root}"
+        --agent "${agent}"
+        --credential "${credential}"
+      )
+      if [[ -n "${source_path}" ]]; then
+        source_base="$(pwd -P)"
+        auth_cmd+=(--source "${source_path}" --source-base "${source_base}")
+      fi
+      if [[ -n "${resolver_name}" ]]; then
+        auth_cmd+=(--resolver "${resolver_name}" --ack-host-resolver)
+      fi
+      run_clean_host_command "${auth_cmd[@]}"
+      exit 0
+      ;;
+    unset)
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --injection-policy)
+            policy_path="$(raw_option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          --managed-root)
+            managed_root="$(raw_option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          --credential)
+            credential="$(option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          -h | --help)
+            auth_usage
+            exit 0
+            ;;
+          *)
+            echo "Unsupported workcell auth unset option: $1" >&2
+            auth_usage >&2
+            exit 2
+            ;;
+        esac
+      done
+      [[ -n "${credential}" ]] || {
+        echo "workcell auth unset requires --credential." >&2
+        exit 2
+      }
+      policy_path="$(resolve_host_path "${policy_path}")"
+      managed_root="$(resolve_host_path "${managed_root}")"
+      auth_cmd=(
+        "${HOST_PYTHON3_BIN}"
+        "${ROOT_DIR}/scripts/lib/manage_injection_policy.py"
+        unset
+        --policy "${policy_path}"
+        --managed-root "${managed_root}"
+        --credential "${credential}"
+      )
+      run_clean_host_command "${auth_cmd[@]}"
+      exit 0
+      ;;
+    status)
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --injection-policy)
+            policy_path="$(raw_option_value_or_die "$1" "${2-}")"
+            policy_path_explicit=1
+            shift 2
+            ;;
+          --agent)
+            agent="$(option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          --mode)
+            mode="$(option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          --workspace)
+            raw_option_value_or_die "$1" "${2-}" >/dev/null
+            shift 2
+            ;;
+          -h | --help)
+            auth_usage
+            exit 0
+            ;;
+          *)
+            echo "Unsupported workcell auth status option: $1" >&2
+            auth_usage >&2
+            exit 2
+            ;;
+        esac
+      done
+      policy_path="$(resolve_host_path "${policy_path}")"
+      if [[ "${policy_path_explicit}" -eq 1 ]] && [[ ! -f "${policy_path}" ]]; then
+        echo "Injection policy file does not exist: ${policy_path}" >&2
+        exit 2
+      fi
+      auth_cmd=(
+        "${HOST_PYTHON3_BIN}"
+        "${ROOT_DIR}/scripts/lib/manage_injection_policy.py"
+        status
+        --policy "${policy_path}"
+        --mode "${mode}"
+      )
+      if [[ -n "${agent}" ]]; then
+        auth_cmd+=(--agent "${agent}")
+      fi
+      run_clean_host_command "${auth_cmd[@]}"
+      exit 0
+      ;;
+    *)
+      echo "Unsupported workcell auth command: ${subcommand}" >&2
+      auth_usage >&2
+      exit 2
+      ;;
+  esac
 }
 
 default_injection_bundle_parent() {
@@ -2065,8 +2367,13 @@ prepare_injection_bundle() {
   local policy_path="${INJECTION_POLICY}"
   local bundle_parent=""
   local default_policy_path=""
+  local resolved_policy_path=""
+  local resolver_metadata_path=""
+  local resolution_mode="launch"
   local manifest_path=""
   local metadata=""
+  local resolver_metadata=""
+  local -a resolver_cmd=()
 
   if [[ -z "${policy_path}" ]] && [[ "${USE_DEFAULT_INJECTION_POLICY}" -eq 1 ]]; then
     default_policy_path="$(default_injection_policy_path)"
@@ -2078,6 +2385,10 @@ prepare_injection_bundle() {
   if [[ -z "${policy_path}" ]]; then
     INJECTION_POLICY_SHA256=""
     INJECTION_CREDENTIAL_KEYS=""
+    INJECTION_CREDENTIAL_INPUT_KINDS=""
+    INJECTION_CREDENTIAL_RESOLVERS=""
+    INJECTION_CREDENTIAL_MATERIALIZATION=""
+    INJECTION_CREDENTIAL_RESOLUTION_STATES=""
     INJECTION_EXTRA_ENDPOINTS=""
     INJECTION_SSH_ENABLED=0
     INJECTION_SSH_CONFIG_ASSURANCE="off"
@@ -2117,10 +2428,36 @@ owner_path.write_text(
 owner_path.chmod(0o600)
 PY
 
+  if [[ "${AUTH_STATUS}" -eq 1 ]] || [[ "${DOCTOR}" -eq 1 ]] || [[ "${INSPECT}" -eq 1 ]] || [[ "${DRY_RUN}" -eq 1 ]]; then
+    resolution_mode="metadata"
+  fi
+  resolved_policy_path="${INJECTION_BUNDLE_ROOT}/resolved-policy.toml"
+  resolver_metadata_path="${INJECTION_BUNDLE_ROOT}/resolver-metadata.json"
+  resolver_cmd=(
+    "${HOST_PYTHON3_BIN}"
+    "${ROOT_DIR}/scripts/lib/resolve_credential_sources.py"
+    --policy "${policy_path}"
+    --agent "${agent}"
+    --mode "${mode}"
+    --resolution-mode "${resolution_mode}"
+    --output-policy "${resolved_policy_path}"
+    --output-metadata "${resolver_metadata_path}"
+    --output-root "${INJECTION_BUNDLE_ROOT}"
+  )
+  if [[ -n "${SELF_STAGING_PROBE_CLAUDE_EXPORT_FILE:-}" ]]; then
+    run_clean_host_command \
+      env \
+      "WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE=${SELF_STAGING_PROBE_CLAUDE_EXPORT_FILE}" \
+      "${resolver_cmd[@]}" >/dev/null
+  else
+    run_clean_host_command "${resolver_cmd[@]}" >/dev/null
+  fi
+
   manifest_path="$(run_clean_host_command \
     "${HOST_PYTHON3_BIN}" \
     "${ROOT_DIR}/scripts/lib/render_injection_bundle.py" \
-    --policy "${policy_path}" \
+    --policy "${resolved_policy_path}" \
+    --policy-metadata "${resolver_metadata_path}" \
     --agent "${agent}" \
     --mode "${mode}" \
     --output-root "${INJECTION_BUNDLE_ROOT}")"
@@ -2166,6 +2503,30 @@ PY
   INJECTION_SSH_ENABLED="$(printf '%s\n' "${metadata}" | sed -n '4p')"
   INJECTION_SSH_CONFIG_ASSURANCE="$(printf '%s\n' "${metadata}" | sed -n '5p')"
   INJECTION_SECRET_COPY_TARGETS="$(printf '%s\n' "${metadata}" | sed -n '6p')"
+  resolver_metadata="$(
+    run_clean_host_command "${HOST_PYTHON3_BIN}" - "${resolver_metadata_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+metadata = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+
+def render_map(name):
+    value = metadata.get(name, {})
+    if not isinstance(value, dict) or not value:
+        return "none"
+    return ",".join(f"{key}:{value[key]}" for key in sorted(value))
+
+print(render_map("credential_input_kinds"))
+print(render_map("credential_resolvers"))
+print(render_map("credential_materialization"))
+print(render_map("credential_resolution_states"))
+PY
+  )"
+  INJECTION_CREDENTIAL_INPUT_KINDS="$(printf '%s\n' "${resolver_metadata}" | sed -n '1p')"
+  INJECTION_CREDENTIAL_RESOLVERS="$(printf '%s\n' "${resolver_metadata}" | sed -n '2p')"
+  INJECTION_CREDENTIAL_MATERIALIZATION="$(printf '%s\n' "${resolver_metadata}" | sed -n '3p')"
+  INJECTION_CREDENTIAL_RESOLUTION_STATES="$(printf '%s\n' "${resolver_metadata}" | sed -n '4p')"
 }
 
 build_recommended_command() {
@@ -2325,6 +2686,32 @@ csv_contains_value() {
   return 1
 }
 
+credential_resolution_state() {
+  local key="$1"
+  local states="${INJECTION_CREDENTIAL_RESOLUTION_STATES:-}"
+  local item=""
+  local IFS=','
+
+  [[ -n "${states}" ]] || return 0
+  for item in ${states}; do
+    [[ -n "${item}" ]] || continue
+    if [[ "${item%%:*}" == "${key}" ]]; then
+      printf '%s\n' "${item#*:}"
+      return 0
+    fi
+  done
+}
+
+credential_is_launch_ready() {
+  local state=""
+
+  state="$(credential_resolution_state "$1")"
+  if [[ -z "${state}" ]] || [[ "${state}" == "source" ]] || [[ "${state}" == "resolved" ]]; then
+    return 0
+  fi
+  return 1
+}
+
 provider_auth_modes() {
   local credential_keys="${INJECTION_CREDENTIAL_KEYS:-}"
   local -a modes=()
@@ -2332,23 +2719,23 @@ provider_auth_modes() {
 
   case "${AGENT:-}" in
     codex)
-      if csv_contains_value "${credential_keys}" "codex_auth"; then
+      if csv_contains_value "${credential_keys}" "codex_auth" && credential_is_launch_ready "codex_auth"; then
         modes+=(codex_auth)
       fi
       ;;
     claude)
-      if csv_contains_value "${credential_keys}" "claude_api_key"; then
+      if csv_contains_value "${credential_keys}" "claude_api_key" && credential_is_launch_ready "claude_api_key"; then
         modes+=(claude_api_key)
       fi
-      if csv_contains_value "${credential_keys}" "claude_auth"; then
+      if csv_contains_value "${credential_keys}" "claude_auth" && credential_is_launch_ready "claude_auth"; then
         modes+=(claude_auth)
       fi
       ;;
     gemini)
-      if csv_contains_value "${credential_keys}" "gemini_env"; then
+      if csv_contains_value "${credential_keys}" "gemini_env" && credential_is_launch_ready "gemini_env"; then
         modes+=(gemini_env)
       fi
-      if csv_contains_value "${credential_keys}" "gemini_oauth"; then
+      if csv_contains_value "${credential_keys}" "gemini_oauth" && credential_is_launch_ready "gemini_oauth"; then
         modes+=(gemini_oauth)
       fi
       ;;
@@ -2366,10 +2753,10 @@ shared_auth_modes() {
   local -a modes=()
   local IFS=','
 
-  if csv_contains_value "${credential_keys}" "github_hosts"; then
+  if csv_contains_value "${credential_keys}" "github_hosts" && credential_is_launch_ready "github_hosts"; then
     modes+=(github_hosts)
   fi
-  if csv_contains_value "${credential_keys}" "github_config"; then
+  if csv_contains_value "${credential_keys}" "github_config" && credential_is_launch_ready "github_config"; then
     modes+=(github_config)
   fi
 
@@ -2390,20 +2777,6 @@ github_auth_present() {
 
 selected_provider_auth_mode() {
   local auth_modes=""
-  local credential_keys="${INJECTION_CREDENTIAL_KEYS:-}"
-
-  if [[ "${AGENT:-}" == "gemini" ]]; then
-    if csv_contains_value "${credential_keys}" "gemini_env"; then
-      printf 'gemini_env\n'
-      return 0
-    fi
-    if csv_contains_value "${credential_keys}" "gemini_oauth"; then
-      printf 'gemini_oauth\n'
-      return 0
-    fi
-    printf 'none\n'
-    return 0
-  fi
 
   auth_modes="$(provider_auth_modes)"
   if [[ "${auth_modes}" == "none" ]]; then
@@ -2449,10 +2822,26 @@ print_injection_status() {
     printf 'injection_policy=none\n'
     printf 'default_injection_policy_path=%s\n' "$(default_injection_policy_path)"
     printf 'supported_credential_keys=codex_auth,claude_api_key,claude_auth,claude_mcp,gemini_env,gemini_oauth,gemini_projects,gcloud_adc,github_config,github_hosts\n'
+    printf 'credential_keys=none\n'
+    printf 'credential_input_kinds=none\n'
+    printf 'credential_resolvers=none\n'
+    printf 'credential_materialization=none\n'
+    printf 'credential_resolution_states=none\n'
+    printf 'provider_auth_mode=none\n'
+    printf 'provider_auth_modes=none\n'
+    printf 'shared_auth_modes=none\n'
+    printf 'github_auth_present=0\n'
+    printf 'ssh_injected=0\n'
+    printf 'ssh_config_assurance=off\n'
+    printf 'secret_copy_targets=none\n'
     return 0
   fi
   printf 'injection_policy_sha256=%s\n' "${INJECTION_POLICY_SHA256}"
   printf 'credential_keys=%s\n' "${INJECTION_CREDENTIAL_KEYS:-none}"
+  printf 'credential_input_kinds=%s\n' "${INJECTION_CREDENTIAL_INPUT_KINDS:-none}"
+  printf 'credential_resolvers=%s\n' "${INJECTION_CREDENTIAL_RESOLVERS:-none}"
+  printf 'credential_materialization=%s\n' "${INJECTION_CREDENTIAL_MATERIALIZATION:-none}"
+  printf 'credential_resolution_states=%s\n' "${INJECTION_CREDENTIAL_RESOLUTION_STATES:-none}"
   printf 'provider_auth_mode=%s\n' "$(selected_provider_auth_mode)"
   printf 'provider_auth_modes=%s\n' "$(provider_auth_modes)"
   printf 'shared_auth_modes=%s\n' "$(shared_auth_modes)"
@@ -3081,17 +3470,84 @@ run_command_with_debug_log() {
   return "${status}"
 }
 
+extract_codex_version_from_dockerfile() {
+  run_clean_host_command "${HOST_PYTHON3_BIN}" - "${ROOT_DIR}/runtime/container/Dockerfile" <<'PY'
+import pathlib
+import re
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+match = re.search(r"^ARG CODEX_VERSION=(.+)$", text, re.MULTILINE)
+if not match:
+    raise SystemExit("Unable to extract CODEX_VERSION from Dockerfile")
+print(match.group(1).strip())
+PY
+}
+
+runtime_build_codex_arch() {
+  local server_arch=""
+
+  server_arch="$(
+    run_workcell_docker_client_command "${HOST_DOCKER_BIN}" version --format '{{.Server.Arch}}' 2>/dev/null
+  )"
+  server_arch="${server_arch//$'\r'/}"
+  server_arch="${server_arch//$'\n'/}"
+  case "${server_arch}" in
+    arm64 | aarch64)
+      printf 'aarch64-unknown-linux-gnu\n'
+      ;;
+    amd64 | x86_64)
+      printf 'x86_64-unknown-linux-gnu\n'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+resolve_codex_release_url() {
+  local codex_arch=""
+  local codex_version=""
+  local release_url=""
+  local resolved_url=""
+
+  codex_arch="$(runtime_build_codex_arch)" || return 0
+  codex_version="$(extract_codex_version_from_dockerfile)" || return 0
+  release_url="https://github.com/openai/codex/releases/download/rust-v${codex_version}/codex-${codex_arch}.tar.gz"
+  resolved_url="$(
+    run_clean_host_command curl -fsSLI \
+      --retry 5 \
+      --retry-all-errors \
+      --retry-delay 5 \
+      --connect-timeout 20 \
+      --max-time 20 \
+      -o /dev/null \
+      -w '%{url_effective}' \
+      "${release_url}" 2>/dev/null || true
+  )"
+  resolved_url="${resolved_url//$'\r'/}"
+  resolved_url="${resolved_url//$'\n'/}"
+  case "${resolved_url}" in
+    https://release-assets.githubusercontent.com/*)
+      printf '%s\n' "${resolved_url}"
+      ;;
+  esac
+}
+
 run_runtime_image_build_with_retries() {
   local build_source_date_epoch="$1"
   local build_status=0
   local attempt=1
   local max_attempts=3
+  local codex_release_url=""
   local safe_builder_context=""
+  local -a build_cmd=()
 
   if [[ -z "${BUILDX_BUILDER:-}" ]]; then
     safe_builder_context="${COLIMA_PROFILE//[^[:alnum:]_.-]/-}"
     BUILDX_BUILDER="workcell-runtime-${safe_builder_context}"
   fi
+  codex_release_url="$(resolve_codex_release_url || true)"
 
   while :; do
     build_status=0
@@ -3122,15 +3578,21 @@ run_runtime_image_build_with_retries() {
       fi
     fi
     ensure_workcell_selected_builder
+    build_cmd=(
+      buildx_cmd build
+      --build-arg "SOURCE_DATE_EPOCH=${build_source_date_epoch}"
+      --provenance=false
+      --sbom=false
+      --load
+      -t "${IMAGE_TAG}"
+      -f "${ROOT_DIR}/runtime/container/Dockerfile"
+      "${ROOT_DIR}"
+    )
+    if [[ -n "${codex_release_url}" ]]; then
+      build_cmd+=(--build-arg "CODEX_RELEASE_URL=${codex_release_url}")
+    fi
     SOURCE_DATE_EPOCH="${build_source_date_epoch}" run_command_with_debug_log runtime-build \
-      buildx_cmd build \
-      --build-arg "SOURCE_DATE_EPOCH=${build_source_date_epoch}" \
-      --provenance=false \
-      --sbom=false \
-      --load \
-      -t "${IMAGE_TAG}" \
-      -f "${ROOT_DIR}/runtime/container/Dockerfile" \
-      "${ROOT_DIR}" || build_status=$?
+      "${build_cmd[@]}" || build_status=$?
     if [[ "${build_status}" -eq 0 ]]; then
       return 0
     fi
@@ -4270,6 +4732,7 @@ ACK_BREAKGLASS=0
 ACK_CONTROL_PLANE_VCS=0
 ACK_ARBITRARY_COMMAND=0
 TEST_FAIL_AFTER_PROFILE_REFRESH=0
+SELF_STAGING_PROBE_CLAUDE_EXPORT_FILE=""
 declare -a AGENT_ARGS=()
 declare -a NORMALIZED_ARGS=()
 
@@ -4281,6 +4744,7 @@ if [[ "${1:-}" == "--self-staging-probe" ]]; then
   MODE="${4:-strict}"
   ALLOW_CONTROL_PLANE_VCS="${5:-0}"
   PRESERVE_STAGING_PROBE_ARTIFACTS="${6:-0}"
+  SELF_STAGING_PROBE_CLAUDE_EXPORT_FILE="${7:-}"
 
   [[ -n "${AGENT}" ]] || {
     echo "--self-staging-probe requires AGENT WORKSPACE INJECTION_POLICY [MODE]" >&2
@@ -4324,6 +4788,11 @@ fi
 if [[ "${1:-}" == "publish-pr" ]]; then
   shift
   publish_pr_main "$@"
+fi
+
+if [[ "${1:-}" == "auth" ]]; then
+  shift
+  auth_main "$@"
 fi
 
 if [[ $# -gt 0 ]]; then
@@ -4680,6 +5149,10 @@ NEEDS_REBUILD=0
 
 if [[ -n "${WORKCELL_EGRESS_HELPER:-}" ]]; then
   echo "WORKCELL_EGRESS_HELPER is reserved for the Workcell test harness." >&2
+  exit 2
+fi
+if [[ -n "${WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE:-}" ]]; then
+  echo "WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE is reserved for the Workcell test harness." >&2
   exit 2
 fi
 
@@ -5093,6 +5566,7 @@ if [[ -n "${AUDIT_TRANSCRIPT_PATH}" ]]; then
 else
   "${DOCKER_RUN[@]}" || DOCKER_STATUS=$?
 fi
+restore_interactive_host_terminal
 capture_session_audit_state "${CONTAINER_NAME}"
 capture_session_file_trace "${CONTAINER_NAME}"
 finalize_session_audit "${COLIMA_PROFILE}" "${EXECUTION_PATH}" "${DOCKER_STATUS}"

--- a/tests/python/test_manage_injection_policy.py
+++ b/tests/python/test_manage_injection_policy.py
@@ -530,7 +530,7 @@ class ManageInjectionPolicyTests(unittest.TestCase):
             self.assertIn("must not be a symlink", result.stderr)
             self.assertFalse((escape_root / "auth.json").exists())
 
-    def test_set_and_unset_remove_old_managed_copy_after_managed_root_migration(self) -> None:
+    def test_switching_managed_roots_requires_cleaning_old_root_first(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             policy_path = root / "injection-policy.toml"
@@ -564,6 +564,13 @@ class ManageInjectionPolicyTests(unittest.TestCase):
                 str(first_source),
             )
             self.assertTrue((old_managed_root / "codex" / "auth.json").is_file())
+            policy_path.write_text(
+                'version = 1\n'
+                '[credentials.codex_auth]\n'
+                'source = "old-credentials/codex/auth.json"\n'
+                'providers = ["codex"]\n',
+                encoding="utf-8",
+            )
 
             self.run_helper(
                 "init",
@@ -572,6 +579,51 @@ class ManageInjectionPolicyTests(unittest.TestCase):
                 "--managed-root",
                 str(new_managed_root),
             )
+            result = self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(new_managed_root),
+                "--agent",
+                "codex",
+                "--credential",
+                "codex_auth",
+                "--source",
+                str(second_source),
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("already managed under a different --managed-root", result.stderr)
+            self.assertTrue((old_managed_root / "codex" / "auth.json").is_file())
+            self.assertFalse((new_managed_root / "codex" / "auth.json").exists())
+
+            result = self.run_helper(
+                "unset",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(new_managed_root),
+                "--credential",
+                "codex_auth",
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("already managed under a different --managed-root", result.stderr)
+            self.assertTrue((old_managed_root / "codex" / "auth.json").is_file())
+            self.assertFalse((new_managed_root / "codex" / "auth.json").exists())
+
+            self.run_helper(
+                "unset",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(old_managed_root),
+                "--credential",
+                "codex_auth",
+            )
+            self.assertFalse((old_managed_root / "codex" / "auth.json").exists())
+
             self.run_helper(
                 "set",
                 "--policy",
@@ -585,19 +637,72 @@ class ManageInjectionPolicyTests(unittest.TestCase):
                 "--source",
                 str(second_source),
             )
-            self.assertFalse((old_managed_root / "codex" / "auth.json").exists())
             self.assertTrue((new_managed_root / "codex" / "auth.json").is_file())
 
+    def test_set_accepts_equivalent_managed_root_alias_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            real_parent = root / "private"
+            alias_parent = root / "alias"
+            managed_root = real_parent / "credentials"
+            first_source = root / "first-auth.json"
+            second_source = root / "second-auth.json"
+            real_parent.mkdir()
+            alias_parent.symlink_to(real_parent, target_is_directory=True)
+            first_source.write_text('{"token":"first"}\n', encoding="utf-8")
+            second_source.write_text('{"token":"second"}\n', encoding="utf-8")
+            first_source.chmod(0o600)
+            second_source.chmod(0o600)
+
             self.run_helper(
-                "unset",
+                "init",
                 "--policy",
                 str(policy_path),
                 "--managed-root",
-                str(new_managed_root),
+                str(managed_root),
+            )
+            self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--agent",
+                "codex",
                 "--credential",
                 "codex_auth",
+                "--source",
+                str(first_source),
             )
-            self.assertFalse((new_managed_root / "codex" / "auth.json").exists())
+
+            alias_source = alias_parent / "credentials" / "codex" / "auth.json"
+            policy_path.write_text(
+                'version = 1\n'
+                '[credentials.codex_auth]\n'
+                f'source = "{alias_source}"\n'
+                'providers = ["codex"]\n',
+                encoding="utf-8",
+            )
+
+            self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--agent",
+                "codex",
+                "--credential",
+                "codex_auth",
+                "--source",
+                str(second_source),
+            )
+
+            self.assertEqual(
+                (managed_root / "codex" / "auth.json").read_text(encoding="utf-8"),
+                '{"token":"second"}\n',
+            )
 
     def test_agentless_status_respects_mode_filter(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/python/test_manage_injection_policy.py
+++ b/tests/python/test_manage_injection_policy.py
@@ -1,0 +1,676 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class ManageInjectionPolicyTests(unittest.TestCase):
+    def run_helper(
+        self,
+        *args: str,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                "scripts/lib/manage_injection_policy.py",
+                *args,
+            ],
+            cwd=Path(__file__).resolve().parents[2],
+            check=check,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_init_set_status_and_unset_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            managed_root = root / "credentials"
+            source_path = root / "auth.json"
+            source_path.write_text("{}\n", encoding="utf-8")
+            source_path.chmod(0o600)
+
+            self.run_helper(
+                "init",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+            )
+            self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--agent",
+                "codex",
+                "--credential",
+                "codex_auth",
+                "--source",
+                str(source_path),
+            )
+            status = self.run_helper(
+                "status",
+                "--policy",
+                str(policy_path),
+                "--agent",
+                "codex",
+            )
+
+            self.assertIn("credential_keys=codex_auth", status.stdout)
+            self.assertIn("credential_input_kinds=codex_auth:source", status.stdout)
+            self.assertIn("provider_auth_mode=codex_auth", status.stdout)
+            self.assertTrue((managed_root / "codex" / "auth.json").is_file())
+
+            unset = self.run_helper(
+                "unset",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--credential",
+                "codex_auth",
+            )
+            self.assertIn("removed=1", unset.stdout)
+            self.assertFalse((managed_root / "codex" / "auth.json").exists())
+
+    def test_set_resolver_records_ephemeral_materialization(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            managed_root = root / "credentials"
+
+            self.run_helper(
+                "init",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+            )
+            self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--agent",
+                "claude",
+                "--credential",
+                "claude_auth",
+                "--resolver",
+                "claude-macos-keychain",
+                "--ack-host-resolver",
+            )
+            status = self.run_helper(
+                "status",
+                "--policy",
+                str(policy_path),
+                "--agent",
+                "claude",
+            )
+
+            self.assertIn("credential_input_kinds=claude_auth:resolver", status.stdout)
+            self.assertIn("credential_resolvers=claude_auth:claude-macos-keychain", status.stdout)
+            self.assertIn("credential_materialization=claude_auth:ephemeral", status.stdout)
+            self.assertIn("credential_resolution_states=claude_auth:configured-only", status.stdout)
+            self.assertIn("provider_auth_mode=none", status.stdout)
+            self.assertIn("provider_auth_modes=none", status.stdout)
+
+    def test_shared_credentials_are_scoped_to_the_requested_agent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            managed_root = root / "credentials"
+            hosts_path = root / "hosts.yml"
+            hosts_path.write_text("github.com:\n", encoding="utf-8")
+            hosts_path.chmod(0o600)
+
+            self.run_helper(
+                "init",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+            )
+            self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--agent",
+                "codex",
+                "--credential",
+                "github_hosts",
+                "--source",
+                str(hosts_path),
+            )
+
+            codex_status = self.run_helper(
+                "status",
+                "--policy",
+                str(policy_path),
+                "--agent",
+                "codex",
+            )
+            claude_status = self.run_helper(
+                "status",
+                "--policy",
+                str(policy_path),
+                "--agent",
+                "claude",
+            )
+
+            self.assertIn("shared_auth_modes=github_hosts", codex_status.stdout)
+            self.assertIn("credential_keys=none", claude_status.stdout)
+            self.assertIn("shared_auth_modes=none", claude_status.stdout)
+
+    def test_set_preserves_existing_selectors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            managed_root = root / "credentials"
+            source_path = root / "auth.json"
+            source_path.write_text("{}\n", encoding="utf-8")
+            source_path.chmod(0o600)
+            policy_path.write_text(
+                'version = 1\n[credentials.codex_auth]\nsource = "/tmp/original.json"\nproviders = ["codex"]\nmodes = ["strict"]\n',
+                encoding="utf-8",
+            )
+
+            self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--agent",
+                "codex",
+                "--credential",
+                "codex_auth",
+                "--source",
+                str(source_path),
+            )
+            rendered = policy_path.read_text(encoding="utf-8")
+
+            self.assertIn('providers = ["codex"]', rendered)
+            self.assertIn('modes = ["strict"]', rendered)
+
+    def test_set_preserves_existing_shared_github_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            managed_root = root / "credentials"
+            hosts_path = root / "hosts.yml"
+            hosts_path.write_text("github.com:\n", encoding="utf-8")
+            hosts_path.chmod(0o600)
+            policy_path.write_text(
+                'version = 1\n[credentials.github_hosts]\nsource = "/tmp/original-hosts.yml"\nproviders = ["codex", "claude"]\n',
+                encoding="utf-8",
+            )
+
+            self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--agent",
+                "codex",
+                "--credential",
+                "github_hosts",
+                "--source",
+                str(hosts_path),
+            )
+            rendered = policy_path.read_text(encoding="utf-8")
+
+            self.assertIn('providers = ["codex", "claude"]', rendered)
+
+    def test_status_rejects_conflicting_source_and_resolver(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            policy_path.write_text(
+                'version = 1\n[credentials.claude_auth]\nsource = "/tmp/auth.json"\nresolver = "claude-macos-keychain"\nmaterialization = "ephemeral"\n',
+                encoding="utf-8",
+            )
+
+            status = self.run_helper(
+                "status",
+                "--policy",
+                str(policy_path),
+                "--agent",
+                "claude",
+                check=False,
+            )
+
+            self.assertNotEqual(status.returncode, 0)
+            self.assertIn(
+                "credentials.claude_auth must not declare both source and resolver",
+                status.stderr,
+            )
+
+    def test_status_rejects_conflicting_source_and_resolver_without_agent_filter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            policy_path.write_text(
+                'version = 1\n[credentials.claude_auth]\nsource = "/tmp/auth.json"\nresolver = "claude-macos-keychain"\nmaterialization = "ephemeral"\n',
+                encoding="utf-8",
+            )
+
+            status = self.run_helper(
+                "status",
+                "--policy",
+                str(policy_path),
+                check=False,
+            )
+
+            self.assertNotEqual(status.returncode, 0)
+            self.assertIn(
+                "credentials.claude_auth must not declare both source and resolver",
+                status.stderr,
+            )
+
+    def test_agentless_status_rejects_unsupported_resolver(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            policy_path.write_text(
+                'version = 1\n[credentials.claude_auth]\nresolver = "bogus"\nmaterialization = "ephemeral"\n',
+                encoding="utf-8",
+            )
+
+            status = self.run_helper(
+                "status",
+                "--policy",
+                str(policy_path),
+                check=False,
+            )
+
+            self.assertNotEqual(status.returncode, 0)
+            self.assertIn(
+                "credentials.claude_auth.resolver is unsupported: bogus",
+                status.stderr,
+            )
+
+    def test_agentless_status_validates_selector_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            policy_path.write_text(
+                'version = 1\n[credentials.codex_auth]\nsource = "/tmp/auth.json"\nproviders = ["bogus"]\n',
+                encoding="utf-8",
+            )
+
+            status = self.run_helper(
+                "status",
+                "--policy",
+                str(policy_path),
+                check=False,
+            )
+
+            self.assertNotEqual(status.returncode, 0)
+            self.assertIn(
+                "credentials.codex_auth.providers contains unsupported value: bogus",
+                status.stderr,
+            )
+
+    def test_status_rejects_shared_github_credentials_without_providers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            policy_path.write_text(
+                'version = 1\n[credentials.github_hosts]\nsource = "/tmp/hosts.yml"\n',
+                encoding="utf-8",
+            )
+
+            status = self.run_helper(
+                "status",
+                "--policy",
+                str(policy_path),
+                "--agent",
+                "codex",
+                check=False,
+            )
+
+            self.assertNotEqual(status.returncode, 0)
+            self.assertIn(
+                "credentials.github_hosts.providers is required so shared GitHub credentials stay least-privilege",
+                status.stderr,
+            )
+
+    def test_set_rejects_credential_declared_in_included_fragment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            fragment_path = root / "fragment.toml"
+            managed_root = root / "credentials"
+            source_path = root / "auth.json"
+            source_path.write_text("{}\n", encoding="utf-8")
+            source_path.chmod(0o600)
+            fragment_path.write_text(
+                'version = 1\n[credentials.codex_auth]\nsource = "/tmp/original.json"\n',
+                encoding="utf-8",
+            )
+            policy_path.write_text(
+                'version = 1\nincludes = ["fragment.toml"]\n',
+                encoding="utf-8",
+            )
+
+            result = self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--agent",
+                "codex",
+                "--credential",
+                "codex_auth",
+                "--source",
+                str(source_path),
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("declared by an included policy fragment", result.stderr)
+
+    def test_unset_rejects_credential_declared_in_included_fragment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            fragment_path = root / "fragment.toml"
+            managed_root = root / "credentials"
+            fragment_path.write_text(
+                'version = 1\n[credentials.codex_auth]\nsource = "/tmp/original.json"\n',
+                encoding="utf-8",
+            )
+            policy_path.write_text(
+                'version = 1\nincludes = ["fragment.toml"]\n',
+                encoding="utf-8",
+            )
+
+            result = self.run_helper(
+                "unset",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--credential",
+                "codex_auth",
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("declared by an included policy fragment", result.stderr)
+
+    def test_set_source_rolls_back_managed_copy_when_policy_write_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            managed_root = root / "credentials"
+            source_path = root / "auth.json"
+            source_path.write_text('{"token":"next"}\n', encoding="utf-8")
+            source_path.chmod(0o600)
+            policy_path.write_text(
+                'version = 1\nunexpected = "value"\n[credentials.codex_auth]\nsource = "/tmp/original.json"\n',
+                encoding="utf-8",
+            )
+
+            result = self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--agent",
+                "codex",
+                "--credential",
+                "codex_auth",
+                "--source",
+                str(source_path),
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse((managed_root / "codex" / "auth.json").exists())
+            self.assertFalse((managed_root / ".workcell-managed-root").exists())
+
+    def test_status_rejects_missing_managed_source_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            managed_root = root / "credentials"
+            source_path = root / "auth.json"
+            source_path.write_text("{}\n", encoding="utf-8")
+            source_path.chmod(0o600)
+
+            self.run_helper(
+                "init",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+            )
+            self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--agent",
+                "codex",
+                "--credential",
+                "codex_auth",
+                "--source",
+                str(source_path),
+            )
+            (managed_root / "codex" / "auth.json").unlink()
+
+            status = self.run_helper(
+                "status",
+                "--policy",
+                str(policy_path),
+                "--agent",
+                "codex",
+                check=False,
+            )
+
+            self.assertNotEqual(status.returncode, 0)
+            self.assertIn("does not exist", status.stderr)
+
+    def test_status_without_policy_reports_resolution_states_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "missing-policy.toml"
+
+            status = self.run_helper(
+                "status",
+                "--policy",
+                str(policy_path),
+            )
+
+            self.assertIn("credential_resolution_states=none", status.stdout)
+
+    def test_set_rejects_symlinked_managed_root_destination(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            managed_root = root / "credentials"
+            managed_root.mkdir()
+            escape_root = root / "escape"
+            escape_root.mkdir()
+            (managed_root / "codex").symlink_to(escape_root, target_is_directory=True)
+            source_path = root / "auth.json"
+            source_path.write_text("{}\n", encoding="utf-8")
+            source_path.chmod(0o600)
+
+            result = self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--agent",
+                "codex",
+                "--credential",
+                "codex_auth",
+                "--source",
+                str(source_path),
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("must not be a symlink", result.stderr)
+            self.assertFalse((escape_root / "auth.json").exists())
+
+    def test_set_and_unset_remove_old_managed_copy_after_managed_root_migration(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            old_managed_root = root / "old-credentials"
+            new_managed_root = root / "new-credentials"
+            first_source = root / "first-auth.json"
+            second_source = root / "second-auth.json"
+            first_source.write_text('{"token":"old"}\n', encoding="utf-8")
+            second_source.write_text('{"token":"new"}\n', encoding="utf-8")
+            first_source.chmod(0o600)
+            second_source.chmod(0o600)
+
+            self.run_helper(
+                "init",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(old_managed_root),
+            )
+            self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(old_managed_root),
+                "--agent",
+                "codex",
+                "--credential",
+                "codex_auth",
+                "--source",
+                str(first_source),
+            )
+            self.assertTrue((old_managed_root / "codex" / "auth.json").is_file())
+
+            self.run_helper(
+                "init",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(new_managed_root),
+            )
+            self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(new_managed_root),
+                "--agent",
+                "codex",
+                "--credential",
+                "codex_auth",
+                "--source",
+                str(second_source),
+            )
+            self.assertFalse((old_managed_root / "codex" / "auth.json").exists())
+            self.assertTrue((new_managed_root / "codex" / "auth.json").is_file())
+
+            self.run_helper(
+                "unset",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(new_managed_root),
+                "--credential",
+                "codex_auth",
+            )
+            self.assertFalse((new_managed_root / "codex" / "auth.json").exists())
+
+    def test_agentless_status_respects_mode_filter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            policy_path.write_text(
+                'version = 1\n[credentials.codex_auth]\nsource = "/tmp/auth.json"\nmodes = ["strict"]\n',
+                encoding="utf-8",
+            )
+
+            status = self.run_helper(
+                "status",
+                "--policy",
+                str(policy_path),
+                "--mode",
+                "build",
+            )
+
+            self.assertIn("credential_keys=none", status.stdout)
+
+    def test_init_failure_does_not_create_managed_root_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            managed_root = root / "credentials"
+            policy_path.write_text('version = 1\nunexpected = "value"\n', encoding="utf-8")
+
+            result = self.run_helper(
+                "init",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse((managed_root / ".workcell-managed-root").exists())
+
+    def test_set_source_accepts_relative_paths_with_source_base(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "injection-policy.toml"
+            managed_root = root / "credentials"
+            source_path = root / "auth.json"
+            source_path.write_text("{}\n", encoding="utf-8")
+            source_path.chmod(0o600)
+
+            self.run_helper(
+                "init",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+            )
+            self.run_helper(
+                "set",
+                "--policy",
+                str(policy_path),
+                "--managed-root",
+                str(managed_root),
+                "--agent",
+                "codex",
+                "--credential",
+                "codex_auth",
+                "--source",
+                "./auth.json",
+                "--source-base",
+                str(root),
+            )
+
+            self.assertTrue((managed_root / "codex" / "auth.json").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_policy_bundle.py
+++ b/tests/python/test_policy_bundle.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+from pathlib import Path
+
+from test_support import load_module
+
+
+class PolicyBundleTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = load_module("scripts/lib/policy_bundle.py")
+
+    def test_load_policy_bundle_merges_includes_and_tracks_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "common.md").write_text("common\n", encoding="utf-8")
+            (root / "auth.json").write_text("{}\n", encoding="utf-8")
+            (root / "common.md").chmod(0o600)
+            (root / "auth.json").chmod(0o600)
+            (root / "shared.toml").write_text(
+                '[documents]\ncommon = "common.md"\n',
+                encoding="utf-8",
+            )
+            root_policy = root / "policy.toml"
+            root_policy.write_text(
+                'version = 1\nincludes = ["shared.toml"]\n[credentials]\ncodex_auth = "auth.json"\n',
+                encoding="utf-8",
+            )
+
+            merged_policy, policy_sources = self.module.load_policy_bundle(root_policy)
+
+            self.assertEqual(
+                merged_policy["documents"]["common"],
+                str((root / "common.md").resolve()),
+            )
+            self.assertEqual(merged_policy["credentials"]["codex_auth"], "auth.json")
+            self.assertEqual(
+                [entry["path"] for entry in policy_sources],
+                ["shared.toml", "policy.toml"],
+            )
+
+    def test_render_policy_toml_round_trips_resolver_entry(self) -> None:
+        policy = {
+            "version": 1,
+            "credentials": {
+                "codex_auth": {"source": "/tmp/codex-auth.json"},
+                "claude_auth": {
+                    "resolver": "claude-macos-keychain",
+                    "materialization": "ephemeral",
+                },
+            },
+        }
+
+        rendered = self.module.render_policy_toml(policy)
+        reparsed = self.module.parse_toml_subset(rendered, Path("/tmp/policy.toml"))
+
+        self.assertEqual(reparsed["credentials"]["codex_auth"]["source"], "/tmp/codex-auth.json")
+        self.assertEqual(
+            reparsed["credentials"]["claude_auth"]["resolver"],
+            "claude-macos-keychain",
+        )
+        self.assertEqual(
+            reparsed["credentials"]["claude_auth"]["materialization"],
+            "ephemeral",
+        )
+
+    def test_validation_helpers_reject_invalid_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            inside = root / "inside.txt"
+            inside.write_text("ok\n", encoding="utf-8")
+            inside.chmod(0o600)
+            outside = root.parent / "outside.txt"
+            outside.write_text("outside\n", encoding="utf-8")
+            expected_inside = self.module.expand_host_path("inside.txt", root)
+
+            self.assertEqual(
+                expected_inside,
+                Path(os.path.abspath(os.fspath(inside))),
+            )
+            self.module.require_path_within(root, expected_inside, "inside")
+            with self.assertRaises(SystemExit):
+                self.module.require_path_within(root, outside, "outside")
+
+            self.assertEqual(
+                self.module.validate_source_path("inside.txt", "inside", root),
+                expected_inside,
+            )
+            with self.assertRaises(SystemExit):
+                self.module.validate_source_path("", "empty", root)
+            with self.assertRaises(SystemExit):
+                self.module.validate_source_path("missing.txt", "missing", root)
+
+            symlink_path = root / "link.txt"
+            symlink_path.symlink_to(inside)
+            with self.assertRaises(SystemExit):
+                self.module.require_no_symlink_in_path_chain(symlink_path, "link")
+            with self.assertRaises(SystemExit):
+                self.module.require_secret_file(symlink_path, "link")
+
+            world_readable = root / "world.txt"
+            world_readable.write_text("secret\n", encoding="utf-8")
+            world_readable.chmod(0o644)
+            with self.assertRaises(SystemExit):
+                self.module.require_secret_file(world_readable, "world")
+
+    def test_selection_comment_and_value_helpers_cover_error_paths(self) -> None:
+        self.assertTrue(
+            self.module.selected_for(None, "codex", "providers", self.module.SUPPORTED_AGENTS)
+        )
+        self.assertFalse(
+            self.module.selected_for(
+                ["claude"],
+                "codex",
+                "providers",
+                self.module.SUPPORTED_AGENTS,
+            )
+        )
+        for invalid in ([], ["codex", 1], ["unknown"]):
+            with self.assertRaises(SystemExit):
+                self.module.selected_for(
+                    invalid,
+                    "codex",
+                    "providers",
+                    self.module.SUPPORTED_AGENTS,
+                )
+
+        self.assertEqual(
+            self.module.strip_comment('value = "a # b" # tail'),
+            'value = "a # b"',
+        )
+        self.assertEqual(
+            self.module.strip_comment(r'value = "a \" # b" # tail'),
+            r'value = "a \" # b"',
+        )
+
+        policy_path = Path("/tmp/policy.toml")
+        self.assertTrue(self.module.parse_value("true", policy_path, 1))
+        self.assertEqual(self.module.parse_value('"value"', policy_path, 1), "value")
+        self.assertEqual(self.module.parse_value('["codex"]', policy_path, 1), ["codex"])
+        self.assertEqual(self.module.parse_value("7", policy_path, 1), 7)
+        for raw in ("", "[1]", "{bad = true}"):
+            with self.assertRaises(SystemExit):
+                self.module.parse_value(raw, policy_path, 1)
+
+    def test_parse_toml_subset_rejects_invalid_structures(self) -> None:
+        policy_path = Path("/tmp/policy.toml")
+        invalid_cases = [
+            "[[unknown]]\n",
+            "[documents]\n[documents]\n",
+            "[credentials.unknown]\nsource = \"/tmp/x\"\n",
+            "[unknown]\nvalue = 1\n",
+            "invalid-line\n",
+            ' = "value"\n',
+            'a.b = "value"\n',
+            'value = "one"\nvalue = "two"\n',
+            '[credentials]\ncodex_auth = "/tmp/x"\n[credentials.codex_auth]\nsource = "/tmp/y"\n',
+        ]
+        for content in invalid_cases:
+            with self.subTest(content=content):
+                with self.assertRaises(SystemExit):
+                    self.module.parse_toml_subset(content, policy_path)
+
+    def test_parse_toml_subset_covers_copies_and_type_corruption_guards(self) -> None:
+        policy_path = Path("/tmp/policy.toml")
+
+        parsed = self.module.parse_toml_subset(
+            '[[copies]]\nsource = "/tmp/source.txt"\ntarget = "/state/injected/source.txt"\n',
+            policy_path,
+        )
+        self.assertEqual(
+            parsed["copies"],
+            [{"source": "/tmp/source.txt", "target": "/state/injected/source.txt"}],
+        )
+
+        invalid_cases = [
+            'copies = "bad"\n[[copies]]\nsource = "/tmp/source.txt"\n',
+            'credentials = "bad"\n[credentials.codex_auth]\nsource = "/tmp/auth.json"\n',
+            'documents = "bad"\n[documents]\ncommon = "/tmp/common.md"\n',
+        ]
+        for content in invalid_cases:
+            with self.subTest(content=content):
+                with self.assertRaises(SystemExit):
+                    self.module.parse_toml_subset(content, policy_path)
+
+    def test_rebase_merge_and_load_helpers_cover_nested_and_error_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            fragment_dir = root / "fragment"
+            fragment_dir.mkdir()
+            (fragment_dir / "doc.md").write_text("doc\n", encoding="utf-8")
+            (fragment_dir / "copy.txt").write_text("copy\n", encoding="utf-8")
+            (fragment_dir / "id_key").write_text("key\n", encoding="utf-8")
+            (fragment_dir / "auth.json").write_text("{}\n", encoding="utf-8")
+            rebased = self.module.rebase_policy_fragment(
+                {
+                    "documents": {"common": "doc.md"},
+                    "copies": [{"source": "copy.txt", "target": "/state/injected/copy.txt"}, "literal"],
+                    "ssh": {
+                        "config": "ssh_config",
+                        "known_hosts": "known_hosts",
+                        "identities": ["id_key"],
+                    },
+                    "credentials": {
+                        "codex_auth": "auth.json",
+                        "github_hosts": {"source": "hosts.yml", "providers": ["codex"]},
+                    },
+                    "version": 1,
+                },
+                fragment_dir,
+            )
+            expected = lambda relative: str(
+                self.module.expand_host_path(relative, fragment_dir)
+            )
+            self.assertEqual(
+                rebased["documents"]["common"],
+                expected("doc.md"),
+            )
+            self.assertEqual(
+                rebased["copies"][1],
+                "literal",
+            )
+            self.assertEqual(
+                rebased["ssh"]["identities"][0],
+                expected("id_key"),
+            )
+            self.assertEqual(
+                rebased["credentials"]["github_hosts"]["source"],
+                expected("hosts.yml"),
+            )
+
+            for addition in (
+                {"version": 2},
+                {"documents": []},
+                {"copies": {}},
+            ):
+                with self.assertRaises(SystemExit):
+                    self.module.merge_policy_fragment({}, addition, root / "bad.toml")
+
+            with self.assertRaises(SystemExit):
+                self.module.merge_policy_fragment(
+                    {"documents": {"common": "a"}},
+                    {"documents": {"common": "b"}},
+                    root / "dup.toml",
+                )
+
+            (root / "doc.md").write_text("doc\n", encoding="utf-8")
+            (root / "shared.toml").write_text(
+                '[documents]\ncommon = "doc.md"\n',
+                encoding="utf-8",
+            )
+            (root / "policy.toml").write_text(
+                'version = 1\nincludes = ["shared.toml"]\n',
+                encoding="utf-8",
+            )
+            merged, sources = self.module.load_policy_bundle(root / "policy.toml")
+            self.assertEqual(
+                merged["documents"]["common"],
+                str((root / "doc.md").resolve()),
+            )
+            self.assertEqual(
+                [entry["path"] for entry in sources],
+                ["shared.toml", "policy.toml"],
+            )
+
+            (root / "cycle-a.toml").write_text('version = 1\nincludes = ["cycle-b.toml"]\n', encoding="utf-8")
+            (root / "cycle-b.toml").write_text('version = 1\nincludes = ["cycle-a.toml"]\n', encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                self.module.load_policy_bundle(root / "cycle-a.toml")
+
+            (root / "dup-policy.toml").write_text(
+                'version = 1\nincludes = ["shared.toml", "shared.toml"]\n',
+                encoding="utf-8",
+            )
+            with self.assertRaises(SystemExit):
+                self.module.load_policy_bundle(root / "dup-policy.toml")
+
+            self.assertEqual(
+                self.module.load_raw_policy(root / "missing.toml"),
+                {"version": 1},
+            )
+
+    def test_helper_guards_cover_versions_includes_and_corrupted_merge_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self.module.validate_allowed_keys({"version": 1}, {"version"}, "policy")
+            with self.assertRaises(SystemExit):
+                self.module.validate_allowed_keys({"unexpected": True}, {"version"}, "policy")
+
+            self.assertTrue(
+                self.module.composite_policy_sha256(
+                    [
+                        {"path": "b.toml", "sha256": "sha256:b"},
+                        {"path": "a.toml", "sha256": "sha256:a"},
+                    ]
+                ).startswith("sha256:")
+            )
+            self.assertEqual(self.module.rebase_fragment_path("", root), "")
+            marker = object()
+            self.assertIs(self.module.rebase_fragment_path(marker, root), marker)
+
+            include_dir = root / "fragment"
+            include_dir.mkdir()
+            with self.assertRaises(SystemExit):
+                self.module.validate_policy_include("fragment", "include", root, root)
+
+            with self.assertRaises(SystemExit):
+                self.module.merge_policy_fragment(
+                    {"documents": []},
+                    {"documents": {"common": "/tmp/common.md"}},
+                    root / "broken-docs.toml",
+                )
+            with self.assertRaises(SystemExit):
+                self.module.merge_policy_fragment(
+                    {"copies": {}},
+                    {"copies": [{"source": "/tmp/source.txt"}]},
+                    root / "broken-copies.toml",
+                )
+
+            version_2 = root / "version-2.toml"
+            version_2.write_text("version = 2\n", encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                self.module.load_policy_bundle(version_2)
+
+            include_string = root / "include-string.toml"
+            include_string.write_text(
+                'version = 1\nincludes = "shared.toml"\n',
+                encoding="utf-8",
+            )
+            with self.assertRaises(SystemExit):
+                self.module.load_policy_bundle(include_string)
+
+            with mock.patch.object(self.module, "parse_toml_subset", return_value=[]):
+                with self.assertRaises(SystemExit):
+                    self.module.load_policy_bundle(version_2)
+
+            with mock.patch.object(
+                self.module,
+                "parse_toml_subset",
+                return_value={"version": 1, "includes": None},
+            ):
+                merged, sources = self.module.load_policy_bundle(version_2)
+            self.assertEqual(merged, {"version": 1})
+            self.assertEqual(len(sources), 1)
+
+            raw_policy = root / "raw-policy.toml"
+            raw_policy.write_text('[documents]\ncommon = "/tmp/common.md"\n', encoding="utf-8")
+            loaded_raw = self.module.load_raw_policy(raw_policy)
+            self.assertEqual(loaded_raw["version"], 1)
+            self.assertEqual(loaded_raw["documents"]["common"], "/tmp/common.md")
+
+            raw_version_2 = root / "raw-version-2.toml"
+            raw_version_2.write_text("version = 2\n", encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                self.module.load_raw_policy(raw_version_2)
+
+            with mock.patch.object(self.module, "parse_toml_subset", return_value=[]):
+                with self.assertRaises(SystemExit):
+                    self.module.load_raw_policy(raw_policy)
+
+    def test_render_helpers_cover_supported_and_invalid_shapes(self) -> None:
+        self.assertEqual(self.module.quote_string("line\nbreak"), '"line\\nbreak"')
+        self.assertEqual(self.module.render_toml_value(False), "false")
+        self.assertEqual(self.module.render_toml_value(3), "3")
+        self.assertEqual(self.module.render_toml_value("value"), '"value"')
+        self.assertEqual(
+            self.module.render_toml_value(["codex", "claude"]),
+            '["codex", "claude"]',
+        )
+        with self.assertRaises(SystemExit):
+            self.module.render_toml_value([1])
+        with self.assertRaises(SystemExit):
+            self.module.render_toml_value({"bad": "value"})
+
+        rendered = self.module.render_policy_toml(
+            {
+                "version": 1,
+                "includes": ["shared.toml"],
+                "documents": {"common": "/tmp/common.md"},
+                "credentials": {
+                    "codex_auth": "/tmp/auth.json",
+                    "github_hosts": {"source": "/tmp/hosts.yml", "providers": ["codex"]},
+                },
+                "ssh": {
+                    "enabled": True,
+                    "config": "/tmp/config",
+                    "known_hosts": "/tmp/known_hosts",
+                    "identities": ["/tmp/id_key"],
+                },
+                "copies": [
+                    {
+                        "source": "/tmp/source.txt",
+                        "target": "/state/injected/source.txt",
+                        "classification": "public",
+                    }
+                ],
+            }
+        )
+        self.assertIn('includes = ["shared.toml"]', rendered)
+        self.assertIn("[documents]", rendered)
+        self.assertIn("[credentials]", rendered)
+        self.assertIn("[credentials.github_hosts]", rendered)
+        self.assertIn("[ssh]", rendered)
+        self.assertIn("[[copies]]", rendered)
+
+        rendered_with_extras = self.module.render_policy_toml(
+            {
+                "version": 1,
+                "ssh": {"enabled": True, "proxy_jump": "bastion"},
+                "copies": [
+                    {
+                        "source": "/tmp/source.txt",
+                        "target": "/state/injected/source.txt",
+                        "classification": "public",
+                        "note": "extra",
+                    }
+                ],
+            }
+        )
+        self.assertIn('proxy_jump = "bastion"', rendered_with_extras)
+        self.assertIn('note = "extra"', rendered_with_extras)
+
+        with self.assertRaises(SystemExit):
+            self.module.render_policy_toml({"version": 1, "copies": ["bad"]})
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "policy.toml"
+            self.module.write_policy_file(policy_path, {"version": 1})
+            self.assertEqual(policy_path.read_text(encoding="utf-8"), "version = 1\n")
+            self.assertEqual(policy_path.stat().st_mode & 0o777, 0o600)
+
+    def test_require_secret_file_rejects_non_files_and_wrong_owners(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            directory = root / "directory"
+            directory.mkdir()
+            with self.assertRaises(SystemExit):
+                self.module.require_secret_file(directory, "directory")
+
+            owned = root / "owned.txt"
+            owned.write_text("secret\n", encoding="utf-8")
+            owned.chmod(0o600)
+            with mock.patch.object(
+                self.module.os,
+                "getuid",
+                return_value=os.getuid() + 1,
+            ):
+                with self.assertRaises(SystemExit):
+                    self.module.require_secret_file(owned, "owned")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_render_injection_bundle.py
+++ b/tests/python/test_render_injection_bundle.py
@@ -134,6 +134,73 @@ class RenderInjectionBundleTests(unittest.TestCase):
                 manifest_b["metadata"]["policy_sha256"],
             )
 
+    def test_policy_metadata_override_preserves_original_entrypoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            credential_path = root / "auth.json"
+            credential_path.write_text('{"token":"one"}\n', encoding="utf-8")
+            credential_path.chmod(0o600)
+
+            override_path = root / "policy-metadata.json"
+            override_path.write_text(
+                json.dumps(
+                    {
+                        "policy_entrypoint": "policy.toml",
+                        "policy_sources": [
+                            {
+                                "path": "policy.toml",
+                                "sha256": "sha256:original",
+                            }
+                        ],
+                    },
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            manifests = []
+            for name in ("resolved-a.toml", "resolved-b.toml"):
+                policy_path = root / name
+                bundle_root = root / f"bundle-{name}"
+                policy_path.write_text(
+                    f'version = 1\n[credentials.codex_auth]\nsource = "{credential_path}"\n',
+                    encoding="utf-8",
+                )
+                subprocess.run(
+                    [
+                        sys.executable,
+                        str(Path(self.module.__file__).resolve()),
+                        "--policy",
+                        str(policy_path),
+                        "--policy-metadata",
+                        str(override_path),
+                        "--agent",
+                        "codex",
+                        "--mode",
+                        "strict",
+                        "--output-root",
+                        str(bundle_root),
+                    ],
+                    check=True,
+                )
+                manifests.append(
+                    json.loads((bundle_root / "manifest.json").read_text(encoding="utf-8"))
+                )
+
+            self.assertEqual(
+                manifests[0]["metadata"]["policy_entrypoint"],
+                "policy.toml",
+            )
+            self.assertEqual(
+                manifests[0]["metadata"]["policy_sources"][0]["path"],
+                "policy.toml",
+            )
+            self.assertEqual(
+                manifests[0]["metadata"]["policy_sha256"],
+                manifests[1]["metadata"]["policy_sha256"],
+            )
+
     def test_load_policy_bundle_rejects_parent_escape_includes(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/tests/python/test_resolve_credential_sources.py
+++ b/tests/python/test_resolve_credential_sources.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class ResolveCredentialSourcesTests(unittest.TestCase):
+    def run_helper(
+        self,
+        policy_path: Path,
+        agent: str,
+        mode: str,
+        resolution_mode: str,
+        output_root: Path,
+        extra_env: dict[str, str] | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        output_policy = output_root / "resolved-policy.toml"
+        output_metadata = output_root / "resolver-metadata.json"
+        env = os.environ.copy()
+        if extra_env:
+            env.update(extra_env)
+        return subprocess.run(
+            [
+                sys.executable,
+                "scripts/lib/resolve_credential_sources.py",
+                "--policy",
+                str(policy_path),
+                "--agent",
+                agent,
+                "--mode",
+                mode,
+                "--resolution-mode",
+                resolution_mode,
+                "--output-policy",
+                str(output_policy),
+                "--output-metadata",
+                str(output_metadata),
+                "--output-root",
+                str(output_root),
+            ],
+            cwd=Path(__file__).resolve().parents[2],
+            check=check,
+            text=True,
+            capture_output=True,
+            env=env,
+        )
+
+    def test_metadata_mode_rewrites_claude_resolver_to_placeholder_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "policy.toml"
+            policy_path.write_text(
+                'version = 1\n[credentials.claude_auth]\nresolver = "claude-macos-keychain"\nmaterialization = "ephemeral"\n',
+                encoding="utf-8",
+            )
+
+            self.run_helper(policy_path, "claude", "strict", "metadata", root)
+
+            resolved_policy = (root / "resolved-policy.toml").read_text(encoding="utf-8")
+            metadata = json.loads((root / "resolver-metadata.json").read_text(encoding="utf-8"))
+
+            self.assertIn('source = ', resolved_policy)
+            self.assertEqual(
+                metadata["credential_resolvers"]["claude_auth"],
+                "claude-macos-keychain",
+            )
+            self.assertEqual(
+                metadata["credential_resolution_states"]["claude_auth"],
+                "configured-only",
+            )
+
+    def test_launch_mode_fails_closed_without_supported_export_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "policy.toml"
+            policy_path.write_text(
+                'version = 1\n[credentials.claude_auth]\nresolver = "claude-macos-keychain"\nmaterialization = "ephemeral"\n',
+                encoding="utf-8",
+            )
+
+            result = self.run_helper(
+                policy_path,
+                "claude",
+                "strict",
+                "launch",
+                root,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Claude macOS login reuse is configured", result.stderr)
+
+    def test_launch_mode_accepts_test_export_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "policy.toml"
+            export_path = root / "claude-export.json"
+            export_path.write_text('{"token":"claude"}\n', encoding="utf-8")
+            export_path.chmod(0o600)
+            policy_path.write_text(
+                'version = 1\n[credentials.claude_auth]\nresolver = "claude-macos-keychain"\nmaterialization = "ephemeral"\n',
+                encoding="utf-8",
+            )
+
+            self.run_helper(
+                policy_path,
+                "claude",
+                "strict",
+                "launch",
+                root,
+                extra_env={"WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE": str(export_path)},
+            )
+
+            metadata = json.loads((root / "resolver-metadata.json").read_text(encoding="utf-8"))
+            resolved_policy = (root / "resolved-policy.toml").read_text(encoding="utf-8")
+
+            self.assertEqual(
+                metadata["credential_resolution_states"]["claude_auth"],
+                "resolved",
+            )
+            self.assertIn("resolved/credentials/claude_auth.json", resolved_policy)
+
+    def test_provider_filtered_resolver_entry_is_dropped_without_crashing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            policy_path = root / "policy.toml"
+            policy_path.write_text(
+                'version = 1\n[credentials.claude_auth]\nresolver = "claude-macos-keychain"\nmaterialization = "ephemeral"\nproviders = ["codex"]\n',
+                encoding="utf-8",
+            )
+
+            self.run_helper(policy_path, "claude", "strict", "metadata", root)
+
+            resolved_policy = (root / "resolved-policy.toml").read_text(encoding="utf-8")
+            metadata = json.loads((root / "resolver-metadata.json").read_text(encoding="utf-8"))
+
+            self.assertNotIn("[credentials.claude_auth]", resolved_policy)
+            self.assertEqual(metadata["credential_input_kinds"], {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scenarios/manifest.json
+++ b/tests/scenarios/manifest.json
@@ -13,6 +13,28 @@
       "requires_credentials": false
     },
     {
+      "id": "shared/auth-commands",
+      "description": "Host-side auth commands manage explicit policy-backed credential inputs without launching the runtime",
+      "lane": "secretless",
+      "platform": "any",
+      "manual": false,
+      "providers": ["codex", "claude", "gemini"],
+      "persona": "developer",
+      "test_file": "shared/test-auth-commands.sh",
+      "requires_credentials": false
+    },
+    {
+      "id": "shared/claude-resolver-launcher",
+      "description": "Claude resolver-backed auth fails closed without an export and resolves through the launcher staging path when the test export hook is present",
+      "lane": "secretless",
+      "platform": "any",
+      "manual": false,
+      "providers": ["claude"],
+      "persona": "developer",
+      "test_file": "shared/test-claude-resolver-launcher.sh",
+      "requires_credentials": false
+    },
+    {
       "id": "shared/publish-pr",
       "description": "Host-side publish-pr dry-run renders signed commit and draft PR commands",
       "lane": "secretless",

--- a/tests/scenarios/shared/test-auth-commands.sh
+++ b/tests/scenarios/shared/test-auth-commands.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-auth-commands-scenario.XXXXXX")"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+POLICY_PATH="${TMP_DIR}/injection-policy.toml"
+MANAGED_ROOT="${TMP_DIR}/managed-credentials"
+SOURCE_AUTH="${TMP_DIR}/codex-auth.json"
+
+printf '{}\n' >"${SOURCE_AUTH}"
+chmod 0600 "${SOURCE_AUTH}"
+
+help_output="$("${ROOT_DIR}/scripts/workcell" auth --help)"
+grep -q '^Usage: workcell auth init \[options\]$' <<<"${help_output}"
+
+init_output="$(
+  cd "${TMP_DIR}"
+  "${ROOT_DIR}/scripts/workcell" auth init \
+    --injection-policy ./injection-policy.toml \
+    --managed-root ./managed-credentials
+)"
+grep -q '^policy_path=.*injection-policy\.toml$' <<<"${init_output}"
+
+set +e
+missing_policy_output="$("${ROOT_DIR}/scripts/workcell" auth status \
+  --injection-policy "${TMP_DIR}/missing-policy.toml" \
+  --agent codex 2>&1)"
+missing_policy_rc=$?
+set -e
+test "${missing_policy_rc}" -eq 2
+grep -q '^Injection policy file does not exist:' <<<"${missing_policy_output}"
+
+set_output="$(
+  cd "${TMP_DIR}"
+  "${ROOT_DIR}/scripts/workcell" auth set \
+    --injection-policy ./injection-policy.toml \
+    --managed-root ./managed-credentials \
+    --agent codex \
+    --credential codex_auth \
+    --source ./codex-auth.json
+)"
+grep -q "^credential=codex_auth$" <<<"${set_output}"
+test -f "${MANAGED_ROOT}/codex/auth.json"
+
+status_output="$("${ROOT_DIR}/scripts/workcell" auth status \
+  --injection-policy "${POLICY_PATH}" \
+  --agent codex)"
+grep -q '^credential_keys=codex_auth$' <<<"${status_output}"
+grep -q '^credential_input_kinds=codex_auth:source$' <<<"${status_output}"
+grep -q '^provider_auth_mode=codex_auth$' <<<"${status_output}"
+
+resolver_output="$("${ROOT_DIR}/scripts/workcell" auth set \
+  --injection-policy "${POLICY_PATH}" \
+  --managed-root "${MANAGED_ROOT}" \
+  --agent claude \
+  --credential claude_auth \
+  --resolver claude-macos-keychain \
+  --ack-host-resolver)"
+grep -q '^resolver=claude-macos-keychain$' <<<"${resolver_output}"
+
+claude_status="$("${ROOT_DIR}/scripts/workcell" auth status \
+  --injection-policy "${POLICY_PATH}" \
+  --agent claude)"
+grep -q '^credential_resolvers=claude_auth:claude-macos-keychain$' <<<"${claude_status}"
+grep -q '^credential_resolution_states=claude_auth:configured-only$' <<<"${claude_status}"
+grep -q '^provider_auth_mode=none$' <<<"${claude_status}"
+grep -q '^provider_auth_modes=none$' <<<"${claude_status}"
+
+claude_launcher_status="$("${ROOT_DIR}/scripts/workcell" \
+  --agent claude \
+  --auth-status \
+  --workspace "${TMP_DIR}" \
+  --injection-policy "${POLICY_PATH}")"
+grep -q '^credential_resolution_states=claude_auth:configured-only$' <<<"${claude_launcher_status}"
+grep -q '^provider_auth_mode=none$' <<<"${claude_launcher_status}"
+grep -q '^provider_auth_modes=none$' <<<"${claude_launcher_status}"
+
+unset_output="$("${ROOT_DIR}/scripts/workcell" auth unset \
+  --injection-policy "${POLICY_PATH}" \
+  --managed-root "${MANAGED_ROOT}" \
+  --credential codex_auth)"
+grep -q '^removed=1$' <<<"${unset_output}"
+test ! -f "${MANAGED_ROOT}/codex/auth.json"
+
+echo "Auth command scenario passed"

--- a/tests/scenarios/shared/test-claude-resolver-launcher.sh
+++ b/tests/scenarios/shared/test-claude-resolver-launcher.sh
@@ -11,7 +11,6 @@ trap cleanup EXIT
 
 WORKSPACE="${TMP_DIR}/workspace"
 POLICY="${TMP_DIR}/policy.toml"
-EXPORT_FILE="${TMP_DIR}/claude-export.json"
 mkdir -p "${WORKSPACE}"
 
 cat >"${POLICY}" <<'EOF'
@@ -37,9 +36,6 @@ set -e
 test "${failure_rc}" -ne 0
 grep -q 'Claude macOS login reuse is configured' <<<"${failure_output}"
 
-printf '{"token":"claude"}\n' >"${EXPORT_FILE}"
-chmod 0600 "${EXPORT_FILE}"
-
 success_output="$("${ROOT_DIR}/scripts/workcell" \
   --self-staging-probe \
   claude \
@@ -48,7 +44,7 @@ success_output="$("${ROOT_DIR}/scripts/workcell" \
   strict \
   0 \
   0 \
-  "${EXPORT_FILE}")"
+  1)"
 
 grep -q '^injection_bundle_root=' <<<"${success_output}"
 grep -q '^direct_mount=' <<<"${success_output}"

--- a/tests/scenarios/shared/test-claude-resolver-launcher.sh
+++ b/tests/scenarios/shared/test-claude-resolver-launcher.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-claude-resolver-launcher.XXXXXX")"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+WORKSPACE="${TMP_DIR}/workspace"
+POLICY="${TMP_DIR}/policy.toml"
+EXPORT_FILE="${TMP_DIR}/claude-export.json"
+mkdir -p "${WORKSPACE}"
+
+cat >"${POLICY}" <<'EOF'
+version = 1
+
+[credentials.claude_auth]
+resolver = "claude-macos-keychain"
+materialization = "ephemeral"
+EOF
+
+set +e
+failure_output="$("${ROOT_DIR}/scripts/workcell" \
+  --self-staging-probe \
+  claude \
+  "${WORKSPACE}" \
+  "${POLICY}" \
+  strict \
+  0 \
+  0 2>&1)"
+failure_rc=$?
+set -e
+
+test "${failure_rc}" -ne 0
+grep -q 'Claude macOS login reuse is configured' <<<"${failure_output}"
+
+printf '{"token":"claude"}\n' >"${EXPORT_FILE}"
+chmod 0600 "${EXPORT_FILE}"
+
+success_output="$("${ROOT_DIR}/scripts/workcell" \
+  --self-staging-probe \
+  claude \
+  "${WORKSPACE}" \
+  "${POLICY}" \
+  strict \
+  0 \
+  0 \
+  "${EXPORT_FILE}")"
+
+grep -q '^injection_bundle_root=' <<<"${success_output}"
+grep -q '^direct_mount=' <<<"${success_output}"
+
+echo "Claude resolver launcher scenario passed"


### PR DESCRIPTION
## Summary
- add host-side `workcell auth` commands for explicit policy-backed credential management
- stage Claude resolver metadata through the launcher while keeping resolver-only auth fail-closed
- restore host terminal state on exit and route Codex runtime downloads through a host-resolved release URL when needed

## Validation
- `scripts/pre-merge.sh --allow-dirty --skip-release-bundle --skip-repro`
- `scripts/verify-coverage.sh`
- targeted auth and resolver scenario/unit tests