### PR TITLE
^R Translate prepare_injection_bundle/direct_mounts into internal/injection

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/omkhar/workcell/internal/host/release"
 	"github.com/omkhar/workcell/internal/host/sessions"
 	"github.com/omkhar/workcell/internal/host/supportmatrix"
+	"github.com/omkhar/workcell/internal/injection"
 	"github.com/omkhar/workcell/internal/publishpr"
 	"github.com/omkhar/workcell/internal/sessionctl"
 )
@@ -184,6 +185,9 @@ func launcherSubcommands() []launcherSubcommand {
 		{"support-matrix-eval", 6, 6, cmdLauncherSupportMatrixEval},
 		{"publish-pr-usage", 0, 0, cmdLauncherPublishPRUsage},
 		{"profile-path", 1, -1, cmdLauncherProfilePath},
+		// PR 23.4 — injection bundle preparation moved into Go.
+		{"injection-stage-direct-mounts", 2, 2, cmdLauncherInjectionStageDirectMounts},
+		{"injection-prepare-bundle", 0, -1, cmdLauncherInjectionPrepareBundle},
 	}
 }
 
@@ -645,6 +649,85 @@ func dispatchProfilePath(kind string, args []string) (string, error) {
 	default:
 		return "", fmt.Errorf("unknown profile-path kind: %s", kind)
 	}
