### PR TITLE
^R Extract hosted-controls policy helpers into internal/metadatautil/hostedcontrols

### DIFF
--- a/cmd/workcell-metadatautil/main.go
+++ b/cmd/workcell-metadatautil/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/omkhar/workcell/internal/metadatautil"
+	"github.com/omkhar/workcell/internal/metadatautil/hostedcontrols"
 	"github.com/omkhar/workcell/internal/metadatautil/workflows"
 )
 
@@ -86,12 +87,12 @@ func main() {
 		if len(os.Args) != 4 {
 			die(fmt.Errorf("usage: %s fetch-rulesets TMP_DIR REPO", os.Args[0]))
 		}
-		err = metadatautil.FetchGitHubHostedControlsRulesets(os.Args[2], os.Args[3])
+		err = hostedcontrols.FetchRulesets(os.Args[2], os.Args[3])
 	case "list-hosted-control-environments":
 		if len(os.Args) != 3 {
 			die(fmt.Errorf("usage: %s list-hosted-control-environments POLICY_PATH", os.Args[0]))
 		}
-		environments, listErr := metadatautil.HostedControlsEnvironmentNames(os.Args[2])
+		environments, listErr := hostedcontrols.EnvironmentNames(os.Args[2])
 		if listErr != nil {
 			die(listErr)
 		}

--- a/internal/metadatautil/hostedcontrols/doc.go
+++ b/internal/metadatautil/hostedcontrols/doc.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package hostedcontrols carries the GitHub-hosted-controls policy
+// parsing helpers that used to live in
+// internal/metadatautil/validate.go: repository variable / workflow
+// environment policy extraction, canonical-value validation,
+// environment-name listing, artifact-name escaping, and the
+// gh-api-driven ruleset fetcher. The host-side verifier
+// (VerifyGitHubHostedControls) remains in the parent metadatautil
+// package for now and calls into this package for the policy helpers
+// it needs.
+package hostedcontrols

--- a/internal/metadatautil/hostedcontrols/hostedcontrols.go
+++ b/internal/metadatautil/hostedcontrols/hostedcontrols.go
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package hostedcontrols
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/tomlsubset"
+)
+
+type WorkflowEnvironmentPolicy struct {
+	Variables             map[string]string
+	RequiredSecrets       []string
+	AllowAdminBypass      bool
+	HasAllowAdminBypass   bool
+	DeploymentBranches    []string
+	HasDeploymentBranches bool
+	DeploymentTags        []string
+	HasDeploymentTags     bool
+}
+
+func RepositoryVariables(policy map[string]any, policyPath string) (map[string]any, error) {
+	expectedRepoVariables, ok := policy["repository_variables"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must define repository_variables as a table of exact expected values", policyPath)
+	}
+	for name, value := range expectedRepoVariables {
+		if strings.TrimSpace(name) == "" {
+			return nil, fmt.Errorf("%s repository_variables entries must map non-empty names to exact string values", policyPath)
+		}
+		if _, ok := value.(string); !ok {
+			return nil, fmt.Errorf("%s repository_variables entries must map non-empty names to exact string values", policyPath)
+		}
+	}
+	for _, requiredName := range []string{
+		"WORKCELL_RELEASE_NO_ATTEST",
+		"WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS",
+	} {
+		if _, ok := expectedRepoVariables[requiredName]; !ok {
+			return nil, fmt.Errorf("%s must declare %s in repository_variables", policyPath, requiredName)
+		}
+	}
+	return expectedRepoVariables, nil
+}
+
+func ValidateCanonicalRepositoryVariables(policy map[string]any, policyPath string) error {
+	repositoryVariables, err := RepositoryVariables(policy, policyPath)
+	if err != nil {
+		return err
+	}
+	if value, _ := repositoryVariables["WORKCELL_RELEASE_NO_ATTEST"].(string); value != "false" {
+		return errors.New("policy/github-hosted-controls.toml must require WORKCELL_RELEASE_NO_ATTEST = \"false\"")
+	}
+	if value, _ := repositoryVariables["WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS"].(string); value != "false" {
+		return errors.New("policy/github-hosted-controls.toml must require WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = \"false\"")
+	}
+	return nil
+}
+
+func WorkflowEnvironments(policy map[string]any, policyPath string) (map[string]WorkflowEnvironmentPolicy, error) {
+	rawEnvironments, ok := policy["workflow_environment"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must define workflow_environment as a table of named environment contracts", policyPath)
+	}
+
+	environments := make(map[string]WorkflowEnvironmentPolicy, len(rawEnvironments))
+	for environmentName, rawEntry := range rawEnvironments {
+		if strings.TrimSpace(environmentName) == "" {
+			return nil, fmt.Errorf("%s workflow_environment entries must use non-empty environment names", policyPath)
+		}
+		entry, ok := rawEntry.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%s workflow_environment.%s must be a table", policyPath, environmentName)
+		}
+
+		variables := map[string]string{}
+		if rawVariables, ok := entry["variables"]; ok {
+			variableTable, ok := rawVariables.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("%s workflow_environment.%s.variables must be a table of exact expected values", policyPath, environmentName)
+			}
+			for name, rawValue := range variableTable {
+				value, ok := rawValue.(string)
+				if strings.TrimSpace(name) == "" || !ok || strings.TrimSpace(value) == "" {
+					return nil, fmt.Errorf("%s workflow_environment.%s.variables must map non-empty names to exact string values", policyPath, environmentName)
+				}
+				variables[name] = value
+			}
+		}
+
+		requiredSecrets := []string{}
+		if rawSecrets, ok := entry["required_secrets"]; ok {
+			secrets, present, err := mustStringSlice(rawSecrets)
+			if err != nil {
+				return nil, fmt.Errorf("%s workflow_environment.%s.required_secrets: %w", policyPath, environmentName, err)
+			}
+			if !present {
+				return nil, fmt.Errorf("%s workflow_environment.%s.required_secrets must be an array of secret names", policyPath, environmentName)
+			}
+			for _, secretName := range secrets {
+				if strings.TrimSpace(secretName) == "" {
+					return nil, fmt.Errorf("%s workflow_environment.%s.required_secrets must be an array of non-empty secret names", policyPath, environmentName)
+				}
+			}
+			requiredSecrets = append(requiredSecrets, secrets...)
+			slices.Sort(requiredSecrets)
+		}
+
+		allowAdminBypass := false
+		hasAllowAdminBypass := false
+		if rawAllowAdminBypass, ok := entry["allow_admin_bypass"]; ok {
+			value, ok := rawAllowAdminBypass.(bool)
+			if !ok {
+				return nil, fmt.Errorf("%s workflow_environment.%s.allow_admin_bypass must be a boolean", policyPath, environmentName)
+			}
+			allowAdminBypass = value
+			hasAllowAdminBypass = true
+		}
+
+		deploymentBranches := []string{}
+		hasDeploymentBranches := false
+		if rawDeploymentBranches, ok := entry["deployment_branches"]; ok {
+			branches, present, err := mustStringSlice(rawDeploymentBranches)
+			if err != nil {
+				return nil, fmt.Errorf("%s workflow_environment.%s.deployment_branches: %w", policyPath, environmentName, err)
+			}
+			if !present {
+				return nil, fmt.Errorf("%s workflow_environment.%s.deployment_branches must be an array of branch names", policyPath, environmentName)
+			}
+			for _, branchName := range branches {
+				if strings.TrimSpace(branchName) == "" {
+					return nil, fmt.Errorf("%s workflow_environment.%s.deployment_branches must be an array of non-empty branch names", policyPath, environmentName)
+				}
+			}
+			deploymentBranches = append(deploymentBranches, branches...)
+			slices.Sort(deploymentBranches)
+			hasDeploymentBranches = true
+		}
+		deploymentTags := []string{}
+		hasDeploymentTags := false
+		if rawDeploymentTags, ok := entry["deployment_tags"]; ok {
+			tags, present, err := mustStringSlice(rawDeploymentTags)
+			if err != nil {
+				return nil, fmt.Errorf("%s workflow_environment.%s.deployment_tags: %w", policyPath, environmentName, err)
+			}
+			if !present {
+				return nil, fmt.Errorf("%s workflow_environment.%s.deployment_tags must be an array of tag patterns", policyPath, environmentName)
+			}
+			for _, tagPattern := range tags {
+				if strings.TrimSpace(tagPattern) == "" {
+					return nil, fmt.Errorf("%s workflow_environment.%s.deployment_tags must be an array of non-empty tag patterns", policyPath, environmentName)
+				}
+			}
+			deploymentTags = append(deploymentTags, tags...)
+			slices.Sort(deploymentTags)
+			hasDeploymentTags = true
+		}
+
+		environments[environmentName] = WorkflowEnvironmentPolicy{
+			Variables:             variables,
+			RequiredSecrets:       requiredSecrets,
+			AllowAdminBypass:      allowAdminBypass,
+			HasAllowAdminBypass:   hasAllowAdminBypass,
+			DeploymentBranches:    deploymentBranches,
+			HasDeploymentBranches: hasDeploymentBranches,
+			DeploymentTags:        deploymentTags,
+			HasDeploymentTags:     hasDeploymentTags,
+		}
+	}
+	return environments, nil
+}
+
+func ValidateCanonicalWorkflowEnvironments(policy map[string]any, policyPath string) error {
+	environments, err := WorkflowEnvironments(policy, policyPath)
+	if err != nil {
+		return err
+	}
+
+	hostedControlsAudit, ok := environments["hosted-controls-audit"]
+	if !ok {
+		return errors.New("policy/github-hosted-controls.toml must declare workflow_environment.hosted-controls-audit")
+	}
+	if len(hostedControlsAudit.Variables) != 0 {
+		return errors.New("policy/github-hosted-controls.toml must not declare public variables for workflow_environment.hosted-controls-audit")
+	}
+	if len(hostedControlsAudit.RequiredSecrets) != 1 || hostedControlsAudit.RequiredSecrets[0] != "WORKCELL_HOSTED_CONTROLS_TOKEN" {
+		return errors.New("policy/github-hosted-controls.toml must require only WORKCELL_HOSTED_CONTROLS_TOKEN for workflow_environment.hosted-controls-audit")
+	}
+	if !hostedControlsAudit.HasAllowAdminBypass || hostedControlsAudit.AllowAdminBypass {
+		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.hosted-controls-audit.allow_admin_bypass = false")
+	}
+	if !hostedControlsAudit.HasDeploymentBranches || len(hostedControlsAudit.DeploymentBranches) != 1 || hostedControlsAudit.DeploymentBranches[0] != "main" {
+		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.hosted-controls-audit.deployment_branches = [\"main\"]")
+	}
+	if !hostedControlsAudit.HasDeploymentTags || len(hostedControlsAudit.DeploymentTags) != 1 || hostedControlsAudit.DeploymentTags[0] != "v*" {
+		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.hosted-controls-audit.deployment_tags = [\"v*\"]")
+	}
+
+	upstreamRefresh, ok := environments["upstream-refresh"]
+	if !ok {
+		return errors.New("policy/github-hosted-controls.toml must declare workflow_environment.upstream-refresh")
+	}
+	if len(upstreamRefresh.RequiredSecrets) != 0 {
+		return errors.New("policy/github-hosted-controls.toml must not declare secrets for workflow_environment.upstream-refresh")
+	}
+	if len(upstreamRefresh.Variables) != 0 {
+		return errors.New("policy/github-hosted-controls.toml must not declare public variables for workflow_environment.upstream-refresh")
+	}
+	if !upstreamRefresh.HasAllowAdminBypass || upstreamRefresh.AllowAdminBypass {
+		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.upstream-refresh.allow_admin_bypass = false")
+	}
+	if !upstreamRefresh.HasDeploymentBranches || len(upstreamRefresh.DeploymentBranches) != 1 || upstreamRefresh.DeploymentBranches[0] != "main" {
+		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.upstream-refresh.deployment_branches = [\"main\"]")
+	}
+	if upstreamRefresh.HasDeploymentTags || len(upstreamRefresh.DeploymentTags) != 0 {
+		return errors.New("policy/github-hosted-controls.toml must not set workflow_environment.upstream-refresh.deployment_tags")
+	}
+	return nil
+}
+
+func EnvironmentNames(policyPath string) ([]string, error) {
+	content, err := os.ReadFile(policyPath)
+	if err != nil {
+		return nil, err
+	}
+	policy, err := tomlsubset.Parse(string(content), policyPath)
+	if err != nil {
+		return nil, err
+	}
+	environments, err := WorkflowEnvironments(policy, policyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(environments))
+	for environmentName := range environments {
+		names = append(names, environmentName)
+	}
+	slices.Sort(names)
+	return names, nil
+}
+
+func EnvironmentArtifactName(environmentName string) string {
+	return strings.ReplaceAll(url.QueryEscape(environmentName), "+", "%20")
+}
+
+func FetchRulesets(tmpDir, repo string) error {
+	var summary []any
+	if err := readJSONFile(filepath.Join(tmpDir, "rulesets-summary.json"), &summary); err != nil {
+		return err
+	}
+
+	details := make([]any, 0, len(summary))
+	for _, raw := range summary {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf("unexpected ruleset summary entry: %v", raw)
+		}
+		idValue, ok := entry["id"].(float64)
+		if !ok {
+			return fmt.Errorf("unexpected ruleset summary id: %v", entry)
+		}
+		rulesetID := strconv.FormatInt(int64(idValue), 10)
+		cmd := exec.Command("gh", "api", fmt.Sprintf("repos/%s/rulesets/%s", repo, rulesetID))
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		output, err := cmd.Output()
+		if err != nil {
+			return fmt.Errorf("gh api repos/%s/rulesets/%s: %w (stderr: %s)", repo, rulesetID, err, strings.TrimSpace(stderr.String()))
+		}
+		var detail any
+		if err := json.Unmarshal(output, &detail); err != nil {
+			return fmt.Errorf("gh api repos/%s/rulesets/%s: parse JSON: %w", repo, rulesetID, err)
+		}
+		details = append(details, detail)
+	}
+	return writeJSONFile(filepath.Join(tmpDir, "rulesets.json"), details)
+}
+
+func UnexpectedEnvironmentVariableNames(actual map[string]any, expected map[string]string) []string {
+	unexpected := make([]string, 0)
+	for name := range actual {
+		if _, ok := expected[name]; !ok {
+			unexpected = append(unexpected, name)
+		}
+	}
+	slices.Sort(unexpected)
+	return unexpected
+}
+
+func UnexpectedEnvironmentSecretNames(actual map[string]struct{}, expected []string) []string {
+	expectedSet := make(map[string]struct{}, len(expected))
+	for _, name := range expected {
+		expectedSet[name] = struct{}{}
+	}
+	unexpected := make([]string, 0)
+	for name := range actual {
+		if _, ok := expectedSet[name]; !ok {
+			unexpected = append(unexpected, name)
+		}
+	}
+	slices.Sort(unexpected)
+	return unexpected
+}
+
+func mustStringSlice(value any) ([]string, bool, error) {
+	raw, ok := value.([]any)
+	if !ok {
+		return nil, false, nil
+	}
+	result := make([]string, 0, len(raw))
+	for _, item := range raw {
+		s, ok := item.(string)
+		if !ok {
+			return nil, false, errors.New("array value must contain only strings")
+		}
+		result = append(result, s)
+	}
+	return result, true, nil
+}
+
+func readJSONFile(path string, target any) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(content, target)
+}
+
+func writeJSONFile(path string, value any) error {
+	content, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	content = append(content, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, content, 0o644)
+}

