### PR TITLE
chore: pre-release v0.5.0 doc fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ What you expected to happen.
 
 **Environment**
 - OS: [e.g. macOS 15.4]
-- Workcell version: [e.g. v0.2.7 or commit SHA]
+- Workcell version: [e.g. v0.5.0 or commit SHA]
 - Provider: [Codex / Claude / Gemini]
 - Mode: [strict / build / breakglass]
 - Docker version: `docker --version`

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -73,16 +73,16 @@ from those attestation entries.
 Verify the image with Cosign:
 
 ```bash
-cosign verify ghcr.io/OWNER/workcell@sha256:DIGEST \
-  --certificate-identity-regexp 'https://github.com/OWNER/workcell/.github/workflows/release.yml@refs/tags/.+' \
+cosign verify ghcr.io/omkhar/workcell@sha256:DIGEST \
+  --certificate-identity-regexp 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
 Verify the same image with GitHub attestation tooling:
 
 ```bash
-gh attestation verify oci://ghcr.io/OWNER/workcell@sha256:DIGEST \
-  --repo OWNER/workcell
+gh attestation verify oci://ghcr.io/omkhar/workcell@sha256:DIGEST \
+  --repo omkhar/workcell
 ```
 
 ## Verifying release assets
@@ -99,7 +99,7 @@ Example:
 ```bash
 cosign verify-blob SHA256SUMS \
   --bundle SHA256SUMS.sigstore.json \
-  --certificate-identity-regexp 'https://github.com/OWNER/workcell/.github/workflows/release.yml@refs/tags/.+' \
+  --certificate-identity-regexp 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 sha256sum -c SHA256SUMS
@@ -108,7 +108,7 @@ sha256sum -c SHA256SUMS
 If you want GitHub's attestation view for the source bundle:
 
 ```bash
-gh attestation verify workcell-VERSION.tar.gz --repo OWNER/workcell
+gh attestation verify workcell-VERSION.tar.gz --repo omkhar/workcell
 ```
 
 ## Scope note

--- a/docs/scenario-gaps.md
+++ b/docs/scenario-gaps.md
@@ -13,8 +13,10 @@ the best evidence today is local or self-hosted macOS verification.
 
 ### End-to-end authenticated coverage for every provider
 
-Manual provider-authenticated smoke exists, but not every documented auth path
-has full automated end-to-end coverage across all providers.
+Provider-authenticated smoke (`scripts/provider-e2e.sh`) is available for
+local use, but it requires a real macOS+Colima environment and live provider
+credentials and is not run in CI. Not every documented auth path has full
+automated end-to-end coverage across all providers.
 
 ### Lower-assurance transition coverage
 

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -1,4 +1,4 @@
-.TH WORKCELL 1 "2026-04-04" "Workcell" "User Commands"
+.TH WORKCELL 1 "2026-04-05" "Workcell" "User Commands"
 .SH NAME
 workcell \- bounded runtime launcher for coding agents
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary

Final documentation fixes before tagging v0.5.0:

- **bug_report.md**: update version example from `v0.2.7` to `v0.5.0`
- **docs/provenance.md**: replace `OWNER` placeholder with `omkhar` in all cosign/gh attestation verification examples
- **docs/scenario-gaps.md**: clarify that `provider-e2e.sh` exists for local use but CI no longer runs a self-hosted provider smoke (those workflows were removed in #67)
- **man/workcell.1**: update date to 2026-04-05

All documentation-only changes, no logic affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)