### PR TITLE
^R Translate auth_main into internal/authpolicy/AuthMain

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -22,6 +23,13 @@ import (
 
 func main() {
 	if err := run(os.Args[1:]); err != nil {
+		var ec *authpolicy.ExitCodeError
+		if errors.As(err, &ec) {
+			if msg := ec.Error(); msg != "" {
+				fmt.Fprintln(os.Stderr, msg)
+			}
+			os.Exit(ec.Code)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -135,6 +143,7 @@ type launcherSubcommand struct {
 func launcherSubcommands() []launcherSubcommand {
 	return []launcherSubcommand{
 		{"session-usage", 0, 0, cmdLauncherSessionUsage},
+		{"auth-cli", 0, -1, cmdLauncherAuthCli},
 		{"auth-usage", 0, 0, cmdLauncherAuthUsage},
 		{"policy-usage", 0, 0, cmdLauncherPolicyUsage},
 		{"session-timeline-cli", 0, -1, cmdLauncherSessionTimelineCli},
@@ -199,6 +208,10 @@ func cmdLauncherSessionUsage(_ []string) error {
 func cmdLauncherAuthUsage(_ []string) error {
 	fmt.Print(authpolicy.AuthUsageText())
 	return nil
+}
+
+func cmdLauncherAuthCli(args []string) error {
+	return authpolicy.AuthMain(args)
 }
 
 func cmdLauncherPolicyUsage(_ []string) error {

--- a/internal/authpolicy/auth_main.go
+++ b/internal/authpolicy/auth_main.go
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package authpolicy
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/host/launcher"
+)
+
+// ExitCodeError carries a non-zero exit code that the workcell-hostutil
+// main wrapper should surface via os.Exit. AuthMain returns this so the
+// bash shim sees the original auth_main exit-code contract (2 for usage
+// failures, 1 for runtime failures).
+type ExitCodeError struct {
+	Code    int
+	Message string
+}
+
+func (e *ExitCodeError) Error() string { return e.Message }
+
+func exit2(format string, args ...any) error {
+	return &ExitCodeError{Code: 2, Message: fmt.Sprintf(format, args...)}
+}
+
+func exit1(format string, args ...any) error {
+	return &ExitCodeError{Code: 1, Message: fmt.Sprintf(format, args...)}
+}
+
+// AuthMain implements `workcell auth <subcommand>`, the Go translation
+// of the bash auth_main function in scripts/workcell. The user-visible
+// CLI surface is kept byte-identical: argument parsing, the four
+// subcommand verbs (init, set, unset, status), and the underlying
+// invocation of the in-process manage_injection_policy command
+// (authpolicy.Run) all mirror the bash behaviour exactly.
+//
+// The first arg may be `--base=PATH`; when present it is used as the
+// resolver base for relative --injection-policy / --managed-root /
+// --source paths, replicating the bash `resolve_host_path` helper that
+// passed `--base "$(pwd -P)"` through every host-path lookup.
+func AuthMain(args []string) error {
+	return authMain(args, os.Stdout, os.Stderr)
+}
+
+func authMain(args []string, stdout, stderr io.Writer) error {
+	base, rest := consumeBaseArg(args)
+
+	subcommand := ""
+	if len(rest) > 0 {
+		subcommand = rest[0]
+	}
+
+	switch subcommand {
+	case "-h", "--help", "help":
+		fmt.Fprint(stdout, AuthUsageText())
+		return nil
+	case "":
+		fmt.Fprint(stderr, AuthUsageText())
+		return &ExitCodeError{Code: 2, Message: ""}
+	}
+	rest = rest[1:]
+
+	policyPath := defaultInjectionPolicyPath()
+	managedRoot := defaultManagedCredentialsRoot()
+
+	switch subcommand {
+	case "init":
+		return authInit(rest, base, policyPath, managedRoot, stdout, stderr)
+	case "set":
+		return authSet(rest, base, policyPath, managedRoot, stdout, stderr)
+	case "unset":
+		return authUnset(rest, base, policyPath, managedRoot, stdout, stderr)
+	case "status":
+		return authStatus(rest, base, policyPath, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "Unsupported workcell auth command: %s\n", subcommand)
+		fmt.Fprint(stderr, AuthUsageText())
+		return &ExitCodeError{Code: 2, Message: ""}
+	}
+}
+
+func consumeBaseArg(args []string) (base string, rest []string) {
+	if len(args) > 0 && strings.HasPrefix(args[0], "--base=") {
+		base = strings.TrimPrefix(args[0], "--base=")
+		return base, args[1:]
+	}
+	return "", args
+}
+
+func defaultInjectionPolicyPath() string {
+	home, err := launcher.RealHome()
+	if err != nil || home == "" {
+		home, _ = os.UserHomeDir()
+	}
+	return home + "/.config/workcell/injection-policy.toml"
+}
+
+func defaultManagedCredentialsRoot() string {
+	home, err := launcher.RealHome()
+	if err != nil || home == "" {
+		home, _ = os.UserHomeDir()
+	}
+	return home + "/.config/workcell/credentials"
+}
+
+// rawOptionValueOrDie mirrors scripts/workcell raw_option_value_or_die:
+// the value may not be empty.
+func rawOptionValueOrDie(option, value string) (string, error) {
+	if value == "" {
+		return "", exit2("Option %s requires a value.", option)
+	}
+	return value, nil
+}
+
+// optionValueOrDie mirrors scripts/workcell option_value_or_die: the
+// value may not be empty and may not start with `--`.
+func optionValueOrDie(option, value string) (string, error) {
+	if value == "" || strings.HasPrefix(value, "--") {
+		return "", exit2("Option %s requires a value.", option)
+	}
+	return value, nil
+}
+
+func resolveHostPath(raw, base string) (string, error) {
+	return launcher.CanonicalizePathFrom(raw, base)
+}
+
+func authInit(args []string, base, policyPath, managedRoot string, stdout, stderr io.Writer) error {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--injection-policy":
+			v, err := nextValue(args, i, false)
+			if err != nil {
+				return err
+			}
+			policyPath = v
+			i++
+		case "--managed-root":
+			v, err := nextValue(args, i, false)
+			if err != nil {
+				return err
+			}
+			managedRoot = v
+			i++
+		case "-h", "--help":
+			fmt.Fprint(stdout, AuthUsageText())
+			return nil
+		default:
+			fmt.Fprintf(stderr, "Unsupported workcell auth init option: %s\n", args[i])
+			fmt.Fprint(stderr, AuthUsageText())
+			return &ExitCodeError{Code: 2, Message: ""}
+		}
+	}
+	resolvedPolicy, err := resolveHostPath(policyPath, base)
+	if err != nil {
+		return exit2("%s", err.Error())
+	}
+	resolvedRoot, err := resolveHostPath(managedRoot, base)
+	if err != nil {
+		return exit2("%s", err.Error())
+	}
+	return runManagePolicy([]string{
+		"init",
+		"--policy", resolvedPolicy,
+		"--managed-root", resolvedRoot,
+	}, stdout, stderr)
+}
+
+func authSet(args []string, base, policyPath, managedRoot string, stdout, stderr io.Writer) error {
+	var (
+		agent           string
+		credential      string
+		sourcePath      string
+		resolverName    string
+		ackHostResolver bool
+	)
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--injection-policy":
+			v, err := nextValue(args, i, false)
+			if err != nil {
+				return err
+			}
+			policyPath = v
+			i++
+		case "--managed-root":
+			v, err := nextValue(args, i, false)
+			if err != nil {
+				return err
+			}
+			managedRoot = v
+			i++
+		case "--agent":
+			v, err := nextValue(args, i, true)
+			if err != nil {
+				return err
+			}
+			agent = v
+			i++
+		case "--credential":
+			v, err := nextValue(args, i, true)
+			if err != nil {
+				return err
+			}
+			credential = v
+			i++
+		case "--source":
+			v, err := nextValue(args, i, false)
+			if err != nil {
+				return err
+			}
+			sourcePath = v
+			i++
+		case "--resolver":
+			v, err := nextValue(args, i, true)
+			if err != nil {
+				return err
+			}
+			resolverName = v
+			i++
+		case "--ack-host-resolver":
+			ackHostResolver = true
+		case "-h", "--help":
+			fmt.Fprint(stdout, AuthUsageText())
+			return nil
+		default:
+			fmt.Fprintf(stderr, "Unsupported workcell auth set option: %s\n", args[i])
+			fmt.Fprint(stderr, AuthUsageText())
+			return &ExitCodeError{Code: 2, Message: ""}
+		}
+	}
+	if agent == "" {
+		return exit2("workcell auth set requires --agent.")
+	}
+	if credential == "" {
+		return exit2("workcell auth set requires --credential.")
+	}
+	if resolverName != "" && !ackHostResolver {
+		return exit2("workcell auth set requires --ack-host-resolver with --resolver.")
+	}
+	resolvedPolicy, err := resolveHostPath(policyPath, base)
+	if err != nil {
+		return exit2("%s", err.Error())
+	}
+	resolvedRoot, err := resolveHostPath(managedRoot, base)
+	if err != nil {
+		return exit2("%s", err.Error())
+	}
+	authCmd := []string{
+		"set",
+		"--policy", resolvedPolicy,
+		"--managed-root", resolvedRoot,
+		"--agent", agent,
+		"--credential", credential,
+	}
+	if sourcePath != "" {
+		sourceBase := base
+		if sourceBase == "" {
+			if cwd, err := os.Getwd(); err == nil {
+				sourceBase = cwd
+			}
+		}
+		authCmd = append(authCmd, "--source", sourcePath, "--source-base", sourceBase)
+	}
+	if resolverName != "" {
+		authCmd = append(authCmd, "--resolver", resolverName, "--ack-host-resolver")
+	}
+	return runManagePolicy(authCmd, stdout, stderr)
+}
+
+func authUnset(args []string, base, policyPath, managedRoot string, stdout, stderr io.Writer) error {
+	var credential string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--injection-policy":
+			v, err := nextValue(args, i, false)
+			if err != nil {
+				return err
+			}
+			policyPath = v
+			i++
+		case "--managed-root":
+			v, err := nextValue(args, i, false)
+			if err != nil {
+				return err
+			}
+			managedRoot = v
+			i++
+		case "--credential":
+			v, err := nextValue(args, i, true)
+			if err != nil {
+				return err
+			}
+			credential = v
+			i++
+		case "-h", "--help":
+			fmt.Fprint(stdout, AuthUsageText())
+			return nil
+		default:
+			fmt.Fprintf(stderr, "Unsupported workcell auth unset option: %s\n", args[i])
+			fmt.Fprint(stderr, AuthUsageText())
+			return &ExitCodeError{Code: 2, Message: ""}
+		}
+	}
+	if credential == "" {
+		return exit2("workcell auth unset requires --credential.")
+	}
+	resolvedPolicy, err := resolveHostPath(policyPath, base)
+	if err != nil {
+		return exit2("%s", err.Error())
+	}
+	resolvedRoot, err := resolveHostPath(managedRoot, base)
+	if err != nil {
+		return exit2("%s", err.Error())
+	}
+	return runManagePolicy([]string{
+		"unset",
+		"--policy", resolvedPolicy,
+		"--managed-root", resolvedRoot,
+		"--credential", credential,
+	}, stdout, stderr)
+}
+
+func authStatus(args []string, base, policyPath string, stdout, stderr io.Writer) error {
+	var (
+		agent              string
+		mode               = "strict"
+		policyPathExplicit bool
+	)
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--injection-policy":
+			v, err := nextValue(args, i, false)
+			if err != nil {
+				return err
+			}
+			policyPath = v
+			policyPathExplicit = true
+			i++
+		case "--agent":
+			v, err := nextValue(args, i, true)
+			if err != nil {
+				return err
+			}
+			agent = v
+			i++
+		case "--mode":
+			v, err := nextValue(args, i, true)
+			if err != nil {
+				return err
+			}
+			mode = v
+			i++
+		case "--workspace":
+			// Accepted for CLI symmetry; ignored by host status.
+			if _, err := nextValue(args, i, false); err != nil {
+				return err
+			}
+			i++
+		case "-h", "--help":
+			fmt.Fprint(stdout, AuthUsageText())
+			return nil
+		default:
+			fmt.Fprintf(stderr, "Unsupported workcell auth status option: %s\n", args[i])
+			fmt.Fprint(stderr, AuthUsageText())
+			return &ExitCodeError{Code: 2, Message: ""}
+		}
+	}
+	resolvedPolicy, err := resolveHostPath(policyPath, base)
+	if err != nil {
+		return exit2("%s", err.Error())
+	}
+	if policyPathExplicit {
+		if info, statErr := os.Stat(resolvedPolicy); statErr != nil || info.IsDir() {
+			return exit2("Injection policy file does not exist: %s", resolvedPolicy)
+		}
+	}
+	authCmd := []string{
+		"status",
+		"--policy", resolvedPolicy,
+		"--mode", mode,
+	}
+	if agent != "" {
+		authCmd = append(authCmd, "--agent", agent)
+	}
+	return runManagePolicy(authCmd, stdout, stderr)
+}
+
+// nextValue returns the value following args[i]. When strict is true it
+// rejects values starting with `--` (option_value_or_die parity); when
+// strict is false only emptiness is rejected (raw_option_value_or_die).
+func nextValue(args []string, i int, strict bool) (string, error) {
+	option := args[i]
+	value := ""
+	if i+1 < len(args) {
+		value = args[i+1]
+	}
+	if strict {
+		return optionValueOrDie(option, value)
+	}
+	return rawOptionValueOrDie(option, value)
+}
+
+// runManagePolicy invokes the in-process manage_injection_policy
+// command directly, mirroring scripts/workcell's run_clean_host_command
+// invocation of scripts/lib/manage_injection_policy. The cwd-based home
+// isolation that run_clean_host_command provides is unnecessary here
+// because Run does not exec subprocesses; it only reads files via paths
+// the caller already canonicalised.
+func runManagePolicy(args []string, stdout, stderr io.Writer) error {
+	code := Run("workcell-manage-injection-policy", args, stdout, stderr)
+	if code == 0 {
+		return nil
+	}
+	return &ExitCodeError{Code: code, Message: ""}
+}
+
+// authMainBuffer is used by tests that need stdout captured separately
+// from stderr without writing to os.Stdout.
+func authMainBuffer(args []string) (string, string, error) {
+	var out, errBuf bytes.Buffer
+	err := authMain(args, &out, &errBuf)
+	return out.String(), errBuf.String(), err
+}

