### PR TITLE
Port Policy, Auth, and Injection Helpers to Go

### DIFF
--- a/cmd/workcell-manage-injection-policy/main.go
+++ b/cmd/workcell-manage-injection-policy/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/omkhar/workcell/internal/authpolicy"
+)
+
+func main() {
+	os.Exit(authpolicy.Run(os.Args[0], os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/cmd/workcell-render-injection-bundle/main.go
+++ b/cmd/workcell-render-injection-bundle/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/omkhar/workcell/internal/injection"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stderr))
+}
+
+func run(args []string, stderr io.Writer) int {
+	fs := flag.NewFlagSet("workcell-render-injection-bundle", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	policyPath := fs.String("policy", "", "")
+	agent := fs.String("agent", "", "")
+	mode := fs.String("mode", "", "")
+	outputRoot := fs.String("output-root", "", "")
+	policyMetadata := fs.String("policy-metadata", "", "")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	if *policyPath == "" || *agent == "" || *mode == "" || *outputRoot == "" {
+		fmt.Fprintln(stderr, "policy, agent, mode, and output-root are required")
+		return 2
+	}
+	if err := injection.RunRenderInjectionBundle(*policyPath, *agent, *mode, *outputRoot, *policyMetadata); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/workcell-resolve-credential-sources/main.go
+++ b/cmd/workcell-resolve-credential-sources/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/omkhar/workcell/internal/authresolve"
+)
+
+func main() {
+	os.Exit(authresolve.Run(os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/internal/authpolicy/manage.go
+++ b/internal/authpolicy/manage.go
@@ -1,0 +1,1181 @@
+package authpolicy
+
+import (
+	"crypto/rand"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/rootio"
+)
+
+var (
+	canonicalCredentialDestinations = map[string][2]string{
+		"codex_auth":      {"codex", "auth.json"},
+		"claude_api_key":  {"claude", "api-key.txt"},
+		"claude_mcp":      {"claude", "mcp.json"},
+		"gemini_env":      {"gemini", "gemini.env"},
+		"gemini_oauth":    {"gemini", "oauth_creds.json"},
+		"gemini_projects": {"gemini", "projects.json"},
+		"gcloud_adc":      {"gemini", "gcloud-adc.json"},
+		"github_hosts":    {"shared", "github-hosts.yml"},
+		"github_config":   {"shared", "github-config.yml"},
+	}
+	allowedResolvers = map[string]map[string]struct{}{
+		"claude_auth": {"claude-macos-keychain": {}},
+	}
+	statusOrder = map[string][]string{
+		"codex":  {"codex_auth"},
+		"claude": {"claude_api_key", "claude_auth"},
+		"gemini": {"gemini_env", "gemini_oauth"},
+	}
+	entryAllowedKeys = map[string]struct{}{
+		"source":          {},
+		"resolver":        {},
+		"materialization": {},
+		"providers":       {},
+		"modes":           {},
+	}
+)
+
+func Run(program string, args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, usage(program))
+		return 2
+	}
+	switch args[0] {
+	case "init":
+		policyPath, managedRoot, err := parseInitArgs(program, args[1:], stderr)
+		if err != nil {
+			return 2
+		}
+		if err := commandInit(policyPath, managedRoot); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		fmt.Fprintln(stdout, "policy_path="+resolveOutputPath(policyPath))
+		fmt.Fprintln(stdout, "managed_root="+resolveOutputPath(managedRoot))
+		return 0
+	case "set":
+		opts, err := parseSetArgs(program, args[1:], stderr)
+		if err != nil {
+			return 2
+		}
+		if err := commandSet(opts); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		printSetOutput(stdout, opts)
+		return 0
+	case "unset":
+		policyPath, managedRoot, credential, err := parseUnsetArgs(program, args[1:], stderr)
+		if err != nil {
+			return 2
+		}
+		removed, err := commandUnset(policyPath, managedRoot, credential)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		fmt.Fprintln(stdout, "policy_path="+policyPath)
+		fmt.Fprintln(stdout, "credential="+credential)
+		fmt.Fprintf(stdout, "removed=%d\n", removed)
+		return 0
+	case "status":
+		opts, err := parseStatusArgs(program, args[1:], stderr)
+		if err != nil {
+			return 2
+		}
+		if err := commandStatus(opts, stdout); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	default:
+		fmt.Fprintln(stderr, usage(program))
+		fmt.Fprintf(stderr, "%s: unsupported command: %s\n", program, args[0])
+		return 2
+	}
+}
+
+type setOptions struct {
+	policyPath      string
+	managedRoot     string
+	agent           string
+	credential      string
+	sourceRaw       string
+	sourceBaseRaw   string
+	resolver        string
+	ackHostResolver bool
+}
+
+type statusOptions struct {
+	policyPath string
+	agent      string
+	mode       string
+}
+
+func usage(program string) string {
+	if program == "" {
+		program = "workcell-manage-injection-policy"
+	}
+	return fmt.Sprintf(
+		"Usage: %s {init,set,unset,status} ...",
+		program,
+	)
+}
+
+func parseInitArgs(program string, args []string, stderr io.Writer) (string, string, error) {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	policy := fs.String("policy", "", "")
+	managedRoot := fs.String("managed-root", "", "")
+	fs.Usage = func() { fmt.Fprintln(stderr, usage(program)) }
+	if err := fs.Parse(args); err != nil {
+		return "", "", err
+	}
+	if fs.NArg() != 0 || *policy == "" || *managedRoot == "" {
+		fs.Usage()
+		return "", "", fmt.Errorf("--policy and --managed-root are required")
+	}
+	return resolveInputPath(*policy), resolveInputPath(*managedRoot), nil
+}
+
+func parseSetArgs(program string, args []string, stderr io.Writer) (setOptions, error) {
+	fs := flag.NewFlagSet("set", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var opts setOptions
+	fs.StringVar(&opts.policyPath, "policy", "", "")
+	fs.StringVar(&opts.managedRoot, "managed-root", "", "")
+	fs.StringVar(&opts.agent, "agent", "", "")
+	fs.StringVar(&opts.credential, "credential", "", "")
+	fs.StringVar(&opts.sourceRaw, "source", "", "")
+	fs.StringVar(&opts.sourceBaseRaw, "source-base", "", "")
+	fs.StringVar(&opts.resolver, "resolver", "", "")
+	fs.BoolVar(&opts.ackHostResolver, "ack-host-resolver", false, "")
+	fs.Usage = func() { fmt.Fprintln(stderr, usage(program)) }
+	if err := fs.Parse(args); err != nil {
+		return setOptions{}, err
+	}
+	if fs.NArg() != 0 || opts.policyPath == "" || opts.managedRoot == "" || opts.agent == "" || opts.credential == "" {
+		fs.Usage()
+		return setOptions{}, fmt.Errorf("missing required flags")
+	}
+	if _, ok := SupportedAgents[opts.agent]; !ok {
+		return setOptions{}, fmt.Errorf("invalid agent: %s", opts.agent)
+	}
+	if _, ok := CredentialKeys[opts.credential]; !ok {
+		return setOptions{}, fmt.Errorf("invalid credential: %s", opts.credential)
+	}
+	if opts.sourceRaw != "" && opts.resolver != "" {
+		// Let the command path report the exact Python-style error.
+	}
+	opts.policyPath = resolveInputPath(opts.policyPath)
+	opts.managedRoot = resolveInputPath(opts.managedRoot)
+	return opts, nil
+}
+
+func parseUnsetArgs(program string, args []string, stderr io.Writer) (string, string, string, error) {
+	fs := flag.NewFlagSet("unset", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	policy := fs.String("policy", "", "")
+	managedRoot := fs.String("managed-root", "", "")
+	credential := fs.String("credential", "", "")
+	fs.Usage = func() { fmt.Fprintln(stderr, usage(program)) }
+	if err := fs.Parse(args); err != nil {
+		return "", "", "", err
+	}
+	if fs.NArg() != 0 || *policy == "" || *managedRoot == "" || *credential == "" {
+		fs.Usage()
+		return "", "", "", fmt.Errorf("missing required flags")
+	}
+	if _, ok := CredentialKeys[*credential]; !ok {
+		return "", "", "", fmt.Errorf("invalid credential: %s", *credential)
+	}
+	return resolveInputPath(*policy), resolveInputPath(*managedRoot), *credential, nil
+}
+
+func parseStatusArgs(program string, args []string, stderr io.Writer) (statusOptions, error) {
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var opts statusOptions
+	fs.StringVar(&opts.policyPath, "policy", "", "")
+	fs.StringVar(&opts.agent, "agent", "", "")
+	fs.StringVar(&opts.mode, "mode", "strict", "")
+	fs.Usage = func() { fmt.Fprintln(stderr, usage(program)) }
+	if err := fs.Parse(args); err != nil {
+		return statusOptions{}, err
+	}
+	if fs.NArg() != 0 || opts.policyPath == "" {
+		fs.Usage()
+		return statusOptions{}, fmt.Errorf("missing required flags")
+	}
+	if opts.agent != "" {
+		if _, ok := SupportedAgents[opts.agent]; !ok {
+			return statusOptions{}, fmt.Errorf("invalid agent: %s", opts.agent)
+		}
+	}
+	if _, ok := SupportedModes[opts.mode]; !ok {
+		return statusOptions{}, fmt.Errorf("invalid mode: %s", opts.mode)
+	}
+	opts.policyPath = resolveInputPath(opts.policyPath)
+	return opts, nil
+}
+
+func resolveInputPath(raw string) string {
+	expanded, err := expandUserPath(raw)
+	if err != nil {
+		return raw
+	}
+	if !filepath.IsAbs(expanded) {
+		expanded, err = filepath.Abs(expanded)
+		if err != nil {
+			return raw
+		}
+	}
+	return filepath.Clean(expanded)
+}
+
+func resolveOutputPath(raw string) string {
+	return resolveInputPath(raw)
+}
+
+func commandInit(policyPath string, managedRoot string) error {
+	if err := validateManagedPath(managedRoot, managedRoot, "managed_root"); err != nil {
+		return err
+	}
+	if _, err := os.Stat(policyPath); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		if err := writeVerifiedPolicy(policyPath, map[string]any{"version": 1}); err != nil {
+			return err
+		}
+	} else {
+		if _, _, err := loadPolicyBundle(policyPath); err != nil {
+			return err
+		}
+	}
+	if err := ensureDirectory(managedRoot); err != nil {
+		return err
+	}
+	if err := writeManagedRootMarker(managedRoot); err != nil {
+		return err
+	}
+	for _, name := range []string{"codex", "claude", "gemini", "shared"} {
+		path := filepath.Join(managedRoot, name)
+		if err := validateManagedPath(managedRoot, path, "managed_root/"+name); err != nil {
+			return err
+		}
+		if err := ensureDirectory(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func commandSet(opts setOptions) error {
+	if err := validateAgentCredential(opts.agent, opts.credential); err != nil {
+		return err
+	}
+	if (opts.sourceRaw == "") == (opts.resolver == "") {
+		return die("Specify exactly one of --source or --resolver")
+	}
+	if err := validateManagedPath(opts.managedRoot, opts.managedRoot, "managed_root"); err != nil {
+		return err
+	}
+
+	policy, err := loadMutablePolicy(opts.policyPath)
+	if err != nil {
+		return err
+	}
+	credentials, _ := policy["credentials"].(map[string]any)
+	if credentials == nil {
+		credentials = map[string]any{}
+		policy["credentials"] = credentials
+	}
+	if err := ensureCredentialNotOnlyInIncludes(opts.policyPath, credentials, opts.credential, "set"); err != nil {
+		return err
+	}
+	existingEntry := credentials[opts.credential]
+	if err := ensureNoForeignManagedSource(opts.policyPath, opts.managedRoot, opts.credential, existingEntry, "set"); err != nil {
+		return err
+	}
+	selectors, err := desiredSelectors(credentials, opts.credential, opts.agent)
+	if err != nil {
+		return err
+	}
+
+	if opts.sourceRaw != "" {
+		sourceBase := filepath.Clean(".")
+		if opts.sourceBaseRaw != "" {
+			sourceBase = resolveInputPath(opts.sourceBaseRaw)
+		} else {
+			sourceBase, err = filepath.Abs(".")
+			if err != nil {
+				return err
+			}
+		}
+		source, err := validateSourcePath(opts.sourceRaw, "credentials."+opts.credential, sourceBase)
+		if err != nil {
+			return err
+		}
+		if _, err := requireSecretFile(source, "credentials."+opts.credential); err != nil {
+			return err
+		}
+		destination, err := canonicalDestinationPath(opts.managedRoot, opts.credential)
+		if err != nil {
+			return err
+		}
+		if err := validateManagedPath(opts.managedRoot, destination, "managed credential path for "+opts.credential); err != nil {
+			return err
+		}
+		managedRootFS, err := openManagedRoot(opts.managedRoot)
+		if err != nil {
+			return err
+		}
+		defer managedRootFS.Close()
+		destinationRel := canonicalDestinationPathPart(opts.credential)
+		priorManagedPath, err := managedSourcePathForEntry(opts.policyPath, opts.managedRoot, opts.credential, existingEntry)
+		if err != nil {
+			return err
+		}
+		priorManagedRel, err := managedRelativePath(opts.managedRoot, priorManagedPath, "managed credential path for "+opts.credential)
+		if err != nil {
+			return err
+		}
+		if priorManagedPath != "" && priorManagedPath != destination {
+			if err := requireNoSymlinkInPathChain(priorManagedPath, "managed credential path for "+opts.credential); err != nil {
+				return err
+			}
+		}
+		previousDestination, err := stageExistingFile(managedRootFS, destinationRel)
+		if err != nil {
+			return err
+		}
+		var priorManagedBackup string
+		if priorManagedPath != "" && priorManagedPath != destination {
+			priorManagedBackup, err = stageExistingFile(managedRootFS, priorManagedRel)
+			if err != nil {
+				_ = restoreStagedFile(managedRootFS, previousDestination, destinationRel)
+				return err
+			}
+		}
+		if err := writeSourceFile(managedRootFS, source, destinationRel); err != nil {
+			_ = restoreStagedFile(managedRootFS, previousDestination, destinationRel)
+			_ = restoreStagedFile(managedRootFS, priorManagedBackup, priorManagedRel)
+			return err
+		}
+		credentials[opts.credential] = mergeSelectors(selectors, map[string]any{
+			"source": destination,
+		})
+		if err := writeVerifiedPolicy(opts.policyPath, policy); err != nil {
+			_ = cleanupStagedFile(managedRootFS, destinationRel)
+			_ = restoreStagedFile(managedRootFS, previousDestination, destinationRel)
+			_ = restoreStagedFile(managedRootFS, priorManagedBackup, priorManagedRel)
+			return err
+		}
+		_ = writeManagedRootMarker(opts.managedRoot)
+		_ = cleanupStagedFile(managedRootFS, previousDestination)
+		_ = cleanupStagedFile(managedRootFS, priorManagedBackup)
+		return nil
+	}
+
+	if _, ok := allowedResolvers[opts.credential]; !ok {
+		return die(fmt.Sprintf("%s does not support resolver %s", opts.credential, opts.resolver))
+	}
+	if _, ok := allowedResolvers[opts.credential][opts.resolver]; !ok {
+		return die(fmt.Sprintf("%s does not support resolver %s", opts.credential, opts.resolver))
+	}
+	if !opts.ackHostResolver {
+		return die("set --resolver requires --ack-host-resolver")
+	}
+	managedPath, err := managedSourcePathForEntry(opts.policyPath, opts.managedRoot, opts.credential, existingEntry)
+	if err != nil {
+		return err
+	}
+	if managedPath != "" {
+		if err := requireNoSymlinkInPathChain(managedPath, "managed credential path for "+opts.credential); err != nil {
+			return err
+		}
+	}
+	managedRootFS, err := openManagedRoot(opts.managedRoot)
+	if err != nil {
+		return err
+	}
+	defer managedRootFS.Close()
+	managedPathRel, err := managedRelativePath(opts.managedRoot, managedPath, "managed credential path for "+opts.credential)
+	if err != nil {
+		return err
+	}
+	stagedManagedPath, err := stageExistingFile(managedRootFS, managedPathRel)
+	if err != nil {
+		return err
+	}
+	credentials[opts.credential] = mergeSelectors(selectors, map[string]any{
+		"resolver":        opts.resolver,
+		"materialization": "ephemeral",
+	})
+	if err := writeVerifiedPolicy(opts.policyPath, policy); err != nil {
+		_ = restoreStagedFile(managedRootFS, stagedManagedPath, managedPathRel)
+		return err
+	}
+	_ = cleanupStagedFile(managedRootFS, stagedManagedPath)
+	return nil
+}
+
+func commandUnset(policyPath string, managedRoot string, credential string) (int, error) {
+	if err := validateManagedPath(managedRoot, managedRoot, "managed_root"); err != nil {
+		return 0, err
+	}
+	policy, err := loadMutablePolicy(policyPath)
+	if err != nil {
+		return 0, err
+	}
+	credentials, _ := policy["credentials"].(map[string]any)
+	if credentials == nil {
+		credentials = map[string]any{}
+	}
+	if err := ensureCredentialNotOnlyInIncludes(policyPath, credentials, credential, "unset"); err != nil {
+		return 0, err
+	}
+	existingEntry := credentials[credential]
+	if err := ensureNoForeignManagedSource(policyPath, managedRoot, credential, existingEntry, "unset"); err != nil {
+		return 0, err
+	}
+	if _, ok := credentials[credential]; !ok {
+		return 0, nil
+	}
+	delete(credentials, credential)
+	if len(credentials) == 0 {
+		delete(policy, "credentials")
+	} else {
+		policy["credentials"] = credentials
+	}
+	managedPath, err := managedSourcePathForEntry(policyPath, managedRoot, credential, existingEntry)
+	if err != nil {
+		return 0, err
+	}
+	if managedPath != "" {
+		if err := requireNoSymlinkInPathChain(managedPath, "managed credential path for "+credential); err != nil {
+			return 0, err
+		}
+	}
+	managedRootFS, err := openManagedRoot(managedRoot)
+	if err != nil {
+		return 0, err
+	}
+	defer managedRootFS.Close()
+	managedPathRel, err := managedRelativePath(managedRoot, managedPath, "managed credential path for "+credential)
+	if err != nil {
+		return 0, err
+	}
+	stagedManagedPath, err := stageExistingFile(managedRootFS, managedPathRel)
+	if err != nil {
+		return 0, err
+	}
+	if err := writeVerifiedPolicy(policyPath, policy); err != nil {
+		_ = restoreStagedFile(managedRootFS, stagedManagedPath, managedPathRel)
+		return 0, err
+	}
+	_ = cleanupStagedFile(managedRootFS, stagedManagedPath)
+	return 1, nil
+}
+
+func commandStatus(opts statusOptions, stdout io.Writer) error {
+	if _, err := os.Stat(opts.policyPath); os.IsNotExist(err) {
+		fmt.Fprintln(stdout, "injection_policy=none")
+		fmt.Fprintln(stdout, "default_injection_policy_path="+opts.policyPath)
+		fmt.Fprintln(stdout, "credential_keys=none")
+		fmt.Fprintln(stdout, "credential_input_kinds=none")
+		fmt.Fprintln(stdout, "credential_resolvers=none")
+		fmt.Fprintln(stdout, "credential_materialization=none")
+		fmt.Fprintln(stdout, "credential_resolution_states=none")
+		if opts.agent != "" {
+			fmt.Fprintln(stdout, "provider_auth_mode=none")
+			fmt.Fprintln(stdout, "provider_auth_modes=none")
+			fmt.Fprintln(stdout, "shared_auth_modes=none")
+			fmt.Fprintln(stdout, "github_auth_present=0")
+		}
+		return nil
+	}
+
+	policy, policySources, err := loadPolicyBundle(opts.policyPath)
+	if err != nil {
+		return err
+	}
+	selected, err := selectedCredentials(policy, opts.agent, opts.mode)
+	if err != nil {
+		return err
+	}
+	for key, raw := range selected {
+		if err := validateStatusCredentialSource(key, raw, filepath.Dir(opts.policyPath)); err != nil {
+			return err
+		}
+	}
+	inputKinds := map[string]string{}
+	resolvers := map[string]string{}
+	materialization := map[string]string{}
+	resolutionStates := map[string]string{}
+	for key, raw := range selected {
+		inputKinds[key] = credentialInputKind(raw)
+		if rawMap, ok := raw.(map[string]any); ok {
+			if resolver, ok := rawMap["resolver"].(string); ok {
+				resolvers[key] = resolver
+			}
+			if mat, ok := rawMap["materialization"].(string); ok {
+				materialization[key] = mat
+			}
+		}
+		if inputKinds[key] == "resolver" {
+			resolutionStates[key] = "configured-only"
+		} else {
+			resolutionStates[key] = "source"
+		}
+	}
+
+	fmt.Fprintln(stdout, "policy_source_sha256="+compositePolicySHA256(policySources))
+	fmt.Fprintln(stdout, "credential_keys="+renderModes(sortedKeys(selected)))
+	fmt.Fprintln(stdout, "credential_input_kinds="+renderMap(inputKinds))
+	fmt.Fprintln(stdout, "credential_resolvers="+renderMap(resolvers))
+	fmt.Fprintln(stdout, "credential_materialization="+renderMap(materialization))
+	fmt.Fprintln(stdout, "credential_resolution_states="+renderMap(resolutionStates))
+	if opts.agent != "" {
+		providerAuthModes := make([]string, 0)
+		for _, key := range statusOrder[opts.agent] {
+			if _, ok := selected[key]; ok && resolutionStates[key] != "configured-only" {
+				providerAuthModes = append(providerAuthModes, key)
+			}
+		}
+		sharedAuthModes := make([]string, 0)
+		for _, key := range []string{"github_hosts", "github_config"} {
+			if _, ok := selected[key]; ok && resolutionStates[key] != "configured-only" {
+				sharedAuthModes = append(sharedAuthModes, key)
+			}
+		}
+		providerAuthMode := "none"
+		if len(providerAuthModes) > 0 {
+			providerAuthMode = providerAuthModes[0]
+		}
+		fmt.Fprintln(stdout, "provider_auth_mode="+providerAuthMode)
+		fmt.Fprintln(stdout, "provider_auth_modes="+renderModes(providerAuthModes))
+		fmt.Fprintln(stdout, "shared_auth_modes="+renderModes(sharedAuthModes))
+		if len(sharedAuthModes) > 0 {
+			fmt.Fprintln(stdout, "github_auth_present=1")
+		} else {
+			fmt.Fprintln(stdout, "github_auth_present=0")
+		}
+	}
+	return nil
+}
+
+func printSetOutput(stdout io.Writer, opts setOptions) {
+	fmt.Fprintln(stdout, "policy_path="+opts.policyPath)
+	fmt.Fprintln(stdout, "credential="+opts.credential)
+	if opts.sourceRaw != "" {
+		fmt.Fprintln(stdout, "source="+resolveInputPath(opts.sourceRaw))
+		fmt.Fprintln(stdout, "managed_source="+filepath.Join(opts.managedRoot, canonicalDestinationPathPart(opts.credential)))
+		if selectors, err := desiredSelectorsFromPolicy(opts.policyPath, opts.credential, opts.agent); err == nil {
+			if providers, ok := selectors["providers"].([]string); ok {
+				fmt.Fprintln(stdout, "providers="+strings.Join(providers, ","))
+			}
+			if modes, ok := selectors["modes"].([]string); ok {
+				fmt.Fprintln(stdout, "modes="+strings.Join(modes, ","))
+			}
+		}
+		return
+	}
+	fmt.Fprintln(stdout, "resolver="+opts.resolver)
+	fmt.Fprintln(stdout, "materialization=ephemeral")
+	fmt.Fprintln(stdout, "resolver_status=configured-fail-closed")
+	if selectors, err := desiredSelectorsFromPolicy(opts.policyPath, opts.credential, opts.agent); err == nil {
+		if providers, ok := selectors["providers"].([]string); ok {
+			fmt.Fprintln(stdout, "providers="+strings.Join(providers, ","))
+		}
+		if modes, ok := selectors["modes"].([]string); ok {
+			fmt.Fprintln(stdout, "modes="+strings.Join(modes, ","))
+		}
+	}
+}
+
+func desiredSelectorsFromPolicy(policyPath string, credential string, agent string) (map[string]any, error) {
+	policy, err := loadMutablePolicy(policyPath)
+	if err != nil {
+		return nil, err
+	}
+	credentials, _ := policy["credentials"].(map[string]any)
+	if credentials == nil {
+		credentials = map[string]any{}
+	}
+	return desiredSelectors(credentials, credential, agent)
+}
+
+func canonicalDestinationPath(managedRoot string, credential string) (string, error) {
+	parts, ok := canonicalCredentialDestinations[credential]
+	if !ok {
+		return "", die(fmt.Sprintf("workcell auth set does not manage %s automatically", credential))
+	}
+	return filepath.Join(managedRoot, parts[0], parts[1]), nil
+}
+
+func canonicalDestinationPathPart(credential string) string {
+	parts := canonicalCredentialDestinations[credential]
+	return filepath.Join(parts[0], parts[1])
+}
+
+func ensureDirectory(path string) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o700)
+}
+
+func validateManagedPath(managedRoot string, path string, label string) error {
+	if err := requireNoSymlinkInPathChain(path, label); err != nil {
+		return err
+	}
+	return requirePathWithin(managedRoot, path, label)
+}
+
+func writeManagedRootMarker(managedRoot string) error {
+	if err := ensureDirectory(managedRoot); err != nil {
+		return err
+	}
+	managedRootFS, err := os.OpenRoot(managedRoot)
+	if err != nil {
+		return err
+	}
+	defer managedRootFS.Close()
+	return rootio.WriteFileAtomic(managedRootFS, managedRootMarker, []byte("managed_by=workcell\n"), 0o600, "."+managedRootMarker+"-")
+}
+
+func isWorkcellManagedRoot(path string) bool {
+	_, err := os.Stat(filepath.Join(path, managedRootMarker))
+	return err == nil
+}
+
+func cleanupStagedFile(root *os.Root, path string) error {
+	if path == "" {
+		return nil
+	}
+	if err := root.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func stageExistingFile(root *os.Root, path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	cleanPath, err := normalizeRootRelativePath(path)
+	if err != nil {
+		return "", err
+	}
+	if _, err := root.Stat(cleanPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	tempPath, err := reserveRootTempPath(root, filepath.Dir(cleanPath), ".workcell-stage-")
+	if err != nil {
+		return "", err
+	}
+	if err := root.Rename(cleanPath, tempPath); err != nil {
+		return "", err
+	}
+	return tempPath, nil
+}
+
+func restoreStagedFile(root *os.Root, stagedPath string, destination string) error {
+	if stagedPath == "" || destination == "" {
+		return nil
+	}
+	cleanDestination, err := normalizeRootRelativePath(destination)
+	if err != nil {
+		return err
+	}
+	if err := root.Rename(stagedPath, cleanDestination); err != nil {
+		return err
+	}
+	return nil
+}
+
+func openManagedRoot(managedRoot string) (*os.Root, error) {
+	if err := ensureDirectory(managedRoot); err != nil {
+		return nil, err
+	}
+	return os.OpenRoot(managedRoot)
+}
+
+func managedRelativePath(managedRoot string, path string, label string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	return rootio.RelativePathWithin(managedRoot, path, label)
+}
+
+func writeSourceFile(root *os.Root, source string, destination string) error {
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	return rootio.WriteFileAtomicFromReader(root, destination, in, 0o600, ".workcell-auth-")
+}
+
+func normalizeRootRelativePath(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return "", fmt.Errorf("path must be relative to managed root: %s", path)
+	}
+	cleanPath := filepath.Clean(path)
+	if cleanPath == "." || cleanPath == string(filepath.Separator) {
+		return "", fmt.Errorf("path must name a file within the managed root: %s", path)
+	}
+	return cleanPath, nil
+}
+
+func reserveRootTempPath(root *os.Root, parent string, prefix string) (string, error) {
+	parent = filepath.Clean(parent)
+	if parent == "." {
+		parent = ""
+	}
+	for attempt := 0; attempt < 32; attempt++ {
+		suffix, err := randomTempSuffix()
+		if err != nil {
+			return "", err
+		}
+		name := prefix + suffix + ".tmp"
+		tempPath := name
+		if parent != "" {
+			tempPath = filepath.Join(parent, name)
+		}
+		tempFile, err := root.OpenFile(tempPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			if closeErr := tempFile.Close(); closeErr != nil {
+				_ = root.Remove(tempPath)
+				return "", closeErr
+			}
+			if removeErr := root.Remove(tempPath); removeErr != nil {
+				return "", removeErr
+			}
+			return tempPath, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("unable to allocate temporary staging path under %s", root.Name())
+}
+
+func randomTempSuffix() (string, error) {
+	var data [8]byte
+	if _, err := rand.Read(data[:]); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", data[:]), nil
+}
+
+func loadMutablePolicy(policyPath string) (map[string]any, error) {
+	policy, err := loadRawPolicy(policyPath)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := policy["version"]; !ok {
+		policy["version"] = 1
+	}
+	return policy, nil
+}
+
+func ensureCredentialNotOnlyInIncludes(policyPath string, credentials map[string]any, credential string, command string) error {
+	if _, ok := credentials[credential]; ok || policyPath == "" {
+		return nil
+	}
+	mergedPolicy, policySources, err := loadPolicyBundle(policyPath)
+	if err != nil {
+		return err
+	}
+	mergedCredentials, _ := mergedPolicy["credentials"].(map[string]any)
+	if mergedCredentials == nil {
+		return nil
+	}
+	if _, ok := mergedCredentials[credential]; !ok {
+		return nil
+	}
+	fragmentPath := ""
+	for _, source := range policySources {
+		sourcePolicy, err := loadRawPolicy(source.Path)
+		if err != nil {
+			return err
+		}
+		sourceCredentials, _ := sourcePolicy["credentials"].(map[string]any)
+		if sourceCredentials != nil {
+			if _, ok := sourceCredentials[credential]; ok {
+				fragmentPath = source.Path
+				break
+			}
+		}
+	}
+	fragmentHint := ""
+	if fragmentPath != "" {
+		fragmentHint = ": " + fragmentPath
+	}
+	return die(fmt.Sprintf("credentials.%s is declared by an included policy fragment; update that fragment directly before using workcell auth %s%s", credential, command, fragmentHint))
+}
+
+func desiredSelectors(credentials map[string]any, credential string, agent string) (map[string]any, error) {
+	existing := credentials[credential]
+	if existing == nil {
+		if _, ok := SharedCredentialKeys[credential]; ok {
+			return map[string]any{"providers": []string{agent}}, nil
+		}
+		return map[string]any{}, nil
+	}
+	if existingMap, ok := existing.(map[string]any); ok {
+		if err := validateAllowedKeys(existingMap, entryAllowedKeys, "credentials."+credential); err != nil {
+			return nil, err
+		}
+		selectors := map[string]any{}
+		if modes, ok := existingMap["modes"]; ok {
+			selectors["modes"] = modes
+		}
+		if _, ok := SharedCredentialKeys[credential]; ok {
+			if providers, ok := existingMap["providers"]; ok {
+				selectors["providers"] = providers
+			} else {
+				selectors["providers"] = []string{agent}
+			}
+		} else if providers, ok := existingMap["providers"]; ok {
+			selectors["providers"] = providers
+		}
+		return selectors, nil
+	}
+	if _, ok := SharedCredentialKeys[credential]; ok {
+		return map[string]any{"providers": []string{agent}}, nil
+	}
+	return map[string]any{}, nil
+}
+
+func mergeSelectors(selectors map[string]any, extra map[string]any) map[string]any {
+	result := map[string]any{}
+	for key, value := range selectors {
+		result[key] = value
+	}
+	for key, value := range extra {
+		result[key] = value
+	}
+	return result
+}
+
+func entrySourcePath(policyPath string, existingSource string) (string, error) {
+	return expandHostPath(existingSource, filepath.Dir(policyPath))
+}
+
+func managedSourcePathForEntry(policyPath string, managedRoot string, credential string, existingEntry any) (string, error) {
+	if _, ok := canonicalCredentialDestinations[credential]; !ok {
+		return "", nil
+	}
+	candidate, err := canonicalDestinationPath(managedRoot, credential)
+	if err != nil {
+		return "", err
+	}
+	var existingSource any
+	switch typed := existingEntry.(type) {
+	case map[string]any:
+		existingSource = typed["source"]
+	case string:
+		existingSource = typed
+	}
+	existingSourceString, ok := existingSource.(string)
+	if ok && existingSourceString == candidate {
+		return candidate, nil
+	}
+	if !ok {
+		return "", nil
+	}
+	existingPath, err := entrySourcePath(policyPath, existingSourceString)
+	if err != nil {
+		return "", err
+	}
+	if pathsEquivalent(existingPath, candidate) {
+		return candidate, nil
+	}
+	return "", nil
+}
+
+func foreignManagedSourcePathForEntry(policyPath string, managedRoot string, credential string, existingEntry any) (string, error) {
+	parts, ok := canonicalCredentialDestinations[credential]
+	if !ok {
+		return "", nil
+	}
+	candidate, err := canonicalDestinationPath(managedRoot, credential)
+	if err != nil {
+		return "", err
+	}
+	var existingSource any
+	switch typed := existingEntry.(type) {
+	case map[string]any:
+		existingSource = typed["source"]
+	case string:
+		existingSource = typed
+	}
+	existingSourceString, ok := existingSource.(string)
+	if !ok {
+		return "", nil
+	}
+	existingPath, err := entrySourcePath(policyPath, existingSourceString)
+	if err != nil {
+		return "", err
+	}
+	if pathsEquivalent(existingPath, candidate) {
+		return "", nil
+	}
+	if filepath.Base(existingPath) != parts[1] || filepath.Base(filepath.Dir(existingPath)) != parts[0] {
+		return "", nil
+	}
+	rootCandidate := filepath.Dir(filepath.Dir(existingPath))
+	if isWorkcellManagedRoot(rootCandidate) {
+		return existingPath, nil
+	}
+	return "", nil
+}
+
+func ensureNoForeignManagedSource(policyPath string, managedRoot string, credential string, existingEntry any, command string) error {
+	foreignPath, err := foreignManagedSourcePathForEntry(policyPath, managedRoot, credential, existingEntry)
+	if err != nil {
+		return err
+	}
+	if foreignPath == "" {
+		return nil
+	}
+	return die(fmt.Sprintf("credentials.%s is already managed under a different --managed-root (%s); run workcell auth %s with that --managed-root before switching roots", credential, filepath.Dir(filepath.Dir(foreignPath)), command))
+}
+
+func validateAgentCredential(agent string, credential string) error {
+	allowed := map[string]struct{}{}
+	for key := range SharedCredentialKeys {
+		allowed[key] = struct{}{}
+	}
+	for key := range AgentScopedCredentialKeys[agent] {
+		allowed[key] = struct{}{}
+	}
+	if _, ok := allowed[credential]; !ok {
+		return die(fmt.Sprintf("%s is not valid for agent %s", credential, agent))
+	}
+	return nil
+}
+
+func validateSelectorValues(values any, label string, allowedValues map[string]struct{}) error {
+	if values == nil {
+		return nil
+	}
+	rawValues, ok := values.([]any)
+	if !ok || len(rawValues) == 0 {
+		return die(fmt.Sprintf("%s must be a non-empty array when specified", label))
+	}
+	for _, value := range rawValues {
+		s, ok := value.(string)
+		if !ok {
+			return die(fmt.Sprintf("%s values must be strings", label))
+		}
+		if _, ok := allowedValues[s]; !ok {
+			return die(fmt.Sprintf("%s contains unsupported value: %s", label, s))
+		}
+	}
+	return nil
+}
+
+func validateStatusCredentialEntry(key string, raw any) error {
+	rawMap, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if err := validateAllowedKeys(rawMap, entryAllowedKeys, "credentials."+key); err != nil {
+		return err
+	}
+	sourceRaw := rawMap["source"]
+	resolver, _ := rawMap["resolver"].(string)
+	providers := rawMap["providers"]
+	materialization, hasMaterialization := rawMap["materialization"]
+	if _, ok := SharedCredentialKeys[key]; ok && providers == nil {
+		return die(fmt.Sprintf("credentials.%s.providers is required so shared GitHub credentials stay least-privilege", key))
+	}
+	if sourceRaw != nil && resolver != "" {
+		return die(fmt.Sprintf("credentials.%s must not declare both source and resolver", key))
+	}
+	if resolver == "" {
+		if hasMaterialization {
+			return die(fmt.Sprintf("credentials.%s.materialization is only valid for resolver-backed auth", key))
+		}
+		if sourceRaw == nil {
+			return die(fmt.Sprintf("credentials.%s must declare source or resolver", key))
+		}
+		return nil
+	}
+	if _, ok := allowedResolvers[key]; !ok || allowedResolvers[key][resolver] == (struct{}{}) {
+		// fallthrough handled below
+	}
+	if _, ok := allowedResolvers[key]; !ok {
+		return die(fmt.Sprintf("credentials.%s.resolver is unsupported: %s", key, resolver))
+	}
+	if _, ok := allowedResolvers[key][resolver]; !ok {
+		return die(fmt.Sprintf("credentials.%s.resolver is unsupported: %s", key, resolver))
+	}
+	if hasMaterialization {
+		if mat, ok := materialization.(string); !ok || mat != "ephemeral" {
+			return die(fmt.Sprintf("credentials.%s.materialization must stay ephemeral for resolver-backed auth", key))
+		}
+	}
+	return nil
+}
+
+func validateStatusCredentialSource(key string, raw any, policyBase string) error {
+	sourceRaw := raw
+	if rawMap, ok := raw.(map[string]any); ok {
+		sourceRaw = rawMap["source"]
+	}
+	if sourceRaw == nil {
+		return nil
+	}
+	source, err := validateSourcePath(sourceRaw, "credentials."+key, policyBase)
+	if err != nil {
+		return err
+	}
+	_, err = requireSecretFile(source, "credentials."+key)
+	return err
+}
+
+func renderMap(value map[string]string) string {
+	if len(value) == 0 {
+		return "none"
+	}
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+":"+value[key])
+	}
+	return strings.Join(parts, ",")
+}
+
+func renderModes(keys []string) string {
+	if len(keys) == 0 {
+		return "none"
+	}
+	return strings.Join(keys, ",")
+}
+
+func credentialInputKind(raw any) string {
+	if rawMap, ok := raw.(map[string]any); ok {
+		if rawMap["resolver"] != nil {
+			return "resolver"
+		}
+	}
+	return "source"
+}
+
+func selectedCredentials(policy map[string]any, agent string, mode string) (map[string]any, error) {
+	credentials, _ := policy["credentials"].(map[string]any)
+	if credentials == nil {
+		return map[string]any{}, nil
+	}
+	if agent == "" {
+		selected := map[string]any{}
+		for key, raw := range credentials {
+			if rawMap, ok := raw.(map[string]any); ok {
+				if err := validateStatusCredentialEntry(key, rawMap); err != nil {
+					return nil, err
+				}
+				if err := validateSelectorValues(rawMap["providers"], "credentials."+key+".providers", SupportedAgents); err != nil {
+					return nil, err
+				}
+				ok, err := selectedFor(rawMap["modes"], mode, "credentials."+key+".modes", SupportedModes)
+				if err != nil {
+					return nil, err
+				}
+				if !ok {
+					continue
+				}
+			}
+			selected[key] = raw
+		}
+		return selected, nil
+	}
+	relevant := map[string]struct{}{}
+	for key := range SharedCredentialKeys {
+		relevant[key] = struct{}{}
+	}
+	for key := range AgentScopedCredentialKeys[agent] {
+		relevant[key] = struct{}{}
+	}
+	selected := map[string]any{}
+	keys := make([]string, 0, len(relevant))
+	for key := range relevant {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		raw, ok := credentials[key]
+		if !ok {
+			continue
+		}
+		if rawMap, ok := raw.(map[string]any); ok {
+			if err := validateStatusCredentialEntry(key, rawMap); err != nil {
+				return nil, err
+			}
+			ok, err := selectedFor(rawMap["providers"], agent, "credentials."+key+".providers", SupportedAgents)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				continue
+			}
+			ok, err = selectedFor(rawMap["modes"], mode, "credentials."+key+".modes", SupportedModes)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				continue
+			}
+		}
+		selected[key] = raw
+	}
+	return selected, nil
+}
+
+func writeVerifiedPolicy(policyPath string, policy map[string]any) error {
+	if err := ensureDirectory(filepath.Dir(policyPath)); err != nil {
+		return err
+	}
+	tempFile, err := os.CreateTemp(filepath.Dir(policyPath), filepath.Base(policyPath)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	if err := tempFile.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	defer func() {
+		_ = os.Remove(tempPath)
+	}()
+	if err := writePolicyFile(tempPath, policy); err != nil {
+		return err
+	}
+	if _, _, err := loadPolicyBundle(tempPath); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, policyPath); err != nil {
+		return err
+	}
+	return os.Chmod(policyPath, 0o600)
+}

--- a/internal/authpolicy/manage_test.go
+++ b/internal/authpolicy/manage_test.go
@@ -1,0 +1,512 @@
+package authpolicy
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type runResult struct {
+	code   int
+	stdout string
+	stderr string
+}
+
+func runAuthPolicy(args ...string) runResult {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := Run("workcell", args, &stdout, &stderr)
+	return runResult{code: code, stdout: stdout.String(), stderr: stderr.String()}
+}
+
+func writeFile(tb testing.TB, path, content string, mode os.FileMode) {
+	tb.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+func readFile(tb testing.TB, path string) string {
+	tb.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return string(data)
+}
+
+func assertMode(tb testing.TB, path string, want os.FileMode) {
+	tb.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		tb.Fatalf("mode mismatch for %s: got %04o want %04o", path, got, want)
+	}
+}
+
+func mustContain(tb testing.TB, text, want string) {
+	tb.Helper()
+	if !strings.Contains(text, want) {
+		tb.Fatalf("%q does not contain %q", text, want)
+	}
+}
+
+func pathVariants(path string) []string {
+	var variants []string
+	seen := map[string]struct{}{}
+	add := func(candidate string) {
+		if candidate == "" {
+			return
+		}
+		if _, ok := seen[candidate]; ok {
+			return
+		}
+		seen[candidate] = struct{}{}
+		variants = append(variants, candidate)
+	}
+
+	add(filepath.Clean(path))
+	if abs, err := filepath.Abs(path); err == nil {
+		add(filepath.Clean(abs))
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		add(filepath.Clean(resolved))
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+			add(filepath.Clean(resolved))
+		}
+	}
+	return variants
+}
+
+func mustContainAny(tb testing.TB, text string, candidates ...string) {
+	tb.Helper()
+	for _, candidate := range candidates {
+		if strings.Contains(text, candidate) {
+			return
+		}
+	}
+	tb.Fatalf("%q does not contain any of %q", text, candidates)
+}
+
+func mustContainAnyPath(tb testing.TB, text, prefix string, candidates ...string) {
+	tb.Helper()
+	parts := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		parts = append(parts, prefix+candidate)
+	}
+	mustContainAny(tb, text, parts...)
+}
+
+func mustContainAnyWrapped(tb testing.TB, text, prefix, suffix string, candidates ...string) {
+	tb.Helper()
+	parts := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		parts = append(parts, prefix+candidate+suffix)
+	}
+	mustContainAny(tb, text, parts...)
+}
+
+func existingPath(tb testing.TB, candidates ...string) string {
+	tb.Helper()
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	tb.Fatalf("none of the candidate paths exist: %q", candidates)
+	return ""
+}
+
+func removeExistingPath(tb testing.TB, candidates ...string) {
+	tb.Helper()
+	path := existingPath(tb, candidates...)
+	if err := os.Remove(path); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+func TestStatusWithoutPolicyReportsNone(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "missing-policy.toml")
+
+	got := runAuthPolicy("status", "--policy", policyPath, "--agent", "codex")
+	if got.code != 0 {
+		t.Fatalf("Run(status) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stdout, "injection_policy=none")
+	mustContain(t, got.stdout, "credential_resolution_states=none")
+}
+
+func TestInitSetStatusUnsetRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "injection-policy.toml")
+	managedRoot := filepath.Join(root, "credentials")
+	sourcePath := filepath.Join(root, "auth.json")
+	writeFile(t, sourcePath, "{}\n", 0o600)
+
+	got := runAuthPolicy("init", "--policy", policyPath, "--managed-root", managedRoot)
+	if got.code != 0 {
+		t.Fatalf("Run(init) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContainAnyPath(t, got.stdout, "policy_path=", pathVariants(policyPath)...)
+	mustContainAnyPath(t, got.stdout, "managed_root=", pathVariants(managedRoot)...)
+	if readFile(t, policyPath) != "version = 1\n" {
+		t.Fatalf("unexpected init policy content: %q", readFile(t, policyPath))
+	}
+	for _, dir := range []string{"codex", "claude", "gemini", "shared"} {
+		if info, err := os.Stat(filepath.Join(managedRoot, dir)); err != nil || !info.IsDir() {
+			t.Fatalf("expected managed root directory %s to exist: %v", dir, err)
+		}
+	}
+
+	got = runAuthPolicy(
+		"set",
+		"--policy", policyPath,
+		"--managed-root", managedRoot,
+		"--agent", "codex",
+		"--credential", "codex_auth",
+		"--source", sourcePath,
+	)
+	if got.code != 0 {
+		t.Fatalf("Run(set source) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	expectedManaged := filepath.Join(managedRoot, "codex", "auth.json")
+	managedVariants := pathVariants(expectedManaged)
+	mustContainAnyWrapped(t, readFile(t, policyPath), `source = "`, `"`, managedVariants...)
+	managedCopy := existingPath(t, managedVariants...)
+	assertMode(t, managedCopy, 0o600)
+	if readFile(t, managedCopy) != "{}\n" {
+		t.Fatalf("unexpected managed copy content: %q", readFile(t, managedCopy))
+	}
+
+	got = runAuthPolicy("status", "--policy", policyPath, "--agent", "codex")
+	if got.code != 0 {
+		t.Fatalf("Run(status) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stdout, "credential_keys=codex_auth")
+	mustContain(t, got.stdout, "credential_input_kinds=codex_auth:source")
+	mustContain(t, got.stdout, "provider_auth_mode=codex_auth")
+	mustContain(t, got.stdout, "shared_auth_modes=none")
+
+	got = runAuthPolicy("unset", "--policy", policyPath, "--managed-root", managedRoot, "--credential", "codex_auth")
+	if got.code != 0 {
+		t.Fatalf("Run(unset) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stdout, "removed=1")
+	for _, candidate := range managedVariants {
+		if _, err := os.Stat(candidate); !os.IsNotExist(err) {
+			t.Fatalf("expected managed copy to be removed, got err=%v for %s", err, candidate)
+		}
+	}
+}
+
+func TestSetResolverAndStatus(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "injection-policy.toml")
+	managedRoot := filepath.Join(root, "credentials")
+	got := runAuthPolicy("init", "--policy", policyPath, "--managed-root", managedRoot)
+	if got.code != 0 {
+		t.Fatalf("Run(init) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+
+	got = runAuthPolicy(
+		"set",
+		"--policy", policyPath,
+		"--managed-root", managedRoot,
+		"--agent", "claude",
+		"--credential", "claude_auth",
+		"--resolver", "claude-macos-keychain",
+		"--ack-host-resolver",
+	)
+	if got.code != 0 {
+		t.Fatalf("Run(set resolver) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	rendered := readFile(t, policyPath)
+	mustContain(t, rendered, `[credentials.claude_auth]`)
+	mustContain(t, rendered, `resolver = "claude-macos-keychain"`)
+	mustContain(t, rendered, `materialization = "ephemeral"`)
+
+	got = runAuthPolicy("status", "--policy", policyPath, "--agent", "claude")
+	if got.code != 0 {
+		t.Fatalf("Run(status) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stdout, "credential_input_kinds=claude_auth:resolver")
+	mustContain(t, got.stdout, "credential_resolvers=claude_auth:claude-macos-keychain")
+	mustContain(t, got.stdout, "credential_materialization=claude_auth:ephemeral")
+	mustContain(t, got.stdout, "credential_resolution_states=claude_auth:configured-only")
+	mustContain(t, got.stdout, "provider_auth_mode=none")
+	mustContain(t, got.stdout, "shared_auth_modes=none")
+}
+
+func TestSharedCredentialsAreScopedToRequestedAgent(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "injection-policy.toml")
+	hostsPath := filepath.Join(root, "hosts.yml")
+	writeFile(t, hostsPath, "github.com:\n", 0o600)
+	writeFile(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.github_hosts]",
+		`source = "` + hostsPath + `"`,
+		`providers = ["codex"]`,
+	}, "\n")+"\n", 0o600)
+
+	codexStatus := runAuthPolicy("status", "--policy", policyPath, "--agent", "codex")
+	if codexStatus.code != 0 {
+		t.Fatalf("Run(status codex) = %d stdout=%q stderr=%q", codexStatus.code, codexStatus.stdout, codexStatus.stderr)
+	}
+	mustContain(t, codexStatus.stdout, "shared_auth_modes=github_hosts")
+
+	claudeStatus := runAuthPolicy("status", "--policy", policyPath, "--agent", "claude")
+	if claudeStatus.code != 0 {
+		t.Fatalf("Run(status claude) = %d stdout=%q stderr=%q", claudeStatus.code, claudeStatus.stdout, claudeStatus.stderr)
+	}
+	mustContain(t, claudeStatus.stdout, "credential_keys=none")
+	mustContain(t, claudeStatus.stdout, "shared_auth_modes=none")
+}
+
+func TestRunRejectsInvalidConfigurations(t *testing.T) {
+	cases := []struct {
+		name         string
+		policy       string
+		agent        string
+		credential   string
+		command      string
+		extraArgs    []string
+		needsInit    bool
+		wantContains string
+	}{
+		{
+			name: "conflicting-source-and-resolver",
+			policy: strings.Join([]string{
+				"version = 1",
+				"[credentials.claude_auth]",
+				`source = "/tmp/auth.json"`,
+				`resolver = "claude-macos-keychain"`,
+				`materialization = "ephemeral"`,
+			}, "\n") + "\n",
+			command:      "status",
+			agent:        "claude",
+			needsInit:    false,
+			wantContains: "credentials.claude_auth must not declare both source and resolver",
+		},
+		{
+			name: "unsupported-resolver",
+			policy: strings.Join([]string{
+				"version = 1",
+				"[credentials.claude_auth]",
+				`resolver = "bogus"`,
+				`materialization = "ephemeral"`,
+			}, "\n") + "\n",
+			command:      "status",
+			agent:        "claude",
+			needsInit:    false,
+			wantContains: "credentials.claude_auth.resolver is unsupported: bogus",
+		},
+		{
+			name: "invalid-selector-values",
+			policy: strings.Join([]string{
+				"version = 1",
+				"[credentials.codex_auth]",
+				`source = "/tmp/auth.json"`,
+				`providers = ["bogus"]`,
+			}, "\n") + "\n",
+			command:      "status",
+			agent:        "codex",
+			needsInit:    false,
+			wantContains: "credentials.codex_auth.providers contains unsupported value: bogus",
+		},
+		{
+			name: "shared-github-without-providers",
+			policy: strings.Join([]string{
+				"version = 1",
+				"[credentials.github_hosts]",
+				`source = "/tmp/hosts.yml"`,
+			}, "\n") + "\n",
+			command:      "status",
+			agent:        "codex",
+			needsInit:    false,
+			wantContains: "credentials.github_hosts.providers is required so shared GitHub credentials stay least-privilege",
+		},
+		{
+			name: "set-rejects-included-credential",
+			policy: strings.Join([]string{
+				"version = 1",
+				`includes = ["fragment.toml"]`,
+			}, "\n") + "\n",
+			command:      "set",
+			agent:        "codex",
+			credential:   "codex_auth",
+			extraArgs:    []string{"--source", "/tmp/auth.json"},
+			needsInit:    false,
+			wantContains: "declared by an included policy fragment",
+		},
+		{
+			name: "unset-rejects-included-credential",
+			policy: strings.Join([]string{
+				"version = 1",
+				`includes = ["fragment.toml"]`,
+			}, "\n") + "\n",
+			command:      "unset",
+			credential:   "codex_auth",
+			needsInit:    false,
+			wantContains: "declared by an included policy fragment",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			policyPath := filepath.Join(root, "injection-policy.toml")
+			writeFile(t, policyPath, tc.policy, 0o600)
+			if strings.Contains(tc.name, "included-credential") {
+				writeFile(t, filepath.Join(root, "fragment.toml"), strings.Join([]string{
+					"version = 1",
+					"[credentials.codex_auth]",
+					`source = "/tmp/original.json"`,
+				}, "\n")+"\n", 0o600)
+			}
+			managedRoot := filepath.Join(root, "credentials")
+			if tc.needsInit {
+				if got := runAuthPolicy("init", "--policy", policyPath, "--managed-root", managedRoot); got.code != 0 {
+					t.Fatalf("Run(init) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+				}
+			}
+
+			args := []string{tc.command, "--policy", policyPath}
+			if tc.command != "status" {
+				args = append(args, "--managed-root", managedRoot)
+			}
+			if tc.agent != "" {
+				args = append(args, "--agent", tc.agent)
+			}
+			if tc.credential != "" {
+				args = append(args, "--credential", tc.credential)
+			}
+			args = append(args, tc.extraArgs...)
+
+			got := runAuthPolicy(args...)
+			if got.code != 1 {
+				t.Fatalf("Run(%s) = %d stdout=%q stderr=%q", tc.command, got.code, got.stdout, got.stderr)
+			}
+			mustContain(t, got.stderr, tc.wantContains)
+		})
+	}
+}
+
+func TestSetRollsBackManagedCopyWhenPolicyWriteFails(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "injection-policy.toml")
+	managedRoot := filepath.Join(root, "credentials")
+	sourcePath := filepath.Join(root, "auth.json")
+	writeFile(t, sourcePath, "{\"token\":\"next\"}\n", 0o600)
+	writeFile(t, policyPath, strings.Join([]string{
+		"version = 1",
+		`unexpected = "value"`,
+		"[credentials.codex_auth]",
+		`source = "/tmp/original.json"`,
+	}, "\n")+"\n", 0o600)
+
+	got := runAuthPolicy(
+		"set",
+		"--policy", policyPath,
+		"--managed-root", managedRoot,
+		"--agent", "codex",
+		"--credential", "codex_auth",
+		"--source", sourcePath,
+	)
+	if got.code != 1 {
+		t.Fatalf("Run(set) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	candidates := append([]string{}, pathVariants(filepath.Join(managedRoot, "codex", "auth.json"))...)
+	candidates = append(candidates, pathVariants(filepath.Join(managedRoot, ".workcell-managed-root"))...)
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			t.Fatalf("expected rollback to remove %s", candidate)
+		}
+	}
+}
+
+func TestStatusRejectsMissingManagedSourceFile(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "injection-policy.toml")
+	managedRoot := filepath.Join(root, "credentials")
+	sourcePath := filepath.Join(root, "auth.json")
+	writeFile(t, sourcePath, "{}\n", 0o600)
+	if got := runAuthPolicy("init", "--policy", policyPath, "--managed-root", managedRoot); got.code != 0 {
+		t.Fatalf("Run(init) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	if got := runAuthPolicy(
+		"set",
+		"--policy", policyPath,
+		"--managed-root", managedRoot,
+		"--agent", "codex",
+		"--credential", "codex_auth",
+		"--source", sourcePath,
+	); got.code != 0 {
+		t.Fatalf("Run(set) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	policyText := readFile(t, policyPath)
+	prefix := `source = "`
+	start := strings.Index(policyText, prefix)
+	if start < 0 {
+		t.Fatalf("could not locate rewritten source path in policy: %q", policyText)
+	}
+	start += len(prefix)
+	end := strings.Index(policyText[start:], `"`)
+	if end < 0 {
+		t.Fatalf("could not parse rewritten source path in policy: %q", policyText)
+	}
+	managedSourcePath := policyText[start : start+end]
+	removeExistingPath(t, pathVariants(managedSourcePath)...)
+
+	got := runAuthPolicy("status", "--policy", policyPath, "--agent", "codex")
+	if got.code != 1 {
+		t.Fatalf("Run(status) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stderr, "does not exist")
+}
+
+func TestSetRejectsSymlinkedManagedRootDestination(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "injection-policy.toml")
+	managedRoot := filepath.Join(root, "credentials")
+	escapeRoot := filepath.Join(root, "escape")
+	sourcePath := filepath.Join(root, "auth.json")
+	writeFile(t, sourcePath, "{}\n", 0o600)
+	if got := runAuthPolicy("init", "--policy", policyPath, "--managed-root", managedRoot); got.code != 0 {
+		t.Fatalf("Run(init) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	if err := os.RemoveAll(filepath.Join(managedRoot, "codex")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(escapeRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(escapeRoot, filepath.Join(managedRoot, "codex")); err != nil {
+		t.Fatal(err)
+	}
+	got := runAuthPolicy(
+		"set",
+		"--policy", policyPath,
+		"--managed-root", managedRoot,
+		"--agent", "codex",
+		"--credential", "codex_auth",
+		"--source", sourcePath,
+	)
+	if got.code != 1 {
+		t.Fatalf("Run(set) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stderr, "must not be a symlink")
+}

--- a/internal/authpolicy/policy.go
+++ b/internal/authpolicy/policy.go
@@ -1,0 +1,1120 @@
+package authpolicy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/omkhar/workcell/internal/rootio"
+)
+
+var (
+	SupportedAgents = map[string]struct{}{
+		"codex":  {},
+		"claude": {},
+		"gemini": {},
+	}
+	SupportedModes = map[string]struct{}{
+		"strict":     {},
+		"build":      {},
+		"breakglass": {},
+	}
+	CredentialKeys = map[string]struct{}{
+		"codex_auth":      {},
+		"claude_auth":     {},
+		"claude_api_key":  {},
+		"claude_mcp":      {},
+		"gemini_env":      {},
+		"gemini_oauth":    {},
+		"gemini_projects": {},
+		"gcloud_adc":      {},
+		"github_hosts":    {},
+		"github_config":   {},
+	}
+	AgentScopedCredentialKeys = map[string]map[string]struct{}{
+		"codex": {
+			"codex_auth": {},
+		},
+		"claude": {
+			"claude_api_key": {},
+			"claude_auth":    {},
+			"claude_mcp":     {},
+		},
+		"gemini": {
+			"gemini_env":      {},
+			"gemini_oauth":    {},
+			"gemini_projects": {},
+			"gcloud_adc":      {},
+		},
+	}
+	SharedCredentialKeys = map[string]struct{}{
+		"github_hosts":  {},
+		"github_config": {},
+	}
+	AllowedRootPolicyKeys = map[string]struct{}{
+		"version":     {},
+		"includes":    {},
+		"documents":   {},
+		"ssh":         {},
+		"copies":      {},
+		"credentials": {},
+	}
+	managedRootMarker = ".workcell-managed-root"
+)
+
+var systemSymlinkAllowlist = map[string]struct{}{}
+
+func init() {
+	if runtime.GOOS == "darwin" {
+		systemSymlinkAllowlist[filepath.Clean("/var")] = struct{}{}
+		systemSymlinkAllowlist[filepath.Clean("/tmp")] = struct{}{}
+	}
+}
+
+type PolicySource struct {
+	Path   string
+	SHA256 string
+}
+
+func die(message string) error {
+	return fmt.Errorf("%s", message)
+}
+
+func expandHostPath(raw string, base string) (string, error) {
+	expanded, err := expandUserPath(raw)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(expanded) {
+		expanded = filepath.Join(base, expanded)
+	}
+	return filepath.Abs(expanded)
+}
+
+func expandUserPath(raw string) (string, error) {
+	switch {
+	case raw == "":
+		return "", fmt.Errorf("empty path")
+	case raw == "~":
+		return os.UserHomeDir()
+	case strings.HasPrefix(raw, "~/"):
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, raw[2:]), nil
+	case strings.HasPrefix(raw, "~"):
+		slash := strings.IndexByte(raw, '/')
+		userName := raw[1:]
+		remainder := ""
+		if slash >= 0 {
+			userName = raw[1:slash]
+			remainder = raw[slash+1:]
+		}
+		if userName == "" {
+			return os.UserHomeDir()
+		}
+		usr, err := user.Lookup(userName)
+		if err != nil {
+			return "", err
+		}
+		if remainder == "" {
+			return usr.HomeDir, nil
+		}
+		return filepath.Join(usr.HomeDir, remainder), nil
+	default:
+		return raw, nil
+	}
+}
+
+func requirePathWithin(root string, candidate string, label string) error {
+	resolvedRoot, err := resolvePathLikePython(root)
+	if err != nil {
+		return err
+	}
+	resolvedCandidate, err := resolvePathLikePython(candidate)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(resolvedRoot, resolvedCandidate)
+	if err != nil {
+		return die(fmt.Sprintf("%s must stay within %s: %s", label, resolvedRoot, resolvedCandidate))
+	}
+	if rel == "." || !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".." {
+		return nil
+	}
+	return die(fmt.Sprintf("%s must stay within %s: %s", label, resolvedRoot, resolvedCandidate))
+}
+
+func requireNoSymlinkInPathChain(path string, label string) error {
+	current := filepath.Clean(path)
+	for {
+		info, err := os.Lstat(current)
+		if err == nil && info.Mode()&os.ModeSymlink != 0 {
+			if _, ok := systemSymlinkAllowlist[current]; !ok {
+				return die(fmt.Sprintf("%s must not be a symlink: %s", label, current))
+			}
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
+}
+
+func validateSourcePath(raw any, label string, base string) (string, error) {
+	rawString, ok := raw.(string)
+	if !ok || rawString == "" {
+		return "", die(fmt.Sprintf("%s must be a non-empty string path", label))
+	}
+	source, err := expandHostPath(rawString, base)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(source); err != nil {
+		if os.IsNotExist(err) {
+			return "", die(fmt.Sprintf("%s does not exist: %s", label, source))
+		}
+		return "", err
+	}
+	if err := requireNoSymlinkInPathChain(source, label); err != nil {
+		return "", err
+	}
+	return source, nil
+}
+
+func validateAllowedKeys(table map[string]any, allowedKeys map[string]struct{}, label string) error {
+	if table == nil {
+		return nil
+	}
+	unknown := make([]string, 0)
+	for key := range table {
+		if _, ok := allowedKeys[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	sort.Strings(unknown)
+	if len(unknown) > 0 {
+		return die(fmt.Sprintf("%s contains unsupported keys: %s", label, strings.Join(unknown, ", ")))
+	}
+	return nil
+}
+
+func selectedFor(values any, current string, label string, allowedValues map[string]struct{}) (bool, error) {
+	if values == nil {
+		return true, nil
+	}
+	rawValues, ok := values.([]any)
+	if !ok || len(rawValues) == 0 {
+		return false, die(fmt.Sprintf("%s must be a non-empty array when specified", label))
+	}
+	for _, value := range rawValues {
+		s, ok := value.(string)
+		if !ok {
+			return false, die(fmt.Sprintf("%s values must be strings", label))
+		}
+		if _, ok := allowedValues[s]; !ok {
+			return false, die(fmt.Sprintf("%s contains unsupported value: %s", label, s))
+		}
+	}
+	for _, value := range rawValues {
+		if value.(string) == current {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func stripComment(line string) string {
+	escaped := false
+	quoteChar := byte(0)
+	result := make([]byte, 0, len(line))
+	for i := 0; i < len(line); i++ {
+		ch := line[i]
+		if escaped {
+			result = append(result, ch)
+			escaped = false
+			continue
+		}
+		if ch == '\\' && quoteChar == '"' {
+			result = append(result, ch)
+			escaped = true
+			continue
+		}
+		if ch == '"' || ch == '\'' {
+			if quoteChar == 0 {
+				quoteChar = ch
+			} else if quoteChar == ch {
+				quoteChar = 0
+			}
+			result = append(result, ch)
+			continue
+		}
+		if ch == '#' && quoteChar == 0 {
+			break
+		}
+		result = append(result, ch)
+	}
+	return strings.TrimSpace(string(result))
+}
+
+func parseValue(raw string, policyPath string, lineno int) (any, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return nil, die(fmt.Sprintf("%s:%d: expected a value", policyPath, lineno))
+	}
+	switch value {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	}
+	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+		parsed, err := strconv.Unquote(value)
+		if err != nil {
+			return nil, err
+		}
+		return parsed, nil
+	}
+	if strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'") {
+		parsed, err := parseSingleQuoted(value)
+		if err != nil {
+			return nil, err
+		}
+		return parsed, nil
+	}
+	if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+		parsed, err := parseStringArray(value, policyPath, lineno)
+		if err != nil {
+			return nil, err
+		}
+		return parsed, nil
+	}
+	if isDigits(value) {
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			return nil, err
+		}
+		return n, nil
+	}
+	return nil, die(fmt.Sprintf("%s:%d: unsupported TOML value; use quoted strings, booleans, integers, or arrays of strings", policyPath, lineno))
+}
+
+func isDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func parseSingleQuoted(value string) (string, error) {
+	if len(value) < 2 || value[0] != '\'' || value[len(value)-1] != '\'' {
+		return "", fmt.Errorf("invalid quoted string: %s", value)
+	}
+	inner := value[1 : len(value)-1]
+	replacer := strings.NewReplacer(`\\`, `\`, `\'`, `'`, `\n`, "\n", `\t`, "\t", `\r`, "\r")
+	return replacer.Replace(inner), nil
+}
+
+func parseStringArray(value string, policyPath string, lineno int) ([]any, error) {
+	inner := strings.TrimSpace(value[1 : len(value)-1])
+	if inner == "" {
+		return []any{}, nil
+	}
+	items := make([]string, 0)
+	var current strings.Builder
+	quoteChar := byte(0)
+	escaped := false
+	for i := 0; i < len(inner); i++ {
+		ch := inner[i]
+		if quoteChar != 0 {
+			current.WriteByte(ch)
+			if escaped {
+				escaped = false
+				continue
+			}
+			if ch == '\\' && quoteChar == '"' {
+				escaped = true
+				continue
+			}
+			if ch == quoteChar {
+				quoteChar = 0
+			}
+			continue
+		}
+		if ch == '\'' || ch == '"' {
+			quoteChar = ch
+			current.WriteByte(ch)
+			continue
+		}
+		if ch == ',' {
+			token := strings.TrimSpace(current.String())
+			current.Reset()
+			if token == "" {
+				continue
+			}
+			parsed, err := parseValue(token, policyPath, lineno)
+			if err != nil {
+				return nil, err
+			}
+			s, ok := parsed.(string)
+			if !ok {
+				return nil, die(fmt.Sprintf("%s:%d: only arrays of strings are supported", policyPath, lineno))
+			}
+			items = append(items, s)
+			continue
+		}
+		current.WriteByte(ch)
+	}
+	if quoteChar != 0 {
+		return nil, die(fmt.Sprintf("%s:%d: only arrays of strings are supported", policyPath, lineno))
+	}
+	token := strings.TrimSpace(current.String())
+	if token != "" {
+		parsed, err := parseValue(token, policyPath, lineno)
+		if err != nil {
+			return nil, err
+		}
+		s, ok := parsed.(string)
+		if !ok {
+			return nil, die(fmt.Sprintf("%s:%d: only arrays of strings are supported", policyPath, lineno))
+		}
+		items = append(items, s)
+	}
+	for _, item := range items {
+		if item == "" {
+			return nil, die(fmt.Sprintf("%s:%d: only arrays of strings are supported", policyPath, lineno))
+		}
+	}
+	result := make([]any, 0, len(items))
+	for _, item := range items {
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+func parseTOMLSubset(content string, policyPath string) (map[string]any, error) {
+	root := map[string]any{}
+	current := root
+	seenTables := map[string]struct{}{}
+	lines := strings.Split(content, "\n")
+	for lineno, rawLine := range lines {
+		line := stripComment(rawLine)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[[") && strings.HasSuffix(line, "]]") {
+			tableName := strings.TrimSpace(line[2 : len(line)-2])
+			if tableName != "copies" {
+				return nil, die(fmt.Sprintf("%s:%d: unsupported array-of-table [%s]", policyPath, lineno+1, tableName))
+			}
+			rawCopies, _ := root["copies"].([]any)
+			entry := map[string]any{}
+			rawCopies = append(rawCopies, entry)
+			root["copies"] = rawCopies
+			current = entry
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			tableName := strings.TrimSpace(line[1 : len(line)-1])
+			if _, seen := seenTables[tableName]; seen {
+				return nil, die(fmt.Sprintf("%s:%d: duplicate table [%s]", policyPath, lineno+1, tableName))
+			}
+			seenTables[tableName] = struct{}{}
+			if strings.HasPrefix(tableName, "credentials.") {
+				credentialKey := strings.SplitN(tableName, ".", 2)[1]
+				if _, ok := CredentialKeys[credentialKey]; !ok {
+					return nil, die(fmt.Sprintf("%s:%d: unsupported credentials table [%s]", policyPath, lineno+1, tableName))
+				}
+				rawCredentials, _ := root["credentials"].(map[string]any)
+				if rawCredentials == nil {
+					rawCredentials = map[string]any{}
+					root["credentials"] = rawCredentials
+				}
+				entry, _ := rawCredentials[credentialKey].(map[string]any)
+				if entry == nil {
+					entry = map[string]any{}
+					rawCredentials[credentialKey] = entry
+				}
+				current = entry
+				continue
+			}
+			if tableName != "documents" && tableName != "ssh" && tableName != "credentials" {
+				return nil, die(fmt.Sprintf("%s:%d: unsupported table [%s]", policyPath, lineno+1, tableName))
+			}
+			table, _ := root[tableName].(map[string]any)
+			if table == nil {
+				table = map[string]any{}
+				root[tableName] = table
+			}
+			current = table
+			continue
+		}
+		if !strings.Contains(line, "=") {
+			return nil, die(fmt.Sprintf("%s:%d: expected key = value", policyPath, lineno+1))
+		}
+		parts := strings.SplitN(line, "=", 2)
+		key := strings.TrimSpace(parts[0])
+		value := parts[1]
+		if key == "" {
+			return nil, die(fmt.Sprintf("%s:%d: empty key", policyPath, lineno+1))
+		}
+		if strings.Contains(key, ".") {
+			return nil, die(fmt.Sprintf("%s:%d: dotted TOML keys are not supported; use explicit [table] headers instead", policyPath, lineno+1))
+		}
+		if _, exists := current[key]; exists {
+			return nil, die(fmt.Sprintf("%s:%d: duplicate key: %s", policyPath, lineno+1, key))
+		}
+		parsed, err := parseValue(value, policyPath, lineno+1)
+		if err != nil {
+			return nil, err
+		}
+		current[key] = parsed
+	}
+	return root, nil
+}
+
+func policySHA256(policyPath string) (string, error) {
+	data, err := os.ReadFile(policyPath)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func compositePolicySHA256(policySources []PolicySource) string {
+	sortedSources := append([]PolicySource(nil), policySources...)
+	sort.Slice(sortedSources, func(i, j int) bool {
+		return sortedSources[i].Path < sortedSources[j].Path
+	})
+	var b strings.Builder
+	b.WriteByte('[')
+	for i, source := range sortedSources {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString("{'path': ")
+		b.WriteString(pythonReprString(source.Path))
+		b.WriteString(", 'sha256': ")
+		b.WriteString(pythonReprString(source.SHA256))
+		b.WriteByte('}')
+	}
+	b.WriteByte(']')
+	sum := sha256.Sum256([]byte(b.String()))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func pythonReprString(value string) string {
+	escaped := strings.ReplaceAll(value, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+	return "'" + escaped + "'"
+}
+
+func logicalPolicyPath(policyPath string, entrypointRoot string) (string, error) {
+	relativePath, err := filepath.Rel(entrypointRoot, policyPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(relativePath), nil
+}
+
+func rebaseFragmentPath(raw any, fragmentDir string) any {
+	rawString, ok := raw.(string)
+	if !ok || rawString == "" {
+		return raw
+	}
+	rebased, err := expandHostPath(rawString, fragmentDir)
+	if err != nil {
+		return raw
+	}
+	return rebased
+}
+
+func rebasePolicyFragment(policy map[string]any, fragmentDir string) map[string]any {
+	rebased := map[string]any{}
+	for key, value := range policy {
+		switch key {
+		case "documents":
+			if table, ok := value.(map[string]any); ok {
+				rebasedTable := map[string]any{}
+				for documentKey, documentValue := range table {
+					rebasedTable[documentKey] = rebaseFragmentPath(documentValue, fragmentDir)
+				}
+				rebased[key] = rebasedTable
+				continue
+			}
+		case "copies":
+			if copies, ok := value.([]any); ok {
+				rebasedCopies := make([]any, 0, len(copies))
+				for _, entry := range copies {
+					entryMap, ok := entry.(map[string]any)
+					if !ok {
+						rebasedCopies = append(rebasedCopies, entry)
+						continue
+					}
+					rebasedEntry := map[string]any{}
+					for k, v := range entryMap {
+						rebasedEntry[k] = v
+					}
+					if source, ok := rebasedEntry["source"]; ok {
+						rebasedEntry["source"] = rebaseFragmentPath(source, fragmentDir)
+					}
+					rebasedCopies = append(rebasedCopies, rebasedEntry)
+				}
+				rebased[key] = rebasedCopies
+				continue
+			}
+		case "ssh":
+			if table, ok := value.(map[string]any); ok {
+				rebasedSSH := map[string]any{}
+				for k, v := range table {
+					rebasedSSH[k] = v
+				}
+				for _, sshKey := range []string{"config", "known_hosts"} {
+					if sshValue, ok := rebasedSSH[sshKey]; ok {
+						rebasedSSH[sshKey] = rebaseFragmentPath(sshValue, fragmentDir)
+					}
+				}
+				if identities, ok := rebasedSSH["identities"].([]any); ok {
+					rebasedIdentities := make([]any, 0, len(identities))
+					for _, identity := range identities {
+						rebasedIdentities = append(rebasedIdentities, rebaseFragmentPath(identity, fragmentDir))
+					}
+					rebasedSSH["identities"] = rebasedIdentities
+				}
+				rebased[key] = rebasedSSH
+				continue
+			}
+		case "credentials":
+			if table, ok := value.(map[string]any); ok {
+				rebasedCredentials := map[string]any{}
+				for credentialKey, credentialValue := range table {
+					if credentialMap, ok := credentialValue.(map[string]any); ok {
+						rebasedCredential := map[string]any{}
+						for k, v := range credentialMap {
+							rebasedCredential[k] = v
+						}
+						if source, ok := rebasedCredential["source"]; ok {
+							rebasedCredential["source"] = rebaseFragmentPath(source, fragmentDir)
+						}
+						rebasedCredentials[credentialKey] = rebasedCredential
+					} else {
+						rebasedCredentials[credentialKey] = rebaseFragmentPath(credentialValue, fragmentDir)
+					}
+				}
+				rebased[key] = rebasedCredentials
+				continue
+			}
+		}
+		rebased[key] = value
+	}
+	return rebased
+}
+
+func validatePolicyInclude(raw any, label string, base string, entrypointRoot string) (string, error) {
+	source, err := validateSourcePath(raw, label, base)
+	if err != nil {
+		return "", err
+	}
+	if info, err := os.Stat(source); err != nil || !info.Mode().IsRegular() {
+		return "", die(fmt.Sprintf("%s must point at a file: %s", label, source))
+	}
+	if err := requirePathWithin(entrypointRoot, source, label); err != nil {
+		return "", err
+	}
+	return source, nil
+}
+
+func mergePolicyFragment(base map[string]any, addition map[string]any, sourcePath string) error {
+	version := 1
+	if rawVersion, ok := addition["version"]; ok {
+		if value, ok := rawVersion.(int); ok {
+			version = value
+		}
+	}
+	if version != 1 {
+		return die(fmt.Sprintf("unsupported injection policy version: %d", version))
+	}
+	for _, tableName := range []string{"documents", "ssh", "credentials"} {
+		tableRaw, ok := addition[tableName]
+		if !ok {
+			continue
+		}
+		table, ok := tableRaw.(map[string]any)
+		if !ok {
+			return die(fmt.Sprintf("injection policy fragment must keep %s as a table: %s", tableName, sourcePath))
+		}
+		destination, _ := base[tableName].(map[string]any)
+		if destination == nil {
+			destination = map[string]any{}
+			base[tableName] = destination
+		}
+		for key, value := range table {
+			if _, exists := destination[key]; exists {
+				return die(fmt.Sprintf("injection policy fragments declare the same setting more than once: %s.%s (%s)", tableName, key, sourcePath))
+			}
+			destination[key] = value
+		}
+	}
+	if copiesRaw, ok := addition["copies"]; ok {
+		copies, ok := copiesRaw.([]any)
+		if !ok {
+			return die(fmt.Sprintf("injection policy fragment must keep copies as an array of tables: %s", sourcePath))
+		}
+		destinationCopies, _ := base["copies"].([]any)
+		destinationCopies = append(destinationCopies, copies...)
+		base["copies"] = destinationCopies
+	}
+	return nil
+}
+
+func loadPolicyBundle(policyPath string) (map[string]any, []PolicySource, error) {
+	resolvedPolicyPath, err := filepath.Abs(policyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	return loadPolicyBundleWithState(resolvedPolicyPath, "", nil, map[string]struct{}{})
+}
+
+func loadPolicyBundleWithState(policyPath string, entrypointRoot string, activeStack []string, loadedPaths map[string]struct{}) (map[string]any, []PolicySource, error) {
+	resolvedPolicyPath, err := filepath.Abs(policyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	if entrypointRoot == "" {
+		entrypointRoot = filepath.Dir(resolvedPolicyPath)
+	}
+	entrypointRoot, err = filepath.Abs(entrypointRoot)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, active := range activeStack {
+		if active == resolvedPolicyPath {
+			cycle := strings.Join(append(activeStack, resolvedPolicyPath), " -> ")
+			return nil, nil, die(fmt.Sprintf("injection policy include cycle detected: %s", cycle))
+		}
+	}
+	if _, ok := loadedPaths[resolvedPolicyPath]; ok {
+		return nil, nil, die(fmt.Sprintf("injection policy includes the same file more than once: %s", resolvedPolicyPath))
+	}
+	loadedPaths[resolvedPolicyPath] = struct{}{}
+
+	content, err := os.ReadFile(resolvedPolicyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	loaded, err := parseTOMLSubset(string(content), resolvedPolicyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := validateAllowedKeys(loaded, AllowedRootPolicyKeys, "root policy"); err != nil {
+		return nil, nil, err
+	}
+	version := 1
+	if rawVersion, ok := loaded["version"]; ok {
+		if value, ok := rawVersion.(int); ok {
+			version = value
+		}
+	}
+	if version != 1 {
+		return nil, nil, die(fmt.Sprintf("unsupported injection policy version: %d", version))
+	}
+	includesRaw, ok := loaded["includes"]
+	includes := []any{}
+	if ok && includesRaw != nil {
+		includes, ok = includesRaw.([]any)
+		if !ok {
+			return nil, nil, die("includes must be an array of strings when specified")
+		}
+	}
+	merged := map[string]any{"version": 1}
+	policySources := make([]PolicySource, 0)
+	nextStack := append(append([]string(nil), activeStack...), resolvedPolicyPath)
+	for index, include := range includes {
+		includePath, err := validatePolicyInclude(include, fmt.Sprintf("includes[%d]", index), filepath.Dir(resolvedPolicyPath), entrypointRoot)
+		if err != nil {
+			return nil, nil, err
+		}
+		includedPolicy, includedSources, err := loadPolicyBundleWithState(includePath, entrypointRoot, nextStack, loadedPaths)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := mergePolicyFragment(merged, includedPolicy, includePath); err != nil {
+			return nil, nil, err
+		}
+		policySources = append(policySources, includedSources...)
+	}
+
+	currentPolicy := clonePolicyMap(loaded)
+	delete(currentPolicy, "includes")
+	if len(activeStack) > 0 {
+		currentPolicy = rebasePolicyFragment(currentPolicy, filepath.Dir(resolvedPolicyPath))
+	}
+	if err := mergePolicyFragment(merged, currentPolicy, resolvedPolicyPath); err != nil {
+		return nil, nil, err
+	}
+	sourceSHA, err := policySHA256(resolvedPolicyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	logicalPath, err := logicalPolicyPath(resolvedPolicyPath, entrypointRoot)
+	if err != nil {
+		return nil, nil, err
+	}
+	policySources = append(policySources, PolicySource{
+		Path:   logicalPath,
+		SHA256: sourceSHA,
+	})
+	return merged, policySources, nil
+}
+
+func loadRawPolicy(policyPath string) (map[string]any, error) {
+	if _, err := os.Stat(policyPath); os.IsNotExist(err) {
+		return map[string]any{"version": 1}, nil
+	}
+	content, err := os.ReadFile(policyPath)
+	if err != nil {
+		return nil, err
+	}
+	loaded, err := parseTOMLSubset(string(content), policyPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateAllowedKeys(loaded, AllowedRootPolicyKeys, "root policy"); err != nil {
+		return nil, err
+	}
+	version := 1
+	if rawVersion, ok := loaded["version"]; ok {
+		if value, ok := rawVersion.(int); ok {
+			version = value
+		}
+	}
+	if version != 1 {
+		return nil, die(fmt.Sprintf("unsupported injection policy version: %d", version))
+	}
+	if _, ok := loaded["version"]; !ok {
+		loaded["version"] = 1
+	}
+	return loaded, nil
+}
+
+func clonePolicyMap(policy map[string]any) map[string]any {
+	cloned := map[string]any{}
+	for key, value := range policy {
+		cloned[key] = cloneValue(value)
+	}
+	return cloned
+}
+
+func cloneValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		cloned := map[string]any{}
+		for key, child := range typed {
+			cloned[key] = cloneValue(child)
+		}
+		return cloned
+	case []any:
+		cloned := make([]any, 0, len(typed))
+		for _, child := range typed {
+			cloned = append(cloned, cloneValue(child))
+		}
+		return cloned
+	default:
+		return typed
+	}
+}
+
+func renderTOMLValue(value any) (string, error) {
+	switch typed := value.(type) {
+	case bool:
+		if typed {
+			return "true", nil
+		}
+		return "false", nil
+	case int:
+		return strconv.Itoa(typed), nil
+	case string:
+		return jsonQuote(typed), nil
+	case []any:
+		items := make([]string, 0, len(typed))
+		for _, item := range typed {
+			s, ok := item.(string)
+			if !ok {
+				return "", die("only arrays of strings are supported in rendered policy output")
+			}
+			items = append(items, jsonQuote(s))
+		}
+		return "[" + strings.Join(items, ", ") + "]", nil
+	case []string:
+		items := make([]string, 0, len(typed))
+		for _, item := range typed {
+			items = append(items, jsonQuote(item))
+		}
+		return "[" + strings.Join(items, ", ") + "]", nil
+	default:
+		return "", die(fmt.Sprintf("unsupported TOML value type: %T", value))
+	}
+}
+
+func jsonQuote(value string) string {
+	escaped := strings.ReplaceAll(value, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	escaped = strings.ReplaceAll(escaped, "\n", `\n`)
+	return `"` + escaped + `"`
+}
+
+func renderPolicyTOML(policy map[string]any) (string, error) {
+	lines := make([]string, 0)
+	version := 1
+	if rawVersion, ok := policy["version"]; ok {
+		if value, ok := rawVersion.(int); ok {
+			version = value
+		}
+	}
+	renderedVersion, err := renderTOMLValue(version)
+	if err != nil {
+		return "", err
+	}
+	lines = append(lines, "version = "+renderedVersion)
+
+	if includes, ok := policy["includes"].([]any); ok && len(includes) > 0 {
+		renderedIncludes, err := renderTOMLValue(includes)
+		if err != nil {
+			return "", err
+		}
+		lines = append(lines, "includes = "+renderedIncludes)
+	}
+
+	if documents, ok := policy["documents"].(map[string]any); ok && len(documents) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, "[documents]")
+		for _, key := range []string{"common", "codex", "claude", "gemini"} {
+			if value, ok := documents[key]; ok {
+				rendered, err := renderTOMLValue(value)
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, key+" = "+rendered)
+			}
+		}
+	}
+
+	if credentials, ok := policy["credentials"].(map[string]any); ok && len(credentials) > 0 {
+		scalarEntries := map[string]any{}
+		for key, value := range credentials {
+			if _, ok := value.(map[string]any); !ok {
+				scalarEntries[key] = value
+			}
+		}
+		if len(scalarEntries) > 0 {
+			lines = append(lines, "")
+			lines = append(lines, "[credentials]")
+			keys := sortedKeys(scalarEntries)
+			for _, key := range keys {
+				rendered, err := renderTOMLValue(scalarEntries[key])
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, key+" = "+rendered)
+			}
+		}
+		keys := sortedKeys(credentials)
+		for _, key := range keys {
+			value := credentials[key]
+			valueMap, ok := value.(map[string]any)
+			if !ok {
+				continue
+			}
+			lines = append(lines, "")
+			lines = append(lines, "[credentials."+key+"]")
+			for _, field := range sortedKeys(valueMap) {
+				rendered, err := renderTOMLValue(valueMap[field])
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, field+" = "+rendered)
+			}
+		}
+	}
+
+	if ssh, ok := policy["ssh"].(map[string]any); ok && len(ssh) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, "[ssh]")
+		ordered := []string{"enabled", "config", "known_hosts", "identities", "providers", "modes", "allow_unsafe_config"}
+		orderedSet := map[string]struct{}{}
+		for _, key := range ordered {
+			orderedSet[key] = struct{}{}
+			if value, ok := ssh[key]; ok {
+				rendered, err := renderTOMLValue(value)
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, key+" = "+rendered)
+			}
+		}
+		extras := make([]string, 0)
+		for key := range ssh {
+			if _, ok := orderedSet[key]; !ok {
+				extras = append(extras, key)
+			}
+		}
+		sort.Strings(extras)
+		for _, key := range extras {
+			rendered, err := renderTOMLValue(ssh[key])
+			if err != nil {
+				return "", err
+			}
+			lines = append(lines, key+" = "+rendered)
+		}
+	}
+
+	if copies, ok := policy["copies"].([]any); ok && len(copies) > 0 {
+		for _, entry := range copies {
+			entryMap, ok := entry.(map[string]any)
+			if !ok {
+				return "", die("copies entries must be TOML tables when rendering policy output")
+			}
+			lines = append(lines, "")
+			lines = append(lines, "[[copies]]")
+			for _, key := range []string{"source", "target", "classification", "providers", "modes"} {
+				if value, ok := entryMap[key]; ok {
+					rendered, err := renderTOMLValue(value)
+					if err != nil {
+						return "", err
+					}
+					lines = append(lines, key+" = "+rendered)
+				}
+			}
+			extras := make([]string, 0)
+			for key := range entryMap {
+				if key == "source" || key == "target" || key == "classification" || key == "providers" || key == "modes" {
+					continue
+				}
+				extras = append(extras, key)
+			}
+			sort.Strings(extras)
+			for _, key := range extras {
+				rendered, err := renderTOMLValue(entryMap[key])
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, key+" = "+rendered)
+			}
+		}
+	}
+
+	return strings.Join(lines, "\n") + "\n", nil
+}
+
+func writePolicyFile(policyPath string, policy map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(policyPath), 0o755); err != nil {
+		return err
+	}
+	rendered, err := renderPolicyTOML(policy)
+	if err != nil {
+		return err
+	}
+	parentRoot, err := os.OpenRoot(filepath.Dir(policyPath))
+	if err != nil {
+		return err
+	}
+	defer parentRoot.Close()
+	return rootio.WriteFileAtomic(parentRoot, filepath.Base(policyPath), []byte(rendered), 0o600, ".workcell-policy-")
+}
+
+func requireSecretFile(source string, label string) (string, error) {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", die(fmt.Sprintf("%s must not be a symlink: %s", label, source))
+	}
+	if !info.Mode().IsRegular() {
+		return "", die(fmt.Sprintf("%s must point at a file: %s", label, source))
+	}
+	statT, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", fmt.Errorf("unexpected stat type")
+	}
+	if int(statT.Uid) != os.Getuid() {
+		return "", die(fmt.Sprintf("%s must be owned by uid %d: %s", label, os.Getuid(), source))
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return "", die(fmt.Sprintf("%s must not be group/world-accessible: %s", label, source))
+	}
+	return source, nil
+}
+
+func resolvePathLikePython(raw string) (string, error) {
+	expanded, err := expandUserPath(raw)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(expanded) {
+		expanded, err = filepath.Abs(expanded)
+		if err != nil {
+			return "", err
+		}
+	}
+	clean := filepath.Clean(expanded)
+	if clean == string(filepath.Separator) {
+		return clean, nil
+	}
+	existing := clean
+	suffix := make([]string, 0)
+	for {
+		if _, err := os.Lstat(existing); err == nil {
+			break
+		}
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			return clean, nil
+		}
+		suffix = append([]string{filepath.Base(existing)}, suffix...)
+		existing = parent
+	}
+	resolvedExisting, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		return "", err
+	}
+	if len(suffix) == 0 {
+		return filepath.Clean(resolvedExisting), nil
+	}
+	parts := append([]string{resolvedExisting}, suffix...)
+	return filepath.Clean(filepath.Join(parts...)), nil
+}
+
+func pathsEquivalent(left string, right string) bool {
+	leftResolved, errLeft := resolvePathLikePython(left)
+	rightResolved, errRight := resolvePathLikePython(right)
+	if errLeft != nil || errRight != nil {
+		return left == right
+	}
+	return leftResolved == rightResolved
+}
+
+func sortedKeys(value map[string]any) []string {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/authresolve/resolve_credential_sources.go
+++ b/internal/authresolve/resolve_credential_sources.go
@@ -1,0 +1,1397 @@
+package authresolve
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/omkhar/workcell/internal/rootio"
+)
+
+const testClaudeExportEnv = "WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE"
+
+var (
+	supportedAgents = map[string]struct{}{
+		"codex":  {},
+		"claude": {},
+		"gemini": {},
+	}
+	supportedModes = map[string]struct{}{
+		"strict":     {},
+		"build":      {},
+		"breakglass": {},
+	}
+	supportedMaterialization = map[string]struct{}{
+		"ephemeral":  {},
+		"persistent": {},
+	}
+	allowedResolvers = map[string]map[string]struct{}{
+		"claude_auth": {
+			"claude-macos-keychain": {},
+		},
+	}
+	sharedCredentialKeys = map[string]struct{}{
+		"github_hosts":  {},
+		"github_config": {},
+	}
+	agentScopedCredentialKeys = map[string]map[string]struct{}{
+		"codex": {
+			"codex_auth": {},
+		},
+		"claude": {
+			"claude_api_key": {},
+			"claude_auth":    {},
+			"claude_mcp":     {},
+		},
+		"gemini": {
+			"gemini_env":      {},
+			"gemini_oauth":    {},
+			"gemini_projects": {},
+			"gcloud_adc":      {},
+		},
+	}
+	allCredentialKeys = map[string]struct{}{
+		"codex_auth":      {},
+		"claude_auth":     {},
+		"claude_api_key":  {},
+		"claude_mcp":      {},
+		"gemini_env":      {},
+		"gemini_oauth":    {},
+		"gemini_projects": {},
+		"gcloud_adc":      {},
+		"github_hosts":    {},
+		"github_config":   {},
+	}
+	rootPolicyKeys = map[string]struct{}{
+		"version":     {},
+		"includes":    {},
+		"documents":   {},
+		"ssh":         {},
+		"copies":      {},
+		"credentials": {},
+	}
+	credentialEntryKeys = map[string]struct{}{
+		"source":          {},
+		"resolver":        {},
+		"materialization": {},
+		"providers":       {},
+		"modes":           {},
+	}
+	systemSymlinkAllowlist = func() map[string]struct{} {
+		if runtime.GOOS == "darwin" {
+			return map[string]struct{}{
+				"/var": {},
+				"/tmp": {},
+			}
+		}
+		return map[string]struct{}{}
+	}()
+)
+
+// PolicySource mirrors the metadata emitted by the Python helper.
+type PolicySource struct {
+	Path   string `json:"path"`
+	Sha256 string `json:"sha256"`
+}
+
+type config struct {
+	policyPath     string
+	agent          string
+	mode           string
+	resolutionMode string
+	outputPolicy   string
+	outputMetadata string
+	outputRoot     string
+}
+
+// Run executes the resolve-credential-sources workflow.
+func Run(args []string, stdout, stderr io.Writer) int {
+	cfg, err := parseArgs(args)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	if err := run(cfg); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func parseArgs(args []string) (config, error) {
+	var cfg config
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "--") {
+			return config{}, fmt.Errorf("unexpected argument: %s", arg)
+		}
+		if i+1 >= len(args) {
+			return config{}, fmt.Errorf("missing value for %s", arg)
+		}
+		value := args[i+1]
+		i++
+		switch arg {
+		case "--policy":
+			cfg.policyPath = value
+		case "--agent":
+			cfg.agent = value
+		case "--mode":
+			cfg.mode = value
+		case "--resolution-mode":
+			cfg.resolutionMode = value
+		case "--output-policy":
+			cfg.outputPolicy = value
+		case "--output-metadata":
+			cfg.outputMetadata = value
+		case "--output-root":
+			cfg.outputRoot = value
+		default:
+			return config{}, fmt.Errorf("unsupported flag: %s", arg)
+		}
+	}
+
+	if cfg.policyPath == "" {
+		return config{}, errors.New("--policy is required")
+	}
+	if cfg.agent == "" {
+		return config{}, errors.New("--agent is required")
+	}
+	if cfg.mode == "" {
+		return config{}, errors.New("--mode is required")
+	}
+	if cfg.resolutionMode == "" {
+		return config{}, errors.New("--resolution-mode is required")
+	}
+	if cfg.outputPolicy == "" {
+		return config{}, errors.New("--output-policy is required")
+	}
+	if cfg.outputMetadata == "" {
+		return config{}, errors.New("--output-metadata is required")
+	}
+	if cfg.outputRoot == "" {
+		return config{}, errors.New("--output-root is required")
+	}
+	if _, ok := supportedAgents[cfg.agent]; !ok {
+		return config{}, fmt.Errorf("unsupported value for --agent: %s", cfg.agent)
+	}
+	if _, ok := supportedModes[cfg.mode]; !ok {
+		return config{}, fmt.Errorf("unsupported value for --mode: %s", cfg.mode)
+	}
+	if cfg.resolutionMode != "launch" && cfg.resolutionMode != "metadata" {
+		return config{}, fmt.Errorf("unsupported value for --resolution-mode: %s", cfg.resolutionMode)
+	}
+	return cfg, nil
+}
+
+func run(cfg config) error {
+	policyPath, err := resolvePath(cfg.policyPath)
+	if err != nil {
+		return err
+	}
+	outputPolicyPath, err := resolvePath(cfg.outputPolicy)
+	if err != nil {
+		return err
+	}
+	outputMetadataPath, err := resolvePath(cfg.outputMetadata)
+	if err != nil {
+		return err
+	}
+	outputRoot, err := resolvePath(cfg.outputRoot)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(outputRoot, 0o700); err != nil {
+		return err
+	}
+	if err := os.Chmod(outputRoot, 0o700); err != nil {
+		return err
+	}
+	outputPolicyRel, err := rootio.RelativePathWithin(outputRoot, outputPolicyPath, "--output-policy")
+	if err != nil {
+		return err
+	}
+	outputMetadataRel, err := rootio.RelativePathWithin(outputRoot, outputMetadataPath, "--output-metadata")
+	if err != nil {
+		return err
+	}
+	outputRootFS, err := os.OpenRoot(outputRoot)
+	if err != nil {
+		return err
+	}
+	defer outputRootFS.Close()
+
+	policy, policySources, err := loadPolicyBundle(policyPath)
+	if err != nil {
+		return err
+	}
+	policy = rebasePolicyFragment(policy, filepath.Dir(policyPath))
+	credentials, ok := policy["credentials"]
+	if credentials == nil {
+		credentials = map[string]any{}
+		ok = true
+	}
+	if !ok {
+		return errors.New("credentials must be a TOML table")
+	}
+	credentialTable, ok := credentials.(map[string]any)
+	if !ok {
+		return errors.New("credentials must be a TOML table")
+	}
+
+	relevantKeys := selectedCredentialKeys(cfg.agent)
+	metadata := map[string]any{
+		"policy_entrypoint":            logicalPolicyPath(policyPath, filepath.Dir(policyPath)),
+		"policy_sources":               policySources,
+		"credential_input_kinds":       map[string]string{},
+		"credential_resolvers":         map[string]string{},
+		"credential_materialization":   map[string]string{},
+		"credential_resolution_states": map[string]string{},
+	}
+
+	for _, key := range relevantKeys {
+		raw, exists := credentialTable[key]
+		if !exists || raw == nil {
+			continue
+		}
+
+		rawMap, isMap := raw.(map[string]any)
+		if !isMap {
+			metadata["credential_input_kinds"].(map[string]string)[key] = "source"
+			metadata["credential_resolution_states"].(map[string]string)[key] = "source"
+			continue
+		}
+
+		if err := validateAllowedKeys(rawMap, credentialEntryKeys, "credentials."+key); err != nil {
+			return err
+		}
+		resolverName, _ := rawMap["resolver"].(string)
+		providers := rawMap["providers"]
+		modes := rawMap["modes"]
+
+		ok, err := selectedFor(providers, cfg.agent, "credentials."+key+".providers", supportedAgents)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			if resolverName != "" {
+				delete(credentialTable, key)
+			}
+			continue
+		}
+		ok, err = selectedFor(modes, cfg.mode, "credentials."+key+".modes", supportedModes)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			if resolverName != "" {
+				delete(credentialTable, key)
+			}
+			continue
+		}
+
+		_, hasSource := rawMap["source"]
+		if hasSource && resolverName != "" {
+			return fmt.Errorf("credentials.%s must not declare both source and resolver", key)
+		}
+		if !hasSource && resolverName == "" {
+			return fmt.Errorf("credentials.%s must declare source or resolver", key)
+		}
+		if resolverName == "" {
+			metadata["credential_input_kinds"].(map[string]string)[key] = "source"
+			metadata["credential_resolution_states"].(map[string]string)[key] = "source"
+			continue
+		}
+
+		resolverSet, ok := allowedResolvers[key]
+		if !ok {
+			return fmt.Errorf("credentials.%s.resolver is unsupported: %s", key, resolverName)
+		}
+		if _, ok := resolverSet[resolverName]; !ok {
+			return fmt.Errorf("credentials.%s.resolver is unsupported: %s", key, resolverName)
+		}
+
+		materialization := "ephemeral"
+		if rawMaterialization, ok := rawMap["materialization"].(string); ok && rawMaterialization != "" {
+			materialization = rawMaterialization
+		}
+		if _, ok := supportedMaterialization[materialization]; !ok {
+			return fmt.Errorf(
+				"credentials.%s.materialization must be one of: ephemeral, persistent",
+				key,
+			)
+		}
+		if materialization != "ephemeral" {
+			return fmt.Errorf(
+				"credentials.%s.materialization must stay ephemeral for resolver-backed auth",
+				key,
+			)
+		}
+
+		relativeDestination := filepath.Join("resolved", "credentials", key+".json")
+		destination := filepath.Join(outputRoot, relativeDestination)
+		state, err := resolveCredential(key, resolverName, outputRootFS, relativeDestination, cfg.resolutionMode)
+		if err != nil {
+			return err
+		}
+
+		rewritten := make(map[string]any, len(rawMap))
+		for k, v := range rawMap {
+			rewritten[k] = v
+		}
+		delete(rewritten, "resolver")
+		delete(rewritten, "materialization")
+		rewritten["source"] = destination
+		credentialTable[key] = rewritten
+
+		metadata["credential_input_kinds"].(map[string]string)[key] = "resolver"
+		metadata["credential_resolvers"].(map[string]string)[key] = resolverName
+		metadata["credential_materialization"].(map[string]string)[key] = materialization
+		metadata["credential_resolution_states"].(map[string]string)[key] = state
+	}
+
+	renderedPolicy, err := renderPolicyTOML(policy)
+	if err != nil {
+		return err
+	}
+	if err := writeAtomicText(outputRootFS, outputPolicyRel, renderedPolicy); err != nil {
+		return err
+	}
+	metadataJSON, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := writeAtomicText(outputRootFS, outputMetadataRel, string(metadataJSON)+"\n"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func selectedCredentialKeys(agent string) []string {
+	keys := make([]string, 0, len(sharedCredentialKeys)+len(agentScopedCredentialKeys[agent]))
+	for key := range sharedCredentialKeys {
+		keys = append(keys, key)
+	}
+	for key := range agentScopedCredentialKeys[agent] {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func resolveCredential(key, resolverName string, outputRoot *os.Root, relativeDestination, resolutionMode string) (string, error) {
+	if key == "claude_auth" && resolverName == "claude-macos-keychain" {
+		return resolveClaudeMacosKeychain(outputRoot, relativeDestination, resolutionMode)
+	}
+	return "", fmt.Errorf("unsupported credential resolver: %s", resolverName)
+}
+
+func resolveClaudeMacosKeychain(outputRoot *os.Root, relativeDestination, resolutionMode string) (string, error) {
+	if exportPath := os.Getenv(testClaudeExportEnv); exportPath != "" {
+		source, err := validateSourcePath(exportPath, testClaudeExportEnv, cwd())
+		if err != nil {
+			return "", err
+		}
+		source, err = requireSecretFile(source, testClaudeExportEnv)
+		if err != nil {
+			return "", err
+		}
+		if err := materializeFileUnderRoot(source, outputRoot, relativeDestination); err != nil {
+			return "", err
+		}
+		return "resolved", nil
+	}
+	if resolutionMode == "metadata" {
+		if err := writePlaceholderUnderRoot(outputRoot, relativeDestination, "claude-macos-keychain"); err != nil {
+			return "", err
+		}
+		return "configured-only", nil
+	}
+	return "", errors.New("Claude macOS login reuse is configured but no supported export path is available. Use claude_api_key or remove credentials.claude_auth.")
+}
+
+func materializeFileUnderRoot(source string, outputRoot *os.Root, relativeDestination string) error {
+	sourceHandle, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer sourceHandle.Close()
+	return rootio.WriteFileAtomicFromReader(outputRoot, relativeDestination, sourceHandle, 0o600, ".workcell-resolve-")
+}
+
+func writePlaceholderUnderRoot(outputRoot *os.Root, relativeDestination, resolver string) error {
+	content := fmt.Sprintf(`{"resolver": %q, "workcell": %q}`+"\n", resolver, "metadata-only")
+	return rootio.WriteFileAtomic(outputRoot, relativeDestination, []byte(content), 0o600, ".workcell-write-")
+}
+
+func writeAtomicText(outputRoot *os.Root, destination, content string) error {
+	return rootio.WriteFileAtomic(outputRoot, destination, []byte(content), 0o600, ".workcell-write-")
+}
+
+func renderPolicyTOML(policy map[string]any) (string, error) {
+	lines := []string{}
+
+	version := policy["version"]
+	if version == nil {
+		version = 1
+	}
+	renderedVersion, err := renderTOMLValue(version)
+	if err != nil {
+		return "", err
+	}
+	lines = append(lines, "version = "+renderedVersion)
+
+	if includes := policy["includes"]; includes != nil {
+		if nonEmpty, ok := includesNonEmpty(includes); !ok || !nonEmpty {
+			goto documents
+		}
+		renderedIncludes, err := renderTOMLValue(includes)
+		if err != nil {
+			return "", err
+		}
+		lines = append(lines, "includes = "+renderedIncludes)
+	}
+
+documents:
+	if documents, ok := policy["documents"].(map[string]any); ok && len(documents) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, "[documents]")
+		for _, key := range []string{"common", "codex", "claude", "gemini"} {
+			if value, ok := documents[key]; ok {
+				rendered, err := renderTOMLValue(value)
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, key+" = "+rendered)
+			}
+		}
+	}
+
+	if credentials, ok := policy["credentials"].(map[string]any); ok && len(credentials) > 0 {
+		scalarEntries := map[string]any{}
+		for key, value := range credentials {
+			if _, ok := value.(map[string]any); !ok {
+				scalarEntries[key] = value
+			}
+		}
+		if len(scalarEntries) > 0 {
+			lines = append(lines, "")
+			lines = append(lines, "[credentials]")
+			keys := sortedKeys(scalarEntries)
+			for _, key := range keys {
+				rendered, err := renderTOMLValue(scalarEntries[key])
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, key+" = "+rendered)
+			}
+		}
+		keys := sortedKeys(credentials)
+		for _, key := range keys {
+			value := credentials[key]
+			valueMap, ok := value.(map[string]any)
+			if !ok {
+				continue
+			}
+			lines = append(lines, "")
+			lines = append(lines, "[credentials."+key+"]")
+			for _, field := range sortedKeys(valueMap) {
+				rendered, err := renderTOMLValue(valueMap[field])
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, field+" = "+rendered)
+			}
+		}
+	}
+
+	if ssh, ok := policy["ssh"].(map[string]any); ok && len(ssh) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, "[ssh]")
+		ordered := []string{"enabled", "config", "known_hosts", "identities", "providers", "modes", "allow_unsafe_config"}
+		seen := map[string]struct{}{}
+		for _, key := range ordered {
+			if value, ok := ssh[key]; ok {
+				rendered, err := renderTOMLValue(value)
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, key+" = "+rendered)
+				seen[key] = struct{}{}
+			}
+		}
+		for _, key := range sortedKeys(ssh) {
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			rendered, err := renderTOMLValue(ssh[key])
+			if err != nil {
+				return "", err
+			}
+			lines = append(lines, key+" = "+rendered)
+		}
+	}
+
+	if copies, ok := policy["copies"].([]any); ok && len(copies) > 0 {
+		for _, entry := range copies {
+			entryMap, ok := entry.(map[string]any)
+			if !ok {
+				return "", errors.New("copies entries must be TOML tables when rendering policy output")
+			}
+			lines = append(lines, "")
+			lines = append(lines, "[[copies]]")
+			ordered := []string{"source", "target", "classification", "providers", "modes"}
+			seen := map[string]struct{}{}
+			for _, key := range ordered {
+				if value, ok := entryMap[key]; ok {
+					rendered, err := renderTOMLValue(value)
+					if err != nil {
+						return "", err
+					}
+					lines = append(lines, key+" = "+rendered)
+					seen[key] = struct{}{}
+				}
+			}
+			for _, key := range sortedKeys(entryMap) {
+				if _, ok := seen[key]; ok {
+					continue
+				}
+				rendered, err := renderTOMLValue(entryMap[key])
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, key+" = "+rendered)
+			}
+		}
+	}
+
+	return strings.Join(lines, "\n") + "\n", nil
+}
+
+func renderTOMLValue(value any) (string, error) {
+	switch v := value.(type) {
+	case bool:
+		if v {
+			return "true", nil
+		}
+		return "false", nil
+	case int:
+		return strconv.Itoa(v), nil
+	case string:
+		return jsonQuote(v), nil
+	case []string:
+		items := make([]string, 0, len(v))
+		for _, item := range v {
+			items = append(items, jsonQuote(item))
+		}
+		return "[" + strings.Join(items, ", ") + "]", nil
+	case []any:
+		items := make([]string, 0, len(v))
+		for _, item := range v {
+			str, ok := item.(string)
+			if !ok {
+				return "", errors.New("only arrays of strings are supported in rendered policy output")
+			}
+			items = append(items, jsonQuote(str))
+		}
+		return "[" + strings.Join(items, ", ") + "]", nil
+	default:
+		return "", fmt.Errorf("unsupported TOML value type: %T", value)
+	}
+}
+
+func jsonQuote(value string) string {
+	escaped := strings.ReplaceAll(value, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	escaped = strings.ReplaceAll(escaped, "\n", `\n`)
+	return `"` + escaped + `"`
+}
+
+func includesNonEmpty(value any) (bool, bool) {
+	switch v := value.(type) {
+	case []string:
+		return len(v) > 0, true
+	case []any:
+		return len(v) > 0, true
+	default:
+		return false, false
+	}
+}
+
+func sortedKeys(value map[string]any) []string {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func loadPolicyBundle(policyPath string) (map[string]any, []PolicySource, error) {
+	resolvedPolicyPath := filepath.Clean(policyPath)
+	entrypointRoot := filepath.Dir(resolvedPolicyPath)
+	return loadPolicyBundleRecursive(resolvedPolicyPath, entrypointRoot, nil, map[string]struct{}{})
+}
+
+func loadPolicyBundleRecursive(policyPath, entrypointRoot string, activeStack []string, loadedPaths map[string]struct{}) (map[string]any, []PolicySource, error) {
+	if containsPath(activeStack, policyPath) {
+		cycle := append(append([]string{}, activeStack...), policyPath)
+		return nil, nil, fmt.Errorf("injection policy include cycle detected: %s", strings.Join(cycle, " -> "))
+	}
+	if _, ok := loadedPaths[policyPath]; ok {
+		return nil, nil, fmt.Errorf("injection policy includes the same file more than once: %s", policyPath)
+	}
+	loadedPaths[policyPath] = struct{}{}
+
+	content, err := os.ReadFile(policyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	loaded, err := parseTOMLSubset(string(content), policyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := validateAllowedKeys(loaded, rootPolicyKeys, "root policy"); err != nil {
+		return nil, nil, err
+	}
+
+	version := loaded["version"]
+	if version == nil {
+		version = 1
+	}
+	if version != 1 {
+		return nil, nil, fmt.Errorf("unsupported injection policy version: %v", version)
+	}
+
+	includes := loaded["includes"]
+	if includes == nil {
+		includes = []any{}
+	}
+	includeList, ok := includes.([]any)
+	if !ok {
+		return nil, nil, errors.New("includes must be an array of strings when specified")
+	}
+
+	merged := map[string]any{"version": 1}
+	var policySources []PolicySource
+	nextStack := append(append([]string{}, activeStack...), policyPath)
+	for idx, include := range includeList {
+		includePath, err := validatePolicyInclude(include, fmt.Sprintf("includes[%d]", idx), filepath.Dir(policyPath), entrypointRoot)
+		if err != nil {
+			return nil, nil, err
+		}
+		includedPolicy, includedSources, err := loadPolicyBundleRecursive(includePath, entrypointRoot, nextStack, loadedPaths)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := mergePolicyFragment(merged, includedPolicy, includePath); err != nil {
+			return nil, nil, err
+		}
+		policySources = append(policySources, includedSources...)
+	}
+
+	currentPolicy := cloneMap(loaded)
+	delete(currentPolicy, "includes")
+	if len(activeStack) > 0 {
+		currentPolicy = rebasePolicyFragment(currentPolicy, filepath.Dir(policyPath))
+	}
+	if err := mergePolicyFragment(merged, currentPolicy, policyPath); err != nil {
+		return nil, nil, err
+	}
+	policySources = append(policySources, PolicySource{
+		Path:   logicalPolicyPath(policyPath, entrypointRoot),
+		Sha256: policySHA256(policyPath),
+	})
+	return merged, policySources, nil
+}
+
+func policySHA256(policyPath string) string {
+	data, err := os.ReadFile(policyPath)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + fmt.Sprintf("%x", sum[:])
+}
+
+func validatePolicyInclude(raw any, label, base, entrypointRoot string) (string, error) {
+	source, err := validateSourcePath(raw, label, base)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("%s must point at a file: %s", label, source)
+	}
+	if err := requirePathWithin(entrypointRoot, source, label); err != nil {
+		return "", err
+	}
+	return source, nil
+}
+
+func mergePolicyFragment(base, addition map[string]any, sourcePath string) error {
+	version := addition["version"]
+	if version == nil {
+		version = 1
+	}
+	if version != 1 {
+		return fmt.Errorf("unsupported injection policy version: %v", version)
+	}
+
+	for _, tableName := range []string{"documents", "ssh", "credentials"} {
+		table := addition[tableName]
+		if table == nil {
+			continue
+		}
+		tableMap, ok := table.(map[string]any)
+		if !ok {
+			return fmt.Errorf("injection policy fragment must keep %s as a table: %s", tableName, sourcePath)
+		}
+		dest, ok := base[tableName]
+		if !ok {
+			dest = map[string]any{}
+			base[tableName] = dest
+		}
+		destMap, ok := dest.(map[string]any)
+		if !ok {
+			return fmt.Errorf("injection policy merge corrupted %s: %s", tableName, sourcePath)
+		}
+		for key, value := range tableMap {
+			if _, exists := destMap[key]; exists {
+				return fmt.Errorf(
+					"injection policy fragments declare the same setting more than once: %s.%s (%s)",
+					tableName, key, sourcePath,
+				)
+			}
+			destMap[key] = value
+		}
+	}
+
+	copies := addition["copies"]
+	if copies == nil {
+		return nil
+	}
+	copyList, ok := copies.([]any)
+	if !ok {
+		return fmt.Errorf("injection policy fragment must keep copies as an array of tables: %s", sourcePath)
+	}
+	dest, ok := base["copies"]
+	if !ok {
+		dest = []any{}
+		base["copies"] = dest
+	}
+	destList, ok := dest.([]any)
+	if !ok {
+		return fmt.Errorf("injection policy merge corrupted copies: %s", sourcePath)
+	}
+	base["copies"] = append(destList, copyList...)
+	return nil
+}
+
+func loadRawPolicy(policyPath string) (map[string]any, error) {
+	if _, err := os.Stat(policyPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]any{"version": 1}, nil
+		}
+		return nil, err
+	}
+	content, err := os.ReadFile(policyPath)
+	if err != nil {
+		return nil, err
+	}
+	loaded, err := parseTOMLSubset(string(content), policyPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateAllowedKeys(loaded, rootPolicyKeys, "root policy"); err != nil {
+		return nil, err
+	}
+	version := loaded["version"]
+	if version == nil {
+		loaded["version"] = 1
+		return loaded, nil
+	}
+	if version != 1 {
+		return nil, fmt.Errorf("unsupported injection policy version: %v", version)
+	}
+	return loaded, nil
+}
+
+func rebasePolicyFragment(policy map[string]any, fragmentDir string) map[string]any {
+	rebased := map[string]any{}
+	for key, value := range policy {
+		switch key {
+		case "documents":
+			if table, ok := value.(map[string]any); ok {
+				rebasedDocs := map[string]any{}
+				for docKey, docValue := range table {
+					rebasedDocs[docKey] = rebaseFragmentPath(docValue, fragmentDir)
+				}
+				rebased[key] = rebasedDocs
+				continue
+			}
+		case "copies":
+			if copies, ok := value.([]any); ok {
+				rebasedCopies := make([]any, 0, len(copies))
+				for _, entry := range copies {
+					entryMap, ok := entry.(map[string]any)
+					if !ok {
+						rebasedCopies = append(rebasedCopies, entry)
+						continue
+					}
+					rebasedEntry := cloneMap(entryMap)
+					if source, ok := rebasedEntry["source"]; ok {
+						rebasedEntry["source"] = rebaseFragmentPath(source, fragmentDir)
+					}
+					rebasedCopies = append(rebasedCopies, rebasedEntry)
+				}
+				rebased[key] = rebasedCopies
+				continue
+			}
+		case "ssh":
+			if table, ok := value.(map[string]any); ok {
+				rebasedSSH := cloneMap(table)
+				for _, sshKey := range []string{"config", "known_hosts"} {
+					if sshValue, ok := rebasedSSH[sshKey]; ok {
+						rebasedSSH[sshKey] = rebaseFragmentPath(sshValue, fragmentDir)
+					}
+				}
+				if identities, ok := rebasedSSH["identities"].([]any); ok {
+					rebasedIDs := make([]any, 0, len(identities))
+					for _, identity := range identities {
+						rebasedIDs = append(rebasedIDs, rebaseFragmentPath(identity, fragmentDir))
+					}
+					rebasedSSH["identities"] = rebasedIDs
+				}
+				rebased[key] = rebasedSSH
+				continue
+			}
+		case "credentials":
+			if table, ok := value.(map[string]any); ok {
+				rebasedCreds := map[string]any{}
+				for credKey, credValue := range table {
+					if credMap, ok := credValue.(map[string]any); ok {
+						rebasedCred := cloneMap(credMap)
+						if source, ok := rebasedCred["source"]; ok {
+							rebasedCred["source"] = rebaseFragmentPath(source, fragmentDir)
+						}
+						rebasedCreds[credKey] = rebasedCred
+						continue
+					}
+					rebasedCreds[credKey] = rebaseFragmentPath(credValue, fragmentDir)
+				}
+				rebased[key] = rebasedCreds
+				continue
+			}
+		}
+		rebased[key] = value
+	}
+	return rebased
+}
+
+func rebaseFragmentPath(raw any, fragmentDir string) any {
+	str, ok := raw.(string)
+	if !ok || str == "" {
+		return raw
+	}
+	return expandHostPath(str, fragmentDir)
+}
+
+func validateSourcePath(raw any, label, base string) (string, error) {
+	str, ok := raw.(string)
+	if !ok || str == "" {
+		return "", fmt.Errorf("%s must be a non-empty string path", label)
+	}
+	source := expandHostPath(str, base)
+	if _, err := os.Stat(source); err != nil {
+		return "", fmt.Errorf("%s does not exist: %s", label, source)
+	}
+	if err := requireNoSymlinkInPathChain(source, label); err != nil {
+		return "", err
+	}
+	return source, nil
+}
+
+func requirePathWithin(root, candidate, label string) error {
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		resolvedRoot, err = filepath.Abs(root)
+		if err != nil {
+			return err
+		}
+	}
+	resolvedCandidate, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		resolvedCandidate, err = filepath.Abs(candidate)
+		if err != nil {
+			return err
+		}
+	}
+	rel, err := filepath.Rel(resolvedRoot, resolvedCandidate)
+	if err != nil {
+		return err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("%s must stay within %s: %s", label, resolvedRoot, resolvedCandidate)
+	}
+	return nil
+}
+
+func requireNoSymlink(path, label string) error {
+	if _, err := os.Lstat(path); err != nil {
+		return err
+	}
+	if fi, err := os.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s must not be a symlink: %s", label, path)
+	}
+	return nil
+}
+
+func requireNoSymlinkInPathChain(path, label string) error {
+	current := path
+	for {
+		fi, err := os.Lstat(current)
+		if err != nil {
+			return err
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			if _, allowed := systemSymlinkAllowlist[current]; !allowed {
+				return fmt.Errorf("%s must not be a symlink: %s", label, current)
+			}
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
+}
+
+func requireSecretFile(source, label string) (string, error) {
+	fi, err := os.Lstat(source)
+	if err != nil {
+		return "", err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("%s must not be a symlink: %s", label, source)
+	}
+	if !fi.Mode().IsRegular() {
+		return "", fmt.Errorf("%s must point at a file: %s", label, source)
+	}
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", fmt.Errorf("%s metadata unavailable: %s", label, source)
+	}
+	if int(stat.Uid) != os.Getuid() {
+		return "", fmt.Errorf("%s must be owned by uid %d: %s", label, os.Getuid(), source)
+	}
+	if fi.Mode().Perm()&0o077 != 0 {
+		return "", fmt.Errorf("%s must not be group/world-accessible: %s", label, source)
+	}
+	return source, nil
+}
+
+func parseTOMLSubset(content, policyPath string) (map[string]any, error) {
+	root := map[string]any{}
+	current := root
+	seenTables := map[string]struct{}{}
+
+	for lineno, rawLine := range strings.Split(content, "\n") {
+		line := stripComment(rawLine)
+		if line == "" {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[[") && strings.HasSuffix(line, "]]") {
+			tableName := strings.TrimSpace(line[2 : len(line)-2])
+			if tableName != "copies" {
+				return nil, fmt.Errorf("%s:%d: unsupported array-of-table [%s]", policyPath, lineno+1, tableName)
+			}
+			copies, _ := root["copies"].([]any)
+			entry := map[string]any{}
+			root["copies"] = append(copies, entry)
+			current = entry
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			tableName := strings.TrimSpace(line[1 : len(line)-1])
+			if _, exists := seenTables[tableName]; exists {
+				return nil, fmt.Errorf("%s:%d: duplicate table [%s]", policyPath, lineno+1, tableName)
+			}
+			seenTables[tableName] = struct{}{}
+
+			if strings.HasPrefix(tableName, "credentials.") {
+				credentialKey := strings.SplitN(tableName, ".", 2)[1]
+				if _, ok := allCredentialKeys[credentialKey]; !ok {
+					return nil, fmt.Errorf("%s:%d: unsupported credentials table [%s]", policyPath, lineno+1, tableName)
+				}
+				credentials, _ := root["credentials"].(map[string]any)
+				if credentials == nil {
+					credentials = map[string]any{}
+					root["credentials"] = credentials
+				}
+				entry, _ := credentials[credentialKey].(map[string]any)
+				if entry == nil {
+					entry = map[string]any{}
+					credentials[credentialKey] = entry
+				}
+				current = entry
+				continue
+			}
+
+			if tableName != "documents" && tableName != "ssh" && tableName != "credentials" {
+				return nil, fmt.Errorf("%s:%d: unsupported table [%s]", policyPath, lineno+1, tableName)
+			}
+			table, _ := root[tableName].(map[string]any)
+			if table == nil {
+				table = map[string]any{}
+				root[tableName] = table
+			}
+			current = table
+			continue
+		}
+
+		if !strings.Contains(line, "=") {
+			return nil, fmt.Errorf("%s:%d: expected key = value", policyPath, lineno+1)
+		}
+
+		key, value, _ := strings.Cut(line, "=")
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("%s:%d: empty key", policyPath, lineno+1)
+		}
+		if strings.Contains(key, ".") {
+			return nil, fmt.Errorf("%s:%d: dotted TOML keys are not supported; use explicit [table] headers instead", policyPath, lineno+1)
+		}
+		if _, exists := current[key]; exists {
+			return nil, fmt.Errorf("%s:%d: duplicate key: %s", policyPath, lineno+1, key)
+		}
+
+		parsed, err := parseValue(value, policyPath, lineno+1)
+		if err != nil {
+			return nil, err
+		}
+		current[key] = parsed
+	}
+
+	return root, nil
+}
+
+func parseValue(raw, policyPath string, lineno int) (any, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return nil, fmt.Errorf("%s:%d: expected a value", policyPath, lineno)
+	}
+	if value == "true" || value == "false" {
+		return value == "true", nil
+	}
+	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+		return strconv.Unquote(value)
+	}
+	if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+		parsed, err := parseStringArray(value)
+		if err != nil {
+			return nil, fmt.Errorf("%s:%d: %v", policyPath, lineno, err)
+		}
+		return parsed, nil
+	}
+	if isDigits(value) {
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			return nil, err
+		}
+		return n, nil
+	}
+	return nil, fmt.Errorf("%s:%d: unsupported TOML value; use quoted strings, booleans, integers, or arrays of strings", policyPath, lineno)
+}
+
+func parseStringArray(raw string) ([]string, error) {
+	inner := strings.TrimSpace(raw[1 : len(raw)-1])
+	if inner == "" {
+		return []string{}, nil
+	}
+	values := []string{}
+	for i := 0; i < len(inner); {
+		for i < len(inner) && (inner[i] == ' ' || inner[i] == '\t' || inner[i] == ',') {
+			i++
+		}
+		if i >= len(inner) {
+			break
+		}
+		quote := inner[i]
+		if quote != '\'' && quote != '"' {
+			return nil, fmt.Errorf("only arrays of strings are supported")
+		}
+		j := i + 1
+		escaped := false
+		for j < len(inner) {
+			c := inner[j]
+			if escaped {
+				escaped = false
+				j++
+				continue
+			}
+			if c == '\\' {
+				escaped = true
+				j++
+				continue
+			}
+			if c == quote {
+				break
+			}
+			j++
+		}
+		if j >= len(inner) {
+			return nil, fmt.Errorf("unterminated string in array")
+		}
+		token := inner[i : j+1]
+		var str string
+		var err error
+		if token[0] == '\'' {
+			str, err = strconv.Unquote(`"` + strings.ReplaceAll(token[1:len(token)-1], `"`, `\"`) + `"`)
+		} else {
+			str, err = strconv.Unquote(token)
+		}
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, str)
+		i = j + 1
+		for i < len(inner) && (inner[i] == ' ' || inner[i] == '\t') {
+			i++
+		}
+		if i < len(inner) {
+			if inner[i] != ',' {
+				return nil, fmt.Errorf("expected comma between array values")
+			}
+			i++
+		}
+	}
+	return values, nil
+}
+
+func stripComment(line string) string {
+	escaped := false
+	quoteChar := byte(0)
+	result := make([]byte, 0, len(line))
+	for i := 0; i < len(line); i++ {
+		ch := line[i]
+		if escaped {
+			result = append(result, ch)
+			escaped = false
+			continue
+		}
+		if ch == '\\' && quoteChar == '"' {
+			result = append(result, ch)
+			escaped = true
+			continue
+		}
+		if ch == '"' || ch == '\'' {
+			if quoteChar == 0 {
+				quoteChar = ch
+			} else if quoteChar == ch {
+				quoteChar = 0
+			}
+			result = append(result, ch)
+			continue
+		}
+		if ch == '#' && quoteChar == 0 {
+			break
+		}
+		result = append(result, ch)
+	}
+	return strings.TrimSpace(string(result))
+}
+
+func validateAllowedKeys(table map[string]any, allowed map[string]struct{}, label string) error {
+	unknown := make([]string, 0)
+	for key := range table {
+		if _, ok := allowed[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	sort.Strings(unknown)
+	if len(unknown) > 0 {
+		return fmt.Errorf("%s contains unsupported keys: %s", label, strings.Join(unknown, ", "))
+	}
+	return nil
+}
+
+func selectedFor(values any, current, label string, allowed map[string]struct{}) (bool, error) {
+	if values == nil {
+		return true, nil
+	}
+	switch arr := values.(type) {
+	case []string:
+		if len(arr) == 0 {
+			return false, fmt.Errorf("%s must be a non-empty array when specified", label)
+		}
+		for _, str := range arr {
+			if _, ok := allowed[str]; !ok {
+				return false, fmt.Errorf("%s contains unsupported value: %s", label, str)
+			}
+			if str == current {
+				return true, nil
+			}
+		}
+		return false, nil
+	case []any:
+		if len(arr) == 0 {
+			return false, fmt.Errorf("%s must be a non-empty array when specified", label)
+		}
+		for _, raw := range arr {
+			str, ok := raw.(string)
+			if !ok {
+				return false, fmt.Errorf("%s values must be strings", label)
+			}
+			if _, ok := allowed[str]; !ok {
+				return false, fmt.Errorf("%s contains unsupported value: %s", label, str)
+			}
+			if str == current {
+				return true, nil
+			}
+		}
+		return false, nil
+	default:
+		return false, fmt.Errorf("%s must be a non-empty array when specified", label)
+	}
+}
+
+func logicalPolicyPath(policyPath, entrypointRoot string) string {
+	rel, err := filepath.Rel(entrypointRoot, policyPath)
+	if err != nil {
+		return policyPath
+	}
+	return filepath.ToSlash(rel)
+}
+
+func expandHostPath(raw, base string) string {
+	expanded := raw
+	if strings.HasPrefix(raw, "~") {
+		if home, err := expandUser(raw); err == nil {
+			expanded = home
+		}
+	}
+	if !filepath.IsAbs(expanded) {
+		expanded = filepath.Join(base, expanded)
+	}
+	abs, err := filepath.Abs(expanded)
+	if err != nil {
+		return filepath.Clean(expanded)
+	}
+	return abs
+}
+
+func expandUser(raw string) (string, error) {
+	if raw == "~" || strings.HasPrefix(raw, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if raw == "~" {
+			return home, nil
+		}
+		return filepath.Join(home, raw[2:]), nil
+	}
+	if !strings.HasPrefix(raw, "~") {
+		return raw, nil
+	}
+	slash := strings.IndexByte(raw, '/')
+	userName := raw[1:]
+	remainder := ""
+	if slash >= 0 {
+		userName = raw[1:slash]
+		remainder = raw[slash+1:]
+	}
+	var home string
+	if userName == "" {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		home = h
+	} else {
+		usr, err := user.Lookup(userName)
+		if err != nil {
+			return "", err
+		}
+		home = usr.HomeDir
+	}
+	if remainder == "" {
+		return home, nil
+	}
+	return filepath.Join(home, remainder), nil
+}
+
+func resolvePath(raw string) (string, error) {
+	expanded := raw
+	if strings.HasPrefix(raw, "~") {
+		userExpanded, err := expandUser(raw)
+		if err == nil {
+			expanded = userExpanded
+		}
+	}
+	abs, err := filepath.Abs(expanded)
+	if err != nil {
+		return "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved, nil
+	}
+	parent := filepath.Dir(abs)
+	resolvedParent, err := filepath.EvalSymlinks(parent)
+	if err == nil {
+		return filepath.Join(resolvedParent, filepath.Base(abs)), nil
+	}
+	return abs, nil
+}
+
+func cloneMap(value map[string]any) map[string]any {
+	clone := make(map[string]any, len(value))
+	for key, val := range value {
+		clone[key] = val
+	}
+	return clone
+}
+
+func containsPath(stack []string, value string) bool {
+	for _, entry := range stack {
+		if entry == value {
+			return true
+		}
+	}
+	return false
+}
+
+func isDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func cwd() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	return wd
+}

--- a/internal/authresolve/resolve_credential_sources_test.go
+++ b/internal/authresolve/resolve_credential_sources_test.go
@@ -1,0 +1,405 @@
+package authresolve
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fileSnapshot struct {
+	data []byte
+	mode os.FileMode
+}
+
+func runResolveCredentialSources(tb testing.TB, args []string, env map[string]string) (int, string, string) {
+	tb.Helper()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if env != nil {
+		for key, value := range env {
+			tb.Setenv(key, value)
+		}
+	}
+	code := Run(args, &stdout, &stderr)
+	return code, stdout.String(), stderr.String()
+}
+
+func snapshotFile(tb testing.TB, path string) fileSnapshot {
+	tb.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return fileSnapshot{data: data, mode: info.Mode().Perm()}
+}
+
+func assertSnapshotEqual(tb testing.TB, path string, want fileSnapshot) {
+	tb.Helper()
+	got := snapshotFile(tb, path)
+	if !bytes.Equal(got.data, want.data) {
+		tb.Fatalf("content mismatch for %s\nGO:\n%s\nWANT:\n%s", path, got.data, want.data)
+	}
+	if got.mode != want.mode {
+		tb.Fatalf("mode mismatch for %s: got %v want %v", path, got.mode, want.mode)
+	}
+}
+
+func writePolicy(tb testing.TB, path, content string) {
+	tb.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+func readJSON(tb testing.TB, path string) map[string]any {
+	tb.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	var value map[string]any
+	if err := json.Unmarshal(data, &value); err != nil {
+		tb.Fatal(err)
+	}
+	return value
+}
+
+func TestRunMetadataModeWritesPlaceholderAndMetadata(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	writePolicy(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.claude_auth]",
+		`resolver = "claude-macos-keychain"`,
+		`materialization = "ephemeral"`,
+	}, "\n")+"\n")
+
+	outputRoot := filepath.Join(root, "out")
+	if err := os.MkdirAll(outputRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := runResolveCredentialSources(t, []string{
+		"--policy", policyPath,
+		"--agent", "claude",
+		"--mode", "strict",
+		"--resolution-mode", "metadata",
+		"--output-policy", filepath.Join(outputRoot, "resolved-policy.toml"),
+		"--output-metadata", filepath.Join(outputRoot, "resolver-metadata.json"),
+		"--output-root", outputRoot,
+	}, nil)
+	if code != 0 {
+		t.Fatalf("Run() = %d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("unexpected output stdout=%q stderr=%q", stdout, stderr)
+	}
+
+	resolvedOutputRoot, err := filepath.EvalSymlinks(outputRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedPolicy := snapshotFile(t, filepath.Join(resolvedOutputRoot, "resolved-policy.toml"))
+	if !bytes.Contains(resolvedPolicy.data, []byte(`source = "`+filepath.Join(resolvedOutputRoot, "resolved", "credentials", "claude_auth.json")+`"`)) {
+		t.Fatalf("resolved policy missing rewritten source path:\n%s", resolvedPolicy.data)
+	}
+	metadata := readJSON(t, filepath.Join(resolvedOutputRoot, "resolver-metadata.json"))
+	if got := metadata["credential_resolvers"].(map[string]any)["claude_auth"]; got != "claude-macos-keychain" {
+		t.Fatalf("credential_resolvers.claude_auth = %v", got)
+	}
+	if got := metadata["credential_resolution_states"].(map[string]any)["claude_auth"]; got != "configured-only" {
+		t.Fatalf("credential_resolution_states.claude_auth = %v", got)
+	}
+	if got := metadata["credential_input_kinds"].(map[string]any)["claude_auth"]; got != "resolver" {
+		t.Fatalf("credential_input_kinds.claude_auth = %v", got)
+	}
+	assertSnapshotEqual(t, filepath.Join(resolvedOutputRoot, "resolved", "credentials", "claude_auth.json"), fileSnapshot{
+		data: []byte("{\"resolver\": \"claude-macos-keychain\", \"workcell\": \"metadata-only\"}\n"),
+		mode: 0o600,
+	})
+}
+
+func TestRunLaunchModeFailsClosedWithoutSupportedExportPath(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	writePolicy(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.claude_auth]",
+		`resolver = "claude-macos-keychain"`,
+		`materialization = "ephemeral"`,
+	}, "\n")+"\n")
+
+	code, stdout, stderr := runResolveCredentialSources(t, []string{
+		"--policy", policyPath,
+		"--agent", "claude",
+		"--mode", "strict",
+		"--resolution-mode", "launch",
+		"--output-policy", filepath.Join(root, "resolved-policy.toml"),
+		"--output-metadata", filepath.Join(root, "resolver-metadata.json"),
+		"--output-root", root,
+	}, nil)
+	if code != 1 {
+		t.Fatalf("Run() = %d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "Claude macOS login reuse is configured") {
+		t.Fatalf("stderr %q missing launch-mode failure", stderr)
+	}
+}
+
+func TestRunLaunchModeAcceptsTestExportFile(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	exportPath := filepath.Join(root, "claude-export.json")
+	writePolicy(t, exportPath, "{\"token\":\"claude\"}\n")
+	if err := os.Chmod(exportPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writePolicy(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.claude_auth]",
+		`resolver = "claude-macos-keychain"`,
+		`materialization = "ephemeral"`,
+	}, "\n")+"\n")
+
+	outputRoot := filepath.Join(root, "out")
+	if err := os.MkdirAll(outputRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := runResolveCredentialSources(t, []string{
+		"--policy", policyPath,
+		"--agent", "claude",
+		"--mode", "strict",
+		"--resolution-mode", "launch",
+		"--output-policy", filepath.Join(outputRoot, "resolved-policy.toml"),
+		"--output-metadata", filepath.Join(outputRoot, "resolver-metadata.json"),
+		"--output-root", outputRoot,
+	}, map[string]string{testClaudeExportEnv: exportPath})
+	if code != 0 {
+		t.Fatalf("Run() = %d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+
+	resolvedOutputRoot, err := filepath.EvalSymlinks(outputRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata := readJSON(t, filepath.Join(resolvedOutputRoot, "resolver-metadata.json"))
+	if got := metadata["credential_resolution_states"].(map[string]any)["claude_auth"]; got != "resolved" {
+		t.Fatalf("credential_resolution_states.claude_auth = %v", got)
+	}
+	resolvedPolicy := snapshotFile(t, filepath.Join(resolvedOutputRoot, "resolved-policy.toml"))
+	if !bytes.Contains(resolvedPolicy.data, []byte("resolved/credentials/claude_auth.json")) {
+		t.Fatalf("resolved policy missing resolved credential path:\n%s", resolvedPolicy.data)
+	}
+	assertSnapshotEqual(t, filepath.Join(resolvedOutputRoot, "resolved", "credentials", "claude_auth.json"), fileSnapshot{
+		data: []byte("{\"token\":\"claude\"}\n"),
+		mode: 0o600,
+	})
+}
+
+func TestRunRejectsOutputPolicyOutsideOutputRoot(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	writePolicy(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.claude_auth]",
+		`resolver = "claude-macos-keychain"`,
+		`materialization = "ephemeral"`,
+	}, "\n")+"\n")
+
+	outputRoot := filepath.Join(root, "out")
+	if err := os.MkdirAll(outputRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := runResolveCredentialSources(t, []string{
+		"--policy", policyPath,
+		"--agent", "claude",
+		"--mode", "strict",
+		"--resolution-mode", "metadata",
+		"--output-policy", filepath.Join(root, "resolved-policy.toml"),
+		"--output-metadata", filepath.Join(outputRoot, "resolver-metadata.json"),
+		"--output-root", outputRoot,
+	}, nil)
+	if code != 1 {
+		t.Fatalf("Run() = %d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "--output-policy must stay within") {
+		t.Fatalf("stderr %q missing output-root containment failure", stderr)
+	}
+}
+
+func TestRunMetadataModeRejectsResolvedCredentialSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	writePolicy(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.claude_auth]",
+		`resolver = "claude-macos-keychain"`,
+		`materialization = "ephemeral"`,
+	}, "\n")+"\n")
+
+	outputRoot := filepath.Join(root, "out")
+	if err := os.MkdirAll(outputRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	escapeRoot := filepath.Join(root, "escape")
+	if err := os.MkdirAll(escapeRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(escapeRoot, filepath.Join(outputRoot, "resolved")); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := runResolveCredentialSources(t, []string{
+		"--policy", policyPath,
+		"--agent", "claude",
+		"--mode", "strict",
+		"--resolution-mode", "metadata",
+		"--output-policy", filepath.Join(outputRoot, "resolved-policy.toml"),
+		"--output-metadata", filepath.Join(outputRoot, "resolver-metadata.json"),
+		"--output-root", outputRoot,
+	}, nil)
+	if code != 1 {
+		t.Fatalf("Run() = %d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("unexpected stdout %q", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(escapeRoot, "credentials", "claude_auth.json")); !os.IsNotExist(err) {
+		t.Fatalf("credential file unexpectedly materialized outside output root: %v", err)
+	}
+}
+
+func TestRunDropsProviderFilteredResolverEntries(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	writePolicy(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.claude_auth]",
+		`resolver = "claude-macos-keychain"`,
+		`materialization = "ephemeral"`,
+		`providers = ["codex"]`,
+	}, "\n")+"\n")
+
+	outputRoot := filepath.Join(root, "out")
+	if err := os.MkdirAll(outputRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := runResolveCredentialSources(t, []string{
+		"--policy", policyPath,
+		"--agent", "claude",
+		"--mode", "strict",
+		"--resolution-mode", "metadata",
+		"--output-policy", filepath.Join(outputRoot, "resolved-policy.toml"),
+		"--output-metadata", filepath.Join(outputRoot, "resolver-metadata.json"),
+		"--output-root", outputRoot,
+	}, nil)
+	if code != 0 {
+		t.Fatalf("Run() = %d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+
+	resolvedOutputRoot, err := filepath.EvalSymlinks(outputRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedPolicy := snapshotFile(t, filepath.Join(resolvedOutputRoot, "resolved-policy.toml"))
+	if string(resolvedPolicy.data) != "version = 1\n" {
+		t.Fatalf("unexpected resolved policy:\n%s", resolvedPolicy.data)
+	}
+	metadata := readJSON(t, filepath.Join(resolvedOutputRoot, "resolver-metadata.json"))
+	if got := metadata["credential_input_kinds"].(map[string]any); len(got) != 0 {
+		t.Fatalf("expected filtered metadata input kinds to be empty, got %#v", got)
+	}
+}
+
+func TestRunRejectsInvalidConfigurations(t *testing.T) {
+	cases := []struct {
+		name         string
+		policy       string
+		agent        string
+		wantContains string
+	}{
+		{
+			name: "conflicting-source-and-resolver",
+			policy: strings.Join([]string{
+				"version = 1",
+				"[credentials.claude_auth]",
+				`source = "/tmp/auth.json"`,
+				`resolver = "claude-macos-keychain"`,
+				`materialization = "ephemeral"`,
+			}, "\n") + "\n",
+			agent:        "claude",
+			wantContains: "credentials.claude_auth must not declare both source and resolver",
+		},
+		{
+			name: "unsupported-resolver",
+			policy: strings.Join([]string{
+				"version = 1",
+				"[credentials.claude_auth]",
+				`resolver = "bogus"`,
+				`materialization = "ephemeral"`,
+			}, "\n") + "\n",
+			agent:        "claude",
+			wantContains: "credentials.claude_auth.resolver is unsupported: bogus",
+		},
+		{
+			name: "invalid-selector-values",
+			policy: strings.Join([]string{
+				"version = 1",
+				"[credentials.codex_auth]",
+				`source = "/tmp/auth.json"`,
+				`providers = ["bogus"]`,
+			}, "\n") + "\n",
+			agent:        "codex",
+			wantContains: "credentials.codex_auth.providers contains unsupported value: bogus",
+		},
+		{
+			name: "resolver-materialization-must-stay-ephemeral",
+			policy: strings.Join([]string{
+				"version = 1",
+				"[credentials.claude_auth]",
+				`resolver = "claude-macos-keychain"`,
+				`materialization = "persistent"`,
+			}, "\n") + "\n",
+			agent:        "claude",
+			wantContains: "credentials.claude_auth.materialization must stay ephemeral for resolver-backed auth",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			policyPath := filepath.Join(root, "policy.toml")
+			writePolicy(t, policyPath, tc.policy)
+			outputRoot := filepath.Join(root, "out")
+			if err := os.MkdirAll(outputRoot, 0o700); err != nil {
+				t.Fatal(err)
+			}
+
+			code, stdout, stderr := runResolveCredentialSources(t, []string{
+				"--policy", policyPath,
+				"--agent", tc.agent,
+				"--mode", "strict",
+				"--resolution-mode", "metadata",
+				"--output-policy", filepath.Join(outputRoot, "resolved-policy.toml"),
+				"--output-metadata", filepath.Join(outputRoot, "resolver-metadata.json"),
+				"--output-root", outputRoot,
+			}, nil)
+			if code != 1 {
+				t.Fatalf("Run() = %d stdout=%q stderr=%q", code, stdout, stderr)
+			}
+			if !strings.Contains(stderr, tc.wantContains) {
+				t.Fatalf("stderr %q does not contain %q", stderr, tc.wantContains)
+			}
+		})
+	}
+}

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -1,0 +1,2071 @@
+package injection
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const (
+	sessionHomeRoot = "/state/agent-home"
+	runInjectedRoot = "/state/injected"
+	directMountRoot = "/opt/workcell/host-inputs"
+)
+
+var (
+	supportedAgents = map[string]struct{}{
+		"codex":  {},
+		"claude": {},
+		"gemini": {},
+	}
+	supportedModes = map[string]struct{}{
+		"strict":     {},
+		"build":      {},
+		"breakglass": {},
+	}
+	supportedClassifications = map[string]struct{}{
+		"public": {},
+		"secret": {},
+	}
+	reservedSSHFilnames = map[string]struct{}{
+		"config":      {},
+		"known_hosts": {},
+	}
+	riskySSHDirectives = map[string]struct{}{
+		"controlmaster":       {},
+		"controlpath":         {},
+		"controlpersist":      {},
+		"forwardagent":        {},
+		"identityagent":       {},
+		"include":             {},
+		"knownhostscommand":   {},
+		"localcommand":        {},
+		"permitlocalcommand":  {},
+		"pkcs11provider":      {},
+		"proxycommand":        {},
+		"securitykeyprovider": {},
+		"sendenv":             {},
+		"setenv":              {},
+		"userknownhostsfile":  {},
+	}
+	reservedTargets = []string{
+		"/state/agent-home/.codex/AGENTS.md",
+		"/state/agent-home/.codex/auth.json",
+		"/state/agent-home/.codex/config.toml",
+		"/state/agent-home/.codex/managed_config.toml",
+		"/state/agent-home/.codex/requirements.toml",
+		"/state/agent-home/.codex/agents",
+		"/state/agent-home/.codex/rules",
+		"/state/agent-home/.codex/mcp",
+		"/state/agent-home/.claude/settings.json",
+		"/state/agent-home/.claude/CLAUDE.md",
+		"/state/agent-home/.claude/.claude.json",
+		"/state/agent-home/.claude.json",
+		"/state/agent-home/.claude/.credentials.json",
+		"/state/agent-home/.claude/workcell",
+		"/state/agent-home/.config/claude-code/auth.json",
+		"/state/agent-home/.mcp.json",
+		"/state/agent-home/.gemini/settings.json",
+		"/state/agent-home/.gemini/GEMINI.md",
+		"/state/agent-home/.gemini/.env",
+		"/state/agent-home/.gemini/oauth_creds.json",
+		"/state/agent-home/.gemini/projects.json",
+		"/state/agent-home/.gemini/trustedFolders.json",
+		"/state/agent-home/.config/gcloud/application_default_credentials.json",
+		"/state/agent-home/.config/gh/config.yml",
+		"/state/agent-home/.config/gh/hosts.yml",
+		"/state/agent-home/.ssh",
+	}
+	canonicalCredentialDestinations = map[string]string{
+		"codex_auth":      "codex/auth.json",
+		"claude_api_key":  "claude/api-key.txt",
+		"claude_mcp":      "claude/mcp.json",
+		"gemini_env":      "gemini/gemini.env",
+		"gemini_oauth":    "gemini/oauth_creds.json",
+		"gemini_projects": "gemini/projects.json",
+		"gcloud_adc":      "gemini/gcloud-adc.json",
+		"github_hosts":    "shared/github-hosts.yml",
+		"github_config":   "shared/github-config.yml",
+	}
+	credentialContainerPaths = map[string]string{
+		"codex_auth":      directMountRoot + "/credentials/codex-auth.json",
+		"claude_auth":     directMountRoot + "/credentials/claude-auth.json",
+		"claude_api_key":  directMountRoot + "/credentials/claude-api-key.txt",
+		"claude_mcp":      directMountRoot + "/credentials/claude-mcp.json",
+		"gemini_env":      directMountRoot + "/credentials/gemini.env",
+		"gemini_oauth":    directMountRoot + "/credentials/gemini-oauth.json",
+		"gemini_projects": directMountRoot + "/credentials/gemini-projects.json",
+		"gcloud_adc":      directMountRoot + "/credentials/gcloud-adc.json",
+		"github_hosts":    directMountRoot + "/credentials/github-hosts.yml",
+		"github_config":   directMountRoot + "/credentials/github-config.yml",
+	}
+	agentScopedCredentialKeys = map[string]map[string]struct{}{
+		"codex": {
+			"codex_auth": {},
+		},
+		"claude": {
+			"claude_api_key": {},
+			"claude_auth":    {},
+			"claude_mcp":     {},
+		},
+		"gemini": {
+			"gemini_env":      {},
+			"gemini_oauth":    {},
+			"gemini_projects": {},
+			"gcloud_adc":      {},
+		},
+	}
+	sharedCredentialKeys = map[string]struct{}{
+		"github_hosts":  {},
+		"github_config": {},
+	}
+	googleAuthEndpoints = []string{
+		"accounts.google.com:443",
+		"oauth2.googleapis.com:443",
+		"sts.googleapis.com:443",
+	}
+	vertexEndpoint    = "aiplatform.googleapis.com:443"
+	geminiProjectKeys = []string{
+		"GOOGLE_CLOUD_PROJECT",
+		"GOOGLE_CLOUD_PROJECT_ID",
+	}
+	geminiVertexLocationKeys = []string{
+		"GOOGLE_CLOUD_LOCATION",
+		"GOOGLE_CLOUD_REGION",
+		"CLOUD_ML_REGION",
+		"VERTEX_LOCATION",
+		"VERTEX_AI_LOCATION",
+	}
+	geminiSupportedEnvKeys = map[string]struct{}{
+		"GEMINI_API_KEY":            {},
+		"GOOGLE_API_KEY":            {},
+		"GOOGLE_GENAI_USE_GCA":      {},
+		"GOOGLE_GENAI_USE_VERTEXAI": {},
+		"GOOGLE_CLOUD_PROJECT":      {},
+		"GOOGLE_CLOUD_PROJECT_ID":   {},
+		"GOOGLE_CLOUD_LOCATION":     {},
+		"GOOGLE_CLOUD_REGION":       {},
+		"CLOUD_ML_REGION":           {},
+		"VERTEX_LOCATION":           {},
+		"VERTEX_AI_LOCATION":        {},
+	}
+	allowedRootPolicyKeys = map[string]struct{}{
+		"version":     {},
+		"includes":    {},
+		"documents":   {},
+		"ssh":         {},
+		"copies":      {},
+		"credentials": {},
+	}
+)
+
+type PolicySource struct {
+	Path   string `json:"path"`
+	Sha256 string `json:"sha256"`
+}
+
+func RunRenderInjectionBundle(policyPath, agent, mode, outputRoot, policyMetadata string) error {
+	resolvedPolicyPath, err := resolvePathLikePython(policyPath)
+	if err != nil {
+		return err
+	}
+	resolvedOutputRoot, err := resolvePathLikePython(outputRoot)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(resolvedOutputRoot, 0o700); err != nil {
+		return err
+	}
+	if err := os.Chmod(resolvedOutputRoot, 0o700); err != nil {
+		return err
+	}
+
+	policy, policySources, err := loadPolicyBundle(Path(resolvedPolicyPath))
+	if err != nil {
+		return err
+	}
+	policyEntrypoint := logicalPolicyPath(Path(resolvedPolicyPath), Path(filepath.Dir(resolvedPolicyPath)))
+	if policyMetadata != "" {
+		policyEntrypoint, policySources, err = loadPolicyMetadataOverride(policyMetadata)
+		if err != nil {
+			return err
+		}
+	}
+
+	renderedDocuments, err := renderDocuments(policy, Path(resolvedOutputRoot), Path(filepath.Dir(resolvedPolicyPath)))
+	if err != nil {
+		return err
+	}
+	renderedCopies, err := renderCopies(policy, Path(resolvedOutputRoot), Path(filepath.Dir(resolvedPolicyPath)), agent, mode)
+	if err != nil {
+		return err
+	}
+	renderedCredentials, err := renderCredentials(policy, Path(filepath.Dir(resolvedPolicyPath)), agent, mode)
+	if err != nil {
+		return err
+	}
+	renderedSSH, err := renderSSH(policy, Path(resolvedOutputRoot), Path(filepath.Dir(resolvedPolicyPath)), agent, mode)
+	if err != nil {
+		return err
+	}
+
+	manifest := map[string]any{
+		"version": 1,
+		"metadata": map[string]any{
+			"policy_entrypoint":   policyEntrypoint,
+			"policy_sha256":       effectivePolicySHA256(policySources, Path(resolvedOutputRoot), renderedDocuments, renderedCopies, renderedCredentials, renderedSSH),
+			"policy_sources":      policySources,
+			"credential_keys":     sortedStringKeysMap(renderedCredentials),
+			"extra_endpoints":     deriveCredentialExtraEndpoints(renderedCredentials),
+			"secret_copy_targets": secretCopyTargets(renderedCopies),
+			"ssh_enabled":         len(renderedSSH) > 0,
+			"ssh_config_assurance": func() string {
+				if renderedSSH == nil {
+					return "off"
+				}
+				if v, ok := renderedSSH["config_assurance"].(string); ok {
+					return v
+				}
+				return "off"
+			}(),
+		},
+		"documents":   renderedDocuments,
+		"copies":      renderedCopies,
+		"credentials": renderedCredentials,
+		"ssh":         renderedSSH,
+	}
+
+	manifestPath := filepath.Join(resolvedOutputRoot, "manifest.json")
+	if err := writeIndentedJSON(manifestPath, manifest, 0o600); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, manifestPath)
+	return nil
+}
+
+func loadPolicyBundle(policyPath Path) (map[string]any, []PolicySource, error) {
+	resolvedPolicyPath, err := resolvePathLikePython(policyPath.String())
+	if err != nil {
+		return nil, nil, err
+	}
+	resolvedPolicy := Path(resolvedPolicyPath)
+	loadedPaths := map[string]struct{}{}
+	merged, sources, err := loadPolicyBundleRecursive(resolvedPolicy, resolvedPolicy.Parent(), nil, loadedPaths)
+	if err != nil {
+		return nil, nil, err
+	}
+	return merged, sources, nil
+}
+
+func loadPolicyBundleRecursive(policyPath, entrypointRoot Path, activeStack []Path, loadedPaths map[string]struct{}) (map[string]any, []PolicySource, error) {
+	resolvedPolicyPath, err := resolvePathLikePython(policyPath.String())
+	if err != nil {
+		return nil, nil, err
+	}
+	resolved := Path(resolvedPolicyPath)
+	if containsPath(activeStack, resolved) {
+		cycle := append(append([]Path{}, activeStack...), resolved)
+		parts := make([]string, 0, len(cycle))
+		for _, p := range cycle {
+			parts = append(parts, p.String())
+		}
+		return nil, nil, fmt.Errorf("injection policy include cycle detected: %s", strings.Join(parts, " -> "))
+	}
+	if _, ok := loadedPaths[resolved.String()]; ok {
+		return nil, nil, fmt.Errorf("injection policy includes the same file more than once: %s", resolved)
+	}
+	loadedPaths[resolved.String()] = struct{}{}
+
+	raw, err := os.ReadFile(resolved.String())
+	if err != nil {
+		return nil, nil, err
+	}
+	loaded, err := parseTOMLSubset(string(raw), resolved)
+	if err != nil {
+		return nil, nil, err
+	}
+	validateAllowedKeys(loaded, allowedRootPolicyKeys, "root policy")
+	version := 1
+	if rawVersion, ok := loaded["version"]; ok {
+		if v, ok := rawVersion.(int); ok {
+			version = v
+		} else {
+			return nil, nil, fmt.Errorf("unsupported injection policy version: %v", rawVersion)
+		}
+	}
+	if version != 1 {
+		return nil, nil, fmt.Errorf("unsupported injection policy version: %d", version)
+	}
+
+	includes, _ := loaded["includes"].([]any)
+	if includes == nil {
+		if rawIncludes, ok := loaded["includes"]; ok && rawIncludes != nil {
+			var err error
+			includes, err = anySlice(rawIncludes, "includes")
+			if err != nil {
+				return nil, nil, err
+			}
+		} else {
+			includes = []any{}
+		}
+	}
+	merged := map[string]any{"version": 1}
+	sources := make([]PolicySource, 0)
+	nextStack := append(append([]Path{}, activeStack...), resolved)
+	for index, include := range includes {
+		includePath, err := validatePolicyInclude(include, fmt.Sprintf("includes[%d]", index), resolved.Parent(), entrypointRoot)
+		if err != nil {
+			return nil, nil, err
+		}
+		included, includedSources, err := loadPolicyBundleRecursive(includePath, entrypointRoot, nextStack, loadedPaths)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := mergePolicyFragment(merged, included, includePath); err != nil {
+			return nil, nil, err
+		}
+		sources = append(sources, includedSources...)
+	}
+
+	currentPolicy := cloneMap(loaded)
+	delete(currentPolicy, "includes")
+	if len(activeStack) > 0 {
+		currentPolicy = rebasePolicyFragment(currentPolicy, resolved.Parent())
+	}
+	if err := mergePolicyFragment(merged, currentPolicy, resolved); err != nil {
+		return nil, nil, err
+	}
+	sources = append(sources, PolicySource{
+		Path:   logicalPolicyPath(resolved, entrypointRoot),
+		Sha256: policySHA256(resolved.String()),
+	})
+	return merged, sources, nil
+}
+
+func loadPolicyMetadataOverride(rawPath string) (string, []PolicySource, error) {
+	resolved, err := resolvePathLikePython(rawPath)
+	if err != nil {
+		return "", nil, err
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return "", nil, err
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return "", nil, fmt.Errorf("policy metadata override must be valid JSON: %s (%s)", resolved, err.Error())
+	}
+	entrypoint, ok := metadata["policy_entrypoint"].(string)
+	if !ok || entrypoint == "" {
+		return "", nil, fmt.Errorf("policy metadata override must include policy_entrypoint: %s", resolved)
+	}
+	rawSources, ok := metadata["policy_sources"].([]any)
+	if !ok || len(rawSources) == 0 {
+		return "", nil, fmt.Errorf("policy metadata override must include policy_sources: %s", resolved)
+	}
+	sources := make([]PolicySource, 0, len(rawSources))
+	for _, rawEntry := range rawSources {
+		entry, ok := rawEntry.(map[string]any)
+		if !ok {
+			return "", nil, fmt.Errorf("policy metadata override sources must be objects: %s", resolved)
+		}
+		pathValue, ok := entry["path"].(string)
+		if !ok || pathValue == "" {
+			return "", nil, fmt.Errorf("policy metadata override source path must be a string: %s", resolved)
+		}
+		shaValue, ok := entry["sha256"].(string)
+		if !ok || shaValue == "" {
+			return "", nil, fmt.Errorf("policy metadata override source sha256 must be a string: %s", resolved)
+		}
+		sources = append(sources, PolicySource{Path: pathValue, Sha256: shaValue})
+	}
+	return entrypoint, sources, nil
+}
+
+func renderDocuments(policy map[string]any, outputRoot, policyDir Path) (map[string]string, error) {
+	raw := policy["documents"]
+	if raw == nil {
+		return map[string]string{}, nil
+	}
+	documents, ok := raw.(map[string]any)
+	if !ok {
+		return nil, errors.New("documents must be a TOML table")
+	}
+	validateAllowedKeys(documents, mapKeysSet([]string{"common", "codex", "claude", "gemini"}), "documents")
+
+	rendered := map[string]string{}
+	ordered := []struct {
+		key     string
+		relpath string
+	}{
+		{"common", "documents/common.md"},
+		{"codex", "documents/codex.md"},
+		{"claude", "documents/claude.md"},
+		{"gemini", "documents/gemini.md"},
+	}
+	for _, item := range ordered {
+		rawValue, ok := documents[item.key]
+		if !ok || rawValue == nil {
+			continue
+		}
+		source, err := validateSourcePath(rawValue, "documents."+item.key, policyDir)
+		if err != nil {
+			return nil, err
+		}
+		if err := ensureIsFile(source, fmt.Sprintf("documents.%s", item.key)); err != nil {
+			return nil, err
+		}
+		if err := stageFile(source, outputRoot, item.relpath); err != nil {
+			return nil, err
+		}
+		rendered[item.key] = item.relpath
+	}
+	return rendered, nil
+}
+
+func renderCopies(policy map[string]any, outputRoot, policyDir Path, agent, mode string) ([]map[string]any, error) {
+	raw := policy["copies"]
+	if raw == nil {
+		return []map[string]any{}, nil
+	}
+	copies, ok := raw.([]any)
+	if !ok {
+		return nil, errors.New("copies must be a TOML array of tables")
+	}
+	rendered := make([]map[string]any, 0, len(copies))
+	copyIndex := 0
+	for _, rawEntry := range copies {
+		entry, ok := rawEntry.(map[string]any)
+		if !ok {
+			return nil, errors.New("each copies entry must be a table")
+		}
+		if err := validateAllowedKeys(entry, mapKeysSet([]string{"source", "target", "classification", "providers", "modes"}), "copies entry"); err != nil {
+			return nil, err
+		}
+		ok, err := selectedFor(entry["providers"], agent, "copies.providers", supportedAgents)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		ok, err = selectedFor(entry["modes"], mode, "copies.modes", supportedModes)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		sourceValue, err := validateSourcePath(entry["source"], "copies.source", policyDir)
+		if err != nil {
+			return nil, err
+		}
+		targetRaw, ok := entry["target"]
+		if !ok {
+			targetRaw = ""
+		}
+		target, err := validateContainerTarget(normalizeContainerTarget(fmt.Sprint(targetRaw)))
+		if err != nil {
+			return nil, err
+		}
+		classification, ok := entry["classification"].(string)
+		if !ok {
+			return nil, errors.New("copies.classification is required")
+		}
+		kind := "file"
+		relpath := fmt.Sprintf("copies/%d", copyIndex)
+		mountPath := directMountRoot + "/copies/" + strconv.Itoa(copyIndex)
+		copyIndex++
+		fileMode, dirMode, err := classificationModes(classification, sourceValue.IsDir())
+		if err != nil {
+			return nil, err
+		}
+
+		var renderedSource any
+		if classification == "secret" {
+			if err := validateSecretTree(sourceValue, "copies.source"); err != nil {
+				return nil, err
+			}
+			kind = func() string {
+				if sourceValue.IsDir() {
+					return "dir"
+				}
+				return "file"
+			}()
+			renderedSource = directMountEntry(sourceValue, mountPath)
+		} else {
+			kind, err = copySource(sourceValue, outputRoot.Join(relpath))
+			if err != nil {
+				return nil, err
+			}
+			renderedSource = relpath
+		}
+
+		rendered = append(rendered, map[string]any{
+			"source":         renderedSource,
+			"target":         target,
+			"kind":           kind,
+			"file_mode":      fileMode,
+			"dir_mode":       dirMode,
+			"classification": classification,
+		})
+	}
+	return rendered, nil
+}
+
+func renderSSH(policy map[string]any, outputRoot, policyDir Path, agent, mode string) (map[string]any, error) {
+	raw := policy["ssh"]
+	if raw == nil {
+		return map[string]any{}, nil
+	}
+	ssh, ok := raw.(map[string]any)
+	if !ok {
+		return nil, errors.New("ssh must be a TOML table")
+	}
+	if err := validateAllowedKeys(ssh, mapKeysSet([]string{"enabled", "config", "known_hosts", "identities", "providers", "modes", "allow_unsafe_config"}), "ssh"); err != nil {
+		return nil, err
+	}
+	enabledRaw, hasEnabled := ssh["enabled"]
+	hasMaterial := false
+	for _, key := range []string{"config", "known_hosts", "identities"} {
+		if _, ok := ssh[key]; ok {
+			hasMaterial = true
+		}
+	}
+	if hasEnabled {
+		enabled, ok := enabledRaw.(bool)
+		if !ok {
+			return nil, errors.New("ssh.enabled must be a boolean when specified")
+		}
+		if !enabled {
+			return map[string]any{}, nil
+		}
+	}
+	if !hasEnabled && !hasMaterial {
+		return map[string]any{}, nil
+	}
+	ok, err := selectedFor(ssh["providers"], agent, "ssh.providers", supportedAgents)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return map[string]any{}, nil
+	}
+	ok, err = selectedFor(ssh["modes"], mode, "ssh.modes", supportedModes)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return map[string]any{}, nil
+	}
+	rendered := map[string]any{
+		"identities": []map[string]any{},
+	}
+	allowUnsafeRaw, hasAllowUnsafe := ssh["allow_unsafe_config"]
+	allowUnsafeConfig := false
+	if hasAllowUnsafe {
+		val, ok := allowUnsafeRaw.(bool)
+		if !ok {
+			return nil, errors.New("ssh.allow_unsafe_config must be a boolean when specified")
+		}
+		allowUnsafeConfig = val
+	}
+	configRaw, hasConfig := ssh["config"]
+	if !hasConfig || configRaw == nil {
+		rendered["config_assurance"] = "no-config"
+	} else if allowUnsafeConfig {
+		rendered["config_assurance"] = "lower-assurance-unsafe-config"
+	} else {
+		rendered["config_assurance"] = "safe"
+	}
+	if hasConfig && configRaw != nil {
+		source, err := validateSourcePath(configRaw, "ssh.config", policyDir)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := validateSecretFile(source, "ssh.config"); err != nil {
+			return nil, err
+		}
+		if err := validateSSHConfigSafety(source, allowUnsafeConfig); err != nil {
+			return nil, err
+		}
+		rendered["config"] = directMountEntry(source, directMountRoot+"/ssh/config")
+	}
+	knownHostsRaw, hasKnownHosts := ssh["known_hosts"]
+	if hasKnownHosts && knownHostsRaw != nil {
+		source, err := validateSourcePath(knownHostsRaw, "ssh.known_hosts", policyDir)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := validateKnownHostsFile(source, "ssh.known_hosts"); err != nil {
+			return nil, err
+		}
+		rendered["known_hosts"] = directMountEntry(source, directMountRoot+"/ssh/known_hosts")
+	}
+	identitiesRaw, hasIdentities := ssh["identities"]
+	identities := []any{}
+	if hasIdentities {
+		if identitiesRaw == nil {
+			identities = []any{}
+		} else {
+			var err error
+			identities, err = anySlice(identitiesRaw, "ssh.identities")
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	renderedIdentities := make([]map[string]any, 0, len(identities))
+	seenIdentityTargets := map[string]struct{}{}
+	for index, rawIdentity := range identities {
+		source, err := validateSourcePath(rawIdentity, fmt.Sprintf("ssh.identities[%d]", index), policyDir)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := validateSecretFile(source, fmt.Sprintf("ssh.identities[%d]", index)); err != nil {
+			return nil, err
+		}
+		if _, reserved := reservedSSHFilnames[source.Base()]; reserved {
+			return nil, fmt.Errorf("ssh.identities[%d] basename collides with a reserved SSH file: %s", index, source.Base())
+		}
+		if _, exists := seenIdentityTargets[source.Base()]; exists {
+			return nil, fmt.Errorf("ssh.identities contains duplicate target basename: %s", source.Base())
+		}
+		seenIdentityTargets[source.Base()] = struct{}{}
+		renderedIdentities = append(renderedIdentities, map[string]any{
+			"source":      source.String(),
+			"mount_path":  directMountRoot + "/ssh/identity-" + strconv.Itoa(index),
+			"target_name": source.Base(),
+		})
+	}
+	rendered["identities"] = renderedIdentities
+	return rendered, nil
+}
+
+func renderCredentials(policy map[string]any, policyDir Path, agent, mode string) (map[string]map[string]string, error) {
+	raw := policy["credentials"]
+	if raw == nil {
+		return map[string]map[string]string{}, nil
+	}
+	credentials, ok := raw.(map[string]any)
+	if !ok {
+		return nil, errors.New("credentials must be a TOML table")
+	}
+	if err := validateAllowedKeys(credentials, mapKeysSet([]string{
+		"codex_auth",
+		"claude_auth",
+		"claude_api_key",
+		"claude_mcp",
+		"gemini_env",
+		"gemini_oauth",
+		"gemini_projects",
+		"gcloud_adc",
+		"github_hosts",
+		"github_config",
+	}), "credentials"); err != nil {
+		return nil, err
+	}
+
+	relevant := map[string]struct{}{}
+	for key := range sharedCredentialKeys {
+		relevant[key] = struct{}{}
+	}
+	if scoped, ok := agentScopedCredentialKeys[agent]; ok {
+		for key := range scoped {
+			relevant[key] = struct{}{}
+		}
+	}
+
+	rendered := map[string]map[string]string{}
+	for _, key := range sortedSetKeys(relevant) {
+		rawValue, ok := credentials[key]
+		if !ok || rawValue == nil {
+			continue
+		}
+
+		var providers any
+		var modes any
+		sourceRaw := rawValue
+		if entry, ok := rawValue.(map[string]any); ok {
+			if err := validateAllowedKeys(entry, mapKeysSet([]string{"source", "providers", "modes"}), "credentials."+key); err != nil {
+				return nil, err
+			}
+			sourceRaw = entry["source"]
+			providers = entry["providers"]
+			modes = entry["modes"]
+		} else if _, ok := rawValue.(string); !ok {
+			return nil, fmt.Errorf("credentials.%s must be a string path or a table", key)
+		}
+
+		if _, shared := sharedCredentialKeys[key]; shared {
+			if _, isTable := rawValue.(map[string]any); isTable && providers == nil {
+				return nil, fmt.Errorf("credentials.%s.providers is required so shared GitHub credentials stay least-privilege", key)
+			}
+		}
+		ok, err := selectedFor(providers, agent, "credentials."+key+".providers", supportedAgents)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		ok, err = selectedFor(modes, mode, "credentials."+key+".modes", supportedModes)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+
+		source, err := validateSourcePath(sourceRaw, "credentials."+key, policyDir)
+		if err != nil {
+			return nil, err
+		}
+		source, err = validateSecretFile(source, "credentials."+key)
+		if err != nil {
+			return nil, err
+		}
+		switch key {
+		case "gemini_env":
+			if _, err := validateGeminiEnvFile(source); err != nil {
+				return nil, err
+			}
+		case "gemini_oauth":
+			if _, err := validateJSONObjFile(source, "credentials.gemini_oauth"); err != nil {
+				return nil, err
+			}
+		case "gcloud_adc":
+			if err := validateGcloudADCFile(source, "credentials.gcloud_adc"); err != nil {
+				return nil, err
+			}
+		case "gemini_projects":
+			if err := validateGeminiProjectsFile(source, "credentials.gemini_projects"); err != nil {
+				return nil, err
+			}
+		}
+		rendered[key] = map[string]string{
+			"source":     source.String(),
+			"mount_path": credentialContainerPaths[key],
+		}
+	}
+	return rendered, nil
+}
+
+func parseTOMLSubset(content string, policyPath Path) (map[string]any, error) {
+	root := map[string]any{}
+	current := root
+	seenTables := map[string]struct{}{}
+	lines := strings.Split(content, "\n")
+	for lineno, rawLine := range lines {
+		line := stripComment(rawLine)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[[") && strings.HasSuffix(line, "]]") {
+			tableName := strings.TrimSpace(line[2 : len(line)-2])
+			if tableName != "copies" {
+				return nil, fmt.Errorf("%s:%d: unsupported array-of-table [%s]", policyPath, lineno+1, tableName)
+			}
+			copies, _ := root["copies"].([]any)
+			entry := map[string]any{}
+			copies = append(copies, entry)
+			root["copies"] = copies
+			current = entry
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			tableName := strings.TrimSpace(line[1 : len(line)-1])
+			if _, exists := seenTables[tableName]; exists {
+				return nil, fmt.Errorf("%s:%d: duplicate table [%s]", policyPath, lineno+1, tableName)
+			}
+			seenTables[tableName] = struct{}{}
+			if strings.HasPrefix(tableName, "credentials.") {
+				credentialKey := strings.SplitN(tableName, ".", 2)[1]
+				if _, ok := credentialContainerPaths[credentialKey]; !ok {
+					return nil, fmt.Errorf("%s:%d: unsupported credentials table [%s]", policyPath, lineno+1, tableName)
+				}
+				credentials, _ := root["credentials"].(map[string]any)
+				if credentials == nil {
+					credentials = map[string]any{}
+					root["credentials"] = credentials
+				}
+				entry, _ := credentials[credentialKey].(map[string]any)
+				if entry == nil {
+					entry = map[string]any{}
+					credentials[credentialKey] = entry
+				}
+				current = entry
+				continue
+			}
+			if tableName != "documents" && tableName != "ssh" && tableName != "credentials" {
+				return nil, fmt.Errorf("%s:%d: unsupported table [%s]", policyPath, lineno+1, tableName)
+			}
+			table, _ := root[tableName].(map[string]any)
+			if table == nil {
+				table = map[string]any{}
+				root[tableName] = table
+			}
+			current = table
+			continue
+		}
+		if !strings.Contains(line, "=") {
+			return nil, fmt.Errorf("%s:%d: expected key = value", policyPath, lineno+1)
+		}
+		parts := strings.SplitN(line, "=", 2)
+		key := strings.TrimSpace(parts[0])
+		if key == "" {
+			return nil, fmt.Errorf("%s:%d: empty key", policyPath, lineno+1)
+		}
+		if strings.Contains(key, ".") {
+			return nil, fmt.Errorf("%s:%d: dotted TOML keys are not supported; use explicit [table] headers instead", policyPath, lineno+1)
+		}
+		if _, exists := current[key]; exists {
+			return nil, fmt.Errorf("%s:%d: duplicate key: %s", policyPath, lineno+1, key)
+		}
+		value, err := parseTOMLValue(parts[1], policyPath, lineno+1)
+		if err != nil {
+			return nil, err
+		}
+		current[key] = value
+	}
+	return root, nil
+}
+
+func parseTOMLValue(raw string, policyPath Path, lineno int) (any, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return nil, fmt.Errorf("%s:%d: expected a value", policyPath, lineno)
+	}
+	if value == "true" {
+		return true, nil
+	}
+	if value == "false" {
+		return false, nil
+	}
+	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+		return strconv.Unquote(value)
+	}
+	if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+		rawArray := strings.TrimSpace(value[1 : len(value)-1])
+		if rawArray == "" {
+			return []any{}, nil
+		}
+		items := splitTOMLArray(rawArray)
+		result := make([]any, 0, len(items))
+		for _, item := range items {
+			trimmed := strings.TrimSpace(item)
+			if !(strings.HasPrefix(trimmed, "\"") && strings.HasSuffix(trimmed, "\"")) {
+				return nil, fmt.Errorf("%s:%d: only arrays of strings are supported", policyPath, lineno)
+			}
+			parsed, err := strconv.Unquote(trimmed)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, parsed)
+		}
+		return result, nil
+	}
+	if digitsOnly(value) {
+		i, err := strconv.Atoi(value)
+		if err != nil {
+			return nil, err
+		}
+		return i, nil
+	}
+	return nil, fmt.Errorf("%s:%d: unsupported TOML value; use quoted strings, booleans, integers, or arrays of strings", policyPath, lineno)
+}
+
+func digitsOnly(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func splitTOMLArray(raw string) []string {
+	items := []string{}
+	start := 0
+	depth := 0
+	quote := rune(0)
+	escaped := false
+	for i, r := range raw {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if quote == '"' && r == '\\' {
+			escaped = true
+			continue
+		}
+		if r == '\'' || r == '"' {
+			if quote == 0 {
+				quote = r
+			} else if quote == r {
+				quote = 0
+			}
+			continue
+		}
+		if quote != 0 {
+			continue
+		}
+		if r == '[' {
+			depth++
+			continue
+		}
+		if r == ']' {
+			depth--
+			continue
+		}
+		if r == ',' && depth == 0 {
+			items = append(items, raw[start:i])
+			start = i + 1
+		}
+	}
+	items = append(items, raw[start:])
+	return items
+}
+
+func stripComment(line string) string {
+	escaped := false
+	quoteChar := rune(0)
+	var result strings.Builder
+	for _, char := range line {
+		if escaped {
+			result.WriteRune(char)
+			escaped = false
+			continue
+		}
+		if char == '\\' && quoteChar == '"' {
+			result.WriteRune(char)
+			escaped = true
+			continue
+		}
+		if char == '"' || char == '\'' {
+			if quoteChar == 0 {
+				quoteChar = char
+			} else if quoteChar == char {
+				quoteChar = 0
+			}
+			result.WriteRune(char)
+			continue
+		}
+		if char == '#' && quoteChar == 0 {
+			break
+		}
+		result.WriteRune(char)
+	}
+	return strings.TrimSpace(result.String())
+}
+
+func validateAllowedKeys(table map[string]any, allowed map[string]struct{}, label string) error {
+	unknown := make([]string, 0)
+	for key := range table {
+		if _, ok := allowed[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	sort.Strings(unknown)
+	if len(unknown) > 0 {
+		return fmt.Errorf("%s contains unsupported keys: %s", label, strings.Join(unknown, ", "))
+	}
+	return nil
+}
+
+func selectedFor(values any, current, label string, allowed map[string]struct{}) (bool, error) {
+	if values == nil {
+		return true, nil
+	}
+	items, err := stringSlice(values, label)
+	if err != nil {
+		return false, err
+	}
+	if len(items) == 0 {
+		return false, fmt.Errorf("%s must be a non-empty array when specified", label)
+	}
+	for _, s := range items {
+		if _, ok := allowed[s]; !ok {
+			return false, fmt.Errorf("%s contains unsupported value: %s", label, s)
+		}
+		if s == current {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func stringSlice(values any, label string) ([]string, error) {
+	switch typed := values.(type) {
+	case nil:
+		return nil, nil
+	case []string:
+		return append([]string(nil), typed...), nil
+	case []any:
+		items := make([]string, 0, len(typed))
+		for _, item := range typed {
+			value, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("%s values must be strings", label)
+			}
+			items = append(items, value)
+		}
+		return items, nil
+	default:
+		return nil, fmt.Errorf("%s must be a non-empty array when specified", label)
+	}
+}
+
+func anySlice(values any, label string) ([]any, error) {
+	switch typed := values.(type) {
+	case nil:
+		return nil, nil
+	case []any:
+		return append([]any(nil), typed...), nil
+	case []string:
+		items := make([]any, 0, len(typed))
+		for _, item := range typed {
+			items = append(items, item)
+		}
+		return items, nil
+	default:
+		return nil, fmt.Errorf("%s must be an array of strings when specified", label)
+	}
+}
+
+func ensureNoSymlinksWithin(root Path) error {
+	return filepath.WalkDir(root.String(), func(current string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if current == root.String() {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("directory injections must not contain symlinks: %s", current)
+		}
+		return nil
+	})
+}
+
+func copySource(source, destination Path) (string, error) {
+	info, err := os.Stat(source.String())
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		if err := ensureNoSymlinksWithin(source); err != nil {
+			return "", err
+		}
+		if err := os.MkdirAll(destination.String(), 0o700); err != nil {
+			return "", err
+		}
+		destinationRoot, err := os.OpenRoot(destination.String())
+		if err != nil {
+			return "", err
+		}
+		defer destinationRoot.Close()
+		if err := filepath.Walk(source.String(), func(current string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			rel, err := filepath.Rel(source.String(), current)
+			if err != nil {
+				return err
+			}
+			if rel == "." {
+				return nil
+			}
+			rel = filepath.Clean(rel)
+			if info.IsDir() {
+				if err := destinationRoot.MkdirAll(rel, 0o755); err != nil {
+					return err
+				}
+				return destinationRoot.Chmod(rel, 0o700)
+			}
+			data, err := os.ReadFile(current)
+			if err != nil {
+				return err
+			}
+			if parent := filepath.Dir(rel); parent != "." {
+				if err := destinationRoot.MkdirAll(parent, 0o755); err != nil {
+					return err
+				}
+			}
+			if err := destinationRoot.WriteFile(rel, data, 0o600); err != nil {
+				return err
+			}
+			return destinationRoot.Chmod(rel, 0o600)
+		}); err != nil {
+			return "", err
+		}
+		if err := os.Chmod(destination.String(), 0o700); err != nil {
+			return "", err
+		}
+		return "dir", nil
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("injection source must be a file or directory: %s", source)
+	}
+	if err := os.MkdirAll(destination.Parent().String(), 0o755); err != nil {
+		return "", err
+	}
+	parentRoot, err := os.OpenRoot(destination.Parent().String())
+	if err != nil {
+		return "", err
+	}
+	defer parentRoot.Close()
+	data, err := os.ReadFile(source.String())
+	if err != nil {
+		return "", err
+	}
+	if err := parentRoot.WriteFile(destination.Base(), data, 0o600); err != nil {
+		return "", err
+	}
+	if err := parentRoot.Chmod(destination.Base(), 0o600); err != nil {
+		return "", err
+	}
+	return "file", nil
+}
+
+func stageFile(source, outputRoot Path, relpath string) error {
+	root, err := os.OpenRoot(outputRoot.String())
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	relpath = filepath.Clean(relpath)
+	if parent := filepath.Dir(relpath); parent != "." {
+		if err := root.MkdirAll(parent, 0o755); err != nil {
+			return err
+		}
+	}
+	data, err := os.ReadFile(source.String())
+	if err != nil {
+		return err
+	}
+	if err := root.WriteFile(relpath, data, 0o600); err != nil {
+		return err
+	}
+	return root.Chmod(relpath, 0o600)
+}
+
+func directMountEntry(source Path, mountPath string) map[string]string {
+	return map[string]string{
+		"source":     source.String(),
+		"mount_path": mountPath,
+	}
+}
+
+func validateSourcePath(raw any, label string, base Path) (Path, error) {
+	rawStr, ok := raw.(string)
+	if !ok || rawStr == "" {
+		return Path(""), fmt.Errorf("%s must be a non-empty string path", label)
+	}
+	source, err := expandHostPath(rawStr, base)
+	if err != nil {
+		return Path(""), err
+	}
+	if _, err := os.Stat(source.String()); err != nil {
+		return Path(""), fmt.Errorf("%s does not exist: %s", label, source)
+	}
+	if err := requireNoSymlinkInPathChain(source, label); err != nil {
+		return Path(""), err
+	}
+	return source, nil
+}
+
+func expandHostPath(raw string, base Path) (Path, error) {
+	expanded, err := expandUserPath(raw)
+	if err != nil {
+		return Path(""), err
+	}
+	if !filepath.IsAbs(expanded) {
+		expanded = filepath.Join(base.String(), expanded)
+	}
+	abs, err := filepath.Abs(expanded)
+	if err != nil {
+		return Path(""), err
+	}
+	return Path(abs), nil
+}
+
+func requirePathWithin(root, candidate Path, label string) error {
+	resolvedRoot, err := filepath.EvalSymlinks(root.String())
+	if err != nil {
+		return err
+	}
+	resolvedCandidate, err := filepath.EvalSymlinks(candidate.String())
+	if err != nil {
+		return err
+	}
+	if resolvedCandidate != resolvedRoot && !strings.HasPrefix(resolvedCandidate, resolvedRoot+string(filepath.Separator)) {
+		return fmt.Errorf("%s must stay within %s: %s", label, resolvedRoot, resolvedCandidate)
+	}
+	return nil
+}
+
+func requireNoSymlink(path Path, label string) error {
+	if info, err := os.Lstat(path.String()); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s must not be a symlink: %s", label, path)
+	}
+	return nil
+}
+
+func requireNoSymlinkInPathChain(path Path, label string) error {
+	current := path.String()
+	for {
+		info, err := os.Lstat(current)
+		if err == nil && info.Mode()&os.ModeSymlink != 0 {
+			if runtime.GOOS != "darwin" || (current != "/var" && current != "/tmp") {
+				return fmt.Errorf("%s must not be a symlink: %s", label, current)
+			}
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
+}
+
+func requireSecretOwnerOnly(path Path, label string) error {
+	info, err := os.Lstat(path.String())
+	if err != nil {
+		return err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("unsupported file stat type")
+	}
+	if int(stat.Uid) != os.Getuid() {
+		return fmt.Errorf("%s must be owned by uid %d: %s", label, os.Getuid(), path)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("%s must not be group/world-accessible: %s", label, path)
+	}
+	return nil
+}
+
+func validateSecretFile(source Path, label string) (Path, error) {
+	if err := requireNoSymlink(source, label); err != nil {
+		return Path(""), err
+	}
+	info, err := os.Stat(source.String())
+	if err != nil {
+		return Path(""), err
+	}
+	if !info.Mode().IsRegular() {
+		return Path(""), fmt.Errorf("%s must point at a file: %s", label, source)
+	}
+	if err := requireSecretOwnerOnly(source, label); err != nil {
+		return Path(""), err
+	}
+	return source, nil
+}
+
+func validateSecretTree(source Path, label string) error {
+	if err := requireNoSymlink(source, label); err != nil {
+		return err
+	}
+	info, err := os.Stat(source.String())
+	if err != nil {
+		return err
+	}
+	if info.Mode().IsRegular() {
+		_, err = validateSecretFile(source, label)
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s must point at a file or directory: %s", label, source)
+	}
+	if err := requireSecretOwnerOnly(source, label); err != nil {
+		return err
+	}
+	if err := ensureNoSymlinksWithin(source); err != nil {
+		return err
+	}
+	return filepath.WalkDir(source.String(), func(current string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if current == source.String() {
+			return nil
+		}
+		child := Path(current)
+		if err := requireNoSymlink(child, label); err != nil {
+			return err
+		}
+		return requireSecretOwnerOnly(child, label)
+	})
+}
+
+func validateKnownHostsFile(source Path, label string) (Path, error) {
+	if err := requireNoSymlink(source, label); err != nil {
+		return Path(""), err
+	}
+	info, err := os.Stat(source.String())
+	if err != nil {
+		return Path(""), err
+	}
+	if !info.Mode().IsRegular() {
+		return Path(""), fmt.Errorf("%s must point at a file: %s", label, source)
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return Path(""), fmt.Errorf("%s must not be group/world-writable: %s", label, source)
+	}
+	return source, nil
+}
+
+func parseSSHDirective(line string) (string, string, bool) {
+	stripped := strings.TrimSpace(line)
+	if stripped == "" || strings.HasPrefix(stripped, "#") {
+		return "", "", false
+	}
+	parts := strings.Fields(stripped)
+	directive := strings.ToLower(parts[0])
+	remainder := ""
+	if len(parts) > 1 {
+		remainder = strings.Join(parts[1:], " ")
+	}
+	return directive, remainder, true
+}
+
+func validateSSHConfigSafety(source Path, allowUnsafe bool) error {
+	if allowUnsafe {
+		return nil
+	}
+	data, err := os.ReadFile(source.String())
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+	for i, line := range lines {
+		directive, remainder, ok := parseSSHDirective(line)
+		if !ok {
+			continue
+		}
+		if _, risky := riskySSHDirectives[directive]; risky {
+			return fmt.Errorf("ssh.config contains unsafe directive %q at line %d; set ssh.allow_unsafe_config = true only when you explicitly accept lower assurance", directive, i+1)
+		}
+		if directive == "match" && strings.Contains(" "+strings.ToLower(remainder)+" ", " exec ") {
+			return fmt.Errorf("ssh.config contains unsafe Match exec at line %d; set ssh.allow_unsafe_config = true only when you explicitly accept lower assurance", i+1)
+		}
+	}
+	return nil
+}
+
+func validateGeminiEnvFile(source Path) (map[string]any, error) {
+	values, err := parseSimpleEnvFile(source)
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range values {
+		if _, ok := geminiSupportedEnvKeys[key]; !ok {
+			return nil, fmt.Errorf("Unsupported key in Gemini auth env file %s: %s.", source, key)
+		}
+		if key != "GOOGLE_GENAI_USE_GCA" && key != "GOOGLE_GENAI_USE_VERTEXAI" && strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("Gemini auth env file %s sets %s but leaves it empty.", source, key)
+		}
+	}
+
+	gcaEnabled, err := parseEnvBooleanValue(values, source, "GOOGLE_GENAI_USE_GCA")
+	if err != nil {
+		return nil, err
+	}
+	vertexEnabled, err := parseEnvBooleanValue(values, source, "GOOGLE_GENAI_USE_VERTEXAI")
+	if err != nil {
+		return nil, err
+	}
+	geminiAPIKey := strings.TrimSpace(values["GEMINI_API_KEY"])
+	googleAPIKey := strings.TrimSpace(values["GOOGLE_API_KEY"])
+	hasProject := false
+	for _, key := range geminiProjectKeys {
+		if strings.TrimSpace(values[key]) != "" {
+			hasProject = true
+			break
+		}
+	}
+	hasLocation := false
+	for _, key := range geminiVertexLocationKeys {
+		if strings.TrimSpace(values[key]) != "" {
+			hasLocation = true
+			break
+		}
+	}
+	if gcaEnabled && vertexEnabled {
+		return nil, fmt.Errorf("Gemini auth env file %s enables both GOOGLE_GENAI_USE_GCA and GOOGLE_GENAI_USE_VERTEXAI. Choose exactly one auth selector.", source)
+	}
+	if hasLocation && !hasProject {
+		return nil, fmt.Errorf("Gemini auth env file %s sets a Google Cloud location without a project.", source)
+	}
+	endpoints := map[string]struct{}{}
+	if vertexEnabled {
+		if googleAPIKey != "" || (hasProject && hasLocation) {
+			endpoints[vertexEndpoint] = struct{}{}
+			for _, key := range geminiVertexLocationKeys {
+				location := normalizeVertexLocation(values[key])
+				if location != "" {
+					endpoints[location+"-aiplatform.googleapis.com:443"] = struct{}{}
+				}
+			}
+			return map[string]any{
+				"selected_auth_type": "vertex-ai",
+				"extra_endpoints":    sortedSetKeys(endpoints),
+			}, nil
+		}
+		return nil, fmt.Errorf("Gemini auth env file %s enables GOOGLE_GENAI_USE_VERTEXAI=true without either GOOGLE_API_KEY or both GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION.", source)
+	}
+	if googleAPIKey != "" {
+		return nil, fmt.Errorf("Gemini auth env file %s sets GOOGLE_API_KEY without GOOGLE_GENAI_USE_VERTEXAI=true.", source)
+	}
+	if gcaEnabled {
+		return map[string]any{
+			"selected_auth_type": "oauth-personal",
+			"extra_endpoints":    append([]string{}, googleAuthEndpoints...),
+		}, nil
+	}
+	if geminiAPIKey != "" {
+		return map[string]any{
+			"selected_auth_type": "gemini-api-key",
+			"extra_endpoints":    []string{},
+		}, nil
+	}
+	return nil, fmt.Errorf("Gemini auth env file %s does not configure a supported Gemini auth mode. Use GEMINI_API_KEY, GOOGLE_GENAI_USE_GCA=true, or GOOGLE_GENAI_USE_VERTEXAI=true with GOOGLE_API_KEY or both GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION.", source)
+}
+
+func parseSimpleEnvFile(source Path) (map[string]string, error) {
+	values := map[string]string{}
+	data, err := os.ReadFile(source.String())
+	if err != nil {
+		return nil, err
+	}
+	for _, rawLine := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "export ") {
+			line = strings.TrimSpace(line[len("export "):])
+		}
+		idx := strings.Index(line, "=")
+		if idx < 0 {
+			return nil, fmt.Errorf("Malformed Gemini auth env file %s: %s. Use KEY=value assignments.", source, strings.TrimSpace(rawLine))
+		}
+		key := strings.TrimSpace(line[:idx])
+		value := stripComment(line[idx+1:])
+		if _, exists := values[key]; exists {
+			return nil, fmt.Errorf("Gemini auth env file %s configures %s more than once.", source, key)
+		}
+		if value != "" && (value[0] == '\'' || value[0] == '"') {
+			if len(value) < 2 || value[len(value)-1] != value[0] {
+				return nil, fmt.Errorf("Malformed Gemini auth env file %s: %s has an unterminated quoted value.", source, key)
+			}
+			if value[0] == '"' {
+				parsed, err := strconv.Unquote(value)
+				if err != nil {
+					return nil, fmt.Errorf("Malformed Gemini auth env file %s: %s has an invalid double-quoted value (%v).", source, key, err)
+				}
+				value = parsed
+			} else {
+				value = value[1 : len(value)-1]
+			}
+		} else if value != "" && (strings.HasSuffix(value, "'") || strings.HasSuffix(value, "\"")) {
+			return nil, fmt.Errorf("Malformed Gemini auth env file %s: %s has an unmatched trailing quote.", source, key)
+		}
+		values[key] = value
+	}
+	return values, nil
+}
+
+func parseEnvBooleanValue(values map[string]string, source Path, key string) (bool, error) {
+	raw, ok := values[key]
+	if !ok {
+		return false, nil
+	}
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	if normalized != "true" && normalized != "false" {
+		return false, fmt.Errorf("Invalid boolean in Gemini auth env file %s: %s=%s. Use true or false.", source, key, raw)
+	}
+	return normalized == "true", nil
+}
+
+func normalizeVertexLocation(value string) string {
+	candidate := strings.ToLower(strings.TrimSpace(value))
+	if candidate == "" {
+		return ""
+	}
+	for _, r := range candidate {
+		if !(r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '-') {
+			return ""
+		}
+	}
+	if strings.HasPrefix(candidate, "-") || strings.HasSuffix(candidate, "-") || strings.Contains(candidate, "--") {
+		return ""
+	}
+	return candidate
+}
+
+func validateJSONObjFile(source Path, label string) (map[string]any, error) {
+	data, err := os.ReadFile(source.String())
+	if err != nil {
+		return nil, err
+	}
+	var parsed any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("%s must contain valid JSON: %s (%s)", label, source, err.Error())
+	}
+	object, ok := parsed.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must contain a JSON object: %s", label, source)
+	}
+	return object, nil
+}
+
+func validateGcloudADCFile(source Path, label string) error {
+	parsed, err := validateJSONObjFile(source, label)
+	if err != nil {
+		return err
+	}
+	adcType, ok := parsed["type"].(string)
+	if !ok || strings.TrimSpace(adcType) == "" {
+		return fmt.Errorf("%s must contain a non-empty JSON string field: type", label)
+	}
+	return nil
+}
+
+func validateGeminiProjectsFile(source Path, label string) error {
+	parsed, err := validateJSONObjFile(source, label)
+	if err != nil {
+		return err
+	}
+	if _, ok := parsed["projects"].(map[string]any); !ok {
+		return fmt.Errorf("%s must contain a JSON object with an object-valued projects field", label)
+	}
+	return nil
+}
+
+func deriveCredentialExtraEndpoints(renderedCredentials map[string]map[string]string) []string {
+	endpoints := map[string]struct{}{}
+	if geminiEnv, ok := renderedCredentials["gemini_env"]; ok {
+		metadata, err := validateGeminiEnvFile(Path(geminiEnv["source"]))
+		if err == nil {
+			for _, endpoint := range metadata["extra_endpoints"].([]string) {
+				endpoints[endpoint] = struct{}{}
+			}
+		}
+	}
+	return sortedSetKeys(endpoints)
+}
+
+func effectivePolicySHA256(
+	policySources []PolicySource,
+	outputRoot Path,
+	renderedDocuments map[string]string,
+	renderedCopies []map[string]any,
+	renderedCredentials map[string]map[string]string,
+	renderedSSH map[string]any,
+) string {
+	documents := map[string]string{}
+	for _, key := range sortedStringKeys(renderedDocuments) {
+		documents[key] = pathMaterialSHA256(outputRoot.Join(renderedDocuments[key]))
+	}
+	copies := make([]map[string]any, 0, len(renderedCopies))
+	for _, entry := range renderedCopies {
+		renderedSource := entry["source"]
+		var sourcePath Path
+		switch value := renderedSource.(type) {
+		case string:
+			sourcePath = outputRoot.Join(value)
+		case map[string]any:
+			if hostSource, ok := value["source"].(string); ok {
+				sourcePath = Path(hostSource)
+			}
+		}
+		copies = append(copies, map[string]any{
+			"classification": entry["classification"],
+			"dir_mode":       entry["dir_mode"],
+			"file_mode":      entry["file_mode"],
+			"kind":           entry["kind"],
+			"sha256":         pathMaterialSHA256(sourcePath),
+			"target":         entry["target"],
+		})
+	}
+	credentials := map[string]map[string]any{}
+	for _, key := range sortedStringKeysMap(renderedCredentials) {
+		value := renderedCredentials[key]
+		credentials[key] = map[string]any{
+			"mount_path": value["mount_path"],
+			"sha256":     pathMaterialSHA256(Path(value["source"])),
+		}
+	}
+	ssh := map[string]any{}
+	if len(renderedSSH) > 0 {
+		if value, ok := renderedSSH["config_assurance"].(string); ok {
+			ssh["config_assurance"] = value
+		} else {
+			ssh["config_assurance"] = "off"
+		}
+		if config, ok := renderedSSH["config"].(map[string]any); ok {
+			if source, ok := config["source"].(string); ok {
+				ssh["config"] = map[string]any{
+					"mount_path": config["mount_path"],
+					"sha256":     pathMaterialSHA256(Path(source)),
+				}
+			}
+		}
+		if knownHosts, ok := renderedSSH["known_hosts"].(map[string]any); ok {
+			if source, ok := knownHosts["source"].(string); ok {
+				ssh["known_hosts"] = map[string]any{
+					"mount_path": knownHosts["mount_path"],
+					"sha256":     pathMaterialSHA256(Path(source)),
+				}
+			}
+		}
+		if identities, ok := renderedSSH["identities"].([]map[string]any); ok {
+			renderedIdentities := make([]map[string]any, 0, len(identities))
+			for _, entry := range identities {
+				renderedIdentities = append(renderedIdentities, map[string]any{
+					"mount_path":  entry["mount_path"],
+					"sha256":      pathMaterialSHA256(Path(entry["source"].(string))),
+					"target_name": entry["target_name"],
+				})
+			}
+			ssh["identities"] = renderedIdentities
+		} else if identities, ok := renderedSSH["identities"].([]any); ok {
+			renderedIdentities := make([]map[string]any, 0, len(identities))
+			for _, rawEntry := range identities {
+				entry := rawEntry.(map[string]any)
+				renderedIdentities = append(renderedIdentities, map[string]any{
+					"mount_path":  entry["mount_path"],
+					"sha256":      pathMaterialSHA256(Path(entry["source"].(string))),
+					"target_name": entry["target_name"],
+				})
+			}
+			ssh["identities"] = renderedIdentities
+		}
+	}
+	canonical, _ := json.Marshal(map[string]any{
+		"credentials":    credentials,
+		"copies":         copies,
+		"documents":      documents,
+		"policy_sources": policySources,
+		"ssh":            ssh,
+	})
+	sum := sha256.Sum256(canonical)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func pathMaterialSHA256(path Path) string {
+	info, err := os.Lstat(path.String())
+	if err != nil {
+		return ""
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, _ := os.Readlink(path.String())
+		sum := sha256.Sum256([]byte("symlink:" + target))
+		return hex.EncodeToString(sum[:])
+	}
+	if info.Mode().IsRegular() {
+		data, err := os.ReadFile(path.String())
+		if err != nil {
+			return ""
+		}
+		sum := sha256.Sum256(data)
+		return hex.EncodeToString(sum[:])
+	}
+	if info.IsDir() {
+		hasher := sha256.New()
+		hasher.Write([]byte("dir\n"))
+		children := []string{}
+		_ = filepath.WalkDir(path.String(), func(current string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if current == path.String() {
+				return nil
+			}
+			children = append(children, current)
+			return nil
+		})
+		sort.Slice(children, func(i, j int) bool {
+			return filepath.ToSlash(strings.TrimPrefix(children[i], path.String()+string(filepath.Separator))) < filepath.ToSlash(strings.TrimPrefix(children[j], path.String()+string(filepath.Separator)))
+		})
+		for _, child := range children {
+			info, err := os.Lstat(child)
+			if err != nil {
+				return ""
+			}
+			relative, err := filepath.Rel(path.String(), child)
+			if err != nil {
+				return ""
+			}
+			relative = filepath.ToSlash(relative)
+			switch {
+			case info.Mode()&os.ModeSymlink != 0:
+				target, _ := os.Readlink(child)
+				hasher.Write([]byte("symlink:" + relative + ":" + target + "\n"))
+			case info.IsDir():
+				hasher.Write([]byte("dir:" + relative + "\n"))
+			case info.Mode().IsRegular():
+				hasher.Write([]byte("file:" + relative + "\n"))
+				data, err := os.ReadFile(child)
+				if err != nil {
+					return ""
+				}
+				hasher.Write(data)
+				hasher.Write([]byte("\n"))
+			default:
+				return ""
+			}
+		}
+		return hex.EncodeToString(hasher.Sum(nil))
+	}
+	return ""
+}
+
+func policySHA256(policyPath string) string {
+	data, err := os.ReadFile(policyPath)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func compositePolicySHA256(policySources []PolicySource) string {
+	data, _ := json.Marshal(policySources)
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func logicalPolicyPath(policyPath, entrypointRoot Path) string {
+	relative, err := filepath.Rel(entrypointRoot.String(), policyPath.String())
+	if err != nil {
+		return policyPath.String()
+	}
+	return filepath.ToSlash(relative)
+}
+
+func rebaseFragmentPath(raw any, fragmentDir Path) any {
+	rawStr, ok := raw.(string)
+	if !ok || rawStr == "" {
+		return raw
+	}
+	expanded, err := expandHostPath(rawStr, fragmentDir)
+	if err != nil {
+		return raw
+	}
+	return expanded.String()
+}
+
+func rebasePolicyFragment(policy map[string]any, fragmentDir Path) map[string]any {
+	rebased := map[string]any{}
+	for key, value := range policy {
+		switch key {
+		case "documents":
+			if documents, ok := value.(map[string]any); ok {
+				rebasedDocs := map[string]any{}
+				for documentKey, documentValue := range documents {
+					rebasedDocs[documentKey] = rebaseFragmentPath(documentValue, fragmentDir)
+				}
+				rebased[key] = rebasedDocs
+				continue
+			}
+		case "copies":
+			if copies, ok := value.([]any); ok {
+				rebasedCopies := make([]any, 0, len(copies))
+				for _, entry := range copies {
+					if entryMap, ok := entry.(map[string]any); ok {
+						rebasedEntry := cloneMap(entryMap)
+						if source, ok := rebasedEntry["source"]; ok {
+							rebasedEntry["source"] = rebaseFragmentPath(source, fragmentDir)
+						}
+						rebasedCopies = append(rebasedCopies, rebasedEntry)
+						continue
+					}
+					rebasedCopies = append(rebasedCopies, entry)
+				}
+				rebased[key] = rebasedCopies
+				continue
+			}
+		case "ssh":
+			if ssh, ok := value.(map[string]any); ok {
+				rebasedSSH := cloneMap(ssh)
+				for _, sshKey := range []string{"config", "known_hosts"} {
+					if sshValue, ok := rebasedSSH[sshKey]; ok {
+						rebasedSSH[sshKey] = rebaseFragmentPath(sshValue, fragmentDir)
+					}
+				}
+				if identities, err := anySlice(rebasedSSH["identities"], "ssh.identities"); err == nil {
+					next := make([]any, 0, len(identities))
+					for _, identity := range identities {
+						next = append(next, rebaseFragmentPath(identity, fragmentDir))
+					}
+					rebasedSSH["identities"] = next
+				}
+				rebased[key] = rebasedSSH
+				continue
+			}
+		case "credentials":
+			if credentials, ok := value.(map[string]any); ok {
+				rebasedCredentials := map[string]any{}
+				for credentialKey, credentialValue := range credentials {
+					if credentialMap, ok := credentialValue.(map[string]any); ok {
+						rebasedCredential := cloneMap(credentialMap)
+						if source, ok := rebasedCredential["source"]; ok {
+							rebasedCredential["source"] = rebaseFragmentPath(source, fragmentDir)
+						}
+						rebasedCredentials[credentialKey] = rebasedCredential
+						continue
+					}
+					rebasedCredentials[credentialKey] = rebaseFragmentPath(credentialValue, fragmentDir)
+				}
+				rebased[key] = rebasedCredentials
+				continue
+			}
+		}
+		rebased[key] = value
+	}
+	return rebased
+}
+
+func validatePolicyInclude(raw any, label string, base, entrypointRoot Path) (Path, error) {
+	source, err := validateSourcePath(raw, label, base)
+	if err != nil {
+		return Path(""), err
+	}
+	if err := ensureIsFile(source, label); err != nil {
+		return Path(""), err
+	}
+	if err := requirePathWithin(entrypointRoot, source, label); err != nil {
+		return Path(""), err
+	}
+	return source, nil
+}
+
+func mergePolicyFragment(base, addition map[string]any, sourcePath Path) error {
+	version := 1
+	if rawVersion, ok := addition["version"]; ok {
+		if v, ok := rawVersion.(int); ok {
+			version = v
+		}
+	}
+	if version != 1 {
+		return fmt.Errorf("unsupported injection policy version: %v", version)
+	}
+	for _, tableName := range []string{"documents", "ssh", "credentials"} {
+		table := addition[tableName]
+		if table == nil {
+			continue
+		}
+		tableMap, ok := table.(map[string]any)
+		if !ok {
+			return fmt.Errorf("injection policy fragment must keep %s as a table: %s", tableName, sourcePath)
+		}
+		destination, _ := base[tableName].(map[string]any)
+		if destination == nil {
+			destination = map[string]any{}
+			base[tableName] = destination
+		}
+		for key, value := range tableMap {
+			if _, exists := destination[key]; exists {
+				return fmt.Errorf("injection policy fragments declare the same setting more than once: %s.%s (%s)", tableName, key, sourcePath)
+			}
+			destination[key] = value
+		}
+	}
+	if copies, ok := addition["copies"]; ok {
+		copyList, ok := copies.([]any)
+		if !ok {
+			return fmt.Errorf("injection policy fragment must keep copies as an array of tables: %s", sourcePath)
+		}
+		destinationCopies, _ := base["copies"].([]any)
+		destinationCopies = append(destinationCopies, copyList...)
+		base["copies"] = destinationCopies
+	}
+	return nil
+}
+
+func ensureIsFile(source Path, label string) error {
+	info, err := os.Stat(source.String())
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s must point at a file: %s", label, source)
+	}
+	return nil
+}
+
+func writeIndentedJSON(pathname string, value any, mode os.FileMode) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(pathname, data, mode); err != nil {
+		return err
+	}
+	return os.Chmod(pathname, mode)
+}
+
+func validateContainerTarget(candidate string) (string, error) {
+	if !targetIsUnder(candidate, sessionHomeRoot) && !targetIsUnder(candidate, runInjectedRoot) {
+		return "", fmt.Errorf("injection target must stay under /state/agent-home or /state/injected: %s", candidate)
+	}
+	if targetIsReserved(candidate) {
+		return "", fmt.Errorf("injection target collides with a Workcell-managed control-plane path: %s", candidate)
+	}
+	return candidate, nil
+}
+
+func normalizeContainerTarget(raw string) string {
+	if strings.HasPrefix(raw, "~/") {
+		raw = path.Join(sessionHomeRoot, raw[2:])
+	}
+	candidate := path.Clean(raw)
+	if !path.IsAbs(candidate) {
+		return raw
+	}
+	if strings.Contains(candidate, "..") {
+		return raw
+	}
+	return candidate
+}
+
+func targetIsUnder(candidate, root string) bool {
+	candidate = path.Clean(candidate)
+	root = path.Clean(root)
+	return candidate == root || strings.HasPrefix(candidate, root+"/")
+}
+
+func targetIsReserved(candidate string) bool {
+	candidate = path.Clean(candidate)
+	for _, reserved := range reservedTargets {
+		if candidate == reserved || strings.HasPrefix(candidate, reserved+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func classificationModes(classification string, isDir bool) (string, string, error) {
+	if _, ok := supportedClassifications[classification]; !ok {
+		return "", "", fmt.Errorf("unsupported injection classification: %s", classification)
+	}
+	if classification == "secret" {
+		return "0600", "0700", nil
+	}
+	return "0644", "0755", nil
+}
+
+func secretCopyTargets(renderedCopies []map[string]any) []string {
+	targets := []string{}
+	for _, entry := range renderedCopies {
+		if classification, _ := entry["classification"].(string); classification == "secret" {
+			if target, ok := entry["target"].(string); ok {
+				targets = append(targets, target)
+			}
+		}
+	}
+	sort.Strings(targets)
+	return targets
+}
+
+func sortedStringKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedStringKeysMap(values map[string]map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedSetKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func mapKeysSet(keys []string) map[string]struct{} {
+	allowed := map[string]struct{}{}
+	for _, key := range keys {
+		allowed[key] = struct{}{}
+	}
+	return allowed
+}
+
+func cloneMap(values map[string]any) map[string]any {
+	clone := map[string]any{}
+	for key, value := range values {
+		clone[key] = value
+	}
+	return clone
+}
+
+func containsPath(stack []Path, candidate Path) bool {
+	for _, item := range stack {
+		if item == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+type Path string
+
+func (p Path) String() string {
+	return string(p)
+}
+
+func (p Path) Parent() Path {
+	return Path(filepath.Dir(string(p)))
+}
+
+func (p Path) Join(rel string) Path {
+	return Path(filepath.Join(string(p), rel))
+}
+
+func (p Path) Base() string {
+	return filepath.Base(string(p))
+}
+
+func (p Path) IsDir() bool {
+	info, err := os.Stat(string(p))
+	return err == nil && info.IsDir()
+}
+
+func newPath(value string) Path {
+	return Path(value)
+}
+
+func init() {
+	// Keep the regex-free helpers isolated; no init-time side effects.
+}

--- a/internal/injection/render_injection_bundle_test.go
+++ b/internal/injection/render_injection_bundle_test.go
@@ -1,0 +1,618 @@
+package injection
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseTOMLSubsetAndHelperErrors(t *testing.T) {
+	t.Parallel()
+
+	policyPath := Path("/tmp/policy.toml")
+	parsed, err := parseTOMLSubset(strings.Join([]string{
+		"version = 1",
+		`includes = ["shared.toml"]`,
+		"[documents]",
+		`common = "common.md"`,
+		"[credentials]",
+		`codex_auth = "auth.json"`,
+		"[ssh]",
+		`enabled = true`,
+		`identities = ["id_ed25519"]`,
+		"[[copies]]",
+		`source = "file.txt"`,
+		`target = "/state/injected/file.txt"`,
+		`classification = "public"`,
+	}, "\n"), policyPath)
+	if err != nil {
+		t.Fatalf("parseTOMLSubset error: %v", err)
+	}
+	if parsed["version"] != 1 {
+		t.Fatalf("version = %#v", parsed["version"])
+	}
+	if got := parsed["includes"].([]any); len(got) != 1 || got[0] != "shared.toml" {
+		t.Fatalf("includes = %#v", parsed["includes"])
+	}
+	if got := parsed["documents"].(map[string]any)["common"]; got != "common.md" {
+		t.Fatalf("documents.common = %#v", got)
+	}
+	if got := parsed["credentials"].(map[string]any)["codex_auth"]; got != "auth.json" {
+		t.Fatalf("credentials.codex_auth = %#v", got)
+	}
+	if got := parsed["ssh"].(map[string]any)["enabled"]; got != true {
+		t.Fatalf("ssh.enabled = %#v", got)
+	}
+	if got := parsed["copies"].([]any); len(got) != 1 {
+		t.Fatalf("copies = %#v", parsed["copies"])
+	}
+
+	scoped, err := parseTOMLSubset(strings.Join([]string{
+		"[credentials.codex_auth]",
+		`source = "auth.json"`,
+		`providers = ["codex"]`,
+		`modes = ["strict"]`,
+	}, "\n"), policyPath)
+	if err != nil {
+		t.Fatalf("parseTOMLSubset scoped error: %v", err)
+	}
+	if got := scoped["credentials"].(map[string]any)["codex_auth"].(map[string]any)["providers"]; !reflect.DeepEqual(got, []any{"codex"}) {
+		t.Fatalf("scoped providers = %#v", got)
+	}
+
+	for _, content := range []string{
+		"[[ssh]]\nfoo = \"bar\"\n",
+		"= \"bar\"\n",
+		"nope\n",
+		`credentials.gemini_env = "gemini.env"` + "\n",
+		"[documents]\n[documents]\n",
+	} {
+		content := content
+		t.Run(strings.ReplaceAll(strings.TrimSpace(content), "\n", " "), func(t *testing.T) {
+			t.Parallel()
+			if _, err := parseTOMLSubset(content, policyPath); err == nil {
+				t.Fatalf("expected parseTOMLSubset to fail for %q", content)
+			}
+		})
+	}
+}
+
+func TestLoadPolicyBundleMergesIncludesRebasesAndRejectsBadIncludes(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fragments := filepath.Join(root, "fragments")
+	if err := os.MkdirAll(fragments, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeText(t, filepath.Join(fragments, "common.md"), "common\n", 0o600)
+	writeText(t, filepath.Join(fragments, "copy.txt"), "copy\n", 0o600)
+	writeText(t, filepath.Join(fragments, "auth.json"), "{}\n", 0o600)
+	writeText(t, filepath.Join(fragments, "ssh_config"), "Host github.com\n", 0o600)
+	writeText(t, filepath.Join(fragments, "id_workcell"), "private\n", 0o600)
+	writeText(t, filepath.Join(fragments, "fragment.toml"), strings.Join([]string{
+		"[documents]",
+		`common = "common.md"`,
+		"[[copies]]",
+		`source = "copy.txt"`,
+		`target = "/state/injected/copy.txt"`,
+		`classification = "public"`,
+		"[ssh]",
+		`enabled = true`,
+		`config = "ssh_config"`,
+		`identities = ["id_workcell"]`,
+		"[credentials]",
+		`codex_auth = "auth.json"`,
+	}, "\n"), 0o600)
+	policyPath := filepath.Join(root, "policy.toml")
+	writeText(t, policyPath, strings.Join([]string{
+		"version = 1",
+		`includes = ["fragments/fragment.toml"]`,
+		"[credentials]",
+		`github_hosts = "/tmp/hosts.yml"`,
+	}, "\n"), 0o600)
+
+	merged, sources, err := loadPolicyBundle(Path(policyPath))
+	if err != nil {
+		t.Fatalf("loadPolicyBundle error: %v", err)
+	}
+	wantDoc, err := filepath.EvalSymlinks(filepath.Join(fragments, "common.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := merged["documents"].(map[string]any)["common"]; got != wantDoc {
+		t.Fatalf("documents.common = %v want %v", got, wantDoc)
+	}
+	wantCopy, err := filepath.EvalSymlinks(filepath.Join(fragments, "copy.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := merged["copies"].([]any)[0].(map[string]any)["source"]; got != wantCopy {
+		t.Fatalf("copies[0].source = %v want %v", got, wantCopy)
+	}
+	wantConfig, err := filepath.EvalSymlinks(filepath.Join(fragments, "ssh_config"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := merged["ssh"].(map[string]any)["config"]; got != wantConfig {
+		t.Fatalf("ssh.config = %v want %v", got, wantConfig)
+	}
+	resolvedAuth, err := filepath.EvalSymlinks(filepath.Join(fragments, "auth.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := merged["credentials"].(map[string]any)["codex_auth"]; got != resolvedAuth {
+		t.Fatalf("credentials.codex_auth = %v", got)
+	}
+	if got := []string{sources[0].Path, sources[1].Path}; !reflect.DeepEqual(got, []string{"fragments/fragment.toml", "policy.toml"}) {
+		t.Fatalf("policy sources = %#v", got)
+	}
+	if !strings.HasPrefix(compositePolicySHA256(sources), "sha256:") {
+		t.Fatalf("compositePolicySHA256 missing hash prefix")
+	}
+
+	overridePath := filepath.Join(root, "policy-metadata.json")
+	writeText(t, overridePath, strings.Join([]string{
+		`{"policy_entrypoint":"policy.toml","policy_sources":[`,
+		`{"path":"policy.toml","sha256":"sha256:original"}`,
+		`]}`,
+	}, ""), 0o600)
+	entrypoint, overrideSources, err := loadPolicyMetadataOverride(overridePath)
+	if err != nil {
+		t.Fatalf("loadPolicyMetadataOverride error: %v", err)
+	}
+	if entrypoint != "policy.toml" || len(overrideSources) != 1 || overrideSources[0].Path != "policy.toml" {
+		t.Fatalf("unexpected override metadata: %#v %#v", entrypoint, overrideSources)
+	}
+
+	writeText(t, filepath.Join(root, "shared.toml"), "version = 1\n", 0o600)
+	outside := filepath.Join(filepath.Dir(root), "escape.toml")
+	writeText(t, outside, "version = 1\n", 0o600)
+
+	badCases := []struct {
+		name   string
+		policy string
+		want   string
+	}{
+		{
+			name: "non-list includes",
+			policy: strings.Join([]string{
+				"version = 1",
+				`includes = "shared.toml"`,
+			}, "\n"),
+			want: "includes must be an array of strings",
+		},
+		{
+			name: "duplicate include file",
+			policy: strings.Join([]string{
+				"version = 1",
+				`includes = ["shared.toml", "shared.toml"]`,
+			}, "\n"),
+			want: "same file more than once",
+		},
+		{
+			name: "escape include",
+			policy: strings.Join([]string{
+				"version = 1",
+				`includes = ["../escape.toml"]`,
+			}, "\n"),
+			want: "must stay within",
+		},
+	}
+	for _, tc := range badCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			p := filepath.Join(root, tc.name+".toml")
+			writeText(t, p, tc.policy, 0o600)
+			if _, _, err := loadPolicyBundle(Path(p)); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestRebasePolicyFragmentAndValidationHelpers(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fragmentDir := filepath.Join(root, "fragment")
+	if err := os.MkdirAll(fragmentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeText(t, filepath.Join(fragmentDir, "common.md"), "common\n", 0o600)
+	writeText(t, filepath.Join(fragmentDir, "copy.txt"), "copy\n", 0o600)
+	writeText(t, filepath.Join(fragmentDir, "ssh_config"), "Host github.com\n", 0o600)
+	writeText(t, filepath.Join(fragmentDir, "known_hosts"), "github.com ssh-ed25519 AAAA\n", 0o600)
+	writeText(t, filepath.Join(fragmentDir, "id_workcell"), "private\n", 0o600)
+	writeText(t, filepath.Join(fragmentDir, "auth.json"), "{}\n", 0o600)
+
+	rebased := rebasePolicyFragment(map[string]any{
+		"documents": map[string]any{"common": "common.md"},
+		"copies": []any{
+			map[string]any{"source": "copy.txt", "target": "/state/injected/copy.txt"},
+			"literal",
+		},
+		"ssh": map[string]any{
+			"config":      "ssh_config",
+			"known_hosts": "known_hosts",
+			"identities":  []any{"id_workcell"},
+		},
+		"credentials": map[string]any{
+			"codex_auth": "auth.json",
+			"github_hosts": map[string]any{
+				"source":    "hosts.yml",
+				"providers": []any{"codex"},
+			},
+		},
+	}, Path(fragmentDir))
+
+	want := func(relative string) string {
+		return filepath.Join(fragmentDir, relative)
+	}
+	if got := rebased["documents"].(map[string]any)["common"]; got != want("common.md") {
+		t.Fatalf("documents.common = %v", got)
+	}
+	if got := rebased["copies"].([]any)[0].(map[string]any)["source"]; got != want("copy.txt") {
+		t.Fatalf("copies[0].source = %v", got)
+	}
+	if got := rebased["copies"].([]any)[1]; got != "literal" {
+		t.Fatalf("copies[1] = %v", got)
+	}
+	if got := rebased["ssh"].(map[string]any)["config"]; got != want("ssh_config") {
+		t.Fatalf("ssh.config = %v", got)
+	}
+	if got := rebased["ssh"].(map[string]any)["known_hosts"]; got != want("known_hosts") {
+		t.Fatalf("ssh.known_hosts = %v", got)
+	}
+	if got := rebased["ssh"].(map[string]any)["identities"].([]any)[0]; got != want("id_workcell") {
+		t.Fatalf("ssh.identities[0] = %v", got)
+	}
+	if got := rebased["credentials"].(map[string]any)["codex_auth"]; got != want("auth.json") {
+		t.Fatalf("credentials.codex_auth = %v", got)
+	}
+	if got := rebased["credentials"].(map[string]any)["github_hosts"].(map[string]any)["source"]; got != want("hosts.yml") {
+		t.Fatalf("credentials.github_hosts.source = %v", got)
+	}
+
+	if ok, err := selectedFor(nil, "codex", "providers", supportedAgents); err != nil || !ok {
+		t.Fatalf("selectedFor(nil) = %v, %v", ok, err)
+	}
+	ok, err := selectedFor([]any{"claude"}, "codex", "providers", supportedAgents)
+	if err != nil {
+		t.Fatalf("selectedFor filter error: %v", err)
+	}
+	if ok {
+		t.Fatal("selectedFor filter unexpectedly matched")
+	}
+	if _, err := selectedFor([]any{"codex", 1}, "codex", "providers", supportedAgents); err == nil {
+		t.Fatal("selectedFor accepted non-string value")
+	}
+	if err := validateAllowedKeys(map[string]any{"a": 1}, map[string]struct{}{"a": {}}, "table"); err != nil {
+		t.Fatalf("validateAllowedKeys error: %v", err)
+	}
+	if err := validateAllowedKeys(map[string]any{"a": 1, "b": 2}, map[string]struct{}{"a": {}}, "table"); err == nil {
+		t.Fatal("validateAllowedKeys accepted unsupported key")
+	}
+
+	target := normalizeContainerTarget("~/notes.txt")
+	if target != "/state/agent-home/notes.txt" {
+		t.Fatalf("normalizeContainerTarget = %s", target)
+	}
+	if got, err := validateContainerTarget("/state/injected/notes.txt"); err != nil || got != "/state/injected/notes.txt" {
+		t.Fatalf("validateContainerTarget = %q, %v", got, err)
+	}
+	for _, bad := range []string{"relative.txt", "/tmp/outside", "/state/agent-home/.mcp.json"} {
+		if _, err := validateContainerTarget(bad); err == nil {
+			t.Fatalf("validateContainerTarget accepted %q", bad)
+		}
+	}
+}
+
+func TestRenderHelpersAndManifestParity(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	output := filepath.Join(root, "bundle")
+	if err := os.MkdirAll(output, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	writeText(t, filepath.Join(root, "common.md"), "common\n", 0o600)
+	writeText(t, filepath.Join(root, "codex.md"), "codex\n", 0o600)
+	writeText(t, filepath.Join(root, "public.txt"), "public\n", 0o600)
+	writeText(t, filepath.Join(root, "secret.txt"), "secret\n", 0o600)
+	writeText(t, filepath.Join(root, "public-dir", "note.txt"), "note\n", 0o600)
+	writeText(t, filepath.Join(root, "secret-dir", "token.txt"), "token\n", 0o600)
+	if err := os.Chmod(filepath.Join(root, "public-dir"), 0o755); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filepath.Join(root, "secret-dir"), 0o700); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	writeText(t, filepath.Join(root, "ssh-config"), "Host github.com\n  IdentityFile ~/.ssh/id_ed25519\n", 0o600)
+	writeText(t, filepath.Join(root, "unsafe-ssh-config"), "Host *\nProxyCommand nc %h %p\n", 0o600)
+	writeText(t, filepath.Join(root, "forwardagent-ssh-config"), "Host *\nForwardAgent yes\n", 0o600)
+	writeText(t, filepath.Join(root, "sendenv-ssh-config"), "Host *\nSendEnv FOO\n", 0o600)
+	writeText(t, filepath.Join(root, "known_hosts"), "github.com ssh-ed25519 AAAA\n", 0o644)
+	writeText(t, filepath.Join(root, "id_a"), "key-a\n", 0o600)
+	writeText(t, filepath.Join(root, "id_b"), "key-b\n", 0o600)
+	writeText(t, filepath.Join(root, "claude-auth.json"), `{"token":"claude"}`+"\n", 0o600)
+	writeText(t, filepath.Join(root, "world-readable-auth.json"), `{"token":"public"}`+"\n", 0o644)
+	writeText(t, filepath.Join(root, "claude-mcp.json"), `{"mcpServers":{}}`+"\n", 0o600)
+	writeText(t, filepath.Join(root, "gemini-projects.json"), `{"projects":{}}`+"\n", 0o600)
+	writeText(t, filepath.Join(root, "gemini.env"), "GOOGLE_GENAI_USE_GCA=true\n", 0o600)
+	writeText(t, filepath.Join(root, "gemini-invalid.env"), "GOOGLE_API_KEY=test\n", 0o600)
+
+	documents, err := renderDocuments(map[string]any{
+		"documents": map[string]any{
+			"common": "common.md",
+			"codex":  "codex.md",
+		},
+	}, Path(output), Path(root))
+	if err != nil {
+		t.Fatalf("renderDocuments error: %v", err)
+	}
+	if documents["common"] != "documents/common.md" || documents["codex"] != "documents/codex.md" {
+		t.Fatalf("renderDocuments = %#v", documents)
+	}
+	if got := readText(t, filepath.Join(output, "documents", "common.md")); got != "common\n" {
+		t.Fatalf("staged document content = %q", got)
+	}
+	assertRenderFileMode(t, filepath.Join(output, "documents", "common.md"), 0o600)
+
+	copies, err := renderCopies(map[string]any{
+		"copies": []any{
+			map[string]any{
+				"source":         "public.txt",
+				"target":         "/state/injected/public.txt",
+				"classification": "public",
+			},
+			map[string]any{
+				"source":         "secret.txt",
+				"target":         "~/.config/workcell/token.txt",
+				"classification": "secret",
+			},
+			map[string]any{
+				"source":         "public-dir",
+				"target":         "/state/injected/public-dir",
+				"classification": "public",
+			},
+			map[string]any{
+				"source":         "secret-dir",
+				"target":         "~/.config/workcell/secrets",
+				"classification": "secret",
+			},
+			map[string]any{
+				"source":         "secret.txt",
+				"target":         "/state/injected/skipped.txt",
+				"classification": "public",
+				"providers":      []any{"claude"},
+			},
+		},
+	}, Path(output), Path(root), "codex", "strict")
+	if err != nil {
+		t.Fatalf("renderCopies error: %v", err)
+	}
+	if len(copies) != 4 {
+		t.Fatalf("renderCopies len = %d", len(copies))
+	}
+	if copies[0]["source"] != "copies/0" {
+		t.Fatalf("renderCopies public source = %#v", copies[0]["source"])
+	}
+	if got := copies[1]["source"].(map[string]string)["mount_path"]; got != "/opt/workcell/host-inputs/copies/1" {
+		t.Fatalf("renderCopies secret mount_path = %q", got)
+	}
+	if kind := copies[2]["kind"]; kind != "dir" {
+		t.Fatalf("renderCopies public dir kind = %#v", kind)
+	}
+	if kind := copies[3]["kind"]; kind != "dir" {
+		t.Fatalf("renderCopies secret dir kind = %#v", kind)
+	}
+	assertRenderFileMode(t, filepath.Join(output, "copies", "0"), 0o600)
+	assertRenderFileMode(t, filepath.Join(output, "copies", "2"), 0o700)
+	if got := readText(t, filepath.Join(output, "copies", "2", "note.txt")); got != "note\n" {
+		t.Fatalf("staged directory content = %q", got)
+	}
+
+	sshRendered, err := renderSSH(map[string]any{
+		"ssh": map[string]any{
+			"enabled":             true,
+			"config":              "ssh-config",
+			"known_hosts":         "known_hosts",
+			"identities":          []any{"id_a", "id_b"},
+			"allow_unsafe_config": true,
+		},
+	}, Path(output), Path(root), "codex", "strict")
+	if err != nil {
+		t.Fatalf("renderSSH error: %v", err)
+	}
+	if sshRendered["config_assurance"] != "lower-assurance-unsafe-config" {
+		t.Fatalf("renderSSH config_assurance = %#v", sshRendered["config_assurance"])
+	}
+	if len(sshRendered["identities"].([]map[string]any)) != 2 {
+		t.Fatalf("renderSSH identities = %#v", sshRendered["identities"])
+	}
+	if _, err := renderSSH(map[string]any{
+		"ssh": map[string]any{
+			"enabled": true,
+			"config":  "unsafe-ssh-config",
+		},
+	}, Path(output), Path(root), "codex", "strict"); err == nil || !strings.Contains(err.Error(), "unsafe directive") {
+		t.Fatalf("renderSSH unsafe config error = %v", err)
+	}
+	for _, fileName := range []string{"forwardagent-ssh-config", "sendenv-ssh-config"} {
+		if _, err := renderSSH(map[string]any{
+			"ssh": map[string]any{
+				"enabled": true,
+				"config":  fileName,
+			},
+		}, Path(output), Path(root), "codex", "strict"); err == nil || !strings.Contains(err.Error(), "unsafe directive") {
+			t.Fatalf("renderSSH %s error = %v", fileName, err)
+		}
+	}
+
+	claudeCredentials, err := renderCredentials(map[string]any{
+		"credentials": map[string]any{
+			"claude_auth": "claude-auth.json",
+			"claude_mcp":  "claude-mcp.json",
+			"github_hosts": map[string]any{
+				"source":    "claude-auth.json",
+				"providers": []any{"claude"},
+			},
+		},
+	}, Path(root), "claude", "strict")
+	if err != nil {
+		t.Fatalf("renderCredentials claude error: %v", err)
+	}
+	if _, ok := claudeCredentials["claude_auth"]; !ok {
+		t.Fatalf("renderCredentials missing claude_auth: %#v", claudeCredentials)
+	}
+	if _, ok := claudeCredentials["claude_mcp"]; !ok {
+		t.Fatalf("renderCredentials missing claude_mcp: %#v", claudeCredentials)
+	}
+	if _, ok := claudeCredentials["github_hosts"]; !ok {
+		t.Fatalf("renderCredentials missing github_hosts: %#v", claudeCredentials)
+	}
+
+	geminiCredentials, err := renderCredentials(map[string]any{
+		"credentials": map[string]any{
+			"gemini_env":      "gemini.env",
+			"gemini_projects": "gemini-projects.json",
+		},
+	}, Path(root), "gemini", "strict")
+	if err != nil {
+		t.Fatalf("renderCredentials gemini error: %v", err)
+	}
+	if _, ok := geminiCredentials["gemini_env"]; !ok {
+		t.Fatalf("renderCredentials missing gemini_env: %#v", geminiCredentials)
+	}
+	if _, ok := geminiCredentials["gemini_projects"]; !ok {
+		t.Fatalf("renderCredentials missing gemini_projects: %#v", geminiCredentials)
+	}
+	if got := deriveCredentialExtraEndpoints(geminiCredentials); !reflect.DeepEqual(got, []string{"accounts.google.com:443", "oauth2.googleapis.com:443", "sts.googleapis.com:443"}) {
+		t.Fatalf("deriveCredentialExtraEndpoints = %#v", got)
+	}
+
+	if _, err := renderCredentials(map[string]any{
+		"credentials": map[string]any{
+			"gemini_env": "gemini-invalid.env",
+		},
+	}, Path(root), "gemini", "strict"); err == nil {
+		t.Fatal("renderCredentials accepted invalid gemini env unexpectedly")
+	}
+	if _, err := renderCredentials(map[string]any{
+		"credentials": map[string]any{
+			"codex_auth": "world-readable-auth.json",
+		},
+	}, Path(root), "codex", "strict"); err == nil || !strings.Contains(err.Error(), "group/world-accessible") {
+		t.Fatalf("renderCredentials world-readable secret error = %v", err)
+	}
+}
+
+func TestRunRenderInjectionBundleWritesManifestAndTracksMaterialChanges(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	outputA := filepath.Join(root, "bundle-a")
+	outputB := filepath.Join(root, "bundle-b")
+	writeText(t, filepath.Join(root, "common.md"), "common\n", 0o600)
+	credentialPath := filepath.Join(root, "auth.json")
+	writeText(t, credentialPath, `{"token":"one"}`+"\n", 0o600)
+	writeText(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[documents]",
+		`common = "common.md"`,
+		"[credentials]",
+		`codex_auth = "auth.json"`,
+	}, "\n"), 0o600)
+
+	if err := RunRenderInjectionBundle(policyPath, "codex", "strict", outputA, ""); err != nil {
+		t.Fatalf("RunRenderInjectionBundle outputA error: %v", err)
+	}
+	manifestA := readManifest(t, filepath.Join(outputA, "manifest.json"))
+
+	writeText(t, credentialPath, `{"token":"two"}`+"\n", 0o600)
+	if err := RunRenderInjectionBundle(policyPath, "codex", "strict", outputB, ""); err != nil {
+		t.Fatalf("RunRenderInjectionBundle outputB error: %v", err)
+	}
+	manifestB := readManifest(t, filepath.Join(outputB, "manifest.json"))
+
+	metaA := manifestA["metadata"].(map[string]any)
+	metaB := manifestB["metadata"].(map[string]any)
+	if metaA["policy_sha256"] == metaB["policy_sha256"] {
+		t.Fatalf("policy hash did not change after credential mutation: %v", metaA["policy_sha256"])
+	}
+	if metaA["ssh_enabled"] != false || metaA["ssh_config_assurance"] != "off" {
+		t.Fatalf("unexpected ssh metadata: %#v", metaA)
+	}
+
+	overridePath := filepath.Join(root, "policy-metadata.json")
+	writeText(t, overridePath, strings.Join([]string{
+		`{"policy_entrypoint":"policy.toml","policy_sources":[`,
+		`{"path":"policy.toml","sha256":"sha256:original"}`,
+		`]}`,
+	}, ""), 0o600)
+	outputC := filepath.Join(root, "bundle-c")
+	if err := RunRenderInjectionBundle(policyPath, "codex", "strict", outputC, overridePath); err != nil {
+		t.Fatalf("RunRenderInjectionBundle override error: %v", err)
+	}
+	manifestC := readManifest(t, filepath.Join(outputC, "manifest.json"))
+	metaC := manifestC["metadata"].(map[string]any)
+	if metaC["policy_entrypoint"] != "policy.toml" {
+		t.Fatalf("policy_entrypoint = %#v", metaC["policy_entrypoint"])
+	}
+	sources := metaC["policy_sources"].([]any)
+	if len(sources) != 1 || sources[0].(map[string]any)["path"] != "policy.toml" {
+		t.Fatalf("policy_sources = %#v", metaC["policy_sources"])
+	}
+}
+
+func writeText(t *testing.T, path, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readText(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func assertRenderFileMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode mismatch for %s: got %04o want %04o", path, got, want)
+	}
+}
+
+func readManifest(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest map[string]any
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}

--- a/internal/policybundle/policy_bundle.go
+++ b/internal/policybundle/policy_bundle.go
@@ -1,0 +1,1252 @@
+package policybundle
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"unicode/utf8"
+)
+
+var SupportedAgents = map[string]struct{}{
+	"codex":  {},
+	"claude": {},
+	"gemini": {},
+}
+
+var SupportedModes = map[string]struct{}{
+	"strict":     {},
+	"build":      {},
+	"breakglass": {},
+}
+
+var CredentialKeys = map[string]struct{}{
+	"codex_auth":      {},
+	"claude_auth":     {},
+	"claude_api_key":  {},
+	"claude_mcp":      {},
+	"gemini_env":      {},
+	"gemini_oauth":    {},
+	"gemini_projects": {},
+	"gcloud_adc":      {},
+	"github_hosts":    {},
+	"github_config":   {},
+}
+
+var AgentScopedCredentialKeys = map[string]map[string]struct{}{
+	"codex": {
+		"codex_auth": {},
+	},
+	"claude": {
+		"claude_api_key": {},
+		"claude_auth":    {},
+		"claude_mcp":     {},
+	},
+	"gemini": {
+		"gemini_env":      {},
+		"gemini_oauth":    {},
+		"gemini_projects": {},
+		"gcloud_adc":      {},
+	},
+}
+
+var SharedCredentialKeys = map[string]struct{}{
+	"github_hosts":  {},
+	"github_config": {},
+}
+
+var AllowedRootPolicyKeys = map[string]struct{}{
+	"version":     {},
+	"includes":    {},
+	"documents":   {},
+	"ssh":         {},
+	"copies":      {},
+	"credentials": {},
+}
+
+var systemSymlinkAllowlist = map[string]struct{}{}
+
+var getUID = os.Getuid
+
+func init() {
+	if runtime.GOOS == "darwin" {
+		systemSymlinkAllowlist["/var"] = struct{}{}
+		systemSymlinkAllowlist["/tmp"] = struct{}{}
+	}
+}
+
+type PolicySource struct {
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"`
+}
+
+func die(message string) error {
+	return errors.New(message)
+}
+
+func ExpandHostPath(raw string, base string) (string, error) {
+	expanded, err := expandUserPath(raw)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(expanded) {
+		expanded = filepath.Join(base, expanded)
+	}
+	return filepath.Abs(expanded)
+}
+
+func RequirePathWithin(root string, candidate string, label string) error {
+	resolvedRoot, err := resolveExistingPath(root)
+	if err != nil {
+		return err
+	}
+	resolvedCandidate, err := resolveExistingPath(candidate)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(resolvedRoot, resolvedCandidate)
+	if err != nil {
+		return err
+	}
+	if rel == "." {
+		return nil
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return die(fmt.Sprintf("%s must stay within %s: %s", label, resolvedRoot, resolvedCandidate))
+	}
+	return nil
+}
+
+func RequireNoSymlinkInPathChain(path string, label string) error {
+	current := filepath.Clean(path)
+	for {
+		info, err := os.Lstat(current)
+		if err == nil {
+			if info.Mode()&os.ModeSymlink != 0 && !systemSymlinkAllowed(current) {
+				return die(fmt.Sprintf("%s must not be a symlink: %s", label, current))
+			}
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
+}
+
+func ValidateSourcePath(raw any, label string, base string) (string, error) {
+	text, ok := raw.(string)
+	if !ok || text == "" {
+		return "", die(fmt.Sprintf("%s must be a non-empty string path", label))
+	}
+	source, err := ExpandHostPath(text, base)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(source); err != nil {
+		return "", die(fmt.Sprintf("%s does not exist: %s", label, source))
+	}
+	if err := RequireNoSymlinkInPathChain(source, label); err != nil {
+		return "", err
+	}
+	return source, nil
+}
+
+func ValidateAllowedKeys(table map[string]any, allowedKeys map[string]struct{}, label string) error {
+	unknown := make([]string, 0)
+	for key := range table {
+		if _, ok := allowedKeys[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	sort.Strings(unknown)
+	if len(unknown) > 0 {
+		return die(fmt.Sprintf("%s contains unsupported keys: %s", label, strings.Join(unknown, ", ")))
+	}
+	return nil
+}
+
+func SelectedFor(values any, current string, label string, allowedValues map[string]struct{}) (bool, error) {
+	if values == nil {
+		return true, nil
+	}
+	items, err := stringList(values)
+	if err != nil {
+		if err.Error() == "values must be strings" {
+			return false, err
+		}
+		return false, die(fmt.Sprintf("%s must be a non-empty array when specified", label))
+	}
+	if len(items) == 0 {
+		return false, die(fmt.Sprintf("%s must be a non-empty array when specified", label))
+	}
+	for _, value := range items {
+		if _, ok := allowedValues[value]; !ok {
+			return false, die(fmt.Sprintf("%s contains unsupported value: %s", label, value))
+		}
+	}
+	return contains(items, current), nil
+}
+
+func StripComment(line string) string {
+	escaped := false
+	quoteChar := byte(0)
+	result := make([]byte, 0, len(line))
+	for i := 0; i < len(line); i++ {
+		char := line[i]
+		if escaped {
+			result = append(result, char)
+			escaped = false
+			continue
+		}
+		if char == '\\' && quoteChar == '"' {
+			result = append(result, char)
+			escaped = true
+			continue
+		}
+		if char == '"' || char == '\'' {
+			if quoteChar == 0 {
+				quoteChar = char
+			} else if quoteChar == char {
+				quoteChar = 0
+			}
+			result = append(result, char)
+			continue
+		}
+		if char == '#' && quoteChar == 0 {
+			break
+		}
+		result = append(result, char)
+	}
+	return strings.TrimSpace(string(result))
+}
+
+func ParseValue(raw string, policyPath string, lineno int) (any, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return nil, die(fmt.Sprintf("%s:%d: expected a value", policyPath, lineno))
+	}
+	if value == "true" || value == "false" {
+		return value == "true", nil
+	}
+	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+		return unquoteDoubleQuoted(value, policyPath, lineno)
+	}
+	if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+		return parseArrayOfStrings(value, policyPath, lineno)
+	}
+	if digitsOnly(value) {
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			return nil, err
+		}
+		return n, nil
+	}
+	return nil, die(fmt.Sprintf(
+		"%s:%d: unsupported TOML value; use quoted strings, booleans, integers, or arrays of strings",
+		policyPath, lineno,
+	))
+}
+
+func ParseTOMLSubset(content string, policyPath string) (map[string]any, error) {
+	root := map[string]any{}
+	current := root
+	seenTables := map[string]struct{}{}
+
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := StripComment(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[[") && strings.HasSuffix(line, "]]") {
+			tableName := strings.TrimSpace(line[2 : len(line)-2])
+			if tableName != "copies" {
+				return nil, die(fmt.Sprintf("%s:%d: unsupported array-of-table [%s]", policyPath, lineNo, tableName))
+			}
+			copies, ok := root["copies"].([]map[string]any)
+			if !ok && root["copies"] != nil {
+				return nil, die(fmt.Sprintf("%s:%d: copies must remain an array of tables", policyPath, lineNo))
+			}
+			entry := map[string]any{}
+			copies = append(copies, entry)
+			root["copies"] = copies
+			current = entry
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			tableName := strings.TrimSpace(line[1 : len(line)-1])
+			if _, ok := seenTables[tableName]; ok {
+				return nil, die(fmt.Sprintf("%s:%d: duplicate table [%s]", policyPath, lineNo, tableName))
+			}
+			seenTables[tableName] = struct{}{}
+			if strings.HasPrefix(tableName, "credentials.") {
+				credentialKey := strings.SplitN(tableName, ".", 2)[1]
+				if _, ok := CredentialKeys[credentialKey]; !ok {
+					return nil, die(fmt.Sprintf("%s:%d: unsupported credentials table [%s]", policyPath, lineNo, tableName))
+				}
+				credentials, ok := root["credentials"].(map[string]any)
+				if !ok {
+					credentials = map[string]any{}
+					root["credentials"] = credentials
+				}
+				entry, ok := credentials[credentialKey].(map[string]any)
+				if !ok {
+					entry = map[string]any{}
+					credentials[credentialKey] = entry
+				}
+				current = entry
+				continue
+			}
+			if tableName != "documents" && tableName != "ssh" && tableName != "credentials" {
+				return nil, die(fmt.Sprintf("%s:%d: unsupported table [%s]", policyPath, lineNo, tableName))
+			}
+			table, ok := root[tableName].(map[string]any)
+			if !ok {
+				table = map[string]any{}
+				root[tableName] = table
+			}
+			current = table
+			continue
+		}
+
+		if !strings.Contains(line, "=") {
+			return nil, die(fmt.Sprintf("%s:%d: expected key = value", policyPath, lineNo))
+		}
+		parts := strings.SplitN(line, "=", 2)
+		key := strings.TrimSpace(parts[0])
+		value := parts[1]
+		if key == "" {
+			return nil, die(fmt.Sprintf("%s:%d: empty key", policyPath, lineNo))
+		}
+		if strings.Contains(key, ".") {
+			return nil, die(fmt.Sprintf(
+				"%s:%d: dotted TOML keys are not supported; use explicit [table] headers instead",
+				policyPath, lineNo,
+			))
+		}
+		if _, ok := current[key]; ok {
+			return nil, die(fmt.Sprintf("%s:%d: duplicate key: %s", policyPath, lineNo, key))
+		}
+		parsed, err := ParseValue(value, policyPath, lineNo)
+		if err != nil {
+			return nil, err
+		}
+		current[key] = parsed
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return root, nil
+}
+
+func PolicySHA256(policyPath string) (string, error) {
+	data, err := os.ReadFile(policyPath)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func CompositePolicySHA256(policySources []PolicySource) string {
+	sources := make([]PolicySource, len(policySources))
+	copy(sources, policySources)
+	sort.SliceStable(sources, func(i, j int) bool {
+		return sources[i].Path < sources[j].Path
+	})
+	var b strings.Builder
+	b.WriteByte('[')
+	for i, source := range sources {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString("{'path': ")
+		b.WriteString(pythonReprString(source.Path))
+		b.WriteString(", 'sha256': ")
+		b.WriteString(pythonReprString(source.SHA256))
+		b.WriteByte('}')
+	}
+	b.WriteByte(']')
+	sum := sha256.Sum256([]byte(b.String()))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func LogicalPolicyPath(policyPath string, entrypointRoot string) (string, error) {
+	rel, err := filepath.Rel(entrypointRoot, policyPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func RebaseFragmentPath(raw any, fragmentDir string) any {
+	text, ok := raw.(string)
+	if !ok || text == "" {
+		return raw
+	}
+	rebased, err := ExpandHostPath(text, fragmentDir)
+	if err != nil {
+		return raw
+	}
+	return rebased
+}
+
+func RebasePolicyFragment(policy map[string]any, fragmentDir string) map[string]any {
+	rebased := map[string]any{}
+	for key, value := range policy {
+		switch key {
+		case "documents":
+			if documents, ok := asStringMap(value); ok {
+				next := map[string]any{}
+				for documentKey, documentValue := range documents {
+					next[documentKey] = RebaseFragmentPath(documentValue, fragmentDir)
+				}
+				rebased[key] = next
+				continue
+			}
+		case "copies":
+			if copies, ok := value.([]map[string]any); ok {
+				next := make([]map[string]any, 0, len(copies))
+				for _, entry := range copies {
+					if entry == nil {
+						next = append(next, nil)
+						continue
+					}
+					rebasedEntry := cloneStringAnyMap(entry)
+					if source, ok := rebasedEntry["source"]; ok {
+						rebasedEntry["source"] = RebaseFragmentPath(source, fragmentDir)
+					}
+					next = append(next, rebasedEntry)
+				}
+				rebased[key] = next
+				continue
+			}
+		case "ssh":
+			if ssh, ok := asStringMap(value); ok {
+				next := cloneAnyMap(ssh)
+				for _, sshKey := range []string{"config", "known_hosts"} {
+					if rawValue, ok := next[sshKey]; ok {
+						next[sshKey] = RebaseFragmentPath(rawValue, fragmentDir)
+					}
+				}
+				if identities, ok := next["identities"].([]string); ok {
+					nextIdentities := make([]string, len(identities))
+					for i, identity := range identities {
+						rebasedIdentity, _ := RebaseFragmentPath(identity, fragmentDir).(string)
+						nextIdentities[i] = rebasedIdentity
+					}
+					next["identities"] = nextIdentities
+				}
+				if identities, ok := next["identities"].([]any); ok {
+					nextIdentities := make([]any, len(identities))
+					for i, identity := range identities {
+						nextIdentities[i] = RebaseFragmentPath(identity, fragmentDir)
+					}
+					next["identities"] = nextIdentities
+				}
+				rebased[key] = next
+				continue
+			}
+		case "credentials":
+			if credentials, ok := asStringMap(value); ok {
+				next := map[string]any{}
+				for credentialKey, credentialValue := range credentials {
+					if entry, ok := asStringMap(credentialValue); ok {
+						rebasedEntry := cloneAnyMap(entry)
+						if source, ok := rebasedEntry["source"]; ok {
+							rebasedEntry["source"] = RebaseFragmentPath(source, fragmentDir)
+						}
+						next[credentialKey] = rebasedEntry
+					} else {
+						next[credentialKey] = RebaseFragmentPath(credentialValue, fragmentDir)
+					}
+				}
+				rebased[key] = next
+				continue
+			}
+		}
+		rebased[key] = value
+	}
+	return rebased
+}
+
+func ValidatePolicyInclude(raw any, label string, base string, entrypointRoot string) (string, error) {
+	source, err := ValidateSourcePath(raw, label, base)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() && !info.Mode().IsRegular() {
+		return "", die(fmt.Sprintf("%s must point at a file: %s", label, source))
+	}
+	if info.IsDir() {
+		return "", die(fmt.Sprintf("%s must point at a file: %s", label, source))
+	}
+	resolvedSource, err := resolveExistingPath(source)
+	if err != nil {
+		return "", err
+	}
+	if err := RequirePathWithin(entrypointRoot, resolvedSource, label); err != nil {
+		return "", err
+	}
+	return resolvedSource, nil
+}
+
+func MergePolicyFragment(base map[string]any, addition map[string]any, sourcePath string) error {
+	version := 1
+	if raw, ok := addition["version"]; ok {
+		if v, ok := raw.(int); ok {
+			version = v
+		} else {
+			return die(fmt.Sprintf("unsupported injection policy version: %v", raw))
+		}
+	}
+	if version != 1 {
+		return die(fmt.Sprintf("unsupported injection policy version: %d", version))
+	}
+
+	for _, tableName := range []string{"documents", "ssh", "credentials"} {
+		table := addition[tableName]
+		if table == nil {
+			continue
+		}
+		tableMap, ok := table.(map[string]any)
+		if !ok {
+			return die(fmt.Sprintf("injection policy fragment must keep %s as a table: %s", tableName, sourcePath))
+		}
+		destination, ok := base[tableName].(map[string]any)
+		if !ok {
+			if base[tableName] != nil {
+				return die(fmt.Sprintf("injection policy merge corrupted %s: %s", tableName, sourcePath))
+			}
+			destination = map[string]any{}
+			base[tableName] = destination
+		}
+		for key, value := range tableMap {
+			if _, exists := destination[key]; exists {
+				return die(fmt.Sprintf(
+					"injection policy fragments declare the same setting more than once: %s.%s (%s)",
+					tableName, key, sourcePath,
+				))
+			}
+			destination[key] = value
+		}
+	}
+
+	copies := addition["copies"]
+	if copies == nil {
+		return nil
+	}
+	copyList, ok := copies.([]map[string]any)
+	if !ok {
+		if _, ok := copies.([]any); ok {
+			return die(fmt.Sprintf("injection policy fragment must keep copies as an array of tables: %s", sourcePath))
+		}
+		return die(fmt.Sprintf("injection policy fragment must keep copies as an array of tables: %s", sourcePath))
+	}
+	destinationCopies, ok := base["copies"].([]map[string]any)
+	if !ok && base["copies"] != nil {
+		return die(fmt.Sprintf("injection policy merge corrupted copies: %s", sourcePath))
+	}
+	destinationCopies = append(destinationCopies, copyList...)
+	base["copies"] = destinationCopies
+	return nil
+}
+
+func LoadPolicyBundle(policyPath string) (map[string]any, []PolicySource, error) {
+	return loadPolicyBundle(policyPath, "", nil, map[string]struct{}{})
+}
+
+func LoadPolicyBundleAt(policyPath string, entrypointRoot string) (map[string]any, []PolicySource, error) {
+	return loadPolicyBundle(policyPath, entrypointRoot, nil, map[string]struct{}{})
+}
+
+func loadPolicyBundle(policyPath string, entrypointRoot string, activeStack []string, loadedPaths map[string]struct{}) (map[string]any, []PolicySource, error) {
+	resolvedPolicyPath, err := resolveExistingPath(policyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	if entrypointRoot == "" {
+		entrypointRoot = filepath.Dir(resolvedPolicyPath)
+	} else {
+		entrypointRoot, err = resolveExistingPath(entrypointRoot)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	if contains(activeStack, resolvedPolicyPath) {
+		cycle := append(append([]string{}, activeStack...), resolvedPolicyPath)
+		return nil, nil, die(fmt.Sprintf("injection policy include cycle detected: %s", strings.Join(cycle, " -> ")))
+	}
+	if _, ok := loadedPaths[resolvedPolicyPath]; ok {
+		return nil, nil, die(fmt.Sprintf("injection policy includes the same file more than once: %s", resolvedPolicyPath))
+	}
+	loadedPaths[resolvedPolicyPath] = struct{}{}
+
+	data, err := os.ReadFile(resolvedPolicyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	loaded, err := ParseTOMLSubset(string(data), resolvedPolicyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	if loaded == nil {
+		return nil, nil, die(fmt.Sprintf("injection policy must decode to a TOML table: %s", resolvedPolicyPath))
+	}
+	if err := ValidateAllowedKeys(loaded, AllowedRootPolicyKeys, "root policy"); err != nil {
+		return nil, nil, err
+	}
+
+	version := 1
+	if rawVersion, ok := loaded["version"]; ok {
+		if v, ok := rawVersion.(int); ok {
+			version = v
+		} else {
+			return nil, nil, die(fmt.Sprintf("unsupported injection policy version: %v", rawVersion))
+		}
+	}
+	if version != 1 {
+		return nil, nil, die(fmt.Sprintf("unsupported injection policy version: %d", version))
+	}
+
+	includes := []string{}
+	if rawIncludes, ok := loaded["includes"]; ok {
+		if rawIncludes == nil {
+			includes = []string{}
+		} else {
+			var ok bool
+			includes, ok = rawIncludes.([]string)
+			if !ok {
+				return nil, nil, die("includes must be an array of strings when specified")
+			}
+		}
+	}
+
+	merged := map[string]any{"version": 1}
+	sources := make([]PolicySource, 0)
+	nextStack := append(append([]string{}, activeStack...), resolvedPolicyPath)
+	for index, include := range includes {
+		includePath, err := ValidatePolicyInclude(include, fmt.Sprintf("includes[%d]", index), filepath.Dir(resolvedPolicyPath), entrypointRoot)
+		if err != nil {
+			return nil, nil, err
+		}
+		includedPolicy, includedSources, err := loadPolicyBundle(includePath, entrypointRoot, nextStack, loadedPaths)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := MergePolicyFragment(merged, includedPolicy, includePath); err != nil {
+			return nil, nil, err
+		}
+		sources = append(sources, includedSources...)
+	}
+
+	currentPolicy := cloneAnyMap(loaded)
+	delete(currentPolicy, "includes")
+	if len(activeStack) > 0 {
+		currentPolicy = RebasePolicyFragment(currentPolicy, filepath.Dir(resolvedPolicyPath))
+	}
+	if err := MergePolicyFragment(merged, currentPolicy, resolvedPolicyPath); err != nil {
+		return nil, nil, err
+	}
+	logicalPath, err := LogicalPolicyPath(resolvedPolicyPath, entrypointRoot)
+	if err != nil {
+		return nil, nil, err
+	}
+	policySHA, err := PolicySHA256(resolvedPolicyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	sources = append(sources, PolicySource{Path: logicalPath, SHA256: policySHA})
+	return merged, sources, nil
+}
+
+func LoadRawPolicy(policyPath string) (map[string]any, error) {
+	if _, err := os.Stat(policyPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]any{"version": 1}, nil
+		}
+		return nil, err
+	}
+	data, err := os.ReadFile(policyPath)
+	if err != nil {
+		return nil, err
+	}
+	loaded, err := ParseTOMLSubset(string(data), policyPath)
+	if err != nil {
+		return nil, err
+	}
+	if loaded == nil {
+		return nil, die(fmt.Sprintf("injection policy must decode to a TOML table: %s", policyPath))
+	}
+	if err := ValidateAllowedKeys(loaded, AllowedRootPolicyKeys, "root policy"); err != nil {
+		return nil, err
+	}
+	if _, ok := loaded["version"]; !ok {
+		loaded["version"] = 1
+		return loaded, nil
+	}
+	version, ok := loaded["version"].(int)
+	if !ok {
+		return nil, die(fmt.Sprintf("unsupported injection policy version: %v", loaded["version"]))
+	}
+	if version != 1 {
+		return nil, die(fmt.Sprintf("unsupported injection policy version: %d", version))
+	}
+	return loaded, nil
+}
+
+func QuoteString(value string) string {
+	return JSONQuote(value)
+}
+
+func JSONQuote(value string) string {
+	escaped := strings.ReplaceAll(value, "\\", "\\\\")
+	escaped = strings.ReplaceAll(escaped, "\"", "\\\"")
+	escaped = strings.ReplaceAll(escaped, "\n", "\\n")
+	return "\"" + escaped + "\""
+}
+
+func RenderTOMLValue(value any) (string, error) {
+	switch typed := value.(type) {
+	case bool:
+		if typed {
+			return "true", nil
+		}
+		return "false", nil
+	case int:
+		return strconv.Itoa(typed), nil
+	case string:
+		return JSONQuote(typed), nil
+	case []string:
+		items := make([]string, len(typed))
+		for i, item := range typed {
+			items[i] = JSONQuote(item)
+		}
+		return "[" + strings.Join(items, ", ") + "]", nil
+	case []any:
+		items := make([]string, len(typed))
+		for i, item := range typed {
+			text, ok := item.(string)
+			if !ok {
+				return "", die("only arrays of strings are supported in rendered policy output")
+			}
+			items[i] = JSONQuote(text)
+		}
+		return "[" + strings.Join(items, ", ") + "]", nil
+	default:
+		return "", die(fmt.Sprintf("unsupported TOML value type: %T", value))
+	}
+}
+
+func RenderPolicyTOML(policy map[string]any) (string, error) {
+	lines := make([]string, 0)
+	version := 1
+	if rawVersion, ok := policy["version"]; ok {
+		if typed, ok := rawVersion.(int); ok {
+			version = typed
+		} else {
+			return "", die(fmt.Sprintf("unsupported TOML value type: %T", rawVersion))
+		}
+	}
+	renderedVersion, err := RenderTOMLValue(version)
+	if err != nil {
+		return "", err
+	}
+	lines = append(lines, "version = "+renderedVersion)
+
+	if includes, ok := policy["includes"].([]string); ok && len(includes) > 0 {
+		rendered, err := RenderTOMLValue(includes)
+		if err != nil {
+			return "", err
+		}
+		lines = append(lines, "includes = "+rendered)
+	}
+
+	if documents, ok := asStringMap(policy["documents"]); ok && len(documents) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, "[documents]")
+		for _, key := range []string{"common", "codex", "claude", "gemini"} {
+			if value, ok := documents[key]; ok {
+				rendered, err := RenderTOMLValue(value)
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, fmt.Sprintf("%s = %s", key, rendered))
+			}
+		}
+	}
+
+	if credentials, ok := asStringMap(policy["credentials"]); ok && len(credentials) > 0 {
+		scalarEntries := map[string]any{}
+		for key, value := range credentials {
+			if _, ok := value.(map[string]any); !ok {
+				scalarEntries[key] = value
+			}
+		}
+		if len(scalarEntries) > 0 {
+			lines = append(lines, "")
+			lines = append(lines, "[credentials]")
+			keys := sortedAnyMapKeys(scalarEntries)
+			for _, key := range keys {
+				rendered, err := RenderTOMLValue(scalarEntries[key])
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, fmt.Sprintf("%s = %s", key, rendered))
+			}
+		}
+		keys := sortedAnyMapKeys(credentials)
+		for _, key := range keys {
+			value := credentials[key]
+			entry, ok := value.(map[string]any)
+			if !ok {
+				continue
+			}
+			lines = append(lines, "")
+			lines = append(lines, fmt.Sprintf("[credentials.%s]", key))
+			for _, field := range sortedAnyMapKeys(entry) {
+				rendered, err := RenderTOMLValue(entry[field])
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, fmt.Sprintf("%s = %s", field, rendered))
+			}
+		}
+	}
+
+	if ssh, ok := asStringMap(policy["ssh"]); ok && len(ssh) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, "[ssh]")
+		ordered := []string{"enabled", "config", "known_hosts", "identities", "providers", "modes", "allow_unsafe_config"}
+		seen := map[string]struct{}{}
+		for _, key := range ordered {
+			if value, ok := ssh[key]; ok {
+				rendered, err := RenderTOMLValue(value)
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, fmt.Sprintf("%s = %s", key, rendered))
+				seen[key] = struct{}{}
+			}
+		}
+		extras := make([]string, 0)
+		for key := range ssh {
+			if _, ok := seen[key]; !ok {
+				extras = append(extras, key)
+			}
+		}
+		sort.Strings(extras)
+		for _, key := range extras {
+			rendered, err := RenderTOMLValue(ssh[key])
+			if err != nil {
+				return "", err
+			}
+			lines = append(lines, fmt.Sprintf("%s = %s", key, rendered))
+		}
+	}
+
+	if copies, ok := policy["copies"].([]map[string]any); ok && len(copies) > 0 {
+		for _, entry := range copies {
+			if entry == nil {
+				return "", die("copies entries must be TOML tables when rendering policy output")
+			}
+			lines = append(lines, "")
+			lines = append(lines, "[[copies]]")
+			ordered := []string{"source", "target", "classification", "providers", "modes"}
+			seen := map[string]struct{}{}
+			for _, key := range ordered {
+				if value, ok := entry[key]; ok {
+					rendered, err := RenderTOMLValue(value)
+					if err != nil {
+						return "", err
+					}
+					lines = append(lines, fmt.Sprintf("%s = %s", key, rendered))
+					seen[key] = struct{}{}
+				}
+			}
+			extras := make([]string, 0)
+			for key := range entry {
+				if _, ok := seen[key]; !ok {
+					extras = append(extras, key)
+				}
+			}
+			sort.Strings(extras)
+			for _, key := range extras {
+				rendered, err := RenderTOMLValue(entry[key])
+				if err != nil {
+					return "", err
+				}
+				lines = append(lines, fmt.Sprintf("%s = %s", key, rendered))
+			}
+		}
+	}
+
+	return strings.Join(lines, "\n") + "\n", nil
+}
+
+func WritePolicyFile(policyPath string, policy map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(policyPath), 0o755); err != nil {
+		return err
+	}
+	rendered, err := RenderPolicyTOML(policy)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(policyPath, []byte(rendered), 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(policyPath, 0o600)
+}
+
+func RequireSecretFile(source string, label string) (string, error) {
+	if err := requireNoSymlink(source, label); err != nil {
+		return "", err
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return "", die(fmt.Sprintf("%s must point at a file: %s", label, source))
+	}
+	if !info.Mode().IsRegular() {
+		return "", die(fmt.Sprintf("%s must point at a file: %s", label, source))
+	}
+	pathStat, err := os.Lstat(source)
+	if err != nil {
+		return "", err
+	}
+	sysStat, ok := pathStat.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", errors.New("unsupported file stat type")
+	}
+	if int(sysStat.Uid) != getUID() {
+		return "", die(fmt.Sprintf("%s must be owned by uid %d: %s", label, getUID(), source))
+	}
+	if pathStat.Mode().Perm()&0o077 != 0 {
+		return "", die(fmt.Sprintf("%s must not be group/world-accessible: %s", label, source))
+	}
+	return source, nil
+}
+
+func requireNoSymlink(source string, label string) error {
+	if info, err := os.Lstat(source); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return die(fmt.Sprintf("%s must not be a symlink: %s", label, source))
+		}
+	}
+	return nil
+}
+
+func expandUserPath(raw string) (string, error) {
+	if raw == "" {
+		return "", errors.New("empty path")
+	}
+	if raw == "~" || strings.HasPrefix(raw, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if raw == "~" {
+			return home, nil
+		}
+		return filepath.Join(home, raw[2:]), nil
+	}
+	if strings.HasPrefix(raw, "~") {
+		slash := strings.IndexByte(raw, '/')
+		userName := raw[1:]
+		remainder := ""
+		if slash >= 0 {
+			userName = raw[1:slash]
+			remainder = raw[slash+1:]
+		}
+		usr, err := user.Lookup(userName)
+		if err != nil || usr.HomeDir == "" {
+			return raw, nil
+		}
+		if remainder == "" {
+			return usr.HomeDir, nil
+		}
+		return filepath.Join(usr.HomeDir, remainder), nil
+	}
+	return raw, nil
+}
+
+func resolveExistingPath(raw string) (string, error) {
+	expanded, err := expandUserPath(raw)
+	if err != nil {
+		return "", err
+	}
+	absolute, err := filepath.Abs(expanded)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(absolute)
+}
+
+func parseArrayOfStrings(raw string, policyPath string, lineno int) ([]string, error) {
+	if len(raw) < 2 {
+		return nil, die(fmt.Sprintf("%s:%d: expected an array value", policyPath, lineno))
+	}
+	inner := strings.TrimSpace(raw[1 : len(raw)-1])
+	if inner == "" {
+		return []string{}, nil
+	}
+	values := make([]string, 0)
+	i := 0
+	for i < len(inner) {
+		for i < len(inner) && isSpace(inner[i]) {
+			i++
+		}
+		if i >= len(inner) {
+			break
+		}
+		if inner[i] == ',' {
+			return nil, die(fmt.Sprintf("%s:%d: only arrays of strings are supported", policyPath, lineno))
+		}
+		if inner[i] != '"' && inner[i] != '\'' {
+			return nil, die(fmt.Sprintf("%s:%d: only arrays of strings are supported", policyPath, lineno))
+		}
+		value, next, err := parseQuotedLiteral(inner, i)
+		if err != nil {
+			return nil, die(fmt.Sprintf("%s:%d: %v", policyPath, lineno, err))
+		}
+		values = append(values, value)
+		i = next
+		for i < len(inner) && isSpace(inner[i]) {
+			i++
+		}
+		if i >= len(inner) {
+			break
+		}
+		if inner[i] != ',' {
+			return nil, die(fmt.Sprintf("%s:%d: only arrays of strings are supported", policyPath, lineno))
+		}
+		i++
+		for i < len(inner) && isSpace(inner[i]) {
+			i++
+		}
+		if i >= len(inner) {
+			break
+		}
+	}
+	return values, nil
+}
+
+func unquoteDoubleQuoted(raw string, policyPath string, lineno int) (string, error) {
+	if len(raw) < 2 || raw[0] != '"' || raw[len(raw)-1] != '"' {
+		return "", die(fmt.Sprintf("%s:%d: unsupported TOML value; use quoted strings, booleans, integers, or arrays of strings", policyPath, lineno))
+	}
+	value, _, err := parseQuotedLiteral(raw, 0)
+	if err != nil {
+		return "", die(fmt.Sprintf("%s:%d: %v", policyPath, lineno, err))
+	}
+	return value, nil
+}
+
+func parseQuotedLiteral(text string, start int) (string, int, error) {
+	quote := text[start]
+	if quote != '"' && quote != '\'' {
+		return "", start, errors.New("expected quoted string")
+	}
+	var b strings.Builder
+	i := start + 1
+	for i < len(text) {
+		char := text[i]
+		if char == quote {
+			return b.String(), i + 1, nil
+		}
+		if char == '\\' {
+			i++
+			if i >= len(text) {
+				return "", start, errors.New("unterminated quoted value")
+			}
+			esc := text[i]
+			switch esc {
+			case '\\', '"', '\'':
+				b.WriteByte(esc)
+			case 'n':
+				b.WriteByte('\n')
+			case 'r':
+				b.WriteByte('\r')
+			case 't':
+				b.WriteByte('\t')
+			case 'b':
+				b.WriteByte('\b')
+			case 'f':
+				b.WriteByte('\f')
+			case 'a':
+				b.WriteByte('\a')
+			case 'v':
+				b.WriteByte('\v')
+			case 'x':
+				if i+2 >= len(text) {
+					return "", start, errors.New("invalid hex escape")
+				}
+				value, err := parseHexUint(text[i+1 : i+3])
+				if err != nil {
+					return "", start, err
+				}
+				b.WriteByte(byte(value))
+				i += 2
+			case 'u':
+				if i+4 >= len(text) {
+					return "", start, errors.New("invalid unicode escape")
+				}
+				value, err := parseHexUint(text[i+1 : i+5])
+				if err != nil {
+					return "", start, err
+				}
+				b.WriteString(string(rune(value)))
+				i += 4
+			case 'U':
+				if i+8 >= len(text) {
+					return "", start, errors.New("invalid unicode escape")
+				}
+				value, err := parseHexUint(text[i+1 : i+9])
+				if err != nil {
+					return "", start, err
+				}
+				if value > utf8.MaxRune {
+					return "", start, errors.New("invalid unicode escape")
+				}
+				b.WriteString(string(rune(value)))
+				i += 8
+			default:
+				return "", start, fmt.Errorf("unknown escape sequence \\%c", esc)
+			}
+			i++
+			continue
+		}
+		b.WriteByte(char)
+		i++
+	}
+	return "", start, errors.New("unterminated quoted value")
+}
+
+func parseHexUint(text string) (uint64, error) {
+	value, err := strconv.ParseUint(text, 16, 64)
+	if err != nil {
+		return 0, errors.New("invalid escape sequence")
+	}
+	return value, nil
+}
+
+func systemSymlinkAllowed(path string) bool {
+	_, ok := systemSymlinkAllowlist[path]
+	return ok
+}
+
+func contains(values []string, current string) bool {
+	for _, value := range values {
+		if value == current {
+			return true
+		}
+	}
+	return false
+}
+
+func digitsOnly(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isSpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', '\f', '\v':
+		return true
+	default:
+		return false
+	}
+}
+
+func stringList(value any) ([]string, error) {
+	switch typed := value.(type) {
+	case []string:
+		return typed, nil
+	case []any:
+		items := make([]string, len(typed))
+		for i, item := range typed {
+			text, ok := item.(string)
+			if !ok {
+				return nil, die("values must be strings")
+			}
+			items[i] = text
+		}
+		return items, nil
+	default:
+		return nil, errors.New("not a string slice")
+	}
+}
+
+func asStringMap(value any) (map[string]any, bool) {
+	typed, ok := value.(map[string]any)
+	return typed, ok
+}
+
+func cloneAnyMap(src map[string]any) map[string]any {
+	dst := make(map[string]any, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}
+
+func cloneStringAnyMap(src map[string]any) map[string]any {
+	return cloneAnyMap(src)
+}
+
+func sortedAnyMapKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func pythonReprString(value string) string {
+	var b strings.Builder
+	b.WriteByte('\'')
+	for i := 0; i < len(value); i++ {
+		switch value[i] {
+		case '\\':
+			b.WriteString("\\\\")
+		case '\'':
+			b.WriteString("\\'")
+		case '\n':
+			b.WriteString("\\n")
+		case '\r':
+			b.WriteString("\\r")
+		case '\t':
+			b.WriteString("\\t")
+		default:
+			b.WriteByte(value[i])
+		}
+	}
+	b.WriteByte('\'')
+	return b.String()
+}

--- a/internal/policybundle/policy_bundle_test.go
+++ b/internal/policybundle/policy_bundle_test.go
@@ -1,0 +1,442 @@
+package policybundle
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestStripCommentAndParseValue(t *testing.T) {
+	t.Parallel()
+
+	if got := StripComment(`value = "keep # hash" # remove`); got != `value = "keep # hash"` {
+		t.Fatalf("StripComment = %q", got)
+	}
+	if got := StripComment(`value = 'keep # hash' # remove`); got != `value = 'keep # hash'` {
+		t.Fatalf("StripComment = %q", got)
+	}
+	if got := StripComment(`value = "escaped \"#\" hash" # remove`); got != `value = "escaped \"#\" hash"` {
+		t.Fatalf("StripComment = %q", got)
+	}
+
+	policyPath := "/tmp/policy.toml"
+	cases := []struct {
+		raw     string
+		want    any
+		wantErr bool
+		lineNo  int
+	}{
+		{raw: "true", want: true, lineNo: 1},
+		{raw: "false", want: false, lineNo: 2},
+		{raw: `"text"`, want: "text", lineNo: 3},
+		{raw: `["a", "b"]`, want: []string{"a", "b"}, lineNo: 4},
+		{raw: "42", want: 42, lineNo: 5},
+		{raw: "1.5", wantErr: true, lineNo: 6},
+		{raw: "[1, 2]", wantErr: true, lineNo: 7},
+		{raw: "", wantErr: true, lineNo: 8},
+	}
+	for _, tc := range cases {
+		got, err := ParseValue(tc.raw, policyPath, tc.lineNo)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("ParseValue(%q) expected error", tc.raw)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("ParseValue(%q) error: %v", tc.raw, err)
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("ParseValue(%q) = %#v, want %#v", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestParseRenderAndReparsePolicySubset(t *testing.T) {
+	t.Parallel()
+
+	rendered, err := RenderPolicyTOML(map[string]any{
+		"version":  1,
+		"includes": []string{"shared.toml"},
+		"documents": map[string]any{
+			"common": "/tmp/common.md",
+		},
+		"credentials": map[string]any{
+			"codex_auth": "/tmp/auth.json",
+			"github_hosts": map[string]any{
+				"source":    "/tmp/hosts.yml",
+				"providers": []string{"codex"},
+			},
+		},
+		"ssh": map[string]any{
+			"enabled":     true,
+			"config":      "/tmp/config",
+			"known_hosts": "/tmp/known_hosts",
+			"identities":  []string{"/tmp/id_key"},
+			"proxy_jump":  "bastion",
+		},
+		"copies": []map[string]any{
+			{
+				"source":         "/tmp/source.txt",
+				"target":         "/state/injected/source.txt",
+				"classification": "public",
+				"note":           "extra",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RenderPolicyTOML error: %v", err)
+	}
+
+	want := strings.Join([]string{
+		"version = 1",
+		`includes = ["shared.toml"]`,
+		"",
+		"[documents]",
+		`common = "/tmp/common.md"`,
+		"",
+		"[credentials]",
+		`codex_auth = "/tmp/auth.json"`,
+		"",
+		"[credentials.github_hosts]",
+		`providers = ["codex"]`,
+		`source = "/tmp/hosts.yml"`,
+		"",
+		"[ssh]",
+		`enabled = true`,
+		`config = "/tmp/config"`,
+		`known_hosts = "/tmp/known_hosts"`,
+		`identities = ["/tmp/id_key"]`,
+		`proxy_jump = "bastion"`,
+		"",
+		"[[copies]]",
+		`source = "/tmp/source.txt"`,
+		`target = "/state/injected/source.txt"`,
+		`classification = "public"`,
+		`note = "extra"`,
+		"",
+	}, "\n")
+	if rendered != want {
+		t.Fatalf("RenderPolicyTOML mismatch\nwant:\n%s\ngot:\n%s", want, rendered)
+	}
+
+	reparsed, err := ParseTOMLSubset(rendered, "/tmp/policy.toml")
+	if err != nil {
+		t.Fatalf("ParseTOMLSubset error: %v", err)
+	}
+	if reparsed["version"] != 1 {
+		t.Fatalf("version = %#v", reparsed["version"])
+	}
+	if reparsed["includes"].([]string)[0] != "shared.toml" {
+		t.Fatalf("includes = %#v", reparsed["includes"])
+	}
+	if reparsed["documents"].(map[string]any)["common"] != "/tmp/common.md" {
+		t.Fatalf("documents = %#v", reparsed["documents"])
+	}
+	if reparsed["credentials"].(map[string]any)["codex_auth"] != "/tmp/auth.json" {
+		t.Fatalf("credentials = %#v", reparsed["credentials"])
+	}
+}
+
+func TestLoadPolicyBundleMergesIncludesAndRebasesPaths(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fragmentDir := filepath.Join(root, "fragment")
+	if err := os.MkdirAll(fragmentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filepath.Join(fragmentDir, "doc.md"), "doc\n", 0o600)
+	mustWriteFile(t, filepath.Join(fragmentDir, "auth.json"), "{}\n", 0o600)
+	mustWriteFile(t, filepath.Join(fragmentDir, "shared.toml"), strings.Join([]string{
+		"[documents]",
+		`common = "doc.md"`,
+		"",
+		"[credentials.codex_auth]",
+		`source = "auth.json"`,
+		`providers = ["codex"]`,
+		`modes = ["strict"]`,
+		"",
+	}, "\n"), 0o600)
+	mustWriteFile(t, filepath.Join(root, "policy.toml"), strings.Join([]string{
+		"version = 1",
+		`includes = ["fragment/shared.toml"]`,
+		"",
+		"[credentials]",
+		`github_hosts = "/tmp/hosts.yml"`,
+		"",
+	}, "\n"), 0o600)
+
+	merged, sources, err := LoadPolicyBundle(filepath.Join(root, "policy.toml"))
+	if err != nil {
+		t.Fatalf("LoadPolicyBundle error: %v", err)
+	}
+	resolvedDoc, err := filepath.EvalSymlinks(filepath.Join(fragmentDir, "doc.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := merged["documents"].(map[string]any)["common"]; got != resolvedDoc {
+		t.Fatalf("documents.common = %v", got)
+	}
+	resolvedAuth, err := filepath.EvalSymlinks(filepath.Join(fragmentDir, "auth.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := merged["credentials"].(map[string]any)["codex_auth"].(map[string]any)["source"]; got != resolvedAuth {
+		t.Fatalf("credentials.codex_auth.source = %v", got)
+	}
+	if got := merged["credentials"].(map[string]any)["github_hosts"]; got != "/tmp/hosts.yml" {
+		t.Fatalf("credentials.github_hosts = %v", got)
+	}
+	if got := []string{sources[0].Path, sources[1].Path}; !reflect.DeepEqual(got, []string{"fragment/shared.toml", "policy.toml"}) {
+		t.Fatalf("policy sources = %#v", got)
+	}
+	if !strings.HasPrefix(sources[0].SHA256, "sha256:") || !strings.HasPrefix(sources[1].SHA256, "sha256:") {
+		t.Fatalf("unexpected source hashes: %#v", sources)
+	}
+}
+
+func TestLoadPolicyBundleRejectsCyclesAndDuplicateIncludes(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "invalid.toml"), "version = 1\nincludes = \"shared.toml\"\n", 0o600)
+	if _, _, err := LoadPolicyBundle(filepath.Join(root, "invalid.toml")); err == nil || !strings.Contains(err.Error(), "includes must be an array of strings") {
+		t.Fatalf("expected invalid includes error, got %v", err)
+	}
+
+	mustWriteFile(t, filepath.Join(root, "a.toml"), "version = 1\nincludes = [\"b.toml\"]\n", 0o600)
+	mustWriteFile(t, filepath.Join(root, "b.toml"), "version = 1\nincludes = [\"a.toml\"]\n", 0o600)
+	if _, _, err := LoadPolicyBundle(filepath.Join(root, "a.toml")); err == nil || !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("expected cycle error, got %v", err)
+	}
+
+	mustWriteFile(t, filepath.Join(root, "shared.toml"), "version = 1\n", 0o600)
+	mustWriteFile(t, filepath.Join(root, "dup.toml"), "version = 1\nincludes = [\"shared.toml\", \"shared.toml\"]\n", 0o600)
+	if _, _, err := LoadPolicyBundle(filepath.Join(root, "dup.toml")); err == nil || !strings.Contains(err.Error(), "more than once") {
+		t.Fatalf("expected duplicate include error, got %v", err)
+	}
+
+	outside := filepath.Join(filepath.Dir(root), filepath.Base(root)+"-escape.toml")
+	mustWriteFile(t, outside, "version = 1\n", 0o600)
+	mustWriteFile(t, filepath.Join(root, "policy.toml"), "version = 1\nincludes = [\"../"+filepath.Base(outside)+"\"]\n", 0o600)
+	if _, _, err := LoadPolicyBundle(filepath.Join(root, "policy.toml")); err == nil || !strings.Contains(err.Error(), "stay within") {
+		t.Fatalf("expected include boundary error, got %v", err)
+	}
+}
+
+func TestParseTOMLSubsetRejectsInvalidStructures(t *testing.T) {
+	t.Parallel()
+
+	policyPath := "/tmp/policy.toml"
+	for _, content := range []string{
+		"[[unknown]]\n",
+		"[documents]\n[documents]\n",
+		"[credentials.unknown]\nsource = \"/tmp/x\"\n",
+		"[unknown]\nvalue = 1\n",
+		"invalid-line\n",
+		" = \"value\"\n",
+		"a.b = \"value\"\n",
+		"value = \"one\"\nvalue = \"two\"\n",
+		"[[credentials.codex_auth]]\nsource = \"/tmp/x\"\n",
+	} {
+		content := content
+		t.Run(strings.ReplaceAll(strings.TrimSpace(content), "\n", " "), func(t *testing.T) {
+			t.Parallel()
+			if _, err := ParseTOMLSubset(content, policyPath); err == nil {
+				t.Fatalf("expected ParseTOMLSubset to fail for %q", content)
+			}
+		})
+	}
+}
+
+func TestRebasePolicyFragmentRebasesAllSupportedPathFields(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fragmentDir := filepath.Join(root, "fragment")
+	if err := os.MkdirAll(fragmentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filepath.Join(fragmentDir, "common.md"), "common\n", 0o600)
+	mustWriteFile(t, filepath.Join(fragmentDir, "copy.txt"), "copy\n", 0o600)
+	mustWriteFile(t, filepath.Join(fragmentDir, "ssh_config"), "Host github.com\n", 0o600)
+	mustWriteFile(t, filepath.Join(fragmentDir, "known_hosts"), "github.com ssh-ed25519 AAAA\n", 0o600)
+	mustWriteFile(t, filepath.Join(fragmentDir, "id_workcell"), "private\n", 0o600)
+	mustWriteFile(t, filepath.Join(fragmentDir, "auth.json"), "{}\n", 0o600)
+
+	rebased := RebasePolicyFragment(map[string]any{
+		"documents": map[string]any{"common": "common.md"},
+		"copies": []map[string]any{
+			{"source": "copy.txt", "target": "/state/injected/copy.txt"},
+		},
+		"ssh": map[string]any{
+			"config":      "ssh_config",
+			"known_hosts": "known_hosts",
+			"identities":  []string{"id_workcell"},
+		},
+		"credentials": map[string]any{
+			"codex_auth": "auth.json",
+			"github_hosts": map[string]any{
+				"source":    "hosts.yml",
+				"providers": []string{"codex"},
+			},
+		},
+	}, fragmentDir)
+
+	if got := rebased["documents"].(map[string]any)["common"]; got != filepath.Join(fragmentDir, "common.md") {
+		t.Fatalf("documents.common = %v", got)
+	}
+	if got := rebased["copies"].([]map[string]any)[0]["source"]; got != filepath.Join(fragmentDir, "copy.txt") {
+		t.Fatalf("copies[0].source = %v", got)
+	}
+	if got := rebased["ssh"].(map[string]any)["config"]; got != filepath.Join(fragmentDir, "ssh_config") {
+		t.Fatalf("ssh.config = %v", got)
+	}
+	if got := rebased["ssh"].(map[string]any)["known_hosts"]; got != filepath.Join(fragmentDir, "known_hosts") {
+		t.Fatalf("ssh.known_hosts = %v", got)
+	}
+	if got := rebased["ssh"].(map[string]any)["identities"].([]string)[0]; got != filepath.Join(fragmentDir, "id_workcell") {
+		t.Fatalf("ssh.identities[0] = %v", got)
+	}
+	if got := rebased["credentials"].(map[string]any)["codex_auth"]; got != filepath.Join(fragmentDir, "auth.json") {
+		t.Fatalf("credentials.codex_auth = %v", got)
+	}
+	if got := rebased["credentials"].(map[string]any)["github_hosts"].(map[string]any)["source"]; got != filepath.Join(fragmentDir, "hosts.yml") {
+		t.Fatalf("credentials.github_hosts.source = %v", got)
+	}
+}
+
+func TestLoadRawWriteAndSecretGuards(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if got, err := LoadRawPolicy(filepath.Join(root, "missing.toml")); err != nil || got["version"] != 1 {
+		t.Fatalf("LoadRawPolicy missing = %#v, %v", got, err)
+	}
+
+	rawPath := filepath.Join(root, "raw.toml")
+	mustWriteFile(t, rawPath, "[documents]\ncommon = \"doc.md\"\n", 0o600)
+	loaded, err := LoadRawPolicy(rawPath)
+	if err != nil {
+		t.Fatalf("LoadRawPolicy error: %v", err)
+	}
+	if loaded["version"] != 1 {
+		t.Fatalf("LoadRawPolicy version = %#v", loaded["version"])
+	}
+
+	policyPath := filepath.Join(root, "policy.toml")
+	if err := WritePolicyFile(policyPath, map[string]any{"version": 1}); err != nil {
+		t.Fatalf("WritePolicyFile error: %v", err)
+	}
+	if got := mustReadFile(t, policyPath); got != "version = 1\n" {
+		t.Fatalf("WritePolicyFile content = %q", got)
+	}
+	assertMode(t, policyPath, 0o600)
+
+	directory := filepath.Join(root, "directory")
+	if err := os.Mkdir(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RequireSecretFile(directory, "directory"); err == nil || !strings.Contains(err.Error(), "must point at a file") {
+		t.Fatalf("expected directory rejection, got %v", err)
+	}
+
+	secret := filepath.Join(root, "secret.txt")
+	mustWriteFile(t, secret, "secret\n", 0o600)
+	link := filepath.Join(root, "link.txt")
+	if err := os.Symlink(secret, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RequireSecretFile(link, "link"); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+
+	oldGetUID := getUID
+	getUID = func() int { return oldGetUID() + 1 }
+	defer func() { getUID = oldGetUID }()
+	if _, err := RequireSecretFile(secret, "secret"); err == nil || !strings.Contains(err.Error(), "owned by uid") {
+		t.Fatalf("expected owner rejection, got %v", err)
+	}
+
+	getUID = oldGetUID
+	worldReadable := filepath.Join(root, "world.txt")
+	mustWriteFile(t, worldReadable, "secret\n", 0o644)
+	if _, err := RequireSecretFile(worldReadable, "world"); err == nil || !strings.Contains(err.Error(), "group/world-accessible") {
+		t.Fatalf("expected permission rejection, got %v", err)
+	}
+}
+
+func TestCompositePolicySHA256IsOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	sources := []PolicySource{
+		{Path: "b.toml", SHA256: "sha256:b"},
+		{Path: "a.toml", SHA256: "sha256:a"},
+	}
+	got := CompositePolicySHA256(sources)
+	wantCanonical := "[{'path': 'a.toml', 'sha256': 'sha256:a'}, {'path': 'b.toml', 'sha256': 'sha256:b'}]"
+	sum := sha256.Sum256([]byte(wantCanonical))
+	want := "sha256:" + hex.EncodeToString(sum[:])
+	if got != want {
+		t.Fatalf("CompositePolicySHA256 = %s, want %s", got, want)
+	}
+}
+
+func TestSelectedForAndValidateAllowedKeys(t *testing.T) {
+	t.Parallel()
+
+	if ok, err := SelectedFor(nil, "codex", "providers", SupportedAgents); err != nil || !ok {
+		t.Fatalf("SelectedFor nil = %v, %v", ok, err)
+	}
+	if ok, err := SelectedFor([]string{"claude"}, "codex", "providers", SupportedAgents); err != nil || ok {
+		t.Fatalf("SelectedFor filter = %v, %v", ok, err)
+	}
+	if _, err := SelectedFor([]any{"codex", 1}, "codex", "providers", SupportedAgents); err == nil || !strings.Contains(err.Error(), "values must be strings") {
+		t.Fatalf("expected string list error, got %v", err)
+	}
+
+	if err := ValidateAllowedKeys(map[string]any{"version": 1}, map[string]struct{}{"version": {}}, "policy"); err != nil {
+		t.Fatalf("ValidateAllowedKeys error: %v", err)
+	}
+	if err := ValidateAllowedKeys(map[string]any{"unexpected": true}, map[string]struct{}{"version": {}}, "policy"); err == nil || !strings.Contains(err.Error(), "unsupported keys") {
+		t.Fatalf("expected unsupported key error, got %v", err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode mismatch for %s: got %04o want %04o", path, got, want)
+	}
+}

--- a/internal/rootio/rootio.go
+++ b/internal/rootio/rootio.go
@@ -1,0 +1,107 @@
+package rootio
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func RelativePathWithin(root, target, label string) (string, error) {
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%s must stay within %s: %s", label, root, target)
+	}
+	return rel, nil
+}
+
+func WriteFileAtomic(root *os.Root, relativePath string, data []byte, mode os.FileMode, tempPrefix string) error {
+	return WriteFileAtomicFromReader(root, relativePath, bytes.NewReader(data), mode, tempPrefix)
+}
+
+func WriteFileAtomicFromReader(root *os.Root, relativePath string, source io.Reader, mode os.FileMode, tempPrefix string) error {
+	cleanPath, err := normalizeRelativePath(relativePath)
+	if err != nil {
+		return err
+	}
+	parent := filepath.Dir(cleanPath)
+	if parent != "." {
+		if err := root.MkdirAll(parent, 0o700); err != nil {
+			return err
+		}
+	}
+	tempFile, tempPath, err := createTempFile(root, parent, tempPrefix, mode)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tempFile.Close()
+		_ = root.Remove(tempPath)
+	}()
+
+	if _, err := io.Copy(tempFile, source); err != nil {
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	if err := root.Rename(tempPath, cleanPath); err != nil {
+		return err
+	}
+	return root.Chmod(cleanPath, mode)
+}
+
+func normalizeRelativePath(relativePath string) (string, error) {
+	if filepath.IsAbs(relativePath) {
+		return "", fmt.Errorf("path must be relative to the opened root: %s", relativePath)
+	}
+	cleanPath := filepath.Clean(relativePath)
+	if cleanPath == "." || cleanPath == string(filepath.Separator) {
+		return "", fmt.Errorf("path must name a file within the opened root: %s", relativePath)
+	}
+	return cleanPath, nil
+}
+
+func createTempFile(root *os.Root, parent, tempPrefix string, mode os.FileMode) (*os.File, string, error) {
+	if tempPrefix == "" {
+		tempPrefix = ".workcell-tmp-"
+	}
+	parent = filepath.Clean(parent)
+	if parent == "." {
+		parent = ""
+	}
+	for attempt := 0; attempt < 32; attempt++ {
+		suffix, err := randomSuffix()
+		if err != nil {
+			return nil, "", err
+		}
+		name := tempPrefix + suffix + ".tmp"
+		tempPath := name
+		if parent != "" {
+			tempPath = filepath.Join(parent, name)
+		}
+		file, err := root.OpenFile(tempPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+		if err == nil {
+			return file, tempPath, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, "", err
+		}
+	}
+	return nil, "", fmt.Errorf("unable to allocate temporary file under %s", root.Name())
+}
+
+func randomSuffix() (string, error) {
+	var data [8]byte
+	if _, err := rand.Read(data[:]); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", data[:]), nil
+}

--- a/internal/rootio/rootio_test.go
+++ b/internal/rootio/rootio_test.go
@@ -1,0 +1,70 @@
+package rootio
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileAtomicWritesContentAndMode(t *testing.T) {
+	rootDir := t.TempDir()
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	if err := WriteFileAtomic(root, filepath.Join("resolved", "credentials", "token.json"), []byte("{\"token\":\"x\"}\n"), 0o600, ".test-"); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(rootDir, "resolved", "credentials", "token.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, []byte("{\"token\":\"x\"}\n")) {
+		t.Fatalf("content mismatch: got %q", data)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %v, want %v", got, os.FileMode(0o600))
+	}
+}
+
+func TestWriteFileAtomicRejectsSymlinkEscape(t *testing.T) {
+	rootDir := t.TempDir()
+	escapeDir := filepath.Join(t.TempDir(), "escape")
+	if err := os.MkdirAll(escapeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(escapeDir, filepath.Join(rootDir, "resolved")); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	err = WriteFileAtomic(root, filepath.Join("resolved", "credentials", "token.json"), []byte("secret\n"), 0o600, ".test-")
+	if err == nil {
+		t.Fatal("WriteFileAtomic unexpectedly succeeded through escaping symlink")
+	}
+	if _, statErr := os.Stat(filepath.Join(escapeDir, "credentials", "token.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("escaped write unexpectedly materialized: %v", statErr)
+	}
+}
+
+func TestRelativePathWithinRejectsOutsideRoot(t *testing.T) {
+	rootDir := t.TempDir()
+	outside := filepath.Join(filepath.Dir(rootDir), "outside.txt")
+	if _, err := RelativePathWithin(rootDir, outside, "test"); err == nil {
+		t.Fatal("RelativePathWithin unexpectedly accepted a path outside the root")
+	}
+}

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -33,21 +33,11 @@ mapfile -t python_files < <(
 
 branding_scan() {
   local pattern="agent-boundary|Agent Boundary|agent boundary"
-
-  if command -v rg >/dev/null 2>&1; then
-    rg -n "${pattern}" "${ROOT_DIR}" \
-      -g '!**/.git/**' \
-      -g '!scripts/validate-repo.sh' \
-      -g '!dist/**' \
-      -g '!tmp/**'
-    return
-  fi
-
-  grep -RInE "${pattern}" "${ROOT_DIR}" \
-    --exclude-dir=.git \
-    --exclude-dir=dist \
-    --exclude-dir=tmp \
-    --exclude=validate-repo.sh
+  git -C "${ROOT_DIR}" grep -nE "${pattern}" -- \
+    . \
+    ':(exclude)scripts/validate-repo.sh' \
+    ':(exclude)dist/**' \
+    ':(exclude)tmp/**'
 }
 
 validate_manpage() {


### PR DESCRIPTION
## Summary
- port the policy bundle, credential resolution, and injection rendering helpers to Go
- add shared `policybundle` and `rootio` support packages with parity-focused tests
- keep Python retirement and shell wrapper churn out of scope

## Verification
- `go test ./internal/policybundle ./internal/rootio ./internal/authresolve ./internal/authpolicy ./internal/injection`
