### PR TITLE
Phase 7 AWS EC2 SSM preview target

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ boundary.
 - pre-1.0 and still tightening the public contract
 - Apple Silicon macOS hosts only today; Linux and Windows are not currently
   supported as launch hosts
-- local host-launched runtime first; there is no Workcell-managed cloud or
-  remote worker plane today
+- local host-launched runtime first; the only cloud-facing path today is the
+  preview-only `remote_vm/aws-ec2-ssm/compat` broker plan, and its live smoke
+  remains certification-only
 - CLI surfaces for Codex, Claude, and Gemini plus host-side detached session
   control and inspection commands
 - GitHub-hosted CI verifies repo shape, reproducibility, release posture, and
@@ -269,12 +270,14 @@ Other defaults that matter:
 
 Useful operator flows:
 
-Use `--target colima|docker-desktop` to select the managed runtime backend.
+Use `--target colima|docker-desktop|aws-ec2-ssm` to select the managed runtime
+backend.
 
 ```bash
 workcell --agent codex --prepare --workspace /path/to/repo
 workcell --agent codex --prepare-only --workspace /path/to/repo
 workcell --target docker-desktop --agent codex --workspace /path/to/repo
+workcell --target aws-ec2-ssm --target-id i-1234567890abcdef0 --agent codex --workspace /path/to/repo --dry-run
 workcell --agent codex --mode development --workspace /path/to/repo -- bash -lc 'git status'
 workcell session list
 workcell session list --verbose
@@ -310,6 +313,9 @@ workcell publish-pr --workspace /path/to/repo --branch feature/name \
   --body-file /tmp/pr-body.md \
   --commit-message-file /tmp/commit-message.txt
 ```
+
+For the preview-only AWS remote VM broker path and its certification gate, see
+[docs/aws-ec2-ssm-preview.md](docs/aws-ec2-ssm-preview.md).
 
 `workcell session list --verbose` adds target, workspace transport, git branch,
 and worktree columns without changing the default compact inventory view.

--- a/docs/aws-ec2-ssm-preview.md
+++ b/docs/aws-ec2-ssm-preview.md
@@ -1,0 +1,101 @@
+# AWS EC2 SSM Preview
+
+Workcell now exposes a preview-only `remote_vm/aws-ec2-ssm/compat` target
+selection path. This is intentionally narrower than the reviewed local Colima
+boundary:
+
+- repo-required support today is deterministic target selection, diagnostics,
+  state-root routing, and shared remote-VM conformance reuse
+- live AWS execution remains certification-only
+- the reviewed live path must use brokered AWS Systems Manager Session Manager
+  access; inbound public SSH is out of bounds for the supported path
+
+Use this page with:
+
+- [docs/remote-vm-contract.md](remote-vm-contract.md)
+- [docs/validation-scenarios.md](validation-scenarios.md)
+- [policy/host-support-matrix.tsv](../policy/host-support-matrix.tsv)
+
+## Canonical Preview Plan
+
+Inspect the reviewed broker plan without attempting live remote execution:
+
+```bash
+workcell \
+  --target aws-ec2-ssm \
+  --target-id i-1234567890abcdef0 \
+  --agent codex \
+  --workspace /path/to/repo \
+  --dry-run
+```
+
+The dry-run path emits:
+
+- `target_kind=remote_vm`
+- `target_provider=aws-ec2-ssm`
+- `target_assurance_class=compat`
+- `runtime_api=brokered`
+- `workspace_transport=remote-materialization`
+- `remote_access_model=brokered`
+- `remote_broker=aws-ssm-session-manager`
+- `inbound_public_ssh=blocked`
+- `live_smoke=certification-only`
+
+`workcell --doctor` exposes the same support boundary through
+`support_matrix_*` plus the required host tools.
+
+## Host Prerequisites
+
+The preview target expects these host-side tools and dependencies:
+
+- `aws`
+- `session-manager-plugin`
+- an EC2 instance managed by AWS Systems Manager
+- an instance profile that includes `AmazonSSMManagedInstanceCore`
+- IAM permissions for `ec2:DescribeInstances`,
+  `ssm:DescribeInstanceInformation`, `ssm:StartSession`,
+  `ssm:ResumeSession`, and `ssm:TerminateSession`
+
+These are host prerequisites. They are not mounted into the reviewed local
+runtime boundary.
+
+## Live Certification Gate
+
+Live AWS use is intentionally blocked on the default launch path until the
+operator performs the separate certification run on reviewed infrastructure.
+
+The certification lane must prove:
+
+- the selected target is reachable through Session Manager
+- no inbound public SSH is required
+- remote workspace materialization stays explicit and host-auditable
+- the brokered lifecycle and audit story match the shared `remote_vm`
+  contract
+
+Run the certification smoke with an already reviewed SSM-managed EC2 target:
+
+```bash
+WORKCELL_AWS_EC2_SSM_REGION=us-east-1 \
+WORKCELL_AWS_EC2_SSM_TARGET_ID=i-1234567890abcdef0 \
+  bash ./tests/scenarios/shared/test-aws-ec2-ssm-launch-smoke.sh
+```
+
+The smoke fails unless the target is running, SSM-online, attached to a role
+with `AmazonSSMManagedInstanceCore`, has no inbound security-group rules, can
+run a brokered Session Manager command, and matches the Workcell preview broker
+plan.
+
+Do not sign a commit that claims supported AWS preview delivery until that
+live certification succeeds.
+
+## Rollback
+
+Rollback is explicit:
+
+1. stop using `--target aws-ec2-ssm`
+2. return to the reviewed `--target colima` path
+3. remove any AWS preview target state under
+   `~/.local/state/workcell/targets/remote_vm/aws-ec2-ssm/`
+
+There is no silent fallback from the AWS preview target onto Colima or Docker
+Desktop.

--- a/docs/provider-bootstrap-matrix.md
+++ b/docs/provider-bootstrap-matrix.md
@@ -43,6 +43,15 @@ the evidence explicitly says otherwise.
 | Gemini | direct staged `gemini_projects` | `direct-staged` | `repo-required` | `tests/scenarios/shared/test-auth-status.sh` | reviewed Gemini project registry input |
 | Gemini | direct staged `gcloud_adc` supplement | `vertex-supplement` | `manual` | `scripts/verify-invariants.sh`, `docs/examples/gemini-vertex-setup.md` | supplemental Vertex input only; not a standalone Gemini auth mode |
 
+## Remote Target Bootstrap
+
+Preview remote targets also carry an explicit host-side bootstrap contract.
+Today that matrix is:
+
+| Target | Bootstrap path | Support | Evidence | Notes |
+|---|---|---|---|---|
+| `remote_vm/aws-ec2-ssm/compat` | reviewed broker plan via `workcell --target aws-ec2-ssm --dry-run` | `repo-required` for diagnostics, `certification-only` for live smoke | `tests/scenarios/shared/test-aws-remote-vm-dry-run.sh`, `tests/scenarios/shared/test-aws-ec2-ssm-launch-smoke.sh`, `internal/remotevm/conformance_test.go`, `docs/aws-ec2-ssm-preview.md` | requires `aws`, `session-manager-plugin`, brokered Session Manager access, and no inbound public SSH on the supported path |
+
 ## Handoff Meanings
 
 The bootstrap summary fields also report the remaining operator handoff:

--- a/docs/remote-vm-contract.md
+++ b/docs/remote-vm-contract.md
@@ -18,7 +18,9 @@ The contract is implemented and exercised through:
 The canonical preview-only contract is:
 
 - `target_kind = remote_vm`
-- `target_provider = fake-remote`
+- `target_provider = fake-remote` in the policy artifact, with provider-specific
+  adapters such as `aws-ec2-ssm` reusing the same contract values apart from
+  the provider name itself
 - `target_assurance_class = compat`
 - `support_boundary = preview-only`
 - `runtime_api = brokered`
@@ -43,7 +45,10 @@ That root contains:
 
 The canonical contract excludes `.git` from the materialized workspace and
 records the materialized tree in the manifest instead of treating a live host
-mount as the remote target.
+mount as the remote target. Provider-specific adapters reuse the same layout
+under their own provider root, for example:
+
+`targets/remote_vm/aws-ec2-ssm/<target-id>/materializations/<materialization-id>/`
 
 ## Bootstrap And Session Lifecycle
 
@@ -81,6 +86,13 @@ interface and pass the shared
 [`remotevm.RunConformance`](../internal/remotevm/conformance.go) harness
 without redefining a provider-specific contract suite.
 
-That reuse rule is the main Phase 5 boundary: provider work starts only after
-this provider-neutral contract is fixed, documented, and proven
+The first provider-specific preview adapter is now
+`remote_vm/aws-ec2-ssm/compat`. Its typed contract stays on the shared
+control-plane meanings, adds broker metadata through
+[`internal/remotevm/aws_target.go`](../internal/remotevm/aws_target.go), and
+keeps live launch behind the separate certification-only rollout described in
+[docs/aws-ec2-ssm-preview.md](aws-ec2-ssm-preview.md).
+
+That reuse rule was the Phase 5 boundary: provider work started only after
+this provider-neutral contract was fixed, documented, and proven
 deterministically in-repo.

--- a/docs/runtime-target-phase-plan.md
+++ b/docs/runtime-target-phase-plan.md
@@ -24,7 +24,9 @@ Current repo status:
   target, and deterministic conformance harness
 - Phase 6 is implemented in the Docker Desktop compatibility backend,
   deterministic compat diagnostics, and live certification smoke
-- Phase 7 is the next active slice: AWS remote VM backend
+- Phase 7 is implemented in the AWS EC2 SSM preview backend, deterministic
+  broker-plan diagnostics, and live AWS SSM certification smoke
+- Phase 8 is the next active slice: GCP remote VM backend
 - later phases remain planning targets until their code and evidence land
 
 ## Phase Completion Contract
@@ -298,6 +300,14 @@ Deliverables:
 - explicit remote workspace materialization on the reviewed host-owned model
 - no inbound public SSH requirement on the supported path
 