--- a/internal/metadatautil/validate.go
+++ b/internal/metadatautil/validate.go
@@ -4,320 +4,22 @@
 package metadatautil
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
+	"github.com/omkhar/workcell/internal/metadatautil/hostedcontrols"
 	"github.com/omkhar/workcell/internal/metadatautil/workflows"
 	"github.com/omkhar/workcell/internal/tomlsubset"
 	"gopkg.in/yaml.v3"
 )
 
-type hostedControlsWorkflowEnvironmentPolicy struct {
-	Variables             map[string]string
-	RequiredSecrets       []string
-	AllowAdminBypass      bool
-	HasAllowAdminBypass   bool
-	DeploymentBranches    []string
-	HasDeploymentBranches bool
-	DeploymentTags        []string
-	HasDeploymentTags     bool
-}
-
-func hostedControlsRepositoryVariables(policy map[string]any, policyPath string) (map[string]any, error) {
-	expectedRepoVariables, ok := policy["repository_variables"].(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("%s must define repository_variables as a table of exact expected values", policyPath)
-	}
-	for name, value := range expectedRepoVariables {
-		if strings.TrimSpace(name) == "" {
-			return nil, fmt.Errorf("%s repository_variables entries must map non-empty names to exact string values", policyPath)
-		}
-		if _, ok := value.(string); !ok {
-			return nil, fmt.Errorf("%s repository_variables entries must map non-empty names to exact string values", policyPath)
-		}
-	}
-	for _, requiredName := range []string{
-		"WORKCELL_RELEASE_NO_ATTEST",
-		"WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS",
-	} {
-		if _, ok := expectedRepoVariables[requiredName]; !ok {
-			return nil, fmt.Errorf("%s must declare %s in repository_variables", policyPath, requiredName)
-		}
-	}
-	return expectedRepoVariables, nil
-}
-
-func validateCanonicalHostedControlsRepositoryVariables(policy map[string]any, policyPath string) error {
-	repositoryVariables, err := hostedControlsRepositoryVariables(policy, policyPath)
-	if err != nil {
-		return err
-	}
-	if value, _ := repositoryVariables["WORKCELL_RELEASE_NO_ATTEST"].(string); value != "false" {
-		return errors.New("policy/github-hosted-controls.toml must require WORKCELL_RELEASE_NO_ATTEST = \"false\"")
-	}
-	if value, _ := repositoryVariables["WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS"].(string); value != "false" {
-		return errors.New("policy/github-hosted-controls.toml must require WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = \"false\"")
-	}
-	return nil
-}
-
-func hostedControlsWorkflowEnvironments(policy map[string]any, policyPath string) (map[string]hostedControlsWorkflowEnvironmentPolicy, error) {
-	rawEnvironments, ok := policy["workflow_environment"].(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("%s must define workflow_environment as a table of named environment contracts", policyPath)
-	}
-
-	environments := make(map[string]hostedControlsWorkflowEnvironmentPolicy, len(rawEnvironments))
-	for environmentName, rawEntry := range rawEnvironments {
-		if strings.TrimSpace(environmentName) == "" {
-			return nil, fmt.Errorf("%s workflow_environment entries must use non-empty environment names", policyPath)
-		}
-		entry, ok := rawEntry.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("%s workflow_environment.%s must be a table", policyPath, environmentName)
-		}
-
-		variables := map[string]string{}
-		if rawVariables, ok := entry["variables"]; ok {
-			variableTable, ok := rawVariables.(map[string]any)
-			if !ok {
-				return nil, fmt.Errorf("%s workflow_environment.%s.variables must be a table of exact expected values", policyPath, environmentName)
-			}
-			for name, rawValue := range variableTable {
-				value, ok := rawValue.(string)
-				if strings.TrimSpace(name) == "" || !ok || strings.TrimSpace(value) == "" {
-					return nil, fmt.Errorf("%s workflow_environment.%s.variables must map non-empty names to exact string values", policyPath, environmentName)
-				}
-				variables[name] = value
-			}
-		}
-
-		requiredSecrets := []string{}
-		if rawSecrets, ok := entry["required_secrets"]; ok {
-			secrets, present, err := MustStringSlice(rawSecrets)
-			if err != nil {
-				return nil, fmt.Errorf("%s workflow_environment.%s.required_secrets: %w", policyPath, environmentName, err)
-			}
-			if !present {
-				return nil, fmt.Errorf("%s workflow_environment.%s.required_secrets must be an array of secret names", policyPath, environmentName)
-			}
-			for _, secretName := range secrets {
-				if strings.TrimSpace(secretName) == "" {
-					return nil, fmt.Errorf("%s workflow_environment.%s.required_secrets must be an array of non-empty secret names", policyPath, environmentName)
-				}
-			}
-			requiredSecrets = append(requiredSecrets, secrets...)
-			slices.Sort(requiredSecrets)
-		}
-
-		allowAdminBypass := false
-		hasAllowAdminBypass := false
-		if rawAllowAdminBypass, ok := entry["allow_admin_bypass"]; ok {
-			value, ok := rawAllowAdminBypass.(bool)
-			if !ok {
-				return nil, fmt.Errorf("%s workflow_environment.%s.allow_admin_bypass must be a boolean", policyPath, environmentName)
-			}
-			allowAdminBypass = value
-			hasAllowAdminBypass = true
-		}
-
-		deploymentBranches := []string{}
-		hasDeploymentBranches := false
-		if rawDeploymentBranches, ok := entry["deployment_branches"]; ok {
-			branches, present, err := MustStringSlice(rawDeploymentBranches)
-			if err != nil {
-				return nil, fmt.Errorf("%s workflow_environment.%s.deployment_branches: %w", policyPath, environmentName, err)
-			}
-			if !present {
-				return nil, fmt.Errorf("%s workflow_environment.%s.deployment_branches must be an array of branch names", policyPath, environmentName)
-			}
-			for _, branchName := range branches {
-				if strings.TrimSpace(branchName) == "" {
-					return nil, fmt.Errorf("%s workflow_environment.%s.deployment_branches must be an array of non-empty branch names", policyPath, environmentName)
-				}
-			}
-			deploymentBranches = append(deploymentBranches, branches...)
-			slices.Sort(deploymentBranches)
-			hasDeploymentBranches = true
-		}
-		deploymentTags := []string{}
-		hasDeploymentTags := false
-		if rawDeploymentTags, ok := entry["deployment_tags"]; ok {
-			tags, present, err := MustStringSlice(rawDeploymentTags)
-			if err != nil {
-				return nil, fmt.Errorf("%s workflow_environment.%s.deployment_tags: %w", policyPath, environmentName, err)
-			}
-			if !present {
-				return nil, fmt.Errorf("%s workflow_environment.%s.deployment_tags must be an array of tag patterns", policyPath, environmentName)
-			}
-			for _, tagPattern := range tags {
-				if strings.TrimSpace(tagPattern) == "" {
-					return nil, fmt.Errorf("%s workflow_environment.%s.deployment_tags must be an array of non-empty tag patterns", policyPath, environmentName)
-				}
-			}
-			deploymentTags = append(deploymentTags, tags...)
-			slices.Sort(deploymentTags)
-			hasDeploymentTags = true
-		}
-
-		environments[environmentName] = hostedControlsWorkflowEnvironmentPolicy{
-			Variables:             variables,
-			RequiredSecrets:       requiredSecrets,
-			AllowAdminBypass:      allowAdminBypass,
-			HasAllowAdminBypass:   hasAllowAdminBypass,
-			DeploymentBranches:    deploymentBranches,
-			HasDeploymentBranches: hasDeploymentBranches,
-			DeploymentTags:        deploymentTags,
-			HasDeploymentTags:     hasDeploymentTags,
-		}
-	}
-	return environments, nil
-}
-
-func validateCanonicalHostedControlsWorkflowEnvironments(policy map[string]any, policyPath string) error {
-	environments, err := hostedControlsWorkflowEnvironments(policy, policyPath)
-	if err != nil {
-		return err
-	}
-
-	hostedControlsAudit, ok := environments["hosted-controls-audit"]
-	if !ok {
-		return errors.New("policy/github-hosted-controls.toml must declare workflow_environment.hosted-controls-audit")
-	}
-	if len(hostedControlsAudit.Variables) != 0 {
-		return errors.New("policy/github-hosted-controls.toml must not declare public variables for workflow_environment.hosted-controls-audit")
-	}
-	if len(hostedControlsAudit.RequiredSecrets) != 1 || hostedControlsAudit.RequiredSecrets[0] != "WORKCELL_HOSTED_CONTROLS_TOKEN" {
-		return errors.New("policy/github-hosted-controls.toml must require only WORKCELL_HOSTED_CONTROLS_TOKEN for workflow_environment.hosted-controls-audit")
-	}
-	if !hostedControlsAudit.HasAllowAdminBypass || hostedControlsAudit.AllowAdminBypass {
-		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.hosted-controls-audit.allow_admin_bypass = false")
-	}
-	if !hostedControlsAudit.HasDeploymentBranches || len(hostedControlsAudit.DeploymentBranches) != 1 || hostedControlsAudit.DeploymentBranches[0] != "main" {
-		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.hosted-controls-audit.deployment_branches = [\"main\"]")
-	}
-	if !hostedControlsAudit.HasDeploymentTags || len(hostedControlsAudit.DeploymentTags) != 1 || hostedControlsAudit.DeploymentTags[0] != "v*" {
-		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.hosted-controls-audit.deployment_tags = [\"v*\"]")
-	}
-
-	upstreamRefresh, ok := environments["upstream-refresh"]
-	if !ok {
-		return errors.New("policy/github-hosted-controls.toml must declare workflow_environment.upstream-refresh")
-	}
-	if len(upstreamRefresh.RequiredSecrets) != 0 {
-		return errors.New("policy/github-hosted-controls.toml must not declare secrets for workflow_environment.upstream-refresh")
-	}
-	if len(upstreamRefresh.Variables) != 0 {
-		return errors.New("policy/github-hosted-controls.toml must not declare public variables for workflow_environment.upstream-refresh")
-	}
-	if !upstreamRefresh.HasAllowAdminBypass || upstreamRefresh.AllowAdminBypass {
-		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.upstream-refresh.allow_admin_bypass = false")
-	}
-	if !upstreamRefresh.HasDeploymentBranches || len(upstreamRefresh.DeploymentBranches) != 1 || upstreamRefresh.DeploymentBranches[0] != "main" {
-		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.upstream-refresh.deployment_branches = [\"main\"]")
-	}
-	if upstreamRefresh.HasDeploymentTags || len(upstreamRefresh.DeploymentTags) != 0 {
-		return errors.New("policy/github-hosted-controls.toml must not set workflow_environment.upstream-refresh.deployment_tags")
-	}
-	return nil
-}
-
-func HostedControlsEnvironmentNames(policyPath string) ([]string, error) {
-	policyText, err := readText(policyPath)
-	if err != nil {
-		return nil, err
-	}
-	policy, err := ParseTOMLSubset(policyText, policyPath)
-	if err != nil {
-		return nil, err
-	}
-	environments, err := hostedControlsWorkflowEnvironments(policy, policyPath)
-	if err != nil {
-		return nil, err
-	}
-
-	names := make([]string, 0, len(environments))
-	for environmentName := range environments {
-		names = append(names, environmentName)
-	}
-	slices.Sort(names)
-	return names, nil
-}
-
-func hostedControlsEnvironmentArtifactName(environmentName string) string {
-	return strings.ReplaceAll(url.QueryEscape(environmentName), "+", "%20")
-}
-
-func FetchGitHubHostedControlsRulesets(tmpDir, repo string) error {
-	var summary []any
-	if err := readJSONFile(filepath.Join(tmpDir, "rulesets-summary.json"), &summary); err != nil {
-		return err
-	}
-
-	details := make([]any, 0, len(summary))
-	for _, raw := range summary {
-		entry, ok := raw.(map[string]any)
-		if !ok {
-			return fmt.Errorf("unexpected ruleset summary entry: %v", raw)
-		}
-		idValue, ok := entry["id"].(float64)
-		if !ok {
-			return fmt.Errorf("unexpected ruleset summary id: %v", entry)
-		}
-		rulesetID := strconv.FormatInt(int64(idValue), 10)
-		cmd := exec.Command("gh", "api", fmt.Sprintf("repos/%s/rulesets/%s", repo, rulesetID))
-		var stderr bytes.Buffer
-		cmd.Stderr = &stderr
-		output, err := cmd.Output()
-		if err != nil {
-			return fmt.Errorf("gh api repos/%s/rulesets/%s: %w (stderr: %s)", repo, rulesetID, err, strings.TrimSpace(stderr.String()))
-		}
-		var detail any
-		if err := json.Unmarshal(output, &detail); err != nil {
-			return fmt.Errorf("gh api repos/%s/rulesets/%s: parse JSON: %w", repo, rulesetID, err)
-		}
-		details = append(details, detail)
-	}
-	return writeJSONFile(filepath.Join(tmpDir, "rulesets.json"), details)
-}
-
-func unexpectedEnvironmentVariableNames(actual map[string]any, expected map[string]string) []string {
-	unexpected := make([]string, 0)
-	for name := range actual {
-		if _, ok := expected[name]; !ok {
-			unexpected = append(unexpected, name)
-		}
-	}
-	slices.Sort(unexpected)
-	return unexpected
-}
-
-func unexpectedEnvironmentSecretNames(actual map[string]struct{}, expected []string) []string {
-	expectedSet := make(map[string]struct{}, len(expected))
-	for _, name := range expected {
-		expectedSet[name] = struct{}{}
-	}
-	unexpected := make([]string, 0)
-	for name := range actual {
-		if _, ok := expectedSet[name]; !ok {
-			unexpected = append(unexpected, name)
-		}
-	}
-	slices.Sort(unexpected)
-	return unexpected
-}
-
-func verifyWorkflowEnvironmentDeploymentPolicy(repo, environmentName string, environmentPolicy hostedControlsWorkflowEnvironmentPolicy, environmentMeta, environmentBranchPolicies map[string]any) error {
+func verifyWorkflowEnvironmentDeploymentPolicy(repo, environmentName string, environmentPolicy hostedcontrols.WorkflowEnvironmentPolicy, environmentMeta, environmentBranchPolicies map[string]any) error {
 	if environmentPolicy.HasAllowAdminBypass {
 		bypass, ok := environmentMeta["can_admins_bypass"].(bool)
 		if !ok || bypass != environmentPolicy.AllowAdminBypass {
@@ -456,11 +158,11 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 	if len(expectedContexts) == 0 {
 		return fmt.Errorf("%s must define required_status_checks.contexts as a non-empty array", policyPath)
 	}
-	expectedRepoVariables, err := hostedControlsRepositoryVariables(policy, policyPath)
+	expectedRepoVariables, err := hostedcontrols.RepositoryVariables(policy, policyPath)
 	if err != nil {
 		return err
 	}
-	expectedWorkflowEnvironments, err := hostedControlsWorkflowEnvironments(policy, policyPath)
+	expectedWorkflowEnvironments, err := hostedcontrols.WorkflowEnvironments(policy, policyPath)
 	if err != nil {
 		return err
 	}
@@ -708,7 +410,7 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		return fmt.Errorf("workflow environments missing on %s: %s", repo, strings.Join(missingWorkflowEnvironments, ", "))
 	}
 	for environmentName, environmentPolicy := range expectedWorkflowEnvironments {
-		artifactName := hostedControlsEnvironmentArtifactName(environmentName)
+		artifactName := hostedcontrols.EnvironmentArtifactName(environmentName)
 		var environmentMeta map[string]any
 		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s.json", artifactName)), &environmentMeta); err != nil {
 			return fmt.Errorf("read %s environment metadata: %w", environmentName, err)
@@ -754,7 +456,7 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		if len(wrongEnvironmentVariables) > 0 {
 			return fmt.Errorf("workflow environment variables on %s/%s do not match policy: %s", repo, environmentName, strings.Join(wrongEnvironmentVariables, ", "))
 		}
-		unexpectedEnvironmentVariables := unexpectedEnvironmentVariableNames(actualEnvironmentVariables, environmentPolicy.Variables)
+		unexpectedEnvironmentVariables := hostedcontrols.UnexpectedEnvironmentVariableNames(actualEnvironmentVariables, environmentPolicy.Variables)
 		if len(unexpectedEnvironmentVariables) > 0 {
 			return fmt.Errorf("workflow environment variables on %s/%s include unexpected entries: %s", repo, environmentName, strings.Join(unexpectedEnvironmentVariables, ", "))
 		}
@@ -785,7 +487,7 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		if len(missingEnvironmentSecrets) > 0 {
 			return fmt.Errorf("workflow environment secrets missing on %s/%s: %s", repo, environmentName, strings.Join(missingEnvironmentSecrets, ", "))
 		}
-		unexpectedEnvironmentSecrets := unexpectedEnvironmentSecretNames(actualEnvironmentSecrets, environmentPolicy.RequiredSecrets)
+		unexpectedEnvironmentSecrets := hostedcontrols.UnexpectedEnvironmentSecretNames(actualEnvironmentSecrets, environmentPolicy.RequiredSecrets)
 		if len(unexpectedEnvironmentSecrets) > 0 {
 			return fmt.Errorf("workflow environment secrets on %s/%s include unexpected entries: %s", repo, environmentName, strings.Join(unexpectedEnvironmentSecrets, ", "))
 		}
@@ -1888,10 +1590,10 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if releaseMode != "review-gated" && releaseMode != "single-owner-public" && releaseMode != "single-owner-private" && releaseMode != "plan-limited-private" {
 		return errors.New("policy/github-hosted-controls.toml must set release_environment.mode to 'review-gated', 'single-owner-public', 'single-owner-private', or 'plan-limited-private'")
 	}
-	if err := validateCanonicalHostedControlsRepositoryVariables(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
+	if err := hostedcontrols.ValidateCanonicalRepositoryVariables(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
 		return err
 	}
-	if err := validateCanonicalHostedControlsWorkflowEnvironments(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
+	if err := hostedcontrols.ValidateCanonicalWorkflowEnvironments(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
 		return err
 	}
 	for _, needle := range []string{

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omkhar/workcell/internal/metadatautil/hostedcontrols"
 	"github.com/omkhar/workcell/internal/metadatautil/workflows"
 )
 
@@ -1129,12 +1130,12 @@ func TestValidateCanonicalHostedControlsRepositoryVariablesRejectsMissingPrivate
 		},
 	}
 
-	err := validateCanonicalHostedControlsRepositoryVariables(policy, "policy/github-hosted-controls.toml")
+	err := hostedcontrols.ValidateCanonicalRepositoryVariables(policy, "policy/github-hosted-controls.toml")
 	if err == nil {
-		t.Fatal("validateCanonicalHostedControlsRepositoryVariables() unexpectedly succeeded")
+		t.Fatal("hostedcontrols.ValidateCanonicalRepositoryVariables() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), "WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS") {
-		t.Fatalf("validateCanonicalHostedControlsRepositoryVariables() error = %v, want missing private attestation flag", err)
+		t.Fatalf("hostedcontrols.ValidateCanonicalRepositoryVariables() error = %v, want missing private attestation flag", err)
 	}
 }
 
@@ -1147,12 +1148,12 @@ func TestValidateCanonicalHostedControlsRepositoryVariablesRejectsWrongPrivateAt
 		},
 	}
 
-	err := validateCanonicalHostedControlsRepositoryVariables(policy, "policy/github-hosted-controls.toml")
+	err := hostedcontrols.ValidateCanonicalRepositoryVariables(policy, "policy/github-hosted-controls.toml")
 	if err == nil {
-		t.Fatal("validateCanonicalHostedControlsRepositoryVariables() unexpectedly succeeded")
+		t.Fatal("hostedcontrols.ValidateCanonicalRepositoryVariables() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), `WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = "false"`) {
-		t.Fatalf("validateCanonicalHostedControlsRepositoryVariables() error = %v, want private attestation value failure", err)
+		t.Fatalf("hostedcontrols.ValidateCanonicalRepositoryVariables() error = %v, want private attestation value failure", err)
 	}
 }
 
@@ -1165,8 +1166,8 @@ func TestValidateCanonicalHostedControlsRepositoryVariablesAcceptsCanonicalValue
 		},
 	}
 
