### PR TITLE
Implement canonical remote VM contract harness

### DIFF
--- a/internal/remotevm/conformance.go
+++ b/internal/remotevm/conformance.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package remotevm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/hostutil"
+)
+
+type ConformanceCase struct {
+	StateRoot         string
+	TargetID          string
+	MaterializationID string
+	BootstrapID       string
+	SessionID         string
+	Agent             string
+	Mode              string
+	ImageRef          string
+	StartedAt         string
+	FinishedAt        string
+	ExitStatus        string
+	SourceWorkspace   string
+}
+
+type ConformanceResult struct {
+	Materialization MaterializeResult
+	Bootstrap       BootstrapResult
+	Started         SessionResult
+	Finished        SessionResult
+	Exported        hostutil.SessionExport
+}
+
+func DefaultConformanceCase(stateRoot, sourceWorkspace string) ConformanceCase {
+	return ConformanceCase{
+		StateRoot:         stateRoot,
+		TargetID:          "fake-remote-target",
+		MaterializationID: "fixture-materialization",
+		BootstrapID:       "fixture-bootstrap",
+		SessionID:         "fixture-session",
+		Agent:             "codex",
+		Mode:              "strict",
+		ImageRef:          "workcell-remotevm:test",
+		StartedAt:         "2026-04-21T00:00:00Z",
+		FinishedAt:        "2026-04-21T00:15:00Z",
+		ExitStatus:        "0",
+		SourceWorkspace:   sourceWorkspace,
+	}
+}
+
+func RunConformance(ctx context.Context, target ConformanceTarget, contract Contract, c ConformanceCase) (ConformanceResult, error) {
+	if err := contract.Validate(); err != nil {
+		return ConformanceResult{}, err
+	}
+	materialization, err := target.MaterializeWorkspace(ctx, MaterializeRequest{
+		StateRoot:         c.StateRoot,
+		TargetID:          c.TargetID,
+		MaterializationID: c.MaterializationID,
+		SourceWorkspace:   c.SourceWorkspace,
+	})
+	if err != nil {
+		return ConformanceResult{}, err
+	}
+	if err := validateMaterialization(contract, materialization, c.SourceWorkspace); err != nil {
+		return ConformanceResult{}, err
+	}
+	bootstrap, err := target.BootstrapTarget(ctx, BootstrapRequest{
+		StateRoot:   c.StateRoot,
+		TargetID:    c.TargetID,
+		BootstrapID: c.BootstrapID,
+		ImageRef:    c.ImageRef,
+	})
+	if err != nil {
+		return ConformanceResult{}, err
+	}
+	if err := validateBootstrap(contract, bootstrap, c); err != nil {
+		return ConformanceResult{}, err
+	}
+	started, err := target.StartSession(ctx, StartSessionRequest{
+		SessionID:       c.SessionID,
+		Agent:           c.Agent,
+		Mode:            c.Mode,
+		StartedAt:       c.StartedAt,
+		Materialization: materialization,
+		Bootstrap:       bootstrap,
+	})
+	if err != nil {
+		return ConformanceResult{}, err
+	}
+	if err := validateStartedSession(contract, started, materialization, bootstrap, c); err != nil {
+		return ConformanceResult{}, err
+	}
+	finished, err := target.FinishSession(ctx, FinishSessionRequest{
+		Started:    started,
+		FinishedAt: c.FinishedAt,
+		ExitStatus: c.ExitStatus,
+	})
+	if err != nil {
+		return ConformanceResult{}, err
+	}
+	if err := validateFinishedSession(contract, finished, c); err != nil {
+		return ConformanceResult{}, err
+	}
+	records, err := hostutil.ListSessionRecordsInRoots([]string{c.StateRoot}, hostutil.SessionListOptions{})
+	if err != nil {
+		return ConformanceResult{}, err
+	}
+	if len(records) != 1 {
+		return ConformanceResult{}, fmt.Errorf("ListSessionRecordsInRoots() len = %d, want 1", len(records))
+	}
+	if got := hostutil.SessionTargetSummary(records[0]); got != "remote_vm/fake-remote/"+c.TargetID {
+		return ConformanceResult{}, fmt.Errorf("SessionTargetSummary() = %q", got)
+	}
+	exported, err := hostutil.ExportSessionRecordInRoots([]string{c.StateRoot}, c.SessionID)
+	if err != nil {
+		return ConformanceResult{}, err
+	}
+	if exported.Session.Status != contract.Session.FinalStatus {
+		return ConformanceResult{}, fmt.Errorf("exported final status = %q, want %q", exported.Session.Status, contract.Session.FinalStatus)
+	}
+	if len(exported.AuditRecords) != len(contract.RequiredAuditEvents) {
+		return ConformanceResult{}, fmt.Errorf("exported audit record len = %d, want %d", len(exported.AuditRecords), len(contract.RequiredAuditEvents))
+	}
+	for idx, want := range contract.RequiredAuditEvents {
+		if !strings.Contains(exported.AuditRecords[idx], "event="+want) {
+			return ConformanceResult{}, fmt.Errorf("audit record %d = %q, want event=%s", idx, exported.AuditRecords[idx], want)
+		}
+	}
+	return ConformanceResult{
+		Materialization: materialization,
+		Bootstrap:       bootstrap,
+		Started:         started,
+		Finished:        finished,
+		Exported:        exported,
+	}, nil
+}
+
+func validateMaterialization(contract Contract, result MaterializeResult, sourceWorkspace string) error {
+	if result.Manifest.TargetKind != contract.TargetKind {
+		return fmt.Errorf("materialization target_kind = %q, want %q", result.Manifest.TargetKind, contract.TargetKind)
+	}
+	if result.Manifest.WorkspaceTransport != contract.WorkspaceTransport {
+		return fmt.Errorf("materialization workspace_transport = %q, want %q", result.Manifest.WorkspaceTransport, contract.WorkspaceTransport)
+	}
+	if result.Manifest.SourceWorkspace != sourceWorkspace {
+		return fmt.Errorf("materialization source_workspace = %q, want %q", result.Manifest.SourceWorkspace, sourceWorkspace)
+	}
+	if _, err := os.Stat(filepath.Join(result.MaterializedWorkspace, ".git")); !os.IsNotExist(err) {
+		return fmt.Errorf("materialized workspace must not contain .git")
+	}
+	mirrorRoot, err := os.MkdirTemp("", "workcell-remotevm-compare.")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(mirrorRoot)
+	entries, err := copyWorkspaceTree(sourceWorkspace, filepath.Join(mirrorRoot, "workspace"), contract.WorkspaceMaterialization.ExcludedPaths)
+	if err != nil {
+		return err
+	}
+	if !slices.EqualFunc(entries, result.Manifest.Entries, func(a, b WorkspaceEntry) bool {
+		return a.Path == b.Path && a.Kind == b.Kind && a.Mode == b.Mode && a.SHA256 == b.SHA256 && a.LinkTarget == b.LinkTarget
+	}) {
+		return fmt.Errorf("materialization manifest entries do not match copied workspace")
+	}
+	return nil
+}
+
+func validateBootstrap(contract Contract, bootstrap BootstrapResult, c ConformanceCase) error {
+	if bootstrap.Manifest.TargetID != c.TargetID {
+		return fmt.Errorf("bootstrap target_id = %q, want %q", bootstrap.Manifest.TargetID, c.TargetID)
+	}
+	if bootstrap.Manifest.TargetAssuranceClass != contract.TargetAssuranceClass {
+		return fmt.Errorf("bootstrap target_assurance_class = %q, want %q", bootstrap.Manifest.TargetAssuranceClass, contract.TargetAssuranceClass)
+	}
+	if bootstrap.Manifest.SupportBoundary != contract.SupportBoundary {
+		return fmt.Errorf("bootstrap support_boundary = %q, want %q", bootstrap.Manifest.SupportBoundary, contract.SupportBoundary)
+	}
+	if bootstrap.Manifest.ImageRef != c.ImageRef {
+		return fmt.Errorf("bootstrap image_ref = %q, want %q", bootstrap.Manifest.ImageRef, c.ImageRef)
+	}
+	return nil
+}
+
+func validateStartedSession(contract Contract, session SessionResult, materialization MaterializeResult, bootstrap BootstrapResult, c ConformanceCase) error {
+	record := session.Record
+	for _, pair := range []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "target_kind", got: record.TargetKind, want: contract.TargetKind},
+		{name: "target_provider", got: record.TargetProvider, want: contract.TargetProvider},
+		{name: "target_id", got: record.TargetID, want: c.TargetID},
+		{name: "target_assurance_class", got: record.TargetAssuranceClass, want: contract.TargetAssuranceClass},
+		{name: "runtime_api", got: record.RuntimeAPI, want: contract.RuntimeAPI},
+		{name: "workspace_transport", got: record.WorkspaceTransport, want: contract.WorkspaceTransport},
+		{name: "workspace", got: record.Workspace, want: materialization.MaterializedWorkspace},
+		{name: "workspace_origin", got: record.WorkspaceOrigin, want: c.SourceWorkspace},
+		{name: "workspace_control_plane", got: record.WorkspaceControlPlane, want: contract.Session.WorkspaceControlPlane},
+		{name: "audit_log_path", got: record.AuditLogPath, want: bootstrap.AuditLogPath},
+		{name: "status", got: record.Status, want: contract.Session.StartStatus},
+	} {
+		if pair.got != pair.want {
+			return fmt.Errorf("started session %s = %q, want %q", pair.name, pair.got, pair.want)
+		}
+	}
+	return nil
+}
+
+func validateFinishedSession(contract Contract, session SessionResult, c ConformanceCase) error {
+	record := session.Record
+	if record.Status != contract.Session.FinalStatus {
+		return fmt.Errorf("finished session status = %q, want %q", record.Status, contract.Session.FinalStatus)
+	}
+	if record.FinishedAt != c.FinishedAt {
+		return fmt.Errorf("finished session finished_at = %q, want %q", record.FinishedAt, c.FinishedAt)
+	}
+	if record.ExitStatus != c.ExitStatus {
+		return fmt.Errorf("finished session exit_status = %q, want %q", record.ExitStatus, c.ExitStatus)
+	}
+	if record.FinalAssurance != contract.Session.Assurance {
+		return fmt.Errorf("finished session final_assurance = %q, want %q", record.FinalAssurance, contract.Session.Assurance)
+	}
+	return nil
+}

