### PR TITLE
Open source preparation: license headers, bug fixes, CI hardening, and contributor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report a defect in Workcell
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. 
+2. 
+3. 
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment**
+- OS: [e.g. macOS 15.4]
+- Workcell version: [e.g. v0.2.7 or commit SHA]
+- Provider: [Codex / Claude / Gemini]
+- Mode: [strict / build / breakglass]
+- Docker version: `docker --version`
+- Colima version (macOS only): `colima version`
+
+**Relevant logs**
+Paste any error output here. Redact tokens, keys, and personal paths.
+
+**Security note**
+If this bug could expose secrets, allow a sandbox escape, or bypass signing
+or provenance checks, please use the [private vulnerability reporting
+process](../SECURITY.md) instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/omkhar/workcell/security/advisories/new
+    about: >
+      Report sandbox escapes, secret exposure, signing or provenance bypasses,
+      or unexpected trust widening via private advisory. Do not open a public
+      issue for security bugs.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Propose a new capability or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Summary**
+One-sentence description of the feature.
+
+**Motivation**
+What problem does this solve? Who benefits and how?
+
+**Proposed design**
+How should it work? If this touches the runtime boundary, trust model, or
+provider adapters, describe how invariants are preserved.
+
+**Alternatives considered**
+What other approaches did you consider, and why did you prefer this one?
+
+**Acceptance criteria**
+How will we know this is done? List concrete, testable outcomes.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -119,3 +119,23 @@ updates:
       runtime-rust:
         patterns:
           - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "10:30"
+      timezone: "America/Toronto"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+      - "go"
+    groups:
+      go-modules:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- What does this change and why? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Dependency update
+- [ ] Refactor / simplification
+- [ ] Security hardening
+
+## Checklist
+
+- [ ] `./scripts/dev-quick-check.sh` passes locally
+- [ ] Tests added or updated for the change
+- [ ] Docs updated if behavior changes (same PR)
+- [ ] Invariants preserved — no silent trust widening
+- [ ] If touching runtime boundary or policy: linked the relevant section of
+      `docs/invariants.md` or `docs/threat-model.md` below
+
+## Runtime / trust notes
+
+<!-- If this touches runtime/, adapters/, policy/, or .github/workflows/,
+     describe the trust assumptions the change depends on. Otherwise delete
+     this section. -->
+
+## Related issues
+
+<!-- Closes #NNN -->

--- a/.github/workflows/macos-boundary.yml
+++ b/.github/workflows/macos-boundary.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: # zizmor: ignore[self-hosted-runner] requires reviewed macOS+Colima boundary coverage
       - self-hosted
       - macOS
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:

--- a/.github/workflows/provider-e2e.yml
+++ b/.github/workflows/provider-e2e.yml
@@ -45,6 +45,7 @@ jobs:
   provider-e2e:
     name: Provider Authenticated Smoke (${{ inputs.provider }})
     needs: provider-e2e-guard
+    if: ${{ github.actor == github.repository_owner && github.ref_name == github.event.repository.default_branch }}
     runs-on: # zizmor: ignore[self-hosted-runner] requires reviewed macOS+Colima authenticated boundary coverage
       - self-hosted
       - macOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          auth_header="$(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 | tr -d '\n')"
-          git -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth_header}" \
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${GITHUB_TOKEN}" \
             fetch "https://github.com/${GITHUB_REPOSITORY}.git" main --depth=1
           git merge-base --is-ancestor "${GITHUB_SHA}" FETCH_HEAD
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,6 +47,8 @@ jobs:
           ACTIONLINT_VERSION: 1.7.11
         run: |
           curl -fsSL \
+            --max-time 60 \
+            --connect-timeout 15 \
             -o actionlint.tar.gz \
             "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,33 @@ Local development expects:
 - `zizmor`
 - `jq`
 
