### PR TITLE
Add Go Foundation for Metadata, Parity, and Mutation Tools

### DIFF
--- a/cmd/workcell-metadatautil/main.go
+++ b/cmd/workcell-metadatautil/main.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/omkhar/workcell/internal/metadatautil"
+)
+
+func die(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		die(fmt.Errorf("usage: %s <command> [args...]", os.Args[0]))
+	}
+
+	var err error
+	switch os.Args[1] {
+	case "generate-control-plane-manifest":
+		if len(os.Args) != 4 {
+			die(fmt.Errorf("usage: %s generate-control-plane-manifest ROOT_DIR OUTPUT_PATH", os.Args[0]))
+		}
+		err = metadatautil.GenerateControlPlaneManifest(os.Args[2], os.Args[3])
+	case "verify-control-plane-manifest":
+		if len(os.Args) != 3 {
+			die(fmt.Errorf("usage: %s verify-control-plane-manifest MANIFEST_PATH", os.Args[0]))
+		}
+		err = metadatautil.ValidateControlPlaneManifest(os.Args[2])
+	case "verify-control-plane-parity":
+		if len(os.Args) != 3 {
+			die(fmt.Errorf("usage: %s verify-control-plane-parity MANIFEST_PATH", os.Args[0]))
+		}
+		rows, rowErr := metadatautil.ControlPlaneParityRows(os.Args[2])
+		if rowErr != nil {
+			die(rowErr)
+		}
+		for _, row := range rows {
+			fmt.Println(row)
+		}
+		return
+	case "check-workflows":
+		if len(os.Args) != 4 {
+			die(fmt.Errorf("usage: %s check-workflows ROOT_DIR POLICY_PATH", os.Args[0]))
+		}
+		err = metadatautil.CheckWorkflows(os.Args[2], os.Args[3])
+	case "fetch-rulesets":
+		if len(os.Args) != 4 {
+			die(fmt.Errorf("usage: %s fetch-rulesets TMP_DIR REPO", os.Args[0]))
+		}
+		err = metadatautil.FetchGitHubHostedControlsRulesets(os.Args[2], os.Args[3])
+	case "verify-github-hosted-controls":
+		if len(os.Args) != 5 {
+			die(fmt.Errorf("usage: %s verify-github-hosted-controls TMP_DIR REPO POLICY_PATH", os.Args[0]))
+		}
+		err = metadatautil.VerifyGitHubHostedControls(os.Args[2], os.Args[3], os.Args[4])
+	case "extract-dockerfile-arg":
+		if len(os.Args) != 4 {
+			die(fmt.Errorf("usage: %s extract-dockerfile-arg DOCKERFILE_PATH ARG_NAME", os.Args[0]))
+		}
+		value, extractErr := metadatautil.ExtractDockerfileArg(os.Args[2], os.Args[3])
+		if extractErr != nil {
+			die(extractErr)
+		}
+		fmt.Println(value)
+		return
+	case "extract-claude-sha":
+		if len(os.Args) != 4 {
+			die(fmt.Errorf("usage: %s extract-claude-sha DOCKERFILE_PATH TARGET_ARCH", os.Args[0]))
+		}
+		value, extractErr := metadatautil.ExtractClaudeSHA(os.Args[2], os.Args[3])
+		if extractErr != nil {
+			die(extractErr)
+		}
+		fmt.Println(value)
+		return
+	case "extract-codex-sha":
+		if len(os.Args) != 4 {
+			die(fmt.Errorf("usage: %s extract-codex-sha DOCKERFILE_PATH TARGET_ARCH", os.Args[0]))
+		}
+		value, extractErr := metadatautil.ExtractCodexSHA(os.Args[2], os.Args[3])
+		if extractErr != nil {
+			die(extractErr)
+		}
+		fmt.Println(value)
+		return
+	case "manifest-checksum":
+		if len(os.Args) != 4 {
+			die(fmt.Errorf("usage: %s manifest-checksum MANIFEST_PATH PLATFORM", os.Args[0]))
+		}
+		value, extractErr := metadatautil.ManifestChecksum(os.Args[2], os.Args[3])
+		if extractErr != nil {
+			die(extractErr)
+		}
+		fmt.Println(value)
+		return
+	case "manifest-version":
+		if len(os.Args) != 4 {
+			die(fmt.Errorf("usage: %s manifest-version MANIFEST_PATH EXPECTED_VERSION", os.Args[0]))
+		}
+		err = metadatautil.ManifestVersion(os.Args[2], os.Args[3])
+	case "generate-build-input-manifest":
+		if len(os.Args) != 9 {
+			die(fmt.Errorf("usage: %s generate-build-input-manifest DOCKERFILE PACKAGE_JSON PACKAGE_LOCK OUTPUT BUILD_REF SOURCE_DATE_EPOCH REQUIRE_TRACKED", os.Args[0]))
+		}
+		sourceEpoch, convErr := strconv.ParseInt(os.Args[7], 10, 64)
+		if convErr != nil {
+			die(convErr)
+		}
+		requireTracked := os.Args[8] == "1"
+		err = metadatautil.GenerateBuildInputManifest(os.Args[2], os.Args[3], os.Args[4], os.Args[5], os.Args[6], sourceEpoch, requireTracked)
+	case "generate-builder-environment-manifest":
+		if len(os.Args) != 18 {
+			die(fmt.Errorf("usage: %s generate-builder-environment-manifest OUTPUT BUILDKIT_IMAGE BUILDX_VERSION_TARGET COSIGN_VERSION_TARGET QEMU_IMAGE SYFT_VERSION_TARGET BUILDX_VERSION BUILDX_INSPECT DOCKER_VERSION_JSON QEMU_VERSION COSIGN_VERSION CURL_VERSION GIT_VERSION GZIP_VERSION SYFT_VERSION TAR_VERSION", os.Args[0]))
+		}
+		err = metadatautil.GenerateBuilderEnvironmentManifest(
+			os.Args[2],
+			os.Args[3],
+			os.Args[4],
+			os.Args[5],
+			os.Args[6],
+			os.Args[7],
+			os.Args[8],
+			os.Args[9],
+			os.Args[10],
+			os.Args[11],
+			os.Args[12],
+			os.Args[13],
+			os.Args[14],
+			os.Args[15],
+			os.Args[16],
+			os.Args[17],
+		)
+	case "check-pinned-inputs":
+		if len(os.Args) != 17 {
+			die(fmt.Errorf("usage: %s check-pinned-inputs DOCKERFILE VALIDATOR_DOCKERFILE REMOTE_VALIDATOR_DOCKERFILE PROVIDERS_PACKAGE_JSON PROVIDERS_PACKAGE_LOCK WORKFLOWS_DIR CI_WORKFLOW RELEASE_WORKFLOW PIN_HYGIENE_WORKFLOW CODEOWNERS CODEX_REQUIREMENTS CODEX_MCP_CONFIG HOSTED_CONTROLS_POLICY HOSTED_CONTROLS_SCRIPT MAX_DEBIAN_SNAPSHOT_AGE_DAYS", os.Args[0]))
+		}
+		maxAge, convErr := strconv.Atoi(os.Args[16])
+		if convErr != nil {
+			die(convErr)
+		}
+		err = metadatautil.CheckPinnedInputs(metadatautil.PinnedInputsConfig{
+			RuntimeDockerfilePath:         os.Args[2],
+			ValidatorDockerfilePath:       os.Args[3],
+			RemoteValidatorDockerfilePath: os.Args[4],
+			ProvidersPackageJSONPath:      os.Args[5],
+			ProvidersPackageLockPath:      os.Args[6],
+			WorkflowsDir:                  os.Args[7],
+			CIWorkflowPath:                os.Args[8],
+			ReleaseWorkflowPath:           os.Args[9],
+			PinHygieneWorkflowPath:        os.Args[10],
+			CodeownersPath:                os.Args[11],
+			CodexRequirementsPath:         os.Args[12],
+			CodexMCPConfigPath:            os.Args[13],
+			HostedControlsPolicyPath:      os.Args[14],
+			HostedControlsScriptPath:      os.Args[15],
+			MaxDebianSnapshotAgeDays:      maxAge,
+		})
+	case "verify-reproducible-build":
+		if len(os.Args) != 7 {
+			die(fmt.Errorf("usage: %s verify-reproducible-build OCI_EXPORT_A OCI_EXPORT_B REPRO_PLATFORMS REPRO_MANIFEST_PATH SOURCE_DATE_EPOCH", os.Args[0]))
+		}
+		sourceEpoch, convErr := strconv.ParseInt(os.Args[6], 10, 64)
+		if convErr != nil {
+			die(convErr)
+		}
+		err = metadatautil.VerifyReproducibleBuild(os.Args[2], os.Args[3], os.Args[4], os.Args[5], sourceEpoch)
+	case "canonicalize-path":
+		if len(os.Args) != 3 {
+			die(fmt.Errorf("usage: %s canonicalize-path PATH", os.Args[0]))
+		}
+		value, canonErr := metadatautil.CanonicalizePath(os.Args[2])
+		if canonErr != nil {
+			die(canonErr)
+		}
+		fmt.Println(value)
+		return
+	case "coverage-percent":
+		if len(os.Args) != 5 {
+			die(fmt.Errorf("usage: %s coverage-percent REPORT_PATH MINIMUM LABEL", os.Args[0]))
+		}
+		minimum, convErr := strconv.ParseFloat(os.Args[3], 64)
+		if convErr != nil {
+			die(convErr)
+		}
+		percent, percentErr := metadatautil.CoveragePercent(os.Args[2])
+		if percentErr != nil {
+			die(percentErr)
+		}
+		if percent < minimum {
+			die(fmt.Errorf("%s is %.2f%%, below the required %.2f%%", os.Args[4], percent, minimum))
+		}
+		fmt.Printf("%s: %.2f%%\n", os.Args[4], percent)
+		return
+	case "coverage-executables":
+		if len(os.Args) != 3 {
+			die(fmt.Errorf("usage: %s coverage-executables MESSAGE_PATH", os.Args[0]))
+		}
+		executables, execErr := metadatautil.CoverageExecutables(os.Args[2])
+		if execErr != nil {
+			die(execErr)
+		}
+		for _, executable := range executables {
+			fmt.Println(executable)
+		}
+		return
+	case "validate-json":
+		if len(os.Args) < 3 {
+			die(fmt.Errorf("usage: %s validate-json FILE...", os.Args[0]))
+		}
+		err = metadatautil.ValidateJSONFiles(os.Args[2:])
+	case "validate-toml":
+		if len(os.Args) < 3 {
+			die(fmt.Errorf("usage: %s validate-toml FILE...", os.Args[0]))
+		}
+		err = metadatautil.ValidateTOMLFiles(os.Args[2:])
+	case "scan-credential-patterns":
+		if len(os.Args) != 3 {
+			die(fmt.Errorf("usage: %s scan-credential-patterns ROOT_DIR", os.Args[0]))
+		}
+		err = metadatautil.ScanCredentialPatterns(os.Args[2])
+	default:
+		die(fmt.Errorf("unknown command: %s", os.Args[1]))
+	}
+
+	if err != nil {
+		die(err)
+	}
+}

--- a/cmd/workcell-run-mutation-tests/main.go
+++ b/cmd/workcell-run-mutation-tests/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/omkhar/workcell/internal/mutation"
+)
+
+func main() {
+	root, err := repoRoot()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := mutation.Run(root); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func repoRoot() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("unable to locate repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..")), nil
+}

