### PR TITLE
^R Translate session_stop_main into internal/sessionctl/StopMain

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -152,6 +152,7 @@ func launcherSubcommands() []launcherSubcommand {
 		{"session-timeline-cli", 0, -1, cmdLauncherSessionTimelineCli},
 		{"session-logs-cli", 0, -1, cmdLauncherSessionLogsCli},
 		{"session-attach-cli", 0, -1, cmdLauncherSessionAttachCli},
+		{"session-stop-cli", 0, -1, cmdLauncherSessionStopCli},
 		{"session-suffix", 0, 0, cmdLauncherSessionSuffix},
 		{"colima-status", 1, 1, cmdLauncherColimaStatus},
 		{"validate-colima-status", 1, 1, cmdLauncherValidateColimaStatus},
@@ -261,6 +262,10 @@ func cmdLauncherSessionLogsCli(args []string) error {
 
 func cmdLauncherSessionAttachCli(args []string) error {
 	return sessionctl.AttachMain(args)
+}
+
+func cmdLauncherSessionStopCli(args []string) error {
+	return sessionctl.StopMain(args)
 }
 
 func cmdLauncherSessionSuffix(_ []string) error {

--- a/internal/sessionctl/stop.go
+++ b/internal/sessionctl/stop.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/omkhar/workcell/internal/authpolicy"
+	"github.com/omkhar/workcell/internal/host/sessions"
+)
+
+// StopMain implements the option-parsing and record-validation half of
+// `workcell session stop --id SESSION_ID [--force]`, the Go translation
+// of session_stop_main in scripts/workcell.
+//
+// Like AttachMain, StopMain is the host-side parsing layer of a hybrid
+// translation.  session_stop_main's body splits into:
+//
+//  1. Option parsing (--id, --force) plus the up-front record load and
+//     detached-session validation - profile and container_name must be
+//     non-empty and the record must describe a detached session
+//     (monitor_pid present).  Those are all on-disk data checks against
+//     the session JSON, so they live here.
+//
+//  2. Live container state probes (session_container_live_state,
+//     session_monitor_pid_is_live, session_container_exit_code), the
+//     graceful->force-kill docker stop/kill transport, audit record
+//     emission, stop-request marker management, and the
+//     stopping/stopped session-record writes.  Those still depend on
+//     sourced bash helpers that
+//     tests/scenarios/shared/test-session-commands.sh mocks via
+//     `bash -lc "source workcell; ..."`, and the docker invocations
+//     need the host docker binary on the host PATH, so they stay in
+//     the bash shim.
+//
+// StopMain emits a plan on stdout for the bash shim to consume:
+//
+//	session_id=<id>
+//	force=0|1
+//	profile=<profile>
+//	container_name=<container>
+//
+// Usage errors (--id missing, unknown flag) exit with code 2 to match
+// the bash CLI surface.  All other errors propagate to main() for the
+// default exit-1 path.
+//
+// State-root forwarding mirrors AttachMain/LogsMain: leading
+// --root=PATH args are consumed via consumeRootArgs because
+// go_hostutil scrubs WORKCELL_STATE_ROOT/COLIMA_STATE_ROOT from the
+// environment.
+func StopMain(args []string) error {
+	return stopMain(args, os.Stdout)
+}
+
+func stopMain(args []string, stdout io.Writer) error {
+	roots, rest := consumeRootArgs(args)
+	sessionID, force, showHelp, err := parseStopArgs(rest)
+	if err != nil {
+		return err
+	}
+	if showHelp {
+		fmt.Fprint(stdout, UsageText())
+		return nil
+	}
+	if sessionID == "" {
+		return &authpolicy.ExitCodeError{Code: 2, Message: "workcell session stop requires --id."}
+	}
+
+	if len(roots) == 0 {
+		roots = lookupRoots()
+	}
+	record, err := sessions.FindSessionRecordInRoots(roots, sessionID)
+	if err != nil {
+		return err
+	}
+
+	if record.Profile == "" {
+		return fmt.Errorf("session stop record is missing a profile: %s", sessionID)
+	}
+	if !sessionIsDetached(record) {
+		return fmt.Errorf("session stop only works for detached sessions started with 'workcell session start': %s\nUse 'workcell session list' to check the control column; attached records are not stoppable.", sessionID)
+	}
+	if record.ContainerName == "" {
+		return fmt.Errorf("session stop record is missing a container name: %s", sessionID)
+	}
+
+	forceFlag := 0
+	if force {
+		forceFlag = 1
+	}
+	fmt.Fprintf(stdout, "session_id=%s\n", record.SessionID)
+	fmt.Fprintf(stdout, "force=%d\n", forceFlag)
+	fmt.Fprintf(stdout, "profile=%s\n", record.Profile)
+	fmt.Fprintf(stdout, "container_name=%s\n", record.ContainerName)
+	return nil
+}
+
+// parseStopArgs walks the bash session_stop_main option loop.
+//
+// --id mirrors option_value_or_die: the value must be non-empty.
+//
+// --force is a boolean toggle that selects docker kill instead of
+// docker stop in the bash transport half.
+//
+// -h / --help mark help output for the caller.
+//
+// Unknown options return an Unsupported-style error matching the bash
+// branch so the user-visible stderr stays byte-identical, wrapped in
+// an ExitCodeError so the launcher exits 2.
+func parseStopArgs(args []string) (sessionID string, force, showHelp bool, err error) {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--id":
+			if i+1 >= len(args) || args[i+1] == "" {
+				return "", false, false, &authpolicy.ExitCodeError{
+					Code:    2,
+					Message: "Option --id requires a value.",
+				}
+			}
+			sessionID = args[i+1]
+			i++
+		case "--force":
+			force = true
+		case "-h", "--help":
+			showHelp = true
+		default:
+			return "", false, false, &authpolicy.ExitCodeError{
+				Code:    2,
+				Message: fmt.Sprintf("Unsupported workcell session stop option: %s", args[i]),
+			}
+		}
+	}
+	return sessionID, force, showHelp, nil
+}

