### PR TITLE
Version repo-local PR lifecycle guidance

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -52,6 +52,11 @@ for convenience.
 - Features/bugfixes exceeding 8 lines of code (including tests) default to highest risk level.
 - Safe refactoring (`.r`) requires provable refactoring via automated tools or test-supported procedural refactoring.
 - Choose the risk level honestly. If you haven't verified invariants, use `!` or `@`.
+- Treat every user request as implicitly including peer review unless the user
+  explicitly narrows that scope.
+- When peer review finds an actionable issue, keep iterating through fixes,
+  validation, and another review pass until no actionable findings remain or a
+  concrete blocker is reported.
 
 ## Commit Grouping
 
@@ -64,6 +69,10 @@ for convenience.
 - Sign every commit.
 - Use feature branches. Do not push directly to `main` or rewrite history.
 - Treat final GitHub publication as a host-side action.
+- For publish, PR follow-up, or merge work in this repository, use the
+  repo-local `workcell-pr-lifecycle` skill. Treat generic GitHub publication
+  skills as fallback only when the repo-local lifecycle instructions do not
+  cover the need.
 - Do not accept failing repo-owned tests, checks, or workflows as "good
   enough." If a lane fails because of the change or a hosted-control drift
   uncovered during the task, keep working until it is fixed or the guarantee is
@@ -71,6 +80,9 @@ for convenience.
 - If the task includes merging, do not stop at PR-green. Follow the merged
   `main` workflows and fix any repo-owned failures they surface before calling
   the work complete.
+- If the task includes publication, review comments, or follow-up CI, do not
+  stop at the first green run. Re-check review surfaces and continue until no
+  actionable findings remain.
 - When a commit changes a user-visible Workcell workflow, support tier, help
   surface, repo-local operator docs, contract entry, or validation evidence,
   land the matching contract/help/doc/test updates in the same change stream

--- a/.agents/skills/workcell-contract-parity/SKILL.md
+++ b/.agents/skills/workcell-contract-parity/SKILL.md
@@ -38,6 +38,11 @@ Docs review is repo-local. Keep Workcell docs, help text, manpages, policies,
 and validators aligned inside this repository. Do not treat external docs as
 the source of truth for repo behavior.
 
+Treat every user request as implicitly including peer review unless the user
+explicitly narrows that scope. For parity work, peer review means continuing
+through findings, fixes, validation, and another review pass until no
+actionable findings remain or a concrete blocker is reported.
+
 ## Read first
 
 - `AGENTS.md`
@@ -71,6 +76,9 @@ If the change is release-bound, also read:
   and bounded enough that a reviewer can reason about the change without
   juggling multiple independent decisions. Split broad work into sequenced PRs
   before host-side publication.
+- For publish, PR follow-up, or merge work in this repository, use the
+  repo-local `workcell-pr-lifecycle` skill so host-side publication, check
+  follow-through, and review sweeps stay versioned in-repo.
 - If `scripts/workcell` changes, regenerate and revalidate
   `runtime/container/control-plane-manifest.json`.
 - Dead code is a simplicity bug. Remove dead code when found, and keep the
@@ -79,6 +87,9 @@ If the change is release-bound, also read:
   from public repo surfaces and clean repo detritus before finishing a change.
 - Re-check PR comments and review threads after CI turns green and immediately
   before merge.
+- Treat newly surfaced review findings, docs drift, or parity regressions as
+  part of the same task. Fix them, rerun validation, and re-review until the
+  change is clean.
 - Do not leave repo-owned tests, checks, or workflows red. If a validation lane
   fails during the task, fix it or explicitly remove/demote the claimed
   guarantee in the same change.
@@ -103,6 +114,8 @@ If the change is release-bound, also read:
 8. If publication or merge is part of the task, follow the repo-owned hosted
    workflows through completion and fix any failures they surface before
    finishing.
