### PR TITLE
docs: formalize release and async review policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Summary
+# Summary
 
 - change:
 - reason:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,35 @@
-# Summary
+## Summary
 
-<!-- What does this change and why? -->
+- change:
+- reason:
+- user-visible impact:
 
-## Type of change
+## Validation
 
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Documentation
-- [ ] Dependency update
-- [ ] Refactor / simplification
-- [ ] Security hardening
+- [ ] I ran the relevant local validation for this change
+- [ ] Required CI is expected to cover the remaining validation
+- [ ] I updated docs, policy, or verification when the change affects release,
+      provenance, hosted controls, or security posture
 
-## Checklist
+## Review sweep
 
-- [ ] `./scripts/dev-quick-check.sh` passes locally
-- [ ] Tests added or updated for the change
-- [ ] Docs updated if behavior changes (same PR)
-- [ ] `CHANGELOG.md` updated if user-visible behavior changes
-- [ ] Invariants preserved — no silent trust widening
-- [ ] If touching runtime boundary or policy: linked the relevant section of
-      `docs/invariants.md` or `docs/threat-model.md` below
+- [ ] I checked top-level PR comments
+- [ ] I checked inline review comments
+- [ ] I checked unresolved review threads
+- [ ] I addressed or explicitly dispositioned actionable feedback
+- [ ] I will re-check comments after CI turns green before merging
+- [ ] I will do one final comment sweep immediately before merging
 
-## Runtime / trust notes
+## Async reviewer note
 
-<!-- If this touches runtime/, adapters/, policy/, or .github/workflows/,
-     describe the trust assumptions the change depends on. Otherwise delete
-     this section. -->
+This repository expects asynchronous review comments from humans and from the
+configured async reviewers listed in `policy/reviewer-identities.toml`. Do not
+merge until those comments have been swept and any actionable feedback has been
+handled.
 
-## Related issues
+## Security and release impact
 
-<!-- Closes #NNN -->
+- [ ] No release or provenance impact
+- [ ] This changes release behavior, release assets, provenance, SBOMs,
+      attestations, workflow permissions, or hosted controls
+- [ ] I updated the relevant runbook or policy files for that impact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,43 @@ the runtime boundary or explicit security guarantees in the name of convenience.
   plane.
 - Ship invariant checks with new controls whenever practical.
 
+## Pull request workflow
+
+- Every PR should remain open for comments and review before merge.
+- Every PR must be checked for:
+  - top-level PR comments
+  - inline review comments
+  - unresolved review threads
+  - asynchronous review comments from configured async reviewers listed in
+    `policy/reviewer-identities.toml`
+- Actionable comments must be addressed or explicitly dispositioned before
+  merge.
+- Re-check comments and review threads after CI turns green and immediately
+  before merge.
+- Async reviewer feedback is advisory input, not a substitute for an
+  independent human approval.
+
+## Release workflow
+
+- For release requests, follow `docs/releasing.md`.
+- Workcell currently operates in single-maintainer release mode. Do not claim
+  independent approval or separation of duties unless it actually happened.
+- Review open pull requests, review feedback, and PR comments before cutting a
+  release, and address actionable feedback as part of the release workflow.
+- Use host-side `./scripts/workcell publish-pr` for release PR publication.
+- Wait for the merged `main` commit to finish required GitHub Actions workflows
+  successfully before pushing the signed release tag.
+- After pushing a release tag, follow the `Release` workflow to completion and
+  verify the GitHub release exists with uploaded assets.
+- In the current single-maintainer operating mode, approving the `release`
+  environment is part of finishing the release when the release workflow is
+  otherwise green.
+- If a release tag already exists and its release workflow failed, do not
+  rewrite or delete the tag. Patch `main` and cut the next patch release
+  instead.
+- Prefer immutable GitHub releases and treat mutable release state as a hosted
+  control gap to close.
+
 ## Change discipline
 
 - Root files define shared contracts; keep them concise.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -28,6 +28,24 @@ not need blanket authority across the whole repository.
 Contributors improve code, docs, tests, workflows, and design material through
 pull requests and issues.
 