--- a/internal/sessionctl/stop_test.go
+++ b/internal/sessionctl/stop_test.go
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/authpolicy"
+)
+
+func TestParseStopArgsRequiresIDValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, err := parseStopArgs([]string{"--id"})
+	if err == nil {
+		t.Fatal("parseStopArgs accepted --id without a value")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("parseStopArgs err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Fatalf("parseStopArgs ExitCodeError.Code = %d, want 2", ec.Code)
+	}
+	if !strings.Contains(ec.Message, "Option --id requires a value") {
+		t.Fatalf("parseStopArgs message = %q, want missing-value rejection", ec.Message)
+	}
+}
+
+func TestParseStopArgsRejectsEmptyIDValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, err := parseStopArgs([]string{"--id", ""})
+	if err == nil {
+		t.Fatal("parseStopArgs accepted empty --id value")
+	}
+}
+
+func TestParseStopArgsRejectsUnknownFlag(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, err := parseStopArgs([]string{"--bogus"})
+	if err == nil {
+		t.Fatal("parseStopArgs accepted unknown flag")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("parseStopArgs err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Fatalf("parseStopArgs ExitCodeError.Code = %d, want 2", ec.Code)
+	}
+	if !strings.Contains(ec.Message, "Unsupported workcell session stop option") {
+		t.Fatalf("parseStopArgs message = %q, want session-stop-specific message", ec.Message)
+	}
+}
+
+func TestParseStopArgsAcceptsCanonical(t *testing.T) {
+	t.Parallel()
+
+	id, force, help, err := parseStopArgs([]string{"--id", "session-1"})
+	if err != nil {
+		t.Fatalf("parseStopArgs error = %v", err)
+	}
+	if help {
+		t.Fatal("parseStopArgs help = true, want false")
+	}
+	if force {
+		t.Fatal("parseStopArgs force = true, want false")
+	}
+	if id != "session-1" {
+		t.Fatalf("parseStopArgs id = %q, want %q", id, "session-1")
+	}
+}
+
+func TestParseStopArgsHandlesForce(t *testing.T) {
+	t.Parallel()
+
+	id, force, help, err := parseStopArgs([]string{"--id", "session-1", "--force"})
+	if err != nil {
+		t.Fatalf("parseStopArgs error = %v", err)
+	}
+	if help {
+		t.Fatal("parseStopArgs help = true, want false")
+	}
+	if !force {
+		t.Fatal("parseStopArgs force = false, want true")
+	}
+	if id != "session-1" {
+		t.Fatalf("parseStopArgs id = %q, want %q", id, "session-1")
+	}
+}
+
+func TestParseStopArgsHandlesHelp(t *testing.T) {
+	t.Parallel()
+
+	for _, flag := range []string{"-h", "--help"} {
+		_, _, help, err := parseStopArgs([]string{flag})
+		if err != nil {
+			t.Fatalf("parseStopArgs(%s) error = %v", flag, err)
+		}
+		if !help {
+			t.Fatalf("parseStopArgs(%s) help = false, want true", flag)
+		}
+	}
+}
+
+func TestStopMainRequiresID(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := stopMain([]string{}, &buf)
+	if err == nil {
+		t.Fatal("stopMain accepted call without --id")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("stopMain err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Fatalf("stopMain ExitCodeError.Code = %d, want 2", ec.Code)
+	}
+	if !strings.Contains(ec.Message, "workcell session stop requires --id.") {
+		t.Fatalf("stopMain message = %q, want canonical require-id message", ec.Message)
+	}
+}
+
+func TestStopMainHelpPrintsUsage(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := stopMain([]string{"--help"}, &buf); err != nil {
+		t.Fatalf("stopMain(--help) error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "Usage: workcell session") {
+		t.Fatalf("stopMain(--help) output = %q, want usage banner", buf.String())
+	}
+}
+
+func TestStopMainEmitsPlanFromRecord(t *testing.T) {
+	root := t.TempDir()
+	writeStopFixtureRecord(t, root, "wcl-detached-fixture", "fixture-1", map[string]string{
+		"profile":           "wcl-detached-fixture",
+		"container_name":    "workcell-session-fixture",
+		"monitor_pid":       "4242",
+		"session_audit_dir": "/tmp/audit-fixture",
+		"status":            "running",
+		"live_status":       "running",
+	})
+
+	var buf bytes.Buffer
+	args := []string{"--root=" + root, "--id", "fixture-1"}
+	if err := stopMain(args, &buf); err != nil {
+		t.Fatalf("stopMain error = %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"session_id=fixture-1\n",
+		"force=0\n",
+		"profile=wcl-detached-fixture\n",
+		"container_name=workcell-session-fixture\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stopMain output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestStopMainPropagatesForce(t *testing.T) {
+	root := t.TempDir()
+	writeStopFixtureRecord(t, root, "wcl-detached-fixture", "fixture-1", map[string]string{
+		"profile":           "wcl-detached-fixture",
+		"container_name":    "workcell-session-fixture",
+		"monitor_pid":       "4242",
+		"session_audit_dir": "/tmp/audit-fixture",
+		"status":            "running",
+		"live_status":       "running",
+	})
+
+	var buf bytes.Buffer
+	args := []string{"--root=" + root, "--id", "fixture-1", "--force"}
+	if err := stopMain(args, &buf); err != nil {
+		t.Fatalf("stopMain error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "force=1\n") {
+		t.Fatalf("stopMain --force did not propagate; output:\n%s", buf.String())
+	}
+}
+
+func TestStopMainRejectsAttachedSession(t *testing.T) {
+	root := t.TempDir()
+	writeStopFixtureRecord(t, root, "wcl-attached", "fixture-attached", map[string]string{
+		"profile":        "wcl-attached",
+		"container_name": "workcell-session-fixture",
+		// no monitor_pid -> attached session
+		"status":      "running",
+		"live_status": "running",
+	})
+
+	var buf bytes.Buffer
+	args := []string{"--root=" + root, "--id", "fixture-attached"}
+	err := stopMain(args, &buf)
+	if err == nil {
+		t.Fatal("stopMain accepted an attached session")
+	}
+	if !strings.Contains(err.Error(), "only works for detached sessions") {
+		t.Fatalf("stopMain error = %v, want detached-required message", err)
+	}
+	if !strings.Contains(err.Error(), "Use 'workcell session list'") {
+		t.Fatalf("stopMain error = %v, want canonical follow-up hint", err)
+	}
+}
+
+func TestStopMainRejectsMissingContainerName(t *testing.T) {
+	root := t.TempDir()
+	writeStopFixtureRecord(t, root, "wcl-detached-fixture", "fixture-bad", map[string]string{
+		"profile":           "wcl-detached-fixture",
+		"monitor_pid":       "4242",
+		"session_audit_dir": "/tmp/audit-fixture",
+		"status":            "running",
+		"live_status":       "running",
+	})
+
+	var buf bytes.Buffer
+	args := []string{"--root=" + root, "--id", "fixture-bad"}
+	err := stopMain(args, &buf)
+	if err == nil {
+		t.Fatal("stopMain accepted record missing container_name")
+	}
+	if !strings.Contains(err.Error(), "missing a container name") {
+		t.Fatalf("stopMain error = %v, want container_name complaint", err)
+	}
+}
+
+// writeStopFixtureRecord lays out a minimal session JSON record under
+// root/<profile>/sessions/<session_id>.json so StopMain's lookup via
+// sessions.FindSessionRecordInRoots can find it without needing the
+// full session-record-write path.  Mirrors writeAttachFixtureRecord
+// in attach_test.go.
+func writeStopFixtureRecord(t *testing.T, root, profile, sessionID string, fields map[string]string) {
+	t.Helper()
+	sessionsDir := filepath.Join(root, profile, "sessions")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions dir: %v", err)
+	}
+	body := `{
+  "version": 1,
+  "session_id": "` + sessionID + `",
+  "agent": "codex",
+  "mode": "strict",
+  "workspace": "/tmp/fixture-workspace",
+  "started_at": "2026-04-08T14:00:00Z"`
+	for key, value := range fields {
+		body += `,
+  "` + key + `": "` + value + `"`
+	}
+	body += "\n}\n"
+	path := filepath.Join(sessionsDir, sessionID+".json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write session record: %v", err)
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "33c011f74cfc66ca36e942402ebf67c0639a693c8f2d1e198216ce95143777d2"
+      "sha256": "d787bd3f1116190fb1b50a62378a09ae42c75372bafdeed28ac18672afea8f89"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -4105,50 +4105,45 @@ session_send_main() {
 }
 
 session_stop_main() {
+  local plan=""
   local session_id=""
   local force=0
+  local profile=""
+  local container_name=""
+  local stop_cli_status=0
   local record_path=""
   local stop_status=0
   local stop_exit_status=""
   local container_state=""
   local current_live_status=""
+  local line=""
+  local key=""
+  local value=""
+  local -a lookup_roots=()
 
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --id)
-        session_id="$(option_value_or_die "$1" "${2-}")"
-        shift 2
-        ;;
-      --force)
-        force=1
-        shift
-        ;;
-      -h | --help)
-        session_usage
-        exit 0
-        ;;
-      *)
-        echo "Unsupported workcell session stop option: $1" >&2
-        session_usage >&2
-        exit 2
-        ;;
+  while IFS= read -r line; do
+    lookup_roots+=("${line}")
+  done < <(session_lookup_root_args)
+  set +e
+  plan="$(go_hostutil launcher session-stop-cli "${lookup_roots[@]}" "$@")"
+  stop_cli_status="$?"
+  set -e
+  if [[ "${stop_cli_status}" -ne 0 ]]; then
+    exit "${stop_cli_status}"
+  fi
+  while IFS= read -r line; do
+    key="${line%%=*}"
+    value="${line#*=}"
+    case "${key}" in
+      session_id) session_id="${value}" ;;
+      force) force="${value}" ;;
+      profile) profile="${value}" ;;
+      container_name) container_name="${value}" ;;
     esac
