### PR TITLE
Align Phase 5 remote VM contract docs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,14 +18,12 @@ The deterministic phase breakdown lives in
 - expand end-to-end coverage for authenticated, lower-assurance, and
   session-supervisor transitions so new orchestration features ship with
   invariant checks
-- define the provider-neutral remote-VM contract, shared fake target, and
-  evidence gates that later
-  `compat` and `remote_vm` targets must satisfy, without implying backend
-  shipment or Tier 1 Linux or Windows host parity before the same guarantees
-  exist
-- keep the shipped canonical host-support matrix and the new shared remote-VM
-  conformance harness authoritative so later targets cannot fork the support
-  contract by accident
+- ship the first cross-platform compatibility backend with explicit
+  lower-assurance labeling, deterministic backend-selection and state-routing
+  behavior, and rollback guidance that preserves the strict Colima path
+- keep the shipped canonical host-support matrix and shared remote-VM
+  conformance harness authoritative so later `compat` and `remote_vm` targets
+  cannot fork the support contract by accident
 
 ## Medium term
 

--- a/docs/implement-first-delivery-plan.md
+++ b/docs/implement-first-delivery-plan.md
@@ -7,8 +7,8 @@ The longer-lived runtime-target and deployment-reach program lives in
 [`docs/runtime-target-expansion-plan.md`](runtime-target-expansion-plan.md),
 and the deterministic phase breakdown lives in
 [`docs/runtime-target-phase-plan.md`](runtime-target-phase-plan.md).
-Phases 1 through 4 of that phase plan are now implemented in the repository;
-this document now defines the immediate bridge into Phase 5 and the
+Phases 1 through 5 of that phase plan are now implemented in the repository;
+this document now defines the immediate bridge into Phase 6 and the
 prerequisite work for later backend phases.
 
 The current repo already includes durable session records plus detached
@@ -21,11 +21,13 @@ Codex host-auth reuse on the reviewed resolver path, `--auth-status`,
 credential-level `why` bootstrap summaries, and the provider/bootstrap support
 matrix on the reviewed policy path. The current repo also ships the trusted
 validation-host lane, canonical host-support matrix, and fail-closed
-unsupported-combination diagnostics from Phase 4. The active work in this
-slice is now the provider-neutral remote-VM control-plane contract. This
-document also records the queued scenario-evidence and later-backend
-prerequisites so later phases can start cleanly without pulling backend
-delivery forward into Phase 5.
+unsupported-combination diagnostics from Phase 4. The current repo now also
+ships the canonical preview-only remote-VM contract, shared fake target, and
+deterministic conformance harness from Phase 5. The active work in this slice
+is now the first cross-platform `compat` backend. This document also records
+the queued scenario-evidence and later-backend prerequisites so later phases
+can start cleanly without pulling raw remote-provider delivery forward into
+Phase 6.
 
 ## Principles
 
@@ -56,20 +58,20 @@ Owner-lane default:
   distinct Codex-agent lanes or threads unless a later change or runbook names
   specific humans explicitly
 
-## Phase 5 Exit Ownership
+## Phase 6 Exit Ownership
 
 - EM:
-  holds the remote-VM phase boundary, preview-scope guardrails, and the
-  decision that the shared contract is ready for provider-specific reuse
+  holds the `compat` support boundary, rollback approval, and the decision
+  that the first cross-platform backend is ready to move forward
 - TL:
-  owns the shared fake remote target, conformance harness, and deterministic
-  remote-contract integration
+  owns `docker-desktop` integration, deterministic backend selection, and
+  rollback readiness on the shared target model
 - contract and docs owner:
-  owns the canonical remote-contract docs, support matrices, and operator
-  guidance that later provider phases must reuse
+  owns explicit `compat` labeling, the canonical matrices, and operator
+  guidance for enable, disable, and rollback
 - validation owner:
-  owns repo-required remote-contract evidence, certification-lane boundaries,
-  and harness reuse requirements for later provider phases
+  owns repo-required backend-selection, state-routing, and fail-closed
+  evidence plus the validation-host certification lane that bounds host claims
 
 ## Delivered Foundation
 
