### PR TITLE
Align Phase 4+ prerequisites after Phase 3

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,18 +15,19 @@ The deterministic phase breakdown lives in
 
 ## Short term
 
-- broaden host-owned auth flows where the current implementation is still thin:
-  more resolver coverage plus explicit browser/bootstrap handoffs for provider
-  onboarding
 - expand end-to-end coverage for authenticated, lower-assurance, and
   session-supervisor transitions so new orchestration features ship with
   invariant checks
-- add a narrow trusted `linux/amd64` validation-host lane plus target-aware
-  diagnostics before broad non-macOS or cloud support claims
-- define the support matrix, remote-VM contract prerequisites, and evidence
-  gates that later `compat` and `remote_vm` targets must satisfy, without
-  implying backend shipment or Tier 1 Linux or Windows host parity before the
-  same guarantees exist
+- ship the narrow trusted `linux/amd64` validation-host lane, versioned
+  support matrix, and target-aware diagnostics before broad non-macOS or cloud
+  support claims
+- define the remote-VM contract prerequisites and evidence gates that later
+  `compat` and `remote_vm` targets must satisfy, without implying backend
+  shipment or Tier 1 Linux or Windows host parity before the same guarantees
+  exist
+- keep one canonical machine-readable support matrix and one shared remote-VM
+  conformance harness so later targets cannot fork the support contract by
+  accident
 
 ## Medium term
 

--- a/docs/enterprise-rollout.md
+++ b/docs/enterprise-rollout.md
@@ -69,14 +69,19 @@ Use your existing device-management, bootstrap, or dotfile workflow to place:
 Keep repo-local provider control files as imported inputs, not as the live
 control plane.
 
-### 3. Prefer direct staged auth inputs
+### 3. Prefer direct staged auth inputs, with reviewed Codex host reuse when needed
 
-Direct staged credentials are the main supported auth path today.
+Direct staged credentials are still the main supported auth path today.
 
 - Codex: `codex_auth`
 - Claude: `claude_auth`, `claude_api_key`, and `claude_mcp`
 - Gemini: `gemini_env`, `gemini_oauth`, and `gemini_projects`
 - Gemini Vertex supplement: `gcloud_adc`
+
+Reviewed Codex host-auth reuse through `codex-home-auth-file` is also
+supported on the same staged host-owned path when a team wants to reuse the
+existing `~/.codex/auth.json` cache file instead of copying it into a separate
+managed location.
 
 Current caveats:
 
@@ -86,7 +91,9 @@ Current caveats:
   mode
 
 See [injection-policy.md](injection-policy.md) for the current by-provider auth
-maturity summary.
+maturity summary and
+[provider-bootstrap-matrix.md](provider-bootstrap-matrix.md) for the explicit
+repo-required versus manual bootstrap tiers.
 
 ### 4. Scope shared GitHub and SSH inputs deliberately
 

--- a/docs/implement-first-delivery-plan.md
+++ b/docs/implement-first-delivery-plan.md
@@ -7,9 +7,9 @@ The longer-lived runtime-target and deployment-reach program lives in
 [`docs/runtime-target-expansion-plan.md`](runtime-target-expansion-plan.md),
 and the deterministic phase breakdown lives in
 [`docs/runtime-target-phase-plan.md`](runtime-target-phase-plan.md).
-Phases 1 and 2 of that phase plan are now implemented in the repository; this
-document now defines the immediate bridge into Phase 3 and the prerequisite
-work for later host-compatibility and remote-target phases.
+Phases 1 through 3 of that phase plan are now implemented in the repository;
+this document now defines the immediate bridge into Phase 4 and the
+prerequisite work for later remote-target phases.
 
 The current repo already includes durable session records plus detached
 host-side session control (`session start|attach|send|stop`) and basic
@@ -17,11 +17,12 @@ observability surfaces (`session list|show|logs|timeline|diff|export`). The
 current repo also stores session, audit, and lock state under Workcell-owned
 target-state roots while preserving compatibility reads for older
 `~/.colima/...` records. The current repo also ships direct staged-auth flows,
