### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ Releases.
 
 ## Unreleased
 
+## v0.10.0 - 2026-04-17
+
+### Added
+
+- expanded host-side session control and observability on the shipped session
+  plane, including detached `session start|attach|send|stop`, richer
+  `session list` status/control rendering, and terminal-session cleanup through
+  `session delete`
+- explicit local-first rollout and provider-auth maturity docs for the current
+  Apple Silicon macOS support boundary and single-maintainer release model
+
+### Changed
+
+- restore `workspace-write` as the managed Codex sandbox while keeping
+  `danger-full-access` reserved for breakglass-style paths
+- tighten the provider-bump policy so reviewed holdbacks can cap Claude to a
+  known-good stable version while other upstream pins continue to refresh
+
+### Fixed
+
+- prevent terminal resize from aborting transcript-capture launches and from
+  crashing attached interactive sessions through Docker's embedded `tini`
+  forwarding path
+- harden host and runtime boundaries against the reviewed security finding set,
+  including control-plane manifest override, provider-directory overwrite,
+  validation-snapshot and build-manifest symlink escapes, shared GitHub
+  credential scoping, trusted-Docker home spoofing, and alignment of the
+  tracked hosted-controls policy with the live repository ruleset
+- pin Claude CLI to `2.1.104` while the known defect in `2.1.105+` remains out
+  of policy
+
 ## v0.9.3 - 2026-04-14
 
 ### Changed

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -46,6 +46,11 @@ honestly in docs, status reports, and release commentary.
   state before concluding.
 - Do not rewrite or delete a failed release tag. Recover by patching `main` and
   cutting the next patch release.
+- In single-maintainer mode, leave an explicit public release-PR comment before
+  merge that records the version, exact head SHA, timestamp, and the exact
+  single-maintainer path used, including maintainer self-review for the
+  `release` environment and any explicit branch-protection bypass actually used
+  for the PR merge because no second approver was configured.
 
 ## Inputs
 
@@ -53,7 +58,7 @@ Set these values before starting:
 
 ```sh
 export REPO="omkhar/workcell"
-export VERSION="v0.9.3"
+export VERSION="vX.Y.Z"
 export RELEASE_BRANCH="codex/release-${VERSION}"
 export RELEASE_TITLE="Release ${VERSION}"
 ```
@@ -323,6 +328,10 @@ following are true:
 - the release documentation review has been completed after CI turned green
 - release-facing docs accurately describe the exact merge diff
 - changelog and release notes are correct
+- the public single-maintainer release comment records the version, exact head
+  SHA, timestamp, and the exact single-maintainer path used, including any
+  release-environment self-review and any explicit PR-merge bypass when
+  applicable
 
 After merge, record the resulting `main` commit SHA. This is the commit that
 will be tagged.

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -46,6 +46,20 @@ They also now cover canonical requirement traceability, host-side policy
 inspection and explainability, and host-side detached session inventory,
 control, logs/timeline, and clean-base diff/export behavior.
 
+## Documentation example coverage
+
+Release-facing examples are expected to map to existing automated evidence even
+when the repo does not add a dedicated new scenario for each page.
+
+| Guide | Primary evidence |
+|---|---|
+| `README.md` install, launch, and session snippets | `scripts/verify-invariants.sh`, `scripts/container-smoke.sh`, `tests/scenarios/shared/test-session-commands.sh`, `cmd/workcell-hostutil/main_test.go` |
+| `docs/getting-started.md` | `scripts/verify-invariants.sh`, `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh` |
+| `docs/examples/quickstart-codex.md` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-publish-pr-dry-run.sh` |
+| `docs/examples/quickstart-claude.md` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-claude-resolver-launcher.sh`, `tests/scenarios/shared/test-publish-pr-dry-run.sh` |
+| `docs/examples/quickstart-gemini.md` | `tests/scenarios/shared/test-auth-status.sh` for the staged `gemini_env` path and `tests/scenarios/shared/test-publish-pr-dry-run.sh` for the host-side publication steps; OAuth and `gcloud_adc` remain manual provider-e2e validation paths |
+| `docs/examples/enterprise-claude-setup.md` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-policy-commands.sh`, `tests/scenarios/shared/test-publish-pr-dry-run.sh` |
+
 ## Manual authenticated smoke
 
 `./scripts/provider-e2e.sh` is the reviewed path for provider-authenticated


### PR DESCRIPTION
## Summary
- cut the v0.10.0 release branch from current main
- ship the reviewed session/runtime, security, pin, and documentation updates
- align release-facing docs, roadmap, and rollout guidance with the current product and single-maintainer release process

## Validation
- ./tests/scenarios/shared/test-auth-commands.sh
- ./tests/scenarios/shared/test-auth-status.sh
- ./tests/scenarios/shared/test-session-commands.sh
- ./tests/scenarios/shared/test-assurance-dry-run.sh
- ./scripts/container-smoke.sh
- ./scripts/verify-invariants.sh
- ./scripts/verify-control-plane-manifest.sh
- ./scripts/update-upstream-pins.sh --check
- git diff --check