### PR TITLE
Add Go fuzz tests for parser/security boundaries (closes #10)

### DIFF
--- a/internal/injection/fuzz_test.go
+++ b/internal/injection/fuzz_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injection
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode"
+)
+
+// FuzzIsSafeRelativeSymlinkTarget pins the security oracle that gates
+// which symlink targets the injection-staging walker allows. The
+// invariant: if isSafeRelativeSymlinkTarget(t) returns true, then t is
+// a relative path with no `..` segments. A future regression that
+// silently accepted an absolute target or a `..`-laden target would
+// re-open the Sec-r2-1 escape that the FIX-10 component-walk closed.
+//
+// We don't seed `..`-bearing targets through `filepath.Clean` because
+// Clean rewrites them; we check the raw segment-by-segment form the
+// helper itself inspects.
+func FuzzIsSafeRelativeSymlinkTarget(f *testing.F) {
+	seeds := []string{
+		"",
+		"private/var",
+		"private/etc",
+		"private/tmp",
+		"a",
+		"a/b/c",
+		"/etc",
+		"/etc/passwd",
+		"..",
+		"../etc",
+		"../../etc/passwd",
+		"a/../b",
+		"a/..",
+		"/",
+		"./relative",
+		"a//b",
+		"a/./b",
+		"\x00",
+		"target with spaces",
+		strings.Repeat("a/", 64) + "leaf",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, target string) {
+		if !isSafeRelativeSymlinkTarget(target) {
+			return
+		}
+		if filepath.IsAbs(target) {
+			t.Fatalf("isSafeRelativeSymlinkTarget accepted absolute target %q", target)
+		}
+		for _, seg := range strings.Split(target, "/") {
+			if seg == ".." {
+				t.Fatalf("isSafeRelativeSymlinkTarget accepted target with .. segment %q", target)
+			}
+		}
+		if target == "" {
+			t.Fatalf("isSafeRelativeSymlinkTarget accepted empty target")
+		}
+	})
+}
+
+// FuzzParseSSHDirective exercises the SSH config line parser that gates
+// the risky-directive denylist in validateSSHConfigSafety. The
+// structural invariants:
+//   - when ok=true, directive is non-empty
+//   - when ok=true, directive is fully lowercase (so the riskySSHDirectives
+//     map lookup is deterministic)
+//   - when ok=true, directive contains no whitespace runes
+//   - lines whose first non-space byte is '#' return ok=false
+//   - whitespace-only lines return ok=false
+//
+// A regression that returned a non-lowercase directive would silently
+// bypass the unsafe-directive denylist (e.g. `ForwardAgent yes` lookup
+// against a lowercase-key map). A regression that returned ok=true on a
+// commented line would have the same effect.
+func FuzzParseSSHDirective(f *testing.F) {
+	seeds := []string{
+		"",
+		"   ",
+		"\t",
+		"# comment",
+		"  # leading space then comment",
+		"Host *",
+		"host *",
+		"HOST *",
+		"ForwardAgent yes",
+		"forwardagent yes",
+		"ProxyCommand nc -X connect %h %p",
+		"Match exec \"true\"",
+		"Match user alice exec /bin/true",
+		"Include ~/.ssh/extra",
+		"IdentityFile ~/.ssh/id_ed25519",
+		"PermitLocalCommand yes",
+		"SetEnv FOO=bar",
+		"\x00",
+		"key\tvalue",
+		"key\tvalue\twith\ttabs",
+		"\xff\xfe",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, line string) {
+		directive, _, ok := parseSSHDirective(line)
+		stripped := strings.TrimSpace(line)
+		if stripped == "" || strings.HasPrefix(stripped, "#") {
+			if ok {
+				t.Fatalf("parseSSHDirective accepted blank/comment line as directive: %q", line)
+			}
+			return
+		}
+		if !ok {
+			return
+		}
+		if directive == "" {
+			t.Fatalf("parseSSHDirective returned ok=true with empty directive for %q", line)
+		}
+		if directive != strings.ToLower(directive) {
+			t.Fatalf("parseSSHDirective returned non-lowercase directive %q for %q", directive, line)
+		}
+		for _, r := range directive {
+			if unicode.IsSpace(r) {
+				t.Fatalf("parseSSHDirective returned directive containing whitespace: %q for %q", directive, line)
+			}
+		}
+	})
+}

