### PR TITLE
^R Promote *-cli and *-usage launcher entries to top-level workcell-hostutil subcommands (fix-11)

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -55,14 +55,54 @@ func run(args []string) error {
 		return runPath(args[1:])
 	case "release":
 		return runRelease(args[1:])
+	case "helper":
+		return runHelper(args[1:])
+	// Deprecated: `launcher` is retained for one PR cycle as an alias
+	// for `helper` so that any straggling caller does not break.  All
+	// in-tree bash callers have been migrated; remove this alias in
+	// the next PR cycle once external mirrors have caught up.
 	case "launcher":
-		return runLauncher(args[1:])
+		return runHelper(args[1:])
 	case "policy":
 		return runHostutilPolicy(args[1:])
 	case "resolve-credentials":
 		return runHostutilResolveCredentials(args[1:])
 	case "pty-transcript":
 		return runHostutilPTYTranscript(args[1:])
+	// Top-level *-cli and *-usage entry points promoted out of the
+	// former `launcher` umbrella so the dispatch table only retains
+	// stateless helpers.  Each case delegates to the same handler the
+	// helper table used to call; no behavioural change.
+	case "auth-cli":
+		return cmdLauncherAuthCli(args[1:])
+	case "auth-usage":
+		return cmdLauncherAuthUsage(args[1:])
+	case "policy-cli":
+		return cmdLauncherPolicyCli(args[1:])
+	case "policy-usage":
+		return cmdLauncherPolicyUsage(args[1:])
+	case "publish-pr-cli":
+		return cmdLauncherPublishPRCli(args[1:])
+	case "publish-pr-usage":
+		return cmdLauncherPublishPRUsage(args[1:])
+	case "session-usage":
+		return cmdLauncherSessionUsage(args[1:])
+	case "session-attach-cli":
+		return cmdLauncherSessionAttachCli(args[1:])
+	case "session-delete-cli":
+		return cmdLauncherSessionDeleteCli(args[1:])
+	case "session-dispatch-cli":
+		return cmdLauncherSessionDispatchCli(args[1:])
+	case "session-logs-cli":
+		return cmdLauncherSessionLogsCli(args[1:])
+	case "session-monitor-cli":
+		return cmdLauncherSessionMonitorCli(args[1:])
+	case "session-send-cli":
+		return cmdLauncherSessionSendCli(args[1:])
+	case "session-stop-cli":
+		return cmdLauncherSessionStopCli(args[1:])
+	case "session-timeline-cli":
+		return cmdLauncherSessionTimelineCli(args[1:])
 	default:
 		return usage()
 	}
@@ -71,9 +111,9 @@ func run(args []string) error {
 // runHostutilPolicy dispatches the absorbed workcell-manage-injection-policy
 // CLI surface (scripts/lib/manage_injection_policy callers). This is the
 // **manage injection-policy** path: it edits the on-disk injection-policy
-// TOML files. Not to be confused with `workcell-hostutil launcher
-// policy-cli` below, which is the **`workcell policy <subcommand>`** Go
-// translation of the bash policy_main user-shell command (init/show/...).
+// TOML files. Not to be confused with `workcell-hostutil policy-cli`
+// below, which is the **`workcell policy <subcommand>`** Go translation
+// of the bash policy_main user-shell command (init/show/...).
 // authpolicy.Run returns a *cliexit.ExitCodeError directly, so we can
 // propagate it without re-wrapping; main()'s typed handler preserves
 // the stdout/stderr/exit-code contract.
@@ -172,36 +212,28 @@ func runRelease(args []string) error {
 	}
 }
 
-// launcherSubcommand describes one workcell-hostutil launcher subcommand.
+// helperSubcommand describes one workcell-hostutil helper subcommand.
 // minArgs and maxArgs count only the args that follow the subcommand
 // name; a maxArgs of -1 means unbounded.
