### PR TITLE
Make release attestations fail-closed with WORKCELL_RELEASE_NO_ATTEST opt-out

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}
+  # Attestations are now opt-out (fail-closed): every release attests its
+  # artifacts unless vars.WORKCELL_RELEASE_NO_ATTEST is set to "true".
+  # The previous opt-in vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS was removed
+  # because a missing toggle silently produced unattested releases.
+  RELEASE_NO_ATTEST: ${{ vars.WORKCELL_RELEASE_NO_ATTEST || 'false' }}
   ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ github.event.repository.visibility == 'public' || vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS == 'true' }}
   IMAGE_NAME: ghcr.io/${{ github.repository }}
   WORKCELL_BUILDKIT_IMAGE: moby/buildkit:buildx-stable-1@sha256:0039c1d47e8748b5afea56f4e85f14febaf34452bd99d9552d2daa82262b5cc5
@@ -485,6 +489,21 @@ jobs:
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
           version: ${{ env.WORKCELL_BUILDX_VERSION }}
 
+      - name: Confirm attestation environment policy
+        env:
+          RELEASE_NO_ATTEST: ${{ env.RELEASE_NO_ATTEST }}
+          ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED }}
+        run: |
+          if [[ "${RELEASE_NO_ATTEST}" == "true" ]]; then
+            echo "::warning::vars.WORKCELL_RELEASE_NO_ATTEST=true — release will skip GitHub attestations."
+            exit 0
+          fi
+          if [[ "${ENABLE_GITHUB_ATTESTATIONS_SUPPORTED}" != "true" ]]; then
+            echo "::error::Release requires GitHub attestations but they are not supported for this repository." >&2
+            echo "::error::Either publish the repository, set vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS=true for the private flow, or explicitly opt out with vars.WORKCELL_RELEASE_NO_ATTEST=true (each release will then ship without attestations)." >&2
+            exit 1
+          fi
+
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
         with:
           cosign-release: ${{ env.WORKCELL_COSIGN_VERSION }}
@@ -883,14 +902,14 @@ jobs:
             dist/workcell-image.spdx.json
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-name: ${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.publish_manifest.outputs.digest }}
           push-to-registry: true
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           sbom-path: dist/workcell-image.spdx.json
           subject-name: ${{ env.IMAGE_NAME }}
@@ -898,43 +917,43 @@ jobs:
           push-to-registry: true
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/${{ env.BUNDLE_NAME }}
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           sbom-path: dist/workcell-source.spdx.json
           subject-path: dist/${{ env.BUNDLE_NAME }}
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell.rb
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell-image.digest
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell-build-inputs.json
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell-control-plane.json
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell-builder-environment.json
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/SHA256SUMS
 

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -237,9 +237,18 @@ func validateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow string) error 
 	if !strings.Contains(releaseWorkflow, "ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ github.event.repository.visibility == 'public' || vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS == 'true' }}") {
 		return errors.New(".github/workflows/release.yml must gate GitHub attestations on public visibility or an explicit private-repo capability flag")
 	}
-	const attestGuard = "if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'"
+	if !strings.Contains(releaseWorkflow, "RELEASE_NO_ATTEST: ${{ vars.WORKCELL_RELEASE_NO_ATTEST || 'false' }}") {
+		return errors.New(".github/workflows/release.yml must expose RELEASE_NO_ATTEST as an explicit opt-out env var sourced from vars.WORKCELL_RELEASE_NO_ATTEST")
+	}
+	if !strings.Contains(releaseWorkflow, "name: Confirm attestation environment policy") {
+		return errors.New(".github/workflows/release.yml must include the fail-closed attestation preflight step")
+	}
+	if !regexp.MustCompile(`(?ms)name: Confirm attestation environment policy.*?ENABLE_GITHUB_ATTESTATIONS_SUPPORTED.*?!= "true".*?exit 1`).MatchString(releaseWorkflow) {
+		return errors.New(".github/workflows/release.yml must keep the fail-closed attestation preflight script body (must `exit 1` when ENABLE_GITHUB_ATTESTATIONS_SUPPORTED is not 'true' and RELEASE_NO_ATTEST is not 'true')")
+	}
+	const attestGuard = "if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'"
 	attestStepRE := regexp.MustCompile(`(?m)^\s*-\s+uses:\s+actions/attest@`)
