### PR TITLE
Port Standalone Helper CLIs to Go

### DIFF
--- a/cmd/workcell-extract-direct-mounts/main.go
+++ b/cmd/workcell-extract-direct-mounts/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/omkhar/workcell/internal/injection"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stderr))
+}
+
+func run(args []string, stderr io.Writer) int {
+	fs := flag.NewFlagSet("workcell-extract-direct-mounts", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	manifestPath := fs.String("manifest", "", "")
+	mountSpecPath := fs.String("mount-spec", "", "")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	if *manifestPath == "" || *mountSpecPath == "" {
+		fmt.Fprintln(stderr, "both --manifest and --mount-spec are required")
+		return 2
+	}
+	if err := injection.RunExtractDirectMounts(*manifestPath, *mountSpecPath); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/workcell-pty-transcript/main.go
+++ b/cmd/workcell-pty-transcript/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/omkhar/workcell/internal/transcript"
+)
+
+func main() {
+	os.Exit(transcript.Run("pty_transcript", os.Stdin, os.Stdout, os.Stderr, os.Args[1:]))
+}

--- a/cmd/workcell-scenario-manifest/main.go
+++ b/cmd/workcell-scenario-manifest/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/omkhar/workcell/internal/scenarios"
+)
+
+func main() {
+	os.Exit(scenarios.Run(os.Args[0], os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/internal/injection/extract_direct_mounts.go
+++ b/internal/injection/extract_direct_mounts.go
@@ -1,0 +1,299 @@
+package injection
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// DirectMount mirrors the JSON shape emitted by the Python helper.
+type DirectMount struct {
+	Source    string `json:"source"`
+	MountPath string `json:"mount_path"`
+}
+
+// RequireDirectMount removes the host source from an entry and returns the direct mount record.
+func RequireDirectMount(entry map[string]any, label string) (DirectMount, error) {
+	source, _ := entry["source"].(string)
+	delete(entry, "source")
+
+	mountPath, _ := entry["mount_path"].(string)
+	if source == "" {
+		return DirectMount{}, fmt.Errorf("%s is missing its host source path", label)
+	}
+	if mountPath == "" {
+		return DirectMount{}, fmt.Errorf("%s is missing its direct mount path", label)
+	}
+	return DirectMount{Source: source, MountPath: mountPath}, nil
+}
+
+// RunExtractDirectMounts reproduces the legacy extract_direct_mounts helper.
+func RunExtractDirectMounts(manifestPath, mountSpecPath string) error {
+	resolvedManifestPath, err := resolvePathLikePython(manifestPath)
+	if err != nil {
+		return err
+	}
+	resolvedMountSpecPath, err := resolvePathLikePython(mountSpecPath)
+	if err != nil {
+		return err
+	}
+
+	manifest, err := loadJSONObject(resolvedManifestPath)
+	if err != nil {
+		return err
+	}
+
+	directMounts, err := collectDirectMounts(manifest)
+	if err != nil {
+		return err
+	}
+
+	if err := writePrettyJSON(resolvedManifestPath, manifest, 0o600); err != nil {
+		return err
+	}
+	if err := writePrettyJSON(resolvedMountSpecPath, directMounts, 0o600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func collectDirectMounts(manifest map[string]any) ([]DirectMount, error) {
+	var directMounts []DirectMount
+
+	if rawCredentials, ok := manifest["credentials"]; ok && rawCredentials != nil {
+		credentials, err := asObjectMap(rawCredentials, "credentials")
+		if err != nil {
+			return nil, err
+		}
+		for _, key := range sortedMapKeys(credentials) {
+			entry, err := asObjectMap(credentials[key], "credentials."+key)
+			if err != nil {
+				return nil, err
+			}
+			directMount, err := RequireDirectMount(entry, "credentials."+key)
+			if err != nil {
+				return nil, err
+			}
+			directMounts = append(directMounts, directMount)
+		}
+	}
+
+	if rawCopies, ok := manifest["copies"]; ok && rawCopies != nil {
+		copies, err := asArray(rawCopies, "copies")
+		if err != nil {
+			return nil, err
+		}
+		for index, rawEntry := range copies {
+			entry, err := asObjectMap(rawEntry, fmt.Sprintf("copies[%d]", index))
+			if err != nil {
+				return nil, err
+			}
+			if rawSource, ok := entry["source"]; ok && rawSource != nil {
+				source, ok := rawSource.(map[string]any)
+				if !ok {
+					continue
+				}
+				directMount, err := RequireDirectMount(source, fmt.Sprintf("copies[%d].source", index))
+				if err != nil {
+					return nil, err
+				}
+				directMounts = append(directMounts, directMount)
+			}
+		}
+	}
+
+	rawSSH, ok := manifest["ssh"]
+	if !ok || rawSSH == nil {
+		return sortDirectMounts(directMounts), nil
+	}
+
+	ssh, err := asObjectMap(rawSSH, "ssh")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, key := range []string{"config", "known_hosts"} {
+		if rawEntry, ok := ssh[key]; ok && rawEntry != nil {
+			entry, err := asObjectMap(rawEntry, "ssh."+key)
+			if err != nil {
+				return nil, err
+			}
+			directMount, err := RequireDirectMount(entry, "ssh."+key)
+			if err != nil {
+				return nil, err
+			}
+			directMounts = append(directMounts, directMount)
+		}
+	}
+
+	if rawIdentities, ok := ssh["identities"]; ok && rawIdentities != nil {
+		identities, err := asArray(rawIdentities, "ssh.identities")
+		if err != nil {
+			return nil, err
+		}
+		for index, rawIdentity := range identities {
+			entry, err := asObjectMap(rawIdentity, fmt.Sprintf("ssh.identities[%d]", index))
+			if err != nil {
+				return nil, err
+			}
+			if _, ok := entry["mount_path"]; ok {
+				directMount, err := RequireDirectMount(entry, fmt.Sprintf("ssh.identities[%d]", index))
+				if err != nil {
+					return nil, err
+				}
+				directMounts = append(directMounts, directMount)
+			}
+		}
+	}
+
+	return sortDirectMounts(directMounts), nil
+}
+
+func sortDirectMounts(directMounts []DirectMount) []DirectMount {
+	sort.SliceStable(directMounts, func(i, j int) bool {
+		return directMounts[i].MountPath < directMounts[j].MountPath
+	})
+	return directMounts
+}
+
+func loadJSONObject(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var manifest map[string]any
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func writePrettyJSON(path string, value any, mode os.FileMode) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, mode); err != nil {
+		return err
+	}
+	return os.Chmod(path, mode)
+}
+
+func asObjectMap(value any, label string) (map[string]any, error) {
+	if value == nil {
+		return nil, fmt.Errorf("%s must be a JSON object", label)
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be a JSON object", label)
+	}
+	return object, nil
+}
+
+func asArray(value any, label string) ([]any, error) {
+	if value == nil {
+		return nil, fmt.Errorf("%s must be a JSON array", label)
+	}
+	array, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be a JSON array", label)
+	}
+	return array, nil
+}
+
+func sortedMapKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func expandUserPath(raw string) (string, error) {
+	if raw == "" {
+		return "", errors.New("empty path")
+	}
+	if raw == "~" || strings.HasPrefix(raw, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if raw == "~" {
+			return home, nil
+		}
+		return filepath.Join(home, raw[2:]), nil
+	}
+	if strings.HasPrefix(raw, "~") {
+		slash := strings.IndexByte(raw, '/')
+		userName := raw[1:]
+		remainder := ""
+		if slash >= 0 {
+			userName = raw[1:slash]
+			remainder = raw[slash+1:]
+		}
+		home := ""
+		if userName == "" {
+			var err error
+			home, err = os.UserHomeDir()
+			if err != nil {
+				return "", err
+			}
+		} else {
+			usr, err := user.Lookup(userName)
+			if err != nil {
+				return "", err
+			}
+			home = usr.HomeDir
+		}
+		if remainder == "" {
+			return home, nil
+		}
+		return filepath.Join(home, remainder), nil
+	}
+	return raw, nil
+}
+
+func resolvePathLikePython(raw string) (string, error) {
+	expanded, err := expandUserPath(raw)
+	if err != nil {
+		return "", err
+	}
+	absolute, err := filepath.Abs(expanded)
+	if err != nil {
+		return "", err
+	}
+	clean := filepath.Clean(absolute)
+	if clean == string(filepath.Separator) {
+		return clean, nil
+	}
+
+	existing := clean
+	suffix := make([]string, 0)
+	for {
+		if _, err := os.Lstat(existing); err == nil {
+			break
+		}
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			return clean, nil
+		}
+		suffix = append([]string{filepath.Base(existing)}, suffix...)
+		existing = parent
+	}
+
+	resolvedExisting, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		return "", err
+	}
+	if len(suffix) == 0 {
+		return filepath.Clean(resolvedExisting), nil
+	}
+	return filepath.Clean(filepath.Join(append([]string{resolvedExisting}, suffix...)...)), nil
+}

--- a/internal/injection/extract_direct_mounts_test.go
+++ b/internal/injection/extract_direct_mounts_test.go
@@ -1,0 +1,293 @@
+package injection
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRequireDirectMountRemovesSourceAndReturnsEntry(t *testing.T) {
+	entry := map[string]any{
+		"source":     "/host/auth.json",
+		"mount_path": "/opt/workcell/host-inputs/credentials/codex-auth.json",
+	}
+
+	directMount, err := RequireDirectMount(entry, "credentials.codex_auth")
+	if err != nil {
+		t.Fatalf("RequireDirectMount returned error: %v", err)
+	}
+	if _, ok := entry["source"]; ok {
+		t.Fatalf("RequireDirectMount did not remove source from entry")
+	}
+	if directMount.Source != "/host/auth.json" {
+		t.Fatalf("unexpected source: %q", directMount.Source)
+	}
+	if directMount.MountPath != "/opt/workcell/host-inputs/credentials/codex-auth.json" {
+		t.Fatalf("unexpected mount path: %q", directMount.MountPath)
+	}
+}
+
+func TestRequireDirectMountRejectsMissingMountPath(t *testing.T) {
+	_, err := RequireDirectMount(map[string]any{"source": "/host/auth.json"}, "credentials.codex_auth")
+	if err == nil {
+		t.Fatalf("RequireDirectMount should have failed")
+	}
+	if got := err.Error(); got != "credentials.codex_auth is missing its direct mount path" {
+		t.Fatalf("unexpected error: %q", got)
+	}
+}
+
+func TestRequireDirectMountRejectsMissingSource(t *testing.T) {
+	_, err := RequireDirectMount(
+		map[string]any{
+			"mount_path": "/opt/workcell/host-inputs/credentials/codex-auth.json",
+		},
+		"credentials.codex_auth",
+	)
+	if err == nil {
+		t.Fatalf("RequireDirectMount should have failed")
+	}
+	if got := err.Error(); got != "credentials.codex_auth is missing its host source path" {
+		t.Fatalf("unexpected error: %q", got)
+	}
+}
+
+func TestRunExtractDirectMountsMutatesManifestAndWritesSortedMounts(t *testing.T) {
+	manifestFixture := map[string]any{
+		"credentials": map[string]any{
+			"codex_auth": map[string]any{
+				"source":     "/host/auth.json",
+				"mount_path": "/opt/workcell/host-inputs/credentials/codex-auth.json",
+			},
+		},
+		"copies": []any{
+			map[string]any{
+				"source": map[string]any{
+					"source":     "/host/secret.txt",
+					"mount_path": "/opt/workcell/host-inputs/copies/0",
+				},
+				"target": "/state/agent-home/.config/workcell/token.txt",
+			},
+		},
+		"ssh": map[string]any{
+			"config": map[string]any{
+				"source":     "/host/ssh-config",
+				"mount_path": "/opt/workcell/host-inputs/ssh/config",
+			},
+			"identities": []any{
+				map[string]any{
+					"source":      "/host/id_a",
+					"mount_path":  "/opt/workcell/host-inputs/ssh/identity-0",
+					"target_name": "id_a",
+				},
+				map[string]any{
+					"source":      "/host/id_b",
+					"target_name": "id_b",
+					"comment":     "ignored because no mount_path",
+				},
+			},
+		},
+	}
+
+	gotManifest, gotMounts := runGoExtractDirectMounts(t, manifestFixture)
+
+	var manifest map[string]any
+	if err := json.Unmarshal(gotManifest, &manifest); err != nil {
+		t.Fatalf("json.Unmarshal manifest: %v", err)
+	}
+	credentials, ok := manifest["credentials"].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected credentials shape: %#v", manifest["credentials"])
+	}
+	codexAuth, ok := credentials["codex_auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected codex_auth shape: %#v", credentials["codex_auth"])
+	}
+	if _, ok := codexAuth["source"]; ok {
+		t.Fatalf("credentials.codex_auth still contains source: %#v", codexAuth)
+	}
+	if got := codexAuth["mount_path"]; got != "/opt/workcell/host-inputs/credentials/codex-auth.json" {
+		t.Fatalf("credentials.codex_auth.mount_path = %v", got)
+	}
+
+	copies, ok := manifest["copies"].([]any)
+	if !ok || len(copies) != 1 {
+		t.Fatalf("unexpected copies shape: %#v", manifest["copies"])
+	}
+	copyEntry, ok := copies[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected copy entry: %#v", copies[0])
+	}
+	copySource, ok := copyEntry["source"].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected copy source shape: %#v", copyEntry["source"])
+	}
+	if _, ok := copySource["source"]; ok {
+		t.Fatalf("copies[0].source still contains source: %#v", copySource)
+	}
+	if got := copySource["mount_path"]; got != "/opt/workcell/host-inputs/copies/0" {
+		t.Fatalf("copies[0].source.mount_path = %v", got)
+	}
+
+	ssh, ok := manifest["ssh"].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected ssh shape: %#v", manifest["ssh"])
+	}
+	sshConfig, ok := ssh["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected ssh.config shape: %#v", ssh["config"])
+	}
+	if _, ok := sshConfig["source"]; ok {
+		t.Fatalf("ssh.config still contains source: %#v", sshConfig)
+	}
+	if got := sshConfig["mount_path"]; got != "/opt/workcell/host-inputs/ssh/config" {
+		t.Fatalf("ssh.config.mount_path = %v", got)
+	}
+	identities, ok := ssh["identities"].([]any)
+	if !ok || len(identities) != 2 {
+		t.Fatalf("unexpected ssh.identities shape: %#v", ssh["identities"])
+	}
+	firstIdentity, ok := identities[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected first identity: %#v", identities[0])
+	}
+	if _, ok := firstIdentity["source"]; ok {
+		t.Fatalf("ssh.identities[0] still contains source: %#v", firstIdentity)
+	}
+	if got := firstIdentity["mount_path"]; got != "/opt/workcell/host-inputs/ssh/identity-0" {
+		t.Fatalf("ssh.identities[0].mount_path = %v", got)
+	}
+	secondIdentity, ok := identities[1].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected second identity: %#v", identities[1])
+	}
+	if got := secondIdentity["source"]; got != "/host/id_b" {
+		t.Fatalf("ssh.identities[1].source = %v", got)
+	}
+
+	var mounts []DirectMount
+	if err := json.Unmarshal(gotMounts, &mounts); err != nil {
+		t.Fatalf("json.Unmarshal mounts: %v", err)
+	}
+	wantMounts := []DirectMount{
+		{Source: "/host/secret.txt", MountPath: "/opt/workcell/host-inputs/copies/0"},
+		{Source: "/host/auth.json", MountPath: "/opt/workcell/host-inputs/credentials/codex-auth.json"},
+		{Source: "/host/ssh-config", MountPath: "/opt/workcell/host-inputs/ssh/config"},
+		{Source: "/host/id_a", MountPath: "/opt/workcell/host-inputs/ssh/identity-0"},
+	}
+	if len(mounts) != len(wantMounts) {
+		t.Fatalf("unexpected mount count: got %d want %d\n%#v", len(mounts), len(wantMounts), mounts)
+	}
+	for i := range wantMounts {
+		if mounts[i] != wantMounts[i] {
+			t.Fatalf("mount %d mismatch: got %#v want %#v", i, mounts[i], wantMounts[i])
+		}
+	}
+}
+
+func TestRunExtractDirectMountsWritesMode0600(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.json")
+	mountSpecPath := filepath.Join(root, "mounts.json")
+
+	if err := os.WriteFile(manifestPath, []byte(`{"copies":[]}`), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err != nil {
+		t.Fatalf("RunExtractDirectMounts returned error: %v", err)
+	}
+
+	assertFileMode(t, manifestPath, 0o600)
+	assertFileMode(t, mountSpecPath, 0o600)
+}
+
+func TestRunExtractDirectMountsLeavesPlainCopySourcesInline(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.json")
+	mountSpecPath := filepath.Join(root, "mounts.json")
+
+	writeFixtureManifest(t, manifestPath, map[string]any{
+		"copies": []any{
+			map[string]any{
+				"source": "copies/0",
+				"target": "/state/injected/public.txt",
+			},
+		},
+	})
+
+	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err != nil {
+		t.Fatalf("RunExtractDirectMounts returned error: %v", err)
+	}
+
+	var manifest map[string]any
+	if err := json.Unmarshal(readFile(t, manifestPath), &manifest); err != nil {
+		t.Fatalf("json.Unmarshal manifest: %v", err)
+	}
+	copies, ok := manifest["copies"].([]any)
+	if !ok || len(copies) != 1 {
+		t.Fatalf("unexpected manifest copies: %#v", manifest["copies"])
+	}
+	entry, ok := copies[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected copy entry: %#v", copies[0])
+	}
+	if got := entry["source"]; got != "copies/0" {
+		t.Fatalf("source mutated unexpectedly: %v", got)
+	}
+
+	var mounts []DirectMount
+	if err := json.Unmarshal(readFile(t, mountSpecPath), &mounts); err != nil {
+		t.Fatalf("json.Unmarshal mounts: %v", err)
+	}
+	if len(mounts) != 0 {
+		t.Fatalf("expected no direct mounts, got %#v", mounts)
+	}
+}
+
+func runGoExtractDirectMounts(t *testing.T, manifestFixture map[string]any) ([]byte, []byte) {
+	t.Helper()
+
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.json")
+	mountSpecPath := filepath.Join(root, "mounts.json")
+
+	writeFixtureManifest(t, manifestPath, manifestFixture)
+	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err != nil {
+		t.Fatalf("RunExtractDirectMounts returned error: %v", err)
+	}
+
+	return readFile(t, manifestPath), readFile(t, mountSpecPath)
+}
+
+func writeFixtureManifest(t *testing.T, path string, fixture map[string]any) {
+	t.Helper()
+	data, err := json.MarshalIndent(fixture, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}
+
+func readFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file %s: %v", path, err)
+	}
+	return data
+}
+
+func assertFileMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode mismatch for %s: got %04o want %04o", path, got, want)
+	}
+}

