### PR TITLE
^B Fix sethify blockers + cliexit foundation (fix-1a)

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/omkhar/workcell/internal/authpolicy"
 	"github.com/omkhar/workcell/internal/authresolve"
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/host/hoststate"
 	"github.com/omkhar/workcell/internal/host/launcher"
 	"github.com/omkhar/workcell/internal/host/release"
@@ -27,25 +28,16 @@ import (
 
 func main() {
 	if err := run(os.Args[1:]); err != nil {
-		// Both authpolicy and publishpr translations carry their bash
-		// exit-code contract through a typed ExitCodeError. The two
-		// types are intentionally distinct because their messages also
-		// differ (auth/policy v. publish-pr), but the dispatch here
-		// stays uniform: surface the embedded message (if any) on
-		// stderr and exit with the typed Code.
-		var authEC *authpolicy.ExitCodeError
-		if errors.As(err, &authEC) {
-			if msg := authEC.Error(); msg != "" {
+		// All Go CLI translations (authpolicy, publishpr, sessionctl,
+		// etc.) funnel their bash exit-code contract through the
+		// canonical cliexit.ExitCodeError so a single errors.As is
+		// enough to recover {Code, Message}.
+		var ec *cliexit.ExitCodeError
+		if errors.As(err, &ec) {
+			if msg := ec.Error(); msg != "" {
 				fmt.Fprintln(os.Stderr, msg)
 			}
-			os.Exit(authEC.Code)
-		}
-		var publishEC *publishpr.ExitCodeError
-		if errors.As(err, &publishEC) {
-			if msg := publishEC.Error(); msg != "" {
-				fmt.Fprintln(os.Stderr, msg)
-			}
-			os.Exit(publishEC.Code)
+			os.Exit(ec.Code)
 		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -85,7 +77,7 @@ func runHostutilPolicy(args []string) error {
 	if code == 0 {
 		return nil
 	}
-	return &authpolicy.ExitCodeError{Code: code, Message: ""}
+	return &cliexit.ExitCodeError{Code: code, Message: ""}
 }
 
 // runHostutilResolveCredentials dispatches the absorbed
@@ -98,7 +90,7 @@ func runHostutilResolveCredentials(args []string) error {
 	if code == 0 {
 		return nil
 	}
-	return &authpolicy.ExitCodeError{Code: code, Message: ""}
+	return &cliexit.ExitCodeError{Code: code, Message: ""}
 }
 
 // runHostutilPTYTranscript dispatches the absorbed
@@ -110,7 +102,7 @@ func runHostutilPTYTranscript(args []string) error {
 	if code == 0 {
 		return nil
 	}
-	return &authpolicy.ExitCodeError{Code: code, Message: ""}
+	return &cliexit.ExitCodeError{Code: code, Message: ""}
 }
 
 func runPath(args []string) error {

--- a/internal/authpolicy/auth_main.go
+++ b/internal/authpolicy/auth_main.go
@@ -10,26 +10,16 @@ import (
 	"os"
 	"strings"
 
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/host/launcher"
 )
 
-// ExitCodeError carries a non-zero exit code that the workcell-hostutil
-// main wrapper should surface via os.Exit. AuthMain returns this so the
-// bash shim sees the original auth_main exit-code contract (2 for usage
-// failures, 1 for runtime failures).
-type ExitCodeError struct {
-	Code    int
-	Message string
-}
-
-func (e *ExitCodeError) Error() string { return e.Message }
-
 func exit2(format string, args ...any) error {
-	return &ExitCodeError{Code: 2, Message: fmt.Sprintf(format, args...)}
+	return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf(format, args...)}
 }
 
 func exit1(format string, args ...any) error {
-	return &ExitCodeError{Code: 1, Message: fmt.Sprintf(format, args...)}
+	return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf(format, args...)}
 }
 
 // AuthMain implements `workcell auth <subcommand>`, the Go translation
@@ -61,7 +51,7 @@ func authMain(args []string, stdout, stderr io.Writer) error {
 		return nil
 	case "":
 		fmt.Fprint(stderr, AuthUsageText())
-		return &ExitCodeError{Code: 2, Message: ""}
+		return &cliexit.ExitCodeError{Code: 2, Message: ""}
 	}
 	rest = rest[1:]
 
@@ -80,7 +70,7 @@ func authMain(args []string, stdout, stderr io.Writer) error {
 	default:
 		fmt.Fprintf(stderr, "Unsupported workcell auth command: %s\n", subcommand)
 		fmt.Fprint(stderr, AuthUsageText())
-		return &ExitCodeError{Code: 2, Message: ""}
+		return &cliexit.ExitCodeError{Code: 2, Message: ""}
 	}
 }
 
@@ -153,7 +143,7 @@ func authInit(args []string, base, policyPath, managedRoot string, stdout, stder
 		default:
 			fmt.Fprintf(stderr, "Unsupported workcell auth init option: %s\n", args[i])
 			fmt.Fprint(stderr, AuthUsageText())
-			return &ExitCodeError{Code: 2, Message: ""}
+			return &cliexit.ExitCodeError{Code: 2, Message: ""}
 		}
 	}
 	resolvedPolicy, err := resolveHostPath(policyPath, base)
@@ -231,7 +221,7 @@ func authSet(args []string, base, policyPath, managedRoot string, stdout, stderr
 		default:
 			fmt.Fprintf(stderr, "Unsupported workcell auth set option: %s\n", args[i])
 			fmt.Fprint(stderr, AuthUsageText())
-			return &ExitCodeError{Code: 2, Message: ""}
+			return &cliexit.ExitCodeError{Code: 2, Message: ""}
 		}
 	}
 	if agent == "" {
@@ -304,7 +294,7 @@ func authUnset(args []string, base, policyPath, managedRoot string, stdout, stde
 		default:
 			fmt.Fprintf(stderr, "Unsupported workcell auth unset option: %s\n", args[i])
 			fmt.Fprint(stderr, AuthUsageText())
-			return &ExitCodeError{Code: 2, Message: ""}
+			return &cliexit.ExitCodeError{Code: 2, Message: ""}
 		}
 	}
 	if credential == "" {
@@ -368,7 +358,7 @@ func authStatus(args []string, base, policyPath string, stdout, stderr io.Writer
 		default:
 			fmt.Fprintf(stderr, "Unsupported workcell auth status option: %s\n", args[i])
 			fmt.Fprint(stderr, AuthUsageText())
-			return &ExitCodeError{Code: 2, Message: ""}
+			return &cliexit.ExitCodeError{Code: 2, Message: ""}
 		}
 	}
 	resolvedPolicy, err := resolveHostPath(policyPath, base)
@@ -417,7 +407,7 @@ func runManagePolicy(args []string, stdout, stderr io.Writer) error {
 	if code == 0 {
 		return nil
 	}
-	return &ExitCodeError{Code: code, Message: ""}
+	return &cliexit.ExitCodeError{Code: code, Message: ""}
 }
 
 // authMainBuffer is used by tests that need stdout captured separately

--- a/internal/authpolicy/auth_main_test.go
+++ b/internal/authpolicy/auth_main_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 // runAuthMain wraps authMain to capture stdout/stderr separately for
@@ -18,7 +20,7 @@ func runAuthMain(args []string) (stdout string, stderr string, code int, errStr 
 	err := authMain(args, &out, &errBuf)
 	code = 0
 	if err != nil {
-		var ec *ExitCodeError
+		var ec *cliexit.ExitCodeError
 		if errors.As(err, &ec) {
 			code = ec.Code
 		} else {
@@ -254,11 +256,11 @@ func TestAuthMainInitEndToEnd(t *testing.T) {
 
 func TestAuthMainExitCodeErrorImplementsError(t *testing.T) {
 	t.Parallel()
-	err := &ExitCodeError{Code: 2, Message: "hello"}
+	err := &cliexit.ExitCodeError{Code: 2, Message: "hello"}
 	if err.Error() != "hello" {
 		t.Fatalf("Error() = %q", err.Error())
 	}
-	var asErr *ExitCodeError
+	var asErr *cliexit.ExitCodeError
 	if !errors.As(error(err), &asErr) {
 		t.Fatal("errors.As failed to unwrap ExitCodeError")
 	}

--- a/internal/cliexit/exit_code_error.go
+++ b/internal/cliexit/exit_code_error.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package cliexit is the canonical exit-code error type used by all
+// workcell Go CLI translations. Each translated bash main returns
+// ExitCodeError when the wrapper main() should propagate a specific
+// exit code; cmd/workcell-hostutil/main.go (and the sibling umbrella
+// binaries) match it with errors.As and propagate the Code.
+package cliexit
+
+import "errors"
+
+// ExitCodeError carries the bash exit-code contract through to the
+// process wrapper.  Code is the os.Exit code to emit; Message, when
+// non-empty, is written to stderr.
+type ExitCodeError struct {
+	Code    int
+	Message string
+}
+
+func (e *ExitCodeError) Error() string { return e.Message }
+
+// IsExitCodeError reports whether err is or wraps an *ExitCodeError.
+// If so, the returned non-nil pointer is the concrete value.
+func IsExitCodeError(err error) (*ExitCodeError, bool) {
+	var ec *ExitCodeError
+	if errors.As(err, &ec) {
+		return ec, true
+	}
+	return nil, false
+}

--- a/internal/cliexit/exit_code_error_test.go
+++ b/internal/cliexit/exit_code_error_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package cliexit
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestExitCodeErrorErrorReturnsMessage(t *testing.T) {
+	err := &ExitCodeError{Code: 2, Message: "boom"}
+	if got := err.Error(); got != "boom" {
+		t.Errorf("Error() = %q, want %q", got, "boom")
+	}
+}
+
+func TestIsExitCodeErrorMatchesDirect(t *testing.T) {
+	want := &ExitCodeError{Code: 7, Message: "x"}
+	got, ok := IsExitCodeError(want)
+	if !ok {
+		t.Fatalf("IsExitCodeError returned ok=false for direct value")
+	}
+	if got != want {
+		t.Errorf("IsExitCodeError pointer = %v, want %v", got, want)
+	}
+}
+
+func TestIsExitCodeErrorUnwrapsWrapped(t *testing.T) {
+	inner := &ExitCodeError{Code: 3, Message: "inner"}
+	wrapped := fmt.Errorf("outer: %w", inner)
+	got, ok := IsExitCodeError(wrapped)
+	if !ok {
+		t.Fatalf("IsExitCodeError returned ok=false for wrapped value")
+	}
+	if got.Code != 3 {
+		t.Errorf("got.Code = %d, want 3", got.Code)
+	}
+}
+
+func TestIsExitCodeErrorRejectsOtherErrors(t *testing.T) {
+	got, ok := IsExitCodeError(errors.New("plain"))
+	if ok || got != nil {
+		t.Fatalf("IsExitCodeError matched a plain error: got=%v ok=%v", got, ok)
+	}
+}

--- a/internal/injection/prepare_bundle.go
+++ b/internal/injection/prepare_bundle.go
@@ -143,15 +143,18 @@ func PrepareBundle(opts PrepareBundleOptions) (*PrepareBundleResult, error) {
 	// Stage synthetic probe inputs (test-only) before invoking the resolver,
 	// matching the env-var contract the bash helper installed for the child
 	// process.  The vars are restored unconditionally so concurrent callers
-	// in the same Go process do not leak state.
+	// in the same Go process do not leak state.  Defer the restore BEFORE
+	// checking err: installSyntheticProbeEnv may fail after it has already
+	// pointed HOME at the synthetic codex home (e.g. the synthetic Claude
+	// export branch fails), and we still owe the caller a clean HOME.
 	restoreEnv, err := installSyntheticProbeEnv(bundleRoot,
 		opts.SelfStagingProbeSyntheticCodexAuth,
 		opts.SelfStagingProbeSyntheticClaudeExport,
 	)
+	defer restoreEnv()
 	if err != nil {
 		return nil, err
 	}
-	defer restoreEnv()
 
 	resolverArgs := []string{
 		"--policy", canonicalPolicy,
@@ -220,10 +223,18 @@ func PrepareBundle(opts PrepareBundleOptions) (*PrepareBundleResult, error) {
 
 // installSyntheticProbeEnv mirrors the bash branches that stage synthetic
 // credential exports for the self-staging probes.  It returns a restore
-// callback the caller MUST defer; otherwise the calling Go process inherits
-// the test-only env vars.
+// callback the caller MUST defer BEFORE checking the error; otherwise the
+// calling Go process inherits the test-only env vars (specifically HOME)
+// on partial failure.  The returned callback is always non-nil and always
+// safe to call exactly once.
+//
+// Failure model: every os.Setenv/os.MkdirAll/writeFile0600 call may
+// happen after we've already pointed HOME at the synthetic codex home,
+// so the partial-state cleanup MUST always be the canonical restore
+// callback (not the no-op `func(){}` shadow that an earlier draft of
+// this helper used).  See prepare_bundle_test.go::TestPrepareBundleRestoresHOMEOnPartialFailure
+// for the regression that motivated this contract.
 func installSyntheticProbeEnv(bundleRoot string, syntheticCodex, syntheticClaude bool) (func(), error) {
-	restore := func() {}
 	originalHome, hadHome := os.LookupEnv("HOME")
 	originalExport, hadExport := os.LookupEnv("WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE")
 
@@ -242,22 +253,22 @@ func installSyntheticProbeEnv(bundleRoot string, syntheticCodex, syntheticClaude
 		syntheticCodexHome := filepath.Join(bundleRoot, "self-staging-probe-codex-home")
 		syntheticCodexAuth := filepath.Join(syntheticCodexHome, ".codex", "auth.json")
 		if err := os.MkdirAll(filepath.Dir(syntheticCodexAuth), 0o700); err != nil {
-			return restore, err
+			return cleanup, err
 		}
 		if err := writeFile0600(syntheticCodexAuth, []byte("{\"token\":\"codex\"}\n")); err != nil {
-			return restore, err
+			return cleanup, err
 		}
 		if err := os.Setenv("HOME", syntheticCodexHome); err != nil {
-			return restore, err
+			return cleanup, err
 		}
 	}
 	if syntheticClaude {
 		syntheticClaudeExport := filepath.Join(bundleRoot, "self-staging-probe-claude-export.json")
 		if err := writeFile0600(syntheticClaudeExport, []byte("{\"token\":\"claude\"}\n")); err != nil {
-			return restore, err
+			return cleanup, err
 		}
 		if err := os.Setenv("WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE", syntheticClaudeExport); err != nil {
-			return restore, err
+			return cleanup, err
 		}
 	}
 	return cleanup, nil

--- a/internal/injection/prepare_bundle_test.go
+++ b/internal/injection/prepare_bundle_test.go
@@ -123,3 +123,48 @@ func TestFormatBundleResultForShellNilSafe(t *testing.T) {
 		t.Fatalf("expected empty string for nil result, got %q", got)
 	}
 }
+
+// TestInstallSyntheticProbeEnvRestoresHomeOnPartialFailure pins the
+// HOME-leak fix.  When the synthetic Claude branch fails after the
+// synthetic Codex branch has already pointed HOME at the bundle's
+// codex-home, the returned cleanup must restore the caller's HOME.
+// The previous code returned a no-op shadow on the error path and
+// the calling Go process inherited the test-only HOME.
+func TestInstallSyntheticProbeEnvRestoresHomeOnPartialFailure(t *testing.T) {
+	// t.Setenv saves and restores HOME at the testing harness level so a
+	// regression in this test cannot leak HOME beyond the test boundary.
+	originalHome := "/tmp/installSyntheticProbeEnv-original"
+	t.Setenv("HOME", originalHome)
+
+	bundleRoot := t.TempDir()
+	// Make the synthetic Claude export path collide with an existing
+	// directory at the same name so writeFile0600's os.OpenFile call
+	// fails: writeFile0600 first MkdirAll's the parent (the bundle root,
+	// already a directory), then OpenFile the leaf, which here is a
+	// pre-created directory so OpenFile returns EISDIR.
+	syntheticClaudePath := filepath.Join(bundleRoot, "self-staging-probe-claude-export.json")
+	if err := os.MkdirAll(syntheticClaudePath, 0o700); err != nil {
+		t.Fatalf("seed collision directory: %v", err)
+	}
+
+	cleanup, err := installSyntheticProbeEnv(bundleRoot, true, true)
+	if cleanup == nil {
+		t.Fatal("installSyntheticProbeEnv returned nil cleanup; callers cannot defer it")
+	}
+	defer cleanup()
+	if err == nil {
+		t.Fatal("installSyntheticProbeEnv did not surface the synthetic-claude write failure")
+	}
+	// Before defer fires, HOME is still pointing at the synthetic codex
+	// home — confirm so we can be sure the post-cleanup assertion is
+	// meaningful.
+	if got := os.Getenv("HOME"); got == originalHome {
+		t.Fatalf("HOME was unexpectedly already restored before cleanup ran: got %q", got)
+	}
+	// Now run cleanup explicitly so we can assert restoration; defer
+	// still runs after the test but is a safety net.
+	cleanup()
+	if got := os.Getenv("HOME"); got != originalHome {
+		t.Fatalf("installSyntheticProbeEnv leaked HOME on partial failure: got %q, want %q", got, originalHome)
+	}
+}

--- a/internal/injection/prepare_direct_mounts.go
+++ b/internal/injection/prepare_direct_mounts.go
@@ -75,15 +75,40 @@ func StageDirectMounts(bundleRoot, mountSpecPath string) ([]string, error) {
 // validateDirectMount mirrors the bash entry validation: source must be an
 // absolute path that points at a regular file or directory, and the mount
 // path must be inside /opt/workcell/host-inputs/.
+//
+// Both inputs are normalised via filepath.Clean before the prefix check so
+// a `..` segment cannot escape the managed host-input root.  Concretely,
+// `strings.HasPrefix("/opt/workcell/host-inputs/../etc/foo", "/opt/workcell/host-inputs/")`
+// returns true on raw strings — filepath.Clean collapses the `..` first so
+// the resulting `/opt/etc/foo` fails the prefix test, matching the bash
+// invariant that the container only sees content explicitly staged under
+// the host-inputs root.
+//
+// The prefix is re-checked against `cleaned + "/"` to handle the edge case
+// where the cleaned mount path is exactly the host-input root (no trailing
+// slash); HasPrefix on the bare path would let an attacker mount the root
+// itself, which has no defensible meaning for a per-entry direct mount.
 func validateDirectMount(hostSource, mountPath string) error {
 	if !filepath.IsAbs(hostSource) {
 		return fmt.Errorf("Direct input source is missing, not absolute, or not a regular file/directory: %s", hostSource)
 	}
-	info, err := os.Stat(hostSource)
+	cleanedSource := filepath.Clean(hostSource)
+	if !filepath.IsAbs(cleanedSource) {
+		return fmt.Errorf("Direct input source is missing, not absolute, or not a regular file/directory: %s", hostSource)
+	}
+	info, err := os.Stat(cleanedSource)
 	if err != nil || !(info.Mode().IsRegular() || info.IsDir()) {
 		return fmt.Errorf("Direct input source is missing, not absolute, or not a regular file/directory: %s", hostSource)
 	}
-	if !strings.HasPrefix(mountPath, hostInputMountPrefix) {
+	// filepath.Clean strips trailing slashes, so the cleaned form of a
+	// legal entry is `/opt/workcell/host-inputs/<leaf>`.  Checking the
+	// cleaned path directly against the prefix (which still has a
+	// trailing slash) rejects both `/opt/workcell/host-inputs/../etc/foo`
+	// (cleans to `/opt/etc/foo`) and the bare root
+	// `/opt/workcell/host-inputs` (no trailing component) — both of
+	// which the old raw-string HasPrefix accepted.
+	cleanedMount := filepath.Clean(mountPath)
+	if !strings.HasPrefix(cleanedMount, hostInputMountPrefix) {
 		return fmt.Errorf("Direct input mount path is outside the managed host-input root: %s", mountPath)
 	}
 	return nil

--- a/internal/injection/prepare_direct_mounts_test.go
+++ b/internal/injection/prepare_direct_mounts_test.go
@@ -87,6 +87,35 @@ func TestStageDirectMountsRejectsMountPathOutsideHostInputs(t *testing.T) {
 	}
 }
 
+// TestStageDirectMountsRejectsTraversalOutOfHostInputs pins the
+// filepath.Clean guard: a `..` segment in the mount path must not let
+// an attacker escape the managed host-input root.  Without the Clean
+// normalisation, strings.HasPrefix("/opt/workcell/host-inputs/../etc/foo",
+// "/opt/workcell/host-inputs/") returns true and the mount would be
+// staged into the container at `/opt/etc/foo`.
+func TestStageDirectMountsRejectsTraversalOutOfHostInputs(t *testing.T) {
+	bundleRoot := t.TempDir()
+	sourceFile := filepath.Join(bundleRoot, "source.txt")
+	if err := os.WriteFile(sourceFile, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	for _, mount := range []string{
+		"/opt/workcell/host-inputs/../etc/foo",
+		"/opt/workcell/host-inputs",          // exact root, no trailing slash
+		"/opt/workcell/host-inputs/./../etc", // mixed `.` and `..`
+		"/opt/workcell/host-inputs/.",        // dot-only suffix collapses to the root
+	} {
+		specPath := filepath.Join(bundleRoot, "spec.json")
+		writeMountSpec(t, specPath, []map[string]any{
+			{"source": sourceFile, "mount_path": mount},
+		})
+		_, err := StageDirectMounts(bundleRoot, specPath)
+		if err == nil || !strings.Contains(err.Error(), "outside the managed host-input root") {
+			t.Fatalf("expected outside-host-input error for mount=%q, got %v", mount, err)
+		}
+	}
+}
+
 func TestStageDirectMountsStagesFileAndReturnsDockerArgs(t *testing.T) {
 	bundleRoot := t.TempDir()
 	sourceFile := filepath.Join(bundleRoot, "src", "secret.json")

--- a/internal/publishpr/host_exec.go
+++ b/internal/publishpr/host_exec.go
@@ -11,6 +11,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 // BashContext carries the scripts/workcell publish_pr_main globals
@@ -109,7 +111,7 @@ func ResolveHostTool(ctx *BashContext, name string, required bool, candidates []
 		}
 	}
 	if required {
-		return "", &ExitCodeError{Code: 1, Message: fmt.Sprintf("Missing trusted host tool: %s", name)}
+		return "", &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("Missing trusted host tool: %s", name)}
 	}
 	return "", nil
 }
@@ -160,14 +162,14 @@ func lookPathIn(trustedPath, name string) string {
 func ResolveExistingExecutableOrDie(ctx *BashContext, rawPath, label string) (string, error) {
 	info, err := os.Stat(rawPath)
 	if err != nil || info.IsDir() {
-		return "", &ExitCodeError{Code: 2, Message: fmt.Sprintf("%s file does not exist: %s", label, rawPath)}
+		return "", &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("%s file does not exist: %s", label, rawPath)}
 	}
 	if info.Mode().Perm()&0o111 == 0 {
-		return "", &ExitCodeError{Code: 2, Message: fmt.Sprintf("%s file is not executable: %s", label, rawPath)}
+		return "", &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("%s file is not executable: %s", label, rawPath)}
 	}
 	canonical := CanonicalizeHostToolPath(rawPath)
 	if canonical == "" || !IsTrustedHostToolPath(rawPath, ctx) || !IsTrustedHostToolPath(canonical, ctx) {
-		return "", &ExitCodeError{Code: 2, Message: fmt.Sprintf("%s must point to a trusted host executable path: %s", label, rawPath)}
+		return "", &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("%s must point to a trusted host executable path: %s", label, rawPath)}
 	}
 	return canonical, nil
 }
@@ -287,7 +289,7 @@ func RunPublishHostCommandInDir(dir string, env *PublishEnv, args []string, stdi
 		env.Home = "/"
 	}
 	if !isDir(dir) {
-		return &ExitCodeError{Code: 2, Message: fmt.Sprintf("Missing host working directory: %s", dir)}
+		return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("Missing host working directory: %s", dir)}
 	}
 	envv := []string{
 		"PATH=" + env.Path,
@@ -308,7 +310,7 @@ func RunPublishHostCommandInDir(dir string, env *PublishEnv, args []string, stdi
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			return &ExitCodeError{Code: exitErr.ExitCode()}
+			return &cliexit.ExitCodeError{Code: exitErr.ExitCode()}
 		}
 		return err
 	}
@@ -358,10 +360,10 @@ func resolveExistingDirectoryOrDie(ctx *BashContext, rawPath string) (string, er
 	}
 	info, err := os.Stat(resolved)
 	if err != nil {
-		return "", &ExitCodeError{Code: 2, Message: fmt.Sprintf("Workspace path does not exist: %s\nResolve it to an existing directory, then rerun with --workspace %s", rawPath, resolved)}
+		return "", &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("Workspace path does not exist: %s\nResolve it to an existing directory, then rerun with --workspace %s", rawPath, resolved)}
 	}
 	if !info.IsDir() {
-		return "", &ExitCodeError{Code: 2, Message: fmt.Sprintf("Workspace path is not a directory: %s", resolved)}
+		return "", &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("Workspace path is not a directory: %s", resolved)}
 	}
 	return resolved, nil
 }
@@ -378,7 +380,7 @@ func resolveExistingFileOrDie(ctx *BashContext, rawPath, label string) (string, 
 	}
 	info, err := os.Stat(resolved)
 	if err != nil || info.IsDir() {
-		return "", &ExitCodeError{Code: 2, Message: fmt.Sprintf("%s file does not exist: %s", label, rawPath)}
+		return "", &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("%s file does not exist: %s", label, rawPath)}
 	}
 	return resolved, nil
 }

--- a/internal/publishpr/publish_pr_cli.go
+++ b/internal/publishpr/publish_pr_cli.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 // PublishPRMain is the in-process entry point invoked by the launcher
@@ -80,10 +82,10 @@ func PublishPRMain(args []string, stdin io.Reader, stdout, stderr io.Writer) err
 	}
 
 	if !workspaceIsGitWorkTree(ctx, resolvedWorkspace) {
-		return &ExitCodeError{Code: 2, Message: fmt.Sprintf("publish-pr requires a git worktree: %s", resolvedWorkspace)}
+		return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("publish-pr requires a git worktree: %s", resolvedWorkspace)}
 	}
 	if !hasRemoteOrigin(ctx, resolvedWorkspace) {
-		return &ExitCodeError{Code: 2, Message: fmt.Sprintf("publish-pr requires an origin remote in %s.", resolvedWorkspace)}
+		return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("publish-pr requires an origin remote in %s.", resolvedWorkspace)}
 	}
 
 	for _, line := range preflight.LowerAssuranceNotice {
@@ -106,7 +108,7 @@ func PublishPRMain(args []string, stdin io.Reader, stdout, stderr io.Writer) err
 			if opts.Snapshot != "worktree" {
 				missing = "staged"
 			}
-			return &ExitCodeError{Code: 2, Message: fmt.Sprintf("publish-pr found no %s changes to publish in %s.", missing, resolvedWorkspace)}
+			return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("publish-pr found no %s changes to publish in %s.", missing, resolvedWorkspace)}
 		}
 	}
 
