### PR TITLE
Hash-pin zizmor workflow install

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -61,10 +61,19 @@ jobs:
 
       - name: Install zizmor
         env:
-          ZIZMOR_VERSION: 1.23.1
+          ZIZMOR_SHA256: a8000f3c683319a523d3b20df0e75457ba591f049cfcbfa98966631b56733c03
+          ZIZMOR_VERSION: 1.24.1
         run: |
-          python3 -m pip install --disable-pip-version-check --user "zizmor==${ZIZMOR_VERSION}"
-          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          curl -fsSL \
+            --max-time 60 \
+            --connect-timeout 15 \
+            -o zizmor.tar.gz \
+            "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+          echo "${ZIZMOR_SHA256}  zizmor.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/bin"
+          tar -xzf zizmor.tar.gz -C "${RUNNER_TEMP}/bin" zizmor
+          chmod 0755 "${RUNNER_TEMP}/bin/zizmor"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
 
       - name: Run workflow contract checks
         run: ./scripts/check-workflows.sh
@@ -87,7 +96,7 @@ jobs:
           advanced-security: ${{ !github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_ZIZMOR_SARIF == 'true' }}
           inputs: .github/workflows
           persona: auditor
-          version: 1.23.1
+          version: 1.24.1
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_ZIZMOR_SARIF == 'true' }}

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -1965,6 +1965,20 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if securityActionlintSHAMatch[1] != releaseActionlintSHAMatch[1] {
 		return errors.New("ACTIONLINT_SHA256 must match between .github/workflows/security.yml and .github/workflows/release.yml")
 	}
