### PR TITLE
fix: gate release attestations on supported hosted controls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ concurrency:
 
 env:
   ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}
+  ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ github.event.repository.visibility == 'public' || vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS == 'true' }}
   IMAGE_NAME: ghcr.io/${{ github.repository }}
   WORKCELL_BUILDKIT_IMAGE: moby/buildkit:buildx-stable-1@sha256:37539dd4d60fc70968d164d3850d903a2c56f6402214a1953fbf9fcb81ada731
   WORKCELL_BUILDX_VERSION: v0.32.1
@@ -604,14 +605,14 @@ jobs:
             dist/workcell-image.spdx.json
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-name: ${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.publish_manifest.outputs.digest }}
           push-to-registry: true
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           sbom-path: dist/workcell-image.spdx.json
           subject-name: ${{ env.IMAGE_NAME }}
@@ -619,12 +620,12 @@ jobs:
           push-to-registry: true
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/${{ env.BUNDLE_NAME }}
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           sbom-path: dist/workcell-source.spdx.json
           subject-path: dist/${{ env.BUNDLE_NAME }}

--- a/README.md
+++ b/README.md
@@ -167,11 +167,12 @@ Tagged releases are rebuilt and verified before publication. The release path:
 - signs the image, source bundle, checksums, build-input manifest,
   control-plane manifest, builder-environment manifest, and both SBOMs with
   keyless Sigstore/Cosign
-- publishes GitHub-native attestations in the canonical upstream repository as
-  an additional verification surface, not a replacement for Sigstore
+- publishes GitHub-native attestations when the reviewed hosted controls say
+  the repository visibility and GitHub plan support them, as an additional
+  verification surface rather than a replacement for Sigstore
 
-Forks can keep the GitHub attestation gate off. The upstream repo treats that
-setting as hosted control-plane state and audits it accordingly.
+Forks can keep the GitHub attestation gates off. The upstream repo treats
+those settings as hosted control-plane state and audits them accordingly.
 
 See [docs/provenance.md](docs/provenance.md) and
 [docs/github-workflows.md](docs/github-workflows.md).

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -23,8 +23,9 @@ reinforce the runtime boundary and release posture, not replace them.
 - it publishes from the archived source bundle, not the live checkout
 - it binds publish outputs to preflight results before signing
 - it signs release assets with keyless Sigstore/Cosign
-- it publishes GitHub attestations in the canonical repo as an additional
-  surface, not a replacement
+- it publishes GitHub attestations as an additional surface, not a
+  replacement, but only when the reviewed hosted controls say the repository
+  visibility and plan support them
 - it uses pinned GitHub Actions and pinned Buildx, QEMU, Cosign, and Syft
   versions
 - it runs with minimal workflow-level permissions and only elevates the publish
@@ -43,7 +44,8 @@ reviewed inputs:
   does not
 - GitHub Actions SHA pinning
 - canonical repository variables such as
-  `WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true`
+  `WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true` and
+  `WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS=false`
 
 `scripts/verify-github-hosted-controls.sh` audits those settings against
 `policy/github-hosted-controls.toml`.
@@ -57,8 +59,10 @@ conditional:
   auditing
 - private code scanning and some SARIF uploads are opt-in because GitHub plan
   support varies
-- the canonical upstream repository enables GitHub attestations through the
-  reviewed repository-variable policy
+- public repos can publish GitHub attestations when enabled
+- private/internal repos only publish GitHub attestations when the reviewed
+  `WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS` variable is explicitly set for
+  a GitHub plan that supports them
 
 ## Deliberate omissions
 

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -24,7 +24,8 @@ Tagged releases publish:
   control-plane manifest, builder-environment manifest, and both SBOMs
 - keyless Sigstore signatures for the published image
 - GitHub attestations for the published image, image SBOM, source bundle, and
-  source SBOM in the canonical upstream repository
+  source SBOM when the reviewed hosted controls say the repository visibility
+  and GitHub plan support that publication path
 
 ## What the release workflow proves
 
@@ -55,9 +56,14 @@ GitHub-independent check.
 
 ## GitHub attestation path
 
