### PR TITLE
Add target-aware session metadata surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,12 +258,14 @@ workcell --agent codex --prepare --workspace /path/to/repo
 workcell --agent codex --prepare-only --workspace /path/to/repo
 workcell --agent codex --mode development --workspace /path/to/repo -- bash -lc 'git status'
 workcell session list
+workcell session list --verbose
 workcell session start --agent codex --workspace /path/to/repo
 workcell session delete --id SESSION_ID
 workcell session attach --id 20260408T120000Z-1a2b3c4d
 workcell session send --id 20260408T120000Z-1a2b3c4d --message "continue with tests"
 workcell session stop --id 20260408T120000Z-1a2b3c4d
 workcell session show --id 20260408T120000Z-1a2b3c4d
+workcell session show --id 20260408T120000Z-1a2b3c4d --text
 workcell session logs --id 20260408T120000Z-1a2b3c4d --kind audit
 workcell session timeline --id 20260408T120000Z-1a2b3c4d
 workcell session diff --id 20260408T120000Z-1a2b3c4d

--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -357,17 +357,20 @@ func launcherUsage() error {
 }
 
 func runLauncherSessionList(args []string) error {
-	if len(args) < 1 || len(args) > 4 {
+	if len(args) < 1 || len(args) > 5 {
 		return launcherUsage()
 	}
 
 	colimaRoot := args[0]
 	format := "lines"
+	verbose := false
 	opts := hostutil.SessionListOptions{}
 	for _, arg := range args[1:] {
 		switch {
 		case arg == "--json":
 			format = "json"
+		case arg == "--verbose":
+			verbose = true
 		case strings.HasPrefix(arg, "--workspace="):
 			opts.Workspace = strings.TrimPrefix(arg, "--workspace=")
 		case strings.HasPrefix(arg, "--profile="):
@@ -375,6 +378,9 @@ func runLauncherSessionList(args []string) error {
 		default:
 			return launcherUsage()
 		}
+	}
+	if format == "json" && verbose {
+		return fmt.Errorf("session-list accepts either --json or --verbose, not both")
 	}
 
 	records, err := hostutil.ListSessionRecords(colimaRoot, opts)
@@ -390,17 +396,36 @@ func runLauncherSessionList(args []string) error {
 		return nil
 	}
 	for _, record := range records {
+		if verbose {
+			fmt.Printf(
+				"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				record.SessionID,
+				record.Status,
+				hostutil.SessionDisplayLiveStatus(record),
+				hostutil.SessionControlMode(record),
+				record.Agent,
+				record.Mode,
+				record.Profile,
+				hostutil.SessionTargetSummary(record),
+				record.TargetAssuranceClass,
+				record.WorkspaceTransport,
+				record.StartedAt,
+				hostutil.SessionAssuranceSummary(record),
+				hostutil.SessionDisplayWorkspace(record),
+			)
+			continue
+		}
 		fmt.Printf(
 			"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			record.SessionID,
 			record.Status,
-			coalesce(record.LiveStatus, record.Status),
+			hostutil.SessionDisplayLiveStatus(record),
 			hostutil.SessionControlMode(record),
 			record.Agent,
 			record.Mode,
 			record.Profile,
 			record.StartedAt,
-			coalesce(record.CurrentAssurance, record.FinalAssurance, record.InitialAssurance),
+			hostutil.SessionAssuranceSummary(record),
 			hostutil.SessionDisplayWorkspace(record),
 		)
 	}
@@ -408,13 +433,26 @@ func runLauncherSessionList(args []string) error {
 }
 
 func runLauncherSessionShow(args []string) error {
-	if len(args) != 2 {
+	if len(args) < 2 || len(args) > 3 {
 		return launcherUsage()
 	}
 
+	format := "json"
+	for _, arg := range args[2:] {
+		if arg != "--text" {
+			return launcherUsage()
+		}
+		format = "text"
+	}
 	record, err := hostutil.FindSessionRecord(args[0], args[1])
 	if err != nil {
 		return err
+	}
+	if format == "text" {
+		for _, line := range hostutil.SessionShowLines(record) {
+			fmt.Println(line)
+		}
+		return nil
 	}
 	content, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
@@ -484,13 +522,4 @@ func runLauncherSessionTimeline(args []string) error {
 		fmt.Println(line)
 	}
 	return nil
-}
-
-func coalesce(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
-		}
-	}
-	return ""
 }

--- a/cmd/workcell-hostutil/main_test.go
+++ b/cmd/workcell-hostutil/main_test.go
@@ -135,6 +135,9 @@ func TestRunLauncherSessionRuntimeMetadata(t *testing.T) {
 	if !strings.Contains(got, "workspace_origin=/tmp/source-workspace") {
 		t.Fatalf("runtime metadata output = %q, want workspace_origin line", got)
 	}
+	if !strings.Contains(got, "target_kind=local_vm") || !strings.Contains(got, "target_provider=colima") {
+		t.Fatalf("runtime metadata output = %q, want target metadata", got)
+	}
 	if !strings.Contains(got, "monitor_pid=4242") {
 		t.Fatalf("runtime metadata output = %q, want monitor_pid line", got)
 	}
@@ -213,6 +216,122 @@ func TestRunLauncherSessionListShowsLiveStatusAndControl(t *testing.T) {
 	}
 	if !strings.Contains(got, "session-1\trunning\trunning\tattached\tcodex\tstrict\twcl-one\t2026-04-08T10:00:00Z\tmanaged-mutable\t/tmp/workspace-a") {
 		t.Fatalf("session list output = %q, want live attached record with attached control", got)
+	}
+	if strings.Contains(got, "\tlocal_vm\t") {
+		t.Fatalf("session list output = %q, want compact text output without extra target columns", got)
+	}
+}
+
+func TestRunLauncherSessionListVerboseShowsTargetMetadata(t *testing.T) {
+	colimaRoot := t.TempDir()
+	if err := hostutil.WriteSessionRecord(filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json"), map[string]string{
+		"session_id":        "session-1",
+		"profile":           "wcl-one",
+		"agent":             "codex",
+		"mode":              "strict",
+		"status":            "running",
+		"live_status":       "running",
+		"workspace":         "/tmp/workspace-a",
+		"workspace_origin":  "/tmp/source-workspace",
+		"started_at":        "2026-04-08T10:00:00Z",
+		"current_assurance": "managed-mutable",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = stdout.ReadFrom(r)
+		close(done)
+	}()
+
+	runErr := run([]string{"launcher", "session-list", colimaRoot, "--verbose"})
+	_ = w.Close()
+	<-done
+	_ = r.Close()
+
+	if runErr != nil {
+		t.Fatalf("run() error = %v", runErr)
+	}
+	got := strings.TrimSpace(stdout.String())
+	want := "session-1\trunning\trunning\tattached\tcodex\tstrict\twcl-one\tlocal_vm/colima/wcl-one\tstrict\tisolated-worktree-mount\t2026-04-08T10:00:00Z\tmanaged-mutable\t/tmp/source-workspace"
+	if got != want {
+		t.Fatalf("session list verbose output = %q, want %q", got, want)
+	}
+}
+
+func TestRunLauncherSessionShowText(t *testing.T) {
+	colimaRoot := t.TempDir()
+	sessionPath := filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json")
+	if err := hostutil.WriteSessionRecord(sessionPath, map[string]string{
+		"session_id":              "session-1",
+		"profile":                 "wcl-one",
+		"agent":                   "codex",
+		"mode":                    "strict",
+		"status":                  "running",
+		"live_status":             "running",
+		"workspace":               "/tmp/workspace-a",
+		"workspace_origin":        "/tmp/source-workspace",
+		"worktree_path":           "/tmp/workspace-a/.worktrees/session-1",
+		"git_branch":              "feature/session-observability",
+		"container_name":          "workcell-session-1",
+		"monitor_pid":             "4242",
+		"session_audit_dir":       "/tmp/session-audit.1234",
+		"started_at":              "2026-04-08T10:00:00Z",
+		"current_assurance":       "managed-mutable",
+		"workspace_control_plane": "masked",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = stdout.ReadFrom(r)
+		close(done)
+	}()
+
+	runErr := run([]string{"launcher", "session-show", colimaRoot, "session-1", "--text"})
+	_ = w.Close()
+	<-done
+	_ = r.Close()
+
+	if runErr != nil {
+		t.Fatalf("run() error = %v", runErr)
+	}
+	got := strings.TrimSpace(stdout.String())
+	if !strings.Contains(got, "target_summary=local_vm/colima/wcl-one") {
+		t.Fatalf("session show --text output = %q, want target summary", got)
+	}
+	if !strings.Contains(got, "control=detached") {
+		t.Fatalf("session show --text output = %q, want control line", got)
+	}
+	if !strings.Contains(got, "git_branch=feature/session-observability") {
+		t.Fatalf("session show --text output = %q, want git branch", got)
+	}
+	if !strings.Contains(got, "workspace_transport=isolated-worktree-mount") {
+		t.Fatalf("session show --text output = %q, want workspace transport", got)
 	}
 }
 

--- a/docs/workcell-session-supervisor-design.md
+++ b/docs/workcell-session-supervisor-design.md
@@ -100,7 +100,13 @@ session metadata.
 - assurance
 - workspace
 
-`workcell session show` returns the full durable record for one session.
+`workcell session list --verbose` adds target identity, target assurance, and
+workspace-transport metadata without changing the default compact table.
+
+`workcell session show` returns the full durable record for one session, and
+`workcell session show --text` renders the same record as stable key=value
+lines, including target metadata, workspace transport, branch, worktree, and
+artifact pointers.
 
 `workcell session logs` prints one retained audit, debug, file-trace, or
 transcript log for a recorded session.
@@ -136,8 +142,6 @@ The current slice does not yet attempt to implement:
 The remaining near-term work is to:
 
 - harden and normalize worktree-per-session defaults
-- expose branch/worktree and assurance state more clearly in operator-facing
-  status views
 - deepen validation coverage for detached-session transitions and
   lower-assurance paths
 - add richer artifact browsing without weakening the host-owned model

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -287,8 +287,10 @@ Detached session records are written under the Colima profile state tree as
 schema in [`internal/hostutil/sessions.go`](../internal/hostutil/sessions.go)
 includes:
 
-- session identity, profile, agent, mode, and UI
+- session identity, profile, target kind, target provider, target id,
+  target assurance class, runtime API, agent, mode, and UI
 - workspace path, workspace origin, workspace root, and worktree path
+- workspace transport as a distinct recorded concept alongside workspace paths
 - git branch, head, and clean-base metadata
 - container name, monitor pid, status, and live status
 - audit, debug, file-trace, and transcript log pointers

--- a/internal/hostutil/sessions.go
+++ b/internal/hostutil/sessions.go
@@ -20,6 +20,12 @@ type SessionRecord struct {
 	Version               int    `json:"version"`
 	SessionID             string `json:"session_id"`
 	Profile               string `json:"profile"`
+	TargetKind            string `json:"target_kind,omitempty"`
+	TargetProvider        string `json:"target_provider,omitempty"`
+	TargetID              string `json:"target_id,omitempty"`
+	TargetAssuranceClass  string `json:"target_assurance_class,omitempty"`
+	RuntimeAPI            string `json:"runtime_api,omitempty"`
+	WorkspaceTransport    string `json:"workspace_transport,omitempty"`
 	Agent                 string `json:"agent"`
 	Mode                  string `json:"mode"`
 	Status                string `json:"status"`
@@ -61,7 +67,14 @@ type SessionExport struct {
 }
 
 func SessionDiffMetadataLines(record SessionRecord) []string {
+	record = normalizeSessionRecord(record)
 	return []string{
+		fmt.Sprintf("target_kind=%s", record.TargetKind),
+		fmt.Sprintf("target_provider=%s", record.TargetProvider),
+		fmt.Sprintf("target_id=%s", record.TargetID),
+		fmt.Sprintf("target_assurance_class=%s", record.TargetAssuranceClass),
+		fmt.Sprintf("runtime_api=%s", record.RuntimeAPI),
+		fmt.Sprintf("workspace_transport=%s", record.WorkspaceTransport),
 		fmt.Sprintf("workspace=%s", record.Workspace),
 		fmt.Sprintf("workspace_origin=%s", record.WorkspaceOrigin),
 		fmt.Sprintf("workspace_root=%s", record.WorkspaceRoot),
@@ -83,9 +96,16 @@ func SessionDiffMetadataLines(record SessionRecord) []string {
 }
 
 func SessionRuntimeMetadataLines(record SessionRecord) []string {
+	record = normalizeSessionRecord(record)
 	return []string{
 		fmt.Sprintf("session_id=%s", record.SessionID),
 		fmt.Sprintf("profile=%s", record.Profile),
+		fmt.Sprintf("target_kind=%s", record.TargetKind),
+		fmt.Sprintf("target_provider=%s", record.TargetProvider),
+		fmt.Sprintf("target_id=%s", record.TargetID),
+		fmt.Sprintf("target_assurance_class=%s", record.TargetAssuranceClass),
+		fmt.Sprintf("runtime_api=%s", record.RuntimeAPI),
+		fmt.Sprintf("workspace_transport=%s", record.WorkspaceTransport),
 		fmt.Sprintf("workspace=%s", record.Workspace),
 		fmt.Sprintf("workspace_origin=%s", record.WorkspaceOrigin),
 		fmt.Sprintf("workspace_root=%s", record.WorkspaceRoot),
@@ -129,11 +149,82 @@ func SessionControlMode(record SessionRecord) string {
 	return "attached"
 }
 
+func SessionDisplayLiveStatus(record SessionRecord) string {
+	return firstNonEmpty(strings.TrimSpace(record.LiveStatus), strings.TrimSpace(record.Status))
+}
+
+func SessionAssuranceSummary(record SessionRecord) string {
+	return firstNonEmpty(
+		strings.TrimSpace(record.CurrentAssurance),
+		strings.TrimSpace(record.FinalAssurance),
+		strings.TrimSpace(record.InitialAssurance),
+	)
+}
+
 func SessionDisplayWorkspace(record SessionRecord) string {
 	if strings.TrimSpace(record.WorkspaceOrigin) != "" {
 		return record.WorkspaceOrigin
 	}
 	return record.Workspace
+}
+
+func SessionTargetSummary(record SessionRecord) string {
+	record = normalizeSessionRecord(record)
+	parts := make([]string, 0, 3)
+	for _, value := range []string{record.TargetKind, record.TargetProvider, record.TargetID} {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		parts = append(parts, value)
+	}
+	return strings.Join(parts, "/")
+}
+
+func SessionShowLines(record SessionRecord) []string {
+	record = normalizeSessionRecord(record)
+	return []string{
+		fmt.Sprintf("session_id=%s", record.SessionID),
+		fmt.Sprintf("profile=%s", record.Profile),
+		fmt.Sprintf("target_kind=%s", record.TargetKind),
+		fmt.Sprintf("target_provider=%s", record.TargetProvider),
+		fmt.Sprintf("target_id=%s", record.TargetID),
+		fmt.Sprintf("target_summary=%s", SessionTargetSummary(record)),
+		fmt.Sprintf("target_assurance_class=%s", record.TargetAssuranceClass),
+		fmt.Sprintf("runtime_api=%s", record.RuntimeAPI),
+		fmt.Sprintf("control=%s", SessionControlMode(record)),
+		fmt.Sprintf("agent=%s", record.Agent),
+		fmt.Sprintf("mode=%s", record.Mode),
+		fmt.Sprintf("ui=%s", record.UI),
+		fmt.Sprintf("execution_path=%s", record.ExecutionPath),
+		fmt.Sprintf("status=%s", record.Status),
+		fmt.Sprintf("live_status=%s", SessionDisplayLiveStatus(record)),
+		fmt.Sprintf("assurance=%s", SessionAssuranceSummary(record)),
+		fmt.Sprintf("workspace_transport=%s", record.WorkspaceTransport),
+		fmt.Sprintf("workspace=%s", record.Workspace),
+		fmt.Sprintf("display_workspace=%s", SessionDisplayWorkspace(record)),
+		fmt.Sprintf("workspace_origin=%s", record.WorkspaceOrigin),
+		fmt.Sprintf("workspace_root=%s", record.WorkspaceRoot),
+		fmt.Sprintf("worktree_path=%s", record.WorktreePath),
+		fmt.Sprintf("git_branch=%s", record.GitBranch),
+		fmt.Sprintf("git_head=%s", record.GitHead),
+		fmt.Sprintf("git_base=%s", record.GitBase),
+		fmt.Sprintf("container_name=%s", record.ContainerName),
+		fmt.Sprintf("monitor_pid=%s", record.MonitorPID),
+		fmt.Sprintf("started_at=%s", record.StartedAt),
+		fmt.Sprintf("observed_at=%s", record.ObservedAt),
+		fmt.Sprintf("finished_at=%s", record.FinishedAt),
+		fmt.Sprintf("exit_status=%s", record.ExitStatus),
+		fmt.Sprintf("initial_assurance=%s", record.InitialAssurance),
+		fmt.Sprintf("current_assurance=%s", record.CurrentAssurance),
+		fmt.Sprintf("final_assurance=%s", record.FinalAssurance),
+		fmt.Sprintf("session_audit_dir=%s", record.SessionAuditDir),
+		fmt.Sprintf("audit_log_path=%s", record.AuditLogPath),
+		fmt.Sprintf("debug_log_path=%s", record.DebugLogPath),
+		fmt.Sprintf("file_trace_log_path=%s", record.FileTraceLogPath),
+		fmt.Sprintf("transcript_log_path=%s", record.TranscriptLogPath),
+		fmt.Sprintf("workspace_control_plane=%s", record.WorkspaceControlPlane),
+	}
 }
 
 func SessionMatchesWorkspace(record SessionRecord, workspace string) bool {
@@ -174,6 +265,18 @@ func WriteSessionRecord(path string, updates map[string]string) error {
 			record.SessionID = value
 		case "profile":
 			record.Profile = value
+		case "target_kind":
+			record.TargetKind = value
+		case "target_provider":
+			record.TargetProvider = value
+		case "target_id":
+			record.TargetID = value
+		case "target_assurance_class":
+			record.TargetAssuranceClass = value
+		case "runtime_api":
+			record.RuntimeAPI = value
+		case "workspace_transport":
+			record.WorkspaceTransport = value
 		case "agent":
 			record.Agent = value
 		case "mode":
@@ -239,6 +342,7 @@ func WriteSessionRecord(path string, updates map[string]string) error {
 		return fmt.Errorf("%s: refusing to overwrite terminal session status %q with %q", path, existingRecord.Status, record.Status)
 	}
 
+	record = normalizeSessionRecord(record)
 	if err := validateSessionRecord(record, path); err != nil {
 		return err
 	}
@@ -270,6 +374,7 @@ func ReadSessionRecord(path string) (SessionRecord, error) {
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {
 		return record, fmt.Errorf("%s: unexpected trailing content", path)
 	}
+	record = normalizeSessionRecord(record)
 	if err := validateSessionRecord(record, path); err != nil {
 		return SessionRecord{}, err
 	}
@@ -422,6 +527,51 @@ func SessionAuditRecords(record SessionRecord) ([]string, error) {
 	return records, nil
 }
 
+func normalizeSessionRecord(record SessionRecord) SessionRecord {
+	if strings.TrimSpace(record.TargetKind) == "" {
+		record.TargetKind = "local_vm"
+	}
+	if strings.TrimSpace(record.TargetProvider) == "" {
+		record.TargetProvider = "colima"
+	}
+	if strings.TrimSpace(record.TargetID) == "" {
+		record.TargetID = strings.TrimSpace(record.Profile)
+	}
+	if strings.TrimSpace(record.TargetAssuranceClass) == "" {
+		record.TargetAssuranceClass = "strict"
+	}
+	if strings.TrimSpace(record.RuntimeAPI) == "" {
+		record.RuntimeAPI = "docker"
+	}
+	if strings.TrimSpace(record.WorkspaceTransport) == "" {
+		record.WorkspaceTransport = deriveWorkspaceTransport(record)
+	}
+	return record
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func deriveWorkspaceTransport(record SessionRecord) string {
+	workspace := strings.TrimSpace(record.Workspace)
+	workspaceOrigin := strings.TrimSpace(record.WorkspaceOrigin)
+	worktreePath := strings.TrimSpace(record.WorktreePath)
+	if workspace == "" {
+		return ""
+	}
+	if (workspaceOrigin != "" && workspaceOrigin != workspace) ||
+		(worktreePath != "" && worktreePath != workspace) {
+		return "isolated-worktree-mount"
+	}
+	return "workspace-mount"
+}
+
 func auditLineHasSessionID(line, sessionID string) bool {
 	for _, field := range strings.Fields(line) {
 		key, value, ok := strings.Cut(field, "=")
@@ -477,6 +627,12 @@ func validateSessionRecord(record SessionRecord, source string) error {
 	}{
 		{name: "session_id", value: record.SessionID},
 		{name: "profile", value: record.Profile},
+		{name: "target_kind", value: record.TargetKind},
+		{name: "target_provider", value: record.TargetProvider},
+		{name: "target_id", value: record.TargetID},
+		{name: "target_assurance_class", value: record.TargetAssuranceClass},
+		{name: "runtime_api", value: record.RuntimeAPI},
+		{name: "workspace_transport", value: record.WorkspaceTransport},
 		{name: "agent", value: record.Agent},
 		{name: "mode", value: record.Mode},
 		{name: "status", value: record.Status},
@@ -516,6 +672,12 @@ func validateSessionRecord(record SessionRecord, source string) error {
 	}{
 		{name: "session_id", value: record.SessionID},
 		{name: "profile", value: record.Profile},
+		{name: "target_kind", value: record.TargetKind},
+		{name: "target_provider", value: record.TargetProvider},
+		{name: "target_id", value: record.TargetID},
+		{name: "target_assurance_class", value: record.TargetAssuranceClass},
+		{name: "runtime_api", value: record.RuntimeAPI},
+		{name: "workspace_transport", value: record.WorkspaceTransport},
 		{name: "agent", value: record.Agent},
 		{name: "mode", value: record.Mode},
 		{name: "status", value: record.Status},

--- a/internal/hostutil/sessions_test.go
+++ b/internal/hostutil/sessions_test.go
@@ -70,6 +70,12 @@ func TestWriteSessionRecordRoundTrip(t *testing.T) {
 	if record.WorkspaceOrigin != "/tmp/source-workspace" {
 		t.Fatalf("workspace origin was not preserved: %+v", record)
 	}
+	if record.TargetKind != "local_vm" || record.TargetProvider != "colima" || record.TargetID != "wcl-fixture" {
+		t.Fatalf("target metadata was not derived correctly: %+v", record)
+	}
+	if record.TargetAssuranceClass != "strict" || record.RuntimeAPI != "docker" || record.WorkspaceTransport != "isolated-worktree-mount" {
+		t.Fatalf("target runtime metadata was not derived correctly: %+v", record)
+	}
 	if record.LiveStatus != "stopped" || record.CurrentAssurance != "managed-mutable" || record.ObservedAt != "2026-04-08T12:00:30Z" {
 		t.Fatalf("observability state was not preserved: %+v", record)
 	}
@@ -99,6 +105,7 @@ func TestSessionDiffMetadataLines(t *testing.T) {
 	t.Parallel()
 
 	lines := SessionDiffMetadataLines(SessionRecord{
+		Profile:               "wcl-one",
 		Workspace:             "/tmp/workspace",
 		WorkspaceOrigin:       "/tmp/source-workspace",
 		WorkspaceRoot:         "/tmp",
@@ -119,6 +126,12 @@ func TestSessionDiffMetadataLines(t *testing.T) {
 	})
 
 	want := []string{
+		"target_kind=local_vm",
+		"target_provider=colima",
+		"target_id=wcl-one",
+		"target_assurance_class=strict",
+		"runtime_api=docker",
+		"workspace_transport=isolated-worktree-mount",
 		"workspace=/tmp/workspace",
 		"workspace_origin=/tmp/source-workspace",
 		"workspace_root=/tmp",
@@ -226,6 +239,19 @@ func TestSessionDisplayWorkspacePrefersWorkspaceOrigin(t *testing.T) {
 	})
 	if got != "/tmp/source-workspace" {
 		t.Fatalf("SessionDisplayWorkspace() = %q, want workspace origin", got)
+	}
+}
+
+func TestSessionTargetSummary(t *testing.T) {
+	t.Parallel()
+
+	got := SessionTargetSummary(SessionRecord{
+		TargetKind:     "remote_vm",
+		TargetProvider: "aws-ec2-ssm",
+		TargetID:       "buildbox-1234",
+	})
+	if got != "remote_vm/aws-ec2-ssm/buildbox-1234" {
+		t.Fatalf("SessionTargetSummary() = %q", got)
 	}
 }
 
@@ -463,6 +489,12 @@ func TestSessionRuntimeMetadataLines(t *testing.T) {
 	want := []string{
 		"session_id=session-1",
 		"profile=wcl-one",
+		"target_kind=local_vm",
+		"target_provider=colima",
+		"target_id=wcl-one",
+		"target_assurance_class=strict",
+		"runtime_api=docker",
+		"workspace_transport=isolated-worktree-mount",
 		"workspace=/tmp/workspace",
 		"workspace_origin=/tmp/source-workspace",
 		"workspace_root=/tmp",
@@ -486,6 +518,87 @@ func TestSessionRuntimeMetadataLines(t *testing.T) {
 	for i := range want {
 		if lines[i] != want[i] {
 			t.Fatalf("SessionRuntimeMetadataLines()[%d] = %q, want %q", i, lines[i], want[i])
+		}
+	}
+}
+
+func TestSessionShowLines(t *testing.T) {
+	t.Parallel()
+
+	lines := SessionShowLines(SessionRecord{
+		SessionID:             "session-1",
+		Profile:               "wcl-one",
+		Workspace:             "/tmp/workspace",
+		WorkspaceOrigin:       "/tmp/source-workspace",
+		WorkspaceRoot:         "/tmp",
+		WorktreePath:          "/tmp/workspace/.worktrees/session-1",
+		GitBranch:             "feature/session-observability",
+		GitHead:               "abcdef1234567890",
+		GitBase:               "1234567890abcdef",
+		ContainerName:         "workcell-session-1",
+		MonitorPID:            "4242",
+		Status:                "running",
+		Mode:                  "strict",
+		LiveStatus:            "running",
+		CurrentAssurance:      "managed-mutable",
+		SessionAuditDir:       "/tmp/session-audit.1234",
+		AuditLogPath:          "/tmp/audit.log",
+		DebugLogPath:          "/tmp/debug.log",
+		FileTraceLogPath:      "/tmp/file-trace.log",
+		TranscriptLogPath:     "/tmp/transcript.log",
+		StartedAt:             "2026-04-08T12:00:00Z",
+		ObservedAt:            "2026-04-08T12:00:30Z",
+		WorkspaceControlPlane: "masked",
+	})
+
+	want := []string{
+		"session_id=session-1",
+		"profile=wcl-one",
+		"target_kind=local_vm",
+		"target_provider=colima",
+		"target_id=wcl-one",
+		"target_summary=local_vm/colima/wcl-one",
+		"target_assurance_class=strict",
+		"runtime_api=docker",
+		"control=detached",
+		"agent=",
+		"mode=strict",
+		"ui=",
+		"execution_path=",
+		"status=running",
+		"live_status=running",
+		"assurance=managed-mutable",
+		"workspace_transport=isolated-worktree-mount",
+		"workspace=/tmp/workspace",
+		"display_workspace=/tmp/source-workspace",
+		"workspace_origin=/tmp/source-workspace",
+		"workspace_root=/tmp",
+		"worktree_path=/tmp/workspace/.worktrees/session-1",
+		"git_branch=feature/session-observability",
+		"git_head=abcdef1234567890",
+		"git_base=1234567890abcdef",
+		"container_name=workcell-session-1",
+		"monitor_pid=4242",
+		"started_at=2026-04-08T12:00:00Z",
+		"observed_at=2026-04-08T12:00:30Z",
+		"finished_at=",
+		"exit_status=",
+		"initial_assurance=",
+		"current_assurance=managed-mutable",
+		"final_assurance=",
+		"session_audit_dir=/tmp/session-audit.1234",
+		"audit_log_path=/tmp/audit.log",
+		"debug_log_path=/tmp/debug.log",
+		"file_trace_log_path=/tmp/file-trace.log",
+		"transcript_log_path=/tmp/transcript.log",
+		"workspace_control_plane=masked",
+	}
+	if len(lines) != len(want) {
+		t.Fatalf("SessionShowLines() len = %d, want %d", len(lines), len(want))
+	}
+	for i := range want {
+		if lines[i] != want[i] {
+			t.Fatalf("SessionShowLines()[%d] = %q, want %q", i, lines[i], want[i])
 		}
 	}
 }

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -591,7 +591,9 @@ Detached session lifecycle on the host:
 .EX
 workcell session start --agent codex --workspace /path/to/repo
 workcell session list
+workcell session list --verbose
 workcell session show --id SESSION_ID
+workcell session show --id SESSION_ID --text
 workcell session delete --id SESSION_ID
 .EE
 .PP

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "7938c1d8c400245b9cba8bf0d57333bb0a6afe0f35763d99c13be70a72f6932a"
+      "sha256": "b576718077a196b764a05954fbff77ecf0d524ae932212324a1a4eaf5e0de0cd"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1223,6 +1223,35 @@ load_session_runtime_metadata() {
   done < <(session_runtime_metadata "${session_id}")
 }
 
+current_target_kind() {
+  printf 'local_vm\n'
+}
+
+current_target_provider() {
+  printf 'colima\n'
+}
+
+current_target_id() {
+  printf '%s\n' "${COLIMA_PROFILE}"
+}
+
+current_target_assurance_class() {
+  printf 'strict\n'
+}
+
+current_runtime_api() {
+  printf 'docker\n'
+}
+
+current_workspace_transport() {
+  if [[ -n "${SESSION_SOURCE_WORKSPACE:-}" ]] && [[ -n "${WORKSPACE:-}" ]] &&
+    [[ "${SESSION_SOURCE_WORKSPACE}" != "${WORKSPACE}" ]]; then
+    printf 'isolated-worktree-mount\n'
+    return 0
+  fi
+  printf 'workspace-mount\n'
+}
+
 session_record_matches_attached_workspace_shape() {
   [[ -n "${SESSION_META_WORKSPACE:-}" ]] || return 1
   [[ -n "${SESSION_META_WORKSPACE_ORIGIN:-}" ]] || return 1
@@ -1999,6 +2028,12 @@ write_session_record_initial() {
   write_session_record "${SESSION_RECORD_PATH}" \
     "session_id=${SESSION_ID}" \
     "profile=${profile}" \
+    "target_kind=$(current_target_kind)" \
+    "target_provider=$(current_target_provider)" \
+    "target_id=$(current_target_id)" \
+    "target_assurance_class=$(current_target_assurance_class)" \
+    "runtime_api=$(current_runtime_api)" \
+    "workspace_transport=$(current_workspace_transport)" \
     "agent=${AGENT}" \
     "mode=${MODE}" \
     "status=$([[ "${SESSION_DETACHED}" -eq 1 ]] && printf 'starting' || printf 'running')" \
@@ -2817,9 +2852,11 @@ Commands:
     --workspace PATH          Filter recorded attached and detached sessions to PATH
     --colima-profile NAME     Filter recorded attached and detached sessions to the selected profile
     --json                    Emit machine-readable JSON instead of the default table with live status and control
+    --verbose                 Emit a wider text table with target and workspace-transport metadata
 
   show
-    --id SESSION_ID           Show one recorded session as JSON
+    --id SESSION_ID           Show one recorded session
+    --text                    Emit stable key=value lines instead of JSON
 
   delete
     --id SESSION_ID           Delete one terminal recorded session and clean stopped local artifacts
@@ -3707,6 +3744,8 @@ session_main() {
   local workspace=""
   local profile=""
   local emit_json=0
+  local emit_verbose=0
+  local emit_text=0
   local session_id=""
   local output_path=""
   local output=""
@@ -3763,6 +3802,10 @@ session_main() {
             emit_json=1
             shift
             ;;
+          --verbose)
+            emit_verbose=1
+            shift
+            ;;
           -h | --help)
             session_usage
             exit 0
@@ -3775,8 +3818,15 @@ session_main() {
         esac
       done
       args=("${COLIMA_STATE_ROOT}")
+      if [[ "${emit_json}" -eq 1 ]] && [[ "${emit_verbose}" -eq 1 ]]; then
+        echo "workcell session list accepts either --json or --verbose, not both." >&2
+        exit 2
+      fi
       if [[ "${emit_json}" -eq 1 ]]; then
         args+=(--json)
+      fi
+      if [[ "${emit_verbose}" -eq 1 ]]; then
+        args+=(--verbose)
       fi
       if [[ -n "${workspace}" ]]; then
         args+=("--workspace=${workspace}")
@@ -3792,6 +3842,9 @@ session_main() {
       fi
       if [[ "${emit_json}" -eq 1 ]]; then
         printf '%s\n' "${output}"
+      elif [[ "${emit_verbose}" -eq 1 ]]; then
+        printf 'session_id\tstatus\tlive_status\tcontrol\tagent\tmode\tprofile\ttarget\ttarget_assurance\tworkspace_transport\tstarted_at\tassurance\tworkspace\n'
+        printf '%s\n' "${output}"
       else
         printf 'session_id\tstatus\tlive_status\tcontrol\tagent\tmode\tprofile\tstarted_at\tassurance\tworkspace\n'
         printf '%s\n' "${output}"
@@ -3804,6 +3857,10 @@ session_main() {
           --id)
             session_id="$(option_value_or_die "$1" "${2-}")"
             shift 2
+            ;;
+          --text)
+            emit_text=1
+            shift
             ;;
           -h | --help)
             session_usage
@@ -3820,7 +3877,11 @@ session_main() {
         echo "workcell session show requires --id." >&2
         exit 2
       }
-      go_hostutil launcher session-show "${COLIMA_STATE_ROOT}" "${session_id}"
+      args=("${COLIMA_STATE_ROOT}" "${session_id}")
+      if [[ "${emit_text}" -eq 1 ]]; then
+        args+=(--text)
+      fi
+      go_hostutil launcher session-show "${args[@]}"
       exit 0
       ;;
     delete)
@@ -4938,6 +4999,12 @@ print_inspect_state() {
   latest_file_trace_log="$(read_latest_log_pointer "${COLIMA_PROFILE}" file-trace || true)"
   latest_transcript_log="$(read_latest_log_pointer "${COLIMA_PROFILE}" transcript || true)"
   printf 'profile=%s\n' "${COLIMA_PROFILE}"
+  printf 'target_kind=%s\n' "$(current_target_kind)"
+  printf 'target_provider=%s\n' "$(current_target_provider)"
+  printf 'target_id=%s\n' "$(current_target_id)"
+  printf 'target_assurance_class=%s\n' "$(current_target_assurance_class)"
+  printf 'runtime_api=%s\n' "$(current_runtime_api)"
+  printf 'workspace_transport=%s\n' "$(current_workspace_transport)"
   printf 'workspace=%s\n' "${WORKSPACE}"
   printf 'workspace_status=%s\n' "$(workspace_status "${WORKSPACE}")"
   printf 'agent=%s\n' "${AGENT:-none}"
@@ -7634,6 +7701,13 @@ fi
 
 printf 'profile=%s mode=%s agent=%s ui=%s workspace=%s\n' \
   "${COLIMA_PROFILE}" "${MODE}" "${AGENT}" "${UI}" "${WORKSPACE}" >&2
+printf 'target_kind=%s target_provider=%s target_id=%s target_assurance_class=%s runtime_api=%s workspace_transport=%s\n' \
+  "$(current_target_kind)" \
+  "$(current_target_provider)" \
+  "$(current_target_id)" \
+  "$(current_target_assurance_class)" \
+  "$(current_runtime_api)" \
+  "$(current_workspace_transport)" >&2
 printf 'agent_autonomy=%s\n' "${AGENT_AUTONOMY}" >&2
 printf 'vm_resources=cpu=%s memory_gib=%s disk_gib=%s\n' "${COLIMA_CPU}" "${COLIMA_MEMORY}" "${COLIMA_DISK}" >&2
 printf 'container_resources=mutability=%s cpu=%s memory=%s\n' \

--- a/tests/scenarios/shared/test-agent-launch-smoke.sh
+++ b/tests/scenarios/shared/test-agent-launch-smoke.sh
@@ -112,12 +112,14 @@ run_agent_version_smoke() {
 
 prepare_runtime
 grep -q "^profile=${PROFILE} mode=strict agent=codex " "${TMP_DIR}/prepare.stderr"
+grep -q '^target_kind=local_vm target_provider=colima target_id='"${PROFILE}"' target_assurance_class=strict runtime_api=docker workspace_transport=workspace-mount$' "${TMP_DIR}/prepare.stderr"
 grep -q "Prepared runtime image recorded for profile ${PROFILE}. No session launched because --prepare-only was requested." "${TMP_DIR}/prepare.stderr"
 
 for agent in codex claude gemini; do
   expected_version="$(expected_runtime_version "${agent}")"
   run_agent_version_smoke "${agent}"
   grep -q "^profile=${PROFILE} mode=strict agent=${agent} " "${TMP_DIR}/${agent}.stderr"
+  grep -q '^target_kind=local_vm target_provider=colima target_id='"${PROFILE}"' target_assurance_class=strict runtime_api=docker workspace_transport=workspace-mount$' "${TMP_DIR}/${agent}.stderr"
   grep -q '^execution_path=managed-tier1 audit_log=' "${TMP_DIR}/${agent}.stderr"
   cat "${TMP_DIR}/${agent}.stdout" "${TMP_DIR}/${agent}.stderr" >"${TMP_DIR}/${agent}.combined"
   grep -q '[^[:space:]]' "${TMP_DIR}/${agent}.combined"

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -227,6 +227,10 @@ grep -q $'^'"${SESSION_TWO}"$'\tfailed\tstopped\tdetached\tclaude\tdevelopment\t
 grep -q $'^'"${SESSION_ATTACHED_LIVE}"$'\trunning\trunning\tattached\tcodex\tstrict\t'"${PROFILE}"$'\t2026-04-08T10:15:00Z\tmanaged-mutable\t'"${WORKSPACE_A}"'$' <<<"${list_output}"
 grep -q $'^'"${SESSION_ONE}"$'\texited\tstopped\tattached\tcodex\tstrict\t'"${PROFILE}"$'\t2026-04-08T10:00:00Z\tmanaged-mutable\t'"${WORKSPACE_A}"'$' <<<"${list_output}"
 
+list_verbose_output="$("${ROOT_DIR}/scripts/workcell" session list --verbose --colima-profile "${PROFILE}")"
+grep -q '^session_id[[:space:]]status[[:space:]]live_status[[:space:]]control[[:space:]]agent[[:space:]]mode[[:space:]]profile[[:space:]]target[[:space:]]target_assurance[[:space:]]workspace_transport[[:space:]]started_at[[:space:]]assurance[[:space:]]workspace$' <<<"${list_verbose_output}"
+grep -q $'^'"${SESSION_TWO}"$'\tfailed\tstopped\tdetached\tclaude\tdevelopment\t'"${PROFILE}"$'\tlocal_vm/colima/'"${PROFILE}"$'\tstrict\tisolated-worktree-mount\t2026-04-08T11:00:00Z\tmanaged-mutable\t'"${WORKSPACE_A}"'$' <<<"${list_verbose_output}"
+
 if command -v script >/dev/null 2>&1; then
   tty_list_cmd=("${ROOT_DIR}/scripts/workcell" session list --colima-profile "${PROFILE}")
   if script_help="$(script --help 2>&1 || true)" && grep -q -- ' -c, --command ' <<<"${script_help}"; then
@@ -303,10 +307,22 @@ grep -q '^This session is still running\.$' <<<"${delete_running_stderr}"
 list_json="$("${ROOT_DIR}/scripts/workcell" session list --json --workspace "${WORKSPACE_A}" --colima-profile "${PROFILE}")"
 grep -q "\"session_id\": \"${SESSION_ONE}\"" <<<"${list_json}"
 grep -q "\"session_id\": \"${SESSION_TWO}\"" <<<"${list_json}"
+grep -q '"target_kind": "local_vm"' <<<"${list_json}"
+grep -q '"target_provider": "colima"' <<<"${list_json}"
+grep -q '"target_assurance_class": "strict"' <<<"${list_json}"
 
 show_output="$("${ROOT_DIR}/scripts/workcell" session show --id "${SESSION_TWO}")"
 grep -q "\"session_id\": \"${SESSION_TWO}\"" <<<"${show_output}"
 grep -q '"status": "failed"' <<<"${show_output}"
+grep -q '"target_kind": "local_vm"' <<<"${show_output}"
+grep -q '"workspace_transport": "isolated-worktree-mount"' <<<"${show_output}"
+
+show_text_output="$("${ROOT_DIR}/scripts/workcell" session show --id "${SESSION_TWO}" --text)"
+grep -q '^target_summary=local_vm/colima/'"${PROFILE}"'$' <<<"${show_text_output}"
+grep -q '^workspace_transport=isolated-worktree-mount$' <<<"${show_text_output}"
+grep -q '^worktree_path='"${WORKSPACE_B}/.worktrees/${SESSION_TWO}"'$' <<<"${show_text_output}"
+show_text_with_git="$("${ROOT_DIR}/scripts/workcell" session show --id "${SESSION_ONE}" --text)"
+grep -q '^git_branch='"${GIT_BRANCH}"'$' <<<"${show_text_with_git}"
 
 diff_stdout="$("${ROOT_DIR}/scripts/workcell" session diff --id "${SESSION_ONE}" --output "${DIFF_PATH}")"
 grep -q "^session_diff=${DIFF_PATH}$" <<<"${diff_stdout}"


### PR DESCRIPTION
## Summary
- persist normalized target metadata in durable session records and runtime metadata helpers
- add `workcell session list --verbose` and `workcell session show --text`
- surface target summaries in docs and scenario coverage for the detached session workflow

## Validation
- `go test ./internal/hostutil ./cmd/workcell-hostutil`
- `bash ./tests/scenarios/shared/test-session-commands.sh`
- `bash ./scripts/verify-operator-contract.sh`
- `bash ./scripts/verify-requirements-coverage.sh`
- `bash ./scripts/check-dead-code.sh`
- `bash ./scripts/check-public-repo-hygiene.sh`

## Notes
- signed commits used the narrow upstream-refresh pre-commit bypass because unrelated pinned-input updates are currently available and were intentionally kept out of scope
