### PR TITLE
^R Move git-probe heredocs + gemini-auth-selection harness into verify/invariants/harnesses/

### DIFF
--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2159,15 +2159,9 @@ git -C "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" init -q
 git -C "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" config user.email "verify@example.com"
 git -C "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" config user.name "Workcell Verify"
 printf 'head\n' >"${VALIDATION_SNAPSHOT_FIXTURE_ROOT}/tracked.txt"
-cat <<'EOF' >"${VALIDATION_SNAPSHOT_FIXTURE_ROOT}/snapshot-probe.sh"
-#!/bin/bash
-set -euo pipefail
-printf 'tracked=%s\n' "$(cat tracked.txt)"
-if [[ -e untracked.txt ]]; then
-  printf 'untracked=%s\n' "$(cat untracked.txt)"
-fi
-EOF
-chmod 0700 "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}/snapshot-probe.sh"
+install -m 0700 \
+  "${ROOT_DIR}/verify/invariants/harnesses/git-probes/snapshot-probe.sh" \
+  "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}/snapshot-probe.sh"
 git -C "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" add tracked.txt
 git -C "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" add snapshot-probe.sh
 git -C "${VALIDATION_SNAPSHOT_FIXTURE_ROOT}" commit -qm "initial"
@@ -2210,18 +2204,9 @@ VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT="$(mktemp -d)"
 git -C "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}" init -q
 git -C "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}" config user.email "verify@example.com"
 git -C "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}" config user.name "Workcell Verify"
-cat <<'EOF' >"${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}/snapshot-kind-probe.sh"
-#!/bin/bash
-set -euo pipefail
-if [[ -d kind ]]; then
-  printf 'kind=dir\n'
-  printf 'payload=%s\n' "$(cat kind/payload.txt)"
-else
-  printf 'kind=file\n'
-  printf 'payload=%s\n' "$(cat kind)"
-fi
-EOF
-chmod 0700 "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}/snapshot-kind-probe.sh"
+install -m 0700 \
+  "${ROOT_DIR}/verify/invariants/harnesses/git-probes/snapshot-kind-probe.sh" \
+  "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}/snapshot-kind-probe.sh"
 printf 'file\n' >"${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}/kind"
 git -C "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}" add kind snapshot-kind-probe.sh
 git -C "${VALIDATION_INDEX_TYPE_CHANGE_FILE_TO_DIR_ROOT}" commit -qm "initial"
@@ -2244,18 +2229,9 @@ VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT="$(mktemp -d)"
 git -C "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}" init -q
 git -C "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}" config user.email "verify@example.com"
 git -C "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}" config user.name "Workcell Verify"
-cat <<'EOF' >"${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}/snapshot-kind-probe.sh"
-#!/bin/bash
-set -euo pipefail
-if [[ -d kind ]]; then
-  printf 'kind=dir\n'
-  printf 'payload=%s\n' "$(cat kind/payload.txt)"
-else
-  printf 'kind=file\n'
-  printf 'payload=%s\n' "$(cat kind)"
-fi
-EOF
-chmod 0700 "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}/snapshot-kind-probe.sh"
+install -m 0700 \
+  "${ROOT_DIR}/verify/invariants/harnesses/git-probes/snapshot-kind-probe.sh" \
+  "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}/snapshot-kind-probe.sh"
 mkdir -p "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}/kind"
 printf 'nested\n' >"${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}/kind/payload.txt"
 git -C "${VALIDATION_INDEX_TYPE_CHANGE_DIR_TO_FILE_ROOT}" add kind/payload.txt snapshot-kind-probe.sh
@@ -2294,18 +2270,9 @@ VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT="$(mktemp -d)"
 git -C "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}" init -q
 git -C "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}" config user.email "verify@example.com"
 git -C "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}" config user.name "Workcell Verify"
-cat <<'EOF' >"${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}/snapshot-kind-probe.sh"
-#!/bin/bash
-set -euo pipefail
-if [[ -d kind ]]; then
-  printf 'kind=dir\n'
-  printf 'payload=%s\n' "$(cat kind/payload.txt)"
-else
-  printf 'kind=file\n'
-  printf 'payload=%s\n' "$(cat kind)"
-fi
-EOF
-chmod 0700 "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}/snapshot-kind-probe.sh"
+install -m 0700 \
+  "${ROOT_DIR}/verify/invariants/harnesses/git-probes/snapshot-kind-probe.sh" \
+  "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}/snapshot-kind-probe.sh"
 printf 'file\n' >"${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}/kind"
 git -C "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}" add kind snapshot-kind-probe.sh
 git -C "${VALIDATION_TYPE_CHANGE_FILE_TO_DIR_ROOT}" commit -qm "initial"