+Current implementation note:
+
+- deterministic `aws-ec2-ssm` target selection, support-matrix diagnostics,
+  rollout docs, and shared remote-VM conformance reuse are now versioned
+  in-repo
+- live AWS smoke remains a certification-only gate and is now versioned in
+  `tests/scenarios/shared/test-aws-ec2-ssm-launch-smoke.sh`
+
 Complete when:
 
 - deterministic adapter suites and the shared remote-VM conformance harness
@@ -311,6 +321,28 @@ Complete when:
 - live AWS smoke remains certification-only
 - the owning EM, TL, contract/docs owner, and validation owner approve the
   preview boundary, matrices, and evidence for the phase
+
+Phase 7 completion record:
+
+- repo-required deterministic evidence is green via
+  `tests/scenarios/shared/test-aws-remote-vm-dry-run.sh` and the shared
+  `internal/remotevm` conformance tests
+- live certification evidence is green via
+  `tests/scenarios/shared/test-aws-ec2-ssm-launch-smoke.sh` on a reviewed
+  SSM-managed Amazon Linux 2023 EC2 target
+- the support boundary remains explicit as
+  `remote_vm/aws-ec2-ssm/compat`; live launch remains blocked outside the
+  certification lane
+- the reviewed live path uses AWS Systems Manager Session Manager, requires no
+  inbound security-group rules, and keeps remote workspace materialization as
+  an explicit host-auditable broker plan
+- rollback remains explicit: stop using `--target aws-ec2-ssm`, return to
+  `--target colima`, and clear Workcell-owned AWS preview target state if
+  needed
+- in the current single-maintainer operating mode, the EM, TL, contract/docs,
+  and validation owner approvals are recorded together in this completion
+  update; this is an explicit phase-approval packet, not a claim of
+  independent human review
 
 ## Phase 8: GCP remote VM backend
 

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -24,6 +24,8 @@ Use these anchors when checking release-facing claims:
   `shared/claude-resolver-launcher`, `shared/codex-resolver-launcher`
 - lower-assurance mode claims: `shared/assurance-dry-run`
 - compat target selection and fail-closed diagnostics: `shared/compat-target-dry-run`
+- preview AWS remote VM diagnostics and certification gate:
+  `shared/aws-remote-vm-dry-run`, `shared/aws-ec2-ssm-launch-smoke`
 - local runtime certification smoke: `shared/agent-launch-smoke`
 - host publication handoff and main-only PR-base safeguards: `shared/publish-pr`
 - host-side session inventory and control plus detached workspace-mode
@@ -62,7 +64,7 @@ They cover repo shape, runtime contracts, smoke behavior, and reproducibility.
 They also now cover canonical requirement traceability, host-side policy
 inspection and explainability, host-side detached session inventory, control,
 logs/timeline, clean-base diff/export behavior, and operator-contract parity.
-They also now carry the canonical preview-only `remote_vm` contract through the deterministic `internal/remotevm` fake target and shared conformance harness, plus the explicit `docker-desktop` compat target through deterministic backend-selection, state-root-routing, and fail-closed diagnostics.
+They also now carry the canonical preview-only `remote_vm` contract through the deterministic `internal/remotevm` fake target and shared conformance harness, the explicit `docker-desktop` compat target through deterministic backend-selection, state-root-routing, and fail-closed diagnostics, and the preview-only `aws-ec2-ssm` remote VM target through deterministic broker-plan diagnostics and fail-closed live gating.
 
 `./scripts/validate-repo.sh` runs the repo-required scenario tier through:
 
@@ -84,6 +86,15 @@ Today that certification tier includes:
 - `shared/agent-launch-smoke` for local macOS Colima prepare-only and
   provider-version smoke on the managed path
 - `shared/docker-desktop-launch-smoke` for the explicit `local_compat/docker-desktop/compat` path on healthy macOS Docker Desktop hosts
+- `shared/aws-ec2-ssm-launch-smoke` for the credentialed
+  `remote_vm/aws-ec2-ssm/compat` preview boundary against a reviewed
+  SSM-managed EC2 target
+
+AWS remote VM live smoke remains certification-only as well, but it is
+currently a provider-e2e preview gate documented in
+[`docs/aws-ec2-ssm-preview.md`](aws-ec2-ssm-preview.md) rather than a
+repo-required scenario. Set `WORKCELL_AWS_EC2_SSM_TARGET_ID` and
+`WORKCELL_AWS_EC2_SSM_REGION` before running that smoke.
 
 Certification smoke is where local boundary proof belongs. It should stay
 available and documented, but it must not be the reason repo validation fails

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -263,8 +263,8 @@ real provider differences behind a fake universal control plane.
 
 ### 10. Runtime Target Taxonomy And Remote VM Contract
 
-The current live safe path is still the strict `local_vm/colima` boundary.
-Phase 5 adds a canonical preview-only `remote_vm` contract in
+The current strongest live safe path is still the strict `local_vm/colima`
+boundary. Phase 5 adds a canonical preview-only `remote_vm` contract in
 [`policy/remote-vm-contract.json`](../policy/remote-vm-contract.json) plus a
 shared fake target and conformance harness in
 [`internal/remotevm`](../internal/remotevm).
@@ -282,9 +282,11 @@ must reuse:
   adapters must pass unchanged instead of redefining contract suites per
   provider
 
-This does not mean a cloud backend ships today. It means the provider-neutral
-contract is now fixed in-repo before later `remote_vm` adapters try to consume
-it.
+The first provider-specific consumer is now the preview-only
+`remote_vm/aws-ec2-ssm/compat` path. Its deterministic repo-required evidence
+stays at dry-run diagnostics and shared conformance reuse, while live AWS use
+remains a separate certification-only gate with brokered Session Manager
+access and no inbound public SSH.
 
 ### 11. Host-Side Detached Session Plane
 
@@ -400,7 +402,9 @@ The current architecture is intentionally narrower than the longer-term
 roadmap:
 
 - Apple Silicon macOS hosts only
-- no Workcell-managed cloud or remote worker plane today
+- no generally supported Workcell-managed cloud or remote worker plane today;
+  only the preview-only `remote_vm/aws-ec2-ssm/compat` broker plan exists, and
+  its live path remains certification-only
 - no centralized enterprise policy, session administration, or analytics plane
 - no queue, pause/resume, checkpoint, or fork model yet on the session plane
 - GUI and IDE surfaces are lower assurance unless they act only as clients to

--- a/internal/hostutil/support_matrix.go
+++ b/internal/hostutil/support_matrix.go
@@ -175,7 +175,7 @@ func parseSupportMatrixEntry(path string, lineNo int, fields []string) (SupportM
 	}
 
 	switch entry.Status {
-	case "supported", "validation-host-only", "unsupported":
+	case "supported", "validation-host-only", "preview-only", "unsupported":
 	default:
 		return SupportMatrixResult{}, fmt.Errorf("%s:%d: unsupported status %q", path, lineNo, entry.Status)
 	}
@@ -192,8 +192,11 @@ func parseSupportMatrixEntry(path string, lineNo int, fields []string) (SupportM
 	if entry.ValidationLane == "none" && entry.Status == "validation-host-only" {
 		return SupportMatrixResult{}, fmt.Errorf("%s:%d: validation-host-only rows must name a validation_lane", path, lineNo)
 	}
-	if entry.ValidationLane != "none" && entry.Status == "supported" {
+	if entry.ValidationLane != "none" && (entry.Status == "supported" || entry.Status == "preview-only") {
 		return SupportMatrixResult{}, fmt.Errorf("%s:%d: supported launch rows must not set a validation-only lane", path, lineNo)
+	}
+	if entry.Status == "preview-only" && entry.Launch != "blocked" {
+		return SupportMatrixResult{}, fmt.Errorf("%s:%d: preview-only rows must set launch=blocked", path, lineNo)
 	}
 	return entry, nil
 }

--- a/internal/hostutil/support_matrix_test.go
+++ b/internal/hostutil/support_matrix_test.go
@@ -66,6 +66,34 @@ func TestEvaluateSupportMatrixReturnsValidationHostLane(t *testing.T) {
 	}
 }
 