--- a/internal/tomlsubset/fuzz_test.go
+++ b/internal/tomlsubset/fuzz_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package tomlsubset
+
+import "testing"
+
+// FuzzParse exercises the hand-rolled TOML subset parser against arbitrary
+// input. The invariant is "no panic": for any byte slice, Parse must either
+// return a non-nil error or a non-nil map; it must not crash. The parser
+// gates auth- and injection-policy TOML files, which can carry
+// attacker-influenceable content via includes/overrides, so a panic in
+// Parse would surface as a process-level DoS at policy load time.
+//
+// Seed corpus mirrors the cases driving parse_test.go (Workcell-shaped
+// valid documents and every reject case the parser enumerates).
+func FuzzParse(f *testing.F) {
+	seeds := []string{
+		"",
+		"\n",
+		"# only a comment\n",
+		"name = \"workcell\"\ncount = 42\nenabled = true\n",
+		"[alpha]\nx = 1\ny = 2\n[beta]\nz = 3\n",
+		"tags = [\"alpha\", \"beta\"]\n",
+		"tags = [\n  \"a\",\n  \"b\",\n]\n",
+		"[credentials.api]\nkey = \"value\"\n",
+		"[t]\nk = \"line with # hash\"\n",
+		"[t]\nk = -17\n",
+		"[t]\nk = 0\n",
+		"[t]\nk = true\n",
+		"[t]\nk = false\n",
+		"[t]\nk = []\n",
+		// reject cases
+		"[[copies]]\nx = 1\n",
+		"a.b = 1\n",
+		"[t]\nk = 1\nk = 2\n",
+		"[t]\nk = 1\n[t]\nm = 2\n",
+		"[t]\nk = \"\"\"hello\"\"\"\n",
+		"[t]\nk = '''hello'''\n",
+		"[t]\nk = { a = 1 }\n",
+		"[t]\nk = 1979-05-27T07:32:00Z\n",
+		"[t]\nk = 07:32:00\n",
+		"[t]\nk = 1979-05-27\n",
+		"[t]\n = 1\n",
+		"[]\nk = 1\n",
+		"[t]\nbare_line\n",
+		"[t]\nk = [\n  \"a\",\n",
+		"[t]\nk = banana\n",
+		// edge shapes
+		"[",
+		"]",
+		"=",
+		"= =",
+		"\"",
+		"\\",
+		"[t]\nk = \"\\u\"\n",
+		"[t]\nk = \"\\x00\"\n",
+		"[t]\nk = \"\\n\"\n",
+		"\x00",
+		"k=\xff\xfe\xfd",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, content string) {
+		root, err := Parse(content, "fuzz.toml")
+		if err == nil && root == nil {
+			t.Fatalf("Parse returned nil map with nil error for %q", content)
+		}
+	})
+}

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -263,6 +263,19 @@ if [[ "${#go_files[@]}" -gt 0 ]]; then
 fi
 go vet ./...
 go test ./...
+
+# Short-budget fuzz pass on parser/security boundaries. Seed corpora
+# already run via `go test ./...`; this pass exercises the random
+# generator briefly so the per-PR signal catches obvious regressions
+# in tomlsubset.Parse, injection.isSafeRelativeSymlinkTarget, and
+# injection.parseSSHDirective.
+FUZZ_TIME="${WORKCELL_FUZZ_TIME:-15s}"
+if [[ "${FUZZ_TIME}" != "0" ]]; then
+  go test -run='^$' -fuzz=FuzzParse -fuzztime="${FUZZ_TIME}" ./internal/tomlsubset
+  go test -run='^$' -fuzz=FuzzIsSafeRelativeSymlinkTarget -fuzztime="${FUZZ_TIME}" ./internal/injection
+  go test -run='^$' -fuzz=FuzzParseSSHDirective -fuzztime="${FUZZ_TIME}" ./internal/injection
+fi
+
 "${ROOT_DIR}/scripts/check-dead-code.sh"
 "${ROOT_DIR}/scripts/check-public-repo-hygiene.sh"
 


### PR DESCRIPTION
## Summary

Adds three Go fuzz tests on attacker-influenceable parser/security boundaries:

1. **`FuzzParse`** (internal/tomlsubset) — hand-rolled TOML subset parser that gates auth- and injection-policy files. Invariant: no panic; non-nil err or non-nil map.
2. **`FuzzIsSafeRelativeSymlinkTarget`** (internal/injection) — security oracle introduced in FIX-10 (Sec-r2-1). Invariant: \`safe(t) ⇒ t != "" && !filepath.IsAbs(t) && no ".." segment\`.
3. **`FuzzParseSSHDirective`** (internal/injection) — gates the risky-directive denylist. Invariants: blank/comment lines return ok=false; accepted directives are non-empty, lowercase, and contain no whitespace.

Seed corpora run via every \`go test ./...\` invocation (so the targets exercise even without \`-fuzz\`). A 15s/target fuzz pass (configurable via \`WORKCELL_FUZZ_TIME\`) hooks into \`scripts/validate-repo.sh\` after the existing \`go test ./...\` line.

Closes code-scanning alert #10 (Scorecard Fuzzing — score moves off 0 once `func FuzzX(f *testing.F)` patterns are present).

## Test plan

- [x] \`go test ./internal/tomlsubset ./internal/injection\` — pass (seeds run as fixed inputs)
- [x] \`go test -run='^$' -fuzz=FuzzParse -fuzztime=15s ./internal/tomlsubset\` — pass, ~1.8M execs
- [x] \`go test -run='^$' -fuzz=FuzzIsSafeRelativeSymlinkTarget -fuzztime=10s ./internal/injection\` — pass, ~3.5M execs
- [x] \`go test -run='^$' -fuzz=FuzzParseSSHDirective -fuzztime=10s ./internal/injection\` — pass, ~1.9M execs
- [x] \`bash scripts/check-pr-shape.sh\` — pass
- [ ] Confirm Scorecard re-scan after merge moves alert #10 to fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)