### PR TITLE
Add session inventory and requirements validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ Useful operator flows:
 workcell --prepare --agent codex --workspace /path/to/repo
 workcell --prepare-only --agent codex --workspace /path/to/repo
 workcell --agent codex --mode development --workspace /path/to/repo -- bash -lc 'git status'
+workcell session list
+workcell session show --id 20260408T120000Z-1a2b3c4d
+workcell session export --id 20260408T120000Z-1a2b3c4d --output /tmp/workcell-session.json
 workcell --inspect --agent codex --workspace /path/to/repo
 workcell --doctor --agent codex --workspace /path/to/repo
 workcell --auth-status --agent codex --workspace /path/to/repo
@@ -122,6 +125,8 @@ What to expect from the safe path:
 - there is no separate "start a container, then attach the agent" step
 - `publish-pr` runs on the host so signed commits and GitHub publication stay
   outside the Tier 1 container
+- completed and aborted launches are recorded as durable host-side session
+  records that you can inspect with `workcell session ...`
 - `--debug-log`, `--file-trace-log`, and `--audit-transcript` are explicit
   lower-assurance operator choices and are off by default
 
@@ -192,8 +197,10 @@ See [docs/provenance.md](docs/provenance.md) and
 | Adapter control planes | [docs/adapter-control-planes.md](docs/adapter-control-planes.md) |
 | Injection policy | [docs/injection-policy.md](docs/injection-policy.md) |
 | Validation coverage | [docs/validation-scenarios.md](docs/validation-scenarios.md) |
+| Requirements validation | [docs/requirements-validation.md](docs/requirements-validation.md) |
 | Scenario gaps | [docs/scenario-gaps.md](docs/scenario-gaps.md) |
 | Use-case coverage | [docs/use-case-matrix.md](docs/use-case-matrix.md) |
+| Session supervisor design | [docs/workcell-session-supervisor-design.md](docs/workcell-session-supervisor-design.md) |
 | Provenance and signing | [docs/provenance.md](docs/provenance.md) |
 | GitHub automation | [docs/github-workflows.md](docs/github-workflows.md) |
 | Contributor workflow | [CONTRIBUTING.md](CONTRIBUTING.md) |

--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -4,10 +4,12 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/omkhar/workcell/internal/hostutil"
 )
@@ -176,6 +178,25 @@ func runLauncher(args []string) error {
 			return launcherUsage()
 		}
 		return hostutil.CleanupStaleSessionAuditDirs(args[1])
