### PR TITLE
Install full validator toolchain via install-dev-tools.sh; align release.yml zizmor to 1.24.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,7 +314,7 @@ jobs:
           advanced-security: false
           inputs: .github/workflows
           persona: auditor
-          version: 1.23.1
+          version: 1.24.1
 
       - name: Run container smoke
         run: ./scripts/container-smoke.sh

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -72,6 +72,33 @@ if ! command -v npm &>/dev/null; then
   append_unique_brew node
   append_unique_apt nodejs npm
 fi
+if ! command -v actionlint &>/dev/null; then
+  missing+=(actionlint)
+  append_unique_brew actionlint
+  append_unique_apt actionlint
+fi
+if ! command -v zizmor &>/dev/null; then
+  missing+=(zizmor)
+  append_unique_brew zizmor
+  # Linux distros do not ship zizmor in apt yet; surface as manual install.
+  append_unique_apt zizmor
+fi
+if ! command -v hadolint &>/dev/null; then
+  missing+=(hadolint)
+  append_unique_brew hadolint
+  append_unique_apt hadolint
+fi
+if ! command -v cosign &>/dev/null; then
+  missing+=(cosign)
+  append_unique_brew cosign
+  append_unique_apt cosign
+fi
+if ! command -v syft &>/dev/null; then
+  missing+=(syft)
+  append_unique_brew syft
+  # syft isn't packaged in apt repos by default; manual fallback.
+  append_unique_apt syft
+fi
 
 if [[ ${#missing[@]} -gt 0 ]]; then
   case "$(uname -s)" in


### PR DESCRIPTION
## Summary

- \`scripts/install-dev-tools.sh\` now installs \`actionlint\`, \`zizmor\`, \`hadolint\`, \`cosign\`, \`syft\` on top of the existing \`shellcheck\`/\`shfmt\`/\`yamllint\`/\`codespell\`/\`jq\`/\`npm\` set. New contributors running \`./scripts/bootstrap-dev.sh\` immediately hit "Missing required tool: ..." from \`dev-quick-check.sh\` / \`pre-merge.sh\` until the full validator toolchain is present.
- \`.github/workflows/release.yml:317\` was pinned to \`zizmor 1.23.1\` while \`security.yml\` runs \`1.24.1\`. Bumped \`release.yml\` to \`1.24.1\` so the two workflows agree.

Closes /sethify Run-2 Doc 🟡 (CONTRIBUTING prereq drift) + Run-2 Security 🔵 (zizmor version drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)