### PR TITLE
Sec-r2-1: reject intermediate-symlink traversal in direct mount sources (fix-10)

### DIFF
--- a/internal/injection/stage_direct_mounts.go
+++ b/internal/injection/stage_direct_mounts.go
@@ -97,37 +97,40 @@ func validateDirectMount(hostSource, mountPath string) error {
 	if !filepath.IsAbs(cleanedSource) {
 		return fmt.Errorf("Direct input source is missing, not absolute, or not a regular file/directory: %s", hostSource)
 	}
-	// Reject symlinked sources up front: a symlink under the user's
-	// host-inputs root that points at /etc/passwd would dereference
-	// through every subsequent stat/open and leak the target's content
-	// into the staged bundle. copyDirContents already skips symlinks
-	// encountered inside a directory source; this closes the matching
-	// escape for the top-level source itself.
+	// Reject symlinked sources up front: a symlink anywhere in the
+	// path under the user's host-inputs root that points at /etc/passwd
+	// would dereference through every subsequent stat/open and leak
+	// the target's content into the staged bundle. copyDirContents
+	// already skips symlinks encountered inside a directory source;
+	// this closes the matching escape for the top-level source path
+	// itself.
 	//
-	// Lstat error handling: any error other than ENOENT (which the
-	// downstream os.Stat will surface with the canonical diagnostic)
-	// is treated as a hard rejection so a transient I/O failure
-	// can't silently skip the symlink check.
+	// Intermediate-component-symlink defense (Sec-r2-1, PR-FIX-10):
+	// the prior FIX-8 implementation only Lstat'd the leaf component,
+	// so an attacker who planted a symlink at any *parent* component
+	// (e.g., `bundle/userdir/parent-link -> /etc`) could route the
+	// staging copy through the swapped-out directory and harvest
+	// arbitrary host content. We now walk every component from the
+	// filesystem root down to the leaf and Lstat each step.
 	//
-	// Intermediate-component-symlink defense (Sec-r2-1): the leaf
-	// path-component is rejected if it is itself a symlink. Intermediate
-	// path components (e.g., a parent dir that's been swapped for a
-	// symlink) are NOT yet inspected here — a comprehensive fix needs
-	// to distinguish user-plantable symlinks from system symlinks
-	// (macOS's /var -> /private/var traverses the temp-dir staging
-	// path used by host-inputs cache and tests), which warrants a
-	// dedicated design pass. Tracked under Sec-r2-1; PR-FIX-10 in
-	// `~/.claude/plans/distributed-wandering-raccoon.md` describes the
-	// follow-up using os.Root (Go 1.24+) or a component-walk allowlist.
-	lstatInfo, lerr := os.Lstat(cleanedSource)
-	if lerr != nil {
-		if !errors.Is(lerr, os.ErrNotExist) {
-			return fmt.Errorf("Direct input source could not be inspected: %s: %v", hostSource, lerr)
-		}
-		// ENOENT falls through to os.Stat which produces the canonical
-		// "missing, not absolute, or not a regular file/directory" diag.
-	} else if lstatInfo.Mode()&fs.ModeSymlink != 0 {
-		return fmt.Errorf("Direct input source must not be a symbolic link: %s", hostSource)
+	// Allowing macOS system symlinks: `/var -> private/var`,
+	// `/etc -> private/etc`, `/tmp -> private/tmp` are *legitimate*
+	// system-level symlinks that any `t.TempDir()` traversal crosses
+	// on macOS. We can't reject every symlink without breaking the
+	// production code path that stages files from `/var/folders/...`.
+	// Instead, we accept a symlink only when its target is a *relative*
+	// path with no `..` components and no leading `/` — the shape used
+	// by macOS bootstrapping. An attacker-planted absolute target
+	// (`-> /etc`) or `..`-escaping target (`-> ../../etc`) is rejected.
+	//
+	// `os.Root` (Go 1.24+) was evaluated as an alternative but it
+	// follows relative symlinks transparently as long as the resolved
+	// path stays within the root, which means a relative-target attacker
+	// link (`parent-link -> ../etc`) is not flagged. Component-walk
+	// with target-shape inspection catches both absolute and
+	// relative-escape attacks while preserving the macOS system path.
+	if err := rejectSymlinkInPath(cleanedSource); err != nil {
+		return err
 	}
 	info, err := os.Stat(cleanedSource)
 	if err != nil || !(info.Mode().IsRegular() || info.IsDir()) {
@@ -145,6 +148,99 @@ func validateDirectMount(hostSource, mountPath string) error {
 		return fmt.Errorf("Direct input mount path is outside the managed host-input root: %s", mountPath)
 	}
 	return nil
+}
+
+// rejectSymlinkInPath walks every component of cleanedSource from the
+// filesystem root down to (and including) the leaf, Lstat'ing each
+// step. Any symlink whose target does not match the "safe relative
+// system" shape — relative path, no `..` segments, no absolute target —
+// is rejected with the same "must not be a symbolic link" diagnostic
+// FIX-8 used for the leaf case.
+//
+// The safe-shape rule accepts the macOS system symlinks
+// (`/var -> private/var`, `/etc -> private/etc`, `/tmp -> private/tmp`),
+// which production host-inputs paths and `t.TempDir()` traversals
+// rely on. It rejects:
+//   - any link with an absolute target (the canonical attack pattern
+//     `parent-link -> /etc`),
+//   - any link whose target contains a `..` segment (the relative
+//     sideways/upward escape `parent-link -> ../../etc`).
+//
+// Errors other than os.ErrNotExist abort the walk: a transient I/O
+// failure on Lstat must not silently skip the symlink check. ENOENT
+// is allowed to propagate so the downstream os.Stat surfaces the
+// canonical "missing, not absolute, or not a regular file/directory"
+// diagnostic.
+//
+// TOCTOU note: filepath component Lstat'ing leaves a window between
+// the walk completing and the subsequent os.Stat/os.Open in
+// stageDirectMountEntry. A complete TOCTOU-free defense would hold an
+// open file descriptor on each directory and stage from there, which
+// would require restructuring stageDirectMountEntry. The current walk
+// closes the *static* symlink-planting hole; an attacker would still
+// need to win a sub-millisecond race to swap a component after the
+// check but before the copy, and they would need write access to a
+// host-input source path — already a privileged position.
+func rejectSymlinkInPath(cleanedSource string) error {
+	// Walk components: split on `/` and join progressively, Lstat'ing
+	// each intermediate path. cleanedSource is guaranteed absolute and
+	// clean by validateDirectMount, so the first byte is `/`.
+	parts := strings.Split(cleanedSource, string(filepath.Separator))
+	current := string(filepath.Separator)
+	for _, part := range parts {
+		if part == "" {
+			continue // leading slash split yields an empty leading element
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				// Allow the downstream os.Stat to produce the canonical
+				// "missing, not absolute, or not a regular file/directory"
+				// diagnostic for the leaf — but the *intermediate*
+				// component being missing is also a real "not found"
+				// case the existing Stat will catch.
+				return nil
+			}
+			return fmt.Errorf("Direct input source could not be inspected: %s: %v", cleanedSource, err)
+		}
+		if info.Mode()&fs.ModeSymlink == 0 {
+			continue
+		}
+		// Component is a symlink: read its target and apply the
+		// safe-shape rule.
+		target, rerr := os.Readlink(current)
+		if rerr != nil {
+			return fmt.Errorf("Direct input source could not be inspected: %s: %v", cleanedSource, rerr)
+		}
+		if !symlinkTargetIsSafeRelativeSystem(target) {
+			return fmt.Errorf("Direct input source must not be a symbolic link: %s", cleanedSource)
+		}
+	}
+	return nil
+}
+
+// symlinkTargetIsSafeRelativeSystem returns true when target is a
+// relative path with no `..` segments and no leading `/`. This is the
+// shape macOS uses for `/var -> private/var`, `/etc -> private/etc`,
+// `/tmp -> private/tmp` and is *not* the shape an attacker would plant
+// to escape the host-inputs staging tree (those almost always use an
+// absolute target or `..`-laden relative target).
+func symlinkTargetIsSafeRelativeSystem(target string) bool {
+	if target == "" {
+		return false
+	}
+	if filepath.IsAbs(target) {
+		return false
+	}
+	// Split on `/` (symlink target is a POSIX path; filepath.Separator
+	// is `/` on Unix). Reject any `..` segment.
+	for _, seg := range strings.Split(target, "/") {
+		if seg == ".." {
+			return false
+		}
+	}
+	return true
 }
 
 // stageDirectMountEntry copies a host source into stagedSource, replicating

--- a/internal/injection/stage_direct_mounts_test.go
+++ b/internal/injection/stage_direct_mounts_test.go
@@ -303,6 +303,111 @@ func TestStageDirectMountsStripsGroupOtherPermissions(t *testing.T) {
 // validateDirectMount must reject the link up front, mirroring the
 // symlink skip that copyDirContents already does for entries it
 // encounters inside a directory source.
+// TestStageDirectMountsRejectsIntermediateSymlinkInSource — round-2
+// sethify Sec-r2-1 / PR-FIX-10. FIX-8 only Lstat'd the leaf component
+// of the mount source; an attacker who plants a symlink at any
+// intermediate component (e.g. `bundle/parent-link -> /etc`) bypasses
+// the check because the LEAF `parent-link/passwd` resolves through
+// the swapped-out parent dir and stat-as-a-regular-file succeeds.
+// rejectSymlinkInPath now walks every component and refuses absolute-
+// target symlinks anywhere in the path.
+func TestStageDirectMountsRejectsIntermediateSymlinkInSource(t *testing.T) {
+	bundleRoot := t.TempDir()
+	// "etc-style" sibling directory we'll pretend has sensitive content.
+	etcLike := filepath.Join(bundleRoot, "etc-like")
+	if err := os.MkdirAll(etcLike, 0o755); err != nil {
+		t.Fatalf("MkdirAll etcLike: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(etcLike, "secret.txt"), []byte("SECRET"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	// Plant a parent-component symlink with an absolute target.
+	parentLink := filepath.Join(bundleRoot, "legit-parent")
+	if err := os.Symlink(etcLike, parentLink); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	// The mount source has the symlink at an *intermediate* path
+	// component; the leaf itself is a perfectly normal file.
+	sourceViaLink := filepath.Join(parentLink, "secret.txt")
+	specPath := filepath.Join(bundleRoot, "spec.json")
+	writeMountSpec(t, specPath, []map[string]any{
+		{"source": sourceViaLink, "mount_path": "/opt/workcell/host-inputs/x"},
+	})
+	_, err := StageDirectMounts(bundleRoot, specPath)
+	if err == nil || !strings.Contains(err.Error(), "must not be a symbolic link") {
+		t.Fatalf("expected intermediate-symlink rejection, got %v", err)
+	}
+}
+
+// TestStageDirectMountsRejectsIntermediateRelativeEscapeSymlink — same
+// attack class, but the planted symlink uses a *relative* target with
+// `..` segments to escape sideways. The component walk's
+// "no `..` in target" rule must catch this even though the resolved
+// path stays within `/`.
+func TestStageDirectMountsRejectsIntermediateRelativeEscapeSymlink(t *testing.T) {
+	bundleRoot := t.TempDir()
+	etcLike := filepath.Join(bundleRoot, "etc-like")
+	if err := os.MkdirAll(etcLike, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(etcLike, "secret.txt"), []byte("SECRET"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	innerDir := filepath.Join(bundleRoot, "inner")
+	if err := os.MkdirAll(innerDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll inner: %v", err)
+	}
+	parentLink := filepath.Join(innerDir, "parent-link")
+	// relative escape: `../etc-like` from inside `inner/`.
+	if err := os.Symlink("../etc-like", parentLink); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	sourceViaLink := filepath.Join(parentLink, "secret.txt")
+	specPath := filepath.Join(bundleRoot, "spec.json")
+	writeMountSpec(t, specPath, []map[string]any{
+		{"source": sourceViaLink, "mount_path": "/opt/workcell/host-inputs/x"},
+	})
+	_, err := StageDirectMounts(bundleRoot, specPath)
+	if err == nil || !strings.Contains(err.Error(), "must not be a symbolic link") {
+		t.Fatalf("expected relative-escape symlink rejection, got %v", err)
+	}
+}
+
+// TestStageDirectMountsAcceptsLegitimateMacosVarPath — guards against
+// over-rejection. macOS `t.TempDir()` lives under `/var/folders/...`
+// and traverses the system `/var -> private/var` symlink. The
+// component walk's safe-relative-system rule must allow this; if not,
+// every production direct-mount staging on a Mac would fail. The
+// helper here uses os.MkdirTemp("/var/folders", ...) only when the
+// system layout makes that traversal meaningful (the test skips on
+// platforms where `/var` isn't a symlink).
+func TestStageDirectMountsAcceptsLegitimateMacosVarPath(t *testing.T) {
+	info, err := os.Lstat("/var")
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Skipf("/var is not a symlink on this platform; nothing to verify")
+	}
+	// t.TempDir on macOS routes through /var/folders/... so its
+	// absolute path crosses /var. Use it as both bundle and source
+	// home so the staging walk inspects the system symlink.
+	bundleRoot := t.TempDir()
+	sourceFile := filepath.Join(bundleRoot, "legit.txt")
+	if err := os.WriteFile(sourceFile, []byte("legit"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	mountPath := "/opt/workcell/host-inputs/legit"
+	specPath := filepath.Join(bundleRoot, "spec.json")
+	writeMountSpec(t, specPath, []map[string]any{
+		{"source": sourceFile, "mount_path": mountPath},
+	})
+	args, err := StageDirectMounts(bundleRoot, specPath)
+	if err != nil {
+		t.Fatalf("StageDirectMounts unexpectedly rejected legitimate /var path: %v", err)
+	}
+	if len(args) != 2 {
+		t.Fatalf("expected 2 args, got %v", args)
+	}
+}
+
 func TestStageDirectMountsRejectsSymlinkedSource(t *testing.T) {
 	bundleRoot := t.TempDir()
 	// Real target file (would otherwise be valid mount content).


### PR DESCRIPTION
## Summary

Closes the FIX-8 intermediate-symlink gap. Previously `validateDirectMount` only Lstat'd the leaf component of a direct-mount source, so an attacker who planted a symlink at any parent component (e.g. `bundle/parent-link -> /etc`) could route the staging copy through the swapped-out directory and harvest arbitrary host content into the container bundle.

## Approach

**Component walk with safe-relative-target rule** (chosen over `os.Root`).

`rejectSymlinkInPath` walks every component of the cleaned source path from `/` down to the leaf and Lstat's each step. When a component is a symlink, the link target is inspected; the safe shape is *relative, no `..` segments, no leading `/`*. This matches the legitimate macOS system symlinks (`/var -> private/var`, `/etc -> private/etc`, `/tmp -> private/tmp`) that every `t.TempDir()` traversal crosses, while rejecting:

- absolute targets (canonical `parent-link -> /etc`)
- relative targets with `..` (sideways escape `parent-link -> ../../etc`)

### Why not `os.Root`?

`os.Root` (Go 1.24+) was evaluated. It catches absolute-target symlinks cleanly (`statat ... path escapes from parent`), but it *follows* relative symlinks transparently as long as the resolved path stays within the root. A relative-target attacker link (`parent-link -> ../../etc-like`) is treated as a normal traversal and not flagged. Component-walk with target-shape inspection covers both attack classes while preserving the macOS legitimate-system path.

## Test plan

- [x] `TestStageDirectMountsRejectsIntermediateSymlinkInSource` — absolute intermediate target; was the FIX-8 bypass.
- [x] `TestStageDirectMountsRejectsIntermediateRelativeEscapeSymlink` — relative `..` intermediate target; not covered by `os.Root`.
- [x] `TestStageDirectMountsAcceptsLegitimateMacosVarPath` — over-rejection guard; verifies `t.TempDir()` paths under `/var/folders/...` still stage cleanly on Darwin.
- [x] Legacy `TestStageDirectMountsRejectsSymlinkedSource` (leaf symlink, absolute target) continues to pass — the new walk subsumes the FIX-8 leaf-only check.
- [x] `go build ./...` clean
- [x] `go test ./...` clean
- [x] `gofmt -l . | wc -l` is 0
- [x] `bash scripts/check-pr-shape.sh` — files=2 lines=259 areas=1
- [x] `bash tests/scenarios/shared/test-session-commands.sh` exit 0

## TOCTOU caveat

Documented inline. The walk closes the *static* symlink-planting hole, not a sub-millisecond race between validate and stage. A complete TOCTOU-free defense would require restructuring `stageDirectMountEntry` to hold dir-fds, which is out of scope for this round-2 fix.