### PR TITLE
[codex] Implement Phase 2 target-state migration

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,14 +21,6 @@ The deterministic phase breakdown lives in
 - expand end-to-end coverage for authenticated, lower-assurance, and
   session-supervisor transitions so new orchestration features ship with
   invariant checks
-- define the runtime-target model explicitly:
-  separate target kind, assurance class, and workspace transport in the
-  control plane, CLI, docs, and session records
-- generalize host-owned state and session metadata away from Colima-specific
-  `profile` and `~/.colima/...` assumptions while preserving compatibility
-  reads for existing records
-- extract `colima` behind the new target model without changing the current
-  strict macOS contract
 - add a narrow trusted `linux/amd64` validation-host lane plus target-aware
   diagnostics before broad non-macOS or cloud support claims
 - define the first cross-platform `compat` target and the first `remote_vm`

--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -356,16 +356,40 @@ func launcherUsage() error {
 	return fmt.Errorf("usage: workcell-hostutil launcher <session-suffix|colima-status|cleanup-stale-log-pointers|profile-lock-is-stale|acquire-profile-lock|write-profile-owner|cleanup-stale-session-audit-dirs|session-record-write|session-list|session-show|session-export|session-diff-metadata|session-runtime-metadata|session-timeline|audit-digest|direct-mount-cache-key|resolve-host-output-candidate|resolve-host-output-directory-candidate|cleanup-stale-injection-bundles|manifest-metadata|resolver-metadata|workspace-cache-key|extract-codex-version|validate-security-options|canonicalize-tool-path|dedupe-endpoints|resolve-endpoints> [args...]")
 }
 
