### PR TITLE
^R Translate publish_pr_main validators into internal/publishpr (24.2a)

### DIFF
--- a/internal/publishpr/doc.go
+++ b/internal/publishpr/doc.go
@@ -3,11 +3,22 @@
 
 // Package publishpr carries the `workcell publish-pr` user interface
 // that historically lived in scripts/workcell as the publish_pr_*
-// bash functions.  This package is the first step of the /sethify
-// PR 24 decomposition; a future sub-PR will move publish_pr_main and
-// its helpers into this package.
+// bash functions. The decomposition is intentionally staged across
+// the /sethify PR 24 chain:
+//
+//   - PR 24.1 (landed): UsageText() — the help banner.
+//   - PR 24.2a (this file's home): ParseArgs, the validators
+//     (ValidateSnapshotName, ValidateBranchName, ValidateBaseName),
+//     LoadTextArg, RepoOwnedChecksExpected, and Preflight. These are
+//     pure-Go translations of the argument parsing + validation +
+//     text-arg loading section of publish_pr_main and carry no host
+//     filesystem or process side effects.
+//   - PR 24.2b (next): the host execution layer that drives git/gh,
+//     emits the dry-run command list, and wires `workcell-hostutil
+//     launcher publish-pr-cli` so scripts/workcell publish_pr_main
+//     becomes a thin shim.
 //
 // Host-side git and GitHub CLI invocation stays outside this package
 // for now (different concern: that is host-side process control, this
-// package is the host-side CLI surface text).
+// package is the host-side CLI surface text and validation).
 package publishpr

