### PR TITLE
Centralize per-provider tables in internal/adapters/{p}/

### DIFF
--- a/internal/adapters/adapters.go
+++ b/internal/adapters/adapters.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package adapters aggregates per-provider table data so the injection,
+// policy, and runtime paths can iterate over them without hard-coding
+// provider names. New adapters register themselves here.
+package adapters
+
+import (
+	"github.com/omkhar/workcell/internal/adapters/claude"
+	"github.com/omkhar/workcell/internal/adapters/codex"
+	"github.com/omkhar/workcell/internal/adapters/gemini"
+	"github.com/omkhar/workcell/internal/adapters/shared"
+	"github.com/omkhar/workcell/internal/providerid"
+)
+
+// AgentScopedCredentialKeys maps each providerid to the set of credential
+// keys scoped exclusively to that adapter (excludes shared keys).
+func AgentScopedCredentialKeys() map[string]map[string]struct{} {
+	out := map[string]map[string]struct{}{}
+	for _, agent := range registry {
+		out[agent.id] = setOf(agent.credentialKeys)
+	}
+	return out
+}
+
+// SharedCredentialKeys returns the set of credential keys provisioned for
+// every adapter (currently the github_* keys).
+func SharedCredentialKeys() map[string]struct{} {
+	return setOf(shared.CredentialKeys)
+}
+
+// CredentialContainerPaths returns the merged container-side mount paths
+// for every adapter-scoped and shared credential key.
+func CredentialContainerPaths() map[string]string {
+	out := map[string]string{}
+	for _, agent := range registry {
+		for k, v := range agent.credentialPaths {
+			out[k] = v
+		}
+	}
+	for k, v := range shared.CredentialContainerPaths {
+		out[k] = v
+	}
+	return out
+}
+
+// ReservedTargets returns the union of in-container paths reserved by
+// every adapter, in providerid-stable order.
+func ReservedTargets() []string {
+	var out []string
+	for _, agent := range registry {
+		out = append(out, agent.reservedTargets...)
+	}
+	out = append(out, shared.ReservedTargets...)
+	return out
+}
+
+type adapter struct {
+	id              string
+	credentialKeys  []string
+	credentialPaths map[string]string
+	reservedTargets []string
+}
+
+var registry = []adapter{
+	{
+		id:              providerid.Codex,
+		credentialKeys:  codex.CredentialKeys,
+		credentialPaths: codex.CredentialContainerPaths,
+		reservedTargets: codex.ReservedTargets,
+	},
+	{
+		id:              providerid.Claude,
+		credentialKeys:  claude.CredentialKeys,
+		credentialPaths: claude.CredentialContainerPaths,
+		reservedTargets: claude.ReservedTargets,
+	},
+	{
+		id:              providerid.Gemini,
+		credentialKeys:  gemini.CredentialKeys,
+		credentialPaths: gemini.CredentialContainerPaths,
+		reservedTargets: gemini.ReservedTargets,
+	},
+}
+
+func setOf(keys []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		out[k] = struct{}{}
+	}
+	return out
+}