@@ -85,37 +87,42 @@ to the next slice rather than as active delivery work:
   the current secretless and authenticated scenario baseline
 - the trusted validation-host lane, canonical host-support matrix, and
   fail-closed unsupported-combination diagnostics from Phase 4
+- the canonical preview-only remote-VM contract, shared fake target, and
+  deterministic conformance harness from Phase 5
 
-## Active Phase 5 Track
+## Active Phase 6 Track
 
-### 1. Remote VM Control-Plane Contract
+### 1. Docker Desktop Compatibility Backend
 
 Scope for this delivery slice:
 
-- define the provider-neutral `remote_vm` contract before any cloud backend
-  ships
-- make remote workspace materialization explicit and auditable
-- define the reviewed brokered-access and remote image/bootstrap model
-- add one canonical shared fake remote target, conformance harness, and
-  fixtures that later cloud adapters must reuse unchanged
-- keep target ordering and backend selection in the longer-lived
-  runtime-target expansion program rather than in this active slice
+- ship the first cross-platform `compat` backend without blurring it into the
+  current strict Colima boundary
+- feature-flag `docker-desktop` and keep it explicitly lower assurance than
+  the strict path
+- make backend selection, state-root routing, and unsupported-combination
+  diagnostics deterministic on top of the completed target model
+- require host-matrix certification evidence plus explicit enable, disable,
+  and rollback guidance in the same slice
+- keep raw `remote_vm` providers and managed-workstation delivery out of this
+  active slice
 
 Staffing:
 
-- EM: remote-contract boundary owner
-- TL: remote contract lead
-- SWE A: remote workspace and audit model
-- SWE B: contract docs, fakes, and deterministic evidence
-- validation owner: shared conformance evidence and certification-lane lead
+- EM: compat support-boundary owner
+- TL: compat backend lead
+- SWE A: backend selection and state routing
+- SWE B: compat docs, rollback guidance, and deterministic evidence
+- validation owner: repo-required selection and fail-closed evidence plus
+  certification-lane lead
 
 Phase boundary:
 
 - this is the active implementation slice and the only track that should change
-  Phase 5 status from planned to complete
+  Phase 6 status from planned to complete
 - the remaining tracks below are prerequisites and follow-on planning surfaces
-  for later deterministic phases, not authority to ship provider adapters in
-  the current slice
+  for later deterministic phases, not authority to ship raw remote VM
+  providers in the current slice
 
 ## Immediate Follow-On Prerequisites
 
@@ -137,7 +144,7 @@ Staffing:
 
 ## Later Phase Handoff
 
-Before Phase 6, 7, 8, or 9 begins implementation, assign distinct owner lanes:
+Before Phase 7, 8, or 9 begins implementation, assign distinct owner lanes:
 
 - EM:
   support-boundary owner for rollout scope, preview/GA decisions, and rollback
@@ -153,12 +160,13 @@ Before Phase 6, 7, 8, or 9 begins implementation, assign distinct owner lanes:
 
 1. treat the completed shared auth/bootstrap path plus the
    provider/bootstrap support matrix and completed Phase 4 host-support
-   surfaces as fixed input to the next slice
-2. define the remote-VM contract and deterministic evidence before any
-   provider-specific backend work
-3. expand authenticated, lower-assurance, and remote-contract coverage as each
+   surfaces plus the completed Phase 5 remote-contract harness as fixed input
+   to the next slice
+2. ship the first `compat` backend before any raw remote-VM provider adapter
+   work
+3. expand authenticated, lower-assurance, and target-contract coverage as each
    later phase lands rather than as a cleanup pass
-4. leave actual `compat` and cloud-backend delivery to the later
+4. leave later raw `remote_vm` and managed-workstation delivery to the later
    runtime-target program phases once these prerequisites and owner handoffs
    are done
 
@@ -171,6 +179,5 @@ Before Phase 6, 7, 8, or 9 begins implementation, assign distinct owner lanes:
 - secret materialization paths that bypass the reviewed host policy flow
 - automatic backend fallback
 - broad Linux or Windows parity claims
-- selecting or shipping `docker-desktop`, `aws-ec2-ssm`, `gcp-vm`, or
-  `azure-vm` in this slice
+- selecting or shipping `aws-ec2-ssm`, `gcp-vm`, or `azure-vm` in this slice
 - Kubernetes-backed execution or managed-workstation delivery in this slice

