### PR TITLE
fix: use gh compare API for release main-branch ancestor check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          git config --local http."https://github.com/".extraheader \
-            "AUTHORIZATION: bearer ${GITHUB_TOKEN}"
-          git fetch "https://github.com/${GITHUB_REPOSITORY}.git" main --depth=1
-          git merge-base --is-ancestor "${GITHUB_SHA}" FETCH_HEAD
+          # Use the GitHub compare API (via gh, which is pre-authenticated) to
+          # verify that the tagged commit is an ancestor of main.  The git-fetch
+          # approach requires re-authenticating against a private repo and has
+          # proven unreliable with the actions/checkout credential cleanup.
+          cmp_status="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/compare/${GITHUB_SHA}...main" \
+            --jq '.status' 2>/dev/null || true)"
+          case "${cmp_status}" in
+            ahead|identical) ;;
+            *)
+              echo "Tagged commit ${GITHUB_SHA} is not an ancestor of main (compare status: ${cmp_status:-error})" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Validate release tag name
         run: |


### PR DESCRIPTION
## Summary

The "Require tag commit on main" step in `release.yml` has failed across two different git credential approaches:

1. `git -c "http...extraheader=AUTHORIZATION: bearer ..."` — original fix from PR #64
2. `git config --local http...extraheader` — attempted fix in PR #69

Both fail with `fatal: could not read Username for 'https://github.com': No such device or address` because `actions/checkout` with `persist-credentials: false` clears credentials in a way that overrides both approaches on this runner.

This PR replaces the git fetch entirely with the GitHub compare API via `gh` (already pre-authenticated in Actions). `gh api repos/.../compare/SHA...main` returns `ahead` or `identical` when the tagged SHA is an ancestor of main, which is the exact check we need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)