### PR TITLE
[codex] Align hosted controls with current review posture

### DIFF
--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -436,8 +436,8 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 	if branchReviewMode == "" {
 		branchReviewMode = "review-gated"
 	}
-	if branchReviewMode != "review-gated" && branchReviewMode != "single-owner-public-pr" && branchReviewMode != "single-owner-private-pr" {
-		return fmt.Errorf("%s must set branch_review.mode to 'review-gated', 'single-owner-public-pr', or 'single-owner-private-pr'", policyPath)
+	if branchReviewMode != "review-gated" && branchReviewMode != "approval-gated" && branchReviewMode != "single-owner-public-pr" && branchReviewMode != "single-owner-private-pr" {
+		return fmt.Errorf("%s must set branch_review.mode to 'review-gated', 'approval-gated', 'single-owner-public-pr', or 'single-owner-private-pr'", policyPath)
 	}
 	releasePolicy, _ := policy["release_environment"].(map[string]any)
 	releaseMode, _ := releasePolicy["mode"].(string)
@@ -568,12 +568,16 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 
 	pullRequestRule := hasRule(branchReview, "pull_request")
 	parameters, _ := pullRequestRule["parameters"].(map[string]any)
-	if branchReviewMode == "review-gated" {
+	if branchReviewMode == "review-gated" || branchReviewMode == "approval-gated" {
 		if count, _ := parameters["required_approving_review_count"].(float64); count < 1 {
 			return fmt.Errorf("default-branch review ruleset on %s must require at least one approving review", repo)
 		}
-		if required, _ := parameters["require_code_owner_review"].(bool); !required {
+		requireCodeOwnerReview, _ := parameters["require_code_owner_review"].(bool)
+		if branchReviewMode == "review-gated" && !requireCodeOwnerReview {
 			return fmt.Errorf("default-branch review ruleset on %s must require code owner review", repo)
+		}
+		if branchReviewMode == "approval-gated" && requireCodeOwnerReview {
+			return fmt.Errorf("default-branch review ruleset on %s must not require code owner review in approval-gated mode", repo)
 		}
 		if resolved, _ := parameters["required_review_thread_resolution"].(bool); !resolved {
 			return fmt.Errorf("default-branch review ruleset on %s must require resolved review threads", repo)

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -66,21 +66,21 @@ func writePinnedInputsFixture(tb testing.TB) PinnedInputsConfig {
 	}
 
 	return PinnedInputsConfig{
-		RuntimeDockerfilePath:         filepath.Join(dstRoot, "runtime", "container", "Dockerfile"),
-		ValidatorDockerfilePath:       filepath.Join(dstRoot, "tools", "validator", "Dockerfile"),
-		ProvidersPackageJSONPath:      filepath.Join(dstRoot, "runtime", "container", "providers", "package.json"),
-		ProvidersPackageLockPath:      filepath.Join(dstRoot, "runtime", "container", "providers", "package-lock.json"),
-		WorkflowsDir:                  filepath.Join(dstRoot, ".github", "workflows"),
-		CIWorkflowPath:                filepath.Join(dstRoot, ".github", "workflows", "ci.yml"),
-		ReleaseWorkflowPath:           filepath.Join(dstRoot, ".github", "workflows", "release.yml"),
-		PinHygieneWorkflowPath:        filepath.Join(dstRoot, ".github", "workflows", "pin-hygiene.yml"),
-		CodeownersPath:                filepath.Join(dstRoot, ".github", "CODEOWNERS"),
-		CodexRequirementsPath:         filepath.Join(dstRoot, "adapters", "codex", "requirements.toml"),
-		CodexMCPConfigPath:            filepath.Join(dstRoot, "adapters", "codex", "mcp", "config.toml"),
-		HostedControlsPolicyPath:      filepath.Join(dstRoot, "policy", "github-hosted-controls.toml"),
-		HostedControlsScriptPath:      filepath.Join(dstRoot, "scripts", "verify-github-hosted-controls.sh"),
-		ProviderBumpPolicyPath:        filepath.Join(dstRoot, "policy", "provider-bumps.toml"),
-		MaxDebianSnapshotAgeDays:      3650,
+		RuntimeDockerfilePath:    filepath.Join(dstRoot, "runtime", "container", "Dockerfile"),
+		ValidatorDockerfilePath:  filepath.Join(dstRoot, "tools", "validator", "Dockerfile"),
+		ProvidersPackageJSONPath: filepath.Join(dstRoot, "runtime", "container", "providers", "package.json"),
+		ProvidersPackageLockPath: filepath.Join(dstRoot, "runtime", "container", "providers", "package-lock.json"),
+		WorkflowsDir:             filepath.Join(dstRoot, ".github", "workflows"),
+		CIWorkflowPath:           filepath.Join(dstRoot, ".github", "workflows", "ci.yml"),
+		ReleaseWorkflowPath:      filepath.Join(dstRoot, ".github", "workflows", "release.yml"),
+		PinHygieneWorkflowPath:   filepath.Join(dstRoot, ".github", "workflows", "pin-hygiene.yml"),
+		CodeownersPath:           filepath.Join(dstRoot, ".github", "CODEOWNERS"),
+		CodexRequirementsPath:    filepath.Join(dstRoot, "adapters", "codex", "requirements.toml"),
+		CodexMCPConfigPath:       filepath.Join(dstRoot, "adapters", "codex", "mcp", "config.toml"),
+		HostedControlsPolicyPath: filepath.Join(dstRoot, "policy", "github-hosted-controls.toml"),
+		HostedControlsScriptPath: filepath.Join(dstRoot, "scripts", "verify-github-hosted-controls.sh"),
+		ProviderBumpPolicyPath:   filepath.Join(dstRoot, "policy", "provider-bumps.toml"),
+		MaxDebianSnapshotAgeDays: 3650,
 	}
 }
 
@@ -157,6 +157,13 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 		branchReviewParameters = map[string]any{
 			"required_approving_review_count":   float64(1),
 			"require_code_owner_review":         true,
+			"required_review_thread_resolution": true,
+		}
+	} else if branchMode == "approval-gated" {
+		branchReviewParameters = map[string]any{
+			"required_approving_review_count":   float64(1),
+			"require_code_owner_review":         false,
+			"require_last_push_approval":        false,
 			"required_review_thread_resolution": true,
 		}
 	}
@@ -363,6 +370,61 @@ func TestVerifyGitHubHostedControlsRejectsExtraPublicCollaboratorsForBranchRevie
 	}
 	if !strings.Contains(err.Error(), "requires exactly one direct collaborator") {
 		t.Fatalf("VerifyGitHubHostedControls() error = %v, want collaborator-count rejection", err)
+	}
+}
+
+func TestVerifyGitHubHostedControlsAcceptsApprovalGatedPublicRepo(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, policyPath := writeHostedControlsFixture(t, "approval-gated", "review-gated", []map[string]any{
+		{
+			"login": "omkhar",
+			"permissions": map[string]any{
+				"admin": true,
+			},
+		},
+		{
+			"login": "extra-maintainer",
+			"permissions": map[string]any{
+				"admin": false,
+			},
+		},
+	})
+
+	if err := VerifyGitHubHostedControls(tmpDir, "omkhar/workcell", policyPath); err != nil {
+		t.Fatalf("VerifyGitHubHostedControls() error = %v, want acceptance for approval-gated public repo", err)
+	}
+}
+
+func TestVerifyGitHubHostedControlsRejectsApprovalGatedWithoutApproval(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, policyPath := writeHostedControlsFixture(t, "approval-gated", "review-gated", []map[string]any{
+		{
+			"login": "omkhar",
+			"permissions": map[string]any{
+				"admin": true,
+			},
+		},
+		{
+			"login": "extra-maintainer",
+			"permissions": map[string]any{
+				"admin": false,
+			},
+		},
+	})
+
+	rewriteFile(t, filepath.Join(tmpDir, "rulesets.json"), func(content string) string {
+		content = strings.Replace(content, `"required_approving_review_count": 1`, `"required_approving_review_count": 0`, 1)
+		return strings.Replace(content, `"required_approving_review_count":1`, `"required_approving_review_count":0`, 1)
+	})
+
+	err := VerifyGitHubHostedControls(tmpDir, "omkhar/workcell", policyPath)
+	if err == nil {
+		t.Fatal("VerifyGitHubHostedControls() unexpectedly accepted approval-gated review rules without an approval requirement")
+	}
+	if !strings.Contains(err.Error(), "must require at least one approving review") {
+		t.Fatalf("VerifyGitHubHostedControls() error = %v, want approval requirement rejection", err)
 	}
 }
 

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -14,6 +14,8 @@ block_deletions = true
 # Valid modes:
 # - "review-gated": require pull requests, at least one approving review,
 #   code owner review, and resolved review threads
+# - "approval-gated": require pull requests, at least one approving review,
+#   and resolved review threads without forcing code owner review on every PR
 # - "single-owner-public-pr": require pull requests and resolved review
 #   threads on a public single-owner repository, while allowing zero required
 #   human approvals because no second maintainer exists yet; comment sweeps for
@@ -21,12 +23,12 @@ block_deletions = true
 # - "single-owner-private-pr": require pull requests on a private user-owned
 #   single-owner repository, but allow zero required approvals and no code
 #   owner/thread gate so merges remain workable without an admin bypass
-mode = "single-owner-public-pr"
+mode = "approval-gated"
 
 [release_environment]
 # Valid modes:
-# - "review-gated": require at least one human reviewer, prevent self-review,
-#   and disallow admin bypass
+# - "review-gated": require at least one human reviewer and disallow admin
+#   bypass
 # - "single-owner-public": require a release environment on a public
 #   single-owner repository, disallow admin bypass, and allow maintainer
 #   self-review until a second release approver exists
@@ -35,7 +37,7 @@ mode = "single-owner-public-pr"
 # - "plan-limited-private": lower-assurance fallback for private repositories
 #   on GitHub plans that cannot enforce environment reviewers; the environment
 #   must still exist, but reviewer gating is not available
-mode = "single-owner-public"
+mode = "review-gated"
 
 [required_status_checks]
 contexts = [


### PR DESCRIPTION
## Summary
- add an `approval-gated` hosted-controls branch review mode for public repos that need one approval plus resolved threads without mandatory code-owner review
- move the canonical policy to `approval-gated` for branch reviews and `review-gated` for the release environment
- add hosted-controls regression coverage and align the live `main-review` ruleset to the new policy

## Validation
- `go test ./internal/metadatautil`
- `./scripts/check-pinned-inputs.sh`
- `./scripts/verify-github-hosted-controls.sh omkhar/workcell`
- `./scripts/validate-repo.sh`
- verified the live `main-review` ruleset now requires one approval and resolved review threads without mandatory code-owner review