### PR TITLE
^R Move install-deps mock binaries out of verify-invariants.sh into harnesses/

### DIFF
--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1286,67 +1286,11 @@ EOF
   chmod 0755 "${INSTALL_DEPS_VERIFY_BIN}/${required_tool}"
 done
 
-cat <<'EOF' >"${INSTALL_DEPS_VERIFY_BIN}/uname"
-#!/bin/bash
-set -euo pipefail
-case "${1:-}" in
-  -s)
-    printf 'Darwin\n'
-    ;;
-  -m)
-    printf 'arm64\n'
-    ;;
-  *)
-    printf 'Darwin\n'
-    ;;
-esac
-EOF
-chmod 0755 "${INSTALL_DEPS_VERIFY_BIN}/uname"
-
-cat <<'EOF' >"${INSTALL_DEPS_VERIFY_BIN}/dirname"
-#!/bin/bash
-set -euo pipefail
-exec /usr/bin/dirname "$@"
-EOF
-chmod 0755 "${INSTALL_DEPS_VERIFY_BIN}/dirname"
-
-cat <<'EOF' >"${INSTALL_DEPS_VERIFY_BIN}/basename"
-#!/bin/bash
-set -euo pipefail
-exec /usr/bin/basename "$@"
-EOF
-chmod 0755 "${INSTALL_DEPS_VERIFY_BIN}/basename"
-
-cat <<'EOF' >"${INSTALL_DEPS_VERIFY_BIN}/sysctl"
-#!/bin/bash
-set -euo pipefail
-if [[ "${1:-}" == "-in" ]] && [[ "${2:-}" == "hw.optional.arm64" ]]; then
-  printf '1\n'
-  exit 0
-fi
-exit 1
-EOF
-chmod 0755 "${INSTALL_DEPS_VERIFY_BIN}/sysctl"
-
-cat <<'EOF' >"${INSTALL_DEPS_VERIFY_BIN}/brew"
-#!/bin/bash
-set -euo pipefail
-if [[ "${1:-}" != "install" ]]; then
-  echo "Expected only brew install during installer dependency bootstrap" >&2
-  exit 1
-fi
-shift
-printf 'install %s\n' "$*" >"${INSTALL_DEPS_LOG}"
-for pkg in "$@"; do
-  cat <<'EOFAKE' >"${INSTALL_DEPS_FAKEBIN}/${pkg}"
-#!/bin/bash
-set -euo pipefail
-exit 0
-EOFAKE
-  chmod 0755 "${INSTALL_DEPS_FAKEBIN}/${pkg}"
+for mock_tool in uname dirname basename sysctl brew; do
+  install -m 0755 \
+    "${ROOT_DIR}/verify/invariants/harnesses/install-deps/${mock_tool}.sh" \
+    "${INSTALL_DEPS_VERIFY_BIN}/${mock_tool}"
 done
-EOF
-chmod 0755 "${INSTALL_DEPS_VERIFY_BIN}/brew"
 
 if ! env -i \
   HOME="${INSTALL_DEPS_VERIFY_HOME}" \

--- a/verify/invariants/harnesses/install-deps/basename.sh
+++ b/verify/invariants/harnesses/install-deps/basename.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+exec /usr/bin/basename "$@"

--- a/verify/invariants/harnesses/install-deps/brew.sh
+++ b/verify/invariants/harnesses/install-deps/brew.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+if [[ "${1:-}" != "install" ]]; then
+  echo "Expected only brew install during installer dependency bootstrap" >&2
+  exit 1
+fi
+shift
+printf 'install %s\n' "$*" >"${INSTALL_DEPS_LOG}"
+for pkg in "$@"; do
+  cat <<'EOFAKE' >"${INSTALL_DEPS_FAKEBIN}/${pkg}"
+#!/bin/bash
+set -euo pipefail
+exit 0
+EOFAKE
+  chmod 0755 "${INSTALL_DEPS_FAKEBIN}/${pkg}"
+done

--- a/verify/invariants/harnesses/install-deps/dirname.sh
+++ b/verify/invariants/harnesses/install-deps/dirname.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+exec /usr/bin/dirname "$@"

--- a/verify/invariants/harnesses/install-deps/sysctl.sh
+++ b/verify/invariants/harnesses/install-deps/sysctl.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+if [[ "${1:-}" == "-in" ]] && [[ "${2:-}" == "hw.optional.arm64" ]]; then
+  printf '1\n'
+  exit 0
+fi
+exit 1

--- a/verify/invariants/harnesses/install-deps/uname.sh
+++ b/verify/invariants/harnesses/install-deps/uname.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+case "${1:-}" in
+  -s)
+    printf 'Darwin\n'
+    ;;
+  -m)
+    printf 'arm64\n'
+    ;;
+  *)
+    printf 'Darwin\n'
+    ;;
+esac


### PR DESCRIPTION
## Summary

First sub-PR of the verify-invariants.sh heredoc harness split
(/sethify PR 34b).  Moves the 5 install-deps mock binaries (`uname`,
`dirname`, `basename`, `sysctl`, `brew`) out of the 7993-line
`scripts/verify-invariants.sh` into individual scripts under
`verify/invariants/harnesses/install-deps/`.  The verify-invariants
loop now installs each one with `install -m 0755` instead of emitting
an in-place quoted heredoc + separate `chmod`.

No behavior change: the resulting installed scripts are byte-identical
to the previous heredoc output (all heredocs used `<<'EOF'`, so no
variable expansion was happening).

Drops 60 LOC from `scripts/verify-invariants.sh`.

Follow-ups (separate PRs):
- 34b-2: process/colima management harnesses
- 34b-3: git probes + the 235-LOC gemini-auth-selection harness
- 34b-4 (maybe): inline injection-policy fixture files (`policy.toml`, `bad-*.toml`, etc.)

## Test plan

- [x] `bash -n scripts/verify-invariants.sh` — syntax clean
- [x] `bash scripts/check-pr-shape.sh` — files=6 lines=106 areas=2 binaries=0
- Behavior preserved: mock scripts byte-identical to the heredoc output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)