### PR TITLE
[codex] Harden managed runtime and validation boundaries

### DIFF
--- a/adapters/codex/.codex/config.toml
+++ b/adapters/codex/.codex/config.toml
@@ -44,17 +44,17 @@ network_access = false
 unified_exec = false
 
 [profiles.strict]
-sandbox_mode = "danger-full-access"
+sandbox_mode = "workspace-write"
 approval_policy = "on-request"
 web_search = "disabled"
 
 [profiles.development]
-sandbox_mode = "danger-full-access"
+sandbox_mode = "workspace-write"
 approval_policy = "on-request"
 web_search = "disabled"
 
 [profiles.build]
-sandbox_mode = "danger-full-access"
+sandbox_mode = "workspace-write"
 approval_policy = "never"
 web_search = "disabled"
 

--- a/adapters/codex/managed_config.toml
+++ b/adapters/codex/managed_config.toml
@@ -43,17 +43,17 @@ network_access = false
 unified_exec = false
 
 [profiles.strict]
-sandbox_mode = "danger-full-access"
+sandbox_mode = "workspace-write"
 approval_policy = "on-request"
 web_search = "disabled"
 
 [profiles.development]
-sandbox_mode = "danger-full-access"
+sandbox_mode = "workspace-write"
 approval_policy = "on-request"
 web_search = "disabled"
 
 [profiles.build]
-sandbox_mode = "danger-full-access"
+sandbox_mode = "workspace-write"
 approval_policy = "never"
 web_search = "disabled"
 

--- a/adapters/codex/requirements.toml
+++ b/adapters/codex/requirements.toml
@@ -4,12 +4,9 @@
 # by design and are intended to be copied into an admin-enforced deployment.
 
 allowed_approval_policies = ["on-request", "never"]
-# Codex's own Linux sandbox is pinned off on the managed Workcell path because
-# it currently depends on unprivileged user namespaces that are unavailable
-# inside the Tier 1 container. Workcell's outer VM-plus-container boundary
-# remains the enforcement point; explicit breakglass is still tracked
-# separately by the launcher/runtime path.
-allowed_sandbox_modes = ["danger-full-access"]
+# Managed sessions should stay on the built-in workspace-write boundary and
+# reserve danger-full-access for explicit breakglass operation only.
+allowed_sandbox_modes = ["workspace-write", "danger-full-access"]
 allowed_web_search_modes = ["disabled"]
 
 [features]

