### PR TITLE
Disable execution of workspace cache host/runtime binaries

### DIFF
--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "01d16bc8495aa41dfd3a25f54acf28e718df7b5eb5b67328db67ca7764fd63e5"
+      "sha256": "52b5be6ab429155970bf1a8a92088de918584c792bb013f32f7b965dc6618519"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -146,11 +146,6 @@ run_clean_host_command_in_dir() {
 
 HOST_GO_BIN="$(resolve_fixed_host_tool go /opt/homebrew/bin/go /usr/local/go/bin/go /usr/local/bin/go /usr/bin/go)"
 go_hostutil() {
-  local prebuilt="${ROOT_DIR}/.workcell-build-cache/hostutil"
-  if [[ -x "${prebuilt}" ]]; then
-    run_clean_host_command_in_dir "${ROOT_DIR}" "${prebuilt}" "$@"
-    return
-  fi
   ensure_go_run_env
   run_clean_host_command_in_dir "${ROOT_DIR}" env \
     GOPATH="${GOPATH}" \
@@ -169,11 +164,6 @@ go_colimautil() {
 }
 
 go_runtimeutil() {
-  local prebuilt="${ROOT_DIR}/.workcell-build-cache/runtimeutil"
-  if [[ -x "${prebuilt}" ]]; then
-    run_clean_host_command_in_dir "${ROOT_DIR}" "${prebuilt}" "$@"
-    return
-  fi
   ensure_go_run_env
   run_clean_host_command_in_dir "${ROOT_DIR}" env \
     GOPATH="${GOPATH}" \


### PR DESCRIPTION
### Motivation
- Prevent crossing the container/host trust boundary by removing execution of workspace-local cached binaries under `${ROOT_DIR}/.workcell-build-cache`, which an attacker-controlled workspace could populate.

### Description
- Remove the fast-path in `scripts/workcell` that directly executed `${ROOT_DIR}/.workcell-build-cache/hostutil` and `${ROOT_DIR}/.workcell-build-cache/runtimeutil` so `go_hostutil` and `go_runtimeutil` always invoke `go run` in the sanitized host environment.

### Testing
- Ran `bash -n scripts/workcell` to validate shell syntax, which succeeded.  
- Attempted `./scripts/workcell --help` but it failed with `Missing trusted host tool: go` due to the test environment lacking a trusted `go` binary, which is an environment limitation rather than a functional regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dedbd37dbc8329b4f8fd9f8fee4914)