### PR TITLE
Refresh release inputs with a Claude 2.1.104 holdback

### DIFF
--- a/internal/metadatautil/provider_bumps_test.go
+++ b/internal/metadatautil/provider_bumps_test.go
@@ -257,7 +257,6 @@ func TestCheckProviderBumpPolicyRejectsUnstableClaudePinWithCeiling(t *testing.T
 		t.Fatalf("CheckProviderBumpPolicy() error = %v", err)
 	}
 }
-
 func TestPlanProviderBumpsHonorsClaudeMaxVersion(t *testing.T) {
 	root := t.TempDir()
 	dockerfilePath := filepath.Join(root, "Dockerfile")
@@ -405,7 +404,6 @@ func TestApplyProviderBumpPlanRejectsUnstableClaudeTargetVersion(t *testing.T) {
 		t.Fatalf("ApplyProviderBumpPlan() error = %v", err)
 	}
 }
-
 func TestPlanProviderBumpsRespectsCurrentRegistryLatestTrack(t *testing.T) {
 	root := t.TempDir()
 	dockerfilePath := filepath.Join(root, "Dockerfile")

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -11,7 +11,7 @@ ARG SOURCE_DATE_EPOCH=0
 # To update: choose a newer snapshot date at https://snapshot.debian.org/,
 # verify packages are available, update this value, and re-run verify-reproducible-build.sh.
 ARG DEBIAN_SNAPSHOT=20260417T000000Z
-ARG RUST_TOOLCHAIN_IMAGE=rust:1.95.0-slim-trixie@sha256:72e5ceb0b77211cd46e45d327e33c12f2ad24b6f48ce54a279e07f95f21382f9
+ARG RUST_TOOLCHAIN_IMAGE=rust:1.95.0-slim-trixie@sha256:275c320a57d0d8b6ab09454ab6d1660d70c745fb3cc85adbefad881b69a212cc
 
 FROM ${RUST_TOOLCHAIN_IMAGE} AS rust-toolchain
 


### PR DESCRIPTION
## Summary
- add a provider bump policy ceiling so Claude can stay pinned at `2.1.104` while other stable providers keep moving
- refresh the runtime and validator release inputs to the current Debian snapshot, Rust toolchain, Codex, and Gemini pins
- update provider bump tests so the holdback policy is enforced in planning and validation

## Validation
- `go test ./internal/metadatautil -run 'ProviderBump|CheckProviderBumpPolicy' -count=1`
- `./scripts/update-upstream-pins.sh --apply`
- `./scripts/update-upstream-pins.sh --check`
- `./scripts/check-pinned-inputs.sh`