### PR TITLE
Upgrade and Deduplicate the Rust Runtime Crate

### DIFF
--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -130,14 +130,22 @@ ARG CLAUDE_VERSION=2.1.86
 # and update the CODEX_SHA256 values for arm64 and amd64 below.
 ARG CODEX_VERSION=0.117.0-alpha.8
 ARG CODEX_RELEASE_URL=
+ARG RUST_VERSION=1.94.1
+ARG RUSTUP_VERSION=1.29.0
+ARG RUSTUP_INIT_LINUX_X86_64_SHA256=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
+ARG RUSTUP_INIT_LINUX_ARM64_SHA256=9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792
 ARG TARGETARCH
 ARG BUILDKIT_MULTI_PLATFORM=1
 ARG SOURCE_DATE_EPOCH
 
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH=/usr/local/cargo/bin:${PATH}
+ENV RUSTUP_HOME=/usr/local/rustup
+
 RUN install_runtime_builder_packages() { \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      cargo \
-      rustc \
+      gcc \
+      libc6-dev \
       && return 0; \
     } \
   && for attempt in 1 2 3; do \
@@ -151,8 +159,39 @@ RUN install_runtime_builder_packages() { \
        fi; \
        sleep "$((attempt * 5))"; \
      done \
+  && rustup_target="" \
+  && rustup_sha256="" \
+  && case "$(dpkg --print-architecture)" in \
+       amd64) \
+         rustup_target="x86_64-unknown-linux-gnu"; \
+         rustup_sha256="${RUSTUP_INIT_LINUX_X86_64_SHA256}"; \
+         ;; \
+       arm64) \
+         rustup_target="aarch64-unknown-linux-gnu"; \
+         rustup_sha256="${RUSTUP_INIT_LINUX_ARM64_SHA256}"; \
+         ;; \
+       *) \
+         echo "Unsupported dpkg architecture for rustup: $(dpkg --print-architecture)" >&2; \
+         exit 1; \
+         ;; \
+     esac \
+  && curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+    "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustup_target}/rustup-init" \
+    -o /tmp/rustup-init \
+  && echo "${rustup_sha256}  /tmp/rustup-init" | sha256sum -c - \
+  && chmod 0755 /tmp/rustup-init \
+  && CARGO_HOME=/usr/local/cargo \
+     RUSTUP_HOME=/usr/local/rustup \
+     /tmp/rustup-init -y --profile minimal --default-toolchain "${RUST_VERSION}" --no-modify-path \
+  && CARGO_HOME=/usr/local/cargo \
+     RUSTUP_HOME=/usr/local/rustup \
+     /usr/local/cargo/bin/rustup default "${RUST_VERSION}" \
+  && ln -sf /usr/local/cargo/bin/cargo /usr/local/bin/cargo \
+  && ln -sf /usr/local/cargo/bin/rustc /usr/local/bin/rustc \
+  && rustc --version | grep -F "rustc ${RUST_VERSION} " >/dev/null \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /var/cache/debconf/*-old /var/cache/ldconfig/aux-cache \
-  && rm -f /etc/ld.so.cache
+  && rm -f /etc/ld.so.cache /tmp/rustup-init \
+  && rm -rf /usr/local/rustup/downloads /usr/local/rustup/tmp
 
 RUN TARGET_ARCH="${TARGETARCH:-}" \
   && if [[ -z "${TARGET_ARCH}" ]]; then \

--- a/runtime/container/rust/Cargo.toml
+++ b/runtime/container/rust/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "workcell-runtime"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
+rust-version = "1.94"
 publish = false
 
 [lib]

--- a/runtime/container/rust/rust-toolchain.toml
+++ b/runtime/container/rust/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.94.1"
+components = ["clippy", "rustfmt"]
+profile = "minimal"

--- a/runtime/container/rust/src/bin/common/launcher_common.rs
+++ b/runtime/container/rust/src/bin/common/launcher_common.rs
@@ -1,0 +1,93 @@
+use std::env;
+use std::ffi::{CString, OsStr, OsString};
+use std::fmt;
+use std::os::raw::c_char;
+use std::os::unix::ffi::OsStrExt;
+
+unsafe extern "C" {
+    static mut environ: *mut *mut c_char;
+}
+
+pub const BASH_PATH: &str = "/bin/bash";
+
+const SANITIZED_ENV_KEYS: &[&str] = &[
+    "BASH_ENV",
+    "ENV",
+    "LD_AUDIT",
+    "LD_LIBRARY_PATH",
+    "LD_PRELOAD",
+    "NODE_OPTIONS",
+    "NODE_PATH",
+    "NODE_EXTRA_CA_CERTS",
+    "npm_config_userconfig",
+    "NPM_CONFIG_USERCONFIG",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NulArgumentError;
+
+impl fmt::Display for NulArgumentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Workcell launcher argument contained a NUL byte.")
+    }
+}
+
+pub fn sanitize_env() {
+    for key in SANITIZED_ENV_KEYS {
+        // Rust 2024 makes process-global env mutation unsafe.
+        unsafe { env::remove_var(key) };
+    }
+}
+
+pub fn set_env_var(key: &str, value: &str) {
+    // Rust 2024 makes process-global env mutation unsafe.
+    unsafe { env::set_var(key, value) };
+}
+
+pub fn osstr_to_cstring(value: &OsStr) -> Result<CString, NulArgumentError> {
+    CString::new(value.as_bytes()).map_err(|_| NulArgumentError)
+}
+
+pub fn build_bash_exec_args(
+    script_path: &'static str,
+    args: Vec<OsString>,
+) -> Result<Vec<CString>, NulArgumentError> {
+    let mut exec_args = Vec::with_capacity(args.len() + 2);
+    exec_args.push(c"/bin/bash".to_owned());
+    exec_args.push(CString::new(script_path).expect("static script path"));
+    for arg in args {
+        exec_args.push(osstr_to_cstring(&arg)?);
+    }
+    Ok(exec_args)
+}
+
+pub fn exit_code_for_errno(errno: i32) -> i32 {
+    if errno == libc::ENOENT { 127 } else { 126 }
+}
+
+pub fn format_exec_error(script_path: &str, errno: i32) -> String {
+    format!(
+        "execve({}, {}): {}",
+        BASH_PATH,
+        script_path,
+        std::io::Error::from_raw_os_error(errno)
+    )
+}
+
+pub fn exec_request(exec_args: &[CString], script_path: &str) -> i32 {
+    let mut argv: Vec<*const c_char> = exec_args.iter().map(|arg| arg.as_ptr()).collect();
+    argv.push(std::ptr::null());
+
+    let rc = unsafe { libc::execve(exec_args[0].as_ptr(), argv.as_ptr(), environ.cast()) };
+    let errno = std::io::Error::last_os_error()
+        .raw_os_error()
+        .unwrap_or(libc::ENOENT);
+
+    if rc != 0 {
+        eprintln!("{}", format_exec_error(script_path, errno));
+    }
+
+    exit_code_for_errno(errno)
+}

--- a/runtime/container/rust/src/bin/workcell-git-launcher.rs
+++ b/runtime/container/rust/src/bin/workcell-git-launcher.rs
@@ -1,13 +1,9 @@
+#[path = "common/launcher_common.rs"]
+mod launcher_common;
+
 use std::env;
 use std::ffi::{CString, OsString};
-use std::os::raw::c_char;
 use std::process;
-
-unsafe extern "C" {
-    static mut environ: *mut *mut c_char;
-}
-
-const BASH_PATH: &str = "/bin/bash";
 const TARGET_NAME: &str = "git";
 const SCRIPT_PATH: &str = "/usr/local/libexec/workcell/git-wrapper.sh";
 
@@ -21,33 +17,8 @@ enum LaunchError {
     NulArgument,
 }
 
-fn sanitize_env() {
-    for key in [
-        "BASH_ENV",
-        "ENV",
-        "LD_AUDIT",
-        "LD_LIBRARY_PATH",
-        "LD_PRELOAD",
-        "NODE_OPTIONS",
-        "NODE_PATH",
-        "NODE_EXTRA_CA_CERTS",
-        "npm_config_userconfig",
-        "NPM_CONFIG_USERCONFIG",
-        "SSL_CERT_FILE",
-        "SSL_CERT_DIR",
-    ] {
-        env::remove_var(key);
-    }
-}
-
 fn build_exec_args(args: Vec<OsString>) -> Result<Vec<CString>, LaunchError> {
-    let mut exec_args = Vec::new();
-    exec_args.push(CString::new(BASH_PATH).expect("static bash path"));
-    exec_args.push(CString::new(SCRIPT_PATH).expect("static script path"));
-    for arg in args {
-        exec_args.push(CString::new(arg.as_encoded_bytes()).map_err(|_| LaunchError::NulArgument)?);
-    }
-    Ok(exec_args)
+    launcher_common::build_bash_exec_args(SCRIPT_PATH, args).map_err(|_| LaunchError::NulArgument)
 }
 
 fn prepare_launch(args: Vec<OsString>) -> Result<LaunchRequest, LaunchError> {
@@ -58,41 +29,8 @@ fn prepare_launch(args: Vec<OsString>) -> Result<LaunchRequest, LaunchError> {
 
 fn format_launch_error(error: LaunchError) -> String {
     match error {
-        LaunchError::NulArgument => "Workcell launcher argument contained a NUL byte.".to_string(),
+        LaunchError::NulArgument => launcher_common::NulArgumentError.to_string(),
     }
-}
-
-fn exit_code_for_errno(errno: i32) -> i32 {
-    if errno == libc::ENOENT {
-        127
-    } else {
-        126
-    }
-}
-
-fn format_exec_error(errno: i32) -> String {
-    format!(
-        "execve({}, {}): {}",
-        BASH_PATH,
-        SCRIPT_PATH,
-        std::io::Error::from_raw_os_error(errno)
-    )
-}
-
-fn exec_request(request: &LaunchRequest) -> i32 {
-    let mut argv: Vec<*const c_char> = request.exec_args.iter().map(|arg| arg.as_ptr()).collect();
-    argv.push(std::ptr::null());
-
-    let rc = unsafe { libc::execve(request.exec_args[0].as_ptr(), argv.as_ptr(), environ.cast()) };
-    let errno = std::io::Error::last_os_error()
-        .raw_os_error()
-        .unwrap_or(libc::ENOENT);
-
-    if rc != 0 {
-        eprintln!("{}", format_exec_error(errno));
-    }
-
-    exit_code_for_errno(errno)
 }
 
 fn main() {
@@ -102,9 +40,12 @@ fn main() {
         process::exit(126);
     });
 
-    sanitize_env();
-    env::set_var("WORKCELL_LAUNCH_TARGET", TARGET_NAME);
-    process::exit(exec_request(&request));
+    launcher_common::sanitize_env();
+    launcher_common::set_env_var("WORKCELL_LAUNCH_TARGET", TARGET_NAME);
+    process::exit(launcher_common::exec_request(
+        &request.exec_args,
+        SCRIPT_PATH,
+    ));
 }
 
 #[cfg(test)]
@@ -121,14 +62,14 @@ mod tests {
     #[test]
     fn sanitize_env_clears_sensitive_loader_and_node_state() {
         let _guard = env_lock().lock().expect("env lock");
-        env::set_var("BASH_ENV", "/tmp/bashenv");
-        env::set_var("LD_PRELOAD", "/tmp/preload.so");
-        env::set_var("NODE_OPTIONS", "--inspect");
-        env::set_var("NODE_EXTRA_CA_CERTS", "/tmp/extra.pem");
-        env::set_var("SSL_CERT_FILE", "/tmp/cert.pem");
-        env::set_var("SSL_CERT_DIR", "/tmp/certs");
+        launcher_common::set_env_var("BASH_ENV", "/tmp/bashenv");
+        launcher_common::set_env_var("LD_PRELOAD", "/tmp/preload.so");
+        launcher_common::set_env_var("NODE_OPTIONS", "--inspect");
+        launcher_common::set_env_var("NODE_EXTRA_CA_CERTS", "/tmp/extra.pem");
+        launcher_common::set_env_var("SSL_CERT_FILE", "/tmp/cert.pem");
+        launcher_common::set_env_var("SSL_CERT_DIR", "/tmp/certs");
 
-        sanitize_env();
+        launcher_common::sanitize_env();
 
         assert!(env::var_os("BASH_ENV").is_none());
         assert!(env::var_os("LD_PRELOAD").is_none());
@@ -141,8 +82,11 @@ mod tests {
     #[test]
     fn prepare_launch_builds_exec_args_and_rejects_nul_bytes() {
         let request = prepare_launch(vec![OsString::from("--version")]).expect("prepare launch");
-        assert_eq!(request.exec_args[0].as_bytes(), BASH_PATH.as_bytes());
-        assert_eq!(request.exec_args[1].as_bytes(), SCRIPT_PATH.as_bytes());
+        assert_eq!(request.exec_args[0].as_bytes(), b"/bin/bash");
+        assert_eq!(
+            request.exec_args[1].as_bytes(),
+            b"/usr/local/libexec/workcell/git-wrapper.sh"
+        );
         assert_eq!(request.exec_args[2].as_bytes(), b"--version");
 
         let invalid = OsString::from_vec(b"gi\0t".to_vec());
@@ -155,9 +99,9 @@ mod tests {
 
     #[test]
     fn exec_failure_helpers_format_messages_and_exit_codes() {
-        assert_eq!(exit_code_for_errno(libc::ENOENT), 127);
-        assert_eq!(exit_code_for_errno(libc::EACCES), 126);
-        let message = format_exec_error(libc::ENOENT);
+        assert_eq!(launcher_common::exit_code_for_errno(libc::ENOENT), 127);
+        assert_eq!(launcher_common::exit_code_for_errno(libc::EACCES), 126);
+        let message = launcher_common::format_exec_error(SCRIPT_PATH, libc::ENOENT);
         assert!(message.contains("execve(/bin/bash, /usr/local/libexec/workcell/git-wrapper.sh):"));
     }
 
@@ -165,12 +109,15 @@ mod tests {
     fn exec_request_returns_failure_code_when_shell_is_unavailable() {
         let request = LaunchRequest {
             exec_args: vec![
-                CString::new("/definitely/missing/bash").expect("missing bash path"),
-                CString::new(SCRIPT_PATH).expect("script path"),
+                c"/definitely/missing/bash".to_owned(),
+                c"/usr/local/libexec/workcell/git-wrapper.sh".to_owned(),
                 CString::new("--version").expect("version arg"),
             ],
         };
 
-        assert_eq!(exec_request(&request), 127);
+        assert_eq!(
+            launcher_common::exec_request(&request.exec_args, SCRIPT_PATH),
+            127
+        );
     }
 }

--- a/runtime/container/rust/src/bin/workcell-launcher.rs
+++ b/runtime/container/rust/src/bin/workcell-launcher.rs
@@ -1,14 +1,10 @@
+#[path = "common/launcher_common.rs"]
+mod launcher_common;
+
 use std::env;
 use std::ffi::{CString, OsStr, OsString};
-use std::os::raw::c_char;
 use std::os::unix::ffi::OsStrExt;
 use std::process;
-
-unsafe extern "C" {
-    static mut environ: *mut *mut c_char;
-}
-
-const BASH_PATH: &str = "/bin/bash";
 
 const LAUNCH_TARGETS: &[(&str, &str)] = &[
     (
@@ -35,29 +31,6 @@ enum LaunchError {
     NulArgument,
 }
 
-fn sanitize_env() {
-    for key in [
-        "BASH_ENV",
-        "ENV",
-        "LD_AUDIT",
-        "LD_LIBRARY_PATH",
-        "LD_PRELOAD",
-        "NODE_OPTIONS",
-        "NODE_PATH",
-        "NODE_EXTRA_CA_CERTS",
-        "npm_config_userconfig",
-        "NPM_CONFIG_USERCONFIG",
-        "SSL_CERT_FILE",
-        "SSL_CERT_DIR",
-    ] {
-        env::remove_var(key);
-    }
-}
-
-fn osstr_to_cstring(value: &OsStr) -> Result<CString, ()> {
-    CString::new(value.as_bytes()).map_err(|_| ())
-}
-
 fn lookup_target(argv0: &OsStr) -> Option<(&'static str, &'static str)> {
     let base = argv0.as_bytes().rsplit(|byte| *byte == b'/').next()?;
     let base = std::str::from_utf8(base).ok()?;
@@ -72,13 +45,7 @@ fn build_exec_args(
     script_path: &'static str,
     args: Vec<OsString>,
 ) -> Result<Vec<CString>, LaunchError> {
-    let mut exec_args = Vec::new();
-    exec_args.push(CString::new(BASH_PATH).expect("static bash path"));
-    exec_args.push(CString::new(script_path).expect("static script path"));
-    for arg in args {
-        exec_args.push(osstr_to_cstring(&arg).map_err(|_| LaunchError::NulArgument)?);
-    }
-    Ok(exec_args)
+    launcher_common::build_bash_exec_args(script_path, args).map_err(|_| LaunchError::NulArgument)
 }
 
 fn prepare_launch(argv0: &OsStr, args: Vec<OsString>) -> Result<LaunchRequest, LaunchError> {
@@ -100,41 +67,8 @@ fn format_launch_error(error: LaunchError) -> String {
         LaunchError::UnsupportedTarget(target) => {
             format!("Unsupported Workcell launcher target: {target}")
         }
-        LaunchError::NulArgument => "Workcell launcher argument contained a NUL byte.".to_string(),
+        LaunchError::NulArgument => launcher_common::NulArgumentError.to_string(),
     }
-}
-
-fn exit_code_for_errno(errno: i32) -> i32 {
-    if errno == libc::ENOENT {
-        127
-    } else {
-        126
-    }
-}
-
-fn format_exec_error(script_path: &str, errno: i32) -> String {
-    format!(
-        "execve({}, {}): {}",
-        BASH_PATH,
-        script_path,
-        std::io::Error::from_raw_os_error(errno)
-    )
-}
-
-fn exec_request(request: &LaunchRequest) -> i32 {
-    let mut argv: Vec<*const c_char> = request.exec_args.iter().map(|arg| arg.as_ptr()).collect();
-    argv.push(std::ptr::null());
-
-    let rc = unsafe { libc::execve(request.exec_args[0].as_ptr(), argv.as_ptr(), environ.cast()) };
-    let errno = std::io::Error::last_os_error()
-        .raw_os_error()
-        .unwrap_or(libc::ENOENT);
-
-    if rc != 0 {
-        eprintln!("{}", format_exec_error(request.script_path, errno));
-    }
-
-    exit_code_for_errno(errno)
 }
 
 fn main() {
@@ -146,9 +80,12 @@ fn main() {
         process::exit(126);
     });
 
-    sanitize_env();
-    env::set_var("WORKCELL_LAUNCH_TARGET", request.target_name);
-    process::exit(exec_request(&request));
+    launcher_common::sanitize_env();
+    launcher_common::set_env_var("WORKCELL_LAUNCH_TARGET", request.target_name);
+    process::exit(launcher_common::exec_request(
+        &request.exec_args,
+        request.script_path,
+    ));
 }
 
 #[cfg(test)]
@@ -192,7 +129,7 @@ mod tests {
             request.script_path,
             "/usr/local/libexec/workcell/provider-wrapper.sh"
         );
-        assert_eq!(request.exec_args[0].as_bytes(), BASH_PATH.as_bytes());
+        assert_eq!(request.exec_args[0].as_bytes(), b"/bin/bash");
         assert_eq!(
             request.exec_args[1].as_bytes(),
             b"/usr/local/libexec/workcell/provider-wrapper.sh"
@@ -220,21 +157,21 @@ mod tests {
 
     #[test]
     fn osstr_to_cstring_rejects_nul_bytes() {
-        assert!(osstr_to_cstring(OsStr::new("codex")).is_ok());
-        assert!(osstr_to_cstring(OsStr::from_bytes(b"co\0dex")).is_err());
+        assert!(launcher_common::osstr_to_cstring(OsStr::new("codex")).is_ok());
+        assert!(launcher_common::osstr_to_cstring(OsStr::from_bytes(b"co\0dex")).is_err());
     }
 
     #[test]
     fn sanitize_env_clears_sensitive_loader_and_node_state() {
         let _guard = env_lock().lock().expect("env lock");
-        env::set_var("BASH_ENV", "/tmp/bashenv");
-        env::set_var("LD_PRELOAD", "/tmp/preload.so");
-        env::set_var("NODE_OPTIONS", "--inspect");
-        env::set_var("NODE_EXTRA_CA_CERTS", "/tmp/extra.pem");
-        env::set_var("SSL_CERT_FILE", "/tmp/cert.pem");
-        env::set_var("SSL_CERT_DIR", "/tmp/certs");
+        launcher_common::set_env_var("BASH_ENV", "/tmp/bashenv");
+        launcher_common::set_env_var("LD_PRELOAD", "/tmp/preload.so");
+        launcher_common::set_env_var("NODE_OPTIONS", "--inspect");
+        launcher_common::set_env_var("NODE_EXTRA_CA_CERTS", "/tmp/extra.pem");
+        launcher_common::set_env_var("SSL_CERT_FILE", "/tmp/cert.pem");
+        launcher_common::set_env_var("SSL_CERT_DIR", "/tmp/certs");
 
-        sanitize_env();
+        launcher_common::sanitize_env();
 
         assert!(env::var_os("BASH_ENV").is_none());
         assert!(env::var_os("LD_PRELOAD").is_none());
@@ -246,9 +183,9 @@ mod tests {
 
     #[test]
     fn exec_failure_helpers_format_messages_and_exit_codes() {
-        assert_eq!(exit_code_for_errno(libc::ENOENT), 127);
-        assert_eq!(exit_code_for_errno(libc::EACCES), 126);
-        let message = format_exec_error(
+        assert_eq!(launcher_common::exit_code_for_errno(libc::ENOENT), 127);
+        assert_eq!(launcher_common::exit_code_for_errno(libc::EACCES), 126);
+        let message = launcher_common::format_exec_error(
             "/usr/local/libexec/workcell/provider-wrapper.sh",
             libc::ENOENT,
         );
@@ -263,13 +200,16 @@ mod tests {
             target_name: "codex",
             script_path: "/usr/local/libexec/workcell/provider-wrapper.sh",
             exec_args: vec![
-                CString::new("/definitely/missing/bash").expect("missing bash path"),
+                c"/definitely/missing/bash".to_owned(),
                 CString::new("/usr/local/libexec/workcell/provider-wrapper.sh")
                     .expect("provider wrapper path"),
                 CString::new("--version").expect("version arg"),
             ],
         };
 
-        assert_eq!(exec_request(&request), 127);
+        assert_eq!(
+            launcher_common::exec_request(&request.exec_args, request.script_path),
+            127
+        );
     }
 }

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::missing_safety_doc)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 use libc::{c_char, c_int, c_long, c_void, pid_t};
 #[cfg(all(
@@ -10,7 +11,7 @@ use std::env;
 use std::ffi::{CStr, CString};
 use std::fs::{self, File};
 use std::io::Read;
-use std::mem;
+use std::mem::{self, MaybeUninit};
 use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::sync::OnceLock;
@@ -107,8 +108,7 @@ const ARG_BLOCK_MESSAGE: &str = "Workcell blocked git control-plane override: re
 const ENV_BLOCK_MESSAGE: &str = "Workcell blocked git control-plane override: remove GIT_CONFIG_*, GIT_CONFIG_GLOBAL, GIT_CONFIG_SYSTEM, GIT_DIR, GIT_WORK_TREE, GIT_COMMON_DIR, GIT_EXEC_PATH, GIT_OBJECT_DIRECTORY, GIT_ALTERNATE_OBJECT_DIRECTORIES, GIT_INDEX_FILE, GIT_ASKPASS, GIT_EDITOR, GIT_SEQUENCE_EDITOR, GIT_SSH, GIT_SSH_COMMAND, SSH_ASKPASS, EDITOR, PAGER, or VISUAL overrides.\n";
 const PROTECTED_RUNTIME_BLOCK_MESSAGE: &str =
     "Workcell blocked direct protected runtime execution outside approved wrappers.\n";
-const MUTABLE_NATIVE_EXEC_BLOCK_MESSAGE: &str =
-    "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile.\n";
+const MUTABLE_NATIVE_EXEC_BLOCK_MESSAGE: &str = "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile.\n";
 
 type ExecveFn =
     unsafe extern "C" fn(*const c_char, *const *const c_char, *const *const c_char) -> c_int;
@@ -383,12 +383,11 @@ fn env_command_targets_protected_runtime(cursor: &str, env_entries: &[String]) -
         )
         .unwrap_or(token.clone());
 
-        if token_is_shell_interpreter(&token_path) {
-            if let Some(target) = next_shebang_token(&mut scan) {
-                if shell_option_executes_command(&target) {
-                    return true;
-                }
-            }
+        if token_is_shell_interpreter(&token_path)
+            && let Some(target) = next_shebang_token(&mut scan)
+            && shell_option_executes_command(&target)
+        {
+            return true;
         }
 
         if classify_protected_runtime_path(&token_path) != ProtectedRuntime::None {
@@ -902,10 +901,10 @@ fn should_block(path: &str, args: &[String]) -> bool {
             _ => {}
         }
 
-        if let Some(spec) = arg.strip_prefix("--config-env=") {
-            if git_config_spec_is_blocked(spec) {
-                return true;
-            }
+        if let Some(spec) = arg.strip_prefix("--config-env=")
+            && git_config_spec_is_blocked(spec)
+        {
+            return true;
         }
         if arg.starts_with("--exec-path=")
             || arg.starts_with("--git-dir=")
@@ -976,16 +975,16 @@ fn env_has_unsafe_git_override(env_entries: &[String]) -> bool {
             return true;
         }
 
-        if let Some(value) = entry.strip_prefix("GIT_CONFIG_GLOBAL=") {
-            if value != "/dev/null" {
-                return true;
-            }
+        if let Some(value) = entry.strip_prefix("GIT_CONFIG_GLOBAL=")
+            && value != "/dev/null"
+        {
+            return true;
         }
 
-        if let Some(value) = entry.strip_prefix("GIT_CONFIG_NOSYSTEM=") {
-            if value != "1" {
-                return true;
-            }
+        if let Some(value) = entry.strip_prefix("GIT_CONFIG_NOSYSTEM=")
+            && value != "1"
+        {
+            return true;
         }
 
         if let Some(value) = entry.strip_prefix("GIT_CONFIG_COUNT=") {
@@ -1018,12 +1017,12 @@ fn report(message: &str) {
 
 #[cfg(target_os = "linux")]
 unsafe fn errno_location() -> *mut c_int {
-    libc::__errno_location()
+    unsafe { libc::__errno_location() }
 }
 
 #[cfg(target_os = "macos")]
 unsafe fn errno_location() -> *mut c_int {
-    libc::__error()
+    unsafe { libc::__error() }
 }
 
 fn report_block(env_bypass: bool) {
@@ -1042,46 +1041,46 @@ fn report_mutable_native_exec_block() {
     report(MUTABLE_NATIVE_EXEC_BLOCK_MESSAGE);
 }
 
-unsafe fn load_symbol<T: Copy>(name: &[u8]) -> T {
-    let symbol = libc::dlsym(libc::RTLD_NEXT, name.as_ptr().cast());
+unsafe fn load_symbol<T: Copy>(name: &CStr) -> T {
+    let symbol = unsafe { libc::dlsym(libc::RTLD_NEXT, name.as_ptr().cast()) };
     assert!(!symbol.is_null(), "missing required symbol {:?}", name);
-    mem::transmute_copy(&symbol)
+    unsafe { mem::transmute_copy(&symbol) }
 }
 
 fn execve_fn() -> ExecveFn {
-    *EXECVE_FN.get_or_init(|| unsafe { load_symbol(b"execve\0") })
+    *EXECVE_FN.get_or_init(|| unsafe { load_symbol(c"execve") })
 }
 
 fn execv_fn() -> ExecvFn {
-    *EXECV_FN.get_or_init(|| unsafe { load_symbol(b"execv\0") })
+    *EXECV_FN.get_or_init(|| unsafe { load_symbol(c"execv") })
 }
 
 fn execvp_fn() -> ExecvpFn {
-    *EXECVP_FN.get_or_init(|| unsafe { load_symbol(b"execvp\0") })
+    *EXECVP_FN.get_or_init(|| unsafe { load_symbol(c"execvp") })
 }
 
 fn execvpe_fn() -> ExecvpeFn {
-    *EXECVPE_FN.get_or_init(|| unsafe { load_symbol(b"execvpe\0") })
+    *EXECVPE_FN.get_or_init(|| unsafe { load_symbol(c"execvpe") })
 }
 
 fn execveat_fn() -> ExecveatFn {
-    *EXECVEAT_FN.get_or_init(|| unsafe { load_symbol(b"execveat\0") })
+    *EXECVEAT_FN.get_or_init(|| unsafe { load_symbol(c"execveat") })
 }
 
 fn fexecve_fn() -> FexecveFn {
-    *FEXECVE_FN.get_or_init(|| unsafe { load_symbol(b"fexecve\0") })
+    *FEXECVE_FN.get_or_init(|| unsafe { load_symbol(c"fexecve") })
 }
 
 fn posix_spawn_fn() -> PosixSpawnFn {
-    *POSIX_SPAWN_FN.get_or_init(|| unsafe { load_symbol(b"posix_spawn\0") })
+    *POSIX_SPAWN_FN.get_or_init(|| unsafe { load_symbol(c"posix_spawn") })
 }
 
 fn posix_spawnp_fn() -> PosixSpawnpFn {
-    *POSIX_SPAWNP_FN.get_or_init(|| unsafe { load_symbol(b"posix_spawnp\0") })
+    *POSIX_SPAWNP_FN.get_or_init(|| unsafe { load_symbol(c"posix_spawnp") })
 }
 
 fn real_syscall_fn() -> SyscallFn {
-    *REAL_SYSCALL_FN.get_or_init(|| unsafe { load_symbol(b"syscall\0") })
+    *REAL_SYSCALL_FN.get_or_init(|| unsafe { load_symbol(c"syscall") })
 }
 
 fn c_path_string(path: *const c_char) -> String {
@@ -1117,10 +1116,11 @@ fn is_git_execveat_target(dirfd: c_int, pathname: &str, flags: c_int) -> bool {
     let Ok(c_path) = CString::new(pathname.as_bytes()) else {
         return false;
     };
-    let mut stat_buf = unsafe { mem::zeroed::<libc::stat>() };
-    if unsafe { libc::fstatat(dirfd, c_path.as_ptr(), &mut stat_buf, 0) } != 0 {
+    let mut stat_buf = MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstatat(dirfd, c_path.as_ptr(), stat_buf.as_mut_ptr(), 0) } != 0 {
         return false;
     }
+    let stat_buf = unsafe { stat_buf.assume_init() };
 
     let Some(signature) = stat_signature_from_stat(&stat_buf) else {
         return false;
@@ -1142,24 +1142,28 @@ pub unsafe extern "C" fn workcell_syscall_shim(
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     {
         if number == SYS_EXECVE {
-            return execve(
-                arg1 as *const c_char,
-                arg2 as *const *const c_char,
-                arg3 as *const *const c_char,
-            ) as c_long;
+            return unsafe {
+                execve(
+                    arg1 as *const c_char,
+                    arg2 as *const *const c_char,
+                    arg3 as *const *const c_char,
+                ) as c_long
+            };
         }
         if number == SYS_EXECVEAT {
-            return execveat(
-                arg1 as c_int,
-                arg2 as *const c_char,
-                arg3 as *const *const c_char,
-                arg4 as *const *const c_char,
-                arg5 as c_int,
-            ) as c_long;
+            return unsafe {
+                execveat(
+                    arg1 as c_int,
+                    arg2 as *const c_char,
+                    arg3 as *const *const c_char,
+                    arg4 as *const *const c_char,
+                    arg5 as c_int,
+                ) as c_long
+            };
         }
     }
 
-    real_syscall_fn()(number, arg1, arg2, arg3, arg4, arg5, arg6)
+    unsafe { real_syscall_fn()(number, arg1, arg2, arg3, arg4, arg5, arg6) }
 }
 
 #[unsafe(no_mangle)]
@@ -1189,14 +1193,14 @@ pub unsafe extern "C" fn execve(
         return -1;
     }
 
-    execve_fn()(path, argv, envp)
+    unsafe { execve_fn()(path, argv, envp) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn execv(path: *const c_char, argv: *const *const c_char) -> c_int {
     let path_string = c_path_string(path);
     let args = collect_cstring_array(argv);
-    let env_entries = collect_cstring_array(environ.cast());
+    let env_entries = collect_cstring_array(unsafe { environ.cast() });
 
     if should_block_protected_runtime_exec(&path_string, &args, &env_entries) {
         report_protected_runtime_block();
@@ -1215,14 +1219,14 @@ pub unsafe extern "C" fn execv(path: *const c_char, argv: *const *const c_char) 
         return -1;
     }
 
-    execv_fn()(path, argv)
+    unsafe { execv_fn()(path, argv) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn execvp(file: *const c_char, argv: *const *const c_char) -> c_int {
     let file_string = c_path_string(file);
     let args = collect_cstring_array(argv);
-    let env_entries = collect_cstring_array(environ.cast());
+    let env_entries = collect_cstring_array(unsafe { environ.cast() });
     let effective_path = resolve_exec_search_target(&file_string, &env_entries);
 
     if should_block_protected_runtime_exec(&effective_path, &args, &env_entries) {
@@ -1242,7 +1246,7 @@ pub unsafe extern "C" fn execvp(file: *const c_char, argv: *const *const c_char)
         return -1;
     }
 
-    execvp_fn()(file, argv)
+    unsafe { execvp_fn()(file, argv) }
 }
 
 #[unsafe(no_mangle)]
@@ -1273,7 +1277,7 @@ pub unsafe extern "C" fn execvpe(
         return -1;
     }
 
-    execvpe_fn()(file, argv, envp)
+    unsafe { execvpe_fn()(file, argv, envp) }
 }
 
 #[unsafe(no_mangle)]
@@ -1308,25 +1312,29 @@ pub unsafe extern "C" fn execveat(
             let mut mutable_shebang_target = false;
 
             if let Ok(c_path) = CString::new(pathname_string.as_bytes()) {
-                let mut stat_buf = mem::zeroed::<libc::stat>();
-                if libc::fstatat(dirfd, c_path.as_ptr(), &mut stat_buf, 0) == 0 {
-                    if let Some(signature) = stat_signature_from_stat(&stat_buf) {
+                unsafe {
+                    let mut stat_buf = MaybeUninit::<libc::stat>::uninit();
+                    if libc::fstatat(dirfd, c_path.as_ptr(), stat_buf.as_mut_ptr(), 0) == 0
+                        && let stat_buf = stat_buf.assume_init()
+                        && let Some(signature) = stat_signature_from_stat(&stat_buf)
+                    {
                         protected_target = stat_matches_protected_runtime(&signature);
                     }
-                }
 
-                let candidate_fd =
-                    libc::openat(dirfd, c_path.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC);
-                if candidate_fd >= 0 {
-                    mutable_native_target = file_descriptor_is_mutable_native_exec(candidate_fd);
-                    if !mutable_native_target {
-                        mutable_shebang_target =
-                            file_descriptor_is_mutable_shebang_to_protected_runtime(
-                                candidate_fd,
-                                &env_entries,
-                            );
+                    let candidate_fd =
+                        libc::openat(dirfd, c_path.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC);
+                    if candidate_fd >= 0 {
+                        mutable_native_target =
+                            file_descriptor_is_mutable_native_exec(candidate_fd);
+                        if !mutable_native_target {
+                            mutable_shebang_target =
+                                file_descriptor_is_mutable_shebang_to_protected_runtime(
+                                    candidate_fd,
+                                    &env_entries,
+                                );
+                        }
+                        libc::close(candidate_fd);
                     }
-                    libc::close(candidate_fd);
                 }
             }
 
@@ -1374,7 +1382,7 @@ pub unsafe extern "C" fn execveat(
         return -1;
     }
 
-    execveat_fn()(dirfd, pathname, argv, envp, flags)
+    unsafe { execveat_fn()(dirfd, pathname, argv, envp, flags) }
 }
 
 #[unsafe(no_mangle)]
@@ -1409,7 +1417,7 @@ pub unsafe extern "C" fn fexecve(
         return -1;
     }
 
-    fexecve_fn()(fd, argv, envp)
+    unsafe { fexecve_fn()(fd, argv, envp) }
 }
 
 #[unsafe(no_mangle)]
@@ -1442,7 +1450,7 @@ pub unsafe extern "C" fn posix_spawn(
         return libc::EPERM;
     }
 
-    posix_spawn_fn()(pid, path, file_actions, attrp, argv, envp)
+    unsafe { posix_spawn_fn()(pid, path, file_actions, attrp, argv, envp) }
 }
 
 #[unsafe(no_mangle)]
@@ -1476,7 +1484,7 @@ pub unsafe extern "C" fn posix_spawnp(
         return libc::EPERM;
     }
 
-    posix_spawnp_fn()(pid, file, file_actions, attrp, argv, envp)
+    unsafe { posix_spawnp_fn()(pid, file, file_actions, attrp, argv, envp) }
 }
 
 #[cfg(test)]

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -200,6 +200,18 @@ remote_validator_snapshot = require_arg(
 )
 codex_version = require_arg(runtime_dockerfile, "CODEX_VERSION", "runtime/container/Dockerfile")
 claude_version = require_arg(runtime_dockerfile, "CLAUDE_VERSION", "runtime/container/Dockerfile")
+runtime_rust_version = require_arg(runtime_dockerfile, "RUST_VERSION", "runtime/container/Dockerfile")
+runtime_rustup_version = require_arg(runtime_dockerfile, "RUSTUP_VERSION", "runtime/container/Dockerfile")
+runtime_rustup_init_linux_x86_64_sha256 = require_arg(
+    runtime_dockerfile,
+    "RUSTUP_INIT_LINUX_X86_64_SHA256",
+    "runtime/container/Dockerfile",
+)
+runtime_rustup_init_linux_arm64_sha256 = require_arg(
+    runtime_dockerfile,
+    "RUSTUP_INIT_LINUX_ARM64_SHA256",
+    "runtime/container/Dockerfile",
+)
 runtime_install_blocks = extract_install_blocks(runtime_dockerfile, "runtime/container/Dockerfile")
 validator_install_blocks = extract_install_blocks(validator_dockerfile, "tools/validator/Dockerfile")
 remote_validator_install_blocks = extract_install_blocks(
@@ -269,6 +281,54 @@ if not re.match(r"^0\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?$", codex_version):
         "runtime/container/Dockerfile CODEX_VERSION must stay pinned to an "
         f"explicit release, found {codex_version!r}"
     )
+if not re.match(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?$", runtime_rust_version):
+    raise SystemExit(
+        "runtime/container/Dockerfile RUST_VERSION must stay pinned to an "
+        f"explicit release, found {runtime_rust_version!r}"
+    )
+if not re.match(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?$", runtime_rustup_version):
+    raise SystemExit(
+        "runtime/container/Dockerfile RUSTUP_VERSION must stay pinned to an "
+        f"explicit release, found {runtime_rustup_version!r}"
+    )
+if not re.fullmatch(r"[0-9a-f]{64}", runtime_rustup_init_linux_x86_64_sha256):
+    raise SystemExit(
+        "runtime/container/Dockerfile RUSTUP_INIT_LINUX_X86_64_SHA256 must be a full SHA256 digest"
+    )
+if not re.fullmatch(r"[0-9a-f]{64}", runtime_rustup_init_linux_arm64_sha256):
+    raise SystemExit(
+        "runtime/container/Dockerfile RUSTUP_INIT_LINUX_ARM64_SHA256 must be a full SHA256 digest"
+    )
+require_contains(
+    runtime_dockerfile,
+    'https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustup_target}/rustup-init',
+    "rustup bootstrap URL",
+    "runtime/container/Dockerfile",
+)
+require_contains(
+    runtime_dockerfile,
+    'ENV CARGO_HOME=/usr/local/cargo',
+    "runtime builder Cargo home",
+    "runtime/container/Dockerfile",
+)
+require_contains(
+    runtime_dockerfile,
+    'ENV PATH=/usr/local/cargo/bin:${PATH}',
+    "runtime builder Cargo PATH export",
+    "runtime/container/Dockerfile",
+)
+require_contains(
+    runtime_dockerfile,
+    'ENV RUSTUP_HOME=/usr/local/rustup',
+    "runtime builder rustup home",
+    "runtime/container/Dockerfile",
+)
+require_contains(
+    runtime_dockerfile,
+    'rustc --version | grep -F "rustc ${RUST_VERSION} "',
+    "installed Rust version verification",
+    "runtime/container/Dockerfile",
+)
 if len(runtime_install_blocks) != 2:
     raise SystemExit(
         "runtime/container/Dockerfile must contain exactly two apt install blocks "
@@ -304,8 +364,8 @@ require_exact_packages(
 require_exact_packages(
     runtime_install_blocks[1],
     [
-        "cargo",
-        "rustc",
+        "gcc",
+        "libc6-dev",
     ],
     "Runtime builder",
     "runtime/container/Dockerfile",
@@ -313,20 +373,20 @@ require_exact_packages(
 require_exact_packages(
     validator_install_blocks[0],
     [
+        "ca-certificates",
         "codespell",
-        "cargo",
+        "curl",
+        "gcc",
         "git",
         "groff-base",
         "jq",
+        "libc6-dev",
         "llvm",
         "mandoc",
         "openssh-client",
         "python3",
         "python3-coverage",
         "procps",
-        "rustc",
-        "rust-clippy",
-        "rustfmt",
         "shellcheck",
         "shfmt",
         "yamllint",

--- a/tools/validator/Dockerfile
+++ b/tools/validator/Dockerfile
@@ -1,11 +1,23 @@
 ARG VALIDATOR_BASE_IMAGE=node:22-trixie-slim@sha256:285a78d9fdb7cd2e4a03639cc7bbf609755ce8c0aa4e3b00086211e3e86a7038
 ARG DEBIAN_SNAPSHOT=20260316T000000Z
+ARG RUST_VERSION=1.94.1
+ARG RUSTUP_VERSION=1.29.0
+ARG RUSTUP_INIT_LINUX_X86_64_SHA256=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
+ARG RUSTUP_INIT_LINUX_ARM64_SHA256=9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792
 
 FROM ${VALIDATOR_BASE_IMAGE}
 
 ARG DEBIAN_SNAPSHOT
+ARG RUST_VERSION
+ARG RUSTUP_VERSION
+ARG RUSTUP_INIT_LINUX_X86_64_SHA256
+ARG RUSTUP_INIT_LINUX_ARM64_SHA256
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH=/usr/local/cargo/bin:${PATH}
+ENV RUSTUP_HOME=/usr/local/rustup
 
 RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
   && printf 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/%s trixie main\n' "${DEBIAN_SNAPSHOT}" > /etc/apt/sources.list \
@@ -14,20 +26,20 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
   && printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "5";\nAcquire::http::Timeout "30";\n' > /etc/apt/apt.conf.d/99workcell-validator-snapshot \
   && install_validator_packages() { \
        DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+         ca-certificates \
          codespell \
-         cargo \
+         curl \
+         gcc \
          git \
          groff-base \
          jq \
+         libc6-dev \
          llvm \
          mandoc \
          openssh-client \
          python3 \
          python3-coverage \
          procps \
-         rustc \
-         rust-clippy \
-         rustfmt \
          shellcheck \
          shfmt \
          yamllint \
@@ -44,7 +56,44 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
        fi; \
        sleep "$((attempt * 5))"; \
      done \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /var/cache/debconf/*-old /var/cache/ldconfig/aux-cache
+  && rustup_target="" \
+  && rustup_sha256="" \
+  && case "$(dpkg --print-architecture)" in \
+       amd64) \
+         rustup_target="x86_64-unknown-linux-gnu"; \
+         rustup_sha256="${RUSTUP_INIT_LINUX_X86_64_SHA256}"; \
+         ;; \
+       arm64) \
+         rustup_target="aarch64-unknown-linux-gnu"; \
+         rustup_sha256="${RUSTUP_INIT_LINUX_ARM64_SHA256}"; \
+         ;; \
+       *) \
+         echo "Unsupported dpkg architecture for rustup: $(dpkg --print-architecture)" >&2; \
+         exit 1; \
+         ;; \
+     esac \
+  && curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+    "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustup_target}/rustup-init" \
+    -o /tmp/rustup-init \
+  && echo "${rustup_sha256}  /tmp/rustup-init" | sha256sum -c - \
+  && chmod 0755 /tmp/rustup-init \
+  && /tmp/rustup-init -y --profile minimal --default-toolchain "${RUST_VERSION}" --component rustfmt --component clippy --no-modify-path \
+  && ln -sf /usr/local/cargo/bin/cargo /usr/local/bin/cargo \
+  && ln -sf /usr/local/cargo/bin/rustc /usr/local/bin/rustc \
+  && ln -sf /usr/local/cargo/bin/rustfmt /usr/local/bin/rustfmt \
+  && ln -sf /usr/local/cargo/bin/cargo-fmt /usr/local/bin/cargo-fmt \
+  && ln -sf /usr/local/cargo/bin/cargo-clippy /usr/local/bin/cargo-clippy \
+  && rustc --version | grep -F "rustc ${RUST_VERSION} " >/dev/null \
+  && cargo fmt --version >/dev/null \
+  && cargo clippy --version >/dev/null \
+  && rm -f /tmp/rustup-init \
+  && rm -rf \
+    /usr/local/rustup/downloads \
+    /usr/local/rustup/tmp \
+    /var/lib/apt/lists/* \
+    /var/cache/apt/* \
+    /var/cache/debconf/*-old \
+    /var/cache/ldconfig/aux-cache
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Summary
- pin the Rust runtime crate to the latest stable toolchain already validated on this branch
- deduplicate launcher plumbing into a shared module
- tighten the runtime crate implementation without mixing Dockerfile churn into the review

## Verification
- `cargo +1.94.1 clippy --all-targets --locked --offline -- -D warnings`
- `cargo +1.94.1 test --locked --offline`