@@ -2328,18 +2295,9 @@ VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT="$(mktemp -d)"
 git -C "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}" init -q
 git -C "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}" config user.email "verify@example.com"
 git -C "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}" config user.name "Workcell Verify"
-cat <<'EOF' >"${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}/snapshot-kind-probe.sh"
-#!/bin/bash
-set -euo pipefail
-if [[ -d kind ]]; then
-  printf 'kind=dir\n'
-  printf 'payload=%s\n' "$(cat kind/payload.txt)"
-else
-  printf 'kind=file\n'
-  printf 'payload=%s\n' "$(cat kind)"
-fi
-EOF
-chmod 0700 "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}/snapshot-kind-probe.sh"
+install -m 0700 \
+  "${ROOT_DIR}/verify/invariants/harnesses/git-probes/snapshot-kind-probe.sh" \
+  "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}/snapshot-kind-probe.sh"
 mkdir -p "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}/kind"
 printf 'nested\n' >"${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}/kind/payload.txt"
 git -C "${VALIDATION_TYPE_CHANGE_DIR_TO_FILE_ROOT}" add kind/payload.txt snapshot-kind-probe.sh
@@ -7352,242 +7310,7 @@ GEMINI_AUTH_SELECTION_STDERR="$(mktemp)"
   extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_render_gemini_trusted_folders
   printf '\n'
   extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_target_is_allowed
