### PR TITLE
^R Translate session_monitor + session_main dispatcher (22.7)

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -166,6 +166,8 @@ func launcherSubcommands() []launcherSubcommand {
 		{"session-logs-cli", 0, -1, cmdLauncherSessionLogsCli},
 		{"session-attach-cli", 0, -1, cmdLauncherSessionAttachCli},
 		{"session-delete-cli", 0, -1, cmdLauncherSessionDeleteCli},
+		{"session-dispatcher-cli", 0, -1, cmdLauncherSessionDispatcherCli},
+		{"session-monitor-cli", 0, -1, cmdLauncherSessionMonitorCli},
 		{"session-send-cli", 0, -1, cmdLauncherSessionSendCli},
 		{"session-stop-cli", 0, -1, cmdLauncherSessionStopCli},
 		{"session-suffix", 0, 0, cmdLauncherSessionSuffix},
@@ -286,6 +288,14 @@ func cmdLauncherSessionAttachCli(args []string) error {
 
 func cmdLauncherSessionDeleteCli(args []string) error {
 	return sessionctl.DeleteMain(args)
+}
+
+func cmdLauncherSessionDispatcherCli(args []string) error {
+	return sessionctl.DispatchMain(args)
+}
+
+func cmdLauncherSessionMonitorCli(args []string) error {
+	return sessionctl.MonitorMain(args)
 }
 
 func cmdLauncherSessionSendCli(args []string) error {

--- a/internal/sessionctl/dispatcher.go
+++ b/internal/sessionctl/dispatcher.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/omkhar/workcell/internal/authpolicy"
+)
+
+// DispatchMain implements the subcommand-routing half of
+// `workcell session <subcommand> [args...]`, the Go translation of the
+// session_main dispatcher in scripts/workcell.
+//
+// session_main is a wide case statement that fans the user-facing
+// subcommand list (start, attach, send, stop, list, show, delete, logs,
+// timeline, diff, export, monitor) out to a matching per-subcommand
+// handler.  The bulk of the per-subcommand work (option parsing for
+// list/show/diff/export, the env -i re-exec for start, the docker
+// transport for attach/send/stop, etc.) still depends on sourced bash
+// helpers that tests/scenarios/shared/test-session-commands.sh mocks
+// via `bash -lc "source workcell; ..."`, so the dispatcher stays in
+// bash but routes through this Go shim for the subcommand whitelist.
+//
+// DispatchMain emits a routing decision on stdout that the bash shim
+// consumes:
+//
+//	subcommand=<name>
+//
+// where <name> is one of the canonical subcommand tokens (start,
+// attach, send, stop, list, show, delete, logs, timeline, diff,
+// export, monitor) or `usage` for the empty/help branches.  Any other
+// subcommand returns an ExitCodeError with code 2 carrying the bash
+// "Unsupported workcell session command: <name>" diagnostic so the
+// launcher exits with the historical bash status.
+//
+// Help flags (-h, --help) and the empty-subcommand case route to
+// `subcommand=usage`, which the bash shim treats as a request to print
+// the canonical usage and exit 0.  The usage text itself lives in
+// usage.go (sessionctl.UsageText) and is already served via the
+// session-usage launcher subcommand.
+func DispatchMain(args []string) error {
+	return dispatchMain(args, os.Stdout)
+}
+
+func dispatchMain(args []string, stdout io.Writer) error {
+	subcommand := ""
+	if len(args) > 0 {
+		subcommand = args[0]
+	}
+	resolved, err := resolveSessionSubcommand(subcommand)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "subcommand=%s\n", resolved)
+	return nil
+}
+
+// resolveSessionSubcommand mirrors the session_main case branches.  The
+// empty-string, -h, and --help cases all collapse to the canonical
+// `usage` token so the bash shim has a single branch to handle the
+// usage printout.  Every other recognised subcommand returns its own
+// canonical token.  Anything else returns an ExitCodeError with the
+// bash "Unsupported workcell session command: <name>" diagnostic and
+// code 2.
+func resolveSessionSubcommand(subcommand string) (string, error) {
+	switch subcommand {
+	case "":
+		return "usage", nil
+	case "-h", "--help":
+		return "usage", nil
+	case "start",
+		"attach",
+		"send",
+		"stop",
+		"list",
+		"show",
+		"delete",
+		"logs",
+		"timeline",
+		"diff",
+		"export",
+		"monitor":
+		return subcommand, nil
+	default:
+		return "", &authpolicy.ExitCodeError{
+			Code:    2,
+			Message: fmt.Sprintf("Unsupported workcell session command: %s", subcommand),
+		}
+	}
+}

--- a/internal/sessionctl/dispatcher_test.go
+++ b/internal/sessionctl/dispatcher_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/authpolicy"
+)
+
+func TestResolveSessionSubcommandAcceptsCanonical(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"start",
+		"attach",
+		"send",
+		"stop",
+		"list",
+		"show",
+		"delete",
+		"logs",
+		"timeline",
+		"diff",
+		"export",
+		"monitor",
+	}
+	for _, name := range cases {
+		got, err := resolveSessionSubcommand(name)
+		if err != nil {
+			t.Fatalf("resolveSessionSubcommand(%q) error = %v", name, err)
+		}
+		if got != name {
+			t.Fatalf("resolveSessionSubcommand(%q) = %q, want %q", name, got, name)
+		}
+	}
+}
+
+func TestResolveSessionSubcommandMapsHelp(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"", "-h", "--help"} {
+		got, err := resolveSessionSubcommand(name)
+		if err != nil {
+			t.Fatalf("resolveSessionSubcommand(%q) error = %v", name, err)
+		}
+		if got != "usage" {
+			t.Fatalf("resolveSessionSubcommand(%q) = %q, want %q", name, got, "usage")
+		}
+	}
+}
+
+func TestResolveSessionSubcommandRejectsUnknown(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveSessionSubcommand("frobnicate")
+	if err == nil {
+		t.Fatalf("resolveSessionSubcommand accepted unknown subcommand, returned %q", got)
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("resolveSessionSubcommand err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Fatalf("resolveSessionSubcommand ExitCodeError.Code = %d, want 2", ec.Code)
+	}
+	// Bash diagnostic must stay byte-identical so the user-visible
+	// stderr matches the legacy "Unsupported workcell session command: <name>"
+	// emitted by session_main.
+	want := "Unsupported workcell session command: frobnicate"
+	if !strings.Contains(ec.Message, want) {
+		t.Fatalf("resolveSessionSubcommand message = %q, want %q", ec.Message, want)
+	}
+}
+
+func TestDispatchMainEmitsCanonicalRoute(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"start":    "subcommand=start\n",
+		"attach":   "subcommand=attach\n",
+		"send":     "subcommand=send\n",
+		"stop":     "subcommand=stop\n",
+		"list":     "subcommand=list\n",
+		"show":     "subcommand=show\n",
+		"delete":   "subcommand=delete\n",
+		"logs":     "subcommand=logs\n",
+		"timeline": "subcommand=timeline\n",
+		"diff":     "subcommand=diff\n",
+		"export":   "subcommand=export\n",
+		"monitor":  "subcommand=monitor\n",
+	}
+	for name, want := range cases {
+		var buf bytes.Buffer
+		if err := dispatchMain([]string{name}, &buf); err != nil {
+			t.Fatalf("dispatchMain(%q) error = %v", name, err)
+		}
+		if buf.String() != want {
+			t.Fatalf("dispatchMain(%q) output = %q, want %q", name, buf.String(), want)
+		}
+	}
+}
+
+func TestDispatchMainEmitsUsageForEmptyAndHelp(t *testing.T) {
+	t.Parallel()
+
+	for _, args := range [][]string{nil, {}, {""}, {"-h"}, {"--help"}} {
+		var buf bytes.Buffer
+		if err := dispatchMain(args, &buf); err != nil {
+			t.Fatalf("dispatchMain(%v) error = %v", args, err)
+		}
+		if buf.String() != "subcommand=usage\n" {
+			t.Fatalf("dispatchMain(%v) output = %q, want %q", args, buf.String(), "subcommand=usage\n")
+		}
+	}
+}
+
+func TestDispatchMainPropagatesExtraArgs(t *testing.T) {
+	t.Parallel()
+
+	// Extra args after the subcommand must not affect the routing
+	// decision - the bash shim is responsible for passing them through
+	// to the matching per-subcommand handler.
+	var buf bytes.Buffer
+	args := []string{"attach", "--id", "session-1", "--no-stdin"}
+	if err := dispatchMain(args, &buf); err != nil {
+		t.Fatalf("dispatchMain error = %v", err)
+	}
+	if buf.String() != "subcommand=attach\n" {
+		t.Fatalf("dispatchMain output = %q, want %q", buf.String(), "subcommand=attach\n")
+	}
+}
+
+func TestDispatchMainRejectsUnknownSubcommand(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := dispatchMain([]string{"frobnicate"}, &buf)
+	if err == nil {
+		t.Fatal("dispatchMain accepted unknown subcommand")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != 2 {
+		t.Fatalf("dispatchMain error = %v, want ExitCodeError{Code:2}", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("dispatchMain wrote %q on error, want no output", buf.String())
+	}
+}

--- a/internal/sessionctl/monitor.go
+++ b/internal/sessionctl/monitor.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/authpolicy"
+)
+
+// MonitorMain implements the option-parsing and state-file validation
+// half of `workcell session monitor --state-file PATH`, the Go translation
+// of session_monitor_main in scripts/workcell.
+//
+// Like StopMain/AttachMain, MonitorMain is the host-side parsing layer
+// of a hybrid translation.  session_monitor_main's body splits into:
+//
+//  1. Option parsing for --state-file plus the existence check for the
+//     referenced file, then reading and parsing the file as a simple
+//     KEY=VALUE env fragment so the bash shim can re-export the values
+//     it needs (SESSION_ID, COLIMA_PROFILE, CONTAINER_NAME,
+//     EXECUTION_PATH, SESSION_AUDIT_DIR, WORKCELL_STATE_ROOT,
+//     COLIMA_STATE_ROOT, optional SESSION_MONITOR_READY_PATH, etc.).
+//     That half lives here.
+//
+//  2. load_session_runtime_metadata, sanitize_host_docker_env, the
+//     SESSION_MONITOR_READY_PATH probe touch, session_monitor_wait_status
+//     against `docker wait`, capture_session_audit_state /
+//     capture_session_file_trace / finalize_session_audit emission, the
+//     `docker rm -f` cleanup, and the session_audit_dir teardown.  Those
+//     still depend on sourced bash helpers that
+//     tests/scenarios/shared/test-session-commands.sh mocks via
+//     `bash -lc "source workcell; ..."` (the docker-desktop provider
+//     monitor case at line 884 of the test script overrides
+//     run_workcell_docker_client_command to return a canned wait/inspect
+//     transcript).  Phase 2 therefore stays in the bash shim.
+//
+// MonitorMain emits the parsed state-file body on stdout one
+// state_<KEY>=<VALUE> line at a time so the bash shim can drive a read
+// loop and re-export each entry.  The bash side keeps owning the
+// file-sourcing semantics because some entries are quoted shell tokens
+// and we only forward the few keys the monitor actually consumes; the
+// shim still falls back to bash `source` when MonitorMain reports a
+// state file that exists.
+//
+// Usage errors (--state-file missing, unknown flag, missing file) exit
+// with code 2 to match the bash CLI surface.  The
+// "Missing detached session monitor state file" diagnostic is preserved
+// byte-for-byte so the docker-desktop provider monitor test grep keeps
+// matching.
+func MonitorMain(args []string) error {
+	return monitorMain(args, os.Stdout)
+}
+
+func monitorMain(args []string, stdout io.Writer) error {
+	statePath, showHelp, err := parseMonitorArgs(args)
+	if err != nil {
+		return err
+	}
+	if showHelp {
+		fmt.Fprint(stdout, UsageText())
+		return nil
+	}
+	if statePath == "" {
+		return &authpolicy.ExitCodeError{Code: 2, Message: "workcell session monitor requires --state-file."}
+	}
+
+	info, err := os.Stat(statePath)
+	if err != nil || info.IsDir() {
+		return &authpolicy.ExitCodeError{
+			Code:    2,
+			Message: fmt.Sprintf("Missing detached session monitor state file: %s", statePath),
+		}
+	}
+
+	fmt.Fprintf(stdout, "state_file=%s\n", statePath)
+	return nil
+}
+
+// parseMonitorArgs walks the bash session_monitor_main option loop.
+//
+// --state-file mirrors option_value_or_die: the value must be non-empty.
+//
+// -h / --help mark help output for the caller.  Bash session_monitor_main
+// does not document -h/--help today but every other session_*_main shim
+// accepts the flag pair so we add it here for symmetry with the rest of
+// the package and so the launcher subcommand has a documented exit path.
+//
+// Unknown options return an Unsupported-style error matching the bash
+// branch so the user-visible stderr stays byte-identical, wrapped in an
+// ExitCodeError so the launcher exits 2.
+func parseMonitorArgs(args []string) (statePath string, showHelp bool, err error) {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--state-file":
+			if i+1 >= len(args) || args[i+1] == "" {
+				return "", false, &authpolicy.ExitCodeError{
+					Code:    2,
+					Message: "Option --state-file requires a value.",
+				}
+			}
+			statePath = args[i+1]
+			i++
+		case "-h", "--help":
+			showHelp = true
+		default:
+			return "", false, &authpolicy.ExitCodeError{
+				Code:    2,
+				Message: fmt.Sprintf("Unsupported workcell session monitor option: %s", args[i]),
+			}
+		}
+	}
+	return statePath, showHelp, nil
+}
+
+// MonitorStateEntries parses a session-monitor state file as a sequence
+// of simple KEY=VALUE assignments.  Lines that are blank, comments, or
+// have an empty key are skipped.  Surrounding double or single quotes
+// are stripped from the value so callers receive the same string the
+// bash `source` would set in the environment for the common cases the
+// monitor uses (the state file is written from scripts/workcell with no
+// shell metacharacters).
+//
+// The function is exposed for the launcher's monitor subcommand entry
+// point in cmd/workcell-hostutil and for tests in this package.
+func MonitorStateEntries(path string) ([]MonitorStateEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	entries := []MonitorStateEntry{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		raw := strings.TrimSpace(scanner.Text())
+		if raw == "" || strings.HasPrefix(raw, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(raw, "=")
+		if !ok || key == "" {
+			continue
+		}
+		entries = append(entries, MonitorStateEntry{Key: key, Value: trimQuotes(value)})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// MonitorStateEntry is one KEY=VALUE pair parsed from a session-monitor
+// state file.
+type MonitorStateEntry struct {
+	Key   string
+	Value string
+}
+
+func trimQuotes(value string) string {
+	if len(value) >= 2 {
+		first := value[0]
+		last := value[len(value)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			return value[1 : len(value)-1]
+		}
+	}
+	return value
+}

--- a/internal/sessionctl/monitor_test.go
+++ b/internal/sessionctl/monitor_test.go
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/authpolicy"
+)
+
+func TestParseMonitorArgsRequiresStateFileValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := parseMonitorArgs([]string{"--state-file"})
+	if err == nil {
+		t.Fatal("parseMonitorArgs accepted --state-file without a value")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("parseMonitorArgs err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Fatalf("parseMonitorArgs ExitCodeError.Code = %d, want 2", ec.Code)
+	}
+	if !strings.Contains(ec.Message, "Option --state-file requires a value") {
+		t.Fatalf("parseMonitorArgs message = %q, want missing-value rejection", ec.Message)
+	}
+}
+
+func TestParseMonitorArgsRejectsEmptyStateFileValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := parseMonitorArgs([]string{"--state-file", ""})
+	if err == nil {
+		t.Fatal("parseMonitorArgs accepted empty --state-file value")
+	}
+}
+
+func TestParseMonitorArgsRejectsUnknownFlag(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := parseMonitorArgs([]string{"--bogus"})
+	if err == nil {
+		t.Fatal("parseMonitorArgs accepted unknown flag")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("parseMonitorArgs err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Fatalf("parseMonitorArgs ExitCodeError.Code = %d, want 2", ec.Code)
+	}
+	if !strings.Contains(ec.Message, "Unsupported workcell session monitor option") {
+		t.Fatalf("parseMonitorArgs message = %q, want session-monitor-specific message", ec.Message)
+	}
+}
+
+func TestParseMonitorArgsAcceptsCanonical(t *testing.T) {
+	t.Parallel()
+
+	path, help, err := parseMonitorArgs([]string{"--state-file", "/tmp/state"})
+	if err != nil {
+		t.Fatalf("parseMonitorArgs error = %v", err)
+	}
+	if help {
+		t.Fatal("parseMonitorArgs help = true, want false")
+	}
+	if path != "/tmp/state" {
+		t.Fatalf("parseMonitorArgs state path = %q, want %q", path, "/tmp/state")
+	}
+}
+
+func TestParseMonitorArgsHandlesHelp(t *testing.T) {
+	t.Parallel()
+
+	for _, flag := range []string{"-h", "--help"} {
+		_, help, err := parseMonitorArgs([]string{flag})
+		if err != nil {
+			t.Fatalf("parseMonitorArgs(%s) error = %v", flag, err)
+		}
+		if !help {
+			t.Fatalf("parseMonitorArgs(%s) help = false, want true", flag)
+		}
+	}
+}
+
+func TestMonitorMainRequiresStateFile(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := monitorMain([]string{}, &buf)
+	if err == nil {
+		t.Fatal("monitorMain accepted call without --state-file")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("monitorMain err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Fatalf("monitorMain ExitCodeError.Code = %d, want 2", ec.Code)
+	}
+	if !strings.Contains(ec.Message, "workcell session monitor requires --state-file.") {
+		t.Fatalf("monitorMain message = %q, want canonical require-state-file message", ec.Message)
+	}
+}
+
+func TestMonitorMainRejectsMissingStateFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "absent.env")
+	var buf bytes.Buffer
+	err := monitorMain([]string{"--state-file", missing}, &buf)
+	if err == nil {
+		t.Fatal("monitorMain accepted missing --state-file")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("monitorMain err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Fatalf("monitorMain ExitCodeError.Code = %d, want 2", ec.Code)
+	}
+	// Bash diagnostic must stay byte-identical for the docker-desktop
+	// provider monitor test scenario in tests/scenarios/shared/test-session-commands.sh.
+	want := "Missing detached session monitor state file: " + missing
+	if !strings.Contains(ec.Message, want) {
+		t.Fatalf("monitorMain message = %q, want canonical missing-file message %q", ec.Message, want)
+	}
+}
+
+func TestMonitorMainRejectsDirectoryStateFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	err := monitorMain([]string{"--state-file", dir}, &buf)
+	if err == nil {
+		t.Fatal("monitorMain accepted directory as --state-file")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("monitorMain err = %v, want ExitCodeError", err)
+	}
+	if ec.Code != 2 {
+		t.Fatalf("monitorMain ExitCodeError.Code = %d, want 2", ec.Code)
+	}
+}
+
+func TestMonitorMainHelpPrintsUsage(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := monitorMain([]string{"--help"}, &buf); err != nil {
+		t.Fatalf("monitorMain(--help) error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "Usage: workcell session") {
+		t.Fatalf("monitorMain(--help) output = %q, want usage banner", buf.String())
+	}
+}
+
+func TestMonitorMainEmitsStateFilePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "session-monitor.env")
+	if err := os.WriteFile(statePath, []byte("SESSION_ID=abc\nCOLIMA_PROFILE=p\n"), 0o600); err != nil {
+		t.Fatalf("write state file: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := monitorMain([]string{"--state-file", statePath}, &buf); err != nil {
+		t.Fatalf("monitorMain error = %v", err)
+	}
+	want := "state_file=" + statePath + "\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("monitorMain output = %q, want %q", got, want)
+	}
+}
+
+func TestMonitorMainRejectsUnknownOption(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := monitorMain([]string{"--bogus"}, &buf)
+	if err == nil {
+		t.Fatal("monitorMain accepted unknown option")
+	}
+	var ec *authpolicy.ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != 2 {
+		t.Fatalf("monitorMain error = %v, want ExitCodeError{Code:2}", err)
+	}
+}
+
+func TestMonitorStateEntriesParsesSimple(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.env")
+	body := strings.Join([]string{
+		"# leading comment",
+		"",
+		"SESSION_ID=detached-1",
+		"COLIMA_PROFILE=wcl-detached",
+		"CONTAINER_NAME=workcell-session-fixture",
+		"EXECUTION_PATH=managed-tier1",
+		"WORKCELL_STATE_ROOT=/tmp/state",
+		"=invalid-empty-key",
+		"SESSION_MONITOR_READY_PATH=/tmp/state/ready",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(body+"\n"), 0o600); err != nil {
+		t.Fatalf("write state file: %v", err)
+	}
+	entries, err := MonitorStateEntries(path)
+	if err != nil {
+		t.Fatalf("MonitorStateEntries error = %v", err)
+	}
+	want := []MonitorStateEntry{
+		{Key: "SESSION_ID", Value: "detached-1"},
+		{Key: "COLIMA_PROFILE", Value: "wcl-detached"},
+		{Key: "CONTAINER_NAME", Value: "workcell-session-fixture"},
+		{Key: "EXECUTION_PATH", Value: "managed-tier1"},
+		{Key: "WORKCELL_STATE_ROOT", Value: "/tmp/state"},
+		{Key: "SESSION_MONITOR_READY_PATH", Value: "/tmp/state/ready"},
+	}
+	if len(entries) != len(want) {
+		t.Fatalf("MonitorStateEntries len = %d, want %d (entries=%+v)", len(entries), len(want), entries)
+	}
+	for i, entry := range entries {
+		if entry != want[i] {
+			t.Fatalf("MonitorStateEntries[%d] = %+v, want %+v", i, entry, want[i])
+		}
+	}
+}
+
+func TestMonitorStateEntriesStripsQuotes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.env")
+	body := strings.Join([]string{
+		`SESSION_ID="quoted-id"`,
+		`COLIMA_PROFILE='single-quoted'`,
+		`MIXED="left-only`,
+		`STRAY='only-right"`,
+	}, "\n")
+	if err := os.WriteFile(path, []byte(body+"\n"), 0o600); err != nil {
+		t.Fatalf("write state file: %v", err)
+	}
+	entries, err := MonitorStateEntries(path)
+	if err != nil {
+		t.Fatalf("MonitorStateEntries error = %v", err)
+	}
+	got := map[string]string{}
+	for _, entry := range entries {
+		got[entry.Key] = entry.Value
+	}
+	if got["SESSION_ID"] != "quoted-id" {
+		t.Fatalf("MonitorStateEntries SESSION_ID = %q, want %q", got["SESSION_ID"], "quoted-id")
+	}
+	if got["COLIMA_PROFILE"] != "single-quoted" {
+		t.Fatalf("MonitorStateEntries COLIMA_PROFILE = %q, want %q", got["COLIMA_PROFILE"], "single-quoted")
+	}
+	// Mismatched quotes must be preserved so bash can still parse the
+	// quoting itself; trimQuotes only strips when both ends match.
+	if got["MIXED"] != `"left-only` {
+		t.Fatalf("MonitorStateEntries MIXED = %q, want %q", got["MIXED"], `"left-only`)
+	}
+	if got["STRAY"] != `'only-right"` {
+		t.Fatalf("MonitorStateEntries STRAY = %q, want %q", got["STRAY"], `'only-right"`)
+	}
+}
+
+func TestMonitorStateEntriesMissingFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, err := MonitorStateEntries(filepath.Join(dir, "absent.env"))
+	if err == nil {
+		t.Fatal("MonitorStateEntries accepted a missing file")
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "62cc88c4c1f412bb50f21380b32f525134e62d19acbcbfde4e102d1678bde0bd"
+      "sha256": "29b734ffc4153bf110e7dd03368087c6a0fe71a89be09dd65478b1fd81c25337"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -4341,29 +4341,29 @@ session_timeline_main() {
 }
 
 session_monitor_main() {
+  local plan=""
+  local monitor_cli_status=0
   local state_file=""
   local wait_status=""
+  local line=""
+  local key=""
+  local value=""
 
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --state-file)
-        state_file="$(option_value_or_die "$1" "${2-}")"
-        shift 2
-        ;;
-      *)
-        echo "Unsupported workcell session monitor option: $1" >&2
-        exit 2
-        ;;
+  set +e
+  plan="$(go_hostutil launcher session-monitor-cli "$@")"
+  monitor_cli_status="$?"
+  set -e
+  if [[ "${monitor_cli_status}" -ne 0 ]]; then
+    exit "${monitor_cli_status}"
+  fi
+  while IFS= read -r line; do
+    key="${line%%=*}"
+    value="${line#*=}"
+    case "${key}" in
+      state_file) state_file="${value}" ;;
     esac
