### PR TITLE
fix: restore release checksum asset contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,7 +347,7 @@ jobs:
       - name: Regenerate control-plane manifest from archived source tree
         env:
           WORKCELL_CONTROL_PLANE_ROOT: ${{ github.workspace }}/dist/release-source
-        run: ./scripts/generate-control-plane-manifest.sh dist/workcell-control-plane-archived.json
+        run: ./scripts/generate-control-plane-manifest.sh dist/workcell-control-plane.json
 
       - name: Verify build input manifest matches preflight
         run: |
@@ -358,7 +358,7 @@ jobs:
       - name: Verify control-plane manifest matches preflight
         run: |
           cmp -s \
-            dist/workcell-control-plane-archived.json \
+            dist/workcell-control-plane.json \
             dist/preflight/workcell-control-plane-preflight.json
 
       - id: build_amd64

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -106,6 +106,19 @@ func CheckWorkflows(rootDir, policyPath string) error {
 
 func ensureWorkflowTools() error { return nil }
 
+func validateReleaseWorkflowControlPlaneFlow(releaseWorkflow string) error {
+	if !strings.Contains(releaseWorkflow, "dist/workcell-control-plane-preflight.json") {
+		return errors.New(".github/workflows/release.yml must keep the reviewed control-plane manifest flow")
+	}
+	if !strings.Contains(releaseWorkflow, "run: ./scripts/generate-control-plane-manifest.sh dist/workcell-control-plane.json") {
+		return errors.New(".github/workflows/release.yml must regenerate the published control-plane manifest under dist/workcell-control-plane.json")
+	}
+	if !regexp.MustCompile(`(?s)Verify control-plane manifest matches preflight.*?cmp -s \\\s+dist/workcell-control-plane\.json \\\s+dist/preflight/workcell-control-plane-preflight\.json`).MatchString(releaseWorkflow) {
+		return errors.New(".github/workflows/release.yml must verify the published control-plane manifest against the preflight artifact")
+	}
+	return nil
+}
+
 func FetchGitHubHostedControlsRulesets(tmpDir, repo string) error {
 	var summary []any
 	if err := readJSONFile(filepath.Join(tmpDir, "rulesets-summary.json"), &summary); err != nil {
@@ -1277,9 +1290,8 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		!strings.Contains(releaseWorkflow, "dist/workcell-image.spdx.sigstore.json") {
 		return errors.New(".github/workflows/release.yml must publish direct signature bundles for release artifacts")
 	}
-	if !strings.Contains(releaseWorkflow, "dist/workcell-control-plane-preflight.json") ||
-		!strings.Contains(releaseWorkflow, "dist/workcell-control-plane.json") {
-		return errors.New(".github/workflows/release.yml must keep the reviewed control-plane manifest flow")
+	if err := validateReleaseWorkflowControlPlaneFlow(releaseWorkflow); err != nil {
+		return err
 	}
 	if strings.Contains(releaseWorkflow, "steps.build.outputs.digest") {
 		return errors.New(".github/workflows/release.yml must not keep referencing the old single-step multi-platform digest output")

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -122,3 +122,53 @@ contexts = [
 		t.Fatalf("CheckWorkflows() error = %v, want missing Validate repository", err)
 	}
 }
+
+func TestValidateReleaseWorkflowControlPlaneFlowRejectsMissingCanonicalArtifact(t *testing.T) {
+	releaseWorkflow := `      - name: Generate preflight control-plane manifest
+        run: |
+          mkdir -p dist
+          ./scripts/generate-control-plane-manifest.sh dist/workcell-control-plane-preflight.json
+
+      - name: Regenerate control-plane manifest from archived source tree
+        env:
+          WORKCELL_CONTROL_PLANE_ROOT: ${{ github.workspace }}/dist/release-source
+        run: ./scripts/generate-control-plane-manifest.sh dist/workcell-control-plane-archived.json
+
+      - name: Verify control-plane manifest matches preflight
+        run: |
+          cmp -s \
+            dist/workcell-control-plane-archived.json \
+            dist/preflight/workcell-control-plane-preflight.json
+`
+
+	err := validateReleaseWorkflowControlPlaneFlow(releaseWorkflow)
+	if err == nil {
+		t.Fatal("validateReleaseWorkflowControlPlaneFlow() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "dist/workcell-control-plane.json") {
+		t.Fatalf("validateReleaseWorkflowControlPlaneFlow() error = %v, want canonical control-plane artifact path", err)
+	}
+}
+
+func TestValidateReleaseWorkflowControlPlaneFlowAcceptsCanonicalArtifact(t *testing.T) {
+	releaseWorkflow := `      - name: Generate preflight control-plane manifest
+        run: |
+          mkdir -p dist
+          ./scripts/generate-control-plane-manifest.sh dist/workcell-control-plane-preflight.json
+
+      - name: Regenerate control-plane manifest from archived source tree
+        env:
+          WORKCELL_CONTROL_PLANE_ROOT: ${{ github.workspace }}/dist/release-source
+        run: ./scripts/generate-control-plane-manifest.sh dist/workcell-control-plane.json
+
+      - name: Verify control-plane manifest matches preflight
+        run: |
+          cmp -s \
+            dist/workcell-control-plane.json \
+            dist/preflight/workcell-control-plane-preflight.json
+`
+
+	if err := validateReleaseWorkflowControlPlaneFlow(releaseWorkflow); err != nil {
+		t.Fatalf("validateReleaseWorkflowControlPlaneFlow() error = %v", err)
+	}
+}

--- a/scripts/generate-release-checksums.sh
+++ b/scripts/generate-release-checksums.sh
@@ -29,7 +29,7 @@ EOF
 output_path="$1"
 shift
 
-seen_basenames=()
+seen_basenames=""
 
 for path in "$@"; do
   [[ -f "${path}" ]] || {
@@ -38,13 +38,15 @@ for path in "$@"; do
   }
 
   base_name="$(basename "${path}")"
-  for seen_base in "${seen_basenames[@]}"; do
-    if [[ "${seen_base}" == "${base_name}" ]]; then
-      echo "Duplicate release asset basename: ${base_name}" >&2
-      exit 1
-    fi
-  done
-  seen_basenames+=("${base_name}")
+  if [[ -n "${seen_basenames}" ]]; then
+    while IFS= read -r seen_base; do
+      if [[ "${seen_base}" == "${base_name}" ]]; then
+        echo "Duplicate release asset basename: ${base_name}" >&2
+        exit 1
+      fi
+    done <<<"${seen_basenames}"
+  fi
+  seen_basenames+="${base_name}"$'\n'
 done
 
 tmp_output="$(mktemp "${TMPDIR:-/tmp}/workcell-sha256sums.XXXXXX")"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2519,6 +2519,25 @@ for script in "${HOST_GATE_SCRIPTS[@]}"; do
   fi
 done
 
+RELEASE_CHECKSUMS_VERIFY_ROOT="${BARRIER_VERIFY_ROOT}/release-checksums"
+mkdir -p "${RELEASE_CHECKSUMS_VERIFY_ROOT}"
+printf 'alpha\n' >"${RELEASE_CHECKSUMS_VERIFY_ROOT}/asset-a.txt"
+printf 'bravo\n' >"${RELEASE_CHECKSUMS_VERIFY_ROOT}/asset-b.txt"
+"${ROOT_DIR}/scripts/generate-release-checksums.sh" \
+  "${RELEASE_CHECKSUMS_VERIFY_ROOT}/SHA256SUMS" \
+  "${RELEASE_CHECKSUMS_VERIFY_ROOT}/asset-a.txt" \
+  "${RELEASE_CHECKSUMS_VERIFY_ROOT}/asset-b.txt"
+if [[ ! -f "${RELEASE_CHECKSUMS_VERIFY_ROOT}/SHA256SUMS" ]]; then
+  echo "Expected generate-release-checksums.sh to emit a checksum manifest for valid release assets" >&2
+  exit 1
+fi
+if ! grep -q '  asset-a.txt$' "${RELEASE_CHECKSUMS_VERIFY_ROOT}/SHA256SUMS" ||
+  ! grep -q '  asset-b.txt$' "${RELEASE_CHECKSUMS_VERIFY_ROOT}/SHA256SUMS"; then
+  echo "Expected generate-release-checksums.sh to list every supplied release asset by basename" >&2
+  cat "${RELEASE_CHECKSUMS_VERIFY_ROOT}/SHA256SUMS" >&2
+  exit 1
+fi
+
 CONTAINER_SMOKE_BASH_ENV_MARKER="${BARRIER_VERIFY_ROOT}/container-smoke-bashenv-ran"
 if ! HOST_BASH_ENV_MARKER="${CONTAINER_SMOKE_BASH_ENV_MARKER}" \
   BASH_ENV="${HOST_BASH_ENV_PAYLOAD}" \

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2537,6 +2537,22 @@ if ! grep -q '  asset-a.txt$' "${RELEASE_CHECKSUMS_VERIFY_ROOT}/SHA256SUMS" ||
   cat "${RELEASE_CHECKSUMS_VERIFY_ROOT}/SHA256SUMS" >&2
   exit 1
 fi
+mkdir -p "${RELEASE_CHECKSUMS_VERIFY_ROOT}/dup-a" "${RELEASE_CHECKSUMS_VERIFY_ROOT}/dup-b"
+printf 'charlie\n' >"${RELEASE_CHECKSUMS_VERIFY_ROOT}/dup-a/asset.txt"
+printf 'delta\n' >"${RELEASE_CHECKSUMS_VERIFY_ROOT}/dup-b/asset.txt"
+if "${ROOT_DIR}/scripts/generate-release-checksums.sh" \
+  "${RELEASE_CHECKSUMS_VERIFY_ROOT}/SHA256SUMS-duplicate" \
+  "${RELEASE_CHECKSUMS_VERIFY_ROOT}/dup-a/asset.txt" \
+  "${RELEASE_CHECKSUMS_VERIFY_ROOT}/dup-b/asset.txt" \
+  >/tmp/workcell-release-checksums-duplicate.out 2>&1; then
+  echo "Expected generate-release-checksums.sh to reject duplicate release asset basenames" >&2
+  exit 1
+fi
+if ! grep -q 'Duplicate release asset basename: asset.txt' /tmp/workcell-release-checksums-duplicate.out; then
+  echo "Expected generate-release-checksums.sh duplicate-basename rejection to explain the conflicting asset" >&2
+  cat /tmp/workcell-release-checksums-duplicate.out >&2
+  exit 1
+fi
 
 CONTAINER_SMOKE_BASH_ENV_MARKER="${BARRIER_VERIFY_ROOT}/container-smoke-bashenv-ran"
 if ! HOST_BASH_ENV_MARKER="${CONTAINER_SMOKE_BASH_ENV_MARKER}" \


### PR DESCRIPTION
## Summary
- generate and verify the canonical published control-plane manifest in the release workflow
- lock the release workflow contract in metadata validation tests
- make release checksum generation portable to the local macOS host shell and exercise it in verify-invariants

## Validation
- go test ./internal/metadatautil/...
- ./scripts/check-pinned-inputs.sh
- bash scripts/validate-repo.sh
- local archived-source checksum harness for generate-control-plane-manifest.sh + generate-release-checksums.sh