### PR TITLE
Add timeout-minutes to every workflow job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
   pr-shape:
     name: Pull request shape
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -53,6 +54,7 @@ jobs:
     name: Validate repository
     needs: pr-shape
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -95,6 +97,7 @@ jobs:
   container-smoke:
     name: Container smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: validate
     permissions:
       contents: read
@@ -110,6 +113,7 @@ jobs:
     name: Install verification (${{ matrix.runner_label }})
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'approved-heavy-ci') }}
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     needs: validate
     permissions:
       contents: read
@@ -191,6 +195,7 @@ jobs:
   reproducible-build-platform:
     name: Reproducible build (${{ matrix.platform_name }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     needs: validate
     permissions:
       contents: read
@@ -224,6 +229,7 @@ jobs:
     name: Reproducible build
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: reproducible-build-platform
     steps:
       - name: Confirm per-platform reproducible builds passed

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,7 @@ jobs:
     name: Analyze (${{ matrix.language }})
     if: ${{ (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'approved-heavy-ci')) && (!github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_CODE_SCANNING == 'true') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       actions: read # Read workflow metadata required by the CodeQL action helpers.
       contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,6 +61,7 @@ jobs:
   spelling-and-manpage:
     name: Spelling and manpage
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/hosted-controls.yml
+++ b/.github/workflows/hosted-controls.yml
@@ -18,6 +18,7 @@ jobs:
   verify-hosted-controls:
     name: Hosted controls verification
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: hosted-controls-audit
     permissions:

--- a/.github/workflows/pin-hygiene.yml
+++ b/.github/workflows/pin-hygiene.yml
@@ -18,6 +18,7 @@ jobs:
   pinned-inputs:
     name: Check pinned inputs
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pr-base-policy.yml
+++ b/.github/workflows/pr-base-policy.yml
@@ -25,6 +25,7 @@ jobs:
   pr-base-policy:
     name: Allowed PR base
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       WORKCELL_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
       WORKCELL_PR_IS_DRAFT: ${{ github.event.pull_request.draft }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
   codeql-preflight:
     name: Release CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       actions: read # Read workflow metadata required by CodeQL helper actions.
       contents: read
@@ -59,6 +60,7 @@ jobs:
   preflight:
     name: Release preflight
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     environment:
       name: hosted-controls-audit
     permissions:
@@ -355,6 +357,7 @@ jobs:
   install-verification:
     name: Release install verification (${{ matrix.runner_label }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     needs:
       - preflight
     permissions:
@@ -437,6 +440,7 @@ jobs:
   release:
     name: Publish release artifacts
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs:
       - codeql-preflight
       - preflight

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,6 +18,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       checks: read # Read existing check metadata that Scorecard correlates in its report.
       contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,6 +20,7 @@ jobs:
     name: Dependency review
     if: ${{ (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref_name != 'main')) && (!github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_DEPENDENCY_REVIEW == 'true') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -36,6 +37,7 @@ jobs:
   actionlint:
     name: GitHub Actions lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -81,6 +83,7 @@ jobs:
   zizmor:
     name: GitHub Actions security analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: read # Read workflow metadata required while emitting Zizmor SARIF.
       contents: read

--- a/.github/workflows/upstream-refresh.yml
+++ b/.github/workflows/upstream-refresh.yml
@@ -18,6 +18,7 @@ jobs:
   refresh:
     name: Refresh pinned upstreams
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: upstream-refresh
     permissions:


### PR DESCRIPTION
## Summary

- Adds `timeout-minutes:` to all 20 jobs across 10 workflows. None previously declared one, so any stuck step inherited GitHub's 6h runner default. Worst offenders: paid macOS install-verification matrix and the release lane's 9 cosign sign-blob steps.

Per-job budgets:

| Workflow | Job | Budget |
| --- | --- | --- |
| ci.yml | pr-shape | 10m |
| ci.yml | validate | 60m |
| ci.yml | container-smoke | 30m |
| ci.yml | install-verification | 45m |
| ci.yml | reproducible-build-platform | 45m |
| ci.yml | reproducible-build (aggregator) | 5m |
| codeql.yml | analyze | 90m |
| docs.yml | spelling-and-manpage | 15m |
| hosted-controls.yml | verify-hosted-controls | 20m |
| pin-hygiene.yml | pinned-inputs | 15m |
| pr-base-policy.yml | pr-base-policy | 5m |
| release.yml | codeql-preflight | 90m |
| release.yml | preflight | 90m |
| release.yml | install-verification | 45m |
| release.yml | release | 60m |
| scorecard.yml | analysis | 15m |
| security.yml | dependency-review | 10m |
| security.yml | actionlint | 10m |
| security.yml | zizmor | 10m |
| upstream-refresh.yml | refresh | 20m |

Closes the /sethify CI/CD blocker carried by both runs.

## Notes for reviewers

- This PR is currently chained on top of PR #178 (and transitively #177). Once those merge, this branch will rebase to drop the prerequisite commits.

## Test plan

- [x] \`actionlint .github/workflows/*.yml\` clean
- [x] \`zizmor .github/workflows/\` clean
- [x] \`./scripts/pre-merge.sh --profile pr-parity --base main\` green
- [ ] Live timeouts will only fire if a job actually hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)