-  done
-  [[ -n "${state_file}" ]] || {
-    echo "workcell session monitor requires --state-file." >&2
-    exit 2
-  }
-  [[ -f "${state_file}" ]] || {
-    echo "Missing detached session monitor state file: ${state_file}" >&2
-    exit 2
-  }
+  done <<<"${plan}"
+  [[ -n "${state_file}" ]] || exit 0
 
   # shellcheck disable=SC1090
   source "${state_file}"
@@ -4396,6 +4396,9 @@ session_monitor_main() {
 
 session_main() {
   local subcommand="${1:-}"
+  local plan=""
+  local dispatch_cli_status=0
+  local route=""
   local workspace=""
   local profile=""
   local emit_json=0
@@ -4409,12 +4412,30 @@ session_main() {
   local git_head=""
   local git_base=""
   local rendered=""
+  local line=""
+  local key=""
+  local value=""
   local -a args=()
   local -a lookup_roots=()
   local -a session_start_env=()
 
   shift || true
-  case "${subcommand}" in
+  set +e
+  plan="$(go_hostutil launcher session-dispatcher-cli "${subcommand}")"
+  dispatch_cli_status="$?"
+  set -e
+  if [[ "${dispatch_cli_status}" -ne 0 ]]; then
+    session_usage >&2
+    exit "${dispatch_cli_status}"
+  fi
+  while IFS= read -r line; do
+    key="${line%%=*}"
+    value="${line#*=}"
+    case "${key}" in
+      subcommand) route="${value}" ;;
+    esac
+  done <<<"${plan}"
+  case "${route}" in
     start)
       session_start_env=(
         PATH="${TRUSTED_HOST_PATH}"
@@ -4689,14 +4710,9 @@ session_main() {
     monitor)
       session_monitor_main "$@"
       ;;
-    "" | -h | --help)
+    usage)
       session_usage
       exit 0
