### PR TITLE
Centralize sanitized-entrypoint preamble across 10 host-side scripts

### DIFF
--- a/scripts/build-and-test.sh
+++ b/scripts/build-and-test.sh
@@ -6,17 +6,8 @@
 #
 # This is a build-time tool, not a runtime entry point; it does not
 # launch a Workcell session or go through the launcher's runtime boundary.
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_KEEP_VALIDATOR_IMAGE="${WORKCELL_KEEP_VALIDATOR_IMAGE:-0}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
-fi
-set -euo pipefail
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 export PATH="${HOME}/.cargo/bin:${TRUSTED_HOST_PATH}"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -1,16 +1,6 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_MAX_DEBIAN_SNAPSHOT_AGE_DAYS="${WORKCELL_MAX_DEBIAN_SNAPSHOT_AGE_DAYS-}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
-fi
-set -euo pipefail
-export PATH="${TRUSTED_HOST_PATH}"
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
@@ -34,13 +24,6 @@ HOSTED_CONTROLS_POLICY_PATH="${ROOT_DIR}/policy/github-hosted-controls.toml"
 HOSTED_CONTROLS_SCRIPT_PATH="${ROOT_DIR}/scripts/verify-github-hosted-controls.sh"
 PROVIDER_BUMP_POLICY_PATH="${ROOT_DIR}/policy/provider-bumps.toml"
 MAX_DEBIAN_SNAPSHOT_AGE_DAYS="${WORKCELL_MAX_DEBIAN_SNAPSHOT_AGE_DAYS:-45}"
-
-require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
-}
 
 GO_BIN="${WORKCELL_GO_BIN:-}"
 

--- a/scripts/generate-control-plane-manifest.sh
+++ b/scripts/generate-control-plane-manifest.sh
@@ -1,16 +1,6 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_CONTROL_PLANE_ROOT="${WORKCELL_CONTROL_PLANE_ROOT-}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
-fi
-set -euo pipefail
-export PATH="${TRUSTED_HOST_PATH}"
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
@@ -19,13 +9,6 @@ if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
 fi
 
 OUTPUT_PATH="${1:-}"
-
-require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
-}
 
 resolve_go_bin() {
   local candidate

--- a/scripts/generate-release-checksums.sh
+++ b/scripts/generate-release-checksums.sh
@@ -1,15 +1,6 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
-fi
-set -euo pipefail
-export PATH="${TRUSTED_HOST_PATH}"
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null

--- a/scripts/lib/trusted-entrypoint.sh
+++ b/scripts/lib/trusted-entrypoint.sh
@@ -3,14 +3,41 @@
 # Source this file immediately after the shebang line of scripts that require
 # a trusted PATH environment and clean process environment.
 # Callers must use a #!/bin/bash -p shebang.
+#
+# On the env -i re-exec this preamble forwards:
+#   - PATH                       set to TRUSTED_HOST_PATH
+#   - HOME, TMPDIR               with safe fallbacks
+#   - WORKCELL_*                 every var in the project's namespace, so a
+#                                caller can pass tunables like
+#                                WORKCELL_KEEP_VALIDATOR_IMAGE without each
+#                                script enumerating its own forwarded set
+#   - WORKCELL_SANITIZED_ENTRYPOINT=1   sentinel that breaks the re-exec loop
+#
+# After re-exec the preamble exports PATH=TRUSTED_HOST_PATH and defines
+# require_tool().  Scripts that need additional path entries (for example
+# ${HOME}/.cargo/bin) can override PATH after sourcing this file.
 readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
+  workcell_trusted_exec_args=(
+    /usr/bin/env -i
+    "PATH=${TRUSTED_HOST_PATH}"
+    "HOME=${HOME:-/tmp}"
+    "TMPDIR=${TMPDIR:-/tmp}"
+    "WORKCELL_SANITIZED_ENTRYPOINT=1"
+  )
+  while IFS= read -r workcell_trusted_env_line; do
+    workcell_trusted_env_name="${workcell_trusted_env_line%%=*}"
+    case "${workcell_trusted_env_name}" in
+      WORKCELL_*) ;;
+      *) continue ;;
+    esac
+    if [[ "${workcell_trusted_env_name}" == "WORKCELL_SANITIZED_ENTRYPOINT" ]]; then
+      continue
+    fi
+    workcell_trusted_exec_args+=("${workcell_trusted_env_line}")
+  done < <(/usr/bin/env)
+  workcell_trusted_exec_args+=(/bin/bash -p "$0" "$@")
+  exec "${workcell_trusted_exec_args[@]}"
 fi
 set -euo pipefail
 export PATH="${TRUSTED_HOST_PATH}"

--- a/scripts/publish-provider-bump-pr.sh
+++ b/scripts/publish-provider-bump-pr.sh
@@ -1,15 +1,6 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
-fi
-set -euo pipefail
-export PATH="${TRUSTED_HOST_PATH}"
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
@@ -36,13 +27,6 @@ Run this from a clean worktree. The disposable publication branch is created
 from the latest available tip of the selected base branch, not the caller's
 current feature branch HEAD.
 EOF
