### PR TITLE
Repair bootstrap and operator contract parity

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -41,6 +41,7 @@ All commits in this repo must use Risk-Aware Commit Notation (based on [Arlo's C
 - **One intention per commit.** Do not mix refactoring, features, bugfixes, or documentation in a single commit. If a task requires both refactoring and a feature change, split them into separate commits (refactoring first, then the feature).
 - **Minimize risk per commit.** Break work into the smallest commits that each achieve the lowest possible risk level. For example, extract a safe refactoring (`.r`) as its own commit before making a risky feature change (`!F`), rather than bundling both into one `!F` commit.
 - **Prefer many small safe commits over fewer risky ones.** A sequence like `.r` then `.r` then `^F` is better than a single `!F` that includes the refactoring.
+- **Keep workflow parity in the same change stream.** When a commit changes a user-visible Workcell workflow, support tier, help surface, contract entry, or validation evidence, land the matching `policy/operator-contract.toml`, `policy/requirements.toml`, help/doc, and test updates in the same series unless the commit message explicitly calls out the staged exception and why it is safe.
 
 ## Notation Justification in Commit Messages
 

--- a/.agents/skills/workcell-contract-parity/SKILL.md
+++ b/.agents/skills/workcell-contract-parity/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: workcell-contract-parity
+description: Keep the Workcell operator contract, docs, help text, and automated evidence in sync when user-visible workflows or compatibility aliases change. Use for CLI/help/man/README/requirements/scenario updates in the Workcell repository.
+---
+
+# Workcell Contract Parity
+
+Use this skill only for the Workcell repository at
+`/Users/omkharanarasaratnam/src/workcell`.
+
+Trigger this skill when a change touches any of:
+
+- public CLI workflows or flags
+- compatibility aliases
+- `scripts/workcell` help or remediation text
+- `policy/operator-contract.toml`
+- `policy/requirements.toml`
+- `README.md`, `man/workcell.1`, or release-facing workflow docs
+- scenario tests or validators that prove a user-visible workflow
+
+## Required context
+
+Read:
+
+- `/Users/omkharanarasaratnam/src/workcell/AGENTS.md`
+- `/Users/omkharanarasaratnam/src/workcell/policy/operator-contract.toml`
+- `/Users/omkharanarasaratnam/src/workcell/policy/requirements.toml`
+- `/Users/omkharanarasaratnam/src/workcell/docs/requirements-validation.md`
+
+When the change is release-bound, also read:
+
+- `/Users/omkharanarasaratnam/src/workcell/docs/releasing.md`
+
+## Contract rules
+
+- `policy/operator-contract.toml` is the workflow source of truth.
+- Every public workflow must have:
+  - a stable workflow id
+  - a support tier
+  - canonical syntax
+  - real discoverability surfaces
+  - repo-relative docs paths
+  - repo-relative automated evidence paths
+- Compatibility aliases must have explicit `alias_probes`, or they do not stay
+  in the contract.
+- Do not claim a discoverability surface that only falls back to generic help.
+- `policy/requirements.toml` must reference the workflow ids for the supported
+  requirement and must also cite the same docs/evidence paths.
+- Design docs are explanatory. Do not treat them as the authoritative command
+  inventory.
+
+## Workflow
+
+1. Enumerate the user-visible workflows affected by the change.
+2. Decide whether each workflow is `supported`, `compatibility-only`, or
+   `internal`.
+3. Update `policy/operator-contract.toml` first:
+   - canonical syntax
+   - alias lifecycle and alias probes
+   - discoverability
+   - docs
+   - evidence
+   - remediation text when the workflow fails closed
+4. Update `policy/requirements.toml` so the relevant requirement references the
+   workflow ids and cites the same docs/evidence paths.
+5. Update the real operator surfaces:
+   - `scripts/workcell`
+   - `README.md`
+   - `man/workcell.1`
+   - only the explanatory docs that should stay in sync
+6. Update or add the smallest test set that proves the changed workflow.
+7. Run the contract validators and the directly affected scenario/unit tests.
+
+## Validation
+
+Always run:
+
+```sh
+go run ./cmd/workcell-metadatautil validate-operator-contract . ./policy/operator-contract.toml ./policy/requirements.toml
+bash ./scripts/verify-operator-contract.sh
+```
+
+Then run the focused evidence you changed, such as:
+
+- `bash ./tests/scenarios/shared/test-session-commands.sh`
+- `bash ./tests/scenarios/shared/test-assurance-dry-run.sh`
+- `bash ./tests/scenarios/shared/test-auth-commands.sh`
+- `bash ./tests/scenarios/shared/test-auth-status.sh`
+- `bash ./tests/scenarios/shared/test-policy-commands.sh`
+- `bash ./tests/scenarios/shared/test-publish-pr-dry-run.sh`
+- `go test ./internal/metadatautil ./internal/testkit`
+
+If the contract changes broadly or release-facing docs move, finish with:
+
+```sh
+bash ./scripts/validate-repo.sh
+```
+
+## Blocking rule
+
+If a public workflow cannot point to current docs and automated evidence in the
+same change, do not leave it as implicitly supported. Either add the missing
+proof or demote the workflow or alias explicitly.

--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ Other defaults that matter:
 - `--agent-autonomy yolo` is the default; `--agent-autonomy prompt` is the
   explicit lower-assurance opt-out
 - `--cache-profile off` is the default
+- `--cache-profile standard` keeps a workspace-scoped persistent non-secret
+  cache plane for package and compiler caches, but it is an explicit
+  lower-assurance path
 - strict launches prepare the reviewed runtime image automatically when needed
 - interactive launches show a spinner with elapsed time by default; use
   `--no-spinner` to force plain heartbeat updates instead
@@ -255,6 +258,7 @@ workcell --agent codex --prepare-only --workspace /path/to/repo
 workcell --agent codex --mode development --workspace /path/to/repo -- bash -lc 'git status'
 workcell session list
 workcell session start --agent codex --workspace /path/to/repo
+workcell session delete --id SESSION_ID
 workcell session attach --id 20260408T120000Z-1a2b3c4d
 workcell session send --id 20260408T120000Z-1a2b3c4d --message "continue with tests"
 workcell session stop --id 20260408T120000Z-1a2b3c4d

--- a/cmd/workcell-metadatautil/main.go
+++ b/cmd/workcell-metadatautil/main.go
@@ -273,6 +273,11 @@ func main() {
 			die(fmt.Errorf("usage: %s validate-requirements ROOT_DIR REQUIREMENTS_PATH", os.Args[0]))
 		}
 		err = metadatautil.ValidateRequirements(os.Args[2], os.Args[3])
+	case "validate-operator-contract":
+		if len(os.Args) != 5 {
+			die(fmt.Errorf("usage: %s validate-operator-contract ROOT_DIR CONTRACT_PATH REQUIREMENTS_PATH", os.Args[0]))
+		}
+		err = metadatautil.ValidateOperatorContract(os.Args[2], os.Args[3], os.Args[4])
 	case "scan-credential-patterns":
 		if len(os.Args) != 3 {
 			die(fmt.Errorf("usage: %s scan-credential-patterns ROOT_DIR", os.Args[0]))

--- a/docs/provider-matrix.md
+++ b/docs/provider-matrix.md
@@ -26,8 +26,9 @@ boundary and one thin adapter per product.
 
 ## Validation traceability
 
-Use [docs/requirements-validation.md](requirements-validation.md) for the
-machine-checked requirement mapping and
+Use [`policy/operator-contract.toml`](../policy/operator-contract.toml) for the
+supported operator workflow surface, [docs/requirements-validation.md](requirements-validation.md)
+for the machine-checked requirement and evidence mapping, and
 [docs/validation-scenarios.md](validation-scenarios.md) for the concrete
 scenario and script anchors behind the auth and control-plane caveats.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -34,6 +34,12 @@ honestly in docs, status reports, and release commentary.
   repo already has permanent regression tests.
 - Before tagging a release, verify that release-facing documentation examples
   are still covered by existing tests or scenario lanes.
+- Before publishing or merging a release PR, verify that
+  `policy/operator-contract.toml`, `policy/requirements.toml`, `workcell --help`,
+  `man/workcell.1`, and any curated `README.md` workflow claims still agree.
+- When a release changes a user-visible workflow, run the repo-local
+  `workcell-contract-parity` skill sweep and treat any parity failure as a
+  release blocker.
 - Review any intentional upstream holdbacks or exceptions before refreshing
   pins, and document them in policy or release notes rather than carrying
   unexplained drift.
@@ -158,6 +164,9 @@ A release is not ready to merge unless all of the following are true:
   `docs/injection-policy.md`, `docs/provider-matrix.md`, and relevant
   quickstarts or setup guides, match the current implementation and auth
   maturity
+- `policy/operator-contract.toml` still points each public workflow at current
+  docs and automated evidence, and compatibility aliases still have working
+  alias probes
 - `ROADMAP.md` and nearby planning or design docs do not describe shipped work
   as future work and do not remove partially shipped work from the roadmap
 - release-sensitive runbooks such as `docs/releasing.md`,
@@ -273,6 +282,7 @@ At minimum, review:
 - `README.md`, `docs/getting-started.md`, and changed quickstarts or setup docs
 - `ROADMAP.md` plus any changed planning or system-design docs
 - changed rollout, auth-maturity, provenance, workflow, or release-runbook docs
+- `policy/operator-contract.toml` and `policy/requirements.toml`
 - any doc statement about supported hosts, CI coverage, session surfaces, auth
   maturity, or release posture that could overstate what the current code and
   validation actually prove
@@ -296,6 +306,7 @@ Run the focused validation needed to justify roadmap and documentation updates
 before committing:
 
 ```sh
+./scripts/verify-operator-contract.sh
 ./tests/scenarios/shared/test-auth-commands.sh
 ./tests/scenarios/shared/test-auth-status.sh
 ./tests/scenarios/shared/test-session-commands.sh

--- a/docs/requirements-validation.md
+++ b/docs/requirements-validation.md
@@ -1,14 +1,27 @@
 # Requirements Validation
 
-Workcell now keeps a canonical requirement-to-evidence mapping in
-[`policy/requirements.toml`](../policy/requirements.toml).
+Workcell now keeps:
+
+- a normative operator workflow contract in
+  [`policy/operator-contract.toml`](../policy/operator-contract.toml)
+- a requirement-to-doc-and-evidence mapping in
+  [`policy/requirements.toml`](../policy/requirements.toml)
 
 ## Purpose
 
-The requirements matrix does two things:
+The operator contract defines:
+
+- which public workflows are supported
+- their canonical syntax and compatibility aliases
+- where those workflows must be discoverable
+- which docs and automated evidence currently back each public workflow
+
+The requirements matrix does three things:
 
 - names the current functional and nonfunctional requirements that the repo is
   claiming as implemented
+- links functional requirements to stable workflow ids from the operator
+  contract
 - points each requirement at concrete automated evidence and supporting
   documentation
 
@@ -32,12 +45,25 @@ This is meant to reduce drift between:
   `docs/enterprise-rollout.md` when present) appear in at least one requirement
   `docs` array
 
-This check runs through the normal validation entrypoints, including
+`./scripts/verify-operator-contract.sh` validates that:
+
+- every public workflow in `policy/operator-contract.toml` is mapped to at
+  least one requirement
+- every requirement workflow reference resolves to a declared workflow id
+- every workflow-cited doc and evidence path exists and is also cited by the
+  referenced requirements
+- required help, README, and manpage surfaces contain the contract-declared
+  workflow syntax
+- compatibility aliases still pass their contract-declared alias probes
+- contract-declared remediation copy still exists in the launcher source
+
+Both checks run through the normal validation entrypoints, including
 `./scripts/dev-quick-check.sh` and `./scripts/validate-repo.sh`.
 
 ## Scope
 
-The matrix is intentionally about the supported repo contract, not every
+The requirements matrix is intentionally not the command-inventory source of
+truth. It is about traceability for the supported repo contract, not every
 possible implementation detail.
 
 It should cover:
@@ -57,10 +83,13 @@ implemented.
 
 When a supported requirement changes:
 
-1. update `policy/requirements.toml`
-2. update or add the automated evidence
-3. update the docs that explain the requirement
-4. rerun the requirement validator
+1. update `policy/operator-contract.toml` when the public workflow surface,
+   canonical syntax, discoverability, compatibility status, docs, or evidence
+   changes
+2. update `policy/requirements.toml`
+3. update or add the automated evidence
+4. update the docs that explain the requirement
+5. rerun both validators
 
 If a requirement cannot point to real automated evidence, it is not ready to be
 claimed as part of the canonical supported contract.

--- a/docs/use-case-matrix.md
+++ b/docs/use-case-matrix.md
@@ -20,7 +20,9 @@ Workcell workflows.
 | repo control-plane masking and provider-home re-seeding | tested | invariants and smoke |
 | repo-mounted validator and release-helper runs stay nonroot with explicit caller identity and isolated writable state | tested | CI, release preflight, `scripts/pre-merge.sh`, and invariant checks |
 | prompt-autonomy downgrade labeling | tested for Codex, partial elsewhere | invariants plus provider-specific coverage |
-| host-side session inventory, detached session control, log and timeline views, clean-base diff, and audit export | tested | `tests/scenarios/shared/test-session-commands.sh`, `internal/hostutil/sessions_test.go`, `cmd/workcell-hostutil/main_test.go` |
+| host-side session inventory, detached session control, delete, log and timeline views, clean-base diff, and audit export | tested | `tests/scenarios/shared/test-session-commands.sh`, `internal/hostutil/sessions_test.go`, `cmd/workcell-hostutil/main_test.go` |
+| detached-session isolated workspace preflight and direct-workspace remediation | tested | `tests/scenarios/shared/test-session-commands.sh` |
+| opt-in persistent cache plane (`--cache-profile standard`) | tested | `tests/scenarios/shared/test-assurance-dry-run.sh`, `scripts/verify-invariants.sh` |
 | bundle installer plus uninstall helper on the supported GitHub-hosted macOS matrix | tested | `scripts/verify-invariants.sh`, CI, tagged release install verification |
 | Homebrew formula install plus uninstall on the supported GitHub-hosted macOS matrix | tested | CI and tagged release install verification |
 | release-bundle reproducibility | tested | `scripts/verify-release-bundle.sh`, tagged release preflight |
@@ -33,8 +35,9 @@ Workcell workflows.
 ## Notes
 
 The most heavily tested paths are the secretless runtime boundary, explicit
-nonroot repo validation and release preflight, reproducibility, and signed
-publication. The most mature host-side operator surfaces are auth/policy
-inspection plus session inventory, detached control, timeline, and export. The
-biggest remaining gaps are local macOS boundary proof, deeper end-to-end
-live-provider coverage, and fuller lower-assurance transition coverage.
+nonroot repo validation and release preflight, reproducibility, signed
+publication, and the host-side operator plane. The most mature host-side
+operator surfaces are auth/policy inspection plus session inventory, detached
+control, delete, timeline, export, and isolated-workspace remediation. The
+biggest remaining gaps are local macOS boundary proof and deeper end-to-end
+live-provider coverage.

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -5,6 +5,8 @@ boundary or release story by itself.
 
 Use this page with:
 
+- [`policy/operator-contract.toml`](../policy/operator-contract.toml) for the
+  normative operator workflow inventory
 - [docs/use-case-matrix.md](use-case-matrix.md) for what is currently covered
 - [docs/requirements-validation.md](requirements-validation.md) for the
   machine-checked requirement-to-evidence mapping
@@ -22,7 +24,9 @@ Use these anchors when checking release-facing claims:
   `shared/claude-resolver-launcher`
 - lower-assurance mode claims: `shared/assurance-dry-run`
 - host publication handoff: `shared/publish-pr`
-- host-side session inventory and control: `shared/session-commands`
+- host-side session inventory and control plus detached workspace-mode
+  remediation: `shared/session-commands`
+- persistent cache-plane contract checks: `shared/assurance-dry-run`
 - Claude hook coverage: `claude-swe/hook-parametric`
 - supported GitHub-hosted macOS release window:
   `scripts/verify-github-macos-release-test-runners.sh`
@@ -43,8 +47,8 @@ These run without provider credentials:
 
 They cover repo shape, runtime contracts, smoke behavior, and reproducibility.
 They also now cover canonical requirement traceability, host-side policy
-inspection and explainability, and host-side detached session inventory,
-control, logs/timeline, and clean-base diff/export behavior.
+inspection and explainability, host-side detached session inventory, control,
+logs/timeline, clean-base diff/export behavior, and operator-contract parity.
 
 ## Documentation example coverage
 

--- a/docs/workcell-session-supervisor-design.md
+++ b/docs/workcell-session-supervisor-design.md
@@ -10,6 +10,10 @@ This document describes the current shipped session-supervisor slice in the
 repository and the gaps that remain without weakening the existing boundary
 model.
 
+For the supported operator inventory, treat
+[`policy/operator-contract.toml`](../policy/operator-contract.toml) plus
+`workcell --help` as authoritative. This design note is explanatory.
+
 ## Current Scope
 
 The current implementation provides durable host-side session records plus
@@ -25,12 +29,15 @@ host-side inventory, observability, and detached-control commands:
 - `workcell session attach`
 - `workcell session send`
 - `workcell session stop`
+- `workcell session delete`
 
 Each launched session writes durable metadata under the managed Colima profile
 state instead of relying only on the transient `session-audit.*` directory.
 
 Detached sessions default to `--session-workspace isolated`, so the detached
-path already points toward worktree-per-session operation on the safe path.
+path already points toward worktree-per-session operation on the safe path. The
+public CLI also supports `--session-workspace direct` when operators
+intentionally want a detached session to reuse the live workspace path.
 
 ## Data Model
 

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -271,10 +271,16 @@ surface includes:
 - `workcell session stop`
 - `workcell session list`
 - `workcell session show`
+- `workcell session delete`
 - `workcell session logs`
 - `workcell session timeline`
 - `workcell session diff`
 - `workcell session export`
+
+The supported operator inventory is maintained in
+[`policy/operator-contract.toml`](../policy/operator-contract.toml). This
+system-design doc explains shape and rationale; it should not be treated as the
+authoritative CLI inventory.
 
 Detached session records are written under the Colima profile state tree as
 `~/.colima/<profile>/sessions/<session-id>.json`. The current session record

--- a/internal/metadatautil/operator_contract.go
+++ b/internal/metadatautil/operator_contract.go
@@ -311,7 +311,7 @@ func optionalStringSlice(spec map[string]any, key string) ([]string, error) {
 		return nil, err
 	}
 	if !found {
-		return nil, nil
+		return nil, fmt.Errorf("must be an array of strings")
 	}
 	for _, item := range values {
 		if strings.TrimSpace(item) == "" {

--- a/internal/metadatautil/operator_contract.go
+++ b/internal/metadatautil/operator_contract.go
@@ -1,0 +1,673 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type operatorWorkflow struct {
+	ID              string
+	Title           string
+	Support         string
+	Canonical       string
+	Aliases         []string
+	AliasLifecycle  string
+	AliasProbes     []string
+	Discoverability []string
+	Docs            []string
+	Evidence        []string
+	Requirements    []string
+	Remediation     []string
+	TargetState     string
+}
+
+type operatorContract struct {
+	Workflows map[string]operatorWorkflow
+}
+
+type requirementTraceability struct {
+	Workflows map[string]struct{}
+	Docs      map[string]struct{}
+	Evidence  map[string]struct{}
+}
+
+func ValidateOperatorContract(rootDir, contractPath, requirementsPath string) error {
+	if err := ValidateRequirements(rootDir, requirementsPath); err != nil {
+		return err
+	}
+
+	contract, err := loadOperatorContract(contractPath)
+	if err != nil {
+		return err
+	}
+
+	requirements, err := loadRequirementTraceability(rootDir, requirementsPath)
+	if err != nil {
+		return err
+	}
+
+	for requirementID, requirement := range requirements {
+		for workflowID := range requirement.Workflows {
+			if _, ok := contract.Workflows[workflowID]; !ok {
+				return fmt.Errorf("%s requirement %s references unknown workflow %s", requirementsPath, requirementID, workflowID)
+			}
+		}
+	}
+
+	surfaces, err := loadOperatorSurfaces(rootDir, contract)
+	if err != nil {
+		return err
+	}
+
+	workcellSource, err := readText(filepath.Join(rootDir, "scripts", "workcell"))
+	if err != nil {
+		return err
+	}
+
+	publicWorkflowCovered := map[string]struct{}{}
+	workflowIDs := make([]string, 0, len(contract.Workflows))
+	for workflowID := range contract.Workflows {
+		workflowIDs = append(workflowIDs, workflowID)
+	}
+	sort.Strings(workflowIDs)
+
+	for _, workflowID := range workflowIDs {
+		workflow := contract.Workflows[workflowID]
+		if isPublicWorkflowTier(workflow.Support) && len(workflow.Requirements) == 0 {
+			return fmt.Errorf("%s workflow %s must cite at least one requirement", contractPath, workflowID)
+		}
+		if isPublicWorkflowTier(workflow.Support) && len(workflow.Docs) == 0 {
+			return fmt.Errorf("%s workflow %s must cite at least one documentation path", contractPath, workflowID)
+		}
+		if isPublicWorkflowTier(workflow.Support) && len(workflow.Evidence) == 0 {
+			return fmt.Errorf("%s workflow %s must cite at least one evidence path", contractPath, workflowID)
+		}
+
+		requirementDocs := map[string]struct{}{}
+		requirementEvidence := map[string]struct{}{}
+		for _, requirementID := range workflow.Requirements {
+			declared, ok := requirements[requirementID]
+			if !ok {
+				return fmt.Errorf("%s workflow %s references unknown requirement %s", contractPath, workflowID, requirementID)
+			}
+			if _, ok := declared.Workflows[workflowID]; !ok {
+				return fmt.Errorf("%s workflow %s must appear in %s requirement %s workflows array", contractPath, workflowID, requirementsPath, requirementID)
+			}
+			mergePathSets(requirementDocs, declared.Docs)
+			mergePathSets(requirementEvidence, declared.Evidence)
+			publicWorkflowCovered[workflowID] = struct{}{}
+		}
+
+		if err := validateWorkflowPathReferences(rootDir, contractPath, requirementsPath, workflowID, "docs", workflow.Docs, requirementDocs); err != nil {
+			return err
+		}
+		if err := validateWorkflowPathReferences(rootDir, contractPath, requirementsPath, workflowID, "evidence", workflow.Evidence, requirementEvidence); err != nil {
+			return err
+		}
+
+		for _, surface := range workflow.Discoverability {
+			content, ok := surfaces[surface]
+			if !ok {
+				return fmt.Errorf("%s workflow %s references unknown discoverability surface %s", contractPath, workflowID, surface)
+			}
+			if !strings.Contains(content, workflow.Canonical) {
+				return fmt.Errorf("%s workflow %s canonical syntax %q missing from %s", contractPath, workflowID, workflow.Canonical, surface)
+			}
+		}
+
+		for _, remediation := range workflow.Remediation {
+			if !strings.Contains(workcellSource, remediation) {
+				return fmt.Errorf("%s workflow %s remediation text %q missing from scripts/workcell", contractPath, workflowID, remediation)
+			}
+		}
+
+		if err := validateAliasProbes(rootDir, contractPath, workflowID, workflow); err != nil {
+			return err
+		}
+	}
+
+	for _, workflowID := range workflowIDs {
+		workflow := contract.Workflows[workflowID]
+		if !isPublicWorkflowTier(workflow.Support) {
+			continue
+		}
+		if _, ok := publicWorkflowCovered[workflowID]; ok {
+			continue
+		}
+		return fmt.Errorf("%s workflow %s must be mapped to at least one requirement", contractPath, workflowID)
+	}
+
+	return nil
+}
+
+func loadOperatorContract(contractPath string) (operatorContract, error) {
+	text, err := readText(contractPath)
+	if err != nil {
+		return operatorContract{}, err
+	}
+	document, err := ParseTOMLSubset(text, contractPath)
+	if err != nil {
+		return operatorContract{}, err
+	}
+
+	version, ok := document["version"].(int)
+	if !ok || version != 1 {
+		return operatorContract{}, fmt.Errorf("%s must set version = 1", contractPath)
+	}
+
+	rawWorkflows, ok := document["workflows"].(map[string]any)
+	if !ok || len(rawWorkflows) == 0 {
+		return operatorContract{}, fmt.Errorf("%s must define a non-empty [workflows] table", contractPath)
+	}
+
+	workflows := make(map[string]operatorWorkflow, len(rawWorkflows))
+	for workflowID, rawSpec := range rawWorkflows {
+		spec, ok := rawSpec.(map[string]any)
+		if !ok {
+			return operatorContract{}, fmt.Errorf("%s workflow %s must be a table", contractPath, workflowID)
+		}
+		workflow, err := parseOperatorWorkflow(contractPath, workflowID, spec)
+		if err != nil {
+			return operatorContract{}, err
+		}
+		workflows[workflowID] = workflow
+	}
+
+	return operatorContract{Workflows: workflows}, nil
+}
+
+func parseOperatorWorkflow(contractPath, workflowID string, spec map[string]any) (operatorWorkflow, error) {
+	allowedKeys := map[string]struct{}{
+		"title":           {},
+		"support":         {},
+		"canonical":       {},
+		"aliases":         {},
+		"alias_lifecycle": {},
+		"alias_probes":    {},
+		"discoverability": {},
+		"docs":            {},
+		"evidence":        {},
+		"requirements":    {},
+		"remediation":     {},
+		"target_state":    {},
+	}
+	for key := range spec {
+		if _, ok := allowedKeys[key]; !ok {
+			return operatorWorkflow{}, fmt.Errorf("%s workflow %s contains unsupported key %s", contractPath, workflowID, key)
+		}
+	}
+	if !isValidWorkflowID(workflowID) {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s must use lowercase snake_case ids", contractPath, workflowID)
+	}
+
+	title, ok := MustString(spec["title"])
+	if !ok || strings.TrimSpace(title) == "" {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s must define a non-empty title", contractPath, workflowID)
+	}
+	support, ok := MustString(spec["support"])
+	if !ok || !isAllowedOperatorSupportTier(support) {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s must define support as supported, compatibility-only, or internal", contractPath, workflowID)
+	}
+	canonical, ok := MustString(spec["canonical"])
+	if !ok || strings.TrimSpace(canonical) == "" {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s must define a non-empty canonical value", contractPath, workflowID)
+	}
+	targetState, ok := MustString(spec["target_state"])
+	if !ok || !isAllowedTargetState(targetState) {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s must define target_state as retain, deprecate, or remove", contractPath, workflowID)
+	}
+
+	aliases, err := optionalStringSlice(spec, "aliases")
+	if err != nil {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s aliases: %w", contractPath, workflowID, err)
+	}
+	aliasProbes, err := optionalStringSlice(spec, "alias_probes")
+	if err != nil {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s alias_probes: %w", contractPath, workflowID, err)
+	}
+	aliasLifecycle, ok := MustString(spec["alias_lifecycle"])
+	if len(aliases) > 0 {
+		if !ok || !isAllowedAliasLifecycle(aliasLifecycle) {
+			return operatorWorkflow{}, fmt.Errorf("%s workflow %s must define alias_lifecycle for aliases", contractPath, workflowID)
+		}
+		if len(aliasProbes) == 0 {
+			return operatorWorkflow{}, fmt.Errorf("%s workflow %s must define alias_probes for aliases", contractPath, workflowID)
+		}
+	} else if ok && strings.TrimSpace(aliasLifecycle) != "" {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s must not define alias_lifecycle without aliases", contractPath, workflowID)
+	} else if len(aliasProbes) > 0 {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s must not define alias_probes without aliases", contractPath, workflowID)
+	}
+
+	discoverability, err := optionalStringSlice(spec, "discoverability")
+	if err != nil {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s discoverability: %w", contractPath, workflowID, err)
+	}
+	for _, surface := range discoverability {
+		if err := validateDiscoverabilitySurface(surface); err != nil {
+			return operatorWorkflow{}, fmt.Errorf("%s workflow %s discoverability %s: %w", contractPath, workflowID, surface, err)
+		}
+	}
+	if support == "internal" && len(discoverability) > 0 {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s must not declare discoverability surfaces for internal workflows", contractPath, workflowID)
+	}
+
+	docs, err := optionalStringSlice(spec, "docs")
+	if err != nil {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s docs: %w", contractPath, workflowID, err)
+	}
+	evidence, err := optionalStringSlice(spec, "evidence")
+	if err != nil {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s evidence: %w", contractPath, workflowID, err)
+	}
+
+	requirements, err := optionalStringSlice(spec, "requirements")
+	if err != nil {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s requirements: %w", contractPath, workflowID, err)
+	}
+	for _, requirementID := range requirements {
+		if !strings.Contains(requirementID, ".") {
+			return operatorWorkflow{}, fmt.Errorf("%s workflow %s requirement %s must include a category prefix such as functional.FR-001", contractPath, workflowID, requirementID)
+		}
+	}
+
+	remediation, err := optionalStringSlice(spec, "remediation")
+	if err != nil {
+		return operatorWorkflow{}, fmt.Errorf("%s workflow %s remediation: %w", contractPath, workflowID, err)
+	}
+
+	return operatorWorkflow{
+		ID:              workflowID,
+		Title:           title,
+		Support:         support,
+		Canonical:       canonical,
+		Aliases:         aliases,
+		AliasLifecycle:  aliasLifecycle,
+		AliasProbes:     aliasProbes,
+		Discoverability: discoverability,
+		Docs:            docs,
+		Evidence:        evidence,
+		Requirements:    requirements,
+		Remediation:     remediation,
+		TargetState:     targetState,
+	}, nil
+}
+
+func optionalStringSlice(spec map[string]any, key string) ([]string, error) {
+	value, ok := spec[key]
+	if !ok {
+		return nil, nil
+	}
+	values, found, err := MustStringSlice(value)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+	for _, item := range values {
+		if strings.TrimSpace(item) == "" {
+			return nil, fmt.Errorf("entries may not be empty")
+		}
+	}
+	return values, nil
+}
+
+func isValidWorkflowID(workflowID string) bool {
+	for _, char := range workflowID {
+		switch {
+		case char >= 'a' && char <= 'z':
+		case char >= '0' && char <= '9':
+		case char == '_':
+		default:
+			return false
+		}
+	}
+	return workflowID != ""
+}
+
+func isAllowedOperatorSupportTier(value string) bool {
+	switch value {
+	case "supported", "compatibility-only", "internal":
+		return true
+	default:
+		return false
+	}
+}
+
+func isAllowedAliasLifecycle(value string) bool {
+	switch value {
+	case "supported", "compatibility-only", "hidden", "deprecated", "removal-candidate":
+		return true
+	default:
+		return false
+	}
+}
+
+func isAllowedTargetState(value string) bool {
+	switch value {
+	case "retain", "deprecate", "remove":
+		return true
+	default:
+		return false
+	}
+}
+
+func isPublicWorkflowTier(value string) bool {
+	return value == "supported" || value == "compatibility-only"
+}
+
+func validateDiscoverabilitySurface(surface string) error {
+	switch {
+	case surface == "top-level-help":
+		return nil
+	case surface == "readme":
+		return nil
+	case surface == "manpage":
+		return nil
+	case strings.HasPrefix(surface, "subcommand-help:"):
+		name := strings.TrimPrefix(surface, "subcommand-help:")
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("subcommand-help entries require a command name")
+		}
+		if strings.Contains(name, " ") {
+			return fmt.Errorf("subcommand-help entries support only a single command token")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported discoverability surface")
+	}
+}
+
+func loadOperatorSurfaces(rootDir string, contract operatorContract) (map[string]string, error) {
+	surfaces := map[string]string{}
+	requested := map[string]struct{}{}
+	for _, workflow := range contract.Workflows {
+		for _, surface := range workflow.Discoverability {
+			requested[surface] = struct{}{}
+		}
+	}
+
+	keys := make([]string, 0, len(requested))
+	for surface := range requested {
+		keys = append(keys, surface)
+	}
+	sort.Strings(keys)
+	for _, surface := range keys {
+		content, err := renderDiscoverabilitySurface(rootDir, surface)
+		if err != nil {
+			return nil, err
+		}
+		surfaces[surface] = content
+	}
+	return surfaces, nil
+}
+
+func renderDiscoverabilitySurface(rootDir, surface string) (string, error) {
+	switch surface {
+	case "top-level-help":
+		return runWorkcellHelp(rootDir)
+	case "readme":
+		return readText(filepath.Join(rootDir, "README.md"))
+	case "manpage":
+		return renderManpageText(filepath.Join(rootDir, "man", "workcell.1"))
+	}
+
+	if strings.HasPrefix(surface, "subcommand-help:") {
+		commandName := strings.TrimPrefix(surface, "subcommand-help:")
+		return runWorkcellHelp(rootDir, commandName)
+	}
+	return "", fmt.Errorf("unsupported discoverability surface %s", surface)
+}
+
+func runWorkcellHelp(rootDir string, args ...string) (string, error) {
+	scriptPath := workcellHelpBinary(rootDir)
+	commandArgs := append(append([]string{}, args...), "--help")
+	cmd := exec.Command(scriptPath, commandArgs...)
+	cmd.Dir = rootDir
+	cmd.Env = sanitizedScriptEnvironment(os.Environ())
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("running %s %s: %w\n%s", scriptPath, strings.Join(commandArgs, " "), err, strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
+}
+
+func renderManpageText(manpagePath string) (string, error) {
+	source, err := readText(manpagePath)
+	if err != nil {
+		return "", err
+	}
+	trimmedSource := strings.TrimSpace(source)
+	if !strings.HasPrefix(trimmedSource, ".") {
+		return source, nil
+	}
+	if _, err := exec.LookPath("mandoc"); err == nil {
+		output, renderErr := exec.Command("mandoc", "-Tascii", manpagePath).CombinedOutput()
+		if renderErr != nil {
+			return "", fmt.Errorf("rendering %s with mandoc: %w\n%s", manpagePath, renderErr, strings.TrimSpace(string(output)))
+		}
+		return stripManpageFormatting(string(output)), nil
+	}
+	if _, err := exec.LookPath("nroff"); err == nil {
+		output, renderErr := exec.Command("nroff", "-man", manpagePath).CombinedOutput()
+		if renderErr != nil {
+			return "", fmt.Errorf("rendering %s with nroff: %w\n%s", manpagePath, renderErr, strings.TrimSpace(string(output)))
+		}
+		return stripManpageFormatting(string(output)), nil
+	}
+	return source, nil
+}
+
+func stripManpageFormatting(content string) string {
+	var builder strings.Builder
+	builder.Grow(len(content))
+	for i := 0; i < len(content); i++ {
+		if i+2 < len(content) && content[i+1] == '\b' {
+			builder.WriteByte(content[i+2])
+			i += 2
+			continue
+		}
+		if content[i] == '\b' {
+			continue
+		}
+		builder.WriteByte(content[i])
+	}
+	return builder.String()
+}
+
+func sanitizedScriptEnvironment(base []string) []string {
+	filtered := make([]string, 0, len(base)+2)
+	for _, entry := range base {
+		switch {
+		case strings.HasPrefix(entry, "BASH_ENV="):
+			continue
+		case strings.HasPrefix(entry, "ENV="):
+			continue
+		default:
+			filtered = append(filtered, entry)
+		}
+	}
+	filtered = append(filtered, "BASH_ENV=", "ENV=")
+	return filtered
+}
+
+func loadRequirementTraceability(rootDir, requirementsPath string) (map[string]requirementTraceability, error) {
+	text, err := readText(requirementsPath)
+	if err != nil {
+		return nil, err
+	}
+	document, err := ParseTOMLSubset(text, requirementsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	refs := map[string]requirementTraceability{}
+	for _, category := range []string{"functional", "nonfunctional"} {
+		rawTable, ok := document[category].(map[string]any)
+		if !ok {
+			continue
+		}
+		for requirementID, rawValue := range rawTable {
+			qualifiedRequirementID := category + "." + requirementID
+			table, ok := rawValue.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("%s requirement %s must be a table", requirementsPath, qualifiedRequirementID)
+			}
+			workflows, err := optionalStringSlice(table, "workflows")
+			if err != nil {
+				return nil, fmt.Errorf("%s requirement %s workflows: %w", requirementsPath, qualifiedRequirementID, err)
+			}
+			workflowSet := map[string]struct{}{}
+			for _, workflowID := range workflows {
+				if !isValidWorkflowID(workflowID) {
+					return nil, fmt.Errorf("%s requirement %s workflow %s must use lowercase snake_case ids", requirementsPath, qualifiedRequirementID, workflowID)
+				}
+				workflowSet[workflowID] = struct{}{}
+			}
+
+			evidenceValues, _, err := MustStringSlice(table["evidence"])
+			if err != nil {
+				return nil, fmt.Errorf("%s requirement %s evidence: %w", requirementsPath, qualifiedRequirementID, err)
+			}
+			evidenceSet := map[string]struct{}{}
+			for _, path := range evidenceValues {
+				canonicalPath, err := canonicalRequirementRepoPath(rootDir, path)
+				if err != nil {
+					return nil, fmt.Errorf("%s requirement %s evidence path %s: %w", requirementsPath, qualifiedRequirementID, path, err)
+				}
+				evidenceSet[canonicalPath] = struct{}{}
+			}
+
+			docValues, _, err := MustStringSlice(table["docs"])
+			if err != nil {
+				return nil, fmt.Errorf("%s requirement %s docs: %w", requirementsPath, qualifiedRequirementID, err)
+			}
+			docSet := map[string]struct{}{}
+			for _, path := range docValues {
+				canonicalPath, err := canonicalRequirementRepoPath(rootDir, path)
+				if err != nil {
+					return nil, fmt.Errorf("%s requirement %s docs path %s: %w", requirementsPath, qualifiedRequirementID, path, err)
+				}
+				docSet[canonicalPath] = struct{}{}
+			}
+
+			refs[qualifiedRequirementID] = requirementTraceability{
+				Workflows: workflowSet,
+				Docs:      docSet,
+				Evidence:  evidenceSet,
+			}
+		}
+	}
+	return refs, nil
+}
+
+func mergePathSets(destination, source map[string]struct{}) {
+	for path := range source {
+		destination[path] = struct{}{}
+	}
+}
+
+func validateWorkflowPathReferences(rootDir, contractPath, requirementsPath, workflowID, field string, paths []string, requirementPaths map[string]struct{}) error {
+	for _, path := range paths {
+		if err := validateWorkflowPath(rootDir, contractPath, workflowID, field, path); err != nil {
+			return err
+		}
+		canonicalPath, err := canonicalRequirementRepoPath(rootDir, path)
+		if err != nil {
+			return fmt.Errorf("%s workflow %s %s path %s: %w", contractPath, workflowID, field, path, err)
+		}
+		if _, ok := requirementPaths[canonicalPath]; !ok {
+			return fmt.Errorf("%s workflow %s %s path %s must be cited by one of its referenced requirements in %s", contractPath, workflowID, field, path, requirementsPath)
+		}
+	}
+	return nil
+}
+
+func validateWorkflowPath(rootDir, contractPath, workflowID, field, path string) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("%s workflow %s %s entries may not be empty", contractPath, workflowID, field)
+	}
+	if filepath.IsAbs(path) {
+		return fmt.Errorf("%s workflow %s %s path %s must be repo-relative", contractPath, workflowID, field, path)
+	}
+
+	target, err := resolveRequirementPath(rootDir, path)
+	if err != nil {
+		return fmt.Errorf("%s workflow %s %s path %s: %w", contractPath, workflowID, field, path, err)
+	}
+	if err := rejectRequirementPathSymlinks(rootDir, target); err != nil {
+		return fmt.Errorf("%s workflow %s %s path %s: %w", contractPath, workflowID, field, path, err)
+	}
+	info, err := os.Lstat(target)
+	if err != nil {
+		return fmt.Errorf("%s workflow %s %s path %s: %w", contractPath, workflowID, field, path, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s workflow %s %s path %s must point to a file", contractPath, workflowID, field, path)
+	}
+	return nil
+}
+
+func validateAliasProbes(rootDir, contractPath, workflowID string, workflow operatorWorkflow) error {
+	for _, probe := range workflow.AliasProbes {
+		args := strings.Fields(probe)
+		if len(args) == 0 {
+			return fmt.Errorf("%s workflow %s alias_probes entries may not be empty", contractPath, workflowID)
+		}
+		output, exitCode, err := runWorkcellCommand(rootDir, args...)
+		if err != nil {
+			return fmt.Errorf("%s workflow %s alias probe %q: %w", contractPath, workflowID, probe, err)
+		}
+		if exitCode != 0 {
+			return fmt.Errorf("%s workflow %s alias probe %q exited %d\n%s", contractPath, workflowID, probe, exitCode, strings.TrimSpace(output))
+		}
+		if usagePrefix := expectedAliasProbeUsage(probe); usagePrefix != "" && !strings.Contains(output, usagePrefix) {
+			return fmt.Errorf("%s workflow %s alias probe %q output missing alias usage %q", contractPath, workflowID, probe, usagePrefix)
+		}
+		if !strings.Contains(output, workflow.Canonical) {
+			return fmt.Errorf("%s workflow %s alias probe %q output missing canonical syntax %q", contractPath, workflowID, probe, workflow.Canonical)
+		}
+	}
+	return nil
+}
+
+func expectedAliasProbeUsage(probe string) string {
+	args := strings.Fields(probe)
+	if len(args) < 2 || args[len(args)-1] != "--help" {
+		return ""
+	}
+	return "Usage: workcell " + strings.Join(args[:len(args)-1], " ")
+}
+
+func runWorkcellCommand(rootDir string, args ...string) (string, int, error) {
+	scriptPath := workcellHelpBinary(rootDir)
+	cmd := exec.Command(scriptPath, args...)
+	cmd.Dir = rootDir
+	cmd.Env = sanitizedScriptEnvironment(os.Environ())
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return string(output), 0, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return string(output), exitErr.ExitCode(), nil
+	}
+	return "", -1, fmt.Errorf("running %s %s: %w", scriptPath, strings.Join(args, " "), err)
+}
+
+func workcellHelpBinary(rootDir string) string {
+	if override := strings.TrimSpace(os.Getenv("WORKCELL_HELP_BIN")); override != "" {
+		return override
+	}
+	return filepath.Join(rootDir, "scripts", "workcell")
+}

--- a/internal/metadatautil/operator_contract_test.go
+++ b/internal/metadatautil/operator_contract_test.go
@@ -225,6 +225,34 @@ func TestLoadOperatorContractRejectsAliasesWithoutAliasProbes(t *testing.T) {
 	}
 }
 
+func TestLoadOperatorContractRejectsWrongTypedOptionalStringSlice(t *testing.T) {
+	root := t.TempDir()
+	writeOperatorContractFixture(t, root, true)
+
+	contractPath := filepath.Join(root, "policy", "operator-contract.toml")
+	contract, err := readText(contractPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract = strings.Replace(
+		contract,
+		`aliases = ["workcell logs audit|debug|file-trace|transcript"]`,
+		`aliases = "workcell logs audit|debug|file-trace|transcript"`,
+		1,
+	)
+	if err := os.WriteFile(contractPath, []byte(contract), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = loadOperatorContract(contractPath)
+	if err == nil {
+		t.Fatal("loadOperatorContract() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "aliases") || !strings.Contains(err.Error(), "array of strings") {
+		t.Fatalf("loadOperatorContract() error = %v, want typed aliases failure", err)
+	}
+}
+
 func TestStripManpageFormattingRemovesBackspaceMarkup(t *testing.T) {
 	input := "w\bwo\bor\brk\bkc\bce\bel\bll\bl\n"
 	if got := stripManpageFormatting(input); got != "workcell\n" {

--- a/internal/metadatautil/operator_contract_test.go
+++ b/internal/metadatautil/operator_contract_test.go
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateOperatorContractAcceptsCanonicalSurface(t *testing.T) {
+	root := t.TempDir()
+	writeOperatorContractFixture(t, root, true)
+
+	contractPath := filepath.Join(root, "policy", "operator-contract.toml")
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	if err := ValidateOperatorContract(root, contractPath, requirementsPath); err != nil {
+		t.Fatalf("ValidateOperatorContract() error = %v", err)
+	}
+}
+
+func TestValidateOperatorContractRejectsMissingCanonicalHelpEntry(t *testing.T) {
+	root := t.TempDir()
+	writeOperatorContractFixture(t, root, false)
+
+	contractPath := filepath.Join(root, "policy", "operator-contract.toml")
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	err := ValidateOperatorContract(root, contractPath, requirementsPath)
+	if err == nil {
+		t.Fatal("ValidateOperatorContract() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "canonical syntax") || !strings.Contains(err.Error(), "top-level-help") {
+		t.Fatalf("ValidateOperatorContract() error = %v, want top-level help parity failure", err)
+	}
+}
+
+func TestValidateOperatorContractRejectsUnknownWorkflowReference(t *testing.T) {
+	root := t.TempDir()
+	writeOperatorContractFixture(t, root, true)
+
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	if err := os.WriteFile(requirementsPath, []byte(`version = 1
+
+[functional.FR-007]
+title = "Durable session inventory"
+summary = "Workcell exposes durable detached-session inventory and control."
+workflows = ["session_commands_surface", "missing_workflow"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+docs = ["README.md", "man/workcell.1"]
+
+[nonfunctional.NFR-001]
+title = "Requirement traceability"
+summary = "Every requirement cites automated evidence."
+evidence = ["internal/example/example_test.go"]
+docs = ["README.md"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	contractPath := filepath.Join(root, "policy", "operator-contract.toml")
+	err := ValidateOperatorContract(root, contractPath, requirementsPath)
+	if err == nil {
+		t.Fatal("ValidateOperatorContract() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "references unknown workflow missing_workflow") {
+		t.Fatalf("ValidateOperatorContract() error = %v, want unknown workflow failure", err)
+	}
+}
+
+func TestValidateOperatorContractRejectsWorkflowEvidenceOutsideRequirement(t *testing.T) {
+	root := t.TempDir()
+	writeOperatorContractFixture(t, root, true)
+
+	extraEvidencePath := filepath.Join(root, "tests", "scenarios", "shared", "test-extra-session-coverage.sh")
+	if err := os.MkdirAll(filepath.Dir(extraEvidencePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(extraEvidencePath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	contractPath := filepath.Join(root, "policy", "operator-contract.toml")
+	contract, err := readText(contractPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract = strings.Replace(
+		contract,
+		`evidence = ["tests/scenarios/shared/test-session-commands.sh"]`,
+		`evidence = ["tests/scenarios/shared/test-extra-session-coverage.sh"]`,
+		1,
+	)
+	if err := os.WriteFile(contractPath, []byte(contract), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	err = ValidateOperatorContract(root, contractPath, requirementsPath)
+	if err == nil {
+		t.Fatal("ValidateOperatorContract() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "must be cited by one of its referenced requirements") {
+		t.Fatalf("ValidateOperatorContract() error = %v, want workflow evidence parity failure", err)
+	}
+}
+
+func TestValidateOperatorContractRejectsWorkflowDocsOutsideRequirement(t *testing.T) {
+	root := t.TempDir()
+	writeOperatorContractFixture(t, root, true)
+
+	extraDocPath := filepath.Join(root, "docs", "session-extra.md")
+	if err := os.MkdirAll(filepath.Dir(extraDocPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(extraDocPath, []byte("session extra\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	contractPath := filepath.Join(root, "policy", "operator-contract.toml")
+	contract, err := readText(contractPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract = strings.Replace(
+		contract,
+		`docs = ["README.md", "man/workcell.1"]`,
+		`docs = ["docs/session-extra.md"]`,
+		1,
+	)
+	if err := os.WriteFile(contractPath, []byte(contract), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	err = ValidateOperatorContract(root, contractPath, requirementsPath)
+	if err == nil {
+		t.Fatal("ValidateOperatorContract() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "must be cited by one of its referenced requirements") {
+		t.Fatalf("ValidateOperatorContract() error = %v, want workflow docs parity failure", err)
+	}
+}
+
+func TestValidateOperatorContractRejectsAliasProbeMissingCanonicalOutput(t *testing.T) {
+	root := t.TempDir()
+	writeOperatorContractFixture(t, root, true)
+
+	workcellPath := filepath.Join(root, "scripts", "workcell")
+	content, err := readText(workcellPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content = strings.Replace(
+		content,
+		`printf 'Usage: workcell logs <audit|debug|file-trace|transcript>\nCompatibility alias for: workcell --logs audit|debug|file-trace|transcript\n'`,
+		`printf 'Usage: workcell logs <audit|debug|file-trace|transcript>\nCompatibility alias for: workcell compatibility-only\n'`,
+		1,
+	)
+	if err := os.WriteFile(workcellPath, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	contractPath := filepath.Join(root, "policy", "operator-contract.toml")
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	err = ValidateOperatorContract(root, contractPath, requirementsPath)
+	if err == nil {
+		t.Fatal("ValidateOperatorContract() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "alias probe") || (!strings.Contains(err.Error(), "missing canonical syntax") && !strings.Contains(err.Error(), "missing alias usage")) {
+		t.Fatalf("ValidateOperatorContract() error = %v, want alias probe parity failure", err)
+	}
+}
+
+func TestValidateOperatorContractRejectsMissingWorkflowEvidence(t *testing.T) {
+	root := t.TempDir()
+	writeOperatorContractFixture(t, root, true)
+
+	contractPath := filepath.Join(root, "policy", "operator-contract.toml")
+	contract, err := readText(contractPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract = strings.Replace(
+		contract,
+		`evidence = ["tests/scenarios/shared/test-session-commands.sh"]`,
+		`evidence = []`,
+		1,
+	)
+	if err := os.WriteFile(contractPath, []byte(contract), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	err = ValidateOperatorContract(root, contractPath, requirementsPath)
+	if err == nil {
+		t.Fatal("ValidateOperatorContract() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "must cite at least one evidence path") {
+		t.Fatalf("ValidateOperatorContract() error = %v, want missing workflow evidence failure", err)
+	}
+}
+
+func TestLoadOperatorContractRejectsAliasesWithoutAliasProbes(t *testing.T) {
+	root := t.TempDir()
+	writeOperatorContractFixture(t, root, true)
+
+	contractPath := filepath.Join(root, "policy", "operator-contract.toml")
+	contract, err := readText(contractPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract = strings.Replace(contract, "alias_probes = [\"logs --help\"]\n", "", 1)
+	if err := os.WriteFile(contractPath, []byte(contract), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = loadOperatorContract(contractPath)
+	if err == nil {
+		t.Fatal("loadOperatorContract() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "must define alias_probes for aliases") {
+		t.Fatalf("loadOperatorContract() error = %v, want alias probe requirement failure", err)
+	}
+}
+
+func TestStripManpageFormattingRemovesBackspaceMarkup(t *testing.T) {
+	input := "w\bwo\bor\brk\bkc\bce\bel\bll\bl\n"
+	if got := stripManpageFormatting(input); got != "workcell\n" {
+		t.Fatalf("stripManpageFormatting() = %q, want %q", got, "workcell\n")
+	}
+}
+
+func writeOperatorContractFixture(t *testing.T, root string, includeDeleteInTopLevelHelp bool) {
+	t.Helper()
+
+	for _, path := range []string{
+		"README.md",
+		"man/workcell.1",
+		"tests/scenarios/shared/test-session-commands.sh",
+		"scripts/verify-invariants.sh",
+		"internal/example/example_test.go",
+	} {
+		mustWriteRequirementFixture(t, root, path)
+	}
+
+	topLevelUsage := "Usage: workcell session <start|attach|send|stop|list|show|delete|logs|timeline|diff|export> [options]\n--logs audit|debug|file-trace|transcript"
+	if !includeDeleteInTopLevelHelp {
+		topLevelUsage = "Usage: workcell session <start|attach|send|stop|list|show|logs|timeline|diff|export> [options]\n--logs audit|debug|file-trace|transcript"
+	}
+
+	workcellPath := filepath.Join(root, "scripts", "workcell")
+	if err := os.MkdirAll(filepath.Dir(workcellPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workcellPath, []byte("#!/bin/sh\nset -eu\nif [ \"$#\" -eq 1 ] && [ \"$1\" = \"--help\" ]; then\ncat <<'EOF'\n"+topLevelUsage+"\n  --session-workspace direct|isolated\nEOF\nexit 0\nfi\nif [ \"$#\" -eq 2 ] && [ \"$1\" = \"session\" ] && [ \"$2\" = \"--help\" ]; then\ncat <<'EOF'\nUsage: workcell session start [launch-options] [-- provider-args...]\n       workcell session delete --id SESSION_ID\n  --session-workspace direct|isolated\nEOF\nexit 0\nfi\nif [ \"$#\" -eq 2 ] && [ \"$1\" = \"logs\" ] && [ \"$2\" = \"--help\" ]; then\nprintf 'Usage: workcell logs <audit|debug|file-trace|transcript>\\nCompatibility alias for: workcell --logs audit|debug|file-trace|transcript\\n'\nexit 0\nfi\nprintf 'unsupported fixture invocation\\n' >&2\nexit 1\n# session start requires a clean source workspace for isolated session cloning:\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	manPath := filepath.Join(root, "man", "workcell.1")
+	if err := os.WriteFile(manPath, []byte(topLevelUsage+"\n--session-workspace direct|isolated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("workcell session delete --id SESSION_ID\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	policyDir := filepath.Join(root, "policy")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(policyDir, "requirements.toml"), []byte(`version = 1
+
+[functional.FR-007]
+title = "Durable session inventory"
+summary = "Workcell exposes durable detached-session inventory and control."
+workflows = ["session_commands_surface", "session_delete", "session_workspace_mode"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+docs = ["README.md", "man/workcell.1"]
+
+[functional.FR-006]
+title = "Host-side operator commands"
+summary = "Workcell exposes non-launch host-side operator commands."
+workflows = ["launch_logs"]
+evidence = ["scripts/verify-invariants.sh"]
+docs = ["man/workcell.1"]
+
+[nonfunctional.NFR-001]
+title = "Requirement traceability"
+summary = "Every requirement cites automated evidence."
+evidence = ["internal/example/example_test.go"]
+docs = ["README.md"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(policyDir, "operator-contract.toml"), []byte(`version = 1
+
+[workflows.session_commands_surface]
+title = "Session command surface"
+support = "supported"
+canonical = "workcell session <start|attach|send|stop|list|show|delete|logs|timeline|diff|export> [options]"
+discoverability = ["top-level-help", "manpage"]
+docs = ["man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.session_delete]
+title = "Delete durable detached sessions"
+support = "supported"
+canonical = "workcell session delete --id SESSION_ID"
+discoverability = ["subcommand-help:session", "readme"]
+docs = ["README.md", "man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.session_workspace_mode]
+title = "Detached session workspace mode"
+support = "supported"
+canonical = "--session-workspace direct|isolated"
+discoverability = ["top-level-help", "subcommand-help:session", "manpage"]
+docs = ["man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+remediation = ["session start requires a clean source workspace for isolated session cloning:"]
+target_state = "retain"
+
+[workflows.launch_logs]
+title = "Read latest profile logs"
+support = "supported"
+canonical = "--logs audit|debug|file-trace|transcript"
+aliases = ["workcell logs audit|debug|file-trace|transcript"]
+alias_lifecycle = "compatibility-only"
+alias_probes = ["logs --help"]
+discoverability = ["top-level-help", "manpage"]
+docs = ["man/workcell.1"]
+evidence = ["scripts/verify-invariants.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/metadatautil/requirements.go
+++ b/internal/metadatautil/requirements.go
@@ -167,7 +167,7 @@ func optionalRequirementWorkflows(table map[string]any) ([]string, error) {
 		return nil, err
 	}
 	if !found {
-		return nil, nil
+		return nil, fmt.Errorf("must be an array of strings")
 	}
 	for _, workflowID := range workflows {
 		if strings.TrimSpace(workflowID) == "" {

--- a/internal/metadatautil/requirements.go
+++ b/internal/metadatautil/requirements.go
@@ -80,10 +80,11 @@ func ValidateRequirements(rootDir, requirementsPath string) error {
 
 func validateRequirementTable(rootDir, requirementsPath, category, id string, table map[string]any, seenTitles map[string]struct{}, referencedDocs map[string]struct{}) error {
 	allowedKeys := map[string]struct{}{
-		"title":    {},
-		"summary":  {},
-		"evidence": {},
-		"docs":     {},
+		"title":     {},
+		"summary":   {},
+		"evidence":  {},
+		"docs":      {},
+		"workflows": {},
 	}
 	for key := range table {
 		if _, ok := allowedKeys[key]; !ok {
@@ -143,7 +144,37 @@ func validateRequirementTable(rootDir, requirementsPath, category, id string, ta
 		}
 		referencedDocs[canonicalPath] = struct{}{}
 	}
+
+	workflows, err := optionalRequirementWorkflows(table)
+	if err != nil {
+		return fmt.Errorf("%s requirement %s workflows: %w", requirementsPath, id, err)
+	}
+	for _, workflowID := range workflows {
+		if !isValidWorkflowID(workflowID) {
+			return fmt.Errorf("%s requirement %s workflow %s must use lowercase snake_case ids", requirementsPath, id, workflowID)
+		}
+	}
 	return nil
+}
+
+func optionalRequirementWorkflows(table map[string]any) ([]string, error) {
+	value, ok := table["workflows"]
+	if !ok {
+		return nil, nil
+	}
+	workflows, found, err := MustStringSlice(value)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+	for _, workflowID := range workflows {
+		if strings.TrimSpace(workflowID) == "" {
+			return nil, fmt.Errorf("entries may not be empty")
+		}
+	}
+	return workflows, nil
 }
 
 func requiredReleaseFacingDocs(rootDir string) ([]string, error) {

--- a/internal/metadatautil/requirements_test.go
+++ b/internal/metadatautil/requirements_test.go
@@ -193,6 +193,47 @@ docs = ["docs/enterprise-rollout.md"]
 	}
 }
 
+func TestValidateRequirementsRejectsWrongTypedWorkflowMetadata(t *testing.T) {
+	root := t.TempDir()
+	for _, path := range []string{
+		"README.md",
+		"scripts/verify-example.sh",
+		"internal/example/example_test.go",
+	} {
+		mustWriteRequirementFixture(t, root, path)
+	}
+
+	requirementsPath := filepath.Join(root, "policy", "requirements.toml")
+	if err := os.MkdirAll(filepath.Dir(requirementsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(requirementsPath, []byte(`version = 1
+
+[functional.FR-001]
+title = "Managed launch"
+summary = "Launch the provider inside the managed runtime."
+workflows = "session_start"
+evidence = ["scripts/verify-example.sh"]
+docs = ["README.md"]
+
+[nonfunctional.NFR-001]
+title = "Requirement traceability"
+summary = "Every requirement cites automated evidence."
+evidence = ["internal/example/example_test.go"]
+docs = ["README.md"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ValidateRequirements(root, requirementsPath)
+	if err == nil {
+		t.Fatal("ValidateRequirements() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "workflows") || !strings.Contains(err.Error(), "array of strings") {
+		t.Fatalf("ValidateRequirements() error = %v, want typed workflows failure", err)
+	}
+}
+
 func TestValidateRequirementsRejectsMissingEvidencePath(t *testing.T) {
 	root := t.TempDir()
 	mustWriteRequirementFixture(t, root, "README.md")

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -105,6 +105,46 @@ var goHelperMutations = []mutationCase{
 			Args: []string{"test", "./internal/injection"},
 		},
 	},
+	{
+		relativePath: "internal/metadatautil/operator_contract.go",
+		original:     `if isPublicWorkflowTier(workflow.Support) && len(workflow.Evidence) == 0 {`,
+		replacement:  `if false && isPublicWorkflowTier(workflow.Support) && len(workflow.Evidence) == 0 {`,
+		label:        "workflow evidence requirement",
+		command: commandSpec{
+			Path: "go",
+			Args: []string{"test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"},
+		},
+	},
+	{
+		relativePath: "internal/metadatautil/operator_contract.go",
+		original:     `if _, ok := requirementPaths[canonicalPath]; !ok {`,
+		replacement:  `if _, ok := requirementPaths[canonicalPath]; false && !ok {`,
+		label:        "workflow requirement path parity",
+		command: commandSpec{
+			Path: "go",
+			Args: []string{"test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"},
+		},
+	},
+	{
+		relativePath: "internal/metadatautil/operator_contract.go",
+		original:     `if len(aliasProbes) == 0 {`,
+		replacement:  `if false && len(aliasProbes) == 0 {`,
+		label:        "alias probe requirement",
+		command: commandSpec{
+			Path: "go",
+			Args: []string{"test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"},
+		},
+	},
+	{
+		relativePath: "internal/metadatautil/operator_contract.go",
+		original:     `if !strings.Contains(output, workflow.Canonical) {`,
+		replacement:  `if false && !strings.Contains(output, workflow.Canonical) {`,
+		label:        "alias probe canonical parity",
+		command: commandSpec{
+			Path: "go",
+			Args: []string{"test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"},
+		},
+	},
 }
 
 var rustMutations = []mutationCase{
@@ -163,7 +203,7 @@ func runGoHelperMutations(repoRoot string) error {
 			}
 			defer os.RemoveAll(tempRoot)
 
-			for _, relativePath := range []string{"cmd", "internal", "go.mod"} {
+			for _, relativePath := range []string{"cmd", "internal", "go.mod", "go.sum"} {
 				if err := copyIntoTempRoot(repoRoot, tempRoot, relativePath); err != nil {
 					results <- result{label: tc.label, err: err}
 					return

--- a/internal/testkit/security_boundary_test.go
+++ b/internal/testkit/security_boundary_test.go
@@ -115,3 +115,42 @@ resolve_workcell_real_home
 		t.Fatalf("resolve_workcell_real_home unexpectedly accepted workspace override: %q", output)
 	}
 }
+
+func TestWorkcellBootstrapResolvesRealHomeBeforeGoHostutil(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "workcell")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(content)
+
+	if strings.Contains(script, `REAL_HOME="$(go_hostutil path home)"`) {
+		t.Fatalf("%s must not resolve REAL_HOME through go_hostutil during early bootstrap", scriptPath)
+	}
+
+	realHomeIndex := strings.Index(script, `REAL_HOME="$(resolve_workcell_real_home)"`)
+	if realHomeIndex == -1 {
+		t.Fatalf("%s must resolve REAL_HOME via resolve_workcell_real_home", scriptPath)
+	}
+
+	cacheRootIndex := strings.Index(script, `export WORKCELL_GO_CACHE_ROOT=`)
+	if cacheRootIndex == -1 {
+		t.Fatalf("%s must export WORKCELL_GO_CACHE_ROOT before early go_hostutil use", scriptPath)
+	}
+	if cacheRootIndex < realHomeIndex {
+		t.Fatalf("%s exports WORKCELL_GO_CACHE_ROOT before REAL_HOME is resolved", scriptPath)
+	}
+
+	goHostutilIndex := strings.Index(script, `go_hostutil() {`)
+	if goHostutilIndex == -1 {
+		t.Fatalf("%s must define go_hostutil", scriptPath)
+	}
+	if realHomeIndex > goHostutilIndex {
+		t.Fatalf("%s resolves REAL_HOME after go_hostutil is defined; want bootstrap home resolved first", scriptPath)
+	}
+	if cacheRootIndex > goHostutilIndex {
+		t.Fatalf("%s exports WORKCELL_GO_CACHE_ROOT after go_hostutil is defined; want cache root fixed first", scriptPath)
+	}
+}

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -104,6 +104,9 @@ func TestValidationGatesLintAllScenarioShellScripts(t *testing.T) {
 		if !strings.Contains(content, "scripts/verify-requirements-coverage.sh") {
 			t.Fatalf("validation scripts must include scripts/verify-requirements-coverage.sh")
 		}
+		if !strings.Contains(content, "scripts/verify-operator-contract.sh") {
+			t.Fatalf("validation scripts must include scripts/verify-operator-contract.sh")
+		}
 		for _, want := range []string{
 			"scripts/bootstrap-dev.sh",
 			"scripts/generate-homebrew-formula.sh",
@@ -114,6 +117,7 @@ func TestValidationGatesLintAllScenarioShellScripts(t *testing.T) {
 			"scripts/uninstall.sh",
 			"scripts/update-upstream-pins.sh",
 			"scripts/verify-github-macos-release-test-runners.sh",
+			"scripts/verify-operator-contract.sh",
 		} {
 			if !strings.Contains(content, want) {
 				t.Fatalf("validation scripts must include %s", want)
@@ -147,6 +151,21 @@ func TestValidationGatesLintAllScenarioShellScripts(t *testing.T) {
 		if !strings.Contains(string(validateRepo), want) {
 			t.Fatalf("%s must lint and format %s", validateRepoPath, want)
 		}
+	}
+}
+
+func TestVerifyOperatorContractIgnoresAmbientHelpOverride(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "verify-operator-contract.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(content)
+
+	if !strings.Contains(script, "env -u WORKCELL_HELP_BIN") {
+		t.Fatalf("%s must clear WORKCELL_HELP_BIN so normal validation probes the repo script", scriptPath)
 	}
 }
 

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -9,7 +9,7 @@ workcell \- bounded runtime launcher for coding agents
 [\fIoptions\fR]
 .br
 .B workcell session
-\fIlist|show|diff|export\fR [\fIoptions\fR]
+\fIstart|attach|send|stop|list|show|delete|logs|timeline|diff|export\fR [\fIoptions\fR]
 .br
 .B workcell auth
 \fIinit|set|unset|status\fR [\fIoptions\fR]
@@ -38,12 +38,12 @@ as the exec-capable temporary directory via
 .BR TMPDIR .
 The supported host platform is Apple Silicon macOS.
 .TP
-.B workcell session list|show|diff|export
-Inspect durable host-side session records without starting the Workcell
-runtime. These records summarize completed or aborted launches, can render a
-read-only diff against the clean launch git base when one was recorded, fail
-closed when the session started dirty or lacks self-contained git metadata,
-and can be exported with the matching profile audit lines.
+.B workcell session start|attach|send|stop|list|show|delete|logs|timeline|diff|export
+Launch, control, inspect, diff, export, and delete durable detached sessions
+without starting a second Workcell runtime. Detached sessions default to an
+isolated clean git clone of the selected workspace, while the host-side
+inventory and retained-log commands operate on durable session records plus the
+matching profile audit state.
 .TP
 .B workcell policy show|validate|diff
 Inspect the merged host-side injection policy without starting the runtime.
@@ -272,6 +272,17 @@ to make the lower-assurance control-plane Git lane explicit.
 .B --workspace PATH
 Select the workspace to mount inside the runtime. The default is the current
 directory.
+.TP
+.B --session-workspace direct|isolated
+Select how
+.B workcell session start
+maps the detached workspace. The default is
+.BR isolated ,
+which requires a clean self-contained git workspace and creates a session-owned
+clone. Use
+.BR direct
+when you intentionally want the detached session to reuse the current workspace
+path in place.
 .TP
 .B --allow-nongit-workspace
 Allow a non-git workspace that contains an explicit agent marker file.
@@ -573,6 +584,22 @@ Viewing the latest retained host logs for a profile:
 .EX
 workcell --agent codex --workspace /path/to/repo --logs audit
 workcell --agent codex --workspace /path/to/repo --logs debug
+.EE
+.PP
+Detached session lifecycle on the host:
+.IP
+.EX
+workcell session start --agent codex --workspace /path/to/repo
+workcell session list
+workcell session show --id SESSION_ID
+workcell session delete --id SESSION_ID
+.EE
+.PP
+Use direct detached workspace mode when you intentionally want to keep the
+session on the live workspace path instead of a clean session-owned clone:
+.IP
+.EX
+workcell session start --session-workspace direct --agent codex --workspace /path/to/repo
 .EE
 .PP
 Prompted launch for a selected provider:

--- a/policy/operator-contract.toml
+++ b/policy/operator-contract.toml
@@ -1,0 +1,361 @@
+version = 1
+
+[workflows.launch_managed]
+title = "Managed provider launch"
+support = "supported"
+canonical = "workcell --agent codex --workspace /path/to/repo"
+discoverability = ["top-level-help", "readme"]
+docs = ["README.md", "docs/provider-matrix.md"]
+evidence = ["tests/scenarios/shared/test-assurance-dry-run.sh", "scripts/container-smoke.sh"]
+requirements = ["functional.FR-001"]
+target_state = "retain"
+
+[workflows.prepare_image]
+title = "Explicit image prepare"
+support = "supported"
+canonical = "--prepare"
+discoverability = ["top-level-help", "readme", "manpage"]
+docs = ["README.md", "man/workcell.1"]
+evidence = ["scripts/verify-invariants.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.prepare_only]
+title = "Prepare without launch"
+support = "supported"
+canonical = "--prepare-only"
+discoverability = ["top-level-help", "readme", "manpage"]
+docs = ["README.md", "man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-agent-launch-smoke.sh", "scripts/verify-invariants.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.repair_profile]
+title = "Repair unmanaged profile state"
+support = "supported"
+canonical = "--repair-profile"
+discoverability = ["top-level-help", "manpage"]
+docs = ["man/workcell.1", "docs/validation-scenarios.md"]
+evidence = ["scripts/verify-invariants.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.publish_pr]
+title = "Host-side PR publication"
+support = "supported"
+canonical = "workcell publish-pr"
+discoverability = ["top-level-help", "subcommand-help:publish-pr", "readme", "manpage"]
+docs = ["README.md", "man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-publish-pr-dry-run.sh"]
+requirements = ["functional.FR-005"]
+target_state = "retain"
+
+[workflows.auth_commands_surface]
+title = "Auth command surface"
+support = "supported"
+canonical = "workcell auth"
+discoverability = ["top-level-help", "manpage"]
+docs = ["README.md", "man/workcell.1", "docs/injection-policy.md"]
+evidence = ["tests/scenarios/shared/test-auth-commands.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.auth_init]
+title = "Initialize auth policy"
+support = "supported"
+canonical = "workcell auth init [options]"
+discoverability = ["subcommand-help:auth"]
+docs = ["docs/injection-policy.md"]
+evidence = ["tests/scenarios/shared/test-auth-commands.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.auth_set]
+title = "Set auth material"
+support = "supported"
+canonical = "workcell auth set [options]"
+discoverability = ["subcommand-help:auth"]
+docs = ["docs/injection-policy.md"]
+evidence = ["tests/scenarios/shared/test-auth-commands.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.auth_unset]
+title = "Unset auth material"
+support = "supported"
+canonical = "workcell auth unset [options]"
+discoverability = ["subcommand-help:auth"]
+docs = ["docs/injection-policy.md"]
+evidence = ["tests/scenarios/shared/test-auth-commands.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.auth_status]
+title = "Inspect auth policy state"
+support = "supported"
+canonical = "workcell auth status [options]"
+discoverability = ["subcommand-help:auth"]
+docs = ["README.md", "docs/injection-policy.md"]
+evidence = ["tests/scenarios/shared/test-auth-commands.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.policy_commands_surface]
+title = "Policy command surface"
+support = "supported"
+canonical = "workcell policy"
+discoverability = ["top-level-help", "manpage"]
+docs = ["README.md", "man/workcell.1", "docs/injection-policy.md"]
+evidence = ["tests/scenarios/shared/test-policy-commands.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.policy_show]
+title = "Render merged policy"
+support = "supported"
+canonical = "workcell policy show [options]"
+discoverability = ["subcommand-help:policy"]
+docs = ["docs/injection-policy.md"]
+evidence = ["tests/scenarios/shared/test-policy-commands.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.policy_validate]
+title = "Validate merged policy"
+support = "supported"
+canonical = "workcell policy validate [options]"
+discoverability = ["subcommand-help:policy"]
+docs = ["docs/injection-policy.md"]
+evidence = ["tests/scenarios/shared/test-policy-commands.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.policy_diff]
+title = "Diff current and canonical policy"
+support = "supported"
+canonical = "workcell policy diff [options]"
+discoverability = ["subcommand-help:policy"]
+docs = ["docs/injection-policy.md"]
+evidence = ["tests/scenarios/shared/test-policy-commands.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.why_credential]
+title = "Explain credential selection"
+support = "supported"
+canonical = "workcell why"
+discoverability = ["top-level-help", "readme", "manpage"]
+docs = ["README.md", "man/workcell.1", "docs/injection-policy.md"]
+evidence = ["tests/scenarios/shared/test-policy-commands.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.session_commands_surface]
+title = "Session command surface"
+support = "supported"
+canonical = "workcell session"
+discoverability = ["top-level-help", "manpage"]
+docs = ["man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.session_start]
+title = "Start detached session"
+support = "supported"
+canonical = "workcell session start"
+discoverability = ["top-level-help", "subcommand-help:session", "readme"]
+docs = ["README.md", "man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.session_workspace_mode]
+title = "Detached session workspace mode"
+support = "supported"
+canonical = "--session-workspace direct|isolated"
+discoverability = ["top-level-help", "subcommand-help:session", "manpage"]
+docs = ["man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+remediation = [
+  "session start requires a git workspace when --session-workspace isolated is selected:",
+  "This workspace is a linked worktree: its .git file points to a .git directory outside the mounted path.",
+  "session start requires a clean source workspace for isolated session cloning:",
+]
+target_state = "retain"
+
+[workflows.session_attach]
+title = "Attach to detached session"
+support = "supported"
+canonical = "workcell session attach --id SESSION_ID"
+discoverability = ["subcommand-help:session"]
+docs = ["man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.session_send]
+title = "Send input to detached session"
+support = "supported"
+canonical = "workcell session send --id SESSION_ID --message TEXT"
+discoverability = ["subcommand-help:session"]
+docs = ["man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.session_stop]
+title = "Stop detached session"
+support = "supported"
+canonical = "workcell session stop --id SESSION_ID [--force]"
+discoverability = ["subcommand-help:session"]
+docs = ["man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.session_list]
+title = "List durable session records"
+support = "supported"
+canonical = "workcell session list"
+discoverability = ["top-level-help", "subcommand-help:session", "readme"]
+docs = ["README.md", "man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.session_show]
+title = "Show one durable session record"
+support = "supported"
+canonical = "workcell session show --id SESSION_ID"
+discoverability = ["top-level-help", "subcommand-help:session"]
+docs = ["man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.session_logs]
+title = "Read retained session logs"
+support = "supported"
+canonical = "workcell session logs --id SESSION_ID --kind audit|debug|file-trace|transcript"
+discoverability = ["subcommand-help:session"]
+docs = ["man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.session_timeline]
+title = "Read retained session audit timeline"
+support = "supported"
+canonical = "workcell session timeline --id SESSION_ID"
+discoverability = ["subcommand-help:session"]
+docs = ["man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.session_diff]
+title = "Diff session workspace against launch base"
+support = "supported"
+canonical = "workcell session diff"
+discoverability = ["subcommand-help:session", "readme"]
+docs = ["README.md", "man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.session_export]
+title = "Export durable session record"
+support = "supported"
+canonical = "workcell session export --id SESSION_ID [--output PATH]"
+discoverability = ["subcommand-help:session"]
+docs = ["man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.session_delete]
+title = "Delete durable detached session"
+support = "supported"
+canonical = "workcell session delete --id SESSION_ID"
+discoverability = ["top-level-help", "subcommand-help:session", "manpage"]
+docs = ["README.md", "man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
+[workflows.launch_doctor]
+title = "Host-side doctor"
+support = "supported"
+canonical = "--doctor"
+aliases = ["workcell doctor"]
+alias_lifecycle = "compatibility-only"
+alias_probes = ["doctor --help"]
+discoverability = ["top-level-help", "readme", "manpage"]
+docs = ["README.md", "man/workcell.1"]
+evidence = ["scripts/verify-invariants.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.launch_inspect]
+title = "Host-side inspect"
+support = "supported"
+canonical = "--inspect"
+aliases = ["workcell inspect"]
+alias_lifecycle = "compatibility-only"
+alias_probes = ["inspect --help"]
+discoverability = ["top-level-help", "readme", "manpage"]
+docs = ["README.md", "man/workcell.1"]
+evidence = ["scripts/verify-invariants.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.launch_logs]
+title = "Read latest profile logs"
+support = "supported"
+canonical = "--logs audit|debug|file-trace|transcript"
+aliases = ["workcell logs audit|debug|file-trace|transcript"]
+alias_lifecycle = "compatibility-only"
+alias_probes = ["logs --help"]
+discoverability = ["top-level-help", "manpage"]
+docs = ["man/workcell.1"]
+evidence = ["scripts/verify-invariants.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.launch_auth_status]
+title = "Inspect launch auth posture"
+support = "supported"
+canonical = "--auth-status"
+aliases = ["workcell auth-status"]
+alias_lifecycle = "compatibility-only"
+alias_probes = ["auth-status --help"]
+discoverability = ["top-level-help", "readme", "manpage"]
+docs = ["README.md", "man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-auth-status.sh", "scripts/verify-invariants.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.launch_gc]
+title = "Clean stale local state"
+support = "supported"
+canonical = "--gc"
+aliases = ["workcell gc"]
+alias_lifecycle = "compatibility-only"
+alias_probes = ["gc --help"]
+discoverability = ["top-level-help", "manpage"]
+docs = ["man/workcell.1"]
+evidence = ["scripts/verify-invariants.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
+[workflows.cache_profile_standard]
+title = "Opt-in persistent cache plane"
+support = "supported"
+canonical = "--cache-profile off|standard"
+discoverability = ["top-level-help", "manpage"]
+docs = ["docs/invariants.md", "man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-assurance-dry-run.sh"]
+requirements = ["functional.FR-009"]
+target_state = "retain"

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -3,6 +3,7 @@ version = 1
 [functional.FR-001]
 title = "Managed provider launch"
 summary = "Workcell launches supported providers directly inside the managed Tier 1 runtime without a separate attach step."
+workflows = ["launch_managed"]
 evidence = [
   "scripts/container-smoke.sh",
   "scripts/verify-invariants.sh",
@@ -65,6 +66,7 @@ docs = [
 [functional.FR-005]
 title = "Host-side publication handoff"
 summary = "Final branch publication remains a host-side action with signed commits and repo hook bypasses handled outside Tier 1."
+workflows = ["publish_pr"]
 evidence = [
   "tests/scenarios/shared/test-publish-pr-dry-run.sh",
   "scripts/verify-invariants.sh",
@@ -77,12 +79,35 @@ docs = [
 
 [functional.FR-006]
 title = "Host-side operator commands"
-summary = "Inspect, doctor, logs, gc, auth/policy explainability, and session management run on the host without starting the runtime."
+summary = "Prepare, repair, inspect, doctor, latest-log retrieval, auth/policy explainability, and other host-side operator commands run without starting the runtime."
+workflows = [
+  "prepare_image",
+  "prepare_only",
+  "repair_profile",
+  "auth_commands_surface",
+  "auth_init",
+  "auth_set",
+  "auth_unset",
+  "auth_status",
+  "policy_commands_surface",
+  "policy_show",
+  "policy_validate",
+  "policy_diff",
+  "why_credential",
+  "launch_doctor",
+  "launch_inspect",
+  "launch_logs",
+  "launch_auth_status",
+  "launch_gc",
+]
 evidence = [
   "scripts/verify-invariants.sh",
   "internal/testkit/validation_entrypoints_test.go",
   "tests/scenarios/shared/test-policy-commands.sh",
   "internal/authpolicy/manage_test.go",
+  "tests/scenarios/shared/test-auth-commands.sh",
+  "tests/scenarios/shared/test-auth-status.sh",
+  "tests/scenarios/shared/test-agent-launch-smoke.sh",
 ]
 docs = [
   "README.md",
@@ -92,14 +117,30 @@ docs = [
 ]
 
 [functional.FR-007]
-title = "Durable session inventory"
-summary = "Workcell records durable host-side launch metadata and exposes list, show, clean-base diff, and export commands for recorded sessions."
+title = "Durable detached session control"
+summary = "Workcell records durable host-side launch metadata and exposes detached session start, control, inspection, retained logs, diff, export, and delete commands."
+workflows = [
+  "session_commands_surface",
+  "session_start",
+  "session_workspace_mode",
+  "session_attach",
+  "session_send",
+  "session_stop",
+  "session_list",
+  "session_show",
+  "session_logs",
+  "session_timeline",
+  "session_diff",
+  "session_export",
+  "session_delete",
+]
 evidence = [
   "tests/scenarios/shared/test-session-commands.sh",
   "internal/hostutil/sessions_test.go",
 ]
 docs = [
   "README.md",
+  "man/workcell.1",
   "docs/workcell-session-supervisor-design.md",
   "docs/workcell-system-design.md",
 ]
@@ -115,6 +156,19 @@ docs = [
   "README.md",
   "docs/getting-started.md",
   "SUPPORT.md",
+]
+
+[functional.FR-009]
+title = "Opt-in persistent cache plane"
+summary = "Workcell can mount a clearly labeled lower-assurance persistent non-secret cache plane when operators select --cache-profile standard."
+workflows = ["cache_profile_standard"]
+evidence = [
+  "tests/scenarios/shared/test-assurance-dry-run.sh",
+  "scripts/verify-invariants.sh",
+]
+docs = [
+  "docs/invariants.md",
+  "man/workcell.1",
 ]
 
 [nonfunctional.NFR-001]

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "f67e368f70e07125f08f9efb25a8094f663db8745bac22b7bba640e366263930"
+      "sha256": "477772384ad2055c2939cc3a2c07ea0cc68aabe0f2e6135d0f56ca3409ad3c65"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "477772384ad2055c2939cc3a2c07ea0cc68aabe0f2e6135d0f56ca3409ad3c65"
+      "sha256": "c600eed5920b359a31c1b60284b64d4dcc7de5dcacc1ba1ea8d2488a28354d92"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/scripts/dev-quick-check.sh
+++ b/scripts/dev-quick-check.sh
@@ -46,6 +46,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/generate-homebrew-formula.sh"
   "${ROOT_DIR}/scripts/update-upstream-pins.sh"
   "${ROOT_DIR}/scripts/verify-github-macos-release-test-runners.sh"
+  "${ROOT_DIR}/scripts/verify-operator-contract.sh"
   "${ROOT_DIR}/scripts/verify-requirements-coverage.sh"
   "${ROOT_DIR}/runtime/container/bin/apt-helper.sh"
   "${ROOT_DIR}/runtime/container/bin/apt-wrapper.sh"
@@ -75,6 +76,7 @@ fi
 go vet ./...
 go test ./...
 "${ROOT_DIR}/scripts/verify-requirements-coverage.sh"
+"${ROOT_DIR}/scripts/verify-operator-contract.sh"
 
 (
   cd "${ROOT_DIR}/runtime/container/rust"

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -157,6 +157,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/verify-github-macos-release-test-runners.sh"
   "${ROOT_DIR}/scripts/verify-release-bundle.sh"
   "${ROOT_DIR}/scripts/verify-invariants.sh"
+  "${ROOT_DIR}/scripts/verify-operator-contract.sh"
   "${ROOT_DIR}/scripts/verify-requirements-coverage.sh"
   "${ROOT_DIR}/scripts/verify-reproducible-build.sh"
   "${ROOT_DIR}/scripts/verify-upstream-codex-release.sh"
@@ -274,6 +275,7 @@ yamllint -d "{extends: default, rules: {comments: disable, document-start: disab
 
 "${ROOT_DIR}/scripts/verify-build-input-manifest.sh"
 "${ROOT_DIR}/scripts/verify-control-plane-manifest.sh"
+"${ROOT_DIR}/scripts/verify-operator-contract.sh"
 "${ROOT_DIR}/scripts/verify-requirements-coverage.sh"
 
 doc_files=()

--- a/scripts/verify-coverage.sh
+++ b/scripts/verify-coverage.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RUST_MIN_COVERAGE="${WORKCELL_RUST_COVERAGE_MIN:-90}"
+GO_METADATAUTIL_MIN_COVERAGE="${WORKCELL_GO_METADATAUTIL_COVERAGE_MIN:-56}"
 REQUIRE_SUPPORTED_COVERAGE="${WORKCELL_REQUIRE_SUPPORTED_COVERAGE:-0}"
 
 require_tool() {
@@ -94,6 +95,28 @@ run_rust_launcher_coverage() {
   (cd "${ROOT_DIR}" && go run ./cmd/workcell-metadatautil coverage-percent "${export_file}" "${RUST_MIN_COVERAGE}" "Rust launcher coverage")
 }
 
+run_go_metadatautil_coverage() {
+  local cover_file="${TMP_ROOT}/go-metadatautil.cover"
+  local summary=""
+
+  (
+    cd "${ROOT_DIR}"
+    go test -coverprofile="${cover_file}" ./internal/metadatautil >/dev/null
+  )
+
+  summary="$(go tool cover -func="${cover_file}" | awk '/^total:/ {gsub(/%/, "", $3); print $3}')"
+  if [[ -z "${summary}" ]]; then
+    echo "Unable to determine Go metadatautil coverage." >&2
+    exit 1
+  fi
+
+  if ! awk -v got="${summary}" -v min="${GO_METADATAUTIL_MIN_COVERAGE}" 'BEGIN { exit !(got + 0 >= min + 0) }'; then
+    echo "Go metadatautil coverage ${summary}% is below ${GO_METADATAUTIL_MIN_COVERAGE}%." >&2
+    exit 1
+  fi
+}
+
 run_rust_launcher_coverage
+run_go_metadatautil_coverage
 
 echo "Workcell supported coverage verification passed."

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1334,6 +1334,16 @@ if ! grep -q -- '--agent-arg VALUE' /tmp/workcell-installed-help.out; then
   exit 1
 fi
 
+if ! WORKCELL_HELP_BIN="${INSTALL_VERIFY_HOME}/.local/bin/workcell" \
+  go run ./cmd/workcell-metadatautil validate-operator-contract \
+  "${ROOT_DIR}" \
+  "${ROOT_DIR}/policy/operator-contract.toml" \
+  "${ROOT_DIR}/policy/requirements.toml" >/tmp/workcell-installed-operator-contract.out 2>&1; then
+  echo "Expected installed ~/.local/bin/workcell help surfaces to satisfy the operator contract" >&2
+  cat /tmp/workcell-installed-operator-contract.out >&2
+  exit 1
+fi
+
 if ! grep -q -- '--container-mutability ephemeral|readonly' /tmp/workcell-installed-help.out; then
   echo "Expected installed ~/.local/bin/workcell --help to describe --container-mutability" >&2
   exit 1
@@ -3889,6 +3899,23 @@ grep -q 'cache_assurance=managed-no-persistent-cache' /tmp/workcell-dry-run-no-i
 
 if ! "${ROOT_DIR}/scripts/workcell" \
   --agent codex \
+  --cache-profile standard \
+  --no-default-injection-policy \
+  --allow-nongit-workspace \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}" \
+  --dry-run >/tmp/workcell-dry-run-cache-standard.out 2>&1; then
+  echo "Expected strict dry-run with persistent cache mode to work without a prepared image marker" >&2
+  cat /tmp/workcell-dry-run-cache-standard.out >&2
+  exit 1
+fi
+grep -q 'cache_profile=standard' /tmp/workcell-dry-run-cache-standard.out
+grep -q 'cache_assurance=lower-assurance-persistent-cache' /tmp/workcell-dry-run-cache-standard.out
+grep -Eq -- "-v .+/workcell/cache/codex/.+/go-mod:/state/cache/go-mod($| )" /tmp/workcell-dry-run-cache-standard.out
+grep -q -- '-e XDG_CACHE_HOME=/state/cache/xdg' /tmp/workcell-dry-run-cache-standard.out
+
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
   --no-default-injection-policy \
   --allow-nongit-workspace \
   --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
@@ -3905,6 +3932,20 @@ grep -q '^provider_native_sandbox_configured=disabled$' /tmp/workcell-inspect.ou
 grep -q '^provider_native_sandbox_effective=disabled$' /tmp/workcell-inspect.out
 grep -q '^provider_native_sandbox_reason=workcell-pinned-off-due-to-bwrap-userns-incompatibility$' /tmp/workcell-inspect.out
 grep -q '^injection_policy=none$' /tmp/workcell-inspect.out
+if ! "${ROOT_DIR}/scripts/workcell" \
+  --agent codex \
+  --cache-profile standard \
+  --no-default-injection-policy \
+  --allow-nongit-workspace \
+  --workspace "${STRICT_PREFLIGHT_WORKSPACE}" \
+  --colima-profile "${STRICT_PREFLIGHT_PROFILE}" \
+  --inspect >/tmp/workcell-inspect-cache-standard.out 2>&1; then
+  echo "Expected --inspect with persistent cache mode to succeed without launching the runtime" >&2
+  exit 1
+fi
+grep -q '^cache_profile=standard$' /tmp/workcell-inspect-cache-standard.out
+grep -q '^cache_assurance=lower-assurance-persistent-cache$' /tmp/workcell-inspect-cache-standard.out
+grep -q '^profile='"${STRICT_PREFLIGHT_PROFILE}"'$' /tmp/workcell-inspect-cache-standard.out
 if ! "${ROOT_DIR}/scripts/workcell" \
   inspect \
   --agent codex \

--- a/scripts/verify-operator-contract.sh
+++ b/scripts/verify-operator-contract.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
+  echo "verify-operator-contract-entrypoint-ok"
+  exit 0
+fi
+
+(
+  cd "${ROOT_DIR}"
+  env -u WORKCELL_HELP_BIN \
+    go run ./cmd/workcell-metadatautil validate-operator-contract \
+    "${ROOT_DIR}" \
+    "${ROOT_DIR}/policy/operator-contract.toml" \
+    "${ROOT_DIR}/policy/requirements.toml"
+)
+
+echo "Operator contract verification passed"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -145,6 +145,15 @@ run_clean_host_command_in_dir() {
 }
 
 HOST_GO_BIN="$(resolve_fixed_host_tool go /opt/homebrew/bin/go /usr/local/go/bin/go /usr/local/bin/go /usr/bin/go)"
+REAL_HOME="$(resolve_workcell_real_home)"
+case "$(uname -s 2>/dev/null || true)" in
+  Darwin)
+    export WORKCELL_GO_CACHE_ROOT="${REAL_HOME}/Library/Caches/workcell/go"
+    ;;
+  *)
+    export WORKCELL_GO_CACHE_ROOT="${XDG_CACHE_HOME:-${REAL_HOME}/.cache}/workcell/go"
+    ;;
+esac
 go_hostutil() {
   ensure_go_run_env
   run_clean_host_command_in_dir "${ROOT_DIR}" env \
@@ -172,7 +181,6 @@ go_runtimeutil() {
     "${HOST_GO_BIN}" run ./cmd/workcell-runtimeutil "$@"
 }
 
-REAL_HOME="$(go_hostutil path home)"
 HOST_GIT_BIN=""
 HOST_COLIMA_BIN=""
 HOST_DOCKER_BIN=""
@@ -220,7 +228,7 @@ usage() {
   cat <<'EOF'
 Usage: workcell [options] [-- provider-args...]
        workcell publish-pr [options]
-       workcell session <start|attach|send|stop|list|show|logs|timeline|diff|export> [options]
+       workcell session <start|attach|send|stop|list|show|delete|logs|timeline|diff|export> [options]
        workcell auth <init|set|unset|status> [options]
        workcell policy <show|validate|diff> [options]
        workcell why --credential KEY --agent NAME [options]
@@ -259,7 +267,8 @@ Options:
   --ack-breakglass              Required with --mode breakglass
   --ack-arbitrary-command       Required with --allow-arbitrary-command
   --workspace PATH              Workspace to mount (default: current directory)
-  --session-workspace MODE      direct or isolated session workspace flow
+  --session-workspace direct|isolated
+                                Detached session workspace flow for session start
   --allow-nongit-workspace      Allow a non-git workspace only when it contains an explicit agent marker
   --allow-control-plane-vcs     Allow readonly Git VCS visibility for masked workspace control-plane paths
   --allow-arbitrary-command     Launch the runtime image with an explicit command after -- on the managed entrypoint
@@ -304,18 +313,19 @@ Workflows:
     workcell why --credential codex_auth --agent codex --mode strict
     workcell session list
     workcell session start --agent codex --workspace /path/to/repo
-    workcell session attach --id 20260408T120000Z-1a2b3c4d
-    workcell session send --id 20260408T120000Z-1a2b3c4d --message 'continue with tests'
-    workcell session stop --id 20260408T120000Z-1a2b3c4d
-    workcell session show --id 20260408T120000Z-1a2b3c4d
-    workcell session logs --id 20260408T120000Z-1a2b3c4d --kind audit
-    workcell session timeline --id 20260408T120000Z-1a2b3c4d
-    workcell session diff --id 20260408T120000Z-1a2b3c4d
-    workcell session export --id 20260408T120000Z-1a2b3c4d
+    workcell session attach --id SESSION_ID
+    workcell session send --id SESSION_ID --message 'continue with tests'
+    workcell session stop --id SESSION_ID
+    workcell session show --id SESSION_ID
+    workcell session delete --id SESSION_ID
+    workcell session logs --id SESSION_ID --kind audit
+    workcell session timeline --id SESSION_ID
+    workcell session diff --id SESSION_ID
+    workcell session export --id SESSION_ID
     workcell --agent codex --inspect --workspace /path/to/repo
     workcell --agent codex --doctor --workspace /path/to/repo
-    workcell logs debug --colima-profile wcl-...
-    workcell logs file-trace --colima-profile wcl-...
+    workcell --logs debug --colima-profile wcl-...
+    workcell --logs file-trace --colima-profile wcl-...
     workcell --agent codex --auth-status --workspace /path/to/repo
     workcell publish-pr --workspace /path/to/repo --branch feature/name \
       --title-file /path/to/pr-title.txt --body-file /path/to/pr-body.md \
@@ -327,6 +337,50 @@ There is no separate container attach/connect step after launch.
 Host-persisted debug logs, session file traces, and full transcripts are
 explicit lower-assurance operator choices and remain off by default.
 EOF
+}
+
+compatibility_alias_usage() {
+  case "$1" in
+    doctor)
+      cat <<'EOF'
+Usage: workcell doctor [launch-options]
+Compatibility alias for: workcell --doctor
+See workcell --help for the full launch-option list.
+EOF
+      ;;
+    inspect)
+      cat <<'EOF'
+Usage: workcell inspect [launch-options]
+Compatibility alias for: workcell --inspect
+See workcell --help for the full launch-option list.
+EOF
+      ;;
+    logs)
+      cat <<'EOF'
+Usage: workcell logs <audit|debug|file-trace|transcript> [launch-options]
+Compatibility alias for: workcell --logs audit|debug|file-trace|transcript
+See workcell --help for the full launch-option list.
+EOF
+      ;;
+    auth-status)
+      cat <<'EOF'
+Usage: workcell auth-status [launch-options]
+Compatibility alias for: workcell --auth-status
+See workcell --help for the full launch-option list.
+EOF
+      ;;
+    gc)
+      cat <<'EOF'
+Usage: workcell gc [launch-options]
+Compatibility alias for: workcell --gc
+See workcell --help for the full launch-option list.
+EOF
+      ;;
+    *)
+      echo "Unsupported compatibility alias: $1" >&2
+      exit 2
+      ;;
+  esac
 }
 
 slugify() {
@@ -1048,18 +1102,7 @@ create_isolated_session_workspace() {
   local target=""
   local branch_name=""
 
-  workspace_is_git_worktree "${source_workspace}" || {
-    echo "session start requires a git workspace when --session-workspace isolated is selected: ${source_workspace}" >&2
-    exit 2
-  }
-  if ! workspace_gitdir_is_self_contained "${source_workspace}"; then
-    echo "session start requires a self-contained git workspace for isolated session cloning: ${source_workspace}" >&2
-    exit 2
-  fi
-  if workspace_git_has_worktree_changes "${source_workspace}"; then
-    echo "session start requires a clean source workspace for isolated session cloning: ${source_workspace}" >&2
-    exit 2
-  fi
+  validate_isolated_session_workspace_source "${source_workspace}"
 
   base_ref="$(run_workspace_safe_git_command_in_dir "${source_workspace}" rev-parse --verify HEAD)"
   target="$(isolated_session_workspace_path "${source_workspace}" "${session_id}")"
@@ -1077,6 +1120,26 @@ create_isolated_session_workspace() {
   run_clean_host_command_in_dir "${ROOT_DIR}" "${HOST_GIT_BIN}" clone --quiet --no-hardlinks "${source_workspace}" "${target}"
   run_workspace_safe_git_command_in_dir "${target}" checkout --quiet -B "${branch_name}" "${base_ref}"
   printf '%s\n' "${target}"
+}
+
+validate_isolated_session_workspace_source() {
+  local source_workspace="$1"
+
+  workspace_is_git_worktree "${source_workspace}" || {
+    echo "session start requires a git workspace when --session-workspace isolated is selected: ${source_workspace}" >&2
+    echo "Next step: rerun with --session-workspace direct if you want to use the current workspace in place." >&2
+    exit 2
+  }
+  if ! workspace_gitdir_is_self_contained "${source_workspace}"; then
+    echo "session start requires a self-contained git workspace for isolated session cloning: ${source_workspace}" >&2
+    echo "Next step: rerun with --session-workspace direct if you want to use the current workspace in place." >&2
+    exit 2
+  fi
+  if workspace_git_has_worktree_changes "${source_workspace}"; then
+    echo "session start requires a clean source workspace for isolated session cloning: ${source_workspace}" >&2
+    echo "Next step: commit or stash the workspace changes, or rerun with --session-workspace direct to use the current workspace in place." >&2
+    exit 2
+  fi
 }
 
 profile_docker_socket_path() {
@@ -2717,6 +2780,9 @@ Commands:
   start
     Launch a detached background session using the standard Workcell launch options.
     Detached sessions default to `--session-workspace isolated`.
+    --session-workspace direct|isolated
+                              Select whether detached sessions clone a clean git workspace
+                              or reuse the current workspace path directly
 
   attach
     --id SESSION_ID           Attach the host terminal to a running detached session
@@ -5069,6 +5135,9 @@ validate_workspace() {
       echo "Refusing git workspace with admin state outside the mounted workspace: ${path}" >&2
       echo "This workspace is a linked worktree: its .git file points to a .git directory outside the mounted path." >&2
       echo "To use this workspace on the safe path, create a standard clone at the same location instead." >&2
+      if [[ "${SESSION_DETACHED:-0}" -eq 1 ]] && [[ "$(effective_session_workspace_mode)" == "isolated" ]]; then
+        echo "Next step: rerun with --session-workspace direct if you want to use the current workspace in place." >&2
+      fi
       echo "Alternatively, pass --mode breakglass --ack-breakglass to proceed with a linked worktree." >&2
       exit 2
     fi
@@ -5081,6 +5150,10 @@ validate_workspace() {
 
   if [[ "${allow_nongit}" -eq 0 ]]; then
     echo "Workspace is not a git worktree: ${path}" >&2
+    if [[ "${SESSION_DETACHED:-0}" -eq 1 ]] && [[ "$(effective_session_workspace_mode)" == "isolated" ]]; then
+      echo "Detached session start with --session-workspace isolated requires a git workspace." >&2
+      echo "Next step: rerun with --session-workspace direct if you want to use the current workspace in place." >&2
+    fi
     echo "Use --allow-nongit-workspace only when you intentionally want a marker-based workspace." >&2
   else
     echo "Non-git workspace lacks an explicit agent marker file: ${path}" >&2
@@ -5176,20 +5249,36 @@ normalize_cli_aliases() {
 
   case "${NORMALIZED_ARGS[0]-}" in
     doctor)
+      if [[ ${#NORMALIZED_ARGS[@]} -eq 2 ]] && [[ "${NORMALIZED_ARGS[1]}" == "--help" ]]; then
+        compatibility_alias_usage doctor
+        exit 0
+      fi
       NORMALIZED_ARGS=(--doctor "${NORMALIZED_ARGS[@]:1}")
       ;;
     inspect)
+      if [[ ${#NORMALIZED_ARGS[@]} -eq 2 ]] && [[ "${NORMALIZED_ARGS[1]}" == "--help" ]]; then
+        compatibility_alias_usage inspect
+        exit 0
+      fi
       NORMALIZED_ARGS=(--inspect "${NORMALIZED_ARGS[@]:1}")
       ;;
     auth-status)
+      if [[ ${#NORMALIZED_ARGS[@]} -eq 2 ]] && [[ "${NORMALIZED_ARGS[1]}" == "--help" ]]; then
+        compatibility_alias_usage auth-status
+        exit 0
+      fi
       NORMALIZED_ARGS=(--auth-status "${NORMALIZED_ARGS[@]:1}")
       ;;
     gc)
+      if [[ ${#NORMALIZED_ARGS[@]} -eq 2 ]] && [[ "${NORMALIZED_ARGS[1]}" == "--help" ]]; then
+        compatibility_alias_usage gc
+        exit 0
+      fi
       NORMALIZED_ARGS=(--gc "${NORMALIZED_ARGS[@]:1}")
       ;;
     logs)
       if [[ ${#NORMALIZED_ARGS[@]} -eq 2 ]] && [[ "${NORMALIZED_ARGS[1]}" == "--help" ]]; then
-        usage
+        compatibility_alias_usage logs
         exit 0
       fi
       if [[ ${#NORMALIZED_ARGS[@]} -lt 2 ]]; then
@@ -7374,6 +7463,7 @@ WORKSPACE_SHADOW_SOURCE="${WORKSPACE}"
 if [[ "${SESSION_DETACHED}" -eq 1 ]] && [[ "$(effective_session_workspace_mode)" == "isolated" ]]; then
   [[ -n "${SESSION_ID}" ]] || SESSION_ID="$(generate_session_id)"
   if [[ "${DRY_RUN}" -eq 1 ]]; then
+    validate_isolated_session_workspace_source "${SESSION_SOURCE_WORKSPACE}"
     WORKSPACE="$(isolated_session_workspace_path "${SESSION_SOURCE_WORKSPACE}" "${SESSION_ID}")"
     WORKSPACE_SHADOW_SOURCE="${SESSION_SOURCE_WORKSPACE}"
   else

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -358,6 +358,7 @@ EOF
     logs)
       cat <<'EOF'
 Usage: workcell logs <audit|debug|file-trace|transcript> [launch-options]
+Print the latest retained log of the selected type.
 Compatibility alias for: workcell --logs audit|debug|file-trace|transcript
 See workcell --help for the full launch-option list.
 EOF

--- a/tests/scenarios/shared/test-assurance-dry-run.sh
+++ b/tests/scenarios/shared/test-assurance-dry-run.sh
@@ -185,6 +185,12 @@ for agent in codex claude gemini; do
   grep -q -- '--read-only' "${TMP_DIR}/readonly-${agent}.stdout"
 done
 
+run_dry_run "cache-standard-codex" --agent codex --cache-profile standard --agent-arg --version
+grep -q '^cache_profile=standard$' "${TMP_DIR}/cache-standard-codex.stderr"
+grep -q '^cache_assurance=lower-assurance-persistent-cache$' "${TMP_DIR}/cache-standard-codex.stderr"
+grep -Eq -- "-v .+/workcell/cache/codex/.+/go-mod:/state/cache/go-mod($| )" "${TMP_DIR}/cache-standard-codex.stdout"
+grep -q -- '-e XDG_CACHE_HOME=/state/cache/xdg' "${TMP_DIR}/cache-standard-codex.stdout"
+
 set +e
 HOME="${HOME_DIR}" XDG_CONFIG_HOME="${HOME_DIR}/.config" \
   "${ROOT_DIR}/scripts/workcell" \

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -451,6 +451,82 @@ detached_start_direct_output="$(
 )"
 grep -Fq -- "-v ${DETACHED_START_WORKSPACE}:/workspace" <<<"${detached_start_direct_output}"
 
+NONGIT_DETACHED_WORKSPACE="${TMP_DIR}/detached-start-nongit"
+mkdir -p "${NONGIT_DETACHED_WORKSPACE}"
+set +e
+nongit_isolated_output="$(
+  "${ROOT_DIR}/scripts/workcell" \
+    session start \
+    --session-workspace isolated \
+    --agent codex \
+    --mode development \
+    --workspace "${NONGIT_DETACHED_WORKSPACE}" \
+    --no-default-injection-policy \
+    --allow-arbitrary-command \
+    --ack-arbitrary-command \
+    --dry-run \
+    -- /bin/true 2>&1 >/dev/null
+)"
+nongit_isolated_status=$?
+set -e
+test "${nongit_isolated_status}" -eq 2
+grep -q "Workspace is not a git worktree: ${NONGIT_DETACHED_WORKSPACE}" <<<"${nongit_isolated_output}"
+grep -q 'Detached session start with --session-workspace isolated requires a git workspace\.' <<<"${nongit_isolated_output}"
+grep -q 'Next step: rerun with --session-workspace direct if you want to use the current workspace in place\.' <<<"${nongit_isolated_output}"
+
+printf 'dirty\n' >>"${DETACHED_START_WORKSPACE}/README.md"
+set +e
+dirty_isolated_output="$(
+  "${ROOT_DIR}/scripts/workcell" \
+    session start \
+    --session-workspace isolated \
+    --agent codex \
+    --mode development \
+    --workspace "${DETACHED_START_WORKSPACE}" \
+    --no-default-injection-policy \
+    --allow-arbitrary-command \
+    --ack-arbitrary-command \
+    --dry-run \
+    -- /bin/true 2>&1 >/dev/null
+)"
+dirty_isolated_status=$?
+set -e
+test "${dirty_isolated_status}" -eq 2
+grep -q "session start requires a clean source workspace for isolated session cloning: ${DETACHED_START_WORKSPACE}" <<<"${dirty_isolated_output}"
+grep -q 'Next step: commit or stash the workspace changes, or rerun with --session-workspace direct to use the current workspace in place\.' <<<"${dirty_isolated_output}"
+
+LINKED_WORKTREE_ROOT="${TMP_DIR}/detached-linked-worktree"
+LINKED_WORKTREE_MAIN="${LINKED_WORKTREE_ROOT}/main"
+LINKED_WORKTREE_PATH="${LINKED_WORKTREE_ROOT}/linked"
+mkdir -p "${LINKED_WORKTREE_ROOT}"
+git init -q "${LINKED_WORKTREE_MAIN}"
+git -C "${LINKED_WORKTREE_MAIN}" config user.name "Workcell Test"
+git -C "${LINKED_WORKTREE_MAIN}" config user.email "workcell@example.com"
+printf 'tracked\n' >"${LINKED_WORKTREE_MAIN}/tracked.txt"
+git -C "${LINKED_WORKTREE_MAIN}" add tracked.txt
+git -C "${LINKED_WORKTREE_MAIN}" commit -q -m init
+git -C "${LINKED_WORKTREE_MAIN}" worktree add -q -b linked "${LINKED_WORKTREE_PATH}"
+set +e
+linked_isolated_output="$(
+  "${ROOT_DIR}/scripts/workcell" \
+    session start \
+    --session-workspace isolated \
+    --agent codex \
+    --mode development \
+    --workspace "${LINKED_WORKTREE_PATH}" \
+    --no-default-injection-policy \
+    --allow-arbitrary-command \
+    --ack-arbitrary-command \
+    --dry-run \
+    -- /bin/true 2>&1 >/dev/null
+)"
+linked_isolated_status=$?
+set -e
+test "${linked_isolated_status}" -eq 2
+grep -q "Refusing git workspace with admin state outside the mounted workspace: ${LINKED_WORKTREE_PATH}" <<<"${linked_isolated_output}"
+grep -q 'This workspace is a linked worktree: its .git file points to a .git directory outside the mounted path\.' <<<"${linked_isolated_output}"
+grep -q 'Next step: rerun with --session-workspace direct if you want to use the current workspace in place\.' <<<"${linked_isolated_output}"
+
 sed '/^if \[\[ \$# -gt 0 \]\]; then$/,$d' "${ROOT_DIR}/scripts/workcell" >"${WORKCELL_FUNCTIONS_COPY}"
 monitor_env_output="$(
   bash -lc '


### PR DESCRIPTION
## Summary
- fix early bootstrap home/cache resolution so managed launches do not share a mutable /tmp Go cache
- add a machine-checked operator contract with per-workflow docs and evidence mapping
- align session/help/man/README surfaces and add regression coverage, mutation checks, and parity guardrails

## Validation
- bash tests/scenarios/shared/test-agent-launch-smoke.sh
- bash tests/scenarios/shared/test-assurance-dry-run.sh
- bash tests/scenarios/shared/test-session-commands.sh
- go test ./internal/metadatautil ./internal/testkit -count=1
- bash scripts/run-mutation-tests.sh
- bash scripts/verify-coverage.sh
- bash scripts/validate-repo.sh