-	guardedAttestStepRE := regexp.MustCompile(`(?ms)^\s*-\s+uses:\s+actions/attest@[^\n]+\n\s+if:\s+env\.ENABLE_GITHUB_ATTESTATIONS == 'true' && env\.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'\n`)
+	guardedAttestStepRE := regexp.MustCompile(`(?ms)^\s*-\s+uses:\s+actions/attest@[^\n]+\n\s+if:\s+env\.RELEASE_NO_ATTEST != 'true' && env\.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'\n`)
 	totalAttestSteps := len(attestStepRE.FindAllString(releaseWorkflow, -1))
 	if totalAttestSteps != 10 {
 		return errors.New(".github/workflows/release.yml must keep exactly ten reviewed GitHub attestation steps")
@@ -365,7 +374,7 @@ func hostedControlsRepositoryVariables(policy map[string]any, policyPath string)
 		}
 	}
 	for _, requiredName := range []string{
-		"WORKCELL_ENABLE_GITHUB_ATTESTATIONS",
+		"WORKCELL_RELEASE_NO_ATTEST",
 		"WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS",
 	} {
 		if _, ok := expectedRepoVariables[requiredName]; !ok {
@@ -380,8 +389,8 @@ func validateCanonicalHostedControlsRepositoryVariables(policy map[string]any, p
 	if err != nil {
 		return err
 	}
-	if value, _ := repositoryVariables["WORKCELL_ENABLE_GITHUB_ATTESTATIONS"].(string); value != "true" {
-		return errors.New("policy/github-hosted-controls.toml must require WORKCELL_ENABLE_GITHUB_ATTESTATIONS = \"true\"")
+	if value, _ := repositoryVariables["WORKCELL_RELEASE_NO_ATTEST"].(string); value != "false" {
+		return errors.New("policy/github-hosted-controls.toml must require WORKCELL_RELEASE_NO_ATTEST = \"false\"")
 	}
 	if value, _ := repositoryVariables["WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS"].(string); value != "false" {
 		return errors.New("policy/github-hosted-controls.toml must require WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = \"false\"")
@@ -2060,7 +2069,7 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		"docker buildx imagetools inspect --raw",
 		"{{json .Manifest}}",
 		"vnd.docker.reference.type",
-		"ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}",
+		"RELEASE_NO_ATTEST: ${{ vars.WORKCELL_RELEASE_NO_ATTEST || 'false' }}",
 		"actions/attest@",
 		"Verify release bundle matches preflight",
 		"Verify control-plane manifest matches preflight",

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -116,7 +116,7 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 		`contexts = ["Allowed PR base", "Validate repository"]`,
 		"",
 		"[repository_variables]",
-		`WORKCELL_ENABLE_GITHUB_ATTESTATIONS = "true"`,
+		`WORKCELL_RELEASE_NO_ATTEST = "false"`,
 		`WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = "false"`,
 		"",
 		"[workflow_environment.hosted-controls-audit]",
@@ -148,8 +148,8 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 	actionsVariables := map[string]any{
 		"variables": []map[string]any{
 			{
-				"name":  "WORKCELL_ENABLE_GITHUB_ATTESTATIONS",
-				"value": "true",
+				"name":  "WORKCELL_RELEASE_NO_ATTEST",
+				"value": "false",
 			},
 			{
 				"name":  "WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -970,17 +970,18 @@ jobs:
 func TestValidateReleaseWorkflowGitHubAttestationFlowRejectsMissingSupportGuard(t *testing.T) {
 	t.Parallel()
 	releaseWorkflow := `env:
-  ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}
+  RELEASE_NO_ATTEST: ${{ vars.WORKCELL_RELEASE_NO_ATTEST || 'false' }}
   ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ !github.event.repository.private || github.event.repository.owner.type != 'User' }}
 
+      - name: Confirm attestation environment policy
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true'
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true'
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true'
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true'
         with:
           subject-name: ${{ env.IMAGE_NAME }}
 `
@@ -997,49 +998,54 @@ func TestValidateReleaseWorkflowGitHubAttestationFlowRejectsMissingSupportGuard(
 func TestValidateReleaseWorkflowGitHubAttestationFlowRejectsUnguardedAttestStep(t *testing.T) {
 	t.Parallel()
 	releaseWorkflow := `env:
-  ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}
+  RELEASE_NO_ATTEST: ${{ vars.WORKCELL_RELEASE_NO_ATTEST || 'false' }}
   ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ github.event.repository.visibility == 'public' || vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS == 'true' }}
 
+      - name: Confirm attestation environment policy
+        run: |
+          if [[ "${ENABLE_GITHUB_ATTESTATIONS_SUPPORTED}" != "true" ]]; then
+            exit 1
+          fi
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-name: ${{ env.IMAGE_NAME }}
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true'
         with:
           sbom-path: dist/workcell-image.spdx.json
           subject-name: ${{ env.IMAGE_NAME }}
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/${{ env.BUNDLE_NAME }}
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           sbom-path: dist/workcell-source.spdx.json
           subject-path: dist/${{ env.BUNDLE_NAME }}
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell.rb
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell-image.digest
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell-build-inputs.json
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell-control-plane.json
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell-builder-environment.json
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/SHA256SUMS
 `
@@ -1056,49 +1062,54 @@ func TestValidateReleaseWorkflowGitHubAttestationFlowRejectsUnguardedAttestStep(
 func TestValidateReleaseWorkflowGitHubAttestationFlowAcceptsSupportGuard(t *testing.T) {
 	t.Parallel()
 	releaseWorkflow := `env:
-  ENABLE_GITHUB_ATTESTATIONS: ${{ vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS || 'false' }}
+  RELEASE_NO_ATTEST: ${{ vars.WORKCELL_RELEASE_NO_ATTEST || 'false' }}
   ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ github.event.repository.visibility == 'public' || vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS == 'true' }}
 
+      - name: Confirm attestation environment policy
+        run: |
+          if [[ "${ENABLE_GITHUB_ATTESTATIONS_SUPPORTED}" != "true" ]]; then
+            exit 1
+          fi
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-name: ${{ env.IMAGE_NAME }}
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           sbom-path: dist/workcell-image.spdx.json
           subject-name: ${{ env.IMAGE_NAME }}
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/${{ env.BUNDLE_NAME }}
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           sbom-path: dist/workcell-source.spdx.json
           subject-path: dist/${{ env.BUNDLE_NAME }}
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell.rb
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell-image.digest
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell-build-inputs.json
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell-control-plane.json
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/workcell-builder-environment.json
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        if: env.ENABLE_GITHUB_ATTESTATIONS == 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
+        if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-path: dist/SHA256SUMS
 `
@@ -1112,7 +1123,7 @@ func TestValidateCanonicalHostedControlsRepositoryVariablesRejectsMissingPrivate
 	t.Parallel()
 	policy := map[string]any{
 		"repository_variables": map[string]any{
-			"WORKCELL_ENABLE_GITHUB_ATTESTATIONS": "true",
+			"WORKCELL_RELEASE_NO_ATTEST": "false",
 		},
 	}
 
@@ -1129,7 +1140,7 @@ func TestValidateCanonicalHostedControlsRepositoryVariablesRejectsWrongPrivateAt
 	t.Parallel()
 	policy := map[string]any{
 		"repository_variables": map[string]any{
-			"WORKCELL_ENABLE_GITHUB_ATTESTATIONS":         "true",
+			"WORKCELL_RELEASE_NO_ATTEST":                  "false",
 			"WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS": "true",
 		},
 	}
@@ -1147,7 +1158,7 @@ func TestValidateCanonicalHostedControlsRepositoryVariablesAcceptsCanonicalValue
 	t.Parallel()
 	policy := map[string]any{
 		"repository_variables": map[string]any{
-			"WORKCELL_ENABLE_GITHUB_ATTESTATIONS":         "true",
+			"WORKCELL_RELEASE_NO_ATTEST":                  "false",
 			"WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS": "false",
 		},
 	}

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -63,12 +63,18 @@ immutable_github_releases = true
 
 [repository_variables]
 # The canonical Workcell repository always requests GitHub-native attestations
-# when the platform supports them. Public repos support that path on all
-# current plans; private/internal repos need explicit hosted-control approval
-# because GitHub only supports them on Enterprise Cloud. Forks can loosen this
+# when the platform supports them. Release attestations are now fail-closed:
+# every release attests its artifacts unless WORKCELL_RELEASE_NO_ATTEST is
+# explicitly set to "true". The hosted-controls policy pins it to "false" so
+# that setting the bypass on the repo cannot silently disable all
+# actions/attest steps while validation still reports green.
+#
+# Public repos support attestations on all current plans;
+# private/internal repos need explicit hosted-control approval because
+# GitHub only supports them on Enterprise Cloud. Forks can loosen this
 # policy, but the upstream repo treats both variables as part of the reviewed
 # control plane so publication posture cannot silently drift.
-WORKCELL_ENABLE_GITHUB_ATTESTATIONS = "true"
+WORKCELL_RELEASE_NO_ATTEST = "false"
 WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = "false"
 
 [workflow_environment.hosted-controls-audit]


### PR DESCRIPTION
## Summary

The previous attestation gate paired \`vars.WORKCELL_ENABLE_GITHUB_ATTESTATIONS\` (opt-in, default false) with a support detector. A missing toggle silently produced unattested releases — the failure mode the original /sethify finding flagged as fail-open.

This change flips the polarity:
- Removes \`ENABLE_GITHUB_ATTESTATIONS\` (opt-in toggle).
- Introduces \`RELEASE_NO_ATTEST\` (opt-out toggle, default false) sourced from \`vars.WORKCELL_RELEASE_NO_ATTEST\`.
- Adds a pre-attest preflight step that hard-fails when the release is not opted out but the environment cannot generate attestations (private repo without the \`WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS\` escape hatch). The error message names the three escape doors so a blocked release is unambiguous.
- Updates all 10 \`actions/attest\` step guards from the conjunction over \`ENABLE_GITHUB_ATTESTATIONS\` to \`env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'\`.

Existing cosign \`sign\` / \`sign-blob\` steps are unaffected — they already run unconditionally and produce sigstore bundles in \`dist/\`.

Closes /sethify Run-1 CI/CD 🟡.

## Test plan

- [x] \`actionlint .github/workflows/release.yml\` clean
- [x] \`zizmor .github/workflows/release.yml\` clean (no findings)
- [ ] CI will run full pre-merge validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)