### PR TITLE
fix: harden host publication and optimize validation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,12 @@ Other defaults that matter:
 Install the launcher symlink and verify the host prerequisites:
 
 ```bash
-./scripts/install.sh
+./install.sh
 workcell --prepare --agent codex --workspace /path/to/repo
 ```
+
+`./install.sh` is the supported repo-root entrypoint. The `scripts/` installer
+helper is an internal implementation detail.
 
 Launch a provider inside the bounded runtime:
 

--- a/docs/examples/quickstart-claude.md
+++ b/docs/examples/quickstart-claude.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Workcell installed with `./scripts/install.sh`
+- Workcell installed with `./install.sh`
 - a repo you want to mount as the workspace
 - a reviewed Claude API key file, or an experimental macOS resolver config
 

--- a/docs/examples/quickstart-codex.md
+++ b/docs/examples/quickstart-codex.md
@@ -8,7 +8,7 @@ runtime.
 - macOS
 - Colima
 - Docker CLI
-- Workcell installed from the repo root with `./scripts/install.sh`
+- Workcell installed from the repo root with `./install.sh`
 
 ## 1. Create a reviewed auth file
 

--- a/docs/examples/quickstart-gemini.md
+++ b/docs/examples/quickstart-gemini.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Workcell installed with `./scripts/install.sh`
+- Workcell installed with `./install.sh`
 - a repo you want to mount as the workspace
 - either a reviewed Gemini env file or reviewed cached OAuth material
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -p
-# Install Workcell into ~/.local/bin.  Forwards to scripts/install.sh.
+# Public Workcell installer entrypoint. Forwards to scripts/install-workcell.sh.
 readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
   exec /usr/bin/env -i \
@@ -20,4 +20,4 @@ if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
 fi
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "${ROOT_DIR}/scripts/install.sh" "$@"
+exec "${ROOT_DIR}/scripts/install-workcell.sh" "$@"

--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -281,11 +281,11 @@ func walkFiles(rootDir, relativeRoot string, excludeParts ...string) ([]string, 
 				return nil
 			}
 		}
-		info, err := os.Stat(path)
+		isRegular, err := dirEntryIsRegular(d)
 		if err != nil {
 			return err
 		}
-		if info.Mode().IsRegular() {
+		if isRegular {
 			paths = append(paths, rel)
 		}
 		return nil
@@ -332,11 +332,11 @@ func walkRepoFiles(rootDir string) ([]string, error) {
 			}
 			return nil
 		}
-		info, err := os.Stat(path)
+		isRegular, err := dirEntryIsRegular(d)
 		if err != nil {
 			return err
 		}
