### PR TITLE
release: tighten v0.10.3 fixups before tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Releases.
 - stop scrubbed host-side Go helper launches from reusing a stale partial
   module cache under `/tmp`, which could make `workcell --agent claude` fail
   before launch with `no required module provides package golang.org/x/sys/unix`
+- keep reviewed Claude `approved_version` exceptions from forcing a future
+  downgrade once the pinned runtime has already moved past the exception
 - add real macOS integration coverage that launches Workcell-managed Codex,
   Claude, and Gemini version probes and exercises the host detached-session
   control plane against live and terminal workloads, including

--- a/internal/metadatautil/provider_bumps.go
+++ b/internal/metadatautil/provider_bumps.go
@@ -452,6 +452,7 @@ func selectClaudeStable(currentVersion string, cutoff time.Time, maxVersion stri
 		return ProviderBumpSelection{}, err
 	}
 	maxAllowed, hasMaxVersion := parseStableVersion(maxVersion)
+	current, hasCurrentVersion := parseStableVersion(currentVersion)
 	approved, hasApprovedVersion := parseStableVersion(approvedVersion)
 	candidates := make([]stableVersion, 0, len(listing.CommonPrefixes))
 	for _, prefix := range listing.CommonPrefixes {
@@ -470,6 +471,13 @@ func selectClaudeStable(currentVersion string, cutoff time.Time, maxVersion stri
 	}
 	sortStableVersionsDesc(candidates)
 	if hasApprovedVersion {
+		if hasCurrentVersion && compareStableVersions(approved, current) <= 0 {
+			return ProviderBumpSelection{
+				Channel:        "stable",
+				CurrentVersion: currentVersion,
+				TargetVersion:  currentVersion,
+			}, nil
+		}
 		for _, candidate := range candidates {
 			if compareStableVersions(candidate, approved) != 0 {
 				continue

--- a/internal/metadatautil/provider_bumps.go
+++ b/internal/metadatautil/provider_bumps.go
@@ -455,6 +455,7 @@ func selectClaudeStable(currentVersion string, cutoff time.Time, maxVersion stri
 	current, hasCurrentVersion := parseStableVersion(currentVersion)
 	approved, hasApprovedVersion := parseStableVersion(approvedVersion)
 	candidates := make([]stableVersion, 0, len(listing.CommonPrefixes))
+	currentPresentInCandidates := false
 	for _, prefix := range listing.CommonPrefixes {
 		match := claudeBucketVersionDirPattern.FindStringSubmatch(prefix.Prefix)
 		if match == nil {
@@ -467,6 +468,9 @@ func selectClaudeStable(currentVersion string, cutoff time.Time, maxVersion stri
 		if hasMaxVersion && compareStableVersions(version, maxAllowed) > 0 {
 			continue
 		}
+		if hasCurrentVersion && compareStableVersions(version, current) == 0 {
+			currentPresentInCandidates = true
+		}
 		candidates = append(candidates, version)
 	}
 	sortStableVersionsDesc(candidates)
@@ -475,9 +479,6 @@ func selectClaudeStable(currentVersion string, cutoff time.Time, maxVersion stri
 	}
 	if hasApprovedVersion {
 		for _, candidate := range candidates {
-			if hasCurrentVersion && compareStableVersions(candidate, current) < 0 {
-				continue
-			}
 			if compareStableVersions(candidate, approved) != 0 {
 				continue
 			}
@@ -509,10 +510,9 @@ func selectClaudeStable(currentVersion string, cutoff time.Time, maxVersion stri
 		}
 		return ProviderBumpSelection{}, fmt.Errorf("claude approved_version %s is not present in the release bucket listing", approvedVersion)
 	}
+	var selected *ProviderBumpSelection
+	var selectedVersion stableVersion
 	for _, candidate := range candidates {
-		if hasCurrentVersion && compareStableVersions(candidate, current) < 0 {
-			continue
-		}
 		manifestURL := fmt.Sprintf("%s/%s/manifest.json", sources.ClaudeReleaseRootURL, candidate.Raw)
 		var manifest claudeManifest
 		if err := fetchJSON(client, manifestURL, &manifest); err != nil {
@@ -530,7 +530,7 @@ func selectClaudeStable(currentVersion string, cutoff time.Time, maxVersion stri
 		if armChecksum == "" || amdChecksum == "" {
 			return ProviderBumpSelection{}, fmt.Errorf("claude manifest for %s is missing Linux checksums", candidate.Raw)
 		}
-		return ProviderBumpSelection{
+		selection := ProviderBumpSelection{
 			Channel:        "stable",
 			CurrentVersion: currentVersion,
 			TargetVersion:  candidate.Raw,
@@ -540,7 +540,32 @@ func selectClaudeStable(currentVersion string, cutoff time.Time, maxVersion stri
 				"arm64": armChecksum,
 				"amd64": amdChecksum,
 			},
-		}, nil
+		}
+		selected = &selection
+		selectedVersion = candidate
+		break
+	}
+	if selected != nil {
+		if hasCurrentVersion && compareStableVersions(selectedVersion, current) < 0 {
+			if hasMaxVersion && compareStableVersions(current, maxAllowed) > 0 {
+				return ProviderBumpSelection{}, fmt.Errorf("current Claude version %s exceeds provider.claude.max_version %s", currentVersion, maxVersion)
+			}
+			if !currentPresentInCandidates {
+				return ProviderBumpSelection{}, fmt.Errorf("current Claude version %s is not present in the release bucket listing", currentVersion)
+			}
+			return ProviderBumpSelection{
+				Channel:        "stable",
+				CurrentVersion: currentVersion,
+				TargetVersion:  currentVersion,
+			}, nil
+		}
+		return *selected, nil
+	}
+	if hasCurrentVersion && hasMaxVersion && compareStableVersions(current, maxAllowed) > 0 {
+		return ProviderBumpSelection{}, fmt.Errorf("current Claude version %s exceeds provider.claude.max_version %s", currentVersion, maxVersion)
+	}
+	if hasCurrentVersion && len(candidates) > 0 && !currentPresentInCandidates && compareStableVersions(current, candidates[0]) > 0 {
+		return ProviderBumpSelection{}, fmt.Errorf("current Claude version %s is not present in the release bucket listing", currentVersion)
 	}
 	return ProviderBumpSelection{
 		Channel:        "stable",

--- a/internal/metadatautil/provider_bumps.go
+++ b/internal/metadatautil/provider_bumps.go
@@ -475,6 +475,9 @@ func selectClaudeStable(currentVersion string, cutoff time.Time, maxVersion stri
 	}
 	if hasApprovedVersion {
 		for _, candidate := range candidates {
+			if hasCurrentVersion && compareStableVersions(candidate, current) < 0 {
+				continue
+			}
 			if compareStableVersions(candidate, approved) != 0 {
 				continue
 			}
@@ -507,6 +510,9 @@ func selectClaudeStable(currentVersion string, cutoff time.Time, maxVersion stri
 		return ProviderBumpSelection{}, fmt.Errorf("claude approved_version %s is not present in the release bucket listing", approvedVersion)
 	}
 	for _, candidate := range candidates {
+		if hasCurrentVersion && compareStableVersions(candidate, current) < 0 {
+			continue
+		}
 		manifestURL := fmt.Sprintf("%s/%s/manifest.json", sources.ClaudeReleaseRootURL, candidate.Raw)
 		var manifest claudeManifest
 		if err := fetchJSON(client, manifestURL, &manifest); err != nil {

--- a/internal/metadatautil/provider_bumps.go
+++ b/internal/metadatautil/provider_bumps.go
@@ -470,14 +470,10 @@ func selectClaudeStable(currentVersion string, cutoff time.Time, maxVersion stri
 		candidates = append(candidates, version)
 	}
 	sortStableVersionsDesc(candidates)
+	if hasApprovedVersion && hasCurrentVersion && compareStableVersions(approved, current) <= 0 {
+		hasApprovedVersion = false
+	}
 	if hasApprovedVersion {
-		if hasCurrentVersion && compareStableVersions(approved, current) <= 0 {
-			return ProviderBumpSelection{
-				Channel:        "stable",
-				CurrentVersion: currentVersion,
-				TargetVersion:  currentVersion,
-			}, nil
-		}
 		for _, candidate := range candidates {
 			if compareStableVersions(candidate, approved) != 0 {
 				continue

--- a/internal/metadatautil/provider_bumps_test.go
+++ b/internal/metadatautil/provider_bumps_test.go
@@ -601,6 +601,106 @@ func TestPlanProviderBumpsIgnoresOlderApprovedClaudeVersionOnceCurrentRuntimeIsN
 	}
 }
 
+func TestPlanProviderBumpsDoesNotDowngradeWhenCurrentClaudeVersionIsStillCoolingOff(t *testing.T) {
+	root := t.TempDir()
+	dockerfilePath := filepath.Join(root, "Dockerfile")
+	packageJSONPath := filepath.Join(root, "package.json")
+	policyPath := filepath.Join(root, "provider-bumps.toml")
+
+	mustWriteText(t, dockerfilePath, strings.Join([]string{
+		"ARG CLAUDE_VERSION=2.1.108",
+		"ARG CODEX_VERSION=0.118.0",
+		"RUN true",
+	}, "\n")+"\n")
+	mustWriteText(t, packageJSONPath, `{"dependencies":{"@google/gemini-cli":"0.36.0"}}`+"\n")
+	mustWriteText(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"cooloff_hours = 12",
+		"",
+		"[provider.codex]",
+		`channel = "stable"`,
+		"",
+		"[provider.claude]",
+		`channel = "stable"`,
+		`max_version = "2.1.108"`,
+		`approved_version = "2.1.108"`,
+		"",
+		"[provider.gemini]",
+		`channel = "stable"`,
+	}, "\n")+"\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/codex-registry":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "dist-tags": {"latest": "0.118.0"},
+  "time": {
+    "created": "2026-01-01T00:00:00Z",
+    "0.118.0": "2026-04-01T00:00:00Z"
+  }
+}`))
+		case "/gemini-registry":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "dist-tags": {"latest": "0.36.0"},
+  "time": {
+    "created": "2026-01-01T00:00:00Z",
+    "0.36.0": "2026-04-01T00:00:00Z"
+  }
+}`))
+		case "/claude-bucket":
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <CommonPrefixes><Prefix>claude-code-releases/2.1.108/</Prefix></CommonPrefixes>
+  <CommonPrefixes><Prefix>claude-code-releases/2.1.107/</Prefix></CommonPrefixes>
+</ListBucketResult>`))
+		case "/claude-release/2.1.108/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "version": "2.1.108",
+  "buildDate": "2026-04-18T00:30:00Z",
+  "platforms": {
+    "linux-arm64": {"checksum": "108arm64108arm64108arm64108arm64108arm64108arm64108arm64108arm64"},
+    "linux-x64": {"checksum": "108amd64108amd64108amd64108amd64108amd64108amd64108amd64108amd64"}
+  }
+}`))
+		case "/claude-release/2.1.107/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "version": "2.1.107",
+  "buildDate": "2026-04-17T00:00:00Z",
+  "platforms": {
+    "linux-arm64": {"checksum": "107arm64107arm64107arm64107arm64107arm64107arm64107arm64107arm64"},
+    "linux-x64": {"checksum": "107amd64107amd64107amd64107amd64107amd64107amd64107amd64107amd64"}
+  }
+}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	now := time.Date(2026, time.April, 18, 5, 0, 0, 0, time.UTC)
+	plan, err := PlanProviderBumps(policyPath, dockerfilePath, packageJSONPath, now, ProviderBumpSources{
+		CodexRegistryURL:      server.URL + "/codex-registry",
+		CodexReleaseAPIURLFmt: server.URL + "/codex-release/rust-v%s",
+		GeminiRegistryURL:     server.URL + "/gemini-registry",
+		ClaudeBucketURL:       server.URL + "/claude-bucket",
+		ClaudeReleaseRootURL:  server.URL + "/claude-release",
+	}, server.Client())
+	if err != nil {
+		t.Fatalf("PlanProviderBumps() error = %v", err)
+	}
+	if got := plan.Providers["claude"].TargetVersion; got != "2.1.108" {
+		t.Fatalf("Claude target = %q, want 2.1.108", got)
+	}
+	if plan.Providers["claude"].Changed {
+		t.Fatal("Claude plan should keep the current version while it is still inside the reviewed cool-off window")
+	}
+}
+
 func TestApplyProviderBumpPlanRejectsUnstableClaudeTargetVersion(t *testing.T) {
 	root := t.TempDir()
 	dockerfilePath := filepath.Join(root, "Dockerfile")

--- a/internal/metadatautil/provider_bumps_test.go
+++ b/internal/metadatautil/provider_bumps_test.go
@@ -500,6 +500,107 @@ func TestPlanProviderBumpsAllowsApprovedClaudeVersionPastCooloff(t *testing.T) {
 	}
 }
 
+func TestPlanProviderBumpsDoesNotDowngradePastApprovedClaudeVersion(t *testing.T) {
+	root := t.TempDir()
+	dockerfilePath := filepath.Join(root, "Dockerfile")
+	packageJSONPath := filepath.Join(root, "package.json")
+	policyPath := filepath.Join(root, "provider-bumps.toml")
+
+	mustWriteText(t, dockerfilePath, strings.Join([]string{
+		"ARG CLAUDE_VERSION=2.1.109",
+		"ARG CODEX_VERSION=0.118.0",
+		"RUN true",
+	}, "\n")+"\n")
+	mustWriteText(t, packageJSONPath, `{"dependencies":{"@google/gemini-cli":"0.36.0"}}`+"\n")
+	mustWriteText(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"cooloff_hours = 12",
+		"",
+		"[provider.codex]",
+		`channel = "stable"`,
+		"",
+		"[provider.claude]",
+		`channel = "stable"`,
+		`max_version = "2.1.110"`,
+		`approved_version = "2.1.108"`,
+		"",
+		"[provider.gemini]",
+		`channel = "stable"`,
+	}, "\n")+"\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/codex-registry":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "dist-tags": {"latest": "0.118.0"},
+  "time": {
+    "created": "2026-01-01T00:00:00Z",
+    "0.118.0": "2026-04-01T00:00:00Z"
+  }
+}`))
+		case "/gemini-registry":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "dist-tags": {"latest": "0.36.0"},
+  "time": {
+    "created": "2026-01-01T00:00:00Z",
+    "0.36.0": "2026-04-01T00:00:00Z"
+  }
+}`))
+		case "/claude-bucket":
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <CommonPrefixes><Prefix>claude-code-releases/2.1.110/</Prefix></CommonPrefixes>
+  <CommonPrefixes><Prefix>claude-code-releases/2.1.109/</Prefix></CommonPrefixes>
+  <CommonPrefixes><Prefix>claude-code-releases/2.1.108/</Prefix></CommonPrefixes>
+</ListBucketResult>`))
+		case "/claude-release/2.1.110/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "version": "2.1.110",
+  "buildDate": "2026-04-18T04:00:00Z",
+  "platforms": {
+    "linux-arm64": {"checksum": "110arm64110arm64110arm64110arm64110arm64110arm64110arm64110arm64"},
+    "linux-x64": {"checksum": "110amd64110amd64110amd64110amd64110amd64110amd64110amd64110amd64"}
+  }
+}`))
+		case "/claude-release/2.1.109/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "version": "2.1.109",
+  "buildDate": "2026-04-17T00:00:00Z",
+  "platforms": {
+    "linux-arm64": {"checksum": "109arm64109arm64109arm64109arm64109arm64109arm64109arm64109arm64"},
+    "linux-x64": {"checksum": "109amd64109amd64109amd64109amd64109amd64109amd64109amd64109amd64"}
+  }
+}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	now := time.Date(2026, time.April, 18, 5, 0, 0, 0, time.UTC)
+	plan, err := PlanProviderBumps(policyPath, dockerfilePath, packageJSONPath, now, ProviderBumpSources{
+		CodexRegistryURL:      server.URL + "/codex-registry",
+		CodexReleaseAPIURLFmt: server.URL + "/codex-release/rust-v%s",
+		GeminiRegistryURL:     server.URL + "/gemini-registry",
+		ClaudeBucketURL:       server.URL + "/claude-bucket",
+		ClaudeReleaseRootURL:  server.URL + "/claude-release",
+	}, server.Client())
+	if err != nil {
+		t.Fatalf("PlanProviderBumps() error = %v", err)
+	}
+	if got := plan.Providers["claude"].TargetVersion; got != "2.1.109" {
+		t.Fatalf("Claude target = %q, want 2.1.109", got)
+	}
+	if plan.Providers["claude"].Changed {
+		t.Fatal("Claude plan should not report a downgrade change when current version already exceeds approved_version")
+	}
+}
+
 func TestApplyProviderBumpPlanRejectsUnstableClaudeTargetVersion(t *testing.T) {
 	root := t.TempDir()
 	dockerfilePath := filepath.Join(root, "Dockerfile")

--- a/internal/metadatautil/provider_bumps_test.go
+++ b/internal/metadatautil/provider_bumps_test.go
@@ -500,7 +500,7 @@ func TestPlanProviderBumpsAllowsApprovedClaudeVersionPastCooloff(t *testing.T) {
 	}
 }
 
-func TestPlanProviderBumpsDoesNotDowngradePastApprovedClaudeVersion(t *testing.T) {
+func TestPlanProviderBumpsIgnoresOlderApprovedClaudeVersionOnceCurrentRuntimeIsNewer(t *testing.T) {
 	root := t.TempDir()
 	dockerfilePath := filepath.Join(root, "Dockerfile")
 	packageJSONPath := filepath.Join(root, "package.json")
@@ -560,7 +560,7 @@ func TestPlanProviderBumpsDoesNotDowngradePastApprovedClaudeVersion(t *testing.T
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{
   "version": "2.1.110",
-  "buildDate": "2026-04-18T04:00:00Z",
+  "buildDate": "2026-04-17T16:00:00Z",
   "platforms": {
     "linux-arm64": {"checksum": "110arm64110arm64110arm64110arm64110arm64110arm64110arm64110arm64"},
     "linux-x64": {"checksum": "110amd64110amd64110amd64110amd64110amd64110amd64110amd64110amd64"}
@@ -593,11 +593,11 @@ func TestPlanProviderBumpsDoesNotDowngradePastApprovedClaudeVersion(t *testing.T
 	if err != nil {
 		t.Fatalf("PlanProviderBumps() error = %v", err)
 	}
-	if got := plan.Providers["claude"].TargetVersion; got != "2.1.109" {
-		t.Fatalf("Claude target = %q, want 2.1.109", got)
+	if got := plan.Providers["claude"].TargetVersion; got != "2.1.110" {
+		t.Fatalf("Claude target = %q, want 2.1.110", got)
 	}
-	if plan.Providers["claude"].Changed {
-		t.Fatal("Claude plan should not report a downgrade change when current version already exceeds approved_version")
+	if !plan.Providers["claude"].Changed {
+		t.Fatal("Claude plan should continue to advance once a newer stable version has cleared the cool-off window")
 	}
 }
 

--- a/internal/metadatautil/provider_bumps_test.go
+++ b/internal/metadatautil/provider_bumps_test.go
@@ -701,6 +701,187 @@ func TestPlanProviderBumpsDoesNotDowngradeWhenCurrentClaudeVersionIsStillCooling
 	}
 }
 
+func TestPlanProviderBumpsRejectsCurrentClaudeVersionAboveMaxVersion(t *testing.T) {
+	root := t.TempDir()
+	dockerfilePath := filepath.Join(root, "Dockerfile")
+	packageJSONPath := filepath.Join(root, "package.json")
+	policyPath := filepath.Join(root, "provider-bumps.toml")
+
+	mustWriteText(t, dockerfilePath, strings.Join([]string{
+		"ARG CLAUDE_VERSION=2.1.109",
+		"ARG CODEX_VERSION=0.118.0",
+		"RUN true",
+	}, "\n")+"\n")
+	mustWriteText(t, packageJSONPath, `{"dependencies":{"@google/gemini-cli":"0.36.0"}}`+"\n")
+	mustWriteText(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"cooloff_hours = 12",
+		"",
+		"[provider.codex]",
+		`channel = "stable"`,
+		"",
+		"[provider.claude]",
+		`channel = "stable"`,
+		`max_version = "2.1.108"`,
+		"",
+		"[provider.gemini]",
+		`channel = "stable"`,
+	}, "\n")+"\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/codex-registry":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "dist-tags": {"latest": "0.118.0"},
+  "time": {
+    "created": "2026-01-01T00:00:00Z",
+    "0.118.0": "2026-04-01T00:00:00Z"
+  }
+}`))
+		case "/gemini-registry":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "dist-tags": {"latest": "0.36.0"},
+  "time": {
+    "created": "2026-01-01T00:00:00Z",
+    "0.36.0": "2026-04-01T00:00:00Z"
+  }
+}`))
+		case "/claude-bucket":
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <CommonPrefixes><Prefix>claude-code-releases/2.1.108/</Prefix></CommonPrefixes>
+  <CommonPrefixes><Prefix>claude-code-releases/2.1.107/</Prefix></CommonPrefixes>
+</ListBucketResult>`))
+		case "/claude-release/2.1.108/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "version": "2.1.108",
+  "buildDate": "2026-04-17T00:00:00Z",
+  "platforms": {
+    "linux-arm64": {"checksum": "108arm64108arm64108arm64108arm64108arm64108arm64108arm64108arm64"},
+    "linux-x64": {"checksum": "108amd64108amd64108amd64108amd64108amd64108amd64108amd64108amd64"}
+  }
+}`))
+		case "/claude-release/2.1.107/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "version": "2.1.107",
+  "buildDate": "2026-04-16T00:00:00Z",
+  "platforms": {
+    "linux-arm64": {"checksum": "107arm64107arm64107arm64107arm64107arm64107arm64107arm64107arm64"},
+    "linux-x64": {"checksum": "107amd64107amd64107amd64107amd64107amd64107amd64107amd64107amd64"}
+  }
+}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	now := time.Date(2026, time.April, 18, 5, 0, 0, 0, time.UTC)
+	_, err := PlanProviderBumps(policyPath, dockerfilePath, packageJSONPath, now, ProviderBumpSources{
+		CodexRegistryURL:      server.URL + "/codex-registry",
+		CodexReleaseAPIURLFmt: server.URL + "/codex-release/rust-v%s",
+		GeminiRegistryURL:     server.URL + "/gemini-registry",
+		ClaudeBucketURL:       server.URL + "/claude-bucket",
+		ClaudeReleaseRootURL:  server.URL + "/claude-release",
+	}, server.Client())
+	if err == nil {
+		t.Fatal("PlanProviderBumps() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "current Claude version 2.1.109 exceeds provider.claude.max_version 2.1.108") {
+		t.Fatalf("PlanProviderBumps() error = %v", err)
+	}
+}
+
+func TestPlanProviderBumpsRejectsMissingCurrentClaudeVersionFromBucket(t *testing.T) {
+	root := t.TempDir()
+	dockerfilePath := filepath.Join(root, "Dockerfile")
+	packageJSONPath := filepath.Join(root, "package.json")
+	policyPath := filepath.Join(root, "provider-bumps.toml")
+
+	mustWriteText(t, dockerfilePath, strings.Join([]string{
+		"ARG CLAUDE_VERSION=2.1.108",
+		"ARG CODEX_VERSION=0.118.0",
+		"RUN true",
+	}, "\n")+"\n")
+	mustWriteText(t, packageJSONPath, `{"dependencies":{"@google/gemini-cli":"0.36.0"}}`+"\n")
+	mustWriteText(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"cooloff_hours = 12",
+		"",
+		"[provider.codex]",
+		`channel = "stable"`,
+		"",
+		"[provider.claude]",
+		`channel = "stable"`,
+		`max_version = "2.1.108"`,
+		"",
+		"[provider.gemini]",
+		`channel = "stable"`,
+	}, "\n")+"\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/codex-registry":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "dist-tags": {"latest": "0.118.0"},
+  "time": {
+    "created": "2026-01-01T00:00:00Z",
+    "0.118.0": "2026-04-01T00:00:00Z"
+  }
+}`))
+		case "/gemini-registry":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "dist-tags": {"latest": "0.36.0"},
+  "time": {
+    "created": "2026-01-01T00:00:00Z",
+    "0.36.0": "2026-04-01T00:00:00Z"
+  }
+}`))
+		case "/claude-bucket":
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <CommonPrefixes><Prefix>claude-code-releases/2.1.107/</Prefix></CommonPrefixes>
+</ListBucketResult>`))
+		case "/claude-release/2.1.107/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "version": "2.1.107",
+  "buildDate": "2026-04-16T00:00:00Z",
+  "platforms": {
+    "linux-arm64": {"checksum": "107arm64107arm64107arm64107arm64107arm64107arm64107arm64107arm64"},
+    "linux-x64": {"checksum": "107amd64107amd64107amd64107amd64107amd64107amd64107amd64107amd64"}
+  }
+}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	now := time.Date(2026, time.April, 18, 5, 0, 0, 0, time.UTC)
+	_, err := PlanProviderBumps(policyPath, dockerfilePath, packageJSONPath, now, ProviderBumpSources{
+		CodexRegistryURL:      server.URL + "/codex-registry",
+		CodexReleaseAPIURLFmt: server.URL + "/codex-release/rust-v%s",
+		GeminiRegistryURL:     server.URL + "/gemini-registry",
+		ClaudeBucketURL:       server.URL + "/claude-bucket",
+		ClaudeReleaseRootURL:  server.URL + "/claude-release",
+	}, server.Client())
+	if err == nil {
+		t.Fatal("PlanProviderBumps() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "current Claude version 2.1.108 is not present in the release bucket listing") {
+		t.Fatalf("PlanProviderBumps() error = %v", err)
+	}
+}
+
 func TestApplyProviderBumpPlanRejectsUnstableClaudeTargetVersion(t *testing.T) {
 	root := t.TempDir()
 	dockerfilePath := filepath.Join(root, "Dockerfile")

--- a/tests/fixtures/session-cli/main.go
+++ b/tests/fixtures/session-cli/main.go
@@ -65,9 +65,7 @@ func runLifecycleFixture(outputPath string) error {
 	}
 	defer out.Close()
 
-	done := make(chan struct{})
 	go func() {
-		defer close(done)
 		for {
 			fifo, err := os.OpenFile(detachedFIFOPath, os.O_RDONLY, 0)
 			if err != nil {
@@ -87,7 +85,6 @@ func runLifecycleFixture(outputPath string) error {
 	defer signal.Stop(sigCh)
 	<-sigCh
 	_ = os.Remove(detachedFIFOPath)
-	<-done
 	return nil
 }
 

--- a/tests/scenarios/shared/test-agent-launch-smoke.sh
+++ b/tests/scenarios/shared/test-agent-launch-smoke.sh
@@ -73,6 +73,25 @@ prepare_runtime() {
     >"${TMP_DIR}/prepare.stdout" 2>"${TMP_DIR}/prepare.stderr"
 }
 
+expected_runtime_version() {
+  local agent="$1"
+
+  case "${agent}" in
+    codex)
+      sed -n 's/^ARG CODEX_VERSION=//p' "${ROOT_DIR}/runtime/container/Dockerfile"
+      ;;
+    claude)
+      sed -n 's/^ARG CLAUDE_VERSION=//p' "${ROOT_DIR}/runtime/container/Dockerfile"
+      ;;
+    gemini)
+      jq -r '.dependencies["@google/gemini-cli"]' "${ROOT_DIR}/runtime/container/providers/package.json"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 run_agent_version_smoke() {
   local agent="$1"
   local status=0
@@ -96,11 +115,13 @@ grep -q "^profile=${PROFILE} mode=strict agent=codex " "${TMP_DIR}/prepare.stder
 grep -q "Prepared runtime image recorded for profile ${PROFILE}. No session launched because --prepare-only was requested." "${TMP_DIR}/prepare.stderr"
 
 for agent in codex claude gemini; do
+  expected_version="$(expected_runtime_version "${agent}")"
   run_agent_version_smoke "${agent}"
   grep -q "^profile=${PROFILE} mode=strict agent=${agent} " "${TMP_DIR}/${agent}.stderr"
   grep -q '^execution_path=managed-tier1 audit_log=' "${TMP_DIR}/${agent}.stderr"
   cat "${TMP_DIR}/${agent}.stdout" "${TMP_DIR}/${agent}.stderr" >"${TMP_DIR}/${agent}.combined"
   grep -q '[^[:space:]]' "${TMP_DIR}/${agent}.combined"
+  grep -Fq "${expected_version}" "${TMP_DIR}/${agent}.combined"
 done
 
 echo "Provider launch smoke scenario passed"

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -18,10 +18,33 @@ SESSION_TAMPERED="20260408T140000Z-55555555-$$"
 CLI_SESSION_FIXTURE_IMAGE="workcell-session-cli-fixture:test-$$"
 CLI_SESSION_FIXTURE_BUILD_DIR="${TMP_DIR}/session-cli-fixture-build"
 WORKCELL_FUNCTIONS_COPY="${ROOT_DIR}/scripts/.workcell-test-functions-$$"
+HOST_DOCKER_BIN=""
+
+resolve_host_docker_bin() {
+  local candidate=""
+
+  candidate="$(command -v docker 2>/dev/null || true)"
+  if [[ -x "${candidate}" ]]; then
+    printf '%s\n' "${candidate}"
+    return 0
+  fi
+  for candidate in \
+    /opt/homebrew/bin/docker \
+    /usr/local/bin/docker \
+    /Applications/Docker.app/Contents/Resources/bin/docker; do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
 
 cleanup() {
   if [[ -n "${CLI_SESSION_FIXTURE_IMAGE:-}" ]]; then
-    docker image rm -f "${CLI_SESSION_FIXTURE_IMAGE}" >/dev/null 2>&1 || true
+    if [[ -n "${HOST_DOCKER_BIN:-}" ]]; then
+      "${HOST_DOCKER_BIN}" image rm -f "${CLI_SESSION_FIXTURE_IMAGE}" >/dev/null 2>&1 || true
+    fi
   fi
   rm -f "${WORKCELL_FUNCTIONS_COPY}"
   rm -rf "${REAL_HOME}/.colima/${PROFILE}"
@@ -1628,7 +1651,7 @@ grep -q 'event=command session_id=detached-lifecycle source=host-cli command=ses
 grep -q 'event=stop-request session_id=detached-lifecycle' "${SESSION_LIFECYCLE_AUDIT_LOG}"
 grep -q 'event=exit session_id=detached-lifecycle source=host-stop-fallback exit_status=0 final_assurance=managed-mutable' "${SESSION_LIFECYCLE_AUDIT_LOG}"
 
-HOST_DOCKER_BIN="$(command -v docker || true)"
+HOST_DOCKER_BIN="$(resolve_host_docker_bin || true)"
 if [[ -n "${HOST_DOCKER_BIN}" ]]; then
   docker_server_arch="$("${HOST_DOCKER_BIN}" version --format '{{.Server.Arch}}')"
   case "${docker_server_arch}" in


### PR DESCRIPTION
## Summary
- stop Claude approved-version exceptions from forcing a future downgrade once current runtime is already newer
- make the macOS launch smoke assert the actual pinned Codex, Claude, and Gemini versions
- tighten detached-session lifecycle test plumbing so it uses trusted Docker discovery and the lifecycle fixture exits promptly on stop

## Validation
- go test ./internal/metadatautil -count=1
- bash tests/scenarios/shared/test-session-commands.sh
- bash tests/scenarios/shared/test-agent-launch-smoke.sh (local rerun hit a host Colima startup race before scenario assertions; this path remains covered by PR CI on a fresh runner)