### PR TITLE
^R Extract auth_usage and policy_usage heredocs into internal/authpolicy

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/omkhar/workcell/internal/authpolicy"
 	"github.com/omkhar/workcell/internal/host/hoststate"
 	"github.com/omkhar/workcell/internal/host/launcher"
 	"github.com/omkhar/workcell/internal/host/release"
@@ -134,6 +135,8 @@ type launcherSubcommand struct {
 func launcherSubcommands() []launcherSubcommand {
 	return []launcherSubcommand{
 		{"session-usage", 0, 0, cmdLauncherSessionUsage},
+		{"auth-usage", 0, 0, cmdLauncherAuthUsage},
+		{"policy-usage", 0, 0, cmdLauncherPolicyUsage},
 		{"session-timeline-cli", 0, -1, cmdLauncherSessionTimelineCli},
 		{"session-logs-cli", 0, -1, cmdLauncherSessionLogsCli},
 		{"session-suffix", 0, 0, cmdLauncherSessionSuffix},
@@ -190,6 +193,16 @@ func runLauncher(args []string) error {
 
 func cmdLauncherSessionUsage(_ []string) error {
 	fmt.Print(sessionctl.UsageText())
+	return nil
+}
+
+func cmdLauncherAuthUsage(_ []string) error {
+	fmt.Print(authpolicy.AuthUsageText())
+	return nil
+}
+
+func cmdLauncherPolicyUsage(_ []string) error {
+	fmt.Print(authpolicy.PolicyUsageText())
 	return nil
 }
 

--- a/internal/authpolicy/usage.go
+++ b/internal/authpolicy/usage.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package authpolicy
+
+// authUsageText is the canonical help text for `workcell auth <cmd>`,
+// migrated verbatim from scripts/workcell's auth_usage() function.
+const authUsageText = `Usage: workcell auth init [options]
+       workcell auth set [options]
+       workcell auth unset [options]
+       workcell auth status [options]
+
+Commands:
+  init
+    --injection-policy PATH     Policy file to create or validate (default: ~/.config/workcell/injection-policy.toml)
+    --managed-root PATH         Managed credential root (default: ~/.config/workcell/credentials)
+
+  set
+    --injection-policy PATH     Policy file to update (default: ~/.config/workcell/injection-policy.toml)
+    --managed-root PATH         Managed credential root (default: ~/.config/workcell/credentials)
+    --agent codex|claude|gemini Agent used for validation and default shared-credential scoping
+    --credential KEY            Credential key to configure
+    --source PATH               Copy PATH into the managed Workcell credential store
+    --resolver NAME             Configure a built-in host resolver
+    --ack-host-resolver         Required with --resolver
+
+  unset
+    --injection-policy PATH     Policy file to update (default: ~/.config/workcell/injection-policy.toml)
+    --managed-root PATH         Managed credential root (default: ~/.config/workcell/credentials)
+    --credential KEY            Credential key to remove
+
+  status
+    --injection-policy PATH     Policy file to inspect (default: ~/.config/workcell/injection-policy.toml)
+    --agent codex|claude|gemini Filter to the selected agent
+    --mode strict|development|build|breakglass
+    --workspace PATH            Accepted for CLI symmetry; ignored by host status
+
+Notes:
+  - auth commands run on the host and do not start the Workcell runtime.
+  - auth set/unset rewrite only the entrypoint policy file; if a credential is
+    declared by an included fragment, update that fragment directly.
+  - resolver-backed credentials remain host-side preprocessing and do not
+    grant Keychain or provider-home access inside Tier 1.
+  - auth status reports provider_bootstrap_* summary fields for the selected
+    agent on the reviewed host-owned path.
+`
+
+// policyUsageText is the canonical help text for `workcell policy <cmd>`,
+// migrated verbatim from scripts/workcell's policy_usage() function.
+const policyUsageText = `Usage: workcell policy show [options]
+       workcell policy validate [options]
+       workcell policy diff [options]
+
+Commands:
+  show
+    --injection-policy PATH     Policy file to render after include expansion
+
+  validate
+    --injection-policy PATH     Policy file to validate
+
+  diff
+    --injection-policy PATH     Policy file to compare against the canonical merged view
+
+Notes:
+  - policy commands run on the host and do not start the Workcell runtime.
+  - when --injection-policy is omitted, commands use the host default policy path.
+  - show renders the merged effective policy after include expansion.
+  - diff compares the selected entrypoint policy file against that canonical
+    merged effective view.
+  - validate fails closed when the selected policy file is missing or invalid.
+  - validate checks source-backed credential paths, but resolver-backed launch
+    readiness remains deferred to the launch path.
+`
+
+// AuthUsageText returns the canonical `workcell auth` help string.
+func AuthUsageText() string {
+	return authUsageText
+}
+
+// PolicyUsageText returns the canonical `workcell policy` help string.
+func PolicyUsageText() string {
+	return policyUsageText
+}

--- a/internal/authpolicy/usage_test.go
+++ b/internal/authpolicy/usage_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package authpolicy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAuthUsageTextNonEmptyAndTrailingNewline(t *testing.T) {
+	t.Parallel()
+	got := AuthUsageText()
+	if got == "" {
+		t.Fatal("AuthUsageText() returned empty string")
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("AuthUsageText() does not end with newline")
+	}
+}
+
+func TestAuthUsageTextListsAllSubcommands(t *testing.T) {
+	t.Parallel()
+	got := AuthUsageText()
+	for _, want := range []string{
+		"Usage:",
+		"workcell auth init",
+		"workcell auth set",
+		"workcell auth unset",
+		"workcell auth status",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("AuthUsageText() missing %q", want)
+		}
+	}
+}
+
+func TestAuthUsageTextDocumentsRequiredFlags(t *testing.T) {
+	t.Parallel()
+	got := AuthUsageText()
+	for _, want := range []string{
+		"--injection-policy PATH",
+		"--managed-root PATH",
+		"--agent codex|claude|gemini",
+		"--credential KEY",
+		"--source PATH",
+		"--resolver NAME",
+		"--ack-host-resolver",
+		"--mode strict|development|build|breakglass",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("AuthUsageText() missing %q", want)
+		}
+	}
+}
+
+func TestPolicyUsageTextNonEmptyAndTrailingNewline(t *testing.T) {
+	t.Parallel()
+	got := PolicyUsageText()
+	if got == "" {
+		t.Fatal("PolicyUsageText() returned empty string")
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("PolicyUsageText() does not end with newline")
+	}
+}
+
+func TestPolicyUsageTextListsAllSubcommands(t *testing.T) {
+	t.Parallel()
+	got := PolicyUsageText()
+	for _, want := range []string{
+		"Usage:",
+		"workcell policy show",
+		"workcell policy validate",
+		"workcell policy diff",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("PolicyUsageText() missing %q", want)
+		}
+	}
+}
+
+func TestPolicyUsageTextDocumentsRequiredFlags(t *testing.T) {
+	t.Parallel()
+	got := PolicyUsageText()
+	for _, want := range []string{
+		"--injection-policy PATH",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("PolicyUsageText() missing %q", want)
+		}
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "e2afaf8aaa745893f74893a991d7a446dd7dbde54c238f573c64b384a3bd7342"
+      "sha256": "216d87d620ad459065f9045c54296d7a7b7583a593475c358a6e6e0e82ff6e3e"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -4955,46 +4955,7 @@ session_main() {
 }
 
 auth_usage() {
-  cat <<'EOF'
-Usage: workcell auth init [options]
-       workcell auth set [options]
-       workcell auth unset [options]
-       workcell auth status [options]
-
-Commands:
-  init
-    --injection-policy PATH     Policy file to create or validate (default: ~/.config/workcell/injection-policy.toml)
-    --managed-root PATH         Managed credential root (default: ~/.config/workcell/credentials)
-
-  set
-    --injection-policy PATH     Policy file to update (default: ~/.config/workcell/injection-policy.toml)
-    --managed-root PATH         Managed credential root (default: ~/.config/workcell/credentials)
-    --agent codex|claude|gemini Agent used for validation and default shared-credential scoping
-    --credential KEY            Credential key to configure
-    --source PATH               Copy PATH into the managed Workcell credential store
-    --resolver NAME             Configure a built-in host resolver
-    --ack-host-resolver         Required with --resolver
-
-  unset
-    --injection-policy PATH     Policy file to update (default: ~/.config/workcell/injection-policy.toml)
-    --managed-root PATH         Managed credential root (default: ~/.config/workcell/credentials)
-    --credential KEY            Credential key to remove
-
-  status
-    --injection-policy PATH     Policy file to inspect (default: ~/.config/workcell/injection-policy.toml)
-    --agent codex|claude|gemini Filter to the selected agent
-    --mode strict|development|build|breakglass
-    --workspace PATH            Accepted for CLI symmetry; ignored by host status
-
-Notes:
-  - auth commands run on the host and do not start the Workcell runtime.
-  - auth set/unset rewrite only the entrypoint policy file; if a credential is
-    declared by an included fragment, update that fragment directly.
-  - resolver-backed credentials remain host-side preprocessing and do not
-    grant Keychain or provider-home access inside Tier 1.
-  - auth status reports provider_bootstrap_* summary fields for the selected
-    agent on the reviewed host-owned path.
-EOF
+  go_hostutil launcher auth-usage
 }
 
 default_injection_policy_path() {
@@ -5241,31 +5202,7 @@ auth_main() {
 }
 
 policy_usage() {
-  cat <<'EOF'
-Usage: workcell policy show [options]
-       workcell policy validate [options]
-       workcell policy diff [options]
-
-Commands:
-  show
-    --injection-policy PATH     Policy file to render after include expansion
-
-  validate
-    --injection-policy PATH     Policy file to validate
-
-  diff
-    --injection-policy PATH     Policy file to compare against the canonical merged view
-
-Notes:
-  - policy commands run on the host and do not start the Workcell runtime.
-  - when --injection-policy is omitted, commands use the host default policy path.
-  - show renders the merged effective policy after include expansion.
-  - diff compares the selected entrypoint policy file against that canonical
-    merged effective view.
-  - validate fails closed when the selected policy file is missing or invalid.
-  - validate checks source-backed credential paths, but resolver-backed launch
-    readiness remains deferred to the launch path.
-EOF
+  go_hostutil launcher policy-usage
 }
 
 policy_main() {


### PR DESCRIPTION
## Summary
- internal/authpolicy/usage.go + tests hold the heredoc text.
- launcherSubcommands() gains auth-usage and policy-usage rows.
- scripts/workcell auth_usage/policy_usage become thin shims.
- control-plane-manifest.json regenerated.

## Test plan
- [x] go test ./internal/authpolicy/ ./cmd/workcell-hostutil/
- [x] gofmt -l . empty
- [x] bash -n scripts/workcell scripts/verify-invariants.sh
- [x] ./scripts/workcell --agent codex --dry-run exit 0
- [x] byte-identical help text vs main

🤖 Generated with [Claude Code](https://claude.com/claude-code)