### PR TITLE
Harden runtime validation and audit handling

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -164,6 +164,24 @@ func runLauncher(args []string) error {
 			fmt.Println("0")
 		}
 		return nil
+	case "acquire-profile-lock":
+		if len(args) != 3 {
+			return launcherUsage()
+		}
+		pid, err := strconv.Atoi(args[2])
+		if err != nil {
+			return fmt.Errorf("parse pid: %w", err)
+		}
+		acquired, err := hostutil.AcquireProfileLock(args[1], pid)
+		if err != nil {
+			return err
+		}
+		if acquired {
+			fmt.Println("1")
+		} else {
+			fmt.Println("0")
+		}
+		return nil
 	case "write-profile-owner":
 		if len(args) != 3 {
 			return launcherUsage()
@@ -319,7 +337,7 @@ func releaseUsage() error {
 }
 
 func launcherUsage() error {
-	return fmt.Errorf("usage: workcell-hostutil launcher <session-suffix|colima-status|cleanup-stale-log-pointers|profile-lock-is-stale|write-profile-owner|cleanup-stale-session-audit-dirs|session-record-write|session-list|session-show|session-export|audit-digest|direct-mount-cache-key|resolve-host-output-candidate|cleanup-stale-injection-bundles|manifest-metadata|resolver-metadata|workspace-cache-key|extract-codex-version|validate-security-options|canonicalize-tool-path|dedupe-endpoints|resolve-endpoints> ...")
+	return fmt.Errorf("usage: workcell-hostutil launcher <session-suffix|colima-status|cleanup-stale-log-pointers|profile-lock-is-stale|acquire-profile-lock|write-profile-owner|cleanup-stale-session-audit-dirs|session-record-write|session-list|session-show|session-export|audit-digest|direct-mount-cache-key|resolve-host-output-candidate|cleanup-stale-injection-bundles|manifest-metadata|resolver-metadata|workspace-cache-key|extract-codex-version|validate-security-options|canonicalize-tool-path|dedupe-endpoints|resolve-endpoints> ...")
 }
 
 func runLauncherSessionList(args []string) error {

--- a/cmd/workcell-render-injection-bundle/main.go
+++ b/cmd/workcell-render-injection-bundle/main.go
@@ -32,6 +32,10 @@ func run(args []string, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "policy, agent, mode, and output-root are required")
 		return 2
 	}
+	if err := injection.ValidateRenderAgentMode(*agent, *mode); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
 	if err := injection.RunRenderInjectionBundle(*policyPath, *agent, *mode, *outputRoot, *policyMetadata); err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1

--- a/cmd/workcell-render-injection-bundle/main_test.go
+++ b/cmd/workcell-render-injection-bundle/main_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunRejectsUnsupportedAgent(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	code := run([]string{
+		"--policy", "policy.toml",
+		"--agent", "codez",
+		"--mode", "strict",
+		"--output-root", "bundle",
+	}, &stderr)
+	if code != 2 {
+		t.Fatalf("run() = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "unsupported agent: codez") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunRejectsUnsupportedMode(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	code := run([]string{
+		"--policy", "policy.toml",
+		"--agent", "codex",
+		"--mode", "strcit",
+		"--output-root", "bundle",
+	}, &stderr)
+	if code != 2 {
+		t.Fatalf("run() = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "unsupported mode: strcit") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}

--- a/internal/hostutil/hostutil_test.go
+++ b/internal/hostutil/hostutil_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -215,6 +216,111 @@ func TestColimaProfileStatusMissingProfileReturnsNoMatch(t *testing.T) {
 	_, err := ColimaProfileStatus(input, "does-not-exist")
 	if !IsNoMatch(err) {
 		t.Fatalf("ColimaProfileStatus() err = %v, want IsNoMatch", err)
+	}
+}
+
+func TestProfileLockIsStaleReportsMalformedOwnerMetadata(t *testing.T) {
+	lockDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stale, err := ProfileLockIsStale(lockDir)
+	if err == nil {
+		t.Fatal("ProfileLockIsStale() error = nil, want parse error")
+	}
+	if stale {
+		t.Fatal("ProfileLockIsStale() stale = true, want false on malformed owner metadata")
+	}
+}
+
+func TestProfileLockIsStaleReportsIncompleteOwnerMetadata(t *testing.T) {
+	lockDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), []byte(`{"pid":`+strconv.Itoa(os.Getpid())+`}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stale, err := ProfileLockIsStale(lockDir)
+	if err == nil {
+		t.Fatal("ProfileLockIsStale() error = nil, want incomplete metadata error")
+	}
+	if stale {
+		t.Fatal("ProfileLockIsStale() stale = true, want false on incomplete owner metadata")
+	}
+}
+
+func TestProfileLockIsStaleRecognizesLiveOwner(t *testing.T) {
+	lockDir := t.TempDir()
+	started, err := processStartTime(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), []byte(`{"pid":`+strconv.Itoa(os.Getpid())+`,"started":"`+started+`"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stale, err := ProfileLockIsStale(lockDir)
+	if err != nil {
+		t.Fatalf("ProfileLockIsStale() error = %v", err)
+	}
+	if stale {
+		t.Fatal("ProfileLockIsStale() stale = true, want false for live owner")
+	}
+}
+
+func TestAcquireProfileLockCreatesOwnerAtomically(t *testing.T) {
+	lockDir := filepath.Join(t.TempDir(), "profile.lock")
+
+	acquired, err := AcquireProfileLock(lockDir, os.Getpid())
+	if err != nil {
+		t.Fatalf("AcquireProfileLock() error = %v", err)
+	}
+	if !acquired {
+		t.Fatal("AcquireProfileLock() = false, want true")
+	}
+
+	content, err := os.ReadFile(filepath.Join(lockDir, "owner.json"))
+	if err != nil {
+		t.Fatalf("read owner.json: %v", err)
+	}
+	var owner struct {
+		PID     int    `json:"pid"`
+		Started string `json:"started"`
+	}
+	if err := json.Unmarshal(content, &owner); err != nil {
+		t.Fatalf("unmarshal owner.json: %v", err)
+	}
+	if owner.PID != os.Getpid() {
+		t.Fatalf("owner PID = %d, want %d", owner.PID, os.Getpid())
+	}
+	if owner.Started == "" {
+		t.Fatal("owner.Started = empty, want process start time")
+	}
+}
+
+func TestAcquireProfileLockReturnsFalseWhenLockExists(t *testing.T) {
+	parent := t.TempDir()
+	lockDir := filepath.Join(parent, "profile.lock")
+	if err := os.MkdirAll(lockDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	acquired, err := AcquireProfileLock(lockDir, os.Getpid())
+	if err != nil {
+		t.Fatalf("AcquireProfileLock() error = %v", err)
+	}
+	if acquired {
+		t.Fatal("AcquireProfileLock() = true, want false for existing lock")
+	}
+
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.Contains(entry.Name(), ".pending.") {
+			t.Fatalf("temporary lock dir leaked: %s", entry.Name())
+		}
 	}
 }
 

--- a/internal/hostutil/launcher.go
+++ b/internal/hostutil/launcher.go
@@ -140,21 +140,61 @@ func ProfileLockIsStale(lockDir string) (bool, error) {
 		Started string `json:"started"`
 	}
 	if err := json.Unmarshal(content, &owner); err != nil {
-		return true, nil
+		return false, fmt.Errorf("parse profile lock owner metadata: %w", err)
 	}
 	if owner.PID <= 0 || owner.Started == "" {
-		return true, nil
+		return false, fmt.Errorf("profile lock owner metadata is incomplete: %s", ownerPath)
 	}
 
 	if err := syscall.Kill(owner.PID, 0); err != nil {
-		return true, nil
+		if errors.Is(err, syscall.ESRCH) {
+			return true, nil
+		}
+		return false, err
 	}
 
 	observed, err := processStartTime(owner.PID)
 	if err != nil {
-		return true, nil
+		if killErr := syscall.Kill(owner.PID, 0); killErr != nil {
+			if errors.Is(killErr, syscall.ESRCH) {
+				return true, nil
+			}
+			return false, killErr
+		}
+		return false, err
 	}
 	return observed != owner.Started, nil
+}
+
+func AcquireProfileLock(lockDir string, pid int) (bool, error) {
+	parentDir := filepath.Dir(lockDir)
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return false, err
+	}
+
+	tempDir, err := os.MkdirTemp(parentDir, filepath.Base(lockDir)+".pending.")
+	if err != nil {
+		return false, err
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.RemoveAll(tempDir)
+		}
+	}()
+
+	if err := WriteProfileOwner(filepath.Join(tempDir, "owner.json"), pid); err != nil {
+		return false, err
+	}
+	if err := os.Rename(tempDir, lockDir); err != nil {
+		if errors.Is(err, os.ErrExist) || errors.Is(err, syscall.EEXIST) || errors.Is(err, syscall.ENOTEMPTY) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	cleanup = false
+	return true, nil
 }
 
 func WriteProfileOwner(ownerPath string, pid int) error {

--- a/internal/hostutil/sessions.go
+++ b/internal/hostutil/sessions.go
@@ -173,6 +173,9 @@ func ListSessionRecords(colimaRoot string, opts SessionListOptions) ([]SessionRe
 			continue
 		}
 		sessionDir := filepath.Join(profileDir, "sessions")
+		if isSymlink(sessionDir) {
+			continue
+		}
 		sessionEntries, err := os.ReadDir(sessionDir)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {

--- a/internal/hostutil/sessions_test.go
+++ b/internal/hostutil/sessions_test.go
@@ -137,6 +137,40 @@ func TestListSessionRecordsReturnsEmptySliceWhenColimaRootMissing(t *testing.T) 
 	}
 }
 
+func TestListSessionRecordsSkipsSymlinkedSessionsDirectories(t *testing.T) {
+	t.Parallel()
+
+	colimaRoot := t.TempDir()
+	externalSessions := filepath.Join(t.TempDir(), "external-sessions")
+	writeSessionFixture(t, filepath.Join(externalSessions, "session-1.json"), SessionRecord{
+		Version:    1,
+		SessionID:  "session-1",
+		Profile:    "wcl-one",
+		Agent:      "codex",
+		Mode:       "strict",
+		Status:     "exited",
+		Workspace:  "/tmp/workspace-a",
+		StartedAt:  "2026-04-08T10:00:00Z",
+		FinishedAt: "2026-04-08T10:05:00Z",
+		ExitStatus: "0",
+	})
+	profileDir := filepath.Join(colimaRoot, "wcl-one")
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(externalSessions, filepath.Join(profileDir, "sessions")); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := ListSessionRecords(colimaRoot, SessionListOptions{})
+	if err != nil {
+		t.Fatalf("ListSessionRecords() error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("ListSessionRecords() len = %d, want 0", len(records))
+	}
+}
+
 func TestExportSessionRecordIncludesMatchingAuditLines(t *testing.T) {
 	t.Parallel()
 

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -179,6 +179,16 @@ type PolicySource struct {
 	Sha256 string `json:"sha256"`
 }
 
+func ValidateRenderAgentMode(agent, mode string) error {
+	if _, ok := supportedAgents[agent]; !ok {
+		return fmt.Errorf("unsupported agent: %s", agent)
+	}
+	if _, ok := supportedModes[mode]; !ok {
+		return fmt.Errorf("unsupported mode: %s", mode)
+	}
+	return nil
+}
+
 func RunRenderInjectionBundle(policyPath, agent, mode, outputRoot, policyMetadata string) error {
 	resolvedPolicyPath, err := resolvePathLikePython(policyPath)
 	if err != nil {
@@ -192,6 +202,9 @@ func RunRenderInjectionBundle(policyPath, agent, mode, outputRoot, policyMetadat
 		return err
 	}
 	if err := os.Chmod(resolvedOutputRoot, 0o700); err != nil {
+		return err
+	}
+	if err := ValidateRenderAgentMode(agent, mode); err != nil {
 		return err
 	}
 
@@ -406,7 +419,9 @@ func renderDocuments(policy map[string]any, outputRoot, policyDir Path) (map[str
 	if !ok {
 		return nil, errors.New("documents must be a TOML table")
 	}
-	validateAllowedKeys(documents, mapKeysSet([]string{"common", "codex", "claude", "gemini"}), "documents")
+	if err := validateAllowedKeys(documents, mapKeysSet([]string{"common", "codex", "claude", "gemini"}), "documents"); err != nil {
+		return nil, err
+	}
 
 	rendered := map[string]string{}
 	ordered := []struct {
@@ -1929,6 +1944,9 @@ func writeIndentedJSON(pathname string, value any, mode os.FileMode) error {
 }
 
 func validateContainerTarget(candidate string) (string, error) {
+	if containsParentPathSegment(candidate) {
+		return "", fmt.Errorf("injection target must not contain parent path segments: %s", candidate)
+	}
 	if !targetIsUnder(candidate, sessionHomeRoot) && !targetIsUnder(candidate, runInjectedRoot) {
 		return "", fmt.Errorf("injection target must stay under /state/agent-home or /state/injected: %s", candidate)
 	}
@@ -1940,16 +1958,25 @@ func validateContainerTarget(candidate string) (string, error) {
 
 func normalizeContainerTarget(raw string) string {
 	if strings.HasPrefix(raw, "~/") {
-		raw = path.Join(sessionHomeRoot, raw[2:])
+		raw = sessionHomeRoot + "/" + raw[2:]
+	}
+	if containsParentPathSegment(raw) {
+		return raw
 	}
 	candidate := path.Clean(raw)
 	if !path.IsAbs(candidate) {
 		return raw
 	}
-	if strings.Contains(candidate, "..") {
-		return raw
-	}
 	return candidate
+}
+
+func containsParentPathSegment(candidate string) bool {
+	for _, segment := range strings.Split(candidate, "/") {
+		if segment == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 func targetIsUnder(candidate, root string) bool {

--- a/internal/injection/render_injection_bundle_test.go
+++ b/internal/injection/render_injection_bundle_test.go
@@ -304,13 +304,43 @@ func TestRebasePolicyFragmentAndValidationHelpers(t *testing.T) {
 	if target != "/state/agent-home/notes.txt" {
 		t.Fatalf("normalizeContainerTarget = %s", target)
 	}
+	if got := normalizeContainerTarget("~/../injected/notes.txt"); got != "/state/agent-home/../injected/notes.txt" {
+		t.Fatalf("normalizeContainerTarget home traversal = %s", got)
+	}
+	if got := normalizeContainerTarget("/state/injected/../agent-home/notes.txt"); got != "/state/injected/../agent-home/notes.txt" {
+		t.Fatalf("normalizeContainerTarget traversal = %s", got)
+	}
 	if got, err := validateContainerTarget("/state/injected/notes.txt"); err != nil || got != "/state/injected/notes.txt" {
 		t.Fatalf("validateContainerTarget = %q, %v", got, err)
 	}
-	for _, bad := range []string{"relative.txt", "/tmp/outside", "/state/agent-home/.mcp.json"} {
+	for _, bad := range []string{"relative.txt", "/tmp/outside", "/state/agent-home/.mcp.json", "/state/injected/../agent-home/notes.txt", "/state/agent-home/../injected/notes.txt"} {
 		if _, err := validateContainerTarget(bad); err == nil {
 			t.Fatalf("validateContainerTarget accepted %q", bad)
 		}
+	}
+}
+
+func TestRenderDocumentsRejectsUnknownKeys(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	output := filepath.Join(root, "bundle")
+	if err := os.MkdirAll(output, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeText(t, filepath.Join(root, "common.md"), "common\n", 0o600)
+
+	_, err := renderDocuments(map[string]any{
+		"documents": map[string]any{
+			"common": "common.md",
+			"extra":  "common.md",
+		},
+	}, Path(output), Path(root))
+	if err == nil {
+		t.Fatal("renderDocuments() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "unsupported keys: extra") {
+		t.Fatalf("renderDocuments() error = %v, want unknown key failure", err)
 	}
 }
 

--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -173,7 +173,7 @@ func gitTrackedFiles(rootDir string) ([]string, bool, error) {
 		return nil, false, nil
 	}
 
-	output, err := gitOutput(rootDir, "ls-files", "-z", "--cached", "--modified", "--others", "--exclude-standard", "--deduplicate")
+	output, err := gitOutput(rootDir, "ls-files", "-z", "--cached", "--modified", "--deduplicate")
 	if err != nil {
 		return nil, false, err
 	}

--- a/internal/metadatautil/core_test.go
+++ b/internal/metadatautil/core_test.go
@@ -5,6 +5,7 @@ package metadatautil
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -62,5 +63,50 @@ func TestWalkRepoFilesSkipsExcludedPaths(t *testing.T) {
 	want := []string{filepath.Join("pkg", "keep.txt")}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("walkRepoFiles() = %#v, want %#v", got, want)
+	}
+}
+
+func TestGitTrackedFilesExcludesUntrackedFiles(t *testing.T) {
+	root := t.TempDir()
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%s) error = %v", root, err)
+	}
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %v\n%s", args, err, output)
+		}
+	}
+
+	run("git", "init", "-q", canonicalRoot)
+	run("git", "-C", canonicalRoot, "config", "user.name", "Workcell Tests")
+	run("git", "-C", canonicalRoot, "config", "user.email", "workcell-tests@example.com")
+	run("git", "-C", canonicalRoot, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(canonicalRoot, "tracked.txt"), []byte("tracked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("git", "-C", canonicalRoot, "add", "tracked.txt")
+	run("git", "-C", canonicalRoot, "commit", "-q", "-m", "init")
+	if err := os.WriteFile(filepath.Join(canonicalRoot, "tracked.txt"), []byte("modified\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(canonicalRoot, "scratch.txt"), []byte("untracked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, tracked, err := gitTrackedFiles(canonicalRoot)
+	if err != nil {
+		t.Fatalf("gitTrackedFiles() error = %v", err)
+	}
+	if !tracked {
+		t.Fatal("gitTrackedFiles() should report tracked repository context")
+	}
+	want := []string{"tracked.txt"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("gitTrackedFiles() = %#v, want %#v", got, want)
 	}
 }

--- a/internal/metadatautil/provider_bumps.go
+++ b/internal/metadatautil/provider_bumps.go
@@ -24,6 +24,7 @@ const (
 	defaultProviderBumpGeminiRegistryURL  = "https://registry.npmjs.org/@google%2fgemini-cli"
 	defaultProviderBumpClaudeBucketURL    = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819?prefix=claude-code-releases/&delimiter=/"
 	defaultProviderBumpClaudeReleaseRoot  = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+	providerBumpUserAgent                 = "workcell-provider-bump/1.0"
 )
 
 var (
@@ -506,7 +507,12 @@ func compareStableVersions(left, right stableVersion) int {
 }
 
 func fetchJSON(client *http.Client, targetURL string, target any) error {
-	resp, err := client.Get(targetURL)
+	req, err := http.NewRequest(http.MethodGet, targetURL, nil)
+	if err != nil {
+		return fmt.Errorf("fetch %s: %w", targetURL, err)
+	}
+	req.Header.Set("User-Agent", providerBumpUserAgent)
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("fetch %s: %w", targetURL, err)
 	}
@@ -522,7 +528,12 @@ func fetchJSON(client *http.Client, targetURL string, target any) error {
 }
 
 func fetchXML(client *http.Client, targetURL string, target any) error {
-	resp, err := client.Get(targetURL)
+	req, err := http.NewRequest(http.MethodGet, targetURL, nil)
+	if err != nil {
+		return fmt.Errorf("fetch %s: %w", targetURL, err)
+	}
+	req.Header.Set("User-Agent", providerBumpUserAgent)
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("fetch %s: %w", targetURL, err)
 	}

--- a/internal/metadatautil/provider_bumps_test.go
+++ b/internal/metadatautil/provider_bumps_test.go
@@ -291,6 +291,25 @@ func TestPlanProviderBumpsRespectsCurrentRegistryLatestTrack(t *testing.T) {
 	}
 }
 
+func TestFetchJSONAddsUserAgentHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); got != providerBumpUserAgent {
+			t.Fatalf("User-Agent = %q, want %q", got, providerBumpUserAgent)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	var decoded map[string]bool
+	if err := fetchJSON(server.Client(), server.URL, &decoded); err != nil {
+		t.Fatalf("fetchJSON() error = %v", err)
+	}
+	if !decoded["ok"] {
+		t.Fatalf("fetchJSON() decoded = %#v", decoded)
+	}
+}
+
 func TestApplyProviderBumpPlanRewritesPinnedVersions(t *testing.T) {
 	root := t.TempDir()
 	dockerfilePath := filepath.Join(root, "Dockerfile")

--- a/internal/metadatautil/requirements.go
+++ b/internal/metadatautil/requirements.go
@@ -142,12 +142,38 @@ func validateRequirementPath(rootDir, requirementsPath, category, id, field, pat
 	if err != nil {
 		return fmt.Errorf("%s requirement %s %s path %s: %w", requirementsPath, id, field, path, err)
 	}
-	info, err := os.Stat(target)
+	if err := rejectRequirementPathSymlinks(rootDir, target); err != nil {
+		return fmt.Errorf("%s requirement %s %s path %s: %w", requirementsPath, id, field, path, err)
+	}
+	info, err := os.Lstat(target)
 	if err != nil {
 		return fmt.Errorf("%s requirement %s %s path %s: %w", requirementsPath, id, field, path, err)
 	}
 	if info.IsDir() {
 		return fmt.Errorf("%s requirement %s %s path %s must point to a file", requirementsPath, id, field, path)
+	}
+	return nil
+}
+
+func rejectRequirementPathSymlinks(rootDir, target string) error {
+	root := filepath.Clean(rootDir)
+	relative, err := filepath.Rel(root, target)
+	if err != nil {
+		return err
+	}
+	current := root
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		if component == "" || component == "." {
+			continue
+		}
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("path must not traverse symlinks")
+		}
 	}
 	return nil
 }

--- a/internal/metadatautil/requirements_test.go
+++ b/internal/metadatautil/requirements_test.go
@@ -177,6 +177,51 @@ docs = ["README.md"]
 	}
 }
 
+func TestValidateRequirementsRejectsSymlinkedPaths(t *testing.T) {
+	root := t.TempDir()
+	outsidePath := filepath.Join(t.TempDir(), "outside.md")
+	if err := os.WriteFile(outsidePath, []byte("outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteRequirementFixture(t, root, "scripts/verify-example.sh")
+	linkPath := filepath.Join(root, "docs", "linked.md")
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsidePath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	if err := os.MkdirAll(filepath.Dir(requirementsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(requirementsPath, []byte(`version = 1
+
+[functional.FR-001]
+title = "Managed launch"
+summary = "Launch the provider inside the managed runtime."
+evidence = ["scripts/verify-example.sh"]
+docs = ["docs/linked.md"]
+
+[nonfunctional.NFR-001]
+title = "Requirement traceability"
+summary = "Every requirement cites automated evidence."
+evidence = ["scripts/verify-example.sh"]
+docs = ["docs/linked.md"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ValidateRequirements(root, requirementsPath)
+	if err == nil {
+		t.Fatal("ValidateRequirements() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "must not traverse symlinks") {
+		t.Fatalf("ValidateRequirements() error = %v, want symlink rejection", err)
+	}
+}
+
 func mustWriteRequirementFixture(tb testing.TB, root, relativePath string) {
 	tb.Helper()
 

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -45,7 +45,7 @@ func collectWorkflowJobNames(content []byte) ([]string, error) {
 }
 
 func CheckWorkflows(rootDir, policyPath string) error {
-	if err := ensureWorkflowTools(); err != nil {
+	if err := ensureWorkflowTools(rootDir); err != nil {
 		return err
 	}
 
@@ -122,7 +122,41 @@ func CheckWorkflows(rootDir, policyPath string) error {
 	return nil
 }
 
-func ensureWorkflowTools() error { return nil }
+func ensureWorkflowTools(rootDir string) error {
+	actionlintPath, err := exec.LookPath("actionlint")
+	if err != nil {
+		return fmt.Errorf("actionlint is required for workflow validation: %w", err)
+	}
+	zizmorPath, err := exec.LookPath("zizmor")
+	if err != nil {
+		return fmt.Errorf("zizmor is required for workflow validation: %w", err)
+	}
+
+	actionlintCmd := exec.Command(actionlintPath)
+	actionlintCmd.Dir = rootDir
+	if output, err := actionlintCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("actionlint failed: %w\n%s", err, strings.TrimSpace(string(output)))
+	}
+
+	workflowPaths, err := filepath.Glob(filepath.Join(rootDir, ".github", "workflows", "*.yml"))
+	if err != nil {
+		return err
+	}
+	zizmorArgs := []string{
+		"--persona", "auditor",
+		"--config", filepath.Join(rootDir, ".github", "zizmor.yml"),
+	}
+	zizmorArgs = append(zizmorArgs, workflowPaths...)
+	zizmorCmd := exec.Command(
+		zizmorPath,
+		zizmorArgs...,
+	)
+	zizmorCmd.Dir = rootDir
+	if output, err := zizmorCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("zizmor failed: %w\n%s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
 
 func validateCodeQLWorkflow(codeqlWorkflow, workflowPath string) error {
 	if regexp.MustCompile(`(?s)- language: go\s+build-mode: none`).MatchString(codeqlWorkflow) {
@@ -1731,7 +1765,8 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		return err
 	}
 	for _, needle := range []string{
-		"actions/variables?per_page=100",
+		"gh api --paginate \"repos/${REPO}/actions/variables?per_page=100\"",
+		"jq -s '{total_count: (map(.total_count // 0) | max // 0), variables: (map(.variables // []) | add)}'",
 		`verify-github-hosted-controls "${TMP_DIR}" "${REPO}" "${POLICY_PATH}"`,
 	} {
 		if !strings.Contains(hostedControlsScript, needle) {

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -10,6 +10,28 @@ import (
 	"testing"
 )
 
+func installWorkflowToolStubs(t *testing.T, root string) {
+	t.Helper()
+
+	binDir := filepath.Join(root, "test-bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(test-bin) error = %v", err)
+	}
+	for _, name := range []string{"actionlint", "zizmor"} {
+		path := filepath.Join(binDir, name)
+		if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", path, err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".github"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.github) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".github", "zizmor.yml"), []byte("rules: []\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(zizmor.yml) error = %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 func writeWorkflowValidationFixtures(t *testing.T, workflowDir string) {
 	t.Helper()
 
@@ -87,6 +109,7 @@ jobs:
 
 func TestCheckWorkflowsRecognizesRequiredJobNames(t *testing.T) {
 	root := t.TempDir()
+	installWorkflowToolStubs(t, root)
 	workflowDir := filepath.Join(root, ".github", "workflows")
 	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
@@ -159,6 +182,7 @@ contexts = [
 
 func TestCheckWorkflowsRejectsMultilineSpoofedName(t *testing.T) {
 	root := t.TempDir()
+	installWorkflowToolStubs(t, root)
 	workflowDir := filepath.Join(root, ".github", "workflows")
 	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)

--- a/internal/scenarios/scenario_script_integration_test.go
+++ b/internal/scenarios/scenario_script_integration_test.go
@@ -174,3 +174,52 @@ func TestRunScenarioTestsSecretlessOnlySkipsNonSecretlessEntries(t *testing.T) {
 		}
 	}
 }
+
+func TestRunScenarioTestsFailsWhenManifestValidationFails(t *testing.T) {
+	t.Parallel()
+
+	scenarioRoot := t.TempDir()
+	writeScenarioScript(t, scenarioRoot, "shared/test-secretless.sh", "#!/bin/sh\nexit 0\n")
+	manifestPath := writeScenarioManifest(t, scenarioRoot, []map[string]any{
+		{
+			"id":                   "shared/duplicate",
+			"description":          "First duplicate",
+			"lane":                 "secretless",
+			"platform":             "any",
+			"manual":               false,
+			"providers":            []string{"codex"},
+			"persona":              "developer",
+			"test_file":            "shared/test-secretless.sh",
+			"requires_credentials": false,
+		},
+		{
+			"id":                   "shared/duplicate",
+			"description":          "Second duplicate",
+			"lane":                 "secretless",
+			"platform":             "any",
+			"manual":               false,
+			"providers":            []string{"codex"},
+			"persona":              "developer",
+			"test_file":            "shared/test-secretless.sh",
+			"requires_credentials": false,
+		},
+	})
+
+	code, stdout, _ := runScenarioScript(
+		t,
+		filepath.Join(repoRoot(t), "scripts", "run-scenario-tests.sh"),
+		map[string]string{
+			"WORKCELL_SCENARIO_ROOT":     scenarioRoot,
+			"WORKCELL_SCENARIO_MANIFEST": manifestPath,
+		},
+	)
+	if code != 1 {
+		t.Fatalf("run-scenario-tests exit code = %d stdout=%q", code, stdout)
+	}
+	if !strings.Contains(stdout, "Duplicate scenario id") {
+		t.Fatalf("stdout %q does not contain manifest failure", stdout)
+	}
+	if strings.Contains(stdout, "Scenario tests passed") {
+		t.Fatalf("stdout %q unexpectedly reported success", stdout)
+	}
+}

--- a/internal/testkit/validation_snapshot_test.go
+++ b/internal/testkit/validation_snapshot_test.go
@@ -214,6 +214,35 @@ func TestValidationSnapshotFailsWhenTrackedBlobIsUnreadable(t *testing.T) {
 	}
 }
 
+func TestValidationSnapshotRejectsGitlinkEntriesInHeadMode(t *testing.T) {
+	t.Parallel()
+
+	tempRoot := t.TempDir()
+	repo := createSnapshotFixtureRepo(t, tempRoot)
+	cmd := exec.Command("git", "-C", repo, "rev-parse", "HEAD")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD failed: %v\n%s", err, output)
+	}
+	headCommit := strings.TrimSpace(string(output))
+	cmd = exec.Command("git", "-C", repo, "update-index", "--add", "--cacheinfo", "160000,"+headCommit+",deps/module")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git update-index gitlink failed: %v\n%s", err, output)
+	}
+	cmd = exec.Command("git", "-C", repo, "commit", "-q", "-m", "add gitlink")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit add gitlink failed: %v\n%s", err, output)
+	}
+
+	code, snapshotOutput := runValidationSnapshotCommand(t, repo, "head", `echo should-not-run`, nil)
+	if code == 0 {
+		t.Fatalf("snapshot unexpectedly succeeded: %q", snapshotOutput)
+	}
+	if !strings.Contains(snapshotOutput, "unsupported HEAD tree entry type commit") {
+		t.Fatalf("snapshot output = %q want gitlink rejection", snapshotOutput)
+	}
+}
+
 func TestValidationSnapshotPreservesGitIndexState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/transcript/pty_darwin.go
+++ b/internal/transcript/pty_darwin.go
@@ -8,6 +8,7 @@ package transcript
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"syscall"
@@ -100,6 +101,7 @@ func spawnPTYReal(command []string, stdin, stdout *os.File, stdinRead, masterRea
 	stdoutFD := int(stdout.Fd())
 	masterFD := int(master.Fd())
 	stdinClosed := false
+	var loopErr error
 
 	for {
 		readfds := syscall.FdSet{}
@@ -123,11 +125,20 @@ func spawnPTYReal(command []string, stdin, stdout *os.File, stdinRead, masterRea
 		if !stdinClosed && fdIsSet(&readfds, stdinFD) {
 			data, readErr := stdinRead(stdinFD)
 			if len(data) > 0 {
-				if err := writeAtFDReal(masterFD, data); err != nil {
-					return 0, err
+				if err := writeAtFD(masterFD, data); err != nil {
+					loopErr = err
+					break
 				}
 			}
-			if readErr != nil || len(data) == 0 {
+			if readErr != nil {
+				if errors.Is(readErr, io.EOF) {
+					stdinClosed = true
+					continue
+				}
+				loopErr = readErr
+				break
+			}
+			if len(data) == 0 {
 				stdinClosed = true
 			}
 		}
@@ -135,26 +146,44 @@ func spawnPTYReal(command []string, stdin, stdout *os.File, stdinRead, masterRea
 		if fdIsSet(&readfds, masterFD) {
 			data, readErr := masterRead(masterFD)
 			if len(data) > 0 {
-				if err := writeAtFDReal(stdoutFD, data); err != nil {
-					return 0, err
+				if err := writeAtFD(stdoutFD, data); err != nil {
+					loopErr = err
+					break
 				}
 			}
-			if readErr != nil || len(data) == 0 {
+			if readErr != nil {
+				if errors.Is(readErr, io.EOF) {
+					break
+				}
+				loopErr = readErr
+				break
+			}
+			if len(data) == 0 {
 				break
 			}
 		}
+	}
+
+	if loopErr != nil && cmd.Process != nil {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
 	}
 
 	err = cmd.Wait()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if !errors.As(err, &exitErr) {
+			if loopErr != nil {
+				return 0, loopErr
+			}
 			return 0, err
 		}
 	}
 	status, ok := cmd.ProcessState.Sys().(syscall.WaitStatus)
 	if !ok {
 		return 0, fmt.Errorf("unexpected process state type %T", cmd.ProcessState.Sys())
+	}
+	if loopErr != nil {
+		return int(status), loopErr
 	}
 	return int(status), nil
 }

--- a/internal/transcript/pty_linux.go
+++ b/internal/transcript/pty_linux.go
@@ -8,6 +8,7 @@ package transcript
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -80,6 +81,7 @@ func spawnPTYReal(command []string, stdin, stdout *os.File, stdinRead, masterRea
 	stdoutFD := int(stdout.Fd())
 	masterFD := int(master.Fd())
 	stdinClosed := false
+	var loopErr error
 
 	for {
 		readfds := syscall.FdSet{}
@@ -103,11 +105,20 @@ func spawnPTYReal(command []string, stdin, stdout *os.File, stdinRead, masterRea
 		if !stdinClosed && fdIsSet(&readfds, stdinFD) {
 			data, readErr := stdinRead(stdinFD)
 			if len(data) > 0 {
-				if err := writeAtFDReal(masterFD, data); err != nil {
-					return 0, err
+				if err := writeAtFD(masterFD, data); err != nil {
+					loopErr = err
+					break
 				}
 			}
-			if readErr != nil || len(data) == 0 {
+			if readErr != nil {
+				if errors.Is(readErr, io.EOF) {
+					stdinClosed = true
+					continue
+				}
+				loopErr = readErr
+				break
+			}
+			if len(data) == 0 {
 				stdinClosed = true
 			}
 		}
@@ -115,26 +126,44 @@ func spawnPTYReal(command []string, stdin, stdout *os.File, stdinRead, masterRea
 		if fdIsSet(&readfds, masterFD) {
 			data, readErr := masterRead(masterFD)
 			if len(data) > 0 {
-				if err := writeAtFDReal(stdoutFD, data); err != nil {
-					return 0, err
+				if err := writeAtFD(stdoutFD, data); err != nil {
+					loopErr = err
+					break
 				}
 			}
-			if readErr != nil || len(data) == 0 {
+			if readErr != nil {
+				if errors.Is(readErr, io.EOF) {
+					break
+				}
+				loopErr = readErr
+				break
+			}
+			if len(data) == 0 {
 				break
 			}
 		}
+	}
+
+	if loopErr != nil && cmd.Process != nil {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
 	}
 
 	err = cmd.Wait()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if !errors.As(err, &exitErr) {
+			if loopErr != nil {
+				return 0, loopErr
+			}
 			return 0, err
 		}
 	}
 	status, ok := cmd.ProcessState.Sys().(syscall.WaitStatus)
 	if !ok {
 		return 0, fmt.Errorf("unexpected process state type %T", cmd.ProcessState.Sys())
+	}
+	if loopErr != nil {
+		return int(status), loopErr
 	}
 	return int(status), nil
 }

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -20,10 +20,28 @@ type ReadFunc func(fd int) ([]byte, error)
 
 type SpawnFunc func(command []string, stdin, stdout *os.File, stdinRead, masterRead ReadFunc) (int, error)
 
+type transcriptLog interface {
+	Write([]byte) (int, error)
+	Sync() error
+	Close() error
+}
+
+type transcriptPersistenceError struct {
+	err error
+}
+
+func (e transcriptPersistenceError) Error() string {
+	return e.err.Error()
+}
+
+func (e transcriptPersistenceError) Unwrap() error {
+	return e.err
+}
+
 var (
-	isTerminal = func(file *os.File) bool {
-		info, err := file.Stat()
-		return err == nil && info.Mode()&os.ModeCharDevice != 0
+	isTerminal  = isInteractiveTerminal
+	openLogFile = func(path string) (transcriptLog, error) {
+		return openLog(path)
 	}
 	spawnPTY  SpawnFunc = spawnPTYReal
 	readAtFD            = readAtFDReal
@@ -62,7 +80,7 @@ func Run(program string, stdin, stdout *os.File, stderr io.Writer, args []string
 		return 2
 	}
 
-	logFile, err := openLog(logPath)
+	logFile, err := openLogFile(logPath)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
@@ -70,40 +88,81 @@ func Run(program string, stdin, stdout *os.File, stderr io.Writer, args []string
 	defer logFile.Close()
 
 	var logMu sync.Mutex
-	writeLog := func(data []byte) {
+	var persistErr error
+	writeLog := func(data []byte) error {
 		if len(data) == 0 {
-			return
+			return nil
 		}
 		logMu.Lock()
-		_, _ = logFile.Write(data)
-		_ = logFile.Sync()
-		logMu.Unlock()
+		defer logMu.Unlock()
+		if persistErr != nil {
+			return transcriptPersistenceError{err: persistErr}
+		}
+		if _, err := logFile.Write(data); err != nil {
+			persistErr = err
+			return transcriptPersistenceError{err: err}
+		}
+		if err := logFile.Sync(); err != nil {
+			persistErr = err
+			return transcriptPersistenceError{err: err}
+		}
+		return nil
+	}
+	reportPersistErr := func() int {
+		if persistErr == nil {
+			return 0
+		}
+		fmt.Fprintf(stderr, "%s failed to persist transcript: %s\n", program, persistErr)
+		return 1
 	}
 
 	startedAt := pythonTimestamp(time.Now())
-	writeLog([]byte("# workcell-transcript-v1 start=" + startedAt + "\n"))
+	if err := writeLog([]byte("# workcell-transcript-v1 start=" + startedAt + "\n")); err != nil {
+		return reportPersistErr()
+	}
 
 	stdinRead := func(fd int) ([]byte, error) {
 		data, err := readAtFD(fd)
-		writeLog(data)
+		if writeErr := writeLog(data); writeErr != nil {
+			return nil, writeErr
+		}
 		return data, err
 	}
 	masterRead := func(fd int) ([]byte, error) {
 		data, err := readAtFD(fd)
-		writeLog(data)
+		if writeErr := writeLog(data); writeErr != nil {
+			return data, writeErr
+		}
 		return data, err
 	}
 
 	waitStatus, spawnErr := spawnPTY(command, stdin, stdout, stdinRead, masterRead)
 	exitCode := exitCodeFromWaitStatus(waitStatus)
 	if spawnErr != nil {
-		exitCode = exitCodeFromSpawnError(spawnErr)
-		fmt.Fprintf(stderr, "%s failed to exec %s: %s\n", program, command[0], spawnErrorText(spawnErr))
+		if !isTranscriptPersistenceError(spawnErr) {
+			exitCode = exitCodeFromSpawnError(spawnErr)
+			fmt.Fprintf(stderr, "%s failed to exec %s: %s\n", program, command[0], spawnErrorText(spawnErr))
+		}
 	}
 
 	finishedAt := pythonTimestamp(time.Now())
-	writeLog(renderFooter(finishedAt, exitCode, waitStatus, spawnErr))
+	_ = writeLog(renderFooter(finishedAt, exitCode, waitStatus, spawnErr))
+	if code := reportPersistErr(); code != 0 {
+		return code
+	}
 	return exitCode
+}
+
+func isInteractiveTerminal(file *os.File) bool {
+	if file == nil {
+		return false
+	}
+	return isTerminalFD(file.Fd())
+}
+
+func isTranscriptPersistenceError(err error) bool {
+	var persistErr transcriptPersistenceError
+	return errors.As(err, &persistErr)
 }
 
 func openLog(path string) (*os.File, error) {

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -5,6 +5,7 @@ package transcript
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -43,10 +44,12 @@ func TestRenderFooterMatchesPythonShape(t *testing.T) {
 
 func TestRunStripsSeparatorRecordsTranscriptAndReturnsExitCode(t *testing.T) {
 	oldIsTerminal := isTerminal
+	oldOpenLog := openLogFile
 	oldSpawn := spawnPTY
 	oldRead := readAtFD
 	defer func() {
 		isTerminal = oldIsTerminal
+		openLogFile = oldOpenLog
 		spawnPTY = oldSpawn
 		readAtFD = oldRead
 	}()
@@ -140,10 +143,12 @@ func TestRunRequiresInteractiveTerminal(t *testing.T) {
 
 func TestRunHandlesSpawnErrorsWithoutTracebacks(t *testing.T) {
 	oldIsTerminal := isTerminal
+	oldOpenLog := openLogFile
 	oldSpawn := spawnPTY
 	oldRead := readAtFD
 	defer func() {
 		isTerminal = oldIsTerminal
+		openLogFile = oldOpenLog
 		spawnPTY = oldSpawn
 		readAtFD = oldRead
 	}()
@@ -161,6 +166,143 @@ func TestRunHandlesSpawnErrorsWithoutTracebacks(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "failed to exec missing-agent") {
 		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestIsInteractiveTerminalRejectsDevNull(t *testing.T) {
+	t.Parallel()
+
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("Open(%s) error = %v", os.DevNull, err)
+	}
+	defer devNull.Close()
+
+	if isInteractiveTerminal(devNull) {
+		t.Fatalf("isInteractiveTerminal(%s) unexpectedly returned true", os.DevNull)
+	}
+}
+
+func TestRunFailsWhenTranscriptPersistenceFails(t *testing.T) {
+	oldIsTerminal := isTerminal
+	oldOpenLog := openLogFile
+	oldSpawn := spawnPTY
+	defer func() {
+		isTerminal = oldIsTerminal
+		openLogFile = oldOpenLog
+		spawnPTY = oldSpawn
+	}()
+
+	isTerminal = func(*os.File) bool { return true }
+	openLogFile = func(string) (transcriptLog, error) {
+		return failingTranscriptLog{syncErr: errors.New("disk full")}, nil
+	}
+	spawnCalled := false
+	spawnPTY = func(command []string, stdin, stdout *os.File, stdinRead, masterRead ReadFunc) (int, error) {
+		spawnCalled = true
+		return 0, nil
+	}
+
+	var stderr bytes.Buffer
+	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "--", "fake-agent"})
+	if code != 1 {
+		t.Fatalf("Run() = %d, want 1", code)
+	}
+	if spawnCalled {
+		t.Fatal("spawnPTY was called despite transcript persistence failure")
+	}
+	if got := stderr.String(); !strings.Contains(got, "failed to persist transcript: disk full") {
+		t.Fatalf("stderr = %q, want persistence failure", got)
+	}
+}
+
+func TestRunPropagatesTranscriptPersistenceFailureFromStdinRead(t *testing.T) {
+	oldIsTerminal := isTerminal
+	oldOpenLog := openLogFile
+	oldSpawn := spawnPTY
+	oldRead := readAtFD
+	defer func() {
+		isTerminal = oldIsTerminal
+		openLogFile = oldOpenLog
+		spawnPTY = oldSpawn
+		readAtFD = oldRead
+	}()
+
+	isTerminal = func(*os.File) bool { return true }
+	openLogFile = func(string) (transcriptLog, error) {
+		return &countingTranscriptLog{failOnSync: 2, err: errors.New("disk full")}, nil
+	}
+	readAtFD = func(fd int) ([]byte, error) {
+		if fd != 10 {
+			t.Fatalf("unexpected fd %d", fd)
+		}
+		return []byte("user input\n"), nil
+	}
+	spawnPTY = func(command []string, stdin, stdout *os.File, stdinRead, masterRead ReadFunc) (int, error) {
+		data, err := stdinRead(10)
+		if data != nil {
+			t.Fatalf("stdinRead data = %q, want nil after persistence failure", data)
+		}
+		if !isTranscriptPersistenceError(err) {
+			t.Fatalf("stdinRead err = %v, want transcript persistence error", err)
+		}
+		return 0, err
+	}
+
+	var stderr bytes.Buffer
+	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "--", "fake-agent"})
+	if code != 1 {
+		t.Fatalf("Run() = %d, want 1", code)
+	}
+	if got := stderr.String(); !strings.Contains(got, "failed to persist transcript: disk full") {
+		t.Fatalf("stderr = %q, want persistence failure", got)
+	} else if strings.Contains(got, "failed to exec") {
+		t.Fatalf("stderr = %q, want no exec failure when persistence fails after spawn", got)
+	}
+}
+
+func TestRunPropagatesTranscriptPersistenceFailureFromMasterRead(t *testing.T) {
+	oldIsTerminal := isTerminal
+	oldOpenLog := openLogFile
+	oldSpawn := spawnPTY
+	oldRead := readAtFD
+	defer func() {
+		isTerminal = oldIsTerminal
+		openLogFile = oldOpenLog
+		spawnPTY = oldSpawn
+		readAtFD = oldRead
+	}()
+
+	isTerminal = func(*os.File) bool { return true }
+	openLogFile = func(string) (transcriptLog, error) {
+		return &countingTranscriptLog{failOnSync: 2, err: errors.New("disk full")}, nil
+	}
+	readAtFD = func(fd int) ([]byte, error) {
+		if fd != 11 {
+			t.Fatalf("unexpected fd %d", fd)
+		}
+		return []byte("child output\n"), nil
+	}
+	spawnPTY = func(command []string, stdin, stdout *os.File, stdinRead, masterRead ReadFunc) (int, error) {
+		data, err := masterRead(11)
+		if string(data) != "child output\n" {
+			t.Fatalf("masterRead data = %q, want child output", data)
+		}
+		if !isTranscriptPersistenceError(err) {
+			t.Fatalf("masterRead err = %v, want transcript persistence error", err)
+		}
+		return 0, err
+	}
+
+	var stderr bytes.Buffer
+	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "--", "fake-agent"})
+	if code != 1 {
+		t.Fatalf("Run() = %d, want 1", code)
+	}
+	if got := stderr.String(); !strings.Contains(got, "failed to persist transcript: disk full") {
+		t.Fatalf("stderr = %q, want persistence failure", got)
+	} else if strings.Contains(got, "failed to exec") {
+		t.Fatalf("stderr = %q, want no exec failure when persistence fails after spawn", got)
 	}
 }
 
@@ -201,4 +343,42 @@ func assertMode(t *testing.T, path string, want os.FileMode) {
 	if got := info.Mode().Perm(); got != want {
 		t.Fatalf("mode mismatch for %s: got %04o want %04o", path, got, want)
 	}
+}
+
+type failingTranscriptLog struct {
+	syncErr error
+}
+
+func (f failingTranscriptLog) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (f failingTranscriptLog) Sync() error {
+	return f.syncErr
+}
+
+func (f failingTranscriptLog) Close() error {
+	return nil
+}
+
+type countingTranscriptLog struct {
+	syncs      int
+	failOnSync int
+	err        error
+}
+
+func (l *countingTranscriptLog) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (l *countingTranscriptLog) Sync() error {
+	l.syncs++
+	if l.failOnSync > 0 && l.syncs >= l.failOnSync {
+		return l.err
+	}
+	return nil
+}
+
+func (l *countingTranscriptLog) Close() error {
+	return nil
 }

--- a/internal/transcript/tty_darwin.go
+++ b/internal/transcript/tty_darwin.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin
+
+package transcript
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func isTerminalFD(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCGETA), uintptr(unsafe.Pointer(&termios)))
+	return errno == 0
+}

--- a/internal/transcript/tty_linux.go
+++ b/internal/transcript/tty_linux.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux
+
+package transcript
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func isTerminalFD(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, errno := syscall.Syscall6(syscall.SYS_IOCTL, fd, uintptr(syscall.TCGETS), uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return errno == 0
+}

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -11,7 +11,7 @@ ARG SOURCE_DATE_EPOCH=0
 # To update: choose a newer snapshot date at https://snapshot.debian.org/,
 # verify packages are available, update this value, and re-run verify-reproducible-build.sh.
 ARG DEBIAN_SNAPSHOT=20260410T000000Z
-ARG RUST_TOOLCHAIN_IMAGE=rust:1.94.1-slim-trixie@sha256:a08d20a404f947ed358dfb63d1ee7e0b88ecad3c45ba9682ccbf2cb09c98acca
+ARG RUST_TOOLCHAIN_IMAGE=rust:1.94.1-slim-trixie@sha256:cf09adf8c3ebaba10779e5c23ff7fe4df4cccdab8a91f199b0c142c53fef3e1a
 
 FROM ${RUST_TOOLCHAIN_IMAGE} AS rust-toolchain
 
@@ -130,7 +130,7 @@ FROM runtime-base AS runtime-builder
 # from the public release bucket, verify the per-platform checksums in the
 # corresponding manifest.json, update CLAUDE_VERSION, and refresh the
 # CLAUDE_SHA256 values below.
-ARG CLAUDE_VERSION=2.1.97
+ARG CLAUDE_VERSION=2.1.98
 # OpenAI Codex CLI version and SHA256 checksums for each architecture.
 # Workcell follows the stable npm channel and matching non-prerelease Rust
 # release after the cool-off in policy/provider-bumps.toml. To update
@@ -205,11 +205,11 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
   && case "${TARGET_ARCH}" in \
     arm64) \
       CLAUDE_PLATFORM="linux-arm64"; \
-      CLAUDE_SHA256="85167cb721655fdd90b002012a28eca273c89dc2fd709be49afe2a7724c365a0"; \
+      CLAUDE_SHA256="67c0b9b7ed9c63f8524ecf5790805842f81d8322254dea849ecb8c7051f8df6b"; \
       ;; \
     amd64) \
       CLAUDE_PLATFORM="linux-x64"; \
-      CLAUDE_SHA256="0d43fcd11d29206563eeef3a1f787f0615c21cd703cc91f3a180915fd5797ef6"; \
+      CLAUDE_SHA256="d40827b5aa8d737a7eb68e3aad990b80e2521540a6bc8a405259b63b25d42ed8"; \
       ;; \
     *) \
       echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; \

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "c6260d2943fe0ce58ffc5ced445e0f9d6cfa5715b1d659ba4ca29c17ed901176"
+      "sha256": "fa07b577c9f3b51c93fcefac2af336ccc3be15a75184058cd61ca8b5f7204be4"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/runtime/container/providers/package-lock.json
+++ b/runtime/container/providers/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google/gemini-cli": "0.37.0"
+        "@google/gemini-cli": "0.37.1"
       }
     },
     "node_modules/@google/gemini-cli": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-0.37.0.tgz",
-      "integrity": "sha512-IdS3MxTxtwbnx7EqNkD0ucVj/jH9MoOuRxuceiQQ93glW3xLGMyQkbqz7HCtDFV1vI57vX2gragNPWyiFKwdEQ==",
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-0.37.1.tgz",
+      "integrity": "sha512-F9koIXd9ZX1yu2MPyMvnwbrdehmPIPqctYI2dy3eS6EKqzg8V83LOvbApGBqrIKec1z2skfnEbC9C6sDNkcojw==",
       "license": "Apache-2.0",
       "bin": {
         "gemini": "bundle/gemini.js"

--- a/runtime/container/providers/package.json
+++ b/runtime/container/providers/package.json
@@ -5,7 +5,7 @@
   "description": "Pinned npm Gemini CLI dependency for Workcell runtime builds",
   "license": "Apache-2.0",
   "dependencies": {
-    "@google/gemini-cli": "0.37.0"
+    "@google/gemini-cli": "0.37.1"
   },
   "overrides": {
     "@tootallnate/once": "3.0.1",

--- a/scripts/run-scenario-tests.sh
+++ b/scripts/run-scenario-tests.sh
@@ -25,6 +25,12 @@ CURRENT_PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
 passed=0
 failed=0
 skipped=0
+SCENARIO_LIST="$(mktemp "${TMPDIR:-/tmp}/workcell-scenarios.XXXXXX")"
+
+cleanup() {
+  rm -f "${SCENARIO_LIST}"
+}
+trap cleanup EXIT
 
 scenario_platform_matches() {
   case "${1:-any}" in
@@ -95,11 +101,13 @@ run_scenario() {
   fi
 }
 
+if ! "${ROOT_DIR}/scripts/lib/scenario_manifest" list-tsv "${MANIFEST}" >"${SCENARIO_LIST}"; then
+  exit 1
+fi
+
 while IFS=$'\t' read -r scenario_id test_file requires_creds lane platform manual; do
   run_scenario "${scenario_id}" "${test_file}" "${requires_creds}" "${lane}" "${platform}" "${manual}"
-done < <(
-  "${ROOT_DIR}/scripts/lib/scenario_manifest" list-tsv "${MANIFEST}"
-)
+done <"${SCENARIO_LIST}"
 
 echo ""
 echo "Results: passed=${passed} failed=${failed} skipped=${skipped}"

--- a/scripts/verify-build-input-manifest.sh
+++ b/scripts/verify-build-input-manifest.sh
@@ -67,7 +67,7 @@ copy_tracked_worktree() {
     fi
     mkdir -p "$(dirname "${destination_path}")"
     cp -pP "${source_path}" "${destination_path}"
-  done < <(safe_git -C "${ROOT_DIR}" ls-files -z --cached --modified --others --exclude-standard --deduplicate)
+  done < <(safe_git -C "${ROOT_DIR}" ls-files -z --cached --modified --deduplicate)
 }
 
 export WORKCELL_BUILD_INPUT_REF="${BUILD_REF}"

--- a/scripts/verify-github-hosted-controls.sh
+++ b/scripts/verify-github-hosted-controls.sh
@@ -14,6 +14,7 @@ require_tool() {
 }
 
 require_tool gh
+require_tool jq
 
 REPO="${1:-}"
 if [[ -z "${REPO}" ]]; then
@@ -35,7 +36,8 @@ build_go_tool_in_repo "${ROOT_DIR}" "${METADATAUTIL_BIN}" ./cmd/workcell-metadat
 
 gh api "repos/${REPO}" >"${TMP_DIR}/repo.json"
 gh api "repos/${REPO}/actions/permissions" >"${TMP_DIR}/actions-permissions.json"
-gh api "repos/${REPO}/actions/variables?per_page=100" >"${TMP_DIR}/actions-variables.json"
+gh api --paginate "repos/${REPO}/actions/variables?per_page=100" |
+  jq -s '{total_count: (map(.total_count // 0) | max // 0), variables: (map(.variables // []) | add)}' >"${TMP_DIR}/actions-variables.json"
 gh api "repos/${REPO}/collaborators?affiliation=direct&per_page=100" >"${TMP_DIR}/collaborators-direct.json"
 gh api "repos/${REPO}/rulesets" >"${TMP_DIR}/rulesets-summary.json"
 "${METADATAUTIL_BIN}" fetch-rulesets "${TMP_DIR}" "${REPO}"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -6749,6 +6749,27 @@ if ! awk '
   exit 1
 fi
 
+if ! sed -n '/^acquire_profile_lock()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | awk '
+  $0 == "  while true; do" && state == 0 { state = 1; next }
+  $0 == "    if ! acquired_state=\"$(go_hostutil launcher acquire-profile-lock \"${lock_dir}\" \"$$\")\"; then" && state == 1 { state = 2; next }
+  $0 == "      echo \"Failed to create managed runtime lock for profile ${profile}.\" >&2" && state == 2 { state = 3; next }
+  $0 == "      return 1" && state == 3 { state = 4; next }
+  $0 == "    fi" && state == 4 { state = 5; next }
+  $0 == "    if [[ \"${acquired_state}\" == \"1\" ]]; then" && state == 5 { state = 6; next }
+  $0 == "      PROFILE_LOCK_DIR=\"${lock_dir}\"" && state == 6 { state = 7; next }
+  $0 == "      return 0" && state == 7 { state = 8; next }
+  $0 == "    fi" && state == 8 { state = 9; next }
+  $0 == "    if ! stale_state=\"$(profile_lock_is_stale \"${lock_dir}\")\"; then" && state == 9 { state = 10; next }
+  $0 == "      echo \"Failed to inspect managed runtime lock state for profile ${profile}.\" >&2" && state == 10 { state = 11; next }
+  $0 == "      return 1" && state == 11 { state = 12; next }
+  $0 == "    fi" && state == 12 { state = 13; next }
+  $0 == "    if [[ \"${stale_state}\" == \"1\" ]]; then" && state == 13 { state = 14; exit }
+  END { exit(state == 14 ? 0 : 1) }
+'; then
+  echo "Expected workcell to acquire profile locks atomically and fail fast when lock state cannot be inspected" >&2
+  exit 1
+fi
+
 # shellcheck disable=SC2016
 for needle in \
   'workspace_runtime_probe_path()' \

--- a/scripts/with-validation-snapshot.sh
+++ b/scripts/with-validation-snapshot.sh
@@ -145,8 +145,7 @@ materialize_tracked_entry() {
       return 0
       ;;
     *)
-      echo "with-validation-snapshot: skipping unsupported mode ${mode} in ${label}: ${tracked_path}" >&2
-      return 0
+      die "with-validation-snapshot: unsupported mode ${mode} in ${label}: ${tracked_path}"
       ;;
   esac
 
@@ -181,7 +180,9 @@ overlay_head_state() {
     obj_type="${remainder%% *}"
     oid="${remainder##* }"
 
-    [[ "${obj_type}" == "blob" ]] || continue
+    if [[ "${obj_type}" != "blob" ]]; then
+      die "with-validation-snapshot: unsupported HEAD tree entry type ${obj_type}: ${tracked_path}"
+    fi
 
     materialize_tracked_entry "${mode}" "${oid}" "${tracked_path}" "HEAD tree"
   done < <(git -C "${REPO_ROOT}" ls-tree -r -z HEAD)

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -927,14 +927,28 @@ acquire_profile_lock() {
   local profile="$1"
   local lock_dir=""
   local lock_parent=""
+  local acquired_state=""
+  local stale_state=""
   local attempts=0
 
   lock_dir="$(profile_lock_dir_path "${profile}")"
   lock_parent="$(dirname "${lock_dir}")"
   mkdir -p "${lock_parent}"
 
-  while ! mkdir "${lock_dir}" 2>/dev/null; do
-    if [[ "$(profile_lock_is_stale "${lock_dir}")" == "1" ]]; then
+  while true; do
+    if ! acquired_state="$(go_hostutil launcher acquire-profile-lock "${lock_dir}" "$$")"; then
+      echo "Failed to create managed runtime lock for profile ${profile}." >&2
+      return 1
+    fi
+    if [[ "${acquired_state}" == "1" ]]; then
+      PROFILE_LOCK_DIR="${lock_dir}"
+      return 0
+    fi
+    if ! stale_state="$(profile_lock_is_stale "${lock_dir}")"; then
+      echo "Failed to inspect managed runtime lock state for profile ${profile}." >&2
+      return 1
+    fi
+    if [[ "${stale_state}" == "1" ]]; then
       rm -rf "${lock_dir}"
       continue
     fi
@@ -944,10 +958,6 @@ acquire_profile_lock() {
     fi
     sleep 1
   done
-
-  PROFILE_LOCK_DIR="${lock_dir}"
-  go_hostutil launcher write-profile-owner "${lock_dir}/owner.json" "$$"
-  chmod 0600 "${lock_dir}/owner.json" 2>/dev/null || true
 }
 
 cleanup_stale_session_audit_dirs() {


### PR DESCRIPTION
## Summary
- harden injection rendering, profile-lock acquisition, transcript persistence handling, build-input tracking, workflow validation, and hosted-control verification paths
- add focused regression tests for symlink traversal, transcript persistence failure propagation, profile lock ownership, scenario manifest failures, build-input tracking, and workflow/tool validation
- refresh upstream pins blocked by the pin-hygiene hook, including Claude/Gemini provider bumps and the runtime Rust base-image digest

## Validation
- `go test ./...`
- `bash ./scripts/verify-build-input-manifest.sh`
- `bash ./scripts/run-scenario-tests.sh --secretless-only`
- `bash ./scripts/validate-repo.sh`