### PR TITLE
Extract GitHub-release helpers into internal/host/release (1 of hostutil split series)

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/omkhar/workcell/internal/host/release"
 	"github.com/omkhar/workcell/internal/hostutil"
 )
 
@@ -85,17 +86,17 @@ func runRelease(args []string) error {
 		if len(args) != 3 {
 			return releaseUsage()
 		}
-		return hostutil.WriteGitHubReleaseCreatePayload(args[1], args[2])
+		return release.WriteGitHubReleaseCreatePayload(args[1], args[2])
 	case "metadata":
 		if len(args) < 4 {
 			return releaseUsage()
 		}
-		return hostutil.WriteGitHubReleaseMetadata(args[1], args[3:], args[2])
+		return release.WriteGitHubReleaseMetadata(args[1], args[3:], args[2])
 	case "encode-name":
 		if len(args) != 2 {
 			return releaseUsage()
 		}
-		fmt.Println(hostutil.EncodeReleaseAssetName(args[1]))
+		fmt.Println(release.EncodeReleaseAssetName(args[1]))
 		return nil
 	case "bundle-manifest":
 		if len(args) != 8 {
@@ -105,7 +106,7 @@ func runRelease(args []string) error {
 		if err != nil {
 			return fmt.Errorf("parse source_date_epoch: %w", err)
 		}
-		return hostutil.WriteReleaseBundleManifest(args[1], args[2], args[3], args[4], sourceDateEpoch, args[6], args[7])
+		return release.WriteReleaseBundleManifest(args[1], args[2], args[3], args[4], sourceDateEpoch, args[6], args[7])
 	default:
 		return releaseUsage()
 	}

--- a/internal/host/release/release.go
+++ b/internal/host/release/release.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package release carries the GitHub-release helpers the
+// workcell-hostutil binary uses when assembling and uploading a
+// release. The functions previously lived in internal/hostutil
+// alongside path canonicalization and session helpers; they were
+// split out to keep the per-concern boundaries cleaner, matching the
+// /sethify Run-1 plan to break the hostutil god-package into focused
+// subpackages.
+package release
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type createPayload struct {
+	TagName              string `json:"tag_name"`
+	Draft                bool   `json:"draft"`
+	GenerateReleaseNotes bool   `json:"generate_release_notes"`
+}
+
+type asset struct {
+	Name string `json:"name"`
+	ID   *int64 `json:"id"`
+}
+
+type response struct {
+	ID        int64   `json:"id"`
+	UploadURL string  `json:"upload_url"`
+	Draft     bool    `json:"draft"`
+	Immutable bool    `json:"immutable"`
+	Assets    []asset `json:"assets"`
+}
+
+type bundleManifest struct {
+	ArchiveRef      string `json:"archive_ref"`
+	BundleName      string `json:"bundle_name"`
+	BundlePrefix    string `json:"bundle_prefix"`
+	BundleSha256    string `json:"bundle_sha256"`
+	ChecksumsSha256 string `json:"checksums_sha256"`
+	SourceDateEpoch int64  `json:"source_date_epoch"`
+}
+
+// WriteGitHubReleaseCreatePayload emits the JSON body the GitHub
+// "create a release" REST call needs.
+func WriteGitHubReleaseCreatePayload(tagName, outputPath string) error {
+	payload := createPayload{
+		TagName:              tagName,
+		Draft:                true,
+		GenerateReleaseNotes: true,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(outputPath, data, 0o644)
+}
+
+// WriteGitHubReleaseMetadata reads a GitHub release response JSON file
+// and writes a NUL-separated record file (release ID, upload URL, draft
+// flag, immutable flag, per-asset name+id pairs) for the host-side
+// uploader to consume.
+func WriteGitHubReleaseMetadata(releaseJSONPath string, assetPaths []string, outputPath string) error {
+	data, err := os.ReadFile(releaseJSONPath)
+	if err != nil {
+		return err
+	}
+
+	var resp response
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return err
+	}
+
+	uploadURL, _, _ := strings.Cut(resp.UploadURL, "{")
+	assetIDs := make(map[string]*int64, len(resp.Assets))
+	for _, asset := range resp.Assets {
+		asset := asset
+		assetIDs[asset.Name] = asset.ID
+	}
+
+	var buffer bytes.Buffer
+	writeField := func(value string) {
+		_, _ = buffer.WriteString(value)
+		_ = buffer.WriteByte(0)
+	}
+
+	writeField(fmt.Sprint(resp.ID))
+	writeField(uploadURL)
+	writeField(fmt.Sprint(resp.Draft))
+	writeField(fmt.Sprint(resp.Immutable))
+	for _, assetPath := range assetPaths {
+		name := filepath.Base(assetPath)
+		writeField(name)
+		if assetID := assetIDs[name]; assetID != nil {
+			writeField(fmt.Sprint(*assetID))
+		} else {
+			writeField("")
+		}
+	}
+
+	return os.WriteFile(outputPath, buffer.Bytes(), 0o644)
+}
+
+// EncodeReleaseAssetName URL-encodes name for the GitHub release asset
+// upload path, with `+` escaped explicitly because GitHub's upload
+// endpoint treats it as a space otherwise.
+func EncodeReleaseAssetName(name string) string {
+	return strings.ReplaceAll(url.PathEscape(name), "+", "%2B")
+}
+
+// WriteReleaseBundleManifest writes the per-release bundle manifest
+// (archive ref, names, sha256s, source-date epoch) the host-side
+// release flow uses to verify and re-publish bundles.
+func WriteReleaseBundleManifest(path, archiveRef, bundleName, bundlePrefix string, sourceDateEpoch int64, bundleSHA256, checksumsSHA256 string) error {
+	manifest := bundleManifest{
+		ArchiveRef:      archiveRef,
+		BundleName:      bundleName,
+		BundlePrefix:    bundlePrefix,
+		BundleSha256:    bundleSHA256,
+		ChecksumsSha256: checksumsSHA256,
+		SourceDateEpoch: sourceDateEpoch,
+	}
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0o644)
+}

--- a/internal/host/release/release_test.go
+++ b/internal/host/release/release_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package release
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteGitHubReleaseCreatePayload(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	outputPath := filepath.Join(tmp, "create.json")
+	if err := WriteGitHubReleaseCreatePayload("v1.2.3", outputPath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(data) != `{"tag_name":"v1.2.3","draft":true,"generate_release_notes":true}` {
+		t.Fatalf("unexpected payload: %s", data)
+	}
+}
+
+func TestWriteGitHubReleaseMetadata(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	releaseJSONPath := filepath.Join(tmp, "release.json")
+	outputPath := filepath.Join(tmp, "metadata.bin")
+	releaseJSON := map[string]any{
+		"id":         123,
+		"upload_url": "https://uploads.github.com/repos/example/workcell/releases/123/assets{?name,label}",
+		"draft":      true,
+		"immutable":  false,
+		"assets": []map[string]any{
+			{"name": "workcell-linux-amd64.tar.gz", "id": 11},
+			{"name": "workcell-linux-arm64.tar.gz"},
+		},
+	}
+	data, err := json.Marshal(releaseJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(releaseJSONPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteGitHubReleaseMetadata(releaseJSONPath, []string{
+		filepath.Join("/tmp", "workcell-linux-amd64.tar.gz"),
+		filepath.Join("/tmp", "workcell-linux-arm64.tar.gz"),
+	}, outputPath); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	records := bytes.Split(got, []byte{0})
+	if len(records) > 0 && len(records[len(records)-1]) == 0 {
+		records = records[:len(records)-1]
+	}
+	want := [][]byte{
+		[]byte("123"),
+		[]byte("https://uploads.github.com/repos/example/workcell/releases/123/assets"),
+		[]byte("true"),
+		[]byte("false"),
+		[]byte("workcell-linux-amd64.tar.gz"),
+		[]byte("11"),
+		[]byte("workcell-linux-arm64.tar.gz"),
+		[]byte(""),
+	}
+	if len(records) != len(want) {
+		t.Fatalf("unexpected record count: got %d want %d", len(records), len(want))
+	}
+	for i := range want {
+		if !bytes.Equal(records[i], want[i]) {
+			t.Fatalf("record %d = %q, want %q", i, records[i], want[i])
+		}
+	}
+}
+
+func TestEncodeReleaseAssetName(t *testing.T) {
+	t.Parallel()
+	got := EncodeReleaseAssetName("workcell a+b.tar.gz")
+	want := "workcell%20a%2Bb.tar.gz"
+	if got != want {
+		t.Fatalf("EncodeReleaseAssetName() = %q, want %q", got, want)
+	}
+}
+
+func TestWriteReleaseBundleManifest(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	outputPath := filepath.Join(tmp, "bundle", "manifest.json")
+	if err := WriteReleaseBundleManifest(outputPath, "HEAD", "workcell.tar.gz", "workcell/", 123, "sha256:aaa", "sha256:bbb"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := strings.Join([]string{
+		"{",
+		`  "archive_ref": "HEAD",`,
+		`  "bundle_name": "workcell.tar.gz",`,
+		`  "bundle_prefix": "workcell/",`,
+		`  "bundle_sha256": "sha256:aaa",`,
+		`  "checksums_sha256": "sha256:bbb",`,
+		`  "source_date_epoch": 123`,
+		"}",
+		"",
+	}, "\n")
+	if string(got) != want {
+		t.Fatalf("unexpected manifest:\n%s", got)
+	}
+}

--- a/internal/hostutil/hostutil.go
+++ b/internal/hostutil/hostutil.go
@@ -4,44 +4,11 @@
 package hostutil
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/omkhar/workcell/internal/pathutil"
 )
-
-type releaseCreatePayload struct {
-	TagName              string `json:"tag_name"`
-	Draft                bool   `json:"draft"`
-	GenerateReleaseNotes bool   `json:"generate_release_notes"`
-}
-
-type releaseAsset struct {
-	Name string `json:"name"`
-	ID   *int64 `json:"id"`
-}
-
-type releaseResponse struct {
-	ID        int64          `json:"id"`
-	UploadURL string         `json:"upload_url"`
-	Draft     bool           `json:"draft"`
-	Immutable bool           `json:"immutable"`
-	Assets    []releaseAsset `json:"assets"`
-}
-
-type releaseBundleManifest struct {
-	ArchiveRef      string `json:"archive_ref"`
-	BundleName      string `json:"bundle_name"`
-	BundlePrefix    string `json:"bundle_prefix"`
-	BundleSha256    string `json:"bundle_sha256"`
-	ChecksumsSha256 string `json:"checksums_sha256"`
-	SourceDateEpoch int64  `json:"source_date_epoch"`
-}
 
 func CanonicalizePath(path string) (string, error) {
 	return CanonicalizePathFrom(path, "")
@@ -78,87 +45,6 @@ func RealHome() (string, error) {
 		return "", err
 	}
 	return CanonicalizePath(home)
-}
-
-func WriteGitHubReleaseCreatePayload(tagName, outputPath string) error {
-	payload := releaseCreatePayload{
-		TagName:              tagName,
-		Draft:                true,
-		GenerateReleaseNotes: true,
-	}
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(outputPath, data, 0o644)
-}
-
-func WriteGitHubReleaseMetadata(releaseJSONPath string, assetPaths []string, outputPath string) error {
-	data, err := os.ReadFile(releaseJSONPath)
-	if err != nil {
-		return err
-	}
-
-	var release releaseResponse
-	if err := json.Unmarshal(data, &release); err != nil {
-		return err
-	}
-
-	uploadURL, _, _ := strings.Cut(release.UploadURL, "{")
-	assetIDs := make(map[string]*int64, len(release.Assets))
-	for _, asset := range release.Assets {
-		asset := asset
-		assetIDs[asset.Name] = asset.ID
-	}
-
-	var buffer bytes.Buffer
-	writeField := func(value string) {
-		_, _ = buffer.WriteString(value)
-		_ = buffer.WriteByte(0)
-	}
-
-	writeField(fmt.Sprint(release.ID))
-	writeField(uploadURL)
-	writeField(fmt.Sprint(release.Draft))
-	writeField(fmt.Sprint(release.Immutable))
-	for _, assetPath := range assetPaths {
-		name := filepath.Base(assetPath)
-		writeField(name)
-		if assetID := assetIDs[name]; assetID != nil {
-			writeField(fmt.Sprint(*assetID))
-		} else {
-			writeField("")
-		}
-	}
-
-	return os.WriteFile(outputPath, buffer.Bytes(), 0o644)
-}
-
-func EncodeReleaseAssetName(name string) string {
-	return strings.ReplaceAll(url.PathEscape(name), "+", "%2B")
-}
-
-func WriteReleaseBundleManifest(path, archiveRef, bundleName, bundlePrefix string, sourceDateEpoch int64, bundleSHA256, checksumsSHA256 string) error {
-	manifest := releaseBundleManifest{
-		ArchiveRef:      archiveRef,
-		BundleName:      bundleName,
-		BundlePrefix:    bundlePrefix,
-		BundleSha256:    bundleSHA256,
-		ChecksumsSha256: checksumsSHA256,
-		SourceDateEpoch: sourceDateEpoch,
-	}
-
-	data, err := json.MarshalIndent(manifest, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-
-	return os.WriteFile(path, data, 0o644)
 }
 
 func expandUser(path string) (string, error) {

--- a/internal/hostutil/hostutil_test.go
+++ b/internal/hostutil/hostutil_test.go
@@ -4,7 +4,6 @@
 package hostutil
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -88,121 +87,6 @@ func TestCanonicalizePathFromUsesExplicitBaseForRelativePaths(t *testing.T) {
 	want := filepath.Join(canonicalBase, "configs", "policy.toml")
 	if got != want {
 		t.Fatalf("CanonicalizePathFrom() = %q, want %q", got, want)
-	}
-}
-
-func TestWriteGitHubReleaseCreatePayload(t *testing.T) {
-	t.Parallel()
-	tmp := t.TempDir()
-	outputPath := filepath.Join(tmp, "create.json")
-	if err := WriteGitHubReleaseCreatePayload("v1.2.3", outputPath); err != nil {
-		t.Fatal(err)
-	}
-
-	data, err := os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(data) != `{"tag_name":"v1.2.3","draft":true,"generate_release_notes":true}` {
-		t.Fatalf("unexpected payload: %s", data)
-	}
-}
-
-func TestWriteGitHubReleaseMetadata(t *testing.T) {
-	t.Parallel()
-	tmp := t.TempDir()
-	releaseJSONPath := filepath.Join(tmp, "release.json")
-	outputPath := filepath.Join(tmp, "metadata.bin")
-	releaseJSON := map[string]any{
-		"id":         123,
-		"upload_url": "https://uploads.github.com/repos/example/workcell/releases/123/assets{?name,label}",
-		"draft":      true,
-		"immutable":  false,
-		"assets": []map[string]any{
-			{"name": "workcell-linux-amd64.tar.gz", "id": 11},
-			{"name": "workcell-linux-arm64.tar.gz"},
-		},
-	}
-	data, err := json.Marshal(releaseJSON)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(releaseJSONPath, data, 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := WriteGitHubReleaseMetadata(releaseJSONPath, []string{
-		filepath.Join("/tmp", "workcell-linux-amd64.tar.gz"),
-		filepath.Join("/tmp", "workcell-linux-arm64.tar.gz"),
-	}, outputPath); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	records := bytes.Split(got, []byte{0})
-	if len(records) > 0 && len(records[len(records)-1]) == 0 {
-		records = records[:len(records)-1]
-	}
-	want := [][]byte{
-		[]byte("123"),
-		[]byte("https://uploads.github.com/repos/example/workcell/releases/123/assets"),
-		[]byte("true"),
-		[]byte("false"),
-		[]byte("workcell-linux-amd64.tar.gz"),
-		[]byte("11"),
-		[]byte("workcell-linux-arm64.tar.gz"),
-		[]byte(""),
-	}
-	if len(records) != len(want) {
-		t.Fatalf("unexpected record count: got %d want %d", len(records), len(want))
-	}
-	for i := range want {
-		if !bytes.Equal(records[i], want[i]) {
-			t.Fatalf("record %d = %q, want %q", i, records[i], want[i])
-		}
-	}
-}
-
-func TestEncodeReleaseAssetName(t *testing.T) {
-	t.Parallel()
-	got := EncodeReleaseAssetName("workcell a+b.tar.gz")
-	want := "workcell%20a%2Bb.tar.gz"
-	if got != want {
-		t.Fatalf("EncodeReleaseAssetName() = %q, want %q", got, want)
-	}
-}
-
-func TestWriteReleaseBundleManifest(t *testing.T) {
-	t.Parallel()
-	tmp := t.TempDir()
-	outputPath := filepath.Join(tmp, "bundle", "manifest.json")
-	if err := WriteReleaseBundleManifest(outputPath, "HEAD", "workcell.tar.gz", "workcell/", 123, "sha256:aaa", "sha256:bbb"); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := strings.Join([]string{
-		"{",
-		`  "archive_ref": "HEAD",`,
-		`  "bundle_name": "workcell.tar.gz",`,
-		`  "bundle_prefix": "workcell/",`,
-		`  "bundle_sha256": "sha256:aaa",`,
-		`  "checksums_sha256": "sha256:bbb",`,
-		`  "source_date_epoch": 123`,
-		"}",
-		"",
-	}, "\n")
-	if string(got) != want {
-		t.Fatalf("unexpected manifest:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

\`internal/hostutil\` mixes nine unrelated concerns (sessions, GitHub releases, paths, Colima, locks, audit, mounts, random hex, launcher). This is the first incremental split per /sethify decision D7 — the GitHub-release helpers move into a focused \`internal/host/release\` package, leaving the rest of hostutil intact for follow-up PRs.

**Moved:**
- \`releaseCreatePayload\` / \`releaseAsset\` / \`releaseResponse\` / \`releaseBundleManifest\` types
- \`WriteGitHubReleaseCreatePayload\`
- \`WriteGitHubReleaseMetadata\`
- \`EncodeReleaseAssetName\`
- \`WriteReleaseBundleManifest\`
- the four matching tests

→ \`internal/host/release/release.go\` + \`release_test.go\`

Updated \`cmd/workcell-hostutil/main.go\` to import the new package; the \`runRelease\` dispatcher still routes the same four subcommands (\`create-payload\`, \`metadata\`, \`encode-name\`, \`bundle-manifest\`) without any runtime contract change.

\`internal/hostutil/hostutil.go\` shrinks from 166 to 52 lines (only path canonicalization and the \`expandUser\` helper remain). The test file drops the four release tests; nothing else moves yet.

Net: **275 insertions, 234 deletions across 5 files**. Subsequent PRs in this series will extract sessions, launcher, audit-path, and other clusters.

Relates to /sethify Run-1 Code Quality 🟡 (hostutil mixed concerns).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green (all 21 packages, including the new \`internal/host/release\`)
- [x] \`gofmt -l .\` empty
- [ ] CI will run full pre-merge validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)