### PR TITLE
^R Translate session_delete_main into internal/sessionctl/DeleteMain (22.6)

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -165,6 +165,7 @@ func launcherSubcommands() []launcherSubcommand {
 		{"session-timeline-cli", 0, -1, cmdLauncherSessionTimelineCli},
 		{"session-logs-cli", 0, -1, cmdLauncherSessionLogsCli},
 		{"session-attach-cli", 0, -1, cmdLauncherSessionAttachCli},
+		{"session-delete-cli", 0, -1, cmdLauncherSessionDeleteCli},
 		{"session-send-cli", 0, -1, cmdLauncherSessionSendCli},
 		{"session-stop-cli", 0, -1, cmdLauncherSessionStopCli},
 		{"session-suffix", 0, 0, cmdLauncherSessionSuffix},
@@ -281,6 +282,10 @@ func cmdLauncherSessionLogsCli(args []string) error {
 
 func cmdLauncherSessionAttachCli(args []string) error {
 	return sessionctl.AttachMain(args)
+}
+
+func cmdLauncherSessionDeleteCli(args []string) error {
+	return sessionctl.DeleteMain(args)
 }
 
 func cmdLauncherSessionSendCli(args []string) error {

--- a/internal/sessionctl/delete.go
+++ b/internal/sessionctl/delete.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/omkhar/workcell/internal/authpolicy"
+)
+
+// DeleteMain implements the option-parsing half of `workcell session
+// delete --id SESSION_ID [--record-only] [--dry-run]`, the Go translation
+// of session_delete_main in scripts/workcell.
+//
+// Like SendMain, DeleteMain is the host-side parsing layer of a hybrid
+// translation.  The bash function's body splits into:
+//
+//  1. Up-front option parsing (--id, --record-only, --dry-run) plus the
+//     no-value check that bash performs with option_value_or_die.  This
+//     half lives here.
+//
+//  2. load_session_runtime_metadata, terminal-status validation,
+//     record-path existence check, container-state probe via
+//     run_profile_docker_command, artifact resolution via
+//     session_delete_resolve_*_artifact, the planned-remove rollup,
+//     dry-run output, and the actual `docker rm`/`rm -f`/`rm -rf`
+//     mutations.  Those still depend on sourced bash helpers that
+//     tests/scenarios/shared/test-session-commands.sh mocks via
+//     `bash -lc "source workcell; ..."` - in particular the cleanup,
+//     compat, dry-run, record-only, and live-container fixtures all
+//     override load_session_runtime_metadata to inject canned
+//     SESSION_META_* globals, so the Go side cannot independently load
+//     the on-disk record without diverging from the established test
+//     surface.  Phase 2 therefore stays in the bash shim.
+//
+// DeleteMain emits a plan on stdout for the bash shim to consume:
+//
+//	session_id=<id>
+//	record_only=0|1
+//	dry_run=0|1
+//
+// Usage errors (--id missing, unknown flag) exit with code 2 to match
+// the bash CLI surface.
+//
+// State-root forwarding mirrors SendMain/AttachMain/LogsMain: leading
+// --root=PATH args are consumed via consumeRootArgs because go_hostutil
+// scrubs WORKCELL_STATE_ROOT/COLIMA_STATE_ROOT from the environment.
+// The Go side does not currently use those roots, but the bash shim
+// keeps prepending them so the contract stays consistent with sibling
+// session-* subcommands.
+func DeleteMain(args []string) error {
+	return deleteMain(args, os.Stdout)
+}
+
+func deleteMain(args []string, stdout io.Writer) error {
+	_, rest := consumeRootArgs(args)
+	sessionID, recordOnly, dryRun, showHelp, err := parseDeleteArgs(rest)
+	if err != nil {
+		return err
+	}
+	if showHelp {
+		fmt.Fprint(stdout, UsageText())
+		return nil
+	}
+	if sessionID == "" {
+		return &authpolicy.ExitCodeError{Code: 2, Message: "workcell session delete requires --id."}
+	}
+
+	recordOnlyFlag := 0
+	if recordOnly {
+		recordOnlyFlag = 1
+	}
+	dryRunFlag := 0
+	if dryRun {
+		dryRunFlag = 1
+	}
+	fmt.Fprintf(stdout, "session_id=%s\n", sessionID)
+	fmt.Fprintf(stdout, "record_only=%d\n", recordOnlyFlag)
+	fmt.Fprintf(stdout, "dry_run=%d\n", dryRunFlag)
+	return nil
+}
+
+// parseDeleteArgs walks the bash session_delete_main option loop.
+//
+// --id mirrors option_value_or_die: the value must be non-empty.
+//
+// --record-only and --dry-run are boolean toggles that flip recordOnly
+// and dryRun respectively.
+//
+// -h / --help mark help output for the caller.
+//
+// Unknown options return an Unsupported-style error matching the bash
+// branch so the user-visible stderr stays byte-identical, wrapped in
+// an ExitCodeError so the launcher exits 2.
+func parseDeleteArgs(args []string) (sessionID string, recordOnly, dryRun, showHelp bool, err error) {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--id":
+			if i+1 >= len(args) || args[i+1] == "" {
+				return "", false, false, false, &authpolicy.ExitCodeError{
+					Code:    2,
+					Message: "Option --id requires a value.",
+				}
+			}
+			sessionID = args[i+1]
+			i++
+		case "--record-only":
+			recordOnly = true
+		case "--dry-run":
+			dryRun = true
+		case "-h", "--help":
+			showHelp = true
+		default:
+			return "", false, false, false, &authpolicy.ExitCodeError{
+				Code:    2,
+				Message: fmt.Sprintf("Unsupported workcell session delete option: %s", args[i]),
+			}
+		}
+	}
+	return sessionID, recordOnly, dryRun, showHelp, nil
+}