+## Current operating mode
+
+Workcell currently operates as a single-maintainer project.
+
+That means:
+
+- routine merges and releases may be performed by one maintainer
+- asynchronous review from humans and configured async reviewers is expected
+  and should be swept before merge
+- asynchronous review is advisory input, not equivalent to an independent
+  human approval
+- the project relies on signed history, strict CI, reproducibility checks,
+  provenance, SBOMs, attestations, hosted controls, and public review artifacts
+  as compensating controls
+
+This is lower assurance than true separation of duties and should be described
+honestly.
+
 ## Decision process
 
 Most changes should land through the normal pull request flow.
@@ -39,6 +57,14 @@ release provenance, or hosted controls should include:
 - the validation or evidence added with the change
 - a clear note about any new or widened lower-assurance behavior
 
+Every mergeable PR should also receive a comment sweep before merge:
+
+- top-level comments reviewed
+- inline comments reviewed
+- unresolved threads resolved or explicitly dispositioned
+- asynchronous reviewer comments checked again after CI turns green
+- one final comment sweep completed immediately before merge
+
 When a change is large or controversial, open an issue first and describe the
 problem, alternatives, and invariants that must remain intact.
 
@@ -47,6 +73,10 @@ problem, alternatives, and invariants that must remain intact.
 Workcell is currently pre-1.0. Breaking changes may happen, but they should be
 called out in [CHANGELOG.md](CHANGELOG.md), reflected in the docs, and kept
 deliberate rather than incidental.
+
+Releases normally land through a short-lived release PR, followed by green
+post-merge `main` CI, a signed tag, the tagged `Release` workflow, and final
+verification of the published GitHub release and assets.
 
 ## Becoming a reviewer or maintainer
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,12 +6,28 @@
 |---|---|---|
 | `@omkhar` | Lead maintainer | runtime boundary, adapters, release posture, policy, docs |
 
+## Current release mode
+
+- Workcell currently operates in single-maintainer release mode.
+- `@omkhar` may merge release PRs, approve the `release` environment, and cut
+  signed tags after required checks and comment sweeps succeed.
+- Asynchronous review from humans and configured async reviewers is expected
+  input but is not a substitute for an independent maintainer.
+- Release status should describe this honestly as single-maintainer operation,
+  not as multi-party approval.
+
 ## Review expectations
 
 - boundary- or policy-affecting changes should not merge without maintainer
   review
 - contributor-facing docs should stay aligned with shipped behavior
 - release and provenance changes should include verification updates
+- every PR should be checked for top-level comments, inline review comments,
+  and unresolved review threads before merge
+- actionable comments from human or asynchronous reviewers should be addressed
+  or explicitly dispositioned before merge
+- comments should be checked again after CI turns green and immediately before
+  merge
 
 ## Growth plan
 
@@ -21,6 +37,8 @@ The project intends to add reviewers and maintainers over time, starting with:
 - provider adapter review capacity
 - docs and onboarding review capacity
 - release and supply-chain review capacity
+- at least one backup release approver who can independently review or approve
+  security-sensitive release work when available
 
 See [GOVERNANCE.md](GOVERNANCE.md) for the role model and
 [ROADMAP.md](ROADMAP.md) for the near-term priorities.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,355 @@
