### PR TITLE
[codex] Fix file:// home path hygiene detection

### DIFF
--- a/internal/testkit/public_repo_hygiene_test.go
+++ b/internal/testkit/public_repo_hygiene_test.go
@@ -101,6 +101,7 @@ func TestCheckPublicRepoHygieneAllowsPortableExamples(t *testing.T) {
 		{name: "file url example path", readme: "Portable example file URL: file:///Users/example/workcell"},
 		{name: "custom uri path", readme: "Portable custom URI: profile:///home/alice/docs"},
 		{name: "custom uri with authority path", readme: "Portable custom URI with authority: notfile://localhost/home/alice/docs"},
+		{name: "multiple home-like url segments", readme: "Legitimate URL with multiple segments: https://example.com/home/alice//Users/bob"},
 		{name: "url segment", readme: "Legitimate URL: https://example.com/home/alice/docs"},
 	}
 

--- a/internal/testkit/public_repo_hygiene_test.go
+++ b/internal/testkit/public_repo_hygiene_test.go
@@ -65,6 +65,8 @@ func TestCheckPublicRepoHygieneRejectsLeakedHomePaths(t *testing.T) {
 		{name: "backtick wrapped path", readme: "Leaked markdown path: `/Users/alice/workcell`", wantOutput: "/Users/alice/workcell"},
 		{name: "angle bracket wrapped path", readme: "Leaked markdown target: </Users/alice/workcell>", wantOutput: "/Users/alice/workcell"},
 		{name: "mixed placeholder and real path", readme: "Mixed paths: `/Users/example` and `/Users/alice/workcell`", wantOutput: "/Users/alice/workcell"},
+		{name: "file url", readme: "Leaked file URL: file:///Users/alice/workcell", wantOutput: "/Users/alice/workcell"},
+		{name: "file url with authority", readme: "Leaked file URL: file://localhost/home/alice/workcell", wantOutput: "/home/alice/workcell"},
 	}
 
 	for _, tc := range testCases {
@@ -96,6 +98,7 @@ func TestCheckPublicRepoHygieneAllowsPortableExamples(t *testing.T) {
 		{name: "plain example path", readme: "Portable example path: /Users/example"},
 		{name: "punctuation delimited example path", readme: "Portable markdown path: `/Users/example`"},
 		{name: "example path with trailing text", readme: "Portable example path in prose: /Users/example next-step"},
+		{name: "file url example path", readme: "Portable example file URL: file:///Users/example/workcell"},
 		{name: "url segment", readme: "Legitimate URL: https://example.com/home/alice/docs"},
 	}
 

--- a/internal/testkit/public_repo_hygiene_test.go
+++ b/internal/testkit/public_repo_hygiene_test.go
@@ -99,6 +99,8 @@ func TestCheckPublicRepoHygieneAllowsPortableExamples(t *testing.T) {
 		{name: "punctuation delimited example path", readme: "Portable markdown path: `/Users/example`"},
 		{name: "example path with trailing text", readme: "Portable example path in prose: /Users/example next-step"},
 		{name: "file url example path", readme: "Portable example file URL: file:///Users/example/workcell"},
+		{name: "custom uri path", readme: "Portable custom URI: profile:///home/alice/docs"},
+		{name: "custom uri with authority path", readme: "Portable custom URI with authority: notfile://localhost/home/alice/docs"},
 		{name: "url segment", readme: "Legitimate URL: https://example.com/home/alice/docs"},
 	}
 

--- a/internal/testkit/public_repo_hygiene_test.go
+++ b/internal/testkit/public_repo_hygiene_test.go
@@ -102,6 +102,7 @@ func TestCheckPublicRepoHygieneAllowsPortableExamples(t *testing.T) {
 		{name: "custom uri path", readme: "Portable custom URI: profile:///home/alice/docs"},
 		{name: "custom uri with authority path", readme: "Portable custom URI with authority: notfile://localhost/home/alice/docs"},
 		{name: "multiple home-like url segments", readme: "Legitimate URL with multiple segments: https://example.com/home/alice//Users/bob"},
+		{name: "url path containing file scheme text", readme: "Legitimate URL path with embedded file text: https://example.com/path/file://localhost/home/alice/docs"},
 		{name: "url segment", readme: "Legitimate URL: https://example.com/home/alice/docs"},
 	}
 

--- a/scripts/check-public-repo-hygiene.sh
+++ b/scripts/check-public-repo-hygiene.sh
@@ -48,7 +48,7 @@ check_public_surfaces() {
           return 1
         }
 
-        return prefix ~ /(^|[^[:alnum:]+.-])file:\/\/([^[:space:]\/?#]+)?$/
+        return prefix ~ /(^|[^[:alnum:]+.\/-])file:\/\/([^[:space:]\/?#]+)?$/
       }
 
       function line_has_disallowed_home_path(line,    search_start, segment, absolute_start, prefix, path) {

--- a/scripts/check-public-repo-hygiene.sh
+++ b/scripts/check-public-repo-hygiene.sh
@@ -48,7 +48,7 @@ check_public_surfaces() {
           return 1
         }
 
-        return prefix ~ /file:\/\/([^[:space:]\/?#]+)?$/
+        return prefix ~ /(^|[^[:alnum:]+.-])file:\/\/([^[:space:]\/?#]+)?$/
       }
 
       function line_has_disallowed_home_path(line,    rest, prefix, path) {

--- a/scripts/check-public-repo-hygiene.sh
+++ b/scripts/check-public-repo-hygiene.sh
@@ -38,13 +38,25 @@ check_public_surfaces() {
           path ~ /^\/home\/example($|[[:space:]]|\/|[][})>"'"'"'`.,:;!?])/
       }
 
-      function line_has_disallowed_home_path(line,    rest, matched, path) {
+      function has_allowed_home_path_prefix(prefix,    last_char) {
+        if (prefix == "") {
+          return 1
+        }
+
+        last_char = substr(prefix, length(prefix), 1)
+        if (last_char !~ /[[:alnum:]\/._~-]/) {
+          return 1
+        }
+
+        return prefix ~ /file:\/\/([^[:space:]\/?#]+)?$/
+      }
+
+      function line_has_disallowed_home_path(line,    rest, prefix, path) {
         rest = line
-        while (match(rest, /(^|[^[:alnum:]\/._~-])(\/Users\/[^[:space:]\/]+([[:space:]\/[:punct:]]|$)|\/home\/[^[:space:]\/]+([[:space:]\/[:punct:]]|$))/)) {
-          matched = substr(rest, RSTART, RLENGTH)
-          path = matched
-          sub(/^[^\/]*/, "", path)
-          if (!is_example_placeholder(path)) {
+        while (match(rest, /(\/Users\/[^[:space:]\/]+([[:space:]\/[:punct:]]|$)|\/home\/[^[:space:]\/]+([[:space:]\/[:punct:]]|$))/)) {
+          prefix = substr(rest, 1, RSTART - 1)
+          path = substr(rest, RSTART, RLENGTH)
+          if (has_allowed_home_path_prefix(prefix) && !is_example_placeholder(path)) {
             return 1
           }
           rest = substr(rest, RSTART + RLENGTH)

--- a/scripts/check-public-repo-hygiene.sh
+++ b/scripts/check-public-repo-hygiene.sh
@@ -51,15 +51,17 @@ check_public_surfaces() {
         return prefix ~ /(^|[^[:alnum:]+.-])file:\/\/([^[:space:]\/?#]+)?$/
       }
 
-      function line_has_disallowed_home_path(line,    rest, prefix, path) {
-        rest = line
-        while (match(rest, /(\/Users\/[^[:space:]\/]+([[:space:]\/[:punct:]]|$)|\/home\/[^[:space:]\/]+([[:space:]\/[:punct:]]|$))/)) {
-          prefix = substr(rest, 1, RSTART - 1)
-          path = substr(rest, RSTART, RLENGTH)
+      function line_has_disallowed_home_path(line,    search_start, segment, absolute_start, prefix, path) {
+        search_start = 1
+        while (match(substr(line, search_start), /(\/Users\/[^[:space:]\/]+([[:space:]\/[:punct:]]|$)|\/home\/[^[:space:]\/]+([[:space:]\/[:punct:]]|$))/)) {
+          segment = substr(line, search_start)
+          absolute_start = search_start + RSTART - 1
+          prefix = substr(line, 1, absolute_start - 1)
+          path = substr(segment, RSTART, RLENGTH)
           if (has_allowed_home_path_prefix(prefix) && !is_example_placeholder(path)) {
             return 1
           }
-          rest = substr(rest, RSTART + RLENGTH)
+          search_start = absolute_start + RLENGTH
         }
         return 0
       }


### PR DESCRIPTION
## Summary
- fix the public repo hygiene matcher so `file:///Users/...` and `file://localhost/home/...` are treated as leaked machine-specific paths
- preserve the existing `https://.../home/...` false-positive guard by only allowing the URL-style exception for `file://`
- add focused regression coverage for leaking and portable `file://` inputs

## Root cause
The boundary hardening treated `/` as part of a URL-safe prefix. That avoided matching `https://example.com/home/...`, but it also let `file://` URLs hide absolute home paths from the hygiene check.

## Validation
- `go test ./internal/testkit -run TestCheckPublicRepoHygiene -count=1`
- `shellcheck scripts/check-public-repo-hygiene.sh`
- `bash ./scripts/check-public-repo-hygiene.sh`
- targeted sink-level mutation checks for the `file://` allowance and URL-authority guard
