### PR TITLE
Align docs with current session and rollout state

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,21 @@ boundary.
 ## Project status
 
 - pre-1.0 and still tightening the public contract
-- Apple Silicon macOS hosts only today
-- CLI surfaces for Codex, Claude, and Gemini
+- Apple Silicon macOS hosts only today; Linux and Windows are not currently
+  supported
+- local host-launched runtime first; there is no Workcell-managed cloud or
+  remote worker plane today
+- CLI surfaces for Codex, Claude, and Gemini plus host-side detached session
+  control and inspection commands
 - GitHub-hosted CI verifies repo shape, reproducibility, release posture, and
   secretless runtime behavior
 - GitHub-hosted CI continuously verifies bundle install/uninstall and Homebrew
   install/uninstall on Apple Silicon `macos-26` and `macos-15`
 - the real macOS Colima boundary is still a local operator exercise because
   GitHub-hosted Linux runners cannot prove it
+- Workcell does not yet ship a centralized enterprise policy, inventory, or
+  analytics plane; team rollout today relies on distributing reviewed
+  host-side files
 
 Breaking changes should be called out in [CHANGELOG.md](CHANGELOG.md) and
 tracked in [ROADMAP.md](ROADMAP.md).
@@ -82,7 +89,8 @@ workcell --agent codex --workspace /path/to/repo
 ```
 
 See [docs/getting-started.md](docs/getting-started.md) for the release install
-path and provider-specific onboarding.
+path and provider-specific onboarding. For team rollout patterns on today's
+local-first product, see [docs/enterprise-rollout.md](docs/enterprise-rollout.md).
 
 ## Install options
 
@@ -162,6 +170,11 @@ derived launch view after selector evaluation and preprocessing.
 `workcell why` explains why one credential is selected, out of scope, filtered,
 or still only configured on the host side.
 
+Direct staged credentials are the primary supported auth path today. Built-in
+resolver coverage is intentionally narrow; for example, the Claude macOS
+resolver scaffold can record intent but is not launch-ready until a supported
+export path exists.
+
 Workcell can stage:
 
 - common or provider-specific instruction fragments
@@ -188,6 +201,10 @@ See [docs/injection-policy.md](docs/injection-policy.md) and
 
 GUI and IDE surfaces are lower assurance unless they act only as clients to
 the same bounded runtime.
+
+See [docs/injection-policy.md](docs/injection-policy.md) for provider auth
+maturity and [docs/enterprise-rollout.md](docs/enterprise-rollout.md) for the
+current team rollout model.
 
 ## Mode map
 
@@ -237,7 +254,13 @@ workcell --agent codex --prepare --workspace /path/to/repo
 workcell --agent codex --prepare-only --workspace /path/to/repo
 workcell --agent codex --mode development --workspace /path/to/repo -- bash -lc 'git status'
 workcell session list
+workcell session start --agent codex --workspace /path/to/repo
+workcell session attach --id 20260408T120000Z-1a2b3c4d
+workcell session send --id 20260408T120000Z-1a2b3c4d --message "continue with tests"
+workcell session stop --id 20260408T120000Z-1a2b3c4d
 workcell session show --id 20260408T120000Z-1a2b3c4d
+workcell session logs --id 20260408T120000Z-1a2b3c4d --kind audit
+workcell session timeline --id 20260408T120000Z-1a2b3c4d
 workcell session diff --id 20260408T120000Z-1a2b3c4d
 workcell session export --id 20260408T120000Z-1a2b3c4d --output /tmp/workcell-session.json
 workcell policy show

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,12 +10,9 @@ The delivery shape for the active slice lives in
 
 ## Short term
 
-- finish Phase 2 of the session supervisor:
-  detached/background sessions, `session start`, `session attach`,
-  `session send`, `session stop`, and default worktree-per-session flows
-- add session observability on top of the current host-side inventory:
-  live status, branch/worktree, assurance state, logs, transcript pointers,
-  and command timeline views
+- finish the current session-supervisor slice around default
+  worktree-per-session flows and richer live status, branch/worktree,
+  assurance, and log rendering on top of the shipped detached session commands
 - broaden host-owned auth flows where the current implementation is still thin:
   more resolver coverage plus explicit browser/bootstrap handoffs for provider
   onboarding
@@ -29,6 +26,8 @@ The delivery shape for the active slice lives in
 
 ## Medium term
 
+- add pause, resume, checkpoint, and fork flows on the same host-controlled
+  session plane
 - add reviewed team workflow packs at the Workcell layer: versioned
   instruction bundles, commands, approved MCP packs, and task templates
 - add a lightweight TUI or dashboard backed by the same host-controlled

--- a/docs/enterprise-rollout.md
+++ b/docs/enterprise-rollout.md
@@ -1,0 +1,133 @@
+# Enterprise Rollout Today
+
+This page describes the current Workcell rollout model for teams.
+
+Workcell is local-first today:
+
+- supported hosts are Apple Silicon macOS only
+- the primary product surface is a host-launched local runtime
+- there is no Workcell-managed cloud or remote worker plane yet
+- there is no centralized Workcell policy, inventory, or analytics service yet
+
+The current rollout model is to distribute reviewed host-side files and let
+operators launch Workcell locally inside the shared VM-plus-container boundary.
+
+## What Workcell standardizes today
+
+Workcell already gives teams one shared contract for:
+
+- the runtime boundary and runtime profiles
+- provider-home seeding and control-plane masking
+- the host-side injection-policy format
+- host-side auth, policy, and explainability commands
+- detached session records and host-side session control
+- host-side publication and release provenance
+
+Those pieces are implemented in the product. They do not depend on a separate
+central administration plane.
+
+## What stays host-local today
+
+These parts are still local to each operator host:
+
+- Workcell installation and updates
+- `~/.config/workcell/` policy files and included fragments
+- managed credential material referenced by `workcell auth`
+- `~/.colima/<profile>/sessions/` durable session records
+- local launch history, retained debug logs, transcripts, and file traces
+
+If you want team-wide consistency today, distribute reviewed host-side files
+through your existing host configuration workflow rather than expecting
+Workcell to act as a central policy service.
+
+## Recommended rollout shape
+
+### 1. Standardize the support boundary
+
+Roll out Workcell only to supported Apple Silicon macOS hosts and treat the
+current GitHub-hosted install matrix as the tested release window, not as proof
+for all macOS variants.
+
+### 2. Distribute reviewed host-side files
+
+Use your existing device-management, bootstrap, or dotfile workflow to place:
+
+- reviewed Workcell policy fragments under `~/.config/workcell/`
+- org-wide instruction docs referenced from `[documents]`
+- reviewed credential files referenced from `[credentials]`
+- reviewed SSH config and identity paths referenced from `[ssh]`
+
+Keep repo-local provider control files as imported inputs, not as the live
+control plane.
+
+### 3. Prefer direct staged auth inputs
+
+Direct staged credentials are the main supported auth path today.
+
+- Codex: `codex_auth`
+- Claude: `claude_auth`, `claude_api_key`, and `claude_mcp`
+- Gemini: `gemini_env`, `gemini_oauth`, and `gemini_projects`
+- Gemini Vertex supplement: `gcloud_adc`
+
+Current caveats:
+
+- the built-in Claude macOS resolver scaffold can record intent, but it remains
+  fail-closed until a supported export path exists
+- `gcloud_adc` is supplemental to Vertex config, not a standalone Gemini auth
+  mode
+
+See [injection-policy.md](injection-policy.md) for the current by-provider auth
+maturity summary.
+
+### 4. Scope shared GitHub and SSH inputs deliberately
+
+When teams want shared GitHub CLI or SSH behavior:
+
+- scope `github_hosts` and `github_config` with `providers = [...]`
+- keep SSH material in the `[ssh]` section rather than ad hoc copies
+- review MCP state explicitly instead of trusting ambient workspace config
+
+This keeps shared inputs least-privilege and visible in policy.
+
+### 5. Keep publication on the host
+
+The supported publication path remains:
+
+1. run the provider inside Workcell
+2. review the resulting changes
+3. publish from the host with `workcell publish-pr`
+
+Do not treat in-session git publication as equivalent to the host-side release
+and signing model.
+
+## What is not centralized yet
+
+Workcell does not yet provide:
+
+- centralized policy distribution inside the product
+- org-wide RBAC, SSO, or SCIM features
+- centralized session inventory or usage analytics
+- a preserved-boundary GUI or IDE client path
+- remote or cloud-spawned workspaces
+
+Those are roadmap items, not part of the supported contract today.
+
+## Assurance notes for rollout decisions
+
+- GitHub-hosted CI proves repo shape, smoke behavior, reproducibility, release
+  posture, and install/uninstall behavior on GitHub-hosted Apple Silicon
+  `macos-26` and `macos-15`.
+- GitHub-hosted CI does not prove the full local macOS Colima boundary.
+- The strongest boundary claim still depends on local validation and operator
+  discipline on supported hosts.
+- Lower-assurance paths such as `development`, `breakglass`, prompt autonomy,
+  package mutation, and host-side transcript capture should stay explicit in
+  rollout guidance.
+
+## Related docs
+
+- [Getting started](getting-started.md)
+- [Injection policy](injection-policy.md)
+- [Provider matrix](provider-matrix.md)
+- [Validation scenarios](validation-scenarios.md)
+- [Roadmap](../ROADMAP.md)

--- a/docs/enterprise-rollout.md
+++ b/docs/enterprise-rollout.md
@@ -12,6 +12,14 @@ Workcell is local-first today:
 The current rollout model is to distribute reviewed host-side files and let
 operators launch Workcell locally inside the shared VM-plus-container boundary.
 
+## Traceability note
+
+- supported-host and release-window claims map to the validated install matrix
+- auth, policy, session, and host-publication claims map to the named anchors
+  in [validation-scenarios.md](validation-scenarios.md)
+- the "not centralized yet" bullets below are support-boundary statements, not
+  claims of automated proof
+
 ## What Workcell standardizes today
 
 Workcell already gives teams one shared contract for:
@@ -129,5 +137,6 @@ Those are roadmap items, not part of the supported contract today.
 - [Getting started](getting-started.md)
 - [Injection policy](injection-policy.md)
 - [Provider matrix](provider-matrix.md)
+- [Requirements validation](requirements-validation.md)
 - [Validation scenarios](validation-scenarios.md)
 - [Roadmap](../ROADMAP.md)

--- a/docs/examples/enterprise-claude-setup.md
+++ b/docs/examples/enterprise-claude-setup.md
@@ -3,6 +3,11 @@
 This pattern is for teams that want a shared Claude baseline without mounting
 whole host homes into the runtime.
 
+It assumes supported Apple Silicon macOS hosts and the current local-first
+Workcell product shape. Workcell does not yet ship a centralized enterprise
+policy or session-administration plane; teams distribute reviewed host-side
+files through their existing host configuration workflow today.
+
 ## Recommended split
 
 Keep these concerns separate:
@@ -52,3 +57,4 @@ workcell --prepare --agent claude --workspace /path/to/repo
 
 - [docs/injection-policy.md](../injection-policy.md)
 - [docs/adapter-control-planes.md](../adapter-control-planes.md)
+- [docs/enterprise-rollout.md](../enterprise-rollout.md)

--- a/docs/examples/enterprise-claude-setup.md
+++ b/docs/examples/enterprise-claude-setup.md
@@ -58,3 +58,5 @@ workcell --prepare --agent claude --workspace /path/to/repo
 - [docs/injection-policy.md](../injection-policy.md)
 - [docs/adapter-control-planes.md](../adapter-control-planes.md)
 - [docs/enterprise-rollout.md](../enterprise-rollout.md)
+- [docs/requirements-validation.md](../requirements-validation.md)
+- [docs/validation-scenarios.md](../validation-scenarios.md)

--- a/docs/examples/gemini-vertex-setup.md
+++ b/docs/examples/gemini-vertex-setup.md
@@ -40,3 +40,5 @@ workcell --prepare --agent gemini --workspace /path/to/repo
 
 - [docs/injection-policy.md](../injection-policy.md)
 - [docs/examples/quickstart-gemini.md](quickstart-gemini.md)
+- [docs/requirements-validation.md](../requirements-validation.md)
+- [docs/validation-scenarios.md](../validation-scenarios.md)

--- a/docs/examples/quickstart-claude.md
+++ b/docs/examples/quickstart-claude.md
@@ -1,14 +1,30 @@
 # Quickstart: Claude in Workcell
 
+This guide assumes a supported Apple Silicon macOS host. GitHub-hosted CI and
+tagged-release install verification currently cover `macos-26` and `macos-15`;
+the strongest local boundary claim still depends on local Colima validation.
+
 ## Prerequisites
 
 - Workcell installed with `./scripts/install.sh`
 - a repo you want to mount as the workspace
-- a reviewed Claude API key file, or an experimental macOS resolver config
+- a reviewed Claude auth export, a reviewed Claude API key file, or an
+  experimental macOS resolver config
 
 ## 1. Create or update the injection policy
 
-Supported flow today: API key helper path
+Launch-ready paths today:
+
+Reviewed exported Claude auth file:
+
+```bash
+workcell auth set \
+  --agent claude \
+  --credential claude_auth \
+  --source /Users/example/.config/workcell/claude-auth.json
+```
+
+Reviewed API key helper path:
 
 ```bash
 workcell auth init