--- a/internal/remotevm/conformance_test.go
+++ b/internal/remotevm/conformance_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package remotevm
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/hostutil"
+)
+
+func TestRunConformanceWithFakeTarget(t *testing.T) {
+	t.Parallel()
+
+	target, err := NewFakeTarget(DefaultContract())
+	if err != nil {
+		t.Fatal(err)
+	}
+	caseSpec := DefaultConformanceCase(t.TempDir(), filepath.Join("testdata", "source-workspace"))
+	result, err := RunConformance(context.Background(), target, DefaultContract(), caseSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := result.Exported.Session.TargetKind, "remote_vm"; got != want {
+		t.Fatalf("exported session target_kind = %q, want %q", got, want)
+	}
+	if got, want := result.Exported.Session.WorkspaceTransport, "remote-materialization"; got != want {
+		t.Fatalf("exported session workspace_transport = %q, want %q", got, want)
+	}
+	if got, want := hostutil.SessionTargetSummary(result.Exported.Session), "remote_vm/fake-remote/"+caseSpec.TargetID; got != want {
+		t.Fatalf("target summary = %q, want %q", got, want)
+	}
+}

--- a/internal/remotevm/contract.go
+++ b/internal/remotevm/contract.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package remotevm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+)
+
+const (
+	TargetKind           = "remote_vm"
+	CanonicalProvider    = "fake-remote"
+	AssuranceClass       = "compat"
+	SupportBoundary      = "preview-only"
+	RuntimeAPI           = "brokered"
+	WorkspaceTransport   = "remote-materialization"
+	AccessModel          = "brokered"
+	MaterializationMode  = "explicit"
+	MaterializationFile  = "materialization.json"
+	MaterializedWorktree = "workspace"
+	BootstrapFile        = "bootstrap.json"
+	WorkspaceControl     = "host-brokered"
+	SessionStartStatus   = "running"
+	SessionFinalStatus   = "exited"
+	SessionAssurance     = "compat-preview-brokered"
+)
+
+var requiredAuditEvents = []string{
+	"workspace_materialized",
+	"bootstrap_ready",
+	"session_started",
+	"session_finished",
+}
+
+type Contract struct {
+	Version                  int                          `json:"version"`
+	TargetKind               string                       `json:"target_kind"`
+	TargetProvider           string                       `json:"target_provider"`
+	TargetAssuranceClass     string                       `json:"target_assurance_class"`
+	SupportBoundary          string                       `json:"support_boundary"`
+	RuntimeAPI               string                       `json:"runtime_api"`
+	WorkspaceTransport       string                       `json:"workspace_transport"`
+	AccessModel              string                       `json:"access_model"`
+	WorkspaceMaterialization WorkspaceMaterializationSpec `json:"workspace_materialization"`
+	Bootstrap                BootstrapSpec                `json:"bootstrap"`
+	Session                  SessionSpec                  `json:"session"`
+	RequiredAuditEvents      []string                     `json:"required_audit_events"`
+}
+
+type WorkspaceMaterializationSpec struct {
+	Mode          string   `json:"mode"`
+	ManifestName  string   `json:"manifest_name"`
+	WorkspaceDir  string   `json:"workspace_dir"`
+	ExcludedPaths []string `json:"excluded_paths"`
+}
+
+type BootstrapSpec struct {
+	ManifestName string `json:"manifest_name"`
+}
+
+type SessionSpec struct {
+	WorkspaceControlPlane string `json:"workspace_control_plane"`
+	StartStatus           string `json:"start_status"`
+	FinalStatus           string `json:"final_status"`
+	Assurance             string `json:"assurance"`
+}
+
+func DefaultContract() Contract {
+	return Contract{
+		Version:              1,
+		TargetKind:           TargetKind,
+		TargetProvider:       CanonicalProvider,
+		TargetAssuranceClass: AssuranceClass,
+		SupportBoundary:      SupportBoundary,
+		RuntimeAPI:           RuntimeAPI,
+		WorkspaceTransport:   WorkspaceTransport,
+		AccessModel:          AccessModel,
+		WorkspaceMaterialization: WorkspaceMaterializationSpec{
+			Mode:          MaterializationMode,
+			ManifestName:  MaterializationFile,
+			WorkspaceDir:  MaterializedWorktree,
+			ExcludedPaths: []string{".git"},
+		},
+		Bootstrap: BootstrapSpec{
+			ManifestName: BootstrapFile,
+		},
+		Session: SessionSpec{
+			WorkspaceControlPlane: WorkspaceControl,
+			StartStatus:           SessionStartStatus,
+			FinalStatus:           SessionFinalStatus,
+			Assurance:             SessionAssurance,
+		},
+		RequiredAuditEvents: append([]string(nil), requiredAuditEvents...),
+	}
+}
+
+func LoadContract(path string) (Contract, error) {
+	var contract Contract
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return contract, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&contract); err != nil {
+		return contract, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != nil && err != io.EOF {
+		return contract, fmt.Errorf("%s: unexpected trailing JSON content", path)
+	}
+	if err := contract.Validate(); err != nil {
+		return contract, fmt.Errorf("%s: %w", path, err)
+	}
+	return contract, nil
+}
+
+func (c Contract) Validate() error {
+	if c.Version != 1 {
+		return fmt.Errorf("unsupported remote-vm contract version %d", c.Version)
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "target_kind", value: c.TargetKind, want: TargetKind},
+		{name: "target_provider", value: c.TargetProvider, want: CanonicalProvider},
+		{name: "target_assurance_class", value: c.TargetAssuranceClass, want: AssuranceClass},
+		{name: "support_boundary", value: c.SupportBoundary, want: SupportBoundary},
+		{name: "runtime_api", value: c.RuntimeAPI, want: RuntimeAPI},
+		{name: "workspace_transport", value: c.WorkspaceTransport, want: WorkspaceTransport},
+		{name: "access_model", value: c.AccessModel, want: AccessModel},
+		{name: "workspace_materialization.mode", value: c.WorkspaceMaterialization.Mode, want: MaterializationMode},
+		{name: "workspace_materialization.manifest_name", value: c.WorkspaceMaterialization.ManifestName, want: MaterializationFile},
+		{name: "workspace_materialization.workspace_dir", value: c.WorkspaceMaterialization.WorkspaceDir, want: MaterializedWorktree},
+		{name: "bootstrap.manifest_name", value: c.Bootstrap.ManifestName, want: BootstrapFile},
+		{name: "session.workspace_control_plane", value: c.Session.WorkspaceControlPlane, want: WorkspaceControl},
+		{name: "session.start_status", value: c.Session.StartStatus, want: SessionStartStatus},
+		{name: "session.final_status", value: c.Session.FinalStatus, want: SessionFinalStatus},
+		{name: "session.assurance", value: c.Session.Assurance, want: SessionAssurance},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("%s may not be empty", field.name)
+		}
+		if field.value != field.want {
+			return fmt.Errorf("%s must be %q, got %q", field.name, field.want, field.value)
+		}
+	}
+	if !slices.Equal(c.WorkspaceMaterialization.ExcludedPaths, []string{".git"}) {
+		return fmt.Errorf("workspace_materialization.excluded_paths must be [\".git\"]")
+	}
+	if !slices.Equal(c.RequiredAuditEvents, requiredAuditEvents) {
+		return fmt.Errorf("required_audit_events must be %v", requiredAuditEvents)
+	}
+	return nil
+}