@@ -198,7 +200,7 @@ func PublishPRMain(args []string, stdin io.Reader, stdout, stderr io.Writer) err
 	}
 	if publishExistingCommits == 1 {
 		if hasWorktreeChanges(ctx, resolvedWorkspace) {
-			return &ExitCodeError{Code: 2, Message: fmt.Sprintf("publish-pr existing-branch mode requires a clean worktree in %s.", resolvedWorkspace)}
+			return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("publish-pr existing-branch mode requires a clean worktree in %s.", resolvedWorkspace)}
 		}
 	} else {
 		if opts.Snapshot == "worktree" {
@@ -207,7 +209,7 @@ func PublishPRMain(args []string, stdin io.Reader, stdout, stderr io.Writer) err
 			}
 		}
 		if !hasStagedChanges(ctx, resolvedWorkspace) {
-			return &ExitCodeError{Code: 2, Message: fmt.Sprintf("publish-pr found no staged changes to commit in %s.", resolvedWorkspace)}
+			return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("publish-pr found no staged changes to commit in %s.", resolvedWorkspace)}
 		}
 		if err := run(commitCmd, nil); err != nil {
 			return err
@@ -257,16 +259,16 @@ func resolveOrStageCommitMessage(ctx *BashContext, opts *Options, preflight *Pre
 	}
 	tmp, mkErr := os.CreateTemp(tmpDir, "workcell-publish-commit.*")
 	if mkErr != nil {
-		return "", noop, &ExitCodeError{Code: 1, Message: fmt.Sprintf("publish-pr could not allocate a commit-message temp file: %v", mkErr)}
+		return "", noop, &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("publish-pr could not allocate a commit-message temp file: %v", mkErr)}
 	}
 	if _, wErr := tmp.WriteString(preflight.CommitMessageText); wErr != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmp.Name())