--- a/docs/remote-vm-contract.md
+++ b/docs/remote-vm-contract.md
@@ -1,0 +1,86 @@
+# Remote VM Contract
+
+Workcell now carries one canonical preview-only `remote_vm` contract in
+[`policy/remote-vm-contract.json`](../policy/remote-vm-contract.json). This is
+the provider-neutral control-plane contract that later cloud adapters must
+reuse; it does not mean a production cloud backend ships today.
+
+The contract is implemented and exercised through:
+
+- [`internal/remotevm`](../internal/remotevm) for the typed contract,
+  canonical fake target, and reusable conformance harness
+- [`internal/remotevm/contract_test.go`](../internal/remotevm/contract_test.go)
+- [`internal/remotevm/fake_target_test.go`](../internal/remotevm/fake_target_test.go)
+- [`internal/remotevm/conformance_test.go`](../internal/remotevm/conformance_test.go)
+
+## Canonical Values
+
+The canonical preview-only contract is:
+
+- `target_kind = remote_vm`
+- `target_provider = fake-remote`
+- `target_assurance_class = compat`
+- `support_boundary = preview-only`
+- `runtime_api = brokered`
+- `workspace_transport = remote-materialization`
+- `access_model = brokered`
+
+Later provider adapters must not fork those control-plane meanings. Provider
+work can add provider-specific bootstrap details, but the shared session,
+audit, workspace-materialization, and conformance semantics stay the same.
+
+## Workspace Materialization
+
+Remote workspaces are explicit and host-auditable. The canonical fake target
+materializes a reviewed source workspace into:
+
+`targets/remote_vm/fake-remote/<target-id>/materializations/<materialization-id>/`
+
+That root contains:
+
+- `workspace/` with the materialized remote workspace contents
+- `materialization.json` with the explicit entry manifest
+
+The canonical contract excludes `.git` from the materialized workspace and
+records the materialized tree in the manifest instead of treating a live host
+mount as the remote target.
+
+## Bootstrap And Session Lifecycle
+
+Target bootstrap is explicit and file-backed:
+
+- `targets/remote_vm/fake-remote/<target-id>/bootstrap/bootstrap.json`
+
+Session records stay on the same Workcell-owned target-state tree:
+
+- `targets/remote_vm/fake-remote/<target-id>/sessions/<session-id>.json`
+
+The shared audit log for that target is:
+
+- `targets/remote_vm/fake-remote/<target-id>/workcell.audit.log`
+
+Required audit events are:
+
+- `workspace_materialized`
+- `bootstrap_ready`
+- `session_started`
+- `session_finished`
+
+The canonical session contract uses:
+
+- `workspace_control_plane = host-brokered`
+- `status = running` at session start
+- `status = exited` at session finish
+- `assurance = compat-preview-brokered`
+
+## Reuse Rule For Later Providers
+
+Later `remote_vm` providers such as `aws-ec2-ssm` and `gcp-vm` must implement
+the shared [`remotevm.ConformanceTarget`](../internal/remotevm/fake_target.go)
+interface and pass the shared
+[`remotevm.RunConformance`](../internal/remotevm/conformance.go) harness
+without redefining a provider-specific contract suite.
+
+That reuse rule is the main Phase 5 boundary: provider work starts only after
+this provider-neutral contract is fixed, documented, and proven
+deterministically in-repo.

--- a/docs/runtime-target-phase-plan.md
+++ b/docs/runtime-target-phase-plan.md
@@ -20,7 +20,9 @@ Current repo status:
   explainability, and provider bootstrap support matrix
 - Phase 4 is implemented in the trusted validation-host lane, canonical
   host-support matrix, and fail-closed unsupported-combination diagnostics
-- Phase 5 is the next active slice: remote VM control-plane contract
+- Phase 5 is implemented in the canonical remote VM contract, shared fake
+  target, and deterministic conformance harness
+- Phase 6 is the next active slice: Docker Desktop compatibility backend
 - later phases remain planning targets until their code and evidence land
 
 ## Phase Completion Contract

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -28,6 +28,10 @@ Use these anchors when checking release-facing claims:
 - host-side session inventory and control plus detached workspace-mode
   remediation: `shared/session-commands`
 - persistent cache-plane contract checks: `shared/assurance-dry-run`
