### PR TITLE
fix: canonicalize symlinked release source roots

### DIFF
--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -13,12 +13,12 @@ Use this page with:
 These run without provider credentials:
 
 - `./scripts/dev-quick-check.sh`
-- `./scripts/build-and-test.sh` (host-native by default; `--docker` reruns repo validation inside the CI validator container)
+- `./scripts/build-and-test.sh` (host-native by default; `--docker` reruns repo validation inside the pinned CI validator container from a disposable snapshot)
 - `./scripts/container-smoke.sh`
 - `./scripts/verify-invariants.sh`
 - `./scripts/verify-release-bundle.sh`
 - `./scripts/verify-reproducible-build.sh`
-- `./scripts/pre-merge.sh`
+- `./scripts/pre-merge.sh` (builds or reuses the same pinned validator container and can run the local stack from a disposable snapshot before optional remote lanes)
 
 They cover repo shape, runtime contracts, smoke behavior, and reproducibility.
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -33,6 +33,7 @@ reproducible runtime for the supported providers.
 - `scripts/container-smoke.sh`: direct container smoke coverage
 - `scripts/verify-invariants.sh`: invariant checks
 - `scripts/build-and-test.sh`: repo-wide validation and local check entry point
+- `scripts/pre-merge.sh`: pinned validator-container pre-merge harness with optional disposable snapshot and remote validation lanes
 
 ## GUI status
 

--- a/scripts/generate-build-input-manifest.sh
+++ b/scripts/generate-build-input-manifest.sh
@@ -21,14 +21,7 @@ if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   exit 0
 fi
 
-ROOT_DIR="${WORKCELL_BUILD_INPUT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 OUTPUT_PATH="${1:-}"
-DOCKERFILE_PATH="${ROOT_DIR}/runtime/container/Dockerfile"
-PACKAGE_JSON_PATH="${ROOT_DIR}/runtime/container/providers/package.json"
-PACKAGE_LOCK_PATH="${ROOT_DIR}/runtime/container/providers/package-lock.json"
-BUILD_REF="${WORKCELL_BUILD_INPUT_REF:-$(git -C "${ROOT_DIR}" rev-parse HEAD 2>/dev/null || printf 'UNKNOWN')}"
-SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -C "${ROOT_DIR}" log -1 --pretty=%ct 2>/dev/null || printf '0')}"
-REQUIRE_TRACKED="${WORKCELL_BUILD_INPUT_REQUIRE_TRACKED:-0}"
 
 require_tool() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -60,6 +53,14 @@ resolve_go_bin() {
   exit 1
 }
 
+resolve_root_path() {
+  local candidate="$1"
+  (
+    cd "${candidate}"
+    pwd -P
+  )
+}
+
 resolve_output_path() {
   local candidate="$1"
 
@@ -75,6 +76,13 @@ resolve_output_path() {
   exit 64
 }
 
+ROOT_DIR="$(resolve_root_path "${WORKCELL_BUILD_INPUT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)}")"
+DOCKERFILE_PATH="${ROOT_DIR}/runtime/container/Dockerfile"
+PACKAGE_JSON_PATH="${ROOT_DIR}/runtime/container/providers/package.json"
+PACKAGE_LOCK_PATH="${ROOT_DIR}/runtime/container/providers/package-lock.json"
+BUILD_REF="${WORKCELL_BUILD_INPUT_REF:-$(git -C "${ROOT_DIR}" rev-parse HEAD 2>/dev/null || printf 'UNKNOWN')}"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -C "${ROOT_DIR}" log -1 --pretty=%ct 2>/dev/null || printf '0')}"
+REQUIRE_TRACKED="${WORKCELL_BUILD_INPUT_REQUIRE_TRACKED:-0}"
 GO_BIN="$(resolve_go_bin)"
 OUTPUT_PATH="$(resolve_output_path "${OUTPUT_PATH}")"
 

--- a/scripts/generate-control-plane-manifest.sh
+++ b/scripts/generate-control-plane-manifest.sh
@@ -18,7 +18,6 @@ if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   exit 0
 fi
 
