### PR TITLE
Tighten Phase 4+ runtime target landing gates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,12 +30,17 @@ The deterministic phase breakdown lives in
 
 ## Medium term
 
+### Session plane
+
 - add pause, resume, checkpoint, and fork flows on the same host-controlled
   session plane
 - add reviewed team workflow packs at the Workcell layer: versioned
   instruction bundles, commands, approved MCP packs, and task templates
 - add a lightweight TUI or dashboard backed by the same host-controlled
   session plane rather than a separate execution path
+
+### Deployment reach
+
 - ship the first cross-platform compatibility backend with explicit
   lower-assurance labeling and backend-aware diagnostics
 - deliver the first remote VM backend for the highest-value use cases:

--- a/docs/implement-first-delivery-plan.md
+++ b/docs/implement-first-delivery-plan.md
@@ -113,8 +113,11 @@ Scope to define before the owning later phase starts:
 - define the narrow trusted `linux/amd64` validation-host lane before broader
   non-macOS or cloud claims
 - express support as `host OS x target kind x assurance class`
+- define a versioned capability and support-matrix artifact that docs and
+  diagnostics both consume
 - add backend-aware diagnostics that fail closed on unsupported host/backend
   combinations
+- add deterministic fixture tests for unsupported host/backend combinations
 - keep Linux and Windows claims limited to what the validation-host evidence
   and docs actually prove
 
@@ -132,6 +135,8 @@ Scope to define before the owning later phase starts:
   ships
 - make remote workspace materialization explicit and auditable
 - define the reviewed brokered-access and remote image/bootstrap model
+- add the shared fake remote target, conformance harness, and fixtures that
+  later cloud adapters must reuse unchanged
 - keep target ordering and backend selection in the longer-lived
   runtime-target expansion program rather than in this active slice
 
@@ -157,6 +162,20 @@ Staffing:
 - SWE A: scenario and migration evidence
 - SWE B: operator verification docs and comparison material
 
+## Backend Phase Handoff
+
+Before Phase 6, 7, 8, or 9 begins implementation, assign:
+
+- EM:
+  support-boundary owner for rollout scope, preview/GA decisions, and rollback
+- TL:
+  integration owner for shared harness reuse, deterministic tests, and target
+  behavior
+- contract and docs owner:
+  owner for canonical matrices, rollout docs, and operator verification
+- validation owner:
+  owner for repo-required evidence and certification-lane definitions
+
 ## Sequence
 
 1. finish the shared auth/bootstrap path on the shipped host-owned policy and
@@ -169,7 +188,8 @@ Staffing:
 4. expand authenticated, lower-assurance, and remote-contract coverage as each
    later phase lands rather than as a cleanup pass
 5. leave actual `compat` and cloud-backend delivery to the later
-   runtime-target program phases once these prerequisites are done
+   runtime-target program phases once these prerequisites and owner handoffs
+   are done
 
 ## Non-Goals In This Slice
 

--- a/docs/runtime-target-expansion-plan.md
+++ b/docs/runtime-target-expansion-plan.md
@@ -105,6 +105,8 @@ targets must stay labeled `compat` or another explicitly lower-assurance class.
 - define a narrow trusted `linux/amd64` validation-host lane before broad
   non-macOS claims
 - express support as `host OS x target kind x assurance class`
+- keep one versioned capability and support-matrix artifact that docs,
+  diagnostics, and rollout guidance derive from
 - do not claim Linux or Windows `strict` parity until the same guarantees are
   proven there
 
@@ -116,6 +118,8 @@ targets must stay labeled `compat` or another explicitly lower-assurance class.
 - add `docker-desktop` as the first `compat` target
 - add `aws-ec2-ssm` as the first `remote_vm` target
 - add `gcp-vm` as the second `remote_vm` target
+- require later cloud adapters to pass the shared remote-VM conformance harness
+  rather than redefining contract suites per provider
 - keep `azure-vm` and managed workstations behind later decision gates
 
 ### 6. Scenario evidence and operator verification
@@ -149,6 +153,9 @@ Current repo status:
 
 - `docker-desktop` is feature-flagged, explicitly `compat`, and backed by
   target-aware diagnostics
+- deterministic target-selection, state-routing, and fail-closed behavior are
+  proven under repo-required tests
+- rollback to the strict Colima path is documented and operator-verifiable
 - Linux and Windows support claims remain limited to what the evidence proves
 
 ### Gate 4: first remote VM preview
@@ -156,12 +163,17 @@ Current repo status:
 - remote workspace materialization is explicit and auditable
 - the remote target uses reviewed brokered access and does not require inbound
   public SSH
+- the shared remote-VM conformance harness stays authoritative for the preview
+- the support boundary remains preview-only and is reflected in canonical
+  matrices plus rollout guidance
 - shared auth/bootstrap and scenario evidence are in place
 
 ### Gate 5: second remote VM on the same contract
 
 - the second cloud provider fits the same control-plane and audit model with
   limited provider-specific delta
+- the unchanged shared conformance harness and canonical matrices still bound
+  the support claim
 
 ### Gate 6: later expansion decision
 

--- a/docs/runtime-target-phase-plan.md
+++ b/docs/runtime-target-phase-plan.md
@@ -133,11 +133,17 @@ Deliverables:
 
 - trusted `linux/amd64` validation-host lane
 - support matrix expressed as `host OS x target kind x assurance class`
+- versioned capability and support-matrix artifact that docs, diagnostics, and
+  rollout guidance derive from
 - backend-aware diagnostics that fail closed on unsupported combinations