--- a/internal/publishpr/publish_pr_main.go
+++ b/internal/publishpr/publish_pr_main.go
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package publishpr
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// ExitCodeError carries a non-zero exit code that the workcell-hostutil
+// main wrapper surfaces via os.Exit. The bash publish_pr_main exits 2
+// for usage / validation failures and 1 for runtime failures; the Go
+// translation preserves that contract through this error type so a
+// future bash shim can recover the exit code byte-identically the way
+// the auth_main translation does.
+type ExitCodeError struct {
+	Code    int
+	Message string
+}
+
+func (e *ExitCodeError) Error() string { return e.Message }
+
+func exit2(format string, args ...any) error {
+	return &ExitCodeError{Code: 2, Message: fmt.Sprintf(format, args...)}
+}
+
+// Options carries the parsed flag set for `workcell publish-pr`.
+// Fields mirror the local variables in the bash publish_pr_main
+// argument-parsing loop so the byte-for-byte semantics survive the
+// translation. Inline-vs-file text inputs are kept as separate fields
+// because the bash function rejects both being set; LoadTextArg
+// reconciles them later when the caller is ready to read the body.
+type Options struct {
+	Workspace         string
+	Branch            string
+	Base              string
+	AllowNonMainBase  bool
+	GhBin             string
+	Snapshot          string
+	Title             string
+	TitleFile         string
+	Body              string
+	BodyFile          string
+	CommitMessage     string
+	CommitMessageFile string
+	Ready             bool
+	DryRun            bool
+	HelpRequested     bool
+}
+
+// DefaultOptions returns an Options populated with the same defaults
+// the bash publish_pr_main function applies before its argument loop:
+// base=main, snapshot=worktree, workspace=$PWD.
+func DefaultOptions() *Options {
+	cwd, _ := os.Getwd()
+	return &Options{
+		Workspace: cwd,
+		Base:      "main",
+		Snapshot:  "worktree",
+	}
+}
+
+// ParseArgs parses the publish-pr argument vector. It mirrors the
+// while/case parsing loop in scripts/workcell publish_pr_main and
+// uses the same error messages so user-visible stderr stays identical.
+// ParseArgs does NOT run --branch / --base / --snapshot validators;
+// callers compose ParseArgs with Validate to keep the responsibilities
+// separated and the unit tests focused.
+func ParseArgs(args []string) (*Options, error) {
+	opts := DefaultOptions()
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "--workspace":
+			v, err := optionValueOrDie(arg, peek(args, i+1))
+			if err != nil {
+				return nil, err
+			}
+			opts.Workspace = v
+			i++
+		case "--branch":
+			v, err := optionValueOrDie(arg, peek(args, i+1))
+			if err != nil {
+				return nil, err
+			}
+			opts.Branch = v
+			i++
+		case "--base":
+			v, err := optionValueOrDie(arg, peek(args, i+1))
+			if err != nil {
+				return nil, err
+			}
+			opts.Base = v
+			i++
+		case "--allow-non-main-base":
+			opts.AllowNonMainBase = true
+		case "--gh-bin":
+			v, err := optionValueOrDie(arg, peek(args, i+1))
+			if err != nil {
+				return nil, err
+			}
+			opts.GhBin = v
+			i++
+		case "--snapshot":
+			v, err := optionValueOrDie(arg, peek(args, i+1))
+			if err != nil {
+				return nil, err
+			}
+			opts.Snapshot = v
+			i++
+		case "--title":
+			v, err := rawOptionValueOrDie(arg, peek(args, i+1))
+			if err != nil {
+				return nil, err
+			}
+			opts.Title = v
+			i++
+		case "--title-file":
+			v, err := optionValueOrDie(arg, peek(args, i+1))
+			if err != nil {
+				return nil, err
+			}
+			opts.TitleFile = v
+			i++
+		case "--body":
+			v, err := rawOptionValueOrDie(arg, peek(args, i+1))
+			if err != nil {
+				return nil, err
+			}
+			opts.Body = v
+			i++
+		case "--body-file":
+			v, err := optionValueOrDie(arg, peek(args, i+1))
+			if err != nil {
+				return nil, err
+			}
+			opts.BodyFile = v
+			i++
+		case "--commit-message":
+			v, err := rawOptionValueOrDie(arg, peek(args, i+1))
+			if err != nil {
+				return nil, err
+			}
+			opts.CommitMessage = v
+			i++
+		case "--commit-message-file":
+			v, err := optionValueOrDie(arg, peek(args, i+1))
+			if err != nil {
+				return nil, err
+			}
+			opts.CommitMessageFile = v
+			i++
+		case "--ready":
+			opts.Ready = true
+		case "--dry-run":
+			opts.DryRun = true
+		case "-h", "--help":
+			opts.HelpRequested = true
+			return opts, nil
+		default:
+			return nil, exit2("Unsupported publish-pr option: %s", arg)
+		}
+	}
+	return opts, nil
+}
+
+// peek returns args[i] if i is in range, or "" otherwise. The bash
+// function uses "${2-}" to surface the next positional argument
+// without dying on set -u; this helper preserves that behaviour.
+func peek(args []string, i int) string {
+	if i < 0 || i >= len(args) {
+		return ""
+	}
+	return args[i]
+}
+
+// optionValueOrDie mirrors scripts/workcell option_value_or_die:
+// the value may not be empty and may not start with `--`.
+func optionValueOrDie(option, value string) (string, error) {
+	if value == "" || strings.HasPrefix(value, "--") {
+		return "", exit2("Option %s requires a value.", option)
+	}
+	return value, nil
+}
+
+// rawOptionValueOrDie mirrors scripts/workcell raw_option_value_or_die:
+// only emptiness is rejected, because user-supplied free-form text
+// (titles, bodies, commit messages) is allowed to start with `--`.
+func rawOptionValueOrDie(option, value string) (string, error) {
+	if value == "" {
+		return "", exit2("Option %s requires a value.", option)
+	}
+	return value, nil
+}
+
+// ValidateSnapshotName mirrors validate_publish_snapshot_name. The
+// bash function emits a two-line stderr message and exits 2; the Go
+// translation packs both lines into the ExitCodeError so callers can
+// write them straight to stderr without re-formatting.
+func ValidateSnapshotName(snapshot string) error {
+	switch snapshot {
+	case "index", "worktree":
+		return nil
+	default:
+		return exit2("Unsupported publish snapshot: %s\nUse --snapshot index or --snapshot worktree.", snapshot)
+	}
+}
+
+// CheckRefFormatFunc lets callers inject a `git check-ref-format`
+// adapter. ValidateBranchName and ValidateBaseName invoke it to honour
+// the bash check that delegates to `${HOST_GIT_BIN} check-ref-format
+// --branch ${branch}`. Returning false means the branch name is
+// invalid.
+type CheckRefFormatFunc func(branch string) bool
+
+// ValidateBranchName mirrors validate_publish_branch_name: the branch
+// must be non-empty, must not be the default (main/master), and must
+// pass `git check-ref-format --branch`.
+func ValidateBranchName(branch string, checkRefFormat CheckRefFormatFunc) error {
+	if branch == "" {
+		return exit2("publish-pr requires --branch.")
+	}
+	if branch == "main" || branch == "master" {
+		return exit2("publish-pr refuses the default branch. Use a feature branch instead.")
+	}
+	if checkRefFormat != nil && !checkRefFormat(branch) {
+		return exit2("Invalid publish branch name: %s", branch)
+	}
+	return nil
+}
+
+// ValidateBaseName mirrors validate_publish_base_name: the base must
+// be non-empty, must pass `git check-ref-format --branch`, and must
+// either be main or carry an explicit --allow-non-main-base waiver.
+func ValidateBaseName(base string, allowNonMainBase bool, checkRefFormat CheckRefFormatFunc) error {
+	if base == "" {
+		return exit2("publish-pr requires a non-empty --base branch name.")
+	}
+	if checkRefFormat != nil && !checkRefFormat(base) {
+		return exit2("Invalid publish base branch name: %s", base)
+	}
+	if base != "main" && !allowNonMainBase {
+		return exit2("publish-pr only supports --base main by default. Use --allow-non-main-base for an explicit lower-assurance draft PR.")
+	}
+	return nil
+}
+
+// RepoOwnedChecksExpected mirrors publish_pr_repo_owned_checks_expected:
+// repo-owned PR checks are expected only when the base is main. The
+// string return type matches the dry-run output contract (the bash
+// function prints `publish_repo_owned_pr_checks_expected=1` or `=0` to
+// stdout, and the scenario regression test in
+// tests/scenarios/shared/test-publish-pr-dry-run.sh greps for exactly
+// those literals).
+func RepoOwnedChecksExpected(base string) string {
+	if base == "main" {
+		return "1"
+	}
+	return "0"
+}
+
+// LoadTextArg mirrors publish_pr_load_text_arg: the bash helper accepts
+// either an inline value (--title) or a file value (--title-file) but
+// not both, reads the file when set, and rejects an empty value when
+// the field is required. The fileReader hook lets tests swap a real
+// disk read for an in-memory fixture.
+func LoadTextArg(inline, file, label string, required bool, fileReader func(string) (string, error)) (string, error) {
+	if inline != "" && file != "" {
+		return "", exit2("Use only one of --%s or --%s-file.", label, label)
+	}
+	if file != "" {
+		if fileReader == nil {
+			fileReader = readFileString
+		}
+		got, err := fileReader(file)
+		if err != nil {
+			return "", exit2("%s file does not exist: %s", label, file)
+		}
+		return got, nil
+	}
+	if inline != "" {
+		return inline, nil
+	}
+	if required {
+		return "", exit2("publish-pr requires --%s or --%s-file.", label, label)
+	}
+	return "", nil
+}
+
+func readFileString(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// PreflightInputs reconciles parsed CLI flags into the resolved values
+// publish_pr_main uses for the rest of the run. The bash function does
+// this just before the git/gh execution begins: it reads the text-arg
+// files, applies the lower-assurance non-main base side effects, and
+// computes repo_owned_pr_checks_expected. Splitting this out into a
+// pure-Go function keeps the validator boundary self-contained and
+// gives the upcoming 24.2b execution PR a typed handoff.
+type PreflightInputs struct {
+	TitleText                 string
+	BodyText                  string
+	CommitMessageText         string
+	PublishBaseMode           string
+	RepoOwnedPRChecksExpected string
+	Ready                     bool
+	LowerAssuranceNotice      []string // stderr lines to emit when downgrading the run
+}
+
+// Preflight applies the bash validators + text-arg loading + base-mode
+// downgrade in one pass. It mirrors the section of publish_pr_main
+// that runs between the argument-parsing loop and the trap RETURN that
+// arms the temp-file cleanup. host-path resolution, gh/git binary
+// lookup, and worktree existence checks remain in the (future)
+// execution layer because they touch the host filesystem and trusted
+// PATH lists.
+func Preflight(opts *Options, checkRefFormat CheckRefFormatFunc, fileReader func(string) (string, error)) (*PreflightInputs, error) {
+	if opts == nil {
+		return nil, exit2("publish-pr preflight requires parsed options.")
+	}
+	if err := ValidateSnapshotName(opts.Snapshot); err != nil {
+		return nil, err
+	}
+	if err := ValidateBranchName(opts.Branch, checkRefFormat); err != nil {
+		return nil, err
+	}
+	if err := ValidateBaseName(opts.Base, opts.AllowNonMainBase, checkRefFormat); err != nil {
+		return nil, err
+	}
+	titleText, err := LoadTextArg(opts.Title, opts.TitleFile, "title", true, fileReader)
+	if err != nil {
+		return nil, err
+	}
+	if titleText == "" {
+		return nil, exit2("publish-pr requires a non-empty PR title.")
+	}
+	bodyText, err := LoadTextArg(opts.Body, opts.BodyFile, "body", false, fileReader)
+	if err != nil {
+		return nil, err
+	}
+	commitText, err := LoadTextArg(opts.CommitMessage, opts.CommitMessageFile, "commit-message", true, fileReader)
+	if err != nil {
+		return nil, err
+	}
+	if commitText == "" {
+		return nil, exit2("publish-pr requires a non-empty commit message.")
+	}
+
+	result := &PreflightInputs{
+		TitleText:                 titleText,
+		BodyText:                  bodyText,
+		CommitMessageText:         commitText,
+		PublishBaseMode:           "main",
+		RepoOwnedPRChecksExpected: RepoOwnedChecksExpected(opts.Base),
+		Ready:                     opts.Ready,
+	}
+	if opts.Base != "main" {
+		result.PublishBaseMode = "lower-assurance-non-main"
+		result.Ready = false
+		result.LowerAssuranceNotice = []string{
+			fmt.Sprintf("publish-pr preflight: repo-owned PR checks are not expected for --base %s; use this only for an explicit lower-assurance draft review unit.", opts.Base),
+			"publish-pr lower-assurance mode: non-main --base stays draft and the normal main-based PR validation and merge gating do not apply to that PR shape.",
+		}
+	}
+	return result, nil
+}
+
+// WriteUsage writes the canonical publish-pr help text to w. It is the
+// shared helper for both the success path (-h / --help on stdout) and
+// the failure path (unsupported option on stderr) so the future
+// launcher wrapper does not duplicate the "fmt.Fprint(stdout/stderr,
+// UsageText())" pattern.
+func WriteUsage(w io.Writer) {
+	fmt.Fprint(w, UsageText())
+}
+
+// IsExitCodeError reports whether err is an *ExitCodeError. Callers in
+// cmd/workcell-hostutil/main.go use errors.As to extract the Code so
+// the bash shim contract survives; this helper keeps that lookup
+// readable.
+func IsExitCodeError(err error) (*ExitCodeError, bool) {
+	var ec *ExitCodeError
+	if errors.As(err, &ec) {
+		return ec, true
+	}
+	return nil, false
+}

--- a/internal/publishpr/publish_pr_main_test.go
+++ b/internal/publishpr/publish_pr_main_test.go
@@ -1,0 +1,542 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package publishpr
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseArgsAppliesDefaults(t *testing.T) {
+	t.Parallel()
+	opts, err := ParseArgs(nil)
+	if err != nil {
+		t.Fatalf("ParseArgs(nil) returned err = %v", err)
+	}
+	if opts.Base != "main" {
+		t.Errorf("Base = %q, want main", opts.Base)
+	}
+	if opts.Snapshot != "worktree" {
+		t.Errorf("Snapshot = %q, want worktree", opts.Snapshot)
+	}
+	if opts.Ready || opts.DryRun || opts.AllowNonMainBase || opts.HelpRequested {
+		t.Errorf("Ready/DryRun/AllowNonMainBase/HelpRequested = %v/%v/%v/%v, want all false",
+			opts.Ready, opts.DryRun, opts.AllowNonMainBase, opts.HelpRequested)
+	}
+}
+
+func TestParseArgsAcceptsAllSupportedFlags(t *testing.T) {
+	t.Parallel()
+	args := []string{
+		"--workspace", "/work",
+		"--branch", "feature/x",
+		"--base", "feature/review-stack",
+		"--allow-non-main-base",
+		"--gh-bin", "/opt/homebrew/bin/gh",
+		"--snapshot", "index",
+		"--title", "T",
+		"--title-file", "/tmp/title.txt",
+		"--body", "B",
+		"--body-file", "/tmp/body.txt",
+		"--commit-message", "C",
+		"--commit-message-file", "/tmp/commit.txt",
+		"--ready",
+		"--dry-run",
+	}
+	opts, err := ParseArgs(args)
+	if err != nil {
+		t.Fatalf("ParseArgs() returned err = %v", err)
+	}
+	want := Options{
+		Workspace:         "/work",
+		Branch:            "feature/x",
+		Base:              "feature/review-stack",
+		AllowNonMainBase:  true,
+		GhBin:             "/opt/homebrew/bin/gh",
+		Snapshot:          "index",
+		Title:             "T",
+		TitleFile:         "/tmp/title.txt",
+		Body:              "B",
+		BodyFile:          "/tmp/body.txt",
+		CommitMessage:     "C",
+		CommitMessageFile: "/tmp/commit.txt",
+		Ready:             true,
+		DryRun:            true,
+	}
+	got := *opts
+	if got != want {
+		t.Errorf("ParseArgs() = %+v, want %+v", got, want)
+	}
+}
+
+func TestParseArgsRejectsUnsupportedOption(t *testing.T) {
+	t.Parallel()
+	_, err := ParseArgs([]string{"--bogus"})
+	ec, ok := IsExitCodeError(err)
+	if !ok {
+		t.Fatalf("ParseArgs() err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Errorf("ExitCodeError.Code = %d, want 2", ec.Code)
+	}
+	if !strings.Contains(ec.Message, "Unsupported publish-pr option: --bogus") {
+		t.Errorf("ExitCodeError.Message = %q, want substring 'Unsupported publish-pr option: --bogus'", ec.Message)
+	}
+}
+
+func TestParseArgsRejectsMissingOptionValue(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"workspace-bare", []string{"--workspace"}},
+		{"workspace-flag-follows", []string{"--workspace", "--branch"}},
+		{"branch-empty", []string{"--branch", ""}},
+		{"base-bare", []string{"--base"}},
+		{"snapshot-bare", []string{"--snapshot"}},
+		{"gh-bin-bare", []string{"--gh-bin"}},
+		{"title-file-bare", []string{"--title-file"}},
+		{"body-file-bare", []string{"--body-file"}},
+		{"commit-message-file-bare", []string{"--commit-message-file"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseArgs(tc.args)
+			ec, ok := IsExitCodeError(err)
+			if !ok {
+				t.Fatalf("ParseArgs(%v) err = %v, want ExitCodeError", tc.args, err)
+			}
+			if ec.Code != 2 {
+				t.Errorf("ExitCodeError.Code = %d, want 2", ec.Code)
+			}
+			if !strings.Contains(ec.Message, "requires a value") {
+				t.Errorf("ExitCodeError.Message = %q, want substring 'requires a value'", ec.Message)
+			}
+		})
+	}
+}
+
+func TestParseArgsAcceptsTitleOrBodyStartingWithDoubleDash(t *testing.T) {
+	t.Parallel()
+	// raw_option_value_or_die in bash accepts values starting with --
+	// for the user-supplied free-form text inputs. ParseArgs preserves
+	// that asymmetry.
+	cases := []struct {
+		flag  string
+		value string
+		check func(*Options) string
+	}{
+		{"--title", "--title-with-dashes", func(o *Options) string { return o.Title }},
+		{"--body", "--body-with-dashes", func(o *Options) string { return o.Body }},
+		{"--commit-message", "--cm-with-dashes", func(o *Options) string { return o.CommitMessage }},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.flag, func(t *testing.T) {
+			t.Parallel()
+			opts, err := ParseArgs([]string{tc.flag, tc.value})
+			if err != nil {
+				t.Fatalf("ParseArgs(%q %q) err = %v", tc.flag, tc.value, err)
+			}
+			if got := tc.check(opts); got != tc.value {
+				t.Errorf("parsed value = %q, want %q", got, tc.value)
+			}
+		})
+	}
+}
+
+func TestParseArgsHelpFlagShortCircuits(t *testing.T) {
+	t.Parallel()
+	for _, flag := range []string{"-h", "--help"} {
+		flag := flag
+		t.Run(flag, func(t *testing.T) {
+			t.Parallel()
+			opts, err := ParseArgs([]string{flag, "--branch", "should-not-parse"})
+			if err != nil {
+				t.Fatalf("ParseArgs(%q) err = %v", flag, err)
+			}
+			if !opts.HelpRequested {
+				t.Errorf("HelpRequested = false, want true")
+			}
+			if opts.Branch != "" {
+				t.Errorf("Branch parsed past help flag: %q", opts.Branch)
+			}
+		})
+	}
+}
+
+func TestValidateSnapshotName(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"index", "worktree"} {
+		if err := ValidateSnapshotName(name); err != nil {
+			t.Errorf("ValidateSnapshotName(%q) err = %v, want nil", name, err)
+		}
+	}
+	err := ValidateSnapshotName("rebased")
+	ec, ok := IsExitCodeError(err)
+	if !ok {
+		t.Fatalf("err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Errorf("Code = %d, want 2", ec.Code)
+	}
+	for _, want := range []string{
+		"Unsupported publish snapshot: rebased",
+		"Use --snapshot index or --snapshot worktree.",
+	} {
+		if !strings.Contains(ec.Message, want) {
+			t.Errorf("Message = %q, want substring %q", ec.Message, want)
+		}
+	}
+}
+
+func TestValidateBranchName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name           string
+		branch         string
+		checkRefFormat CheckRefFormatFunc
+		wantSubstring  string
+	}{
+		{"empty", "", nil, "publish-pr requires --branch."},
+		{"main-default", "main", nil, "refuses the default branch"},
+		{"master-default", "master", nil, "refuses the default branch"},
+		{"check-ref-rejects", "feature/x", func(string) bool { return false }, "Invalid publish branch name: feature/x"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateBranchName(tc.branch, tc.checkRefFormat)
+			ec, ok := IsExitCodeError(err)
+			if !ok {
+				t.Fatalf("err = %v, want ExitCodeError", err)
+			}
+			if ec.Code != 2 {
+				t.Errorf("Code = %d, want 2", ec.Code)
+			}
+			if !strings.Contains(ec.Message, tc.wantSubstring) {
+				t.Errorf("Message = %q, want substring %q", ec.Message, tc.wantSubstring)
+			}
+		})
+	}
+
+	if err := ValidateBranchName("feature/ok", func(string) bool { return true }); err != nil {
+		t.Errorf("happy-path err = %v, want nil", err)
+	}
+	if err := ValidateBranchName("feature/no-check", nil); err != nil {
+		t.Errorf("nil-check err = %v, want nil (no ref-format check applied)", err)
+	}
+}
+
+func TestValidateBaseName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name           string
+		base           string
+		allowNonMain   bool
+		checkRefFormat CheckRefFormatFunc
+		wantSubstring  string
+	}{
+		{"empty", "", false, nil, "requires a non-empty --base"},
+		{"non-main-no-waiver", "feature/x", false, nil, "only supports --base main by default"},
+		{"check-ref-rejects", "bad..ref", false, func(string) bool { return false }, "Invalid publish base branch name: bad..ref"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateBaseName(tc.base, tc.allowNonMain, tc.checkRefFormat)
+			ec, ok := IsExitCodeError(err)
+			if !ok {
+				t.Fatalf("err = %v, want ExitCodeError", err)
+			}
+			if ec.Code != 2 {
+				t.Errorf("Code = %d, want 2", ec.Code)
+			}
+			if !strings.Contains(ec.Message, tc.wantSubstring) {
+				t.Errorf("Message = %q, want substring %q", ec.Message, tc.wantSubstring)
+			}
+		})
+	}
+
+	// Main base accepted without waiver, non-main accepted with waiver.
+	if err := ValidateBaseName("main", false, func(string) bool { return true }); err != nil {
+		t.Errorf("main err = %v, want nil", err)
+	}
+	if err := ValidateBaseName("feature/review-stack", true, func(string) bool { return true }); err != nil {
+		t.Errorf("waivered non-main err = %v, want nil", err)
+	}
+}
+
+func TestRepoOwnedChecksExpected(t *testing.T) {
+	t.Parallel()
+	if got := RepoOwnedChecksExpected("main"); got != "1" {
+		t.Errorf("RepoOwnedChecksExpected(main) = %q, want 1", got)
+	}
+	if got := RepoOwnedChecksExpected("feature/review-stack"); got != "0" {
+		t.Errorf("RepoOwnedChecksExpected(non-main) = %q, want 0", got)
+	}
+}
+
+func TestLoadTextArg(t *testing.T) {
+	t.Parallel()
+	reader := func(p string) (string, error) {
+		switch p {
+		case "ok":
+			return "from-file", nil
+		case "missing":
+			return "", errors.New("stat ok")
+		}
+		return "", errors.New("unknown")
+	}
+
+	t.Run("inline-and-file-both-set", func(t *testing.T) {
+		t.Parallel()
+		_, err := LoadTextArg("inline", "ok", "title", true, reader)
+		ec, ok := IsExitCodeError(err)
+		if !ok || ec.Code != 2 {
+			t.Fatalf("err = %v, want ExitCodeError{Code=2}", err)
+		}
+		if !strings.Contains(ec.Message, "Use only one of --title or --title-file.") {
+			t.Errorf("Message = %q", ec.Message)
+		}
+	})
+
+	t.Run("file-wins-when-inline-empty", func(t *testing.T) {
+		t.Parallel()
+		got, err := LoadTextArg("", "ok", "title", true, reader)
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if got != "from-file" {
+			t.Errorf("got = %q, want from-file", got)
+		}
+	})
+
+	t.Run("file-missing-reports-label", func(t *testing.T) {
+		t.Parallel()
+		_, err := LoadTextArg("", "missing", "body", false, reader)
+		ec, ok := IsExitCodeError(err)
+		if !ok {
+			t.Fatalf("err = %v, want ExitCodeError", err)
+		}
+		if !strings.Contains(ec.Message, "body file does not exist: missing") {
+			t.Errorf("Message = %q", ec.Message)
+		}
+	})
+
+	t.Run("inline-returned-verbatim", func(t *testing.T) {
+		t.Parallel()
+		got, err := LoadTextArg("hello", "", "title", true, reader)
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if got != "hello" {
+			t.Errorf("got = %q, want hello", got)
+		}
+	})
+
+	t.Run("optional-empty-ok", func(t *testing.T) {
+		t.Parallel()
+		got, err := LoadTextArg("", "", "body", false, reader)
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if got != "" {
+			t.Errorf("got = %q, want empty", got)
+		}
+	})
+
+	t.Run("required-empty-fails", func(t *testing.T) {
+		t.Parallel()
+		_, err := LoadTextArg("", "", "title", true, reader)
+		ec, ok := IsExitCodeError(err)
+		if !ok || ec.Code != 2 {
+			t.Fatalf("err = %v, want ExitCodeError{Code=2}", err)
+		}
+		if !strings.Contains(ec.Message, "publish-pr requires --title or --title-file.") {
+			t.Errorf("Message = %q", ec.Message)
+		}
+	})
+}
+
+func TestPreflightHappyPathMain(t *testing.T) {
+	t.Parallel()
+	opts := &Options{
+		Branch:        "feature/x",
+		Base:          "main",
+		Snapshot:      "worktree",
+		Title:         "Title",
+		CommitMessage: "Commit",
+		Ready:         true,
+	}
+	result, err := Preflight(opts, func(string) bool { return true }, nil)
+	if err != nil {
+		t.Fatalf("Preflight err = %v", err)
+	}
+	if result.PublishBaseMode != "main" {
+		t.Errorf("PublishBaseMode = %q, want main", result.PublishBaseMode)
+	}
+	if result.RepoOwnedPRChecksExpected != "1" {
+		t.Errorf("RepoOwnedPRChecksExpected = %q, want 1", result.RepoOwnedPRChecksExpected)
+	}
+	if !result.Ready {
+		t.Errorf("Ready = false, want true (main base preserves --ready)")
+	}
+	if len(result.LowerAssuranceNotice) != 0 {
+		t.Errorf("LowerAssuranceNotice = %v, want empty", result.LowerAssuranceNotice)
+	}
+}
+
+func TestPreflightDowngradesLowerAssuranceNonMain(t *testing.T) {
+	t.Parallel()
+	opts := &Options{
+		Branch:           "feature/x",
+		Base:             "feature/review-stack",
+		AllowNonMainBase: true,
+		Snapshot:         "worktree",
+		Title:            "Title",
+		CommitMessage:    "Commit",
+		Ready:            true,
+	}
+	result, err := Preflight(opts, func(string) bool { return true }, nil)
+	if err != nil {
+		t.Fatalf("Preflight err = %v", err)
+	}
+	if result.PublishBaseMode != "lower-assurance-non-main" {
+		t.Errorf("PublishBaseMode = %q, want lower-assurance-non-main", result.PublishBaseMode)
+	}
+	if result.RepoOwnedPRChecksExpected != "0" {
+		t.Errorf("RepoOwnedPRChecksExpected = %q, want 0", result.RepoOwnedPRChecksExpected)
+	}
+	if result.Ready {
+		t.Errorf("Ready = true, want false (non-main base must stay draft)")
+	}
+	if len(result.LowerAssuranceNotice) != 2 {
+		t.Fatalf("LowerAssuranceNotice len = %d, want 2", len(result.LowerAssuranceNotice))
+	}
+	if !strings.Contains(result.LowerAssuranceNotice[0], "feature/review-stack") {
+		t.Errorf("notice[0] = %q, want substring 'feature/review-stack'", result.LowerAssuranceNotice[0])
+	}
+	if !strings.Contains(result.LowerAssuranceNotice[1], "lower-assurance mode") {
+		t.Errorf("notice[1] = %q, want substring 'lower-assurance mode'", result.LowerAssuranceNotice[1])
+	}
+}
+
+func TestPreflightRejectsEmptyTitleAndCommit(t *testing.T) {
+	t.Parallel()
+	// Empty title is rejected (the bash function exits 2 with
+	// "requires a non-empty PR title" after LoadTextArg returns "").
+	opts := &Options{
+		Branch:        "feature/x",
+		Base:          "main",
+		Snapshot:      "worktree",
+		Title:         " ",
+		CommitMessage: "commit",
+	}
+	// A space-only title is treated as non-empty by the bash function
+	// because it uses `-z` which only rejects truly empty strings; the
+	// Go translation matches that behaviour. So this test focuses on
+	// the truly-empty path via missing inline + missing file.
+	if _, err := Preflight(opts, func(string) bool { return true }, nil); err != nil {
+		t.Fatalf("Preflight space-only title err = %v, want nil", err)
+	}
+
+	emptyTitleOpts := &Options{
+		Branch:        "feature/x",
+		Base:          "main",
+		Snapshot:      "worktree",
+		CommitMessage: "commit",
+	}
+	_, err := Preflight(emptyTitleOpts, func(string) bool { return true }, nil)
+	ec, ok := IsExitCodeError(err)
+	if !ok {
+		t.Fatalf("err = %v, want ExitCodeError", err)
+	}
+	if !strings.Contains(ec.Message, "--title or --title-file") {
+		t.Errorf("Message = %q, want substring '--title or --title-file'", ec.Message)
+	}
+
+	emptyCommitOpts := &Options{
+		Branch:   "feature/x",
+		Base:     "main",
+		Snapshot: "worktree",
+		Title:    "T",
+	}
+	_, err = Preflight(emptyCommitOpts, func(string) bool { return true }, nil)
+	ec, ok = IsExitCodeError(err)
+	if !ok {
+		t.Fatalf("err = %v, want ExitCodeError", err)
+	}
+	if !strings.Contains(ec.Message, "--commit-message or --commit-message-file") {
+		t.Errorf("Message = %q, want substring '--commit-message or --commit-message-file'", ec.Message)
+	}
+}
+
+func TestPreflightPropagatesValidatorErrors(t *testing.T) {
+	t.Parallel()
+	// Snapshot validator failure short-circuits before text-arg loading.
+	bad := &Options{
+		Branch:        "feature/x",
+		Base:          "main",
+		Snapshot:      "bogus",
+		Title:         "T",
+		CommitMessage: "C",
+	}
+	_, err := Preflight(bad, func(string) bool { return true }, nil)
+	ec, ok := IsExitCodeError(err)
+	if !ok {
+		t.Fatalf("err = %v, want ExitCodeError", err)
+	}
+	if !strings.Contains(ec.Message, "Unsupported publish snapshot: bogus") {
+		t.Errorf("Message = %q", ec.Message)
+	}
+}
+
+func TestPreflightRejectsNilOptions(t *testing.T) {
+	t.Parallel()
+	_, err := Preflight(nil, nil, nil)
+	ec, ok := IsExitCodeError(err)
+	if !ok {
+		t.Fatalf("err = %v, want ExitCodeError", err)
+	}
+	if !strings.Contains(ec.Message, "requires parsed options") {
+		t.Errorf("Message = %q", ec.Message)
+	}
+}
+
+func TestWriteUsageMatchesUsageText(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	WriteUsage(&buf)
+	if buf.String() != UsageText() {
+		t.Errorf("WriteUsage output diverges from UsageText()")
+	}
+}
+
+func TestIsExitCodeErrorWraps(t *testing.T) {
+	t.Parallel()
+	base := &ExitCodeError{Code: 7, Message: "boom"}
+	wrapped := wrapErrForTest(base)
+	got, ok := IsExitCodeError(wrapped)
+	if !ok {
+		t.Fatalf("IsExitCodeError(wrapped) = false, want true")
+	}
+	if got.Code != 7 || got.Message != "boom" {
+		t.Errorf("unwrapped = %+v, want {Code:7 Message:boom}", got)
+	}
+	if _, ok := IsExitCodeError(errors.New("plain")); ok {
+		t.Errorf("IsExitCodeError(plain) = true, want false")
+	}
+}
+
+func wrapErrForTest(err error) error {
+	return errors.Join(errors.New("preamble"), err)
+}