--- a/internal/sessionctl/delete_test.go
+++ b/internal/sessionctl/delete_test.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/authpolicy"
+)
+
+func TestParseDeleteArgsRequiresIDValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, _, err := parseDeleteArgs([]string{"--id"})
+	if err == nil {
+		t.Fatal("parseDeleteArgs accepted --id without a value")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("parseDeleteArgs err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Fatalf("parseDeleteArgs ExitCodeError.Code = %d, want 2", ec.Code)
+	}
+	if !strings.Contains(ec.Message, "Option --id requires a value") {
+		t.Fatalf("parseDeleteArgs message = %q, want missing-value rejection", ec.Message)
+	}
+}
+
+func TestParseDeleteArgsRejectsEmptyIDValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, _, err := parseDeleteArgs([]string{"--id", ""})
+	if err == nil {
+		t.Fatal("parseDeleteArgs accepted empty --id value")
+	}
+}
+
+func TestParseDeleteArgsRejectsUnknownFlag(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, _, err := parseDeleteArgs([]string{"--bogus"})
+	if err == nil {
+		t.Fatal("parseDeleteArgs accepted unknown flag")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("parseDeleteArgs err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Fatalf("parseDeleteArgs ExitCodeError.Code = %d, want 2", ec.Code)
+	}
+	if !strings.Contains(ec.Message, "Unsupported workcell session delete option") {
+		t.Fatalf("parseDeleteArgs message = %q, want session-delete-specific message", ec.Message)
+	}
+}
+
+func TestParseDeleteArgsAcceptsCanonical(t *testing.T) {
+	t.Parallel()
+
+	id, recordOnly, dryRun, help, err := parseDeleteArgs([]string{"--id", "session-1"})
+	if err != nil {
+		t.Fatalf("parseDeleteArgs error = %v", err)
+	}
+	if help {
+		t.Fatal("parseDeleteArgs help = true, want false")
+	}
+	if recordOnly {
+		t.Fatal("parseDeleteArgs record_only = true, want false")
+	}
+	if dryRun {
+		t.Fatal("parseDeleteArgs dry_run = true, want false")
+	}
+	if id != "session-1" {
+		t.Fatalf("parseDeleteArgs id = %q, want %q", id, "session-1")
+	}
+}
+
+func TestParseDeleteArgsHandlesRecordOnly(t *testing.T) {
+	t.Parallel()
+
+	id, recordOnly, dryRun, _, err := parseDeleteArgs([]string{"--id", "s", "--record-only"})
+	if err != nil {
+		t.Fatalf("parseDeleteArgs error = %v", err)
+	}
+	if !recordOnly {
+		t.Fatal("parseDeleteArgs --record-only did not set recordOnly")
+	}
+	if dryRun {
+		t.Fatal("parseDeleteArgs --record-only set dry_run unexpectedly")
+	}
+	if id != "s" {
+		t.Fatalf("parseDeleteArgs id = %q, want %q", id, "s")
+	}
+}
+
+func TestParseDeleteArgsHandlesDryRun(t *testing.T) {
+	t.Parallel()
+
+	id, recordOnly, dryRun, _, err := parseDeleteArgs([]string{"--id", "s", "--dry-run"})
+	if err != nil {
+		t.Fatalf("parseDeleteArgs error = %v", err)
+	}
+	if recordOnly {
+		t.Fatal("parseDeleteArgs --dry-run set record_only unexpectedly")
+	}
+	if !dryRun {
+		t.Fatal("parseDeleteArgs --dry-run did not set dryRun")
+	}
+	if id != "s" {
+		t.Fatalf("parseDeleteArgs id = %q, want %q", id, "s")
+	}
+}
+
+func TestParseDeleteArgsHandlesBothToggles(t *testing.T) {
+	t.Parallel()
+
+	_, recordOnly, dryRun, _, err := parseDeleteArgs([]string{"--id", "s", "--record-only", "--dry-run"})
+	if err != nil {
+		t.Fatalf("parseDeleteArgs error = %v", err)
+	}
+	if !recordOnly || !dryRun {
+		t.Fatalf("parseDeleteArgs combined toggles = (record_only=%v, dry_run=%v), want both true", recordOnly, dryRun)
+	}
+}
+
+func TestParseDeleteArgsHandlesHelp(t *testing.T) {
+	t.Parallel()
+
+	for _, flag := range []string{"-h", "--help"} {
+		_, _, _, help, err := parseDeleteArgs([]string{flag})
+		if err != nil {
+			t.Fatalf("parseDeleteArgs(%s) error = %v", flag, err)
+		}
+		if !help {
+			t.Fatalf("parseDeleteArgs(%s) help = false, want true", flag)
+		}
+	}
+}
+
+func TestDeleteMainRequiresID(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := deleteMain([]string{}, &buf)
+	if err == nil {
+		t.Fatal("deleteMain accepted call without --id")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("deleteMain err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Fatalf("deleteMain ExitCodeError.Code = %d, want 2", ec.Code)
+	}
+	if !strings.Contains(ec.Message, "workcell session delete requires --id.") {
+		t.Fatalf("deleteMain message = %q, want canonical require-id message", ec.Message)
+	}
+}
+
+func TestDeleteMainHelpPrintsUsage(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := deleteMain([]string{"--help"}, &buf); err != nil {
+		t.Fatalf("deleteMain(--help) error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "Usage: workcell session") {
+		t.Fatalf("deleteMain(--help) output = %q, want usage banner", buf.String())
+	}
+}
+
+func TestDeleteMainEmitsPlan(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := deleteMain([]string{"--id", "session-1"}, &buf); err != nil {
+		t.Fatalf("deleteMain error = %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"session_id=session-1\n",
+		"record_only=0\n",
+		"dry_run=0\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("deleteMain output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestDeleteMainPropagatesRecordOnly(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	args := []string{"--id", "session-1", "--record-only"}
+	if err := deleteMain(args, &buf); err != nil {
+		t.Fatalf("deleteMain error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "record_only=1\n") {
+		t.Fatalf("deleteMain --record-only did not propagate; output:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "dry_run=0\n") {
+		t.Fatalf("deleteMain --record-only flipped dry_run; output:\n%s", buf.String())
+	}
+}
+
+func TestDeleteMainPropagatesDryRun(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	args := []string{"--id", "session-1", "--dry-run"}
+	if err := deleteMain(args, &buf); err != nil {
+		t.Fatalf("deleteMain error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "dry_run=1\n") {
+		t.Fatalf("deleteMain --dry-run did not propagate; output:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "record_only=0\n") {
+		t.Fatalf("deleteMain --dry-run flipped record_only; output:\n%s", buf.String())
+	}
+}
+
+func TestDeleteMainPropagatesBothToggles(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	args := []string{"--id", "session-1", "--record-only", "--dry-run"}
+	if err := deleteMain(args, &buf); err != nil {
+		t.Fatalf("deleteMain error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "record_only=1\n") {
+		t.Fatalf("deleteMain combined --record-only missing; output:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "dry_run=1\n") {
+		t.Fatalf("deleteMain combined --dry-run missing; output:\n%s", buf.String())
+	}
+}
+
+func TestDeleteMainStripsRootArgs(t *testing.T) {
+	t.Parallel()
+
+	// --root= forwarding is unused by DeleteMain today but must not break
+	// argument parsing - the bash shim unconditionally prepends
+	// session_lookup_root_args output.
+	var buf bytes.Buffer
+	args := []string{"--root=/tmp/state-1", "--root=", "--id", "session-1", "--dry-run"}
+	if err := deleteMain(args, &buf); err != nil {
+		t.Fatalf("deleteMain error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "session_id=session-1\n") {
+		t.Fatalf("deleteMain stripped roots but lost session_id; output:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "dry_run=1\n") {
+		t.Fatalf("deleteMain stripped roots but lost dry_run; output:\n%s", buf.String())
+	}
+}
+
+func TestDeleteMainRejectsUnknownOption(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := deleteMain([]string{"--bogus"}, &buf)
+	if err == nil {
+		t.Fatal("deleteMain accepted unknown option")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != 2 {
+		t.Fatalf("deleteMain error = %v, want ExitCodeError{Code:2}", err)
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "314d03db6b1cf43f6323b9a84ed92debd282d14c16624a48b2ed66cf22a6a046"
+      "sha256": "62cc88c4c1f412bb50f21380b32f525134e62d19acbcbfde4e102d1678bde0bd"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -4093,6 +4093,8 @@ session_delete_resolve_dir_artifact() {
 }
 
 session_delete_main() {
+  local plan=""
+  local delete_cli_status=0
   local session_id=""
   local record_path=""
   local current_live_status=""
@@ -4108,41 +4110,36 @@ session_delete_main() {
   local remove_session_audit_dir=0
   local remove_transcript_log=0
   local session_audit_dir=""
+  local line=""
+  local key=""
+  local value=""
   local -a removed=()
   local -a kept=()
   local -a missing=()
   local -a unavailable=()
   local -a planned_remove=()
+  local -a lookup_roots=()
 
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --id)
-        session_id="$(option_value_or_die "$1" "${2-}")"
-        shift 2
-        ;;
-      --record-only)
-        record_only=1
-        shift
-        ;;
-      --dry-run)
-        dry_run=1
-        shift
-        ;;
-      -h | --help)
-        session_usage
-        exit 0
-        ;;
-      *)
-        echo "Unsupported workcell session delete option: $1" >&2
-        session_usage >&2
-        exit 2
-        ;;
+  while IFS= read -r line; do
+    lookup_roots+=("${line}")
+  done < <(session_lookup_root_args)
+  set +e
+  plan="$(go_hostutil launcher session-delete-cli "${lookup_roots[@]}" "$@")"
+  delete_cli_status="$?"
+  set -e
+  if [[ "${delete_cli_status}" -ne 0 ]]; then
+    exit "${delete_cli_status}"
+  fi
+  while IFS= read -r line; do
+    key="${line%%=*}"
+    value="${line#*=}"
+    case "${key}" in
+      session_id) session_id="${value}" ;;
+      record_only) record_only="${value}" ;;
+      dry_run) dry_run="${value}" ;;
     esac
-  done
-  [[ -n "${session_id}" ]] || {
-    echo "workcell session delete requires --id." >&2
-    exit 2
-  }
+  done <<<"${plan}"
+  [[ -n "${session_id}" ]] || exit 0
 
   load_session_runtime_metadata "${session_id}"
   [[ -n "${SESSION_META_PROFILE}" ]] || {


### PR DESCRIPTION
## Summary

Translate the 231-line `session_delete_main` bash function (`scripts/workcell:4095-4326`) into a hybrid Go/bash implementation, mirroring the `SendMain` pattern from PR #238 and the broader 22.x session_*_main translation series.

* **Go (parser layer)**: `internal/sessionctl/delete.go` (+124 LOC) owns the option loop (`--id`, `--record-only`, `--dry-run`, `-h/--help`), the require-id-value gate (`Option --id requires a value.`), and the canonical `workcell session delete requires --id.` exit-2 path. Usage errors flow back as `authpolicy.ExitCodeError{Code:2}` so the launcher exits 2 in line with the bash CLI surface. DeleteMain emits a `session_id=/record_only=/dry_run=` plan on stdout for the bash shim to consume.
* **Tests**: `internal/sessionctl/delete_test.go` (+275 LOC, 14 tests) covers the parsing matrix end-to-end: require/empty/unknown rejection, `--record-only` and `--dry-run` toggles individually and combined, `-h/--help`, the `deleteMain` require-id wiring, plan emission, `--root=` forwarding, and the unknown-option `ExitCodeError` exit-2 check.
* **Launcher dispatch**: `cmd/workcell-hostutil/main.go` registers `session-delete-cli` alongside `session-attach-cli`, `session-send-cli`, and `session-stop-cli`, with a new `cmdLauncherSessionDeleteCli`.
* **Bash shim**: `scripts/workcell session_delete_main` is now a shim that invokes `go_hostutil launcher session-delete-cli` with `session_lookup_root_args` forwarding, reads back the plan, and continues into the bash phase 2: `load_session_runtime_metadata`, terminal-status validation, container-state probe via `run_profile_docker_command`, artifact resolution via `session_delete_resolve_*_artifact`, the planned-remove rollup, the dry-run print path, and the `docker rm` / `rm -f` / `rm -rf` mutation path.
* **Manifest**: `runtime/container/control-plane-manifest.json` regenerated for the updated `scripts/workcell` sha256.

## Hybrid-translation rationale

Phase 2 stays in bash because `tests/scenarios/shared/test-session-commands.sh` heavily mocks `load_session_runtime_metadata` (the cleanup, compat, dry-run, record-only, and live-container fixtures all inject canned `SESSION_META_*` globals) and writes on-disk records that intentionally do not satisfy the strict JSON validator in `internal/host/sessions` (e.g. `status=exited` without `finished_at`/`exit_status`/`final_assurance`). A Go-side metadata load would diverge from the established mock surface, so the hybrid split owns parsing in Go and metadata + mutation in bash. This is the same split that SendMain uses.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/sessionctl/ ./cmd/workcell-hostutil/`
- [x] `gofmt -l .` (0 files)
- [x] `bash -n scripts/workcell scripts/verify-invariants.sh`
- [x] `bash tests/scenarios/shared/test-session-commands.sh` (Section B gate)
- [x] `bash scripts/check-pr-shape.sh` (files=5 lines=459 areas=4 binary_files=0)