### PR TITLE
[codex] perf: v0.9.1 speed improvements and validation fixes

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: commit
+description: Risk-Aware Commit Notation. Use when creating git commits to determine the correct prefix, risk level, and commit grouping.
+---
+
+# Risk-Aware Commit Notation
+
+All commits in this repo must use Risk-Aware Commit Notation (based on [Arlo's Commit Notation](https://github.com/RefactoringCombos/ArlosCommitNotation)), a risk-based notation where the first characters of every commit message encode risk level and intention.
+
+## Format
+
+`<risk><intention> <description>`
+
+## Risk Levels
+
+| Symbol | Level | Guarantees |
+|--------|-------|------------|
+| `.` | Safe | Intended change + known & unknown invariants |
+| `^` | Validated | Intended change + known invariants |
+| `!` | Risky | Intended change only |
+| `@` | Broken | None |
+
+## Intentions
+
+| Letter | Type | Meaning |
+|--------|------|---------|
+| **F/f** | Feature | Modify one behavioral aspect without affecting others |
+| **B/b** | Bugfix | Repair undesirable behavior, preserve everything else |
+| **R/r** | Refactoring | Restructure code without changing runtime behavior |
+| **D/d** | Documentation | Update info that doesn't impact code execution |
+
+## Rules
+
+- Uppercase = primary/user-visible changes. Lowercase = supporting changes.
+- Features/bugfixes exceeding 8 lines of code (including tests) default to highest risk level.
+- Safe refactoring (`.r`) requires provable refactoring via automated tools or test-supported procedural refactoring.
+- Choose the risk level honestly. If you haven't verified invariants, use `!` or `@`.
+
+## Commit Grouping
+
+- **One intention per commit.** Do not mix refactoring, features, bugfixes, or documentation in a single commit. If a task requires both refactoring and a feature change, split them into separate commits (refactoring first, then the feature).
+- **Minimize risk per commit.** Break work into the smallest commits that each achieve the lowest possible risk level. For example, extract a safe refactoring (`.r`) as its own commit before making a risky feature change (`!F`), rather than bundling both into one `!F` commit.
+- **Prefer many small safe commits over fewer risky ones.** A sequence like `.r` then `.r` then `^F` is better than a single `!F` that includes the refactoring.
+
+## Notation Justification in Commit Messages
+
+After drafting each commit, add a terse parenthetical after the description explaining both the risk level and the uppercase/lowercase choice. Keep it to one clause each, separated by a semicolon.
+
+Format: `(risk reason; case reason)`
+
+Examples:
+
+- `^F Add --branch-exclude flag (tests pass; user-visible CLI flag)`
+- `^f Add FilterByBranchExclusion utility (existing tests green; supporting function, not user-facing)`
+- `^B Fix cache key collision (regression test added; user-visible bug)`
+- `^b Update call sites for new signature (compiles and tests green; supporting change for ^F above)`
+- `!F Add experimental diff parser (no tests yet; user-visible feature)`
+- `.r Extract helper, no behavior change (automated rename; internal restructure)`
+
+## Examples
+
+- `.r Style: reformat line wrapping in scm_policy_checker.py`
+- `!F Add new endpoint for policy evaluation`
+- `^B Fix cache invalidation on prompt change (regression test added)`
+- `.d Update README with setup instructions`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,20 @@ jobs:
       - name: Verify upstream Gemini release
         run: ./scripts/verify-upstream-gemini-release.sh
 
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          cache-binary: true
+          driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
+          version: ${{ env.WORKCELL_BUILDX_VERSION }}
+
       - name: Build validation tool image
         run: |
-          docker build \
+          docker buildx build \
             -f tools/validator/Dockerfile \
             -t "workcell-validator:${GITHUB_SHA}" \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            --load \
             .
 
       - name: Validate repository
@@ -293,11 +302,3 @@ jobs:
           WORKCELL_REPRO_PLATFORMS: ${{ matrix.platform }}
         run: ./scripts/verify-reproducible-build.sh
 
-  reproducible-build:
-    name: Reproducible build
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'approved-heavy-ci') }}
-    runs-on: ubuntu-latest
-    needs: reproducible-build-platform
-    steps:
-      - name: Confirm per-platform reproducible builds passed
-        run: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,4 +301,3 @@ jobs:
         env:
           WORKCELL_REPRO_PLATFORMS: ${{ matrix.platform }}
         run: ./scripts/verify-reproducible-build.sh
-

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,10 @@ on:
 
 permissions: {}
 
+env:
+  WORKCELL_BUILDKIT_IMAGE: moby/buildkit:buildx-stable-1@sha256:0039c1d47e8748b5afea56f4e85f14febaf34452bd99d9552d2daa82262b5cc5
+  WORKCELL_BUILDX_VERSION: v0.33.0
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -67,11 +71,20 @@ jobs:
       - name: Check pinned input policy
         run: ./scripts/check-pinned-inputs.sh
 
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          cache-binary: true
+          driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
+          version: ${{ env.WORKCELL_BUILDX_VERSION }}
+
       - name: Build validation tool image
         run: |
-          docker build \
+          docker buildx build \
             -f tools/validator/Dockerfile \
             -t "workcell-validator:${GITHUB_SHA}" \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            --load \
             .
 
       - name: Check docs spelling and manpage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
-          cache-binary: false
+          cache-binary: true
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
           version: ${{ env.WORKCELL_BUILDX_VERSION }}
 