-  done
-  [[ -n "${session_id}" ]] || {
-    echo "workcell session stop requires --id." >&2
-    exit 2
-  }
+  done <<<"${plan}"
+  [[ -n "${session_id}" ]] || exit 0
 
   load_session_runtime_metadata "${session_id}"
-  [[ -n "${SESSION_META_PROFILE}" ]] || {
-    echo "session stop record is missing a profile: ${session_id}" >&2
-    exit 1
-  }
-  session_require_detached_runtime_metadata "stop" "${session_id}" 1 || exit 1
-  [[ -n "${SESSION_META_CONTAINER_NAME}" ]] || {
-    echo "session stop record is missing a container name: ${session_id}" >&2
-    exit 1
-  }
   HOST_DOCKER_BIN="$(resolve_host_tool docker /opt/homebrew/bin/docker /usr/local/bin/docker /Applications/Docker.app/Contents/Resources/bin/docker)"
   sanitize_host_docker_env
   current_live_status="${SESSION_META_LIVE_STATUS:-${SESSION_META_STATUS}}"

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -1496,12 +1496,32 @@ if grep -Eq '^audit\|wcl-detached-fixture\|detached-fixture\|attach\|' "${SESSIO
 fi
 
 SESSION_STOP_STOPPED_RECORD="${DETACHED_STATE_DIR}/session-stop.stopped.record"