-type launcherSubcommand struct {
+//
+// PR-FIX-11 renamed this from launcherSubcommand to helperSubcommand
+// after every `*-cli`/`*-usage` row was promoted to a top-level
+// workcell-hostutil subcommand.  The helper table now holds only
+// stateless helpers (cache keys, path math, validators, etc.).
+type helperSubcommand struct {
 	name    string
 	minArgs int
 	maxArgs int
 	handler func(args []string) error
 }
 
-// launcherSubcommands returns the dispatch table.  It is a function (not
+// helperSubcommands returns the dispatch table.  It is a function (not
 // a package-level var) because several of the session handlers below
-// call back into launcherUsage, which itself reads this table; using a
+// call back into helperUsage, which itself reads this table; using a
 // function defers the table's construction past package-init time and
 // avoids a Go initialization cycle.
-func launcherSubcommands() []launcherSubcommand {
-	return []launcherSubcommand{
-		{"session-usage", 0, 0, cmdLauncherSessionUsage},
-		{"auth-cli", 0, -1, cmdLauncherAuthCli},
-		{"auth-usage", 0, 0, cmdLauncherAuthUsage},
-		{"policy-usage", 0, 0, cmdLauncherPolicyUsage},
-		{"policy-cli", 0, -1, cmdLauncherPolicyCli},
-		{"session-timeline-cli", 0, -1, cmdLauncherSessionTimelineCli},
-		{"session-logs-cli", 0, -1, cmdLauncherSessionLogsCli},
-		{"session-attach-cli", 0, -1, cmdLauncherSessionAttachCli},
-		{"session-delete-cli", 0, -1, cmdLauncherSessionDeleteCli},
-		{"session-dispatch-cli", 0, -1, cmdLauncherSessionDispatchCli},
-		{"session-monitor-cli", 0, -1, cmdLauncherSessionMonitorCli},
-		{"session-send-cli", 0, -1, cmdLauncherSessionSendCli},
-		{"session-stop-cli", 0, -1, cmdLauncherSessionStopCli},
+func helperSubcommands() []helperSubcommand {
+	return []helperSubcommand{
 		{"session-suffix", 0, 0, cmdLauncherSessionSuffix},
 		{"colima-status", 1, 1, cmdLauncherColimaStatus},
 		{"validate-colima-status", 1, 1, cmdLauncherValidateColimaStatus},
@@ -236,12 +268,10 @@ func launcherSubcommands() []launcherSubcommand {
 		{"dedupe-endpoints", 1, 1, cmdLauncherDedupeEndpoints},
 		{"resolve-endpoints", 1, 1, cmdLauncherResolveEndpoints},
 		{"support-matrix-eval", 6, 6, cmdLauncherSupportMatrixEval},
-		{"publish-pr-usage", 0, 0, cmdLauncherPublishPRUsage},
 		{"profile-path", 1, -1, cmdLauncherProfilePath},
 		// PR 23.4 — injection bundle preparation moved into Go.
 		{"injection-stage-direct-mounts", 2, 2, cmdLauncherInjectionStageDirectMounts},
 		{"injection-prepare-bundle", 0, -1, cmdLauncherInjectionPrepareBundle},
-		{"publish-pr-cli", 0, -1, cmdLauncherPublishPRCli},
 		// lookup-state-roots takes the two state-root values as
 		// positional args (in WORKCELL,COLIMA order) so the bash shim
 		// does not need to leak them through env -i to the cleaned
@@ -251,24 +281,24 @@ func launcherSubcommands() []launcherSubcommand {
 	}
 }
 
-func runLauncher(args []string) error {
+func runHelper(args []string) error {
 	if len(args) == 0 {
-		return launcherUsage()
+		return helperUsage()
 	}
 	rest := args[1:]
-	for _, sub := range launcherSubcommands() {
+	for _, sub := range helperSubcommands() {
 		if sub.name != args[0] {
 			continue
 		}
 		if len(rest) < sub.minArgs {
-			return launcherUsage()
+			return helperUsage()
 		}
 		if sub.maxArgs >= 0 && len(rest) > sub.maxArgs {
-			return launcherUsage()
+			return helperUsage()
 		}
 		return sub.handler(rest)
 	}
-	return launcherUsage()
+	return helperUsage()
 }
 
 func cmdLauncherSessionUsage(_ []string) error {
@@ -295,12 +325,14 @@ func cmdLauncherPublishPRUsage(_ []string) error {
 	return nil
 }
 
-// cmdLauncherPolicyCli is the launcher entry point for the Go
-// translation of scripts/workcell's policy_main bash function — the
-// **user-facing `workcell policy <subcommand>`** surface (init, show,
-// etc.). Not to be confused with `workcell-hostutil policy` (above),
-// which is the **manage-injection-policy** TOML-editing surface
-// absorbed from the former workcell-manage-injection-policy binary.
+// cmdLauncherPolicyCli is the top-level `workcell-hostutil policy-cli`
+// entry point for the Go translation of scripts/workcell's policy_main
+// bash function — the **user-facing `workcell policy <subcommand>`**
+// surface (init, show, etc.). Not to be confused with `workcell-hostutil
+// policy` (above), which is the **manage-injection-policy** TOML-editing
+// surface absorbed from the former workcell-manage-injection-policy
+// binary.  PR-FIX-11 promoted this entry point out of the helper
+// dispatch table.
 // Usage errors (missing/unknown subcommand, unknown option) exit with
 // code 2 to match the bash CLI surface; all other errors propagate to
 // main() for the default exit-1 path.
@@ -408,7 +440,7 @@ func cmdLauncherRunHostColimaWithTimeout(args []string) error {
 // most convenient.
 func parseColimaInvocationArgs(args []string) (int, launcher.HostColimaInvocation, []string, error) {
 	if len(args) == 0 {
-		return 0, launcher.HostColimaInvocation{}, nil, launcherUsage()
+		return 0, launcher.HostColimaInvocation{}, nil, helperUsage()
 	}
 	timeoutSeconds, err := strconv.Atoi(args[0])
 	if err != nil {
@@ -437,7 +469,7 @@ func parseColimaInvocationArgs(args []string) (int, launcher.HostColimaInvocatio
 		case strings.HasPrefix(arg, "--cwd="):
 			inv.CWD = strings.TrimPrefix(arg, "--cwd=")
 		default:
-			return 0, launcher.HostColimaInvocation{}, nil, launcherUsage()
+			return 0, launcher.HostColimaInvocation{}, nil, helperUsage()
 		}
 		rest = rest[1:]
 	}
@@ -469,7 +501,7 @@ func cmdLauncherRouteProfileDockerCommand(args []string) error {
 		case strings.HasPrefix(arg, "--context-name="):
 			contextName = strings.TrimPrefix(arg, "--context-name=")
 		default:
-			return launcherUsage()
+			return helperUsage()
 		}
 	}
 	route, err := launcher.RouteProfileDockerCommand(provider, socketPath, contextName)
@@ -513,7 +545,7 @@ func cmdLauncherPrepareCurrentDockerClientPlan(args []string) error {
 		case arg == "--context-healthy=0":
 			contextHealthy = false
 		default:
-			return launcherUsage()
+			return helperUsage()
 		}
 	}
 	plan, err := launcher.PrepareCurrentDockerClientPlan(backend, contextName, contextExists, contextHealthy)
@@ -932,7 +964,7 @@ func parsePrepareBundleArgs(args []string) (*injection.PrepareBundleOptions, err
 }
 
 func usage() error {
-	return fmt.Errorf("usage: workcell-hostutil <path|release|launcher|policy|resolve-credentials|pty-transcript> [args...]")
+	return fmt.Errorf("usage: workcell-hostutil <path|release|helper|policy|resolve-credentials|pty-transcript|auth-cli|auth-usage|policy-cli|policy-usage|publish-pr-cli|publish-pr-usage|session-usage|session-attach-cli|session-delete-cli|session-dispatch-cli|session-logs-cli|session-monitor-cli|session-send-cli|session-stop-cli|session-timeline-cli> [args...]")
 }
 
 func pathUsage() error {
@@ -943,18 +975,18 @@ func releaseUsage() error {
 	return fmt.Errorf("usage: workcell-hostutil release <create-payload|metadata|encode-name|bundle-manifest> [args...]")
 }
 
-func launcherUsage() error {
-	subs := launcherSubcommands()
+func helperUsage() error {
+	subs := helperSubcommands()
 	names := make([]string, 0, len(subs))
 	for _, sub := range subs {
 		names = append(names, sub.name)
 	}
-	return fmt.Errorf("usage: workcell-hostutil launcher <%s> [args...]", strings.Join(names, "|"))
+	return fmt.Errorf("usage: workcell-hostutil helper <%s> [args...]", strings.Join(names, "|"))
 }
 
 func parseSessionRoots(args []string) ([]string, []string, error) {
 	if len(args) == 0 {
-		return nil, nil, launcherUsage()
+		return nil, nil, helperUsage()
 	}
 
 	if strings.HasPrefix(args[0], "--root=") {
@@ -962,13 +994,13 @@ func parseSessionRoots(args []string) ([]string, []string, error) {
 		for len(args) > 0 && strings.HasPrefix(args[0], "--root=") {
 			root := strings.TrimPrefix(args[0], "--root=")
 			if root == "" {
-				return nil, nil, launcherUsage()
+				return nil, nil, helperUsage()
 			}
 			roots = append(roots, root)
 			args = args[1:]
 		}
 		if len(roots) == 0 {
-			return nil, nil, launcherUsage()
+			return nil, nil, helperUsage()
 		}
 		return roots, args, nil
 	}
@@ -996,7 +1028,7 @@ func runLauncherSessionList(args []string) error {
 		case strings.HasPrefix(arg, "--profile="):
 			opts.Profile = strings.TrimPrefix(arg, "--profile=")
 		default:
-			return launcherUsage()
+			return helperUsage()
 		}
 	}
 	if format == "json" && verbose {
@@ -1060,13 +1092,13 @@ func runLauncherSessionShow(args []string) error {
 		return err
 	}
 	if len(rest) < 1 || len(rest) > 2 {
-		return launcherUsage()
+		return helperUsage()
 	}
 
 	format := "json"
 	for _, arg := range rest[1:] {
 		if arg != "--text" {
-			return launcherUsage()
+			return helperUsage()
 		}
 		format = "text"
 	}
@@ -1094,7 +1126,7 @@ func runLauncherSessionExport(args []string) error {
 		return err
 	}
 	if len(rest) != 1 {
-		return launcherUsage()
+		return helperUsage()
 	}
 
 	exported, err := sessions.ExportSessionRecordInRoots(roots, rest[0])
@@ -1115,7 +1147,7 @@ func runLauncherSessionDiffMetadata(args []string) error {
 		return err
 	}
 	if len(rest) != 1 {
-		return launcherUsage()
+		return helperUsage()
 	}
 
 	record, err := sessions.FindSessionRecordInRoots(roots, rest[0])
@@ -1134,7 +1166,7 @@ func runLauncherSessionRuntimeMetadata(args []string) error {
 		return err
 	}
 	if len(rest) != 1 {
-		return launcherUsage()
+		return helperUsage()
 	}
 
 	record, recordPath, err := sessions.FindSessionRecordWithPathInRoots(roots, rest[0])
@@ -1154,7 +1186,7 @@ func runLauncherSessionTimeline(args []string) error {
 		return err
 	}
 	if len(rest) != 1 {
-		return launcherUsage()
+		return helperUsage()
 	}
 
 	lines, err := sessions.SessionTimelineRecordsInRoots(roots, rest[0])

--- a/cmd/workcell-hostutil/main_test.go
+++ b/cmd/workcell-hostutil/main_test.go
@@ -62,7 +62,7 @@ func TestRunLauncherSessionTimeline(t *testing.T) {
 		close(done)
 	}()
 
-	runErr := run([]string{"launcher", "session-timeline", colimaRoot, "session-1"})
+	runErr := run([]string{"helper", "session-timeline", colimaRoot, "session-1"})
 	_ = w.Close()
 	<-done
 	_ = r.Close()
@@ -124,7 +124,7 @@ func TestRunLauncherSessionRuntimeMetadata(t *testing.T) {
 		close(done)
 	}()
 
-	runErr := run([]string{"launcher", "session-runtime-metadata", colimaRoot, "session-1"})
+	runErr := run([]string{"helper", "session-runtime-metadata", colimaRoot, "session-1"})
 	_ = w.Close()
 	<-done
 	_ = r.Close()
@@ -185,7 +185,7 @@ func TestRunLauncherSessionRuntimeMetadataSupportsMultipleRoots(t *testing.T) {
 	}()
 
 	runErr := run([]string{
-		"launcher",
+		"helper",
 		"session-runtime-metadata",
 		"--root=" + stateRoot,
 		"--root=" + legacyRoot,
@@ -260,7 +260,7 @@ func TestRunLauncherSessionListShowsLiveStatusAndControl(t *testing.T) {
 		close(done)
 	}()
 
-	runErr := run([]string{"launcher", "session-list", colimaRoot})
+	runErr := run([]string{"helper", "session-list", colimaRoot})
 	_ = w.Close()
 	<-done
 	_ = r.Close()
@@ -314,7 +314,7 @@ func TestRunLauncherSessionListVerboseShowsTargetMetadata(t *testing.T) {
 		close(done)
 	}()
 
-	runErr := run([]string{"launcher", "session-list", colimaRoot, "--verbose"})
+	runErr := run([]string{"helper", "session-list", colimaRoot, "--verbose"})
 	_ = w.Close()
 	<-done
 	_ = r.Close()
@@ -370,7 +370,7 @@ func TestRunLauncherSessionShowText(t *testing.T) {
 		close(done)
 	}()
 
-	runErr := run([]string{"launcher", "session-show", colimaRoot, "session-1", "--text"})
+	runErr := run([]string{"helper", "session-show", colimaRoot, "session-1", "--text"})
 	_ = w.Close()
 	<-done
 	_ = r.Close()
@@ -414,10 +414,10 @@ func TestResolveHostOutputDirectoryCandidateRejectsRegularFile(t *testing.T) {
 	}
 }
 
-func TestLauncherUsageListsDirectoryCandidateResolver(t *testing.T) {
-	if err := launcherUsage(); err == nil {
-		t.Fatal("launcherUsage unexpectedly returned nil")
+func TestHelperUsageListsDirectoryCandidateResolver(t *testing.T) {
+	if err := helperUsage(); err == nil {
+		t.Fatal("helperUsage unexpectedly returned nil")
 	} else if !strings.Contains(err.Error(), "resolve-host-output-directory-candidate") {
-		t.Fatalf("launcherUsage error = %q, want resolve-host-output-directory-candidate", err)
+		t.Fatalf("helperUsage error = %q, want resolve-host-output-directory-candidate", err)
 	}
 }

--- a/internal/host/stateroot/stateroot.go
+++ b/internal/host/stateroot/stateroot.go
@@ -71,7 +71,7 @@ func LookupRoots() ([]string, error) {
 // FormatRootArgs returns the --root=VALUE strings for non-empty
 // workcellRoot and colimaRoot, in that fixed order. This is the single
 // Go owner of the bash↔Go state-root contract; scripts/workcell shells
-// out through `workcell-hostutil launcher lookup-state-roots` to
+// out through `workcell-hostutil helper lookup-state-roots` to
 // consume it, so the order and the "skip empty" rule live in exactly
 // one place.
 //

--- a/internal/publishpr/doc.go
+++ b/internal/publishpr/doc.go
@@ -28,8 +28,8 @@
 //     `printf %q` shape that
 //     tests/scenarios/shared/test-publish-pr-dry-run.sh greps for.
 //
-// PublishPRMain wires the four concerns together as the launcher entry
-// point for `workcell-hostutil launcher publish-pr-cli`; scripts/workcell
-// publish_pr_main is the thin shim that forwards bash-side globals as
-// --bash-* flags.
+// PublishPRMain wires the four concerns together as the entry point
+// for the top-level `workcell-hostutil publish-pr-cli` subcommand;
+// scripts/workcell publish_pr_main is the thin shim that forwards
+// bash-side globals as --bash-* flags.
 package publishpr

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "9515c617bade235d8ab9577bdafbc5cf3043771088a1f41702d442d9a82f82a2"
+      "sha256": "756f14e231cb2f7784c24a603248fe49970a51fabe56ed2aaeb828c881d796db"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",
@@ -18,7 +18,7 @@
     },
     {
       "repo_path": "scripts/lib/sessionctl-shim.sh",
-      "sha256": "07fcc20cf54aca8cddba0f98889737c2d89cc3014ab4c4b1c015a85fb3469dce"
+      "sha256": "6ece45ed3b6343cbab7d796e29330acbcfcdeec37ed110256397525a7b57eded"
     },
     {
       "repo_path": "scripts/lib/shellproto.sh",

--- a/scripts/lib/sessionctl-shim.sh
+++ b/scripts/lib/sessionctl-shim.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Omkhar Arasaratnam
 #
-# Shared shim that fronts every session_*_main launcher call.  The five
+# Shared shim that fronts every session_*_main hostutil call.  The five
 # session_send_main / session_stop_main / session_delete_main /
 # session_monitor_main / session_attach_main bash functions used to each
 # reimplement the same 8-line "read state-root flags, capture the Go
@@ -14,7 +14,7 @@
 #
 # session_run_cli_with_roots <subcommand> [args...]
 #
-#   Runs go_hostutil's `launcher <subcommand>` after prepending the
+#   Runs go_hostutil's top-level `<subcommand>` after prepending the
 #   --root=PATH state-root args supplied by session_lookup_root_args.
 #   Emits the captured stdout (the Go side's KEY=VALUE plan) on the
 #   shim's stdout, and returns the child's exit status so the calling
@@ -37,7 +37,7 @@ session_run_cli_with_roots() {
   done < <(session_lookup_root_args)
   set +e
   local plan
-  plan="$(go_hostutil launcher "${subcommand}" "${lookup_roots[@]}" "$@")"
+  plan="$(go_hostutil "${subcommand}" "${lookup_roots[@]}" "$@")"
   local status="$?"
   set -e
   printf '%s\n' "${plan}"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -220,7 +220,7 @@ INSTALL_VERIFY_HOME="$(mktemp -d)"
 ROOT_DRY_RUN_PROFILE_NAME="$(
   workspace="$(cd "${ROOT_DIR}" && pwd -P)"
   slug="$(printf '%s' "${workspace##*/}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g; s/^$/workspace/' | cut -c1-10)"
-  digest="$(go_verify_hostutil launcher workspace-cache-key "${workspace}" | cut -c1-8)"
+  digest="$(go_verify_hostutil helper workspace-cache-key "${workspace}" | cut -c1-8)"
   printf 'wcl-%s-%s\n' "${slug}" "${digest}"
 )"
 ROOT_DRY_RUN_PROFILE_DIR="${REAL_HOME}/.colima/${ROOT_DRY_RUN_PROFILE_NAME}"
@@ -239,7 +239,7 @@ DETACHED_SESSION_WORKSPACE=""
 DETACHED_SESSION_SOURCE_SENTINEL_PATH=""
 VERIFY_INVARIANTS_CLEANUP_ACTIVE=0
 ROOT_STRICT_SUPPORT_OUTPUT="$(
-  go_verify_hostutil launcher support-matrix-eval \
+  go_verify_hostutil helper support-matrix-eval \
     "${ROOT_DIR}/policy/host-support-matrix.tsv" \
     "$(detected_verify_host_os)" \
     "$(detected_verify_host_arch)" \
@@ -5191,24 +5191,24 @@ grep -q -- '--cap-add SETUID' /tmp/workcell-default-autonomy-dry-run.stdout
 grep -q -- '--cap-add SETGID' /tmp/workcell-default-autonomy-dry-run.stdout
 grep -q -- '--security-opt no-new-privileges:true' /tmp/workcell-default-autonomy-dry-run.stdout
 
-if ! go_verify_hostutil launcher validate-security-options '["name=apparmor","name=seccomp,profile=builtin","name=cgroupns"]' >/dev/null; then
+if ! go_verify_hostutil helper validate-security-options '["name=apparmor","name=seccomp,profile=builtin","name=cgroupns"]' >/dev/null; then
   echo "Expected launcher validate-security-options to accept canonical AppArmor+seccomp daemon options" >&2
   exit 1
 fi
-if go_verify_hostutil launcher validate-security-options '["name=cgroupns"]' >/dev/null 2>&1; then
+if go_verify_hostutil helper validate-security-options '["name=cgroupns"]' >/dev/null 2>&1; then
   echo "Expected launcher validate-security-options to reject daemon options missing seccomp/MAC" >&2
   exit 1
 fi
-if ! go_verify_hostutil launcher validate-container-security-options '["no-new-privileges:true"]' >/dev/null; then
+if ! go_verify_hostutil helper validate-container-security-options '["no-new-privileges:true"]' >/dev/null; then
   echo "Expected launcher validate-container-security-options to accept canonical HostConfig.SecurityOpt" >&2
   exit 1
 fi
-if go_verify_hostutil launcher validate-container-security-options '["no-new-privileges:true","seccomp=unconfined"]' >/dev/null 2>&1; then
+if go_verify_hostutil helper validate-container-security-options '["no-new-privileges:true","seccomp=unconfined"]' >/dev/null 2>&1; then
   echo "Expected launcher validate-container-security-options to reject seccomp=unconfined" >&2
   exit 1
 fi
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "validate_runtime_security_posture" "go_hostutil launcher validate-security-options"; then
-  echo "Expected validate_runtime_security_posture to validate daemon SecurityOptions through the launcher subcommand" >&2
+if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "validate_runtime_security_posture" "go_hostutil helper validate-security-options"; then
+  echo "Expected validate_runtime_security_posture to validate daemon SecurityOptions through the helper subcommand" >&2
   exit 1
 fi
 
@@ -7427,7 +7427,7 @@ fi
 
 if ! sed -n '/^acquire_profile_lock()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | awk '
   $0 == "  while true; do" && state == 0 { state = 1; next }
-  $0 == "    if ! acquired_state=\"$(go_hostutil launcher acquire-profile-lock \"${lock_dir}\" \"$$\")\"; then" && state == 1 { state = 2; next }
+  $0 == "    if ! acquired_state=\"$(go_hostutil helper acquire-profile-lock \"${lock_dir}\" \"$$\")\"; then" && state == 1 { state = 2; next }
   $0 == "      echo \"Failed to create managed runtime lock for profile ${profile}.\" >&2" && state == 2 { state = 3; next }
   $0 == "      return 1" && state == 3 { state = 4; next }
   $0 == "    fi" && state == 4 { state = 5; next }

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -265,7 +265,7 @@ session_lookup_root_args() {
   # The two roots are forwarded on argv (rather than via env) because
   # go_hostutil routes through run_clean_host_command, whose env -i
   # would otherwise strip them.
-  go_hostutil launcher lookup-state-roots \
+  go_hostutil helper lookup-state-roots \
     "${WORKCELL_STATE_ROOT:-}" \
     "${COLIMA_STATE_ROOT:-}"
 }
@@ -453,7 +453,7 @@ slugify() {
 }
 
 generate_session_suffix() {
-  go_hostutil launcher session-suffix
+  go_hostutil helper session-suffix
 }
 
 lower_ascii() {
@@ -596,7 +596,7 @@ docker_desktop_context_name() {
 profile_dir() {
   local profile="$1"
 
-  go_hostutil launcher profile-path dir "${COLIMA_STATE_ROOT}" "${profile}"
+  go_hostutil helper profile-path dir "${COLIMA_STATE_ROOT}" "${profile}"
 }
 
 target_kind_for_profile_state() {
@@ -645,20 +645,20 @@ profile_target_state_dir() {
 
   target_kind="$(target_kind_for_profile_state "${profile}")"
   target_provider="$(target_provider_for_profile_state "${profile}")"
-  go_hostutil launcher profile-path target-state-dir \
+  go_hostutil helper profile-path target-state-dir \
     "${WORKCELL_TARGET_STATE_ROOT}" "${target_kind}" "${target_provider}" "${profile}"
 }
 
 profile_lima_dir() {
   local profile="$1"
 
-  go_hostutil launcher profile-path lima-dir "${COLIMA_STATE_ROOT}" "${profile}"
+  go_hostutil helper profile-path lima-dir "${COLIMA_STATE_ROOT}" "${profile}"
 }
 
 profile_disk_dir() {
   local profile="$1"
 
-  go_hostutil launcher profile-path disk-dir "${COLIMA_STATE_ROOT}" "${profile}"
+  go_hostutil helper profile-path disk-dir "${COLIMA_STATE_ROOT}" "${profile}"
 }
 
 remove_profile_state_dirs() {
@@ -700,7 +700,7 @@ profile_state_dirs_exist() {
 profile_colima_config_path() {
   local profile="$1"
 
-  go_hostutil launcher profile-path colima-config "${COLIMA_STATE_ROOT}" "${profile}"
+  go_hostutil helper profile-path colima-config "${COLIMA_STATE_ROOT}" "${profile}"
 }
 
 run_host_colima() {
@@ -755,7 +755,7 @@ run_host_colima_with_timeout() {
   if [[ -z "${HOST_COLIMA_BIN:-}" ]]; then
     HOST_COLIMA_BIN="$(resolve_host_tool colima /opt/homebrew/bin/colima /usr/local/bin/colima)"
   fi
-  go_hostutil launcher run-host-colima-with-timeout "${timeout_seconds}" \
+  go_hostutil helper run-host-colima-with-timeout "${timeout_seconds}" \
     --colima-bin="${HOST_COLIMA_BIN}" \
     --real-home="${REAL_HOME:-}" \
     --colima-home="${COLIMA_STATE_ROOT:-}" \
@@ -780,7 +780,7 @@ colima_profile_status() {
   # trailer to preserve the contract verify-invariants depends on.
   local stderr_capture status_output rc trailer
   stderr_capture="$(mktemp)"
-  status_output="$(printf '%s' "${list_output}" | go_hostutil launcher colima-status "${profile}" 2>"${stderr_capture}")"
+  status_output="$(printf '%s' "${list_output}" | go_hostutil helper colima-status "${profile}" 2>"${stderr_capture}")"
   rc=$?
   if ((rc != 0)); then
     trailer="$(tail -n1 "${stderr_capture}" 2>/dev/null || true)"
@@ -956,7 +956,7 @@ prepare_current_target_docker_client() {
   # check fails, exactly as the original case-block did.
   local plan_stderr plan_output rc trailer
   plan_stderr="$(mktemp)"
-  plan_output="$(go_hostutil launcher prepare-current-docker-client-plan \
+  plan_output="$(go_hostutil helper prepare-current-docker-client-plan \
     --backend="${TARGET_BACKEND:-}" \
     --context-name="${desktop_context}" \
     "--context-exists=${context_exists_flag}" \
@@ -1471,14 +1471,14 @@ profile_audit_log_path() {
 
   target_kind="$(target_kind_for_profile_state "${profile}")"
   target_provider="$(target_provider_for_profile_state "${profile}")"
-  go_hostutil launcher profile-path audit-log \
+  go_hostutil helper profile-path audit-log \
     "${WORKCELL_TARGET_STATE_ROOT}" "${target_kind}" "${target_provider}" "${profile}"
 }
 
 legacy_profile_audit_log_path() {
   local profile="$1"
 
-  go_hostutil launcher profile-path legacy-audit-log "${COLIMA_STATE_ROOT}" "${profile}"
+  go_hostutil helper profile-path legacy-audit-log "${COLIMA_STATE_ROOT}" "${profile}"
 }
 
 profile_sessions_dir_path() {
@@ -1488,14 +1488,14 @@ profile_sessions_dir_path() {
 
   target_kind="$(target_kind_for_profile_state "${profile}")"
   target_provider="$(target_provider_for_profile_state "${profile}")"
-  go_hostutil launcher profile-path sessions-dir \
+  go_hostutil helper profile-path sessions-dir \
     "${WORKCELL_TARGET_STATE_ROOT}" "${target_kind}" "${target_provider}" "${profile}"
 }
 
 legacy_profile_sessions_dir_path() {
   local profile="$1"
 
-  go_hostutil launcher profile-path legacy-sessions-dir "${COLIMA_STATE_ROOT}" "${profile}"
+  go_hostutil helper profile-path legacy-sessions-dir "${COLIMA_STATE_ROOT}" "${profile}"
 }
 
 generate_session_id() {
@@ -1509,7 +1509,7 @@ profile_lock_dir_path() {
 
   target_kind="$(target_kind_for_profile_state "${profile}")"
   target_provider="$(target_provider_for_profile_state "${profile}")"
-  go_hostutil launcher profile-path lock-dir \
+  go_hostutil helper profile-path lock-dir \
     "${WORKCELL_STATE_ROOT}" "${target_kind}" "${target_provider}" "${profile}"
 }
 
@@ -1521,7 +1521,7 @@ profile_latest_log_pointer_path() {
 
   target_kind="$(target_kind_for_profile_state "${profile}")"
   target_provider="$(target_provider_for_profile_state "${profile}")"
-  go_hostutil launcher profile-path latest-log-pointer \
+  go_hostutil helper profile-path latest-log-pointer \
     "${WORKCELL_TARGET_STATE_ROOT}" "${target_kind}" "${target_provider}" "${profile}" "${kind}"
 }
 
@@ -1529,7 +1529,7 @@ legacy_profile_latest_log_pointer_path() {
   local profile="$1"
   local kind="$2"
 
-  go_hostutil launcher profile-path legacy-latest-log-pointer \
+  go_hostutil helper profile-path legacy-latest-log-pointer \
     "${COLIMA_STATE_ROOT}" "${profile}" "${kind}"
 }
 
@@ -1681,7 +1681,7 @@ run_profile_docker_command() {
   # diagnostic to its stderr and exits 1, which we surface here.
   local route_stderr route_output rc trailer
   route_stderr="$(mktemp)"
-  route_output="$(go_hostutil launcher route-profile-docker-command \
+  route_output="$(go_hostutil helper route-profile-docker-command \
     "--provider=${provider}" \
     "--socket-path=${socket_path}" \
     "--context-name=${context_name}" 2>"${route_stderr}")"
@@ -1766,7 +1766,7 @@ session_runtime_metadata() {
   while IFS= read -r root; do
     lookup_roots+=("${root}")
   done < <(session_lookup_root_args)
-  go_hostutil launcher session-runtime-metadata "${lookup_roots[@]}" "${session_id}"
+  go_hostutil helper session-runtime-metadata "${lookup_roots[@]}" "${session_id}"
 }
 
 load_session_runtime_metadata() {
@@ -2017,7 +2017,7 @@ current_workspace_transport() {
 refresh_support_matrix_state() {
   local metadata=""
 
-  metadata="$(go_hostutil launcher support-matrix-eval \
+  metadata="$(go_hostutil helper support-matrix-eval \
     "${WORKCELL_HOST_SUPPORT_MATRIX_PATH}" \
     "$(detected_host_os)" \
     "$(detected_host_arch)" \
@@ -2495,16 +2495,16 @@ cleanup_stale_latest_log_pointers() {
   local state_root="$1"
   local legacy_root="${2:-}"
 
-  go_hostutil launcher cleanup-stale-log-pointers "${state_root}"
+  go_hostutil helper cleanup-stale-log-pointers "${state_root}"
   if [[ -n "${legacy_root}" ]]; then
-    go_hostutil launcher cleanup-stale-log-pointers "${legacy_root}"
+    go_hostutil helper cleanup-stale-log-pointers "${legacy_root}"
   fi
 }
 
 profile_lock_is_stale() {
   local lock_dir="$1"
 
-  go_hostutil launcher profile-lock-is-stale "${lock_dir}"
+  go_hostutil helper profile-lock-is-stale "${lock_dir}"
 }
 
 acquire_profile_lock() {
@@ -2520,7 +2520,7 @@ acquire_profile_lock() {
   mkdir -p "${lock_parent}"
 
   while true; do
-    if ! acquired_state="$(go_hostutil launcher acquire-profile-lock "${lock_dir}" "$$")"; then
+    if ! acquired_state="$(go_hostutil helper acquire-profile-lock "${lock_dir}" "$$")"; then
       echo "Failed to create managed runtime lock for profile ${profile}." >&2
       return 1
     fi
@@ -2548,9 +2548,9 @@ cleanup_stale_session_audit_dirs() {
   local state_root="$1"
   local legacy_root="${2:-}"
 
-  go_hostutil launcher cleanup-stale-session-audit-dirs "${state_root}"
+  go_hostutil helper cleanup-stale-session-audit-dirs "${state_root}"
   if [[ -n "${legacy_root}" ]]; then
-    go_hostutil launcher cleanup-stale-session-audit-dirs "${legacy_root}"
+    go_hostutil helper cleanup-stale-session-audit-dirs "${legacy_root}"
   fi
 }
 
@@ -2572,7 +2572,7 @@ audit_record_digest() {
   local timestamp="$2"
   shift 2
 
-  go_hostutil launcher audit-digest "${prev_digest}" "${timestamp}" "$@"
+  go_hostutil helper audit-digest "${prev_digest}" "${timestamp}" "$@"
 }
 
 stash_profile_audit_log() {
@@ -2942,7 +2942,7 @@ write_session_record() {
   local path="$1"
   shift
 
-  go_hostutil launcher session-record-write "${path}" "$@"
+  go_hostutil helper session-record-write "${path}" "$@"
 }
 
 write_session_record_initial() {
@@ -3298,11 +3298,11 @@ resolve_host_path() {
 }
 
 resolve_host_output_candidate() {
-  go_hostutil launcher resolve-host-output-candidate "$1"
+  go_hostutil helper resolve-host-output-candidate "$1"
 }
 
 resolve_host_output_directory_candidate() {
-  go_hostutil launcher resolve-host-output-directory-candidate "$1"
+  go_hostutil helper resolve-host-output-directory-candidate "$1"
 }
 
 resolve_existing_directory_or_die() {
@@ -3324,7 +3324,7 @@ resolve_existing_directory_or_die() {
 }
 
 publish_pr_usage() {
-  go_hostutil launcher publish-pr-usage
+  go_hostutil publish-pr-usage
 }
 
 resolve_existing_file_or_die() {
@@ -3542,7 +3542,7 @@ publish_pr_main() {
   stderr_file="$(mktemp "${TMPDIR:-/tmp}/workcell-publish-pr-stderr.XXXXXX")"
   trap 'rm -f "${stderr_file}"' RETURN
   local rc=0
-  go_hostutil launcher publish-pr-cli \
+  go_hostutil publish-pr-cli \
     "--bash-root-dir=${ROOT_DIR}" \
     "--bash-workspace-root=${WORKSPACE:-${PWD}}" \
     "--bash-real-home=${REAL_HOME}" \
@@ -3581,7 +3581,7 @@ publish_pr_main() {
 }
 
 session_usage() {
-  go_hostutil launcher session-usage
+  go_hostutil session-usage
 }
 
 session_git_metadata_lines() {
@@ -4278,7 +4278,7 @@ session_logs_main() {
   while IFS= read -r root; do
     lookup_roots+=("${root}")
   done < <(session_lookup_root_args)
-  go_hostutil launcher session-logs-cli "${lookup_roots[@]}" "$@"
+  go_hostutil session-logs-cli "${lookup_roots[@]}" "$@"
   exit $?
 }
 
@@ -4287,7 +4287,7 @@ session_timeline_main() {
   while IFS= read -r root; do
     lookup_roots+=("${root}")
   done < <(session_lookup_root_args)
-  go_hostutil launcher session-timeline-cli "${lookup_roots[@]}" "$@"
+  go_hostutil session-timeline-cli "${lookup_roots[@]}" "$@"
   exit $?
 }
 
@@ -4360,7 +4360,7 @@ session_main() {
 
   shift || true
   set +e
-  plan="$(go_hostutil launcher session-dispatch-cli "${subcommand}")"
+  plan="$(go_hostutil session-dispatch-cli "${subcommand}")"
   dispatch_cli_status="$?"
   set -e
   if [[ "${dispatch_cli_status}" -ne 0 ]]; then
@@ -4449,7 +4449,7 @@ session_main() {
         validate_colima_profile_name "${profile}"
         args+=("--profile=${profile}")
       fi
-      output="$(go_hostutil launcher session-list "${args[@]}")"
+      output="$(go_hostutil helper session-list "${args[@]}")"
       if [[ -z "${output}" ]]; then
         echo "No recorded sessions."
         exit 0
@@ -4498,7 +4498,7 @@ session_main() {
       if [[ "${emit_text}" -eq 1 ]]; then
         args+=(--text)
       fi
-      go_hostutil launcher session-show "${args[@]}"
+      go_hostutil helper session-show "${args[@]}"
       exit 0
       ;;
     delete)
@@ -4539,7 +4539,7 @@ session_main() {
       while IFS= read -r root; do
         lookup_roots+=("${root}")
       done < <(session_lookup_root_args)
-      metadata="$(go_hostutil launcher session-diff-metadata "${lookup_roots[@]}" "${session_id}")"
+      metadata="$(go_hostutil helper session-diff-metadata "${lookup_roots[@]}" "${session_id}")"
       workspace="$(shellproto_field "${metadata}" workspace)"
       git_branch="$(shellproto_field "${metadata}" git_branch)"
       git_head="$(shellproto_field "${metadata}" git_head)"
@@ -4616,7 +4616,7 @@ session_main() {
       while IFS= read -r root; do
         lookup_roots+=("${root}")
       done < <(session_lookup_root_args)
-      output="$(go_hostutil launcher session-export "${lookup_roots[@]}" "${session_id}")"
+      output="$(go_hostutil helper session-export "${lookup_roots[@]}" "${session_id}")"
       if [[ -n "${output_path}" ]]; then
         output_path="$(resolve_host_output_candidate "${output_path}")"
         mkdir -p "$(dirname "${output_path}")"
@@ -4653,7 +4653,7 @@ auth_main() {
   stderr_file="$(mktemp "${TMPDIR:-/tmp}/workcell-auth-stderr.XXXXXX")"
   trap 'rm -f "${stderr_file}"' RETURN
   local rc=0
-  go_hostutil launcher auth-cli "--base=$(pwd -P)" "$@" 2>"${stderr_file}" || rc=$?
+  go_hostutil auth-cli "--base=$(pwd -P)" "$@" 2>"${stderr_file}" || rc=$?
   local stderr_capture=""
   stderr_capture="$(cat "${stderr_file}")"
   rm -f "${stderr_file}"
@@ -4671,7 +4671,7 @@ auth_main() {
 }
 
 policy_main() {
-  go_hostutil launcher policy-cli "$@"
+  go_hostutil policy-cli "$@"
   exit $?
 }
 
@@ -4760,7 +4760,7 @@ default_injection_bundle_parent() {
 cleanup_stale_injection_bundles() {
   local bundle_parent="$1"
 
-  go_hostutil launcher cleanup-stale-injection-bundles "${bundle_parent}"
+  go_hostutil helper cleanup-stale-injection-bundles "${bundle_parent}"
 }
 
 cleanup_workcell_temp_root() {
@@ -4834,7 +4834,7 @@ cleanup_workcell_cache_roots() {
 prepare_injection_bundle() {
   # PR 23.4 shim: the full pipeline (resolver, renderer, direct-mount
   # extraction + staging, metadata fan-out) now runs in-process inside the
-  # workcell-hostutil launcher subcommand.  Bash imports the resulting
+  # workcell-hostutil helper subcommand.  Bash imports the resulting
   # variables via a single "while read" loop.
   local agent="$1"
   local mode="$2"
@@ -4870,7 +4870,7 @@ prepare_injection_bundle() {
   stdout_capture="$(mktemp)"
   stderr_capture="$(mktemp)"
   rc=0
-  go_hostutil launcher injection-prepare-bundle \
+  go_hostutil helper injection-prepare-bundle \
     "--agent=${agent}" \
     "--mode=${mode}" \
     "--policy=${INJECTION_POLICY:-}" \
@@ -5732,7 +5732,7 @@ prepare_cache_mounts() {
   esac
 
   workspace_cache_key="$(
-    go_hostutil launcher workspace-cache-key "${workspace}"
+    go_hostutil helper workspace-cache-key "${workspace}"
   )"
   cache_root="$(resolve_host_path "${XDG_STATE_HOME:-${REAL_HOME}/.local/state}/workcell/cache/${agent}/${workspace_cache_key}")"
   if [[ "${DRY_RUN}" -eq 0 ]]; then
@@ -6046,7 +6046,7 @@ colima_start_hit_recoverable_docker_boot_race() {
 }
 
 extract_codex_version_from_dockerfile() {
-  go_hostutil launcher extract-codex-version "${ROOT_DIR}/runtime/container/Dockerfile"
+  go_hostutil helper extract-codex-version "${ROOT_DIR}/runtime/container/Dockerfile"
 }
 
 runtime_build_codex_arch() {
@@ -6241,7 +6241,7 @@ derive_profile_name() {
   slug="$(slugify "$(basename "${workspace}")" | cut -c1-10)"
   [[ -n "${slug}" ]] || slug="workspace"
   hash="$(
-    go_hostutil launcher workspace-cache-key "${workspace}" | cut -c1-8
+    go_hostutil helper workspace-cache-key "${workspace}" | cut -c1-8
   )"
   # Keep the derived Colima profile name short enough to avoid guest SSH
   # readiness hangs observed with longer managed profile names on macOS vz.
@@ -6318,7 +6318,7 @@ validate_colima_profile() {
   local status=""
 
   status="$(run_host_colima status --profile "${profile}" 2>&1)"
-  if ! printf '%s' "${status}" | go_hostutil launcher validate-colima-status "${profile}"; then
+  if ! printf '%s' "${status}" | go_hostutil helper validate-colima-status "${profile}"; then
     return 1
   fi
 
@@ -6387,7 +6387,7 @@ validate_runtime_security_posture() {
     exit 2
   }
 
-  go_hostutil launcher validate-security-options "${security_options_json}"
+  go_hostutil helper validate-security-options "${security_options_json}"
 }
 
 is_trusted_host_tool_path() {
@@ -6433,7 +6433,7 @@ is_trusted_host_tool_path() {
 
 canonicalize_host_tool_path() {
   local candidate="$1"
-  go_hostutil launcher canonicalize-tool-path "${candidate}"
+  go_hostutil helper canonicalize-tool-path "${candidate}"
 }
 
 resolve_host_tool() {
@@ -6599,7 +6599,7 @@ credential_extra_endpoints() {
 }
 
 dedupe_endpoint_list() {
-  go_hostutil launcher dedupe-endpoints "$1"
+  go_hostutil helper dedupe-endpoints "$1"
 }
 
 build_runtime_host_aliases() {
@@ -6617,7 +6617,7 @@ build_runtime_host_aliases() {
     else
       RUNTIME_NETWORK_ARGS+=(--add-host "${host}:${ip}")
     fi
-  done < <(go_hostutil launcher resolve-endpoints "${endpoint_list}")
+  done < <(go_hostutil helper resolve-endpoints "${endpoint_list}")
 
 }
 

--- a/verify/invariants/harnesses/process-colima/workcell-colima-timeout.sh
+++ b/verify/invariants/harnesses/process-colima/workcell-colima-timeout.sh
@@ -1,6 +1,6 @@
 # Now that run_host_colima_with_timeout delegates the actual timeout
-# enforcement to the Go launcher subcommand
-# (workcell-hostutil launcher run-host-colima-with-timeout), this harness
+# enforcement to the Go helper subcommand
+# (workcell-hostutil helper run-host-colima-with-timeout), this harness
 # verifies the bash shim correctly forwards args and env-derived flags to
 # go_hostutil. The end-to-end timeout behaviour is covered by
 # TestRunHostColimaWithTimeoutKillsRunawayChild /
@@ -26,9 +26,9 @@ if [[ "${status}" -ne 124 ]]; then
 fi
 
 case "${captured_args}" in
-  *"launcher run-host-colima-with-timeout 1 "*) ;;
+  *"helper run-host-colima-with-timeout 1 "*) ;;
   *)
-    echo "Expected captured args to include 'launcher run-host-colima-with-timeout 1': ${captured_args}" >&2
+    echo "Expected captured args to include 'helper run-host-colima-with-timeout 1': ${captured_args}" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

PR-FIX-11 from the `distributed-wandering-raccoon` plan (W2 architecture finding). The `launcherSubcommands()` dispatch table previously mixed two unrelated concerns:

1. **Stateless helpers** — path math, cache keys, validators, etc.
2. **Top-level CLI entry points** — every `*-cli` / `*-usage` row that `scripts/workcell` shells out to as a user-facing surface.

This PR splits them apart so the dispatch table only retains stateless helpers, and promotes the entry points to top-level `workcell-hostutil` subcommands.

## Promoted entries (15)

Each is now reachable as `workcell-hostutil <name>` rather than `workcell-hostutil launcher <name>`:

| Auth/Policy | Publish-PR | Session |
|---|---|---|
| `auth-cli` / `auth-usage` | `publish-pr-cli` / `publish-pr-usage` | `session-usage` |
| `policy-cli` / `policy-usage` | | `session-attach-cli` |
| | | `session-delete-cli` |
| | | `session-dispatch-cli` |
| | | `session-logs-cli` |
| | | `session-monitor-cli` |
| | | `session-send-cli` |
| | | `session-stop-cli` |
| | | `session-timeline-cli` |

## Helper table rename

The 38 remaining stateless helpers stay in the dispatch table, which was renamed `launcherSubcommands` → `helperSubcommands`. The top-level `launcher` case was renamed to `helper`. `launcher` is kept as a **deprecated alias for one PR cycle** so external mirrors do not break mid-flight.

## Bash migration

All in-tree bash callers were migrated atomically:

- `scripts/workcell` — 44 invocation sites updated (`*-cli`/`*-usage` drop the `launcher` token; stateless helpers swap `launcher` → `helper`)
- `scripts/lib/sessionctl-shim.sh` — the centralized session shim drops the `launcher` token since every session `*-cli` it dispatches is now top-level
- `scripts/verify-invariants.sh` — the `go_verify_hostutil` invocations switched to `helper`, plus the `function_block_contains_fixed` literal and the embedded `acquire-profile-lock` awk match both updated
- `verify/invariants/harnesses/process-colima/workcell-colima-timeout.sh` — captured-argv check now expects `helper run-host-colima-with-timeout`

`main_test.go` cases were switched to `helper` so the new naming is exercised end-to-end. The control-plane manifest was regenerated (sha256 `aa85e3ea` → `66866179`) to capture the new `scripts/workcell` content.

## No behavioural change

Every promoted top-level case delegates to the same handler the dispatch table used to call; no logic change.

## Shape

- files: 9 / 25
- lines: 314 / 1200
- areas: 5 / 8

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages green)
- [x] `gofmt -l .` returns 0
- [x] `go vet ./...` clean
- [x] `bash -n` on every changed shell script
- [x] `bash tests/scenarios/shared/test-session-commands.sh` — Section B gate passes
- [x] `bash scripts/check-pr-shape.sh --base-ref origin/main` passes
- [x] Manifest regenerated with `scripts/generate-control-plane-manifest.sh`
- [x] `git grep 'go_hostutil launcher'` returns 0 hits across the tree
- [ ] CI: pre-merge / verify-invariants / control-plane harness lanes