### PR TITLE
[codex] Enforce repo-owned green completion rules

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -64,6 +64,13 @@ for convenience.
 - Sign every commit.
 - Use feature branches. Do not push directly to `main` or rewrite history.
 - Treat final GitHub publication as a host-side action.
+- Do not accept failing repo-owned tests, checks, or workflows as "good
+  enough." If a lane fails because of the change or a hosted-control drift
+  uncovered during the task, keep working until it is fixed or the guarantee is
+  explicitly changed in the same review unit.
+- If the task includes merging, do not stop at PR-green. Follow the merged
+  `main` workflows and fix any repo-owned failures they surface before calling
+  the work complete.
 - When a commit changes a user-visible Workcell workflow, support tier, help
   surface, repo-local operator docs, contract entry, or validation evidence,
   land the matching contract/help/doc/test updates in the same change stream

--- a/.agents/skills/workcell-contract-parity/SKILL.md
+++ b/.agents/skills/workcell-contract-parity/SKILL.md
@@ -79,6 +79,11 @@ If the change is release-bound, also read:
   from public repo surfaces and clean repo detritus before finishing a change.
 - Re-check PR comments and review threads after CI turns green and immediately
   before merge.
+- Do not leave repo-owned tests, checks, or workflows red. If a validation lane
+  fails during the task, fix it or explicitly remove/demote the claimed
+  guarantee in the same change.
+- If the task includes merging, continue through the merged `main` workflow set
+  and treat any repo-owned failure as part of the same change until resolved.
 
 ## Workflow
 
@@ -95,6 +100,9 @@ If the change is release-bound, also read:
    large opportunistic refactors, or more than one reviewer-sized concern,
    split it before pushing for review.
 7. Run the contract validators and the focused tests.
+8. If publication or merge is part of the task, follow the repo-owned hosted
+   workflows through completion and fix any failures they surface before
+   finishing.
 
 ## Validation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,12 @@ the runtime boundary or explicit security guarantees in the name of convenience.
   merge.
 - Re-check comments and review threads after CI turns green and immediately
   before merge.
+- Do not treat failing tests, checks, or repo-owned workflows as acceptable.
+  If a repo-owned validation lane fails, keep working until it is fixed or the
+  guarantee is explicitly removed or demoted in the same change.
+- When the task includes merging a PR, follow the merged `main` workflows to a
+  finished state and treat any repo-owned failure as actionable work, not as an
+  acceptable post-merge residue.
 - Async reviewer feedback is advisory input, not a substitute for an
   independent human approval.
 


### PR DESCRIPTION
## Summary
- tighten repo policy so repo-owned tests, checks, and workflows cannot be left red
- require merge tasks to follow merged `main` workflows through completion
- mirror the same expectation in the repo-local `commit` and `workcell-contract-parity` skills

## Why
A recent hosted-controls drift showed that stopping at PR-green is not enough for this repository. The maintainer workflow should treat repo-owned post-merge failures as part of the same task until resolved.

## Validation
- `bash ./scripts/validate-repo.sh`