-ROOT_DIR="${WORKCELL_CONTROL_PLANE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 OUTPUT_PATH="${1:-}"
 
 require_tool() {
@@ -51,6 +50,14 @@ resolve_go_bin() {
   exit 1
 }
 
+resolve_root_path() {
+  local candidate="$1"
+  (
+    cd "${candidate}"
+    pwd -P
+  )
+}
+
 resolve_output_path() {
   local candidate="$1"
 
@@ -66,6 +73,7 @@ resolve_output_path() {
   exit 64
 }
 
+ROOT_DIR="$(resolve_root_path "${WORKCELL_CONTROL_PLANE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)}")"
 GO_BIN="$(resolve_go_bin)"
 OUTPUT_PATH="$(resolve_output_path "${OUTPUT_PATH}")"
 

--- a/scripts/verify-build-input-manifest.sh
+++ b/scripts/verify-build-input-manifest.sh
@@ -90,14 +90,18 @@ if safe_git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; th
   mkdir -p "${ROOT_DIR}/tmp"
   NESTED_ROOT="$(mktemp -d "${ROOT_DIR}/tmp/workcell-build-input-nested.XXXXXX")"
   ARCHIVE_ROOT="${TMP_ROOT}/archived-source"
+  ARCHIVE_ROOT_LINK="${TMP_ROOT}/archived-source-link"
   copy_tracked_worktree "${ARCHIVE_ROOT}"
   copy_tracked_worktree "${NESTED_ROOT}"
+  ln -s "${ARCHIVE_ROOT}" "${ARCHIVE_ROOT_LINK}"
 
   unset WORKCELL_BUILD_INPUT_REQUIRE_TRACKED
   WORKCELL_BUILD_INPUT_ROOT="${ARCHIVE_ROOT}" \
     "${ROOT_DIR}/scripts/generate-build-input-manifest.sh" "${TMP_ROOT}/archive-outside.json"
   WORKCELL_BUILD_INPUT_ROOT="${NESTED_ROOT}" \
     "${ROOT_DIR}/scripts/generate-build-input-manifest.sh" "${TMP_ROOT}/archive-nested.json"
+  WORKCELL_BUILD_INPUT_ROOT="${ARCHIVE_ROOT_LINK}" \
+    "${ROOT_DIR}/scripts/generate-build-input-manifest.sh" "${TMP_ROOT}/archive-symlink-root.json"
   (
     cd "${TMP_ROOT}"
     WORKCELL_BUILD_INPUT_ROOT="${ARCHIVE_ROOT}" \
@@ -107,6 +111,7 @@ if safe_git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; th
   digest_archive_outside="$(shasum -a 256 "${TMP_ROOT}/archive-outside.json" | awk '{print $1}')"
   digest_archive_nested="$(shasum -a 256 "${TMP_ROOT}/archive-nested.json" | awk '{print $1}')"
   digest_archive_relative="$(shasum -a 256 "${TMP_ROOT}/archive-relative.json" | awk '{print $1}')"
+  digest_archive_symlink_root="$(shasum -a 256 "${TMP_ROOT}/archive-symlink-root.json" | awk '{print $1}')"
   if [[ "${digest_a}" != "${digest_archive_outside}" ]]; then
     echo "Archived-source manifest diverged from the tracked working-tree manifest: ${digest_archive_outside} != ${digest_a}" >&2
     diff -u "${TMP_ROOT}/a.json" "${TMP_ROOT}/archive-outside.json" || true
@@ -120,6 +125,11 @@ if safe_git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; th
   if [[ "${digest_archive_outside}" != "${digest_archive_relative}" ]]; then
     echo "Relative-output archived-source manifest diverged from absolute-output archived-source manifest: ${digest_archive_relative} != ${digest_archive_outside}" >&2
     diff -u "${TMP_ROOT}/archive-outside.json" "${TMP_ROOT}/archive-relative.json" || true
+    exit 1
+  fi
+  if [[ "${digest_archive_outside}" != "${digest_archive_symlink_root}" ]]; then
+    echo "Symlink-root archived-source manifest diverged from physical-root archived-source manifest: ${digest_archive_symlink_root} != ${digest_archive_outside}" >&2
+    diff -u "${TMP_ROOT}/archive-outside.json" "${TMP_ROOT}/archive-symlink-root.json" || true
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary
- canonicalize overridden manifest source roots to their physical directory before generating manifests
- add build-input regression coverage for symlinked archived roots
- preserve the release workflow hardening from the prior repair by comparing archived-source outputs under distinct filenames

## Validation
- bash scripts/verify-control-plane-manifest.sh
- bash scripts/verify-build-input-manifest.sh
- bash scripts/validate-repo.sh
- local reproduction of the archived-source build-input diff from the failed release run
