### PR TITLE
^R Sethify round-2 docs + polish + Q4 (fix-7)

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -307,7 +307,7 @@ func cmdLauncherPublishPRUsage(_ []string) error {
 func cmdLauncherPolicyCli(args []string) error {
 	err := authpolicy.PolicyMain(args)
 	if authpolicy.IsPolicyMainUsageError(err) {
-		os.Exit(2)
+		return &cliexit.ExitCodeError{Code: 2}
 	}
 	return err
 }
@@ -365,8 +365,7 @@ func cmdLauncherColimaStatus(args []string) error {
 	status, statusErr := launcher.ColimaProfileStatus(input, args[0])
 	if statusErr != nil {
 		if launcher.IsNoMatch(statusErr) {
-			fmt.Fprintln(os.Stderr, statusErr)
-			os.Exit(3)
+			return &cliexit.ExitCodeError{Code: 3, Message: statusErr.Error()}
 		}
 		return statusErr
 	}
@@ -393,7 +392,7 @@ func cmdLauncherRunHostColimaWithTimeout(args []string) error {
 		return runErr
 	}
 	if code != 0 {
-		os.Exit(code)
+		return &cliexit.ExitCodeError{Code: code}
 	}
 	return nil
 }
@@ -740,16 +739,15 @@ func cmdLauncherProfilePath(args []string) error {
 	value, err := dispatchProfilePath(kind, rest)
 	if err != nil {
 		if errors.Is(err, hoststate.ErrUnsupportedLogPointerKind) {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(2)
+			return &cliexit.ExitCodeError{Code: 2, Message: err.Error()}
 		}
 		var keyErr *hoststate.InvalidStateKeyError
 		if errors.As(err, &keyErr) {
-			fmt.Fprintln(os.Stderr, keyErr.Error())
+			msg := keyErr.Error()
 			if keyErr.Hint != "" {
-				fmt.Fprintln(os.Stderr, keyErr.Hint)
+				msg = msg + "\n" + keyErr.Hint
 			}
-			os.Exit(2)
+			return &cliexit.ExitCodeError{Code: 2, Message: msg}
 		}
 		return err
 	}

--- a/cmd/workcell-metadatautil/main.go
+++ b/cmd/workcell-metadatautil/main.go
@@ -425,6 +425,9 @@ func cmdRunMutationTests(_ []string) error {
 // The original workcell-run-mutation-tests standalone binary had the
 // same shape; preserved here for parity. A more robust fix would
 // take repo-root as an explicit argv arg.
+//
+// TODO(workcell-citools-repo-root): take repo-root as an explicit
+// argv arg so this helper stops depending on runtime.Caller layout.
 func metadatautilRepoRoot() (string, error) {
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {

--- a/internal/cliexit/exit_code_error.go
+++ b/internal/cliexit/exit_code_error.go
@@ -21,7 +21,7 @@ type ExitCodeError struct {
 func (e *ExitCodeError) Error() string { return e.Message }
 
 // IsExitCodeError reports whether err is or wraps an *ExitCodeError.
-// If so, the returned non-nil pointer is the concrete value.
+// If so, the returned non-nil pointer is the unwrapped `*ExitCodeError`.
 func IsExitCodeError(err error) (*ExitCodeError, bool) {
 	var ec *ExitCodeError
 	if errors.As(err, &ec) {

--- a/internal/injection/prepare_bundle.go
+++ b/internal/injection/prepare_bundle.go
@@ -22,19 +22,46 @@ import (
 // prepare_injection_bundle helper consumed.  The bash caller supplies these
 // via command-line flags on the launcher subcommand.
 type PrepareBundleOptions struct {
-	Agent                                 string
-	Mode                                  string
-	PolicyPath                            string
-	UseDefaultPolicy                      bool
-	AuthStatus                            bool
-	Doctor                                bool
-	Inspect                               bool
-	DryRun                                bool
-	SelfStagingProbeSyntheticCodexAuth    bool
+	// Agent is the target agent name (e.g. "claude", "codex"); required.
+	Agent string
+	// Mode is the agent execution mode (e.g. "auto", "manual"); required.
+	Mode string
+	// PolicyPath is an explicit injection-policy TOML path.  When empty
+	// and UseDefaultPolicy is true, the default
+	// DefaultInjectionPolicyPath is consulted.
+	PolicyPath string
+	// UseDefaultPolicy enables the implicit per-user policy fallback
+	// when PolicyPath is empty.
+	UseDefaultPolicy bool
+	// AuthStatus, when true, runs the auth-status diagnostic path
+	// (no bundle materialization).
+	AuthStatus bool
+	// Doctor, when true, runs the doctor diagnostic path.
+	Doctor bool
+	// Inspect, when true, runs the inspect diagnostic path.
+	Inspect bool
+	// DryRun, when true, plans the bundle without writing any files.
+	DryRun bool
+	// SelfStagingProbeSyntheticCodexAuth is a test-only flag that
+	// stages a synthetic ~/.codex/auth.json credential to exercise the
+	// self-staging probe code path.  Production callers MUST leave
+	// this false.
+	SelfStagingProbeSyntheticCodexAuth bool
+	// SelfStagingProbeSyntheticClaudeExport is a test-only flag that
+	// stages a synthetic Claude keychain export to exercise the
+	// self-staging probe code path.  Production callers MUST leave
+	// this false.
 	SelfStagingProbeSyntheticClaudeExport bool
-	RealHome                              string
-	ProcessPID                            int
-	BundleParentOverride                  string // optional; bash currently always supplies the default
+	// RealHome is the real host HOME, used to derive the default
+	// policy and bundle parent paths.  Required.
+	RealHome string
+	// ProcessPID is the launching process PID; used to namespace the
+	// per-run bundle directory under the cache parent.
+	ProcessPID int
+	// BundleParentOverride is an optional bundle parent directory.
+	// Empty in production (the bash caller always supplies the
+	// default); tests use this to redirect into a t.TempDir.
+	BundleParentOverride string
 }
 
 // PrepareBundleResult is the byte-for-byte translation of the env-var state
@@ -42,21 +69,51 @@ type PrepareBundleOptions struct {
 // INJECTION_* / DIRECT_* shell variable so the bash shim can re-export the
 // values verbatim.
 type PrepareBundleResult struct {
-	InjectionBundleRoot                 string
-	DirectMountSpecPath                 string
-	DirectSourceMounts                  []string
-	InjectionPolicySHA256               string
-	InjectionCredentialKeys             string
-	InjectionCredentialInputKinds       string
-	InjectionCredentialResolvers        string
-	InjectionCredentialMaterialization  string
+	// InjectionBundleRoot is the absolute path to the per-run bundle
+	// staging directory (INJECTION_BUNDLE_ROOT).
+	InjectionBundleRoot string
+	// DirectMountSpecPath is the path to the direct-mount spec file
+	// (DIRECT_MOUNT_SPEC_PATH).
+	DirectMountSpecPath string
+	// DirectSourceMounts is the list of resolved source-mount paths
+	// (DIRECT_SOURCE_MOUNTS, one per line in bash).
+	DirectSourceMounts []string
+	// InjectionPolicySHA256 is the SHA-256 of the policy file consumed
+	// for this run (INJECTION_POLICY_SHA256).
+	InjectionPolicySHA256 string
+	// InjectionCredentialKeys is the newline-joined list of credential
+	// keys the policy materialized (INJECTION_CREDENTIAL_KEYS).
+	InjectionCredentialKeys string
+	// InjectionCredentialInputKinds carries the per-credential input
+	// kind classification (INJECTION_CREDENTIAL_INPUT_KINDS).
+	InjectionCredentialInputKinds string
+	// InjectionCredentialResolvers carries the per-credential resolver
+	// names (INJECTION_CREDENTIAL_RESOLVERS).
+	InjectionCredentialResolvers string
+	// InjectionCredentialMaterialization carries the per-credential
+	// materialization mode (INJECTION_CREDENTIAL_MATERIALIZATION).
+	InjectionCredentialMaterialization string
+	// InjectionCredentialResolutionStates carries the per-credential
+	// resolution-state token (INJECTION_CREDENTIAL_RESOLUTION_STATES).
 	InjectionCredentialResolutionStates string
-	InjectionProviderAuthReadyStates    string
-	InjectionSharedAuthReadyStates      string
-	InjectionExtraEndpoints             string
-	InjectionSSHEnabled                 string
-	InjectionSSHConfigAssurance         string
-	InjectionSecretCopyTargets          string
+	// InjectionProviderAuthReadyStates carries the provider-auth
+	// readiness state lines (INJECTION_PROVIDER_AUTH_READY_STATES).
+	InjectionProviderAuthReadyStates string
+	// InjectionSharedAuthReadyStates carries the shared-auth readiness
+	// state lines (INJECTION_SHARED_AUTH_READY_STATES).
+	InjectionSharedAuthReadyStates string
+	// InjectionExtraEndpoints carries any additional endpoint URLs the
+	// policy declared (INJECTION_EXTRA_ENDPOINTS).
+	InjectionExtraEndpoints string
+	// InjectionSSHEnabled is "1" when the policy enables SSH
+	// passthrough, "0" otherwise (INJECTION_SSH_ENABLED).
+	InjectionSSHEnabled string
+	// InjectionSSHConfigAssurance carries the SSH config assurance
+	// level marker (INJECTION_SSH_CONFIG_ASSURANCE).
+	InjectionSSHConfigAssurance string
+	// InjectionSecretCopyTargets carries the secret-copy target paths
+	// (INJECTION_SECRET_COPY_TARGETS).
+	InjectionSecretCopyTargets string
 }
 
 // DefaultInjectionPolicyPath returns the path the bash helper would have
@@ -242,7 +299,7 @@ func PrepareBundle(opts PrepareBundleOptions) (*PrepareBundleResult, error) {
 // happen after we've already pointed HOME at the synthetic codex home,
 // so the partial-state cleanup MUST always be the canonical restore
 // callback (not the no-op `func(){}` shadow that an earlier draft of
-// this helper used).  See prepare_bundle_test.go::TestPrepareBundleRestoresHOMEOnPartialFailure
+// this helper used).  See prepare_bundle_test.go::TestInstallSyntheticProbeEnvRestoresHomeOnPartialFailure
 // for the regression that motivated this contract.
 func installSyntheticProbeEnv(bundleRoot string, syntheticCodex, syntheticClaude bool) (func(), error) {
 	originalHome, hadHome := os.LookupEnv("HOME")

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -10,10 +10,19 @@ import (
 	"strings"
 )
 
+// ExpandUserPathBestEffort expands `~`, `~/...`, and `~user`/`~user/...`
+// references via os.UserHomeDir or user.Lookup.  When a `~user` lookup
+// fails (unknown user or empty home), it returns the input verbatim
+// rather than an error.  Use this when callers can tolerate an
+// unexpanded fallback (e.g. logging or display paths).
 func ExpandUserPathBestEffort(raw string) (string, error) {
 	return expandUserPath(raw, false)
 }
 
+// ExpandUserPathStrict behaves like ExpandUserPathBestEffort but
+// surfaces user.Lookup failures (or empty home directories) as errors
+// instead of returning the input verbatim.  Use this when an
+// unexpanded path would be a correctness bug.
 func ExpandUserPathStrict(raw string) (string, error) {
 	return expandUserPath(raw, true)
 }
@@ -45,6 +54,10 @@ func ExpandUserPathHomeOnly(raw string) string {
 	return raw
 }
 
+// CanonicalizeExpandedPath returns an absolute, symlink-resolved form
+// of the input.  Relative inputs are first made absolute via filepath.Abs
+// against the process CWD; the result is then passed through
+// ResolveBestEffort so missing trailing components do not cause failure.
 func CanonicalizeExpandedPath(path string) (string, error) {
 	if !filepath.IsAbs(path) {
 		abs, err := filepath.Abs(path)
@@ -56,6 +69,11 @@ func CanonicalizeExpandedPath(path string) (string, error) {
 	return ResolveBestEffort(filepath.Clean(path))
 }
 
+// ResolveBestEffort walks up the path until it finds an existing
+// ancestor, evaluates its symlinks, then re-joins the missing suffix.
+// This matches the "canonicalize what exists, accept the rest verbatim"
+// shape that scripts/workcell uses when staging not-yet-created bundle
+// directories.
 func ResolveBestEffort(path string) (string, error) {
 	if path == string(filepath.Separator) {
 		return path, nil

--- a/internal/publishpr/doc.go
+++ b/internal/publishpr/doc.go
@@ -3,22 +3,33 @@
 
 // Package publishpr carries the `workcell publish-pr` user interface
 // that historically lived in scripts/workcell as the publish_pr_*
-// bash functions. The decomposition is intentionally staged across
-// the /sethify PR 24 chain:
+// bash functions.  The package owns four concerns:
 //
-//   - PR 24.1 (landed): UsageText() — the help banner.
-//   - PR 24.2a (this file's home): ParseArgs, the validators
-//     (ValidateSnapshotName, ValidateBranchName, ValidateBaseName),
-//     LoadTextArg, RepoOwnedChecksExpected, and Preflight. These are
-//     pure-Go translations of the argument parsing + validation +
-//     text-arg loading section of publish_pr_main and carry no host
-//     filesystem or process side effects.
-//   - PR 24.2b (next): the host execution layer that drives git/gh,
-//     emits the dry-run command list, and wires `workcell-hostutil
-//     launcher publish-pr-cli` so scripts/workcell publish_pr_main
-//     becomes a thin shim.
+//   - UsageText: the help banner emitted on -h / --help and on usage
+//     errors.
 //
-// Host-side git and GitHub CLI invocation stays outside this package
-// for now (different concern: that is host-side process control, this
-// package is the host-side CLI surface text and validation).
+//   - Argument parsing and validation: ParseArgs walks the publish-pr
+//     option vector with the same diagnostics the bash function did;
+//     ValidateSnapshotName, ValidateBranchName, and ValidateBaseName
+//     mirror the validate_publish_* bash helpers; LoadTextArg reconciles
+//     inline vs --*-file inputs; Preflight bundles the validators with
+//     base-mode downgrade and text-arg loading into one pass.
+//     RepoOwnedChecksExpected mirrors publish_pr_repo_owned_checks_expected
+//     so the dry-run output keeps byte-identical literals.
+//
+//   - Host execution layer: BashContext + RunPublishHostCommandInDir +
+//     the resolved git/gh wrappers (runCleanGit, etc.) drive the host-
+//     side process control under the env -i sandbox.  IsTrustedHostToolPath,
+//     CanonicalizeHostToolPath, ResolveHostTool, and
+//     ResolveExistingExecutableOrDie own the trusted-PATH allowlist
+//     that scripts/workcell::is_trusted_host_tool_path enforces.
+//
+//   - Dry-run emission: EmitCommand + bashQuote replicate the
+//     `printf %q` shape that
+//     tests/scenarios/shared/test-publish-pr-dry-run.sh greps for.
+//
+// PublishPRMain wires the four concerns together as the launcher entry
+// point for `workcell-hostutil launcher publish-pr-cli`; scripts/workcell
+// publish_pr_main is the thin shim that forwards bash-side globals as
+// --bash-* flags.
 package publishpr

--- a/internal/publishpr/host_exec.go
+++ b/internal/publishpr/host_exec.go
@@ -22,12 +22,27 @@ import (
 // these as --bash-* flags because `go_hostutil` runs the Go binary
 // under `env -i` and would otherwise lose them.
 type BashContext struct {
-	RootDir         string
-	WorkspaceRoot   string
-	RealHome        string
+	// RootDir is the workcell repo root (ROOT_DIR in bash); used to
+	// exclude in-repo paths from the trusted-host-tool allowlist.
+	RootDir string
+	// WorkspaceRoot is the user-supplied --workspace (WORKSPACE in
+	// bash); used as the base for relative paths and excluded from
+	// the trusted-host-tool allowlist.
+	WorkspaceRoot string
+	// RealHome is the real (non-sandbox) host HOME (REAL_HOME in bash);
+	// re-exported to child processes that need access to the user's
+	// gh/ssh config.
+	RealHome string
+	// TrustedHostPath is the allow-listed PATH used for binary lookups
+	// (TRUSTED_HOST_PATH in bash); re-applied inside every env -i
+	// child invocation.
 	TrustedHostPath string
-	HostGitBin      string
-	HostGhBin       string
+	// HostGitBin is the resolved trusted path to `git`
+	// (HOST_GIT_BIN in bash); used for every git invocation.
+	HostGitBin string
+	// HostGhBin is the resolved trusted path to `gh`
+	// (HOST_GH_BIN in bash); used for the final PR-create step.
+	HostGhBin string
 }
 
 // trustedHostToolPrefixes mirrors the allowlist embedded in
@@ -190,8 +205,8 @@ func EmitCommand(w io.Writer, args []string) {
 // characters; never wrap the whole token in single quotes when only
 // printable characters are present; use ANSI-C `$'...'` only for non-
 // printable bytes. The empty string becomes a pair of bare ASCII
-// single-quote characters (the literal form `if s == "" { return ... }`
-// below uses). The dry-run scenario
+// single-quote characters (the two-character literal returned at
+// line ~199 below by the `if s == ""` branch). The dry-run scenario
 // in tests/scenarios/shared/test-publish-pr-dry-run.sh greps for the
 // exact backslash form, so any divergence surfaces there.
 func bashQuote(s string) string {

--- a/internal/publishpr/publish_pr_main.go
+++ b/internal/publishpr/publish_pr_main.go
@@ -23,21 +23,58 @@ func exit2(format string, args ...any) error {
 // because the bash function rejects both being set; LoadTextArg
 // reconciles them later when the caller is ready to read the body.
 type Options struct {
-	Workspace         string
-	Branch            string
-	Base              string
-	AllowNonMainBase  bool
-	GhBin             string
-	Snapshot          string
-	Title             string
-	TitleFile         string
-	Body              string
-	BodyFile          string
-	CommitMessage     string
+	// Workspace is the host-side worktree to operate on; defaults to
+	// the process CWD.  Must resolve to an existing directory; rejected
+	// otherwise by resolveExistingDirectoryOrDie.
+	Workspace string
+	// Branch is the publish branch name; required (rejected when empty),
+	// must pass `git check-ref-format --branch`, and must not be the
+	// default branch (main/master).
+	Branch string
+	// Base is the target branch for the PR; defaults to "main".  Must
+	// pass `git check-ref-format --branch`; non-main values require
+	// AllowNonMainBase.
+	Base string
+	// AllowNonMainBase waives the main-only Base check, downgrading the
+	// run to the lower-assurance draft path.
+	AllowNonMainBase bool
+	// GhBin is an optional explicit path to the host `gh` binary; when
+	// non-empty it must point to a trusted executable
+	// (IsTrustedHostToolPath).
+	GhBin string
+	// Snapshot selects which working-tree slice to publish; must be
+	// "worktree" or "index" (or "staged" — same as "index"); rejected
+	// otherwise by ValidateSnapshotName.  Defaults to "worktree".
+	Snapshot string
+	// Title is the inline PR title.  Mutually exclusive with TitleFile;
+	// one of the two MUST yield a non-empty value at Preflight.
+	Title string
+	// TitleFile is a host-path whose trimmed contents become the PR
+	// title.  Mutually exclusive with Title.
+	TitleFile string
+	// Body is the inline PR body.  Mutually exclusive with BodyFile;
+	// both may be empty (PR body is optional).
+	Body string
+	// BodyFile is a host-path whose trimmed contents become the PR body.
+	// Mutually exclusive with Body.
+	BodyFile string
+	// CommitMessage is the inline commit message used for the publish
+	// commit.  Mutually exclusive with CommitMessageFile; one of the
+	// two MUST yield a non-empty value at Preflight.
+	CommitMessage string
+	// CommitMessageFile is a host-path whose trimmed contents become
+	// the commit message.  Mutually exclusive with CommitMessage.
 	CommitMessageFile string
-	Ready             bool
-	DryRun            bool
-	HelpRequested     bool
+	// Ready, when true, flips the gh PR off draft (publish_pr_main's
+	// `--ready` flag).
+	Ready bool
+	// DryRun, when true, prints the planned host commands instead of
+	// executing them; output shape is asserted by
+	// tests/scenarios/shared/test-publish-pr-dry-run.sh.
+	DryRun bool
+	// HelpRequested is set when ParseArgs encountered -h / --help and
+	// short-circuited; callers should emit UsageText and exit 0.
+	HelpRequested bool
 }
 
 // DefaultOptions returns an Options populated with the same defaults
@@ -295,13 +332,29 @@ func readFileString(path string) (string, error) {
 // pure-Go function keeps the validator boundary self-contained and
 // gives the upcoming 24.2b execution PR a typed handoff.
 type PreflightInputs struct {
-	TitleText                 string
-	BodyText                  string
-	CommitMessageText         string
-	PublishBaseMode           string
+	// TitleText is the resolved, non-empty PR title (LoadTextArg of
+	// Title/TitleFile).
+	TitleText string
+	// BodyText is the resolved PR body; may be empty (PR body is
+	// optional).
+	BodyText string
+	// CommitMessageText is the resolved, non-empty commit message
+	// (LoadTextArg of CommitMessage/CommitMessageFile).
+	CommitMessageText string
+	// PublishBaseMode is "main" for the standard run and
+	// "lower-assurance" when --allow-non-main-base downgraded the run.
+	PublishBaseMode string
+	// RepoOwnedPRChecksExpected mirrors publish_pr_repo_owned_checks_expected:
+	// "1" when the resolved base is main, "0" otherwise.  Kept as a
+	// string because the dry-run scenario greps for the literal
+	// `publish_repo_owned_pr_checks_expected=1|0`.
 	RepoOwnedPRChecksExpected string
-	Ready                     bool
-	LowerAssuranceNotice      []string // stderr lines to emit when downgrading the run
+	// Ready propagates Options.Ready so the host execution layer can
+	// flip the gh PR off draft without re-parsing the option vector.
+	Ready bool
+	// LowerAssuranceNotice carries stderr lines to emit when the run
+	// has been downgraded (non-main base).  Empty for standard runs.
+	LowerAssuranceNotice []string
 }
 
 // Preflight applies the bash validators + text-arg loading + base-mode

--- a/internal/sessionctl/doc.go
+++ b/internal/sessionctl/doc.go
@@ -5,11 +5,11 @@
 // `workcell session <cmd>` user interface that historically lived in
 // scripts/workcell as the session_* bash functions.
 //
-// Each user-facing subcommand has a matching `<verb>Main` entry point
-// in this package (AttachMain, SendMain, StopMain, DeleteMain,
-// MonitorMain, TimelineMain, LogsMain) plus a private `<verb>Main`
-// helper that accepts injected stdout/stderr writers for tests.  These
-// functions own:
+// Each user-facing subcommand has a matching `<Verb>Main` exported
+// entry point in this package (AttachMain, SendMain, StopMain,
+// DeleteMain, MonitorMain, TimelineMain, LogsMain) plus a private
+// `<verb>Main` helper that accepts injected stdout/stderr writers for
+// tests.  These functions own:
 //
 //   - Up-front option parsing (--id, --message, --no-newline, etc.)
 //     mirroring the bash option_value_or_die / raw_option_value_or_die

--- a/internal/sessionctl/monitor.go
+++ b/internal/sessionctl/monitor.go
@@ -137,8 +137,7 @@ func parseMonitorArgs(args []string) (statePath string, showHelp bool, err error
 // monitor uses (the state file is written from scripts/workcell with no
 // shell metacharacters).
 //
-// The function is exposed for the launcher's monitor subcommand entry
-// point in cmd/workcell-hostutil and for tests in this package.
+// The function is exposed for tests in this package.
 func MonitorStateEntries(path string) ([]MonitorStateEntry, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/internal/sessionctl/send.go
+++ b/internal/sessionctl/send.go
@@ -43,8 +43,9 @@ import (
 //	append_newline=0|1
 //
 // State-root forwarding mirrors AttachMain/LogsMain: leading
-// --root=PATH args are consumed via consumeRootArgs because go_hostutil
-// scrubs WORKCELL_STATE_ROOT/COLIMA_STATE_ROOT from the environment.
+// --root=PATH args are consumed via stateroot.ConsumeRootArgs because
+// go_hostutil scrubs WORKCELL_STATE_ROOT/COLIMA_STATE_ROOT from the
+// environment.
 // The Go side does not currently use those roots, but the bash shim
 // keeps prepending them so the contract stays consistent with sibling
 // session-* subcommands and so a future tightening of SendMain that

--- a/internal/sessionctl/stop.go
+++ b/internal/sessionctl/stop.go
@@ -51,7 +51,7 @@ import (
 // default exit-1 path.
 //
 // State-root forwarding mirrors AttachMain/LogsMain: leading
-// --root=PATH args are consumed via consumeRootArgs because
+// --root=PATH args are consumed via stateroot.ConsumeRootArgs because
 // go_hostutil scrubs WORKCELL_STATE_ROOT/COLIMA_STATE_ROOT from the
 // environment.
 func StopMain(args []string) error {

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "b302a971ae49b84814d04cbe4b51a4091ed61bb0e6c0b142b0c4dadf231b2454"
+      "sha256": "9515c617bade235d8ab9577bdafbc5cf3043771088a1f41702d442d9a82f82a2"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",
@@ -22,7 +22,7 @@
     },
     {
       "repo_path": "scripts/lib/shellproto.sh",
-      "sha256": "8b6460e7f20b4eaa853b8b52fa3805108e09e4f9c901be84188810d87954ff58"
+      "sha256": "87149270a2ff536e552c9ea093e9db827d37892bb5f07b94c5629bcf621f487a"
     },
     {
       "repo_path": "scripts/lib/trusted-docker-client.sh",

--- a/scripts/lib/shellproto.sh
+++ b/scripts/lib/shellproto.sh
@@ -56,3 +56,60 @@ shellproto_field() {
   done <<<"${plan}"
   printf '%s' "${default_value}"
 }
+
+# shellproto_assign_globals <plan> <key1:var1> <key2:var2> ...
+#
+#   Walks the multi-line plan in $1 once and, for each KEY=VALUE line
+#   whose KEY matches one of the supplied <key>:<var> pairs, assigns
+#   VALUE to the named shell variable.  This replaces the
+#   `while IFS=...; case ${key} in ... esac; done <<<"${plan}"` shape
+#   that the larger bash multi-key parsers in scripts/workcell used to
+#   carry by hand; centralising the loop here avoids per-call drift
+#   (e.g. one site forgetting the *=* skip, another mis-handling values
+#   that contain '=').
+#
+#   Empty values are accepted: `key=\n` clears the named variable.
+#   Lines without '=' are skipped silently (forward-compat with
+#   future header rows).  Only the first occurrence of a key wins,
+#   matching the Go side's WriteFields contract.
+#
+#   Variables that never appear in the plan are left at their existing
+#   value; the caller is expected to pre-clear them when a clean slate
+#   is required.
+#
+# Typical use:
+#
+#   shellproto_assign_globals "${plan}" \
+#     session_id:SESSION_META_ID \
+#     profile:SESSION_META_PROFILE
+shellproto_assign_globals() {
+  local plan="$1"
+  shift
+  local pair key var line lk lv i
+  local -a pair_keys=()
+  local -a pair_vars=()
+  local -a pair_seen=()
+  for pair in "$@"; do
+    pair_keys+=("${pair%%:*}")
+    pair_vars+=("${pair#*:}")
+    pair_seen+=("0")
+  done
+  while IFS= read -r line; do
+    if [[ "${line}" != *=* ]]; then
+      continue
+    fi
+    lk="${line%%=*}"
+    lv="${line#*=}"
+    i=0
+    while [[ "${i}" -lt "${#pair_keys[@]}" ]]; do
+      key="${pair_keys[i]}"
+      var="${pair_vars[i]}"
+      if [[ "${pair_seen[i]}" == "0" && "${lk}" == "${key}" ]]; then
+        printf -v "${var}" '%s' "${lv}"
+        pair_seen[i]="1"
+        break
+      fi
+      i=$((i + 1))
+    done
+  done <<<"${plan}"
+}

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1771,9 +1771,7 @@ session_runtime_metadata() {
 
 load_session_runtime_metadata() {
   local session_id="$1"
-  local line=""
-  local key=""
-  local value=""
+  local plan=""
 
   SESSION_META_PROFILE=""
   SESSION_META_RECORD_PATH=""
@@ -1798,34 +1796,30 @@ load_session_runtime_metadata() {
   SESSION_META_FILE_TRACE_LOG_PATH=""
   SESSION_META_TRANSCRIPT_LOG_PATH=""
 
-  while IFS= read -r line; do
-    key="${line%%=*}"
-    value="${line#*=}"
-    case "${key}" in
-      record_path) SESSION_META_RECORD_PATH="${value}" ;;
-      profile) SESSION_META_PROFILE="${value}" ;;
-      target_kind) SESSION_META_TARGET_KIND="${value}" ;;
-      target_provider) SESSION_META_TARGET_PROVIDER="${value}" ;;
-      target_id) SESSION_META_TARGET_ID="${value}" ;;
-      target_assurance_class) SESSION_META_TARGET_ASSURANCE_CLASS="${value}" ;;
-      runtime_api) SESSION_META_RUNTIME_API="${value}" ;;
-      workspace_transport) SESSION_META_WORKSPACE_TRANSPORT="${value}" ;;
-      workspace) SESSION_META_WORKSPACE="${value}" ;;
-      workspace_origin) SESSION_META_WORKSPACE_ORIGIN="${value}" ;;
-      worktree_path) SESSION_META_WORKTREE_PATH="${value}" ;;
-      git_branch) SESSION_META_GIT_BRANCH="${value}" ;;
-      container_name) SESSION_META_CONTAINER_NAME="${value}" ;;
-      monitor_pid) SESSION_META_MONITOR_PID="${value}" ;;
-      status) SESSION_META_STATUS="${value}" ;;
-      live_status) SESSION_META_LIVE_STATUS="${value}" ;;
-      current_assurance) SESSION_META_CURRENT_ASSURANCE="${value}" ;;
-      session_audit_dir) SESSION_META_SESSION_AUDIT_DIR="${value}" ;;
-      audit_log_path) SESSION_META_AUDIT_LOG_PATH="${value}" ;;
-      debug_log_path) SESSION_META_DEBUG_LOG_PATH="${value}" ;;
-      file_trace_log_path) SESSION_META_FILE_TRACE_LOG_PATH="${value}" ;;
-      transcript_log_path) SESSION_META_TRANSCRIPT_LOG_PATH="${value}" ;;
-    esac
-  done < <(session_runtime_metadata "${session_id}")
+  plan="$(session_runtime_metadata "${session_id}")"
+  shellproto_assign_globals "${plan}" \
+    record_path:SESSION_META_RECORD_PATH \
+    profile:SESSION_META_PROFILE \
+    target_kind:SESSION_META_TARGET_KIND \
+    target_provider:SESSION_META_TARGET_PROVIDER \
+    target_id:SESSION_META_TARGET_ID \
+    target_assurance_class:SESSION_META_TARGET_ASSURANCE_CLASS \
+    runtime_api:SESSION_META_RUNTIME_API \
+    workspace_transport:SESSION_META_WORKSPACE_TRANSPORT \
+    workspace:SESSION_META_WORKSPACE \
+    workspace_origin:SESSION_META_WORKSPACE_ORIGIN \
+    worktree_path:SESSION_META_WORKTREE_PATH \
+    git_branch:SESSION_META_GIT_BRANCH \
+    container_name:SESSION_META_CONTAINER_NAME \
+    monitor_pid:SESSION_META_MONITOR_PID \
+    status:SESSION_META_STATUS \
+    live_status:SESSION_META_LIVE_STATUS \
+    current_assurance:SESSION_META_CURRENT_ASSURANCE \
+    session_audit_dir:SESSION_META_SESSION_AUDIT_DIR \
+    audit_log_path:SESSION_META_AUDIT_LOG_PATH \
+    debug_log_path:SESSION_META_DEBUG_LOG_PATH \
+    file_trace_log_path:SESSION_META_FILE_TRACE_LOG_PATH \
+    transcript_log_path:SESSION_META_TRANSCRIPT_LOG_PATH
 }
 
 session_meta_target_summary() {
@@ -2021,9 +2015,6 @@ current_workspace_transport() {
 }
 
 refresh_support_matrix_state() {
-  local line=""
-  local key=""
-  local value=""
   local metadata=""
 
   metadata="$(go_hostutil launcher support-matrix-eval \
@@ -2042,19 +2033,14 @@ refresh_support_matrix_state() {
   SUPPORT_MATRIX_VALIDATION_LANE=""
   SUPPORT_MATRIX_REASON=""
 
-  while IFS= read -r line; do
-    key="${line%%=*}"
-    value="${line#*=}"
-    case "${key}" in
-      host_os) SUPPORT_MATRIX_HOST_OS="${value}" ;;
-      host_arch) SUPPORT_MATRIX_HOST_ARCH="${value}" ;;
-      support_matrix_status) SUPPORT_MATRIX_STATUS="${value}" ;;
-      support_matrix_launch) SUPPORT_MATRIX_LAUNCH="${value}" ;;
-      support_matrix_evidence) SUPPORT_MATRIX_EVIDENCE="${value}" ;;
-      support_matrix_validation_lane) SUPPORT_MATRIX_VALIDATION_LANE="${value}" ;;
-      support_matrix_reason) SUPPORT_MATRIX_REASON="${value}" ;;
-    esac
-  done <<<"${metadata}"
+  shellproto_assign_globals "${metadata}" \
+    host_os:SUPPORT_MATRIX_HOST_OS \
+    host_arch:SUPPORT_MATRIX_HOST_ARCH \
+    support_matrix_status:SUPPORT_MATRIX_STATUS \
+    support_matrix_launch:SUPPORT_MATRIX_LAUNCH \
+    support_matrix_evidence:SUPPORT_MATRIX_EVIDENCE \
+    support_matrix_validation_lane:SUPPORT_MATRIX_VALIDATION_LANE \
+    support_matrix_reason:SUPPORT_MATRIX_REASON
 
   [[ -n "${SUPPORT_MATRIX_HOST_OS}" ]] || SUPPORT_MATRIX_HOST_OS="$(detected_host_os)"
   [[ -n "${SUPPORT_MATRIX_HOST_ARCH}" ]] || SUPPORT_MATRIX_HOST_ARCH="$(detected_host_arch)"
@@ -2966,24 +2952,16 @@ write_session_record_initial() {
   local git_branch=""
   local git_head=""
   local git_base=""
+  local git_plan=""
 
   [[ -n "${SESSION_ID}" ]] || SESSION_ID="$(generate_session_id)"
   sessions_dir="$(profile_sessions_dir_path "${profile}")"
   mkdir -p "${sessions_dir}"
   SESSION_RECORD_PATH="${sessions_dir}/${SESSION_ID}.json"
-  while IFS= read -r line; do
-    case "${line%%=*}" in
-      git_branch)
-        git_branch="${line#*=}"
-        ;;
-      git_head)
-        git_head="${line#*=}"
-        ;;
-      git_base)
-        git_base="${line#*=}"
-        ;;
-    esac
-  done < <(session_git_metadata_lines "${WORKSPACE}")
+  git_plan="$(session_git_metadata_lines "${WORKSPACE}")"
+  git_branch="$(shellproto_field "${git_plan}" git_branch)"
+  git_head="$(shellproto_field "${git_plan}" git_head)"
+  git_base="$(shellproto_field "${git_plan}" git_base)"
   write_session_record "${SESSION_RECORD_PATH}" \
     "session_id=${SESSION_ID}" \
     "profile=${profile}" \

