### PR TITLE
Tighten peer-review loop rules and Phase 4 support docs

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -57,6 +57,10 @@ for convenience.
 - When peer review finds an actionable issue, keep iterating through fixes,
   validation, and another review pass until no actionable findings remain or a
   concrete blocker is reported.
+- Treat that review loop as unbounded. If the peer or follow-up review pass
+  finds new issues after a fix, keep iterating with that peer until all
+  findings are resolved, explicitly dispositioned, or blocked by a concrete
+  external constraint.
 
 ## Commit Grouping
 

--- a/.agents/skills/workcell-contract-parity/SKILL.md
+++ b/.agents/skills/workcell-contract-parity/SKILL.md
@@ -42,6 +42,10 @@ Treat every user request as implicitly including peer review unless the user
 explicitly narrows that scope. For parity work, peer review means continuing
 through findings, fixes, validation, and another review pass until no
 actionable findings remain or a concrete blocker is reported.
+Treat that as an open-ended peer loop. If a peer, validator, or review surface
+finds new parity issues after a fix, continue re-reviewing with that peer or
+surface until every finding is resolved, explicitly dispositioned, or blocked
+by a concrete external constraint.
 
 ## Read first
 

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -41,6 +41,10 @@ explicitly narrows that scope. For PR work, peer review means continuing
 through review, fixes, validation, another review pass, and hosted workflow
 follow-through until no actionable findings remain or a concrete blocker is
 reported.
+Treat that as a continuing loop with the same peers and review surfaces. If a
+comment sweep, thread sweep, CI rerun, or follow-up review produces new
+findings after a fix, keep iterating until every finding is resolved,
+explicitly dispositioned, or blocked by a concrete external constraint.
 
 ## Read first
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,10 @@ the runtime boundary or explicit security guarantees in the name of convenience.
 - Peer review means continuing through review, fixes, revalidation, and another
   review pass until no actionable findings remain or a concrete blocker is
   reported.
+- Treat peer review as an open-ended loop, not a single extra pass. If a peer
+  or review surface returns new findings after a fix, keep iterating with that
+  peer or surface until every finding is addressed, explicitly dispositioned,
+  or blocked by a concrete external constraint.
 - Apply that default across repo-local skills, documentation work, CI follow-up,
   publication, merge, and release actions. Do not stop at "implemented" if
   review, checks, or hosted workflows still expose actionable problems.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ boundary.
 
 - pre-1.0 and still tightening the public contract
 - Apple Silicon macOS hosts only today; Linux and Windows are not currently
-  supported
+  supported as launch hosts
 - local host-launched runtime first; there is no Workcell-managed cloud or
   remote worker plane today
 - CLI surfaces for Codex, Claude, and Gemini plus host-side detached session
@@ -54,6 +54,9 @@ boundary.
   install/uninstall on Apple Silicon `macos-26` and `macos-15`
 - the real macOS Colima boundary is still a local operator exercise because
   GitHub-hosted Linux runners cannot prove it
+- the canonical host support boundary lives in
+  [docs/host-support-matrix.md](docs/host-support-matrix.md), and
+  `--doctor` / `--inspect` emit matching `support_matrix_*` lines
 - Workcell does not yet ship a centralized enterprise policy, inventory, or
   analytics plane; team rollout today relies on distributing reviewed
   host-side files
@@ -91,6 +94,8 @@ workcell --agent codex --workspace /path/to/repo
 See [docs/getting-started.md](docs/getting-started.md) for the release install
 path and provider-specific onboarding. For team rollout patterns on today's
 local-first product, see [docs/enterprise-rollout.md](docs/enterprise-rollout.md).
+Use [docs/host-support-matrix.md](docs/host-support-matrix.md) to interpret the
+host support boundary that `--doctor` and `--inspect` report.
 
 ## Install options
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ boundary.
 - the real macOS Colima boundary is still a local operator exercise because
   GitHub-hosted Linux runners cannot prove it
 - the canonical host support boundary lives in
-  [docs/host-support-matrix.md](docs/host-support-matrix.md), and
+  [policy/host-support-matrix.tsv](policy/host-support-matrix.tsv), and
   `--doctor` / `--inspect` emit matching `support_matrix_*` lines
 - Workcell does not yet ship a centralized enterprise policy, inventory, or
   analytics plane; team rollout today relies on distributing reviewed
@@ -94,7 +94,7 @@ workcell --agent codex --workspace /path/to/repo
 See [docs/getting-started.md](docs/getting-started.md) for the release install
 path and provider-specific onboarding. For team rollout patterns on today's
 local-first product, see [docs/enterprise-rollout.md](docs/enterprise-rollout.md).
-Use [docs/host-support-matrix.md](docs/host-support-matrix.md) to interpret the
+Use [policy/host-support-matrix.tsv](policy/host-support-matrix.tsv) to interpret the
 host support boundary that `--doctor` and `--inspect` report.
 
 ## Install options

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,16 +18,14 @@ The deterministic phase breakdown lives in
 - expand end-to-end coverage for authenticated, lower-assurance, and
   session-supervisor transitions so new orchestration features ship with
   invariant checks
-- ship the narrow trusted `linux/amd64` validation-host lane, versioned
-  support matrix, and target-aware diagnostics before broad non-macOS or cloud
-  support claims
-- define the remote-VM contract prerequisites and evidence gates that later
+- define the provider-neutral remote-VM contract, shared fake target, and
+  evidence gates that later
   `compat` and `remote_vm` targets must satisfy, without implying backend
   shipment or Tier 1 Linux or Windows host parity before the same guarantees
   exist
-- keep one canonical machine-readable support matrix and one shared remote-VM
-  conformance harness so later targets cannot fork the support contract by
-  accident
+- keep the shipped canonical host-support matrix and the new shared remote-VM
+  conformance harness authoritative so later targets cannot fork the support
+  contract by accident
 
 ## Medium term
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -15,7 +15,7 @@
 - if auth is involved, run `workcell auth status --agent <provider>` and
   `workcell --agent <provider> --auth-status --workspace /path/to/repo`
 - compare the reported `support_matrix_*` lines with
-  [docs/host-support-matrix.md](docs/host-support-matrix.md)
+  [policy/host-support-matrix.tsv](policy/host-support-matrix.tsv)
 - capture the exact command, provider, mode, and host environment
 
 ## Include this context

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -14,6 +14,8 @@
 - run `workcell --agent <provider> --inspect --workspace /path/to/repo`
 - if auth is involved, run `workcell auth status --agent <provider>` and
   `workcell --agent <provider> --auth-status --workspace /path/to/repo`
+- compare the reported `support_matrix_*` lines with
+  [docs/host-support-matrix.md](docs/host-support-matrix.md)
 - capture the exact command, provider, mode, and host environment
 
 ## Include this context


### PR DESCRIPTION
## Summary
- make repo-local peer review explicitly open-ended across AGENTS and the repo-local skills
- clarify the shipped Phase 4 host-support boundary in README, SUPPORT, and ROADMAP

## Validation
- `go test ./internal/injection ./internal/transcript`
- `bash ./scripts/check-public-repo-hygiene.sh`
- `bash ./scripts/validate-repo.sh` *(currently fails in unrelated existing mutation/contract lanes under `internal/metadatautil` and Rust mutation coverage; this branch does not touch those paths)*