### PR TITLE
Add build-and-test harness, harden snapshot materialization

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: commit
+description: Risk-Aware Commit Notation. Use when creating git commits to determine the correct prefix, risk level, and commit grouping.
+---
+
+# Risk-Aware Commit Notation
+
+All commits in this repo must use Risk-Aware Commit Notation (based on [Arlo's Commit Notation](https://github.com/RefactoringCombos/ArlosCommitNotation)), a risk-based notation where the first characters of every commit message encode risk level and intention.
+
+## Format
+
+`<risk><intention> <description>`
+
+## Risk Levels
+
+| Symbol | Level | Guarantees |
+|--------|-------|------------|
+| `.` | Safe | Intended change + known & unknown invariants |
+| `^` | Validated | Intended change + known invariants |
+| `!` | Risky | Intended change only |
+| `@` | Broken | None |
+
+## Intentions
+
+| Letter | Type | Meaning |
+|--------|------|---------|
+| **F/f** | Feature | Modify one behavioral aspect without affecting others |
+| **B/b** | Bugfix | Repair undesirable behavior, preserve everything else |
+| **R/r** | Refactoring | Restructure code without changing runtime behavior |
+| **D/d** | Documentation | Update info that doesn't impact code execution |
+
+## Rules
+
+- Uppercase = primary/user-visible changes. Lowercase = supporting changes.
+- Features/bugfixes exceeding 8 lines of code (including tests) default to highest risk level.
+- Safe refactoring (`.r`) requires provable refactoring via automated tools or test-supported procedural refactoring.
+- Choose the risk level honestly. If you haven't verified invariants, use `!` or `@`.
+
+## Commit Grouping
+
+- **One intention per commit.** Do not mix refactoring, features, bugfixes, or documentation in a single commit. If a task requires both refactoring and a feature change, split them into separate commits (refactoring first, then the feature).
+- **Minimize risk per commit.** Break work into the smallest commits that each achieve the lowest possible risk level. For example, extract a safe refactoring (`.r`) as its own commit before making a risky feature change (`!F`), rather than bundling both into one `!F` commit.
+- **Prefer many small safe commits over fewer risky ones.** A sequence like `.r` then `.r` then `^F` is better than a single `!F` that includes the refactoring.
+
+## Notation Justification in Commit Messages
+
+After drafting each commit, add a terse parenthetical after the description explaining both the risk level and the uppercase/lowercase choice. Keep it to one clause each, separated by a semicolon.
+
+Format: `(risk reason; case reason)`
+
+Examples:
+
+- `^F Add --branch-exclude flag (tests pass; user-visible CLI flag)`
+- `^f Add FilterByBranchExclusion utility (existing tests green; supporting function, not user-facing)`
+- `^B Fix cache key collision (regression test added; user-visible bug)`
+- `^b Update call sites for new signature (compiles and tests green; supporting change for ^F above)`
+- `!F Add experimental diff parser (no tests yet; user-visible feature)`
+- `.r Extract helper, no behavior change (automated rename; internal restructure)`
+
+## Examples
+
+- `.r Style: reformat line wrapping in scm_policy_checker.py`
+- `!F Add new endpoint for policy evaluation`
+- `^B Fix cache invalidation on prompt change (regression test added)`
+- `.d Update README with setup instructions`

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = .git,dist,tmp,runtime/container/providers/node_modules,runtime/container/rust/vendor,runtime/container/rust/target
+skip = .git,.venv,dist,tmp,runtime/container/providers/node_modules,runtime/container/rust/vendor,runtime/container/rust/target
 quiet-level = 2
 ignore-regex = ^\s*\.IP\s+\\\(bu\s+2$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.lock -merge

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .env.*
 .mcp.local.json
 *.local
+.claude/settings.local.json
 *.override
 *.pem
 *.key

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,10 @@ adapters/codex/.codex/memories/
 adapters/codex/.codex/tmp/
 dist/
 tmp/
+.venv/
 runtime/container/providers/node_modules/
 runtime/container/providers/mirror/
 runtime/container/rust/target/
 __pycache__/
+.pytest_cache/
 *.pyc

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD060": false
+}

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Other defaults that matter:
 Install the launcher symlink and verify the host prerequisites:
 
 ```bash
-./scripts/install.sh
+./install.sh
 workcell --prepare --agent codex --workspace /path/to/repo
 ```
 
@@ -116,6 +116,33 @@ What to expect from the safe path:
   outside the Tier 1 container
 - `--debug-log`, `--file-trace-log`, and `--audit-transcript` are explicit
   lower-assurance operator choices and are off by default
+
+## Contributing
+
+Validation tiers, from fastest to most thorough:
+
+```bash
+scripts/dev-quick-check.sh      # seconds, host tools only (shellcheck, cargo, pytest)
+scripts/build-and-test.sh       # minutes, all checks, host tools only
+scripts/pre-merge.sh            # full release gate with Docker, repro builds
+```
+
+`dev-quick-check.sh` is the normal edit loop. `build-and-test.sh` runs the
+full validation suite directly on the host using locally installed tools. CI
+is the authority on exact tool versions; local runs catch issues early without
+Docker overhead. `pre-merge.sh` adds container-smoke tests, reproducible-build
+verification, and release-specific checks (requires Docker).
+
+`build-and-test.sh` flags:
+
+```bash
+scripts/build-and-test.sh --install   # install missing host tools (brew, pip, npm)
+scripts/build-and-test.sh --list      # list files that would be checked
+scripts/build-and-test.sh --strict    # exit on first failure
+scripts/build-and-test.sh --auto-fix  # run markdownlint --fix before linting
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites and workflow details.
 
 ## Session inputs
 

--- a/README.md
+++ b/README.md
@@ -133,13 +133,10 @@ is the authority on exact tool versions; local runs catch issues early without
 Docker overhead. `pre-merge.sh` adds container-smoke tests, reproducible-build
 verification, and release-specific checks (requires Docker).
 
-`build-and-test.sh` flags:
+To install missing host tools:
 
 ```bash
 scripts/build-and-test.sh --install   # install missing host tools (brew, pip, npm)
-scripts/build-and-test.sh --list      # list files that would be checked
-scripts/build-and-test.sh --strict    # exit on first failure
-scripts/build-and-test.sh --auto-fix  # run markdownlint --fix before linting
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites and workflow details.

--- a/adapters/claude/hooks/guard-bash.sh
+++ b/adapters/claude/hooks/guard-bash.sh
@@ -275,7 +275,7 @@ command_has_source_command_word() {
 command="$(printf '%s' "${WORKCELL_HOOK_PAYLOAD}" | jq -er '.tool_input.command | select(type == "string")' 2>/dev/null || true)"
 [[ -n "${command}" ]] || exit 0
 
-command_lower="${command,,}"
+command_lower="$(printf '%s' "${command}" | tr '[:upper:]' '[:lower:]')"
 command_lower_dequoted="$(printf '%s' "${command_lower}" | tr -d "\"'")"
 command_lower_deescaped="$(printf '%s' "${command_lower_dequoted}" | tr -d "\\")"
 command_substitution_marker="\$("

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -13,7 +13,7 @@ Use this page with:
 These run without provider credentials:
 
 - `./scripts/dev-quick-check.sh`
-- `./scripts/validate-repo.sh`
+- `./scripts/build-and-test.sh` (runs in the same container as CI)
 - `./scripts/container-smoke.sh`
 - `./scripts/verify-invariants.sh`
 - `./scripts/verify-release-bundle.sh`

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -13,7 +13,7 @@ Use this page with:
 These run without provider credentials:
 
 - `./scripts/dev-quick-check.sh`
-- `./scripts/build-and-test.sh` (runs in the same container as CI)
+- `./scripts/build-and-test.sh` (host-native, no Docker required)
 - `./scripts/container-smoke.sh`
 - `./scripts/verify-invariants.sh`
 - `./scripts/verify-release-bundle.sh`

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -p
+# Install Workcell into ~/.local/bin.  Forwards to scripts/install.sh.
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
+  exec /usr/bin/env -i \
+    PATH="${TRUSTED_HOST_PATH}" \
+    HOME="${HOME:-/tmp}" \
+    SHELL="${SHELL:-/bin/zsh}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    WORKCELL_SANITIZED_ENTRYPOINT=1 \
+    /bin/bash -p "$0" "$@"
+fi
+set -euo pipefail
+export PATH="${TRUSTED_HOST_PATH}"
+
+if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
+  head -n 1 "$0" >/dev/null
+  echo "install-entrypoint-ok"
+  exit 0
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${ROOT_DIR}/scripts/install.sh" "$@"

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -32,7 +32,7 @@ reproducible runtime for the supported providers.
 - `scripts/colima-egress-allowlist.sh`: VM-level network posture helper
 - `scripts/container-smoke.sh`: direct container smoke coverage
 - `scripts/verify-invariants.sh`: invariant checks
-- `scripts/validate-repo.sh`: repo-wide validation
+- `scripts/build-and-test.sh`: repo-wide validation and local check entry point
 
 ## GUI status
 

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "0687bf201d4cfa1bc1db5b3330c9c5114d82f6d4c52f92374c6329f1d5e931de"
+      "sha256": "1463ff394459723322a35a93be05f9674a305fde054afda34c1806ade522a4c2"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -34,7 +34,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/claude/hooks/guard-bash.sh",
       "runtime_path": "/opt/workcell/adapters/claude/hooks/guard-bash.sh",
-      "sha256": "d40e2b13f22fa9f1a92cf3033df6f465f6195d6f9bf256bbcdec328e61803804"
+      "sha256": "fd81d0f21dccf0e97cee2b69138e2fa8d40450caee326e1e2b4cd348d7fb6379"
     },
     {
       "kind": "adapter-baseline",

--- a/scripts/build-and-test.sh
+++ b/scripts/build-and-test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash -p
+# Host-side validation harness.  Runs repo-level checks (linting,
+# compilation, tests, manifest verification) directly on the host using
+# locally installed tools.  CI is the authority on exact tool versions;
+# this script catches issues early without Docker overhead.
+#
+# This is a build-time tool, not a runtime entry point; it does not
+# launch a Workcell session or go through the launcher's runtime boundary.
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
+  exec /usr/bin/env -i \
+    PATH="${TRUSTED_HOST_PATH}" \
+    HOME="${HOME:-/tmp}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    WORKCELL_SANITIZED_ENTRYPOINT=1 \
+    /bin/bash -p "$0" "$@"
+fi
+set -euo pipefail
+export PATH="${HOME}/.cargo/bin:${TRUSTED_HOST_PATH}"
+
+if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
+  head -n 1 "$0" >/dev/null
+  echo "build-and-test-entrypoint-ok"
+  exit 0
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Handle flags that build-and-test.sh owns before passing the rest to
+# validate-repo.sh.
+for arg in "$@"; do
+  case "${arg}" in
+    --install)
+      exec "${ROOT_DIR}/scripts/install-dev-tools.sh"
+      ;;
+    -h | --help)
+      cat <<EOF
+Usage: build-and-test.sh [OPTIONS]
+
+Host-side validation harness. Runs check-pinned-inputs.sh and
+validate-repo.sh directly on the host using locally installed tools.
+
+Options:
+  --install     Install missing host tools (brew/apt) and set up Python venv
+  --auto-fix    Run markdownlint --fix before linting
+  --strict      Exit on first check failure
+  -l, --list    List files that would be checked, then exit
+  -h, --help    Show this help
+EOF
+      exit 0
+      ;;
+  esac
+done
+
+# Activate the repo venv if it exists (provides pytest).
+if [[ -f "${ROOT_DIR}/.venv/bin/activate" ]]; then
+  # shellcheck source=/dev/null
+  source "${ROOT_DIR}/.venv/bin/activate"
+fi
+
+# --- Host-side checks (same as CI, before validation) ---
+"${ROOT_DIR}/scripts/check-pinned-inputs.sh"
+"${ROOT_DIR}/scripts/verify-build-input-manifest.sh"
+
+# --- Repo validation (linting, compilation, tests, manifests) ---
+"${ROOT_DIR}/scripts/validate-repo.sh" "$@"

