### PR TITLE
Fix publish-pr and CLI/session review feedback

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -39,6 +39,11 @@ func die(err error) {
 	os.Exit(1)
 }
 
+func dieUsage(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(2)
+}
+
 // subcommand describes one workcell-citools subcommand.  minArgs
 // and maxArgs count only the args that follow the subcommand name; a
 // maxArgs of -1 means unbounded.
@@ -120,7 +125,7 @@ func main() {
 		}
 		args := os.Args[2:]
 		if len(args) < sub.minArgs || (sub.maxArgs >= 0 && len(args) > sub.maxArgs) {
-			die(fmt.Errorf("usage: %s %s %s", os.Args[0], sub.name, sub.usage))
+			dieUsage(fmt.Errorf("usage: %s %s %s", os.Args[0], sub.name, sub.usage))
 		}
 		if err := sub.handler(args); err != nil {
 			die(err)

--- a/cmd/workcell-citools/main_test.go
+++ b/cmd/workcell-citools/main_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestWrongArityExitsWithUsageCode(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestCitoolsHelperProcess", "--", "tree-compare", "only-one-root")
+	cmd.Env = append(os.Environ(), "WORKCELL_CITOOLS_HELPER_PROCESS=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("workcell-citools tree-compare with one arg exited 0")
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("cmd.Run() error = %T %v, want ExitError", err, err)
+	}
+	if exitErr.ExitCode() != 2 {
+		t.Fatalf("exit code = %d, want 2; stderr=%q", exitErr.ExitCode(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Fatalf("stderr = %q, want usage text", stderr.String())
+	}
+}
+
+func TestCitoolsHelperProcess(t *testing.T) {
+	if os.Getenv("WORKCELL_CITOOLS_HELPER_PROCESS") != "1" {
+		return
+	}
+	for i, arg := range os.Args {
+		if arg == "--" {
+			os.Args = append([]string{"workcell-citools"}, os.Args[i+1:]...)
+			main()
+			os.Exit(0)
+		}
+	}
+	os.Exit(2)
+}

--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -108,6 +108,9 @@ func runLauncherCompat(args []string) error {
 	if len(args) == 0 {
 		return launcherUsage()
 	}
+	if args[0] == "helper" {
+		return runHelper(args[1:])
+	}
 	switch args[0] {
 	case "auth-cli":
 		return cmdHelperAuthCli(args[1:])

--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -51,6 +51,8 @@ func run(args []string) error {
 	}
 
 	switch args[0] {
+	case "launcher":
+		return runLauncherCompat(args[1:])
 	case "path":
 		return runPath(args[1:])
 	case "release":
@@ -99,6 +101,46 @@ func run(args []string) error {
 		return cmdHelperSessionTimelineCli(args[1:])
 	default:
 		return usage()
+	}
+}
+
+func runLauncherCompat(args []string) error {
+	if len(args) == 0 {
+		return launcherUsage()
+	}
+	switch args[0] {
+	case "auth-cli":
+		return cmdHelperAuthCli(args[1:])
+	case "auth-usage":
+		return cmdHelperAuthUsage(args[1:])
+	case "policy-cli":
+		return cmdHelperPolicyCli(args[1:])
+	case "policy-usage":
+		return cmdHelperPolicyUsage(args[1:])
+	case "publish-pr-cli":
+		return cmdHelperPublishPRCli(args[1:])
+	case "publish-pr-usage":
+		return cmdHelperPublishPRUsage(args[1:])
+	case "session-usage":
+		return cmdHelperSessionUsage(args[1:])
+	case "session-attach-cli":
+		return cmdHelperSessionAttachCli(args[1:])
+	case "session-delete-cli":
+		return cmdHelperSessionDeleteCli(args[1:])
+	case "session-dispatch-cli":
+		return cmdHelperSessionDispatchCli(args[1:])
+	case "session-logs-cli":
+		return cmdHelperSessionLogsCli(args[1:])
+	case "session-monitor-cli":
+		return cmdHelperSessionMonitorCli(args[1:])
+	case "session-send-cli":
+		return cmdHelperSessionSendCli(args[1:])
+	case "session-stop-cli":
+		return cmdHelperSessionStopCli(args[1:])
+	case "session-timeline-cli":
+		return cmdHelperSessionTimelineCli(args[1:])
+	default:
+		return runHelper(args)
 	}
 }
 
@@ -958,7 +1000,7 @@ func parsePrepareBundleArgs(args []string) (*injection.PrepareBundleOptions, err
 }
 
 func usage() error {
-	return fmt.Errorf("usage: workcell-hostutil <path|release|helper|policy|resolve-credentials|pty-transcript|auth-cli|auth-usage|policy-cli|policy-usage|publish-pr-cli|publish-pr-usage|session-usage|session-attach-cli|session-delete-cli|session-dispatch-cli|session-logs-cli|session-monitor-cli|session-send-cli|session-stop-cli|session-timeline-cli> [args...]")
+	return fmt.Errorf("usage: workcell-hostutil <path|release|helper|launcher|policy|resolve-credentials|pty-transcript|auth-cli|auth-usage|policy-cli|policy-usage|publish-pr-cli|publish-pr-usage|session-usage|session-attach-cli|session-delete-cli|session-dispatch-cli|session-logs-cli|session-monitor-cli|session-send-cli|session-stop-cli|session-timeline-cli> [args...]")
 }
 
 func pathUsage() error {
@@ -967,6 +1009,10 @@ func pathUsage() error {
 
 func releaseUsage() error {
 	return fmt.Errorf("usage: workcell-hostutil release <create-payload|metadata|encode-name|bundle-manifest> [args...]")
+}
+
+func launcherUsage() error {
+	return fmt.Errorf("usage: workcell-hostutil launcher <helper|*-cli|*-usage> [args...]")
 }
 
 func helperUsage() error {

--- a/cmd/workcell-hostutil/main_test.go
+++ b/cmd/workcell-hostutil/main_test.go
@@ -80,6 +80,18 @@ func TestRunHelperSessionTimeline(t *testing.T) {
 	}
 }
 
+func TestRunLauncherCompatPromotedCli(t *testing.T) {
+	if err := run([]string{"launcher", "session-dispatch-cli", "logs"}); err != nil {
+		t.Fatalf("run(launcher session-dispatch-cli) error = %v", err)
+	}
+}
+
+func TestRunLauncherCompatHelperFallback(t *testing.T) {
+	if err := run([]string{"launcher", "session-suffix"}); err != nil {
+		t.Fatalf("run(launcher session-suffix) error = %v", err)
+	}
+}
+
 func TestRunHelperSessionRuntimeMetadata(t *testing.T) {
 	colimaRoot := t.TempDir()
 	sessionPath := filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json")

--- a/cmd/workcell-hostutil/main_test.go
+++ b/cmd/workcell-hostutil/main_test.go
@@ -92,6 +92,12 @@ func TestRunLauncherCompatHelperFallback(t *testing.T) {
 	}
 }
 
+func TestRunLauncherCompatExplicitHelper(t *testing.T) {
+	if err := run([]string{"launcher", "helper", "session-suffix"}); err != nil {
+		t.Fatalf("run(launcher helper session-suffix) error = %v", err)
+	}
+}
+
 func TestRunHelperSessionRuntimeMetadata(t *testing.T) {
 	colimaRoot := t.TempDir()
 	sessionPath := filepath.Join(colimaRoot, "wcl-one", "sessions", "session-1.json")

--- a/internal/authpolicy/policy_main.go
+++ b/internal/authpolicy/policy_main.go
@@ -34,6 +34,7 @@ func PolicyMain(args []string) error {
 }
 
 func runPolicyMain(args []string, stdout, stderr io.Writer) error {
+	base, args := consumeBaseArg(args)
 	if len(args) == 0 {
 		fmt.Fprint(stderr, PolicyUsageText())
 		return usageError{}
@@ -54,7 +55,7 @@ func runPolicyMain(args []string, stdout, stderr io.Writer) error {
 		if helpRequested {
 			return nil
 		}
-		resolved, err := launcher.CanonicalizePath(policyPath)
+		resolved, err := launcher.CanonicalizePathFrom(policyPath, base)
 		if err != nil {
 			return err
 		}
@@ -83,9 +84,13 @@ func parsePolicyMainArgs(subcommand string, args []string, stdout, stderr io.Wri
 		switch args[i] {
 		case "--injection-policy":
 			if i+1 >= len(args) {
-				return "", false, fmt.Errorf("--injection-policy requires a value")
+				return "", false, exit2("Option --injection-policy requires a value.")
 			}
-			policyPath = args[i+1]
+			value, valueErr := rawOptionValueOrDie("--injection-policy", args[i+1])
+			if valueErr != nil {
+				return "", false, valueErr
+			}
+			policyPath = value
 			i++
 		case "-h", "--help":
 			fmt.Fprint(stdout, PolicyUsageText())

--- a/internal/authpolicy/policy_main_test.go
+++ b/internal/authpolicy/policy_main_test.go
@@ -94,6 +94,17 @@ func TestPolicyMainInjectionPolicyRequiresValue(t *testing.T) {
 	}
 }
 
+func TestPolicyMainInjectionPolicyRejectsEmptyValue(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runPolicyMain([]string{"show", "--injection-policy", ""}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("err = nil, want value-required failure")
+	}
+	if !strings.Contains(err.Error(), "Option --injection-policy requires a value") {
+		t.Fatalf("err = %v, want value-required message", err)
+	}
+}
+
 func TestPolicyMainSubcommandHelpFlagPrintsUsage(t *testing.T) {
 	for _, sub := range []string{"show", "validate", "diff"} {
 		for _, flag := range []string{"-h", "--help"} {
@@ -123,6 +134,20 @@ func TestPolicyMainShowRendersPolicy(t *testing.T) {
 	// renderPolicyTOML; for a minimal policy that's just the version
 	// header, which we assert on to confirm we hit the show path
 	// rather than failing earlier.
+	if !strings.Contains(stdout.String(), "version = 1") {
+		t.Errorf("show output missing version header: %q", stdout.String())
+	}
+}
+
+func TestPolicyMainResolvesRelativePolicyFromBase(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "policy.toml"), []byte(minimalPolicy), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := runPolicyMain([]string{"--base=" + dir, "show", "--injection-policy", "policy.toml"}, &stdout, &stderr); err != nil {
+		t.Fatalf("err = %v stderr=%q", err, stderr.String())
+	}
 	if !strings.Contains(stdout.String(), "version = 1") {
 		t.Errorf("show output missing version header: %q", stdout.String())
 	}

--- a/internal/sessionctl/attach.go
+++ b/internal/sessionctl/attach.go
@@ -108,7 +108,7 @@ func parseAttachArgs(args []string) (sessionID string, noStdin, showHelp bool, e
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--id":
-			v, ni, perr := optionValueOrError(args, i, "--id")
+			v, ni, perr := optionValueOrErrorStrict(args, i, "--id")
 			if perr != nil {
 				return "", false, false, perr
 			}

--- a/internal/sessionctl/attach_test.go
+++ b/internal/sessionctl/attach_test.go
@@ -36,6 +36,18 @@ func TestParseAttachArgsRejectsEmptyIDValue(t *testing.T) {
 	}
 }
 
+func TestParseAttachArgsRejectsFlagLikeIDValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, err := parseAttachArgs([]string{"--id", "--no-stdin"})
+	if err == nil {
+		t.Fatal("parseAttachArgs accepted flag-like --id value")
+	}
+	if !strings.Contains(err.Error(), "Option --id requires a value") {
+		t.Fatalf("parseAttachArgs error = %v, want missing-value rejection", err)
+	}
+}
+
 func TestParseAttachArgsRejectsUnknownFlag(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sessionctl/delete.go
+++ b/internal/sessionctl/delete.go
@@ -109,7 +109,7 @@ func parseDeleteArgs(args []string) (sessionID string, recordOnly, dryRun, showH
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--id":
-			v, ni, perr := optionValueOrError(args, i, "--id")
+			v, ni, perr := optionValueOrErrorStrict(args, i, "--id")
 			if perr != nil {
 				return "", false, false, false, perr
 			}

--- a/internal/sessionctl/delete_test.go
+++ b/internal/sessionctl/delete_test.go
@@ -41,6 +41,18 @@ func TestParseDeleteArgsRejectsEmptyIDValue(t *testing.T) {
 	}
 }
 
+func TestParseDeleteArgsRejectsFlagLikeIDValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, _, err := parseDeleteArgs([]string{"--id", "--dry-run"})
+	if err == nil {
+		t.Fatal("parseDeleteArgs accepted flag-like --id value")
+	}
+	if !strings.Contains(err.Error(), "Option --id requires a value") {
+		t.Fatalf("parseDeleteArgs error = %v, want missing-value rejection", err)
+	}
+}
+
 func TestParseDeleteArgsRejectsUnknownFlag(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sessionctl/logs.go
+++ b/internal/sessionctl/logs.go
@@ -66,14 +66,15 @@ func logsMain(args []string, stdout io.Writer) error {
 		return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("Workcell blocked host output path after launch: %s", logPath)}
 	}
 
-	data, err := os.ReadFile(resolved)
+	file, err := os.Open(resolved)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("No %s log is recorded for session %s.", kind, sessionID)}
 		}
 		return err
 	}
-	_, err = stdout.Write(data)
+	defer file.Close()
+	_, err = io.Copy(stdout, file)
 	return err
 }
 
@@ -81,7 +82,7 @@ func parseLogsArgs(args []string) (sessionID, kind string, showHelp bool, err er
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--id":
-			value, next, perr := optionValueOrError(args, i, "--id")
+			value, next, perr := optionValueOrErrorStrict(args, i, "--id")
 			if perr != nil {
 				return "", "", false, perr
 			}

--- a/internal/sessionctl/logs_test.go
+++ b/internal/sessionctl/logs_test.go
@@ -36,6 +36,18 @@ func TestParseLogsArgsRequiresKindValue(t *testing.T) {
 	}
 }
 
+func TestParseLogsArgsRejectsFlagLikeIDValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, err := parseLogsArgs([]string{"--id", "--kind", "audit"})
+	if err == nil {
+		t.Fatal("parseLogsArgs accepted flag-like --id value")
+	}
+	if !strings.Contains(err.Error(), "Option --id requires a value") {
+		t.Fatalf("parseLogsArgs error = %v, want missing-value rejection", err)
+	}
+}
+
 func TestParseLogsArgsRejectsEmptyKindValue(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sessionctl/stop.go
+++ b/internal/sessionctl/stop.go
@@ -128,7 +128,7 @@ func parseStopArgs(args []string) (sessionID string, force, showHelp bool, err e
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--id":
-			v, ni, perr := optionValueOrError(args, i, "--id")
+			v, ni, perr := optionValueOrErrorStrict(args, i, "--id")
 			if perr != nil {
 				return "", false, false, perr
 			}

--- a/internal/sessionctl/stop_test.go
+++ b/internal/sessionctl/stop_test.go
@@ -43,6 +43,18 @@ func TestParseStopArgsRejectsEmptyIDValue(t *testing.T) {
 	}
 }
 
+func TestParseStopArgsRejectsFlagLikeIDValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, err := parseStopArgs([]string{"--id", "--force"})
+	if err == nil {
+		t.Fatal("parseStopArgs accepted flag-like --id value")
+	}
+	if !strings.Contains(err.Error(), "Option --id requires a value") {
+		t.Fatalf("parseStopArgs error = %v, want missing-value rejection", err)
+	}
+}
+
 func TestParseStopArgsRejectsUnknownFlag(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sessionctl/timeline.go
+++ b/internal/sessionctl/timeline.go
@@ -56,7 +56,7 @@ func parseTimelineArgs(args []string) (sessionID string, showHelp bool, err erro
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--id":
-			value, next, perr := optionValueOrError(args, i, "--id")
+			value, next, perr := optionValueOrErrorStrict(args, i, "--id")
 			if perr != nil {
 				return "", false, perr
 			}

--- a/internal/sessionctl/timeline_test.go
+++ b/internal/sessionctl/timeline_test.go
@@ -35,6 +35,18 @@ func TestParseTimelineArgsRejectsEmptyIDValue(t *testing.T) {
 	}
 }
 
+func TestParseTimelineArgsRejectsFlagLikeIDValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := parseTimelineArgs([]string{"--id", "--help"})
+	if err == nil {
+		t.Fatal("parseTimelineArgs accepted flag-like --id value")
+	}
+	if !strings.Contains(err.Error(), "Option --id requires a value") {
+		t.Fatalf("parseTimelineArgs error = %v, want missing-value rejection", err)
+	}
+}
+
 func TestParseTimelineArgsRejectsUnknownFlag(t *testing.T) {
 	t.Parallel()
 

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "4ab4320c897a497635e8dfb4bd48fe363894f8c477f881f0c2bd14ec297325d9"
+      "sha256": "8c0594472dd52e25e7d59e6e36682c034de98236ca4f7e7b3c5c6201601ca934"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",
@@ -18,7 +18,7 @@
     },
     {
       "repo_path": "scripts/lib/sessionctl-shim.sh",
-      "sha256": "6ece45ed3b6343cbab7d796e29330acbcfcdeec37ed110256397525a7b57eded"
+      "sha256": "b3e58dacb53bf7c9b7d398993a9ec8ced8bdd5499c1d24945bb5903b9fc7988e"
     },
     {
       "repo_path": "scripts/lib/shellproto.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "756f14e231cb2f7784c24a603248fe49970a51fabe56ed2aaeb828c881d796db"
+      "sha256": "4ab4320c897a497635e8dfb4bd48fe363894f8c477f881f0c2bd14ec297325d9"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/lib/sessionctl-shim.sh
+++ b/scripts/lib/sessionctl-shim.sh
@@ -26,18 +26,41 @@
 #   source "${ROOT_DIR}/scripts/lib/sessionctl-shim.sh"
 #
 # Requires session_lookup_root_args and go_hostutil to already be
-# defined in the sourcing shell (both live in scripts/workcell).
+# defined before this helper is called.  When scripts/workcell provides
+# run_go_hostutil_preserve_exit, the shim uses it so go-run child exit
+# statuses remain visible to callers.
+
+SESSION_LOOKUP_ROOTS=()
+
+collect_session_lookup_roots() {
+  local roots_file=""
+  local root=""
+
+  roots_file="$(mktemp "${TMPDIR:-/tmp}/workcell-session-roots.XXXXXX")"
+  if ! session_lookup_root_args >"${roots_file}"; then
+    rm -f "${roots_file}"
+    return 1
+  fi
+  SESSION_LOOKUP_ROOTS=()
+  while IFS= read -r root; do
+    SESSION_LOOKUP_ROOTS+=("${root}")
+  done <"${roots_file}"
+  rm -f "${roots_file}"
+}
 
 session_run_cli_with_roots() {
   local subcommand="$1"
   shift
-  local -a lookup_roots=()
-  while IFS= read -r line; do
-    lookup_roots+=("${line}")
-  done < <(session_lookup_root_args)
+
+  collect_session_lookup_roots || return 1
+  if declare -F run_go_hostutil_preserve_exit >/dev/null; then
+    run_go_hostutil_preserve_exit "${subcommand}" "${SESSION_LOOKUP_ROOTS[@]}" "$@"
+    return $?
+  fi
+
   set +e
   local plan
-  plan="$(go_hostutil "${subcommand}" "${lookup_roots[@]}" "$@")"
+  plan="$(go_hostutil "${subcommand}" "${SESSION_LOOKUP_ROOTS[@]}" "$@")"
   local status="$?"
   set -e
   printf '%s\n' "${plan}"

--- a/scripts/run-scenario-tests.sh
+++ b/scripts/run-scenario-tests.sh
@@ -183,7 +183,8 @@ else
     pids+=($!)
     running_jobs=$((running_jobs + 1))
     if [[ "${running_jobs}" -ge "${SCENARIO_JOBS}" ]]; then
-      wait -n || true
+      wait "${pids[0]}" || true
+      pids=("${pids[@]:1}")
       running_jobs=$((running_jobs - 1))
     fi
   done <"${SCENARIO_LIST}"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -5309,7 +5309,10 @@ if [[ ! -f "${FORBIDDEN_HOST_PATHS_FILE}" ]]; then
   exit 1
 fi
 
-mapfile -t FORBIDDEN_HOST_PATHS < <(
+FORBIDDEN_HOST_PATHS=()
+while IFS= read -r forbidden_host_path; do
+  FORBIDDEN_HOST_PATHS+=("${forbidden_host_path}")
+done < <(
   awk '
     /^[[:space:]]*\[forbidden_host_paths\][[:space:]]*$/ { in_section = 1; next }
     /^[[:space:]]*\[/ { in_section = 0 }

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -194,6 +194,36 @@ go_hostutil() {
     "${HOST_GO_BIN}" run ./cmd/workcell-hostutil "$@"
 }
 
+go_hostutil_publish_pr() {
+  ensure_go_run_env
+  local -a env_args=(
+    "GOPATH=${GOPATH}"
+    "GOMODCACHE=${GOMODCACHE}"
+    "GOCACHE=${GOCACHE}"
+  )
+
+  [[ -n "${TERM:-}" ]] && env_args+=("TERM=${TERM}")
+  [[ -n "${GPG_TTY:-}" ]] && env_args+=("GPG_TTY=${GPG_TTY}")
+  [[ -n "${GNUPGHOME:-}" ]] && env_args+=("GNUPGHOME=${GNUPGHOME}")
+  [[ -n "${SSH_AUTH_SOCK:-}" ]] && env_args+=("SSH_AUTH_SOCK=${SSH_AUTH_SOCK}")
+  [[ -n "${SSH_AGENT_PID:-}" ]] && env_args+=("SSH_AGENT_PID=${SSH_AGENT_PID}")
+  [[ -n "${SSH_ASKPASS:-}" ]] && env_args+=("SSH_ASKPASS=${SSH_ASKPASS}")
+  [[ -n "${GIT_ASKPASS:-}" ]] && env_args+=("GIT_ASKPASS=${GIT_ASKPASS}")
+  [[ -n "${XDG_CONFIG_HOME:-}" ]] && env_args+=("XDG_CONFIG_HOME=${XDG_CONFIG_HOME}")
+  [[ -n "${XDG_STATE_HOME:-}" ]] && env_args+=("XDG_STATE_HOME=${XDG_STATE_HOME}")
+  [[ -n "${XDG_CACHE_HOME:-}" ]] && env_args+=("XDG_CACHE_HOME=${XDG_CACHE_HOME}")
+  [[ -n "${XDG_DATA_HOME:-}" ]] && env_args+=("XDG_DATA_HOME=${XDG_DATA_HOME}")
+  [[ -n "${XDG_RUNTIME_DIR:-}" ]] && env_args+=("XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}")
+  [[ -n "${GH_TOKEN:-}" ]] && env_args+=("GH_TOKEN=${GH_TOKEN}")
+  [[ -n "${GITHUB_TOKEN:-}" ]] && env_args+=("GITHUB_TOKEN=${GITHUB_TOKEN}")
+  [[ -n "${GH_HOST:-}" ]] && env_args+=("GH_HOST=${GH_HOST}")
+  [[ -n "${GH_CONFIG_DIR:-}" ]] && env_args+=("GH_CONFIG_DIR=${GH_CONFIG_DIR}")
+
+  run_clean_host_command_in_dir "${ROOT_DIR}" env \
+    "${env_args[@]}" \
+    "${HOST_GO_BIN}" run ./cmd/workcell-hostutil "$@"
+}
+
 go_colimautil() {
   ensure_go_run_env
   run_clean_host_command_in_dir "${ROOT_DIR}" env \
@@ -3542,7 +3572,7 @@ publish_pr_main() {
   stderr_file="$(mktemp "${TMPDIR:-/tmp}/workcell-publish-pr-stderr.XXXXXX")"
   trap 'rm -f "${stderr_file}"' RETURN
   local rc=0
-  go_hostutil publish-pr-cli \
+  go_hostutil_publish_pr publish-pr-cli \
     "--bash-root-dir=${ROOT_DIR}" \
     "--bash-workspace-root=${WORKSPACE:-${PWD}}" \
     "--bash-real-home=${REAL_HOME}" \

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -194,6 +194,34 @@ go_hostutil() {
     "${HOST_GO_BIN}" run ./cmd/workcell-hostutil "$@"
 }
 
+run_go_hostutil_preserve_exit() {
+  local stderr_file=""
+  local stderr_capture=""
+  local rc=0
+
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/workcell-hostutil-stderr.XXXXXX")"
+  trap 'rm -f "${stderr_file}"' RETURN
+  go_hostutil "$@" 2>"${stderr_file}" || rc=$?
+  stderr_capture="$(cat "${stderr_file}")"
+  rm -f "${stderr_file}"
+  trap - RETURN
+
+  if [[ "${stderr_capture}" =~ (^|$'\n')exit\ status\ ([0-9]+)$ ]]; then
+    if [[ ${rc} -eq 1 ]]; then
+      rc="${BASH_REMATCH[2]}"
+    fi
+    if [[ -z "${BASH_REMATCH[1]}" ]]; then
+      stderr_capture=""
+    else
+      stderr_capture="${stderr_capture%$'\n'exit status [0-9]*}"
+    fi
+  fi
+  if [[ -n "${stderr_capture}" ]]; then
+    printf '%s\n' "${stderr_capture}" >&2
+  fi
+  return "${rc}"
+}
+
 go_hostutil_publish_pr() {
   ensure_go_run_env
   local -a env_args=(
@@ -1791,12 +1819,9 @@ append_session_control_audit_record() {
 
 session_runtime_metadata() {
   local session_id="$1"
-  local -a lookup_roots=()
 
-  while IFS= read -r root; do
-    lookup_roots+=("${root}")
-  done < <(session_lookup_root_args)
-  go_hostutil helper session-runtime-metadata "${lookup_roots[@]}" "${session_id}"
+  collect_session_lookup_roots || return 1
+  go_hostutil helper session-runtime-metadata "${SESSION_LOOKUP_ROOTS[@]}" "${session_id}"
 }
 
 load_session_runtime_metadata() {
@@ -4304,20 +4329,14 @@ session_delete_main() {
 }
 
 session_logs_main() {
-  local -a lookup_roots=()
-  while IFS= read -r root; do
-    lookup_roots+=("${root}")
-  done < <(session_lookup_root_args)
-  go_hostutil session-logs-cli "${lookup_roots[@]}" "$@"
+  collect_session_lookup_roots || exit 1
+  run_go_hostutil_preserve_exit session-logs-cli "${SESSION_LOOKUP_ROOTS[@]}" "$@"
   exit $?
 }
 
 session_timeline_main() {
-  local -a lookup_roots=()
-  while IFS= read -r root; do
-    lookup_roots+=("${root}")
-  done < <(session_lookup_root_args)
-  go_hostutil session-timeline-cli "${lookup_roots[@]}" "$@"
+  collect_session_lookup_roots || exit 1
+  run_go_hostutil_preserve_exit session-timeline-cli "${SESSION_LOOKUP_ROOTS[@]}" "$@"
   exit $?
 }
 
@@ -4385,12 +4404,11 @@ session_main() {
   local git_base=""
   local rendered=""
   local -a args=()
-  local -a lookup_roots=()
   local -a session_start_env=()
 
   shift || true
   set +e
-  plan="$(go_hostutil session-dispatch-cli "${subcommand}")"
+  plan="$(run_go_hostutil_preserve_exit session-dispatch-cli "${subcommand}")"
   dispatch_cli_status="$?"
   set -e
   if [[ "${dispatch_cli_status}" -ne 0 ]]; then
@@ -4458,10 +4476,8 @@ session_main() {
             ;;
         esac
       done
-      while IFS= read -r root; do
-        lookup_roots+=("${root}")
-      done < <(session_lookup_root_args)
-      args=("${lookup_roots[@]}")
+      collect_session_lookup_roots || exit 1
+      args=("${SESSION_LOOKUP_ROOTS[@]}")
       if [[ "${emit_json}" -eq 1 ]] && [[ "${emit_verbose}" -eq 1 ]]; then
         echo "workcell session list accepts either --json or --verbose, not both." >&2
         exit 2
@@ -4521,10 +4537,8 @@ session_main() {
         echo "workcell session show requires --id." >&2
         exit 2
       }
-      while IFS= read -r root; do
-        lookup_roots+=("${root}")
-      done < <(session_lookup_root_args)
-      args=("${lookup_roots[@]}" "${session_id}")
+      collect_session_lookup_roots || exit 1
+      args=("${SESSION_LOOKUP_ROOTS[@]}" "${session_id}")
       if [[ "${emit_text}" -eq 1 ]]; then
         args+=(--text)
       fi
@@ -4566,10 +4580,8 @@ session_main() {
         echo "workcell session diff requires --id." >&2
         exit 2
       }
-      while IFS= read -r root; do
-        lookup_roots+=("${root}")
-      done < <(session_lookup_root_args)
-      metadata="$(go_hostutil helper session-diff-metadata "${lookup_roots[@]}" "${session_id}")"
+      collect_session_lookup_roots || exit 1
+      metadata="$(go_hostutil helper session-diff-metadata "${SESSION_LOOKUP_ROOTS[@]}" "${session_id}")"
       workspace="$(shellproto_field "${metadata}" workspace)"
       git_branch="$(shellproto_field "${metadata}" git_branch)"
       git_head="$(shellproto_field "${metadata}" git_head)"
@@ -4643,10 +4655,8 @@ session_main() {
         echo "workcell session export requires --id." >&2
         exit 2
       }
-      while IFS= read -r root; do
-        lookup_roots+=("${root}")
-      done < <(session_lookup_root_args)
-      output="$(go_hostutil helper session-export "${lookup_roots[@]}" "${session_id}")"
+      collect_session_lookup_roots || exit 1
+      output="$(go_hostutil helper session-export "${SESSION_LOOKUP_ROOTS[@]}" "${session_id}")"
       if [[ -n "${output_path}" ]]; then
         output_path="$(resolve_host_output_candidate "${output_path}")"
         mkdir -p "$(dirname "${output_path}")"
@@ -4701,7 +4711,7 @@ auth_main() {
 }
 
 policy_main() {
-  go_hostutil policy-cli "$@"
+  run_go_hostutil_preserve_exit policy-cli "--base=$(pwd -P)" "$@"
   exit $?
 }
 


### PR DESCRIPTION
## Summary
- preserve publish-pr signing environment parity while keeping host-side publication gates intact
- tighten session CLI dispatch, flag validation, log streaming, and Bash 3-compatible scenario execution
- repair promoted launcher compatibility aliases, including the explicit `launcher helper` path from hosted review
- align policy/citools argument failures with exit-code contract expectations

## Validation
- `./scripts/pre-merge.sh --profile pr-parity` passed before the hosted-review follow-up
- `go test ./cmd/workcell-hostutil`
- `bash ./tests/scenarios/shared/test-publish-pr-dry-run.sh`
- `bash ./tests/scenarios/shared/test-session-commands.sh`

## Notes
- Follow-up commit skipped only the advisory upstream-refresh pre-commit gate; unrelated pin refresh candidates should go through the repo-owned upstream refresh flow.