### PR TITLE
Default publish-pr to main-based review units

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -69,6 +69,9 @@ for convenience.
 - Sign every commit.
 - Use feature branches. Do not push directly to `main` or rewrite history.
 - Treat final GitHub publication as a host-side action.
+- Default remote review units to `main`-based pull requests. Keep non-`main`
+  base PRs draft-only and non-mergeable, and do not treat them as carrying the
+  same repo-owned PR validation guarantees as `main`-based review units.
 - For publish, PR follow-up, or merge work in this repository, use the
   repo-local `workcell-pr-lifecycle` skill. Treat generic GitHub publication
   skills as fallback only when the repo-local lifecycle instructions do not

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -59,6 +59,10 @@ If the task is release-bound, also read:
 
 - Final GitHub publication is a host-side action. Use `./scripts/workcell
   publish-pr`; do not normalize direct publication from the Tier 1 session.
+- `main` is the only supported PR base by default. If a lower-assurance
+  non-`main` base path exists, keep that PR draft-only, treat it as
+  non-mergeable, and do not claim the normal `main`-based repo-owned
+  validation or merge gating exists for that branch shape.
 - Keep PRs reviewer-sized and single-purpose. Split broad work before
   publication.
 - Sign every commit and use feature branches.
@@ -87,7 +91,8 @@ If the task is release-bound, also read:
 2. Create signed commits using the repo-local `commit` skill.
 3. Run the focused local validation for the change before publication.
 4. Publish with host-side `./scripts/workcell publish-pr` using a draft PR by
-   default.
+   default and targeting `main` unless an explicit lower-assurance exception is
+   part of the task.
 5. Follow repo-owned checks to completion.
 6. If a repo-owned check fails:
    - inspect the failing GitHub Actions logs or PR checks
@@ -98,7 +103,8 @@ If the task is release-bound, also read:
 7. Sweep top-level comments, inline comments, unresolved threads, and async
    reviewer feedback.
 8. When checks are green and no actionable findings remain, mark the PR ready
-   unless the user explicitly asked to keep it draft.
+   unless the user explicitly asked to keep it draft. Do not mark non-`main`
+   base PRs ready; they stay lower-assurance draft-only review units.
 9. After marking ready, re-check checks and review surfaces again.
 10. If merge is part of the task, repeat the review sweep immediately before
     merge, merge, then follow merged `main` workflows until repo-owned lanes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,10 @@ the runtime boundary or explicit security guarantees in the name of convenience.
 - For publish, PR follow-up, or merge requests in this repository, use the
   repo-local `workcell-pr-lifecycle` skill. Repo-local publication rules
   override generic GitHub publication skills.
+- `main` is the only supported PR base by default. Non-`main` base PRs are
+  lower-assurance exceptions: keep them draft, do not merge them, and do not
+  expect the normal `main`-based repo-owned validation or merge gating for
+  that branch shape.
 - Every PR should remain open for comments and review before merge.
 - Every PR must be checked for:
   - top-level PR comments

--- a/README.md
+++ b/README.md
@@ -249,7 +249,10 @@ Other defaults that matter:
 - there is no separate "start a container, then attach the agent" step
 - `publish-pr` runs on the host so signed commits and GitHub publication stay
   outside the Tier 1 container, and it blocks over-broad branch diffs before
-  push so published PRs stay reviewable
+  push so published PRs stay reviewable; `main` is the only supported PR base
+  by default, and non-`main` bases remain an explicit lower-assurance draft-only
+  escape hatch with an explicit preflight warning that repo-owned PR checks are
+  not expected for that base
 - completed and aborted launches are recorded as durable host-side session
   records that you can inspect with `workcell session ...`
 - `workcell session diff` compares the current workspace against the clean git
@@ -288,6 +291,12 @@ workcell --agent codex --auth-status --workspace /path/to/repo
 ./scripts/publish-provider-bump-pr.sh
 workcell --logs audit --colima-profile wcl-...
 workcell publish-pr --workspace /path/to/repo --branch feature/name \
+  --title-file /tmp/pr-title.txt \
+  --body-file /tmp/pr-body.md \
+  --commit-message-file /tmp/commit-message.txt
+# Lower-assurance exception: non-main bases stay draft-only.
+workcell publish-pr --workspace /path/to/repo --branch feature/name \
+  --base feature/review-stack --allow-non-main-base \
   --title-file /tmp/pr-title.txt \
   --body-file /tmp/pr-body.md \
   --commit-message-file /tmp/commit-message.txt

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -370,6 +370,11 @@ as
 Prepare a host-side publication flow for the mounted workspace: switch to or
 create a feature branch, optionally stage the worktree, create a signed commit,
 push it, and open a GitHub pull request using host Git and GitHub CLI state.
