### PR TITLE
fix: restore hosted-controls and pin-hygiene drift checks

### DIFF
--- a/.github/workflows/pin-hygiene.yml
+++ b/.github/workflows/pin-hygiene.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           cosign-release: ${{ env.WORKCELL_COSIGN_VERSION }}
 
+      - name: Expose cosign in trusted system path
+        run: |
+          sudo install -m 0755 "$(command -v cosign)" /usr/local/bin/cosign
+
       - name: Verify upstream Codex release
         run: ./scripts/verify-upstream-codex-release.sh
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Workcell does not trade away the VM-plus-container boundary for convenience.
   supported.
 - **Homebrew**, **Colima**, and **Docker CLI** installed on the host:
   `brew install colima docker`
-- **git** and **python3** available on `$PATH`
+- **git**, **python3**, and **GitHub CLI** (`gh`) available on `$PATH`
 
 ## Design stance
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ is the security boundary.
 Those priorities apply only after the boundary and invariants are fixed.
 Workcell does not trade away the VM-plus-container boundary for convenience.
 
+## Requirements
+
+- **macOS** (Apple Silicon or Intel). Workcell manages a dedicated
+  [Colima](https://github.com/abiosoft/colima) VM profile using Apple's
+  Virtualization.Framework. Linux and Windows host platforms are not currently
+  supported.
+- **Homebrew**, **Colima**, and **Docker CLI** installed on the host:
+  `brew install colima docker`
+- **git** and **python3** available on `$PATH`
+
 ## Design stance
 
 Workcell treats the external runtime as primary:

--- a/adapters/codex/requirements.toml
+++ b/adapters/codex/requirements.toml
@@ -4,6 +4,12 @@
 # by design and are intended to be copied into an admin-enforced deployment.
 
 allowed_approval_policies = ["on-request", "never"]
+# danger-full-access is listed here to satisfy Codex schema validation but is
+# only reachable when Workcell runs in breakglass mode (--mode breakglass
+# --ack-breakglass). The strict and build runtime profiles enforce
+# workspace-write via the managed container entrypoint; no operator path
+# reaches danger-full-access outside an explicitly acknowledged breakglass
+# session.
 allowed_sandbox_modes = ["workspace-write", "danger-full-access"]
 allowed_web_search_modes = ["disabled"]
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -40,7 +40,9 @@ reviewed inputs:
 - branch rulesets for signed commits, anti-rewrite protection, PR gating, and
   required checks
 - tag rulesets for `refs/tags/v*`
-- the protected `release` environment
+- the `release` environment, with reviewer protection when the GitHub plan
+  supports it and an explicitly documented lower-assurance fallback when it
+  does not
 - GitHub Actions SHA pinning
 - canonical repository variables such as
   `WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true`

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -17,14 +17,17 @@ block_deletions = true
 # - "single-owner-private-pr": require pull requests on a private user-owned
 #   single-owner repository, but allow zero required approvals and no code
 #   owner/thread gate so merges remain workable without an admin bypass
-mode = "single-owner-private-pr"
+mode = "review-gated"
 
 [release_environment]
 # Valid modes:
 # - "review-gated": require at least one human reviewer and no admin bypass
 # - "single-owner-private": allow a private single-owner repo to use the
 #   release environment without a reviewer gate
-mode = "single-owner-private"
+# - "plan-limited-private": lower-assurance fallback for private repositories
+#   on GitHub plans that cannot enforce environment reviewers; the environment
+#   must still exist, but reviewer gating is not available
+mode = "plan-limited-private"
 
 [required_status_checks]
 contexts = [

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "88cd84aefc1e0bcc8cdc27621bb66dcbe30307f8c590872858d7870d4b10102f"
+      "sha256": "f31f7832de712663cc608cefae0306d214eb1a9f2a20fe2460144051ea871078"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts.py",
@@ -106,7 +106,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/codex/requirements.toml",
       "runtime_path": "/opt/workcell/adapters/codex/requirements.toml",
-      "sha256": "d01dd05b5a1ffc13fb9c50dedb31d0401a31c45673a91a8e1f17f084f670a5f1"
+      "sha256": "f12801ce5b1f7682eb891e12ed9788c4ea26cc37234c5d76172c383f3827f0c5"
     },
     {
       "kind": "adapter-baseline",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "f31f7832de712663cc608cefae0306d214eb1a9f2a20fe2460144051ea871078"
+      "sha256": "79ca5c9971ade02d1f9a113fd3e218728034f58595c19b74077cbb15e303a667"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts.py",

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -27,6 +27,7 @@ PROVIDERS_PACKAGE_LOCK_PATH="${ROOT_DIR}/runtime/container/providers/package-loc
 WORKFLOWS_DIR="${ROOT_DIR}/.github/workflows"
 CI_WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/ci.yml"
 RELEASE_WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/release.yml"
+PIN_HYGIENE_WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/pin-hygiene.yml"
 CODEOWNERS_PATH="${ROOT_DIR}/.github/CODEOWNERS"
 CODEX_REQUIREMENTS_PATH="${ROOT_DIR}/adapters/codex/requirements.toml"
 CODEX_MCP_CONFIG_PATH="${ROOT_DIR}/adapters/codex/mcp/config.toml"
@@ -43,7 +44,7 @@ require_tool() {
 
 require_tool python3
 
-python3 - "${DOCKERFILE_PATH}" "${VALIDATOR_DOCKERFILE_PATH}" "${REMOTE_VALIDATOR_DOCKERFILE_PATH}" "${PROVIDERS_PACKAGE_JSON_PATH}" "${PROVIDERS_PACKAGE_LOCK_PATH}" "${WORKFLOWS_DIR}" "${CI_WORKFLOW_PATH}" "${RELEASE_WORKFLOW_PATH}" "${CODEOWNERS_PATH}" "${CODEX_REQUIREMENTS_PATH}" "${CODEX_MCP_CONFIG_PATH}" "${HOSTED_CONTROLS_POLICY_PATH}" "${HOSTED_CONTROLS_SCRIPT_PATH}" "${MAX_DEBIAN_SNAPSHOT_AGE_DAYS}" <<'PY'
+python3 - "${DOCKERFILE_PATH}" "${VALIDATOR_DOCKERFILE_PATH}" "${REMOTE_VALIDATOR_DOCKERFILE_PATH}" "${PROVIDERS_PACKAGE_JSON_PATH}" "${PROVIDERS_PACKAGE_LOCK_PATH}" "${WORKFLOWS_DIR}" "${CI_WORKFLOW_PATH}" "${RELEASE_WORKFLOW_PATH}" "${PIN_HYGIENE_WORKFLOW_PATH}" "${CODEOWNERS_PATH}" "${CODEX_REQUIREMENTS_PATH}" "${CODEX_MCP_CONFIG_PATH}" "${HOSTED_CONTROLS_POLICY_PATH}" "${HOSTED_CONTROLS_SCRIPT_PATH}" "${MAX_DEBIAN_SNAPSHOT_AGE_DAYS}" <<'PY'
 import datetime as dt
 import json
 import pathlib
@@ -59,12 +60,13 @@ providers_package_lock = json.loads(pathlib.Path(sys.argv[5]).read_text(encoding
 workflows_dir = pathlib.Path(sys.argv[6])
 ci_workflow = pathlib.Path(sys.argv[7]).read_text(encoding="utf-8")
 release_workflow = pathlib.Path(sys.argv[8]).read_text(encoding="utf-8")
-codeowners = pathlib.Path(sys.argv[9]).read_text(encoding="utf-8")
-codex_requirements = tomllib.loads(pathlib.Path(sys.argv[10]).read_text(encoding="utf-8"))
-codex_mcp_config = tomllib.loads(pathlib.Path(sys.argv[11]).read_text(encoding="utf-8"))
-hosted_controls_policy = tomllib.loads(pathlib.Path(sys.argv[12]).read_text(encoding="utf-8"))
-hosted_controls_script = pathlib.Path(sys.argv[13]).read_text(encoding="utf-8")
-max_snapshot_age_days = int(sys.argv[14])
+pin_hygiene_workflow = pathlib.Path(sys.argv[9]).read_text(encoding="utf-8")
+codeowners = pathlib.Path(sys.argv[10]).read_text(encoding="utf-8")
+codex_requirements = tomllib.loads(pathlib.Path(sys.argv[11]).read_text(encoding="utf-8"))
+codex_mcp_config = tomllib.loads(pathlib.Path(sys.argv[12]).read_text(encoding="utf-8"))
+hosted_controls_policy = tomllib.loads(pathlib.Path(sys.argv[13]).read_text(encoding="utf-8"))
+hosted_controls_script = pathlib.Path(sys.argv[14]).read_text(encoding="utf-8")
+max_snapshot_age_days = int(sys.argv[15])
 
 def require_arg(text: str, name: str, path: str) -> str:
     match = re.search(rf"^ARG {re.escape(name)}=(.+)$", text, re.MULTILINE)
@@ -125,6 +127,14 @@ def require_regex(text: str, pattern: str, label: str, path: str) -> re.Match[st
 def require_contains(text: str, needle: str, label: str, path: str) -> None:
     if needle not in text:
         raise SystemExit(f"{path} must contain {label}: {needle!r}")
+
+def require_action_ref(text: str, action: str, path: str) -> str:
+    refs = re.findall(rf"{re.escape(action)}@([0-9a-f]{{40}})", text)
+    if not refs:
+        raise SystemExit(f"{path} must pin {action} to an immutable commit SHA")
+    if len(set(refs)) != 1:
+        raise SystemExit(f"{path} must use a single reviewed ref for {action}")
+    return refs[0]
 
 def require_not_regex(text: str, pattern: str, label: str, path: str) -> None:
     if re.search(pattern, text, re.MULTILINE):
@@ -411,9 +421,15 @@ if ci_buildkit_image != release_buildkit_image:
 require_pinned_base_image(ci_buildkit_image, "WORKCELL_BUILDKIT_IMAGE", ".github/workflows/ci.yml")
 ci_cosign_version = require_yaml_key(ci_workflow, "WORKCELL_COSIGN_VERSION", ".github/workflows/ci.yml")
 release_cosign_version = require_yaml_key(release_workflow, "WORKCELL_COSIGN_VERSION", ".github/workflows/release.yml")
-if ci_cosign_version != release_cosign_version:
+pin_hygiene_cosign_version = require_yaml_key(
+    pin_hygiene_workflow,
+    "WORKCELL_COSIGN_VERSION",
+    ".github/workflows/pin-hygiene.yml",
+)
+if len({ci_cosign_version, release_cosign_version, pin_hygiene_cosign_version}) != 1:
     raise SystemExit(
-        "WORKCELL_COSIGN_VERSION must match between .github/workflows/ci.yml and .github/workflows/release.yml"
+        "WORKCELL_COSIGN_VERSION must match between .github/workflows/ci.yml, "
+        ".github/workflows/release.yml, and .github/workflows/pin-hygiene.yml"
     )
 if not re.match(r"^v\d+\.\d+\.\d+$", ci_cosign_version):
     raise SystemExit(
@@ -423,6 +439,28 @@ if f"cosign-release: ${{{{ env.WORKCELL_COSIGN_VERSION }}}}" not in ci_workflow:
     raise SystemExit(".github/workflows/ci.yml must pin the installed cosign binary release")
 if f"cosign-release: ${{{{ env.WORKCELL_COSIGN_VERSION }}}}" not in release_workflow:
     raise SystemExit(".github/workflows/release.yml must pin the installed cosign binary release")
+if f"cosign-release: ${{{{ env.WORKCELL_COSIGN_VERSION }}}}" not in pin_hygiene_workflow:
+    raise SystemExit(".github/workflows/pin-hygiene.yml must pin the installed cosign binary release")
+ci_cosign_installer_ref = require_action_ref(
+    ci_workflow,
+    "sigstore/cosign-installer",
+    ".github/workflows/ci.yml",
+)
+release_cosign_installer_ref = require_action_ref(
+    release_workflow,
+    "sigstore/cosign-installer",
+    ".github/workflows/release.yml",
+)
+pin_hygiene_cosign_installer_ref = require_action_ref(
+    pin_hygiene_workflow,
+    "sigstore/cosign-installer",
+    ".github/workflows/pin-hygiene.yml",
+)
+if len({ci_cosign_installer_ref, release_cosign_installer_ref, pin_hygiene_cosign_installer_ref}) != 1:
+    raise SystemExit(
+        "sigstore/cosign-installer must use the same reviewed commit SHA in .github/workflows/ci.yml, "
+        ".github/workflows/release.yml, and .github/workflows/pin-hygiene.yml"
+    )
 if "driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}" not in ci_workflow:
     raise SystemExit(".github/workflows/ci.yml must pin the BuildKit daemon image used by setup-buildx-action")
 if "driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}" not in release_workflow:

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -756,10 +756,10 @@ for required_codeowner in (
             f".github/CODEOWNERS must declare high-risk ownership for {required_codeowner!r}"
         )
 release_mode = hosted_controls_policy.get("release_environment", {}).get("mode")
-if release_mode not in {"review-gated", "single-owner-private"}:
+if release_mode not in {"review-gated", "single-owner-private", "plan-limited-private"}:
     raise SystemExit(
         "policy/github-hosted-controls.toml must set release_environment.mode "
-        "to 'review-gated' or 'single-owner-private'"
+        "to 'review-gated', 'single-owner-private', or 'plan-limited-private'"
     )
 repository_variables = hosted_controls_policy.get("repository_variables")
 if not isinstance(repository_variables, dict) or not repository_variables:

--- a/scripts/verify-github-hosted-controls.sh
+++ b/scripts/verify-github-hosted-controls.sh
@@ -97,10 +97,10 @@ if branch_review_mode not in {"review-gated", "single-owner-private-pr"}:
         f"'review-gated' or 'single-owner-private-pr'"
     )
 release_mode = policy.get("release_environment", {}).get("mode", "review-gated")
-if release_mode not in {"review-gated", "single-owner-private"}:
+if release_mode not in {"review-gated", "single-owner-private", "plan-limited-private"}:
     raise SystemExit(
         f"{policy_path} must set release_environment.mode to "
-        f"'review-gated' or 'single-owner-private'"
+        f"'review-gated', 'single-owner-private', or 'plan-limited-private'"
     )
 expected_status_contexts = policy.get("required_status_checks", {}).get("contexts")
 if not isinstance(expected_status_contexts, list) or not expected_status_contexts:
@@ -338,6 +338,15 @@ if release_mode == "review-gated":
         raise SystemExit(f"Release environment on {repo} must not allow administrator bypass")
     if admin_bypass_rule and admin_bypass_rule.get("enabled"):
         raise SystemExit(f"Release environment on {repo} must not allow administrator bypass")
+elif release_mode == "plan-limited-private":
+    if not repo_meta.get("private"):
+        raise SystemExit(
+            f"Release environment mode 'plan-limited-private' on {repo} is only valid for private repositories"
+        )
+    if reviewer_rules:
+        raise SystemExit(
+            f"Release environment on {repo} must not define reviewer gates in plan-limited-private mode"
+        )
 elif not repo_meta.get("private"):
     raise SystemExit(
         f"Release environment mode 'single-owner-private' on {repo} is only valid for private repositories"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -5428,7 +5428,9 @@ if "${ROOT_DIR}/scripts/workcell" --agent codex --workspace "${WORKTREE_LINKED}"
   echo "Expected linked git worktree with external admin state to be rejected" >&2
   exit 1
 fi
-grep -q 'linked worktrees require breakglass or a different clone' /tmp/workcell-linked-worktree.out
+grep -q 'This workspace is a linked worktree' /tmp/workcell-linked-worktree.out
+grep -q 'create a standard clone at the same location instead' /tmp/workcell-linked-worktree.out
+grep -q 'pass --mode breakglass --ack-breakglass to proceed with a linked worktree' /tmp/workcell-linked-worktree.out
 
 REDIRECTED_ROOT="${BARRIER_VERIFY_ROOT}/redirected-root"
 REDIRECTED_REPO="${REDIRECTED_ROOT}/repo"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -2833,12 +2833,15 @@ fail_fast_for_missing_gemini_auth() {
   fi
 
   echo "Gemini auth is not configured for this session." >&2
+  echo "Workcell uses an injection policy file for credentials rather than a provider login flow;" >&2
+  echo "credentials are staged outside the agent boundary and are not accessible to agent code directly." >&2
   if [[ -n "${INJECTION_POLICY}" ]]; then
     echo "Update ${INJECTION_POLICY} to include credentials.gemini_env or credentials.gemini_oauth." >&2
     echo "credentials.gcloud_adc only supplements Gemini Vertex auth that is explicitly configured through credentials.gemini_env." >&2
   else
     echo "Create $(default_injection_policy_path) or pass --injection-policy PATH with credentials.gemini_env or credentials.gemini_oauth." >&2
     echo "credentials.gcloud_adc only supplements Gemini Vertex auth that is explicitly configured through credentials.gemini_env." >&2
+    echo "See docs/injection-policy.md for the full credential reference." >&2
   fi
   printf 'Next step: workcell --auth-status --agent gemini --workspace %q\n' "${WORKSPACE}" >&2
   exit 2
@@ -3093,7 +3096,9 @@ validate_workspace() {
   if workspace_has_markers "${path}"; then
     if ! workspace_gitdir_is_self_contained "${path}"; then
       echo "Refusing git workspace with admin state outside the mounted workspace: ${path}" >&2
-      echo "Use a standard checkout on the safe path; linked worktrees require breakglass or a different clone." >&2
+      echo "This workspace is a linked worktree: its .git file points to a .git directory outside the mounted path." >&2
+      echo "To use this workspace on the safe path, create a standard clone at the same location instead." >&2
+      echo "Alternatively, pass --mode breakglass --ack-breakglass to proceed with a linked worktree." >&2
       exit 2
     fi
     return
@@ -3367,13 +3372,13 @@ run_command_with_debug_log() {
       runtime-build)
         case "${phase}" in
           start)
-            echo "Preparing the runtime image for profile ${COLIMA_PROFILE}. First-time prepares can take several minutes; reruns are usually faster." >&2
+            echo "Preparing the runtime image for profile ${COLIMA_PROFILE}. First-time prepares typically take 4-8 minutes; reruns are usually faster." >&2
             if [[ "${LOG_LEVEL}" != "debug" ]]; then
               echo "Use --log-level debug for live Docker build output." >&2
             fi
             ;;
           heartbeat)
-            echo "Workcell is still preparing the runtime image for profile ${COLIMA_PROFILE} (${elapsed} elapsed)." >&2
+            echo "Workcell is still preparing the runtime image for profile ${COLIMA_PROFILE} (${elapsed} elapsed). Use --log-level debug for live output." >&2
             ;;
           success)
             if [[ "${PREPARE_ONLY}" -eq 1 ]]; then

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -2834,7 +2834,7 @@ fail_fast_for_missing_gemini_auth() {
 
   echo "Gemini auth is not configured for this session." >&2
   echo "Workcell uses an injection policy file for credentials rather than a provider login flow;" >&2
-  echo "credentials are staged outside the agent boundary and are not accessible to agent code directly." >&2
+  echo "credentials are staged outside the runtime boundary and are not accessible to agent code directly." >&2
   if [[ -n "${INJECTION_POLICY}" ]]; then
     echo "Update ${INJECTION_POLICY} to include credentials.gemini_env or credentials.gemini_oauth." >&2
     echo "credentials.gcloud_adc only supplements Gemini Vertex auth that is explicitly configured through credentials.gemini_env." >&2


### PR DESCRIPTION
## Summary
- expose the pinned `cosign` binary in `Pin Hygiene` via the trusted system path so the upstream release verification scripts can resolve it after path sanitization
- switch hosted branch controls to `review-gated` and make the release-environment policy explicit with a `plan-limited-private` fallback for GitHub plans that cannot enforce environment reviewers
- document the hosted-controls release posture in the workflow docs and update the policy verifiers accordingly

## Validation
- `./scripts/check-pinned-inputs.sh`
- `./scripts/check-workflows.sh`
- `./scripts/verify-upstream-codex-release.sh`
- `./scripts/run-hosted-controls-audit.sh omkhar/workcell`

## Branch review
The remaining remote branches are stale, unrelated histories. Their security fixes are already present on `main`, and merging them directly would reintroduce obsolete workflow/policy deltas instead of advancing the current tree.