-		return "", noop, &ExitCodeError{Code: 1, Message: fmt.Sprintf("publish-pr could not write commit message: %v", wErr)}
+		return "", noop, &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("publish-pr could not write commit message: %v", wErr)}
 	}
 	if cErr := tmp.Close(); cErr != nil {
 		_ = os.Remove(tmp.Name())
-		return "", noop, &ExitCodeError{Code: 1, Message: fmt.Sprintf("publish-pr could not close commit message temp file: %v", cErr)}
+		return "", noop, &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("publish-pr could not close commit message temp file: %v", cErr)}
 	}
 	_ = os.Chmod(tmp.Name(), 0o600)
 	name := tmp.Name()

--- a/internal/publishpr/publish_pr_main.go
+++ b/internal/publishpr/publish_pr_main.go
@@ -4,28 +4,23 @@
 package publishpr
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
-// ExitCodeError carries a non-zero exit code that the workcell-hostutil
-// main wrapper surfaces via os.Exit. The bash publish_pr_main exits 2
-// for usage / validation failures and 1 for runtime failures; the Go
-// translation preserves that contract through this error type so a
-// future bash shim can recover the exit code byte-identically the way
-// the auth_main translation does.
-type ExitCodeError struct {
-	Code    int
-	Message string
-}
-
-func (e *ExitCodeError) Error() string { return e.Message }
+// ExitCodeError is kept as a package-local type alias for cliexit.ExitCodeError
+// so existing publishpr-internal test code that references the local name
+// continues to compile. Production code should reference cliexit.ExitCodeError
+// directly; this alias is a compatibility shim slated for removal in the
+// follow-up sessionctl/publishpr type-sweep.
+type ExitCodeError = cliexit.ExitCodeError
 
 func exit2(format string, args ...any) error {
-	return &ExitCodeError{Code: 2, Message: fmt.Sprintf(format, args...)}
+	return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf(format, args...)}
 }
 
 // Options carries the parsed flag set for `workcell publish-pr`.