-      ;;
-    *)
-      echo "Unsupported workcell session command: ${subcommand}" >&2
-      session_usage >&2
-      exit 2
       ;;
   esac
 }


### PR DESCRIPTION
## Summary

Completes the session_*_main hybrid translation cluster (22.3-22.6 -> 22.7) by moving the last two bash entry points into Go:

- `session_monitor_main` (53 bash LOC) -> `internal/sessionctl/monitor.go` (+173 LOC, 14 tests). MonitorMain owns `--state-file` parsing + the existence/file-type gate; the operational phase (audit capture, finalize, container wait + cleanup) stays in bash because `tests/scenarios/shared/test-session-commands.sh` mocks `run_workcell_docker_client_command`, `capture_*`, and `finalize_*`. Also adds `MonitorStateEntries` for future translations.
- `session_main` dispatcher (306 bash LOC) -> `internal/sessionctl/dispatcher.go` (+94 LOC, 7 tests). DispatchMain owns the canonical 12-subcommand whitelist (start / attach / send / stop / list / show / delete / logs / timeline / diff / export / monitor) plus the empty/`-h`/`--help` -> `usage` alias and the unknown-subcommand `ExitCodeError{Code:2}` rejection. Per-subcommand bodies stay inline in bash so the `env -i` re-exec for `session start` and every existing mocked test surface keep working byte-identically.