--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package adapters
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/providerid"
+)
+
+// Parity assertions for the credential / reserved-target tables: every
+// non-empty credential key has a container mount path, every scoped key
+// is also present in CredentialContainerPaths, no key is both shared
+// and adapter-scoped.
+
+func TestAgentScopedCredentialKeysCoversAllProviders(t *testing.T) {
+	got := AgentScopedCredentialKeys()
+	for _, want := range []string{providerid.Codex, providerid.Claude, providerid.Gemini} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("provider %q missing from AgentScopedCredentialKeys", want)
+		}
+	}
+}
+
+func TestScopedCredentialKeysHaveContainerPaths(t *testing.T) {
+	paths := CredentialContainerPaths()
+	for provider, keys := range AgentScopedCredentialKeys() {
+		for key := range keys {
+			if _, ok := paths[key]; !ok {
+				t.Errorf("provider %q scoped credential key %q has no container path", provider, key)
+			}
+		}
+	}
+}
+
+func TestSharedCredentialKeysHaveContainerPaths(t *testing.T) {
+	paths := CredentialContainerPaths()
+	for key := range SharedCredentialKeys() {
+		if _, ok := paths[key]; !ok {
+			t.Errorf("shared credential key %q has no container path", key)
+		}
+	}
+}
+
+func TestNoKeyIsBothScopedAndShared(t *testing.T) {
+	shared := SharedCredentialKeys()
+	for provider, keys := range AgentScopedCredentialKeys() {
+		for key := range keys {
+			if _, ok := shared[key]; ok {
+				t.Errorf("credential key %q is listed as both shared and scoped to %q", key, provider)
+			}
+		}
+	}
+}
+
+func TestReservedTargetsAreCleanAndUnique(t *testing.T) {
+	seen := map[string]struct{}{}
+	for _, target := range ReservedTargets() {
+		if target == "" {
+			t.Error("empty reserved target")
+		}
+		if target[0] != '/' {
+			t.Errorf("reserved target %q is not absolute", target)
+		}
+		if _, dup := seen[target]; dup {
+			t.Errorf("duplicate reserved target %q", target)
+		}
+		seen[target] = struct{}{}
+	}
+}
+
+func TestCredentialContainerPathsRootedAtHostInputs(t *testing.T) {
+	const wantPrefix = "/opt/workcell/host-inputs/credentials/"
+	paths := CredentialContainerPaths()
+	keys := make([]string, 0, len(paths))
+	for k := range paths {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if got := paths[k]; len(got) <= len(wantPrefix) || got[:len(wantPrefix)] != wantPrefix {
+			t.Errorf("container path for %q is %q, want prefix %q", k, got, wantPrefix)
+		}
+	}
+}

--- a/internal/adapters/claude/tables.go
+++ b/internal/adapters/claude/tables.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package claude carries the per-adapter tables consumed by the injection
+// and policy paths. Keeping them here means adding a new credential key,
+// reserved home path, or risky directive for one provider is a one-package
+// edit instead of touching the central injection package.
+package claude
+
+import "github.com/omkhar/workcell/internal/providerid"
+
+const ProviderID = providerid.Claude
+
+// CredentialKeys lists the policy keys that route to this adapter when
+// emitting a credentials.<key> table. Order is stable for deterministic
+// rendering.
+var CredentialKeys = []string{
+	"claude_api_key",
+	"claude_auth",
+	"claude_mcp",
+}
+
+// CredentialContainerPaths maps each adapter-scoped credential key to the
+// in-container mount path the runtime materializes it at.
+var CredentialContainerPaths = map[string]string{
+	"claude_auth":    "/opt/workcell/host-inputs/credentials/claude-auth.json",
+	"claude_api_key": "/opt/workcell/host-inputs/credentials/claude-api-key.txt",
+	"claude_mcp":     "/opt/workcell/host-inputs/credentials/claude-mcp.json",
+}
+
+// ReservedTargets are container paths the adapter owns. Injection policy
+// MUST NOT permit user copies/symlinks into these — workcell synthesizes
+// them on its own.
+var ReservedTargets = []string{
+	"/state/agent-home/.claude",
+	"/state/agent-home/.config/claude-code",
+	"/state/agent-home/.claude/settings.json",
+	"/state/agent-home/.claude/CLAUDE.md",
+	"/state/agent-home/.claude/.claude.json",
+	"/state/agent-home/.claude.json",
+	"/state/agent-home/.claude/.credentials.json",
+	"/state/agent-home/.claude/workcell",
+	"/state/agent-home/.config/claude-code/auth.json",
+	"/state/agent-home/.mcp.json",
+}

--- a/internal/adapters/codex/tables.go
+++ b/internal/adapters/codex/tables.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package codex carries the per-adapter tables consumed by the injection
+// and policy paths.
+package codex
+
+import "github.com/omkhar/workcell/internal/providerid"
+
+const ProviderID = providerid.Codex
+
+var CredentialKeys = []string{
+	"codex_auth",
+}
+
+var CredentialContainerPaths = map[string]string{
+	"codex_auth": "/opt/workcell/host-inputs/credentials/codex-auth.json",
+}
+
+var ReservedTargets = []string{
+	"/state/agent-home/.codex",
+	"/state/agent-home/.codex/AGENTS.md",
+	"/state/agent-home/.codex/auth.json",
+	"/state/agent-home/.codex/config.toml",
+	"/state/agent-home/.codex/managed_config.toml",
+	"/state/agent-home/.codex/requirements.toml",
+	"/state/agent-home/.codex/agents",
+	"/state/agent-home/.codex/rules",
+	"/state/agent-home/.codex/mcp",
+}

