### PR TITLE
Add deterministic scenario validation tiers

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,10 +3,15 @@
 Workcell is still pre-1.0. The next roadmap slices should turn the shipped
 host-side inspection and policy surfaces into a first-class session platform,
 then expand deployment reach without weakening the current VM plus container
-boundary. Delivered features belong in the changelog and user docs rather than
+boundary. Deployment reach should expand through explicit runtime-target
+classes and support tiers rather than a flat notion of interchangeable
+backends. Delivered features belong in the changelog and user docs rather than
 remaining on this roadmap.
 The delivery shape for the active slice lives in
-`docs/implement-first-delivery-plan.md`.
+`docs/implement-first-delivery-plan.md`. The longer-lived runtime-target and
+deployment-reach program lives in `docs/runtime-target-expansion-plan.md`.
+The deterministic phase breakdown lives in
+`docs/runtime-target-phase-plan.md`.
 
 ## Short term
 
@@ -19,10 +24,19 @@ The delivery shape for the active slice lives in
 - expand end-to-end coverage for authenticated, lower-assurance, and
   session-supervisor transitions so new orchestration features ship with
   invariant checks
-- define the first remote and non-macOS deployment targets explicitly:
-  trusted `linux/amd64` validation hosts, operator-managed deployment targets,
-  and the first cloud-spawn path, without claiming Tier 1 Linux or Windows host
-  parity before the same guarantees exist
+- define the runtime-target model explicitly:
+  separate target kind, assurance class, and workspace transport in the
+  control plane, CLI, docs, and session records
+- generalize host-owned state and session metadata away from Colima-specific
+  `profile` and `~/.colima/...` assumptions while preserving compatibility
+  reads for existing records
+- extract `colima` behind the new target model without changing the current
+  strict macOS contract
+- add a narrow trusted `linux/amd64` validation-host lane plus target-aware
+  diagnostics before broad non-macOS or cloud support claims
+- define the first cross-platform `compat` target and the first `remote_vm`
+  target explicitly, without claiming Tier 1 Linux or Windows host parity
+  before the same guarantees exist
 
 ## Medium term
 
@@ -32,20 +46,30 @@ The delivery shape for the active slice lives in
   instruction bundles, commands, approved MCP packs, and task templates
 - add a lightweight TUI or dashboard backed by the same host-controlled
   session plane rather than a separate execution path
-- deliver the first cloud-spawned workspace path for the highest-value use
-  cases:
+- ship the first cross-platform compatibility backend with explicit
+  lower-assurance labeling and backend-aware diagnostics
+- deliver the first remote VM backend for the highest-value use cases:
   secure ephemeral repro and PR environments, standardized onboarding
   environments, and sandboxed agent workspaces in the operator's own account
+- reuse the same remote VM contract for the second cloud provider with limited
+  provider-specific delta
+- keep managed workstations as a separate discovery track rather than treating
+  them as the same class as raw remote VMs
 - improve comparison material and use-case guidance for teams evaluating
   Workcell in cloud, hybrid, and regulated development workflows
 - make release assets and operator verification flows easier to consume
 
 ## Long term
 
-- expand cloud spawning across the major providers `AWS`, `Azure`, and `GCP`
-  through thin provider adapters rather than provider-specific trust models
+- expand remote VM support across the major providers through thin provider
+  adapters on the same host-owned control-plane model:
+  `AWS` first, `GCP` second, and `Azure` demand-gated third
 - add explicit Linux and Windows support only where the same boundary
-  guarantees, validation coverage, and operator story can be stated honestly
+  guarantees, validation coverage, and operator story can be stated honestly;
+  until then, keep those paths labeled `compat`
+- evaluate managed workstation targets as a separate product mode with their
+  own lifecycle and trust model rather than as peers to local VM or remote VM
+  targets
 - add enterprise policy administration, centralized session inventory, and
   usage and audit analytics
 - add preserved-boundary GUI and IDE entrypoints backed by the same session
@@ -56,3 +80,9 @@ The delivery shape for the active slice lives in
 - weakening the dedicated VM plus container boundary for convenience
 - pretending provider config or prompt files are the primary security boundary
 - claiming Linux or Windows parity before the same security guarantees exist
+- automatic backend fallback
+- a fake universal backend abstraction that hides real provider and runtime
+  differences
+- treating `compat` backends as equivalent to the current strict Colima path
+- folding Kubernetes-backed execution into the same near-term backend program
+- treating managed workstations as interchangeable with raw remote VMs

--- a/docs/implement-first-delivery-plan.md
+++ b/docs/implement-first-delivery-plan.md
@@ -3,6 +3,12 @@
 This document turns the current short-term roadmap into a concrete delivery
 shape that keeps the boundary model intact and favors additive host-side
 changes on top of the inspection and policy surfaces that already shipped.
+The longer-lived runtime-target and deployment-reach program lives in
+[`docs/runtime-target-expansion-plan.md`](runtime-target-expansion-plan.md),
+and the deterministic phase breakdown lives in
+[`docs/runtime-target-phase-plan.md`](runtime-target-phase-plan.md);
+this document covers only the active slice that must land before broader target
+claims become supportable.
 
 The current repo already includes durable session records plus detached
 host-side session control (`session start|attach|send|stop`) and basic
@@ -17,8 +23,12 @@ rendering, and deeper validation coverage.
   orchestration
 - build mutable workflow features on top of the shipped read-only inspection
   surface rather than replacing it
+- preserve session-platform parity as target identity, assurance, and workspace
+  transport metadata evolve
 - share one policy and auth evaluation path across launcher, diagnostics, and
   operator tooling
+- require explicit scenario evidence and operator verification material before
+  broadening support claims
 - bias toward simple, testable, fail-closed behavior over broad feature reach
 
 ## Distinguished Engineer Checkpoints
@@ -42,6 +52,8 @@ Scope for this delivery slice:
   `session send`, and `session stop`
 - default the safe path to one worktree per session when the operator opts into
   orchestrated session flows
+- carry target identity, assurance, workspace mode, and workspace transport
+  through the session surface as the underlying state model evolves
 - keep the detached session path file-backed and host-owned rather than adding
   same-user local socket trust as a shortcut
 - keep the implementation host-owned and file-backed; do not add same-user
