### PR TITLE
chore: add zizmor.yml to CODEOWNERS and document release-env upgrade path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 /.github/workflows/ @omkhar
 /.github/dependabot.yml @omkhar
 /.github/dependency-review-config.yml @omkhar
+/.github/zizmor.yml @omkhar
 
 # Runtime boundary, launchers, and release/signing paths.
 /scripts/ @omkhar

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -21,7 +21,9 @@ mode = "review-gated"
 
 [release_environment]
 # Valid modes:
-# - "review-gated": require at least one human reviewer and no admin bypass
+# - "review-gated": require at least one human reviewer and no admin bypass;
+#   upgrade to this once the repository is public (public repos on the free
+#   plan can enforce environment reviewers, private repos cannot)
 # - "single-owner-private": allow a private single-owner repo to use the
 #   release environment without a reviewer gate
 # - "plan-limited-private": lower-assurance fallback for private repositories

--- a/runtime/container/rust/src/bin/workcell-launcher.rs
+++ b/runtime/container/rust/src/bin/workcell-launcher.rs
@@ -198,6 +198,20 @@ mod tests {
     }
 
     #[test]
+    fn all_launch_targets_have_no_nul_bytes() {
+        for (name, path) in LAUNCH_TARGETS {
+            assert!(
+                CString::new(*name).is_ok(),
+                "LAUNCH_TARGETS entry name contains a NUL byte: {name:?}"
+            );
+            assert!(
+                CString::new(*path).is_ok(),
+                "LAUNCH_TARGETS entry path contains a NUL byte: {path:?}"
+            );
+        }
+    }
+
+    #[test]
     fn exec_request_returns_failure_code_when_shell_is_unavailable() {
         let request = LaunchRequest {
             target_name: "codex",

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -163,6 +163,10 @@ prepare_smoke_workspace() {
 
   rm -f "${path_list_raw}" "${path_list_filtered}"
   mkdir -p "${SMOKE_WORKSPACE}/tmp"
+  # 1777 (sticky + world-writable) mirrors the container's /tmp posture so the
+  # mapped runtime user can write here without elevated privileges.  The second
+  # chmod re-applies 1777 after align_path_for_mapped_runtime_user, which resets
+  # the workspace root to 0755 as part of UID alignment.
   chmod 1777 "${SMOKE_WORKSPACE}" "${SMOKE_WORKSPACE}/tmp"
   align_path_for_mapped_runtime_user "${SMOKE_WORKSPACE}" 0644 0755
   chmod 1777 "${SMOKE_WORKSPACE}/tmp"


### PR DESCRIPTION
## Summary

Four follow-up items from the adversarial open-source review:

- **CODEOWNERS**: add `/.github/zizmor.yml` — the only `.github/` security-scanning config not explicitly listed
- **Policy doc**: annotate the `release_environment` comment in `policy/github-hosted-controls.toml` to document when/why to upgrade from `plan-limited-private` to `review-gated` (public repos on the free plan can enforce environment reviewers; private repos on this plan cannot — API confirmed)
- **container-smoke.sh**: add comment explaining the `chmod 1777` double-apply — it's intentional to mirror the container's `/tmp` posture and restore permissions after `align_path_for_mapped_runtime_user` resets the workspace root to 0755
- **Rust test**: add `all_launch_targets_have_no_nul_bytes` to validate that `CString` conversion succeeds for every name and path in `LAUNCH_TARGETS`, making the NUL-safety contract explicit

## No functional change

CODEOWNERS and policy-doc are documentation. The `container-smoke.sh` change is comment-only. The Rust test only exercises the static constants — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)