--- a/internal/adapters/gemini/tables.go
+++ b/internal/adapters/gemini/tables.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package gemini carries the per-adapter tables consumed by the injection
+// and policy paths.
+package gemini
+
+import "github.com/omkhar/workcell/internal/providerid"
+
+const ProviderID = providerid.Gemini
+
+var CredentialKeys = []string{
+	"gemini_env",
+	"gemini_oauth",
+	"gemini_projects",
+	"gcloud_adc",
+}
+
+var CredentialContainerPaths = map[string]string{
+	"gemini_env":      "/opt/workcell/host-inputs/credentials/gemini.env",
+	"gemini_oauth":    "/opt/workcell/host-inputs/credentials/gemini-oauth.json",
+	"gemini_projects": "/opt/workcell/host-inputs/credentials/gemini-projects.json",
+	"gcloud_adc":      "/opt/workcell/host-inputs/credentials/gcloud-adc.json",
+}
+
+var ReservedTargets = []string{
+	"/state/agent-home/.gemini",
+	"/state/agent-home/.config/gcloud",
+	"/state/agent-home/.gemini/settings.json",
+	"/state/agent-home/.gemini/GEMINI.md",
+	"/state/agent-home/.gemini/.env",
+	"/state/agent-home/.gemini/oauth_creds.json",
+	"/state/agent-home/.gemini/projects.json",
+	"/state/agent-home/.gemini/trustedFolders.json",
+	"/state/agent-home/.config/gcloud/application_default_credentials.json",
+}
+
+// GoogleAuthEndpoints are the extra outbound endpoints Gemini requires for
+// Google OAuth / ADC.
+var GoogleAuthEndpoints = []string{
+	"accounts.google.com:443",
+	"oauth2.googleapis.com:443",
+	"sts.googleapis.com:443",
+}

--- a/internal/adapters/shared/tables.go
+++ b/internal/adapters/shared/tables.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package shared holds credential keys and reserved targets that all
+// adapters share — currently just GitHub host config / hosts.
+package shared
+
+var CredentialKeys = []string{
+	"github_hosts",
+	"github_config",
+}
+
+var CredentialContainerPaths = map[string]string{
+	"github_hosts":  "/opt/workcell/host-inputs/credentials/github-hosts.yml",
+	"github_config": "/opt/workcell/host-inputs/credentials/github-config.yml",
+}
+
+var ReservedTargets = []string{
+	"/state/agent-home/.config/gh",
+	"/state/agent-home/.config/gh/config.yml",
+	"/state/agent-home/.config/gh/hosts.yml",
+	"/state/agent-home/.ssh",
+}

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/omkhar/workcell/internal/adapters"
+	"github.com/omkhar/workcell/internal/adapters/gemini"
 	"github.com/omkhar/workcell/internal/providerid"
 	"github.com/omkhar/workcell/internal/tomlsubset"
 )
@@ -67,79 +69,13 @@ var (
 		"setenv":              {},
 		"userknownhostsfile":  {},
 	}
