### PR TITLE
^R Translate session_send_main into internal/sessionctl/SendMain

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -152,6 +152,7 @@ func launcherSubcommands() []launcherSubcommand {
 		{"session-timeline-cli", 0, -1, cmdLauncherSessionTimelineCli},
 		{"session-logs-cli", 0, -1, cmdLauncherSessionLogsCli},
 		{"session-attach-cli", 0, -1, cmdLauncherSessionAttachCli},
+		{"session-send-cli", 0, -1, cmdLauncherSessionSendCli},
 		{"session-stop-cli", 0, -1, cmdLauncherSessionStopCli},
 		{"session-suffix", 0, 0, cmdLauncherSessionSuffix},
 		{"colima-status", 1, 1, cmdLauncherColimaStatus},
@@ -262,6 +263,10 @@ func cmdLauncherSessionLogsCli(args []string) error {
 
 func cmdLauncherSessionAttachCli(args []string) error {
 	return sessionctl.AttachMain(args)
+}
+
+func cmdLauncherSessionSendCli(args []string) error {
+	return sessionctl.SendMain(args)
 }
 
 func cmdLauncherSessionStopCli(args []string) error {

--- a/internal/sessionctl/send.go
+++ b/internal/sessionctl/send.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/authpolicy"
+)
+
+// SendMain implements the option-parsing half of `workcell session send
+// --id SESSION_ID --message TEXT [--no-newline]`, the Go translation of
+// session_send_main in scripts/workcell.
+//
+// Like AttachMain, SendMain is the host-side parsing layer of a hybrid
+// translation.  The bash function's body splits into:
+//
+//  1. Up-front option parsing (--id, --message, --no-newline) with the
+//     bash idioms option_value_or_die / raw_option_value_or_die.  This
+//     half lives here.
+//
+//  2. Live-session metadata load (load_session_runtime_metadata), the
+//     `run_profile_docker_command exec` transport call that injects the
+//     payload into the detached container's stdin FIFO, audit emission,
+//     and the loaded-session summary printout.  Those still depend on
+//     sourced bash helpers that tests/scenarios/shared/test-session-commands.sh
+//     mocks via `bash -lc "source workcell; ..."`, so they stay in the
+//     bash shim.  Crucially, several of those test cases exercise the
+//     bash function without populating an on-disk session record, so
+//     SendMain deliberately does NOT call FindSessionRecordInRoots -
+//     metadata validation is left to bash's load_session_runtime_metadata.
+//
+// SendMain emits a plan on stdout for the bash shim to consume:
+//
+//	session_id=<id>
+//	message=<message>
+//	append_newline=0|1
+//
+// State-root forwarding mirrors AttachMain/LogsMain: leading
+// --root=PATH args are consumed via consumeRootArgs because go_hostutil
+// scrubs WORKCELL_STATE_ROOT/COLIMA_STATE_ROOT from the environment.
+// The Go side does not currently use those roots, but the bash shim
+// keeps prepending them so the contract stays consistent with sibling
+// session-* subcommands and so a future tightening of SendMain that
+// does need on-disk lookup will not require a shim change.
+func SendMain(args []string) error {
+	return sendMain(args, os.Stdout)
+}
+
+func sendMain(args []string, stdout io.Writer) error {
+	_, rest := consumeRootArgs(args)
+	sessionID, message, appendNewline, showHelp, err := parseSendArgs(rest)
+	if err != nil {
+		return err
+	}
+	if showHelp {
+		fmt.Fprint(stdout, UsageText())
+		return nil
+	}
+	if sessionID == "" {
+		return &authpolicy.ExitCodeError{Code: 2, Message: "workcell session send requires --id."}
+	}
+	if message == "" {
+		return &authpolicy.ExitCodeError{Code: 2, Message: "workcell session send requires --message."}
+	}
+
+	appendFlag := 0
+	if appendNewline {
+		appendFlag = 1
+	}
+	fmt.Fprintf(stdout, "session_id=%s\n", sessionID)
+	fmt.Fprintf(stdout, "message=%s\n", message)
+	fmt.Fprintf(stdout, "append_newline=%d\n", appendFlag)
+	return nil
+}
+
+// parseSendArgs walks the bash session_send_main option loop.
+//
+// --id mirrors option_value_or_die: the value must be non-empty and
+// must not start with `--` (catches a missing value swallowed by the
+// next flag, e.g. `--id --message foo`).
+//
+// --message mirrors raw_option_value_or_die: the value must only be
+// non-empty so the operator can legitimately send a payload that starts
+// with `--`.
+//
+// --no-newline is a boolean toggle.
+//
+// -h / --help mark help output for the caller.
+//
+// Unknown options return an Unsupported-style error matching the bash
+// branch so the user-visible stderr stays byte-identical.
+func parseSendArgs(args []string) (sessionID, message string, appendNewline, showHelp bool, err error) {
+	appendNewline = true
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--id":
+			v, perr := optionValueForSend(args, i, false)
+			if perr != nil {
+				return "", "", false, false, perr
+			}
+			sessionID = v
+			i++
+		case "--message":
+			v, perr := optionValueForSend(args, i, true)
+			if perr != nil {
+				return "", "", false, false, perr
+			}
+			message = v
+			i++
+		case "--no-newline":
+			appendNewline = false
+		case "-h", "--help":
+			showHelp = true
+		default:
+			return "", "", false, false, &authpolicy.ExitCodeError{
+				Code:    2,
+				Message: fmt.Sprintf("Unsupported workcell session send option: %s", args[i]),
+			}
+		}
+	}
+	return sessionID, message, appendNewline, showHelp, nil
+}
+
+// optionValueForSend returns the value following args[i].  When raw is
+// false, the value mirrors option_value_or_die: empty or `--`-prefixed
+// values are rejected (so the missing-value case is caught when the
+// next flag is consumed).  When raw is true, the value mirrors
+// raw_option_value_or_die: only empty is rejected.
+//
+// The exit-2 wrapping matches the bash CLI contract that usage errors
+// flow back as exit status 2.
+func optionValueForSend(args []string, i int, raw bool) (string, error) {
+	option := args[i]
+	if i+1 >= len(args) {
+		return "", &authpolicy.ExitCodeError{
+			Code:    2,
+			Message: fmt.Sprintf("Option %s requires a value.", option),
+		}
+	}
+	value := args[i+1]
+	if value == "" {
+		return "", &authpolicy.ExitCodeError{
+			Code:    2,
+			Message: fmt.Sprintf("Option %s requires a value.", option),
+		}
+	}
+	if !raw && strings.HasPrefix(value, "--") {
+		return "", &authpolicy.ExitCodeError{
+			Code:    2,
+			Message: fmt.Sprintf("Option %s requires a value.", option),
+		}
+	}
+	return value, nil
+}