-On macOS, also install Colima for the real VM boundary path.
+On macOS with Homebrew:
+
+```bash
+brew install go shellcheck shfmt actionlint zizmor jq
+brew install --cask docker
+rustup-init  # installs cargo, rustfmt, clippy
+```
+
+For the real VM boundary path:
+
+```bash
+brew install colima
+```
+
+## Commit signing
+
+Every commit on `main` must be signed. Set up GPG or SSH signing before your
+first contribution:
+
+```bash
+git config --global commit.gpgsign true
+git config --global user.signingkey <your-key>
+```
+
+See [GitHub's docs on signing commits][sign-docs] for setup details.
+
+[sign-docs]: https://docs.github.com/en/authentication/managing-commit-signature-verification
 
 ## Recommended workflow
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,16 @@
+Workcell
+Copyright 2026 Omkhar Arasaratnam
+
+This product includes software developed at the Workcell project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,9 +5,18 @@
 Do not disclose new sandbox escapes, credential leaks, signing bypasses, or
 boundary-preservation bugs in a public issue.
 
-Use GitHub Private Vulnerability Reporting or a GitHub security advisory for
-this repository. If that is unavailable, contact the repository owner privately
-through GitHub first.
+Use [GitHub Private Vulnerability Reporting][pvr] to open a security advisory
+for this repository. If that channel is unavailable, contact the repository
+owner privately through GitHub first.
+
+[pvr]: https://github.com/omkhar/workcell/security/advisories/new
+
+## Response
+
+We aim to acknowledge reports within **5 business days** and to provide an
+initial assessment within **10 business days**. Critical issues (sandbox
+escapes, secret exposure) will be prioritised. You will be credited in the
+advisory unless you request otherwise.
 
 ## In scope
 
@@ -19,6 +28,23 @@ High-priority reports include:
 - silent trust widening through repo content or workflow changes
 - release signing, SBOM, or provenance regressions
 
+## Out of scope
+
+The following are not in scope for this policy:
+
+- social engineering attacks
+- physical access attacks
+- bugs in third-party providers (Codex, Claude, Gemini) that do not
+  involve a Workcell boundary violation
+- issues reproducible only in unsupported configurations (non-macOS host,
+  `breakglass` mode used as intended)
+
 ## Supported branch
 
-Security fixes are expected on `main`.
+Security fixes are applied to `main`. There are no long-lived release branches.
+
+## Disclosure
+
+We follow a coordinated disclosure model. Please allow a reasonable fix window
+before public disclosure. We will notify you when a fix is ready and work with
+you on timing.

--- a/cmd/workcell-extract-direct-mounts/main.go
+++ b/cmd/workcell-extract-direct-mounts/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package main
 
 import (

--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package main
 
 import (

--- a/cmd/workcell-manage-injection-policy/main.go
+++ b/cmd/workcell-manage-injection-policy/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package main
 
 import (

--- a/cmd/workcell-metadatautil/main.go
+++ b/cmd/workcell-metadatautil/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package main
 
 import (

--- a/cmd/workcell-pty-transcript/main.go
+++ b/cmd/workcell-pty-transcript/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package main
 
 import (

--- a/cmd/workcell-render-injection-bundle/main.go
+++ b/cmd/workcell-render-injection-bundle/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package main
 
 import (

--- a/cmd/workcell-resolve-credential-sources/main.go
+++ b/cmd/workcell-resolve-credential-sources/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package main
 
 import (

--- a/cmd/workcell-run-mutation-tests/main.go
+++ b/cmd/workcell-run-mutation-tests/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package main
 
 import (

--- a/cmd/workcell-runtimeutil/main.go
+++ b/cmd/workcell-runtimeutil/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package main
 
 import (

--- a/cmd/workcell-scenario-manifest/main.go
+++ b/cmd/workcell-scenario-manifest/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package main
 
 import (

--- a/cmd/workcell-treecompare/main.go
+++ b/cmd/workcell-treecompare/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package main
 
 import (

--- a/internal/authpolicy/manage.go
+++ b/internal/authpolicy/manage.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package authpolicy
 
 import (

--- a/internal/authpolicy/manage_test.go
+++ b/internal/authpolicy/manage_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package authpolicy
 
 import (

--- a/internal/authpolicy/policy.go
+++ b/internal/authpolicy/policy.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package authpolicy
 
 import (

--- a/internal/authresolve/resolve_credential_sources.go
+++ b/internal/authresolve/resolve_credential_sources.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package authresolve
 
 import (

--- a/internal/authresolve/resolve_credential_sources_test.go
+++ b/internal/authresolve/resolve_credential_sources_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package authresolve
 
 import (

--- a/internal/hostutil/hostutil.go
+++ b/internal/hostutil/hostutil.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package hostutil
 
 import (

--- a/internal/hostutil/hostutil_test.go
+++ b/internal/hostutil/hostutil_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package hostutil
 
 import (

--- a/internal/hostutil/launcher.go
+++ b/internal/hostutil/launcher.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package hostutil
 
 import (
@@ -129,7 +132,7 @@ func ProfileLockIsStale(lockDir string) (bool, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			return true, nil
 		}
-		return true, nil
+		return false, err
 	}
 
 	var owner struct {
@@ -217,7 +220,7 @@ func CleanupStaleSessionAuditDirs(colimaRoot string) error {
 			if err != nil {
 				continue
 			}
-			if statUID(info) != uid || info.IsDir() == false || info.Mode()&os.ModeSymlink != 0 {
+			if statUID(info) != uid || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 				continue
 			}
 			if info.ModTime().After(cutoff) {
@@ -528,17 +531,16 @@ func injectionBundleIsLive(bundlePath string, cutoff time.Time) (bool, error) {
 	}
 
 	var owner struct {
-		PID     any    `json:"pid"`
+		PID     int    `json:"pid"`
 		Started string `json:"started"`
 	}
 	if err := json.Unmarshal(content, &owner); err != nil {
 		return false, nil
 	}
-	pid, ok := owner.PID.(float64)
-	if !ok || owner.Started == "" {
+	if owner.PID <= 0 || owner.Started == "" {
 		return false, nil
 	}
-	started, err := processStartTime(int(pid))
+	started, err := processStartTime(owner.PID)
 	if err != nil {
 		return false, nil
 	}

--- a/internal/injection/extract_direct_mounts.go
+++ b/internal/injection/extract_direct_mounts.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package injection
 
 import (
@@ -93,11 +96,7 @@ func collectDirectMounts(manifest map[string]any) ([]DirectMount, error) {
 			if err != nil {
 				return nil, err
 			}
-			if rawSource, ok := entry["source"]; ok && rawSource != nil {
-				source, ok := rawSource.(map[string]any)
-				if !ok {
-					continue
-				}
+			if source, ok := entry["source"].(map[string]any); ok {
 				directMount, err := RequireDirectMount(source, fmt.Sprintf("copies[%d].source", index))
 				if err != nil {
 					return nil, err

--- a/internal/injection/extract_direct_mounts_test.go
+++ b/internal/injection/extract_direct_mounts_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package injection
 
 import (

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package injection
 
 import (

--- a/internal/injection/render_injection_bundle_test.go
+++ b/internal/injection/render_injection_bundle_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package injection
 
 import (

--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package metadatautil
 
 import (

--- a/internal/metadatautil/coverage.go
+++ b/internal/metadatautil/coverage.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package metadatautil
 
 import (

--- a/internal/metadatautil/path.go
+++ b/internal/metadatautil/path.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package metadatautil
 
 import (

--- a/internal/metadatautil/reproducible_build.go
+++ b/internal/metadatautil/reproducible_build.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package metadatautil
 
 import (

--- a/internal/metadatautil/reproducible_build_test.go
+++ b/internal/metadatautil/reproducible_build_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package metadatautil
 
 import (

--- a/internal/metadatautil/toml.go
+++ b/internal/metadatautil/toml.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package metadatautil
 
 import (

--- a/internal/metadatautil/toml_test.go
+++ b/internal/metadatautil/toml_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package metadatautil
 
 import (

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package metadatautil
 
 import (
@@ -168,7 +171,6 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		return err
 	}
 
-	defaultBranch, _ := repoMeta["default_branch"].(string)
 	owner, _ := repoMeta["owner"].(map[string]any)
 	ownerLogin, _ := owner["login"].(string)
 	ownerType, _ := owner["type"].(string)
@@ -495,7 +497,6 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		}
 	}
 
-	_ = defaultBranch
 	return nil
 }
 

--- a/internal/metadatautil/validation_tools.go
+++ b/internal/metadatautil/validation_tools.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package metadatautil
 
 import (

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package metadatautil
 
 import (

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package mutation
 
 import (

--- a/internal/paritytree/tree.go
+++ b/internal/paritytree/tree.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package paritytree
 
 import (

--- a/internal/paritytree/tree_test.go
+++ b/internal/paritytree/tree_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package paritytree
 
 import (

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package pathutil
 
 import (

--- a/internal/policybundle/policy_bundle.go
+++ b/internal/policybundle/policy_bundle.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package policybundle
 
 import (

--- a/internal/policybundle/policy_bundle_test.go
+++ b/internal/policybundle/policy_bundle_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package policybundle
 
 import (

--- a/internal/rootio/rootio.go
+++ b/internal/rootio/rootio.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package rootio
 
 import (

--- a/internal/rootio/rootio_test.go
+++ b/internal/rootio/rootio_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package rootio
 
 import (

--- a/internal/runtimeutil/runtimeutil.go
+++ b/internal/runtimeutil/runtimeutil.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package runtimeutil
 
 import (

--- a/internal/runtimeutil/runtimeutil_test.go
+++ b/internal/runtimeutil/runtimeutil_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package runtimeutil
 
 import (

--- a/internal/scenarios/scenario_manifest.go
+++ b/internal/scenarios/scenario_manifest.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package scenarios
 
 import (

--- a/internal/scenarios/scenario_manifest_test.go
+++ b/internal/scenarios/scenario_manifest_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package scenarios
 
 import (

--- a/internal/scenarios/scenario_script_integration_test.go
+++ b/internal/scenarios/scenario_script_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package scenarios
 
 import (

--- a/internal/testkit/parity.go
+++ b/internal/testkit/parity.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package testkit
 
 import (

--- a/internal/testkit/parity_test.go
+++ b/internal/testkit/parity_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package testkit
 
 import (

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package testkit
 
 import (

--- a/internal/testkit/validation_snapshot_test.go
+++ b/internal/testkit/validation_snapshot_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package testkit
 
 import (

--- a/internal/transcript/pty_darwin.go
+++ b/internal/transcript/pty_darwin.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 //go:build darwin
 
 package transcript

--- a/internal/transcript/pty_linux.go
+++ b/internal/transcript/pty_linux.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 //go:build linux
 
 package transcript

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package transcript
 
 import (

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 package transcript
 
 import (

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "56113deacee4a698ca2b2f6543c6b7abc43e7052a3bc01eda6f2bcef9f8b438c"
+      "sha256": "d78f98942720482cc73b2d108bd3cd4259a8a90926f45853b3b8503f590b36a8"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/runtime/container/rust/src/bin/common/launcher_common.rs
+++ b/runtime/container/rust/src/bin/common/launcher_common.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 use std::env;
 use std::ffi::{CString, OsStr, OsString};
 use std::fmt;

--- a/runtime/container/rust/src/bin/workcell-git-launcher.rs
+++ b/runtime/container/rust/src/bin/workcell-git-launcher.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 #[path = "common/launcher_common.rs"]
 mod launcher_common;
 

--- a/runtime/container/rust/src/bin/workcell-launcher.rs
+++ b/runtime/container/rust/src/bin/workcell-launcher.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 #[path = "common/launcher_common.rs"]
 mod launcher_common;
 

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
 #![allow(clippy::missing_safety_doc)]
 #![deny(unsafe_op_in_unsafe_fn)]
 

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -787,6 +787,7 @@ profile_image_marker_value() {
   local key="$2"
   local marker_path=""
 
+  [[ "${key}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || return 1
   marker_path="$(profile_image_marker_path "${profile}")"
   [[ -f "${marker_path}" ]] || return 1
   sed -n "s/^${key}=//p" "${marker_path}" | head -n1


### PR DESCRIPTION
## Summary

Prepares the repository for public open-source release. Four focused commits:

1. **SPDX license headers + NOTICE** — `SPDX-License-Identifier: Apache-2.0` and copyright notice on all 54 Go source files and 4 non-vendor Rust source files. Adds `NOTICE` for Apache 2.0 attribution compliance.

2. **Bug fixes in Go host utilities** — `ProfileLockIsStale` now returns `false, err` on unexpected read failures rather than silently treating the lock as stale (risks concurrent corruption). Simplifies `!info.IsDir()` expression. Removes runtime type assertion in `injectionBundleIsLive` by using typed `int` PID. Adds identifier validation in `profile_image_marker_value` to prevent sed metacharacter injection.

3. **GitHub issue/PR templates and contributor docs** — Bug report, feature request, and security advisory contact templates. PR template with invariant-preservation checklist. `CONTRIBUTING.md` gets Homebrew install commands and commit signing setup. `SECURITY.md` gets 5/10 business-day response SLA, out-of-scope section, and coordinated disclosure statement.

4. **CI hardening and dependency coverage** — Replaces base64-obfuscated `GITHUB_TOKEN` with direct bearer auth in `release.yml`. Adds `timeout-minutes: 60` to self-hosted macOS job. Adds defensive owner+branch guard on `provider-e2e`. Adds `--max-time`/`--connect-timeout` to `actionlint` curl. Adds `gomod` ecosystem to Dependabot for root `go.mod`.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `shellcheck` clean on `scripts/workcell`
- [x] `actionlint` clean on all workflows
- [x] `codespell` clean on new files

## Notes

The git history has also been locally cleaned (stripped internal `^b`/`^B`/`^F` risk-notation prefixes from 11 commits) but cannot be force-pushed to main due to branch protection. The cleaned history can be applied after temporarily disabling force-push protection post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)