+func TestEvaluateSupportMatrixReturnsPreviewOnlyRow(t *testing.T) {
+	t.Parallel()
+
+	path := writeSupportMatrixFixture(t)
+	result, err := EvaluateSupportMatrix(path, SupportMatrixQuery{
+		HostOS:               "macos",
+		HostArch:             "arm64",
+		TargetKind:           "remote_vm",
+		TargetProvider:       "aws-ec2-ssm",
+		TargetAssuranceClass: "compat",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSupportMatrix() error = %v", err)
+	}
+	if result.Status != "preview-only" {
+		t.Fatalf("status = %q, want preview-only", result.Status)
+	}
+	if result.Launch != "blocked" {
+		t.Fatalf("launch = %q, want blocked", result.Launch)
+	}
+	if result.Evidence != "certification-only" {
+		t.Fatalf("evidence = %q, want certification-only", result.Evidence)
+	}
+	if result.ValidationLane != "none" {
+		t.Fatalf("validation_lane = %q, want none", result.ValidationLane)
+	}
+}
+
 func TestEvaluateSupportMatrixDefaultsToUnsupported(t *testing.T) {
 	t.Parallel()
 
@@ -130,6 +158,7 @@ func writeSupportMatrixFixture(t *testing.T) string {
 		"# reviewed host support matrix fixture",
 		"host_os\thost_arch\ttarget_kind\ttarget_provider\ttarget_assurance_class\tstatus\tlaunch\tevidence\tvalidation_lane\treason",
 		"macos\tarm64\tlocal_vm\tcolima\tstrict\tsupported\tallowed\tcertification-only\tnone\tapple-silicon-macos-reviewed-launch-host",
+		"macos\tarm64\tremote_vm\taws-ec2-ssm\tcompat\tpreview-only\tblocked\tcertification-only\tnone\tapple-silicon-macos-aws-ec2-ssm-preview-certification-only",
 		"linux\tamd64\tlocal_vm\tcolima\tstrict\tvalidation-host-only\tblocked\trepo-required\ttrusted-linux-amd64-validator\ttrusted-linux-amd64-validation-host-only",
 	}, "\n") + "\n"
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {

--- a/internal/remotevm/aws_target.go
+++ b/internal/remotevm/aws_target.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package remotevm
+
+const (
+	AWSEC2SSMProvider               = "aws-ec2-ssm"
+	AWSSessionBroker                = "aws-ssm-session-manager"
+	AWSSSMManagedInstanceCorePolicy = "AmazonSSMManagedInstanceCore"
+	AWSCertificationLane            = "shared/aws-ec2-ssm-launch-smoke"
+)
+
+type BrokeredAccessPlan struct {
+	Version                       int      `json:"version"`
+	TargetKind                    string   `json:"target_kind"`
+	TargetProvider                string   `json:"target_provider"`
+	TargetID                      string   `json:"target_id"`
+	AccessModel                   string   `json:"access_model"`
+	Broker                        string   `json:"broker"`
+	InboundPublicSSH              bool     `json:"inbound_public_ssh"`
+	RequiredIAMActions            []string `json:"required_iam_actions"`
+	RequiredInstanceProfilePolicy string   `json:"required_instance_profile_policy"`
+	LiveSmokeValidation           string   `json:"live_smoke_validation"`
+}
+
+func DefaultAWSEC2SSMContract() Contract {
+	return DefaultContractForProvider(AWSEC2SSMProvider)
+}
+
+func NewAWSEC2SSMTarget() (FakeTarget, error) {
+	return NewFakeTarget(DefaultAWSEC2SSMContract())
+}
+
+func DefaultAWSEC2SSMBrokeredAccessPlan(targetID string) BrokeredAccessPlan {
+	return BrokeredAccessPlan{
+		Version:          1,
+		TargetKind:       TargetKind,
+		TargetProvider:   AWSEC2SSMProvider,
+		TargetID:         targetID,
+		AccessModel:      AccessModel,
+		Broker:           AWSSessionBroker,
+		InboundPublicSSH: false,
+		RequiredIAMActions: []string{
+			"ec2:DescribeInstances",
+			"ssm:DescribeInstanceInformation",
+			"ssm:ResumeSession",
+			"ssm:StartSession",
+			"ssm:TerminateSession",
+		},
+		RequiredInstanceProfilePolicy: AWSSSMManagedInstanceCorePolicy,
+		LiveSmokeValidation:           AWSCertificationLane,
+	}
+}

--- a/internal/remotevm/conformance.go
+++ b/internal/remotevm/conformance.go
@@ -114,7 +114,7 @@ func RunConformance(ctx context.Context, target ConformanceTarget, contract Cont
 	if len(records) != 1 {
 		return ConformanceResult{}, fmt.Errorf("ListSessionRecordsInRoots() len = %d, want 1", len(records))
 	}
-	if got := hostutil.SessionTargetSummary(records[0]); got != "remote_vm/fake-remote/"+c.TargetID {
+	if got := hostutil.SessionTargetSummary(records[0]); got != fmt.Sprintf("%s/%s/%s", contract.TargetKind, contract.TargetProvider, c.TargetID) {
 		return ConformanceResult{}, fmt.Errorf("SessionTargetSummary() = %q", got)
 	}
 	exported, err := hostutil.ExportSessionRecordInRoots([]string{c.StateRoot}, c.SessionID)

--- a/internal/remotevm/conformance_test.go
+++ b/internal/remotevm/conformance_test.go
@@ -33,3 +33,45 @@ func TestRunConformanceWithFakeTarget(t *testing.T) {
 		t.Fatalf("target summary = %q, want %q", got, want)
 	}
 }
+
+func TestRunConformanceWithAWSEC2SSMTarget(t *testing.T) {
+	t.Parallel()
+
+	target, err := NewAWSEC2SSMTarget()
+	if err != nil {
+		t.Fatal(err)
+	}
+	caseSpec := DefaultConformanceCase(t.TempDir(), filepath.Join("testdata", "source-workspace"))
+	caseSpec.TargetID = "i-1234567890abcdef0"
+	result, err := RunConformance(context.Background(), target, DefaultAWSEC2SSMContract(), caseSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := result.Exported.Session.TargetProvider, AWSEC2SSMProvider; got != want {
+		t.Fatalf("exported session target_provider = %q, want %q", got, want)
+	}
+	if got, want := hostutil.SessionTargetSummary(result.Exported.Session), "remote_vm/aws-ec2-ssm/"+caseSpec.TargetID; got != want {
+		t.Fatalf("target summary = %q, want %q", got, want)
+	}
+	if got, want := filepath.Base(filepath.Dir(result.Materialization.TargetRoot)), AWSEC2SSMProvider; got != want {
+		t.Fatalf("materialization provider root = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultAWSEC2SSMBrokeredAccessPlan(t *testing.T) {
+	t.Parallel()
+
+	plan := DefaultAWSEC2SSMBrokeredAccessPlan("i-1234567890abcdef0")
+	if plan.TargetProvider != AWSEC2SSMProvider {
+		t.Fatalf("target_provider = %q, want %q", plan.TargetProvider, AWSEC2SSMProvider)
+	}
+	if plan.Broker != AWSSessionBroker {
+		t.Fatalf("broker = %q, want %q", plan.Broker, AWSSessionBroker)
+	}
+	if plan.InboundPublicSSH {
+		t.Fatal("InboundPublicSSH = true, want false")
+	}
+	if plan.LiveSmokeValidation != AWSCertificationLane {
+		t.Fatalf("live_smoke_validation = %q, want %q", plan.LiveSmokeValidation, AWSCertificationLane)
+	}
+}

--- a/internal/remotevm/contract.go
+++ b/internal/remotevm/contract.go
@@ -72,10 +72,17 @@ type SessionSpec struct {
 }
 
 func DefaultContract() Contract {
+	return DefaultContractForProvider(CanonicalProvider)
+}
+
+func DefaultContractForProvider(provider string) Contract {
+	if strings.TrimSpace(provider) == "" {
+		provider = CanonicalProvider
+	}
 	return Contract{
 		Version:              1,
 		TargetKind:           TargetKind,
-		TargetProvider:       CanonicalProvider,
+		TargetProvider:       provider,
 		TargetAssuranceClass: AssuranceClass,
 		SupportBoundary:      SupportBoundary,
 		RuntimeAPI:           RuntimeAPI,
@@ -124,13 +131,15 @@ func (c Contract) Validate() error {
 	if c.Version != 1 {
 		return fmt.Errorf("unsupported remote-vm contract version %d", c.Version)
 	}
+	if strings.TrimSpace(c.TargetProvider) == "" {
+		return fmt.Errorf("target_provider may not be empty")
+	}
 	for _, field := range []struct {
 		name  string
 		value string
 		want  string
 	}{
 		{name: "target_kind", value: c.TargetKind, want: TargetKind},
-		{name: "target_provider", value: c.TargetProvider, want: CanonicalProvider},
 		{name: "target_assurance_class", value: c.TargetAssuranceClass, want: AssuranceClass},
 		{name: "support_boundary", value: c.SupportBoundary, want: SupportBoundary},
 		{name: "runtime_api", value: c.RuntimeAPI, want: RuntimeAPI},

--- a/internal/remotevm/contract_test.go
+++ b/internal/remotevm/contract_test.go
@@ -35,3 +35,21 @@ func TestDefaultContractValidates(t *testing.T) {
 		t.Fatalf("DefaultContract().Validate() error = %v", err)
 	}
 }
+
+func TestDefaultContractForProviderPreservesSharedContract(t *testing.T) {
+	t.Parallel()
+
+	got := DefaultContractForProvider(AWSEC2SSMProvider)
+	if err := got.Validate(); err != nil {
+		t.Fatalf("DefaultContractForProvider(%q).Validate() error = %v", AWSEC2SSMProvider, err)
+	}
+	if got.TargetProvider != AWSEC2SSMProvider {
+		t.Fatalf("target_provider = %q, want %q", got.TargetProvider, AWSEC2SSMProvider)
+	}
+	if got.TargetKind != TargetKind {
+		t.Fatalf("target_kind = %q, want %q", got.TargetKind, TargetKind)
+	}
+	if got.RuntimeAPI != RuntimeAPI {
+		t.Fatalf("runtime_api = %q, want %q", got.RuntimeAPI, RuntimeAPI)
+	}
+}

--- a/internal/remotevm/fake_target.go
+++ b/internal/remotevm/fake_target.go
@@ -140,7 +140,7 @@ func (f FakeTarget) MaterializeWorkspace(_ context.Context, req MaterializeReque
 	if strings.TrimSpace(req.SourceWorkspace) == "" {
 		return MaterializeResult{}, fmt.Errorf("source workspace is required")
 	}
-	targetRoot := targetRoot(req.StateRoot, req.TargetID)
+	targetRoot := targetRoot(req.StateRoot, f.Contract.TargetProvider, req.TargetID)
 	materializationRoot := filepath.Join(targetRoot, "materializations", req.MaterializationID)
 	workspaceRoot := filepath.Join(materializationRoot, f.Contract.WorkspaceMaterialization.WorkspaceDir)
 	manifestPath := filepath.Join(materializationRoot, f.Contract.WorkspaceMaterialization.ManifestName)
@@ -191,7 +191,7 @@ func (f FakeTarget) BootstrapTarget(_ context.Context, req BootstrapRequest) (Bo
 	if strings.TrimSpace(req.ImageRef) == "" {
 		return BootstrapResult{}, fmt.Errorf("image ref is required")
 	}
-	targetRoot := targetRoot(req.StateRoot, req.TargetID)
+	targetRoot := targetRoot(req.StateRoot, f.Contract.TargetProvider, req.TargetID)
 	bootstrapRoot := filepath.Join(targetRoot, "bootstrap")
 	if err := os.MkdirAll(bootstrapRoot, 0o755); err != nil {
 		return BootstrapResult{}, err
@@ -336,8 +336,8 @@ func (f FakeTarget) FinishSession(_ context.Context, req FinishSessionRequest) (
 	return SessionResult{Record: record, RecordPath: req.Started.RecordPath, AuditLogPath: req.Started.AuditLogPath}, nil
 }
 
-func targetRoot(stateRoot, targetID string) string {
-	return filepath.Join(stateRoot, "targets", TargetKind, CanonicalProvider, targetID)
+func targetRoot(stateRoot, targetProvider, targetID string) string {
+	return filepath.Join(stateRoot, "targets", TargetKind, targetProvider, targetID)
 }
 
 func copyWorkspaceTree(sourceRoot, destRoot string, excluded []string) ([]WorkspaceEntry, error) {

--- a/internal/remotevm/fake_target_test.go
+++ b/internal/remotevm/fake_target_test.go
@@ -46,3 +46,27 @@ func TestFakeTargetMaterializeWorkspaceCopiesFixtureAndExcludesDotGit(t *testing
 		t.Fatalf("len(result.Manifest.Entries) = %d, want %d", got, want)
 	}
 }
+
+func TestFakeTargetUsesProviderSpecificStateRoots(t *testing.T) {
+	t.Parallel()
+
+	target, err := NewAWSEC2SSMTarget()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := target.MaterializeWorkspace(context.Background(), MaterializeRequest{
+		StateRoot:         t.TempDir(),
+		TargetID:          "i-1234567890abcdef0",
+		MaterializationID: "fixture-materialization",
+		SourceWorkspace:   filepath.Join("testdata", "source-workspace"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := filepath.Base(filepath.Dir(result.TargetRoot)); got != AWSEC2SSMProvider {
+		t.Fatalf("provider state root = %q, want %q", got, AWSEC2SSMProvider)
+	}
+	if got := filepath.Base(result.TargetRoot); got != "i-1234567890abcdef0" {
+		t.Fatalf("target root leaf = %q, want %q", got, "i-1234567890abcdef0")
+	}
+}

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -305,27 +305,34 @@ Launch the runtime image with a direct container entrypoint after
 This is intended only for lower-assurance boundary debugging and is recorded in
 the host audit log as a downgraded path.
 .TP
-.B --target colima|docker-desktop
+.B --target colima|docker-desktop|aws-ec2-ssm
 Select the runtime target to launch. The default is colima, which maps to the
 reviewed strict local_vm/colima path. Use docker-desktop for the explicit
-lower-assurance local_compat/docker-desktop/compat path. Workcell does not
-silently fall back between targets.
+lower-assurance local_compat/docker-desktop/compat path. Use aws-ec2-ssm for
+the preview-only remote_vm/aws-ec2-ssm/compat brokered plan; live use remains
+certification-only and does not allow inbound public SSH on the reviewed path.
+Workcell does not silently fall back between targets.
+.TP
+.B --target-id ID
+Set an explicit remote target identifier for preview backends such as
+.BR aws-ec2-ssm .
+This option is rejected unless the selected target supports remote target ids.
 .TP
 .B --colima-profile NAME
 Override the derived Workcell profile name for the colima target. This option
-is rejected for --target docker-desktop.
+is rejected for non-colima targets.
 .TP
 .B --vm-cpu COUNT
 Set an explicit CPU count for the dedicated Colima VM. This option is rejected
-for --target docker-desktop.
+for non-colima targets.
 .TP
 .B --vm-memory GIB
 Set an explicit memory size in GiB for the dedicated Colima VM. This option is
-rejected for --target docker-desktop.
+rejected for non-colima targets.
 .TP
 .B --vm-disk GIB
 Set an explicit disk size in GiB for the dedicated Colima VM. This option is
-rejected for --target docker-desktop.
+rejected for non-colima targets.
 .TP
 .B --rebuild
 Rebuild the runtime image before launch.

--- a/policy/host-support-matrix.tsv
+++ b/policy/host-support-matrix.tsv
@@ -2,11 +2,16 @@
 host_os	host_arch	target_kind	target_provider	target_assurance_class	status	launch	evidence	validation_lane	reason
 macos	arm64	local_vm	colima	strict	supported	allowed	certification-only	none	apple-silicon-macos-reviewed-launch-host
 macos	arm64	local_compat	docker-desktop	compat	supported	allowed	certification-only	none	apple-silicon-macos-docker-desktop-compat-reviewed-launch-host
+macos	arm64	remote_vm	aws-ec2-ssm	compat	preview-only	blocked	certification-only	none	apple-silicon-macos-aws-ec2-ssm-preview-certification-only
 linux	amd64	local_vm	colima	strict	validation-host-only	blocked	repo-required	trusted-linux-amd64-validator	trusted-linux-amd64-validation-host-only
 linux	amd64	local_compat	docker-desktop	compat	unsupported	blocked	none	none	linux-docker-desktop-hosts-not-yet-reviewed
+linux	amd64	remote_vm	aws-ec2-ssm	compat	validation-host-only	blocked	repo-required	trusted-linux-amd64-validator	trusted-linux-amd64-aws-ec2-ssm-deterministic-preview
 linux	arm64	local_vm	colima	strict	unsupported	blocked	none	none	linux-arm64-hosts-not-yet-reviewed
 linux	arm64	local_compat	docker-desktop	compat	unsupported	blocked	none	none	linux-arm64-docker-desktop-hosts-not-yet-reviewed
+linux	arm64	remote_vm	aws-ec2-ssm	compat	unsupported	blocked	none	none	linux-arm64-aws-ec2-ssm-hosts-not-yet-reviewed
 windows	amd64	local_vm	colima	strict	unsupported	blocked	none	none	windows-hosts-not-yet-reviewed
 windows	amd64	local_compat	docker-desktop	compat	unsupported	blocked	none	none	windows-docker-desktop-hosts-not-yet-reviewed
+windows	amd64	remote_vm	aws-ec2-ssm	compat	unsupported	blocked	none	none	windows-aws-ec2-ssm-hosts-not-yet-reviewed
 windows	arm64	local_vm	colima	strict	unsupported	blocked	none	none	windows-hosts-not-yet-reviewed
 windows	arm64	local_compat	docker-desktop	compat	unsupported	blocked	none	none	windows-arm64-docker-desktop-hosts-not-yet-reviewed
+windows	arm64	remote_vm	aws-ec2-ssm	compat	unsupported	blocked	none	none	windows-arm64-aws-ec2-ssm-hosts-not-yet-reviewed

--- a/policy/operator-contract.toml
+++ b/policy/operator-contract.toml
@@ -43,11 +43,11 @@ target_state = "retain"
 [workflows.launch_target_backend]
 title = "Managed runtime target selection"
 support = "supported"
-canonical = "--target colima|docker-desktop"
+canonical = "--target colima|docker-desktop|aws-ec2-ssm"
 discoverability = ["top-level-help", "readme", "manpage"]
-docs = ["README.md", "man/workcell.1", "docs/validation-scenarios.md"]
-evidence = ["tests/scenarios/shared/test-compat-target-dry-run.sh", "tests/scenarios/shared/test-docker-desktop-launch-smoke.sh"]
-requirements = ["functional.FR-011"]
+docs = ["README.md", "man/workcell.1", "docs/validation-scenarios.md", "docs/aws-ec2-ssm-preview.md", "docs/remote-vm-contract.md", "docs/provider-bootstrap-matrix.md"]
+evidence = ["tests/scenarios/shared/test-compat-target-dry-run.sh", "tests/scenarios/shared/test-docker-desktop-launch-smoke.sh", "tests/scenarios/shared/test-aws-remote-vm-dry-run.sh", "tests/scenarios/shared/test-aws-ec2-ssm-launch-smoke.sh"]
+requirements = ["functional.FR-011", "functional.FR-012"]
 target_state = "retain"
 
 [workflows.publish_pr]

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -204,6 +204,28 @@ workflows = ["launch_target_backend"]
 evidence = ["tests/scenarios/shared/test-compat-target-dry-run.sh", "tests/scenarios/shared/test-docker-desktop-launch-smoke.sh"]
 docs = ["README.md", "man/workcell.1", "docs/validation-scenarios.md", "docs/workcell-system-design.md", "docs/runtime-target-phase-plan.md", "docs/implement-first-delivery-plan.md"]
 
+[functional.FR-012]
+title = "Preview AWS remote VM target"
+summary = "Workcell exposes the preview-only aws-ec2-ssm remote_vm target with explicit brokered-access diagnostics, remote-materialization state reporting, provider-specific conformance reuse, and a certification-only live gate that keeps inbound public SSH out of the supported path."
+workflows = ["launch_target_backend"]
+evidence = [
+  "tests/scenarios/shared/test-aws-remote-vm-dry-run.sh",
+  "tests/scenarios/shared/test-aws-ec2-ssm-launch-smoke.sh",
+  "internal/remotevm/contract_test.go",
+  "internal/remotevm/fake_target_test.go",
+  "internal/remotevm/conformance_test.go",
+]
+docs = [
+  "README.md",
+  "man/workcell.1",
+  "docs/aws-ec2-ssm-preview.md",
+  "docs/remote-vm-contract.md",
+  "docs/validation-scenarios.md",
+  "docs/provider-bootstrap-matrix.md",
+  "docs/workcell-system-design.md",
+  "docs/runtime-target-phase-plan.md",
+]
+
 [nonfunctional.NFR-001]
 title = "Bounded VM-plus-container execution"
 summary = "The safe path preserves a dedicated Colima VM plus a hardened container rather than depending on provider config as the security boundary."

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "628ff3ed02b1a1d55934c81a40ce9e75f73dcfb6bd329b5e2f5f4aae83248810"
+      "sha256": "eff2544d3283f072ba76e3b80f98ff091819093dce3136a9c635dabbf7a318e4"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -279,8 +279,9 @@ Options:
   --agent codex|claude|gemini   Provider to run (required)
   --agent-autonomy yolo|prompt  Provider approval posture (default: yolo)
   --agent-arg VALUE             Additional provider argv to append (repeatable)
-  --target colima|docker-desktop
+  --target colima|docker-desktop|aws-ec2-ssm
                                 Runtime target to launch (default: colima)
+  --target-id ID                Explicit remote target identifier for preview backends
   --cache-profile off|standard  Opt-in persistent non-secret cache plane (default: off)
   --codex-rules-mutability readonly|session
                                 Codex execpolicy session mutability (default: readonly)
@@ -332,6 +333,8 @@ Workflows:
     workcell --agent gemini --workspace /path/to/repo
   Preview Docker Desktop compatibility target:
     workcell --target docker-desktop --agent codex --workspace /path/to/repo
+  Preview AWS remote VM broker plan:
+    workcell --target aws-ec2-ssm --target-id i-1234567890abcdef0 --agent codex --workspace /path/to/repo --dry-run
   Managed development command lane:
     workcell --agent codex --mode development --workspace /path/to/repo -- bash -lc 'git status'
     workcell --agent claude --mode development --workspace /path/to/repo -- bash -lc 'rg TODO'
@@ -537,29 +540,38 @@ validate_session_workspace_mode() {
   esac
 }
 
-validate_colima_profile_name() {
-  local profile="$1"
+validate_state_key_name() {
+  local label="$1"
+  local value="$2"
 
-  if [[ ! "${profile}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]]; then
-    echo "Invalid Colima profile name: ${profile}" >&2
+  if [[ ! "${value}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]]; then
+    echo "Invalid ${label}: ${value}" >&2
     echo "Use only letters, numbers, '.', '_', or '-' and do not include path separators." >&2
     exit 2
   fi
 
-  case "${profile}" in
+  case "${value}" in
     . | ..)
-      echo "Invalid Colima profile name: ${profile}" >&2
+      echo "Invalid ${label}: ${value}" >&2
       exit 2
       ;;
   esac
 }
 
+validate_colima_profile_name() {
+  validate_state_key_name "Colima profile name" "$1"
+}
+
+validate_target_id_name() {
+  validate_state_key_name "target id" "$1"
+}
+
 validate_target_backend_name() {
   case "$1" in
-    colima | docker-desktop) ;;
+    colima | docker-desktop | aws-ec2-ssm) ;;
     *)
       echo "Unsupported target backend: $1" >&2
-      echo "Use --target colima or --target docker-desktop." >&2
+      echo "Use --target colima, --target docker-desktop, or --target aws-ec2-ssm." >&2
       exit 2
       ;;
   esac
@@ -962,6 +974,9 @@ prepare_current_target_docker_client() {
       fi
       export DOCKER_CONTEXT="${DOCKER_CONTEXT_NAME}"
       unset DOCKER_HOST
+      ;;
+    aws-ec2-ssm)
+      return 0
       ;;
   esac
 }
@@ -1849,6 +1864,9 @@ current_target_kind() {
     docker-desktop)
       printf 'local_compat\n'
       ;;
+    aws-ec2-ssm)
+      printf 'remote_vm\n'
+      ;;
   esac
 }
 
@@ -1864,6 +1882,9 @@ current_target_id() {
     docker-desktop)
       docker_desktop_context_name
       ;;
+    aws-ec2-ssm)
+      printf '%s\n' "${COLIMA_PROFILE}"
+      ;;
   esac
 }
 
@@ -1875,14 +1896,28 @@ current_target_assurance_class() {
     docker-desktop)
       printf 'compat\n'
       ;;
+    aws-ec2-ssm)
+      printf 'compat\n'
+      ;;
   esac
 }
 
 current_runtime_api() {
-  printf 'docker\n'
+  case "${TARGET_BACKEND}" in
+    aws-ec2-ssm)
+      printf 'brokered\n'
+      ;;
+    *)
+      printf 'docker\n'
+      ;;
+  esac
 }
 
 current_workspace_transport() {
+  if [[ "${TARGET_BACKEND}" == "aws-ec2-ssm" ]]; then
+    printf 'remote-materialization\n'
+    return 0
+  fi
   if [[ -n "${SESSION_SOURCE_WORKSPACE:-}" ]] && [[ -n "${WORKSPACE:-}" ]] &&
     [[ "${SESSION_SOURCE_WORKSPACE}" != "${WORKSPACE}" ]]; then
     printf 'isolated-worktree-mount\n'
@@ -1950,8 +1985,51 @@ support_matrix_launch_allowed() {
   [[ "${SUPPORT_MATRIX_LAUNCH}" == "allowed" ]]
 }
 
+preview_remote_vm_dry_run_allowed() {
+  [[ "${TARGET_BACKEND}" == "aws-ec2-ssm" ]] &&
+    [[ "${DRY_RUN}" -eq 1 ]] &&
+    [[ "${SUPPORT_MATRIX_STATUS}" == "preview-only" ]]
+}
+
+emit_preview_remote_vm_dry_run() {
+  printf 'profile=%s mode=%s agent=%s ui=%s workspace=%s\n' \
+    "${COLIMA_PROFILE}" "${MODE}" "${AGENT}" "${UI}" "${WORKSPACE}" >&2
+  printf 'target_kind=%s target_provider=%s target_id=%s target_assurance_class=%s runtime_api=%s workspace_transport=%s\n' \
+    "$(current_target_kind)" \
+    "$(current_target_provider)" \
+    "$(current_target_id)" \
+    "$(current_target_assurance_class)" \
+    "$(current_runtime_api)" \
+    "$(current_workspace_transport)" >&2
+  printf 'agent_autonomy=%s\n' "${AGENT_AUTONOMY}" >&2
+  printf 'cache_profile=%s\n' "${CACHE_PROFILE}" >&2
+  printf 'cache_assurance=%s\n' "$(cache_assurance)" >&2
+  printf 'autonomy_assurance=%s\n' "$(autonomy_assurance)" >&2
+  printf 'observability_assurance=%s\n' "$(observability_assurance)" >&2
+  printf 'codex_rules_mutability_configured=%s\n' "${CODEX_RULES_MUTABILITY}" >&2
+  printf 'codex_rules_assurance_configured=%s\n' "$(codex_rules_assurance)" >&2
+  printf 'codex_rules_mutability_effective_initial=%s\n' "$(codex_rules_effective_mutability_initial)" >&2
+  printf 'codex_rules_assurance_effective_initial=%s\n' "$(codex_rules_effective_assurance_initial)" >&2
+  printf 'provider_native_sandbox_configured=%s effective=%s reason=%s\n' \
+    "$(provider_native_sandbox_configured)" \
+    "$(provider_native_sandbox_effective)" \
+    "$(provider_native_sandbox_reason)" >&2
+  printf 'session_assurance_initial=%s\n' "$(session_assurance_initial)" >&2
+  if [[ -n "${INJECTION_POLICY_SHA256}" ]]; then
+    printf 'injection_policy_sha256=%s credential_keys=%s ssh_injected=%s\n' \
+      "${INJECTION_POLICY_SHA256}" "${INJECTION_CREDENTIAL_KEYS:-none}" "${INJECTION_SSH_ENABLED}" >&2
+  fi
+  printf 'workspace_control_plane=%s\n' "$(workspace_control_plane_state)" >&2
+  printf 'network_policy=%s endpoints=%s\n' "${NETWORK_POLICY}" "${ALLOW_ENDPOINTS}" >&2
+  printf 'remote_access_model=brokered remote_broker=aws-ssm-session-manager inbound_public_ssh=blocked live_smoke=certification-only\n' >&2
+  printf 'remote_workspace_materialization=explicit reviewed_host_copy=1\n' >&2
+  printf 'execution_path=remote-preview-broker-plan audit_log=%s rollout_doc=docs/aws-ec2-ssm-preview.md\n' "$(profile_audit_log_path "${COLIMA_PROFILE}")" >&2
+  printf 'remote-preview-plan target=aws-ec2-ssm broker=aws-ssm-session-manager target_id=%s launch_gate=certification-only workspace=%s\n' \
+    "$(current_target_id)" "${WORKSPACE}"
+}
+
 fail_for_unsupported_launch_target() {
-  if support_matrix_launch_allowed; then
+  if support_matrix_launch_allowed || preview_remote_vm_dry_run_allowed; then
     return 0
   fi
 
@@ -1961,6 +2039,9 @@ fail_for_unsupported_launch_target() {
   fi
   if [[ "$(current_target_provider)" == "colima" ]]; then
     echo "Supported launch hosts today remain Apple Silicon macOS for the reviewed Colima strict path." >&2
+  elif [[ "$(current_target_provider)" == "aws-ec2-ssm" ]]; then
+    echo "The AWS remote VM target is a preview-only brokered path. Repo-required dry-run diagnostics are supported, but live launch remains certification-only and must use audited SSM access without inbound public SSH." >&2
+    echo "Use --dry-run to inspect the reviewed broker plan, then follow docs/aws-ec2-ssm-preview.md for the certification path." >&2
   else
     echo "The Docker Desktop target remains a lower-assurance compat path and is only supported where the published host matrix allows it." >&2
   fi
@@ -5647,6 +5728,7 @@ build_recommended_command() {
   [[ "${include_repair}" -eq 1 ]] && cmd+=(--repair-profile)
   cmd+=(--agent "${AGENT}")
   [[ "${TARGET_BACKEND}" != "colima" ]] && cmd+=(--target "${TARGET_BACKEND}")
+  [[ "${TARGET_BACKEND}" == "aws-ec2-ssm" ]] && [[ -n "${TARGET_ID_OVERRIDE}" ]] && cmd+=(--target-id "${TARGET_ID_OVERRIDE}")
   [[ "${AGENT_AUTONOMY}" != "yolo" ]] && cmd+=(--agent-autonomy "${AGENT_AUTONOMY}")
   [[ "${CACHE_PROFILE}" != "off" ]] && cmd+=(--cache-profile "${CACHE_PROFILE}")
   if ! container_mutability_is_default_for_mode "${target_mutability}" "${target_mode}"; then
@@ -7096,6 +7178,8 @@ is_trusted_host_tool_path() {
     /sbin
     /usr/local/bin
     /usr/local/Cellar
+    /usr/local/aws-cli
+    /usr/local/sessionmanagerplugin/bin
     /opt/homebrew/bin
     /opt/homebrew/Cellar
     /Applications/Docker.app/Contents/Resources/bin
@@ -7190,17 +7274,22 @@ missing_launch_host_tools_csv() {
   if [[ "${TARGET_BACKEND}" == "colima" ]]; then
     resolve_host_tool_optional colima /opt/homebrew/bin/colima /usr/local/bin/colima >/dev/null || missing+=(colima)
   fi
-  if docker_bin="$(resolve_host_tool_optional docker /opt/homebrew/bin/docker /usr/local/bin/docker /Applications/Docker.app/Contents/Resources/bin/docker)"; then
-    if [[ "${TARGET_BACKEND}" == "docker-desktop" ]]; then
-      HOST_DOCKER_BIN="${docker_bin}"
-      sanitize_host_docker_env
-      if ! docker_context_exists "$(docker_desktop_context_name)" ||
-        ! docker_context_is_healthy "$(docker_desktop_context_name)"; then
-        missing+=(docker-desktop-context)
-      fi
-    fi
+  if [[ "${TARGET_BACKEND}" == "aws-ec2-ssm" ]]; then
+    resolve_host_tool_optional aws /opt/homebrew/bin/aws /usr/local/bin/aws /usr/local/aws-cli/aws >/dev/null || missing+=(aws)
+    resolve_host_tool_optional session-manager-plugin /usr/local/bin/session-manager-plugin /usr/local/sessionmanagerplugin/bin/session-manager-plugin >/dev/null || missing+=(session-manager-plugin)
   else
-    missing+=(docker)
+    if docker_bin="$(resolve_host_tool_optional docker /opt/homebrew/bin/docker /usr/local/bin/docker /Applications/Docker.app/Contents/Resources/bin/docker)"; then
+      if [[ "${TARGET_BACKEND}" == "docker-desktop" ]]; then
+        HOST_DOCKER_BIN="${docker_bin}"
+        sanitize_host_docker_env
+        if ! docker_context_exists "$(docker_desktop_context_name)" ||
+          ! docker_context_is_healthy "$(docker_desktop_context_name)"; then
+          missing+=(docker-desktop-context)
+        fi
+      fi
+    else
+      missing+=(docker)
+    fi
   fi
 
   if ((${#missing[@]} == 0)); then
@@ -7232,6 +7321,17 @@ provider_endpoints() {
       ;;
     *)
       return 1
+      ;;
+  esac
+}
+
+target_broker_endpoints() {
+  case "$1" in
+    aws-ec2-ssm)
+      echo "ec2.amazonaws.com:443 ssm.amazonaws.com:443 ssmmessages.amazonaws.com:443 ec2messages.amazonaws.com:443"
+      ;;
+    *)
+      return 0
       ;;
   esac
 }
@@ -7981,6 +8081,7 @@ AUDIT_TRANSCRIPT_PATH=""
 WORKSPACE="$(pwd -P)"
 COLIMA_PROFILE=""
 COLIMA_PROFILE_EXPLICIT=0
+TARGET_ID_OVERRIDE=""
 INJECTION_POLICY=""
 USE_DEFAULT_INJECTION_POLICY=1
 VM_CPU_OVERRIDE=""
@@ -8102,6 +8203,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --target)
       TARGET_BACKEND="$(option_value_or_die "$1" "${2-}")"
+      shift 2
+      ;;
+    --target-id)
+      TARGET_ID_OVERRIDE="$(option_value_or_die "$1" "${2-}")"
       shift 2
       ;;
     --agent-autonomy)
@@ -8282,7 +8387,14 @@ validate_cache_profile_name "${CACHE_PROFILE}"
 validate_codex_rules_mutability_name "${CODEX_RULES_MUTABILITY}"
 validate_log_level_name "${LOG_LEVEL}"
 validate_session_workspace_mode "${SESSION_WORKSPACE_MODE}"
-if [[ "${TARGET_BACKEND}" == "docker-desktop" ]]; then
+if [[ "${TARGET_BACKEND}" != "aws-ec2-ssm" ]] && [[ -n "${TARGET_ID_OVERRIDE}" ]]; then
+  echo "--target-id only supports --target aws-ec2-ssm." >&2
+  exit 2
+fi
+if [[ -n "${TARGET_ID_OVERRIDE}" ]]; then
+  validate_target_id_name "${TARGET_ID_OVERRIDE}"
+fi
+if [[ "${TARGET_BACKEND}" != "colima" ]]; then
   if [[ "${COLIMA_PROFILE_EXPLICIT:-0}" -eq 1 ]]; then
     echo "--colima-profile only supports --target colima." >&2
     exit 2
@@ -8295,6 +8407,10 @@ if [[ "${TARGET_BACKEND}" == "docker-desktop" ]]; then
     echo "--repair-profile only supports --target colima." >&2
     exit 2
   fi
+fi
+if [[ "${TARGET_BACKEND}" == "aws-ec2-ssm" ]] && [[ "${PREPARE}" -eq 1 ]]; then
+  echo "--prepare and --prepare-only do not apply to --target aws-ec2-ssm." >&2
+  exit 2
 fi
 if [[ "${SESSION_DETACHED}" -eq 0 ]] && [[ -n "${SESSION_WORKSPACE_MODE}" ]]; then
   echo "--session-workspace applies only to workcell session start." >&2
@@ -8453,7 +8569,11 @@ HOST_TOOL_MISSING_CSV="$(missing_launch_host_tools_csv)"
 HOST_GIT_BIN="$(resolve_host_tool git /usr/bin/git /opt/homebrew/bin/git /usr/local/bin/git)"
 HOST_DOCKER_BIN="docker"
 if [[ -z "${COLIMA_PROFILE}" ]]; then
-  COLIMA_PROFILE="$(derive_profile_name "${WORKSPACE}")"
+  if [[ "${TARGET_BACKEND}" == "aws-ec2-ssm" ]] && [[ -n "${TARGET_ID_OVERRIDE}" ]]; then
+    COLIMA_PROFILE="${TARGET_ID_OVERRIDE}"
+  else
+    COLIMA_PROFILE="$(derive_profile_name "${WORKSPACE}")"
+  fi
 fi
 validate_colima_profile_name "${COLIMA_PROFILE}"
 if [[ -n "${LOGS_KIND}" ]]; then
@@ -8540,6 +8660,14 @@ if [[ "${DOCTOR}" -eq 1 ]]; then
   printf 'doctor_workspace_binding=%s\n' "${PROFILE_MARKER_WORKSPACE:-none}"
   printf 'doctor_prepared_image=%s\n' "${prepared_image}"
   if ! support_matrix_launch_allowed; then
+    if [[ "${SUPPORT_MATRIX_STATUS}" == "preview-only" ]] && [[ "${TARGET_BACKEND}" == "aws-ec2-ssm" ]]; then
+      if [[ "${HOST_TOOL_MISSING_CSV}" != "none" ]]; then
+        printf 'doctor_recommended_next=install-host-tools\n'
+      else
+        printf 'doctor_recommended_next=review-aws-preview-rollout\n'
+      fi
+      exit 0
+    fi
     printf 'doctor_recommended_next=use-supported-host\n'
   elif [[ "${HOST_TOOL_MISSING_CSV}" != "none" ]]; then
     printf 'doctor_recommended_next=install-host-tools\n'
@@ -8628,13 +8756,16 @@ if [[ "${DRY_RUN}" -eq 0 ]] && [[ "${MODE}" == "strict" ]] && [[ "${PREPARE}" -e
     "This is expected on the first launch for a workspace or after profile cleanup."
 fi
 
+ALLOW_ENDPOINTS="$(dedupe_endpoint_list "$(provider_endpoints "${AGENT}") $(target_broker_endpoints "${TARGET_BACKEND}") $(credential_extra_endpoints) $(provider_auth_recovery_extra_endpoints) ${INJECTION_EXTRA_ENDPOINTS} ${EXTRA_ENDPOINTS:-}")"
+if [[ "${TARGET_BACKEND}" != "aws-ec2-ssm" ]] && [[ "${CONTAINER_MUTABILITY}" == "ephemeral" ]]; then
+  ALLOW_ENDPOINTS="$(dedupe_endpoint_list "${ALLOW_ENDPOINTS} snapshot.debian.org:443")"
+fi
+if [[ "${TARGET_BACKEND}" == "aws-ec2-ssm" ]]; then
+  emit_preview_remote_vm_dry_run
+  exit 0
+fi
 if [[ "${DRY_RUN}" -eq 0 ]]; then
   prepare_current_target_docker_client
-fi
-
-ALLOW_ENDPOINTS="$(dedupe_endpoint_list "$(provider_endpoints "${AGENT}") $(credential_extra_endpoints) $(provider_auth_recovery_extra_endpoints) ${INJECTION_EXTRA_ENDPOINTS} ${EXTRA_ENDPOINTS:-}")"
-if [[ "${CONTAINER_MUTABILITY}" == "ephemeral" ]]; then
-  ALLOW_ENDPOINTS="$(dedupe_endpoint_list "${ALLOW_ENDPOINTS} snapshot.debian.org:443")"
 fi
 WORKSPACE_SHADOW_SOURCE="${WORKSPACE}"
 if [[ "${SESSION_DETACHED}" -eq 1 ]] && [[ "$(effective_session_workspace_mode)" == "isolated" ]]; then

--- a/tests/scenarios/manifest.json
+++ b/tests/scenarios/manifest.json
@@ -136,6 +136,29 @@
       "requires_credentials": false
     },
     {
+      "id": "shared/aws-remote-vm-dry-run",
+      "description": "AWS remote VM preview target selection keeps the brokered target metadata, support boundary, and certification-only live gate explicit while allowing deterministic dry-run planning",
+      "lane": "secretless",
+      "platform": "any",
+      "manual": false,
+      "providers": ["codex", "claude", "gemini"],
+      "persona": "developer",
+      "test_file": "shared/test-aws-remote-vm-dry-run.sh",
+      "requires_credentials": false
+    },
+    {
+      "id": "shared/aws-ec2-ssm-launch-smoke",
+      "description": "AWS EC2 SSM certification smoke proves a reviewed target is SSM-online, has no inbound security-group rules, uses AmazonSSMManagedInstanceCore, and matches the Workcell preview broker plan",
+      "lane": "provider-e2e",
+      "platform": "any",
+      "validation_tier": "certification",
+      "manual": false,
+      "providers": ["codex"],
+      "persona": "validation-owner",
+      "test_file": "shared/test-aws-ec2-ssm-launch-smoke.sh",
+      "requires_credentials": true
+    },
+    {
       "id": "shared/session-commands",
       "description": "Host-side session inventory and detached control-plane commands cover durable records plus public CLI attach/send/stop/delete lifecycle handling for running and terminal workloads",
       "lane": "secretless",

--- a/tests/scenarios/manifest.json
+++ b/tests/scenarios/manifest.json
@@ -150,7 +150,7 @@
       "id": "shared/aws-ec2-ssm-launch-smoke",
       "description": "AWS EC2 SSM certification smoke proves a reviewed target is SSM-online, has no inbound security-group rules, uses AmazonSSMManagedInstanceCore, and matches the Workcell preview broker plan",
       "lane": "provider-e2e",
-      "platform": "any",
+      "platform": "macos",
       "validation_tier": "certification",
       "manual": false,
       "providers": ["codex"],

--- a/tests/scenarios/shared/test-aws-ec2-ssm-launch-smoke.sh
+++ b/tests/scenarios/shared/test-aws-ec2-ssm-launch-smoke.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-aws-ec2-ssm-launch-smoke.XXXXXX")"
+TARGET_ID="${WORKCELL_AWS_EC2_SSM_TARGET_ID:-${INSTANCE_ID:-}}"
+AWS_REGION_SELECTED="${WORKCELL_AWS_EC2_SSM_REGION:-${AWS_REGION:-${AWS_DEFAULT_REGION:-}}}"
+
+cleanup() {
+  local status=$?
+  if [[ "${status}" -ne 0 ]]; then
+    for file in \
+      aws-identity.json \
+      instance.json \
+      instance-profile.json \
+      role-policies.json \
+      ssm-instance.json \
+      session-manager.out \
+      workcell-doctor.stdout workcell-doctor.stderr \
+      workcell-dry-run.stdout workcell-dry-run.stderr; do
+      [[ -f "${TMP_DIR}/${file}" ]] || continue
+      printf -- '--- %s ---\n' "${file}" >&2
+      cat "${TMP_DIR}/${file}" >&2
+    done
+  fi
+  chmod -R u+w "${TMP_DIR}" 2>/dev/null || true
+  rm -rf "${TMP_DIR}"
+  exit "${status}"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+require_tool() {
+  local tool="$1"
+  command -v "${tool}" >/dev/null 2>&1 || fail "Missing required host tool: ${tool}"
+}
+
+aws_json() {
+  AWS_PAGER='' aws --region "${AWS_REGION_SELECTED}" "$@" --output json
+}
+
+require_tool aws
+require_tool session-manager-plugin
+require_tool jq
+
+[[ -n "${TARGET_ID}" ]] || fail "Set WORKCELL_AWS_EC2_SSM_TARGET_ID to the SSM-managed EC2 instance id."
+if [[ -z "${AWS_REGION_SELECTED}" ]]; then
+  AWS_REGION_SELECTED="$(AWS_PAGER='' aws configure get region 2>/dev/null || true)"
+fi
+[[ -n "${AWS_REGION_SELECTED}" ]] || fail "Set WORKCELL_AWS_EC2_SSM_REGION or AWS_REGION."
+
+HOME_DIR="${TMP_DIR}/home"
+WORKSPACE="${TMP_DIR}/workspace"
+mkdir -p "${HOME_DIR}/.config" "${WORKSPACE}"
+git -C "${WORKSPACE}" init -q
+printf 'aws ec2 ssm certification workspace\n' >"${WORKSPACE}/README.md"
+WORKSPACE="$(cd "${WORKSPACE}" && pwd -P)"
+
+aws_json sts get-caller-identity >"${TMP_DIR}/aws-identity.json"
+
+aws_json ec2 describe-instances \
+  --instance-ids "${TARGET_ID}" \
+  >"${TMP_DIR}/instance.json"
+jq -e '(.Reservations | length == 1) and (.Reservations[0].Instances | length == 1)' "${TMP_DIR}/instance.json" >/dev/null
+[[ "$(jq -r '.Reservations[0].Instances[0].State.Name' "${TMP_DIR}/instance.json")" == "running" ]] ||
+  fail "EC2 target ${TARGET_ID} is not running."
+
+mapfile -t SECURITY_GROUP_IDS < <(jq -r '.Reservations[0].Instances[0].SecurityGroups[].GroupId' "${TMP_DIR}/instance.json")
+((${#SECURITY_GROUP_IDS[@]} > 0)) || fail "EC2 target ${TARGET_ID} has no security groups."
+for sg_id in "${SECURITY_GROUP_IDS[@]}"; do
+  aws_json ec2 describe-security-groups --group-ids "${sg_id}" >"${TMP_DIR}/security-group-${sg_id}.json"
+  jq -e '.SecurityGroups[0].IpPermissions == []' "${TMP_DIR}/security-group-${sg_id}.json" >/dev/null ||
+    fail "Security group ${sg_id} must have no inbound rules for AWS EC2 SSM certification."
+done
+
+INSTANCE_PROFILE_ARN="$(jq -r '.Reservations[0].Instances[0].IamInstanceProfile.Arn // empty' "${TMP_DIR}/instance.json")"
+[[ -n "${INSTANCE_PROFILE_ARN}" ]] || fail "EC2 target ${TARGET_ID} has no IAM instance profile."
+INSTANCE_PROFILE_NAME="${INSTANCE_PROFILE_ARN##*/}"
+aws_json iam get-instance-profile \
+  --instance-profile-name "${INSTANCE_PROFILE_NAME}" \
+  >"${TMP_DIR}/instance-profile.json"
+ROLE_NAME="$(jq -r '.InstanceProfile.Roles[0].RoleName // empty' "${TMP_DIR}/instance-profile.json")"
+[[ -n "${ROLE_NAME}" ]] || fail "Instance profile ${INSTANCE_PROFILE_NAME} has no role."
+aws_json iam list-attached-role-policies \
+  --role-name "${ROLE_NAME}" \
+  >"${TMP_DIR}/role-policies.json"
+jq -e 'any(.AttachedPolicies[]?; .PolicyArn == "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore")' \
+  "${TMP_DIR}/role-policies.json" >/dev/null ||
+  fail "Role ${ROLE_NAME} must attach AmazonSSMManagedInstanceCore."
+
+aws_json ssm describe-instance-information \
+  --filters "Key=InstanceIds,Values=${TARGET_ID}" \
+  >"${TMP_DIR}/ssm-instance.json"
+jq -e '.InstanceInformationList | length == 1' "${TMP_DIR}/ssm-instance.json" >/dev/null
+[[ "$(jq -r '.InstanceInformationList[0].PingStatus' "${TMP_DIR}/ssm-instance.json")" == "Online" ]] ||
+  fail "SSM target ${TARGET_ID} is not Online."
+[[ "$(jq -r '.InstanceInformationList[0].ResourceType' "${TMP_DIR}/ssm-instance.json")" == "EC2Instance" ]] ||
+  fail "SSM target ${TARGET_ID} is not an EC2 managed instance."
+
+HOME="${HOME_DIR}" XDG_CONFIG_HOME="${HOME_DIR}/.config" \
+  "${ROOT_DIR}/scripts/workcell" \
+  --target aws-ec2-ssm \
+  --target-id "${TARGET_ID}" \
+  --agent codex \
+  --workspace "${WORKSPACE}" \
+  --no-default-injection-policy \
+  --doctor \
+  >"${TMP_DIR}/workcell-doctor.stdout" 2>"${TMP_DIR}/workcell-doctor.stderr"
+grep -q '^target_kind=remote_vm$' "${TMP_DIR}/workcell-doctor.stdout"
+grep -q '^target_provider=aws-ec2-ssm$' "${TMP_DIR}/workcell-doctor.stdout"
+grep -q "^target_id=${TARGET_ID}\$" "${TMP_DIR}/workcell-doctor.stdout"
+grep -q '^support_matrix_status=preview-only$' "${TMP_DIR}/workcell-doctor.stdout"
+grep -q '^support_matrix_evidence=certification-only$' "${TMP_DIR}/workcell-doctor.stdout"
+grep -q '^doctor_missing_host_tools=none$' "${TMP_DIR}/workcell-doctor.stdout"
+grep -q '^doctor_recommended_next=review-aws-preview-rollout$' "${TMP_DIR}/workcell-doctor.stdout"
+
+HOME="${HOME_DIR}" XDG_CONFIG_HOME="${HOME_DIR}/.config" \
+  "${ROOT_DIR}/scripts/workcell" \
+  --target aws-ec2-ssm \
+  --target-id "${TARGET_ID}" \
+  --agent codex \
+  --workspace "${WORKSPACE}" \
+  --no-default-injection-policy \
+  --dry-run \
+  >"${TMP_DIR}/workcell-dry-run.stdout" 2>"${TMP_DIR}/workcell-dry-run.stderr"
+grep -q "^target_kind=remote_vm target_provider=aws-ec2-ssm target_id=${TARGET_ID} target_assurance_class=compat runtime_api=brokered workspace_transport=remote-materialization\$" \
+  "${TMP_DIR}/workcell-dry-run.stderr"
+grep -q '^remote_access_model=brokered remote_broker=aws-ssm-session-manager inbound_public_ssh=blocked live_smoke=certification-only$' \
+  "${TMP_DIR}/workcell-dry-run.stderr"
+grep -q '^remote_workspace_materialization=explicit reviewed_host_copy=1$' \
+  "${TMP_DIR}/workcell-dry-run.stderr"
+grep -Eq "^remote-preview-plan target=aws-ec2-ssm broker=aws-ssm-session-manager target_id=${TARGET_ID} launch_gate=certification-only workspace=${WORKSPACE}\$" \
+  "${TMP_DIR}/workcell-dry-run.stdout"
+
+set +e
+AWS_PAGER='' aws --region "${AWS_REGION_SELECTED}" ssm start-session \
+  --target "${TARGET_ID}" \
+  --document-name AWS-StartInteractiveCommand \
+  --parameters '{"command":["sh -lc '\''echo workcell-session-manager-ok; systemctl is-active amazon-ssm-agent; hostname; exit'\''"]}' \
+  >"${TMP_DIR}/session-manager.out" 2>&1
+session_rc=$?
+set -e
+[[ "${session_rc}" -eq 0 ]] || fail "Session Manager command failed with exit code ${session_rc}."
+grep -q 'workcell-session-manager-ok' "${TMP_DIR}/session-manager.out"
+grep -q '^active' "${TMP_DIR}/session-manager.out"
+
+echo "AWS EC2 SSM launch smoke passed for ${TARGET_ID} in ${AWS_REGION_SELECTED}"

--- a/tests/scenarios/shared/test-aws-remote-vm-dry-run.sh
+++ b/tests/scenarios/shared/test-aws-remote-vm-dry-run.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-aws-remote-vm-scenario.XXXXXX")"
+cleanup() {
+  chmod -R u+w "${TMP_DIR}" 2>/dev/null || true
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+HOME_DIR="${TMP_DIR}/home"
+WORKSPACE="${TMP_DIR}/workspace"
+TARGET_ID="i-1234567890abcdef0"
+mkdir -p "${HOME_DIR}/.config" "${WORKSPACE}"
+git -C "${WORKSPACE}" init -q
+printf 'scenario workspace\n' >"${WORKSPACE}/README.md"
+
+resolve_host_tool_optional() {
+  local candidate=""
+  local name="$1"
+  shift
+  for candidate in "$@" "$(command -v "${name}" 2>/dev/null || true)"; do
+    [[ -n "${candidate}" ]] || continue
+    [[ -x "${candidate}" ]] || continue
+    printf '%s\n' "${candidate}"
+    return 0
+  done
+  return 1
+}
+
+aws_preview_missing_state() {
+  local -a missing=()
+
+  resolve_host_tool_optional aws /opt/homebrew/bin/aws /usr/local/bin/aws /usr/local/aws-cli/aws >/dev/null || missing+=(aws)
+  resolve_host_tool_optional session-manager-plugin /usr/local/bin/session-manager-plugin /usr/local/sessionmanagerplugin/bin/session-manager-plugin >/dev/null || missing+=(session-manager-plugin)
+  if ((${#missing[@]} == 0)); then
+    printf 'none\n'
+    return 0
+  fi
+  local IFS=','
+  printf '%s\n' "${missing[*]}"
+}
+
+run_with_support_override() {
+  local label="$1"
+  local host_os="$2"
+  local host_arch="$3"
+  shift 3
+  HOME="${HOME_DIR}" XDG_CONFIG_HOME="${HOME_DIR}/.config" \
+    WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT=1 \
+    WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS="${host_os}" \
+    WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH="${host_arch}" \
+    /bin/bash -p "${ROOT_DIR}/scripts/workcell" \
+    "$@" \
+    --workspace "${WORKSPACE}" \
+    --no-default-injection-policy \
+    >"${TMP_DIR}/${label}.stdout" 2>"${TMP_DIR}/${label}.stderr"
+}
+
+run_with_support_override_expect_failure() {
+  local expected_rc="$1"
+  local label="$2"
+  local host_os="$3"
+  local host_arch="$4"
+  shift 4
+  set +e
+  HOME="${HOME_DIR}" XDG_CONFIG_HOME="${HOME_DIR}/.config" \
+    WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT=1 \
+    WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS="${host_os}" \
+    WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH="${host_arch}" \
+    /bin/bash -p "${ROOT_DIR}/scripts/workcell" \
+    "$@" \
+    --workspace "${WORKSPACE}" \
+    --no-default-injection-policy \
+    >"${TMP_DIR}/${label}.stdout" 2>"${TMP_DIR}/${label}.stderr"
+  local rc=$?
+  set -e
+  if [[ "${rc}" -ne "${expected_rc}" ]]; then
+    echo "Unexpected exit code for ${label}: ${rc} (expected ${expected_rc})" >&2
+    cat "${TMP_DIR}/${label}.stderr" >&2
+    exit 1
+  fi
+}
+
+EXPECTED_MISSING="$(aws_preview_missing_state)"
+
+run_with_support_override \
+  "aws-preview-doctor" \
+  macos \
+  arm64 \
+  --target aws-ec2-ssm \
+  --target-id "${TARGET_ID}" \
+  --agent codex \
+  --doctor
+grep -q '^target_kind=remote_vm$' "${TMP_DIR}/aws-preview-doctor.stdout"
+grep -q '^target_provider=aws-ec2-ssm$' "${TMP_DIR}/aws-preview-doctor.stdout"
+grep -q "^target_id=${TARGET_ID}\$" "${TMP_DIR}/aws-preview-doctor.stdout"
+grep -q '^target_assurance_class=compat$' "${TMP_DIR}/aws-preview-doctor.stdout"
+grep -q '^support_matrix_status=preview-only$' "${TMP_DIR}/aws-preview-doctor.stdout"
+grep -q '^support_matrix_launch=blocked$' "${TMP_DIR}/aws-preview-doctor.stdout"
+grep -q '^support_matrix_evidence=certification-only$' "${TMP_DIR}/aws-preview-doctor.stdout"
+grep -q '^support_matrix_reason=apple-silicon-macos-aws-ec2-ssm-preview-certification-only$' "${TMP_DIR}/aws-preview-doctor.stdout"
+grep -q '^runtime_api=brokered$' "${TMP_DIR}/aws-preview-doctor.stdout"
+grep -q '^workspace_transport=remote-materialization$' "${TMP_DIR}/aws-preview-doctor.stdout"
+grep -q '^profile_dir=none$' "${TMP_DIR}/aws-preview-doctor.stdout"
+grep -Eq "^target_state_dir=.*/targets/remote_vm/aws-ec2-ssm/${TARGET_ID}\$" "${TMP_DIR}/aws-preview-doctor.stdout"
+grep -Eq "^profile_marker=.*/targets/remote_vm/aws-ec2-ssm/${TARGET_ID}/workcell\\.managed\$" "${TMP_DIR}/aws-preview-doctor.stdout"
+grep -Eq "^image_marker=.*/targets/remote_vm/aws-ec2-ssm/${TARGET_ID}/workcell\\.image-ready\$" "${TMP_DIR}/aws-preview-doctor.stdout"
+if [[ "${EXPECTED_MISSING}" == "none" ]]; then
+  grep -q '^doctor_missing_host_tools=none$' "${TMP_DIR}/aws-preview-doctor.stdout"
+  grep -q '^doctor_recommended_next=review-aws-preview-rollout$' "${TMP_DIR}/aws-preview-doctor.stdout"
+else
+  grep -q "^doctor_missing_host_tools=${EXPECTED_MISSING}\$" "${TMP_DIR}/aws-preview-doctor.stdout"
+  grep -q '^doctor_recommended_next=install-host-tools$' "${TMP_DIR}/aws-preview-doctor.stdout"
+fi
+
+run_with_support_override \
+  "aws-preview-dry-run" \
+  macos \
+  arm64 \
+  --target aws-ec2-ssm \
+  --target-id "${TARGET_ID}" \
+  --agent codex \
+  --dry-run
+grep -q "^target_kind=remote_vm target_provider=aws-ec2-ssm target_id=${TARGET_ID} target_assurance_class=compat runtime_api=brokered workspace_transport=remote-materialization\$" "${TMP_DIR}/aws-preview-dry-run.stderr"
+grep -q '^remote_access_model=brokered remote_broker=aws-ssm-session-manager inbound_public_ssh=blocked live_smoke=certification-only$' "${TMP_DIR}/aws-preview-dry-run.stderr"
+grep -Eq "^execution_path=remote-preview-broker-plan audit_log=.*/targets/remote_vm/aws-ec2-ssm/${TARGET_ID}/workcell\\.audit\\.log rollout_doc=docs/aws-ec2-ssm-preview\\.md\$" "${TMP_DIR}/aws-preview-dry-run.stderr"
+grep -Eq "^remote-preview-plan target=aws-ec2-ssm broker=aws-ssm-session-manager target_id=${TARGET_ID} launch_gate=certification-only workspace=.*/workspace\$" "${TMP_DIR}/aws-preview-dry-run.stdout"
+
+run_with_support_override_expect_failure \
+  2 \
+  "aws-preview-live-blocked" \
+  macos \
+  arm64 \
+  --target aws-ec2-ssm \
+  --target-id "${TARGET_ID}" \
+  --agent codex
+grep -q 'The AWS remote VM target is a preview-only brokered path' "${TMP_DIR}/aws-preview-live-blocked.stderr"
+grep -q 'docs/aws-ec2-ssm-preview.md' "${TMP_DIR}/aws-preview-live-blocked.stderr"
+
+run_with_support_override \
+  "aws-preview-doctor-unsupported" \
+  linux \
+  arm64 \
+  --target aws-ec2-ssm \
+  --target-id "${TARGET_ID}" \
+  --agent codex \
+  --doctor
+grep -q '^support_matrix_status=unsupported$' "${TMP_DIR}/aws-preview-doctor-unsupported.stdout"
+grep -q '^support_matrix_launch=blocked$' "${TMP_DIR}/aws-preview-doctor-unsupported.stdout"
+grep -q '^doctor_recommended_next=use-supported-host$' "${TMP_DIR}/aws-preview-doctor-unsupported.stdout"
+
+echo "AWS remote VM dry-run scenario passed"


### PR DESCRIPTION
## Summary
- add preview-only `aws-ec2-ssm` remote VM target selection with explicit SSM broker diagnostics and blocked live launch path
- add provider-aware remote VM contract/conformance coverage plus AWS-specific broker plan helpers
- update support matrix, operator contract, requirements, docs, manpage, and scenario manifest with deterministic dry-run and live certification evidence

## Validation
- `bash ./scripts/validate-repo.sh`
- `WORKCELL_AWS_EC2_SSM_REGION=us-east-1 WORKCELL_AWS_EC2_SSM_TARGET_ID=i-0992a7bfdcdd510d4 bash ./tests/scenarios/shared/test-aws-ec2-ssm-launch-smoke.sh`
- `./scripts/pre-merge.sh --profile pr-parity --base main`
- `bash ./scripts/workcell --gc`

## Notes
- Temporary AWS certification instance `i-0992a7bfdcdd510d4` was terminated after the live smoke.
- Upstream pin refresh was eligible during commit; dedicated refresh workflow was triggered separately: https://github.com/omkhar/workcell/actions/runs/24864110740.