### PR TITLE
Release v0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Releases.
 
 ## Unreleased
 
+## v0.10.5 - 2026-04-25
+
 ### Fixed
 
 - allow protected `v*` release tags to enter the dedicated


### PR DESCRIPTION
Prepare v0.10.5 as the recovery release after the immutable v0.10.4 tag failed before publication.\n\nValidation:\n- ./scripts/update-upstream-pins.sh --check\n- ./scripts/verify-requirements-coverage.sh\n- ./scripts/verify-scenario-coverage.sh\n- ./scripts/verify-operator-contract.sh\n- git diff --check\n- ./scripts/validate-repo.sh\n- ./scripts/pre-merge.sh --profile pr-parity\n- ./scripts/workcell --gc