### PR TITLE
^R Extract workflow validators into internal/metadatautil/workflows

### DIFF
--- a/cmd/workcell-metadatautil/main.go
+++ b/cmd/workcell-metadatautil/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/omkhar/workcell/internal/metadatautil"
+	"github.com/omkhar/workcell/internal/metadatautil/workflows"
 )
 
 func die(err error) {
@@ -51,7 +52,7 @@ func main() {
 		if len(os.Args) != 4 {
 			die(fmt.Errorf("usage: %s check-workflows ROOT_DIR POLICY_PATH", os.Args[0]))
 		}
-		err = metadatautil.CheckWorkflows(os.Args[2], os.Args[3])
+		err = workflows.CheckWorkflows(os.Args[2], os.Args[3])
 	case "generate-workflow-lane-manifest":
 		if len(os.Args) != 5 {
 			die(fmt.Errorf("usage: %s generate-workflow-lane-manifest ROOT_DIR POLICY_PATH OUTPUT_PATH", os.Args[0]))

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -18,336 +17,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/omkhar/workcell/internal/metadatautil/workflows"
 	"github.com/omkhar/workcell/internal/tomlsubset"
 	"gopkg.in/yaml.v3"
 )
-
-type workflowDocument struct {
-	Jobs map[string]workflowJob `yaml:"jobs"`
-}
-
-type workflowJob struct {
-	Name string `yaml:"name"`
-}
-
-func collectWorkflowJobNames(content []byte) ([]string, error) {
-	var document workflowDocument
-	if err := yaml.Unmarshal(content, &document); err != nil {
-		return nil, err
-	}
-
-	names := make([]string, 0, len(document.Jobs))
-	for _, job := range document.Jobs {
-		name := strings.TrimSpace(job.Name)
-		if name == "" {
-			continue
-		}
-		names = append(names, name)
-	}
-	return names, nil
-}
-
-func CheckWorkflows(rootDir, policyPath string) error {
-	if err := ensureWorkflowTools(rootDir); err != nil {
-		return err
-	}
-
-	policyText, err := readText(policyPath)
-	if err != nil {
-		return err
-	}
-	policy, err := ParseTOMLSubset(policyText, policyPath)
-	if err != nil {
-		return err
-	}
-
-	contexts, err := requireStringSliceTable(policy, "required_status_checks", "contexts", policyPath)
-	if err != nil {
-		return err
-	}
-	requiredJobNames := append([]string{}, contexts...)
-	if len(requiredJobNames) == 0 {
-		return fmt.Errorf("%s must define at least one required status-check context", policyPath)
-	}
-
-	workflowDir := filepath.Join(rootDir, ".github", "workflows")
-	workflowPaths, err := filepath.Glob(filepath.Join(workflowDir, "*.yml"))
-	if err != nil {
-		return err
-	}
-
-	jobNames := map[string]struct{}{}
-	for _, path := range workflowPaths {
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		names, err := collectWorkflowJobNames(content)
-		if err != nil {
-			return fmt.Errorf("%s: parse workflow job names: %w", path, err)
-		}
-		for _, name := range names {
-			jobNames[name] = struct{}{}
-		}
-	}
-
-	missing := make([]string, 0)
-	for _, expected := range requiredJobNames {
-		if _, ok := jobNames[expected]; !ok {
-			missing = append(missing, expected)
-		}
-	}
-	slices.Sort(missing)
-	if len(missing) > 0 {
-		return fmt.Errorf(
-			"workflow jobs are missing required status-check names from %s: %s",
-			policyPath,
-			strings.Join(missing, ", "),
-		)
-	}
-
-	codeqlWorkflowPath := filepath.Join(workflowDir, "codeql.yml")
-	codeqlWorkflow, err := readText(codeqlWorkflowPath)
-	if err != nil {
-		return err
-	}
-	if err := validateCodeQLWorkflow(codeqlWorkflow, codeqlWorkflowPath); err != nil {
-		return err
-	}
-
-	releaseWorkflowPath := filepath.Join(workflowDir, "release.yml")
-	releaseWorkflow, err := readText(releaseWorkflowPath)
-	if err != nil {
-		return err
-	}
-	if err := validateReleaseWorkflowCodeQLFlow(releaseWorkflow); err != nil {
-		return err
-	}
-	return nil
-}
-
-func ensureWorkflowTools(rootDir string) error {
-	actionlintPath, err := exec.LookPath("actionlint")
-	if err != nil {
-		return fmt.Errorf("actionlint is required for workflow validation: %w", err)
-	}
-	zizmorPath, err := exec.LookPath("zizmor")
-	if err != nil {
-		return fmt.Errorf("zizmor is required for workflow validation: %w", err)
-	}
-
-	actionlintCmd := exec.Command(actionlintPath)
-	actionlintCmd.Dir = rootDir
-	if output, err := actionlintCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("actionlint failed: %w\n%s", err, strings.TrimSpace(string(output)))
-	}
-
-	workflowPaths, err := filepath.Glob(filepath.Join(rootDir, ".github", "workflows", "*.yml"))
-	if err != nil {
-		return err
-	}
-	zizmorArgs := []string{
-		"--persona", "auditor",
-		"--config", filepath.Join(rootDir, ".github", "zizmor.yml"),
-	}
-	zizmorArgs = append(zizmorArgs, workflowPaths...)
-	zizmorCmd := exec.Command(
-		zizmorPath,
-		zizmorArgs...,
-	)
-	zizmorCmd.Dir = rootDir
-	if output, err := zizmorCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("zizmor failed: %w\n%s", err, strings.TrimSpace(string(output)))
-	}
-	return nil
-}
-
-func validateCodeQLWorkflow(codeqlWorkflow, workflowPath string) error {
-	if regexp.MustCompile(`(?s)- language: go\s+build-mode: none`).MatchString(codeqlWorkflow) {
-		return fmt.Errorf("%s must not configure Go CodeQL with build-mode: none", workflowPath)
-	}
-	for _, needle := range []string{
-		"- language: rust",
-		"build-mode: none",
-		"- language: javascript-typescript",
-		"- language: go",
-		"build-mode: autobuild",
-		"github/codeql-action/init@",
-		"github/codeql-action/autobuild@",
-		"github/codeql-action/analyze@",
-	} {
-		if !strings.Contains(codeqlWorkflow, needle) {
-			return fmt.Errorf("%s must contain %q", workflowPath, needle)
-		}
-	}
-	return nil
-}
-
-func validateReleaseWorkflowCodeQLFlow(releaseWorkflow string) error {
-	for _, needle := range []string{
-		"name: Release CodeQL (${{ matrix.language }})",
-		"- language: rust",
-		"- language: javascript-typescript",
-		"- language: go",
-		"build-mode: autobuild",
-		"github/codeql-action/autobuild@",
-		"- codeql-preflight",
-	} {
-		if !strings.Contains(releaseWorkflow, needle) {
-			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
-		}
-	}
-	if regexp.MustCompile(`(?s)- language: go\s+build-mode: none`).MatchString(releaseWorkflow) {
-		return errors.New(".github/workflows/release.yml must not configure Go CodeQL with build-mode: none")
-	}
-	return nil
-}
-
-func validateCIWorkflowPRShapeFlow(ciWorkflow string) error {
-	for _, needle := range []string{
-		"name: Pull request shape",
-		"fetch-depth: 0",
-		"WORKCELL_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}",
-		"Check pull request shape",
-		`./scripts/ci/job-pr-shape.sh --base "${WORKCELL_PR_BASE_REF}"`,
-		"Skip outside pull requests",
-		`PR shape gate applies only to pull requests.`,
-	} {
-		if !strings.Contains(ciWorkflow, needle) {
-			return fmt.Errorf(".github/workflows/ci.yml must contain %q", needle)
-		}
-	}
-	return nil
-}
-
-func validateReleaseWorkflowControlPlaneFlow(releaseWorkflow string) error {
-	if !strings.Contains(releaseWorkflow, "dist/workcell-control-plane-preflight.json") {
-		return errors.New(".github/workflows/release.yml must keep the reviewed control-plane manifest flow")
-	}
-	if !strings.Contains(releaseWorkflow, "run: ./scripts/generate-control-plane-manifest.sh dist/workcell-control-plane.json") {
-		return errors.New(".github/workflows/release.yml must regenerate the published control-plane manifest under dist/workcell-control-plane.json")
-	}
-	if !regexp.MustCompile(`(?s)Verify control-plane manifest matches preflight.*?cmp -s \\\s+dist/workcell-control-plane\.json \\\s+dist/preflight/workcell-control-plane-preflight\.json`).MatchString(releaseWorkflow) {
-		return errors.New(".github/workflows/release.yml must verify the published control-plane manifest against the preflight artifact")
-	}
-	return nil
-}
-
-func validateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow string) error {
-	if !strings.Contains(releaseWorkflow, "ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ github.event.repository.visibility == 'public' || vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS == 'true' }}") {
-		return errors.New(".github/workflows/release.yml must gate GitHub attestations on public visibility or an explicit private-repo capability flag")
-	}
-	if !strings.Contains(releaseWorkflow, "RELEASE_NO_ATTEST: ${{ vars.WORKCELL_RELEASE_NO_ATTEST || 'false' }}") {
-		return errors.New(".github/workflows/release.yml must expose RELEASE_NO_ATTEST as an explicit opt-out env var sourced from vars.WORKCELL_RELEASE_NO_ATTEST")
-	}
-	if !strings.Contains(releaseWorkflow, "name: Confirm attestation environment policy") {
-		return errors.New(".github/workflows/release.yml must include the fail-closed attestation preflight step")
-	}
-	if !regexp.MustCompile(`(?ms)name: Confirm attestation environment policy.*?ENABLE_GITHUB_ATTESTATIONS_SUPPORTED.*?!= "true".*?exit 1`).MatchString(releaseWorkflow) {
-		return errors.New(".github/workflows/release.yml must keep the fail-closed attestation preflight script body (must `exit 1` when ENABLE_GITHUB_ATTESTATIONS_SUPPORTED is not 'true' and RELEASE_NO_ATTEST is not 'true')")
-	}
-	const attestGuard = "if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'"
-	attestStepRE := regexp.MustCompile(`(?m)^\s*-\s+uses:\s+actions/attest@`)
-	guardedAttestStepRE := regexp.MustCompile(`(?ms)^\s*-\s+uses:\s+actions/attest@[^\n]+\n\s+if:\s+env\.RELEASE_NO_ATTEST != 'true' && env\.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'\n`)
-	totalAttestSteps := len(attestStepRE.FindAllString(releaseWorkflow, -1))
-	if totalAttestSteps != 10 {
-		return errors.New(".github/workflows/release.yml must keep exactly ten reviewed GitHub attestation steps")
-	}
-	if len(guardedAttestStepRE.FindAllString(releaseWorkflow, -1)) != totalAttestSteps {
-		return fmt.Errorf(".github/workflows/release.yml must guard every actions/attest step with %q", attestGuard)
-	}
-	for _, needle := range []string{
-		"subject-name: ${{ env.IMAGE_NAME }}",
-		"sbom-path: dist/workcell-image.spdx.json",
-		"subject-path: dist/${{ env.BUNDLE_NAME }}",
-		"sbom-path: dist/workcell-source.spdx.json",
-		"subject-path: dist/workcell.rb",
-		"subject-path: dist/workcell-image.digest",
-		"subject-path: dist/workcell-build-inputs.json",
-		"subject-path: dist/workcell-control-plane.json",
-		"subject-path: dist/workcell-builder-environment.json",
-		"subject-path: dist/SHA256SUMS",
-	} {
-		if !strings.Contains(releaseWorkflow, needle) {
-			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
-		}
-	}
-	return nil
-}
-
-func validateMacOSInstallVerificationFlow(workflowText, workflowPath, artifactName, jobName string) error {
-	for _, needle := range []string{
-		fmt.Sprintf("name: %s", artifactName),
-		jobName,
-		"macos-26",
-		"macos-15",
-		"actions/upload-artifact@",
-		"actions/download-artifact@",
-		`"${bundle_dir}/scripts/install.sh"`,
-		`"${bundle_dir}/scripts/uninstall.sh"`,
-		"brew tap-new",
-		"brew --repo",
-		"brew install \"${tap_name}/workcell\"",
-		"brew uninstall --force \"${tap_name}/workcell\"",
-		"brew list --versions workcell",
-	} {
-		if !strings.Contains(workflowText, needle) {
-			return fmt.Errorf("%s must contain %q", workflowPath, needle)
-		}
-	}
-
-	if !strings.Contains(workflowText, "find dist/install -maxdepth 1 -type f -name 'workcell-*.tar.gz'") {
-		return fmt.Errorf("%s must resolve the reviewed install-candidate bundle from the artifact download", workflowPath)
-	}
-
-	return nil
-}
-
-func validateUpstreamRefreshWorkflow(workflowText string) error {
-	for _, needle := range []string{
-		"name: Upstream refresh",
-		"workflow_dispatch:",
-		"./scripts/update-upstream-pins.sh --apply",
-		"./scripts/update-upstream-pins.sh --check",
-		"./scripts/check-pinned-inputs.sh",
-		"environment:\n      name: upstream-refresh",
-		"actions/upload-artifact@",
-		"name: upstream-refresh-candidate",
-		"metadata.json",
-		"gh issue",
-		"persist-credentials: false",
-		"fetch-depth: 0",
-		"contents: read",
-		"issues: write",
-		"pull-requests: read",
-		"WORKCELL_COSIGN_VERSION:",
-		"sigstore/cosign-installer@",
-		"cosign-release: ${{ env.WORKCELL_COSIGN_VERSION }}",
-		`sudo install -m 0755 "$(command -v cosign)" /usr/local/bin/cosign`,
-	} {
-		if !strings.Contains(workflowText, needle) {
-			return fmt.Errorf(".github/workflows/upstream-refresh.yml must contain %q", needle)
-		}
-	}
-	for _, forbidden := range []string{
-		"WORKCELL_UPSTREAM_REFRESH_GIT_NAME",
-		"WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL",
-		"WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT",
-		"WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY",
-		"WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID",
-		"gpg --batch --with-colons --list-secret-keys",
-		"git commit -S",
-		"gh pr create",
-		`git push "https://x-access-token:`,
-		"contents: write",
-		"pull-requests: write",
-	} {
-		if strings.Contains(workflowText, forbidden) {
-			return fmt.Errorf(".github/workflows/upstream-refresh.yml must not contain %q", forbidden)
-		}
-	}
-	return nil
-}
 
 type hostedControlsWorkflowEnvironmentPolicy struct {
 	Variables             map[string]string
@@ -1926,10 +1599,10 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if strings.Contains(ciWorkflow, "docker/setup-qemu-action@") {
 		return errors.New(".github/workflows/ci.yml must not configure QEMU in CI now that arm64 reproducible builds use a native runner")
 	}
-	if err := validateCIWorkflowPRShapeFlow(ciWorkflow); err != nil {
+	if err := workflows.ValidateCIWorkflowPRShapeFlow(ciWorkflow); err != nil {
 		return err
 	}
-	if err := validateMacOSInstallVerificationFlow(ciWorkflow, ".github/workflows/ci.yml", "workcell-ci-install-candidate", "name: Install verification (${{ matrix.runner_label }})"); err != nil {
+	if err := workflows.ValidateMacOSInstallVerificationFlow(ciWorkflow, ".github/workflows/ci.yml", "workcell-ci-install-candidate", "name: Install verification (${{ matrix.runner_label }})"); err != nil {
 		return err
 	}
 	if !strings.Contains(releaseWorkflow, "cache-binary: false") {
@@ -2091,13 +1764,13 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		!strings.Contains(releaseWorkflow, "dist/workcell-image.spdx.sigstore.json") {
 		return errors.New(".github/workflows/release.yml must publish direct signature bundles for release artifacts")
 	}
-	if err := validateReleaseWorkflowControlPlaneFlow(releaseWorkflow); err != nil {
+	if err := workflows.ValidateReleaseWorkflowControlPlaneFlow(releaseWorkflow); err != nil {
 		return err
 	}
-	if err := validateMacOSInstallVerificationFlow(releaseWorkflow, ".github/workflows/release.yml", "workcell-release-install-candidate", "name: Release install verification (${{ matrix.runner_label }})"); err != nil {
+	if err := workflows.ValidateMacOSInstallVerificationFlow(releaseWorkflow, ".github/workflows/release.yml", "workcell-release-install-candidate", "name: Release install verification (${{ matrix.runner_label }})"); err != nil {
 		return err
 	}
-	if err := validateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow); err != nil {
+	if err := workflows.ValidateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow); err != nil {
 		return err
 	}
 	if strings.Contains(releaseWorkflow, "steps.build.outputs.digest") {
@@ -2121,7 +1794,7 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if !strings.Contains(releaseWorkflow, "environment:\n      name: hosted-controls-audit") {
 		return errors.New(".github/workflows/release.yml release preflight must bind to the hosted-controls-audit environment")
 	}
-	if err := validateUpstreamRefreshWorkflow(upstreamRefreshWorkflow); err != nil {
+	if err := workflows.ValidateUpstreamRefreshWorkflow(upstreamRefreshWorkflow); err != nil {
 		return err
 	}
 	hostedControlsWorkflow, err := readText(filepath.Join(cfg.WorkflowsDir, "hosted-controls.yml"))

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/metadatautil/workflows"
 )
 
 func installWorkflowToolStubs(t *testing.T, root string) {
@@ -194,8 +196,8 @@ contexts = [
 		t.Fatalf("WriteFile(policy.toml) error = %v", err)
 	}
 
-	if err := CheckWorkflows(root, policyPath); err != nil {
-		t.Fatalf("CheckWorkflows() error = %v", err)
+	if err := workflows.CheckWorkflows(root, policyPath); err != nil {
+		t.Fatalf("workflows.CheckWorkflows() error = %v", err)
 	}
 }
 
@@ -234,12 +236,12 @@ contexts = [
 		t.Fatalf("WriteFile(policy.toml) error = %v", err)
 	}
 
-	err := CheckWorkflows(root, policyPath)
+	err := workflows.CheckWorkflows(root, policyPath)
 	if err == nil {
-		t.Fatal("CheckWorkflows() unexpectedly succeeded")
+		t.Fatal("workflows.CheckWorkflows() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), "Validate repository") {
-		t.Fatalf("CheckWorkflows() error = %v, want missing Validate repository", err)
+		t.Fatalf("workflows.CheckWorkflows() error = %v, want missing Validate repository", err)
 	}
 }
 
@@ -497,12 +499,12 @@ func TestValidateReleaseWorkflowControlPlaneFlowRejectsMissingCanonicalArtifact(
             dist/preflight/workcell-control-plane-preflight.json
 `
 
-	err := validateReleaseWorkflowControlPlaneFlow(releaseWorkflow)
+	err := workflows.ValidateReleaseWorkflowControlPlaneFlow(releaseWorkflow)
 	if err == nil {
-		t.Fatal("validateReleaseWorkflowControlPlaneFlow() unexpectedly succeeded")
+		t.Fatal("workflows.ValidateReleaseWorkflowControlPlaneFlow() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), "dist/workcell-control-plane.json") {
-		t.Fatalf("validateReleaseWorkflowControlPlaneFlow() error = %v, want canonical control-plane artifact path", err)
+		t.Fatalf("workflows.ValidateReleaseWorkflowControlPlaneFlow() error = %v, want canonical control-plane artifact path", err)
 	}
 }
 
@@ -525,8 +527,8 @@ func TestValidateReleaseWorkflowControlPlaneFlowAcceptsCanonicalArtifact(t *test
             dist/preflight/workcell-control-plane-preflight.json
 `
 
-	if err := validateReleaseWorkflowControlPlaneFlow(releaseWorkflow); err != nil {
-		t.Fatalf("validateReleaseWorkflowControlPlaneFlow() error = %v", err)
+	if err := workflows.ValidateReleaseWorkflowControlPlaneFlow(releaseWorkflow); err != nil {
+		t.Fatalf("workflows.ValidateReleaseWorkflowControlPlaneFlow() error = %v", err)
 	}
 }
 
@@ -563,12 +565,12 @@ func TestValidateMacOSInstallVerificationFlowRejectsMissingBundleUninstall(t *te
           brew list --versions workcell
 `
 
-	err := validateMacOSInstallVerificationFlow(workflow, ".github/workflows/ci.yml", "workcell-ci-install-candidate", "name: Install verification (${{ matrix.runner_label }})")
+	err := workflows.ValidateMacOSInstallVerificationFlow(workflow, ".github/workflows/ci.yml", "workcell-ci-install-candidate", "name: Install verification (${{ matrix.runner_label }})")
 	if err == nil {
-		t.Fatal("validateMacOSInstallVerificationFlow() unexpectedly succeeded")
+		t.Fatal("workflows.ValidateMacOSInstallVerificationFlow() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), "scripts/uninstall.sh") {
-		t.Fatalf("validateMacOSInstallVerificationFlow() error = %v, want missing bundle uninstall check", err)
+		t.Fatalf("workflows.ValidateMacOSInstallVerificationFlow() error = %v, want missing bundle uninstall check", err)
 	}
 }
 
@@ -601,8 +603,8 @@ func TestValidateMacOSInstallVerificationFlowAcceptsCanonicalFlow(t *testing.T) 
           brew list --versions workcell
 `
 
-	if err := validateMacOSInstallVerificationFlow(workflow, ".github/workflows/ci.yml", "workcell-ci-install-candidate", "name: Install verification (${{ matrix.runner_label }})"); err != nil {
-		t.Fatalf("validateMacOSInstallVerificationFlow() error = %v", err)
+	if err := workflows.ValidateMacOSInstallVerificationFlow(workflow, ".github/workflows/ci.yml", "workcell-ci-install-candidate", "name: Install verification (${{ matrix.runner_label }})"); err != nil {
+		t.Fatalf("workflows.ValidateMacOSInstallVerificationFlow() error = %v", err)
 	}
 }
 
@@ -624,12 +626,12 @@ func TestValidateCodeQLWorkflowRejectsGoBuildlessMode(t *testing.T) {
       - uses: github/codeql-action/analyze@deadbeef
 `
 
-	err := validateCodeQLWorkflow(workflow, ".github/workflows/codeql.yml")
+	err := workflows.ValidateCodeQLWorkflow(workflow, ".github/workflows/codeql.yml")
 	if err == nil {
-		t.Fatal("validateCodeQLWorkflow() unexpectedly succeeded")
+		t.Fatal("workflows.ValidateCodeQLWorkflow() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), "build-mode: none") {
-		t.Fatalf("validateCodeQLWorkflow() error = %v, want go build-mode rejection", err)
+		t.Fatalf("workflows.ValidateCodeQLWorkflow() error = %v, want go build-mode rejection", err)
 	}
 }
 
@@ -652,8 +654,8 @@ func TestValidateCodeQLWorkflowAcceptsGoAutobuild(t *testing.T) {
       - uses: github/codeql-action/analyze@deadbeef
 `
 
-	if err := validateCodeQLWorkflow(workflow, ".github/workflows/codeql.yml"); err != nil {
-		t.Fatalf("validateCodeQLWorkflow() error = %v", err)
+	if err := workflows.ValidateCodeQLWorkflow(workflow, ".github/workflows/codeql.yml"); err != nil {
+		t.Fatalf("workflows.ValidateCodeQLWorkflow() error = %v", err)
 	}
 }
 
@@ -670,12 +672,12 @@ func TestValidateReleaseWorkflowCodeQLFlowRejectsMissingGoAutobuild(t *testing.T
       - preflight
 `
 
-	err := validateReleaseWorkflowCodeQLFlow(workflow)
+	err := workflows.ValidateReleaseWorkflowCodeQLFlow(workflow)
 	if err == nil {
-		t.Fatal("validateReleaseWorkflowCodeQLFlow() unexpectedly succeeded")
+		t.Fatal("workflows.ValidateReleaseWorkflowCodeQLFlow() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), "Release CodeQL") {
-		t.Fatalf("validateReleaseWorkflowCodeQLFlow() error = %v, want missing release CodeQL job", err)
+		t.Fatalf("workflows.ValidateReleaseWorkflowCodeQLFlow() error = %v, want missing release CodeQL job", err)
 	}
 }
 
@@ -705,8 +707,8 @@ func TestValidateReleaseWorkflowCodeQLFlowAcceptsMatrixJob(t *testing.T) {
       - install-verification
 `
 
-	if err := validateReleaseWorkflowCodeQLFlow(workflow); err != nil {
-		t.Fatalf("validateReleaseWorkflowCodeQLFlow() error = %v", err)
+	if err := workflows.ValidateReleaseWorkflowCodeQLFlow(workflow); err != nil {
+		t.Fatalf("workflows.ValidateReleaseWorkflowCodeQLFlow() error = %v", err)
 	}
 }
 
@@ -731,12 +733,12 @@ func TestValidateCIWorkflowPRShapeFlowRejectsLegacyInlineShapeGate(t *testing.T)
         run: echo "PR shape gate applies only to pull requests."
 `
 
-	err := validateCIWorkflowPRShapeFlow(workflow)
+	err := workflows.ValidateCIWorkflowPRShapeFlow(workflow)
 	if err == nil {
-		t.Fatal("validateCIWorkflowPRShapeFlow() unexpectedly succeeded")
+		t.Fatal("workflows.ValidateCIWorkflowPRShapeFlow() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), "./scripts/ci/job-pr-shape.sh --base") {
-		t.Fatalf("validateCIWorkflowPRShapeFlow() error = %v, want shared job gate", err)
+		t.Fatalf("workflows.ValidateCIWorkflowPRShapeFlow() error = %v, want shared job gate", err)
 	}
 }
 
@@ -759,8 +761,8 @@ func TestValidateCIWorkflowPRShapeFlowAcceptsSharedJobGate(t *testing.T) {
         run: echo "PR shape gate applies only to pull requests."
 `
 
-	if err := validateCIWorkflowPRShapeFlow(workflow); err != nil {
-		t.Fatalf("validateCIWorkflowPRShapeFlow() error = %v", err)
+	if err := workflows.ValidateCIWorkflowPRShapeFlow(workflow); err != nil {
+		t.Fatalf("workflows.ValidateCIWorkflowPRShapeFlow() error = %v", err)
 	}
 }
 
@@ -808,12 +810,12 @@ jobs:
           gh pr create --draft
 `
 
-	err := validateUpstreamRefreshWorkflow(workflow)
+	err := workflows.ValidateUpstreamRefreshWorkflow(workflow)
 	if err == nil {
-		t.Fatal("validateUpstreamRefreshWorkflow() unexpectedly succeeded")
+		t.Fatal("workflows.ValidateUpstreamRefreshWorkflow() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), `gh pr create`) {
-		t.Fatalf("validateUpstreamRefreshWorkflow() error = %v, want GitHub-side PR publication rejection", err)
+		t.Fatalf("workflows.ValidateUpstreamRefreshWorkflow() error = %v, want GitHub-side PR publication rejection", err)
 	}
 }
 
@@ -860,8 +862,8 @@ jobs:
           gh issue create --title "Upstream refresh candidate" --body "metadata.json"
 `
 
-	if err := validateUpstreamRefreshWorkflow(workflow); err != nil {
-		t.Fatalf("validateUpstreamRefreshWorkflow() error = %v", err)
+	if err := workflows.ValidateUpstreamRefreshWorkflow(workflow); err != nil {
+		t.Fatalf("workflows.ValidateUpstreamRefreshWorkflow() error = %v", err)
 	}
 }
 
@@ -908,12 +910,12 @@ jobs:
           gh issue create --title "Upstream refresh candidate" --body "metadata.json"
 `
 
-	err := validateUpstreamRefreshWorkflow(workflow)
+	err := workflows.ValidateUpstreamRefreshWorkflow(workflow)
 	if err == nil {
-		t.Fatal("validateUpstreamRefreshWorkflow() unexpectedly succeeded")
+		t.Fatal("workflows.ValidateUpstreamRefreshWorkflow() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), "WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY") {
-		t.Fatalf("validateUpstreamRefreshWorkflow() error = %v, want hosted signing input rejection", err)
+		t.Fatalf("workflows.ValidateUpstreamRefreshWorkflow() error = %v, want hosted signing input rejection", err)
 	}
 }
 
@@ -958,12 +960,12 @@ jobs:
           gh issue create --title "Upstream refresh candidate" --body "metadata.json"
 `
 
-	err := validateUpstreamRefreshWorkflow(workflow)
+	err := workflows.ValidateUpstreamRefreshWorkflow(workflow)
 	if err == nil {
-		t.Fatal("validateUpstreamRefreshWorkflow() unexpectedly succeeded")
+		t.Fatal("workflows.ValidateUpstreamRefreshWorkflow() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), `environment:\n      name: upstream-refresh`) {
-		t.Fatalf("validateUpstreamRefreshWorkflow() error = %v, want upstream-refresh environment binding rejection", err)
+		t.Fatalf("workflows.ValidateUpstreamRefreshWorkflow() error = %v, want upstream-refresh environment binding rejection", err)
 	}
 }
 
@@ -986,12 +988,12 @@ func TestValidateReleaseWorkflowGitHubAttestationFlowRejectsMissingSupportGuard(
           subject-name: ${{ env.IMAGE_NAME }}
 `
 
-	err := validateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow)
+	err := workflows.ValidateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow)
 	if err == nil {
-		t.Fatal("validateReleaseWorkflowGitHubAttestationFlow() unexpectedly succeeded")
+		t.Fatal("workflows.ValidateReleaseWorkflowGitHubAttestationFlow() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), "public visibility or an explicit private-repo capability flag") {
-		t.Fatalf("validateReleaseWorkflowGitHubAttestationFlow() error = %v, want support guard failure", err)
+		t.Fatalf("workflows.ValidateReleaseWorkflowGitHubAttestationFlow() error = %v, want support guard failure", err)
 	}
 }
 
@@ -1050,12 +1052,12 @@ func TestValidateReleaseWorkflowGitHubAttestationFlowRejectsUnguardedAttestStep(
           subject-path: dist/SHA256SUMS
 `
 
-	err := validateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow)
+	err := workflows.ValidateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow)
 	if err == nil {
-		t.Fatal("validateReleaseWorkflowGitHubAttestationFlow() unexpectedly succeeded")
+		t.Fatal("workflows.ValidateReleaseWorkflowGitHubAttestationFlow() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), "guard every actions/attest step") {
-		t.Fatalf("validateReleaseWorkflowGitHubAttestationFlow() error = %v, want unguarded attestation failure", err)
+		t.Fatalf("workflows.ValidateReleaseWorkflowGitHubAttestationFlow() error = %v, want unguarded attestation failure", err)
 	}
 }
 
@@ -1114,8 +1116,8 @@ func TestValidateReleaseWorkflowGitHubAttestationFlowAcceptsSupportGuard(t *test
           subject-path: dist/SHA256SUMS
 `
 
-	if err := validateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow); err != nil {
-		t.Fatalf("validateReleaseWorkflowGitHubAttestationFlow() error = %v", err)
+	if err := workflows.ValidateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow); err != nil {
+		t.Fatalf("workflows.ValidateReleaseWorkflowGitHubAttestationFlow() error = %v", err)
 	}
 }
 

--- a/internal/metadatautil/workflows/doc.go
+++ b/internal/metadatautil/workflows/doc.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package workflows carries the GitHub Actions workflow validators
+// that used to live in internal/metadatautil/validate.go. It exposes
+// CheckWorkflows as the public entry point and the per-flow
+// ValidateX/EnsureWorkflowTools helpers used by the workflow_validation
+// tests in the parent metadatautil package.
+package workflows

--- a/internal/metadatautil/workflows/workflows.go
+++ b/internal/metadatautil/workflows/workflows.go
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package workflows
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/tomlsubset"
+	"gopkg.in/yaml.v3"
+)
+
+type workflowDocument struct {
+	Jobs map[string]workflowJob `yaml:"jobs"`
+}
+
+type workflowJob struct {
+	Name string `yaml:"name"`
+}
+
+func CollectWorkflowJobNames(content []byte) ([]string, error) {
+	var document workflowDocument
+	if err := yaml.Unmarshal(content, &document); err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(document.Jobs))
+	for _, job := range document.Jobs {
+		name := strings.TrimSpace(job.Name)
+		if name == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func CheckWorkflows(rootDir, policyPath string) error {
+	if err := EnsureWorkflowTools(rootDir); err != nil {
+		return err
+	}
+
+	policyText, err := readText(policyPath)
+	if err != nil {
+		return err
+	}
+	policy, err := tomlsubset.Parse(policyText, policyPath)
+	if err != nil {
+		return err
+	}
+
+	contexts, err := requireStringSliceTable(policy, "required_status_checks", "contexts", policyPath)
+	if err != nil {
+		return err
+	}
+	requiredJobNames := append([]string{}, contexts...)
+	if len(requiredJobNames) == 0 {
+		return fmt.Errorf("%s must define at least one required status-check context", policyPath)
+	}
+
+	workflowDir := filepath.Join(rootDir, ".github", "workflows")
+	workflowPaths, err := filepath.Glob(filepath.Join(workflowDir, "*.yml"))
+	if err != nil {
+		return err
+	}
+
+	jobNames := map[string]struct{}{}
+	for _, path := range workflowPaths {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		names, err := CollectWorkflowJobNames(content)
+		if err != nil {
+			return fmt.Errorf("%s: parse workflow job names: %w", path, err)
+		}
+		for _, name := range names {
+			jobNames[name] = struct{}{}
+		}
+	}
+
+	missing := make([]string, 0)
+	for _, expected := range requiredJobNames {
+		if _, ok := jobNames[expected]; !ok {
+			missing = append(missing, expected)
+		}
+	}
+	slices.Sort(missing)
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"workflow jobs are missing required status-check names from %s: %s",
+			policyPath,
+			strings.Join(missing, ", "),
+		)
+	}
+
+	codeqlWorkflowPath := filepath.Join(workflowDir, "codeql.yml")
+	codeqlWorkflow, err := readText(codeqlWorkflowPath)
+	if err != nil {
+		return err
+	}
+	if err := ValidateCodeQLWorkflow(codeqlWorkflow, codeqlWorkflowPath); err != nil {
+		return err
+	}
+
+	releaseWorkflowPath := filepath.Join(workflowDir, "release.yml")
+	releaseWorkflow, err := readText(releaseWorkflowPath)
+	if err != nil {
+		return err
+	}
+	if err := ValidateReleaseWorkflowCodeQLFlow(releaseWorkflow); err != nil {
+		return err
+	}
+	return nil
+}
+
+func EnsureWorkflowTools(rootDir string) error {
+	actionlintPath, err := exec.LookPath("actionlint")
+	if err != nil {
+		return fmt.Errorf("actionlint is required for workflow validation: %w", err)
+	}
+	zizmorPath, err := exec.LookPath("zizmor")
+	if err != nil {
+		return fmt.Errorf("zizmor is required for workflow validation: %w", err)
+	}
+
+	actionlintCmd := exec.Command(actionlintPath)
+	actionlintCmd.Dir = rootDir
+	if output, err := actionlintCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("actionlint failed: %w\n%s", err, strings.TrimSpace(string(output)))
+	}
+
+	workflowPaths, err := filepath.Glob(filepath.Join(rootDir, ".github", "workflows", "*.yml"))
+	if err != nil {
+		return err
+	}
+	zizmorArgs := []string{
+		"--persona", "auditor",
+		"--config", filepath.Join(rootDir, ".github", "zizmor.yml"),
+	}
+	zizmorArgs = append(zizmorArgs, workflowPaths...)
+	zizmorCmd := exec.Command(
+		zizmorPath,
+		zizmorArgs...,
+	)
+	zizmorCmd.Dir = rootDir
+	if output, err := zizmorCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("zizmor failed: %w\n%s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func ValidateCodeQLWorkflow(codeqlWorkflow, workflowPath string) error {
+	if regexp.MustCompile(`(?s)- language: go\s+build-mode: none`).MatchString(codeqlWorkflow) {
+		return fmt.Errorf("%s must not configure Go CodeQL with build-mode: none", workflowPath)
+	}
+	for _, needle := range []string{
+		"- language: rust",
+		"build-mode: none",
+		"- language: javascript-typescript",
+		"- language: go",
+		"build-mode: autobuild",
+		"github/codeql-action/init@",
+		"github/codeql-action/autobuild@",
+		"github/codeql-action/analyze@",
+	} {
+		if !strings.Contains(codeqlWorkflow, needle) {
+			return fmt.Errorf("%s must contain %q", workflowPath, needle)
+		}
+	}
+	return nil
+}
+
+func ValidateReleaseWorkflowCodeQLFlow(releaseWorkflow string) error {
+	for _, needle := range []string{
+		"name: Release CodeQL (${{ matrix.language }})",
+		"- language: rust",
+		"- language: javascript-typescript",
+		"- language: go",
+		"build-mode: autobuild",
+		"github/codeql-action/autobuild@",
+		"- codeql-preflight",
+	} {
+		if !strings.Contains(releaseWorkflow, needle) {
+			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
+		}
+	}
+	if regexp.MustCompile(`(?s)- language: go\s+build-mode: none`).MatchString(releaseWorkflow) {
+		return errors.New(".github/workflows/release.yml must not configure Go CodeQL with build-mode: none")
+	}
+	return nil
+}
+
+func ValidateCIWorkflowPRShapeFlow(ciWorkflow string) error {
+	for _, needle := range []string{
+		"name: Pull request shape",
+		"fetch-depth: 0",
+		"WORKCELL_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}",
+		"Check pull request shape",
+		`./scripts/ci/job-pr-shape.sh --base "${WORKCELL_PR_BASE_REF}"`,
+		"Skip outside pull requests",
+		`PR shape gate applies only to pull requests.`,
+	} {
+		if !strings.Contains(ciWorkflow, needle) {
+			return fmt.Errorf(".github/workflows/ci.yml must contain %q", needle)
+		}
+	}
+	return nil
+}
+
+func ValidateReleaseWorkflowControlPlaneFlow(releaseWorkflow string) error {
+	if !strings.Contains(releaseWorkflow, "dist/workcell-control-plane-preflight.json") {
+		return errors.New(".github/workflows/release.yml must keep the reviewed control-plane manifest flow")
+	}
+	if !strings.Contains(releaseWorkflow, "run: ./scripts/generate-control-plane-manifest.sh dist/workcell-control-plane.json") {
+		return errors.New(".github/workflows/release.yml must regenerate the published control-plane manifest under dist/workcell-control-plane.json")
+	}
+	if !regexp.MustCompile(`(?s)Verify control-plane manifest matches preflight.*?cmp -s \\\s+dist/workcell-control-plane\.json \\\s+dist/preflight/workcell-control-plane-preflight\.json`).MatchString(releaseWorkflow) {
+		return errors.New(".github/workflows/release.yml must verify the published control-plane manifest against the preflight artifact")
+	}
+	return nil
+}
+
+func ValidateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow string) error {
+	if !strings.Contains(releaseWorkflow, "ENABLE_GITHUB_ATTESTATIONS_SUPPORTED: ${{ github.event.repository.visibility == 'public' || vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS == 'true' }}") {
+		return errors.New(".github/workflows/release.yml must gate GitHub attestations on public visibility or an explicit private-repo capability flag")
+	}
+	if !strings.Contains(releaseWorkflow, "RELEASE_NO_ATTEST: ${{ vars.WORKCELL_RELEASE_NO_ATTEST || 'false' }}") {
+		return errors.New(".github/workflows/release.yml must expose RELEASE_NO_ATTEST as an explicit opt-out env var sourced from vars.WORKCELL_RELEASE_NO_ATTEST")
+	}
+	if !strings.Contains(releaseWorkflow, "name: Confirm attestation environment policy") {
+		return errors.New(".github/workflows/release.yml must include the fail-closed attestation preflight step")
+	}
+	if !regexp.MustCompile(`(?ms)name: Confirm attestation environment policy.*?ENABLE_GITHUB_ATTESTATIONS_SUPPORTED.*?!= "true".*?exit 1`).MatchString(releaseWorkflow) {
+		return errors.New(".github/workflows/release.yml must keep the fail-closed attestation preflight script body (must `exit 1` when ENABLE_GITHUB_ATTESTATIONS_SUPPORTED is not 'true' and RELEASE_NO_ATTEST is not 'true')")
+	}
+	const attestGuard = "if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'"
+	attestStepRE := regexp.MustCompile(`(?m)^\s*-\s+uses:\s+actions/attest@`)
+	guardedAttestStepRE := regexp.MustCompile(`(?ms)^\s*-\s+uses:\s+actions/attest@[^\n]+\n\s+if:\s+env\.RELEASE_NO_ATTEST != 'true' && env\.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'\n`)
+	totalAttestSteps := len(attestStepRE.FindAllString(releaseWorkflow, -1))
+	if totalAttestSteps != 10 {
+		return errors.New(".github/workflows/release.yml must keep exactly ten reviewed GitHub attestation steps")
+	}
+	if len(guardedAttestStepRE.FindAllString(releaseWorkflow, -1)) != totalAttestSteps {
+		return fmt.Errorf(".github/workflows/release.yml must guard every actions/attest step with %q", attestGuard)
+	}
+	for _, needle := range []string{
+		"subject-name: ${{ env.IMAGE_NAME }}",
+		"sbom-path: dist/workcell-image.spdx.json",
+		"subject-path: dist/${{ env.BUNDLE_NAME }}",
+		"sbom-path: dist/workcell-source.spdx.json",
+		"subject-path: dist/workcell.rb",
+		"subject-path: dist/workcell-image.digest",
+		"subject-path: dist/workcell-build-inputs.json",
+		"subject-path: dist/workcell-control-plane.json",
+		"subject-path: dist/workcell-builder-environment.json",
+		"subject-path: dist/SHA256SUMS",
+	} {
+		if !strings.Contains(releaseWorkflow, needle) {
+			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
+		}
+	}
+	return nil
+}
+
+func ValidateMacOSInstallVerificationFlow(workflowText, workflowPath, artifactName, jobName string) error {
+	for _, needle := range []string{
+		fmt.Sprintf("name: %s", artifactName),
+		jobName,
+		"macos-26",
+		"macos-15",
+		"actions/upload-artifact@",
+		"actions/download-artifact@",
+		`"${bundle_dir}/scripts/install.sh"`,
+		`"${bundle_dir}/scripts/uninstall.sh"`,
+		"brew tap-new",
+		"brew --repo",
+		"brew install \"${tap_name}/workcell\"",
+		"brew uninstall --force \"${tap_name}/workcell\"",
+		"brew list --versions workcell",
+	} {
+		if !strings.Contains(workflowText, needle) {
+			return fmt.Errorf("%s must contain %q", workflowPath, needle)
+		}
+	}
+
+	if !strings.Contains(workflowText, "find dist/install -maxdepth 1 -type f -name 'workcell-*.tar.gz'") {
+		return fmt.Errorf("%s must resolve the reviewed install-candidate bundle from the artifact download", workflowPath)
+	}
+
+	return nil
+}
+
+func ValidateUpstreamRefreshWorkflow(workflowText string) error {
+	for _, needle := range []string{
+		"name: Upstream refresh",
+		"workflow_dispatch:",
+		"./scripts/update-upstream-pins.sh --apply",
+		"./scripts/update-upstream-pins.sh --check",
+		"./scripts/check-pinned-inputs.sh",
+		"environment:\n      name: upstream-refresh",
+		"actions/upload-artifact@",
+		"name: upstream-refresh-candidate",
+		"metadata.json",
+		"gh issue",
+		"persist-credentials: false",
+		"fetch-depth: 0",
+		"contents: read",
+		"issues: write",
+		"pull-requests: read",
+		"WORKCELL_COSIGN_VERSION:",
+		"sigstore/cosign-installer@",
+		"cosign-release: ${{ env.WORKCELL_COSIGN_VERSION }}",
+		`sudo install -m 0755 "$(command -v cosign)" /usr/local/bin/cosign`,
+	} {
+		if !strings.Contains(workflowText, needle) {
+			return fmt.Errorf(".github/workflows/upstream-refresh.yml must contain %q", needle)
+		}
+	}
+	for _, forbidden := range []string{
+		"WORKCELL_UPSTREAM_REFRESH_GIT_NAME",
+		"WORKCELL_UPSTREAM_REFRESH_GIT_EMAIL",
+		"WORKCELL_UPSTREAM_REFRESH_GPG_FINGERPRINT",
+		"WORKCELL_UPSTREAM_REFRESH_GPG_PRIVATE_KEY",
+		"WORKCELL_UPSTREAM_REFRESH_GPG_KEY_ID",
+		"gpg --batch --with-colons --list-secret-keys",
+		"git commit -S",
+		"gh pr create",
+		`git push "https://x-access-token:`,
+		"contents: write",
+		"pull-requests: write",
+	} {
+		if strings.Contains(workflowText, forbidden) {
+			return fmt.Errorf(".github/workflows/upstream-refresh.yml must not contain %q", forbidden)
+		}
+	}
+	return nil
+}
+
+func readText(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func mustStringSlice(value any) ([]string, bool, error) {
+	raw, ok := value.([]any)
+	if !ok {
+		return nil, false, nil
+	}
+	result := make([]string, 0, len(raw))
+	for _, item := range raw {
+		s, ok := item.(string)
+		if !ok {
+			return nil, false, errors.New("array value must contain only strings")
+		}
+		result = append(result, s)
+	}
+	return result, true, nil
+}
+
+func requireStringSliceTable(root map[string]any, tableName, key, sourcePath string) ([]string, error) {
+	table, ok := root[tableName].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must define %s.%s as a non-empty array", sourcePath, tableName, key)
+	}
+	values, ok, err := mustStringSlice(table[key])
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("%s must define %s.%s as a non-empty array", sourcePath, tableName, key)
+	}
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("%s must define %s.%s as a non-empty array", sourcePath, tableName, key)
+		}
+	}
+	return values, nil
+}


### PR DESCRIPTION
## Summary

First sub-PR of the `internal/metadatautil/validate.go` decomposition
(Section C of the /sethify-remediation plan). Moves the GitHub Actions
workflow validation cluster from `internal/metadatautil/validate.go`
into a new `internal/metadatautil/workflows/` subpackage.

Moved (with exported names so existing tests in `package metadatautil`
can keep using them via `workflows.X`):
- `CollectWorkflowJobNames` (was `collectWorkflowJobNames`)
- `CheckWorkflows`, `EnsureWorkflowTools`
- `ValidateCodeQLWorkflow`, `ValidateReleaseWorkflowCodeQLFlow`
- `ValidateCIWorkflowPRShapeFlow`
- `ValidateReleaseWorkflowControlPlaneFlow`
- `ValidateReleaseWorkflowGitHubAttestationFlow`
- `ValidateMacOSInstallVerificationFlow`
- `ValidateUpstreamRefreshWorkflow`
- `workflowDocument`, `workflowJob` types

The new subpackage avoids a circular dep with `metadatautil` by
inlining `readText`, `requireStringSliceTable`, and `mustStringSlice`
and calling `tomlsubset.Parse` directly instead of routing through
`metadatautil.ParseTOMLSubset`.

`CheckPinnedInputs` in `metadatautil/validate.go` now calls the new
`workflows` package for the CI / release / macOS install / upstream
refresh validators it invokes mid-pinning-validation.

`isSafePullRequestTargetWorkflow` + `parseWorkflowRoot` +
`yamlMappingValues` + `yamlScalarValue` stay in `validate.go` for now;
they move with `CheckPinnedInputs` when that cluster itself is
extracted in a later sub-PR. Likewise, the hosted-controls validators
and tests stay in `metadatautil` for the hostedcontrols sub-PR.

Drops 341 LOC from `validate.go`. No behavior change.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages green, metadatautil tests still
  exercise the moved validators via `workflows.X`
- [x] `gofmt -l .` — empty
- [x] `bash scripts/check-pr-shape.sh` — files=5 lines=842 areas=2 binaries=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)