### PR TITLE
Enforce upstream refresh hosted-controls parity

### DIFF
--- a/.github/workflows/upstream-refresh.yml
+++ b/.github/workflows/upstream-refresh.yml
@@ -80,20 +80,32 @@ jobs:
         env:
           WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL }}
           WORKCELL_UPSTREAM_REFRESH_GIT_NAME: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GIT_NAME }}
-          WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID: ${{ secrets.WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID }}
+          WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT }}
           WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY: ${{ secrets.WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY }}
         run: |
-          if [[ -z "${WORKCELL_UPSTREAM_REFRESH_GIT_NAME}" || -z "${WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL}" || -z "${WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY}" || -z "${WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID}" ]]; then
-            echo "Configure WORKCELL_UPSTREAM_REFRESH_GIT_NAME, WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL, WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY, and WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID before running upstream-refresh." >&2
+          if [[ -z "${WORKCELL_UPSTREAM_REFRESH_GIT_NAME}" || -z "${WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL}" || -z "${WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY}" || -z "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}" ]]; then
+            echo "Configure WORKCELL_UPSTREAM_REFRESH_GIT_NAME, WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL, WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY, and WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT before running upstream-refresh." >&2
             exit 1
           fi
           export GNUPGHOME="${RUNNER_TEMP}/gnupg"
           install -d -m 0700 "${GNUPGHOME}"
           printf '%s' "${WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY}" | gpg --batch --import
-          gpg --batch --list-secret-keys "${WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID}" >/dev/null
+          actual_fingerprint="$(
+            gpg --batch --with-colons --list-secret-keys |
+              awk -F: '$1 == "fpr" { print $10; exit }'
+          )"
+          if [[ -z "${actual_fingerprint}" ]]; then
+            echo "Unable to resolve a primary secret-key fingerprint after importing WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY." >&2
+            exit 1
+          fi
+          if [[ "${actual_fingerprint}" != "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}" ]]; then
+            echo "Imported signing key fingerprint ${actual_fingerprint} does not match audited fingerprint ${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}." >&2
+            exit 1
+          fi
+          gpg --batch --list-secret-keys "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}" >/dev/null
           git config user.name "${WORKCELL_UPSTREAM_REFRESH_GIT_NAME}"
           git config user.email "${WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL}"
-          git config user.signingkey "${WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID}"
+          git config user.signingkey "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}"
           git config commit.gpgsign true
           git config gpg.program gpg
           echo "GNUPGHOME=${GNUPGHOME}" >> "${GITHUB_ENV}"

--- a/cmd/workcell-metadatautil/main.go
+++ b/cmd/workcell-metadatautil/main.go
@@ -86,6 +86,18 @@ func main() {
 			die(fmt.Errorf("usage: %s fetch-rulesets TMP_DIR REPO", os.Args[0]))
 		}
 		err = metadatautil.FetchGitHubHostedControlsRulesets(os.Args[2], os.Args[3])
+	case "list-hosted-control-environments":
+		if len(os.Args) != 3 {
+			die(fmt.Errorf("usage: %s list-hosted-control-environments POLICY_PATH", os.Args[0]))
+		}
+		environments, listErr := metadatautil.HostedControlsEnvironmentNames(os.Args[2])
+		if listErr != nil {
+			die(listErr)
+		}
+		for _, environmentName := range environments {
+			fmt.Println(environmentName)
+		}
+		return
 	case "verify-github-hosted-controls":
 		if len(os.Args) != 5 {
 			die(fmt.Errorf("usage: %s verify-github-hosted-controls TMP_DIR REPO POLICY_PATH", os.Args[0]))

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -71,15 +71,22 @@ Other macOS versions are not install-gated today.
 - it runs on a weekday schedule and on manual dispatch
 - it refreshes provider pins, the Linux runtime and validator base images,
   Debian snapshot, Go/Rust/Hadolint toolchains, and release-build helper pins
-- it requires a maintainer-owned GitHub-verified signing key through
-  `WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY` and
-  `WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID`, plus matching
-  `WORKCELL_UPSTREAM_REFRESH_GIT_NAME` and
-  `WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL` repository variables
+- it binds to the `upstream-refresh` GitHub environment and requires the
+  environment-scoped public identity variables
+  `WORKCELL_UPSTREAM_REFRESH_GIT_NAME`,
+  `WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL`, and
+  `WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT`, plus the matching
+  environment secret `WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY`
+- it imports the signing key at runtime and fails closed unless the imported
+  primary secret-key fingerprint exactly matches the audited
+  `WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT` value
 - it opens a draft PR instead of mutating `main`
 - it leaves expensive validation behind the same maintainer approval gate used
   for other public-repo PRs instead of auto-dispatching workflows during
   publication
+- unattended scheduled signing remains a lower-assurance single-maintainer
+  exception until a stronger hosted signing path replaces the exported private
+  key flow
 
 `ci.yml` and `docs.yml` use the same explicit nonroot validator contract when
 they bind-mount the repository: the workflow computes the caller UID/GID,
@@ -113,6 +120,8 @@ reviewed inputs:
 - the `release` environment, with reviewer protection when the GitHub plan
   supports it and an explicitly documented lower-assurance fallback when it
   does not
+- the `hosted-controls-audit` and `upstream-refresh` environments, including
+  their required secrets and the audited public refresh identity
 - GitHub Actions SHA pinning
 - canonical repository variables such as
   `WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true` and

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -492,6 +493,10 @@ func HostedControlsEnvironmentNames(policyPath string) ([]string, error) {
 	return names, nil
 }
 
+func hostedControlsEnvironmentArtifactName(environmentName string) string {
+	return url.PathEscape(environmentName)
+}
+
 func FetchGitHubHostedControlsRulesets(tmpDir, repo string) error {
 	var summary []any
 	if err := readJSONFile(filepath.Join(tmpDir, "rulesets-summary.json"), &summary); err != nil {
@@ -863,8 +868,9 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		return fmt.Errorf("workflow environments missing on %s: %s", repo, strings.Join(missingWorkflowEnvironments, ", "))
 	}
 	for environmentName, environmentPolicy := range expectedWorkflowEnvironments {
+		artifactName := hostedControlsEnvironmentArtifactName(environmentName)
 		var environmentMeta map[string]any
-		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s.json", environmentName)), &environmentMeta); err != nil {
+		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s.json", artifactName)), &environmentMeta); err != nil {
 			return fmt.Errorf("read %s environment metadata: %w", environmentName, err)
 		}
 		if actualName, ok := environmentMeta["name"].(string); ok && actualName != "" && actualName != environmentName {
@@ -872,7 +878,7 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		}
 
 		var environmentVariables map[string]any
-		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s-variables.json", environmentName)), &environmentVariables); err != nil {
+		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s-variables.json", artifactName)), &environmentVariables); err != nil {
 			return fmt.Errorf("read %s environment variables: %w", environmentName, err)
 		}
 		actualEnvironmentVariables := map[string]any{}
@@ -910,7 +916,7 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		}
 
 		var environmentSecrets map[string]any
