### PR TITLE
Align Phase 3 planning docs with shipped repo state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,9 +23,10 @@ The deterministic phase breakdown lives in
   invariant checks
 - add a narrow trusted `linux/amd64` validation-host lane plus target-aware
   diagnostics before broad non-macOS or cloud support claims
-- define the first cross-platform `compat` target and the first `remote_vm`
-  target explicitly, without claiming Tier 1 Linux or Windows host parity
-  before the same guarantees exist
+- define the support matrix, remote-VM contract prerequisites, and evidence
+  gates that later `compat` and `remote_vm` targets must satisfy, without
+  implying backend shipment or Tier 1 Linux or Windows host parity before the
+  same guarantees exist
 
 ## Medium term
 

--- a/docs/implement-first-delivery-plan.md
+++ b/docs/implement-first-delivery-plan.md
@@ -8,17 +8,20 @@ The longer-lived runtime-target and deployment-reach program lives in
 and the deterministic phase breakdown lives in
 [`docs/runtime-target-phase-plan.md`](runtime-target-phase-plan.md).
 Phases 1 and 2 of that phase plan are now implemented in the repository; this
-document remains as the delivered-scope reference for those slices and the
-immediate bridge to later runtime-target work.
+document now defines the immediate bridge into Phase 3 and the prerequisite
+work for later host-compatibility and remote-target phases.
 
 The current repo already includes durable session records plus detached
 host-side session control (`session start|attach|send|stop`) and basic
 observability surfaces (`session list|show|logs|timeline|diff|export`). The
 current repo also stores session, audit, and lock state under Workcell-owned
 target-state roots while preserving compatibility reads for older
-`~/.colima/...` records. The remaining work in this slice is to broaden shared
-auth/bootstrap coverage, expand host-compat validation, and deepen scenario
-coverage as later runtime-target phases land.
+`~/.colima/...` records. The current repo also ships direct staged-auth flows,
+`--auth-status`, and host-side auth explainability on the reviewed policy
+path. The active work in this slice is to complete the shared auth/bootstrap
+path. This document also records the queued validation-host and remote-VM
+contract prerequisites so later phases can start cleanly without pulling
+backend delivery forward into Phase 3.
 
 ## Principles
 
@@ -43,82 +46,104 @@ coverage as later runtime-target phases land.
   verify every changed code path preserves the runtime boundary, does not widen
   credential exposure, and keeps host-side git/control-plane execution explicit
 
-## Active Tracks
+## Phase 3 Exit Ownership
 
-### 1. Session Supervisor Phase 2
+- EM:
+  holds the phase boundary, prevents later validation-host or remote-VM work
+  from being counted as Phase 3 delivery, and blocks support claims that
+  outrun the evidence
+- TL:
+  owns the integrated Phase 3 landing criteria across code, deterministic
+  tests, and launcher/operator behavior
+- contract and docs owner:
+  owns the provider/bootstrap support matrix plus the operator and rollout docs
+  that bound what Phase 3 actually supports
 
-Scope for this delivery slice:
+## Delivered Foundation
 
-- preserve the shipped durable session inventory and detached control surface:
-  `session list`, `session show`, `session logs`, `session timeline`,
-  `session diff`, `session export`, `session start`, `session attach`,
-  `session send`, and `session stop`
-- default the safe path to one worktree per session when the operator opts into
-  orchestrated session flows
-- carry target identity, assurance, workspace mode, and workspace transport
-  through the session surface as the underlying state model evolves
-- keep the detached session path file-backed and host-owned rather than adding
-  same-user local socket trust as a shortcut
-- keep the implementation host-owned and file-backed; do not add same-user
-  local socket trust as a shortcut
+The following foundation is already merged and should now be treated as input
+to the next slice rather than as active delivery work:
 
-Staffing:
+- session inventory, detached control, logs/timeline, diff/export, and richer
+  target-aware session metadata
+- Workcell-owned target-state roots with compatibility reads for older
+  Colima-shaped records
+- direct staged-auth flows, `--auth-status`, policy explainability, and the
+  current secretless and authenticated scenario baseline
 
-- TL: session supervisor lead
-- SWE A: hostutil and launcher metadata plumbing
-- SWE B: shell command surface and scenario coverage
+## Active Phase 3 Track
 
-### 2. Session Observability
-
-Scope for this delivery slice:
-
-- extend the shipped logs, transcript pointers, and command timeline views
-  with clearer live status, branch/worktree, and assurance rendering
-- make the same rendering target-aware so operators can understand which
-  execution shape they are inspecting without guessing from Colima-specific
-  names
-- keep the first operator-facing surfaces CLI-first
-- add a lightweight TUI or dashboard only after the session object and status
-  model stabilize
-- keep the observability path read-only with the same host-owned metadata model
-
-Staffing:
-
-- TL: supervisor UX lead
-- SWE A: host-side session state and status rendering
-- SWE B: shell integration and artifact plumbing
-
-### 3. Runtime Target Foundations, Auth, and Validation Reach
+### 1. Shared Auth and Bootstrap Completion
 
 Scope for this delivery slice:
 
