### PR TITLE
Teach repo-local skills to capture continuous improvements

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -61,6 +61,10 @@ for convenience.
   finds new issues after a fix, keep iterating with that peer until all
   findings are resolved, explicitly dispositioned, or blocked by a concrete
   external constraint.
+- Treat repeated user correction, recurring review friction, or repeated CI
+  surprises as a signal to improve the repo-local instructions. When a durable
+  gap is exposed, update the relevant repo-local skill, `AGENTS.md`, or
+  runbook in a reviewable change rather than relying on ad hoc memory.
 
 ## Commit Grouping
 
@@ -104,6 +108,9 @@ for convenience.
   detritus before finalizing the change.
 - If commit hooks are bypassed, rerun the equivalent validations manually and
   record the reason in the working notes or final report.
+- If a task teaches a reusable lesson about commit sizing, validation,
+  publication, or follow-up discipline, capture that lesson in the repo-local
+  instructions in the same change stream or in a separate follow-on PR.
 
 ## Notation Justification in Commit Messages
 

--- a/.agents/skills/workcell-contract-parity/SKILL.md
+++ b/.agents/skills/workcell-contract-parity/SKILL.md
@@ -46,6 +46,10 @@ Treat that as an open-ended peer loop. If a peer, validator, or review surface
 finds new parity issues after a fix, continue re-reviewing with that peer or
 surface until every finding is resolved, explicitly dispositioned, or blocked
 by a concrete external constraint.
+Treat repeated docs confusion, support-boundary ambiguity, or validator churn
+as a signal to improve the repo-local contract surfaces themselves. When a
+durable parity lesson appears, version it in the relevant skill, contract, or
+docs rather than keeping it only in working memory.
 
 ## Read first
 
@@ -127,6 +131,9 @@ If the change is release-bound, also read:
    finishing.
 9. Re-review the affected contract surfaces after fixes land and before calling
    the task done. Do not stop while actionable findings remain.
+10. If the task exposed a reusable parity or operator-guidance gap, update the
+    relevant repo-local instruction surface in the same change stream or in a
+    separate follow-on review unit.
 
 ## Validation
 

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -45,6 +45,10 @@ Treat that as a continuing loop with the same peers and review surfaces. If a
 comment sweep, thread sweep, CI rerun, or follow-up review produces new
 findings after a fix, keep iterating until every finding is resolved,
 explicitly dispositioned, or blocked by a concrete external constraint.
+Treat repeated PR friction, publication fallbacks, or hosted-check surprises as
+signals that the repo-local lifecycle instructions should improve. When a
+durable process lesson appears, capture it in a versioned repo-local update
+instead of leaving it as an unwritten workaround.
 
 ## Read first
 
@@ -129,6 +133,9 @@ If the task is release-bound, also read:
 11. If merge is part of the task, repeat the review sweep immediately before
     merge, merge, then follow merged `main` workflows until repo-owned lanes
     are green.
+11. If the task exposed a reusable PR-lifecycle or hosted-validation lesson,
+    update the relevant repo-local instructions in the same change stream or a
+    separate follow-on PR.
 
 ## Validation
 

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -133,7 +133,7 @@ If the task is release-bound, also read:
 11. If merge is part of the task, repeat the review sweep immediately before
     merge, merge, then follow merged `main` workflows until repo-owned lanes
     are green.
-11. If the task exposed a reusable PR-lifecycle or hosted-validation lesson,
+12. If the task exposed a reusable PR-lifecycle or hosted-validation lesson,
     update the relevant repo-local instructions in the same change stream or a
     separate follow-on PR.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,19 @@ the runtime boundary or explicit security guarantees in the name of convenience.
   publication, merge, and release actions. Do not stop at "implemented" if
   review, checks, or hosted workflows still expose actionable problems.
 
+## Continuous improvement default
+
+- Treat repeated friction, user correction, recurring CI churn, or manual
+  workaround as a signal that the repo-local instructions should improve.
+- When a task exposes a durable gap in `AGENTS.md`, a repo-local skill,
+  runbook, validator, or publication workflow, capture that improvement in a
+  versioned repo-local change instead of relying on conversational memory.
+- Prefer explicit, reviewable skill and runbook updates over implicit habits.
+- If the improvement would muddy the active review unit, cut it as a separate
+  follow-on commit or PR rather than leaving the lesson unversioned.
+- Do not claim the skills "learn automatically." In this repository, skill
+  adaptation must happen through committed, reviewable instruction updates.
+
 ## Mandatory rules
 
 - Sign every commit. Do not create or rewrite commits in this repository


### PR DESCRIPTION
## Summary
- add a repo-level continuous-improvement default in `AGENTS.md`
- require each repo-local skill to capture durable lessons from user feedback, repeated friction, and CI churn in versioned instructions
- keep adaptation explicit and reviewable instead of relying on conversational memory

## Validation
- `bash ./scripts/check-public-repo-hygiene.sh`
- `bash ./scripts/check-dead-code.sh`
- `bash ./scripts/validate-repo.sh` *(reproduces unrelated baseline failures in untouched injection, transcript, and contract lanes on a clean main-derived tree)*