-}
-
-require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
 }
 
 resolve_base_ref() {

--- a/scripts/publish-upstream-refresh-pr.sh
+++ b/scripts/publish-upstream-refresh-pr.sh
@@ -1,15 +1,6 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
-fi
-set -euo pipefail
-export PATH="${TRUSTED_HOST_PATH}"
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
@@ -35,13 +26,6 @@ Run this from a clean worktree. The disposable publication workspace is created
 from the latest available tip of the selected base branch, not the caller's
 current feature branch HEAD.
 EOF
-}
-
-require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
 }
 
 resolve_base_ref() {

--- a/scripts/update-provider-pins.sh
+++ b/scripts/update-provider-pins.sh
@@ -1,15 +1,6 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
-fi
-set -euo pipefail
-export PATH="${TRUSTED_HOST_PATH}"
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
@@ -37,13 +28,6 @@ Modes:
 
 Without a mode flag, the script prints a human-readable summary.
 EOF
-}
-
-require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
 }
 
 NPM_BIN="${WORKCELL_NPM_BIN:-}"

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -1,15 +1,6 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
-fi
-set -euo pipefail
-export PATH="${TRUSTED_HOST_PATH}"
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
@@ -42,13 +33,6 @@ Modes:
 
 Without a mode flag, the script prints a human-readable summary.
 EOF
-}
-
-require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
 }
 
 while [[ $# -gt 0 ]]; do

--- a/scripts/verify-control-plane-manifest.sh
+++ b/scripts/verify-control-plane-manifest.sh
@@ -1,28 +1,12 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
-fi
-set -euo pipefail
-export PATH="${TRUSTED_HOST_PATH}"
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
   echo "verify-control-plane-manifest-entrypoint-ok"
   exit 0
 fi
-
-require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
-}
 
 resolve_go_bin() {
   local candidate

--- a/scripts/verify-github-macos-release-test-runners.sh
+++ b/scripts/verify-github-macos-release-test-runners.sh
@@ -1,15 +1,6 @@
 #!/bin/bash -p
-readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
-  exec /usr/bin/env -i \
-    PATH="${TRUSTED_HOST_PATH}" \
-    HOME="${HOME:-/tmp}" \
-    TMPDIR="${TMPDIR:-/tmp}" \
-    WORKCELL_SANITIZED_ENTRYPOINT=1 \
-    /bin/bash -p "$0" "$@"
-fi
-set -euo pipefail
-export PATH="${TRUSTED_HOST_PATH}"
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
@@ -22,13 +13,6 @@ usage() {
 Usage: verify-github-macos-release-test-runners.sh EXPECTED_LATEST EXPECTED_PREVIOUS
 EOF
   exit 2
-}
-
-require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
 }
 
 trim() {


### PR DESCRIPTION
## Summary

\`scripts/lib/trusted-entrypoint.sh\` now auto-forwards every \`WORKCELL_*\` env var on the \`env -i\` re-exec, so calling scripts no longer enumerate their own forwarded set. Migrates 10 entrypoint-pattern scripts to source the lib (net **−121 lines**), eliminating per-script \`TRUSTED_HOST_PATH\` / \`require_tool\` duplications.

Migrated scripts:
- \`scripts/build-and-test.sh\`
- \`scripts/check-pinned-inputs.sh\`
- \`scripts/generate-control-plane-manifest.sh\`
- \`scripts/generate-release-checksums.sh\`
- \`scripts/publish-provider-bump-pr.sh\`
- \`scripts/publish-upstream-refresh-pr.sh\`
- \`scripts/update-provider-pins.sh\`
- \`scripts/update-upstream-pins.sh\`
- \`scripts/verify-control-plane-manifest.sh\`
- \`scripts/verify-github-macos-release-test-runners.sh\`

Each migrated script keeps its own \`--self-entrypoint-probe\` and any post-PATH overrides (e.g. build-and-test.sh's \`\${HOME}/.cargo/bin\` prefix). All 10 probes still return their per-script \`<name>-entrypoint-ok\` sentinel.

Closes /sethify Run-2 Architecture #3 for the entrypoint-pattern script subset.

## Notes for reviewers

- Chained on top of PRs #177–#181. Will rebase to drop those commits once they merge.
- The lib's \`while IFS= read … < <(/usr/bin/env)\` loop matches \`WORKCELL_*\` names by prefix (excluding the \`WORKCELL_SANITIZED_ENTRYPOINT\` sentinel) — verified via smoke test that unrelated env vars are scrubbed and \`WORKCELL_FOO\` is forwarded.
- Out of scope (deferred follow-ups): scripts forwarding non-WORKCELL_* env vars (\`SOURCE_DATE_EPOCH\`, \`SHELL\`, \`BUILDX_BUILDER\`, \`GITHUB_*\`, hardcoded \`HOME=/tmp\`), the env-scrubbing-shebang pattern (\`uninstall.sh\`, \`colima-egress-allowlist.sh\`), \`verify-invariants.sh\`'s custom sentinel, and \`require_tool\` redefs in scripts that don't use the re-exec pattern.

## Test plan

- [x] \`shellcheck -x\` clean on lib + all 10 migrated scripts
- [x] \`<script> --self-entrypoint-probe\` green for all 10 migrated scripts
- [x] Smoke test: caller's \`WORKCELL_FOO=hello\` forwarded; unrelated env vars scrubbed; PATH set to canonical
- [x] \`./scripts/pre-merge.sh --profile pr-parity --base main\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)