### PR TITLE
Require live certification before signing support claims

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -71,6 +71,10 @@ for convenience.
   opportunistic cleanup, and behavior changes into one remote review unit.
   Split broad work before pushing.
 - Sign every commit.
+- Before signing a commit that introduces or materially changes a supported
+  end-to-end workflow, backend, support-tier claim, or certification-only
+  validation path, run the relevant live certification successfully. Do not
+  sign a support-claim commit while planning to gather certification later.
 - Use feature branches. Do not push directly to `main` or rewrite history.
 - Treat final GitHub publication as a host-side action.
 - Default remote review units to `main`-based pull requests. Keep non-`main`

--- a/.agents/skills/workcell-contract-parity/SKILL.md
+++ b/.agents/skills/workcell-contract-parity/SKILL.md
@@ -65,6 +65,9 @@ If the change is release-bound, also read:
   same docs and evidence.
 - Every supported public workflow must have canonical syntax, support tier,
   discoverability, docs, and automated evidence.
+- If a supported workflow depends on certification-only evidence, that live
+  certification must pass before you sign the commit that claims or changes
+  support for the workflow.
 - Compatibility aliases must have explicit `alias_probes`.
 - Design docs are explanatory, not the authoritative command inventory.
 - The runtime boundary is the primary control. Do not treat hooks, prompt text,

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -78,6 +78,11 @@ If the task is release-bound, also read:
 - Keep PRs reviewer-sized and single-purpose. Split broad work before
   publication.
 - Sign every commit and use feature branches.
+- If the change introduces or materially changes a supported end-to-end
+  workflow, backend, support-tier claim, or certification-only validation
+  path, ensure the relevant live certification passed before the signed commit
+  was created. Do not use PR publication as a substitute for required
+  end-to-end certification.
 - Open the PR as a draft first. Mark it ready only after the review and check
   gates below are satisfied.
 - Do not stop at PR creation. Follow repo-owned checks until they are green,
@@ -100,26 +105,28 @@ If the task is release-bound, also read:
 
 1. Confirm the branch is reviewable and the local worktree only contains the
    intended scope.
-2. Create signed commits using the repo-local `commit` skill.
-3. Run the focused local validation for the change before publication.
-4. Publish `main`-based PRs with host-side `./scripts/repo-publish-pr.sh`
+2. Run any required live end-to-end certification before signing commits for
+   support-claim or backend changes.
+3. Create signed commits using the repo-local `commit` skill.
+4. Run the focused local validation for the change before publication.
+5. Publish `main`-based PRs with host-side `./scripts/repo-publish-pr.sh`
    using a draft PR by default. Only fall back to the lower-level
    `./scripts/workcell publish-pr` path for explicit lower-assurance
    non-`main` exceptions or other repo-approved special cases.
-5. Follow repo-owned checks to completion.
-6. If a repo-owned check fails:
+6. Follow repo-owned checks to completion.
+7. If a repo-owned check fails:
    - inspect the failing GitHub Actions logs or PR checks
    - fix the underlying issue locally
    - rerun the smallest local validation that proves the fix
    - push the signed follow-up commit host-side to the existing branch
    - continue following checks until green
-7. Sweep top-level comments, inline comments, unresolved threads, and async
+8. Sweep top-level comments, inline comments, unresolved threads, and async
    reviewer feedback.
-8. When checks are green and no actionable findings remain, mark the PR ready
+9. When checks are green and no actionable findings remain, mark the PR ready
    unless the user explicitly asked to keep it draft. Do not mark non-`main`
    base PRs ready; they stay lower-assurance draft-only review units.
-9. After marking ready, re-check checks and review surfaces again.
-10. If merge is part of the task, repeat the review sweep immediately before
+10. After marking ready, re-check checks and review surfaces again.
+11. If merge is part of the task, repeat the review sweep immediately before
     merge, merge, then follow merged `main` workflows until repo-owned lanes
     are green.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,11 @@ the runtime boundary or explicit security guarantees in the name of convenience.
 
 - Sign every commit. Do not create or rewrite commits in this repository
   without a verified signature from the maintainer identity.
+- Before signing a commit that introduces or materially changes a supported
+  end-to-end workflow, backend, support-tier claim, or certification-only
+  validation path, run the relevant live end-to-end certification
+  successfully. Do not sign "implementation first, certification later"
+  commits for that class of change.
 - Treat final GitHub publication as a host-side action. Prepare branch,
   signed commit message, and PR metadata inside Workcell, then use
   `workcell publish-pr` on the host rather than publishing directly from the

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -89,6 +89,11 @@ Certification smoke is where local boundary proof belongs. It should stay
 available and documented, but it must not be the reason repo validation fails
 on a machine that lacks the live runtime prerequisites.
 
+When a change introduces or materially changes a supported end-to-end
+workflow, backend, support-tier claim, or certification-only validation path,
+this certification tier becomes a pre-signing gate: complete the relevant live
+smoke successfully before signing the commit that claims the new support.
+
 ## Documentation example coverage
 
 Release-facing examples are expected to map to existing automated evidence even


### PR DESCRIPTION
## Summary
- make live end-to-end certification a pre-signing prerequisite for supported workflow, backend, and support-claim changes
- thread that rule through `AGENTS.md` and the repo-local commit / PR lifecycle / contract parity skills
- document the certification-only validation tier as an explicit pre-signing gate for support-claim changes

## Validation
- `bash ./scripts/check-public-repo-hygiene.sh`
- `bash ./scripts/check-dead-code.sh`

## Notes
- `bash ./scripts/validate-repo.sh` on a clean main-derived tree currently reproduces unrelated baseline failures in untouched mutation and contract lanes; this review unit is doc-and-skill only