### PR TITLE
Upstream refresh: daily cron + generated-at timestamp

### DIFF
--- a/.github/workflows/upstream-refresh.yml
+++ b/.github/workflows/upstream-refresh.yml
@@ -2,7 +2,9 @@ name: Upstream refresh
 
 on:
   schedule:
-    - cron: "15 13 * * 1-5"
+    # Daily at 13:15 UTC. Snapshot CVE timing does not respect business
+    # hours, so the workflow runs every day rather than Mon-Fri only.
+    - cron: "15 13 * * *"
   workflow_dispatch:
 
 permissions: {}
@@ -150,12 +152,15 @@ jobs:
             gh label create "${tracking_label}" --color "0E8A16" --description "Latest upstream refresh candidate tracking issue"
           fi
 
+          generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
           if [[ "${REFRESH_CHANGED}" != 'true' ]]; then
             {
               echo "## Latest result"
               echo
               echo "No upstream refresh changes were detected."
               echo
+              echo "- generated: \`${generated_at}\`"
               echo "- run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
               echo "- base ref: ${GITHUB_REF}"
               echo "- base sha: $(git rev-parse HEAD)"
@@ -167,6 +172,7 @@ jobs:
               echo "Skipped candidate publication because a refresh PR is already open:"
               echo "${REFRESH_EXISTING_PR_URL}"
               echo
+              echo "- generated: \`${generated_at}\`"
               echo "- run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
               echo "- base ref: ${GITHUB_REF}"
               echo "- base sha: $(git rev-parse HEAD)"
@@ -177,6 +183,7 @@ jobs:
             {
               echo "## Latest candidate"
               echo
+              echo "- generated: \`${generated_at}\`"
               echo "- run: $(jq -r '.run_url' "${metadata_path}")"
               echo "- artifact: \`$(jq -r '.artifact_name' "${metadata_path}")\`"
               echo "- base ref: \`$(jq -r '.base_ref' "${metadata_path}")\`"


### PR DESCRIPTION
## Summary

Two surgical hardening changes to the \`upstream-refresh\` workflow:

1. **Cron \`15 13 * * 1-5\` → \`15 13 * * *\`** (daily). Snapshot CVE timing doesn't respect business hours and the prior Mon-Fri schedule allowed weekends to add up to 72 h of drift between consecutive candidates.
2. **Add a \`generated: <ISO timestamp>\` line** to all three branches of the tracking-issue body (no-change / skip-existing-PR / new-candidate). The tracking issue previously displayed only the \`base sha\`, so an abandoned candidate looked indistinguishable from a freshly produced one. A visible timestamp lets the maintainer see at a glance whether the candidate is fresh or sitting stale.

## Deferred (intentional)

**Auto-PR creation** (replacing the issue-and-artifact handoff with a direct PR via \`gh\` CLI) is deferred. It requires:
- Elevating workflow permissions (\`contents: write\`, \`pull-requests: write\`)
- Resolving how bot-pushed feature branches interact with this repo's GPG-signed-commit invariant

Tracked as a follow-up. The fresh-timestamp signal in this PR achieves most of the same operator benefit (knowing the candidate is current) without the permission/signing complexity.

## Test plan

- [x] \`go test ./internal/metadatautil/\` — pass (includes upstream-refresh workflow validation)
- [x] \`actionlint .github/workflows/upstream-refresh.yml\` — clean
- [x] \`bash scripts/check-pr-shape.sh\` — pass
- [ ] CI green on validate-repo, GitHub Actions lint, GitHub Actions security analysis, zizmor

🤖 Generated with [Claude Code](https://claude.com/claude-code)