--- a/internal/scenarios/scenario_manifest.go
+++ b/internal/scenarios/scenario_manifest.go
@@ -1,0 +1,424 @@
+package scenarios
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var (
+	validLanes     = map[string]struct{}{"secretless": {}, "provider-e2e": {}}
+	validPlatforms = map[string]struct{}{"any": {}, "linux": {}, "macos": {}}
+	validProviders = map[string]struct{}{"codex": {}, "claude": {}, "gemini": {}}
+	personaPrefix  = "^[a-z][a-z0-9-]*$"
+)
+
+type Scenario struct {
+	ID                  string
+	Description         string
+	Persona             string
+	Providers           []string
+	RequiresCredentials bool
+	Manual              bool
+	Lane                string
+	Platform            string
+	TestFile            string
+}
+
+func nonEmptyString(value any, label string) (string, error) {
+	str, ok := value.(string)
+	if !ok || strings.TrimSpace(str) == "" {
+		return "", fmt.Errorf("%s must be a non-empty string", label)
+	}
+	return str, nil
+}
+
+func optionalBool(scenario map[string]any, key, scenarioID string, defaultValue bool) (bool, error) {
+	value, ok := scenario[key]
+	if !ok {
+		return defaultValue, nil
+	}
+	boolValue, ok := value.(bool)
+	if !ok {
+		return false, fmt.Errorf("scenario %s: %s must be boolean", scenarioID, key)
+	}
+	return boolValue, nil
+}
+
+func normalizeTestFile(value any, scenarioID string, manual bool) (string, error) {
+	if value == "" || value == nil {
+		if manual {
+			return "", nil
+		}
+		return "", fmt.Errorf("scenario %s: test_file is required for automated scenarios", scenarioID)
+	}
+
+	raw, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("scenario %s: test_file must be a string", scenarioID)
+	}
+
+	if strings.HasPrefix(raw, "/") {
+		return "", fmt.Errorf("scenario %s: test_file must stay under tests/scenarios without traversal", scenarioID)
+	}
+
+	parts := strings.Split(raw, "/")
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return "", fmt.Errorf("scenario %s: test_file must stay under tests/scenarios without traversal", scenarioID)
+		}
+	}
+	if path.Ext(raw) != ".sh" || !strings.HasPrefix(path.Base(raw), "test-") {
+		return "", fmt.Errorf("scenario %s: test_file must reference a scenario shell script", scenarioID)
+	}
+	return path.Clean(raw), nil
+}
+
+func loadManifest(pathname string) (map[string]any, error) {
+	content, err := os.ReadFile(pathname)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("Scenario manifest does not exist: %s", pathname)
+		}
+		return nil, err
+	}
+
+	var manifest any
+	if err := json.Unmarshal(content, &manifest); err != nil {
+		return nil, err
+	}
+	root, ok := manifest.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("scenario manifest must contain a JSON object")
+	}
+	return root, nil
+}
+
+func LoadScenarios(manifestPath string) ([]Scenario, error) {
+	manifest, err := loadManifest(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	if manifest["version"] != float64(1) {
+		return nil, fmt.Errorf("scenario manifest version must be 1")
+	}
+
+	rawScenarios, ok := manifest["scenarios"].([]any)
+	if !ok || len(rawScenarios) == 0 {
+		return nil, fmt.Errorf("scenario manifest must contain a non-empty scenarios array")
+	}
+
+	seenIDs := map[string]struct{}{}
+	seenTestFiles := map[string]struct{}{}
+	scenarios := make([]Scenario, 0, len(rawScenarios))
+	for index, raw := range rawScenarios {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("scenario entry %d must be an object", index+1)
+		}
+
+		scenarioID, err := nonEmptyString(entry["id"], fmt.Sprintf("scenario entry %d id", index+1))
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seenIDs[scenarioID]; ok {
+			return nil, fmt.Errorf("Duplicate scenario id: %s", scenarioID)
+		}
+		seenIDs[scenarioID] = struct{}{}
+
+		description, err := nonEmptyString(entry["description"], fmt.Sprintf("scenario %s description", scenarioID))
+		if err != nil {
+			return nil, err
+		}
+		persona, err := nonEmptyString(entry["persona"], fmt.Sprintf("scenario %s persona", scenarioID))
+		if err != nil {
+			return nil, err
+		}
+		if !isPersonaValid(persona) {
+			return nil, fmt.Errorf("scenario %s: persona must match %s", scenarioID, personaPrefix)
+		}
+
+		rawProviders, ok := entry["providers"].([]any)
+		if !ok || len(rawProviders) == 0 {
+			return nil, fmt.Errorf("scenario %s: providers must be a non-empty list", scenarioID)
+		}
+		normalizedProviders := make([]string, 0, len(rawProviders))
+		for _, provider := range rawProviders {
+			providerName, err := nonEmptyString(provider, fmt.Sprintf("scenario %s provider", scenarioID))
+			if err != nil {
+				return nil, err
+			}
+			if _, ok := validProviders[providerName]; !ok {
+				return nil, fmt.Errorf(
+					"scenario %s: provider must be one of: %s",
+					scenarioID,
+					strings.Join(sortedKeys(validProviders), ", "),
+				)
+			}
+			for _, existing := range normalizedProviders {
+				if existing == providerName {
+					return nil, fmt.Errorf("scenario %s: duplicate provider %s", scenarioID, providerName)
+				}
+			}
+			normalizedProviders = append(normalizedProviders, providerName)
+		}
+
+		requiresCredentials, err := optionalBool(entry, "requires_credentials", scenarioID, false)
+		if err != nil {
+			return nil, err
+		}
+		manual, err := optionalBool(entry, "manual", scenarioID, false)
+		if err != nil {
+			return nil, err
+		}
+
+		lane := "secretless"
+		if requiresCredentials {
+			lane = "provider-e2e"
+		}
+		if rawLane, ok := entry["lane"]; ok {
+			laneValue, ok := rawLane.(string)
+			if !ok || !containsKey(validLanes, laneValue) {
+				return nil, fmt.Errorf("scenario %s: lane must be one of: %s", scenarioID, strings.Join(sortedKeys(validLanes), ", "))
+			}
+			lane = laneValue
+		}
+		if lane == "secretless" && requiresCredentials {
+			return nil, fmt.Errorf("scenario %s: cannot be secretless and require credentials", scenarioID)
+		}
+
+		platform := "any"
+		if rawPlatform, ok := entry["platform"]; ok {
+			platformValue, ok := rawPlatform.(string)
+			if !ok || !containsKey(validPlatforms, platformValue) {
+				return nil, fmt.Errorf(
+					"scenario %s: platform must be one of: %s",
+					scenarioID,
+					strings.Join(sortedKeys(validPlatforms), ", "),
+				)
+			}
+			platform = platformValue
+		}
+
+		testFile, err := normalizeTestFile(entry["test_file"], scenarioID, manual)
+		if err != nil {
+			return nil, err
+		}
+		if testFile != "" {
+			if _, ok := seenTestFiles[testFile]; ok {
+				return nil, fmt.Errorf("duplicate scenario test_file: %s", testFile)
+			}
+			seenTestFiles[testFile] = struct{}{}
+		}
+
+		scenarios = append(scenarios, Scenario{
+			ID:                  scenarioID,
+			Description:         description,
+			Persona:             persona,
+			Providers:           normalizedProviders,
+			RequiresCredentials: requiresCredentials,
+			Manual:              manual,
+			Lane:                lane,
+			Platform:            platform,
+			TestFile:            testFile,
+		})
+	}
+
+	return scenarios, nil
+}
+
+func containsKey(values map[string]struct{}, key string) bool {
+	_, ok := values[key]
+	return ok
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func isPersonaValid(persona string) bool {
+	if persona == "" || persona[0] < 'a' || persona[0] > 'z' {
+		return false
+	}
+	for _, r := range persona[1:] {
+		if r >= 'a' && r <= 'z' {
+			continue
+		}
+		if r >= '0' && r <= '9' {
+			continue
+		}
+		if r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func ScenarioShellTests(scenarioRoot string) ([]string, error) {
+	absRoot, err := filepath.Abs(scenarioRoot)
+	if err != nil {
+		return nil, err
+	}
+	if info, err := os.Stat(absRoot); err != nil || !info.IsDir() {
+		return []string{}, nil
+	}
+
+	paths := []string{}
+	if err := filepath.WalkDir(absRoot, func(current string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, "test-") || filepath.Ext(name) != ".sh" {
+			return nil
+		}
+		rel, err := filepath.Rel(absRoot, current)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, filepath.ToSlash(rel))
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func VerifyCoverage(scenarioRoot, manifestPath string) error {
+	absRoot, err := filepath.Abs(scenarioRoot)
+	if err != nil {
+		return err
+	}
+	root, err := os.OpenRoot(absRoot)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
+	scenarios, err := LoadScenarios(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	manifestTestFiles := map[string]struct{}{}
+	for _, scenario := range scenarios {
+		if scenario.TestFile != "" {
+			manifestTestFiles[scenario.TestFile] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(manifestTestFiles))
+	for key := range manifestTestFiles {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, testFile := range keys {
+		info, err := root.Stat(filepath.FromSlash(testFile))
+		if err != nil || !info.Mode().IsRegular() {
+			return fmt.Errorf("Missing test file: tests/scenarios/%s", testFile)
+		}
+	}
+
+	shellTests, err := ScenarioShellTests(absRoot)
+	if err != nil {
+		return err
+	}
+	orphaned := make([]string, 0)
+	for _, testFile := range shellTests {
+		if _, ok := manifestTestFiles[testFile]; !ok {
+			orphaned = append(orphaned, testFile)
+		}
+	}
+	if len(orphaned) > 0 {
+		return fmt.Errorf("Scenario scripts missing from manifest: %s", strings.Join(orphaned, ", "))
+	}
+	return nil
+}
+
+func ListTSV(manifestPath string, w io.Writer) error {
+	scenarios, err := LoadScenarios(manifestPath)
+	if err != nil {
+		return err
+	}
+	for _, scenario := range scenarios {
+		requires := "0"
+		if scenario.RequiresCredentials {
+			requires = "1"
+		}
+		manual := "0"
+		if scenario.Manual {
+			manual = "1"
+		}
+		if _, err := fmt.Fprintln(w, strings.Join([]string{
+			scenario.ID,
+			scenario.TestFile,
+			requires,
+			scenario.Lane,
+			scenario.Platform,
+			manual,
+		}, "\t")); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func Usage(program string) string {
+	if program == "" {
+		program = "workcell-scenario-manifest"
+	}
+	return fmt.Sprintf(
+		"Usage: %s [list-tsv|verify-coverage] ...",
+		program,
+	)
+}
+
+func Run(program string, args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, Usage(program))
+		return 2
+	}
+
+	switch args[0] {
+	case "list-tsv":
+		if len(args) != 2 {
+			fmt.Fprintln(stderr, Usage(program))
+			return 2
+		}
+		if err := ListTSV(args[1], stdout); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	case "verify-coverage":
+		if len(args) != 3 {
+			fmt.Fprintln(stderr, Usage(program))
+			return 2
+		}
+		if err := VerifyCoverage(args[1], args[2]); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	default:
+		fmt.Fprintln(stderr, Usage(program))
+		fmt.Fprintf(stderr, "%s: unsupported command: %s\n", program, args[0])
+		return 2
+	}
+}

--- a/internal/scenarios/scenario_manifest_test.go
+++ b/internal/scenarios/scenario_manifest_test.go
@@ -1,0 +1,259 @@
+package scenarios
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeManifest(tb testing.TB, root string, payload any) string {
+	tb.Helper()
+	manifestDir := filepath.Join(root, "tests", "scenarios")
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	data = append(data, '\n')
+	manifestPath := filepath.Join(manifestDir, "manifest.json")
+	if err := os.WriteFile(manifestPath, data, 0o600); err != nil {
+		tb.Fatal(err)
+	}
+	return manifestPath
+}
+
+func writeScript(tb testing.TB, root, relPath string) {
+	tb.Helper()
+	pathname := filepath.Join(root, "tests", "scenarios", filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(pathname), 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.WriteFile(pathname, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+type runResult struct {
+	code   int
+	stdout string
+	stderr string
+}
+
+func runGo(program string, args []string) runResult {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := Run(program, args, &stdout, &stderr)
+	return runResult{code: code, stdout: stdout.String(), stderr: stderr.String()}
+}
+
+func TestLoadScenariosAndListTSV(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := writeManifest(t, root, map[string]any{
+		"version": 1,
+		"scenarios": []any{
+			map[string]any{
+				"id":                   "shared/example",
+				"description":          "Example scenario",
+				"persona":              "developer",
+				"providers":            []any{"codex", "claude"},
+				"requires_credentials": false,
+				"manual":               false,
+				"test_file":            "shared/test-example.sh",
+			},
+			map[string]any{
+				"id":                   "shared/manual",
+				"description":          "Manual scenario",
+				"persona":              "tester",
+				"providers":            []any{"gemini"},
+				"requires_credentials": false,
+				"manual":               true,
+				"lane":                 "provider-e2e",
+				"platform":             "macos",
+				"test_file":            "",
+			},
+		},
+	})
+
+	scenarios, err := LoadScenarios(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(scenarios) != 2 {
+		t.Fatalf("expected 2 scenarios, got %d", len(scenarios))
+	}
+	if scenarios[0].Lane != "secretless" || scenarios[0].Platform != "any" || scenarios[0].Manual || scenarios[0].RequiresCredentials {
+		t.Fatalf("unexpected defaults for first scenario: %#v", scenarios[0])
+	}
+	if scenarios[1].TestFile != "" || !scenarios[1].Manual || scenarios[1].Lane != "provider-e2e" || scenarios[1].Platform != "macos" {
+		t.Fatalf("unexpected manual scenario normalization: %#v", scenarios[1])
+	}
+
+	got := runGo("scenario_manifest", []string{"list-tsv", manifestPath})
+	if got.code != 0 {
+		t.Fatalf("Run(list-tsv) = %d stderr=%q", got.code, got.stderr)
+	}
+	if got.stderr != "" {
+		t.Fatalf("unexpected stderr: %q", got.stderr)
+	}
+	want := "shared/example\tshared/test-example.sh\t0\tsecretless\tany\t0\nshared/manual\t\t0\tprovider-e2e\tmacos\t1\n"
+	if got.stdout != want {
+		t.Fatalf("unexpected list-tsv output: %q", got.stdout)
+	}
+}
+
+func TestRunRejectsInvalidManifestsAndCoverage(t *testing.T) {
+	cases := []struct {
+		name         string
+		manifest     map[string]any
+		command      []string
+		setup        func(testing.TB, string)
+		wantContains string
+	}{
+		{
+			name: "duplicate-id",
+			manifest: map[string]any{
+				"version": 1,
+				"scenarios": []any{
+					map[string]any{
+						"id":          "shared/duplicate",
+						"description": "One",
+						"persona":     "developer",
+						"providers":   []any{"codex"},
+						"test_file":   "shared/test-one.sh",
+					},
+					map[string]any{
+						"id":          "shared/duplicate",
+						"description": "Two",
+						"persona":     "developer",
+						"providers":   []any{"claude"},
+						"test_file":   "shared/test-two.sh",
+					},
+				},
+			},
+			command:      []string{"list-tsv"},
+			wantContains: "Duplicate scenario id: shared/duplicate",
+		},
+		{
+			name: "missing-test-file",
+			manifest: map[string]any{
+				"version": 1,
+				"scenarios": []any{
+					map[string]any{
+						"id":                   "shared/missing",
+						"description":          "Missing script",
+						"persona":              "developer",
+						"providers":            []any{"codex"},
+						"requires_credentials": false,
+						"manual":               false,
+						"test_file":            "shared/test-missing.sh",
+					},
+				},
+			},
+			command:      []string{"verify-coverage"},
+			wantContains: "Missing test file: tests/scenarios/shared/test-missing.sh",
+			setup: func(tb testing.TB, root string) {
+				writeScript(tb, root, "shared/test-orphan.sh")
+			},
+		},
+		{
+			name: "orphan-test-file",
+			manifest: map[string]any{
+				"version": 1,
+				"scenarios": []any{
+					map[string]any{
+						"id":                   "shared/present",
+						"description":          "Present script",
+						"persona":              "developer",
+						"providers":            []any{"codex"},
+						"requires_credentials": false,
+						"manual":               false,
+						"test_file":            "shared/test-present.sh",
+					},
+				},
+			},
+			command:      []string{"verify-coverage"},
+			wantContains: "Scenario scripts missing from manifest: shared/test-orphan.sh",
+			setup: func(tb testing.TB, root string) {
+				writeScript(tb, root, "shared/test-present.sh")
+				writeScript(tb, root, "shared/test-orphan.sh")
+			},
+		},
+		{
+			name: "path-traversal",
+			manifest: map[string]any{
+				"version": 1,
+				"scenarios": []any{
+					map[string]any{
+						"id":          "shared/traversal",
+						"description": "Traversal",
+						"persona":     "developer",
+						"providers":   []any{"codex"},
+						"test_file":   "../escape.sh",
+					},
+				},
+			},
+			command:      []string{"list-tsv"},
+			wantContains: "test_file must stay under tests/scenarios without traversal",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			manifestPath := writeManifest(t, root, tc.manifest)
+			if tc.setup != nil {
+				tc.setup(t, root)
+			}
+
+			var goArgs []string
+			switch tc.command[0] {
+			case "list-tsv":
+				goArgs = []string{"list-tsv", manifestPath}
+			case "verify-coverage":
+				goArgs = []string{"verify-coverage", filepath.Join(root, "tests", "scenarios"), manifestPath}
+			default:
+				t.Fatalf("unsupported command in test: %s", tc.command[0])
+			}
+
+			got := runGo("scenario_manifest", goArgs)
+			if got.code != 1 {
+				t.Fatalf("exit code mismatch: got %d want 1\nstdout=%q\nstderr=%q", got.code, got.stdout, got.stderr)
+			}
+			if !strings.Contains(got.stderr, tc.wantContains) {
+				t.Fatalf("stderr %q does not contain %q", got.stderr, tc.wantContains)
+			}
+		})
+	}
+}
+
+func TestVerifyCoverageWithoutRoot(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := writeManifest(t, root, map[string]any{
+		"version": 1,
+		"scenarios": []any{
+			map[string]any{
+				"id":                   "shared/example",
+				"description":          "Example scenario",
+				"persona":              "developer",
+				"providers":            []any{"codex"},
+				"requires_credentials": false,
+				"manual":               false,
+				"test_file":            "shared/test-example.sh",
+			},
+		},
+	})
+	writeScript(t, root, "shared/test-example.sh")
+
+	got := runGo("scenario_manifest", []string{"verify-coverage", filepath.Join(root, "tests", "scenarios"), manifestPath})
+	if got.code != 0 {
+		t.Fatalf("Run(verify-coverage) = %d stderr=%q", got.code, got.stderr)
+	}
+	if got.stderr != "" {
+		t.Fatalf("unexpected stderr: %q", got.stderr)
+	}
+}

--- a/internal/scenarios/scenario_script_integration_test.go
+++ b/internal/scenarios/scenario_script_integration_test.go
@@ -1,0 +1,173 @@
+package scenarios
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func repoRoot(tb testing.TB) string {
+	tb.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		tb.Fatal("unable to determine repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func writeScenarioScript(tb testing.TB, root, relativePath, body string) {
+	tb.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relativePath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+func writeScenarioManifest(tb testing.TB, root string, scenarios []map[string]any) string {
+	tb.Helper()
+	manifestPath := filepath.Join(root, "manifest.json")
+	data, err := json.MarshalIndent(map[string]any{
+		"version":   1,
+		"scenarios": scenarios,
+	}, "", "  ")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(manifestPath, data, 0o600); err != nil {
+		tb.Fatal(err)
+	}
+	return manifestPath
+}
+
+func runScenarioScript(tb testing.TB, scriptPath string, env map[string]string, args ...string) (int, string, string) {
+	tb.Helper()
+	cmd := exec.Command(scriptPath, args...)
+	cmd.Dir = repoRoot(tb)
+	cmd.Env = os.Environ()
+	for key, value := range env {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return 0, string(output), ""
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode(), string(output), ""
+	}
+	tb.Fatalf("run %s failed: %v", scriptPath, err)
+	return 0, "", ""
+}
+
+func TestVerifyScenarioCoverageRejectsOrphanScripts(t *testing.T) {
+	t.Parallel()
+
+	scenarioRoot := t.TempDir()
+	writeScenarioScript(t, scenarioRoot, "shared/test-secretless.sh", "#!/bin/sh\nexit 0\n")
+	writeScenarioScript(t, scenarioRoot, "shared/test-orphan.sh", "#!/bin/sh\nexit 0\n")
+	manifestPath := writeScenarioManifest(t, scenarioRoot, []map[string]any{
+		{
+			"id":                   "shared/secretless",
+			"description":          "Secretless fixture",
+			"lane":                 "secretless",
+			"platform":             "any",
+			"manual":               false,
+			"providers":            []string{"codex"},
+			"persona":              "developer",
+			"test_file":            "shared/test-secretless.sh",
+			"requires_credentials": false,
+		},
+	})
+
+	code, stdout, _ := runScenarioScript(
+		t,
+		filepath.Join(repoRoot(t), "scripts", "verify-scenario-coverage.sh"),
+		map[string]string{
+			"WORKCELL_SCENARIO_ROOT":     scenarioRoot,
+			"WORKCELL_SCENARIO_MANIFEST": manifestPath,
+		},
+	)
+	if code != 1 {
+		t.Fatalf("verify-scenario-coverage exit code = %d stdout=%q", code, stdout)
+	}
+	if !strings.Contains(stdout, "Scenario scripts missing from manifest") {
+		t.Fatalf("stdout %q does not contain orphan warning", stdout)
+	}
+	if !strings.Contains(stdout, "shared/test-orphan.sh") {
+		t.Fatalf("stdout %q does not mention orphan script", stdout)
+	}
+}
+
+func TestRunScenarioTestsSecretlessOnlySkipsNonSecretlessEntries(t *testing.T) {
+	t.Parallel()
+
+	scenarioRoot := t.TempDir()
+	writeScenarioScript(t, scenarioRoot, "shared/test-secretless.sh", "#!/bin/sh\nset -eu\nprintf 'secretless-ran\\n'\n")
+	writeScenarioScript(t, scenarioRoot, "shared/test-provider.sh", "#!/bin/sh\nset -eu\necho provider-ran >&2\nexit 1\n")
+	writeScenarioScript(t, scenarioRoot, "shared/test-manual.sh", "#!/bin/sh\nset -eu\necho manual-ran >&2\nexit 1\n")
+	manifestPath := writeScenarioManifest(t, scenarioRoot, []map[string]any{
+		{
+			"id":                   "shared/secretless",
+			"description":          "Secretless fixture",
+			"lane":                 "secretless",
+			"platform":             "any",
+			"manual":               false,
+			"providers":            []string{"codex"},
+			"persona":              "developer",
+			"test_file":            "shared/test-secretless.sh",
+			"requires_credentials": false,
+		},
+		{
+			"id":                   "shared/provider",
+			"description":          "Provider fixture",
+			"lane":                 "provider-e2e",
+			"platform":             "any",
+			"manual":               false,
+			"providers":            []string{"codex"},
+			"persona":              "developer",
+			"test_file":            "shared/test-provider.sh",
+			"requires_credentials": true,
+		},
+		{
+			"id":                   "shared/manual",
+			"description":          "Manual fixture",
+			"lane":                 "secretless",
+			"platform":             "any",
+			"manual":               true,
+			"providers":            []string{"codex"},
+			"persona":              "developer",
+			"test_file":            "shared/test-manual.sh",
+			"requires_credentials": false,
+		},
+	})
+
+	code, stdout, _ := runScenarioScript(
+		t,
+		filepath.Join(repoRoot(t), "scripts", "run-scenario-tests.sh"),
+		map[string]string{
+			"WORKCELL_SCENARIO_ROOT":     scenarioRoot,
+			"WORKCELL_SCENARIO_MANIFEST": manifestPath,
+		},
+		"--secretless-only",
+	)
+	if code != 0 {
+		t.Fatalf("run-scenario-tests exit code = %d stdout=%q", code, stdout)
+	}
+	for _, want := range []string{
+		"secretless-ran",
+		"PASS shared/secretless",
+		"SKIP shared/provider (lane provider-e2e)",
+		"SKIP shared/manual (manual lane)",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout %q does not contain %q", stdout, want)
+		}
+	}
+}

--- a/internal/transcript/pty_darwin.go
+++ b/internal/transcript/pty_darwin.go
@@ -1,0 +1,178 @@
+//go:build darwin
+
+package transcript
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"unsafe"
+)
+
+const ptyNameBufferSize = 128
+
+func openPTY() (*os.File, string, error) {
+	masterFD, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := ioctlNoArg(masterFD, syscall.TIOCPTYGRANT); err != nil {
+		_ = syscall.Close(masterFD)
+		return nil, "", err
+	}
+	if err := ioctlNoArg(masterFD, syscall.TIOCPTYUNLK); err != nil {
+		_ = syscall.Close(masterFD)
+		return nil, "", err
+	}
+	name, err := ptySlaveName(masterFD)
+	if err != nil {
+		_ = syscall.Close(masterFD)
+		return nil, "", err
+	}
+	return os.NewFile(uintptr(masterFD), "pty-master"), name, nil
+}
+
+func ptySlaveName(masterFD int) (string, error) {
+	buf := make([]byte, ptyNameBufferSize)
+	if err := ioctlBytes(masterFD, syscall.TIOCPTYGNAME, &buf[0]); err != nil {
+		return "", err
+	}
+	if n := indexByte(buf, 0); n >= 0 {
+		buf = buf[:n]
+	}
+	if len(buf) == 0 {
+		return "", errors.New("pty slave name is empty")
+	}
+	return string(buf), nil
+}
+
+func ioctlNoArg(fd int, req uintptr) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), req, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func ioctlBytes(fd int, req uintptr, ptr *byte) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), req, uintptr(unsafe.Pointer(ptr)))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func spawnPTYReal(command []string, stdin, stdout *os.File, stdinRead, masterRead ReadFunc) (int, error) {
+	master, slaveName, err := openPTY()
+	if err != nil {
+		return 0, err
+	}
+	defer master.Close()
+
+	slave, err := os.OpenFile(slaveName, os.O_RDWR, 0)
+	if err != nil {
+		return 0, err
+	}
+	defer slave.Close()
+
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Stdin = slave
+	cmd.Stdout = slave
+	cmd.Stderr = slave
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid:  true,
+		Setctty: true,
+		Ctty:    0,
+	}
+
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+
+	_ = slave.Close()
+
+	stdinFD := int(stdin.Fd())
+	stdoutFD := int(stdout.Fd())
+	masterFD := int(master.Fd())
+	stdinClosed := false
+
+	for {
+		readfds := syscall.FdSet{}
+		maxFD := masterFD
+		fdSet(&readfds, masterFD)
+		if !stdinClosed {
+			fdSet(&readfds, stdinFD)
+			if stdinFD > maxFD {
+				maxFD = stdinFD
+			}
+		}
+
+		err = syscall.Select(maxFD+1, &readfds, nil, nil, nil)
+		if err != nil {
+			if errors.Is(err, syscall.EINTR) {
+				continue
+			}
+			return 0, err
+		}
+
+		if !stdinClosed && fdIsSet(&readfds, stdinFD) {
+			data, readErr := stdinRead(stdinFD)
+			if len(data) > 0 {
+				if err := writeAtFDReal(masterFD, data); err != nil {
+					return 0, err
+				}
+			}
+			if readErr != nil || len(data) == 0 {
+				stdinClosed = true
+			}
+		}
+
+		if fdIsSet(&readfds, masterFD) {
+			data, readErr := masterRead(masterFD)
+			if len(data) > 0 {
+				if err := writeAtFDReal(stdoutFD, data); err != nil {
+					return 0, err
+				}
+			}
+			if readErr != nil || len(data) == 0 {
+				break
+			}
+		}
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			return 0, err
+		}
+	}
+	status, ok := cmd.ProcessState.Sys().(syscall.WaitStatus)
+	if !ok {
+		return 0, fmt.Errorf("unexpected process state type %T", cmd.ProcessState.Sys())
+	}
+	return int(status), nil
+}
+
+func fdSet(set *syscall.FdSet, fd int) {
+	index := fd / 32
+	bit := uint(fd % 32)
+	set.Bits[index] |= 1 << bit
+}
+
+func fdIsSet(set *syscall.FdSet, fd int) bool {
+	index := fd / 32
+	bit := uint(fd % 32)
+	return set.Bits[index]&(1<<bit) != 0
+}
+
+func indexByte(b []byte, target byte) int {
+	for i, c := range b {
+		if c == target {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/transcript/pty_linux.go
+++ b/internal/transcript/pty_linux.go
@@ -1,0 +1,151 @@
+//go:build linux
+
+package transcript
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+const ptyNameBufferSize = 128
+
+func openPTY() (*os.File, string, error) {
+	masterFD, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, "", err
+	}
+
+	unlock := 0
+	if err := ioctlInt(masterFD, syscall.TIOCSPTLCK, &unlock); err != nil {
+		_ = syscall.Close(masterFD)
+		return nil, "", err
+	}
+
+	ptyNum := 0
+	if err := ioctlInt(masterFD, syscall.TIOCGPTN, &ptyNum); err != nil {
+		_ = syscall.Close(masterFD)
+		return nil, "", err
+	}
+
+	name := "/dev/pts/" + strconv.Itoa(ptyNum)
+	return os.NewFile(uintptr(masterFD), "pty-master"), name, nil
+}
+
+func ioctlInt(fd int, req uintptr, value *int) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), req, uintptr(unsafe.Pointer(value)))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func spawnPTYReal(command []string, stdin, stdout *os.File, stdinRead, masterRead ReadFunc) (int, error) {
+	master, slaveName, err := openPTY()
+	if err != nil {
+		return 0, err
+	}
+	defer master.Close()
+
+	slave, err := os.OpenFile(slaveName, os.O_RDWR, 0)
+	if err != nil {
+		return 0, err
+	}
+	defer slave.Close()
+
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Stdin = slave
+	cmd.Stdout = slave
+	cmd.Stderr = slave
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid:  true,
+		Setctty: true,
+		Ctty:    0,
+	}
+
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+
+	_ = slave.Close()
+
+	stdinFD := int(stdin.Fd())
+	stdoutFD := int(stdout.Fd())
+	masterFD := int(master.Fd())
+	stdinClosed := false
+
+	for {
+		readfds := syscall.FdSet{}
+		maxFD := masterFD
+		fdSet(&readfds, masterFD)
+		if !stdinClosed {
+			fdSet(&readfds, stdinFD)
+			if stdinFD > maxFD {
+				maxFD = stdinFD
+			}
+		}
+
+		_, err = syscall.Select(maxFD+1, &readfds, nil, nil, nil)
+		if err != nil {
+			if errors.Is(err, syscall.EINTR) {
+				continue
+			}
+			return 0, err
+		}
+
+		if !stdinClosed && fdIsSet(&readfds, stdinFD) {
+			data, readErr := stdinRead(stdinFD)
+			if len(data) > 0 {
+				if err := writeAtFDReal(masterFD, data); err != nil {
+					return 0, err
+				}
+			}
+			if readErr != nil || len(data) == 0 {
+				stdinClosed = true
+			}
+		}
+
+		if fdIsSet(&readfds, masterFD) {
+			data, readErr := masterRead(masterFD)
+			if len(data) > 0 {
+				if err := writeAtFDReal(stdoutFD, data); err != nil {
+					return 0, err
+				}
+			}
+			if readErr != nil || len(data) == 0 {
+				break
+			}
+		}
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			return 0, err
+		}
+	}
+	status, ok := cmd.ProcessState.Sys().(syscall.WaitStatus)
+	if !ok {
+		return 0, fmt.Errorf("unexpected process state type %T", cmd.ProcessState.Sys())
+	}
+	return int(status), nil
+}
+
+func fdSet(set *syscall.FdSet, fd int) {
+	wordBits := 8 * int(unsafe.Sizeof(set.Bits[0]))
+	index := fd / wordBits
+	bit := uint(fd % wordBits)
+	set.Bits[index] |= 1 << bit
+}
+
+func fdIsSet(set *syscall.FdSet, fd int) bool {
+	wordBits := 8 * int(unsafe.Sizeof(set.Bits[0]))
+	index := fd / wordBits
+	bit := uint(fd % wordBits)
+	return set.Bits[index]&(1<<bit) != 0
+}

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -1,0 +1,203 @@
+package transcript
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type ReadFunc func(fd int) ([]byte, error)
+
+type SpawnFunc func(command []string, stdin, stdout *os.File, stdinRead, masterRead ReadFunc) (int, error)
+
+var (
+	isTerminal = func(file *os.File) bool {
+		info, err := file.Stat()
+		return err == nil && info.Mode()&os.ModeCharDevice != 0
+	}
+	spawnPTY  SpawnFunc = spawnPTYReal
+	readAtFD            = readAtFDReal
+	writeAtFD           = writeAtFDReal
+)
+
+func Run(program string, stdin, stdout *os.File, stderr io.Writer, args []string) int {
+	fs := flag.NewFlagSet(program, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var logPath string
+	fs.StringVar(&logPath, "log", "", "")
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, "Usage: %s --log PATH -- command...\n", program)
+	}
+
+	if err := fs.Parse(args); err != nil {
+		fs.Usage()
+		return 2
+	}
+	if logPath == "" {
+		fs.Usage()
+		fmt.Fprintln(stderr, "--log is required")
+		return 2
+	}
+
+	command := fs.Args()
+	if len(command) > 0 && command[0] == "--" {
+		command = command[1:]
+	}
+	if len(command) == 0 {
+		fmt.Fprintf(stderr, "%s requires a command after --\n", program)
+		return 2
+	}
+	if !isTerminal(stdin) || !isTerminal(stdout) {
+		fmt.Fprintf(stderr, "%s requires an interactive terminal\n", program)
+		return 2
+	}
+
+	logFile, err := openLog(logPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	defer logFile.Close()
+
+	var logMu sync.Mutex
+	writeLog := func(data []byte) {
+		if len(data) == 0 {
+			return
+		}
+		logMu.Lock()
+		_, _ = logFile.Write(data)
+		_ = logFile.Sync()
+		logMu.Unlock()
+	}
+
+	startedAt := pythonTimestamp(time.Now())
+	writeLog([]byte("# workcell-transcript-v1 start=" + startedAt + "\n"))
+
+	stdinRead := func(fd int) ([]byte, error) {
+		data, err := readAtFD(fd)
+		writeLog(data)
+		return data, err
+	}
+	masterRead := func(fd int) ([]byte, error) {
+		data, err := readAtFD(fd)
+		writeLog(data)
+		return data, err
+	}
+
+	waitStatus, spawnErr := spawnPTY(command, stdin, stdout, stdinRead, masterRead)
+	exitCode := exitCodeFromWaitStatus(waitStatus)
+	if spawnErr != nil {
+		exitCode = exitCodeFromSpawnError(spawnErr)
+		fmt.Fprintf(stderr, "%s failed to exec %s: %s\n", program, command[0], spawnErrorText(spawnErr))
+	}
+
+	finishedAt := pythonTimestamp(time.Now())
+	writeLog(renderFooter(finishedAt, exitCode, waitStatus, spawnErr))
+	return exitCode
+}
+
+func openLog(path string) (*os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
+}
+
+func exitCodeFromWaitStatus(status int) int {
+	waitStatus := syscall.WaitStatus(status)
+	if waitStatus.Exited() {
+		return waitStatus.ExitStatus()
+	}
+	if waitStatus.Signaled() {
+		return 128 + int(waitStatus.Signal())
+	}
+	return 1
+}
+
+func exitCodeFromSpawnError(err error) int {
+	if errors.Is(err, syscall.ENOENT) || errors.Is(err, exec.ErrNotFound) {
+		return 127
+	}
+	return 126
+}
+
+func spawnErrorText(err error) string {
+	if errors.Is(err, syscall.ENOENT) || errors.Is(err, exec.ErrNotFound) {
+		return "No such file or directory"
+	}
+	return err.Error()
+}
+
+func renderFooter(finishedAt string, exitCode int, waitStatus int, spawnErr error) []byte {
+	statusField := "wait_status=spawn-error"
+	if spawnErr == nil {
+		statusField = fmt.Sprintf("wait_status=%d", waitStatus)
+	}
+	errnoField := ""
+	if spawnErr != nil {
+		errnoField = fmt.Sprintf(" spawn_errno=%d", spawnErrno(spawnErr))
+	}
+	return []byte(
+		fmt.Sprintf("\n# workcell-transcript-v1 end=%s %s%s exit_code=%d\n",
+			finishedAt, statusField, errnoField, exitCode),
+	)
+}
+
+func spawnErrno(err error) int {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return int(errno)
+	}
+	if errors.Is(err, syscall.ENOENT) || errors.Is(err, exec.ErrNotFound) {
+		return int(syscall.ENOENT)
+	}
+	return 1
+}
+
+func pythonTimestamp(t time.Time) string {
+	t = t.UTC()
+	frac := t.Nanosecond() / 1000
+	if frac == 0 {
+		return t.Format("2006-01-02T15:04:05") + "+00:00"
+	}
+	fracText := fmt.Sprintf("%06d", frac)
+	for len(fracText) > 0 && fracText[len(fracText)-1] == '0' {
+		fracText = fracText[:len(fracText)-1]
+	}
+	return t.Format("2006-01-02T15:04:05") + "." + fracText + "+00:00"
+}
+
+func readAtFDReal(fd int) ([]byte, error) {
+	buf := make([]byte, 1024)
+	n, err := syscall.Read(fd, buf)
+	if n > 0 {
+		return buf[:n], err
+	}
+	return nil, err
+}
+
+func writeAtFDReal(fd int, data []byte) error {
+	for len(data) > 0 {
+		n, err := syscall.Write(fd, data)
+		if err != nil {
+			return err
+		}
+		data = data[n:]
+	}
+	return nil
+}

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -1,0 +1,201 @@
+package transcript
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestExitCodeFromWaitStatus(t *testing.T) {
+	t.Parallel()
+
+	if got := exitCodeFromWaitStatus(7 << 8); got != 7 {
+		t.Fatalf("exitCodeFromWaitStatus(exit) = %d", got)
+	}
+	if got := exitCodeFromWaitStatus(int(syscall.SIGTERM)); got != 128+int(syscall.SIGTERM) {
+		t.Fatalf("exitCodeFromWaitStatus(signal) = %d", got)
+	}
+	if got := exitCodeFromWaitStatus(0x7F); got != 1 {
+		t.Fatalf("exitCodeFromWaitStatus(other) = %d", got)
+	}
+}
+
+func TestRenderFooterMatchesPythonShape(t *testing.T) {
+	t.Parallel()
+
+	got := string(renderFooter("2026-04-02T10:20:30+00:00", 7, 1792, nil))
+	if !strings.HasPrefix(got, "\n# workcell-transcript-v1 end=2026-04-02T10:20:30+00:00 wait_status=1792 exit_code=7\n") {
+		t.Fatalf("unexpected footer: %q", got)
+	}
+	got = string(renderFooter("2026-04-02T10:20:30+00:00", 127, 0, syscall.ENOENT))
+	if !strings.Contains(got, "wait_status=spawn-error spawn_errno=2 exit_code=127") {
+		t.Fatalf("unexpected spawn footer: %q", got)
+	}
+}
+
+func TestRunStripsSeparatorRecordsTranscriptAndReturnsExitCode(t *testing.T) {
+	oldIsTerminal := isTerminal
+	oldSpawn := spawnPTY
+	oldRead := readAtFD
+	defer func() {
+		isTerminal = oldIsTerminal
+		spawnPTY = oldSpawn
+		readAtFD = oldRead
+	}()
+
+	isTerminal = func(*os.File) bool { return true }
+
+	var reads [][]byte
+	readAtFD = func(fd int) ([]byte, error) {
+		switch fd {
+		case 10:
+			return []byte("user input\n"), nil
+		case 11:
+			return []byte("child output\n"), nil
+		default:
+			return nil, io.EOF
+		}
+	}
+
+	spawnPTY = func(command []string, stdin, stdout *os.File, stdinRead, masterRead ReadFunc) (int, error) {
+		if len(command) != 2 || command[0] != "fake-agent" || command[1] != "--version" {
+			t.Fatalf("unexpected command: %#v", command)
+		}
+		if data, err := stdinRead(10); err != nil || string(data) != "user input\n" {
+			t.Fatalf("stdinRead = %q, %v", data, err)
+		}
+		if data, err := masterRead(11); err != nil || string(data) != "child output\n" {
+			t.Fatalf("masterRead = %q, %v", data, err)
+		}
+		reads = append(reads, []byte("called"))
+		return 7 << 8, nil
+	}
+
+	logPath := filepath.Join(t.TempDir(), "transcript.log")
+	var stderr bytes.Buffer
+	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", logPath, "--", "fake-agent", "--version"})
+	if code != 7 {
+		t.Fatalf("Run() = %d, want 7", code)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+	if len(reads) != 1 {
+		t.Fatalf("spawn was not called")
+	}
+
+	transcript := readFile(t, logPath)
+	if !bytes.Contains(transcript, []byte("# workcell-transcript-v1 start=")) {
+		t.Fatalf("missing start header: %q", transcript)
+	}
+	if !bytes.Contains(transcript, []byte("user input\nchild output\n")) {
+		t.Fatalf("missing transcript bytes: %q", transcript)
+	}
+	if !bytes.Contains(transcript, []byte("wait_status=1792")) {
+		t.Fatalf("missing wait status: %q", transcript)
+	}
+	if !bytes.Contains(transcript, []byte("exit_code=7")) {
+		t.Fatalf("missing exit code: %q", transcript)
+	}
+	assertMode(t, logPath, 0o600)
+}
+
+func TestRunRequiresCommandAfterSeparator(t *testing.T) {
+	oldIsTerminal := isTerminal
+	defer func() { isTerminal = oldIsTerminal }()
+	isTerminal = func(*os.File) bool { return true }
+
+	var stderr bytes.Buffer
+	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "--"})
+	if code != 2 {
+		t.Fatalf("Run() = %d, want 2", code)
+	}
+	if got := stderr.String(); got != "pty_transcript requires a command after --\n" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestRunRequiresInteractiveTerminal(t *testing.T) {
+	oldIsTerminal := isTerminal
+	defer func() { isTerminal = oldIsTerminal }()
+	isTerminal = func(*os.File) bool { return false }
+
+	var stderr bytes.Buffer
+	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "echo"})
+	if code != 2 {
+		t.Fatalf("Run() = %d, want 2", code)
+	}
+	if got := stderr.String(); got != "pty_transcript requires an interactive terminal\n" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestRunHandlesSpawnErrorsWithoutTracebacks(t *testing.T) {
+	oldIsTerminal := isTerminal
+	oldSpawn := spawnPTY
+	oldRead := readAtFD
+	defer func() {
+		isTerminal = oldIsTerminal
+		spawnPTY = oldSpawn
+		readAtFD = oldRead
+	}()
+
+	isTerminal = func(*os.File) bool { return true }
+	readAtFD = func(int) ([]byte, error) { return nil, io.EOF }
+	spawnPTY = func(command []string, stdin, stdout *os.File, stdinRead, masterRead ReadFunc) (int, error) {
+		return 0, syscall.ENOENT
+	}
+
+	var stderr bytes.Buffer
+	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "missing-agent"})
+	if code != 127 {
+		t.Fatalf("Run() = %d, want 127", code)
+	}
+	if !strings.Contains(stderr.String(), "failed to exec missing-agent") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestOpenPTYReturnsSlavePath(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("pty backend only covered on unix")
+	}
+
+	master, slaveName, err := openPTY()
+	if err != nil {
+		t.Fatalf("openPTY() error = %v", err)
+	}
+	defer master.Close()
+
+	if slaveName == "" {
+		t.Fatal("openPTY() returned empty slave name")
+	}
+	if _, err := os.Stat(slaveName); err != nil {
+		t.Fatalf("slave path %q not accessible: %v", slaveName, err)
+	}
+}
+
+func readFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return data
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode mismatch for %s: got %04o want %04o", path, got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- port `scenario_manifest`, `extract_direct_mounts`, and `pty_transcript` to Go
- add dedicated Go tests and CLI entrypoints for the standalone helpers
- keep shell cutover out of scope so the review stays focused on helper parity

## Verification
- `go test ./internal/scenarios ./internal/injection ./internal/transcript`