+The supported base branch is
+.BR main ;
+non-main bases remain an explicit lower-assurance draft-only escape hatch.
+Dry-run output reports whether repo-owned PR checks are expected for the chosen
+base.
 Use
 \fB--gh-bin\fR
 to pin an explicit host GitHub CLI binary when needed, or use
@@ -639,6 +644,14 @@ Publishing a prepared workspace snapshot from the host side:
 .IP
 .EX
 workcell publish-pr --workspace /path/to/repo --branch feature/name \\
+  --title-file /tmp/pr-title.txt --body-file /tmp/pr-body.md \\
+  --commit-message-file /tmp/commit-message.txt
+.EE
+.IP
+.EX
+# Lower-assurance exception: non-main bases stay draft-only.
+workcell publish-pr --workspace /path/to/repo --branch feature/name \\
+  --base feature/review-stack --allow-non-main-base \\
   --title-file /tmp/pr-title.txt --body-file /tmp/pr-body.md \\
   --commit-message-file /tmp/commit-message.txt
 .EE

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -68,7 +68,7 @@ docs = [
 
 [functional.FR-005]
 title = "Host-side publication handoff"
-summary = "Final branch publication remains a host-side action with signed commits and repo hook bypasses handled outside Tier 1."
+summary = "Final branch publication remains a host-side action with signed commits and repo hook bypasses handled outside Tier 1, with main as the supported PR base by default and any non-main base kept draft-only as a lower-assurance exception."
 workflows = ["publish_pr"]
 evidence = [
   "tests/scenarios/shared/test-publish-pr-dry-run.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "6f19f924b2041423d564099c9432ec3414e861fa228b2fcb2b15816b3074ce08"
+      "sha256": "8c486e5e0f3bf337143210bc8181a2a27b948c6aa1022dfc99bda4d1bdbba15b"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -67,6 +67,33 @@ assert_output_matches_regex() {
   fi
 }
 
+extract_named_function_block() {
+  local file_path="$1"
+  local function_name="$2"
+
+  sed -n "/^${function_name}()/,/^}/p" "${file_path}"
+}
+
+function_block_contains_regex() {
+  local file_path="$1"
+  local function_name="$2"
+  local regex="$3"
+  local block_text=""
+
+  block_text="$(extract_named_function_block "${file_path}" "${function_name}")"
+  grep -q -- "${regex}" <<<"${block_text}"
+}
+
+function_block_contains_fixed() {
+  local file_path="$1"
+  local function_name="$2"
+  local needle="$3"
+  local block_text=""
+
+  block_text="$(extract_named_function_block "${file_path}" "${function_name}")"
+  grep -Fq -- "${needle}" <<<"${block_text}"
+}
+
 script_supports_command_flag() {
   local script_help=""
 
@@ -1124,7 +1151,7 @@ fi
 
 rm -rf "${codex_managed_config_tmpdir}"
 
-if ! sed -n '/^run_host_colima()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq "HOME=\"\${REAL_HOME}\""; then
+if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "run_host_colima" "HOME=\"\${REAL_HOME}\""; then
   echo "Expected run_host_colima to restore the real host HOME instead of the Docker client sandbox home" >&2
   exit 1
 fi
@@ -2773,17 +2800,17 @@ if ! rg -q 'bootstrap_policy=allowlist endpoints=%s' "${ROOT_DIR}/scripts/workce
   exit 1
 fi
 
-if ! sed -n '/^validate_colima_profile()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'validate_colima_profile_config'; then
+if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "validate_colima_profile" 'validate_colima_profile_config'; then
   echo "Expected validate_colima_profile to re-check the managed Colima config before reusing a running profile" >&2
   exit 1
 fi
 
-if ! sed -n '/^git_alias_value_is_blocked()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'git_commit_short_arg_is_no_verify'; then
+if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "git_alias_value_is_blocked" 'git_commit_short_arg_is_no_verify'; then
   echo "Expected git_alias_value_is_blocked to reuse the precise short-option no-verify parser" >&2
   exit 1
 fi
 
-if ! sed -n '/^resolve_existing_executable_or_die()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'is_trusted_host_tool_path'; then
+if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "resolve_existing_executable_or_die" 'is_trusted_host_tool_path'; then
   echo "Expected resolve_existing_executable_or_die to reject untrusted host executable paths" >&2
   exit 1
 fi
@@ -2797,28 +2824,28 @@ for _git_env_var in GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_IN
   fi
 done
 
-if ! sed -n '/^git_index_materialize_regular_file()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'cat-file blob'; then
+if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "git_index_materialize_regular_file" 'cat-file blob'; then
   echo "Expected git_index_materialize_regular_file to materialize tracked blobs without checkout-index" >&2
   exit 1
 fi
 
-if ! sed -n '/^git_index_materialize_regular_file()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'failed to read tracked blob'; then
+if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "git_index_materialize_regular_file" 'failed to read tracked blob'; then
   echo "Expected git_index_materialize_regular_file to fail closed when a tracked control-plane blob is unreadable" >&2
   exit 1
 fi
 
 # shellcheck disable=SC2016
-if ! sed -n '/^git_index_materialize_regular_file()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq 'rm -f "${destination_path}"'; then
+if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "git_index_materialize_regular_file" 'rm -f "${destination_path}"'; then
   echo "Expected git_index_materialize_regular_file to remove partially materialized files after blob read failures" >&2
   exit 1
 fi
 
-if ! sed -n '/^git_index_populate_shadow_dir()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq '*/../*'; then
+if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "git_index_populate_shadow_dir" '*/../*'; then
   echo "Expected git_index_populate_shadow_dir to reject unsafe index paths before shadow materialization" >&2
   exit 1
 fi
 
-if ! sed -n '/^sanitize_shadowed_git_config()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'git_config_key_is_blocked'; then
+if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "sanitize_shadowed_git_config" 'git_config_key_is_blocked'; then
   echo "Expected sanitize_shadowed_git_config to reuse the shared blocked git-config key matcher" >&2
   exit 1
 fi
@@ -2860,27 +2887,27 @@ if [[ "${go_cache_root_actual}" != "${go_cache_root_expected}" ]]; then
   exit 1
 fi
 
-if ! sed -n '/^validate_publish_base_name()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'check-ref-format'; then
+if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "validate_publish_base_name" 'check-ref-format'; then
   echo "Expected validate_publish_base_name to validate the publish-pr --base branch name" >&2
   exit 1
 fi
 
-if ! sed -n '/^publish_pr_main()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q 'core.hooksPath=/dev/null'; then
+if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "publish_pr_main" 'core.hooksPath=/dev/null'; then
   echo "Expected publish_pr_main to disable repo hooks for host-side publish git commands" >&2
   exit 1
 fi
 
-if ! sed -n '/^publish_pr_main()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -q -- '--no-verify'; then
+if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "publish_pr_main" '--no-verify'; then
   echo "Expected publish_pr_main to bypass repo hooks explicitly on host-side commit and push" >&2
   exit 1
 fi
 
-if ! sed -n '/^add_shadow_git_hooks_mount()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq "copy_tree_without_symlinks"; then
+if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "add_shadow_git_hooks_mount" "copy_tree_without_symlinks"; then
   echo "Expected add_shadow_git_hooks_mount to avoid copying symlinked hook content into the readonly shadow" >&2
   exit 1
 fi
 
-if ! sed -n '/^add_shadow_git_config_mount()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | grep -Fq "! -L \"\${source_path}\""; then
+if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "add_shadow_git_config_mount" "! -L \"\${source_path}\""; then
   echo "Expected add_shadow_git_config_mount to ignore symlinked git config files" >&2
   exit 1
 fi
@@ -3618,11 +3645,11 @@ if ! rg -q '^render_clear_plan\(\)' "${ROOT_DIR}/scripts/colima-egress-allowlist
   echo "Expected dual-stack allowlist helper to render clear rules in the VM apply plan" >&2
   exit 1
 fi
-if ! sed -n '/^render_allowlist_apply_plan()/,/^}/p' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" | grep -q 'render_clear_plan'; then
+if ! function_block_contains_regex "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" "render_allowlist_apply_plan" 'render_clear_plan'; then
   echo "Expected dual-stack allowlist apply plan to include render_clear_plan" >&2
   exit 1
 fi
-if sed -n '/^render_allowlist_apply_plan()/,/^}/p' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" | grep -q '^[[:space:]]*clear_rules$'; then
+if function_block_contains_regex "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" "render_allowlist_apply_plan" '^[[:space:]]*clear_rules$'; then
   echo "Expected dual-stack allowlist apply plan to avoid invoking clear_rules during render" >&2
   exit 1
 fi

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -5313,6 +5313,9 @@ PUBLISH_PR_DRY_RUN="$("${ROOT_DIR}/scripts/workcell" publish-pr \
   --dry-run)"
 grep -q '^publish_snapshot=worktree$' <<<"${PUBLISH_PR_DRY_RUN}"
 grep -q '^publish_branch=feature/publish-fixture$' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q '^publish_base=main$' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q '^publish_base_mode=main$' <<<"${PUBLISH_PR_DRY_RUN}"
+grep -q '^publish_repo_owned_pr_checks_expected=1$' <<<"${PUBLISH_PR_DRY_RUN}"
 grep -q -- ' -c core.hooksPath=/dev/null -C ' <<<"${PUBLISH_PR_DRY_RUN}"
 grep -q -- 'switch --no-guess -c feature/publish-fixture' <<<"${PUBLISH_PR_DRY_RUN}"
 grep -q -- ' add -A ' <<<"${PUBLISH_PR_DRY_RUN}"
@@ -5382,6 +5385,35 @@ if "${ROOT_DIR}/scripts/workcell" publish-pr \
   exit 1
 fi
 grep -q 'Invalid publish base branch name: topic.lock' /tmp/workcell-publish-pr-invalid-base.out
+
+if "${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${PUBLISH_PR_FIXTURE}" \
+  --branch feature/publish-non-main-base \
+  --base feature/review-stack \
+  --title "Unsupported non-main base" \
+  --commit-message "Unsupported non-main base commit" \
+  --dry-run >/tmp/workcell-publish-pr-non-main-base.out 2>&1; then
+  echo "Expected publish-pr to reject a non-main base branch without the explicit lower-assurance override" >&2
+  exit 1
+fi
+grep -q 'publish-pr only supports --base main by default' /tmp/workcell-publish-pr-non-main-base.out
+
+PUBLISH_PR_NON_MAIN_DRY_RUN="$("${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${PUBLISH_PR_FIXTURE}" \
+  --branch feature/publish-non-main-base \
+  --base feature/review-stack \
+  --allow-non-main-base \
+  --title "Lower assurance non-main base" \
+  --commit-message "Lower assurance non-main base commit" \
+  --ready \
+  --dry-run 2>&1)"
+grep -q '^publish_base=feature/review-stack$' <<<"${PUBLISH_PR_NON_MAIN_DRY_RUN}"
+grep -q '^publish_base_mode=lower-assurance-non-main$' <<<"${PUBLISH_PR_NON_MAIN_DRY_RUN}"
+grep -q '^publish_repo_owned_pr_checks_expected=0$' <<<"${PUBLISH_PR_NON_MAIN_DRY_RUN}"
+grep -q '^publish_draft=1$' <<<"${PUBLISH_PR_NON_MAIN_DRY_RUN}"
+grep -q 'publish-pr preflight: repo-owned PR checks are not expected for --base feature/review-stack' <<<"${PUBLISH_PR_NON_MAIN_DRY_RUN}"
+grep -q 'normal main-based PR validation and merge gating do not apply to that PR shape' <<<"${PUBLISH_PR_NON_MAIN_DRY_RUN}"
+grep -q -- "gh pr create --base feature/review-stack --head feature/publish-non-main-base --title Lower\\\\ assurance\\\\ non-main\\\\ base --draft --body ''" <<<"${PUBLISH_PR_NON_MAIN_DRY_RUN}"
 
 cat <<'EOF' >"${PUBLISH_PR_FIXTURE}/gh-untrusted"
 #!/usr/bin/env bash

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -2580,6 +2580,7 @@ Options:
   --workspace PATH              Workspace to publish (default: current directory)
   --branch NAME                 Feature branch to create or switch to (required)
   --base NAME                   Base branch for the PR (default: main)
+  --allow-non-main-base         Allow a lower-assurance draft PR against a non-main base
   --gh-bin PATH                 Host GitHub CLI to use for PR creation
   --snapshot index|worktree     Publish the current index or stage the worktree (default: worktree)
   --title TEXT                  PR title
@@ -2598,6 +2599,13 @@ Notes:
     and publication stay outside the Tier 1 container boundary.
   - It blocks over-broad branch diffs before push so published PRs stay
     reviewable by a human without juggling unrelated concerns.
+  - By default publish-pr only supports --base main because repo-owned PR
+    workflows and hosted controls only cover main-based review units.
+  - --allow-non-main-base is an explicit lower-assurance escape hatch: the PR
+    stays draft-only and the normal main-based PR validation and merge gating
+    do not apply to that PR shape.
+  - publish-pr preflights whether repo-owned PR checks are expected for the
+    chosen base and surfaces the effective validation mode in dry-run output.
   - Host-side git commands explicitly bypass repo hooks during publication
     because workspace hook content is untrusted; signed commits remain
     mandatory.
@@ -2718,6 +2726,7 @@ validate_publish_branch_name() {
 
 validate_publish_base_name() {
   local base="$1"
+  local allow_non_main_base="$2"
 
   if [[ -z "${base}" ]]; then
     echo "publish-pr requires a non-empty --base branch name." >&2
@@ -2725,6 +2734,10 @@ validate_publish_base_name() {
   fi
   if ! "${HOST_GIT_BIN}" check-ref-format --branch "${base}" >/dev/null 2>&1; then
     echo "Invalid publish base branch name: ${base}" >&2
+    exit 2
+  fi
+  if [[ "${base}" != "main" ]] && [[ "${allow_non_main_base}" -ne 1 ]]; then
+    echo "publish-pr only supports --base main by default. Use --allow-non-main-base for an explicit lower-assurance draft PR." >&2
     exit 2
   fi
 }
@@ -2789,10 +2802,21 @@ publish_pr_has_staged_changes() {
   ! run_clean_host_command_in_dir "${workspace}" "${HOST_GIT_BIN}" diff --cached --quiet --exit-code
 }
 
+publish_pr_repo_owned_checks_expected() {
+  local base="$1"
+
+  if [[ "${base}" == "main" ]]; then
+    printf '1'
+  else
+    printf '0'
+  fi
+}
+
 publish_pr_main() {
   local workspace="${PWD}"
   local branch=""
   local base="main"
+  local allow_non_main_base=0
   local gh_bin=""
   local snapshot="worktree"
   local title=""
@@ -2811,6 +2835,8 @@ publish_pr_main() {
   local resolved_commit_message_file=""
   local pr_url=""
   local shape_base_ref=""
+  local publish_base_mode="main"
+  local repo_owned_pr_checks_expected="1"
   local -a cleanup_files=()
   local -a branch_cmd=()
   local -a add_cmd=()
@@ -2834,6 +2860,10 @@ publish_pr_main() {
       --base)
         base="$(option_value_or_die "$1" "${2-}")"
         shift 2
+        ;;
+      --allow-non-main-base)
+        allow_non_main_base=1
+        shift
         ;;
       --gh-bin)
         gh_bin="$(option_value_or_die "$1" "${2-}")"
@@ -2895,7 +2925,7 @@ publish_pr_main() {
   fi
   validate_publish_snapshot_name "${snapshot}"
   validate_publish_branch_name "${branch}"
-  validate_publish_base_name "${base}"
+  validate_publish_base_name "${base}" "${allow_non_main_base}"
   if [[ -n "${gh_bin}" ]]; then
     HOST_GH_BIN="$(resolve_existing_executable_or_die "${gh_bin}" "gh-bin")"
   elif [[ -n "${HOST_GH_BIN:-}" ]]; then
@@ -2926,6 +2956,13 @@ publish_pr_main() {
   if [[ -z "${commit_message_text}" ]]; then
     echo "publish-pr requires a non-empty commit message." >&2
     exit 2
+  fi
+  repo_owned_pr_checks_expected="$(publish_pr_repo_owned_checks_expected "${base}")"
+  if [[ "${base}" != "main" ]]; then
+    publish_base_mode="lower-assurance-non-main"
+    echo "publish-pr preflight: repo-owned PR checks are not expected for --base ${base}; use this only for an explicit lower-assurance draft review unit." >&2
+    echo "publish-pr lower-assurance mode: non-main --base stays draft and the normal main-based PR validation and merge gating do not apply to that PR shape." >&2
+    ready=0
   fi
 
   if [[ "${snapshot}" == "worktree" ]]; then
@@ -2978,6 +3015,8 @@ publish_pr_main() {
     printf 'publish_snapshot=%s\n' "${snapshot}"
     printf 'publish_branch=%s\n' "${branch}"
     printf 'publish_base=%s\n' "${base}"
+    printf 'publish_base_mode=%s\n' "${publish_base_mode}"
+    printf 'publish_repo_owned_pr_checks_expected=%s\n' "${repo_owned_pr_checks_expected}"
     printf 'publish_draft=%s\n' "$([[ "${ready}" -eq 0 ]] && printf '1' || printf '0')"
     emit_command "${branch_cmd[@]}"
     if [[ "${snapshot}" == "worktree" ]]; then

--- a/tests/scenarios/manifest.json
+++ b/tests/scenarios/manifest.json
@@ -70,7 +70,7 @@
     },
     {
       "id": "shared/publish-pr",
-      "description": "Host-side publish-pr covers dry-run command rendering plus a signed local publication handoff with repo hooks bypassed",
+      "description": "Host-side publish-pr covers dry-run command rendering, main-only base enforcement, and the explicit lower-assurance non-main draft handoff with repo hooks bypassed",
       "lane": "secretless",
       "platform": "any",
       "manual": false,

--- a/tests/scenarios/shared/test-publish-pr-dry-run.sh
+++ b/tests/scenarios/shared/test-publish-pr-dry-run.sh
@@ -129,6 +129,8 @@ worktree_dry_run="$("${ROOT_DIR}/scripts/workcell" publish-pr \
 grep -q '^publish_snapshot=worktree$' <<<"${worktree_dry_run}"
 grep -q '^publish_branch=feature/publish-scenario$' <<<"${worktree_dry_run}"
 grep -q '^publish_base=main$' <<<"${worktree_dry_run}"
+grep -q '^publish_base_mode=main$' <<<"${worktree_dry_run}"
+grep -q '^publish_repo_owned_pr_checks_expected=1$' <<<"${worktree_dry_run}"
 grep -q '^publish_draft=1$' <<<"${worktree_dry_run}"
 grep -q -- ' -c core.hooksPath=/dev/null -C ' <<<"${worktree_dry_run}"
 grep -q -- 'switch --no-guess -c feature/publish-scenario' <<<"${worktree_dry_run}"
@@ -179,6 +181,36 @@ default_branch_rc=$?
 set -e
 test "${default_branch_rc}" -eq 2
 grep -q 'publish-pr refuses the default branch' <<<"${default_branch_output}"
+
+set +e
+unsupported_base_output="$("${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${FIXTURE}" \
+  --branch feature/non-main-base \
+  --base feature/review-stack \
+  --title "Unsupported non-main base" \
+  --commit-message "Unsupported non-main base" \
+  --dry-run 2>&1)"
+unsupported_base_rc=$?
+set -e
+test "${unsupported_base_rc}" -eq 2
+grep -q 'publish-pr only supports --base main by default' <<<"${unsupported_base_output}"
+
+allowed_non_main_dry_run="$("${ROOT_DIR}/scripts/workcell" publish-pr \
+  --workspace "${FIXTURE}" \
+  --branch feature/non-main-base \
+  --base feature/review-stack \
+  --allow-non-main-base \
+  --title "Lower assurance non-main base" \
+  --commit-message "Lower assurance non-main base" \
+  --ready \
+  --dry-run 2>&1)"
+grep -q '^publish_base=feature/review-stack$' <<<"${allowed_non_main_dry_run}"
+grep -q '^publish_base_mode=lower-assurance-non-main$' <<<"${allowed_non_main_dry_run}"
+grep -q '^publish_repo_owned_pr_checks_expected=0$' <<<"${allowed_non_main_dry_run}"
+grep -q '^publish_draft=1$' <<<"${allowed_non_main_dry_run}"
+grep -q 'publish-pr preflight: repo-owned PR checks are not expected for --base feature/review-stack' <<<"${allowed_non_main_dry_run}"
+grep -q 'normal main-based PR validation and merge gating do not apply to that PR shape' <<<"${allowed_non_main_dry_run}"
+grep -q -- "gh pr create --base feature/review-stack --head feature/non-main-base --title Lower\\\\ assurance\\\\ non-main\\\\ base --draft --body ''" <<<"${allowed_non_main_dry_run}"
 
 no_remote_fixture="${TMP_DIR}/publish-pr-no-remote"
 git init -q "${no_remote_fixture}"


### PR DESCRIPTION
## Summary
- default `workcell publish-pr` to `main`-based review units and reject non-`main` bases unless the operator opts into a lower-assurance draft path
- surface the effective validation mode and whether repo-owned PR checks are expected in `publish-pr` dry-run output
- align repo-local PR lifecycle instructions, README/man pages, requirements, and publication scenarios with the main-based review-unit contract

## Testing
- `bash ./scripts/validate-repo.sh`
