### PR TITLE
^F Enforce parity evidence in PR publication (publish scenario green; user-visible publication workflow)

### DIFF
--- a/.agents/skills/workcell-contract-parity/SKILL.md
+++ b/.agents/skills/workcell-contract-parity/SKILL.md
@@ -76,6 +76,10 @@ If the change is release-bound, also read:
   `WORKCELL_HELP_BIN` override.
 - Final GitHub publication is host-side and branch-based. Do not normalize
   direct pushes to `main`.
+- In this repository, the parity-enforcing `main`-based publication path is
+  `./scripts/repo-publish-pr.sh`, which delegates to
+  `./scripts/workcell publish-pr` only after fresh local `pr-parity`
+  evidence exists.
 - Anything pushed for review must stay human-reviewable. Keep PRs single-purpose
   and bounded enough that a reviewer can reason about the change without
   juggling multiple independent decisions. Split broad work into sequenced PRs

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -61,8 +61,11 @@ If the task is release-bound, also read:
 
 ## Invariants
 
-- Final GitHub publication is a host-side action. Use `./scripts/workcell
-  publish-pr`; do not normalize direct publication from the Tier 1 session.
+- Final GitHub publication is a host-side action. Use the repo-local
+  `./scripts/repo-publish-pr.sh` wrapper for `main`-based PRs so fresh local
+  parity evidence is enforced before it delegates to
+  `./scripts/workcell publish-pr`; do not normalize direct publication from
+  the Tier 1 session.
 - `main` is the only supported PR base by default. If a lower-assurance
   non-`main` base path exists, keep that PR draft-only, treat it as
   non-mergeable, and do not claim the normal `main`-based repo-owned
@@ -94,9 +97,10 @@ If the task is release-bound, also read:
    intended scope.
 2. Create signed commits using the repo-local `commit` skill.
 3. Run the focused local validation for the change before publication.
-4. Publish with host-side `./scripts/workcell publish-pr` using a draft PR by
-   default and targeting `main` unless an explicit lower-assurance exception is
-   part of the task.
+4. Publish `main`-based PRs with host-side `./scripts/repo-publish-pr.sh`
+   using a draft PR by default. Only fall back to the lower-level
+   `./scripts/workcell publish-pr` path for explicit lower-assurance
+   non-`main` exceptions or other repo-approved special cases.
 5. Follow repo-owned checks to completion.
 6. If a repo-owned check fails:
    - inspect the failing GitHub Actions logs or PR checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,10 @@ the runtime boundary or explicit security guarantees in the name of convenience.
 - For publish, PR follow-up, or merge requests in this repository, use the
   repo-local `workcell-pr-lifecycle` skill. Repo-local publication rules
   override generic GitHub publication skills.
+- For `main`-based PR publication in this repository, use the host-side
+  repo-local wrapper `./scripts/repo-publish-pr.sh`. It requires fresh local
+  `pr-parity` evidence before delegating to the lower-level
+  `./scripts/workcell publish-pr` helper.
 - `main` is the only supported PR base by default. Non-`main` base PRs are
   lower-assurance exceptions: keep them draft, do not merge them, and do not
   expect the normal `main`-based repo-owned validation or merge gating for
@@ -98,7 +102,8 @@ the runtime boundary or explicit security guarantees in the name of convenience.
   independent approval or separation of duties unless it actually happened.
 - Review open pull requests, review feedback, and PR comments before cutting a
   release, and address actionable feedback as part of the release workflow.
