### PR TITLE
^R Translate policy_main into internal/authpolicy/PolicyMain

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -137,6 +137,7 @@ func launcherSubcommands() []launcherSubcommand {
 		{"session-usage", 0, 0, cmdLauncherSessionUsage},
 		{"auth-usage", 0, 0, cmdLauncherAuthUsage},
 		{"policy-usage", 0, 0, cmdLauncherPolicyUsage},
+		{"policy-cli", 0, -1, cmdLauncherPolicyCli},
 		{"session-timeline-cli", 0, -1, cmdLauncherSessionTimelineCli},
 		{"session-logs-cli", 0, -1, cmdLauncherSessionLogsCli},
 		{"session-suffix", 0, 0, cmdLauncherSessionSuffix},
@@ -204,6 +205,19 @@ func cmdLauncherAuthUsage(_ []string) error {
 func cmdLauncherPolicyUsage(_ []string) error {
 	fmt.Print(authpolicy.PolicyUsageText())
 	return nil
+}
+
+// cmdLauncherPolicyCli is the launcher entry point for the Go
+// translation of scripts/workcell's policy_main bash function.  Usage
+// errors (missing/unknown subcommand, unknown option) exit with code 2
+// to match the bash CLI surface; all other errors propagate to main()
+// for the default exit-1 path.
+func cmdLauncherPolicyCli(args []string) error {
+	err := authpolicy.PolicyMain(args)
+	if authpolicy.IsPolicyMainUsageError(err) {
+		os.Exit(2)
+	}
+	return err
 }
 
 func cmdLauncherSessionTimelineCli(args []string) error {

--- a/internal/authpolicy/policy_main.go
+++ b/internal/authpolicy/policy_main.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package authpolicy
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/omkhar/workcell/internal/host/launcher"
+)
+
+// PolicyMain implements `workcell policy {show,validate,diff}`, the Go
+// translation of the bash policy_main function in scripts/workcell.
+//
+// The bash version dispatches one of three host-only, read-only
+// subcommands against an entrypoint policy file (defaulting to
+// ~/.config/workcell/injection-policy.toml).  Behavior mirrors bash
+// exactly:
+//   - `policy help|-h|--help` prints PolicyUsageText() and returns nil.
+//   - `policy show|validate|diff [--injection-policy PATH]` resolves the
+//     policy path relative to the caller's working directory and
+//     dispatches to commandShow/commandValidate/commandDiff.
+//   - missing/unsupported subcommand or unknown option returns a
+//     usageError; the launcher wrapper translates that into exit 2 to
+//     match scripts/workcell's `exit 2` on the same input.
+//
+// Stdout and stderr go to os.Stdout/os.Stderr; runPolicyMain is the
+// io.Writer-aware seam used by the unit tests.
+func PolicyMain(args []string) error {
+	return runPolicyMain(args, os.Stdout, os.Stderr)
+}
+
+func runPolicyMain(args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		fmt.Fprint(stderr, PolicyUsageText())
+		return usageError{}
+	}
+	subcommand := args[0]
+	switch subcommand {
+	case "-h", "--help", "help":
+		fmt.Fprint(stdout, PolicyUsageText())
+		return nil
+	}
+	rest := args[1:]
+	switch subcommand {
+	case "show", "validate", "diff":
+		policyPath, helpRequested, err := parsePolicyMainArgs(subcommand, rest, stdout, stderr)
+		if err != nil {
+			return err
+		}
+		if helpRequested {
+			return nil
+		}
+		resolved, err := launcher.CanonicalizePath(policyPath)
+		if err != nil {
+			return err
+		}
+		switch subcommand {
+		case "show":
+			return commandShow(resolved, stdout)
+		case "validate":
+			return commandValidate(resolved, stdout)
+		case "diff":
+			return commandDiff(resolved, stdout)
+		}
+	}
+	fmt.Fprintf(stderr, "Unsupported workcell policy command: %s\n", subcommand)
+	fmt.Fprint(stderr, PolicyUsageText())
+	return usageError{}
+}
+
+// parsePolicyMainArgs mirrors the bash `policy {show|validate|diff}`
+// option loop: --injection-policy PATH, -h/--help, anything else is a
+// usage error.  The returned policyPath defaults to
+// defaultInjectionPolicyPath() when the flag is omitted; helpRequested
+// is true when the caller hit -h/--help inside the option loop, in
+// which case PolicyUsageText has already been written to stdout.
+func parsePolicyMainArgs(subcommand string, args []string, stdout, stderr io.Writer) (policyPath string, helpRequested bool, err error) {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--injection-policy":
+			if i+1 >= len(args) {
+				return "", false, fmt.Errorf("--injection-policy requires a value")
+			}
+			policyPath = args[i+1]
+			i++
+		case "-h", "--help":
+			fmt.Fprint(stdout, PolicyUsageText())
+			return "", true, nil
+		default:
+			fmt.Fprintf(stderr, "Unsupported workcell policy %s option: %s\n", subcommand, args[i])
+			fmt.Fprint(stderr, PolicyUsageText())
+			return "", false, usageError{}
+		}
+	}
+	if policyPath == "" {
+		def, derr := defaultInjectionPolicyPath()
+		if derr != nil {
+			return "", false, derr
+		}
+		policyPath = def
+	}
+	return policyPath, false, nil
+}
+
+// defaultInjectionPolicyPath mirrors scripts/workcell's
+// default_injection_policy_path: ${REAL_HOME}/.config/workcell/
+// injection-policy.toml.  REAL_HOME is the canonicalized user home as
+// produced by launcher.RealHome().
+func defaultInjectionPolicyPath() (string, error) {
+	home, err := launcher.RealHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "workcell", "injection-policy.toml"), nil
+}
+
+// usageError marks errors that should produce a usage-style (exit 2)
+// exit from workcell-hostutil.  It carries no message because callers
+// have already written the appropriate stderr text.
+type usageError struct{}
+
+func (usageError) Error() string { return "usage error" }
+
+// IsPolicyMainUsageError reports whether err originated from PolicyMain
+// as a usage-style error.  cmd/workcell-hostutil translates this into
+// exit code 2 to preserve scripts/workcell's policy_main contract.
+func IsPolicyMainUsageError(err error) bool {
+	var ue usageError
+	return errors.As(err, &ue)
+}