+}
+
+// cmdLauncherInjectionStageDirectMounts is the launcher subcommand entry
+// point for the PR 23.4 Go translation of prepare_injection_direct_mounts.
+// It accepts BUNDLE_ROOT and MOUNT_SPEC_PATH and prints one "-v" argument
+// pair per output line so bash can split it back into the DIRECT_SOURCE_MOUNTS
+// array.
+func cmdLauncherInjectionStageDirectMounts(args []string) error {
+	dockerArgs, err := injection.StageDirectMounts(args[0], args[1])
+	if err != nil {
+		return err
+	}
+	for _, arg := range dockerArgs {
+		fmt.Println(arg)
+	}
+	return nil
+}
+
+// cmdLauncherInjectionPrepareBundle is the launcher subcommand entry point
+// for the PR 23.4 Go translation of prepare_injection_bundle.  It reads the
+// bash globals from CLI flags, executes the full pipeline in-process, and
+// prints KEY=VALUE lines (one per bash global) so the shim can re-export
+// them via a read loop.
+func cmdLauncherInjectionPrepareBundle(args []string) error {
+	opts, err := parsePrepareBundleArgs(args)
+	if err != nil {
+		return err
+	}
+	result, err := injection.PrepareBundle(*opts)
+	if err != nil {
+		return err
+	}
+	fmt.Print(injection.FormatBundleResultForShell(result))
+	return nil
+}
+
+func parsePrepareBundleArgs(args []string) (*injection.PrepareBundleOptions, error) {
+	opts := &injection.PrepareBundleOptions{ProcessPID: os.Getpid()}
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return nil, fmt.Errorf("expected KEY=VALUE, got %q", arg)
+		}
+		switch key {
+		case "--agent":
+			opts.Agent = value
+		case "--mode":
+			opts.Mode = value
+		case "--policy":
+			opts.PolicyPath = value
+		case "--use-default-policy":
+			opts.UseDefaultPolicy = value == "1" || value == "true"
+		case "--auth-status":
+			opts.AuthStatus = value == "1" || value == "true"
+		case "--doctor":
+			opts.Doctor = value == "1" || value == "true"
+		case "--inspect":
+			opts.Inspect = value == "1" || value == "true"
+		case "--dry-run":
+			opts.DryRun = value == "1" || value == "true"
+		case "--synthetic-codex-auth":
+			opts.SelfStagingProbeSyntheticCodexAuth = value == "1" || value == "true"
+		case "--synthetic-claude-export":
+			opts.SelfStagingProbeSyntheticClaudeExport = value == "1" || value == "true"
+		case "--real-home":
+			opts.RealHome = value
+		case "--bundle-parent":
+			opts.BundleParentOverride = value
+		case "--pid":
+			pid, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid --pid: %v", err)
+			}
+			opts.ProcessPID = pid
+		default:
+			return nil, fmt.Errorf("unknown flag: %s", key)
+		}
+	}
+	return opts, nil
 }
 
 func usage() error {

--- a/internal/injection/prepare_bundle.go
+++ b/internal/injection/prepare_bundle.go
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injection
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/omkhar/workcell/internal/authresolve"
+	"github.com/omkhar/workcell/internal/host/hoststate"
+	"github.com/omkhar/workcell/internal/host/launcher"
+)
+
+// PrepareBundleOptions captures every bash global that the legacy
+// prepare_injection_bundle helper consumed.  The bash caller supplies these
+// via command-line flags on the launcher subcommand.
+type PrepareBundleOptions struct {
+	Agent                                 string
+	Mode                                  string
+	PolicyPath                            string
+	UseDefaultPolicy                      bool
+	AuthStatus                            bool
+	Doctor                                bool
+	Inspect                               bool
+	DryRun                                bool
+	SelfStagingProbeSyntheticCodexAuth    bool
+	SelfStagingProbeSyntheticClaudeExport bool
+	RealHome                              string
+	ProcessPID                            int
+	BundleParentOverride                  string // optional; bash currently always supplies the default
+}
+
+// PrepareBundleResult is the byte-for-byte translation of the env-var state
+// that the legacy bash helper produced.  Each field maps to one
+// INJECTION_* / DIRECT_* shell variable so the bash shim can re-export the
+// values verbatim.
+type PrepareBundleResult struct {
+	InjectionBundleRoot                 string
+	DirectMountSpecPath                 string
+	DirectSourceMounts                  []string
+	InjectionPolicySHA256               string
+	InjectionCredentialKeys             string
+	InjectionCredentialInputKinds       string
+	InjectionCredentialResolvers        string
+	InjectionCredentialMaterialization  string
+	InjectionCredentialResolutionStates string
+	InjectionProviderAuthReadyStates    string
+	InjectionSharedAuthReadyStates      string
+	InjectionExtraEndpoints             string
+	InjectionSSHEnabled                 string
+	InjectionSSHConfigAssurance         string
+	InjectionSecretCopyTargets          string
+}
+
+// DefaultInjectionPolicyPath returns the path the bash helper would have
+// produced for the implicit per-user policy.
+func DefaultInjectionPolicyPath(realHome string) string {
+	return filepath.Join(realHome, ".config", "workcell", "injection-policy.toml")
+}
+
+// DefaultInjectionBundleParent returns the canonical parent directory the
+// bash helper used as the host-inputs cache root.  The caller is expected
+// to pass a real home path that has already been canonicalized.
+func DefaultInjectionBundleParent(realHome string) string {
+	return filepath.Join(realHome, "Library", "Caches", "colima", "workcell-host-inputs")
+}
+
+// PrepareBundle implements the legacy prepare_injection_bundle helper.
+//
+// The function returns a fully-populated PrepareBundleResult.  When no policy
+// is configured (legacy: INJECTION_POLICY empty and USE_DEFAULT_INJECTION_POLICY=0,
+// or the default policy file does not exist), the result has empty string
+// fields and an SSH-enabled marker of "0", mirroring the bash early-return
+// branch.
+func PrepareBundle(opts PrepareBundleOptions) (*PrepareBundleResult, error) {
+	if opts.Agent == "" || opts.Mode == "" {
+		return nil, errors.New("agent and mode are required")
+	}
+	if opts.RealHome == "" {
+		return nil, errors.New("real home is required")
+	}
+
+	policyPath := opts.PolicyPath
+	if policyPath == "" && opts.UseDefaultPolicy {
+		candidate := DefaultInjectionPolicyPath(opts.RealHome)
+		if info, err := os.Stat(candidate); err == nil && info.Mode().IsRegular() {
+			policyPath = candidate
+		}
+	}
+
+	bundleParent := opts.BundleParentOverride
+	if bundleParent == "" {
+		bundleParent = DefaultInjectionBundleParent(opts.RealHome)
+	}
+	if err := os.MkdirAll(bundleParent, 0o755); err != nil {
+		return nil, err
+	}
+	_ = os.Chmod(bundleParent, 0o700) // best effort; bash had "|| true"
+	if err := hoststate.CleanupStaleInjectionBundles(bundleParent); err != nil {
+		return nil, err
+	}
+
+	// Empty-policy branch: the bash helper cleared every INJECTION_* env var
+	// and the SSH flag, then returned.
+	if policyPath == "" {
+		return &PrepareBundleResult{InjectionSSHEnabled: "0", InjectionSSHConfigAssurance: "off"}, nil
+	}
+
+	canonicalPolicy, err := launcher.CanonicalizePath(policyPath)
+	if err != nil {
+		return nil, err
+	}
+	if info, err := os.Stat(canonicalPolicy); err != nil || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("Injection policy file does not exist: %s", canonicalPolicy)
+	}
+
+	bundleRoot, err := os.MkdirTemp(bundleParent, "workcell-injections.*")
+	if err != nil {
+		return nil, err
+	}
+	bundleRoot, err = launcher.CanonicalizePath(bundleRoot)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(bundleRoot, 0o700); err != nil {
+		return nil, err
+	}
+	if err := launcher.WriteProfileOwner(filepath.Join(bundleRoot, "owner.json"), opts.ProcessPID); err != nil {
+		return nil, err
+	}
+
+	resolutionMode := "launch"
+	if opts.AuthStatus || opts.Doctor || opts.Inspect || opts.DryRun {
+		resolutionMode = "metadata"
+	}
+	resolvedPolicyPath := filepath.Join(bundleRoot, "resolved-policy.toml")
+	resolverMetadataPath := filepath.Join(bundleRoot, "resolver-metadata.json")
+
+	// Stage synthetic probe inputs (test-only) before invoking the resolver,
+	// matching the env-var contract the bash helper installed for the child
+	// process.  The vars are restored unconditionally so concurrent callers
+	// in the same Go process do not leak state.
+	restoreEnv, err := installSyntheticProbeEnv(bundleRoot,
+		opts.SelfStagingProbeSyntheticCodexAuth,
+		opts.SelfStagingProbeSyntheticClaudeExport,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer restoreEnv()
+
+	resolverArgs := []string{
+		"--policy", canonicalPolicy,
+		"--agent", opts.Agent,
+		"--mode", opts.Mode,
+		"--resolution-mode", resolutionMode,
+		"--output-policy", resolvedPolicyPath,
+		"--output-metadata", resolverMetadataPath,
+		"--output-root", bundleRoot,
+	}
+	if rc := authresolve.Run(resolverArgs, devNull{}, os.Stderr); rc != 0 {
+		return nil, fmt.Errorf("resolve_credential_sources exited %d", rc)
+	}
+
+	if err := RunRenderInjectionBundle(resolvedPolicyPath, opts.Agent, opts.Mode, bundleRoot, resolverMetadataPath); err != nil {
+		return nil, err
+	}
+	manifestPath := filepath.Join(bundleRoot, "manifest.json")
+	if info, err := os.Stat(manifestPath); err != nil || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("Injection manifest was not rendered: %s", manifestPath)
+	}
+
+	mountSpecPath, err := launcher.CanonicalizePath(bundleRoot + ".mounts.json")
+	if err != nil {
+		return nil, err
+	}
+	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err != nil {
+		return nil, err
+	}
+
+	dockerArgs, err := StageDirectMounts(bundleRoot, mountSpecPath)
+	if err != nil {
+		return nil, err
+	}
+
+	manifestLines, err := hoststate.ManifestMetadataLines(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	resolverLines, err := hoststate.ResolverMetadataLines(resolverMetadataPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(manifestLines) < 6 || len(resolverLines) < 6 {
+		return nil, errors.New("manifest or resolver metadata returned fewer than six lines")
+	}
+
+	return &PrepareBundleResult{
+		InjectionBundleRoot:                 bundleRoot,
+		DirectMountSpecPath:                 mountSpecPath,
+		DirectSourceMounts:                  dockerArgs,
+		InjectionPolicySHA256:               manifestLines[0],
+		InjectionCredentialKeys:             manifestLines[1],
+		InjectionExtraEndpoints:             manifestLines[2],
+		InjectionSSHEnabled:                 manifestLines[3],
+		InjectionSSHConfigAssurance:         manifestLines[4],
+		InjectionSecretCopyTargets:          manifestLines[5],
+		InjectionCredentialInputKinds:       resolverLines[0],
+		InjectionCredentialResolvers:        resolverLines[1],
+		InjectionCredentialMaterialization:  resolverLines[2],
+		InjectionCredentialResolutionStates: resolverLines[3],
+		InjectionProviderAuthReadyStates:    resolverLines[4],
+		InjectionSharedAuthReadyStates:      resolverLines[5],
+	}, nil
+}
+
+// installSyntheticProbeEnv mirrors the bash branches that stage synthetic
+// credential exports for the self-staging probes.  It returns a restore
+// callback the caller MUST defer; otherwise the calling Go process inherits
+// the test-only env vars.
+func installSyntheticProbeEnv(bundleRoot string, syntheticCodex, syntheticClaude bool) (func(), error) {
+	restore := func() {}
+	originalHome, hadHome := os.LookupEnv("HOME")
+	originalExport, hadExport := os.LookupEnv("WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE")
+
+	cleanup := func() {
+		if hadHome {
+			_ = os.Setenv("HOME", originalHome)
+		}
+		if hadExport {
+			_ = os.Setenv("WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE", originalExport)
+		} else {
+			_ = os.Unsetenv("WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE")
+		}
+	}
+
+	if syntheticCodex {
+		syntheticCodexHome := filepath.Join(bundleRoot, "self-staging-probe-codex-home")
+		syntheticCodexAuth := filepath.Join(syntheticCodexHome, ".codex", "auth.json")
+		if err := os.MkdirAll(filepath.Dir(syntheticCodexAuth), 0o700); err != nil {
+			return restore, err
+		}
+		if err := writeFile0600(syntheticCodexAuth, []byte("{\"token\":\"codex\"}\n")); err != nil {
+			return restore, err
+		}
+		if err := os.Setenv("HOME", syntheticCodexHome); err != nil {
+			return restore, err
+		}
+	}
+	if syntheticClaude {
+		syntheticClaudeExport := filepath.Join(bundleRoot, "self-staging-probe-claude-export.json")
+		if err := writeFile0600(syntheticClaudeExport, []byte("{\"token\":\"claude\"}\n")); err != nil {
+			return restore, err
+		}
+		if err := os.Setenv("WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE", syntheticClaudeExport); err != nil {
+			return restore, err
+		}
+	}
+	return cleanup, nil
+}
+
+// writeFile0600 writes data to path with mode 0o600 (matching the bash
+// "umask 077" + printf > path sequence for synthetic probes).
+func writeFile0600(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// devNull discards writes; we use it where bash redirected ">/dev/null".
+type devNull struct{}
+
+func (devNull) Write(p []byte) (int, error) { return len(p), nil }
+
+// FormatBundleResultForShell emits the result as one KEY=VALUE line per
+// variable, in a format that bash can re-import via "while read".  Array
+// values use a NUL byte separator within the value and are tagged with a
+// leading "\0" so the shim can split on \0 rather than parsing quoting.
+func FormatBundleResultForShell(result *PrepareBundleResult) string {
+	if result == nil {
+		return ""
+	}
+	var out string
+	out += "INJECTION_BUNDLE_ROOT=" + result.InjectionBundleRoot + "\n"
+	out += "DIRECT_MOUNT_SPEC_PATH=" + result.DirectMountSpecPath + "\n"
+	out += "DIRECT_SOURCE_MOUNTS_COUNT=" + strconv.Itoa(len(result.DirectSourceMounts)) + "\n"
+	for i, arg := range result.DirectSourceMounts {
+		out += "DIRECT_SOURCE_MOUNTS_" + strconv.Itoa(i) + "=" + arg + "\n"
+	}
+	out += "INJECTION_POLICY_SHA256=" + result.InjectionPolicySHA256 + "\n"
+	out += "INJECTION_CREDENTIAL_KEYS=" + result.InjectionCredentialKeys + "\n"
+	out += "INJECTION_CREDENTIAL_INPUT_KINDS=" + result.InjectionCredentialInputKinds + "\n"
+	out += "INJECTION_CREDENTIAL_RESOLVERS=" + result.InjectionCredentialResolvers + "\n"
+	out += "INJECTION_CREDENTIAL_MATERIALIZATION=" + result.InjectionCredentialMaterialization + "\n"
+	out += "INJECTION_CREDENTIAL_RESOLUTION_STATES=" + result.InjectionCredentialResolutionStates + "\n"
+	out += "INJECTION_PROVIDER_AUTH_READY_STATES=" + result.InjectionProviderAuthReadyStates + "\n"
+	out += "INJECTION_SHARED_AUTH_READY_STATES=" + result.InjectionSharedAuthReadyStates + "\n"
+	out += "INJECTION_EXTRA_ENDPOINTS=" + result.InjectionExtraEndpoints + "\n"
+	out += "INJECTION_SSH_ENABLED=" + result.InjectionSSHEnabled + "\n"
+	out += "INJECTION_SSH_CONFIG_ASSURANCE=" + result.InjectionSSHConfigAssurance + "\n"
+	out += "INJECTION_SECRET_COPY_TARGETS=" + result.InjectionSecretCopyTargets + "\n"
+	return out
+}

--- a/internal/injection/prepare_bundle_test.go
+++ b/internal/injection/prepare_bundle_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injection
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrepareBundleNoPolicyClearsState(t *testing.T) {
+	realHome := t.TempDir()
+	result, err := PrepareBundle(PrepareBundleOptions{
+		Agent:                "codex",
+		Mode:                 "strict",
+		RealHome:             realHome,
+		BundleParentOverride: filepath.Join(realHome, "host-inputs"),
+		ProcessPID:           os.Getpid(),
+	})
+	if err != nil {
+		t.Fatalf("PrepareBundle returned error: %v", err)
+	}
+	if result.InjectionBundleRoot != "" {
+		t.Fatalf("expected empty bundle root, got %q", result.InjectionBundleRoot)
+	}
+	if result.InjectionSSHEnabled != "0" {
+		t.Fatalf("expected SSH disabled marker, got %q", result.InjectionSSHEnabled)
+	}
+	if result.InjectionSSHConfigAssurance != "off" {
+		t.Fatalf("expected SSH assurance 'off', got %q", result.InjectionSSHConfigAssurance)
+	}
+}
+
+func TestPrepareBundleRejectsMissingPolicy(t *testing.T) {
+	realHome := t.TempDir()
+	_, err := PrepareBundle(PrepareBundleOptions{
+		Agent:                "codex",
+		Mode:                 "strict",
+		PolicyPath:           filepath.Join(realHome, "missing-policy.toml"),
+		RealHome:             realHome,
+		BundleParentOverride: filepath.Join(realHome, "host-inputs"),
+		ProcessPID:           os.Getpid(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "Injection policy file does not exist") {
+		t.Fatalf("expected policy-missing error, got %v", err)
+	}
+}
+
+func TestPrepareBundleRequiresAgentAndMode(t *testing.T) {
+	if _, err := PrepareBundle(PrepareBundleOptions{Agent: "", Mode: "strict", RealHome: "/tmp"}); err == nil {
+		t.Fatalf("expected error for empty agent")
+	}
+	if _, err := PrepareBundle(PrepareBundleOptions{Agent: "codex", Mode: "", RealHome: "/tmp"}); err == nil {
+		t.Fatalf("expected error for empty mode")
+	}
+}
+
+func TestPrepareBundleRequiresRealHome(t *testing.T) {
+	if _, err := PrepareBundle(PrepareBundleOptions{Agent: "codex", Mode: "strict"}); err == nil {
+		t.Fatalf("expected error for empty real home")
+	}
+}
+
+func TestDefaultInjectionPolicyPath(t *testing.T) {
+	got := DefaultInjectionPolicyPath("/home/u")
+	want := "/home/u/.config/workcell/injection-policy.toml"
+	if got != want {
+		t.Fatalf("DefaultInjectionPolicyPath = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultInjectionBundleParent(t *testing.T) {
+	got := DefaultInjectionBundleParent("/home/u")
+	want := "/home/u/Library/Caches/colima/workcell-host-inputs"
+	if got != want {
+		t.Fatalf("DefaultInjectionBundleParent = %q, want %q", got, want)
+	}
+}
+
+func TestFormatBundleResultForShellEmitsExpectedKeys(t *testing.T) {
+	result := &PrepareBundleResult{
+		InjectionBundleRoot:                 "/tmp/bundle",
+		DirectMountSpecPath:                 "/tmp/bundle.mounts.json",
+		DirectSourceMounts:                  []string{"-v", "/a:/b:ro", "-v", "/c:/d:ro"},
+		InjectionPolicySHA256:               "abc123",
+		InjectionCredentialKeys:             "claude_oauth,codex_auth",
+		InjectionCredentialInputKinds:       "claude_oauth:keychain",
+		InjectionCredentialResolvers:        "claude_oauth:keychain_export",
+		InjectionCredentialMaterialization:  "claude_oauth:direct_mount",
+		InjectionCredentialResolutionStates: "claude_oauth:ready",
+		InjectionProviderAuthReadyStates:    "anthropic:ready",
+		InjectionSharedAuthReadyStates:      "session-jwt:ready",
+		InjectionExtraEndpoints:             "api.example.com:443",
+		InjectionSSHEnabled:                 "1",
+		InjectionSSHConfigAssurance:         "on",
+		InjectionSecretCopyTargets:          "claude_oauth",
+	}
+	output := FormatBundleResultForShell(result)
+	for _, expected := range []string{
+		"INJECTION_BUNDLE_ROOT=/tmp/bundle",
+		"DIRECT_MOUNT_SPEC_PATH=/tmp/bundle.mounts.json",
+		"DIRECT_SOURCE_MOUNTS_COUNT=4",
+		"DIRECT_SOURCE_MOUNTS_0=-v",
+		"DIRECT_SOURCE_MOUNTS_1=/a:/b:ro",
+		"DIRECT_SOURCE_MOUNTS_2=-v",
+		"DIRECT_SOURCE_MOUNTS_3=/c:/d:ro",
+		"INJECTION_POLICY_SHA256=abc123",
+		"INJECTION_CREDENTIAL_KEYS=claude_oauth,codex_auth",
+		"INJECTION_SSH_ENABLED=1",
+		"INJECTION_SSH_CONFIG_ASSURANCE=on",
+		"INJECTION_SECRET_COPY_TARGETS=claude_oauth",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected output to contain %q; output:\n%s", expected, output)
+		}
+	}
+}
+
+func TestFormatBundleResultForShellNilSafe(t *testing.T) {
+	if got := FormatBundleResultForShell(nil); got != "" {
+		t.Fatalf("expected empty string for nil result, got %q", got)
+	}
+}

--- a/internal/injection/prepare_direct_mounts.go
+++ b/internal/injection/prepare_direct_mounts.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injection
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/host/hoststate"
+	"github.com/omkhar/workcell/internal/runtimeutil"
+)
+
+// hostInputMountPrefix is the only mount root that may be staged for the
+// container via direct mounts.  Matches the bash guard "/opt/workcell/host-inputs/*".
+const hostInputMountPrefix = "/opt/workcell/host-inputs/"
+
+// StageDirectMounts replicates the legacy prepare_injection_direct_mounts helper
+// in Go.  It reads the mount spec produced by extract_direct_mounts, validates
+// each entry, stages the host source into ${bundleRoot}/direct-mounts/${hash},
+// and returns the docker "-v src:dst:ro" arguments interleaved (as bash did).
+//
+// The function returns an empty slice when the mount-spec file is missing
+// (bash returned 0 in that case).  It returns a usage-style error when the
+// bundle root is empty.
+func StageDirectMounts(bundleRoot, mountSpecPath string) ([]string, error) {
+	if _, err := os.Stat(mountSpecPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if bundleRoot == "" {
+		return nil, errors.New("Direct input staging requires an injection bundle root.")
+	}
+
+	stagedRoot := filepath.Join(bundleRoot, "direct-mounts")
+	if err := os.MkdirAll(stagedRoot, 0o755); err != nil {
+		return nil, err
+	}
+
+	mounts, err := runtimeutil.ListDirectMounts(mountSpecPath)
+	if err != nil {
+		return nil, err
+	}
+
+	args := make([]string, 0, len(mounts)*2)
+	for _, mount := range mounts {
+		if mount.Source == "" {
+			continue
+		}
+		if err := validateDirectMount(mount.Source, mount.MountPath); err != nil {
+			return nil, err
+		}
+		entryHash := hoststate.DirectMountCacheKey(mount.Source, mount.MountPath)
+		stagedSource := filepath.Join(stagedRoot, entryHash)
+		if err := os.RemoveAll(stagedSource); err != nil {
+			return nil, err
+		}
+		if err := stageDirectMountEntry(mount.Source, stagedSource); err != nil {
+			return nil, err
+		}
+		// bash: chmod -R go-rwx — best effort; ignore errors as bash did.
+		_ = chmodRecursiveGoNoAccess(stagedSource)
+		args = append(args, "-v", fmt.Sprintf("%s:%s:ro", stagedSource, mount.MountPath))
+	}
+	return args, nil
+}
+
+// validateDirectMount mirrors the bash entry validation: source must be an
+// absolute path that points at a regular file or directory, and the mount
+// path must be inside /opt/workcell/host-inputs/.
+func validateDirectMount(hostSource, mountPath string) error {
+	if !filepath.IsAbs(hostSource) {
+		return fmt.Errorf("Direct input source is missing, not absolute, or not a regular file/directory: %s", hostSource)
+	}
+	info, err := os.Stat(hostSource)
+	if err != nil || !(info.Mode().IsRegular() || info.IsDir()) {
+		return fmt.Errorf("Direct input source is missing, not absolute, or not a regular file/directory: %s", hostSource)
+	}
+	if !strings.HasPrefix(mountPath, hostInputMountPrefix) {
+		return fmt.Errorf("Direct input mount path is outside the managed host-input root: %s", mountPath)
+	}
+	return nil
+}
+
+// stageDirectMountEntry copies a host source into stagedSource, replicating
+// "cp -R ${src}/." for directories and "cp -f ${src}" for files.
+func stageDirectMountEntry(hostSource, stagedSource string) error {
+	info, err := os.Stat(hostSource)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		if err := os.MkdirAll(stagedSource, 0o755); err != nil {
+			return err
+		}
+		return copyDirContents(hostSource, stagedSource)
+	}
+	if err := os.MkdirAll(filepath.Dir(stagedSource), 0o755); err != nil {
+		return err
+	}
+	return copyFileWithMode(hostSource, stagedSource, info.Mode().Perm())
+}
+
+// copyDirContents mirrors "cp -R src/. dst": recurses into src and writes
+// every entry under dst, preserving the relative directory structure and
+// per-file modes.  Symlinks are dereferenced (matching bash cp -R semantics
+// when the source has no special suppression flag).
+func copyDirContents(src, dst string) error {
+	return filepath.WalkDir(src, func(current string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, current)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		target := filepath.Join(dst, rel)
+		info, err := os.Stat(current) // follows symlinks, matching cp -R default
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode().Perm())
+		}
+		if info.Mode().IsRegular() {
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			return copyFileWithMode(current, target, info.Mode().Perm())
+		}
+		// Non-regular files (devices, sockets, FIFOs) are skipped — bash
+		// cp would refuse most of these too, and they have no defensible
+		// meaning inside a container input mount.
+		return nil
+	})
+}
+
+func copyFileWithMode(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	return os.Chmod(dst, mode)
+}
+
+// chmodRecursiveGoNoAccess strips group/other rwx bits from every entry under
+// root, mirroring "chmod -R go-rwx".  Errors are returned to the caller; the
+// bash original masked them with "|| true", which the caller can mimic.
+func chmodRecursiveGoNoAccess(root string) error {
+	return filepath.WalkDir(root, func(current string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, statErr := os.Stat(current)
+		if statErr != nil {
+			return statErr
+		}
+		return os.Chmod(current, info.Mode().Perm()&^0o077)
+	})
+}

--- a/internal/injection/prepare_direct_mounts_test.go
+++ b/internal/injection/prepare_direct_mounts_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injection
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/host/hoststate"
+)
+
+func writeMountSpec(t *testing.T, path string, entries []map[string]any) {
+	t.Helper()
+	data, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestStageDirectMountsMissingSpecReturnsEmpty(t *testing.T) {
+	bundleRoot := t.TempDir()
+	args, err := StageDirectMounts(bundleRoot, filepath.Join(bundleRoot, "does-not-exist"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 0 {
+		t.Fatalf("expected no args, got %v", args)
+	}
+}
+
+func TestStageDirectMountsEmptyBundleRootRejected(t *testing.T) {
+	specPath := filepath.Join(t.TempDir(), "spec.json")
+	writeMountSpec(t, specPath, []map[string]any{})
+	_, err := StageDirectMounts("", specPath)
+	if err == nil {
+		t.Fatalf("expected error for empty bundle root")
+	}
+	if !strings.Contains(err.Error(), "injection bundle root") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStageDirectMountsRejectsNonAbsoluteSource(t *testing.T) {
+	bundleRoot := t.TempDir()
+	specPath := filepath.Join(bundleRoot, "spec.json")
+	writeMountSpec(t, specPath, []map[string]any{
+		{"source": "relative.txt", "mount_path": "/opt/workcell/host-inputs/foo"},
+	})
+	_, err := StageDirectMounts(bundleRoot, specPath)
+	if err == nil || !strings.Contains(err.Error(), "not absolute") {
+		t.Fatalf("expected 'not absolute' error, got %v", err)
+	}
+}
+
+func TestStageDirectMountsRejectsMissingSource(t *testing.T) {
+	bundleRoot := t.TempDir()
+	specPath := filepath.Join(bundleRoot, "spec.json")
+	writeMountSpec(t, specPath, []map[string]any{
+		{"source": "/nonexistent/path/does/not/exist", "mount_path": "/opt/workcell/host-inputs/foo"},
+	})
+	_, err := StageDirectMounts(bundleRoot, specPath)
+	if err == nil {
+		t.Fatalf("expected error for missing source")
+	}
+}
+
+func TestStageDirectMountsRejectsMountPathOutsideHostInputs(t *testing.T) {
+	bundleRoot := t.TempDir()
+	sourceFile := filepath.Join(bundleRoot, "source.txt")
+	if err := os.WriteFile(sourceFile, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	specPath := filepath.Join(bundleRoot, "spec.json")
+	writeMountSpec(t, specPath, []map[string]any{
+		{"source": sourceFile, "mount_path": "/etc/passwd"},
+	})
+	_, err := StageDirectMounts(bundleRoot, specPath)
+	if err == nil || !strings.Contains(err.Error(), "outside the managed host-input root") {
+		t.Fatalf("expected outside-host-input error, got %v", err)
+	}
+}
+
+func TestStageDirectMountsStagesFileAndReturnsDockerArgs(t *testing.T) {
+	bundleRoot := t.TempDir()
+	sourceFile := filepath.Join(bundleRoot, "src", "secret.json")
+	if err := os.MkdirAll(filepath.Dir(sourceFile), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(sourceFile, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	mountPath := "/opt/workcell/host-inputs/credentials/secret.json"
+	specPath := filepath.Join(bundleRoot, "spec.json")
+	writeMountSpec(t, specPath, []map[string]any{
+		{"source": sourceFile, "mount_path": mountPath},
+	})
+
+	args, err := StageDirectMounts(bundleRoot, specPath)
+	if err != nil {
+		t.Fatalf("StageDirectMounts: %v", err)
+	}
+	if len(args) != 2 {
+		t.Fatalf("expected 2 args, got %v", args)
+	}
+	if args[0] != "-v" {
+		t.Fatalf("expected '-v' first, got %q", args[0])
+	}
+	hash := hoststate.DirectMountCacheKey(sourceFile, mountPath)
+	expectedStaged := filepath.Join(bundleRoot, "direct-mounts", hash)
+	expectedArg := expectedStaged + ":" + mountPath + ":ro"
+	if args[1] != expectedArg {
+		t.Fatalf("expected %q, got %q", expectedArg, args[1])
+	}
+	if _, err := os.Stat(expectedStaged); err != nil {
+		t.Fatalf("expected staged file to exist: %v", err)
+	}
+}
+
+func TestStageDirectMountsStagesDirectoryRecursively(t *testing.T) {
+	bundleRoot := t.TempDir()
+	sourceDir := filepath.Join(bundleRoot, "src-dir")
+	nested := filepath.Join(sourceDir, "nested", "file.txt")
+	if err := os.MkdirAll(filepath.Dir(nested), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(nested, []byte("payload"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	mountPath := "/opt/workcell/host-inputs/configs"
+	specPath := filepath.Join(bundleRoot, "spec.json")
+	writeMountSpec(t, specPath, []map[string]any{
+		{"source": sourceDir, "mount_path": mountPath},
+	})
+
+	args, err := StageDirectMounts(bundleRoot, specPath)
+	if err != nil {
+		t.Fatalf("StageDirectMounts: %v", err)
+	}
+	if len(args) != 2 {
+		t.Fatalf("expected 2 args, got %v", args)
+	}
+	hash := hoststate.DirectMountCacheKey(sourceDir, mountPath)
+	stagedNested := filepath.Join(bundleRoot, "direct-mounts", hash, "nested", "file.txt")
+	data, err := os.ReadFile(stagedNested)
+	if err != nil {
+		t.Fatalf("read staged file: %v", err)
+	}
+	if string(data) != "payload" {
+		t.Fatalf("staged content mismatch: %q", string(data))
+	}
+}
+
+func TestStageDirectMountsStripsGroupOtherPermissions(t *testing.T) {
+	bundleRoot := t.TempDir()
+	sourceFile := filepath.Join(bundleRoot, "src.txt")
+	if err := os.WriteFile(sourceFile, []byte("hi"), 0o666); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	mountPath := "/opt/workcell/host-inputs/x"
+	specPath := filepath.Join(bundleRoot, "spec.json")
+	writeMountSpec(t, specPath, []map[string]any{
+		{"source": sourceFile, "mount_path": mountPath},
+	})
+
+	if _, err := StageDirectMounts(bundleRoot, specPath); err != nil {
+		t.Fatalf("StageDirectMounts: %v", err)
+	}
+	hash := hoststate.DirectMountCacheKey(sourceFile, mountPath)
+	staged := filepath.Join(bundleRoot, "direct-mounts", hash)
+	info, err := os.Stat(staged)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("expected group/other bits cleared, got %o", info.Mode().Perm())
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "3ccb91943d5fd3d887f41602d4d7fb2a195fd588ec701d4b4b8dc40ea7c33dee"
+      "sha256": "2e048c1fdd5706642f8b1c39c1ff47bd52873f7124f4b6613ff1295e38d6a634"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "2e048c1fdd5706642f8b1c39c1ff47bd52873f7124f4b6613ff1295e38d6a634"
+      "sha256": "b42ad978084d02dfed31db735c3831e4bfc15020f532a95fc7ca773f5f9e16f2"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -198,15 +198,6 @@ go_colimautil() {
     "${HOST_GO_BIN}" run ./cmd/workcell-colimautil "$@"
 }
 
-go_runtimeutil() {
-  ensure_go_run_env
-  run_clean_host_command_in_dir "${ROOT_DIR}" env \
-    GOPATH="${GOPATH}" \
-    GOMODCACHE="${GOMODCACHE}" \
-    GOCACHE="${GOCACHE}" \
-    "${HOST_GO_BIN}" run ./cmd/workcell-runtimeutil "$@"
-}
-
 HOST_GIT_BIN=""
 HOST_COLIMA_BIN=""
 HOST_DOCKER_BIN=""
@@ -5069,195 +5060,74 @@ cleanup_workcell_cache_roots() {
   fi
 }
 
-prepare_injection_direct_mounts() {
-  local mount_spec_path="$1"
-  local host_source=""
-  local mount_path=""
-  local staged_root=""
-  local staged_source=""
-  local entry_hash=""
-
-  DIRECT_SOURCE_MOUNTS=()
-  [[ -f "${mount_spec_path}" ]] || return 0
-  [[ -n "${INJECTION_BUNDLE_ROOT}" ]] || {
-    echo "Direct input staging requires an injection bundle root." >&2
-    exit 2
-  }
-  staged_root="${INJECTION_BUNDLE_ROOT}/direct-mounts"
-  mkdir -p "${staged_root}"
-
-  while IFS=$'\t' read -r host_source mount_path; do
-    [[ -n "${host_source}" ]] || continue
-
-    if [[ "${host_source}" != /* ]] || [[ ! -e "${host_source}" ]] ||
-      { [[ ! -f "${host_source}" ]] && [[ ! -d "${host_source}" ]]; }; then
-      echo "Direct input source is missing, not absolute, or not a regular file/directory: ${host_source}" >&2
-      exit 2
-    fi
-
-    case "${mount_path}" in
-      /opt/workcell/host-inputs/*) ;;
-      *)
-        echo "Direct input mount path is outside the managed host-input root: ${mount_path}" >&2
-        exit 2
-        ;;
-    esac
-
-    entry_hash="$(go_hostutil launcher direct-mount-cache-key "${host_source}" "${mount_path}")"
-    staged_source="${staged_root}/${entry_hash}"
-    rm -rf "${staged_source}"
-    if [[ -d "${host_source}" ]]; then
-      mkdir -p "${staged_source}"
-      cp -R "${host_source}/." "${staged_source}"
-    else
-      mkdir -p "$(dirname "${staged_source}")"
-      cp -f "${host_source}" "${staged_source}"
-    fi
-    chmod -R go-rwx "${staged_source}" 2>/dev/null || true
-
-    DIRECT_SOURCE_MOUNTS+=(-v "${staged_source}:${mount_path}:ro")
-  done < <(go_runtimeutil list-direct-mounts "${mount_spec_path}")
-}
-
 prepare_injection_bundle() {
+  # PR 23.4 shim: the full pipeline (resolver, renderer, direct-mount
+  # extraction + staging, metadata fan-out) now runs in-process inside the
+  # workcell-hostutil launcher subcommand.  Bash imports the resulting
+  # variables via a single "while read" loop.
   local agent="$1"
   local mode="$2"
-  local policy_path="${INJECTION_POLICY}"
-  local bundle_parent=""
-  local default_policy_path=""
-  local resolved_policy_path=""
-  local resolver_metadata_path=""
-  local resolution_mode="launch"
-  local manifest_path=""
-  local metadata=""
-  local resolver_metadata=""
-  local synthetic_claude_export=""
-  local synthetic_codex_home=""
-  local synthetic_codex_auth=""
-  local -a resolver_cmd=()
-  local -a resolver_env=()
+  local key=""
+  local value=""
+  local synthetic_codex="0"
+  local synthetic_claude="0"
 
-  if [[ -z "${policy_path}" ]] && [[ "${USE_DEFAULT_INJECTION_POLICY}" -eq 1 ]]; then
-    default_policy_path="$(default_injection_policy_path)"
-    if [[ -f "${default_policy_path}" ]]; then
-      policy_path="${default_policy_path}"
-    fi
-  fi
+  case "${SELF_STAGING_PROBE_SYNTHETIC_CODEX_AUTH:-0}" in
+    1 | true) synthetic_codex="1" ;;
+  esac
+  case "${SELF_STAGING_PROBE_SYNTHETIC_CLAUDE_EXPORT:-0}" in
+    1 | true) synthetic_claude="1" ;;
+  esac
 
-  bundle_parent="$(default_injection_bundle_parent)"
-  mkdir -p "${bundle_parent}"
-  chmod 0700 "${bundle_parent}" 2>/dev/null || true
-  cleanup_stale_injection_bundles "${bundle_parent}"
+  DIRECT_SOURCE_MOUNTS=()
+  INJECTION_BUNDLE_ROOT=""
+  DIRECT_MOUNT_SPEC_PATH=""
+  INJECTION_POLICY_SHA256=""
+  INJECTION_CREDENTIAL_KEYS=""
+  INJECTION_CREDENTIAL_INPUT_KINDS=""
+  INJECTION_CREDENTIAL_RESOLVERS=""
+  INJECTION_CREDENTIAL_MATERIALIZATION=""
+  INJECTION_CREDENTIAL_RESOLUTION_STATES=""
+  INJECTION_PROVIDER_AUTH_READY_STATES=""
+  INJECTION_SHARED_AUTH_READY_STATES=""
+  INJECTION_EXTRA_ENDPOINTS=""
+  INJECTION_SSH_ENABLED=0
+  INJECTION_SSH_CONFIG_ASSURANCE="off"
+  INJECTION_SECRET_COPY_TARGETS=""
 
-  if [[ -z "${policy_path}" ]]; then
-    INJECTION_POLICY_SHA256=""
-    INJECTION_CREDENTIAL_KEYS=""
-    INJECTION_CREDENTIAL_INPUT_KINDS=""
-    INJECTION_CREDENTIAL_RESOLVERS=""
-    INJECTION_CREDENTIAL_MATERIALIZATION=""
-    INJECTION_CREDENTIAL_RESOLUTION_STATES=""
-    INJECTION_PROVIDER_AUTH_READY_STATES=""
-    INJECTION_SHARED_AUTH_READY_STATES=""
-    INJECTION_EXTRA_ENDPOINTS=""
-    INJECTION_SSH_ENABLED=0
-    INJECTION_SSH_CONFIG_ASSURANCE="off"
-    INJECTION_SECRET_COPY_TARGETS=""
-    return 0
-  fi
-
-  policy_path="$(resolve_host_path "${policy_path}")"
-  if [[ ! -f "${policy_path}" ]]; then
-    echo "Injection policy file does not exist: ${policy_path}" >&2
-    exit 2
-  fi
-
-  INJECTION_BUNDLE_ROOT="$(mktemp -d "${bundle_parent%/}/workcell-injections.XXXXXX")"
-  INJECTION_BUNDLE_ROOT="$(resolve_host_path "${INJECTION_BUNDLE_ROOT}")"
-  chmod 0700 "${INJECTION_BUNDLE_ROOT}"
-  go_hostutil launcher write-profile-owner "${INJECTION_BUNDLE_ROOT}/owner.json" "$$"
-
-  if [[ "${AUTH_STATUS}" -eq 1 ]] || [[ "${DOCTOR}" -eq 1 ]] || [[ "${INSPECT}" -eq 1 ]] || [[ "${DRY_RUN}" -eq 1 ]]; then
-    resolution_mode="metadata"
-  fi
-  resolved_policy_path="${INJECTION_BUNDLE_ROOT}/resolved-policy.toml"
-  resolver_metadata_path="${INJECTION_BUNDLE_ROOT}/resolver-metadata.json"
-  resolver_cmd=(
-    "${ROOT_DIR}/scripts/lib/resolve_credential_sources"
-    --policy "${policy_path}"
-    --agent "${agent}"
-    --mode "${mode}"
-    --resolution-mode "${resolution_mode}"
-    --output-policy "${resolved_policy_path}"
-    --output-metadata "${resolver_metadata_path}"
-    --output-root "${INJECTION_BUNDLE_ROOT}"
-  )
-  if [[ "${SELF_STAGING_PROBE_SYNTHETIC_CODEX_AUTH}" == "1" ]]; then
-    synthetic_codex_home="${INJECTION_BUNDLE_ROOT}/self-staging-probe-codex-home"
-    synthetic_codex_auth="${synthetic_codex_home}/.codex/auth.json"
-    mkdir -p "$(dirname "${synthetic_codex_auth}")"
-    umask 077
-    printf '{"token":"codex"}\n' >"${synthetic_codex_auth}"
-    ensure_go_run_env
-    resolver_env+=(
-      "HOME=${synthetic_codex_home}"
-      "WORKCELL_GO_CACHE_ROOT=${WORKCELL_GO_CACHE_ROOT}"
-      "GOPATH=${GOPATH}"
-      "GOMODCACHE=${GOMODCACHE}"
-      "GOCACHE=${GOCACHE}"
-    )
-  fi
-  if [[ "${SELF_STAGING_PROBE_SYNTHETIC_CLAUDE_EXPORT}" == "1" ]]; then
-    synthetic_claude_export="${INJECTION_BUNDLE_ROOT}/self-staging-probe-claude-export.json"
-    umask 077
-    printf '{"token":"claude"}\n' >"${synthetic_claude_export}"
-    resolver_env+=("WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE=${synthetic_claude_export}")
-  fi
-  if [[ "${#resolver_env[@]}" -gt 0 ]]; then
-    run_clean_host_command env "${resolver_env[@]}" "${resolver_cmd[@]}" >/dev/null
-  else
-    run_clean_host_command "${resolver_cmd[@]}" >/dev/null
-  fi
-
-  manifest_path="$(run_clean_host_command \
-    "${ROOT_DIR}/scripts/lib/render_injection_bundle" \
-    --policy "${resolved_policy_path}" \
-    --policy-metadata "${resolver_metadata_path}" \
-    --agent "${agent}" \
-    --mode "${mode}" \
-    --output-root "${INJECTION_BUNDLE_ROOT}")"
-  manifest_path="${manifest_path//$'\n'/}"
-
-  if [[ "${manifest_path}" != "${INJECTION_BUNDLE_ROOT}/manifest.json" ]]; then
-    echo "Unexpected injection manifest path from renderer: ${manifest_path}" >&2
-    exit 2
-  fi
-
-  if [[ ! -f "${manifest_path}" ]]; then
-    echo "Injection manifest was not rendered: ${manifest_path}" >&2
-    exit 2
-  fi
-
-  DIRECT_MOUNT_SPEC_PATH="${INJECTION_BUNDLE_ROOT}.mounts.json"
-  DIRECT_MOUNT_SPEC_PATH="$(resolve_host_path "${DIRECT_MOUNT_SPEC_PATH}")"
-  run_clean_host_command \
-    "${ROOT_DIR}/scripts/lib/extract_direct_mounts" \
-    --manifest "${manifest_path}" \
-    --mount-spec "${DIRECT_MOUNT_SPEC_PATH}" >/dev/null
-  prepare_injection_direct_mounts "${DIRECT_MOUNT_SPEC_PATH}"
-  metadata="$(go_hostutil launcher manifest-metadata "${manifest_path}")"
-  INJECTION_POLICY_SHA256="$(printf '%s\n' "${metadata}" | sed -n '1p')"
-  INJECTION_CREDENTIAL_KEYS="$(printf '%s\n' "${metadata}" | sed -n '2p')"
-  INJECTION_EXTRA_ENDPOINTS="$(printf '%s\n' "${metadata}" | sed -n '3p')"
-  INJECTION_SSH_ENABLED="$(printf '%s\n' "${metadata}" | sed -n '4p')"
-  INJECTION_SSH_CONFIG_ASSURANCE="$(printf '%s\n' "${metadata}" | sed -n '5p')"
-  INJECTION_SECRET_COPY_TARGETS="$(printf '%s\n' "${metadata}" | sed -n '6p')"
-  resolver_metadata="$(go_hostutil launcher resolver-metadata "${resolver_metadata_path}")"
-  INJECTION_CREDENTIAL_INPUT_KINDS="$(printf '%s\n' "${resolver_metadata}" | sed -n '1p')"
-  INJECTION_CREDENTIAL_RESOLVERS="$(printf '%s\n' "${resolver_metadata}" | sed -n '2p')"
-  INJECTION_CREDENTIAL_MATERIALIZATION="$(printf '%s\n' "${resolver_metadata}" | sed -n '3p')"
-  INJECTION_CREDENTIAL_RESOLUTION_STATES="$(printf '%s\n' "${resolver_metadata}" | sed -n '4p')"
-  INJECTION_PROVIDER_AUTH_READY_STATES="$(printf '%s\n' "${resolver_metadata}" | sed -n '5p')"
-  INJECTION_SHARED_AUTH_READY_STATES="$(printf '%s\n' "${resolver_metadata}" | sed -n '6p')"
+  while IFS='=' read -r key value; do
+    [[ -n "${key}" ]] || continue
+    case "${key}" in
+      INJECTION_BUNDLE_ROOT) INJECTION_BUNDLE_ROOT="${value}" ;;
+      DIRECT_MOUNT_SPEC_PATH) DIRECT_MOUNT_SPEC_PATH="${value}" ;;
+      DIRECT_SOURCE_MOUNTS_COUNT) ;;
+      DIRECT_SOURCE_MOUNTS_*) DIRECT_SOURCE_MOUNTS+=("${value}") ;;
+      INJECTION_POLICY_SHA256) INJECTION_POLICY_SHA256="${value}" ;;
+      INJECTION_CREDENTIAL_KEYS) INJECTION_CREDENTIAL_KEYS="${value}" ;;
+      INJECTION_CREDENTIAL_INPUT_KINDS) INJECTION_CREDENTIAL_INPUT_KINDS="${value}" ;;
+      INJECTION_CREDENTIAL_RESOLVERS) INJECTION_CREDENTIAL_RESOLVERS="${value}" ;;
+      INJECTION_CREDENTIAL_MATERIALIZATION) INJECTION_CREDENTIAL_MATERIALIZATION="${value}" ;;
+      INJECTION_CREDENTIAL_RESOLUTION_STATES) INJECTION_CREDENTIAL_RESOLUTION_STATES="${value}" ;;
+      INJECTION_PROVIDER_AUTH_READY_STATES) INJECTION_PROVIDER_AUTH_READY_STATES="${value}" ;;
+      INJECTION_SHARED_AUTH_READY_STATES) INJECTION_SHARED_AUTH_READY_STATES="${value}" ;;
+      INJECTION_EXTRA_ENDPOINTS) INJECTION_EXTRA_ENDPOINTS="${value}" ;;
+      INJECTION_SSH_ENABLED) INJECTION_SSH_ENABLED="${value}" ;;
+      INJECTION_SSH_CONFIG_ASSURANCE) INJECTION_SSH_CONFIG_ASSURANCE="${value}" ;;
+      INJECTION_SECRET_COPY_TARGETS) INJECTION_SECRET_COPY_TARGETS="${value}" ;;
+    esac
+  done < <(go_hostutil launcher injection-prepare-bundle \
+    "--agent=${agent}" \
+    "--mode=${mode}" \
+    "--policy=${INJECTION_POLICY:-}" \
+    "--use-default-policy=${USE_DEFAULT_INJECTION_POLICY:-0}" \
+    "--auth-status=${AUTH_STATUS:-0}" \
+    "--doctor=${DOCTOR:-0}" \
+    "--inspect=${INSPECT:-0}" \
+    "--dry-run=${DRY_RUN:-0}" \
+    "--synthetic-codex-auth=${synthetic_codex}" \
+    "--synthetic-claude-export=${synthetic_claude}" \
+    "--real-home=${REAL_HOME}" \
+    "--pid=$$")
 }
 
 build_recommended_command() {

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -5095,6 +5095,37 @@ prepare_injection_bundle() {
   INJECTION_SSH_CONFIG_ASSURANCE="off"
   INJECTION_SECRET_COPY_TARGETS=""
 
+  local stdout_capture stderr_capture rc trailer
+  stdout_capture="$(mktemp)"
+  stderr_capture="$(mktemp)"
+  rc=0
+  go_hostutil launcher injection-prepare-bundle \
+    "--agent=${agent}" \
+    "--mode=${mode}" \
+    "--policy=${INJECTION_POLICY:-}" \
+    "--use-default-policy=${USE_DEFAULT_INJECTION_POLICY:-0}" \
+    "--auth-status=${AUTH_STATUS:-0}" \
+    "--doctor=${DOCTOR:-0}" \
+    "--inspect=${INSPECT:-0}" \
+    "--dry-run=${DRY_RUN:-0}" \
+    "--synthetic-codex-auth=${synthetic_codex}" \
+    "--synthetic-claude-export=${synthetic_claude}" \
+    "--real-home=${REAL_HOME}" \
+    "--pid=$$" >"${stdout_capture}" 2>"${stderr_capture}" || rc=$?
+  if ((rc != 0)); then
+    # go run swallows the child's non-zero exit and emits "exit status N"
+    # on stderr; recover the original code so the bash CLI surface matches
+    # the pre-translation contract callers (and the resolver-launcher
+    # scenarios) depend on.
+    trailer="$(tail -n1 "${stderr_capture}" 2>/dev/null || true)"
+    case "${trailer}" in
+      "exit status "[0-9]*)
+        rc="${trailer##* }"
+        sed -i.bak -e '$d' "${stderr_capture}" 2>/dev/null && rm -f "${stderr_capture}.bak"
+        ;;
+    esac
+  fi
+  cat "${stderr_capture}" >&2 || true
   while IFS='=' read -r key value; do
     [[ -n "${key}" ]] || continue
     case "${key}" in
@@ -5115,19 +5146,9 @@ prepare_injection_bundle() {
       INJECTION_SSH_CONFIG_ASSURANCE) INJECTION_SSH_CONFIG_ASSURANCE="${value}" ;;
       INJECTION_SECRET_COPY_TARGETS) INJECTION_SECRET_COPY_TARGETS="${value}" ;;
     esac
-  done < <(go_hostutil launcher injection-prepare-bundle \
-    "--agent=${agent}" \
-    "--mode=${mode}" \
-    "--policy=${INJECTION_POLICY:-}" \
-    "--use-default-policy=${USE_DEFAULT_INJECTION_POLICY:-0}" \
-    "--auth-status=${AUTH_STATUS:-0}" \
-    "--doctor=${DOCTOR:-0}" \
-    "--inspect=${INSPECT:-0}" \
-    "--dry-run=${DRY_RUN:-0}" \
-    "--synthetic-codex-auth=${synthetic_codex}" \
-    "--synthetic-claude-export=${synthetic_claude}" \
-    "--real-home=${REAL_HOME}" \
-    "--pid=$$")
+  done <"${stdout_capture}"
+  rm -f "${stdout_capture}" "${stderr_capture}"
+  return "${rc}"
 }
 
 build_recommended_command() {


### PR DESCRIPTION
## Summary
- prepare_injection_bundle (140 LOC) + prepare_injection_direct_mounts (49 LOC) move to Go.
- scripts/workcell helpers become thin shims.
- control-plane-manifest.json regenerated.

## Test plan
- [x] go test ./internal/injection/ + relevant cmds
- [x] gofmt -l . empty
- [x] bash -n scripts/workcell scripts/verify-invariants.sh
- [x] shellcheck SC2317 clean
- [x] bash tests/scenarios/shared/test-session-commands.sh exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)