### PR TITLE
^R Translate profile path helpers into Go

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -180,6 +180,7 @@ func launcherSubcommands() []launcherSubcommand {
 		{"resolve-endpoints", 1, 1, cmdLauncherResolveEndpoints},
 		{"support-matrix-eval", 6, 6, cmdLauncherSupportMatrixEval},
 		{"publish-pr-usage", 0, 0, cmdLauncherPublishPRUsage},
+		{"profile-path", 1, -1, cmdLauncherProfilePath},
 	}
 }
 
@@ -443,6 +444,120 @@ func cmdLauncherSupportMatrixEval(args []string) error {
 		fmt.Println(line)
 	}
 	return nil
+}
+
+// cmdLauncherProfilePath dispatches the profile-path umbrella
+// subcommand.  Each kind exposes a thin, byte-identical replacement for
+// the matching scripts/workcell profile_* helper.
+//
+// Usage forms:
+//
+//	profile-path dir          STATE_ROOT PROFILE
+//	profile-path lima-dir     STATE_ROOT PROFILE
+//	profile-path disk-dir     STATE_ROOT PROFILE
+//	profile-path target-state-dir          TARGET_STATE_ROOT TARGET_KIND TARGET_PROVIDER PROFILE
+//	profile-path audit-log                 TARGET_STATE_ROOT TARGET_KIND TARGET_PROVIDER PROFILE
+//	profile-path legacy-audit-log          STATE_ROOT PROFILE
+//	profile-path sessions-dir              TARGET_STATE_ROOT TARGET_KIND TARGET_PROVIDER PROFILE
+//	profile-path legacy-sessions-dir       STATE_ROOT PROFILE
+//	profile-path lock-dir                  WORKCELL_STATE_ROOT TARGET_KIND TARGET_PROVIDER PROFILE
+//	profile-path latest-log-pointer        TARGET_STATE_ROOT TARGET_KIND TARGET_PROVIDER PROFILE KIND
+//	profile-path legacy-latest-log-pointer STATE_ROOT PROFILE KIND
+//	profile-path colima-config             STATE_ROOT PROFILE
+func cmdLauncherProfilePath(args []string) error {
+	kind := args[0]
+	rest := args[1:]
+	value, err := dispatchProfilePath(kind, rest)
+	if err != nil {
+		if errors.Is(err, hoststate.ErrUnsupportedLogPointerKind) {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		var keyErr *hoststate.InvalidStateKeyError
+		if errors.As(err, &keyErr) {
+			fmt.Fprintln(os.Stderr, keyErr.Error())
+			if keyErr.Hint != "" {
+				fmt.Fprintln(os.Stderr, keyErr.Hint)
+			}
+			os.Exit(2)
+		}
+		return err
+	}
+	fmt.Println(value)
+	return nil
+}
+
+func dispatchProfilePath(kind string, args []string) (string, error) {
+	expect := func(n int) error {
+		if len(args) != n {
+			return fmt.Errorf("profile-path %s expects %d args, got %d", kind, n, len(args))
+		}
+		return nil
+	}
+	switch kind {
+	case "dir":
+		if err := expect(2); err != nil {
+			return "", err
+		}
+		return hoststate.ProfileDir(args[0], args[1])
+	case "lima-dir":
+		if err := expect(2); err != nil {
+			return "", err
+		}
+		return hoststate.ProfileLimaDir(args[0], args[1])
+	case "disk-dir":
+		if err := expect(2); err != nil {
+			return "", err
+		}
+		return hoststate.ProfileDiskDir(args[0], args[1])
+	case "target-state-dir":
+		if err := expect(4); err != nil {
+			return "", err
+		}
+		return hoststate.ProfileTargetStateDir(args[0], args[1], args[2], args[3])
+	case "audit-log":
+		if err := expect(4); err != nil {
+			return "", err
+		}
+		return hoststate.ProfileAuditLogPath(args[0], args[1], args[2], args[3])
+	case "legacy-audit-log":
+		if err := expect(2); err != nil {
+			return "", err
+		}
+		return hoststate.LegacyProfileAuditLogPath(args[0], args[1])
+	case "sessions-dir":
+		if err := expect(4); err != nil {
+			return "", err
+		}
+		return hoststate.ProfileSessionsDirPath(args[0], args[1], args[2], args[3])
+	case "legacy-sessions-dir":
+		if err := expect(2); err != nil {
+			return "", err
+		}
+		return hoststate.LegacyProfileSessionsDirPath(args[0], args[1])
+	case "lock-dir":
+		if err := expect(4); err != nil {
+			return "", err
+		}
+		return hoststate.ProfileLockDirPath(args[0], args[1], args[2], args[3])
+	case "latest-log-pointer":
+		if err := expect(5); err != nil {
+			return "", err
+		}
+		return hoststate.ProfileLatestLogPointerPath(args[0], args[1], args[2], args[3], args[4])
+	case "legacy-latest-log-pointer":
+		if err := expect(3); err != nil {
+			return "", err
+		}
+		return hoststate.LegacyProfileLatestLogPointerPath(args[0], args[1], args[2])
+	case "colima-config":
+		if err := expect(2); err != nil {
+			return "", err
+		}
+		return hoststate.ProfileColimaConfigPath(args[0], args[1])
+	default:
+		return "", fmt.Errorf("unknown profile-path kind: %s", kind)
+	}
 }
 
 func usage() error {

--- a/internal/host/hoststate/profilepaths.go
+++ b/internal/host/hoststate/profilepaths.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package hoststate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+// ValidateProfileName mirrors the bash validate_state_key_name regex for
+// Colima profile names. It rejects empty inputs, path separators, and
+// the reserved "." / ".." entries with the same exit-code-2 semantics as
+// the legacy bash helper.
+func ValidateProfileName(profile string) error {
+	return ValidateStateKeyName("Colima profile name", profile)
+}
+
+// ValidateStateKeyName mirrors the bash validate_state_key_name helper:
+// 1-64 chars, [A-Za-z0-9._-], must start with [A-Za-z0-9], and may not
+// be "." or "..".
+func ValidateStateKeyName(label, value string) error {
+	if !stateKeyPattern.MatchString(value) {
+		return &InvalidStateKeyError{
+			Label: label,
+			Value: value,
+			Hint:  "Use only letters, numbers, '.', '_', or '-' and do not include path separators.",
+		}
+	}
+	if value == "." || value == ".." {
+		return &InvalidStateKeyError{Label: label, Value: value}
+	}
+	return nil
+}
+
+var stateKeyPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$`)
+
+// InvalidStateKeyError is returned when a profile or target id fails the
+// validate_state_key_name shape check. It carries the bash error label
+// so callers can render byte-identical diagnostics.
+type InvalidStateKeyError struct {
+	Label string
+	Value string
+	Hint  string
+}
+
+func (e *InvalidStateKeyError) Error() string {
+	return fmt.Sprintf("Invalid %s: %s", e.Label, e.Value)
+}
+
+// ProfileDir returns "${colimaStateRoot}/${profile}".  It mirrors the
+// bash profile_dir helper and validates the profile name.
+func ProfileDir(colimaStateRoot, profile string) (string, error) {
+	if err := ValidateProfileName(profile); err != nil {
+		return "", err
+	}
+	return filepath.Join(colimaStateRoot, profile), nil
+}
+
+// ProfileLimaDir mirrors the bash profile_lima_dir helper.
+func ProfileLimaDir(colimaStateRoot, profile string) (string, error) {
+	if err := ValidateProfileName(profile); err != nil {
+		return "", err
+	}
+	return filepath.Join(colimaStateRoot, "_lima", "colima-"+profile), nil
+}
+
+// ProfileDiskDir mirrors the bash profile_disk_dir helper.
+func ProfileDiskDir(colimaStateRoot, profile string) (string, error) {
+	if err := ValidateProfileName(profile); err != nil {
+		return "", err
+	}
+	return filepath.Join(colimaStateRoot, "_lima", "_disks", "colima-"+profile), nil
+}
+
+// ProfileTargetStateDir mirrors the bash profile_target_state_dir
+// helper.  The bash version resolves target_kind and target_provider
+// from environment-derived getters; Go exposes them as explicit args so
+// the function stays pure and unit-testable.
+func ProfileTargetStateDir(targetStateRoot, targetKind, targetProvider, profile string) (string, error) {
+	if err := ValidateProfileName(profile); err != nil {
+		return "", err
+	}
+	return filepath.Join(targetStateRoot, targetKind, targetProvider, profile), nil
+}
+
+// ProfileAuditLogPath mirrors profile_audit_log_path.
+func ProfileAuditLogPath(targetStateRoot, targetKind, targetProvider, profile string) (string, error) {
+	dir, err := ProfileTargetStateDir(targetStateRoot, targetKind, targetProvider, profile)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "workcell.audit.log"), nil
+}
+
+// LegacyProfileAuditLogPath mirrors legacy_profile_audit_log_path.
+func LegacyProfileAuditLogPath(colimaStateRoot, profile string) (string, error) {
+	dir, err := ProfileDir(colimaStateRoot, profile)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "workcell.audit.log"), nil
+}
+
+// ProfileSessionsDirPath mirrors profile_sessions_dir_path.
+func ProfileSessionsDirPath(targetStateRoot, targetKind, targetProvider, profile string) (string, error) {
+	dir, err := ProfileTargetStateDir(targetStateRoot, targetKind, targetProvider, profile)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "sessions"), nil
+}
+
+// LegacyProfileSessionsDirPath mirrors legacy_profile_sessions_dir_path.
+func LegacyProfileSessionsDirPath(colimaStateRoot, profile string) (string, error) {
+	dir, err := ProfileDir(colimaStateRoot, profile)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "sessions"), nil
+}
+
+// ProfileLockDirPath mirrors profile_lock_dir_path.
+func ProfileLockDirPath(workcellStateRoot, targetKind, targetProvider, profile string) (string, error) {
+	if err := ValidateProfileName(profile); err != nil {
+		return "", err
+	}
+	return filepath.Join(workcellStateRoot, "locks", targetKind, targetProvider, profile+".lock"), nil
+}
+
+// LatestLogPointerKinds enumerates the bash-accepted kind values for
+// profile_latest_log_pointer_path. Matching the bash case statement
+// keeps the Go helper a drop-in equivalent.
+var LatestLogPointerKinds = map[string]struct{}{
+	"debug":      {},
+	"file-trace": {},
+	"transcript": {},
+}
+
+// ErrUnsupportedLogPointerKind is returned when an invalid kind is
+// passed to ProfileLatestLogPointerPath. The bash helper exits 2 on
+// this case; callers translate the error accordingly.
+var ErrUnsupportedLogPointerKind = errors.New("unsupported latest log pointer kind")
+
+// ProfileLatestLogPointerPath mirrors profile_latest_log_pointer_path.
+func ProfileLatestLogPointerPath(targetStateRoot, targetKind, targetProvider, profile, kind string) (string, error) {
+	if _, ok := LatestLogPointerKinds[kind]; !ok {
+		return "", fmt.Errorf("%w: %s", ErrUnsupportedLogPointerKind, kind)
+	}
+	dir, err := ProfileTargetStateDir(targetStateRoot, targetKind, targetProvider, profile)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "workcell.latest-"+kind+"-log"), nil
+}
+
+// LegacyProfileLatestLogPointerPath mirrors
+// legacy_profile_latest_log_pointer_path.
+func LegacyProfileLatestLogPointerPath(colimaStateRoot, profile, kind string) (string, error) {
+	if _, ok := LatestLogPointerKinds[kind]; !ok {
+		return "", fmt.Errorf("%w: %s", ErrUnsupportedLogPointerKind, kind)
+	}
+	dir, err := ProfileDir(colimaStateRoot, profile)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "workcell.latest-"+kind+"-log"), nil
+}
+
+// ProfileColimaConfigPath returns the first existing config candidate
+// for the named profile, or the canonical first candidate if none of
+// the three legacy locations exist.  This matches the bash helper at
+// scripts/workcell:699.
+func ProfileColimaConfigPath(colimaStateRoot, profile string) (string, error) {
+	profileDir, err := ProfileDir(colimaStateRoot, profile)
+	if err != nil {
+		return "", err
+	}
+	limaDir, err := ProfileLimaDir(colimaStateRoot, profile)
+	if err != nil {
+		return "", err
+	}
+	candidates := []string{
+		filepath.Join(profileDir, "colima.yaml"),
+		filepath.Join(limaDir, "colima.yaml"),
+		filepath.Join(limaDir, "lima.yaml"),
+	}
+	for _, candidate := range candidates {
+		info, err := os.Stat(candidate)
+		if err != nil {
+			continue
+		}
+		if info.Mode().IsRegular() {
+			return candidate, nil
+		}
+	}
+	return candidates[0], nil
+}

--- a/internal/host/hoststate/profilepaths_test.go
+++ b/internal/host/hoststate/profilepaths_test.go
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package hoststate
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateProfileNameAccepts(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"wcl-target",
+		"wcl",
+		"a",
+		"A1",
+		"profile.with.dots",
+		"under_score",
+		"hy-phen",
+	}
+	for _, name := range cases {
+		if err := ValidateProfileName(name); err != nil {
+			t.Errorf("ValidateProfileName(%q) error = %v, want nil", name, err)
+		}
+	}
+}
+
+func TestValidateProfileNameRejects(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"",
+		".",
+		"..",
+		"-leading-dash",
+		"_leading-underscore",
+		".leading-dot",
+		"contains/slash",
+		"contains space",
+		"x" + string(make([]byte, 64)), // > 64 chars
+	}
+	for _, name := range cases {
+		err := ValidateProfileName(name)
+		if err == nil {
+			t.Errorf("ValidateProfileName(%q) = nil, want error", name)
+			continue
+		}
+		var keyErr *InvalidStateKeyError
+		if !errors.As(err, &keyErr) {
+			t.Errorf("ValidateProfileName(%q) = %v, want *InvalidStateKeyError", name, err)
+		}
+	}
+}
+
+func TestProfileDir(t *testing.T) {
+	t.Parallel()
+	got, err := ProfileDir("/state/colima", "wcl-target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/state/colima/wcl-target" {
+		t.Errorf("ProfileDir = %q", got)
+	}
+}
+
+func TestProfileLimaDirAndDiskDir(t *testing.T) {
+	t.Parallel()
+	lima, err := ProfileLimaDir("/state/colima", "wcl-target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lima != "/state/colima/_lima/colima-wcl-target" {
+		t.Errorf("ProfileLimaDir = %q", lima)
+	}
+	disk, err := ProfileDiskDir("/state/colima", "wcl-target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disk != "/state/colima/_lima/_disks/colima-wcl-target" {
+		t.Errorf("ProfileDiskDir = %q", disk)
+	}
+}
+
+func TestProfileTargetStateDir(t *testing.T) {
+	t.Parallel()
+	got, err := ProfileTargetStateDir("/state/targets", "local_vm", "colima", "wcl-target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "/state/targets/local_vm/colima/wcl-target"
+	if got != want {
+		t.Errorf("ProfileTargetStateDir = %q, want %q", got, want)
+	}
+}
+
+func TestProfileAuditLogPathAndLegacy(t *testing.T) {
+	t.Parallel()
+	target, err := ProfileAuditLogPath("/state/targets", "local_vm", "colima", "wcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != "/state/targets/local_vm/colima/wcl/workcell.audit.log" {
+		t.Errorf("ProfileAuditLogPath = %q", target)
+	}
+	legacy, err := LegacyProfileAuditLogPath("/state/colima", "wcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy != "/state/colima/wcl/workcell.audit.log" {
+		t.Errorf("LegacyProfileAuditLogPath = %q", legacy)
+	}
+}
+
+func TestProfileSessionsDirPathAndLegacy(t *testing.T) {
+	t.Parallel()
+	target, err := ProfileSessionsDirPath("/state/targets", "local_vm", "colima", "wcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != "/state/targets/local_vm/colima/wcl/sessions" {
+		t.Errorf("ProfileSessionsDirPath = %q", target)
+	}
+	legacy, err := LegacyProfileSessionsDirPath("/state/colima", "wcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy != "/state/colima/wcl/sessions" {
+		t.Errorf("LegacyProfileSessionsDirPath = %q", legacy)
+	}
+}
+
+func TestProfileLockDirPath(t *testing.T) {
+	t.Parallel()
+	got, err := ProfileLockDirPath("/state", "local_vm", "colima", "wcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/state/locks/local_vm/colima/wcl.lock" {
+		t.Errorf("ProfileLockDirPath = %q", got)
+	}
+}
+
+func TestProfileLatestLogPointerPath(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"debug", "file-trace", "transcript"} {
+		got, err := ProfileLatestLogPointerPath("/state/targets", "local_vm", "colima", "wcl", kind)
+		if err != nil {
+			t.Fatalf("kind %q: %v", kind, err)
+		}
+		want := "/state/targets/local_vm/colima/wcl/workcell.latest-" + kind + "-log"
+		if got != want {
+			t.Errorf("kind %q: got %q want %q", kind, got, want)
+		}
+		legacy, err := LegacyProfileLatestLogPointerPath("/state/colima", "wcl", kind)
+		if err != nil {
+			t.Fatalf("legacy kind %q: %v", kind, err)
+		}
+		wantLegacy := "/state/colima/wcl/workcell.latest-" + kind + "-log"
+		if legacy != wantLegacy {
+			t.Errorf("legacy kind %q: got %q want %q", kind, legacy, wantLegacy)
+		}
+	}
+}
+
+func TestProfileLatestLogPointerPathRejectsUnsupportedKind(t *testing.T) {
+	t.Parallel()
+	_, err := ProfileLatestLogPointerPath("/state/targets", "local_vm", "colima", "wcl", "unknown")
+	if !errors.Is(err, ErrUnsupportedLogPointerKind) {
+		t.Errorf("err = %v, want ErrUnsupportedLogPointerKind", err)
+	}
+	_, err = LegacyProfileLatestLogPointerPath("/state/colima", "wcl", "unknown")
+	if !errors.Is(err, ErrUnsupportedLogPointerKind) {
+		t.Errorf("legacy err = %v, want ErrUnsupportedLogPointerKind", err)
+	}
+}
+
+func TestProfileColimaConfigPathPicksFirstExisting(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	limaDir := filepath.Join(root, "_lima", "colima-wcl")
+	if err := os.MkdirAll(limaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	limaYaml := filepath.Join(limaDir, "lima.yaml")
+	if err := os.WriteFile(limaYaml, []byte("v: 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ProfileColimaConfigPath(root, "wcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != limaYaml {
+		t.Errorf("ProfileColimaConfigPath = %q, want %q", got, limaYaml)
+	}
+}
+
+func TestProfileColimaConfigPathPrefersProfileColimaYaml(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	profileDir := filepath.Join(root, "wcl")
+	limaDir := filepath.Join(root, "_lima", "colima-wcl")
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(limaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	first := filepath.Join(profileDir, "colima.yaml")
+	second := filepath.Join(limaDir, "colima.yaml")
+	third := filepath.Join(limaDir, "lima.yaml")
+	for _, p := range []string{first, second, third} {
+		if err := os.WriteFile(p, []byte("v: 1\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := ProfileColimaConfigPath(root, "wcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != first {
+		t.Errorf("ProfileColimaConfigPath = %q, want %q", got, first)
+	}
+}
+
+func TestProfileColimaConfigPathFallsBackToFirstCandidate(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	got, err := ProfileColimaConfigPath(root, "wcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(root, "wcl", "colima.yaml")
+	if got != want {
+		t.Errorf("ProfileColimaConfigPath = %q, want %q", got, want)
+	}
+}
+
+func TestProfilePathHelpersRejectInvalidProfile(t *testing.T) {
+	t.Parallel()
+	check := func(name string, err error) {
+		t.Helper()
+		var keyErr *InvalidStateKeyError
+		if !errors.As(err, &keyErr) {
+			t.Errorf("%s err = %v, want *InvalidStateKeyError", name, err)
+		}
+	}
+	_, err := ProfileDir("/state", "../escape")
+	check("ProfileDir", err)
+	_, err = ProfileLimaDir("/state", "../escape")
+	check("ProfileLimaDir", err)
+	_, err = ProfileDiskDir("/state", "../escape")
+	check("ProfileDiskDir", err)
+	_, err = ProfileTargetStateDir("/state", "local_vm", "colima", "../escape")
+	check("ProfileTargetStateDir", err)
+	_, err = ProfileLockDirPath("/state", "local_vm", "colima", "../escape")
+	check("ProfileLockDirPath", err)
+	_, err = ProfileColimaConfigPath("/state", "../escape")
+	check("ProfileColimaConfigPath", err)
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "96dc037d9f2744112d812771c66ad30db48263aa18ef4bcb31f00740ada8e2fd"
+      "sha256": "aa4aeb5c4ee00722da8b760effa216e5bdac50c9cfbeff69f4ef8adaa0d24899"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -592,8 +592,7 @@ docker_desktop_context_name() {
 profile_dir() {
   local profile="$1"
 
-  validate_colima_profile_name "${profile}"
-  printf '%s/%s\n' "${COLIMA_STATE_ROOT}" "${profile}"
+  go_hostutil launcher profile-path dir "${COLIMA_STATE_ROOT}" "${profile}"
 }
 
 target_kind_for_profile_state() {
@@ -640,24 +639,22 @@ profile_target_state_dir() {
   local target_kind=""
   local target_provider=""
 
-  validate_colima_profile_name "${profile}"
   target_kind="$(target_kind_for_profile_state "${profile}")"
   target_provider="$(target_provider_for_profile_state "${profile}")"
-  printf '%s/%s/%s/%s\n' "${WORKCELL_TARGET_STATE_ROOT}" "${target_kind}" "${target_provider}" "${profile}"
+  go_hostutil launcher profile-path target-state-dir \
+    "${WORKCELL_TARGET_STATE_ROOT}" "${target_kind}" "${target_provider}" "${profile}"
 }
 
 profile_lima_dir() {
   local profile="$1"
 
-  validate_colima_profile_name "${profile}"
-  printf '%s/_lima/colima-%s\n' "${COLIMA_STATE_ROOT}" "${profile}"
+  go_hostutil launcher profile-path lima-dir "${COLIMA_STATE_ROOT}" "${profile}"
 }
 
 profile_disk_dir() {
   local profile="$1"
 
-  validate_colima_profile_name "${profile}"
-  printf '%s/_lima/_disks/colima-%s\n' "${COLIMA_STATE_ROOT}" "${profile}"
+  go_hostutil launcher profile-path disk-dir "${COLIMA_STATE_ROOT}" "${profile}"
 }
 
 remove_profile_state_dirs() {
@@ -698,23 +695,8 @@ profile_state_dirs_exist() {
 
 profile_colima_config_path() {
   local profile="$1"
-  local candidate=""
-  local -a candidates=()
 
-  candidates=(
-    "$(profile_dir "${profile}")/colima.yaml"
-    "$(profile_lima_dir "${profile}")/colima.yaml"
-    "$(profile_lima_dir "${profile}")/lima.yaml"
-  )
-
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "${candidate}" ]]; then
-      printf '%s\n' "${candidate}"
-      return 0
-    fi
-  done
-
-  printf '%s\n' "${candidates[0]}"
+  go_hostutil launcher profile-path colima-config "${COLIMA_STATE_ROOT}" "${profile}"
 }
 
 run_host_colima() {
@@ -1453,30 +1435,36 @@ profile_runtime_image_cache_value() {
 
 profile_audit_log_path() {
   local profile="$1"
+  local target_kind=""
+  local target_provider=""
 
-  validate_colima_profile_name "${profile}"
-  printf '%s/workcell.audit.log\n' "$(profile_target_state_dir "${profile}")"
+  target_kind="$(target_kind_for_profile_state "${profile}")"
+  target_provider="$(target_provider_for_profile_state "${profile}")"
+  go_hostutil launcher profile-path audit-log \
+    "${WORKCELL_TARGET_STATE_ROOT}" "${target_kind}" "${target_provider}" "${profile}"
 }
 
 legacy_profile_audit_log_path() {
   local profile="$1"
 
-  validate_colima_profile_name "${profile}"
-  printf '%s/workcell.audit.log\n' "$(profile_dir "${profile}")"
+  go_hostutil launcher profile-path legacy-audit-log "${COLIMA_STATE_ROOT}" "${profile}"
 }
 
 profile_sessions_dir_path() {
   local profile="$1"
+  local target_kind=""
+  local target_provider=""
 
-  validate_colima_profile_name "${profile}"
-  printf '%s/sessions\n' "$(profile_target_state_dir "${profile}")"
+  target_kind="$(target_kind_for_profile_state "${profile}")"
+  target_provider="$(target_provider_for_profile_state "${profile}")"
+  go_hostutil launcher profile-path sessions-dir \
+    "${WORKCELL_TARGET_STATE_ROOT}" "${target_kind}" "${target_provider}" "${profile}"
 }
 
 legacy_profile_sessions_dir_path() {
   local profile="$1"
 
-  validate_colima_profile_name "${profile}"
-  printf '%s/sessions\n' "$(profile_dir "${profile}")"
+  go_hostutil launcher profile-path legacy-sessions-dir "${COLIMA_STATE_ROOT}" "${profile}"
 }
 
 generate_session_id() {
@@ -1488,40 +1476,30 @@ profile_lock_dir_path() {
   local target_kind=""
   local target_provider=""
 
-  validate_colima_profile_name "${profile}"
   target_kind="$(target_kind_for_profile_state "${profile}")"
   target_provider="$(target_provider_for_profile_state "${profile}")"
-  printf '%s/locks/%s/%s/%s.lock\n' "${WORKCELL_STATE_ROOT}" "${target_kind}" "${target_provider}" "${profile}"
+  go_hostutil launcher profile-path lock-dir \
+    "${WORKCELL_STATE_ROOT}" "${target_kind}" "${target_provider}" "${profile}"
 }
 
 profile_latest_log_pointer_path() {
   local profile="$1"
   local kind="$2"
+  local target_kind=""
+  local target_provider=""
 
-  validate_colima_profile_name "${profile}"
-  case "${kind}" in
-    debug | file-trace | transcript) ;;
-    *)
-      echo "Unsupported latest log pointer kind: ${kind}" >&2
-      exit 2
-      ;;
-  esac
-  printf '%s/workcell.latest-%s-log\n' "$(profile_target_state_dir "${profile}")" "${kind}"
+  target_kind="$(target_kind_for_profile_state "${profile}")"
+  target_provider="$(target_provider_for_profile_state "${profile}")"
+  go_hostutil launcher profile-path latest-log-pointer \
+    "${WORKCELL_TARGET_STATE_ROOT}" "${target_kind}" "${target_provider}" "${profile}" "${kind}"
 }
 
 legacy_profile_latest_log_pointer_path() {
   local profile="$1"
   local kind="$2"
 
-  validate_colima_profile_name "${profile}"
-  case "${kind}" in
-    debug | file-trace | transcript) ;;
-    *)
-      echo "Unsupported latest log pointer kind: ${kind}" >&2
-      exit 2
-      ;;
-  esac
-  printf '%s/workcell.latest-%s-log\n' "$(profile_dir "${profile}")" "${kind}"
+  go_hostutil launcher profile-path legacy-latest-log-pointer \
+    "${COLIMA_STATE_ROOT}" "${profile}" "${kind}"
 }
 
 write_latest_log_pointer() {


### PR DESCRIPTION
## Summary
- profile_sessions_dir_path, profile_colima_config_path, profile_target_state_dir, and their sibling state-path helpers (profile_dir, profile_lima_dir, profile_disk_dir, profile_audit_log_path, profile_lock_dir_path, profile_latest_log_pointer_path, plus the legacy_* variants) move to Go as pure path-computation functions in internal/host/hoststate.
- launcherSubcommands() gains a profile-path umbrella row that dispatches to each kind.
- scripts/workcell helpers become thin shims that route through workcell-hostutil; the bash side still resolves target_kind / target_provider so SESSION_META overrides keep working.
- internal/host/hoststate now owns ValidateProfileName (matching the bash validate_state_key_name regex) and the latest-log-pointer kind allowlist.
- control-plane-manifest.json regenerated for the new scripts/workcell hash.

## Test plan
- [x] go test ./internal/host/hoststate/ ./internal/host/launcher/ ./cmd/workcell-hostutil/
- [x] go test ./... (full suite green)
- [x] gofmt -l . empty
- [x] bash -n scripts/workcell scripts/verify-invariants.sh
- [x] shellcheck --severity=info scripts/workcell clean (no SC2317)
- [x] bash tests/scenarios/shared/test-session-commands.sh exit 0
- [x] bash scripts/check-pr-shape.sh (files=5 lines=663 areas=4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)