### PR TITLE
fix: preserve manifest output paths across release roots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,23 +342,23 @@ jobs:
           WORKCELL_BUILD_INPUT_ROOT: ${{ github.workspace }}/dist/release-source
           WORKCELL_BUILD_INPUT_REF: ${{ github.sha }}
           SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
-        run: ./scripts/generate-build-input-manifest.sh dist/workcell-build-inputs.json
+        run: ./scripts/generate-build-input-manifest.sh dist/workcell-build-inputs-archived.json
 
       - name: Regenerate control-plane manifest from archived source tree
         env:
           WORKCELL_CONTROL_PLANE_ROOT: ${{ github.workspace }}/dist/release-source
-        run: ./scripts/generate-control-plane-manifest.sh dist/workcell-control-plane.json
+        run: ./scripts/generate-control-plane-manifest.sh dist/workcell-control-plane-archived.json
 
       - name: Verify build input manifest matches preflight
         run: |
           cmp -s \
-            dist/workcell-build-inputs.json \
+            dist/workcell-build-inputs-archived.json \
             dist/preflight/workcell-build-inputs-preflight.json
 
       - name: Verify control-plane manifest matches preflight
         run: |
           cmp -s \
-            dist/workcell-control-plane.json \
+            dist/workcell-control-plane-archived.json \
             dist/preflight/workcell-control-plane-preflight.json
 
       - id: build_amd64

--- a/scripts/generate-build-input-manifest.sh
+++ b/scripts/generate-build-input-manifest.sh
@@ -60,11 +60,22 @@ resolve_go_bin() {
   exit 1
 }
 
