### PR TITLE
Fix small-bug cluster: scenarios, metadatautil, scripts/workcell trap, mutation runner

### DIFF
--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -133,7 +133,7 @@ func ensureTrackedRegularFile(rootDir, repoPath string) error {
 		if errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("missing control-plane artifact: %s", repoPath)
 		}
-		return fmt.Errorf("control-plane artifact must be a regular file: %s", repoPath)
+		return fmt.Errorf("checking control-plane artifact %s: %w", repoPath, err)
 	}
 	return nil
 }

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -226,18 +226,20 @@ func runGoHelperMutations(repoRoot string) error {
 	close(results)
 
 	var failures []string
+	var harnessErrors []error
 	for r := range results {
 		if r.err != nil {
-			return r.err
+			harnessErrors = append(harnessErrors, fmt.Errorf("%s: %w", r.label, r.err))
+			continue
 		}
 		if r.pass {
 			failures = append(failures, r.label)
 		}
 	}
 	if len(failures) > 0 {
-		return fmt.Errorf("go helper mutation coverage did not catch: %s", strings.Join(failures, ", "))
+		harnessErrors = append(harnessErrors, fmt.Errorf("go helper mutation coverage did not catch: %s", strings.Join(failures, ", ")))
 	}
-	return nil
+	return errors.Join(harnessErrors...)
 }
 
 // runRustGuardMutations runs all Rust mutation cases in parallel. Each case
@@ -292,18 +294,20 @@ func runRustGuardMutations(repoRoot string) error {
 	close(results)
 
 	var failures []string
+	var harnessErrors []error
 	for r := range results {
 		if r.err != nil {
-			return r.err
+			harnessErrors = append(harnessErrors, fmt.Errorf("%s: %w", r.label, r.err))
+			continue
 		}
 		if r.pass {
 			failures = append(failures, r.label)
 		}
 	}
 	if len(failures) > 0 {
-		return fmt.Errorf("rust mutation coverage did not catch: %s", strings.Join(failures, ", "))
+		harnessErrors = append(harnessErrors, fmt.Errorf("rust mutation coverage did not catch: %s", strings.Join(failures, ", ")))
 	}
-	return nil
+	return errors.Join(harnessErrors...)
 }
 
 type commandSpec struct {

--- a/internal/scenarios/scenario_manifest.go
+++ b/internal/scenarios/scenario_manifest.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -290,7 +291,14 @@ func ScenarioShellTests(scenarioRoot string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if info, err := os.Stat(absRoot); err != nil || !info.IsDir() {
+	info, err := os.Stat(absRoot)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("stat scenario root %s: %w", absRoot, err)
+	}
+	if !info.IsDir() {
 		return []string{}, nil
 	}
 
@@ -349,8 +357,14 @@ func VerifyCoverage(scenarioRoot, manifestPath string) error {
 	slices.Sort(keys)
 	for _, testFile := range keys {
 		info, err := root.Stat(filepath.FromSlash(testFile))
-		if err != nil || !info.Mode().IsRegular() {
-			return fmt.Errorf("missing test file: tests/scenarios/%s", testFile)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return fmt.Errorf("missing test file: tests/scenarios/%s", testFile)
+			}
+			return fmt.Errorf("stat tests/scenarios/%s: %w", testFile, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("tests/scenarios/%s must be a regular file", testFile)
 		}
 	}
 

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "0b74e971a42685c917481a4b427cf2ee04ffe2f020dc59f37b933462203645ae"
+      "sha256": "f63ef5fa1a64600ee77cd1924fe659ab4c8c84ed229baaed7e889e5341a9d87e"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -3716,6 +3716,10 @@ publish_pr_main() {
       exit 2
     fi
   fi
+  # Register the RETURN trap before writing into the temp file so a
+  # printf/chmod failure (set -e) cannot exit before the trap is armed and
+  # leak the commit message file.
+  trap 'if ((${#cleanup_files[@]} > 0)); then rm -f "${cleanup_files[@]}"; fi' RETURN
   if [[ -n "${commit_message_file}" ]]; then
     resolved_commit_message_file="$(resolve_existing_file_or_die "${commit_message_file}" "commit-message")"
   else
@@ -3724,7 +3728,6 @@ publish_pr_main() {
     printf '%s' "${commit_message_text}" >"${resolved_commit_message_file}"
     chmod 0600 "${resolved_commit_message_file}" 2>/dev/null || true
   fi
-  trap 'if ((${#cleanup_files[@]} > 0)); then rm -f "${cleanup_files[@]}"; fi' RETURN
 
   publish_git_cmd=("${HOST_GIT_BIN}" -c core.hooksPath=/dev/null -C "${resolved_workspace}")
   if [[ "${current_branch}" == "${branch}" ]]; then


### PR DESCRIPTION
## Summary

Four narrow correctness fixes from the /sethify Run-2 review:

1. **\`internal/scenarios/scenario_manifest.go\`** — distinguish \`os.ErrNotExist\` / \`fs.ErrNotExist\` from other stat errors.
2. **\`internal/metadatautil/core.go\`** — \`ensureTrackedRegularFile\` wraps non-ENOENT errors with \`%w\` instead of overwriting.
3. **\`scripts/workcell:3722-3727\`** — RETURN trap registered before mktemp+printf+chmod to prevent temp-file leak on \`set -e\` exit.
4. **\`internal/mutation/runner.go\`** — collect-all goroutine errors via \`errors.Join\` instead of early-return.

Includes control-plane manifest regen after the \`scripts/workcell\` edit.

The Run-2 sessions.go \`targets/\` skip was reverted in-PR — the dual-traversal is intentional for \`TestListSessionRecordsSupportsLegacyProfileNamedTargets\`.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] \`./scripts/pre-merge.sh --profile pr-parity --base main\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)