-The canonical upstream repo also publishes GitHub attestations. That posture is
-treated as part of the reviewed hosted control plane through the
-`WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true` repository variable.
+The canonical upstream repo also publishes GitHub attestations when the
+reviewed hosted controls allow it. That posture is tracked through two
+repository variables:
+
+- `WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true` requests GitHub attestations
+- `WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS=true` is only allowed when the
+  repository is private/internal and the GitHub plan actually supports private
+  artifact attestations
 
 This does not replace Sigstore. It adds:
 
@@ -78,7 +84,8 @@ cosign verify ghcr.io/omkhar/workcell@sha256:DIGEST \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
-Verify the same image with GitHub attestation tooling:
+If the canonical repo published GitHub attestations for that release, verify
+the same image with GitHub attestation tooling:
 
 ```bash
 gh attestation verify oci://ghcr.io/omkhar/workcell@sha256:DIGEST \
@@ -105,7 +112,8 @@ cosign verify-blob SHA256SUMS \
 sha256sum -c SHA256SUMS
 ```
 
-If you want GitHub's attestation view for the source bundle:
+If you want GitHub's attestation view for the source bundle and the canonical
+repo published GitHub attestations for that release:
 
 ```bash
 gh attestation verify workcell-VERSION.tar.gz --repo omkhar/workcell

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -119,6 +119,61 @@ func validateReleaseWorkflowControlPlaneFlow(releaseWorkflow string) error {
 	return nil
 }
 
+func validateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow string) error {
+	if !strings.Contains(releaseWorkflow, "ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ github.event.repository.visibility == 'public' || vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS == 'true' }}") {
+		return errors.New(".github/workflows/release.yml must gate GitHub attestations on public visibility or an explicit private-repo capability flag")
+	}
+	const attestGuard = "if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'"
+	attestStepRE := regexp.MustCompile(`(?m)^\s*-\s+uses:\s+actions/attest@`)
+	guardedAttestStepRE := regexp.MustCompile(`(?ms)^\s*-\s+uses:\s+actions/attest@[^\n]+\n\s+if:\s+env\.ENABLE_GITHUB_ATTESTATIONS == 'true' && env\.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'\n`)
+	totalAttestSteps := len(attestStepRE.FindAllString(releaseWorkflow, -1))
+	if totalAttestSteps != 4 {
+		return errors.New(".github/workflows/release.yml must keep exactly four reviewed GitHub attestation steps")
+	}
+	if len(guardedAttestStepRE.FindAllString(releaseWorkflow, -1)) != totalAttestSteps {
+		return fmt.Errorf(".github/workflows/release.yml must guard every actions/attest step with %q", attestGuard)
+	}
+	return nil
+}
+
+func hostedControlsRepositoryVariables(policy map[string]any, policyPath string) (map[string]any, error) {
+	expectedRepoVariables, ok := policy["repository_variables"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must define repository_variables as a table of exact expected values", policyPath)
+	}
+	for name, value := range expectedRepoVariables {
+		if strings.TrimSpace(name) == "" {
+			return nil, fmt.Errorf("%s repository_variables entries must map non-empty names to exact string values", policyPath)
+		}
+		if _, ok := value.(string); !ok {
+			return nil, fmt.Errorf("%s repository_variables entries must map non-empty names to exact string values", policyPath)
+		}
+	}
+	for _, requiredName := range []string{
+		"WORKCELL_ENABLE_GITHUB_ATTESTATIONS",
+		"WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS",
+	} {
+		if _, ok := expectedRepoVariables[requiredName]; !ok {
+			return nil, fmt.Errorf("%s must declare %s in repository_variables", policyPath, requiredName)
+		}
+	}
+	return expectedRepoVariables, nil
+}
+
+func validateCanonicalHostedControlsRepositoryVariables(policy map[string]any, policyPath string) error {
+	repositoryVariables, err := hostedControlsRepositoryVariables(policy, policyPath)
+	if err != nil {
+		return err
+	}
+	if value, _ := repositoryVariables["WORKCELL_ENABLE_GITHUB_ATTESTATIONS"].(string); value != "true" {
+		return errors.New("policy/github-hosted-controls.toml must require WORKCELL_ENABLE_GITHUB_ATTESTATIONS = \"true\"")
+	}
+	if value, _ := repositoryVariables["WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS"].(string); value != "false" {
+		return errors.New("policy/github-hosted-controls.toml must require WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = \"false\"")
+	}
+	return nil
+}
+
 func FetchGitHubHostedControlsRulesets(tmpDir, repo string) error {
 	var summary []any
 	if err := readJSONFile(filepath.Join(tmpDir, "rulesets-summary.json"), &summary); err != nil {
@@ -220,20 +275,9 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 	if len(expectedContexts) == 0 {
 		return fmt.Errorf("%s must define required_status_checks.contexts as a non-empty array", policyPath)
 	}
-	expectedRepoVariables, ok := policy["repository_variables"].(map[string]any)
-	if !ok {
-		return fmt.Errorf("%s must define repository_variables as a table of exact expected values", policyPath)
-	}
-	for name, value := range expectedRepoVariables {
-		if strings.TrimSpace(name) == "" {
-			return fmt.Errorf("%s repository_variables entries must map non-empty names to exact string values", policyPath)
-		}
-		if _, ok := value.(string); !ok {
-			return fmt.Errorf("%s repository_variables entries must map non-empty names to exact string values", policyPath)
-		}
-	}
-	if _, ok := expectedRepoVariables["WORKCELL_ENABLE_GITHUB_ATTESTATIONS"]; !ok {
-		return fmt.Errorf("%s must declare WORKCELL_ENABLE_GITHUB_ATTESTATIONS in repository_variables", policyPath)
+	expectedRepoVariables, err := hostedControlsRepositoryVariables(policy, policyPath)
+	if err != nil {
+		return err
 	}
 
 	if enabled, _ := actionsPermissions["enabled"].(bool); !enabled {
@@ -1293,6 +1337,9 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err := validateReleaseWorkflowControlPlaneFlow(releaseWorkflow); err != nil {
 		return err
 	}
+	if err := validateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow); err != nil {
+		return err
+	}
 	if strings.Contains(releaseWorkflow, "steps.build.outputs.digest") {
 		return errors.New(".github/workflows/release.yml must not keep referencing the old single-step multi-platform digest output")
 	}
@@ -1391,12 +1438,8 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if releaseMode != "review-gated" && releaseMode != "single-owner-private" && releaseMode != "plan-limited-private" {
 		return errors.New("policy/github-hosted-controls.toml must set release_environment.mode to 'review-gated', 'single-owner-private', or 'plan-limited-private'")
 	}
-	repositoryVariables, ok := hostedControlsPolicy["repository_variables"].(map[string]any)
-	if !ok || len(repositoryVariables) == 0 {
-		return errors.New("policy/github-hosted-controls.toml must declare canonical repository variables")
-	}
-	if value, _ := repositoryVariables["WORKCELL_ENABLE_GITHUB_ATTESTATIONS"].(string); value != "true" {
-		return errors.New("policy/github-hosted-controls.toml must require WORKCELL_ENABLE_GITHUB_ATTESTATIONS = \"true\"")
+	if err := validateCanonicalHostedControlsRepositoryVariables(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
+		return err
 	}
 	for _, needle := range []string{
 		"actions/variables?per_page=100",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -172,3 +172,119 @@ func TestValidateReleaseWorkflowControlPlaneFlowAcceptsCanonicalArtifact(t *test
 		t.Fatalf("validateReleaseWorkflowControlPlaneFlow() error = %v", err)
 	}
 }
+
+func TestValidateReleaseWorkflowGitHubAttestationFlowRejectsMissingSupportGuard(t *testing.T) {
+	releaseWorkflow := `env:
+  ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}
+  ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ !github.event.repository.private || github.event.repository.owner.type != 'User' }}
+
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+`
+
+	err := validateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow)
+	if err == nil {
+		t.Fatal("validateReleaseWorkflowGitHubAttestationFlow() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "public visibility or an explicit private-repo capability flag") {
+		t.Fatalf("validateReleaseWorkflowGitHubAttestationFlow() error = %v, want support guard failure", err)
+	}
+}
+
+func TestValidateReleaseWorkflowGitHubAttestationFlowRejectsUnguardedAttestStep(t *testing.T) {
+	releaseWorkflow := `env:
+  ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}
+  ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ github.event.repository.visibility == 'public' || vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS == 'true' }}
+
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+`
+
+	err := validateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow)
+	if err == nil {
+		t.Fatal("validateReleaseWorkflowGitHubAttestationFlow() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "guard every actions/attest step") {
+		t.Fatalf("validateReleaseWorkflowGitHubAttestationFlow() error = %v, want unguarded attestation failure", err)
+	}
+}
+
+func TestValidateReleaseWorkflowGitHubAttestationFlowAcceptsSupportGuard(t *testing.T) {
+	releaseWorkflow := `env:
+  ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}
+  ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ github.event.repository.visibility == 'public' || vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS == 'true' }}
+
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+`
+
+	if err := validateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow); err != nil {
+		t.Fatalf("validateReleaseWorkflowGitHubAttestationFlow() error = %v", err)
+	}
+}
+
+func TestValidateCanonicalHostedControlsRepositoryVariablesRejectsMissingPrivateAttestationFlag(t *testing.T) {
+	policy := map[string]any{
+		"repository_variables": map[string]any{
+			"WORKCELL_ENABLE_GITHUB_ATTESTATIONS": "true",
+		},
+	}
+
+	err := validateCanonicalHostedControlsRepositoryVariables(policy, "policy/github-hosted-controls.toml")
+	if err == nil {
+		t.Fatal("validateCanonicalHostedControlsRepositoryVariables() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS") {
+		t.Fatalf("validateCanonicalHostedControlsRepositoryVariables() error = %v, want missing private attestation flag", err)
+	}
+}
+
+func TestValidateCanonicalHostedControlsRepositoryVariablesRejectsWrongPrivateAttestationFlag(t *testing.T) {
+	policy := map[string]any{
+		"repository_variables": map[string]any{
+			"WORKCELL_ENABLE_GITHUB_ATTESTATIONS":         "true",
+			"WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS": "true",
+		},
+	}
+
+	err := validateCanonicalHostedControlsRepositoryVariables(policy, "policy/github-hosted-controls.toml")
+	if err == nil {
+		t.Fatal("validateCanonicalHostedControlsRepositoryVariables() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), `WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = "false"`) {
+		t.Fatalf("validateCanonicalHostedControlsRepositoryVariables() error = %v, want private attestation value failure", err)
+	}
+}
+
+func TestValidateCanonicalHostedControlsRepositoryVariablesAcceptsCanonicalValues(t *testing.T) {
+	policy := map[string]any{
+		"repository_variables": map[string]any{
+			"WORKCELL_ENABLE_GITHUB_ATTESTATIONS":         "true",
+			"WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS": "false",
+		},
+	}
+
+	if err := validateCanonicalHostedControlsRepositoryVariables(policy, "policy/github-hosted-controls.toml"); err != nil {
+		t.Fatalf("validateCanonicalHostedControlsRepositoryVariables() error = %v", err)
+	}
+}

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -41,8 +41,11 @@ contexts = [
 ]
 
 [repository_variables]
-# The canonical Workcell repository publishes both Sigstore materials and
-# GitHub-native attestations on tagged releases. Forks can loosen this policy,
-# but the upstream repo treats the variable as part of the reviewed control
-# plane so publication posture cannot silently drift.
+# The canonical Workcell repository always requests GitHub-native attestations
+# when the platform supports them. Public repos support that path on all
+# current plans; private/internal repos need explicit hosted-control approval
+# because GitHub only supports them on Enterprise Cloud. Forks can loosen this
+# policy, but the upstream repo treats both variables as part of the reviewed
+# control plane so publication posture cannot silently drift.
 WORKCELL_ENABLE_GITHUB_ATTESTATIONS = "true"
+WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = "false"


### PR DESCRIPTION
## Summary
- gate release attestation steps on public visibility or an explicit private-repo support flag
- add hosted-control policy and invariant coverage for the new private attestation variable
- update release provenance/workflow docs to describe conditional GitHub attestation publication

## Validation
- go test ./internal/metadatautil/...
- ./scripts/check-pinned-inputs.sh
- bash scripts/validate-repo.sh