### PR TITLE
^B Sethify round-2 critical: red + near-red + cliexit completion (fix-5)

### DIFF
--- a/cmd/workcell-metadatautil/main.go
+++ b/cmd/workcell-metadatautil/main.go
@@ -19,7 +19,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/omkhar/workcell/internal/metadatautil"
@@ -121,14 +123,25 @@ func main() {
 }
 
 func rootUsageError(badCommand string) error {
-	names := make([]string, 0, len(subcommands()))
+	names := make([]string, 0, len(subcommands())+1)
 	for _, sub := range subcommands() {
 		names = append(names, sub.name)
 	}
-	if badCommand == "" {
-		return fmt.Errorf("usage: %s <command> [args...]", os.Args[0])
+	// scenario-manifest is dispatched directly in main() and so is not
+	// part of the subcommands() table, but it is still a known command
+	// for help/error output purposes.
+	names = append(names, "scenario-manifest")
+	sort.Strings(names)
+	var lines strings.Builder
+	for _, name := range names {
+		lines.WriteString("  ")
+		lines.WriteString(name)
+		lines.WriteString("\n")
 	}
-	return fmt.Errorf("unknown command: %s", badCommand)
+	if badCommand == "" {
+		return fmt.Errorf("usage: %s <command> [args...]\n\nCommands:\n%s", os.Args[0], lines.String())
+	}
+	return fmt.Errorf("unknown command: %s\n\nKnown commands:\n%s", badCommand, lines.String())
 }
 
 func cmdGenerateControlPlaneManifest(args []string) error {

--- a/internal/injection/stage_direct_mounts.go
+++ b/internal/injection/stage_direct_mounts.go
@@ -97,6 +97,15 @@ func validateDirectMount(hostSource, mountPath string) error {
 	if !filepath.IsAbs(cleanedSource) {
 		return fmt.Errorf("Direct input source is missing, not absolute, or not a regular file/directory: %s", hostSource)
 	}
+	// Reject symlinked sources up front: a symlink under
+	// /opt/workcell/host-inputs/ that points at /etc/passwd would
+	// dereference through every subsequent stat/open and leak the
+	// target's content into the staged bundle. copyDirContents already
+	// skips symlinks encountered inside a directory source; this
+	// closes the matching escape for the top-level source itself.
+	if lstatInfo, lerr := os.Lstat(cleanedSource); lerr == nil && lstatInfo.Mode()&fs.ModeSymlink != 0 {
+		return fmt.Errorf("Direct input source must not be a symbolic link: %s", hostSource)
+	}
 	info, err := os.Stat(cleanedSource)
 	if err != nil || !(info.Mode().IsRegular() || info.IsDir()) {
 		return fmt.Errorf("Direct input source is missing, not absolute, or not a regular file/directory: %s", hostSource)

--- a/internal/injection/stage_direct_mounts_test.go
+++ b/internal/injection/stage_direct_mounts_test.go
@@ -295,3 +295,32 @@ func TestStageDirectMountsStripsGroupOtherPermissions(t *testing.T) {
 		t.Fatalf("expected group/other bits cleared, got %o", info.Mode().Perm())
 	}
 }
+
+// TestStageDirectMountsRejectsSymlinkedSource — round-2 sethify Sec-symlink-source.
+// A symlinked top-level mount source dereferences through every
+// subsequent stat/open and would leak the target's content into the
+// staged bundle (cf. /etc/passwd / ~/.ssh/* escape class).
+// validateDirectMount must reject the link up front, mirroring the
+// symlink skip that copyDirContents already does for entries it
+// encounters inside a directory source.
+func TestStageDirectMountsRejectsSymlinkedSource(t *testing.T) {
+	bundleRoot := t.TempDir()
+	// Real target file (would otherwise be valid mount content).
+	realFile := filepath.Join(bundleRoot, "real.txt")
+	if err := os.WriteFile(realFile, []byte("real-content"), 0o600); err != nil {
+		t.Fatalf("WriteFile real: %v", err)
+	}
+	// Symlink that points at it; this is what the spec references.
+	linkSource := filepath.Join(bundleRoot, "link.txt")
+	if err := os.Symlink(realFile, linkSource); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	specPath := filepath.Join(bundleRoot, "spec.json")
+	writeMountSpec(t, specPath, []map[string]any{
+		{"source": linkSource, "mount_path": "/opt/workcell/host-inputs/x"},
+	})
+	_, err := StageDirectMounts(bundleRoot, specPath)
+	if err == nil || !strings.Contains(err.Error(), "must not be a symbolic link") {
+		t.Fatalf("expected symlink-rejection error, got %v", err)
+	}
+}

--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -461,6 +461,8 @@ func GenerateControlPlaneManifest(rootDir, outputPath string) error {
 		"scripts/check-publish-commit-signatures.sh",
 		"scripts/lib/extract_direct_mounts",
 		"scripts/lib/render_injection_bundle",
+		"scripts/lib/sessionctl-shim.sh",
+		"scripts/lib/shellproto.sh",
 		"scripts/lib/trusted-docker-client.sh",
 	}
 	runtimeArtifacts := []ControlPlaneArtifact{

--- a/internal/publishpr/publish_pr_cli.go
+++ b/internal/publishpr/publish_pr_cli.go
@@ -33,7 +33,7 @@ func PublishPRMain(args []string, stdin io.Reader, stdout, stderr io.Writer) err
 		// branch (unsupported option); ParseArgs error messages start
 		// with "Unsupported publish-pr option:" in that case, so we
 		// gate the usage echo on the prefix to stay byte-identical.
-		if ec, ok := IsExitCodeError(err); ok && strings.HasPrefix(ec.Message, "Unsupported publish-pr option:") {
+		if ec, ok := cliexit.IsExitCodeError(err); ok && strings.HasPrefix(ec.Message, "Unsupported publish-pr option:") {
 			WriteUsage(stderr)
 		}
 		return err

--- a/internal/publishpr/publish_pr_main.go
+++ b/internal/publishpr/publish_pr_main.go
@@ -12,13 +12,6 @@ import (
 	"github.com/omkhar/workcell/internal/cliexit"
 )
 
-// ExitCodeError is kept as a package-local type alias for cliexit.ExitCodeError
-// so existing publishpr-internal test code that references the local name
-// continues to compile. Production code should reference cliexit.ExitCodeError
-// directly; this alias is a compatibility shim slated for removal in the
-// follow-up sessionctl/publishpr type-sweep.
-type ExitCodeError = cliexit.ExitCodeError
-
 func exit2(format string, args ...any) error {
 	return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf(format, args...)}
 }
@@ -376,11 +369,4 @@ func Preflight(opts *Options, checkRefFormat CheckRefFormatFunc, fileReader func
 // UsageText())" pattern.
 func WriteUsage(w io.Writer) {
 	fmt.Fprint(w, UsageText())
-}
-
-// IsExitCodeError reports whether err is a *cliexit.ExitCodeError. It
-// forwards to cliexit.IsExitCodeError and is preserved here for source
-// compatibility with the existing publishpr callers and tests.
-func IsExitCodeError(err error) (*cliexit.ExitCodeError, bool) {
-	return cliexit.IsExitCodeError(err)
 }

--- a/internal/publishpr/publish_pr_main_test.go
+++ b/internal/publishpr/publish_pr_main_test.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 func TestParseArgsAppliesDefaults(t *testing.T) {
@@ -75,7 +77,7 @@ func TestParseArgsAcceptsAllSupportedFlags(t *testing.T) {
 func TestParseArgsRejectsUnsupportedOption(t *testing.T) {
 	t.Parallel()
 	_, err := ParseArgs([]string{"--bogus"})
-	ec, ok := IsExitCodeError(err)
+	ec, ok := cliexit.IsExitCodeError(err)
 	if !ok {
 		t.Fatalf("ParseArgs() err = %v, want ExitCodeError", err)
 	}
@@ -108,7 +110,7 @@ func TestParseArgsRejectsMissingOptionValue(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := ParseArgs(tc.args)
-			ec, ok := IsExitCodeError(err)
+			ec, ok := cliexit.IsExitCodeError(err)
 			if !ok {
 				t.Fatalf("ParseArgs(%v) err = %v, want ExitCodeError", tc.args, err)
 			}
@@ -179,7 +181,7 @@ func TestValidateSnapshotName(t *testing.T) {
 		}
 	}
 	err := ValidateSnapshotName("rebased")
-	ec, ok := IsExitCodeError(err)
+	ec, ok := cliexit.IsExitCodeError(err)
 	if !ok {
 		t.Fatalf("err = %v, want ExitCodeError", err)
 	}
@@ -214,7 +216,7 @@ func TestValidateBranchName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := ValidateBranchName(tc.branch, tc.checkRefFormat)
-			ec, ok := IsExitCodeError(err)
+			ec, ok := cliexit.IsExitCodeError(err)
 			if !ok {
 				t.Fatalf("err = %v, want ExitCodeError", err)
 			}
@@ -253,7 +255,7 @@ func TestValidateBaseName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := ValidateBaseName(tc.base, tc.allowNonMain, tc.checkRefFormat)
-			ec, ok := IsExitCodeError(err)
+			ec, ok := cliexit.IsExitCodeError(err)
 			if !ok {
 				t.Fatalf("err = %v, want ExitCodeError", err)
 			}
@@ -300,7 +302,7 @@ func TestLoadTextArg(t *testing.T) {
 	t.Run("inline-and-file-both-set", func(t *testing.T) {
 		t.Parallel()
 		_, err := LoadTextArg("inline", "ok", "title", true, reader)
-		ec, ok := IsExitCodeError(err)
+		ec, ok := cliexit.IsExitCodeError(err)
 		if !ok || ec.Code != 2 {
 			t.Fatalf("err = %v, want ExitCodeError{Code=2}", err)
 		}
@@ -323,7 +325,7 @@ func TestLoadTextArg(t *testing.T) {
 	t.Run("file-missing-reports-label", func(t *testing.T) {
 		t.Parallel()
 		_, err := LoadTextArg("", "missing", "body", false, reader)
-		ec, ok := IsExitCodeError(err)
+		ec, ok := cliexit.IsExitCodeError(err)
 		if !ok {
 			t.Fatalf("err = %v, want ExitCodeError", err)
 		}
@@ -357,7 +359,7 @@ func TestLoadTextArg(t *testing.T) {
 	t.Run("required-empty-fails", func(t *testing.T) {
 		t.Parallel()
 		_, err := LoadTextArg("", "", "title", true, reader)
-		ec, ok := IsExitCodeError(err)
+		ec, ok := cliexit.IsExitCodeError(err)
 		if !ok || ec.Code != 2 {
 			t.Fatalf("err = %v, want ExitCodeError{Code=2}", err)
 		}
@@ -456,7 +458,7 @@ func TestPreflightRejectsEmptyTitleAndCommit(t *testing.T) {
 		CommitMessage: "commit",
 	}
 	_, err := Preflight(emptyTitleOpts, func(string) bool { return true }, nil)
-	ec, ok := IsExitCodeError(err)
+	ec, ok := cliexit.IsExitCodeError(err)
 	if !ok {
 		t.Fatalf("err = %v, want ExitCodeError", err)
 	}
@@ -471,7 +473,7 @@ func TestPreflightRejectsEmptyTitleAndCommit(t *testing.T) {
 		Title:    "T",
 	}
 	_, err = Preflight(emptyCommitOpts, func(string) bool { return true }, nil)
-	ec, ok = IsExitCodeError(err)
+	ec, ok = cliexit.IsExitCodeError(err)
 	if !ok {
 		t.Fatalf("err = %v, want ExitCodeError", err)
 	}
@@ -491,7 +493,7 @@ func TestPreflightPropagatesValidatorErrors(t *testing.T) {
 		CommitMessage: "C",
 	}
 	_, err := Preflight(bad, func(string) bool { return true }, nil)
-	ec, ok := IsExitCodeError(err)
+	ec, ok := cliexit.IsExitCodeError(err)
 	if !ok {
 		t.Fatalf("err = %v, want ExitCodeError", err)
 	}
@@ -503,7 +505,7 @@ func TestPreflightPropagatesValidatorErrors(t *testing.T) {
 func TestPreflightRejectsNilOptions(t *testing.T) {
 	t.Parallel()
 	_, err := Preflight(nil, nil, nil)
-	ec, ok := IsExitCodeError(err)
+	ec, ok := cliexit.IsExitCodeError(err)
 	if !ok {
 		t.Fatalf("err = %v, want ExitCodeError", err)
 	}
@@ -523,17 +525,17 @@ func TestWriteUsageMatchesUsageText(t *testing.T) {
 
 func TestIsExitCodeErrorWraps(t *testing.T) {
 	t.Parallel()
-	base := &ExitCodeError{Code: 7, Message: "boom"}
+	base := &cliexit.ExitCodeError{Code: 7, Message: "boom"}
 	wrapped := wrapErrForTest(base)
-	got, ok := IsExitCodeError(wrapped)
+	got, ok := cliexit.IsExitCodeError(wrapped)
 	if !ok {
-		t.Fatalf("IsExitCodeError(wrapped) = false, want true")
+		t.Fatalf("cliexit.IsExitCodeError(wrapped) = false, want true")
 	}
 	if got.Code != 7 || got.Message != "boom" {
 		t.Errorf("unwrapped = %+v, want {Code:7 Message:boom}", got)
 	}
-	if _, ok := IsExitCodeError(errors.New("plain")); ok {
-		t.Errorf("IsExitCodeError(plain) = true, want false")
+	if _, ok := cliexit.IsExitCodeError(errors.New("plain")); ok {
+		t.Errorf("cliexit.IsExitCodeError(plain) = true, want false")
 	}
 }
 

--- a/internal/sessionctl/attach_test.go
+++ b/internal/sessionctl/attach_test.go
@@ -5,11 +5,14 @@ package sessionctl
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 func TestParseAttachArgsRequiresIDValue(t *testing.T) {
@@ -237,5 +240,31 @@ func writeAttachFixtureRecord(t *testing.T, root, profile, sessionID string, fie
 	path := filepath.Join(sessionsDir, sessionID+".json")
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatalf("write session record: %v", err)
+	}
+}
+
+// TestAttachMainRejectsNewlineInID guards rejectControlChars at the
+// session-attach input boundary: a CR/LF in --id would let the bash
+// shim see forged session_id=... plan lines after the first newline.
+// Mirrors monitor_test.go's TestMonitorMainRejectsNewlineInStateFile.
+func TestAttachMainRejectsNewlineInID(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"session-1\nsession_id=other", "session-1\rsession_id=other"} {
+		var buf bytes.Buffer
+		err := attachMain([]string{"--id", value}, &buf, io.Discard)
+		if err == nil {
+			t.Fatalf("attachMain accepted --id value containing control character: %q", value)
+		}
+		var ec *cliexit.ExitCodeError
+		if !errors.As(err, &ec) || ec.Code != 2 {
+			t.Fatalf("attachMain error = %v, want ExitCodeError{Code:2}", err)
+		}
+		if !strings.Contains(ec.Message, "must not contain newline or carriage-return") {
+			t.Fatalf("attachMain message = %q, want newline-rejection diagnostic", ec.Message)
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("attachMain wrote %q on rejection, want no stdout output", buf.String())
+		}
 	}
 }

--- a/internal/sessionctl/delete_test.go
+++ b/internal/sessionctl/delete_test.go
@@ -274,3 +274,27 @@ func TestDeleteMainRejectsUnknownOption(t *testing.T) {
 		t.Fatalf("deleteMain error = %v, want ExitCodeError{Code:2}", err)
 	}
 }
+
+// TestDeleteMainRejectsNewlineInID — sibling guard to
+// monitor_test.go's TestMonitorMainRejectsNewlineInStateFile.
+func TestDeleteMainRejectsNewlineInID(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"session-1\nsession_id=other", "session-1\rsession_id=other"} {
+		var buf bytes.Buffer
+		err := deleteMain([]string{"--id", value}, &buf, io.Discard)
+		if err == nil {
+			t.Fatalf("deleteMain accepted --id value containing control character: %q", value)
+		}
+		var ec *cliexit.ExitCodeError
+		if !errors.As(err, &ec) || ec.Code != 2 {
+			t.Fatalf("deleteMain error = %v, want ExitCodeError{Code:2}", err)
+		}
+		if !strings.Contains(ec.Message, "must not contain newline or carriage-return") {
+			t.Fatalf("deleteMain message = %q, want newline-rejection diagnostic", ec.Message)
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("deleteMain wrote %q on rejection, want no stdout output", buf.String())
+		}
+	}
+}

--- a/internal/sessionctl/logs.go
+++ b/internal/sessionctl/logs.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/host/hoststate"
 	"github.com/omkhar/workcell/internal/host/sessions"
 	"github.com/omkhar/workcell/internal/host/stateroot"
@@ -34,10 +35,10 @@ func logsMain(args []string, stdout io.Writer) error {
 		return nil
 	}
 	if sessionID == "" {
-		return errors.New("workcell session logs requires --id.")
+		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session logs requires --id."}
 	}
 	if kind == "" {
-		return errors.New("workcell session logs requires --kind.")
+		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session logs requires --kind."}
 	}
 	if err := validateLogsKindName(kind); err != nil {
 		return err
@@ -53,18 +54,18 @@ func logsMain(args []string, stdout io.Writer) error {
 
 	logPath := logPathForKind(record, kind)
 	if logPath == "" {
-		return fmt.Errorf("No %s log is recorded for session %s.", kind, sessionID)
+		return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("No %s log is recorded for session %s.", kind, sessionID)}
 	}
 
 	resolved, err := hoststate.ResolveHostOutputCandidate(logPath)
 	if err != nil || resolved != logPath {
-		return fmt.Errorf("Workcell blocked host output path after launch: %s", logPath)
+		return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("Workcell blocked host output path after launch: %s", logPath)}
 	}
 
 	data, err := os.ReadFile(resolved)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("No %s log is recorded for session %s.", kind, sessionID)
+			return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("No %s log is recorded for session %s.", kind, sessionID)}
 		}
 		return err
 	}
@@ -76,21 +77,23 @@ func parseLogsArgs(args []string) (sessionID, kind string, showHelp bool, err er
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--id":
-			if i+1 >= len(args) || args[i+1] == "" {
-				return "", "", false, fmt.Errorf("--id requires a non-empty value")
+			value, next, perr := optionValueOrError(args, i, "--id")
+			if perr != nil {
+				return "", "", false, perr
 			}
-			sessionID = args[i+1]
-			i++
+			sessionID = value
+			i = next
 		case "--kind":
-			if i+1 >= len(args) || args[i+1] == "" {
-				return "", "", false, fmt.Errorf("--kind requires a non-empty value")
+			value, next, perr := optionValueOrError(args, i, "--kind")
+			if perr != nil {
+				return "", "", false, perr
 			}
-			kind = args[i+1]
-			i++
+			kind = value
+			i = next
 		case "-h", "--help":
 			showHelp = true
 		default:
-			return "", "", false, fmt.Errorf("Unsupported workcell session logs option: %s", args[i])
+			return "", "", false, unsupportedOption("session logs", args[i])
 		}
 	}
 	return sessionID, kind, showHelp, nil
@@ -101,7 +104,7 @@ func validateLogsKindName(kind string) error {
 	case "audit", "debug", "file-trace", "transcript":
 		return nil
 	}
-	return fmt.Errorf("Unsupported log kind: %s\nUse --logs audit, --logs debug, --logs file-trace, or --logs transcript.", kind)
+	return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("Unsupported log kind: %s\nUse --logs audit, --logs debug, --logs file-trace, or --logs transcript.", kind)}
 }
 
 func logPathForKind(record sessions.SessionRecord, kind string) string {

--- a/internal/sessionctl/logs_test.go
+++ b/internal/sessionctl/logs_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/host/sessions"
 )
 
@@ -17,8 +18,12 @@ func TestParseLogsArgsRequiresIDValue(t *testing.T) {
 	if err == nil {
 		t.Fatal("parseLogsArgs accepted --id without a value")
 	}
-	if !strings.Contains(err.Error(), "non-empty") {
-		t.Fatalf("parseLogsArgs error = %v, want non-empty rejection", err)
+	if !strings.Contains(err.Error(), "requires a value") {
+		t.Fatalf("parseLogsArgs error = %v, want requires-a-value rejection", err)
+	}
+	ec, ok := cliexit.IsExitCodeError(err)
+	if !ok || ec.Code != 2 {
+		t.Fatalf("parseLogsArgs error = %v, want *cliexit.ExitCodeError{Code:2}", err)
 	}
 }
 

--- a/internal/sessionctl/parsehelpers_test.go
+++ b/internal/sessionctl/parsehelpers_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/cliexit"
+)
+
+func TestOptionValueOrErrorReturnsValueAndAdvancedIndex(t *testing.T) {
+	t.Parallel()
+
+	value, next, err := optionValueOrError([]string{"--id", "session-1"}, 0, "--id")
+	if err != nil {
+		t.Fatalf("optionValueOrError err = %v, want nil", err)
+	}
+	if value != "session-1" {
+		t.Errorf("value = %q, want session-1", value)
+	}
+	if next != 1 {
+		t.Errorf("next = %d, want 1", next)
+	}
+}
+
+func TestOptionValueOrErrorRejectsEmptyNextToken(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := optionValueOrError([]string{"--id", ""}, 0, "--id")
+	ec, ok := cliexit.IsExitCodeError(err)
+	if !ok || ec.Code != 2 {
+		t.Fatalf("err = %v, want *cliexit.ExitCodeError{Code:2}", err)
+	}
+	if !strings.Contains(ec.Message, "requires a value") {
+		t.Errorf("Message = %q, want substring 'requires a value'", ec.Message)
+	}
+}
+
+func TestOptionValueOrErrorRejectsAtEndOfArgs(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := optionValueOrError([]string{"--id"}, 0, "--id")
+	ec, ok := cliexit.IsExitCodeError(err)
+	if !ok || ec.Code != 2 {
+		t.Fatalf("err = %v, want *cliexit.ExitCodeError{Code:2}", err)
+	}
+	if !strings.Contains(ec.Message, "--id") {
+		t.Errorf("Message = %q, want substring '--id'", ec.Message)
+	}
+}
+
+func TestUnsupportedOptionBuildsMessageAndExit2(t *testing.T) {
+	t.Parallel()
+
+	err := unsupportedOption("session send", "--bogus")
+	ec, ok := cliexit.IsExitCodeError(err)
+	if !ok || ec.Code != 2 {
+		t.Fatalf("err = %v, want *cliexit.ExitCodeError{Code:2}", err)
+	}
+	if !strings.Contains(ec.Message, "Unsupported workcell session send option: --bogus") {
+		t.Errorf("Message = %q, want substring 'Unsupported workcell session send option: --bogus'", ec.Message)
+	}
+}
+
+func TestRejectControlCharsAcceptsCleanValue(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"session-1", "Verify PR title", "tab\there", ""} {
+		if err := rejectControlChars("session send", "--id", value); err != nil {
+			t.Errorf("rejectControlChars(%q) err = %v, want nil", value, err)
+		}
+	}
+}
+
+func TestRejectControlCharsRejectsNewline(t *testing.T) {
+	t.Parallel()
+
+	err := rejectControlChars("session send", "--message", "hello\nsession_id=other")
+	ec, ok := cliexit.IsExitCodeError(err)
+	if !ok || ec.Code != 2 {
+		t.Fatalf("err = %v, want *cliexit.ExitCodeError{Code:2}", err)
+	}
+	if !strings.Contains(ec.Message, "newline") {
+		t.Errorf("Message = %q, want substring 'newline'", ec.Message)
+	}
+}
+
+func TestRejectControlCharsRejectsCarriageReturn(t *testing.T) {
+	t.Parallel()
+
+	err := rejectControlChars("session send", "--message", "hello\rsmuggled")
+	ec, ok := cliexit.IsExitCodeError(err)
+	if !ok || ec.Code != 2 {
+		t.Fatalf("err = %v, want *cliexit.ExitCodeError{Code:2}", err)
+	}
+	if !strings.Contains(ec.Message, "carriage-return") {
+		t.Errorf("Message = %q, want substring 'carriage-return'", ec.Message)
+	}
+}
+
+func TestRejectControlCharsAcceptsTab(t *testing.T) {
+	t.Parallel()
+
+	// Tab is allowed: it isn't a record/field separator in the bash
+	// `IFS= read -r line` loop that parses the KEY=VALUE plan, and
+	// users may legitimately include tabs in --message bodies.
+	if err := rejectControlChars("session send", "--message", "col1\tcol2"); err != nil {
+		t.Errorf("rejectControlChars(tab) err = %v, want nil", err)
+	}
+}

--- a/internal/sessionctl/send_test.go
+++ b/internal/sessionctl/send_test.go
@@ -260,3 +260,43 @@ func TestSendMainRejectsUnknownOption(t *testing.T) {
 		t.Fatalf("sendMain error = %v, want ExitCodeError{Code:2}", err)
 	}
 }
+
+// TestSendMainRejectsControlCharsInUserInputs guards rejectControlChars
+// at the session-send input boundary for the two user-controlled
+// fields (--id and --message). A CR/LF in either would let the bash
+// shim see forged plan lines after the first newline.
+func TestSendMainRejectsControlCharsInUserInputs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"id-newline", []string{"--id", "session-1\nsession_id=other", "--message", "ok"}},
+		{"id-cr", []string{"--id", "session-1\rsession_id=other", "--message", "ok"}},
+		{"message-newline", []string{"--id", "session-1", "--message", "hello\nsession_id=other"}},
+		{"message-cr", []string{"--id", "session-1", "--message", "hello\rsession_id=other"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			err := sendMain(tc.args, &buf, io.Discard)
+			if err == nil {
+				t.Fatalf("sendMain accepted control-char value: %v", tc.args)
+			}
+			var ec *cliexit.ExitCodeError
+			if !errors.As(err, &ec) || ec.Code != 2 {
+				t.Fatalf("sendMain error = %v, want ExitCodeError{Code:2}", err)
+			}
+			if !strings.Contains(ec.Message, "must not contain newline or carriage-return") {
+				t.Fatalf("sendMain message = %q, want newline-rejection diagnostic", ec.Message)
+			}
+			if buf.Len() != 0 {
+				t.Fatalf("sendMain wrote %q on rejection, want no stdout output", buf.String())
+			}
+		})
+	}
+}

--- a/internal/sessionctl/stop_test.go
+++ b/internal/sessionctl/stop_test.go
@@ -267,3 +267,28 @@ func writeStopFixtureRecord(t *testing.T, root, profile, sessionID string, field
 		t.Fatalf("write session record: %v", err)
 	}
 }
+
+// TestStopMainRejectsNewlineInID — sibling guard to
+// monitor_test.go's TestMonitorMainRejectsNewlineInStateFile. CRLF
+// injection into --id would let the shim see forged plan lines.
+func TestStopMainRejectsNewlineInID(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"session-1\nsession_id=other", "session-1\rsession_id=other"} {
+		var buf bytes.Buffer
+		err := stopMain([]string{"--id", value}, &buf, io.Discard)
+		if err == nil {
+			t.Fatalf("stopMain accepted --id value containing control character: %q", value)
+		}
+		var ec *cliexit.ExitCodeError
+		if !errors.As(err, &ec) || ec.Code != 2 {
+			t.Fatalf("stopMain error = %v, want ExitCodeError{Code:2}", err)
+		}
+		if !strings.Contains(ec.Message, "must not contain newline or carriage-return") {
+			t.Fatalf("stopMain message = %q, want newline-rejection diagnostic", ec.Message)
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("stopMain wrote %q on rejection, want no stdout output", buf.String())
+		}
+	}
+}

--- a/internal/sessionctl/timeline.go
+++ b/internal/sessionctl/timeline.go
@@ -4,9 +4,9 @@
 package sessionctl
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/host/sessions"
 	"github.com/omkhar/workcell/internal/host/stateroot"
 )
@@ -32,7 +32,7 @@ func TimelineMain(args []string) error {
 		return nil
 	}
 	if sessionID == "" {
-		return errors.New("workcell session timeline requires --id.")
+		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session timeline requires --id."}
 	}
 
 	if len(roots) == 0 {
@@ -52,15 +52,16 @@ func parseTimelineArgs(args []string) (sessionID string, showHelp bool, err erro
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--id":
-			if i+1 >= len(args) || args[i+1] == "" {
-				return "", false, fmt.Errorf("--id requires a non-empty value")
+			value, next, perr := optionValueOrError(args, i, "--id")
+			if perr != nil {
+				return "", false, perr
 			}
-			sessionID = args[i+1]
-			i++
+			sessionID = value
+			i = next
 		case "-h", "--help":
 			showHelp = true
 		default:
-			return "", false, fmt.Errorf("Unsupported workcell session timeline option: %s", args[i])
+			return "", false, unsupportedOption("session timeline", args[i])
 		}
 	}
 	return sessionID, showHelp, nil

--- a/internal/sessionctl/timeline_test.go
+++ b/internal/sessionctl/timeline_test.go
@@ -6,6 +6,8 @@ package sessionctl
 import (
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 func TestParseTimelineArgsRequiresIDValue(t *testing.T) {
@@ -15,8 +17,12 @@ func TestParseTimelineArgsRequiresIDValue(t *testing.T) {
 	if err == nil {
 		t.Fatal("parseTimelineArgs accepted --id without a value")
 	}
-	if !strings.Contains(err.Error(), "non-empty") {
-		t.Fatalf("parseTimelineArgs error = %v, want non-empty rejection", err)
+	if !strings.Contains(err.Error(), "requires a value") {
+		t.Fatalf("parseTimelineArgs error = %v, want requires-a-value rejection", err)
+	}
+	ec, ok := cliexit.IsExitCodeError(err)
+	if !ok || ec.Code != 2 {
+		t.Fatalf("parseTimelineArgs error = %v, want *cliexit.ExitCodeError{Code:2}", err)
 	}
 }
 

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -17,6 +17,14 @@
       "sha256": "f1057951d6f65e12d82a7bc2b5002afde5664670d8f4ed7d9bc289bbec5f5901"
     },
     {
+      "repo_path": "scripts/lib/sessionctl-shim.sh",
+      "sha256": "07fcc20cf54aca8cddba0f98889737c2d89cc3014ab4c4b1c015a85fb3469dce"
+    },
+    {
+      "repo_path": "scripts/lib/shellproto.sh",
+      "sha256": "8b6460e7f20b4eaa853b8b52fa3805108e09e4f9c901be84188810d87954ff58"
+    },
+    {
       "repo_path": "scripts/lib/trusted-docker-client.sh",
       "sha256": "cc7ae4af8703361a675b3e262808938de85f65870002151c48760bf7f5aade71"
     }

--- a/scripts/dev-quick-check.sh
+++ b/scripts/dev-quick-check.sh
@@ -53,6 +53,8 @@ shell_files=(
   "${ROOT_DIR}/scripts/lib/render_injection_bundle"
   "${ROOT_DIR}/scripts/lib/resolve_credential_sources"
   "${ROOT_DIR}/scripts/lib/scenario_manifest"
+  "${ROOT_DIR}/scripts/lib/sessionctl-shim.sh"
+  "${ROOT_DIR}/scripts/lib/shellproto.sh"
   "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
   "${ROOT_DIR}/scripts/generate-homebrew-formula.sh"
   "${ROOT_DIR}/scripts/update-upstream-pins.sh"

--- a/scripts/lib/sessionctl-shim.sh
+++ b/scripts/lib/sessionctl-shim.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
+# shellcheck shell=bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Omkhar Arasaratnam
 #

--- a/scripts/lib/shellproto.sh
+++ b/scripts/lib/shellproto.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
+# shellcheck shell=bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Omkhar Arasaratnam
 #

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -152,6 +152,8 @@ shell_files=(
   "${ROOT_DIR}/scripts/lib/render_injection_bundle"
   "${ROOT_DIR}/scripts/lib/resolve_credential_sources"
   "${ROOT_DIR}/scripts/lib/scenario_manifest"
+  "${ROOT_DIR}/scripts/lib/sessionctl-shim.sh"
+  "${ROOT_DIR}/scripts/lib/shellproto.sh"
   "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
   "${ROOT_DIR}/scripts/generate-control-plane-manifest.sh"
   "${ROOT_DIR}/scripts/generate-builder-environment-manifest.sh"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1269,6 +1269,16 @@ if ! rg -q 'source "\$\{ROOT_DIR\}/scripts/lib/trusted-docker-client\.sh"' "${RO
   exit 1
 fi
 
+if ! rg -q 'source "\$\{ROOT_DIR\}/scripts/lib/shellproto\.sh"' "${ROOT_DIR}/scripts/workcell"; then
+  echo "Expected scripts/workcell to source the shellproto helper" >&2
+  exit 1
+fi
+
+if ! rg -q 'source "\$\{ROOT_DIR\}/scripts/lib/sessionctl-shim\.sh"' "${ROOT_DIR}/scripts/workcell"; then
+  echo "Expected scripts/workcell to source the sessionctl shim helper" >&2
+  exit 1
+fi
+
 INSTALL_DEPS_VERIFY_BIN="${BARRIER_VERIFY_ROOT}/install-deps-bin"
 INSTALL_DEPS_LOG="${BARRIER_VERIFY_ROOT}/install-deps-brew.log"
 INSTALL_DEPS_VERIFY_HOME="$(mktemp -d "${BARRIER_VERIFY_ROOT}/install-deps-home.XXXXXX")"


### PR DESCRIPTION
PR-FIX-5 of the round-2 sethify fix-up rollout. Closes the 2 🔴 + 2 🟠 + adoption-tail items from the /sethify review of the round-1 fix-up rollout (`42a8ee5..5b007a2`).

## 🔴 Blockers
- **B-new-1**: `scripts/lib/shellproto.sh` and `scripts/lib/sessionctl-shim.sh` added to `hostArtifacts` in `internal/metadatautil/core.go`; manifest regenerated.
- **B-new-2**: Both shims added to `shell_files` arrays in `dev-quick-check.sh` and `validate-repo.sh`; `# shellcheck shell=bash` directives added.

## 🟠 Near-red
- **Q17 regression**: `rootUsageError` actually prints subcommand list now (was building `names` then discarding); scenario-manifest visible in error output.
- **Sec-symlink-source**: `validateDirectMount` rejects symlinked top-level sources via `os.Lstat`; closes the same escape class `copyDirContents` skip already addressed for inside-directory entries.

## CI hygiene
- `verify-invariants.sh` static-scan invariants for the 2 new boot-time `source` statements.

## A3/A4 cliexit completion
- `logs.go`, `timeline.go` migrated to `cliexit.ExitCodeError{Code:2}` for usage / `Code:1` for runtime; closes the exit-code-demotion B4-class bug for the last 2 sessionctl Main funcs.
- `publishpr.ExitCodeError` type alias + `IsExitCodeError` forwarder removed; test file migrated to `cliexit.*`.

## Test coverage
- New `internal/sessionctl/parsehelpers_test.go` (8 tests).
- New newline-rejection regression tests in `attach_test.go`, `send_test.go`, `stop_test.go`, `delete_test.go` mirroring monitor_test's pattern. Closes the PR-FIX-1A test-coverage gap.

## Shape
files=22, areas=6, 371 insertions / 61 deletions. Well under limits.

## Test plan
- [ ] Validate repository CI green
- [ ] Reproducible build CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)