-`--auth-status`, and host-side auth explainability on the reviewed policy
-path. The active work in this slice is to complete the shared auth/bootstrap
-path. This document also records the queued validation-host and remote-VM
-contract prerequisites so later phases can start cleanly without pulling
-backend delivery forward into Phase 3.
+Codex host-auth reuse on the reviewed resolver path, `--auth-status`,
+credential-level `why` bootstrap summaries, and the provider/bootstrap support
+matrix on the reviewed policy path. The active work in this slice is now the
+validation-host and host-compatibility bridge. This document also records the
+queued remote-VM contract prerequisites so later phases can start cleanly
+without pulling backend delivery forward into Phase 4.
 
 ## Principles
 
@@ -46,18 +47,21 @@ backend delivery forward into Phase 3.
   verify every changed code path preserves the runtime boundary, does not widen
   credential exposure, and keeps host-side git/control-plane execution explicit
 
-## Phase 3 Exit Ownership
+## Phase 4 Exit Ownership
 
 - EM:
-  holds the phase boundary, prevents later validation-host or remote-VM work
-  from being counted as Phase 3 delivery, and blocks support claims that
+  holds the phase boundary, prevents later remote-VM work from being counted
+  as Phase 4 delivery, and blocks support claims that
   outrun the evidence
 - TL:
-  owns the integrated Phase 3 landing criteria across code, deterministic
+  owns the integrated Phase 4 landing criteria across code, deterministic
   tests, and launcher/operator behavior
 - contract and docs owner:
-  owns the provider/bootstrap support matrix plus the operator and rollout docs
-  that bound what Phase 3 actually supports
+  owns the support matrix plus the operator and rollout docs that bound what
+  Phase 4 actually supports
+- validation owner:
+  owns the repo-required evidence, validation-host certification lane, and the
+  fail-closed unsupported-combination coverage that Phase 4 depends on
 
 ## Delivered Foundation
 
@@ -68,53 +72,21 @@ to the next slice rather than as active delivery work:
   target-aware session metadata
 - Workcell-owned target-state roots with compatibility reads for older
   Colima-shaped records
-- direct staged-auth flows, `--auth-status`, policy explainability, and the
-  current secretless and authenticated scenario baseline
+- direct staged-auth flows, Codex host-auth reuse, `--auth-status`,
+  policy/bootstrap explainability, the provider/bootstrap support matrix, and
+  the current secretless and authenticated scenario baseline
 
-## Active Phase 3 Track
+## Active Phase 4 Track
 
-### 1. Shared Auth and Bootstrap Completion
+### 1. Validation Host And Host-Compatibility Matrix
 
 Scope for this delivery slice:
-
-- broaden built-in resolver coverage where the current implementation is still
-  intentionally narrow
-- keep direct staged inputs as the primary supported auth path until broader
-  resolver evidence exists
-- make browser/setup handoffs explicit and host-owned where provider bootstrap
-  still needs operator intervention
-- keep auth selection, explainability, and launch-time diagnostics on one
-  reviewed host-owned path
-- publish an explicit provider/bootstrap support matrix that marks each auth
-  path as repo-required, certification-only, or manual
-- separate deterministic repo-required auth/bootstrap evidence from
-  live-provider certification and manual provider-e2e validation
-
-Staffing:
-
-- TL: auth integrations lead
-- SWE A: resolver metadata and auth-state reasoning
-- SWE B: bootstrap handoffs, diagnostics, and scenario coverage
-
-Phase boundary:
-
-- this is the active implementation slice and the only track that should change
-  Phase 3 status from planned to complete
-- the remaining tracks below are prerequisites and follow-on planning surfaces
-  for later deterministic phases, not authority to ship backend delivery in the
-  current slice
-
-## Immediate Follow-On Prerequisites
-
-### 2. Validation Host And Host-Compatibility Matrix
-
-Scope to define before the owning later phase starts:
 
 - define the narrow trusted `linux/amd64` validation-host lane before broader
   non-macOS or cloud claims
 - express support as `host OS x target kind x assurance class`
-- define a versioned capability and support-matrix artifact that docs and
-  diagnostics both consume
+- define one canonical versioned capability and support-matrix artifact that
+  docs, diagnostics, fixture tests, and rollout guidance all consume
 - add backend-aware diagnostics that fail closed on unsupported host/backend
   combinations
 - add deterministic fixture tests for unsupported host/backend combinations
@@ -126,8 +98,19 @@ Staffing:
 - TL: validation-host and rollout lead
 - SWE A: validation-host tooling and diagnostics
 - SWE B: support matrix docs and operator guidance
