### PR TITLE
^R Extract publish_pr_usage heredoc into internal/publishpr

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/omkhar/workcell/internal/host/release"
 	"github.com/omkhar/workcell/internal/host/sessions"
 	"github.com/omkhar/workcell/internal/host/supportmatrix"
+	"github.com/omkhar/workcell/internal/publishpr"
 	"github.com/omkhar/workcell/internal/sessionctl"
 )
 
@@ -165,6 +166,7 @@ func launcherSubcommands() []launcherSubcommand {
 		{"dedupe-endpoints", 1, 1, cmdLauncherDedupeEndpoints},
 		{"resolve-endpoints", 1, 1, cmdLauncherResolveEndpoints},
 		{"support-matrix-eval", 6, 6, cmdLauncherSupportMatrixEval},
+		{"publish-pr-usage", 0, 0, cmdLauncherPublishPRUsage},
 	}
 }
 
@@ -190,6 +192,11 @@ func runLauncher(args []string) error {
 
 func cmdLauncherSessionUsage(_ []string) error {
 	fmt.Print(sessionctl.UsageText())
+	return nil
+}
+
+func cmdLauncherPublishPRUsage(_ []string) error {
+	fmt.Print(publishpr.UsageText())
 	return nil
 }
 

--- a/internal/publishpr/doc.go
+++ b/internal/publishpr/doc.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package publishpr carries the `workcell publish-pr` user interface
+// that historically lived in scripts/workcell as the publish_pr_*
+// bash functions.  This package is the first step of the /sethify
+// PR 24 decomposition; a future sub-PR will move publish_pr_main and
+// its helpers into this package.
+//
+// Host-side git and GitHub CLI invocation stays outside this package
+// for now (different concern: that is host-side process control, this
+// package is the host-side CLI surface text).
+package publishpr

--- a/internal/publishpr/usage.go
+++ b/internal/publishpr/usage.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package publishpr
+
+// usageText is the canonical help text for `workcell publish-pr`,
+// migrated verbatim from scripts/workcell's publish_pr_usage()
+// function.
+const usageText = "Usage: workcell publish-pr [options]\n" +
+	"\n" +
+	"Options:\n" +
+	"  --workspace PATH              Workspace to publish (default: current directory)\n" +
+	"  --branch NAME                 Feature branch to create or switch to (required)\n" +
+	"  --base NAME                   Base branch for the PR (default: main)\n" +
+	"  --allow-non-main-base         Allow a lower-assurance draft PR against a non-main base\n" +
+	"  --gh-bin PATH                 Host GitHub CLI to use for PR creation\n" +
+	"  --snapshot index|worktree     Publish the current index or stage the worktree (default: worktree)\n" +
+	"  --title TEXT                  PR title\n" +
+	"  --title-file PATH             Read the PR title from PATH\n" +
+	"  --body TEXT                   PR body (default: empty)\n" +
+	"  --body-file PATH              Read the PR body from PATH\n" +
+	"  --commit-message TEXT         Commit message to sign and publish\n" +
+	"  --commit-message-file PATH    Read the commit message from PATH\n" +
+	"  --ready                       Create a ready PR instead of a draft PR\n" +
+	"  --dry-run                     Print the planned host commands and exit\n" +
+	"  -h, --help                    Show this help text\n" +
+	"\n" +
+	"Notes:\n" +
+	"  - publish-pr runs on the host, not inside the Workcell container.\n" +
+	"  - It uses the host Git and GitHub CLI configuration so maintainer signing\n" +
+	"    and publication stay outside the Tier 1 container boundary.\n" +
+	"  - It blocks over-broad branch diffs before push so published PRs stay\n" +
+	"    reviewable by a human without juggling unrelated concerns.\n" +
+	"  - By default publish-pr only supports --base main because repo-owned PR\n" +
+	"    workflows and hosted controls only cover main-based review units.\n" +
+	"  - --allow-non-main-base is an explicit lower-assurance escape hatch: the PR\n" +
+	"    stays draft-only and the normal main-based PR validation and merge gating\n" +
+	"    do not apply to that PR shape.\n" +
+	"  - publish-pr preflights whether repo-owned PR checks are expected for the\n" +
+	"    chosen base and surfaces the effective validation mode in dry-run output.\n" +
+	"  - Host-side git commands explicitly bypass repo hooks during publication\n" +
+	"    because workspace hook content is untrusted; new commits are signed and\n" +
+	"    every commit being published must verify against host signing trust.\n" +
+	"  - The default snapshot is worktree, which stages the current tracked and\n" +
+	"    untracked workspace changes with `git add -A` before committing.\n"
+
+// UsageText returns the canonical `workcell publish-pr` help string.
+func UsageText() string {
+	return usageText
+}

--- a/internal/publishpr/usage_test.go
+++ b/internal/publishpr/usage_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package publishpr
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUsageTextNonEmpty(t *testing.T) {
+	t.Parallel()
+	if got := UsageText(); got == "" {
+		t.Fatalf("UsageText() returned empty string")
+	}
+}
+
+func TestUsageTextEndsWithNewline(t *testing.T) {
+	t.Parallel()
+	got := UsageText()
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("UsageText() does not end with newline")
+	}
+}
+
+func TestUsageTextDocumentsRequiredFlags(t *testing.T) {
+	t.Parallel()
+	got := UsageText()
+	for _, want := range []string{
+		"Usage: workcell publish-pr [options]",
+		"--workspace PATH",
+		"--branch NAME",
+		"--base NAME",
+		"--allow-non-main-base",
+		"--gh-bin PATH",
+		"--snapshot index|worktree",
+		"--title TEXT",
+		"--title-file PATH",
+		"--body TEXT",
+		"--body-file PATH",
+		"--commit-message TEXT",
+		"--commit-message-file PATH",
+		"--ready",
+		"--dry-run",
+		"-h, --help",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("UsageText() missing %q", want)
+		}
+	}
+}
+
+func TestUsageTextDocumentsNotes(t *testing.T) {
+	t.Parallel()
+	got := UsageText()
+	for _, want := range []string{
+		"publish-pr runs on the host, not inside the Workcell container.",
+		"--allow-non-main-base is an explicit lower-assurance escape hatch",
+		"Host-side git commands explicitly bypass repo hooks during publication",
+		"The default snapshot is worktree",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("UsageText() missing note %q", want)
+		}
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "e2afaf8aaa745893f74893a991d7a446dd7dbde54c238f573c64b384a3bd7342"
+      "sha256": "db436d126c09337d796e244358eb5b582ebaa322608366aa26e909507c6d4d86"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -3310,45 +3310,7 @@ resolve_existing_directory_or_die() {
 }
 
 publish_pr_usage() {
-  cat <<'EOF'
-Usage: workcell publish-pr [options]
-
-Options:
-  --workspace PATH              Workspace to publish (default: current directory)
-  --branch NAME                 Feature branch to create or switch to (required)
-  --base NAME                   Base branch for the PR (default: main)
-  --allow-non-main-base         Allow a lower-assurance draft PR against a non-main base
-  --gh-bin PATH                 Host GitHub CLI to use for PR creation
-  --snapshot index|worktree     Publish the current index or stage the worktree (default: worktree)
-  --title TEXT                  PR title
-  --title-file PATH             Read the PR title from PATH
-  --body TEXT                   PR body (default: empty)
-  --body-file PATH              Read the PR body from PATH
-  --commit-message TEXT         Commit message to sign and publish
-  --commit-message-file PATH    Read the commit message from PATH
-  --ready                       Create a ready PR instead of a draft PR
-  --dry-run                     Print the planned host commands and exit
-  -h, --help                    Show this help text
-
-Notes:
-  - publish-pr runs on the host, not inside the Workcell container.
-  - It uses the host Git and GitHub CLI configuration so maintainer signing
-    and publication stay outside the Tier 1 container boundary.
-  - It blocks over-broad branch diffs before push so published PRs stay
-    reviewable by a human without juggling unrelated concerns.
-  - By default publish-pr only supports --base main because repo-owned PR
-    workflows and hosted controls only cover main-based review units.
-  - --allow-non-main-base is an explicit lower-assurance escape hatch: the PR
-    stays draft-only and the normal main-based PR validation and merge gating
-    do not apply to that PR shape.
-  - publish-pr preflights whether repo-owned PR checks are expected for the
-    chosen base and surfaces the effective validation mode in dry-run output.
-  - Host-side git commands explicitly bypass repo hooks during publication
-    because workspace hook content is untrusted; new commits are signed and
-    every commit being published must verify against host signing trust.
-  - The default snapshot is worktree, which stages the current tracked and
-    untracked workspace changes with `git add -A` before committing.
-EOF
+  go_hostutil launcher publish-pr-usage
 }
 
 resolve_existing_file_or_die() {


### PR DESCRIPTION
## Summary
- internal/publishpr/usage.go + tests hold the heredoc text.
- launcherSubcommands() gains publish-pr-usage row.
- scripts/workcell publish_pr_usage becomes a thin shim.
- control-plane-manifest.json regenerated.

## Test plan
- [x] go test ./internal/publishpr/ ./cmd/workcell-hostutil/
- [x] gofmt -l . empty
- [x] bash -n scripts/workcell scripts/verify-invariants.sh
- [x] ./scripts/workcell --agent codex --dry-run exit 0
- [x] byte-identical help text vs main

🤖 Generated with [Claude Code](https://claude.com/claude-code)