-func runLauncherSessionList(args []string) error {
-	if len(args) < 1 || len(args) > 5 {
-		return launcherUsage()
+func parseSessionRoots(args []string) ([]string, []string, error) {
+	if len(args) == 0 {
+		return nil, nil, launcherUsage()
 	}
 
-	colimaRoot := args[0]
+	if strings.HasPrefix(args[0], "--root=") {
+		roots := make([]string, 0, len(args))
+		for len(args) > 0 && strings.HasPrefix(args[0], "--root=") {
+			root := strings.TrimPrefix(args[0], "--root=")
+			if root == "" {
+				return nil, nil, launcherUsage()
+			}
+			roots = append(roots, root)
+			args = args[1:]
+		}
+		if len(roots) == 0 {
+			return nil, nil, launcherUsage()
+		}
+		return roots, args, nil
+	}
+
+	return []string{args[0]}, args[1:], nil
+}
+
+func runLauncherSessionList(args []string) error {
+	roots, rest, err := parseSessionRoots(args)
+	if err != nil {
+		return err
+	}
+
 	format := "lines"
 	verbose := false
 	opts := hostutil.SessionListOptions{}
-	for _, arg := range args[1:] {
+	for _, arg := range rest {
 		switch {
 		case arg == "--json":
 			format = "json"
@@ -383,7 +407,7 @@ func runLauncherSessionList(args []string) error {
 		return fmt.Errorf("session-list accepts either --json or --verbose, not both")
 	}
 
-	records, err := hostutil.ListSessionRecords(colimaRoot, opts)
+	records, err := hostutil.ListSessionRecordsInRoots(roots, opts)
 	if err != nil {
 		return err
 	}
@@ -435,18 +459,22 @@ func runLauncherSessionList(args []string) error {
 }
 
 func runLauncherSessionShow(args []string) error {
-	if len(args) < 2 || len(args) > 3 {
+	roots, rest, err := parseSessionRoots(args)
+	if err != nil {
+		return err
+	}
+	if len(rest) < 1 || len(rest) > 2 {
 		return launcherUsage()
 	}
 
 	format := "json"
-	for _, arg := range args[2:] {
+	for _, arg := range rest[1:] {
 		if arg != "--text" {
 			return launcherUsage()
 		}
 		format = "text"
 	}
-	record, err := hostutil.FindSessionRecord(args[0], args[1])
+	record, err := hostutil.FindSessionRecordInRoots(roots, rest[0])
 	if err != nil {
 		return err
 	}
@@ -465,11 +493,15 @@ func runLauncherSessionShow(args []string) error {
 }
 
 func runLauncherSessionExport(args []string) error {
-	if len(args) != 2 {
+	roots, rest, err := parseSessionRoots(args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
 		return launcherUsage()
 	}
 
-	exported, err := hostutil.ExportSessionRecord(args[0], args[1])
+	exported, err := hostutil.ExportSessionRecordInRoots(roots, rest[0])
 	if err != nil {
 		return err
 	}
@@ -482,11 +514,15 @@ func runLauncherSessionExport(args []string) error {
 }
 
 func runLauncherSessionDiffMetadata(args []string) error {
-	if len(args) != 2 {
+	roots, rest, err := parseSessionRoots(args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
 		return launcherUsage()
 	}
 
-	record, err := hostutil.FindSessionRecord(args[0], args[1])
+	record, err := hostutil.FindSessionRecordInRoots(roots, rest[0])
 	if err != nil {
 		return err
 	}
@@ -497,26 +533,35 @@ func runLauncherSessionDiffMetadata(args []string) error {
 }
 
 func runLauncherSessionRuntimeMetadata(args []string) error {
-	if len(args) != 2 {
+	roots, rest, err := parseSessionRoots(args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
 		return launcherUsage()
 	}
 
-	record, err := hostutil.FindSessionRecord(args[0], args[1])
+	record, recordPath, err := hostutil.FindSessionRecordWithPathInRoots(roots, rest[0])
 	if err != nil {
 		return err
 	}
 	for _, line := range hostutil.SessionRuntimeMetadataLines(record) {
 		fmt.Println(line)
 	}
+	fmt.Printf("record_path=%s\n", recordPath)
 	return nil
 }
 
 func runLauncherSessionTimeline(args []string) error {
-	if len(args) != 2 {
+	roots, rest, err := parseSessionRoots(args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
 		return launcherUsage()
 	}
 
-	lines, err := hostutil.SessionTimelineRecords(args[0], args[1])
+	lines, err := hostutil.SessionTimelineRecordsInRoots(roots, rest[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/workcell-hostutil/main_test.go
+++ b/cmd/workcell-hostutil/main_test.go
@@ -149,6 +149,63 @@ func TestRunLauncherSessionRuntimeMetadata(t *testing.T) {
 	}
 }
 
+func TestRunLauncherSessionRuntimeMetadataSupportsMultipleRoots(t *testing.T) {
+	stateRoot := t.TempDir()
+	legacyRoot := t.TempDir()
+	sessionPath := filepath.Join(stateRoot, "targets", "local_vm", "colima", "wcl-one", "sessions", "session-1.json")
+	if err := hostutil.WriteSessionRecord(sessionPath, map[string]string{
+		"session_id":        "session-1",
+		"profile":           "wcl-one",
+		"agent":             "codex",
+		"mode":              "strict",
+		"status":            "running",
+		"workspace":         "/tmp/workspace-a",
+		"started_at":        "2026-04-08T10:00:00Z",
+		"current_assurance": "managed-mutable",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = stdout.ReadFrom(r)
+		close(done)
+	}()
+
+	runErr := run([]string{
+		"launcher",
+		"session-runtime-metadata",
+		"--root=" + stateRoot,
+		"--root=" + legacyRoot,
+		"session-1",
+	})
+	_ = w.Close()
+	<-done
+	_ = r.Close()
+
+	if runErr != nil {
+		t.Fatalf("run() error = %v", runErr)
+	}
+	got := strings.TrimSpace(stdout.String())
+	if !strings.Contains(got, "profile=wcl-one") {
+		t.Fatalf("runtime metadata output = %q, want profile line", got)
+	}
+	if !strings.Contains(got, "record_path="+sessionPath) {
+		t.Fatalf("runtime metadata output = %q, want record_path line", got)
+	}
+}
+
 func TestRunLauncherSessionListShowsLiveStatusAndControl(t *testing.T) {
 	colimaRoot := t.TempDir()
 	if err := hostutil.WriteSessionRecord(filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json"), map[string]string{

--- a/docs/enterprise-rollout.md
+++ b/docs/enterprise-rollout.md
@@ -41,7 +41,8 @@ These parts are still local to each operator host:
 - Workcell installation and updates
 - `~/.config/workcell/` policy files and included fragments
 - managed credential material referenced by `workcell auth`
-- `~/.colima/<profile>/sessions/` durable session records
+- `~/.local/state/workcell/targets/local_vm/colima/<profile>/sessions/`
+  durable session records
 - local launch history, retained debug logs, transcripts, and file traces
 
 If you want team-wide consistency today, distribute reviewed host-side files

--- a/docs/implement-first-delivery-plan.md
+++ b/docs/implement-first-delivery-plan.md
@@ -7,16 +7,18 @@ The longer-lived runtime-target and deployment-reach program lives in
 [`docs/runtime-target-expansion-plan.md`](runtime-target-expansion-plan.md),
 and the deterministic phase breakdown lives in
 [`docs/runtime-target-phase-plan.md`](runtime-target-phase-plan.md).
-Phase 1 of that phase plan is now implemented in the repository; this document
-remains as the delivered-scope reference for that slice and the immediate
-bridge to later runtime-target work.
+Phases 1 and 2 of that phase plan are now implemented in the repository; this
+document remains as the delivered-scope reference for those slices and the
+immediate bridge to later runtime-target work.
 
 The current repo already includes durable session records plus detached
 host-side session control (`session start|attach|send|stop`) and basic
 observability surfaces (`session list|show|logs|timeline|diff|export`). The
-remaining work in this slice is to make those commands feel like one coherent
-session platform with safer default workspace isolation, richer status
-rendering, and deeper validation coverage.
+current repo also stores session, audit, and lock state under Workcell-owned
+target-state roots while preserving compatibility reads for older
+`~/.colima/...` records. The remaining work in this slice is to broaden shared
+auth/bootstrap coverage, expand host-compat validation, and deepen scenario
+coverage as later runtime-target phases land.
 
 ## Principles
 

--- a/docs/runtime-target-expansion-plan.md
+++ b/docs/runtime-target-expansion-plan.md
@@ -137,6 +137,12 @@ targets must stay labeled `compat` or another explicitly lower-assurance class.
 - session and audit state are no longer Colima-shaped at the program level
 - session-surface parity is preserved
 
+Current repo status:
+
+- Gate 1 is implemented
+- Gate 2 is implemented
+- later gates remain planning targets until their code and evidence land
+
 ### Gate 3: compatibility target certified
 
 - `docker-desktop` is feature-flagged, explicitly `compat`, and backed by

--- a/docs/runtime-target-phase-plan.md
+++ b/docs/runtime-target-phase-plan.md
@@ -14,6 +14,8 @@ Current repo status:
 
 - Phase 0 is implemented in the validation substrate
 - Phase 1 is implemented in the session platform and deterministic evidence
+- Phase 2 is implemented in the target-state migration and Colima
+  compatibility-read path
 - later phases remain planning targets until their code and evidence land
 
 ## Phase Completion Contract

--- a/docs/workcell-session-supervisor-design.md
+++ b/docs/workcell-session-supervisor-design.md
@@ -31,8 +31,9 @@ host-side inventory, observability, and detached-control commands:
 - `workcell session stop`
 - `workcell session delete`
 
-Each launched session writes durable metadata under the managed Colima profile
-state instead of relying only on the transient `session-audit.*` directory.
+Each launched session writes durable metadata under the Workcell-owned
+target-state root instead of relying only on the transient `session-audit.*`
+directory.
 
 Detached sessions default to `--session-workspace isolated`, so the detached
 path already points toward worktree-per-session operation on the safe path. The
@@ -53,11 +54,13 @@ Each session record stores the durable host-side view of one launch, including:
 - initial, current, and final assurance state
 - workspace control-plane mode
 
-The durable record lives under:
+The durable record lives under the target-state root, by default:
 
-- `~/.colima/<profile>/sessions/<session_id>.json`
+- `~/.local/state/workcell/targets/local_vm/colima/<profile>/sessions/<session_id>.json`
 
-The transient `session-audit.*` directory remains separate and disposable.
+Compatibility reads still accept older legacy records under
+`~/.colima/<profile>/sessions/<session_id>.json`. The transient
+`session-audit.*` directory remains separate and disposable.
 
 ## Why This Shape
 
@@ -70,13 +73,16 @@ That matters because:
 - `--gc` already cleans transient audit dirs
 - durable session inventory should survive the transient session cleanup path
 
-Storing records under `sessions/` instead of inside `session-audit.*` avoids
-confusing retention with ephemeral runtime scratch state.
+Storing records under a Workcell-owned target-state root instead of inside
+`session-audit.*` or the Colima runtime tree avoids confusing durable control
+state with ephemeral runtime scratch state.
 
 ## Audit Relationship
 
 The current implementation adds `session_id` to launch, control, assurance, and
-exit audit records in the profile audit log.
+exit audit records in the target audit log, which by default lives beside the
+session records under
+`~/.local/state/workcell/targets/local_vm/colima/<profile>/workcell.audit.log`.
 
 That allows:
 
@@ -145,8 +151,6 @@ The current slice does not yet attempt to implement:
 
 The remaining near-term work is to:
 
-- decouple session, audit, and lock state from Colima-shaped program-level
-  assumptions while preserving compatibility reads
 - deepen validation coverage for detached-session transitions and
   lower-assurance paths
 - add richer artifact browsing without weakening the host-owned model

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -282,7 +282,10 @@ The supported operator inventory is maintained in
 system-design doc explains shape and rationale; it should not be treated as the
 authoritative CLI inventory.
 
-Detached session records are written under the Colima profile state tree as
+Detached session records are written under the Workcell-owned target-state tree
+as
+`~/.local/state/workcell/targets/local_vm/colima/<profile>/sessions/<session-id>.json`.
+Compatibility reads still accept older legacy records under
 `~/.colima/<profile>/sessions/<session-id>.json`. The current session record
 schema in [`internal/hostutil/sessions.go`](../internal/hostutil/sessions.go)
 includes:

--- a/internal/hostutil/hostutil_test.go
+++ b/internal/hostutil/hostutil_test.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCanonicalizePathResolvesHomeAndSymlinks(t *testing.T) {
@@ -336,6 +337,101 @@ func TestAcquireProfileLockReturnsFalseWhenLockExists(t *testing.T) {
 	for _, entry := range entries {
 		if strings.Contains(entry.Name(), ".pending.") {
 			t.Fatalf("temporary lock dir leaked: %s", entry.Name())
+		}
+	}
+}
+
+func TestCleanupStaleLatestLogPointersSupportsTargetAndLegacyRoots(t *testing.T) {
+	t.Parallel()
+
+	scratchRoot := t.TempDir()
+	targetRoot := filepath.Join(scratchRoot, "state-root")
+	legacyRoot := filepath.Join(scratchRoot, "legacy-root")
+	targetProfileDir := filepath.Join(targetRoot, "targets", "local_vm", "colima", "wcl-target")
+	legacyProfileDir := filepath.Join(legacyRoot, "wcl-legacy")
+	if err := os.MkdirAll(targetProfileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(legacyProfileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	existingTarget := filepath.Join(scratchRoot, "existing-debug.log")
+	if err := os.WriteFile(existingTarget, []byte("debug\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	targetPointer := filepath.Join(targetProfileDir, "workcell.latest-debug-log")
+	legacyPointer := filepath.Join(legacyProfileDir, "workcell.latest-transcript-log")
+	if err := os.WriteFile(targetPointer, []byte(existingTarget+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPointer, []byte(filepath.Join(scratchRoot, "missing-transcript.log")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CleanupStaleLatestLogPointers(targetRoot); err != nil {
+		t.Fatalf("CleanupStaleLatestLogPointers(target) error = %v", err)
+	}
+	if err := CleanupStaleLatestLogPointers(legacyRoot); err != nil {
+		t.Fatalf("CleanupStaleLatestLogPointers(legacy) error = %v", err)
+	}
+
+	if _, err := os.Stat(targetPointer); err != nil {
+		t.Fatalf("target pointer should remain: %v", err)
+	}
+	if _, err := os.Stat(legacyPointer); !os.IsNotExist(err) {
+		t.Fatalf("legacy pointer should be removed, err = %v", err)
+	}
+}
+
+func TestCleanupStaleSessionAuditDirsSupportsTargetAndLegacyRoots(t *testing.T) {
+	t.Parallel()
+
+	scratchRoot := t.TempDir()
+	targetRoot := filepath.Join(scratchRoot, "state-root")
+	legacyRoot := filepath.Join(scratchRoot, "legacy-root")
+	targetProfileDir := filepath.Join(targetRoot, "targets", "local_vm", "colima", "wcl-target")
+	legacyProfileDir := filepath.Join(legacyRoot, "wcl-legacy")
+	if err := os.MkdirAll(targetProfileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(legacyProfileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	targetStale := filepath.Join(targetProfileDir, "session-audit.stale")
+	targetRecent := filepath.Join(targetProfileDir, "session-audit.recent")
+	legacyStale := filepath.Join(legacyProfileDir, "session-audit.stale")
+	legacyRecent := filepath.Join(legacyProfileDir, "session-audit.recent")
+	for _, dir := range []string{targetStale, targetRecent, legacyStale, legacyRecent} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	old := time.Now().Add(-13 * time.Hour)
+	for _, dir := range []string{targetStale, legacyStale} {
+		if err := os.Chtimes(dir, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := CleanupStaleSessionAuditDirs(targetRoot); err != nil {
+		t.Fatalf("CleanupStaleSessionAuditDirs(target) error = %v", err)
+	}
+	if err := CleanupStaleSessionAuditDirs(legacyRoot); err != nil {
+		t.Fatalf("CleanupStaleSessionAuditDirs(legacy) error = %v", err)
+	}
+
+	for _, dir := range []string{targetStale, legacyStale} {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Fatalf("stale session-audit dir should be removed: %s err=%v", dir, err)
+		}
+	}
+	for _, dir := range []string{targetRecent, legacyRecent} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatalf("recent session-audit dir should remain: %s err=%v", dir, err)
 		}
 	}
 }

--- a/internal/hostutil/launcher.go
+++ b/internal/hostutil/launcher.go
@@ -60,37 +60,18 @@ func IsNoMatch(err error) bool {
 	return errors.Is(err, errNoMatch)
 }
 
-func CleanupStaleLatestLogPointers(colimaRoot string) error {
-	root := filepath.Clean(colimaRoot)
-	info, err := os.Stat(root)
+func CleanupStaleLatestLogPointers(stateRoot string) error {
+	stateDirs, err := sessionStateDirs(stateRoot)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
 		return err
 	}
-	if !info.IsDir() {
-		return fmt.Errorf("%s is not a directory", root)
-	}
-
 	uid := uint32(os.Getuid())
 	pointerNames := []string{
 		"workcell.latest-debug-log",
 		"workcell.latest-file-trace-log",
 		"workcell.latest-transcript-log",
 	}
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return err
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		profileDir := filepath.Join(root, entry.Name())
-		if isSymlink(profileDir) {
-			continue
-		}
+	for _, profileDir := range stateDirs {
 		for _, pointerName := range pointerNames {
 			pointerPath := filepath.Join(profileDir, pointerName)
 			info, err := os.Lstat(pointerPath)
@@ -220,33 +201,14 @@ func WriteProfileOwner(ownerPath string, pid int) error {
 	return os.Chmod(ownerPath, 0o600)
 }
 
-func CleanupStaleSessionAuditDirs(colimaRoot string) error {
-	root := filepath.Clean(colimaRoot)
-	info, err := os.Stat(root)
+func CleanupStaleSessionAuditDirs(stateRoot string) error {
+	stateDirs, err := sessionStateDirs(stateRoot)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
 		return err
 	}
-	if !info.IsDir() {
-		return fmt.Errorf("%s is not a directory", root)
-	}
-
 	cutoff := time.Now().Add(-12 * time.Hour)
 	uid := uint32(os.Getuid())
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return err
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		profileDir := filepath.Join(root, entry.Name())
-		if isSymlink(profileDir) {
-			continue
-		}
+	for _, profileDir := range stateDirs {
 		candidates, err := os.ReadDir(profileDir)
 		if err != nil {
 			continue

--- a/internal/hostutil/sessions.go
+++ b/internal/hostutil/sessions.go
@@ -66,6 +66,11 @@ type SessionExport struct {
 	AuditRecords []string      `json:"audit_records,omitempty"`
 }
 
+type SessionRecordLocation struct {
+	Record SessionRecord
+	Path   string
+}
+
 func SessionDiffMetadataLines(record SessionRecord) []string {
 	record = normalizeSessionRecord(record)
 	return []string{
@@ -398,12 +403,12 @@ func ReadSessionRecord(path string) (SessionRecord, error) {
 	return record, nil
 }
 
-func ListSessionRecords(colimaRoot string, opts SessionListOptions) ([]SessionRecord, error) {
-	root := filepath.Clean(colimaRoot)
+func sessionStateDirs(root string) ([]string, error) {
+	root = filepath.Clean(root)
 	info, err := os.Stat(root)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return []SessionRecord{}, nil
+			return []string{}, nil
 		}
 		return nil, err
 	}
@@ -411,25 +416,87 @@ func ListSessionRecords(colimaRoot string, opts SessionListOptions) ([]SessionRe
 		return nil, fmt.Errorf("%s is not a directory", root)
 	}
 
+	targetsRoot := filepath.Join(root, "targets")
+	if targetsInfo, err := os.Stat(targetsRoot); err == nil {
+		if !targetsInfo.IsDir() {
+			return nil, fmt.Errorf("%s is not a directory", targetsRoot)
+		}
+		return targetStateDirs(targetsRoot)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
 	entries, err := os.ReadDir(root)
 	if err != nil {
 		return nil, err
 	}
-
-	records := make([]SessionRecord, 0)
+	stateDirs := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
-		if opts.Profile != "" && entry.Name() != opts.Profile {
+		stateDir := filepath.Join(root, entry.Name())
+		if isSymlink(stateDir) {
 			continue
 		}
+		stateDirs = append(stateDirs, stateDir)
+	}
+	return stateDirs, nil
+}
 
-		profileDir := filepath.Join(root, entry.Name())
-		if isSymlink(profileDir) {
+func targetStateDirs(targetsRoot string) ([]string, error) {
+	kinds, err := os.ReadDir(targetsRoot)
+	if err != nil {
+		return nil, err
+	}
+	stateDirs := make([]string, 0)
+	for _, kindEntry := range kinds {
+		if !kindEntry.IsDir() {
 			continue
 		}
-		sessionDir := filepath.Join(profileDir, "sessions")
+		kindDir := filepath.Join(targetsRoot, kindEntry.Name())
+		if isSymlink(kindDir) {
+			continue
+		}
+		providers, err := os.ReadDir(kindDir)
+		if err != nil {
+			return nil, err
+		}
+		for _, providerEntry := range providers {
+			if !providerEntry.IsDir() {
+				continue
+			}
+			providerDir := filepath.Join(kindDir, providerEntry.Name())
+			if isSymlink(providerDir) {
+				continue
+			}
+			ids, err := os.ReadDir(providerDir)
+			if err != nil {
+				return nil, err
+			}
+			for _, idEntry := range ids {
+				if !idEntry.IsDir() {
+					continue
+				}
+				stateDir := filepath.Join(providerDir, idEntry.Name())
+				if isSymlink(stateDir) {
+					continue
+				}
+				stateDirs = append(stateDirs, stateDir)
+			}
+		}
+	}
+	return stateDirs, nil
+}
+
+func listSessionRecordLocationsFromRoot(root string, opts SessionListOptions) ([]SessionRecordLocation, error) {
+	stateDirs, err := sessionStateDirs(root)
+	if err != nil {
+		return nil, err
+	}
+	locations := make([]SessionRecordLocation, 0)
+	for _, stateDir := range stateDirs {
+		sessionDir := filepath.Join(stateDir, "sessions")
 		if isSymlink(sessionDir) {
 			continue
 		}
@@ -458,46 +525,106 @@ func ListSessionRecords(colimaRoot string, opts SessionListOptions) ([]SessionRe
 			if !SessionMatchesWorkspace(record, opts.Workspace) {
 				continue
 			}
-			records = append(records, record)
+			if opts.Profile != "" && record.Profile != opts.Profile {
+				continue
+			}
+			locations = append(locations, SessionRecordLocation{
+				Record: record,
+				Path:   sessionPath,
+			})
 		}
 	}
+	return locations, nil
+}
 
-	sort.SliceStable(records, func(i, j int) bool {
-		if records[i].StartedAt == records[j].StartedAt {
-			return records[i].SessionID > records[j].SessionID
+func sortSessionRecordLocations(locations []SessionRecordLocation) {
+	sort.SliceStable(locations, func(i, j int) bool {
+		if locations[i].Record.StartedAt == locations[j].Record.StartedAt {
+			return locations[i].Record.SessionID > locations[j].Record.SessionID
 		}
-		return records[i].StartedAt > records[j].StartedAt
+		return locations[i].Record.StartedAt > locations[j].Record.StartedAt
 	})
+}
+
+func ListSessionRecordLocationsInRoots(roots []string, opts SessionListOptions) ([]SessionRecordLocation, error) {
+	locations := make([]SessionRecordLocation, 0)
+	priorRootSessionIDs := map[string]struct{}{}
+	for _, root := range roots {
+		current, err := listSessionRecordLocationsFromRoot(root, opts)
+		if err != nil {
+			return nil, err
+		}
+		currentRootSessionIDs := map[string]struct{}{}
+		for _, location := range current {
+			if _, exists := priorRootSessionIDs[location.Record.SessionID]; exists {
+				continue
+			}
+			locations = append(locations, location)
+			currentRootSessionIDs[location.Record.SessionID] = struct{}{}
+		}
+		for sessionID := range currentRootSessionIDs {
+			priorRootSessionIDs[sessionID] = struct{}{}
+		}
+	}
+	sortSessionRecordLocations(locations)
+	if locations == nil {
+		return []SessionRecordLocation{}, nil
+	}
+	return locations, nil
+}
+
+func ListSessionRecords(root string, opts SessionListOptions) ([]SessionRecord, error) {
+	return ListSessionRecordsInRoots([]string{root}, opts)
+}
+
+func ListSessionRecordsInRoots(roots []string, opts SessionListOptions) ([]SessionRecord, error) {
+	locations, err := ListSessionRecordLocationsInRoots(roots, opts)
+	if err != nil {
+		return nil, err
+	}
+	records := make([]SessionRecord, 0, len(locations))
+	for _, location := range locations {
+		records = append(records, location.Record)
+	}
 	if records == nil {
 		return []SessionRecord{}, nil
 	}
 	return records, nil
 }
 
-func FindSessionRecord(colimaRoot, sessionID string) (SessionRecord, error) {
-	records, err := ListSessionRecords(colimaRoot, SessionListOptions{})
+func FindSessionRecordInRoots(roots []string, sessionID string) (SessionRecord, error) {
+	record, _, err := FindSessionRecordWithPathInRoots(roots, sessionID)
+	return record, err
+}
+
+func FindSessionRecordWithPathInRoots(roots []string, sessionID string) (SessionRecord, string, error) {
+	locations, err := ListSessionRecordLocationsInRoots(roots, SessionListOptions{})
 	if err != nil {
-		return SessionRecord{}, err
+		return SessionRecord{}, "", err
 	}
 
-	var match *SessionRecord
-	for i := range records {
-		if records[i].SessionID != sessionID {
+	var match *SessionRecordLocation
+	for i := range locations {
+		if locations[i].Record.SessionID != sessionID {
 			continue
 		}
 		if match != nil {
-			return SessionRecord{}, fmt.Errorf("multiple session records matched %q", sessionID)
+			return SessionRecord{}, "", fmt.Errorf("multiple session records matched %q", sessionID)
 		}
-		match = &records[i]
+		match = &locations[i]
 	}
 	if match == nil {
-		return SessionRecord{}, os.ErrNotExist
+		return SessionRecord{}, "", os.ErrNotExist
 	}
-	return *match, nil
+	return match.Record, match.Path, nil
 }
 
-func ExportSessionRecord(colimaRoot, sessionID string) (SessionExport, error) {
-	record, err := FindSessionRecord(colimaRoot, sessionID)
+func ExportSessionRecord(root, sessionID string) (SessionExport, error) {
+	return ExportSessionRecordInRoots([]string{root}, sessionID)
+}
+
+func ExportSessionRecordInRoots(roots []string, sessionID string) (SessionExport, error) {
+	record, err := FindSessionRecordInRoots(roots, sessionID)
 	if err != nil {
 		return SessionExport{}, err
 	}
@@ -509,8 +636,12 @@ func ExportSessionRecord(colimaRoot, sessionID string) (SessionExport, error) {
 	return SessionExport{Session: record, AuditRecords: records}, nil
 }
 
-func SessionTimelineRecords(colimaRoot, sessionID string) ([]string, error) {
-	record, err := FindSessionRecord(colimaRoot, sessionID)
+func SessionTimelineRecords(root, sessionID string) ([]string, error) {
+	return SessionTimelineRecordsInRoots([]string{root}, sessionID)
+}
+
+func SessionTimelineRecordsInRoots(roots []string, sessionID string) ([]string, error) {
+	record, err := FindSessionRecordInRoots(roots, sessionID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/hostutil/sessions.go
+++ b/internal/hostutil/sessions.go
@@ -418,7 +418,10 @@ func sessionStateDirs(root string) ([]string, error) {
 
 	stateDirs := make([]string, 0)
 	targetsRoot := filepath.Join(root, "targets")
-	if targetsInfo, err := os.Stat(targetsRoot); err == nil {
+	if isSymlink(targetsRoot) {
+		// Ignore symlinked targets roots so session discovery stays confined to
+		// the configured state root.
+	} else if targetsInfo, err := os.Stat(targetsRoot); err == nil {
 		if !targetsInfo.IsDir() {
 			return nil, fmt.Errorf("%s is not a directory", targetsRoot)
 		}

--- a/internal/hostutil/sessions.go
+++ b/internal/hostutil/sessions.go
@@ -416,12 +416,17 @@ func sessionStateDirs(root string) ([]string, error) {
 		return nil, fmt.Errorf("%s is not a directory", root)
 	}
 
+	stateDirs := make([]string, 0)
 	targetsRoot := filepath.Join(root, "targets")
 	if targetsInfo, err := os.Stat(targetsRoot); err == nil {
 		if !targetsInfo.IsDir() {
 			return nil, fmt.Errorf("%s is not a directory", targetsRoot)
 		}
-		return targetStateDirs(targetsRoot)
+		targetDirs, err := targetStateDirs(targetsRoot)
+		if err != nil {
+			return nil, err
+		}
+		stateDirs = append(stateDirs, targetDirs...)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
@@ -430,7 +435,6 @@ func sessionStateDirs(root string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	stateDirs := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue

--- a/internal/hostutil/sessions_test.go
+++ b/internal/hostutil/sessions_test.go
@@ -368,6 +368,49 @@ func TestListSessionRecordsInRootsReadsTargetStateAndLegacyRoots(t *testing.T) {
 	}
 }
 
+func TestListSessionRecordsSupportsLegacyProfileNamedTargets(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeSessionFixture(t, filepath.Join(root, "targets", "sessions", "session-targets.json"), SessionRecord{
+		Version:        1,
+		SessionID:      "session-targets",
+		Profile:        "targets",
+		Agent:          "codex",
+		Mode:           "strict",
+		Status:         "exited",
+		Workspace:      "/tmp/workspace-targets",
+		StartedAt:      "2026-04-08T10:00:00Z",
+		FinishedAt:     "2026-04-08T10:05:00Z",
+		ExitStatus:     "0",
+		FinalAssurance: "managed-mutable",
+	})
+	writeSessionFixture(t, filepath.Join(root, "wcl-one", "sessions", "session-1.json"), SessionRecord{
+		Version:        1,
+		SessionID:      "session-1",
+		Profile:        "wcl-one",
+		Agent:          "claude",
+		Mode:           "development",
+		Status:         "failed",
+		Workspace:      "/tmp/workspace-one",
+		StartedAt:      "2026-04-08T11:00:00Z",
+		FinishedAt:     "2026-04-08T11:03:00Z",
+		ExitStatus:     "17",
+		FinalAssurance: "managed-mutable",
+	})
+
+	records, err := ListSessionRecords(root, SessionListOptions{})
+	if err != nil {
+		t.Fatalf("ListSessionRecords() error = %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("ListSessionRecords() len = %d, want 2", len(records))
+	}
+	if records[0].SessionID != "session-1" || records[1].SessionID != "session-targets" {
+		t.Fatalf("unexpected record set from legacy root with targets dir: %+v", records)
+	}
+}
+
 func TestFindSessionRecordWithPathInRootsPrefersEarlierRootOnDuplicateSessionID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/hostutil/sessions_test.go
+++ b/internal/hostutil/sessions_test.go
@@ -324,6 +324,94 @@ func TestListSessionRecordsSkipsSymlinkedSessionsDirectories(t *testing.T) {
 	}
 }
 
+func TestListSessionRecordsInRootsReadsTargetStateAndLegacyRoots(t *testing.T) {
+	t.Parallel()
+
+	stateRoot := t.TempDir()
+	legacyRoot := t.TempDir()
+	writeSessionFixture(t, filepath.Join(stateRoot, "targets", "local_vm", "colima", "wcl-two", "sessions", "session-2.json"), SessionRecord{
+		Version:        1,
+		SessionID:      "session-2",
+		Profile:        "wcl-two",
+		Agent:          "claude",
+		Mode:           "development",
+		Status:         "failed",
+		Workspace:      "/tmp/workspace-b",
+		StartedAt:      "2026-04-08T11:00:00Z",
+		FinishedAt:     "2026-04-08T11:03:00Z",
+		ExitStatus:     "17",
+		FinalAssurance: "managed-mutable",
+	})
+	writeSessionFixture(t, filepath.Join(legacyRoot, "wcl-one", "sessions", "session-1.json"), SessionRecord{
+		Version:        1,
+		SessionID:      "session-1",
+		Profile:        "wcl-one",
+		Agent:          "codex",
+		Mode:           "strict",
+		Status:         "exited",
+		Workspace:      "/tmp/workspace-a",
+		StartedAt:      "2026-04-08T10:00:00Z",
+		FinishedAt:     "2026-04-08T10:05:00Z",
+		ExitStatus:     "0",
+		FinalAssurance: "managed-mutable",
+	})
+
+	records, err := ListSessionRecordsInRoots([]string{stateRoot, legacyRoot}, SessionListOptions{})
+	if err != nil {
+		t.Fatalf("ListSessionRecordsInRoots() error = %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("ListSessionRecordsInRoots() len = %d, want 2", len(records))
+	}
+	if records[0].SessionID != "session-2" || records[1].SessionID != "session-1" {
+		t.Fatalf("unexpected multi-root sort order: %+v", records)
+	}
+}
+
+func TestFindSessionRecordWithPathInRootsPrefersEarlierRootOnDuplicateSessionID(t *testing.T) {
+	t.Parallel()
+
+	stateRoot := t.TempDir()
+	legacyRoot := t.TempDir()
+	targetPath := filepath.Join(stateRoot, "targets", "local_vm", "colima", "wcl-one", "sessions", "session-1.json")
+	legacyPath := filepath.Join(legacyRoot, "wcl-one", "sessions", "session-1.json")
+	writeSessionFixture(t, targetPath, SessionRecord{
+		Version:          1,
+		SessionID:        "session-1",
+		Profile:          "wcl-one",
+		Agent:            "codex",
+		Mode:             "strict",
+		Status:           "running",
+		Workspace:        "/tmp/workspace-a",
+		StartedAt:        "2026-04-08T11:00:00Z",
+		CurrentAssurance: "managed-mutable",
+	})
+	writeSessionFixture(t, legacyPath, SessionRecord{
+		Version:        1,
+		SessionID:      "session-1",
+		Profile:        "wcl-one",
+		Agent:          "claude",
+		Mode:           "development",
+		Status:         "exited",
+		Workspace:      "/tmp/workspace-b",
+		StartedAt:      "2026-04-08T10:00:00Z",
+		FinishedAt:     "2026-04-08T10:05:00Z",
+		ExitStatus:     "0",
+		FinalAssurance: "managed-mutable",
+	})
+
+	record, path, err := FindSessionRecordWithPathInRoots([]string{stateRoot, legacyRoot}, "session-1")
+	if err != nil {
+		t.Fatalf("FindSessionRecordWithPathInRoots() error = %v", err)
+	}
+	if path != targetPath {
+		t.Fatalf("FindSessionRecordWithPathInRoots() path = %q, want %q", path, targetPath)
+	}
+	if record.Agent != "codex" || record.Status != "running" {
+		t.Fatalf("FindSessionRecordWithPathInRoots() record = %+v, want target-root record", record)
+	}
+}
+
 func TestExportSessionRecordIncludesMatchingAuditLines(t *testing.T) {
 	t.Parallel()
 

--- a/internal/hostutil/sessions_test.go
+++ b/internal/hostutil/sessions_test.go
@@ -411,6 +411,53 @@ func TestListSessionRecordsSupportsLegacyProfileNamedTargets(t *testing.T) {
 	}
 }
 
+func TestListSessionRecordsSkipsSymlinkedTargetsRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	external := t.TempDir()
+	if err := os.Symlink(filepath.Join(external, "targets"), filepath.Join(root, "targets")); err != nil {
+		t.Fatal(err)
+	}
+	writeSessionFixture(t, filepath.Join(external, "targets", "local_vm", "colima", "external-profile", "sessions", "session-external.json"), SessionRecord{
+		Version:        1,
+		SessionID:      "session-external",
+		Profile:        "external-profile",
+		Agent:          "codex",
+		Mode:           "strict",
+		Status:         "exited",
+		Workspace:      "/tmp/workspace-external",
+		StartedAt:      "2026-04-08T09:00:00Z",
+		FinishedAt:     "2026-04-08T09:05:00Z",
+		ExitStatus:     "0",
+		FinalAssurance: "managed-mutable",
+	})
+	writeSessionFixture(t, filepath.Join(root, "wcl-one", "sessions", "session-1.json"), SessionRecord{
+		Version:        1,
+		SessionID:      "session-1",
+		Profile:        "wcl-one",
+		Agent:          "claude",
+		Mode:           "development",
+		Status:         "failed",
+		Workspace:      "/tmp/workspace-one",
+		StartedAt:      "2026-04-08T11:00:00Z",
+		FinishedAt:     "2026-04-08T11:03:00Z",
+		ExitStatus:     "17",
+		FinalAssurance: "managed-mutable",
+	})
+
+	records, err := ListSessionRecords(root, SessionListOptions{})
+	if err != nil {
+		t.Fatalf("ListSessionRecords() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("ListSessionRecords() len = %d, want 1", len(records))
+	}
+	if records[0].SessionID != "session-1" {
+		t.Fatalf("unexpected record set from root with symlinked targets dir: %+v", records)
+	}
+}
+
 func TestFindSessionRecordWithPathInRootsPrefersEarlierRootOnDuplicateSessionID(t *testing.T) {
 	t.Parallel()
 

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -450,7 +450,7 @@ of its contents into per-session runtime state unless
 .B --no-default-injection-policy
 is set.
 .TP
-.I ~/.colima/PROFILE/workcell.audit.log
+.I ~/.local/state/workcell/targets/local_vm/colima/PROFILE/workcell.audit.log
 Durable host-side metadata audit log written by the managed launcher for real
 runs.
 .SH SESSION INJECTIONS

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "cded15c421e3f73fabf5a4067d301e88745d39ee600462508796c7840c809dd5"
+      "sha256": "a9f6fd8584b7fea8f4bed6eb71cb8de84c4e25872994a6949b0d9cb0a203d182"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "8703cd7a4b98a35fcb7369a1c6d70c1851da9cd876fb90de63ee2e70df0cb9e3"
+      "sha256": "2590f2e6c23aca9d61d781aa2a4d10ca4f4f5d9ad48e406fcc88c541ab840788"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "a9f6fd8584b7fea8f4bed6eb71cb8de84c4e25872994a6949b0d9cb0a203d182"
+      "sha256": "8703cd7a4b98a35fcb7369a1c6d70c1851da9cd876fb90de63ee2e70df0cb9e3"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "2590f2e6c23aca9d61d781aa2a4d10ca4f4f5d9ad48e406fcc88c541ab840788"
+      "sha256": "adff372c4a56a9cdb4c7a86f836eb47299b97de0e8a41ff404e027c992cbcd08"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -185,6 +185,8 @@ HOST_GIT_BIN=""
 HOST_COLIMA_BIN=""
 HOST_DOCKER_BIN=""
 COLIMA_STATE_ROOT="${REAL_HOME}/.colima"
+WORKCELL_STATE_ROOT="${XDG_STATE_HOME:-${REAL_HOME}/.local/state}/workcell"
+WORKCELL_TARGET_STATE_ROOT="${WORKCELL_STATE_ROOT}/targets"
 PROFILE_PREEXISTED=0
 PROFILE_RUNNING=0
 PROFILE_VALIDATED=0
@@ -200,6 +202,7 @@ SESSION_ID=""
 SESSION_RECORD_PATH=""
 SESSION_RECORD_WRITTEN=0
 SESSION_RECORD_FINALIZED=0
+SESSION_META_RECORD_PATH=""
 SESSION_STOP_REQUEST_MARKER_NAME=".workcell-stop-requested"
 LAST_COMMAND_DEBUG_CAPTURE_PATH=""
 SESSION_MONITOR_ENV_PATH=""
@@ -223,6 +226,10 @@ INJECTION_SSH_ENABLED=0
 INJECTION_SECRET_COPY_TARGETS=""
 PROFILE_LOCK_DIR=""
 NO_SPINNER=0
+
+session_lookup_root_args() {
+  printf '%s\n' "--root=${WORKCELL_STATE_ROOT}" "--root=${COLIMA_STATE_ROOT}"
+}
 
 usage() {
   cat <<'EOF'
@@ -513,6 +520,13 @@ profile_dir() {
 
   validate_colima_profile_name "${profile}"
   printf '%s/%s\n' "${COLIMA_STATE_ROOT}" "${profile}"
+}
+
+profile_target_state_dir() {
+  local profile="$1"
+
+  validate_colima_profile_name "${profile}"
+  printf '%s/local_vm/colima/%s\n' "${WORKCELL_TARGET_STATE_ROOT}" "${profile}"
 }
 
 profile_lima_dir() {
@@ -992,10 +1006,24 @@ profile_audit_log_path() {
   local profile="$1"
 
   validate_colima_profile_name "${profile}"
+  printf '%s/workcell.audit.log\n' "$(profile_target_state_dir "${profile}")"
+}
+
+legacy_profile_audit_log_path() {
+  local profile="$1"
+
+  validate_colima_profile_name "${profile}"
   printf '%s/workcell.audit.log\n' "$(profile_dir "${profile}")"
 }
 
 profile_sessions_dir_path() {
+  local profile="$1"
+
+  validate_colima_profile_name "${profile}"
+  printf '%s/sessions\n' "$(profile_target_state_dir "${profile}")"
+}
+
+legacy_profile_sessions_dir_path() {
   local profile="$1"
 
   validate_colima_profile_name "${profile}"
@@ -1010,10 +1038,25 @@ profile_lock_dir_path() {
   local profile="$1"
 
   validate_colima_profile_name "${profile}"
-  printf '%s/locks/%s.lock\n' "${COLIMA_STATE_ROOT}" "${profile}"
+  printf '%s/locks/local_vm/colima/%s.lock\n' "${WORKCELL_STATE_ROOT}" "${profile}"
 }
 
 profile_latest_log_pointer_path() {
+  local profile="$1"
+  local kind="$2"
+
+  validate_colima_profile_name "${profile}"
+  case "${kind}" in
+    debug | file-trace | transcript) ;;
+    *)
+      echo "Unsupported latest log pointer kind: ${kind}" >&2
+      exit 2
+      ;;
+  esac
+  printf '%s/workcell.latest-%s-log\n' "$(profile_target_state_dir "${profile}")" "${kind}"
+}
+
+legacy_profile_latest_log_pointer_path() {
   local profile="$1"
   local kind="$2"
 
@@ -1166,8 +1209,17 @@ append_session_control_audit_record() {
   local profile="$1"
   local session_id="$2"
   local event_name="$3"
+  local audit_path=""
 
   shift 3
+  audit_path="${SESSION_META_AUDIT_LOG_PATH:-}"
+  if [[ -n "${audit_path}" ]]; then
+    append_audit_record_to_path "${audit_path}" \
+      "event=${event_name}" \
+      "session_id=${session_id}" \
+      "$@"
+    return 0
+  fi
   append_audit_record "${profile}" \
     "event=${event_name}" \
     "session_id=${session_id}" \
@@ -1176,8 +1228,12 @@ append_session_control_audit_record() {
 
 session_runtime_metadata() {
   local session_id="$1"
+  local -a lookup_roots=()
 
-  go_hostutil launcher session-runtime-metadata "${COLIMA_STATE_ROOT}" "${session_id}"
+  while IFS= read -r root; do
+    lookup_roots+=("${root}")
+  done < <(session_lookup_root_args)
+  go_hostutil launcher session-runtime-metadata "${lookup_roots[@]}" "${session_id}"
 }
 
 load_session_runtime_metadata() {
@@ -1187,6 +1243,7 @@ load_session_runtime_metadata() {
   local value=""
 
   SESSION_META_PROFILE=""
+  SESSION_META_RECORD_PATH=""
   SESSION_META_TARGET_KIND=""
   SESSION_META_TARGET_PROVIDER=""
   SESSION_META_TARGET_ID=""
@@ -1212,6 +1269,7 @@ load_session_runtime_metadata() {
     key="${line%%=*}"
     value="${line#*=}"
     case "${key}" in
+      record_path) SESSION_META_RECORD_PATH="${value}" ;;
       profile) SESSION_META_PROFILE="${value}" ;;
       target_kind) SESSION_META_TARGET_KIND="${value}" ;;
       target_provider) SESSION_META_TARGET_PROVIDER="${value}" ;;
@@ -1665,20 +1723,32 @@ read_latest_log_pointer() {
   local kind="$2"
   local pointer_path=""
   local resolved_pointer_path=""
+  local -a candidates=()
 
-  pointer_path="$(profile_latest_log_pointer_path "${profile}" "${kind}")"
-  if ! resolved_pointer_path="$(resolve_host_output_candidate "${pointer_path}")"; then
-    echo "Workcell blocked latest ${kind} pointer path after launch: ${pointer_path}" >&2
-    return 1
-  fi
-  [[ -f "${resolved_pointer_path}" ]] || return 1
-  head -n1 "${resolved_pointer_path}"
+  candidates=(
+    "$(profile_latest_log_pointer_path "${profile}" "${kind}")"
+    "$(legacy_profile_latest_log_pointer_path "${profile}" "${kind}")"
+  )
+  for pointer_path in "${candidates[@]}"; do
+    if ! resolved_pointer_path="$(resolve_host_output_candidate "${pointer_path}")"; then
+      echo "Workcell blocked latest ${kind} pointer path after launch: ${pointer_path}" >&2
+      return 1
+    fi
+    [[ -f "${resolved_pointer_path}" ]] || continue
+    head -n1 "${resolved_pointer_path}"
+    return 0
+  done
+  return 1
 }
 
 cleanup_stale_latest_log_pointers() {
-  local colima_root="$1"
+  local state_root="$1"
+  local legacy_root="${2:-}"
 
-  go_hostutil launcher cleanup-stale-log-pointers "${colima_root}"
+  go_hostutil launcher cleanup-stale-log-pointers "${state_root}"
+  if [[ -n "${legacy_root}" ]]; then
+    go_hostutil launcher cleanup-stale-log-pointers "${legacy_root}"
+  fi
 }
 
 profile_lock_is_stale() {
@@ -1725,9 +1795,13 @@ acquire_profile_lock() {
 }
 
 cleanup_stale_session_audit_dirs() {
-  local colima_root="$1"
+  local state_root="$1"
+  local legacy_root="${2:-}"
 
-  go_hostutil launcher cleanup-stale-session-audit-dirs "${colima_root}"
+  go_hostutil launcher cleanup-stale-session-audit-dirs "${state_root}"
+  if [[ -n "${legacy_root}" ]]; then
+    go_hostutil launcher cleanup-stale-session-audit-dirs "${legacy_root}"
+  fi
 }
 
 audit_record_digest() {
@@ -1786,12 +1860,19 @@ read_profile_marker_workspace() {
 append_audit_record() {
   local profile="$1"
   shift
-  local audit_path
+  local audit_path=""
+
+  audit_path="$(profile_audit_log_path "${profile}")"
+  append_audit_record_to_path "${audit_path}" "$@"
+}
+
+append_audit_record_to_path() {
+  local audit_path="$1"
+  shift
   local timestamp
   local prev_digest=""
   local record_digest=""
 
-  audit_path="$(profile_audit_log_path "${profile}")"
   mkdir -p "$(dirname "${audit_path}")"
   umask 077
   touch "${audit_path}"
@@ -2168,8 +2249,8 @@ write_session_record_final() {
 prepare_session_audit_state() {
   local profile="$1"
 
-  mkdir -p "$(profile_dir "${profile}")"
-  SESSION_AUDIT_DIR="$(mktemp -d "$(profile_dir "${profile}")/session-audit.XXXXXX")"
+  mkdir -p "$(profile_target_state_dir "${profile}")"
+  SESSION_AUDIT_DIR="$(mktemp -d "$(profile_target_state_dir "${profile}")/session-audit.XXXXXX")"
   chmod 0700 "${SESSION_AUDIT_DIR}" 2>/dev/null || true
   SESSION_AUDIT_STATE_FILE="${SESSION_AUDIT_DIR}/session-assurance"
   SESSION_AUDIT_CONTAINER_FILE="/var/lib/workcell/session-assurance"
@@ -3042,8 +3123,16 @@ render_session_diff_bundle() {
 session_record_path_for() {
   local profile="$1"
   local session_id="$2"
+  local target_path=""
+  local legacy_path=""
 
-  printf '%s/%s.json\n' "$(profile_sessions_dir_path "${profile}")" "${session_id}"
+  target_path="$(profile_sessions_dir_path "${profile}")/${session_id}.json"
+  legacy_path="$(legacy_profile_sessions_dir_path "${profile}")/${session_id}.json"
+  if [[ -f "${legacy_path}" ]] && [[ ! -f "${target_path}" ]]; then
+    printf '%s\n' "${legacy_path}"
+    return 0
+  fi
+  printf '%s\n' "${target_path}"
 }
 
 start_detached_session_monitor() {
@@ -3254,7 +3343,10 @@ session_send_main() {
     "source=host-cli" \
     "command=session-send" \
     "argv=${message}"
-  record_path="$(session_record_path_for "${SESSION_META_PROFILE}" "${session_id}")"
+  record_path="${SESSION_META_RECORD_PATH}"
+  if [[ -z "${record_path}" ]]; then
+    record_path="$(session_record_path_for "${SESSION_META_PROFILE}" "${session_id}")"
+  fi
   write_session_record "${record_path}" \
     "observed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || exit 1
   load_session_runtime_metadata "${session_id}"
@@ -3320,7 +3412,10 @@ session_stop_main() {
     exit 1
   fi
 
-  record_path="$(session_record_path_for "${SESSION_META_PROFILE}" "${session_id}")"
+  record_path="${SESSION_META_RECORD_PATH}"
+  if [[ -z "${record_path}" ]]; then
+    record_path="$(session_record_path_for "${SESSION_META_PROFILE}" "${session_id}")"
+  fi
   if [[ "${container_state}" != "running" ]]; then
     if [[ "${container_state}" == "stopped" ]] && ! session_monitor_pid_is_live; then
       session_record_stop_request_marker || exit 1
@@ -3554,7 +3649,10 @@ session_delete_main() {
     exit 1
   fi
 
-  record_path="$(session_record_path_for "${SESSION_META_PROFILE}" "${session_id}")"
+  record_path="${SESSION_META_RECORD_PATH}"
+  if [[ -z "${record_path}" ]]; then
+    record_path="$(session_record_path_for "${SESSION_META_PROFILE}" "${session_id}")"
+  fi
   if [[ ! -f "${record_path}" ]]; then
     echo "session delete could not find the recorded session file: ${session_id}" >&2
     exit 1
@@ -3774,6 +3872,7 @@ session_logs_main() {
 
 session_timeline_main() {
   local session_id=""
+  local -a lookup_roots=()
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -3797,7 +3896,10 @@ session_timeline_main() {
     exit 2
   }
 
-  go_hostutil launcher session-timeline "${COLIMA_STATE_ROOT}" "${session_id}"
+  while IFS= read -r root; do
+    lookup_roots+=("${root}")
+  done < <(session_lookup_root_args)
+  go_hostutil launcher session-timeline "${lookup_roots[@]}" "${session_id}"
   exit 0
 }
 
@@ -3865,6 +3967,7 @@ session_main() {
   local git_base=""
   local rendered=""
   local -a args=()
+  local -a lookup_roots=()
 
   shift || true
   case "${subcommand}" in
@@ -3927,7 +4030,10 @@ session_main() {
             ;;
         esac
       done
-      args=("${COLIMA_STATE_ROOT}")
+      while IFS= read -r root; do
+        lookup_roots+=("${root}")
+      done < <(session_lookup_root_args)
+      args=("${lookup_roots[@]}")
       if [[ "${emit_json}" -eq 1 ]] && [[ "${emit_verbose}" -eq 1 ]]; then
         echo "workcell session list accepts either --json or --verbose, not both." >&2
         exit 2
@@ -3987,7 +4093,10 @@ session_main() {
         echo "workcell session show requires --id." >&2
         exit 2
       }
-      args=("${COLIMA_STATE_ROOT}" "${session_id}")
+      while IFS= read -r root; do
+        lookup_roots+=("${root}")
+      done < <(session_lookup_root_args)
+      args=("${lookup_roots[@]}" "${session_id}")
       if [[ "${emit_text}" -eq 1 ]]; then
         args+=(--text)
       fi
@@ -4029,7 +4138,10 @@ session_main() {
         echo "workcell session diff requires --id." >&2
         exit 2
       }
-      metadata="$(go_hostutil launcher session-diff-metadata "${COLIMA_STATE_ROOT}" "${session_id}")"
+      while IFS= read -r root; do
+        lookup_roots+=("${root}")
+      done < <(session_lookup_root_args)
+      metadata="$(go_hostutil launcher session-diff-metadata "${lookup_roots[@]}" "${session_id}")"
       while IFS= read -r line; do
         case "${line%%=*}" in
           workspace)
@@ -4115,7 +4227,10 @@ session_main() {
         echo "workcell session export requires --id." >&2
         exit 2
       }
-      output="$(go_hostutil launcher session-export "${COLIMA_STATE_ROOT}" "${session_id}")"
+      while IFS= read -r root; do
+        lookup_roots+=("${root}")
+      done < <(session_lookup_root_args)
+      output="$(go_hostutil launcher session-export "${lookup_roots[@]}" "${session_id}")"
       if [[ -n "${output_path}" ]]; then
         output_path="$(resolve_host_output_candidate "${output_path}")"
         mkdir -p "$(dirname "${output_path}")"
@@ -5132,6 +5247,7 @@ print_inspect_state() {
   printf 'provider_native_sandbox_reason=%s\n' "$(provider_native_sandbox_reason)"
   printf 'log_level=%s\n' "${LOG_LEVEL}"
   printf 'profile_dir=%s\n' "$(profile_dir "${COLIMA_PROFILE}")"
+  printf 'target_state_dir=%s\n' "$(profile_target_state_dir "${COLIMA_PROFILE}")"
   printf 'profile_marker=%s\n' "$(profile_marker_path "${COLIMA_PROFILE}")"
   printf 'image_marker=%s\n' "$(profile_image_marker_path "${COLIMA_PROFILE}")"
   printf 'audit_log=%s\n' "$(profile_audit_log_path "${COLIMA_PROFILE}")"
@@ -5149,6 +5265,9 @@ show_requested_logs() {
   case "${LOGS_KIND}" in
     audit)
       log_path="$(profile_audit_log_path "${COLIMA_PROFILE}")"
+      if [[ ! -f "${log_path}" ]]; then
+        log_path="$(legacy_profile_audit_log_path "${COLIMA_PROFILE}")"
+      fi
       ;;
     debug | file-trace | transcript)
       log_path="$(read_latest_log_pointer "${COLIMA_PROFILE}" "${LOGS_KIND}" || true)"
@@ -7396,8 +7515,8 @@ if [[ -n "${AUDIT_TRANSCRIPT_PATH}" ]]; then
 fi
 if [[ "${GC}" -eq 1 ]]; then
   cleanup_stale_injection_bundles "$(default_injection_bundle_parent)"
-  cleanup_stale_session_audit_dirs "${COLIMA_STATE_ROOT}"
-  cleanup_stale_latest_log_pointers "${COLIMA_STATE_ROOT}"
+  cleanup_stale_session_audit_dirs "${WORKCELL_STATE_ROOT}" "${COLIMA_STATE_ROOT}"
+  cleanup_stale_latest_log_pointers "${WORKCELL_STATE_ROOT}" "${COLIMA_STATE_ROOT}"
   echo "Cleaned stale Workcell injection, session-audit, and broken latest-log pointer state."
   exit 0
 fi

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1817,6 +1817,9 @@ stash_profile_audit_log() {
   local audit_log=""
 
   audit_log="$(profile_audit_log_path "${profile}")"
+  if [[ ! -f "${audit_log}" ]]; then
+    audit_log="$(legacy_profile_audit_log_path "${profile}")"
+  fi
   [[ -f "${audit_log}" ]] || return 0
 
   PROFILE_AUDIT_LOG_STASH="$(mktemp "${TMPDIR:-/tmp}/workcell-audit-log.XXXXXX")"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1672,6 +1672,9 @@ write_session_monitor_env_file() {
     SESSION_RECORD_FINALIZED
     SESSION_MONITOR_READY_PATH
     UI
+    WORKCELL_STATE_ROOT
+    WORKCELL_TARGET_STATE_ROOT
+    XDG_STATE_HOME
     WORKSPACE
   )
 
@@ -1804,6 +1807,19 @@ cleanup_stale_session_audit_dirs() {
   fi
 }
 
+file_is_trailing_suffix_of_file() {
+  local suffix_path="$1"
+  local file_path="$2"
+  local suffix_size=""
+
+  [[ -f "${suffix_path}" ]] || return 1
+  [[ -f "${file_path}" ]] || return 1
+  suffix_size="$(wc -c <"${suffix_path}" | tr -d '[:space:]')"
+  [[ "${suffix_size}" =~ ^[0-9]+$ ]] || return 1
+  [[ "${suffix_size}" -gt 0 ]] || return 1
+  cmp -s "${suffix_path}" <(tail -c "${suffix_size}" "${file_path}" 2>/dev/null)
+}
+
 audit_record_digest() {
   local prev_digest="$1"
   local timestamp="$2"
@@ -1814,16 +1830,24 @@ audit_record_digest() {
 
 stash_profile_audit_log() {
   local profile="$1"
-  local audit_log=""
+  local target_audit_log=""
+  local legacy_audit_log=""
+  local preserved_any=0
 
-  audit_log="$(profile_audit_log_path "${profile}")"
-  if [[ ! -f "${audit_log}" ]]; then
-    audit_log="$(legacy_profile_audit_log_path "${profile}")"
-  fi
-  [[ -f "${audit_log}" ]] || return 0
+  target_audit_log="$(profile_audit_log_path "${profile}")"
+  legacy_audit_log="$(legacy_profile_audit_log_path "${profile}")"
+  [[ -s "${legacy_audit_log}" ]] && preserved_any=1
+  [[ -s "${target_audit_log}" ]] && preserved_any=1
+  [[ "${preserved_any}" -eq 1 ]] || return 0
 
   PROFILE_AUDIT_LOG_STASH="$(mktemp "${TMPDIR:-/tmp}/workcell-audit-log.XXXXXX")"
-  cp "${audit_log}" "${PROFILE_AUDIT_LOG_STASH}"
+  : >"${PROFILE_AUDIT_LOG_STASH}"
+  if [[ -s "${legacy_audit_log}" ]]; then
+    cat "${legacy_audit_log}" >>"${PROFILE_AUDIT_LOG_STASH}"
+  fi
+  if [[ -s "${target_audit_log}" ]]; then
+    cat "${target_audit_log}" >>"${PROFILE_AUDIT_LOG_STASH}"
+  fi
   chmod 0600 "${PROFILE_AUDIT_LOG_STASH}" 2>/dev/null || true
 }
 
@@ -1841,10 +1865,14 @@ restore_profile_audit_log() {
   audit_log="$(profile_audit_log_path "${profile}")"
   mkdir -p "$(dirname "${audit_log}")"
   if [[ -f "${audit_log}" ]] && [[ -s "${audit_log}" ]]; then
-    merged_log="$(mktemp "${TMPDIR:-/tmp}/workcell-audit-merged.XXXXXX")"
-    cat "${PROFILE_AUDIT_LOG_STASH}" "${audit_log}" >"${merged_log}"
-    chmod 0600 "${merged_log}" 2>/dev/null || true
-    mv "${merged_log}" "${audit_log}"
+    if file_is_trailing_suffix_of_file "${audit_log}" "${PROFILE_AUDIT_LOG_STASH}"; then
+      cp "${PROFILE_AUDIT_LOG_STASH}" "${audit_log}"
+    else
+      merged_log="$(mktemp "${TMPDIR:-/tmp}/workcell-audit-merged.XXXXXX")"
+      cat "${PROFILE_AUDIT_LOG_STASH}" "${audit_log}" >"${merged_log}"
+      chmod 0600 "${merged_log}" 2>/dev/null || true
+      mv "${merged_log}" "${audit_log}"
+    fi
   else
     cp "${PROFILE_AUDIT_LOG_STASH}" "${audit_log}"
   fi
@@ -3140,6 +3168,7 @@ session_record_path_for() {
 
 start_detached_session_monitor() {
   local monitor_stderr="/dev/null"
+  local -a monitor_env=()
 
   [[ -n "${SESSION_AUDIT_DIR}" ]] || {
     echo "Detached session monitor requires a session audit directory." >&2
@@ -3152,12 +3181,18 @@ start_detached_session_monitor() {
   if [[ -n "${DEBUG_LOG_PATH}" ]]; then
     monitor_stderr="${DEBUG_LOG_PATH}"
   fi
+  monitor_env=(
+    PATH="${TRUSTED_HOST_PATH}"
+    HOME="${REAL_HOME}"
+    LC_ALL=C
+    LANG=C
+    WORKCELL_SESSION_DETACHED=0
+  )
+  [[ -n "${XDG_STATE_HOME:-}" ]] && monitor_env+=("XDG_STATE_HOME=${XDG_STATE_HOME}")
+  [[ -n "${WORKCELL_STATE_ROOT:-}" ]] && monitor_env+=("WORKCELL_STATE_ROOT=${WORKCELL_STATE_ROOT}")
+  [[ -n "${WORKCELL_TARGET_STATE_ROOT:-}" ]] && monitor_env+=("WORKCELL_TARGET_STATE_ROOT=${WORKCELL_TARGET_STATE_ROOT}")
   env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${REAL_HOME}" \
-    LC_ALL=C \
-    LANG=C \
-    WORKCELL_SESSION_DETACHED=0 \
+    "${monitor_env[@]}" \
     /bin/bash "${BASH_SOURCE[0]}" session monitor --state-file "${SESSION_MONITOR_ENV_PATH}" \
     >/dev/null 2>>"${monitor_stderr}" &
   SESSION_MONITOR_PID="$!"
@@ -3933,6 +3968,9 @@ session_monitor_main() {
 
   # shellcheck disable=SC1090
   source "${state_file}"
+  if [[ -n "${WORKCELL_STATE_ROOT:-}" ]]; then
+    WORKCELL_TARGET_STATE_ROOT="${WORKCELL_TARGET_STATE_ROOT:-${WORKCELL_STATE_ROOT}/targets}"
+  fi
   HOST_DOCKER_BIN="$(resolve_host_tool docker /opt/homebrew/bin/docker /usr/local/bin/docker /Applications/Docker.app/Contents/Resources/bin/docker)"
   sanitize_host_docker_env
   if [[ -n "${SESSION_MONITOR_READY_PATH:-}" ]]; then

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -185,7 +185,7 @@ HOST_GIT_BIN=""
 HOST_COLIMA_BIN=""
 HOST_DOCKER_BIN=""
 COLIMA_STATE_ROOT="${REAL_HOME}/.colima"
-WORKCELL_STATE_ROOT="${XDG_STATE_HOME:-${REAL_HOME}/.local/state}/workcell"
+WORKCELL_STATE_ROOT="${WORKCELL_STATE_ROOT:-${XDG_STATE_HOME:-${REAL_HOME}/.local/state}/workcell}"
 WORKCELL_TARGET_STATE_ROOT="${WORKCELL_STATE_ROOT}/targets"
 PROFILE_PREEXISTED=0
 PROFILE_RUNNING=0
@@ -3971,27 +3971,28 @@ session_main() {
   local rendered=""
   local -a args=()
   local -a lookup_roots=()
+  local -a session_start_env=()
 
   shift || true
   case "${subcommand}" in
     start)
+      session_start_env=(
+        PATH="${TRUSTED_HOST_PATH}"
+        HOME="${REAL_HOME}"
+        TMPDIR="${TMPDIR:-/tmp}"
+        LC_ALL=C
+        LANG=C
+        WORKCELL_SESSION_DETACHED=1
+      )
+      [[ -n "${XDG_STATE_HOME:-}" ]] && session_start_env+=("XDG_STATE_HOME=${XDG_STATE_HOME}")
+      [[ -n "${WORKCELL_STATE_ROOT:-}" ]] && session_start_env+=("WORKCELL_STATE_ROOT=${WORKCELL_STATE_ROOT}")
       if [[ "${#}" -eq 0 ]]; then
         exec env -i \
-          PATH="${TRUSTED_HOST_PATH}" \
-          HOME="${REAL_HOME}" \
-          TMPDIR="${TMPDIR:-/tmp}" \
-          LC_ALL=C \
-          LANG=C \
-          WORKCELL_SESSION_DETACHED=1 \
+          "${session_start_env[@]}" \
           /bin/bash "${BASH_SOURCE[0]}"
       fi
       exec env -i \
-        PATH="${TRUSTED_HOST_PATH}" \
-        HOME="${REAL_HOME}" \
-        TMPDIR="${TMPDIR:-/tmp}" \
-        LC_ALL=C \
-        LANG=C \
-        WORKCELL_SESSION_DETACHED=1 \
+        "${session_start_env[@]}" \
         /bin/bash "${BASH_SOURCE[0]}" "$@"
       ;;
     attach)

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -48,13 +48,18 @@ cleanup() {
   fi
   rm -f "${WORKCELL_FUNCTIONS_COPY}"
   rm -rf "${REAL_HOME}/.colima/${PROFILE}"
+  rm -rf "${XDG_STATE_HOME:-${REAL_HOME}/.local/state}/workcell/targets/local_vm/colima/${PROFILE}"
   rm -rf "${TMP_DIR}"
 }
 trap cleanup EXIT
 
 COLIMA_ROOT="${REAL_HOME}/.colima"
-SESSIONS_DIR="${COLIMA_ROOT}/${PROFILE}/sessions"
-AUDIT_LOG="${COLIMA_ROOT}/${PROFILE}/workcell.audit.log"
+WORKCELL_STATE_ROOT="${XDG_STATE_HOME:-${REAL_HOME}/.local/state}/workcell"
+TARGET_STATE_DIR="${WORKCELL_STATE_ROOT}/targets/local_vm/colima/${PROFILE}"
+LEGACY_STATE_DIR="${COLIMA_ROOT}/${PROFILE}"
+LEGACY_SESSIONS_DIR="${LEGACY_STATE_DIR}/sessions"
+SESSIONS_DIR="${TARGET_STATE_DIR}/sessions"
+AUDIT_LOG="${TARGET_STATE_DIR}/workcell.audit.log"
 EXPORT_PATH="${TMP_DIR}/session-export.json"
 WORKSPACE_A="${TMP_DIR}/workspace-a"
 WORKSPACE_B="${TMP_DIR}/workspace-b"
@@ -77,7 +82,7 @@ DETACHED_WORKSPACE="${WORKSPACE_A}/.git/session-sandboxes/${DETACHED_SESSION}"
 DETACHED_BRANCH="workcell/session/${DETACHED_SESSION}"
 DETACHED_BACKEND="${TMP_DIR}/detached-session-backend"
 
-mkdir -p "${SESSIONS_DIR}" "${WORKSPACE_A}" "${WORKSPACE_B}"
+mkdir -p "${SESSIONS_DIR}" "${LEGACY_STATE_DIR}" "${WORKSPACE_A}" "${WORKSPACE_B}"
 WORKSPACE_A="$(cd "${WORKSPACE_A}" && pwd -P)"
 WORKSPACE_B="$(cd "${WORKSPACE_B}" && pwd -P)"
 
@@ -549,6 +554,52 @@ grep -q 'To use this workspace on the safe path, create a standard clone at the 
 grep -q 'Alternatively, pass --mode breakglass --ack-breakglass to proceed with a linked worktree\.' <<<"${linked_isolated_output}"
 
 sed '/^if \[\[ \$# -gt 0 \]\]; then$/,$d' "${ROOT_DIR}/scripts/workcell" >"${WORKCELL_FUNCTIONS_COPY}"
+state_path_output="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    COLIMA_PROFILE="$2"
+    printf "target_state_dir=%s\n" "$(profile_target_state_dir "${COLIMA_PROFILE}")"
+    printf "sessions_dir=%s\n" "$(profile_sessions_dir_path "${COLIMA_PROFILE}")"
+    printf "audit_log=%s\n" "$(profile_audit_log_path "${COLIMA_PROFILE}")"
+    printf "lock_dir=%s\n" "$(profile_lock_dir_path "${COLIMA_PROFILE}")"
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${PROFILE}"
+)"
+grep -q '^target_state_dir='"${TARGET_STATE_DIR}"'$' <<<"${state_path_output}"
+grep -q '^sessions_dir='"${TARGET_STATE_DIR}/sessions"'$' <<<"${state_path_output}"
+grep -q '^audit_log='"${TARGET_STATE_DIR}/workcell.audit.log"'$' <<<"${state_path_output}"
+grep -q '^lock_dir='"${WORKCELL_STATE_ROOT}/locks/local_vm/colima/${PROFILE}.lock"'$' <<<"${state_path_output}"
+
+mkdir -p "${LEGACY_SESSIONS_DIR}"
+printf '{}' >"${LEGACY_SESSIONS_DIR}/${SESSION_ONE}.json"
+legacy_record_path_output="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    COLIMA_PROFILE="$2"
+    SESSION_ID="$3"
+    printf "record_path=%s\n" "$(session_record_path_for "${COLIMA_PROFILE}" "${SESSION_ID}")"
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${PROFILE}" "${SESSION_ONE}"
+)"
+grep -q '^record_path='"${LEGACY_SESSIONS_DIR}/${SESSION_ONE}.json"'$' <<<"${legacy_record_path_output}"
+rm -f "${LEGACY_SESSIONS_DIR}/${SESSION_ONE}.json"
+
+rm -f "${LEGACY_STATE_DIR}/workcell.latest-transcript-log"
+printf '%s\n' "${DETACHED_TRANSCRIPT_LOG}" >"${LEGACY_STATE_DIR}/workcell.latest-transcript-log"
+legacy_pointer_output="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    COLIMA_PROFILE="$2"
+    printf "pointer=%s\n" "$(read_latest_log_pointer "${COLIMA_PROFILE}" transcript)"
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${PROFILE}"
+)"
+grep -q '^pointer='"${DETACHED_TRANSCRIPT_LOG}"'$' <<<"${legacy_pointer_output}"
+rm -f "${LEGACY_STATE_DIR}/workcell.latest-transcript-log"
+
 monitor_env_output="$(
   bash -lc '
     set -euo pipefail

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -460,6 +460,7 @@ if grep -Eq -- "-e WORKCELL_DETACHED_STDIN_PATH=/run/workcell/session-stdin" <<<
   echo "Detached session start kept the detached stdin FIFO under a path that blocks host command injection" >&2
   exit 1
 fi
+custom_state_home="${TMP_DIR}/detached-state-home"
 detached_start_direct_output="$(
   WORKCELL_SESSION_WORKSPACE_MODE=isolated \
     "${ROOT_DIR}/scripts/workcell" \
@@ -570,6 +571,22 @@ grep -q '^target_state_dir='"${TARGET_STATE_DIR}"'$' <<<"${state_path_output}"
 grep -q '^sessions_dir='"${TARGET_STATE_DIR}/sessions"'$' <<<"${state_path_output}"
 grep -q '^audit_log='"${TARGET_STATE_DIR}/workcell.audit.log"'$' <<<"${state_path_output}"
 grep -q '^lock_dir='"${WORKCELL_STATE_ROOT}/locks/local_vm/colima/${PROFILE}.lock"'$' <<<"${state_path_output}"
+
+detached_start_custom_state_output="$(
+  XDG_STATE_HOME="${custom_state_home}" \
+    /bin/bash "${ROOT_DIR}/scripts/workcell" \
+    session start \
+    --session-workspace direct \
+    --agent codex \
+    --mode development \
+    --workspace "${DETACHED_START_WORKSPACE}" \
+    --no-default-injection-policy \
+    --allow-arbitrary-command \
+    --ack-arbitrary-command \
+    --dry-run \
+    -- /bin/true 2>&1
+)"
+grep -Fq -- "audit_log=${custom_state_home}/workcell/targets/local_vm/colima/" <<<"${detached_start_custom_state_output}"
 
 mkdir -p "${LEGACY_SESSIONS_DIR}"
 printf '{}' >"${LEGACY_SESSIONS_DIR}/${SESSION_ONE}.json"

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -600,6 +600,30 @@ legacy_pointer_output="$(
 grep -q '^pointer='"${DETACHED_TRANSCRIPT_LOG}"'$' <<<"${legacy_pointer_output}"
 rm -f "${LEGACY_STATE_DIR}/workcell.latest-transcript-log"
 
+legacy_audit_migration_output="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    FIXTURE_ROOT="$2"
+    COLIMA_STATE_ROOT="${FIXTURE_ROOT}/colima"
+    WORKCELL_STATE_ROOT="${FIXTURE_ROOT}/workcell"
+    WORKCELL_TARGET_STATE_ROOT="${WORKCELL_STATE_ROOT}/targets"
+    PROFILE_NAME="audit-migration-fixture"
+    LEGACY_LOG="$(legacy_profile_audit_log_path "${PROFILE_NAME}")"
+    TARGET_LOG="$(profile_audit_log_path "${PROFILE_NAME}")"
+    mkdir -p "$(dirname "${LEGACY_LOG}")"
+    printf "legacy-audit-line\n" >"${LEGACY_LOG}"
+    stash_profile_audit_log "${PROFILE_NAME}"
+    rm -f "${LEGACY_LOG}"
+    restore_profile_audit_log "${PROFILE_NAME}"
+    printf "target_log=%s\n" "${TARGET_LOG}"
+    cat "${TARGET_LOG}"
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${TMP_DIR}/audit-migration-fixture"
+)"
+grep -q '^target_log='"${TMP_DIR}/audit-migration-fixture/workcell/targets/local_vm/colima/audit-migration-fixture/workcell.audit.log"'$' <<<"${legacy_audit_migration_output}"
+grep -q '^legacy-audit-line$' <<<"${legacy_audit_migration_output}"
+
 monitor_env_output="$(
   bash -lc '
     set -euo pipefail

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -641,23 +641,58 @@ legacy_audit_migration_output="$(
 grep -q '^target_log='"${TMP_DIR}/audit-migration-fixture/workcell/targets/local_vm/colima/audit-migration-fixture/workcell.audit.log"'$' <<<"${legacy_audit_migration_output}"
 grep -q '^legacy-audit-line$' <<<"${legacy_audit_migration_output}"
 
+merged_audit_migration_output="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    FIXTURE_ROOT="$2"
+    COLIMA_STATE_ROOT="${FIXTURE_ROOT}/colima"
+    WORKCELL_STATE_ROOT="${FIXTURE_ROOT}/workcell"
+    WORKCELL_TARGET_STATE_ROOT="${WORKCELL_STATE_ROOT}/targets"
+    PROFILE_NAME="merged-audit-migration-fixture"
+    LEGACY_LOG="$(legacy_profile_audit_log_path "${PROFILE_NAME}")"
+    TARGET_LOG="$(profile_audit_log_path "${PROFILE_NAME}")"
+    mkdir -p "$(dirname "${LEGACY_LOG}")" "$(dirname "${TARGET_LOG}")"
+    printf "legacy-audit-line\n" >"${LEGACY_LOG}"
+    printf "target-audit-line\n" >"${TARGET_LOG}"
+    stash_profile_audit_log "${PROFILE_NAME}"
+    restore_profile_audit_log "${PROFILE_NAME}"
+    printf "target_log=%s\n" "${TARGET_LOG}"
+    cat "${TARGET_LOG}"
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${TMP_DIR}/merged-audit-migration-fixture"
+)"
+grep -q '^target_log='"${TMP_DIR}/merged-audit-migration-fixture/workcell/targets/local_vm/colima/merged-audit-migration-fixture/workcell.audit.log"'$' <<<"${merged_audit_migration_output}"
+grep -q '^legacy-audit-line$' <<<"${merged_audit_migration_output}"
+grep -q '^target-audit-line$' <<<"${merged_audit_migration_output}"
+[[ "$(grep -c '^target-audit-line$' <<<"${merged_audit_migration_output}")" -eq 1 ]] || {
+  echo "audit migration duplicated target history during restore" >&2
+  exit 1
+}
+
 monitor_env_output="$(
   bash -lc '
     set -euo pipefail
     source "$1"
     trap - EXIT
+    XDG_STATE_HOME="$5"
+    WORKCELL_STATE_ROOT="${XDG_STATE_HOME}/workcell"
+    WORKCELL_TARGET_STATE_ROOT="${WORKCELL_STATE_ROOT}/targets"
     SESSION_AUDIT_DIR="$2"
     SESSION_RECORD_PATH="$3"
     SESSION_RECORD_WRITTEN=1
     SESSION_RECORD_FINALIZED=0
     write_session_monitor_env_file "$4"
     cat "$4"
-  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${DETACHED_STATE_DIR}" "${SESSIONS_DIR}/${DETACHED_SESSION}.json" "${DETACHED_STATE_DIR}/session-monitor.env"
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${DETACHED_STATE_DIR}" "${SESSIONS_DIR}/${DETACHED_SESSION}.json" "${DETACHED_STATE_DIR}/session-monitor.env" "${TMP_DIR}/monitor-xdg-state"
 )"
 grep -q '^SESSION_RECORD_PATH=' <<<"${monitor_env_output}"
 grep -q '^SESSION_RECORD_WRITTEN=1$' <<<"${monitor_env_output}"
 grep -q '^SESSION_RECORD_FINALIZED=0$' <<<"${monitor_env_output}"
 grep -q '^SESSION_MONITOR_READY_PATH=' <<<"${monitor_env_output}"
+grep -q '^XDG_STATE_HOME='"${TMP_DIR}/monitor-xdg-state"'$' <<<"${monitor_env_output}"
+grep -q '^WORKCELL_STATE_ROOT='"${TMP_DIR}/monitor-xdg-state/workcell"'$' <<<"${monitor_env_output}"
+grep -q '^WORKCELL_TARGET_STATE_ROOT='"${TMP_DIR}/monitor-xdg-state/workcell/targets"'$' <<<"${monitor_env_output}"
 
 monitor_ready_probe_output="$(
   bash -lc '


### PR DESCRIPTION
## Summary
- move durable detached-session state into Workcell-owned target roots instead of using `.colima` as the universal program state model
- preserve compatibility reads for legacy session records and latest-log pointers while keeping detached control paths on the recorded session file
- update GC, hostutil lookup, docs, and scenario coverage to prove the new target-state layout and legacy fallback paths

## Validation
- `go test ./internal/hostutil ./cmd/workcell-hostutil`
- `bash ./tests/scenarios/shared/test-session-commands.sh`
- `./scripts/generate-control-plane-manifest.sh ./runtime/container/control-plane-manifest.json`
- `bash ./scripts/validate-repo.sh`