@@ -59,6 +71,9 @@ Scope for this delivery slice:
 
 - extend the shipped logs, transcript pointers, and command timeline views
   with clearer live status, branch/worktree, and assurance rendering
+- make the same rendering target-aware so operators can understand which
+  execution shape they are inspecting without guessing from Colima-specific
+  names
 - keep the first operator-facing surfaces CLI-first
 - add a lightweight TUI or dashboard only after the session object and status
   model stabilize
@@ -70,18 +85,27 @@ Staffing:
 - SWE A: host-side session state and status rendering
 - SWE B: shell integration and artifact plumbing
 
-### 3. Deployment Reach And Auth Coverage
+### 3. Runtime Target Foundations, Auth, and Validation Reach
 
 Scope for this delivery slice:
 
+- define the runtime-target model explicitly:
+  separate target kind, assurance class, and workspace transport in launcher
+  metadata, diagnostics, and session records
+- generalize host-owned state, audit metadata, and detached-session records
+  away from Colima-specific `profile` and `~/.colima/...` assumptions while
+  preserving compatibility reads for existing records
 - keep the shipped auth helpers and explainability surface aligned with new
   launch modes
 - broaden resolver coverage without turning provider-native auth into the
   security boundary
 - keep browser or setup handoffs explicit and host-owned where provider
   onboarding still needs credential bootstrap help
-- define the first remote and cloud deployment targets without weakening the
-  Tier 1 boundary or overstating Linux and Windows support
+- define a narrow trusted `linux/amd64` validation-host lane plus phase gates
+  for non-macOS and remote-target evidence
+- define the first cross-platform `compat` target and the first `remote_vm`
+  target without weakening the Tier 1 boundary or overstating Linux and
+  Windows support
 
 Staffing:
 
@@ -89,16 +113,37 @@ Staffing:
 - SWE A: resolver metadata and auth-state reasoning
 - SWE B: deployment-target documentation and scenario coverage
 
+### 4. Scenario Evidence And Operator Verification
+
+Scope for this delivery slice:
+
+- expand authenticated, lower-assurance, session-supervisor, migration, and
+  remote-workspace scenario coverage as each target-facing phase lands
+- treat comparison material and operator verification flows as delivery
+  criteria, not post-hoc documentation cleanup
+- keep the first operator-facing rollout guidance CLI-first and host-owned
+
+Staffing:
+
+- TL: validation and contract lead
+- SWE A: scenario and migration evidence
+- SWE B: operator verification docs and comparison material
+
 ## Sequence
 
 1. build mutable orchestration on top of the shipped inventory and inspection
    surface rather than replacing it
 2. add worktree-per-session defaults and status surfaces before any dashboard
    work
-3. expand authenticated and lower-assurance scenario coverage as new session
-   commands land
-4. only then add the first remote or cloud-spawn path against the same
-   host-owned policy model
+3. refactor state, diagnostics, and auth/bootstrap onto the runtime-target
+   model while preserving session-surface parity
+4. define trusted `linux/amd64` validation hosts and explicit evidence gates
+   before broad non-macOS or remote-target claims
+5. expand authenticated and lower-assurance scenario coverage as each phase
+   lands rather than as a cleanup pass
+6. only then define and prepare the first cross-platform `compat` and
+   `remote_vm` paths against the same host-owned policy model, leaving their
+   actual delivery to the runtime-target expansion program
 
 ## Non-Goals In This Slice
 
@@ -107,3 +152,6 @@ Staffing:
 - default-open networking
 - workspace-controlled policy overrides
 - secret materialization paths that bypass the reviewed host policy flow
+- automatic backend fallback
+- broad Linux or Windows parity claims
+- Kubernetes-backed execution or managed-workstation delivery in this slice

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -269,8 +269,15 @@ Useful commands:
 
 ```sh
 ./scripts/verify-requirements-coverage.sh
-./scripts/run-scenario-tests.sh --secretless-only
+./scripts/run-scenario-tests.sh --repo-required
 ./scripts/verify-scenario-coverage.sh
+```
+
+When a release touches the local runtime boundary or launch path, also run the
+local certification lane on a machine that has the live runtime prerequisites:
+
+```sh
+./scripts/run-scenario-tests.sh --secretless-only --certification-only
 ```
 
 Perform the release documentation review on the exact branch diff:

