### PR TITLE
Add policy inspection, session diff, and launch progress UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ Releases.
 
 ## Unreleased
 
+## v0.9.0 - 2026-04-14
+
+### Added
+
+- host-side `workcell policy show|validate|diff` commands and `workcell why`
+  so operators can inspect merged credential policy decisions without launching
+  a session
+- `workcell session diff` with recorded git launch metadata for reviewable
+  session output against the session start point
+- interactive launch spinner support with text heartbeat fallback plus a
+  user-facing `--no-spinner` override
+
+### Changed
+
+- expanded the roadmap and delivery planning docs around `Implement first` and
+  `Implement next` priorities for supervisor, policy, auth, and observability
+- surfaced richer host-side auth readiness and selection reporting in
+  `workcell auth status` and launch-time `--auth-status`
+- synced the man page, policy docs, and scenario coverage with the current
+  session, policy, and launch UX surfaces
+
+### Fixed
+
+- aligned `workcell why` with launch and status credential scoping so
+  out-of-scope credentials are never reported as selected
+- failed closed on `workcell session diff` when the source session launched
+  from a dirty git workspace
+- replaced session-record rewrites with atomic write-and-rename handling
+
 ## v0.8.1 - 2026-04-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ Other defaults that matter:
   explicit lower-assurance opt-out
 - `--cache-profile off` is the default
 - strict launches prepare the reviewed runtime image automatically when needed
+- interactive launches show a spinner with elapsed time by default; use
+  `--no-spinner` to force plain heartbeat updates instead
 - `--prepare` and `--prepare-only` remain useful when you want to make that step explicit
 
 ## Safe-path expectations
@@ -222,7 +224,9 @@ Other defaults that matter:
 - completed and aborted launches are recorded as durable host-side session
   records that you can inspect with `workcell session ...`
 - `workcell session diff` compares the current workspace against the clean git
-  base recorded at launch and fails closed when the launch started dirty
+  base recorded at launch and fails closed when the launch started dirty, when
+  no launch git base was recorded, or when the workspace is not a self-contained
+  git worktree
 - `--debug-log`, `--file-trace-log`, and `--audit-transcript` are explicit
   lower-assurance operator choices and are off by default
 

--- a/README.md
+++ b/README.md
@@ -151,11 +151,16 @@ Use the host-side auth helpers instead of hand-editing the common case:
 workcell auth init
 workcell auth set --agent codex --credential codex_auth --source /path/to/auth.json
 workcell auth status --agent codex
