### PR TITLE
Enforce traceability for release-facing docs

### DIFF
--- a/docs/requirements-validation.md
+++ b/docs/requirements-validation.md
@@ -27,6 +27,10 @@ This is meant to reduce drift between:
 - requirement ids and titles are unique
 - every requirement cites at least one automated evidence file
 - every evidence and documentation path is repo-relative and exists in the repo
+- every release-facing Markdown example and the current release-evaluation docs
+  (`docs/provider-matrix.md`, `docs/validation-scenarios.md`, and
+  `docs/enterprise-rollout.md` when present) appear in at least one requirement
+  `docs` array
 
 This check runs through the normal validation entrypoints, including
 `./scripts/dev-quick-check.sh` and `./scripts/validate-repo.sh`.
@@ -60,3 +64,7 @@ When a supported requirement changes:
 
 If a requirement cannot point to real automated evidence, it is not ready to be
 claimed as part of the canonical supported contract.
+
+When adding a new Markdown file under `docs/examples/`, update
+`policy/requirements.toml` in the same change so the release-facing example
+docs remain machine-checked.

--- a/internal/metadatautil/requirements.go
+++ b/internal/metadatautil/requirements.go
@@ -28,6 +28,7 @@ func ValidateRequirements(rootDir, requirementsPath string) error {
 
 	seenIDs := map[string]struct{}{}
 	seenTitles := map[string]struct{}{}
+	referencedDocs := map[string]struct{}{}
 	for _, categorySpec := range []struct {
 		category string
 		prefix   string
@@ -59,15 +60,25 @@ func ValidateRequirements(rootDir, requirementsPath string) error {
 			if !ok {
 				return fmt.Errorf("%s requirement %s must be a table", requirementsPath, id)
 			}
-			if err := validateRequirementTable(rootDir, requirementsPath, category, id, table, seenTitles); err != nil {
+			if err := validateRequirementTable(rootDir, requirementsPath, category, id, table, seenTitles, referencedDocs); err != nil {
 				return err
 			}
 		}
 	}
+	requiredDocs, err := requiredReleaseFacingDocs(rootDir)
+	if err != nil {
+		return err
+	}
+	for _, docPath := range requiredDocs {
+		if _, ok := referencedDocs[docPath]; ok {
+			continue
+		}
+		return fmt.Errorf("%s must cite release-facing documentation path %s in at least one requirement docs array", requirementsPath, docPath)
+	}
 	return nil
 }
 
-func validateRequirementTable(rootDir, requirementsPath, category, id string, table map[string]any, seenTitles map[string]struct{}) error {
+func validateRequirementTable(rootDir, requirementsPath, category, id string, table map[string]any, seenTitles map[string]struct{}, referencedDocs map[string]struct{}) error {
 	allowedKeys := map[string]struct{}{
 		"title":    {},
 		"summary":  {},
@@ -126,8 +137,53 @@ func validateRequirementTable(rootDir, requirementsPath, category, id string, ta
 		if err := validateRequirementPath(rootDir, requirementsPath, category, id, "docs", path); err != nil {
 			return err
 		}
+		referencedDocs[path] = struct{}{}
 	}
 	return nil
+}
+
+func requiredReleaseFacingDocs(rootDir string) ([]string, error) {
+	requiredDocs := []string{}
+	staticDocs := []string{
+		"docs/enterprise-rollout.md",
+		"docs/provider-matrix.md",
+		"docs/validation-scenarios.md",
+	}
+	for _, path := range staticDocs {
+		target, err := resolveRequirementPath(rootDir, path)
+		if err != nil {
+			return nil, err
+		}
+		info, err := os.Lstat(target)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		if info.IsDir() {
+			continue
+		}
+		requiredDocs = append(requiredDocs, path)
+	}
+
+	examplesDir := filepath.Join(rootDir, "docs", "examples")
+	entries, err := os.ReadDir(examplesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			sort.Strings(requiredDocs)
+			return requiredDocs, nil
+		}
+		return nil, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".md" {
+			continue
+		}
+		requiredDocs = append(requiredDocs, filepath.ToSlash(filepath.Join("docs", "examples", entry.Name())))
+	}
+	sort.Strings(requiredDocs)
+	return requiredDocs, nil
 }
 
 func validateRequirementPath(rootDir, requirementsPath, category, id, field, path string) error {

--- a/internal/metadatautil/requirements.go
+++ b/internal/metadatautil/requirements.go
@@ -137,7 +137,11 @@ func validateRequirementTable(rootDir, requirementsPath, category, id string, ta
 		if err := validateRequirementPath(rootDir, requirementsPath, category, id, "docs", path); err != nil {
 			return err
 		}
-		referencedDocs[path] = struct{}{}
+		canonicalPath, err := canonicalRequirementRepoPath(rootDir, path)
+		if err != nil {
+			return fmt.Errorf("%s requirement %s docs path %s: %w", requirementsPath, id, path, err)
+		}
+		referencedDocs[canonicalPath] = struct{}{}
 	}
 	return nil
 }
@@ -245,6 +249,19 @@ func resolveRequirementPath(rootDir, path string) (string, error) {
 		return "", fmt.Errorf("path escapes repository root")
 	}
 	return target, nil
+}
+
+func canonicalRequirementRepoPath(rootDir, path string) (string, error) {
+	target, err := resolveRequirementPath(rootDir, path)
+	if err != nil {
+		return "", err
+	}
+	root := filepath.Clean(rootDir)
+	relative, err := filepath.Rel(root, target)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(filepath.Clean(relative)), nil
 }
 
 func isAutomatedEvidencePath(path string) bool {

--- a/internal/metadatautil/requirements_test.go
+++ b/internal/metadatautil/requirements_test.go
@@ -43,6 +43,107 @@ docs = ["docs/guide.md"]
 	}
 }
 
