### PR TITLE
Fix release preflight audit environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,6 @@ jobs:
   preflight:
     name: Release preflight
     runs-on: ubuntu-latest
-    environment:
-      name: hosted-controls-audit
     permissions:
       actions: read # Read workflow metadata needed by artifact and code-scanning actions.
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
   preflight:
     name: Release preflight
     runs-on: ubuntu-latest
+    environment:
+      name: hosted-controls-audit
     permissions:
       actions: read # Read workflow metadata needed by artifact and code-scanning actions.
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Releases.
 
 ## Unreleased
 
+### Fixed
+
+- keep tag-triggered release preflight off the `main`-only
+  `hosted-controls-audit` environment while preserving required hosted-controls
+  verification through the repository token.
+
 ## v0.10.4 - 2026-04-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ Releases.
 
 ### Fixed
 
-- keep tag-triggered release preflight off the `main`-only
-  `hosted-controls-audit` environment while preserving required hosted-controls
-  verification through the repository token.
+- allow protected `v*` release tags to enter the dedicated
+  `hosted-controls-audit` environment so release preflight can run
+  hosted-controls verification without bypassing the environment secret gate.
 
 ## v0.10.4 - 2026-04-25
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -119,12 +119,11 @@ reviewed inputs:
   supports it and an explicitly documented lower-assurance fallback when it
   does not
 - the `hosted-controls-audit` and `upstream-refresh` environments, including
-  their exact secret and variable contents plus their `main`-only branch
-  restriction and disabled admin bypass posture
-- tag-triggered release preflight runs the same hosted-controls audit without
-  binding to the `main`-only `hosted-controls-audit` environment; it requires
-  the repository-level `WORKCELL_HOSTED_CONTROLS_TOKEN` secret and fails closed
-  when that token is unavailable
+  their exact secret and variable contents plus their disabled admin bypass
+  posture
+- `hosted-controls-audit` permits the `main` branch and protected `v*` release
+  tags so scheduled/main audits and tag-triggered release preflight both use a
+  dedicated environment gate for `WORKCELL_HOSTED_CONTROLS_TOKEN`
 - GitHub Actions SHA pinning
 - canonical repository variables such as
   `WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true` and

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -121,6 +121,10 @@ reviewed inputs:
 - the `hosted-controls-audit` and `upstream-refresh` environments, including
   their exact secret and variable contents plus their `main`-only branch
   restriction and disabled admin bypass posture