-- Use host-side `./scripts/workcell publish-pr` for release PR publication.
+- Use host-side `./scripts/repo-publish-pr.sh` for release PR publication
+  after fresh local `pr-parity` evidence exists.
 - Wait for the merged `main` commit to finish required GitHub Actions workflows
   successfully before pushing the signed release tag.
 - After pushing a release tag, follow the `Release` workflow to completion and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,11 @@ See [GitHub's docs on signing commits][sign-docs] for setup details.
    ./scripts/pre-merge.sh
    ```
 
-6. Open a PR against `main`.
+6. Publish against `main` with the repo-local parity wrapper:
+
+   ```bash
+   ./scripts/repo-publish-pr.sh
+   ```
 
 The pre-commit hook blocks unrelated commits when stable provider pin bumps are
 pending and points you at `./scripts/publish-provider-bump-pr.sh`.
@@ -147,27 +151,41 @@ validator container from a disposable snapshot of the current worktree.
 
 ### Full local gate
 
-`./scripts/pre-merge.sh` is the normal pre-PR gate. It covers:
+`./scripts/pre-merge.sh` is the normal local parity entrypoint. It supports
+three explicit profiles:
 
-- pinned-input checks
-- upstream release verification for pinned provider artifacts
-- validator-image rebuild
-- workflow lint
-- repo validation
-- invariant checks
-- host-side `publish-pr` scenario coverage
+- `repo-core`: repo-required deterministic checks
+- `pr-parity` (default): the mirrored local subset of required `main`-based PR
+  workflows plus parity evidence generation for publication
+- `release-preflight`: `pr-parity` plus the extra mirrored release-facing
+  hygiene lanes
+
+The default `pr-parity` profile covers the shared mirrored workflow bodies:
+
+- workflow lint and workflow-lane manifest verification
+- PR shape
+- validator-backed shared validate job
+- docs parity
 - container smoke
-- source-bundle reproducibility
-- runtime-image reproducibility
+- runtime-image reproducibility on locally supported platforms
+
+`release-preflight` adds the mirrored pin-hygiene lane. `repo-core` keeps the
+smaller deterministic subset for repo-owned contract work.
 
 Helpful flags:
 
 ```bash
 ./scripts/pre-merge.sh --allow-dirty
+./scripts/pre-merge.sh --profile repo-core
+./scripts/pre-merge.sh --profile release-preflight
 ./scripts/pre-merge.sh --skip-repro
 ./scripts/pre-merge.sh --skip-release-bundle
 ./scripts/pre-merge.sh --rebuild-validator
 ```
+
+For `main`-based PRs, `./scripts/repo-publish-pr.sh` consumes the fresh
+`pr-parity` evidence emitted by `./scripts/pre-merge.sh` and refuses to publish
+if that evidence does not match the tree being sent for review.
 
 ## Pull requests
 

--- a/docs/enterprise-rollout.md
+++ b/docs/enterprise-rollout.md
@@ -111,7 +111,8 @@ The supported publication path remains:
 
 1. run the provider inside Workcell
 2. review the resulting changes
-3. publish from the host with `workcell publish-pr`
+3. run local `pr-parity`, then publish from the host with
+   `./scripts/repo-publish-pr.sh`
 
 Do not treat in-session git publication as equivalent to the host-side release
 and signing model.

--- a/docs/examples/enterprise-claude-setup.md
+++ b/docs/examples/enterprise-claude-setup.md
@@ -45,7 +45,9 @@ providers = ["claude"]
 - the session gets only the reviewed credentials it needs
 - the macOS Claude resolver can still be recorded separately, but it is
   currently fail-closed until a supported export path exists
-- final publication still stays on the host with `workcell publish-pr`
+- final publication still stays on the host through the repo-local
+  `./scripts/repo-publish-pr.sh` wrapper, which delegates to the lower-level
+  `workcell publish-pr` helper after fresh local parity evidence exists
 
 ## Launch
 

--- a/docs/examples/quickstart-claude.md
+++ b/docs/examples/quickstart-claude.md
@@ -117,7 +117,8 @@ workcell auth set \
 ## 6. Publish the result on the host
 
 ```bash
-workcell publish-pr --workspace /path/to/repo --branch feature/my-change \
+./scripts/pre-merge.sh --profile pr-parity
+./scripts/repo-publish-pr.sh --workspace /path/to/repo --branch feature/my-change \
   --title-file /tmp/pr-title.txt --body-file /tmp/pr-body.md \
   --commit-message-file /tmp/commit-message.txt
 ```

--- a/docs/examples/quickstart-codex.md
+++ b/docs/examples/quickstart-codex.md
@@ -122,7 +122,8 @@ workcell --agent codex --mode breakglass --ack-breakglass --workspace /path/to/r
 Prepare the PR metadata, then publish from the host:
 
 ```bash
-workcell publish-pr \
+./scripts/pre-merge.sh --profile pr-parity
+./scripts/repo-publish-pr.sh \
   --workspace /path/to/repo \
   --branch feature/name \
   --title-file /tmp/pr-title.txt \

--- a/docs/examples/quickstart-gemini.md
+++ b/docs/examples/quickstart-gemini.md
@@ -91,7 +91,8 @@ workcell auth set \
 ## 6. Publish the result on the host
 
 ```bash
-workcell publish-pr --workspace /path/to/repo --branch feature/my-change \
+./scripts/pre-merge.sh --profile pr-parity
+./scripts/repo-publish-pr.sh --workspace /path/to/repo --branch feature/my-change \
   --title-file /tmp/pr-title.txt --body-file /tmp/pr-body.md \
   --commit-message-file /tmp/commit-message.txt
 ```

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -3,6 +3,20 @@
 Workcell keeps the workflow set narrow and reviewable. GitHub automation should
 reinforce the runtime boundary and release posture, not replace them.
 
+Workcell also keeps a machine-checked lane inventory so local parity and
+GitHub-only behavior do not drift silently:
+
+- [`policy/workflow-lane-policy.json`](../policy/workflow-lane-policy.json)
+  declares each expanded workflow lane's profiles, authority, and local mode
+- [`policy/workflow-lanes.json`](../policy/workflow-lanes.json) is the
+  generated manifest derived from the live workflow YAML plus that policy
+- `./scripts/verify-workflow-lanes.sh` fails if the manifest drifts
+- `./scripts/ci-plan.sh` explains which mirrored lanes apply locally for a
+  given profile, event, labels, and changed files
+
+That inventory underpins the local `./scripts/pre-merge.sh` profiles and the
+repo-local `./scripts/repo-publish-pr.sh` publication gate.
+
 ## Workflow inventory
 
 | Workflow | Purpose |
@@ -73,6 +87,20 @@ passes isolated writable roots, and creates those paths inside the validator
 before repo validation or docs checks run. That contract still holds when the
 caller UID lacks a passwd entry inside the image because the launcher
 synthesizes an isolated writable home for those lanes.
+
+The mirrored local workflow bodies live under `scripts/ci/`:
+
+- `job-pr-shape.sh`
+- `job-validate.sh`
+- `job-docs.sh`
+- `job-pin-hygiene.sh`
+- `build-validator-image.sh`
+- `run-validate-in-validator.sh`
+- `run-docs-in-validator.sh`
+
+GitHub workflow YAML stays responsible for event routing, permissions, runners,
+and hosted-only concerns. The shared scripts keep the mirrorable job logic
+identical between local parity runs and GitHub CI.
 
 ## Hosted controls
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -48,7 +48,9 @@ honestly in docs, status reports, and release commentary.
 - Review any intentional upstream holdbacks or exceptions before refreshing
   pins, and document them in policy or release notes rather than carrying
   unexplained drift.
-- Publish PRs from the host with `./scripts/workcell publish-pr`.
+- Publish `main`-based release PRs from the host with
+  `./scripts/repo-publish-pr.sh` after fresh local `pr-parity` evidence
+  exists.
 - For agentic release PR publication and follow-up, use the repo-local
   `workcell-pr-lifecycle` skill in addition to this release runbook.
 - Wait for `main` to be green before pushing the release tag.
@@ -354,10 +356,12 @@ git commit -S -m "release: ${VERSION}"
 
 ## 5. Publish the release PR from the host
 
-Prepare and publish the release PR with the host-side helper:
+Prepare and publish the release PR with the host-side helper after running the
+local parity gate:
 
 ```sh
-./scripts/workcell publish-pr
+./scripts/pre-merge.sh --profile pr-parity
+./scripts/repo-publish-pr.sh
 ```
 
 In `review-gated` mode, stop with the first checkpoint packet before running

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -46,7 +46,12 @@ state:
 - `./scripts/verify-invariants.sh`
 - `./scripts/verify-release-bundle.sh`
 - `./scripts/verify-reproducible-build.sh`
-- `./scripts/pre-merge.sh` (builds or reuses the same pinned validator container and can run the local stack from a disposable snapshot)
+- `./scripts/pre-merge.sh` profiles:
+  - `repo-core` for deterministic repo-required validation
+  - `pr-parity` for the local mirror of required `main`-based PR checks
+  - `release-preflight` for the additional mirrored release-facing lanes
+- `./scripts/repo-publish-pr.sh` for `main`-based PR publication after fresh
+  local `pr-parity` evidence exists
 
 They cover repo shape, runtime contracts, smoke behavior, and reproducibility.
 They also now cover canonical requirement traceability, host-side policy
@@ -118,6 +123,14 @@ GitHub-hosted CI proves:
 
 GitHub-hosted CI does not prove the full macOS Colima boundary. That remains a
 local exercise.
+
+Workcell now also keeps a machine-checked local parity inventory in:
+
+- [`policy/workflow-lane-policy.json`](../policy/workflow-lane-policy.json)
+- [`policy/workflow-lanes.json`](../policy/workflow-lanes.json)
+
+Use `./scripts/ci-plan.sh` to see which mirrored lanes a given local
+`pre-merge` profile will execute and which lanes remain GitHub-only.
 
 ## Credential placement rule
 

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -322,9 +322,11 @@ material:
 - [`docs/provenance.md`](provenance.md) and [`docs/releasing.md`](releasing.md)
   describe release-time signing, attestation, and publication expectations
 
-Final GitHub publication is intentionally host-side. `workcell publish-pr`
-keeps branch push, commit signing, and PR creation outside the bounded Tier 1
-runtime.
+Final GitHub publication is intentionally host-side. In this repository the
+supported `main`-based PR path goes through `./scripts/repo-publish-pr.sh`,
+which delegates to `workcell publish-pr` after fresh local parity evidence
+exists. That keeps branch push, commit signing, and PR creation outside the
+bounded Tier 1 runtime.
 
 ## End-to-End Flow
 
@@ -361,7 +363,8 @@ The supported publication path remains:
 
 1. run the provider inside Workcell
 2. review the resulting changes
-3. publish from the host with `workcell publish-pr`
+3. run local `pr-parity`, then publish from the host with
+   `./scripts/repo-publish-pr.sh`
 
 This keeps commit signing and repository publication outside the in-container
 runtime boundary.

--- a/scripts/publish-provider-bump-pr.sh
+++ b/scripts/publish-provider-bump-pr.sh
@@ -29,7 +29,8 @@ Usage: scripts/publish-provider-bump-pr.sh [--base BRANCH] [--draft] [--now RFC3
 
 Creates a disposable worktree, updates pinned provider versions to the newest
 stable releases older than the configured cool-off, validates the result, and
-publishes a signed pull request through workcell publish-pr.
+publishes a signed pull request through the repo-local parity-enforcing
+publication wrapper.
 
 Run this from a clean worktree. The disposable publication branch is created
 from the latest available tip of the selected base branch, not the caller's
@@ -136,9 +137,7 @@ else
   exit 0
 fi
 
-"${worktree_root}/scripts/validate-repo.sh"
-"${worktree_root}/scripts/container-smoke.sh"
-"${worktree_root}/scripts/verify-invariants.sh"
+"${worktree_root}/scripts/pre-merge.sh" --profile pr-parity --allow-dirty
 
 codex_version="$(
   cd "${worktree_root}"
@@ -167,9 +166,7 @@ cat >"${body_file}" <<EOF
 
 ## Validation
 
-- \`./scripts/validate-repo.sh\`
-- \`./scripts/container-smoke.sh\`
-- \`./scripts/verify-invariants.sh\`
+- \`./scripts/pre-merge.sh --profile pr-parity --allow-dirty\`
 EOF
 
 cat >"${commit_file}" <<EOF
@@ -181,8 +178,7 @@ Bump stable provider pins
 EOF
 
 publish_cmd=(
-  "${ROOT_DIR}/scripts/workcell"
-  publish-pr
+  "${ROOT_DIR}/scripts/repo-publish-pr.sh"
   --workspace "${worktree_root}"
   --branch "${branch_name}"
   --base "${BASE_BRANCH}"

--- a/scripts/repo-publish-pr.sh
+++ b/scripts/repo-publish-pr.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKSPACE="${PWD}"
+BASE_BRANCH="main"
+SNAPSHOT="worktree"
+ALLOW_PARITY_OVERRIDE=0
+PARITY_OVERRIDE_REASON=""
+PASSTHROUGH_ARGS=()
+
+usage() {
+  cat <<'EOF'
+Usage: repo-publish-pr.sh [workcell publish-pr options]
+
+Repo-local publication wrapper that requires matching local PR-parity evidence
+for the tree being published before handing off to scripts/workcell publish-pr.
+
+Options handled here:
+  --workspace PATH
+  --base BRANCH
+  --snapshot index|worktree
+  --allow-parity-override
+  --parity-override-reason TEXT
+  -h, --help
+
+All other options are passed through to scripts/workcell publish-pr.
+EOF
+}
+
+resolve_workspace() {
+  local candidate="$1"
+  if [[ -z "${candidate}" ]]; then
+    printf '%s\n' "${PWD}"
+    return 0
+  fi
+  if [[ ! -d "${candidate}" ]]; then
+    echo "Workspace path does not exist: ${candidate}" >&2
+    exit 2
+  fi
+  (
+    cd "${candidate}" &&
+      pwd -P
+  )
+}
+
+compute_snapshot_tree() {
+  local workspace="$1"
+  local snapshot_mode="$2"
+  local tmp_index=""
+  local tree_oid=""
+
+  case "${snapshot_mode}" in
+    index)
+      git -C "${workspace}" write-tree
+      return 0
+      ;;
+    worktree) ;;
+    *)
+      echo "Unsupported publish snapshot: ${snapshot_mode}" >&2
+      exit 2
+      ;;
+  esac
+
+  tmp_index="$(mktemp "${TMPDIR:-/tmp}/workcell-publish-index.XXXXXX")"
+  rm -f "${tmp_index}"
+  trap 'rm -f "${tmp_index}"' RETURN
+  GIT_INDEX_FILE="${tmp_index}" git -C "${workspace}" read-tree HEAD
+  GIT_INDEX_FILE="${tmp_index}" git -C "${workspace}" add -A
+  tree_oid="$(GIT_INDEX_FILE="${tmp_index}" git -C "${workspace}" write-tree)"
+  rm -f "${tmp_index}"
+  trap - RETURN
+  printf '%s\n' "${tree_oid}"
+}
+
+verify_pr_parity_evidence() {
+  local workspace="$1"
+  local snapshot_mode="$2"
+  local base_branch="$3"
+  local evidence_dir=""
+  local evidence_path=""
+  local expected_tree=""
+
+  evidence_dir="$(git -C "${workspace}" rev-parse --absolute-git-dir)/workcell-parity"
+  evidence_path="${evidence_dir}/pr-parity.json"
+  if [[ ! -f "${evidence_path}" ]]; then
+    echo "Missing local PR-parity evidence for ${workspace}." >&2
+    echo "Run ./scripts/pre-merge.sh --profile pr-parity first, or use --allow-parity-override with a reason." >&2
+    exit 2
+  fi
+  expected_tree="$(compute_snapshot_tree "${workspace}" "${snapshot_mode}")"
+
+  jq -e \
+    --arg base "${base_branch}" \
+    --arg tree_oid "${expected_tree}" \
+    '
+      .version == 1 and
+      .profile == "pr-parity" and
+      .base_branch == $base and
+      .tree_oid == $tree_oid
+    ' "${evidence_path}" >/dev/null || {
+    echo "Local PR-parity evidence does not match the tree being published." >&2
+    echo "Expected base=${base_branch} tree_oid=${expected_tree}." >&2
+    echo "Re-run ./scripts/pre-merge.sh --profile pr-parity before publishing, or use --allow-parity-override with a reason." >&2
+    exit 2
+  }
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workspace)
+      WORKSPACE="$(resolve_workspace "${2:-}")"
+      shift 2
+      ;;
+    --base)
+      BASE_BRANCH="${2:-}"
+      [[ -n "${BASE_BRANCH}" ]] || {
+        echo "--base requires a branch name" >&2
+        exit 2
+      }
+      PASSTHROUGH_ARGS+=("$1" "$BASE_BRANCH")
+      shift 2
+      ;;
+    --snapshot)
+      SNAPSHOT="${2:-}"
+      [[ -n "${SNAPSHOT}" ]] || {
+        echo "--snapshot requires a value" >&2
+        exit 2
+      }
+      PASSTHROUGH_ARGS+=("$1" "$SNAPSHOT")
+      shift 2
+      ;;
+    --allow-parity-override)
+      ALLOW_PARITY_OVERRIDE=1
+      shift
+      ;;
+    --parity-override-reason)
+      PARITY_OVERRIDE_REASON="${2:-}"
+      [[ -n "${PARITY_OVERRIDE_REASON}" ]] || {
+        echo "--parity-override-reason requires a value" >&2
+        exit 2
+      }
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      PASSTHROUGH_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+WORKSPACE="$(resolve_workspace "${WORKSPACE}")"
+
+if [[ "${ALLOW_PARITY_OVERRIDE}" -eq 1 ]]; then
+  if [[ -z "${PARITY_OVERRIDE_REASON}" ]]; then
+    echo "--allow-parity-override requires --parity-override-reason." >&2
+    exit 2
+  fi
+  echo "repo-publish-pr parity override: ${PARITY_OVERRIDE_REASON}" >&2
+elif [[ "${BASE_BRANCH}" == "main" ]]; then
+  verify_pr_parity_evidence "${WORKSPACE}" "${SNAPSHOT}" "${BASE_BRANCH}"
+fi
+
+exec "${ROOT_DIR}/scripts/workcell" publish-pr --workspace "${WORKSPACE}" "${PASSTHROUGH_ARGS[@]}"

--- a/tests/scenarios/shared/test-publish-pr-dry-run.sh
+++ b/tests/scenarios/shared/test-publish-pr-dry-run.sh
@@ -10,6 +10,20 @@ cleanup() {
 }
 trap cleanup EXIT
 
+compute_worktree_tree_oid() {
+  local repo_root="$1"
+  local tmp_index=""
+  local tree_oid=""
+
+  tmp_index="$(mktemp "${TMPDIR:-/tmp}/workcell-publish-tree.XXXXXX")"
+  rm -f "${tmp_index}"
+  GIT_INDEX_FILE="${tmp_index}" git -C "${repo_root}" read-tree HEAD
+  GIT_INDEX_FILE="${tmp_index}" git -C "${repo_root}" add -A
+  tree_oid="$(GIT_INDEX_FILE="${tmp_index}" git -C "${repo_root}" write-tree)"
+  rm -f "${tmp_index}"
+  printf '%s\n' "${tree_oid}"
+}
+
 FIXTURE="${TMP_DIR}/publish-pr-fixture"
 ORIGIN="${TMP_DIR}/publish-pr-origin.git"
 SSH_SIGNING_KEY="${TMP_DIR}/signing_key"
@@ -169,6 +183,70 @@ if grep -q -- ' add -A ' <<<"${index_dry_run}"; then
   echo "publish-pr index snapshot should not auto-stage the worktree" >&2
   exit 1
 fi
+
+set +e
+missing_parity_output="$("${ROOT_DIR}/scripts/repo-publish-pr.sh" \
+  --workspace "${FIXTURE}" \
+  --branch feature/repo-wrapper-missing \
+  --title "Missing parity evidence" \
+  --commit-message "Missing parity evidence" \
+  --dry-run 2>&1)"
+missing_parity_rc=$?
+set -e
+test "${missing_parity_rc}" -eq 2
+grep -q 'Missing local PR-parity evidence' <<<"${missing_parity_output}"
+
+mkdir -p "$(git -C "${FIXTURE}" rev-parse --absolute-git-dir)/workcell-parity"
+cat >"$(git -C "${FIXTURE}" rev-parse --absolute-git-dir)/workcell-parity/pr-parity.json" <<'EOF'
+{
+  "version": 1,
+  "profile": "pr-parity",
+  "base_branch": "main",
+  "tree_oid": "deadbeef"
+}
+EOF
+set +e
+mismatched_parity_output="$("${ROOT_DIR}/scripts/repo-publish-pr.sh" \
+  --workspace "${FIXTURE}" \
+  --branch feature/repo-wrapper-mismatch \
+  --title "Mismatched parity evidence" \
+  --commit-message "Mismatched parity evidence" \
+  --dry-run 2>&1)"
+mismatched_parity_rc=$?
+set -e
+test "${mismatched_parity_rc}" -eq 2
+grep -q 'Local PR-parity evidence does not match the tree being published' <<<"${mismatched_parity_output}"
+
+current_tree_oid="$(compute_worktree_tree_oid "${FIXTURE}")"
+cat >"$(git -C "${FIXTURE}" rev-parse --absolute-git-dir)/workcell-parity/pr-parity.json" <<EOF
+{
+  "version": 1,
+  "profile": "pr-parity",
+  "base_branch": "main",
+  "tree_oid": "${current_tree_oid}"
+}
+EOF
+wrapper_dry_run="$("${ROOT_DIR}/scripts/repo-publish-pr.sh" \
+  --workspace "${FIXTURE}" \
+  --branch feature/repo-wrapper-ok \
+  --title "Repo wrapper title" \
+  --commit-message "Repo wrapper commit" \
+  --dry-run)"
+grep -q '^publish_branch=feature/repo-wrapper-ok$' <<<"${wrapper_dry_run}"
+grep -q '^publish_base=main$' <<<"${wrapper_dry_run}"
+grep -q '^publish_snapshot=worktree$' <<<"${wrapper_dry_run}"
+
+rm -f "$(git -C "${FIXTURE}" rev-parse --absolute-git-dir)/workcell-parity/pr-parity.json"
+override_dry_run="$("${ROOT_DIR}/scripts/repo-publish-pr.sh" \
+  --workspace "${FIXTURE}" \
+  --branch feature/repo-wrapper-override \
+  --title "Repo wrapper override" \
+  --commit-message "Repo wrapper override" \
+  --allow-parity-override \
+  --parity-override-reason "manual parity waiver for scenario" \
+  --dry-run 2>&1)"
+grep -q 'repo-publish-pr parity override: manual parity waiver for scenario' <<<"${override_dry_run}"
+grep -q '^publish_branch=feature/repo-wrapper-override$' <<<"${override_dry_run}"
 
 set +e
 default_branch_output="$("${ROOT_DIR}/scripts/workcell" publish-pr \


### PR DESCRIPTION
## Summary
- require parity evidence in the repo-local publication flow
- align repo docs and skills with the canonical local PR-parity path

## Validation
- `bash ./tests/scenarios/shared/test-publish-pr-dry-run.sh`
- `bash ./scripts/check-public-repo-hygiene.sh`
- `bash ./scripts/check-pr-shape.sh --base-ref codex/pr-parity-validation-fixes --head-ref HEAD --max-files 25 --max-lines 1200 --max-areas 8 --max-binaries 0`