+SESSION_STOP_STOPPED_STATE_ROOT="${DETACHED_STATE_DIR}/session-stop.stopped.state-root"
+mkdir -p "${SESSION_STOP_STOPPED_STATE_ROOT}/wcl-detached-fixture/sessions"
+cat >"${SESSION_STOP_STOPPED_STATE_ROOT}/wcl-detached-fixture/sessions/detached-fixture.json" <<EOF_JSON
+{
+  "version": 1,
+  "session_id": "detached-fixture",
+  "profile": "wcl-detached-fixture",
+  "agent": "codex",
+  "mode": "strict",
+  "status": "running",
+  "live_status": "running",
+  "workspace": "/tmp/detached-fixture-workspace",
+  "container_name": "workcell-session-fixture",
+  "monitor_pid": "4242",
+  "session_audit_dir": "/tmp/detached-fixture-audit",
+  "started_at": "2026-04-08T14:00:00Z"
+}
+EOF_JSON
 set +e
 bash -lc '
   set -euo pipefail
   source "$1"
   trap - EXIT
   RECORD_FILE="$2"
+  WORKCELL_STATE_ROOT="$3"
+  COLIMA_STATE_ROOT="$3"
   HOST_DOCKER_BIN="/bin/false"
   resolve_host_tool() { printf "/bin/false\n"; }
   sanitize_host_docker_env() { :; }