@@ -383,14 +378,9 @@ func WriteUsage(w io.Writer) {
 	fmt.Fprint(w, UsageText())
 }
 
-// IsExitCodeError reports whether err is an *ExitCodeError. Callers in
-// cmd/workcell-hostutil/main.go use errors.As to extract the Code so
-// the bash shim contract survives; this helper keeps that lookup
-// readable.
-func IsExitCodeError(err error) (*ExitCodeError, bool) {
-	var ec *ExitCodeError
-	if errors.As(err, &ec) {
-		return ec, true
-	}
-	return nil, false
+// IsExitCodeError reports whether err is a *cliexit.ExitCodeError. It
+// forwards to cliexit.IsExitCodeError and is preserved here for source
+// compatibility with the existing publishpr callers and tests.
+func IsExitCodeError(err error) (*cliexit.ExitCodeError, bool) {
+	return cliexit.IsExitCodeError(err)
 }

--- a/internal/sessionctl/attach.go
+++ b/internal/sessionctl/attach.go
@@ -4,11 +4,11 @@
 package sessionctl
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/host/sessions"
 )
 
@@ -43,21 +43,27 @@ import (
 // --root=PATH args are consumed via consumeRootArgs because go_hostutil
 // scrubs WORKCELL_STATE_ROOT/COLIMA_STATE_ROOT from the environment.
 func AttachMain(args []string) error {
-	return attachMain(args, os.Stdout)
+	return attachMain(args, os.Stdout, os.Stderr)
 }
 
-func attachMain(args []string, stdout io.Writer) error {
+func attachMain(args []string, stdout, stderr io.Writer) error {
 	roots, rest := consumeRootArgs(args)
 	sessionID, noStdin, showHelp, err := parseAttachArgs(rest)
 	if err != nil {
 		return err
 	}
 	if showHelp {
-		fmt.Fprint(stdout, UsageText())
+		// Usage banner goes to stderr so the bash shim, which captures
+		// stdout into `$plan`, surfaces it to the user instead of
+		// swallowing it.
+		fmt.Fprint(stderr, UsageText())
 		return nil
 	}
 	if sessionID == "" {
-		return errors.New("workcell session attach requires --id.")
+		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session attach requires --id."}
+	}
+	if err := rejectControlChars("session attach", "--id", sessionID); err != nil {
+		return err
 	}
 
 	if len(roots) == 0 {
@@ -72,7 +78,7 @@ func attachMain(args []string, stdout io.Writer) error {
 		return fmt.Errorf("session attach record is missing a profile: %s", sessionID)
 	}
 	if !sessionIsDetached(record) {
-		return fmt.Errorf("session attach only works for detached sessions started with 'workcell session start': %s\nUse 'workcell session list' to check the control column; attached records are not stoppable.", sessionID)
+		return fmt.Errorf("session attach only works for detached sessions started with 'workcell session start': %s\nUse 'workcell session list' to check the control column; attached records are not attachable.", sessionID)
 	}
 	if record.ContainerName == "" {
 		return fmt.Errorf("session attach record is missing a container name: %s", sessionID)
@@ -93,17 +99,18 @@ func parseAttachArgs(args []string) (sessionID string, noStdin, showHelp bool, e
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--id":
-			if i+1 >= len(args) || args[i+1] == "" {
-				return "", false, false, fmt.Errorf("--id requires a non-empty value")
+			v, ni, perr := optionValueOrError(args, i, "--id")
+			if perr != nil {
+				return "", false, false, perr
 			}
-			sessionID = args[i+1]
-			i++
+			sessionID = v
+			i = ni
 		case "--no-stdin":
 			noStdin = true
 		case "-h", "--help":
 			showHelp = true
 		default:
-			return "", false, false, fmt.Errorf("Unsupported workcell session attach option: %s", args[i])
+			return "", false, false, unsupportedOption("session attach", args[i])
 		}
 	}
 	return sessionID, noStdin, showHelp, nil

--- a/internal/sessionctl/attach_test.go
+++ b/internal/sessionctl/attach_test.go
@@ -5,6 +5,7 @@ package sessionctl
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,8 +19,8 @@ func TestParseAttachArgsRequiresIDValue(t *testing.T) {
 	if err == nil {
 		t.Fatal("parseAttachArgs accepted --id without a value")
 	}
-	if !strings.Contains(err.Error(), "non-empty") {
-		t.Fatalf("parseAttachArgs error = %v, want non-empty rejection", err)
+	if !strings.Contains(err.Error(), "Option --id requires a value.") {
+		t.Fatalf("parseAttachArgs error = %v, want canonical require-value message", err)
 	}
 }
 
@@ -98,7 +99,7 @@ func TestAttachMainRequiresID(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := attachMain([]string{}, &buf)
+	err := attachMain([]string{}, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("attachMain accepted call without --id")
 	}
@@ -110,12 +111,12 @@ func TestAttachMainRequiresID(t *testing.T) {
 func TestAttachMainHelpPrintsUsage(t *testing.T) {
 	t.Parallel()
 
-	var buf bytes.Buffer
-	if err := attachMain([]string{"--help"}, &buf); err != nil {
+	var stderr bytes.Buffer
+	if err := attachMain([]string{"--help"}, io.Discard, &stderr); err != nil {
 		t.Fatalf("attachMain(--help) error = %v", err)
 	}
-	if !strings.Contains(buf.String(), "Usage: workcell session") {
-		t.Fatalf("attachMain(--help) output = %q, want usage banner", buf.String())
+	if !strings.Contains(stderr.String(), "Usage: workcell session") {
+		t.Fatalf("attachMain(--help) stderr = %q, want usage banner", stderr.String())
 	}
 }
 
@@ -132,7 +133,7 @@ func TestAttachMainEmitsPlanFromRecord(t *testing.T) {
 
 	var buf bytes.Buffer
 	args := []string{"--root=" + root, "--id", "fixture-1"}
-	if err := attachMain(args, &buf); err != nil {
+	if err := attachMain(args, &buf, io.Discard); err != nil {
 		t.Fatalf("attachMain error = %v", err)
 	}
 	out := buf.String()
@@ -161,7 +162,7 @@ func TestAttachMainPropagatesNoStdin(t *testing.T) {
 
 	var buf bytes.Buffer
 	args := []string{"--root=" + root, "--id", "fixture-1", "--no-stdin"}
-	if err := attachMain(args, &buf); err != nil {
+	if err := attachMain(args, &buf, io.Discard); err != nil {
 		t.Fatalf("attachMain error = %v", err)
 	}
 	if !strings.Contains(buf.String(), "no_stdin=1\n") {
@@ -181,7 +182,7 @@ func TestAttachMainRejectsAttachedSession(t *testing.T) {
 
 	var buf bytes.Buffer
 	args := []string{"--root=" + root, "--id", "fixture-attached"}
-	err := attachMain(args, &buf)
+	err := attachMain(args, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("attachMain accepted an attached session")
 	}
@@ -202,7 +203,7 @@ func TestAttachMainRejectsMissingContainerName(t *testing.T) {
 
 	var buf bytes.Buffer
 	args := []string{"--root=" + root, "--id", "fixture-bad"}
-	err := attachMain(args, &buf)
+	err := attachMain(args, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("attachMain accepted record missing container_name")
 	}

--- a/internal/sessionctl/delete.go
+++ b/internal/sessionctl/delete.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/omkhar/workcell/internal/authpolicy"
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 // DeleteMain implements the option-parsing half of `workcell session
@@ -52,21 +52,27 @@ import (
 // keeps prepending them so the contract stays consistent with sibling
 // session-* subcommands.
 func DeleteMain(args []string) error {
-	return deleteMain(args, os.Stdout)
+	return deleteMain(args, os.Stdout, os.Stderr)
 }
 
-func deleteMain(args []string, stdout io.Writer) error {
+func deleteMain(args []string, stdout, stderr io.Writer) error {
 	_, rest := consumeRootArgs(args)
 	sessionID, recordOnly, dryRun, showHelp, err := parseDeleteArgs(rest)
 	if err != nil {
 		return err
 	}
 	if showHelp {
-		fmt.Fprint(stdout, UsageText())
+		// Usage banner goes to stderr so the bash shim, which captures
+		// stdout into `$plan`, surfaces it to the user instead of
+		// swallowing it.
+		fmt.Fprint(stderr, UsageText())
 		return nil
 	}
 	if sessionID == "" {
-		return &authpolicy.ExitCodeError{Code: 2, Message: "workcell session delete requires --id."}
+		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session delete requires --id."}
+	}
+	if err := rejectControlChars("session delete", "--id", sessionID); err != nil {
+		return err
 	}
 
 	recordOnlyFlag := 0
@@ -99,14 +105,12 @@ func parseDeleteArgs(args []string) (sessionID string, recordOnly, dryRun, showH
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--id":
-			if i+1 >= len(args) || args[i+1] == "" {
-				return "", false, false, false, &authpolicy.ExitCodeError{
-					Code:    2,
-					Message: "Option --id requires a value.",
-				}
+			v, ni, perr := optionValueOrError(args, i, "--id")
+			if perr != nil {
+				return "", false, false, false, perr
 			}
-			sessionID = args[i+1]
-			i++
+			sessionID = v
+			i = ni
 		case "--record-only":
 			recordOnly = true
 		case "--dry-run":
@@ -114,10 +118,7 @@ func parseDeleteArgs(args []string) (sessionID string, recordOnly, dryRun, showH
 		case "-h", "--help":
 			showHelp = true
 		default:
-			return "", false, false, false, &authpolicy.ExitCodeError{
-				Code:    2,
-				Message: fmt.Sprintf("Unsupported workcell session delete option: %s", args[i]),
-			}
+			return "", false, false, false, unsupportedOption("session delete", args[i])
 		}
 	}
 	return sessionID, recordOnly, dryRun, showHelp, nil

--- a/internal/sessionctl/delete_test.go
+++ b/internal/sessionctl/delete_test.go
@@ -6,10 +6,11 @@ package sessionctl
 import (
 	"bytes"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
-	"github.com/omkhar/workcell/internal/authpolicy"
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 func TestParseDeleteArgsRequiresIDValue(t *testing.T) {
@@ -19,7 +20,7 @@ func TestParseDeleteArgsRequiresIDValue(t *testing.T) {
 	if err == nil {
 		t.Fatal("parseDeleteArgs accepted --id without a value")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) {
 		t.Fatalf("parseDeleteArgs err = %v, want ExitCodeError", err)
 	}
@@ -47,7 +48,7 @@ func TestParseDeleteArgsRejectsUnknownFlag(t *testing.T) {
 	if err == nil {
 		t.Fatal("parseDeleteArgs accepted unknown flag")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) {
 		t.Fatalf("parseDeleteArgs err = %v, want ExitCodeError", err)
 	}
@@ -146,11 +147,11 @@ func TestDeleteMainRequiresID(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := deleteMain([]string{}, &buf)
+	err := deleteMain([]string{}, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("deleteMain accepted call without --id")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) {
 		t.Fatalf("deleteMain err = %v, want ExitCodeError", err)
 	}
@@ -165,12 +166,12 @@ func TestDeleteMainRequiresID(t *testing.T) {
 func TestDeleteMainHelpPrintsUsage(t *testing.T) {
 	t.Parallel()
 
-	var buf bytes.Buffer
-	if err := deleteMain([]string{"--help"}, &buf); err != nil {
+	var stderr bytes.Buffer
+	if err := deleteMain([]string{"--help"}, io.Discard, &stderr); err != nil {
 		t.Fatalf("deleteMain(--help) error = %v", err)
 	}
-	if !strings.Contains(buf.String(), "Usage: workcell session") {
-		t.Fatalf("deleteMain(--help) output = %q, want usage banner", buf.String())
+	if !strings.Contains(stderr.String(), "Usage: workcell session") {
+		t.Fatalf("deleteMain(--help) stderr = %q, want usage banner", stderr.String())
 	}
 }
 
@@ -178,7 +179,7 @@ func TestDeleteMainEmitsPlan(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if err := deleteMain([]string{"--id", "session-1"}, &buf); err != nil {
+	if err := deleteMain([]string{"--id", "session-1"}, &buf, io.Discard); err != nil {
 		t.Fatalf("deleteMain error = %v", err)
 	}
 	out := buf.String()
@@ -198,7 +199,7 @@ func TestDeleteMainPropagatesRecordOnly(t *testing.T) {
 
 	var buf bytes.Buffer
 	args := []string{"--id", "session-1", "--record-only"}
-	if err := deleteMain(args, &buf); err != nil {
+	if err := deleteMain(args, &buf, io.Discard); err != nil {
 		t.Fatalf("deleteMain error = %v", err)
 	}
 	if !strings.Contains(buf.String(), "record_only=1\n") {
@@ -214,7 +215,7 @@ func TestDeleteMainPropagatesDryRun(t *testing.T) {
 
 	var buf bytes.Buffer
 	args := []string{"--id", "session-1", "--dry-run"}
-	if err := deleteMain(args, &buf); err != nil {
+	if err := deleteMain(args, &buf, io.Discard); err != nil {
 		t.Fatalf("deleteMain error = %v", err)
 	}
 	if !strings.Contains(buf.String(), "dry_run=1\n") {
@@ -230,7 +231,7 @@ func TestDeleteMainPropagatesBothToggles(t *testing.T) {
 
 	var buf bytes.Buffer
 	args := []string{"--id", "session-1", "--record-only", "--dry-run"}
-	if err := deleteMain(args, &buf); err != nil {
+	if err := deleteMain(args, &buf, io.Discard); err != nil {
 		t.Fatalf("deleteMain error = %v", err)
 	}
 	if !strings.Contains(buf.String(), "record_only=1\n") {
@@ -249,7 +250,7 @@ func TestDeleteMainStripsRootArgs(t *testing.T) {
 	// session_lookup_root_args output.
 	var buf bytes.Buffer
 	args := []string{"--root=/tmp/state-1", "--root=", "--id", "session-1", "--dry-run"}
-	if err := deleteMain(args, &buf); err != nil {
+	if err := deleteMain(args, &buf, io.Discard); err != nil {
 		t.Fatalf("deleteMain error = %v", err)
 	}
 	if !strings.Contains(buf.String(), "session_id=session-1\n") {
@@ -264,11 +265,11 @@ func TestDeleteMainRejectsUnknownOption(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := deleteMain([]string{"--bogus"}, &buf)
+	err := deleteMain([]string{"--bogus"}, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("deleteMain accepted unknown option")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) || ec.Code != 2 {
 		t.Fatalf("deleteMain error = %v, want ExitCodeError{Code:2}", err)
 	}

--- a/internal/sessionctl/dispatcher.go
+++ b/internal/sessionctl/dispatcher.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/omkhar/workcell/internal/authpolicy"
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 // DispatchMain implements the subcommand-routing half of
@@ -86,7 +86,7 @@ func resolveSessionSubcommand(subcommand string) (string, error) {
 		"monitor":
 		return subcommand, nil
 	default:
-		return "", &authpolicy.ExitCodeError{
+		return "", &cliexit.ExitCodeError{
 			Code:    2,
 			Message: fmt.Sprintf("Unsupported workcell session command: %s", subcommand),
 		}

--- a/internal/sessionctl/dispatcher_test.go
+++ b/internal/sessionctl/dispatcher_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omkhar/workcell/internal/authpolicy"
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 func TestResolveSessionSubcommandAcceptsCanonical(t *testing.T) {
@@ -61,7 +61,7 @@ func TestResolveSessionSubcommandRejectsUnknown(t *testing.T) {
 	if err == nil {
 		t.Fatalf("resolveSessionSubcommand accepted unknown subcommand, returned %q", got)
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) {
 		t.Fatalf("resolveSessionSubcommand err = %v, want ExitCodeError", err)
 	}
@@ -143,7 +143,7 @@ func TestDispatchMainRejectsUnknownSubcommand(t *testing.T) {
 	if err == nil {
 		t.Fatal("dispatchMain accepted unknown subcommand")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) || ec.Code != 2 {
 		t.Fatalf("dispatchMain error = %v, want ExitCodeError{Code:2}", err)
 	}

--- a/internal/sessionctl/monitor.go
+++ b/internal/sessionctl/monitor.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/omkhar/workcell/internal/authpolicy"
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 // MonitorMain implements the option-parsing and state-file validation
@@ -54,25 +54,40 @@ import (
 // byte-for-byte so the docker-desktop provider monitor test grep keeps
 // matching.
 func MonitorMain(args []string) error {
-	return monitorMain(args, os.Stdout)
+	return monitorMain(args, os.Stdout, os.Stderr)
 }
 
-func monitorMain(args []string, stdout io.Writer) error {
-	statePath, showHelp, err := parseMonitorArgs(args)
+func monitorMain(args []string, stdout, stderr io.Writer) error {
+	// State-root forwarding mirrors the other session_*_main shims:
+	// leading --root=PATH args are consumed here because the shared
+	// scripts/lib/sessionctl-shim.sh helper always prepends
+	// session_lookup_root_args output before forwarding to go_hostutil.
+	// MonitorMain itself does not need the roots (it operates only on
+	// the explicit --state-file path the bash detached-start writer
+	// produced), but the contract stays consistent with the rest of
+	// the session_* dispatch surface.
+	_, rest := consumeRootArgs(args)
+	statePath, showHelp, err := parseMonitorArgs(rest)
 	if err != nil {
 		return err
 	}
 	if showHelp {
-		fmt.Fprint(stdout, UsageText())
+		// Usage banner goes to stderr so the bash shim, which captures
+		// stdout into `$plan`, surfaces it to the user instead of
+		// swallowing it.
+		fmt.Fprint(stderr, UsageText())
 		return nil
 	}
 	if statePath == "" {
-		return &authpolicy.ExitCodeError{Code: 2, Message: "workcell session monitor requires --state-file."}
+		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session monitor requires --state-file."}
+	}
+	if err := rejectControlChars("session monitor", "--state-file", statePath); err != nil {
+		return err
 	}
 
 	info, err := os.Stat(statePath)
 	if err != nil || info.IsDir() {
-		return &authpolicy.ExitCodeError{
+		return &cliexit.ExitCodeError{
 			Code:    2,
 			Message: fmt.Sprintf("Missing detached session monitor state file: %s", statePath),
 		}
@@ -98,21 +113,16 @@ func parseMonitorArgs(args []string) (statePath string, showHelp bool, err error
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--state-file":
-			if i+1 >= len(args) || args[i+1] == "" {
-				return "", false, &authpolicy.ExitCodeError{
-					Code:    2,
-					Message: "Option --state-file requires a value.",
-				}
+			v, ni, perr := optionValueOrError(args, i, "--state-file")
+			if perr != nil {
+				return "", false, perr
 			}
-			statePath = args[i+1]
-			i++
+			statePath = v
+			i = ni
 		case "-h", "--help":
 			showHelp = true
 		default:
-			return "", false, &authpolicy.ExitCodeError{
-				Code:    2,
-				Message: fmt.Sprintf("Unsupported workcell session monitor option: %s", args[i]),
-			}
+			return "", false, unsupportedOption("session monitor", args[i])
 		}
 	}
 	return statePath, showHelp, nil

--- a/internal/sessionctl/monitor_test.go
+++ b/internal/sessionctl/monitor_test.go
@@ -6,12 +6,13 @@ package sessionctl
 import (
 	"bytes"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/omkhar/workcell/internal/authpolicy"
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 func TestParseMonitorArgsRequiresStateFileValue(t *testing.T) {
@@ -21,7 +22,7 @@ func TestParseMonitorArgsRequiresStateFileValue(t *testing.T) {
 	if err == nil {
 		t.Fatal("parseMonitorArgs accepted --state-file without a value")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) {
 		t.Fatalf("parseMonitorArgs err = %v, want ExitCodeError", err)
 	}
@@ -49,7 +50,7 @@ func TestParseMonitorArgsRejectsUnknownFlag(t *testing.T) {
 	if err == nil {
 		t.Fatal("parseMonitorArgs accepted unknown flag")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) {
 		t.Fatalf("parseMonitorArgs err = %v, want ExitCodeError", err)
 	}
@@ -94,11 +95,11 @@ func TestMonitorMainRequiresStateFile(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := monitorMain([]string{}, &buf)
+	err := monitorMain([]string{}, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("monitorMain accepted call without --state-file")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) {
 		t.Fatalf("monitorMain err = %v, want ExitCodeError", err)
 	}
@@ -116,11 +117,11 @@ func TestMonitorMainRejectsMissingStateFile(t *testing.T) {
 	dir := t.TempDir()
 	missing := filepath.Join(dir, "absent.env")
 	var buf bytes.Buffer
-	err := monitorMain([]string{"--state-file", missing}, &buf)
+	err := monitorMain([]string{"--state-file", missing}, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("monitorMain accepted missing --state-file")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) {
 		t.Fatalf("monitorMain err = %v, want ExitCodeError", err)
 	}
@@ -140,11 +141,11 @@ func TestMonitorMainRejectsDirectoryStateFile(t *testing.T) {
 
 	dir := t.TempDir()
 	var buf bytes.Buffer
-	err := monitorMain([]string{"--state-file", dir}, &buf)
+	err := monitorMain([]string{"--state-file", dir}, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("monitorMain accepted directory as --state-file")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) {
 		t.Fatalf("monitorMain err = %v, want ExitCodeError", err)
 	}
@@ -156,12 +157,12 @@ func TestMonitorMainRejectsDirectoryStateFile(t *testing.T) {
 func TestMonitorMainHelpPrintsUsage(t *testing.T) {
 	t.Parallel()
 
-	var buf bytes.Buffer
-	if err := monitorMain([]string{"--help"}, &buf); err != nil {
+	var stderr bytes.Buffer
+	if err := monitorMain([]string{"--help"}, io.Discard, &stderr); err != nil {
 		t.Fatalf("monitorMain(--help) error = %v", err)
 	}
-	if !strings.Contains(buf.String(), "Usage: workcell session") {
-		t.Fatalf("monitorMain(--help) output = %q, want usage banner", buf.String())
+	if !strings.Contains(stderr.String(), "Usage: workcell session") {
+		t.Fatalf("monitorMain(--help) stderr = %q, want usage banner", stderr.String())
 	}
 }
 
@@ -174,7 +175,7 @@ func TestMonitorMainEmitsStateFilePath(t *testing.T) {
 		t.Fatalf("write state file: %v", err)
 	}
 	var buf bytes.Buffer
-	if err := monitorMain([]string{"--state-file", statePath}, &buf); err != nil {
+	if err := monitorMain([]string{"--state-file", statePath}, &buf, io.Discard); err != nil {
 		t.Fatalf("monitorMain error = %v", err)
 	}
 	want := "state_file=" + statePath + "\n"
@@ -187,13 +188,39 @@ func TestMonitorMainRejectsUnknownOption(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := monitorMain([]string{"--bogus"}, &buf)
+	err := monitorMain([]string{"--bogus"}, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("monitorMain accepted unknown option")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) || ec.Code != 2 {
 		t.Fatalf("monitorMain error = %v, want ExitCodeError{Code:2}", err)
+	}
+}
+
+// TestMonitorMainRejectsNewlineInStateFile guards the rejectControlChars
+// hook: a newline in --state-file would let an attacker forge additional
+// state_<KEY>=<VALUE> plan lines into the shim's read loop (CRLF
+// injection).  Mirrors the matching guards in attach/send/stop/delete.
+func TestMonitorMainRejectsNewlineInStateFile(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"/tmp/state\nstate_file=/etc/passwd", "/tmp/state\rstate_file=/etc/passwd"} {
+		var buf bytes.Buffer
+		err := monitorMain([]string{"--state-file", value}, &buf, io.Discard)
+		if err == nil {
+			t.Fatalf("monitorMain accepted --state-file value containing control character: %q", value)
+		}
+		var ec *cliexit.ExitCodeError
+		if !errors.As(err, &ec) || ec.Code != 2 {
+			t.Fatalf("monitorMain error = %v, want ExitCodeError{Code:2}", err)
+		}
+		if !strings.Contains(ec.Message, "must not contain newline or carriage-return") {
+			t.Fatalf("monitorMain message = %q, want newline-rejection diagnostic", ec.Message)
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("monitorMain wrote %q on rejection, want no stdout output", buf.String())
+		}
 	}
 }
 

--- a/internal/sessionctl/parsehelpers.go
+++ b/internal/sessionctl/parsehelpers.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/cliexit"
+)
+
+// optionValueOrError reads args[i+1] as the value for the args[i] flag.
+// It returns the value, the new index (i+1), and a *cliexit.ExitCodeError
+// with Code 2 if the value is missing or empty.  This mirrors the bash
+// option_value_or_die helper for the simple "next token is the value"
+// case shared across parseStopArgs, parseDeleteArgs, parseMonitorArgs,
+// and parseAttachArgs.
+//
+// parseSendArgs has its own helper because it needs the raw/strict
+// distinction (raw_option_value_or_die for --message vs option_value_or_die
+// for --id).
+func optionValueOrError(args []string, i int, flag string) (string, int, error) {
+	if i+1 >= len(args) || args[i+1] == "" {
+		return "", i, &cliexit.ExitCodeError{
+			Code:    2,
+			Message: fmt.Sprintf("Option %s requires a value.", flag),
+		}
+	}
+	return args[i+1], i + 1, nil
+}
+
+// unsupportedOption returns the exit-2 error for an unknown flag.  subcmd
+// is the human-readable subcommand name (e.g. "session send") used in the
+// "Unsupported workcell <subcmd> option" diagnostic to mirror the bash
+// case-statement's "*)" branch.
+func unsupportedOption(subcmd, flag string) error {
+	return &cliexit.ExitCodeError{
+		Code:    2,
+		Message: fmt.Sprintf("Unsupported workcell %s option: %s", subcmd, flag),
+	}
+}
+
+// rejectControlChars returns a *cliexit.ExitCodeError with Code 2 when the
+// supplied value contains a newline or carriage return.  The bash shim
+// transports key=value plan lines from the Go side as newline-separated
+// records, so a CR/LF in a user-controlled field would let an attacker
+// forge additional plan entries (a CRLF-injection).  Reject conservatively
+// so the bash shim never sees a multi-line value.
+func rejectControlChars(subcmd, flag, value string) error {
+	if strings.ContainsAny(value, "\n\r") {
+		return &cliexit.ExitCodeError{
+			Code:    2,
+			Message: fmt.Sprintf("workcell %s %s must not contain newline or carriage-return characters.", subcmd, flag),
+		}
+	}
+	return nil
+}

--- a/internal/sessionctl/send.go
+++ b/internal/sessionctl/send.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/omkhar/workcell/internal/authpolicy"
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 // SendMain implements the option-parsing half of `workcell session send
@@ -48,24 +48,33 @@ import (
 // session-* subcommands and so a future tightening of SendMain that
 // does need on-disk lookup will not require a shim change.
 func SendMain(args []string) error {
-	return sendMain(args, os.Stdout)
+	return sendMain(args, os.Stdout, os.Stderr)
 }
 
-func sendMain(args []string, stdout io.Writer) error {
+func sendMain(args []string, stdout, stderr io.Writer) error {
 	_, rest := consumeRootArgs(args)
 	sessionID, message, appendNewline, showHelp, err := parseSendArgs(rest)
 	if err != nil {
 		return err
 	}
 	if showHelp {
-		fmt.Fprint(stdout, UsageText())
+		// Usage banner goes to stderr so the bash shim, which captures
+		// stdout into `$plan`, surfaces it to the user instead of
+		// swallowing it.
+		fmt.Fprint(stderr, UsageText())
 		return nil
 	}
 	if sessionID == "" {
-		return &authpolicy.ExitCodeError{Code: 2, Message: "workcell session send requires --id."}
+		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session send requires --id."}
 	}
 	if message == "" {
-		return &authpolicy.ExitCodeError{Code: 2, Message: "workcell session send requires --message."}
+		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session send requires --message."}
+	}
+	if err := rejectControlChars("session send", "--id", sessionID); err != nil {
+		return err
+	}
+	if err := rejectControlChars("session send", "--message", message); err != nil {
+		return err
 	}
 
 	appendFlag := 0
@@ -117,10 +126,7 @@ func parseSendArgs(args []string) (sessionID, message string, appendNewline, sho
 		case "-h", "--help":
 			showHelp = true
 		default:
-			return "", "", false, false, &authpolicy.ExitCodeError{
-				Code:    2,
-				Message: fmt.Sprintf("Unsupported workcell session send option: %s", args[i]),
-			}
+			return "", "", false, false, unsupportedOption("session send", args[i])
 		}
 	}
 	return sessionID, message, appendNewline, showHelp, nil
@@ -133,24 +139,27 @@ func parseSendArgs(args []string) (sessionID, message string, appendNewline, sho
 // raw_option_value_or_die: only empty is rejected.
 //
 // The exit-2 wrapping matches the bash CLI contract that usage errors
-// flow back as exit status 2.
+// flow back as exit status 2.  This helper is intentionally separate
+// from the shared optionValueOrError because parseSendArgs needs the
+// raw/strict distinction; sibling parse functions only ever need the
+// "non-empty" check.
 func optionValueForSend(args []string, i int, raw bool) (string, error) {
 	option := args[i]
 	if i+1 >= len(args) {
-		return "", &authpolicy.ExitCodeError{
+		return "", &cliexit.ExitCodeError{
 			Code:    2,
 			Message: fmt.Sprintf("Option %s requires a value.", option),
 		}
 	}
 	value := args[i+1]
 	if value == "" {
-		return "", &authpolicy.ExitCodeError{
+		return "", &cliexit.ExitCodeError{
 			Code:    2,
 			Message: fmt.Sprintf("Option %s requires a value.", option),
 		}
 	}
 	if !raw && strings.HasPrefix(value, "--") {
-		return "", &authpolicy.ExitCodeError{
+		return "", &cliexit.ExitCodeError{
 			Code:    2,
 			Message: fmt.Sprintf("Option %s requires a value.", option),
 		}

--- a/internal/sessionctl/send_test.go
+++ b/internal/sessionctl/send_test.go
@@ -6,10 +6,11 @@ package sessionctl
 import (
 	"bytes"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
-	"github.com/omkhar/workcell/internal/authpolicy"
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 func TestParseSendArgsRequiresIDValue(t *testing.T) {
@@ -152,14 +153,14 @@ func TestSendMainRequiresID(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := sendMain([]string{"--message", "hello"}, &buf)
+	err := sendMain([]string{"--message", "hello"}, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("sendMain accepted call without --id")
 	}
 	if !strings.Contains(err.Error(), "workcell session send requires --id.") {
 		t.Fatalf("sendMain error = %v, want canonical require-id message", err)
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) || ec.Code != 2 {
 		t.Fatalf("sendMain error = %v, want ExitCodeError{Code:2}", err)
 	}
@@ -169,14 +170,14 @@ func TestSendMainRequiresMessage(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := sendMain([]string{"--id", "session-1"}, &buf)
+	err := sendMain([]string{"--id", "session-1"}, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("sendMain accepted call without --message")
 	}
 	if !strings.Contains(err.Error(), "workcell session send requires --message.") {
 		t.Fatalf("sendMain error = %v, want canonical require-message message", err)
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) || ec.Code != 2 {
 		t.Fatalf("sendMain error = %v, want ExitCodeError{Code:2}", err)
 	}
@@ -185,12 +186,12 @@ func TestSendMainRequiresMessage(t *testing.T) {
 func TestSendMainHelpPrintsUsage(t *testing.T) {
 	t.Parallel()
 
-	var buf bytes.Buffer
-	if err := sendMain([]string{"--help"}, &buf); err != nil {
+	var stderr bytes.Buffer
+	if err := sendMain([]string{"--help"}, io.Discard, &stderr); err != nil {
 		t.Fatalf("sendMain(--help) error = %v", err)
 	}
-	if !strings.Contains(buf.String(), "Usage: workcell session") {
-		t.Fatalf("sendMain(--help) output = %q, want usage banner", buf.String())
+	if !strings.Contains(stderr.String(), "Usage: workcell session") {
+		t.Fatalf("sendMain(--help) stderr = %q, want usage banner", stderr.String())
 	}
 }
 
@@ -199,7 +200,7 @@ func TestSendMainEmitsPlan(t *testing.T) {
 
 	var buf bytes.Buffer
 	args := []string{"--id", "session-1", "--message", "hello world"}
-	if err := sendMain(args, &buf); err != nil {
+	if err := sendMain(args, &buf, io.Discard); err != nil {
 		t.Fatalf("sendMain error = %v", err)
 	}
 	out := buf.String()
@@ -219,7 +220,7 @@ func TestSendMainPropagatesNoNewline(t *testing.T) {
 
 	var buf bytes.Buffer
 	args := []string{"--id", "session-1", "--message", "hello", "--no-newline"}
-	if err := sendMain(args, &buf); err != nil {
+	if err := sendMain(args, &buf, io.Discard); err != nil {
 		t.Fatalf("sendMain error = %v", err)
 	}
 	if !strings.Contains(buf.String(), "append_newline=0\n") {
@@ -235,7 +236,7 @@ func TestSendMainStripsRootArgs(t *testing.T) {
 	// session_lookup_root_args output.
 	var buf bytes.Buffer
 	args := []string{"--root=/tmp/state-1", "--root=", "--id", "session-1", "--message", "beta"}
-	if err := sendMain(args, &buf); err != nil {
+	if err := sendMain(args, &buf, io.Discard); err != nil {
 		t.Fatalf("sendMain error = %v", err)
 	}
 	if !strings.Contains(buf.String(), "session_id=session-1\n") {
@@ -250,11 +251,11 @@ func TestSendMainRejectsUnknownOption(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := sendMain([]string{"--bogus"}, &buf)
+	err := sendMain([]string{"--bogus"}, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("sendMain accepted unknown option")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) || ec.Code != 2 {
 		t.Fatalf("sendMain error = %v, want ExitCodeError{Code:2}", err)
 	}

--- a/internal/sessionctl/stop.go
+++ b/internal/sessionctl/stop.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/omkhar/workcell/internal/authpolicy"
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/host/sessions"
 )
 
@@ -52,21 +52,27 @@ import (
 // go_hostutil scrubs WORKCELL_STATE_ROOT/COLIMA_STATE_ROOT from the
 // environment.
 func StopMain(args []string) error {
-	return stopMain(args, os.Stdout)
+	return stopMain(args, os.Stdout, os.Stderr)
 }
 
-func stopMain(args []string, stdout io.Writer) error {
+func stopMain(args []string, stdout, stderr io.Writer) error {
 	roots, rest := consumeRootArgs(args)
 	sessionID, force, showHelp, err := parseStopArgs(rest)
 	if err != nil {
 		return err
 	}
 	if showHelp {
-		fmt.Fprint(stdout, UsageText())
+		// Usage banner goes to stderr so the bash shim, which captures
+		// stdout into `$plan`, surfaces it to the user instead of
+		// swallowing it.
+		fmt.Fprint(stderr, UsageText())
 		return nil
 	}
 	if sessionID == "" {
-		return &authpolicy.ExitCodeError{Code: 2, Message: "workcell session stop requires --id."}
+		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session stop requires --id."}
+	}
+	if err := rejectControlChars("session stop", "--id", sessionID); err != nil {
+		return err
 	}
 
 	if len(roots) == 0 {
@@ -114,23 +120,18 @@ func parseStopArgs(args []string) (sessionID string, force, showHelp bool, err e
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--id":
-			if i+1 >= len(args) || args[i+1] == "" {
-				return "", false, false, &authpolicy.ExitCodeError{
-					Code:    2,
-					Message: "Option --id requires a value.",
-				}
+			v, ni, perr := optionValueOrError(args, i, "--id")
+			if perr != nil {
+				return "", false, false, perr
 			}
-			sessionID = args[i+1]
-			i++
+			sessionID = v
+			i = ni
 		case "--force":
 			force = true
 		case "-h", "--help":
 			showHelp = true
 		default:
-			return "", false, false, &authpolicy.ExitCodeError{
-				Code:    2,
-				Message: fmt.Sprintf("Unsupported workcell session stop option: %s", args[i]),
-			}
+			return "", false, false, unsupportedOption("session stop", args[i])
 		}
 	}
 	return sessionID, force, showHelp, nil

--- a/internal/sessionctl/stop_test.go
+++ b/internal/sessionctl/stop_test.go
@@ -6,12 +6,13 @@ package sessionctl
 import (
 	"bytes"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/omkhar/workcell/internal/authpolicy"
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 func TestParseStopArgsRequiresIDValue(t *testing.T) {
@@ -21,7 +22,7 @@ func TestParseStopArgsRequiresIDValue(t *testing.T) {
 	if err == nil {
 		t.Fatal("parseStopArgs accepted --id without a value")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) {
 		t.Fatalf("parseStopArgs err = %v, want ExitCodeError", err)
 	}
@@ -49,7 +50,7 @@ func TestParseStopArgsRejectsUnknownFlag(t *testing.T) {
 	if err == nil {
 		t.Fatal("parseStopArgs accepted unknown flag")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) {
 		t.Fatalf("parseStopArgs err = %v, want ExitCodeError", err)
 	}
@@ -115,11 +116,11 @@ func TestStopMainRequiresID(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := stopMain([]string{}, &buf)
+	err := stopMain([]string{}, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("stopMain accepted call without --id")
 	}
-	var ec *authpolicy.ExitCodeError
+	var ec *cliexit.ExitCodeError
 	if !errors.As(err, &ec) {
 		t.Fatalf("stopMain err = %v, want ExitCodeError", err)
 	}
@@ -134,12 +135,12 @@ func TestStopMainRequiresID(t *testing.T) {
 func TestStopMainHelpPrintsUsage(t *testing.T) {
 	t.Parallel()
 
-	var buf bytes.Buffer
-	if err := stopMain([]string{"--help"}, &buf); err != nil {
+	var stderr bytes.Buffer
+	if err := stopMain([]string{"--help"}, io.Discard, &stderr); err != nil {
 		t.Fatalf("stopMain(--help) error = %v", err)
 	}
-	if !strings.Contains(buf.String(), "Usage: workcell session") {
-		t.Fatalf("stopMain(--help) output = %q, want usage banner", buf.String())
+	if !strings.Contains(stderr.String(), "Usage: workcell session") {
+		t.Fatalf("stopMain(--help) stderr = %q, want usage banner", stderr.String())
 	}
 }
 
@@ -156,7 +157,7 @@ func TestStopMainEmitsPlanFromRecord(t *testing.T) {
 
 	var buf bytes.Buffer
 	args := []string{"--root=" + root, "--id", "fixture-1"}
-	if err := stopMain(args, &buf); err != nil {
+	if err := stopMain(args, &buf, io.Discard); err != nil {
 		t.Fatalf("stopMain error = %v", err)
 	}
 	out := buf.String()
@@ -185,7 +186,7 @@ func TestStopMainPropagatesForce(t *testing.T) {
 
 	var buf bytes.Buffer
 	args := []string{"--root=" + root, "--id", "fixture-1", "--force"}
-	if err := stopMain(args, &buf); err != nil {
+	if err := stopMain(args, &buf, io.Discard); err != nil {
 		t.Fatalf("stopMain error = %v", err)
 	}
 	if !strings.Contains(buf.String(), "force=1\n") {
@@ -205,7 +206,7 @@ func TestStopMainRejectsAttachedSession(t *testing.T) {
 
 	var buf bytes.Buffer
 	args := []string{"--root=" + root, "--id", "fixture-attached"}
-	err := stopMain(args, &buf)
+	err := stopMain(args, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("stopMain accepted an attached session")
 	}
@@ -229,7 +230,7 @@ func TestStopMainRejectsMissingContainerName(t *testing.T) {
 
 	var buf bytes.Buffer
 	args := []string{"--root=" + root, "--id", "fixture-bad"}
-	err := stopMain(args, &buf)
+	err := stopMain(args, &buf, io.Discard)
 	if err == nil {
 		t.Fatal("stopMain accepted record missing container_name")
 	}


### PR DESCRIPTION
PR-FIX-1A of a 4-PR sethify fix-up rollout from the `/sethify` review against the 8-PR rollout (`c70b41a..42a8ee5`).

## Summary
- All 4 🔴 sethify blockers fixed (B1-B4)
- Sec 2 defense-in-depth (filepath.Clean)
- New `internal/cliexit/` package as canonical ExitCodeError type
- Shared option-parser helpers (Q1)

The Q4 bash shim dedup, D4 dispatcher rename, D3 doc.go update, Q3 var rename, and W3 CanonicalSubcommands export defer to PR-FIX-1B (file shape limit forced the split).

## Blocker fixes
- **B1** — `--help` swallowed: send/stop/delete/monitor emit usage to stderr instead of stdout. Tests cover stderr capture.
- **B2** — HOME env leak: `installSyntheticProbeEnv` returns canonical cleanup on every error path; `PrepareBundle` defers it before err check. Regression test triggers `writeFile0600` collision after HOME is set.
- **B3** — Newline injection: `rejectControlChars` guards added for user-controlled fields in send (`--message`), stop/delete (`--id`), monitor (`--state-file`). Negative tests for `\n` and `\r`.
- **B4** — `attach.go` validation errors now return `&cliexit.ExitCodeError{Code:2}` (was plain `errors.New`/`fmt.Errorf`, silently demoting exit code).

## Defense-in-depth
- **Sec 2** — `validateDirectMount` calls `filepath.Clean` and re-checks prefix; tests cover `..`, bare root, `./..`, dot-only suffix.

## Foundation (W8 partial + Q1)
- New `internal/cliexit/exit_code_error.go` with the canonical type + `IsExitCodeError` helper.
- `authpolicy.ExitCodeError` fully migrated; `publishpr.ExitCodeError` kept as type alias.
- `sessionctl` imports cliexit directly across all parse-only Main funcs + dispatcher.
- `internal/sessionctl/parsehelpers.go` extracts shared loop helpers.

## Shape
files=25 (at limit), lines=775, areas=2, binary_files=0.

## Test plan
- [ ] Validate repository CI green
- [ ] Reproducible build (amd64 + arm64) CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)