-- define the runtime-target model explicitly:
-  separate target kind, assurance class, and workspace transport in launcher
-  metadata, diagnostics, and session records
-- generalize host-owned state, audit metadata, and detached-session records
-  away from Colima-specific `profile` and `~/.colima/...` assumptions while
-  preserving compatibility reads for existing records
-- keep the shipped auth helpers and explainability surface aligned with new
-  launch modes
-- broaden resolver coverage without turning provider-native auth into the
-  security boundary
-- keep browser or setup handoffs explicit and host-owned where provider
-  onboarding still needs credential bootstrap help
-- define a narrow trusted `linux/amd64` validation-host lane plus phase gates
-  for non-macOS and remote-target evidence
-- define the first cross-platform `compat` target and the first `remote_vm`
-  target without weakening the Tier 1 boundary or overstating Linux and
-  Windows support
+- broaden built-in resolver coverage where the current implementation is still
+  intentionally narrow
+- keep direct staged inputs as the primary supported auth path until broader
+  resolver evidence exists
+- make browser/setup handoffs explicit and host-owned where provider bootstrap
+  still needs operator intervention
+- keep auth selection, explainability, and launch-time diagnostics on one
+  reviewed host-owned path
+- publish an explicit provider/bootstrap support matrix that marks each auth
+  path as repo-required, certification-only, or manual
+- separate deterministic repo-required auth/bootstrap evidence from
+  live-provider certification and manual provider-e2e validation
 
 Staffing:
 
 - TL: auth integrations lead
 - SWE A: resolver metadata and auth-state reasoning
-- SWE B: deployment-target documentation and scenario coverage
+- SWE B: bootstrap handoffs, diagnostics, and scenario coverage
+
+Phase boundary:
+
+- this is the active implementation slice and the only track that should change
+  Phase 3 status from planned to complete
+- the remaining tracks below are prerequisites and follow-on planning surfaces
+  for later deterministic phases, not authority to ship backend delivery in the
+  current slice
+
+## Immediate Follow-On Prerequisites
+
+### 2. Validation Host And Host-Compatibility Matrix
+
+Scope to define before the owning later phase starts:
+
+- define the narrow trusted `linux/amd64` validation-host lane before broader
+  non-macOS or cloud claims
+- express support as `host OS x target kind x assurance class`
+- add backend-aware diagnostics that fail closed on unsupported host/backend
+  combinations
+- keep Linux and Windows claims limited to what the validation-host evidence
+  and docs actually prove
+
+Staffing:
+
+- TL: validation-host and rollout lead
+- SWE A: validation-host tooling and diagnostics
+- SWE B: support matrix docs and operator guidance
+
+### 3. Remote VM Contract Preparation
+
+Scope to define before the owning later phase starts:
+
+- define the provider-neutral `remote_vm` contract before any cloud backend
+  ships
+- make remote workspace materialization explicit and auditable
+- define the reviewed brokered-access and remote image/bootstrap model
+- keep target ordering and backend selection in the longer-lived
+  runtime-target expansion program rather than in this active slice
+
+Staffing:
+
+- TL: remote contract lead
+- SWE A: remote workspace and audit model
+- SWE B: contract docs, fakes, and deterministic evidence
 
 ### 4. Scenario Evidence And Operator Verification
 
-Scope for this delivery slice:
+Scope to expand as each later phase lands:
 
 - expand authenticated, lower-assurance, session-supervisor, migration, and
   remote-workspace scenario coverage as each target-facing phase lands
@@ -134,19 +159,17 @@ Staffing:
 
 ## Sequence
 
-1. build mutable orchestration on top of the shipped inventory and inspection
-   surface rather than replacing it
-2. add worktree-per-session defaults and status surfaces before any dashboard
-   work
-3. refactor state, diagnostics, and auth/bootstrap onto the runtime-target
-   model while preserving session-surface parity
-4. define trusted `linux/amd64` validation hosts and explicit evidence gates
-   before broad non-macOS or remote-target claims
-5. expand authenticated and lower-assurance scenario coverage as each phase
-   lands rather than as a cleanup pass
-6. only then define and prepare the first cross-platform `compat` and
-   `remote_vm` paths against the same host-owned policy model, leaving their
-   actual delivery to the runtime-target expansion program
+1. finish the shared auth/bootstrap path on the shipped host-owned policy and
+   explainability surface, and freeze the provider/bootstrap support matrix for
+   this phase
+2. only after Phase 3 exits green, define trusted `linux/amd64` validation
+   hosts plus an explicit host-compatibility matrix
+3. only after that, define the remote-VM contract and deterministic evidence
+   before any provider-specific backend work
+4. expand authenticated, lower-assurance, and remote-contract coverage as each
+   later phase lands rather than as a cleanup pass
+5. leave actual `compat` and cloud-backend delivery to the later
+   runtime-target program phases once these prerequisites are done
 
 ## Non-Goals In This Slice
 
