### PR TITLE
Integrate Go helper port and validation hardening

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: commit
+description: Risk-Aware Commit Notation. Use when creating git commits to determine the correct prefix, risk level, and commit grouping.
+---
+
+# Risk-Aware Commit Notation
+
+All commits in this repo must use Risk-Aware Commit Notation (based on [Arlo's Commit Notation](https://github.com/RefactoringCombos/ArlosCommitNotation)), a risk-based notation where the first characters of every commit message encode risk level and intention.
+
+## Format
+
+`<risk><intention> <description>`
+
+## Risk Levels
+
+| Symbol | Level | Guarantees |
+|--------|-------|------------|
+| `.` | Safe | Intended change + known & unknown invariants |
+| `^` | Validated | Intended change + known invariants |
+| `!` | Risky | Intended change only |
+| `@` | Broken | None |
+
+## Intentions
+
+| Letter | Type | Meaning |
+|--------|------|---------|
+| **F/f** | Feature | Modify one behavioral aspect without affecting others |
+| **B/b** | Bugfix | Repair undesirable behavior, preserve everything else |
+| **R/r** | Refactoring | Restructure code without changing runtime behavior |
+| **D/d** | Documentation | Update info that doesn't impact code execution |
+
+## Rules
+
+- Uppercase = primary/user-visible changes. Lowercase = supporting changes.
+- Features/bugfixes exceeding 8 lines of code (including tests) default to highest risk level.
+- Safe refactoring (`.r`) requires provable refactoring via automated tools or test-supported procedural refactoring.
+- Choose the risk level honestly. If you haven't verified invariants, use `!` or `@`.
+
+## Commit Grouping
+
+- **One intention per commit.** Do not mix refactoring, features, bugfixes, or documentation in a single commit. If a task requires both refactoring and a feature change, split them into separate commits (refactoring first, then the feature).
+- **Minimize risk per commit.** Break work into the smallest commits that each achieve the lowest possible risk level. For example, extract a safe refactoring (`.r`) as its own commit before making a risky feature change (`!F`), rather than bundling both into one `!F` commit.
+- **Prefer many small safe commits over fewer risky ones.** A sequence like `.r` then `.r` then `^F` is better than a single `!F` that includes the refactoring.
+
+## Notation Justification in Commit Messages
+
+After drafting each commit, add a terse parenthetical after the description explaining both the risk level and the uppercase/lowercase choice. Keep it to one clause each, separated by a semicolon.
+
+Format: `(risk reason; case reason)`
+
+Examples:
+
+- `^F Add --branch-exclude flag (tests pass; user-visible CLI flag)`
+- `^f Add FilterByBranchExclusion utility (existing tests green; supporting function, not user-facing)`
+- `^B Fix cache key collision (regression test added; user-visible bug)`
+- `^b Update call sites for new signature (compiles and tests green; supporting change for ^F above)`
+- `!F Add experimental diff parser (no tests yet; user-visible feature)`
+- `.r Extract helper, no behavior change (automated rename; internal restructure)`
+
+## Examples
+
+- `.r Style: reformat line wrapping in scm_policy_checker.py`
+- `!F Add new endpoint for policy evaluation`
+- `^B Fix cache invalidation on prompt change (regression test added)`
+- `.d Update README with setup instructions`

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = .git,dist,tmp,runtime/container/providers/node_modules,runtime/container/rust/vendor,runtime/container/rust/target
+skip = .git,.venv,dist,tmp,runtime/container/providers/node_modules,runtime/container/rust/vendor,runtime/container/rust/target
 quiet-level = 2
 ignore-regex = ^\s*\.IP\s+\\\(bu\s+2$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.lock -merge

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .env.*
 .mcp.local.json
 *.local
+.claude/settings.local.json
 *.override
 *.pem
 *.key

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,10 @@ adapters/codex/.codex/memories/
 adapters/codex/.codex/tmp/
 dist/
 tmp/
+.venv/
 runtime/container/providers/node_modules/
 runtime/container/providers/mirror/
 runtime/container/rust/target/
 __pycache__/
+.pytest_cache/
 *.pyc

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD060": false
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ ergonomics second.
 Local development expects:
 
 - `git`
+- `go`
 - `docker`
-- `python3`
 - `shellcheck`
 - `shfmt`
 - `cargo`, `rustfmt`, and `clippy`
@@ -53,8 +53,17 @@ On macOS, also install Colima for the real VM boundary path.
 `./scripts/dev-quick-check.sh` is the normal edit loop. It covers:
 
 - shell lint and format checks
-- Python compile and unit tests
 - Rust fmt, clippy, and tests
+
+For fuller repo validation without the entire pre-merge stack, use:
+
+```bash
+./scripts/build-and-test.sh
+./scripts/build-and-test.sh --docker
+```
+
+The default path is host-native. `--docker` reruns repo validation inside the
+validator container from a disposable snapshot of the current worktree.
 
 ### Full local gate
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Other defaults that matter:
 Install the launcher symlink and verify the host prerequisites:
 
 ```bash
-./scripts/install.sh
+./install.sh
 workcell --prepare --agent codex --workspace /path/to/repo
 ```
 
@@ -116,6 +116,33 @@ What to expect from the safe path:
   outside the Tier 1 container
 - `--debug-log`, `--file-trace-log`, and `--audit-transcript` are explicit
   lower-assurance operator choices and are off by default
+
+## Contributing
+
+Validation tiers, from fastest to most thorough:
+
+```bash
+scripts/dev-quick-check.sh      # seconds, host tools only (shellcheck, cargo, pytest)
+scripts/build-and-test.sh       # minutes, all checks, host tools only
+scripts/pre-merge.sh            # full release gate with Docker, repro builds
+```
+
+`dev-quick-check.sh` is the normal edit loop. `build-and-test.sh` runs the
+full validation suite directly on the host using locally installed tools. CI
+is the authority on exact tool versions; local runs catch issues early without
+Docker overhead. `pre-merge.sh` adds container-smoke tests, reproducible-build
+verification, and release-specific checks (requires Docker).
+
+`build-and-test.sh` flags:
+
+```bash
+scripts/build-and-test.sh --install   # install missing host tools (brew, pip, npm)
+scripts/build-and-test.sh --list      # list files that would be checked
+scripts/build-and-test.sh --strict    # exit on first failure
+scripts/build-and-test.sh --auto-fix  # run markdownlint --fix before linting
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites and workflow details.
 
 ## Session inputs
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Workcell does not trade away the VM-plus-container boundary for convenience.
   supported.
 - **Homebrew**, **Colima**, and **Docker CLI** installed on the host:
   `brew install colima docker`
-- **git**, **python3**, and **GitHub CLI** (`gh`) available on `$PATH`
+- **git**, **go**, and **GitHub CLI** (`gh`) available on `$PATH`
 
 ## Design stance
 
@@ -82,7 +82,7 @@ Other defaults that matter:
 Install the launcher symlink and verify the host prerequisites:
 
 ```bash
-./install.sh
+./scripts/install.sh
 workcell --prepare --agent codex --workspace /path/to/repo
 ```
 
@@ -116,30 +116,6 @@ What to expect from the safe path:
   outside the Tier 1 container
 - `--debug-log`, `--file-trace-log`, and `--audit-transcript` are explicit
   lower-assurance operator choices and are off by default
-
-## Contributing
-
-Validation tiers, from fastest to most thorough:
-
-```bash
-scripts/dev-quick-check.sh      # seconds, host tools only (shellcheck, cargo, pytest)
-scripts/build-and-test.sh       # minutes, all checks, host tools only
-scripts/pre-merge.sh            # full release gate with Docker, repro builds
-```
-
-`dev-quick-check.sh` is the normal edit loop. `build-and-test.sh` runs the
-full validation suite directly on the host using locally installed tools. CI
-is the authority on exact tool versions; local runs catch issues early without
-Docker overhead. `pre-merge.sh` adds container-smoke tests, reproducible-build
-verification, and release-specific checks (requires Docker).
-
-To install missing host tools:
-
-```bash
-scripts/build-and-test.sh --install   # install missing host tools (brew, pip, npm)
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites and workflow details.
 
 ## Session inputs
 

--- a/README.md
+++ b/README.md
@@ -133,13 +133,10 @@ is the authority on exact tool versions; local runs catch issues early without
 Docker overhead. `pre-merge.sh` adds container-smoke tests, reproducible-build
 verification, and release-specific checks (requires Docker).
 
-`build-and-test.sh` flags:
+To install missing host tools:
 
 ```bash
 scripts/build-and-test.sh --install   # install missing host tools (brew, pip, npm)
-scripts/build-and-test.sh --list      # list files that would be checked
-scripts/build-and-test.sh --strict    # exit on first failure
-scripts/build-and-test.sh --auto-fix  # run markdownlint --fix before linting
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites and workflow details.

--- a/adapters/claude/hooks/guard-bash.sh
+++ b/adapters/claude/hooks/guard-bash.sh
@@ -275,7 +275,7 @@ command_has_source_command_word() {
 command="$(printf '%s' "${WORKCELL_HOOK_PAYLOAD}" | jq -er '.tool_input.command | select(type == "string")' 2>/dev/null || true)"
 [[ -n "${command}" ]] || exit 0
 
-command_lower="${command,,}"
+command_lower="$(printf '%s' "${command}" | tr '[:upper:]' '[:lower:]')"
 command_lower_dequoted="$(printf '%s' "${command_lower}" | tr -d "\"'")"
 command_lower_deescaped="$(printf '%s' "${command_lower_dequoted}" | tr -d "\\")"
 command_substitution_marker="\$("

--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -132,6 +132,10 @@ func runLauncher(args []string) error {
 		}
 		status, statusErr := hostutil.ColimaProfileStatus(input, args[1])
 		if statusErr != nil {
+			if hostutil.IsNoMatch(statusErr) {
+				fmt.Fprintln(os.Stderr, statusErr)
+				os.Exit(3)
+			}
 			return statusErr
 		}
 		fmt.Println(status)
@@ -174,6 +178,12 @@ func runLauncher(args []string) error {
 			return launcherUsage()
 		}
 		fmt.Println(hostutil.AuditRecordDigest(args[1], args[2], args[3:]))
+		return nil
+	case "direct-mount-cache-key":
+		if len(args) != 3 {
+			return launcherUsage()
+		}
+		fmt.Println(hostutil.DirectMountCacheKey(args[1], args[2]))
 		return nil
 	case "resolve-host-output-candidate":
 		if len(args) != 2 {
@@ -285,5 +295,5 @@ func releaseUsage() error {
 }
 
 func launcherUsage() error {
-	return fmt.Errorf("usage: workcell-hostutil launcher <session-suffix|colima-status|cleanup-stale-log-pointers|profile-lock-is-stale|write-profile-owner|cleanup-stale-session-audit-dirs|audit-digest|resolve-host-output-candidate|cleanup-stale-injection-bundles|manifest-metadata|resolver-metadata|workspace-cache-key|extract-codex-version|validate-security-options|canonicalize-tool-path|dedupe-endpoints|resolve-endpoints> ...")
+	return fmt.Errorf("usage: workcell-hostutil launcher <session-suffix|colima-status|cleanup-stale-log-pointers|profile-lock-is-stale|write-profile-owner|cleanup-stale-session-audit-dirs|audit-digest|direct-mount-cache-key|resolve-host-output-candidate|cleanup-stale-injection-bundles|manifest-metadata|resolver-metadata|workspace-cache-key|extract-codex-version|validate-security-options|canonicalize-tool-path|dedupe-endpoints|resolve-endpoints> ...")
 }

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -13,7 +13,7 @@ Use this page with:
 These run without provider credentials:
 
 - `./scripts/dev-quick-check.sh`
-- `./scripts/build-and-test.sh` (host-native, no Docker required)
+- `./scripts/build-and-test.sh` (host-native by default; `--docker` reruns repo validation inside the CI validator container)
 - `./scripts/container-smoke.sh`
 - `./scripts/verify-invariants.sh`
 - `./scripts/verify-release-bundle.sh`

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -13,7 +13,7 @@ Use this page with:
 These run without provider credentials:
 
 - `./scripts/dev-quick-check.sh`
-- `./scripts/validate-repo.sh`
+- `./scripts/build-and-test.sh` (runs in the same container as CI)
 - `./scripts/container-smoke.sh`
 - `./scripts/verify-invariants.sh`
 - `./scripts/verify-release-bundle.sh`

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -13,7 +13,7 @@ Use this page with:
 These run without provider credentials:
 
 - `./scripts/dev-quick-check.sh`
-- `./scripts/build-and-test.sh` (runs in the same container as CI)
+- `./scripts/build-and-test.sh` (host-native, no Docker required)
 - `./scripts/container-smoke.sh`
 - `./scripts/verify-invariants.sh`
 - `./scripts/verify-release-bundle.sh`

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ go 1.26.0
 toolchain go1.26.1
 
 require github.com/BurntSushi/toml v1.6.0
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -p
+# Install Workcell into ~/.local/bin.  Forwards to scripts/install.sh.
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
+  exec /usr/bin/env -i \
+    PATH="${TRUSTED_HOST_PATH}" \
+    HOME="${HOME:-/tmp}" \
+    SHELL="${SHELL:-/bin/zsh}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    WORKCELL_SANITIZED_ENTRYPOINT=1 \
+    /bin/bash -p "$0" "$@"
+fi
+set -euo pipefail
+export PATH="${TRUSTED_HOST_PATH}"
+
+if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
+  head -n 1 "$0" >/dev/null
+  echo "install-entrypoint-ok"
+  exit 0
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${ROOT_DIR}/scripts/install.sh" "$@"

--- a/internal/hostutil/hostutil_test.go
+++ b/internal/hostutil/hostutil_test.go
@@ -2,6 +2,8 @@ package hostutil
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -187,6 +189,29 @@ func TestWriteReleaseBundleManifest(t *testing.T) {
 	}, "\n")
 	if string(got) != want {
 		t.Fatalf("unexpected manifest:\n%s", got)
+	}
+}
+
+func TestDirectMountCacheKeyMatchesNULTerminatedHash(t *testing.T) {
+	got := DirectMountCacheKey("/host/auth.json", "/opt/workcell/host-inputs/credentials/codex-auth.json")
+
+	sum := sha256.Sum256([]byte("/host/auth.json\x00/opt/workcell/host-inputs/credentials/codex-auth.json\x00"))
+	want := hex.EncodeToString(sum[:8])
+	if got != want {
+		t.Fatalf("DirectMountCacheKey() = %q, want %q", got, want)
+	}
+}
+
+func TestColimaProfileStatusMissingProfileReturnsNoMatch(t *testing.T) {
+	input := []byte(strings.Join([]string{
+		`{"name":"default","status":"Running"}`,
+		`{"name":"workcell-test","status":"Stopped"}`,
+		"",
+	}, "\n"))
+
+	_, err := ColimaProfileStatus(input, "does-not-exist")
+	if !IsNoMatch(err) {
+		t.Fatalf("ColimaProfileStatus() err = %v, want IsNoMatch", err)
 	}
 }
 

--- a/internal/hostutil/launcher.go
+++ b/internal/hostutil/launcher.go
@@ -53,6 +53,10 @@ func ColimaProfileStatus(listJSON []byte, profile string) (string, error) {
 	return "", errNoMatch
 }
 
+func IsNoMatch(err error) bool {
+	return errors.Is(err, errNoMatch)
+}
+
 func CleanupStaleLatestLogPointers(colimaRoot string) error {
 	root := filepath.Clean(colimaRoot)
 	info, err := os.Stat(root)
@@ -229,6 +233,11 @@ func AuditRecordDigest(prevDigest, timestamp string, args []string) string {
 	values := append([]string{prevDigest, timestamp}, args...)
 	sum := sha256.Sum256([]byte(strings.Join(values, "\x00")))
 	return hex.EncodeToString(sum[:])
+}
+
+func DirectMountCacheKey(hostSource, mountPath string) string {
+	sum := sha256.Sum256([]byte(hostSource + "\x00" + mountPath + "\x00"))
+	return hex.EncodeToString(sum[:8])
 }
 
 func ResolveHostOutputCandidate(raw string) (string, error) {

--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -17,7 +17,6 @@ import (
 
 var (
 	hexDigestPattern      = regexp.MustCompile(`^[0-9a-f]{64}$`)
-	workflowNamePattern   = regexp.MustCompile(`^ {4}name:\s*(.+?)\s*$`)
 	workflowPermissionsRE = regexp.MustCompile(`(?m)^permissions:\s+\{\}$`)
 	actionRefPattern      = regexp.MustCompile(`(?:^|[^[:alnum:]/_.-])%s@([0-9a-f]{40})`)
 	aptInstallPattern     = regexp.MustCompile(`apt-get install -y --no-install-recommends(?s:(.*?))&&`)

--- a/internal/metadatautil/reproducible_build_test.go
+++ b/internal/metadatautil/reproducible_build_test.go
@@ -94,6 +94,22 @@ func TestVerifyReproducibleBuildReportsMismatch(t *testing.T) {
 	}
 }
 
+func TestGenerateAndVerifyReproducibleBuildManifest(t *testing.T) {
+	root := t.TempDir()
+	layoutA := filepath.Join(root, "layout-a")
+	layoutB := filepath.Join(root, "layout-b")
+	writeSyntheticOCIExport(t, layoutA)
+	writeSyntheticOCIExport(t, layoutB)
+
+	manifestPath := filepath.Join(root, "repro.json")
+	if err := GenerateReproducibleBuildManifest(layoutA, "linux/amd64,linux/arm64", manifestPath, 1700000000); err != nil {
+		t.Fatalf("GenerateReproducibleBuildManifest() error = %v", err)
+	}
+	if err := VerifyReproducibleBuildManifest(layoutB, "linux/amd64,linux/arm64", manifestPath); err != nil {
+		t.Fatalf("VerifyReproducibleBuildManifest() error = %v", err)
+	}
+}
+
 func writeSyntheticOCIExport(t *testing.T, root string) {
 	t.Helper()
 

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -11,7 +12,34 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
+
+type workflowDocument struct {
+	Jobs map[string]workflowJob `yaml:"jobs"`
+}
+
+type workflowJob struct {
+	Name string `yaml:"name"`
+}
+
+func collectWorkflowJobNames(content []byte) ([]string, error) {
+	var document workflowDocument
+	if err := yaml.Unmarshal(content, &document); err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(document.Jobs))
+	for _, job := range document.Jobs {
+		name := strings.TrimSpace(job.Name)
+		if name == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
 
 func CheckWorkflows(rootDir, policyPath string) error {
 	if err := ensureWorkflowTools(); err != nil {
@@ -43,16 +71,16 @@ func CheckWorkflows(rootDir, policyPath string) error {
 
 	jobNames := map[string]struct{}{}
 	for _, path := range workflowPaths {
-		content, err := readText(path)
+		content, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
-		for _, match := range workflowNamePattern.FindAllStringSubmatch(content, -1) {
-			name := strings.TrimSpace(match[1])
-			name = strings.Trim(name, `"'`)
-			if name != "" {
-				jobNames[name] = struct{}{}
-			}
+		names, err := collectWorkflowJobNames(content)
+		if err != nil {
+			return fmt.Errorf("%s: parse workflow job names: %w", path, err)
+		}
+		for _, name := range names {
+			jobNames[name] = struct{}{}
 		}
 	}
 

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -1,0 +1,121 @@
+package metadatautil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckWorkflowsRecognizesRequiredJobNames(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "ci.yml"), []byte(`name: CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Validate repository
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
+  container-smoke:
+    name: Container smoke
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
+  reproducible-build:
+    name: Reproducible build
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(ci.yml) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "security.yml"), []byte(`name: Security
+
+on:
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    name: GitHub Actions lint
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
+  zizmor:
+    name: GitHub Actions security analysis
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(security.yml) error = %v", err)
+	}
+
+	policyPath := filepath.Join(root, "policy.toml")
+	if err := os.WriteFile(policyPath, []byte(`[required_status_checks]
+contexts = [
+  "Validate repository",
+  "Container smoke",
+  "Reproducible build",
+  "GitHub Actions lint",
+  "GitHub Actions security analysis",
+]
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(policy.toml) error = %v", err)
+	}
+
+	if err := CheckWorkflows(root, policyPath); err != nil {
+		t.Fatalf("CheckWorkflows() error = %v", err)
+	}
+}
+
+func TestCheckWorkflowsRejectsMultilineSpoofedName(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "ci.yml"), []byte(`name: CI
+
+on:
+  workflow_dispatch:
+
+env:
+  SPOOFED_NAME: |
+    name: Validate repository
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(ci.yml) error = %v", err)
+	}
+
+	policyPath := filepath.Join(root, "policy.toml")
+	if err := os.WriteFile(policyPath, []byte(`[required_status_checks]
+contexts = [
+  "Validate repository",
+]
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(policy.toml) error = %v", err)
+	}
+
+	err := CheckWorkflows(root, policyPath)
+	if err == nil {
+		t.Fatal("CheckWorkflows() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "Validate repository") {
+		t.Fatalf("CheckWorkflows() error = %v, want missing Validate repository", err)
+	}
+}

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -7,6 +7,29 @@ import (
 	"testing"
 )
 
+func TestVerifyInvariantsUsesDedicatedSanitizedEntrypoint(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "verify-invariants.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(content)
+
+	for _, want := range []string{
+		"#!/bin/bash -p",
+		"WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT",
+		`exec /usr/bin/env -i \`,
+		`/bin/bash -p "$0" "$@"`,
+		"unset BASH_ENV ENV",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("%s does not contain %q", scriptPath, want)
+		}
+	}
+}
+
 func TestDevQuickCheckStaysBoundedToFastLocalWork(t *testing.T) {
 	t.Parallel()
 

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -82,4 +82,71 @@ func TestValidationGatesLintAllScenarioShellScripts(t *testing.T) {
 		}
 	}
 
+	if !strings.Contains(string(quickCheck), "scripts/verify-go-python-parity.sh") {
+		t.Fatalf("%s must include scripts/verify-go-python-parity.sh", quickCheckPath)
+	}
+	if !strings.Contains(string(validateRepo), "scripts/verify-go-python-parity.sh") {
+		t.Fatalf("%s must include scripts/verify-go-python-parity.sh", validateRepoPath)
+	}
+	for _, want := range []string{
+		`${ROOT_DIR}/install.sh`,
+		`${ROOT_DIR}/scripts/build-and-test.sh`,
+		`${ROOT_DIR}/scripts/install-dev-tools.sh`,
+	} {
+		if !strings.Contains(string(validateRepo), want) {
+			t.Fatalf("%s must lint and format %s", validateRepoPath, want)
+		}
+	}
+}
+
+func TestBuildAndTestDockerModeUsesSnapshotBackedValidatorRun(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "build-and-test.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(content)
+
+	for _, want := range []string{
+		"--docker",
+		`"${ROOT_DIR}/scripts/with-validation-snapshot.sh"`,
+		"--mode worktree",
+		"--include-untracked",
+		`./scripts/validate-repo.sh`,
+		`./scripts/verify-invariants.sh`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("%s does not contain %q", scriptPath, want)
+		}
+	}
+
+	if strings.Contains(script, `-v "${ROOT_DIR}:/workspace"`) {
+		t.Fatalf("%s should mount a disposable snapshot into the validator container, not the live worktree", scriptPath)
+	}
+}
+
+func TestInstallDevToolsBootstrapsNodeAndPythonVenvPrereqs(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "install-dev-tools.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(content)
+
+	for _, want := range []string{
+		`command -v npm`,
+		`python3 -m venv --help`,
+		`append_unique_brew node`,
+		`append_unique_apt nodejs npm`,
+		`append_unique_brew python`,
+		`append_unique_apt python3 python3-venv python3-pip`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("%s does not contain %q", scriptPath, want)
+		}
+	}
 }

--- a/internal/testkit/validation_snapshot_test.go
+++ b/internal/testkit/validation_snapshot_test.go
@@ -210,3 +210,168 @@ func TestValidationSnapshotFailsWhenTrackedBlobIsUnreadable(t *testing.T) {
 		t.Fatalf("snapshot output = %q want failed to read blob", snapshotOutput)
 	}
 }
+
+func TestValidationSnapshotPreservesGitIndexState(t *testing.T) {
+	t.Parallel()
+
+	tempRoot := t.TempDir()
+	repo := createSnapshotFixtureRepo(t, tempRoot)
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("index\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "-C", repo, "add", "README.md")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add README.md failed: %v\n%s", err, output)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("worktree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		mode          string
+		expectedIndex string
+		expectedFile  string
+	}{
+		{mode: "head", expectedIndex: "fixture", expectedFile: "fixture"},
+		{mode: "index", expectedIndex: "index", expectedFile: "index"},
+		{mode: "worktree", expectedIndex: "index", expectedFile: "worktree"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.mode, func(t *testing.T) {
+			t.Parallel()
+
+			code, output := runValidationSnapshotCommand(
+				t,
+				repo,
+				tc.mode,
+				`printf 'index=%s\n' "$(git show :README.md | tr -d '\n')"; printf 'worktree=%s\n' "$(tr -d '\n' < README.md)"`,
+				nil,
+			)
+			if code != 0 {
+				t.Fatalf("snapshot exit code = %d output=%q", code, output)
+			}
+			expected := "index=" + tc.expectedIndex + "\nworktree=" + tc.expectedFile + "\n"
+			if output != expected {
+				t.Fatalf("snapshot output = %q want %q", output, expected)
+			}
+		})
+	}
+}
+
+func TestValidationSnapshotPreservesIntentToAddState(t *testing.T) {
+	t.Parallel()
+
+	tempRoot := t.TempDir()
+	repo := createSnapshotFixtureRepo(t, tempRoot)
+	if err := os.WriteFile(filepath.Join(repo, "planned.txt"), []byte("planned\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "-C", repo, "add", "-N", "planned.txt")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add -N planned.txt failed: %v\n%s", err, output)
+	}
+
+	cases := []struct {
+		mode          string
+		expectedIndex string
+		expectedDiff  string
+		expectedFile  string
+	}{
+		{mode: "index", expectedIndex: "present", expectedDiff: "", expectedFile: "missing"},
+		{mode: "worktree", expectedIndex: "present", expectedDiff: "", expectedFile: "present"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.mode, func(t *testing.T) {
+			t.Parallel()
+
+			code, output := runValidationSnapshotCommand(
+				t,
+				repo,
+				tc.mode,
+				`if git ls-files --error-unmatch planned.txt >/dev/null 2>&1; then echo index=present; else echo index=missing; fi; printf 'cached=%s\n' "$(git diff --cached --name-status -- planned.txt | tr -d '\n')"; if [ -e planned.txt ]; then echo file=present; else echo file=missing; fi`,
+				nil,
+			)
+			if code != 0 {
+				t.Fatalf("snapshot exit code = %d output=%q", code, output)
+			}
+			expected := "index=" + tc.expectedIndex + "\ncached=" + tc.expectedDiff + "\nfile=" + tc.expectedFile + "\n"
+			if output != expected {
+				t.Fatalf("snapshot output = %q want %q", output, expected)
+			}
+		})
+	}
+}
+
+func TestValidationSnapshotPreservesIntentToAddWithoutWorktreeCopy(t *testing.T) {
+	t.Parallel()
+
+	tempRoot := t.TempDir()
+	repo := createSnapshotFixtureRepo(t, tempRoot)
+	if err := os.WriteFile(filepath.Join(repo, "planned.txt"), []byte("planned\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "-C", repo, "add", "-N", "planned.txt")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add -N planned.txt failed: %v\n%s", err, output)
+	}
+	if err := os.Remove(filepath.Join(repo, "planned.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	code, output := runValidationSnapshotCommand(
+		t,
+		repo,
+		"index",
+		`if git ls-files --error-unmatch planned.txt >/dev/null 2>&1; then echo index=present; else echo index=missing; fi; printf 'cached=%s\n' "$(git diff --cached --name-status -- planned.txt | tr -d '\n')"; if [ -e planned.txt ]; then echo file=present; else echo file=missing; fi`,
+		nil,
+	)
+	if code != 0 {
+		t.Fatalf("snapshot exit code = %d output=%q", code, output)
+	}
+	expected := "index=present\ncached=\nfile=missing\n"
+	if output != expected {
+		t.Fatalf("snapshot output = %q want %q", output, expected)
+	}
+}
+
+func TestValidationSnapshotPreservesIgnoredIntentToAddState(t *testing.T) {
+	t.Parallel()
+
+	tempRoot := t.TempDir()
+	repo := createSnapshotFixtureRepo(t, tempRoot)
+	if err := os.WriteFile(filepath.Join(repo, ".gitignore"), []byte("planned.txt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "-C", repo, "add", ".gitignore")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add .gitignore failed: %v\n%s", err, output)
+	}
+	cmd = exec.Command("git", "-C", repo, "commit", "-q", "-m", "add ignore")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit add ignore failed: %v\n%s", err, output)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "planned.txt"), []byte("planned\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd = exec.Command("git", "-C", repo, "add", "-N", "-f", "planned.txt")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add -N -f planned.txt failed: %v\n%s", err, output)
+	}
+
+	code, output := runValidationSnapshotCommand(
+		t,
+		repo,
+		"index",
+		`if git ls-files --error-unmatch planned.txt >/dev/null 2>&1; then echo index=present; else echo index=missing; fi; printf 'cached=%s\n' "$(git diff --cached --name-status -- planned.txt | tr -d '\n')"; if [ -e planned.txt ]; then echo file=present; else echo file=missing; fi`,
+		nil,
+	)
+	if code != 0 {
+		t.Fatalf("snapshot exit code = %d output=%q", code, output)
+	}
+	expected := "index=present\ncached=\nfile=missing\n"
+	if output != expected {
+		t.Fatalf("snapshot output = %q want %q", output, expected)
+	}
+}

--- a/internal/testkit/validation_snapshot_test.go
+++ b/internal/testkit/validation_snapshot_test.go
@@ -46,17 +46,17 @@ func createSnapshotFixtureRepo(tb testing.TB, root string) string {
 	return repo
 }
 
-func runValidationSnapshot(tb testing.TB, repo string, extraEnv map[string]string) (int, string, string) {
+func runValidationSnapshotCommand(tb testing.TB, repo string, mode string, command string, extraEnv map[string]string) (int, string) {
 	tb.Helper()
 
 	script := filepath.Join(repoRoot(tb), "scripts", "with-validation-snapshot.sh")
 	cmd := exec.Command(
 		script,
 		"--repo", repo,
-		"--mode", "head",
+		"--mode", mode,
 		"--",
 		"/bin/sh", "-c",
-		`pwd; printf '%s\n' "$WORKCELL_VALIDATION_SNAPSHOT_DIR"; if [ -d .git ]; then echo True; else echo False; fi`,
+		command,
 	)
 	cmd.Env = os.Environ()
 	for key, value := range extraEnv {
@@ -64,13 +64,24 @@ func runValidationSnapshot(tb testing.TB, repo string, extraEnv map[string]strin
 	}
 	output, err := cmd.CombinedOutput()
 	if err == nil {
-		return 0, string(output), ""
+		return 0, string(output)
 	}
 	if exitErr, ok := err.(*exec.ExitError); ok {
-		return exitErr.ExitCode(), string(output), string(exitErr.Stderr)
+		return exitErr.ExitCode(), string(output)
 	}
 	tb.Fatalf("snapshot command failed: %v", err)
-	return 0, "", ""
+	return 0, ""
+}
+
+func runValidationSnapshot(tb testing.TB, repo string, extraEnv map[string]string) (int, string) {
+	tb.Helper()
+	return runValidationSnapshotCommand(
+		tb,
+		repo,
+		"head",
+		`pwd; printf '%s\n' "$WORKCELL_VALIDATION_SNAPSHOT_DIR"; if [ -d .git ]; then echo True; else echo False; fi`,
+		extraEnv,
+	)
 }
 
 func TestValidationSnapshotDefaultsToRepoParent(t *testing.T) {
@@ -79,7 +90,7 @@ func TestValidationSnapshotDefaultsToRepoParent(t *testing.T) {
 	tempRoot := t.TempDir()
 	repo := createSnapshotFixtureRepo(t, tempRoot)
 
-	code, stdout, _ := runValidationSnapshot(t, repo, nil)
+	code, stdout := runValidationSnapshot(t, repo, nil)
 	if code != 0 {
 		t.Fatalf("snapshot exit code = %d stdout=%q", code, stdout)
 	}
@@ -113,7 +124,7 @@ func TestValidationSnapshotParentOverrideIsHonored(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	code, stdout, _ := runValidationSnapshot(t, repo, map[string]string{
+	code, stdout := runValidationSnapshot(t, repo, map[string]string{
 		"WORKCELL_VALIDATION_SNAPSHOT_PARENT": overrideParent,
 	})
 	if code != 0 {
@@ -132,5 +143,70 @@ func TestValidationSnapshotParentOverrideIsHonored(t *testing.T) {
 	}
 	if gitDir != "True" {
 		t.Fatalf("git dir flag = %q want True", gitDir)
+	}
+}
+
+func TestValidationSnapshotPreservesTrackedSymlinks(t *testing.T) {
+	t.Parallel()
+
+	tempRoot := t.TempDir()
+	repo := createSnapshotFixtureRepo(t, tempRoot)
+	linkPath := filepath.Join(repo, "link.txt")
+	if err := os.Symlink("README.md", linkPath); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "-C", repo, "add", "link.txt")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add link.txt failed: %v\n%s", err, output)
+	}
+	cmd = exec.Command("git", "-C", repo, "commit", "-q", "-m", "add symlink")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit add symlink failed: %v\n%s", err, output)
+	}
+
+	for _, mode := range []string{"head", "index", "worktree"} {
+		mode := mode
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+
+			code, output := runValidationSnapshotCommand(
+				t,
+				repo,
+				mode,
+				`if [ -L link.txt ]; then printf 'target=%s\n' "$(readlink link.txt)"; else echo missing; fi`,
+				nil,
+			)
+			if code != 0 {
+				t.Fatalf("snapshot exit code = %d output=%q", code, output)
+			}
+			if strings.TrimSpace(output) != "target=README.md" {
+				t.Fatalf("snapshot output = %q want target=README.md", output)
+			}
+		})
+	}
+}
+
+func TestValidationSnapshotFailsWhenTrackedBlobIsUnreadable(t *testing.T) {
+	t.Parallel()
+
+	tempRoot := t.TempDir()
+	repo := createSnapshotFixtureRepo(t, tempRoot)
+	cmd := exec.Command("git", "-C", repo, "rev-parse", "HEAD:README.md")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse README blob failed: %v\n%s", err, output)
+	}
+	oid := strings.TrimSpace(string(output))
+	objectPath := filepath.Join(repo, ".git", "objects", oid[:2], oid[2:])
+	if err := os.Remove(objectPath); err != nil {
+		t.Fatalf("remove blob object: %v", err)
+	}
+
+	code, snapshotOutput := runValidationSnapshotCommand(t, repo, "head", `echo should-not-run`, nil)
+	if code == 0 {
+		t.Fatalf("snapshot unexpectedly succeeded: %q", snapshotOutput)
+	}
+	if !strings.Contains(snapshotOutput, "failed to read blob") {
+		t.Fatalf("snapshot output = %q want failed to read blob", snapshotOutput)
 	}
 }

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -32,7 +32,7 @@ reproducible runtime for the supported providers.
 - `scripts/colima-egress-allowlist.sh`: VM-level network posture helper
 - `scripts/container-smoke.sh`: direct container smoke coverage
 - `scripts/verify-invariants.sh`: invariant checks
-- `scripts/validate-repo.sh`: repo-wide validation
+- `scripts/build-and-test.sh`: repo-wide validation and local check entry point
 
 ## GUI status
 

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -187,14 +187,7 @@ RUN install_runtime_builder_packages() { \
     -o /tmp/rustup-init \
   && echo "${rustup_sha256}  /tmp/rustup-init" | sha256sum -c - \
   && chmod 0755 /tmp/rustup-init \
-  && CARGO_HOME=/usr/local/cargo \
-     RUSTUP_HOME=/usr/local/rustup \
-     /tmp/rustup-init -y --profile minimal --default-toolchain "${RUST_VERSION}" --no-modify-path \
-  && CARGO_HOME=/usr/local/cargo \
-     RUSTUP_HOME=/usr/local/rustup \
-     /usr/local/cargo/bin/rustup default "${RUST_VERSION}" \
-  && ln -sf /usr/local/cargo/bin/cargo /usr/local/bin/cargo \
-  && ln -sf /usr/local/cargo/bin/rustc /usr/local/bin/rustc \
+  && /tmp/rustup-init -y --profile minimal --default-toolchain "${RUST_VERSION}" --no-modify-path \
   && rustc --version | grep -F "rustc ${RUST_VERSION} " >/dev/null \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /var/cache/debconf/*-old /var/cache/ldconfig/aux-cache \
   && rm -f /etc/ld.so.cache /tmp/rustup-init \
@@ -301,9 +294,9 @@ RUN SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}" \
     CARGO_HOME=/workcell-rust/cargo-home \
     CARGO_TARGET_DIR=/tmp/workcell-rust-target \
     cargo build \
-    --release \
-    --locked \
-    --offline \
+      --release \
+      --locked \
+      --offline \
   && install -m 0644 /tmp/workcell-rust-target/release/libworkcell_exec_guard.so /usr/local/lib/libworkcell_exec_guard.so \
   && install -m 0644 /tmp/workcell-rust-target/release/workcell-launcher /usr/local/libexec/workcell/core/launcher \
   && install -m 0644 /tmp/workcell-rust-target/release/workcell-git-launcher /usr/local/libexec/workcell/core/git \

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "0687bf201d4cfa1bc1db5b3330c9c5114d82f6d4c52f92374c6329f1d5e931de"
+      "sha256": "1463ff394459723322a35a93be05f9674a305fde054afda34c1806ade522a4c2"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "1463ff394459723322a35a93be05f9674a305fde054afda34c1806ade522a4c2"
+      "sha256": "56113deacee4a698ca2b2f6543c6b7abc43e7052a3bc01eda6f2bcef9f8b438c"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",
@@ -14,7 +14,7 @@
     },
     {
       "repo_path": "scripts/lib/trusted-docker-client.sh",
-      "sha256": "6e5c0ef2c0a710be998a88cb0d2384c610f8a53184d7c8109108e3e4515a3695"
+      "sha256": "1d165051ed01d85507e7219f3533b3738f31353e349e5cdcced32af514908013"
     }
   ],
   "runtime_artifacts": [

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -34,7 +34,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/claude/hooks/guard-bash.sh",
       "runtime_path": "/opt/workcell/adapters/claude/hooks/guard-bash.sh",
-      "sha256": "d40e2b13f22fa9f1a92cf3033df6f465f6195d6f9bf256bbcdec328e61803804"
+      "sha256": "fd81d0f21dccf0e97cee2b69138e2fa8d40450caee326e1e2b4cd348d7fb6379"
     },
     {
       "kind": "adapter-baseline",

--- a/scripts/build-and-test.sh
+++ b/scripts/build-and-test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash -p
+# Host-side validation harness.  Runs repo-level checks (linting,
+# compilation, tests, manifest verification) directly on the host using
+# locally installed tools.  CI is the authority on exact tool versions;
+# this script catches issues early without Docker overhead.
+#
+# This is a build-time tool, not a runtime entry point; it does not
+# launch a Workcell session or go through the launcher's runtime boundary.
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
+  exec /usr/bin/env -i \
+    PATH="${TRUSTED_HOST_PATH}" \
+    HOME="${HOME:-/tmp}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    WORKCELL_SANITIZED_ENTRYPOINT=1 \
+    /bin/bash -p "$0" "$@"
+fi
+set -euo pipefail
+export PATH="${HOME}/.cargo/bin:${TRUSTED_HOST_PATH}"
+
+if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
+  head -n 1 "$0" >/dev/null
+  echo "build-and-test-entrypoint-ok"
+  exit 0
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Handle flags that build-and-test.sh owns before passing the rest to
+# validate-repo.sh.
+for arg in "$@"; do
+  case "${arg}" in
+    --install)
+      exec "${ROOT_DIR}/scripts/install-dev-tools.sh"
+      ;;
+    -h | --help)
+      cat <<EOF
+Usage: build-and-test.sh [OPTIONS]
+
+Host-side validation harness. Runs check-pinned-inputs.sh and
+validate-repo.sh directly on the host using locally installed tools.
+
+Options:
+  --install     Install missing host tools (brew/apt) and set up Python venv
+  --auto-fix    Run markdownlint --fix before linting
+  --strict      Exit on first check failure
+  -l, --list    List files that would be checked, then exit
+  -h, --help    Show this help
+EOF
+      exit 0
+      ;;
+  esac
+done
+
+# Activate the repo venv if it exists (provides pytest).
+if [[ -f "${ROOT_DIR}/.venv/bin/activate" ]]; then
+  # shellcheck source=/dev/null
+  source "${ROOT_DIR}/.venv/bin/activate"
+fi
+
+# --- Host-side checks (same as CI, before validation) ---
+"${ROOT_DIR}/scripts/check-pinned-inputs.sh"
+"${ROOT_DIR}/scripts/verify-build-input-manifest.sh"
+
+# --- Repo validation (linting, compilation, tests, manifests) ---
+"${ROOT_DIR}/scripts/validate-repo.sh" "$@"

--- a/scripts/build-and-test.sh
+++ b/scripts/build-and-test.sh
@@ -6,7 +6,7 @@
 #
 # This is a build-time tool, not a runtime entry point; it does not
 # launch a Workcell session or go through the launcher's runtime boundary.
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
   exec /usr/bin/env -i \
     PATH="${TRUSTED_HOST_PATH}" \
@@ -25,6 +25,61 @@ if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
 fi
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+USE_DOCKER=0
+
+default_snapshot_parent() {
+  local raw_parent=""
+
+  if [[ -n "${WORKCELL_VALIDATION_SNAPSHOT_PARENT:-}" ]]; then
+    raw_parent="${WORKCELL_VALIDATION_SNAPSHOT_PARENT}"
+  elif [[ -n "${XDG_CACHE_HOME:-}" ]]; then
+    raw_parent="${XDG_CACHE_HOME}/workcell-validation-snapshots"
+  elif [[ -n "${HOME:-}" ]]; then
+    if [[ "${OSTYPE:-}" == darwin* ]]; then
+      raw_parent="${HOME}/Library/Caches/workcell-validation-snapshots"
+    else
+      raw_parent="${HOME}/.cache/workcell-validation-snapshots"
+    fi
+  else
+    raw_parent="$(dirname "${ROOT_DIR}")"
+  fi
+
+  case "${raw_parent}" in
+    /*)
+      printf '%s\n' "${raw_parent}"
+      ;;
+    *)
+      printf '%s\n' "${ROOT_DIR}/${raw_parent}"
+      ;;
+  esac
+}
+
+run_validate_repo_in_validator_snapshot() {
+  local image_tag="$1"
+  shift
+
+  local snapshot_parent=""
+  snapshot_parent="$(default_snapshot_parent)"
+  mkdir -p "${snapshot_parent}"
+
+  # shellcheck disable=SC2016
+  env \
+    "WORKCELL_VALIDATION_SNAPSHOT_PARENT=${snapshot_parent}" \
+    "${ROOT_DIR}/scripts/with-validation-snapshot.sh" \
+    --repo "${ROOT_DIR}" \
+    --mode worktree \
+    --include-untracked \
+    -- \
+    /bin/bash -p -c '
+      workspace="$(pwd -P)"
+      docker run --rm \
+        -v "${workspace}:/workspace" \
+        -w /workspace \
+        "$1" \
+        ./scripts/validate-repo.sh "${@:2}"
+      ./scripts/verify-invariants.sh
+    ' bash "${image_tag}" "$@"
+}
 
 # Handle flags that build-and-test.sh owns before passing the rest to
 # validate-repo.sh.
@@ -33,20 +88,31 @@ for arg in "$@"; do
     --install)
       exec "${ROOT_DIR}/scripts/install-dev-tools.sh"
       ;;
+    --docker)
+      USE_DOCKER=1
+      ;;
     -h | --help)
       cat <<EOF
 Usage: build-and-test.sh [OPTIONS]
 
 Host-side validation harness. Runs check-pinned-inputs.sh and
-validate-repo.sh directly on the host using locally installed tools.
+validate-repo.sh directly on the host using locally installed tools. Use
+--docker to rerun repo validation inside the CI validator container from a
+disposable snapshot of the current worktree.
 
 Options:
   --install     Install missing host tools (brew/apt) and set up Python venv
+  --docker      Run repo validation inside the validator container
   -h, --help    Show this help
 EOF
       exit 0
       ;;
   esac
+done
+
+validate_args=()
+for arg in "$@"; do
+  [[ "${arg}" == "--docker" ]] || validate_args+=("${arg}")
 done
 
 # Activate the repo venv if it exists (provides pytest).
@@ -59,5 +125,18 @@ fi
 "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
 "${ROOT_DIR}/scripts/verify-build-input-manifest.sh"
 
-# --- Repo validation (linting, compilation, tests, manifests) ---
-"${ROOT_DIR}/scripts/validate-repo.sh" "$@"
+if [[ "${USE_DOCKER}" -eq 1 ]]; then
+  IMAGE_TAG="workcell-validator:local"
+
+  if ! command -v docker &>/dev/null; then
+    echo "ERROR: --docker requires Docker. Install Docker Desktop or colima." >&2
+    exit 1
+  fi
+
+  echo "Building validator image..."
+  docker build -f "${ROOT_DIR}/tools/validator/Dockerfile" -t "${IMAGE_TAG}" "${ROOT_DIR}"
+  run_validate_repo_in_validator_snapshot "${IMAGE_TAG}" ${validate_args[@]:+"${validate_args[@]}"}
+else
+  # --- Repo validation (linting, compilation, tests, manifests) ---
+  "${ROOT_DIR}/scripts/validate-repo.sh" ${validate_args[@]:+"${validate_args[@]}"}
+fi

--- a/scripts/build-and-test.sh
+++ b/scripts/build-and-test.sh
@@ -42,9 +42,6 @@ validate-repo.sh directly on the host using locally installed tools.
 
 Options:
   --install     Install missing host tools (brew/apt) and set up Python venv
-  --auto-fix    Run markdownlint --fix before linting
-  --strict      Exit on first check failure
-  -l, --list    List files that would be checked, then exit
   -h, --help    Show this help
 EOF
       exit 0

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
   exec /usr/bin/env -i \
     PATH="${TRUSTED_HOST_PATH}" \

--- a/scripts/colima-egress-allowlist.sh
+++ b/scripts/colima-egress-allowlist.sh
@@ -27,6 +27,10 @@ scrub_host_process_env
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly ROOT_DIR
+# shellcheck source=/dev/null
+source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
+# shellcheck source=/dev/null
+source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
 GO_BIN="${WORKCELL_GO_BIN:-}"
 LIMACTL_BIN=""
 TEST_RUN_IN_VM_CAPTURE_DIR=""
@@ -41,8 +45,18 @@ EOF
 }
 
 resolve_go_bin() {
+  local candidate=""
+
   if [[ -n "${GO_BIN}" && -x "${GO_BIN}" ]]; then
-    return 0
+    case "${GO_BIN}" in
+      /opt/homebrew/bin/go | /usr/local/go/bin/go | /usr/local/bin/go | /usr/bin/go)
+        return 0
+        ;;
+      *)
+        echo "Untrusted go binary path: ${GO_BIN}" >&2
+        exit 1
+        ;;
+    esac
   fi
   for candidate in \
     /opt/homebrew/bin/go \
@@ -59,9 +73,12 @@ resolve_go_bin() {
 }
 
 run_clean_repo_command() {
-  local home="${REAL_HOME:-${HOME:-/tmp}}"
+  local home="${REAL_HOME:-}"
 
   [[ "$#" -gt 0 ]] || return 0
+  if [[ -z "${home}" ]]; then
+    home="$(resolve_workcell_real_home 2>/dev/null || true)"
+  fi
   if [[ ! -d "${home}" ]]; then
     home="/"
   fi
@@ -79,49 +96,12 @@ run_clean_repo_command() {
 
 go_runtimeutil() {
   resolve_go_bin
-  run_clean_repo_command "${GO_BIN}" run ./cmd/workcell-runtimeutil "$@"
-}
-
-resolve_workcell_real_home() {
-  local uid entry home user_name getent_bin="" dscl_bin=""
-
-  uid="$(id -u)"
-  user_name="$(id -un)"
-  for candidate in /usr/bin/getent /bin/getent; do
-    if [[ -x "${candidate}" ]]; then
-      getent_bin="${candidate}"
-      break
-    fi
-  done
-  if [[ -n "${getent_bin}" ]]; then
-    entry="$("${getent_bin}" passwd "${uid}" 2>/dev/null || true)"
-    if [[ -n "${entry}" ]]; then
-      IFS=: read -r _ _ _ _ _ home _ <<<"${entry}"
-      if [[ -n "${home}" ]]; then
-        printf '%s\n' "${home}"
-        return 0
-      fi
-    fi
-  fi
-
-  if [[ -x /usr/bin/dscl ]]; then
-    dscl_bin=/usr/bin/dscl
-  fi
-  if [[ -n "${dscl_bin}" ]]; then
-    home="$("${dscl_bin}" . -read "/Users/${user_name}" NFSHomeDirectory 2>/dev/null | awk 'END {print $2}')"
-    if [[ -n "${home}" ]]; then
-      printf '%s\n' "${home}"
-      return 0
-    fi
-  fi
-
-  if [[ -n "${HOME:-}" && -d "${HOME}" ]]; then
-    printf '%s\n' "${HOME}"
-    return 0
-  fi
-
-  echo "Unable to resolve real home directory for uid ${uid}" >&2
-  return 1
+  ensure_go_run_env
+  run_clean_repo_command env \
+    GOPATH="${GOPATH}" \
+    GOMODCACHE="${GOMODCACHE}" \
+    GOCACHE="${GOCACHE}" \
+    "${GO_BIN}" run ./cmd/workcell-runtimeutil "$@"
 }
 
 resolve_host_tool() {
@@ -182,9 +162,12 @@ canonicalize_host_tool_path() {
 }
 
 run_clean_host_command() {
-  local home="${REAL_HOME:-/}"
+  local home="${REAL_HOME:-}"
 
   [[ "$#" -gt 0 ]] || return 0
+  if [[ -z "${home}" ]]; then
+    home="$(resolve_workcell_real_home 2>/dev/null || true)"
+  fi
   if [[ ! -d "${home}" ]]; then
     home="/"
   fi
@@ -395,6 +378,14 @@ build_allowlist_rules() {
     else
       host="${endpoint%:*}"
       port="${endpoint##*:}"
+    fi
+    if [[ "${host}" == \[*\] ]]; then
+      IPV6_RULES+=("sudo ip6tables -A WORKCELL_EGRESS6 -p tcp -d ${host:1:${#host}-2} --dport ${port} -j ACCEPT")
+      continue
+    fi
+    if [[ "${host}" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+      RULES+=("sudo iptables -A WORKCELL_EGRESS -p tcp -d ${host} --dport ${port} -j ACCEPT")
+      continue
     fi
     while IFS= read -r ip; do
       [[ -n "${ip}" ]] || continue

--- a/scripts/dev-quick-check.sh
+++ b/scripts/dev-quick-check.sh
@@ -53,7 +53,10 @@ done < <(find "${ROOT_DIR}/tests/scenarios" -type f -name 'test-*.sh' -print | s
 shellcheck -x "${shell_files[@]}"
 shfmt -ln=bash -i 2 -ci -d "${shell_files[@]}"
 "${ROOT_DIR}/scripts/lint-dockerfiles.sh"
-mapfile -d '' -t go_files < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
+go_files=()
+while IFS= read -r -d '' item; do
+  go_files+=("${item}")
+done < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
 if [[ "${#go_files[@]}" -gt 0 ]]; then
   if gofmt -l "${go_files[@]}" | grep -q .; then
     echo "Go files are not formatted with gofmt." >&2

--- a/scripts/go-port-validate.sh
+++ b/scripts/go-port-validate.sh
@@ -18,7 +18,10 @@ require_tool gofmt
 
 (
   cd "${ROOT_DIR}"
-  mapfile -d '' -t go_files < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
+  go_files=()
+  while IFS= read -r -d '' item; do
+    go_files+=("${item}")
+  done < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
   if [[ "${#go_files[@]}" -gt 0 ]]; then
     if gofmt -l "${go_files[@]}" | grep -q .; then
       echo "Go files are not formatted with gofmt." >&2

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -3,24 +3,93 @@
 # Detects macOS (brew) vs Linux (apt) and installs missing packages.
 set -euo pipefail
 
+append_unique_brew() {
+  local candidate=""
+  local existing=""
+
+  for candidate in "$@"; do
+    for existing in "${brew_missing[@]:-}"; do
+      if [[ "${existing}" == "${candidate}" ]]; then
+        candidate=""
+        break
+      fi
+    done
+    [[ -n "${candidate}" ]] || continue
+    brew_missing+=("${candidate}")
+  done
+}
+
+append_unique_apt() {
+  local candidate=""
+  local existing=""
+
+  for candidate in "$@"; do
+    for existing in "${apt_missing[@]:-}"; do
+      if [[ "${existing}" == "${candidate}" ]]; then
+        candidate=""
+        break
+      fi
+    done
+    [[ -n "${candidate}" ]] || continue
+    apt_missing+=("${candidate}")
+  done
+}
+
+python_venv_supported() {
+  command -v python3 &>/dev/null || return 1
+  python3 -m venv --help >/dev/null 2>&1
+}
+
 echo "Checking host tools..."
 missing=()
+brew_missing=()
+apt_missing=()
 
-command -v shellcheck &>/dev/null || missing+=(shellcheck)
-command -v shfmt &>/dev/null || missing+=(shfmt)
-command -v yamllint &>/dev/null || missing+=(yamllint)
-command -v codespell &>/dev/null || missing+=(codespell)
-command -v jq &>/dev/null || missing+=(jq)
+if ! command -v shellcheck &>/dev/null; then
+  missing+=(shellcheck)
+  append_unique_brew shellcheck
+  append_unique_apt shellcheck
+fi
+if ! command -v shfmt &>/dev/null; then
+  missing+=(shfmt)
+  append_unique_brew shfmt
+  append_unique_apt shfmt
+fi
+if ! command -v yamllint &>/dev/null; then
+  missing+=(yamllint)
+  append_unique_brew yamllint
+  append_unique_apt yamllint
+fi
+if ! command -v codespell &>/dev/null; then
+  missing+=(codespell)
+  append_unique_brew codespell
+  append_unique_apt codespell
+fi
+if ! command -v jq &>/dev/null; then
+  missing+=(jq)
+  append_unique_brew jq
+  append_unique_apt jq
+fi
+if ! command -v npm &>/dev/null; then
+  missing+=(npm)
+  append_unique_brew node
+  append_unique_apt nodejs npm
+fi
+if ! python_venv_supported; then
+  missing+=(python3-venv)
+  append_unique_brew python
+  append_unique_apt python3 python3-venv python3-pip
+fi
 
 if [[ ${#missing[@]} -gt 0 ]]; then
   case "$(uname -s)" in
     Darwin)
-      echo "  brew install ${missing[*]}"
-      brew install "${missing[@]}"
+      echo "  brew install ${brew_missing[*]}"
+      brew install "${brew_missing[@]}"
       ;;
     Linux)
-      echo "  sudo apt-get install ${missing[*]}"
-      sudo apt-get update -qq && sudo apt-get install -y "${missing[@]}"
+      echo "  sudo apt-get install ${apt_missing[*]}"
+      sudo apt-get update -qq && sudo apt-get install -y "${apt_missing[@]}"
       ;;
     *)
       echo "Unsupported OS. Install manually: ${missing[*]}" >&2
@@ -36,6 +105,10 @@ fi
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VENV_DIR="${ROOT_DIR}/.venv"
+if ! python_venv_supported; then
+  echo "Missing required Python venv support after install." >&2
+  exit 1
+fi
 if [[ ! -d "${VENV_DIR}" ]] || ! "${VENV_DIR}/bin/python3" -c "import pytest" &>/dev/null; then
   echo "  Setting up Python venv with pytest..."
   python3 -m venv "${VENV_DIR}"

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# Install development tools needed by validate-repo.sh and dev-quick-check.sh.
+# Detects macOS (brew) vs Linux (apt) and installs missing packages.
+set -euo pipefail
+
+echo "Checking host tools..."
+missing=()
+
+command -v shellcheck &>/dev/null || missing+=(shellcheck)
+command -v shfmt &>/dev/null || missing+=(shfmt)
+command -v yamllint &>/dev/null || missing+=(yamllint)
+command -v codespell &>/dev/null || missing+=(codespell)
+command -v jq &>/dev/null || missing+=(jq)
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  case "$(uname -s)" in
+    Darwin)
+      echo "  brew install ${missing[*]}"
+      brew install "${missing[@]}"
+      ;;
+    Linux)
+      echo "  sudo apt-get install ${missing[*]}"
+      sudo apt-get update -qq && sudo apt-get install -y "${missing[@]}"
+      ;;
+    *)
+      echo "Unsupported OS. Install manually: ${missing[*]}" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if ! command -v markdownlint &>/dev/null; then
+  echo "  npm install -g markdownlint-cli"
+  npm install -g markdownlint-cli
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="${ROOT_DIR}/.venv"
+if [[ ! -d "${VENV_DIR}" ]] || ! "${VENV_DIR}/bin/python3" -c "import pytest" &>/dev/null; then
+  echo "  Setting up Python venv with pytest..."
+  python3 -m venv "${VENV_DIR}"
+  "${VENV_DIR}/bin/pip" install --quiet pytest
+fi
+
+echo "Done."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -58,13 +58,17 @@ write_debug_wrapper() {
   mkdir -p "${debug_dir}"
   chmod 0700 "${debug_dir}" 2>/dev/null || true
   rm -f "${install_path}"
+  local quoted_root_dir
+  quoted_root_dir="$(printf '%q' "${root_dir}")"
+  local quoted_debug_dir
+  quoted_debug_dir="$(printf '%q' "${debug_dir}")"
   cat >"${install_path}" <<EOF
 #!/usr/bin/env -S BASH_ENV= ENV= bash
 set -euo pipefail
 # Workcell debug installer wrapper
 
-ROOT_DIR=${root_dir@Q}
-DEBUG_DIR=${debug_dir@Q}
+ROOT_DIR=${quoted_root_dir}
+DEBUG_DIR=${quoted_debug_dir}
 DEFAULT_DEBUG_LOG="\${DEBUG_DIR}/latest-debug.log"
 HAS_DEBUG_LOG=0
 HAS_REBUILD=0
@@ -96,7 +100,7 @@ if [[ "\${SKIP_AUTO_DEBUG}" -eq 0 ]] && [[ "\${HAS_REBUILD}" -eq 0 ]]; then
   EXTRA_ARGS+=(--rebuild)
 fi
 
-exec "\${ROOT_DIR}/scripts/workcell" "\${EXTRA_ARGS[@]}" "\$@"
+exec "\${ROOT_DIR}/scripts/workcell" \${EXTRA_ARGS[@]:+"\${EXTRA_ARGS[@]}"} "\$@"
 EOF
   chmod 0755 "${install_path}"
 }
@@ -140,5 +144,14 @@ if [[ "${DEBUG_INSTALL}" -eq 1 ]]; then
   echo "Launch-time rebuilds: enabled"
 fi
 if [[ ":${PATH}:" != *":${INSTALL_DIR}:"* ]]; then
-  echo "Add ${INSTALL_DIR} to PATH to run it without a full path."
+  case "${SHELL:-/bin/zsh}" in
+    */bash) rc_file=".bashrc" ;;
+    *) rc_file=".zshrc" ;;
+  esac
+  echo ""
+  echo "Add this line to ~/${rc_file}:"
+  # shellcheck disable=SC2016
+  echo '  export PATH="$HOME/.local/bin:$PATH"'
+  echo ""
+  echo "Or run it now for this session only."
 fi

--- a/scripts/lib/go-run-env.sh
+++ b/scripts/lib/go-run-env.sh
@@ -75,6 +75,6 @@ build_go_tool_in_repo() {
   go_bin="$(resolve_go_bin)"
   (
     cd "${repo_root}" &&
-      "${go_bin}" build -buildvcs=false -o "${output_path}" "$@"
+      "${go_bin}" build -o "${output_path}" "$@"
   )
 }

--- a/scripts/lib/trusted-docker-client.sh
+++ b/scripts/lib/trusted-docker-client.sh
@@ -1,35 +1,26 @@
 # shellcheck shell=bash
 resolve_workcell_real_home() {
-  local uid entry home user_name
+  local uid="" user="" home=""
 
   uid="$(id -u)"
-  user_name="$(id -un)"
+  user="$(id -un)"
+
   if command -v getent >/dev/null 2>&1; then
-    entry="$(getent passwd "${uid}" 2>/dev/null || true)"
-    if [[ -n "${entry}" ]]; then
-      IFS=: read -r _ _ _ _ _ home _ <<<"${entry}"
-      if [[ -n "${home}" ]]; then
-        printf '%s\n' "${home}"
-        return 0
-      fi
-    fi
+    home="$(getent passwd "${uid}" 2>/dev/null | awk -F: 'NR==1 {print $6}' || true)"
+  fi
+  if [[ -z "${home}" ]] && command -v dscl >/dev/null 2>&1; then
+    home="$(dscl . -read "/Users/${user}" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
+  fi
+  if [[ -z "${home}" && -r /etc/passwd ]]; then
+    home="$(awk -F: -v uid="${uid}" '$3 == uid {print $6; exit}' /etc/passwd)"
   fi
 
-  if command -v dscl >/dev/null 2>&1; then
-    home="$(dscl . -read "/Users/${user_name}" NFSHomeDirectory 2>/dev/null | awk '{print $2}' | tail -n 1)"
-    if [[ -n "${home}" ]]; then
-      printf '%s\n' "${home}"
-      return 0
-    fi
+  if [[ -z "${home}" ]]; then
+    echo "Unable to resolve real home directory for uid ${uid}" >&2
+    return 1
   fi
 
-  if [[ -n "${HOME:-}" && -d "${HOME}" ]]; then
-    printf '%s\n' "${HOME}"
-    return 0
-  fi
-
-  echo "Unable to resolve real home directory for uid ${uid}" >&2
-  return 1
+  printf '%s\n' "${home}"
 }
 
 copy_workcell_docker_state_tree() {

--- a/scripts/lint-dockerfiles.sh
+++ b/scripts/lint-dockerfiles.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REQUIRE_DOCKERFILE_LINT="${WORKCELL_REQUIRE_DOCKERFILE_LINT:-0}"
 
-mapfile -d '' -t dockerfiles < <(
+dockerfiles=()
+while IFS= read -r -d '' file; do
+  dockerfiles+=("${file}")
+done < <(
   find "${ROOT_DIR}" \
     -path "${ROOT_DIR}/.git" -prune -o \
     -path "${ROOT_DIR}/dist" -prune -o \

--- a/scripts/pre-merge.sh
+++ b/scripts/pre-merge.sh
@@ -92,15 +92,50 @@ has_untracked_files() {
   grep -qE '^\?\?' <<<"${status_output}"
 }
 
+default_local_snapshot_parent() {
+  local raw_parent=""
+
+  if [[ -n "${WORKCELL_VALIDATION_SNAPSHOT_PARENT:-}" ]]; then
+    raw_parent="${WORKCELL_VALIDATION_SNAPSHOT_PARENT}"
+  elif [[ -n "${XDG_CACHE_HOME:-}" ]]; then
+    raw_parent="${XDG_CACHE_HOME}/workcell-validation-snapshots"
+  elif [[ -n "${HOME:-}" ]]; then
+    if [[ "${OSTYPE:-}" == darwin* ]]; then
+      raw_parent="${HOME}/Library/Caches/workcell-validation-snapshots"
+    else
+      raw_parent="${HOME}/.cache/workcell-validation-snapshots"
+    fi
+  else
+    # Keep local validation snapshots outside Workcell-managed Colima caches so
+    # host-invariant cleanup tests cannot race with the validation workspace,
+    # while still landing under a user cache path that Docker can bind-mount.
+    raw_parent="$(dirname "${ROOT_DIR}")"
+  fi
+
+  case "${raw_parent}" in
+    /*)
+      printf '%s\n' "${raw_parent}"
+      ;;
+    *)
+      printf '%s\n' "${ROOT_DIR}/${raw_parent}"
+      ;;
+  esac
+}
+
 run_from_local_snapshot() {
   local -a snapshot_cmd=()
+  local snapshot_parent=""
   local status=0
 
   [[ -n "${LOCAL_SNAPSHOT_MODE}" ]] || return 0
   [[ "${LOCAL_SNAPSHOT_ACTIVE}" == "1" ]] && return 0
 
   echo "[pre-merge] local validation will run from snapshot (${LOCAL_SNAPSHOT_MODE})." >&2
+  snapshot_parent="$(default_local_snapshot_parent)"
+  mkdir -p "${snapshot_parent}"
   snapshot_cmd=(
+    env
+    "WORKCELL_VALIDATION_SNAPSHOT_PARENT=${snapshot_parent}"
     "${ROOT_DIR}/scripts/with-validation-snapshot.sh"
     --repo "${ROOT_DIR}"
     --mode "${LOCAL_SNAPSHOT_MODE}"
@@ -273,6 +308,7 @@ done
 
 require_tool docker
 require_tool git
+require_tool shellcheck
 
 if [[ "${LOCAL_INCLUDE_UNTRACKED}" -eq 1 ]] && [[ "${LOCAL_SNAPSHOT_MODE}" != "worktree" ]]; then
   echo "--local-include-untracked requires --local-snapshot worktree." >&2
@@ -301,8 +337,22 @@ build_validator_image
 echo "[pre-merge] workflow lint and policy analysis"
 "${ROOT_DIR}/scripts/check-workflows.sh"
 
+heavy_shellcheck_targets=()
+for file in \
+  "${ROOT_DIR}/scripts/workcell" \
+  "${ROOT_DIR}/scripts/verify-invariants.sh"; do
+  if [[ -f "${file}" ]]; then
+    heavy_shellcheck_targets+=("${file}")
+  fi
+done
+if ((${#heavy_shellcheck_targets[@]} > 0)); then
+  echo "[pre-merge] host shellcheck for large shell harnesses"
+  shellcheck -x "${heavy_shellcheck_targets[@]}"
+fi
+
 echo "[pre-merge] repository validation in validator container"
 docker run --rm \
+  -e WORKCELL_SKIP_HEAVY_HOST_SHELLCHECK=1 \
   -v "${ROOT_DIR}:/workspace" \
   -w /workspace \
   "${VALIDATOR_IMAGE}" \

--- a/scripts/pre-merge.sh
+++ b/scripts/pre-merge.sh
@@ -308,13 +308,6 @@ docker run --rm \
   "${VALIDATOR_IMAGE}" \
   ./scripts/validate-repo.sh
 
-echo "[pre-merge] scenario tests (container exec guard required)"
-docker run --rm \
-  -v "${ROOT_DIR}:/workspace" \
-  -w /workspace \
-  "${VALIDATOR_IMAGE}" \
-  ./scripts/run-scenario-tests.sh --secretless-only
-
 echo "[pre-merge] host launcher invariants"
 "${ROOT_DIR}/scripts/verify-invariants.sh"
 

--- a/scripts/pre-merge.sh
+++ b/scripts/pre-merge.sh
@@ -308,6 +308,13 @@ docker run --rm \
   "${VALIDATOR_IMAGE}" \
   ./scripts/validate-repo.sh
 
+echo "[pre-merge] scenario tests (container exec guard required)"
+docker run --rm \
+  -v "${ROOT_DIR}:/workspace" \
+  -w /workspace \
+  "${VALIDATOR_IMAGE}" \
+  ./scripts/run-scenario-tests.sh --secretless-only
+
 echo "[pre-merge] host launcher invariants"
 "${ROOT_DIR}/scripts/verify-invariants.sh"
 

--- a/scripts/provider-e2e.sh
+++ b/scripts/provider-e2e.sh
@@ -267,7 +267,7 @@ while [[ $# -gt 0 ]]; do
       REQUIRE_INJECTION=1
       shift
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
@@ -357,7 +357,10 @@ if [[ "${DRY_RUN}" -eq 1 ]]; then
   printf 'provider_e2e_workspace=%s\n' "${WORKSPACE}"
   printf 'provider_e2e_injection_source=%s\n' "${INJECTION_SOURCE}"
   if ((${#GENERATED_CREDENTIAL_KEYS[@]} > 0)); then
-    printf 'provider_e2e_credential_keys=%s\n' "$(IFS=,; printf '%s' "${GENERATED_CREDENTIAL_KEYS[*]}")"
+    printf 'provider_e2e_credential_keys=%s\n' "$(
+      IFS=,
+      printf '%s' "${GENERATED_CREDENTIAL_KEYS[*]}"
+    )"
   else
     printf 'provider_e2e_credential_keys=\n'
   fi

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -137,7 +137,8 @@ upload_url="${release_metadata[1]}"
 
 for ((i = 2; i < ${#release_metadata[@]}; i += 2)); do
   asset_name="${release_metadata[i]}"
-  asset_id="${release_metadata[i+1]}"
+  j=$((i + 1))
+  asset_id="${release_metadata[j]}"
 
   if [[ -n "${asset_id}" ]]; then
     delete_status="$(api DELETE "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" "" "${TMP_ROOT}/delete-${asset_id}.json")"

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -128,13 +128,16 @@ esac
 
 "${HOSTUTIL_BIN}" release metadata "${release_json}" "${TMP_ROOT}/release-metadata.txt" "$@"
 
-mapfile -d '' -t release_metadata <"${TMP_ROOT}/release-metadata.txt"
+release_metadata=()
+while IFS= read -r -d '' item; do
+  release_metadata+=("${item}")
+done <"${TMP_ROOT}/release-metadata.txt"
 release_id="${release_metadata[0]}"
 upload_url="${release_metadata[1]}"
 
 for ((i = 2; i < ${#release_metadata[@]}; i += 2)); do
   asset_name="${release_metadata[i]}"
-  asset_id="${release_metadata[i + 1]}"
+  asset_id="${release_metadata[i+1]}"
 
   if [[ -n "${asset_id}" ]]; then
     delete_status="$(api DELETE "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" "" "${TMP_ROOT}/delete-${asset_id}.json")"

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -129,16 +129,15 @@ esac
 "${HOSTUTIL_BIN}" release metadata "${release_json}" "${TMP_ROOT}/release-metadata.txt" "$@"
 
 release_metadata=()
-while IFS= read -r -d '' item; do
-  release_metadata+=("${item}")
+while IFS= read -r -d '' field; do
+  release_metadata+=("${field}")
 done <"${TMP_ROOT}/release-metadata.txt"
 release_id="${release_metadata[0]}"
 upload_url="${release_metadata[1]}"
 
 for ((i = 2; i < ${#release_metadata[@]}; i += 2)); do
   asset_name="${release_metadata[i]}"
-  j=$((i + 1))
-  asset_id="${release_metadata[j]}"
+  asset_id="${release_metadata[i + 1]}"
 
   if [[ -n "${asset_id}" ]]; then
     delete_status="$(api DELETE "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" "" "${TMP_ROOT}/delete-${asset_id}.json")"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -85,11 +85,13 @@ append_unique_value() {
   local existing=""
 
   [[ -n "${value}" ]] || return 0
-  for existing in "${PROFILE_NAMES[@]}"; do
-    if [[ "${existing}" == "${value}" ]]; then
-      return 0
-    fi
-  done
+  if [[ ${#PROFILE_NAMES[@]} -gt 0 ]]; then
+    for existing in "${PROFILE_NAMES[@]}"; do
+      if [[ "${existing}" == "${value}" ]]; then
+        return 0
+      fi
+    done
+  fi
   PROFILE_NAMES+=("${value}")
 }
 
@@ -98,11 +100,13 @@ append_unique_temp_root() {
   local existing=""
 
   [[ -n "${value}" ]] || return 0
-  for existing in "${TEMP_ROOTS[@]}"; do
-    if [[ "${existing}" == "${value}" ]]; then
-      return 0
-    fi
-  done
+  if [[ ${#TEMP_ROOTS[@]} -gt 0 ]]; then
+    for existing in "${TEMP_ROOTS[@]}"; do
+      if [[ "${existing}" == "${value}" ]]; then
+        return 0
+      fi
+    done
+  fi
   TEMP_ROOTS+=("${value}")
 }
 
@@ -347,9 +351,11 @@ COLIMA_BIN="$(resolve_host_tool_optional colima /opt/homebrew/bin/colima /usr/lo
 
 collect_profiles
 
-for profile in "${PROFILE_NAMES[@]}"; do
-  delete_managed_profile "${profile}" "${COLIMA_BIN}"
-done
+if [[ ${#PROFILE_NAMES[@]} -gt 0 ]]; then
+  for profile in "${PROFILE_NAMES[@]}"; do
+    delete_managed_profile "${profile}" "${COLIMA_BIN}"
+  done
+fi
 
 remove_workcell_launcher_install "${INSTALL_PATH}"
 remove_workcell_symlink "${MAN_PATH}" "man/workcell.1" "man page"
@@ -360,9 +366,11 @@ remove_path "${SHADOW_ROOT}"
 
 append_unique_temp_root "/tmp"
 append_unique_temp_root "${TMPDIR:-}"
-for temp_root in "${TEMP_ROOTS[@]}"; do
-  cleanup_temp_root "${temp_root}"
-done
+if [[ ${#TEMP_ROOTS[@]} -gt 0 ]]; then
+  for temp_root in "${TEMP_ROOTS[@]}"; do
+    cleanup_temp_root "${temp_root}"
+  done
+fi
 
 if [[ "${REMOVED_COUNT}" -eq 0 ]]; then
   echo "No Workcell-owned install links or managed host state found."

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -41,7 +41,7 @@ build_metadatautil() {
     return 0
   fi
   METADATAUTIL_BIN="$(mktemp "${TMPDIR:-/tmp}/workcell-metadatautil.XXXXXX")"
-  (cd "${ROOT_DIR}" && go build -o "${METADATAUTIL_BIN}" ./cmd/workcell-metadatautil)
+  (cd "${ROOT_DIR}" && go build -buildvcs=false -o "${METADATAUTIL_BIN}" ./cmd/workcell-metadatautil)
 }
 
 run_metadatautil() {

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -50,9 +50,13 @@ run_metadatautil() {
 
 trap cleanup EXIT
 
-mapfile -t python_files < <(
+python_files=()
+while IFS= read -r file; do
+  python_files+=("${file}")
+done < <(
   find "${ROOT_DIR}" \
     -path "${ROOT_DIR}/.git" -prune -o \
+    -path "${ROOT_DIR}/.venv" -prune -o \
     -path "${ROOT_DIR}/dist" -prune -o \
     -path "${ROOT_DIR}/tmp" -prune -o \
     -path "${ROOT_DIR}/runtime/container/providers/node_modules" -prune -o \
@@ -177,7 +181,10 @@ if [[ "${#python_files[@]}" -gt 0 ]]; then
   printf '  %s\n' "${python_files[@]}" >&2
   exit 1
 fi
-mapfile -d '' -t go_files < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
+go_files=()
+while IFS= read -r -d '' file; do
+  go_files+=("${file}")
+done < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
 if [[ "${#go_files[@]}" -gt 0 ]]; then
   if gofmt -l "${go_files[@]}" | grep -q .; then
     echo "Go files are not formatted with gofmt." >&2
@@ -187,7 +194,10 @@ fi
 go vet ./...
 go test ./...
 
-mapfile -t json_files < <(
+json_files=()
+while IFS= read -r file; do
+  json_files+=("${file}")
+done < <(
   find "${ROOT_DIR}/adapters" "${ROOT_DIR}/.github" "${ROOT_DIR}/runtime/container/providers" "${ROOT_DIR}/tests/scenarios" \
     -path '*/node_modules' -prune -o \
     -type f -name '*.json' -print | sort
@@ -196,7 +206,10 @@ if [[ "${#json_files[@]}" -gt 0 ]]; then
   run_metadatautil validate-json "${json_files[@]}"
 fi
 
-mapfile -t toml_files < <(
+toml_files=()
+while IFS= read -r file; do
+  toml_files+=("${file}")
+done < <(
   find "${ROOT_DIR}" \
     -path "${ROOT_DIR}/.git" -prune -o \
     -path "${ROOT_DIR}/dist" -prune -o \
@@ -221,6 +234,7 @@ while IFS= read -r -d '' file; do
   doc_files+=("${file}")
 done < <(find "${ROOT_DIR}" \
   -path "${ROOT_DIR}/.git" -prune -o \
+  -path "${ROOT_DIR}/.venv" -prune -o \
   -path "${ROOT_DIR}/dist" -prune -o \
   -path "${ROOT_DIR}/tmp" -prune -o \
   -path "${ROOT_DIR}/runtime/container/providers/node_modules" -prune -o \

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKIP_HEAVY_HOST_SHELLCHECK="${WORKCELL_SKIP_HEAVY_HOST_SHELLCHECK:-0}"
 
 require_tool() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -40,7 +41,7 @@ build_metadatautil() {
     return 0
   fi
   METADATAUTIL_BIN="$(mktemp "${TMPDIR:-/tmp}/workcell-metadatautil.XXXXXX")"
-  (cd "${ROOT_DIR}" && go build -buildvcs=false -o "${METADATAUTIL_BIN}" ./cmd/workcell-metadatautil)
+  (cd "${ROOT_DIR}" && go build -o "${METADATAUTIL_BIN}" ./cmd/workcell-metadatautil)
 }
 
 run_metadatautil() {
@@ -99,8 +100,8 @@ validate_manpage() {
 
 shell_files=(
   "${ROOT_DIR}/install.sh"
-  "${ROOT_DIR}/scripts/build-and-test.sh"
   "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
+  "${ROOT_DIR}/scripts/build-and-test.sh"
   "${ROOT_DIR}/scripts/workcell"
   "${ROOT_DIR}/scripts/check-workflows.sh"
   "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"
@@ -159,7 +160,24 @@ while IFS= read -r file; do
   shell_files+=("${file}")
 done < <(find "${ROOT_DIR}/tests/scenarios" -type f -name 'test-*.sh' -print | sort)
 
-shellcheck -x "${shell_files[@]}"
+should_skip_shellcheck_file() {
+  local file="$1"
+
+  [[ "${SKIP_HEAVY_HOST_SHELLCHECK}" == "1" ]] || return 1
+  case "${file}" in
+    "${ROOT_DIR}/scripts/workcell" | "${ROOT_DIR}/scripts/verify-invariants.sh")
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+for file in "${shell_files[@]}"; do
+  if should_skip_shellcheck_file "${file}"; then
+    continue
+  fi
+  shellcheck -x "${file}"
+done
 shfmt -ln=bash -i 2 -ci -d "${shell_files[@]}"
 "${ROOT_DIR}/scripts/lint-dockerfiles.sh"
 
@@ -180,13 +198,13 @@ for scratch_dir in \
 done
 
 if [[ "${#python_files[@]}" -gt 0 ]]; then
-  echo "Unexpected repo-owned Python source files remain:" >&2
+  echo "Unexpected Python source files remain in scripts/lib:" >&2
   printf '  %s\n' "${python_files[@]}" >&2
   exit 1
 fi
 go_files=()
-while IFS= read -r -d '' file; do
-  go_files+=("${file}")
+while IFS= read -r -d '' path; do
+  go_files+=("${path}")
 done < <(find "${ROOT_DIR}/cmd" "${ROOT_DIR}/internal" -type f -name '*.go' -print0 | sort -z)
 if [[ "${#go_files[@]}" -gt 0 ]]; then
   if gofmt -l "${go_files[@]}" | grep -q .; then
@@ -198,8 +216,9 @@ go vet ./...
 go test ./...
 
 json_files=()
-while IFS= read -r file; do
-  json_files+=("${file}")
+while IFS= read -r path; do
+  [[ -n "${path}" ]] || continue
+  json_files+=("${path}")
 done < <(
   find "${ROOT_DIR}/adapters" "${ROOT_DIR}/.github" "${ROOT_DIR}/runtime/container/providers" "${ROOT_DIR}/tests/scenarios" \
     -path '*/node_modules' -prune -o \
@@ -210,8 +229,9 @@ if [[ "${#json_files[@]}" -gt 0 ]]; then
 fi
 
 toml_files=()
-while IFS= read -r file; do
-  toml_files+=("${file}")
+while IFS= read -r path; do
+  [[ -n "${path}" ]] || continue
+  toml_files+=("${path}")
 done < <(
   find "${ROOT_DIR}" \
     -path "${ROOT_DIR}/.git" -prune -o \
@@ -237,9 +257,9 @@ while IFS= read -r -d '' file; do
   doc_files+=("${file}")
 done < <(find "${ROOT_DIR}" \
   -path "${ROOT_DIR}/.git" -prune -o \
-  -path "${ROOT_DIR}/.venv" -prune -o \
   -path "${ROOT_DIR}/dist" -prune -o \
   -path "${ROOT_DIR}/tmp" -prune -o \
+  -path "${ROOT_DIR}/.venv" -prune -o \
   -path "${ROOT_DIR}/runtime/container/providers/node_modules" -prune -o \
   -path "${ROOT_DIR}/runtime/container/rust/vendor" -prune -o \
   -path "${ROOT_DIR}/runtime/container/rust/target" -prune -o \

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -98,6 +98,8 @@ validate_manpage() {
 }
 
 shell_files=(
+  "${ROOT_DIR}/install.sh"
+  "${ROOT_DIR}/scripts/build-and-test.sh"
   "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
   "${ROOT_DIR}/scripts/workcell"
   "${ROOT_DIR}/scripts/check-workflows.sh"
@@ -105,6 +107,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/container-smoke.sh"
   "${ROOT_DIR}/scripts/dev-quick-check.sh"
   "${ROOT_DIR}/scripts/go-port-validate.sh"
+  "${ROOT_DIR}/scripts/install-dev-tools.sh"
   "${ROOT_DIR}/scripts/lint-dockerfiles.sh"
   "${ROOT_DIR}/scripts/dev-remote-validate.sh"
   "${ROOT_DIR}/scripts/lib/extract_direct_mounts"

--- a/scripts/verify-coverage.sh
+++ b/scripts/verify-coverage.sh
@@ -75,7 +75,10 @@ run_rust_launcher_coverage() {
 
   (cd "${ROOT_DIR}" && go run ./cmd/workcell-metadatautil coverage-executables "${message_file}") >"${TMP_ROOT}/rust-binaries.txt"
 
-  mapfile -t rust_binaries <"${TMP_ROOT}/rust-binaries.txt"
+  rust_binaries=()
+  while IFS= read -r line; do
+    rust_binaries+=("${line}")
+  done <"${TMP_ROOT}/rust-binaries.txt"
   if [[ "${#rust_binaries[@]}" -eq 0 ]]; then
     echo "Unable to locate instrumented Rust test executables for coverage." >&2
     exit 1

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S -i PATH=/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin BASH_ENV= ENV= /bin/bash
+#!/usr/bin/env -S BASH_ENV= ENV= bash
 # shellcheck shell=bash
 set -Eeuo pipefail
 

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1362,7 +1362,10 @@ if [[ -e "${INJECTION_POLICY_FIXTURE_ROOT}/bundle/credentials/codex-auth.json" ]
   exit 1
 fi
 
-mapfile -t actual_mount_paths < <(jq -r '.[].mount_path' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle.mounts.json" | sort -u)
+actual_mount_paths=()
+while IFS= read -r line; do
+  actual_mount_paths+=("${line}")
+done < <(jq -r '.[].mount_path' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle.mounts.json" | sort -u)
 expected_mount_paths=(
   "/opt/workcell/host-inputs/credentials/codex-auth.json"
   "/opt/workcell/host-inputs/credentials/github-hosts.yml"
@@ -1415,7 +1418,10 @@ EOF
 [[ "$(jq -r '.documents.common' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes/manifest.json")" == "documents/common.md" ]]
 [[ "$(jq -r '.credentials.codex_auth.mount_path' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes/manifest.json")" == "/opt/workcell/host-inputs/credentials/codex-auth.json" ]]
 [[ "$(jq -r '.metadata.policy_sha256' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes/manifest.json")" == sha256:* ]]
-mapfile -t included_policy_source_names < <(jq -r '.metadata.policy_sources[].path | split("/")[-1]' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes/manifest.json")
+included_policy_source_names=()
+while IFS= read -r line; do
+  included_policy_source_names+=("${line}")
+done < <(jq -r '.metadata.policy_sources[].path | split("/")[-1]' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes/manifest.json")
 if [[ "${included_policy_source_names[*]}" != "fragment-docs.toml fragment-credentials.toml policy-with-includes.toml" ]]; then
   echo "unexpected included policy source order: ${included_policy_source_names[*]}" >&2
   exit 1

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -p
+#!/usr/bin/env -S -i PATH=/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin BASH_ENV= ENV= /bin/bash
 # shellcheck shell=bash
 set -Eeuo pipefail
 
@@ -76,6 +76,15 @@ require_tool jq
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
+
+go_verify_metadatautil() {
+  run_go_in_repo "${ROOT_DIR}" run ./cmd/workcell-metadatautil "$@"
+}
+
+go_verify_hostutil() {
+  run_go_in_repo "${ROOT_DIR}" run ./cmd/workcell-hostutil "$@"
+}
+
 HOST_GATE_SCRIPTS=(
   "${ROOT_DIR}/scripts/build-and-test.sh"
   "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
@@ -112,7 +121,7 @@ REPO_LOCAL_REMOTE_CONFIG_PATH="${ROOT_DIR}/tmp/verify-remote-validate-repo.env"
 ROOT_DRY_RUN_PROFILE_NAME="$(
   workspace="$(cd "${ROOT_DIR}" && pwd -P)"
   slug="$(printf '%s' "${workspace##*/}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g; s/^$/workspace/' | cut -c1-10)"
-  digest="$(run_go_in_repo "${ROOT_DIR}" run ./cmd/workcell-hostutil launcher workspace-cache-key "${workspace}" | cut -c1-8)"
+  digest="$(go_verify_hostutil launcher workspace-cache-key "${workspace}" | cut -c1-8)"
   printf 'workcell-%s-%s\n' "${slug}" "${digest}"
 )"
 ROOT_DRY_RUN_PROFILE_DIR="${REAL_HOME}/.colima/${ROOT_DRY_RUN_PROFILE_NAME}"
@@ -166,16 +175,8 @@ extract_top_level_bash_function() {
 cleanup() {
   [[ "${VERIFY_INVARIANTS_CLEANUP_ACTIVE}" -eq 0 ]] || return 0
   VERIFY_INVARIANTS_CLEANUP_ACTIVE=1
-  trap - EXIT
+  trap - EXIT ERR
   set +e
-
-  remove_tree() {
-    local path="$1"
-
-    [[ -n "${path}" && -e "${path}" ]] || return 0
-    chmod -R u+w "${path}" 2>/dev/null || true
-    rm -rf "${path}" 2>/dev/null || true
-  }
 
   delete_verify_colima_profile "${LIVE_DEBUG_PROFILE_NAME:-}"
   delete_verify_colima_profile "${AUDIT_RESTORE_PROFILE_NAME:-}"
@@ -185,16 +186,17 @@ cleanup() {
   delete_verify_colima_profile "${TRANSCRIPT_LOG_PROFILE:-}"
   delete_verify_colima_profile "${BROKEN_DEBUG_POINTER_PROFILE:-}"
   delete_verify_colima_profile "${UNMANAGED_PROFILE_NAME:-}"
-  remove_tree "${CODEX_VERIFY_HOME}"
-  remove_tree "${BARRIER_VERIFY_ROOT}"
-  remove_tree "${INSTALL_VERIFY_HOME}"
-  remove_tree "${REMOTE_VALIDATE_CONFIG_ROOT}"
+  chmod -R u+w "${CODEX_VERIFY_HOME}" "${BARRIER_VERIFY_ROOT}" "${INSTALL_VERIFY_HOME}" 2>/dev/null || true
+  rm -rf "${CODEX_VERIFY_HOME}"
+  rm -rf "${BARRIER_VERIFY_ROOT}"
+  rm -rf "${INSTALL_VERIFY_HOME}"
+  rm -rf "${REMOTE_VALIDATE_CONFIG_ROOT}"
   rm -f "${REPO_LOCAL_REMOTE_CONFIG_PATH}"
   if [[ -n "${BROWSER_PROFILE_FIXTURE}" ]] && [[ -d "${BROWSER_PROFILE_FIXTURE}" ]]; then
     rmdir "${BROWSER_PROFILE_FIXTURE}" 2>/dev/null || true
   fi
   if [[ -n "${COLIMA_PROFILE_FIXTURE}" ]] && [[ -d "${COLIMA_PROFILE_FIXTURE}" ]]; then
-    remove_tree "${COLIMA_PROFILE_FIXTURE}"
+    rm -rf "${COLIMA_PROFILE_FIXTURE}"
   fi
   rm -f "${LEGACY_LOCAL_REMOTE_CONFIG_PATH}"
 }
@@ -251,7 +253,7 @@ rg() {
 
 canonicalize_verify_tool_path() {
   local candidate="$1"
-  (cd "${ROOT_DIR}" && go run ./cmd/workcell-metadatautil canonicalize-path "${candidate}")
+  go_verify_metadatautil canonicalize-path "${candidate}"
 }
 
 verify_tool_path_is_trusted() {
@@ -1200,9 +1202,7 @@ test ! -e "${INSTALL_VERIFY_HOME}/.local/share/man/man1/workcell.1"
 grep -q 'Preserved ~/.config/workcell and any user-specified debug/file-trace/transcript files.' /tmp/workcell-uninstall-debug.out
 
 CUSTOM_DEBUG_DIR="${INSTALL_VERIFY_HOME}/custom-workcell-debug"
-CUSTOM_DEBUG_DIR_REAL="$(
-  cd "${ROOT_DIR}" && go run ./cmd/workcell-metadatautil canonicalize-path "${CUSTOM_DEBUG_DIR}"
-)"
+CUSTOM_DEBUG_DIR_REAL="$(go_verify_metadatautil canonicalize-path "${CUSTOM_DEBUG_DIR}")"
 if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" "${ROOT_DIR}/scripts/install.sh" --debug --debug-dir "${CUSTOM_DEBUG_DIR}" >/tmp/workcell-install-custom-debug.out 2>&1; then
   echo "Expected scripts/install.sh --debug --debug-dir to succeed in a clean temporary HOME" >&2
   cat /tmp/workcell-install-custom-debug.out >&2
@@ -1364,6 +1364,7 @@ fi
 
 actual_mount_paths=()
 while IFS= read -r line; do
+  [[ -n "${line}" ]] || continue
   actual_mount_paths+=("${line}")
 done < <(jq -r '.[].mount_path' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle.mounts.json" | sort -u)
 expected_mount_paths=(
@@ -1420,6 +1421,7 @@ EOF
 [[ "$(jq -r '.metadata.policy_sha256' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes/manifest.json")" == sha256:* ]]
 included_policy_source_names=()
 while IFS= read -r line; do
+  [[ -n "${line}" ]] || continue
   included_policy_source_names+=("${line}")
 done < <(jq -r '.metadata.policy_sources[].path | split("/")[-1]' "${INJECTION_POLICY_FIXTURE_ROOT}/bundle-includes/manifest.json")
 if [[ "${included_policy_source_names[*]}" != "fragment-docs.toml fragment-credentials.toml policy-with-includes.toml" ]]; then
@@ -2143,9 +2145,12 @@ EOF
 } >"${WORKCELL_START_TIMEOUT_CLEANUP_HARNESS}"
 bash "${WORKCELL_START_TIMEOUT_CLEANUP_HARNESS}"
 
-if ! rg -q 'REAL_HOME="\$\(go_hostutil path home\)"' "${ROOT_DIR}/scripts/workcell" ||
-  ! rg -q 'run_clean_host_command_in_dir "\$\{ROOT_DIR\}" env' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to invoke the bootstrap Go helper under a scrubbed environment" >&2
+if ! rg -q 'run_clean_host_command_in_dir "\$\{ROOT_DIR\}" env' "${ROOT_DIR}/scripts/workcell" ||
+  ! rg -q 'GOPATH="\$\{GOPATH\}"' "${ROOT_DIR}/scripts/workcell" ||
+  ! rg -q 'GOMODCACHE="\$\{GOMODCACHE\}"' "${ROOT_DIR}/scripts/workcell" ||
+  ! rg -q 'GOCACHE="\$\{GOCACHE\}"' "${ROOT_DIR}/scripts/workcell" ||
+  ! rg -q '"\$\{HOST_GO_BIN\}" run ./cmd/workcell-hostutil "\$@"' "${ROOT_DIR}/scripts/workcell"; then
+  echo "Expected scripts/workcell to invoke the bootstrap Go helper from the repo root under a scrubbed environment with explicit Go caches" >&2
   exit 1
 fi
 
@@ -2200,9 +2205,12 @@ if ! rg -q 'is_trusted_host_tool_path' "${ROOT_DIR}/scripts/colima-egress-allowl
   exit 1
 fi
 
-if ! rg -q 'run_clean_repo_command "\$\{GO_BIN\}" run ./cmd/workcell-runtimeutil' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" ||
-  ! rg -q 'go_runtimeutil canonicalize-path' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Expected scripts/colima-egress-allowlist.sh to invoke host Go helpers under a scrubbed environment" >&2
+if ! rg -q 'run_clean_repo_command env' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" ||
+  ! rg -q 'GOPATH="\$\{GOPATH\}"' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" ||
+  ! rg -q 'GOMODCACHE="\$\{GOMODCACHE\}"' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" ||
+  ! rg -q 'GOCACHE="\$\{GOCACHE\}"' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" ||
+  ! rg -q '"\$\{GO_BIN\}" run ./cmd/workcell-runtimeutil "\$@"' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
+  echo "Expected scripts/colima-egress-allowlist.sh to invoke Go runtime helpers under a scrubbed environment with explicit Go caches" >&2
   exit 1
 fi
 
@@ -2272,6 +2280,11 @@ if ! rg -q 'snapshot\.debian\.org:80' "${ROOT_DIR}/scripts/workcell"; then
   exit 1
 fi
 
+if ! rg -q 'static\.rust-lang\.org:443' "${ROOT_DIR}/scripts/workcell"; then
+  echo "Expected scripts/workcell bootstrap endpoints to allow static.rust-lang.org for rustup bootstrapping" >&2
+  exit 1
+fi
+
 if ! rg -q 'docker-images-prod\.[^.]+\.r2\.cloudflarestorage\.com:443' "${ROOT_DIR}/scripts/workcell"; then
   echo "Expected scripts/workcell bootstrap endpoints to allow Docker blob storage on Cloudflare R2" >&2
   exit 1
@@ -2331,8 +2344,25 @@ if ! sed -n '/^git_index_materialize_regular_file()/,/^}/p' "${ROOT_DIR}/scripts
   exit 1
 fi
 
+if ! sed -n '/^git_index_materialize_regular_file()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'failed to read tracked blob'; then
+  echo "Expected git_index_materialize_regular_file to fail closed when a tracked control-plane blob is unreadable" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC2016
+if ! sed -n '/^git_index_materialize_regular_file()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq 'rm -f "${destination_path}"'; then
+  echo "Expected git_index_materialize_regular_file to remove partially materialized files after blob read failures" >&2
+  exit 1
+fi
+
 if ! sed -n '/^git_index_populate_shadow_dir()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq '*/../*'; then
   echo "Expected git_index_populate_shadow_dir to reject unsafe index paths before shadow materialization" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC2016
+if ! grep -Fq -- '-path "${ROOT_DIR}/.venv" -prune -o' "${ROOT_DIR}/scripts/validate-repo.sh"; then
+  echo "Expected validate-repo.sh to prune repo-local virtualenv content from documentation scans" >&2
   exit 1
 fi
 
@@ -2785,7 +2815,7 @@ if PATH="${DOCKER_CONTEXT_SELECTOR_FAKEBIN}:${PATH}" \
   HOME=/tmp \
   ROOT_DIR="${ROOT_DIR}" \
   BARRIER_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}" \
-  /bin/bash -c '
+  /bin/bash -lc '
     set -euo pipefail
     source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
     export DOCKER_CONTEXT_NAME=colima
@@ -2804,7 +2834,7 @@ selected_context="$(
   HOME=/tmp \
   ROOT_DIR="${ROOT_DIR}" \
   BARRIER_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}" \
-  /bin/bash -c '
+  /bin/bash -lc '
     set -euo pipefail
     source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
     unset DOCKER_CONTEXT_NAME
@@ -2826,7 +2856,7 @@ fallback_context="$(
     HOME=/tmp \
     ROOT_DIR="${ROOT_DIR}" \
     BARRIER_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}" \
-    /bin/bash -c '
+    /bin/bash -lc '
       set -euo pipefail
       source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
       unset DOCKER_CONTEXT_NAME
@@ -2890,7 +2920,7 @@ printf '%s\n' "$PWD"
 EOS
 chmod 0755 "${FAKE_DOCKER_BIN}/docker"
 
-ROOT_DIR="${ROOT_DIR}" PATH="${FAKE_DOCKER_BIN}:${PATH}" HOME=/tmp /bin/bash -c '
+ROOT_DIR="${ROOT_DIR}" PATH="${FAKE_DOCKER_BIN}:${PATH}" HOME=/tmp /bin/bash -lc '
   set -euo pipefail
   source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
   export HOME="${BARRIER_VERIFY_ROOT}/docker-client-home"
@@ -4047,29 +4077,29 @@ COLIMA_PROFILE_STATUS_HARNESS="$(mktemp)"
   cat <<'EOF'
 set -euo pipefail
 
+ROOT_DIR="__ROOT_DIR__"
 TRUSTED_HOST_PATH="${PATH}"
 
+# Match scripts/workcell's scrubbed repo-root go_hostutil invocation.
+source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
+
 go_hostutil() {
-  local scope="$1"
-  local action="$2"
-  local profile="$3"
-  local payload=""
+  local host_go_bin=""
 
-  payload="$(cat)"
-  [[ "${scope}" == "launcher" && "${action}" == "colima-status" ]] || return 1
-  [[ "${payload}" != '{not-json' ]] || return 1
-
-  case "${profile}" in
-    workcell-workcell-ac42b1dc)
-      printf 'Stopped\n'
-      ;;
-    workcell-other)
-      printf 'Running\n'
-      ;;
-    *)
-      return 3
-      ;;
-  esac
+  ensure_go_run_env
+  host_go_bin="$(resolve_go_bin)"
+  (
+    cd "${ROOT_DIR}" &&
+      env -i \
+        PATH="${TRUSTED_HOST_PATH}" \
+        HOME=/tmp \
+        LC_ALL=C \
+        LANG=C \
+        GOPATH="${GOPATH}" \
+        GOMODCACHE="${GOMODCACHE}" \
+        GOCACHE="${GOCACHE}" \
+        "${host_go_bin}" run ./cmd/workcell-hostutil "$@"
+  )
 }
 
 run_host_colima() {
@@ -4158,7 +4188,7 @@ if [[ -n "$(maybe_reap_stale_profile_processes workcell-parse-failure)" ]]; then
   exit 1
 fi
 EOF
-} >"${COLIMA_PROFILE_STATUS_HARNESS}"
+} | sed "s|__ROOT_DIR__|${ROOT_DIR}|g" >"${COLIMA_PROFILE_STATUS_HARNESS}"
 /bin/bash "${COLIMA_PROFILE_STATUS_HARNESS}"
 rm -f "${COLIMA_PROFILE_STATUS_HARNESS}"
 if ! "${ROOT_DIR}/scripts/workcell" \
@@ -4228,6 +4258,7 @@ fi
 PREMERGE_HARNESS_ROOT="${BARRIER_VERIFY_ROOT}/premerge-harness"
 PREMERGE_FAKEBIN="${PREMERGE_HARNESS_ROOT}/fakebin"
 PREMERGE_LOG="${PREMERGE_HARNESS_ROOT}/premerge.log"
+PREMERGE_DEFAULT_SNAPSHOT_PARENT="$(dirname "${PREMERGE_HARNESS_ROOT}")"
 rm -rf "${PREMERGE_HARNESS_ROOT}"
 mkdir -p "${PREMERGE_HARNESS_ROOT}/scripts" "${PREMERGE_HARNESS_ROOT}/tools/validator" "${PREMERGE_FAKEBIN}"
 install -m 0755 "${ROOT_DIR}/scripts/pre-merge.sh" "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh"
@@ -4235,6 +4266,7 @@ cat >"${PREMERGE_HARNESS_ROOT}/scripts/with-validation-snapshot.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'with-validation-snapshot.sh %s\n' "$*" >>"${PREMERGE_LOG}"
+printf 'WORKCELL_VALIDATION_SNAPSHOT_PARENT=%s\n' "${WORKCELL_VALIDATION_SNAPSHOT_PARENT-}" >>"${PREMERGE_LOG}"
 while [[ $# -gt 0 ]]; do
   if [[ "$1" == "--" ]]; then
     shift
@@ -4367,6 +4399,7 @@ if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
   exit 1
 fi
 grep -q 'local validation will run from snapshot (head).' /tmp/workcell-premerge-local-snapshot.out
+grep -q "WORKCELL_VALIDATION_SNAPSHOT_PARENT=${PREMERGE_DEFAULT_SNAPSHOT_PARENT}" "${PREMERGE_LOG}"
 grep -q 'check-pinned-inputs.sh ' "${PREMERGE_LOG}"
 
 : >"${PREMERGE_LOG}"
@@ -4434,6 +4467,7 @@ if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
   PREMERGE_LOG="${PREMERGE_LOG}" \
   WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
   WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
+  WORKCELL_VALIDATION_SNAPSHOT_PARENT='relative-snapshots' \
   WORKCELL_PREMERGE_REPRO_PLATFORMS='linux/arm64' \
   "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
   --local-snapshot worktree \
@@ -4444,6 +4478,7 @@ if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
 fi
 grep -q 'local validation will run from snapshot (worktree).' /tmp/workcell-premerge-local-snapshot.out
 grep -q 'with-validation-snapshot.sh --repo ' "${PREMERGE_LOG}"
+grep -q "WORKCELL_VALIDATION_SNAPSHOT_PARENT=${PREMERGE_HARNESS_ROOT}/relative-snapshots" "${PREMERGE_LOG}"
 grep -q -- '--mode worktree --include-untracked -- env WORKCELL_PREMERGE_LOCAL_SNAPSHOT_ACTIVE=1 ./scripts/pre-merge.sh --local-snapshot worktree --local-include-untracked' "${PREMERGE_LOG}"
 grep -q 'check-pinned-inputs.sh ' "${PREMERGE_LOG}"
 grep -q 'verify-reproducible-build.sh ' "${PREMERGE_LOG}"
@@ -4819,6 +4854,52 @@ fi
 grep -q '"tracked": true' "${MASK_SNAPSHOT_ROOT}/dirs/.claude/settings.json"
 chmod -R u+w "${MASK_SNAPSHOT_ROOT}" 2>/dev/null || true
 rm -rf "${MASK_SNAPSHOT_ROOT}"
+
+CONFLICT_SHADOW_REPO="${BARRIER_VERIFY_ROOT}/conflict-shadow-repo"
+git init -q "${CONFLICT_SHADOW_REPO}"
+git -C "${CONFLICT_SHADOW_REPO}" config user.name "Workcell Verify"
+git -C "${CONFLICT_SHADOW_REPO}" config user.email "workcell-verify@example.com"
+mkdir -p "${CONFLICT_SHADOW_REPO}/.claude"
+cat <<'EOF' >"${CONFLICT_SHADOW_REPO}/.claude/settings.json"
+{"value":"base"}
+EOF
+git -C "${CONFLICT_SHADOW_REPO}" add .claude/settings.json
+git -C "${CONFLICT_SHADOW_REPO}" commit -q -m init
+git -C "${CONFLICT_SHADOW_REPO}" checkout -q -b other
+cat <<'EOF' >"${CONFLICT_SHADOW_REPO}/.claude/settings.json"
+{"value":"other"}
+EOF
+git -C "${CONFLICT_SHADOW_REPO}" commit -q -am other
+git -C "${CONFLICT_SHADOW_REPO}" checkout -q master
+cat <<'EOF' >"${CONFLICT_SHADOW_REPO}/.claude/settings.json"
+{"value":"master"}
+EOF
+git -C "${CONFLICT_SHADOW_REPO}" commit -q -am master
+if git -C "${CONFLICT_SHADOW_REPO}" merge other >/tmp/workcell-conflict-shadow-merge.out 2>&1; then
+  echo "Expected conflict-shadow fixture merge to leave unresolved index stages" >&2
+  exit 1
+fi
+CONFLICT_SHADOW_OUTPUT="$("${ROOT_DIR}/scripts/workcell" \
+  --self-staging-probe \
+  codex \
+  "${CONFLICT_SHADOW_REPO}" \
+  "${AUTH_STATUS_ROOT}/policy.toml" \
+  strict \
+  0 \
+  1)"
+CONFLICT_SHADOW_ROOT="$(printf '%s\n' "${CONFLICT_SHADOW_OUTPUT}" | sed -n 's/^shadow_root=//p' | head -n1)"
+if [[ -z "${CONFLICT_SHADOW_ROOT}" ]] || [[ ! -d "${CONFLICT_SHADOW_ROOT}" ]]; then
+  echo "Expected conflicted shadow staging probe to expose a shadow root" >&2
+  printf '%s\n' "${CONFLICT_SHADOW_OUTPUT}" >&2
+  exit 1
+fi
+if [[ -e "${CONFLICT_SHADOW_ROOT}/dirs/.claude/settings.json" ]]; then
+  echo "Expected unresolved git index entries to be excluded from the control-plane shadow without leaking stage 1/2/3 blobs" >&2
+  cat "${CONFLICT_SHADOW_ROOT}/dirs/.claude/settings.json" >&2
+  exit 1
+fi
+chmod -R u+w "${CONFLICT_SHADOW_ROOT}" 2>/dev/null || true
+rm -rf "${CONFLICT_SHADOW_ROOT}"
 
 mkdir -p "${MASK_VERIFY_WORKSPACE}/symlinked"
 ln -s "${REAL_HOME}/.ssh/config" "${MASK_VERIFY_WORKSPACE}/symlinked/GEMINI.md"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -77,6 +77,7 @@ require_tool jq
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
 HOST_GATE_SCRIPTS=(
+  "${ROOT_DIR}/scripts/build-and-test.sh"
   "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
   "${ROOT_DIR}/scripts/container-smoke.sh"
   "${ROOT_DIR}/scripts/generate-build-input-manifest.sh"
@@ -2778,7 +2779,7 @@ if PATH="${DOCKER_CONTEXT_SELECTOR_FAKEBIN}:${PATH}" \
   HOME=/tmp \
   ROOT_DIR="${ROOT_DIR}" \
   BARRIER_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}" \
-  /bin/bash -lc '
+  /bin/bash -c '
     set -euo pipefail
     source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
     export DOCKER_CONTEXT_NAME=colima
@@ -2797,7 +2798,7 @@ selected_context="$(
   HOME=/tmp \
   ROOT_DIR="${ROOT_DIR}" \
   BARRIER_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}" \
-  /bin/bash -lc '
+  /bin/bash -c '
     set -euo pipefail
     source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
     unset DOCKER_CONTEXT_NAME
@@ -2819,7 +2820,7 @@ fallback_context="$(
     HOME=/tmp \
     ROOT_DIR="${ROOT_DIR}" \
     BARRIER_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}" \
-    /bin/bash -lc '
+    /bin/bash -c '
       set -euo pipefail
       source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
       unset DOCKER_CONTEXT_NAME
@@ -2883,7 +2884,7 @@ printf '%s\n' "$PWD"
 EOS
 chmod 0755 "${FAKE_DOCKER_BIN}/docker"
 
-ROOT_DIR="${ROOT_DIR}" PATH="${FAKE_DOCKER_BIN}:${PATH}" HOME=/tmp /bin/bash -lc '
+ROOT_DIR="${ROOT_DIR}" PATH="${FAKE_DOCKER_BIN}:${PATH}" HOME=/tmp /bin/bash -c '
   set -euo pipefail
   source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
   export HOME="${BARRIER_VERIFY_ROOT}/docker-client-home"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1,5 +1,15 @@
-#!/usr/bin/env -S BASH_ENV= ENV= bash
+#!/bin/bash -p
 # shellcheck shell=bash
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+if [[ "${WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
+  exec /usr/bin/env -i \
+    PATH="${TRUSTED_HOST_PATH}" \
+    HOME="${HOME:-/tmp}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT=1 \
+    /bin/bash -p "$0" "$@"
+fi
+unset BASH_ENV ENV
 set -Eeuo pipefail
 
 report_verify_invariants_failure() {
@@ -62,7 +72,6 @@ free_bytes_for_path() {
   /bin/df -Pk "${target_path}" | awk 'NR==2 {print $4 * 1024}'
 }
 
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 export PATH="${TRUSTED_HOST_PATH}"
 require_tool() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -4258,9 +4267,14 @@ fi
 PREMERGE_HARNESS_ROOT="${BARRIER_VERIFY_ROOT}/premerge-harness"
 PREMERGE_FAKEBIN="${PREMERGE_HARNESS_ROOT}/fakebin"
 PREMERGE_LOG="${PREMERGE_HARNESS_ROOT}/premerge.log"
-PREMERGE_DEFAULT_SNAPSHOT_PARENT="$(dirname "${PREMERGE_HARNESS_ROOT}")"
+PREMERGE_DEFAULT_HOME="${PREMERGE_HARNESS_ROOT}/home"
+if [[ "${OSTYPE:-}" == darwin* ]]; then
+  PREMERGE_DEFAULT_SNAPSHOT_PARENT="${PREMERGE_DEFAULT_HOME}/Library/Caches/workcell-validation-snapshots"
+else
+  PREMERGE_DEFAULT_SNAPSHOT_PARENT="${PREMERGE_DEFAULT_HOME}/.cache/workcell-validation-snapshots"
+fi
 rm -rf "${PREMERGE_HARNESS_ROOT}"
-mkdir -p "${PREMERGE_HARNESS_ROOT}/scripts" "${PREMERGE_HARNESS_ROOT}/tools/validator" "${PREMERGE_FAKEBIN}"
+mkdir -p "${PREMERGE_HARNESS_ROOT}/scripts" "${PREMERGE_HARNESS_ROOT}/tools/validator" "${PREMERGE_FAKEBIN}" "${PREMERGE_DEFAULT_HOME}"
 install -m 0755 "${ROOT_DIR}/scripts/pre-merge.sh" "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh"
 cat >"${PREMERGE_HARNESS_ROOT}/scripts/with-validation-snapshot.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -4389,9 +4403,12 @@ grep -q -- '--local-include-untracked requires --local-snapshot worktree.' /tmp/
 
 : >"${PREMERGE_LOG}"
 if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
+  HOME="${PREMERGE_DEFAULT_HOME}" \
+  XDG_CACHE_HOME='' \
   PREMERGE_LOG="${PREMERGE_LOG}" \
   WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
   WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
+  WORKCELL_VALIDATION_SNAPSHOT_PARENT='' \
   "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
   --local-snapshot head >/tmp/workcell-premerge-local-snapshot.out 2>&1; then
   echo "Expected --local-snapshot head pre-merge harness to succeed on a dirty worktree" >&2

--- a/scripts/verify-release-bundle.sh
+++ b/scripts/verify-release-bundle.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
   exec /usr/bin/env -i \
     BUILDX_BUILDER="${BUILDX_BUILDER-}" \

--- a/scripts/verify-reproducible-build.sh
+++ b/scripts/verify-reproducible-build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
   exec /usr/bin/env -i \
     BUILDX_BUILDER="${BUILDX_BUILDER-}" \
@@ -58,17 +58,6 @@ docker_cmd() {
     docker "$@"
   fi
 }
-
-if [[ "${1:-}" == "--self-docker-probe" ]]; then
-  require_tool docker
-  setup_workcell_trusted_docker_client
-  if [[ -n "${DOCKER_CONTEXT_NAME:-}" ]]; then
-    select_docker_context
-  fi
-  buildx_cmd version >/dev/null
-  echo "verify-reproducible-build-docker-probe-ok"
-  exit 0
-fi
 
 build_oci_layout() {
   local platforms="$1"
@@ -129,6 +118,15 @@ cleanup() {
 
 trap cleanup EXIT
 
+if [[ "${1:-}" == "--self-docker-probe" ]]; then
+  require_tool docker
+  setup_workcell_trusted_docker_client
+  select_docker_context
+  buildx_cmd version >/dev/null
+  echo "verify-reproducible-build-docker-probe-ok"
+  exit 0
+fi
+
 require_tool docker
 require_tool go
 setup_workcell_trusted_docker_client
@@ -153,7 +151,7 @@ REPRO_REFERENCE_MANIFEST="${OCI_EXPORT_ROOT}/reference.json"
 case "${REPRO_BUILD_MODE}" in
   parallel)
     build_oci_layout_pair "${REPRO_PLATFORMS}" "${OCI_EXPORT_A}" "${OCI_EXPORT_B}"
-    (cd "${ROOT_DIR}" && go run ./cmd/workcell-metadatautil generate-reproducible-build-manifest "${OCI_EXPORT_A}" "${REPRO_PLATFORMS}" "${REPRO_REFERENCE_MANIFEST}" "${SOURCE_DATE_EPOCH}")
+    (cd "${ROOT_DIR}" && go run ./cmd/workcell-metadatautil verify-reproducible-build "${OCI_EXPORT_A}" "${OCI_EXPORT_B}" "${REPRO_PLATFORMS}" "${REPRO_MANIFEST_PATH}" "${SOURCE_DATE_EPOCH}")
     ;;
   serial)
     build_oci_layout "${REPRO_PLATFORMS}" "${OCI_EXPORT_A}"
@@ -162,17 +160,16 @@ case "${REPRO_BUILD_MODE}" in
     OCI_EXPORT_A=""
     prune_repro_builder_cache
     build_oci_layout "${REPRO_PLATFORMS}" "${OCI_EXPORT_B}"
+    (cd "${ROOT_DIR}" && go run ./cmd/workcell-metadatautil verify-reproducible-build-manifest "${OCI_EXPORT_B}" "${REPRO_PLATFORMS}" "${REPRO_REFERENCE_MANIFEST}")
+    if [[ -n "${REPRO_MANIFEST_PATH}" ]]; then
+      mkdir -p "$(dirname "${REPRO_MANIFEST_PATH}")"
+      cp "${REPRO_REFERENCE_MANIFEST}" "${REPRO_MANIFEST_PATH}"
+    fi
     ;;
   *)
     echo "Unsupported WORKCELL_REPRO_BUILD_MODE: ${REPRO_BUILD_MODE}" >&2
     exit 2
     ;;
 esac
-
-(cd "${ROOT_DIR}" && go run ./cmd/workcell-metadatautil verify-reproducible-build-manifest "${OCI_EXPORT_B}" "${REPRO_PLATFORMS}" "${REPRO_REFERENCE_MANIFEST}")
-if [[ -n "${REPRO_MANIFEST_PATH}" ]]; then
-  mkdir -p "$(dirname "${REPRO_MANIFEST_PATH}")"
-  cp "${REPRO_REFERENCE_MANIFEST}" "${REPRO_MANIFEST_PATH}"
-fi
 
 echo "Workcell reproducible build verification passed."

--- a/scripts/verify-upstream-claude-release.sh
+++ b/scripts/verify-upstream-claude-release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
   exec /usr/bin/env -i \
     PATH="${TRUSTED_HOST_PATH}" \

--- a/scripts/verify-upstream-codex-release.sh
+++ b/scripts/verify-upstream-codex-release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
   exec /usr/bin/env -i \
     PATH="${TRUSTED_HOST_PATH}" \

--- a/scripts/with-validation-snapshot.sh
+++ b/scripts/with-validation-snapshot.sh
@@ -277,8 +277,8 @@ SNAPSHOT_PARENT="${WORKCELL_VALIDATION_SNAPSHOT_PARENT:-$(dirname "${REPO_ROOT}"
 SNAPSHOT_PARENT="$(cd "${SNAPSHOT_PARENT}" && pwd)" || die "Snapshot parent does not exist: ${SNAPSHOT_PARENT}"
 SNAPSHOT_DIR="$(mktemp -d "${SNAPSHOT_PARENT}/workcell-validation-snapshot.XXXXXX")"
 # Clone without checkout so repository-controlled smudge/clean filters in
-# .gitattributes cannot execute during snapshot creation.  All modes
-# materialize tracked content via cat-file blob in overlay_index_state.
+# .gitattributes cannot execute during snapshot creation.  Each mode
+# materializes tracked content via cat-file blob in its overlay function.
 git clone -q --no-hardlinks --no-checkout "${REPO_ROOT}" "${SNAPSHOT_DIR}"
 
 case "${SNAPSHOT_MODE}" in

--- a/scripts/with-validation-snapshot.sh
+++ b/scripts/with-validation-snapshot.sh
@@ -34,6 +34,48 @@ require_tool() {
   command -v "$1" >/dev/null 2>&1 || die "Missing required tool: $1"
 }
 
+populate_snapshot_head_index() {
+  git -C "${SNAPSHOT_DIR}" read-tree HEAD >/dev/null 2>&1 ||
+    die "with-validation-snapshot: failed to populate HEAD index in snapshot"
+}
+
+populate_snapshot_index_from_source() {
+  local source_git_dir=""
+  local snapshot_git_dir=""
+  local shared_index=""
+
+  source_git_dir="$(git -C "${REPO_ROOT}" rev-parse --absolute-git-dir)" ||
+    die "with-validation-snapshot: failed to resolve source git dir"
+  snapshot_git_dir="$(git -C "${SNAPSHOT_DIR}" rev-parse --absolute-git-dir)" ||
+    die "with-validation-snapshot: failed to resolve snapshot git dir"
+  cp -p "${source_git_dir}/index" "${snapshot_git_dir}/index" ||
+    die "with-validation-snapshot: failed to copy source index into snapshot"
+  while IFS= read -r shared_index; do
+    cp -p "${shared_index}" "${snapshot_git_dir}/$(basename "${shared_index}")" ||
+      die "with-validation-snapshot: failed to copy shared index into snapshot"
+  done < <(find "${source_git_dir}" -maxdepth 1 -type f -name 'sharedindex.*' -print)
+}
+
+path_exists_in_head() {
+  local tracked_path="$1"
+
+  IFS= read -r -d '' _ < <(
+    GIT_LITERAL_PATHSPECS=1 git -C "${REPO_ROOT}" ls-tree -r -z --name-only HEAD -- "${tracked_path}"
+  )
+}
+
+path_is_intent_to_add() {
+  local tracked_path="$1"
+
+  if path_exists_in_head "${tracked_path}"; then
+    return 1
+  fi
+  if GIT_LITERAL_PATHSPECS=1 git -C "${REPO_ROOT}" diff --cached --quiet -- "${tracked_path}"; then
+    return 0
+  fi
+  return 1
+}
+
 copy_path_into_snapshot() {
   local relative_path="$1"
   local source_path="${REPO_ROOT}/${relative_path}"
@@ -168,6 +210,9 @@ overlay_index_state() {
     stage="${remainder##* }"
     [[ "${stage}" == "0" ]] || continue
 
+    if path_is_intent_to_add "${tracked_path}"; then
+      continue
+    fi
     materialize_tracked_entry "${mode}" "${oid}" "${tracked_path}" "git index"
   done < <(git -C "${REPO_ROOT}" ls-files -z --stage)
 }
@@ -263,7 +308,7 @@ git -C "${REPO_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
 REPO_ROOT="$(git -C "${REPO_ROOT}" rev-parse --show-toplevel)"
 
 SNAPSHOT_PARENT="${WORKCELL_VALIDATION_SNAPSHOT_PARENT:-$(dirname "${REPO_ROOT}")}"
-SNAPSHOT_PARENT="$(cd "${SNAPSHOT_PARENT}" && pwd)" || die "Snapshot parent does not exist: ${SNAPSHOT_PARENT}"
+SNAPSHOT_PARENT="$(cd "${SNAPSHOT_PARENT}" && pwd -P)" || die "Snapshot parent does not exist: ${SNAPSHOT_PARENT}"
 SNAPSHOT_DIR="$(mktemp -d "${SNAPSHOT_PARENT}/workcell-validation-snapshot.XXXXXX")"
 # Clone without checkout so repository-controlled smudge/clean filters in
 # .gitattributes cannot execute during snapshot creation.  Each mode
@@ -272,12 +317,15 @@ git clone -q --no-hardlinks --no-checkout "${REPO_ROOT}" "${SNAPSHOT_DIR}"
 
 case "${SNAPSHOT_MODE}" in
   head)
+    populate_snapshot_head_index
     overlay_head_state
     ;;
   index)
+    populate_snapshot_index_from_source
     overlay_index_state
     ;;
   worktree)
+    populate_snapshot_index_from_source
     overlay_index_state
     overlay_worktree_state
     ;;

--- a/scripts/with-validation-snapshot.sh
+++ b/scripts/with-validation-snapshot.sh
@@ -54,13 +54,133 @@ remove_path_from_snapshot() {
   rm -rf "${target_path}"
 }
 
+overlay_head_state() {
+  local entry=""
+  local metadata=""
+  local mode=""
+  local obj_type=""
+  local oid=""
+  local tracked_path=""
+  local dest=""
+  local install_mode=""
+
+  # Materialize HEAD's committed tree via cat-file to bypass smudge/clean
+  # filters.  Uses git ls-tree which outputs: <mode> <type> <oid>\t<path>\0
+  while IFS= read -r -d '' entry; do
+    metadata="${entry%%$'\t'*}"
+    tracked_path="${entry#*$'\t'}"
+    mode="${metadata%% *}"
+    local remainder="${metadata#* }"
+    obj_type="${remainder%% *}"
+    oid="${remainder##* }"
+
+    [[ "${obj_type}" == "blob" ]] || continue
+
+    case "${mode}" in
+      100644) install_mode="0644" ;;
+      100755) install_mode="0755" ;;
+      120000)
+        echo "with-validation-snapshot: skipping symlink in HEAD tree: ${tracked_path}" >&2
+        continue
+        ;;
+      *)
+        echo "with-validation-snapshot: skipping unsupported mode ${mode} in HEAD tree: ${tracked_path}" >&2
+        continue
+        ;;
+    esac
+
+    case "${tracked_path}" in
+      '' | . | .. | ./* | /* | */../* | ../* | */..)
+        echo "with-validation-snapshot: unsafe path in HEAD tree rejected: ${tracked_path}" >&2
+        continue
+        ;;
+    esac
+
+    if [[ ${#oid} -lt 40 ]] || [[ ! "${oid}" =~ ^[0-9a-f]+$ ]]; then
+      echo "with-validation-snapshot: malformed OID in HEAD tree: ${oid}" >&2
+      continue
+    fi
+
+    dest="${SNAPSHOT_DIR}/${tracked_path}"
+    if [[ -d "${dest}" ]]; then
+      rm -rf "${dest}"
+    fi
+    mkdir -p "$(dirname "${dest}")"
+    if ! git -C "${REPO_ROOT}" cat-file blob "${oid}" >"${dest}"; then
+      echo "with-validation-snapshot: failed to read blob ${oid} for path: ${tracked_path}" >&2
+      rm -f "${dest}"
+      continue
+    fi
+    chmod "${install_mode}" "${dest}" 2>/dev/null || true
+  done < <(git -C "${REPO_ROOT}" ls-tree -r -z HEAD)
+}
+
 overlay_index_state() {
   local tracked_path=""
+  local entry=""
+  local metadata=""
+  local mode=""
+  local oid=""
+  local remainder=""
+  local stage=""
+  local dest=""
+  local install_mode=""
 
   while IFS= read -r -d '' tracked_path; do
     remove_path_from_snapshot "${tracked_path}"
   done < <(git -C "${SNAPSHOT_DIR}" ls-files -z)
-  git -C "${REPO_ROOT}" checkout-index -a -f --prefix="${SNAPSHOT_DIR}/"
+
+  # Materialize each tracked blob via cat-file to bypass smudge/clean filters
+  # that a malicious .gitattributes could use for code execution.  Only regular
+  # file modes (100644, 100755) are materialized; symlinks and submodules are
+  # intentionally skipped since the validation snapshot does not need them.
+  while IFS= read -r -d '' entry; do
+    metadata="${entry%%$'\t'*}"
+    tracked_path="${entry#*$'\t'}"
+    mode="${metadata%% *}"
+    remainder="${metadata#* }"
+    oid="${remainder%% *}"
+    stage="${remainder##* }"
+    [[ "${stage}" == "0" ]] || continue
+
+    case "${mode}" in
+      100644) install_mode="0644" ;;
+      100755) install_mode="0755" ;;
+      120000)
+        echo "with-validation-snapshot: skipping symlink in git index: ${tracked_path}" >&2
+        continue
+        ;;
+      *)
+        echo "with-validation-snapshot: skipping unsupported mode ${mode} in git index: ${tracked_path}" >&2
+        continue
+        ;;
+    esac
+
+    # Reject paths that could escape SNAPSHOT_DIR
+    case "${tracked_path}" in
+      '' | . | .. | ./* | /* | */../* | ../* | */..)
+        echo "with-validation-snapshot: unsafe path in git index rejected: ${tracked_path}" >&2
+        continue
+        ;;
+    esac
+
+    if [[ ${#oid} -lt 40 ]] || [[ ! "${oid}" =~ ^[0-9a-f]+$ ]]; then
+      echo "with-validation-snapshot: malformed OID in git index: ${oid}" >&2
+      continue
+    fi
+
+    dest="${SNAPSHOT_DIR}/${tracked_path}"
+    if [[ -d "${dest}" ]]; then
+      rm -rf "${dest}"
+    fi
+    mkdir -p "$(dirname "${dest}")"
+    if ! git -C "${REPO_ROOT}" cat-file blob "${oid}" >"${dest}"; then
+      echo "with-validation-snapshot: failed to read blob ${oid} for path: ${tracked_path}" >&2
+      rm -f "${dest}"
+      continue
+    fi
+    chmod "${install_mode}" "${dest}" 2>/dev/null || true
+  done < <(git -C "${REPO_ROOT}" ls-files -z --stage)
 }
 
 overlay_worktree_state() {
@@ -156,11 +276,15 @@ REPO_ROOT="$(git -C "${REPO_ROOT}" rev-parse --show-toplevel)"
 SNAPSHOT_PARENT="${WORKCELL_VALIDATION_SNAPSHOT_PARENT:-$(dirname "${REPO_ROOT}")}"
 SNAPSHOT_PARENT="$(cd "${SNAPSHOT_PARENT}" && pwd)" || die "Snapshot parent does not exist: ${SNAPSHOT_PARENT}"
 SNAPSHOT_DIR="$(mktemp -d "${SNAPSHOT_PARENT}/workcell-validation-snapshot.XXXXXX")"
-rm -rf "${SNAPSHOT_DIR}"
-git clone -q --no-hardlinks "${REPO_ROOT}" "${SNAPSHOT_DIR}"
-git -C "${SNAPSHOT_DIR}" checkout -q --detach HEAD
+# Clone without checkout so repository-controlled smudge/clean filters in
+# .gitattributes cannot execute during snapshot creation.  All modes
+# materialize tracked content via cat-file blob in overlay_index_state.
+git clone -q --no-hardlinks --no-checkout "${REPO_ROOT}" "${SNAPSHOT_DIR}"
 
 case "${SNAPSHOT_MODE}" in
+  head)
+    overlay_head_state
+    ;;
   index)
     overlay_index_state
     ;;

--- a/scripts/with-validation-snapshot.sh
+++ b/scripts/with-validation-snapshot.sh
@@ -54,6 +54,71 @@ remove_path_from_snapshot() {
   rm -rf "${target_path}"
 }
 
+validate_tracked_path() {
+  local tracked_path="$1"
+  local label="$2"
+
+  case "${tracked_path}" in
+    '' | . | .. | ./* | /* | */../* | ../* | */..)
+      die "with-validation-snapshot: unsafe path in ${label} rejected: ${tracked_path}"
+      ;;
+  esac
+}
+
+validate_blob_oid() {
+  local oid="$1"
+  local label="$2"
+
+  if [[ ${#oid} -lt 40 ]] || [[ ! "${oid}" =~ ^[0-9a-f]+$ ]]; then
+    die "with-validation-snapshot: malformed OID in ${label}: ${oid}"
+  fi
+}
+
+materialize_tracked_entry() {
+  local mode="$1"
+  local oid="$2"
+  local tracked_path="$3"
+  local label="$4"
+  local dest="${SNAPSHOT_DIR}/${tracked_path}"
+  local install_mode=""
+  local link_target=""
+
+  validate_tracked_path "${tracked_path}" "${label}"
+  validate_blob_oid "${oid}" "${label}"
+
+  case "${mode}" in
+    100644)
+      install_mode="0644"
+      ;;
+    100755)
+      install_mode="0755"
+      ;;
+    120000)
+      rm -rf "${dest}"
+      mkdir -p "$(dirname "${dest}")"
+      if ! IFS= read -r -d '' link_target < <(git -C "${REPO_ROOT}" cat-file blob "${oid}" && printf '\0'); then
+        die "with-validation-snapshot: failed to read symlink blob ${oid} for path: ${tracked_path}"
+      fi
+      ln -s "${link_target}" "${dest}"
+      return 0
+      ;;
+    *)
+      echo "with-validation-snapshot: skipping unsupported mode ${mode} in ${label}: ${tracked_path}" >&2
+      return 0
+      ;;
+  esac
+
+  if [[ -d "${dest}" ]]; then
+    rm -rf "${dest}"
+  fi
+  mkdir -p "$(dirname "${dest}")"
+  if ! git -C "${REPO_ROOT}" cat-file blob "${oid}" >"${dest}"; then
+    rm -f "${dest}"
+    die "with-validation-snapshot: failed to read blob ${oid} for path: ${tracked_path}"
+  fi
+  chmod "${install_mode}" "${dest}" 2>/dev/null || true
+}
+
 overlay_head_state() {
   local entry=""
   local metadata=""
@@ -76,42 +141,7 @@ overlay_head_state() {
 
     [[ "${obj_type}" == "blob" ]] || continue
 
-    case "${mode}" in
-      100644) install_mode="0644" ;;
-      100755) install_mode="0755" ;;
-      120000)
-        echo "with-validation-snapshot: skipping symlink in HEAD tree: ${tracked_path}" >&2
-        continue
-        ;;
-      *)
-        echo "with-validation-snapshot: skipping unsupported mode ${mode} in HEAD tree: ${tracked_path}" >&2
-        continue
-        ;;
-    esac
-
-    case "${tracked_path}" in
-      '' | . | .. | ./* | /* | */../* | ../* | */..)
-        echo "with-validation-snapshot: unsafe path in HEAD tree rejected: ${tracked_path}" >&2
-        continue
-        ;;
-    esac
-
-    if [[ ${#oid} -lt 40 ]] || [[ ! "${oid}" =~ ^[0-9a-f]+$ ]]; then
-      echo "with-validation-snapshot: malformed OID in HEAD tree: ${oid}" >&2
-      continue
-    fi
-
-    dest="${SNAPSHOT_DIR}/${tracked_path}"
-    if [[ -d "${dest}" ]]; then
-      rm -rf "${dest}"
-    fi
-    mkdir -p "$(dirname "${dest}")"
-    if ! git -C "${REPO_ROOT}" cat-file blob "${oid}" >"${dest}"; then
-      echo "with-validation-snapshot: failed to read blob ${oid} for path: ${tracked_path}" >&2
-      rm -f "${dest}"
-      continue
-    fi
-    chmod "${install_mode}" "${dest}" 2>/dev/null || true
+    materialize_tracked_entry "${mode}" "${oid}" "${tracked_path}" "HEAD tree"
   done < <(git -C "${REPO_ROOT}" ls-tree -r -z HEAD)
 }
 
@@ -123,17 +153,12 @@ overlay_index_state() {
   local oid=""
   local remainder=""
   local stage=""
-  local dest=""
-  local install_mode=""
-
   while IFS= read -r -d '' tracked_path; do
     remove_path_from_snapshot "${tracked_path}"
   done < <(git -C "${SNAPSHOT_DIR}" ls-files -z)
 
   # Materialize each tracked blob via cat-file to bypass smudge/clean filters
-  # that a malicious .gitattributes could use for code execution.  Only regular
-  # file modes (100644, 100755) are materialized; symlinks and submodules are
-  # intentionally skipped since the validation snapshot does not need them.
+  # that a malicious .gitattributes could use for code execution.
   while IFS= read -r -d '' entry; do
     metadata="${entry%%$'\t'*}"
     tracked_path="${entry#*$'\t'}"
@@ -143,43 +168,7 @@ overlay_index_state() {
     stage="${remainder##* }"
     [[ "${stage}" == "0" ]] || continue
 
-    case "${mode}" in
-      100644) install_mode="0644" ;;
-      100755) install_mode="0755" ;;
-      120000)
-        echo "with-validation-snapshot: skipping symlink in git index: ${tracked_path}" >&2
-        continue
-        ;;
-      *)
-        echo "with-validation-snapshot: skipping unsupported mode ${mode} in git index: ${tracked_path}" >&2
-        continue
-        ;;
-    esac
-
-    # Reject paths that could escape SNAPSHOT_DIR
-    case "${tracked_path}" in
-      '' | . | .. | ./* | /* | */../* | ../* | */..)
-        echo "with-validation-snapshot: unsafe path in git index rejected: ${tracked_path}" >&2
-        continue
-        ;;
-    esac
-
-    if [[ ${#oid} -lt 40 ]] || [[ ! "${oid}" =~ ^[0-9a-f]+$ ]]; then
-      echo "with-validation-snapshot: malformed OID in git index: ${oid}" >&2
-      continue
-    fi
-
-    dest="${SNAPSHOT_DIR}/${tracked_path}"
-    if [[ -d "${dest}" ]]; then
-      rm -rf "${dest}"
-    fi
-    mkdir -p "$(dirname "${dest}")"
-    if ! git -C "${REPO_ROOT}" cat-file blob "${oid}" >"${dest}"; then
-      echo "with-validation-snapshot: failed to read blob ${oid} for path: ${tracked_path}" >&2
-      rm -f "${dest}"
-      continue
-    fi
-    chmod "${install_mode}" "${dest}" 2>/dev/null || true
+    materialize_tracked_entry "${mode}" "${oid}" "${tracked_path}" "git index"
   done < <(git -C "${REPO_ROOT}" ls-files -z --stage)
 }
 

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -519,13 +519,29 @@ run_host_colima_with_timeout() {
 colima_profile_status() {
   local profile="$1"
   local list_output=""
+  local status_output=""
+  local status_error=""
+  local status_error_path=""
 
   if ! list_output="$(run_host_colima list --json 2>/dev/null)"; then
     return 1
   fi
   [[ -n "${list_output}" ]] || return 3
 
-  printf '%s' "${list_output}" | go_hostutil launcher colima-status "${profile}"
+  status_error_path="$(mktemp "${TMPDIR:-/tmp}/workcell-colima-status.XXXXXX")"
+  if status_output="$(printf '%s' "${list_output}" | go_hostutil launcher colima-status "${profile}" 2>"${status_error_path}")"; then
+    rm -f "${status_error_path}"
+    printf '%s\n' "${status_output}"
+    return 0
+  fi
+
+  status_error="$(cat "${status_error_path}" 2>/dev/null || true)"
+  rm -f "${status_error_path}"
+  if printf '%s\n' "${status_error}" | grep -Fq -- 'not found'; then
+    return 3
+  fi
+
+  return 1
 }
 
 profile_process_pids() {
@@ -2120,9 +2136,7 @@ prepare_injection_direct_mounts() {
         ;;
     esac
 
-    entry_hash="$(
-      go_hostutil launcher audit-digest "" "" "${host_source}" "${mount_path}" | cut -c1-16
-    )"
+    entry_hash="$(go_hostutil launcher direct-mount-cache-key "${host_source}" "${mount_path}")"
     staged_source="${staged_root}/${entry_hash}"
     rm -rf "${staged_source}"
     if [[ -d "${host_source}" ]]; then
@@ -2159,6 +2173,11 @@ prepare_injection_bundle() {
     fi
   fi
 
+  bundle_parent="$(default_injection_bundle_parent)"
+  mkdir -p "${bundle_parent}"
+  chmod 0700 "${bundle_parent}" 2>/dev/null || true
+  cleanup_stale_injection_bundles "${bundle_parent}"
+
   if [[ -z "${policy_path}" ]]; then
     INJECTION_POLICY_SHA256=""
     INJECTION_CREDENTIAL_KEYS=""
@@ -2179,10 +2198,6 @@ prepare_injection_bundle() {
     exit 2
   fi
 
-  bundle_parent="$(default_injection_bundle_parent)"
-  mkdir -p "${bundle_parent}"
-  chmod 0700 "${bundle_parent}" 2>/dev/null || true
-  cleanup_stale_injection_bundles "${bundle_parent}"
   INJECTION_BUNDLE_ROOT="$(mktemp -d "${bundle_parent%/}/workcell-injections.XXXXXX")"
   INJECTION_BUNDLE_ROOT="$(resolve_host_path "${INJECTION_BUNDLE_ROOT}")"
   chmod 0700 "${INJECTION_BUNDLE_ROOT}"
@@ -3987,11 +4002,11 @@ git_index_materialize_regular_file() {
   local mode=""
   local oid=""
   local remainder=""
+  local stage=""
   local install_mode=""
+  local found=0
 
   workspace_is_git_worktree "${workspace}" || return 1
-  local stage=""
-  local found=0
   while IFS= read -r -d '' entry; do
     metadata="${entry%%$'\t'*}"
     mode="${metadata%% *}"
@@ -4017,12 +4032,7 @@ git_index_materialize_regular_file() {
     100755)
       install_mode="0755"
       ;;
-    120000)
-      echo "Workcell shadow materialization: skipping symlink: ${relative_path}" >&2
-      return 1
-      ;;
     *)
-      echo "Workcell shadow materialization: skipping unsupported mode ${mode}: ${relative_path}" >&2
       return 1
       ;;
   esac
@@ -4031,8 +4041,8 @@ git_index_materialize_regular_file() {
   # Materialize tracked blobs directly so repo-local checkout filters and other
   # worktree-side behaviors cannot influence host-side control-plane shadowing.
   if ! run_clean_host_command git -C "${workspace}" cat-file blob "${oid}" >"${destination_path}"; then
-    echo "Workcell shadow materialization: failed to read blob ${oid} for path: ${relative_path}" >&2
     rm -f "${destination_path}"
+    echo "Workcell blocked shadow materialization: failed to read tracked blob ${oid} for ${relative_path}" >&2
     return 1
   fi
   chmod "${install_mode}" "${destination_path}" 2>/dev/null || true
@@ -4057,7 +4067,7 @@ git_index_populate_shadow_dir() {
   exec 3<"${tracked_paths_file}"
   while IFS= read -r -d '' tracked_path <&3; do
     case "${tracked_path}" in
-      '' | . | .. | ./* | /* | */../* | ../* | */..)
+      '' | /* | */../* | ../* | */..)
         echo "Workcell blocked control-plane shadow materialization: unsafe path in git index rejected: ${tracked_path}" >&2
         exec 3<&-
         rm -f "${tracked_paths_file}"
@@ -4364,7 +4374,7 @@ prepare_workspace_control_plane_shadow() {
 }
 
 bootstrap_endpoints() {
-  echo "auth.docker.io:443 docker.io:443 index.docker.io:443 registry-1.docker.io:443 production.cloudflare.docker.com:443 docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443 github.com:443 objects.githubusercontent.com:443 release-assets.githubusercontent.com:443 registry.npmjs.org:443 storage.googleapis.com:443 snapshot.debian.org:80"
+  echo "auth.docker.io:443 docker.io:443 index.docker.io:443 registry-1.docker.io:443 production.cloudflare.docker.com:443 docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443 github.com:443 objects.githubusercontent.com:443 release-assets.githubusercontent.com:443 registry.npmjs.org:443 static.rust-lang.org:443 storage.googleapis.com:443 snapshot.debian.org:80"
 }
 
 AGENT=""

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -3990,13 +3990,25 @@ git_index_materialize_regular_file() {
   local install_mode=""
 
   workspace_is_git_worktree "${workspace}" || return 1
-  IFS= read -r -d '' entry < <(run_clean_host_command git -C "${workspace}" ls-files -z --stage -- "${relative_path}") || true
-  [[ -n "${entry}" ]] || return 1
+  local stage=""
+  local found=0
+  while IFS= read -r -d '' entry; do
+    metadata="${entry%%$'\t'*}"
+    mode="${metadata%% *}"
+    remainder="${metadata#* }"
+    oid="${remainder%% *}"
+    stage="${remainder##* }"
+    if [[ "${stage}" == "0" ]]; then
+      found=1
+      break
+    fi
+  done < <(run_clean_host_command git -C "${workspace}" ls-files -z --stage -- "${relative_path}")
+  [[ "${found}" -eq 1 ]] || return 1
 
-  metadata="${entry%%$'\t'*}"
-  mode="${metadata%% *}"
-  remainder="${metadata#* }"
-  oid="${remainder%% *}"
+  if [[ ${#oid} -lt 40 ]] || [[ ! "${oid}" =~ ^[0-9a-f]+$ ]]; then
+    echo "Workcell blocked shadow materialization: malformed OID in git index: ${oid}" >&2
+    return 1
+  fi
 
   case "${mode}" in
     100644)
@@ -4005,7 +4017,12 @@ git_index_materialize_regular_file() {
     100755)
       install_mode="0755"
       ;;
+    120000)
+      echo "Workcell shadow materialization: skipping symlink: ${relative_path}" >&2
+      return 1
+      ;;
     *)
+      echo "Workcell shadow materialization: skipping unsupported mode ${mode}: ${relative_path}" >&2
       return 1
       ;;
   esac
@@ -4013,7 +4030,11 @@ git_index_materialize_regular_file() {
   mkdir -p "$(dirname "${destination_path}")"
   # Materialize tracked blobs directly so repo-local checkout filters and other
   # worktree-side behaviors cannot influence host-side control-plane shadowing.
-  run_clean_host_command git -C "${workspace}" cat-file blob "${oid}" >"${destination_path}"
+  if ! run_clean_host_command git -C "${workspace}" cat-file blob "${oid}" >"${destination_path}"; then
+    echo "Workcell shadow materialization: failed to read blob ${oid} for path: ${relative_path}" >&2
+    rm -f "${destination_path}"
+    return 1
+  fi
   chmod "${install_mode}" "${destination_path}" 2>/dev/null || true
 }
 
@@ -4036,7 +4057,7 @@ git_index_populate_shadow_dir() {
   exec 3<"${tracked_paths_file}"
   while IFS= read -r -d '' tracked_path <&3; do
     case "${tracked_path}" in
-      '' | /* | */../* | ../* | */..)
+      '' | . | .. | ./* | /* | */../* | ../* | */..)
         echo "Workcell blocked control-plane shadow materialization: unsafe path in git index rejected: ${tracked_path}" >&2
         exec 3<&-
         rm -f "${tracked_paths_file}"

--- a/tests/scenarios/shared/test-assurance-dry-run.sh
+++ b/tests/scenarios/shared/test-assurance-dry-run.sh
@@ -72,6 +72,8 @@ for agent in codex claude gemini; do
   grep -q '^workspace_control_plane=unmasked$' "${TMP_DIR}/breakglass-${agent}.stderr"
   grep -q '^network_policy=unrestricted ' "${TMP_DIR}/breakglass-${agent}.stderr"
   grep -q '^execution_path=lower-assurance-breakglass audit_log=' "${TMP_DIR}/breakglass-${agent}.stderr"
+  grep -q '^autonomy_assurance=managed-yolo$' "${TMP_DIR}/breakglass-${agent}.stderr"
+  grep -q '^session_assurance_initial=managed-mutable$' "${TMP_DIR}/breakglass-${agent}.stderr"
 done
 
 for agent in codex claude gemini; do

--- a/workflows/go-porting.md
+++ b/workflows/go-porting.md
@@ -1,0 +1,91 @@
+# Go Porting Workflow
+
+This workflow defines the compatibility-first migration path for replacing
+repo-owned Python with Go on the experimental branch.
+
+## Scope
+
+Tranche 1 covers the bounded helper surface under `scripts/lib/` plus the
+repo-owned Python tests and mutation harness that define current behavior.
+
+Tranche 2 covers the remaining launcher- and invariant-side host utilities that
+still need Go-backed replacements. Track those separately so the shared helper
+migration does not stall on unrelated one-off host-side probes.
+
+## Dependencies
+
+Prefer the Go standard library by default. Treat every non-stdlib dependency
+as a policy exception that needs an explicit written rationale covering:
+
+- why the gap is not practical to solve with stdlib and small local code
+- why the dependency improves safety or compatibility more than it increases
+  supply-chain surface
+- how widely the dependency would spread through the repo
+
+Until a dependency clears that bar, do not add it.
+
+## Team
+
+Use parallel workstreams with explicit ownership:
+
+1. Contract and fixtures
+   Capture CLI contracts, file formats, permissions, and error-path behavior.
+2. Low-coupling tools
+   Port `scenario_manifest`, `extract_direct_mounts`, and `pty_transcript`
+   first to prove the Go CLI and parity harness with minimal blast radius.
+3. Shared policy core
+   Port duplicated parsing, include-merging, path validation, and TOML rendering
+   logic into one Go library before touching the highest-coupling helpers.
+4. Injection pipeline
+   Port `render_injection_bundle` and `resolve_credential_sources` against the
+   shared library rather than independently.
+5. Host auth management
+   Port `manage_injection_policy` only after the shared policy primitives are
+   stable, because it depends on the same selector and validation semantics.
+6. Verification and benchmarks
+   Keep parity gates green, then compare Python and Go implementations for
+   runtime, filesystem behavior, and operator-facing output.
+
+## Order Of Operations
+
+1. Freeze the Python baseline with unit, mutation, and coverage checks.
+2. Add Go parity tests that compare future Go helpers against the current
+   Python outputs on the same fixtures.
+3. Port the low-coupling helpers first to validate the Go module layout and
+   the parity harness on small surfaces.
+4. Port the shared policy and injection cluster as a unit to avoid duplicated
+   parsing drift.
+5. Replace call sites only after the Go entrypoint has parity coverage and the
+   current Python tests pass against the new implementation.
+6. Remove Python from validation scripts last, after the helper cutover is
+   complete and remaining inline snippets are either ported or explicitly
+   deferred.
+
+## Compatibility Gates
+
+Every helper cutover should preserve:
+
+- CLI flags and exit status semantics
+- JSON and TOML output shape
+- deterministic ordering where current tests rely on it
+- file modes for secrets and staged outputs
+- path validation and symlink rejection behavior
+- mutation-test resistance for security-sensitive branches
+
+## Local Validation
+
+Use the bounded baseline script before and after each porting step:
+
+```bash
+./scripts/go-port-validate.sh
+```
+
+For non-functional comparison, benchmark only fixture-driven helpers with stable
+inputs and compare:
+
+- wall-clock runtime
+- peak memory where practical
+- bytes written and file mode outcomes
+
+Do not switch shell entrypoints to Go until the compatibility harness proves the
+new helper is a drop-in replacement.

--- a/workflows/python-to-go-migration.md
+++ b/workflows/python-to-go-migration.md
@@ -1,0 +1,113 @@
+# Python To Go Migration Workflow
+
+Use this workflow when porting repo-owned Python helpers to Go.
+
+## Goal
+
+Replace Python helper implementations without weakening the Workcell runtime
+boundary, broadening parser behavior, or creating compatibility drift at the
+shell/runtime boundary.
+
+## Design order
+
+Optimize in this order:
+
+1. Compatibility with current Python behavior
+2. Simplicity
+3. Security invariant preservation
+4. Performance
+5. Idiomatic correctness
+
+That order applies only after the current boundary and assurance model stay
+intact.
+
+## Dependencies
+
+Default to the Go standard library. Any non-stdlib dependency needs an explicit
+written rationale that explains why it is unavoidable, why a small local
+implementation is worse, and why the added supply-chain surface is justified.
+
+## Migration sequence
+
+### 1. Freeze the legacy baseline first
+
+Before porting anything, capture a passing baseline for:
+
+- `./scripts/verify-coverage.sh`
+- `./scripts/run-mutation-tests.sh`
+- `./scripts/run-scenario-tests.sh --secretless-only`
+- `./scripts/verify-scenario-coverage.sh`
+- `./scripts/verify-control-plane-parity.sh`
+
+### 2. Keep the shell contract stable
+
+Do not churn shell call sites more than once. Prefer stable Go binaries under
+`cmd/` plus extensionless wrappers when cutover begins. Keep Python as the
+oracle until parity is proven.
+
+### 3. Port leaf tools before the policy cluster
+
+Port in this order:
+
+1. `scenario_manifest`
+2. `extract_direct_mounts`
+3. `pty_transcript`
+4. shared policy library replacing `policy_bundle.py`
+5. `resolve_credential_sources`
+6. `manage_injection_policy`
+7. `render_injection_bundle`
+
+The policy and rendering cluster should move only after the shared parser and
+validation behavior exist in one Go library.
+
+### 4. Add parity gates before cutover
+
+For each helper, run Python and Go against the same fixtures and compare:
+
+- exit code
+- stdout/stderr
+- rewritten JSON or TOML
+- output file layout
+- file contents
+- file modes
+
+Normalize only fields that are inherently unstable, such as PTY transcript
+timestamps.
+
+### 5. Cut over call sites in batches
+
+After parity is green for a helper, switch all direct consumers of that helper
+in one change. Keep control-plane manifests, invariant checks, and validation
+scripts in sync with the new entrypoints.
+
+### 6. Replace validation plumbing after helper parity
+
+Only after the helper ports are stable should the repo remove:
+
+- Python mutation coverage for helper paths
+- residual helper-specific host-language invocations in shell validation
+
+### 7. Treat inline shell Python as a second migration wave
+
+Porting the helper entrypoints does not remove the remaining host-side utility
+logic embedded in shell scripts. Handle that second wave by domain rather than
+file-by-file.
+
+## Local validation matrix
+
+- Functional: differential Python-vs-Go fixture tests plus existing unit,
+  invariant, scenario, and smoke coverage.
+- Non-functional: startup time, max RSS, binary size, and output tree size on
+  fixed local fixtures.
+- Avoid hard performance thresholds for Docker, Colima, networked auth, or
+  TTY-scheduling-heavy paths.
+
+## Review questions
+
+Before merging any migration slice, ask:
+
+1. Did this preserve current Python behavior at the CLI and filesystem level?
+2. Did this keep the runtime boundary and control-plane masking rules intact?
+3. Did this reduce future cutover work, or only move code around?
+4. Are validation and invariant checks still exercising the migrated path?
+5. Is any remaining Python dependency explicit and temporary?


### PR DESCRIPTION
## Summary
- integrate the Go helper/launcher port onto current main and add the migration workflow docs
- carry forward the accepted build-and-test/snapshot work and fold in the adversarial-review fixes
- harden build-and-test bootstrap, pre-merge snapshots, and restore the low-disk serial reproducible-build path

## Validation
- `go test ./... -count=1`
- `./scripts/pre-merge.sh --local-snapshot worktree --local-include-untracked`

## Notes
- supersedes #61 and #62; their accepted changes are included here with additional review-driven fixes