### PR TITLE
Use cmd.Output() not CombinedOutput() for gh api ruleset detail

### DIFF
--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -4,6 +4,7 @@
 package metadatautil
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -593,13 +594,15 @@ func FetchGitHubHostedControlsRulesets(tmpDir, repo string) error {
 		}
 		rulesetID := strconv.FormatInt(int64(idValue), 10)
 		cmd := exec.Command("gh", "api", fmt.Sprintf("repos/%s/rulesets/%s", repo, rulesetID))
-		output, err := cmd.CombinedOutput()
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		output, err := cmd.Output()
 		if err != nil {
-			return fmt.Errorf("gh api repos/%s/rulesets/%s: %w", repo, rulesetID, err)
+			return fmt.Errorf("gh api repos/%s/rulesets/%s: %w (stderr: %s)", repo, rulesetID, err, strings.TrimSpace(stderr.String()))
 		}
 		var detail any
 		if err := json.Unmarshal(output, &detail); err != nil {
-			return err
+			return fmt.Errorf("gh api repos/%s/rulesets/%s: parse JSON: %w", repo, rulesetID, err)
 		}
 		details = append(details, detail)
 	}


### PR DESCRIPTION
## Summary

\`VerifyGitHubHostedControls\` fetches each repo ruleset detail via \`gh api repos/.../rulesets/<id>\` and feeds the raw bytes to \`json.Unmarshal\`. The previous \`cmd.CombinedOutput()\` interleaves stdout and stderr, so any \`gh\` stderr line (deprecation warning, auth refresh notice, retry message, paginate progress) corrupts the JSON parse with a confusing "unexpected character" error.

- Switch to \`cmd.Output()\` so stderr stays separate.
- Capture stderr in a \`bytes.Buffer\` and surface it explicitly on error.
- Wrap the \`json.Unmarshal\` error with the ruleset ID for clearer diagnostics.

Closes /sethify Run-1 Correctness #5.

## Notes for reviewers

- Chained on top of PRs #177–#180. Will rebase to drop those commits once they merge.
- Two other \`CombinedOutput\` sites in this file (lines 140 and 158, running \`actionlint\`/\`zizmor\`) are intentional — those need merged stdout+stderr for diagnostic.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/metadatautil/...\` green
- [x] \`./scripts/pre-merge.sh --profile pr-parity --base main\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)