### PR TITLE
^R Extract Colima + profile-lock cluster into internal/host/launcher

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/omkhar/workcell/internal/host/launcher"
 	"github.com/omkhar/workcell/internal/host/release"
 	"github.com/omkhar/workcell/internal/host/sessions"
 	"github.com/omkhar/workcell/internal/host/supportmatrix"
@@ -124,7 +125,7 @@ func runLauncher(args []string) error {
 		if len(args) != 1 {
 			return launcherUsage()
 		}
-		value, err := hostutil.RandomHex(4)
+		value, err := launcher.RandomHex(4)
 		if err != nil {
 			return err
 		}
@@ -138,9 +139,9 @@ func runLauncher(args []string) error {
 		if err != nil {
 			return err
 		}
-		status, statusErr := hostutil.ColimaProfileStatus(input, args[1])
+		status, statusErr := launcher.ColimaProfileStatus(input, args[1])
 		if statusErr != nil {
-			if hostutil.IsNoMatch(statusErr) {
+			if launcher.IsNoMatch(statusErr) {
 				fmt.Fprintln(os.Stderr, statusErr)
 				os.Exit(3)
 			}
@@ -157,7 +158,7 @@ func runLauncher(args []string) error {
 		if len(args) != 2 {
 			return launcherUsage()
 		}
-		stale, err := hostutil.ProfileLockIsStale(args[1])
+		stale, err := launcher.ProfileLockIsStale(args[1])
 		if err != nil {
 			return err
 		}
@@ -175,7 +176,7 @@ func runLauncher(args []string) error {
 		if err != nil {
 			return fmt.Errorf("parse pid: %w", err)
 		}
-		acquired, err := hostutil.AcquireProfileLock(args[1], pid)
+		acquired, err := launcher.AcquireProfileLock(args[1], pid)
 		if err != nil {
 			return err
 		}
@@ -193,7 +194,7 @@ func runLauncher(args []string) error {
 		if err != nil {
 			return fmt.Errorf("parse pid: %w", err)
 		}
-		return hostutil.WriteProfileOwner(args[1], pid)
+		return launcher.WriteProfileOwner(args[1], pid)
 	case "cleanup-stale-session-audit-dirs":
 		if len(args) != 2 {
 			return launcherUsage()

--- a/internal/host/launcher/doc.go
+++ b/internal/host/launcher/doc.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package launcher provides host-side primitives for managing the
+// Colima/profile lifecycle: profile status inspection, per-profile lock
+// acquisition, random session-suffix generation, and process-aliveness
+// checks shared across the launcher control plane.
+package launcher

--- a/internal/host/launcher/launcher.go
+++ b/internal/host/launcher/launcher.go
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package launcher
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+var errNoMatch = errors.New("not found")
+
+func RandomHex(n int) (string, error) {
+	if n <= 0 {
+		return "", errors.New("random hex size must be positive")
+	}
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func IsNoMatch(err error) bool {
+	return errors.Is(err, errNoMatch)
+}
+
+func ColimaProfileStatus(listJSON []byte, profile string) (string, error) {
+	records, err := decodeJSONObjectSequence(listJSON)
+	if err != nil {
+		return "", err
+	}
+	for _, record := range records {
+		name, _ := record["name"].(string)
+		if name != profile {
+			continue
+		}
+		status, _ := record["status"].(string)
+		if status == "" {
+			return "", errors.New("profile status missing status field")
+		}
+		return status, nil
+	}
+	return "", errNoMatch
+}
+
+func ProfileLockIsStale(lockDir string) (bool, error) {
+	ownerPath := filepath.Join(lockDir, "owner.json")
+	content, err := os.ReadFile(ownerPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+		return false, err
+	}
+
+	var owner struct {
+		PID     int    `json:"pid"`
+		Started string `json:"started"`
+	}
+	if err := json.Unmarshal(content, &owner); err != nil {
+		return false, fmt.Errorf("parse profile lock owner metadata: %w", err)
+	}
+	if owner.PID <= 0 || owner.Started == "" {
+		return false, fmt.Errorf("profile lock owner metadata is incomplete: %s", ownerPath)
+	}
+
+	if err := syscall.Kill(owner.PID, 0); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return true, nil
+		}
+		return false, err
+	}
+
+	observed, err := ProcessStartTime(owner.PID)
+	if err != nil {
+		if killErr := syscall.Kill(owner.PID, 0); killErr != nil {
+			if errors.Is(killErr, syscall.ESRCH) {
+				return true, nil
+			}
+			return false, killErr
+		}
+		return false, err
+	}
+	return observed != owner.Started, nil
+}
+
+func AcquireProfileLock(lockDir string, pid int) (bool, error) {
+	parentDir := filepath.Dir(lockDir)
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return false, err
+	}
+
+	tempDir, err := os.MkdirTemp(parentDir, filepath.Base(lockDir)+".pending.")
+	if err != nil {
+		return false, err
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.RemoveAll(tempDir)
+		}
+	}()
+
+	if err := WriteProfileOwner(filepath.Join(tempDir, "owner.json"), pid); err != nil {
+		return false, err
+	}
+	if err := os.Rename(tempDir, lockDir); err != nil {
+		if errors.Is(err, os.ErrExist) || errors.Is(err, syscall.EEXIST) || errors.Is(err, syscall.ENOTEMPTY) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	cleanup = false
+	return true, nil
+}
+
+func WriteProfileOwner(ownerPath string, pid int) error {
+	started, err := ProcessStartTime(pid)
+	if err != nil {
+		return err
+	}
+	payload := map[string]any{
+		"pid":     pid,
+		"started": started,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(ownerPath), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(ownerPath, data, 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(ownerPath, 0o600)
+}
+
+// ProcessStartTime returns the `ps -o lstart=` value for pid, or an error
+// satisfying IsProcessGone if pid no longer exists.
+func ProcessStartTime(pid int) (string, error) {
+	cmd := exec.Command("ps", "-o", "lstart=", "-p", strconv.Itoa(pid))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// `ps -p PID` exits non-zero with empty output when the
+		// process does not exist. Distinguish that from other failures
+		// (PATH issue, permissions, transient ps error) so callers can
+		// decide whether the process is definitively gone vs unknown.
+		if exitErr, ok := err.(*exec.ExitError); ok && len(strings.TrimSpace(string(output))) == 0 && len(exitErr.Stderr) == 0 {
+			return "", processGoneErr{pid: pid}
+		}
+		return "", err
+	}
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return "", processGoneErr{pid: pid}
+	}
+	return trimmed, nil
+}
+
+// IsProcessGone reports whether err came from ProcessStartTime because
+// the target PID could not be observed (process has exited).
+func IsProcessGone(err error) bool {
+	var gone processGoneErr
+	return errors.As(err, &gone)
+}
+
+type processGoneErr struct {
+	pid int
+}
+
+func (e processGoneErr) Error() string {
+	return fmt.Sprintf("process %d not found", e.pid)
+}
+
+func decodeJSONObjectSequence(raw []byte) ([]map[string]any, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, errNoMatch
+	}
+
+	if trimmed[0] == '[' {
+		var records []map[string]any
+		if err := json.Unmarshal(trimmed, &records); err != nil {
+			return nil, err
+		}
+		return records, nil
+	}
+
+	var records []map[string]any
+	for _, line := range bytes.Split(trimmed, []byte{'\n'}) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal(line, &record); err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return records, nil
+}

--- a/internal/host/launcher/launcher_test.go
+++ b/internal/host/launcher/launcher_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package launcher
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestColimaProfileStatusMissingProfileReturnsNoMatch(t *testing.T) {
+	t.Parallel()
+	input := []byte(strings.Join([]string{
+		`{"name":"default","status":"Running"}`,
+		`{"name":"workcell-test","status":"Stopped"}`,
+		"",
+	}, "\n"))
+
+	_, err := ColimaProfileStatus(input, "does-not-exist")
+	if !IsNoMatch(err) {
+		t.Fatalf("ColimaProfileStatus() err = %v, want IsNoMatch", err)
+	}
+}
+
+func TestProfileLockIsStaleReportsMalformedOwnerMetadata(t *testing.T) {
+	t.Parallel()
+	lockDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stale, err := ProfileLockIsStale(lockDir)
+	if err == nil {
+		t.Fatal("ProfileLockIsStale() error = nil, want parse error")
+	}
+	if stale {
+		t.Fatal("ProfileLockIsStale() stale = true, want false on malformed owner metadata")
+	}
+}
+
+func TestProfileLockIsStaleReportsIncompleteOwnerMetadata(t *testing.T) {
+	t.Parallel()
+	lockDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), []byte(`{"pid":`+strconv.Itoa(os.Getpid())+`}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stale, err := ProfileLockIsStale(lockDir)
+	if err == nil {
+		t.Fatal("ProfileLockIsStale() error = nil, want incomplete metadata error")
+	}
+	if stale {
+		t.Fatal("ProfileLockIsStale() stale = true, want false on incomplete owner metadata")
+	}
+}
+
+func TestProfileLockIsStaleRecognizesLiveOwner(t *testing.T) {
+	t.Parallel()
+	lockDir := t.TempDir()
+	started, err := ProcessStartTime(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), []byte(`{"pid":`+strconv.Itoa(os.Getpid())+`,"started":"`+started+`"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stale, err := ProfileLockIsStale(lockDir)
+	if err != nil {
+		t.Fatalf("ProfileLockIsStale() error = %v", err)
+	}
+	if stale {
+		t.Fatal("ProfileLockIsStale() stale = true, want false for live owner")
+	}
+}
+
+func TestAcquireProfileLockCreatesOwnerAtomically(t *testing.T) {
+	t.Parallel()
+	lockDir := filepath.Join(t.TempDir(), "profile.lock")
+
+	acquired, err := AcquireProfileLock(lockDir, os.Getpid())
+	if err != nil {
+		t.Fatalf("AcquireProfileLock() error = %v", err)
+	}
+	if !acquired {
+		t.Fatal("AcquireProfileLock() = false, want true")
+	}
+
+	content, err := os.ReadFile(filepath.Join(lockDir, "owner.json"))
+	if err != nil {
+		t.Fatalf("read owner.json: %v", err)
+	}
+	var owner struct {
+		PID     int    `json:"pid"`
+		Started string `json:"started"`
+	}
+	if err := json.Unmarshal(content, &owner); err != nil {
+		t.Fatalf("unmarshal owner.json: %v", err)
+	}
+	if owner.PID != os.Getpid() {
+		t.Fatalf("owner PID = %d, want %d", owner.PID, os.Getpid())
+	}
+	if owner.Started == "" {
+		t.Fatal("owner.Started = empty, want process start time")
+	}
+}
+
+func TestAcquireProfileLockReturnsFalseWhenLockExists(t *testing.T) {
+	t.Parallel()
+	parent := t.TempDir()
+	lockDir := filepath.Join(parent, "profile.lock")
+	if err := os.MkdirAll(lockDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	acquired, err := AcquireProfileLock(lockDir, os.Getpid())
+	if err != nil {
+		t.Fatalf("AcquireProfileLock() error = %v", err)
+	}
+	if acquired {
+		t.Fatal("AcquireProfileLock() = true, want false for existing lock")
+	}
+
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.Contains(entry.Name(), ".pending.") {
+			t.Fatalf("temporary lock dir leaked: %s", entry.Name())
+		}
+	}
+}

--- a/internal/hostutil/hostutil_test.go
+++ b/internal/hostutil/hostutil_test.go
@@ -6,11 +6,8 @@ package hostutil
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 )
@@ -98,130 +95,6 @@ func TestDirectMountCacheKeyMatchesNULTerminatedHash(t *testing.T) {
 	want := hex.EncodeToString(sum[:8])
 	if got != want {
 		t.Fatalf("DirectMountCacheKey() = %q, want %q", got, want)
-	}
-}
-
-func TestColimaProfileStatusMissingProfileReturnsNoMatch(t *testing.T) {
-	t.Parallel()
-	input := []byte(strings.Join([]string{
-		`{"name":"default","status":"Running"}`,
-		`{"name":"workcell-test","status":"Stopped"}`,
-		"",
-	}, "\n"))
-
-	_, err := ColimaProfileStatus(input, "does-not-exist")
-	if !IsNoMatch(err) {
-		t.Fatalf("ColimaProfileStatus() err = %v, want IsNoMatch", err)
-	}
-}
-
-func TestProfileLockIsStaleReportsMalformedOwnerMetadata(t *testing.T) {
-	t.Parallel()
-	lockDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), []byte("{"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	stale, err := ProfileLockIsStale(lockDir)
-	if err == nil {
-		t.Fatal("ProfileLockIsStale() error = nil, want parse error")
-	}
-	if stale {
-		t.Fatal("ProfileLockIsStale() stale = true, want false on malformed owner metadata")
-	}
-}
-
-func TestProfileLockIsStaleReportsIncompleteOwnerMetadata(t *testing.T) {
-	t.Parallel()
-	lockDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), []byte(`{"pid":`+strconv.Itoa(os.Getpid())+`}`+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	stale, err := ProfileLockIsStale(lockDir)
-	if err == nil {
-		t.Fatal("ProfileLockIsStale() error = nil, want incomplete metadata error")
-	}
-	if stale {
-		t.Fatal("ProfileLockIsStale() stale = true, want false on incomplete owner metadata")
-	}
-}
-
-func TestProfileLockIsStaleRecognizesLiveOwner(t *testing.T) {
-	t.Parallel()
-	lockDir := t.TempDir()
-	started, err := processStartTime(os.Getpid())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), []byte(`{"pid":`+strconv.Itoa(os.Getpid())+`,"started":"`+started+`"}`+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	stale, err := ProfileLockIsStale(lockDir)
-	if err != nil {
-		t.Fatalf("ProfileLockIsStale() error = %v", err)
-	}
-	if stale {
-		t.Fatal("ProfileLockIsStale() stale = true, want false for live owner")
-	}
-}
-
-func TestAcquireProfileLockCreatesOwnerAtomically(t *testing.T) {
-	t.Parallel()
-	lockDir := filepath.Join(t.TempDir(), "profile.lock")
-
-	acquired, err := AcquireProfileLock(lockDir, os.Getpid())
-	if err != nil {
-		t.Fatalf("AcquireProfileLock() error = %v", err)
-	}
-	if !acquired {
-		t.Fatal("AcquireProfileLock() = false, want true")
-	}
-
-	content, err := os.ReadFile(filepath.Join(lockDir, "owner.json"))
-	if err != nil {
-		t.Fatalf("read owner.json: %v", err)
-	}
-	var owner struct {
-		PID     int    `json:"pid"`
-		Started string `json:"started"`
-	}
-	if err := json.Unmarshal(content, &owner); err != nil {
-		t.Fatalf("unmarshal owner.json: %v", err)
-	}
-	if owner.PID != os.Getpid() {
-		t.Fatalf("owner PID = %d, want %d", owner.PID, os.Getpid())
-	}
-	if owner.Started == "" {
-		t.Fatal("owner.Started = empty, want process start time")
-	}
-}
-
-func TestAcquireProfileLockReturnsFalseWhenLockExists(t *testing.T) {
-	t.Parallel()
-	parent := t.TempDir()
-	lockDir := filepath.Join(parent, "profile.lock")
-	if err := os.MkdirAll(lockDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	acquired, err := AcquireProfileLock(lockDir, os.Getpid())
-	if err != nil {
-		t.Fatalf("AcquireProfileLock() error = %v", err)
-	}
-	if acquired {
-		t.Fatal("AcquireProfileLock() = true, want false for existing lock")
-	}
-
-	entries, err := os.ReadDir(parent)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, entry := range entries {
-		if strings.Contains(entry.Name(), ".pending.") {
-			t.Fatalf("temporary lock dir leaked: %s", entry.Name())
-		}
 	}
 }
 

--- a/internal/hostutil/launcher.go
+++ b/internal/hostutil/launcher.go
@@ -4,9 +4,7 @@
 package hostutil
 
 import (
-	"bytes"
 	"context"
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -14,54 +12,19 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/omkhar/workcell/internal/host/launcher"
 	"github.com/omkhar/workcell/internal/host/sessions"
 )
 
 var codexVersionPattern = regexp.MustCompile(`(?m)^\s*ARG CODEX_VERSION=(.+)$`)
-
-func RandomHex(n int) (string, error) {
-	if n <= 0 {
-		return "", errors.New("random hex size must be positive")
-	}
-	buf := make([]byte, n)
-	if _, err := rand.Read(buf); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(buf), nil
-}
-
-func ColimaProfileStatus(listJSON []byte, profile string) (string, error) {
-	records, err := decodeJSONObjectSequence(listJSON)
-	if err != nil {
-		return "", err
-	}
-	for _, record := range records {
-		name, _ := record["name"].(string)
-		if name != profile {
-			continue
-		}
-		status, _ := record["status"].(string)
-		if status == "" {
-			return "", errors.New("profile status missing status field")
-		}
-		return status, nil
-	}
-	return "", errNoMatch
-}
-
-func IsNoMatch(err error) bool {
-	return errors.Is(err, errNoMatch)
-}
 
 func CleanupStaleLatestLogPointers(stateRoot string) error {
 	stateDirs, err := sessions.StateDirs(stateRoot)
@@ -110,101 +73,6 @@ func CleanupStaleLatestLogPointers(stateRoot string) error {
 		}
 	}
 	return nil
-}
-
-func ProfileLockIsStale(lockDir string) (bool, error) {
-	ownerPath := filepath.Join(lockDir, "owner.json")
-	content, err := os.ReadFile(ownerPath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return true, nil
-		}
-		return false, err
-	}
-
-	var owner struct {
-		PID     int    `json:"pid"`
-		Started string `json:"started"`
-	}
-	if err := json.Unmarshal(content, &owner); err != nil {
-		return false, fmt.Errorf("parse profile lock owner metadata: %w", err)
-	}
-	if owner.PID <= 0 || owner.Started == "" {
-		return false, fmt.Errorf("profile lock owner metadata is incomplete: %s", ownerPath)
-	}
-
-	if err := syscall.Kill(owner.PID, 0); err != nil {
-		if errors.Is(err, syscall.ESRCH) {
-			return true, nil
-		}
-		return false, err
-	}
-
-	observed, err := processStartTime(owner.PID)
-	if err != nil {
-		if killErr := syscall.Kill(owner.PID, 0); killErr != nil {
-			if errors.Is(killErr, syscall.ESRCH) {
-				return true, nil
-			}
-			return false, killErr
-		}
-		return false, err
-	}
-	return observed != owner.Started, nil
-}
-
-func AcquireProfileLock(lockDir string, pid int) (bool, error) {
-	parentDir := filepath.Dir(lockDir)
-	if err := os.MkdirAll(parentDir, 0o755); err != nil {
-		return false, err
-	}
-
-	tempDir, err := os.MkdirTemp(parentDir, filepath.Base(lockDir)+".pending.")
-	if err != nil {
-		return false, err
-	}
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.RemoveAll(tempDir)
-		}
-	}()
-
-	if err := WriteProfileOwner(filepath.Join(tempDir, "owner.json"), pid); err != nil {
-		return false, err
-	}
-	if err := os.Rename(tempDir, lockDir); err != nil {
-		if errors.Is(err, os.ErrExist) || errors.Is(err, syscall.EEXIST) || errors.Is(err, syscall.ENOTEMPTY) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	cleanup = false
-	return true, nil
-}
-
-func WriteProfileOwner(ownerPath string, pid int) error {
-	started, err := processStartTime(pid)
-	if err != nil {
-		return err
-	}
-	payload := map[string]any{
-		"pid":     pid,
-		"started": started,
-	}
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	if err := os.MkdirAll(filepath.Dir(ownerPath), 0o755); err != nil {
-		return err
-	}
-	if err := os.WriteFile(ownerPath, data, 0o600); err != nil {
-		return err
-	}
-	return os.Chmod(ownerPath, 0o600)
 }
 
 func CleanupStaleSessionAuditDirs(stateRoot string) error {
@@ -522,57 +390,6 @@ func ResolveEndpoints(raw string) ([]string, error) {
 	return results, nil
 }
 
-var errNoMatch = errors.New("not found")
-
-func decodeJSONObjectSequence(raw []byte) ([]map[string]any, error) {
-	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 {
-		return nil, errNoMatch
-	}
-
-	if trimmed[0] == '[' {
-		var records []map[string]any
-		if err := json.Unmarshal(trimmed, &records); err != nil {
-			return nil, err
-		}
-		return records, nil
-	}
-
-	var records []map[string]any
-	for _, line := range bytes.Split(trimmed, []byte{'\n'}) {
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
-			continue
-		}
-		var record map[string]any
-		if err := json.Unmarshal(line, &record); err != nil {
-			return nil, err
-		}
-		records = append(records, record)
-	}
-	return records, nil
-}
-
-func processStartTime(pid int) (string, error) {
-	cmd := exec.Command("ps", "-o", "lstart=", "-p", strconv.Itoa(pid))
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		// `ps -p PID` exits non-zero with empty output when the
-		// process does not exist. Distinguish that from other failures
-		// (PATH issue, permissions, transient ps error) so callers can
-		// decide whether the process is definitively gone vs unknown.
-		if exitErr, ok := err.(*exec.ExitError); ok && len(strings.TrimSpace(string(output))) == 0 && len(exitErr.Stderr) == 0 {
-			return "", processGoneErr{pid: pid}
-		}
-		return "", err
-	}
-	trimmed := strings.TrimSpace(string(output))
-	if trimmed == "" {
-		return "", processGoneErr{pid: pid}
-	}
-	return trimmed, nil
-}
-
 func injectionBundleIsLive(bundlePath string, cutoff time.Time) (bool, error) {
 	ownerMetaPath := filepath.Join(bundlePath, "owner.json")
 	content, err := os.ReadFile(ownerMetaPath)
@@ -600,13 +417,13 @@ func injectionBundleIsLive(bundlePath string, cutoff time.Time) (bool, error) {
 	if owner.PID <= 0 || owner.Started == "" {
 		return false, nil
 	}
-	started, err := processStartTime(owner.PID)
+	started, err := launcher.ProcessStartTime(owner.PID)
 	if err != nil {
-		// processStartTime distinguishes ESRCH ("process gone") from
-		// other errors via processNotFound. If the process is
-		// definitively gone, the bundle is dead. Anything else is a
+		// launcher.ProcessStartTime distinguishes ESRCH ("process gone")
+		// from other errors via launcher.IsProcessGone. If the process
+		// is definitively gone, the bundle is dead. Anything else is a
 		// transient lookup failure - keep the bundle.
-		if processNotFound(err) {
+		if launcher.IsProcessGone(err) {
 			return false, nil
 		}
 		return true, fmt.Errorf("process start time for pid %d: %w", owner.PID, err)
@@ -685,19 +502,6 @@ func currentUID() (uint32, bool) {
 		return 0, false
 	}
 	return uint32(uid), true
-}
-
-type processGoneErr struct {
-	pid int
-}
-
-func (e processGoneErr) Error() string {
-	return fmt.Sprintf("process %d not found", e.pid)
-}
-
-func processNotFound(err error) bool {
-	var gone processGoneErr
-	return errors.As(err, &gone)
 }
 
 func isSymlink(path string) bool {


### PR DESCRIPTION
## Summary

Fourth sub-PR of the `internal/hostutil` decomposition. Extracts the
colima profile inspection, profile-lock acquisition, `RandomHex`, and
process-aliveness helpers into a new `internal/host/launcher/` package.

- Moved out of `internal/hostutil/launcher.go`: `ColimaProfileStatus`,
  `IsNoMatch`, `ProfileLockIsStale`, `AcquireProfileLock`,
  `WriteProfileOwner`, `RandomHex`, plus their unexported helpers
  (`processStartTime`, `processGoneErr`, `decodeJSONObjectSequence`).
- `ProcessStartTime` and `IsProcessGone` are exported so the remaining
  `hostutil.injectionBundleIsLive` can still observe owner liveness
  without duplicating the `ps -o lstart=` helper.
- `cmd/workcell-hostutil/main.go` moves its `session-suffix` /
  `colima-status` / `profile-lock-*` / `write-profile-owner`
  subcommands to the new package.
- Tests follow the code into `internal/host/launcher/launcher_test.go`.

Drops ~200 LOC from `internal/hostutil/launcher.go`. No behavior change.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages green
- [x] `gofmt -l .` — empty
- [x] `bash scripts/check-pr-shape.sh` — files=6 lines=709 areas=2 binaries=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)