--- a/docs/runtime-target-expansion-plan.md
+++ b/docs/runtime-target-expansion-plan.md
@@ -1,0 +1,181 @@
+# Runtime Target Expansion Plan
+
+This document is the durable planning surface for Workcell's runtime-target and
+deployment-reach expansion. It complements:
+
+- [ROADMAP.md](../ROADMAP.md) for high-level direction and non-goals
+- [runtime-target-phase-plan.md](runtime-target-phase-plan.md) for the
+  deterministic delivery-phase breakdown
+- [docs/implement-first-delivery-plan.md](implement-first-delivery-plan.md) for
+  the active slice that is in flight now
+
+It exists to keep the longer program coherent across iterations without
+turning the roadmap into a checklist or overloading the active-slice plan with
+later-phase decisions.
+
+## Current Contract
+
+Today Workcell's supported Tier 1 contract is:
+
+- Apple Silicon macOS host
+- dedicated Colima VM plus hardened container
+- host-owned control plane, policy, audit, and detached session flows
+
+This program does not relax that contract. It expands deployment reach by
+introducing explicit runtime-target classes, support tiers, and review gates so
+new targets can be added without overstating equivalence to the current strict
+path.
+
+## Terms
+
+- `target kind`: the execution shape being selected, such as `local_vm`,
+  `local_compat`, `remote_vm`, or `managed_workstation`
+- `assurance class`: the support tier attached to a target, such as `strict` or
+  `compat`
+- `workspace transport`: how the workspace reaches the runtime, such as local
+  mount, isolated worktree mount, or remote materialization
+
+These are separate concepts in the control plane, docs, diagnostics, and
+session records.
+`strict` is reserved for targets that preserve the dedicated VM plus hardened
+container boundary and pass backend-specific invariant checks. Other supported
+targets must stay labeled `compat` or another explicitly lower-assurance class.
+
+## Planning Principles
+
+- keep one shared boundary and many thin adapters; do not hide real provider
+  differences behind a fake universal abstraction
+- keep the host control plane authoritative for policy, diagnostics, and audit
+- preserve the active session-platform slice as state, diagnostics, and target
+  metadata evolve
+- require explicit scenario evidence and operator verification material before
+  broadening support claims
+- treat managed workstations as a separate product mode from raw remote VMs
+- keep Kubernetes-backed execution out of this program
+
+## Recommended Support Order
+
+### Current strict target
+
+- `colima` remains the strict macOS default
+
+### First cross-platform compatibility target
+
+- `docker-desktop` is the first cross-platform `compat` target on macOS, Linux,
+  and Windows
+- it must stay explicitly lower assurance than the current Colima path
+
+### Remote VM targets
+
+- `aws-ec2-ssm` is the first `remote_vm` target
+- `gcp-vm` is the second `remote_vm` target on the same control-plane contract
+- `azure-vm` is demand-gated and follows only after the first two remote VM
+  targets stabilize
+
+### Managed workstation targets
+
+- `gcp-cloud-workstations` stays a later managed-workstation track
+- other managed-workstation candidates are evaluated separately from the raw
+  remote VM program
+
+## Program Workstreams
+
+### 1. Session platform parity
+
+- preserve and extend the shipped session surface during target-model and state
+  migration
+- carry target, assurance, and workspace-transport rendering into session
+  inspection and control flows, not only `doctor` and `inspect`
+
+### 2. Runtime target and state model
+
+- introduce explicit target identity and capability reporting
+- generalize session, audit, and lock state away from Colima-specific paths
+  while preserving compatibility reads
+- keep `colima` behavior unchanged until the new model is proven
+
+### 3. Shared auth and bootstrap
+
+- broaden resolver coverage and bootstrap handoffs on the same host-owned auth
+  path used by launcher, diagnostics, and operator tooling
+- make remote-target auth dependencies explicit before any cloud preview
+
+### 4. Trusted validation hosts and host compatibility
+
+- define a narrow trusted `linux/amd64` validation-host lane before broad
+  non-macOS claims
+- express support as `host OS x target kind x assurance class`
+- do not claim Linux or Windows `strict` parity until the same guarantees are
+  proven there
+
+### 5. Backend delivery
+
+- extract `colima` behind the new target model first
+- add `docker-desktop` as the first `compat` target
+- add `aws-ec2-ssm` as the first `remote_vm` target
+- add `gcp-vm` as the second `remote_vm` target
+- keep `azure-vm` and managed workstations behind later decision gates
+
+### 6. Scenario evidence and operator verification
+
+- expand authenticated, lower-assurance, session-supervisor, migration, and
+  remote-workspace scenario coverage as each phase lands
+- treat comparison material, operator verification guidance, and rollout docs
+  as exit criteria rather than post-hoc documentation
+
+## Phase Gates
+
+### Gate 1: target taxonomy approved
+
+- target kind, assurance class, and workspace transport are frozen as separate
+  concepts
+- no support claim weakens the current strict Colima contract
+
+### Gate 2: Colima parity complete
+
+- Colima runs unchanged through the new target model
+- session and audit state are no longer Colima-shaped at the program level
+- session-surface parity is preserved
+
+### Gate 3: compatibility target certified
+
+- `docker-desktop` is feature-flagged, explicitly `compat`, and backed by
+  target-aware diagnostics
+- Linux and Windows support claims remain limited to what the evidence proves
+
+### Gate 4: first remote VM preview
+
+- remote workspace materialization is explicit and auditable
+- the remote target uses reviewed brokered access and does not require inbound
+  public SSH
+- shared auth/bootstrap and scenario evidence are in place
+
+### Gate 5: second remote VM on the same contract
+
+- the second cloud provider fits the same control-plane and audit model with
+  limited provider-specific delta
+
+### Gate 6: later expansion decision
+
+- demand and support load justify whether `azure-vm` or managed workstations
+  become funded follow-on work
+
+## Program Non-Goals
+
+- automatic backend fallback
+- a flat backend abstraction that hides real provider and runtime differences
+- treating `compat` targets as equivalent to the current strict Colima path
+- Kubernetes-backed execution modes in this program
+- folding managed workstations into the same target class as raw remote VMs
+- Linux or Windows `strict` parity claims before the same guarantees are
+  implemented and validated
+
+## Maintenance Expectations
+
+- update [ROADMAP.md](../ROADMAP.md) when direction, support tiers, or
+  non-goals change
+- update this document when sequencing, target order, or review gates change
+- update [docs/implement-first-delivery-plan.md](implement-first-delivery-plan.md)
+  when the active slice or immediate next slice changes
+- keep docs, support claims, and automated evidence aligned in the same change
+  before new target claims are treated as supported