-		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s-secrets.json", environmentName)), &environmentSecrets); err != nil {
+		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s-secrets.json", artifactName)), &environmentSecrets); err != nil {
 			return fmt.Errorf("read %s environment secrets: %w", environmentName, err)
 		}
 		actualEnvironmentSecrets := map[string]struct{}{}
@@ -2013,7 +2019,10 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	for _, needle := range []string{
 		"gh api --paginate \"repos/${REPO}/actions/variables?per_page=100\"",
 		"jq -s '{total_count: (map(.total_count // 0) | max // 0), variables: (map(.variables // []) | add)}'",
+		"gh api --paginate \"repos/${REPO}/environments?per_page=100\"",
 		`list-hosted-control-environments "${POLICY_PATH}"`,
+		"safe_environment_name=\"${encoded_environment_name}\"",
+		"environment-${safe_environment_name}.json",
 		"repos/${REPO}/environments/${encoded_environment_name}/variables?per_page=100",
 		"repos/${REPO}/environments/${encoded_environment_name}/secrets?per_page=100",
 		`verify-github-hosted-controls "${TMP_DIR}" "${REPO}" "${POLICY_PATH}"`,

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -494,7 +494,7 @@ func HostedControlsEnvironmentNames(policyPath string) ([]string, error) {
 }
 
 func hostedControlsEnvironmentArtifactName(environmentName string) string {
-	return url.PathEscape(environmentName)
+	return strings.ReplaceAll(url.QueryEscape(environmentName), "+", "%20")
 }
 
 func FetchGitHubHostedControlsRulesets(tmpDir, repo string) error {

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -302,8 +302,14 @@ func validateUpstreamRefreshWorkflow(workflowText string) error {
 		"./scripts/update-upstream-pins.sh --apply",
 		"./scripts/update-upstream-pins.sh --check",
 		"./scripts/check-pinned-inputs.sh",
+		"environment:\n      name: upstream-refresh",
+		"WORKCELL_UPSTREAM_REFRESH_GIT_NAME",
+		"WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL",
+		"WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT",
 		"WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY",
-		"WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID",
+		"gpg --batch --with-colons --list-secret-keys",
+		`if [[ "${actual_fingerprint}" != "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}" ]]; then`,
+		`git config user.signingkey "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}"`,
 		"git commit -S -F",
 		"gh pr create",
 		"--draft",
@@ -316,7 +322,15 @@ func validateUpstreamRefreshWorkflow(workflowText string) error {
 			return fmt.Errorf(".github/workflows/upstream-refresh.yml must contain %q", needle)
 		}
 	}
+	if strings.Contains(workflowText, "WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID") {
+		return errors.New(".github/workflows/upstream-refresh.yml must not depend on WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID; audit and verify the full fingerprint instead")
+	}
 	return nil
+}
+
+type hostedControlsWorkflowEnvironmentPolicy struct {
+	Variables       map[string]string
+	RequiredSecrets []string
 }
 
 func hostedControlsRepositoryVariables(policy map[string]any, policyPath string) (map[string]any, error) {
@@ -355,6 +369,127 @@ func validateCanonicalHostedControlsRepositoryVariables(policy map[string]any, p
 		return errors.New("policy/github-hosted-controls.toml must require WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = \"false\"")
 	}
 	return nil
+}
+
+func hostedControlsWorkflowEnvironments(policy map[string]any, policyPath string) (map[string]hostedControlsWorkflowEnvironmentPolicy, error) {
+	rawEnvironments, ok := policy["workflow_environment"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must define workflow_environment as a table of named environment contracts", policyPath)
+	}
+
+	environments := make(map[string]hostedControlsWorkflowEnvironmentPolicy, len(rawEnvironments))
+	for environmentName, rawEntry := range rawEnvironments {
+		if strings.TrimSpace(environmentName) == "" {
+			return nil, fmt.Errorf("%s workflow_environment entries must use non-empty environment names", policyPath)
+		}
+		entry, ok := rawEntry.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%s workflow_environment.%s must be a table", policyPath, environmentName)
+		}
+
+		variables := map[string]string{}
+		if rawVariables, ok := entry["variables"]; ok {
+			variableTable, ok := rawVariables.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("%s workflow_environment.%s.variables must be a table of exact expected values", policyPath, environmentName)
+			}
+			for name, rawValue := range variableTable {
+				value, ok := rawValue.(string)
+				if strings.TrimSpace(name) == "" || !ok || strings.TrimSpace(value) == "" {
+					return nil, fmt.Errorf("%s workflow_environment.%s.variables must map non-empty names to exact string values", policyPath, environmentName)
+				}
+				variables[name] = value
+			}
+		}
+
+		requiredSecrets := []string{}
+		if rawSecrets, ok := entry["required_secrets"]; ok {
+			secrets, present, err := MustStringSlice(rawSecrets)
+			if err != nil {
+				return nil, fmt.Errorf("%s workflow_environment.%s.required_secrets: %w", policyPath, environmentName, err)
+			}
+			if !present {
+				return nil, fmt.Errorf("%s workflow_environment.%s.required_secrets must be an array of secret names", policyPath, environmentName)
+			}
+			for _, secretName := range secrets {
+				if strings.TrimSpace(secretName) == "" {
+					return nil, fmt.Errorf("%s workflow_environment.%s.required_secrets must be an array of non-empty secret names", policyPath, environmentName)
+				}
+			}
+			requiredSecrets = append(requiredSecrets, secrets...)
+			sort.Strings(requiredSecrets)
+		}
+
+		environments[environmentName] = hostedControlsWorkflowEnvironmentPolicy{
+			Variables:       variables,
+			RequiredSecrets: requiredSecrets,
+		}
+	}
+	return environments, nil
+}
+
+func validateCanonicalHostedControlsWorkflowEnvironments(policy map[string]any, policyPath string) error {
+	environments, err := hostedControlsWorkflowEnvironments(policy, policyPath)
+	if err != nil {
+		return err
+	}
+
+	hostedControlsAudit, ok := environments["hosted-controls-audit"]
+	if !ok {
+		return errors.New("policy/github-hosted-controls.toml must declare workflow_environment.hosted-controls-audit")
+	}
+	if len(hostedControlsAudit.Variables) != 0 {
+		return errors.New("policy/github-hosted-controls.toml must not declare public variables for workflow_environment.hosted-controls-audit")
+	}
+	if len(hostedControlsAudit.RequiredSecrets) != 1 || hostedControlsAudit.RequiredSecrets[0] != "WORKCELL_HOSTED_CONTROLS_TOKEN" {
+		return errors.New("policy/github-hosted-controls.toml must require only WORKCELL_HOSTED_CONTROLS_TOKEN for workflow_environment.hosted-controls-audit")
+	}
+
+	upstreamRefresh, ok := environments["upstream-refresh"]
+	if !ok {
+		return errors.New("policy/github-hosted-controls.toml must declare workflow_environment.upstream-refresh")
+	}
+	if len(upstreamRefresh.RequiredSecrets) != 1 || upstreamRefresh.RequiredSecrets[0] != "WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY" {
+		return errors.New("policy/github-hosted-controls.toml must require only WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY for workflow_environment.upstream-refresh")
+	}
+	if _, ok := upstreamRefresh.Variables["WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID"]; ok {
+		return errors.New("policy/github-hosted-controls.toml must not declare WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID for workflow_environment.upstream-refresh")
+	}
+	for _, requiredName := range []string{
+		"WORKCELL_UPSTREAM_REFRESH_GIT_NAME",
+		"WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL",
+		"WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT",
+	} {
+		if value, ok := upstreamRefresh.Variables[requiredName]; !ok || strings.TrimSpace(value) == "" {
+			return fmt.Errorf("policy/github-hosted-controls.toml must declare a non-empty workflow_environment.upstream-refresh.variables.%s value", requiredName)
+		}
+	}
+	if !regexp.MustCompile(`^[A-F0-9]{40}$`).MatchString(upstreamRefresh.Variables["WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT"]) {
+		return errors.New("policy/github-hosted-controls.toml must declare workflow_environment.upstream-refresh.variables.WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT as a full uppercase 40-hex fingerprint")
+	}
+	return nil
+}
+
+func HostedControlsEnvironmentNames(policyPath string) ([]string, error) {
+	policyText, err := readText(policyPath)
+	if err != nil {
+		return nil, err
+	}
+	policy, err := ParseTOMLSubset(policyText, policyPath)
+	if err != nil {
+		return nil, err
+	}
+	environments, err := hostedControlsWorkflowEnvironments(policy, policyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(environments))
+	for environmentName := range environments {
+		names = append(names, environmentName)
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 func FetchGitHubHostedControlsRulesets(tmpDir, repo string) error {
@@ -399,6 +534,10 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 	}
 	var actionsVariables map[string]any
 	if err := readJSONFile(filepath.Join(tmpDir, "actions-variables.json"), &actionsVariables); err != nil {
+		return err
+	}
+	var environmentsIndex map[string]any
+	if err := readJSONFile(filepath.Join(tmpDir, "environments.json"), &environmentsIndex); err != nil {
 		return err
 	}
 	var directCollaborators []any
@@ -473,6 +612,10 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		return fmt.Errorf("%s must define required_status_checks.contexts as a non-empty array", policyPath)
 	}
 	expectedRepoVariables, err := hostedControlsRepositoryVariables(policy, policyPath)
+	if err != nil {
+		return err
+	}
+	expectedWorkflowEnvironments, err := hostedControlsWorkflowEnvironments(policy, policyPath)
 	if err != nil {
 		return err
 	}
@@ -695,6 +838,103 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 	sort.Strings(wrongRepoVariables)
 	if len(wrongRepoVariables) > 0 {
 		return fmt.Errorf("repository variables on %s do not match policy: %s", repo, strings.Join(wrongRepoVariables, ", "))
+	}
+
+	actualEnvironmentNames := map[string]struct{}{}
+	if environments, ok := environmentsIndex["environments"].([]any); ok {
+		for _, raw := range environments {
+			entry, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if name, _ := entry["name"].(string); name != "" {
+				actualEnvironmentNames[name] = struct{}{}
+			}
+		}
+	}
+	missingWorkflowEnvironments := make([]string, 0)
+	for environmentName := range expectedWorkflowEnvironments {
+		if _, ok := actualEnvironmentNames[environmentName]; !ok {
+			missingWorkflowEnvironments = append(missingWorkflowEnvironments, environmentName)
+		}
+	}
+	sort.Strings(missingWorkflowEnvironments)
+	if len(missingWorkflowEnvironments) > 0 {
+		return fmt.Errorf("workflow environments missing on %s: %s", repo, strings.Join(missingWorkflowEnvironments, ", "))
+	}
+	for environmentName, environmentPolicy := range expectedWorkflowEnvironments {
+		var environmentMeta map[string]any
+		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s.json", environmentName)), &environmentMeta); err != nil {
+			return fmt.Errorf("read %s environment metadata: %w", environmentName, err)
+		}
+		if actualName, ok := environmentMeta["name"].(string); ok && actualName != "" && actualName != environmentName {
+			return fmt.Errorf("workflow environment metadata for %s on %s resolved to %s", environmentName, repo, actualName)
+		}
+
+		var environmentVariables map[string]any
+		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s-variables.json", environmentName)), &environmentVariables); err != nil {
+			return fmt.Errorf("read %s environment variables: %w", environmentName, err)
+		}
+		actualEnvironmentVariables := map[string]any{}
+		if variables, ok := environmentVariables["variables"].([]any); ok {
+			for _, raw := range variables {
+				entry, ok := raw.(map[string]any)
+				if !ok {
+					continue
+				}
+				name, _ := entry["name"].(string)
+				if name != "" {
+					actualEnvironmentVariables[name] = entry["value"]
+				}
+			}
+		}
+		missingEnvironmentVariables := make([]string, 0)
+		for name := range environmentPolicy.Variables {
+			if _, ok := actualEnvironmentVariables[name]; !ok {
+				missingEnvironmentVariables = append(missingEnvironmentVariables, name)
+			}
+		}
+		sort.Strings(missingEnvironmentVariables)
+		if len(missingEnvironmentVariables) > 0 {
+			return fmt.Errorf("workflow environment variables missing on %s/%s: %s", repo, environmentName, strings.Join(missingEnvironmentVariables, ", "))
+		}
+		wrongEnvironmentVariables := make([]string, 0)
+		for name, expectedValue := range environmentPolicy.Variables {
+			if actualEnvironmentVariables[name] != expectedValue {
+				wrongEnvironmentVariables = append(wrongEnvironmentVariables, fmt.Sprintf("%s=%#v (expected %#v)", name, actualEnvironmentVariables[name], expectedValue))
+			}
+		}
+		sort.Strings(wrongEnvironmentVariables)
+		if len(wrongEnvironmentVariables) > 0 {
+			return fmt.Errorf("workflow environment variables on %s/%s do not match policy: %s", repo, environmentName, strings.Join(wrongEnvironmentVariables, ", "))
+		}
+
+		var environmentSecrets map[string]any
+		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s-secrets.json", environmentName)), &environmentSecrets); err != nil {
+			return fmt.Errorf("read %s environment secrets: %w", environmentName, err)
+		}
+		actualEnvironmentSecrets := map[string]struct{}{}
+		if secrets, ok := environmentSecrets["secrets"].([]any); ok {
+			for _, raw := range secrets {
+				entry, ok := raw.(map[string]any)
+				if !ok {
+					continue
+				}
+				if name, _ := entry["name"].(string); name != "" {
+					actualEnvironmentSecrets[name] = struct{}{}
+				}
+			}
+		}
+		missingEnvironmentSecrets := make([]string, 0)
+		for _, name := range environmentPolicy.RequiredSecrets {
+			if _, ok := actualEnvironmentSecrets[name]; !ok {
+				missingEnvironmentSecrets = append(missingEnvironmentSecrets, name)
+			}
+		}
+		sort.Strings(missingEnvironmentSecrets)
+		if len(missingEnvironmentSecrets) > 0 {
+			return fmt.Errorf("workflow environment secrets missing on %s/%s: %s", repo, environmentName, strings.Join(missingEnvironmentSecrets, ", "))
+		}
 	}
 
 	protectionRules, _ := releaseEnv["protection_rules"].([]any)