--- a/scripts/build-and-test.sh
+++ b/scripts/build-and-test.sh
@@ -42,9 +42,6 @@ validate-repo.sh directly on the host using locally installed tools.
 
 Options:
   --install     Install missing host tools (brew/apt) and set up Python venv
-  --auto-fix    Run markdownlint --fix before linting
-  --strict      Exit on first check failure
-  -l, --list    List files that would be checked, then exit
   -h, --help    Show this help
 EOF
       exit 0

--- a/scripts/dev-quick-check.sh
+++ b/scripts/dev-quick-check.sh
@@ -53,7 +53,10 @@ done < <(find "${ROOT_DIR}/tests/scenarios" -type f -name 'test-*.sh' -print | s
 shellcheck -x "${shell_files[@]}"
 shfmt -ln=bash -i 2 -ci -d "${shell_files[@]}"
 "${ROOT_DIR}/scripts/lint-dockerfiles.sh"
-mapfile -d '' -t go_files < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
+go_files=()
+while IFS= read -r -d '' item; do
+  go_files+=("${item}")
+done < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
 if [[ "${#go_files[@]}" -gt 0 ]]; then
   if gofmt -l "${go_files[@]}" | grep -q .; then
     echo "Go files are not formatted with gofmt." >&2

--- a/scripts/go-port-validate.sh
+++ b/scripts/go-port-validate.sh
@@ -18,7 +18,10 @@ require_tool gofmt
 
 (
   cd "${ROOT_DIR}"
-  mapfile -d '' -t go_files < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
+  go_files=()
+  while IFS= read -r -d '' item; do
+    go_files+=("${item}")
+  done < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
   if [[ "${#go_files[@]}" -gt 0 ]]; then
     if gofmt -l "${go_files[@]}" | grep -q .; then
       echo "Go files are not formatted with gofmt." >&2

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# Install development tools needed by validate-repo.sh and dev-quick-check.sh.
+# Detects macOS (brew) vs Linux (apt) and installs missing packages.
+set -euo pipefail
+
+echo "Checking host tools..."
+missing=()
+
+command -v shellcheck &>/dev/null || missing+=(shellcheck)
+command -v shfmt &>/dev/null || missing+=(shfmt)
+command -v yamllint &>/dev/null || missing+=(yamllint)
+command -v codespell &>/dev/null || missing+=(codespell)
+command -v jq &>/dev/null || missing+=(jq)
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  case "$(uname -s)" in
+    Darwin)
+      echo "  brew install ${missing[*]}"
+      brew install "${missing[@]}"
+      ;;
+    Linux)
+      echo "  sudo apt-get install ${missing[*]}"
+      sudo apt-get update -qq && sudo apt-get install -y "${missing[@]}"
+      ;;
+    *)
+      echo "Unsupported OS. Install manually: ${missing[*]}" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if ! command -v markdownlint &>/dev/null; then
+  echo "  npm install -g markdownlint-cli"
+  npm install -g markdownlint-cli
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="${ROOT_DIR}/.venv"
+if [[ ! -d "${VENV_DIR}" ]] || ! "${VENV_DIR}/bin/python3" -c "import pytest" &>/dev/null; then
+  echo "  Setting up Python venv with pytest..."
+  python3 -m venv "${VENV_DIR}"
+  "${VENV_DIR}/bin/pip" install --quiet pytest
+fi
+
+echo "Done."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -58,13 +58,17 @@ write_debug_wrapper() {
   mkdir -p "${debug_dir}"
   chmod 0700 "${debug_dir}" 2>/dev/null || true
   rm -f "${install_path}"
+  local quoted_root_dir
+  quoted_root_dir="$(printf '%q' "${root_dir}")"
+  local quoted_debug_dir
+  quoted_debug_dir="$(printf '%q' "${debug_dir}")"
   cat >"${install_path}" <<EOF
 #!/usr/bin/env -S BASH_ENV= ENV= bash
 set -euo pipefail
 # Workcell debug installer wrapper
 
-ROOT_DIR=${root_dir@Q}
-DEBUG_DIR=${debug_dir@Q}
+ROOT_DIR=${quoted_root_dir}
+DEBUG_DIR=${quoted_debug_dir}
 DEFAULT_DEBUG_LOG="\${DEBUG_DIR}/latest-debug.log"
 HAS_DEBUG_LOG=0
 HAS_REBUILD=0
@@ -96,7 +100,7 @@ if [[ "\${SKIP_AUTO_DEBUG}" -eq 0 ]] && [[ "\${HAS_REBUILD}" -eq 0 ]]; then
   EXTRA_ARGS+=(--rebuild)
 fi
 
-exec "\${ROOT_DIR}/scripts/workcell" "\${EXTRA_ARGS[@]}" "\$@"
+exec "\${ROOT_DIR}/scripts/workcell" \${EXTRA_ARGS[@]:+"\${EXTRA_ARGS[@]}"} "\$@"
 EOF
   chmod 0755 "${install_path}"
 }