+# Releasing Workcell
+
+This runbook defines the repeatable process for cutting a new Workcell release.
+
+## Current assurance model
+
+Workcell currently operates in single-maintainer release mode.
+
+That means:
+
+- one maintainer may open, merge, tag, approve the release environment, and
+  verify publication
+- asynchronous review from humans and configured async reviewers is still
+  expected and must be swept before merge
+- asynchronous review is advisory input, not equivalent to an independent
+  human approval
+- signed history, strict CI, reproducibility checks, provenance, SBOMs,
+  attestations, immutable releases, and public review artifacts are the primary
+  compensating controls
+
+This is lower assurance than true separation of duties and should be described
+honestly in docs, status reports, and release commentary.
+
+## Principles
+
+- Review and finish open pull requests before cutting a release.
+- Address actionable PR comments and review feedback as part of release work.
+- Use signed commits and signed tags.
+- Before tagging a release, make sure shipped features are documented and do
+  not remain on the roadmap. Remove roadmap items only after the code and
+  focused validation confirm they are fully implemented.
+- Publish PRs from the host with `./scripts/workcell publish-pr`.
+- Wait for `main` to be green before pushing the release tag.
+- Follow the tag-triggered `Release` workflow through completion.
+- Approve the `release` environment only after release preflight and install
+  verification are green.
+- Verify the published GitHub release, attached assets, and immutable-release
+  state before concluding.
+- Do not rewrite or delete a failed release tag. Recover by patching `main` and
+  cutting the next patch release.
+
+## Inputs
+
+Set these values before starting:
+
+```sh
+export REPO="omkhar/workcell"
+export VERSION="v0.9.3"
+export RELEASE_BRANCH="codex/release-${VERSION}"
+export RELEASE_TITLE="Release ${VERSION}"
+```
+
+If a previously pushed release tag already failed, do not reuse it. Bump the
+patch version instead.
+
+## PR comment sweep
+
+Every PR involved in the release path must go through a comment sweep.
+
+Configured async reviewer identities live in
+`policy/reviewer-identities.toml`.
+
+A PR is not ready to merge until all of the following are true:
+
+- top-level PR comments have been reviewed
+- inline review comments and review threads have been reviewed
+- unresolved review threads are resolved or explicitly closed with rationale
+- actionable comments from human reviewers and configured async reviewers are
+  fixed or answered
+- the comment sweep has been repeated after CI turned green
+- the comment sweep has been repeated immediately before merge
+
+If no async reviewer identities are configured, still sweep all PR comments,
+review comments, and unresolved review threads before merge.
+
+The required sweep points are:
+
+1. after the PR is published
+2. after required CI turns green
+3. immediately before merge
+
+Useful commands:
+
+```sh
+gh pr view <pr-number> --repo "${REPO}" --comments
+gh pr checks <pr-number> --repo "${REPO}"
+```
+
+Use the GitHub API or GraphQL as needed to inspect unresolved review threads.
+
+## 1. Start from a clean `main` worktree
+
+Use a dedicated release worktree or an otherwise clean checkout rooted at
+`main`.
+
+```sh
+git fetch origin --tags
+git checkout main
+git pull --ff-only origin main
+```
+
+Confirm the working tree is clean before making release changes.
+
+## 2. Review open pull requests first
+
+List open PRs:
+
+```sh
+gh pr list --repo "${REPO}" --state open
+```
+
+For each open PR that is part of the release path:
+
+1. inspect the PR, changed files, checks, reviews, and comments
+2. perform the PR comment sweep
+3. address actionable review feedback and comment threads
+4. re-run or fix CI until the PR is green
+5. perform the PR comment sweep again after CI is green
+6. merge only after the final pre-merge comment sweep succeeds
+
+Useful commands:
+
+```sh
+gh pr view <pr-number> --repo "${REPO}" --comments --web
+gh pr checks <pr-number> --repo "${REPO}" --watch
+gh pr diff <pr-number> --repo "${REPO}"
+```
+
+## 3. Confirm the next version
+
+Check the latest existing tags before choosing the next release:
+
+```sh
+git tag --sort=-v:refname | head
+```
+
+Rules:
+
+- normal case: cut the next patch release
+- recovery case: if a release tag already exists but its release workflow
+  failed, do not reuse that tag; patch `main` and cut the next patch release
+
+## 4. Prepare the release branch
+
+Create the release branch from up-to-date `main`:
+
+```sh
+git checkout -b "${RELEASE_BRANCH}"
+```
+
+Update the changelog for the new version and date.
+
+Before opening the release PR, sweep the roadmap and nearby planning docs:
+
+- remove features from `ROADMAP.md` only when the current code and tests prove
+  they are shipped
+- keep any partially implemented work on the roadmap
+- update user or design docs when shipped features would otherwise still appear
+  as future work
+
+Before opening the release PR, verify release inputs that commonly drift:
+
+```sh
+./scripts/update-upstream-pins.sh --check
+```
+
+If the check fails because reviewed upstream pins or Debian snapshots drifted,
+refresh them:
+
+```sh
+./scripts/update-upstream-pins.sh --apply
+```
+
+Then update the changelog entry to describe the refresh and continue with the
+new patch version if needed.
+
+Run the focused validation needed to justify roadmap and documentation updates
+before committing:
+
+```sh
+./tests/scenarios/shared/test-auth-commands.sh
+./tests/scenarios/shared/test-auth-status.sh
+./tests/scenarios/shared/test-session-commands.sh
+```
+
+Then run basic validation before committing:
+
+```sh
+git diff --check
+```
+
+Create a signed release commit:
+
+```sh
+git add -A
+git commit -S -m "release: ${VERSION}"
+```
+
+## 5. Publish the release PR from the host
+
+Prepare and publish the release PR with the host-side helper:
+
+```sh
+./scripts/workcell publish-pr
+```
+
+As soon as the PR exists, perform the first PR comment sweep.
+
+## 6. Follow release PR checks and comments until green
+
+Stay on the release PR until all required checks succeed and all actionable
+comments are addressed.
+
+Useful commands:
+
+```sh
+gh pr checks <pr-number> --repo "${REPO}" --watch
+gh pr view <pr-number> --repo "${REPO}" --comments
+```
+
+If CI fails:
+
+1. inspect the failing workflow or job logs
+2. fix the issue on the same release branch
+3. commit with a signed follow-up commit
+4. push and re-run checks
+5. repeat until green
+
+When required checks turn green, perform the second PR comment sweep.
+
+Do not merge while required checks are failing or while comment sweeps are
+incomplete.
+
+## 7. Merge the release PR to `main`
+
+In the current single-maintainer operating model, merge after all of the
+following are true:
+
+- required checks are green
+- the PR comment sweep has been completed after CI turned green
+- the final pre-merge comment sweep has been completed
+- changelog and release notes are correct
+
+After merge, record the resulting `main` commit SHA. This is the commit that
+will be tagged.
+
+## 8. Wait for post-merge `main` CI
+
+Do not tag immediately after merging. First wait for the workflows on the
+merged `main` commit to finish green.
+
+Example:
+
+```sh
+gh run list --repo "${REPO}" --commit <main-commit-sha>
+```
+
+Proceed only when every required workflow on the merge commit has completed
+successfully.
+
+## 9. Create and push the signed tag
+
+Create a signed tag on the merged `main` commit:
+
+```sh
+git tag -s "${VERSION}" -m "${VERSION}" <main-commit-sha>
+git tag -v "${VERSION}"
+git push origin "refs/tags/${VERSION}"
+```
+
+Never move or rewrite an existing release tag.
+
+## 10. Follow the tag-triggered `Release` workflow
+
+Watch the `Release` workflow for the tagged commit until it completes:
+
+```sh
+gh run list --repo "${REPO}" --workflow Release --limit 10
+gh run watch <release-run-id> --repo "${REPO}"
+```
+
+If the workflow enters a waiting state for the `release` environment:
+
+1. verify that preflight and install verification jobs are green
+2. approve the environment in the standard single-maintainer path
+3. continue watching until publication finishes
+
+If the release workflow fails:
+
+1. inspect the failing job and step
+2. determine whether the issue can be fixed on `main`
+3. patch `main` through a normal PR
+4. cut the next patch release
+5. do not rewrite or delete the failed tag
+
+## 11. Verify the GitHub release
+
+Confirm the GitHub release exists and assets are uploaded:
+
+```sh
+gh release view "${VERSION}" --repo "${REPO}" \
+  --json name,tagName,isDraft,isPrerelease,isImmutable,url,assets
+```
+
+At minimum, verify:
+
+- the release record exists
+- the release is not a draft
+- the release is not a prerelease unless intentionally marked that way
+- the release is immutable
+- expected assets are present, including the release tarball, Homebrew formula,
+  checksums, signed metadata, manifests, and SBOMs
+
+If `isImmutable` is false, treat that as a hosted-control regression to fix.
+
+## 12. Final closeout
+
+At the end of the release, confirm all of the following:
+
+- no open PRs remain that should have been part of the release
+- actionable PR comments were addressed or dispositioned
+- `main` is green
+- the signed release tag exists on GitHub
+- the `Release` workflow completed successfully
+- the GitHub release exists with uploaded assets
+- the GitHub release is immutable
+
+## Recovery notes
+
+### Failed release tag already exists
+
+If a release tag was already pushed and its release workflow failed:
+
+- do not delete the tag
+- do not force-move the tag
+- patch `main`
+- cut the next patch release instead
+
+### Upstream drift during release
+
+A common release-preflight failure is drift in reviewed upstream pins or the
+Debian snapshot. Check with:
+
+```sh
+./scripts/update-upstream-pins.sh --check
+```
+
+If drift is reported, apply the refresh:
+
+```sh
+./scripts/update-upstream-pins.sh --apply
+```
+
+Then update the changelog, merge the fix to `main`, and cut the next patch
+release rather than reusing the failed tag.

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -422,16 +422,16 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 	if branchReviewMode == "" {
 		branchReviewMode = "review-gated"
 	}