@@ -1532,7 +1552,7 @@ bash -lc '
     esac
   }
   session_stop_main --id detached-fixture
-' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_STOP_STOPPED_RECORD}" >/dev/null 2>&1
+' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_STOP_STOPPED_RECORD}" "${SESSION_STOP_STOPPED_STATE_ROOT}" >/dev/null 2>&1
 session_stop_stopped_status=$?
 set -e
 if [[ "${session_stop_stopped_status}" -eq 0 ]]; then
@@ -1546,7 +1566,25 @@ fi
 
 SESSION_STOP_DEAD_MONITOR_RECORD="${DETACHED_STATE_DIR}/session-stop.dead-monitor.record"
 SESSION_STOP_DEAD_MONITOR_AUDIT_DIR="${DETACHED_STATE_DIR}/session-stop.dead-monitor.audit"
+SESSION_STOP_DEAD_MONITOR_STATE_ROOT="${DETACHED_STATE_DIR}/session-stop.dead-monitor.state-root"
 mkdir -p "${SESSION_STOP_DEAD_MONITOR_AUDIT_DIR}"
+mkdir -p "${SESSION_STOP_DEAD_MONITOR_STATE_ROOT}/wcl-detached-fixture/sessions"
+cat >"${SESSION_STOP_DEAD_MONITOR_STATE_ROOT}/wcl-detached-fixture/sessions/detached-fixture.json" <<EOF_JSON
+{
+  "version": 1,
+  "session_id": "detached-fixture",
+  "profile": "wcl-detached-fixture",
+  "agent": "codex",
+  "mode": "strict",
+  "status": "running",
+  "live_status": "running",
+  "workspace": "/tmp/detached-fixture-workspace",
+  "container_name": "workcell-session-fixture",
+  "monitor_pid": "4242",
+  "session_audit_dir": "${SESSION_STOP_DEAD_MONITOR_AUDIT_DIR}",
+  "started_at": "2026-04-08T14:00:00Z"
+}
+EOF_JSON
 stop_dead_monitor_output="$(
   bash -lc '
     set -euo pipefail
@@ -1554,6 +1592,8 @@ stop_dead_monitor_output="$(
     trap - EXIT
     RECORD_FILE="$2"
     AUDIT_DIR="$3"
+    WORKCELL_STATE_ROOT="$4"
+    COLIMA_STATE_ROOT="$4"
     HOST_DOCKER_BIN="/bin/false"
     LOAD_COUNT=0
     resolve_host_tool() { printf "/bin/false\n"; }
@@ -1600,7 +1640,7 @@ stop_dead_monitor_output="$(
     else
       printf "marker=cleared\n"
     fi
