### PR TITLE
Extract sessions package into internal/host/sessions (3 of hostutil split series)

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/omkhar/workcell/internal/host/release"
+	"github.com/omkhar/workcell/internal/host/sessions"
 	"github.com/omkhar/workcell/internal/host/supportmatrix"
 	"github.com/omkhar/workcell/internal/hostutil"
 )
@@ -210,7 +211,7 @@ func runLauncher(args []string) error {
 			}
 			updates[key] = value
 		}
-		return hostutil.WriteSessionRecord(args[1], updates)
+		return sessions.WriteSessionRecord(args[1], updates)
 	case "session-list":
 		return runLauncherSessionList(args[1:])
 	case "session-show":
@@ -408,7 +409,7 @@ func runLauncherSessionList(args []string) error {
 
 	format := "lines"
 	verbose := false
-	opts := hostutil.SessionListOptions{}
+	opts := sessions.SessionListOptions{}
 	for _, arg := range rest {
 		switch {
 		case arg == "--json":
@@ -427,7 +428,7 @@ func runLauncherSessionList(args []string) error {
 		return fmt.Errorf("session-list accepts either --json or --verbose, not both")
 	}
 
-	records, err := hostutil.ListSessionRecordsInRoots(roots, opts)
+	records, err := sessions.ListSessionRecordsInRoots(roots, opts)
 	if err != nil {
 		return err
 	}
@@ -445,19 +446,19 @@ func runLauncherSessionList(args []string) error {
 				"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 				record.SessionID,
 				record.Status,
-				hostutil.SessionDisplayLiveStatus(record),
-				hostutil.SessionControlMode(record),
+				sessions.SessionDisplayLiveStatus(record),
+				sessions.SessionControlMode(record),
 				record.Agent,
 				record.Mode,
 				record.Profile,
-				hostutil.SessionTargetSummary(record),
+				sessions.SessionTargetSummary(record),
 				record.TargetAssuranceClass,
 				record.WorkspaceTransport,
-				hostutil.SessionDisplayGitBranch(record),
-				hostutil.SessionDisplayWorktree(record),
+				sessions.SessionDisplayGitBranch(record),
+				sessions.SessionDisplayWorktree(record),
 				record.StartedAt,
-				hostutil.SessionAssuranceSummary(record),
-				hostutil.SessionDisplayWorkspace(record),
+				sessions.SessionAssuranceSummary(record),
+				sessions.SessionDisplayWorkspace(record),
 			)
 			continue
 		}
@@ -465,14 +466,14 @@ func runLauncherSessionList(args []string) error {
 			"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			record.SessionID,
 			record.Status,
-			hostutil.SessionDisplayLiveStatus(record),
-			hostutil.SessionControlMode(record),
+			sessions.SessionDisplayLiveStatus(record),
+			sessions.SessionControlMode(record),
 			record.Agent,
 			record.Mode,
 			record.Profile,
 			record.StartedAt,
-			hostutil.SessionAssuranceSummary(record),
-			hostutil.SessionDisplayWorkspace(record),
+			sessions.SessionAssuranceSummary(record),
+			sessions.SessionDisplayWorkspace(record),
 		)
 	}
 	return nil
@@ -494,12 +495,12 @@ func runLauncherSessionShow(args []string) error {
 		}
 		format = "text"
 	}