--- a/tests/scenarios/manifest.json
+++ b/tests/scenarios/manifest.json
@@ -193,6 +193,17 @@
       "requires_credentials": false
     },
     {
+      "id": "shared/shellproto-lib",
+      "description": "Sources scripts/lib/shellproto.sh and exercises shellproto_field and shellproto_assign_globals against canonical fixtures (key with embedded '=', missing key, first-occurrence-wins, empty plan)",
+      "lane": "secretless",
+      "platform": "any",
+      "manual": false,
+      "providers": ["codex", "claude", "gemini"],
+      "persona": "developer",
+      "test_file": "shared/test-shellproto-lib.sh",
+      "requires_credentials": false
+    },
+    {
       "id": "claude-swe/hook-parametric",
       "description": "Claude guard-bash.sh blocks all commands in the fixture file",
       "lane": "secretless",

--- a/tests/scenarios/shared/test-shellproto-lib.sh
+++ b/tests/scenarios/shared/test-shellproto-lib.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Omkhar Arasaratnam
+#
+# tests/scenarios/shared/test-shellproto-lib.sh — targeted unit tests
+# for scripts/lib/shellproto.sh helpers (shellproto_field and
+# shellproto_assign_globals).  The bash KEY=VALUE parser used by every
+# session_*_main shim and the support-matrix/git-metadata bulk loaders
+# now routes through these helpers, so a regression here would cascade
+# into every shim.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "${ROOT_DIR}/scripts/lib/shellproto.sh"
+
+PASS_COUNT=0
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local description="$1"
+  local got="$2"
+  local want="$3"
+  if [[ "${got}" != "${want}" ]]; then
+    fail "${description}: got=[${got}] want=[${want}]"
+  fi
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+# ---- shellproto_field cases -----------------------------------------------
+
+# Key with '=' in the value: the value side of the first '=' is kept verbatim.
+plan_eq_in_value="$(printf 'token=abc=def=ghi\nstatus=ok\n')"
+assert_eq "shellproto_field keeps '=' in value" \
+  "$(shellproto_field "${plan_eq_in_value}" token)" \
+  "abc=def=ghi"
+
+# Missing key returns the default.
+plan_missing="$(printf 'a=1\nb=2\n')"
+assert_eq "shellproto_field returns default for missing key" \
+  "$(shellproto_field "${plan_missing}" c default-val)" \
+  "default-val"
+assert_eq "shellproto_field returns empty for missing key with no default" \
+  "$(shellproto_field "${plan_missing}" c)" \
+  ""
+
+# First occurrence wins.
+plan_duplicate="$(printf 'k=first\nk=second\nk=third\n')"
+assert_eq "shellproto_field returns first occurrence" \
+  "$(shellproto_field "${plan_duplicate}" k)" \
+  "first"
+
+# Empty plan returns default.
+assert_eq "shellproto_field empty plan returns default" \
+  "$(shellproto_field "" any fallback)" \
+  "fallback"
+
+# Lines without '=' are skipped (forward-compat hook).
+plan_with_garbage="$(printf '# header\nrandom-noise\nkey=value\n')"
+assert_eq "shellproto_field skips non-KV lines" \
+  "$(shellproto_field "${plan_with_garbage}" key)" \
+  "value"
+
+# Empty value is accepted.
+plan_empty_value="$(printf 'present=\nother=visible\n')"
+assert_eq "shellproto_field accepts empty value" \
+  "$(shellproto_field "${plan_empty_value}" present default-not-used)" \
+  ""
+
+# ---- shellproto_assign_globals cases --------------------------------------
+
+# Basic assignment.
+G_ONE="" G_TWO="" G_THREE=""
+plan_basic="$(printf 'one=alpha\ntwo=beta\nthree=gamma\n')"
+shellproto_assign_globals "${plan_basic}" \
+  one:G_ONE \
+  two:G_TWO \
+  three:G_THREE
+assert_eq "assign_globals one" "${G_ONE}" "alpha"
+assert_eq "assign_globals two" "${G_TWO}" "beta"
+assert_eq "assign_globals three" "${G_THREE}" "gamma"
+
+# '=' in value survives.
+G_TOKEN=""
+plan_eq="$(printf 'token=k1=v1=v2\n')"
+shellproto_assign_globals "${plan_eq}" token:G_TOKEN
+assert_eq "assign_globals preserves '=' in value" "${G_TOKEN}" "k1=v1=v2"
+
+# Missing key leaves variable unchanged at caller-supplied value.
+G_KEEP="preset-value"
+shellproto_assign_globals "$(printf 'other=val\n')" missing:G_KEEP
+assert_eq "assign_globals leaves missing var unchanged" "${G_KEEP}" "preset-value"
+
+# First occurrence wins.
+G_FIRST=""
+plan_dup="$(printf 'k=first\nk=second\n')"
+shellproto_assign_globals "${plan_dup}" k:G_FIRST
+assert_eq "assign_globals first occurrence wins" "${G_FIRST}" "first"
+
+# Empty plan leaves variables untouched.
+G_UNTOUCHED="initial"
+shellproto_assign_globals "" some:G_UNTOUCHED
+assert_eq "assign_globals empty plan leaves var unchanged" "${G_UNTOUCHED}" "initial"
+
+# Partial match: only the keys present are reassigned; unmatched lines noop.
+G_A="" G_B=""
+plan_partial="$(printf 'a=A\nstray=Z\nb=B\n')"
+shellproto_assign_globals "${plan_partial}" a:G_A b:G_B
+assert_eq "assign_globals partial match a" "${G_A}" "A"
+assert_eq "assign_globals partial match b" "${G_B}" "B"
+
+# Empty value clears the named variable.
+G_CLEAR="prior"
+shellproto_assign_globals "$(printf 'flag=\n')" flag:G_CLEAR
+assert_eq "assign_globals empty value clears var" "${G_CLEAR}" ""
+
+printf 'OK: shellproto helpers passed %d assertions\n' "${PASS_COUNT}"


### PR DESCRIPTION
## Summary

Round-2 sethify documentation, naming, and polish fix-ups + the Q4 bash KEY=VALUE parser centralization that fix-6 deferred. Plan reference: `~/.claude/plans/distributed-wandering-raccoon.md` PR-FIX-7.

Shape: 16 files, 617 lines, 5 areas (under the 25/1200/8 budget).

## What changed

### Docs / naming nits (10 items)

- `internal/sessionctl/stop.go`, `send.go`: fix stale godoc cross-reference (`consumeRootArgs` → `stateroot.ConsumeRootArgs`).
- `internal/publishpr/doc.go`: rewrite the staged PR-24.x planning prose to describe what the package contains today (parsing, validation, host execution, dry-run emission).
- `internal/cliexit/exit_code_error.go::IsExitCodeError`: clarify that the returned pointer is the unwrapped `*ExitCodeError`.
- `internal/publishpr/host_exec.go::bashQuote`: rewrite the awkward parenthetical pointing to the empty-string return.
- `internal/injection/prepare_bundle.go`: fix the test cross-reference from `TestPrepareBundleRestoresHOMEOnPartialFailure` to the actual test name `TestInstallSyntheticProbeEnvRestoresHomeOnPartialFailure`.
- `internal/sessionctl/monitor.go`: strip the inaccurate claim that `MonitorStateEntries` is exposed for a launcher caller — the launcher only emits a state-file plan line for the bash shim.
- `cmd/workcell-metadatautil/main.go::metadatautilRepoRoot`: add `TODO(workcell-citools-repo-root)` marker so the deferred-work item is grep-able.
- `internal/sessionctl/doc.go`: disambiguate `<verb>Main` vs `<Verb>Main` (exported entry points vs private writer-aware helpers).
- `internal/pathutil/pathutil.go`: add minimal one-line godocs to the four older exports.

### Per-field godocs (D6, ~58 fields)

- `internal/publishpr.Options` (15 fields) + `PreflightInputs` (7 fields): each field documents the bash-side validation constraint where one applies.
- `internal/publishpr.BashContext` (6 fields): each field cross-references the matching `scripts/workcell` global.
- `internal/injection.PrepareBundleOptions` (~14 fields) + `PrepareBundleResult` (~15 fields): the test-only `SelfStagingProbe*` fields explicitly note that production callers MUST leave them false.

### os.Exit consistency

Four launcher subcommands now return `*cliexit.ExitCodeError` instead of calling `os.Exit` directly:

- `cmdLauncherPolicyCli` (code 2 on usage error)
- `cmdLauncherColimaStatus` (code 3 on no-match)
- `cmdLauncherRunHostColimaWithTimeout` (forwards child exit code)
- `cmdLauncherProfilePath` (code 2 on unsupported kind / invalid state key)

### Q4 carryover from fix-6 — bash KEY=VALUE parser centralization

- `scripts/lib/shellproto.sh`: add `shellproto_assign_globals` (multi-variable bulk assignment with first-occurrence-wins semantics, bash 3.2 compatible).
- `scripts/workcell::load_session_runtime_metadata` (22-key parser): migrated to `shellproto_assign_globals`.
- `scripts/workcell::refresh_support_matrix_state` (7-key parser): migrated.
- `scripts/workcell::write_session_record_initial` git case (3 keys): migrated to three `shellproto_field` calls.
- `tests/scenarios/shared/test-shellproto-lib.sh`: new targeted unit test (17 assertions) covering both helpers — `=` in value, missing-key default, first-occurrence-wins, empty plan, non-KV-line skip, empty value, partial match.
- `runtime/container/control-plane-manifest.json`: refresh SHA-256s for `scripts/workcell` and `scripts/lib/shellproto.sh`.

### Deferred

`t.Parallel()` additions for the seven launcher tests were deferred — the two `paths_test.go` tests use `t.Setenv` (which panics under `t.Parallel`), and the five `colima_test.go` tests carry "Intentionally serial" comments documenting ETXTBSY-race avoidance when execing freshly-written scripts. Flipping them mechanically would break correctness, so they remain serial.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all green
- [x] `gofmt -l .` returns 0 entries
- [x] `shellcheck -x scripts/lib/shellproto.sh scripts/lib/sessionctl-shim.sh` clean
- [x] `bash -n scripts/workcell scripts/verify-invariants.sh scripts/lib/*.sh` clean
- [x] `tests/scenarios/shared/test-shellproto-lib.sh` passes 17 assertions
- [x] `scripts/check-pr-shape.sh` passes (16 files, 617 LOC, 5 areas)
- [x] `runtime/container/control-plane-manifest.json` regenerated