-  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_STOP_DEAD_MONITOR_RECORD}" "${SESSION_STOP_DEAD_MONITOR_AUDIT_DIR}"
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_STOP_DEAD_MONITOR_RECORD}" "${SESSION_STOP_DEAD_MONITOR_AUDIT_DIR}" "${SESSION_STOP_DEAD_MONITOR_STATE_ROOT}"
 )"
 grep -q '^session_id=detached-fixture$' <<<"${stop_dead_monitor_output}"
 grep -q '^stop_requested=1$' <<<"${stop_dead_monitor_output}"
@@ -1611,7 +1651,25 @@ grep -q '^record|.*/detached-fixture\.json|status=exited|live_status=stopped|obs
 
 SESSION_STOP_ALREADY_STOPPED_RECORD="${DETACHED_STATE_DIR}/session-stop.already-stopped.record"
 SESSION_STOP_ALREADY_STOPPED_AUDIT_DIR="${DETACHED_STATE_DIR}/session-stop.already-stopped.audit"
+SESSION_STOP_ALREADY_STOPPED_STATE_ROOT="${DETACHED_STATE_DIR}/session-stop.already-stopped.state-root"
 mkdir -p "${SESSION_STOP_ALREADY_STOPPED_AUDIT_DIR}"
+mkdir -p "${SESSION_STOP_ALREADY_STOPPED_STATE_ROOT}/wcl-detached-fixture/sessions"
+cat >"${SESSION_STOP_ALREADY_STOPPED_STATE_ROOT}/wcl-detached-fixture/sessions/detached-fixture.json" <<EOF_JSON
+{
+  "version": 1,
+  "session_id": "detached-fixture",
+  "profile": "wcl-detached-fixture",
+  "agent": "codex",
+  "mode": "strict",
+  "status": "stopping",
+  "live_status": "stopping",
+  "workspace": "/tmp/detached-fixture-workspace",
+  "container_name": "workcell-session-fixture",
+  "monitor_pid": "4242",
+  "session_audit_dir": "${SESSION_STOP_ALREADY_STOPPED_AUDIT_DIR}",
+  "started_at": "2026-04-08T14:00:00Z"
+}
+EOF_JSON
 stop_already_stopped_output="$(
   bash -lc '
     set -euo pipefail
@@ -1619,6 +1677,8 @@ stop_already_stopped_output="$(
     trap - EXIT
     RECORD_FILE="$2"
     AUDIT_DIR="$3"
+    WORKCELL_STATE_ROOT="$4"
+    COLIMA_STATE_ROOT="$4"
     HOST_DOCKER_BIN="/bin/false"
     resolve_host_tool() { printf "/bin/false\n"; }
     sanitize_host_docker_env() { :; }
@@ -1660,7 +1720,7 @@ stop_already_stopped_output="$(
     else
       printf "marker=cleared\n"
     fi
-  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_STOP_ALREADY_STOPPED_RECORD}" "${SESSION_STOP_ALREADY_STOPPED_AUDIT_DIR}"
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_STOP_ALREADY_STOPPED_RECORD}" "${SESSION_STOP_ALREADY_STOPPED_AUDIT_DIR}" "${SESSION_STOP_ALREADY_STOPPED_STATE_ROOT}"
 )"
 grep -q '^session_id=detached-fixture$' <<<"${stop_already_stopped_output}"
 grep -q '^stop_requested=1$' <<<"${stop_already_stopped_output}"
@@ -1675,7 +1735,25 @@ fi
 
 SESSION_STOP_ALREADY_STOPPED_RUNNING_RECORD="${DETACHED_STATE_DIR}/session-stop.already-stopped-running.record"
 SESSION_STOP_ALREADY_STOPPED_RUNNING_AUDIT_DIR="${DETACHED_STATE_DIR}/session-stop.already-stopped-running.audit"
+SESSION_STOP_ALREADY_STOPPED_RUNNING_STATE_ROOT="${DETACHED_STATE_DIR}/session-stop.already-stopped-running.state-root"
 mkdir -p "${SESSION_STOP_ALREADY_STOPPED_RUNNING_AUDIT_DIR}"