+- validation owner: repo-required evidence and certification-lane lead
 
-### 3. Remote VM Contract Preparation
+Phase boundary:
+
+- this is the active implementation slice and the only track that should change
+  Phase 4 status from planned to complete
+- the remaining tracks below are prerequisites and follow-on planning surfaces
+  for later deterministic phases, not authority to ship backend delivery in the
+  current slice
+
+## Immediate Follow-On Prerequisites
+
+### 2. Remote VM Contract Preparation
 
 Scope to define before the owning later phase starts:
 
@@ -135,18 +118,20 @@ Scope to define before the owning later phase starts:
   ships
 - make remote workspace materialization explicit and auditable
 - define the reviewed brokered-access and remote image/bootstrap model
-- add the shared fake remote target, conformance harness, and fixtures that
-  later cloud adapters must reuse unchanged
+- add one canonical shared fake remote target, conformance harness, and
+  fixtures that later cloud adapters must reuse unchanged
 - keep target ordering and backend selection in the longer-lived
   runtime-target expansion program rather than in this active slice
 
 Staffing:
 
+- EM: remote-contract boundary owner
 - TL: remote contract lead
 - SWE A: remote workspace and audit model
 - SWE B: contract docs, fakes, and deterministic evidence
+- validation owner: shared conformance evidence and certification-lane lead
 
-### 4. Scenario Evidence And Operator Verification
+### 3. Scenario Evidence And Operator Verification
 
 Scope to expand as each later phase lands:
 
@@ -162,9 +147,9 @@ Staffing:
 - SWE A: scenario and migration evidence
 - SWE B: operator verification docs and comparison material
 
-## Backend Phase Handoff
+## Later Phase Handoff
 
-Before Phase 6, 7, 8, or 9 begins implementation, assign:
+Before Phase 5, 6, 7, 8, or 9 begins implementation, assign:
 
 - EM:
   support-boundary owner for rollout scope, preview/GA decisions, and rollback
@@ -178,13 +163,12 @@ Before Phase 6, 7, 8, or 9 begins implementation, assign:
 
 ## Sequence
 
-1. finish the shared auth/bootstrap path on the shipped host-owned policy and
-   explainability surface, and freeze the provider/bootstrap support matrix for
-   this phase
-2. only after Phase 3 exits green, define trusted `linux/amd64` validation
-   hosts plus an explicit host-compatibility matrix
-3. only after that, define the remote-VM contract and deterministic evidence
-   before any provider-specific backend work
+1. treat the completed shared auth/bootstrap path plus the
+   provider/bootstrap support matrix as fixed input to the next slice
+2. define trusted `linux/amd64` validation hosts plus an explicit
+   host-compatibility matrix
+3. only after Phase 4 exits green, define the remote-VM contract and
+   deterministic evidence before any provider-specific backend work
 4. expand authenticated, lower-assurance, and remote-contract coverage as each
    later phase lands rather than as a cleanup pass
 5. leave actual `compat` and cloud-backend delivery to the later

--- a/docs/runtime-target-expansion-plan.md
+++ b/docs/runtime-target-expansion-plan.md
@@ -105,8 +105,8 @@ targets must stay labeled `compat` or another explicitly lower-assurance class.
 - define a narrow trusted `linux/amd64` validation-host lane before broad
   non-macOS claims
 - express support as `host OS x target kind x assurance class`
-- keep one versioned capability and support-matrix artifact that docs,
-  diagnostics, and rollout guidance derive from
+- keep one canonical versioned capability and support-matrix artifact that
+  docs, diagnostics, fixture tests, and rollout guidance derive from
 - do not claim Linux or Windows `strict` parity until the same guarantees are
   proven there
 
@@ -156,6 +156,8 @@ Current repo status:
 - deterministic target-selection, state-routing, and fail-closed behavior are
   proven under repo-required tests
 - rollback to the strict Colima path is documented and operator-verifiable
+- the canonical support matrix and validation-host evidence bound the support
+  claim for each published host combination
 - Linux and Windows support claims remain limited to what the evidence proves
 
 ### Gate 4: first remote VM preview
@@ -166,7 +168,8 @@ Current repo status:
 - the shared remote-VM conformance harness stays authoritative for the preview
 - the support boundary remains preview-only and is reflected in canonical
   matrices plus rollout guidance