--- a/internal/authpolicy/manage.go
+++ b/internal/authpolicy/manage.go
@@ -812,6 +812,9 @@ func explainCredentialSelection(policy map[string]any, policyBase string, creden
 	}
 	rawMap, ok := raw.(map[string]any)
 	if !ok {
+		if _, shared := SharedCredentialKeys[credential]; shared {
+			return credentialSelectionReport{}, die(fmt.Sprintf("credentials.%s.providers is required so shared GitHub credentials stay least-privilege", credential))
+		}
 		if !credentialAllowedForAgent(agent, credential) {
 			return credentialSelectionReport{
 				selected:  false,
@@ -1374,6 +1377,9 @@ func validateSelectorValues(values any, label string, allowedValues map[string]s
 func validateStatusCredentialEntry(key string, raw any) error {
 	rawMap, ok := raw.(map[string]any)
 	if !ok {
+		if _, shared := SharedCredentialKeys[key]; shared {
+			return die(fmt.Sprintf("credentials.%s.providers is required so shared GitHub credentials stay least-privilege", key))
+		}
 		return nil
 	}
 	if err := validateAllowedKeys(rawMap, entryAllowedKeys, "credentials."+key); err != nil {
@@ -1560,10 +1566,10 @@ func selectedCredentials(policy map[string]any, agent string, mode string) (map[
 	if agent == "" {
 		selected := map[string]any{}
 		for key, raw := range credentials {
+			if err := validateStatusCredentialEntry(key, raw); err != nil {
+				return nil, err
+			}
 			if rawMap, ok := raw.(map[string]any); ok {
-				if err := validateStatusCredentialEntry(key, rawMap); err != nil {
-					return nil, err
-				}
 				if err := validateSelectorValues(rawMap["providers"], "credentials."+key+".providers", SupportedAgents); err != nil {
 					return nil, err
 				}
@@ -1597,10 +1603,10 @@ func selectedCredentials(policy map[string]any, agent string, mode string) (map[
 		if !ok {
 			continue
 		}
+		if err := validateStatusCredentialEntry(key, raw); err != nil {
+			return nil, err
+		}
 		if rawMap, ok := raw.(map[string]any); ok {
-			if err := validateStatusCredentialEntry(key, rawMap); err != nil {
-				return nil, err
-			}
 			ok, err := selectedFor(rawMap["providers"], agent, "credentials."+key+".providers", SupportedAgents)
 			if err != nil {
 				return nil, err

--- a/internal/authpolicy/manage_test.go
+++ b/internal/authpolicy/manage_test.go
@@ -600,6 +600,18 @@ func TestRunRejectsInvalidConfigurations(t *testing.T) {
 			wantContains: "credentials.github_hosts.providers is required so shared GitHub credentials stay least-privilege",
 		},
 		{
+			name: "shared-github-string-form",
+			policy: strings.Join([]string{
+				"version = 1",
+				"[credentials]",
+				`github_hosts = "/tmp/hosts.yml"`,
+			}, "\n") + "\n",
+			command:      "status",
+			agent:        "codex",
+			needsInit:    false,
+			wantContains: "credentials.github_hosts.providers is required so shared GitHub credentials stay least-privilege",
+		},
+		{
 			name: "set-rejects-included-credential",
 			policy: strings.Join([]string{
 				"version = 1",

--- a/internal/authresolve/resolve_credential_sources.go
+++ b/internal/authresolve/resolve_credential_sources.go
@@ -272,6 +272,9 @@ func run(cfg config) error {
 
 		rawMap, isMap := raw.(map[string]any)
 		if !isMap {
+			if _, shared := sharedCredentialKeys[key]; shared {
+				return fmt.Errorf("credentials.%s.providers is required so shared GitHub credentials stay least-privilege", key)
+			}
 			source, err := validateSourcePath(raw, "credentials."+key, cwd())
 			if err != nil {
 				return err
@@ -291,6 +294,9 @@ func run(cfg config) error {
 		resolverName, _ := rawMap["resolver"].(string)
 		providers := rawMap["providers"]
 		modes := rawMap["modes"]
+		if _, shared := sharedCredentialKeys[key]; shared && providers == nil {
+			return fmt.Errorf("credentials.%s.providers is required so shared GitHub credentials stay least-privilege", key)
+		}
 
 		ok, err := selectedFor(providers, cfg.agent, "credentials."+key+".providers", supportedAgents)
 		if err != nil {

--- a/internal/authresolve/resolve_credential_sources_test.go
+++ b/internal/authresolve/resolve_credential_sources_test.go
@@ -86,6 +86,7 @@ func TestRunMetadataModeWritesPlaceholderAndMetadata(t *testing.T) {
 		"version = 1",
 		"[credentials.github_hosts]",
 		`source = "` + githubHostsPath + `"`,
+		`providers = ["claude"]`,
 		"[credentials.claude_auth]",
 		`resolver = "claude-macos-keychain"`,
 		`materialization = "ephemeral"`,
@@ -159,6 +160,39 @@ func TestRunMetadataModeWritesPlaceholderAndMetadata(t *testing.T) {
 	}
 	if lines[5] != "github_hosts:ready" {
 		t.Fatalf("shared ready line = %q", lines[5])
+	}
+}
+
+func TestRunMetadataModeRejectsSharedCredentialStringForm(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	writePolicy(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials]",
+		`github_hosts = "/tmp/hosts.yml"`,
+	}, "\n")+"\n")
+
+	outputRoot := filepath.Join(root, "out")
+	if err := os.MkdirAll(outputRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := runResolveCredentialSources(t, []string{
+		"--policy", policyPath,
+		"--agent", "codex",
+		"--mode", "strict",
+		"--resolution-mode", "metadata",
+		"--output-policy", filepath.Join(outputRoot, "resolved-policy.toml"),
+		"--output-metadata", filepath.Join(outputRoot, "resolver-metadata.json"),
+		"--output-root", outputRoot,
+	}, nil)
+	if code != 1 {
+		t.Fatalf("Run() = %d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "providers is required") {
+		t.Fatalf("stderr %q missing shared credential scoping failure", stderr)
 	}
 }
 

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -64,6 +64,12 @@ var (
 		"userknownhostsfile":  {},
 	}
 	reservedTargets = []string{
+		"/state/agent-home/.codex",
+		"/state/agent-home/.claude",
+		"/state/agent-home/.config/claude-code",
+		"/state/agent-home/.gemini",
+		"/state/agent-home/.config/gcloud",
+		"/state/agent-home/.config/gh",
 		"/state/agent-home/.codex/AGENTS.md",
 		"/state/agent-home/.codex/auth.json",
 		"/state/agent-home/.codex/config.toml",
@@ -705,7 +711,8 @@ func renderCredentials(policy map[string]any, policyDir Path, agent, mode string
 		var providers any
 		var modes any
 		sourceRaw := rawValue
-		if entry, ok := rawValue.(map[string]any); ok {
+		entry, isTable := rawValue.(map[string]any)
+		if isTable {
 			if err := validateAllowedKeys(entry, mapKeysSet([]string{"source", "providers", "modes"}), "credentials."+key); err != nil {
 				return nil, err
 			}
@@ -717,7 +724,7 @@ func renderCredentials(policy map[string]any, policyDir Path, agent, mode string
 		}
 
 		if _, shared := sharedCredentialKeys[key]; shared {
-			if _, isTable := rawValue.(map[string]any); isTable && providers == nil {
+			if !isTable || providers == nil {
 				return nil, fmt.Errorf("credentials.%s.providers is required so shared GitHub credentials stay least-privilege", key)
 			}
 		}

--- a/internal/injection/render_injection_bundle_test.go
+++ b/internal/injection/render_injection_bundle_test.go
@@ -313,7 +313,19 @@ func TestRebasePolicyFragmentAndValidationHelpers(t *testing.T) {
 	if got, err := validateContainerTarget("/state/injected/notes.txt"); err != nil || got != "/state/injected/notes.txt" {
 		t.Fatalf("validateContainerTarget = %q, %v", got, err)
 	}
-	for _, bad := range []string{"relative.txt", "/tmp/outside", "/state/agent-home/.mcp.json", "/state/injected/../agent-home/notes.txt", "/state/agent-home/../injected/notes.txt"} {
+	for _, bad := range []string{
+		"relative.txt",
+		"/tmp/outside",
+		"/state/agent-home/.claude",
+		"/state/agent-home/.codex",
+		"/state/agent-home/.gemini",
+		"/state/agent-home/.config/claude-code",
+		"/state/agent-home/.config/gh",
+		"/state/agent-home/.config/gcloud",
+		"/state/agent-home/.mcp.json",
+		"/state/injected/../agent-home/notes.txt",
+		"/state/agent-home/../injected/notes.txt",
+	} {
 		if _, err := validateContainerTarget(bad); err == nil {
 			t.Fatalf("validateContainerTarget accepted %q", bad)
 		}
@@ -341,6 +353,22 @@ func TestRenderDocumentsRejectsUnknownKeys(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported keys: extra") {
 		t.Fatalf("renderDocuments() error = %v, want unknown key failure", err)
+	}
+}
+
+func TestRenderCredentialsRejectsSharedCredentialStringForm(t *testing.T) {
+	t.Parallel()
+
+	_, err := renderCredentials(map[string]any{
+		"credentials": map[string]any{
+			"github_hosts": "/tmp/hosts.yml",
+		},
+	}, Path("/tmp"), "codex", "strict")
+	if err == nil {
+		t.Fatal("renderCredentials() unexpectedly accepted shared credential string form")
+	}
+	if !strings.Contains(err.Error(), "providers is required") {
+		t.Fatalf("renderCredentials() error = %v, want shared credential scoping failure", err)
 	}
 }
 

--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -106,7 +106,11 @@ func ensureRegularFile(path string) error {
 }
 
 func ensureNoSymlinkPrefix(rootDir, repoPath string) error {
-	relativeParts := strings.Split(filepath.Clean(repoPath), string(filepath.Separator))
+	return ensureNoSymlinkRelativePath(rootDir, repoPath, "control-plane artifact")
+}
+
+func ensureNoSymlinkRelativePath(rootDir, relativePath, label string) error {
+	relativeParts := strings.Split(filepath.Clean(relativePath), string(filepath.Separator))
 	current := rootDir
 	for _, part := range relativeParts {
 		current = filepath.Join(current, part)
@@ -115,7 +119,7 @@ func ensureNoSymlinkPrefix(rootDir, repoPath string) error {
 			return err
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("control-plane artifact must not be a symlink: %s", repoPath)
+			return fmt.Errorf("%s must not be a symlink: %s", label, relativePath)
 		}
 	}
 	return nil
@@ -182,7 +186,10 @@ func gitTrackedFiles(rootDir string) ([]string, bool, error) {
 		if path == "" {
 			continue
 		}
-		info, err := os.Stat(filepath.Join(rootDir, path))
+		if err := ensureNoSymlinkRelativePath(rootDir, path, "tracked release input"); err != nil {
+			return nil, true, err
+		}
+		info, err := os.Lstat(filepath.Join(rootDir, path))
 		if err != nil || !info.Mode().IsRegular() {
 			continue
 		}
@@ -367,7 +374,10 @@ func digestMap(rootDir string, paths []string) (map[string]string, error) {
 	result := make(map[string]string, len(paths))
 	for _, relativePath := range paths {
 		candidate := filepath.Join(rootDir, relativePath)
-		info, err := os.Stat(candidate)
+		if err := ensureNoSymlinkRelativePath(rootDir, relativePath, "tracked release input"); err != nil {
+			return nil, err
+		}
+		info, err := os.Lstat(candidate)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				return nil, fmt.Errorf(

--- a/internal/metadatautil/core_test.go
+++ b/internal/metadatautil/core_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -108,5 +109,68 @@ func TestGitTrackedFilesExcludesUntrackedFiles(t *testing.T) {
 	want := []string{"tracked.txt"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("gitTrackedFiles() = %#v, want %#v", got, want)
+	}
+}
+
+func TestGitTrackedFilesRejectsTrackedSymlinks(t *testing.T) {
+	root := t.TempDir()
+	outsideRoot := t.TempDir()
+	outsidePath := filepath.Join(outsideRoot, "outside.txt")
+	if err := os.WriteFile(outsidePath, []byte("outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%s) error = %v", root, err)
+	}
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %v\n%s", args, err, output)
+		}
+	}
+
+	run("git", "init", "-q", canonicalRoot)
+	run("git", "-C", canonicalRoot, "config", "user.name", "Workcell Tests")
+	run("git", "-C", canonicalRoot, "config", "user.email", "workcell-tests@example.com")
+	run("git", "-C", canonicalRoot, "config", "commit.gpgsign", "false")
+	if err := os.Symlink(outsidePath, filepath.Join(canonicalRoot, "leak.txt")); err != nil {
+		t.Fatal(err)
+	}
+	run("git", "-C", canonicalRoot, "add", "leak.txt")
+	run("git", "-C", canonicalRoot, "commit", "-q", "-m", "add leak")
+
+	_, tracked, err := gitTrackedFiles(canonicalRoot)
+	if !tracked {
+		t.Fatal("gitTrackedFiles() should report tracked repository context")
+	}
+	if err == nil {
+		t.Fatal("gitTrackedFiles() unexpectedly accepted a tracked symlink")
+	}
+	if !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("gitTrackedFiles() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestDigestMapRejectsSymlinkedInputs(t *testing.T) {
+	root := t.TempDir()
+	outsideRoot := t.TempDir()
+	outsidePath := filepath.Join(outsideRoot, "outside.txt")
+	if err := os.WriteFile(outsidePath, []byte("outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsidePath, filepath.Join(root, "leak.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := digestMap(root, []string{"leak.txt"})
+	if err == nil {
+		t.Fatal("digestMap() unexpectedly accepted a symlink")
+	}
+	if !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("digestMap() error = %v, want symlink rejection", err)
 	}
 }

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -407,6 +407,20 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 	owner, _ := repoMeta["owner"].(map[string]any)
 	ownerLogin, _ := owner["login"].(string)
 	ownerType, _ := owner["type"].(string)
+	requireSingleOwnerCollaborator := func(mode string) error {
+		if len(directCollaborators) != 1 {
+			return fmt.Errorf("%s on %s requires exactly one direct collaborator", mode, repo)
+		}
+		collaborator, _ := directCollaborators[0].(map[string]any)
+		if login, _ := collaborator["login"].(string); login != ownerLogin {
+			return fmt.Errorf("%s on %s requires the owner to be the only direct collaborator", mode, repo)
+		}
+		permissions, _ := collaborator["permissions"].(map[string]any)
+		if admin, _ := permissions["admin"].(bool); !admin {
+			return fmt.Errorf("%s on %s requires the owner to retain admin permission", mode, repo)
+		}
+		return nil
+	}
 
 	branchIntegrityPolicy, ok := policy["branch_integrity"].(map[string]any)
 	if !ok {
@@ -572,16 +586,8 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 			if ownerType != "User" {
 				return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s is only valid for user-owned repositories", repo)
 			}
-			if len(directCollaborators) != 1 {
-				return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s requires exactly one direct collaborator", repo)
-			}
-			collaborator, _ := directCollaborators[0].(map[string]any)
-			if login, _ := collaborator["login"].(string); login != ownerLogin {
-				return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s requires the owner to be the only direct collaborator", repo)
-			}
-			permissions, _ := collaborator["permissions"].(map[string]any)
-			if admin, _ := permissions["admin"].(bool); !admin {
-				return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s requires the owner to retain admin permission", repo)
+			if err := requireSingleOwnerCollaborator("branch review mode 'single-owner-private-pr'"); err != nil {
+				return err
 			}
 		} else {
 			if private, _ := repoMeta["private"].(bool); private {
@@ -589,6 +595,9 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 			}
 			if ownerType != "User" {
 				return fmt.Errorf("branch review mode 'single-owner-public-pr' on %s is only valid for user-owned repositories", repo)
+			}
+			if err := requireSingleOwnerCollaborator("branch review mode 'single-owner-public-pr'"); err != nil {
+				return err
 			}
 		}
 		if count, _ := parameters["required_approving_review_count"].(float64); count != 0 {
@@ -722,6 +731,9 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		if ownerType != "User" {
 			return fmt.Errorf("release environment mode 'single-owner-public' on %s is only valid for user-owned repositories", repo)
 		}
+		if err := requireSingleOwnerCollaborator("release environment mode 'single-owner-public'"); err != nil {
+			return err
+		}
 		if len(reviewerRules) == 0 {
 			return fmt.Errorf("release environment on %s must define a reviewer gate in single-owner-public mode", repo)
 		}
@@ -752,16 +764,8 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		if ownerType != "User" {
 			return fmt.Errorf("release environment mode 'single-owner-private' on %s is only valid for user-owned repositories", repo)
 		}
-		if len(directCollaborators) != 1 {
-			return fmt.Errorf("release environment mode 'single-owner-private' on %s requires exactly one direct collaborator", repo)
-		}
-		collaborator, _ := directCollaborators[0].(map[string]any)
-		if login, _ := collaborator["login"].(string); login != ownerLogin {
-			return fmt.Errorf("release environment mode 'single-owner-private' on %s requires the owner to be the only direct collaborator", repo)
-		}
-		permissions, _ := collaborator["permissions"].(map[string]any)
-		if admin, _ := permissions["admin"].(bool); !admin {
-			return fmt.Errorf("release environment mode 'single-owner-private' on %s requires the owner to retain admin permission", repo)
+		if err := requireSingleOwnerCollaborator("release environment mode 'single-owner-private'"); err != nil {
+			return err
 		}
 	}
 
@@ -1329,6 +1333,9 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err := requireEqual("RUSTUP_VERSION", validatorRustupVersion, cfg.ValidatorDockerfilePath, remoteValidatorRustupVersion, cfg.RemoteValidatorDockerfilePath); err != nil {
 		return err
 	}
+	if !regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?$`).MatchString(validatorRustupVersion) {
+		return fmt.Errorf("RUSTUP_VERSION must be an exact pinned release, found %q", validatorRustupVersion)
+	}
 	validatorRustupSHAx86_64, err := requireArg(validatorDockerfile, "RUSTUP_INIT_LINUX_X86_64_SHA256", cfg.ValidatorDockerfilePath)
 	if err != nil {
 		return err
@@ -1340,6 +1347,9 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err := requireEqual("RUSTUP_INIT_LINUX_X86_64_SHA256", validatorRustupSHAx86_64, cfg.ValidatorDockerfilePath, remoteValidatorRustupSHAx86_64, cfg.RemoteValidatorDockerfilePath); err != nil {
 		return err
 	}
+	if !isHexDigest(validatorRustupSHAx86_64) {
+		return fmt.Errorf("RUSTUP_INIT_LINUX_X86_64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorRustupSHAx86_64)
+	}
 	validatorRustupSHAArm64, err := requireArg(validatorDockerfile, "RUSTUP_INIT_LINUX_ARM64_SHA256", cfg.ValidatorDockerfilePath)
 	if err != nil {
 		return err
@@ -1350,6 +1360,9 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	}
 	if err := requireEqual("RUSTUP_INIT_LINUX_ARM64_SHA256", validatorRustupSHAArm64, cfg.ValidatorDockerfilePath, remoteValidatorRustupSHAArm64, cfg.RemoteValidatorDockerfilePath); err != nil {
 		return err
+	}
+	if !isHexDigest(validatorRustupSHAArm64) {
+		return fmt.Errorf("RUSTUP_INIT_LINUX_ARM64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorRustupSHAArm64)
 	}
 
 	rootPackage, _ := providersPackageLock["packages"].(map[string]any)

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func metadatautilRepoRoot(tb testing.TB) string {
+	tb.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		tb.Fatal("unable to determine repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func copyFixtureFile(tb testing.TB, srcRoot, dstRoot, relativePath string) {
+	tb.Helper()
+	sourcePath := filepath.Join(srcRoot, filepath.FromSlash(relativePath))
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	targetPath := filepath.Join(dstRoot, filepath.FromSlash(relativePath))
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.WriteFile(targetPath, data, 0o644); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+func writePinnedInputsFixture(tb testing.TB) PinnedInputsConfig {
+	tb.Helper()
+
+	srcRoot := metadatautilRepoRoot(tb)
+	dstRoot := tb.TempDir()
+	for _, relativePath := range []string{
+		"go.mod",
+		".github/CODEOWNERS",
+		".github/workflows/ci.yml",
+		".github/workflows/release.yml",
+		".github/workflows/hosted-controls.yml",
+		".github/workflows/security.yml",
+		".github/workflows/pin-hygiene.yml",
+		".github/workflows/upstream-refresh.yml",
+		"adapters/codex/requirements.toml",
+		"adapters/codex/mcp/config.toml",
+		"policy/github-hosted-controls.toml",
+		"policy/provider-bumps.toml",
+		"runtime/container/Dockerfile",
+		"runtime/container/providers/package.json",
+		"runtime/container/providers/package-lock.json",
+		"runtime/container/rust/Cargo.toml",
+		"runtime/container/rust/rust-toolchain.toml",
+		"scripts/verify-github-hosted-controls.sh",
+		"tools/remote-validator/Dockerfile",
+		"tools/validator/Dockerfile",
+	} {
+		copyFixtureFile(tb, srcRoot, dstRoot, relativePath)
+	}
+
+	return PinnedInputsConfig{
+		RuntimeDockerfilePath:         filepath.Join(dstRoot, "runtime", "container", "Dockerfile"),
+		ValidatorDockerfilePath:       filepath.Join(dstRoot, "tools", "validator", "Dockerfile"),
+		RemoteValidatorDockerfilePath: filepath.Join(dstRoot, "tools", "remote-validator", "Dockerfile"),
+		ProvidersPackageJSONPath:      filepath.Join(dstRoot, "runtime", "container", "providers", "package.json"),
+		ProvidersPackageLockPath:      filepath.Join(dstRoot, "runtime", "container", "providers", "package-lock.json"),
+		WorkflowsDir:                  filepath.Join(dstRoot, ".github", "workflows"),
+		CIWorkflowPath:                filepath.Join(dstRoot, ".github", "workflows", "ci.yml"),
+		ReleaseWorkflowPath:           filepath.Join(dstRoot, ".github", "workflows", "release.yml"),
+		PinHygieneWorkflowPath:        filepath.Join(dstRoot, ".github", "workflows", "pin-hygiene.yml"),
+		CodeownersPath:                filepath.Join(dstRoot, ".github", "CODEOWNERS"),
+		CodexRequirementsPath:         filepath.Join(dstRoot, "adapters", "codex", "requirements.toml"),
+		CodexMCPConfigPath:            filepath.Join(dstRoot, "adapters", "codex", "mcp", "config.toml"),
+		HostedControlsPolicyPath:      filepath.Join(dstRoot, "policy", "github-hosted-controls.toml"),
+		HostedControlsScriptPath:      filepath.Join(dstRoot, "scripts", "verify-github-hosted-controls.sh"),
+		ProviderBumpPolicyPath:        filepath.Join(dstRoot, "policy", "provider-bumps.toml"),
+		MaxDebianSnapshotAgeDays:      3650,
+	}
+}
+
+func rewriteFile(tb testing.TB, path string, rewrite func(string) string) {
+	tb.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(rewrite(string(content))), 0o644); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, directCollaborators []map[string]any) (string, string) {
+	tb.Helper()
+
+	root := tb.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	policy := strings.Join([]string{
+		"[branch_integrity]",
+		"require_signed_commits = true",
+		"block_force_pushes = true",
+		"block_deletions = true",
+		"",
+		"[branch_review]",
+		`mode = "` + branchMode + `"`,
+		"",
+		"[release_environment]",
+		`mode = "` + releaseMode + `"`,
+		"",
+		"[required_status_checks]",
+		`contexts = ["Validate repository"]`,
+		"",
+		"[repository_variables]",
+		`WORKCELL_ENABLE_GITHUB_ATTESTATIONS = "true"`,
+		`WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = "false"`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(policyPath, []byte(policy), 0o644); err != nil {
+		tb.Fatal(err)
+	}
+
+	repoJSON := map[string]any{
+		"private": false,
+		"owner": map[string]any{
+			"login": "omkhar",
+			"type":  "User",
+		},
+	}
+	actionsPermissions := map[string]any{
+		"enabled":              true,
+		"sha_pinning_required": true,
+	}
+	actionsVariables := map[string]any{
+		"variables": []map[string]any{
+			{
+				"name":  "WORKCELL_ENABLE_GITHUB_ATTESTATIONS",
+				"value": "true",
+			},
+			{
+				"name":  "WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS",
+				"value": "false",
+			},
+		},
+	}
+	branchReviewParameters := map[string]any{
+		"required_approving_review_count":   float64(0),
+		"require_code_owner_review":         false,
+		"require_last_push_approval":        false,
+		"required_review_thread_resolution": true,
+	}
+	if branchMode == "review-gated" {
+		branchReviewParameters = map[string]any{
+			"required_approving_review_count":   float64(1),
+			"require_code_owner_review":         true,
+			"required_review_thread_resolution": true,
+		}
+	}
+	rulesets := []map[string]any{
+		{
+			"name":        "default-branch-integrity",
+			"enforcement": "active",
+			"target":      "branch",
+			"conditions": map[string]any{
+				"ref_name": map[string]any{
+					"include": []any{"~DEFAULT_BRANCH"},
+				},
+			},
+			"rules": []map[string]any{
+				{"type": "required_signatures"},
+				{"type": "non_fast_forward"},
+				{"type": "deletion"},
+			},
+			"bypass_actors": []any{},
+		},
+		{
+			"name":        "default-branch-review",
+			"enforcement": "active",
+			"target":      "branch",
+			"conditions": map[string]any{
+				"ref_name": map[string]any{
+					"include": []any{"~DEFAULT_BRANCH"},
+				},
+			},
+			"rules": []map[string]any{
+				{
+					"type":       "pull_request",
+					"parameters": branchReviewParameters,
+				},
+			},
+			"bypass_actors": []map[string]any{
+				{
+					"actor_type":  "RepositoryRole",
+					"bypass_mode": "pull_request",
+				},
+			},
+		},
+		{
+			"name":        "default-branch-status",
+			"enforcement": "active",
+			"target":      "branch",
+			"conditions": map[string]any{
+				"ref_name": map[string]any{
+					"include": []any{"~DEFAULT_BRANCH"},
+				},
+			},
+			"rules": []map[string]any{
+				{
+					"type": "required_status_checks",
+					"parameters": map[string]any{
+						"strict_required_status_checks_policy": true,
+						"required_status_checks": []map[string]any{
+							{"context": "Validate repository"},
+						},
+					},
+				},
+			},
+			"bypass_actors": []any{},
+		},
+		{
+			"name":        "release-tags",
+			"enforcement": "active",
+			"target":      "tag",
+			"conditions": map[string]any{
+				"ref_name": map[string]any{
+					"include": []any{"refs/tags/v*"},
+				},
+			},
+			"rules": []map[string]any{
+				{"type": "creation"},
+				{"type": "update"},
+				{"type": "deletion"},
+			},
+			"bypass_actors": []map[string]any{
+				{
+					"actor_type":  "RepositoryRole",
+					"bypass_mode": "always",
+				},
+			},
+		},
+	}
+
+	releaseReviewRule := map[string]any{
+		"type": "required_reviewers",
+		"reviewers": []map[string]any{
+			{"type": "User", "id": float64(1)},
+		},
+		"prevent_self_review": false,
+	}
+	if releaseMode == "review-gated" {
+		releaseReviewRule["prevent_self_review"] = true
+	}
+	releaseEnv := map[string]any{
+		"protection_rules": []map[string]any{
+			releaseReviewRule,
+			{
+				"type":    "admin_bypass",
+				"enabled": false,
+			},
+		},
+		"can_admins_bypass": false,
+	}
+
+	for _, fixture := range []struct {
+		name  string
+		value any
+	}{
+		{"repo.json", repoJSON},
+		{"actions-permissions.json", actionsPermissions},
+		{"actions-variables.json", actionsVariables},
+		{"collaborators-direct.json", directCollaborators},
+		{"rulesets.json", rulesets},
+		{"environment-release.json", releaseEnv},
+	} {
+		if err := writeJSONFile(filepath.Join(root, fixture.name), fixture.value); err != nil {
+			tb.Fatal(err)
+		}
+	}
+
+	return root, policyPath
+}
+
+func TestCheckPinnedInputsRejectsUnpinnedRustupVersion(t *testing.T) {
+	t.Parallel()
+
+	cfg := writePinnedInputsFixture(t)
+	rewriteFile(t, cfg.ValidatorDockerfilePath, func(content string) string {
+		return strings.Replace(content, "ARG RUSTUP_VERSION=", "ARG RUSTUP_VERSION=stable-", 1)
+	})
+
+	err := CheckPinnedInputs(cfg)
+	if err == nil {
+		t.Fatal("CheckPinnedInputs() unexpectedly accepted a non-release rustup version")
+	}
+	if !strings.Contains(err.Error(), "RUSTUP_VERSION") {
+		t.Fatalf("CheckPinnedInputs() error = %v, want rustup version rejection", err)
+	}
+}
+
+func TestCheckPinnedInputsRejectsInvalidRustupDigest(t *testing.T) {
+	t.Parallel()
+
+	cfg := writePinnedInputsFixture(t)
+	rewriteFile(t, cfg.ValidatorDockerfilePath, func(content string) string {
+		content = strings.Replace(content, "ARG RUSTUP_INIT_LINUX_X86_64_SHA256=", "ARG RUSTUP_INIT_LINUX_X86_64_SHA256=deadbeef", 1)
+		return strings.Replace(content, "ARG RUSTUP_INIT_LINUX_ARM64_SHA256=", "ARG RUSTUP_INIT_LINUX_ARM64_SHA256=feedface", 1)
+	})
+
+	err := CheckPinnedInputs(cfg)
+	if err == nil {
+		t.Fatal("CheckPinnedInputs() unexpectedly accepted a non-sha256 rustup digest")
+	}
+	if !strings.Contains(err.Error(), "RUSTUP_INIT_LINUX") {
+		t.Fatalf("CheckPinnedInputs() error = %v, want rustup digest rejection", err)
+	}
+}
+
+func TestVerifyGitHubHostedControlsRejectsExtraPublicCollaboratorsForBranchReview(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, policyPath := writeHostedControlsFixture(t, "single-owner-public-pr", "single-owner-public", []map[string]any{
+		{
+			"login": "omkhar",
+			"permissions": map[string]any{
+				"admin": true,
+			},
+		},
+		{
+			"login": "extra-maintainer",
+			"permissions": map[string]any{
+				"admin": false,
+			},
+		},
+	})
+
+	err := VerifyGitHubHostedControls(tmpDir, "omkhar/workcell", policyPath)
+	if err == nil {
+		t.Fatal("VerifyGitHubHostedControls() unexpectedly accepted extra collaborators in single-owner-public-pr mode")
+	}
+	if !strings.Contains(err.Error(), "requires exactly one direct collaborator") {
+		t.Fatalf("VerifyGitHubHostedControls() error = %v, want collaborator-count rejection", err)
+	}
+}
+
+func TestVerifyGitHubHostedControlsRejectsExtraPublicCollaboratorsForReleaseEnv(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, policyPath := writeHostedControlsFixture(t, "review-gated", "single-owner-public", []map[string]any{
+		{
+			"login": "omkhar",
+			"permissions": map[string]any{
+				"admin": true,
+			},
+		},
+		{
+			"login": "extra-maintainer",
+			"permissions": map[string]any{
+				"admin": false,
+			},
+		},
+	})
+
+	err := VerifyGitHubHostedControls(tmpDir, "omkhar/workcell", policyPath)
+	if err == nil {
+		t.Fatal("VerifyGitHubHostedControls() unexpectedly accepted extra collaborators in single-owner-public release mode")
+	}
+	if !strings.Contains(err.Error(), "requires exactly one direct collaborator") {
+		t.Fatalf("VerifyGitHubHostedControls() error = %v, want collaborator-count rejection", err)
+	}
+}

--- a/internal/testkit/codex_workspace_write_test.go
+++ b/internal/testkit/codex_workspace_write_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCodexManagedConfigKeepsWorkspaceWriteOutsideBreakglass(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(repoRoot(t), "adapters", "codex", ".codex", "config.toml")
+	managedConfigPath := filepath.Join(repoRoot(t), "adapters", "codex", "managed_config.toml")
+	requirementsPath := filepath.Join(repoRoot(t), "adapters", "codex", "requirements.toml")
+	config, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	managedConfig, err := os.ReadFile(managedConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requirements, err := os.ReadFile(requirementsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for path, raw := range map[string]string{
+		configPath:        string(config),
+		managedConfigPath: string(managedConfig),
+	} {
+		for _, want := range []string{
+			"[profiles.strict]\nsandbox_mode = \"workspace-write\"",
+			"[profiles.development]\nsandbox_mode = \"workspace-write\"",
+			"[profiles.build]\nsandbox_mode = \"workspace-write\"",
+			"[profiles.breakglass]\nsandbox_mode = \"danger-full-access\"",
+		} {
+			if !strings.Contains(raw, want) {
+				t.Fatalf("%s does not contain %q", path, want)
+			}
+		}
+	}
+
+	requirementsText := string(requirements)
+	if !strings.Contains(requirementsText, `allowed_sandbox_modes = ["workspace-write", "danger-full-access"]`) {
+		t.Fatalf("%s does not allow managed workspace-write mode", requirementsPath)
+	}
+}

--- a/internal/testkit/security_boundary_test.go
+++ b/internal/testkit/security_boundary_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runBashProbe(tb testing.TB, script string, env map[string]string) (int, string) {
+	tb.Helper()
+
+	cmd := exec.Command("bash", "-p", "-lc", script)
+	cmd.Env = append(os.Environ(), "BASH_ENV=", "ENV=")
+	for key, value := range env {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return 0, string(output)
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode(), string(output)
+	}
+	tb.Fatalf("bash probe failed: %v", err)
+	return 0, ""
+}
+
+func TestHomeControlPlaneIgnoresManifestEnvOverride(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(repoRoot(t), "runtime", "container", "home-control-plane.sh")
+	code, output := runBashProbe(t, `set -euo pipefail
+source() {
+  if [[ "$1" == "/usr/local/libexec/workcell/assurance.sh" ]]; then
+    return 0
+  fi
+  builtin source "$@"
+}
+builtin source "`+scriptPath+`"
+printf '%s\n' "$(workcell_control_plane_manifest_path)"
+`, map[string]string{
+		"WORKCELL_CONTROL_PLANE_MANIFEST": "/tmp/workcell-attacker-manifest.json",
+	})
+	if code != 0 {
+		t.Fatalf("probe exit code = %d output=%q", code, output)
+	}
+	if strings.TrimSpace(output) != "/usr/local/libexec/workcell/control-plane-manifest.json" {
+		t.Fatalf("control-plane manifest path = %q", strings.TrimSpace(output))
+	}
+}
+
+func TestHomeControlPlaneRejectsManagedDirectoryTargets(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(repoRoot(t), "runtime", "container", "home-control-plane.sh")
+	for _, target := range []string{
+		"/state/agent-home/.claude",
+		"/state/agent-home/.codex",
+		"/state/agent-home/.gemini",
+		"/state/agent-home/.config/gh",
+		"/state/agent-home/.config/gcloud",
+		"/state/agent-home/.config/claude-code",
+	} {
+		target := target
+		t.Run(filepath.Base(target), func(t *testing.T) {
+			t.Parallel()
+
+			code, output := runBashProbe(t, `set -euo pipefail
+source() {
+  if [[ "$1" == "/usr/local/libexec/workcell/assurance.sh" ]]; then
+    return 0
+  fi
+  builtin source "$@"
+}
+builtin source "`+scriptPath+`"
+if workcell_target_is_allowed "`+target+`"; then
+  printf 'allowed\n'
+else
+  printf 'blocked\n'
+fi
+`, nil)
+			if code != 0 {
+				t.Fatalf("probe exit code = %d output=%q", code, output)
+			}
+			if strings.TrimSpace(output) != "blocked" {
+				t.Fatalf("target %s unexpectedly allowed: %q", target, output)
+			}
+		})
+	}
+}
+
+func TestResolveWorkcellRealHomeRejectsWorkspaceOverride(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	overrideHome := filepath.Join(workspace, "attacker-home")
+	if err := os.MkdirAll(overrideHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "lib", "trusted-docker-client.sh")
+	code, output := runBashProbe(t, `set -euo pipefail
+ROOT_DIR="`+workspace+`"
+source "`+scriptPath+`"
+resolve_workcell_real_home
+`, map[string]string{
+		"HOME":                      t.TempDir(),
+		"WORKCELL_DOCKER_REAL_HOME": overrideHome,
+	})
+	if code == 0 {
+		t.Fatalf("resolve_workcell_real_home unexpectedly accepted workspace override: %q", output)
+	}
+}

--- a/internal/testkit/validation_snapshot_test.go
+++ b/internal/testkit/validation_snapshot_test.go
@@ -189,6 +189,39 @@ func TestValidationSnapshotPreservesTrackedSymlinks(t *testing.T) {
 	}
 }
 
+func TestValidationSnapshotRejectsUnsafeTrackedSymlinks(t *testing.T) {
+	t.Parallel()
+
+	tempRoot := t.TempDir()
+	repo := createSnapshotFixtureRepo(t, tempRoot)
+	if err := os.Symlink("/etc/passwd", filepath.Join(repo, "leak")); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "-C", repo, "add", "leak")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add leak failed: %v\n%s", err, output)
+	}
+	cmd = exec.Command("git", "-C", repo, "commit", "-q", "-m", "add unsafe symlink")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit add unsafe symlink failed: %v\n%s", err, output)
+	}
+
+	for _, mode := range []string{"head", "index", "worktree"} {
+		mode := mode
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+
+			code, output := runValidationSnapshotCommand(t, repo, mode, `echo should-not-run`, nil)
+			if code == 0 {
+				t.Fatalf("snapshot unexpectedly succeeded: %q", output)
+			}
+			if !strings.Contains(output, "unsafe symlink target") {
+				t.Fatalf("snapshot output = %q want unsafe symlink target rejection", output)
+			}
+		})
+	}
+}
+
 func TestValidationSnapshotFailsWhenTrackedBlobIsUnreadable(t *testing.T) {
 	t.Parallel()
 

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -14,7 +14,7 @@
     },
     {
       "repo_path": "scripts/lib/trusted-docker-client.sh",
-      "sha256": "63686e152c4a4b4f1bbad39114797181c94f7f243eb4c0d8052cfca4fdb763ec"
+      "sha256": "bfb4107724bbd994486fa0e0afed5bbf295e1e5b57936c4d72fc821b23a8354b"
     }
   ],
   "runtime_artifacts": [
@@ -82,7 +82,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/codex/.codex/config.toml",
       "runtime_path": "/opt/workcell/adapters/codex/.codex/config.toml",
-      "sha256": "523adb1596d5916574cf00f0a1e7f76fa7724cb948198c178773dbd2e2d5a867"
+      "sha256": "9a5fa873da71d3f216ee393a8ce19c7e9f9eef309a6aa641afdaff2e8c18bf95"
     },
     {
       "kind": "adapter-baseline",
@@ -94,7 +94,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/codex/managed_config.toml",
       "runtime_path": "/opt/workcell/adapters/codex/managed_config.toml",
-      "sha256": "478df1caa04cd8a761a33d46ea96fce0413a036ca577e369f7ecec28459a0969"
+      "sha256": "eeb453c5725a8ec6f5832d4a197e24c13dcf27a3abdd8108766b5d6883177430"
     },
     {
       "kind": "adapter-baseline",
@@ -106,7 +106,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/codex/requirements.toml",
       "runtime_path": "/opt/workcell/adapters/codex/requirements.toml",
-      "sha256": "4eb2570eb49d29925c6a688e2d42755de30ccd58f5bf120c6c7cda8d27ee3e10"
+      "sha256": "6848ce9b85adfdb165a0609d0d7fc61cb8aad2ac4fb36a4b75670646f808666c"
     },
     {
       "kind": "adapter-baseline",
@@ -160,7 +160,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/home-control-plane.sh",
       "runtime_path": "/usr/local/libexec/workcell/home-control-plane.sh",
-      "sha256": "1349a27c813ca3d1f20a090dd109a3dd50407eec457f420642209f2a601d16da"
+      "sha256": "b3d482570219ea44dc00734dd89befa4999f18bdef9b9890f651d07f87472c98"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -14,7 +14,7 @@
     },
     {
       "repo_path": "scripts/lib/trusted-docker-client.sh",
-      "sha256": "bfb4107724bbd994486fa0e0afed5bbf295e1e5b57936c4d72fc821b23a8354b"
+      "sha256": "604e5e13d27386a53f519bec5d8e9caf6f2fb78e17f4ead2c8ca8fd4fd9e1c7b"
     }
   ],
   "runtime_artifacts": [

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -160,7 +160,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/home-control-plane.sh",
       "runtime_path": "/usr/local/libexec/workcell/home-control-plane.sh",
-      "sha256": "b3d482570219ea44dc00734dd89befa4999f18bdef9b9890f651d07f87472c98"
+      "sha256": "1160b465e29599a14d52effc4bd422983a4a3a529138b2a5274134fe31ae35e1"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -1149,7 +1149,6 @@ workcell_target_is_allowed() {
 
   case "${target_path}" in
     /state/agent-home/.codex | \
-      /state/agent-home/.codex/* | \
       /state/agent-home/.claude | \
       /state/agent-home/.claude/* | \
       /state/agent-home/.config/claude-code | \
@@ -1174,7 +1173,8 @@ workcell_target_is_allowed() {
       /state/agent-home/.codex/rules | \
       /state/agent-home/.codex/rules/* | \
       /state/agent-home/.codex/mcp | \
-      /state/agent-home/.codex/mcp/*)
+      /state/agent-home/.codex/mcp/* | \
+      /state/agent-home/.codex/*)
       return 1
       ;;
   esac

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -384,7 +384,7 @@ workcell_file_trace_stop_watcher() {
 
 WORKCELL_WORKSPACE_IMPORT_ROOT="${WORKCELL_WORKSPACE_IMPORT_ROOT:-/opt/workcell/workspace-control-plane}"
 WORKCELL_CODEX_RULES_MUTABILITY="${WORKCELL_CODEX_RULES_MUTABILITY:-readonly}"
-WORKCELL_CONTROL_PLANE_MANIFEST="${WORKCELL_CONTROL_PLANE_MANIFEST:-/usr/local/libexec/workcell/control-plane-manifest.json}"
+WORKCELL_CONTROL_PLANE_MANIFEST="/usr/local/libexec/workcell/control-plane-manifest.json"
 
 workcell_session_assurance() {
   workcell_runtime_state_value WORKCELL_SESSION_ASSURANCE || true
@@ -1148,29 +1148,25 @@ workcell_target_is_allowed() {
   esac
 
   case "${target_path}" in
-    /state/agent-home/.codex/AGENTS.md | \
+    /state/agent-home/.codex | \
+      /state/agent-home/.codex/* | \
+      /state/agent-home/.claude | \
+      /state/agent-home/.claude/* | \
+      /state/agent-home/.config/claude-code | \
+      /state/agent-home/.config/claude-code/* | \
+      /state/agent-home/.gemini | \
+      /state/agent-home/.gemini/* | \
+      /state/agent-home/.config/gcloud | \
+      /state/agent-home/.config/gcloud/* | \
+      /state/agent-home/.config/gh | \
+      /state/agent-home/.config/gh/* | \
+      /state/agent-home/.codex/AGENTS.md | \
       /state/agent-home/.codex/auth.json | \
       /state/agent-home/.codex/config.toml | \
       /state/agent-home/.codex/managed_config.toml | \
       /state/agent-home/.codex/requirements.toml | \
-      /state/agent-home/.claude/settings.json | \
-      /state/agent-home/.claude/CLAUDE.md | \
-      /state/agent-home/.claude/.claude.json | \
       /state/agent-home/.claude.json | \
-      /state/agent-home/.claude/.credentials.json | \
-      /state/agent-home/.claude/workcell | \
-      /state/agent-home/.claude/workcell/* | \
-      /state/agent-home/.config/claude-code/auth.json | \
       /state/agent-home/.mcp.json | \
-      /state/agent-home/.gemini/settings.json | \
-      /state/agent-home/.gemini/GEMINI.md | \
-      /state/agent-home/.gemini/.env | \
-      /state/agent-home/.gemini/oauth_creds.json | \
-      /state/agent-home/.gemini/projects.json | \
-      /state/agent-home/.gemini/trustedFolders.json | \
-      /state/agent-home/.config/gcloud/application_default_credentials.json | \
-      /state/agent-home/.config/gh/config.yml | \
-      /state/agent-home/.config/gh/hosts.yml | \
       /state/agent-home/.ssh | \
       /state/agent-home/.ssh/* | \
       /state/agent-home/.codex/agents | \

--- a/scripts/lib/trusted-docker-client.sh
+++ b/scripts/lib/trusted-docker-client.sh
@@ -4,7 +4,7 @@ canonicalize_workcell_dir() {
 
   [[ -d "${candidate}" ]] || return 1
   (
-    cd "${candidate}"
+    cd "${candidate}" || exit 1
     pwd -P
   )
 }

--- a/scripts/lib/trusted-docker-client.sh
+++ b/scripts/lib/trusted-docker-client.sh
@@ -1,30 +1,51 @@
 # shellcheck shell=bash
-resolve_workcell_real_home() {
-  local uid="" user="" home="" fallback_parent="" fallback_home=""
+canonicalize_workcell_dir() {
+  local candidate="$1"
 
-  if [[ -n "${WORKCELL_DOCKER_REAL_HOME:-}" ]]; then
-    if [[ -d "${WORKCELL_DOCKER_REAL_HOME}" ]]; then
-      printf '%s\n' "${WORKCELL_DOCKER_REAL_HOME}"
-      return 0
-    fi
-    echo "Configured WORKCELL_DOCKER_REAL_HOME does not exist: ${WORKCELL_DOCKER_REAL_HOME}" >&2
-    return 1
-  fi
+  [[ -d "${candidate}" ]] || return 1
+  (
+    cd "${candidate}"
+    pwd -P
+  )
+}
+
+workcell_path_within_root() {
+  local candidate="$1"
+  local root="$2"
+  local candidate_real="" root_real=""
+
+  candidate_real="$(canonicalize_workcell_dir "${candidate}")" || return 1
+  root_real="$(canonicalize_workcell_dir "${root}")" || return 1
+  [[ "${candidate_real}" == "${root_real}" ]] || [[ "${candidate_real}" == "${root_real}"/* ]]
+}
+
+discover_workcell_real_home() {
+  local uid="" user="" home="" fallback_parent="" fallback_home="" source=""
 
   uid="$(id -u)"
   user="$(id -un 2>/dev/null || true)"
 
   if command -v getent >/dev/null 2>&1; then
     home="$(getent passwd "${uid}" 2>/dev/null | awk -F: 'NR==1 {print $6}' || true)"
+    if [[ -n "${home}" ]] && [[ -d "${home}" ]]; then
+      source="identity"
+    fi
   fi
   if [[ -z "${home}" ]] && command -v dscl >/dev/null 2>&1; then
     home="$(dscl . -read "/Users/${user}" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
+    if [[ -n "${home}" ]] && [[ -d "${home}" ]]; then
+      source="identity"
+    fi
   fi
   if [[ -z "${home}" && -r /etc/passwd ]]; then
     home="$(awk -F: -v uid="${uid}" '$3 == uid {print $6; exit}' /etc/passwd)"
+    if [[ -n "${home}" ]] && [[ -d "${home}" ]]; then
+      source="identity"
+    fi
   fi
   if [[ -n "${HOME:-}" ]] && { [[ -z "${home}" ]] || [[ ! -d "${home}" ]]; }; then
     home="${HOME}"
+    source="env"
   fi
 
   if [[ -z "${home}" ]]; then
@@ -38,11 +59,56 @@ resolve_workcell_real_home() {
     fallback_home="${fallback_parent%/}/workcell-home-${uid}"
     mkdir -p "${fallback_home}"
     chmod 0700 "${fallback_home}" 2>/dev/null || true
-    printf '%s\n' "${fallback_home}"
+    printf 'synthetic\t%s\n' "${fallback_home}"
     return 0
   fi
 
-  printf '%s\n' "${home}"
+  printf '%s\t%s\n' "${source:-env}" "${home}"
+}
+
+resolve_workcell_real_home() {
+  local discovered_source="" discovered_home="" override_home="" discovered_real="" override_real=""
+
+  IFS=$'\t' read -r discovered_source discovered_home < <(discover_workcell_real_home)
+
+  if [[ -z "${WORKCELL_DOCKER_REAL_HOME:-}" ]]; then
+    printf '%s\n' "${discovered_home}"
+    return 0
+  fi
+
+  if [[ ! -d "${WORKCELL_DOCKER_REAL_HOME}" ]]; then
+    echo "Configured WORKCELL_DOCKER_REAL_HOME does not exist: ${WORKCELL_DOCKER_REAL_HOME}" >&2
+    return 1
+  fi
+  override_home="${WORKCELL_DOCKER_REAL_HOME}"
+  override_real="$(canonicalize_workcell_dir "${override_home}")" || {
+    echo "Configured WORKCELL_DOCKER_REAL_HOME is not a directory: ${override_home}" >&2
+    return 1
+  }
+
+  if [[ "${discovered_source}" == "identity" ]]; then
+    discovered_real="$(canonicalize_workcell_dir "${discovered_home}")" || {
+      echo "Discovered Docker home is not a directory: ${discovered_home}" >&2
+      return 1
+    }
+    if [[ "${override_real}" != "${discovered_real}" ]]; then
+      echo "Configured WORKCELL_DOCKER_REAL_HOME must match the operator home: ${override_home}" >&2
+      return 1
+    fi
+    printf '%s\n' "${override_real}"
+    return 0
+  fi
+
+  if [[ -z "${WORKCELL_DOCKER_HOST_HOME_ROOT:-}" ]]; then
+    echo "Configured WORKCELL_DOCKER_REAL_HOME requires WORKCELL_DOCKER_HOST_HOME_ROOT when the operator home cannot be discovered safely" >&2
+    return 1
+  fi
+  if [[ -n "${ROOT_DIR:-}" ]] && workcell_path_within_root "${override_real}" "${ROOT_DIR}"; then
+    echo "Configured WORKCELL_DOCKER_REAL_HOME must not point inside the workspace: ${override_home}" >&2
+    return 1
+  fi
+
+  printf '%s\n' "${override_real}"
 }
 
 copy_workcell_docker_state_tree() {

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -901,7 +901,7 @@ verify_codex_managed_config_invariants() {
     "approval_policy" \
     "sandbox_mode" \
     "web_search" || return 1
-  require_toml_assignment "${file}" "profiles.strict" "sandbox_mode" '"danger-full-access"' || return 1
+  require_toml_assignment "${file}" "profiles.strict" "sandbox_mode" '"workspace-write"' || return 1
   require_toml_assignment "${file}" "profiles.strict" "approval_policy" '"on-request"' || return 1
   require_toml_assignment "${file}" "profiles.strict" "web_search" '"disabled"' || return 1
   require_toml_section_absent "${file}" "profiles.strict.sandbox_workspace_write" || return 1
@@ -910,7 +910,7 @@ verify_codex_managed_config_invariants() {
     "approval_policy" \
     "sandbox_mode" \
     "web_search" || return 1
-  require_toml_assignment "${file}" "profiles.development" "sandbox_mode" '"danger-full-access"' || return 1
+  require_toml_assignment "${file}" "profiles.development" "sandbox_mode" '"workspace-write"' || return 1
   require_toml_assignment "${file}" "profiles.development" "approval_policy" '"on-request"' || return 1
   require_toml_assignment "${file}" "profiles.development" "web_search" '"disabled"' || return 1
   require_toml_section_absent "${file}" "profiles.development.sandbox_workspace_write" || return 1
@@ -919,7 +919,7 @@ verify_codex_managed_config_invariants() {
     "approval_policy" \
     "sandbox_mode" \
     "web_search" || return 1
-  require_toml_assignment "${file}" "profiles.build" "sandbox_mode" '"danger-full-access"' || return 1
+  require_toml_assignment "${file}" "profiles.build" "sandbox_mode" '"workspace-write"' || return 1
   require_toml_assignment "${file}" "profiles.build" "approval_policy" '"never"' || return 1
   require_toml_assignment "${file}" "profiles.build" "web_search" '"disabled"' || return 1
   require_toml_section_absent "${file}" "profiles.build.sandbox_workspace_write" || return 1
@@ -943,8 +943,14 @@ assert_codex_managed_config_rejected() {
   fi
 }
 
+CODEX_CONFIG="${ROOT_DIR}/adapters/codex/.codex/config.toml"
 CODEX_MANAGED_CONFIG="${ROOT_DIR}/adapters/codex/managed_config.toml"
+verify_codex_managed_config_invariants "${CODEX_CONFIG}" || exit 1
 verify_codex_managed_config_invariants "${CODEX_MANAGED_CONFIG}" || exit 1
+if ! grep -Fq 'allowed_sandbox_modes = ["workspace-write", "danger-full-access"]' "${ROOT_DIR}/adapters/codex/requirements.toml"; then
+  echo 'Expected adapters/codex/requirements.toml to allow workspace-write for managed sessions and danger-full-access only for breakglass' >&2
+  exit 1
+fi
 
 codex_managed_config_tmpdir="$(mktemp -d)"
 

--- a/scripts/with-validation-snapshot.sh
+++ b/scripts/with-validation-snapshot.sh
@@ -116,6 +116,18 @@ validate_blob_oid() {
   fi
 }
 
+validate_symlink_target() {
+  local link_target="$1"
+  local label="$2"
+  local tracked_path="$3"
+
+  case "${link_target}" in
+    '' | /* | .. | ../* | */../* | */..)
+      die "with-validation-snapshot: unsafe symlink target in ${label} rejected for ${tracked_path}: ${link_target}"
+      ;;
+  esac
+}
+
 materialize_tracked_entry() {
   local mode="$1"
   local oid="$2"
@@ -141,7 +153,8 @@ materialize_tracked_entry() {
       if ! IFS= read -r -d '' link_target < <(git -C "${REPO_ROOT}" cat-file blob "${oid}" && printf '\0'); then
         die "with-validation-snapshot: failed to read symlink blob ${oid} for path: ${tracked_path}"
       fi
-      ln -s "${link_target}" "${dest}"
+      validate_symlink_target "${link_target}" "${label}" "${tracked_path}"
+      ln -s -- "${link_target}" "${dest}"
       return 0
       ;;
     *)


### PR DESCRIPTION
## Summary
- restore Codex managed profiles to workspace-write outside breakglass and cover the live-seeded config path
- block validation snapshot and release-input symlink escapes
- harden shared credential scoping, control-plane target restrictions, hosted-controls validation, and trusted Docker home resolution

## Root cause
Several recent changes relaxed or omitted boundary checks around managed agent config, symlink handling, shared GitHub credentials, and trusted control-plane state. In combination, those changes weakened defense-in-depth for validation, injection, and managed runtime paths.

## Validation
- go test ./cmd/workcell-metadatautil ./internal/authpolicy ./internal/authresolve ./internal/injection ./internal/metadatautil ./internal/testkit
- ./scripts/verify-control-plane-manifest.sh
- ./scripts/pre-merge.sh --help