### PR TITLE
Tidy mutation runner with goCmd helper, rename resolvePathLikePython, drop Python-mirror comments

### DIFF
--- a/internal/authpolicy/policy.go
+++ b/internal/authpolicy/policy.go
@@ -143,11 +143,11 @@ func expandUserPath(raw string) (string, error) {
 }
 
 func requirePathWithin(root string, candidate string, label string) error {
-	resolvedRoot, err := resolvePathLikePython(root)
+	resolvedRoot, err := resolveAbsPath(root)
 	if err != nil {
 		return err
 	}
-	resolvedCandidate, err := resolvePathLikePython(candidate)
+	resolvedCandidate, err := resolveAbsPath(candidate)
 	if err != nil {
 		return err
 	}
@@ -1014,7 +1014,7 @@ func requireSecretFile(source string, label string) (string, error) {
 	return source, nil
 }
 
-func resolvePathLikePython(raw string) (string, error) {
+func resolveAbsPath(raw string) (string, error) {
 	expanded, err := expandUserPath(raw)
 	if err != nil {
 		return "", err
@@ -1054,8 +1054,8 @@ func resolvePathLikePython(raw string) (string, error) {
 }
 
 func pathsEquivalent(left string, right string) bool {
-	leftResolved, errLeft := resolvePathLikePython(left)
-	rightResolved, errRight := resolvePathLikePython(right)
+	leftResolved, errLeft := resolveAbsPath(left)
+	rightResolved, errRight := resolveAbsPath(right)
 	if errLeft != nil || errRight != nil {
 		return left == right
 	}

--- a/internal/authresolve/resolve_credential_sources.go
+++ b/internal/authresolve/resolve_credential_sources.go
@@ -107,7 +107,7 @@ var (
 	}()
 )
 
-// PolicySource mirrors the metadata emitted by the Python helper.
+// PolicySource is the per-policy-file metadata this resolver emits.
 type PolicySource struct {
 	Path   string `json:"path"`
 	Sha256 string `json:"sha256"`

--- a/internal/injection/extract_direct_mounts.go
+++ b/internal/injection/extract_direct_mounts.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-// DirectMount mirrors the JSON shape emitted by the Python helper.
+// DirectMount is the JSON shape this binary emits for each direct mount.
 type DirectMount struct {
 	Source    string `json:"source"`
 	MountPath string `json:"mount_path"`
@@ -38,11 +38,11 @@ func RequireDirectMount(entry map[string]any, label string) (DirectMount, error)
 
 // RunExtractDirectMounts reproduces the legacy extract_direct_mounts helper.
 func RunExtractDirectMounts(manifestPath, mountSpecPath string) error {
-	resolvedManifestPath, err := resolvePathLikePython(manifestPath)
+	resolvedManifestPath, err := resolveAbsPath(manifestPath)
 	if err != nil {
 		return err
 	}
-	resolvedMountSpecPath, err := resolvePathLikePython(mountSpecPath)
+	resolvedMountSpecPath, err := resolveAbsPath(mountSpecPath)
 	if err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func expandUserPath(raw string) (string, error) {
 	return raw, nil
 }
 
-func resolvePathLikePython(raw string) (string, error) {
+func resolveAbsPath(raw string) (string, error) {
 	expanded, err := expandUserPath(raw)
 	if err != nil {
 		return "", err

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -125,11 +125,11 @@ func ValidateRenderAgentMode(agent, mode string) error {
 }
 
 func RunRenderInjectionBundle(policyPath, agent, mode, outputRoot, policyMetadata string) error {
-	resolvedPolicyPath, err := resolvePathLikePython(policyPath)
+	resolvedPolicyPath, err := resolveAbsPath(policyPath)
 	if err != nil {
 		return err
 	}
-	resolvedOutputRoot, err := resolvePathLikePython(outputRoot)
+	resolvedOutputRoot, err := resolveAbsPath(outputRoot)
 	if err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ func RunRenderInjectionBundle(policyPath, agent, mode, outputRoot, policyMetadat
 }
 
 func loadPolicyBundle(policyPath Path) (map[string]any, []PolicySource, error) {
-	resolvedPolicyPath, err := resolvePathLikePython(policyPath.String())
+	resolvedPolicyPath, err := resolveAbsPath(policyPath.String())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -221,7 +221,7 @@ func loadPolicyBundle(policyPath Path) (map[string]any, []PolicySource, error) {
 }
 
 func loadPolicyBundleRecursive(policyPath, entrypointRoot Path, activeStack []Path, loadedPaths map[string]struct{}) (map[string]any, []PolicySource, error) {
-	resolvedPolicyPath, err := resolvePathLikePython(policyPath.String())
+	resolvedPolicyPath, err := resolveAbsPath(policyPath.String())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -306,7 +306,7 @@ func loadPolicyBundleRecursive(policyPath, entrypointRoot Path, activeStack []Pa
 }
 
 func loadPolicyMetadataOverride(rawPath string) (string, []PolicySource, error) {
-	resolved, err := resolvePathLikePython(rawPath)
+	resolved, err := resolveAbsPath(rawPath)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -22,16 +22,24 @@ type mutationCase struct {
 	command      commandSpec
 }
 
+// goCmd builds a commandSpec that invokes the host `go` binary with the
+// given argv tail. The mutation table previously inlined a four-line
+// commandSpec literal at each site; this helper compresses each to a
+// single line.
+func goCmd(args ...string) commandSpec {
+	return commandSpec{
+		Path: "go",
+		Args: args,
+	}
+}
+
 var goHelperMutations = []mutationCase{
 	{
 		relativePath: "internal/injection/render_injection_bundle.go",
 		original:     `if targetIsReserved(candidate) {`,
 		replacement:  `if false && targetIsReserved(candidate) {`,
 		label:        "reserved target protection",
-		command: commandSpec{
-			Path: "go",
-			Args: []string{"test", "./internal/injection"},
-		},
+		command:      goCmd("test", "./internal/injection"),
 	},
 	{
 		relativePath: "internal/injection/render_injection_bundle.go",
@@ -49,101 +57,71 @@ var goHelperMutations = []mutationCase{
 			`		"claude_api_key",`,
 			`		// "claude_mcp",`,
 		}, "\n"),
-		label: "claude mcp credential support",
-		command: commandSpec{
-			Path: "go",
-			Args: []string{"test", "./internal/injection"},
-		},
+		label:   "claude mcp credential support",
+		command: goCmd("test", "./internal/injection"),
 	},
 	{
 		relativePath: "internal/injection/render_injection_bundle.go",
 		original:     `if info.Mode().Perm()&0o077 != 0 {`,
 		replacement:  `if false && info.Mode().Perm()&0o077 != 0 {`,
 		label:        "secret permission hygiene",
-		command: commandSpec{
-			Path: "go",
-			Args: []string{"test", "./internal/injection"},
-		},
+		command:      goCmd("test", "./internal/injection"),
 	},
 	{
 		relativePath: "internal/transcript/transcript.go",
 		original:     `if !isTerminal(stdin) || !isTerminal(stdout) {`,
 		replacement:  `if false && (!isTerminal(stdin) || !isTerminal(stdout)) {`,
 		label:        "interactive terminal requirement",
-		command: commandSpec{
-			Path: "go",
-			Args: []string{"test", "./internal/transcript"},
-		},
+		command:      goCmd("test", "./internal/transcript"),
 	},
 	{
 		relativePath: "internal/injection/extract_direct_mounts.go",
 		original:     `delete(entry, "source")`,
 		replacement:  `// delete(entry, "source")`,
 		label:        "manifest source stripping",
-		command: commandSpec{
-			Path: "go",
-			Args: []string{"test", "./internal/injection"},
-		},
+		command:      goCmd("test", "./internal/injection"),
 	},
 	{
 		relativePath: "internal/injection/render_injection_bundle.go",
 		original:     `"forwardagent":        {},`,
 		replacement:  `// "forwardagent":        {},`,
 		label:        "forwardagent ssh directive blocking",
-		command: commandSpec{
-			Path: "go",
-			Args: []string{"test", "./internal/injection"},
-		},
+		command:      goCmd("test", "./internal/injection"),
 	},
 	{
 		relativePath: "internal/injection/render_injection_bundle.go",
 		original:     `"sendenv":             {},`,
 		replacement:  `// "sendenv":             {},`,
 		label:        "sendenv ssh directive blocking",
-		command: commandSpec{
-			Path: "go",
-			Args: []string{"test", "./internal/injection"},
-		},
+		command:      goCmd("test", "./internal/injection"),
 	},
 	{
 		relativePath: "internal/metadatautil/operator_contract.go",
 		original:     `if isPublicWorkflowTier(workflow.Support) && len(workflow.Evidence) == 0 {`,
 		replacement:  `if false && isPublicWorkflowTier(workflow.Support) && len(workflow.Evidence) == 0 {`,
 		label:        "workflow evidence requirement",
-		command: commandSpec{
-			Path: "go",
-			Args: []string{"test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"},
-		},
+		command:      goCmd("test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"),
 	},
 	{
 		relativePath: "internal/metadatautil/operator_contract.go",
 		original:     `if _, ok := requirementPaths[canonicalPath]; !ok {`,
 		replacement:  `if _, ok := requirementPaths[canonicalPath]; false && !ok {`,
 		label:        "workflow requirement path parity",
-		command: commandSpec{
-			Path: "go",
-			Args: []string{"test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"},
-		},
+		command:      goCmd("test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"),
 	},
 	{
 		relativePath: "internal/metadatautil/operator_contract.go",
 		original:     `if len(aliasProbes) == 0 {`,
 		replacement:  `if false && len(aliasProbes) == 0 {`,
 		label:        "alias probe requirement",
-		command: commandSpec{
-			Path: "go",
-			Args: []string{"test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"},
-		},
+		command:      goCmd("test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"),
 	},
 	{
 		relativePath: "internal/metadatautil/operator_contract.go",
 		original:     `if !strings.Contains(output, workflow.Canonical) {`,
 		replacement:  `if false && !strings.Contains(output, workflow.Canonical) {`,
 		label:        "alias probe canonical parity",
-		command: commandSpec{
-			Path: "go",
-			Args: []string{"test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"},
-		},
+		command:      goCmd("test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"),
 	},
 }
 


### PR DESCRIPTION
## Summary

Three small, independent cleanups that the /sethify Run-2 Code Quality 🟡 cluster flagged. None of them change runtime behaviour.

1. \`internal/mutation/runner.go\`: extract the repeated \`command: commandSpec{ Path: "go", Args: []string{...} }\` literal into a \`goCmd(args ...string) commandSpec\` helper. Eleven sites compress from four lines each to one line; the table now reads \`goCmd("test", "./internal/injection")\` instead of a Path/Args pair.

2. Rename \`resolvePathLikePython\` → \`resolveAbsPath\` across the two defining files (\`internal/injection/extract_direct_mounts.go\` and \`internal/authpolicy/policy.go\`) and all callers (\`internal/injection/render_injection_bundle.go\`, \`internal/authpolicy/policy.go\`). The \"LikePython\" suffix is historical residue from the Python → Go migration; the function resolves an absolute path with home expansion regardless of which language used to host it.

3. Drop two \"mirrors the Python helper\" doc comments (\`internal/injection/extract_direct_mounts.go:DirectMount\`, \`internal/authresolve/resolve_credential_sources.go:PolicySource\`) and rewrite them as descriptions of the current Go behaviour. The Python helper has been gone for over a year.

Net diff: **37 insertions, 59 deletions across 5 files**.

Closes /sethify Run-2 Code Quality 🟡 (goCmd helper, resolveAbsPath rename, Python-mirror doc-comment scrub). Leaves the \`scripts/verify-invariants.sh\` harness split for a follow-up PR (it depends on PRs 30/31 — already landed — plus PR 32 still pending).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green (21 packages)
- [ ] CI will run full pre-merge validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)