--- a/internal/sessionctl/send_test.go
+++ b/internal/sessionctl/send_test.go
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/authpolicy"
+)
+
+func TestParseSendArgsRequiresIDValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, _, err := parseSendArgs([]string{"--id"})
+	if err == nil {
+		t.Fatal("parseSendArgs accepted --id without a value")
+	}
+	if !strings.Contains(err.Error(), "Option --id requires a value.") {
+		t.Fatalf("parseSendArgs error = %v, want canonical require-value message", err)
+	}
+}
+
+func TestParseSendArgsRejectsEmptyIDValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, _, err := parseSendArgs([]string{"--id", ""})
+	if err == nil {
+		t.Fatal("parseSendArgs accepted empty --id value")
+	}
+}
+
+func TestParseSendArgsRejectsDashDashIDValue(t *testing.T) {
+	t.Parallel()
+
+	// --id uses option_value_or_die in bash, which rejects --*-prefixed
+	// values so a missing value swallowed by the next flag fails fast.
+	_, _, _, _, err := parseSendArgs([]string{"--id", "--message", "hello"})
+	if err == nil {
+		t.Fatal("parseSendArgs accepted --id with --message swallowed as value")
+	}
+}
+
+func TestParseSendArgsRequiresMessageValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, _, err := parseSendArgs([]string{"--message"})
+	if err == nil {
+		t.Fatal("parseSendArgs accepted --message without a value")
+	}
+	if !strings.Contains(err.Error(), "Option --message requires a value.") {
+		t.Fatalf("parseSendArgs error = %v, want canonical require-value message", err)
+	}
+}
+
+func TestParseSendArgsRejectsEmptyMessageValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, _, err := parseSendArgs([]string{"--message", ""})
+	if err == nil {
+		t.Fatal("parseSendArgs accepted empty --message value")
+	}
+}
+
+func TestParseSendArgsAcceptsDashDashMessageValue(t *testing.T) {
+	t.Parallel()
+
+	// --message uses raw_option_value_or_die in bash, which permits
+	// values that start with `--` so operators can send a payload such
+	// as "--flag" verbatim.
+	id, msg, newline, _, err := parseSendArgs([]string{"--id", "s", "--message", "--literal-flag"})
+	if err != nil {
+		t.Fatalf("parseSendArgs error = %v", err)
+	}
+	if id != "s" {
+		t.Fatalf("parseSendArgs id = %q, want %q", id, "s")
+	}
+	if msg != "--literal-flag" {
+		t.Fatalf("parseSendArgs message = %q, want %q", msg, "--literal-flag")
+	}
+	if !newline {
+		t.Fatal("parseSendArgs default append_newline = false, want true")
+	}
+}
+
+func TestParseSendArgsRejectsUnknownFlag(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, _, err := parseSendArgs([]string{"--bogus"})
+	if err == nil {
+		t.Fatal("parseSendArgs accepted unknown flag")
+	}
+	if !strings.Contains(err.Error(), "Unsupported workcell session send option") {
+		t.Fatalf("parseSendArgs error = %v, want session-send-specific message", err)
+	}
+}
+
+func TestParseSendArgsAcceptsCanonical(t *testing.T) {
+	t.Parallel()
+
+	id, msg, newline, help, err := parseSendArgs([]string{"--id", "session-1", "--message", "hello"})
+	if err != nil {
+		t.Fatalf("parseSendArgs error = %v", err)
+	}
+	if help {
+		t.Fatal("parseSendArgs help = true, want false")
+	}
+	if !newline {
+		t.Fatal("parseSendArgs append_newline = false, want true (default)")
+	}
+	if id != "session-1" {
+		t.Fatalf("parseSendArgs id = %q, want %q", id, "session-1")
+	}
+	if msg != "hello" {
+		t.Fatalf("parseSendArgs message = %q, want %q", msg, "hello")
+	}
+}
+
+func TestParseSendArgsHandlesNoNewline(t *testing.T) {
+	t.Parallel()
+
+	id, msg, newline, _, err := parseSendArgs([]string{"--id", "s", "--message", "m", "--no-newline"})
+	if err != nil {
+		t.Fatalf("parseSendArgs error = %v", err)
+	}
+	if newline {
+		t.Fatal("parseSendArgs --no-newline did not clear append_newline")
+	}
+	if id != "s" || msg != "m" {
+		t.Fatalf("parseSendArgs id/msg = %q/%q, want s/m", id, msg)
+	}
+}
+
+func TestParseSendArgsHandlesHelp(t *testing.T) {
+	t.Parallel()
+
+	for _, flag := range []string{"-h", "--help"} {
+		_, _, _, help, err := parseSendArgs([]string{flag})
+		if err != nil {
+			t.Fatalf("parseSendArgs(%s) error = %v", flag, err)
+		}
+		if !help {
+			t.Fatalf("parseSendArgs(%s) help = false, want true", flag)
+		}
+	}
+}
+
+func TestSendMainRequiresID(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := sendMain([]string{"--message", "hello"}, &buf)
+	if err == nil {
+		t.Fatal("sendMain accepted call without --id")
+	}
+	if !strings.Contains(err.Error(), "workcell session send requires --id.") {
+		t.Fatalf("sendMain error = %v, want canonical require-id message", err)
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != 2 {
+		t.Fatalf("sendMain error = %v, want ExitCodeError{Code:2}", err)
+	}
+}
+
+func TestSendMainRequiresMessage(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := sendMain([]string{"--id", "session-1"}, &buf)
+	if err == nil {
+		t.Fatal("sendMain accepted call without --message")
+	}
+	if !strings.Contains(err.Error(), "workcell session send requires --message.") {
+		t.Fatalf("sendMain error = %v, want canonical require-message message", err)
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != 2 {
+		t.Fatalf("sendMain error = %v, want ExitCodeError{Code:2}", err)
+	}
+}
+
+func TestSendMainHelpPrintsUsage(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := sendMain([]string{"--help"}, &buf); err != nil {
+		t.Fatalf("sendMain(--help) error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "Usage: workcell session") {
+		t.Fatalf("sendMain(--help) output = %q, want usage banner", buf.String())
+	}
+}
+
+func TestSendMainEmitsPlan(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	args := []string{"--id", "session-1", "--message", "hello world"}
+	if err := sendMain(args, &buf); err != nil {
+		t.Fatalf("sendMain error = %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"session_id=session-1\n",
+		"message=hello world\n",
+		"append_newline=1\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("sendMain output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestSendMainPropagatesNoNewline(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	args := []string{"--id", "session-1", "--message", "hello", "--no-newline"}
+	if err := sendMain(args, &buf); err != nil {
+		t.Fatalf("sendMain error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "append_newline=0\n") {
+		t.Fatalf("sendMain --no-newline did not propagate; output:\n%s", buf.String())
+	}
+}
+
+func TestSendMainStripsRootArgs(t *testing.T) {
+	t.Parallel()
+
+	// --root= forwarding is unused by SendMain today but must not break
+	// argument parsing - the bash shim unconditionally prepends
+	// session_lookup_root_args output.
+	var buf bytes.Buffer
+	args := []string{"--root=/tmp/state-1", "--root=", "--id", "session-1", "--message", "beta"}
+	if err := sendMain(args, &buf); err != nil {
+		t.Fatalf("sendMain error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "session_id=session-1\n") {
+		t.Fatalf("sendMain stripped roots but lost session_id; output:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "message=beta\n") {
+		t.Fatalf("sendMain stripped roots but lost message; output:\n%s", buf.String())
+	}
+}
+
+func TestSendMainRejectsUnknownOption(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := sendMain([]string{"--bogus"}, &buf)
+	if err == nil {
+		t.Fatal("sendMain accepted unknown option")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != 2 {
+		t.Fatalf("sendMain error = %v, want ExitCodeError{Code:2}", err)
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "d787bd3f1116190fb1b50a62378a09ae42c75372bafdeed28ac18672afea8f89"
+      "sha256": "9eac4bbf6504c3554064214a0c2afb50efb2f8e02846696ef161e1fc9f61cca7"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -4008,6 +4008,8 @@ session_attach_main() {
 }
 
 session_send_main() {
+  local plan=""
+  local send_main_status=0
   local session_id=""
   local message=""
   local append_newline=1
@@ -4016,40 +4018,31 @@ session_send_main() {
   local runtime_uid=""
   local runtime_gid=""
   local send_status=0
+  local line=""
+  local key=""
+  local value=""
+  local -a lookup_roots=()
 
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --id)
-        session_id="$(option_value_or_die "$1" "${2-}")"
-        shift 2
-        ;;
-      --message)
-        message="$(raw_option_value_or_die "$1" "${2-}")"
-        shift 2
-        ;;
-      --no-newline)
-        append_newline=0
-        shift
-        ;;
-      -h | --help)
-        session_usage
-        exit 0
-        ;;
-      *)
-        echo "Unsupported workcell session send option: $1" >&2
-        session_usage >&2
-        exit 2
-        ;;
+  while IFS= read -r line; do
+    lookup_roots+=("${line}")
+  done < <(session_lookup_root_args)
+  set +e
+  plan="$(go_hostutil launcher session-send-cli "${lookup_roots[@]}" "$@")"
+  send_main_status="$?"
+  set -e
+  if [[ "${send_main_status}" -ne 0 ]]; then
+    exit "${send_main_status}"
+  fi
+  while IFS= read -r line; do
+    key="${line%%=*}"
+    value="${line#*=}"
+    case "${key}" in
+      session_id) session_id="${value}" ;;
+      message) message="${value}" ;;
+      append_newline) append_newline="${value}" ;;
     esac
-  done
-  [[ -n "${session_id}" ]] || {
-    echo "workcell session send requires --id." >&2
-    exit 2
-  }
-  [[ -n "${message}" ]] || {
-    echo "workcell session send requires --message." >&2
-    exit 2
-  }
+  done <<<"${plan}"
+  [[ -n "${session_id}" ]] || exit 0
 
   if [[ "${append_newline}" -eq 1 ]]; then
     payload="${message}"$'\n'


### PR DESCRIPTION
## Summary
- internal/sessionctl/send.go + tests translate session_send_main (96 bash LOC) into Go.
- Hybrid pattern (mirrors PR 22.3 attach): Go owns option parsing (--id / --message / --no-newline) and emits a plan; bash keeps load_session_runtime_metadata, the run_profile_docker_command exec, audit emission, and the loaded-session summary so test-session-commands.sh's bash-level mocks continue to drive the failure-path tests that do not provision an on-disk session record.
- --root= forwarding shim per the lesson from PR 22.2: bash prepends session_lookup_root_args, Go consumes via consumeRootArgs (currently unused on the send side, kept for shim symmetry and forward-compat).
- launcherSubcommands() gains session-send-cli row alongside session-attach-cli / session-logs-cli.
- scripts/workcell session_send_main becomes a thin shim that forks to the Go binary, parses key=value plan output, and continues with bash for runtime metadata, transport, audit, and summary.
- runtime/container/control-plane-manifest.json regenerated to reflect the new scripts/workcell hash.

## Test plan
- [x] go build ./...
- [x] go test ./internal/sessionctl/ ./cmd/workcell-hostutil/
- [x] gofmt -l . empty
- [x] bash -n scripts/workcell scripts/verify-invariants.sh
- [x] shellcheck --severity=info scripts/workcell (no SC2317)
- [x] ./scripts/workcell --agent codex --dry-run (exits 2 in linked worktree as expected)
- [x] bash tests/scenarios/shared/test-session-commands.sh exit 0

Generated with [Claude Code](https://claude.com/claude-code)