--- a/docs/runtime-target-phase-plan.md
+++ b/docs/runtime-target-phase-plan.md
@@ -1,0 +1,210 @@
+# Runtime Target Deterministic Phase Plan
+
+This document turns the runtime-target expansion program into deterministic
+delivery phases that can be completed, reviewed, and verified atomically. It
+complements:
+
+- [ROADMAP.md](../ROADMAP.md) for high-level direction
+- [docs/runtime-target-expansion-plan.md](runtime-target-expansion-plan.md) for
+  the durable program model
+- [docs/implement-first-delivery-plan.md](implement-first-delivery-plan.md) for
+  the current active slice
+
+Current repo status:
+
+- Phase 0 is implemented in the validation substrate
+- later phases remain planning targets until their code and evidence land
+
+## Phase Completion Contract
+
+Each phase is complete only when:
+
+- code, docs, and support-boundary claims land in the same change set
+- `./scripts/validate-repo.sh` is green without depending on live Colima,
+  cloud state, or real provider credentials
+- environment-dependent runtime proof stays in explicit certification lanes
+  rather than the repo-required validation path
+- the phase does not overstate host, backend, or assurance support beyond what
+  the current evidence proves
+
+## Phase 0: Validation substrate hardening
+
+Goal:
+
+- separate deterministic repo-required validation from local runtime or cloud
+  certification smoke
+
+Deliverables:
+
+- scenario metadata distinguishes repo-required validation from certification
+  smoke
+- `./scripts/validate-repo.sh` runs only the repo-required scenario tier
+- local runtime smoke remains available through an explicit certification lane
+- docs explain which commands are repo-required versus certification-only
+
+Complete when:
+
+- repo validation no longer depends on live Colima or cloud state
+- certification smoke still has an explicit, documented invocation
+
+## Phase 1: Session platform completion and target taxonomy freeze
+
+Goal:
+
+- finish the current session-platform slice while freezing `target kind`,
+  `assurance class`, and `workspace transport` as separate control-plane
+  concepts
+
+Deliverables:
+
+- coherent session inventory, inspection, and detached control surfaces
+- safer default worktree-per-session behavior where the current slice calls for
+  it
+- target-aware session rendering, diagnostics, and durable metadata
+
+Complete when:
+
+- the shipped session surface remains coherent under deterministic scenario and
+  unit coverage
+- target taxonomy is fixed in code, docs, and session records
+
+## Phase 2: State-model decoupling and Colima driver extraction
+
+Goal:
+
+- remove program-level Colima shaping while preserving the current strict
+  macOS behavior
+
+Deliverables:
+
+- session, audit, and lock state no longer depend on `.colima` or `profile`
+  as the universal program model
+- compatibility reads preserve existing durable records
+- `colima` becomes an explicit driver on the new target model
+
+Complete when:
+
+- migration fixtures pass
+- Colima parity is proven without user-visible regression
+
+## Phase 3: Shared auth and bootstrap
+
+Goal:
+
+- move resolver coverage and provider bootstrap handoffs onto one reviewed
+  host-owned auth path
+
+Deliverables:
+
+- broader resolver coverage
+- explicit host-owned browser or setup handoffs where provider bootstrap still
+  needs them
+- shared diagnostics and explainability across launcher and operator tooling
+
+Complete when:
+
+- deterministic auth and bootstrap suites pass without live provider
+  dependence
+
+## Phase 4: Trusted validation hosts and host-compatibility matrix
+
+Goal:
+
+- define the validation-host bridge and support matrix before broader host
+  claims
+
+Deliverables:
+
+- trusted `linux/amd64` validation-host lane
+- support matrix expressed as `host OS x target kind x assurance class`
+- backend-aware diagnostics that fail closed on unsupported combinations
+
+Complete when:
+
+- Linux and Windows support claims are limited to what the validation-host
+  evidence and docs prove
+
+## Phase 5: Remote VM control-plane contract
+
+Goal:
+
+- define the provider-neutral remote VM contract before any cloud-specific
+  backend ships
+
+Deliverables:
+
+- explicit remote workspace materialization
+- reviewed brokered-access model
+- remote image/bootstrap contract and session/audit lifecycle
+
+Complete when:
+
+- deterministic remote-contract tests pass without real cloud dependence
+
+## Phase 6: Docker Desktop compatibility backend
+
+Goal:
+
+- ship the first cross-platform `compat` target without blurring it into the
+  current strict boundary
+
+Deliverables:
+
+- feature-flagged `docker-desktop` target
+- explicit `compat` labeling in docs, diagnostics, and session metadata
+- host-matrix certification evidence
+
+Complete when:
+
+- the repo keeps `docker-desktop` support clearly lower assurance than the
+  current strict Colima path
+
+## Phase 7: AWS remote VM backend
+
+Goal:
+
+- implement the remote VM contract on the first cloud provider
+
+Deliverables:
+
+- `aws-ec2-ssm` target
+- audited lifecycle and brokered access
+- explicit remote workspace materialization on the reviewed host-owned model
+
+Complete when:
+
+- deterministic adapter and contract suites pass
+- live AWS smoke remains certification-only
+
+## Phase 8: GCP remote VM backend
+
+Goal:
+
+- implement the same remote VM contract on a second provider
+
+Deliverables:
+
+- `gcp-vm` target with limited provider-specific delta
+- parity on lifecycle, audit, and workspace materialization semantics
+
+Complete when:
+
+- deterministic adapter and contract suites pass
+- live GCP smoke remains certification-only
+
+## Phase 9: Later expansion decision gate
+
+Goal:
+
+- decide whether `azure-vm` or managed workstations become funded follow-on
+  work
+
+Deliverables:
+
+- recorded decision, rationale, and demand/support evidence
+- updated roadmap and program-plan references
+
+Complete when:
+
+- the next funded lane is explicit and the rejected paths are documented as
+  deferred rather than implied

--- a/docs/scenario-gaps.md
+++ b/docs/scenario-gaps.md
@@ -9,7 +9,8 @@ not yet covered as deeply as the core secretless validation path.
 
 The strongest local claim depends on the actual Colima plus
 Virtualization.Framework boundary. GitHub-hosted runners cannot prove that, so
-the best evidence today is still local macOS verification.
+the best evidence today is still the local macOS certification lane:
+`./scripts/run-scenario-tests.sh --secretless-only --certification-only`.
 
 ### End-to-end authenticated coverage for every provider
 
@@ -47,7 +48,7 @@ more explicit end-to-end scenarios, especially:
 
 ## Why these gaps remain acceptable for now
 
-The core secretless path is covered by invariants, smoke tests, repo
-validation, reproducibility checks, and tagged release preflight. The open
+The core repo-required path is covered by invariants, smoke tests, deterministic
+repo validation, reproducibility checks, and tagged release preflight. The open
 gaps are mostly at the edges: live-provider auth, local macOS proof, and
 explicit lower-assurance transitions.

--- a/docs/use-case-matrix.md
+++ b/docs/use-case-matrix.md
@@ -29,15 +29,15 @@ Workcell workflows.
 | runtime-image reproducibility | tested | `scripts/verify-reproducible-build.sh`, CI, tagged release preflight |
 | Sigstore signing and SBOM publication | tested | successful tagged release workflow |
 | GitHub attestations on tagged releases | tested at release time | `release.yml` publish job |
-| full macOS Colima boundary proof | gap | local exercise only |
+| full macOS Colima boundary proof | gap | local certification lane exists, but it is still not repo-required proof |
 | exhaustive live-provider auth UX across all providers | gap | manual provider-e2e path exists, but automation is partial |
 
 ## Notes
 