-- shared auth/bootstrap and scenario evidence are in place
+- shared auth/bootstrap, validation-host support matrices, and scenario
+  evidence are in place
 
 ### Gate 5: second remote VM on the same contract
 

--- a/docs/runtime-target-phase-plan.md
+++ b/docs/runtime-target-phase-plan.md
@@ -16,8 +16,10 @@ Current repo status:
 - Phase 1 is implemented in the session platform and deterministic evidence
 - Phase 2 is implemented in the target-state migration and Colima
   compatibility-read path
-- Phase 3 is the next active slice: shared auth/bootstrap completion on top of
-  the shipped direct staged-auth and explainability surfaces
+- Phase 3 is implemented in the shared auth/bootstrap path, explicit bootstrap
+  explainability, and provider bootstrap support matrix
+- Phase 4 is the next active slice: trusted validation hosts and the
+  host-compatibility matrix
 - later phases remain planning targets until their code and evidence land
 
 ## Phase Completion Contract
@@ -149,6 +151,21 @@ Complete when:
 - Linux and Windows support claims are limited to what the validation-host
   evidence and docs prove
 
+Phase 4 exit ownership:
+
+- EM:
+  owns the support boundary for the validation-host lane and blocks broader
+  host claims that outrun the evidence
+- TL:
+  owns the integrated validation-host, diagnostics, and fail-closed behavior
+  across the code and fixture surfaces
+- contract and docs owner:
+  owns the canonical support-matrix artifact plus the rollout and operator
+  docs derived from it
+- validation owner:
+  owns repo-required unsupported-combination coverage and the validation-host
+  certification lane that bounds the supported host claims
+
 ## Phase 5: Remote VM control-plane contract
 
 Goal:
@@ -172,8 +189,26 @@ Complete when:
   later cloud adapters can consume them without redefining the contract
 - the remote workspace-materialization, brokered-access, and audit contract is
   documented alongside the tests that prove it
+- the owning docs and validation surfaces point later provider phases at the
+  same canonical fake target and conformance harness rather than allowing
+  provider-specific forks of the contract
 
-## Backend phase exit ownership
+Phase 5 exit ownership:
+
+- EM:
+  owns the remote-VM phase boundary, preview-scope guardrails, and the
+  decision that the shared contract is ready for provider-specific reuse
+- TL:
+  owns the fake remote target, shared conformance harness, and deterministic
+  contract integration
+- contract and docs owner:
+  owns the canonical remote-contract docs, support matrices, and operator
+  guidance that later provider phases must reuse
+- validation owner:
+  owns repo-required remote-contract evidence, certification-lane boundaries,
+  and harness reuse requirements for later provider phases
+
+## Phase 6 through Phase 9 exit ownership
 
 The following owner model applies to Phases 6 through 9:
 

--- a/docs/use-case-matrix.md
+++ b/docs/use-case-matrix.md
@@ -14,7 +14,7 @@ Workcell workflows.
 | Use case | Status | Primary evidence |
 |---|---|---|
 | secretless provider launch on the managed path | tested | `scripts/container-smoke.sh`, `scripts/verify-invariants.sh` |
-| provider auth injected through the reviewed policy model | tested for direct staged inputs; built-in resolver coverage remains limited | container smoke, auth-status tests, provider-specific helpers |
+| provider auth injected through the reviewed policy model | tested for direct staged inputs plus Codex host-auth reuse; the Claude macOS resolver remains fail-closed scaffold only | container smoke, auth-status tests, policy tests, provider-specific helpers |
 | host-side policy inspection and credential explainability | tested | `tests/scenarios/shared/test-policy-commands.sh`, `internal/authpolicy/manage_test.go` |
 | host-side signed `publish-pr` handoff | tested | shared scenario tests and invariant checks |
 | repo control-plane masking and provider-home re-seeding | tested | invariants and smoke |


### PR DESCRIPTION
## Summary
- align the active delivery plan with the shipped Phase 3 auth/bootstrap foundation
- tighten Phase 4 ownership around the canonical support matrix and validation-host evidence
- tighten Phase 5+ handoffs so later backend phases reuse one canonical remote-VM contract and conformance harness

## Validation
- bash ./scripts/validate-repo.sh