+- deterministic fixture tests for unsupported host/backend combinations
 
 Complete when:
 
-- the support matrix and validation-host invocation are documented in the repo
+- the machine-readable support matrix and validation-host invocation are
+  documented in the repo
+- target-aware diagnostics and fixture tests derive unsupported-combination
+  behavior from the same support-matrix artifact
 - target-aware diagnostics fail closed for unsupported host/backend
   combinations
 - Linux and Windows support claims are limited to what the validation-host
@@ -155,12 +161,34 @@ Deliverables:
 - explicit remote workspace materialization
 - reviewed brokered-access model
 - remote image/bootstrap contract and session/audit lifecycle
+- reusable fake remote target plus shared remote-VM conformance harness
+- fixture-backed deterministic tests that later cloud adapters can run
+  unchanged against that harness
 
 Complete when:
 
 - deterministic remote-contract tests pass without real cloud dependence
+- the shared fake remote target and conformance harness are in the repo and
+  later cloud adapters can consume them without redefining the contract
 - the remote workspace-materialization, brokered-access, and audit contract is
   documented alongside the tests that prove it
+
+## Backend phase exit ownership
+
+The following owner model applies to Phases 6 through 9:
+
+- EM:
+  owns support-boundary approval, rollout scope, and the final decision that a
+  target is ready to move forward
+- TL:
+  owns deterministic backend integration, shared harness reuse, and rollback
+  readiness
+- contract and docs owner:
+  owns support-matrix, rollout, and operator-verification updates in the same
+  change as target enablement
+- validation owner:
+  owns repo-required evidence, certification-lane definitions, and any
+  required live-smoke gating
 
 ## Phase 6: Docker Desktop compatibility backend
 
@@ -174,34 +202,52 @@ Deliverables:
 - feature-flagged `docker-desktop` target
 - explicit `compat` labeling in docs, diagnostics, and session metadata
 - host-matrix certification evidence
+- repo-required target-selection, state-root-routing, and fail-closed
+  diagnostic tests for the `docker-desktop` path
+- explicit enable, disable, and rollback procedure back to the strict Colima
+  path without silent fallback
 
 Complete when:
 
 - the repo keeps `docker-desktop` support clearly lower assurance than the
   current strict Colima path
+- deterministic backend-selection, state-root-routing, and fail-closed
+  diagnostic behavior is proven under repo-required tests
 - the support matrix, rollout guidance, and operator verification material all
   describe the target as `compat` rather than implying strict parity
 - host-matrix certification evidence is published alongside the docs and
   diagnostics that define the supported combinations
+- the owning EM, TL, contract/docs owner, and validation owner approve the
+  enablement, rollback path, and support boundary for the phase
 
 ## Phase 7: AWS remote VM backend
 
 Goal:
 
-- implement the remote VM contract on the first cloud provider
+- implement the remote VM contract on the first cloud provider as a preview
+  target
 
 Deliverables:
 
 - `aws-ec2-ssm` target
+- preview-only support boundary and limited rollout gate
 - audited lifecycle and brokered access
 - explicit remote workspace materialization on the reviewed host-owned model
+- no inbound public SSH requirement on the supported path
 
 Complete when:
 
-- deterministic adapter and contract suites pass
+- deterministic adapter suites and the shared remote-VM conformance harness
+  pass
+- the canonical provider/bootstrap matrix and host-compat support matrix are
+  updated in the same change as the AWS rollout docs
 - the AWS-specific support-boundary, operator rollout path, and audited access
   model are documented alongside the target enablement change
+- the preview-only support boundary and enablement gate are explicit in docs,
+  diagnostics, and rollout guidance
 - live AWS smoke remains certification-only
+- the owning EM, TL, contract/docs owner, and validation owner approve the
+  preview boundary, matrices, and evidence for the phase
 
 ## Phase 8: GCP remote VM backend
 
@@ -213,13 +259,19 @@ Deliverables:
 
 - `gcp-vm` target with limited provider-specific delta
 - parity on lifecycle, audit, and workspace materialization semantics
+- reuse of the unchanged shared remote-VM conformance harness
 
 Complete when:
 
-- deterministic adapter and contract suites pass
+- deterministic adapter suites and the shared remote-VM conformance harness
+  pass
+- the canonical provider/bootstrap matrix and host-compat support matrix are
+  updated in the same change as the GCP rollout docs
 - the GCP-specific support-boundary, operator rollout path, and audited access
   model are documented alongside the target enablement change
 - live GCP smoke remains certification-only
+- the owning EM, TL, contract/docs owner, and validation owner approve the
+  support boundary, matrices, and evidence for the phase
 
 ## Phase 9: Later expansion decision gate
 
@@ -237,3 +289,5 @@ Complete when:
 
 - the next funded lane is explicit and the rejected paths are documented as
   deferred rather than implied
+- the owning EM, TL, contract/docs owner, and validation owner record the
+  decision and its support-load implications in the planning surfaces


### PR DESCRIPTION
## Summary
- tighten Phase 4 and Phase 5 so host-compatibility and remote contract work have shared machine-readable artifacts and reusable conformance harnesses
- add explicit owner handoff, rollback, and preview-boundary requirements for later backend phases
- align the roadmap so deployment-reach sequencing reads consistently from Phase 4 onward

## Validation
- bash ./scripts/validate-repo.sh

## Notes
- docs and planning only; no runtime behavior changes