@@ -157,4 +180,6 @@ Staffing:
 - secret materialization paths that bypass the reviewed host policy flow
 - automatic backend fallback
 - broad Linux or Windows parity claims
+- selecting or shipping `docker-desktop`, `aws-ec2-ssm`, `gcp-vm`, or
+  `azure-vm` in this slice
 - Kubernetes-backed execution or managed-workstation delivery in this slice

--- a/docs/runtime-target-expansion-plan.md
+++ b/docs/runtime-target-expansion-plan.md
@@ -110,6 +110,8 @@ targets must stay labeled `compat` or another explicitly lower-assurance class.
 
 ### 5. Backend delivery
 
+- keep backend selection and ordering in this program doc rather than pulling
+  it forward into the active auth/bootstrap slice
 - extract `colima` behind the new target model first
 - add `docker-desktop` as the first `compat` target
 - add `aws-ec2-ssm` as the first `remote_vm` target

--- a/docs/runtime-target-phase-plan.md
+++ b/docs/runtime-target-phase-plan.md
@@ -16,6 +16,8 @@ Current repo status:
 - Phase 1 is implemented in the session platform and deterministic evidence
 - Phase 2 is implemented in the target-state migration and Colima
   compatibility-read path
+- Phase 3 is the next active slice: shared auth/bootstrap completion on top of
+  the shipped direct staged-auth and explainability surfaces
 - later phases remain planning targets until their code and evidence land
 
 ## Phase Completion Contract
@@ -99,15 +101,26 @@ Goal:
 
 Deliverables:
 
-- broader resolver coverage
+- broader resolver coverage on top of the shipped direct staged-auth path
 - explicit host-owned browser or setup handoffs where provider bootstrap still
   needs them
 - shared diagnostics and explainability across launcher and operator tooling
+- updated provider/bootstrap support matrix that names which auth inputs and
+  bootstrap paths are repo-required, certification-only, or manual
+- clear separation between repo-required deterministic auth/bootstrap evidence
+  and live-provider certification or manual provider-e2e paths
 
 Complete when:
 
 - deterministic auth and bootstrap suites pass without live provider
   dependence
+- the provider/bootstrap support matrix and rollout docs make the supported
+  resolver and bootstrap paths explicit enough to freeze scope for the phase
+- launcher, operator, and rollout docs describe the reviewed bootstrap and
+  explainability path without implying broader resolver support than the
+  current evidence proves
+- any remaining live-provider bootstrap checks stay explicitly documented as
+  certification-only or manual validation lanes
 
 ## Phase 4: Trusted validation hosts and host-compatibility matrix
 
@@ -124,6 +137,9 @@ Deliverables:
 
 Complete when:
 
+- the support matrix and validation-host invocation are documented in the repo
+- target-aware diagnostics fail closed for unsupported host/backend
+  combinations
 - Linux and Windows support claims are limited to what the validation-host
   evidence and docs prove
 
@@ -143,6 +159,8 @@ Deliverables:
 Complete when:
 
 - deterministic remote-contract tests pass without real cloud dependence
+- the remote workspace-materialization, brokered-access, and audit contract is
+  documented alongside the tests that prove it
 
 ## Phase 6: Docker Desktop compatibility backend
 
@@ -161,6 +179,10 @@ Complete when:
 
 - the repo keeps `docker-desktop` support clearly lower assurance than the
   current strict Colima path
+- the support matrix, rollout guidance, and operator verification material all
+  describe the target as `compat` rather than implying strict parity
+- host-matrix certification evidence is published alongside the docs and
+  diagnostics that define the supported combinations
 
 ## Phase 7: AWS remote VM backend
 
@@ -177,6 +199,8 @@ Deliverables:
 Complete when:
 
 - deterministic adapter and contract suites pass
+- the AWS-specific support-boundary, operator rollout path, and audited access
+  model are documented alongside the target enablement change
 - live AWS smoke remains certification-only
 
 ## Phase 8: GCP remote VM backend
@@ -193,6 +217,8 @@ Deliverables:
 Complete when:
 
 - deterministic adapter and contract suites pass
+- the GCP-specific support-boundary, operator rollout path, and audited access
+  model are documented alongside the target enablement change
 - live GCP smoke remains certification-only
 
 ## Phase 9: Later expansion decision gate


### PR DESCRIPTION
## Summary
- align the roadmap and phase docs with the repo state after Phases 1 and 2
- keep Phase 3 scoped to shared auth/bootstrap completion rather than backend delivery
- tighten later phase completion gates so host-compatibility and remote-VM work require matching docs and evidence

## Validation
- bash ./scripts/validate-repo.sh

## Notes
- no behavior changes; planning/docs only