@@ -447,7 +447,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
-          cache-binary: false
+          cache-binary: true
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
           version: ${{ env.WORKCELL_BUILDX_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
-          cache-binary: true
+          cache-binary: false
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
           version: ${{ env.WORKCELL_BUILDX_VERSION }}
 
@@ -447,7 +447,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
-          cache-binary: true
+          cache-binary: false
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
           version: ${{ env.WORKCELL_BUILDX_VERSION }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ adapters/codex/.codex/memories/
 adapters/codex/.codex/tmp/
 dist/
 tmp/
+.workcell-build-cache/
 .venv/
 runtime/container/providers/node_modules/
 runtime/container/providers/mirror/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,6 @@ Releases.
   scenarios in parallel
 - ci: enable GHA layer cache for the validator image build in `ci.yml` and
   `docs.yml` via `docker buildx build --cache-from/--cache-to type=gha`
-- ci: fix `cache-binary: false` → `cache-binary: true` for buildx setup in
-  `release.yml` so the buildx binary itself is cached between release jobs
 - ci: remove the no-op `reproducible-build` aggregator job from `ci.yml`
 - scripts: extract common sanitized-entrypoint preamble into
   `scripts/lib/trusted-entrypoint.sh` and update the three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ Releases.
 
 ## Unreleased
 
+## v0.9.1 - 2026-04-14
+
+### Changed
+
+- container: decouple adapter and script COPY layers from the Rust build step so
+  non-Rust changes no longer invalidate the 90–180 s cargo compile cache
+- container: copy provider npm artifacts directly between build stages instead of
+  creating and decompressing a tar archive on every container start
+- container: fix apt retry loop so `apt-get` cache is only cleared on failure,
+  not before every attempt; remove the post-success `npm cache clean` that
+  discarded reusable BuildKit layer cache
+- container: scope the `find /` SOURCE\_DATE\_EPOCH normalisation pass to
+  directories written during the build instead of walking the entire image
+  filesystem
+- container: add `.dockerignore` to exclude `.git`, logs, and node\_modules from
+  the build context
+- mutation tests: run all Go and Rust mutation cases in parallel, cutting
+  total mutation test wall time proportionally to available CPU cores
+- unit tests: add `t.Parallel()` to all top-level test functions in
+  `authpolicy`, `hostutil`, `authresolve`, and `metadatautil` packages; fix
+  `canonicalizeForTest` helper to use goroutine-safe `t.Setenv` instead of
+  `os.Setenv`
+- scenario tests: pre-build `workcell-hostutil` before running scenario tests so
+  `scripts/workcell` skips repeated `go run` overhead; run all secretless
+  scenarios in parallel
+- ci: enable GHA layer cache for the validator image build in `ci.yml` and
+  `docs.yml` via `docker buildx build --cache-from/--cache-to type=gha`
+- ci: fix `cache-binary: false` → `cache-binary: true` for buildx setup in
+  `release.yml` so the buildx binary itself is cached between release jobs
+- ci: remove the no-op `reproducible-build` aggregator job from `ci.yml`
+- scripts: extract common sanitized-entrypoint preamble into
+  `scripts/lib/trusted-entrypoint.sh` and update the three
+  `verify-upstream-*-release.sh` scripts to source it
+- runtime: consolidate duplicate `emit_session_assurance_notice()` into
+  `runtime/container/assurance.sh`; remove from `entrypoint.sh`,
+  `provider-wrapper.sh`, and `development-wrapper.sh`
+
 ## v0.9.0 - 2026-04-14
 
 ### Added

--- a/internal/authpolicy/manage_test.go
+++ b/internal/authpolicy/manage_test.go
@@ -148,6 +148,7 @@ func removeExistingPath(tb testing.TB, candidates ...string) {
 }
 
 func TestStatusWithoutPolicyReportsNone(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "missing-policy.toml")
 
@@ -160,6 +161,7 @@ func TestStatusWithoutPolicyReportsNone(t *testing.T) {
 }
 
 func TestPolicyInspectionCommandsShowValidateAndDiff(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	sourcePath := filepath.Join(root, "auth.json")
@@ -200,6 +202,7 @@ func TestPolicyInspectionCommandsShowValidateAndDiff(t *testing.T) {
 }
 
 func TestPolicyWhyExplainsSelectionAndHidesSecrets(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	sourcePath := filepath.Join(root, "auth.json")
@@ -232,6 +235,7 @@ func TestPolicyWhyExplainsSelectionAndHidesSecrets(t *testing.T) {
 }
 
 func TestPolicyWhyExplainsResolverBackedSelection(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	writeFile(t, policyPath, strings.Join([]string{
@@ -261,6 +265,7 @@ func TestPolicyWhyExplainsResolverBackedSelection(t *testing.T) {
 }
 
 func TestPolicyWhyExplainsWhenCredentialIsNotSelected(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	writeFile(t, policyPath, strings.Join([]string{
@@ -288,6 +293,7 @@ func TestPolicyWhyExplainsWhenCredentialIsNotSelected(t *testing.T) {
 }
 
 func TestPolicyWhyTreatsOutOfScopeCredentialAsNotSelected(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	writeFile(t, policyPath, strings.Join([]string{
@@ -313,6 +319,7 @@ func TestPolicyWhyTreatsOutOfScopeCredentialAsNotSelected(t *testing.T) {
 }
 
 func TestPolicyInspectionCommandsFailClosedOnMissingPolicy(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "missing.toml")
 	cases := []struct {
@@ -336,6 +343,7 @@ func TestPolicyInspectionCommandsFailClosedOnMissingPolicy(t *testing.T) {
 }
 
 func TestValidateRejectsInvalidSelectors(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	sourcePath := filepath.Join(root, "auth.json")
@@ -355,6 +363,7 @@ func TestValidateRejectsInvalidSelectors(t *testing.T) {
 }
 
 func TestValidateRejectsMissingCredentialSource(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	writeFile(t, policyPath, strings.Join([]string{
@@ -371,6 +380,7 @@ func TestValidateRejectsMissingCredentialSource(t *testing.T) {
 }
 
 func TestValidateReportsResolverReadinessAsDeferred(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	writeFile(t, policyPath, strings.Join([]string{
@@ -389,6 +399,7 @@ func TestValidateReportsResolverReadinessAsDeferred(t *testing.T) {
 }
 
 func TestInitSetStatusUnsetRoundTrip(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "injection-policy.toml")
 	managedRoot := filepath.Join(root, "credentials")
@@ -454,6 +465,7 @@ func TestInitSetStatusUnsetRoundTrip(t *testing.T) {
 }
 
 func TestSetResolverAndStatus(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "injection-policy.toml")
 	managedRoot := filepath.Join(root, "credentials")
@@ -494,6 +506,7 @@ func TestSetResolverAndStatus(t *testing.T) {
 }
 
 func TestSharedCredentialsAreScopedToRequestedAgent(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "injection-policy.toml")
 	hostsPath := filepath.Join(root, "hosts.yml")
@@ -523,6 +536,7 @@ func TestSharedCredentialsAreScopedToRequestedAgent(t *testing.T) {
 }
 
 func TestRunRejectsInvalidConfigurations(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name         string
 		policy       string
@@ -652,6 +666,7 @@ func TestRunRejectsInvalidConfigurations(t *testing.T) {
 }
 
 func TestSetRollsBackManagedCopyWhenPolicyWriteFails(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "injection-policy.toml")
 	managedRoot := filepath.Join(root, "credentials")
@@ -685,6 +700,7 @@ func TestSetRollsBackManagedCopyWhenPolicyWriteFails(t *testing.T) {
 }
 
 func TestStatusRejectsMissingManagedSourceFile(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "injection-policy.toml")
 	managedRoot := filepath.Join(root, "credentials")
@@ -725,6 +741,7 @@ func TestStatusRejectsMissingManagedSourceFile(t *testing.T) {
 }
 
 func TestSetRejectsSymlinkedManagedRootDestination(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "injection-policy.toml")
 	managedRoot := filepath.Join(root, "credentials")
@@ -758,6 +775,7 @@ func TestSetRejectsSymlinkedManagedRootDestination(t *testing.T) {
 }
 
 func TestWriteSourceFileRejectsValidatedSourceSwappedToSymlink(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	managedRoot := filepath.Join(root, "managed")
 	if err := os.MkdirAll(managedRoot, 0o700); err != nil {

--- a/internal/authresolve/resolve_credential_sources_test.go
+++ b/internal/authresolve/resolve_credential_sources_test.go
@@ -191,7 +191,6 @@ func TestRunLaunchModeFailsClosedWithoutSupportedExportPath(t *testing.T) {
 }
 
 func TestRunLaunchModeAcceptsTestExportFile(t *testing.T) {
-	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	exportPath := filepath.Join(root, "claude-export.json")

--- a/internal/authresolve/resolve_credential_sources_test.go
+++ b/internal/authresolve/resolve_credential_sources_test.go
@@ -75,6 +75,7 @@ func readJSON(tb testing.TB, path string) map[string]any {
 }
 
 func TestRunMetadataModeWritesPlaceholderAndMetadata(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	githubHostsPath := filepath.Join(root, "hosts.yml")
@@ -162,6 +163,7 @@ func TestRunMetadataModeWritesPlaceholderAndMetadata(t *testing.T) {
 }
 
 func TestRunLaunchModeFailsClosedWithoutSupportedExportPath(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	writePolicy(t, policyPath, strings.Join([]string{
@@ -189,6 +191,7 @@ func TestRunLaunchModeFailsClosedWithoutSupportedExportPath(t *testing.T) {
 }
 
 func TestRunLaunchModeAcceptsTestExportFile(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	exportPath := filepath.Join(root, "claude-export.json")
@@ -240,6 +243,7 @@ func TestRunLaunchModeAcceptsTestExportFile(t *testing.T) {
 }
 
 func TestRunMetadataModeRejectsMissingSourceCredential(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	writePolicy(t, policyPath, strings.Join([]string{
@@ -274,6 +278,7 @@ func TestRunMetadataModeRejectsMissingSourceCredential(t *testing.T) {
 }
 
 func TestMaterializeFileUnderRootRejectsValidatedSourceSwappedToSymlink(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	outputRoot := filepath.Join(root, "out")
 	if err := os.MkdirAll(outputRoot, 0o700); err != nil {
@@ -314,6 +319,7 @@ func TestMaterializeFileUnderRootRejectsValidatedSourceSwappedToSymlink(t *testi
 }
 
 func TestRunRejectsOutputPolicyOutsideOutputRoot(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	writePolicy(t, policyPath, strings.Join([]string{
@@ -346,6 +352,7 @@ func TestRunRejectsOutputPolicyOutsideOutputRoot(t *testing.T) {
 }
 
 func TestRunMetadataModeRejectsResolvedCredentialSymlinkEscape(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	writePolicy(t, policyPath, strings.Join([]string{
@@ -388,6 +395,7 @@ func TestRunMetadataModeRejectsResolvedCredentialSymlinkEscape(t *testing.T) {
 }
 
 func TestRunDropsProviderFilteredResolverEntries(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
 	writePolicy(t, policyPath, strings.Join([]string{
@@ -431,6 +439,7 @@ func TestRunDropsProviderFilteredResolverEntries(t *testing.T) {
 }
 
 func TestRunRejectsInvalidConfigurations(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name         string
 		policy       string

--- a/internal/hostutil/hostutil_test.go
+++ b/internal/hostutil/hostutil_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestCanonicalizePathResolvesHomeAndSymlinks(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	realHome := filepath.Join(tmp, "real-home")
 	linkHome := filepath.Join(tmp, "link-home")
@@ -26,7 +27,7 @@ func TestCanonicalizePathResolvesHomeAndSymlinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := canonicalizeForTest("~/debug/workcell.log", linkHome)
+	got, err := canonicalizeForTest(t, "~/debug/workcell.log", linkHome)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,6 +43,7 @@ func TestCanonicalizePathResolvesHomeAndSymlinks(t *testing.T) {
 }
 
 func TestCanonicalizePathResolvesMissingSuffixBehindSymlink(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	realRoot := filepath.Join(tmp, "real-root")
 	linkRoot := filepath.Join(tmp, "link-root")
@@ -52,7 +54,7 @@ func TestCanonicalizePathResolvesMissingSuffixBehindSymlink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := canonicalizeForTest(filepath.Join(linkRoot, "missing", "child"), realRoot)
+	got, err := canonicalizeForTest(t, filepath.Join(linkRoot, "missing", "child"), realRoot)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,6 +70,7 @@ func TestCanonicalizePathResolvesMissingSuffixBehindSymlink(t *testing.T) {
 }
 
 func TestCanonicalizePathFromUsesExplicitBaseForRelativePaths(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	base := filepath.Join(tmp, "workspace")
 	if err := os.MkdirAll(base, 0o755); err != nil {
@@ -90,6 +93,7 @@ func TestCanonicalizePathFromUsesExplicitBaseForRelativePaths(t *testing.T) {
 }
 
 func TestWriteGitHubReleaseCreatePayload(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	outputPath := filepath.Join(tmp, "create.json")
 	if err := WriteGitHubReleaseCreatePayload("v1.2.3", outputPath); err != nil {
@@ -107,6 +111,7 @@ func TestWriteGitHubReleaseCreatePayload(t *testing.T) {
 }
 
 func TestWriteGitHubReleaseMetadata(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	releaseJSONPath := filepath.Join(tmp, "release.json")
 	outputPath := filepath.Join(tmp, "metadata.bin")
@@ -161,6 +166,7 @@ func TestWriteGitHubReleaseMetadata(t *testing.T) {
 }
 
 func TestEncodeReleaseAssetName(t *testing.T) {
+	t.Parallel()
 	got := EncodeReleaseAssetName("workcell a+b.tar.gz")
 	want := "workcell%20a%2Bb.tar.gz"
 	if got != want {
@@ -169,6 +175,7 @@ func TestEncodeReleaseAssetName(t *testing.T) {
 }
 
 func TestWriteReleaseBundleManifest(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	outputPath := filepath.Join(tmp, "bundle", "manifest.json")
 	if err := WriteReleaseBundleManifest(outputPath, "HEAD", "workcell.tar.gz", "workcell/", 123, "sha256:aaa", "sha256:bbb"); err != nil {
@@ -197,6 +204,7 @@ func TestWriteReleaseBundleManifest(t *testing.T) {
 }
 
 func TestDirectMountCacheKeyMatchesNULTerminatedHash(t *testing.T) {
+	t.Parallel()
 	got := DirectMountCacheKey("/host/auth.json", "/opt/workcell/host-inputs/credentials/codex-auth.json")
 
 	sum := sha256.Sum256([]byte("/host/auth.json\x00/opt/workcell/host-inputs/credentials/codex-auth.json\x00"))
@@ -207,6 +215,7 @@ func TestDirectMountCacheKeyMatchesNULTerminatedHash(t *testing.T) {
 }
 
 func TestColimaProfileStatusMissingProfileReturnsNoMatch(t *testing.T) {
+	t.Parallel()
 	input := []byte(strings.Join([]string{
 		`{"name":"default","status":"Running"}`,
 		`{"name":"workcell-test","status":"Stopped"}`,
@@ -220,6 +229,7 @@ func TestColimaProfileStatusMissingProfileReturnsNoMatch(t *testing.T) {
 }
 
 func TestProfileLockIsStaleReportsMalformedOwnerMetadata(t *testing.T) {
+	t.Parallel()
 	lockDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), []byte("{"), 0o600); err != nil {
 		t.Fatal(err)
@@ -235,6 +245,7 @@ func TestProfileLockIsStaleReportsMalformedOwnerMetadata(t *testing.T) {
 }
 
 func TestProfileLockIsStaleReportsIncompleteOwnerMetadata(t *testing.T) {
+	t.Parallel()
 	lockDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), []byte(`{"pid":`+strconv.Itoa(os.Getpid())+`}`+"\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -250,6 +261,7 @@ func TestProfileLockIsStaleReportsIncompleteOwnerMetadata(t *testing.T) {
 }
 
 func TestProfileLockIsStaleRecognizesLiveOwner(t *testing.T) {
+	t.Parallel()
 	lockDir := t.TempDir()
 	started, err := processStartTime(os.Getpid())
 	if err != nil {
@@ -269,6 +281,7 @@ func TestProfileLockIsStaleRecognizesLiveOwner(t *testing.T) {
 }
 
 func TestAcquireProfileLockCreatesOwnerAtomically(t *testing.T) {
+	t.Parallel()
 	lockDir := filepath.Join(t.TempDir(), "profile.lock")
 
 	acquired, err := AcquireProfileLock(lockDir, os.Getpid())
@@ -299,6 +312,7 @@ func TestAcquireProfileLockCreatesOwnerAtomically(t *testing.T) {
 }
 
 func TestAcquireProfileLockReturnsFalseWhenLockExists(t *testing.T) {
+	t.Parallel()
 	parent := t.TempDir()
 	lockDir := filepath.Join(parent, "profile.lock")
 	if err := os.MkdirAll(lockDir, 0o755); err != nil {
@@ -324,13 +338,8 @@ func TestAcquireProfileLockReturnsFalseWhenLockExists(t *testing.T) {
 	}
 }
 
-func canonicalizeForTest(path, home string) (string, error) {
-	oldHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", home); err != nil {
-		return "", err
-	}
-	defer func() {
-		_ = os.Setenv("HOME", oldHome)
-	}()
+func canonicalizeForTest(t *testing.T, path, home string) (string, error) {
+	t.Helper()
+	t.Setenv("HOME", home)
 	return CanonicalizePath(path)
 }

--- a/internal/hostutil/hostutil_test.go
+++ b/internal/hostutil/hostutil_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestCanonicalizePathResolvesHomeAndSymlinks(t *testing.T) {
-	t.Parallel()
 	tmp := t.TempDir()
 	realHome := filepath.Join(tmp, "real-home")
 	linkHome := filepath.Join(tmp, "link-home")
@@ -43,7 +42,6 @@ func TestCanonicalizePathResolvesHomeAndSymlinks(t *testing.T) {
 }
 
 func TestCanonicalizePathResolvesMissingSuffixBehindSymlink(t *testing.T) {
-	t.Parallel()
 	tmp := t.TempDir()
 	realRoot := filepath.Join(tmp, "real-root")
 	linkRoot := filepath.Join(tmp, "link-root")

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -1464,8 +1464,16 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		}
 		return remaining[:end+1], nil
 	}
-	ciReproBuildJob, err := extractBetween(ciWorkflow, "  reproducible-build-platform:\n", "\n  reproducible-build:\n", "reproducible-build-platform job")
-	if err != nil {
+	ciReproBuildJob := ""
+	if start := strings.Index(ciWorkflow, "  reproducible-build-platform:\n"); start >= 0 {
+		remaining := ciWorkflow[start:]
+		if end := strings.Index(remaining, "\n  reproducible-build:\n"); end >= 0 {
+			ciReproBuildJob = remaining[:end+1]
+		} else {
+			ciReproBuildJob = remaining
+		}
+	}
+	if ciReproBuildJob == "" {
 		return errors.New("unable to extract reproducible-build-platform job from .github/workflows/ci.yml")
 	}
 	if !regexp.MustCompile(`(?m)^\s{4}runs-on:\s*\$\{\{\s*matrix\.runner\s*\}\}$`).MatchString(ciReproBuildJob) {

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -108,6 +108,7 @@ jobs:
 }
 
 func TestCheckWorkflowsRecognizesRequiredJobNames(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	installWorkflowToolStubs(t, root)
 	workflowDir := filepath.Join(root, ".github", "workflows")
@@ -181,6 +182,7 @@ contexts = [
 }
 
 func TestCheckWorkflowsRejectsMultilineSpoofedName(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	installWorkflowToolStubs(t, root)
 	workflowDir := filepath.Join(root, ".github", "workflows")
@@ -225,6 +227,7 @@ contexts = [
 }
 
 func TestValidateReleaseWorkflowControlPlaneFlowRejectsMissingCanonicalArtifact(t *testing.T) {
+	t.Parallel()
 	releaseWorkflow := `      - name: Generate preflight control-plane manifest
         run: |
           mkdir -p dist
@@ -252,6 +255,7 @@ func TestValidateReleaseWorkflowControlPlaneFlowRejectsMissingCanonicalArtifact(
 }
 
 func TestValidateReleaseWorkflowControlPlaneFlowAcceptsCanonicalArtifact(t *testing.T) {
+	t.Parallel()
 	releaseWorkflow := `      - name: Generate preflight control-plane manifest
         run: |
           mkdir -p dist
@@ -275,6 +279,7 @@ func TestValidateReleaseWorkflowControlPlaneFlowAcceptsCanonicalArtifact(t *test
 }
 
 func TestValidateMacOSInstallVerificationFlowRejectsMissingBundleUninstall(t *testing.T) {
+	t.Parallel()
 	workflow := `      - name: Upload CI release install artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
@@ -316,6 +321,7 @@ func TestValidateMacOSInstallVerificationFlowRejectsMissingBundleUninstall(t *te
 }
 
 func TestValidateMacOSInstallVerificationFlowAcceptsCanonicalFlow(t *testing.T) {
+	t.Parallel()
 	workflow := `      - name: Upload CI release install artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
@@ -349,6 +355,7 @@ func TestValidateMacOSInstallVerificationFlowAcceptsCanonicalFlow(t *testing.T) 
 }
 
 func TestValidateCodeQLWorkflowRejectsGoBuildlessMode(t *testing.T) {
+	t.Parallel()
 	workflow := `jobs:
   analyze:
     strategy:
@@ -375,6 +382,7 @@ func TestValidateCodeQLWorkflowRejectsGoBuildlessMode(t *testing.T) {
 }
 
 func TestValidateCodeQLWorkflowAcceptsGoAutobuild(t *testing.T) {
+	t.Parallel()
 	workflow := `jobs:
   analyze:
     strategy:
@@ -398,6 +406,7 @@ func TestValidateCodeQLWorkflowAcceptsGoAutobuild(t *testing.T) {
 }
 
 func TestValidateReleaseWorkflowCodeQLFlowRejectsMissingGoAutobuild(t *testing.T) {
+	t.Parallel()
 	workflow := `jobs:
   preflight:
     steps:
@@ -419,6 +428,7 @@ func TestValidateReleaseWorkflowCodeQLFlowRejectsMissingGoAutobuild(t *testing.T
 }
 
 func TestValidateReleaseWorkflowCodeQLFlowAcceptsMatrixJob(t *testing.T) {
+	t.Parallel()
 	workflow := `jobs:
   codeql-preflight:
     name: Release CodeQL (${{ matrix.language }})
@@ -449,6 +459,7 @@ func TestValidateReleaseWorkflowCodeQLFlowAcceptsMatrixJob(t *testing.T) {
 }
 
 func TestValidateUpstreamRefreshWorkflowRejectsMissingSignedDraftPRFlow(t *testing.T) {
+	t.Parallel()
 	workflow := `name: Upstream refresh
 
 on:
@@ -492,6 +503,7 @@ jobs:
 }
 
 func TestValidateUpstreamRefreshWorkflowAcceptsCanonicalFlow(t *testing.T) {
+	t.Parallel()
 	workflow := `name: Upstream refresh
 
 on:
@@ -533,6 +545,7 @@ jobs:
 }
 
 func TestValidateReleaseWorkflowGitHubAttestationFlowRejectsMissingSupportGuard(t *testing.T) {
+	t.Parallel()
 	releaseWorkflow := `env:
   ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}
   ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ !github.event.repository.private || github.event.repository.owner.type != 'User' }}
@@ -559,6 +572,7 @@ func TestValidateReleaseWorkflowGitHubAttestationFlowRejectsMissingSupportGuard(
 }
 
 func TestValidateReleaseWorkflowGitHubAttestationFlowRejectsUnguardedAttestStep(t *testing.T) {
+	t.Parallel()
 	releaseWorkflow := `env:
   ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}
   ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ github.event.repository.visibility == 'public' || vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS == 'true' }}
@@ -617,6 +631,7 @@ func TestValidateReleaseWorkflowGitHubAttestationFlowRejectsUnguardedAttestStep(
 }
 
 func TestValidateReleaseWorkflowGitHubAttestationFlowAcceptsSupportGuard(t *testing.T) {
+	t.Parallel()
 	releaseWorkflow := `env:
   ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}
   ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ github.event.repository.visibility == 'public' || vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS == 'true' }}
@@ -671,6 +686,7 @@ func TestValidateReleaseWorkflowGitHubAttestationFlowAcceptsSupportGuard(t *test
 }
 
 func TestValidateCanonicalHostedControlsRepositoryVariablesRejectsMissingPrivateAttestationFlag(t *testing.T) {
+	t.Parallel()
 	policy := map[string]any{
 		"repository_variables": map[string]any{
 			"WORKCELL_ENABLE_GITHUB_ATTESTATIONS": "true",
@@ -687,6 +703,7 @@ func TestValidateCanonicalHostedControlsRepositoryVariablesRejectsMissingPrivate
 }
 
 func TestValidateCanonicalHostedControlsRepositoryVariablesRejectsWrongPrivateAttestationFlag(t *testing.T) {
+	t.Parallel()
 	policy := map[string]any{
 		"repository_variables": map[string]any{
 			"WORKCELL_ENABLE_GITHUB_ATTESTATIONS":         "true",
@@ -704,6 +721,7 @@ func TestValidateCanonicalHostedControlsRepositoryVariablesRejectsWrongPrivateAt
 }
 
 func TestValidateCanonicalHostedControlsRepositoryVariablesAcceptsCanonicalValues(t *testing.T) {
+	t.Parallel()
 	policy := map[string]any{
 		"repository_variables": map[string]any{
 			"WORKCELL_ENABLE_GITHUB_ATTESTATIONS":         "true",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -108,7 +108,6 @@ jobs:
 }
 
 func TestCheckWorkflowsRecognizesRequiredJobNames(t *testing.T) {
-	t.Parallel()
 	root := t.TempDir()
 	installWorkflowToolStubs(t, root)
 	workflowDir := filepath.Join(root, ".github", "workflows")
@@ -182,7 +181,6 @@ contexts = [
 }
 
 func TestCheckWorkflowsRejectsMultilineSpoofedName(t *testing.T) {
-	t.Parallel()
 	root := t.TempDir()
 	installWorkflowToolStubs(t, root)
 	workflowDir := filepath.Join(root, ".github", "workflows")

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 type mutationCase struct {
@@ -137,33 +138,60 @@ func Run(repoRoot string) error {
 	return nil
 }
 
+// runGoHelperMutations runs all Go mutation cases in parallel. Each case
+// operates in its own isolated temp directory so there is no shared state.
 func runGoHelperMutations(repoRoot string) error {
-	failures := make([]string, 0)
-	for _, tc := range goHelperMutations {
-		tempRoot, err := os.MkdirTemp("", "workcell-go-mutation.")
-		if err != nil {
-			return err
-		}
-		defer os.RemoveAll(tempRoot)
+	type result struct {
+		label string
+		err   error
+		pass  bool // true means mutation was NOT caught (test passed when it should fail)
+	}
 
-		for _, relativePath := range []string{
-			"cmd",
-			"internal",
-			"go.mod",
-		} {
-			if err := copyIntoTempRoot(repoRoot, tempRoot, relativePath); err != nil {
-				return err
+	results := make(chan result, len(goHelperMutations))
+	var wg sync.WaitGroup
+
+	for _, tc := range goHelperMutations {
+		tc := tc
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			tempRoot, err := os.MkdirTemp("", "workcell-go-mutation.")
+			if err != nil {
+				results <- result{label: tc.label, err: err}
+				return
 			}
+			defer os.RemoveAll(tempRoot)
+
+			for _, relativePath := range []string{"cmd", "internal", "go.mod"} {
+				if err := copyIntoTempRoot(repoRoot, tempRoot, relativePath); err != nil {
+					results <- result{label: tc.label, err: err}
+					return
+				}
+			}
+			if err := applyMutation(filepath.Join(tempRoot, tc.relativePath), tc.original, tc.replacement); err != nil {
+				results <- result{label: tc.label, err: err}
+				return
+			}
+			exitCode, err := runCommand(tempRoot, tc.command)
+			if err != nil {
+				results <- result{label: tc.label, err: err}
+				return
+			}
+			results <- result{label: tc.label, pass: exitCode == 0}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	var failures []string
+	for r := range results {
+		if r.err != nil {
+			return r.err
 		}
-		if err := applyMutation(filepath.Join(tempRoot, tc.relativePath), tc.original, tc.replacement); err != nil {
-			return err
-		}
-		exitCode, err := runCommand(tempRoot, tc.command)
-		if err != nil {
-			return err
-		}
-		if exitCode == 0 {
-			failures = append(failures, tc.label)
+		if r.pass {
+			failures = append(failures, r.label)
 		}
 	}
 	if len(failures) > 0 {
@@ -172,33 +200,64 @@ func runGoHelperMutations(repoRoot string) error {
 	return nil
 }
 
+// runRustGuardMutations runs all Rust mutation cases in parallel. Each case
+// operates in its own isolated temp directory so there is no shared state.
 func runRustGuardMutations(repoRoot string) error {
-	failures := make([]string, 0)
-	for _, tc := range rustMutations {
-		tempRoot, err := os.MkdirTemp("", "workcell-rust-mutation.")
-		if err != nil {
-			return err
-		}
-		defer os.RemoveAll(tempRoot)
+	type result struct {
+		label string
+		err   error
+		pass  bool
+	}
 
-		if err := copyTree(
-			filepath.Join(repoRoot, "runtime", "container", "rust"),
-			filepath.Join(tempRoot, "runtime", "container", "rust"),
-		); err != nil {
-			return err
+	results := make(chan result, len(rustMutations))
+	var wg sync.WaitGroup
+
+	for _, tc := range rustMutations {
+		tc := tc
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			tempRoot, err := os.MkdirTemp("", "workcell-rust-mutation.")
+			if err != nil {
+				results <- result{label: tc.label, err: err}
+				return
+			}
+			defer os.RemoveAll(tempRoot)
+
+			if err := copyTree(
+				filepath.Join(repoRoot, "runtime", "container", "rust"),
+				filepath.Join(tempRoot, "runtime", "container", "rust"),
+			); err != nil {
+				results <- result{label: tc.label, err: err}
+				return
+			}
+			if err := applyMutation(filepath.Join(tempRoot, tc.relativePath), tc.original, tc.replacement); err != nil {
+				results <- result{label: tc.label, err: err}
+				return
+			}
+			exitCode, err := runCommand(filepath.Join(tempRoot, "runtime", "container", "rust"), commandSpec{
+				Path: "cargo",
+				Args: []string{"test", "--locked", "--offline"},
+			})
+			if err != nil {
+				results <- result{label: tc.label, err: err}
+				return
+			}
+			results <- result{label: tc.label, pass: exitCode == 0}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	var failures []string
+	for r := range results {
+		if r.err != nil {
+			return r.err
 		}
-		if err := applyMutation(filepath.Join(tempRoot, tc.relativePath), tc.original, tc.replacement); err != nil {
-			return err
-		}
-		exitCode, err := runCommand(filepath.Join(tempRoot, "runtime", "container", "rust"), commandSpec{
-			Path: "cargo",
-			Args: []string{"test", "--locked", "--offline"},
-		})
-		if err != nil {
-			return err
-		}
-		if exitCode == 0 {
-			failures = append(failures, tc.label)
+		if r.pass {
+			failures = append(failures, r.label)
 		}
 	}
 	if len(failures) > 0 {

--- a/runtime/container/.dockerignore
+++ b/runtime/container/.dockerignore
@@ -1,0 +1,6 @@
+.git
+**/.DS_Store
+**/*.log
+**/node_modules
+**/__pycache__
+**/.cache

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -55,7 +55,6 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
        && return 0; \
      } \
   && for attempt in 1 2 3; do \
-       rm -rf /var/lib/apt/lists/*; \
        if DEBIAN_FRONTEND=noninteractive apt-get update \
          && install_runtime_packages; then \
          break; \
@@ -63,6 +62,7 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
        if [[ "${attempt}" -eq 3 ]]; then \
          exit 1; \
        fi; \
+       rm -rf /var/lib/apt/lists/*; \
        sleep "$((attempt * 5))"; \
      done \
   && ln -sf /usr/bin/fdfind /usr/local/bin/fd \
@@ -86,16 +86,22 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /var/cache/debconf/*-old /var/cache/ldconfig/aux-cache \
   && rm -f /etc/ld.so.cache \
   && find /var/log -type f -delete \
-  && find / \
-    \( \
-      -path '/dev' -o -path '/dev/*' -o \
-      -path '/proc' -o -path '/proc/*' -o \
-      -path '/run' -o -path '/run/*' -o \
-      -path '/sys' -o -path '/sys/*' -o \
-      -path '/tmp' -o -path '/tmp/*' \
-    \) -prune -o \
-    \( -path '/etc/hostname' -o -path '/etc/hosts' -o -path '/etc/resolv.conf' \) -prune -o \
-    -print0 | LC_ALL=C sort -z | xargs -0 touch -h -d "@${SOURCE_DATE_EPOCH}"
+  && find \
+      /etc/apt \
+      /etc/workcell \
+      /opt/workcell \
+      /state \
+      /usr/local/bin \
+      /usr/local/lib \
+      /usr/local/libexec \
+      /usr/share \
+      /var \
+      \( \
+        -path '/var/lib/apt/lists' -o \
+        -path '/var/cache/apt' \
+      \) -prune -o \
+      \( -path '/etc/hostname' -o -path '/etc/hosts' -o -path '/etc/resolv.conf' \) -prune -o \
+      -print0 | LC_ALL=C sort -z | xargs -0 touch -h -d "@${SOURCE_DATE_EPOCH}"
 
 FROM runtime-base AS provider-builder
 
@@ -121,12 +127,7 @@ RUN install_provider_packages() { \
        npm cache clean --force >/dev/null 2>&1 || true; \
        sleep "$((attempt * 5))"; \
      done \
-  && npm cache clean --force \
-  && find /opt/workcell/providers -print0 | LC_ALL=C sort -z | xargs -0 touch -h -d "@${SOURCE_DATE_EPOCH}" \
-  && tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner \
-    -cf /opt/workcell/providers.tar -C /opt/workcell/providers . \
-  && rm -rf /opt/workcell/providers \
-  && rm -rf /root/.npm /root/.cache
+  && find /opt/workcell/providers -print0 | LC_ALL=C sort -z | xargs -0 touch -h -d "@${SOURCE_DATE_EPOCH}"
 
 FROM runtime-base AS runtime-builder
 
@@ -168,7 +169,6 @@ RUN install_runtime_builder_packages() { \
       && return 0; \
     } \
   && for attempt in 1 2 3; do \
-       rm -rf /var/lib/apt/lists/*; \
        if DEBIAN_FRONTEND=noninteractive apt-get update \
          && install_runtime_builder_packages; then \
          break; \
@@ -176,6 +176,7 @@ RUN install_runtime_builder_packages() { \
        if [[ "${attempt}" -eq 3 ]]; then \
          exit 1; \
        fi; \
+       rm -rf /var/lib/apt/lists/*; \
        sleep "$((attempt * 5))"; \
      done \
   && toolchain_target="" \
@@ -280,20 +281,9 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
   && touch -d "@${SOURCE_DATE_EPOCH}" /usr/local/libexec/workcell/real/codex \
   && rm -f /tmp/codex.tar.gz
 
-COPY adapters /opt/workcell/adapters
-COPY runtime/container/bin/git /usr/local/libexec/workcell/git-wrapper.sh
-COPY runtime/container/bin/node /usr/local/libexec/workcell/node-wrapper.sh
-COPY runtime/container/bin/apt-helper.sh /usr/local/libexec/workcell/apt-helper.sh
-COPY runtime/container/bin/apt-wrapper.sh /usr/local/libexec/workcell/apt-wrapper.sh
+# Copy ONLY the Rust source before the expensive compile so that changes to
+# adapters or shell scripts do not invalidate the cargo build cache layer.
 COPY runtime/container/rust /workcell-rust
-COPY runtime/container/assurance.sh /usr/local/libexec/workcell/assurance.sh
-COPY runtime/container/development-wrapper.sh /usr/local/libexec/workcell/development-wrapper.sh
-COPY runtime/container/provider-policy.sh /usr/local/libexec/workcell/provider-policy.sh
-COPY runtime/container/home-control-plane.sh /usr/local/libexec/workcell/home-control-plane.sh
-COPY runtime/container/provider-wrapper.sh /usr/local/libexec/workcell/provider-wrapper.sh
-COPY runtime/container/runtime-user.sh /usr/local/libexec/workcell/runtime-user.sh
-COPY runtime/container/public-node-guard.mjs /usr/local/libexec/workcell/public-node-guard.mjs
-COPY runtime/container/entrypoint.sh /usr/local/libexec/workcell/entrypoint.sh
 
 RUN export \
       SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}" \
@@ -321,10 +311,27 @@ RUN export \
   && install -m 0644 /tmp/workcell-rust-target/release/libworkcell_exec_guard.so /usr/local/lib/libworkcell_exec_guard.so \
   && install -m 0644 /tmp/workcell-rust-target/release/workcell-launcher /usr/local/libexec/workcell/core/launcher \
   && install -m 0644 /tmp/workcell-rust-target/release/workcell-git-launcher /usr/local/libexec/workcell/core/git \
-  && mkdir -p /etc/claude-code \
-  && cp /opt/workcell/adapters/claude/managed-settings.json /etc/claude-code/managed-settings.json \
-  && rm -rf /tmp/workcell-rust-target /workcell-rust \
   && printf '/usr/local/lib/libworkcell_exec_guard.so\n' > /etc/ld.so.preload \
+  && rm -rf /tmp/workcell-rust-target /workcell-rust
+
+# Copy adapters and control-plane scripts AFTER cargo build so that changes to
+# these frequently-modified files do not invalidate the Rust compilation cache.
+COPY adapters /opt/workcell/adapters
+COPY runtime/container/bin/git /usr/local/libexec/workcell/git-wrapper.sh
+COPY runtime/container/bin/node /usr/local/libexec/workcell/node-wrapper.sh
+COPY runtime/container/bin/apt-helper.sh /usr/local/libexec/workcell/apt-helper.sh
+COPY runtime/container/bin/apt-wrapper.sh /usr/local/libexec/workcell/apt-wrapper.sh
+COPY runtime/container/assurance.sh /usr/local/libexec/workcell/assurance.sh
+COPY runtime/container/development-wrapper.sh /usr/local/libexec/workcell/development-wrapper.sh
+COPY runtime/container/provider-policy.sh /usr/local/libexec/workcell/provider-policy.sh
+COPY runtime/container/home-control-plane.sh /usr/local/libexec/workcell/home-control-plane.sh
+COPY runtime/container/provider-wrapper.sh /usr/local/libexec/workcell/provider-wrapper.sh
+COPY runtime/container/runtime-user.sh /usr/local/libexec/workcell/runtime-user.sh
+COPY runtime/container/public-node-guard.mjs /usr/local/libexec/workcell/public-node-guard.mjs
+COPY runtime/container/entrypoint.sh /usr/local/libexec/workcell/entrypoint.sh
+
+RUN mkdir -p /etc/claude-code \
+  && cp /opt/workcell/adapters/claude/managed-settings.json /etc/claude-code/managed-settings.json \
   && chmod 0444 \
     /etc/claude-code/managed-settings.json \
   && chmod 0444 \
@@ -360,7 +367,9 @@ ARG SOURCE_DATE_EPOCH
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-COPY --from=provider-builder /opt/workcell/providers.tar /tmp/workcell-providers.tar
+# Copy provider node_modules directly — extraction at build time avoids
+# tar decompression overhead on every container cold start.
+COPY --from=provider-builder /opt/workcell/providers /opt/workcell/providers
 COPY --from=runtime-builder /etc/claude-code/managed-settings.json /etc/claude-code/managed-settings.json
 COPY --from=runtime-builder /etc/ld.so.preload /etc/ld.so.preload
 COPY --from=runtime-builder /opt/workcell/adapters /opt/workcell/adapters
@@ -369,9 +378,6 @@ COPY --from=runtime-builder /usr/local/libexec/workcell /usr/local/libexec/workc
 COPY runtime/container/control-plane-manifest.json /usr/local/libexec/workcell/control-plane-manifest.json
 
 RUN mv /usr/bin/git /usr/local/libexec/workcell/real/git \
-  && mkdir -p /opt/workcell/providers \
-  && tar -xf /tmp/workcell-providers.tar -C /opt/workcell/providers \
-  && rm -f /tmp/workcell-providers.tar \
   && chmod 0644 /usr/local/libexec/workcell/real/git \
   && mv /usr/local/bin/node /usr/local/libexec/workcell/real/node \
   && chmod 0755 /usr/local/libexec/workcell/real/node \

--- a/runtime/container/assurance.sh
+++ b/runtime/container/assurance.sh
@@ -97,3 +97,23 @@ workcell_effective_codex_rules_assurance() {
   effective_mutability="$(workcell_effective_codex_rules_mutability "$@")" || return 1
   workcell_codex_rules_assurance "${effective_mutability}"
 }
+
+emit_session_assurance_notice() {
+  local assurance=""
+
+  if [[ "${WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED:-0}" == "1" ]]; then
+    return 0
+  fi
+
+  assurance="$(workcell_runtime_state_value WORKCELL_SESSION_ASSURANCE || true)"
+  case "${assurance}" in
+    lower-assurance-control-plane-vcs)
+      echo "Workcell warning: this session intentionally exposed readonly workspace control-plane paths for Git VCS operations. Treat workspace control-plane contents as lower-assurance until container exit." >&2
+      export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1
+      ;;
+    lower-assurance-package-mutation)
+      echo "Workcell warning: this session previously ran package-manager mutations as root. In-container control-plane integrity is now lower-assurance until container exit." >&2
+      export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1
+      ;;
+  esac
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "e82273d77f39e5fc1a8c0d3ed7598538c1329f3100bdcfe11dafca4aea0d6c1b"
+      "sha256": "e8e868d0cd42b6fa65276892d6faf559019c643dd94447bc7d80270999dde82a"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",
@@ -124,7 +124,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/assurance.sh",
       "runtime_path": "/usr/local/libexec/workcell/assurance.sh",
-      "sha256": "e4acc20f65d4b98ae1ccc8b04a6a2ba9eae7cbf6fba500f640ce2b1328bdafa0"
+      "sha256": "07c1f00041176babe1b7341ff2d95ac3365dd5f74230247506873f7b757a8e79"
     },
     {
       "kind": "runtime-control-plane",
@@ -142,13 +142,13 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/development-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/development-wrapper.sh",
-      "sha256": "aa38fe3a0fe0bac43a894e80c5f8587150ac0d09c41eade8fb23b23386e2ba4c"
+      "sha256": "26bf6e4b9655169b405593d72bd38637dee2a76001b996b4f4ebbc0c81f30341"
     },
     {
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/entrypoint.sh",
       "runtime_path": "/usr/local/libexec/workcell/entrypoint.sh",
-      "sha256": "3a37cd8db6cbbbc2417d671335303e0bf4ebe5bf013923b6e02bccad443b3c3b"
+      "sha256": "12eff3190732abaa7a745e4a71b59c830368cb48e98ac9a93737c517d57825eb"
     },
     {
       "kind": "runtime-control-plane",
@@ -178,7 +178,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-wrapper.sh",
-      "sha256": "83bf3c5849292ab0ec20e6ce88b062d716d991a8953961e569175b31fe32ef29"
+      "sha256": "bf0627a4f90d6bfd9a118e5d66254bc8e7d3e61f98b0c25552b98148c102ddac"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "e8e868d0cd42b6fa65276892d6faf559019c643dd94447bc7d80270999dde82a"
+      "sha256": "8ded5af6596b9e616051a4dd7e8307810ad1b0dafee8d401327e8e18b261ff12"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/runtime/container/development-wrapper.sh
+++ b/runtime/container/development-wrapper.sh
@@ -58,26 +58,8 @@ sanitize_development_env() {
   export PATH="${TRUSTED_PATH}"
 }
 
-emit_session_assurance_notice() {
-  local assurance=""
-
-  if [[ "${WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED:-0}" == "1" ]]; then
-    return 0
-  fi
-
-  assurance="$(workcell_runtime_state_value WORKCELL_SESSION_ASSURANCE || true)"
-  case "${assurance}" in
-    lower-assurance-control-plane-vcs)
-      echo "Workcell warning: this session intentionally exposed readonly workspace control-plane paths for Git VCS operations. Treat workspace control-plane contents as lower-assurance until container exit." >&2
-      export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1
-      ;;
-    lower-assurance-package-mutation)
-      echo "Workcell warning: this session previously ran package-manager mutations as root. In-container control-plane integrity is now lower-assurance until container exit." >&2
-      export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1
-      ;;
-  esac
-}
-
+# shellcheck source=runtime/container/assurance.sh
+source /usr/local/libexec/workcell/assurance.sh
 # shellcheck source=runtime/container/home-control-plane.sh
 source /usr/local/libexec/workcell/home-control-plane.sh
 # shellcheck source=runtime/container/runtime-user.sh

--- a/runtime/container/entrypoint.sh
+++ b/runtime/container/entrypoint.sh
@@ -21,26 +21,6 @@ source /usr/local/libexec/workcell/home-control-plane.sh
 # shellcheck source=runtime/container/runtime-user.sh
 source /usr/local/libexec/workcell/runtime-user.sh
 
-emit_session_assurance_notice() {
-  local assurance=""
-
-  if [[ "${WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED:-0}" == "1" ]]; then
-    return 0
-  fi
-
-  assurance="$(workcell_runtime_state_value WORKCELL_SESSION_ASSURANCE || true)"
-  case "${assurance}" in
-    lower-assurance-control-plane-vcs)
-      echo "Workcell warning: this session intentionally exposed readonly workspace control-plane paths for Git VCS operations. Treat workspace control-plane contents as lower-assurance until container exit." >&2
-      export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1
-      ;;
-    lower-assurance-package-mutation)
-      echo "Workcell warning: this session previously ran package-manager mutations as root. In-container control-plane integrity is now lower-assurance until container exit." >&2
-      export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1
-      ;;
-  esac
-}
-
 WORKCELL_FILE_TRACE_CHILD_PID=""
 WORKCELL_FILE_TRACE_STATUS=0
 WORKCELL_FILE_TRACE_TEARDOWN_DONE=0

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -54,26 +54,6 @@ sanitize_provider_env() {
   export PATH="${TRUSTED_PATH}"
 }
 
-emit_session_assurance_notice() {
-  local assurance=""
-
-  if [[ "${WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED:-0}" == "1" ]]; then
-    return 0
-  fi
-
-  assurance="$(workcell_runtime_state_value WORKCELL_SESSION_ASSURANCE || true)"
-  case "${assurance}" in
-    lower-assurance-control-plane-vcs)
-      echo "Workcell warning: this session intentionally exposed readonly workspace control-plane paths for Git VCS operations. Treat workspace control-plane contents as lower-assurance until container exit." >&2
-      export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1
-      ;;
-    lower-assurance-package-mutation)
-      echo "Workcell warning: this session previously ran package-manager mutations as root. In-container control-plane integrity is now lower-assurance until container exit." >&2
-      export WORKCELL_SESSION_ASSURANCE_NOTICE_EMITTED=1
-      ;;
-  esac
-}
-
 emit_codex_rules_mutability_notice() {
   local configured_mutability=""
   local effective_mutability=""

--- a/scripts/lib/trusted-entrypoint.sh
+++ b/scripts/lib/trusted-entrypoint.sh
@@ -1,0 +1,23 @@
+# shellcheck shell=bash
+# Common sanitized-entrypoint preamble for host-side scripts.
+# Source this file immediately after the shebang line of scripts that require
+# a trusted PATH environment and clean process environment.
+# Callers must use a #!/bin/bash -p shebang.
+readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
+  exec /usr/bin/env -i \
+    PATH="${TRUSTED_HOST_PATH}" \
+    HOME="${HOME:-/tmp}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    WORKCELL_SANITIZED_ENTRYPOINT=1 \
+    /bin/bash -p "$0" "$@"
+fi
+set -euo pipefail
+export PATH="${TRUSTED_HOST_PATH}"
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required tool: $1" >&2
+    exit 1
+  }
+}

--- a/scripts/run-scenario-tests.sh
+++ b/scripts/run-scenario-tests.sh
@@ -21,14 +21,12 @@ case "${1:-}" in
 esac
 
 CURRENT_PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
-
-passed=0
-failed=0
-skipped=0
 SCENARIO_LIST="$(mktemp "${TMPDIR:-/tmp}/workcell-scenarios.XXXXXX")"
+RESULTS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-scenario-results.XXXXXX")"
 
 cleanup() {
   rm -f "${SCENARIO_LIST}"
+  rm -rf "${RESULTS_DIR}"
 }
 trap cleanup EXIT
 
@@ -46,6 +44,7 @@ scenario_platform_matches() {
   esac
 }
 
+# Returns: 0 = pass, 1 = fail, 2 = skip
 run_scenario() {
   local scenario_id="$1"
   local test_file="$2"
@@ -56,48 +55,42 @@ run_scenario() {
 
   if [[ "${manual}" == "1" ]]; then
     echo "SKIP ${scenario_id} (manual lane)"
-    skipped=$((skipped + 1))
-    return
+    return 2
   fi
 
   if ! scenario_platform_matches "${platform}"; then
     echo "SKIP ${scenario_id} (platform ${platform})"
-    skipped=$((skipped + 1))
-    return
+    return 2
   fi
 
   if [[ "${RUN_ALL}" -eq 0 ]] && [[ "${lane}" != "secretless" ]]; then
     echo "SKIP ${scenario_id} (lane ${lane})"
-    skipped=$((skipped + 1))
-    return
+    return 2
   fi
 
   if [[ "${RUN_ALL}" -eq 0 ]] && [[ "${requires_creds}" == "1" ]]; then
     echo "SKIP ${scenario_id} (requires credentials)"
-    skipped=$((skipped + 1))
-    return
+    return 2
   fi
 
   if [[ -z "${test_file}" ]]; then
     echo "SKIP ${scenario_id} (no test_file)"
-    skipped=$((skipped + 1))
-    return
+    return 2
   fi
 
   local full_test_path="${SCENARIO_ROOT}/${test_file}"
 
   if [[ ! -f "${full_test_path}" ]]; then
     echo "SKIP ${scenario_id} (test file not found: ${test_file})"
-    skipped=$((skipped + 1))
-    return
+    return 2
   fi
 
   if bash "${full_test_path}"; then
     echo "PASS ${scenario_id}"
-    passed=$((passed + 1))
+    return 0
   else
     echo "FAIL ${scenario_id}"
-    failed=$((failed + 1))
+    return 1
   fi
 }
 
@@ -105,9 +98,44 @@ if ! "${ROOT_DIR}/scripts/lib/scenario_manifest" list-tsv "${MANIFEST}" >"${SCEN
   exit 1
 fi
 
+# Run all scenarios in parallel; each writes its exit code to a per-index file.
+idx=0
+declare -a pids=()
+
 while IFS=$'\t' read -r scenario_id test_file requires_creds lane platform manual; do
-  run_scenario "${scenario_id}" "${test_file}" "${requires_creds}" "${lane}" "${platform}" "${manual}"
+  idx=$((idx + 1))
+  result_file="${RESULTS_DIR}/${idx}.exit"
+  (
+    exit_code=0
+    run_scenario "${scenario_id}" "${test_file}" "${requires_creds}" "${lane}" "${platform}" "${manual}" || exit_code="$?"
+    printf '%d\n' "${exit_code}" >"${result_file}"
+  ) &
+  pids+=($!)
 done <"${SCENARIO_LIST}"
+
+# Wait for all background jobs to complete
+for pid in "${pids[@]}"; do
+  wait "${pid}" || true
+done
+
+# Aggregate results from per-scenario exit files.
+# Exit codes: 0 = pass, 1 = fail, 2 = skip
+passed=0
+failed=0
+skipped=0
+for i in $(seq 1 "${idx}"); do
+  result_file="${RESULTS_DIR}/${i}.exit"
+  if [[ -f "${result_file}" ]]; then
+    code=$(<"${result_file}")
+    case "${code}" in
+      0) passed=$((passed + 1)) ;;
+      2) skipped=$((skipped + 1)) ;;
+      *) failed=$((failed + 1)) ;;
+    esac
+  else
+    failed=$((failed + 1))
+  fi
+done
 
 echo ""
 echo "Results: passed=${passed} failed=${failed} skipped=${skipped}"

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -39,11 +39,13 @@ require_tool git
 require_cargo_subcommand clippy
 
 METADATAUTIL_BIN=""
+BUILD_CACHE_DIR="${ROOT_DIR}/.workcell-build-cache"
 
 cleanup() {
   if [[ -n "${METADATAUTIL_BIN}" && -e "${METADATAUTIL_BIN}" ]]; then
     rm -f "${METADATAUTIL_BIN}"
   fi
+  rm -rf "${BUILD_CACHE_DIR}"
 }
 
 build_metadatautil() {
@@ -124,6 +126,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/dev-remote-validate.sh"
   "${ROOT_DIR}/scripts/lib/extract_direct_mounts"
   "${ROOT_DIR}/scripts/lib/go-run-env.sh"
+  "${ROOT_DIR}/scripts/lib/trusted-entrypoint.sh"
   "${ROOT_DIR}/scripts/lib/manage_injection_policy"
   "${ROOT_DIR}/scripts/lib/pty_transcript"
   "${ROOT_DIR}/scripts/lib/render_injection_bundle"
@@ -343,6 +346,10 @@ fi
 
 "${ROOT_DIR}/scripts/run-mutation-tests.sh"
 "${ROOT_DIR}/scripts/verify-coverage.sh"
+
+# Pre-build hostutil so scenario tests skip `go run` overhead on every invocation
+mkdir -p "${BUILD_CACHE_DIR}"
+(cd "${ROOT_DIR}" && go build -buildvcs=false -o "${BUILD_CACHE_DIR}/hostutil" ./cmd/workcell-hostutil)
 
 # Check E: Scenario coverage and control-plane parity
 "${ROOT_DIR}/scripts/run-scenario-tests.sh" --secretless-only

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2374,7 +2374,7 @@ for script in "${HOST_GATE_SCRIPTS[@]}"; do
     echo "Expected ${script} to use an absolute privileged Bash shebang before self-sanitizing its host entrypoint" >&2
     exit 1
   fi
-  if ! rg -q 'WORKCELL_SANITIZED_ENTRYPOINT' "${script}"; then
+  if ! rg -q 'WORKCELL_SANITIZED_ENTRYPOINT|trusted-entrypoint\.sh' "${script}"; then
     echo "Expected ${script} to self-sanitize its host entrypoint before running release or boundary checks" >&2
     exit 1
   fi

--- a/scripts/verify-upstream-claude-release.sh
+++ b/scripts/verify-upstream-claude-release.sh
@@ -1,15 +1,6 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
-fi
-set -euo pipefail
-export PATH="${TRUSTED_HOST_PATH}"
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
@@ -28,13 +19,6 @@ cleanup() {
 }
 
 trap cleanup EXIT
-
-require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
-}
 
 extract_claude_version() {
   (cd "${ROOT_DIR}" && go run ./cmd/workcell-metadatautil extract-dockerfile-arg "${DOCKERFILE_PATH}" CLAUDE_VERSION)

--- a/scripts/verify-upstream-codex-release.sh
+++ b/scripts/verify-upstream-codex-release.sh
@@ -1,15 +1,6 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
-fi
-set -euo pipefail
-export PATH="${TRUSTED_HOST_PATH}"
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
@@ -28,13 +19,6 @@ cleanup() {
 }
 
 trap cleanup EXIT
-
-require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
-}
 
 extract_codex_version() {
   (cd "${ROOT_DIR}" && go run ./cmd/workcell-metadatautil extract-dockerfile-arg "${DOCKERFILE_PATH}" CODEX_VERSION)

--- a/scripts/verify-upstream-gemini-release.sh
+++ b/scripts/verify-upstream-gemini-release.sh
@@ -1,15 +1,6 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
-fi
-set -euo pipefail
-export PATH="${TRUSTED_HOST_PATH}"
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
@@ -20,13 +11,6 @@ fi
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PACKAGE_JSON_PATH="${ROOT_DIR}/runtime/container/providers/package.json"
 PACKAGE_LOCK_PATH="${ROOT_DIR}/runtime/container/providers/package-lock.json"
-
-require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
-}
 
 require_tool curl
 require_tool jq

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -146,6 +146,11 @@ run_clean_host_command_in_dir() {
 
 HOST_GO_BIN="$(resolve_fixed_host_tool go /opt/homebrew/bin/go /usr/local/go/bin/go /usr/local/bin/go /usr/bin/go)"
 go_hostutil() {
+  local prebuilt="${ROOT_DIR}/.workcell-build-cache/hostutil"
+  if [[ -x "${prebuilt}" ]]; then
+    "${prebuilt}" "$@"
+    return
+  fi
   ensure_go_run_env
   run_clean_host_command_in_dir "${ROOT_DIR}" env \
     GOPATH="${GOPATH}" \
@@ -164,6 +169,11 @@ go_colimautil() {
 }
 
 go_runtimeutil() {
+  local prebuilt="${ROOT_DIR}/.workcell-build-cache/runtimeutil"
+  if [[ -x "${prebuilt}" ]]; then
+    "${prebuilt}" "$@"
+    return
+  fi
   ensure_go_run_env
   run_clean_host_command_in_dir "${ROOT_DIR}" env \
     GOPATH="${GOPATH}" \

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -148,7 +148,7 @@ HOST_GO_BIN="$(resolve_fixed_host_tool go /opt/homebrew/bin/go /usr/local/go/bin
 go_hostutil() {
   local prebuilt="${ROOT_DIR}/.workcell-build-cache/hostutil"
   if [[ -x "${prebuilt}" ]]; then
-    "${prebuilt}" "$@"
+    run_clean_host_command_in_dir "${ROOT_DIR}" "${prebuilt}" "$@"
     return
   fi
   ensure_go_run_env
@@ -171,7 +171,7 @@ go_colimautil() {
 go_runtimeutil() {
   local prebuilt="${ROOT_DIR}/.workcell-build-cache/runtimeutil"
   if [[ -x "${prebuilt}" ]]; then
-    "${prebuilt}" "$@"
+    run_clean_host_command_in_dir "${ROOT_DIR}" "${prebuilt}" "$@"
     return
   fi
   ensure_go_run_env

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-session-scenario.XXXXXX")"
 TMP_DIR="$(cd "${TMP_DIR}" && pwd -P)"
-REAL_HOME="$(cd "${ROOT_DIR}" && go run ./cmd/workcell-hostutil path home)"
+# shellcheck source=/dev/null
+source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
+REAL_HOME="$(resolve_workcell_real_home)"
 PROFILE="wcl-session-scenario-$$"
 SESSION_ONE="20260408T100000Z-11111111-$$"
 SESSION_TWO="20260408T110000Z-22222222-$$"


### PR DESCRIPTION
## Summary
- speed up container builds by preserving expensive layers and build caches
- parallelize mutation, Go, and scenario validation paths to reduce wall-clock time
- simplify trusted entrypoint and assurance shell logic while updating control-plane hashes
- fix validator regressions around Go 1.26 parallel tests, scrubbed-host HOME handling, and session scenario home resolution
- add the v0.9.1 changelog entry and a repo-local commit notation skill for Codex

## Why
- the branch focuses on faster developer feedback loops without weakening the runtime boundary
- the follow-up fixes keep the validation and publish path green after the performance changes
- the new skill documents the repo's required risk-aware commit format for future signed commits

## Impact
- container and scenario workflows should complete faster
- duplicated shell logic is reduced across runtime wrappers and verification scripts
- cached host helper binaries now preserve the same sanitized HOME behavior as the go-run fallback
- contributor tooling now includes explicit commit notation guidance

## Validation
- `./scripts/validate-repo.sh`