### PR TITLE
docs: add commit convention guidance and update man page date

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,22 @@ See [GitHub's docs on signing commits][sign-docs] for setup details.
 
 5. Open a PR against `main`.
 
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>: <description>
+
+[optional body]
+```
+
+Common types: `feat`, `fix`, `docs`, `chore`, `test`, `refactor`.
+
+Keep the subject line under 72 characters. If the change touches the
+runtime boundary, trust model, or provider adapters, mention it in the
+body.
+
 ## Validation levels
 
 ### Fast local gate

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -1,4 +1,4 @@
-.TH WORKCELL 1 "2026-03-28" "Workcell" "User Commands"
+.TH WORKCELL 1 "2026-04-04" "Workcell" "User Commands"
 .SH NAME
 workcell \- bounded runtime launcher for coding agents
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md**: document Conventional Commits format for external contributors — type, description, 72-char limit, note about boundary changes in body
- **man/workcell.1**: update date from 2026-03-28 → 2026-04-04 (open source prep release date)

Documentation only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)