### PR TITLE
[codex] Complete phase 1 session platform surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,12 @@ workcell publish-pr --workspace /path/to/repo --branch feature/name \
   --commit-message-file /tmp/commit-message.txt
 ```
 
+`workcell session list --verbose` adds target, workspace transport, git branch,
+and worktree columns without changing the default compact inventory view.
+`workcell session show --text` renders stable key=value lines for the same
+target-aware record, and `workcell session start|send|stop` emit stable
+key=value summaries so host-side detached control stays scriptable.
+
 ## Release posture
 
 Tagged releases are rebuilt and verified before publication. The release path:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,9 +15,6 @@ The deterministic phase breakdown lives in
 
 ## Short term
 
-- finish the current session-supervisor slice around default
-  worktree-per-session flows and richer live status, branch/worktree,
-  assurance, and log rendering on top of the shipped detached session commands
 - broaden host-owned auth flows where the current implementation is still thin:
   more resolver coverage plus explicit browser/bootstrap handoffs for provider
   onboarding

--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -398,7 +398,7 @@ func runLauncherSessionList(args []string) error {
 	for _, record := range records {
 		if verbose {
 			fmt.Printf(
-				"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 				record.SessionID,
 				record.Status,
 				hostutil.SessionDisplayLiveStatus(record),
@@ -409,6 +409,8 @@ func runLauncherSessionList(args []string) error {
 				hostutil.SessionTargetSummary(record),
 				record.TargetAssuranceClass,
 				record.WorkspaceTransport,
+				hostutil.SessionDisplayGitBranch(record),
+				hostutil.SessionDisplayWorktree(record),
 				record.StartedAt,
 				hostutil.SessionAssuranceSummary(record),
 				hostutil.SessionDisplayWorkspace(record),

--- a/cmd/workcell-hostutil/main_test.go
+++ b/cmd/workcell-hostutil/main_test.go
@@ -265,7 +265,7 @@ func TestRunLauncherSessionListVerboseShowsTargetMetadata(t *testing.T) {
 		t.Fatalf("run() error = %v", runErr)
 	}
 	got := strings.TrimSpace(stdout.String())
-	want := "session-1\trunning\trunning\tattached\tcodex\tstrict\twcl-one\tlocal_vm/colima/wcl-one\tstrict\tisolated-worktree-mount\t2026-04-08T10:00:00Z\tmanaged-mutable\t/tmp/source-workspace"
+	want := "session-1\trunning\trunning\tattached\tcodex\tstrict\twcl-one\tlocal_vm/colima/wcl-one\tstrict\tisolated-worktree-mount\tnone\t/tmp/workspace-a\t2026-04-08T10:00:00Z\tmanaged-mutable\t/tmp/source-workspace"
 	if got != want {
 		t.Fatalf("session list verbose output = %q, want %q", got, want)
 	}
@@ -332,6 +332,12 @@ func TestRunLauncherSessionShowText(t *testing.T) {
 	}
 	if !strings.Contains(got, "workspace_transport=isolated-worktree-mount") {
 		t.Fatalf("session show --text output = %q, want workspace transport", got)
+	}
+	if !strings.Contains(got, "display_worktree=/tmp/workspace-a/.worktrees/session-1") {
+		t.Fatalf("session show --text output = %q, want display worktree", got)
+	}
+	if !strings.Contains(got, "display_git_branch=feature/session-observability") {
+		t.Fatalf("session show --text output = %q, want display git branch", got)
 	}
 }
 

--- a/docs/implement-first-delivery-plan.md
+++ b/docs/implement-first-delivery-plan.md
@@ -6,9 +6,10 @@ changes on top of the inspection and policy surfaces that already shipped.
 The longer-lived runtime-target and deployment-reach program lives in
 [`docs/runtime-target-expansion-plan.md`](runtime-target-expansion-plan.md),
 and the deterministic phase breakdown lives in
-[`docs/runtime-target-phase-plan.md`](runtime-target-phase-plan.md);
-this document covers only the active slice that must land before broader target
-claims become supportable.
+[`docs/runtime-target-phase-plan.md`](runtime-target-phase-plan.md).
+Phase 1 of that phase plan is now implemented in the repository; this document
+remains as the delivered-scope reference for that slice and the immediate
+bridge to later runtime-target work.
 
 The current repo already includes durable session records plus detached
 host-side session control (`session start|attach|send|stop`) and basic

--- a/docs/runtime-target-phase-plan.md
+++ b/docs/runtime-target-phase-plan.md
@@ -13,6 +13,7 @@ complements:
 Current repo status:
 
 - Phase 0 is implemented in the validation substrate
+- Phase 1 is implemented in the session platform and deterministic evidence
 - later phases remain planning targets until their code and evidence land
 
 ## Phase Completion Contract

--- a/docs/workcell-session-supervisor-design.md
+++ b/docs/workcell-session-supervisor-design.md
@@ -100,13 +100,14 @@ session metadata.
 - assurance
 - workspace
 
-`workcell session list --verbose` adds target identity, target assurance, and
-workspace-transport metadata without changing the default compact table.
+`workcell session list --verbose` adds target identity, target assurance,
+workspace transport, git branch, and worktree metadata without changing the
+default compact table.
 
 `workcell session show` returns the full durable record for one session, and
 `workcell session show --text` renders the same record as stable key=value
-lines, including target metadata, workspace transport, branch, worktree, and
-artifact pointers.
+lines, including target metadata, workspace transport, display workspace,
+branch, worktree, and artifact pointers.
 
 `workcell session logs` prints one retained audit, debug, file-trace, or
 transcript log for a recorded session.
@@ -125,6 +126,9 @@ either to stdout or a user-selected host file.
 Detached sessions can be started, attached to, steered, and stopped from the
 host without introducing a separate always-on daemon or same-user local socket
 trust.
+`workcell session start`, `workcell session send`, and `workcell session stop`
+emit stable key=value summaries so detached-session control stays scriptable on
+the host.
 
 ## Current Non-Goals
 
@@ -141,7 +145,8 @@ The current slice does not yet attempt to implement:
 
 The remaining near-term work is to:
 
-- harden and normalize worktree-per-session defaults
+- decouple session, audit, and lock state from Colima-shaped program-level
+  assumptions while preserving compatibility reads
 - deepen validation coverage for detached-session transitions and
   lower-assurance paths
 - add richer artifact browsing without weakening the host-owned model

--- a/internal/hostutil/sessions.go
+++ b/internal/hostutil/sessions.go
@@ -110,6 +110,7 @@ func SessionRuntimeMetadataLines(record SessionRecord) []string {
 		fmt.Sprintf("workspace_origin=%s", record.WorkspaceOrigin),
 		fmt.Sprintf("workspace_root=%s", record.WorkspaceRoot),
 		fmt.Sprintf("worktree_path=%s", record.WorktreePath),
+		fmt.Sprintf("git_branch=%s", record.GitBranch),
 		fmt.Sprintf("container_name=%s", record.ContainerName),
 		fmt.Sprintf("status=%s", record.Status),
 		fmt.Sprintf("mode=%s", record.Mode),
@@ -168,6 +169,20 @@ func SessionDisplayWorkspace(record SessionRecord) string {
 	return record.Workspace
 }
 
+func SessionDisplayWorktree(record SessionRecord) string {
+	if strings.TrimSpace(record.WorktreePath) != "" {
+		return record.WorktreePath
+	}
+	return record.Workspace
+}
+
+func SessionDisplayGitBranch(record SessionRecord) string {
+	if strings.TrimSpace(record.GitBranch) != "" {
+		return record.GitBranch
+	}
+	return "none"
+}
+
 func SessionTargetSummary(record SessionRecord) string {
 	record = normalizeSessionRecord(record)
 	parts := make([]string, 0, 3)
@@ -203,6 +218,8 @@ func SessionShowLines(record SessionRecord) []string {
 		fmt.Sprintf("workspace_transport=%s", record.WorkspaceTransport),
 		fmt.Sprintf("workspace=%s", record.Workspace),
 		fmt.Sprintf("display_workspace=%s", SessionDisplayWorkspace(record)),
+		fmt.Sprintf("display_worktree=%s", SessionDisplayWorktree(record)),
+		fmt.Sprintf("display_git_branch=%s", SessionDisplayGitBranch(record)),
 		fmt.Sprintf("workspace_origin=%s", record.WorkspaceOrigin),
 		fmt.Sprintf("workspace_root=%s", record.WorkspaceRoot),
 		fmt.Sprintf("worktree_path=%s", record.WorktreePath),

--- a/internal/hostutil/sessions_test.go
+++ b/internal/hostutil/sessions_test.go
@@ -242,6 +242,26 @@ func TestSessionDisplayWorkspacePrefersWorkspaceOrigin(t *testing.T) {
 	}
 }
 
+func TestSessionDisplayWorktreePrefersRecordedWorktreePath(t *testing.T) {
+	t.Parallel()
+
+	got := SessionDisplayWorktree(SessionRecord{
+		Workspace:    "/tmp/source-workspace",
+		WorktreePath: "/tmp/source-workspace/.git/workcell-sessions/session-1/repo",
+	})
+	if got != "/tmp/source-workspace/.git/workcell-sessions/session-1/repo" {
+		t.Fatalf("SessionDisplayWorktree() = %q, want worktree path", got)
+	}
+}
+
+func TestSessionDisplayGitBranchFallsBackToNone(t *testing.T) {
+	t.Parallel()
+
+	if got := SessionDisplayGitBranch(SessionRecord{}); got != "none" {
+		t.Fatalf("SessionDisplayGitBranch() = %q, want none", got)
+	}
+}
+
 func TestSessionTargetSummary(t *testing.T) {
 	t.Parallel()
 
@@ -472,6 +492,7 @@ func TestSessionRuntimeMetadataLines(t *testing.T) {
 		WorkspaceOrigin:   "/tmp/source-workspace",
 		WorkspaceRoot:     "/tmp",
 		WorktreePath:      "/tmp/workspace/.worktrees/session-1",
+		GitBranch:         "feature/session-diff",
 		ContainerName:     "workcell-session-1",
 		Status:            "running",
 		Mode:              "strict",
@@ -499,6 +520,7 @@ func TestSessionRuntimeMetadataLines(t *testing.T) {
 		"workspace_origin=/tmp/source-workspace",
 		"workspace_root=/tmp",
 		"worktree_path=/tmp/workspace/.worktrees/session-1",
+		"git_branch=feature/session-diff",
 		"container_name=workcell-session-1",
 		"status=running",
 		"mode=strict",
@@ -571,6 +593,8 @@ func TestSessionShowLines(t *testing.T) {
 		"workspace_transport=isolated-worktree-mount",
 		"workspace=/tmp/workspace",
 		"display_workspace=/tmp/source-workspace",
+		"display_worktree=/tmp/workspace/.worktrees/session-1",
+		"display_git_branch=feature/session-observability",
 		"workspace_origin=/tmp/source-workspace",
 		"workspace_root=/tmp",
 		"worktree_path=/tmp/workspace/.worktrees/session-1",

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -592,10 +592,23 @@ Detached session lifecycle on the host:
 workcell session start --agent codex --workspace /path/to/repo
 workcell session list
 workcell session list --verbose
+workcell session send --id SESSION_ID --message "continue with tests"
+workcell session stop --id SESSION_ID
 workcell session show --id SESSION_ID
 workcell session show --id SESSION_ID --text
 workcell session delete --id SESSION_ID
 .EE
+.PP
+The verbose inventory adds target, workspace transport, git branch, and
+worktree columns without changing the default compact table.
+.B workcell session show --text
+and the detached control commands
+.BR "workcell session start" ,
+.BR "workcell session send" ,
+and
+.BR "workcell session stop"
+emit stable key=value output so host-side automation can inspect or steer one
+session without parsing human-oriented prose.
 .PP
 Use direct detached workspace mode when you intentionally want to keep the
 session on the live workspace path instead of a clean session-owned clone:

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "b576718077a196b764a05954fbff77ecf0d524ae932212324a1a4eaf5e0de0cd"
+      "sha256": "11e2f55c80b211f4918c9bb0f0a64b9f144ab98f67fea5f8cf71ba6ff2f77d55"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1187,9 +1187,16 @@ load_session_runtime_metadata() {
   local value=""
 
   SESSION_META_PROFILE=""
+  SESSION_META_TARGET_KIND=""
+  SESSION_META_TARGET_PROVIDER=""
+  SESSION_META_TARGET_ID=""
+  SESSION_META_TARGET_ASSURANCE_CLASS=""
+  SESSION_META_RUNTIME_API=""
+  SESSION_META_WORKSPACE_TRANSPORT=""
   SESSION_META_WORKSPACE=""
   SESSION_META_WORKSPACE_ORIGIN=""
   SESSION_META_WORKTREE_PATH=""
+  SESSION_META_GIT_BRANCH=""
   SESSION_META_CONTAINER_NAME=""
   SESSION_META_MONITOR_PID=""
   SESSION_META_STATUS=""
@@ -1206,9 +1213,16 @@ load_session_runtime_metadata() {
     value="${line#*=}"
     case "${key}" in
       profile) SESSION_META_PROFILE="${value}" ;;
+      target_kind) SESSION_META_TARGET_KIND="${value}" ;;
+      target_provider) SESSION_META_TARGET_PROVIDER="${value}" ;;
+      target_id) SESSION_META_TARGET_ID="${value}" ;;
+      target_assurance_class) SESSION_META_TARGET_ASSURANCE_CLASS="${value}" ;;
+      runtime_api) SESSION_META_RUNTIME_API="${value}" ;;
+      workspace_transport) SESSION_META_WORKSPACE_TRANSPORT="${value}" ;;
       workspace) SESSION_META_WORKSPACE="${value}" ;;
       workspace_origin) SESSION_META_WORKSPACE_ORIGIN="${value}" ;;
       worktree_path) SESSION_META_WORKTREE_PATH="${value}" ;;
+      git_branch) SESSION_META_GIT_BRANCH="${value}" ;;
       container_name) SESSION_META_CONTAINER_NAME="${value}" ;;
       monitor_pid) SESSION_META_MONITOR_PID="${value}" ;;
       status) SESSION_META_STATUS="${value}" ;;
@@ -1221,6 +1235,69 @@ load_session_runtime_metadata() {
       transcript_log_path) SESSION_META_TRANSCRIPT_LOG_PATH="${value}" ;;
     esac
   done < <(session_runtime_metadata "${session_id}")
+}
+
+session_meta_target_summary() {
+  local value=""
+  local -a parts=()
+
+  for value in \
+    "${SESSION_META_TARGET_KIND:-}" \
+    "${SESSION_META_TARGET_PROVIDER:-}" \
+    "${SESSION_META_TARGET_ID:-}"; do
+    [[ -n "${value}" ]] || continue
+    parts+=("${value}")
+  done
+  if [[ "${#parts[@]}" -eq 0 ]]; then
+    printf '\n'
+    return 0
+  fi
+  (
+    IFS='/'
+    printf '%s\n' "${parts[*]}"
+  )
+}
+
+session_meta_display_workspace() {
+  if [[ -n "${SESSION_META_WORKSPACE_ORIGIN:-}" ]]; then
+    printf '%s\n' "${SESSION_META_WORKSPACE_ORIGIN}"
+    return 0
+  fi
+  printf '%s\n' "${SESSION_META_WORKSPACE:-}"
+}
+
+session_meta_display_worktree() {
+  if [[ -n "${SESSION_META_WORKTREE_PATH:-}" ]]; then
+    printf '%s\n' "${SESSION_META_WORKTREE_PATH}"
+    return 0
+  fi
+  printf '%s\n' "${SESSION_META_WORKSPACE:-}"
+}
+
+session_meta_display_git_branch() {
+  if [[ -n "${SESSION_META_GIT_BRANCH:-}" ]]; then
+    printf '%s\n' "${SESSION_META_GIT_BRANCH}"
+    return 0
+  fi
+  printf 'none\n'
+}
+
+emit_loaded_session_control_summary() {
+  printf 'target_kind=%s\n' "${SESSION_META_TARGET_KIND:-}"
+  printf 'target_provider=%s\n' "${SESSION_META_TARGET_PROVIDER:-}"
+  printf 'target_id=%s\n' "${SESSION_META_TARGET_ID:-}"
+  printf 'target_summary=%s\n' "$(session_meta_target_summary)"
+  printf 'target_assurance_class=%s\n' "${SESSION_META_TARGET_ASSURANCE_CLASS:-}"
+  printf 'runtime_api=%s\n' "${SESSION_META_RUNTIME_API:-}"
+  printf 'workspace_transport=%s\n' "${SESSION_META_WORKSPACE_TRANSPORT:-}"
+  printf 'workspace=%s\n' "${SESSION_META_WORKSPACE:-}"
+  printf 'display_workspace=%s\n' "$(session_meta_display_workspace)"
+  printf 'workspace_origin=%s\n' "${SESSION_META_WORKSPACE_ORIGIN:-}"
+  printf 'display_worktree=%s\n' "$(session_meta_display_worktree)"
+  printf 'worktree_path=%s\n' "${SESSION_META_WORKTREE_PATH:-}"
+  printf 'display_git_branch=%s\n' "$(session_meta_display_git_branch)"
+  printf 'git_branch=%s\n' "${SESSION_META_GIT_BRANCH:-}"
+  printf 'assurance=%s\n' "${SESSION_META_CURRENT_ASSURANCE:-}"
 }
 
 current_target_kind() {
@@ -2852,7 +2929,8 @@ Commands:
     --workspace PATH          Filter recorded attached and detached sessions to PATH
     --colima-profile NAME     Filter recorded attached and detached sessions to the selected profile
     --json                    Emit machine-readable JSON instead of the default table with live status and control
-    --verbose                 Emit a wider text table with target and workspace-transport metadata
+    --verbose                 Emit a wider text table with target, workspace transport,
+                              branch, and worktree metadata
 
   show
     --id SESSION_ID           Show one recorded session
@@ -2890,6 +2968,8 @@ Notes:
   - `session delete` never rewrites the shared profile audit log.
   - `session delete` cleans only explicitly recorded session-owned artifacts and
     refuses running sessions or running session containers.
+  - `session start`, `session send`, and `session stop` emit stable key=value
+    summaries so detached-session control stays scriptable on the host.
 EOF
 }
 
@@ -3089,6 +3169,7 @@ session_send_main() {
   local message=""
   local append_newline=1
   local payload=""
+  local record_path=""
   local runtime_uid=""
   local runtime_gid=""
   local send_status=0
@@ -3164,8 +3245,16 @@ session_send_main() {
     "source=host-cli" \
     "command=session-send" \
     "argv=${message}"
+  record_path="$(session_record_path_for "${SESSION_META_PROFILE}" "${session_id}")"
+  write_session_record "${record_path}" \
+    "observed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || exit 1
+  load_session_runtime_metadata "${session_id}"
   printf 'session_id=%s\n' "${session_id}"
   printf 'sent_bytes=%s\n' "${#payload}"
+  printf 'status=%s\n' "${SESSION_META_STATUS:-}"
+  printf 'live_status=%s\n' "${SESSION_META_LIVE_STATUS:-${SESSION_META_STATUS:-}}"
+  printf 'control_mode=detached\n'
+  emit_loaded_session_control_summary
   exit 0
 }
 
@@ -3239,11 +3328,19 @@ session_stop_main() {
       load_session_runtime_metadata "${session_id}"
       printf 'session_id=%s\n' "${session_id}"
       printf 'stop_requested=1\n'
+      printf 'status=%s\n' "${SESSION_META_STATUS:-}"
+      printf 'live_status=%s\n' "${SESSION_META_LIVE_STATUS:-${SESSION_META_STATUS:-}}"
+      printf 'control_mode=detached\n'
+      emit_loaded_session_control_summary
       return 0
     fi
     if [[ "${container_state}" == "stopped" ]] && session_monitor_pid_is_live; then
       printf 'session_id=%s\n' "${session_id}"
       printf 'stop_requested=1\n'
+      printf 'status=%s\n' "${SESSION_META_STATUS:-}"
+      printf 'live_status=%s\n' "${SESSION_META_LIVE_STATUS:-${SESSION_META_STATUS:-}}"
+      printf 'control_mode=detached\n'
+      emit_loaded_session_control_summary
       return 0
     fi
     echo "session stop requires a detached session that is still running: ${session_id}" >&2
@@ -3319,6 +3416,10 @@ session_stop_main() {
   esac
   printf 'session_id=%s\n' "${session_id}"
   printf 'stop_requested=1\n'
+  printf 'status=%s\n' "${SESSION_META_STATUS:-}"
+  printf 'live_status=%s\n' "${SESSION_META_LIVE_STATUS:-${SESSION_META_STATUS:-}}"
+  printf 'control_mode=detached\n'
+  emit_loaded_session_control_summary
   exit 0
 }
 
@@ -3843,7 +3944,7 @@ session_main() {
       if [[ "${emit_json}" -eq 1 ]]; then
         printf '%s\n' "${output}"
       elif [[ "${emit_verbose}" -eq 1 ]]; then
-        printf 'session_id\tstatus\tlive_status\tcontrol\tagent\tmode\tprofile\ttarget\ttarget_assurance\tworkspace_transport\tstarted_at\tassurance\tworkspace\n'
+        printf 'session_id\tstatus\tlive_status\tcontrol\tagent\tmode\tprofile\ttarget\ttarget_assurance\tworkspace_transport\tgit_branch\tworktree\tstarted_at\tassurance\tworkspace\n'
         printf '%s\n' "${output}"
       else
         printf 'session_id\tstatus\tlive_status\tcontrol\tagent\tmode\tprofile\tstarted_at\tassurance\tworkspace\n'
@@ -7901,6 +8002,7 @@ if [[ "${SESSION_DETACHED}" -eq 1 ]]; then
   printf 'workspace_root=%s\n' "${PROFILE_WORKSPACE_ROOT}"
   printf 'worktree_path=%s\n' "${WORKSPACE}"
   printf 'git_branch=%s\n' "${session_git_branch:-none}"
+  emit_loaded_session_control_summary
   printf 'monitor_pid=%s\n' "${SESSION_MONITOR_PID}"
   printf 'audit_log_path=%s\n' "$(profile_audit_log_path "${COLIMA_PROFILE}")"
   printf 'debug_log_path=%s\n' "${DEBUG_LOG_PATH:-none}"

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -228,8 +228,8 @@ grep -q $'^'"${SESSION_ATTACHED_LIVE}"$'\trunning\trunning\tattached\tcodex\tstr
 grep -q $'^'"${SESSION_ONE}"$'\texited\tstopped\tattached\tcodex\tstrict\t'"${PROFILE}"$'\t2026-04-08T10:00:00Z\tmanaged-mutable\t'"${WORKSPACE_A}"'$' <<<"${list_output}"
 
 list_verbose_output="$("${ROOT_DIR}/scripts/workcell" session list --verbose --colima-profile "${PROFILE}")"
-grep -q '^session_id[[:space:]]status[[:space:]]live_status[[:space:]]control[[:space:]]agent[[:space:]]mode[[:space:]]profile[[:space:]]target[[:space:]]target_assurance[[:space:]]workspace_transport[[:space:]]started_at[[:space:]]assurance[[:space:]]workspace$' <<<"${list_verbose_output}"
-grep -q $'^'"${SESSION_TWO}"$'\tfailed\tstopped\tdetached\tclaude\tdevelopment\t'"${PROFILE}"$'\tlocal_vm/colima/'"${PROFILE}"$'\tstrict\tisolated-worktree-mount\t2026-04-08T11:00:00Z\tmanaged-mutable\t'"${WORKSPACE_A}"'$' <<<"${list_verbose_output}"
+grep -q '^session_id[[:space:]]status[[:space:]]live_status[[:space:]]control[[:space:]]agent[[:space:]]mode[[:space:]]profile[[:space:]]target[[:space:]]target_assurance[[:space:]]workspace_transport[[:space:]]git_branch[[:space:]]worktree[[:space:]]started_at[[:space:]]assurance[[:space:]]workspace$' <<<"${list_verbose_output}"
+grep -q $'^'"${SESSION_TWO}"$'\tfailed\tstopped\tdetached\tclaude\tdevelopment\t'"${PROFILE}"$'\tlocal_vm/colima/'"${PROFILE}"$'\tstrict\tisolated-worktree-mount\tnone\t'"${WORKSPACE_B}/.worktrees/${SESSION_TWO}"$'\t2026-04-08T11:00:00Z\tmanaged-mutable\t'"${WORKSPACE_A}"'$' <<<"${list_verbose_output}"
 
 if command -v script >/dev/null 2>&1; then
   tty_list_cmd=("${ROOT_DIR}/scripts/workcell" session list --colima-profile "${PROFILE}")
@@ -320,8 +320,12 @@ grep -q '"workspace_transport": "isolated-worktree-mount"' <<<"${show_output}"
 show_text_output="$("${ROOT_DIR}/scripts/workcell" session show --id "${SESSION_TWO}" --text)"
 grep -q '^target_summary=local_vm/colima/'"${PROFILE}"'$' <<<"${show_text_output}"
 grep -q '^workspace_transport=isolated-worktree-mount$' <<<"${show_text_output}"
+grep -q '^display_workspace='"${WORKSPACE_A}"'$' <<<"${show_text_output}"
+grep -q '^display_worktree='"${WORKSPACE_B}/.worktrees/${SESSION_TWO}"'$' <<<"${show_text_output}"
+grep -q '^display_git_branch=none$' <<<"${show_text_output}"
 grep -q '^worktree_path='"${WORKSPACE_B}/.worktrees/${SESSION_TWO}"'$' <<<"${show_text_output}"
 show_text_with_git="$("${ROOT_DIR}/scripts/workcell" session show --id "${SESSION_ONE}" --text)"
+grep -q '^display_git_branch='"${GIT_BRANCH}"'$' <<<"${show_text_with_git}"
 grep -q '^git_branch='"${GIT_BRANCH}"'$' <<<"${show_text_with_git}"
 
 diff_stdout="$("${ROOT_DIR}/scripts/workcell" session diff --id "${SESSION_ONE}" --output "${DIFF_PATH}")"
@@ -865,16 +869,49 @@ session_send_success_output="$(
     source "$1"
     trap - EXIT
     RECORD_FILE="$2"
+    COLIMA_STATE_ROOT="$3"
+    PROFILE_DIR="${COLIMA_STATE_ROOT}/wcl-detached-fixture"
+    RECORD_PATH="${PROFILE_DIR}/sessions/detached-fixture.json"
+    SESSION_AUDIT_DIR="${PROFILE_DIR}/session-audit.detached-fixture"
     HOST_DOCKER_BIN="/bin/false"
+    mkdir -p "${PROFILE_DIR}/sessions" "${SESSION_AUDIT_DIR}"
+    cat >"${RECORD_PATH}" <<EOF_JSON
+{
+  "version": 1,
+  "session_id": "detached-fixture",
+  "profile": "wcl-detached-fixture",
+  "agent": "codex",
+  "mode": "strict",
+  "status": "running",
+  "live_status": "running",
+  "workspace": "/tmp/detached-fixture-workspace",
+  "container_name": "workcell-session-fixture",
+  "monitor_pid": "4242",
+  "session_audit_dir": "${SESSION_AUDIT_DIR}",
+  "started_at": "2026-04-08T14:00:00Z",
+  "current_assurance": "managed-mutable",
+  "initial_assurance": "managed-mutable"
+}
+EOF_JSON
     resolve_host_tool() { printf "/bin/false\n"; }
     sanitize_host_docker_env() { :; }
     session_monitor_pid_is_live() { return 0; }
     load_session_runtime_metadata() {
       SESSION_META_PROFILE="wcl-detached-fixture"
+      SESSION_META_TARGET_KIND="local_vm"
+      SESSION_META_TARGET_PROVIDER="colima"
+      SESSION_META_TARGET_ID="wcl-detached-fixture"
+      SESSION_META_TARGET_ASSURANCE_CLASS="strict"
+      SESSION_META_RUNTIME_API="docker"
+      SESSION_META_WORKSPACE_TRANSPORT="workspace-mount"
+      SESSION_META_WORKSPACE="/tmp/detached-fixture-workspace"
+      SESSION_META_WORKSPACE_ORIGIN="/tmp/detached-fixture-workspace"
+      SESSION_META_WORKTREE_PATH="/tmp/detached-fixture-workspace"
       SESSION_META_CONTAINER_NAME="workcell-session-fixture"
       SESSION_META_MONITOR_PID="4242"
       SESSION_META_STATUS="running"
       SESSION_META_LIVE_STATUS="running"
+      SESSION_META_CURRENT_ASSURANCE="managed-mutable"
     }
     append_session_control_audit_record() {
       printf "audit|%s|%s|%s|%s\n" "$1" "$2" "$3" "$4" >>"${RECORD_FILE}"
@@ -890,10 +927,19 @@ session_send_success_output="$(
       esac
     }
     session_send_main --id detached-fixture --no-newline --message beta
-  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_SEND_SUCCESS_RECORD}"
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_SEND_SUCCESS_RECORD}" "${DETACHED_STATE_DIR}/session-send.success.root"
 )"
 grep -q '^session_id=detached-fixture$' <<<"${session_send_success_output}"
 grep -q '^sent_bytes=4$' <<<"${session_send_success_output}"
+grep -q '^status=running$' <<<"${session_send_success_output}"
+grep -q '^live_status=running$' <<<"${session_send_success_output}"
+grep -q '^control_mode=detached$' <<<"${session_send_success_output}"
+grep -q '^target_summary=local_vm/colima/wcl-detached-fixture$' <<<"${session_send_success_output}"
+grep -q '^workspace_transport=workspace-mount$' <<<"${session_send_success_output}"
+grep -q '^display_workspace=/tmp/detached-fixture-workspace$' <<<"${session_send_success_output}"
+grep -q '^display_worktree=/tmp/detached-fixture-workspace$' <<<"${session_send_success_output}"
+grep -q '^display_git_branch=none$' <<<"${session_send_success_output}"
+grep -q '^assurance=managed-mutable$' <<<"${session_send_success_output}"
 grep -q '^transport|wcl-detached-fixture|exec --user ' "${SESSION_SEND_SUCCESS_RECORD}"
 if grep -q '/proc/1/fd/0' "${SESSION_SEND_SUCCESS_RECORD}"; then
   echo "Detached session send still contains the PID 1 stdin fallback on the success path" >&2
@@ -1388,7 +1434,20 @@ session_delete_cleanup_output="$(
     mkdir -p "${PROFILE_DIR}/sessions"
     : >"${PROFILE_DIR}/docker.sock"
     mkdir -p "${SESSION_AUDIT_DIR}"
-    : >"${RECORD_PATH}"
+    cat >"${RECORD_PATH}" <<EOF_JSON
+{
+  "version": 1,
+  "session_id": "detached-fixture",
+  "profile": "wcl-detached-fixture",
+  "agent": "codex",
+  "mode": "strict",
+  "status": "exited",
+  "live_status": "stopped",
+  "workspace": "/tmp/detached-fixture-workspace",
+  "container_name": "workcell-session-fixture",
+  "started_at": "2026-04-08T14:00:00Z"
+}
+EOF_JSON
     printf "debug\n" >"${DEBUG_LOG}"
     printf "trace\n" >"${FILE_TRACE_LOG}"
     printf "transcript\n" >"${TRANSCRIPT_LOG}"
@@ -1457,7 +1516,20 @@ session_delete_record_only_output="$(
     mkdir -p "${PROFILE_DIR}/sessions"
     : >"${PROFILE_DIR}/docker.sock"
     mkdir -p "${SESSION_AUDIT_DIR}"
-    : >"${RECORD_PATH}"
+    cat >"${RECORD_PATH}" <<EOF_JSON
+{
+  "version": 1,
+  "session_id": "detached-fixture",
+  "profile": "wcl-detached-fixture",
+  "agent": "codex",
+  "mode": "strict",
+  "status": "exited",
+  "live_status": "stopped",
+  "workspace": "/tmp/detached-fixture-workspace",
+  "container_name": "workcell-session-fixture",
+  "started_at": "2026-04-08T14:00:00Z"
+}
+EOF_JSON
     printf "debug\n" >"${DEBUG_LOG}"
     printf "trace\n" >"${FILE_TRACE_LOG}"
     printf "transcript\n" >"${TRANSCRIPT_LOG}"
@@ -1523,7 +1595,20 @@ session_delete_dry_run_output="$(
     mkdir -p "${PROFILE_DIR}/sessions"
     : >"${PROFILE_DIR}/docker.sock"
     mkdir -p "${SESSION_AUDIT_DIR}"
-    : >"${RECORD_PATH}"
+    cat >"${RECORD_PATH}" <<EOF_JSON
+{
+  "version": 1,
+  "session_id": "detached-fixture",
+  "profile": "wcl-detached-fixture",
+  "agent": "codex",
+  "mode": "strict",
+  "status": "failed",
+  "live_status": "stopped",
+  "workspace": "/tmp/detached-fixture-workspace",
+  "container_name": "workcell-session-fixture",
+  "started_at": "2026-04-08T14:00:00Z"
+}
+EOF_JSON
     printf "debug\n" >"${DEBUG_LOG}"
     printf "trace\n" >"${FILE_TRACE_LOG}"
     printf "transcript\n" >"${TRANSCRIPT_LOG}"
@@ -1583,7 +1668,20 @@ bash -lc '
   DEBUG_LOG="${PROFILE_DIR}/detached.debug.log"
   mkdir -p "${PROFILE_DIR}/sessions"
   : >"${PROFILE_DIR}/docker.sock"
-  : >"${RECORD_PATH}"
+  cat >"${RECORD_PATH}" <<EOF_JSON
+{
+  "version": 1,
+  "session_id": "detached-fixture",
+  "profile": "wcl-detached-fixture",
+  "agent": "codex",
+  "mode": "strict",
+  "status": "exited",
+  "live_status": "stopped",
+  "workspace": "/tmp/detached-fixture-workspace",
+  "container_name": "workcell-session-fixture",
+  "started_at": "2026-04-08T14:00:00Z"
+}
+EOF_JSON
   printf "debug\n" >"${DEBUG_LOG}"
   HOST_DOCKER_BIN="/bin/false"
   resolve_host_tool() { printf "/bin/false\n"; }
@@ -1729,8 +1827,8 @@ EOF_JSON
   ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_LIFECYCLE_ROOT}" "${SESSION_LIFECYCLE_RECORD}" "${WORKSPACE_A}"
 )"
 grep -q '^attach_output=attached$' <<<"${session_lifecycle_output}"
-grep -q '^send_output=session_id=detached-lifecycle|sent_bytes=7|$' <<<"${session_lifecycle_output}"
-grep -q '^stop_output=session_id=detached-lifecycle|stop_requested=1|$' <<<"${session_lifecycle_output}"
+grep -q '^send_output=session_id=detached-lifecycle|sent_bytes=7|status=running|live_status=running|control_mode=detached|target_kind=local_vm|target_provider=colima|target_id=wcl-detached-lifecycle|target_summary=local_vm/colima/wcl-detached-lifecycle|target_assurance_class=strict|runtime_api=docker|workspace_transport=workspace-mount|workspace='"${WORKSPACE_A}"'|display_workspace='"${WORKSPACE_A}"'|workspace_origin='"${WORKSPACE_A}"'|display_worktree='"${WORKSPACE_A}"'|worktree_path='"${WORKSPACE_A}"'|display_git_branch=none|git_branch=|assurance=managed-mutable|$' <<<"${session_lifecycle_output}"
+grep -q '^stop_output=session_id=detached-lifecycle|stop_requested=1|status=exited|live_status=stopped|control_mode=detached|target_kind=local_vm|target_provider=colima|target_id=wcl-detached-lifecycle|target_summary=local_vm/colima/wcl-detached-lifecycle|target_assurance_class=strict|runtime_api=docker|workspace_transport=workspace-mount|workspace='"${WORKSPACE_A}"'|display_workspace='"${WORKSPACE_A}"'|workspace_origin='"${WORKSPACE_A}"'|display_worktree='"${WORKSPACE_A}"'|worktree_path='"${WORKSPACE_A}"'|display_git_branch=none|git_branch=|assurance=managed-mutable|$' <<<"${session_lifecycle_output}"
 grep -q '^delete_output=session_id=detached-lifecycle|deleted=1|record_only=0|dry_run=0|removed=record,container,session_audit_dir,debug_log,file_trace_log,transcript_log|kept=none|missing=none|unavailable=none|$' <<<"${session_lifecycle_output}"
 test -f "${SESSION_LIFECYCLE_AUDIT_LOG}"
 grep -q '^transport|wcl-detached-lifecycle|attach --no-stdin workcell-session-fixture$' "${SESSION_LIFECYCLE_RECORD}"
@@ -2029,9 +2127,9 @@ PY
     printf "cli_delete_output=%s\n" "$(tr "\n" "|" <<<"${delete_output}")"
   ' _ "${ROOT_DIR}" "${REAL_HOME}" "${CLI_SESSION_FIXTURE_IMAGE}" "${HOST_DOCKER_BIN}"
   )"
-  grep -q '^cli_send_output=session_id=cli-life-[0-9]\+|sent_bytes=7|$' <<<"${cli_lifecycle_output}"
   grep -q '^cli_stdin_payload=resume$' <<<"${cli_lifecycle_output}"
-  grep -q '^cli_stop_output=session_id=cli-life-[0-9]\+|stop_requested=1|$' <<<"${cli_lifecycle_output}"
+  grep -Eq '^cli_send_output=session_id=cli-life-[0-9]+[|]sent_bytes=7[|]status=running[|]live_status=running[|]control_mode=detached[|]target_kind=local_vm[|]target_provider=colima[|]target_id=wcl-cli-life-[0-9]+[|]target_summary=local_vm/colima/wcl-cli-life-[0-9]+[|]target_assurance_class=strict[|]runtime_api=docker[|]workspace_transport=isolated-worktree-mount[|]workspace=.*/workcell-cli-lifecycle-workspace\.[^|]+[|]display_workspace=.*/workcell-cli-lifecycle-workspace\.[^|]+[|]workspace_origin=.*/workcell-cli-lifecycle-workspace\.[^|]+[|]display_worktree=.*/workcell-cli-lifecycle-workspace\.[^|]+/.git/workcell-sessions/cli-life-[0-9]+/repo[|]worktree_path=.*/workcell-cli-lifecycle-workspace\.[^|]+/.git/workcell-sessions/cli-life-[0-9]+/repo[|]display_git_branch=none[|]git_branch=[|]assurance=managed-mutable[|]$' <<<"${cli_lifecycle_output}"
+  grep -Eq '^cli_stop_output=session_id=cli-life-[0-9]+[|]stop_requested=1[|]status=exited[|]live_status=stopped[|]control_mode=detached[|]target_kind=local_vm[|]target_provider=colima[|]target_id=wcl-cli-life-[0-9]+[|]target_summary=local_vm/colima/wcl-cli-life-[0-9]+[|]target_assurance_class=strict[|]runtime_api=docker[|]workspace_transport=isolated-worktree-mount[|]workspace=.*/workcell-cli-lifecycle-workspace\.[^|]+[|]display_workspace=.*/workcell-cli-lifecycle-workspace\.[^|]+[|]workspace_origin=.*/workcell-cli-lifecycle-workspace\.[^|]+[|]display_worktree=.*/workcell-cli-lifecycle-workspace\.[^|]+/.git/workcell-sessions/cli-life-[0-9]+/repo[|]worktree_path=.*/workcell-cli-lifecycle-workspace\.[^|]+/.git/workcell-sessions/cli-life-[0-9]+/repo[|]display_git_branch=none[|]git_branch=[|]assurance=managed-mutable[|]$' <<<"${cli_lifecycle_output}"
   grep -q '^cli_delete_output=session_id=cli-life-[0-9]\+|deleted=1|record_only=0|dry_run=0|removed=record,container,session_audit_dir,debug_log,file_trace_log,transcript_log|kept=none|missing=none|unavailable=none|$' <<<"${cli_lifecycle_output}"
 else
   echo "Skipping public CLI detached workload integration: docker CLI unavailable on PATH" >&2


### PR DESCRIPTION
## Summary
- complete the Phase 1 session-platform slice across `session list --verbose`, `session show --text`, and detached `session start|send|stop` summaries
- add deterministic shell and Go coverage for target identity, workspace transport, branch, and worktree rendering
- update operator docs and phase-plan references, and regenerate the control-plane manifest

## Validation
- `go test ./internal/hostutil ./cmd/workcell-hostutil`
- `bash ./tests/scenarios/shared/test-session-commands.sh`
- `./scripts/generate-control-plane-manifest.sh ./runtime/container/control-plane-manifest.json`
- `bash ./scripts/verify-operator-contract.sh`
- `bash ./scripts/verify-requirements-coverage.sh`
- `bash ./scripts/check-dead-code.sh`
- `bash ./scripts/check-public-repo-hygiene.sh`
- `bash ./scripts/validate-repo.sh`
