### PR TITLE
fix: release preflight git fetch auth using git config --local

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${GITHUB_TOKEN}" \
-            fetch "https://github.com/${GITHUB_REPOSITORY}.git" main --depth=1
+          git config --local http."https://github.com/".extraheader \
+            "AUTHORIZATION: bearer ${GITHUB_TOKEN}"
+          git fetch "https://github.com/${GITHUB_REPOSITORY}.git" main --depth=1
           git merge-base --is-ancestor "${GITHUB_SHA}" FETCH_HEAD
 
       - name: Validate release tag name


### PR DESCRIPTION
## Summary

The `release.yml` preflight step "Require tag commit on main" was failing with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

The `git -c` URL-scoped extraheader approach is not reliably applied when `actions/checkout` (with `persist-credentials: false`) performs credential cleanup in the runner environment. Switching to `git config --local` writes directly to `.git/config`, which has highest precedence over global and system configs, ensuring the bearer token is always applied to the fetch.

Discovered during the v0.5.0 release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)