@@ -140,5 +144,14 @@ if [[ "${DEBUG_INSTALL}" -eq 1 ]]; then
   echo "Launch-time rebuilds: enabled"
 fi
 if [[ ":${PATH}:" != *":${INSTALL_DIR}:"* ]]; then
-  echo "Add ${INSTALL_DIR} to PATH to run it without a full path."
+  case "${SHELL:-/bin/zsh}" in
+    */bash) rc_file=".bashrc" ;;
+    *) rc_file=".zshrc" ;;
+  esac
+  echo ""
+  echo "Add this line to ~/${rc_file}:"
+  # shellcheck disable=SC2016
+  echo '  export PATH="$HOME/.local/bin:$PATH"'
+  echo ""
+  echo "Or run it now for this session only."
 fi

--- a/scripts/lint-dockerfiles.sh
+++ b/scripts/lint-dockerfiles.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REQUIRE_DOCKERFILE_LINT="${WORKCELL_REQUIRE_DOCKERFILE_LINT:-0}"
 
-mapfile -d '' -t dockerfiles < <(
+dockerfiles=()
+while IFS= read -r -d '' file; do
+  dockerfiles+=("${file}")
+done < <(
   find "${ROOT_DIR}" \
     -path "${ROOT_DIR}/.git" -prune -o \
     -path "${ROOT_DIR}/dist" -prune -o \

--- a/scripts/pre-merge.sh
+++ b/scripts/pre-merge.sh
@@ -308,13 +308,6 @@ docker run --rm \
   "${VALIDATOR_IMAGE}" \
   ./scripts/validate-repo.sh
 
-echo "[pre-merge] scenario tests (container exec guard required)"
-docker run --rm \
-  -v "${ROOT_DIR}:/workspace" \
-  -w /workspace \
-  "${VALIDATOR_IMAGE}" \
-  ./scripts/run-scenario-tests.sh --secretless-only
-
 echo "[pre-merge] host launcher invariants"
 "${ROOT_DIR}/scripts/verify-invariants.sh"
 

--- a/scripts/pre-merge.sh
+++ b/scripts/pre-merge.sh
@@ -308,6 +308,13 @@ docker run --rm \
   "${VALIDATOR_IMAGE}" \
   ./scripts/validate-repo.sh
 
+echo "[pre-merge] scenario tests (container exec guard required)"
+docker run --rm \
+  -v "${ROOT_DIR}:/workspace" \
+  -w /workspace \
+  "${VALIDATOR_IMAGE}" \
+  ./scripts/run-scenario-tests.sh --secretless-only
+
 echo "[pre-merge] host launcher invariants"
 "${ROOT_DIR}/scripts/verify-invariants.sh"
 

--- a/scripts/provider-e2e.sh
+++ b/scripts/provider-e2e.sh
@@ -267,7 +267,7 @@ while [[ $# -gt 0 ]]; do
       REQUIRE_INJECTION=1
       shift
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
@@ -357,7 +357,10 @@ if [[ "${DRY_RUN}" -eq 1 ]]; then
   printf 'provider_e2e_workspace=%s\n' "${WORKSPACE}"
   printf 'provider_e2e_injection_source=%s\n' "${INJECTION_SOURCE}"
   if ((${#GENERATED_CREDENTIAL_KEYS[@]} > 0)); then
-    printf 'provider_e2e_credential_keys=%s\n' "$(IFS=,; printf '%s' "${GENERATED_CREDENTIAL_KEYS[*]}")"
+    printf 'provider_e2e_credential_keys=%s\n' "$(
+      IFS=,
+      printf '%s' "${GENERATED_CREDENTIAL_KEYS[*]}"
+    )"
   else
     printf 'provider_e2e_credential_keys=\n'
   fi

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -137,7 +137,8 @@ upload_url="${release_metadata[1]}"
 
 for ((i = 2; i < ${#release_metadata[@]}; i += 2)); do
   asset_name="${release_metadata[i]}"
-  asset_id="${release_metadata[i+1]}"
+  j=$((i + 1))
+  asset_id="${release_metadata[j]}"
 
   if [[ -n "${asset_id}" ]]; then
     delete_status="$(api DELETE "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" "" "${TMP_ROOT}/delete-${asset_id}.json")"

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -128,13 +128,16 @@ esac
 
 "${HOSTUTIL_BIN}" release metadata "${release_json}" "${TMP_ROOT}/release-metadata.txt" "$@"
 
-mapfile -d '' -t release_metadata <"${TMP_ROOT}/release-metadata.txt"
+release_metadata=()
+while IFS= read -r -d '' item; do
+  release_metadata+=("${item}")
+done <"${TMP_ROOT}/release-metadata.txt"
 release_id="${release_metadata[0]}"
 upload_url="${release_metadata[1]}"
 
 for ((i = 2; i < ${#release_metadata[@]}; i += 2)); do
   asset_name="${release_metadata[i]}"
-  asset_id="${release_metadata[i + 1]}"
+  asset_id="${release_metadata[i+1]}"
 
   if [[ -n "${asset_id}" ]]; then
     delete_status="$(api DELETE "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" "" "${TMP_ROOT}/delete-${asset_id}.json")"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -85,11 +85,13 @@ append_unique_value() {
   local existing=""
 
   [[ -n "${value}" ]] || return 0
-  for existing in "${PROFILE_NAMES[@]}"; do
-    if [[ "${existing}" == "${value}" ]]; then
-      return 0
-    fi
-  done
+  if [[ ${#PROFILE_NAMES[@]} -gt 0 ]]; then
+    for existing in "${PROFILE_NAMES[@]}"; do
+      if [[ "${existing}" == "${value}" ]]; then
+        return 0
+      fi
+    done
+  fi
   PROFILE_NAMES+=("${value}")
 }
 
@@ -98,11 +100,13 @@ append_unique_temp_root() {
   local existing=""
 
   [[ -n "${value}" ]] || return 0
-  for existing in "${TEMP_ROOTS[@]}"; do
-    if [[ "${existing}" == "${value}" ]]; then
-      return 0
-    fi
-  done
+  if [[ ${#TEMP_ROOTS[@]} -gt 0 ]]; then
+    for existing in "${TEMP_ROOTS[@]}"; do
+      if [[ "${existing}" == "${value}" ]]; then
+        return 0
+      fi
+    done
+  fi
   TEMP_ROOTS+=("${value}")
 }
 
@@ -347,9 +351,11 @@ COLIMA_BIN="$(resolve_host_tool_optional colima /opt/homebrew/bin/colima /usr/lo
 
 collect_profiles
 
-for profile in "${PROFILE_NAMES[@]}"; do
-  delete_managed_profile "${profile}" "${COLIMA_BIN}"
-done
+if [[ ${#PROFILE_NAMES[@]} -gt 0 ]]; then
+  for profile in "${PROFILE_NAMES[@]}"; do
+    delete_managed_profile "${profile}" "${COLIMA_BIN}"
+  done
+fi
 
 remove_workcell_launcher_install "${INSTALL_PATH}"
 remove_workcell_symlink "${MAN_PATH}" "man/workcell.1" "man page"
@@ -360,9 +366,11 @@ remove_path "${SHADOW_ROOT}"
 
 append_unique_temp_root "/tmp"
 append_unique_temp_root "${TMPDIR:-}"
-for temp_root in "${TEMP_ROOTS[@]}"; do
-  cleanup_temp_root "${temp_root}"
-done
+if [[ ${#TEMP_ROOTS[@]} -gt 0 ]]; then
+  for temp_root in "${TEMP_ROOTS[@]}"; do
+    cleanup_temp_root "${temp_root}"
+  done
+fi
 
 if [[ "${REMOVED_COUNT}" -eq 0 ]]; then
   echo "No Workcell-owned install links or managed host state found."

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -50,9 +50,13 @@ run_metadatautil() {
 
 trap cleanup EXIT
 
-mapfile -t python_files < <(
+python_files=()
+while IFS= read -r file; do
+  python_files+=("${file}")
+done < <(
   find "${ROOT_DIR}" \
     -path "${ROOT_DIR}/.git" -prune -o \
+    -path "${ROOT_DIR}/.venv" -prune -o \
     -path "${ROOT_DIR}/dist" -prune -o \
     -path "${ROOT_DIR}/tmp" -prune -o \
     -path "${ROOT_DIR}/runtime/container/providers/node_modules" -prune -o \
@@ -177,7 +181,10 @@ if [[ "${#python_files[@]}" -gt 0 ]]; then
   printf '  %s\n' "${python_files[@]}" >&2
   exit 1
 fi
-mapfile -d '' -t go_files < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
+go_files=()
+while IFS= read -r -d '' file; do
+  go_files+=("${file}")
+done < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
 if [[ "${#go_files[@]}" -gt 0 ]]; then
   if gofmt -l "${go_files[@]}" | grep -q .; then
     echo "Go files are not formatted with gofmt." >&2
@@ -187,7 +194,10 @@ fi
 go vet ./...
 go test ./...
 
-mapfile -t json_files < <(
+json_files=()
+while IFS= read -r file; do
+  json_files+=("${file}")
+done < <(
   find "${ROOT_DIR}/adapters" "${ROOT_DIR}/.github" "${ROOT_DIR}/runtime/container/providers" "${ROOT_DIR}/tests/scenarios" \
     -path '*/node_modules' -prune -o \
     -type f -name '*.json' -print | sort
@@ -196,7 +206,10 @@ if [[ "${#json_files[@]}" -gt 0 ]]; then
   run_metadatautil validate-json "${json_files[@]}"
 fi
 
-mapfile -t toml_files < <(
+toml_files=()
+while IFS= read -r file; do
+  toml_files+=("${file}")
+done < <(
   find "${ROOT_DIR}" \
     -path "${ROOT_DIR}/.git" -prune -o \
     -path "${ROOT_DIR}/dist" -prune -o \
@@ -221,6 +234,7 @@ while IFS= read -r -d '' file; do
   doc_files+=("${file}")
 done < <(find "${ROOT_DIR}" \
   -path "${ROOT_DIR}/.git" -prune -o \
+  -path "${ROOT_DIR}/.venv" -prune -o \
   -path "${ROOT_DIR}/dist" -prune -o \
   -path "${ROOT_DIR}/tmp" -prune -o \
   -path "${ROOT_DIR}/runtime/container/providers/node_modules" -prune -o \

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -98,6 +98,8 @@ validate_manpage() {
 }
 
 shell_files=(
+  "${ROOT_DIR}/install.sh"
+  "${ROOT_DIR}/scripts/build-and-test.sh"
   "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
   "${ROOT_DIR}/scripts/workcell"
   "${ROOT_DIR}/scripts/check-workflows.sh"
@@ -105,6 +107,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/container-smoke.sh"
   "${ROOT_DIR}/scripts/dev-quick-check.sh"
   "${ROOT_DIR}/scripts/go-port-validate.sh"
+  "${ROOT_DIR}/scripts/install-dev-tools.sh"
   "${ROOT_DIR}/scripts/lint-dockerfiles.sh"
   "${ROOT_DIR}/scripts/dev-remote-validate.sh"
   "${ROOT_DIR}/scripts/lib/extract_direct_mounts"

--- a/scripts/verify-coverage.sh
+++ b/scripts/verify-coverage.sh
@@ -75,7 +75,10 @@ run_rust_launcher_coverage() {
 
   (cd "${ROOT_DIR}" && go run ./cmd/workcell-metadatautil coverage-executables "${message_file}") >"${TMP_ROOT}/rust-binaries.txt"
 
-  mapfile -t rust_binaries <"${TMP_ROOT}/rust-binaries.txt"
+  rust_binaries=()
+  while IFS= read -r line; do
+    rust_binaries+=("${line}")
+  done <"${TMP_ROOT}/rust-binaries.txt"
   if [[ "${#rust_binaries[@]}" -eq 0 ]]; then
     echo "Unable to locate instrumented Rust test executables for coverage." >&2
     exit 1

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1362,7 +1362,10 @@ if [[ -e "${INJECTION_POLICY_FIXTURE_ROOT}/bundle/credentials/codex-auth.json" ]
   exit 1
 fi
 
-mapfile -t actual_mount_paths < <(jq -r '.[].mount_path' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle.mounts.json" | sort -u)
+actual_mount_paths=()
+while IFS= read -r line; do
+  actual_mount_paths+=("${line}")
+done < <(jq -r '.[].mount_path' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle.mounts.json" | sort -u)
 expected_mount_paths=(
   "/opt/workcell/host-inputs/credentials/codex-auth.json"
   "/opt/workcell/host-inputs/credentials/github-hosts.yml"
@@ -1415,7 +1418,10 @@ EOF
 [[ "$(jq -r '.documents.common' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes/manifest.json")" == "documents/common.md" ]]
 [[ "$(jq -r '.credentials.codex_auth.mount_path' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes/manifest.json")" == "/opt/workcell/host-inputs/credentials/codex-auth.json" ]]
 [[ "$(jq -r '.metadata.policy_sha256' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes/manifest.json")" == sha256:* ]]
-mapfile -t included_policy_source_names < <(jq -r '.metadata.policy_sources[].path | split("/")[-1]' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes/manifest.json")
+included_policy_source_names=()
+while IFS= read -r line; do
+  included_policy_source_names+=("${line}")
+done < <(jq -r '.metadata.policy_sources[].path | split("/")[-1]' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes/manifest.json")
 if [[ "${included_policy_source_names[*]}" != "fragment-docs.toml fragment-credentials.toml policy-with-includes.toml" ]]; then
   echo "unexpected included policy source order: ${included_policy_source_names[*]}" >&2
   exit 1

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -77,6 +77,7 @@ require_tool jq
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
 HOST_GATE_SCRIPTS=(
+  "${ROOT_DIR}/scripts/build-and-test.sh"
   "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
   "${ROOT_DIR}/scripts/container-smoke.sh"
   "${ROOT_DIR}/scripts/generate-build-input-manifest.sh"
@@ -2778,7 +2779,7 @@ if PATH="${DOCKER_CONTEXT_SELECTOR_FAKEBIN}:${PATH}" \
   HOME=/tmp \
   ROOT_DIR="${ROOT_DIR}" \
   BARRIER_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}" \
-  /bin/bash -lc '
+  /bin/bash -c '
     set -euo pipefail
     source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
     export DOCKER_CONTEXT_NAME=colima
@@ -2797,7 +2798,7 @@ selected_context="$(
   HOME=/tmp \
   ROOT_DIR="${ROOT_DIR}" \
   BARRIER_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}" \
-  /bin/bash -lc '
+  /bin/bash -c '
     set -euo pipefail
     source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
     unset DOCKER_CONTEXT_NAME
@@ -2819,7 +2820,7 @@ fallback_context="$(
     HOME=/tmp \
     ROOT_DIR="${ROOT_DIR}" \
     BARRIER_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}" \
-    /bin/bash -lc '
+    /bin/bash -c '
       set -euo pipefail
       source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
       unset DOCKER_CONTEXT_NAME
@@ -2883,7 +2884,7 @@ printf '%s\n' "$PWD"
 EOS
 chmod 0755 "${FAKE_DOCKER_BIN}/docker"
 
-ROOT_DIR="${ROOT_DIR}" PATH="${FAKE_DOCKER_BIN}:${PATH}" HOME=/tmp /bin/bash -lc '
+ROOT_DIR="${ROOT_DIR}" PATH="${FAKE_DOCKER_BIN}:${PATH}" HOME=/tmp /bin/bash -c '
   set -euo pipefail
   source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
   export HOME="${BARRIER_VERIFY_ROOT}/docker-client-home"

--- a/scripts/with-validation-snapshot.sh
+++ b/scripts/with-validation-snapshot.sh
@@ -277,8 +277,8 @@ SNAPSHOT_PARENT="${WORKCELL_VALIDATION_SNAPSHOT_PARENT:-$(dirname "${REPO_ROOT}"
 SNAPSHOT_PARENT="$(cd "${SNAPSHOT_PARENT}" && pwd)" || die "Snapshot parent does not exist: ${SNAPSHOT_PARENT}"
 SNAPSHOT_DIR="$(mktemp -d "${SNAPSHOT_PARENT}/workcell-validation-snapshot.XXXXXX")"
 # Clone without checkout so repository-controlled smudge/clean filters in
-# .gitattributes cannot execute during snapshot creation.  All modes
-# materialize tracked content via cat-file blob in overlay_index_state.
+# .gitattributes cannot execute during snapshot creation.  Each mode
+# materializes tracked content via cat-file blob in its overlay function.
 git clone -q --no-hardlinks --no-checkout "${REPO_ROOT}" "${SNAPSHOT_DIR}"
 
 case "${SNAPSHOT_MODE}" in

--- a/scripts/with-validation-snapshot.sh
+++ b/scripts/with-validation-snapshot.sh
@@ -54,13 +54,133 @@ remove_path_from_snapshot() {
   rm -rf "${target_path}"
 }
 
+overlay_head_state() {
+  local entry=""
+  local metadata=""
+  local mode=""
+  local obj_type=""
+  local oid=""
+  local tracked_path=""
+  local dest=""
+  local install_mode=""
+
+  # Materialize HEAD's committed tree via cat-file to bypass smudge/clean
+  # filters.  Uses git ls-tree which outputs: <mode> <type> <oid>\t<path>\0
+  while IFS= read -r -d '' entry; do
+    metadata="${entry%%$'\t'*}"
+    tracked_path="${entry#*$'\t'}"
+    mode="${metadata%% *}"
+    local remainder="${metadata#* }"
+    obj_type="${remainder%% *}"
+    oid="${remainder##* }"
+
+    [[ "${obj_type}" == "blob" ]] || continue
+
+    case "${mode}" in
+      100644) install_mode="0644" ;;
+      100755) install_mode="0755" ;;
+      120000)
+        echo "with-validation-snapshot: skipping symlink in HEAD tree: ${tracked_path}" >&2
+        continue
+        ;;
+      *)
+        echo "with-validation-snapshot: skipping unsupported mode ${mode} in HEAD tree: ${tracked_path}" >&2
+        continue
+        ;;
+    esac
+
+    case "${tracked_path}" in
+      '' | . | .. | ./* | /* | */../* | ../* | */..)
+        echo "with-validation-snapshot: unsafe path in HEAD tree rejected: ${tracked_path}" >&2
+        continue
+        ;;
+    esac
+
+    if [[ ${#oid} -lt 40 ]] || [[ ! "${oid}" =~ ^[0-9a-f]+$ ]]; then
+      echo "with-validation-snapshot: malformed OID in HEAD tree: ${oid}" >&2
+      continue
+    fi
+
+    dest="${SNAPSHOT_DIR}/${tracked_path}"
+    if [[ -d "${dest}" ]]; then
+      rm -rf "${dest}"
+    fi
+    mkdir -p "$(dirname "${dest}")"
+    if ! git -C "${REPO_ROOT}" cat-file blob "${oid}" >"${dest}"; then
+      echo "with-validation-snapshot: failed to read blob ${oid} for path: ${tracked_path}" >&2
+      rm -f "${dest}"
+      continue
+    fi
+    chmod "${install_mode}" "${dest}" 2>/dev/null || true
+  done < <(git -C "${REPO_ROOT}" ls-tree -r -z HEAD)
+}
+
 overlay_index_state() {
   local tracked_path=""
+  local entry=""
+  local metadata=""
+  local mode=""
+  local oid=""
+  local remainder=""
+  local stage=""
+  local dest=""
+  local install_mode=""
 
   while IFS= read -r -d '' tracked_path; do
     remove_path_from_snapshot "${tracked_path}"
   done < <(git -C "${SNAPSHOT_DIR}" ls-files -z)
-  git -C "${REPO_ROOT}" checkout-index -a -f --prefix="${SNAPSHOT_DIR}/"
+
+  # Materialize each tracked blob via cat-file to bypass smudge/clean filters
+  # that a malicious .gitattributes could use for code execution.  Only regular
+  # file modes (100644, 100755) are materialized; symlinks and submodules are
+  # intentionally skipped since the validation snapshot does not need them.
+  while IFS= read -r -d '' entry; do
+    metadata="${entry%%$'\t'*}"
+    tracked_path="${entry#*$'\t'}"
+    mode="${metadata%% *}"
+    remainder="${metadata#* }"
+    oid="${remainder%% *}"
+    stage="${remainder##* }"
+    [[ "${stage}" == "0" ]] || continue
+
+    case "${mode}" in
+      100644) install_mode="0644" ;;
+      100755) install_mode="0755" ;;
+      120000)
+        echo "with-validation-snapshot: skipping symlink in git index: ${tracked_path}" >&2
+        continue
+        ;;
+      *)
+        echo "with-validation-snapshot: skipping unsupported mode ${mode} in git index: ${tracked_path}" >&2
+        continue
+        ;;
+    esac
+
+    # Reject paths that could escape SNAPSHOT_DIR
+    case "${tracked_path}" in
+      '' | . | .. | ./* | /* | */../* | ../* | */..)
+        echo "with-validation-snapshot: unsafe path in git index rejected: ${tracked_path}" >&2
+        continue
+        ;;
+    esac
+
+    if [[ ${#oid} -lt 40 ]] || [[ ! "${oid}" =~ ^[0-9a-f]+$ ]]; then
+      echo "with-validation-snapshot: malformed OID in git index: ${oid}" >&2
+      continue
+    fi
+
+    dest="${SNAPSHOT_DIR}/${tracked_path}"
+    if [[ -d "${dest}" ]]; then
+      rm -rf "${dest}"
+    fi
+    mkdir -p "$(dirname "${dest}")"
+    if ! git -C "${REPO_ROOT}" cat-file blob "${oid}" >"${dest}"; then
+      echo "with-validation-snapshot: failed to read blob ${oid} for path: ${tracked_path}" >&2
+      rm -f "${dest}"
+      continue
+    fi
+    chmod "${install_mode}" "${dest}" 2>/dev/null || true
+  done < <(git -C "${REPO_ROOT}" ls-files -z --stage)
 }
 
 overlay_worktree_state() {
@@ -156,11 +276,15 @@ REPO_ROOT="$(git -C "${REPO_ROOT}" rev-parse --show-toplevel)"
 SNAPSHOT_PARENT="${WORKCELL_VALIDATION_SNAPSHOT_PARENT:-$(dirname "${REPO_ROOT}")}"
 SNAPSHOT_PARENT="$(cd "${SNAPSHOT_PARENT}" && pwd)" || die "Snapshot parent does not exist: ${SNAPSHOT_PARENT}"
 SNAPSHOT_DIR="$(mktemp -d "${SNAPSHOT_PARENT}/workcell-validation-snapshot.XXXXXX")"
-rm -rf "${SNAPSHOT_DIR}"
-git clone -q --no-hardlinks "${REPO_ROOT}" "${SNAPSHOT_DIR}"
-git -C "${SNAPSHOT_DIR}" checkout -q --detach HEAD
+# Clone without checkout so repository-controlled smudge/clean filters in
+# .gitattributes cannot execute during snapshot creation.  All modes
+# materialize tracked content via cat-file blob in overlay_index_state.
+git clone -q --no-hardlinks --no-checkout "${REPO_ROOT}" "${SNAPSHOT_DIR}"
 
 case "${SNAPSHOT_MODE}" in
+  head)
+    overlay_head_state
+    ;;
   index)
     overlay_index_state
     ;;

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -3990,13 +3990,25 @@ git_index_materialize_regular_file() {
   local install_mode=""
 
   workspace_is_git_worktree "${workspace}" || return 1
-  IFS= read -r -d '' entry < <(run_clean_host_command git -C "${workspace}" ls-files -z --stage -- "${relative_path}") || true
-  [[ -n "${entry}" ]] || return 1
+  local stage=""
+  local found=0
+  while IFS= read -r -d '' entry; do
+    metadata="${entry%%$'\t'*}"
+    mode="${metadata%% *}"
+    remainder="${metadata#* }"
+    oid="${remainder%% *}"
+    stage="${remainder##* }"
+    if [[ "${stage}" == "0" ]]; then
+      found=1
+      break
+    fi
+  done < <(run_clean_host_command git -C "${workspace}" ls-files -z --stage -- "${relative_path}")
+  [[ "${found}" -eq 1 ]] || return 1
 
-  metadata="${entry%%$'\t'*}"
-  mode="${metadata%% *}"
-  remainder="${metadata#* }"
-  oid="${remainder%% *}"
+  if [[ ${#oid} -lt 40 ]] || [[ ! "${oid}" =~ ^[0-9a-f]+$ ]]; then
+    echo "Workcell blocked shadow materialization: malformed OID in git index: ${oid}" >&2
+    return 1
+  fi
 
   case "${mode}" in
     100644)
@@ -4005,7 +4017,12 @@ git_index_materialize_regular_file() {
     100755)
       install_mode="0755"
       ;;
+    120000)
+      echo "Workcell shadow materialization: skipping symlink: ${relative_path}" >&2
+      return 1
+      ;;
     *)
+      echo "Workcell shadow materialization: skipping unsupported mode ${mode}: ${relative_path}" >&2
       return 1
       ;;
   esac
@@ -4013,7 +4030,11 @@ git_index_materialize_regular_file() {
   mkdir -p "$(dirname "${destination_path}")"
   # Materialize tracked blobs directly so repo-local checkout filters and other
   # worktree-side behaviors cannot influence host-side control-plane shadowing.
-  run_clean_host_command git -C "${workspace}" cat-file blob "${oid}" >"${destination_path}"
+  if ! run_clean_host_command git -C "${workspace}" cat-file blob "${oid}" >"${destination_path}"; then
+    echo "Workcell shadow materialization: failed to read blob ${oid} for path: ${relative_path}" >&2
+    rm -f "${destination_path}"
+    return 1
+  fi
   chmod "${install_mode}" "${destination_path}" 2>/dev/null || true
 }
 
@@ -4036,7 +4057,7 @@ git_index_populate_shadow_dir() {
   exec 3<"${tracked_paths_file}"
   while IFS= read -r -d '' tracked_path <&3; do
     case "${tracked_path}" in
-      '' | /* | */../* | ../* | */..)
+      '' | . | .. | ./* | /* | */../* | ../* | */..)
         echo "Workcell blocked control-plane shadow materialization: unsafe path in git index rejected: ${tracked_path}" >&2
         exec 3<&-
         rm -f "${tracked_paths_file}"

--- a/tests/scenarios/shared/test-assurance-dry-run.sh
+++ b/tests/scenarios/shared/test-assurance-dry-run.sh
@@ -72,6 +72,8 @@ for agent in codex claude gemini; do
   grep -q '^workspace_control_plane=unmasked$' "${TMP_DIR}/breakglass-${agent}.stderr"
   grep -q '^network_policy=unrestricted ' "${TMP_DIR}/breakglass-${agent}.stderr"
   grep -q '^execution_path=lower-assurance-breakglass audit_log=' "${TMP_DIR}/breakglass-${agent}.stderr"
+  grep -q '^autonomy_assurance=managed-yolo$' "${TMP_DIR}/breakglass-${agent}.stderr"
+  grep -q '^session_assurance_initial=managed-mutable$' "${TMP_DIR}/breakglass-${agent}.stderr"
 done
 
 for agent in codex claude gemini; do


### PR DESCRIPTION
## Summary

Replaces #52, which could not cleanly rebase after PRs #58 and #59 retired Python helpers and rewrote validation tooling. Only the still-relevant changes survive.

**Security hardening**: Validation snapshots and host-side shadow materialization used `git checkout-index`, which executes smudge/clean filters controlled by `.gitattributes` inside the repo. A malicious `.gitattributes` could run arbitrary code during snapshot creation or control-plane shadowing. Both `with-validation-snapshot.sh` and `scripts/workcell` now materialize blobs via `git cat-file blob` with OID validation, symlink skipping, and path traversal guards.

**Bash 3 compatibility**: macOS ships bash 3.2, which lacks `mapfile` and `${var,,}`. All `mapfile` calls replaced with portable `while read` loops across 7 scripts. `guard-bash.sh` lowercasing replaced with `tr`, fixing a silent failure where blocked commands exited 1 (script error) instead of 2 (blocked).

**Host validation harness**: `build-and-test.sh` runs the full check suite locally without Docker. `install-dev-tools.sh` bootstraps host tools. Root `install.sh` provides a sanitized entry point.

**Shell correctness**: Empty-array iteration guards in `uninstall.sh`, portable quoting in `install.sh` debug wrapper, `bash -lc` to `bash -c` in `verify-invariants.sh` test subshells.

**Sanitized git and .gitignore**: `.claude/settings.local.json` was only excluded by the user's global gitignore. The build-input manifest verifier runs with `HOME=/tmp`, so it never saw that rule. Added to repo `.gitignore`. `.venv` added to find prune lists and `.codespellrc` skip list.

## Testing

- `scripts/build-and-test.sh` passes end-to-end on host (build-input manifest, shellcheck, shfmt, go vet, go test, yamllint, codespell, cargo fmt/clippy/test, mutation tests, scenario tests, coverage)
- CI "Validate repository" job passes
- Hook parametric test: 10 commands blocked, 5 legitimate commands permitted
- Both shfmt 3.8.0 (CI) and 3.13.0 (local) produce identical formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)