-	if err := validateCanonicalHostedControlsRepositoryVariables(policy, "policy/github-hosted-controls.toml"); err != nil {
-		t.Fatalf("validateCanonicalHostedControlsRepositoryVariables() error = %v", err)
+	if err := hostedcontrols.ValidateCanonicalRepositoryVariables(policy, "policy/github-hosted-controls.toml"); err != nil {
+		t.Fatalf("hostedcontrols.ValidateCanonicalRepositoryVariables() error = %v", err)
 	}
 }
 
@@ -1181,12 +1182,12 @@ func TestValidateCanonicalHostedControlsWorkflowEnvironmentsRejectsMissingHosted
 		},
 	}
 
-	err := validateCanonicalHostedControlsWorkflowEnvironments(policy, "policy/github-hosted-controls.toml")
+	err := hostedcontrols.ValidateCanonicalWorkflowEnvironments(policy, "policy/github-hosted-controls.toml")
 	if err == nil {
-		t.Fatal("validateCanonicalHostedControlsWorkflowEnvironments() unexpectedly succeeded")
+		t.Fatal("hostedcontrols.ValidateCanonicalWorkflowEnvironments() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), "workflow_environment.hosted-controls-audit") {
-		t.Fatalf("validateCanonicalHostedControlsWorkflowEnvironments() error = %v, want hosted-controls-audit rejection", err)
+		t.Fatalf("hostedcontrols.ValidateCanonicalWorkflowEnvironments() error = %v, want hosted-controls-audit rejection", err)
 	}
 }
 
