### PR TITLE
^R Translate docker client + process helpers into Go

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -156,6 +156,9 @@ func launcherSubcommands() []launcherSubcommand {
 		{"colima-status", 1, 1, cmdLauncherColimaStatus},
 		{"validate-colima-status", 1, 1, cmdLauncherValidateColimaStatus},
 		{"run-host-colima-with-timeout", 1, -1, cmdLauncherRunHostColimaWithTimeout},
+		{"docker-desktop-context-name", 0, 0, cmdLauncherDockerDesktopContextName},
+		{"route-profile-docker-command", 1, -1, cmdLauncherRouteProfileDockerCommand},
+		{"prepare-current-docker-client-plan", 1, -1, cmdLauncherPrepareCurrentDockerClientPlan},
 		{"cleanup-stale-log-pointers", 1, 1, cmdLauncherCleanupStaleLogPointers},
 		{"profile-lock-is-stale", 1, 1, cmdLauncherProfileLockIsStale},
 		{"acquire-profile-lock", 2, 2, cmdLauncherAcquireProfileLock},
@@ -355,6 +358,92 @@ func parseColimaInvocationArgs(args []string) (int, launcher.HostColimaInvocatio
 		rest = rest[1:]
 	}
 	return timeoutSeconds, inv, rest, nil
+}
+
+func cmdLauncherDockerDesktopContextName(_ []string) error {
+	fmt.Println(launcher.DockerDesktopContextName)
+	return nil
+}
+
+// cmdLauncherRouteProfileDockerCommand implements the
+// `route-profile-docker-command` launcher subcommand.  The bash caller
+// passes the provider via --provider and, depending on the provider,
+// either --socket-path (colima) or --context-name (docker-desktop).
+// On success the env-prefix tokens are emitted to stdout one per line
+// so the bash shim can capture them into an array with `mapfile`.  An
+// unsupported provider exits with status 1 after printing the bash
+// "Unsupported target provider for Docker command routing" diagnostic
+// to stderr.
+func cmdLauncherRouteProfileDockerCommand(args []string) error {
+	var provider, socketPath, contextName string
+	for _, arg := range args {
+		switch {
+		case strings.HasPrefix(arg, "--provider="):
+			provider = strings.TrimPrefix(arg, "--provider=")
+		case strings.HasPrefix(arg, "--socket-path="):
+			socketPath = strings.TrimPrefix(arg, "--socket-path=")
+		case strings.HasPrefix(arg, "--context-name="):
+			contextName = strings.TrimPrefix(arg, "--context-name=")
+		default:
+			return launcherUsage()
+		}
+	}
+	route, err := launcher.RouteProfileDockerCommand(provider, socketPath, contextName)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+	for _, token := range route.EnvPrefix {
+		fmt.Println(token)
+	}
+	return nil
+}
+
+// cmdLauncherPrepareCurrentDockerClientPlan implements the
+// `prepare-current-docker-client-plan` launcher subcommand.  Required
+// arg: --backend=BACKEND.  Optional: --context-name=NAME,
+// --context-exists=0|1, --context-healthy=0|1 (consulted only for
+// docker-desktop).  On success it prints `mode=...` (and, for
+// docker-desktop, `context=NAME`) on stdout.  When the docker-desktop
+// context check fails the helper exits with status 2 after writing the
+// two-line bash diagnostic to stderr, matching the original `exit 2`
+// in scripts/workcell.
+func cmdLauncherPrepareCurrentDockerClientPlan(args []string) error {
+	var backend, contextName string
+	contextExists := false
+	contextHealthy := false
+	for _, arg := range args {
+		switch {
+		case strings.HasPrefix(arg, "--backend="):
+			backend = strings.TrimPrefix(arg, "--backend=")
+		case strings.HasPrefix(arg, "--context-name="):
+			contextName = strings.TrimPrefix(arg, "--context-name=")
+		case arg == "--context-exists=1":
+			contextExists = true
+		case arg == "--context-exists=0":
+			contextExists = false
+		case arg == "--context-healthy=1":
+			contextHealthy = true
+		case arg == "--context-healthy=0":
+			contextHealthy = false
+		default:
+			return launcherUsage()
+		}
+	}
+	plan, err := launcher.PrepareCurrentDockerClientPlan(backend, contextName, contextExists, contextHealthy)
+	if err != nil {
+		var planErr *launcher.PrepareDockerClientPlanError
+		if errors.As(err, &planErr) {
+			fmt.Fprintln(os.Stderr, planErr.Error())
+			os.Exit(2)
+		}
+		return err
+	}
+	fmt.Printf("mode=%s\n", plan.Mode)
+	if plan.ContextName != "" {
+		fmt.Printf("context=%s\n", plan.ContextName)
+	}
+	return nil
 }
 
 func cmdLauncherCleanupStaleLogPointers(args []string) error {

--- a/internal/host/launcher/dockerclient.go
+++ b/internal/host/launcher/dockerclient.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package launcher
+
+import (
+	"errors"
+	"fmt"
+)
+
+// DockerDesktopContextName returns the docker context name workcell
+// expects when the active target backend is Docker Desktop.  Mirrors
+// the bash docker_desktop_context_name helper, which has always been a
+// constant of "desktop-linux".
+const DockerDesktopContextName = "desktop-linux"
+
+// DockerCommandRoute describes how to invoke a docker subcommand
+// targeted at a specific profile's runtime: the env-prefix tokens to
+// place before the docker binary plus the resolved provider name.
+// Mirrors the case-statement at the heart of run_profile_docker_command
+// in scripts/workcell.
+type DockerCommandRoute struct {
+	// Provider is the resolved target provider, e.g. "colima" or
+	// "docker-desktop".
+	Provider string
+	// EnvPrefix is the sequence of tokens that should precede the
+	// docker binary on the command line.  For example
+	// {"env", "DOCKER_HOST=unix:///.../docker.sock"}.
+	EnvPrefix []string
+}
+
+// RouteProfileDockerCommand returns the env prefix that scripts/workcell
+// must place before HOST_DOCKER_BIN when dispatching a docker command at
+// the given profile.  socketPath is required for the colima provider;
+// contextName is required for docker-desktop.  An unrecognised provider
+// returns an error whose Error() message is byte-identical to the bash
+// "Unsupported target provider for Docker command routing" diagnostic.
+func RouteProfileDockerCommand(provider, socketPath, contextName string) (DockerCommandRoute, error) {
+	switch provider {
+	case "colima":
+		if socketPath == "" {
+			return DockerCommandRoute{}, errors.New("RouteProfileDockerCommand: socket path is required for colima provider")
+		}
+		return DockerCommandRoute{
+			Provider:  provider,
+			EnvPrefix: []string{"env", "DOCKER_HOST=unix://" + socketPath},
+		}, nil
+	case "docker-desktop":
+		if contextName == "" {
+			return DockerCommandRoute{}, errors.New("RouteProfileDockerCommand: context name is required for docker-desktop provider")
+		}
+		return DockerCommandRoute{
+			Provider:  provider,
+			EnvPrefix: []string{"env", "DOCKER_CONTEXT=" + contextName},
+		}, nil
+	default:
+		return DockerCommandRoute{}, fmt.Errorf("Unsupported target provider for Docker command routing: %s", provider)
+	}
+}
+
+// PrepareDockerClientMode encodes the behaviour
+// prepare_current_target_docker_client must apply for a given target
+// backend.  scripts/workcell consumes it as a textual directive on
+// stdout (one of "noop", "docker-desktop", or "abort").  When the mode
+// is "docker-desktop" the plan also carries the context name that bash
+// must export as DOCKER_CONTEXT.
+type PrepareDockerClientMode string
+
+const (
+	// PrepareDockerClientModeNoop indicates the bash helper should
+	// leave the docker client environment untouched after the
+	// initial sanitize call.  Matches the colima / aws-ec2-ssm /
+	// gcp-vm bash cases.
+	PrepareDockerClientModeNoop PrepareDockerClientMode = "noop"
+
+	// PrepareDockerClientModeDockerDesktop indicates the bash
+	// helper should export DOCKER_CONTEXT to the plan's context
+	// name and unset DOCKER_HOST.  Matches the docker-desktop bash
+	// branch.
+	PrepareDockerClientModeDockerDesktop PrepareDockerClientMode = "docker-desktop"
+)
+
+// PrepareDockerClientPlan describes the env actions
+// prepare_current_target_docker_client must perform.
+type PrepareDockerClientPlan struct {
+	Mode        PrepareDockerClientMode
+	ContextName string
+}
+
+// PrepareDockerClientPlanError is returned when the docker-desktop
+// context check fails.  scripts/workcell expects this case to exit with
+// status 2 after printing two stderr lines, matching the original bash
+// case-block.
+type PrepareDockerClientPlanError struct {
+	ContextName string
+}
+
+func (e *PrepareDockerClientPlanError) Error() string {
+	return fmt.Sprintf(
+		"Docker Desktop target requires a healthy docker context named %s.\nEnable Docker Desktop and make sure the %s context is available before retrying.",
+		e.ContextName, e.ContextName,
+	)
+}
+
+// PrepareCurrentDockerClientPlan derives the plan
+// prepare_current_target_docker_client should apply.  contextExists
+// and contextHealthy are only consulted when backend == "docker-desktop";
+// callers may pass false unconditionally for the other backends.
+func PrepareCurrentDockerClientPlan(backend, contextName string, contextExists, contextHealthy bool) (PrepareDockerClientPlan, error) {
+	switch backend {
+	case "colima", "aws-ec2-ssm", "gcp-vm":
+		return PrepareDockerClientPlan{Mode: PrepareDockerClientModeNoop}, nil
+	case "docker-desktop":
+		if contextName == "" {
+			return PrepareDockerClientPlan{}, errors.New("PrepareCurrentDockerClientPlan: context name is required for docker-desktop backend")
+		}
+		if !contextExists || !contextHealthy {
+			return PrepareDockerClientPlan{}, &PrepareDockerClientPlanError{ContextName: contextName}
+		}
+		return PrepareDockerClientPlan{Mode: PrepareDockerClientModeDockerDesktop, ContextName: contextName}, nil
+	default:
+		return PrepareDockerClientPlan{}, fmt.Errorf("PrepareCurrentDockerClientPlan: unsupported target backend %q", backend)
+	}
+}

--- a/internal/host/launcher/dockerclient_test.go
+++ b/internal/host/launcher/dockerclient_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package launcher
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDockerDesktopContextNameConstant(t *testing.T) {
+	if DockerDesktopContextName != "desktop-linux" {
+		t.Fatalf("DockerDesktopContextName = %q, want desktop-linux", DockerDesktopContextName)
+	}
+}
+
+func TestRouteProfileDockerCommand(t *testing.T) {
+	cases := []struct {
+		name        string
+		provider    string
+		socketPath  string
+		contextName string
+		want        DockerCommandRoute
+		wantErr     string
+	}{
+		{
+			name:       "colima emits DOCKER_HOST env",
+			provider:   "colima",
+			socketPath: "/state/wcl-profile/docker.sock",
+			want: DockerCommandRoute{
+				Provider:  "colima",
+				EnvPrefix: []string{"env", "DOCKER_HOST=unix:///state/wcl-profile/docker.sock"},
+			},
+		},
+		{
+			name:        "docker-desktop emits DOCKER_CONTEXT env",
+			provider:    "docker-desktop",
+			contextName: "desktop-linux",
+			want: DockerCommandRoute{
+				Provider:  "docker-desktop",
+				EnvPrefix: []string{"env", "DOCKER_CONTEXT=desktop-linux"},
+			},
+		},
+		{
+			name:     "colima without socket path errors",
+			provider: "colima",
+			wantErr:  "socket path is required",
+		},
+		{
+			name:     "docker-desktop without context name errors",
+			provider: "docker-desktop",
+			wantErr:  "context name is required",
+		},
+		{
+			name:     "unsupported provider matches bash diagnostic byte-for-byte",
+			provider: "aws-ec2-ssm",
+			wantErr:  "Unsupported target provider for Docker command routing: aws-ec2-ssm",
+		},
+		{
+			name:     "empty provider also unsupported",
+			provider: "",
+			wantErr:  "Unsupported target provider for Docker command routing: ",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := RouteProfileDockerCommand(tc.provider, tc.socketPath, tc.contextName)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("RouteProfileDockerCommand = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrepareCurrentDockerClientPlan(t *testing.T) {
+	cases := []struct {
+		name           string
+		backend        string
+		contextName    string
+		contextExists  bool
+		contextHealthy bool
+		wantMode       PrepareDockerClientMode
+		wantContext    string
+		wantErr        string
+		wantPlanErr    bool
+	}{
+		{name: "colima -> noop", backend: "colima", wantMode: PrepareDockerClientModeNoop},
+		{name: "aws-ec2-ssm -> noop", backend: "aws-ec2-ssm", wantMode: PrepareDockerClientModeNoop},
+		{name: "gcp-vm -> noop", backend: "gcp-vm", wantMode: PrepareDockerClientModeNoop},
+		{
+			name:           "docker-desktop healthy context yields directive",
+			backend:        "docker-desktop",
+			contextName:    "desktop-linux",
+			contextExists:  true,
+			contextHealthy: true,
+			wantMode:       PrepareDockerClientModeDockerDesktop,
+			wantContext:    "desktop-linux",
+		},
+		{
+			name:        "docker-desktop missing context errors with bash diagnostic",
+			backend:     "docker-desktop",
+			contextName: "desktop-linux",
+			wantPlanErr: true,
+		},
+		{
+			name:           "docker-desktop unhealthy context errors",
+			backend:        "docker-desktop",
+			contextName:    "desktop-linux",
+			contextExists:  true,
+			contextHealthy: false,
+			wantPlanErr:    true,
+		},
+		{
+			name:        "docker-desktop without context name programmer error",
+			backend:     "docker-desktop",
+			contextName: "",
+			wantErr:     "context name is required",
+		},
+		{
+			name:    "unknown backend programmer error",
+			backend: "kubernetes",
+			wantErr: "unsupported target backend",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan, err := PrepareCurrentDockerClientPlan(tc.backend, tc.contextName, tc.contextExists, tc.contextHealthy)
+			if tc.wantPlanErr {
+				var planErr *PrepareDockerClientPlanError
+				if !errors.As(err, &planErr) {
+					t.Fatalf("expected PrepareDockerClientPlanError, got %v", err)
+				}
+				if planErr.ContextName != tc.contextName {
+					t.Fatalf("plan error context = %q, want %q", planErr.ContextName, tc.contextName)
+				}
+				if !strings.Contains(planErr.Error(), "Docker Desktop target requires a healthy docker context named "+tc.contextName) {
+					t.Fatalf("plan error message %q lacks bash diagnostic prefix", planErr.Error())
+				}
+				if !strings.Contains(planErr.Error(), "Enable Docker Desktop") {
+					t.Fatalf("plan error message %q lacks bash followup line", planErr.Error())
+				}
+				return
+			}
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if plan.Mode != tc.wantMode {
+				t.Fatalf("plan.Mode = %q, want %q", plan.Mode, tc.wantMode)
+			}
+			if plan.ContextName != tc.wantContext {
+				t.Fatalf("plan.ContextName = %q, want %q", plan.ContextName, tc.wantContext)
+			}
+		})
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "b42ad978084d02dfed31db735c3831e4bfc15020f532a95fc7ca773f5f9e16f2"
+      "sha256": "33c011f74cfc66ca36e942402ebf67c0639a693c8f2d1e198216ce95143777d2"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -926,22 +926,65 @@ prepare_optional_target_docker_client() {
 prepare_current_target_docker_client() {
   HOST_DOCKER_BIN="$(resolve_host_tool docker /opt/homebrew/bin/docker /usr/local/bin/docker /Applications/Docker.app/Contents/Resources/bin/docker)"
   sanitize_host_docker_env
-  case "${TARGET_BACKEND}" in
-    colima)
+
+  local desktop_context=""
+  local context_exists_flag="0"
+  local context_healthy_flag="0"
+  if [[ "${TARGET_BACKEND:-}" == "docker-desktop" ]]; then
+    desktop_context="$(docker_desktop_context_name)"
+    docker_context_exists "${desktop_context}" && context_exists_flag="1"
+    docker_context_is_healthy "${desktop_context}" && context_healthy_flag="1"
+  fi
+
+  # Delegate the case-statement that historically lived in this body to
+  # the Go translation in internal/host/launcher/dockerclient.go.  go run
+  # wraps non-zero exit status as a trailer on stderr; we extract it so
+  # the bash side can continue to exit 2 when the docker-desktop context
+  # check fails, exactly as the original case-block did.
+  local plan_stderr plan_output rc trailer
+  plan_stderr="$(mktemp)"
+  plan_output="$(go_hostutil launcher prepare-current-docker-client-plan \
+    --backend="${TARGET_BACKEND:-}" \
+    --context-name="${desktop_context}" \
+    "--context-exists=${context_exists_flag}" \
+    "--context-healthy=${context_healthy_flag}" 2>"${plan_stderr}")"
+  rc=$?
+  if ((rc != 0)); then
+    trailer="$(tail -n1 "${plan_stderr}" 2>/dev/null || true)"
+    case "${trailer}" in
+      "exit status "[0-9]*)
+        rc="${trailer##* }"
+        # Strip the trailer line so the bash diagnostic remains the
+        # only thing emitted to stderr.
+        sed -i.bak '$d' "${plan_stderr}" 2>/dev/null || true
+        rm -f "${plan_stderr}.bak"
+        ;;
+    esac
+    cat "${plan_stderr}" >&2
+    rm -f "${plan_stderr}"
+    exit "${rc}"
+  fi
+  rm -f "${plan_stderr}"
+
+  local plan_mode="" plan_context=""
+  while IFS='=' read -r key value; do
+    case "${key}" in
+      mode) plan_mode="${value}" ;;
+      context) plan_context="${value}" ;;
+    esac
+  done <<<"${plan_output}"
+
+  case "${plan_mode}" in
+    noop)
       return 0
       ;;
     docker-desktop)
-      DOCKER_CONTEXT_NAME="$(docker_desktop_context_name)"
-      if ! docker_context_exists "${DOCKER_CONTEXT_NAME}" || ! docker_context_is_healthy "${DOCKER_CONTEXT_NAME}"; then
-        echo "Docker Desktop target requires a healthy docker context named ${DOCKER_CONTEXT_NAME}." >&2
-        echo "Enable Docker Desktop and make sure the ${DOCKER_CONTEXT_NAME} context is available before retrying." >&2
-        exit 2
-      fi
-      export DOCKER_CONTEXT="${DOCKER_CONTEXT_NAME}"
+      export DOCKER_CONTEXT="${plan_context}"
       unset DOCKER_HOST
       ;;
-    aws-ec2-ssm | gcp-vm)
-      return 0
+    *)
+      echo "prepare_current_target_docker_client: unexpected plan mode '${plan_mode}'" >&2
+      exit 1
       ;;
   esac
 }