-		if info.Mode().IsRegular() {
+		if isRegular {
 			paths = append(paths, rel)
 		}
 		return nil
@@ -346,6 +346,21 @@ func walkRepoFiles(rootDir string) ([]string, error) {
 	}
 	sort.Strings(paths)
 	return paths, nil
+}
+
+func dirEntryIsRegular(d fs.DirEntry) (bool, error) {
+	mode := d.Type()
+	if mode.IsRegular() {
+		return true, nil
+	}
+	if mode&fs.ModeType != 0 {
+		return false, nil
+	}
+	info, err := d.Info()
+	if err != nil {
+		return false, err
+	}
+	return info.Mode().IsRegular(), nil
 }
 
 func digestMap(rootDir string, paths []string) (map[string]string, error) {

--- a/internal/metadatautil/core_test.go
+++ b/internal/metadatautil/core_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestWalkFilesSkipsExcludedPaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "adapters", "keep"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "adapters", "node_modules", "skip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "adapters", "keep", "a.txt"), []byte("a"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "adapters", "node_modules", "skip", "b.txt"), []byte("b"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := walkFiles(root, "adapters", "node_modules", "target")
+	if err != nil {
+		t.Fatalf("walkFiles() error = %v", err)
+	}
+	want := []string{filepath.Join("adapters", "keep", "a.txt")}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("walkFiles() = %#v, want %#v", got, want)
+	}
+}
+
+func TestWalkRepoFilesSkipsExcludedPaths(t *testing.T) {
+	root := t.TempDir()
+	for _, dir := range []string{".git", "dist", "tmp", "node_modules", "target", "pkg"} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "pkg", "keep.txt"), []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "dist", "ignore.txt"), []byte("ignore"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "target", "ignore.txt"), []byte("ignore"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "pkg", "skip.pyc"), []byte("skip"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := walkRepoFiles(root)
+	if err != nil {
+		t.Fatalf("walkRepoFiles() error = %v", err)
+	}
+	want := []string{filepath.Join("pkg", "keep.txt")}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("walkRepoFiles() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/metadatautil/coverage.go
+++ b/internal/metadatautil/coverage.go
@@ -4,9 +4,12 @@
 package metadatautil
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 )
@@ -36,32 +39,57 @@ func CoveragePercent(reportPath string) (float64, error) {
 }
 
 func CoverageExecutables(messagePath string) ([]string, error) {
-	content, err := os.ReadFile(messagePath)
+	handle, err := os.Open(messagePath)
 	if err != nil {
 		return nil, err
 	}
+	defer handle.Close()
+
+	reader := bufio.NewReader(handle)
 	executables := make([]string, 0)
-	for _, rawLine := range splitLines(string(content)) {
-		if rawLine == "" || rawLine[0] != '{' {
+	var lineBuf bytes.Buffer
+	for {
+		fragment, isPrefix, readErr := reader.ReadLine()
+		if len(fragment) == 0 && errors.Is(readErr, io.EOF) {
+			break
+		}
+		if len(fragment) > 0 {
+			lineBuf.Write(fragment)
+		}
+		if isPrefix {
+			if readErr != nil && !errors.Is(readErr, io.EOF) {
+				return nil, readErr
+			}
 			continue
 		}
-		var message map[string]any
-		if err := json.Unmarshal([]byte(rawLine), &message); err != nil {
-			continue
-		}
-		if message["reason"] != "compiler-artifact" {
-			continue
-		}
-		executable, _ := message["executable"].(string)
-		target, _ := message["target"].(map[string]any)
-		if executable != "" && target != nil {
-			if kind, _ := target["kind"].([]any); len(kind) == 1 {
-				if label, _ := kind[0].(string); label == "bin" {
-					executables = append(executables, executable)
+
+		line := bytes.TrimSpace(lineBuf.Bytes())
+		if len(line) > 0 && line[0] == '{' {
+			var message map[string]any
+			if err := json.Unmarshal(line, &message); err == nil {
+				if message["reason"] == "compiler-artifact" {
+					executable, _ := message["executable"].(string)
+					target, _ := message["target"].(map[string]any)
+					if executable != "" && target != nil {
+						if kind, _ := target["kind"].([]any); len(kind) == 1 {
+							if label, _ := kind[0].(string); label == "bin" {
+								executables = append(executables, executable)
+							}
+						}
+					}
 				}
 			}
 		}
+		lineBuf.Reset()
+
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return nil, readErr
+		}
 	}
+
 	if len(executables) == 0 {
 		return nil, errors.New("Unable to locate instrumented Rust test executables for coverage")
 	}
@@ -88,24 +116,6 @@ func jsonNumberToFloat64(value any) (float64, bool) {
 		}
 	}
 	return 0, false
-}
-
-func splitLines(text string) []string {
-	if text == "" {
-		return nil
-	}
-	lines := make([]string, 0)
-	start := 0
-	for i := 0; i < len(text); i++ {
-		if text[i] == '\n' {
-			lines = append(lines, text[start:i])
-			start = i + 1
-		}
-	}
-	if start <= len(text) {
-		lines = append(lines, text[start:])
-	}
-	return lines
 }
 
 func formatCoveragePercent(label string, percent float64) string {

--- a/internal/metadatautil/coverage_test.go
+++ b/internal/metadatautil/coverage_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestCoverageExecutablesParsesJSONLStream(t *testing.T) {
+	root := t.TempDir()
+	messagePath := filepath.Join(root, "cargo-messages.jsonl")
+	if err := os.WriteFile(messagePath, []byte(
+		"noise\n"+
+			`{"reason":"compiler-artifact","executable":"/tmp/bin-a","target":{"kind":["bin"]}}`+"\n"+
+			`{"reason":"compiler-artifact","executable":"/tmp/bin-b","target":{"kind":["lib"]}}`+"\n"+
+			`{"reason":"compiler-artifact","executable":"/tmp/bin-a","target":{"kind":["bin"]}}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	got, err := CoverageExecutables(messagePath)
+	if err != nil {
+		t.Fatalf("CoverageExecutables() error = %v", err)
+	}
+	want := []string{"/tmp/bin-a"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CoverageExecutables() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -119,6 +119,12 @@ var rustMutations = []mutationCase{
 		replacement:  `false`,
 		label:        "root-prefix matcher",
 	},
+	{
+		relativePath: "runtime/container/rust/src/lib.rs",
+		original:     `            | "core.fsmonitor"` + "\n",
+		replacement:  ``,
+		label:        "core.fsmonitor git-config blocking",
+	},
 }
 
 func Run(repoRoot string) error {

--- a/internal/paritytree/tree.go
+++ b/internal/paritytree/tree.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -32,7 +33,7 @@ func Snapshot(root string) ([]Entry, error) {
 			return nil
 		}
 
-		info, err := os.Lstat(path)
+		info, err := d.Info()
 		if err != nil {
 			return err
 		}
@@ -55,13 +56,20 @@ func Snapshot(root string) ([]Entry, error) {
 		case info.Mode().IsDir():
 			entry.Kind = "dir"
 		case info.Mode().IsRegular():
-			content, err := os.ReadFile(path)
+			file, err := os.Open(path)
 			if err != nil {
 				return err
 			}
-			sum := sha256.Sum256(content)
+			hasher := sha256.New()
+			if _, err := io.Copy(hasher, file); err != nil {
+				_ = file.Close()
+				return err
+			}
+			if err := file.Close(); err != nil {
+				return err
+			}
 			entry.Kind = "file"
-			entry.SHA256 = hex.EncodeToString(sum[:])
+			entry.SHA256 = hex.EncodeToString(hasher.Sum(nil))
 		default:
 			entry.Kind = "other"
 		}

--- a/internal/paritytree/tree_test.go
+++ b/internal/paritytree/tree_test.go
@@ -4,6 +4,8 @@
 package paritytree
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,13 +57,14 @@ func TestSnapshotCapturesSymlinks(t *testing.T) {
 	if len(entries) != 3 {
 		t.Fatalf("len(entries) = %d, want 3", len(entries))
 	}
-	if entries[0].Path != "dir" || entries[0].Kind != "dir" {
+	if entries[0].Path != "dir" || entries[0].Kind != "dir" || !entries[0].Mode.IsDir() {
 		t.Fatalf("dir entry = %#v", entries[0])
 	}
-	if entries[1].Path != filepath.ToSlash(filepath.Join("dir", "file.txt")) || entries[1].Kind != "file" {
+	wantHash := sha256.Sum256([]byte("hello"))
+	if entries[1].Path != filepath.ToSlash(filepath.Join("dir", "file.txt")) || entries[1].Kind != "file" || !entries[1].Mode.IsRegular() || entries[1].SHA256 != hex.EncodeToString(wantHash[:]) {
 		t.Fatalf("file entry = %#v", entries[1])
 	}
-	if entries[2].Path != "link.txt" || entries[2].Kind != "symlink" {
+	if entries[2].Path != "link.txt" || entries[2].Kind != "symlink" || entries[2].Mode&os.ModeSymlink == 0 || entries[2].LinkTarget != filepath.Join("dir", "file.txt") {
 		t.Fatalf("symlink entry = %#v", entries[2])
 	}
 }

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -348,11 +348,15 @@ execution cannot retake unmediated native code execution.
 .TP
 .I ~/.local/bin/workcell
 Installed launcher path used by
-.BR scripts/install.sh .
+.BR install.sh .
 .TP
 .I ~/.local/share/man/man1/workcell.1
 Installed man page path used by
-.BR scripts/install.sh .
+.BR install.sh .
+.TP
+.I scripts/install-workcell.sh
+Internal repository installer implementation invoked by
+.BR install.sh .
 .TP
 .I scripts/uninstall.sh
 Repository helper that removes Workcell-owned install links, managed Colima

--- a/runtime/container/bin/git
+++ b/runtime/container/bin/git
@@ -15,7 +15,7 @@ git_config_key_is_blocked() {
   local key_lower="$1"
 
   case "${key_lower}" in
-    core.askpass | core.editor | core.hookspath | core.pager | core.sshcommand | core.worktree | credential.helper | credential.*.helper | diff.external | include.path | includeif.*.path | pager.* | sequence.editor)
+    core.askpass | core.editor | core.fsmonitor | core.hookspath | core.pager | core.sshcommand | core.worktree | credential.helper | credential.*.helper | diff.external | include.path | includeif.*.path | pager.* | sequence.editor)
       return 0
       ;;
   esac
@@ -38,6 +38,7 @@ has_hooks_path_env_bypass() {
     { [[ "${GIT_CONFIG_PARAMETERS,,}" == *"core.hookspath"* ]] ||
       [[ "${GIT_CONFIG_PARAMETERS,,}" == *"core.askpass"* ]] ||
       [[ "${GIT_CONFIG_PARAMETERS,,}" == *"core.editor"* ]] ||
+      [[ "${GIT_CONFIG_PARAMETERS,,}" == *"core.fsmonitor"* ]] ||
       [[ "${GIT_CONFIG_PARAMETERS,,}" == *"core.pager"* ]] ||
       [[ "${GIT_CONFIG_PARAMETERS,,}" == *"core.sshcommand"* ]] ||
       [[ "${GIT_CONFIG_PARAMETERS,,}" == *"core.worktree"* ]] ||
@@ -66,6 +67,7 @@ has_hooks_path_env_bypass() {
     if git_config_key_is_blocked "${key_lower}" ||
       [[ "${value,,}" == *"core.askpass"* ]] ||
       [[ "${value,,}" == *"core.editor"* ]] ||
+      [[ "${value,,}" == *"core.fsmonitor"* ]] ||
       [[ "${value,,}" == *"core.hookspath"* ]] ||
       [[ "${value,,}" == *"core.pager"* ]] ||
       [[ "${value,,}" == *"core.sshcommand"* ]] ||
@@ -103,6 +105,7 @@ alias_body_is_blocked() {
     [[ "${alias_body_lower}" == *"--work-tree"* ]] ||
     [[ "${alias_body_lower}" == *"core.askpass"* ]] ||
     [[ "${alias_body_lower}" == *"core.editor"* ]] ||
+    [[ "${alias_body_lower}" == *"core.fsmonitor"* ]] ||
     [[ "${alias_body_lower}" == *"git_exec_path="* ]] ||
     [[ "${alias_body_lower}" == *"git_dir="* ]] ||
     [[ "${alias_body_lower}" == *"git_work_tree="* ]] ||

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "d78f98942720482cc73b2d108bd3cd4259a8a90926f45853b3b8503f590b36a8"
+      "sha256": "9ec5ab5b2ffa8b6dbe4442aa6f0ea8dfd745859c8ccb5c65525b9be855d13e0c"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",
@@ -148,13 +148,13 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/bin/git",
       "runtime_path": "/usr/local/libexec/workcell/git-wrapper.sh",
-      "sha256": "2102d42e9c2119982fff5ee72cb763bf19c302f8e5a2b3888caac54c6f8196ec"
+      "sha256": "60f58c4f9b34c7a8c652a34819125ffb4be71ca9bfe61e60eb01b24fa2edf3d9"
     },
     {
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/home-control-plane.sh",
       "runtime_path": "/usr/local/libexec/workcell/home-control-plane.sh",
-      "sha256": "037598825db0939d33c724b9337cf925e3487429c0d9bebd82365df87fce90ad"
+      "sha256": "1349a27c813ca3d1f20a090dd109a3dd50407eec457f420642209f2a601d16da"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -648,6 +648,43 @@ workcell_copy_manifest_credential_file() {
   return 0
 }
 
+workcell_manifest_copy_rows() {
+  jq -r '
+    .copies[]? |
+    [
+      (if (.source | type) == "object" then (.source.source // "") else .source end | if . == null then "null" else tostring end),
+      (if (.source | type) == "object" then (.source.mount_path // "") else "" end | if . == null then "" else tostring end),
+      (.target | if . == null then "null" else tostring end),
+      (.kind | if . == null then "null" else tostring end),
+      (.file_mode | if . == null then "null" else tostring end),
+      (.dir_mode | if . == null then "null" else tostring end)
+    ] | join("\u001f")
+  ' "$(workcell_manifest_path)"
+}
+
+workcell_manifest_ssh_config_rows() {
+  jq -r '
+    (.ssh // {}) as $ssh
+    | if ($ssh.config | type) == "object" then
+        ["config", ($ssh.config.source // ""), ($ssh.config.mount_path // "")] | map(tostring) | join("\u001f")
+      elif $ssh.config != null then
+        ["config", $ssh.config, ""] | map(tostring) | join("\u001f")
+      else empty end,
+      if ($ssh.known_hosts | type) == "object" then
+        ["known_hosts", ($ssh.known_hosts.source // ""), ($ssh.known_hosts.mount_path // "")] | map(tostring) | join("\u001f")
+      elif $ssh.known_hosts != null then
+        ["known_hosts", $ssh.known_hosts, ""] | map(tostring) | join("\u001f")
+      else empty end
+  ' "$(workcell_manifest_path)"
+}
+
+workcell_manifest_ssh_identity_rows() {
+  jq -r '
+    (.ssh.identities // [])[]? |
+    ["identity", (.source // ""), (.mount_path // ""), (.target_name // "null")] | map(tostring) | join("\u001f")
+  ' "$(workcell_manifest_path)"
+}
+
 workcell_trim_leading_whitespace() {
   local value="$1"
 
@@ -1263,7 +1300,6 @@ workcell_seed_codex_rules() {
 }
 
 workcell_apply_manifest_copies() {
-  local entry_json=""
   local source_rel=""
   local mount_path=""
   local target_path=""
@@ -1275,13 +1311,7 @@ workcell_apply_manifest_copies() {
   mkdir -p /state/injected
   chmod 0755 /state/injected 2>/dev/null || true
 
-  while IFS= read -r entry_json; do
-    source_rel="$(jq -r 'if (.source | type) == "object" then (.source.source // "") else .source end' <<<"${entry_json}")"
-    mount_path="$(jq -r 'if (.source | type) == "object" then (.source.mount_path // "") else "" end' <<<"${entry_json}")"
-    target_path="$(jq -r '.target' <<<"${entry_json}")"
-    kind="$(jq -r '.kind' <<<"${entry_json}")"
-    file_mode="$(jq -r '.file_mode' <<<"${entry_json}")"
-    dir_mode="$(jq -r '.dir_mode' <<<"${entry_json}")"
+  while IFS=$'\x1f' read -r source_rel mount_path target_path kind file_mode dir_mode; do
     [[ -n "${source_rel}${mount_path}" ]] || continue
     workcell_copy_manifest_entry \
       "$(workcell_resolve_manifest_input_path "${source_rel}" "${mount_path}")" \
@@ -1289,7 +1319,7 @@ workcell_apply_manifest_copies() {
       "${kind}" \
       "${file_mode}" \
       "${dir_mode}"
-  done < <(jq -c '.copies[]?' "$(workcell_manifest_path)")
+  done < <(workcell_manifest_copy_rows)
 }
 
 workcell_apply_manifest_ssh() {
@@ -1297,17 +1327,33 @@ workcell_apply_manifest_ssh() {
   local config_mount_path=""
   local known_hosts_source=""
   local known_hosts_mount_path=""
-  local identity_source=""
-  local identity_mount_path=""
-  local identity_name=""
+  local row_type=""
+  local row_source=""
+  local row_mount_path=""
+  local row_target_name=""
+  local -a identity_rows=()
 
   workcell_ensure_manifest || return 0
-  config_source="$(workcell_manifest_string 'if (.ssh.config | type) == "object" then (.ssh.config.source // empty) else (.ssh.config // empty) end')"
-  config_mount_path="$(workcell_manifest_string 'if (.ssh.config | type) == "object" then (.ssh.config.mount_path // empty) else empty end')"
-  known_hosts_source="$(workcell_manifest_string 'if (.ssh.known_hosts | type) == "object" then (.ssh.known_hosts.source // empty) else (.ssh.known_hosts // empty) end')"
-  known_hosts_mount_path="$(workcell_manifest_string 'if (.ssh.known_hosts | type) == "object" then (.ssh.known_hosts.mount_path // empty) else empty end')"
+  while IFS=$'\x1f' read -r row_type row_source row_mount_path row_target_name; do
+    case "${row_type}" in
+      config)
+        config_source="${row_source}"
+        config_mount_path="${row_mount_path}"
+        ;;
+      known_hosts)
+        known_hosts_source="${row_source}"
+        known_hosts_mount_path="${row_mount_path}"
+        ;;
+    esac
+  done < <(workcell_manifest_ssh_config_rows)
+
+  while IFS=$'\x1f' read -r row_type row_source row_mount_path row_target_name; do
+    [[ "${row_type}" == "identity" ]] || continue
+    identity_rows+=("${row_source}"$'\x1f'"${row_mount_path}"$'\x1f'"${row_target_name}")
+  done < <(workcell_manifest_ssh_identity_rows)
+
   if [[ -z "${config_source}" ]] && [[ -z "${known_hosts_source}" ]] &&
-    [[ "$(workcell_manifest_string '(.ssh.identities // []) | length')" == "0" ]]; then
+    [[ "${#identity_rows[@]}" -eq 0 ]]; then
     return 0
   fi
 
@@ -1326,15 +1372,14 @@ workcell_apply_manifest_ssh() {
     chmod 0600 "${HOME}/.ssh/known_hosts"
   fi
 
-  while IFS= read -r entry_json; do
-    identity_source="$(jq -r '.source // ""' <<<"${entry_json}")"
-    identity_mount_path="$(jq -r '.mount_path // ""' <<<"${entry_json}")"
-    identity_name="$(jq -r '.target_name' <<<"${entry_json}")"
-    [[ -n "${identity_source}${identity_mount_path}" ]] || continue
-    workcell_reset_session_target "${HOME}/.ssh/${identity_name}" "SSH identity"
-    cp "$(workcell_resolve_manifest_input_path "${identity_source}" "${identity_mount_path}")" "${HOME}/.ssh/${identity_name}"
-    chmod 0600 "${HOME}/.ssh/${identity_name}"
-  done < <(jq -c '.ssh.identities[]?' "$(workcell_manifest_path)")
+  while IFS=$'\x1f' read -r row_source row_mount_path row_target_name; do
+    [[ -n "${row_source}${row_mount_path}" ]] || continue
+    workcell_reset_session_target "${HOME}/.ssh/${row_target_name}" "SSH identity"
+    cp "$(workcell_resolve_manifest_input_path "${row_source}" "${row_mount_path}")" "${HOME}/.ssh/${row_target_name}"
+    chmod 0600 "${HOME}/.ssh/${row_target_name}"
+  done < <(
+    printf '%s\n' "${identity_rows[@]}"
+  )
 }
 
 seed_codex_home() {

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -834,6 +834,7 @@ fn git_config_key_is_blocked(key: &str) -> bool {
         key.to_ascii_lowercase().as_str(),
         "core.askpass"
             | "core.editor"
+            | "core.fsmonitor"
             | "core.hookspath"
             | "core.pager"
             | "core.sshcommand"
@@ -947,6 +948,7 @@ fn env_has_unsafe_git_override(env_entries: &[String]) -> bool {
         if let Some(value) = entry.strip_prefix("GIT_CONFIG_PARAMETERS=") {
             let lower = value.to_ascii_lowercase();
             if lower.contains("core.hookspath")
+                || lower.contains("core.fsmonitor")
                 || lower.contains("core.worktree")
                 || lower.contains("include.path")
                 || lower.contains("includeif.")
@@ -1577,6 +1579,19 @@ mod tests {
     fn env_has_unsafe_git_override_blocks_git_index_file() {
         assert!(env_has_unsafe_git_override(&[
             "GIT_INDEX_FILE=/attacker/index".to_string()
+        ]));
+    }
+
+    #[test]
+    fn git_config_key_is_blocked_blocks_core_fsmonitor() {
+        assert!(git_config_key_is_blocked("core.fsmonitor"));
+        assert!(git_config_key_is_blocked("Core.FsMonitor"));
+    }
+
+    #[test]
+    fn env_has_unsafe_git_override_blocks_core_fsmonitor_parameters() {
+        assert!(env_has_unsafe_git_override(&[
+            "GIT_CONFIG_PARAMETERS='core.fsmonitor=/attacker/fsmonitor'".to_string()
         ]));
     }
 

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2893,11 +2893,21 @@ EOF
     exit 1
   fi
   grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-hooks-lower.out
+  if git -c core.fsmonitor=/tmp/workcell-fsmonitor status >/tmp/git-guard-fsmonitor.out 2>&1; then
+    echo "expected Workcell git guard to reject inline core.fsmonitor override" >&2
+    exit 1
+  fi
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-fsmonitor.out
   if GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath GIT_CONFIG_VALUE_0=/dev/null git commit -m smoke >/tmp/git-guard-env.out 2>&1; then
     echo "expected Workcell git guard to reject GIT_CONFIG_* hook override" >&2
     exit 1
   fi
   grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-env.out
+  if GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.fsmonitor GIT_CONFIG_VALUE_0=/tmp/workcell-fsmonitor git status >/tmp/git-guard-env-fsmonitor.out 2>&1; then
+    echo "expected Workcell git guard to reject GIT_CONFIG_* fsmonitor override" >&2
+    exit 1
+  fi
+  grep -Eq "Workcell blocked git hook bypass|Workcell blocked git control-plane override" /tmp/git-guard-env-fsmonitor.out
   if GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=Core.HooksPath GIT_CONFIG_VALUE_0=/dev/null git commit -m smoke >/tmp/git-guard-env-mixed.out 2>&1; then
     echo "expected Workcell git guard to reject mixed-case GIT_CONFIG_* hook override" >&2
     exit 1

--- a/scripts/install-workcell.sh
+++ b/scripts/install-workcell.sh
@@ -12,7 +12,7 @@ GO_BIN="${WORKCELL_GO_BIN:-}"
 
 usage() {
   cat <<'EOF'
-Usage: install.sh [--debug] [--debug-dir PATH]
+Usage: ./install.sh [--debug] [--debug-dir PATH]
 
 Install Workcell into ~/.local/bin and the man page into ~/.local/share/man/man1.
 

--- a/scripts/lib/go-run-env.sh
+++ b/scripts/lib/go-run-env.sh
@@ -75,6 +75,6 @@ build_go_tool_in_repo() {
   go_bin="$(resolve_go_bin)"
   (
     cd "${repo_root}" &&
-      "${go_bin}" build -o "${output_path}" "$@"
+      "${go_bin}" build -buildvcs=false -o "${output_path}" "$@"
   )
 }

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -136,8 +136,9 @@ release_id="${release_metadata[0]}"
 upload_url="${release_metadata[1]}"
 
 for ((i = 2; i < ${#release_metadata[@]}; i += 2)); do
+  asset_id_index=$((i + 1))
   asset_name="${release_metadata[i]}"
-  asset_id="${release_metadata[i+1]}"
+  asset_id="${release_metadata[asset_id_index]}"
 
   if [[ -n "${asset_id}" ]]; then
     delete_status="$(api DELETE "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" "" "${TMP_ROOT}/delete-${asset_id}.json")"

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -137,7 +137,7 @@ upload_url="${release_metadata[1]}"
 
 for ((i = 2; i < ${#release_metadata[@]}; i += 2)); do
   asset_name="${release_metadata[i]}"
-  asset_id="${release_metadata[i + 1]}"
+  asset_id="${release_metadata[i+1]}"
 
   if [[ -n "${asset_id}" ]]; then
     delete_status="$(api DELETE "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" "" "${TMP_ROOT}/delete-${asset_id}.json")"

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -122,7 +122,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/generate-builder-environment-manifest.sh"
   "${ROOT_DIR}/scripts/generate-release-checksums.sh"
   "${ROOT_DIR}/scripts/generate-build-input-manifest.sh"
-  "${ROOT_DIR}/scripts/install.sh"
+  "${ROOT_DIR}/scripts/install-workcell.sh"
   "${ROOT_DIR}/scripts/uninstall.sh"
   "${ROOT_DIR}/scripts/pre-merge.sh"
   "${ROOT_DIR}/scripts/publish-github-release.sh"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2339,6 +2339,11 @@ if ! sed -n '/^git_alias_value_is_blocked()/,/^}/p' "${ROOT_DIR}/scripts/workcel
   exit 1
 fi
 
+if ! sed -n '/^resolve_existing_executable_or_die()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'is_trusted_host_tool_path'; then
+  echo "Expected resolve_existing_executable_or_die to reject untrusted host executable paths" >&2
+  exit 1
+fi
+
 for _git_env_var in GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_INDEX_FILE; do
   # shellcheck disable=SC2016
   printf -v _git_env_literal '"${%s:-}"' "${_git_env_var}"
@@ -2369,9 +2374,19 @@ if ! sed -n '/^git_index_populate_shadow_dir()/,/^}/p' "${ROOT_DIR}/scripts/work
   exit 1
 fi
 
+if ! sed -n '/^sanitize_shadowed_git_config()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'git_config_key_is_blocked'; then
+  echo "Expected sanitize_shadowed_git_config to reuse the shared blocked git-config key matcher" >&2
+  exit 1
+fi
+
 # shellcheck disable=SC2016
 if ! grep -Fq -- '-path "${ROOT_DIR}/.venv" -prune -o' "${ROOT_DIR}/scripts/validate-repo.sh"; then
   echo "Expected validate-repo.sh to prune repo-local virtualenv content from documentation scans" >&2
+  exit 1
+fi
+
+if ! grep -Fq "build -buildvcs=false -o \"\${output_path}\"" "${ROOT_DIR}/scripts/lib/go-run-env.sh"; then
+  echo "Expected build_go_tool_in_repo to disable Go VCS stamping in untrusted repos" >&2
   exit 1
 fi
 
@@ -4818,6 +4833,34 @@ if "${ROOT_DIR}/scripts/workcell" publish-pr \
 fi
 grep -q 'Invalid publish base branch name: topic.lock' /tmp/workcell-publish-pr-invalid-base.out
 
+cat <<'EOF' >"${PUBLISH_PR_FIXTURE}/gh-untrusted"
+#!/usr/bin/env bash
+printf 'https://example.invalid/pr/123\n'
+EOF
+chmod +x "${PUBLISH_PR_FIXTURE}/gh-untrusted"
+if "${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${PUBLISH_PR_FIXTURE}" \
+  --branch feature/publish-untrusted-gh \
+  --gh-bin "${PUBLISH_PR_FIXTURE}/gh-untrusted" \
+  --title "Untrusted gh" \
+  --commit-message "Untrusted gh commit" \
+  --dry-run >/tmp/workcell-publish-pr-untrusted-gh.out 2>&1; then
+  echo "Expected publish-pr to reject an untrusted --gh-bin path" >&2
+  exit 1
+fi
+grep -q 'gh-bin must point to a trusted host executable path' /tmp/workcell-publish-pr-untrusted-gh.out
+
+if HOST_GH_BIN="${PUBLISH_PR_FIXTURE}/gh-untrusted" bash "${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${PUBLISH_PR_FIXTURE}" \
+  --branch feature/publish-untrusted-host-gh \
+  --title "Untrusted host gh" \
+  --commit-message "Untrusted host gh commit" \
+  --dry-run >/tmp/workcell-publish-pr-untrusted-host-gh.out 2>&1; then
+  echo "Expected publish-pr to reject an untrusted HOST_GH_BIN path" >&2
+  exit 1
+fi
+grep -q 'HOST_GH_BIN must point to a trusted host executable path' /tmp/workcell-publish-pr-untrusted-host-gh.out
+
 git -C "${PUBLISH_PR_FIXTURE}" reset -q --hard HEAD
 git -C "${PUBLISH_PR_FIXTURE}" clean -fdq
 if "${ROOT_DIR}/scripts/workcell" publish-pr \
@@ -4831,6 +4874,115 @@ if "${ROOT_DIR}/scripts/workcell" publish-pr \
   exit 1
 fi
 grep -q 'publish-pr found no workspace changes to publish' /tmp/workcell-publish-pr-noop.out
+
+SHADOW_GIT_CONFIG_HARNESS="$(mktemp)"
+{
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" lower_ascii
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" git_config_key_is_blocked
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" git_alias_value_is_blocked
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" git_commit_short_arg_is_no_verify
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" sanitize_shadowed_git_config
+  cat <<'EOF'
+set -Eeuo pipefail
+HOST_GIT_BIN="$(command -v git)"
+sanitize_shadowed_git_config "$1"
+EOF
+} >"${SHADOW_GIT_CONFIG_HARNESS}"
+chmod +x "${SHADOW_GIT_CONFIG_HARNESS}"
+SHADOW_GIT_CONFIG_FIXTURE="${BARRIER_VERIFY_ROOT}/shadowed-git-config"
+cat <<'EOF' >"${SHADOW_GIT_CONFIG_FIXTURE}"
+[core]
+  askPass = /tmp/askpass
+  editor = /tmp/editor
+  fsMonitor = /tmp/fsmonitor
+  hooksPath = /tmp/hooks
+  pager = /tmp/pager
+  sshCommand = ssh -F /tmp/config
+  worktree = /tmp/worktree
+[credential]
+  helper = store
+[credential "https://example.invalid"]
+  helper = cache
+[diff]
+  external = /tmp/diff
+[include]
+  path = /tmp/include
+[includeIf "gitdir:/tmp/"]
+  path = /tmp/includeif
+[pager]
+  log = /tmp/pager-log
+[sequence]
+  editor = /tmp/sequence-editor
+[alias]
+  bad = -c core.fsmonitor=/tmp/fsmonitor status
+  good = status
+[safe]
+  keep = value
+EOF
+"${SHADOW_GIT_CONFIG_HARNESS}" "${SHADOW_GIT_CONFIG_FIXTURE}"
+for blocked_key in \
+  core.askpass \
+  core.editor \
+  core.fsmonitor \
+  core.hookspath \
+  core.pager \
+  core.sshcommand \
+  core.worktree \
+  credential.helper \
+  diff.external \
+  include.path \
+  pager.log \
+  sequence.editor \
+  alias.bad; do
+  if git config --file "${SHADOW_GIT_CONFIG_FIXTURE}" --get-all "${blocked_key}" >/dev/null 2>&1; then
+    echo "Expected sanitize_shadowed_git_config to strip ${blocked_key}" >&2
+    exit 1
+  fi
+done
+if git config --file "${SHADOW_GIT_CONFIG_FIXTURE}" --name-only --get-regexp '^credential\..*\.helper$' >/dev/null 2>&1; then
+  echo "Expected sanitize_shadowed_git_config to strip credential.*.helper entries" >&2
+  exit 1
+fi
+if git config --file "${SHADOW_GIT_CONFIG_FIXTURE}" --name-only --get-regexp '^includeif\..*\.path$' >/dev/null 2>&1; then
+  echo "Expected sanitize_shadowed_git_config to strip includeIf.*.path entries" >&2
+  exit 1
+fi
+[[ "$(git config --file "${SHADOW_GIT_CONFIG_FIXTURE}" --get alias.good)" == "status" ]]
+[[ "$(git config --file "${SHADOW_GIT_CONFIG_FIXTURE}" --get safe.keep)" == "value" ]]
+
+BUILDVCS_FIXTURE="${BARRIER_VERIFY_ROOT}/buildvcs-fixture"
+mkdir -p "${BUILDVCS_FIXTURE}"
+git init -q "${BUILDVCS_FIXTURE}"
+cat <<'EOF' >"${BUILDVCS_FIXTURE}/go.mod"
+module example.com/workcell/buildvcsfixture
+
+go 1.25.0
+EOF
+cat <<'EOF' >"${BUILDVCS_FIXTURE}/main.go"
+package main
+
+func main() {}
+EOF
+BUILDVCS_MARKER="${BUILDVCS_FIXTURE}/fsmonitor.log"
+cat >"${BUILDVCS_FIXTURE}/fsmonitor.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'fsmonitor-invoked\n' >>"${BUILDVCS_MARKER}"
+exit 0
+EOF
+chmod +x "${BUILDVCS_FIXTURE}/fsmonitor.sh"
+BUILDVCS_OUTPUT="${BUILDVCS_FIXTURE}/fixture-bin"
+git -C "${BUILDVCS_FIXTURE}" config core.fsmonitor "${BUILDVCS_FIXTURE}/fsmonitor.sh"
+build_go_tool_in_repo "${BUILDVCS_FIXTURE}" "${BUILDVCS_OUTPUT}" .
+[[ -x "${BUILDVCS_OUTPUT}" ]]
+if [[ -e "${BUILDVCS_MARKER}" ]]; then
+  echo "Expected build_go_tool_in_repo to avoid repo-controlled fsmonitor execution" >&2
+  exit 1
+fi
 
 MASK_SNAPSHOT_WORKSPACE="${BARRIER_VERIFY_ROOT}/mask-snapshot-workspace"
 mkdir -p "${MASK_SNAPSHOT_WORKSPACE}/.claude"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1031,8 +1031,8 @@ if ! rg -q 'source "\$\{ROOT_DIR\}/scripts/lib/trusted-docker-client\.sh"' "${RO
   exit 1
 fi
 
-if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" "${ROOT_DIR}/scripts/install.sh" >/tmp/workcell-install.out 2>&1; then
-  echo "Expected scripts/install.sh to succeed in a clean temporary HOME" >&2
+if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" "${ROOT_DIR}/install.sh" >/tmp/workcell-install.out 2>&1; then
+  echo "Expected install.sh to succeed in a clean temporary HOME" >&2
   cat /tmp/workcell-install.out >&2
   exit 1
 fi
@@ -1135,8 +1135,8 @@ test ! -e "/tmp/workcell-uninstall-verify.log.$$"
 test ! -e "/tmp/workcell-docker.verify-uninstall.$$"
 grep -q 'Preserved ~/.config/workcell and any user-specified debug/file-trace/transcript files.' /tmp/workcell-uninstall.out
 
-if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" "${ROOT_DIR}/scripts/install.sh" --debug >/tmp/workcell-install-debug.out 2>&1; then
-  echo "Expected scripts/install.sh --debug to succeed in a clean temporary HOME" >&2
+if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" "${ROOT_DIR}/install.sh" --debug >/tmp/workcell-install-debug.out 2>&1; then
+  echo "Expected install.sh --debug to succeed in a clean temporary HOME" >&2
   cat /tmp/workcell-install-debug.out >&2
   exit 1
 fi
@@ -1212,8 +1212,8 @@ grep -q 'Preserved ~/.config/workcell and any user-specified debug/file-trace/tr
 
 CUSTOM_DEBUG_DIR="${INSTALL_VERIFY_HOME}/custom-workcell-debug"
 CUSTOM_DEBUG_DIR_REAL="$(go_verify_metadatautil canonicalize-path "${CUSTOM_DEBUG_DIR}")"
-if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" "${ROOT_DIR}/scripts/install.sh" --debug --debug-dir "${CUSTOM_DEBUG_DIR}" >/tmp/workcell-install-custom-debug.out 2>&1; then
-  echo "Expected scripts/install.sh --debug --debug-dir to succeed in a clean temporary HOME" >&2
+if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" "${ROOT_DIR}/install.sh" --debug --debug-dir "${CUSTOM_DEBUG_DIR}" >/tmp/workcell-install-custom-debug.out 2>&1; then
+  echo "Expected install.sh --debug --debug-dir to succeed in a clean temporary HOME" >&2
   cat /tmp/workcell-install-custom-debug.out >&2
   exit 1
 fi

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1446,14 +1446,22 @@ resolve_existing_executable_or_die() {
   local raw_path="$1"
   local label="$2"
   local resolved_path=""
+  local canonical_path=""
 
   resolved_path="$(resolve_existing_file_or_die "${raw_path}" "${label}")"
   if [[ ! -x "${resolved_path}" ]]; then
     echo "${label} file is not executable: ${raw_path}" >&2
     exit 2
   fi
+  canonical_path="$(canonicalize_host_tool_path "${resolved_path}")"
+  if [[ -z "${canonical_path}" ]] ||
+    ! is_trusted_host_tool_path "${resolved_path}" ||
+    ! is_trusted_host_tool_path "${canonical_path}"; then
+    echo "${label} must point to a trusted host executable path: ${raw_path}" >&2
+    exit 2
+  fi
 
-  printf '%s\n' "${resolved_path}"
+  printf '%s\n' "${canonical_path}"
 }
 
 run_publish_host_command_in_dir() {
@@ -1699,17 +1707,23 @@ publish_pr_main() {
   done
 
   resolved_workspace="$(resolve_existing_directory_or_die "${workspace}")"
-  HOST_GIT_BIN="${HOST_GIT_BIN:-$(resolve_host_tool git /usr/bin/git /opt/homebrew/bin/git /usr/local/bin/git)}"
+  if [[ -n "${HOST_GIT_BIN:-}" ]]; then
+    HOST_GIT_BIN="$(resolve_existing_executable_or_die "${HOST_GIT_BIN}" "HOST_GIT_BIN")"
+  else
+    HOST_GIT_BIN="$(resolve_host_tool git /usr/bin/git /opt/homebrew/bin/git /usr/local/bin/git)"
+  fi
   validate_publish_snapshot_name "${snapshot}"
   validate_publish_branch_name "${branch}"
   validate_publish_base_name "${base}"
   if [[ -n "${gh_bin}" ]]; then
     HOST_GH_BIN="$(resolve_existing_executable_or_die "${gh_bin}" "gh-bin")"
+  elif [[ -n "${HOST_GH_BIN:-}" ]]; then
+    HOST_GH_BIN="$(resolve_existing_executable_or_die "${HOST_GH_BIN}" "HOST_GH_BIN")"
   elif [[ "${dry_run}" -eq 1 ]]; then
-    HOST_GH_BIN="${HOST_GH_BIN:-$(resolve_host_tool_optional gh /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh || true)}"
+    HOST_GH_BIN="$(resolve_host_tool_optional gh /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh || true)"
     [[ -n "${HOST_GH_BIN}" ]] || HOST_GH_BIN="gh"
   else
-    HOST_GH_BIN="${HOST_GH_BIN:-$(resolve_host_tool gh /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh)}"
+    HOST_GH_BIN="$(resolve_host_tool gh /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh)"
   fi
 
   if ! workspace_has_markers "${resolved_workspace}"; then
@@ -3805,13 +3819,23 @@ git_alias_value_is_blocked() {
     [[ "${alias_body_lower}" == *"--exec-path"* ]] ||
     [[ "${alias_body_lower}" == *"--git-dir"* ]] ||
     [[ "${alias_body_lower}" == *"--work-tree"* ]] ||
+    [[ "${alias_body_lower}" == *"core.askpass"* ]] ||
+    [[ "${alias_body_lower}" == *"core.editor"* ]] ||
+    [[ "${alias_body_lower}" == *"core.fsmonitor"* ]] ||
     [[ "${alias_body_lower}" == *"git_exec_path="* ]] ||
     [[ "${alias_body_lower}" == *"git_dir="* ]] ||
     [[ "${alias_body_lower}" == *"git_work_tree="* ]] ||
     [[ "${alias_body_lower}" == *"git_common_dir="* ]] ||
     [[ "${alias_body_lower}" == *"core.hookspath"* ]] ||
+    [[ "${alias_body_lower}" == *"core.pager"* ]] ||
+    [[ "${alias_body_lower}" == *"core.sshcommand"* ]] ||
+    [[ "${alias_body_lower}" == *"core.worktree"* ]] ||
+    [[ "${alias_body_lower}" == *"credential.helper"* ]] ||
+    [[ "${alias_body_lower}" == *"diff.external"* ]] ||
     [[ "${alias_body_lower}" == *"include.path"* ]] ||
-    [[ "${alias_body_lower}" == *"includeif."* ]]; then
+    [[ "${alias_body_lower}" == *"includeif."* ]] ||
+    [[ "${alias_body_lower}" == *"pager."* ]] ||
+    [[ "${alias_body_lower}" == *"sequence.editor"* ]]; then
     return 0
   fi
 
@@ -3825,6 +3849,19 @@ git_alias_value_is_blocked() {
       return 0
     fi
   done
+
+  return 1
+}
+
+git_config_key_is_blocked() {
+  local key_lower=""
+
+  key_lower="$(lower_ascii "$1")"
+  case "${key_lower}" in
+    core.askpass | core.editor | core.fsmonitor | core.hookspath | core.pager | core.sshcommand | core.worktree | credential.helper | credential.*.helper | diff.external | include.path | includeif.*.path | pager.* | sequence.editor)
+      return 0
+      ;;
+  esac
 
   return 1
 }
@@ -3859,10 +3896,11 @@ sanitize_shadowed_git_config() {
   [[ -f "${config_path}" ]] || return 0
 
   while IFS= read -r key; do
+    if git_config_key_is_blocked "${key}"; then
+      "${HOST_GIT_BIN}" config --file "${config_path}" --unset-all "${key}" >/dev/null 2>&1 || true
+      continue
+    fi
     case "$(lower_ascii "${key}")" in
-      core.hookspath | core.worktree | include.path | includeif.*.path)
-        "${HOST_GIT_BIN}" config --file "${config_path}" --unset-all "${key}" >/dev/null 2>&1 || true
-        ;;
       alias.*)
         while IFS= read -r value; do
           if git_alias_value_is_blocked "${value}"; then

--- a/tests/scenarios/manifest.json
+++ b/tests/scenarios/manifest.json
@@ -46,6 +46,17 @@
       "requires_credentials": false
     },
     {
+      "id": "shared/home-control-plane-manifest",
+      "description": "Shared home-control-plane manifest parsing uses one-pass jq readers for copy and ssh entries",
+      "lane": "secretless",
+      "platform": "any",
+      "manual": false,
+      "providers": ["codex", "claude", "gemini"],
+      "persona": "developer",
+      "test_file": "shared/test-home-control-plane-manifest.sh",
+      "requires_credentials": false
+    },
+    {
       "id": "shared/assurance-dry-run",
       "description": "Dry-run scenarios surface prompt-autonomy, breakglass, readonly, arbitrary-command, and control-plane VCS assurance labels across adapters",
       "lane": "secretless",

--- a/tests/scenarios/shared/test-home-control-plane-manifest.sh
+++ b/tests/scenarios/shared/test-home-control-plane-manifest.sh
@@ -9,6 +9,34 @@ cleanup() {
 }
 trap cleanup EXIT
 
+source() {
+  return 0
+}
+
+jq() {
+  printf '1' >>"${JQ_COUNT_FILE}"
+  printf '%s\n' "$*" >>"${JQ_LOG}"
+  command jq "$@"
+}
+
+workcell_die() {
+  printf '%s\n' "$*" >&2
+  return 1
+}
+
+mkdir() {
+  return 0
+}
+
+chmod() {
+  return 0
+}
+
+cp() {
+  printf '%s\t%s\n' "$1" "$2" >>"${SSH_LOG}"
+  return 0
+}
+
 MANIFEST_ROOT="${TMP_DIR}/manifest-root"
 DIRECT_INPUT_ROOT="/opt/workcell/host-inputs"
 JQ_LOG="${TMP_DIR}/jq.log"
@@ -17,7 +45,7 @@ COPIES_LOG="${TMP_DIR}/copies.log"
 SSH_LOG="${TMP_DIR}/ssh.log"
 MANIFEST_PATH="${MANIFEST_ROOT}/manifest.json"
 
-mkdir -p "${MANIFEST_ROOT}/ssh"
+command mkdir -p "${MANIFEST_ROOT}/ssh"
 
 cat >"${MANIFEST_ROOT}/string-copy.txt" <<'EOF'
 string copy source
@@ -86,34 +114,6 @@ cat >"${MANIFEST_PATH}" <<EOF
   }
 }
 EOF
-
-source() {
-  return 0
-}
-
-jq() {
-  printf '1' >>"${JQ_COUNT_FILE}"
-  printf '%s\n' "$*" >>"${JQ_LOG}"
-  command jq "$@"
-}
-
-workcell_die() {
-  printf '%s\n' "$*" >&2
-  return 1
-}
-
-mkdir() {
-  return 0
-}
-
-chmod() {
-  return 0
-}
-
-cp() {
-  printf '%s\t%s\n' "$1" "$2" >>"${SSH_LOG}"
-  return 0
-}
 
 HOME="${TMP_DIR}/session-home"
 # shellcheck disable=SC2034

--- a/tests/scenarios/shared/test-home-control-plane-manifest.sh
+++ b/tests/scenarios/shared/test-home-control-plane-manifest.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-home-control-plane-manifest.XXXXXX")"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+MANIFEST_ROOT="${TMP_DIR}/manifest-root"
+DIRECT_INPUT_ROOT="/opt/workcell/host-inputs"
+JQ_LOG="${TMP_DIR}/jq.log"
+JQ_COUNT_FILE="${TMP_DIR}/jq.count"
+COPIES_LOG="${TMP_DIR}/copies.log"
+SSH_LOG="${TMP_DIR}/ssh.log"
+MANIFEST_PATH="${MANIFEST_ROOT}/manifest.json"
+
+mkdir -p "${MANIFEST_ROOT}/ssh"
+
+cat >"${MANIFEST_ROOT}/string-copy.txt" <<'EOF'
+string copy source
+EOF
+cat >"${MANIFEST_ROOT}/object-copy.txt" <<'EOF'
+object copy source
+EOF
+cat >"${MANIFEST_ROOT}/ssh-config.cfg" <<'EOF'
+Host example
+  User example
+EOF
+cat >"${MANIFEST_ROOT}/ssh-known_hosts" <<'EOF'
+example ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIexample
+EOF
+cat >"${MANIFEST_ROOT}/ssh/id_one" <<'EOF'
+identity one
+EOF
+cat >"${MANIFEST_ROOT}/ssh/id_two" <<'EOF'
+identity two
+EOF
+
+cat >"${MANIFEST_PATH}" <<EOF
+{
+  "copies": [
+    {
+      "source": "string-copy.txt",
+      "target": "${TMP_DIR}/injected/string-copy.out",
+      "kind": "file",
+      "file_mode": "0640",
+      "dir_mode": "0750"
+    },
+    {
+      "source": {
+        "source": "object-copy.txt"
+      },
+      "target": "${TMP_DIR}/injected/object-copy.out",
+      "kind": "file",
+      "file_mode": "0600",
+      "dir_mode": "0700"
+    },
+    {
+      "source": {
+        "mount_path": "${DIRECT_INPUT_ROOT}/mounted-copy.txt"
+      },
+      "target": "${TMP_DIR}/injected/mounted-copy.out",
+      "kind": "file",
+      "file_mode": "0644",
+      "dir_mode": "0755"
+    }
+  ],
+  "ssh": {
+    "config": {
+      "mount_path": "${DIRECT_INPUT_ROOT}/ssh-config.cfg"
+    },
+    "known_hosts": "ssh-known_hosts",
+    "identities": [
+      {
+        "source": "ssh/id_one",
+        "target_name": "id_one"
+      },
+      {
+        "source": "ssh/id_two",
+        "target_name": "id_two"
+      }
+    ]
+  }
+}
+EOF
+
+source() {
+  return 0
+}
+
+jq() {
+  printf '1' >>"${JQ_COUNT_FILE}"
+  printf '%s\n' "$*" >>"${JQ_LOG}"
+  command jq "$@"
+}
+
+workcell_die() {
+  printf '%s\n' "$*" >&2
+  return 1
+}
+
+mkdir() {
+  return 0
+}
+
+chmod() {
+  return 0
+}
+
+cp() {
+  printf '%s\t%s\n' "$1" "$2" >>"${SSH_LOG}"
+  return 0
+}
+
+HOME="${TMP_DIR}/session-home"
+# shellcheck disable=SC2034
+WORKCELL_INJECTION_MANIFEST="${MANIFEST_PATH}"
+
+# shellcheck source=/dev/null
+builtin source "${ROOT_DIR}/runtime/container/home-control-plane.sh"
+
+workcell_target_is_allowed() {
+  return 0
+}
+
+workcell_prepare_session_directory() {
+  return 0
+}
+
+workcell_reset_session_target() {
+  return 0
+}
+
+workcell_validate_direct_mount_path() {
+  case "$1" in
+    "${DIRECT_INPUT_ROOT}"/*) ;;
+    *)
+      workcell_die "unexpected direct mount path: $1"
+      ;;
+  esac
+}
+
+workcell_copy_manifest_entry() {
+  printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" >>"${COPIES_LOG}"
+  return 0
+}
+
+workcell_apply_manifest_copies
+workcell_apply_manifest_ssh
+
+expected_copy_string="$(printf '%s\t%s\t%s\t%s\t%s' "${MANIFEST_ROOT}/string-copy.txt" "${TMP_DIR}/injected/string-copy.out" "file" "0640" "0750")"
+expected_copy_object="$(printf '%s\t%s\t%s\t%s\t%s' "${MANIFEST_ROOT}/object-copy.txt" "${TMP_DIR}/injected/object-copy.out" "file" "0600" "0700")"
+expected_copy_mount="$(printf '%s\t%s\t%s\t%s\t%s' "${DIRECT_INPUT_ROOT}/mounted-copy.txt" "${TMP_DIR}/injected/mounted-copy.out" "file" "0644" "0755")"
+expected_ssh_config="$(printf '%s\t%s' "${DIRECT_INPUT_ROOT}/ssh-config.cfg" "${HOME}/.ssh/config")"
+expected_ssh_known_hosts="$(printf '%s\t%s' "${MANIFEST_ROOT}/ssh-known_hosts" "${HOME}/.ssh/known_hosts")"
+expected_ssh_identity_one="$(printf '%s\t%s' "${MANIFEST_ROOT}/ssh/id_one" "${HOME}/.ssh/id_one")"
+expected_ssh_identity_two="$(printf '%s\t%s' "${MANIFEST_ROOT}/ssh/id_two" "${HOME}/.ssh/id_two")"
+
+grep -Fx "${expected_copy_string}" "${COPIES_LOG}" >/dev/null
+grep -Fx "${expected_copy_object}" "${COPIES_LOG}" >/dev/null
+grep -Fx "${expected_copy_mount}" "${COPIES_LOG}" >/dev/null
+grep -Fx "${expected_ssh_config}" "${SSH_LOG}" >/dev/null
+grep -Fx "${expected_ssh_known_hosts}" "${SSH_LOG}" >/dev/null
+grep -Fx "${expected_ssh_identity_one}" "${SSH_LOG}" >/dev/null
+grep -Fx "${expected_ssh_identity_two}" "${SSH_LOG}" >/dev/null
+
+test "$(wc -c <"${JQ_COUNT_FILE}")" -eq 3
+
+echo "home-control-plane manifest parsing scenario passed"

--- a/tests/scenarios/shared/test-publish-pr-dry-run.sh
+++ b/tests/scenarios/shared/test-publish-pr-dry-run.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-publish-pr-scenario.XXXXXX")"
 
 cleanup() {
+  rm -f "${TRUSTED_GH_STUB:-}"
   rm -rf "${TMP_DIR}"
 }
 trap cleanup EXIT
@@ -13,7 +14,7 @@ FIXTURE="${TMP_DIR}/publish-pr-fixture"
 ORIGIN="${TMP_DIR}/publish-pr-origin.git"
 SSH_SIGNING_KEY="${TMP_DIR}/signing_key"
 ALLOWED_SIGNERS="${TMP_DIR}/allowed_signers"
-GH_STUB="${TMP_DIR}/gh-stub"
+UNTRUSTED_GH_STUB="${TMP_DIR}/gh-stub"
 GH_LOG="${TMP_DIR}/gh.log"
 HOOK_MARKER_DIR="${TMP_DIR}/hook-markers"
 TITLE_FILE="${TMP_DIR}/pr-title.txt"
@@ -22,6 +23,20 @@ COMMIT_MESSAGE_FILE="${TMP_DIR}/commit-message.txt"
 LIVE_TITLE_FILE="${TMP_DIR}/live-pr-title.txt"
 LIVE_BODY_FILE="${TMP_DIR}/live-pr-body.md"
 LIVE_COMMIT_MESSAGE_FILE="${TMP_DIR}/live-commit-message.txt"
+TRUSTED_BIN_DIR=""
+TRUSTED_GH_STUB=""
+
+for candidate in /opt/homebrew/bin /usr/local/bin; do
+  if [[ -d "${candidate}" ]] && [[ -w "${candidate}" ]]; then
+    TRUSTED_BIN_DIR="${candidate}"
+    break
+  fi
+done
+if [[ -z "${TRUSTED_BIN_DIR}" ]]; then
+  echo "missing writable trusted host bin directory" >&2
+  exit 1
+fi
+TRUSTED_GH_STUB="${TRUSTED_BIN_DIR}/workcell-gh-scenario-${RANDOM}-$$"
 
 mkdir -p "${FIXTURE}" "${HOOK_MARKER_DIR}"
 git init -q --bare "${ORIGIN}"
@@ -144,19 +159,54 @@ EOF
 cat >"${LIVE_COMMIT_MESSAGE_FILE}" <<'EOF'
 Live scenario commit
 EOF
-cat >"${GH_STUB}" <<EOF
+cat >"${UNTRUSTED_GH_STUB}" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "\$*" >"${GH_LOG}"
 printf 'https://example.invalid/pr/123\n'
 EOF
-chmod +x "${GH_STUB}"
+chmod +x "${UNTRUSTED_GH_STUB}"
+
+set +e
+untrusted_gh_output="$("${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${FIXTURE}" \
+  --branch feature/publish-live \
+  --gh-bin "${UNTRUSTED_GH_STUB}" \
+  --title-file "${LIVE_TITLE_FILE}" \
+  --body-file "${LIVE_BODY_FILE}" \
+  --commit-message-file "${LIVE_COMMIT_MESSAGE_FILE}" \
+  --dry-run 2>&1)"
+untrusted_gh_rc=$?
+set -e
+test "${untrusted_gh_rc}" -eq 2
+grep -q 'gh-bin must point to a trusted host executable path' <<<"${untrusted_gh_output}"
+
+set +e
+host_gh_output="$(HOST_GH_BIN="${UNTRUSTED_GH_STUB}" bash "${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${FIXTURE}" \
+  --branch feature/publish-live \
+  --title-file "${LIVE_TITLE_FILE}" \
+  --body-file "${LIVE_BODY_FILE}" \
+  --commit-message-file "${LIVE_COMMIT_MESSAGE_FILE}" \
+  --dry-run 2>&1)"
+host_gh_rc=$?
+set -e
+test "${host_gh_rc}" -eq 2
+grep -q 'HOST_GH_BIN must point to a trusted host executable path' <<<"${host_gh_output}"
+
+cat >"${TRUSTED_GH_STUB}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >"${GH_LOG}"
+printf 'https://example.invalid/pr/123\n'
+EOF
+chmod +x "${TRUSTED_GH_STUB}"
 
 publish_output="$(
   "${ROOT_DIR}/scripts/workcell" publish-pr \
     --workspace "${FIXTURE}" \
     --branch feature/publish-live \
-    --gh-bin "${GH_STUB}" \
+    --gh-bin "${TRUSTED_GH_STUB}" \
     --title-file "${LIVE_TITLE_FILE}" \
     --body-file "${LIVE_BODY_FILE}" \
     --commit-message-file "${LIVE_COMMIT_MESSAGE_FILE}" \


### PR DESCRIPTION
## Summary
- harden host-side publication and git config sanitization paths
- implement the empirically highest-impact local performance improvements
- expand scenario, invariant, and mutation coverage for the new controls

## Review scope
- reviewed all currently open PRs: none
- reviewed Rick Erickson PRs #52 and #61: both were closed and superseded; no practical delta remained beyond main

## Validation
- bash scripts/validate-repo.sh
- go test ./internal/metadatautil ./internal/paritytree ./internal/mutation
- cargo +1.94.1 test --manifest-path runtime/container/rust/Cargo.toml --locked --offline
- bash tests/scenarios/shared/test-home-control-plane-manifest.sh
- bash tests/scenarios/shared/test-publish-pr-dry-run.sh