### PR TITLE
Add control-plane lockstep invariant under verify/invariants/

### DIFF
--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -7990,4 +7990,8 @@ for scenario_script_basename in \
   fi
 done
 
+# Concrete control-plane lockstep invariant: every policy/ file must be
+# mentioned in a user-facing doc surface so additions stay operator-visible.
+"${ROOT_DIR}/verify/invariants/control-plane-lockstep.sh"
+
 echo "Workcell invariant verification passed."

--- a/verify/invariants/control-plane-lockstep.sh
+++ b/verify/invariants/control-plane-lockstep.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# verify/invariants/control-plane-lockstep.sh
+#
+# Concrete lockstep invariant for AGENTS.md L157 ("runtime/, policy/,
+# adapters/, verify/, workflows/ should evolve in lockstep").  Asserts that
+# every policy/*.{toml,tsv,json} file is mentioned by name in at least one
+# user-facing markdown surface, so a new policy file cannot land without an
+# operator-visible doc pointer.
+#
+# This is the first concrete check living under verify/invariants/; the
+# directory previously held only narrative markdown.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SEARCH_ROOTS=(
+  "${ROOT_DIR}/docs"
+  "${ROOT_DIR}/verify"
+  "${ROOT_DIR}/README.md"
+  "${ROOT_DIR}/SECURITY.md"
+  "${ROOT_DIR}/AGENTS.md"
+  "${ROOT_DIR}/CONTRIBUTING.md"
+)
+
+missing=()
+for path in "${ROOT_DIR}"/policy/*; do
+  base="$(basename "${path}")"
+  case "${base}" in
+    README.md) continue ;;
+  esac
+  hit=0
+  for root in "${SEARCH_ROOTS[@]}"; do
+    if [[ -e "${root}" ]] && grep -rlqF "${base}" "${root}" 2>/dev/null; then
+      hit=1
+      break
+    fi
+  done
+  if [[ "${hit}" -eq 0 ]]; then
+    missing+=("${base}")
+  fi
+done
+
+if [[ "${#missing[@]}" -gt 0 ]]; then
+  echo "Control-plane lockstep invariant failed: policy/ files missing from user-facing docs:" >&2
+  for name in "${missing[@]}"; do
+    echo "  - policy/${name}" >&2
+  done
+  exit 1
+fi
+
+echo "Control-plane lockstep invariant passed: every policy/ file is documented."


### PR DESCRIPTION
## Summary

\`verify/invariants/\` previously held only narrative markdown despite AGENTS.md L157 listing it as a lockstep-evolved domain. Adds the first concrete live check: \`verify/invariants/control-plane-lockstep.sh\` asserts every file under \`policy/\` is referenced by name in a user-facing doc (docs/, verify/, README.md, SECURITY.md, AGENTS.md, CONTRIBUTING.md). Wired into \`scripts/verify-invariants.sh\` as the last assertion before the pass banner.

All 9 current policy files already pass. Future undocumented policy additions will fail the invariant.

Closes /sethify Run-2 Architecture 🟡 (verify/invariants/ empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)