### PR TITLE
Gate release.yml preflight on main checks being green

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,36 @@ jobs:
               ;;
           esac
 
+      - name: Require main checks green for tagged commit
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # Per AGENTS.md ("Wait for the merged main commit to finish required
+          # GitHub Actions workflows successfully before pushing the signed
+          # release tag"), block release publication if check-runs on the
+          # tagged commit show failures or unfinished work.  Tag-ancestry
+          # alone is not enough: a tag pushed before main CI completes, or
+          # against a red main, must not produce a release.
+          failed="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs" \
+            --paginate \
+            --jq '.check_runs[] | select(.status == "completed" and (.conclusion | IN("failure","cancelled","timed_out","action_required"))) | "\(.name) (\(.conclusion))"' \
+            2>/dev/null || true)"
+          if [[ -n "${failed}" ]]; then
+            echo "Tagged commit ${GITHUB_SHA} has failed required checks:" >&2
+            printf '%s\n' "${failed}" >&2
+            exit 1
+          fi
+          pending="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs" \
+            --paginate \
+            --jq '.check_runs[] | select(.status != "completed") | .name' \
+            2>/dev/null || true)"
+          if [[ -n "${pending}" ]]; then
+            echo "Tagged commit ${GITHUB_SHA} has check-runs not yet completed:" >&2
+            printf '%s\n' "${pending}" >&2
+            echo "Wait for main checks to finish before re-running this release." >&2
+            exit 1
+          fi
+
       - name: Validate release tag name
         run: |
           [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]


### PR DESCRIPTION
## Summary

- Adds a `Require main checks green for tagged commit` step in `release.yml::preflight` that queries `gh api repos/.../commits/$GITHUB_SHA/check-runs --paginate` and hard-fails when any check has a non-success conclusion or is not yet `completed`.
- Enforces AGENTS.md L141 ("Wait for the merged main commit to finish required GitHub Actions workflows successfully before pushing the signed release tag"), which was previously documented as policy but unenforced in CI.

Closes the /sethify Run-2 CI/CD blocker.

## Notes for reviewers

- This PR is currently chained on top of PR #177 (the `verify-invariants -b master` modernization). Once #177 merges, this branch will rebase to drop those commits.
- The check considers \`failure\`, \`cancelled\`, \`timed_out\`, and \`action_required\` as failures. \`skipped\` and \`neutral\` are allowed.
- The check considers any non-\`completed\` status as pending and fails the preflight, with a clear "wait for main checks to finish" message.

## Test plan

- [x] \`actionlint .github/workflows/release.yml\` clean
- [x] \`zizmor .github/workflows/release.yml\` clean
- [x] \`./scripts/pre-merge.sh --profile pr-parity --base main\` green
- [ ] Live validation will happen on the next release tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)