### PR TITLE
Merge reviewed local branches and release hardening

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,19 +6,24 @@ labels: bug
 assignees: ''
 ---
 
-**Describe the bug**
+## Describe the bug
+
 A clear description of what the bug is.
 
-**To reproduce**
-Steps to reproduce the behavior:
-1. 
-2. 
-3. 
+## To reproduce
 
-**Expected behavior**
+Steps to reproduce the behavior:
+
+1. Run `...`
+2. Observe `...`
+3. Note the failure
+
+## Expected behavior
+
 What you expected to happen.
 
-**Environment**
+## Environment
+
 - OS: [e.g. macOS 15.4]
 - Workcell version: [e.g. v0.5.0 or commit SHA]
 - Provider: [Codex / Claude / Gemini]
@@ -26,10 +31,12 @@ What you expected to happen.
 - Docker version: `docker --version`
 - Colima version (macOS only): `colima version`
 
-**Relevant logs**
+## Relevant logs
+
 Paste any error output here. Redact tokens, keys, and personal paths.
 
-**Security note**
+## Security note
+
 If this bug could expose secrets, allow a sandbox escape, or bypass signing
 or provenance checks, please use the [private vulnerability reporting
 process](../SECURITY.md) instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/usage_question.md
+++ b/.github/ISSUE_TEMPLATE/usage_question.md
@@ -6,23 +6,27 @@ labels: ""
 assignees: ""
 ---
 
-**What are you trying to do?**
+## What are you trying to do?
+
 Describe the task or workflow you are trying to run.
 
-**Command**
+## Command
+
 Paste the exact `workcell ...` command you ran.
 
-**Environment**
+## Environment
+
 - OS:
 - Workcell version or commit SHA:
 - Provider:
 - Mode:
 
-**What did you expect?**
+## What did you expect?
 
-**What happened instead?**
+## What happened instead?
 
-**Helpful context**
+## Helpful context
+
 Include output from:
 
 - `workcell --agent <provider> --doctor --workspace /path/to/repo`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Summary
+# Summary
 
 <!-- What does this change and why? -->
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,8 @@ jobs:
           actionlint_archive="${RUNNER_TEMP}/actionlint.tar.gz"
           actionlint_bin="${RUNNER_TEMP}/actionlint"
           curl -fsSL \
