### PR TITLE
Repair mainline validate-repo baseline

### DIFF
--- a/cmd/workcell-metadatautil/main.go
+++ b/cmd/workcell-metadatautil/main.go
@@ -180,21 +180,21 @@ func main() {
 			die(convErr)
 		}
 		err = metadatautil.CheckPinnedInputs(metadatautil.PinnedInputsConfig{
-			RuntimeDockerfilePath:         os.Args[2],
-			ValidatorDockerfilePath:       os.Args[3],
-			ProvidersPackageJSONPath:      os.Args[4],
-			ProvidersPackageLockPath:      os.Args[5],
-			WorkflowsDir:                  os.Args[6],
-			CIWorkflowPath:                os.Args[7],
-			ReleaseWorkflowPath:           os.Args[8],
-			PinHygieneWorkflowPath:        os.Args[9],
-			CodeownersPath:                os.Args[10],
-			CodexRequirementsPath:         os.Args[11],
-			CodexMCPConfigPath:            os.Args[12],
-			HostedControlsPolicyPath:      os.Args[13],
-			HostedControlsScriptPath:      os.Args[14],
-			ProviderBumpPolicyPath:        os.Args[15],
-			MaxDebianSnapshotAgeDays:      maxAge,
+			RuntimeDockerfilePath:    os.Args[2],
+			ValidatorDockerfilePath:  os.Args[3],
+			ProvidersPackageJSONPath: os.Args[4],
+			ProvidersPackageLockPath: os.Args[5],
+			WorkflowsDir:             os.Args[6],
+			CIWorkflowPath:           os.Args[7],
+			ReleaseWorkflowPath:      os.Args[8],
+			PinHygieneWorkflowPath:   os.Args[9],
+			CodeownersPath:           os.Args[10],
+			CodexRequirementsPath:    os.Args[11],
+			CodexMCPConfigPath:       os.Args[12],
+			HostedControlsPolicyPath: os.Args[13],
+			HostedControlsScriptPath: os.Args[14],
+			ProviderBumpPolicyPath:   os.Args[15],
+			MaxDebianSnapshotAgeDays: maxAge,
 		})
 	case "verify-reproducible-build":
 		if len(os.Args) != 7 {

--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -31,21 +31,21 @@ type ControlPlaneArtifact struct {
 }
 
 type PinnedInputsConfig struct {
-	RuntimeDockerfilePath         string
-	ValidatorDockerfilePath       string
-	ProvidersPackageJSONPath      string
-	ProvidersPackageLockPath      string
-	WorkflowsDir                  string
-	CIWorkflowPath                string
-	ReleaseWorkflowPath           string
-	PinHygieneWorkflowPath        string
-	CodeownersPath                string
-	CodexRequirementsPath         string
-	CodexMCPConfigPath            string
-	HostedControlsPolicyPath      string
-	HostedControlsScriptPath      string
-	ProviderBumpPolicyPath        string
-	MaxDebianSnapshotAgeDays      int
+	RuntimeDockerfilePath    string
+	ValidatorDockerfilePath  string
+	ProvidersPackageJSONPath string
+	ProvidersPackageLockPath string
+	WorkflowsDir             string
+	CIWorkflowPath           string
+	ReleaseWorkflowPath      string
+	PinHygieneWorkflowPath   string
+	CodeownersPath           string
+	CodexRequirementsPath    string
+	CodexMCPConfigPath       string
+	HostedControlsPolicyPath string
+	HostedControlsScriptPath string
+	ProviderBumpPolicyPath   string
+	MaxDebianSnapshotAgeDays int
 }
 
 func readText(path string) (string, error) {

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -1140,55 +1140,55 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err := requireEqual("Go toolchain version", goToolchainVersion, goModPath, validatorGoVersion, cfg.ValidatorDockerfilePath); err != nil {
 		return err
 	}
-		expectedGoLanguageVersion, err := goLanguageVersionFromToolchain(goToolchainVersion, goModPath)
-		if err != nil {
-			return err
-		}
-		if goLanguageVersion != expectedGoLanguageVersion {
-			return fmt.Errorf("go language version in %s must match the toolchain major/minor at patch zero, expected %q, found %q", goModPath, expectedGoLanguageVersion, goLanguageVersion)
-		}
-		validatorGoSHAx86_64, err := requireArg(validatorDockerfile, "GO_LINUX_X86_64_SHA256", cfg.ValidatorDockerfilePath)
-		if err != nil {
-			return err
-		}
-		if !isHexDigest(validatorGoSHAx86_64) {
-			return fmt.Errorf("GO_LINUX_X86_64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorGoSHAx86_64)
-		}
-		validatorGoSHAArm64, err := requireArg(validatorDockerfile, "GO_LINUX_ARM64_SHA256", cfg.ValidatorDockerfilePath)
-		if err != nil {
-			return err
-		}
-		if !isHexDigest(validatorGoSHAArm64) {
-			return fmt.Errorf("GO_LINUX_ARM64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorGoSHAArm64)
-		}
-		validatorHadolintVersion, err := requireArg(validatorDockerfile, "HADOLINT_VERSION", cfg.ValidatorDockerfilePath)
-		if err != nil {
-			return err
-		}
-		if !regexp.MustCompile(`^v\d+\.\d+\.\d+$`).MatchString(validatorHadolintVersion) {
-			return fmt.Errorf("HADOLINT_VERSION must be an exact pinned release, found %q", validatorHadolintVersion)
-		}
-		validatorHadolintSHAx86_64, err := requireArg(validatorDockerfile, "HADOLINT_LINUX_X86_64_SHA256", cfg.ValidatorDockerfilePath)
-		if err != nil {
-			return err
-		}
-		if !isHexDigest(validatorHadolintSHAx86_64) {
-			return fmt.Errorf("HADOLINT_LINUX_X86_64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorHadolintSHAx86_64)
-		}
-		validatorHadolintSHAArm64, err := requireArg(validatorDockerfile, "HADOLINT_LINUX_ARM64_SHA256", cfg.ValidatorDockerfilePath)
-		if err != nil {
-			return err
-		}
-		if !isHexDigest(validatorHadolintSHAArm64) {
-			return fmt.Errorf("HADOLINT_LINUX_ARM64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorHadolintSHAArm64)
-		}
-		validatorMarkdownlintVersion, err := requireArg(validatorDockerfile, "MARKDOWNLINT_VERSION", cfg.ValidatorDockerfilePath)
-		if err != nil {
-			return err
-		}
-		if !regexp.MustCompile(`^0\.\d+\.\d+$`).MatchString(validatorMarkdownlintVersion) {
-			return fmt.Errorf("MARKDOWNLINT_VERSION must be an exact pinned release, found %q", validatorMarkdownlintVersion)
-		}
+	expectedGoLanguageVersion, err := goLanguageVersionFromToolchain(goToolchainVersion, goModPath)
+	if err != nil {
+		return err
+	}
+	if goLanguageVersion != expectedGoLanguageVersion {
+		return fmt.Errorf("go language version in %s must match the toolchain major/minor at patch zero, expected %q, found %q", goModPath, expectedGoLanguageVersion, goLanguageVersion)
+	}
+	validatorGoSHAx86_64, err := requireArg(validatorDockerfile, "GO_LINUX_X86_64_SHA256", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if !isHexDigest(validatorGoSHAx86_64) {
+		return fmt.Errorf("GO_LINUX_X86_64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorGoSHAx86_64)
+	}
+	validatorGoSHAArm64, err := requireArg(validatorDockerfile, "GO_LINUX_ARM64_SHA256", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if !isHexDigest(validatorGoSHAArm64) {
+		return fmt.Errorf("GO_LINUX_ARM64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorGoSHAArm64)
+	}
+	validatorHadolintVersion, err := requireArg(validatorDockerfile, "HADOLINT_VERSION", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if !regexp.MustCompile(`^v\d+\.\d+\.\d+$`).MatchString(validatorHadolintVersion) {
+		return fmt.Errorf("HADOLINT_VERSION must be an exact pinned release, found %q", validatorHadolintVersion)
+	}
+	validatorHadolintSHAx86_64, err := requireArg(validatorDockerfile, "HADOLINT_LINUX_X86_64_SHA256", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if !isHexDigest(validatorHadolintSHAx86_64) {
+		return fmt.Errorf("HADOLINT_LINUX_X86_64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorHadolintSHAx86_64)
+	}
+	validatorHadolintSHAArm64, err := requireArg(validatorDockerfile, "HADOLINT_LINUX_ARM64_SHA256", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if !isHexDigest(validatorHadolintSHAArm64) {
+		return fmt.Errorf("HADOLINT_LINUX_ARM64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorHadolintSHAArm64)
+	}
+	validatorMarkdownlintVersion, err := requireArg(validatorDockerfile, "MARKDOWNLINT_VERSION", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if !regexp.MustCompile(`^0\.\d+\.\d+$`).MatchString(validatorMarkdownlintVersion) {
+		return fmt.Errorf("MARKDOWNLINT_VERSION must be an exact pinned release, found %q", validatorMarkdownlintVersion)
+	}
 	for _, needle := range []string{
 		`COPY tools/markdownlint/package.json tools/markdownlint/package-lock.json /usr/local/lib/workcell-markdownlint/`,
 		`npm ci --prefix /usr/local/lib/workcell-markdownlint --ignore-scripts --omit=dev`,

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -160,7 +160,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/home-control-plane.sh",
       "runtime_path": "/usr/local/libexec/workcell/home-control-plane.sh",
-      "sha256": "1160b465e29599a14d52effc4bd422983a4a3a529138b2a5274134fe31ae35e1"
+      "sha256": "fc93fbc1616340208f6aefe522530580b6fa0466003f7ea29a9b2c31a4b2df5e"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -256,7 +256,7 @@ workcell_file_trace_diff_snapshots() {
   done <"${after_path}"
 
   for path_key in "${!before_map[@]}"; do
-    if [[ ! -v after_map["${path_key}"] ]]; then
+    if [[ -z "${after_map[${path_key}]+x}" ]]; then
       workcell_file_trace_emit \
         "event=delete" \
         "phase=${phase}" \
@@ -273,7 +273,7 @@ workcell_file_trace_diff_snapshots() {
   done
 
   for path_key in "${!after_map[@]}"; do
-    if [[ ! -v before_map["${path_key}"] ]]; then
+    if [[ -z "${before_map[${path_key}]+x}" ]]; then
       workcell_file_trace_emit \
         "event=create" \
         "phase=${phase}" \


### PR DESCRIPTION
## Summary
- reformat the metadatautil Go files that were failing the repo-wide gofmt gate
- make `home-control-plane.sh` use portable associative-array membership checks on macOS bash
- refresh the committed control-plane manifest after the script change

## Validation
- `./scripts/validate-repo.sh`