+- canonical preview-only remote VM contract:
+  `internal/remotevm/contract_test.go`,
+  `internal/remotevm/fake_target_test.go`,
+  `internal/remotevm/conformance_test.go`
 - Claude hook coverage: `claude-swe/hook-parametric`
 - supported GitHub-hosted macOS release window:
   `scripts/verify-github-macos-release-test-runners.sh`
@@ -57,6 +61,9 @@ They cover repo shape, runtime contracts, smoke behavior, and reproducibility.
 They also now cover canonical requirement traceability, host-side policy
 inspection and explainability, host-side detached session inventory, control,
 logs/timeline, clean-base diff/export behavior, and operator-contract parity.
+They also now carry the canonical preview-only `remote_vm` contract through
+the deterministic `internal/remotevm` fake target and shared conformance
+harness.
 
 `./scripts/validate-repo.sh` runs the repo-required scenario tier through:
 

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -261,7 +261,32 @@ Provider integration remains intentionally thin and explicit:
 Workcell keeps one shared boundary and many thin adapters. It does not hide the
 real provider differences behind a fake universal control plane.
 
-### 10. Host-Side Detached Session Plane
+### 10. Runtime Target Taxonomy And Remote VM Contract
+
+The current live safe path is still the strict `local_vm/colima` boundary.
+Phase 5 adds a canonical preview-only `remote_vm` contract in
+[`policy/remote-vm-contract.json`](../policy/remote-vm-contract.json) plus a
+shared fake target and conformance harness in
+[`internal/remotevm`](../internal/remotevm).
+
+That contract fixes the control-plane meanings that later remote providers
+must reuse:
+
+- explicit host-owned remote workspace materialization rather than an implicit
+  live host mount
+- brokered access and bootstrap metadata rather than ambient host socket or
+  credential passthrough
+- `target kind`, `assurance class`, `runtime API`, and `workspace transport`
+  as separate recorded concepts in session and audit state
+- a shared fake target plus deterministic conformance harness that later cloud
+  adapters must pass unchanged instead of redefining contract suites per
+  provider
+
+This does not mean a cloud backend ships today. It means the provider-neutral
+contract is now fixed in-repo before later `remote_vm` adapters try to consume
+it.
+
+### 11. Host-Side Detached Session Plane
 
 Workcell now includes a host-owned detached session plane. The current CLI
 surface includes:
@@ -308,7 +333,7 @@ clean per-session git worktree on the host for supported source workspaces.
 The current session plane is intentionally file-backed and host-owned. It does
 not require a separate daemon, local socket trust, or centralized service.
 
-### 11. Verification and Release Posture
+### 12. Verification and Release Posture
 
 The repository pairs runtime controls with verification and provenance
 material:

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -176,6 +176,23 @@ docs = [
   "man/workcell.1",
 ]
 
+[functional.FR-010]
+title = "Canonical remote VM contract"
+summary = "Workcell defines a canonical preview-only remote_vm contract with explicit workspace materialization, brokered bootstrap and session lifecycle, and a shared fake target plus conformance harness that later provider adapters must reuse unchanged."
+evidence = [
+  "internal/remotevm/contract_test.go",
+  "internal/remotevm/fake_target_test.go",
+  "internal/remotevm/conformance_test.go",
+]
+docs = [
+  "docs/remote-vm-contract.md",
+  "docs/workcell-system-design.md",
+  "docs/validation-scenarios.md",
+  "docs/runtime-target-phase-plan.md",
+  "docs/implement-first-delivery-plan.md",
+  "ROADMAP.md",
+]
+
 [nonfunctional.NFR-001]
 title = "Bounded VM-plus-container execution"
 summary = "The safe path preserves a dedicated Colima VM plus a hardened container rather than depending on provider config as the security boundary."


### PR DESCRIPTION
## Summary
- document the canonical preview-only remote VM contract and later-provider reuse rule
- mark Phase 5 implemented and Phase 6 active across the planning and design docs
- add requirements and validation-traceability links for the remote VM contract evidence

## Validation
- `bash ./scripts/validate-repo.sh`