+mkdir -p "${SESSION_STOP_ALREADY_STOPPED_RUNNING_STATE_ROOT}/wcl-detached-fixture/sessions"
+cat >"${SESSION_STOP_ALREADY_STOPPED_RUNNING_STATE_ROOT}/wcl-detached-fixture/sessions/detached-fixture.json" <<EOF_JSON
+{
+  "version": 1,
+  "session_id": "detached-fixture",
+  "profile": "wcl-detached-fixture",
+  "agent": "codex",
+  "mode": "strict",
+  "status": "running",
+  "live_status": "running",
+  "workspace": "/tmp/detached-fixture-workspace",
+  "container_name": "workcell-session-fixture",
+  "monitor_pid": "4242",
+  "session_audit_dir": "${SESSION_STOP_ALREADY_STOPPED_RUNNING_AUDIT_DIR}",
+  "started_at": "2026-04-08T14:00:00Z"
+}
+EOF_JSON
 stop_already_stopped_running_output="$(
   bash -lc '
     set -euo pipefail
@@ -1683,6 +1761,8 @@ stop_already_stopped_running_output="$(
     trap - EXIT
     RECORD_FILE="$2"
     AUDIT_DIR="$3"
+    WORKCELL_STATE_ROOT="$4"
+    COLIMA_STATE_ROOT="$4"
     HOST_DOCKER_BIN="/bin/false"
     resolve_host_tool() { printf "/bin/false\n"; }
     sanitize_host_docker_env() { :; }
@@ -1724,7 +1804,7 @@ stop_already_stopped_running_output="$(
     else
       printf "marker=cleared\n"
     fi
-  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_STOP_ALREADY_STOPPED_RUNNING_RECORD}" "${SESSION_STOP_ALREADY_STOPPED_RUNNING_AUDIT_DIR}"
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_STOP_ALREADY_STOPPED_RUNNING_RECORD}" "${SESSION_STOP_ALREADY_STOPPED_RUNNING_AUDIT_DIR}" "${SESSION_STOP_ALREADY_STOPPED_RUNNING_STATE_ROOT}"
 )"
 grep -q '^session_id=detached-fixture$' <<<"${stop_already_stopped_running_output}"
 grep -q '^stop_requested=1$' <<<"${stop_already_stopped_running_output}"


### PR DESCRIPTION
## Summary
- Translate the option-parsing and record-validation half of `session_stop_main` from `scripts/workcell` into `internal/sessionctl/StopMain`, mirroring the hybrid pattern used by `AttachMain`. The Go layer handles `--id`/`--force`/`--help`, looks up the on-disk session record via `sessions.FindSessionRecordInRoots`, and emits a `key=value` plan that the bash shim consumes.
- Keep the live-container preflight, audit-record emission, docker stop/kill transport, stop-request marker management, and stopping/stopped record writes in the bash shim so the existing sourced helpers and host docker binary keep working under the `bash -lc "source workcell; ..."` test mocks.
- Wire `session-stop-cli` into the `launcherSubcommands()` dispatch table next to `session-attach-cli`, update the four bash session-stop fixture tests in `tests/scenarios/shared/test-session-commands.sh` to lay down a state-root session JSON record (so the Go launcher half can find the session via `WORKCELL_STATE_ROOT`), and regenerate `runtime/container/control-plane-manifest.json` so the host-artifact sha tracks the new `scripts/workcell` shim.

## Sizes
- `internal/sessionctl/stop.go`: +137 LOC
- `internal/sessionctl/stop_test.go`: +268 LOC (12 tests: --id missing/empty, --force, unknown flag, -h/--help, canonical accept, attached-session rejection, missing container_name, help-prints-usage, requires-id, plan output, force propagation)
- `scripts/workcell` `session_stop_main`: 167 -> 142 LOC (the parsing + record-validation prologue moved to Go)
- Total: 561 lines, 6 files, 5 areas, 0 binaries (within the 1200/25/8/0 PR-shape limits)

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/sessionctl/ ./cmd/workcell-hostutil/`
- [x] `go test ./...` (full suite green)
- [x] `gofmt -l .` -> 0
- [x] `bash -n scripts/workcell scripts/verify-invariants.sh`
- [x] `bash tests/scenarios/shared/test-session-commands.sh` -> exit 0 (Section B gate)
- [x] `bash scripts/check-pr-shape.sh` -> files=6 lines=561 areas=5 binary_files=0
- [x] `bash scripts/verify-control-plane-manifest.sh` -> exit 0
- [x] Commit signed with key `48405D072D95D996` (omkhar@gmail.com)