+func TestValidateRequirementsRequiresReleaseFacingDocsToBeMapped(t *testing.T) {
+	root := t.TempDir()
+	for _, path := range []string{
+		"README.md",
+		"docs/provider-matrix.md",
+		"docs/validation-scenarios.md",
+		"docs/enterprise-rollout.md",
+		"docs/examples/quickstart-codex.md",
+		"docs/examples/quickstart-claude.md",
+		"docs/examples/quickstart-gemini.md",
+		"scripts/verify-example.sh",
+		"internal/example/example_test.go",
+	} {
+		mustWriteRequirementFixture(t, root, path)
+	}
+
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	if err := os.MkdirAll(filepath.Dir(requirementsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(requirementsPath, []byte(`version = 1
+
+[functional.FR-001]
+title = "Managed launch"
+summary = "Launch the provider inside the managed runtime."
+evidence = ["scripts/verify-example.sh"]
+docs = [
+  "README.md",
+  "docs/provider-matrix.md",
+  "docs/validation-scenarios.md",
+  "docs/examples/quickstart-codex.md",
+  "docs/examples/quickstart-claude.md",
+  "docs/examples/quickstart-gemini.md",
+]
+
+[nonfunctional.NFR-001]
+title = "Requirement traceability"
+summary = "Every requirement cites automated evidence."
+evidence = ["internal/example/example_test.go"]
+docs = ["docs/enterprise-rollout.md"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ValidateRequirements(root, requirementsPath); err != nil {
+		t.Fatalf("ValidateRequirements() error = %v", err)
+	}
+}
+
+func TestValidateRequirementsRejectsUnmappedReleaseFacingDoc(t *testing.T) {
+	root := t.TempDir()
+	for _, path := range []string{
+		"README.md",
+		"docs/provider-matrix.md",
+		"docs/validation-scenarios.md",
+		"docs/enterprise-rollout.md",
+		"docs/examples/quickstart-codex.md",
+		"docs/examples/quickstart-claude.md",
+		"docs/examples/quickstart-gemini.md",
+		"scripts/verify-example.sh",
+		"internal/example/example_test.go",
+	} {
+		mustWriteRequirementFixture(t, root, path)
+	}
+
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	if err := os.MkdirAll(filepath.Dir(requirementsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(requirementsPath, []byte(`version = 1
+
+[functional.FR-001]
+title = "Managed launch"
+summary = "Launch the provider inside the managed runtime."
+evidence = ["scripts/verify-example.sh"]
+docs = [
+  "README.md",
+  "docs/provider-matrix.md",
+  "docs/validation-scenarios.md",
+  "docs/examples/quickstart-codex.md",
+  "docs/examples/quickstart-claude.md",
+]
+
+[nonfunctional.NFR-001]
+title = "Requirement traceability"
+summary = "Every requirement cites automated evidence."
+evidence = ["internal/example/example_test.go"]
+docs = ["docs/enterprise-rollout.md"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ValidateRequirements(root, requirementsPath)
+	if err == nil {
+		t.Fatal("ValidateRequirements() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "docs/examples/quickstart-gemini.md") {
+		t.Fatalf("ValidateRequirements() error = %v, want missing release-facing doc failure", err)
+	}
+}
+
 func TestValidateRequirementsRejectsMissingEvidencePath(t *testing.T) {
 	root := t.TempDir()
 	mustWriteRequirementFixture(t, root, "README.md")

--- a/internal/metadatautil/requirements_test.go
+++ b/internal/metadatautil/requirements_test.go
@@ -144,6 +144,55 @@ docs = ["docs/enterprise-rollout.md"]
 	}
 }
 
+func TestValidateRequirementsAcceptsNormalizedReleaseFacingDocPaths(t *testing.T) {
+	root := t.TempDir()
+	for _, path := range []string{
+		"README.md",
+		"docs/provider-matrix.md",
+		"docs/validation-scenarios.md",
+		"docs/enterprise-rollout.md",
+		"docs/examples/quickstart-codex.md",
+		"docs/examples/quickstart-claude.md",
+		"docs/examples/quickstart-gemini.md",
+		"scripts/verify-example.sh",
+		"internal/example/example_test.go",
+	} {
+		mustWriteRequirementFixture(t, root, path)
+	}
+
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	if err := os.MkdirAll(filepath.Dir(requirementsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(requirementsPath, []byte(`version = 1
+
+[functional.FR-001]
+title = "Managed launch"
+summary = "Launch the provider inside the managed runtime."
+evidence = ["scripts/verify-example.sh"]
+docs = [
+  "README.md",
+  "./docs/provider-matrix.md",
+  "docs/validation-scenarios.md",
+  "docs/examples/../examples/quickstart-codex.md",
+  "docs/examples/quickstart-claude.md",
+  "docs/examples/quickstart-gemini.md",
+]
+
+[nonfunctional.NFR-001]
+title = "Requirement traceability"
+summary = "Every requirement cites automated evidence."
+evidence = ["internal/example/example_test.go"]
+docs = ["docs/enterprise-rollout.md"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ValidateRequirements(root, requirementsPath); err != nil {
+		t.Fatalf("ValidateRequirements() error = %v", err)
+	}
+}
+
 func TestValidateRequirementsRejectsMissingEvidencePath(t *testing.T) {
 	root := t.TempDir()
 	mustWriteRequirementFixture(t, root, "README.md")

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -12,6 +12,9 @@ docs = [
   "README.md",
   "docs/invariants.md",
   "docs/provider-matrix.md",
+  "docs/examples/quickstart-codex.md",
+  "docs/examples/quickstart-claude.md",
+  "docs/examples/quickstart-gemini.md",
 ]
 
 [functional.FR-002]
@@ -21,11 +24,15 @@ evidence = [
   "tests/scenarios/shared/test-auth-commands.sh",
   "tests/scenarios/shared/test-auth-status.sh",
   "internal/authpolicy/manage_test.go",
+  "scripts/container-smoke.sh",
+  "scripts/verify-invariants.sh",
 ]
 docs = [
   "README.md",
   "docs/injection-policy.md",
   "docs/examples/injection-policy.toml",
+  "docs/examples/enterprise-claude-setup.md",
+  "docs/examples/gemini-vertex-setup.md",
 ]
 
 [functional.FR-003]


### PR DESCRIPTION
## Summary
- require release-facing Markdown examples and evaluation docs to be mapped in `policy/requirements.toml`
- add validator coverage for missing traceability entries
- tighten the requirements-validation doc so the written promise matches the machine check

## Validation
- `go test ./internal/metadatautil -count=1`
- `./scripts/verify-requirements-coverage.sh`
- `git diff --check`