### PR TITLE
Bound HTTP timeout, request context, and response body in provider_bumps fetches

### DIFF
--- a/internal/metadatautil/provider_bumps.go
+++ b/internal/metadatautil/provider_bumps.go
@@ -4,6 +4,7 @@
 package metadatautil
 
 import (
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -26,6 +27,16 @@ const (
 	defaultProviderBumpClaudeBucketURL    = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819?prefix=claude-code-releases/&delimiter=/"
 	defaultProviderBumpClaudeReleaseRoot  = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
 	providerBumpUserAgent                 = "workcell-provider-bump/1.0"
+	// providerBumpHTTPTimeout caps every upstream metadata fetch (npm
+	// registry, GitHub release API, GCS bucket listing) end-to-end.
+	providerBumpHTTPTimeout = 30 * time.Second
+	// providerBumpMaxJSONBytes / providerBumpMaxXMLBytes cap the success-path
+	// response body so a misbehaving or hostile upstream cannot OOM the
+	// caller (upstream-refresh, hosted-controls audit, release preflight).
+	// The error path already wraps in LimitReader(4096); these mirror that
+	// pattern for the success path.
+	providerBumpMaxJSONBytes = 4 << 20 // 4 MiB
+	providerBumpMaxXMLBytes  = 1 << 20 // 1 MiB
 )
 
 var (
@@ -226,7 +237,7 @@ func PlanProviderBumps(policyPath, dockerfilePath, providersPackageJSONPath stri
 		return nil, err
 	}
 	if client == nil {
-		client = http.DefaultClient
+		client = &http.Client{Timeout: providerBumpHTTPTimeout}
 	}
 	cutoff := now.UTC().Add(-time.Duration(policy.CooloffHours) * time.Hour)
 
@@ -736,7 +747,9 @@ func compareStableVersions(left, right stableVersion) int {
 }
 
 func fetchJSON(client *http.Client, targetURL string, target any) error {
-	req, err := http.NewRequest(http.MethodGet, targetURL, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), providerBumpHTTPTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
 	if err != nil {
 		return fmt.Errorf("fetch %s: %w", targetURL, err)
 	}
@@ -750,14 +763,16 @@ func fetchJSON(client *http.Client, targetURL string, target any) error {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return fmt.Errorf("fetch %s: unexpected status %d: %s", targetURL, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
-	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, providerBumpMaxJSONBytes)).Decode(target); err != nil {
 		return fmt.Errorf("decode %s: %w", targetURL, err)
 	}
 	return nil
 }
 
 func fetchXML(client *http.Client, targetURL string, target any) error {
-	req, err := http.NewRequest(http.MethodGet, targetURL, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), providerBumpHTTPTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
 	if err != nil {
 		return fmt.Errorf("fetch %s: %w", targetURL, err)
 	}
@@ -771,7 +786,7 @@ func fetchXML(client *http.Client, targetURL string, target any) error {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return fmt.Errorf("fetch %s: unexpected status %d: %s", targetURL, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
-	if err := xml.NewDecoder(resp.Body).Decode(target); err != nil {
+	if err := xml.NewDecoder(io.LimitReader(resp.Body, providerBumpMaxXMLBytes)).Decode(target); err != nil {
 		return fmt.Errorf("decode %s: %w", targetURL, err)
 	}
 	return nil


### PR DESCRIPTION
## Summary

- \`PlanProviderBumps\` no longer falls back to \`http.DefaultClient\` (zero timeout); the default client is now \`&http.Client{Timeout: 30s}\`.
- \`fetchJSON\` and \`fetchXML\` use \`http.NewRequestWithContext\` with a \`context.WithTimeout\` so a hung NPM/GitHub/GCS upstream cancels cleanly.
- Success-path JSON/XML decoders now wrap \`resp.Body\` in \`io.LimitReader\` (4 MiB JSON, 1 MiB XML), mirroring the existing 4096-byte error-path cap. A multi-GB hostile response can no longer OOM upstream-refresh / hosted-controls / release-preflight.

Closes /sethify Run-1 Correctness #4 (HTTP timeout) and Run-2 Security #1 (unbounded decoder).

## Notes for reviewers

- Chained on top of PRs #177, #178, #179. Will rebase to drop those commits once they merge.
- The 4 MiB / 1 MiB ceilings are generous: real npm registry metadata for \`@openai/codex\` and \`@google/gemini-cli\` is well under 100 KB; the GCS XML bucket listing under 100 KB; GitHub release JSON well under 1 MB.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/metadatautil/...\` green
- [x] \`./scripts/pre-merge.sh --profile pr-parity --base main\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)