@@ -36,8 +52,9 @@ future supported export and verify the configured-only state with
 
 ## 2. Optional explicit prepare
 
-If you configured `claude_api_key`, a normal strict launch prepares the reviewed
-runtime image automatically when needed:
+If you configured a launch-ready Claude auth input such as `claude_auth` or
+`claude_api_key`, a normal strict launch prepares the reviewed runtime image
+automatically when needed:
 
 ```bash
 workcell --agent claude --workspace /path/to/repo

--- a/docs/examples/quickstart-claude.md
+++ b/docs/examples/quickstart-claude.md
@@ -124,4 +124,5 @@ workcell publish-pr --workspace /path/to/repo --branch feature/my-change \
 
 - [docs/injection-policy.md](../injection-policy.md)
 - [docs/adapter-control-planes.md](../adapter-control-planes.md)
+- [docs/requirements-validation.md](../requirements-validation.md)
 - [docs/validation-scenarios.md](../validation-scenarios.md)

--- a/docs/examples/quickstart-codex.md
+++ b/docs/examples/quickstart-codex.md
@@ -116,3 +116,5 @@ workcell publish-pr \
 - [Injection policy](../injection-policy.md)
 - [Codex adapter](../../adapters/codex/README.md)
 - [Adapter control planes](../adapter-control-planes.md)
+- [Requirements validation](../requirements-validation.md)
+- [Validation scenarios](../validation-scenarios.md)

--- a/docs/examples/quickstart-codex.md
+++ b/docs/examples/quickstart-codex.md
@@ -3,9 +3,14 @@
 This guide walks through the normal Codex path inside Workcell's bounded
 runtime.
 
+It assumes a supported Apple Silicon macOS host. GitHub-hosted CI and
+tagged-release install verification currently cover `macos-26` and `macos-15`;
+the strongest local boundary claim still depends on local Colima validation.
+
 ## Prerequisites
 
 - macOS
+- Apple Silicon host
 - Colima
 - Docker CLI
 - Workcell installed with `./scripts/install.sh`

--- a/docs/examples/quickstart-gemini.md
+++ b/docs/examples/quickstart-gemini.md
@@ -94,3 +94,5 @@ workcell publish-pr --workspace /path/to/repo --branch feature/my-change \
 - [docs/injection-policy.md](../injection-policy.md)
 - [docs/examples/gemini-vertex-setup.md](gemini-vertex-setup.md)
 - [docs/adapter-control-planes.md](../adapter-control-planes.md)
+- [docs/requirements-validation.md](../requirements-validation.md)
+- [docs/validation-scenarios.md](../validation-scenarios.md)

--- a/docs/examples/quickstart-gemini.md
+++ b/docs/examples/quickstart-gemini.md
@@ -1,5 +1,9 @@
 # Quickstart: Gemini in Workcell
 
+This guide assumes a supported Apple Silicon macOS host. GitHub-hosted CI and
+tagged-release install verification currently cover `macos-26` and `macos-15`;
+the strongest local boundary claim still depends on local Colima validation.
+
 ## Prerequisites
 
 - Workcell installed with `./scripts/install.sh`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,6 +122,9 @@ workcell --agent codex --agent-autonomy prompt --workspace /path/to/repo
 - [Claude quickstart](examples/quickstart-claude.md)
 - [Gemini quickstart](examples/quickstart-gemini.md)
 
+For team rollout patterns on today's local-first product, see
+[Enterprise rollout today](enterprise-rollout.md).
+
 ## 6. Understand the contract
 
 - [Security invariants](invariants.md)

--- a/docs/implement-first-delivery-plan.md
+++ b/docs/implement-first-delivery-plan.md
@@ -4,6 +4,13 @@ This document turns the current short-term roadmap into a concrete delivery
 shape that keeps the boundary model intact and favors additive host-side
 changes on top of the inspection and policy surfaces that already shipped.
 
+The current repo already includes durable session records plus detached
+host-side session control (`session start|attach|send|stop`) and basic
+observability surfaces (`session list|show|logs|timeline|diff|export`). The
+remaining work in this slice is to make those commands feel like one coherent
+session platform with safer default workspace isolation, richer status
+rendering, and deeper validation coverage.
+
 ## Principles
 
 - keep new control paths host-owned and file-backed before introducing live
@@ -29,13 +36,14 @@ changes on top of the inspection and policy surfaces that already shipped.
 
 Scope for this delivery slice:
 
-- preserve the shipped durable session inventory and inspection surface:
-  `session list`, `session show`, `session diff`, and `session export`
-- add durable session creation and detached execution
-- add `workcell session attach`, `workcell session send`, and
-  `workcell session stop`
+- preserve the shipped durable session inventory and detached control surface:
+  `session list`, `session show`, `session logs`, `session timeline`,
+  `session diff`, `session export`, `session start`, `session attach`,
+  `session send`, and `session stop`
 - default the safe path to one worktree per session when the operator opts into
   orchestrated session flows
+- keep the detached session path file-backed and host-owned rather than adding
+  same-user local socket trust as a shortcut
 - keep the implementation host-owned and file-backed; do not add same-user
   local socket trust as a shortcut
 
@@ -49,8 +57,8 @@ Staffing:
 
 Scope for this delivery slice:
 
-- surface live status, branch/worktree, assurance state, logs, transcript
-  pointers, and command timeline views
+- extend the shipped logs, transcript pointers, and command timeline views
+  with clearer live status, branch/worktree, and assurance rendering
 - keep the first operator-facing surfaces CLI-first
 - add a lightweight TUI or dashboard only after the session object and status
   model stabilize

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -56,12 +56,24 @@ Today, `claude-macos-keychain` is a fail-closed resolver scaffold: it lets you
 record the intended host-side auth source in policy, but Workcell still aborts
 launch unless a supported export path exists.
 
+## Provider auth maturity
+
+Direct staged credential files are the primary supported auth path today.
+Built-in host resolvers are intentionally narrow and currently limited to the
+Claude macOS resolver scaffold described above.
+
+| Provider | Launch-ready inputs today | Additional reviewed inputs | Current caveats |
+|---|---|---|---|
+| Codex | `codex_auth` | shared GitHub CLI and SSH inputs via policy as needed | direct staged auth file is the normal path |
+| Claude | `claude_auth`, `claude_api_key`, `claude_mcp` | shared GitHub CLI and SSH inputs via policy as needed | the built-in `claude-macos-keychain` resolver can record intent but remains fail-closed until a supported export path exists |
+| Gemini | `gemini_env`, `gemini_oauth`, `gemini_projects` | `gcloud_adc` as a supplemental Vertex input plus shared GitHub CLI and SSH inputs via policy as needed | `gcloud_adc` is not a standalone Gemini auth mode |
+
 ## Credential keys
 
 | Key | Session target | Notes |
 |---|---|---|
 | `codex_auth` | `~/.codex/auth.json` | persisted Codex auth |
-| `claude_auth` | Claude auth mirrors under `~/.claude/`, `~/.claude.json`, and `~/.config/claude-code/` | on macOS, prefer the built-in `claude-macos-keychain` host resolver |
+| `claude_auth` | Claude auth mirrors under `~/.claude/`, `~/.claude.json`, and `~/.config/claude-code/` | direct staged auth file is launch-ready; the built-in `claude-macos-keychain` resolver remains fail-closed scaffold only |
 | `claude_api_key` | helper-backed Claude API key access | avoids seeding a second plaintext key copy into the session |
 | `claude_mcp` | `~/.mcp.json` | reviewed Claude MCP config |
 | `gemini_env` | `~/.gemini/.env` | API key, GCA, or Vertex configuration |

--- a/docs/provider-matrix.md
+++ b/docs/provider-matrix.md
@@ -8,8 +8,11 @@ through a native control-plane mapping.
 | Provider | Tier 1 surface today | Managed control plane | Long-lived auth inputs | Notes |
 |---|---|---|---|---|
 | Codex | CLI | `~/.codex/config.toml`, `managed_config.toml`, `requirements.toml`, rules, MCP config, rendered `AGENTS.md` | `codex_auth` | best fit for the shared boundary model |
-| Claude | Claude Code CLI | `~/.claude/settings.json`, rendered `CLAUDE.md`, `.mcp.json`, auth mirrors, reviewed Bash hook | `claude_auth`, `claude_api_key`, `claude_mcp` | hooks are defense in depth, not the primary boundary |
-| Gemini | Gemini CLI | `~/.gemini/settings.json`, rendered `GEMINI.md`, `.env`, OAuth creds, `projects.json`, trusted folders | `gemini_env`, `gemini_oauth`, `gemini_projects`, `gcloud_adc` | Gemini's own sandbox is not the Tier 1 boundary here |
+| Claude | Claude Code CLI | `~/.claude/settings.json`, rendered `CLAUDE.md`, `.mcp.json`, auth mirrors, reviewed Bash hook | `claude_auth`, `claude_api_key`, `claude_mcp` | direct staged `claude_auth` and `claude_api_key` are supported; the built-in macOS resolver scaffold remains fail-closed |
+| Gemini | Gemini CLI | `~/.gemini/settings.json`, rendered `GEMINI.md`, `.env`, OAuth creds, `projects.json`, trusted folders | `gemini_env`, `gemini_oauth`, `gemini_projects`, `gcloud_adc` | Gemini's own sandbox is not the Tier 1 boundary here; `gcloud_adc` is supplemental to Vertex config |
+
+For provider auth maturity and rollout caveats, see
+[docs/injection-policy.md](injection-policy.md).
 
 ## Tiering rule
 

--- a/docs/provider-matrix.md
+++ b/docs/provider-matrix.md
@@ -23,3 +23,14 @@ For provider auth maturity and rollout caveats, see
 
 Do not force one provider's control model onto another. Keep one shared
 boundary and one thin adapter per product.
+
+## Validation traceability
+
+Use [docs/requirements-validation.md](requirements-validation.md) for the
+machine-checked requirement mapping and
+[docs/validation-scenarios.md](validation-scenarios.md) for the concrete
+scenario and script anchors behind the auth and control-plane caveats.
+
+The Tier 1, 2, and 3 rule is a support classification. It is not a claim that
+GUI, IDE, or cloud paths receive the same validation depth as the Tier 1 CLI
+path.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -88,6 +88,33 @@ gh pr checks <pr-number> --repo "${REPO}"
 
 Use the GitHub API or GraphQL as needed to inspect unresolved review threads.
 
+## Documentation review gate
+
+Every release branch must also go through an explicit documentation review.
+
+A release is not ready to merge unless all of the following are true:
+
+- `CHANGELOG.md` accurately summarizes the release contents and date
+- `README.md` and `docs/getting-started.md` still describe the current support
+  boundary, install path, and tested release-install matrix honestly
+- provider and rollout docs that affect the release, such as
+  `docs/injection-policy.md`, `docs/provider-matrix.md`, and relevant
+  quickstarts or setup guides, match the current implementation and auth
+  maturity
+- `ROADMAP.md` and nearby planning or design docs do not describe shipped work
+  as future work and do not remove partially shipped work from the roadmap
+- release-sensitive runbooks such as `docs/releasing.md`,
+  `docs/provenance.md`, and `docs/github-workflows.md` still describe the
+  current release process accurately
+- release-facing documentation claims are backed by code, CI, or focused manual
+  validation rather than assumption
+
+The required documentation review points are:
+
+1. while preparing the release branch
+2. again after the release PR checks turn green
+3. immediately before merge if the release diff changed after the second review
+
 ## 1. Start from a clean `main` worktree
 
 Use a dedicated release worktree or an otherwise clean checkout rooted at
@@ -157,6 +184,23 @@ Before opening the release PR, sweep the roadmap and nearby planning docs:
 - keep any partially implemented work on the roadmap
 - update user or design docs when shipped features would otherwise still appear
   as future work
+
+Perform the release documentation review on the exact branch diff:
+
+```sh
+git diff --stat main...HEAD -- CHANGELOG.md README.md ROADMAP.md docs
+git diff main...HEAD -- CHANGELOG.md README.md ROADMAP.md docs
+```
+
+At minimum, review:
+
+- the changelog entry for the release version and date
+- `README.md`, `docs/getting-started.md`, and changed quickstarts or setup docs
+- `ROADMAP.md` plus any changed planning or system-design docs
+- changed rollout, auth-maturity, provenance, workflow, or release-runbook docs
+- any doc statement about supported hosts, CI coverage, session surfaces, auth
+  maturity, or release posture that could overstate what the current code and
+  validation actually prove
 
 Before opening the release PR, verify release inputs that commonly drift:
 
@@ -228,6 +272,9 @@ If CI fails:
 
 When required checks turn green, perform the second PR comment sweep.
 
+Then repeat the documentation review on the exact release PR diff before
+deciding the branch is ready to merge.
+
 Do not merge while required checks are failing or while comment sweeps are
 incomplete.
 
@@ -239,6 +286,8 @@ following are true:
 - required checks are green
 - the PR comment sweep has been completed after CI turned green
 - the final pre-merge comment sweep has been completed
+- the release documentation review has been completed after CI turned green
+- release-facing docs accurately describe the exact merge diff
 - changelog and release notes are correct
 
 After merge, record the resulting `main` commit SHA. This is the commit that

--- a/docs/use-case-matrix.md
+++ b/docs/use-case-matrix.md
@@ -14,13 +14,13 @@ Workcell workflows.
 | Use case | Status | Primary evidence |
 |---|---|---|
 | secretless provider launch on the managed path | tested | `scripts/container-smoke.sh`, `scripts/verify-invariants.sh` |
-| provider auth injected through the reviewed policy model | tested | container smoke, auth-status tests, provider-specific helpers |
+| provider auth injected through the reviewed policy model | tested for direct staged inputs; built-in resolver coverage remains limited | container smoke, auth-status tests, provider-specific helpers |
 | host-side policy inspection and credential explainability | tested | `tests/scenarios/shared/test-policy-commands.sh`, `internal/authpolicy/manage_test.go` |
 | host-side signed `publish-pr` handoff | tested | shared scenario tests and invariant checks |
 | repo control-plane masking and provider-home re-seeding | tested | invariants and smoke |
 | repo-mounted validator and release-helper runs stay nonroot with explicit caller identity and isolated writable state | tested | CI, release preflight, `scripts/pre-merge.sh`, and invariant checks |
 | prompt-autonomy downgrade labeling | tested for Codex, partial elsewhere | invariants plus provider-specific coverage |
-| host-side session inventory, clean-base diff, and audit export | tested | `tests/scenarios/shared/test-session-commands.sh`, `internal/hostutil/sessions_test.go` |
+| host-side session inventory, detached session control, log and timeline views, clean-base diff, and audit export | tested | `tests/scenarios/shared/test-session-commands.sh`, `internal/hostutil/sessions_test.go`, `cmd/workcell-hostutil/main_test.go` |
 | bundle installer plus uninstall helper on the supported GitHub-hosted macOS matrix | tested | `scripts/verify-invariants.sh`, CI, tagged release install verification |
 | Homebrew formula install plus uninstall on the supported GitHub-hosted macOS matrix | tested | CI and tagged release install verification |
 | release-bundle reproducibility | tested | `scripts/verify-release-bundle.sh`, tagged release preflight |
@@ -35,6 +35,6 @@ Workcell workflows.
 The most heavily tested paths are the secretless runtime boundary, explicit
 nonroot repo validation and release preflight, reproducibility, and signed
 publication. The most mature host-side operator surfaces are auth/policy
-inspection plus session inventory and export. The biggest remaining gaps are
-local macOS boundary proof, deeper end-to-end live-provider coverage, and
-fuller lower-assurance transition coverage.
+inspection plus session inventory, detached control, timeline, and export. The
+biggest remaining gaps are local macOS boundary proof, deeper end-to-end
+live-provider coverage, and fuller lower-assurance transition coverage.

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -24,8 +24,8 @@ These run without provider credentials:
 
 They cover repo shape, runtime contracts, smoke behavior, and reproducibility.
 They also now cover canonical requirement traceability, host-side policy
-inspection and explainability, and host-side session inventory plus clean-base
-diff/export behavior.
+inspection and explainability, and host-side detached session inventory,
+control, logs/timeline, and clean-base diff/export behavior.
 
 ## Manual authenticated smoke
 

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -10,6 +10,25 @@ Use this page with:
   machine-checked requirement-to-evidence mapping
 - [docs/scenario-gaps.md](scenario-gaps.md) for what is still missing
 
+## Traceability anchors
+
+[`tests/scenarios/manifest.json`](../tests/scenarios/manifest.json) is the
+canonical scenario index.
+
+Use these anchors when checking release-facing claims:
+
+- auth and resolver posture:
+  `shared/auth-commands`, `shared/auth-status`,
+  `shared/claude-resolver-launcher`
+- lower-assurance mode claims: `shared/assurance-dry-run`
+- host publication handoff: `shared/publish-pr`
+- host-side session inventory and control: `shared/session-commands`
+- Claude hook coverage: `claude-swe/hook-parametric`
+- supported GitHub-hosted macOS release window:
+  `scripts/verify-github-macos-release-test-runners.sh`
+- Gemini Vertex supplemental `gcloud_adc` and allowlist behavior:
+  `scripts/verify-invariants.sh`
+
 ## Local secretless checks
 
 These run without provider credentials:

--- a/docs/workcell-session-supervisor-design.md
+++ b/docs/workcell-session-supervisor-design.md
@@ -2,53 +2,49 @@
 
 ## Goal
 
-Workcell needs a session-supervisor layer so operators can reason about Workcell
+Workcell needs a session-supervisor layer so operators can reason about
 launches as durable session objects rather than as one-off foreground shell
 commands.
 
-This document defines the first implementation phase that is now practical in
-this repository without weakening the existing boundary model.
+This document describes the current shipped session-supervisor slice in the
+repository and the gaps that remain without weakening the existing boundary
+model.
 
-## Phase 1 Scope
+## Current Scope
 
-Phase 1 adds durable host-side session records plus host-side inventory and
-inspection commands:
+The current implementation provides durable host-side session records plus
+host-side inventory, observability, and detached-control commands:
 
 - `workcell session list`
 - `workcell session show --id ...`
+- `workcell session logs --id ... --kind ...`
+- `workcell session timeline --id ...`
 - `workcell session diff --id ...`
 - `workcell session export --id ...`
+- `workcell session start`
+- `workcell session attach`
+- `workcell session send`
+- `workcell session stop`
 
 Each launched session writes durable metadata under the managed Colima profile
 state instead of relying only on the transient `session-audit.*` directory.
 
+Detached sessions default to `--session-workspace isolated`, so the detached
+path already points toward worktree-per-session operation on the safe path.
+
 ## Data Model
 
-Each session record stores:
+Each session record stores the durable host-side view of one launch, including:
 
-- `session_id`
-- `profile`
-- `agent`
-- `mode`
-- `status`
-- `ui`
-- `execution_path`
-- `workspace`
-- `git_branch`
-- `git_head`
-- `git_base`
-- `container_name`
-- `session_audit_dir`
-- `audit_log_path`
-- `debug_log_path`
-- `file_trace_log_path`
-- `transcript_log_path`
-- `started_at`
-- `finished_at`
-- `exit_status`
-- `initial_assurance`
-- `final_assurance`
-- `workspace_control_plane`
+- session identity and profile metadata
+- agent, mode, and UI
+- workspace root, workspace origin, and worktree path
+- git branch, head, and clean launch base when available
+- runtime container name, monitor PID, and live status
+- retained audit, debug, file-trace, and transcript paths
+- start, observe, and finish timestamps
+- initial, current, and final assurance state
+- workspace control-plane mode
 
 The durable record lives under:
 
@@ -72,15 +68,17 @@ confusing retention with ephemeral runtime scratch state.
 
 ## Audit Relationship
 
-Phase 1 also adds `session_id` to launch, assurance-change, and exit audit
-records in the profile audit log.
+The current implementation adds `session_id` to launch, control, assurance, and
+exit audit records in the profile audit log.
 
-That allows `workcell session export` to bundle:
+That allows:
 
-- the durable session record
-- matching audit log lines for that session
+- the durable session record to stay machine-readable
+- `workcell session export` to bundle matching audit records
+- `workcell session timeline` to print the session-specific audit trail
+- `workcell session logs` to resolve one retained log for a recorded session
 
-This is a clean bridge between human-readable audit history and machine-readable
+This is the bridge between human-readable audit history and machine-readable
 session metadata.
 
 ## User Experience
@@ -88,15 +86,20 @@ session metadata.
 `workcell session list` is optimized for a quick host-side inventory:
 
 - session id
-- status
-- agent
-- mode
+- status and live status
+- agent and mode
 - profile
 - start time
 - assurance
 - workspace
 
 `workcell session show` returns the full durable record for one session.
+
+`workcell session logs` prints one retained audit, debug, file-trace, or
+transcript log for a recorded session.
+
+`workcell session timeline` prints the audit-log records that match one
+session.
 
 `workcell session diff` renders the current workspace status and diff against
 the clean git base recorded when the session started. It fails closed if the
@@ -106,36 +109,34 @@ workspace is no longer a self-contained git worktree on the host.
 `workcell session export` returns the full record plus matching audit records,
 either to stdout or a user-selected host file.
 
-## Explicit Non-Goals For Phase 1
+Detached sessions can be started, attached to, steered, and stopped from the
+host without introducing a separate always-on daemon or same-user local socket
+trust.
 
-Phase 1 does not attempt to implement:
+## Current Non-Goals
 
-- background execution
+The current slice does not yet attempt to implement:
+
+- a session queue or warm-pool system
 - pause or resume
-- follow-up prompts
-- interactive takeover
-- per-task worktree creation
-- a long-running daemon
+- checkpoints or forks
+- centralized multi-host inventory or analytics
+- preserved-boundary GUI or IDE clients
 - remote worker fleets
 
-Those remain later phases.
+## Remaining Work
 
-## Future Phases
+The remaining near-term work is to:
 
-Phase 2 should add:
+- harden and normalize worktree-per-session defaults
+- expose branch/worktree and assurance state more clearly in operator-facing
+  status views
+- deepen validation coverage for detached-session transitions and
+  lower-assurance paths
+- add richer artifact browsing without weakening the host-owned model
 
-- `workcell session start` as a durable session creator
-- per-session worktree or branch isolation
-- attach and takeover
-- follow-up prompts to a running session
-- artifact browsing beyond raw audit export
-
-Phase 3 should add:
-
-- pause and resume
-- optional warm pools
-- GUI and IDE clients against the same host-controlled session plane
-- enterprise inventory and policy surfaces
+Longer-term product-direction items such as pause/resume, checkpoints, GUI
+clients, and enterprise inventory belong in [ROADMAP.md](../ROADMAP.md).
 
 ## Peer Review
 
@@ -149,15 +150,17 @@ Phase 3 should add:
    Reason: profile audit logs are cumulative and otherwise cannot be filtered
    safely to one launch.
 
-3. Phase 1 should stay host-side and file-based.
+3. The session plane should stay host-side and file-based first.
    Reason: introducing a daemon, sockets, or background workers before the data
    model stabilizes would add complexity faster than it adds operator value.
 
-### Residual Risks
+## Residual Risks
 
 - There is no retention policy yet for durable session records.
 - Aborted launches rely on host cleanup logic to mark the record as aborted.
-- The current phase gives inventory and inspection, not orchestration.
+- Detached-session control exists, but there is still no queue, pause/resume,
+  or centralized session administration plane.
 
-Those are acceptable for a first slice because the main goal here is to create
-durable, auditable session objects without weakening the reviewed boundary.
+Those are acceptable for the current slice because the main goal here is to
+create durable, auditable session objects and bounded detached-session control
+without weakening the reviewed boundary.

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -1,122 +1,117 @@
-# Workcell System Design and Feature Review
+# Workcell System Design
 
 ## Purpose
 
-This document explains how Workcell works today based on the repository's
-runtime code, policy code, adapters, and verification material. It also
-compares the current design to modern coding-agent systems and identifies the
-single next feature that should be added to Workcell first.
+This document describes the current Workcell architecture as implemented in the
+repository today. Roadmap direction and future product strategy live in
+[`ROADMAP.md`](../ROADMAP.md) and
+[`docs/implement-first-delivery-plan.md`](implement-first-delivery-plan.md)
+rather than in this design doc.
 
 ## Executive Summary
 
-Workcell is a host-launched, policy-driven runtime for coding agents. Its core
-design is:
+Workcell is a host-launched, policy-driven runtime for coding agents. Its
+current architecture is:
 
-1. A trusted host control plane prepares and validates the session.
-2. A dedicated Colima VM provides the primary machine boundary on macOS.
-3. A hardened container inside that VM provides the agent execution runtime.
-4. Thin provider adapters seed provider-native homes and configuration without
-   pretending the providers are interchangeable.
-5. Multiple policy layers prevent the workspace from silently taking over the
-   control plane.
-6. Verification and provenance tooling try to make the boundary auditable and
-   reproducible.
+1. a trusted host control plane in [`scripts/workcell`](../scripts/workcell)
+   prepares and validates each session
+2. a dedicated Colima VM provides the primary machine boundary on supported
+   Apple Silicon macOS hosts
+3. a hardened container inside that VM provides the agent execution runtime
+4. thin provider adapters seed provider-native homes and configuration without
+   pretending provider config is the security boundary
+5. host-side policy rendering, control-plane masking, and explicit injection
+   determine what material enters the runtime
+6. host-side durable session records, audit logs, and detached session control
+   make the runtime inspectable without introducing a daemonized control plane
 
-The most important architectural fact is that Workcell does not treat prompt
-files, provider settings, or repo rules as the security boundary. The real
-boundary is the host-controlled VM plus container path, reinforced by control
-plane masking, provider wrappers, syscall-level exec interception, egress
-controls, and explicit credential injection.
-
-The biggest missing product capability is not stronger isolation. Workcell is
-already strong there. The biggest missing capability is a first-class session
-supervisor that can run, track, resume, and compare multiple isolated agent
-sessions in parallel.
+The main architectural point is unchanged across providers: Workcell does not
+trust prompt files, provider settings, or repo-local control-plane files as the
+primary boundary. The supported boundary is the host-controlled VM plus
+container path, reinforced by explicit injection, managed provider homes,
+control-plane masking, provider wrappers, and release-time provenance.
 
 ## Design Goals
 
-The repository's own priorities are clear:
+The repository working agreement prioritizes:
 
-1. Developer experience
-2. Simplicity
-3. Security invariants
-4. Performance
-5. Idiomatic correctness
+1. developer experience
+2. simplicity
+3. security invariants
+4. performance
+5. idiomatic correctness
 
-Within that frame, Workcell optimizes for these system properties:
+Within that order, the system is designed to:
 
-- Keep the trusted control plane on the host.
-- Preserve a dedicated VM plus container boundary for supported adapters.
-- Make lower-assurance paths explicit instead of silently widening trust.
-- Keep provider-specific behavior visible rather than hiding it behind a fake
-  abstraction layer.
-- Prefer auditable configuration and invariant checks over implicit behavior.
+- keep the trusted control plane on the host
+- preserve a dedicated VM plus container boundary for supported adapters
+- make lower-assurance paths explicit instead of silently widening trust
+- keep provider-specific behavior visible instead of hiding it behind a fake
+  universal abstraction
+- prefer auditable configuration and invariant checks over hidden magic
 
 ## Non-Goals
 
 Workcell is not trying to be:
 
-- A generic shared-kernel container sandbox.
-- A provider-agnostic agent framework that erases real CLI differences.
-- A repo-local prompt/config convention presented as a security system.
-- A host-side PR publishing tool that pushes from inside the bounded session.
+- a generic shared-kernel container sandbox
+- a provider-agnostic agent framework that erases real CLI differences
+- a repo-local prompt/config convention presented as a security system
+- a remote worker or cloud-agent platform today
+- a centralized enterprise policy or analytics plane today
 
 ## System Overview
 
 ### 1. Host Control Plane
 
-The main control plane is [`scripts/workcell`](../scripts/workcell). It is a
-host-side launcher, validator, policy renderer, and audit collector.
+The main orchestrator is [`scripts/workcell`](../scripts/workcell). The host
+control plane is responsible for:
 
-Its core responsibilities are:
+- scrubbing the host environment before launch
+- resolving trusted host binaries and helper scripts
+- computing and validating the Colima profile for the workspace
+- validating runtime assumptions such as `vz`, mount shape, and the bounded
+  Docker path
+- loading auth policy and injection policy
+- resolving host-side credential sources before launch
+- rendering the staged injection bundle and metadata
+- shadowing repo-local control-plane paths on the safe path
+- applying the VM egress allowlist
+- preparing the runtime image when required
+- launching the runtime container with controlled mounts, tmpfs state, and
+  managed environment variables
+- recording audit metadata, assurance state, and detached session records
 
-- Scrub the host environment before session launch.
-- Resolve trusted host binaries and helper scripts.
-- Compute a deterministic Colima profile per workspace.
-- Validate the Colima runtime assumptions:
-  - `vz` VM type
-  - `virtiofs` mount type
-  - Docker runtime
-  - exactly one writable workspace mount
-  - no SSH agent forwarding
-- Resolve injection policy and credential sources.
-- Render a staged injection bundle on the host.
-- Shadow repo-local control-plane paths on the safe path.
-- Apply the VM egress allowlist.
-- Build or prepare the runtime image.
-- Launch the container with controlled mounts, tmpfs mounts, and managed env.
-- Record session metadata, assurance metadata, and optional debug logs.
+Operationally, `scripts/workcell` is the real control plane. Trust-sensitive
+decisions are made before the provider CLI starts.
 
-Operationally, `scripts/workcell` is the system's real orchestrator today.
-Almost every trust-sensitive decision is made before the provider CLI starts.
+### 2. Host-Side Structured Helpers
 
-### 2. Host Policy Helpers
+The shell launcher delegates structured policy and metadata work to small Go
+packages under [`internal/`](../internal):
 
-The host launcher delegates structured policy work to small Go packages in
-`internal/` and `cmd/`.
+- [`internal/authpolicy`](../internal/authpolicy): host-side auth-policy state
+  and `workcell auth ...`
+- [`internal/authresolve`](../internal/authresolve): host-side credential source
+  resolution and preprocessing
+- [`internal/injection`](../internal/injection): staged injection bundle
+  rendering and validation
+- [`internal/hostutil`](../internal/hostutil): session records, timeline/export
+  helpers, and host utility subcommands
+- [`internal/metadatautil`](../internal/metadatautil): metadata and validation
+  helpers used by repo checks and release posture
+- [`internal/runtimeutil`](../internal/runtimeutil): runtime-related utility
+  helpers
 
-Important components include:
+This split keeps orchestration visible in shell while moving structured data
+validation and rendering into typed code.
 
-- `internal/authpolicy`
-  - manages local auth-policy state via `workcell auth`.
-- `internal/authresolve`
-  - resolves credential sources before launch.
-- `internal/injection`
-  - renders the staged injection bundle and manifest.
-- `internal/assurance`
-  - models session assurance metadata.
-- `internal/endpointpolicy`
-  - tracks extra endpoint handling.
+### 3. Runtime Boundary and Profiles
 
-This split is healthy. The shell launcher owns orchestration, while the Go code
-owns structured data validation and rendering.
+The supported safe path is two-tier:
 
-### 3. Runtime Boundary
-
-The runtime boundary is two-tier on the safe path:
-
-1. A dedicated Colima VM on the host.
-2. A hardened agent container inside that VM.
+1. a dedicated Colima VM on the host
+2. a hardened agent container inside that VM
 
 The container launch path applies controls such as:
 
@@ -125,27 +120,26 @@ The container launch path applies controls such as:
 - `--cap-drop ALL`
 - `--pids-limit 1024`
 - tmpfs mounts for `/tmp`, `/run`, and `/state`
-- a tightly constrained environment
-- a single writable workspace mount
+- a tightly managed environment
+- a selected workspace mount at `/workspace`
 
-Modes in `runtime/profiles/*.env` tune network posture and resources:
+Runtime profiles in [`runtime/profiles/`](../runtime/profiles) separate
+posture and expectations:
 
-- `strict`
-  - deny-by-default style safe path with allowlisted egress.
-- `development`
-  - broader developer convenience, still managed.
-- `build`
-  - broader build-oriented access.
-- `breakglass`
-  - explicit higher-trust mode with widened behavior.
+- `strict`: default managed provider lane
+- `development`: managed interactive lane with broader command flexibility
+- `build`: broader preparation and dependency-refresh lane
+- `breakglass`: explicit higher-trust lane requiring acknowledgement
+
+The system relies on profile-specific guarantees, not on provider prompt text
+that describes those guarantees after the fact.
 
 ### 4. Workspace and Control-Plane Isolation
 
-One of Workcell's strongest and most unusual controls is workspace
-control-plane masking.
+On the safe path, Workcell prevents mutable workspace content from silently
+becoming the live provider control plane.
 
-On the safe path, `scripts/workcell` prevents mutable workspace content from
-becoming the active provider control plane. It masks or shadows paths such as:
+Repo-local control-plane paths such as:
 
 - `AGENTS.md`
 - `CLAUDE.md`
@@ -154,616 +148,240 @@ becoming the active provider control plane. It masks or shadows paths such as:
 - `.codex/`
 - `.claude/`
 - `.gemini/`
-- editor control directories
-- mutable git hook/config paths
+- mutable git hook and config paths
 
-For tracked files, the masking path materializes content from the git index
-rather than the live working tree. That matters because it narrows the gap
-between "what the developer reviewed" and "what the runtime consumes."
+are masked or shadowed by Workcell and then imported into the managed provider
+home as reviewed inputs.
 
-The workspace can still provide reviewed instructions, but only through an
-import path controlled by Workcell rather than by direct trust of live repo
-state.
+For tracked files, the shadow path can materialize content from the git index
+instead of live mutable workspace state. That narrows the gap between what the
+operator reviewed and what the runtime consumes.
 
 ### 5. Injection and Credential Flow
 
-Workcell's injection model is the supported path for credentials, SSH material,
-and reviewed documentation fragments.
+Workcell's supported path for credentials, shared GitHub state, SSH material,
+and reviewed documentation fragments is explicit injection policy.
 
 The flow is:
 
-1. The host loads the injection policy.
-2. Credential sources are resolved on the host.
-3. A staged injection bundle is rendered with a manifest.
-4. Files are mounted into controlled paths in the container.
-5. Session home seeding copies or links only approved targets.
+1. load the injection policy on the host
+2. resolve host-side credential sources and selector scope
+3. render a staged injection bundle and manifest
+4. mount the staged bundle into controlled runtime paths
+5. reseed the managed provider home from approved sources
 
-Important properties:
+Important properties of the current implementation:
 
-- Secrets are staged and classified explicitly.
-- Supported target paths are tightly enumerated.
-- Reserved home paths cannot be overwritten arbitrarily.
-- SSH material is validated and constrained.
-- Resolver-backed credentials are a host preprocessing step, not a live
-  pass-through to host agents or host keychains.
-- Resolver coverage is intentionally narrow today. In practice, direct staged
-  injection is the main path, with only limited host-side resolver support.
+- secrets are staged and classified explicitly
+- supported target paths are tightly enumerated
+- reserved provider-home paths cannot be overwritten arbitrarily
+- shared GitHub and SSH inputs are opt-in and policy-scoped
+- resolver-backed credentials are a host preprocessing step, not live host
+  socket or keychain passthrough
+- direct staged credentials are the primary supported auth path today
+- built-in resolver coverage is intentionally narrow; for example,
+  `claude-macos-keychain` remains a fail-closed scaffold rather than a launch
+  path
 
-This is consistent with the repository's stated security model: credentials may
-be made usable to the runtime, but host credential systems are not the runtime
-boundary and must not be mounted through casually.
-
-### 6. Container Entry and Provider Launch
+### 6. Container Entry and Provider Launch Chain
 
 Inside the container, the launch chain is deliberately layered:
 
-1. `runtime/container/entrypoint.sh`
-2. `runtime/container/runtime-user.sh`
-3. `runtime/container/home-control-plane.sh`
-4. `runtime/container/provider-wrapper.sh`
+1. [`runtime/container/entrypoint.sh`](../runtime/container/entrypoint.sh)
+2. [`runtime/container/runtime-user.sh`](../runtime/container/runtime-user.sh)
+3. [`runtime/container/home-control-plane.sh`](../runtime/container/home-control-plane.sh)
+4. [`runtime/container/provider-wrapper.sh`](../runtime/container/provider-wrapper.sh)
 5. provider binary
 
-This separation matters.
+This chain exists to keep the provider home, runtime state, and policy checks
+under Workcell control.
 
-`entrypoint.sh` is PID 1. It validates the managed environment, handles user
-mapping for mutable sessions, seeds provider home, validates launch targets, and
-routes non-provider commands through the development wrapper when that lower
-assurance path is allowed.
+`entrypoint.sh` validates the managed environment, maps the runtime user for
+mutable sessions, seeds runtime state, and routes lower-assurance development
+commands only through the managed wrapper path.
 
-`provider-wrapper.sh` then:
+`home-control-plane.sh` rebuilds the effective provider home under
+`/state/agent-home`, verifies control-plane artifacts, layers baseline and
+imported docs, and seeds auth, MCP, rules, and SSH material.
 
-- sanitizes environment variables
-- reloads runtime state
-- reseeds the home if needed
-- forces managed autonomy flags
-- rejects dangerous provider-native overrides before execution
+`provider-wrapper.sh` and
+[`runtime/container/provider-policy.sh`](../runtime/container/provider-policy.sh)
+then sanitize the environment and reject trust-widening provider flags or
+config overrides before launching the provider.
 
-`provider-policy.sh` adds another gate by rejecting trust-widening provider
-flags such as:
+### 7. Runtime Mutability and Assurance
 
-- alternative config/profile overrides
-- local autonomy overrides
-- unsafe plugin or MCP config overrides
-- additional directory or remote overrides
+Workcell distinguishes between the default managed path and explicit
+lower-assurance behavior.
 
-Only the top-level `breakglass` path can enable true breakglass behavior.
-Nested invocations cannot silently upgrade themselves.
+Examples already implemented in the runtime:
 
-### 7. Session Home as a Managed Control Plane
+- `development` is a managed lane, but not equivalent to `strict`
+- mutable package installation is mediated and recorded as a downgrade
+- prompt autonomy, transcript capture, and other widened paths are explicit
+- `breakglass` is separate and acknowledged rather than silently inherited
 
-`runtime/container/home-control-plane.sh` is the system's in-container control
-plane builder.
+Assurance is therefore a runtime property that Workcell records and surfaces,
+not a marketing label applied equally to every mode.
 
-It:
+### 8. Exec Guard and Wrapper Defense in Depth
 
-- verifies control-plane artifact hashes
-- rebuilds the effective provider home under `/state/agent-home`
-- layers baseline docs, imported workspace docs, and injected docs
-- renders provider-specific config files
-- seeds auth material, MCP config, rules, and SSH material
-- optionally captures file-trace metadata
+The deepest technical enforcement layer is the Rust exec guard under
+[`runtime/container/rust/`](../runtime/container/rust), loaded with
+`LD_PRELOAD`.
 
-The layered documentation model is especially important:
+Its role is to prevent bypasses beneath shell wrappers, including:
 
-1. adapter baseline doc
-2. imported workspace `AGENTS.md`
-3. imported provider doc such as `CLAUDE.md` or `GEMINI.md`
-4. injected common doc
-5. injected provider-specific doc
-
-This allows Workcell to preserve provider-native instruction formats without
-allowing the workspace to become the sole trust root.
-
-### 8. Runtime Mutability and Assurance Downgrades
-
-Workcell distinguishes between the safe immutable path and explicit lower
-assurance behavior.
-
-Examples:
-
-- Mutable sessions map the container user to the host UID/GID.
-- Package mutation is mediated by `apt-wrapper.sh` and `apt-helper.sh`.
-- APT mutations are allowed only in mutable sessions and downgrade assurance to
-  `lower-assurance-package-mutation`.
-- The downgrade is persisted and auditable.
-
-This is a pragmatic design choice. Workcell does not pretend that package
-installation inside a mutable developer session has the same assurance profile
-as a stricter replayable path.
-
-### 9. Exec Guard and Wrapper Defense in Depth
-
-The deepest technical control in the repository is the Rust exec guard in
-`runtime/container/rust/src/lib.rs`, built as `libworkcell_exec_guard.so` and
-loaded with `LD_PRELOAD`.
-
-It intercepts multiple execution paths including:
-
-- `execve`
-- `execv`
-- `execvp`
-- `execvpe`
-- `execveat`
-- `fexecve`
-- `posix_spawn`
-- `posix_spawnp`
-- raw Linux syscall paths for `execve` and `execveat`
-
-Its policy role is to stop bypasses beneath the shell-wrapper layer, including:
-
-- direct execution of protected runtimes outside approved wrappers
-- shebang scripts from mutable paths that target protected runtimes
-- native ELF execution from mutable paths in strict mode
+- direct protected-runtime execution outside approved wrappers
+- shebang execution from mutable paths targeting protected runtimes
+- native execution paths that bypass policy on the strict path
 - git hook and config bypass patterns
 
-Workcell reinforces this with command wrappers:
+Workcell reinforces this with command wrappers such as:
 
-- `runtime/container/bin/git`
-  - blocks dangerous git env/config and hook bypasses.
-- `runtime/container/bin/node`
-  - strips risky Node execution flags and blocks direct protected-runtime
-    execution paths.
-- `runtime/container/public-node-guard.mjs`
-  - prevents execution of copied protected provider packages through Node.
+- [`runtime/container/bin/git`](../runtime/container/bin/git)
+- [`runtime/container/bin/node`](../runtime/container/bin/node)
+- [`runtime/container/public-node-guard.mjs`](../runtime/container/public-node-guard.mjs)
 
-This layered model is stronger than depending on shell aliases, repo policy
-files, or CLI settings alone.
+The result is defense in depth below prompt files, shell aliases, and
+provider-native settings.
 
-### 10. Provider Adapters
+### 9. Thin Provider Adapters
 
-The adapters are intentionally thin and provider-specific.
+Provider integration remains intentionally thin and explicit:
 
-#### Codex
+- Codex: managed config, requirements, rules, and MCP material under the
+  Workcell boundary
+- Claude Code: reviewed settings, baseline instructions, auth mirrors, MCP
+  config, and shell-hook policy support
+- Gemini CLI: managed settings, trust-state seeding, and explicit auth material
+  such as `.env`, OAuth, project, and optional Vertex supplement files
 
-The Codex adapter seeds managed config and rules, disables provider-native web
-search by default, pins provider-native sandboxing off in favor of the outer
-Workcell boundary, and injects managed requirements and MCP config.
+Workcell keeps one shared boundary and many thin adapters. It does not hide the
+real provider differences behind a fake universal control plane.
 
-#### Claude Code
+### 10. Host-Side Detached Session Plane
 
-The Claude adapter seeds reviewed settings, baseline instructions, auth mirrors,
-MCP config, and a `PreToolUse` hook that blocks trust-widening shell patterns.
+Workcell now includes a host-owned detached session plane. The current CLI
+surface includes:
 
-#### Gemini CLI
+- `workcell session start`
+- `workcell session attach`
+- `workcell session send`
+- `workcell session stop`
+- `workcell session list`
+- `workcell session show`
+- `workcell session logs`
+- `workcell session timeline`
+- `workcell session diff`
+- `workcell session export`
 
-The Gemini adapter seeds reviewed settings, disables IDE-style trust defaults in
-the managed path, enforces tool sandbox expectations, validates auth-related
-files, and manages trust state for `/workspace`.
+Detached session records are written under the Colima profile state tree as
+`~/.colima/<profile>/sessions/<session-id>.json`. The current session record
+schema in [`internal/hostutil/sessions.go`](../internal/hostutil/sessions.go)
+includes:
 
-The important architectural point is that Workcell keeps one shared boundary and
-many thin adapters, which is consistent with the repository's own guidance.
+- session identity, profile, agent, mode, and UI
+- workspace path, workspace origin, workspace root, and worktree path
+- git branch, head, and clean-base metadata
+- container name, monitor pid, status, and live status
+- audit, debug, file-trace, and transcript log pointers
+- start, observe, and finish timestamps
+- initial, current, and final assurance
+- workspace control-plane state
 
-### 11. Verification and Release
+Detached sessions default to `--session-workspace isolated`, which clones a
+clean per-session git worktree on the host for supported source workspaces.
 
-The repo includes a serious verification and provenance story.
+The current session plane is intentionally file-backed and host-owned. It does
+not require a separate daemon, local socket trust, or centralized service.
 
-Key pieces:
+### 11. Verification and Release Posture
 
-- `verify/invariants/`
-  - invariant-oriented checks and expected controls.
-- `docs/invariants.md`
-  - design-level invariant contract.
-- `docs/threat-model.md`
-  - threat assumptions and abuse paths.
-- `docs/provenance.md`
-  - release and attestation model.
-- `docs/validation-scenarios.md`
-  - scenario coverage and known limits.
+The repository pairs runtime controls with verification and provenance
+material:
 
-Release publication is intentionally host-side. `workcell publish-pr` stages,
-signs, pushes, and opens the PR from outside the Tier 1 session. That preserves
-the design claim that GitHub publication is a host action, not an in-container
-trust escalation.
+- [`verify/invariants/`](../verify/invariants) and
+  [`docs/invariants.md`](invariants.md) define the safe-path contract
+- [`docs/threat-model.md`](threat-model.md) documents trust boundaries and
+  abuse paths
+- [`docs/validation-scenarios.md`](validation-scenarios.md) tracks scenario
+  coverage and remaining gaps
+- [`docs/provenance.md`](provenance.md) and [`docs/releasing.md`](releasing.md)
+  describe release-time signing, attestation, and publication expectations
 
-## End-to-End Execution Flow
+Final GitHub publication is intentionally host-side. `workcell publish-pr`
+keeps branch push, commit signing, and PR creation outside the bounded Tier 1
+runtime.
+
+## End-to-End Flow
 
 ### Safe Launch Flow
 
 The normal strict-path launch is:
 
-1. Operator runs `workcell --agent <provider> --workspace <repo>`.
-2. Host launcher scrubs env and validates workspace eligibility.
-3. Host launcher validates or creates the Colima profile.
-4. Host launcher validates runtime assumptions and mount shape.
-5. Injection policy is resolved and rendered into a staged bundle.
-6. Workspace control-plane files are shadowed and imported.
-7. VM-level egress allowlist is applied.
-8. Runtime image is prepared if required.
-9. Container starts with hardened flags and managed env.
-10. Container PID 1 seeds runtime state and effective provider home.
-11. Provider wrapper enforces managed autonomy and provider policy.
-12. Agent starts in the bounded runtime.
+1. the operator runs `workcell --agent <provider> --workspace <repo>`
+2. the host launcher scrubs the environment and validates workspace and profile
+   assumptions
+3. auth and injection policy are resolved on the host
+4. repo-local control-plane files are shadowed or imported through Workcell
+5. the runtime image and VM egress posture are prepared
+6. the container starts with hardened flags and managed environment variables
+7. the managed provider home is rebuilt under `/state/agent-home`
+8. the provider wrapper validates flags and starts the provider inside the
+   bounded runtime
 
-### Development Flow
+### Detached Session Flow
 
-`development` mode is still managed, but it allows non-provider commands through
-`development-wrapper.sh`. This is a deliberate convenience path, not the same
-assurance level as strict provider-only execution.
+The current detached flow adds host-owned lifecycle state:
 
-### Breakglass Flow
-
-`breakglass` exists, but the system tries hard to make it explicit:
-
-- it must be requested
-- its semantics are separate
-- nested invocations cannot silently self-upgrade into it
-
-This is the correct pattern for enterprise trust boundaries. Higher-trust paths
-exist, but they are not smuggled in as normal behavior.
+1. `workcell session start` allocates a durable session id
+2. detached sessions default to an isolated per-session workspace when the
+   source workspace supports it
+3. the launcher writes a durable session record and audit state on the host
+4. the runtime executes in the same bounded environment as foreground launches
+5. the operator can later inspect, attach, steer, stop, diff, or export the
+   session from the host
 
 ### Publish Flow
 
-The PR publication path intentionally exits the bounded runtime:
-
-1. Work is completed inside Workcell.
-2. Operator runs `workcell publish-pr` on the host.
-3. The host creates or switches branch, stages changes, commits with signing,
-   pushes, and opens a draft PR.
-
-This keeps the signing identity and final repository publication outside the
-agent session boundary.
-
-## What Workcell Already Does Well
-
-Workcell is stronger than many current agent runtimes in several areas:
-
-- It has a real, explicit runtime boundary instead of relying on prompt files or
-  repo-local config alone.
-- It treats workspace trust and host trust as different problems.
-- It masks repo-local control-plane paths to reduce prompt/config injection from
-  mutable workspace state.
-- It uses syscall-level exec interception rather than trusting shell wrappers
-  alone.
-- It has explicit lower-assurance states instead of silently widening trust.
-- It keeps provider differences explicit with thin adapters.
-- It has a credible audit and provenance story.
-- It now has a first durable host-side session inventory slice for completed or
-  aborted launches.
-
-These are foundational strengths. They should be preserved.
-
-## Current Functional Gaps
-
-Workcell's current gaps are mostly product and workflow gaps, not core boundary
-gaps.
-
-### Gaps in the Current Product Surface
-
-- No first-class multi-agent orchestration.
-- No background session supervisor or queue.
-- No built-in pause, resume, takeover, or follow-up model for live sessions.
-- No first-class worktree-per-task or branch-per-session workflow.
-- No checkpoint, fork, or snapshot model for active sessions.
-- GUI mode is intentionally not implemented yet as a preserved-boundary path.
-- No preserved-boundary GUI or IDE session surface.
-- No org-level policy administration plane or session analytics plane.
-- Limited host credential resolver coverage.
-- No reusable team workflow layer at the Workcell level comparable to agent
-  packs, commands, or enterprise agent profiles.
-
-## Comparison With Modern Coding-Agent Systems
-
-### Trail of Bits `claude-code-config`
-
-Reference: [GitHub repository](https://github.com/trailofbits/claude-code-config)
-
-What it emphasizes:
-
-- reusable slash commands
-- plugin-distributed skills, agents, and commands
-- hook-driven workflow controls
-- a statusline with live session context and cost data
-- optional local-model support through LM Studio
-
-What Workcell has instead:
-
-- stronger runtime isolation
-- stronger separation between workspace trust and control-plane trust
-- stronger enforcement beneath the CLI layer
-
-What Workcell is missing relative to that workflow model:
-
-- a first-class reusable workflow/command library at the Workcell layer
-- an agent-pack or subagent-pack concept that is independent of one provider
-- lightweight UX features such as live status and session ergonomics
-
-### Penligent's Sandbox Architecture
-
-Reference: [Sandboxes for Coding Agents](https://www.penligent.ai/hackinglabs/he/sandboxes-for-coding-agents/)
-
-The article argues that production systems need separate control, execution,
-policy, artifact, verification, and lifecycle planes, and that state management
-is as important as isolation.
-
-Workcell already covers:
-
-- control plane
-- execution plane
-- policy plane
-- verification plane
-- part of the artifact plane
-
-Workcell is weaker on:
-
-- lifecycle plane as a first-class product surface
-- pause/resume/snapshot/fork semantics
-- user-facing artifact browsing and replay workflows
-- warm-pool style responsiveness and session management
-
-### Dagger `container-use`
-
-Reference: [GitHub repository](https://github.com/dagger/container-use)
-
-What it emphasizes:
-
-- multiple agents in parallel
-- a fresh isolated environment per agent
-- per-agent git branch isolation
-- real-time command visibility
-- direct intervention into a live agent terminal
-- MCP-compatible integration across multiple agent products
-
-Workcell is stronger on boundary rigor, but weaker on orchestration:
-
-- Workcell does not yet have per-task isolated session management as a product.
-- Workcell does not yet expose a direct session-takeover workflow.
-- Workcell does not yet make live command history a first-class user interface.
-
-### Cursor Cloud/Background Agents
-
-References:
-
-- [Background agents docs](https://docs.cursor.com/en/background-agents)
-- [Cloud agents announcement](https://cursor.com/blog/cloud-agents)
-- [Cloud agents with computer use](https://cursor.com/blog/agent-computer-use)
-- [Self-hosted cloud agents](https://cursor.com/blog/self-hosted-cloud-agents/)
-- [Cloud agents changelog](https://cursor.com/changelog/02-24-26/)
-
-What Cursor emphasizes:
-
-- many asynchronous agents in parallel
-- isolated remote machines
-- follow-up prompts while the agent is still running
-- takeover into the remote environment
-- multi-surface access from desktop, web, mobile, Slack, and GitHub
-- self-hosted worker fleets for enterprise
-
-Workcell is missing most of this operating model:
-
-- no background session supervisor
-- no background queue
-- no pause/resume/follow-up UX
-- no remote worker or fleet model
-- no handoff between CLI and GUI surfaces
-
-### GitHub Copilot Cloud Agent and Custom Agents
-
-References:
-
-- [Managing cloud agents](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/use-copilot-agents/manage-agents)
-- [Creating custom agents](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/use-copilot-agents/cloud-agent/create-custom-agents)
-- [About agent management](https://docs.github.com/en/copilot/concepts/agents/cloud-agent/agent-management)
-- [Managing Copilot cloud agent in your enterprise](https://docs.github.com/en/copilot/how-tos/administer-copilot/manage-for-enterprise/manage-agents/manage-copilot-cloud-agent)
-
-What GitHub emphasizes:
-
-- cloud sessions that create PRs directly
-- steering input during a running session
-- resume in VS Code or CLI
-- repository, organization, and enterprise-level custom agents
-- centralized enterprise AI controls
-- enterprise session inventory and audit views
-
-Workcell is missing:
-
-- org and enterprise-level agent/profile distribution
-- session list and centralized activity views
-- resume/follow-up workflows
-- a durable admin plane for policy and usage management
-
-### Aider and Similar Terminal-First Agents
-
-Reference: [Aider watch mode](https://aider.chat/docs/usage/watch.html)
-
-Terminal-first agents like Aider emphasize small-loop developer productivity:
-
-- quick iteration from the terminal
-- watch mode and automation hooks
-- low-friction editing workflows
-
-Workcell is currently more rigorous than it is fast-moving. It could benefit
-from more loop-shortening features without giving up the boundary model.
-
-## Finalized Next Feature: Workcell Supervisor
-
-The next feature that should be present in Workcell is a first-class **Workcell
-Supervisor**.
-
-This should be a host-side session orchestration layer that manages multiple
-bounded Workcell sessions as durable objects rather than treating every launch as
-an isolated foreground shell command.
-
-Workcell now has the phase 1 foundation for that direction: durable session
-records and host-side session inventory/export commands. The remaining gap is
-true orchestration rather than inventory alone.
-
-### Why This Is the Right Next Feature
-
-It is the highest-leverage addition because it:
-
-- closes the largest gap with Cursor, Copilot, and Container Use
-- compounds Workcell's existing boundary strengths instead of weakening them
-- improves developer throughput more than another round of low-level hardening
-- creates the foundation for enterprise control-plane features later
-
-### What the Supervisor Should Do
-
-The minimum viable Supervisor should provide:
-
-1. Session objects
-   - each launch becomes a named session with durable metadata
-2. Per-session worktree or branch isolation
-   - default to a new git worktree per task on the safe path
-3. Parallel execution
-   - run multiple sessions concurrently without workspace conflicts
-4. Follow-up prompts
-   - send steering input to a running or paused session
-5. Pause and resume
-   - preserve long-running work without keeping a foreground terminal attached
-6. Takeover
-   - attach directly to a live session shell or provider TTY
-7. Session inventory
-   - list status, branch/worktree, mode, assurance state, runtime age, and logs
-8. Artifact capture
-   - diff, transcript, command log, assurance downgrade events, and outputs
-9. Policy inheritance
-   - all existing Workcell controls still apply to every session
-
-### Recommended CLI Shape
-
-Possible commands:
-
-- `workcell session start`
-- `workcell session list`
-- `workcell session follow`
-- `workcell session send`
-- `workcell session attach`
-- `workcell session pause`
-- `workcell session resume`
-- `workcell session stop`
-- `workcell session diff`
-- `workcell session export`
-
-### Recommended Internal Model
-
-The Supervisor should introduce a stable session record containing:
-
-- session id
-- workspace root
-- worktree path
-- branch name
-- provider and mode
-- assurance state
-- active runtime identifiers
-- timestamps
-- artifact paths
-- operator identity
-
-The host should own this metadata. The runtime should remain disposable.
-
-### Phase 2 Extensions
-
-Once the Supervisor exists, Workcell can add higher-level features safely:
-
-- lightweight TUI or web session dashboard
-- GitHub and Slack entrypoints
-- resumable checkpoints and forks
-- warm pools or prepared base runtimes
-- reusable team profiles, commands, and agent packs
-- central policy distribution and enterprise analytics
-
-## Features Workcell Should Add After the Supervisor
-
-In priority order:
-
-1. Team workflow packs
-   - versioned commands, subagents, instruction bundles, and approved MCP packs
-     at the Workcell layer
-2. Session observability
-   - live status, command timeline, cost/context counters, and artifact browser
-3. Checkpoint and fork support
-   - especially for long-running validation or UI tasks
-4. Enterprise policy plane
-   - centralized policy distribution, session inventory, and usage analytics
-5. Preserved-boundary GUI surfaces
-   - IDE and web entrypoints backed by the same host-controlled supervisor
-6. Broader auth resolver support
-   - enterprise secret managers and brokered credential flows
-
-## Enterprise Productivity Recommendations
-
-If the goal is to improve enterprise developer productivity without trading away
-the core Workcell boundary, the program should be:
-
-### 1. Turn Safe Sessions Into a Queueable Platform
-
-Today, Workcell is primarily a secure launcher. Enterprises need it to become a
-secure session platform. The Supervisor is the bridge from "secure shell entry"
-to "secure developer throughput."
-
-### 2. Default to Isolated Worktrees Per Task
-
-This removes a common source of friction and makes multi-session execution
-practical. It also improves auditability because each task has a clearer branch
-and diff boundary.
-
-### 3. Make Session State Visible
-
-Enterprise teams need to know:
-
-- what is running
-- who started it
-- what it changed
-- what network and credential posture it had
-- whether assurance was downgraded
-
-Workcell already captures much of the raw data needed for this. It needs a user
-surface, not a new security primitive.
-
-### 4. Add Reusable Team-Level Workflow Assets
-
-Popular agent systems have learned that productivity comes from repeatable
-workflows, not only from model quality. Workcell should support:
-
-- review agents
-- refactor agents
-- release agents
-- documentation agents
-- approved MCP bundles
-- approved command packs
-
-These should be distributed as reviewed, auditable Workcell assets rather than
-as ad hoc repo-local prompt files.
-
-### 5. Add Resume and Steering as First-Class Actions
-
-Enterprise developers often want to:
-
-- start work asynchronously
-- redirect the agent mid-task
-- inspect the environment
-- take over locally
-
-Modern systems treat this as normal. Workcell currently treats sessions as
-foreground launches. That is too limiting for large teams.
-
-### 6. Keep the Boundary Model Intact
-
-The main trap to avoid is copying the UX of popular agent systems by weakening
-the security model. Workcell should not give up:
-
-- control-plane masking
-- explicit assurance states
-- host-side publication
-- deny-by-default trust assumptions
-- thin provider adapters with managed policy
-
-The right move is to add orchestration and visibility on top of the current
-boundary, not to replace the boundary with convenience features.
-
-## Bottom Line
-
-Workcell already has the shape of a strong enterprise-safe coding-agent runtime.
-Its main weakness is not architecture drift at the isolation layer. Its weakness
-is that the product surface stops too early.
-
-The system needs to evolve from:
-
-- "securely launch one bounded agent session"
-
-to:
-
-- "securely operate, steer, compare, and audit many bounded agent sessions"
-
-That is the missing capability that best aligns with both modern coding-agent
-workflows and Workcell's existing strengths.
+The supported publication path remains:
+
+1. run the provider inside Workcell
+2. review the resulting changes
+3. publish from the host with `workcell publish-pr`
+
+This keeps commit signing and repository publication outside the in-container
+runtime boundary.
+
+## Current Limits
+
+The current architecture is intentionally narrower than the longer-term
+roadmap:
+
+- Apple Silicon macOS hosts only
+- no Workcell-managed cloud or remote worker plane today
+- no centralized enterprise policy, session administration, or analytics plane
+- no queue, pause/resume, checkpoint, or fork model yet on the session plane
+- GUI and IDE surfaces are lower assurance unless they act only as clients to
+  the same bounded runtime
+- built-in auth resolver coverage remains narrow, with direct staged inputs as
+  the primary supported auth path
+- the strongest macOS boundary claim still depends on local validation rather
+  than GitHub-hosted CI alone
+
+## Light Comparison
+
+Compared with cloud-first or IDE-first agent systems, Workcell currently
+prioritizes:
+
+- explicit local runtime boundaries over remote execution
+- host-owned publication and signing over in-session repository publication
+- reviewed provider-home seeding over trusting repo-local mutable config as the
+  live control plane
+- explicit lower-assurance labeling over flattening all modes into one trust
+  story
+
+Roadmap direction such as broader session orchestration, deployment reach, and
+team-level administration lives in [`ROADMAP.md`](../ROADMAP.md), not in this
+architecture description.

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -183,4 +183,5 @@ docs = [
   "docs/github-workflows.md",
   "docs/provenance.md",
   "docs/validation-scenarios.md",
+  "docs/enterprise-rollout.md",
 ]


### PR DESCRIPTION
## Summary
- align README, roadmap, and rollout docs with the current local-first product shape
- reconcile session-platform docs with the shipped detached session surface
- clarify provider auth maturity and normalize quickstart support-boundary language