-The most heavily tested paths are the secretless runtime boundary, explicit
-nonroot repo validation and release preflight, reproducibility, signed
-publication, and the host-side operator plane. The most mature host-side
-operator surfaces are auth/policy inspection plus session inventory, detached
-control, delete, timeline, export, and isolated-workspace remediation. The
-biggest remaining gaps are local macOS boundary proof and deeper end-to-end
-live-provider coverage.
+The most heavily tested paths are the repo-required secretless runtime
+boundary, explicit nonroot repo validation and release preflight,
+reproducibility, signed publication, and the host-side operator plane. The
+most mature host-side operator surfaces are auth/policy inspection plus
+session inventory, detached control, delete, timeline, export, and
+isolated-workspace remediation. The biggest remaining gaps are local macOS
+boundary proof and deeper end-to-end live-provider coverage.

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -23,6 +23,7 @@ Use these anchors when checking release-facing claims:
   `shared/auth-commands`, `shared/auth-status`,
   `shared/claude-resolver-launcher`
 - lower-assurance mode claims: `shared/assurance-dry-run`
+- local runtime certification smoke: `shared/agent-launch-smoke`
 - host publication handoff: `shared/publish-pr`
 - host-side session inventory and control plus detached workspace-mode
   remediation: `shared/session-commands`
@@ -33,9 +34,11 @@ Use these anchors when checking release-facing claims:
 - Gemini Vertex supplemental `gcloud_adc` and allowlist behavior:
   `scripts/verify-invariants.sh`
 
-## Local secretless checks
+## Repo-required deterministic checks
 
-These run without provider credentials:
+These are the checks that must stay green for normal repo validation. They run
+without provider credentials and must not depend on live Colima or cloud
+state:
 
 - `./scripts/dev-quick-check.sh`
 - `./scripts/build-and-test.sh` (host-native by default; `--docker` reruns repo validation inside the pinned CI validator container from a disposable snapshot)
@@ -49,6 +52,26 @@ They cover repo shape, runtime contracts, smoke behavior, and reproducibility.
 They also now cover canonical requirement traceability, host-side policy
 inspection and explainability, host-side detached session inventory, control,
 logs/timeline, clean-base diff/export behavior, and operator-contract parity.
+
+`./scripts/validate-repo.sh` runs the repo-required scenario tier through:
+
+- `./scripts/run-scenario-tests.sh --repo-required`
+
+## Local certification smoke
+
+These checks are still valuable, but they are intentionally not part of the
+repo-required validation path because they depend on a live runtime boundary.
+
+- `./scripts/run-scenario-tests.sh --secretless-only --certification-only`
+
+Today that certification tier includes:
+
+- `shared/agent-launch-smoke` for local macOS Colima prepare-only and
+  provider-version smoke on the managed path
+
+Certification smoke is where local boundary proof belongs. It should stay
+available and documented, but it must not be the reason repo validation fails
+on a machine that lacks the live runtime prerequisites.
 
 ## Documentation example coverage
 
@@ -67,8 +90,8 @@ when the repo does not add a dedicated new scenario for each page.
 ## Manual authenticated smoke
 
 `./scripts/provider-e2e.sh` is the reviewed path for provider-authenticated
-checks. It is deliberately separate from default CI so the default path stays
-secretless.
+checks. It is deliberately separate from default CI and from the repo-required
+scenario tier so the default path stays deterministic and secretless.
 
 Use it when you need to verify:
 

--- a/internal/scenarios/scenario_manifest.go
+++ b/internal/scenarios/scenario_manifest.go
@@ -16,10 +16,11 @@ import (
 )
 
 var (
-	validLanes     = map[string]struct{}{"secretless": {}, "provider-e2e": {}}
-	validPlatforms = map[string]struct{}{"any": {}, "linux": {}, "macos": {}}
-	validProviders = map[string]struct{}{"codex": {}, "claude": {}, "gemini": {}}
-	personaPrefix  = "^[a-z][a-z0-9-]*$"
+	validLanes           = map[string]struct{}{"secretless": {}, "provider-e2e": {}}
+	validPlatforms       = map[string]struct{}{"any": {}, "linux": {}, "macos": {}}
+	validProviders       = map[string]struct{}{"codex": {}, "claude": {}, "gemini": {}}
+	validValidationTiers = map[string]struct{}{"repo-required": {}, "certification": {}}
+	personaPrefix        = "^[a-z][a-z0-9-]*$"
 )
 
 type Scenario struct {
@@ -31,6 +32,7 @@ type Scenario struct {
 	Manual              bool
 	Lane                string
 	Platform            string
+	ValidationTier      string
 	TestFile            string
 }
 
@@ -209,6 +211,19 @@ func LoadScenarios(manifestPath string) ([]Scenario, error) {
 			platform = platformValue
 		}
 
+		validationTier := "repo-required"
+		if rawValidationTier, ok := entry["validation_tier"]; ok {
+			validationTierValue, ok := rawValidationTier.(string)
+			if !ok || !containsKey(validValidationTiers, validationTierValue) {
+				return nil, fmt.Errorf(
+					"scenario %s: validation_tier must be one of: %s",
+					scenarioID,
+					strings.Join(sortedKeys(validValidationTiers), ", "),
+				)
+			}
+			validationTier = validationTierValue
+		}
+
 		testFile, err := normalizeTestFile(entry["test_file"], scenarioID, manual)
 		if err != nil {
 			return nil, err
@@ -229,6 +244,7 @@ func LoadScenarios(manifestPath string) ([]Scenario, error) {
 			Manual:              manual,
 			Lane:                lane,
 			Platform:            platform,
+			ValidationTier:      validationTier,
 			TestFile:            testFile,
 		})
 	}
