### PR TITLE
Docs consistency pass: man, README, codex adapter README, CONTRIBUTING, dead markdownlint rule, auth unset

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,3 @@
 {
-  "MD013": false,
-  "MD060": false
+  "MD013": false
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,8 +136,13 @@ boundary, trust model, or provider adapters, mention it in the body.
 
 `./scripts/dev-quick-check.sh` is the normal edit loop. It covers:
 
-- shell lint and format checks
-- Rust fmt, clippy, and tests
+- shell lint and format checks (`shellcheck`, `shfmt`)
+- Dockerfile lint via `hadolint`
+- Go formatting (`gofmt -l`), `go vet ./...`, and `go test ./...`
+- Rust fmt, clippy, and tests inside `runtime/container/rust/`
+- Dead-code check (`scripts/check-dead-code.sh`)
+- Public repo hygiene check (`scripts/check-public-repo-hygiene.sh`)
+- Requirements coverage and operator-contract verification
 
 For fuller repo validation without the entire pre-merge stack, use:
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,10 @@
 [![Security](https://github.com/omkhar/workcell/actions/workflows/security.yml/badge.svg)](https://github.com/omkhar/workcell/actions/workflows/security.yml)
 
 Workcell runs coding agents inside a bounded local runtime on Apple Silicon
-macOS: a dedicated Colima VM plus a hardened container inside that VM. It
-supports
-Codex, Claude Code, and Gemini through thin provider adapters that seed each
-provider's native control plane without pretending provider config is the
-security boundary.
+macOS: a dedicated Colima VM plus a hardened container inside that VM. It ships
+Tier 1 adapters for Codex, Claude Code, and Gemini that seed each provider's
+native control plane without pretending provider config is the security
+boundary.
 
 This project is for teams that want local agent velocity without turning the
 host home directory, keychain, provider state, or local sockets into the trust
@@ -166,6 +165,7 @@ Use the host-side auth helpers instead of hand-editing the common case:
 workcell auth init
 workcell auth set --agent codex --credential codex_auth --source /path/to/auth.json
 workcell auth status --agent codex
+workcell auth unset --agent codex --credential codex_auth
 workcell policy validate
 workcell why --agent codex --mode strict --credential codex_auth
 workcell --agent codex --auth-status --workspace /path/to/repo
@@ -404,8 +404,13 @@ See [docs/provenance.md](docs/provenance.md) and
 - `runtime/`: VM and container boundary implementation
 - `policy/`: shared contract layer and hosted-control policy
 - `adapters/`: provider-native baselines for Codex, Claude, and Gemini
+- `cmd/`: host-side and runtime-side Go entrypoints (the `workcell-*` binaries)
+- `internal/`: shared Go packages backing the `cmd/` binaries
 - `scripts/`: launcher, validation, release, audit, and bootstrap entrypoints
 - `verify/`: invariant-oriented verification material
+- `man/`: workcell.1 manpage
+- `tests/`: scenario manifests and fixtures
+- `tools/`: developer tooling (markdownlint, validator image)
 - `docs/`: user-facing design, quickstarts, install, and release docs
 - `workflows/`: implementation notes such as adapter porting guidance
 

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,13 +1,19 @@
 # Codex Adapter
 
-The Codex adapter maps the shared Workcell boundary into Codex-native controls:
+The Codex adapter maps the shared Workcell boundary into Codex-native controls.
+Adapter layout (paths relative to `adapters/codex/`):
 
-- `~/.codex/config.toml`
-- `managed_config.toml`
-- `requirements.toml`
-- `AGENTS.md`
-- rules
-- MCP config
+- `.codex/config.toml`: managed Codex configuration template seeded into the
+  session-local Codex home as `~/.codex/config.toml`
+- `.codex/AGENTS.md`: managed agent guidance seeded into the session-local
+  Codex home
+- `.codex/rules/`: managed execpolicy rules seeded into the session-local
+  Codex home
+- `.codex/agents/`: managed sub-agent guidance
+- `managed_config.toml`: workcell-side managed-mode TOML consumed by the
+  launcher
+- `requirements.toml`: workcell-side adapter requirements contract
+- `mcp/config.toml`: MCP server config
 
 Workcell re-seeds this state into the session-local Codex home on launch.
 Repo-local control files stay masked on the safe path and are imported only as

--- a/docs/examples/quickstart-claude.md
+++ b/docs/examples/quickstart-claude.md
@@ -8,8 +8,8 @@ the strongest local boundary claim still depends on local Colima validation.
 
 - Workcell installed with `./scripts/install.sh`
 - a repo you want to mount as the workspace
-- a reviewed Claude auth export, a reviewed Claude API key file, or an
-  experimental macOS resolver config
+- a reviewed Claude auth export, a reviewed Claude API key file, or a
+  fail-closed macOS resolver scaffold config (manual support tier today)
 
 ## 1. Create or update the injection policy
 
@@ -78,8 +78,8 @@ workcell --agent claude --auth-status --workspace /path/to/repo
 `workcell auth status` reports the host policy view. `--auth-status` reports the
 staged launch view after selector evaluation and resolver preprocessing.
 
-If you configured only `claude_auth` via the experimental macOS resolver, expect
-`credential_resolution_states=claude_auth:configured-only` and
+If you configured only `claude_auth` via the fail-closed macOS resolver
+scaffold, expect `credential_resolution_states=claude_auth:configured-only` and
 `provider_auth_mode=none` until a supported export path exists. The bootstrap
 summary will also report `provider_bootstrap_path=host-export-scaffold` and
 `provider_bootstrap_support=manual`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -91,6 +91,12 @@ Check the host-side view at any time:
 workcell auth status --agent codex
 ```
 
+To roll back a credential entry from the host policy, use:
+
+```bash
+workcell auth unset --agent codex --credential codex_auth
+```
+
 That output, `workcell --auth-status`, and `workcell why` all include bootstrap
 summary fields. Use
 [docs/provider-bootstrap-matrix.md](provider-bootstrap-matrix.md) to interpret

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -1,4 +1,4 @@
-.TH WORKCELL 1 "2026-04-14" "Workcell" "User Commands"
+.TH WORKCELL 1 "2026-04-25" "Workcell" "User Commands"
 .SH NAME
 workcell \- bounded runtime launcher for coding agents
 .SH SYNOPSIS
@@ -400,7 +400,9 @@ verify every commit being published, push it, and open a GitHub pull request
 using host Git and GitHub CLI state.
 The supported base branch is
 .BR main ;
-non-main bases remain an explicit lower-assurance draft-only escape hatch.
+non-main bases remain an explicit lower-assurance draft-only escape hatch
+selected via
+.BR --allow-non-main-base .
 Dry-run output reports whether repo-owned PR checks are expected for the chosen
 base.
 Use
@@ -408,6 +410,15 @@ Use
 to pin an explicit host GitHub CLI binary when needed, or use
 .BR "workcell publish-pr --help"
 for the full option set.
+.TP
+.B --allow-non-main-base
+Explicit publish-pr opt-in for using a non-
+.BR main
+base branch. The resulting pull request stays draft-only and does not receive
+repo-owned PR validation or merge gating. Pair with
+.B --base BRANCH
+to name the target. This is the only supported way to publish against a
+stacked-review or feature-branch base.
 .TP
 .B -h, --help
 Show usage information.


### PR DESCRIPTION
## Summary

Eight documentation/dead-rule fixes from /sethify:

1. \`man/workcell.1:1\` — bump \`.TH\` date to v0.10.5 ship date (2026-04-25)
2. \`man/workcell.1\` — document \`--allow-non-main-base\` under OPTIONS
3. \`README.md:402-410\` — add \`cmd/\`, \`internal/\`, \`man/\`, \`tests/\`, \`tools/\` to Repository layout
4. \`README.md:7-12\` — rephrase the bare "It supports" lead per AGENTS.md L53
5. \`adapters/codex/README.md:4-10\` — align listed adapter paths with the on-disk layout
6. \`CONTRIBUTING.md:137-140\` — expand dev-quick-check.sh check list (gofmt, vet, hadolint, dead-code, etc.)
7. \`.markdownlint.json:3\` — remove dead \`MD060\` disable (rule doesn't exist in markdownlint-cli 0.48.0)
8. \`README.md\` + \`docs/getting-started.md\` — add \`workcell auth unset\` to auth examples
9. \`docs/examples/quickstart-claude.md\` — align "experimental macOS resolver" → "fail-closed macOS resolver scaffold"

Closes /sethify Run-2 Doc 🟡 ×5 and 🔵 ×3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)