+	_, securityZizmorVersionMatch, err := requireRegex(securityWorkflow, `(?m)^\s*ZIZMOR_VERSION:\s*([0-9]+\.[0-9]+\.[0-9]+)\s*$`, "security zizmor version", ".github/workflows/security.yml")
+	if err != nil {
+		return err
+	}
+	if _, _, err := requireRegex(securityWorkflow, `(?m)^\s*ZIZMOR_SHA256:\s*([0-9a-f]{64})\s*$`, "security zizmor sha", ".github/workflows/security.yml"); err != nil {
+		return err
+	}
+	_, securityZizmorActionVersionMatch, err := requireRegex(securityWorkflow, `(?m)^\s*version:\s*([0-9]+\.[0-9]+\.[0-9]+)\s*$`, "security zizmor action version", ".github/workflows/security.yml")
+	if err != nil {
+		return err
+	}
+	if securityZizmorVersionMatch[1] != securityZizmorActionVersionMatch[1] {
+		return errors.New("ZIZMOR_VERSION must match the zizmor-action version in .github/workflows/security.yml")
+	}
 	for _, workflow := range []struct {
 		text string
 		path string
@@ -1986,8 +2000,9 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		"github.event_name == 'workflow_dispatch' && github.ref_name != 'main'",
 		"base-ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || '' }}",
 		"head-ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || '' }}",
-		"ZIZMOR_VERSION: 1.23.1",
-		`python3 -m pip install --disable-pip-version-check --user "zizmor==${ZIZMOR_VERSION}"`,
+		"https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz",
+		`echo "${ZIZMOR_SHA256}  zizmor.tar.gz" | sha256sum -c -`,
+		`tar -xzf zizmor.tar.gz -C "${RUNNER_TEMP}/bin" zizmor`,
 		"./scripts/check-workflows.sh",
 	} {
 		if !strings.Contains(securityWorkflow, needle) {

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -408,6 +408,42 @@ func TestCheckPinnedInputsRejectsInvalidValidatorToolDigests(t *testing.T) {
 	}
 }
 
+func TestCheckPinnedInputsRejectsInvalidZizmorDigest(t *testing.T) {
+	t.Parallel()
+
+	cfg := writePinnedInputsFixture(t)
+	securityWorkflowPath := filepath.Join(cfg.WorkflowsDir, "security.yml")
+	rewriteFile(t, securityWorkflowPath, func(content string) string {
+		return strings.Replace(content, "ZIZMOR_SHA256: a8000f3c683319a523d3b20df0e75457ba591f049cfcbfa98966631b56733c03", "ZIZMOR_SHA256: deadbeef", 1)
+	})
+
+	err := CheckPinnedInputs(cfg)
+	if err == nil {
+		t.Fatal("CheckPinnedInputs() unexpectedly accepted a non-sha256 zizmor digest")
+	}
+	if !strings.Contains(err.Error(), "security zizmor sha") {
+		t.Fatalf("CheckPinnedInputs() error = %v, want zizmor digest rejection", err)
+	}
+}
+
+func TestCheckPinnedInputsRejectsZizmorVersionMismatch(t *testing.T) {
+	t.Parallel()
+
+	cfg := writePinnedInputsFixture(t)
+	securityWorkflowPath := filepath.Join(cfg.WorkflowsDir, "security.yml")
+	rewriteFile(t, securityWorkflowPath, func(content string) string {
+		return strings.Replace(content, "version: 1.24.1", "version: 1.24.0", 1)
+	})
+
+	err := CheckPinnedInputs(cfg)
+	if err == nil {
+		t.Fatal("CheckPinnedInputs() unexpectedly accepted mismatched zizmor versions")
+	}
+	if !strings.Contains(err.Error(), "ZIZMOR_VERSION must match") {
+		t.Fatalf("CheckPinnedInputs() error = %v, want zizmor version mismatch rejection", err)
+	}
+}
+
 func TestVerifyGitHubHostedControlsRejectsExtraPublicCollaboratorsForBranchReview(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -79,6 +79,7 @@ require_tool docker
 require_tool go
 require_tool jq
 require_tool mktemp
+require_tool shasum
 
 github_api_get() {
   local url="$1"
@@ -133,7 +134,7 @@ extract_yaml_scalar() {
   awk -v key="${key}" '$1 == key ":" { print $2; exit }' "${file}"
 }
 
-extract_actionlint_env_value() {
+extract_workflow_env_value() {
   local file="$1"
   local key="$2"
   awk -v key="${key}:" '$1 == key { print $2; exit }' "${file}"
@@ -292,6 +293,18 @@ target_actionlint_sha="$(
     awk '/actionlint_'"${target_actionlint_version}"'_linux_amd64\.tar\.gz$/ { print $1; exit }'
 )"
 
+zizmor_release_json="$(github_api_get 'https://api.github.com/repos/zizmorcore/zizmor/releases/latest')"
+target_zizmor_version="$(jq -r '.tag_name | sub("^v"; "")' <<<"${zizmor_release_json}")"
+target_zizmor_url="$(github_release_asset_url "${zizmor_release_json}" 'zizmor-x86_64-unknown-linux-gnu.tar.gz')"
+target_zizmor_sha="$(
+  curl -fsSL \
+    --max-time 60 \
+    --connect-timeout 15 \
+    "${target_zizmor_url}" |
+    shasum -a 256 |
+    awk '{ print $1 }'
+)"
+
 current_runtime_base="$(extract_dockerfile_arg "${RUNTIME_DOCKERFILE_PATH}" NODE_BASE_IMAGE)"
 current_validator_base="$(extract_dockerfile_arg "${VALIDATOR_DOCKERFILE_PATH}" VALIDATOR_BASE_IMAGE)"
 current_runtime_snapshot="$(extract_dockerfile_arg "${RUNTIME_DOCKERFILE_PATH}" DEBIAN_SNAPSHOT)"
@@ -317,8 +330,10 @@ current_cosign_version="$(extract_yaml_scalar "${CI_WORKFLOW_PATH}" WORKCELL_COS
 current_upstream_refresh_cosign_version="$(extract_yaml_scalar "${UPSTREAM_REFRESH_WORKFLOW_PATH}" WORKCELL_COSIGN_VERSION)"
 current_qemu_image="$(extract_yaml_scalar "${CI_WORKFLOW_PATH}" WORKCELL_QEMU_IMAGE)"
 current_syft_version="$(extract_yaml_scalar "${RELEASE_WORKFLOW_PATH}" WORKCELL_SYFT_VERSION)"
-current_actionlint_version="$(extract_actionlint_env_value "${SECURITY_WORKFLOW_PATH}" ACTIONLINT_VERSION)"
-current_actionlint_sha="$(extract_actionlint_env_value "${SECURITY_WORKFLOW_PATH}" ACTIONLINT_SHA256)"
+current_actionlint_version="$(extract_workflow_env_value "${SECURITY_WORKFLOW_PATH}" ACTIONLINT_VERSION)"
+current_actionlint_sha="$(extract_workflow_env_value "${SECURITY_WORKFLOW_PATH}" ACTIONLINT_SHA256)"
+current_zizmor_version="$(extract_workflow_env_value "${SECURITY_WORKFLOW_PATH}" ZIZMOR_VERSION)"
+current_zizmor_sha="$(extract_workflow_env_value "${SECURITY_WORKFLOW_PATH}" ZIZMOR_SHA256)"
 
 runtime_base_track="${current_runtime_base%@*}"
 validator_base_track="${current_validator_base%@*}"
@@ -374,7 +389,9 @@ for current_target_pair in \
   "${current_qemu_image}|${target_qemu_image}" \
   "${current_syft_version}|${target_syft_version}" \
   "${current_actionlint_version}|${target_actionlint_version}" \
-  "${current_actionlint_sha}|${target_actionlint_sha}"; do
+  "${current_actionlint_sha}|${target_actionlint_sha}" \
+  "${current_zizmor_version}|${target_zizmor_version}" \
+  "${current_zizmor_sha}|${target_zizmor_sha}"; do
   current_value="${current_target_pair%%|*}"
   target_value="${current_target_pair#*|}"
   if [[ "${current_value}" != "${target_value}" ]]; then
@@ -415,6 +432,7 @@ print_summary() {
   print_summary_line "qemu-image" "${current_qemu_image}" "${target_qemu_image}"
   print_summary_line "syft-version" "${current_syft_version}" "${target_syft_version}"
   print_summary_line "actionlint-version" "${current_actionlint_version}" "${target_actionlint_version}"
+  print_summary_line "zizmor-version" "${current_zizmor_version}" "${target_zizmor_version}"
   printf '%s\n' "${provider_summary}"
 }
 
@@ -478,6 +496,9 @@ replace_line_with_prefix "${RELEASE_WORKFLOW_PATH}" '          ACTIONLINT_VERSIO
 
 replace_line_with_prefix "${SECURITY_WORKFLOW_PATH}" '          ACTIONLINT_SHA256:' "          ACTIONLINT_SHA256: ${target_actionlint_sha}"
 replace_line_with_prefix "${SECURITY_WORKFLOW_PATH}" '          ACTIONLINT_VERSION:' "          ACTIONLINT_VERSION: ${target_actionlint_version}"
+replace_line_with_prefix "${SECURITY_WORKFLOW_PATH}" '          ZIZMOR_SHA256:' "          ZIZMOR_SHA256: ${target_zizmor_sha}"
+replace_line_with_prefix "${SECURITY_WORKFLOW_PATH}" '          ZIZMOR_VERSION:' "          ZIZMOR_VERSION: ${target_zizmor_version}"
+replace_line_with_prefix "${SECURITY_WORKFLOW_PATH}" '          version:' "          version: ${target_zizmor_version}"
 
 "${ROOT_DIR}/scripts/update-provider-pins.sh" --apply
 "${ROOT_DIR}/scripts/check-pinned-inputs.sh"


### PR DESCRIPTION
## Summary
- install zizmor from the pinned release archive plus SHA256 digest
- teach workflow metadata validation about the archive URL/hash pairing
- keep update-upstream-pins aware of the pinned zizmor artifact

## Validation
- ./scripts/update-upstream-pins.sh --check
- go test ./internal/metadatautil ./internal/testkit
- ./scripts/check-pinned-inputs.sh
- ./scripts/check-workflows.sh
- bash ./scripts/validate-repo.sh
- ./scripts/pre-merge.sh --profile pr-parity --allow-dirty