@@ -374,6 +390,7 @@ func ListTSV(manifestPath string, w io.Writer) error {
 			requires,
 			scenario.Lane,
 			scenario.Platform,
+			scenario.ValidationTier,
 			manual,
 		}, "\t")); err != nil {
 			return err

--- a/internal/scenarios/scenario_manifest_test.go
+++ b/internal/scenarios/scenario_manifest_test.go
@@ -89,10 +89,10 @@ func TestLoadScenariosAndListTSV(t *testing.T) {
 	if len(scenarios) != 2 {
 		t.Fatalf("expected 2 scenarios, got %d", len(scenarios))
 	}
-	if scenarios[0].Lane != "secretless" || scenarios[0].Platform != "any" || scenarios[0].Manual || scenarios[0].RequiresCredentials {
+	if scenarios[0].Lane != "secretless" || scenarios[0].Platform != "any" || scenarios[0].ValidationTier != "repo-required" || scenarios[0].Manual || scenarios[0].RequiresCredentials {
 		t.Fatalf("unexpected defaults for first scenario: %#v", scenarios[0])
 	}
-	if scenarios[1].TestFile != "" || !scenarios[1].Manual || scenarios[1].Lane != "provider-e2e" || scenarios[1].Platform != "macos" {
+	if scenarios[1].TestFile != "" || !scenarios[1].Manual || scenarios[1].Lane != "provider-e2e" || scenarios[1].Platform != "macos" || scenarios[1].ValidationTier != "repo-required" {
 		t.Fatalf("unexpected manual scenario normalization: %#v", scenarios[1])
 	}
 
@@ -103,7 +103,7 @@ func TestLoadScenariosAndListTSV(t *testing.T) {
 	if got.stderr != "" {
 		t.Fatalf("unexpected stderr: %q", got.stderr)
 	}
-	want := "shared/example\tshared/test-example.sh\t0\tsecretless\tany\t0\nshared/manual\t\t0\tprovider-e2e\tmacos\t1\n"
+	want := "shared/example\tshared/test-example.sh\t0\tsecretless\tany\trepo-required\t0\nshared/manual\t\t0\tprovider-e2e\tmacos\trepo-required\t1\n"
 	if got.stdout != want {
 		t.Fatalf("unexpected list-tsv output: %q", got.stdout)
 	}
@@ -202,6 +202,24 @@ func TestRunRejectsInvalidManifestsAndCoverage(t *testing.T) {
 			},
 			command:      []string{"list-tsv"},
 			wantContains: "test_file must stay under tests/scenarios without traversal",
+		},
+		{
+			name: "invalid-validation-tier",
+			manifest: map[string]any{
+				"version": 1,
+				"scenarios": []any{
+					map[string]any{
+						"id":              "shared/tier",
+						"description":     "Tier",
+						"persona":         "developer",
+						"providers":       []any{"codex"},
+						"validation_tier": "unknown",
+						"test_file":       "shared/test-tier.sh",
+					},
+				},
+			},
+			command:      []string{"list-tsv"},
+			wantContains: "validation_tier must be one of: certification, repo-required",
 		},
 	}
 

--- a/internal/scenarios/scenario_script_integration_test.go
+++ b/internal/scenarios/scenario_script_integration_test.go
@@ -108,23 +108,37 @@ func TestVerifyScenarioCoverageRejectsOrphanScripts(t *testing.T) {
 	}
 }
 
-func TestRunScenarioTestsSecretlessOnlySkipsNonSecretlessEntries(t *testing.T) {
+func TestRunScenarioTestsRepoRequiredOnlySkipsCertificationEntries(t *testing.T) {
 	t.Parallel()
 
 	scenarioRoot := t.TempDir()
-	writeScenarioScript(t, scenarioRoot, "shared/test-secretless.sh", "#!/bin/sh\nset -eu\nprintf 'secretless-ran\\n'\n")
+	writeScenarioScript(t, scenarioRoot, "shared/test-required.sh", "#!/bin/sh\nset -eu\nprintf 'required-ran\\n'\n")
+	writeScenarioScript(t, scenarioRoot, "shared/test-certification.sh", "#!/bin/sh\nset -eu\necho certification-ran >&2\nexit 1\n")
 	writeScenarioScript(t, scenarioRoot, "shared/test-provider.sh", "#!/bin/sh\nset -eu\necho provider-ran >&2\nexit 1\n")
 	writeScenarioScript(t, scenarioRoot, "shared/test-manual.sh", "#!/bin/sh\nset -eu\necho manual-ran >&2\nexit 1\n")
 	manifestPath := writeScenarioManifest(t, scenarioRoot, []map[string]any{
 		{
-			"id":                   "shared/secretless",
-			"description":          "Secretless fixture",
+			"id":                   "shared/required",
+			"description":          "Repo-required fixture",
 			"lane":                 "secretless",
 			"platform":             "any",
+			"validation_tier":      "repo-required",
 			"manual":               false,
 			"providers":            []string{"codex"},
 			"persona":              "developer",
-			"test_file":            "shared/test-secretless.sh",
+			"test_file":            "shared/test-required.sh",
+			"requires_credentials": false,
+		},
+		{
+			"id":                   "shared/certification",
+			"description":          "Certification fixture",
+			"lane":                 "secretless",
+			"platform":             "any",
+			"validation_tier":      "certification",
+			"manual":               false,
+			"providers":            []string{"codex"},
+			"persona":              "developer",
+			"test_file":            "shared/test-certification.sh",
 			"requires_credentials": false,
 		},
 		{
@@ -158,16 +172,72 @@ func TestRunScenarioTestsSecretlessOnlySkipsNonSecretlessEntries(t *testing.T) {
 			"WORKCELL_SCENARIO_ROOT":     scenarioRoot,
 			"WORKCELL_SCENARIO_MANIFEST": manifestPath,
 		},
-		"--secretless-only",
 	)
 	if code != 0 {
 		t.Fatalf("run-scenario-tests exit code = %d stdout=%q", code, stdout)
 	}
 	for _, want := range []string{
-		"secretless-ran",
-		"PASS shared/secretless",
+		"required-ran",
+		"PASS shared/required",
+		"SKIP shared/certification (validation tier certification)",
 		"SKIP shared/provider (lane provider-e2e)",
 		"SKIP shared/manual (manual lane)",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout %q does not contain %q", stdout, want)
+		}
+	}
+}
+
+func TestRunScenarioTestsCertificationOnlySkipsRepoRequiredEntries(t *testing.T) {
+	t.Parallel()
+
+	scenarioRoot := t.TempDir()
+	writeScenarioScript(t, scenarioRoot, "shared/test-required.sh", "#!/bin/sh\nset -eu\necho required-ran >&2\nexit 1\n")
+	writeScenarioScript(t, scenarioRoot, "shared/test-certification.sh", "#!/bin/sh\nset -eu\nprintf 'certification-ran\\n'\n")
+	manifestPath := writeScenarioManifest(t, scenarioRoot, []map[string]any{
+		{
+			"id":                   "shared/required",
+			"description":          "Repo-required fixture",
+			"lane":                 "secretless",
+			"platform":             "any",
+			"validation_tier":      "repo-required",
+			"manual":               false,
+			"providers":            []string{"codex"},
+			"persona":              "developer",
+			"test_file":            "shared/test-required.sh",
+			"requires_credentials": false,
+		},
+		{
+			"id":                   "shared/certification",
+			"description":          "Certification fixture",
+			"lane":                 "secretless",
+			"platform":             "any",
+			"validation_tier":      "certification",
+			"manual":               false,
+			"providers":            []string{"codex"},
+			"persona":              "developer",
+			"test_file":            "shared/test-certification.sh",
+			"requires_credentials": false,
+		},
+	})
+
+	code, stdout, _ := runScenarioScript(
+		t,
+		filepath.Join(repoRoot(t), "scripts", "run-scenario-tests.sh"),
+		map[string]string{
+			"WORKCELL_SCENARIO_ROOT":     scenarioRoot,
+			"WORKCELL_SCENARIO_MANIFEST": manifestPath,
+		},
+		"--certification-only",
+	)
+	if code != 0 {
+		t.Fatalf("run-scenario-tests exit code = %d stdout=%q", code, stdout)
+	}
+	for _, want := range []string{
+		"SKIP shared/required (validation tier repo-required)",
+		"certification-ran",
+		"PASS shared/certification",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("stdout %q does not contain %q", stdout, want)

--- a/internal/scenarios/scenario_script_integration_test.go
+++ b/internal/scenarios/scenario_script_integration_test.go
@@ -245,6 +245,78 @@ func TestRunScenarioTestsCertificationOnlySkipsRepoRequiredEntries(t *testing.T)
 	}
 }
 
+func TestRunScenarioTestsAllIncludesCertificationByDefault(t *testing.T) {
+	t.Parallel()
+
+	scenarioRoot := t.TempDir()
+	writeScenarioScript(t, scenarioRoot, "shared/test-required.sh", "#!/bin/sh\nset -eu\nprintf 'required-ran\\n'\n")
+	writeScenarioScript(t, scenarioRoot, "shared/test-certification.sh", "#!/bin/sh\nset -eu\nprintf 'certification-ran\\n'\n")
+	writeScenarioScript(t, scenarioRoot, "shared/test-provider.sh", "#!/bin/sh\nset -eu\nprintf 'provider-ran\\n'\n")
+	manifestPath := writeScenarioManifest(t, scenarioRoot, []map[string]any{
+		{
+			"id":                   "shared/required",
+			"description":          "Repo-required fixture",
+			"lane":                 "secretless",
+			"platform":             "any",
+			"validation_tier":      "repo-required",
+			"manual":               false,
+			"providers":            []string{"codex"},
+			"persona":              "developer",
+			"test_file":            "shared/test-required.sh",
+			"requires_credentials": false,
+		},
+		{
+			"id":                   "shared/certification",
+			"description":          "Certification fixture",
+			"lane":                 "secretless",
+			"platform":             "any",
+			"validation_tier":      "certification",
+			"manual":               false,
+			"providers":            []string{"codex"},
+			"persona":              "developer",
+			"test_file":            "shared/test-certification.sh",
+			"requires_credentials": false,
+		},
+		{
+			"id":                   "shared/provider",
+			"description":          "Provider fixture",
+			"lane":                 "provider-e2e",
+			"platform":             "any",
+			"validation_tier":      "repo-required",
+			"manual":               false,
+			"providers":            []string{"codex"},
+			"persona":              "developer",
+			"test_file":            "shared/test-provider.sh",
+			"requires_credentials": true,
+		},
+	})
+
+	code, stdout, _ := runScenarioScript(
+		t,
+		filepath.Join(repoRoot(t), "scripts", "run-scenario-tests.sh"),
+		map[string]string{
+			"WORKCELL_SCENARIO_ROOT":     scenarioRoot,
+			"WORKCELL_SCENARIO_MANIFEST": manifestPath,
+		},
+		"--all",
+	)
+	if code != 0 {
+		t.Fatalf("run-scenario-tests --all exit code = %d stdout=%q", code, stdout)
+	}
+	for _, want := range []string{
+		"required-ran",
+		"PASS shared/required",
+		"certification-ran",
+		"PASS shared/certification",
+		"provider-ran",
+		"PASS shared/provider",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout %q does not contain %q", stdout, want)
+		}
+	}
+}
+
 func TestRunScenarioTestsFailsWhenManifestValidationFails(t *testing.T) {
 	t.Parallel()
 

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -152,6 +152,12 @@ func TestValidationGatesLintAllScenarioShellScripts(t *testing.T) {
 	if strings.Contains(string(validateRepo), "scripts/verify-go-python-parity.sh") {
 		t.Fatalf("%s must not include scripts/verify-go-python-parity.sh", validateRepoPath)
 	}
+	if !strings.Contains(string(validateRepo), `scripts/run-scenario-tests.sh" --repo-required`) {
+		t.Fatalf("%s must run the repo-required scenario tier", validateRepoPath)
+	}
+	if strings.Contains(string(validateRepo), `scripts/run-scenario-tests.sh" --secretless-only`) {
+		t.Fatalf("%s must not depend on the broader secretless scenario lane", validateRepoPath)
+	}
 	for _, want := range []string{
 		`${ROOT_DIR}/.githooks/pre-commit`,
 		`${ROOT_DIR}/scripts/check-dead-code.sh`,

--- a/scripts/run-scenario-tests.sh
+++ b/scripts/run-scenario-tests.sh
@@ -12,6 +12,7 @@ fi
 
 RUN_ALL=0
 TIER_SELECTION="repo-required"
+TIER_SELECTION_EXPLICIT=0
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --all)
@@ -22,12 +23,15 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     --repo-required)
       TIER_SELECTION="repo-required"
+      TIER_SELECTION_EXPLICIT=1
       ;;
     --include-certification)
       TIER_SELECTION="include-certification"
+      TIER_SELECTION_EXPLICIT=1
       ;;
     --certification-only)
       TIER_SELECTION="certification-only"
+      TIER_SELECTION_EXPLICIT=1
       ;;
     *)
       echo "Usage: run-scenario-tests.sh [--secretless-only|--all] [--repo-required|--include-certification|--certification-only]" >&2
@@ -36,6 +40,10 @@ while [[ "$#" -gt 0 ]]; do
   esac
   shift
 done
+
+if [[ "${RUN_ALL}" -eq 1 ]] && [[ "${TIER_SELECTION_EXPLICIT}" -eq 0 ]]; then
+  TIER_SELECTION="include-certification"
+fi
 
 CURRENT_PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
 SCENARIO_LIST="$(mktemp "${TMPDIR:-/tmp}/workcell-scenarios.XXXXXX")"

--- a/scripts/run-scenario-tests.sh
+++ b/scripts/run-scenario-tests.sh
@@ -11,14 +11,31 @@ if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
 fi
 
 RUN_ALL=0
-case "${1:-}" in
-  --all) RUN_ALL=1 ;;
-  --secretless-only | "") ;;
-  *)
-    echo "Usage: run-scenario-tests.sh [--secretless-only|--all]" >&2
-    exit 1
-    ;;
-esac
+TIER_SELECTION="repo-required"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --all)
+      RUN_ALL=1
+      ;;
+    --secretless-only)
+      RUN_ALL=0
+      ;;
+    --repo-required)
+      TIER_SELECTION="repo-required"
+      ;;
+    --include-certification)
+      TIER_SELECTION="include-certification"
+      ;;
+    --certification-only)
+      TIER_SELECTION="certification-only"
+      ;;
+    *)
+      echo "Usage: run-scenario-tests.sh [--secretless-only|--all] [--repo-required|--include-certification|--certification-only]" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
 
 CURRENT_PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
 SCENARIO_LIST="$(mktemp "${TMPDIR:-/tmp}/workcell-scenarios.XXXXXX")"
