### PR TITLE
Foundation: guard PR base and serialize scenarios

### DIFF
--- a/.github/workflows/pr-base-policy.yml
+++ b/.github/workflows/pr-base-policy.yml
@@ -1,0 +1,41 @@
+name: PR base policy
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
+      - converted_to_draft
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-base-policy:
+    name: Allowed PR base
+    runs-on: ubuntu-latest
+    env:
+      WORKCELL_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+      WORKCELL_PR_IS_DRAFT: ${{ github.event.pull_request.draft }}
+    steps:
+      - name: Allow supported main-based PRs
+        if: env.WORKCELL_PR_BASE_REF == 'main'
+        run: |
+          echo "main remains the only supported PR base by default."
+
+      - name: Allow lower-assurance non-main draft PRs
+        if: env.WORKCELL_PR_BASE_REF != 'main' && env.WORKCELL_PR_IS_DRAFT == 'true'
+        run: |
+          echo "Non-main PR bases remain lower-assurance draft-only PRs."
+
+      - name: Block unsupported non-main ready PRs
+        if: env.WORKCELL_PR_BASE_REF != 'main' && env.WORKCELL_PR_IS_DRAFT != 'true'
+        run: |
+          echo "Ready pull requests must target main. Non-main PR bases stay draft-only lower-assurance review units." >&2
+          exit 1

--- a/.github/workflows/pr-base-policy.yml
+++ b/.github/workflows/pr-base-policy.yml
@@ -1,6 +1,11 @@
 name: PR base policy
 
 on:
+  # kusari-inspector suppress: trusted metadata-only pull_request_target
+  # exception. Security review: pull_request would let a same-repo PR rewrite
+  # its own ready-state guard, so this workflow must run from trusted
+  # base-branch code with permissions: {}, no checkout, no reusable workflows,
+  # and no external actions.
   pull_request_target:
     types:
       - opened

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -8,6 +8,7 @@ reinforce the runtime boundary and release posture, not replace them.
 | Workflow | Purpose |
 |---|---|
 | `ci.yml` | repository validation, smoke, reproducibility, pin verification, upstream release re-verification, and continuous package install/uninstall verification on pushes and PRs |
+| `pr-base-policy.yml` | trusted base-branch guard that keeps `main` as the supported ready-PR base and leaves non-`main` PR bases as draft-only lower-assurance review units |
 | `docs.yml` | fast spelling and manpage feedback for docs-only changes |
 | `security.yml` | workflow lint, dependency review, and `zizmor` |
 | `codeql.yml` | code scanning for shipped Rust, Go, and JavaScript surfaces |
@@ -110,7 +111,10 @@ conditional:
 
 Workcell does not use:
 
-- `pull_request_target`
+- general-purpose `pull_request_target` workflows; the only exception is
+  `pr-base-policy.yml`, which reads pull-request metadata from trusted
+  base-branch workflow code, keeps top-level `permissions: {}`, and must not
+  check out repository contents or use external actions
 - ambient PAT-style workflow credentials
 - GitHub-hosted macOS claims for the full Colima boundary
 - stale-issue or other bot churn unrelated to the runtime or release posture

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -24,7 +24,7 @@ Use these anchors when checking release-facing claims:
   `shared/claude-resolver-launcher`, `shared/codex-resolver-launcher`
 - lower-assurance mode claims: `shared/assurance-dry-run`
 - local runtime certification smoke: `shared/agent-launch-smoke`
-- host publication handoff: `shared/publish-pr`
+- host publication handoff and main-only PR-base safeguards: `shared/publish-pr`
 - host-side session inventory and control plus detached workspace-mode
   remediation: `shared/session-commands`
 - persistent cache-plane contract checks: `shared/assurance-dry-run`
@@ -56,6 +56,10 @@ logs/timeline, clean-base diff/export behavior, and operator-contract parity.
 `./scripts/validate-repo.sh` runs the repo-required scenario tier through:
 
 - `./scripts/run-scenario-tests.sh --repo-required`