+9. Re-review the affected contract surfaces after fixes land and before calling
+   the task done. Do not stop while actionable findings remain.
 
 ## Validation
 

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: workcell-pr-lifecycle
+description: Publish, follow, and merge Workcell pull requests through the repo-approved host-side workflow. Use when the user asks to commit, raise a PR, follow checks, mark ready, address review feedback, or merge in the Workcell repository.
+---
+
+# Workcell PR Lifecycle
+
+Use this skill only in the Workcell repository root, identified by:
+
+- `AGENTS.md`
+- `scripts/workcell`
+- `policy/reviewer-identities.toml`
+
+Use it when a task includes any part of the Workcell pull request lifecycle:
+
+- preparing signed commits for publication
+- opening a PR
+- following PR checks
+- fixing CI or review feedback
+- marking a PR ready
+- merging a PR
+
+## Standing priorities
+
+Always prefer, in order:
+
+1. Simplicity
+2. Correctness
+3. Linting and clean validation
+4. Appropriate test coverage
+5. Security
+6. Performance
+7. Current idiomatic correctness
+
+These priorities apply only inside the repo invariants. Do not trade away the
+runtime boundary, explicit security guarantees, or host-side publication rules
+for convenience.
+
+Treat every user request as implicitly including peer review unless the user
+explicitly narrows that scope. For PR work, peer review means continuing
+through review, fixes, validation, another review pass, and hosted workflow
+follow-through until no actionable findings remain or a concrete blocker is
+reported.
+
+## Read first
+
+- `AGENTS.md`
+- `.agents/skills/commit/SKILL.md`
+- `policy/reviewer-identities.toml`
+
+If the task changes user-visible Workcell workflows, docs, or evidence, also
+use the repo-local `workcell-contract-parity` skill.
+
+If the task is release-bound, also read:
+
+- `docs/releasing.md`
+
+## Invariants
+
+- Final GitHub publication is a host-side action. Use `./scripts/workcell
+  publish-pr`; do not normalize direct publication from the Tier 1 session.
+- Keep PRs reviewer-sized and single-purpose. Split broad work before
+  publication.
+- Sign every commit and use feature branches.
+- Open the PR as a draft first. Mark it ready only after the review and check
+  gates below are satisfied.
+- Do not stop at PR creation. Follow repo-owned checks until they are green,
+  fix failures, and rerun the relevant local validation before pushing more
+  commits.
+- Sweep top-level comments, inline comments, unresolved review threads, and
+  configured async reviewers in `policy/reviewer-identities.toml`.
+- Mark the PR ready only after repo-owned checks are green and the review
+  surfaces have no actionable findings.
+- After marking ready, re-check checks and review surfaces again. Some repos
+  gate differently once a PR leaves draft.
+- If the task includes merging, re-check review surfaces immediately before
+  merge, then follow merged `main` workflows until all repo-owned lanes are
+  green.
+- Do not accept failing repo-owned tests, checks, or workflows as acceptable
+  residue. Fix them or explicitly change the claimed guarantee in the same
+  review unit.
+
+## Workflow
+
+1. Confirm the branch is reviewable and the local worktree only contains the
+   intended scope.
+2. Create signed commits using the repo-local `commit` skill.
+3. Run the focused local validation for the change before publication.
+4. Publish with host-side `./scripts/workcell publish-pr` using a draft PR by
+   default.
+5. Follow repo-owned checks to completion.
+6. If a repo-owned check fails:
+   - inspect the failing GitHub Actions logs or PR checks
+   - fix the underlying issue locally
+   - rerun the smallest local validation that proves the fix
+   - push the signed follow-up commit host-side to the existing branch
+   - continue following checks until green
+7. Sweep top-level comments, inline comments, unresolved threads, and async
+   reviewer feedback.
+8. When checks are green and no actionable findings remain, mark the PR ready
+   unless the user explicitly asked to keep it draft.
+9. After marking ready, re-check checks and review surfaces again.
+10. If merge is part of the task, repeat the review sweep immediately before
+    merge, merge, then follow merged `main` workflows until repo-owned lanes
+    are green.
+
+## Validation
+
+Always run the smallest local validation that proves the actual change. When
+the work updates repo-wide instructions or multiple docs/skills, finish with:
+
+```sh
+bash ./scripts/validate-repo.sh
+```
+
+Use the GitHub plugin helpers when they fit the task:
+
+- `github:gh-fix-ci` for failing Actions lanes
+- `github:gh-address-comments` for actionable review feedback
+
+## Blocking rule
+
+Do not call PR work complete while any of these remain true:
+
+- the branch has unpublished intended changes
+- repo-owned checks are still red or unreviewed
+- review surfaces still contain actionable findings
+- merged `main` workflows still show repo-owned failures for a merge task

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,17 @@ runtime boundary with provider-specific adapters.
 These priorities apply only within the defined invariant set. Do not trade away
 the runtime boundary or explicit security guarantees in the name of convenience.
 