@@ -51,7 +68,8 @@ run_scenario() {
   local requires_creds="$3"
   local lane="$4"
   local platform="$5"
-  local manual="$6"
+  local validation_tier="$6"
+  local manual="$7"
 
   if [[ "${manual}" == "1" ]]; then
     echo "SKIP ${scenario_id} (manual lane)"
@@ -62,6 +80,21 @@ run_scenario() {
     echo "SKIP ${scenario_id} (platform ${platform})"
     return 2
   fi
+
+  case "${TIER_SELECTION}" in
+    repo-required)
+      if [[ "${validation_tier}" != "repo-required" ]]; then
+        echo "SKIP ${scenario_id} (validation tier ${validation_tier})"
+        return 2
+      fi
+      ;;
+    certification-only)
+      if [[ "${validation_tier}" != "certification" ]]; then
+        echo "SKIP ${scenario_id} (validation tier ${validation_tier})"
+        return 2
+      fi
+      ;;
+  esac
 
   if [[ "${RUN_ALL}" -eq 0 ]] && [[ "${lane}" != "secretless" ]]; then
     echo "SKIP ${scenario_id} (lane ${lane})"
@@ -102,12 +135,12 @@ fi
 idx=0
 declare -a pids=()
 
-while IFS=$'\t' read -r scenario_id test_file requires_creds lane platform manual; do
+while IFS=$'\t' read -r scenario_id test_file requires_creds lane platform validation_tier manual; do
   idx=$((idx + 1))
   result_file="${RESULTS_DIR}/${idx}.exit"
   (
     exit_code=0
-    run_scenario "${scenario_id}" "${test_file}" "${requires_creds}" "${lane}" "${platform}" "${manual}" || exit_code="$?"
+    run_scenario "${scenario_id}" "${test_file}" "${requires_creds}" "${lane}" "${platform}" "${validation_tier}" "${manual}" || exit_code="$?"
     printf '%d\n' "${exit_code}" >"${result_file}"
   ) &
   pids+=($!)

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -352,8 +352,8 @@ fi
 mkdir -p "${BUILD_CACHE_DIR}"
 (cd "${ROOT_DIR}" && go build -buildvcs=false -o "${BUILD_CACHE_DIR}/hostutil" ./cmd/workcell-hostutil)
 
