### PR TITLE
Extract support-matrix into internal/host/supportmatrix (2 of hostutil split series)

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/omkhar/workcell/internal/host/release"
+	"github.com/omkhar/workcell/internal/host/supportmatrix"
 	"github.com/omkhar/workcell/internal/hostutil"
 )
 
@@ -340,7 +341,7 @@ func runLauncher(args []string) error {
 		if len(args) != 7 {
 			return launcherUsage()
 		}
-		result, err := hostutil.EvaluateSupportMatrix(args[1], hostutil.SupportMatrixQuery{
+		result, err := supportmatrix.Evaluate(args[1], supportmatrix.Query{
 			HostOS:               args[2],
 			HostArch:             args[3],
 			TargetKind:           args[4],
@@ -350,7 +351,7 @@ func runLauncher(args []string) error {
 		if err != nil {
 			return err
 		}
-		for _, line := range hostutil.SupportMatrixMetadataLines(result) {
+		for _, line := range supportmatrix.MetadataLines(result) {
 			fmt.Println(line)
 		}
 		return nil

--- a/internal/host/supportmatrix/supportmatrix.go
+++ b/internal/host/supportmatrix/supportmatrix.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Omkhar Arasaratnam
 
-package hostutil
+package supportmatrix
 
 import (
 	"bufio"
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-type SupportMatrixQuery struct {
+type Query struct {
 	HostOS               string
 	HostArch             string
 	TargetKind           string
@@ -18,7 +18,7 @@ type SupportMatrixQuery struct {
 	TargetAssuranceClass string
 }
 
-type SupportMatrixResult struct {
+type Result struct {
 	HostOS               string
 	HostArch             string
 	TargetKind           string
@@ -31,7 +31,7 @@ type SupportMatrixResult struct {
 	Reason               string
 }
 
-var supportMatrixColumns = []string{
+var columns = []string{
 	"host_os",
 	"host_arch",
 	"target_kind",
@@ -44,9 +44,9 @@ var supportMatrixColumns = []string{
 	"reason",
 }
 
-func EvaluateSupportMatrix(path string, query SupportMatrixQuery) (SupportMatrixResult, error) {
-	query = normalizeSupportMatrixQuery(query)
-	result := defaultSupportMatrixResult(query)
+func Evaluate(path string, query Query) (Result, error) {
+	query = normalizeQuery(query)
+	result := defaultResult(query)
 
 	file, err := os.Open(path)
 	if err != nil {
@@ -65,13 +65,13 @@ func EvaluateSupportMatrix(path string, query SupportMatrixQuery) (SupportMatrix
 		}
 		fields := strings.Split(line, "\t")
 		if !headerSeen {
-			if err := validateSupportMatrixHeader(path, lineNo, fields); err != nil {
+			if err := validateHeader(path, lineNo, fields); err != nil {
 				return result, err
 			}
 			headerSeen = true
 			continue
 		}
-		entry, err := parseSupportMatrixEntry(path, lineNo, fields)
+		entry, err := parseEntry(path, lineNo, fields)
 		if err != nil {
 			return result, err
 		}
@@ -88,7 +88,7 @@ func EvaluateSupportMatrix(path string, query SupportMatrixQuery) (SupportMatrix
 	return result, nil
 }
 
-func SupportMatrixMetadataLines(result SupportMatrixResult) []string {
+func MetadataLines(result Result) []string {
 	return []string{
 		fmt.Sprintf("host_os=%s", result.HostOS),
 		fmt.Sprintf("host_arch=%s", result.HostArch),
@@ -100,7 +100,7 @@ func SupportMatrixMetadataLines(result SupportMatrixResult) []string {
 	}
 }
 
-func normalizeSupportMatrixQuery(query SupportMatrixQuery) SupportMatrixQuery {
+func normalizeQuery(query Query) Query {
 	query.HostOS = strings.TrimSpace(query.HostOS)
 	query.HostArch = strings.TrimSpace(query.HostArch)
 	query.TargetKind = strings.TrimSpace(query.TargetKind)
@@ -109,8 +109,8 @@ func normalizeSupportMatrixQuery(query SupportMatrixQuery) SupportMatrixQuery {
 	return query
 }
 
-func defaultSupportMatrixResult(query SupportMatrixQuery) SupportMatrixResult {
-	return SupportMatrixResult{
+func defaultResult(query Query) Result {
+	return Result{
 		HostOS:               query.HostOS,
 		HostArch:             query.HostArch,
 		TargetKind:           query.TargetKind,
@@ -124,11 +124,11 @@ func defaultSupportMatrixResult(query SupportMatrixQuery) SupportMatrixResult {
 	}
 }
 
-func validateSupportMatrixHeader(path string, lineNo int, fields []string) error {
-	if len(fields) != len(supportMatrixColumns) {
-		return fmt.Errorf("%s:%d: expected %d tab-separated columns in header, got %d", path, lineNo, len(supportMatrixColumns), len(fields))
+func validateHeader(path string, lineNo int, fields []string) error {
+	if len(fields) != len(columns) {
+		return fmt.Errorf("%s:%d: expected %d tab-separated columns in header, got %d", path, lineNo, len(columns), len(fields))
 	}
-	for idx, want := range supportMatrixColumns {
+	for idx, want := range columns {
 		if fields[idx] != want {
 			return fmt.Errorf("%s:%d: header column %d must be %q, got %q", path, lineNo, idx+1, want, fields[idx])
 		}
@@ -136,12 +136,12 @@ func validateSupportMatrixHeader(path string, lineNo int, fields []string) error
 	return nil
 }
 
-func parseSupportMatrixEntry(path string, lineNo int, fields []string) (SupportMatrixResult, error) {
-	if len(fields) != len(supportMatrixColumns) {
-		return SupportMatrixResult{}, fmt.Errorf("%s:%d: expected %d tab-separated columns, got %d", path, lineNo, len(supportMatrixColumns), len(fields))
+func parseEntry(path string, lineNo int, fields []string) (Result, error) {
+	if len(fields) != len(columns) {
+		return Result{}, fmt.Errorf("%s:%d: expected %d tab-separated columns, got %d", path, lineNo, len(columns), len(fields))
 	}
 
-	entry := SupportMatrixResult{
+	entry := Result{
 		HostOS:               strings.TrimSpace(fields[0]),
 		HostArch:             strings.TrimSpace(fields[1]),
 		TargetKind:           strings.TrimSpace(fields[2]),
@@ -170,38 +170,38 @@ func parseSupportMatrixEntry(path string, lineNo int, fields []string) (SupportM
 		{name: "reason", value: entry.Reason},
 	} {
 		if pair.value == "" {
-			return SupportMatrixResult{}, fmt.Errorf("%s:%d: %s may not be empty", path, lineNo, pair.name)
+			return Result{}, fmt.Errorf("%s:%d: %s may not be empty", path, lineNo, pair.name)
 		}
 	}
 
 	switch entry.Status {
 	case "supported", "validation-host-only", "preview-only", "unsupported":
 	default:
-		return SupportMatrixResult{}, fmt.Errorf("%s:%d: unsupported status %q", path, lineNo, entry.Status)
+		return Result{}, fmt.Errorf("%s:%d: unsupported status %q", path, lineNo, entry.Status)
 	}
 	switch entry.Launch {
 	case "allowed", "blocked":
 	default:
-		return SupportMatrixResult{}, fmt.Errorf("%s:%d: unsupported launch value %q", path, lineNo, entry.Launch)
+		return Result{}, fmt.Errorf("%s:%d: unsupported launch value %q", path, lineNo, entry.Launch)
 	}
 	switch entry.Evidence {
 	case "repo-required", "certification-only", "manual-only", "none":
 	default:
-		return SupportMatrixResult{}, fmt.Errorf("%s:%d: unsupported evidence value %q", path, lineNo, entry.Evidence)
+		return Result{}, fmt.Errorf("%s:%d: unsupported evidence value %q", path, lineNo, entry.Evidence)
 	}
 	if entry.ValidationLane == "none" && entry.Status == "validation-host-only" {
-		return SupportMatrixResult{}, fmt.Errorf("%s:%d: validation-host-only rows must name a validation_lane", path, lineNo)
+		return Result{}, fmt.Errorf("%s:%d: validation-host-only rows must name a validation_lane", path, lineNo)
 	}
 	if entry.ValidationLane != "none" && (entry.Status == "supported" || entry.Status == "preview-only") {
-		return SupportMatrixResult{}, fmt.Errorf("%s:%d: supported launch rows must not set a validation-only lane", path, lineNo)
+		return Result{}, fmt.Errorf("%s:%d: supported launch rows must not set a validation-only lane", path, lineNo)
 	}
 	if entry.Status == "preview-only" && entry.Launch != "blocked" {
-		return SupportMatrixResult{}, fmt.Errorf("%s:%d: preview-only rows must set launch=blocked", path, lineNo)
+		return Result{}, fmt.Errorf("%s:%d: preview-only rows must set launch=blocked", path, lineNo)
 	}
 	return entry, nil
 }
 
-func (entry SupportMatrixResult) matches(query SupportMatrixQuery) bool {
+func (entry Result) matches(query Query) bool {
 	return entry.HostOS == query.HostOS &&
 		entry.HostArch == query.HostArch &&
 		entry.TargetKind == query.TargetKind &&

--- a/internal/host/supportmatrix/supportmatrix_test.go
+++ b/internal/host/supportmatrix/supportmatrix_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Omkhar Arasaratnam
 
-package hostutil
+package supportmatrix
 
 import (
 	"os"
@@ -10,11 +10,11 @@ import (
 	"testing"
 )
 
-func TestEvaluateSupportMatrixMatchesReviewedRow(t *testing.T) {
+func TestEvaluateMatchesReviewedRow(t *testing.T) {
 	t.Parallel()
 
 	path := writeSupportMatrixFixture(t)
-	result, err := EvaluateSupportMatrix(path, SupportMatrixQuery{
+	result, err := Evaluate(path, Query{
 		HostOS:               "macos",
 		HostArch:             "arm64",
 		TargetKind:           "local_vm",
@@ -22,7 +22,7 @@ func TestEvaluateSupportMatrixMatchesReviewedRow(t *testing.T) {
 		TargetAssuranceClass: "strict",
 	})
 	if err != nil {
-		t.Fatalf("EvaluateSupportMatrix() error = %v", err)
+		t.Fatalf("Evaluate() error = %v", err)
 	}
 	if result.Status != "supported" {
 		t.Fatalf("status = %q, want supported", result.Status)
@@ -38,11 +38,11 @@ func TestEvaluateSupportMatrixMatchesReviewedRow(t *testing.T) {
 	}
 }
 
-func TestEvaluateSupportMatrixReturnsValidationHostLane(t *testing.T) {
+func TestEvaluateReturnsValidationHostLane(t *testing.T) {
 	t.Parallel()
 
 	path := writeSupportMatrixFixture(t)
-	result, err := EvaluateSupportMatrix(path, SupportMatrixQuery{
+	result, err := Evaluate(path, Query{
 		HostOS:               "linux",
 		HostArch:             "amd64",
 		TargetKind:           "local_vm",
@@ -50,7 +50,7 @@ func TestEvaluateSupportMatrixReturnsValidationHostLane(t *testing.T) {
 		TargetAssuranceClass: "strict",
 	})
 	if err != nil {
-		t.Fatalf("EvaluateSupportMatrix() error = %v", err)
+		t.Fatalf("Evaluate() error = %v", err)
 	}
 	if result.Status != "validation-host-only" {
 		t.Fatalf("status = %q, want validation-host-only", result.Status)
@@ -66,7 +66,7 @@ func TestEvaluateSupportMatrixReturnsValidationHostLane(t *testing.T) {
 	}
 }
 
-func TestEvaluateSupportMatrixReturnsPreviewOnlyRow(t *testing.T) {
+func TestEvaluateReturnsPreviewOnlyRow(t *testing.T) {
 	t.Parallel()
 
 	path := writeSupportMatrixFixture(t)
@@ -75,7 +75,7 @@ func TestEvaluateSupportMatrixReturnsPreviewOnlyRow(t *testing.T) {
 		t.Run(provider, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := EvaluateSupportMatrix(path, SupportMatrixQuery{
+			result, err := Evaluate(path, Query{
 				HostOS:               "macos",
 				HostArch:             "arm64",
 				TargetKind:           "remote_vm",
@@ -83,7 +83,7 @@ func TestEvaluateSupportMatrixReturnsPreviewOnlyRow(t *testing.T) {
 				TargetAssuranceClass: "compat",
 			})
 			if err != nil {
-				t.Fatalf("EvaluateSupportMatrix() error = %v", err)
+				t.Fatalf("Evaluate() error = %v", err)
 			}
 			if result.Status != "preview-only" {
 				t.Fatalf("status = %q, want preview-only", result.Status)
@@ -101,11 +101,11 @@ func TestEvaluateSupportMatrixReturnsPreviewOnlyRow(t *testing.T) {
 	}
 }
 
-func TestEvaluateSupportMatrixDefaultsToUnsupported(t *testing.T) {
+func TestEvaluateDefaultsToUnsupported(t *testing.T) {
 	t.Parallel()
 
 	path := writeSupportMatrixFixture(t)
-	result, err := EvaluateSupportMatrix(path, SupportMatrixQuery{
+	result, err := Evaluate(path, Query{
 		HostOS:               "windows",
 		HostArch:             "amd64",
 		TargetKind:           "local_vm",
@@ -113,7 +113,7 @@ func TestEvaluateSupportMatrixDefaultsToUnsupported(t *testing.T) {
 		TargetAssuranceClass: "strict",
 	})
 	if err != nil {
-		t.Fatalf("EvaluateSupportMatrix() error = %v", err)
+		t.Fatalf("Evaluate() error = %v", err)
 	}
 	if result.Status != "unsupported" {
 		t.Fatalf("status = %q, want unsupported", result.Status)
@@ -132,7 +132,7 @@ func TestEvaluateSupportMatrixDefaultsToUnsupported(t *testing.T) {
 	}
 }
 
-func TestEvaluateSupportMatrixRejectsInvalidRows(t *testing.T) {
+func TestEvaluateRejectsInvalidRows(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -144,7 +144,7 @@ func TestEvaluateSupportMatrixRejectsInvalidRows(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := EvaluateSupportMatrix(path, SupportMatrixQuery{
+	_, err := Evaluate(path, Query{
 		HostOS:               "linux",
 		HostArch:             "amd64",
 		TargetKind:           "local_vm",
@@ -152,7 +152,7 @@ func TestEvaluateSupportMatrixRejectsInvalidRows(t *testing.T) {
 		TargetAssuranceClass: "strict",
 	})
 	if err == nil || !strings.Contains(err.Error(), "validation-host-only rows must name a validation_lane") {
-		t.Fatalf("EvaluateSupportMatrix() error = %v, want validation-lane rejection", err)
+		t.Fatalf("Evaluate() error = %v, want validation-lane rejection", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Continues the \`internal/hostutil\` split started in #201 (release). The support-matrix evaluator and TSV parser move into a focused \`internal/host/supportmatrix\` package, matching /sethify decision D7 to break the hostutil god-package into per-concern subpackages.

**Moved files (git rename-detected):**
- \`internal/hostutil/support_matrix.go\` → \`internal/host/supportmatrix/supportmatrix.go\`
- \`internal/hostutil/support_matrix_test.go\` → \`internal/host/supportmatrix/supportmatrix_test.go\`

**Renamed exported symbols** to match the new package convention (the \`SupportMatrix\` prefix is redundant once the package is named \`supportmatrix\`):
- \`SupportMatrixQuery\` → \`Query\`
- \`SupportMatrixResult\` → \`Result\`
- \`EvaluateSupportMatrix\` → \`Evaluate\`
- \`SupportMatrixMetadataLines\` → \`MetadataLines\`
- (4 unexported helpers also slimmed)

Updated \`cmd/workcell-hostutil/main.go\` to import the new package and call \`supportmatrix.Evaluate\` / \`supportmatrix.MetadataLines\` instead of the hostutil-prefixed names. The launcher subcommand \`support-matrix-eval\` still routes through unchanged argv.

Relates to /sethify Run-1 Code Quality 🟡 (hostutil mixed concerns).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green (the \`supportmatrix\` package's 5 tests still pass)
- [x] \`gofmt -l .\` empty
- [ ] CI will run full pre-merge validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)