--- a/internal/authpolicy/policy_main_test.go
+++ b/internal/authpolicy/policy_main_test.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package authpolicy
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// minimalPolicy is the smallest entrypoint policy that loadPolicyBundle
+// accepts: a version stanza plus an empty credentials table.  The
+// parser allows only version/includes/documents/ssh/copies/credentials
+// at the root, so we keep the fixture intentionally narrow.
+const minimalPolicy = `version = 1
+
+[credentials]
+`
+
+func writeMinimalPolicy(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "injection-policy.toml")
+	if err := os.WriteFile(path, []byte(minimalPolicy), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+func TestPolicyMainNoArgsIsUsageError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runPolicyMain(nil, &stdout, &stderr)
+	if !IsPolicyMainUsageError(err) {
+		t.Fatalf("err = %v, want usageError", err)
+	}
+	if !strings.Contains(stderr.String(), "Usage:") {
+		t.Errorf("stderr missing usage text: %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout wrote on empty args: %q", stdout.String())
+	}
+}
+
+func TestPolicyMainHelpSubcommands(t *testing.T) {
+	for _, flag := range []string{"help", "-h", "--help"} {
+		t.Run(flag, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := runPolicyMain([]string{flag}, &stdout, &stderr); err != nil {
+				t.Fatalf("err = %v", err)
+			}
+			if !strings.Contains(stdout.String(), "workcell policy show") {
+				t.Errorf("stdout missing usage: %q", stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Errorf("stderr unexpectedly populated: %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestPolicyMainUnknownSubcommandIsUsageError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runPolicyMain([]string{"bogus"}, &stdout, &stderr)
+	if !IsPolicyMainUsageError(err) {
+		t.Fatalf("err = %v, want usageError", err)
+	}
+	if !strings.Contains(stderr.String(), "Unsupported workcell policy command: bogus") {
+		t.Errorf("stderr missing rejection: %q", stderr.String())
+	}
+}
+
+func TestPolicyMainUnknownOptionIsUsageError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runPolicyMain([]string{"show", "--bogus"}, &stdout, &stderr)
+	if !IsPolicyMainUsageError(err) {
+		t.Fatalf("err = %v, want usageError", err)
+	}
+	if !strings.Contains(stderr.String(), "Unsupported workcell policy show option: --bogus") {
+		t.Errorf("stderr missing rejection: %q", stderr.String())
+	}
+}
+
+func TestPolicyMainInjectionPolicyRequiresValue(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runPolicyMain([]string{"show", "--injection-policy"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("err = nil, want value-required failure")
+	}
+	if !strings.Contains(err.Error(), "--injection-policy requires a value") {
+		t.Fatalf("err = %v, want value-required message", err)
+	}
+}
+
+func TestPolicyMainSubcommandHelpFlagPrintsUsage(t *testing.T) {
+	for _, sub := range []string{"show", "validate", "diff"} {
+		for _, flag := range []string{"-h", "--help"} {
+			t.Run(sub+"/"+flag, func(t *testing.T) {
+				var stdout, stderr bytes.Buffer
+				if err := runPolicyMain([]string{sub, flag}, &stdout, &stderr); err != nil {
+					t.Fatalf("err = %v", err)
+				}
+				if !strings.Contains(stdout.String(), "workcell policy show") {
+					t.Errorf("stdout missing usage: %q", stdout.String())
+				}
+				if stderr.Len() != 0 {
+					t.Errorf("stderr unexpectedly populated: %q", stderr.String())
+				}
+			})
+		}
+	}
+}
+
+func TestPolicyMainShowRendersPolicy(t *testing.T) {
+	path := writeMinimalPolicy(t)
+	var stdout, stderr bytes.Buffer
+	if err := runPolicyMain([]string{"show", "--injection-policy", path}, &stdout, &stderr); err != nil {
+		t.Fatalf("err = %v stderr=%q", err, stderr.String())
+	}
+	// commandShow renders the merged effective policy via
+	// renderPolicyTOML; for a minimal policy that's just the version
+	// header, which we assert on to confirm we hit the show path
+	// rather than failing earlier.
+	if !strings.Contains(stdout.String(), "version = 1") {
+		t.Errorf("show output missing version header: %q", stdout.String())
+	}
+}
+
+func TestPolicyMainValidateReportsPolicyValid(t *testing.T) {
+	path := writeMinimalPolicy(t)
+	var stdout, stderr bytes.Buffer
+	if err := runPolicyMain([]string{"validate", "--injection-policy", path}, &stdout, &stderr); err != nil {
+		t.Fatalf("err = %v stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "policy_valid=1") {
+		t.Errorf("validate output missing policy_valid=1: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "resolver_readiness=not-applicable") {
+		t.Errorf("validate output missing resolver_readiness: %q", stdout.String())
+	}
+}
+
+func TestPolicyMainDiffReportsClean(t *testing.T) {
+	path := writeMinimalPolicy(t)
+	var stdout, stderr bytes.Buffer
+	if err := runPolicyMain([]string{"diff", "--injection-policy", path}, &stdout, &stderr); err != nil {
+		t.Fatalf("err = %v stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "diff_status=") {
+		t.Errorf("diff output missing diff_status: %q", stdout.String())
+	}
+}
+
+func TestPolicyMainShowMissingPolicyReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "absent.toml")
+	var stdout, stderr bytes.Buffer
+	err := runPolicyMain([]string{"show", "--injection-policy", missing}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("err = nil, want load failure for missing policy")
+	}
+	if IsPolicyMainUsageError(err) {
+		t.Fatalf("err = %v, want runtime (not usage) error", err)
+	}
+}
+
+func TestParsePolicyMainArgsDefaultsToInjectionPolicyPath(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	var stdout, stderr bytes.Buffer
+	got, helpRequested, err := parsePolicyMainArgs("show", nil, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if helpRequested {
+		t.Fatal("helpRequested = true, want false")
+	}
+	want := filepath.Join(tmp, ".config", "workcell", "injection-policy.toml")
+	// CanonicalizePath/RealHome resolves the HOME dir; compare by
+	// suffix so symlinked tmp dirs (e.g. macOS /private/var) still pass.
+	if !strings.HasSuffix(got, filepath.Join(".config", "workcell", "injection-policy.toml")) {
+		t.Fatalf("policyPath = %q, want suffix .config/workcell/injection-policy.toml (sample want=%q)", got, want)
+	}
+}
+
+func TestParsePolicyMainArgsAcceptsExplicitPath(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	got, helpRequested, err := parsePolicyMainArgs("validate", []string{"--injection-policy", "/etc/policy.toml"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if helpRequested {
+		t.Fatal("helpRequested = true, want false")
+	}
+	if got != "/etc/policy.toml" {
+		t.Fatalf("policyPath = %q, want /etc/policy.toml", got)
+	}
+}
+
+func TestIsPolicyMainUsageError(t *testing.T) {
+	t.Parallel()
+	if !IsPolicyMainUsageError(usageError{}) {
+		t.Error("IsPolicyMainUsageError(usageError{}) = false, want true")
+	}
+	if IsPolicyMainUsageError(nil) {
+		t.Error("IsPolicyMainUsageError(nil) = true, want false")
+	}
+	if IsPolicyMainUsageError(os.ErrNotExist) {
+		t.Error("IsPolicyMainUsageError(ErrNotExist) = true, want false")
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "216d87d620ad459065f9045c54296d7a7b7583a593475c358a6e6e0e82ff6e3e"
+      "sha256": "e262db9319c73bd292119e62860bc7c91575eb085e6fcf8f02ea7a79d51e8946"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "e262db9319c73bd292119e62860bc7c91575eb085e6fcf8f02ea7a79d51e8946"
+      "sha256": "68d9210705d4cf8b0c1e33ceea3878a12905bfb26babc13ad1d6de5cf126827f"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -5201,10 +5201,6 @@ auth_main() {
   esac
 }
 
-policy_usage() {
-  go_hostutil launcher policy-usage
-}
-
 policy_main() {
   go_hostutil launcher policy-cli "$@"
   exit $?

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -5206,55 +5206,8 @@ policy_usage() {
 }
 
 policy_main() {
-  local subcommand="${1:-}"
-  local policy_path=""
-  local -a policy_cmd=()
-
-  if [[ "${subcommand}" == "-h" ]] || [[ "${subcommand}" == "--help" ]] || [[ "${subcommand}" == "help" ]]; then
-    policy_usage
-    exit 0
-  fi
-  [[ -n "${subcommand}" ]] || {
-    policy_usage >&2
-    exit 2
-  }
-  shift
-
-  policy_path="$(default_injection_policy_path)"
-  case "${subcommand}" in
-    show | validate | diff)
-      while [[ $# -gt 0 ]]; do
-        case "$1" in
-          --injection-policy)
-            policy_path="$(raw_option_value_or_die "$1" "${2-}")"
-            shift 2
-            ;;
-          -h | --help)
-            policy_usage
-            exit 0
-            ;;
-          *)
-            echo "Unsupported workcell policy ${subcommand} option: $1" >&2
-            policy_usage >&2
-            exit 2
-            ;;
-        esac
-      done
-      policy_path="$(resolve_host_path "${policy_path}")"
-      policy_cmd=(
-        "${ROOT_DIR}/scripts/lib/manage_injection_policy"
-        "${subcommand}"
-        --policy "${policy_path}"
-      )
-      run_clean_host_command "${policy_cmd[@]}"
-      exit 0
-      ;;
-    *)
-      echo "Unsupported workcell policy command: ${subcommand}" >&2
-      policy_usage >&2
-      exit 2
-      ;;
-  esac
+  go_hostutil launcher policy-cli "$@"
+  exit $?
 }
 
 why_usage() {


### PR DESCRIPTION
## Summary
- internal/authpolicy/policy_main.go + tests translate policy_main.
- launcherSubcommands() gains policy-cli row.
- scripts/workcell policy_main becomes a shim.
- control-plane-manifest.json regenerated.

## Test plan
- [x] go test ./internal/authpolicy/ ./cmd/workcell-hostutil/
- [x] gofmt -l . empty
- [x] bash -n scripts/workcell scripts/verify-invariants.sh
- [x] bash tests/scenarios/shared/test-session-commands.sh exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)