@@ -1678,6 +1918,7 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		return err
 	}
 	for _, needle := range []string{
+		`name: hosted-controls-audit`,
 		`run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
 		`WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}`,
 		`WORKCELL_HOSTED_CONTROLS_REQUIRED: "0"`,
@@ -1766,9 +2007,15 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err := validateCanonicalHostedControlsRepositoryVariables(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
 		return err
 	}
+	if err := validateCanonicalHostedControlsWorkflowEnvironments(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
+		return err
+	}
 	for _, needle := range []string{
 		"gh api --paginate \"repos/${REPO}/actions/variables?per_page=100\"",
 		"jq -s '{total_count: (map(.total_count // 0) | max // 0), variables: (map(.variables // []) | add)}'",
+		`list-hosted-control-environments "${POLICY_PATH}"`,
+		"repos/${REPO}/environments/${encoded_environment_name}/variables?per_page=100",
+		"repos/${REPO}/environments/${encoded_environment_name}/secrets?per_page=100",
 		`verify-github-hosted-controls "${TMP_DIR}" "${REPO}" "${POLICY_PATH}"`,
 	} {
 		if !strings.Contains(hostedControlsScript, needle) {

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -100,6 +100,11 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 
 	root := tb.TempDir()
 	policyPath := filepath.Join(root, "policy.toml")
+	const (
+		upstreamRefreshName        = "Omkhar Arasaratnam"
+		upstreamRefreshEmail       = "omkhar@gmail.com"
+		upstreamRefreshFingerprint = "90554248C4F7CC086BB745D0DA5A8E9F536C42FD"
+	)
 	policy := strings.Join([]string{
 		"[branch_integrity]",
 		"require_signed_commits = true",
@@ -118,6 +123,17 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 		"[repository_variables]",
 		`WORKCELL_ENABLE_GITHUB_ATTESTATIONS = "true"`,
 		`WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = "false"`,
+		"",
+		"[workflow_environment.hosted-controls-audit]",
+		`required_secrets = ["WORKCELL_HOSTED_CONTROLS_TOKEN"]`,
+		"",
+		"[workflow_environment.upstream-refresh]",
+		`required_secrets = ["WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY"]`,
+		"",
+		"[workflow_environment.upstream-refresh.variables]",
+		`WORKCELL_UPSTREAM_REFRESH_GIT_NAME = "` + upstreamRefreshName + `"`,
+		`WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL = "` + upstreamRefreshEmail + `"`,
+		`WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT = "` + upstreamRefreshFingerprint + `"`,
 		"",
 	}, "\n")
 	if err := os.WriteFile(policyPath, []byte(policy), 0o644); err != nil {
@@ -145,6 +161,13 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 				"name":  "WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS",
 				"value": "false",
 			},
+		},
+	}
+	environmentsIndex := map[string]any{
+		"environments": []map[string]any{
+			{"name": "hosted-controls-audit"},
+			{"name": "release"},
+			{"name": "upstream-refresh"},
 		},
 	}
 	branchReviewParameters := map[string]any{
@@ -256,6 +279,7 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 		releaseReviewRule["prevent_self_review"] = true
 	}
 	releaseEnv := map[string]any{
+		"name": "release",
 		"protection_rules": []map[string]any{
 			releaseReviewRule,
 			{
@@ -265,6 +289,41 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 		},
 		"can_admins_bypass": false,
 	}
+	hostedControlsAuditEnv := map[string]any{
+		"name": "hosted-controls-audit",
+	}
+	hostedControlsAuditVariables := map[string]any{
+		"variables": []map[string]any{},
+	}
+	hostedControlsAuditSecrets := map[string]any{
+		"secrets": []map[string]any{
+			{"name": "WORKCELL_HOSTED_CONTROLS_TOKEN"},
+		},
+	}
+	upstreamRefreshEnv := map[string]any{
+		"name": "upstream-refresh",
+	}
+	upstreamRefreshVariables := map[string]any{
+		"variables": []map[string]any{
+			{
+				"name":  "WORKCELL_UPSTREAM_REFRESH_GIT_NAME",
+				"value": upstreamRefreshName,
+			},
+			{
+				"name":  "WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL",
+				"value": upstreamRefreshEmail,
+			},
+			{
+				"name":  "WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT",
+				"value": upstreamRefreshFingerprint,
+			},
+		},
+	}
+	upstreamRefreshSecrets := map[string]any{
+		"secrets": []map[string]any{
+			{"name": "WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY"},
+		},
+	}
 
 	for _, fixture := range []struct {
 		name  string
@@ -273,9 +332,16 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 		{"repo.json", repoJSON},
 		{"actions-permissions.json", actionsPermissions},
 		{"actions-variables.json", actionsVariables},
+		{"environments.json", environmentsIndex},
 		{"collaborators-direct.json", directCollaborators},
 		{"rulesets.json", rulesets},
+		{"environment-hosted-controls-audit.json", hostedControlsAuditEnv},
+		{"environment-hosted-controls-audit-variables.json", hostedControlsAuditVariables},
+		{"environment-hosted-controls-audit-secrets.json", hostedControlsAuditSecrets},
 		{"environment-release.json", releaseEnv},
+		{"environment-upstream-refresh.json", upstreamRefreshEnv},
+		{"environment-upstream-refresh-variables.json", upstreamRefreshVariables},
+		{"environment-upstream-refresh-secrets.json", upstreamRefreshSecrets},
 	} {
 		if err := writeJSONFile(filepath.Join(root, fixture.name), fixture.value); err != nil {
 			tb.Fatal(err)
@@ -465,5 +531,55 @@ func TestVerifyGitHubHostedControlsRejectsNonOwnerPublicCollaboratorForBranchRev
 	}
 	if !strings.Contains(err.Error(), "requires the owner to be the only direct collaborator") {
 		t.Fatalf("VerifyGitHubHostedControls() error = %v, want owner-only collaborator rejection", err)
+	}
+}
+
+func TestVerifyGitHubHostedControlsRejectsMissingUpstreamRefreshSecret(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, policyPath := writeHostedControlsFixture(t, "review-gated", "review-gated", []map[string]any{
+		{
+			"login": "omkhar",
+			"permissions": map[string]any{
+				"admin": true,
+			},
+		},
+	})
+
+	rewriteFile(t, filepath.Join(tmpDir, "environment-upstream-refresh-secrets.json"), func(content string) string {
+		return strings.Replace(content, `"WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY"`, `"WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY_REMOVED"`, 1)
+	})
+
+	err := VerifyGitHubHostedControls(tmpDir, "omkhar/workcell", policyPath)
+	if err == nil {
+		t.Fatal("VerifyGitHubHostedControls() unexpectedly accepted a missing upstream-refresh private-key secret")
+	}
+	if !strings.Contains(err.Error(), "workflow environment secrets missing on omkhar/workcell/upstream-refresh") {
+		t.Fatalf("VerifyGitHubHostedControls() error = %v, want upstream-refresh secret rejection", err)
+	}
+}
+
+func TestVerifyGitHubHostedControlsRejectsWrongUpstreamRefreshFingerprint(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, policyPath := writeHostedControlsFixture(t, "review-gated", "review-gated", []map[string]any{
+		{
+			"login": "omkhar",
+			"permissions": map[string]any{
+				"admin": true,
+			},
+		},
+	})
+
+	rewriteFile(t, filepath.Join(tmpDir, "environment-upstream-refresh-variables.json"), func(content string) string {
+		return strings.Replace(content, "90554248C4F7CC086BB745D0DA5A8E9F536C42FD", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 1)
+	})
+
+	err := VerifyGitHubHostedControls(tmpDir, "omkhar/workcell", policyPath)
+	if err == nil {
+		t.Fatal("VerifyGitHubHostedControls() unexpectedly accepted a mismatched upstream-refresh fingerprint")
+	}
+	if !strings.Contains(err.Error(), "workflow environment variables on omkhar/workcell/upstream-refresh do not match policy") {
+		t.Fatalf("VerifyGitHubHostedControls() error = %v, want upstream-refresh fingerprint rejection", err)
 	}
 }

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -1168,3 +1168,11 @@ func TestHostedControlsEnvironmentArtifactNameEscapesSlashes(t *testing.T) {
 		t.Fatalf("hostedControlsEnvironmentArtifactName() = %q, want %q", got, "prod%2Fus%20west")
 	}
 }
+
+func TestHostedControlsEnvironmentArtifactNameEscapesReservedCharacters(t *testing.T) {
+	t.Parallel()
+
+	if got := hostedControlsEnvironmentArtifactName("prod+east:blue&green=1"); got != "prod%2Beast%3Ablue%26green%3D1" {
+		t.Fatalf("hostedControlsEnvironmentArtifactName() = %q, want %q", got, "prod%2Beast%3Ablue%26green%3D1")
+	}
+}

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -1160,3 +1160,11 @@ func TestValidateCanonicalHostedControlsWorkflowEnvironmentsAcceptsCanonicalValu
 		t.Fatalf("validateCanonicalHostedControlsWorkflowEnvironments() error = %v", err)
 	}
 }
+
+func TestHostedControlsEnvironmentArtifactNameEscapesSlashes(t *testing.T) {
+	t.Parallel()
+
+	if got := hostedControlsEnvironmentArtifactName("prod/us west"); got != "prod%2Fus%20west" {
+		t.Fatalf("hostedControlsEnvironmentArtifactName() = %q, want %q", got, "prod%2Fus%20west")
+	}
+}

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -680,6 +680,8 @@ env:
 
 jobs:
   refresh:
+    environment:
+      name: upstream-refresh
     permissions:
       contents: write
       pull-requests: write
@@ -697,8 +699,19 @@ jobs:
       - run: ./scripts/update-upstream-pins.sh --check
       - run: ./scripts/check-pinned-inputs.sh
       - env:
+          WORKCELL_UPSTREAM_REFRESH_GIT_NAME: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GIT_NAME }}
+          WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL }}
+          WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT }}
           WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY: ${{ secrets.WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY }}
-          WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID: ${{ secrets.WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID }}
+        run: |
+          actual_fingerprint="$(
+            gpg --batch --with-colons --list-secret-keys |
+              awk -F: '$1 == "fpr" { print $10; exit }'
+          )"
+          if [[ "${actual_fingerprint}" != "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}" ]]; then
+            exit 1
+          fi
+          git config user.signingkey "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}"
       - run: |
           git commit -m "unsigned refresh"
 `