+## Peer review default
+
+- Treat every user request as implicitly asking for peer review unless the user
+  explicitly narrows or waives that expectation.
+- Peer review means continuing through review, fixes, revalidation, and another
+  review pass until no actionable findings remain or a concrete blocker is
+  reported.
+- Apply that default across repo-local skills, documentation work, CI follow-up,
+  publication, merge, and release actions. Do not stop at "implemented" if
+  review, checks, or hosted workflows still expose actionable problems.
+
 ## Mandatory rules
 
 - Sign every commit. Do not create or rewrite commits in this repository
@@ -46,6 +57,9 @@ the runtime boundary or explicit security guarantees in the name of convenience.
 
 ## Pull request workflow
 
+- For publish, PR follow-up, or merge requests in this repository, use the
+  repo-local `workcell-pr-lifecycle` skill. Repo-local publication rules
+  override generic GitHub publication skills.
 - Every PR should remain open for comments and review before merge.
 - Every PR must be checked for:
   - top-level PR comments
@@ -57,6 +71,9 @@ the runtime boundary or explicit security guarantees in the name of convenience.
   merge.
 - Re-check comments and review threads after CI turns green and immediately
   before merge.
+- Treat newly surfaced review findings the same way as pre-merge findings:
+  address them, rerun the relevant validation, and re-review until the PR has
+  no actionable findings left.
 - Do not treat failing tests, checks, or repo-owned workflows as acceptable.
   If a repo-owned validation lane fails, keep working until it is fixed or the
   guarantee is explicitly removed or demoted in the same change.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -23,6 +23,11 @@ honestly in docs, status reports, and release commentary.
 
 ## Principles
 
+- Treat a release request as implicitly including peer review unless the
+  maintainer explicitly narrows that scope.
+- For release work, peer review means continuing through review findings,
+  validation failures, documentation drift, and hosted workflow failures until
+  no actionable findings remain or a concrete blocker is reported.
 - Review and finish open pull requests before cutting a release.
 - Address actionable PR comments and review feedback as part of release work.
 - Use signed commits and signed tags.
@@ -44,6 +49,8 @@ honestly in docs, status reports, and release commentary.
   pins, and document them in policy or release notes rather than carrying
   unexplained drift.
 - Publish PRs from the host with `./scripts/workcell publish-pr`.
+- For agentic release PR publication and follow-up, use the repo-local
+  `workcell-pr-lifecycle` skill in addition to this release runbook.
 - Wait for `main` to be green before pushing the release tag.
 - Follow the tag-triggered `Release` workflow through completion.
 - Approve the `release` environment only after release preflight and install


### PR DESCRIPTION
## Summary

- make peer review the default across repo-local instructions and skills
- add a versioned `workcell-pr-lifecycle` skill so Workcell PR publication/follow-up does not depend on mutable upstream plugin guidance
- point AGENTS and existing repo-local skills at the repo-local PR lifecycle workflow

## Validation

- `bash ./scripts/validate-repo.sh`
