### PR TITLE
^R Sethify round-2 architecture closures (fix-6)

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/omkhar/workcell/internal/host/launcher"
 	"github.com/omkhar/workcell/internal/host/release"
 	"github.com/omkhar/workcell/internal/host/sessions"
+	"github.com/omkhar/workcell/internal/host/stateroot"
 	"github.com/omkhar/workcell/internal/host/supportmatrix"
 	"github.com/omkhar/workcell/internal/injection"
 	"github.com/omkhar/workcell/internal/publishpr"
@@ -73,40 +74,29 @@ func run(args []string) error {
 // TOML files. Not to be confused with `workcell-hostutil launcher
 // policy-cli` below, which is the **`workcell policy <subcommand>`** Go
 // translation of the bash policy_main user-shell command (init/show/...).
-// The previous standalone binary deferred to authpolicy.Run; we keep
-// the same contract here so callers see identical stdout/stderr and
-// exit codes.
+// authpolicy.Run returns a *cliexit.ExitCodeError directly, so we can
+// propagate it without re-wrapping; main()'s typed handler preserves
+// the stdout/stderr/exit-code contract.
 func runHostutilPolicy(args []string) error {
-	code := authpolicy.Run("workcell-hostutil policy", args, os.Stdout, os.Stderr)
-	if code == 0 {
-		return nil
-	}
-	return &cliexit.ExitCodeError{Code: code, Message: ""}
+	return authpolicy.Run("workcell-hostutil policy", args, os.Stdout, os.Stderr)
 }
 
 // runHostutilResolveCredentials dispatches the absorbed
 // workcell-resolve-credential-sources CLI surface.  authresolve.Run
-// already writes stdout/stderr and returns the bash-shaped exit code;
-// we wrap it in an ExitCodeError so main()'s typed handler can
-// preserve the contract.
+// writes diagnostics to stderr and returns a *cliexit.ExitCodeError
+// directly, so we can propagate it untouched and let main()'s typed
+// handler preserve the bash exit-code contract.
 func runHostutilResolveCredentials(args []string) error {
-	code := authresolve.Run(args, os.Stdout, os.Stderr)
-	if code == 0 {
-		return nil
-	}
-	return &cliexit.ExitCodeError{Code: code, Message: ""}
+	return authresolve.Run(args, os.Stdout, os.Stderr)
 }
 
 // runHostutilPTYTranscript dispatches the absorbed
 // workcell-pty-transcript CLI surface.  transcript.Run wants the
 // raw *os.File for stdin/stdout (it tees PTY output and stamps
-// timestamps), so we forward os.Stdin/os.Stdout directly.
+// timestamps), so we forward os.Stdin/os.Stdout directly.  Run returns
+// a *cliexit.ExitCodeError directly, so we propagate it untouched.
 func runHostutilPTYTranscript(args []string) error {
-	code := transcript.Run("workcell-hostutil pty-transcript", os.Stdin, os.Stdout, os.Stderr, args)
-	if code == 0 {
-		return nil
-	}
-	return &cliexit.ExitCodeError{Code: code, Message: ""}
+	return transcript.Run("workcell-hostutil pty-transcript", os.Stdin, os.Stdout, os.Stderr, args)
 }
 
 func runPath(args []string) error {
@@ -252,6 +242,12 @@ func launcherSubcommands() []launcherSubcommand {
 		{"injection-stage-direct-mounts", 2, 2, cmdLauncherInjectionStageDirectMounts},
 		{"injection-prepare-bundle", 0, -1, cmdLauncherInjectionPrepareBundle},
 		{"publish-pr-cli", 0, -1, cmdLauncherPublishPRCli},
+		// lookup-state-roots takes the two state-root values as
+		// positional args (in WORKCELL,COLIMA order) so the bash shim
+		// does not need to leak them through env -i to the cleaned
+		// host process; bash forwards `${WORKCELL_STATE_ROOT:-} ${COLIMA_STATE_ROOT:-}`
+		// directly on the command line.
+		{"lookup-state-roots", 2, 2, cmdLauncherLookupStateRoots},
 	}
 }
 
@@ -854,7 +850,9 @@ func cmdLauncherInjectionStageDirectMounts(args []string) error {
 // for the PR 23.4 Go translation of prepare_injection_bundle.  It reads the
 // bash globals from CLI flags, executes the full pipeline in-process, and
 // prints KEY=VALUE lines (one per bash global) so the shim can re-export
-// them via a read loop.
+// them via a read loop.  FormatBundleResultForShell is fail-closed: if
+// any value carries a forbidden control char we propagate the error and
+// emit nothing so bash never re-imports a partial plan.
 func cmdLauncherInjectionPrepareBundle(args []string) error {
 	opts, err := parsePrepareBundleArgs(args)
 	if err != nil {
@@ -864,7 +862,25 @@ func cmdLauncherInjectionPrepareBundle(args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Print(injection.FormatBundleResultForShell(result))
+	formatted, err := injection.FormatBundleResultForShell(result)
+	if err != nil {
+		return err
+	}
+	fmt.Print(formatted)
+	return nil
+}
+
+// cmdLauncherLookupStateRoots is the launcher subcommand entry point
+// that scripts/workcell::session_lookup_root_args shells out to so the
+// bash↔Go state-root contract has a single Go owner.  The two roots
+// arrive as positional args in (workcell, colima) order rather than as
+// env vars because go_hostutil routes through run_clean_host_command,
+// which strips the process env via env -i.  Each non-empty value is
+// emitted on its own line as a ready-to-consume `--root=PATH` token.
+func cmdLauncherLookupStateRoots(args []string) error {
+	for _, line := range stateroot.FormatRootArgs(args[0], args[1]) {
+		fmt.Println(line)
+	}
 	return nil
 }
 

--- a/cmd/workcell-metadatautil/main.go
+++ b/cmd/workcell-metadatautil/main.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/metadatautil"
 	"github.com/omkhar/workcell/internal/metadatautil/hostedcontrols"
 	"github.com/omkhar/workcell/internal/metadatautil/pinnedinputs"
@@ -100,11 +101,18 @@ func main() {
 	}
 	// scenario-manifest preserves the bash contract of distinct exit
 	// codes for usage (2) vs. runtime (1) errors that
-	// scenarios.Run encodes; we forward through it directly rather
-	// than collapsing into the generic error-then-die path used by
-	// the other subcommands.
+	// scenarios.Run encodes; scenarios.Run already wrote the
+	// diagnostic to stderr and returns a *cliexit.ExitCodeError, so we
+	// forward Code straight through to os.Exit instead of routing it
+	// through die() (which would double-print the message).
 	if os.Args[1] == "scenario-manifest" {
-		os.Exit(scenarios.Run("workcell-metadatautil scenario-manifest", os.Args[2:], os.Stdout, os.Stderr))
+		if err := scenarios.Run("workcell-metadatautil scenario-manifest", os.Args[2:], os.Stdout, os.Stderr); err != nil {
+			if ec, ok := cliexit.IsExitCodeError(err); ok {
+				os.Exit(ec.Code)
+			}
+			die(err)
+		}
+		return
 	}
 	for _, sub := range subcommands() {
 		if sub.name != os.Args[1] {

--- a/internal/authpolicy/auth_main.go
+++ b/internal/authpolicy/auth_main.go
@@ -401,13 +401,10 @@ func nextValue(args []string, i int, strict bool) (string, error) {
 // invocation of scripts/lib/manage_injection_policy. The cwd-based home
 // isolation that run_clean_host_command provides is unnecessary here
 // because Run does not exec subprocesses; it only reads files via paths
-// the caller already canonicalised.
+// the caller already canonicalised.  Run returns a *cliexit.ExitCodeError
+// directly, so we propagate it untouched.
 func runManagePolicy(args []string, stdout, stderr io.Writer) error {
-	code := Run("workcell-manage-injection-policy", args, stdout, stderr)
-	if code == 0 {
-		return nil
-	}
-	return &cliexit.ExitCodeError{Code: code, Message: ""}
+	return Run("workcell-manage-injection-policy", args, stdout, stderr)
 }
 
 // authMainBuffer is used by tests that need stdout captured separately

--- a/internal/authpolicy/manage.go
+++ b/internal/authpolicy/manage.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/omkhar/workcell/internal/authresolve"
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/providerid"
 	"github.com/omkhar/workcell/internal/rootio"
 	"github.com/omkhar/workcell/internal/secretfile"
@@ -46,113 +47,121 @@ var (
 	}
 )
 
-func Run(program string, args []string, stdout, stderr io.Writer) int {
+// Run is the byte-for-byte translation of the bash
+// workcell-manage-injection-policy entry point.  It writes diagnostics
+// to stderr exactly as the original did and returns a
+// *cliexit.ExitCodeError encoding the bash exit-code contract; the
+// caller (cmd/workcell-hostutil/main.go) recovers Code via errors.As
+// and propagates it to os.Exit.  Returning the typed error rather than
+// an int keeps the package on the canonical error-returning idiom
+// every other Go CLI translation in this repo uses.
+func Run(program string, args []string, stdout, stderr io.Writer) error {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, usage(program))
-		return 2
+		return &cliexit.ExitCodeError{Code: 2}
 	}
 	switch args[0] {
 	case "init":
 		policyPath, managedRoot, err := parseInitArgs(program, args[1:], stderr)
 		if err != nil {
-			return 2
+			return &cliexit.ExitCodeError{Code: 2}
 		}
 		if err := commandInit(policyPath, managedRoot); err != nil {
 			fmt.Fprintln(stderr, err)
-			return 1
+			return &cliexit.ExitCodeError{Code: 1}
 		}
 		fmt.Fprintln(stdout, "policy_path="+resolveOutputPath(policyPath))
 		fmt.Fprintln(stdout, "managed_root="+resolveOutputPath(managedRoot))
-		return 0
+		return nil
 	case "set":
 		opts, err := parseSetArgs(program, args[1:], stderr)
 		if err != nil {
-			return 2
+			return &cliexit.ExitCodeError{Code: 2}
 		}
 		if err := commandSet(opts); err != nil {
 			fmt.Fprintln(stderr, err)
-			return 1
+			return &cliexit.ExitCodeError{Code: 1}
 		}
 		printSetOutput(stdout, opts)
-		return 0
+		return nil
 	case "unset":
 		policyPath, managedRoot, credential, err := parseUnsetArgs(program, args[1:], stderr)
 		if err != nil {
-			return 2
+			return &cliexit.ExitCodeError{Code: 2}
 		}
 		removed, err := commandUnset(policyPath, managedRoot, credential)
 		if err != nil {
 			fmt.Fprintln(stderr, err)
-			return 1
+			return &cliexit.ExitCodeError{Code: 1}
 		}
 		fmt.Fprintln(stdout, "policy_path="+policyPath)
 		fmt.Fprintln(stdout, "credential="+credential)
 		fmt.Fprintf(stdout, "removed=%d\n", removed)
-		return 0
+		return nil
 	case "status":
 		opts, err := parseStatusArgs(program, args[1:], stderr)
 		if err != nil {
-			return 2
+			return &cliexit.ExitCodeError{Code: 2}
 		}
 		if err := commandStatus(opts, stdout); err != nil {
 			fmt.Fprintln(stderr, err)
-			return 1
+			return &cliexit.ExitCodeError{Code: 1}
 		}
-		return 0
+		return nil
 	case "show":
 		policyPath, err := parsePolicyPathArgs(program, "show", args[1:], stderr)
 		if err != nil {
-			return 2
+			return &cliexit.ExitCodeError{Code: 2}
 		}
 		if err := commandShow(policyPath, stdout); err != nil {
 			fmt.Fprintln(stderr, err)
-			return 1
+			return &cliexit.ExitCodeError{Code: 1}
 		}
-		return 0
+		return nil
 	case "validate":
 		policyPath, err := parsePolicyPathArgs(program, "validate", args[1:], stderr)
 		if err != nil {
-			return 2
+			return &cliexit.ExitCodeError{Code: 2}
 		}
 		if err := commandValidate(policyPath, stdout); err != nil {
 			fmt.Fprintln(stderr, err)
-			return 1
+			return &cliexit.ExitCodeError{Code: 1}
 		}
-		return 0
+		return nil
 	case "diff":
 		policyPath, err := parsePolicyPathArgs(program, "diff", args[1:], stderr)
 		if err != nil {
-			return 2
+			return &cliexit.ExitCodeError{Code: 2}
 		}
 		if err := commandDiff(policyPath, stdout); err != nil {
 			fmt.Fprintln(stderr, err)
-			return 1
+			return &cliexit.ExitCodeError{Code: 1}
 		}
-		return 0
+		return nil
 	case "why":
 		opts, err := parseWhyArgs(program, args[1:], stderr)
 		if err != nil {
-			return 2
+			return &cliexit.ExitCodeError{Code: 2}
 		}
 		if err := commandWhy(opts, stdout); err != nil {
 			fmt.Fprintln(stderr, err)
-			return 1
+			return &cliexit.ExitCodeError{Code: 1}
 		}
-		return 0
+		return nil
 	case "bootstrap-summary":
 		opts, err := parseBootstrapSummaryArgs(program, args[1:], stderr)
 		if err != nil {
-			return 2
+			return &cliexit.ExitCodeError{Code: 2}
 		}
 		if err := commandBootstrapSummary(opts, stdout); err != nil {
 			fmt.Fprintln(stderr, err)
-			return 1
+			return &cliexit.ExitCodeError{Code: 1}
 		}
-		return 0
+		return nil
 	default:
 		fmt.Fprintln(stderr, usage(program))
 		fmt.Fprintf(stderr, "%s: unsupported command: %s\n", program, args[0])
-		return 2
+		return &cliexit.ExitCodeError{Code: 2}
 	}
 }
 

--- a/internal/authpolicy/manage_test.go
+++ b/internal/authpolicy/manage_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 type runResult struct {
@@ -20,8 +22,22 @@ type runResult struct {
 func runAuthPolicy(args ...string) runResult {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run("workcell", args, &stdout, &stderr)
-	return runResult{code: code, stdout: stdout.String(), stderr: stderr.String()}
+	err := Run("workcell", args, &stdout, &stderr)
+	return runResult{code: exitCodeFromRunErr(err), stdout: stdout.String(), stderr: stderr.String()}
+}
+
+// exitCodeFromRunErr extracts the bash exit-code contract out of the
+// typed error Run now returns.  Tests previously asserted on the int
+// return; routing it through *cliexit.ExitCodeError preserves those
+// assertions verbatim.
+func exitCodeFromRunErr(err error) int {
+	if err == nil {
+		return 0
+	}
+	if ec, ok := cliexit.IsExitCodeError(err); ok {
+		return ec.Code
+	}
+	return 1
 }
 
 func writeFile(tb testing.TB, path, content string, mode os.FileMode) {

--- a/internal/authpolicy/policy.go
+++ b/internal/authpolicy/policy.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -16,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/omkhar/workcell/internal/pathutil"
 	"github.com/omkhar/workcell/internal/providerid"
 	"github.com/omkhar/workcell/internal/rootio"
 	"github.com/omkhar/workcell/internal/secretfile"
@@ -106,40 +106,16 @@ func expandHostPath(raw string, base string) (string, error) {
 	return filepath.Abs(expanded)
 }
 
+// expandUserPath is a thin wrapper around pathutil.ExpandUserPathStrict
+// that preserves the "empty raw input is an error" rule the bash
+// caller's input-validation layer relied on.  All other tilde-expansion
+// semantics (including the ~user lookup) live in the shared pathutil
+// helper so we have a single Go owner of the expansion rules.
 func expandUserPath(raw string) (string, error) {
-	switch {
-	case raw == "":
+	if raw == "" {
 		return "", fmt.Errorf("empty path")
-	case raw == "~":
-		return os.UserHomeDir()
-	case strings.HasPrefix(raw, "~/"):
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, raw[2:]), nil
-	case strings.HasPrefix(raw, "~"):
-		slash := strings.IndexByte(raw, '/')
-		userName := raw[1:]
-		remainder := ""
-		if slash >= 0 {
-			userName = raw[1:slash]
-			remainder = raw[slash+1:]
-		}
-		if userName == "" {
-			return os.UserHomeDir()
-		}
-		usr, err := user.Lookup(userName)
-		if err != nil {
-			return "", err
-		}
-		if remainder == "" {
-			return usr.HomeDir, nil
-		}
-		return filepath.Join(usr.HomeDir, remainder), nil
-	default:
-		return raw, nil
 	}
+	return pathutil.ExpandUserPathStrict(raw)
 }
 
 func requirePathWithin(root string, candidate string, label string) error {

--- a/internal/authresolve/resolve_credential_sources.go
+++ b/internal/authresolve/resolve_credential_sources.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/providerid"
 	"github.com/omkhar/workcell/internal/rootio"
 	"github.com/omkhar/workcell/internal/secretfile"
@@ -123,18 +124,23 @@ type config struct {
 	outputRoot     string
 }
 
-// Run executes the resolve-credential-sources workflow.
-func Run(args []string, stdout, stderr io.Writer) int {
+// Run executes the resolve-credential-sources workflow.  Diagnostics
+// land on stderr exactly as the bash predecessor wrote them, and the
+// returned error is either nil or a *cliexit.ExitCodeError carrying
+// the bash exit-code contract.  The hostutil wrapper recovers Code via
+// errors.As and propagates it to os.Exit, keeping a single typed
+// channel for every translated bash main in this repo.
+func Run(args []string, stdout, stderr io.Writer) error {
 	cfg, err := parseArgs(args)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
-		return 2
+		return &cliexit.ExitCodeError{Code: 2}
 	}
 	if err := run(cfg); err != nil {
 		fmt.Fprintln(stderr, err)
-		return 1
+		return &cliexit.ExitCodeError{Code: 1}
 	}
-	return 0
+	return nil
 }
 
 func parseArgs(args []string) (config, error) {

--- a/internal/authresolve/resolve_credential_sources_test.go
+++ b/internal/authresolve/resolve_credential_sources_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/host/hoststate"
 )
 
@@ -26,8 +27,21 @@ func runResolveCredentialSources(tb testing.TB, args []string, env map[string]st
 	for key, value := range env {
 		tb.Setenv(key, value)
 	}
-	code := Run(args, &stdout, &stderr)
-	return code, stdout.String(), stderr.String()
+	err := Run(args, &stdout, &stderr)
+	return exitCodeFromRunErr(err), stdout.String(), stderr.String()
+}
+
+// exitCodeFromRunErr extracts the bash exit-code contract from the
+// typed error Run returns so existing `code != 0` assertions keep
+// working without churn.
+func exitCodeFromRunErr(err error) int {
+	if err == nil {
+		return 0
+	}
+	if ec, ok := cliexit.IsExitCodeError(err); ok {
+		return ec.Code
+	}
+	return 1
 }
 
 func snapshotFile(tb testing.TB, path string) fileSnapshot {

--- a/internal/host/hoststate/hoststate.go
+++ b/internal/host/hoststate/hoststate.go
@@ -430,19 +430,12 @@ func currentUID() (uint32, bool) {
 	return uint32(uid), true
 }
 
+// expandUserPathForLauncher is a thin alias for
+// pathutil.ExpandUserPathHomeOnly that keeps the call-site idiomatic.
+// The launcher deliberately uses the "no `~user` lookup" variant so a
+// pointer file under WORKCELL_STATE_ROOT cannot force os/user database
+// queries; all other tilde-expansion semantics live in the shared
+// pathutil helper.
 func expandUserPathForLauncher(raw string) string {
-	if raw == "" {
-		return ""
-	}
-	if raw == "~" || strings.HasPrefix(raw, "~/") {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return raw
-		}
-		if raw == "~" {
-			return home
-		}
-		return filepath.Join(home, raw[2:])
-	}
-	return raw
+	return pathutil.ExpandUserPathHomeOnly(raw)
 }

--- a/internal/host/stateroot/stateroot.go
+++ b/internal/host/stateroot/stateroot.go
@@ -53,3 +53,37 @@ func LookupRoots() []string {
 	}
 	return roots
 }
+
+// FormattedRootArgs returns the --root=VALUE strings for non-empty
+// WORKCELL_STATE_ROOT and COLIMA_STATE_ROOT env vars, in that fixed
+// order.  This is the single Go owner of the bash↔Go state-root
+// contract; scripts/workcell::session_lookup_root_args shells out
+// through workcell-hostutil to consume it, so the order and the
+// "skip empty" rule live in exactly one place.
+func FormattedRootArgs() []string {
+	roots := LookupRoots()
+	out := make([]string, 0, len(roots))
+	for _, root := range roots {
+		out = append(out, "--root="+root)
+	}
+	return out
+}
+
+// FormatRootArgs is the argv-driven sibling of FormattedRootArgs: it
+// returns the --root=VALUE strings for non-empty workcellRoot and
+// colimaRoot, in that fixed order.  scripts/workcell shells out
+// through go_hostutil → run_clean_host_command, which calls env -i and
+// strips the process env, so the bash shim cannot rely on
+// FormattedRootArgs reading env vars; instead it forwards
+// `${WORKCELL_STATE_ROOT:-} ${COLIMA_STATE_ROOT:-}` on argv and lets
+// this helper apply the same skip-empty rule.  Keeping both functions
+// in this package means the rule still lives in exactly one place.
+func FormatRootArgs(workcellRoot, colimaRoot string) []string {
+	out := make([]string, 0, 2)
+	for _, root := range []string{workcellRoot, colimaRoot} {
+		if root != "" {
+			out = append(out, "--root="+root)
+		}
+	}
+	return out
+}

--- a/internal/host/stateroot/stateroot_test.go
+++ b/internal/host/stateroot/stateroot_test.go
@@ -66,3 +66,58 @@ func TestLookupRootsSkipsEmpty(t *testing.T) {
 		t.Fatalf("LookupRoots() = %v, want [/tmp/wc]", got)
 	}
 }
+
+func TestFormattedRootArgsEmitsRootFlagPerNonEmptyEnv(t *testing.T) {
+	t.Setenv("WORKCELL_STATE_ROOT", "/tmp/wc")
+	t.Setenv("COLIMA_STATE_ROOT", "/tmp/colima")
+
+	got := FormattedRootArgs()
+	want := []string{"--root=/tmp/wc", "--root=/tmp/colima"}
+	if len(got) != len(want) {
+		t.Fatalf("FormattedRootArgs() = %v, want %v", got, want)
+	}
+	for i, line := range got {
+		if line != want[i] {
+			t.Fatalf("FormattedRootArgs()[%d] = %q, want %q", i, line, want[i])
+		}
+	}
+}
+
+func TestFormattedRootArgsSkipsEmpty(t *testing.T) {
+	t.Setenv("WORKCELL_STATE_ROOT", "")
+	t.Setenv("COLIMA_STATE_ROOT", "/tmp/colima")
+
+	got := FormattedRootArgs()
+	if len(got) != 1 || got[0] != "--root=/tmp/colima" {
+		t.Fatalf("FormattedRootArgs() = %v, want [--root=/tmp/colima]", got)
+	}
+}
+
+func TestFormatRootArgsEmitsBothInWorkcellThenColimaOrder(t *testing.T) {
+	t.Parallel()
+
+	got := FormatRootArgs("/tmp/wc", "/tmp/colima")
+	want := []string{"--root=/tmp/wc", "--root=/tmp/colima"}
+	if len(got) != len(want) {
+		t.Fatalf("FormatRootArgs() = %v, want %v", got, want)
+	}
+	for i, line := range got {
+		if line != want[i] {
+			t.Fatalf("FormatRootArgs()[%d] = %q, want %q", i, line, want[i])
+		}
+	}
+}
+
+func TestFormatRootArgsSkipsEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := FormatRootArgs("", "/tmp/colima"); len(got) != 1 || got[0] != "--root=/tmp/colima" {
+		t.Fatalf("FormatRootArgs(empty,/tmp/colima) = %v, want [--root=/tmp/colima]", got)
+	}
+	if got := FormatRootArgs("/tmp/wc", ""); len(got) != 1 || got[0] != "--root=/tmp/wc" {
+		t.Fatalf("FormatRootArgs(/tmp/wc,empty) = %v, want [--root=/tmp/wc]", got)
+	}
+	if got := FormatRootArgs("", ""); len(got) != 0 {
+		t.Fatalf("FormatRootArgs(empty,empty) = %v, want []", got)
+	}
+}

--- a/internal/injection/extract_direct_mounts.go
+++ b/internal/injection/extract_direct_mounts.go
@@ -8,11 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
 	"slices"
 	"sort"
-	"strings"
+
+	"github.com/omkhar/workcell/internal/pathutil"
 )
 
 // DirectMount is the JSON shape this binary emits for each direct mount.
@@ -216,48 +216,16 @@ func sortedMapKeys(values map[string]any) []string {
 	return keys
 }
 
+// expandUserPath is a thin wrapper around pathutil.ExpandUserPathStrict
+// that preserves the "empty raw input is an error" rule the bash
+// caller's input-validation layer relied on.  All other tilde-expansion
+// semantics live in the shared pathutil helper so we have a single Go
+// owner of the expansion rules.
 func expandUserPath(raw string) (string, error) {
 	if raw == "" {
 		return "", errors.New("empty path")
 	}
-	if raw == "~" || strings.HasPrefix(raw, "~/") {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		if raw == "~" {
-			return home, nil
-		}
-		return filepath.Join(home, raw[2:]), nil
-	}
-	if strings.HasPrefix(raw, "~") {
-		slash := strings.IndexByte(raw, '/')
-		userName := raw[1:]
-		remainder := ""
-		if slash >= 0 {
-			userName = raw[1:slash]
-			remainder = raw[slash+1:]
-		}
-		home := ""
-		if userName == "" {
-			var err error
-			home, err = os.UserHomeDir()
-			if err != nil {
-				return "", err
-			}
-		} else {
-			usr, err := user.Lookup(userName)
-			if err != nil {
-				return "", err
-			}
-			home = usr.HomeDir
-		}
-		if remainder == "" {
-			return home, nil
-		}
-		return filepath.Join(home, remainder), nil
-	}
-	return raw, nil
+	return pathutil.ExpandUserPathStrict(raw)
 }
 
 func resolveAbsPath(raw string) (string, error) {

--- a/internal/injection/prepare_bundle.go
+++ b/internal/injection/prepare_bundle.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/omkhar/workcell/internal/authresolve"
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/host/hoststate"
 	"github.com/omkhar/workcell/internal/host/launcher"
 	"github.com/omkhar/workcell/internal/shellproto"
@@ -167,8 +168,15 @@ func PrepareBundle(opts PrepareBundleOptions) (*PrepareBundleResult, error) {
 		"--output-metadata", resolverMetadataPath,
 		"--output-root", bundleRoot,
 	}
-	if rc := authresolve.Run(resolverArgs, devNull{}, os.Stderr); rc != 0 {
-		return nil, fmt.Errorf("resolve_credential_sources exited %d", rc)
+	if runErr := authresolve.Run(resolverArgs, devNull{}, os.Stderr); runErr != nil {
+		// authresolve.Run returns *cliexit.ExitCodeError; lift the Code
+		// into the diagnostic so the existing exit-status message stays
+		// byte-identical.
+		code := 1
+		if ec, ok := cliexit.IsExitCodeError(runErr); ok {
+			code = ec.Code
+		}
+		return nil, fmt.Errorf("resolve_credential_sources exited %d", code)
 	}
 
 	if err := RunRenderInjectionBundle(resolvedPolicyPath, opts.Agent, opts.Mode, bundleRoot, resolverMetadataPath); err != nil {
@@ -299,9 +307,16 @@ func (devNull) Write(p []byte) (int, error) { return len(p), nil }
 // DIRECT_SOURCE_MOUNTS_0=val, DIRECT_SOURCE_MOUNTS_1=val, ...) so the
 // shim can rebuild the bash array without needing to parse any in-line
 // separator.
-func FormatBundleResultForShell(result *PrepareBundleResult) string {
+//
+// Fail-closed: if any field value contains a forbidden control
+// character (newline or carriage return) the function returns an error
+// and emits NOTHING — the caller MUST surface the error so the bash
+// shim never re-imports a partial plan with a smuggled-in extra KEY=
+// line.  Upstream extractors already constrain values to printable
+// tokens, so this should only fire if a contract break slips in.
+func FormatBundleResultForShell(result *PrepareBundleResult) (string, error) {
 	if result == nil {
-		return ""
+		return "", nil
 	}
 	fields := make([]shellproto.Field, 0, 16+len(result.DirectSourceMounts))
 	fields = append(fields,
@@ -330,15 +345,10 @@ func FormatBundleResultForShell(result *PrepareBundleResult) string {
 		shellproto.Field{Key: "INJECTION_SECRET_COPY_TARGETS", Value: result.InjectionSecretCopyTargets},
 	)
 	var b strings.Builder
-	// WriteFields can only fail if a value contains a forbidden control
-	// character; the bundle result fields are all derived from policy
-	// content that the bash caller already constrains to printable
-	// tokens (see resolve_credential_sources / extract_direct_mounts),
-	// so an error here would indicate a contract break by an upstream
-	// emitter rather than user input.  Drop validation errors silently
-	// so the existing string-returning signature stays stable - the
-	// shellproto package's input-validation is best-effort defence in
-	// depth, and we already trust the upstream extractors.
-	_ = shellproto.WriteFields(&b, fields)
-	return b.String()
+	if err := shellproto.WriteFields(&b, fields); err != nil {
+		// Drop the partial buffer on the floor: the bash shim
+		// MUST NOT see a half-emitted plan.
+		return "", fmt.Errorf("format bundle result for shell: %w", err)
+	}
+	return b.String(), nil
 }

--- a/internal/injection/prepare_bundle_test.go
+++ b/internal/injection/prepare_bundle_test.go
@@ -97,7 +97,10 @@ func TestFormatBundleResultForShellEmitsExpectedKeys(t *testing.T) {
 		InjectionSSHConfigAssurance:         "on",
 		InjectionSecretCopyTargets:          "claude_oauth",
 	}
-	output := FormatBundleResultForShell(result)
+	output, err := FormatBundleResultForShell(result)
+	if err != nil {
+		t.Fatalf("FormatBundleResultForShell err = %v, want nil", err)
+	}
 	for _, expected := range []string{
 		"INJECTION_BUNDLE_ROOT=/tmp/bundle",
 		"DIRECT_MOUNT_SPEC_PATH=/tmp/bundle.mounts.json",
@@ -119,8 +122,37 @@ func TestFormatBundleResultForShellEmitsExpectedKeys(t *testing.T) {
 }
 
 func TestFormatBundleResultForShellNilSafe(t *testing.T) {
-	if got := FormatBundleResultForShell(nil); got != "" {
+	got, err := FormatBundleResultForShell(nil)
+	if err != nil {
+		t.Fatalf("FormatBundleResultForShell(nil) err = %v, want nil", err)
+	}
+	if got != "" {
 		t.Fatalf("expected empty string for nil result, got %q", got)
+	}
+}
+
+// TestFormatBundleResultForShellRejectsControlChars pins the
+// fail-closed contract: when an upstream extractor smuggles a newline
+// into a field value, FormatBundleResultForShell must return an error
+// and emit NOTHING.  A partial KEY=VALUE plan would let the bash shim
+// re-import a forged second record (e.g. `INJECTION_SSH_ENABLED=1`)
+// and confuse the launcher; the shellproto.WriteFields contract
+// already validates each value at the emit boundary, so this test
+// only needs to assert that we surface that error to the caller
+// instead of dropping it on the floor.
+func TestFormatBundleResultForShellRejectsControlChars(t *testing.T) {
+	t.Parallel()
+
+	result := &PrepareBundleResult{
+		InjectionBundleRoot: "/tmp/bundle\nINJECTION_SSH_ENABLED=1",
+		DirectMountSpecPath: "/tmp/bundle.mounts.json",
+	}
+	got, err := FormatBundleResultForShell(result)
+	if err == nil {
+		t.Fatalf("FormatBundleResultForShell err = nil, want error for newline-containing field; got output %q", got)
+	}
+	if got != "" {
+		t.Fatalf("FormatBundleResultForShell output = %q, want empty on error", got)
 	}
 }
 

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -18,6 +18,33 @@ func ExpandUserPathStrict(raw string) (string, error) {
 	return expandUserPath(raw, true)
 }
 
+// ExpandUserPathHomeOnly expands `~` and `~/...` to the current user's
+// home directory and returns any other input verbatim — it never
+// consults user.Lookup.  This is the launcher-side variant: pointer
+// files read under WORKCELL_STATE_ROOT may legitimately reference paths
+// like `~/Library/...` but a `~someotheruser` reference would force a
+// host-level lookup, which the launcher deliberately avoids so a
+// hostile (or just non-existent) pointer cannot poke at the OS user
+// database.  Errors from os.UserHomeDir are surfaced as nil-result
+// rather than a returned error so the call site can keep its
+// best-effort fallback shape.
+func ExpandUserPathHomeOnly(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if raw == "~" || strings.HasPrefix(raw, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return raw
+		}
+		if raw == "~" {
+			return home
+		}
+		return filepath.Join(home, raw[2:])
+	}
+	return raw
+}
+
 func CanonicalizeExpandedPath(path string) (string, error) {
 	if !filepath.IsAbs(path) {
 		abs, err := filepath.Abs(path)

--- a/internal/publishpr/publish_pr_cli.go
+++ b/internal/publishpr/publish_pr_cli.go
@@ -175,7 +175,9 @@ func PublishPRMain(args []string, stdin io.Reader, stdout, stderr io.Writer) err
 	}
 
 	if opts.DryRun {
-		emitDryRunHeader(stdout, opts, preflight, resolvedWorkspace, publishExistingCommits, draft)
+		if err := emitDryRunHeader(stdout, opts, preflight, resolvedWorkspace, publishExistingCommits, draft); err != nil {
+			return err
+		}
 		EmitCommand(stdout, branchCmd)
 		if opts.Snapshot == "worktree" && publishExistingCommits == 0 {
 			EmitCommand(stdout, addCmd)
@@ -236,18 +238,20 @@ func PublishPRMain(args []string, stdin io.Reader, stdout, stderr io.Writer) err
 	})
 }
 
-func emitDryRunHeader(stdout io.Writer, opts *Options, preflight *PreflightInputs, resolvedWorkspace string, publishExistingCommits int, draft bool) {
+// emitDryRunHeader writes the publish-pr dry-run KEY=VALUE plan header.
+// Fail-closed at the shellproto boundary: if any value contains a
+// forbidden control character we return the error rather than emit a
+// partial header.  Every value here originates from a tightly
+// validated CLI flag or a constant, so this should be impossible in
+// practice — but returning the error is the right shape so a future
+// regression that smuggles in a newline cannot silently corrupt the
+// bash-side plan re-import loop.
+func emitDryRunHeader(stdout io.Writer, opts *Options, preflight *PreflightInputs, resolvedWorkspace string, publishExistingCommits int, draft bool) error {
 	draftFlag := "0"
 	if draft {
 		draftFlag = "1"
 	}
-	// WriteFields can only fail if a value contains a forbidden control
-	// character; every value here originates either from a tightly
-	// validated CLI flag (publish_branch_name / publish_base_name) or
-	// from a constant.  Drop validation errors silently to preserve the
-	// void-returning signature - the input boundary has already
-	// rejected anything that could break the bash parser.
-	_ = shellproto.WriteFields(stdout, []shellproto.Field{
+	return shellproto.WriteFields(stdout, []shellproto.Field{
 		{Key: "publish_workspace", Value: resolvedWorkspace},
 		{Key: "publish_snapshot", Value: opts.Snapshot},
 		{Key: "publish_branch", Value: opts.Branch},

--- a/internal/scenarios/scenario_manifest.go
+++ b/internal/scenarios/scenario_manifest.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/providerid"
 )
 
@@ -425,36 +426,41 @@ func Usage(program string) string {
 	)
 }
 
-func Run(program string, args []string, stdout, stderr io.Writer) int {
+// Run is the Go translation of the bash workcell-scenario-manifest
+// entry point.  Diagnostics go to stderr exactly as the bash original
+// did; the returned error is either nil or a *cliexit.ExitCodeError
+// whose Code is the bash exit-code contract.  The metadatautil wrapper
+// recovers Code via errors.As and forwards it to os.Exit.
+func Run(program string, args []string, stdout, stderr io.Writer) error {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, Usage(program))
-		return 2
+		return &cliexit.ExitCodeError{Code: 2}
 	}
 
 	switch args[0] {
 	case "list-tsv":
 		if len(args) != 2 {
 			fmt.Fprintln(stderr, Usage(program))
-			return 2
+			return &cliexit.ExitCodeError{Code: 2}
 		}
 		if err := ListTSV(args[1], stdout); err != nil {
 			fmt.Fprintln(stderr, err)
-			return 1
+			return &cliexit.ExitCodeError{Code: 1}
 		}
-		return 0
+		return nil
 	case "verify-coverage":
 		if len(args) != 3 {
 			fmt.Fprintln(stderr, Usage(program))
-			return 2
+			return &cliexit.ExitCodeError{Code: 2}
 		}
 		if err := VerifyCoverage(args[1], args[2]); err != nil {
 			fmt.Fprintln(stderr, err)
-			return 1
+			return &cliexit.ExitCodeError{Code: 1}
 		}
-		return 0
+		return nil
 	default:
 		fmt.Fprintln(stderr, Usage(program))
 		fmt.Fprintf(stderr, "%s: unsupported command: %s\n", program, args[0])
-		return 2
+		return &cliexit.ExitCodeError{Code: 2}
 	}
 }

--- a/internal/scenarios/scenario_manifest_test.go
+++ b/internal/scenarios/scenario_manifest_test.go
@@ -10,7 +10,22 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/cliexit"
 )
+
+// exitCodeFromRunErr extracts the bash exit-code contract out of the
+// typed error Run returns so existing `code != 0` assertions keep
+// working without churn.
+func exitCodeFromRunErr(err error) int {
+	if err == nil {
+		return 0
+	}
+	if ec, ok := cliexit.IsExitCodeError(err); ok {
+		return ec.Code
+	}
+	return 1
+}
 
 func writeManifest(tb testing.TB, root string, payload any) string {
 	tb.Helper()
@@ -50,8 +65,8 @@ type runResult struct {
 func runGo(program string, args []string) runResult {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(program, args, &stdout, &stderr)
-	return runResult{code: code, stdout: stdout.String(), stderr: stderr.String()}
+	err := Run(program, args, &stdout, &stderr)
+	return runResult{code: exitCodeFromRunErr(err), stdout: stdout.String(), stderr: stderr.String()}
 }
 
 func TestLoadScenariosAndListTSV(t *testing.T) {

--- a/internal/sessionctl/parsehelpers.go
+++ b/internal/sessionctl/parsehelpers.go
@@ -15,19 +15,46 @@ import (
 // with Code 2 if the value is missing or empty.  This mirrors the bash
 // option_value_or_die helper for the simple "next token is the value"
 // case shared across parseStopArgs, parseDeleteArgs, parseMonitorArgs,
-// and parseAttachArgs.
+// parseAttachArgs, parseTimelineArgs, and parseSendArgs (--message).
 //
-// parseSendArgs has its own helper because it needs the raw/strict
-// distinction (raw_option_value_or_die for --message vs option_value_or_die
-// for --id).
+// parseSendArgs additionally rejects `--`-prefixed values for --id to
+// mirror the bash strict variant; for that mode call
+// optionValueOrErrorStrict, which is the same helper with the
+// `--`-prefix check enabled.
 func optionValueOrError(args []string, i int, flag string) (string, int, error) {
-	if i+1 >= len(args) || args[i+1] == "" {
+	return optionValueOrErrorMode(args, i, flag, false)
+}
+
+// optionValueOrErrorStrict is the strict variant: it additionally
+// rejects values starting with `--` so the operator's missing-value
+// gets caught when the next flag is consumed.  Used by parseSendArgs
+// for --id (bash option_value_or_die contract); parseSendArgs --message
+// keeps the raw mode so payloads may legitimately begin with `--`.
+func optionValueOrErrorStrict(args []string, i int, flag string) (string, int, error) {
+	return optionValueOrErrorMode(args, i, flag, true)
+}
+
+func optionValueOrErrorMode(args []string, i int, flag string, rejectDashDash bool) (string, int, error) {
+	if i+1 >= len(args) {
 		return "", i, &cliexit.ExitCodeError{
 			Code:    2,
 			Message: fmt.Sprintf("Option %s requires a value.", flag),
 		}
 	}
-	return args[i+1], i + 1, nil
+	value := args[i+1]
+	if value == "" {
+		return "", i, &cliexit.ExitCodeError{
+			Code:    2,
+			Message: fmt.Sprintf("Option %s requires a value.", flag),
+		}
+	}
+	if rejectDashDash && strings.HasPrefix(value, "--") {
+		return "", i, &cliexit.ExitCodeError{
+			Code:    2,
+			Message: fmt.Sprintf("Option %s requires a value.", flag),
+		}
+	}
+	return value, i + 1, nil
 }
 
 // unsupportedOption returns the exit-2 error for an unknown flag.  subcmd

--- a/internal/sessionctl/parsehelpers_test.go
+++ b/internal/sessionctl/parsehelpers_test.go
@@ -51,6 +51,49 @@ func TestOptionValueOrErrorRejectsAtEndOfArgs(t *testing.T) {
 	}
 }
 
+func TestOptionValueOrErrorAcceptsDashDashPrefixedValue(t *testing.T) {
+	t.Parallel()
+
+	// optionValueOrError is the raw mode: --message values may
+	// legitimately begin with `--` (the operator is sending a
+	// payload), so only the non-empty check fires.
+	value, next, err := optionValueOrError([]string{"--message", "--hello"}, 0, "--message")
+	if err != nil {
+		t.Fatalf("optionValueOrError err = %v, want nil", err)
+	}
+	if value != "--hello" || next != 1 {
+		t.Fatalf("value=%q next=%d, want --hello 1", value, next)
+	}
+}
+
+func TestOptionValueOrErrorStrictRejectsDashDashPrefixedValue(t *testing.T) {
+	t.Parallel()
+
+	// optionValueOrErrorStrict is the bash option_value_or_die
+	// contract: a `--`-prefixed next token is treated as the missing
+	// value swallowed by the next flag.
+	_, _, err := optionValueOrErrorStrict([]string{"--id", "--message"}, 0, "--id")
+	ec, ok := cliexit.IsExitCodeError(err)
+	if !ok || ec.Code != 2 {
+		t.Fatalf("err = %v, want *cliexit.ExitCodeError{Code:2}", err)
+	}
+	if !strings.Contains(ec.Message, "--id") {
+		t.Errorf("Message = %q, want substring '--id'", ec.Message)
+	}
+}
+
+func TestOptionValueOrErrorStrictAcceptsPlainValue(t *testing.T) {
+	t.Parallel()
+
+	value, next, err := optionValueOrErrorStrict([]string{"--id", "session-1"}, 0, "--id")
+	if err != nil {
+		t.Fatalf("optionValueOrErrorStrict err = %v, want nil", err)
+	}
+	if value != "session-1" || next != 1 {
+		t.Fatalf("value=%q next=%d, want session-1 1", value, next)
+	}
+}
+
 func TestUnsupportedOptionBuildsMessageAndExit2(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sessionctl/send.go
+++ b/internal/sessionctl/send.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/host/stateroot"
@@ -93,13 +92,13 @@ func sendMain(args []string, stdout, stderr io.Writer) error {
 
 // parseSendArgs walks the bash session_send_main option loop.
 //
-// --id mirrors option_value_or_die: the value must be non-empty and
-// must not start with `--` (catches a missing value swallowed by the
-// next flag, e.g. `--id --message foo`).
+// --id uses the strict optionValueOrErrorStrict helper: the value must
+// be non-empty and must not start with `--` (catches a missing value
+// swallowed by the next flag, e.g. `--id --message foo`).
 //
-// --message mirrors raw_option_value_or_die: the value must only be
-// non-empty so the operator can legitimately send a payload that starts
-// with `--`.
+// --message uses the raw optionValueOrError helper: the value must
+// only be non-empty so the operator can legitimately send a payload
+// that starts with `--`.
 //
 // --no-newline is a boolean toggle.
 //
@@ -112,19 +111,19 @@ func parseSendArgs(args []string) (sessionID, message string, appendNewline, sho
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--id":
-			v, perr := optionValueForSend(args, i, false)
+			v, ni, perr := optionValueOrErrorStrict(args, i, "--id")
 			if perr != nil {
 				return "", "", false, false, perr
 			}
 			sessionID = v
-			i++
+			i = ni
 		case "--message":
-			v, perr := optionValueForSend(args, i, true)
+			v, ni, perr := optionValueOrError(args, i, "--message")
 			if perr != nil {
 				return "", "", false, false, perr
 			}
 			message = v
-			i++
+			i = ni
 		case "--no-newline":
 			appendNewline = false
 		case "-h", "--help":
@@ -134,39 +133,4 @@ func parseSendArgs(args []string) (sessionID, message string, appendNewline, sho
 		}
 	}
 	return sessionID, message, appendNewline, showHelp, nil
-}
-
-// optionValueForSend returns the value following args[i].  When raw is
-// false, the value mirrors option_value_or_die: empty or `--`-prefixed
-// values are rejected (so the missing-value case is caught when the
-// next flag is consumed).  When raw is true, the value mirrors
-// raw_option_value_or_die: only empty is rejected.
-//
-// The exit-2 wrapping matches the bash CLI contract that usage errors
-// flow back as exit status 2.  This helper is intentionally separate
-// from the shared optionValueOrError because parseSendArgs needs the
-// raw/strict distinction; sibling parse functions only ever need the
-// "non-empty" check.
-func optionValueForSend(args []string, i int, raw bool) (string, error) {
-	option := args[i]
-	if i+1 >= len(args) {
-		return "", &cliexit.ExitCodeError{
-			Code:    2,
-			Message: fmt.Sprintf("Option %s requires a value.", option),
-		}
-	}
-	value := args[i+1]
-	if value == "" {
-		return "", &cliexit.ExitCodeError{
-			Code:    2,
-			Message: fmt.Sprintf("Option %s requires a value.", option),
-		}
-	}
-	if !raw && strings.HasPrefix(value, "--") {
-		return "", &cliexit.ExitCodeError{
-			Code:    2,
-			Message: fmt.Sprintf("Option %s requires a value.", option),
-		}
-	}
-	return value, nil
 }

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 type ReadFunc func(fd int) ([]byte, error)
@@ -48,7 +50,12 @@ var (
 	writeAtFD           = writeAtFDReal
 )
 
-func Run(program string, stdin, stdout *os.File, stderr io.Writer, args []string) int {
+// Run is the Go translation of the bash workcell-pty-transcript entry
+// point.  Diagnostics land on stderr exactly as the original did; the
+// returned error is either nil (exit 0) or a *cliexit.ExitCodeError
+// whose Code carries the bash exit-code contract.  The hostutil wrapper
+// recovers Code via errors.As and propagates it to os.Exit.
+func Run(program string, stdin, stdout *os.File, stderr io.Writer, args []string) error {
 	fs := flag.NewFlagSet(program, flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var logPath string
@@ -59,12 +66,12 @@ func Run(program string, stdin, stdout *os.File, stderr io.Writer, args []string
 
 	if err := fs.Parse(args); err != nil {
 		fs.Usage()
-		return 2
+		return &cliexit.ExitCodeError{Code: 2}
 	}
 	if logPath == "" {
 		fs.Usage()
 		fmt.Fprintln(stderr, "--log is required")
-		return 2
+		return &cliexit.ExitCodeError{Code: 2}
 	}
 
 	command := fs.Args()
@@ -73,17 +80,17 @@ func Run(program string, stdin, stdout *os.File, stderr io.Writer, args []string
 	}
 	if len(command) == 0 {
 		fmt.Fprintf(stderr, "%s requires a command after --\n", program)
-		return 2
+		return &cliexit.ExitCodeError{Code: 2}
 	}
 	if !isTerminal(stdin) || !isTerminal(stdout) {
 		fmt.Fprintf(stderr, "%s requires an interactive terminal\n", program)
-		return 2
+		return &cliexit.ExitCodeError{Code: 2}
 	}
 
 	logFile, err := openLogFile(logPath)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
-		return 1
+		return &cliexit.ExitCodeError{Code: 1}
 	}
 	defer logFile.Close()
 
@@ -108,12 +115,12 @@ func Run(program string, stdin, stdout *os.File, stderr io.Writer, args []string
 		}
 		return nil
 	}
-	reportPersistErr := func() int {
+	reportPersistErr := func() error {
 		if persistErr == nil {
-			return 0
+			return nil
 		}
 		fmt.Fprintf(stderr, "%s failed to persist transcript: %s\n", program, persistErr)
-		return 1
+		return &cliexit.ExitCodeError{Code: 1}
 	}
 
 	startedAt := pythonTimestamp(time.Now())
@@ -147,10 +154,13 @@ func Run(program string, stdin, stdout *os.File, stderr io.Writer, args []string
 
 	finishedAt := pythonTimestamp(time.Now())
 	_ = writeLog(renderFooter(finishedAt, exitCode, waitStatus, spawnErr))
-	if code := reportPersistErr(); code != 0 {
-		return code
+	if err := reportPersistErr(); err != nil {
+		return err
 	}
-	return exitCode
+	if exitCode == 0 {
+		return nil
+	}
+	return &cliexit.ExitCodeError{Code: exitCode}
 }
 
 func isInteractiveTerminal(file *os.File) bool {

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -15,7 +15,23 @@ import (
 	"testing"
 	"time"
 	"unsafe"
+
+	"github.com/omkhar/workcell/internal/cliexit"
 )
+
+// runForTest invokes Run and recovers the bash exit-code contract from
+// the *cliexit.ExitCodeError the package returns.  Lets the existing
+// `code := Run(...); if code != N` test assertions stay as-is.
+func runForTest(program string, stdin, stdout *os.File, stderr io.Writer, args []string) int {
+	err := Run(program, stdin, stdout, stderr, args)
+	if err == nil {
+		return 0
+	}
+	if ec, ok := cliexit.IsExitCodeError(err); ok {
+		return ec.Code
+	}
+	return 1
+}
 
 func TestExitCodeFromWaitStatus(t *testing.T) {
 	t.Parallel()
@@ -86,7 +102,7 @@ func TestRunStripsSeparatorRecordsTranscriptAndReturnsExitCode(t *testing.T) {
 
 	logPath := filepath.Join(t.TempDir(), "transcript.log")
 	var stderr bytes.Buffer
-	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", logPath, "--", "fake-agent", "--version"})
+	code := runForTest("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", logPath, "--", "fake-agent", "--version"})
 	if code != 7 {
 		t.Fatalf("Run() = %d, want 7", code)
 	}
@@ -119,7 +135,7 @@ func TestRunRequiresCommandAfterSeparator(t *testing.T) {
 	isTerminal = func(*os.File) bool { return true }
 
 	var stderr bytes.Buffer
-	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "--"})
+	code := runForTest("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "--"})
 	if code != 2 {
 		t.Fatalf("Run() = %d, want 2", code)
 	}
@@ -134,7 +150,7 @@ func TestRunRequiresInteractiveTerminal(t *testing.T) {
 	isTerminal = func(*os.File) bool { return false }
 
 	var stderr bytes.Buffer
-	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "echo"})
+	code := runForTest("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "echo"})
 	if code != 2 {
 		t.Fatalf("Run() = %d, want 2", code)
 	}
@@ -162,7 +178,7 @@ func TestRunHandlesSpawnErrorsWithoutTracebacks(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "missing-agent"})
+	code := runForTest("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "missing-agent"})
 	if code != 127 {
 		t.Fatalf("Run() = %d, want 127", code)
 	}
@@ -206,7 +222,7 @@ func TestRunFailsWhenTranscriptPersistenceFails(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "--", "fake-agent"})
+	code := runForTest("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "--", "fake-agent"})
 	if code != 1 {
 		t.Fatalf("Run() = %d, want 1", code)
 	}
@@ -252,7 +268,7 @@ func TestRunPropagatesTranscriptPersistenceFailureFromStdinRead(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "--", "fake-agent"})
+	code := runForTest("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "--", "fake-agent"})
 	if code != 1 {
 		t.Fatalf("Run() = %d, want 1", code)
 	}
@@ -297,7 +313,7 @@ func TestRunPropagatesTranscriptPersistenceFailureFromMasterRead(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	code := Run("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "--", "fake-agent"})
+	code := runForTest("pty_transcript", os.Stdin, os.Stdout, &stderr, []string{"--log", filepath.Join(t.TempDir(), "transcript.log"), "--", "fake-agent"})
 	if code != 1 {
 		t.Fatalf("Run() = %d, want 1", code)
 	}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "652f5fef953bdef4056619ae00bc30628e14e886387833c186a63e32c89dbb6e"
+      "sha256": "b302a971ae49b84814d04cbe4b51a4091ed61bb0e6c0b142b0c4dadf231b2454"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -259,7 +259,15 @@ NO_SPINNER=0
 TARGET_BACKEND="colima"
 
 session_lookup_root_args() {
-  printf '%s\n' "--root=${WORKCELL_STATE_ROOT}" "--root=${COLIMA_STATE_ROOT}"
+  # Single Go owner: internal/host/stateroot.FormatRootArgs prints one
+  # --root=PATH line per non-empty argument, in that fixed order, with
+  # the skip-empty rule living in exactly one place (the Go helper).
+  # The two roots are forwarded on argv (rather than via env) because
+  # go_hostutil routes through run_clean_host_command, whose env -i
+  # would otherwise strip them.
+  go_hostutil launcher lookup-state-roots \
+    "${WORKCELL_STATE_ROOT:-}" \
+    "${COLIMA_STATE_ROOT:-}"
 }
 
 usage() {


### PR DESCRIPTION
## Summary

PR-FIX-6 closes the major architectural warnings the round-2 fix-up rollout (PR-FIX-5) left as adoption gaps. Each section is a mechanical translation — no redesign.

### A1/A2 — State-root single source of truth
`internal/host/stateroot` is now the single Go owner of the bash↔Go state-root contract. New `FormattedRootArgs` (env-driven) + `FormatRootArgs` (argv-driven sibling for `go_hostutil` callers whose env gets stripped by `run_clean_host_command`). New `workcell-hostutil launcher lookup-state-roots WORKCELL_ROOT COLIMA_ROOT` subcommand. `scripts/workcell::session_lookup_root_args` becomes a one-line shell-out.

### A5 — Run(...) int → error
Four `Run(...) int` package APIs migrate to `Run(...) error`:
- `internal/authpolicy.Run`
- `internal/authresolve.Run`
- `internal/transcript.Run`
- `internal/scenarios.Run`

All four now return either `nil` or a `*cliexit.ExitCodeError` carrying the bash exit-code contract. Cmd wrappers in `cmd/workcell-hostutil` and `cmd/workcell-metadatautil` shrink to plain `return X.Run(...)`. Test helpers route the typed error back to `int` so existing exit-code assertions stay byte-identical.

### A6/Q2 — shellproto fail-closed at the emit boundary
`FormatBundleResultForShell` now returns `(string, error)` and drops the partial buffer on any control-char rejection. `emitDryRunHeader` returns `error` and propagates. The two `_ = shellproto.WriteFields(...)` discard sites are gone. New `TestFormatBundleResultForShellRejectsControlChars` pins the fail-closed contract: a forbidden newline in `INJECTION_BUNDLE_ROOT` causes the helper to return an error and emit nothing — so bash never re-imports a partial plan with a smuggled-in extra `KEY=` line.

### A7 — Three private expandUserPath copies → pathutil
- `internal/authpolicy/policy.go` and `internal/injection/extract_direct_mounts.go` become thin "empty-input is an error" wrappers over `pathutil.ExpandUserPathStrict`.
- `internal/host/hoststate/hoststate.go::expandUserPathForLauncher` now calls the new `pathutil.ExpandUserPathHomeOnly` (skips the `~user` lookup so a launcher-side pointer file cannot force `os/user` database queries).

### Q5 — optionValueForSend consolidation
`optionValueForSend` is gone. `internal/sessionctl/parsehelpers.go` gains an `optionValueOrErrorStrict` variant; `parseSendArgs` uses `optionValueOrError` for `--message` (raw) and `optionValueOrErrorStrict` for `--id` (rejects `--`-prefixed values). New `parsehelpers_test` cases pin both modes.

### Deferred — Q4 (bash KEY=VALUE parsers)
The plan called for a `shellproto_assign_globals` helper + 3 call-site migrations in `scripts/workcell`. Shape budget capped at 25 files; Q4 would have pushed the diff to 26. Will be picked up as a small follow-up.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [x] `gofmt -l .` → 0
- [x] `bash -n scripts/workcell scripts/verify-invariants.sh scripts/lib/*.sh`
- [x] `bash tests/scenarios/shared/test-session-commands.sh` (Section B gate)
- [x] `bash scripts/check-pr-shape.sh` (files=25 lines=792 areas=4)
- [x] `runtime/container/control-plane-manifest.json` regenerated (scripts/workcell changed)
- [ ] CI green (parent agent not waiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)