-	reservedTargets = []string{
-		"/state/agent-home/.codex",
-		"/state/agent-home/.claude",
-		"/state/agent-home/.config/claude-code",
-		"/state/agent-home/.gemini",
-		"/state/agent-home/.config/gcloud",
-		"/state/agent-home/.config/gh",
-		"/state/agent-home/.codex/AGENTS.md",
-		"/state/agent-home/.codex/auth.json",
-		"/state/agent-home/.codex/config.toml",
-		"/state/agent-home/.codex/managed_config.toml",
-		"/state/agent-home/.codex/requirements.toml",
-		"/state/agent-home/.codex/agents",
-		"/state/agent-home/.codex/rules",
-		"/state/agent-home/.codex/mcp",
-		"/state/agent-home/.claude/settings.json",
-		"/state/agent-home/.claude/CLAUDE.md",
-		"/state/agent-home/.claude/.claude.json",
-		"/state/agent-home/.claude.json",
-		"/state/agent-home/.claude/.credentials.json",
-		"/state/agent-home/.claude/workcell",
-		"/state/agent-home/.config/claude-code/auth.json",
-		"/state/agent-home/.mcp.json",
-		"/state/agent-home/.gemini/settings.json",
-		"/state/agent-home/.gemini/GEMINI.md",
-		"/state/agent-home/.gemini/.env",
-		"/state/agent-home/.gemini/oauth_creds.json",
-		"/state/agent-home/.gemini/projects.json",
-		"/state/agent-home/.gemini/trustedFolders.json",
-		"/state/agent-home/.config/gcloud/application_default_credentials.json",
-		"/state/agent-home/.config/gh/config.yml",
-		"/state/agent-home/.config/gh/hosts.yml",
-		"/state/agent-home/.ssh",
-	}
-	credentialContainerPaths = map[string]string{
-		"codex_auth":      directMountRoot + "/credentials/codex-auth.json",
-		"claude_auth":     directMountRoot + "/credentials/claude-auth.json",
-		"claude_api_key":  directMountRoot + "/credentials/claude-api-key.txt",
-		"claude_mcp":      directMountRoot + "/credentials/claude-mcp.json",
-		"gemini_env":      directMountRoot + "/credentials/gemini.env",
-		"gemini_oauth":    directMountRoot + "/credentials/gemini-oauth.json",
-		"gemini_projects": directMountRoot + "/credentials/gemini-projects.json",
-		"gcloud_adc":      directMountRoot + "/credentials/gcloud-adc.json",
-		"github_hosts":    directMountRoot + "/credentials/github-hosts.yml",
-		"github_config":   directMountRoot + "/credentials/github-config.yml",
-	}
-	agentScopedCredentialKeys = map[string]map[string]struct{}{
-		providerid.Codex: {
-			"codex_auth": {},
-		},
-		providerid.Claude: {
-			"claude_api_key": {},
-			"claude_auth":    {},
-			"claude_mcp":     {},
-		},
-		providerid.Gemini: {
-			"gemini_env":      {},
-			"gemini_oauth":    {},
-			"gemini_projects": {},
-			"gcloud_adc":      {},
-		},
-	}
-	sharedCredentialKeys = map[string]struct{}{
-		"github_hosts":  {},
-		"github_config": {},
-	}
-	googleAuthEndpoints = []string{
-		"accounts.google.com:443",
-		"oauth2.googleapis.com:443",
-		"sts.googleapis.com:443",
-	}
-	vertexEndpoint    = "aiplatform.googleapis.com:443"
-	geminiProjectKeys = []string{
+	reservedTargets           = adapters.ReservedTargets()
+	credentialContainerPaths  = adapters.CredentialContainerPaths()
+	agentScopedCredentialKeys = adapters.AgentScopedCredentialKeys()
+	sharedCredentialKeys      = adapters.SharedCredentialKeys()
+	googleAuthEndpoints       = gemini.GoogleAuthEndpoints
+	vertexEndpoint            = "aiplatform.googleapis.com:443"
+	geminiProjectKeys         = []string{
 		"GOOGLE_CLOUD_PROJECT",
 		"GOOGLE_CLOUD_PROJECT_ID",
 	}


### PR DESCRIPTION
## Summary

- Moves four per-provider tables (\`reservedTargets\`, \`credentialContainerPaths\`, \`agentScopedCredentialKeys\`, \`sharedCredentialKeys\`) out of \`internal/injection/render_injection_bundle.go\` into new \`internal/adapters/{claude,codex,gemini,shared}/tables.go\` packages, with \`internal/adapters/adapters.go\` as the aggregating registry.
- Pulls Gemini's \`GoogleAuthEndpoints\` from \`internal/adapters/gemini\` directly.
- Decision D7 from the /sethify plan: \`internal/adapters/<p>/\` (Go) preserves \`adapters/\` at repo root as the runtime config root.

Adds \`internal/adapters/adapters_test.go\` with parity assertions: every adapter-scoped credential key has a container path, no key is both shared and scoped, every reserved target is absolute and unique, all container paths share the \`/opt/workcell/host-inputs/credentials/\` prefix.

Net diff: 329 lines added, 71 deleted (412 total — under the 1200-line PR shape budget). Deletion of dormant \`internal/policybundle\` (D6) follows in a separate review unit because the four-file deletion blows the same budget.

Closes /sethify Run-1 Architecture 🔴 #1 (provider-table duplication). Relates to 🔴 #2 (policybundle deletion follow-up).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green (21 packages including policybundle, which still exists in this PR)
- [ ] CI will run full pre-merge validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)