### PR TITLE
Finish reviewability docs and validation follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ Other defaults that matter:
 - Workcell launches the selected provider directly inside the bounded runtime
 - there is no separate "start a container, then attach the agent" step
 - `publish-pr` runs on the host so signed commits and GitHub publication stay
-  outside the Tier 1 container
+  outside the Tier 1 container, and it blocks over-broad branch diffs before
+  push so published PRs stay reviewable
 - completed and aborted launches are recorded as durable host-side session
   records that you can inspect with `workcell session ...`
 - `workcell session diff` compares the current workspace against the clean git

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -113,6 +113,10 @@ Each checkpoint packet should stay short and include:
 - documentation and roadmap status
 - any open risks, tradeoffs, or deviations from the normal path
 
+Release-path pull requests should stay human-reviewable. Split opportunistic
+cleanup, unrelated fixes, or separate reviewer-sized concerns into other PRs
+before publishing the release path.
+
 If the maintainer gives feedback, incorporate it and refresh the packet before
 continuing.
 

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -44,6 +44,9 @@ func TestDevQuickCheckStaysBoundedToFastLocalWork(t *testing.T) {
 	script := string(content)
 
 	for _, want := range []string{
+		"scripts/check-dead-code.sh",
+		"scripts/check-public-repo-hygiene.sh",
+		"scripts/check-pr-shape.sh",
 		"gofmt -l",
 		"go vet ./...",
 		"go test ./...",
@@ -98,6 +101,15 @@ func TestValidationGatesLintAllScenarioShellScripts(t *testing.T) {
 		if !strings.Contains(content, "scripts/go-port-validate.sh") {
 			t.Fatalf("validation scripts must include scripts/go-port-validate.sh")
 		}
+		if !strings.Contains(content, "scripts/check-dead-code.sh") {
+			t.Fatalf("validation scripts must include scripts/check-dead-code.sh")
+		}
+		if !strings.Contains(content, "scripts/check-public-repo-hygiene.sh") {
+			t.Fatalf("validation scripts must include scripts/check-public-repo-hygiene.sh")
+		}
+		if !strings.Contains(content, "scripts/check-pr-shape.sh") {
+			t.Fatalf("validation scripts must include scripts/check-pr-shape.sh")
+		}
 		if !strings.Contains(content, "scripts/lint-dockerfiles.sh") {
 			t.Fatalf("validation scripts must include scripts/lint-dockerfiles.sh")
 		}
@@ -109,6 +121,9 @@ func TestValidationGatesLintAllScenarioShellScripts(t *testing.T) {
 		}
 		for _, want := range []string{
 			"scripts/bootstrap-dev.sh",
+			"scripts/check-dead-code.sh",
+			"scripts/check-public-repo-hygiene.sh",
+			"scripts/check-pr-shape.sh",
 			"scripts/generate-homebrew-formula.sh",
 			"scripts/install-workcell.sh",
 			"scripts/install.sh",
@@ -139,6 +154,9 @@ func TestValidationGatesLintAllScenarioShellScripts(t *testing.T) {
 	}
 	for _, want := range []string{
 		`${ROOT_DIR}/.githooks/pre-commit`,
+		`${ROOT_DIR}/scripts/check-dead-code.sh`,
+		`${ROOT_DIR}/scripts/check-public-repo-hygiene.sh`,
+		`${ROOT_DIR}/scripts/check-pr-shape.sh`,
 		`${ROOT_DIR}/scripts/install.sh`,
 		`${ROOT_DIR}/scripts/build-and-test.sh`,
 		`${ROOT_DIR}/scripts/install-dev-tools.sh`,


### PR DESCRIPTION
## Summary
- document that host-side publish blocks over-broad branch diffs so published PRs stay reviewable
- add the same human-reviewable PR guidance to the release runbook
- cover the new dead-code, hygiene, and PR-shape gates in validation entrypoint tests

## Testing
- go test ./internal/testkit -count=1
- ./scripts/check-pr-shape.sh --base-ref refs/remotes/origin/main --head-ref HEAD --max-files 25 --max-lines 1200 --max-areas 8 --max-binaries 0
- git diff --check origin/main...HEAD