### PR TITLE
^R Sethify residual polish (fix-9)

### DIFF
--- a/internal/host/stateroot/stateroot.go
+++ b/internal/host/stateroot/stateroot.go
@@ -45,14 +45,27 @@ var envVarNames = []string{"WORKCELL_STATE_ROOT", "COLIMA_STATE_ROOT"}
 // emit the workcell state root and the colima state root in that
 // order, skipping unset/empty values so the caller never receives a
 // bogus path.  Returns a fresh slice each call.
-func LookupRoots() []string {
+//
+// Returns an error if either env var contains newline, carriage-return,
+// or NUL — those would let an attacker-controlled env propagate the
+// same forged-record injection that FormatRootArgs defends against on
+// the argv-driven path. The check stays symmetric across both helpers
+// so any future plan-emission consumer of LookupRoots inherits the
+// same input-boundary defense.
+func LookupRoots() ([]string, error) {
+	for _, name := range envVarNames {
+		v := os.Getenv(name)
+		if strings.ContainsAny(v, "\n\r\x00") {
+			return nil, fmt.Errorf("%s must not contain newline, carriage-return, or NUL", name)
+		}
+	}
 	roots := make([]string, 0, len(envVarNames))
 	for _, name := range envVarNames {
 		if v := os.Getenv(name); v != "" {
 			roots = append(roots, v)
 		}
 	}
-	return roots
+	return roots, nil
 }
 
 // FormatRootArgs returns the --root=VALUE strings for non-empty
@@ -71,15 +84,24 @@ func LookupRoots() []string {
 // or NUL — those would let an attacker-controlled env var inject
 // forged --root= lines into the bash consumer's `while read` loop.
 func FormatRootArgs(workcellRoot, colimaRoot string) ([]string, error) {
-	for label, root := range map[string]string{"WORKCELL_STATE_ROOT": workcellRoot, "COLIMA_STATE_ROOT": colimaRoot} {
-		if strings.ContainsAny(root, "\n\r\x00") {
-			return nil, fmt.Errorf("%s must not contain newline, carriage-return, or NUL", label)
+	// Validate in fixed envVarNames order so error messages are
+	// deterministic when both inputs are bad — map iteration would
+	// randomize the labeled name reported back.
+	pairs := [...]struct {
+		label, root string
+	}{
+		{envVarNames[0], workcellRoot},
+		{envVarNames[1], colimaRoot},
+	}
+	for _, p := range pairs {
+		if strings.ContainsAny(p.root, "\n\r\x00") {
+			return nil, fmt.Errorf("%s must not contain newline, carriage-return, or NUL", p.label)
 		}
 	}
-	out := make([]string, 0, 2)
-	for _, root := range []string{workcellRoot, colimaRoot} {
-		if root != "" {
-			out = append(out, "--root="+root)
+	out := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		if p.root != "" {
+			out = append(out, "--root="+p.root)
 		}
 	}
 	return out, nil

--- a/internal/host/stateroot/stateroot_test.go
+++ b/internal/host/stateroot/stateroot_test.go
@@ -3,7 +3,10 @@
 
 package stateroot
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+)
 
 func TestConsumeRootArgsStripsLeadingRootFlags(t *testing.T) {
 	t.Parallel()
@@ -45,7 +48,10 @@ func TestLookupRootsReadsEnv(t *testing.T) {
 	t.Setenv("WORKCELL_STATE_ROOT", "/tmp/wc")
 	t.Setenv("COLIMA_STATE_ROOT", "/tmp/colima")
 
-	got := LookupRoots()
+	got, err := LookupRoots()
+	if err != nil {
+		t.Fatalf("LookupRoots err = %v, want nil", err)
+	}
 	want := []string{"/tmp/wc", "/tmp/colima"}
 	if len(got) != len(want) {
 		t.Fatalf("LookupRoots() = %v, want %v", got, want)
@@ -61,9 +67,35 @@ func TestLookupRootsSkipsEmpty(t *testing.T) {
 	t.Setenv("WORKCELL_STATE_ROOT", "/tmp/wc")
 	t.Setenv("COLIMA_STATE_ROOT", "")
 
-	got := LookupRoots()
+	got, err := LookupRoots()
+	if err != nil {
+		t.Fatalf("LookupRoots err = %v, want nil", err)
+	}
 	if len(got) != 1 || got[0] != "/tmp/wc" {
 		t.Fatalf("LookupRoots() = %v, want [/tmp/wc]", got)
+	}
+}
+
+func TestLookupRootsRejectsControlChars(t *testing.T) {
+	// NUL bytes are rejected by os.Setenv itself, so this test only
+	// covers \n and \r — the bytes that survive process boundaries
+	// and still break the bash `while read` loop. FormatRootArgs's
+	// argv path covers NUL via TestFormatRootArgsRejectsControlChars.
+	for _, root := range []string{"\n", "\r", "/tmp/wc\nsmuggled"} {
+		t.Run("workcell="+strconv.Quote(root), func(t *testing.T) {
+			t.Setenv("WORKCELL_STATE_ROOT", root)
+			t.Setenv("COLIMA_STATE_ROOT", "")
+			if _, err := LookupRoots(); err == nil {
+				t.Errorf("LookupRoots accepted control char in WORKCELL_STATE_ROOT")
+			}
+		})
+		t.Run("colima="+strconv.Quote(root), func(t *testing.T) {
+			t.Setenv("WORKCELL_STATE_ROOT", "")
+			t.Setenv("COLIMA_STATE_ROOT", root)
+			if _, err := LookupRoots(); err == nil {
+				t.Errorf("LookupRoots accepted control char in COLIMA_STATE_ROOT")
+			}
+		})
 	}
 }
 

--- a/internal/injection/stage_direct_mounts.go
+++ b/internal/injection/stage_direct_mounts.go
@@ -109,13 +109,16 @@ func validateDirectMount(hostSource, mountPath string) error {
 	// is treated as a hard rejection so a transient I/O failure
 	// can't silently skip the symlink check.
 	//
-	// Intermediate-component-symlink defense (Sec-r2-1): the comprehensive
-	// fix requires distinguishing user-plantable symlinks from system
-	// symlinks (macOS's /var -> /private/var traverses the temp-dir
-	// staging path used by host-inputs cache and tests), which needs
-	// a dedicated design pass. The leaf-only check here closes the
-	// most obvious vector (the original FIX-5 finding) and is left
-	// as a known gap for follow-up.
+	// Intermediate-component-symlink defense (Sec-r2-1): the leaf
+	// path-component is rejected if it is itself a symlink. Intermediate
+	// path components (e.g., a parent dir that's been swapped for a
+	// symlink) are NOT yet inspected here — a comprehensive fix needs
+	// to distinguish user-plantable symlinks from system symlinks
+	// (macOS's /var -> /private/var traverses the temp-dir staging
+	// path used by host-inputs cache and tests), which warrants a
+	// dedicated design pass. Tracked under Sec-r2-1; PR-FIX-10 in
+	// `~/.claude/plans/distributed-wandering-raccoon.md` describes the
+	// follow-up using os.Root (Go 1.24+) or a component-walk allowlist.
 	lstatInfo, lerr := os.Lstat(cleanedSource)
 	if lerr != nil {
 		if !errors.Is(lerr, os.ErrNotExist) {

--- a/internal/metadatautil/path.go
+++ b/internal/metadatautil/path.go
@@ -4,8 +4,6 @@
 package metadatautil
 
 import (
-	"errors"
-
 	"github.com/omkhar/workcell/internal/pathutil"
 )
 
@@ -17,7 +15,7 @@ import (
 // pathutil.CanonicalizePath directly.
 func CanonicalizePath(raw string) (string, error) {
 	if raw == "" {
-		return "", errors.New("empty path")
+		return "", pathutil.ErrEmptyPath
 	}
 	return pathutil.CanonicalizePath(raw, pathutil.Options{})
 }

--- a/internal/pathutil/canonicalize.go
+++ b/internal/pathutil/canonicalize.go
@@ -4,7 +4,6 @@
 package pathutil
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 )
@@ -39,7 +38,7 @@ type Options struct {
 // new code should call CanonicalizePath directly.
 func CanonicalizePath(path string, opts Options) (string, error) {
 	if opts.Strict && path == "" {
-		return "", errors.New("empty path")
+		return "", ErrEmptyPath
 	}
 
 	expanded, err := expandUserPath(path, opts.Strict)

--- a/internal/pathutil/canonicalize_test.go
+++ b/internal/pathutil/canonicalize_test.go
@@ -4,9 +4,9 @@
 package pathutil
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -17,8 +17,8 @@ func TestCanonicalizePathStrictRejectsEmpty(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty strict path")
 	}
-	if !strings.Contains(err.Error(), "empty path") {
-		t.Fatalf("error %q does not mention empty path", err.Error())
+	if !errors.Is(err, ErrEmptyPath) {
+		t.Fatalf("error %q is not ErrEmptyPath", err.Error())
 	}
 }
 

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -11,7 +11,13 @@ import (
 	"strings"
 )
 
-var errEmptyPath = errors.New("path is empty")
+// ErrEmptyPath is the sentinel returned by
+// ExpandUserPathStrictRequireNonEmpty for empty inputs (and reused by
+// the package's other empty-input gates, including
+// CanonicalizePath via canonicalize.go). Callers can match it via
+// errors.Is to detect the missing-input case and stamp a
+// domain-specific message.
+var ErrEmptyPath = errors.New("pathutil: path is empty")
 
 // ExpandUserPathBestEffort expands `~`, `~/...`, and `~user`/`~user/...`
 // references via os.UserHomeDir or user.Lookup.  When a `~user` lookup
@@ -31,21 +37,23 @@ func ExpandUserPathStrict(raw string) (string, error) {
 }
 
 // ExpandUserPathStrictRequireNonEmpty rejects an empty raw input with
-// errEmptyPath, then delegates to ExpandUserPathStrict.  The two
+// ErrEmptyPath, then delegates to ExpandUserPathStrict.  The two
 // near-identical private wrappers in internal/authpolicy and
 // internal/injection used to inline this check; consolidating here
 // keeps the empty-input contract in a single place.
+//
+// The function name is intentionally verbose — Strict and BestEffort
+// describe the error-handling axis, RequireNonEmpty is the empty-input
+// axis. If a 5th expansion variant arrives (e.g., a Strict + NonEmpty +
+// no-`~user`-lookup combination) the package should be reshaped into a
+// pathutil.ExpandUserPath(raw, ExpandOpts{...}) options-style API so
+// the variant count stays manageable.
 func ExpandUserPathStrictRequireNonEmpty(raw string) (string, error) {
 	if raw == "" {
-		return "", errEmptyPath
+		return "", ErrEmptyPath
 	}
 	return ExpandUserPathStrict(raw)
 }
-
-// ErrEmptyPath is the sentinel returned by
-// ExpandUserPathStrictRequireNonEmpty for empty inputs.  Exposed so
-// callers can errors.Is-wrap and stamp a domain-specific message.
-var ErrEmptyPath = errEmptyPath
 
 // ExpandUserPathHomeOnly expands `~` and `~/...` to the current user's
 // home directory and returns any other input verbatim — it never

--- a/internal/publishpr/publish_pr_cli.go
+++ b/internal/publishpr/publish_pr_cli.go
@@ -233,8 +233,12 @@ func PublishPRMain(args []string, stdin io.Reader, stdout, stderr io.Writer) err
 	prURL := strings.TrimRight(prOut.String(), "\n")
 	// Fail-closed: render through a buffer first so a forbidden control
 	// character in any field aborts the whole plan emission rather than
-	// leaving the bash shim with a half-imported plan. Mirrors the
-	// pattern FormatBundleResultForShell uses in internal/injection.
+	// leaving the bash shim with a half-imported plan. Applies the same
+	// fail-closed contract as FormatBundleResultForShell in
+	// internal/injection (which buffers into a strings.Builder and
+	// returns the rendered string to its caller); the structural shape
+	// is different — this emitter writes the buffer to its io.Writer
+	// directly because the caller passes stdout in.
 	var buf bytes.Buffer
 	if err := shellproto.WriteFields(&buf, []shellproto.Field{
 		{Key: "publish_branch", Value: opts.Branch},

--- a/internal/sessionctl/attach.go
+++ b/internal/sessionctl/attach.go
@@ -71,7 +71,11 @@ func attachMain(args []string, stdout, stderr io.Writer) error {
 	}
 
 	if len(roots) == 0 {
-		roots = stateroot.LookupRoots()
+		envRoots, lookupErr := stateroot.LookupRoots()
+		if lookupErr != nil {
+			return &cliexit.ExitCodeError{Code: 2, Message: lookupErr.Error()}
+		}
+		roots = envRoots
 	}
 	record, err := sessions.FindSessionRecordInRoots(roots, sessionID)
 	if err != nil {

--- a/internal/sessionctl/logs.go
+++ b/internal/sessionctl/logs.go
@@ -45,7 +45,11 @@ func logsMain(args []string, stdout io.Writer) error {
 	}
 
 	if len(roots) == 0 {
-		roots = stateroot.LookupRoots()
+		envRoots, lookupErr := stateroot.LookupRoots()
+		if lookupErr != nil {
+			return &cliexit.ExitCodeError{Code: 2, Message: lookupErr.Error()}
+		}
+		roots = envRoots
 	}
 	record, err := sessions.FindSessionRecordInRoots(roots, sessionID)
 	if err != nil {

--- a/internal/sessionctl/stop.go
+++ b/internal/sessionctl/stop.go
@@ -79,7 +79,11 @@ func stopMain(args []string, stdout, stderr io.Writer) error {
 	}
 
 	if len(roots) == 0 {
-		roots = stateroot.LookupRoots()
+		envRoots, lookupErr := stateroot.LookupRoots()
+		if lookupErr != nil {
+			return &cliexit.ExitCodeError{Code: 2, Message: lookupErr.Error()}
+		}
+		roots = envRoots
 	}
 	record, err := sessions.FindSessionRecordInRoots(roots, sessionID)
 	if err != nil {

--- a/internal/sessionctl/timeline.go
+++ b/internal/sessionctl/timeline.go
@@ -36,7 +36,11 @@ func TimelineMain(args []string) error {
 	}
 
 	if len(roots) == 0 {
-		roots = stateroot.LookupRoots()
+		envRoots, lookupErr := stateroot.LookupRoots()
+		if lookupErr != nil {
+			return &cliexit.ExitCodeError{Code: 2, Message: lookupErr.Error()}
+		}
+		roots = envRoots
 	}
 	lines, err := sessions.SessionTimelineRecordsInRoots(roots, sessionID)
 	if err != nil {


### PR DESCRIPTION
First of 4 PRs closing the residual sethify items.

## 7 polish items closed
1. **`FormatRootArgs` map → fixed-order slice** — deterministic error labels
2. **`LookupRoots` control-char rejection** — symmetric with FormatRootArgs; signature now `([]string, error)`; 4 sessionctl callers propagate
3. **`ErrEmptyPath` collapsed** — single exported declaration
4. **Sec-r2-1 comment precision** — names the gap precisely, points at PR-FIX-10 follow-up
5. **Pathutil empty-path wording unified** — both `canonicalize.go` and `metadatautil/path.go` now return `ErrEmptyPath`
6. **publishpr doc accuracy** — "mirrors FormatBundleResultForShell" softened to "applies the same fail-closed contract" (structural shape is different)
7. **`ExpandUserPathStrictRequireNonEmpty` name verbosity note** — doc-only acknowledgment + future options-style API pointer

## Shape
files=12, lines=149/71, areas=4. All 27 packages pass.

## Test plan
- [ ] Validate repository CI green
- [ ] Reproducible build CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)