-	if branchReviewMode != "review-gated" && branchReviewMode != "single-owner-private-pr" {
-		return fmt.Errorf("%s must set branch_review.mode to 'review-gated' or 'single-owner-private-pr'", policyPath)
+	if branchReviewMode != "review-gated" && branchReviewMode != "single-owner-public-pr" && branchReviewMode != "single-owner-private-pr" {
+		return fmt.Errorf("%s must set branch_review.mode to 'review-gated', 'single-owner-public-pr', or 'single-owner-private-pr'", policyPath)
 	}
 	releasePolicy, _ := policy["release_environment"].(map[string]any)
 	releaseMode, _ := releasePolicy["mode"].(string)
 	if releaseMode == "" {
 		releaseMode = "review-gated"
 	}
-	if releaseMode != "review-gated" && releaseMode != "single-owner-private" && releaseMode != "plan-limited-private" {
-		return fmt.Errorf("%s must set release_environment.mode to 'review-gated', 'single-owner-private', or 'plan-limited-private'", policyPath)
+	if releaseMode != "review-gated" && releaseMode != "single-owner-public" && releaseMode != "single-owner-private" && releaseMode != "plan-limited-private" {
+		return fmt.Errorf("%s must set release_environment.mode to 'review-gated', 'single-owner-public', 'single-owner-private', or 'plan-limited-private'", policyPath)
 	}
 	expectedContexts, err := requireStringSliceTable(policy, "required_status_checks", "contexts", policyPath)
 	if err != nil {
@@ -565,30 +565,46 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 			return fmt.Errorf("default-branch review ruleset on %s must require resolved review threads", repo)
 		}
 	} else {
-		if private, _ := repoMeta["private"].(bool); !private {
-			return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s is only valid for private repositories", repo)
-		}
-		if ownerType != "User" {
-			return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s is only valid for user-owned repositories", repo)
-		}
-		if len(directCollaborators) != 1 {
-			return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s requires exactly one direct collaborator", repo)
-		}
-		collaborator, _ := directCollaborators[0].(map[string]any)
-		if login, _ := collaborator["login"].(string); login != ownerLogin {
-			return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s requires the owner to be the only direct collaborator", repo)
-		}
-		permissions, _ := collaborator["permissions"].(map[string]any)
-		if admin, _ := permissions["admin"].(bool); !admin {
-			return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s requires the owner to retain admin permission", repo)
+		if branchReviewMode == "single-owner-private-pr" {
+			if private, _ := repoMeta["private"].(bool); !private {
+				return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s is only valid for private repositories", repo)
+			}
+			if ownerType != "User" {
+				return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s is only valid for user-owned repositories", repo)
+			}
+			if len(directCollaborators) != 1 {
+				return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s requires exactly one direct collaborator", repo)
+			}
+			collaborator, _ := directCollaborators[0].(map[string]any)
+			if login, _ := collaborator["login"].(string); login != ownerLogin {
+				return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s requires the owner to be the only direct collaborator", repo)
+			}
+			permissions, _ := collaborator["permissions"].(map[string]any)
+			if admin, _ := permissions["admin"].(bool); !admin {
+				return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s requires the owner to retain admin permission", repo)
+			}
+		} else {
+			if private, _ := repoMeta["private"].(bool); private {
+				return fmt.Errorf("branch review mode 'single-owner-public-pr' on %s is only valid for public repositories", repo)
+			}
+			if ownerType != "User" {
+				return fmt.Errorf("branch review mode 'single-owner-public-pr' on %s is only valid for user-owned repositories", repo)
+			}
 		}
 		if count, _ := parameters["required_approving_review_count"].(float64); count != 0 {
-			return fmt.Errorf("default-branch review ruleset on %s must require zero approving reviews in single-owner-private-pr mode", repo)
+			return fmt.Errorf("default-branch review ruleset on %s must require zero approving reviews in %s mode", repo, branchReviewMode)
 		}
 		if required, _ := parameters["require_code_owner_review"].(bool); required {
-			return fmt.Errorf("default-branch review ruleset on %s must not require code owner review in single-owner-private-pr mode", repo)
+			return fmt.Errorf("default-branch review ruleset on %s must not require code owner review in %s mode", repo, branchReviewMode)
 		}
-		if resolved, _ := parameters["required_review_thread_resolution"].(bool); resolved {
+		if lastPushApproval, _ := parameters["require_last_push_approval"].(bool); lastPushApproval {
+			return fmt.Errorf("default-branch review ruleset on %s must not require last-push approval in %s mode", repo, branchReviewMode)
+		}
+		resolved, _ := parameters["required_review_thread_resolution"].(bool)
+		if branchReviewMode == "single-owner-public-pr" && !resolved {
+			return fmt.Errorf("default-branch review ruleset on %s must require resolved review threads in single-owner-public-pr mode", repo)
+		}
+		if branchReviewMode == "single-owner-private-pr" && resolved {
 			return fmt.Errorf("default-branch review ruleset on %s must not require resolved review threads in single-owner-private-pr mode", repo)
 		}
 	}
@@ -698,6 +714,36 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		}
 		if len(reviewerRules) > 0 {
 			return fmt.Errorf("release environment on %s must not define reviewer gates in plan-limited-private mode", repo)
+		}
+	case "single-owner-public":
+		if private, _ := repoMeta["private"].(bool); private {
+			return fmt.Errorf("release environment mode 'single-owner-public' on %s is only valid for public repositories", repo)
+		}
+		if ownerType != "User" {
+			return fmt.Errorf("release environment mode 'single-owner-public' on %s is only valid for user-owned repositories", repo)
+		}
+		if len(reviewerRules) == 0 {
+			return fmt.Errorf("release environment on %s must define a reviewer gate in single-owner-public mode", repo)
+		}
+		hasReviewer := false
+		for _, rule := range reviewerRules {
+			if reviewers, _ := rule["reviewers"].([]any); len(reviewers) > 0 {
+				hasReviewer = true
+			}
+			if preventSelfReview, _ := rule["prevent_self_review"].(bool); preventSelfReview {
+				return fmt.Errorf("release environment on %s must allow self-review in single-owner-public mode", repo)
+			}
+		}
+		if !hasReviewer {
+			return fmt.Errorf("release environment on %s must define at least one reviewer in single-owner-public mode", repo)
+		}
+		if bypass, _ := releaseEnv["can_admins_bypass"].(bool); bypass {
+			return fmt.Errorf("release environment on %s must not allow administrator bypass", repo)
+		}
+		if adminBypassRule != nil {
+			if enabled, _ := adminBypassRule["enabled"].(bool); enabled {
+				return fmt.Errorf("release environment on %s must not allow administrator bypass", repo)
+			}
 		}
 	default:
 		if private, _ := repoMeta["private"].(bool); !private {
@@ -1775,8 +1821,8 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	}
 	releaseEnvironment, _ := hostedControlsPolicy["release_environment"].(map[string]any)
 	releaseMode, _ := releaseEnvironment["mode"].(string)
-	if releaseMode != "review-gated" && releaseMode != "single-owner-private" && releaseMode != "plan-limited-private" {
-		return errors.New("policy/github-hosted-controls.toml must set release_environment.mode to 'review-gated', 'single-owner-private', or 'plan-limited-private'")
+	if releaseMode != "review-gated" && releaseMode != "single-owner-public" && releaseMode != "single-owner-private" && releaseMode != "plan-limited-private" {
+		return errors.New("policy/github-hosted-controls.toml must set release_environment.mode to 'review-gated', 'single-owner-public', 'single-owner-private', or 'plan-limited-private'")
 	}
 	if err := validateCanonicalHostedControlsRepositoryVariables(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
 		return err

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -14,22 +14,28 @@ block_deletions = true
 # Valid modes:
 # - "review-gated": require pull requests, at least one approving review,
 #   code owner review, and resolved review threads
+# - "single-owner-public-pr": require pull requests and resolved review
+#   threads on a public single-owner repository, while allowing zero required
+#   human approvals because no second maintainer exists yet; comment sweeps for
+#   human and async reviewers remain mandatory before merge
 # - "single-owner-private-pr": require pull requests on a private user-owned
 #   single-owner repository, but allow zero required approvals and no code
 #   owner/thread gate so merges remain workable without an admin bypass
-mode = "review-gated"
+mode = "single-owner-public-pr"
 
 [release_environment]
 # Valid modes:
-# - "review-gated": require at least one human reviewer and no admin bypass;
-#   upgrade to this once the repository is public (public repos on the free
-#   plan can enforce environment reviewers, private repos cannot)
+# - "review-gated": require at least one human reviewer, prevent self-review,
+#   and disallow admin bypass
+# - "single-owner-public": require a release environment on a public
+#   single-owner repository, disallow admin bypass, and allow maintainer
+#   self-review until a second release approver exists
 # - "single-owner-private": allow a private single-owner repo to use the
-#   release environment without a reviewer gate
+#   release environment without a second reviewer gate
 # - "plan-limited-private": lower-assurance fallback for private repositories
 #   on GitHub plans that cannot enforce environment reviewers; the environment
 #   must still exist, but reviewer gating is not available
-mode = "review-gated"
+mode = "single-owner-public"
 
 [required_status_checks]
 contexts = [
@@ -39,6 +45,18 @@ contexts = [
   "GitHub Actions lint",
   "GitHub Actions security analysis",
 ]
+
+[actions_policy]
+# Release and CI workflows should run with the narrowest practical default
+# token posture and only permit pinned actions from GitHub or explicitly
+# trusted publishers.
+allow_only_pinned_verified_or_explicitly_trusted_actions = true
+default_workflow_token_permissions = "read"
+
+[release_assets]
+# Tagged releases should be published as immutable GitHub releases so release
+# records and attached assets cannot be silently rewritten after publication.
+immutable_github_releases = true
 
 [repository_variables]
 # The canonical Workcell repository always requests GitHub-native attestations

--- a/policy/reviewer-identities.toml
+++ b/policy/reviewer-identities.toml
@@ -1,0 +1,14 @@
+# Provider-neutral reviewer identities used for PR comment sweeps and release
+# comment checks.
+#
+# Keep this file focused on who should be swept before merge rather than on
+# provider branding. Review tooling and runbooks should treat these identities
+# as configuration, not hard-coded special cases.
+
+[human_reviewers]
+github_logins = ["omkhar"]
+
+[async_reviewers]
+# Add GitHub logins for configured asynchronous reviewers when they exist.
+# Leave the list empty if no async reviewer identity is currently configured.
+github_logins = []


### PR DESCRIPTION
## Summary
- add a repo runbook for single-maintainer releases
- make PR comment sweeps and async review checks explicit policy
- move async reviewer identities into provider-neutral repo config
- keep the local Codex skill as a thin adapter over the repo runbook

## Validation
- git diff --check
- python3 TOML parse for hosted controls and reviewer identities
- provider-name grep on repo policy files