@@ -1208,12 +1209,12 @@ func TestValidateCanonicalHostedControlsWorkflowEnvironmentsRejectsUnexpectedUps
 		},
 	}
 
-	err := validateCanonicalHostedControlsWorkflowEnvironments(policy, "policy/github-hosted-controls.toml")
+	err := hostedcontrols.ValidateCanonicalWorkflowEnvironments(policy, "policy/github-hosted-controls.toml")
 	if err == nil {
-		t.Fatal("validateCanonicalHostedControlsWorkflowEnvironments() unexpectedly succeeded")
+		t.Fatal("hostedcontrols.ValidateCanonicalWorkflowEnvironments() unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), "must not declare secrets") {
-		t.Fatalf("validateCanonicalHostedControlsWorkflowEnvironments() error = %v, want upstream-refresh secret rejection", err)
+		t.Fatalf("hostedcontrols.ValidateCanonicalWorkflowEnvironments() error = %v, want upstream-refresh secret rejection", err)
 	}
 }
 
@@ -1234,23 +1235,23 @@ func TestValidateCanonicalHostedControlsWorkflowEnvironmentsAcceptsCanonicalValu
 		},
 	}
 
-	if err := validateCanonicalHostedControlsWorkflowEnvironments(policy, "policy/github-hosted-controls.toml"); err != nil {
-		t.Fatalf("validateCanonicalHostedControlsWorkflowEnvironments() error = %v", err)
+	if err := hostedcontrols.ValidateCanonicalWorkflowEnvironments(policy, "policy/github-hosted-controls.toml"); err != nil {
+		t.Fatalf("hostedcontrols.ValidateCanonicalWorkflowEnvironments() error = %v", err)
 	}
 }
 
 func TestHostedControlsEnvironmentArtifactNameEscapesSlashes(t *testing.T) {
 	t.Parallel()
 
-	if got := hostedControlsEnvironmentArtifactName("prod/us west"); got != "prod%2Fus%20west" {
-		t.Fatalf("hostedControlsEnvironmentArtifactName() = %q, want %q", got, "prod%2Fus%20west")
+	if got := hostedcontrols.EnvironmentArtifactName("prod/us west"); got != "prod%2Fus%20west" {
+		t.Fatalf("hostedcontrols.EnvironmentArtifactName() = %q, want %q", got, "prod%2Fus%20west")
 	}
 }
 
 func TestHostedControlsEnvironmentArtifactNameEscapesReservedCharacters(t *testing.T) {
 	t.Parallel()
 
-	if got := hostedControlsEnvironmentArtifactName("prod+east:blue&green=1"); got != "prod%2Beast%3Ablue%26green%3D1" {
-		t.Fatalf("hostedControlsEnvironmentArtifactName() = %q, want %q", got, "prod%2Beast%3Ablue%26green%3D1")
+	if got := hostedcontrols.EnvironmentArtifactName("prod+east:blue&green=1"); got != "prod%2Beast%3Ablue%26green%3D1" {
+		t.Fatalf("hostedcontrols.EnvironmentArtifactName() = %q, want %q", got, "prod%2Beast%3Ablue%26green%3D1")
 	}
 }


### PR DESCRIPTION
## Summary

Second sub-PR of the `internal/metadatautil/validate.go` decomposition.
Moves the GitHub-hosted-controls policy parsing and gh-api fetcher
out of `internal/metadatautil/validate.go` into a new
`internal/metadatautil/hostedcontrols/` subpackage.

Moved (with shorter, in-subpackage exported names):
- `WorkflowEnvironmentPolicy` type
- `RepositoryVariables`, `ValidateCanonicalRepositoryVariables`
- `WorkflowEnvironments`, `ValidateCanonicalWorkflowEnvironments`
- `EnvironmentNames`, `EnvironmentArtifactName`
- `FetchRulesets`
- `UnexpectedEnvironmentVariableNames`, `UnexpectedEnvironmentSecretNames`

The host-side verifier (`VerifyGitHubHostedControls` and the
`verifyWorkflowEnvironmentDeploymentPolicy` helper) stays in
`validate.go` for now; it now calls into the new package via the
exported names.  The hostedcontrols package inlines its TOML and JSON
I/O helpers to avoid a circular dep with `metadatautil`.

`cmd/workcell-metadatautil/main.go` updates its two callers
(`fetch-hosted-controls-rulesets`, `list-hosted-control-environments`)
to use the new package, and `workflow_validation_test.go` updates the
hosted-controls test callsites accordingly.

Drops 316 LOC from `validate.go`. No behavior change.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages green
- [x] `gofmt -l .` — empty
- [x] `bash scripts/check-pr-shape.sh` — files=5 lines=726 areas=2 binaries=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)