-# Check E: Scenario coverage and control-plane parity
-"${ROOT_DIR}/scripts/run-scenario-tests.sh" --secretless-only
+# Check E: deterministic repo-required scenarios plus control-plane parity
+"${ROOT_DIR}/scripts/run-scenario-tests.sh" --repo-required
 "${ROOT_DIR}/scripts/verify-scenario-coverage.sh"
 "${ROOT_DIR}/scripts/verify-control-plane-parity.sh"
 

--- a/tests/scenarios/manifest.json
+++ b/tests/scenarios/manifest.json
@@ -17,6 +17,7 @@
       "description": "macOS secretless smoke launches Workcell-managed Codex, Claude, and Gemini entrypoints against the real runtime and version probes each provider",
       "lane": "secretless",
       "platform": "macos",
+      "validation_tier": "certification",
       "manual": false,
       "providers": ["codex", "claude", "gemini"],
       "persona": "developer",

--- a/workflows/python-to-go-migration.md
+++ b/workflows/python-to-go-migration.md
@@ -35,9 +35,14 @@ Before porting anything, capture a passing baseline for:
 
 - `./scripts/verify-coverage.sh`
 - `./scripts/run-mutation-tests.sh`
-- `./scripts/run-scenario-tests.sh --secretless-only`
+- `./scripts/run-scenario-tests.sh --repo-required`
 - `./scripts/verify-scenario-coverage.sh`
 - `./scripts/verify-control-plane-parity.sh`
+
+If the helper touches the live runtime boundary, also capture the local
+certification lane separately:
+
+- `./scripts/run-scenario-tests.sh --secretless-only --certification-only`
 
 ### 2. Keep the shell contract stable
 


### PR DESCRIPTION
## Summary
- classify scenario manifest entries as `repo-required` or `certification`
- make `validate-repo` depend only on the deterministic repo-required scenario tier while keeping explicit local certification smoke available
- add durable runtime-target expansion and deterministic phase-planning docs for the remaining rollout

## Validation
- `bash ./scripts/run-scenario-tests.sh --repo-required`
- `bash ./scripts/run-scenario-tests.sh --secretless-only --certification-only`
- `bash ./scripts/validate-repo.sh`

## Notes
- stacked on top of #124
- signed commits used the narrow upstream-refresh pre-commit bypass because unrelated pinned-input updates are currently available and were intentionally kept out of scope
