### PR TITLE
^R Migrate authpolicy and authresolve to shared tomlsubset

### DIFF
--- a/internal/authpolicy/policy.go
+++ b/internal/authpolicy/policy.go
@@ -232,225 +232,142 @@ func selectedFor(values any, current string, label string, allowedValues map[str
 	return false, nil
 }
 
-var stripComment = tomlsubset.StripComment
-
-func parseValue(raw string, policyPath string, lineno int) (any, error) {
-	value := strings.TrimSpace(raw)
-	if value == "" {
-		return nil, die(fmt.Sprintf("%s:%d: expected a value", policyPath, lineno))
-	}
-	switch value {
-	case "true":
-		return true, nil
-	case "false":
-		return false, nil
-	}
-	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
-		parsed, err := strconv.Unquote(value)
-		if err != nil {
-			return nil, err
-		}
-		return parsed, nil
-	}
-	if strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'") {
-		parsed, err := parseSingleQuoted(value)
-		if err != nil {
-			return nil, err
-		}
-		return parsed, nil
-	}
-	if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
-		parsed, err := parseStringArray(value, policyPath, lineno)
-		if err != nil {
-			return nil, err
-		}
-		return parsed, nil
-	}
-	if isDigits(value) {
-		n, err := strconv.Atoi(value)
-		if err != nil {
-			return nil, err
-		}
-		return n, nil
-	}
-	return nil, die(fmt.Sprintf("%s:%d: unsupported TOML value; use quoted strings, booleans, integers, or arrays of strings", policyPath, lineno))
-}
-
-func isDigits(value string) bool {
-	if value == "" {
-		return false
-	}
-	for _, r := range value {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return true
-}
-
-func parseSingleQuoted(value string) (string, error) {
-	if len(value) < 2 || value[0] != '\'' || value[len(value)-1] != '\'' {
-		return "", fmt.Errorf("invalid quoted string: %s", value)
-	}
-	inner := value[1 : len(value)-1]
-	replacer := strings.NewReplacer(`\\`, `\`, `\'`, `'`, `\n`, "\n", `\t`, "\t", `\r`, "\r")
-	return replacer.Replace(inner), nil
-}
-
-func parseStringArray(value string, policyPath string, lineno int) ([]any, error) {
-	inner := strings.TrimSpace(value[1 : len(value)-1])
-	if inner == "" {
-		return []any{}, nil
-	}
-	items := make([]string, 0)
-	var current strings.Builder
-	quoteChar := byte(0)
-	escaped := false
-	for i := 0; i < len(inner); i++ {
-		ch := inner[i]
-		if quoteChar != 0 {
-			current.WriteByte(ch)
-			if escaped {
-				escaped = false
-				continue
-			}
-			if ch == '\\' && quoteChar == '"' {
-				escaped = true
-				continue
-			}
-			if ch == quoteChar {
-				quoteChar = 0
-			}
-			continue
-		}
-		if ch == '\'' || ch == '"' {
-			quoteChar = ch
-			current.WriteByte(ch)
-			continue
-		}
-		if ch == ',' {
-			token := strings.TrimSpace(current.String())
-			current.Reset()
-			if token == "" {
-				continue
-			}
-			parsed, err := parseValue(token, policyPath, lineno)
-			if err != nil {
-				return nil, err
-			}
-			s, ok := parsed.(string)
-			if !ok {
-				return nil, die(fmt.Sprintf("%s:%d: only arrays of strings are supported", policyPath, lineno))
-			}
-			items = append(items, s)
-			continue
-		}
-		current.WriteByte(ch)
-	}
-	if quoteChar != 0 {
-		return nil, die(fmt.Sprintf("%s:%d: only arrays of strings are supported", policyPath, lineno))
-	}
-	token := strings.TrimSpace(current.String())
-	if token != "" {
-		parsed, err := parseValue(token, policyPath, lineno)
-		if err != nil {
-			return nil, err
-		}
-		s, ok := parsed.(string)
-		if !ok {
-			return nil, die(fmt.Sprintf("%s:%d: only arrays of strings are supported", policyPath, lineno))
-		}
-		items = append(items, s)
-	}
-	for _, item := range items {
-		if item == "" {
-			return nil, die(fmt.Sprintf("%s:%d: only arrays of strings are supported", policyPath, lineno))
-		}
-	}
-	result := make([]any, 0, len(items))
-	for _, item := range items {
-		result = append(result, item)
-	}
-	return result, nil
-}
-
+// parseTOMLSubset parses an injection-policy TOML file via the shared
+// tomlsubset.ParseDocument API and reshapes the result into the
+// map[string]any tree the rest of authpolicy consumes.  Injection policy
+// allows one specific array-of-tables construct ([[copies]]) which the
+// shared strict parser rejects, so we strip those blocks out and parse
+// each entry separately through tomlsubset.Parse before reassembling.
 func parseTOMLSubset(content string, policyPath string) (map[string]any, error) {
-	root := map[string]any{}
-	current := root
-	seenTables := map[string]struct{}{}
+	subsetContent, copiesEntries, err := extractCopiesBlocks(content, policyPath)
+	if err != nil {
+		return nil, err
+	}
+	doc, err := tomlsubset.ParseDocument(subsetContent, policyPath)
+	if err != nil {
+		return nil, die(err.Error())
+	}
+	root, err := documentToPolicyMap(doc, policyPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(copiesEntries) > 0 {
+		copies := make([]any, 0, len(copiesEntries))
+		for _, entry := range copiesEntries {
+			copies = append(copies, entry)
+		}
+		root["copies"] = copies
+	}
+	return root, nil
+}
+
+// extractCopiesBlocks scans content for `[[copies]]` headers, parses each
+// following key/value block as a single TOML subset table via
+// tomlsubset.Parse, and returns the remaining content with those blocks
+// elided plus the parsed entries in declaration order.  Any other
+// [[array-of-table]] header is rejected here so the caller-visible error
+// message matches the legacy parser.
+func extractCopiesBlocks(content, policyPath string) (string, []map[string]any, error) {
+	var (
+		kept    strings.Builder
+		entries []map[string]any
+	)
 	lines := strings.Split(content, "\n")
-	for lineno, rawLine := range lines {
-		line := stripComment(rawLine)
-		if line == "" {
-			continue
-		}
-		if strings.HasPrefix(line, "[[") && strings.HasSuffix(line, "]]") {
-			tableName := strings.TrimSpace(line[2 : len(line)-2])
+	for idx := 0; idx < len(lines); idx++ {
+		rawLine := lines[idx]
+		stripped := tomlsubset.StripComment(rawLine)
+		if strings.HasPrefix(stripped, "[[") && strings.HasSuffix(stripped, "]]") {
+			tableName := strings.TrimSpace(stripped[2 : len(stripped)-2])
 			if tableName != "copies" {
-				return nil, die(fmt.Sprintf("%s:%d: unsupported array-of-table [%s]", policyPath, lineno+1, tableName))
+				return "", nil, die(fmt.Sprintf("%s:%d: unsupported array-of-table [%s]", policyPath, idx+1, tableName))
 			}
-			rawCopies, _ := root["copies"].([]any)
-			entry := map[string]any{}
-			rawCopies = append(rawCopies, entry)
-			root["copies"] = rawCopies
-			current = entry
+			block, consumed, err := readCopiesBlock(lines, idx+1, policyPath)
+			if err != nil {
+				return "", nil, err
+			}
+			entries = append(entries, block)
+			idx = consumed - 1
+			// Emit a blank line so downstream line numbers stay roughly
+			// aligned for diagnostic output.
+			kept.WriteByte('\n')
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			tableName := strings.TrimSpace(line[1 : len(line)-1])
-			if _, seen := seenTables[tableName]; seen {
-				return nil, die(fmt.Sprintf("%s:%d: duplicate table [%s]", policyPath, lineno+1, tableName))
+		kept.WriteString(rawLine)
+		kept.WriteByte('\n')
+	}
+	result := kept.String()
+	if strings.HasSuffix(result, "\n") {
+		result = result[:len(result)-1]
+	}
+	return result, entries, nil
+}
+
+// readCopiesBlock consumes lines starting at idx until the next [header]
+// (single or double-bracketed) or end of input, parses the collected
+// `key = value` pairs as a one-off TOML subset table, and returns the
+// parsed entry plus the next unconsumed line index.
+func readCopiesBlock(lines []string, idx int, policyPath string) (map[string]any, int, error) {
+	var block strings.Builder
+	end := idx
+	for end < len(lines) {
+		stripped := tomlsubset.StripComment(lines[end])
+		if strings.HasPrefix(stripped, "[") {
+			break
+		}
+		block.WriteString(lines[end])
+		block.WriteByte('\n')
+		end++
+	}
+	parsed, err := tomlsubset.Parse(block.String(), policyPath)
+	if err != nil {
+		return nil, end, die(err.Error())
+	}
+	return parsed, end, nil
+}
+
+// documentToPolicyMap converts a tomlsubset.Document into the
+// nested-map shape the rest of authpolicy expects.  Only the
+// `documents`, `ssh`, `credentials`, and `credentials.<name>` tables get
+// special structural treatment; any other table name is rejected to
+// preserve the strict subset semantics of the legacy parser.
+func documentToPolicyMap(doc *tomlsubset.Document, policyPath string) (map[string]any, error) {
+	root := map[string]any{}
+	for _, pair := range doc.TopLevel.Pairs {
+		root[pair.Key] = pair.Value
+	}
+	for _, table := range doc.Tables {
+		name := table.Name
+		if strings.HasPrefix(name, "credentials.") {
+			credentialKey := strings.SplitN(name, ".", 2)[1]
+			if _, ok := CredentialKeys[credentialKey]; !ok {
+				return nil, die(fmt.Sprintf("%s:%d: unsupported credentials table [%s]", policyPath, table.Line, name))
 			}
-			seenTables[tableName] = struct{}{}
-			if strings.HasPrefix(tableName, "credentials.") {
-				credentialKey := strings.SplitN(tableName, ".", 2)[1]
-				if _, ok := CredentialKeys[credentialKey]; !ok {
-					return nil, die(fmt.Sprintf("%s:%d: unsupported credentials table [%s]", policyPath, lineno+1, tableName))
-				}
-				rawCredentials, _ := root["credentials"].(map[string]any)
-				if rawCredentials == nil {
-					rawCredentials = map[string]any{}
-					root["credentials"] = rawCredentials
-				}
-				entry, _ := rawCredentials[credentialKey].(map[string]any)
-				if entry == nil {
-					entry = map[string]any{}
-					rawCredentials[credentialKey] = entry
-				}
-				current = entry
-				continue
+			credentials, _ := root["credentials"].(map[string]any)
+			if credentials == nil {
+				credentials = map[string]any{}
+				root["credentials"] = credentials
 			}
-			if tableName != "documents" && tableName != "ssh" && tableName != "credentials" {
-				return nil, die(fmt.Sprintf("%s:%d: unsupported table [%s]", policyPath, lineno+1, tableName))
+			entry, _ := credentials[credentialKey].(map[string]any)
+			if entry == nil {
+				entry = map[string]any{}
+				credentials[credentialKey] = entry
 			}
-			table, _ := root[tableName].(map[string]any)
-			if table == nil {
-				table = map[string]any{}
-				root[tableName] = table
+			for _, pair := range table.Pairs {
+				entry[pair.Key] = pair.Value
 			}
-			current = table
 			continue
 		}
-		if !strings.Contains(line, "=") {
-			return nil, die(fmt.Sprintf("%s:%d: expected key = value", policyPath, lineno+1))
+		if name != "documents" && name != "ssh" && name != "credentials" {
+			return nil, die(fmt.Sprintf("%s:%d: unsupported table [%s]", policyPath, table.Line, name))
 		}
-		parts := strings.SplitN(line, "=", 2)
-		key := strings.TrimSpace(parts[0])
-		value := parts[1]
-		if key == "" {
-			return nil, die(fmt.Sprintf("%s:%d: empty key", policyPath, lineno+1))
+		target, _ := root[name].(map[string]any)
+		if target == nil {
+			target = map[string]any{}
+			root[name] = target
 		}
-		if strings.Contains(key, ".") {
-			return nil, die(fmt.Sprintf("%s:%d: dotted TOML keys are not supported; use explicit [table] headers instead", policyPath, lineno+1))
+		for _, pair := range table.Pairs {
+			target[pair.Key] = pair.Value
 		}
-		if _, exists := current[key]; exists {
-			return nil, die(fmt.Sprintf("%s:%d: duplicate key: %s", policyPath, lineno+1, key))
-		}
-		parsed, err := parseValue(value, policyPath, lineno+1)
-		if err != nil {
-			return nil, err
-		}
-		current[key] = parsed
 	}
 	return root, nil
 }

--- a/internal/authpolicy/policy_toml_rejection_test.go
+++ b/internal/authpolicy/policy_toml_rejection_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package authpolicy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestParseTOMLSubsetRejectsForbiddenConstructs is a table-driven check
+// that the migrated parseTOMLSubset (which now delegates to the shared
+// tomlsubset.ParseDocument API) still rejects the five forbidden subset
+// constructs the legacy parser caught.  Each row is the smallest input
+// that exercises one rule, plus a substring that must appear in the
+// returned error so the diagnostic stays meaningful for operators.
+func TestParseTOMLSubsetRejectsForbiddenConstructs(t *testing.T) {
+	t.Parallel()
+	type row struct {
+		name      string
+		content   string
+		wantError string
+	}
+	rows := []row{
+		{
+			name:      "array_of_tables_unsupported_name",
+			content:   "[[notcopies]]\nsource = \"/tmp/x\"\n",
+			wantError: "unsupported array-of-table",
+		},
+		{
+			name:      "dotted_key_in_credentials",
+			content:   "[credentials]\nfoo.bar = \"baz\"\n",
+			wantError: "dotted TOML keys are not supported",
+		},
+		{
+			name:      "duplicate_key_in_documents",
+			content:   "[documents]\ncommon = \"/tmp/a\"\ncommon = \"/tmp/b\"\n",
+			wantError: "duplicate key: common",
+		},
+		{
+			name:      "multi_line_basic_string",
+			content:   "version = \"\"\"hi\nthere\"\"\"\n",
+			wantError: "multi-line strings are not supported",
+		},
+		{
+			name:      "inline_table",
+			content:   "[ssh]\nidentities = { primary = \"id_rsa\" }\n",
+			wantError: "inline tables are not supported",
+		},
+	}
+	for _, r := range rows {
+		r := r
+		t.Run(r.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseTOMLSubset(r.content, "test.toml")
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", r.wantError)
+			}
+			if !strings.Contains(err.Error(), r.wantError) {
+				t.Fatalf("error %q does not contain %q", err.Error(), r.wantError)
+			}
+		})
+	}
+}
+
+// TestParseTOMLSubsetAcceptsCopiesArrayOfTables confirms the one
+// permitted array-of-tables construct ([[copies]]) still works through
+// the migrated parser.  The legacy parser tolerated this specifically
+// because injection policy fragments use it for file-copy entries.
+func TestParseTOMLSubsetAcceptsCopiesArrayOfTables(t *testing.T) {
+	t.Parallel()
+	content := strings.Join([]string{
+		"version = 1",
+		"",
+		"[[copies]]",
+		"source = \"/tmp/a\"",
+		"target = \"/state/a\"",
+		"classification = \"public\"",
+		"",
+		"[[copies]]",
+		"source = \"/tmp/b\"",
+		"target = \"/state/b\"",
+		"classification = \"secret\"",
+	}, "\n")
+	loaded, err := parseTOMLSubset(content, "copies.toml")
+	if err != nil {
+		t.Fatalf("parseTOMLSubset: %v", err)
+	}
+	copies, ok := loaded["copies"].([]any)
+	if !ok {
+		t.Fatalf("copies missing or wrong type: %#v", loaded["copies"])
+	}
+	if len(copies) != 2 {
+		t.Fatalf("want 2 copies entries, got %d", len(copies))
+	}
+	first, ok := copies[0].(map[string]any)
+	if !ok {
+		t.Fatalf("copies[0] wrong shape: %#v", copies[0])
+	}
+	if got := first["source"]; got != "/tmp/a" {
+		t.Fatalf("copies[0].source = %#v, want /tmp/a", got)
+	}
+}
+
+// TestParseTOMLSubsetUnsupportedTopLevelTable exercises the path where
+// a top-level [header] that is not `documents`, `ssh`, `credentials`, or
+// `credentials.<name>` is rejected.  Shipped non-injection TOMLs in
+// policy/ and adapters/ trip this and we want the migrated parser to
+// keep producing the same diagnostic.
+func TestParseTOMLSubsetUnsupportedTopLevelTable(t *testing.T) {
+	t.Parallel()
+	_, err := parseTOMLSubset("[forbidden_host_paths]\nkey = \"value\"\n", "test.toml")
+	if err == nil {
+		t.Fatal("expected unsupported-table error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported table [forbidden_host_paths]") {
+		t.Fatalf("error %q does not name the offending table", err.Error())
+	}
+}
+
+// TestParseTOMLSubsetShippedPolicyFiles walks every real-world TOML in
+// policy/ and adapters/*/requirements.toml and confirms the migrated
+// parser rejects each one.  None of these files conform to the injection
+// policy schema authpolicy enforces, so they MUST all fail to parse —
+// either because they use [[rules.prefix_rules]] (rejected as an
+// array-of-table other than [[copies]]) or because they declare a
+// top-level table that is not in the authpolicy whitelist.
+//
+// The intent of this test is twofold:
+//
+//  1. Verify the shared tomlsubset.ParseDocument propagates errors
+//     through the migrated authpolicy.parseTOMLSubset adapter without
+//     silently accepting otherwise-malformed input.
+//  2. Lock in the negative ground truth: if a future change accidentally
+//     widens the authpolicy schema (say, by allowing [forbidden_host_paths]
+//     or [[rules.prefix_rules]]), this test fails immediately.
+func TestParseTOMLSubsetShippedPolicyFiles(t *testing.T) {
+	t.Parallel()
+	repoRoot := findRepoRoot(t)
+	paths := []string{
+		"policy/forbidden-host-paths.toml",
+		"policy/github-hosted-controls.toml",
+		"policy/operator-contract.toml",
+		"policy/provider-bumps.toml",
+		"policy/requirements.toml",
+		"policy/reviewer-identities.toml",
+		"adapters/codex/requirements.toml",
+	}
+	for _, rel := range paths {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			t.Parallel()
+			abs := filepath.Join(repoRoot, rel)
+			data, err := os.ReadFile(abs)
+			if err != nil {
+				t.Fatalf("read %s: %v", abs, err)
+			}
+			_, err = parseTOMLSubset(string(data), abs)
+			if err == nil {
+				t.Fatalf("expected %s to be rejected by authpolicy.parseTOMLSubset, but it parsed clean", rel)
+			}
+		})
+	}
+}
+
+// findRepoRoot walks up from the test file's working directory until it
+// finds the repo's go.mod, so the shipped-policy walk works regardless
+// of where `go test` is invoked from.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := wd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find go.mod walking up from %s", wd)
+		}
+		dir = parent
+	}
+}

--- a/internal/authresolve/resolve_credential_sources.go
+++ b/internal/authresolve/resolve_credential_sources.go
@@ -1105,187 +1105,143 @@ func requireSecretFile(source, label string) (string, error) {
 	return source, nil
 }
 
+// parseTOMLSubset parses an injection-policy TOML file via the shared
+// tomlsubset.ParseDocument API and reshapes the result into the
+// map[string]any tree the rest of authresolve consumes.  Injection policy
+// allows one specific array-of-tables construct ([[copies]]) which the
+// shared strict parser rejects, so we strip those blocks out and parse
+// each entry separately through tomlsubset.Parse before reassembling.
 func parseTOMLSubset(content, policyPath string) (map[string]any, error) {
-	root := map[string]any{}
-	current := root
-	seenTables := map[string]struct{}{}
-
-	for lineno, rawLine := range strings.Split(content, "\n") {
-		line := stripComment(rawLine)
-		if line == "" {
-			continue
-		}
-
-		if strings.HasPrefix(line, "[[") && strings.HasSuffix(line, "]]") {
-			tableName := strings.TrimSpace(line[2 : len(line)-2])
-			if tableName != "copies" {
-				return nil, fmt.Errorf("%s:%d: unsupported array-of-table [%s]", policyPath, lineno+1, tableName)
-			}
-			copies, _ := root["copies"].([]any)
-			entry := map[string]any{}
-			root["copies"] = append(copies, entry)
-			current = entry
-			continue
-		}
-
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			tableName := strings.TrimSpace(line[1 : len(line)-1])
-			if _, exists := seenTables[tableName]; exists {
-				return nil, fmt.Errorf("%s:%d: duplicate table [%s]", policyPath, lineno+1, tableName)
-			}
-			seenTables[tableName] = struct{}{}
-
-			if strings.HasPrefix(tableName, "credentials.") {
-				credentialKey := strings.SplitN(tableName, ".", 2)[1]
-				if _, ok := allCredentialKeys[credentialKey]; !ok {
-					return nil, fmt.Errorf("%s:%d: unsupported credentials table [%s]", policyPath, lineno+1, tableName)
-				}
-				credentials, _ := root["credentials"].(map[string]any)
-				if credentials == nil {
-					credentials = map[string]any{}
-					root["credentials"] = credentials
-				}
-				entry, _ := credentials[credentialKey].(map[string]any)
-				if entry == nil {
-					entry = map[string]any{}
-					credentials[credentialKey] = entry
-				}
-				current = entry
-				continue
-			}
-
-			if tableName != "documents" && tableName != "ssh" && tableName != "credentials" {
-				return nil, fmt.Errorf("%s:%d: unsupported table [%s]", policyPath, lineno+1, tableName)
-			}
-			table, _ := root[tableName].(map[string]any)
-			if table == nil {
-				table = map[string]any{}
-				root[tableName] = table
-			}
-			current = table
-			continue
-		}
-
-		if !strings.Contains(line, "=") {
-			return nil, fmt.Errorf("%s:%d: expected key = value", policyPath, lineno+1)
-		}
-
-		key, value, _ := strings.Cut(line, "=")
-		key = strings.TrimSpace(key)
-		if key == "" {
-			return nil, fmt.Errorf("%s:%d: empty key", policyPath, lineno+1)
-		}
-		if strings.Contains(key, ".") {
-			return nil, fmt.Errorf("%s:%d: dotted TOML keys are not supported; use explicit [table] headers instead", policyPath, lineno+1)
-		}
-		if _, exists := current[key]; exists {
-			return nil, fmt.Errorf("%s:%d: duplicate key: %s", policyPath, lineno+1, key)
-		}
-
-		parsed, err := parseValue(value, policyPath, lineno+1)
-		if err != nil {
-			return nil, err
-		}
-		current[key] = parsed
+	subsetContent, copiesEntries, err := extractCopiesBlocks(content, policyPath)
+	if err != nil {
+		return nil, err
 	}
-
+	doc, err := tomlsubset.ParseDocument(subsetContent, policyPath)
+	if err != nil {
+		return nil, err
+	}
+	root, err := documentToPolicyMap(doc, policyPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(copiesEntries) > 0 {
+		copies := make([]any, 0, len(copiesEntries))
+		for _, entry := range copiesEntries {
+			copies = append(copies, entry)
+		}
+		root["copies"] = copies
+	}
 	return root, nil
 }
 
-func parseValue(raw, policyPath string, lineno int) (any, error) {
-	value := strings.TrimSpace(raw)
-	if value == "" {
-		return nil, fmt.Errorf("%s:%d: expected a value", policyPath, lineno)
-	}
-	if value == "true" || value == "false" {
-		return value == "true", nil
-	}
-	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
-		return strconv.Unquote(value)
-	}
-	if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
-		parsed, err := parseStringArray(value)
-		if err != nil {
-			return nil, fmt.Errorf("%s:%d: %v", policyPath, lineno, err)
+// extractCopiesBlocks scans content for `[[copies]]` headers, parses each
+// following key/value block as a single TOML subset table via
+// tomlsubset.Parse, and returns the remaining content with those blocks
+// elided plus the parsed entries in declaration order.  Any other
+// [[array-of-table]] header is rejected here so the caller-visible error
+// message matches the legacy parser.
+func extractCopiesBlocks(content, policyPath string) (string, []map[string]any, error) {
+	var (
+		kept    strings.Builder
+		entries []map[string]any
+	)
+	lines := strings.Split(content, "\n")
+	for idx := 0; idx < len(lines); idx++ {
+		rawLine := lines[idx]
+		stripped := tomlsubset.StripComment(rawLine)
+		if strings.HasPrefix(stripped, "[[") && strings.HasSuffix(stripped, "]]") {
+			tableName := strings.TrimSpace(stripped[2 : len(stripped)-2])
+			if tableName != "copies" {
+				return "", nil, fmt.Errorf("%s:%d: unsupported array-of-table [%s]", policyPath, idx+1, tableName)
+			}
+			block, consumed, err := readCopiesBlock(lines, idx+1, policyPath)
+			if err != nil {
+				return "", nil, err
+			}
+			entries = append(entries, block)
+			idx = consumed - 1
+			kept.WriteByte('\n')
+			continue
 		}
-		return parsed, nil
+		kept.WriteString(rawLine)
+		kept.WriteByte('\n')
 	}
-	if isDigits(value) {
-		n, err := strconv.Atoi(value)
-		if err != nil {
-			return nil, err
-		}
-		return n, nil
+	result := kept.String()
+	if strings.HasSuffix(result, "\n") {
+		result = result[:len(result)-1]
 	}
-	return nil, fmt.Errorf("%s:%d: unsupported TOML value; use quoted strings, booleans, integers, or arrays of strings", policyPath, lineno)
+	return result, entries, nil
 }
 
-func parseStringArray(raw string) ([]string, error) {
-	inner := strings.TrimSpace(raw[1 : len(raw)-1])
-	if inner == "" {
-		return []string{}, nil
-	}
-	values := []string{}
-	for i := 0; i < len(inner); {
-		for i < len(inner) && (inner[i] == ' ' || inner[i] == '\t' || inner[i] == ',') {
-			i++
-		}
-		if i >= len(inner) {
+// readCopiesBlock consumes lines starting at idx until the next [header]
+// (single or double-bracketed) or end of input, parses the collected
+// `key = value` pairs as a one-off TOML subset table, and returns the
+// parsed entry plus the next unconsumed line index.
+func readCopiesBlock(lines []string, idx int, policyPath string) (map[string]any, int, error) {
+	var block strings.Builder
+	end := idx
+	for end < len(lines) {
+		stripped := tomlsubset.StripComment(lines[end])
+		if strings.HasPrefix(stripped, "[") {
 			break
 		}
-		quote := inner[i]
-		if quote != '\'' && quote != '"' {
-			return nil, fmt.Errorf("only arrays of strings are supported")
-		}
-		j := i + 1
-		escaped := false
-		for j < len(inner) {
-			c := inner[j]
-			if escaped {
-				escaped = false
-				j++
-				continue
-			}
-			if c == '\\' {
-				escaped = true
-				j++
-				continue
-			}
-			if c == quote {
-				break
-			}
-			j++
-		}
-		if j >= len(inner) {
-			return nil, fmt.Errorf("unterminated string in array")
-		}
-		token := inner[i : j+1]
-		var str string
-		var err error
-		if token[0] == '\'' {
-			str, err = strconv.Unquote(`"` + strings.ReplaceAll(token[1:len(token)-1], `"`, `\"`) + `"`)
-		} else {
-			str, err = strconv.Unquote(token)
-		}
-		if err != nil {
-			return nil, err
-		}
-		values = append(values, str)
-		i = j + 1
-		for i < len(inner) && (inner[i] == ' ' || inner[i] == '\t') {
-			i++
-		}
-		if i < len(inner) {
-			if inner[i] != ',' {
-				return nil, fmt.Errorf("expected comma between array values")
-			}
-			i++
-		}
+		block.WriteString(lines[end])
+		block.WriteByte('\n')
+		end++
 	}
-	return values, nil
+	parsed, err := tomlsubset.Parse(block.String(), policyPath)
+	if err != nil {
+		return nil, end, err
+	}
+	return parsed, end, nil
 }
 
-var stripComment = tomlsubset.StripComment
+// documentToPolicyMap converts a tomlsubset.Document into the
+// nested-map shape the rest of authresolve expects.  Only the
+// `documents`, `ssh`, `credentials`, and `credentials.<name>` tables get
+// special structural treatment; any other table name is rejected to
+// preserve the strict subset semantics of the legacy parser.
+func documentToPolicyMap(doc *tomlsubset.Document, policyPath string) (map[string]any, error) {
+	root := map[string]any{}
+	for _, pair := range doc.TopLevel.Pairs {
+		root[pair.Key] = pair.Value
+	}
+	for _, table := range doc.Tables {
+		name := table.Name
+		if strings.HasPrefix(name, "credentials.") {
+			credentialKey := strings.SplitN(name, ".", 2)[1]
+			if _, ok := allCredentialKeys[credentialKey]; !ok {
+				return nil, fmt.Errorf("%s:%d: unsupported credentials table [%s]", policyPath, table.Line, name)
+			}
+			credentials, _ := root["credentials"].(map[string]any)
+			if credentials == nil {
+				credentials = map[string]any{}
+				root["credentials"] = credentials
+			}
+			entry, _ := credentials[credentialKey].(map[string]any)
+			if entry == nil {
+				entry = map[string]any{}
+				credentials[credentialKey] = entry
+			}
+			for _, pair := range table.Pairs {
+				entry[pair.Key] = pair.Value
+			}
+			continue
+		}
+		if name != "documents" && name != "ssh" && name != "credentials" {
+			return nil, fmt.Errorf("%s:%d: unsupported table [%s]", policyPath, table.Line, name)
+		}
+		target, _ := root[name].(map[string]any)
+		if target == nil {
+			target = map[string]any{}
+			root[name] = target
+		}
+		for _, pair := range table.Pairs {
+			target[pair.Key] = pair.Value
+		}
+	}
+	return root, nil
+}
 
 func validateAllowedKeys(table map[string]any, allowed map[string]struct{}, label string) error {
 	unknown := make([]string, 0)
@@ -1445,18 +1401,6 @@ func containsPath(stack []string, value string) bool {
 		}
 	}
 	return false
-}
-
-func isDigits(value string) bool {
-	if value == "" {
-		return false
-	}
-	for i := 0; i < len(value); i++ {
-		if value[i] < '0' || value[i] > '9' {
-			return false
-		}
-	}
-	return true
 }
 
 func cwd() string {

--- a/internal/authresolve/resolve_credential_sources_toml_rejection_test.go
+++ b/internal/authresolve/resolve_credential_sources_toml_rejection_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package authresolve
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestParseTOMLSubsetRejectsForbiddenConstructs is a table-driven check
+// that the migrated parseTOMLSubset (which now delegates to the shared
+// tomlsubset.ParseDocument API) still rejects the five forbidden subset
+// constructs the legacy parser caught.  Each row is the smallest input
+// that exercises one rule, plus a substring that must appear in the
+// returned error so the diagnostic stays meaningful for operators.
+func TestParseTOMLSubsetRejectsForbiddenConstructs(t *testing.T) {
+	t.Parallel()
+	type row struct {
+		name      string
+		content   string
+		wantError string
+	}
+	rows := []row{
+		{
+			name:      "array_of_tables_unsupported_name",
+			content:   "[[notcopies]]\nsource = \"/tmp/x\"\n",
+			wantError: "unsupported array-of-table",
+		},
+		{
+			name:      "dotted_key_in_credentials",
+			content:   "[credentials]\nfoo.bar = \"baz\"\n",
+			wantError: "dotted TOML keys are not supported",
+		},
+		{
+			name:      "duplicate_key_in_documents",
+			content:   "[documents]\ncommon = \"/tmp/a\"\ncommon = \"/tmp/b\"\n",
+			wantError: "duplicate key: common",
+		},
+		{
+			name:      "multi_line_basic_string",
+			content:   "version = \"\"\"hi\nthere\"\"\"\n",
+			wantError: "multi-line strings are not supported",
+		},
+		{
+			name:      "inline_table",
+			content:   "[ssh]\nidentities = { primary = \"id_rsa\" }\n",
+			wantError: "inline tables are not supported",
+		},
+	}
+	for _, r := range rows {
+		r := r
+		t.Run(r.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseTOMLSubset(r.content, "test.toml")
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", r.wantError)
+			}
+			if !strings.Contains(err.Error(), r.wantError) {
+				t.Fatalf("error %q does not contain %q", err.Error(), r.wantError)
+			}
+		})
+	}
+}
+
+// TestParseTOMLSubsetAcceptsCopiesArrayOfTables confirms the one
+// permitted array-of-tables construct ([[copies]]) still works through
+// the migrated parser.  The legacy parser tolerated this specifically
+// because injection policy fragments use it for file-copy entries.
+func TestParseTOMLSubsetAcceptsCopiesArrayOfTables(t *testing.T) {
+	t.Parallel()
+	content := strings.Join([]string{
+		"version = 1",
+		"",
+		"[[copies]]",
+		"source = \"/tmp/a\"",
+		"target = \"/state/a\"",
+		"classification = \"public\"",
+		"",
+		"[[copies]]",
+		"source = \"/tmp/b\"",
+		"target = \"/state/b\"",
+		"classification = \"secret\"",
+	}, "\n")
+	loaded, err := parseTOMLSubset(content, "copies.toml")
+	if err != nil {
+		t.Fatalf("parseTOMLSubset: %v", err)
+	}
+	copies, ok := loaded["copies"].([]any)
+	if !ok {
+		t.Fatalf("copies missing or wrong type: %#v", loaded["copies"])
+	}
+	if len(copies) != 2 {
+		t.Fatalf("want 2 copies entries, got %d", len(copies))
+	}
+	first, ok := copies[0].(map[string]any)
+	if !ok {
+		t.Fatalf("copies[0] wrong shape: %#v", copies[0])
+	}
+	if got := first["source"]; got != "/tmp/a" {
+		t.Fatalf("copies[0].source = %#v, want /tmp/a", got)
+	}
+}
+
+// TestParseTOMLSubsetUnsupportedTopLevelTable exercises the path where
+// a top-level [header] that is not `documents`, `ssh`, `credentials`, or
+// `credentials.<name>` is rejected.  Shipped non-injection TOMLs in
+// policy/ and adapters/ trip this and we want the migrated parser to
+// keep producing the same diagnostic.
+func TestParseTOMLSubsetUnsupportedTopLevelTable(t *testing.T) {
+	t.Parallel()
+	_, err := parseTOMLSubset("[forbidden_host_paths]\nkey = \"value\"\n", "test.toml")
+	if err == nil {
+		t.Fatal("expected unsupported-table error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported table [forbidden_host_paths]") {
+		t.Fatalf("error %q does not name the offending table", err.Error())
+	}
+}
+
+// TestParseTOMLSubsetShippedPolicyFiles walks every real-world TOML in
+// policy/ and adapters/*/requirements.toml and confirms the migrated
+// parser rejects each one.  None of these files conform to the injection
+// policy schema authresolve enforces, so they MUST all fail to parse —
+// either because they use [[rules.prefix_rules]] (rejected as an
+// array-of-table other than [[copies]]) or because they declare a
+// top-level table that is not in the authresolve whitelist.
+//
+// The intent of this test is twofold:
+//
+//  1. Verify the shared tomlsubset.ParseDocument propagates errors
+//     through the migrated authresolve.parseTOMLSubset adapter without
+//     silently accepting otherwise-malformed input.
+//  2. Lock in the negative ground truth: if a future change accidentally
+//     widens the authresolve schema (say, by allowing [forbidden_host_paths]
+//     or [[rules.prefix_rules]]), this test fails immediately.
+func TestParseTOMLSubsetShippedPolicyFiles(t *testing.T) {
+	t.Parallel()
+	repoRoot := findRepoRoot(t)
+	paths := []string{
+		"policy/forbidden-host-paths.toml",
+		"policy/github-hosted-controls.toml",
+		"policy/operator-contract.toml",
+		"policy/provider-bumps.toml",
+		"policy/requirements.toml",
+		"policy/reviewer-identities.toml",
+		"adapters/codex/requirements.toml",
+	}
+	for _, rel := range paths {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			t.Parallel()
+			abs := filepath.Join(repoRoot, rel)
+			data, err := os.ReadFile(abs)
+			if err != nil {
+				t.Fatalf("read %s: %v", abs, err)
+			}
+			_, err = parseTOMLSubset(string(data), abs)
+			if err == nil {
+				t.Fatalf("expected %s to be rejected by authresolve.parseTOMLSubset, but it parsed clean", rel)
+			}
+		})
+	}
+}
+
+// findRepoRoot walks up from the test file's working directory until it
+// finds the repo's go.mod, so the shipped-policy walk works regardless
+// of where `go test` is invoked from.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := wd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find go.mod walking up from %s", wd)
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Summary
- internal/authpolicy/ + internal/authresolve/ now use the shared
  tomlsubset.ParseDocument API from PR 36.
- Private parseTOMLSubset/stripComment copies deleted.
- Rejection tests added for the 5 forbidden subset constructs and every
  shipped policy/*.toml + adapters/*/requirements.toml.

## Test plan
- [x] go test ./internal/tomlsubset/ ./internal/authpolicy/ ./internal/authresolve/
- [x] go test ./... (full repo, no regressions)
- [x] gofmt -l . empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)