+	case "session-record-write":
+		if len(args) < 3 {
+			return launcherUsage()
+		}
+		updates := map[string]string{}
+		for _, pair := range args[2:] {
+			key, value, ok := strings.Cut(pair, "=")
+			if !ok || key == "" {
+				return fmt.Errorf("invalid session record update %q", pair)
+			}
+			updates[key] = value
+		}
+		return hostutil.WriteSessionRecord(args[1], updates)
+	case "session-list":
+		return runLauncherSessionList(args[1:])
+	case "session-show":
+		return runLauncherSessionShow(args[1:])
+	case "session-export":
+		return runLauncherSessionExport(args[1:])
 	case "audit-digest":
 		if len(args) < 3 {
 			return launcherUsage()
@@ -298,5 +319,97 @@ func releaseUsage() error {
 }
 
 func launcherUsage() error {
-	return fmt.Errorf("usage: workcell-hostutil launcher <session-suffix|colima-status|cleanup-stale-log-pointers|profile-lock-is-stale|write-profile-owner|cleanup-stale-session-audit-dirs|audit-digest|direct-mount-cache-key|resolve-host-output-candidate|cleanup-stale-injection-bundles|manifest-metadata|resolver-metadata|workspace-cache-key|extract-codex-version|validate-security-options|canonicalize-tool-path|dedupe-endpoints|resolve-endpoints> ...")
+	return fmt.Errorf("usage: workcell-hostutil launcher <session-suffix|colima-status|cleanup-stale-log-pointers|profile-lock-is-stale|write-profile-owner|cleanup-stale-session-audit-dirs|session-record-write|session-list|session-show|session-export|audit-digest|direct-mount-cache-key|resolve-host-output-candidate|cleanup-stale-injection-bundles|manifest-metadata|resolver-metadata|workspace-cache-key|extract-codex-version|validate-security-options|canonicalize-tool-path|dedupe-endpoints|resolve-endpoints> ...")
+}
+
+func runLauncherSessionList(args []string) error {
+	if len(args) < 1 || len(args) > 4 {
+		return launcherUsage()
+	}
+
+	colimaRoot := args[0]
+	format := "lines"
+	opts := hostutil.SessionListOptions{}
+	for _, arg := range args[1:] {
+		switch {
+		case arg == "--json":
+			format = "json"
+		case strings.HasPrefix(arg, "--workspace="):
+			opts.Workspace = strings.TrimPrefix(arg, "--workspace=")
+		case strings.HasPrefix(arg, "--profile="):
+			opts.Profile = strings.TrimPrefix(arg, "--profile=")
+		default:
+			return launcherUsage()
+		}
+	}
+
+	records, err := hostutil.ListSessionRecords(colimaRoot, opts)
+	if err != nil {
+		return err
+	}
+	if format == "json" {
+		content, err := json.MarshalIndent(records, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s\n", content)
+		return nil
+	}
+	for _, record := range records {
+		fmt.Printf(
+			"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			record.SessionID,
+			record.Status,
+			record.Agent,
+			record.Mode,
+			record.Profile,
+			record.StartedAt,
+			coalesce(record.FinalAssurance, record.InitialAssurance),
+			record.Workspace,
+		)
+	}
+	return nil
+}
+
+func runLauncherSessionShow(args []string) error {
+	if len(args) != 2 {
+		return launcherUsage()
+	}
+
+	record, err := hostutil.FindSessionRecord(args[0], args[1])
+	if err != nil {
+		return err
+	}
+	content, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", content)
+	return nil
+}
+
+func runLauncherSessionExport(args []string) error {
+	if len(args) != 2 {
+		return launcherUsage()
+	}
+
+	exported, err := hostutil.ExportSessionRecord(args[0], args[1])
+	if err != nil {
+		return err
+	}
+	content, err := json.MarshalIndent(exported, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", content)
+	return nil
+}
+
+func coalesce(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/cmd/workcell-metadatautil/main.go
+++ b/cmd/workcell-metadatautil/main.go
@@ -269,6 +269,11 @@ func main() {
 			die(fmt.Errorf("usage: %s validate-toml FILE...", os.Args[0]))
 		}
 		err = metadatautil.ValidateTOMLFiles(os.Args[2:])
+	case "validate-requirements":
+		if len(os.Args) != 4 {
+			die(fmt.Errorf("usage: %s validate-requirements ROOT_DIR REQUIREMENTS_PATH", os.Args[0]))
+		}
+		err = metadatautil.ValidateRequirements(os.Args[2], os.Args[3])
 	case "scan-credential-patterns":
 		if len(os.Args) != 3 {
 			die(fmt.Errorf("usage: %s scan-credential-patterns ROOT_DIR", os.Args[0]))

--- a/docs/requirements-validation.md
+++ b/docs/requirements-validation.md
@@ -1,0 +1,61 @@
+# Requirements Validation
+
+Workcell now keeps a canonical requirement-to-evidence mapping in
+[`policy/requirements.toml`](../policy/requirements.toml).
+
+## Purpose
+
+The requirements matrix does two things:
+
+- names the current functional and nonfunctional requirements that the repo is
+  claiming as implemented
+- points each requirement at concrete automated evidence and supporting
+  documentation
+
+This is meant to reduce drift between:
+
+- what the docs say Workcell does
+- what the tests and validation scripts actually prove
+- what maintainers treat as the supported contract
+
+## Validation Rule
+
+`./scripts/verify-requirements-coverage.sh` validates that:
+
+- the matrix is syntactically valid
+- functional and nonfunctional requirement sections are both present
+- requirement ids and titles are unique
+- every requirement cites at least one automated evidence file
+- every evidence and documentation path is repo-relative and exists in the repo
+
+This check runs through the normal validation entrypoints, including
+`./scripts/dev-quick-check.sh` and `./scripts/validate-repo.sh`.
+
+## Scope
+
+The matrix is intentionally about the supported repo contract, not every
+possible implementation detail.
+
+It should cover:
+
+- the main managed launch path
+- host-side operator commands
+- auth and injection behavior
+- assurance and audit behavior
+- release and reproducibility guarantees
+- newly added product capabilities such as session inventory
+
+It should not be used to smuggle in speculative roadmap items that are not yet
+implemented.
+
+## Maintenance Rules
+
+When a supported requirement changes:
+
+1. update `policy/requirements.toml`
+2. update or add the automated evidence
+3. update the docs that explain the requirement
+4. rerun the requirement validator
+
+If a requirement cannot point to real automated evidence, it is not ready to be
+claimed as part of the canonical supported contract.

--- a/docs/use-case-matrix.md
+++ b/docs/use-case-matrix.md
@@ -18,6 +18,7 @@ Workcell workflows.
 | host-side signed `publish-pr` handoff | tested | shared scenario tests and invariant checks |
 | repo control-plane masking and provider-home re-seeding | tested | invariants and smoke |
 | prompt-autonomy downgrade labeling | tested for Codex, partial elsewhere | invariants plus provider-specific coverage |
+| host-side session inventory and audit export | tested | `tests/scenarios/shared/test-session-commands.sh`, `internal/hostutil/sessions_test.go` |
 | release-bundle reproducibility | tested | `scripts/verify-release-bundle.sh`, tagged release preflight |
 | runtime-image reproducibility | tested | `scripts/verify-reproducible-build.sh`, CI, tagged release preflight |
 | Sigstore signing and SBOM publication | tested | successful tagged release workflow |

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -6,6 +6,8 @@ boundary or release story by itself.
 Use this page with:
 
 - [docs/use-case-matrix.md](use-case-matrix.md) for what is currently covered
+- [docs/requirements-validation.md](requirements-validation.md) for the
+  machine-checked requirement-to-evidence mapping
 - [docs/scenario-gaps.md](scenario-gaps.md) for what is still missing
 
 ## Local secretless checks
@@ -21,6 +23,8 @@ These run without provider credentials:
 - `./scripts/pre-merge.sh` (builds or reuses the same pinned validator container and can run the local stack from a disposable snapshot before optional remote lanes)
 
 They cover repo shape, runtime contracts, smoke behavior, and reproducibility.
+They also now cover canonical requirement traceability and host-side session
+inventory behavior.
 
 ## Manual authenticated smoke
 

--- a/docs/workcell-session-supervisor-design.md
+++ b/docs/workcell-session-supervisor-design.md
@@ -1,0 +1,153 @@
+# Workcell Session Supervisor Design
+
+## Goal
+
+Workcell needs a session-supervisor layer so operators can reason about Workcell
+launches as durable session objects rather than as one-off foreground shell
+commands.
+
+This document defines the first implementation phase that is now practical in
+this repository without weakening the existing boundary model.
+
+## Phase 1 Scope
+
+Phase 1 adds durable host-side session records and inventory commands:
+
+- `workcell session list`
+- `workcell session show --id ...`
+- `workcell session export --id ...`
+
+Each launched session writes durable metadata under the managed Colima profile
+state instead of relying only on the transient `session-audit.*` directory.
+
+## Data Model
+
+Each session record stores:
+
+- `session_id`
+- `profile`
+- `agent`
+- `mode`
+- `status`
+- `ui`
+- `execution_path`
+- `workspace`
+- `container_name`
+- `session_audit_dir`
+- `audit_log_path`
+- `debug_log_path`
+- `file_trace_log_path`
+- `transcript_log_path`
+- `started_at`
+- `finished_at`
+- `exit_status`
+- `initial_assurance`
+- `final_assurance`
+- `workspace_control_plane`
+
+The durable record lives under:
+
+- `~/.colima/<profile>/sessions/<session_id>.json`
+
+The transient `session-audit.*` directory remains separate and disposable.
+
+## Why This Shape
+
+This design is intentionally host-owned.
+
+That matters because:
+
+- the host launcher already owns the trusted control plane
+- the transient container should stay disposable
+- `--gc` already cleans transient audit dirs
+- durable session inventory should survive the transient session cleanup path
+
+Storing records under `sessions/` instead of inside `session-audit.*` avoids
+confusing retention with ephemeral runtime scratch state.
+
+## Audit Relationship
+
+Phase 1 also adds `session_id` to launch, assurance-change, and exit audit
+records in the profile audit log.
+
+That allows `workcell session export` to bundle:
+
+- the durable session record
+- matching audit log lines for that session
+
+This is a clean bridge between human-readable audit history and machine-readable
+session metadata.
+
+## User Experience
+
+`workcell session list` is optimized for a quick host-side inventory:
+
+- session id
+- status
+- agent
+- mode
+- profile
+- start time
+- assurance
+- workspace
+
+`workcell session show` returns the full durable record for one session.
+
+`workcell session export` returns the full record plus matching audit records,
+either to stdout or a user-selected host file.
+
+## Explicit Non-Goals For Phase 1
+
+Phase 1 does not attempt to implement:
+
+- background execution
+- pause or resume
+- follow-up prompts
+- interactive takeover
+- per-task worktree creation
+- a long-running daemon
+- remote worker fleets
+
+Those remain later phases.
+
+## Future Phases
+
+Phase 2 should add:
+
+- `workcell session start` as a durable session creator
+- per-session worktree or branch isolation
+- attach and takeover
+- follow-up prompts to a running session
+- artifact browsing beyond raw audit export
+
+Phase 3 should add:
+
+- pause and resume
+- optional warm pools
+- GUI and IDE clients against the same host-controlled session plane
+- enterprise inventory and policy surfaces
+
+## Peer Review
+
+### Findings
+
+1. Durable records must not live in `session-audit.*`.
+   Reason: `--gc` already treats those directories as stale runtime scratch and
+   can delete them.
+
+2. Session export needs an explicit session key in the audit log.
+   Reason: profile audit logs are cumulative and otherwise cannot be filtered
+   safely to one launch.
+
+3. Phase 1 should stay host-side and file-based.
+   Reason: introducing a daemon, sockets, or background workers before the data
+   model stabilizes would add complexity faster than it adds operator value.
+
+### Residual Risks
+
+- There is no retention policy yet for durable session records.
+- Aborted launches rely on host cleanup logic to mark the record as aborted.
+- The current phase gives inventory and export, not orchestration.
+
+Those are acceptable for a first slice because the main goal here is to create
+durable, auditable session objects without weakening the reviewed boundary.

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -1,0 +1,769 @@
+# Workcell System Design and Feature Review
+
+## Purpose
+
+This document explains how Workcell works today based on the repository's
+runtime code, policy code, adapters, and verification material. It also
+compares the current design to modern coding-agent systems and identifies the
+single next feature that should be added to Workcell first.
+
+## Executive Summary
+
+Workcell is a host-launched, policy-driven runtime for coding agents. Its core
+design is:
+
+1. A trusted host control plane prepares and validates the session.
+2. A dedicated Colima VM provides the primary machine boundary on macOS.
+3. A hardened container inside that VM provides the agent execution runtime.
+4. Thin provider adapters seed provider-native homes and configuration without
+   pretending the providers are interchangeable.
+5. Multiple policy layers prevent the workspace from silently taking over the
+   control plane.
+6. Verification and provenance tooling try to make the boundary auditable and
+   reproducible.
+
+The most important architectural fact is that Workcell does not treat prompt
+files, provider settings, or repo rules as the security boundary. The real
+boundary is the host-controlled VM plus container path, reinforced by control
+plane masking, provider wrappers, syscall-level exec interception, egress
+controls, and explicit credential injection.
+
+The biggest missing product capability is not stronger isolation. Workcell is
+already strong there. The biggest missing capability is a first-class session
+supervisor that can run, track, resume, and compare multiple isolated agent
+sessions in parallel.
+
+## Design Goals
+
+The repository's own priorities are clear:
+
+1. Developer experience
+2. Simplicity
+3. Security invariants
+4. Performance
+5. Idiomatic correctness
+
+Within that frame, Workcell optimizes for these system properties:
+
+- Keep the trusted control plane on the host.
+- Preserve a dedicated VM plus container boundary for supported adapters.
+- Make lower-assurance paths explicit instead of silently widening trust.
+- Keep provider-specific behavior visible rather than hiding it behind a fake
+  abstraction layer.
+- Prefer auditable configuration and invariant checks over implicit behavior.
+
+## Non-Goals
+
+Workcell is not trying to be:
+
+- A generic shared-kernel container sandbox.
+- A provider-agnostic agent framework that erases real CLI differences.
+- A repo-local prompt/config convention presented as a security system.
+- A host-side PR publishing tool that pushes from inside the bounded session.
+
+## System Overview
+
+### 1. Host Control Plane
+
+The main control plane is [`scripts/workcell`](../scripts/workcell). It is a
+host-side launcher, validator, policy renderer, and audit collector.
+
+Its core responsibilities are:
+
+- Scrub the host environment before session launch.
+- Resolve trusted host binaries and helper scripts.
+- Compute a deterministic Colima profile per workspace.
+- Validate the Colima runtime assumptions:
+  - `vz` VM type
+  - `virtiofs` mount type
+  - Docker runtime
+  - exactly one writable workspace mount
+  - no SSH agent forwarding
+- Resolve injection policy and credential sources.
+- Render a staged injection bundle on the host.
+- Shadow repo-local control-plane paths on the safe path.
+- Apply the VM egress allowlist.
+- Build or prepare the runtime image.
+- Launch the container with controlled mounts, tmpfs mounts, and managed env.
+- Record session metadata, assurance metadata, and optional debug logs.
+
+Operationally, `scripts/workcell` is the system's real orchestrator today.
+Almost every trust-sensitive decision is made before the provider CLI starts.
+
+### 2. Host Policy Helpers
+
+The host launcher delegates structured policy work to small Go packages in
+`internal/` and `cmd/`.
+
+Important components include:
+
+- `internal/authpolicy`
+  - manages local auth-policy state via `workcell auth`.
+- `internal/authresolve`
+  - resolves credential sources before launch.
+- `internal/injection`
+  - renders the staged injection bundle and manifest.
+- `internal/assurance`
+  - models session assurance metadata.
+- `internal/endpointpolicy`
+  - tracks extra endpoint handling.
+
+This split is healthy. The shell launcher owns orchestration, while the Go code
+owns structured data validation and rendering.
+
+### 3. Runtime Boundary
+
+The runtime boundary is two-tier on the safe path:
+
+1. A dedicated Colima VM on the host.
+2. A hardened agent container inside that VM.
+
+The container launch path applies controls such as:
+
+- `--init`
+- `--security-opt no-new-privileges:true`
+- `--cap-drop ALL`
+- `--pids-limit 1024`
+- tmpfs mounts for `/tmp`, `/run`, and `/state`
+- a tightly constrained environment
+- a single writable workspace mount
+
+Modes in `runtime/profiles/*.env` tune network posture and resources:
+
+- `strict`
+  - deny-by-default style safe path with allowlisted egress.
+- `development`
+  - broader developer convenience, still managed.
+- `build`
+  - broader build-oriented access.
+- `breakglass`
+  - explicit higher-trust mode with widened behavior.
+
+### 4. Workspace and Control-Plane Isolation
+
+One of Workcell's strongest and most unusual controls is workspace
+control-plane masking.
+
+On the safe path, `scripts/workcell` prevents mutable workspace content from
+becoming the active provider control plane. It masks or shadows paths such as:
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `GEMINI.md`
+- `.mcp.json`
+- `.codex/`
+- `.claude/`
+- `.gemini/`
+- editor control directories
+- mutable git hook/config paths
+
+For tracked files, the masking path materializes content from the git index
+rather than the live working tree. That matters because it narrows the gap
+between "what the developer reviewed" and "what the runtime consumes."
+
+The workspace can still provide reviewed instructions, but only through an
+import path controlled by Workcell rather than by direct trust of live repo
+state.
+
+### 5. Injection and Credential Flow
+
+Workcell's injection model is the supported path for credentials, SSH material,
+and reviewed documentation fragments.
+
+The flow is:
+
+1. The host loads the injection policy.
+2. Credential sources are resolved on the host.
+3. A staged injection bundle is rendered with a manifest.
+4. Files are mounted into controlled paths in the container.
+5. Session home seeding copies or links only approved targets.
+
+Important properties:
+
+- Secrets are staged and classified explicitly.
+- Supported target paths are tightly enumerated.
+- Reserved home paths cannot be overwritten arbitrarily.
+- SSH material is validated and constrained.
+- Resolver-backed credentials are a host preprocessing step, not a live
+  pass-through to host agents or host keychains.
+- Resolver coverage is intentionally narrow today. In practice, direct staged
+  injection is the main path, with only limited host-side resolver support.
+
+This is consistent with the repository's stated security model: credentials may
+be made usable to the runtime, but host credential systems are not the runtime
+boundary and must not be mounted through casually.
+
+### 6. Container Entry and Provider Launch
+
+Inside the container, the launch chain is deliberately layered:
+
+1. `runtime/container/entrypoint.sh`
+2. `runtime/container/runtime-user.sh`
+3. `runtime/container/home-control-plane.sh`
+4. `runtime/container/provider-wrapper.sh`
+5. provider binary
+
+This separation matters.
+
+`entrypoint.sh` is PID 1. It validates the managed environment, handles user
+mapping for mutable sessions, seeds provider home, validates launch targets, and
+routes non-provider commands through the development wrapper when that lower
+assurance path is allowed.
+
+`provider-wrapper.sh` then:
+
+- sanitizes environment variables
+- reloads runtime state
+- reseeds the home if needed
+- forces managed autonomy flags
+- rejects dangerous provider-native overrides before execution
+
+`provider-policy.sh` adds another gate by rejecting trust-widening provider
+flags such as:
+
+- alternative config/profile overrides
+- local autonomy overrides
+- unsafe plugin or MCP config overrides
+- additional directory or remote overrides
+
+Only the top-level `breakglass` path can enable true breakglass behavior.
+Nested invocations cannot silently upgrade themselves.
+
+### 7. Session Home as a Managed Control Plane
+
+`runtime/container/home-control-plane.sh` is the system's in-container control
+plane builder.
+
+It:
+
+- verifies control-plane artifact hashes
+- rebuilds the effective provider home under `/state/agent-home`
+- layers baseline docs, imported workspace docs, and injected docs
+- renders provider-specific config files
+- seeds auth material, MCP config, rules, and SSH material
+- optionally captures file-trace metadata
+
+The layered documentation model is especially important:
+
+1. adapter baseline doc
+2. imported workspace `AGENTS.md`
+3. imported provider doc such as `CLAUDE.md` or `GEMINI.md`
+4. injected common doc
+5. injected provider-specific doc
+
+This allows Workcell to preserve provider-native instruction formats without
+allowing the workspace to become the sole trust root.
+
+### 8. Runtime Mutability and Assurance Downgrades
+
+Workcell distinguishes between the safe immutable path and explicit lower
+assurance behavior.
+
+Examples:
+
+- Mutable sessions map the container user to the host UID/GID.
+- Package mutation is mediated by `apt-wrapper.sh` and `apt-helper.sh`.
+- APT mutations are allowed only in mutable sessions and downgrade assurance to
+  `lower-assurance-package-mutation`.
+- The downgrade is persisted and auditable.
+
+This is a pragmatic design choice. Workcell does not pretend that package
+installation inside a mutable developer session has the same assurance profile
+as a stricter replayable path.
+
+### 9. Exec Guard and Wrapper Defense in Depth
+
+The deepest technical control in the repository is the Rust exec guard in
+`runtime/container/rust/src/lib.rs`, built as `libworkcell_exec_guard.so` and
+loaded with `LD_PRELOAD`.
+
+It intercepts multiple execution paths including:
+
+- `execve`
+- `execv`
+- `execvp`
+- `execvpe`
+- `execveat`
+- `fexecve`
+- `posix_spawn`
+- `posix_spawnp`
+- raw Linux syscall paths for `execve` and `execveat`
+
+Its policy role is to stop bypasses beneath the shell-wrapper layer, including:
+
+- direct execution of protected runtimes outside approved wrappers
+- shebang scripts from mutable paths that target protected runtimes
+- native ELF execution from mutable paths in strict mode
+- git hook and config bypass patterns
+
+Workcell reinforces this with command wrappers:
+
+- `runtime/container/bin/git`
+  - blocks dangerous git env/config and hook bypasses.
+- `runtime/container/bin/node`
+  - strips risky Node execution flags and blocks direct protected-runtime
+    execution paths.
+- `runtime/container/public-node-guard.mjs`
+  - prevents execution of copied protected provider packages through Node.
+
+This layered model is stronger than depending on shell aliases, repo policy
+files, or CLI settings alone.
+
+### 10. Provider Adapters
+
+The adapters are intentionally thin and provider-specific.
+
+#### Codex
+
+The Codex adapter seeds managed config and rules, disables provider-native web
+search by default, pins provider-native sandboxing off in favor of the outer
+Workcell boundary, and injects managed requirements and MCP config.
+
+#### Claude Code
+
+The Claude adapter seeds reviewed settings, baseline instructions, auth mirrors,
+MCP config, and a `PreToolUse` hook that blocks trust-widening shell patterns.
+
+#### Gemini CLI
+
+The Gemini adapter seeds reviewed settings, disables IDE-style trust defaults in
+the managed path, enforces tool sandbox expectations, validates auth-related
+files, and manages trust state for `/workspace`.
+
+The important architectural point is that Workcell keeps one shared boundary and
+many thin adapters, which is consistent with the repository's own guidance.
+
+### 11. Verification and Release
+
+The repo includes a serious verification and provenance story.
+
+Key pieces:
+
+- `verify/invariants/`
+  - invariant-oriented checks and expected controls.
+- `docs/invariants.md`
+  - design-level invariant contract.
+- `docs/threat-model.md`
+  - threat assumptions and abuse paths.
+- `docs/provenance.md`
+  - release and attestation model.
+- `docs/validation-scenarios.md`
+  - scenario coverage and known limits.
+
+Release publication is intentionally host-side. `workcell publish-pr` stages,
+signs, pushes, and opens the PR from outside the Tier 1 session. That preserves
+the design claim that GitHub publication is a host action, not an in-container
+trust escalation.
+
+## End-to-End Execution Flow
+
+### Safe Launch Flow
+
+The normal strict-path launch is:
+
+1. Operator runs `workcell --agent <provider> --workspace <repo>`.
+2. Host launcher scrubs env and validates workspace eligibility.
+3. Host launcher validates or creates the Colima profile.
+4. Host launcher validates runtime assumptions and mount shape.
+5. Injection policy is resolved and rendered into a staged bundle.
+6. Workspace control-plane files are shadowed and imported.
+7. VM-level egress allowlist is applied.
+8. Runtime image is prepared if required.
+9. Container starts with hardened flags and managed env.
+10. Container PID 1 seeds runtime state and effective provider home.
+11. Provider wrapper enforces managed autonomy and provider policy.
+12. Agent starts in the bounded runtime.
+
+### Development Flow
+
+`development` mode is still managed, but it allows non-provider commands through
+`development-wrapper.sh`. This is a deliberate convenience path, not the same
+assurance level as strict provider-only execution.
+
+### Breakglass Flow
+
+`breakglass` exists, but the system tries hard to make it explicit:
+
+- it must be requested
+- its semantics are separate
+- nested invocations cannot silently self-upgrade into it
+
+This is the correct pattern for enterprise trust boundaries. Higher-trust paths
+exist, but they are not smuggled in as normal behavior.
+
+### Publish Flow
+
+The PR publication path intentionally exits the bounded runtime:
+
+1. Work is completed inside Workcell.
+2. Operator runs `workcell publish-pr` on the host.
+3. The host creates or switches branch, stages changes, commits with signing,
+   pushes, and opens a draft PR.
+
+This keeps the signing identity and final repository publication outside the
+agent session boundary.
+
+## What Workcell Already Does Well
+
+Workcell is stronger than many current agent runtimes in several areas:
+
+- It has a real, explicit runtime boundary instead of relying on prompt files or
+  repo-local config alone.
+- It treats workspace trust and host trust as different problems.
+- It masks repo-local control-plane paths to reduce prompt/config injection from
+  mutable workspace state.
+- It uses syscall-level exec interception rather than trusting shell wrappers
+  alone.
+- It has explicit lower-assurance states instead of silently widening trust.
+- It keeps provider differences explicit with thin adapters.
+- It has a credible audit and provenance story.
+- It now has a first durable host-side session inventory slice for completed or
+  aborted launches.
+
+These are foundational strengths. They should be preserved.
+
+## Current Functional Gaps
+
+Workcell's current gaps are mostly product and workflow gaps, not core boundary
+gaps.
+
+### Gaps in the Current Product Surface
+
+- No first-class multi-agent orchestration.
+- No background session supervisor or queue.
+- No built-in pause, resume, takeover, or follow-up model for live sessions.
+- No first-class worktree-per-task or branch-per-session workflow.
+- No checkpoint, fork, or snapshot model for active sessions.
+- GUI mode is intentionally not implemented yet as a preserved-boundary path.
+- No preserved-boundary GUI or IDE session surface.
+- No org-level policy administration plane or session analytics plane.
+- Limited host credential resolver coverage.
+- No reusable team workflow layer at the Workcell level comparable to agent
+  packs, commands, or enterprise agent profiles.
+
+## Comparison With Modern Coding-Agent Systems
+
+### Trail of Bits `claude-code-config`
+
+Reference: [GitHub repository](https://github.com/trailofbits/claude-code-config)
+
+What it emphasizes:
+
+- reusable slash commands
+- plugin-distributed skills, agents, and commands
+- hook-driven workflow controls
+- a statusline with live session context and cost data
+- optional local-model support through LM Studio
+
+What Workcell has instead:
+
+- stronger runtime isolation
+- stronger separation between workspace trust and control-plane trust
+- stronger enforcement beneath the CLI layer
+
+What Workcell is missing relative to that workflow model:
+
+- a first-class reusable workflow/command library at the Workcell layer
+- an agent-pack or subagent-pack concept that is independent of one provider
+- lightweight UX features such as live status and session ergonomics
+
+### Penligent's Sandbox Architecture
+
+Reference: [Sandboxes for Coding Agents](https://www.penligent.ai/hackinglabs/he/sandboxes-for-coding-agents/)
+
+The article argues that production systems need separate control, execution,
+policy, artifact, verification, and lifecycle planes, and that state management
+is as important as isolation.
+
+Workcell already covers:
+
+- control plane
+- execution plane
+- policy plane
+- verification plane
+- part of the artifact plane
+
+Workcell is weaker on:
+
+- lifecycle plane as a first-class product surface
+- pause/resume/snapshot/fork semantics
+- user-facing artifact browsing and replay workflows
+- warm-pool style responsiveness and session management
+
+### Dagger `container-use`
+
+Reference: [GitHub repository](https://github.com/dagger/container-use)
+
+What it emphasizes:
+
+- multiple agents in parallel
+- a fresh isolated environment per agent
+- per-agent git branch isolation
+- real-time command visibility
+- direct intervention into a live agent terminal
+- MCP-compatible integration across multiple agent products
+
+Workcell is stronger on boundary rigor, but weaker on orchestration:
+
+- Workcell does not yet have per-task isolated session management as a product.
+- Workcell does not yet expose a direct session-takeover workflow.
+- Workcell does not yet make live command history a first-class user interface.
+
+### Cursor Cloud/Background Agents
+
+References:
+
+- [Background agents docs](https://docs.cursor.com/en/background-agents)
+- [Cloud agents announcement](https://cursor.com/blog/cloud-agents)
+- [Cloud agents with computer use](https://cursor.com/blog/agent-computer-use)
+- [Self-hosted cloud agents](https://cursor.com/blog/self-hosted-cloud-agents/)
+- [Cloud agents changelog](https://cursor.com/changelog/02-24-26/)
+
+What Cursor emphasizes:
+
+- many asynchronous agents in parallel
+- isolated remote machines
+- follow-up prompts while the agent is still running
+- takeover into the remote environment
+- multi-surface access from desktop, web, mobile, Slack, and GitHub
+- self-hosted worker fleets for enterprise
+
+Workcell is missing most of this operating model:
+
+- no background session supervisor
+- no background queue
+- no pause/resume/follow-up UX
+- no remote worker or fleet model
+- no handoff between CLI and GUI surfaces
+
+### GitHub Copilot Cloud Agent and Custom Agents
+
+References:
+
+- [Managing cloud agents](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/use-copilot-agents/manage-agents)
+- [Creating custom agents](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/use-copilot-agents/cloud-agent/create-custom-agents)
+- [About agent management](https://docs.github.com/en/copilot/concepts/agents/cloud-agent/agent-management)
+- [Managing Copilot cloud agent in your enterprise](https://docs.github.com/en/copilot/how-tos/administer-copilot/manage-for-enterprise/manage-agents/manage-copilot-cloud-agent)
+
+What GitHub emphasizes:
+
+- cloud sessions that create PRs directly
+- steering input during a running session
+- resume in VS Code or CLI
+- repository, organization, and enterprise-level custom agents
+- centralized enterprise AI controls
+- enterprise session inventory and audit views
+
+Workcell is missing:
+
+- org and enterprise-level agent/profile distribution
+- session list and centralized activity views
+- resume/follow-up workflows
+- a durable admin plane for policy and usage management
+
+### Aider and Similar Terminal-First Agents
+
+Reference: [Aider watch mode](https://aider.chat/docs/usage/watch.html)
+
+Terminal-first agents like Aider emphasize small-loop developer productivity:
+
+- quick iteration from the terminal
+- watch mode and automation hooks
+- low-friction editing workflows
+
+Workcell is currently more rigorous than it is fast-moving. It could benefit
+from more loop-shortening features without giving up the boundary model.
+
+## Finalized Next Feature: Workcell Supervisor
+
+The next feature that should be present in Workcell is a first-class **Workcell
+Supervisor**.
+
+This should be a host-side session orchestration layer that manages multiple
+bounded Workcell sessions as durable objects rather than treating every launch as
+an isolated foreground shell command.
+
+Workcell now has the phase 1 foundation for that direction: durable session
+records and host-side session inventory/export commands. The remaining gap is
+true orchestration rather than inventory alone.
+
+### Why This Is the Right Next Feature
+
+It is the highest-leverage addition because it:
+
+- closes the largest gap with Cursor, Copilot, and Container Use
+- compounds Workcell's existing boundary strengths instead of weakening them
+- improves developer throughput more than another round of low-level hardening
+- creates the foundation for enterprise control-plane features later
+
+### What the Supervisor Should Do
+
+The minimum viable Supervisor should provide:
+
+1. Session objects
+   - each launch becomes a named session with durable metadata
+2. Per-session worktree or branch isolation
+   - default to a new git worktree per task on the safe path
+3. Parallel execution
+   - run multiple sessions concurrently without workspace conflicts
+4. Follow-up prompts
+   - send steering input to a running or paused session
+5. Pause and resume
+   - preserve long-running work without keeping a foreground terminal attached
+6. Takeover
+   - attach directly to a live session shell or provider TTY
+7. Session inventory
+   - list status, branch/worktree, mode, assurance state, runtime age, and logs
+8. Artifact capture
+   - diff, transcript, command log, assurance downgrade events, and outputs
+9. Policy inheritance
+   - all existing Workcell controls still apply to every session
+
+### Recommended CLI Shape
+
+Possible commands:
+
+- `workcell session start`
+- `workcell session list`
+- `workcell session follow`
+- `workcell session send`
+- `workcell session attach`
+- `workcell session pause`
+- `workcell session resume`
+- `workcell session stop`
+- `workcell session diff`
+- `workcell session export`
+
+### Recommended Internal Model
+
+The Supervisor should introduce a stable session record containing:
+
+- session id
+- workspace root
+- worktree path
+- branch name
+- provider and mode
+- assurance state
+- active runtime identifiers
+- timestamps
+- artifact paths
+- operator identity
+
+The host should own this metadata. The runtime should remain disposable.
+
+### Phase 2 Extensions
+
+Once the Supervisor exists, Workcell can add higher-level features safely:
+
+- lightweight TUI or web session dashboard
+- GitHub and Slack entrypoints
+- resumable checkpoints and forks
+- warm pools or prepared base runtimes
+- reusable team profiles, commands, and agent packs
+- central policy distribution and enterprise analytics
+
+## Features Workcell Should Add After the Supervisor
+
+In priority order:
+
+1. Team workflow packs
+   - versioned commands, subagents, instruction bundles, and approved MCP packs
+     at the Workcell layer
+2. Session observability
+   - live status, command timeline, cost/context counters, and artifact browser
+3. Checkpoint and fork support
+   - especially for long-running validation or UI tasks
+4. Enterprise policy plane
+   - centralized policy distribution, session inventory, and usage analytics
+5. Preserved-boundary GUI surfaces
+   - IDE and web entrypoints backed by the same host-controlled supervisor
+6. Broader auth resolver support
+   - enterprise secret managers and brokered credential flows
+
+## Enterprise Productivity Recommendations
+
+If the goal is to improve enterprise developer productivity without trading away
+the core Workcell boundary, the program should be:
+
+### 1. Turn Safe Sessions Into a Queueable Platform
+
+Today, Workcell is primarily a secure launcher. Enterprises need it to become a
+secure session platform. The Supervisor is the bridge from "secure shell entry"
+to "secure developer throughput."
+
+### 2. Default to Isolated Worktrees Per Task
+
+This removes a common source of friction and makes multi-session execution
+practical. It also improves auditability because each task has a clearer branch
+and diff boundary.
+
+### 3. Make Session State Visible
+
+Enterprise teams need to know:
+
+- what is running
+- who started it
+- what it changed
+- what network and credential posture it had
+- whether assurance was downgraded
+
+Workcell already captures much of the raw data needed for this. It needs a user
+surface, not a new security primitive.
+
+### 4. Add Reusable Team-Level Workflow Assets
+
+Popular agent systems have learned that productivity comes from repeatable
+workflows, not only from model quality. Workcell should support:
+
+- review agents
+- refactor agents
+- release agents
+- documentation agents
+- approved MCP bundles
+- approved command packs
+
+These should be distributed as reviewed, auditable Workcell assets rather than
+as ad hoc repo-local prompt files.
+
+### 5. Add Resume and Steering as First-Class Actions
+
+Enterprise developers often want to:
+
+- start work asynchronously
+- redirect the agent mid-task
+- inspect the environment
+- take over locally
+
+Modern systems treat this as normal. Workcell currently treats sessions as
+foreground launches. That is too limiting for large teams.
+
+### 6. Keep the Boundary Model Intact
+
+The main trap to avoid is copying the UX of popular agent systems by weakening
+the security model. Workcell should not give up:
+
+- control-plane masking
+- explicit assurance states
+- host-side publication
+- deny-by-default trust assumptions
+- thin provider adapters with managed policy
+
+The right move is to add orchestration and visibility on top of the current
+boundary, not to replace the boundary with convenience features.
+
+## Bottom Line
+
+Workcell already has the shape of a strong enterprise-safe coding-agent runtime.
+Its main weakness is not architecture drift at the isolation layer. Its weakness
+is that the product surface stops too early.
+
+The system needs to evolve from:
+
+- "securely launch one bounded agent session"
+
+to:
+
+- "securely operate, steer, compare, and audit many bounded agent sessions"
+
+That is the missing capability that best aligns with both modern coding-agent
+workflows and Workcell's existing strengths.

--- a/internal/hostutil/sessions.go
+++ b/internal/hostutil/sessions.go
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package hostutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type SessionRecord struct {
+	Version               int    `json:"version"`
+	SessionID             string `json:"session_id"`
+	Profile               string `json:"profile"`
+	Agent                 string `json:"agent"`
+	Mode                  string `json:"mode"`
+	Status                string `json:"status"`
+	UI                    string `json:"ui,omitempty"`
+	ExecutionPath         string `json:"execution_path,omitempty"`
+	Workspace             string `json:"workspace"`
+	ContainerName         string `json:"container_name,omitempty"`
+	SessionAuditDir       string `json:"session_audit_dir,omitempty"`
+	AuditLogPath          string `json:"audit_log_path,omitempty"`
+	DebugLogPath          string `json:"debug_log_path,omitempty"`
+	FileTraceLogPath      string `json:"file_trace_log_path,omitempty"`
+	TranscriptLogPath     string `json:"transcript_log_path,omitempty"`
+	StartedAt             string `json:"started_at"`
+	FinishedAt            string `json:"finished_at,omitempty"`
+	ExitStatus            string `json:"exit_status,omitempty"`
+	InitialAssurance      string `json:"initial_assurance,omitempty"`
+	FinalAssurance        string `json:"final_assurance,omitempty"`
+	WorkspaceControlPlane string `json:"workspace_control_plane,omitempty"`
+}
+
+type SessionListOptions struct {
+	Workspace string
+	Profile   string
+}
+
+type SessionExport struct {
+	Session      SessionRecord `json:"session"`
+	AuditRecords []string      `json:"audit_records,omitempty"`
+}
+
+func WriteSessionRecord(path string, updates map[string]string) error {
+	record := SessionRecord{Version: 1}
+	if existing, err := ReadSessionRecord(path); err == nil {
+		record = existing
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	for key, value := range updates {
+		switch key {
+		case "session_id":
+			record.SessionID = value
+		case "profile":
+			record.Profile = value
+		case "agent":
+			record.Agent = value
+		case "mode":
+			record.Mode = value
+		case "status":
+			record.Status = value
+		case "ui":
+			record.UI = value
+		case "execution_path":
+			record.ExecutionPath = value
+		case "workspace":
+			record.Workspace = value
+		case "container_name":
+			record.ContainerName = value
+		case "session_audit_dir":
+			record.SessionAuditDir = value
+		case "audit_log_path":
+			record.AuditLogPath = value
+		case "debug_log_path":
+			record.DebugLogPath = value
+		case "file_trace_log_path":
+			record.FileTraceLogPath = value
+		case "transcript_log_path":
+			record.TranscriptLogPath = value
+		case "started_at":
+			record.StartedAt = value
+		case "finished_at":
+			record.FinishedAt = value
+		case "exit_status":
+			record.ExitStatus = value
+		case "initial_assurance":
+			record.InitialAssurance = value
+		case "final_assurance":
+			record.FinalAssurance = value
+		case "workspace_control_plane":
+			record.WorkspaceControlPlane = value
+		default:
+			return fmt.Errorf("unsupported session record field %q", key)
+		}
+	}
+
+	if err := validateSessionRecord(record, path); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+func ReadSessionRecord(path string) (SessionRecord, error) {
+	var record SessionRecord
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return record, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&record); err != nil {
+		return record, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return record, fmt.Errorf("%s: unexpected trailing content", path)
+	}
+	if err := validateSessionRecord(record, path); err != nil {
+		return SessionRecord{}, err
+	}
+	return record, nil
+}
+
+func ListSessionRecords(colimaRoot string, opts SessionListOptions) ([]SessionRecord, error) {
+	root := filepath.Clean(colimaRoot)
+	info, err := os.Stat(root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", root)
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+
+	records := make([]SessionRecord, 0)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if opts.Profile != "" && entry.Name() != opts.Profile {
+			continue
+		}
+
+		profileDir := filepath.Join(root, entry.Name())
+		if isSymlink(profileDir) {
+			continue
+		}
+		sessionDir := filepath.Join(profileDir, "sessions")
+		sessionEntries, err := os.ReadDir(sessionDir)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		for _, sessionEntry := range sessionEntries {
+			if sessionEntry.IsDir() {
+				continue
+			}
+			if filepath.Ext(sessionEntry.Name()) != ".json" {
+				continue
+			}
+			sessionPath := filepath.Join(sessionDir, sessionEntry.Name())
+			if isSymlink(sessionPath) {
+				continue
+			}
+			record, err := ReadSessionRecord(sessionPath)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", sessionPath, err)
+			}
+			if opts.Workspace != "" && record.Workspace != opts.Workspace {
+				continue
+			}
+			records = append(records, record)
+		}
+	}
+
+	sort.SliceStable(records, func(i, j int) bool {
+		if records[i].StartedAt == records[j].StartedAt {
+			return records[i].SessionID > records[j].SessionID
+		}
+		return records[i].StartedAt > records[j].StartedAt
+	})
+	if records == nil {
+		return []SessionRecord{}, nil
+	}
+	return records, nil
+}
+
+func FindSessionRecord(colimaRoot, sessionID string) (SessionRecord, error) {
+	records, err := ListSessionRecords(colimaRoot, SessionListOptions{})
+	if err != nil {
+		return SessionRecord{}, err
+	}
+
+	var match *SessionRecord
+	for i := range records {
+		if records[i].SessionID != sessionID {
+			continue
+		}
+		if match != nil {
+			return SessionRecord{}, fmt.Errorf("multiple session records matched %q", sessionID)
+		}
+		match = &records[i]
+	}
+	if match == nil {
+		return SessionRecord{}, os.ErrNotExist
+	}
+	return *match, nil
+}
+
+func ExportSessionRecord(colimaRoot, sessionID string) (SessionExport, error) {
+	record, err := FindSessionRecord(colimaRoot, sessionID)
+	if err != nil {
+		return SessionExport{}, err
+	}
+
+	export := SessionExport{Session: record}
+	if record.AuditLogPath == "" {
+		return export, nil
+	}
+
+	data, err := os.ReadFile(record.AuditLogPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return export, nil
+		}
+		return SessionExport{}, err
+	}
+
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if auditLineHasSessionID(line, record.SessionID) {
+			export.AuditRecords = append(export.AuditRecords, line)
+		}
+	}
+	return export, nil
+}
+
+func auditLineHasSessionID(line, sessionID string) bool {
+	for _, field := range strings.Fields(line) {
+		key, value, ok := strings.Cut(field, "=")
+		if ok && key == "session_id" && value == sessionID {
+			return true
+		}
+	}
+	return false
+}
+
+func validateSessionRecord(record SessionRecord, source string) error {
+	if record.Version != 1 {
+		return fmt.Errorf("%s: unsupported session record version %d", source, record.Version)
+	}
+	for field, value := range map[string]string{
+		"session_id": record.SessionID,
+		"profile":    record.Profile,
+		"agent":      record.Agent,
+		"mode":       record.Mode,
+		"status":     record.Status,
+		"workspace":  record.Workspace,
+		"started_at": record.StartedAt,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s: missing required session record field %s", source, field)
+		}
+	}
+
+	switch record.Status {
+	case "running", "exited", "failed", "aborted":
+	default:
+		return fmt.Errorf("%s: unsupported session status %q", source, record.Status)
+	}
+
+	if record.Status == "running" {
+		if record.FinishedAt != "" || record.ExitStatus != "" || record.FinalAssurance != "" {
+			return fmt.Errorf("%s: running sessions may not set finished_at, exit_status, or final_assurance", source)
+		}
+		return nil
+	}
+
+	for field, value := range map[string]string{
+		"finished_at":     record.FinishedAt,
+		"exit_status":     record.ExitStatus,
+		"final_assurance": record.FinalAssurance,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s: completed sessions must set %s", source, field)
+		}
+	}
+	return nil
+}

--- a/internal/hostutil/sessions.go
+++ b/internal/hostutil/sessions.go
@@ -146,7 +146,7 @@ func ListSessionRecords(colimaRoot string, opts SessionListOptions) ([]SessionRe
 	info, err := os.Stat(root)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
+			return []SessionRecord{}, nil
 		}
 		return nil, err
 	}

--- a/internal/hostutil/sessions_test.go
+++ b/internal/hostutil/sessions_test.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package hostutil
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteSessionRecordRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	recordPath := filepath.Join(root, "wcl-fixture", "sessions", "session-1.json")
+	if err := WriteSessionRecord(recordPath, map[string]string{
+		"session_id":              "session-1",
+		"profile":                 "wcl-fixture",
+		"agent":                   "codex",
+		"mode":                    "strict",
+		"status":                  "running",
+		"ui":                      "cli",
+		"execution_path":          "managed-tier1",
+		"workspace":               "/tmp/workspace",
+		"started_at":              "2026-04-08T12:00:00Z",
+		"initial_assurance":       "managed-mutable",
+		"workspace_control_plane": "masked",
+	}); err != nil {
+		t.Fatalf("WriteSessionRecord(running) error = %v", err)
+	}
+
+	if err := WriteSessionRecord(recordPath, map[string]string{
+		"status":              "exited",
+		"finished_at":         "2026-04-08T12:05:00Z",
+		"exit_status":         "0",
+		"final_assurance":     "managed-mutable",
+		"audit_log_path":      "/tmp/audit.log",
+		"debug_log_path":      "/tmp/debug.log",
+		"file_trace_log_path": "/tmp/file-trace.log",
+	}); err != nil {
+		t.Fatalf("WriteSessionRecord(exited) error = %v", err)
+	}
+
+	record, err := ReadSessionRecord(recordPath)
+	if err != nil {
+		t.Fatalf("ReadSessionRecord() error = %v", err)
+	}
+	if record.Status != "exited" || record.ExitStatus != "0" || record.FinalAssurance != "managed-mutable" {
+		t.Fatalf("unexpected record: %+v", record)
+	}
+}
+
+func TestWriteSessionRecordRejectsUnknownField(t *testing.T) {
+	t.Parallel()
+
+	err := WriteSessionRecord(filepath.Join(t.TempDir(), "record.json"), map[string]string{
+		"session_id": "session-1",
+		"profile":    "wcl-fixture",
+		"agent":      "codex",
+		"mode":       "strict",
+		"status":     "running",
+		"workspace":  "/tmp/workspace",
+		"started_at": "2026-04-08T12:00:00Z",
+		"unknown":    "value",
+	})
+	if err == nil {
+		t.Fatal("WriteSessionRecord() unexpectedly succeeded")
+	}
+}
+
+func TestListSessionRecordsSortsNewestFirstAndFilters(t *testing.T) {
+	t.Parallel()
+
+	colimaRoot := t.TempDir()
+	writeSessionFixture(t, filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json"), SessionRecord{
+		Version:        1,
+		SessionID:      "session-1",
+		Profile:        "wcl-one",
+		Agent:          "codex",
+		Mode:           "strict",
+		Status:         "exited",
+		Workspace:      "/tmp/workspace-a",
+		StartedAt:      "2026-04-08T10:00:00Z",
+		FinishedAt:     "2026-04-08T10:05:00Z",
+		ExitStatus:     "0",
+		FinalAssurance: "managed-mutable",
+	})
+	writeSessionFixture(t, filepath.Join(colimaRoot, "wcl-two", "sessions", "session-2.json"), SessionRecord{
+		Version:        1,
+		SessionID:      "session-2",
+		Profile:        "wcl-two",
+		Agent:          "claude",
+		Mode:           "development",
+		Status:         "failed",
+		Workspace:      "/tmp/workspace-b",
+		StartedAt:      "2026-04-08T11:00:00Z",
+		FinishedAt:     "2026-04-08T11:03:00Z",
+		ExitStatus:     "17",
+		FinalAssurance: "managed-mutable",
+	})
+
+	records, err := ListSessionRecords(colimaRoot, SessionListOptions{})
+	if err != nil {
+		t.Fatalf("ListSessionRecords() error = %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("ListSessionRecords() len = %d, want 2", len(records))
+	}
+	if records[0].SessionID != "session-2" || records[1].SessionID != "session-1" {
+		t.Fatalf("unexpected sort order: %+v", records)
+	}
+
+	filtered, err := ListSessionRecords(colimaRoot, SessionListOptions{Workspace: "/tmp/workspace-a"})
+	if err != nil {
+		t.Fatalf("ListSessionRecords(filter) error = %v", err)
+	}
+	if len(filtered) != 1 || filtered[0].SessionID != "session-1" {
+		t.Fatalf("unexpected filter result: %+v", filtered)
+	}
+}
+
+func TestExportSessionRecordIncludesMatchingAuditLines(t *testing.T) {
+	t.Parallel()
+
+	colimaRoot := t.TempDir()
+	auditLogPath := filepath.Join(colimaRoot, "wcl-one", "workcell.audit.log")
+	if err := os.MkdirAll(filepath.Dir(auditLogPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(auditLogPath, []byte(
+		"timestamp=2026-04-08T10:00:00Z event=launch session_id=session-1 record_digest=aaa\n"+
+			"timestamp=2026-04-08T10:01:00Z event=launch session_id=session-2 record_digest=bbb\n"+
+			"timestamp=2026-04-08T10:02:00Z event=exit session_id=session-1 record_digest=ccc\n",
+	), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	writeSessionFixture(t, filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json"), SessionRecord{
+		Version:        1,
+		SessionID:      "session-1",
+		Profile:        "wcl-one",
+		Agent:          "codex",
+		Mode:           "strict",
+		Status:         "exited",
+		Workspace:      "/tmp/workspace-a",
+		StartedAt:      "2026-04-08T10:00:00Z",
+		FinishedAt:     "2026-04-08T10:05:00Z",
+		ExitStatus:     "0",
+		FinalAssurance: "managed-mutable",
+		AuditLogPath:   auditLogPath,
+	})
+
+	exported, err := ExportSessionRecord(colimaRoot, "session-1")
+	if err != nil {
+		t.Fatalf("ExportSessionRecord() error = %v", err)
+	}
+	if len(exported.AuditRecords) != 2 {
+		t.Fatalf("ExportSessionRecord() audit record len = %d, want 2", len(exported.AuditRecords))
+	}
+}
+
+func TestReadSessionRecordRejectsUnknownJSONField(t *testing.T) {
+	t.Parallel()
+
+	recordPath := filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(recordPath, []byte(`{
+  "version": 1,
+  "session_id": "session-1",
+  "profile": "wcl-one",
+  "agent": "codex",
+  "mode": "strict",
+  "status": "running",
+  "workspace": "/tmp/workspace",
+  "started_at": "2026-04-08T10:00:00Z",
+  "unexpected": "value"
+}
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ReadSessionRecord(recordPath)
+	if err == nil {
+		t.Fatal("ReadSessionRecord() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("ReadSessionRecord() error = %v, want unknown field failure", err)
+	}
+}
+
+func TestWriteSessionRecordRejectsCompletedRecordMissingExitMetadata(t *testing.T) {
+	t.Parallel()
+
+	err := WriteSessionRecord(filepath.Join(t.TempDir(), "record.json"), map[string]string{
+		"session_id":  "session-1",
+		"profile":     "wcl-fixture",
+		"agent":       "codex",
+		"mode":        "strict",
+		"status":      "failed",
+		"workspace":   "/tmp/workspace",
+		"started_at":  "2026-04-08T12:00:00Z",
+		"finished_at": "2026-04-08T12:05:00Z",
+	})
+	if err == nil {
+		t.Fatal("WriteSessionRecord() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "completed sessions must set exit_status") {
+		t.Fatalf("WriteSessionRecord() error = %v, want exit_status failure", err)
+	}
+}
+
+func writeSessionFixture(tb testing.TB, path string, record SessionRecord) {
+	tb.Helper()
+
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		tb.Fatal(err)
+	}
+}

--- a/internal/hostutil/sessions_test.go
+++ b/internal/hostutil/sessions_test.go
@@ -122,6 +122,21 @@ func TestListSessionRecordsSortsNewestFirstAndFilters(t *testing.T) {
 	}
 }
 
+func TestListSessionRecordsReturnsEmptySliceWhenColimaRootMissing(t *testing.T) {
+	t.Parallel()
+
+	records, err := ListSessionRecords(filepath.Join(t.TempDir(), "missing"), SessionListOptions{})
+	if err != nil {
+		t.Fatalf("ListSessionRecords() error = %v", err)
+	}
+	if records == nil {
+		t.Fatal("ListSessionRecords() returned nil, want empty slice")
+	}
+	if len(records) != 0 {
+		t.Fatalf("ListSessionRecords() len = %d, want 0", len(records))
+	}
+}
+
 func TestExportSessionRecordIncludesMatchingAuditLines(t *testing.T) {
 	t.Parallel()
 

--- a/internal/metadatautil/requirements.go
+++ b/internal/metadatautil/requirements.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func ValidateRequirements(rootDir, requirementsPath string) error {
+	text, err := readText(requirementsPath)
+	if err != nil {
+		return err
+	}
+	document, err := ParseTOMLSubset(text, requirementsPath)
+	if err != nil {
+		return err
+	}
+
+	version, ok := document["version"].(int)
+	if !ok || version != 1 {
+		return fmt.Errorf("%s must set version = 1", requirementsPath)
+	}
+
+	seenIDs := map[string]struct{}{}
+	seenTitles := map[string]struct{}{}
+	for category, prefix := range map[string]string{
+		"functional":    "FR-",
+		"nonfunctional": "NFR-",
+	} {
+		rawTable, ok := document[category].(map[string]any)
+		if !ok || len(rawTable) == 0 {
+			return fmt.Errorf("%s must define a non-empty [%s] requirement table", requirementsPath, category)
+		}
+		ids := make([]string, 0, len(rawTable))
+		for id := range rawTable {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		for _, id := range ids {
+			if !strings.HasPrefix(id, prefix) {
+				return fmt.Errorf("%s requirement %s must use prefix %s", requirementsPath, id, prefix)
+			}
+			if _, ok := seenIDs[id]; ok {
+				return fmt.Errorf("%s defines duplicate requirement id %s", requirementsPath, id)
+			}
+			seenIDs[id] = struct{}{}
+
+			table, ok := rawTable[id].(map[string]any)
+			if !ok {
+				return fmt.Errorf("%s requirement %s must be a table", requirementsPath, id)
+			}
+			if err := validateRequirementTable(rootDir, requirementsPath, category, id, table, seenTitles); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateRequirementTable(rootDir, requirementsPath, category, id string, table map[string]any, seenTitles map[string]struct{}) error {
+	allowedKeys := map[string]struct{}{
+		"title":    {},
+		"summary":  {},
+		"evidence": {},
+		"docs":     {},
+	}
+	for key := range table {
+		if _, ok := allowedKeys[key]; !ok {
+			return fmt.Errorf("%s requirement %s contains unsupported key %s", requirementsPath, id, key)
+		}
+	}
+
+	title, ok := MustString(table["title"])
+	if !ok || strings.TrimSpace(title) == "" {
+		return fmt.Errorf("%s requirement %s must define a non-empty title", requirementsPath, id)
+	}
+	if _, ok := seenTitles[title]; ok {
+		return fmt.Errorf("%s requirement %s reuses title %q", requirementsPath, id, title)
+	}
+	seenTitles[title] = struct{}{}
+
+	summary, ok := MustString(table["summary"])
+	if !ok || strings.TrimSpace(summary) == "" {
+		return fmt.Errorf("%s requirement %s must define a non-empty summary", requirementsPath, id)
+	}
+
+	evidence, ok, err := MustStringSlice(table["evidence"])
+	if err != nil {
+		return fmt.Errorf("%s requirement %s evidence: %w", requirementsPath, id, err)
+	}
+	if !ok || len(evidence) == 0 {
+		return fmt.Errorf("%s requirement %s must define a non-empty evidence array", requirementsPath, id)
+	}
+
+	docs, ok, err := MustStringSlice(table["docs"])
+	if err != nil {
+		return fmt.Errorf("%s requirement %s docs: %w", requirementsPath, id, err)
+	}
+	if !ok || len(docs) == 0 {
+		return fmt.Errorf("%s requirement %s must define a non-empty docs array", requirementsPath, id)
+	}
+
+	automatedEvidence := false
+	for _, path := range evidence {
+		if err := validateRequirementPath(rootDir, requirementsPath, category, id, "evidence", path); err != nil {
+			return err
+		}
+		if isAutomatedEvidencePath(path) {
+			automatedEvidence = true
+		}
+	}
+	if !automatedEvidence {
+		return fmt.Errorf("%s requirement %s must cite at least one automated evidence path", requirementsPath, id)
+	}
+	for _, path := range docs {
+		if err := validateRequirementPath(rootDir, requirementsPath, category, id, "docs", path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRequirementPath(rootDir, requirementsPath, category, id, field, path string) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("%s requirement %s %s entries may not be empty", requirementsPath, id, field)
+	}
+	if filepath.IsAbs(path) {
+		return fmt.Errorf("%s requirement %s %s path %s must be repo-relative", requirementsPath, id, field, path)
+	}
+
+	target, err := resolveRequirementPath(rootDir, path)
+	if err != nil {
+		return fmt.Errorf("%s requirement %s %s path %s: %w", requirementsPath, id, field, path, err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		return fmt.Errorf("%s requirement %s %s path %s: %w", requirementsPath, id, field, path, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s requirement %s %s path %s must point to a file", requirementsPath, id, field, path)
+	}
+	return nil
+}
+
+func resolveRequirementPath(rootDir, path string) (string, error) {
+	root := filepath.Clean(rootDir)
+	target := filepath.Join(root, filepath.FromSlash(path))
+	relative, err := filepath.Rel(root, target)
+	if err != nil {
+		return "", err
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes repository root")
+	}
+	return target, nil
+}
+
+func isAutomatedEvidencePath(path string) bool {
+	base := filepath.Base(path)
+	switch {
+	case strings.HasSuffix(path, "_test.go"):
+		return true
+	case strings.HasPrefix(base, "test-"):
+		return true
+	case strings.HasPrefix(base, "verify-"):
+		return true
+	case base == "container-smoke.sh", base == "build-and-test.sh", base == "dev-quick-check.sh", base == "pre-merge.sh", base == "provider-e2e.sh":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/metadatautil/requirements_test.go
+++ b/internal/metadatautil/requirements_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateRequirementsAcceptsCanonicalMatrix(t *testing.T) {
+	root := t.TempDir()
+	mustWriteRequirementFixture(t, root, "README.md")
+	mustWriteRequirementFixture(t, root, "docs/guide.md")
+	mustWriteRequirementFixture(t, root, "scripts/verify-example.sh")
+	mustWriteRequirementFixture(t, root, "internal/example/example_test.go")
+
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	if err := os.MkdirAll(filepath.Dir(requirementsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(requirementsPath, []byte(`version = 1
+
+[functional.FR-001]
+title = "Managed launch"
+summary = "Launch the provider inside the managed runtime."
+evidence = ["scripts/verify-example.sh"]
+docs = ["README.md", "docs/guide.md"]
+
+[nonfunctional.NFR-001]
+title = "Requirement traceability"
+summary = "Every requirement cites automated evidence."
+evidence = ["internal/example/example_test.go"]
+docs = ["docs/guide.md"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ValidateRequirements(root, requirementsPath); err != nil {
+		t.Fatalf("ValidateRequirements() error = %v", err)
+	}
+}
+
+func TestValidateRequirementsRejectsMissingEvidencePath(t *testing.T) {
+	root := t.TempDir()
+	mustWriteRequirementFixture(t, root, "README.md")
+	mustWriteRequirementFixture(t, root, "docs/guide.md")
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	if err := os.MkdirAll(filepath.Dir(requirementsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(requirementsPath, []byte(`version = 1
+
+[functional.FR-001]
+title = "Managed launch"
+summary = "Launch the provider inside the managed runtime."
+evidence = ["scripts/missing.sh"]
+docs = ["README.md"]
+
+[nonfunctional.NFR-001]
+title = "Requirement traceability"
+summary = "Every requirement cites automated evidence."
+evidence = ["docs/guide.md"]
+docs = ["docs/guide.md"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ValidateRequirements(root, requirementsPath)
+	if err == nil {
+		t.Fatal("ValidateRequirements() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "scripts/missing.sh") {
+		t.Fatalf("ValidateRequirements() error = %v, want missing evidence path", err)
+	}
+}
+
+func TestValidateRequirementsRejectsNonAutomatedEvidenceOnly(t *testing.T) {
+	root := t.TempDir()
+	mustWriteRequirementFixture(t, root, "README.md")
+	mustWriteRequirementFixture(t, root, "docs/guide.md")
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	if err := os.MkdirAll(filepath.Dir(requirementsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(requirementsPath, []byte(`version = 1
+
+[functional.FR-001]
+title = "Managed launch"
+summary = "Launch the provider inside the managed runtime."
+evidence = ["README.md"]
+docs = ["README.md"]
+
+[nonfunctional.NFR-001]
+title = "Requirement traceability"
+summary = "Every requirement cites automated evidence."
+evidence = ["docs/guide.md"]
+docs = ["docs/guide.md"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ValidateRequirements(root, requirementsPath)
+	if err == nil {
+		t.Fatal("ValidateRequirements() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "automated evidence") {
+		t.Fatalf("ValidateRequirements() error = %v, want automated evidence failure", err)
+	}
+}
+
+func TestValidateRequirementsRejectsRepoEscapingPaths(t *testing.T) {
+	root := t.TempDir()
+	mustWriteRequirementFixture(t, root, "README.md")
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	if err := os.MkdirAll(filepath.Dir(requirementsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(requirementsPath, []byte(`version = 1
+
+[functional.FR-001]
+title = "Managed launch"
+summary = "Launch the provider inside the managed runtime."
+evidence = ["../outside.sh"]
+docs = ["README.md"]
+
+[nonfunctional.NFR-001]
+title = "Requirement traceability"
+summary = "Every requirement cites automated evidence."
+evidence = ["../outside.sh"]
+docs = ["README.md"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ValidateRequirements(root, requirementsPath)
+	if err == nil {
+		t.Fatal("ValidateRequirements() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "escapes repository root") {
+		t.Fatalf("ValidateRequirements() error = %v, want repo root escape failure", err)
+	}
+}
+
+func TestValidateRequirementsRejectsAbsolutePaths(t *testing.T) {
+	root := t.TempDir()
+	mustWriteRequirementFixture(t, root, "README.md")
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	if err := os.MkdirAll(filepath.Dir(requirementsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(requirementsPath, []byte(`version = 1
+
+[functional.FR-001]
+title = "Managed launch"
+summary = "Launch the provider inside the managed runtime."
+evidence = ["/tmp/verify-example.sh"]
+docs = ["README.md"]
+
+[nonfunctional.NFR-001]
+title = "Requirement traceability"
+summary = "Every requirement cites automated evidence."
+evidence = ["README.md"]
+docs = ["README.md"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ValidateRequirements(root, requirementsPath)
+	if err == nil {
+		t.Fatal("ValidateRequirements() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "must be repo-relative") {
+		t.Fatalf("ValidateRequirements() error = %v, want absolute path failure", err)
+	}
+}
+
+func mustWriteRequirementFixture(tb testing.TB, root, relativePath string) {
+	tb.Helper()
+
+	path := filepath.Join(root, filepath.FromSlash(relativePath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("fixture\n"), 0o644); err != nil {
+		tb.Fatal(err)
+	}
+}

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -100,6 +100,9 @@ func TestValidationGatesLintAllScenarioShellScripts(t *testing.T) {
 		if !strings.Contains(content, "scripts/lint-dockerfiles.sh") {
 			t.Fatalf("validation scripts must include scripts/lint-dockerfiles.sh")
 		}
+		if !strings.Contains(content, "scripts/verify-requirements-coverage.sh") {
+			t.Fatalf("validation scripts must include scripts/verify-requirements-coverage.sh")
+		}
 		if !strings.Contains(content, "gofmt -l") {
 			t.Fatalf("validation scripts must include gofmt formatting checks")
 		}
@@ -174,6 +177,26 @@ func TestInstallDevToolsBootstrapsNodeAndPythonVenvPrereqs(t *testing.T) {
 		`append_unique_apt nodejs npm`,
 		`append_unique_brew python`,
 		`append_unique_apt python3 python3-venv python3-pip`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("%s does not contain %q", scriptPath, want)
+		}
+	}
+}
+
+func TestInstallWorkcellDebugWrapperSkipsSessionCommands(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "install-workcell.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(content)
+
+	for _, want := range []string{
+		"session)",
+		"SKIP_AUTO_DEBUG=1",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("%s does not contain %q", scriptPath, want)

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -1,4 +1,4 @@
-.TH WORKCELL 1 "2026-04-05" "Workcell" "User Commands"
+.TH WORKCELL 1 "2026-04-08" "Workcell" "User Commands"
 .SH NAME
 workcell \- bounded runtime launcher for coding agents
 .SH SYNOPSIS
@@ -7,6 +7,9 @@ workcell \- bounded runtime launcher for coding agents
 .br
 .B workcell publish-pr
 [\fIoptions\fR]
+.br
+.B workcell session
+\fIlist|show|export\fR [\fIoptions\fR]
 .br
 .B workcell auth
 \fIinit|set|unset|status\fR [\fIoptions\fR]
@@ -27,6 +30,11 @@ and uses
 .I /state/tmp
 as the exec-capable temporary directory via
 .BR TMPDIR .
+.TP
+.B workcell session list|show|export
+Inspect durable host-side session records without starting the Workcell
+runtime. These records summarize completed or aborted launches and can be
+exported with the matching profile audit lines.
 .SH OPTIONS
 .TP
 .B --agent codex|claude|gemini

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -1,0 +1,157 @@
+version = 1
+
+[functional.FR-001]
+title = "Managed provider launch"
+summary = "Workcell launches supported providers directly inside the managed Tier 1 runtime without a separate attach step."
+evidence = [
+  "scripts/container-smoke.sh",
+  "scripts/verify-invariants.sh",
+  "tests/scenarios/shared/test-assurance-dry-run.sh",
+]
+docs = [
+  "README.md",
+  "docs/invariants.md",
+  "docs/provider-matrix.md",
+]
+
+[functional.FR-002]
+title = "Policy-backed auth and injection"
+summary = "Workcell manages explicit host-side auth policy and stages reviewed credentials and instruction fragments through the injection bundle path."
+evidence = [
+  "tests/scenarios/shared/test-auth-commands.sh",
+  "tests/scenarios/shared/test-auth-status.sh",
+  "internal/authpolicy/manage_test.go",
+]
+docs = [
+  "README.md",
+  "docs/injection-policy.md",
+  "docs/examples/injection-policy.toml",
+]
+
+[functional.FR-003]
+title = "Workspace control-plane masking"
+summary = "Workcell masks repo-local control-plane files on the safe path and reseeds reviewed content into the effective provider home."
+evidence = [
+  "scripts/container-smoke.sh",
+  "scripts/verify-invariants.sh",
+  "tests/scenarios/shared/test-home-control-plane-manifest.sh",
+]
+docs = [
+  "docs/invariants.md",
+  "docs/adapter-control-planes.md",
+  "docs/workcell-system-design.md",
+]
+
+[functional.FR-004]
+title = "Explicit lower-assurance modes"
+summary = "Development, breakglass, prompt autonomy, arbitrary command, and control-plane VCS paths stay explicit and visibly lower assurance."
+evidence = [
+  "tests/scenarios/shared/test-assurance-dry-run.sh",
+  "scripts/verify-invariants.sh",
+]
+docs = [
+  "README.md",
+  "docs/invariants.md",
+  "man/workcell.1",
+]
+
+[functional.FR-005]
+title = "Host-side publication handoff"
+summary = "Final branch publication remains a host-side action with signed commits and repo hook bypasses handled outside Tier 1."
+evidence = [
+  "tests/scenarios/shared/test-publish-pr-dry-run.sh",
+  "scripts/verify-invariants.sh",
+]
+docs = [
+  "README.md",
+  "docs/provenance.md",
+  "man/workcell.1",
+]
+
+[functional.FR-006]
+title = "Host-side operator commands"
+summary = "Inspect, doctor, logs, gc, and auth/session management run on the host without starting the runtime."
+evidence = [
+  "scripts/verify-invariants.sh",
+  "internal/testkit/validation_entrypoints_test.go",
+]
+docs = [
+  "README.md",
+  "man/workcell.1",
+  "docs/validation-scenarios.md",
+]
+
+[functional.FR-007]
+title = "Durable session inventory"
+summary = "Workcell records durable host-side launch metadata and exposes list, show, and export commands for recorded sessions."
+evidence = [
+  "tests/scenarios/shared/test-session-commands.sh",
+  "internal/hostutil/sessions_test.go",
+]
+docs = [
+  "README.md",
+  "docs/workcell-session-supervisor-design.md",
+  "docs/workcell-system-design.md",
+]
+
+[nonfunctional.NFR-001]
+title = "Bounded VM-plus-container execution"
+summary = "The safe path preserves a dedicated Colima VM plus a hardened container rather than depending on provider config as the security boundary."
+evidence = [
+  "scripts/container-smoke.sh",
+  "scripts/verify-invariants.sh",
+]
+docs = [
+  "README.md",
+  "docs/invariants.md",
+  "docs/threat-model.md",
+]
+
+[nonfunctional.NFR-002]
+title = "Visible assurance and audit state"
+summary = "Workcell records launch, downgrade, and exit metadata so assurance changes stay visible to operators."
+evidence = [
+  "tests/scenarios/shared/test-assurance-dry-run.sh",
+  "scripts/verify-invariants.sh",
+]
+docs = [
+  "docs/validation-scenarios.md",
+  "docs/workcell-system-design.md",
+  "man/workcell.1",
+]
+
+[nonfunctional.NFR-003]
+title = "Reproducible runtime build"
+summary = "The runtime image must remain reproducible across the reviewed build workflow and per-platform CI lanes."
+evidence = [
+  "scripts/verify-reproducible-build.sh",
+  "internal/metadatautil/workflow_validation_test.go",
+]
+docs = [
+  "docs/provenance.md",
+  "docs/github-workflows.md",
+]
+
+[nonfunctional.NFR-004]
+title = "Release provenance validation"
+summary = "Release artifacts, control-plane manifests, and signing metadata must remain validated and reproducible before publication."
+evidence = [
+  "scripts/verify-release-bundle.sh",
+  "scripts/verify-control-plane-manifest.sh",
+]
+docs = [
+  "docs/provenance.md",
+  "docs/github-workflows.md",
+]
+
+[nonfunctional.NFR-005]
+title = "Canonical requirement traceability"
+summary = "The repository must maintain a machine-checked mapping from supported requirements to automated evidence and documentation."
+evidence = [
+  "scripts/verify-requirements-coverage.sh",
+  "internal/metadatautil/requirements_test.go",
+]
+docs = [
+  "docs/requirements-validation.md",
+  "docs/validation-scenarios.md",
+]

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "89e3a2a0ed129d744620430ef3ad9ba33814a160c955f70d127ee0a8a987a67b"
+      "sha256": "95f8f7503b014a9e445438d17d054f60a5c37d708d655aee59b532030f79848c"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/scripts/dev-quick-check.sh
+++ b/scripts/dev-quick-check.sh
@@ -39,6 +39,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/lib/scenario_manifest"
   "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
   "${ROOT_DIR}/scripts/verify-go-python-parity.sh"
+  "${ROOT_DIR}/scripts/verify-requirements-coverage.sh"
   "${ROOT_DIR}/runtime/container/bin/apt-helper.sh"
   "${ROOT_DIR}/runtime/container/bin/apt-wrapper.sh"
   "${ROOT_DIR}/runtime/container/development-wrapper.sh"
@@ -66,6 +67,7 @@ if [[ "${#go_files[@]}" -gt 0 ]]; then
 fi
 go vet ./...
 go test ./...
+"${ROOT_DIR}/scripts/verify-requirements-coverage.sh"
 
 (
   cd "${ROOT_DIR}/runtime/container/rust"

--- a/scripts/install-workcell.sh
+++ b/scripts/install-workcell.sh
@@ -84,6 +84,9 @@ for ARG in "\$@"; do
     --auth-status | --doctor | --gc | --help | --inspect | --logs | --prepare-only | -h | auth-status | doctor | gc | help | inspect | logs | publish-pr)
       SKIP_AUTO_DEBUG=1
       ;;
+    session)
+      SKIP_AUTO_DEBUG=1
+      ;;
     --debug-log)
       HAS_DEBUG_LOG=1
       ;;

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -140,6 +140,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/verify-control-plane-manifest.sh"
   "${ROOT_DIR}/scripts/verify-release-bundle.sh"
   "${ROOT_DIR}/scripts/verify-invariants.sh"
+  "${ROOT_DIR}/scripts/verify-requirements-coverage.sh"
   "${ROOT_DIR}/scripts/verify-reproducible-build.sh"
   "${ROOT_DIR}/scripts/verify-upstream-codex-release.sh"
   "${ROOT_DIR}/scripts/verify-upstream-gemini-release.sh"
@@ -256,6 +257,7 @@ yamllint -d "{extends: default, rules: {comments: disable, document-start: disab
 
 "${ROOT_DIR}/scripts/verify-build-input-manifest.sh"
 "${ROOT_DIR}/scripts/verify-control-plane-manifest.sh"
+"${ROOT_DIR}/scripts/verify-requirements-coverage.sh"
 
 doc_files=()
 while IFS= read -r -d '' file; do

--- a/scripts/verify-requirements-coverage.sh
+++ b/scripts/verify-requirements-coverage.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=/dev/null
+source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
+
+if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
+  echo "verify-requirements-coverage-entrypoint-ok"
+  exit 0
+fi
+
+run_go_in_repo "${ROOT_DIR}" run ./cmd/workcell-metadatautil validate-requirements "${ROOT_DIR}" "${ROOT_DIR}/policy/requirements.toml"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -155,6 +155,10 @@ SESSION_AUDIT_STATE_FILE=""
 SESSION_AUDIT_CONTAINER_FILE=""
 SESSION_FILE_TRACE_CONTAINER_FILE="/var/tmp/workcell-file-trace.log"
 FINAL_SESSION_ASSURANCE=""
+SESSION_ID=""
+SESSION_RECORD_PATH=""
+SESSION_RECORD_WRITTEN=0
+SESSION_RECORD_FINALIZED=0
 INJECTION_POLICY_SHA256=""
 INJECTION_CREDENTIAL_KEYS=""
 INJECTION_CREDENTIAL_INPUT_KINDS=""
@@ -170,6 +174,7 @@ usage() {
   cat <<'EOF'
 Usage: workcell [options] [-- provider-args...]
        workcell publish-pr [options]
+       workcell session <list|show|export> [options]
        workcell auth <init|set|unset|status> [options]
 
 Options:
@@ -245,6 +250,9 @@ Workflows:
     workcell auth set --agent codex --credential codex_auth --source /path/to/auth.json
     workcell auth set --agent claude --credential claude_auth --resolver claude-macos-keychain --ack-host-resolver
     workcell auth status --agent codex
+    workcell session list
+    workcell session show --id 20260408T120000Z-1a2b3c4d
+    workcell session export --id 20260408T120000Z-1a2b3c4d
     workcell inspect --agent codex --workspace /path/to/repo
     workcell doctor --agent codex --workspace /path/to/repo
     workcell logs debug --colima-profile wcl-...
@@ -697,10 +705,16 @@ restore_interactive_host_terminal() {
   printf '\033[0m\033[?25h\033[?2004l\033[?1004l\033[?1000l\033[?1002l\033[?1003l\033[?1006l\033[?1049l' >/dev/tty 2>/dev/null || true
 }
 
-# cleanup is only reached through trap 'cleanup' EXIT; validator/CI ShellCheck
+# cleanup is only reached through trap 'cleanup "$?"' EXIT; validator/CI ShellCheck
 # still misclassifies the trap-only body as unreachable.
 # shellcheck disable=SC2317,SC2329
 cleanup() {
+  local exit_status="${1:-0}"
+
+  if [[ "${SESSION_RECORD_WRITTEN}" -eq 1 ]] && [[ "${SESSION_RECORD_FINALIZED}" -eq 0 ]]; then
+    write_session_record_final "aborted" "${exit_status}" "${FINAL_SESSION_ASSURANCE:-$(session_assurance_initial)}" || true
+  fi
+
   if [[ -n "${CONTROL_PLANE_SHADOW_ROOT}" ]] && [[ -e "${CONTROL_PLANE_SHADOW_ROOT}" ]]; then
     chmod -R u+w "${CONTROL_PLANE_SHADOW_ROOT}" 2>/dev/null || true
     rm -rf "${CONTROL_PLANE_SHADOW_ROOT}"
@@ -759,7 +773,7 @@ cleanup() {
   restore_interactive_host_terminal
 }
 
-trap 'cleanup' EXIT
+trap 'cleanup "$?"' EXIT
 
 profile_marker_path() {
   local profile="$1"
@@ -806,6 +820,17 @@ profile_audit_log_path() {
 
   validate_colima_profile_name "${profile}"
   printf '%s/workcell.audit.log\n' "$(profile_dir "${profile}")"
+}
+
+profile_sessions_dir_path() {
+  local profile="$1"
+
+  validate_colima_profile_name "${profile}"
+  printf '%s/sessions\n' "$(profile_dir "${profile}")"
+}
+
+generate_session_id() {
+  printf '%s-%s\n' "$(date -u '+%Y%m%dT%H%M%SZ')" "$(generate_session_suffix)"
 }
 
 profile_lock_dir_path() {
@@ -1146,6 +1171,7 @@ append_launch_audit_record() {
 
   append_audit_record "${profile}" \
     "event=launch" \
+    "session_id=${SESSION_ID}" \
     "profile=${profile}" \
     "mode=${MODE}" \
     "agent=${AGENT}" \
@@ -1191,6 +1217,7 @@ append_assurance_change_audit_record() {
 
   append_audit_record "${profile}" \
     "event=assurance-change" \
+    "session_id=${SESSION_ID}" \
     "profile=${profile}" \
     "mode=${MODE}" \
     "agent=${AGENT}" \
@@ -1210,6 +1237,7 @@ append_exit_audit_record() {
 
   append_audit_record "${profile}" \
     "event=exit" \
+    "session_id=${SESSION_ID}" \
     "profile=${profile}" \
     "mode=${MODE}" \
     "agent=${AGENT}" \
@@ -1245,6 +1273,58 @@ append_exit_audit_record() {
     "package_mutation_downgraded=${downgraded}"
 }
 
+write_session_record() {
+  local path="$1"
+  shift
+
+  go_hostutil launcher session-record-write "${path}" "$@"
+}
+
+write_session_record_initial() {
+  local profile="$1"
+  local execution_path="$2"
+  local sessions_dir=""
+
+  [[ -n "${SESSION_ID}" ]] || SESSION_ID="$(generate_session_id)"
+  sessions_dir="$(profile_sessions_dir_path "${profile}")"
+  mkdir -p "${sessions_dir}"
+  SESSION_RECORD_PATH="${sessions_dir}/${SESSION_ID}.json"
+  write_session_record "${SESSION_RECORD_PATH}" \
+    "session_id=${SESSION_ID}" \
+    "profile=${profile}" \
+    "agent=${AGENT}" \
+    "mode=${MODE}" \
+    "status=running" \
+    "ui=${UI}" \
+    "execution_path=${execution_path}" \
+    "workspace=${WORKSPACE}" \
+    "container_name=${CONTAINER_NAME}" \
+    "session_audit_dir=${SESSION_AUDIT_DIR}" \
+    "audit_log_path=$(profile_audit_log_path "${profile}")" \
+    "debug_log_path=${DEBUG_LOG_PATH}" \
+    "file_trace_log_path=${FILE_TRACE_LOG_PATH}" \
+    "transcript_log_path=${AUDIT_TRANSCRIPT_PATH}" \
+    "started_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    "initial_assurance=$(session_assurance_initial)" \
+    "workspace_control_plane=$(workspace_control_plane_state)"
+  SESSION_RECORD_WRITTEN=1
+}
+
+write_session_record_final() {
+  local status="$1"
+  local exit_status="$2"
+  local final_assurance="$3"
+
+  [[ "${SESSION_RECORD_WRITTEN}" -eq 1 ]] || return 0
+  [[ -n "${SESSION_RECORD_PATH}" ]] || return 0
+  write_session_record "${SESSION_RECORD_PATH}" \
+    "status=${status}" \
+    "finished_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    "exit_status=${exit_status}" \
+    "final_assurance=${final_assurance}"
+  SESSION_RECORD_FINALIZED=1
+}
+
 prepare_session_audit_state() {
   local profile="$1"
 
@@ -1253,6 +1333,10 @@ prepare_session_audit_state() {
   chmod 0700 "${SESSION_AUDIT_DIR}" 2>/dev/null || true
   SESSION_AUDIT_STATE_FILE="${SESSION_AUDIT_DIR}/session-assurance"
   SESSION_AUDIT_CONTAINER_FILE="/var/lib/workcell/session-assurance"
+  SESSION_ID="$(generate_session_id)"
+  SESSION_RECORD_PATH=""
+  SESSION_RECORD_WRITTEN=0
+  SESSION_RECORD_FINALIZED=0
   rm -f "${SESSION_AUDIT_STATE_FILE}"
 }
 
@@ -1305,6 +1389,11 @@ finalize_session_audit() {
     append_assurance_change_audit_record "${profile}" "${final_assurance}"
   fi
   append_exit_audit_record "${profile}" "${execution_path}" "${exit_status}" "${final_assurance}" "${downgraded}"
+  if [[ "${exit_status}" -eq 0 ]]; then
+    write_session_record_final "exited" "${exit_status}" "${final_assurance}"
+  else
+    write_session_record_final "failed" "${exit_status}" "${final_assurance}"
+  fi
   FINAL_SESSION_ASSURANCE="${final_assurance}"
 }
 
@@ -1810,6 +1899,169 @@ publish_pr_main() {
   printf 'publish_pr_url=%s\n' "${pr_url}"
   printf 'publish_snapshot=%s\n' "${snapshot}"
   exit 0
+}
+
+session_usage() {
+  cat <<'EOF'
+Usage: workcell session list [options]
+       workcell session show --id SESSION_ID
+       workcell session export --id SESSION_ID [--output PATH]
+
+Commands:
+  list
+    --workspace PATH          Filter recorded sessions to PATH
+    --colima-profile NAME     Filter recorded sessions to the selected profile
+    --json                    Emit machine-readable JSON instead of the default table
+
+  show
+    --id SESSION_ID           Show one recorded session as JSON
+
+  export
+    --id SESSION_ID           Export one recorded session plus matching audit records as JSON
+    --output PATH             Write the exported JSON bundle to PATH instead of stdout
+
+Notes:
+  - session commands run on the host and do not start the Workcell runtime.
+  - records are durable host-side metadata for completed or aborted launches.
+  - `session export` includes audit records that match the recorded session id.
+EOF
+}
+
+session_main() {
+  local subcommand="${1:-}"
+  local workspace=""
+  local profile=""
+  local emit_json=0
+  local session_id=""
+  local output_path=""
+  local output=""
+  local -a args=()
+
+  shift || true
+  case "${subcommand}" in
+    list)
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --workspace)
+            workspace="$(resolve_host_path "$(option_value_or_die "$1" "${2-}")")"
+            shift 2
+            ;;
+          --colima-profile)
+            profile="$(option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          --json)
+            emit_json=1
+            shift
+            ;;
+          -h | --help)
+            session_usage
+            exit 0
+            ;;
+          *)
+            echo "Unsupported workcell session list option: $1" >&2
+            session_usage >&2
+            exit 2
+            ;;
+        esac
+      done
+      args=("${COLIMA_STATE_ROOT}")
+      if [[ "${emit_json}" -eq 1 ]]; then
+        args+=(--json)
+      fi
+      if [[ -n "${workspace}" ]]; then
+        args+=("--workspace=${workspace}")
+      fi
+      if [[ -n "${profile}" ]]; then
+        validate_colima_profile_name "${profile}"
+        args+=("--profile=${profile}")
+      fi
+      output="$(go_hostutil launcher session-list "${args[@]}")"
+      if [[ -z "${output}" ]]; then
+        echo "No recorded sessions."
+        exit 0
+      fi
+      if [[ "${emit_json}" -eq 1 ]]; then
+        printf '%s\n' "${output}"
+      else
+        printf 'session_id\tstatus\tagent\tmode\tprofile\tstarted_at\tassurance\tworkspace\n'
+        printf '%s\n' "${output}"
+      fi
+      exit 0
+      ;;
+    show)
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --id)
+            session_id="$(option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          -h | --help)
+            session_usage
+            exit 0
+            ;;
+          *)
+            echo "Unsupported workcell session show option: $1" >&2
+            session_usage >&2
+            exit 2
+            ;;
+        esac
+      done
+      [[ -n "${session_id}" ]] || {
+        echo "workcell session show requires --id." >&2
+        exit 2
+      }
+      go_hostutil launcher session-show "${COLIMA_STATE_ROOT}" "${session_id}"
+      exit 0
+      ;;
+    export)
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --id)
+            session_id="$(option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          --output)
+            output_path="$(raw_option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          -h | --help)
+            session_usage
+            exit 0
+            ;;
+          *)
+            echo "Unsupported workcell session export option: $1" >&2
+            session_usage >&2
+            exit 2
+            ;;
+        esac
+      done
+      [[ -n "${session_id}" ]] || {
+        echo "workcell session export requires --id." >&2
+        exit 2
+      }
+      output="$(go_hostutil launcher session-export "${COLIMA_STATE_ROOT}" "${session_id}")"
+      if [[ -n "${output_path}" ]]; then
+        output_path="$(resolve_host_output_candidate "${output_path}")"
+        mkdir -p "$(dirname "${output_path}")"
+        printf '%s\n' "${output}" >"${output_path}"
+        chmod 0600 "${output_path}" 2>/dev/null || true
+        printf 'session_export=%s\n' "${output_path}"
+      else
+        printf '%s\n' "${output}"
+      fi
+      exit 0
+      ;;
+    "" | -h | --help)
+      session_usage
+      exit 0
+      ;;
+    *)
+      echo "Unsupported workcell session command: ${subcommand}" >&2
+      session_usage >&2
+      exit 2
+      ;;
+  esac
 }
 
 auth_usage() {
@@ -4518,6 +4770,11 @@ if [[ "${1:-}" == "publish-pr" ]]; then
   publish_pr_main "$@"
 fi
 
+if [[ "${1:-}" == "session" ]]; then
+  shift
+  session_main "$@"
+fi
+
 if [[ "${1:-}" == "auth" ]]; then
   shift
   auth_main "$@"
@@ -5285,6 +5542,7 @@ if [[ "${PREPARE_ONLY}" -eq 1 ]]; then
   echo "Prepared runtime image recorded for profile ${COLIMA_PROFILE}. No session launched because --prepare-only was requested." >&2
   exit 0
 fi
+write_session_record_initial "${COLIMA_PROFILE}" "${EXECUTION_PATH}"
 append_launch_audit_record "${COLIMA_PROFILE}" "${EXECUTION_PATH}"
 
 DOCKER_STATUS=0

--- a/tests/scenarios/manifest.json
+++ b/tests/scenarios/manifest.json
@@ -68,6 +68,17 @@
       "requires_credentials": false
     },
     {
+      "id": "shared/session-commands",
+      "description": "Host-side session inventory lists, shows, and exports durable launch records without starting the runtime",
+      "lane": "secretless",
+      "platform": "any",
+      "manual": false,
+      "providers": ["codex", "claude", "gemini"],
+      "persona": "developer",
+      "test_file": "shared/test-session-commands.sh",
+      "requires_credentials": false
+    },
+    {
       "id": "claude-swe/hook-parametric",
       "description": "Claude guard-bash.sh blocks all commands in the fixture file",
       "lane": "secretless",

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-session-scenario.XXXXXX")"
+TMP_DIR="$(cd "${TMP_DIR}" && pwd -P)"
+REAL_HOME="$(cd "${ROOT_DIR}" && go run ./cmd/workcell-hostutil path home)"
+PROFILE="wcl-session-scenario-$$"
+SESSION_ONE="20260408T100000Z-11111111-$$"
+SESSION_TWO="20260408T110000Z-22222222-$$"
+
+cleanup() {
+  rm -rf "${REAL_HOME}/.colima/${PROFILE}"
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+COLIMA_ROOT="${REAL_HOME}/.colima"
+SESSIONS_DIR="${COLIMA_ROOT}/${PROFILE}/sessions"
+AUDIT_LOG="${COLIMA_ROOT}/${PROFILE}/workcell.audit.log"
+EXPORT_PATH="${TMP_DIR}/session-export.json"
+WORKSPACE_A="${TMP_DIR}/workspace-a"
+WORKSPACE_B="${TMP_DIR}/workspace-b"
+
+mkdir -p "${SESSIONS_DIR}" "${WORKSPACE_A}" "${WORKSPACE_B}"
+WORKSPACE_A="$(cd "${WORKSPACE_A}" && pwd -P)"
+WORKSPACE_B="$(cd "${WORKSPACE_B}" && pwd -P)"
+
+cat >"${SESSIONS_DIR}/20260408T100000Z-11111111.json" <<EOF
+{
+  "version": 1,
+  "session_id": "${SESSION_ONE}",
+  "profile": "${PROFILE}",
+  "agent": "codex",
+  "mode": "strict",
+  "status": "exited",
+  "ui": "cli",
+  "execution_path": "managed-tier1",
+  "workspace": "${WORKSPACE_A}",
+  "audit_log_path": "${AUDIT_LOG}",
+  "started_at": "2026-04-08T10:00:00Z",
+  "finished_at": "2026-04-08T10:05:00Z",
+  "exit_status": "0",
+  "initial_assurance": "managed-mutable",
+  "final_assurance": "managed-mutable",
+  "workspace_control_plane": "masked"
+}
+EOF
+
+cat >"${SESSIONS_DIR}/20260408T110000Z-22222222.json" <<EOF
+{
+  "version": 1,
+  "session_id": "${SESSION_TWO}",
+  "profile": "${PROFILE}",
+  "agent": "claude",
+  "mode": "development",
+  "status": "failed",
+  "ui": "cli",
+  "execution_path": "lower-assurance-development",
+  "workspace": "${WORKSPACE_B}",
+  "audit_log_path": "${AUDIT_LOG}",
+  "started_at": "2026-04-08T11:00:00Z",
+  "finished_at": "2026-04-08T11:03:00Z",
+  "exit_status": "17",
+  "initial_assurance": "managed-mutable",
+  "final_assurance": "managed-mutable",
+  "workspace_control_plane": "masked"
+}
+EOF
+
+cat >"${AUDIT_LOG}" <<EOF
+timestamp=2026-04-08T10:00:00Z event=launch session_id=${SESSION_ONE} record_digest=aaa
+timestamp=2026-04-08T11:00:00Z event=launch session_id=${SESSION_TWO} record_digest=bbb
+timestamp=2026-04-08T11:03:00Z event=exit session_id=${SESSION_TWO} record_digest=ccc
+EOF
+
+list_output="$("${ROOT_DIR}/scripts/workcell" session list --colima-profile "${PROFILE}")"
+grep -q '^session_id[[:space:]]status[[:space:]]agent[[:space:]]mode[[:space:]]profile[[:space:]]started_at[[:space:]]assurance[[:space:]]workspace$' <<<"${list_output}"
+grep -q $'^'"${SESSION_TWO}"$'\tfailed\tclaude\tdevelopment\t'"${PROFILE}"$'\t2026-04-08T11:00:00Z\tmanaged-mutable\t'"${WORKSPACE_B}"'$' <<<"${list_output}"
+grep -q $'^'"${SESSION_ONE}"$'\texited\tcodex\tstrict\t'"${PROFILE}"$'\t2026-04-08T10:00:00Z\tmanaged-mutable\t'"${WORKSPACE_A}"'$' <<<"${list_output}"
+
+list_json="$("${ROOT_DIR}/scripts/workcell" session list --json --workspace "${WORKSPACE_A}" --colima-profile "${PROFILE}")"
+grep -q "\"session_id\": \"${SESSION_ONE}\"" <<<"${list_json}"
+if grep -q "\"session_id\": \"${SESSION_TWO}\"" <<<"${list_json}"; then
+  echo "session list --workspace returned an unexpected session" >&2
+  exit 1
+fi
+
+show_output="$("${ROOT_DIR}/scripts/workcell" session show --id "${SESSION_TWO}")"
+grep -q "\"session_id\": \"${SESSION_TWO}\"" <<<"${show_output}"
+grep -q '"status": "failed"' <<<"${show_output}"
+
+export_stdout="$("${ROOT_DIR}/scripts/workcell" session export --id "${SESSION_TWO}" --output "${EXPORT_PATH}")"
+grep -q "^session_export=${EXPORT_PATH}$" <<<"${export_stdout}"
+grep -q "\"session_id\": \"${SESSION_TWO}\"" "${EXPORT_PATH}"
+grep -q '"audit_records": \[' "${EXPORT_PATH}"
+grep -q 'record_digest=ccc' "${EXPORT_PATH}"
+
+missing_output="$(
+  "${ROOT_DIR}/scripts/workcell" session show --id missing-session 2>&1 >/dev/null || true
+)"
+grep -q 'file does not exist' <<<"${missing_output}"


### PR DESCRIPTION
## Summary
- add durable host-side session records and session list/show/export commands
- add a canonical requirements matrix plus validator and validation entrypoints
- add design docs, peer review notes, and scenario/unit coverage for the new surface

## Validation
- go test ./...
- ./scripts/validate-repo.sh
- ./scripts/container-smoke.sh
- ./scripts/verify-release-bundle.sh