--- a/internal/authpolicy/auth_main_test.go
+++ b/internal/authpolicy/auth_main_test.go
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package authpolicy
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runAuthMain wraps authMain to capture stdout/stderr separately for
+// assertion. It does NOT use t.Parallel-incompatible globals.
+func runAuthMain(args []string) (stdout string, stderr string, code int, errStr string) {
+	var out, errBuf bytes.Buffer
+	err := authMain(args, &out, &errBuf)
+	code = 0
+	if err != nil {
+		var ec *ExitCodeError
+		if errors.As(err, &ec) {
+			code = ec.Code
+		} else {
+			code = 1
+		}
+		errStr = err.Error()
+	}
+	return out.String(), errBuf.String(), code, errStr
+}
+
+func TestAuthMainHelpFlagPrintsUsage(t *testing.T) {
+	t.Parallel()
+	for _, arg := range []string{"--help", "-h", "help"} {
+		stdout, _, code, _ := runAuthMain([]string{arg})
+		if code != 0 {
+			t.Fatalf("authMain(%q) code = %d, want 0", arg, code)
+		}
+		if !strings.HasPrefix(stdout, "Usage: workcell auth init") {
+			t.Fatalf("authMain(%q) stdout = %q", arg, stdout)
+		}
+	}
+}
+
+func TestAuthMainNoSubcommandFailsExitTwo(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, code, _ := runAuthMain(nil)
+	if code != 2 {
+		t.Fatalf("authMain([]) code = %d, want 2", code)
+	}
+	if stdout != "" {
+		t.Fatalf("authMain([]) stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "Usage: workcell auth init") {
+		t.Fatalf("authMain([]) stderr = %q", stderr)
+	}
+}
+
+func TestAuthMainUnknownSubcommandFailsExitTwo(t *testing.T) {
+	t.Parallel()
+	_, stderr, code, _ := runAuthMain([]string{"bogus"})
+	if code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr, "Unsupported workcell auth command: bogus") {
+		t.Fatalf("stderr = %q", stderr)
+	}
+}
+
+func TestAuthMainInitUnknownOption(t *testing.T) {
+	t.Parallel()
+	_, stderr, code, _ := runAuthMain([]string{"init", "--bogus", "value"})
+	if code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr, "Unsupported workcell auth init option: --bogus") {
+		t.Fatalf("stderr = %q", stderr)
+	}
+}
+
+func TestAuthMainSetMissingAgent(t *testing.T) {
+	t.Parallel()
+	_, _, code, err := runAuthMain([]string{"set", "--credential", "codex_auth"})
+	if code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	if !strings.Contains(err, "requires --agent") {
+		t.Fatalf("err = %q", err)
+	}
+}
+
+func TestAuthMainSetMissingCredential(t *testing.T) {
+	t.Parallel()
+	_, _, code, err := runAuthMain([]string{"set", "--agent", "codex"})
+	if code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	if !strings.Contains(err, "requires --credential") {
+		t.Fatalf("err = %q", err)
+	}
+}
+
+func TestAuthMainSetResolverRequiresAck(t *testing.T) {
+	t.Parallel()
+	_, _, code, err := runAuthMain([]string{
+		"set",
+		"--agent", "claude",
+		"--credential", "claude_auth",
+		"--resolver", "claude-macos-keychain",
+	})
+	if code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	if !strings.Contains(err, "requires --ack-host-resolver with --resolver") {
+		t.Fatalf("err = %q", err)
+	}
+}
+
+func TestAuthMainUnsetMissingCredential(t *testing.T) {
+	t.Parallel()
+	_, _, code, err := runAuthMain([]string{"unset"})
+	if code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	if !strings.Contains(err, "requires --credential") {
+		t.Fatalf("err = %q", err)
+	}
+}
+
+func TestAuthMainStatusMissingPolicyFileExitTwo(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "missing.toml")
+	_, _, code, errStr := runAuthMain([]string{
+		"--base=" + dir,
+		"status",
+		"--injection-policy", missing,
+		"--agent", "codex",
+	})
+	if code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	if !strings.Contains(errStr, "Injection policy file does not exist:") {
+		t.Fatalf("errStr = %q", errStr)
+	}
+}
+
+func TestAuthMainStatusUnknownOption(t *testing.T) {
+	t.Parallel()
+	_, stderr, code, _ := runAuthMain([]string{"status", "--bogus", "x"})
+	if code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr, "Unsupported workcell auth status option: --bogus") {
+		t.Fatalf("stderr = %q", stderr)
+	}
+}
+
+func TestAuthMainStatusWorkspaceIgnored(t *testing.T) {
+	t.Parallel()
+	// Without --injection-policy this falls back to the user default,
+	// which the in-process Run will treat as missing. We just want to
+	// observe that --workspace did not provoke an unknown-option error.
+	_, stderr, code, _ := runAuthMain([]string{
+		"status",
+		"--workspace", "/tmp/anywhere",
+	})
+	// The status command exits non-zero because the default policy
+	// file does not exist on a sandboxed test machine, but the failure
+	// must not mention --workspace as an unknown option.
+	if code == 0 {
+		// In case the default policy does exist on a dev box, that is
+		// still acceptable: --workspace was accepted.
+		return
+	}
+	if strings.Contains(stderr, "Unsupported workcell auth status option: --workspace") {
+		t.Fatalf("--workspace must be accepted; stderr = %q", stderr)
+	}
+}
+
+func TestAuthMainConsumeBaseArg(t *testing.T) {
+	t.Parallel()
+	base, rest := consumeBaseArg([]string{"--base=/x", "init"})
+	if base != "/x" {
+		t.Fatalf("base = %q, want /x", base)
+	}
+	if len(rest) != 1 || rest[0] != "init" {
+		t.Fatalf("rest = %v, want [init]", rest)
+	}
+
+	base, rest = consumeBaseArg([]string{"init"})
+	if base != "" {
+		t.Fatalf("base = %q, want empty", base)
+	}
+	if len(rest) != 1 || rest[0] != "init" {
+		t.Fatalf("rest = %v, want [init]", rest)
+	}
+}
+
+func TestAuthMainOptionValueOrDieRejectsDoubleDash(t *testing.T) {
+	t.Parallel()
+	if _, err := optionValueOrDie("--agent", "--credential"); err == nil {
+		t.Fatal("optionValueOrDie should reject value starting with --")
+	}
+	if _, err := optionValueOrDie("--agent", "codex"); err != nil {
+		t.Fatalf("optionValueOrDie rejected valid value: %v", err)
+	}
+}
+
+func TestAuthMainRawOptionValueOrDieAllowsDoubleDash(t *testing.T) {
+	t.Parallel()
+	// raw accepts any non-empty value (paths starting with -- are odd
+	// but historically allowed by the bash raw_option_value_or_die).
+	if _, err := rawOptionValueOrDie("--policy", "./x"); err != nil {
+		t.Fatalf("rawOptionValueOrDie rejected valid value: %v", err)
+	}
+	if _, err := rawOptionValueOrDie("--policy", ""); err == nil {
+		t.Fatal("rawOptionValueOrDie should reject empty value")
+	}
+}
+
+func TestAuthMainInitMissingValue(t *testing.T) {
+	t.Parallel()
+	_, _, code, err := runAuthMain([]string{"init", "--injection-policy"})
+	if code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	if !strings.Contains(err, "Option --injection-policy requires a value.") {
+		t.Fatalf("err = %q", err)
+	}
+}
+
+func TestAuthMainInitEndToEnd(t *testing.T) {
+	// Not parallel: relies on stable cwd-relative resolution.
+	dir := t.TempDir()
+	policy := filepath.Join(dir, "policy.toml")
+	managed := filepath.Join(dir, "managed")
+	stdout, _, code, errStr := runAuthMain([]string{
+		"--base=" + dir,
+		"init",
+		"--injection-policy", policy,
+		"--managed-root", managed,
+	})
+	if code != 0 {
+		t.Fatalf("code = %d errStr = %q", code, errStr)
+	}
+	if !strings.Contains(stdout, "policy_path=") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+	if !strings.Contains(stdout, "managed_root=") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+func TestAuthMainExitCodeErrorImplementsError(t *testing.T) {
+	t.Parallel()
+	err := &ExitCodeError{Code: 2, Message: "hello"}
+	if err.Error() != "hello" {
+		t.Fatalf("Error() = %q", err.Error())
+	}
+	var asErr *ExitCodeError
+	if !errors.As(error(err), &asErr) {
+		t.Fatal("errors.As failed to unwrap ExitCodeError")
+	}
+}
+
+func TestAuthMainBufferHelper(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, err := authMainBuffer([]string{"--help"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	if !strings.HasPrefix(stdout, "Usage:") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "c742611b198db4a584a5affee3716c98c4e0af5b4c333affd4371f2766bf0f36"
+      "sha256": "26b60d7510cc11a1df311616902965e482041455afc1e4b81807b7f7534d3d90"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "216d87d620ad459065f9045c54296d7a7b7583a593475c358a6e6e0e82ff6e3e"
+      "sha256": "c742611b198db4a584a5affee3716c98c4e0af5b4c333affd4371f2766bf0f36"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -4967,238 +4967,31 @@ default_managed_credentials_root() {
 }
 
 auth_main() {
-  local subcommand="${1:-}"
-  local policy_path=""
-  local policy_path_explicit=0
-  local managed_root=""
-  local agent=""
-  local credential=""
-  local source_path=""
-  local source_base=""
-  local resolver_name=""
-  local mode="strict"
-  local ack_host_resolver=0
-  local -a auth_cmd=()
-
-  if [[ "${subcommand}" == "-h" ]] || [[ "${subcommand}" == "--help" ]] || [[ "${subcommand}" == "help" ]]; then
-    auth_usage
-    exit 0
+  # Invoke the in-process auth-cli launcher and translate the launcher's
+  # exit code back to the bash auth_main contract (2 for usage failures,
+  # 1 for runtime failures). go run swallows the child's non-zero exit
+  # and always exits 1 itself, so we sniff its "exit status N" trailer
+  # on stderr to recover the original code, then strip that trailer so
+  # the user-visible stderr stays byte-identical to the legacy bash.
+  local stderr_file=""
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/workcell-auth-stderr.XXXXXX")"
+  trap 'rm -f "${stderr_file}"' RETURN
+  local rc=0
+  go_hostutil launcher auth-cli "--base=$(pwd -P)" "$@" 2>"${stderr_file}" || rc=$?
+  local stderr_capture=""
+  stderr_capture="$(cat "${stderr_file}")"
+  rm -f "${stderr_file}"
+  trap - RETURN
+  if [[ ${rc} -eq 1 ]] && [[ "${stderr_capture}" == *"exit status 2" ]]; then
+    rc=2
   fi
-  [[ -n "${subcommand}" ]] || {
-    auth_usage >&2
-    exit 2
-  }
-  shift
-
-  policy_path="$(default_injection_policy_path)"
-  managed_root="$(default_managed_credentials_root)"
-
-  case "${subcommand}" in
-    init)
-      while [[ $# -gt 0 ]]; do
-        case "$1" in
-          --injection-policy)
-            policy_path="$(raw_option_value_or_die "$1" "${2-}")"
-            policy_path_explicit=1
-            shift 2
-            ;;
-          --managed-root)
-            managed_root="$(raw_option_value_or_die "$1" "${2-}")"
-            shift 2
-            ;;
-          -h | --help)
-            auth_usage
-            exit 0
-            ;;
-          *)
-            echo "Unsupported workcell auth init option: $1" >&2
-            auth_usage >&2
-            exit 2
-            ;;
-        esac
-      done
-      policy_path="$(resolve_host_path "${policy_path}")"
-      managed_root="$(resolve_host_path "${managed_root}")"
-      auth_cmd=(
-        "${ROOT_DIR}/scripts/lib/manage_injection_policy"
-        init
-        --policy "${policy_path}"
-        --managed-root "${managed_root}"
-      )
-      run_clean_host_policy_command "${auth_cmd[@]}"
-      exit 0
-      ;;
-    set)
-      while [[ $# -gt 0 ]]; do
-        case "$1" in
-          --injection-policy)
-            policy_path="$(raw_option_value_or_die "$1" "${2-}")"
-            policy_path_explicit=1
-            shift 2
-            ;;
-          --managed-root)
-            managed_root="$(raw_option_value_or_die "$1" "${2-}")"
-            shift 2
-            ;;
-          --agent)
-            agent="$(option_value_or_die "$1" "${2-}")"
-            shift 2
-            ;;
-          --credential)
-            credential="$(option_value_or_die "$1" "${2-}")"
-            shift 2
-            ;;
-          --source)
-            source_path="$(raw_option_value_or_die "$1" "${2-}")"
-            shift 2
-            ;;
-          --resolver)
-            resolver_name="$(option_value_or_die "$1" "${2-}")"
-            shift 2
-            ;;
-          --ack-host-resolver)
-            ack_host_resolver=1
-            shift
-            ;;
-          -h | --help)
-            auth_usage
-            exit 0
-            ;;
-          *)
-            echo "Unsupported workcell auth set option: $1" >&2
-            auth_usage >&2
-            exit 2
-            ;;
-        esac
-      done
-      [[ -n "${agent}" ]] || {
-        echo "workcell auth set requires --agent." >&2
-        exit 2
-      }
-      [[ -n "${credential}" ]] || {
-        echo "workcell auth set requires --credential." >&2
-        exit 2
-      }
-      if [[ -n "${resolver_name}" ]] && [[ "${ack_host_resolver}" -ne 1 ]]; then
-        echo "workcell auth set requires --ack-host-resolver with --resolver." >&2
-        exit 2
-      fi
-      policy_path="$(resolve_host_path "${policy_path}")"
-      managed_root="$(resolve_host_path "${managed_root}")"
-      auth_cmd=(
-        "${ROOT_DIR}/scripts/lib/manage_injection_policy"
-        set
-        --policy "${policy_path}"
-        --managed-root "${managed_root}"
-        --agent "${agent}"
-        --credential "${credential}"
-      )
-      if [[ -n "${source_path}" ]]; then
-        source_base="$(pwd -P)"
-        auth_cmd+=(--source "${source_path}" --source-base "${source_base}")
-      fi
-      if [[ -n "${resolver_name}" ]]; then
-        auth_cmd+=(--resolver "${resolver_name}" --ack-host-resolver)
-      fi
-      run_clean_host_command "${auth_cmd[@]}"
-      exit 0
-      ;;
-    unset)
-      while [[ $# -gt 0 ]]; do
-        case "$1" in
-          --injection-policy)
-            policy_path="$(raw_option_value_or_die "$1" "${2-}")"
-            shift 2
-            ;;
-          --managed-root)
-            managed_root="$(raw_option_value_or_die "$1" "${2-}")"
-            shift 2
-            ;;
-          --credential)
-            credential="$(option_value_or_die "$1" "${2-}")"
-            shift 2
-            ;;
-          -h | --help)
-            auth_usage
-            exit 0
-            ;;
-          *)
-            echo "Unsupported workcell auth unset option: $1" >&2
-            auth_usage >&2
-            exit 2
-            ;;
-        esac
-      done
-      [[ -n "${credential}" ]] || {
-        echo "workcell auth unset requires --credential." >&2
-        exit 2
-      }
-      policy_path="$(resolve_host_path "${policy_path}")"
-      managed_root="$(resolve_host_path "${managed_root}")"
-      auth_cmd=(
-        "${ROOT_DIR}/scripts/lib/manage_injection_policy"
-        unset
-        --policy "${policy_path}"
-        --managed-root "${managed_root}"
-        --credential "${credential}"
-      )
-      run_clean_host_command "${auth_cmd[@]}"
-      exit 0
-      ;;
-    status)
-      while [[ $# -gt 0 ]]; do
-        case "$1" in
-          --injection-policy)
-            policy_path="$(raw_option_value_or_die "$1" "${2-}")"
-            policy_path_explicit=1
-            shift 2
-            ;;
-          --agent)
-            agent="$(option_value_or_die "$1" "${2-}")"
-            shift 2
-            ;;
-          --mode)
-            mode="$(option_value_or_die "$1" "${2-}")"
-            shift 2
-            ;;
-          --workspace)
-            raw_option_value_or_die "$1" "${2-}" >/dev/null
-            shift 2
-            ;;
-          -h | --help)
-            auth_usage
-            exit 0
-            ;;
-          *)
-            echo "Unsupported workcell auth status option: $1" >&2
-            auth_usage >&2
-            exit 2
-            ;;
-        esac
-      done
-      policy_path="$(resolve_host_path "${policy_path}")"
-      if [[ "${policy_path_explicit}" -eq 1 ]] && [[ ! -f "${policy_path}" ]]; then
-        echo "Injection policy file does not exist: ${policy_path}" >&2
-        exit 2
-      fi
-      auth_cmd=(
-        "${ROOT_DIR}/scripts/lib/manage_injection_policy"
-        status
-        --policy "${policy_path}"
-        --mode "${mode}"
-      )
-      if [[ -n "${agent}" ]]; then
-        auth_cmd+=(--agent "${agent}")
-      fi
-      run_clean_host_policy_command "${auth_cmd[@]}"
-      exit 0
-      ;;
-    *)
-      echo "Unsupported workcell auth command: ${subcommand}" >&2
-      auth_usage >&2
-      exit 2
-      ;;
-  esac
+  if [[ "${stderr_capture}" == *$'\nexit status '* ]]; then
+    stderr_capture="${stderr_capture%$'\n'exit status *}"
+  fi
+  if [[ -n "${stderr_capture}" ]]; then
+    printf '%s\n' "${stderr_capture}" >&2
+  fi
+  exit "${rc}"
 }
 
 policy_usage() {

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -4958,10 +4958,6 @@ default_injection_policy_path() {
   printf '%s/.config/workcell/injection-policy.toml\n' "${REAL_HOME}"
 }
 
-default_managed_credentials_root() {
-  printf '%s/.config/workcell/credentials\n' "${REAL_HOME}"
-}
-
 auth_main() {
   # Invoke the in-process auth-cli launcher and translate the launcher's
   # exit code back to the bash auth_main contract (2 for usage failures,

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -4954,10 +4954,6 @@ session_main() {
   esac
 }
 
-auth_usage() {
-  go_hostutil launcher auth-usage
-}
-
 default_injection_policy_path() {
   printf '%s/.config/workcell/injection-policy.toml\n' "${REAL_HOME}"
 }


### PR DESCRIPTION
## Summary
- New internal/authpolicy/auth_main.go + tests translating auth_main (234 bash LOC).
- launcherSubcommands() gains auth-cli row.
- scripts/workcell auth_main becomes a thin shim.
- control-plane-manifest.json regenerated.

## Test plan
- [x] go test ./internal/authpolicy/ ./cmd/workcell-hostutil/
- [x] gofmt -l . empty
- [x] bash -n scripts/workcell scripts/verify-invariants.sh
- [x] bash tests/scenarios/shared/test-session-commands.sh exit 0
- [x] bash tests/scenarios/shared/test-auth-commands.sh exit 0

Generated with Claude Code