@@ -1614,17 +1657,44 @@ run_profile_docker_command() {
   case "${provider}" in
     colima)
       socket_path="$(profile_docker_socket_path "${profile}")"
-      run_workcell_docker_client_command env DOCKER_HOST="unix://${socket_path}" "${HOST_DOCKER_BIN}" "$@"
       ;;
     docker-desktop)
       context_name="$(target_id_for_profile_state "${profile}")"
-      run_workcell_docker_client_command env DOCKER_CONTEXT="${context_name}" "${HOST_DOCKER_BIN}" "$@"
-      ;;
-    *)
-      echo "Unsupported target provider for Docker command routing: ${provider}" >&2
-      return 1
       ;;
   esac
+
+  # Delegate the env-prefix decision to the Go translation; on
+  # unsupported providers the helper emits the original bash
+  # diagnostic to its stderr and exits 1, which we surface here.
+  local route_stderr route_output rc trailer
+  route_stderr="$(mktemp)"
+  route_output="$(go_hostutil launcher route-profile-docker-command \
+    "--provider=${provider}" \
+    "--socket-path=${socket_path}" \
+    "--context-name=${context_name}" 2>"${route_stderr}")"
+  rc=$?
+  if ((rc != 0)); then
+    trailer="$(tail -n1 "${route_stderr}" 2>/dev/null || true)"
+    case "${trailer}" in
+      "exit status "[0-9]*)
+        rc="${trailer##* }"
+        sed -i.bak '$d' "${route_stderr}" 2>/dev/null || true
+        rm -f "${route_stderr}.bak"
+        ;;
+    esac
+    cat "${route_stderr}" >&2
+    rm -f "${route_stderr}"
+    return "${rc}"
+  fi
+  rm -f "${route_stderr}"
+
+  local -a env_prefix=()
+  while IFS= read -r token; do
+    [[ -n "${token}" ]] || continue
+    env_prefix+=("${token}")
+  done <<<"${route_output}"
+
+  run_workcell_docker_client_command "${env_prefix[@]}" "${HOST_DOCKER_BIN}" "$@"
 }
 
 profile_docker_transport_available() {


### PR DESCRIPTION
## Summary
- `prepare_current_target_docker_client` and `run_profile_docker_command` case-statements move to `internal/host/launcher/dockerclient.go`.
- Three new `workcell-hostutil launcher` subcommands wire them through: `docker-desktop-context-name`, `route-profile-docker-command`, `prepare-current-docker-client-plan`.
- scripts/workcell helpers become shims that still call the bash mock seams (`resolve_host_tool`, `sanitize_host_docker_env`, `docker_context_exists`, `docker_context_is_healthy`, `target_provider_for_profile_state`, `profile_docker_socket_path`, `target_id_for_profile_state`) so the existing `tests/scenarios/shared/test-session-commands.sh` mock surface is preserved; the case-block decisions themselves now live in Go.
- Both shims use the `colima_profile_status`-style `go run` exit-status trailer recovery so original exit codes survive `go run` wrapping (preserves `exit 2` on docker-desktop context failure).
- The shipped env-prefix format is preserved byte-for-byte (`env DOCKER_HOST=unix://... ${HOST_DOCKER_BIN} args...` / `env DOCKER_CONTEXT=name ${HOST_DOCKER_BIN} args...`), matching the load-bearing assertions in `test-session-commands.sh` around `session_monitor_main` docker-desktop dispatch.
- `control-plane-manifest.json` regenerated.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/host/launcher/ ./cmd/workcell-hostutil/ ./...` green
- [x] `gofmt -l .` empty
- [x] `go vet ./...` clean
- [x] `bash -n scripts/workcell scripts/verify-invariants.sh`
- [x] `shellcheck --severity=info scripts/workcell` SC2317/SC2329 clean
- [x] `bash tests/scenarios/shared/test-session-commands.sh` exit 0
- [x] `bash scripts/check-pr-shape.sh` passes (files=5 lines=496 areas=4 binary=0)
- [ ] `bash scripts/verify-invariants.sh` — fails locally on a pre-existing linked-worktree assertion (`~/.local/bin/workcell --workspace ${ROOT_DIR} --dry-run`), unrelated to docker translation. None of `verify/invariants/harnesses/process-colima/*.sh` reference `prepare_current_target_docker_client`, `run_profile_docker_command`, or `sanitize_host_docker_env`.

PR 25b.2 of the /sethify-remediation chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)