### PR TITLE
Harden upstream verifier fetches

### DIFF
--- a/scripts/verify-github-macos-release-test-runners.sh
+++ b/scripts/verify-github-macos-release-test-runners.sh
@@ -49,8 +49,10 @@ require_tool curl
 require_tool grep
 require_tool sort
 
-runner_images_readme="$(curl -fsSL "${RUNNER_IMAGES_README_URL}")"
-docs_page="$(curl -fsSL "${GITHUB_HOSTED_RUNNERS_DOCS_URL}")"
+runner_images_readme="$(curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+  "${RUNNER_IMAGES_README_URL}")"
+docs_page="$(curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+  "${GITHUB_HOSTED_RUNNERS_DOCS_URL}")"
 
 runner_rows=""
 

--- a/scripts/verify-upstream-claude-release.sh
+++ b/scripts/verify-upstream-claude-release.sh
@@ -37,7 +37,8 @@ verify_asset() {
   local binary_path="${work_dir}/claude"
 
   mkdir -p "${work_dir}"
-  curl -fsSL "${CLAUDE_RELEASE_ROOT}/${CLAUDE_VERSION}/${platform}/claude" -o "${binary_path}"
+  curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+    "${CLAUDE_RELEASE_ROOT}/${CLAUDE_VERSION}/${platform}/claude" -o "${binary_path}"
   echo "${expected_sha}  ${binary_path}" | sha256sum -c - >/dev/null
 }
 
@@ -51,7 +52,8 @@ require_tool go
 require_tool sha256sum
 
 CLAUDE_VERSION="$(extract_claude_version)"
-curl -fsSL "${CLAUDE_RELEASE_ROOT}/${CLAUDE_VERSION}/manifest.json" -o "${MANIFEST_PATH}"
+curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+  "${CLAUDE_RELEASE_ROOT}/${CLAUDE_VERSION}/manifest.json" -o "${MANIFEST_PATH}"
 
 (cd "${ROOT_DIR}" && go run ./cmd/workcell-metadatautil manifest-version "${MANIFEST_PATH}" "${CLAUDE_VERSION}")
 

--- a/scripts/verify-upstream-codex-release.sh
+++ b/scripts/verify-upstream-codex-release.sh
@@ -39,8 +39,10 @@ verify_asset() {
   local work_dir="${TMP_ROOT}/${target_arch}"
 
   mkdir -p "${work_dir}"
-  curl -fsSL "${asset_root}/${tarball_name}" -o "${work_dir}/${tarball_name}"
-  curl -fsSL "${asset_root}/${bundle_name}" -o "${work_dir}/${bundle_name}"
+  curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+    "${asset_root}/${tarball_name}" -o "${work_dir}/${tarball_name}"
+  curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+    "${asset_root}/${bundle_name}" -o "${work_dir}/${bundle_name}"
 
   echo "${codex_sha}  ${work_dir}/${tarball_name}" | sha256sum -c - >/dev/null
   tar -xzf "${work_dir}/${tarball_name}" -C "${work_dir}"

--- a/scripts/verify-upstream-gemini-release.sh
+++ b/scripts/verify-upstream-gemini-release.sh
@@ -32,7 +32,8 @@ verify_registry_package() {
   local expected_integrity="$6"
   local metadata_path="${TMPDIR:-/tmp}/workcell-${registry_path##*/}-${version}.json"
 
-  curl -fsSL "https://registry.npmjs.org/${registry_path}/${version}" -o "${metadata_path}"
+  curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+    "https://registry.npmjs.org/${registry_path}/${version}" -o "${metadata_path}"
 
   local actual_version actual_resolved actual_integrity
   actual_version="$(jq -r '.version' "${metadata_path}")"


### PR DESCRIPTION
Retry transient network/server errors in upstream verifier fetches while preserving the existing SHA, signature, manifest, and integrity checks. This addresses the merged-main CI failure where the Codex release verifier stopped on a single GitHub 502.