--- a/internal/remotevm/contract_test.go
+++ b/internal/remotevm/contract_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package remotevm
+
+import (
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func TestDefaultContractMatchesPolicyArtifact(t *testing.T) {
+	t.Parallel()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	policyPath := filepath.Join(filepath.Dir(file), "..", "..", "policy", "remote-vm-contract.json")
+	got, err := LoadContract(policyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := DefaultContract()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("LoadContract(%s) = %#v, want %#v", policyPath, got, want)
+	}
+}
+
+func TestDefaultContractValidates(t *testing.T) {
+	t.Parallel()
+
+	if err := DefaultContract().Validate(); err != nil {
+		t.Fatalf("DefaultContract().Validate() error = %v", err)
+	}
+}

--- a/internal/remotevm/doc.go
+++ b/internal/remotevm/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package remotevm defines the canonical preview-only remote_vm contract used
+// by the shared fake target and conformance harness. Later cloud adapters are
+// expected to satisfy this contract without forking the lifecycle semantics.
+package remotevm

--- a/internal/remotevm/fake_target.go
+++ b/internal/remotevm/fake_target.go
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package remotevm
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/hostutil"
+)
+
+type WorkspaceEntry struct {
+	Path       string      `json:"path"`
+	Kind       string      `json:"kind"`
+	Mode       fs.FileMode `json:"mode"`
+	SHA256     string      `json:"sha256,omitempty"`
+	LinkTarget string      `json:"link_target,omitempty"`
+}
+
+type WorkspaceManifest struct {
+	Version               int              `json:"version"`
+	TargetKind            string           `json:"target_kind"`
+	TargetProvider        string           `json:"target_provider"`
+	TargetID              string           `json:"target_id"`
+	WorkspaceTransport    string           `json:"workspace_transport"`
+	SourceWorkspace       string           `json:"source_workspace"`
+	MaterializationID     string           `json:"materialization_id"`
+	MaterializedWorkspace string           `json:"materialized_workspace"`
+	ExcludedPaths         []string         `json:"excluded_paths"`
+	Entries               []WorkspaceEntry `json:"entries"`
+}
+
+type BootstrapManifest struct {
+	Version              int    `json:"version"`
+	TargetKind           string `json:"target_kind"`
+	TargetProvider       string `json:"target_provider"`
+	TargetID             string `json:"target_id"`
+	TargetAssuranceClass string `json:"target_assurance_class"`
+	SupportBoundary      string `json:"support_boundary"`
+	RuntimeAPI           string `json:"runtime_api"`
+	AccessModel          string `json:"access_model"`
+	BootstrapID          string `json:"bootstrap_id"`
+	ImageRef             string `json:"image_ref"`
+}
+
+type MaterializeRequest struct {
+	StateRoot         string
+	TargetID          string
+	MaterializationID string
+	SourceWorkspace   string
+}
+
+type MaterializeResult struct {
+	TargetRoot            string
+	MaterializationRoot   string
+	ManifestPath          string
+	MaterializedWorkspace string
+	Manifest              WorkspaceManifest
+}
+
+type BootstrapRequest struct {
+	StateRoot   string
+	TargetID    string
+	BootstrapID string
+	ImageRef    string
+}
+
+type BootstrapResult struct {
+	TargetRoot   string
+	ManifestPath string
+	AuditLogPath string
+	Manifest     BootstrapManifest
+}
+
+type StartSessionRequest struct {
+	SessionID       string
+	Agent           string
+	Mode            string
+	StartedAt       string
+	Materialization MaterializeResult
+	Bootstrap       BootstrapResult
+}
+
+type FinishSessionRequest struct {
+	Started    SessionResult
+	FinishedAt string
+	ExitStatus string
+}
+
+type SessionResult struct {
+	Record       hostutil.SessionRecord
+	RecordPath   string
+	AuditLogPath string
+}
+
+type ConformanceTarget interface {
+	MaterializeWorkspace(context.Context, MaterializeRequest) (MaterializeResult, error)
+	BootstrapTarget(context.Context, BootstrapRequest) (BootstrapResult, error)
+	StartSession(context.Context, StartSessionRequest) (SessionResult, error)
+	FinishSession(context.Context, FinishSessionRequest) (SessionResult, error)
+}
+
+type FakeTarget struct {
+	Contract Contract
+}
+
+func NewFakeTarget(contract Contract) (FakeTarget, error) {
+	if contract.Version == 0 &&
+		contract.TargetKind == "" &&
+		contract.TargetProvider == "" &&
+		contract.TargetAssuranceClass == "" {
+		contract = DefaultContract()
+	}
+	if err := contract.Validate(); err != nil {
+		return FakeTarget{}, err
+	}
+	return FakeTarget{Contract: contract}, nil
+}
+
+func (f FakeTarget) MaterializeWorkspace(_ context.Context, req MaterializeRequest) (MaterializeResult, error) {
+	if strings.TrimSpace(req.StateRoot) == "" {
+		return MaterializeResult{}, fmt.Errorf("state root is required")
+	}
+	if strings.TrimSpace(req.TargetID) == "" {
+		return MaterializeResult{}, fmt.Errorf("target id is required")
+	}
+	if strings.TrimSpace(req.MaterializationID) == "" {
+		return MaterializeResult{}, fmt.Errorf("materialization id is required")
+	}
+	if strings.TrimSpace(req.SourceWorkspace) == "" {
+		return MaterializeResult{}, fmt.Errorf("source workspace is required")
+	}
+	targetRoot := targetRoot(req.StateRoot, req.TargetID)
+	materializationRoot := filepath.Join(targetRoot, "materializations", req.MaterializationID)
+	workspaceRoot := filepath.Join(materializationRoot, f.Contract.WorkspaceMaterialization.WorkspaceDir)
+	manifestPath := filepath.Join(materializationRoot, f.Contract.WorkspaceMaterialization.ManifestName)
+	if err := os.RemoveAll(materializationRoot); err != nil {
+		return MaterializeResult{}, err
+	}
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		return MaterializeResult{}, err
+	}
+	entries, err := copyWorkspaceTree(req.SourceWorkspace, workspaceRoot, f.Contract.WorkspaceMaterialization.ExcludedPaths)
+	if err != nil {
+		return MaterializeResult{}, err
+	}
+	manifest := WorkspaceManifest{
+		Version:               1,
+		TargetKind:            f.Contract.TargetKind,
+		TargetProvider:        f.Contract.TargetProvider,
+		TargetID:              req.TargetID,
+		WorkspaceTransport:    f.Contract.WorkspaceTransport,
+		SourceWorkspace:       req.SourceWorkspace,
+		MaterializationID:     req.MaterializationID,
+		MaterializedWorkspace: workspaceRoot,
+		ExcludedPaths:         append([]string(nil), f.Contract.WorkspaceMaterialization.ExcludedPaths...),
+		Entries:               entries,
+	}
+	if err := writeJSON(manifestPath, manifest); err != nil {
+		return MaterializeResult{}, err
+	}
+	return MaterializeResult{
+		TargetRoot:            targetRoot,
+		MaterializationRoot:   materializationRoot,
+		ManifestPath:          manifestPath,
+		MaterializedWorkspace: workspaceRoot,
+		Manifest:              manifest,
+	}, nil
+}
+
+func (f FakeTarget) BootstrapTarget(_ context.Context, req BootstrapRequest) (BootstrapResult, error) {
+	if strings.TrimSpace(req.StateRoot) == "" {
+		return BootstrapResult{}, fmt.Errorf("state root is required")
+	}
+	if strings.TrimSpace(req.TargetID) == "" {
+		return BootstrapResult{}, fmt.Errorf("target id is required")
+	}
+	if strings.TrimSpace(req.BootstrapID) == "" {
+		return BootstrapResult{}, fmt.Errorf("bootstrap id is required")
+	}
+	if strings.TrimSpace(req.ImageRef) == "" {
+		return BootstrapResult{}, fmt.Errorf("image ref is required")
+	}
+	targetRoot := targetRoot(req.StateRoot, req.TargetID)
+	bootstrapRoot := filepath.Join(targetRoot, "bootstrap")
+	if err := os.MkdirAll(bootstrapRoot, 0o755); err != nil {
+		return BootstrapResult{}, err
+	}
+	manifestPath := filepath.Join(bootstrapRoot, f.Contract.Bootstrap.ManifestName)
+	manifest := BootstrapManifest{
+		Version:              1,
+		TargetKind:           f.Contract.TargetKind,
+		TargetProvider:       f.Contract.TargetProvider,
+		TargetID:             req.TargetID,
+		TargetAssuranceClass: f.Contract.TargetAssuranceClass,
+		SupportBoundary:      f.Contract.SupportBoundary,
+		RuntimeAPI:           f.Contract.RuntimeAPI,
+		AccessModel:          f.Contract.AccessModel,
+		BootstrapID:          req.BootstrapID,
+		ImageRef:             req.ImageRef,
+	}
+	if err := writeJSON(manifestPath, manifest); err != nil {
+		return BootstrapResult{}, err
+	}
+	return BootstrapResult{
+		TargetRoot:   targetRoot,
+		ManifestPath: manifestPath,
+		AuditLogPath: filepath.Join(targetRoot, "workcell.audit.log"),
+		Manifest:     manifest,
+	}, nil
+}
+
+func (f FakeTarget) StartSession(_ context.Context, req StartSessionRequest) (SessionResult, error) {
+	if strings.TrimSpace(req.SessionID) == "" {
+		return SessionResult{}, fmt.Errorf("session id is required")
+	}
+	if strings.TrimSpace(req.Agent) == "" {
+		return SessionResult{}, fmt.Errorf("agent is required")
+	}
+	if strings.TrimSpace(req.Mode) == "" {
+		return SessionResult{}, fmt.Errorf("mode is required")
+	}
+	if strings.TrimSpace(req.StartedAt) == "" {
+		return SessionResult{}, fmt.Errorf("started at is required")
+	}
+	if _, err := os.Stat(req.Materialization.ManifestPath); err != nil {
+		return SessionResult{}, err
+	}
+	if _, err := os.Stat(req.Bootstrap.ManifestPath); err != nil {
+		return SessionResult{}, err
+	}
+	recordPath := filepath.Join(req.Bootstrap.TargetRoot, "sessions", req.SessionID+".json")
+	record := hostutil.SessionRecord{
+		Version:               1,
+		SessionID:             req.SessionID,
+		Profile:               req.Bootstrap.Manifest.TargetID,
+		TargetKind:            f.Contract.TargetKind,
+		TargetProvider:        f.Contract.TargetProvider,
+		TargetID:              req.Bootstrap.Manifest.TargetID,
+		TargetAssuranceClass:  f.Contract.TargetAssuranceClass,
+		RuntimeAPI:            f.Contract.RuntimeAPI,
+		WorkspaceTransport:    f.Contract.WorkspaceTransport,
+		Agent:                 req.Agent,
+		Mode:                  req.Mode,
+		Status:                f.Contract.Session.StartStatus,
+		Workspace:             req.Materialization.MaterializedWorkspace,
+		WorkspaceOrigin:       req.Materialization.Manifest.SourceWorkspace,
+		WorkspaceRoot:         req.Materialization.MaterializedWorkspace,
+		WorktreePath:          req.Materialization.MaterializedWorkspace,
+		AuditLogPath:          req.Bootstrap.AuditLogPath,
+		StartedAt:             req.StartedAt,
+		ObservedAt:            req.StartedAt,
+		InitialAssurance:      f.Contract.Session.Assurance,
+		CurrentAssurance:      f.Contract.Session.Assurance,
+		WorkspaceControlPlane: f.Contract.Session.WorkspaceControlPlane,
+	}
+	if err := hostutil.WriteSessionRecord(recordPath, map[string]string{
+		"session_id":              record.SessionID,
+		"profile":                 record.Profile,
+		"target_kind":             record.TargetKind,
+		"target_provider":         record.TargetProvider,
+		"target_id":               record.TargetID,
+		"target_assurance_class":  record.TargetAssuranceClass,
+		"runtime_api":             record.RuntimeAPI,
+		"workspace_transport":     record.WorkspaceTransport,
+		"agent":                   record.Agent,
+		"mode":                    record.Mode,
+		"status":                  record.Status,
+		"workspace":               record.Workspace,
+		"workspace_origin":        record.WorkspaceOrigin,
+		"workspace_root":          record.WorkspaceRoot,
+		"worktree_path":           record.WorktreePath,
+		"audit_log_path":          record.AuditLogPath,
+		"started_at":              record.StartedAt,
+		"observed_at":             record.ObservedAt,
+		"initial_assurance":       record.InitialAssurance,
+		"current_assurance":       record.CurrentAssurance,
+		"workspace_control_plane": record.WorkspaceControlPlane,
+	}); err != nil {
+		return SessionResult{}, err
+	}
+	for _, line := range []string{
+		fmt.Sprintf("ts=%s session_id=%s event=workspace_materialized target_kind=%s target_provider=%s target_id=%s workspace_transport=%s materialization_id=%s workspace_origin=%s workspace=%s", req.StartedAt, req.SessionID, f.Contract.TargetKind, f.Contract.TargetProvider, req.Bootstrap.Manifest.TargetID, f.Contract.WorkspaceTransport, req.Materialization.Manifest.MaterializationID, req.Materialization.Manifest.SourceWorkspace, req.Materialization.MaterializedWorkspace),
+		fmt.Sprintf("ts=%s session_id=%s event=bootstrap_ready target_kind=%s target_provider=%s target_id=%s runtime_api=%s access_model=%s bootstrap_id=%s image_ref=%s", req.StartedAt, req.SessionID, f.Contract.TargetKind, f.Contract.TargetProvider, req.Bootstrap.Manifest.TargetID, f.Contract.RuntimeAPI, f.Contract.AccessModel, req.Bootstrap.Manifest.BootstrapID, req.Bootstrap.Manifest.ImageRef),
+		fmt.Sprintf("ts=%s session_id=%s event=session_started target_kind=%s target_provider=%s target_id=%s status=%s workspace_control_plane=%s", req.StartedAt, req.SessionID, f.Contract.TargetKind, f.Contract.TargetProvider, req.Bootstrap.Manifest.TargetID, f.Contract.Session.StartStatus, f.Contract.Session.WorkspaceControlPlane),
+	} {
+		if err := appendAuditLine(req.Bootstrap.AuditLogPath, line); err != nil {
+			return SessionResult{}, err
+		}
+	}
+	record, err := hostutil.ReadSessionRecord(recordPath)
+	if err != nil {
+		return SessionResult{}, err
+	}
+	return SessionResult{Record: record, RecordPath: recordPath, AuditLogPath: req.Bootstrap.AuditLogPath}, nil
+}
+
+func (f FakeTarget) FinishSession(_ context.Context, req FinishSessionRequest) (SessionResult, error) {
+	if strings.TrimSpace(req.FinishedAt) == "" {
+		return SessionResult{}, fmt.Errorf("finished at is required")
+	}
+	if strings.TrimSpace(req.ExitStatus) == "" {
+		return SessionResult{}, fmt.Errorf("exit status is required")
+	}
+	if req.Started.RecordPath == "" {
+		return SessionResult{}, fmt.Errorf("started session record path is required")
+	}
+	if err := hostutil.WriteSessionRecord(req.Started.RecordPath, map[string]string{
+		"status":            f.Contract.Session.FinalStatus,
+		"live_status":       "stopped",
+		"observed_at":       req.FinishedAt,
+		"finished_at":       req.FinishedAt,
+		"exit_status":       req.ExitStatus,
+		"final_assurance":   f.Contract.Session.Assurance,
+		"current_assurance": f.Contract.Session.Assurance,
+	}); err != nil {
+		return SessionResult{}, err
+	}
+	if err := appendAuditLine(req.Started.AuditLogPath, fmt.Sprintf("ts=%s session_id=%s event=session_finished target_kind=%s target_provider=%s target_id=%s status=%s exit_status=%s", req.FinishedAt, req.Started.Record.SessionID, f.Contract.TargetKind, f.Contract.TargetProvider, req.Started.Record.TargetID, f.Contract.Session.FinalStatus, req.ExitStatus)); err != nil {
+		return SessionResult{}, err
+	}
+	record, err := hostutil.ReadSessionRecord(req.Started.RecordPath)
+	if err != nil {
+		return SessionResult{}, err
+	}
+	return SessionResult{Record: record, RecordPath: req.Started.RecordPath, AuditLogPath: req.Started.AuditLogPath}, nil
+}
+
+func targetRoot(stateRoot, targetID string) string {
+	return filepath.Join(stateRoot, "targets", TargetKind, CanonicalProvider, targetID)
+}
+
+func copyWorkspaceTree(sourceRoot, destRoot string, excluded []string) ([]WorkspaceEntry, error) {
+	entries := make([]WorkspaceEntry, 0)
+	err := filepath.WalkDir(sourceRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == sourceRoot {
+			return nil
+		}
+		rel, err := filepath.Rel(sourceRoot, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if isExcludedPath(rel, excluded) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		destPath := filepath.Join(destRoot, filepath.FromSlash(rel))
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+				return err
+			}
+			if err := os.Symlink(target, destPath); err != nil {
+				return err
+			}
+			entries = append(entries, WorkspaceEntry{Path: rel, Kind: "symlink", Mode: info.Mode(), LinkTarget: target})
+		case info.IsDir():
+			if err := os.MkdirAll(destPath, info.Mode().Perm()); err != nil {
+				return err
+			}
+			entries = append(entries, WorkspaceEntry{Path: rel, Kind: "dir", Mode: info.Mode()})
+		case info.Mode().IsRegular():
+			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+				return err
+			}
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(destPath, content, info.Mode().Perm()); err != nil {
+				return err
+			}
+			sum := sha256.Sum256(content)
+			entries = append(entries, WorkspaceEntry{
+				Path:   rel,
+				Kind:   "file",
+				Mode:   info.Mode(),
+				SHA256: hex.EncodeToString(sum[:]),
+			})
+		default:
+			return fmt.Errorf("unsupported workspace entry kind for %s", rel)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+	return entries, nil
+}
+
+func isExcludedPath(rel string, excluded []string) bool {
+	for _, item := range excluded {
+		if rel == item || strings.HasPrefix(rel, item+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func writeJSON(path string, value any) error {
+	content, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	content = append(content, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, content, 0o644)
+}
+
+func appendAuditLine(path, line string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	handle, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer handle.Close()
+	if _, err := io.WriteString(handle, line+"\n"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/remotevm/fake_target_test.go
+++ b/internal/remotevm/fake_target_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package remotevm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFakeTargetMaterializeWorkspaceCopiesFixtureAndExcludesDotGit(t *testing.T) {
+	t.Parallel()
+
+	contract := DefaultContract()
+	target, err := NewFakeTarget(contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceRoot := filepath.Join("testdata", "source-workspace")
+	tempWorkspace := t.TempDir()
+	if _, err := copyWorkspaceTree(sourceRoot, tempWorkspace, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tempWorkspace, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempWorkspace, ".git", "config"), []byte("[core]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := target.MaterializeWorkspace(context.Background(), MaterializeRequest{
+		StateRoot:         t.TempDir(),
+		TargetID:          "fake-remote-target",
+		MaterializationID: "fixture-materialization",
+		SourceWorkspace:   tempWorkspace,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(result.MaterializedWorkspace, ".git")); !os.IsNotExist(err) {
+		t.Fatalf(".git unexpectedly materialized: %v", err)
+	}
+	if got, want := len(result.Manifest.Entries), 3; got != want {
+		t.Fatalf("len(result.Manifest.Entries) = %d, want %d", got, want)
+	}
+}

--- a/internal/remotevm/testdata/source-workspace/README.md
+++ b/internal/remotevm/testdata/source-workspace/README.md
@@ -1,0 +1,1 @@
+# Fixture Workspace

--- a/internal/remotevm/testdata/source-workspace/subdir/config.txt
+++ b/internal/remotevm/testdata/source-workspace/subdir/config.txt
@@ -1,0 +1,1 @@
+remote vm contract fixture

--- a/policy/remote-vm-contract.json
+++ b/policy/remote-vm-contract.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "target_kind": "remote_vm",
+  "target_provider": "fake-remote",
+  "target_assurance_class": "compat",
+  "support_boundary": "preview-only",
+  "runtime_api": "brokered",
+  "workspace_transport": "remote-materialization",
+  "access_model": "brokered",
+  "workspace_materialization": {
+    "mode": "explicit",
+    "manifest_name": "materialization.json",
+    "workspace_dir": "workspace",
+    "excluded_paths": [
+      ".git"
+    ]
+  },
+  "bootstrap": {
+    "manifest_name": "bootstrap.json"
+  },
+  "session": {
+    "workspace_control_plane": "host-brokered",
+    "start_status": "running",
+    "final_status": "exited",
+    "assurance": "compat-preview-brokered"
+  },
+  "required_audit_events": [
+    "workspace_materialized",
+    "bootstrap_ready",
+    "session_started",
+    "session_finished"
+  ]
+}

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -516,6 +516,7 @@
       "job_name": "Dependency review",
       "workflow_events": [
         "pull_request",
+        "push",
         "workflow_dispatch"
       ],
       "authority": "github-only",

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -6752,7 +6752,7 @@ EOF
       exit 1
     fi
     for required in \
-      'slow_apt_helper=/tmp/workcell-slow-apt-helper.sh' \
+      'slow_apt_helper=/state/tmp/workcell-slow-apt-helper.sh' \
       '/bin/bash /usr/local/libexec/workcell/apt-broker.sh' \
       'sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get update' \
       'slow-apt-helper-ok' \


### PR DESCRIPTION
## Summary
- add the canonical preview-only `remote_vm` contract artifact and typed `internal/remotevm` package
- add the shared fake target, explicit workspace materialization flow, and reusable conformance harness
- refresh repo-owned parity metadata and the apt-broker invariant probe needed to keep local `pr-parity` green

## Validation
- `go test ./internal/remotevm ./internal/hostutil ./cmd/workcell-hostutil ./internal/testkit`
- `bash ./scripts/verify-requirements-coverage.sh`
- `bash ./scripts/check-public-repo-hygiene.sh`
- `bash ./scripts/validate-repo.sh`
- `bash ./scripts/pre-merge.sh --profile pr-parity`