+- tag-triggered release preflight runs the same hosted-controls audit without
+  binding to the `main`-only `hosted-controls-audit` environment; it requires
+  the repository-level `WORKCELL_HOSTED_CONTROLS_TOKEN` secret and fails closed
+  when that token is unavailable
 - GitHub Actions SHA pinning
 - canonical repository variables such as
   `WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true` and

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -2037,10 +2037,14 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	for _, needle := range []string{
 		`run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
 		`WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"`,
+		`WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}`,
 	} {
 		if !strings.Contains(releaseWorkflow, needle) {
 			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
 		}
+	}
+	if strings.Contains(releaseWorkflow, "environment:\n      name: hosted-controls-audit") {
+		return errors.New(".github/workflows/release.yml must not bind tag-triggered release preflight to the main-only hosted-controls-audit environment")
 	}
 	if err := validateUpstreamRefreshWorkflow(upstreamRefreshWorkflow); err != nil {
 		return err

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -343,6 +344,8 @@ type hostedControlsWorkflowEnvironmentPolicy struct {
 	HasAllowAdminBypass   bool
 	DeploymentBranches    []string
 	HasDeploymentBranches bool
+	DeploymentTags        []string
+	HasDeploymentTags     bool
 }
 
 func hostedControlsRepositoryVariables(policy map[string]any, policyPath string) (map[string]any, error) {
@@ -462,6 +465,25 @@ func hostedControlsWorkflowEnvironments(policy map[string]any, policyPath string
 			sort.Strings(deploymentBranches)
 			hasDeploymentBranches = true
 		}
+		deploymentTags := []string{}
+		hasDeploymentTags := false
+		if rawDeploymentTags, ok := entry["deployment_tags"]; ok {
+			tags, present, err := MustStringSlice(rawDeploymentTags)
+			if err != nil {
+				return nil, fmt.Errorf("%s workflow_environment.%s.deployment_tags: %w", policyPath, environmentName, err)
+			}
+			if !present {
+				return nil, fmt.Errorf("%s workflow_environment.%s.deployment_tags must be an array of tag patterns", policyPath, environmentName)
+			}
+			for _, tagPattern := range tags {
+				if strings.TrimSpace(tagPattern) == "" {
+					return nil, fmt.Errorf("%s workflow_environment.%s.deployment_tags must be an array of non-empty tag patterns", policyPath, environmentName)
+				}
+			}
+			deploymentTags = append(deploymentTags, tags...)
+			sort.Strings(deploymentTags)
+			hasDeploymentTags = true
+		}
 
 		environments[environmentName] = hostedControlsWorkflowEnvironmentPolicy{
 			Variables:             variables,
@@ -470,6 +492,8 @@ func hostedControlsWorkflowEnvironments(policy map[string]any, policyPath string
 			HasAllowAdminBypass:   hasAllowAdminBypass,
 			DeploymentBranches:    deploymentBranches,
 			HasDeploymentBranches: hasDeploymentBranches,
+			DeploymentTags:        deploymentTags,
+			HasDeploymentTags:     hasDeploymentTags,
 		}
 	}
 	return environments, nil
@@ -497,6 +521,9 @@ func validateCanonicalHostedControlsWorkflowEnvironments(policy map[string]any, 
 	if !hostedControlsAudit.HasDeploymentBranches || len(hostedControlsAudit.DeploymentBranches) != 1 || hostedControlsAudit.DeploymentBranches[0] != "main" {
 		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.hosted-controls-audit.deployment_branches = [\"main\"]")
 	}
+	if !hostedControlsAudit.HasDeploymentTags || len(hostedControlsAudit.DeploymentTags) != 1 || hostedControlsAudit.DeploymentTags[0] != "v*" {
+		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.hosted-controls-audit.deployment_tags = [\"v*\"]")
+	}
 
 	upstreamRefresh, ok := environments["upstream-refresh"]
 	if !ok {
@@ -513,6 +540,9 @@ func validateCanonicalHostedControlsWorkflowEnvironments(policy map[string]any, 
 	}
 	if !upstreamRefresh.HasDeploymentBranches || len(upstreamRefresh.DeploymentBranches) != 1 || upstreamRefresh.DeploymentBranches[0] != "main" {
 		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.upstream-refresh.deployment_branches = [\"main\"]")
+	}
+	if upstreamRefresh.HasDeploymentTags || len(upstreamRefresh.DeploymentTags) != 0 {
+		return errors.New("policy/github-hosted-controls.toml must not set workflow_environment.upstream-refresh.deployment_tags")
 	}
 	return nil
 }
@@ -607,7 +637,7 @@ func verifyWorkflowEnvironmentDeploymentPolicy(repo, environmentName string, env
 			return fmt.Errorf("workflow environment %s/%s must set can_admins_bypass=%t", repo, environmentName, environmentPolicy.AllowAdminBypass)
 		}
 	}
-	if !environmentPolicy.HasDeploymentBranches {
+	if !environmentPolicy.HasDeploymentBranches && !environmentPolicy.HasDeploymentTags {
 		return nil
 	}
 
@@ -623,6 +653,7 @@ func verifyWorkflowEnvironmentDeploymentPolicy(repo, environmentName string, env
 	}
 
 	actualBranches := make([]string, 0)
+	actualTags := make([]string, 0)
 	if branchPolicies, ok := environmentBranchPolicies["branch_policies"].([]any); ok {
 		for _, raw := range branchPolicies {
 			entry, ok := raw.(map[string]any)
@@ -630,18 +661,22 @@ func verifyWorkflowEnvironmentDeploymentPolicy(repo, environmentName string, env
 				continue
 			}
 			if name, _ := entry["name"].(string); name != "" {
-				actualBranches = append(actualBranches, name)
+				switch typ, _ := entry["type"].(string); typ {
+				case "", "branch":
+					actualBranches = append(actualBranches, name)
+				case "tag":
+					actualTags = append(actualTags, name)
+				}
 			}
 		}
 	}
 	sort.Strings(actualBranches)
-	if len(actualBranches) != len(environmentPolicy.DeploymentBranches) {
+	sort.Strings(actualTags)
+	if !slices.Equal(actualBranches, environmentPolicy.DeploymentBranches) {
 		return fmt.Errorf("workflow environment %s/%s must restrict deployment branches to %s", repo, environmentName, strings.Join(environmentPolicy.DeploymentBranches, ", "))
 	}
-	for idx, expectedBranch := range environmentPolicy.DeploymentBranches {
-		if actualBranches[idx] != expectedBranch {
-			return fmt.Errorf("workflow environment %s/%s must restrict deployment branches to %s", repo, environmentName, strings.Join(environmentPolicy.DeploymentBranches, ", "))
-		}
+	if !slices.Equal(actualTags, environmentPolicy.DeploymentTags) {
+		return fmt.Errorf("workflow environment %s/%s must restrict deployment tags to %s", repo, environmentName, strings.Join(environmentPolicy.DeploymentTags, ", "))
 	}
 	return nil
 }
@@ -2043,8 +2078,8 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
 		}
 	}
-	if strings.Contains(releaseWorkflow, "environment:\n      name: hosted-controls-audit") {
-		return errors.New(".github/workflows/release.yml must not bind tag-triggered release preflight to the main-only hosted-controls-audit environment")
+	if !strings.Contains(releaseWorkflow, "environment:\n      name: hosted-controls-audit") {
+		return errors.New(".github/workflows/release.yml release preflight must bind to the hosted-controls-audit environment")
 	}
 	if err := validateUpstreamRefreshWorkflow(upstreamRefreshWorkflow); err != nil {
 		return err

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -123,6 +123,7 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 		`required_secrets = ["WORKCELL_HOSTED_CONTROLS_TOKEN"]`,
 		"allow_admin_bypass = false",
 		`deployment_branches = ["main"]`,
+		`deployment_tags = ["v*"]`,
 		"",
 		"[workflow_environment.upstream-refresh]",
 		"allow_admin_bypass = false",
@@ -314,12 +315,13 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 	}
 	hostedControlsAuditDeploymentBranches := map[string]any{
 		"branch_policies": []map[string]any{
-			{"name": "main"},
+			{"name": "main", "type": "branch"},
+			{"name": "v*", "type": "tag"},
 		},
 	}
 	upstreamRefreshDeploymentBranches := map[string]any{
 		"branch_policies": []map[string]any{
-			{"name": "main"},
+			{"name": "main", "type": "branch"},
 		},
 	}
 

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -1157,6 +1157,7 @@ func TestValidateCanonicalHostedControlsWorkflowEnvironmentsRejectsUnexpectedUps
 				"required_secrets":    []any{"WORKCELL_HOSTED_CONTROLS_TOKEN"},
 				"allow_admin_bypass":  false,
 				"deployment_branches": []any{"main"},
+				"deployment_tags":     []any{"v*"},
 			},
 			"upstream-refresh": map[string]any{
 				"required_secrets":    []any{"WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY"},
@@ -1183,6 +1184,7 @@ func TestValidateCanonicalHostedControlsWorkflowEnvironmentsAcceptsCanonicalValu
 				"required_secrets":    []any{"WORKCELL_HOSTED_CONTROLS_TOKEN"},
 				"allow_admin_bypass":  false,
 				"deployment_branches": []any{"main"},
+				"deployment_tags":     []any{"v*"},
 			},
 			"upstream-refresh": map[string]any{
 				"allow_admin_bypass":  false,

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -75,6 +75,7 @@ WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = "false"
 required_secrets = ["WORKCELL_HOSTED_CONTROLS_TOKEN"]
 allow_admin_bypass = false
 deployment_branches = ["main"]
+deployment_tags = ["v*"]
 
 [workflow_environment.upstream-refresh]
 allow_admin_bypass = false


### PR DESCRIPTION
## Summary
- recover from the failed v0.10.4 release preflight by allowing protected v* tags into the hosted-controls-audit environment
- keep release preflight on a dedicated environment gate for WORKCELL_HOSTED_CONTROLS_TOKEN instead of bypassing secret-environment protection
- add type-aware hosted-control policy validation for deployment tag policies

## Validation
- ./scripts/verify-github-hosted-controls.sh omkhar/workcell
- ./scripts/validate-repo.sh
- ./scripts/pre-merge.sh --profile pr-parity

## Release recovery
v0.10.4 was pushed and failed release preflight before publication. Per docs/releasing.md, do not rewrite that tag; after this lands, cut the next patch release.