+workcell policy validate
+workcell why --agent codex --mode strict --credential codex_auth
 workcell --agent codex --auth-status --workspace /path/to/repo
 ```
 
 `workcell auth status` shows the host policy view. `--auth-status` shows the
 derived launch view after selector evaluation and preprocessing.
+`workcell policy show|validate|diff` inspects the merged host policy, and
+`workcell why` explains why one credential is selected, filtered, or still only
+configured on the host side.
 
 Workcell can stage:
 
@@ -216,6 +221,8 @@ Other defaults that matter:
   outside the Tier 1 container
 - completed and aborted launches are recorded as durable host-side session
   records that you can inspect with `workcell session ...`
+- `workcell session diff` compares the current workspace against the clean git
+  base recorded at launch and fails closed when the launch started dirty
 - `--debug-log`, `--file-trace-log`, and `--audit-transcript` are explicit
   lower-assurance operator choices and are off by default
 
@@ -227,7 +234,11 @@ workcell --agent codex --prepare-only --workspace /path/to/repo
 workcell --agent codex --mode development --workspace /path/to/repo -- bash -lc 'git status'
 workcell session list
 workcell session show --id 20260408T120000Z-1a2b3c4d
+workcell session diff --id 20260408T120000Z-1a2b3c4d
 workcell session export --id 20260408T120000Z-1a2b3c4d --output /tmp/workcell-session.json
+workcell policy show
+workcell policy diff
+workcell why --agent codex --mode strict --credential codex_auth
 workcell --agent codex --doctor --workspace /path/to/repo
 workcell --agent codex --inspect --workspace /path/to/repo
 workcell --agent codex --auth-status --workspace /path/to/repo

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ workcell --agent codex --auth-status --workspace /path/to/repo
 `workcell auth status` shows the host policy view. `--auth-status` shows the
 derived launch view after selector evaluation and preprocessing.
 `workcell policy show|validate|diff` inspects the merged host policy, and
-`workcell why` explains why one credential is selected, filtered, or still only
-configured on the host side.
+`workcell why` explains why one credential is selected, out of scope, filtered,
+or still only configured on the host side.
 
 Workcell can stage:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,30 @@
 
 Workcell is still pre-1.0. The near-term roadmap is about making the current
 security model easier to adopt, easier to verify, and easier to contribute to.
+The delivery shape for the active slice lives in
+`docs/implement-first-delivery-plan.md`.
+
+## Implement first
+
+- ship Phase 2 of the Workcell session supervisor:
+  detached/background sessions, `session start`, `session attach`,
+  `session send`, `session stop`, `session diff`, and default
+  worktree-per-session flows
+- add `workcell why` and richer policy inspection so operators can see why
+  a path, credential, endpoint, or control-plane input is allowed or blocked
+- improve host-owned auth flows: better resolver coverage, clearer
+  `auth-status` diagnostics, and explicit login/setup handoffs where provider
+  onboarding needs browser or credential bootstrap help
+
+## Implement next
+
+- add reviewed team workflow packs at the Workcell layer: versioned
+  instruction bundles, commands, approved MCP packs, and task templates
+- add session observability on top of the supervisor:
+  live status, branch/worktree, assurance state, logs, transcript pointers,
+  and command timeline views
+- add a lightweight TUI or dashboard backed by the same host-controlled
+  session plane rather than a separate execution path
 
 ## Next 90 days
 

--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -215,6 +215,8 @@ func runLauncher(args []string) error {
 		return runLauncherSessionShow(args[1:])
 	case "session-export":
 		return runLauncherSessionExport(args[1:])
+	case "session-diff-metadata":
+		return runLauncherSessionDiffMetadata(args[1:])
 	case "audit-digest":
 		if len(args) < 3 {
 			return launcherUsage()
@@ -337,7 +339,7 @@ func releaseUsage() error {
 }
 
 func launcherUsage() error {
-	return fmt.Errorf("usage: workcell-hostutil launcher <session-suffix|colima-status|cleanup-stale-log-pointers|profile-lock-is-stale|acquire-profile-lock|write-profile-owner|cleanup-stale-session-audit-dirs|session-record-write|session-list|session-show|session-export|audit-digest|direct-mount-cache-key|resolve-host-output-candidate|cleanup-stale-injection-bundles|manifest-metadata|resolver-metadata|workspace-cache-key|extract-codex-version|validate-security-options|canonicalize-tool-path|dedupe-endpoints|resolve-endpoints> [args...]")
+	return fmt.Errorf("usage: workcell-hostutil launcher <session-suffix|colima-status|cleanup-stale-log-pointers|profile-lock-is-stale|acquire-profile-lock|write-profile-owner|cleanup-stale-session-audit-dirs|session-record-write|session-list|session-show|session-export|session-diff-metadata|audit-digest|direct-mount-cache-key|resolve-host-output-candidate|cleanup-stale-injection-bundles|manifest-metadata|resolver-metadata|workspace-cache-key|extract-codex-version|validate-security-options|canonicalize-tool-path|dedupe-endpoints|resolve-endpoints> [args...]")
 }
 
 func runLauncherSessionList(args []string) error {
@@ -420,6 +422,21 @@ func runLauncherSessionExport(args []string) error {
 		return err
 	}
 	fmt.Printf("%s\n", content)
+	return nil
+}
+
+func runLauncherSessionDiffMetadata(args []string) error {
+	if len(args) != 2 {
+		return launcherUsage()
+	}
+
+	record, err := hostutil.FindSessionRecord(args[0], args[1])
+	if err != nil {
+		return err
+	}
+	for _, line := range hostutil.SessionDiffMetadataLines(record) {
+		fmt.Println(line)
+	}
 	return nil
 }
 

--- a/docs/implement-first-delivery-plan.md
+++ b/docs/implement-first-delivery-plan.md
@@ -1,0 +1,88 @@
+# Implement-First Delivery Plan
+
+This document turns the near-term roadmap into a concrete delivery shape that
+keeps the boundary model intact and favors additive host-side changes.
+
+## Principles
+
+- keep new control paths host-owned and file-backed before introducing live
+  orchestration
+- prefer read-only inspection commands before mutable workflow features
+- share one policy and auth evaluation path across launcher, diagnostics, and
+  operator tooling
+- bias toward simple, testable, fail-closed behavior over broad feature reach
+
+## Distinguished Engineer Checkpoints
+
+- initial design review:
+  freeze the phase boundary, confirm host-only ownership, and reject changes
+  that depend on provider config or same-user local trust
+- final line-by-line review:
+  verify every changed code path preserves the runtime boundary, does not widen
+  credential exposure, and keeps host-side git/control-plane execution explicit
+
+## Active Tracks
+
+### 1. Session Supervisor Phase 2 Foundation
+
+Scope for this delivery slice:
+
+- extend durable session records with git/workspace metadata needed for review
+- add `workcell session diff` as a host-only inspection surface
+- keep the implementation file-backed; do not add a daemon or socket protocol
+- defer `attach`, `send`, `stop`, and detached orchestration until the session
+  object and review surfaces stabilize
+
+Staffing:
+
+- TL: session supervisor lead
+- SWE A: hostutil and launcher metadata plumbing
+- SWE B: shell command surface and scenario coverage
+
+### 2. Policy Explainability
+
+Scope for this delivery slice:
+
+- add `workcell policy show`
+- add `workcell policy validate`
+- add `workcell policy diff`
+- add a scoped `workcell why` for credential selection and status reasons
+- keep outputs read-only and redact-by-default
+
+Staffing:
+
+- TL: policy explainability lead
+- SWE A: policy evaluator and CLI command implementation
+- SWE B: shell integration and scenario coverage
+
+### 3. Auth Diagnostics
+
+Scope for this delivery slice:
+
+- improve shared auth posture metadata without expanding resolver trust
+- keep `auth status` and launcher-facing auth posture aligned
+- provide clearer provider-ready versus configured-only distinctions
+- keep browser or setup handoffs explicit and host-owned
+
+Staffing:
+
+- TL: auth integrations lead
+- SWE A: resolver metadata and auth-state reasoning
+- SWE B: shell output, recovery guidance, and scenario coverage
+
+## Sequence
+
+1. land read-only inspection primitives first:
+   policy commands, `why`, session metadata, session diff
+2. unify auth posture reason codes across offline and launch-time paths
+3. expand scenario coverage before adding any mutable orchestration commands
+4. revisit detached sessions and live takeover only after the durable session
+   object proves stable in tests and operator use
+
+## Non-Goals In This Slice
+
+- a background daemon
+- same-user local socket trust
+- default-open networking
+- workspace-controlled policy overrides
+- secret materialization paths that bypass the reviewed host policy flow

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -31,8 +31,10 @@ Secret-bearing inputs are handled more carefully than public inputs:
 | `includes = [...]` | compose a policy from smaller operator-owned fragments |
 
 `workcell auth init|set|unset|status` manages the entrypoint policy file only.
-If a credential is declared by an included fragment, update that fragment
-directly.
+`workcell policy show|validate|diff` inspects the merged policy, and
+`workcell why --credential ... --agent ... --mode ...` explains one credential
+decision without launching the runtime. If a credential is declared by an
+included fragment, update that fragment directly.
 
 Selectors let you scope entries to only some launches:
 

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -33,7 +33,8 @@ Secret-bearing inputs are handled more carefully than public inputs:
 `workcell auth init|set|unset|status` manages the entrypoint policy file only.
 `workcell policy show|validate|diff` inspects the merged policy, and
 `workcell why --credential ... --agent ... --mode ...` explains one credential
-decision without launching the runtime. If a credential is declared by an
+decision, including out-of-scope cases, without launching the runtime. If a
+credential is declared by an
 included fragment, update that fragment directly.
 
 Selectors let you scope entries to only some launches:

--- a/docs/use-case-matrix.md
+++ b/docs/use-case-matrix.md
@@ -15,11 +15,12 @@ Workcell workflows.
 |---|---|---|
 | secretless provider launch on the managed path | tested | `scripts/container-smoke.sh`, `scripts/verify-invariants.sh` |
 | provider auth injected through the reviewed policy model | tested | container smoke, auth-status tests, provider-specific helpers |
+| host-side policy inspection and credential explainability | tested | `tests/scenarios/shared/test-policy-commands.sh`, `internal/authpolicy/manage_test.go` |
 | host-side signed `publish-pr` handoff | tested | shared scenario tests and invariant checks |
 | repo control-plane masking and provider-home re-seeding | tested | invariants and smoke |
 | repo-mounted validator and release-helper runs stay nonroot with explicit caller identity and isolated writable state | tested | CI, release preflight, `scripts/pre-merge.sh`, and invariant checks |
 | prompt-autonomy downgrade labeling | tested for Codex, partial elsewhere | invariants plus provider-specific coverage |
-| host-side session inventory and audit export | tested | `tests/scenarios/shared/test-session-commands.sh`, `internal/hostutil/sessions_test.go` |
+| host-side session inventory, clean-base diff, and audit export | tested | `tests/scenarios/shared/test-session-commands.sh`, `internal/hostutil/sessions_test.go` |
 | bundle installer plus uninstall helper on the supported GitHub-hosted macOS matrix | tested | `scripts/verify-invariants.sh`, CI, tagged release install verification |
 | Homebrew formula install plus uninstall on the supported GitHub-hosted macOS matrix | tested | CI and tagged release install verification |
 | release-bundle reproducibility | tested | `scripts/verify-release-bundle.sh`, tagged release preflight |
@@ -33,6 +34,7 @@ Workcell workflows.
 
 The most heavily tested paths are the secretless runtime boundary, explicit
 nonroot repo validation and release preflight, reproducibility, and signed
-publication. The biggest remaining gaps are local macOS boundary proof, deeper
-end-to-end live-provider coverage, and fuller lower-assurance transition
-coverage.
+publication. The most mature host-side operator surfaces are auth/policy
+inspection plus session inventory and export. The biggest remaining gaps are
+local macOS boundary proof, deeper end-to-end live-provider coverage, and
+fuller lower-assurance transition coverage.

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -23,8 +23,9 @@ These run without provider credentials:
 - `./scripts/pre-merge.sh` (builds or reuses the same pinned validator container and can run the local stack from a disposable snapshot before optional remote lanes)
 
 They cover repo shape, runtime contracts, smoke behavior, and reproducibility.
-They also now cover canonical requirement traceability and host-side session
-inventory behavior.
+They also now cover canonical requirement traceability, host-side policy
+inspection and explainability, and host-side session inventory plus clean-base
+diff/export behavior.
 
 ## Manual authenticated smoke
 

--- a/docs/workcell-session-supervisor-design.md
+++ b/docs/workcell-session-supervisor-design.md
@@ -11,10 +11,12 @@ this repository without weakening the existing boundary model.
 
 ## Phase 1 Scope
 
-Phase 1 adds durable host-side session records and inventory commands:
+Phase 1 adds durable host-side session records plus host-side inventory and
+inspection commands:
 
 - `workcell session list`
 - `workcell session show --id ...`
+- `workcell session diff --id ...`
 - `workcell session export --id ...`
 
 Each launched session writes durable metadata under the managed Colima profile
@@ -32,6 +34,9 @@ Each session record stores:
 - `ui`
 - `execution_path`
 - `workspace`
+- `git_branch`
+- `git_head`
+- `git_base`
 - `container_name`
 - `session_audit_dir`
 - `audit_log_path`
@@ -93,6 +98,11 @@ session metadata.
 
 `workcell session show` returns the full durable record for one session.
 
+`workcell session diff` renders the current workspace status and diff against
+the clean git base recorded when the session started. It fails closed if the
+workspace was already dirty at launch, if no git base was recorded, or if the
+workspace is no longer a self-contained git worktree on the host.
+
 `workcell session export` returns the full record plus matching audit records,
 either to stdout or a user-selected host file.
 
@@ -147,7 +157,7 @@ Phase 3 should add:
 
 - There is no retention policy yet for durable session records.
 - Aborted launches rely on host cleanup logic to mark the record as aborted.
-- The current phase gives inventory and export, not orchestration.
+- The current phase gives inventory and inspection, not orchestration.
 
 Those are acceptable for a first slice because the main goal here is to create
 durable, auditable session objects without weakening the reviewed boundary.

--- a/internal/authpolicy/manage.go
+++ b/internal/authpolicy/manage.go
@@ -812,6 +812,14 @@ func explainCredentialSelection(policy map[string]any, policyBase string, creden
 	}
 	rawMap, ok := raw.(map[string]any)
 	if !ok {
+		if !credentialAllowedForAgent(agent, credential) {
+			return credentialSelectionReport{
+				selected:  false,
+				reason:    "credential is not in scope for agent " + agent,
+				readiness: "out-of-scope",
+				inputKind: "source",
+			}, nil
+		}
 		if err := validateStatusCredentialSource(credential, raw, policyBase); err != nil {
 			return credentialSelectionReport{}, err
 		}
@@ -844,6 +852,11 @@ func explainCredentialSelection(policy map[string]any, policyBase string, creden
 			return credentialSelectionReport{}, err
 		}
 		report.modes = values
+	}
+	if !credentialAllowedForAgent(agent, credential) {
+		report.reason = "credential is not in scope for agent " + agent
+		report.readiness = "out-of-scope"
+		return report, nil
 	}
 	providerMatch := true
 	if len(report.providers) > 0 {
@@ -911,10 +924,7 @@ func explainReadyStates(policy map[string]any, policyBase string, agent string, 
 	}
 
 	relevant := map[string]struct{}{}
-	for key := range SharedCredentialKeys {
-		relevant[key] = struct{}{}
-	}
-	for key := range AgentScopedCredentialKeys[agent] {
+	for key := range allowedCredentialsForAgent(agent) {
 		relevant[key] = struct{}{}
 	}
 	keys := make([]string, 0, len(relevant))
@@ -1334,6 +1344,13 @@ func ensureNoForeignManagedSource(policyPath string, managedRoot string, credent
 }
 
 func validateAgentCredential(agent string, credential string) error {
+	if !credentialAllowedForAgent(agent, credential) {
+		return die(fmt.Sprintf("%s is not valid for agent %s", credential, agent))
+	}
+	return nil
+}
+
+func allowedCredentialsForAgent(agent string) map[string]struct{} {
 	allowed := map[string]struct{}{}
 	for key := range SharedCredentialKeys {
 		allowed[key] = struct{}{}
@@ -1341,10 +1358,12 @@ func validateAgentCredential(agent string, credential string) error {
 	for key := range AgentScopedCredentialKeys[agent] {
 		allowed[key] = struct{}{}
 	}
-	if _, ok := allowed[credential]; !ok {
-		return die(fmt.Sprintf("%s is not valid for agent %s", credential, agent))
-	}
-	return nil
+	return allowed
+}
+
+func credentialAllowedForAgent(agent string, credential string) bool {
+	_, ok := allowedCredentialsForAgent(agent)[credential]
+	return ok
 }
 
 func validateSelectorValues(values any, label string, allowedValues map[string]struct{}) error {

--- a/internal/authpolicy/manage.go
+++ b/internal/authpolicy/manage.go
@@ -100,6 +100,46 @@ func Run(program string, args []string, stdout, stderr io.Writer) int {
 			return 1
 		}
 		return 0
+	case "show":
+		policyPath, err := parsePolicyPathArgs(program, "show", args[1:], stderr)
+		if err != nil {
+			return 2
+		}
+		if err := commandShow(policyPath, stdout); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	case "validate":
+		policyPath, err := parsePolicyPathArgs(program, "validate", args[1:], stderr)
+		if err != nil {
+			return 2
+		}
+		if err := commandValidate(policyPath, stdout); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	case "diff":
+		policyPath, err := parsePolicyPathArgs(program, "diff", args[1:], stderr)
+		if err != nil {
+			return 2
+		}
+		if err := commandDiff(policyPath, stdout); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	case "why":
+		opts, err := parseWhyArgs(program, args[1:], stderr)
+		if err != nil {
+			return 2
+		}
+		if err := commandWhy(opts, stdout); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
 	default:
 		fmt.Fprintln(stderr, usage(program))
 		fmt.Fprintf(stderr, "%s: unsupported command: %s\n", program, args[0])
@@ -124,14 +164,46 @@ type statusOptions struct {
 	mode       string
 }
 
+type whyOptions struct {
+	policyPath string
+	agent      string
+	mode       string
+	credential string
+}
+
+type credentialSelectionReport struct {
+	selected  bool
+	reason    string
+	readiness string
+	inputKind string
+	providers []string
+	modes     []string
+	resolver  string
+}
+
 func usage(program string) string {
 	if program == "" {
 		program = "workcell-manage-injection-policy"
 	}
 	return fmt.Sprintf(
-		"Usage: %s {init,set,unset,status} ...",
+		"Usage: %s {init,set,unset,status,show,validate,diff,why} ...",
 		program,
 	)
+}
+
+func parsePolicyPathArgs(program string, command string, args []string, stderr io.Writer) (string, error) {
+	fs := flag.NewFlagSet(command, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	policy := fs.String("policy", "", "")
+	fs.Usage = func() { fmt.Fprintln(stderr, usage(program)) }
+	if err := fs.Parse(args); err != nil {
+		return "", err
+	}
+	if fs.NArg() != 0 || *policy == "" {
+		fs.Usage()
+		return "", fmt.Errorf("missing required flags")
+	}
+	return resolveInputPath(*policy), nil
 }
 
 func parseInitArgs(program string, args []string, stderr io.Writer) (string, string, error) {
@@ -223,6 +295,35 @@ func parseStatusArgs(program string, args []string, stderr io.Writer) (statusOpt
 	}
 	if _, ok := SupportedModes[opts.mode]; !ok {
 		return statusOptions{}, fmt.Errorf("invalid mode: %s", opts.mode)
+	}
+	opts.policyPath = resolveInputPath(opts.policyPath)
+	return opts, nil
+}
+
+func parseWhyArgs(program string, args []string, stderr io.Writer) (whyOptions, error) {
+	fs := flag.NewFlagSet("why", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var opts whyOptions
+	fs.StringVar(&opts.policyPath, "policy", "", "")
+	fs.StringVar(&opts.agent, "agent", "", "")
+	fs.StringVar(&opts.mode, "mode", "", "")
+	fs.StringVar(&opts.credential, "credential", "", "")
+	fs.Usage = func() { fmt.Fprintln(stderr, usage(program)) }
+	if err := fs.Parse(args); err != nil {
+		return whyOptions{}, err
+	}
+	if fs.NArg() != 0 || opts.policyPath == "" || opts.agent == "" || opts.mode == "" || opts.credential == "" {
+		fs.Usage()
+		return whyOptions{}, fmt.Errorf("missing required flags")
+	}
+	if _, ok := SupportedAgents[opts.agent]; !ok {
+		return whyOptions{}, fmt.Errorf("invalid agent: %s", opts.agent)
+	}
+	if _, ok := SupportedModes[opts.mode]; !ok {
+		return whyOptions{}, fmt.Errorf("invalid mode: %s", opts.mode)
+	}
+	if _, ok := CredentialKeys[opts.credential]; !ok {
+		return whyOptions{}, fmt.Errorf("invalid credential: %s", opts.credential)
 	}
 	opts.policyPath = resolveInputPath(opts.policyPath)
 	return opts, nil
@@ -497,6 +598,8 @@ func commandStatus(opts statusOptions, stdout io.Writer) error {
 		fmt.Fprintln(stdout, "credential_resolvers=none")
 		fmt.Fprintln(stdout, "credential_materialization=none")
 		fmt.Fprintln(stdout, "credential_resolution_states=none")
+		fmt.Fprintln(stdout, "provider_auth_ready_states=none")
+		fmt.Fprintln(stdout, "shared_auth_ready_states=none")
 		if opts.agent != "" {
 			fmt.Fprintln(stdout, "provider_auth_mode=none")
 			fmt.Fprintln(stdout, "provider_auth_modes=none")
@@ -523,6 +626,8 @@ func commandStatus(opts statusOptions, stdout io.Writer) error {
 	resolvers := map[string]string{}
 	materialization := map[string]string{}
 	resolutionStates := map[string]string{}
+	providerReadyStates := map[string]string{}
+	sharedReadyStates := map[string]string{}
 	for key, raw := range selected {
 		inputKinds[key] = credentialInputKind(raw)
 		if rawMap, ok := raw.(map[string]any); ok {
@@ -539,6 +644,24 @@ func commandStatus(opts statusOptions, stdout io.Writer) error {
 			resolutionStates[key] = "source"
 		}
 	}
+	if opts.agent != "" {
+		providerReadyStates, sharedReadyStates, err = explainReadyStates(policy, filepath.Dir(opts.policyPath), opts.agent, opts.mode)
+		if err != nil {
+			return err
+		}
+	} else {
+		for key := range selected {
+			readyState := "ready"
+			if resolutionStates[key] == "configured-only" {
+				readyState = "configured-only"
+			}
+			if _, ok := SharedCredentialKeys[key]; ok {
+				sharedReadyStates[key] = readyState
+			} else {
+				providerReadyStates[key] = readyState
+			}
+		}
+	}
 
 	fmt.Fprintln(stdout, "policy_source_sha256="+compositePolicySHA256(policySources))
 	fmt.Fprintln(stdout, "credential_keys="+renderModes(sortedKeys(selected)))
@@ -546,6 +669,8 @@ func commandStatus(opts statusOptions, stdout io.Writer) error {
 	fmt.Fprintln(stdout, "credential_resolvers="+renderMap(resolvers))
 	fmt.Fprintln(stdout, "credential_materialization="+renderMap(materialization))
 	fmt.Fprintln(stdout, "credential_resolution_states="+renderMap(resolutionStates))
+	fmt.Fprintln(stdout, "provider_auth_ready_states="+renderMap(providerReadyStates))
+	fmt.Fprintln(stdout, "shared_auth_ready_states="+renderMap(sharedReadyStates))
 	if opts.agent != "" {
 		providerAuthModes := make([]string, 0)
 		for _, key := range statusOrder[opts.agent] {
@@ -573,6 +698,256 @@ func commandStatus(opts statusOptions, stdout io.Writer) error {
 		}
 	}
 	return nil
+}
+
+func commandShow(policyPath string, stdout io.Writer) error {
+	policy, _, err := loadPolicyBundle(policyPath)
+	if err != nil {
+		return err
+	}
+	rendered, err := renderPolicyTOML(policy)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(stdout, rendered)
+	return err
+}
+
+func commandValidate(policyPath string, stdout io.Writer) error {
+	policy, _, err := loadPolicyBundle(policyPath)
+	if err != nil {
+		return err
+	}
+	credentials, _ := policy["credentials"].(map[string]any)
+	hasResolverBacked := false
+	for key, raw := range credentials {
+		if rawMap, ok := raw.(map[string]any); ok {
+			if err := validateStatusCredentialEntry(key, rawMap); err != nil {
+				return err
+			}
+			if resolver, ok := rawMap["resolver"].(string); ok && resolver != "" {
+				hasResolverBacked = true
+			}
+		}
+		if err := validateStatusCredentialSource(key, raw, filepath.Dir(policyPath)); err != nil {
+			return err
+		}
+	}
+	if _, err := selectedCredentials(policy, "", "strict"); err != nil {
+		return err
+	}
+	if _, err := renderPolicyTOML(policy); err != nil {
+		return err
+	}
+	fmt.Fprintln(stdout, "policy_valid=1")
+	if hasResolverBacked {
+		fmt.Fprintln(stdout, "resolver_readiness=deferred-to-launch")
+	} else {
+		fmt.Fprintln(stdout, "resolver_readiness=not-applicable")
+	}
+	return nil
+}
+
+func commandDiff(policyPath string, stdout io.Writer) error {
+	source, err := os.ReadFile(policyPath)
+	if err != nil {
+		return err
+	}
+	policy, _, err := loadPolicyBundle(policyPath)
+	if err != nil {
+		return err
+	}
+	rendered, err := renderPolicyTOML(policy)
+	if err != nil {
+		return err
+	}
+	sourceText := string(source)
+	if sourceText == rendered {
+		fmt.Fprintln(stdout, "diff_status=clean")
+		return nil
+	}
+	fmt.Fprintln(stdout, "diff_status=changed")
+	_, err = io.WriteString(stdout, renderTextDiff("current", "canonical", sourceText, rendered))
+	return err
+}
+
+func commandWhy(opts whyOptions, stdout io.Writer) error {
+	policy, _, err := loadPolicyBundle(opts.policyPath)
+	if err != nil {
+		return err
+	}
+	if _, err := selectedCredentials(policy, opts.agent, opts.mode); err != nil {
+		return err
+	}
+	report, err := explainCredentialSelection(policy, filepath.Dir(opts.policyPath), opts.credential, opts.agent, opts.mode)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(stdout, "policy_path="+opts.policyPath)
+	fmt.Fprintln(stdout, "credential="+opts.credential)
+	fmt.Fprintln(stdout, "agent="+opts.agent)
+	fmt.Fprintln(stdout, "mode="+opts.mode)
+	fmt.Fprintf(stdout, "selected=%d\n", boolToInt(report.selected))
+	fmt.Fprintln(stdout, "selection_reason="+report.reason)
+	fmt.Fprintln(stdout, "credential_readiness="+report.readiness)
+	fmt.Fprintln(stdout, "credential_input_kind="+report.inputKind)
+	fmt.Fprintln(stdout, "credential_providers="+renderModes(report.providers))
+	fmt.Fprintln(stdout, "credential_modes="+renderModes(report.modes))
+	if report.resolver != "" {
+		fmt.Fprintln(stdout, "credential_resolver="+report.resolver)
+	}
+	return nil
+}
+
+func explainCredentialSelection(policy map[string]any, policyBase string, credential string, agent string, mode string) (credentialSelectionReport, error) {
+	credentials, _ := policy["credentials"].(map[string]any)
+	raw, ok := credentials[credential]
+	if !ok {
+		return credentialSelectionReport{
+			selected:  false,
+			reason:    "not configured in policy",
+			readiness: "absent",
+			inputKind: "none",
+		}, nil
+	}
+	rawMap, ok := raw.(map[string]any)
+	if !ok {
+		if err := validateStatusCredentialSource(credential, raw, policyBase); err != nil {
+			return credentialSelectionReport{}, err
+		}
+		return credentialSelectionReport{
+			selected:  true,
+			reason:    "scalar credential entry is selected without provider or mode restrictions",
+			readiness: "ready",
+			inputKind: "source",
+		}, nil
+	}
+	if err := validateStatusCredentialEntry(credential, rawMap); err != nil {
+		return credentialSelectionReport{}, err
+	}
+	report := credentialSelectionReport{
+		inputKind: credentialInputKind(rawMap),
+	}
+	if resolver, ok := rawMap["resolver"].(string); ok {
+		report.resolver = resolver
+	}
+	if providers, ok := rawMap["providers"]; ok {
+		values, err := selectorStrings(providers, "credentials."+credential+".providers", SupportedAgents)
+		if err != nil {
+			return credentialSelectionReport{}, err
+		}
+		report.providers = values
+	}
+	if modes, ok := rawMap["modes"]; ok {
+		values, err := selectorStrings(modes, "credentials."+credential+".modes", SupportedModes)
+		if err != nil {
+			return credentialSelectionReport{}, err
+		}
+		report.modes = values
+	}
+	providerMatch := true
+	if len(report.providers) > 0 {
+		providerMatch = false
+		for _, candidate := range report.providers {
+			if candidate == agent {
+				providerMatch = true
+				break
+			}
+		}
+	}
+	modeMatch := true
+	if len(report.modes) > 0 {
+		modeMatch = false
+		for _, candidate := range report.modes {
+			if candidate == mode {
+				modeMatch = true
+				break
+			}
+		}
+	}
+	report.selected = providerMatch && modeMatch
+	switch {
+	case !providerMatch:
+		report.readiness = "filtered-provider"
+	case !modeMatch:
+		report.readiness = "filtered-mode"
+	case report.inputKind == "resolver":
+		report.readiness = "configured-only"
+	default:
+		if err := validateStatusCredentialSource(credential, rawMap, policyBase); err != nil {
+			return credentialSelectionReport{}, err
+		}
+		report.readiness = "ready"
+	}
+	reasons := make([]string, 0, 2)
+	if providerMatch {
+		if len(report.providers) == 0 {
+			reasons = append(reasons, "providers not restricted")
+		} else {
+			reasons = append(reasons, "agent matches providers")
+		}
+	} else {
+		reasons = append(reasons, "agent does not match providers")
+	}
+	if modeMatch {
+		if len(report.modes) == 0 {
+			reasons = append(reasons, "modes not restricted")
+		} else {
+			reasons = append(reasons, "mode matches modes")
+		}
+	} else {
+		reasons = append(reasons, "mode does not match modes")
+	}
+	report.reason = strings.Join(reasons, "; ")
+	return report, nil
+}
+
+func explainReadyStates(policy map[string]any, policyBase string, agent string, mode string) (map[string]string, map[string]string, error) {
+	providerReadyStates := map[string]string{}
+	sharedReadyStates := map[string]string{}
+	credentials, _ := policy["credentials"].(map[string]any)
+	if credentials == nil {
+		return providerReadyStates, sharedReadyStates, nil
+	}
+
+	relevant := map[string]struct{}{}
+	for key := range SharedCredentialKeys {
+		relevant[key] = struct{}{}
+	}
+	for key := range AgentScopedCredentialKeys[agent] {
+		relevant[key] = struct{}{}
+	}
+	keys := make([]string, 0, len(relevant))
+	for key := range relevant {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if _, ok := credentials[key]; !ok {
+			continue
+		}
+		report, err := explainCredentialSelection(policy, policyBase, key, agent, mode)
+		if err != nil {
+			return nil, nil, err
+		}
+		if report.readiness == "" || report.readiness == "absent" {
+			continue
+		}
+		if _, ok := SharedCredentialKeys[key]; ok {
+			sharedReadyStates[key] = report.readiness
+		} else {
+			providerReadyStates[key] = report.readiness
+		}
+	}
+	return providerReadyStates, sharedReadyStates, nil
+}
+
+func boolToInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
 }
 
 func printSetOutput(stdout io.Writer, opts setOptions) {
@@ -973,23 +1348,8 @@ func validateAgentCredential(agent string, credential string) error {
 }
 
 func validateSelectorValues(values any, label string, allowedValues map[string]struct{}) error {
-	if values == nil {
-		return nil
-	}
-	rawValues, ok := values.([]any)
-	if !ok || len(rawValues) == 0 {
-		return die(fmt.Sprintf("%s must be a non-empty array when specified", label))
-	}
-	for _, value := range rawValues {
-		s, ok := value.(string)
-		if !ok {
-			return die(fmt.Sprintf("%s values must be strings", label))
-		}
-		if _, ok := allowedValues[s]; !ok {
-			return die(fmt.Sprintf("%s contains unsupported value: %s", label, s))
-		}
-	}
-	return nil
+	_, err := selectorStrings(values, label, allowedValues)
+	return err
 }
 
 func validateStatusCredentialEntry(key string, raw any) error {
@@ -1070,6 +1430,98 @@ func renderModes(keys []string) string {
 		return "none"
 	}
 	return strings.Join(keys, ",")
+}
+
+func renderTextDiff(fromName string, toName string, fromText string, toText string) string {
+	fromLines := splitDiffLines(fromText)
+	toLines := splitDiffLines(toText)
+	matrix := make([][]int, len(fromLines)+1)
+	for i := range matrix {
+		matrix[i] = make([]int, len(toLines)+1)
+	}
+	for i := len(fromLines) - 1; i >= 0; i-- {
+		for j := len(toLines) - 1; j >= 0; j-- {
+			if fromLines[i] == toLines[j] {
+				matrix[i][j] = matrix[i+1][j+1] + 1
+				continue
+			}
+			if matrix[i+1][j] >= matrix[i][j+1] {
+				matrix[i][j] = matrix[i+1][j]
+			} else {
+				matrix[i][j] = matrix[i][j+1]
+			}
+		}
+	}
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "--- %s\n", fromName)
+	fmt.Fprintf(&builder, "+++ %s\n", toName)
+	i, j := 0, 0
+	for i < len(fromLines) && j < len(toLines) {
+		if fromLines[i] == toLines[j] {
+			builder.WriteByte(' ')
+			builder.WriteString(fromLines[i])
+			builder.WriteByte('\n')
+			i++
+			j++
+			continue
+		}
+		if matrix[i+1][j] >= matrix[i][j+1] {
+			builder.WriteByte('-')
+			builder.WriteString(fromLines[i])
+			builder.WriteByte('\n')
+			i++
+			continue
+		}
+		builder.WriteByte('+')
+		builder.WriteString(toLines[j])
+		builder.WriteByte('\n')
+		j++
+	}
+	for ; i < len(fromLines); i++ {
+		builder.WriteByte('-')
+		builder.WriteString(fromLines[i])
+		builder.WriteByte('\n')
+	}
+	for ; j < len(toLines); j++ {
+		builder.WriteByte('+')
+		builder.WriteString(toLines[j])
+		builder.WriteByte('\n')
+	}
+	return builder.String()
+}
+
+func splitDiffLines(text string) []string {
+	if text == "" {
+		return nil
+	}
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	if strings.HasSuffix(text, "\n") {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+func selectorStrings(values any, label string, allowedValues map[string]struct{}) ([]string, error) {
+	if values == nil {
+		return nil, nil
+	}
+	rawValues, ok := values.([]any)
+	if !ok || len(rawValues) == 0 {
+		return nil, die(fmt.Sprintf("%s must be a non-empty array when specified", label))
+	}
+	parsed := make([]string, 0, len(rawValues))
+	for _, value := range rawValues {
+		s, ok := value.(string)
+		if !ok {
+			return nil, die(fmt.Sprintf("%s values must be strings", label))
+		}
+		if _, ok := allowedValues[s]; !ok {
+			return nil, die(fmt.Sprintf("%s contains unsupported value: %s", label, s))
+		}
+		parsed = append(parsed, s)
+	}
+	return parsed, nil
 }
 
 func credentialInputKind(raw any) string {

--- a/internal/authpolicy/manage_test.go
+++ b/internal/authpolicy/manage_test.go
@@ -287,6 +287,31 @@ func TestPolicyWhyExplainsWhenCredentialIsNotSelected(t *testing.T) {
 	mustContain(t, got.stdout, "credential_input_kind=source")
 }
 
+func TestPolicyWhyTreatsOutOfScopeCredentialAsNotSelected(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	writeFile(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.claude_api_key]",
+		`source = "/no/such/file"`,
+	}, "\n")+"\n", 0o600)
+
+	got := runAuthPolicy(
+		"why",
+		"--policy", policyPath,
+		"--credential", "claude_api_key",
+		"--agent", "codex",
+		"--mode", "strict",
+	)
+	if got.code != 0 {
+		t.Fatalf("Run(why) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stdout, "selected=0")
+	mustContain(t, got.stdout, "selection_reason=credential is not in scope for agent codex")
+	mustContain(t, got.stdout, "credential_readiness=out-of-scope")
+	mustContain(t, got.stdout, "credential_input_kind=source")
+}
+
 func TestPolicyInspectionCommandsFailClosedOnMissingPolicy(t *testing.T) {
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "missing.toml")

--- a/internal/authpolicy/manage_test.go
+++ b/internal/authpolicy/manage_test.go
@@ -64,6 +64,13 @@ func mustContain(tb testing.TB, text, want string) {
 	}
 }
 
+func mustNotContain(tb testing.TB, text, want string) {
+	tb.Helper()
+	if strings.Contains(text, want) {
+		tb.Fatalf("%q unexpectedly contains %q", text, want)
+	}
+}
+
 func pathVariants(path string) []string {
 	var variants []string
 	seen := map[string]struct{}{}
@@ -152,6 +159,210 @@ func TestStatusWithoutPolicyReportsNone(t *testing.T) {
 	mustContain(t, got.stdout, "credential_resolution_states=none")
 }
 
+func TestPolicyInspectionCommandsShowValidateAndDiff(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	sourcePath := filepath.Join(root, "auth.json")
+	writeFile(t, sourcePath, "super-secret-token\n", 0o600)
+	writeFile(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"# local note",
+		"[credentials.codex_auth]",
+		`source = "` + sourcePath + `"`,
+		`providers = ["codex"]`,
+		`modes = ["strict"]`,
+	}, "\n")+"\n", 0o600)
+
+	got := runAuthPolicy("show", "--policy", policyPath)
+	if got.code != 0 {
+		t.Fatalf("Run(show) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	if !(strings.Index(got.stdout, `modes = ["strict"]`) < strings.Index(got.stdout, `providers = ["codex"]`) && strings.Index(got.stdout, `providers = ["codex"]`) < strings.Index(got.stdout, `source = "`+sourcePath+`"`)) {
+		t.Fatalf("show output not canonicalized as expected: %q", got.stdout)
+	}
+	mustNotContain(t, got.stdout, "local note")
+
+	got = runAuthPolicy("validate", "--policy", policyPath)
+	if got.code != 0 {
+		t.Fatalf("Run(validate) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stdout, "policy_valid=1")
+	mustContain(t, got.stdout, "resolver_readiness=not-applicable")
+
+	got = runAuthPolicy("diff", "--policy", policyPath)
+	if got.code != 0 {
+		t.Fatalf("Run(diff) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stdout, "diff_status=changed")
+	mustContain(t, got.stdout, "--- current")
+	mustContain(t, got.stdout, "+++ canonical")
+	mustContain(t, got.stdout, "-# local note")
+}
+
+func TestPolicyWhyExplainsSelectionAndHidesSecrets(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	sourcePath := filepath.Join(root, "auth.json")
+	writeFile(t, sourcePath, "super-secret-token\n", 0o600)
+	writeFile(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.codex_auth]",
+		`source = "` + sourcePath + `"`,
+		`providers = ["codex"]`,
+		`modes = ["strict"]`,
+	}, "\n")+"\n", 0o600)
+
+	got := runAuthPolicy(
+		"why",
+		"--policy", policyPath,
+		"--credential", "codex_auth",
+		"--agent", "codex",
+		"--mode", "strict",
+	)
+	if got.code != 0 {
+		t.Fatalf("Run(why) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stdout, "selected=1")
+	mustContain(t, got.stdout, "selection_reason=agent matches providers; mode matches modes")
+	mustContain(t, got.stdout, "credential_readiness=ready")
+	mustContain(t, got.stdout, "credential_input_kind=source")
+	mustContain(t, got.stdout, "credential_providers=codex")
+	mustContain(t, got.stdout, "credential_modes=strict")
+	mustNotContain(t, got.stdout, "super-secret-token")
+}
+
+func TestPolicyWhyExplainsResolverBackedSelection(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	writeFile(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.claude_auth]",
+		`resolver = "claude-macos-keychain"`,
+		`materialization = "ephemeral"`,
+		`providers = ["claude"]`,
+		`modes = ["strict"]`,
+	}, "\n")+"\n", 0o600)
+
+	got := runAuthPolicy(
+		"why",
+		"--policy", policyPath,
+		"--credential", "claude_auth",
+		"--agent", "claude",
+		"--mode", "strict",
+	)
+	if got.code != 0 {
+		t.Fatalf("Run(why) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stdout, "selected=1")
+	mustContain(t, got.stdout, "credential_readiness=configured-only")
+	mustContain(t, got.stdout, "credential_input_kind=resolver")
+	mustContain(t, got.stdout, "credential_resolver=claude-macos-keychain")
+	mustContain(t, got.stdout, "selection_reason=agent matches providers; mode matches modes")
+}
+
+func TestPolicyWhyExplainsWhenCredentialIsNotSelected(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	writeFile(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.codex_auth]",
+		`source = "/tmp/auth.json"`,
+		`providers = ["claude"]`,
+		`modes = ["build"]`,
+	}, "\n")+"\n", 0o600)
+
+	got := runAuthPolicy(
+		"why",
+		"--policy", policyPath,
+		"--credential", "codex_auth",
+		"--agent", "codex",
+		"--mode", "strict",
+	)
+	if got.code != 0 {
+		t.Fatalf("Run(why) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stdout, "selected=0")
+	mustContain(t, got.stdout, "selection_reason=agent does not match providers; mode does not match modes")
+	mustContain(t, got.stdout, "credential_readiness=filtered-provider")
+	mustContain(t, got.stdout, "credential_input_kind=source")
+}
+
+func TestPolicyInspectionCommandsFailClosedOnMissingPolicy(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "missing.toml")
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "show", args: []string{"show", "--policy", policyPath}},
+		{name: "validate", args: []string{"validate", "--policy", policyPath}},
+		{name: "diff", args: []string{"diff", "--policy", policyPath}},
+		{name: "why", args: []string{"why", "--policy", policyPath, "--credential", "codex_auth", "--agent", "codex", "--mode", "strict"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runAuthPolicy(tc.args...)
+			if got.code != 1 {
+				t.Fatalf("Run(%s) = %d stdout=%q stderr=%q", tc.name, got.code, got.stdout, got.stderr)
+			}
+			mustContainAny(t, got.stderr, "does not exist", "no such file or directory")
+		})
+	}
+}
+
+func TestValidateRejectsInvalidSelectors(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	sourcePath := filepath.Join(root, "auth.json")
+	writeFile(t, sourcePath, "{}\n", 0o600)
+	writeFile(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.codex_auth]",
+		`source = "` + sourcePath + `"`,
+		`providers = ["bogus"]`,
+	}, "\n")+"\n", 0o600)
+
+	got := runAuthPolicy("validate", "--policy", policyPath)
+	if got.code != 1 {
+		t.Fatalf("Run(validate) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stderr, "credentials.codex_auth.providers contains unsupported value: bogus")
+}
+
+func TestValidateRejectsMissingCredentialSource(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	writeFile(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.codex_auth]",
+		`source = "/no/such/file"`,
+	}, "\n")+"\n", 0o600)
+
+	got := runAuthPolicy("validate", "--policy", policyPath)
+	if got.code != 1 {
+		t.Fatalf("Run(validate) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContainAny(t, got.stderr, "does not exist", "no such file or directory")
+}
+
+func TestValidateReportsResolverReadinessAsDeferred(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	writeFile(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.claude_auth]",
+		`resolver = "claude-macos-keychain"`,
+		`materialization = "ephemeral"`,
+	}, "\n")+"\n", 0o600)
+
+	got := runAuthPolicy("validate", "--policy", policyPath)
+	if got.code != 0 {
+		t.Fatalf("Run(validate) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stdout, "policy_valid=1")
+	mustContain(t, got.stdout, "resolver_readiness=deferred-to-launch")
+}
+
 func TestInitSetStatusUnsetRoundTrip(t *testing.T) {
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "injection-policy.toml")
@@ -200,6 +411,8 @@ func TestInitSetStatusUnsetRoundTrip(t *testing.T) {
 	}
 	mustContain(t, got.stdout, "credential_keys=codex_auth")
 	mustContain(t, got.stdout, "credential_input_kinds=codex_auth:source")
+	mustContain(t, got.stdout, "provider_auth_ready_states=codex_auth:ready")
+	mustContain(t, got.stdout, "shared_auth_ready_states=none")
 	mustContain(t, got.stdout, "provider_auth_mode=codex_auth")
 	mustContain(t, got.stdout, "shared_auth_modes=none")
 
@@ -249,6 +462,8 @@ func TestSetResolverAndStatus(t *testing.T) {
 	mustContain(t, got.stdout, "credential_resolvers=claude_auth:claude-macos-keychain")
 	mustContain(t, got.stdout, "credential_materialization=claude_auth:ephemeral")
 	mustContain(t, got.stdout, "credential_resolution_states=claude_auth:configured-only")
+	mustContain(t, got.stdout, "provider_auth_ready_states=claude_auth:configured-only")
+	mustContain(t, got.stdout, "shared_auth_ready_states=none")
 	mustContain(t, got.stdout, "provider_auth_mode=none")
 	mustContain(t, got.stdout, "shared_auth_modes=none")
 }
@@ -269,6 +484,8 @@ func TestSharedCredentialsAreScopedToRequestedAgent(t *testing.T) {
 	if codexStatus.code != 0 {
 		t.Fatalf("Run(status codex) = %d stdout=%q stderr=%q", codexStatus.code, codexStatus.stdout, codexStatus.stderr)
 	}
+	mustContain(t, codexStatus.stdout, "provider_auth_ready_states=none")
+	mustContain(t, codexStatus.stdout, "shared_auth_ready_states=github_hosts:ready")
 	mustContain(t, codexStatus.stdout, "shared_auth_modes=github_hosts")
 
 	claudeStatus := runAuthPolicy("status", "--policy", policyPath, "--agent", "claude")
@@ -276,6 +493,7 @@ func TestSharedCredentialsAreScopedToRequestedAgent(t *testing.T) {
 		t.Fatalf("Run(status claude) = %d stdout=%q stderr=%q", claudeStatus.code, claudeStatus.stdout, claudeStatus.stderr)
 	}
 	mustContain(t, claudeStatus.stdout, "credential_keys=none")
+	mustContain(t, claudeStatus.stdout, "shared_auth_ready_states=github_hosts:filtered-provider")
 	mustContain(t, claudeStatus.stdout, "shared_auth_modes=none")
 }
 

--- a/internal/authpolicy/policy.go
+++ b/internal/authpolicy/policy.go
@@ -214,24 +214,15 @@ func validateAllowedKeys(table map[string]any, allowedKeys map[string]struct{}, 
 }
 
 func selectedFor(values any, current string, label string, allowedValues map[string]struct{}) (bool, error) {
-	if values == nil {
+	rawValues, err := selectorStrings(values, label, allowedValues)
+	if err != nil {
+		return false, err
+	}
+	if rawValues == nil {
 		return true, nil
 	}
-	rawValues, ok := values.([]any)
-	if !ok || len(rawValues) == 0 {
-		return false, die(fmt.Sprintf("%s must be a non-empty array when specified", label))
-	}
 	for _, value := range rawValues {
-		s, ok := value.(string)
-		if !ok {
-			return false, die(fmt.Sprintf("%s values must be strings", label))
-		}
-		if _, ok := allowedValues[s]; !ok {
-			return false, die(fmt.Sprintf("%s contains unsupported value: %s", label, s))
-		}
-	}
-	for _, value := range rawValues {
-		if value.(string) == current {
+		if value == current {
 			return true, nil
 		}
 	}

--- a/internal/authresolve/resolve_credential_sources.go
+++ b/internal/authresolve/resolve_credential_sources.go
@@ -260,6 +260,8 @@ func run(cfg config) error {
 		"credential_resolvers":         map[string]string{},
 		"credential_materialization":   map[string]string{},
 		"credential_resolution_states": map[string]string{},
+		"provider_auth_ready_states":   map[string]string{},
+		"shared_auth_ready_states":     map[string]string{},
 	}
 
 	for _, key := range relevantKeys {
@@ -270,8 +272,16 @@ func run(cfg config) error {
 
 		rawMap, isMap := raw.(map[string]any)
 		if !isMap {
+			source, err := validateSourcePath(raw, "credentials."+key, cwd())
+			if err != nil {
+				return err
+			}
+			if _, err := requireSecretFile(source, "credentials."+key); err != nil {
+				return err
+			}
 			metadata["credential_input_kinds"].(map[string]string)[key] = "source"
 			metadata["credential_resolution_states"].(map[string]string)[key] = "source"
+			recordAuthReadyState(metadata, key, "ready")
 			continue
 		}
 
@@ -287,6 +297,7 @@ func run(cfg config) error {
 			return err
 		}
 		if !ok {
+			recordAuthReadyState(metadata, key, "filtered-provider")
 			if resolverName != "" {
 				delete(credentialTable, key)
 			}
@@ -297,6 +308,7 @@ func run(cfg config) error {
 			return err
 		}
 		if !ok {
+			recordAuthReadyState(metadata, key, "filtered-mode")
 			if resolverName != "" {
 				delete(credentialTable, key)
 			}
@@ -311,8 +323,16 @@ func run(cfg config) error {
 			return fmt.Errorf("credentials.%s must declare source or resolver", key)
 		}
 		if resolverName == "" {
+			source, err := validateSourcePath(rawMap["source"], "credentials."+key, cwd())
+			if err != nil {
+				return err
+			}
+			if _, err := requireSecretFile(source, "credentials."+key); err != nil {
+				return err
+			}
 			metadata["credential_input_kinds"].(map[string]string)[key] = "source"
 			metadata["credential_resolution_states"].(map[string]string)[key] = "source"
+			recordAuthReadyState(metadata, key, "ready")
 			continue
 		}
 
@@ -361,6 +381,7 @@ func run(cfg config) error {
 		metadata["credential_resolvers"].(map[string]string)[key] = resolverName
 		metadata["credential_materialization"].(map[string]string)[key] = materialization
 		metadata["credential_resolution_states"].(map[string]string)[key] = state
+		recordAuthReadyState(metadata, key, authReadyStateForResolution(state))
 	}
 
 	renderedPolicy, err := renderPolicyTOML(policy)
@@ -378,6 +399,23 @@ func run(cfg config) error {
 		return err
 	}
 	return nil
+}
+
+func recordAuthReadyState(metadata map[string]any, key, state string) {
+	if _, ok := sharedCredentialKeys[key]; ok {
+		metadata["shared_auth_ready_states"].(map[string]string)[key] = state
+		return
+	}
+	metadata["provider_auth_ready_states"].(map[string]string)[key] = state
+}
+
+func authReadyStateForResolution(state string) string {
+	switch state {
+	case "resolved", "source":
+		return "ready"
+	default:
+		return state
+	}
 }
 
 func selectedCredentialKeys(agent string) []string {

--- a/internal/authresolve/resolve_credential_sources_test.go
+++ b/internal/authresolve/resolve_credential_sources_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/hostutil"
 )
 
 type fileSnapshot struct {
@@ -75,11 +77,20 @@ func readJSON(tb testing.TB, path string) map[string]any {
 func TestRunMetadataModeWritesPlaceholderAndMetadata(t *testing.T) {
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
+	githubHostsPath := filepath.Join(root, "hosts.yml")
+	claudeApiKeyPath := filepath.Join(root, "claude-api-key.json")
+	writePolicy(t, githubHostsPath, "github.com:\n")
+	writePolicy(t, claudeApiKeyPath, "{\"token\":\"unused\"}\n")
 	writePolicy(t, policyPath, strings.Join([]string{
 		"version = 1",
+		"[credentials.github_hosts]",
+		`source = "` + githubHostsPath + `"`,
 		"[credentials.claude_auth]",
 		`resolver = "claude-macos-keychain"`,
 		`materialization = "ephemeral"`,
+		"[credentials.claude_api_key]",
+		`source = "` + claudeApiKeyPath + `"`,
+		`providers = ["gemini"]`,
 	}, "\n")+"\n")
 
 	outputRoot := filepath.Join(root, "out")
@@ -121,10 +132,33 @@ func TestRunMetadataModeWritesPlaceholderAndMetadata(t *testing.T) {
 	if got := metadata["credential_input_kinds"].(map[string]any)["claude_auth"]; got != "resolver" {
 		t.Fatalf("credential_input_kinds.claude_auth = %v", got)
 	}
+	if got := metadata["provider_auth_ready_states"].(map[string]any)["claude_auth"]; got != "configured-only" {
+		t.Fatalf("provider_auth_ready_states.claude_auth = %v", got)
+	}
+	if got := metadata["provider_auth_ready_states"].(map[string]any)["claude_api_key"]; got != "filtered-provider" {
+		t.Fatalf("provider_auth_ready_states.claude_api_key = %v", got)
+	}
+	if got := metadata["shared_auth_ready_states"].(map[string]any)["github_hosts"]; got != "ready" {
+		t.Fatalf("shared_auth_ready_states.github_hosts = %v", got)
+	}
 	assertSnapshotEqual(t, filepath.Join(resolvedOutputRoot, "resolved", "credentials", "claude_auth.json"), fileSnapshot{
 		data: []byte("{\"resolver\": \"claude-macos-keychain\", \"workcell\": \"metadata-only\"}\n"),
 		mode: 0o600,
 	})
+
+	lines, err := hostutil.ResolverMetadataLines(filepath.Join(resolvedOutputRoot, "resolver-metadata.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 6 {
+		t.Fatalf("ResolverMetadataLines() len = %d, want 6", len(lines))
+	}
+	if lines[4] != "claude_api_key:filtered-provider,claude_auth:configured-only" {
+		t.Fatalf("provider ready line = %q", lines[4])
+	}
+	if lines[5] != "github_hosts:ready" {
+		t.Fatalf("shared ready line = %q", lines[5])
+	}
 }
 
 func TestRunLaunchModeFailsClosedWithoutSupportedExportPath(t *testing.T) {
@@ -203,6 +237,40 @@ func TestRunLaunchModeAcceptsTestExportFile(t *testing.T) {
 		data: []byte("{\"token\":\"claude\"}\n"),
 		mode: 0o600,
 	})
+}
+
+func TestRunMetadataModeRejectsMissingSourceCredential(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	writePolicy(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.codex_auth]",
+		`source = "/no/such/file"`,
+	}, "\n")+"\n")
+	outputRoot := filepath.Join(root, "out")
+	if err := os.MkdirAll(outputRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	resolvedOutputRoot, err := filepath.EvalSymlinks(outputRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := runResolveCredentialSources(t, []string{
+		"--policy", policyPath,
+		"--agent", "codex",
+		"--mode", "strict",
+		"--resolution-mode", "metadata",
+		"--output-policy", filepath.Join(resolvedOutputRoot, "resolved-policy.toml"),
+		"--output-metadata", filepath.Join(resolvedOutputRoot, "resolver-metadata.json"),
+		"--output-root", resolvedOutputRoot,
+	}, nil)
+	if code != 1 {
+		t.Fatalf("Run() = %d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "does not exist") && !strings.Contains(stderr, "no such file or directory") {
+		t.Fatalf("stderr %q missing missing-source failure", stderr)
+	}
 }
 
 func TestMaterializeFileUnderRootRejectsValidatedSourceSwappedToSymlink(t *testing.T) {

--- a/internal/hostutil/launcher.go
+++ b/internal/hostutil/launcher.go
@@ -413,6 +413,8 @@ func ResolverMetadataLines(metadataPath string) ([]string, error) {
 		renderStringMap(metadata["credential_resolvers"]),
 		renderStringMap(metadata["credential_materialization"]),
 		renderStringMap(metadata["credential_resolution_states"]),
+		renderStringMap(metadata["provider_auth_ready_states"]),
+		renderStringMap(metadata["shared_auth_ready_states"]),
 	}, nil
 }
 

--- a/internal/hostutil/sessions.go
+++ b/internal/hostutil/sessions.go
@@ -25,6 +25,9 @@ type SessionRecord struct {
 	UI                    string `json:"ui,omitempty"`
 	ExecutionPath         string `json:"execution_path,omitempty"`
 	Workspace             string `json:"workspace"`
+	GitBranch             string `json:"git_branch,omitempty"`
+	GitHead               string `json:"git_head,omitempty"`
+	GitBase               string `json:"git_base,omitempty"`
 	ContainerName         string `json:"container_name,omitempty"`
 	SessionAuditDir       string `json:"session_audit_dir,omitempty"`
 	AuditLogPath          string `json:"audit_log_path,omitempty"`
@@ -47,6 +50,15 @@ type SessionListOptions struct {
 type SessionExport struct {
 	Session      SessionRecord `json:"session"`
 	AuditRecords []string      `json:"audit_records,omitempty"`
+}
+
+func SessionDiffMetadataLines(record SessionRecord) []string {
+	return []string{
+		fmt.Sprintf("workspace=%s", record.Workspace),
+		fmt.Sprintf("git_branch=%s", record.GitBranch),
+		fmt.Sprintf("git_head=%s", record.GitHead),
+		fmt.Sprintf("git_base=%s", record.GitBase),
+	}
 }
 
 func WriteSessionRecord(path string, updates map[string]string) error {
@@ -75,6 +87,12 @@ func WriteSessionRecord(path string, updates map[string]string) error {
 			record.ExecutionPath = value
 		case "workspace":
 			record.Workspace = value
+		case "git_branch":
+			record.GitBranch = value
+		case "git_head":
+			record.GitHead = value
+		case "git_base":
+			record.GitBase = value
 		case "container_name":
 			record.ContainerName = value
 		case "session_audit_dir":
@@ -117,7 +135,7 @@ func WriteSessionRecord(path string, updates map[string]string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o600)
+	return writeFileAtomically(path, data, 0o600)
 }
 
 func ReadSessionRecord(path string) (SessionRecord, error) {
@@ -279,6 +297,41 @@ func auditLineHasSessionID(line, sessionID string) bool {
 		}
 	}
 	return false
+}
+
+func writeFileAtomically(path string, data []byte, mode os.FileMode) error {
+	tempFile, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if err := tempFile.Chmod(mode); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if _, err := tempFile.Write(data); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Sync(); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return err
+	}
+	removeTemp = false
+	return os.Chmod(path, mode)
 }
 
 func validateSessionRecord(record SessionRecord, source string) error {

--- a/internal/hostutil/sessions_test.go
+++ b/internal/hostutil/sessions_test.go
@@ -25,6 +25,9 @@ func TestWriteSessionRecordRoundTrip(t *testing.T) {
 		"ui":                      "cli",
 		"execution_path":          "managed-tier1",
 		"workspace":               "/tmp/workspace",
+		"git_branch":              "feature/session-diff",
+		"git_head":                "abcdef1234567890",
+		"git_base":                "1234567890abcdef",
 		"started_at":              "2026-04-08T12:00:00Z",
 		"initial_assurance":       "managed-mutable",
 		"workspace_control_plane": "masked",
@@ -50,6 +53,46 @@ func TestWriteSessionRecordRoundTrip(t *testing.T) {
 	}
 	if record.Status != "exited" || record.ExitStatus != "0" || record.FinalAssurance != "managed-mutable" {
 		t.Fatalf("unexpected record: %+v", record)
+	}
+	if record.GitBranch != "feature/session-diff" || record.GitHead != "abcdef1234567890" || record.GitBase != "1234567890abcdef" {
+		t.Fatalf("git metadata was not preserved: %+v", record)
+	}
+	info, err := os.Stat(recordPath)
+	if err != nil {
+		t.Fatalf("Stat(%s) error = %v", recordPath, err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("session record mode = %o, want 0600", info.Mode().Perm())
+	}
+	entries, err := os.ReadDir(filepath.Dir(recordPath))
+	if err != nil {
+		t.Fatalf("ReadDir(%s) error = %v", filepath.Dir(recordPath), err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "session-1.json" {
+		t.Fatalf("session record directory contains unexpected files: %+v", entries)
+	}
+}
+
+func TestSessionDiffMetadataLines(t *testing.T) {
+	t.Parallel()
+
+	lines := SessionDiffMetadataLines(SessionRecord{
+		Workspace: "/tmp/workspace",
+	})
+
+	want := []string{
+		"workspace=/tmp/workspace",
+		"git_branch=",
+		"git_head=",
+		"git_base=",
+	}
+	if len(lines) != len(want) {
+		t.Fatalf("SessionDiffMetadataLines() len = %d, want %d", len(lines), len(want))
+	}
+	for i := range want {
+		if lines[i] != want[i] {
+			t.Fatalf("SessionDiffMetadataLines()[%d] = %q, want %q", i, lines[i], want[i])
+		}
 	}
 }
 

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -1,4 +1,4 @@
-.TH WORKCELL 1 "2026-04-08" "Workcell" "User Commands"
+.TH WORKCELL 1 "2026-04-14" "Workcell" "User Commands"
 .SH NAME
 workcell \- bounded runtime launcher for coding agents
 .SH SYNOPSIS
@@ -9,10 +9,16 @@ workcell \- bounded runtime launcher for coding agents
 [\fIoptions\fR]
 .br
 .B workcell session
-\fIlist|show|export\fR [\fIoptions\fR]
+\fIlist|show|diff|export\fR [\fIoptions\fR]
 .br
 .B workcell auth
 \fIinit|set|unset|status\fR [\fIoptions\fR]
+.br
+.B workcell policy
+\fIshow|validate|diff\fR [\fIoptions\fR]
+.br
+.B workcell why
+--credential \fIKEY\fR --agent \fINAME\fR [\fIoptions\fR]
 .SH DESCRIPTION
 .B workcell
 starts the selected coding agent inside a bounded local runtime with explicit
@@ -32,10 +38,18 @@ as the exec-capable temporary directory via
 .BR TMPDIR .
 The supported host platform is Apple Silicon macOS.
 .TP
-.B workcell session list|show|export
+.B workcell session list|show|diff|export
 Inspect durable host-side session records without starting the Workcell
-runtime. These records summarize completed or aborted launches and can be
-exported with the matching profile audit lines.
+runtime. These records summarize completed or aborted launches, can render a
+read-only diff against the clean launch git base when one was recorded, and
+can be exported with the matching profile audit lines.
+.TP
+.B workcell policy show|validate|diff
+Inspect the merged host-side injection policy without starting the runtime.
+.TP
+.B workcell why
+Explain why a credential is selected, filtered, or still only configured for a
+specific agent and mode without starting the runtime.
 .SH OPTIONS
 .TP
 .B --agent codex|claude|gemini
@@ -156,6 +170,17 @@ Manage explicit host-side credential policy state without starting the Workcell
 runtime. Resolver-backed credentials are still host-only preprocessing and do
 not pass Keychain or provider-home access into Tier 1.
 .TP
+.B workcell policy show|validate|diff
+Render the merged policy, validate fail-closed source-backed entries, or diff
+the selected entrypoint file against the canonical merged render.
+.TP
+.B workcell why
+Explain one credential decision, including selector filtering and whether the
+selected entry is ready or still configured-only on the host. When omitted,
+.B --mode
+defaults to
+.BR strict .
+.TP
 .B --log-level normal|debug
 Select launch-time logging verbosity. The default is
 .BR normal .
@@ -163,6 +188,10 @@ Use
 .BR debug
 to surface successful Colima and runtime-build output in addition to the normal
 high-signal launcher messages.
+.TP
+.B --no-spinner
+Disable the interactive launch spinner and fall back to heartbeat text updates
+instead. This affects only interactive launch and prepare flows.
 .TP
 .B --debug-log PATH
 Persist launcher stderr plus any build/output streams that Workcell explicitly

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -175,8 +175,9 @@ Render the merged policy, validate fail-closed source-backed entries, or diff
 the selected entrypoint file against the canonical merged render.
 .TP
 .B workcell why
-Explain one credential decision, including selector filtering and whether the
-selected entry is ready or still configured-only on the host. When omitted,
+Explain one credential decision, including agent scope, selector filtering, and
+whether the selected entry is ready or still configured-only on the host. When
+omitted,
 .B --mode
 defaults to
 .BR strict .

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -41,8 +41,9 @@ The supported host platform is Apple Silicon macOS.
 .B workcell session list|show|diff|export
 Inspect durable host-side session records without starting the Workcell
 runtime. These records summarize completed or aborted launches, can render a
-read-only diff against the clean launch git base when one was recorded, and
-can be exported with the matching profile audit lines.
+read-only diff against the clean launch git base when one was recorded, fail
+closed when the session started dirty or lacks self-contained git metadata,
+and can be exported with the matching profile audit lines.
 .TP
 .B workcell policy show|validate|diff
 Inspect the merged host-side injection policy without starting the runtime.

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -70,20 +70,23 @@ docs = [
 
 [functional.FR-006]
 title = "Host-side operator commands"
-summary = "Inspect, doctor, logs, gc, and auth/session management run on the host without starting the runtime."
+summary = "Inspect, doctor, logs, gc, auth/policy explainability, and session management run on the host without starting the runtime."
 evidence = [
   "scripts/verify-invariants.sh",
   "internal/testkit/validation_entrypoints_test.go",
+  "tests/scenarios/shared/test-policy-commands.sh",
+  "internal/authpolicy/manage_test.go",
 ]
 docs = [
   "README.md",
   "man/workcell.1",
+  "docs/injection-policy.md",
   "docs/validation-scenarios.md",
 ]
 
 [functional.FR-007]
 title = "Durable session inventory"
-summary = "Workcell records durable host-side launch metadata and exposes list, show, and export commands for recorded sessions."
+summary = "Workcell records durable host-side launch metadata and exposes list, show, clean-base diff, and export commands for recorded sessions."
 evidence = [
   "tests/scenarios/shared/test-session-commands.sh",
   "internal/hostutil/sessions_test.go",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "e2303e9ceef4380be81437f4ffd8dbada5f48883b13e7cdb550b1197e8ad93f6"
+      "sha256": "9eedcc207c3a7db5beb2d0ecd97239e7dc80afeda092ace622b0f520092662e8"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "9eedcc207c3a7db5beb2d0ecd97239e7dc80afeda092ace622b0f520092662e8"
+      "sha256": "e82273d77f39e5fc1a8c0d3ed7598538c1329f3100bdcfe11dafca4aea0d6c1b"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1226,6 +1226,11 @@ if ! grep -q -- '--no-default-injection-policy' /tmp/workcell-installed-help.out
   exit 1
 fi
 
+if ! grep -q -- '--no-spinner' /tmp/workcell-installed-help.out; then
+  echo "Expected installed ~/.local/bin/workcell --help to describe --no-spinner" >&2
+  exit 1
+fi
+
 if ! grep -q 'Provider to run (required)' /tmp/workcell-installed-help.out; then
   echo "Expected installed ~/.local/bin/workcell --help to describe --agent as required" >&2
   exit 1

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -2009,7 +2009,8 @@ Notes:
   - `session diff` is read-only and compares the current workspace state to the
     clean launch git base recorded when the session started.
   - `session diff` is unavailable when the session started from a dirty git
-    worktree or from a workspace without a recorded git base.
+    worktree, from a workspace without a recorded git base, or from a workspace
+    that is not a self-contained git worktree.
   - `session export` includes audit records that match the recorded session id.
 EOF
 }

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -197,17 +197,22 @@ INJECTION_CREDENTIAL_INPUT_KINDS=""
 INJECTION_CREDENTIAL_RESOLVERS=""
 INJECTION_CREDENTIAL_MATERIALIZATION=""
 INJECTION_CREDENTIAL_RESOLUTION_STATES=""
+INJECTION_PROVIDER_AUTH_READY_STATES=""
+INJECTION_SHARED_AUTH_READY_STATES=""
 INJECTION_EXTRA_ENDPOINTS=""
 INJECTION_SSH_ENABLED=0
 INJECTION_SECRET_COPY_TARGETS=""
 PROFILE_LOCK_DIR=""
+NO_SPINNER=0
 
 usage() {
   cat <<'EOF'
 Usage: workcell [options] [-- provider-args...]
        workcell publish-pr [options]
-       workcell session <list|show|export> [options]
+       workcell session <list|show|diff|export> [options]
        workcell auth <init|set|unset|status> [options]
+       workcell policy <show|validate|diff> [options]
+       workcell why --credential KEY --agent NAME [options]
 
 Options:
   --agent codex|claude|gemini   Provider to run (required)
@@ -223,6 +228,7 @@ Options:
   --injection-policy PATH       Host-side injection policy to stage into each session
   --no-default-injection-policy Ignore ~/.config/workcell/injection-policy.toml for this launch
   --log-level normal|debug      Launcher/build verbosity (default: normal)
+  --no-spinner                  Disable the interactive launch spinner and use heartbeat text instead
   --debug-log PATH              Persist launcher stderr and captured build output to PATH
   --file-trace-log PATH         Persist session file transaction trace to PATH
   --audit-transcript PATH       Persist full interactive terminal transcript to PATH
@@ -282,8 +288,11 @@ Workflows:
     workcell auth set --agent codex --credential codex_auth --source /path/to/auth.json
     workcell auth set --agent claude --credential claude_auth --resolver claude-macos-keychain --ack-host-resolver
     workcell auth status --agent codex
+    workcell policy validate
+    workcell why --credential codex_auth --agent codex --mode strict
     workcell session list
     workcell session show --id 20260408T120000Z-1a2b3c4d
+    workcell session diff --id 20260408T120000Z-1a2b3c4d
     workcell session export --id 20260408T120000Z-1a2b3c4d
     workcell --agent codex --inspect --workspace /path/to/repo
     workcell --agent codex --doctor --workspace /path/to/repo
@@ -1334,11 +1343,27 @@ write_session_record_initial() {
   local profile="$1"
   local execution_path="$2"
   local sessions_dir=""
+  local git_branch=""
+  local git_head=""
+  local git_base=""
 
   [[ -n "${SESSION_ID}" ]] || SESSION_ID="$(generate_session_id)"
   sessions_dir="$(profile_sessions_dir_path "${profile}")"
   mkdir -p "${sessions_dir}"
   SESSION_RECORD_PATH="${sessions_dir}/${SESSION_ID}.json"
+  while IFS= read -r line; do
+    case "${line%%=*}" in
+      git_branch)
+        git_branch="${line#*=}"
+        ;;
+      git_head)
+        git_head="${line#*=}"
+        ;;
+      git_base)
+        git_base="${line#*=}"
+        ;;
+    esac
+  done < <(session_git_metadata_lines "${WORKSPACE}")
   write_session_record "${SESSION_RECORD_PATH}" \
     "session_id=${SESSION_ID}" \
     "profile=${profile}" \
@@ -1354,6 +1379,9 @@ write_session_record_initial() {
     "debug_log_path=${DEBUG_LOG_PATH}" \
     "file_trace_log_path=${FILE_TRACE_LOG_PATH}" \
     "transcript_log_path=${AUDIT_TRANSCRIPT_PATH}" \
+    "git_branch=${git_branch}" \
+    "git_head=${git_head}" \
+    "git_base=${git_base}" \
     "started_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
     "initial_assurance=$(session_assurance_initial)" \
     "workspace_control_plane=$(workspace_control_plane_state)"
@@ -1731,7 +1759,7 @@ publish_pr_has_remote_origin() {
 publish_pr_has_worktree_changes() {
   local workspace="$1"
 
-  [[ -n "$(run_clean_host_command_in_dir "${workspace}" "${HOST_GIT_BIN}" status --short --untracked-files=all)" ]]
+  workspace_git_has_worktree_changes "${workspace}"
 }
 publish_pr_has_staged_changes() {
   local workspace="$1"
@@ -1955,6 +1983,7 @@ session_usage() {
   cat <<'EOF'
 Usage: workcell session list [options]
        workcell session show --id SESSION_ID
+       workcell session diff --id SESSION_ID [--output PATH]
        workcell session export --id SESSION_ID [--output PATH]
 
 Commands:
@@ -1966,6 +1995,10 @@ Commands:
   show
     --id SESSION_ID           Show one recorded session as JSON
 
+  diff
+    --id SESSION_ID           Diff the current workspace against the recorded launch git base
+    --output PATH             Write the rendered diff bundle to PATH instead of stdout
+
   export
     --id SESSION_ID           Export one recorded session plus matching audit records as JSON
     --output PATH             Write the exported JSON bundle to PATH instead of stdout
@@ -1973,8 +2006,79 @@ Commands:
 Notes:
   - session commands run on the host and do not start the Workcell runtime.
   - records are durable host-side metadata for completed or aborted launches.
+  - `session diff` is read-only and compares the current workspace state to the
+    clean launch git base recorded when the session started.
+  - `session diff` is unavailable when the session started from a dirty git
+    worktree or from a workspace without a recorded git base.
   - `session export` includes audit records that match the recorded session id.
 EOF
+}
+
+session_git_metadata_lines() {
+  local workspace="$1"
+  local git_branch=""
+  local git_head=""
+  local git_base=""
+
+  if workspace_is_git_worktree "${workspace}"; then
+    git_branch="$(run_clean_host_command_in_dir "${workspace}" git branch --show-current 2>/dev/null || true)"
+    git_head="$(run_clean_host_command_in_dir "${workspace}" git rev-parse --verify HEAD 2>/dev/null || true)"
+    if [[ -n "${git_head}" ]] && ! workspace_git_has_worktree_changes "${workspace}"; then
+      git_base="${git_head}"
+    fi
+  fi
+
+  printf 'git_branch=%s\n' "${git_branch}"
+  printf 'git_head=%s\n' "${git_head}"
+  printf 'git_base=%s\n' "${git_base}"
+}
+
+render_session_diff_bundle() {
+  local session_id="$1"
+  local workspace="$2"
+  local git_branch="$3"
+  local git_head="$4"
+  local git_base="$5"
+  local status_output=""
+  local diff_output=""
+
+  status_output="$(
+    run_clean_host_command_in_dir "${workspace}" \
+      git \
+      -c core.hooksPath=/dev/null \
+      -c core.fsmonitor=false \
+      -c diff.external= \
+      -c color.ui=false \
+      status --short --untracked-files=all
+  )"
+  diff_output="$(
+    run_clean_host_command_in_dir "${workspace}" \
+      git \
+      -c core.hooksPath=/dev/null \
+      -c core.fsmonitor=false \
+      -c diff.external= \
+      -c color.ui=false \
+      -c pager.diff=false \
+      diff --no-ext-diff --no-textconv --submodule=short "${git_base}" --
+  )"
+
+  printf 'session_id=%s\n' "${session_id}"
+  printf 'workspace=%s\n' "${workspace}"
+  printf 'git_branch=%s\n' "${git_branch:-none}"
+  printf 'git_head=%s\n' "${git_head:-none}"
+  printf 'git_base=%s\n' "${git_base}"
+  printf '\n[status]\n'
+  if [[ -n "${status_output}" ]]; then
+    printf '%s\n' "${status_output}"
+  else
+    printf 'clean\n'
+  fi
+  printf '\n[diff]\n'
+  if [[ -n "${diff_output}" ]]; then
+    printf '%s\n' "${diff_output}"
+  else
+    printf 'clean\n'
+  fi
 }
 
 session_main() {
@@ -1985,6 +2089,11 @@ session_main() {
   local session_id=""
   local output_path=""
   local output=""
+  local metadata=""
+  local git_branch=""
+  local git_head=""
+  local git_base=""
+  local rendered=""
   local -a args=()
 
   shift || true
@@ -2062,6 +2171,92 @@ session_main() {
         exit 2
       }
       go_hostutil launcher session-show "${COLIMA_STATE_ROOT}" "${session_id}"
+      exit 0
+      ;;
+    diff)
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --id)
+            session_id="$(option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          --output)
+            output_path="$(raw_option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          -h | --help)
+            session_usage
+            exit 0
+            ;;
+          *)
+            echo "Unsupported workcell session diff option: $1" >&2
+            session_usage >&2
+            exit 2
+            ;;
+        esac
+      done
+      [[ -n "${session_id}" ]] || {
+        echo "workcell session diff requires --id." >&2
+        exit 2
+      }
+      metadata="$(go_hostutil launcher session-diff-metadata "${COLIMA_STATE_ROOT}" "${session_id}")"
+      while IFS= read -r line; do
+        case "${line%%=*}" in
+          workspace)
+            workspace="${line#*=}"
+            ;;
+          git_branch)
+            git_branch="${line#*=}"
+            ;;
+          git_head)
+            git_head="${line#*=}"
+            ;;
+          git_base)
+            git_base="${line#*=}"
+            ;;
+        esac
+      done <<<"${metadata}"
+      [[ -n "${workspace}" ]] || {
+        echo "session diff record is missing a workspace path: ${session_id}" >&2
+        exit 1
+      }
+      [[ -d "${workspace}" ]] || {
+        echo "Recorded workspace does not exist on the host: ${workspace}" >&2
+        exit 1
+      }
+      if [[ -n "${git_head}" ]] && [[ -z "${git_base}" ]]; then
+        echo "session diff requires a clean git launch baseline; relaunch from a clean workspace: ${session_id}" >&2
+        exit 1
+      fi
+      [[ -n "${git_base}" ]] || {
+        echo "session diff requires recorded git metadata for ${session_id}." >&2
+        exit 1
+      }
+      if [[ -z "${HOST_GIT_BIN}" ]]; then
+        HOST_GIT_BIN="$(resolve_host_tool git /usr/bin/git /opt/homebrew/bin/git /usr/local/bin/git)"
+      fi
+      if ! workspace_is_git_worktree "${workspace}"; then
+        echo "Recorded workspace is no longer a git worktree: ${workspace}" >&2
+        exit 1
+      fi
+      if ! workspace_gitdir_is_self_contained "${workspace}"; then
+        echo "session diff refuses linked worktrees with git admin state outside the workspace: ${workspace}" >&2
+        exit 1
+      fi
+      if ! run_clean_host_command_in_dir "${workspace}" git cat-file -e "${git_base}^{commit}" >/dev/null 2>&1; then
+        echo "session diff refuses to compare against a git base that is not present in the current repository: ${git_base}" >&2
+        exit 1
+      fi
+      rendered="$(render_session_diff_bundle "${session_id}" "${workspace}" "${git_branch}" "${git_head}" "${git_base}")"
+      if [[ -n "${output_path}" ]]; then
+        output_path="$(resolve_host_output_candidate "${output_path}")"
+        mkdir -p "$(dirname "${output_path}")"
+        printf '%s\n' "${rendered}" >"${output_path}"
+        chmod 0600 "${output_path}" 2>/dev/null || true
+        printf 'session_diff=%s\n' "${output_path}"
+      else
+        printf '%s\n' "${rendered}"
+      fi
       exit 0
       ;;
     export)
@@ -2398,6 +2593,163 @@ auth_main() {
   esac
 }
 
+policy_usage() {
+  cat <<'EOF'
+Usage: workcell policy show [options]
+       workcell policy validate [options]
+       workcell policy diff [options]
+
+Commands:
+  show
+    --injection-policy PATH     Policy file to render after include expansion
+
+  validate
+    --injection-policy PATH     Policy file to validate
+
+  diff
+    --injection-policy PATH     Policy file to compare against the canonical merged view
+
+Notes:
+  - policy commands run on the host and do not start the Workcell runtime.
+  - when --injection-policy is omitted, commands use the host default policy path.
+  - show renders the merged effective policy after include expansion.
+  - diff compares the selected entrypoint policy file against that canonical
+    merged effective view.
+  - validate fails closed when the selected policy file is missing or invalid.
+  - validate checks source-backed credential paths, but resolver-backed launch
+    readiness remains deferred to the launch path.
+EOF
+}
+
+policy_main() {
+  local subcommand="${1:-}"
+  local policy_path=""
+  local -a policy_cmd=()
+
+  if [[ "${subcommand}" == "-h" ]] || [[ "${subcommand}" == "--help" ]] || [[ "${subcommand}" == "help" ]]; then
+    policy_usage
+    exit 0
+  fi
+  [[ -n "${subcommand}" ]] || {
+    policy_usage >&2
+    exit 2
+  }
+  shift
+
+  policy_path="$(default_injection_policy_path)"
+  case "${subcommand}" in
+    show | validate | diff)
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --injection-policy)
+            policy_path="$(raw_option_value_or_die "$1" "${2-}")"
+            shift 2
+            ;;
+          -h | --help)
+            policy_usage
+            exit 0
+            ;;
+          *)
+            echo "Unsupported workcell policy ${subcommand} option: $1" >&2
+            policy_usage >&2
+            exit 2
+            ;;
+        esac
+      done
+      policy_path="$(resolve_host_path "${policy_path}")"
+      policy_cmd=(
+        "${ROOT_DIR}/scripts/lib/manage_injection_policy"
+        "${subcommand}"
+        --policy "${policy_path}"
+      )
+      run_clean_host_command "${policy_cmd[@]}"
+      exit 0
+      ;;
+    *)
+      echo "Unsupported workcell policy command: ${subcommand}" >&2
+      policy_usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+why_usage() {
+  cat <<'EOF'
+Usage: workcell why --credential KEY --agent NAME [options]
+
+Options:
+  --credential KEY            Credential key to explain
+  --injection-policy PATH     Policy file to inspect (default: ~/.config/workcell/injection-policy.toml)
+  --agent codex|claude|gemini Agent selector for selection reasoning
+  --mode strict|development|build|breakglass
+                                Selector mode to explain (default: strict)
+
+Notes:
+  - `workcell why` is host-side and read-only.
+  - it explains credential selection, ready state, and policy-source scope.
+EOF
+}
+
+why_main() {
+  local policy_path=""
+  local credential=""
+  local agent=""
+  local mode="strict"
+  local -a why_cmd=()
+
+  policy_path="$(default_injection_policy_path)"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --credential)
+        credential="$(option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      --injection-policy)
+        policy_path="$(raw_option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      --agent)
+        agent="$(option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      --mode)
+        mode="$(option_value_or_die "$1" "${2-}")"
+        shift 2
+        ;;
+      -h | --help)
+        why_usage
+        exit 0
+        ;;
+      *)
+        echo "Unsupported workcell why option: $1" >&2
+        why_usage >&2
+        exit 2
+        ;;
+    esac
+  done
+  [[ -n "${credential}" ]] || {
+    echo "workcell why requires --credential." >&2
+    exit 2
+  }
+  [[ -n "${agent}" ]] || {
+    echo "workcell why requires --agent." >&2
+    exit 2
+  }
+  policy_path="$(resolve_host_path "${policy_path}")"
+  why_cmd=(
+    "${ROOT_DIR}/scripts/lib/manage_injection_policy"
+    why
+    --policy "${policy_path}"
+    --credential "${credential}"
+    --mode "${mode}"
+  )
+  if [[ -n "${agent}" ]]; then
+    why_cmd+=(--agent "${agent}")
+  fi
+  run_clean_host_command "${why_cmd[@]}"
+  exit 0
+}
+
 default_injection_bundle_parent() {
   resolve_host_path "${REAL_HOME}/Library/Caches/colima/workcell-host-inputs"
 }
@@ -2491,6 +2843,8 @@ prepare_injection_bundle() {
     INJECTION_CREDENTIAL_RESOLVERS=""
     INJECTION_CREDENTIAL_MATERIALIZATION=""
     INJECTION_CREDENTIAL_RESOLUTION_STATES=""
+    INJECTION_PROVIDER_AUTH_READY_STATES=""
+    INJECTION_SHARED_AUTH_READY_STATES=""
     INJECTION_EXTRA_ENDPOINTS=""
     INJECTION_SSH_ENABLED=0
     INJECTION_SSH_CONFIG_ASSURANCE="off"
@@ -2574,6 +2928,8 @@ prepare_injection_bundle() {
   INJECTION_CREDENTIAL_RESOLVERS="$(printf '%s\n' "${resolver_metadata}" | sed -n '2p')"
   INJECTION_CREDENTIAL_MATERIALIZATION="$(printf '%s\n' "${resolver_metadata}" | sed -n '3p')"
   INJECTION_CREDENTIAL_RESOLUTION_STATES="$(printf '%s\n' "${resolver_metadata}" | sed -n '4p')"
+  INJECTION_PROVIDER_AUTH_READY_STATES="$(printf '%s\n' "${resolver_metadata}" | sed -n '5p')"
+  INJECTION_SHARED_AUTH_READY_STATES="$(printf '%s\n' "${resolver_metadata}" | sed -n '6p')"
 }
 
 build_recommended_command() {
@@ -2881,6 +3237,8 @@ print_injection_status() {
     printf 'credential_resolvers=none\n'
     printf 'credential_materialization=none\n'
     printf 'credential_resolution_states=none\n'
+    printf 'provider_auth_ready_states=none\n'
+    printf 'shared_auth_ready_states=none\n'
     printf 'provider_auth_mode=none\n'
     printf 'provider_auth_modes=none\n'
     printf 'shared_auth_modes=none\n'
@@ -2896,6 +3254,8 @@ print_injection_status() {
   printf 'credential_resolvers=%s\n' "${INJECTION_CREDENTIAL_RESOLVERS:-none}"
   printf 'credential_materialization=%s\n' "${INJECTION_CREDENTIAL_MATERIALIZATION:-none}"
   printf 'credential_resolution_states=%s\n' "${INJECTION_CREDENTIAL_RESOLUTION_STATES:-none}"
+  printf 'provider_auth_ready_states=%s\n' "${INJECTION_PROVIDER_AUTH_READY_STATES:-none}"
+  printf 'shared_auth_ready_states=%s\n' "${INJECTION_SHARED_AUTH_READY_STATES:-none}"
   printf 'provider_auth_mode=%s\n' "$(selected_provider_auth_mode)"
   printf 'provider_auth_modes=%s\n' "$(provider_auth_modes)"
   printf 'shared_auth_modes=%s\n' "$(shared_auth_modes)"
@@ -3328,12 +3688,15 @@ run_command_with_debug_log() {
   local log_root=""
   local log_path=""
   local heartbeat_pid=""
+  local spinner_pid=""
+  local spinner_enabled=0
   local tail_pid=""
   local start_seconds=0
   local pid=""
   local status=0
   local timed_out=0
   local timeout_seconds=0
+  local heartbeat_interval_seconds=30
   local next_heartbeat=0
 
   format_elapsed_compact() {
@@ -3346,6 +3709,53 @@ run_command_with_debug_log() {
     else
       printf '%ds' "${seconds}"
     fi
+  }
+
+  progress_summary_line() {
+    local elapsed="$1"
+
+    case "${label}" in
+      colima-start)
+        printf 'Starting managed Colima profile %s... %s elapsed' "${COLIMA_PROFILE}" "${elapsed}"
+        ;;
+      runtime-build)
+        printf 'Preparing runtime image for profile %s... %s elapsed' "${COLIMA_PROFILE}" "${elapsed}"
+        ;;
+      *)
+        printf 'Workcell is still running %s... %s elapsed' "${label}" "${elapsed}"
+        ;;
+    esac
+  }
+
+  clear_progress_spinner_line() {
+    [[ "${spinner_enabled}" -eq 1 ]] || return 0
+    printf '\r\033[2K' >&2
+  }
+
+  start_progress_spinner() {
+    local target_pid="$1"
+    local -a spinner_frames=('|' '/' '-' "\\")
+
+    [[ "${spinner_enabled}" -eq 1 ]] || return 0
+    (
+      local frame_index=0
+      local frame=""
+      while kill -0 "${target_pid}" >/dev/null 2>&1; do
+        frame="${spinner_frames[frame_index]}"
+        printf '\r\033[2K[%s] %s' "${frame}" "$(progress_summary_line "$(format_elapsed_compact "$((SECONDS - start_seconds))")")" >&2
+        frame_index=$(((frame_index + 1) % 4))
+        sleep 0.2
+      done
+    ) &
+    spinner_pid=$!
+  }
+
+  stop_progress_spinner() {
+    [[ -n "${spinner_pid}" ]] || return 0
+    kill "${spinner_pid}" >/dev/null 2>&1 || true
+    wait "${spinner_pid}" 2>/dev/null || true
+    spinner_pid=""
+    clear_progress_spinner_line
   }
 
   maybe_print_progress_update() {
@@ -3402,6 +3812,14 @@ run_command_with_debug_log() {
   chmod 0700 "${log_root}" 2>/dev/null || true
   log_path="$(mktemp "${log_root}/workcell-${label}.log.XXXXXX")"
   start_seconds="${SECONDS}"
+  if [[ -t 2 ]]; then
+    if [[ "${LOG_LEVEL}" != "debug" ]]; then
+      heartbeat_interval_seconds=5
+      if [[ "${NO_SPINNER}" -eq 0 ]] && [[ "${TERM:-}" != "dumb" ]]; then
+        spinner_enabled=1
+      fi
+    fi
+  fi
   case "${label}" in
     colima-start)
       timeout_seconds="${WORKCELL_COLIMA_START_TIMEOUT_SECONDS:-180}"
@@ -3411,7 +3829,11 @@ run_command_with_debug_log() {
   if ((timeout_seconds > 0)); then
     "$@" >"${log_path}" 2>&1 &
     pid=$!
-    next_heartbeat=$((SECONDS + 30))
+    if [[ "${spinner_enabled}" -eq 1 ]]; then
+      start_progress_spinner "${pid}"
+    elif [[ "${LOG_LEVEL}" != "debug" ]]; then
+      next_heartbeat=$((SECONDS + heartbeat_interval_seconds))
+    fi
     if [[ "${LOG_LEVEL}" == "debug" ]]; then
       tail -n +1 -f "${log_path}" >&2 &
       tail_pid=$!
@@ -3421,9 +3843,9 @@ run_command_with_debug_log() {
       if ! kill -0 "${pid}" >/dev/null 2>&1; then
         break
       fi
-      if ((SECONDS >= next_heartbeat)); then
+      if [[ "${spinner_enabled}" -eq 0 ]] && [[ "${LOG_LEVEL}" != "debug" ]] && ((SECONDS >= next_heartbeat)); then
         maybe_print_progress_update heartbeat "$(format_elapsed_compact "$((SECONDS - start_seconds))")"
-        next_heartbeat=$((SECONDS + 30))
+        next_heartbeat=$((SECONDS + heartbeat_interval_seconds))
       fi
       if ((SECONDS - start_seconds >= timeout_seconds)); then
         timed_out=1
@@ -3439,6 +3861,7 @@ run_command_with_debug_log() {
     if ((timed_out == 1)); then
       status=124
     fi
+    stop_progress_spinner
     if [[ -n "${tail_pid}" ]]; then
       kill "${tail_pid}" >/dev/null 2>&1 || true
       wait "${tail_pid}" 2>/dev/null || true
@@ -3459,21 +3882,26 @@ run_command_with_debug_log() {
   else
     "$@" >"${log_path}" 2>&1 &
     pid=$!
-    (
-      while kill -0 "${pid}" >/dev/null 2>&1; do
-        sleep 30
-        if ! kill -0 "${pid}" >/dev/null 2>&1; then
-          break
-        fi
-        maybe_print_progress_update heartbeat "$(format_elapsed_compact "$((SECONDS - start_seconds))")"
-      done
-    ) &
-    heartbeat_pid=$!
+    if [[ "${spinner_enabled}" -eq 1 ]]; then
+      start_progress_spinner "${pid}"
+    else
+      (
+        while kill -0 "${pid}" >/dev/null 2>&1; do
+          sleep "${heartbeat_interval_seconds}"
+          if ! kill -0 "${pid}" >/dev/null 2>&1; then
+            break
+          fi
+          maybe_print_progress_update heartbeat "$(format_elapsed_compact "$((SECONDS - start_seconds))")"
+        done
+      ) &
+      heartbeat_pid=$!
+    fi
     if wait "${pid}"; then
       :
     else
       status=$?
     fi
+    stop_progress_spinner
     if [[ -n "${heartbeat_pid}" ]]; then
       kill "${heartbeat_pid}" >/dev/null 2>&1 || true
       wait "${heartbeat_pid}" 2>/dev/null || true
@@ -4248,6 +4676,17 @@ workspace_is_git_worktree() {
   run_clean_host_command git -C "${workspace}" rev-parse --is-inside-work-tree >/dev/null 2>&1
 }
 
+workspace_git_has_worktree_changes() {
+  local workspace="$1"
+
+  workspace_is_git_worktree "${workspace}" || return 1
+  [[ -n "$(run_clean_host_command_in_dir "${workspace}" "${HOST_GIT_BIN}" \
+    -c core.hooksPath=/dev/null \
+    -c core.fsmonitor=false \
+    -c color.ui=false \
+    status --short --untracked-files=all)" ]]
+}
+
 git_index_has_path() {
   local workspace="$1"
   local relative_path="$2"
@@ -4754,6 +5193,16 @@ if [[ "${1:-}" == "auth" ]]; then
   auth_main "$@"
 fi
 
+if [[ "${1:-}" == "policy" ]]; then
+  shift
+  policy_main "$@"
+fi
+
+if [[ "${1:-}" == "why" ]]; then
+  shift
+  why_main "$@"
+fi
+
 if [[ $# -gt 0 ]]; then
   normalize_cli_aliases "$@"
   set -- "${NORMALIZED_ARGS[@]}"
@@ -4804,6 +5253,10 @@ while [[ $# -gt 0 ]]; do
     --log-level)
       LOG_LEVEL="$(option_value_or_die "$1" "${2-}")"
       shift 2
+      ;;
+    --no-spinner)
+      NO_SPINNER=1
+      shift
       ;;
     --debug-log)
       DEBUG_LOG_PATH="$(raw_option_value_or_die "$1" "${2-}")"

--- a/tests/scenarios/manifest.json
+++ b/tests/scenarios/manifest.json
@@ -24,6 +24,17 @@
       "requires_credentials": false
     },
     {
+      "id": "shared/policy-commands",
+      "description": "Host-side policy commands render, validate, diff, and explain merged credential policy without launching the runtime",
+      "lane": "secretless",
+      "platform": "any",
+      "manual": false,
+      "providers": ["codex", "claude", "gemini"],
+      "persona": "developer",
+      "test_file": "shared/test-policy-commands.sh",
+      "requires_credentials": false
+    },
+    {
       "id": "shared/claude-resolver-launcher",
       "description": "Claude resolver-backed auth fails closed without an export and resolves through the launcher staging path when the test export hook is present",
       "lane": "secretless",
@@ -69,7 +80,7 @@
     },
     {
       "id": "shared/session-commands",
-      "description": "Host-side session inventory lists, shows, and exports durable launch records without starting the runtime",
+      "description": "Host-side session inventory lists, shows, diffs, and exports durable launch records without starting the runtime",
       "lane": "secretless",
       "platform": "any",
       "manual": false,

--- a/tests/scenarios/shared/test-auth-commands.sh
+++ b/tests/scenarios/shared/test-auth-commands.sh
@@ -53,6 +53,8 @@ status_output="$("${ROOT_DIR}/scripts/workcell" auth status \
   --agent codex)"
 grep -q '^credential_keys=codex_auth$' <<<"${status_output}"
 grep -q '^credential_input_kinds=codex_auth:source$' <<<"${status_output}"
+grep -q '^provider_auth_ready_states=codex_auth:ready$' <<<"${status_output}"
+grep -q '^shared_auth_ready_states=none$' <<<"${status_output}"
 grep -q '^provider_auth_mode=codex_auth$' <<<"${status_output}"
 
 resolver_output="$("${ROOT_DIR}/scripts/workcell" auth set \
@@ -69,6 +71,8 @@ claude_status="$("${ROOT_DIR}/scripts/workcell" auth status \
   --agent claude)"
 grep -q '^credential_resolvers=claude_auth:claude-macos-keychain$' <<<"${claude_status}"
 grep -q '^credential_resolution_states=claude_auth:configured-only$' <<<"${claude_status}"
+grep -q '^provider_auth_ready_states=claude_auth:configured-only$' <<<"${claude_status}"
+grep -q '^shared_auth_ready_states=none$' <<<"${claude_status}"
 grep -q '^provider_auth_mode=none$' <<<"${claude_status}"
 grep -q '^provider_auth_modes=none$' <<<"${claude_status}"
 
@@ -78,6 +82,8 @@ claude_launcher_status="$("${ROOT_DIR}/scripts/workcell" \
   --workspace "${TMP_DIR}" \
   --injection-policy "${POLICY_PATH}")"
 grep -q '^credential_resolution_states=claude_auth:configured-only$' <<<"${claude_launcher_status}"
+grep -q '^provider_auth_ready_states=claude_auth:configured-only$' <<<"${claude_launcher_status}"
+grep -q '^shared_auth_ready_states=none$' <<<"${claude_launcher_status}"
 grep -q '^provider_auth_mode=none$' <<<"${claude_launcher_status}"
 grep -q '^provider_auth_modes=none$' <<<"${claude_launcher_status}"
 

--- a/tests/scenarios/shared/test-auth-status.sh
+++ b/tests/scenarios/shared/test-auth-status.sh
@@ -64,6 +64,8 @@ run_auth_status() {
 
 codex_output="$(run_auth_status codex)"
 grep -Eq '^credential_keys=(codex_auth,github_hosts|github_hosts,codex_auth)$' <<<"${codex_output}"
+grep -q '^provider_auth_ready_states=codex_auth:ready$' <<<"${codex_output}"
+grep -q '^shared_auth_ready_states=github_hosts:ready$' <<<"${codex_output}"
 grep -q '^provider_auth_mode=codex_auth$' <<<"${codex_output}"
 grep -q '^provider_auth_modes=codex_auth$' <<<"${codex_output}"
 grep -q '^shared_auth_modes=github_hosts$' <<<"${codex_output}"
@@ -77,15 +79,20 @@ codex_alias_output="$("${ROOT_DIR}/scripts/workcell" \
   --workspace "${WORKSPACE}" \
   --injection-policy "${AUTH_ROOT}/policy.toml")"
 grep -q '^provider_auth_mode=codex_auth$' <<<"${codex_alias_output}"
+grep -q '^provider_auth_ready_states=codex_auth:ready$' <<<"${codex_alias_output}"
 grep -q '^shared_auth_modes=github_hosts$' <<<"${codex_alias_output}"
 
 claude_output="$(run_auth_status claude)"
+grep -q '^provider_auth_ready_states=claude_api_key:ready,claude_auth:ready$' <<<"${claude_output}"
+grep -q '^shared_auth_ready_states=github_hosts:ready$' <<<"${claude_output}"
 grep -q '^provider_auth_mode=claude_api_key$' <<<"${claude_output}"
 grep -q '^provider_auth_modes=claude_api_key,claude_auth$' <<<"${claude_output}"
 grep -q '^shared_auth_modes=github_hosts$' <<<"${claude_output}"
 grep -q '^github_auth_present=1$' <<<"${claude_output}"
 
 gemini_output="$(run_auth_status gemini)"
+grep -q '^provider_auth_ready_states=gemini_env:ready$' <<<"${gemini_output}"
+grep -q '^shared_auth_ready_states=github_hosts:ready$' <<<"${gemini_output}"
 grep -q '^provider_auth_mode=gemini_env$' <<<"${gemini_output}"
 grep -q '^provider_auth_modes=gemini_env$' <<<"${gemini_output}"
 grep -q '^shared_auth_modes=github_hosts$' <<<"${gemini_output}"

--- a/tests/scenarios/shared/test-policy-commands.sh
+++ b/tests/scenarios/shared/test-policy-commands.sh
@@ -13,6 +13,7 @@ AUTH_JSON="${TMP_DIR}/auth.json"
 HOSTS_YML="${TMP_DIR}/hosts.yml"
 SHARED_POLICY="${TMP_DIR}/shared.toml"
 POLICY_PATH="${TMP_DIR}/policy.toml"
+OUT_OF_SCOPE_POLICY_PATH="${TMP_DIR}/out-of-scope-policy.toml"
 
 printf '{"token":"super-secret"}\n' >"${AUTH_JSON}"
 chmod 0600 "${AUTH_JSON}"
@@ -38,6 +39,14 @@ source = "${AUTH_JSON}"
 modes = ["strict"]
 EOF
 chmod 0600 "${POLICY_PATH}"
+
+cat >"${OUT_OF_SCOPE_POLICY_PATH}" <<EOF
+version = 1
+
+[credentials.claude_api_key]
+source = "/no/such/file"
+EOF
+chmod 0600 "${OUT_OF_SCOPE_POLICY_PATH}"
 
 show_output="$("${ROOT_DIR}/scripts/workcell" policy show --injection-policy "${POLICY_PATH}")"
 grep -q '^version = 1$' <<<"${show_output}"
@@ -76,6 +85,15 @@ grep -q '^selected=0$' <<<"${why_filtered}"
 grep -q '^credential_readiness=filtered-provider$' <<<"${why_filtered}"
 grep -q '^credential_providers=codex$' <<<"${why_filtered}"
 grep -q '^selection_reason=agent does not match providers; modes not restricted$' <<<"${why_filtered}"
+
+why_out_of_scope="$("${ROOT_DIR}/scripts/workcell" why \
+  --credential claude_api_key \
+  --agent codex \
+  --mode strict \
+  --injection-policy "${OUT_OF_SCOPE_POLICY_PATH}")"
+grep -q '^selected=0$' <<<"${why_out_of_scope}"
+grep -q '^credential_readiness=out-of-scope$' <<<"${why_out_of_scope}"
+grep -q '^selection_reason=credential is not in scope for agent codex$' <<<"${why_out_of_scope}"
 
 set +e
 missing_output="$("${ROOT_DIR}/scripts/workcell" policy validate --injection-policy "${TMP_DIR}/missing.toml" 2>&1)"

--- a/tests/scenarios/shared/test-policy-commands.sh
+++ b/tests/scenarios/shared/test-policy-commands.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-policy-commands-scenario.XXXXXX")"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+AUTH_JSON="${TMP_DIR}/auth.json"
+HOSTS_YML="${TMP_DIR}/hosts.yml"
+SHARED_POLICY="${TMP_DIR}/shared.toml"
+POLICY_PATH="${TMP_DIR}/policy.toml"
+
+printf '{"token":"super-secret"}\n' >"${AUTH_JSON}"
+chmod 0600 "${AUTH_JSON}"
+cat >"${HOSTS_YML}" <<'EOF'
+github.com:
+  oauth_token: ghp-example
+EOF
+chmod 0600 "${HOSTS_YML}"
+
+cat >"${SHARED_POLICY}" <<EOF
+[credentials.github_hosts]
+source = "${HOSTS_YML}"
+providers = ["codex"]
+EOF
+chmod 0600 "${SHARED_POLICY}"
+
+cat >"${POLICY_PATH}" <<EOF
+version = 1
+includes = ["${SHARED_POLICY}"]
+
+[credentials.codex_auth]
+source = "${AUTH_JSON}"
+modes = ["strict"]
+EOF
+chmod 0600 "${POLICY_PATH}"
+
+show_output="$("${ROOT_DIR}/scripts/workcell" policy show --injection-policy "${POLICY_PATH}")"
+grep -q '^version = 1$' <<<"${show_output}"
+grep -q '^\[credentials.codex_auth\]$' <<<"${show_output}"
+grep -q '^\[credentials.github_hosts\]$' <<<"${show_output}"
+
+validate_output="$("${ROOT_DIR}/scripts/workcell" policy validate --injection-policy "${POLICY_PATH}")"
+grep -q '^policy_valid=1$' <<<"${validate_output}"
+
+diff_output="$("${ROOT_DIR}/scripts/workcell" policy diff --injection-policy "${POLICY_PATH}")"
+grep -q '^diff_status=changed$' <<<"${diff_output}"
+grep -q '^--- current$' <<<"${diff_output}"
+grep -q '^+++ canonical$' <<<"${diff_output}"
+grep -q '^\+\[credentials.github_hosts\]$' <<<"${diff_output}"
+
+why_selected="$("${ROOT_DIR}/scripts/workcell" why \
+  --credential codex_auth \
+  --agent codex \
+  --mode strict \
+  --injection-policy "${POLICY_PATH}")"
+grep -q '^selected=1$' <<<"${why_selected}"
+grep -q '^credential_readiness=ready$' <<<"${why_selected}"
+grep -q '^credential_input_kind=source$' <<<"${why_selected}"
+grep -q '^selection_reason=providers not restricted; mode matches modes$' <<<"${why_selected}"
+if grep -q 'super-secret' <<<"${why_selected}"; then
+  echo "workcell why leaked credential material" >&2
+  exit 1
+fi
+
+why_filtered="$("${ROOT_DIR}/scripts/workcell" why \
+  --credential github_hosts \
+  --agent claude \
+  --mode strict \
+  --injection-policy "${POLICY_PATH}")"
+grep -q '^selected=0$' <<<"${why_filtered}"
+grep -q '^credential_readiness=filtered-provider$' <<<"${why_filtered}"
+grep -q '^credential_providers=codex$' <<<"${why_filtered}"
+grep -q '^selection_reason=agent does not match providers; modes not restricted$' <<<"${why_filtered}"
+
+set +e
+missing_output="$("${ROOT_DIR}/scripts/workcell" policy validate --injection-policy "${TMP_DIR}/missing.toml" 2>&1)"
+missing_rc=$?
+set -e
+test "${missing_rc}" -eq 1
+grep -Eq 'missing\.toml|no such file or directory|file does not exist' <<<"${missing_output}"
+
+echo "Policy command scenario passed"

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -8,6 +8,7 @@ REAL_HOME="$(cd "${ROOT_DIR}" && go run ./cmd/workcell-hostutil path home)"
 PROFILE="wcl-session-scenario-$$"
 SESSION_ONE="20260408T100000Z-11111111-$$"
 SESSION_TWO="20260408T110000Z-22222222-$$"
+SESSION_DIRTY="20260408T120000Z-33333333-$$"
 
 cleanup() {
   rm -rf "${REAL_HOME}/.colima/${PROFILE}"
@@ -21,10 +22,29 @@ AUDIT_LOG="${COLIMA_ROOT}/${PROFILE}/workcell.audit.log"
 EXPORT_PATH="${TMP_DIR}/session-export.json"
 WORKSPACE_A="${TMP_DIR}/workspace-a"
 WORKSPACE_B="${TMP_DIR}/workspace-b"
+DIFF_PATH="${TMP_DIR}/session-diff.txt"
+TEXTCONV_MARKER="${WORKSPACE_A}/textconv-ran"
 
 mkdir -p "${SESSIONS_DIR}" "${WORKSPACE_A}" "${WORKSPACE_B}"
 WORKSPACE_A="$(cd "${WORKSPACE_A}" && pwd -P)"
 WORKSPACE_B="$(cd "${WORKSPACE_B}" && pwd -P)"
+
+git -C "${WORKSPACE_A}" init >/dev/null
+cat >"${WORKSPACE_A}/textconv.sh" <<EOF
+#!/bin/sh
+touch "${TEXTCONV_MARKER}"
+cat "\$1"
+EOF
+chmod +x "${WORKSPACE_A}/textconv.sh"
+git -C "${WORKSPACE_A}" config diff.workcell.textconv "${WORKSPACE_A}/textconv.sh"
+printf '*.txt diff=workcell\n' >"${WORKSPACE_A}/.gitattributes"
+printf 'base\n' >"${WORKSPACE_A}/tracked.txt"
+git -C "${WORKSPACE_A}" add .gitattributes tracked.txt
+git -C "${WORKSPACE_A}" -c user.name='Workcell Test' -c user.email='workcell@example.com' commit -m 'initial' >/dev/null
+GIT_BASE="$(git -C "${WORKSPACE_A}" rev-parse HEAD)"
+GIT_BRANCH="$(git -C "${WORKSPACE_A}" branch --show-current)"
+printf 'updated\n' >"${WORKSPACE_A}/tracked.txt"
+printf 'new file\n' >"${WORKSPACE_A}/new.txt"
 
 cat >"${SESSIONS_DIR}/20260408T100000Z-11111111.json" <<EOF
 {
@@ -37,6 +57,9 @@ cat >"${SESSIONS_DIR}/20260408T100000Z-11111111.json" <<EOF
   "ui": "cli",
   "execution_path": "managed-tier1",
   "workspace": "${WORKSPACE_A}",
+  "git_branch": "${GIT_BRANCH}",
+  "git_head": "${GIT_BASE}",
+  "git_base": "${GIT_BASE}",
   "audit_log_path": "${AUDIT_LOG}",
   "started_at": "2026-04-08T10:00:00Z",
   "finished_at": "2026-04-08T10:05:00Z",
@@ -108,6 +131,44 @@ fi
 show_output="$("${ROOT_DIR}/scripts/workcell" session show --id "${SESSION_TWO}")"
 grep -q "\"session_id\": \"${SESSION_TWO}\"" <<<"${show_output}"
 grep -q '"status": "failed"' <<<"${show_output}"
+
+diff_stdout="$("${ROOT_DIR}/scripts/workcell" session diff --id "${SESSION_ONE}" --output "${DIFF_PATH}")"
+grep -q "^session_diff=${DIFF_PATH}$" <<<"${diff_stdout}"
+grep -q "^session_id=${SESSION_ONE}$" "${DIFF_PATH}"
+grep -q "^git_branch=${GIT_BRANCH}$" "${DIFF_PATH}"
+grep -q '^ M tracked.txt$' "${DIFF_PATH}"
+grep -Fq '?? new.txt' "${DIFF_PATH}"
+grep -q '^-base$' "${DIFF_PATH}"
+grep -q '^+updated$' "${DIFF_PATH}"
+test ! -e "${TEXTCONV_MARKER}"
+
+cat >"${SESSIONS_DIR}/20260408T120000Z-33333333.json" <<EOF
+{
+  "version": 1,
+  "session_id": "${SESSION_DIRTY}",
+  "profile": "${PROFILE}",
+  "agent": "codex",
+  "mode": "strict",
+  "status": "exited",
+  "ui": "cli",
+  "execution_path": "managed-tier1",
+  "workspace": "${WORKSPACE_A}",
+  "git_branch": "${GIT_BRANCH}",
+  "git_head": "${GIT_BASE}",
+  "audit_log_path": "${AUDIT_LOG}",
+  "started_at": "2026-04-08T12:00:00Z",
+  "finished_at": "2026-04-08T12:05:00Z",
+  "exit_status": "0",
+  "initial_assurance": "managed-mutable",
+  "final_assurance": "managed-mutable",
+  "workspace_control_plane": "masked"
+}
+EOF
+
+dirty_diff_output="$(
+  "${ROOT_DIR}/scripts/workcell" session diff --id "${SESSION_DIRTY}" 2>&1 >/dev/null || true
+)"
+grep -q 'session diff requires a clean git launch baseline' <<<"${dirty_diff_output}"
 
 export_stdout="$("${ROOT_DIR}/scripts/workcell" session export --id "${SESSION_TWO}" --output "${EXPORT_PATH}")"
 grep -q "^session_export=${EXPORT_PATH}$" <<<"${export_stdout}"


### PR DESCRIPTION
## Summary
- add host-side policy inspection commands, `workcell why`, and richer auth readiness reporting
- add `workcell session diff`, record clean git launch metadata, and write session records atomically
- improve launch progress UX with interactive spinner support, text heartbeat fallback, and a `--no-spinner` override
- sync roadmap, operator docs, man page, invariants, manifests, and scenario coverage with the shipped CLI surface

## Testing
- `go test ./...`
- `bash tests/scenarios/shared/test-auth-commands.sh`
- `bash tests/scenarios/shared/test-auth-status.sh`
- `bash tests/scenarios/shared/test-policy-commands.sh`
- `bash tests/scenarios/shared/test-session-commands.sh`
- `./scripts/validate-repo.sh`