-  cat <<'EOF'
-set -Eeuo pipefail
-trap 'echo "Gemini auth selection harness failed at line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
-export PS4='+ gemini-harness:${LINENO}: '
-set -x
-
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "${TMP_DIR}"' EXIT
-
-workcell_die() {
-  printf '%s\n' "$*" >&2
-  exit 1
-}
-
-expect_fatal_function_failure() {
-  local stdout_path="$1"
-  local stderr_path="$2"
-  shift 2
-
-  if ( "$@" ) >"${stdout_path}" 2>"${stderr_path}"; then
-    return 0
-  fi
-
-  return 1
-}
-
-expect_auth_type() {
-  local env_contents="$1"
-  local oauth_present="$2"
-  local expected="$3"
-  local env_path="${TMP_DIR}/gemini.env"
-  local oauth_path="${TMP_DIR}/oauth.json"
-  local selected=""
-
-  rm -f "${env_path}" "${oauth_path}"
-  if [[ -n "${env_contents}" ]]; then
-    printf '%s\n' "${env_contents}" >"${env_path}"
-  fi
-  if [[ "${oauth_present}" == "1" ]]; then
-    printf '{}\n' >"${oauth_path}"
-  fi
-
-  selected="$(workcell_gemini_selected_auth_type "${env_path}" "${oauth_path}")"
-  if [[ "${selected}" != "${expected}" ]]; then
-    echo "Expected Gemini auth type ${expected}, got ${selected}" >&2
-    exit 1
-  fi
-}
-
-expect_auth_type 'GEMINI_API_KEY=test-key' 0 'gemini-api-key'
-expect_auth_type ' export GEMINI_API_KEY = "quoted-key" # comment' 0 'gemini-api-key'
-expect_auth_type $'GOOGLE_GENAI_USE_GCA=true\nGEMINI_API_KEY=test-key' 0 'oauth-personal'
-expect_auth_type $'GOOGLE_GENAI_USE_GCA="true" # comment\nGOOGLE_CLOUD_PROJECT=my-proj' 0 'oauth-personal'
-expect_auth_type $'GOOGLE_GENAI_USE_VERTEXAI="true" # comment\nGOOGLE_CLOUD_PROJECT=my-proj\nGOOGLE_CLOUD_LOCATION="us-central1" # comment' 0 'vertex-ai'
-expect_auth_type $'GOOGLE_GENAI_USE_VERTEXAI=true\nGOOGLE_API_KEY=vertex-key' 0 'vertex-ai'
-expect_auth_type $'GEMINI_API_KEY=test-key\nGOOGLE_CLOUD_PROJECT=my-proj' 0 'gemini-api-key'
-expect_auth_type '' 1 'oauth-personal'
-
-printf 'GOOGLE_API_KEY=test-key\n' >"${TMP_DIR}/google-api-key-only.env"
-if workcell_gemini_selected_auth_type "${TMP_DIR}/google-api-key-only.env" "${TMP_DIR}/missing-oauth.json" >/dev/null 2>&1; then
-  echo "Expected bare GOOGLE_API_KEY to stay unset until Gemini Vertex auth is explicitly selected" >&2
-  exit 1
-fi
-
-if workcell_gemini_selected_auth_type "${TMP_DIR}/missing.env" "${TMP_DIR}/missing-oauth.json" >/dev/null 2>&1; then
-  echo "Expected Gemini auth selection to stay unset when no credential material is present" >&2
-  exit 1
-fi
-
-printf 'GOOGLE_GENAI_USE_GCA=maybe\n' >"${TMP_DIR}/invalid-bool.env"
-if expect_fatal_function_failure /tmp/gemini-invalid-bool.stdout /tmp/gemini-invalid-bool.stderr \
-  workcell_validate_gemini_env_auth_config "${TMP_DIR}/invalid-bool.env"; then
-  echo "Expected invalid Gemini auth booleans to be rejected" >&2
-  exit 1
-fi
-grep -q 'Invalid boolean in Gemini auth env file' /tmp/gemini-invalid-bool.stderr
-
-printf 'GOOGLE_GENAI_USE_VERTEXAI true\n' >"${TMP_DIR}/malformed.env"
-if expect_fatal_function_failure /tmp/gemini-malformed.stdout /tmp/gemini-malformed.stderr \
-  workcell_validate_gemini_env_auth_config "${TMP_DIR}/malformed.env"; then
-  echo "Expected malformed Gemini auth env syntax to be rejected" >&2
-  exit 1
-fi
-grep -q 'Malformed Gemini auth env file' /tmp/gemini-malformed.stderr
-
-printf 'UNSUPPORTED_KEY=test\n' >"${TMP_DIR}/unsupported.env"
-if expect_fatal_function_failure /tmp/gemini-unsupported.stdout /tmp/gemini-unsupported.stderr \
-  workcell_validate_gemini_env_auth_config "${TMP_DIR}/unsupported.env"; then
-  echo "Expected unsupported Gemini auth env keys to be rejected" >&2
-  exit 1
-fi
-grep -q 'Unsupported key in Gemini auth env file' /tmp/gemini-unsupported.stderr
-
-printf 'GEMINI_API_KEY=one\nGEMINI_API_KEY=two\n' >"${TMP_DIR}/duplicate-api-key.env"
-if expect_fatal_function_failure /tmp/gemini-duplicate-api-key.stdout /tmp/gemini-duplicate-api-key.stderr \
-  workcell_validate_gemini_env_auth_config "${TMP_DIR}/duplicate-api-key.env"; then
-  echo "Expected duplicate GEMINI_API_KEY assignments to be rejected" >&2
-  exit 1
-fi
-grep -q 'configures GEMINI_API_KEY more than once' /tmp/gemini-duplicate-api-key.stderr
-
-printf ' export GOOGLE_GENAI_USE_GCA=true\nGOOGLE_GENAI_USE_GCA=false\n' >"${TMP_DIR}/duplicate-exported-bool.env"
-if expect_fatal_function_failure /tmp/gemini-duplicate-exported-bool.stdout /tmp/gemini-duplicate-exported-bool.stderr \
-  workcell_validate_gemini_env_auth_config "${TMP_DIR}/duplicate-exported-bool.env"; then
-  echo "Expected duplicate exported Gemini auth selectors to be rejected" >&2
-  exit 1
-fi
-grep -q 'configures GOOGLE_GENAI_USE_GCA more than once' /tmp/gemini-duplicate-exported-bool.stderr
-
-printf 'GOOGLE_GENAI_USE_GCA=true\nGOOGLE_GENAI_USE_VERTEXAI=true\n' >"${TMP_DIR}/conflicting-selectors.env"
-if expect_fatal_function_failure /tmp/gemini-conflicting.stdout /tmp/gemini-conflicting.stderr \
-  workcell_validate_gemini_env_auth_config "${TMP_DIR}/conflicting-selectors.env"; then
-  echo "Expected contradictory Gemini auth selectors to be rejected" >&2
-  exit 1
-fi
-grep -q 'enables both GOOGLE_GENAI_USE_GCA and GOOGLE_GENAI_USE_VERTEXAI' /tmp/gemini-conflicting.stderr
-
-printf 'GOOGLE_GENAI_USE_VERTEXAI=true\nGOOGLE_API_KEY=vertex-key\n' >"${TMP_DIR}/vertex-express.env"
-if ! workcell_validate_gemini_env_auth_config "${TMP_DIR}/vertex-express.env" >/tmp/gemini-vertex-express.stdout 2>/tmp/gemini-vertex-express.stderr; then
-  echo "Expected Gemini Vertex express-mode env config to validate" >&2
-  cat /tmp/gemini-vertex-express.stderr >&2
-  exit 1
-fi
-
-printf 'GOOGLE_API_KEY=vertex-key\n' >"${TMP_DIR}/google-api-key-only.env"
-if expect_fatal_function_failure /tmp/gemini-google-api-key.stdout /tmp/gemini-google-api-key.stderr \
-  workcell_validate_gemini_env_auth_config "${TMP_DIR}/google-api-key-only.env"; then
-  echo "Expected bare GOOGLE_API_KEY to be rejected without GOOGLE_GENAI_USE_VERTEXAI=true" >&2
-  exit 1
-fi
-grep -q 'sets GOOGLE_API_KEY without GOOGLE_GENAI_USE_VERTEXAI=true' /tmp/gemini-google-api-key.stderr
-
-printf 'GOOGLE_CLOUD_LOCATION=us-central1\n' >"${TMP_DIR}/location-only.env"
-if expect_fatal_function_failure /tmp/gemini-location-only.stdout /tmp/gemini-location-only.stderr \
-  workcell_validate_gemini_env_auth_config "${TMP_DIR}/location-only.env"; then
-  echo "Expected location-only Gemini env config to be rejected" >&2
-  exit 1
-fi
-grep -q 'sets a Google Cloud location without a project' /tmp/gemini-location-only.stderr
-
-printf 'GOOGLE_CLOUD_PROJECT=my-proj\n' >"${TMP_DIR}/project-only.env"
-if expect_fatal_function_failure /tmp/gemini-project-only.stdout /tmp/gemini-project-only.stderr \
-  workcell_validate_gemini_env_auth_config "${TMP_DIR}/project-only.env"; then
-  echo "Expected project-only Gemini env config to be rejected" >&2
-  exit 1
-fi
-grep -q 'does not configure a supported Gemini auth mode' /tmp/gemini-project-only.stderr
-
-SETTINGS_PATH="${TMP_DIR}/settings.json"
-cat >"${SETTINGS_PATH}" <<'JSON'
-{"security":{"folderTrust":{"enabled":false}}}
-JSON
-workcell_set_gemini_selected_auth_type "${SETTINGS_PATH}" "gemini-api-key"
-if ! jq -e '.security.auth.selectedType == "gemini-api-key"' "${SETTINGS_PATH}" >/dev/null; then
-  echo "Gemini selected auth type should be persisted into the seeded settings" >&2
-  exit 1
-fi
-if ! jq -e '.security.folderTrust.enabled == false' "${SETTINGS_PATH}" >/dev/null; then
-  echo "Gemini selected auth type update should preserve existing settings" >&2
-  exit 1
-fi
-workcell_set_gemini_folder_trust_enabled "${SETTINGS_PATH}" true
-if ! jq -e '.security.folderTrust.enabled == true' "${SETTINGS_PATH}" >/dev/null; then
-  echo "Gemini folder-trust helper should restore trust prompts for breakglass sessions" >&2
-  exit 1
-fi
-workcell_set_gemini_folder_trust_enabled "${SETTINGS_PATH}" false
-
-TRUSTED_FOLDERS_PATH="${TMP_DIR}/trustedFolders.json"
-TRUSTED_WORKSPACE=$'/workspace/quoted"path\\segment'
-workcell_render_gemini_trusted_folders "${TRUSTED_FOLDERS_PATH}" "${TRUSTED_WORKSPACE}"
-if [[ "$(jq -S -c '.' "${TRUSTED_FOLDERS_PATH}")" != "$(jq -S -c -n --arg path "${TRUSTED_WORKSPACE}" '{($path): "TRUST_FOLDER"}')" ]]; then
-  echo "Expected trustedFolders.json to preserve the exact workspace path" >&2
-  exit 1
-fi
-
-printf '{"projects":[]}\n' >"${TMP_DIR}/invalid-projects.json"
-if expect_fatal_function_failure /tmp/gemini-invalid-projects.stdout /tmp/gemini-invalid-projects.stderr \
-  workcell_validate_gemini_projects_config "${TMP_DIR}/invalid-projects.json"; then
-  echo "Expected invalid Gemini projects config to be rejected" >&2
-  exit 1
-fi
-grep -q 'Gemini projects config must contain a JSON object with an object-valued projects field' /tmp/gemini-invalid-projects.stderr
-
-printf '{"projects":{}}\n' >"${TMP_DIR}/valid-projects.json"
-if ! workcell_validate_gemini_projects_config "${TMP_DIR}/valid-projects.json" >/tmp/gemini-valid-projects.stdout 2>/tmp/gemini-valid-projects.stderr; then
-  echo "Expected valid Gemini projects config to be accepted" >&2
-  cat /tmp/gemini-valid-projects.stderr >&2
-  exit 1
-fi
-
-if workcell_target_is_allowed '/state/agent-home/.gemini/trustedFolders.json'; then
-  echo "Expected runtime manifest guard to reserve Gemini trustedFolders.json" >&2
-  exit 1
-fi
-if workcell_target_is_allowed '/state/agent-home/.claude/settings.json'; then
-  echo "Expected runtime manifest guard to reserve Claude settings.json" >&2
-  exit 1
-fi
-if workcell_target_is_allowed '/state/agent-home/.claude/.credentials.json'; then
-  echo "Expected runtime manifest guard to reserve injected Claude credentials" >&2
-  exit 1
-fi
-if workcell_target_is_allowed '/state/agent-home/.claude/.claude.json'; then
-  echo "Expected runtime manifest guard to reserve injected Claude session config" >&2
-  exit 1
-fi
-if workcell_target_is_allowed '/state/agent-home/.claude.json'; then
-  echo "Expected runtime manifest guard to reserve injected Claude global config" >&2
-  exit 1
-fi
-if workcell_target_is_allowed '/state/agent-home/.config/claude-code/auth.json'; then
-  echo "Expected runtime manifest guard to reserve injected Claude auth.json" >&2
-  exit 1
-fi
-if workcell_target_is_allowed '/state/agent-home/.gemini/settings.json'; then
-  echo "Expected runtime manifest guard to reserve Gemini settings.json" >&2
-  exit 1
-fi
-if workcell_target_is_allowed '/state/agent-home/.ssh/config'; then
-  echo "Expected runtime manifest guard to reserve seeded SSH config paths" >&2
-  exit 1
-fi
-if ! workcell_target_is_allowed '/state/agent-home/workcell-benign-note.txt'; then
-  echo "Expected runtime manifest guard to allow benign session-local targets under /state/agent-home" >&2
-  exit 1
-fi
-if ! workcell_target_is_allowed '/state/injected/documents/org-policy.md'; then
-  echo "Expected runtime manifest guard to allow staged injected documents under /state/injected" >&2
-  exit 1
-fi
-if workcell_target_is_allowed '/workspace/not-allowed.txt'; then
-  echo "Expected runtime manifest guard to reject targets outside managed session roots" >&2
-  exit 1
-fi
-EOF
+  cat "${ROOT_DIR}/verify/invariants/harnesses/gemini-auth-selection.sh"
 } >"${GEMINI_AUTH_SELECTION_HARNESS}"
 /bin/bash "${GEMINI_AUTH_SELECTION_HARNESS}" >"${GEMINI_AUTH_SELECTION_STDOUT}" 2>"${GEMINI_AUTH_SELECTION_STDERR}" || {
   echo "Gemini auth selection harness stdout (tail):" >&2

--- a/verify/invariants/harnesses/gemini-auth-selection.sh
+++ b/verify/invariants/harnesses/gemini-auth-selection.sh
@@ -1,0 +1,234 @@
+set -Eeuo pipefail
+trap 'echo "Gemini auth selection harness failed at line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
+export PS4='+ gemini-harness:${LINENO}: '
+set -x
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+workcell_die() {
+  printf '%s\n' "$*" >&2
+  exit 1
+}
+
+expect_fatal_function_failure() {
+  local stdout_path="$1"
+  local stderr_path="$2"
+  shift 2
+
+  if ( "$@" ) >"${stdout_path}" 2>"${stderr_path}"; then
+    return 0
+  fi
+
+  return 1
+}
+
+expect_auth_type() {
+  local env_contents="$1"
+  local oauth_present="$2"
+  local expected="$3"
+  local env_path="${TMP_DIR}/gemini.env"
+  local oauth_path="${TMP_DIR}/oauth.json"
+  local selected=""
+
+  rm -f "${env_path}" "${oauth_path}"
+  if [[ -n "${env_contents}" ]]; then
+    printf '%s\n' "${env_contents}" >"${env_path}"
+  fi
+  if [[ "${oauth_present}" == "1" ]]; then
+    printf '{}\n' >"${oauth_path}"
+  fi
+
+  selected="$(workcell_gemini_selected_auth_type "${env_path}" "${oauth_path}")"
+  if [[ "${selected}" != "${expected}" ]]; then
+    echo "Expected Gemini auth type ${expected}, got ${selected}" >&2
+    exit 1
+  fi
+}
+
+expect_auth_type 'GEMINI_API_KEY=test-key' 0 'gemini-api-key'
+expect_auth_type ' export GEMINI_API_KEY = "quoted-key" # comment' 0 'gemini-api-key'
+expect_auth_type $'GOOGLE_GENAI_USE_GCA=true\nGEMINI_API_KEY=test-key' 0 'oauth-personal'
+expect_auth_type $'GOOGLE_GENAI_USE_GCA="true" # comment\nGOOGLE_CLOUD_PROJECT=my-proj' 0 'oauth-personal'
+expect_auth_type $'GOOGLE_GENAI_USE_VERTEXAI="true" # comment\nGOOGLE_CLOUD_PROJECT=my-proj\nGOOGLE_CLOUD_LOCATION="us-central1" # comment' 0 'vertex-ai'
+expect_auth_type $'GOOGLE_GENAI_USE_VERTEXAI=true\nGOOGLE_API_KEY=vertex-key' 0 'vertex-ai'
+expect_auth_type $'GEMINI_API_KEY=test-key\nGOOGLE_CLOUD_PROJECT=my-proj' 0 'gemini-api-key'
+expect_auth_type '' 1 'oauth-personal'
+
+printf 'GOOGLE_API_KEY=test-key\n' >"${TMP_DIR}/google-api-key-only.env"
+if workcell_gemini_selected_auth_type "${TMP_DIR}/google-api-key-only.env" "${TMP_DIR}/missing-oauth.json" >/dev/null 2>&1; then
+  echo "Expected bare GOOGLE_API_KEY to stay unset until Gemini Vertex auth is explicitly selected" >&2
+  exit 1
+fi
+
+if workcell_gemini_selected_auth_type "${TMP_DIR}/missing.env" "${TMP_DIR}/missing-oauth.json" >/dev/null 2>&1; then
+  echo "Expected Gemini auth selection to stay unset when no credential material is present" >&2
+  exit 1
+fi
+
+printf 'GOOGLE_GENAI_USE_GCA=maybe\n' >"${TMP_DIR}/invalid-bool.env"
+if expect_fatal_function_failure /tmp/gemini-invalid-bool.stdout /tmp/gemini-invalid-bool.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/invalid-bool.env"; then
+  echo "Expected invalid Gemini auth booleans to be rejected" >&2
+  exit 1
+fi
+grep -q 'Invalid boolean in Gemini auth env file' /tmp/gemini-invalid-bool.stderr
+
+printf 'GOOGLE_GENAI_USE_VERTEXAI true\n' >"${TMP_DIR}/malformed.env"
+if expect_fatal_function_failure /tmp/gemini-malformed.stdout /tmp/gemini-malformed.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/malformed.env"; then
+  echo "Expected malformed Gemini auth env syntax to be rejected" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-malformed.stderr
+
+printf 'UNSUPPORTED_KEY=test\n' >"${TMP_DIR}/unsupported.env"
+if expect_fatal_function_failure /tmp/gemini-unsupported.stdout /tmp/gemini-unsupported.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/unsupported.env"; then
+  echo "Expected unsupported Gemini auth env keys to be rejected" >&2
+  exit 1
+fi
+grep -q 'Unsupported key in Gemini auth env file' /tmp/gemini-unsupported.stderr
+
+printf 'GEMINI_API_KEY=one\nGEMINI_API_KEY=two\n' >"${TMP_DIR}/duplicate-api-key.env"
+if expect_fatal_function_failure /tmp/gemini-duplicate-api-key.stdout /tmp/gemini-duplicate-api-key.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/duplicate-api-key.env"; then
+  echo "Expected duplicate GEMINI_API_KEY assignments to be rejected" >&2
+  exit 1
+fi
+grep -q 'configures GEMINI_API_KEY more than once' /tmp/gemini-duplicate-api-key.stderr
+
+printf ' export GOOGLE_GENAI_USE_GCA=true\nGOOGLE_GENAI_USE_GCA=false\n' >"${TMP_DIR}/duplicate-exported-bool.env"
+if expect_fatal_function_failure /tmp/gemini-duplicate-exported-bool.stdout /tmp/gemini-duplicate-exported-bool.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/duplicate-exported-bool.env"; then
+  echo "Expected duplicate exported Gemini auth selectors to be rejected" >&2
+  exit 1
+fi
+grep -q 'configures GOOGLE_GENAI_USE_GCA more than once' /tmp/gemini-duplicate-exported-bool.stderr
+
+printf 'GOOGLE_GENAI_USE_GCA=true\nGOOGLE_GENAI_USE_VERTEXAI=true\n' >"${TMP_DIR}/conflicting-selectors.env"
+if expect_fatal_function_failure /tmp/gemini-conflicting.stdout /tmp/gemini-conflicting.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/conflicting-selectors.env"; then
+  echo "Expected contradictory Gemini auth selectors to be rejected" >&2
+  exit 1
+fi
+grep -q 'enables both GOOGLE_GENAI_USE_GCA and GOOGLE_GENAI_USE_VERTEXAI' /tmp/gemini-conflicting.stderr
+
+printf 'GOOGLE_GENAI_USE_VERTEXAI=true\nGOOGLE_API_KEY=vertex-key\n' >"${TMP_DIR}/vertex-express.env"
+if ! workcell_validate_gemini_env_auth_config "${TMP_DIR}/vertex-express.env" >/tmp/gemini-vertex-express.stdout 2>/tmp/gemini-vertex-express.stderr; then
+  echo "Expected Gemini Vertex express-mode env config to validate" >&2
+  cat /tmp/gemini-vertex-express.stderr >&2
+  exit 1
+fi
+
+printf 'GOOGLE_API_KEY=vertex-key\n' >"${TMP_DIR}/google-api-key-only.env"
+if expect_fatal_function_failure /tmp/gemini-google-api-key.stdout /tmp/gemini-google-api-key.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/google-api-key-only.env"; then
+  echo "Expected bare GOOGLE_API_KEY to be rejected without GOOGLE_GENAI_USE_VERTEXAI=true" >&2
+  exit 1
+fi
+grep -q 'sets GOOGLE_API_KEY without GOOGLE_GENAI_USE_VERTEXAI=true' /tmp/gemini-google-api-key.stderr
+
+printf 'GOOGLE_CLOUD_LOCATION=us-central1\n' >"${TMP_DIR}/location-only.env"
+if expect_fatal_function_failure /tmp/gemini-location-only.stdout /tmp/gemini-location-only.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/location-only.env"; then
+  echo "Expected location-only Gemini env config to be rejected" >&2
+  exit 1
+fi
+grep -q 'sets a Google Cloud location without a project' /tmp/gemini-location-only.stderr
+
+printf 'GOOGLE_CLOUD_PROJECT=my-proj\n' >"${TMP_DIR}/project-only.env"
+if expect_fatal_function_failure /tmp/gemini-project-only.stdout /tmp/gemini-project-only.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/project-only.env"; then
+  echo "Expected project-only Gemini env config to be rejected" >&2
+  exit 1
+fi
+grep -q 'does not configure a supported Gemini auth mode' /tmp/gemini-project-only.stderr
+
+SETTINGS_PATH="${TMP_DIR}/settings.json"
+cat >"${SETTINGS_PATH}" <<'JSON'
+{"security":{"folderTrust":{"enabled":false}}}
+JSON
+workcell_set_gemini_selected_auth_type "${SETTINGS_PATH}" "gemini-api-key"
+if ! jq -e '.security.auth.selectedType == "gemini-api-key"' "${SETTINGS_PATH}" >/dev/null; then
+  echo "Gemini selected auth type should be persisted into the seeded settings" >&2
+  exit 1
+fi
+if ! jq -e '.security.folderTrust.enabled == false' "${SETTINGS_PATH}" >/dev/null; then
+  echo "Gemini selected auth type update should preserve existing settings" >&2
+  exit 1
+fi
+workcell_set_gemini_folder_trust_enabled "${SETTINGS_PATH}" true
+if ! jq -e '.security.folderTrust.enabled == true' "${SETTINGS_PATH}" >/dev/null; then
+  echo "Gemini folder-trust helper should restore trust prompts for breakglass sessions" >&2
+  exit 1
+fi
+workcell_set_gemini_folder_trust_enabled "${SETTINGS_PATH}" false
+
+TRUSTED_FOLDERS_PATH="${TMP_DIR}/trustedFolders.json"
+TRUSTED_WORKSPACE=$'/workspace/quoted"path\\segment'
+workcell_render_gemini_trusted_folders "${TRUSTED_FOLDERS_PATH}" "${TRUSTED_WORKSPACE}"
+if [[ "$(jq -S -c '.' "${TRUSTED_FOLDERS_PATH}")" != "$(jq -S -c -n --arg path "${TRUSTED_WORKSPACE}" '{($path): "TRUST_FOLDER"}')" ]]; then
+  echo "Expected trustedFolders.json to preserve the exact workspace path" >&2
+  exit 1
+fi
+
+printf '{"projects":[]}\n' >"${TMP_DIR}/invalid-projects.json"
+if expect_fatal_function_failure /tmp/gemini-invalid-projects.stdout /tmp/gemini-invalid-projects.stderr \
+  workcell_validate_gemini_projects_config "${TMP_DIR}/invalid-projects.json"; then
+  echo "Expected invalid Gemini projects config to be rejected" >&2
+  exit 1
+fi
+grep -q 'Gemini projects config must contain a JSON object with an object-valued projects field' /tmp/gemini-invalid-projects.stderr
+
+printf '{"projects":{}}\n' >"${TMP_DIR}/valid-projects.json"
+if ! workcell_validate_gemini_projects_config "${TMP_DIR}/valid-projects.json" >/tmp/gemini-valid-projects.stdout 2>/tmp/gemini-valid-projects.stderr; then
+  echo "Expected valid Gemini projects config to be accepted" >&2
+  cat /tmp/gemini-valid-projects.stderr >&2
+  exit 1
+fi
+
+if workcell_target_is_allowed '/state/agent-home/.gemini/trustedFolders.json'; then
+  echo "Expected runtime manifest guard to reserve Gemini trustedFolders.json" >&2
+  exit 1
+fi
+if workcell_target_is_allowed '/state/agent-home/.claude/settings.json'; then
+  echo "Expected runtime manifest guard to reserve Claude settings.json" >&2
+  exit 1
+fi
+if workcell_target_is_allowed '/state/agent-home/.claude/.credentials.json'; then
+  echo "Expected runtime manifest guard to reserve injected Claude credentials" >&2
+  exit 1
+fi
+if workcell_target_is_allowed '/state/agent-home/.claude/.claude.json'; then
+  echo "Expected runtime manifest guard to reserve injected Claude session config" >&2
+  exit 1
+fi
+if workcell_target_is_allowed '/state/agent-home/.claude.json'; then
+  echo "Expected runtime manifest guard to reserve injected Claude global config" >&2
+  exit 1
+fi
+if workcell_target_is_allowed '/state/agent-home/.config/claude-code/auth.json'; then
+  echo "Expected runtime manifest guard to reserve injected Claude auth.json" >&2
+  exit 1
+fi
+if workcell_target_is_allowed '/state/agent-home/.gemini/settings.json'; then
+  echo "Expected runtime manifest guard to reserve Gemini settings.json" >&2
+  exit 1
+fi
+if workcell_target_is_allowed '/state/agent-home/.ssh/config'; then
+  echo "Expected runtime manifest guard to reserve seeded SSH config paths" >&2
+  exit 1
+fi
+if ! workcell_target_is_allowed '/state/agent-home/workcell-benign-note.txt'; then
+  echo "Expected runtime manifest guard to allow benign session-local targets under /state/agent-home" >&2
+  exit 1
+fi
+if ! workcell_target_is_allowed '/state/injected/documents/org-policy.md'; then
+  echo "Expected runtime manifest guard to allow staged injected documents under /state/injected" >&2
+  exit 1
+fi
+if workcell_target_is_allowed '/workspace/not-allowed.txt'; then
+  echo "Expected runtime manifest guard to reject targets outside managed session roots" >&2
+  exit 1
+fi

--- a/verify/invariants/harnesses/git-probes/snapshot-kind-probe.sh
+++ b/verify/invariants/harnesses/git-probes/snapshot-kind-probe.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+if [[ -d kind ]]; then
+  printf 'kind=dir\n'
+  printf 'payload=%s\n' "$(cat kind/payload.txt)"
+else
+  printf 'kind=file\n'
+  printf 'payload=%s\n' "$(cat kind)"
+fi

--- a/verify/invariants/harnesses/git-probes/snapshot-probe.sh
+++ b/verify/invariants/harnesses/git-probes/snapshot-probe.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+printf 'tracked=%s\n' "$(cat tracked.txt)"
+if [[ -e untracked.txt ]]; then
+  printf 'untracked=%s\n' "$(cat untracked.txt)"
+fi


### PR DESCRIPTION
## Summary

PR 34b-3 in the /sethify-remediation chain (Section E close-out, sibling of #215 and #220). Extracts two inline-heredoc patterns out of `scripts/verify-invariants.sh`:

1. **Five identical git-probe heredocs.** The 1× `snapshot-probe.sh` (line 2162) and 4× `snapshot-kind-probe.sh` (lines 2213, 2247, 2297, 2331) `cat <<EOF >fixture/...` blocks plus their `chmod 0700` follow-ups are replaced with `install -m 0700 "${ROOT_DIR}/verify/invariants/harnesses/git-probes/<probe>.sh" <fixture-path>`. The four `snapshot-kind-probe.sh` heredocs all had byte-identical bodies, so they now share a single fixture file.

2. **The 235-line `GEMINI_AUTH_SELECTION_HARNESS` body.** The 17 `extract_top_level_bash_function` calls and the post-assembly `/bin/bash "${HARNESS}"` invocation stay in `verify-invariants.sh`; only the inline `cat <<'EOF' ... EOF` block is replaced with `cat "${ROOT_DIR}/verify/invariants/harnesses/gemini-auth-selection.sh"`.

`scripts/verify-invariants.sh`: **7790 → 7513 LOC** (-277).

This closes out Section E of the /sethify-remediation work (Section B is the next big block — see `~/.claude/plans/twinkling-roaming-feigenbaum.md`).

## Test plan

- [x] `bash -n scripts/verify-invariants.sh scripts/workcell` clean
- [x] Assembled the gemini-auth harness locally (extract step + cat of the new body) and `bash -n` on the result: parses
- [x] `bash -n` on each new probe fixture: parses
- [x] `scripts/check-pr-shape.sh`: files=4 lines=558 areas=2 binary_files=0
- [ ] CI: `Validate (macOS)` runs the assembled gemini-auth + snapshot harnesses — real gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)