### PR DESCRIPTION
## Summary
- `internal/publishpr/publish_pr_main.go` adds the pure-Go translation of `publish_pr_main`'s argument-parsing, validator, text-arg loading, and preflight phases (`ParseArgs`, `ValidateSnapshotName`, `ValidateBranchName`, `ValidateBaseName`, `LoadTextArg`, `RepoOwnedChecksExpected`, `Preflight`).
- `ExitCodeError` carries the bash exit-code contract (2 for usage/validation, 1 for runtime) so 24.2b can plumb it through the launcher shim the same way the auth_main translation did in 23.2.
- This PR is the first half of the planned 24.2 split. The bash function `publish_pr_main` is intentionally untouched; the host execution layer + `publish-pr-cli` launcher wiring + bash shim swap land in 24.2b. New Go code is dormant until 24.2b lights up the launcher subcommand.
- `internal/publishpr/doc.go` updated to describe the staged decomposition (24.1 / 24.2a / 24.2b).

## Test plan
- [x] `go test ./internal/publishpr/ ./cmd/workcell-hostutil/` green
- [x] `gofmt -l .` empty
- [x] `bash -n scripts/workcell scripts/verify-invariants.sh` clean
- [x] `shellcheck --severity=info scripts/workcell` clean (no SC2317 unreachable; bash unchanged)
- [x] `bash tests/scenarios/shared/test-session-commands.sh` exit 0
- [x] `bash tests/scenarios/shared/test-publish-pr-dry-run.sh` exit 0
- [x] `bash scripts/check-pr-shape.sh ...` passed: files=3 lines=957 areas=1 binary_files=0
- [x] `publish_pr_repo_owned_checks_expected` invariant preserved (bash function unchanged; verify-invariants.sh still drives the existing legacy path)

## What's left for 24.2b
- Host execution layer that drives git/gh via the trusted-host PATH + env -i sandbox (`run_publish_host_command_in_dir`).
- `emit_command` translation for the dry-run output, including `%q` quoting parity with the existing scenario assertions.
- Trusted host tool resolution (`resolve_existing_executable_or_die`, `resolve_host_tool`, `is_trusted_host_tool_path`) in Go.
- New `publish-pr-cli` launcher subcommand row in `cmd/workcell-hostutil/main.go`.
- `scripts/workcell` `publish_pr_main` body swapped for the `go_hostutil launcher publish-pr-cli` shim with `go run` exit-code-trailer stripping.
- Manifest regeneration once the launcher row lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)