+
+That scenario runner executes serially by default so repo-required checks do
+not race on shared host-side state. Set `WORKCELL_SCENARIO_JOBS` above `1`
+only for explicit local debugging where you accept lower determinism.
 
 ## Local certification smoke
 

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -1814,6 +1814,9 @@ func isSafePullRequestTargetWorkflow(workflowText, workflowPath string) error {
 	if filepath.Base(workflowPath) != "pr-base-policy.yml" {
 		return fmt.Errorf("%s must not contain pull_request_target triggers", workflowPath)
 	}
+	if !strings.Contains(workflowText, "kusari-inspector suppress") {
+		return fmt.Errorf("%s must document the reviewed Kusari suppression for pull_request_target", workflowPath)
+	}
 	if !regexp.MustCompile(`(?m)^permissions:\s*\{\}\s*$`).MatchString(workflowText) {
 		return fmt.Errorf("%s must keep top-level permissions: {}", workflowPath)
 	}

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -62,8 +62,9 @@ func CheckWorkflows(rootDir, policyPath string) error {
 	if err != nil {
 		return err
 	}
-	if len(contexts) == 0 {
-		return fmt.Errorf("%s must define required_status_checks.contexts as a non-empty array", policyPath)
+	requiredJobNames := append([]string{}, contexts...)
+	if len(requiredJobNames) == 0 {
+		return fmt.Errorf("%s must define at least one required status-check context", policyPath)
 	}
 
 	workflowDir := filepath.Join(rootDir, ".github", "workflows")
@@ -88,7 +89,7 @@ func CheckWorkflows(rootDir, policyPath string) error {
 	}
 
 	missing := make([]string, 0)
-	for _, expected := range contexts {
+	for _, expected := range requiredJobNames {
 		if _, ok := jobNames[expected]; !ok {
 			missing = append(missing, expected)
 		}
@@ -1740,7 +1741,9 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 			return fmt.Errorf("workflow-level empty permissions declaration missing in %s", workflowPath)
 		}
 		if strings.Contains(workflowText, "pull_request_target") {
-			return fmt.Errorf("%s must not contain pull_request_target triggers", workflowPath)
+			if err := isSafePullRequestTargetWorkflow(workflowText, workflowPath); err != nil {
+				return err
+			}
 		}
 		if regexp.MustCompile(`secrets\.[A-Z0-9_]*(?:PAT|PERSONAL_ACCESS_TOKEN)\b|GH_PAT\b|PERSONAL_ACCESS_TOKEN\b`).MatchString(workflowText) {
 			return fmt.Errorf("%s must not contain long-lived personal access tokens", workflowPath)
@@ -1805,6 +1808,28 @@ func requireStringSliceTable(root map[string]any, tableName, key, sourcePath str
 		}
 	}
 	return values, nil
+}
+
+func isSafePullRequestTargetWorkflow(workflowText, workflowPath string) error {
+	if filepath.Base(workflowPath) != "pr-base-policy.yml" {
+		return fmt.Errorf("%s must not contain pull_request_target triggers", workflowPath)
+	}
+	if !regexp.MustCompile(`(?m)^permissions:\s*\{\}\s*$`).MatchString(workflowText) {
+		return fmt.Errorf("%s must keep top-level permissions: {}", workflowPath)
+	}
+	if regexp.MustCompile(`(?m)^[[:space:]]{2,}permissions:`).MatchString(workflowText) {
+		return fmt.Errorf("%s must not grant job-level permissions under pull_request_target", workflowPath)
+	}
+	if regexp.MustCompile(`(?m)^[[:space:]]{4,}uses:\s+`).MatchString(workflowText) {
+		return fmt.Errorf("%s must not call reusable workflows under pull_request_target", workflowPath)
+	}
+	if strings.Contains(workflowText, "actions/checkout@") {
+		return fmt.Errorf("%s must not checkout repository contents when using pull_request_target", workflowPath)
+	}
+	if regexp.MustCompile(`(?m)^\s*-\s+uses:\s+`).MatchString(workflowText) {
+		return fmt.Errorf("%s must not use external actions when using pull_request_target", workflowPath)
+	}
+	return nil
 }
 
 func mustGlob(pattern string) []string {

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -113,7 +113,7 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 		`mode = "` + releaseMode + `"`,
 		"",
 		"[required_status_checks]",
-		`contexts = ["Validate repository"]`,
+		`contexts = ["Allowed PR base", "Validate repository"]`,
 		"",
 		"[repository_variables]",
 		`WORKCELL_ENABLE_GITHUB_ATTESTATIONS = "true"`,
@@ -214,6 +214,7 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 					"parameters": map[string]any{
 						"strict_required_status_checks_policy": true,
 						"required_status_checks": []map[string]any{
+							{"context": "Allowed PR base"},
 							{"context": "Validate repository"},
 						},
 					},

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -160,11 +160,30 @@ jobs:
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(security.yml) error = %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "pr-base-policy.yml"), []byte(`name: PR base policy
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions: {}
+
+jobs:
+  pr-base-policy:
+    name: Allowed PR base
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(pr-base-policy.yml) error = %v", err)
+	}
 	writeWorkflowValidationFixtures(t, workflowDir)
 
 	policyPath := filepath.Join(root, "policy.toml")
 	if err := os.WriteFile(policyPath, []byte(`[required_status_checks]
 contexts = [
+  "Allowed PR base",
   "Validate repository",
   "Container smoke",
   "Reproducible build",
@@ -221,6 +240,113 @@ contexts = [
 	}
 	if !strings.Contains(err.Error(), "Validate repository") {
 		t.Fatalf("CheckWorkflows() error = %v, want missing Validate repository", err)
+	}
+}
+
+func TestSafePullRequestTargetWorkflowAllowsTrustedPRBasePolicy(t *testing.T) {
+	t.Parallel()
+
+	workflow := `name: PR base policy
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions: {}
+
+jobs:
+  pr-base-policy:
+    name: Allowed PR base
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`
+	if err := isSafePullRequestTargetWorkflow(workflow, ".github/workflows/pr-base-policy.yml"); err != nil {
+		t.Fatalf("isSafePullRequestTargetWorkflow() error = %v", err)
+	}
+}
+
+func TestSafePullRequestTargetWorkflowRejectsCheckout(t *testing.T) {
+	t.Parallel()
+
+	workflow := `name: PR base policy
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions: {}
+
+jobs:
+  pr-base-policy:
+    name: Allowed PR base
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+`
+	err := isSafePullRequestTargetWorkflow(workflow, ".github/workflows/pr-base-policy.yml")
+	if err == nil {
+		t.Fatal("isSafePullRequestTargetWorkflow() unexpectedly accepted checkout under pull_request_target")
+	}
+	if !strings.Contains(err.Error(), "must not checkout repository contents") {
+		t.Fatalf("isSafePullRequestTargetWorkflow() error = %v, want checkout rejection", err)
+	}
+}
+
+func TestSafePullRequestTargetWorkflowRejectsJobLevelPermissions(t *testing.T) {
+	t.Parallel()
+
+	workflow := `name: PR base policy
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions: {}
+
+jobs:
+  pr-base-policy:
+    name: Allowed PR base
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: true
+`
+	err := isSafePullRequestTargetWorkflow(workflow, ".github/workflows/pr-base-policy.yml")
+	if err == nil {
+		t.Fatal("isSafePullRequestTargetWorkflow() unexpectedly accepted job-level permissions under pull_request_target")
+	}
+	if !strings.Contains(err.Error(), "must not grant job-level permissions") {
+		t.Fatalf("isSafePullRequestTargetWorkflow() error = %v, want job-level permissions rejection", err)
+	}
+}
+
+func TestSafePullRequestTargetWorkflowRejectsReusableWorkflowCalls(t *testing.T) {
+	t.Parallel()
+
+	workflow := `name: PR base policy
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions: {}
+
+jobs:
+  pr-base-policy:
+    uses: ./.github/workflows/reusable.yml
+`
+	err := isSafePullRequestTargetWorkflow(workflow, ".github/workflows/pr-base-policy.yml")
+	if err == nil {
+		t.Fatal("isSafePullRequestTargetWorkflow() unexpectedly accepted reusable workflow invocation under pull_request_target")
+	}
+	if !strings.Contains(err.Error(), "must not call reusable workflows") {
+		t.Fatalf("isSafePullRequestTargetWorkflow() error = %v, want reusable workflow rejection", err)
 	}
 }
 

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -249,6 +249,7 @@ func TestSafePullRequestTargetWorkflowAllowsTrustedPRBasePolicy(t *testing.T) {
 	workflow := `name: PR base policy
 
 on:
+  # kusari-inspector suppress: trusted metadata-only pull_request_target exception.
   pull_request_target:
     types:
       - opened
@@ -273,6 +274,7 @@ func TestSafePullRequestTargetWorkflowRejectsCheckout(t *testing.T) {
 	workflow := `name: PR base policy
 
 on:
+  # kusari-inspector suppress: trusted metadata-only pull_request_target exception.
   pull_request_target:
     types:
       - opened
@@ -301,6 +303,7 @@ func TestSafePullRequestTargetWorkflowRejectsJobLevelPermissions(t *testing.T) {
 	workflow := `name: PR base policy
 
 on:
+  # kusari-inspector suppress: trusted metadata-only pull_request_target exception.
   pull_request_target:
     types:
       - opened
@@ -331,6 +334,7 @@ func TestSafePullRequestTargetWorkflowRejectsReusableWorkflowCalls(t *testing.T)
 	workflow := `name: PR base policy
 
 on:
+  # kusari-inspector suppress: trusted metadata-only pull_request_target exception.
   pull_request_target:
     types:
       - opened
@@ -347,6 +351,34 @@ jobs:
 	}
 	if !strings.Contains(err.Error(), "must not call reusable workflows") {
 		t.Fatalf("isSafePullRequestTargetWorkflow() error = %v, want reusable workflow rejection", err)
+	}
+}
+
+func TestSafePullRequestTargetWorkflowRequiresSuppressionComment(t *testing.T) {
+	t.Parallel()
+
+	workflow := `name: PR base policy
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions: {}
+
+jobs:
+  pr-base-policy:
+    name: Allowed PR base
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`
+	err := isSafePullRequestTargetWorkflow(workflow, ".github/workflows/pr-base-policy.yml")
+	if err == nil {
+		t.Fatal("isSafePullRequestTargetWorkflow() unexpectedly accepted a pull_request_target workflow without a Kusari suppression comment")
+	}
+	if !strings.Contains(err.Error(), "must document the reviewed Kusari suppression") {
+		t.Fatalf("isSafePullRequestTargetWorkflow() error = %v, want Kusari suppression rejection", err)
 	}
 }
 

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -40,6 +40,7 @@ mode = "review-gated"
 
 [required_status_checks]
 contexts = [
+  "Allowed PR base",
   "Pull request shape",
   "Validate repository",
   "Container smoke",

--- a/scripts/run-scenario-tests.sh
+++ b/scripts/run-scenario-tests.sh
@@ -46,8 +46,20 @@ if [[ "${RUN_ALL}" -eq 1 ]] && [[ "${TIER_SELECTION_EXPLICIT}" -eq 0 ]]; then
 fi
 
 CURRENT_PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
+SCENARIO_JOBS="${WORKCELL_SCENARIO_JOBS:-1}"
 SCENARIO_LIST="$(mktemp "${TMPDIR:-/tmp}/workcell-scenarios.XXXXXX")"
 RESULTS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-scenario-results.XXXXXX")"
+
+case "${SCENARIO_JOBS}" in
+  '' | *[!0-9]*)
+    echo "WORKCELL_SCENARIO_JOBS must be a positive integer." >&2
+    exit 1
+    ;;
+  0)
+    echo "WORKCELL_SCENARIO_JOBS must be at least 1." >&2
+    exit 1
+    ;;
+esac
 
 cleanup() {
   rm -f "${SCENARIO_LIST}"
@@ -139,25 +151,47 @@ if ! "${ROOT_DIR}/scripts/lib/scenario_manifest" list-tsv "${MANIFEST}" >"${SCEN
   exit 1
 fi
 
-# Run all scenarios in parallel; each writes its exit code to a per-index file.
 idx=0
-declare -a pids=()
+run_scenario_record() {
+  local result_file="$1"
+  shift
 
-while IFS=$'\t' read -r scenario_id test_file requires_creds lane platform validation_tier manual; do
-  idx=$((idx + 1))
-  result_file="${RESULTS_DIR}/${idx}.exit"
   (
     exit_code=0
-    run_scenario "${scenario_id}" "${test_file}" "${requires_creds}" "${lane}" "${platform}" "${validation_tier}" "${manual}" || exit_code="$?"
+    run_scenario "$@" || exit_code="$?"
     printf '%d\n' "${exit_code}" >"${result_file}"
-  ) &
-  pids+=($!)
-done <"${SCENARIO_LIST}"
+  )
+}
 
-# Wait for all background jobs to complete
-for pid in "${pids[@]}"; do
-  wait "${pid}" || true
-done
+if [[ "${SCENARIO_JOBS}" -eq 1 ]]; then
+  while IFS=$'\t' read -r scenario_id test_file requires_creds lane platform validation_tier manual; do
+    idx=$((idx + 1))
+    result_file="${RESULTS_DIR}/${idx}.exit"
+    run_scenario_record "${result_file}" \
+      "${scenario_id}" "${test_file}" "${requires_creds}" "${lane}" "${platform}" "${validation_tier}" "${manual}"
+  done <"${SCENARIO_LIST}"
+else
+  # Explicit opt-in parallel mode for local debugging; repo-required validation
+  # stays serial by default because several scenarios share host-side state.
+  declare -a pids=()
+  running_jobs=0
+  while IFS=$'\t' read -r scenario_id test_file requires_creds lane platform validation_tier manual; do
+    idx=$((idx + 1))
+    result_file="${RESULTS_DIR}/${idx}.exit"
+    run_scenario_record "${result_file}" \
+      "${scenario_id}" "${test_file}" "${requires_creds}" "${lane}" "${platform}" "${validation_tier}" "${manual}" &
+    pids+=($!)
+    running_jobs=$((running_jobs + 1))
+    if [[ "${running_jobs}" -ge "${SCENARIO_JOBS}" ]]; then
+      wait -n || true
+      running_jobs=$((running_jobs - 1))
+    fi
+  done <"${SCENARIO_LIST}"
+
+  for pid in "${pids[@]}"; do
+    wait "${pid}" || true
+  done
+fi
 
 # Aggregate results from per-scenario exit files.
 # Exit codes: 0 = pass, 1 = fail, 2 = skip


### PR DESCRIPTION
## Summary
- add the trusted Allowed PR base workflow plus hosted-control metadata validation for the narrow pull_request_target exception
- serialize repo-required scenario execution by default and keep bounded parallelism as an explicit opt-in

## Validation
- `bash ./scripts/validate-repo.sh`