-	record, err := hostutil.FindSessionRecordInRoots(roots, rest[0])
+	record, err := sessions.FindSessionRecordInRoots(roots, rest[0])
 	if err != nil {
 		return err
 	}
 	if format == "text" {
-		for _, line := range hostutil.SessionShowLines(record) {
+		for _, line := range sessions.SessionShowLines(record) {
 			fmt.Println(line)
 		}
 		return nil
@@ -521,7 +522,7 @@ func runLauncherSessionExport(args []string) error {
 		return launcherUsage()
 	}
 
-	exported, err := hostutil.ExportSessionRecordInRoots(roots, rest[0])
+	exported, err := sessions.ExportSessionRecordInRoots(roots, rest[0])
 	if err != nil {
 		return err
 	}
@@ -542,11 +543,11 @@ func runLauncherSessionDiffMetadata(args []string) error {
 		return launcherUsage()
 	}
 
-	record, err := hostutil.FindSessionRecordInRoots(roots, rest[0])
+	record, err := sessions.FindSessionRecordInRoots(roots, rest[0])
 	if err != nil {
 		return err
 	}
-	for _, line := range hostutil.SessionDiffMetadataLines(record) {
+	for _, line := range sessions.SessionDiffMetadataLines(record) {
 		fmt.Println(line)
 	}
 	return nil
@@ -561,11 +562,11 @@ func runLauncherSessionRuntimeMetadata(args []string) error {
 		return launcherUsage()
 	}
 
-	record, recordPath, err := hostutil.FindSessionRecordWithPathInRoots(roots, rest[0])
+	record, recordPath, err := sessions.FindSessionRecordWithPathInRoots(roots, rest[0])
 	if err != nil {
 		return err
 	}
-	for _, line := range hostutil.SessionRuntimeMetadataLines(record) {
+	for _, line := range sessions.SessionRuntimeMetadataLines(record) {
 		fmt.Println(line)
 	}
 	fmt.Printf("record_path=%s\n", recordPath)
@@ -581,7 +582,7 @@ func runLauncherSessionTimeline(args []string) error {
 		return launcherUsage()
 	}
 
-	lines, err := hostutil.SessionTimelineRecordsInRoots(roots, rest[0])
+	lines, err := sessions.SessionTimelineRecordsInRoots(roots, rest[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/workcell-hostutil/main_test.go
+++ b/cmd/workcell-hostutil/main_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omkhar/workcell/internal/host/sessions"
 	"github.com/omkhar/workcell/internal/hostutil"
 )
 
@@ -28,7 +29,7 @@ func TestRunLauncherSessionTimeline(t *testing.T) {
 	}
 
 	sessionPath := filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json")
-	if err := hostutil.WriteSessionRecord(sessionPath, map[string]string{
+	if err := sessions.WriteSessionRecord(sessionPath, map[string]string{
 		"session_id":      "session-1",
 		"profile":         "wcl-one",
 		"agent":           "codex",
@@ -82,7 +83,7 @@ func TestRunLauncherSessionTimeline(t *testing.T) {
 func TestRunLauncherSessionRuntimeMetadata(t *testing.T) {
 	colimaRoot := t.TempDir()
 	sessionPath := filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json")
-	if err := hostutil.WriteSessionRecord(sessionPath, map[string]string{
+	if err := sessions.WriteSessionRecord(sessionPath, map[string]string{
 		"session_id":          "session-1",
 		"profile":             "wcl-one",
 		"agent":               "codex",
@@ -153,7 +154,7 @@ func TestRunLauncherSessionRuntimeMetadataSupportsMultipleRoots(t *testing.T) {
 	stateRoot := t.TempDir()
 	legacyRoot := t.TempDir()
 	sessionPath := filepath.Join(stateRoot, "targets", "local_vm", "colima", "wcl-one", "sessions", "session-1.json")
-	if err := hostutil.WriteSessionRecord(sessionPath, map[string]string{
+	if err := sessions.WriteSessionRecord(sessionPath, map[string]string{
 		"session_id":        "session-1",
 		"profile":           "wcl-one",
 		"agent":             "codex",
@@ -208,7 +209,7 @@ func TestRunLauncherSessionRuntimeMetadataSupportsMultipleRoots(t *testing.T) {
 
 func TestRunLauncherSessionListShowsLiveStatusAndControl(t *testing.T) {
 	colimaRoot := t.TempDir()
-	if err := hostutil.WriteSessionRecord(filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json"), map[string]string{
+	if err := sessions.WriteSessionRecord(filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json"), map[string]string{
 		"session_id":        "session-1",
 		"profile":           "wcl-one",
 		"agent":             "codex",
@@ -225,7 +226,7 @@ func TestRunLauncherSessionListShowsLiveStatusAndControl(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := hostutil.WriteSessionRecord(filepath.Join(colimaRoot, "wcl-two", "sessions", "session-2.json"), map[string]string{
+	if err := sessions.WriteSessionRecord(filepath.Join(colimaRoot, "wcl-two", "sessions", "session-2.json"), map[string]string{
 		"session_id":        "session-2",
 		"profile":           "wcl-two",
 		"agent":             "claude",
@@ -281,7 +282,7 @@ func TestRunLauncherSessionListShowsLiveStatusAndControl(t *testing.T) {
 
 func TestRunLauncherSessionListVerboseShowsTargetMetadata(t *testing.T) {
 	colimaRoot := t.TempDir()
-	if err := hostutil.WriteSessionRecord(filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json"), map[string]string{
+	if err := sessions.WriteSessionRecord(filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json"), map[string]string{
 		"session_id":        "session-1",
 		"profile":           "wcl-one",
 		"agent":             "codex",
@@ -331,7 +332,7 @@ func TestRunLauncherSessionListVerboseShowsTargetMetadata(t *testing.T) {
 func TestRunLauncherSessionShowText(t *testing.T) {
 	colimaRoot := t.TempDir()
 	sessionPath := filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json")
-	if err := hostutil.WriteSessionRecord(sessionPath, map[string]string{
+	if err := sessions.WriteSessionRecord(sessionPath, map[string]string{
 		"session_id":              "session-1",
 		"profile":                 "wcl-one",
 		"agent":                   "codex",

--- a/internal/host/sessions/sessions.go
+++ b/internal/host/sessions/sessions.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Omkhar Arasaratnam
 
-package hostutil
+package sessions
 
 import (
 	"bytes"
@@ -401,6 +401,22 @@ func ReadSessionRecord(path string) (SessionRecord, error) {
 		return SessionRecord{}, err
 	}
 	return record, nil
+}
+
+func isSymlink(path string) bool {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeSymlink != 0
+}
+
+// StateDirs lists the per-profile state directories under root. Exported
+// so internal/hostutil/launcher.go can iterate them when cleaning stale
+// session log pointers and audit dirs; the cleanup helpers themselves
+// stay in launcher because they touch broader launcher state.
+func StateDirs(root string) ([]string, error) {
+	return sessionStateDirs(root)
 }
 
 func sessionStateDirs(root string) ([]string, error) {

--- a/internal/host/sessions/sessions_test.go
+++ b/internal/host/sessions/sessions_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Omkhar Arasaratnam
 
-package hostutil
+package sessions
 
 import (
 	"encoding/json"

--- a/internal/hostutil/launcher.go
+++ b/internal/hostutil/launcher.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/omkhar/workcell/internal/host/sessions"
 )
 
 var codexVersionPattern = regexp.MustCompile(`(?m)^\s*ARG CODEX_VERSION=(.+)$`)
@@ -62,7 +64,7 @@ func IsNoMatch(err error) bool {
 }
 
 func CleanupStaleLatestLogPointers(stateRoot string) error {
-	stateDirs, err := sessionStateDirs(stateRoot)
+	stateDirs, err := sessions.StateDirs(stateRoot)
 	if err != nil {
 		return err
 	}
@@ -206,7 +208,7 @@ func WriteProfileOwner(ownerPath string, pid int) error {
 }
 
 func CleanupStaleSessionAuditDirs(stateRoot string) error {
-	stateDirs, err := sessionStateDirs(stateRoot)
+	stateDirs, err := sessions.StateDirs(stateRoot)
 	if err != nil {
 		return err
 	}

--- a/internal/remotevm/conformance.go
+++ b/internal/remotevm/conformance.go
@@ -11,7 +11,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/omkhar/workcell/internal/hostutil"
+	"github.com/omkhar/workcell/internal/host/sessions"
 	"github.com/omkhar/workcell/internal/providerid"
 )
 
@@ -35,7 +35,7 @@ type ConformanceResult struct {
 	Bootstrap       BootstrapResult
 	Started         SessionResult
 	Finished        SessionResult
-	Exported        hostutil.SessionExport
+	Exported        sessions.SessionExport
 }
 
 func DefaultConformanceCase(stateRoot, sourceWorkspace string) ConformanceCase {
@@ -108,17 +108,17 @@ func RunConformance(ctx context.Context, target ConformanceTarget, contract Cont
 	if err := validateFinishedSession(contract, finished, c); err != nil {
 		return ConformanceResult{}, err
 	}
-	records, err := hostutil.ListSessionRecordsInRoots([]string{c.StateRoot}, hostutil.SessionListOptions{})
+	records, err := sessions.ListSessionRecordsInRoots([]string{c.StateRoot}, sessions.SessionListOptions{})
 	if err != nil {
 		return ConformanceResult{}, err
 	}
 	if len(records) != 1 {
 		return ConformanceResult{}, fmt.Errorf("ListSessionRecordsInRoots() len = %d, want 1", len(records))
 	}
-	if got := hostutil.SessionTargetSummary(records[0]); got != fmt.Sprintf("%s/%s/%s", contract.TargetKind, contract.TargetProvider, c.TargetID) {
+	if got := sessions.SessionTargetSummary(records[0]); got != fmt.Sprintf("%s/%s/%s", contract.TargetKind, contract.TargetProvider, c.TargetID) {
 		return ConformanceResult{}, fmt.Errorf("SessionTargetSummary() = %q", got)
 	}
-	exported, err := hostutil.ExportSessionRecordInRoots([]string{c.StateRoot}, c.SessionID)
+	exported, err := sessions.ExportSessionRecordInRoots([]string{c.StateRoot}, c.SessionID)
 	if err != nil {
 		return ConformanceResult{}, err
 	}

--- a/internal/remotevm/conformance_test.go
+++ b/internal/remotevm/conformance_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/omkhar/workcell/internal/hostutil"
+	"github.com/omkhar/workcell/internal/host/sessions"
 )
 
 func TestRunConformanceWithFakeTarget(t *testing.T) {
@@ -29,7 +29,7 @@ func TestRunConformanceWithFakeTarget(t *testing.T) {
 	if got, want := result.Exported.Session.WorkspaceTransport, "remote-materialization"; got != want {
 		t.Fatalf("exported session workspace_transport = %q, want %q", got, want)
 	}
-	if got, want := hostutil.SessionTargetSummary(result.Exported.Session), "remote_vm/fake-remote/"+caseSpec.TargetID; got != want {
+	if got, want := sessions.SessionTargetSummary(result.Exported.Session), "remote_vm/fake-remote/"+caseSpec.TargetID; got != want {
 		t.Fatalf("target summary = %q, want %q", got, want)
 	}
 }
@@ -50,7 +50,7 @@ func TestRunConformanceWithAWSEC2SSMTarget(t *testing.T) {
 	if got, want := result.Exported.Session.TargetProvider, AWSEC2SSMProvider; got != want {
 		t.Fatalf("exported session target_provider = %q, want %q", got, want)
 	}
-	if got, want := hostutil.SessionTargetSummary(result.Exported.Session), "remote_vm/aws-ec2-ssm/"+caseSpec.TargetID; got != want {
+	if got, want := sessions.SessionTargetSummary(result.Exported.Session), "remote_vm/aws-ec2-ssm/"+caseSpec.TargetID; got != want {
 		t.Fatalf("target summary = %q, want %q", got, want)
 	}
 	if got, want := filepath.Base(filepath.Dir(result.Materialization.TargetRoot)), AWSEC2SSMProvider; got != want {
@@ -74,7 +74,7 @@ func TestRunConformanceWithGCPVMTarget(t *testing.T) {
 	if got, want := result.Exported.Session.TargetProvider, GCPVMProvider; got != want {
 		t.Fatalf("exported session target_provider = %q, want %q", got, want)
 	}
-	if got, want := hostutil.SessionTargetSummary(result.Exported.Session), "remote_vm/gcp-vm/"+caseSpec.TargetID; got != want {
+	if got, want := sessions.SessionTargetSummary(result.Exported.Session), "remote_vm/gcp-vm/"+caseSpec.TargetID; got != want {
 		t.Fatalf("target summary = %q, want %q", got, want)
 	}
 	if got, want := filepath.Base(filepath.Dir(result.Materialization.TargetRoot)), GCPVMProvider; got != want {

--- a/internal/remotevm/fake_target.go
+++ b/internal/remotevm/fake_target.go
@@ -16,7 +16,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/omkhar/workcell/internal/hostutil"
+	"github.com/omkhar/workcell/internal/host/sessions"
 )
 
 type WorkspaceEntry struct {
@@ -98,7 +98,7 @@ type FinishSessionRequest struct {
 }
 
 type SessionResult struct {
-	Record       hostutil.SessionRecord
+	Record       sessions.SessionRecord
 	RecordPath   string
 	AuditLogPath string
 }
@@ -252,7 +252,7 @@ func (f FakeTarget) StartSession(_ context.Context, req StartSessionRequest) (Se
 		return SessionResult{}, err
 	}
 	recordPath := filepath.Join(req.Bootstrap.TargetRoot, "sessions", sessionID+".json")
-	record := hostutil.SessionRecord{
+	record := sessions.SessionRecord{
 		Version:               1,
 		SessionID:             sessionID,
 		Profile:               req.Bootstrap.Manifest.TargetID,
@@ -276,7 +276,7 @@ func (f FakeTarget) StartSession(_ context.Context, req StartSessionRequest) (Se
 		CurrentAssurance:      f.Contract.Session.Assurance,
 		WorkspaceControlPlane: f.Contract.Session.WorkspaceControlPlane,
 	}
-	if err := hostutil.WriteSessionRecord(recordPath, map[string]string{
+	if err := sessions.WriteSessionRecord(recordPath, map[string]string{
 		"session_id":              record.SessionID,
 		"profile":                 record.Profile,
 		"target_kind":             record.TargetKind,
@@ -310,7 +310,7 @@ func (f FakeTarget) StartSession(_ context.Context, req StartSessionRequest) (Se
 			return SessionResult{}, err
 		}
 	}
-	record, err = hostutil.ReadSessionRecord(recordPath)
+	record, err = sessions.ReadSessionRecord(recordPath)
 	if err != nil {
 		return SessionResult{}, err
 	}
@@ -327,7 +327,7 @@ func (f FakeTarget) FinishSession(_ context.Context, req FinishSessionRequest) (
 	if req.Started.RecordPath == "" {
 		return SessionResult{}, fmt.Errorf("started session record path is required")
 	}
-	if err := hostutil.WriteSessionRecord(req.Started.RecordPath, map[string]string{
+	if err := sessions.WriteSessionRecord(req.Started.RecordPath, map[string]string{
 		"status":            f.Contract.Session.FinalStatus,
 		"live_status":       "stopped",
 		"observed_at":       req.FinishedAt,
@@ -341,7 +341,7 @@ func (f FakeTarget) FinishSession(_ context.Context, req FinishSessionRequest) (
 	if err := appendAuditLine(req.Started.AuditLogPath, fmt.Sprintf("ts=%s session_id=%s event=session_finished target_kind=%s target_provider=%s target_id=%s status=%s exit_status=%s", req.FinishedAt, req.Started.Record.SessionID, f.Contract.TargetKind, f.Contract.TargetProvider, req.Started.Record.TargetID, f.Contract.Session.FinalStatus, req.ExitStatus)); err != nil {
 		return SessionResult{}, err
 	}
-	record, err := hostutil.ReadSessionRecord(req.Started.RecordPath)
+	record, err := sessions.ReadSessionRecord(req.Started.RecordPath)
 	if err != nil {
 		return SessionResult{}, err
 	}

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -145,7 +145,7 @@ workflows = [
 ]
 evidence = [
   "tests/scenarios/shared/test-session-commands.sh",
-  "internal/hostutil/sessions_test.go",
+  "internal/host/sessions/sessions_test.go",
 ]
 docs = [
   "README.md",


### PR DESCRIPTION
## Summary

Continues the \`internal/hostutil\` split started in #201 (release) and #203 (supportmatrix). The full session-record model + read/write/list/export/timeline helpers move into a focused \`internal/host/sessions\` package.

**Moved files (git rename-detected):**
- \`internal/hostutil/sessions.go\` → \`internal/host/sessions/sessions.go\`
- \`internal/hostutil/sessions_test.go\` → \`internal/host/sessions/sessions_test.go\`

**Cross-package coupling resolved:**
- \`sessions.go\` used \`hostutil.isSymlink\`; copied the 7-line helper into the sessions package since it's a trivial primitive.
- \`internal/hostutil/launcher.go\` (\`CleanupStaleLatestLogPointers\` and \`CleanupStaleSessionAuditDirs\`) called the unexported \`sessionStateDirs\` from sessions. Exposed \`sessions.StateDirs\` as the public entry point and updated the two launcher callers.

Updated 27 session-symbol references across the callers (\`cmd/workcell-hostutil\`, \`internal/remotevm/*\`) from \`hostutil.X\` to \`sessions.X\`. Dropped now-unused \`hostutil\` imports from the three remotevm files (sessions was the only thing they used).

\`internal/hostutil\` shrinks from 4 source files to 2 (\`hostutil.go\` + \`launcher.go\`).

Relates to /sethify Run-1 Code Quality 🟡 (hostutil mixed concerns).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green (all 21 packages including the new \`internal/host/sessions\`)
- [x] \`gofmt -l .\` empty
- [ ] CI will run full pre-merge validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)