--- a/cmd/workcell-treecompare/main.go
+++ b/cmd/workcell-treecompare/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/omkhar/workcell/internal/paritytree"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "usage: %s LEFT_ROOT RIGHT_ROOT\n", os.Args[0])
+		os.Exit(64)
+	}
+	if err := paritytree.CompareDirectoryTrees(os.Args[1], os.Args[2]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/omkhar/workcell
+
+go 1.26.0
+
+toolchain go1.26.1
+
+require github.com/BurntSushi/toml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=

--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -1,0 +1,883 @@
+package metadatautil
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	hexDigestPattern      = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	workflowNamePattern   = regexp.MustCompile(`^ {4}name:\s*(.+?)\s*$`)
+	workflowPermissionsRE = regexp.MustCompile(`(?m)^permissions:\s+\{\}$`)
+	actionRefPattern      = regexp.MustCompile(`(?:^|[^[:alnum:]/_.-])%s@([0-9a-f]{40})`)
+	aptInstallPattern     = regexp.MustCompile(`apt-get install -y --no-install-recommends(?s:(.*?))&&`)
+)
+
+type ControlPlaneArtifact struct {
+	Kind        string
+	RepoPath    string
+	RuntimePath string
+}
+
+type PinnedInputsConfig struct {
+	RuntimeDockerfilePath         string
+	ValidatorDockerfilePath       string
+	RemoteValidatorDockerfilePath string
+	ProvidersPackageJSONPath      string
+	ProvidersPackageLockPath      string
+	WorkflowsDir                  string
+	CIWorkflowPath                string
+	ReleaseWorkflowPath           string
+	PinHygieneWorkflowPath        string
+	CodeownersPath                string
+	CodexRequirementsPath         string
+	CodexMCPConfigPath            string
+	HostedControlsPolicyPath      string
+	HostedControlsScriptPath      string
+	MaxDebianSnapshotAgeDays      int
+}
+
+func readText(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func readJSONFile(path string, target any) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(content, target)
+}
+
+func writeJSONFile(path string, value any) error {
+	content, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	content = append(content, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, content, 0o644)
+}
+
+func sha256HexFile(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func isHexDigest(value string) bool {
+	return hexDigestPattern.MatchString(value)
+}
+
+func resolveRepoRootFromDockerfile(dockerfilePath string) string {
+	return filepath.Clean(filepath.Join(filepath.Dir(dockerfilePath), "..", ".."))
+}
+
+func ensureRegularFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("control-plane artifact must be a regular file: %s", path)
+	}
+	return nil
+}
+
+func ensureNoSymlinkPrefix(rootDir, repoPath string) error {
+	relativeParts := strings.Split(filepath.Clean(repoPath), string(filepath.Separator))
+	current := rootDir
+	for _, part := range relativeParts {
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("Control-plane artifact must not be a symlink: %s", repoPath)
+		}
+	}
+	return nil
+}
+
+func ensureTrackedRegularFile(rootDir, repoPath string) error {
+	path := filepath.Join(rootDir, repoPath)
+	if err := ensureNoSymlinkPrefix(rootDir, repoPath); err != nil {
+		return err
+	}
+	if err := ensureRegularFile(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("Missing control-plane artifact: %s", repoPath)
+		}
+		return fmt.Errorf("Control-plane artifact must be a regular file: %s", repoPath)
+	}
+	return nil
+}
+
+func gitOutput(rootDir string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", rootDir}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+func gitInsideWorkTree(rootDir string) bool {
+	output, err := gitOutput(rootDir, "rev-parse", "--is-inside-work-tree")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(output) == "true"
+}
+
+func gitTopLevel(rootDir string) (string, error) {
+	output, err := gitOutput(rootDir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(strings.TrimSpace(output)), nil
+}
+
+func gitTrackedFiles(rootDir string) ([]string, bool, error) {
+	if !gitInsideWorkTree(rootDir) {
+		return nil, false, nil
+	}
+	topLevel, err := gitTopLevel(rootDir)
+	if err != nil {
+		return nil, false, nil
+	}
+	if filepath.Clean(topLevel) != filepath.Clean(rootDir) {
+		return nil, false, nil
+	}
+
+	output, err := gitOutput(rootDir, "ls-files", "-z", "--cached", "--modified", "--others", "--exclude-standard", "--deduplicate")
+	if err != nil {
+		return nil, false, err
+	}
+	parts := strings.Split(output, "\x00")
+	tracked := make([]string, 0, len(parts))
+	for _, path := range parts {
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(rootDir, path))
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		if path != "" {
+			tracked = append(tracked, path)
+		}
+	}
+	sort.Strings(tracked)
+	return tracked, true, nil
+}
+
+func gitTrackedSubset(rootDir string, paths []string, requireTracked bool) ([]string, error) {
+	unique := make([]string, 0, len(paths))
+	seen := map[string]struct{}{}
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		unique = append(unique, path)
+	}
+	sort.Strings(unique)
+
+	if !gitInsideWorkTree(rootDir) {
+		return unique, nil
+	}
+	topLevel, err := gitTopLevel(rootDir)
+	if err != nil {
+		return unique, nil
+	}
+	if filepath.Clean(topLevel) != filepath.Clean(rootDir) {
+		return unique, nil
+	}
+
+	args := append([]string{"ls-files", "--"}, unique...)
+	output, err := gitOutput(rootDir, args...)
+	if err != nil {
+		return nil, err
+	}
+	tracked := map[string]struct{}{}
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line != "" {
+			tracked[line] = struct{}{}
+		}
+	}
+	omitted := make([]string, 0)
+	rendered := make([]string, 0, len(unique))
+	for _, path := range unique {
+		if _, ok := tracked[path]; ok {
+			rendered = append(rendered, path)
+			continue
+		}
+		omitted = append(omitted, path)
+	}
+	if requireTracked && len(omitted) > 0 {
+		var builder strings.Builder
+		builder.WriteString("Release-critical inputs must be tracked before generating a verified build input manifest:\n")
+		for _, path := range omitted {
+			builder.WriteString("  - ")
+			builder.WriteString(path)
+			builder.WriteByte('\n')
+		}
+		return nil, errors.New(strings.TrimSuffix(builder.String(), "\n"))
+	}
+	return rendered, nil
+}
+
+func walkFiles(rootDir, relativeRoot string, excludeParts ...string) ([]string, error) {
+	base := filepath.Join(rootDir, relativeRoot)
+	excluded := map[string]struct{}{}
+	for _, part := range excludeParts {
+		excluded[part] = struct{}{}
+	}
+
+	paths := make([]string, 0)
+	err := filepath.WalkDir(base, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(rootDir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		parts := strings.Split(rel, string(filepath.Separator))
+		for _, part := range parts {
+			if _, ok := excluded[part]; ok {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			paths = append(paths, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func walkRepoFiles(rootDir string) ([]string, error) {
+	excluded := map[string]struct{}{
+		".git":         {},
+		"dist":         {},
+		"tmp":          {},
+		"node_modules": {},
+		"target":       {},
+	}
+	paths := make([]string, 0)
+	err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(rootDir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		parts := strings.Split(rel, string(filepath.Separator))
+		for _, part := range parts {
+			if _, ok := excluded[part]; ok {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+		if strings.Contains(rel, "__pycache__") || strings.HasSuffix(rel, ".pyc") {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			paths = append(paths, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func digestMap(rootDir string, paths []string) (map[string]string, error) {
+	result := make(map[string]string, len(paths))
+	for _, relativePath := range paths {
+		candidate := filepath.Join(rootDir, relativePath)
+		info, err := os.Stat(candidate)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf(
+					"Tracked release input is missing from the working tree; stage the deletion or restore the file before generating a verified build input manifest: %s",
+					relativePath,
+				)
+			}
+			return nil, err
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("Tracked release input is missing from the working tree; stage the deletion or restore the file before generating a verified build input manifest: %s", relativePath)
+		}
+		sum, err := sha256HexFile(candidate)
+		if err != nil {
+			return nil, err
+		}
+		result[relativePath] = sum
+	}
+	return result, nil
+}
+
+func ExtractDockerfileArg(dockerfilePath, argName string) (string, error) {
+	text, err := readText(dockerfilePath)
+	if err != nil {
+		return "", err
+	}
+	pattern := regexp.MustCompile(`(?m)^ARG ` + regexp.QuoteMeta(argName) + `=(.+)$`)
+	match := pattern.FindStringSubmatch(text)
+	if match == nil {
+		return "", fmt.Errorf("Unable to extract %s from %s", argName, dockerfilePath)
+	}
+	return strings.TrimSpace(match[1]), nil
+}
+
+func ExtractClaudeSHA(dockerfilePath, targetArch string) (string, error) {
+	text, err := readText(dockerfilePath)
+	if err != nil {
+		return "", err
+	}
+	pattern := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(targetArch) + `\)\s+\\\s*CLAUDE_PLATFORM="[^"]+";\s+\\\s*CLAUDE_SHA256="([0-9a-f]{64})";`)
+	match := pattern.FindStringSubmatch(text)
+	if match == nil {
+		return "", fmt.Errorf("Unable to extract CLAUDE_SHA256 for %s", targetArch)
+	}
+	return match[1], nil
+}
+
+func ExtractCodexSHA(dockerfilePath, targetArch string) (string, error) {
+	text, err := readText(dockerfilePath)
+	if err != nil {
+		return "", err
+	}
+	pattern := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(targetArch) + `\)\s+\\(?:\s*CLAUDE_[A-Z0-9_]+="[^"]+";\s+\\)*\s*CODEX_ARCH="[^"]+";\s+\\\s*CODEX_SHA256="([0-9a-f]{64})";`)
+	match := pattern.FindStringSubmatch(text)
+	if match == nil {
+		return "", fmt.Errorf("Unable to extract CODEX_SHA256 for %s", targetArch)
+	}
+	return match[1], nil
+}
+
+func ManifestChecksum(manifestPath, platform string) (string, error) {
+	var manifest map[string]any
+	if err := readJSONFile(manifestPath, &manifest); err != nil {
+		return "", err
+	}
+	platforms, ok := manifest["platforms"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("Missing checksum for %s in Claude release manifest", platform)
+	}
+	entry, ok := platforms[platform].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("Missing checksum for %s in Claude release manifest", platform)
+	}
+	checksum, ok := entry["checksum"].(string)
+	if !ok || checksum == "" {
+		return "", fmt.Errorf("Missing checksum for %s in Claude release manifest", platform)
+	}
+	return checksum, nil
+}
+
+func ManifestVersion(manifestPath, expectedVersion string) error {
+	var manifest map[string]any
+	if err := readJSONFile(manifestPath, &manifest); err != nil {
+		return err
+	}
+	version, _ := manifest["version"].(string)
+	if version != expectedVersion {
+		return fmt.Errorf(
+			"Claude release manifest version %q does not match pinned %q",
+			version,
+			expectedVersion,
+		)
+	}
+	return nil
+}
+
+func GenerateControlPlaneManifest(rootDir, outputPath string) error {
+	hostArtifacts := []string{
+		"scripts/workcell",
+		"scripts/lib/extract_direct_mounts",
+		"scripts/lib/render_injection_bundle",
+		"scripts/lib/trusted-docker-client.sh",
+	}
+	runtimeArtifacts := []ControlPlaneArtifact{
+		{Kind: "adapter-baseline", RepoPath: "adapters/claude/.claude/settings.json", RuntimePath: "/opt/workcell/adapters/claude/.claude/settings.json"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/claude/CLAUDE.md", RuntimePath: "/opt/workcell/adapters/claude/CLAUDE.md"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/claude/hooks/guard-bash.sh", RuntimePath: "/opt/workcell/adapters/claude/hooks/guard-bash.sh"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/claude/managed-settings.json", RuntimePath: "/opt/workcell/adapters/claude/managed-settings.json"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/claude/mcp-template.json", RuntimePath: "/opt/workcell/adapters/claude/mcp-template.json"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/AGENTS.md", RuntimePath: "/opt/workcell/adapters/codex/.codex/AGENTS.md"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/agents/anthropic_claude_compat.md", RuntimePath: "/opt/workcell/adapters/codex/.codex/agents/anthropic_claude_compat.md"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/agents/apple_platform_boundary.md", RuntimePath: "/opt/workcell/adapters/codex/.codex/agents/apple_platform_boundary.md"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/agents/distinguished_security.md", RuntimePath: "/opt/workcell/adapters/codex/.codex/agents/distinguished_security.md"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/agents/openai_codex_platform.md", RuntimePath: "/opt/workcell/adapters/codex/.codex/agents/openai_codex_platform.md"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/config.toml", RuntimePath: "/opt/workcell/adapters/codex/.codex/config.toml"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/rules/default.rules", RuntimePath: "/opt/workcell/adapters/codex/.codex/rules/default.rules"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/managed_config.toml", RuntimePath: "/opt/workcell/adapters/codex/managed_config.toml"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/mcp/config.toml", RuntimePath: "/opt/workcell/adapters/codex/mcp/config.toml"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/requirements.toml", RuntimePath: "/opt/workcell/adapters/codex/requirements.toml"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/gemini/.gemini/settings.json", RuntimePath: "/opt/workcell/adapters/gemini/.gemini/settings.json"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/gemini/GEMINI.md", RuntimePath: "/opt/workcell/adapters/gemini/GEMINI.md"},
+		{Kind: "runtime-control-plane", RepoPath: "runtime/container/assurance.sh", RuntimePath: "/usr/local/libexec/workcell/assurance.sh"},
+		{Kind: "runtime-control-plane", RepoPath: "runtime/container/bin/apt-helper.sh", RuntimePath: "/usr/local/libexec/workcell/apt-helper.sh"},
+		{Kind: "runtime-control-plane", RepoPath: "runtime/container/bin/apt-wrapper.sh", RuntimePath: "/usr/local/libexec/workcell/apt-wrapper.sh"},
+		{Kind: "runtime-control-plane", RepoPath: "runtime/container/entrypoint.sh", RuntimePath: "/usr/local/libexec/workcell/entrypoint.sh"},
+		{Kind: "runtime-control-plane", RepoPath: "runtime/container/bin/git", RuntimePath: "/usr/local/libexec/workcell/git-wrapper.sh"},
+		{Kind: "runtime-control-plane", RepoPath: "runtime/container/home-control-plane.sh", RuntimePath: "/usr/local/libexec/workcell/home-control-plane.sh"},
+		{Kind: "runtime-control-plane", RepoPath: "runtime/container/bin/node", RuntimePath: "/usr/local/libexec/workcell/node-wrapper.sh"},
+		{Kind: "runtime-control-plane", RepoPath: "runtime/container/provider-policy.sh", RuntimePath: "/usr/local/libexec/workcell/provider-policy.sh"},
+		{Kind: "runtime-control-plane", RepoPath: "runtime/container/provider-wrapper.sh", RuntimePath: "/usr/local/libexec/workcell/provider-wrapper.sh"},
+		{Kind: "runtime-control-plane", RepoPath: "runtime/container/public-node-guard.mjs", RuntimePath: "/usr/local/libexec/workcell/public-node-guard.mjs"},
+		{Kind: "runtime-control-plane", RepoPath: "runtime/container/runtime-user.sh", RuntimePath: "/usr/local/libexec/workcell/runtime-user.sh"},
+		{Kind: "runtime-control-plane", RepoPath: "adapters/claude/managed-settings.json", RuntimePath: "/etc/claude-code/managed-settings.json"},
+	}
+
+	renderedHost := make([]map[string]any, 0, len(hostArtifacts))
+	for _, repoPath := range hostArtifacts {
+		if err := ensureTrackedRegularFile(rootDir, repoPath); err != nil {
+			return err
+		}
+		sum, err := sha256HexFile(filepath.Join(rootDir, repoPath))
+		if err != nil {
+			return err
+		}
+		renderedHost = append(renderedHost, map[string]any{
+			"repo_path": repoPath,
+			"sha256":    sum,
+		})
+	}
+
+	renderedRuntime := make([]map[string]any, 0, len(runtimeArtifacts))
+	for _, artifact := range runtimeArtifacts {
+		if err := ensureTrackedRegularFile(rootDir, artifact.RepoPath); err != nil {
+			return err
+		}
+		sum, err := sha256HexFile(filepath.Join(rootDir, artifact.RepoPath))
+		if err != nil {
+			return err
+		}
+		renderedRuntime = append(renderedRuntime, map[string]any{
+			"kind":         artifact.Kind,
+			"repo_path":    artifact.RepoPath,
+			"runtime_path": artifact.RuntimePath,
+			"sha256":       sum,
+		})
+	}
+
+	manifest := map[string]any{
+		"schema_version":    2,
+		"host_artifacts":    renderedHost,
+		"runtime_artifacts": renderedRuntime,
+	}
+	return writeJSONFile(outputPath, manifest)
+}
+
+func ValidateControlPlaneManifest(manifestPath string) error {
+	var manifest map[string]any
+	if err := readJSONFile(manifestPath, &manifest); err != nil {
+		return err
+	}
+	schemaVersion, ok := manifest["schema_version"].(float64)
+	if !ok || schemaVersion != 2 {
+		return errors.New("control-plane manifest must use schema_version 2")
+	}
+
+	hostArtifacts, ok := manifest["host_artifacts"].([]any)
+	if !ok || len(hostArtifacts) == 0 {
+		return errors.New("control-plane manifest must include non-empty host_artifacts")
+	}
+	runtimeArtifacts, ok := manifest["runtime_artifacts"].([]any)
+	if !ok || len(runtimeArtifacts) == 0 {
+		return errors.New("control-plane manifest must include non-empty runtime_artifacts")
+	}
+
+	seenHost := map[string]struct{}{}
+	for _, raw := range hostArtifacts {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf("unexpected host artifact shape: %v", raw)
+		}
+		if len(entry) != 2 {
+			return fmt.Errorf("unexpected host artifact shape: %v", entry)
+		}
+		repoPath, ok := entry["repo_path"].(string)
+		if !ok || repoPath == "" {
+			return fmt.Errorf("unexpected host artifact shape: %v", entry)
+		}
+		if _, exists := seenHost[repoPath]; exists {
+			return fmt.Errorf("duplicate host artifact path: %s", repoPath)
+		}
+		seenHost[repoPath] = struct{}{}
+		sha256Value, ok := entry["sha256"].(string)
+		if !ok || !isHexDigest(sha256Value) {
+			return fmt.Errorf("invalid host artifact digest: %v", entry)
+		}
+	}
+
+	seenRuntime := map[string]struct{}{}
+	for _, raw := range runtimeArtifacts {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf("runtime artifact is missing data: %v", raw)
+		}
+		for _, key := range []string{"kind", "repo_path", "runtime_path", "sha256"} {
+			if _, exists := entry[key]; !exists {
+				return fmt.Errorf("runtime artifact is missing %s: %v", key, entry)
+			}
+		}
+		runtimePath, ok := entry["runtime_path"].(string)
+		if !ok || !strings.HasPrefix(runtimePath, "/") {
+			return fmt.Errorf("runtime artifact path must be absolute: %v", entry)
+		}
+		if _, exists := seenRuntime[runtimePath]; exists {
+			return fmt.Errorf("duplicate runtime artifact path: %s", runtimePath)
+		}
+		seenRuntime[runtimePath] = struct{}{}
+		sha256Value, ok := entry["sha256"].(string)
+		if !ok || !isHexDigest(sha256Value) {
+			return fmt.Errorf("invalid runtime artifact digest: %v", entry)
+		}
+	}
+	return nil
+}
+
+func ControlPlaneParityRows(manifestPath string) ([]string, error) {
+	var manifest map[string]any
+	if err := readJSONFile(manifestPath, &manifest); err != nil {
+		return nil, err
+	}
+	runtimeArtifacts, ok := manifest["runtime_artifacts"].([]any)
+	if !ok {
+		return nil, errors.New("control-plane manifest must include runtime_artifacts")
+	}
+	runtimePaths := map[string]struct{}{}
+	for _, raw := range runtimeArtifacts {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		runtimePath, _ := entry["runtime_path"].(string)
+		if runtimePath != "" {
+			runtimePaths[runtimePath] = struct{}{}
+		}
+	}
+
+	rows := make([]string, 0, 4)
+	for _, provider := range []string{"codex", "claude", "gemini"} {
+		prefix := "/opt/workcell/adapters/" + provider + "/"
+		for runtimePath := range runtimePaths {
+			if strings.HasPrefix(runtimePath, prefix) {
+				rows = append(rows, "prefix\t"+provider+"\t"+prefix)
+				break
+			}
+		}
+	}
+	if _, ok := runtimePaths["/etc/claude-code/managed-settings.json"]; ok {
+		rows = append(rows, "path\tclaude-managed-settings\t/etc/claude-code/managed-settings.json")
+	}
+	return rows, nil
+}
+
+func GenerateBuilderEnvironmentManifest(
+	outputPath, buildkitImage, buildxVersionTarget, cosignVersionTarget, qemuImage, syftVersionTarget, buildxVersion, buildxInspect, dockerVersionJSON, qemuVersion, cosignVersion, curlVersion, gitVersion, gzipVersion, syftVersion, tarVersion string,
+) error {
+	var dockerVersion any
+	if err := json.Unmarshal([]byte(dockerVersionJSON), &dockerVersion); err != nil {
+		return err
+	}
+
+	builder := map[string]any{
+		"buildkit_image":        buildkitImage,
+		"buildx_inspect":        buildxInspect,
+		"buildx_version_target": buildxVersionTarget,
+		"buildx_version":        buildxVersion,
+		"cosign_version_target": cosignVersionTarget,
+		"cosign_version":        cosignVersion,
+		"curl_version":          curlVersion,
+		"docker_version":        dockerVersion,
+		"git_version":           gitVersion,
+		"gzip_version":          gzipVersion,
+		"syft_version_target":   syftVersionTarget,
+		"syft_version":          syftVersion,
+		"tar_version":           tarVersion,
+	}
+	if qemuImage != "" {
+		builder["qemu"] = map[string]any{
+			"image":   qemuImage,
+			"version": qemuVersion,
+		}
+	}
+
+	manifest := map[string]any{
+		"schema_version": 1,
+		"builder":        builder,
+	}
+	return writeJSONFile(outputPath, manifest)
+}
+
+func GenerateBuildInputManifest(
+	dockerfilePath, packageJSONPath, packageLockPath, outputPath, buildRef string, sourceDateEpoch int64, requireTracked bool,
+) error {
+	rootDir := resolveRepoRootFromDockerfile(dockerfilePath)
+	dockerfile, err := readText(dockerfilePath)
+	if err != nil {
+		return err
+	}
+	packageJSONText, err := readText(packageJSONPath)
+	if err != nil {
+		return err
+	}
+	packageLockText, err := readText(packageLockPath)
+	if err != nil {
+		return err
+	}
+
+	nodeBaseImage, err := ExtractDockerfileArg(dockerfilePath, "NODE_BASE_IMAGE")
+	if err != nil {
+		return err
+	}
+	debianSnapshot, err := ExtractDockerfileArg(dockerfilePath, "DEBIAN_SNAPSHOT")
+	if err != nil {
+		return err
+	}
+	claudeVersion, err := ExtractDockerfileArg(dockerfilePath, "CLAUDE_VERSION")
+	if err != nil {
+		return err
+	}
+	codexVersion, err := ExtractDockerfileArg(dockerfilePath, "CODEX_VERSION")
+	if err != nil {
+		return err
+	}
+
+	claudeAssets := map[string]any{}
+	for _, target := range []struct {
+		arch     string
+		platform string
+	}{
+		{arch: "arm64", platform: "linux-arm64"},
+		{arch: "amd64", platform: "linux-x64"},
+	} {
+		sha, err := ExtractClaudeSHA(dockerfilePath, target.arch)
+		if err != nil {
+			return err
+		}
+		claudeAssets[target.arch] = map[string]any{
+			"platform": target.platform,
+			"sha256":   sha,
+			"url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/" +
+				claudeVersion + "/" + target.platform + "/claude",
+		}
+	}
+
+	codexAssets := map[string]any{}
+	for _, target := range []struct {
+		arch string
+		name string
+	}{
+		{arch: "arm64", name: "aarch64-unknown-linux-gnu"},
+		{arch: "amd64", name: "x86_64-unknown-linux-gnu"},
+	} {
+		sha, err := ExtractCodexSHA(dockerfilePath, target.arch)
+		if err != nil {
+			return err
+		}
+		codexAssets[target.arch] = map[string]any{
+			"arch":   target.name,
+			"sha256": sha,
+			"url":    "https://github.com/openai/codex/releases/download/rust-v" + codexVersion + "/codex-" + target.name + ".tar.gz",
+		}
+	}
+
+	var packageJSON map[string]any
+	if err := json.Unmarshal([]byte(packageJSONText), &packageJSON); err != nil {
+		return err
+	}
+	var packageLock map[string]any
+	if err := json.Unmarshal([]byte(packageLockText), &packageLock); err != nil {
+		return err
+	}
+
+	dependencies := map[string]any{}
+	rawDependencies, _ := packageJSON["dependencies"].(map[string]any)
+	lockPackages, _ := packageLock["packages"].(map[string]any)
+	for _, name := range sortedKeys(rawDependencies) {
+		pkgEntry, ok := lockPackages["node_modules/"+name].(map[string]any)
+		if !ok {
+			return fmt.Errorf("Missing pinned package entry for %s", name)
+		}
+		version, _ := pkgEntry["version"].(string)
+		resolved, _ := pkgEntry["resolved"].(string)
+		integrity, _ := pkgEntry["integrity"].(string)
+		dependencies[name] = map[string]any{
+			"version":   version,
+			"resolved":  resolved,
+			"integrity": integrity,
+		}
+	}
+
+	adapterContextPaths, err := walkFiles(rootDir, "adapters", "node_modules", "target")
+	if err != nil {
+		return err
+	}
+	runtimeContainerContextPaths, err := walkFiles(rootDir, filepath.Join("runtime", "container"), "node_modules", "target")
+	if err != nil {
+		return err
+	}
+	runtimeContextPaths, err := gitTrackedSubset(rootDir, append(append([]string{".dockerignore"}, adapterContextPaths...), runtimeContainerContextPaths...), requireTracked)
+	if err != nil {
+		return err
+	}
+	runtimeContextInputs, err := digestMap(rootDir, runtimeContextPaths)
+	if err != nil {
+		return err
+	}
+
+	trackedFiles, tracked, err := gitTrackedFiles(rootDir)
+	if err != nil {
+		return err
+	}
+	excludedPrefixes := []string{
+		"dist/",
+		"tmp/",
+		"runtime/container/providers/node_modules/",
+		"runtime/container/rust/target/",
+	}
+	runtimeContextSet := map[string]struct{}{}
+	for _, path := range runtimeContextPaths {
+		runtimeContextSet[path] = struct{}{}
+	}
+
+	var verificationPaths []string
+	if !tracked {
+		verificationPaths, err = walkRepoFiles(rootDir)
+		if err != nil {
+			return err
+		}
+		verificationPaths = filterVerificationPaths(verificationPaths, runtimeContextSet, excludedPrefixes)
+	} else {
+		verificationPaths = filterVerificationPaths(trackedFiles, runtimeContextSet, excludedPrefixes)
+	}
+	verificationInputs, err := digestMap(rootDir, verificationPaths)
+	if err != nil {
+		return err
+	}
+
+	manifest := map[string]any{
+		"schema_version": 1,
+		"build": map[string]any{
+			"ref":               buildRef,
+			"source_date_epoch": sourceDateEpoch,
+		},
+		"runtime": map[string]any{
+			"dockerfile_sha256": sha256HexString(dockerfile),
+			"node_base_image":   nodeBaseImage,
+			"debian_snapshot":   debianSnapshot,
+			"claude": map[string]any{
+				"version": claudeVersion,
+				"assets":  claudeAssets,
+			},
+			"codex": map[string]any{
+				"version": codexVersion,
+				"assets":  codexAssets,
+			},
+			"providers": map[string]any{
+				"package_json_sha256": sha256HexString(packageJSONText),
+				"package_lock_sha256": sha256HexString(packageLockText),
+				"dependencies":        dependencies,
+			},
+			"context_inputs": runtimeContextInputs,
+		},
+		"verification": map[string]any{
+			"inputs": verificationInputs,
+		},
+	}
+	return writeJSONFile(outputPath, manifest)
+}
+
+func sha256HexString(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(sum[:])
+}
+
+func filterVerificationPaths(paths []string, runtimeContextSet map[string]struct{}, excludedPrefixes []string) []string {
+	filtered := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if _, ok := runtimeContextSet[path]; ok {
+			continue
+		}
+		skip := false
+		for _, prefix := range excludedPrefixes {
+			if strings.HasPrefix(path, prefix) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			filtered = append(filtered, path)
+		}
+	}
+	return filtered
+}
+
+func sortedKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/metadatautil/coverage.go
+++ b/internal/metadatautil/coverage.go
@@ -1,0 +1,110 @@
+package metadatautil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func CoveragePercent(reportPath string) (float64, error) {
+	var report map[string]any
+	if err := readJSONFile(reportPath, &report); err != nil {
+		return 0, err
+	}
+	if totals, ok := report["totals"].(map[string]any); ok {
+		if percent, ok := jsonNumberToFloat64(totals["percent_covered"]); ok {
+			return percent, nil
+		}
+	}
+	if data, ok := report["data"].([]any); ok && len(data) > 0 {
+		if entry, ok := data[0].(map[string]any); ok {
+			if totals, ok := entry["totals"].(map[string]any); ok {
+				if lines, ok := totals["lines"].(map[string]any); ok {
+					if percent, ok := jsonNumberToFloat64(lines["percent"]); ok {
+						return percent, nil
+					}
+				}
+			}
+		}
+	}
+	return 0, errors.New("coverage report does not contain a supported totals.percent_covered or data[0].totals.lines.percent field")
+}
+
+func CoverageExecutables(messagePath string) ([]string, error) {
+	content, err := os.ReadFile(messagePath)
+	if err != nil {
+		return nil, err
+	}
+	executables := make([]string, 0)
+	for _, rawLine := range splitLines(string(content)) {
+		if rawLine == "" || rawLine[0] != '{' {
+			continue
+		}
+		var message map[string]any
+		if err := json.Unmarshal([]byte(rawLine), &message); err != nil {
+			continue
+		}
+		if message["reason"] != "compiler-artifact" {
+			continue
+		}
+		executable, _ := message["executable"].(string)
+		target, _ := message["target"].(map[string]any)
+		if executable != "" && target != nil {
+			if kind, _ := target["kind"].([]any); len(kind) == 1 {
+				if label, _ := kind[0].(string); label == "bin" {
+					executables = append(executables, executable)
+				}
+			}
+		}
+	}
+	if len(executables) == 0 {
+		return nil, errors.New("Unable to locate instrumented Rust test executables for coverage")
+	}
+	sort.Strings(executables)
+	unique := executables[:0]
+	var last string
+	for i, executable := range executables {
+		if i == 0 || executable != last {
+			unique = append(unique, executable)
+			last = executable
+		}
+	}
+	return unique, nil
+}
+
+func jsonNumberToFloat64(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return typed, true
+	case json.Number:
+		parsed, err := typed.Float64()
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return 0, false
+}
+
+func splitLines(text string) []string {
+	if text == "" {
+		return nil
+	}
+	lines := make([]string, 0)
+	start := 0
+	for i := 0; i < len(text); i++ {
+		if text[i] == '\n' {
+			lines = append(lines, text[start:i])
+			start = i + 1
+		}
+	}
+	if start <= len(text) {
+		lines = append(lines, text[start:])
+	}
+	return lines
+}
+
+func formatCoveragePercent(label string, percent float64) string {
+	return fmt.Sprintf("%s: %.2f%%", label, percent)
+}

--- a/internal/metadatautil/path.go
+++ b/internal/metadatautil/path.go
@@ -1,0 +1,32 @@
+package metadatautil
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/pathutil"
+)
+
+func expandUserPath(raw string) (string, error) {
+	if raw == "" {
+		return "", errors.New("empty path")
+	}
+	return pathutil.ExpandUserPathBestEffort(raw)
+}
+
+func CanonicalizePath(raw string) (string, error) {
+	expanded, err := expandUserPath(raw)
+	if err != nil {
+		return "", err
+	}
+	return pathutil.CanonicalizeExpandedPath(expanded)
+}
+
+func canonicalizeToShellPath(raw string) string {
+	canonical, err := CanonicalizePath(raw)
+	if err != nil {
+		return raw
+	}
+	return strings.TrimSuffix(canonical, string(filepath.Separator))
+}

--- a/internal/metadatautil/reproducible_build.go
+++ b/internal/metadatautil/reproducible_build.go
@@ -1,0 +1,330 @@
+package metadatautil
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type reproducibleBuildPlatformDigest struct {
+	ImageManifestDigest string `json:"image_manifest_digest"`
+	ConfigDigest        string `json:"config_digest"`
+}
+
+type reproducibleBuildManifest struct {
+	OCISubjectDigest string                                     `json:"oci_subject_digest"`
+	SourceDateEpoch  int64                                      `json:"source_date_epoch"`
+	Platforms        map[string]reproducibleBuildPlatformDigest `json:"platforms"`
+}
+
+type reproducibleBuildReport struct {
+	subjectDigest   string
+	manifestDigests map[string]string
+	configDigests   map[string]string
+}
+
+func VerifyReproducibleBuild(layoutA, layoutB, platformsCSV, manifestPath string, sourceDateEpoch int64) error {
+	platforms, err := parseReproducibleBuildPlatforms(platformsCSV)
+	if err != nil {
+		return err
+	}
+	reportA, err := inspectOCIExport(layoutA, platforms)
+	if err != nil {
+		return err
+	}
+	reportB, err := inspectOCIExport(layoutB, platforms)
+	if err != nil {
+		return err
+	}
+
+	problems := make([]string, 0)
+	for _, platform := range platforms {
+		if reportA.manifestDigests[platform] != reportB.manifestDigests[platform] {
+			problems = append(problems, fmt.Sprintf(
+				"Manifest digests (%s): %s != %s",
+				platform,
+				reportA.manifestDigests[platform],
+				reportB.manifestDigests[platform],
+			))
+		}
+		if reportA.configDigests[platform] != reportB.configDigests[platform] {
+			problems = append(problems, fmt.Sprintf(
+				"Config digests (%s): %s != %s",
+				platform,
+				reportA.configDigests[platform],
+				reportB.configDigests[platform],
+			))
+		}
+	}
+	if reportA.subjectDigest != reportB.subjectDigest {
+		problems = append(problems, fmt.Sprintf(
+			"Non-reproducible OCI export subject digest: %s != %s",
+			reportA.subjectDigest,
+			reportB.subjectDigest,
+		))
+	}
+	if len(problems) > 0 {
+		return errors.New(strings.Join(problems, "\n"))
+	}
+
+	if manifestPath == "" {
+		return nil
+	}
+	platformManifests := make(map[string]reproducibleBuildPlatformDigest, len(platforms))
+	for _, platform := range platforms {
+		platformManifests[platform] = reproducibleBuildPlatformDigest{
+			ImageManifestDigest: reportA.manifestDigests[platform],
+			ConfigDigest:        reportA.configDigests[platform],
+		}
+	}
+	return writeJSONFile(manifestPath, reproducibleBuildManifest{
+		OCISubjectDigest: reportA.subjectDigest,
+		SourceDateEpoch:  sourceDateEpoch,
+		Platforms:        platformManifests,
+	})
+}
+
+func inspectOCIExport(layoutDir string, platforms []string) (reproducibleBuildReport, error) {
+	index, err := readOCIIndex(layoutDir)
+	if err != nil {
+		return reproducibleBuildReport{}, err
+	}
+	subjectDigest, err := ociSubjectDigestFromIndex(index)
+	if err != nil {
+		return reproducibleBuildReport{}, err
+	}
+
+	manifestDigests := make(map[string]string, len(platforms))
+	configDigests := make(map[string]string, len(platforms))
+	for _, platform := range platforms {
+		manifestDigest, err := ociManifestDigest(layoutDir, index, platform)
+		if err != nil {
+			return reproducibleBuildReport{}, err
+		}
+		configDigest, err := ociConfigDigest(layoutDir, manifestDigest)
+		if err != nil {
+			return reproducibleBuildReport{}, err
+		}
+		manifestDigests[platform] = manifestDigest
+		configDigests[platform] = configDigest
+	}
+
+	return reproducibleBuildReport{
+		subjectDigest:   subjectDigest,
+		manifestDigests: manifestDigests,
+		configDigests:   configDigests,
+	}, nil
+}
+
+func parseReproducibleBuildPlatforms(raw string) ([]string, error) {
+	parts := strings.Split(raw, ",")
+	platforms := make([]string, 0, len(parts))
+	for _, part := range parts {
+		platform := strings.TrimSpace(part)
+		if platform == "" {
+			continue
+		}
+		platforms = append(platforms, platform)
+	}
+	if len(platforms) == 0 {
+		return nil, errors.New("WORKCELL_REPRO_PLATFORMS must contain at least one platform")
+	}
+	return platforms, nil
+}
+
+func readOCIIndex(layoutDir string) (map[string]any, error) {
+	var index map[string]any
+	if err := readJSONFile(filepath.Join(layoutDir, "index.json"), &index); err != nil {
+		return nil, err
+	}
+	return index, nil
+}
+
+func ociSubjectDigestFromIndex(index map[string]any) (string, error) {
+	manifests, ok := index["manifests"].([]any)
+	if !ok || len(manifests) == 0 {
+		return "", errors.New("OCI export index does not contain any manifests")
+	}
+	if allOCIManifestsLackPlatform(manifests) {
+		if len(manifests) != 1 {
+			return "", errors.New("Expected a single top-level OCI index wrapper entry for multi-platform export")
+		}
+		digest, ok := ociManifestEntryDigest(manifests[0])
+		if !ok || !strings.HasPrefix(digest, "sha256:") {
+			return "", fmt.Errorf("Malformed wrapped OCI index digest: %q", digest)
+		}
+		return digest, nil
+	}
+	canonical, err := canonicalOCIIndexBytes(index)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func canonicalOCIIndexBytes(index map[string]any) ([]byte, error) {
+	stripped := stripOCIAnnotations(index)
+	return json.Marshal(stripped)
+}
+
+func stripOCIAnnotations(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(typed))
+		for key, nested := range typed {
+			if key == "annotations" {
+				continue
+			}
+			result[key] = stripOCIAnnotations(nested)
+		}
+		return result
+	case []any:
+		result := make([]any, 0, len(typed))
+		for _, nested := range typed {
+			result = append(result, stripOCIAnnotations(nested))
+		}
+		return result
+	default:
+		return value
+	}
+}
+
+func ociManifestDigest(layoutDir string, index map[string]any, platform string) (string, error) {
+	requestedOS, requestedArch, requestedVariant, err := parsePlatformSelector(platform)
+	if err != nil {
+		return "", err
+	}
+	manifests, err := ociManifestEntries(layoutDir, index)
+	if err != nil {
+		return "", err
+	}
+	matches := make([]string, 0)
+	for _, rawManifest := range manifests {
+		entry, ok := rawManifest.(map[string]any)
+		if !ok {
+			continue
+		}
+		platformInfo, _ := entry["platform"].(map[string]any)
+		if platformInfo == nil {
+			continue
+		}
+		if platformValueString(platformInfo, "os") != requestedOS {
+			continue
+		}
+		if platformValueString(platformInfo, "architecture") != requestedArch {
+			continue
+		}
+		if platformValueString(platformInfo, "variant") != requestedVariant {
+			continue
+		}
+		digest, ok := ociManifestEntryDigest(entry)
+		if ok {
+			matches = append(matches, digest)
+		}
+	}
+	if len(matches) != 1 {
+		return "", fmt.Errorf("Expected exactly one manifest for %q, found %d", platform, len(matches))
+	}
+	return matches[0], nil
+}
+
+func ociManifestEntries(layoutDir string, index map[string]any) ([]any, error) {
+	manifests, ok := index["manifests"].([]any)
+	if !ok || len(manifests) == 0 {
+		return nil, errors.New("OCI export index does not contain any manifests")
+	}
+	if !allOCIManifestsLackPlatform(manifests) {
+		return manifests, nil
+	}
+	if len(manifests) != 1 {
+		return nil, errors.New("Expected a single top-level OCI index wrapper entry for multi-platform export")
+	}
+	digest, ok := ociManifestEntryDigest(manifests[0])
+	if !ok || !strings.HasPrefix(digest, "sha256:") {
+		return nil, fmt.Errorf("Malformed wrapped OCI index digest: %q", digest)
+	}
+	nestedIndexPath := filepath.Join(layoutDir, "blobs", "sha256", strings.TrimPrefix(digest, "sha256:"))
+	var nestedIndex map[string]any
+	if err := readJSONFile(nestedIndexPath, &nestedIndex); err != nil {
+		return nil, err
+	}
+	nestedManifests, ok := nestedIndex["manifests"].([]any)
+	if !ok || len(nestedManifests) == 0 {
+		return nil, errors.New("OCI export index does not contain any manifests")
+	}
+	return nestedManifests, nil
+}
+
+func ociConfigDigest(layoutDir, manifestDigest string) (string, error) {
+	if !strings.HasPrefix(manifestDigest, "sha256:") {
+		return "", fmt.Errorf("Malformed OCI manifest digest: %q", manifestDigest)
+	}
+	digest := strings.TrimPrefix(manifestDigest, "sha256:")
+	root := filepath.Join(layoutDir, "blobs", "sha256")
+	for {
+		var manifest map[string]any
+		if err := readJSONFile(filepath.Join(root, digest), &manifest); err != nil {
+			return "", err
+		}
+		if config, ok := manifest["config"].(map[string]any); ok {
+			configDigest, _ := config["digest"].(string)
+			if configDigest == "" {
+				return "", fmt.Errorf("Malformed OCI config digest: %q", config)
+			}
+			return configDigest, nil
+		}
+		manifests, ok := manifest["manifests"].([]any)
+		if !ok || len(manifests) == 0 {
+			return "", fmt.Errorf("Malformed OCI index: %q", manifest)
+		}
+		nextDigest, ok := ociManifestEntryDigest(manifests[0])
+		if !ok || !strings.HasPrefix(nextDigest, "sha256:") {
+			return "", fmt.Errorf("Malformed OCI manifest digest: %q", nextDigest)
+		}
+		digest = strings.TrimPrefix(nextDigest, "sha256:")
+	}
+}
+
+func parsePlatformSelector(platform string) (string, string, string, error) {
+	parts := strings.Split(platform, "/")
+	switch len(parts) {
+	case 2:
+		return parts[0], parts[1], "", nil
+	case 3:
+		return parts[0], parts[1], parts[2], nil
+	default:
+		return "", "", "", fmt.Errorf("Unsupported platform selector: %q", platform)
+	}
+}
+
+func platformValueString(platformInfo map[string]any, key string) string {
+	value, _ := platformInfo[key].(string)
+	return value
+}
+
+func ociManifestEntryDigest(entry any) (string, bool) {
+	manifest, ok := entry.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	digest, ok := manifest["digest"].(string)
+	return digest, ok
+}
+
+func allOCIManifestsLackPlatform(manifests []any) bool {
+	for _, rawManifest := range manifests {
+		manifest, ok := rawManifest.(map[string]any)
+		if !ok {
+			return false
+		}
+		if _, ok := manifest["platform"]; ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/metadatautil/reproducible_build_test.go
+++ b/internal/metadatautil/reproducible_build_test.go
@@ -1,0 +1,158 @@
+package metadatautil
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseTOMLSubsetAllowsMultilineArraysWithTrailingComma(t *testing.T) {
+	parsed, err := ParseTOMLSubset(`
+[required_status_checks]
+contexts = [
+  "Validate repository",
+  "Reproducible build",
+]
+`, "/tmp/policy.toml")
+	if err != nil {
+		t.Fatalf("ParseTOMLSubset() error = %v", err)
+	}
+	table, ok := parsed["required_status_checks"].(map[string]any)
+	if !ok {
+		t.Fatalf("required_status_checks table missing or wrong type: %#v", parsed["required_status_checks"])
+	}
+	contexts, ok := table["contexts"].([]any)
+	if !ok {
+		t.Fatalf("contexts missing or wrong type: %#v", table["contexts"])
+	}
+	if len(contexts) != 2 || contexts[0] != "Validate repository" || contexts[1] != "Reproducible build" {
+		t.Fatalf("contexts = %#v, want two entries", contexts)
+	}
+}
+
+func TestVerifyReproducibleBuildWritesManifest(t *testing.T) {
+	root := t.TempDir()
+	layoutA := filepath.Join(root, "layout-a")
+	layoutB := filepath.Join(root, "layout-b")
+	writeSyntheticOCIExport(t, layoutA)
+	writeSyntheticOCIExport(t, layoutB)
+
+	manifestPath := filepath.Join(root, "repro.json")
+	if err := VerifyReproducibleBuild(layoutA, layoutB, "linux/amd64,linux/arm64", manifestPath, 1700000000); err != nil {
+		t.Fatalf("VerifyReproducibleBuild() error = %v", err)
+	}
+
+	manifestBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	var manifest struct {
+		OCISubjectDigest string `json:"oci_subject_digest"`
+		SourceDateEpoch  int64  `json:"source_date_epoch"`
+		Platforms        map[string]struct {
+			ImageManifestDigest string `json:"image_manifest_digest"`
+			ConfigDigest        string `json:"config_digest"`
+		} `json:"platforms"`
+	}
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if manifest.OCISubjectDigest != "sha256:wrapped-index" {
+		t.Fatalf("subject digest = %q, want %q", manifest.OCISubjectDigest, "sha256:wrapped-index")
+	}
+	if manifest.SourceDateEpoch != 1700000000 {
+		t.Fatalf("source_date_epoch = %d, want %d", manifest.SourceDateEpoch, 1700000000)
+	}
+	if got := manifest.Platforms["linux/amd64"]; got.ImageManifestDigest != "sha256:manifest-amd64" || got.ConfigDigest != "sha256:config-amd64" {
+		t.Fatalf("amd64 platform digests = %+v, want manifest-amd64/config-amd64", got)
+	}
+	if got := manifest.Platforms["linux/arm64"]; got.ImageManifestDigest != "sha256:manifest-arm64" || got.ConfigDigest != "sha256:config-arm64" {
+		t.Fatalf("arm64 platform digests = %+v, want manifest-arm64/config-arm64", got)
+	}
+}
+
+func TestVerifyReproducibleBuildReportsMismatch(t *testing.T) {
+	root := t.TempDir()
+	layoutA := filepath.Join(root, "layout-a")
+	layoutB := filepath.Join(root, "layout-b")
+	writeSyntheticOCIExport(t, layoutA)
+	writeSyntheticOCIExport(t, layoutB)
+
+	badManifest := filepath.Join(layoutB, "blobs", "sha256", "manifest-arm64")
+	if err := os.WriteFile(badManifest, []byte(`{"config":{"digest":"sha256:config-arm64-bad"}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	err := VerifyReproducibleBuild(layoutA, layoutB, "linux/amd64,linux/arm64", "", 1700000000)
+	if err == nil {
+		t.Fatalf("VerifyReproducibleBuild() error = nil, want mismatch")
+	}
+	if !strings.Contains(err.Error(), "Config digests (linux/arm64):") {
+		t.Fatalf("VerifyReproducibleBuild() error = %q, want config mismatch", err)
+	}
+}
+
+func writeSyntheticOCIExport(t *testing.T, root string) {
+	t.Helper()
+
+	mustWriteJSONFile := func(path string, value any) {
+		t.Helper()
+		data, err := json.MarshalIndent(value, "", "  ")
+		if err != nil {
+			t.Fatalf("json.MarshalIndent() error = %v", err)
+		}
+		data = append(data, '\n')
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+	}
+
+	mustWriteJSONFile(filepath.Join(root, "index.json"), map[string]any{
+		"annotations": map[string]any{
+			"ignored": "top-level",
+		},
+		"manifests": []any{
+			map[string]any{
+				"digest": "sha256:wrapped-index",
+			},
+		},
+	})
+
+	mustWriteJSONFile(filepath.Join(root, "blobs", "sha256", "wrapped-index"), map[string]any{
+		"annotations": map[string]any{
+			"ignored": "nested",
+		},
+		"manifests": []any{
+			map[string]any{
+				"digest": "sha256:manifest-amd64",
+				"platform": map[string]any{
+					"os":           "linux",
+					"architecture": "amd64",
+				},
+			},
+			map[string]any{
+				"digest": "sha256:manifest-arm64",
+				"platform": map[string]any{
+					"os":           "linux",
+					"architecture": "arm64",
+				},
+			},
+		},
+	})
+
+	mustWriteJSONFile(filepath.Join(root, "blobs", "sha256", "manifest-amd64"), map[string]any{
+		"config": map[string]any{
+			"digest": "sha256:config-amd64",
+		},
+	})
+	mustWriteJSONFile(filepath.Join(root, "blobs", "sha256", "manifest-arm64"), map[string]any{
+		"config": map[string]any{
+			"digest": "sha256:config-arm64",
+		},
+	})
+}

--- a/internal/metadatautil/toml.go
+++ b/internal/metadatautil/toml.go
@@ -1,0 +1,306 @@
+package metadatautil
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func stripComment(line string) string {
+	escaped := false
+	quoteChar := byte(0)
+	result := make([]byte, 0, len(line))
+
+	for i := 0; i < len(line); i++ {
+		char := line[i]
+		if escaped {
+			result = append(result, char)
+			escaped = false
+			continue
+		}
+		if char == '\\' && quoteChar == '"' {
+			result = append(result, char)
+			escaped = true
+			continue
+		}
+		if char == '\'' || char == '"' {
+			if quoteChar == 0 {
+				quoteChar = char
+			} else if quoteChar == char {
+				quoteChar = 0
+			}
+			result = append(result, char)
+			continue
+		}
+		if char == '#' && quoteChar == 0 {
+			break
+		}
+		result = append(result, char)
+	}
+	return strings.TrimSpace(string(result))
+}
+
+func parseTomlValue(raw string, context string) (any, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return nil, fmt.Errorf("%s: expected a value", context)
+	}
+	switch value {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	}
+	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+		parsed, err := strconv.Unquote(value)
+		if err != nil {
+			return nil, fmt.Errorf("%s: invalid quoted string: %w", context, err)
+		}
+		return parsed, nil
+	}
+	if strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'") {
+		return strings.Trim(value, "'"), nil
+	}
+	if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+		return parseTomlArray(value, context)
+	}
+	if i, err := strconv.Atoi(value); err == nil {
+		return i, nil
+	}
+	return nil, fmt.Errorf("%s: unsupported TOML value", context)
+}
+
+func parseTomlArray(raw string, context string) ([]any, error) {
+	inner := strings.TrimSpace(raw[1 : len(raw)-1])
+	if inner == "" {
+		return []any{}, nil
+	}
+
+	items := splitTomlArray(inner)
+	values := make([]any, 0, len(items))
+	for _, item := range items {
+		if strings.TrimSpace(item) == "" {
+			continue
+		}
+		value, err := parseTomlValue(item, context)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func splitTomlArray(raw string) []string {
+	items := make([]string, 0)
+	quoteChar := byte(0)
+	escaped := false
+	start := 0
+	for i := 0; i < len(raw); i++ {
+		char := raw[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if char == '\\' && quoteChar == '"' {
+			escaped = true
+			continue
+		}
+		if char == '\'' || char == '"' {
+			if quoteChar == 0 {
+				quoteChar = char
+			} else if quoteChar == char {
+				quoteChar = 0
+			}
+			continue
+		}
+		if char == ',' && quoteChar == 0 {
+			if item := strings.TrimSpace(raw[start:i]); item != "" {
+				items = append(items, item)
+			}
+			start = i + 1
+		}
+	}
+	if item := strings.TrimSpace(raw[start:]); item != "" {
+		items = append(items, item)
+	}
+	return items
+}
+
+func tomlArrayClosed(raw string) bool {
+	depth := 0
+	quoteChar := byte(0)
+	escaped := false
+	for i := 0; i < len(raw); i++ {
+		char := raw[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if char == '\\' && quoteChar == '"' {
+			escaped = true
+			continue
+		}
+		if char == '\'' || char == '"' {
+			if quoteChar == 0 {
+				quoteChar = char
+			} else if quoteChar == char {
+				quoteChar = 0
+			}
+			continue
+		}
+		if quoteChar != 0 {
+			continue
+		}
+		switch char {
+		case '[':
+			depth++
+		case ']':
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+	return depth == 0
+}
+
+func parseTomlPath(raw string) ([]string, error) {
+	parts := strings.Split(raw, ".")
+	path := make([]string, 0, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			return nil, errors.New("empty table component")
+		}
+		if strings.Contains(name, " ") {
+			return nil, fmt.Errorf("unsupported table component %q", name)
+		}
+		path = append(path, name)
+	}
+	return path, nil
+}
+
+func ensureTomlTable(root map[string]any, path []string) (map[string]any, error) {
+	current := root
+	for _, part := range path {
+		existing, ok := current[part]
+		if !ok {
+			child := map[string]any{}
+			current[part] = child
+			current = child
+			continue
+		}
+		child, ok := existing.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%s is not a table", strings.Join(path, "."))
+		}
+		current = child
+	}
+	return current, nil
+}
+
+func ParseTOMLSubset(content string, sourcePath string) (map[string]any, error) {
+	root := map[string]any{}
+	current := root
+	seenTables := map[string]struct{}{}
+
+	lines := strings.Split(content, "\n")
+	for idx := 0; idx < len(lines); idx++ {
+		rawLine := lines[idx]
+		lineNo := idx + 1
+		line := stripComment(rawLine)
+		if line == "" {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[[") && strings.HasSuffix(line, "]]") {
+			return nil, fmt.Errorf("%s:%d: unsupported array-of-table", sourcePath, lineNo)
+		}
+
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			tableName := strings.TrimSpace(line[1 : len(line)-1])
+			if tableName == "" {
+				return nil, fmt.Errorf("%s:%d: empty table name", sourcePath, lineNo)
+			}
+			if _, exists := seenTables[tableName]; exists {
+				return nil, fmt.Errorf("%s:%d: duplicate table [%s]", sourcePath, lineNo, tableName)
+			}
+			path, err := parseTomlPath(tableName)
+			if err != nil {
+				return nil, fmt.Errorf("%s:%d: %w", sourcePath, lineNo, err)
+			}
+			current, err = ensureTomlTable(root, path)
+			if err != nil {
+				return nil, fmt.Errorf("%s:%d: %w", sourcePath, lineNo, err)
+			}
+			seenTables[tableName] = struct{}{}
+			continue
+		}
+
+		if !strings.Contains(line, "=") {
+			return nil, fmt.Errorf("%s:%d: expected key = value", sourcePath, lineNo)
+		}
+		parts := strings.SplitN(line, "=", 2)
+		key := strings.TrimSpace(parts[0])
+		if key == "" {
+			return nil, fmt.Errorf("%s:%d: empty key", sourcePath, lineNo)
+		}
+		if strings.Contains(key, ".") {
+			return nil, fmt.Errorf("%s:%d: dotted TOML keys are not supported", sourcePath, lineNo)
+		}
+		if _, exists := current[key]; exists {
+			return nil, fmt.Errorf("%s:%d: duplicate key: %s", sourcePath, lineNo, key)
+		}
+		valueText := parts[1]
+		if strings.HasPrefix(strings.TrimSpace(valueText), "[") && !tomlArrayClosed(valueText) {
+			for {
+				idx++
+				if idx >= len(lines) {
+					return nil, fmt.Errorf("%s:%d: unterminated TOML array", sourcePath, lineNo)
+				}
+				nextLine := stripComment(lines[idx])
+				if nextLine == "" {
+					continue
+				}
+				valueText += "\n" + nextLine
+				if tomlArrayClosed(valueText) {
+					break
+				}
+			}
+		}
+		value, err := parseTomlValue(valueText, fmt.Sprintf("%s:%d", sourcePath, lineNo))
+		if err != nil {
+			return nil, err
+		}
+		current[key] = value
+	}
+
+	return root, nil
+}
+
+func MustString(value any) (string, bool) {
+	s, ok := value.(string)
+	return s, ok
+}
+
+func MustStringMap(value any) (map[string]any, bool) {
+	m, ok := value.(map[string]any)
+	return m, ok
+}
+
+func MustStringSlice(value any) ([]string, bool, error) {
+	raw, ok := value.([]any)
+	if !ok {
+		return nil, false, nil
+	}
+	result := make([]string, 0, len(raw))
+	for _, item := range raw {
+		s, ok := item.(string)
+		if !ok {
+			return nil, false, errors.New("array value must contain only strings")
+		}
+		result = append(result, s)
+	}
+	return result, true, nil
+}

--- a/internal/metadatautil/toml_test.go
+++ b/internal/metadatautil/toml_test.go
@@ -1,0 +1,42 @@
+package metadatautil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseTOMLSubsetSupportsMultilineStringArrays(t *testing.T) {
+	parsed, err := ParseTOMLSubset(`
+[required_status_checks]
+contexts = [
+  "Validate repository",
+  "Container smoke",
+  "Reproducible build",
+]
+`, "policy/github-hosted-controls.toml")
+	if err != nil {
+		t.Fatalf("ParseTOMLSubset returned error: %v", err)
+	}
+
+	required, ok := parsed["required_status_checks"].(map[string]any)
+	if !ok {
+		t.Fatalf("required_status_checks missing or wrong type: %#v", parsed["required_status_checks"])
+	}
+
+	contexts, ok, err := MustStringSlice(required["contexts"])
+	if err != nil {
+		t.Fatalf("MustStringSlice returned error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("contexts missing or wrong type: %#v", required["contexts"])
+	}
+
+	expected := []string{
+		"Validate repository",
+		"Container smoke",
+		"Reproducible build",
+	}
+	if !reflect.DeepEqual(contexts, expected) {
+		t.Fatalf("contexts mismatch: got %#v want %#v", contexts, expected)
+	}
+}

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -1,0 +1,1403 @@
+package metadatautil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func CheckWorkflows(rootDir, policyPath string) error {
+	if err := ensureWorkflowTools(); err != nil {
+		return err
+	}
+
+	policyText, err := readText(policyPath)
+	if err != nil {
+		return err
+	}
+	policy, err := ParseTOMLSubset(policyText, policyPath)
+	if err != nil {
+		return err
+	}
+
+	contexts, err := requireStringSliceTable(policy, "required_status_checks", "contexts", policyPath)
+	if err != nil {
+		return err
+	}
+	if len(contexts) == 0 {
+		return fmt.Errorf("%s must define required_status_checks.contexts as a non-empty array", policyPath)
+	}
+
+	workflowDir := filepath.Join(rootDir, ".github", "workflows")
+	workflowPaths, err := filepath.Glob(filepath.Join(workflowDir, "*.yml"))
+	if err != nil {
+		return err
+	}
+
+	jobNames := map[string]struct{}{}
+	for _, path := range workflowPaths {
+		content, err := readText(path)
+		if err != nil {
+			return err
+		}
+		for _, match := range workflowNamePattern.FindAllStringSubmatch(content, -1) {
+			name := strings.TrimSpace(match[1])
+			name = strings.Trim(name, `"'`)
+			if name != "" {
+				jobNames[name] = struct{}{}
+			}
+		}
+	}
+
+	missing := make([]string, 0)
+	for _, expected := range contexts {
+		if _, ok := jobNames[expected]; !ok {
+			missing = append(missing, expected)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"Workflow jobs are missing required status-check names from %s: %s",
+			policyPath,
+			strings.Join(missing, ", "),
+		)
+	}
+	return nil
+}
+
+func ensureWorkflowTools() error { return nil }
+
+func FetchGitHubHostedControlsRulesets(tmpDir, repo string) error {
+	var summary []any
+	if err := readJSONFile(filepath.Join(tmpDir, "rulesets-summary.json"), &summary); err != nil {
+		return err
+	}
+
+	details := make([]any, 0, len(summary))
+	for _, raw := range summary {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf("unexpected ruleset summary entry: %v", raw)
+		}
+		idValue, ok := entry["id"].(float64)
+		if !ok {
+			return fmt.Errorf("unexpected ruleset summary id: %v", entry)
+		}
+		rulesetID := strconv.FormatInt(int64(idValue), 10)
+		cmd := exec.Command("gh", "api", fmt.Sprintf("repos/%s/rulesets/%s", repo, rulesetID))
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("gh api repos/%s/rulesets/%s: %w", repo, rulesetID, err)
+		}
+		var detail any
+		if err := json.Unmarshal(output, &detail); err != nil {
+			return err
+		}
+		details = append(details, detail)
+	}
+	return writeJSONFile(filepath.Join(tmpDir, "rulesets.json"), details)
+}
+
+func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
+	var repoMeta map[string]any
+	if err := readJSONFile(filepath.Join(tmpDir, "repo.json"), &repoMeta); err != nil {
+		return err
+	}
+	var actionsPermissions map[string]any
+	if err := readJSONFile(filepath.Join(tmpDir, "actions-permissions.json"), &actionsPermissions); err != nil {
+		return err
+	}
+	var actionsVariables map[string]any
+	if err := readJSONFile(filepath.Join(tmpDir, "actions-variables.json"), &actionsVariables); err != nil {
+		return err
+	}
+	var directCollaborators []any
+	if err := readJSONFile(filepath.Join(tmpDir, "collaborators-direct.json"), &directCollaborators); err != nil {
+		return err
+	}
+	var rulesets []any
+	if err := readJSONFile(filepath.Join(tmpDir, "rulesets.json"), &rulesets); err != nil {
+		return err
+	}
+	var releaseEnv map[string]any
+	if err := readJSONFile(filepath.Join(tmpDir, "environment-release.json"), &releaseEnv); err != nil {
+		return err
+	}
+	policyText, err := readText(policyPath)
+	if err != nil {
+		return err
+	}
+	policy, err := ParseTOMLSubset(policyText, policyPath)
+	if err != nil {
+		return err
+	}
+
+	defaultBranch, _ := repoMeta["default_branch"].(string)
+	owner, _ := repoMeta["owner"].(map[string]any)
+	ownerLogin, _ := owner["login"].(string)
+	ownerType, _ := owner["type"].(string)
+
+	branchIntegrityPolicy, ok := policy["branch_integrity"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s must define branch_integrity as a table with explicit booleans", policyPath)
+	}
+	for _, key := range []string{"require_signed_commits", "block_force_pushes", "block_deletions"} {
+		if value, ok := branchIntegrityPolicy[key].(bool); !ok || !value {
+			return fmt.Errorf("%s must set branch_integrity.%s = true", policyPath, key)
+		}
+	}
+	branchReviewPolicy, _ := policy["branch_review"].(map[string]any)
+	branchReviewMode, _ := branchReviewPolicy["mode"].(string)
+	if branchReviewMode == "" {
+		branchReviewMode = "review-gated"
+	}
+	if branchReviewMode != "review-gated" && branchReviewMode != "single-owner-private-pr" {
+		return fmt.Errorf("%s must set branch_review.mode to 'review-gated' or 'single-owner-private-pr'", policyPath)
+	}
+	releasePolicy, _ := policy["release_environment"].(map[string]any)
+	releaseMode, _ := releasePolicy["mode"].(string)
+	if releaseMode == "" {
+		releaseMode = "review-gated"
+	}
+	if releaseMode != "review-gated" && releaseMode != "single-owner-private" && releaseMode != "plan-limited-private" {
+		return fmt.Errorf("%s must set release_environment.mode to 'review-gated', 'single-owner-private', or 'plan-limited-private'", policyPath)
+	}
+	expectedContexts, err := requireStringSliceTable(policy, "required_status_checks", "contexts", policyPath)
+	if err != nil {
+		return err
+	}
+	if len(expectedContexts) == 0 {
+		return fmt.Errorf("%s must define required_status_checks.contexts as a non-empty array", policyPath)
+	}
+	expectedRepoVariables, ok := policy["repository_variables"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s must define repository_variables as a table of exact expected values", policyPath)
+	}
+	for name, value := range expectedRepoVariables {
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("%s repository_variables entries must map non-empty names to exact string values", policyPath)
+		}
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("%s repository_variables entries must map non-empty names to exact string values", policyPath)
+		}
+	}
+	if _, ok := expectedRepoVariables["WORKCELL_ENABLE_GITHUB_ATTESTATIONS"]; !ok {
+		return fmt.Errorf("%s must declare WORKCELL_ENABLE_GITHUB_ATTESTATIONS in repository_variables", policyPath)
+	}
+
+	if enabled, _ := actionsPermissions["enabled"].(bool); !enabled {
+		return fmt.Errorf("GitHub Actions must be enabled on %s", repo)
+	}
+	if required, _ := actionsPermissions["sha_pinning_required"].(bool); !required {
+		return fmt.Errorf("GitHub Actions SHA pinning must be required on %s", repo)
+	}
+
+	activeRulesets := make([]map[string]any, 0)
+	for _, raw := range rulesets {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if enforcement, _ := entry["enforcement"].(string); enforcement == "active" {
+			activeRulesets = append(activeRulesets, entry)
+		}
+	}
+	if len(activeRulesets) == 0 {
+		return fmt.Errorf("No active rulesets found on %s", repo)
+	}
+
+	hasRefInclude := func(ruleset map[string]any, expected string) bool {
+		conditions, _ := ruleset["conditions"].(map[string]any)
+		refName, _ := conditions["ref_name"].(map[string]any)
+		include, _ := refName["include"].([]any)
+		for _, raw := range include {
+			if s, _ := raw.(string); s == expected {
+				return true
+			}
+		}
+		return false
+	}
+	hasRule := func(ruleset map[string]any, ruleType string) map[string]any {
+		rules, _ := ruleset["rules"].([]any)
+		for _, raw := range rules {
+			entry, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if typ, _ := entry["type"].(string); typ == ruleType {
+				return entry
+			}
+		}
+		return nil
+	}
+	requireBypassShape := func(ruleset map[string]any, actorType, bypassMode string, requireNonEmpty bool) error {
+		actors, _ := ruleset["bypass_actors"].([]any)
+		if requireNonEmpty && len(actors) == 0 {
+			return fmt.Errorf("Ruleset %v on %s must declare an explicit bypass actor", ruleset["name"], repo)
+		}
+		for _, raw := range actors {
+			entry, ok := raw.(map[string]any)
+			if !ok {
+				return fmt.Errorf("Ruleset %v on %s must only use %s/%s bypass actors", ruleset["name"], repo, actorType, bypassMode)
+			}
+			if at, _ := entry["actor_type"].(string); at != actorType {
+				return fmt.Errorf("Ruleset %v on %s must only use %s/%s bypass actors", ruleset["name"], repo, actorType, bypassMode)
+			}
+			if bm, _ := entry["bypass_mode"].(string); bm != bypassMode {
+				return fmt.Errorf("Ruleset %v on %s must only use %s/%s bypass actors", ruleset["name"], repo, actorType, bypassMode)
+			}
+		}
+		return nil
+	}
+
+	var branchIntegrity, branchReview, branchStatusChecks, tagRelease map[string]any
+	for _, ruleset := range activeRulesets {
+		target, _ := ruleset["target"].(string)
+		if target == "branch" && hasRefInclude(ruleset, "~DEFAULT_BRANCH") {
+			if hasRule(ruleset, "required_signatures") != nil && hasRule(ruleset, "non_fast_forward") != nil && hasRule(ruleset, "deletion") != nil {
+				branchIntegrity = ruleset
+			}
+			if hasRule(ruleset, "pull_request") != nil {
+				branchReview = ruleset
+			}
+			if hasRule(ruleset, "required_status_checks") != nil {
+				branchStatusChecks = ruleset
+			}
+		}
+		if target == "tag" && hasRefInclude(ruleset, "refs/tags/v*") {
+			if hasRule(ruleset, "creation") != nil && hasRule(ruleset, "update") != nil && hasRule(ruleset, "deletion") != nil {
+				tagRelease = ruleset
+			}
+		}
+	}
+	if branchIntegrity == nil {
+		return fmt.Errorf("Missing active default-branch integrity ruleset on %s with required_signatures, non_fast_forward, and deletion", repo)
+	}
+	if branchReview == nil {
+		return fmt.Errorf("Missing active default-branch review ruleset on %s with a pull_request rule", repo)
+	}
+	if branchStatusChecks == nil {
+		return fmt.Errorf("Missing active default-branch status-check ruleset on %s with a required_status_checks rule", repo)
+	}
+	if actors, _ := branchIntegrity["bypass_actors"].([]any); len(actors) > 0 {
+		return fmt.Errorf("Default-branch integrity ruleset on %s must not declare bypass actors", repo)
+	}
+	if err := requireBypassShape(branchReview, "RepositoryRole", "pull_request", false); err != nil {
+		return err
+	}
+	if tagRelease == nil {
+		return fmt.Errorf("Missing active release-tag ruleset on %s for refs/tags/v* with creation/update/deletion protection", repo)
+	}
+	if err := requireBypassShape(tagRelease, "RepositoryRole", "always", true); err != nil {
+		return err
+	}
+
+	pullRequestRule := hasRule(branchReview, "pull_request")
+	parameters, _ := pullRequestRule["parameters"].(map[string]any)
+	if branchReviewMode == "review-gated" {
+		if count, _ := parameters["required_approving_review_count"].(float64); count < 1 {
+			return fmt.Errorf("Default-branch review ruleset on %s must require at least one approving review", repo)
+		}
+		if required, _ := parameters["require_code_owner_review"].(bool); !required {
+			return fmt.Errorf("Default-branch review ruleset on %s must require code owner review", repo)
+		}
+		if resolved, _ := parameters["required_review_thread_resolution"].(bool); !resolved {
+			return fmt.Errorf("Default-branch review ruleset on %s must require resolved review threads", repo)
+		}
+	} else {
+		if private, _ := repoMeta["private"].(bool); !private {
+			return fmt.Errorf("Branch review mode 'single-owner-private-pr' on %s is only valid for private repositories", repo)
+		}
+		if ownerType != "User" {
+			return fmt.Errorf("Branch review mode 'single-owner-private-pr' on %s is only valid for user-owned repositories", repo)
+		}
+		if len(directCollaborators) != 1 {
+			return fmt.Errorf("Branch review mode 'single-owner-private-pr' on %s requires exactly one direct collaborator", repo)
+		}
+		collaborator, _ := directCollaborators[0].(map[string]any)
+		if login, _ := collaborator["login"].(string); login != ownerLogin {
+			return fmt.Errorf("Branch review mode 'single-owner-private-pr' on %s requires the owner to be the only direct collaborator", repo)
+		}
+		permissions, _ := collaborator["permissions"].(map[string]any)
+		if admin, _ := permissions["admin"].(bool); !admin {
+			return fmt.Errorf("Branch review mode 'single-owner-private-pr' on %s requires the owner to retain admin permission", repo)
+		}
+		if count, _ := parameters["required_approving_review_count"].(float64); count != 0 {
+			return fmt.Errorf("Default-branch review ruleset on %s must require zero approving reviews in single-owner-private-pr mode", repo)
+		}
+		if required, _ := parameters["require_code_owner_review"].(bool); required {
+			return fmt.Errorf("Default-branch review ruleset on %s must not require code owner review in single-owner-private-pr mode", repo)
+		}
+		if resolved, _ := parameters["required_review_thread_resolution"].(bool); resolved {
+			return fmt.Errorf("Default-branch review ruleset on %s must not require resolved review threads in single-owner-private-pr mode", repo)
+		}
+	}
+
+	statusRule := hasRule(branchStatusChecks, "required_status_checks")
+	statusParameters, _ := statusRule["parameters"].(map[string]any)
+	if strict, _ := statusParameters["strict_required_status_checks_policy"].(bool); !strict {
+		return fmt.Errorf("Default-branch status-check ruleset on %s must require strict status checks", repo)
+	}
+	requiredStatusChecks, _ := statusParameters["required_status_checks"].([]any)
+	actualStatus := map[string]struct{}{}
+	for _, raw := range requiredStatusChecks {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if context, _ := entry["context"].(string); context != "" {
+			actualStatus[context] = struct{}{}
+		}
+	}
+	missingStatus := make([]string, 0)
+	for _, expected := range expectedContexts {
+		if _, ok := actualStatus[expected]; !ok {
+			missingStatus = append(missingStatus, expected)
+		}
+	}
+	sort.Strings(missingStatus)
+	if len(missingStatus) > 0 {
+		return fmt.Errorf("Default-branch status-check ruleset on %s is missing required contexts: %s", repo, strings.Join(missingStatus, ", "))
+	}
+
+	actualRepoVariables := map[string]any{}
+	if variables, ok := actionsVariables["variables"].([]any); ok {
+		for _, raw := range variables {
+			entry, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			name, _ := entry["name"].(string)
+			if name != "" {
+				actualRepoVariables[name] = entry["value"]
+			}
+		}
+	}
+	missingRepoVariables := make([]string, 0)
+	for name := range expectedRepoVariables {
+		if _, ok := actualRepoVariables[name]; !ok {
+			missingRepoVariables = append(missingRepoVariables, name)
+		}
+	}
+	sort.Strings(missingRepoVariables)
+	if len(missingRepoVariables) > 0 {
+		return fmt.Errorf("Repository variables missing on %s: %s", repo, strings.Join(missingRepoVariables, ", "))
+	}
+	wrongRepoVariables := make([]string, 0)
+	for name, expectedValue := range expectedRepoVariables {
+		if actualRepoVariables[name] != expectedValue {
+			wrongRepoVariables = append(wrongRepoVariables, fmt.Sprintf("%s=%#v (expected %#v)", name, actualRepoVariables[name], expectedValue))
+		}
+	}
+	sort.Strings(wrongRepoVariables)
+	if len(wrongRepoVariables) > 0 {
+		return fmt.Errorf("Repository variables on %s do not match policy: %s", repo, strings.Join(wrongRepoVariables, ", "))
+	}
+
+	protectionRules, _ := releaseEnv["protection_rules"].([]any)
+	reviewerRules := make([]map[string]any, 0)
+	var adminBypassRule map[string]any
+	for _, raw := range protectionRules {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typ, _ := entry["type"].(string); typ == "required_reviewers" {
+			reviewerRules = append(reviewerRules, entry)
+		}
+		if typ, _ := entry["type"].(string); typ == "admin_bypass" {
+			adminBypassRule = entry
+		}
+	}
+	switch releaseMode {
+	case "review-gated":
+		if len(reviewerRules) == 0 {
+			return fmt.Errorf("Release environment on %s must require a human reviewer", repo)
+		}
+		hasReviewer := false
+		for _, rule := range reviewerRules {
+			if reviewers, _ := rule["reviewers"].([]any); len(reviewers) > 0 {
+				hasReviewer = true
+				break
+			}
+		}
+		if !hasReviewer {
+			return fmt.Errorf("Release environment on %s must define at least one reviewer", repo)
+		}
+		if bypass, _ := releaseEnv["can_admins_bypass"].(bool); bypass {
+			return fmt.Errorf("Release environment on %s must not allow administrator bypass", repo)
+		}
+		if adminBypassRule != nil {
+			if enabled, _ := adminBypassRule["enabled"].(bool); enabled {
+				return fmt.Errorf("Release environment on %s must not allow administrator bypass", repo)
+			}
+		}
+	case "plan-limited-private":
+		if private, _ := repoMeta["private"].(bool); !private {
+			return fmt.Errorf("Release environment mode 'plan-limited-private' on %s is only valid for private repositories", repo)
+		}
+		if len(reviewerRules) > 0 {
+			return fmt.Errorf("Release environment on %s must not define reviewer gates in plan-limited-private mode", repo)
+		}
+	default:
+		if private, _ := repoMeta["private"].(bool); !private {
+			return fmt.Errorf("Release environment mode 'single-owner-private' on %s is only valid for private repositories", repo)
+		}
+		if ownerType != "User" {
+			return fmt.Errorf("Release environment mode 'single-owner-private' on %s is only valid for user-owned repositories", repo)
+		}
+		if len(directCollaborators) != 1 {
+			return fmt.Errorf("Release environment mode 'single-owner-private' on %s requires exactly one direct collaborator", repo)
+		}
+		collaborator, _ := directCollaborators[0].(map[string]any)
+		if login, _ := collaborator["login"].(string); login != ownerLogin {
+			return fmt.Errorf("Release environment mode 'single-owner-private' on %s requires the owner to be the only direct collaborator", repo)
+		}
+		permissions, _ := collaborator["permissions"].(map[string]any)
+		if admin, _ := permissions["admin"].(bool); !admin {
+			return fmt.Errorf("Release environment mode 'single-owner-private' on %s requires the owner to retain admin permission", repo)
+		}
+	}
+
+	_ = defaultBranch
+	return nil
+}
+
+func CheckPinnedInputs(cfg PinnedInputsConfig) error {
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(cfg.RuntimeDockerfilePath), "..", ".."))
+	goModPath := filepath.Join(repoRoot, "go.mod")
+	cargoManifestPath := filepath.Join(repoRoot, "runtime", "container", "rust", "Cargo.toml")
+	rustToolchainPath := filepath.Join(repoRoot, "runtime", "container", "rust", "rust-toolchain.toml")
+
+	runtimeDockerfile, err := readText(cfg.RuntimeDockerfilePath)
+	if err != nil {
+		return err
+	}
+	validatorDockerfile, err := readText(cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	remoteValidatorDockerfile, err := readText(cfg.RemoteValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	providersPackageJSONText, err := readText(cfg.ProvidersPackageJSONPath)
+	if err != nil {
+		return err
+	}
+	providersPackageLockText, err := readText(cfg.ProvidersPackageLockPath)
+	if err != nil {
+		return err
+	}
+	ciWorkflow, err := readText(cfg.CIWorkflowPath)
+	if err != nil {
+		return err
+	}
+	releaseWorkflow, err := readText(cfg.ReleaseWorkflowPath)
+	if err != nil {
+		return err
+	}
+	pinHygieneWorkflow, err := readText(cfg.PinHygieneWorkflowPath)
+	if err != nil {
+		return err
+	}
+	codeowners, err := readText(cfg.CodeownersPath)
+	if err != nil {
+		return err
+	}
+	hostedControlsPolicyText, err := readText(cfg.HostedControlsPolicyPath)
+	if err != nil {
+		return err
+	}
+	hostedControlsScript, err := readText(cfg.HostedControlsScriptPath)
+	if err != nil {
+		return err
+	}
+	codexRequirementsText, err := readText(cfg.CodexRequirementsPath)
+	if err != nil {
+		return err
+	}
+	codexMCPConfigText, err := readText(cfg.CodexMCPConfigPath)
+	if err != nil {
+		return err
+	}
+	goModText, err := readText(goModPath)
+	if err != nil {
+		return err
+	}
+	cargoManifestText, err := readText(cargoManifestPath)
+	if err != nil {
+		return err
+	}
+	rustToolchainText, err := readText(rustToolchainPath)
+	if err != nil {
+		return err
+	}
+
+	var providersPackageJSON map[string]any
+	if err := json.Unmarshal([]byte(providersPackageJSONText), &providersPackageJSON); err != nil {
+		return err
+	}
+	var providersPackageLock map[string]any
+	if err := json.Unmarshal([]byte(providersPackageLockText), &providersPackageLock); err != nil {
+		return err
+	}
+	hostedControlsPolicy, err := ParseTOMLSubset(hostedControlsPolicyText, cfg.HostedControlsPolicyPath)
+	if err != nil {
+		return err
+	}
+
+	requireArg := func(text, name, path string) (string, error) {
+		match := regexp.MustCompile(`(?m)^ARG ` + regexp.QuoteMeta(name) + `=(.+)$`).FindStringSubmatch(text)
+		if match == nil {
+			return "", fmt.Errorf("Unable to extract %s from %s", name, path)
+		}
+		return strings.TrimSpace(match[1]), nil
+	}
+	requireYAMLKey := func(text, name, path string) (string, error) {
+		match := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(name) + `:\s*(.+)$`).FindStringSubmatch(text)
+		if match == nil {
+			return "", fmt.Errorf("Unable to extract %s from %s", name, path)
+		}
+		return strings.TrimSpace(match[1]), nil
+	}
+	requirePinnedBaseImage := func(image, label, path string) error {
+		if !regexp.MustCompile(`^[^@]+@sha256:[0-9a-f]{64}$`).MatchString(image) {
+			return fmt.Errorf("%s in %s must be pinned by immutable digest, found %q", label, path, image)
+		}
+		return nil
+	}
+	verifySnapshotFreshness := func(snapshot, path string) error {
+		ts, err := time.Parse("20060102T150405Z", snapshot)
+		if err != nil {
+			return fmt.Errorf("Debian snapshot %s in %s is not valid", snapshot, path)
+		}
+		now := time.Now().UTC()
+		ageDays := int(now.Sub(ts).Hours() / 24)
+		if ageDays > cfg.MaxDebianSnapshotAgeDays {
+			return fmt.Errorf(
+				"Debian snapshot %s in %s is %d days old; refresh it or raise WORKCELL_MAX_DEBIAN_SNAPSHOT_AGE_DAYS",
+				snapshot,
+				path,
+				ageDays,
+			)
+		}
+		return nil
+	}
+	extractInstallBlocks := func(text, path string) ([][]string, error) {
+		matches := aptInstallPattern.FindAllStringSubmatch(text, -1)
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("Unable to find apt install blocks in %s", path)
+		}
+		blocks := make([][]string, 0, len(matches))
+		for _, match := range matches {
+			body := strings.ReplaceAll(match[1], "\\", " ")
+			fields := strings.Fields(body)
+			if len(fields) == 0 {
+				return nil, fmt.Errorf("Unable to extract package list from install block in %s", path)
+			}
+			blocks = append(blocks, fields)
+		}
+		return blocks, nil
+	}
+	requireExactPackages := func(actual, expected []string, label, path string) error {
+		if len(actual) != len(expected) {
+			return fmt.Errorf("%s package set in %s changed.\nexpected: %v\nactual:   %v", label, path, expected, actual)
+		}
+		for i := range actual {
+			if actual[i] != expected[i] {
+				return fmt.Errorf("%s package set in %s changed.\nexpected: %v\nactual:   %v", label, path, expected, actual)
+			}
+		}
+		return nil
+	}
+	requireRegex := func(text, pattern, label, path string) (*regexp.Regexp, []string, error) {
+		re := regexp.MustCompile(pattern)
+		match := re.FindStringSubmatch(text)
+		if match == nil {
+			return nil, nil, fmt.Errorf("%s in %s must match %q", label, path, pattern)
+		}
+		return re, match, nil
+	}
+	requireActionRef := func(text, action, path string) (string, error) {
+		re := regexp.MustCompile(regexp.QuoteMeta(action) + `@([0-9a-f]{40})`)
+		matches := re.FindAllStringSubmatch(text, -1)
+		if len(matches) == 0 {
+			return "", fmt.Errorf("%s must pin %s to an immutable commit SHA", path, action)
+		}
+		refs := map[string]struct{}{}
+		for _, match := range matches {
+			refs[match[1]] = struct{}{}
+		}
+		if len(refs) != 1 {
+			return "", fmt.Errorf("%s must use a single reviewed ref for %s", path, action)
+		}
+		for ref := range refs {
+			return ref, nil
+		}
+		return "", nil
+	}
+	requireGoDirective := func(text, directive, path string) (string, error) {
+		match := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(directive) + ` ([0-9]+\.[0-9]+\.[0-9]+)$`).FindStringSubmatch(text)
+		if match == nil {
+			return "", fmt.Errorf("Unable to extract %s from %s", directive, path)
+		}
+		return match[1], nil
+	}
+	requireToolchainDirective := func(text, path string) (string, error) {
+		match := regexp.MustCompile(`(?m)^toolchain go([0-9]+\.[0-9]+\.[0-9]+)$`).FindStringSubmatch(text)
+		if match == nil {
+			return "", fmt.Errorf("Unable to extract toolchain from %s", path)
+		}
+		return match[1], nil
+	}
+	requireTOMLString := func(text, key, path string) (string, error) {
+		match := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(key) + `\s*=\s*"([^"]+)"\s*$`).FindStringSubmatch(text)
+		if match == nil {
+			return "", fmt.Errorf("Unable to extract %s from %s", key, path)
+		}
+		return match[1], nil
+	}
+	requireEqual := func(label, left, leftPath, right, rightPath string) error {
+		if left != right {
+			return fmt.Errorf("%s must match between %s (%q) and %s (%q)", label, leftPath, left, rightPath, right)
+		}
+		return nil
+	}
+	majorMinor := func(version, path string) (string, error) {
+		match := regexp.MustCompile(`^([0-9]+\.[0-9]+)\.[0-9]+$`).FindStringSubmatch(version)
+		if match == nil {
+			return "", fmt.Errorf("Expected a semantic version in %s, found %q", path, version)
+		}
+		return match[1], nil
+	}
+	goLanguageVersionFromToolchain := func(version, path string) (string, error) {
+		match := regexp.MustCompile(`^([0-9]+\.[0-9]+)\.[0-9]+$`).FindStringSubmatch(version)
+		if match == nil {
+			return "", fmt.Errorf("Expected a semantic Go toolchain version in %s, found %q", path, version)
+		}
+		return match[1] + ".0", nil
+	}
+	extractReproMatrixEntries := func(strategyBlock, path string) ([][3]string, error) {
+		re := regexp.MustCompile(`(?m)^\s{10}- platform:\s*(\S+)\n^\s{12}platform_name:\s*(\S+)\n^\s{12}runner:\s*(\S+)$`)
+		matches := re.FindAllStringSubmatch(strategyBlock, -1)
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("Unable to extract reproducible-build matrix entries from %s", path)
+		}
+		result := make([][3]string, 0, len(matches))
+		for _, match := range matches {
+			result = append(result, [3]string{match[1], match[2], match[3]})
+		}
+		return result, nil
+	}
+	requireNoRegistryBootstrapMCP := func(text, path string) error {
+		disallowedFragments := []string{
+			"npx",
+			"npm exec",
+			"pnpm dlx",
+			"yarn dlx",
+			"bunx",
+			"@upstash/context7-mcp",
+			"exa-mcp-server",
+		}
+		lines := strings.Split(text, "\n")
+		for _, line := range lines {
+			line = stripComment(line)
+			lower := strings.ToLower(line)
+			for _, fragment := range disallowedFragments {
+				if strings.Contains(lower, fragment) {
+					return fmt.Errorf("%s must not seed mutable registry-backed MCP commands; found %q", path, line)
+				}
+			}
+		}
+		return nil
+	}
+
+	runtimeBaseImage, err := requireArg(runtimeDockerfile, "NODE_BASE_IMAGE", cfg.RuntimeDockerfilePath)
+	if err != nil {
+		return err
+	}
+	validatorBaseImage, err := requireArg(validatorDockerfile, "VALIDATOR_BASE_IMAGE", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	remoteValidatorBaseImage, err := requireArg(remoteValidatorDockerfile, "VALIDATOR_BASE_IMAGE", cfg.RemoteValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	runtimeSnapshot, err := requireArg(runtimeDockerfile, "DEBIAN_SNAPSHOT", cfg.RuntimeDockerfilePath)
+	if err != nil {
+		return err
+	}
+	validatorSnapshot, err := requireArg(validatorDockerfile, "DEBIAN_SNAPSHOT", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	remoteValidatorSnapshot, err := requireArg(remoteValidatorDockerfile, "DEBIAN_SNAPSHOT", cfg.RemoteValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	codexVersion, err := requireArg(runtimeDockerfile, "CODEX_VERSION", cfg.RuntimeDockerfilePath)
+	if err != nil {
+		return err
+	}
+	claudeVersion, err := requireArg(runtimeDockerfile, "CLAUDE_VERSION", cfg.RuntimeDockerfilePath)
+	if err != nil {
+		return err
+	}
+
+	runtimeInstallBlocks, err := extractInstallBlocks(runtimeDockerfile, cfg.RuntimeDockerfilePath)
+	if err != nil {
+		return err
+	}
+	validatorInstallBlocks, err := extractInstallBlocks(validatorDockerfile, cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	remoteValidatorInstallBlocks, err := extractInstallBlocks(remoteValidatorDockerfile, cfg.RemoteValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+
+	if err := requirePinnedBaseImage(runtimeBaseImage, "NODE_BASE_IMAGE", cfg.RuntimeDockerfilePath); err != nil {
+		return err
+	}
+	if err := requirePinnedBaseImage(validatorBaseImage, "VALIDATOR_BASE_IMAGE", cfg.ValidatorDockerfilePath); err != nil {
+		return err
+	}
+	if err := requirePinnedBaseImage(remoteValidatorBaseImage, "VALIDATOR_BASE_IMAGE", cfg.RemoteValidatorDockerfilePath); err != nil {
+		return err
+	}
+	if err := verifySnapshotFreshness(runtimeSnapshot, cfg.RuntimeDockerfilePath); err != nil {
+		return err
+	}
+	if err := verifySnapshotFreshness(validatorSnapshot, cfg.ValidatorDockerfilePath); err != nil {
+		return err
+	}
+	if err := verifySnapshotFreshness(remoteValidatorSnapshot, cfg.RemoteValidatorDockerfilePath); err != nil {
+		return err
+	}
+	if err := requireNoRegistryBootstrapMCP(codexRequirementsText, cfg.CodexRequirementsPath); err != nil {
+		return err
+	}
+	if err := requireNoRegistryBootstrapMCP(codexMCPConfigText, cfg.CodexMCPConfigPath); err != nil {
+		return err
+	}
+	if _, _, err := requireRegex(runtimeDockerfile, `curl -fsSL "https://storage\.googleapis\.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/\$\{CLAUDE_VERSION\}/\$\{CLAUDE_PLATFORM\}/claude"`, "Claude native release download URL", cfg.RuntimeDockerfilePath); err != nil {
+		return err
+	}
+	if _, match, err := requireRegex(runtimeDockerfile, `^\s*arm64\)\s+\\\s*CLAUDE_PLATFORM="([^"]+)";\s+\\\s*CLAUDE_SHA256="([0-9a-f]{64})";`, "arm64 Claude mapping", cfg.RuntimeDockerfilePath); err != nil {
+		return err
+	} else if match[1] != "linux-arm64" {
+		return fmt.Errorf("arm64 Claude mapping in %s must use linux-arm64", cfg.RuntimeDockerfilePath)
+	}
+	if _, match, err := requireRegex(runtimeDockerfile, `^\s*amd64\)\s+\\\s*CLAUDE_PLATFORM="([^"]+)";\s+\\\s*CLAUDE_SHA256="([0-9a-f]{64})";`, "amd64 Claude mapping", cfg.RuntimeDockerfilePath); err != nil {
+		return err
+	} else if match[1] != "linux-x64" {
+		return fmt.Errorf("amd64 Claude mapping in %s must use linux-x64", cfg.RuntimeDockerfilePath)
+	}
+	if !regexp.MustCompile(`^0\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?$`).MatchString(codexVersion) {
+		return fmt.Errorf("runtime/container/Dockerfile CODEX_VERSION must stay pinned to an explicit release, found %q", codexVersion)
+	}
+	if !regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?$`).MatchString(claudeVersion) {
+		return fmt.Errorf("runtime/container/Dockerfile CLAUDE_VERSION must stay pinned to an explicit release, found %q", claudeVersion)
+	}
+	if _, match, err := requireRegex(runtimeDockerfile, `^\s*arm64\)\s+\\(?:\s*CLAUDE_[A-Z0-9_]+="[^"]+";\s+\\)*\s*CODEX_ARCH="([^"]+)";\s+\\\s*CODEX_SHA256="([0-9a-f]{64})";`, "arm64 Codex mapping", cfg.RuntimeDockerfilePath); err != nil {
+		return err
+	} else if match[1] != "aarch64-unknown-linux-gnu" {
+		return fmt.Errorf("arm64 Codex mapping in %s must use aarch64-unknown-linux-gnu", cfg.RuntimeDockerfilePath)
+	}
+	if _, match, err := requireRegex(runtimeDockerfile, `^\s*amd64\)\s+\\(?:\s*CLAUDE_[A-Z0-9_]+="[^"]+";\s+\\)*\s*CODEX_ARCH="([^"]+)";\s+\\\s*CODEX_SHA256="([0-9a-f]{64})";`, "amd64 Codex mapping", cfg.RuntimeDockerfilePath); err != nil {
+		return err
+	} else if match[1] != "x86_64-unknown-linux-gnu" {
+		return fmt.Errorf("amd64 Codex mapping in %s must use x86_64-unknown-linux-gnu", cfg.RuntimeDockerfilePath)
+	}
+	if len(runtimeInstallBlocks) != 2 {
+		return fmt.Errorf("runtime/container/Dockerfile must contain exactly two apt install blocks (runtime base and runtime builder)")
+	}
+	if len(validatorInstallBlocks) != 1 {
+		return errors.New("tools/validator/Dockerfile must contain exactly one apt install block")
+	}
+	if len(remoteValidatorInstallBlocks) != 1 {
+		return errors.New("tools/remote-validator/Dockerfile must contain exactly one apt install block")
+	}
+	if err := requireExactPackages(runtimeInstallBlocks[0], []string{"bash", "bubblewrap", "ca-certificates", "curl", "fd-find", "git", "jq", "less", "openssh-client", "passwd", "procps", "ripgrep", "sudo", "unzip", "util-linux", "xz-utils"}, "Runtime base", cfg.RuntimeDockerfilePath); err != nil {
+		return err
+	}
+	if err := requireExactPackages(runtimeInstallBlocks[1], []string{"gcc", "libc6-dev"}, "Runtime builder", cfg.RuntimeDockerfilePath); err != nil {
+		return err
+	}
+	if err := requireExactPackages(validatorInstallBlocks[0], []string{"ca-certificates", "codespell", "curl", "gcc", "git", "groff-base", "jq", "libc6-dev", "llvm", "mandoc", "openssh-client", "procps", "shellcheck", "shfmt", "yamllint"}, "Validator", cfg.ValidatorDockerfilePath); err != nil {
+		return err
+	}
+	if err := requireExactPackages(remoteValidatorInstallBlocks[0], []string{"ca-certificates", "codespell", "curl", "docker-cli", "docker-buildx", "gcc", "git", "groff-base", "jq", "libc6-dev", "llvm", "mandoc", "openssh-client", "procps", "shellcheck", "shfmt", "yamllint"}, "Remote validator", cfg.RemoteValidatorDockerfilePath); err != nil {
+		return err
+	}
+	goLanguageVersion, err := requireGoDirective(goModText, "go", goModPath)
+	if err != nil {
+		return err
+	}
+	goToolchainVersion, err := requireToolchainDirective(goModText, goModPath)
+	if err != nil {
+		return err
+	}
+	validatorGoVersion, err := requireArg(validatorDockerfile, "GO_VERSION", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	remoteValidatorGoVersion, err := requireArg(remoteValidatorDockerfile, "GO_VERSION", cfg.RemoteValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if err := requireEqual("GO_VERSION", validatorGoVersion, cfg.ValidatorDockerfilePath, remoteValidatorGoVersion, cfg.RemoteValidatorDockerfilePath); err != nil {
+		return err
+	}
+	if err := requireEqual("Go toolchain version", goToolchainVersion, goModPath, validatorGoVersion, cfg.ValidatorDockerfilePath); err != nil {
+		return err
+	}
+	expectedGoLanguageVersion, err := goLanguageVersionFromToolchain(goToolchainVersion, goModPath)
+	if err != nil {
+		return err
+	}
+	if goLanguageVersion != expectedGoLanguageVersion {
+		return fmt.Errorf("go language version in %s must match the toolchain major/minor at patch zero, expected %q, found %q", goModPath, expectedGoLanguageVersion, goLanguageVersion)
+	}
+	validatorGoSHAx86_64, err := requireArg(validatorDockerfile, "GO_LINUX_X86_64_SHA256", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	remoteValidatorGoSHAx86_64, err := requireArg(remoteValidatorDockerfile, "GO_LINUX_X86_64_SHA256", cfg.RemoteValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if err := requireEqual("GO_LINUX_X86_64_SHA256", validatorGoSHAx86_64, cfg.ValidatorDockerfilePath, remoteValidatorGoSHAx86_64, cfg.RemoteValidatorDockerfilePath); err != nil {
+		return err
+	}
+	validatorGoSHAArm64, err := requireArg(validatorDockerfile, "GO_LINUX_ARM64_SHA256", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	remoteValidatorGoSHAArm64, err := requireArg(remoteValidatorDockerfile, "GO_LINUX_ARM64_SHA256", cfg.RemoteValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if err := requireEqual("GO_LINUX_ARM64_SHA256", validatorGoSHAArm64, cfg.ValidatorDockerfilePath, remoteValidatorGoSHAArm64, cfg.RemoteValidatorDockerfilePath); err != nil {
+		return err
+	}
+	cargoEdition, err := requireTOMLString(cargoManifestText, "edition", cargoManifestPath)
+	if err != nil {
+		return err
+	}
+	if cargoEdition != "2024" {
+		return fmt.Errorf("%s must use edition 2024, found %q", cargoManifestPath, cargoEdition)
+	}
+	cargoRustVersion, err := requireTOMLString(cargoManifestText, "rust-version", cargoManifestPath)
+	if err != nil {
+		return err
+	}
+	rustToolchainVersion, err := requireTOMLString(rustToolchainText, "channel", rustToolchainPath)
+	if err != nil {
+		return err
+	}
+	runtimeRustVersion, err := requireArg(runtimeDockerfile, "RUST_VERSION", cfg.RuntimeDockerfilePath)
+	if err != nil {
+		return err
+	}
+	validatorRustVersion, err := requireArg(validatorDockerfile, "RUST_VERSION", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	remoteValidatorRustVersion, err := requireArg(remoteValidatorDockerfile, "RUST_VERSION", cfg.RemoteValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if err := requireEqual("RUST_VERSION", runtimeRustVersion, cfg.RuntimeDockerfilePath, validatorRustVersion, cfg.ValidatorDockerfilePath); err != nil {
+		return err
+	}
+	if err := requireEqual("RUST_VERSION", runtimeRustVersion, cfg.RuntimeDockerfilePath, remoteValidatorRustVersion, cfg.RemoteValidatorDockerfilePath); err != nil {
+		return err
+	}
+	if err := requireEqual("Rust toolchain channel", rustToolchainVersion, rustToolchainPath, runtimeRustVersion, cfg.RuntimeDockerfilePath); err != nil {
+		return err
+	}
+	expectedCargoRustVersion, err := majorMinor(rustToolchainVersion, rustToolchainPath)
+	if err != nil {
+		return err
+	}
+	if cargoRustVersion != expectedCargoRustVersion {
+		return fmt.Errorf("rust-version in %s must match the pinned toolchain major/minor, expected %q, found %q", cargoManifestPath, expectedCargoRustVersion, cargoRustVersion)
+	}
+	runtimeRustupVersion, err := requireArg(runtimeDockerfile, "RUSTUP_VERSION", cfg.RuntimeDockerfilePath)
+	if err != nil {
+		return err
+	}
+	validatorRustupVersion, err := requireArg(validatorDockerfile, "RUSTUP_VERSION", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	remoteValidatorRustupVersion, err := requireArg(remoteValidatorDockerfile, "RUSTUP_VERSION", cfg.RemoteValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if err := requireEqual("RUSTUP_VERSION", runtimeRustupVersion, cfg.RuntimeDockerfilePath, validatorRustupVersion, cfg.ValidatorDockerfilePath); err != nil {
+		return err
+	}
+	if err := requireEqual("RUSTUP_VERSION", runtimeRustupVersion, cfg.RuntimeDockerfilePath, remoteValidatorRustupVersion, cfg.RemoteValidatorDockerfilePath); err != nil {
+		return err
+	}
+	runtimeRustupSHAx86_64, err := requireArg(runtimeDockerfile, "RUSTUP_INIT_LINUX_X86_64_SHA256", cfg.RuntimeDockerfilePath)
+	if err != nil {
+		return err
+	}
+	validatorRustupSHAx86_64, err := requireArg(validatorDockerfile, "RUSTUP_INIT_LINUX_X86_64_SHA256", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	remoteValidatorRustupSHAx86_64, err := requireArg(remoteValidatorDockerfile, "RUSTUP_INIT_LINUX_X86_64_SHA256", cfg.RemoteValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if err := requireEqual("RUSTUP_INIT_LINUX_X86_64_SHA256", runtimeRustupSHAx86_64, cfg.RuntimeDockerfilePath, validatorRustupSHAx86_64, cfg.ValidatorDockerfilePath); err != nil {
+		return err
+	}
+	if err := requireEqual("RUSTUP_INIT_LINUX_X86_64_SHA256", runtimeRustupSHAx86_64, cfg.RuntimeDockerfilePath, remoteValidatorRustupSHAx86_64, cfg.RemoteValidatorDockerfilePath); err != nil {
+		return err
+	}
+	runtimeRustupSHAArm64, err := requireArg(runtimeDockerfile, "RUSTUP_INIT_LINUX_ARM64_SHA256", cfg.RuntimeDockerfilePath)
+	if err != nil {
+		return err
+	}
+	validatorRustupSHAArm64, err := requireArg(validatorDockerfile, "RUSTUP_INIT_LINUX_ARM64_SHA256", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	remoteValidatorRustupSHAArm64, err := requireArg(remoteValidatorDockerfile, "RUSTUP_INIT_LINUX_ARM64_SHA256", cfg.RemoteValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if err := requireEqual("RUSTUP_INIT_LINUX_ARM64_SHA256", runtimeRustupSHAArm64, cfg.RuntimeDockerfilePath, validatorRustupSHAArm64, cfg.ValidatorDockerfilePath); err != nil {
+		return err
+	}
+	if err := requireEqual("RUSTUP_INIT_LINUX_ARM64_SHA256", runtimeRustupSHAArm64, cfg.RuntimeDockerfilePath, remoteValidatorRustupSHAArm64, cfg.RemoteValidatorDockerfilePath); err != nil {
+		return err
+	}
+
+	rootPackage, _ := providersPackageLock["packages"].(map[string]any)
+	rootDependencies, _ := rootPackage[""].(map[string]any)
+	expectedDependencies, _ := providersPackageJSON["dependencies"].(map[string]any)
+	actualDependencies, _ := rootDependencies["dependencies"].(map[string]any)
+	if len(actualDependencies) != len(expectedDependencies) {
+		return errors.New("runtime/container/providers/package-lock.json root dependencies do not match package.json")
+	}
+	for name, expected := range expectedDependencies {
+		if actualDependencies[name] != expected {
+			return errors.New("runtime/container/providers/package-lock.json root dependencies do not match package.json")
+		}
+	}
+	for packageName, expectedVersionAny := range expectedDependencies {
+		expectedVersion, _ := expectedVersionAny.(string)
+		pkgEntry, ok := rootPackage["node_modules/"+packageName].(map[string]any)
+		if !ok {
+			return fmt.Errorf("Missing pinned provider package entry for %s", packageName)
+		}
+		if version, _ := pkgEntry["version"].(string); version != expectedVersion {
+			return fmt.Errorf("Pinned provider package %s is %s, expected %s", packageName, version, expectedVersion)
+		}
+		if integrity, _ := pkgEntry["integrity"].(string); integrity == "" {
+			return fmt.Errorf("Pinned provider package %s is missing an integrity hash", packageName)
+		}
+		if resolved, _ := pkgEntry["resolved"].(string); !strings.HasPrefix(resolved, "https://registry.npmjs.org/") {
+			return fmt.Errorf("Pinned provider package %s uses an unexpected source: %q", packageName, resolved)
+		}
+	}
+	for packagePath, rawEntry := range rootPackage {
+		if packagePath == "" {
+			continue
+		}
+		entry, _ := rawEntry.(map[string]any)
+		if link, _ := entry["link"].(bool); link {
+			return fmt.Errorf("Linked npm dependencies are not allowed in the provider lockfile: %s", packagePath)
+		}
+		if integrity, _ := entry["integrity"].(string); integrity == "" {
+			return fmt.Errorf("Provider lockfile entry is missing integrity data: %s", packagePath)
+		}
+		if resolved, _ := entry["resolved"].(string); !strings.HasPrefix(resolved, "https://registry.npmjs.org/") {
+			return fmt.Errorf("Provider lockfile entry uses an unexpected source (%s): %q", packagePath, resolved)
+		}
+	}
+
+	ciBuildxVersion, err := requireYAMLKey(ciWorkflow, "WORKCELL_BUILDX_VERSION", ".github/workflows/ci.yml")
+	if err != nil {
+		return err
+	}
+	releaseBuildxVersion, err := requireYAMLKey(releaseWorkflow, "WORKCELL_BUILDX_VERSION", ".github/workflows/release.yml")
+	if err != nil {
+		return err
+	}
+	if ciBuildxVersion != releaseBuildxVersion {
+		return errors.New("WORKCELL_BUILDX_VERSION must match between .github/workflows/ci.yml and .github/workflows/release.yml")
+	}
+	if !regexp.MustCompile(`^v\d+\.\d+\.\d+$`).MatchString(ciBuildxVersion) {
+		return fmt.Errorf("WORKCELL_BUILDX_VERSION must be an exact pinned release (for example v0.32.1), found %q", ciBuildxVersion)
+	}
+
+	ciQEMUImage, err := requireYAMLKey(ciWorkflow, "WORKCELL_QEMU_IMAGE", ".github/workflows/ci.yml")
+	if err != nil {
+		return err
+	}
+	releaseQEMUImage, err := requireYAMLKey(releaseWorkflow, "WORKCELL_QEMU_IMAGE", ".github/workflows/release.yml")
+	if err != nil {
+		return err
+	}
+	if ciQEMUImage != releaseQEMUImage {
+		return errors.New("WORKCELL_QEMU_IMAGE must match between .github/workflows/ci.yml and .github/workflows/release.yml")
+	}
+	if err := requirePinnedBaseImage(ciQEMUImage, "WORKCELL_QEMU_IMAGE", ".github/workflows/ci.yml"); err != nil {
+		return err
+	}
+	ciBuildkitImage, err := requireYAMLKey(ciWorkflow, "WORKCELL_BUILDKIT_IMAGE", ".github/workflows/ci.yml")
+	if err != nil {
+		return err
+	}
+	releaseBuildkitImage, err := requireYAMLKey(releaseWorkflow, "WORKCELL_BUILDKIT_IMAGE", ".github/workflows/release.yml")
+	if err != nil {
+		return err
+	}
+	if ciBuildkitImage != releaseBuildkitImage {
+		return errors.New("WORKCELL_BUILDKIT_IMAGE must match between .github/workflows/ci.yml and .github/workflows/release.yml")
+	}
+	if err := requirePinnedBaseImage(ciBuildkitImage, "WORKCELL_BUILDKIT_IMAGE", ".github/workflows/ci.yml"); err != nil {
+		return err
+	}
+
+	ciCosignVersion, err := requireYAMLKey(ciWorkflow, "WORKCELL_COSIGN_VERSION", ".github/workflows/ci.yml")
+	if err != nil {
+		return err
+	}
+	releaseCosignVersion, err := requireYAMLKey(releaseWorkflow, "WORKCELL_COSIGN_VERSION", ".github/workflows/release.yml")
+	if err != nil {
+		return err
+	}
+	pinHygieneCosignVersion, err := requireYAMLKey(pinHygieneWorkflow, "WORKCELL_COSIGN_VERSION", ".github/workflows/pin-hygiene.yml")
+	if err != nil {
+		return err
+	}
+	if len(map[string]struct{}{ciCosignVersion: {}, releaseCosignVersion: {}, pinHygieneCosignVersion: {}}) != 1 {
+		return errors.New("WORKCELL_COSIGN_VERSION must match between .github/workflows/ci.yml, .github/workflows/release.yml, and .github/workflows/pin-hygiene.yml")
+	}
+	if !regexp.MustCompile(`^v\d+\.\d+\.\d+$`).MatchString(ciCosignVersion) {
+		return fmt.Errorf("WORKCELL_COSIGN_VERSION must be an exact pinned release, found %q", ciCosignVersion)
+	}
+	for _, workflow := range []struct {
+		text string
+		path string
+	}{{ciWorkflow, ".github/workflows/ci.yml"}, {releaseWorkflow, ".github/workflows/release.yml"}, {pinHygieneWorkflow, ".github/workflows/pin-hygiene.yml"}} {
+		if !strings.Contains(workflow.text, "cosign-release: ${{ env.WORKCELL_COSIGN_VERSION }}") {
+			return fmt.Errorf("%s must pin the installed cosign binary release", workflow.path)
+		}
+	}
+	ciCosignInstallerRef, err := requireActionRef(ciWorkflow, "sigstore/cosign-installer", ".github/workflows/ci.yml")
+	if err != nil {
+		return err
+	}
+	releaseCosignInstallerRef, err := requireActionRef(releaseWorkflow, "sigstore/cosign-installer", ".github/workflows/release.yml")
+	if err != nil {
+		return err
+	}
+	pinHygieneCosignInstallerRef, err := requireActionRef(pinHygieneWorkflow, "sigstore/cosign-installer", ".github/workflows/pin-hygiene.yml")
+	if err != nil {
+		return err
+	}
+	if len(map[string]struct{}{ciCosignInstallerRef: {}, releaseCosignInstallerRef: {}, pinHygieneCosignInstallerRef: {}}) != 1 {
+		return errors.New("sigstore/cosign-installer must use the same reviewed commit SHA in .github/workflows/ci.yml, .github/workflows/release.yml, and .github/workflows/pin-hygiene.yml")
+	}
+	if !strings.Contains(ciWorkflow, "driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}") {
+		return errors.New(".github/workflows/ci.yml must pin the BuildKit daemon image used by setup-buildx-action")
+	}
+	if !strings.Contains(releaseWorkflow, "driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}") {
+		return errors.New(".github/workflows/release.yml must pin the BuildKit daemon image used by setup-buildx-action")
+	}
+	if !strings.Contains(ciWorkflow, "cache-binary: true") {
+		return errors.New("Pinned buildx binary caching must stay enabled in .github/workflows/ci.yml")
+	}
+	extractBetween := func(text, startMarker, endMarker, label string) (string, error) {
+		start := strings.Index(text, startMarker)
+		if start < 0 {
+			return "", fmt.Errorf("Unable to extract %s from .github/workflows/ci.yml", label)
+		}
+		remaining := text[start:]
+		end := strings.Index(remaining, endMarker)
+		if end < 0 {
+			return "", fmt.Errorf("Unable to extract %s from .github/workflows/ci.yml", label)
+		}
+		return remaining[:end+1], nil
+	}
+	ciReproBuildJob, err := extractBetween(ciWorkflow, "  reproducible-build-platform:\n", "\n  reproducible-build:\n", "reproducible-build-platform job")
+	if err != nil {
+		return errors.New("Unable to extract reproducible-build-platform job from .github/workflows/ci.yml")
+	}
+	if !regexp.MustCompile(`(?m)^\s{4}runs-on:\s*\$\{\{\s*matrix\.runner\s*\}\}$`).MatchString(ciReproBuildJob) {
+		return errors.New(".github/workflows/ci.yml must route reproducible-build-platform through runs-on: ${{ matrix.runner }}")
+	}
+	ciReproStrategyBlock, err := extractBetween(ciReproBuildJob, "    strategy:\n", "\n    steps:\n", "reproducible-build-platform strategy block")
+	if err != nil {
+		return errors.New("Unable to extract reproducible-build-platform strategy block from .github/workflows/ci.yml")
+	}
+	expectedCiReproStrategyBlock := "    strategy:\n" +
+		"      fail-fast: false\n" +
+		"      matrix:\n" +
+		"        include:\n" +
+		"          - platform: linux/amd64\n" +
+		"            platform_name: amd64\n" +
+		"            runner: ubuntu-latest\n" +
+		"          - platform: linux/arm64\n" +
+		"            platform_name: arm64\n" +
+		"            runner: ubuntu-24.04-arm\n"
+	if ciReproStrategyBlock != expectedCiReproStrategyBlock {
+		return errors.New(".github/workflows/ci.yml must keep the reviewed reproducible-build matrix structure, including a single native ubuntu-24.04-arm lane for linux/arm64")
+	}
+	entries, err := extractReproMatrixEntries(ciReproStrategyBlock, ".github/workflows/ci.yml")
+	if err != nil {
+		return err
+	}
+	arm64Entries := make([][3]string, 0)
+	for _, entry := range entries {
+		if entry[0] == "linux/arm64" {
+			arm64Entries = append(arm64Entries, entry)
+		}
+	}
+	if len(arm64Entries) != 1 || arm64Entries[0] != [3]string{"linux/arm64", "arm64", "ubuntu-24.04-arm"} {
+		return errors.New(".github/workflows/ci.yml must define exactly one linux/arm64 reproducible-build matrix entry and it must use runner ubuntu-24.04-arm")
+	}
+	if strings.Contains(ciWorkflow, "docker/setup-qemu-action@") {
+		return errors.New(".github/workflows/ci.yml must not configure QEMU in CI now that arm64 reproducible builds use a native runner")
+	}
+	if !strings.Contains(releaseWorkflow, "cache-binary: false") {
+		return errors.New("The publishing release workflow must not cache the Buildx binary")
+	}
+	if !strings.Contains(releaseWorkflow, "cache-image: false") {
+		return errors.New("The publishing release workflow must not cache the QEMU helper image")
+	}
+	releaseSyftVersion, err := requireYAMLKey(releaseWorkflow, "WORKCELL_SYFT_VERSION", ".github/workflows/release.yml")
+	if err != nil {
+		return err
+	}
+	if !regexp.MustCompile(`^v\d+\.\d+\.\d+$`).MatchString(releaseSyftVersion) {
+		return fmt.Errorf("WORKCELL_SYFT_VERSION must be an exact pinned release, found %q", releaseSyftVersion)
+	}
+	if !strings.Contains(releaseWorkflow, "syft-version: ${{ env.WORKCELL_SYFT_VERSION }}") {
+		return errors.New(".github/workflows/release.yml must pin the Syft version used for release SBOM generation")
+	}
+	if !strings.Contains(releaseWorkflow, "anchore/sbom-action/download-syft@") {
+		return errors.New(".github/workflows/release.yml must install the pinned Syft CLI before generating the builder environment manifest")
+	}
+	if !strings.Contains(releaseWorkflow, "docker buildx imagetools create") {
+		return errors.New(".github/workflows/release.yml must assemble the published multi-arch manifest with docker buildx imagetools create")
+	}
+	if regexp.MustCompile(`docker/build-push-action@.*?platforms:\s*linux/amd64,linux/arm64`).MatchString(releaseWorkflow) {
+		return errors.New(".github/workflows/release.yml must not publish the final multi-arch image through one opaque multi-platform build-push step")
+	}
+	if !strings.Contains(runtimeDockerfile, "COPY runtime/container/rust /workcell-rust") {
+		return errors.New("runtime/container/Dockerfile must vendor the reviewed Rust runtime sources into the builder stage")
+	}
+	if !strings.Contains(runtimeDockerfile, "COPY runtime/container/control-plane-manifest.json /usr/local/libexec/workcell/control-plane-manifest.json") {
+		return errors.New("runtime/container/Dockerfile must copy the reviewed control-plane manifest into the runtime image")
+	}
+	if !strings.Contains(runtimeDockerfile, "cargo build \\") || !strings.Contains(runtimeDockerfile, "--locked \\") || !strings.Contains(runtimeDockerfile, "--offline \\") {
+		return errors.New("runtime/container/Dockerfile must build the shipped Rust launcher artifacts with cargo --locked --offline")
+	}
+	if !strings.Contains(runtimeDockerfile, "CARGO_HOME=/workcell-rust/cargo-home") {
+		return errors.New("runtime/container/Dockerfile must isolate Cargo home inside the vendored runtime source tree")
+	}
+	for _, needle := range []string{
+		"name: workcell-release-preflight",
+		"actions/download-artifact@",
+		"context: dist/release-source",
+		"WORKCELL_BUILD_INPUT_ROOT: ${{ github.workspace }}/dist/release-source",
+		"WORKCELL_CONTROL_PLANE_ROOT: ${{ github.workspace }}/dist/release-source",
+		"Verify published platform digests match preflight",
+		`"imagetools", "inspect", "--raw"`,
+		"{{json .Manifest}}",
+		"vnd.docker.reference.type",
+		"ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}",
+		"actions/attest@",
+		"Verify release bundle matches preflight",
+		"Verify control-plane manifest matches preflight",
+		"github/codeql-action/init@",
+		"github/codeql-action/analyze@",
+		"./scripts/publish-github-release.sh",
+	} {
+		if !strings.Contains(releaseWorkflow, needle) {
+			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
+		}
+	}
+	if strings.Contains(releaseWorkflow, "{{json .manifest}}") {
+		return errors.New(".github/workflows/release.yml must not use the unsupported lowercase Buildx .manifest template field")
+	}
+	if !strings.Contains(releaseWorkflow, "dist/${{ env.BUNDLE_NAME }}.sigstore.json") ||
+		!strings.Contains(releaseWorkflow, "dist/workcell-control-plane.sigstore.json") ||
+		!strings.Contains(releaseWorkflow, "dist/workcell-source.spdx.sigstore.json") ||
+		!strings.Contains(releaseWorkflow, "dist/workcell-image.spdx.sigstore.json") {
+		return errors.New(".github/workflows/release.yml must publish direct signature bundles for release artifacts")
+	}
+	if !strings.Contains(releaseWorkflow, "dist/workcell-control-plane-preflight.json") ||
+		!strings.Contains(releaseWorkflow, "dist/workcell-control-plane.json") {
+		return errors.New(".github/workflows/release.yml must keep the reviewed control-plane manifest flow")
+	}
+	if strings.Contains(releaseWorkflow, "steps.build.outputs.digest") {
+		return errors.New(".github/workflows/release.yml must not keep referencing the old single-step multi-platform digest output")
+	}
+	if strings.Contains(releaseWorkflow, "gh release ") {
+		return errors.New(".github/workflows/release.yml must not depend on an ambient gh CLI; use a pinned release-publish action")
+	}
+	if !strings.Contains(releaseWorkflow, "./scripts/publish-github-release.sh") {
+		return errors.New(".github/workflows/release.yml must publish assets through the reviewed repo-local GitHub Release API script")
+	}
+	for _, needle := range []string{
+		`run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+		`WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"`,
+	} {
+		if !strings.Contains(releaseWorkflow, needle) {
+			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
+		}
+	}
+	hostedControlsWorkflow, err := readText(filepath.Join(cfg.WorkflowsDir, "hosted-controls.yml"))
+	if err != nil {
+		return err
+	}
+	for _, needle := range []string{
+		`run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+		`WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}`,
+		`WORKCELL_HOSTED_CONTROLS_REQUIRED: "0"`,
+	} {
+		if !strings.Contains(hostedControlsWorkflow, needle) {
+			return fmt.Errorf(".github/workflows/hosted-controls.yml must contain %q", needle)
+		}
+	}
+	for _, needle := range []string{
+		"./scripts/verify-upstream-claude-release.sh",
+	} {
+		if !strings.Contains(ciWorkflow, needle) {
+			return fmt.Errorf(".github/workflows/ci.yml must contain %q", needle)
+		}
+		if !strings.Contains(releaseWorkflow, needle) {
+			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
+		}
+	}
+	for _, needle := range []string{
+		"./scripts/verify-upstream-codex-release.sh",
+		"./scripts/verify-upstream-claude-release.sh",
+	} {
+		if !strings.Contains(pinHygieneWorkflow, needle) {
+			return fmt.Errorf(".github/workflows/pin-hygiene.yml must contain %q", needle)
+		}
+	}
+	for _, needle := range []string{
+		"environment:\n      name: release",
+		`sudo install -m 0755 "$(command -v cosign)" /usr/local/bin/cosign`,
+		`sudo install -m 0755 "$(command -v syft)" /usr/local/bin/syft`,
+		`actionlint_archive="${RUNNER_TEMP}/actionlint.tar.gz"`,
+		`tar -xzf "${actionlint_archive}" -C "${RUNNER_TEMP}" actionlint`,
+		"Reclaim runner space before reproducible image check",
+		`docker image rm -f "workcell-validator:${GITHUB_SHA}" >/dev/null 2>&1 || true`,
+		"git -c safe.directory=/workspace archive \\",
+		"docker buildx prune -af || true",
+	} {
+		if !strings.Contains(releaseWorkflow, needle) {
+			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
+		}
+	}
+	for _, workflowPath := range mustGlob(filepath.Join(cfg.WorkflowsDir, "*.yml")) {
+		workflowText, err := readText(workflowPath)
+		if err != nil {
+			return err
+		}
+		if !workflowPermissionsRE.MatchString(workflowText) {
+			return fmt.Errorf("workflow-level empty permissions declaration missing in %s", workflowPath)
+		}
+		if strings.Contains(workflowText, "pull_request_target") {
+			return fmt.Errorf("%s must not contain pull_request_target triggers", workflowPath)
+		}
+		if regexp.MustCompile(`secrets\.[A-Z0-9_]*(?:PAT|PERSONAL_ACCESS_TOKEN)\b|GH_PAT\b|PERSONAL_ACCESS_TOKEN\b`).MatchString(workflowText) {
+			return fmt.Errorf("%s must not contain long-lived personal access tokens", workflowPath)
+		}
+		for _, match := range regexp.MustCompile(`(?m)^\s*-\s+uses:\s+([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)@([^\s#]+)`).FindAllStringSubmatch(workflowText, -1) {
+			if !regexp.MustCompile(`^[0-9a-f]{40}$`).MatchString(match[2]) {
+				return fmt.Errorf("%s must pin GitHub Actions by full commit SHA; found %s@%s", workflowPath, match[1], match[2])
+			}
+		}
+	}
+	for _, required := range []string{
+		"/.github/workflows/ @omkhar",
+		"/scripts/ @omkhar",
+		"/runtime/container/ @omkhar",
+		"/docs/provenance.md @omkhar",
+	} {
+		if !strings.Contains(codeowners, required) {
+			return fmt.Errorf(".github/CODEOWNERS must declare high-risk ownership for %q", required)
+		}
+	}
+	releaseEnvironment, _ := hostedControlsPolicy["release_environment"].(map[string]any)
+	releaseMode, _ := releaseEnvironment["mode"].(string)
+	if releaseMode != "review-gated" && releaseMode != "single-owner-private" && releaseMode != "plan-limited-private" {
+		return errors.New("policy/github-hosted-controls.toml must set release_environment.mode to 'review-gated', 'single-owner-private', or 'plan-limited-private'")
+	}
+	repositoryVariables, ok := hostedControlsPolicy["repository_variables"].(map[string]any)
+	if !ok || len(repositoryVariables) == 0 {
+		return errors.New("policy/github-hosted-controls.toml must declare canonical repository variables")
+	}
+	if value, _ := repositoryVariables["WORKCELL_ENABLE_GITHUB_ATTESTATIONS"].(string); value != "true" {
+		return errors.New("policy/github-hosted-controls.toml must require WORKCELL_ENABLE_GITHUB_ATTESTATIONS = \"true\"")
+	}
+	for _, needle := range []string{
+		"actions/variables?per_page=100",
+		"WORKCELL_ENABLE_GITHUB_ATTESTATIONS",
+	} {
+		if !strings.Contains(hostedControlsScript, needle) {
+			return fmt.Errorf("scripts/verify-github-hosted-controls.sh must contain %q", needle)
+		}
+	}
+	if err := requireNoRegistryBootstrapMCP(codexRequirementsText, cfg.CodexRequirementsPath); err != nil {
+		return err
+	}
+	if err := requireNoRegistryBootstrapMCP(codexMCPConfigText, cfg.CodexMCPConfigPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func requireStringSliceTable(root map[string]any, tableName, key, sourcePath string) ([]string, error) {
+	table, ok := root[tableName].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must define %s.%s as a non-empty array", sourcePath, tableName, key)
+	}
+	values, ok, err := MustStringSlice(table[key])
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("%s must define %s.%s as a non-empty array", sourcePath, tableName, key)
+	}
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("%s must define %s.%s as a non-empty array", sourcePath, tableName, key)
+		}
+	}
+	return values, nil
+}
+
+func mustGlob(pattern string) []string {
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		panic(err)
+	}
+	return matches
+}

--- a/internal/metadatautil/validation_tools.go
+++ b/internal/metadatautil/validation_tools.go
@@ -1,0 +1,99 @@
+package metadatautil
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+var credentialPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`sk-[A-Za-z0-9]{40,}`),
+	regexp.MustCompile(`AIza[A-Za-z0-9\-_]{35}`),
+	regexp.MustCompile(`ya29\.[A-Za-z0-9\-_]+`),
+}
+
+func ValidateJSONFiles(paths []string) error {
+	for _, path := range paths {
+		var decoded any
+		if err := readJSONFile(path, &decoded); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func ValidateTOMLFiles(paths []string) error {
+	for _, path := range paths {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		var decoded any
+		if err := toml.Unmarshal(content, &decoded); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func ScanCredentialPatterns(rootDir string) error {
+	scanRoots := []string{
+		filepath.Join(rootDir, "tests"),
+		filepath.Join(rootDir, "docs", "examples"),
+	}
+
+	var findings []string
+	for _, scanRoot := range scanRoots {
+		info, err := os.Stat(scanRoot)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if !info.IsDir() {
+			continue
+		}
+
+		err = filepath.WalkDir(scanRoot, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				if d.Name() == ".git" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return nil
+			}
+			text := string(content)
+			for _, pattern := range credentialPatterns {
+				if pattern.MatchString(text) {
+					findings = append(findings, fmt.Sprintf("Possible credential in %s", path))
+					break
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(findings) == 0 {
+		return nil
+	}
+
+	sort.Strings(findings)
+	return fmt.Errorf("%s\nFound %d possible credential(s) in tests/ or docs/examples/", strings.Join(findings, "\n"), len(findings))
+}

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -1,0 +1,301 @@
+package mutation
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type mutationCase struct {
+	relativePath string
+	original     string
+	replacement  string
+	label        string
+	command      commandSpec
+}
+
+var goHelperMutations = []mutationCase{
+	{
+		relativePath: "internal/injection/render_injection_bundle.go",
+		original:     `if targetIsReserved(candidate) {`,
+		replacement:  `if false && targetIsReserved(candidate) {`,
+		label:        "reserved target protection",
+		command: commandSpec{
+			Path: "go",
+			Args: []string{"test", "./internal/injection"},
+		},
+	},
+	{
+		relativePath: "internal/injection/render_injection_bundle.go",
+		original: strings.Join([]string{
+			`if err := validateAllowedKeys(credentials, mapKeysSet([]string{`,
+			`		"codex_auth",`,
+			`		"claude_auth",`,
+			`		"claude_api_key",`,
+			`		"claude_mcp",`,
+		}, "\n"),
+		replacement: strings.Join([]string{
+			`if err := validateAllowedKeys(credentials, mapKeysSet([]string{`,
+			`		"codex_auth",`,
+			`		"claude_auth",`,
+			`		"claude_api_key",`,
+			`		// "claude_mcp",`,
+		}, "\n"),
+		label: "claude mcp credential support",
+		command: commandSpec{
+			Path: "go",
+			Args: []string{"test", "./internal/injection"},
+		},
+	},
+	{
+		relativePath: "internal/injection/render_injection_bundle.go",
+		original:     `if info.Mode().Perm()&0o077 != 0 {`,
+		replacement:  `if false && info.Mode().Perm()&0o077 != 0 {`,
+		label:        "secret permission hygiene",
+		command: commandSpec{
+			Path: "go",
+			Args: []string{"test", "./internal/injection"},
+		},
+	},
+	{
+		relativePath: "internal/transcript/transcript.go",
+		original:     `if !isTerminal(stdin) || !isTerminal(stdout) {`,
+		replacement:  `if false && (!isTerminal(stdin) || !isTerminal(stdout)) {`,
+		label:        "interactive terminal requirement",
+		command: commandSpec{
+			Path: "go",
+			Args: []string{"test", "./internal/transcript"},
+		},
+	},
+	{
+		relativePath: "internal/injection/extract_direct_mounts.go",
+		original:     `delete(entry, "source")`,
+		replacement:  `// delete(entry, "source")`,
+		label:        "manifest source stripping",
+		command: commandSpec{
+			Path: "go",
+			Args: []string{"test", "./internal/injection"},
+		},
+	},
+	{
+		relativePath: "internal/injection/render_injection_bundle.go",
+		original:     `"forwardagent":        {},`,
+		replacement:  `// "forwardagent":        {},`,
+		label:        "forwardagent ssh directive blocking",
+		command: commandSpec{
+			Path: "go",
+			Args: []string{"test", "./internal/injection"},
+		},
+	},
+	{
+		relativePath: "internal/injection/render_injection_bundle.go",
+		original:     `"sendenv":             {},`,
+		replacement:  `// "sendenv":             {},`,
+		label:        "sendenv ssh directive blocking",
+		command: commandSpec{
+			Path: "go",
+			Args: []string{"test", "./internal/injection"},
+		},
+	},
+}
+
+var rustMutations = []mutationCase{
+	{
+		relativePath: "runtime/container/rust/src/lib.rs",
+		original:     `matches!(value, Some(candidate) if !candidate.is_empty() && !candidate.eq_ignore_ascii_case("strict"))`,
+		replacement:  `matches!(value, Some(candidate) if !candidate.is_empty())`,
+		label:        "strict-mode matcher",
+	},
+	{
+		relativePath: "runtime/container/rust/src/lib.rs",
+		original:     `path == root`,
+		replacement:  `false`,
+		label:        "root-prefix matcher",
+	},
+}
+
+func Run(repoRoot string) error {
+	if err := runGoHelperMutations(repoRoot); err != nil {
+		return err
+	}
+	if err := runRustGuardMutations(repoRoot); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runGoHelperMutations(repoRoot string) error {
+	failures := make([]string, 0)
+	for _, tc := range goHelperMutations {
+		tempRoot, err := os.MkdirTemp("", "workcell-go-mutation.")
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(tempRoot)
+
+		for _, relativePath := range []string{
+			"cmd",
+			"internal",
+			"go.mod",
+		} {
+			if err := copyIntoTempRoot(repoRoot, tempRoot, relativePath); err != nil {
+				return err
+			}
+		}
+		if err := applyMutation(filepath.Join(tempRoot, tc.relativePath), tc.original, tc.replacement); err != nil {
+			return err
+		}
+		exitCode, err := runCommand(tempRoot, tc.command)
+		if err != nil {
+			return err
+		}
+		if exitCode == 0 {
+			failures = append(failures, tc.label)
+		}
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("Go helper mutation coverage did not catch: %s", strings.Join(failures, ", "))
+	}
+	return nil
+}
+
+func runRustGuardMutations(repoRoot string) error {
+	failures := make([]string, 0)
+	for _, tc := range rustMutations {
+		tempRoot, err := os.MkdirTemp("", "workcell-rust-mutation.")
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(tempRoot)
+
+		if err := copyTree(
+			filepath.Join(repoRoot, "runtime", "container", "rust"),
+			filepath.Join(tempRoot, "runtime", "container", "rust"),
+		); err != nil {
+			return err
+		}
+		if err := applyMutation(filepath.Join(tempRoot, tc.relativePath), tc.original, tc.replacement); err != nil {
+			return err
+		}
+		exitCode, err := runCommand(filepath.Join(tempRoot, "runtime", "container", "rust"), commandSpec{
+			Path: "cargo",
+			Args: []string{"test", "--locked", "--offline"},
+		})
+		if err != nil {
+			return err
+		}
+		if exitCode == 0 {
+			failures = append(failures, tc.label)
+		}
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("Rust mutation coverage did not catch: %s", strings.Join(failures, ", "))
+	}
+	return nil
+}
+
+type commandSpec struct {
+	Path string
+	Args []string
+	Env  map[string]string
+}
+
+func runCommand(cwd string, spec commandSpec) (int, error) {
+	cmd := exec.Command(spec.Path, spec.Args...)
+	cmd.Dir = cwd
+	if spec.Env != nil {
+		env := os.Environ()
+		for key, value := range spec.Env {
+			env = append(env, key+"="+value)
+		}
+		cmd.Env = env
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err == nil {
+		return 0, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), nil
+	}
+	return 0, err
+}
+
+func applyMutation(path string, original string, replacement string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	text := string(content)
+	if !strings.Contains(text, original) {
+		return fmt.Errorf("mutation anchor not found in %s: %s", path, original)
+	}
+	updated := strings.Replace(text, original, replacement, 1)
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(updated), info.Mode().Perm())
+}
+
+func copyTree(sourceRoot string, destinationRoot string) error {
+	return filepath.WalkDir(sourceRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(sourceRoot, path)
+		if err != nil {
+			return err
+		}
+		targetPath := filepath.Join(destinationRoot, relative)
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return os.MkdirAll(targetPath, info.Mode().Perm())
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			return os.Symlink(target, targetPath)
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(targetPath, content, info.Mode().Perm())
+	})
+}
+
+func copyIntoTempRoot(repoRoot string, tempRoot string, relativePath string) error {
+	sourcePath := filepath.Join(repoRoot, relativePath)
+	info, err := os.Lstat(sourcePath)
+	if err != nil {
+		return err
+	}
+	targetPath := filepath.Join(tempRoot, relativePath)
+	if info.IsDir() {
+		return copyTree(sourcePath, targetPath)
+	}
+	return copyFile(sourcePath, targetPath, info.Mode())
+}
+
+func copyFile(sourcePath string, targetPath string, mode fs.FileMode) error {
+	content, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(targetPath, content, mode.Perm())
+}

--- a/internal/paritytree/tree.go
+++ b/internal/paritytree/tree.go
@@ -1,0 +1,96 @@
+package paritytree
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+)
+
+type Entry struct {
+	Path       string
+	Mode       fs.FileMode
+	Kind       string
+	LinkTarget string
+	SHA256     string
+}
+
+func Snapshot(root string) ([]Entry, error) {
+	entries := make([]Entry, 0)
+	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root {
+			return nil
+		}
+
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		entry := Entry{
+			Path: filepath.ToSlash(rel),
+			Mode: info.Mode(),
+		}
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			entry.Kind = "symlink"
+			entry.LinkTarget = target
+		case info.Mode().IsDir():
+			entry.Kind = "dir"
+		case info.Mode().IsRegular():
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			sum := sha256.Sum256(content)
+			entry.Kind = "file"
+			entry.SHA256 = hex.EncodeToString(sum[:])
+		default:
+			entry.Kind = "other"
+		}
+		entries = append(entries, entry)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+	return entries, nil
+}
+
+func CompareDirectoryTrees(leftRoot, rightRoot string) error {
+	leftSnapshot, err := Snapshot(leftRoot)
+	if err != nil {
+		return err
+	}
+	rightSnapshot, err := Snapshot(rightRoot)
+	if err != nil {
+		return err
+	}
+	if reflect.DeepEqual(leftSnapshot, rightSnapshot) {
+		return nil
+	}
+	return fmt.Errorf(
+		"tree mismatch between %s and %s\nleft=%#v\nright=%#v",
+		leftRoot,
+		rightRoot,
+		leftSnapshot,
+		rightSnapshot,
+	)
+}

--- a/internal/paritytree/tree_test.go
+++ b/internal/paritytree/tree_test.go
@@ -1,0 +1,64 @@
+package paritytree
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCompareDirectoryTreesDetectsMismatch(t *testing.T) {
+	t.Parallel()
+
+	left := t.TempDir()
+	right := t.TempDir()
+	if err := os.WriteFile(filepath.Join(left, "value.txt"), []byte("left"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(right, "value.txt"), []byte("right"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := CompareDirectoryTrees(left, right)
+	if err == nil {
+		t.Fatal("CompareDirectoryTrees returned nil error")
+	}
+	if !strings.Contains(err.Error(), "tree mismatch") {
+		t.Fatalf("error %q does not mention tree mismatch", err)
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "sha256") {
+		t.Fatalf("error %q does not mention sha256 mismatch", err)
+	}
+}
+
+func TestSnapshotCapturesSymlinks(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "dir"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "dir", "file.txt"), []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("dir", "file.txt"), filepath.Join(root, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := Snapshot(root)
+	if err != nil {
+		t.Fatalf("Snapshot returned error: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("len(entries) = %d, want 3", len(entries))
+	}
+	if entries[0].Path != "dir" || entries[0].Kind != "dir" {
+		t.Fatalf("dir entry = %#v", entries[0])
+	}
+	if entries[1].Path != filepath.ToSlash(filepath.Join("dir", "file.txt")) || entries[1].Kind != "file" {
+		t.Fatalf("file entry = %#v", entries[1])
+	}
+	if entries[2].Path != "link.txt" || entries[2].Kind != "symlink" {
+		t.Fatalf("symlink entry = %#v", entries[2])
+	}
+}

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -1,0 +1,98 @@
+package pathutil
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+func ExpandUserPathBestEffort(raw string) (string, error) {
+	return expandUserPath(raw, false)
+}
+
+func ExpandUserPathStrict(raw string) (string, error) {
+	return expandUserPath(raw, true)
+}
+
+func CanonicalizeExpandedPath(path string) (string, error) {
+	if !filepath.IsAbs(path) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return "", err
+		}
+		path = abs
+	}
+	return ResolveBestEffort(filepath.Clean(path))
+}
+
+func ResolveBestEffort(path string) (string, error) {
+	if path == string(filepath.Separator) {
+		return path, nil
+	}
+
+	existing := path
+	suffix := make([]string, 0)
+	for {
+		if _, err := os.Lstat(existing); err == nil {
+			break
+		}
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			return path, nil
+		}
+		suffix = append([]string{filepath.Base(existing)}, suffix...)
+		existing = parent
+	}
+
+	resolvedExisting, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		return "", err
+	}
+	if len(suffix) == 0 {
+		return filepath.Clean(resolvedExisting), nil
+	}
+	parts := append([]string{resolvedExisting}, suffix...)
+	return filepath.Clean(filepath.Join(parts...)), nil
+}
+
+func expandUserPath(raw string, strict bool) (string, error) {
+	switch {
+	case raw == "~":
+		return os.UserHomeDir()
+	case strings.HasPrefix(raw, "~/"):
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, raw[2:]), nil
+	case !strings.HasPrefix(raw, "~"):
+		return raw, nil
+	}
+
+	slash := strings.IndexByte(raw, '/')
+	userName := raw[1:]
+	remainder := ""
+	if slash >= 0 {
+		userName = raw[1:slash]
+		remainder = raw[slash+1:]
+	}
+	if userName == "" {
+		return os.UserHomeDir()
+	}
+
+	lookup, err := user.Lookup(userName)
+	if err != nil || lookup.HomeDir == "" {
+		if strict {
+			if err != nil {
+				return "", err
+			}
+			return "", os.ErrNotExist
+		}
+		return raw, nil
+	}
+	if remainder == "" {
+		return lookup.HomeDir, nil
+	}
+	return filepath.Join(lookup.HomeDir, remainder), nil
+}

--- a/internal/testkit/parity.go
+++ b/internal/testkit/parity.go
@@ -1,0 +1,258 @@
+package testkit
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// CommandSpec describes a command invocation for parity checks.
+type CommandSpec struct {
+	Path string
+	Args []string
+	Dir  string
+	Env  []string
+}
+
+// CommandResult captures the observable surface of a command invocation.
+type CommandResult struct {
+	ExitCode int
+	Stdout   []byte
+	Stderr   []byte
+	Duration time.Duration
+}
+
+// TreeEntry describes one file-system entry in a snapshot.
+type TreeEntry struct {
+	Path       string
+	Mode       os.FileMode
+	Kind       string
+	SHA256     string
+	LinkTarget string
+}
+
+// TreePair identifies two roots that should contain the same tree.
+type TreePair struct {
+	LeftRoot  string
+	RightRoot string
+}
+
+// ParityCase compares two command invocations and optional output trees.
+type ParityCase struct {
+	Name      string
+	Left      CommandSpec
+	Right     CommandSpec
+	TreePairs []TreePair
+}
+
+// RunCommand executes a command and captures stdout, stderr, exit code, and duration.
+func RunCommand(ctx context.Context, spec CommandSpec) (CommandResult, error) {
+	cmd := exec.CommandContext(ctx, spec.Path, spec.Args...)
+	if spec.Dir != "" {
+		cmd.Dir = spec.Dir
+	}
+	if spec.Env != nil {
+		cmd.Env = append([]string(nil), spec.Env...)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	startedAt := time.Now()
+	err := cmd.Run()
+	result := CommandResult{
+		Stdout:   stdout.Bytes(),
+		Stderr:   stderr.Bytes(),
+		Duration: time.Since(startedAt),
+	}
+
+	if err == nil {
+		result.ExitCode = 0
+		return result, nil
+	}
+
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		result.ExitCode = exitErr.ExitCode()
+		return result, nil
+	}
+
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return result, ctxErr
+	}
+
+	var execErr *exec.Error
+	if errors.As(err, &execErr) {
+		return result, err
+	}
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		return result, err
+	}
+	return result, err
+}
+
+// CompareCommandResults reports the first mismatch between two command results.
+func CompareCommandResults(leftLabel, rightLabel string, left, right CommandResult) error {
+	if left.ExitCode != right.ExitCode {
+		return fmt.Errorf("%s exit code %d != %s exit code %d", leftLabel, left.ExitCode, rightLabel, right.ExitCode)
+	}
+	if !bytes.Equal(left.Stdout, right.Stdout) {
+		return fmt.Errorf("%s stdout mismatch with %s", leftLabel, rightLabel)
+	}
+	if !bytes.Equal(left.Stderr, right.Stderr) {
+		return fmt.Errorf("%s stderr mismatch with %s", leftLabel, rightLabel)
+	}
+	return nil
+}
+
+// SnapshotTree records a deterministic snapshot of a directory tree.
+func SnapshotTree(root string) ([]TreeEntry, error) {
+	info, err := os.Lstat(root)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", root)
+	}
+
+	var entries []TreeEntry
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+
+		entry := TreeEntry{
+			Path: rel,
+			Mode: info.Mode(),
+		}
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			entry.Kind = "symlink"
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			entry.LinkTarget = target
+		case info.IsDir():
+			entry.Kind = "dir"
+		case info.Mode().IsRegular():
+			entry.Kind = "file"
+			digest, err := hashFile(path)
+			if err != nil {
+				return err
+			}
+			entry.SHA256 = digest
+		default:
+			entry.Kind = "other"
+		}
+		entries = append(entries, entry)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+	return entries, nil
+}
+
+// CompareTreeSnapshots reports the first mismatch between two tree snapshots.
+func CompareTreeSnapshots(leftLabel string, left []TreeEntry, rightLabel string, right []TreeEntry) error {
+	if len(left) != len(right) {
+		return fmt.Errorf("%s has %d entries, %s has %d entries", leftLabel, len(left), rightLabel, len(right))
+	}
+	for i := range left {
+		l := left[i]
+		r := right[i]
+		if l.Path != r.Path {
+			return fmt.Errorf("tree path mismatch at index %d: %s != %s", i, l.Path, r.Path)
+		}
+		if l.Kind != r.Kind {
+			return fmt.Errorf("tree kind mismatch for %s: %s != %s", l.Path, l.Kind, r.Kind)
+		}
+		if l.Mode != r.Mode {
+			return fmt.Errorf("tree mode mismatch for %s: %s != %s", l.Path, l.Mode, r.Mode)
+		}
+		if l.SHA256 != r.SHA256 {
+			return fmt.Errorf("tree sha256 mismatch for %s", l.Path)
+		}
+		if l.LinkTarget != r.LinkTarget {
+			return fmt.Errorf("tree symlink target mismatch for %s: %s != %s", l.Path, l.LinkTarget, r.LinkTarget)
+		}
+	}
+	return nil
+}
+
+// CompareDirectoryTrees snapshots and compares two directories.
+func CompareDirectoryTrees(leftRoot, rightRoot string) error {
+	left, err := SnapshotTree(leftRoot)
+	if err != nil {
+		return fmt.Errorf("snapshot %s: %w", leftRoot, err)
+	}
+	right, err := SnapshotTree(rightRoot)
+	if err != nil {
+		return fmt.Errorf("snapshot %s: %w", rightRoot, err)
+	}
+	return CompareTreeSnapshots(leftRoot, left, rightRoot, right)
+}
+
+// RunParityCase executes both sides of a parity case and compares outputs and trees.
+func RunParityCase(ctx context.Context, c ParityCase) error {
+	left, err := RunCommand(ctx, c.Left)
+	if err != nil {
+		return fmt.Errorf("%s left command: %w", c.Name, err)
+	}
+	right, err := RunCommand(ctx, c.Right)
+	if err != nil {
+		return fmt.Errorf("%s right command: %w", c.Name, err)
+	}
+	if err := CompareCommandResults(c.Name+" left", c.Name+" right", left, right); err != nil {
+		return fmt.Errorf("%s: %w", c.Name, err)
+	}
+	for _, pair := range c.TreePairs {
+		if err := CompareDirectoryTrees(pair.LeftRoot, pair.RightRoot); err != nil {
+			return fmt.Errorf("%s: %w", c.Name, err)
+		}
+	}
+	return nil
+}
+
+func hashFile(path string) (string, error) {
+	handle, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer handle.Close()
+
+	sum := sha256.New()
+	if _, err := io.Copy(sum, handle); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(sum.Sum(nil)), nil
+}

--- a/internal/testkit/parity_test.go
+++ b/internal/testkit/parity_test.go
@@ -1,0 +1,200 @@
+package testkit
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func repoRoot(tb testing.TB) string {
+	tb.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		tb.Fatal("unable to determine repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}
+
+func shellCommand(body, root string) string {
+	return "/bin/sh -c " + shellQuote(body) + " sh " + shellQuote(root)
+}
+
+func TestRunCommandCapturesExitCodeAndStreams(t *testing.T) {
+	t.Parallel()
+
+	result, err := RunCommand(context.Background(), CommandSpec{
+		Path: "/bin/sh",
+		Args: []string{"-c", "printf out; printf err >&2; exit 7"},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand returned error: %v", err)
+	}
+	if result.ExitCode != 7 {
+		t.Fatalf("exit code = %d, want 7", result.ExitCode)
+	}
+	if string(result.Stdout) != "out" {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, "out")
+	}
+	if string(result.Stderr) != "err" {
+		t.Fatalf("stderr = %q, want %q", result.Stderr, "err")
+	}
+}
+
+func TestSnapshotTreeCapturesModesAndSymlinks(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	dirPath := filepath.Join(root, "dir")
+	if err := os.Mkdir(dirPath, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(dirPath, "file.txt")
+	if err := os.WriteFile(filePath, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkPath := filepath.Join(root, "link.txt")
+	if err := os.Symlink(filepath.Join("dir", "file.txt"), linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := SnapshotTree(root)
+	if err != nil {
+		t.Fatalf("SnapshotTree returned error: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("len(entries) = %d, want 3", len(entries))
+	}
+	if entries[0].Path != "dir" || entries[0].Kind != "dir" {
+		t.Fatalf("dir entry = %#v", entries[0])
+	}
+	if entries[1].Path != filepath.ToSlash(filepath.Join("dir", "file.txt")) || entries[1].Kind != "file" {
+		t.Fatalf("file entry = %#v", entries[1])
+	}
+	sum := sha256.Sum256([]byte("hello"))
+	if entries[1].SHA256 != hex.EncodeToString(sum[:]) {
+		t.Fatalf("file sha256 = %q, want %q", entries[1].SHA256, hex.EncodeToString(sum[:]))
+	}
+	if entries[2].Path != "link.txt" || entries[2].Kind != "symlink" {
+		t.Fatalf("symlink entry = %#v", entries[2])
+	}
+	if entries[2].LinkTarget != filepath.Join("dir", "file.txt") {
+		t.Fatalf("symlink target = %q, want %q", entries[2].LinkTarget, filepath.Join("dir", "file.txt"))
+	}
+}
+
+func TestCompareDirectoryTreesDetectsMismatch(t *testing.T) {
+	t.Parallel()
+
+	left := t.TempDir()
+	right := t.TempDir()
+	if err := os.WriteFile(filepath.Join(left, "value.txt"), []byte("left"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(right, "value.txt"), []byte("right"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := CompareDirectoryTrees(left, right)
+	if err == nil {
+		t.Fatal("CompareDirectoryTrees returned nil error")
+	}
+	if !strings.Contains(err.Error(), "sha256") {
+		t.Fatalf("error %q does not mention sha256 mismatch", err)
+	}
+}
+
+func TestRunParityCaseComparesOutputsAndTrees(t *testing.T) {
+	t.Parallel()
+
+	leftRoot := t.TempDir()
+	rightRoot := t.TempDir()
+	script := `printf "same\n"; printf "same\n" >&2; mkdir -p "$1/out"; printf "payload\n" > "$1/out/data.txt"`
+	caseSpec := ParityCase{
+		Name: "demo",
+		Left: CommandSpec{
+			Path: "/bin/sh",
+			Args: []string{"-c", script, "sh", leftRoot},
+		},
+		Right: CommandSpec{
+			Path: "/bin/sh",
+			Args: []string{"-c", script, "sh", rightRoot},
+		},
+		TreePairs: []TreePair{{LeftRoot: leftRoot, RightRoot: rightRoot}},
+	}
+
+	if err := RunParityCase(context.Background(), caseSpec); err != nil {
+		t.Fatalf("RunParityCase returned error: %v", err)
+	}
+}
+
+func TestParityScriptDetectsTreeMismatch(t *testing.T) {
+	t.Parallel()
+
+	leftRoot := t.TempDir()
+	rightRoot := t.TempDir()
+	script := `mkdir -p "$1/out"; printf "same\n"; printf "same\n" >&2; printf "left\n" > "$1/out/data.txt"`
+	leftCmd := shellCommand(script, leftRoot)
+	rightCmd := shellCommand(`mkdir -p "$1/out"; printf "same\n"; printf "same\n" >&2; printf "right\n" > "$1/out/data.txt"`, rightRoot)
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "verify-go-python-parity.sh")
+
+	cmd := exec.Command(
+		"bash",
+		scriptPath,
+		"--name",
+		"tree-mismatch",
+		"--python-cmd",
+		leftCmd,
+		"--go-cmd",
+		rightCmd,
+		"--compare-root",
+		leftRoot+":"+rightRoot,
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("script succeeded unexpectedly: %s", out)
+	}
+	if !strings.Contains(string(out), "tree mismatch") {
+		t.Fatalf("script output %q does not mention tree mismatch", out)
+	}
+}
+
+func TestParityScriptPassesForMatchingCommandOutputs(t *testing.T) {
+	t.Parallel()
+
+	leftRoot := t.TempDir()
+	rightRoot := t.TempDir()
+	script := `printf "same\n"; printf "same\n" >&2; mkdir -p "$1/out"; printf "payload\n" > "$1/out/data.txt"`
+	leftCmd := shellCommand(script, leftRoot)
+	rightCmd := shellCommand(script, rightRoot)
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "verify-go-python-parity.sh")
+
+	cmd := exec.Command(
+		"bash",
+		scriptPath,
+		"--name",
+		"parity-smoke",
+		"--python-cmd",
+		leftCmd,
+		"--go-cmd",
+		rightCmd,
+		"--compare-root",
+		leftRoot+":"+rightRoot,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "parity passed") {
+		t.Fatalf("script output %q does not mention success", out)
+	}
+}

--- a/scripts/go-port-validate.sh
+++ b/scripts/go-port-validate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required tool: $1" >&2
+    exit 1
+  }
+}
+
+require_tool go
+require_tool gofmt
+
+"${ROOT_DIR}/scripts/verify-scenario-coverage.sh"
+"${ROOT_DIR}/scripts/run-mutation-tests.sh"
+
+(
+  cd "${ROOT_DIR}"
+  mapfile -d '' -t go_files < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
+  if [[ "${#go_files[@]}" -gt 0 ]]; then
+    if gofmt -l "${go_files[@]}" | grep -q .; then
+      echo "Go files are not formatted with gofmt." >&2
+      exit 1
+    fi
+  fi
+  go vet ./...
+  go test ./...
+)
+
+echo "Go port validation baseline passed."

--- a/scripts/verify-go-python-parity.sh
+++ b/scripts/verify-go-python-parity.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: verify-go-python-parity.sh --name NAME --python-cmd CMD --go-cmd CMD [--compare-root LEFT:RIGHT]...
+
+Runs two command strings, compares exit code/stdout/stderr, and optionally compares
+matching directory trees. Commands run from the repository root.
+EOF
+  exit 64
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required tool: $1" >&2
+    exit 1
+  }
+}
+
+name=""
+python_cmd=""
+go_cmd=""
+compare_roots=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)
+      name="${2:-}"
+      shift 2
+      ;;
+    --python-cmd)
+      python_cmd="${2:-}"
+      shift 2
+      ;;
+    --go-cmd)
+      go_cmd="${2:-}"
+      shift 2
+      ;;
+    --compare-root)
+      compare_roots+=("${2:-}")
+      shift 2
+      ;;
+    --help | -h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+[[ -n "${name}" && -n "${python_cmd}" && -n "${go_cmd}" ]] || usage
+
+require_tool go
+require_tool bash
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/workcell-go-python-parity.XXXXXX")"
+cleanup() {
+  rm -rf "${TMP_ROOT}"
+}
+trap cleanup EXIT
+
+run_command() {
+  local command="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  local status_file="$4"
+
+  local status=0
+  if (
+    cd "${ROOT_DIR}"
+    bash -lc "${command}"
+  ) >"${stdout_file}" 2>"${stderr_file}"; then
+    status=0
+  else
+    status=$?
+  fi
+  printf '%s\n' "${status}" >"${status_file}"
+}
+
+compare_trees() {
+  local left_root="$1"
+  local right_root="$2"
+  (
+    cd "${ROOT_DIR}"
+    go run ./cmd/workcell-treecompare "${left_root}" "${right_root}"
+  )
+}
+
+python_stdout="${TMP_ROOT}/python.stdout"
+python_stderr="${TMP_ROOT}/python.stderr"
+python_status="${TMP_ROOT}/python.status"
+go_stdout="${TMP_ROOT}/go.stdout"
+go_stderr="${TMP_ROOT}/go.stderr"
+go_status="${TMP_ROOT}/go.status"
+
+run_command "${python_cmd}" "${python_stdout}" "${python_stderr}" "${python_status}"
+run_command "${go_cmd}" "${go_stdout}" "${go_stderr}" "${go_status}"
+
+if ! cmp -s "${python_status}" "${go_status}"; then
+  echo "${name}: exit code mismatch" >&2
+  echo "python=$(<"${python_status}")" >&2
+  echo "go=$(<"${go_status}")" >&2
+  exit 1
+fi
+
+if ! cmp -s "${python_stdout}" "${go_stdout}"; then
+  echo "${name}: stdout mismatch" >&2
+  exit 1
+fi
+
+if ! cmp -s "${python_stderr}" "${go_stderr}"; then
+  echo "${name}: stderr mismatch" >&2
+  exit 1
+fi
+
+for pair in "${compare_roots[@]}"; do
+  left_root="${pair%%:*}"
+  right_root="${pair#*:}"
+  if [[ -z "${left_root}" || -z "${right_root}" || "${left_root}" == "${right_root}" ]]; then
+    echo "${name}: invalid compare-root entry: ${pair}" >&2
+    exit 1
+  fi
+  compare_trees "${left_root}" "${right_root}"
+done
+
+echo "${name}: parity passed"


### PR DESCRIPTION
## Summary
- add the Go module and the first Go toolchain surface for the repo
- port metadata, parity, and mutation utilities into Go entrypoints and shared packages
- keep shell cutover and Python retirement out of scope

## Dependency note
- add `github.com/BurntSushi/toml` as the only non-stdlib Go dependency, used to validate real TOML instead of maintaining a custom parser

## Verification
- `go test ./internal/metadatautil ./internal/paritytree ./internal/testkit`