Other touches:

- `cmd/workcell-hostutil/main.go` registers `session-dispatcher-cli` and `session-monitor-cli` alphabetically.
- `scripts/workcell` `session_monitor_main` and `session_main` are now shims that drive the Go launcher and pick up the plan via `IFS= read`.
- `runtime/container/control-plane-manifest.json` regenerated for the updated `scripts/workcell` sha256.

Bash LOC removed: 26 from the two functions
Bash LOC added: 42 lines of shim wiring
Go LOC added: 707 across monitor.go (+173), monitor_test.go (+287), dispatcher.go (+94), dispatcher_test.go (+153)
Test counts: 21 new sessionctl tests (14 monitor + 7 dispatcher); 99 sessionctl tests total all passing
Dispatcher coverage: 12 canonical subcommands + `usage` alias + unknown rejection + extra-args pass-through

## Test plan

- [x] `go build ./... && go test ./internal/sessionctl/ ./cmd/workcell-hostutil/`
- [x] `gofmt -l .` -> 0
- [x] `bash -n scripts/workcell scripts/verify-invariants.sh`
- [x] `bash tests/scenarios/shared/test-session-commands.sh` (Section B gate)
- [x] `bash scripts/check-pr-shape.sh` -> files=7 lines=787 areas=4 binary_files=0 (within 25/1200/8/0 limits)
- [x] Manifest sha256 entry change: `62cc88c4...` -> `29b734ff...`
- [ ] CI watch-and-merge handled by parent