@@ -713,6 +726,121 @@ jobs:
 }
 
 func TestValidateUpstreamRefreshWorkflowAcceptsCanonicalFlow(t *testing.T) {
+	t.Parallel()
+	workflow := `name: Upstream refresh
+
+on:
+  workflow_dispatch:
+
+env:
+  WORKCELL_COSIGN_VERSION: v3.0.6
+
+jobs:
+  refresh:
+    environment:
+      name: upstream-refresh
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+        with:
+          cosign-release: ${{ env.WORKCELL_COSIGN_VERSION }}
+      - run: |
+          sudo install -m 0755 "$(command -v cosign)" /usr/local/bin/cosign
+      - run: ./scripts/update-upstream-pins.sh --apply
+      - run: |
+          ./scripts/update-upstream-pins.sh --check
+          ./scripts/check-pinned-inputs.sh
+      - env:
+          WORKCELL_UPSTREAM_REFRESH_GIT_NAME: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GIT_NAME }}
+          WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL }}
+          WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT }}
+          WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY: ${{ secrets.WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY }}
+        run: |
+          actual_fingerprint="$(
+            gpg --batch --with-colons --list-secret-keys |
+              awk -F: '$1 == "fpr" { print $10; exit }'
+          )"
+          if [[ "${actual_fingerprint}" != "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}" ]]; then
+            exit 1
+          fi
+          git config user.name "${WORKCELL_UPSTREAM_REFRESH_GIT_NAME}"
+          git config user.email "${WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL}"
+          git config user.signingkey "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}"
+          git commit -S -F "${commit_file}"
+          gh pr create --draft
+`
+
+	if err := validateUpstreamRefreshWorkflow(workflow); err != nil {
+		t.Fatalf("validateUpstreamRefreshWorkflow() error = %v", err)
+	}
+}
+
+func TestValidateUpstreamRefreshWorkflowRejectsDeprecatedKeyIDBinding(t *testing.T) {
+	t.Parallel()
+	workflow := `name: Upstream refresh
+
+on:
+  workflow_dispatch:
+
+env:
+  WORKCELL_COSIGN_VERSION: v3.0.6
+
+jobs:
+  refresh:
+    environment:
+      name: upstream-refresh
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+        with:
+          cosign-release: ${{ env.WORKCELL_COSIGN_VERSION }}
+      - run: |
+          sudo install -m 0755 "$(command -v cosign)" /usr/local/bin/cosign
+      - run: ./scripts/update-upstream-pins.sh --apply
+      - run: |
+          ./scripts/update-upstream-pins.sh --check
+          ./scripts/check-pinned-inputs.sh
+      - env:
+          WORKCELL_UPSTREAM_REFRESH_GIT_NAME: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GIT_NAME }}
+          WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL }}
+          WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT }}
+          WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY: ${{ secrets.WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY }}
+          WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID: ${{ secrets.WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID }}
+        run: |
+          actual_fingerprint="$(
+            gpg --batch --with-colons --list-secret-keys |
+              awk -F: '$1 == "fpr" { print $10; exit }'
+          )"
+          if [[ "${actual_fingerprint}" != "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}" ]]; then
+            exit 1
+          fi
+          git config user.signingkey "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}"
+          git commit -S -F "${commit_file}"
+          gh pr create --draft
+`
+
+	err := validateUpstreamRefreshWorkflow(workflow)
+	if err == nil {
+		t.Fatal("validateUpstreamRefreshWorkflow() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID") {
+		t.Fatalf("validateUpstreamRefreshWorkflow() error = %v, want deprecated key-id rejection", err)
+	}
+}
+
+func TestValidateUpstreamRefreshWorkflowRejectsMissingEnvironmentBinding(t *testing.T) {
 	t.Parallel()
 	workflow := `name: Upstream refresh
 
@@ -742,15 +870,29 @@ jobs:
           ./scripts/update-upstream-pins.sh --check
           ./scripts/check-pinned-inputs.sh
       - env:
+          WORKCELL_UPSTREAM_REFRESH_GIT_NAME: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GIT_NAME }}
+          WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL }}
+          WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT: ${{ vars.WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT }}
           WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY: ${{ secrets.WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY }}
-          WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID: ${{ secrets.WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID }}
         run: |
+          actual_fingerprint="$(
+            gpg --batch --with-colons --list-secret-keys |
+              awk -F: '$1 == "fpr" { print $10; exit }'
+          )"
+          if [[ "${actual_fingerprint}" != "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}" ]]; then
+            exit 1
+          fi
+          git config user.signingkey "${WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT}"
           git commit -S -F "${commit_file}"
           gh pr create --draft
 `
 
-	if err := validateUpstreamRefreshWorkflow(workflow); err != nil {
-		t.Fatalf("validateUpstreamRefreshWorkflow() error = %v", err)
+	err := validateUpstreamRefreshWorkflow(workflow)
+	if err == nil {
+		t.Fatal("validateUpstreamRefreshWorkflow() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), `environment:\n      name: upstream-refresh`) {
+		t.Fatalf("validateUpstreamRefreshWorkflow() error = %v, want upstream-refresh environment binding rejection", err)
 	}
 }
 
@@ -941,5 +1083,80 @@ func TestValidateCanonicalHostedControlsRepositoryVariablesAcceptsCanonicalValue
 
 	if err := validateCanonicalHostedControlsRepositoryVariables(policy, "policy/github-hosted-controls.toml"); err != nil {
 		t.Fatalf("validateCanonicalHostedControlsRepositoryVariables() error = %v", err)
+	}
+}
+
+func TestValidateCanonicalHostedControlsWorkflowEnvironmentsRejectsMissingHostedControlsAudit(t *testing.T) {
+	t.Parallel()
+	policy := map[string]any{
+		"workflow_environment": map[string]any{
+			"upstream-refresh": map[string]any{
+				"required_secrets": []any{"WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY"},
+				"variables": map[string]any{
+					"WORKCELL_UPSTREAM_REFRESH_GIT_NAME":        "Omkhar Arasaratnam",
+					"WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL":       "omkhar@gmail.com",
+					"WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT": "90554248C4F7CC086BB745D0DA5A8E9F536C42FD",
+				},
+			},
+		},
+	}
+
+	err := validateCanonicalHostedControlsWorkflowEnvironments(policy, "policy/github-hosted-controls.toml")
+	if err == nil {
+		t.Fatal("validateCanonicalHostedControlsWorkflowEnvironments() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "workflow_environment.hosted-controls-audit") {
+		t.Fatalf("validateCanonicalHostedControlsWorkflowEnvironments() error = %v, want hosted-controls-audit rejection", err)
+	}
+}
+
+func TestValidateCanonicalHostedControlsWorkflowEnvironmentsRejectsDeprecatedKeyID(t *testing.T) {
+	t.Parallel()
+	policy := map[string]any{
+		"workflow_environment": map[string]any{
+			"hosted-controls-audit": map[string]any{
+				"required_secrets": []any{"WORKCELL_HOSTED_CONTROLS_TOKEN"},
+			},
+			"upstream-refresh": map[string]any{
+				"required_secrets": []any{"WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY"},
+				"variables": map[string]any{
+					"WORKCELL_UPSTREAM_REFRESH_GIT_NAME":        "Omkhar Arasaratnam",
+					"WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL":       "omkhar@gmail.com",
+					"WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT": "90554248C4F7CC086BB745D0DA5A8E9F536C42FD",
+					"WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID":      "DA5A8E9F536C42FD",
+				},
+			},
+		},
+	}
+
+	err := validateCanonicalHostedControlsWorkflowEnvironments(policy, "policy/github-hosted-controls.toml")
+	if err == nil {
+		t.Fatal("validateCanonicalHostedControlsWorkflowEnvironments() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID") {
+		t.Fatalf("validateCanonicalHostedControlsWorkflowEnvironments() error = %v, want deprecated key-id rejection", err)
+	}
+}
+
+func TestValidateCanonicalHostedControlsWorkflowEnvironmentsAcceptsCanonicalValues(t *testing.T) {
+	t.Parallel()
+	policy := map[string]any{
+		"workflow_environment": map[string]any{
+			"hosted-controls-audit": map[string]any{
+				"required_secrets": []any{"WORKCELL_HOSTED_CONTROLS_TOKEN"},
+			},
+			"upstream-refresh": map[string]any{
+				"required_secrets": []any{"WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY"},
+				"variables": map[string]any{
+					"WORKCELL_UPSTREAM_REFRESH_GIT_NAME":        "Omkhar Arasaratnam",
+					"WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL":       "omkhar@gmail.com",
+					"WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT": "90554248C4F7CC086BB745D0DA5A8E9F536C42FD",
+				},
+			},
+		},
+	}
+
+	if err := validateCanonicalHostedControlsWorkflowEnvironments(policy, "policy/github-hosted-controls.toml"); err != nil {
+		t.Fatalf("validateCanonicalHostedControlsWorkflowEnvironments() error = %v", err)
 	}
 }

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -70,3 +70,14 @@ immutable_github_releases = true
 # control plane so publication posture cannot silently drift.
 WORKCELL_ENABLE_GITHUB_ATTESTATIONS = "true"
 WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = "false"
+
+[workflow_environment.hosted-controls-audit]
+required_secrets = ["WORKCELL_HOSTED_CONTROLS_TOKEN"]
+
+[workflow_environment.upstream-refresh]
+required_secrets = ["WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY"]
+
+[workflow_environment.upstream-refresh.variables]
+WORKCELL_UPSTREAM_REFRESH_GIT_NAME = "Omkhar Arasaratnam"
+WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL = "omkhar@gmail.com"
+WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT = "90554248C4F7CC086BB745D0DA5A8E9F536C42FD"

--- a/scripts/verify-github-hosted-controls.sh
+++ b/scripts/verify-github-hosted-controls.sh
@@ -41,7 +41,8 @@ gh api --paginate "repos/${REPO}/actions/variables?per_page=100" |
 gh api "repos/${REPO}/collaborators?affiliation=direct&per_page=100" >"${TMP_DIR}/collaborators-direct.json"
 gh api "repos/${REPO}/rulesets" >"${TMP_DIR}/rulesets-summary.json"
 "${METADATAUTIL_BIN}" fetch-rulesets "${TMP_DIR}" "${REPO}"
-gh api "repos/${REPO}/environments" >"${TMP_DIR}/environments.json"
+gh api --paginate "repos/${REPO}/environments?per_page=100" |
+  jq -s '{total_count: (map(.total_count // 0) | max // 0), environments: (map(.environments // []) | add)}' >"${TMP_DIR}/environments.json"
 if gh api "repos/${REPO}/environments/release" >"${TMP_DIR}/environment-release.json" 2>/dev/null; then
   :
 else
@@ -51,16 +52,17 @@ fi
 while IFS= read -r environment_name; do
   [[ -n "${environment_name}" ]] || continue
   encoded_environment_name="$(jq -rn --arg value "${environment_name}" '$value | @uri')"
-  if gh api "repos/${REPO}/environments/${encoded_environment_name}" >"${TMP_DIR}/environment-${environment_name}.json" 2>/dev/null; then
+  safe_environment_name="${encoded_environment_name}"
+  if gh api "repos/${REPO}/environments/${encoded_environment_name}" >"${TMP_DIR}/environment-${safe_environment_name}.json" 2>/dev/null; then
     :
   else
     echo "Missing required ${environment_name} environment on ${REPO}" >&2
     exit 1
   fi
   gh api --paginate "repos/${REPO}/environments/${encoded_environment_name}/variables?per_page=100" |
-    jq -s '{total_count: (map(.total_count // 0) | max // 0), variables: (map(.variables // []) | add)}' >"${TMP_DIR}/environment-${environment_name}-variables.json"
+    jq -s '{total_count: (map(.total_count // 0) | max // 0), variables: (map(.variables // []) | add)}' >"${TMP_DIR}/environment-${safe_environment_name}-variables.json"
   gh api --paginate "repos/${REPO}/environments/${encoded_environment_name}/secrets?per_page=100" |
-    jq -s '{total_count: (map(.total_count // 0) | max // 0), secrets: (map(.secrets // []) | add)}' >"${TMP_DIR}/environment-${environment_name}-secrets.json"
+    jq -s '{total_count: (map(.total_count // 0) | max // 0), secrets: (map(.secrets // []) | add)}' >"${TMP_DIR}/environment-${safe_environment_name}-secrets.json"
 done < <("${METADATAUTIL_BIN}" list-hosted-control-environments "${POLICY_PATH}")
 
 "${METADATAUTIL_BIN}" verify-github-hosted-controls "${TMP_DIR}" "${REPO}" "${POLICY_PATH}"

--- a/scripts/verify-github-hosted-controls.sh
+++ b/scripts/verify-github-hosted-controls.sh
@@ -48,5 +48,19 @@ else
   echo "Missing required release environment on ${REPO}" >&2
   exit 1
 fi
+while IFS= read -r environment_name; do
+  [[ -n "${environment_name}" ]] || continue
+  encoded_environment_name="$(jq -rn --arg value "${environment_name}" '$value | @uri')"
+  if gh api "repos/${REPO}/environments/${encoded_environment_name}" >"${TMP_DIR}/environment-${environment_name}.json" 2>/dev/null; then
+    :
+  else
+    echo "Missing required ${environment_name} environment on ${REPO}" >&2
+    exit 1
+  fi
+  gh api --paginate "repos/${REPO}/environments/${encoded_environment_name}/variables?per_page=100" |
+    jq -s '{total_count: (map(.total_count // 0) | max // 0), variables: (map(.variables // []) | add)}' >"${TMP_DIR}/environment-${environment_name}-variables.json"
+  gh api --paginate "repos/${REPO}/environments/${encoded_environment_name}/secrets?per_page=100" |
+    jq -s '{total_count: (map(.total_count // 0) | max // 0), secrets: (map(.secrets // []) | add)}' >"${TMP_DIR}/environment-${environment_name}-secrets.json"
+done < <("${METADATAUTIL_BIN}" list-hosted-control-environments "${POLICY_PATH}")
 
 "${METADATAUTIL_BIN}" verify-github-hosted-controls "${TMP_DIR}" "${REPO}" "${POLICY_PATH}"


### PR DESCRIPTION
## Summary

- move upstream refresh signing identity to audited environment-scoped hosted controls
- verify the imported refresh signing key against the audited full fingerprint before signing
- extend hosted-controls verification to audit required workflow environments, vars, and secret names

## Validation

- `go test ./cmd/workcell-metadatautil ./internal/metadatautil/... ./internal/testkit/...`
- `./scripts/validate-repo.sh`
- `./scripts/verify-github-hosted-controls.sh omkhar/workcell` now fails on the currently missing `hosted-controls-audit` token and empty `upstream-refresh` environment inputs, which is the intended new detection path
