### PR TITLE
[codex] Fix detached session git_branch summary output

### DIFF
--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "11e2f55c80b211f4918c9bb0f0a64b9f144ab98f67fea5f8cf71ba6ff2f77d55"
+      "sha256": "cded15c421e3f73fabf5a4067d301e88745d39ee600462508796c7840c809dd5"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1282,6 +1282,15 @@ session_meta_display_git_branch() {
   printf 'none\n'
 }
 
+ensure_session_meta_git_branch() {
+  local fallback_git_branch="${1:-}"
+
+  if [[ -n "${SESSION_META_GIT_BRANCH:-}" ]]; then
+    return 0
+  fi
+  SESSION_META_GIT_BRANCH="${fallback_git_branch:-none}"
+}
+
 emit_loaded_session_control_summary() {
   printf 'target_kind=%s\n' "${SESSION_META_TARGET_KIND:-}"
   printf 'target_provider=%s\n' "${SESSION_META_TARGET_PROVIDER:-}"
@@ -7993,6 +8002,7 @@ if [[ "${SESSION_DETACHED}" -eq 1 ]]; then
   detached_status="${SESSION_META_STATUS:-running}"
   detached_live_status="${SESSION_META_LIVE_STATUS:-running}"
   DETACHED_SESSION_ACTIVE=1
+  ensure_session_meta_git_branch "${session_git_branch}"
   printf 'session_id=%s\n' "${SESSION_ID}"
   printf 'status=%s\n' "${detached_status}"
   printf 'live_status=%s\n' "${detached_live_status}"
@@ -8001,7 +8011,6 @@ if [[ "${SESSION_DETACHED}" -eq 1 ]]; then
   printf 'workspace_origin=%s\n' "${SESSION_SOURCE_WORKSPACE}"
   printf 'workspace_root=%s\n' "${PROFILE_WORKSPACE_ROOT}"
   printf 'worktree_path=%s\n' "${WORKSPACE}"
-  printf 'git_branch=%s\n' "${session_git_branch:-none}"
   emit_loaded_session_control_summary
   printf 'monitor_pid=%s\n' "${SESSION_MONITOR_PID}"
   printf 'audit_log_path=%s\n' "$(profile_audit_log_path "${COLIMA_PROFILE}")"

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -606,6 +606,59 @@ if [[ "${monitor_ready_failure_status}" -eq 0 ]]; then
   exit 1
 fi
 
+detached_summary_output="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    SESSION_ID="detached-summary"
+    SESSION_META_TARGET_KIND="local_vm"
+    SESSION_META_TARGET_PROVIDER="colima"
+    SESSION_META_TARGET_ID="wcl-detached-summary"
+    SESSION_META_TARGET_ASSURANCE_CLASS="strict"
+    SESSION_META_RUNTIME_API="docker"
+    SESSION_META_WORKSPACE_TRANSPORT="workspace-mount"
+    SESSION_META_WORKSPACE="/tmp/detached-summary"
+    SESSION_META_WORKSPACE_ORIGIN="/tmp/detached-summary"
+    SESSION_META_WORKTREE_PATH="/tmp/detached-summary"
+    SESSION_META_CURRENT_ASSURANCE="managed-mutable"
+    session_git_branch=""
+    ensure_session_meta_git_branch "${session_git_branch}"
+    printf "session_id=%s\n" "${SESSION_ID}"
+    emit_loaded_session_control_summary
+  ' _ "${WORKCELL_FUNCTIONS_COPY}"
+)"
+test "$(grep -c '^git_branch=' <<<"${detached_summary_output}")" -eq 1
+grep -q '^display_git_branch=none$' <<<"${detached_summary_output}"
+grep -q '^git_branch=none$' <<<"${detached_summary_output}"
+
+detached_summary_runtime_branch_output="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    SESSION_ID="detached-summary-runtime"
+    SESSION_META_TARGET_KIND="local_vm"
+    SESSION_META_TARGET_PROVIDER="colima"
+    SESSION_META_TARGET_ID="wcl-detached-summary-runtime"
+    SESSION_META_TARGET_ASSURANCE_CLASS="strict"
+    SESSION_META_RUNTIME_API="docker"
+    SESSION_META_WORKSPACE_TRANSPORT="workspace-mount"
+    SESSION_META_WORKSPACE="/tmp/detached-summary-runtime"
+    SESSION_META_WORKSPACE_ORIGIN="/tmp/detached-summary-runtime"
+    SESSION_META_WORKTREE_PATH="/tmp/detached-summary-runtime"
+    SESSION_META_GIT_BRANCH="runtime-branch"
+    SESSION_META_CURRENT_ASSURANCE="managed-mutable"
+    session_git_branch="host-branch"
+    ensure_session_meta_git_branch "${session_git_branch}"
+    printf "session_id=%s\n" "${SESSION_ID}"
+    emit_loaded_session_control_summary
+  ' _ "${WORKCELL_FUNCTIONS_COPY}"
+)"
+test "$(grep -c '^git_branch=' <<<"${detached_summary_runtime_branch_output}")" -eq 1
+grep -q '^display_git_branch=runtime-branch$' <<<"${detached_summary_runtime_branch_output}"
+grep -q '^git_branch=runtime-branch$' <<<"${detached_summary_runtime_branch_output}"
+
 monitor_wait_status_output="$(
   bash -lc '
     set -euo pipefail


### PR DESCRIPTION
## Summary
- stop detached `session start` from emitting two `git_branch` keys
- seed the rendered detached-start summary from the host branch probe only when runtime metadata is missing
- add a focused regression around the detached summary formatter and keep control-plane parity up to date

## Root cause
Detached `session start` printed `git_branch` once from the host-side workspace probe and then a second time from loaded runtime metadata. In detached-head or non-git cases, the second key could be empty and overwrite the stable `none` fallback for parsers that keep the last value.

## Validation
- `bash ./tests/scenarios/shared/test-session-commands.sh`
- `./scripts/generate-control-plane-manifest.sh ./runtime/container/control-plane-manifest.json`
- `bash ./scripts/verify-operator-contract.sh`
- `bash ./scripts/verify-requirements-coverage.sh`
- `bash ./scripts/check-dead-code.sh`
- `bash ./scripts/check-public-repo-hygiene.sh`
- `bash ./scripts/validate-repo.sh`