+resolve_output_path() {
+  local candidate="$1"
+
+  case "${candidate}" in
+    /*) printf '%s\n' "${candidate}" ;;
+    ./*) printf '%s/%s\n' "$(pwd -P)" "${candidate#./}" ;;
+    *) printf '%s/%s\n' "$(pwd -P)" "${candidate}" ;;
+  esac
+}
+
 [[ -n "${OUTPUT_PATH}" ]] || {
   echo "usage: $0 OUTPUT_PATH" >&2
   exit 64
 }
 
 GO_BIN="$(resolve_go_bin)"
+OUTPUT_PATH="$(resolve_output_path "${OUTPUT_PATH}")"
 
 (cd "${ROOT_DIR}" && "${GO_BIN}" run ./cmd/workcell-metadatautil generate-build-input-manifest "${DOCKERFILE_PATH}" "${PACKAGE_JSON_PATH}" "${PACKAGE_LOCK_PATH}" "${OUTPUT_PATH}" "${BUILD_REF}" "${SOURCE_DATE_EPOCH}" "${REQUIRE_TRACKED}")

--- a/scripts/generate-control-plane-manifest.sh
+++ b/scripts/generate-control-plane-manifest.sh
@@ -51,11 +51,22 @@ resolve_go_bin() {
   exit 1
 }
 
+resolve_output_path() {
+  local candidate="$1"
+
+  case "${candidate}" in
+    /*) printf '%s\n' "${candidate}" ;;
+    ./*) printf '%s/%s\n' "$(pwd -P)" "${candidate#./}" ;;
+    *) printf '%s/%s\n' "$(pwd -P)" "${candidate}" ;;
+  esac
+}
+
 [[ -n "${OUTPUT_PATH}" ]] || {
   echo "usage: $0 OUTPUT_PATH" >&2
   exit 64
 }
 
 GO_BIN="$(resolve_go_bin)"
+OUTPUT_PATH="$(resolve_output_path "${OUTPUT_PATH}")"
 
 (cd "${ROOT_DIR}" && "${GO_BIN}" run ./cmd/workcell-metadatautil generate-control-plane-manifest "${ROOT_DIR}" "${OUTPUT_PATH}")

--- a/scripts/verify-build-input-manifest.sh
+++ b/scripts/verify-build-input-manifest.sh
@@ -98,9 +98,15 @@ if safe_git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; th
     "${ROOT_DIR}/scripts/generate-build-input-manifest.sh" "${TMP_ROOT}/archive-outside.json"
   WORKCELL_BUILD_INPUT_ROOT="${NESTED_ROOT}" \
     "${ROOT_DIR}/scripts/generate-build-input-manifest.sh" "${TMP_ROOT}/archive-nested.json"
+  (
+    cd "${TMP_ROOT}"
+    WORKCELL_BUILD_INPUT_ROOT="${ARCHIVE_ROOT}" \
+      "${ROOT_DIR}/scripts/generate-build-input-manifest.sh" "archive-relative.json"
+  )
 
   digest_archive_outside="$(shasum -a 256 "${TMP_ROOT}/archive-outside.json" | awk '{print $1}')"
   digest_archive_nested="$(shasum -a 256 "${TMP_ROOT}/archive-nested.json" | awk '{print $1}')"
+  digest_archive_relative="$(shasum -a 256 "${TMP_ROOT}/archive-relative.json" | awk '{print $1}')"
   if [[ "${digest_a}" != "${digest_archive_outside}" ]]; then
     echo "Archived-source manifest diverged from the tracked working-tree manifest: ${digest_archive_outside} != ${digest_a}" >&2
     diff -u "${TMP_ROOT}/a.json" "${TMP_ROOT}/archive-outside.json" || true
@@ -109,6 +115,11 @@ if safe_git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; th
   if [[ "${digest_archive_outside}" != "${digest_archive_nested}" ]]; then
     echo "Nested archived-source manifest diverged from standalone archived-source manifest: ${digest_archive_nested} != ${digest_archive_outside}" >&2
     diff -u "${TMP_ROOT}/archive-outside.json" "${TMP_ROOT}/archive-nested.json" || true
+    exit 1
+  fi
+  if [[ "${digest_archive_outside}" != "${digest_archive_relative}" ]]; then
+    echo "Relative-output archived-source manifest diverged from absolute-output archived-source manifest: ${digest_archive_relative} != ${digest_archive_outside}" >&2
+    diff -u "${TMP_ROOT}/archive-outside.json" "${TMP_ROOT}/archive-relative.json" || true
     exit 1
   fi
 fi

--- a/scripts/verify-control-plane-manifest.sh
+++ b/scripts/verify-control-plane-manifest.sh
@@ -132,9 +132,15 @@ if safe_git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; th
     "${ROOT_DIR}/scripts/generate-control-plane-manifest.sh" "${TMP_ROOT}/archive-outside.json"
   WORKCELL_CONTROL_PLANE_ROOT="${NESTED_ROOT}" \
     "${ROOT_DIR}/scripts/generate-control-plane-manifest.sh" "${TMP_ROOT}/archive-nested.json"
+  (
+    cd "${TMP_ROOT}"
+    WORKCELL_CONTROL_PLANE_ROOT="${ARCHIVE_ROOT}" \
+      "${ROOT_DIR}/scripts/generate-control-plane-manifest.sh" "archive-relative.json"
+  )
 
   digest_archive_outside="$(shasum -a 256 "${TMP_ROOT}/archive-outside.json" | awk '{print $1}')"
   digest_archive_nested="$(shasum -a 256 "${TMP_ROOT}/archive-nested.json" | awk '{print $1}')"
+  digest_archive_relative="$(shasum -a 256 "${TMP_ROOT}/archive-relative.json" | awk '{print $1}')"
   if [[ "${digest_a}" != "${digest_archive_outside}" ]]; then
     echo "Archived-source control-plane manifest diverged from the tracked working-tree manifest: ${digest_archive_outside} != ${digest_a}" >&2
     diff -u "${TMP_ROOT}/a.json" "${TMP_ROOT}/archive-outside.json" || true
@@ -143,6 +149,11 @@ if safe_git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; th
   if [[ "${digest_archive_outside}" != "${digest_archive_nested}" ]]; then
     echo "Nested archived-source control-plane manifest diverged from standalone archived-source manifest: ${digest_archive_nested} != ${digest_archive_outside}" >&2
     diff -u "${TMP_ROOT}/archive-outside.json" "${TMP_ROOT}/archive-nested.json" || true
+    exit 1
+  fi
+  if [[ "${digest_archive_outside}" != "${digest_archive_relative}" ]]; then
+    echo "Relative-output archived-source control-plane manifest diverged from absolute-output archived-source manifest: ${digest_archive_relative} != ${digest_archive_outside}" >&2
+    diff -u "${TMP_ROOT}/archive-outside.json" "${TMP_ROOT}/archive-relative.json" || true
     exit 1
   fi
 


### PR DESCRIPTION
## Summary
- preserve caller-relative output paths when manifest scripts are pointed at archived source roots
- add regression coverage for relative-output archived-root generation
- harden release verification to compare archived manifests under distinct output names

## Validation
- bash scripts/verify-control-plane-manifest.sh
- bash scripts/verify-build-input-manifest.sh
- bash scripts/validate-repo.sh
- local reproduction of the failed archived-source release comparison path