+            --max-time 60 \
+            --connect-timeout 15 \
             -o "${actionlint_archive}" \
             "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           echo "${ACTIONLINT_SHA256}  ${actionlint_archive}" | sha256sum -c -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ first.
 
 Use [Conventional Commits](https://www.conventionalcommits.org/) format:
 
-```
+```text
 <type>: <description>
 
 [optional body]

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -1090,6 +1090,52 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err := requireEqual("HADOLINT_LINUX_ARM64_SHA256", validatorHadolintSHAArm64, cfg.ValidatorDockerfilePath, remoteValidatorHadolintSHAArm64, cfg.RemoteValidatorDockerfilePath); err != nil {
 		return err
 	}
+	validatorMarkdownlintVersion, err := requireArg(validatorDockerfile, "MARKDOWNLINT_VERSION", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	remoteValidatorMarkdownlintVersion, err := requireArg(remoteValidatorDockerfile, "MARKDOWNLINT_VERSION", cfg.RemoteValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if err := requireEqual("MARKDOWNLINT_VERSION", validatorMarkdownlintVersion, cfg.ValidatorDockerfilePath, remoteValidatorMarkdownlintVersion, cfg.RemoteValidatorDockerfilePath); err != nil {
+		return err
+	}
+	if !regexp.MustCompile(`^0\.\d+\.\d+$`).MatchString(validatorMarkdownlintVersion) {
+		return fmt.Errorf("MARKDOWNLINT_VERSION must be an exact pinned release, found %q", validatorMarkdownlintVersion)
+	}
+	validatorMarkdownlintSHA, err := requireArg(validatorDockerfile, "MARKDOWNLINT_SHA512", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	remoteValidatorMarkdownlintSHA, err := requireArg(remoteValidatorDockerfile, "MARKDOWNLINT_SHA512", cfg.RemoteValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if err := requireEqual("MARKDOWNLINT_SHA512", validatorMarkdownlintSHA, cfg.ValidatorDockerfilePath, remoteValidatorMarkdownlintSHA, cfg.RemoteValidatorDockerfilePath); err != nil {
+		return err
+	}
+	if !regexp.MustCompile(`^[0-9a-f]{128}$`).MatchString(validatorMarkdownlintSHA) {
+		return fmt.Errorf("MARKDOWNLINT_SHA512 must be a 128-character lowercase hex digest, found %q", validatorMarkdownlintSHA)
+	}
+	for _, dockerfile := range []struct {
+		text string
+		path string
+	}{
+		{text: validatorDockerfile, path: cfg.ValidatorDockerfilePath},
+		{text: remoteValidatorDockerfile, path: cfg.RemoteValidatorDockerfilePath},
+	} {
+		for _, needle := range []string{
+			`npm pack "markdownlint-cli@${MARKDOWNLINT_VERSION}" --pack-destination "${markdownlint_tmpdir}"`,
+			`echo "${MARKDOWNLINT_SHA512}  ${markdownlint_tmpdir}/markdownlint-cli-${MARKDOWNLINT_VERSION}.tgz" | sha512sum -c -`,
+			`npm install -g "${markdownlint_tmpdir}/markdownlint-cli-${MARKDOWNLINT_VERSION}.tgz"`,
+			`markdownlint --version | grep -F "${MARKDOWNLINT_VERSION}" >/dev/null`,
+		} {
+			if !strings.Contains(dockerfile.text, needle) {
+				return fmt.Errorf("%s must contain %q", dockerfile.path, needle)
+			}
+		}
+	}
 	cargoEdition, err := requireTOMLString(cargoManifestText, "edition", cargoManifestPath)
 	if err != nil {
 		return err
@@ -1425,6 +1471,12 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	} {
 		if !strings.Contains(workflow.text, "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz") {
 			return fmt.Errorf("%s must derive the actionlint archive URL from ACTIONLINT_VERSION", workflow.path)
+		}
+		if !strings.Contains(workflow.text, "--max-time 60") {
+			return fmt.Errorf("%s must bound actionlint download wall-clock time", workflow.path)
+		}
+		if !strings.Contains(workflow.text, "--connect-timeout 15") {
+			return fmt.Errorf("%s must bound actionlint download connect time", workflow.path)
 		}
 	}
 	for _, needle := range []string{

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -211,6 +211,27 @@ func TestInstallDevToolsBootstrapsCommonHostPrereqs(t *testing.T) {
 	}
 }
 
+func TestGenerateHomebrewFormulaPinsExplicitVersion(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "generate-homebrew-formula.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(content)
+
+	for _, want := range []string{
+		`FORMULA_VERSION="${VERSION}"`,
+		`FORMULA_VERSION="${FORMULA_VERSION#v}"`,
+		`version "${FORMULA_VERSION}"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("%s does not contain %q", scriptPath, want)
+		}
+	}
+}
+
 func TestInstallWorkcellBootstrapsRequiredHostDependencies(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/generate-homebrew-formula.sh
+++ b/scripts/generate-homebrew-formula.sh
@@ -21,6 +21,11 @@ OUTPUT_PATH="$3"
 shift 3
 
 REPOSITORY="${GITHUB_REPOSITORY:-omkhar/workcell}"
+FORMULA_VERSION="${VERSION}"
+
+if [[ "${FORMULA_VERSION}" =~ ^v[0-9] ]]; then
+  FORMULA_VERSION="${FORMULA_VERSION#v}"
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -45,6 +50,7 @@ class Workcell < Formula
   desc "Bounded runtime launcher for coding agents"
   homepage "https://github.com/${REPOSITORY}"
   url "https://github.com/${REPOSITORY}/releases/download/${VERSION}/workcell-${VERSION}.tar.gz"
+  version "${FORMULA_VERSION}"
   sha256 "${BUNDLE_SHA256}"
   license "Apache-2.0"
 

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -3,6 +3,8 @@
 # Detects macOS (brew) vs Linux (apt) and installs missing packages.
 set -euo pipefail
 
+readonly MARKDOWNLINT_VERSION="0.48.0"
+
 append_unique_brew() {
   local candidate=""
   local existing=""
@@ -89,8 +91,8 @@ if [[ ${#missing[@]} -gt 0 ]]; then
 fi
 
 if ! command -v markdownlint &>/dev/null; then
-  echo "  npm install -g markdownlint-cli"
-  npm install -g markdownlint-cli
+  echo "  npm install -g markdownlint-cli@${MARKDOWNLINT_VERSION}"
+  npm install -g "markdownlint-cli@${MARKDOWNLINT_VERSION}"
 fi
 
 echo "Done."

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -22,6 +22,7 @@ require_tool shellcheck
 require_tool shfmt
 require_tool go
 require_tool gofmt
+require_tool markdownlint
 require_tool yamllint
 require_tool cargo
 require_tool rustfmt
@@ -277,10 +278,27 @@ done < <(find "${ROOT_DIR}" \
   -path "${ROOT_DIR}/runtime/container/rust/target" -prune -o \
   -type f \( -name '*.md' -o -name '*.txt' -o -name '*.1' \) -print0 | sort -z)
 
+markdown_files=()
+while IFS= read -r -d '' file; do
+  markdown_files+=("${file}")
+done < <(find "${ROOT_DIR}" \
+  -path "${ROOT_DIR}/.git" -prune -o \
+  -path "${ROOT_DIR}/dist" -prune -o \
+  -path "${ROOT_DIR}/tmp" -prune -o \
+  -path "${ROOT_DIR}/.venv" -prune -o \
+  -path "${ROOT_DIR}/runtime/container/providers/node_modules" -prune -o \
+  -path "${ROOT_DIR}/runtime/container/rust/vendor" -prune -o \
+  -path "${ROOT_DIR}/runtime/container/rust/target" -prune -o \
+  -type f -name '*.md' -print0 | sort -z)
+
 if command -v codespell >/dev/null 2>&1; then
   codespell --config "${ROOT_DIR}/.codespellrc" "${doc_files[@]}"
 else
   echo "Skipping spelling checks because codespell is not installed locally." >&2
+fi
+
+if [[ "${#markdown_files[@]}" -gt 0 ]]; then
+  markdownlint "${markdown_files[@]}"
 fi
 
 validate_manpage

--- a/tools/remote-validator/Dockerfile
+++ b/tools/remote-validator/Dockerfile
@@ -6,6 +6,8 @@ ARG GO_LINUX_ARM64_SHA256=c958a1fe1b361391db163a485e21f5f228142d6f8b584f6bef89b2
 ARG HADOLINT_VERSION=v2.14.0
 ARG HADOLINT_LINUX_X86_64_SHA256=6bf226944684f56c84dd014e8b979d27425c0148f61b3bd99bcc6f39e9dc5a47
 ARG HADOLINT_LINUX_ARM64_SHA256=331f1d3511b84a4f1e3d18d52fec284723e4019552f4f47b19322a53ce9a40ed
+ARG MARKDOWNLINT_VERSION=0.48.0
+ARG MARKDOWNLINT_SHA512=36465036ed84d10e6a2c4107c168faef87982124cb0f88cc1e40730e86ee8d777592ffb20b18bc8ce683feb66840d5b514104c306429b96e52a3c079d4dfded0
 ARG RUST_VERSION=1.94.1
 ARG RUSTUP_VERSION=1.29.0
 ARG RUSTUP_INIT_LINUX_X86_64_SHA256=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
@@ -20,6 +22,8 @@ ARG GO_LINUX_ARM64_SHA256
 ARG HADOLINT_VERSION
 ARG HADOLINT_LINUX_X86_64_SHA256
 ARG HADOLINT_LINUX_ARM64_SHA256
+ARG MARKDOWNLINT_VERSION
+ARG MARKDOWNLINT_SHA512
 ARG RUST_VERSION
 ARG RUSTUP_VERSION
 ARG RUSTUP_INIT_LINUX_X86_64_SHA256
@@ -121,12 +125,18 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
     -o /usr/local/bin/hadolint \
   && echo "${hadolint_sha256}  /usr/local/bin/hadolint" | sha256sum -c - \
   && chmod 0755 /usr/local/bin/hadolint \
+  && markdownlint_tmpdir="$(mktemp -d)" \
+  && npm pack "markdownlint-cli@${MARKDOWNLINT_VERSION}" --pack-destination "${markdownlint_tmpdir}" \
+  && echo "${MARKDOWNLINT_SHA512}  ${markdownlint_tmpdir}/markdownlint-cli-${MARKDOWNLINT_VERSION}.tgz" | sha512sum -c - \
+  && npm install -g "${markdownlint_tmpdir}/markdownlint-cli-${MARKDOWNLINT_VERSION}.tgz" \
   && go version | grep -F "go version go${GO_VERSION} " >/dev/null \
   && rustc --version | grep -F "rustc ${RUST_VERSION} " >/dev/null \
   && cargo fmt --version >/dev/null \
   && cargo clippy --version >/dev/null \
   && hadolint --version >/dev/null \
+  && markdownlint --version | grep -F "${MARKDOWNLINT_VERSION}" >/dev/null \
   && rm -f /tmp/rustup-init "/tmp/${go_archive}" \
+  && rm -rf "${markdownlint_tmpdir}" \
   && rm -rf \
     /usr/local/rustup/downloads \
     /usr/local/rustup/tmp \

--- a/tools/validator/Dockerfile
+++ b/tools/validator/Dockerfile
@@ -6,6 +6,8 @@ ARG GO_LINUX_ARM64_SHA256=c958a1fe1b361391db163a485e21f5f228142d6f8b584f6bef89b2
 ARG HADOLINT_VERSION=v2.14.0
 ARG HADOLINT_LINUX_X86_64_SHA256=6bf226944684f56c84dd014e8b979d27425c0148f61b3bd99bcc6f39e9dc5a47
 ARG HADOLINT_LINUX_ARM64_SHA256=331f1d3511b84a4f1e3d18d52fec284723e4019552f4f47b19322a53ce9a40ed
+ARG MARKDOWNLINT_VERSION=0.48.0
+ARG MARKDOWNLINT_SHA512=36465036ed84d10e6a2c4107c168faef87982124cb0f88cc1e40730e86ee8d777592ffb20b18bc8ce683feb66840d5b514104c306429b96e52a3c079d4dfded0
 ARG RUST_VERSION=1.94.1
 ARG RUSTUP_VERSION=1.29.0
 ARG RUSTUP_INIT_LINUX_X86_64_SHA256=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
@@ -20,6 +22,8 @@ ARG GO_LINUX_ARM64_SHA256
 ARG HADOLINT_VERSION
 ARG HADOLINT_LINUX_X86_64_SHA256
 ARG HADOLINT_LINUX_ARM64_SHA256
+ARG MARKDOWNLINT_VERSION
+ARG MARKDOWNLINT_SHA512
 ARG RUST_VERSION
 ARG RUSTUP_VERSION
 ARG RUSTUP_INIT_LINUX_X86_64_SHA256
@@ -119,12 +123,18 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
     -o /usr/local/bin/hadolint \
   && echo "${hadolint_sha256}  /usr/local/bin/hadolint" | sha256sum -c - \
   && chmod 0755 /usr/local/bin/hadolint \
+  && markdownlint_tmpdir="$(mktemp -d)" \
+  && npm pack "markdownlint-cli@${MARKDOWNLINT_VERSION}" --pack-destination "${markdownlint_tmpdir}" \
+  && echo "${MARKDOWNLINT_SHA512}  ${markdownlint_tmpdir}/markdownlint-cli-${MARKDOWNLINT_VERSION}.tgz" | sha512sum -c - \
+  && npm install -g "${markdownlint_tmpdir}/markdownlint-cli-${MARKDOWNLINT_VERSION}.tgz" \
   && go version | grep -F "go version go${GO_VERSION} " >/dev/null \
   && rustc --version | grep -F "rustc ${RUST_VERSION} " >/dev/null \
   && cargo fmt --version >/dev/null \
   && cargo clippy --version >/dev/null \
   && hadolint --version >/dev/null \
+  && markdownlint --version | grep -F "${MARKDOWNLINT_VERSION}" >/dev/null \
   && rm -f /tmp/rustup-init "/tmp/${go_archive}" \
+  && rm -rf "${markdownlint_tmpdir}" \
   && rm -rf \
     /usr/local/rustup/downloads \
     /usr/local/rustup/tmp \


### PR DESCRIPTION
## Summary
- pin markdownlint in both validator images and validate markdown docs in the repo gate
- harden release actionlint download timeouts and clean up issue/PR templates for the new markdown lint gate
- close the remaining reviewed local-only integration branches with a signed history-only merge so main can be left clean after merge

## Validation
- `./scripts/check-pinned-inputs.sh`
- `./scripts/check-workflows.sh`
- `./scripts/validate-repo.sh`
- `go test ./internal/metadatautil`
- `markdownlint` over tracked markdown excluding build and vendor trees

## Review notes
- reviewed the remaining non-merged local branches and carried forward the missing release-quality deltas instead of replaying stale branch contents wholesale
- the final merge commit uses the `ours` strategy only to close reviewed obsolete branch histories without reintroducing superseded code
