### PR TITLE
Add Copilot CLI Tier 1 parity roadmap

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ What you expected to happen.
 
 - OS: [e.g. macOS 15.4]
 - Workcell version: [e.g. v0.5.0 or commit SHA]
-- Provider: [Codex / Claude / Gemini]
+- Provider: [Codex / Claude / Gemini; use "Copilot CLI roadmap" only for planned-support docs issues]
 - Mode: [strict / build / breakglass]
 - Docker version: `docker --version`
 - Colima version (macOS only): `colima version`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Workcell runs coding agents inside a bounded local runtime on Apple Silicon
 macOS: a dedicated Colima VM plus a hardened container inside that VM. It ships
 Tier 1 adapters for Codex, Claude Code, and Gemini that seed each provider's
 native control plane without pretending provider config is the security
-boundary.
+boundary. GitHub Copilot CLI is the next committed Tier 1 provider-parity
+track, but current releases do not support `--agent copilot`.
 
 This project is for teams that want local agent velocity without turning the
 host home directory, keychain, provider state, or local sockets into the trust
@@ -49,6 +50,9 @@ boundary.
   certification-only
 - CLI surfaces for Codex, Claude, and Gemini plus host-side detached session
   control and inspection commands
+- GitHub Copilot CLI is planned for the same Tier 1 adapter support bar as the
+  current providers; it is not launch-ready until the adapter, auth path,
+  quickstart, deterministic evidence, and live certification land together
 - GitHub-hosted CI verifies repo shape, reproducibility, release posture, and
   secretless runtime behavior
 - GitHub-hosted CI continuously verifies bundle install/uninstall and Homebrew
@@ -201,6 +205,11 @@ Workcell can stage:
 It does not support whole-home passthrough, arbitrary environment-variable
 secret injection, or host socket forwarding on the safe path.
 
+Copilot CLI credentials and `~/.copilot` state are not supported inputs yet.
+The planned Copilot adapter must use an explicit staged credential, session-local
+Copilot home and cache paths, and reviewed GitHub-token handling before it can
+join the supported provider set.
+
 See [docs/injection-policy.md](docs/injection-policy.md) and
 [docs/examples/injection-policy.toml](docs/examples/injection-policy.toml).
 The by-provider bootstrap tiers and handoffs live in
@@ -213,6 +222,12 @@ The by-provider bootstrap tiers and handoffs live in
 | Codex | CLI | `~/.codex/config.toml`, `AGENTS.md`, rules, MCP config | [docs/examples/quickstart-codex.md](docs/examples/quickstart-codex.md) |
 | Claude | Claude Code CLI | `~/.claude/settings.json`, `CLAUDE.md`, `.mcp.json`, auth mirrors, hooks, host-side macOS auth resolver scaffold | [docs/examples/quickstart-claude.md](docs/examples/quickstart-claude.md) |
 | Gemini | Gemini CLI | `~/.gemini/settings.json`, `GEMINI.md`, `.env`, `projects.json` | [docs/examples/quickstart-gemini.md](docs/examples/quickstart-gemini.md) |
+
+Planned provider parity:
+
+| Provider | Target surface | Required before support |
+|---|---|---|
+| GitHub Copilot CLI | planned Tier 1 CLI adapter; not current support | `--agent copilot`, explicit token staging, session-local `COPILOT_HOME` and `COPILOT_CACHE_HOME`, unsafe-argument policy, quickstart, deterministic tests, and live `copilot -p` certification |
 
 GUI and IDE surfaces are lower assurance unless they act only as clients to
 the same bounded runtime.
@@ -343,6 +358,8 @@ Tagged releases are rebuilt and verified before publication. The release path:
   targets the newest two GitHub-hosted Apple Silicon macOS runner labels
 - refuses to publish if any reviewed provider, Linux base image, Linux
   toolchain, or release-build pin is behind the latest tracked upstream
+- adds Copilot upstream pin verification only after Copilot becomes a supported
+  provider adapter
 - publishes from the archived source bundle rather than the live checkout
 - gates publication on bundle and Homebrew install verification on
   GitHub-hosted Apple Silicon `macos-26` and `macos-15`
@@ -403,7 +420,8 @@ See [docs/provenance.md](docs/provenance.md) and
 
 - `runtime/`: VM and container boundary implementation
 - `policy/`: shared contract layer and hosted-control policy
-- `adapters/`: provider-native baselines for Codex, Claude, and Gemini
+- `adapters/`: provider-native baselines for Codex, Claude, and Gemini; the
+  Copilot baseline joins here only when its adapter support lands
 - `cmd/`: host-side and runtime-side Go entrypoints (the `workcell-*` binaries)
 - `internal/`: shared Go packages backing the `cmd/` binaries
 - `scripts/`: launcher, validation, release, audit, and bootstrap entrypoints

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,13 @@ operator hosts, Windows hosts, Linux `arm64`, and Raspberry Pi remain
 unsupported until their support-matrix rows, diagnostics, docs, rollback
 guidance, and live certification evidence land together.
 
+Authoritative provider support status remains in
+[`docs/provider-matrix.md`](docs/provider-matrix.md). Codex, Claude Code, and
+Gemini are the supported Tier 1 provider adapters today. GitHub Copilot CLI is
+now the next committed provider-parity track, but it is not a support claim
+until its adapter, auth path, docs, deterministic evidence, and live
+certification land together.
+
 The active delivery shape lives in
 [`docs/implement-first-delivery-plan.md`](docs/implement-first-delivery-plan.md).
 The longer-lived runtime-target and deployment-reach program lives in
@@ -36,6 +43,9 @@ The deterministic phase breakdown lives in
   launch claims.
 - Keep open-source adoption grounded in quickstart reliability, public
   invariants, contributor ergonomics, and honest support labels.
+- Promote provider expansion through the same Tier 1 adapter bar as the current
+  Codex, Claude, and Gemini adapters, rather than through provider-specific
+  shortcuts.
 
 ## Current Support Boundary
 
@@ -53,8 +63,11 @@ The deterministic phase breakdown lives in
 - Phases 10 through 12 are now implemented as contract, evidence, and readiness
   gates. They do not add a managed-workstation backend, Linux support, Windows
   support, or any new launch target.
+- GitHub Copilot CLI is planned as the next Tier 1 provider adapter. Current
+  releases do not support `--agent copilot`, Copilot credential keys, or a
+  Copilot quickstart.
 
-## Next Ten Phases
+## Next Provider And Target Phases
 
 ### Phase 10: Managed Workstation Contract
 
@@ -118,10 +131,61 @@ Exit gates:
 - support-matrix promotion criteria and fail-closed diagnostics are specified
 - the gate creates no Linux or Windows operator-host support claim by itself
 
+### Provider Parity Phase: GitHub Copilot CLI Tier 1 Adapter Parity
+
+Deliver GitHub Copilot CLI to the same end-state support bar as Codex, Claude
+Code, and Gemini before the Linux operator-host expansion resumes. This is a
+provider-adapter phase, not a host-support promotion.
+
+Exit gates:
+
+- `workcell --agent copilot --workspace /path/to/repo` launches Copilot CLI
+  fully inside the bounded Workcell runtime
+- Copilot home, cache, settings, permissions, sessions, logs, plugins, hooks,
+  MCP/LSP state, and instruction imports are session-local or explicitly
+  staged; host `~/.copilot`, host keychains, ambient `gh` auth, and whole-home
+  passthrough remain outside the safe path
+- the primary auth path is an explicit staged credential such as
+  `copilot_github_token`, exported only to the managed Copilot child process as
+  `COPILOT_GITHUB_TOKEN`
+- Copilot auth fallback is fail-closed: `GH_TOKEN`, `GITHUB_TOKEN`,
+  keychain/plaintext config fallback, and `gh auth token` fallback are scrubbed
+  or rejected unless a separate reviewed lower-assurance path explicitly
+  enables them
+- `COPILOT_HOME` and `COPILOT_CACHE_HOME` are set to Workcell-owned paths, and
+  BYOK provider env, remote control, plugins, MCP expansion, ACP, and custom
+  instruction overrides are either blocked or explicitly reviewed before
+  support
+- Copilot telemetry, OpenTelemetry, and content-capture environment variables
+  are scrubbed by default in `strict`; any enablement is lower-assurance,
+  explicitly acknowledged, audited, and covered by deterministic tests
+- `--agent-autonomy prompt` and `--agent-autonomy yolo` map to reviewed
+  Copilot permission flags without letting user argv silently widen tool, path,
+  URL, remote-session, or update behavior
+- workspace control-plane masking accounts for Copilot-specific files such as
+  `AGENTS.md`, `.github/copilot-instructions.md`,
+  `.github/instructions/**`, and `.github/copilot/settings*.json`
+- README, provider matrix, bootstrap matrix, injection policy, adapter control
+  planes, quickstart, validation scenarios, requirements, operator contract,
+  and release-facing docs land with the implementation
+- release preflight, upstream provider-pin verification, provenance docs,
+  manifests, and release validation include Copilot before any support
+  promotion
+- deterministic repo-required tests cover provider selection, auth policy,
+  bootstrap summaries, control-plane seeding, unsafe-argument rejection, and
+  scenario manifest parity, including fail-closed auth fallback and
+  telemetry/content-capture behavior
+- live provider certification proves a non-destructive `copilot -p` launch with
+  staged credentials before any signed commit claims Copilot support
+- product, enterprise/security, adapter-maintainer, validation, docs/contract,
+  and release review lenses have no unresolved P0/P1 objections about support
+  labels, auth, masking, or certification
+
 ### Phase 13: Linux `amd64` `local_compat` Certification Candidate
 
 Move Linux earlier than the old late-roadmap position, but only as a narrow
-candidate for lower-assurance operator-host support.
+candidate for lower-assurance operator-host support after the Copilot provider
+parity phase records its adapter-support outcome.
 
 Exit gates:
 
@@ -235,6 +299,8 @@ Exit gates:
 
 - publish a short supported quickstart for the strict macOS path
 - publish a clearly labeled Docker Desktop compat quickstart
+- publish the Copilot CLI quickstart only with its adapter, auth, and
+  certification evidence; until then, keep Copilot labeled as planned parity
 - explain why Docker, devcontainers, prompt rules, and provider config are not
   equivalent to Workcell's runtime boundary
 - keep examples and provider adapters thin, versioned, and honest about
@@ -248,6 +314,9 @@ Exit gates:
 
 - provide an enterprise evaluation guide, control evidence packet, deployment
   decision tree, and pilot rollout plan
+- require Copilot enterprise rollout material to document licensing/policy
+  prerequisites, token ownership, audit expectations, and the ban on host
+  `~/.copilot`, keychain, and ambient GitHub CLI passthrough before support
 - keep customer-owned cloud resources, no broad IAM grants, no public ingress,
   and explicit rollback as non-negotiable cloud preview requirements
 - support MDM-friendly install, upgrade, uninstall, rollback, and support
@@ -264,6 +333,10 @@ Exit gates:
   security boundary
 - claiming Linux, Windows, Linux `arm64`, or Raspberry Pi support before the
   support matrix, docs, diagnostics, and certification evidence exist
+- claiming GitHub Copilot CLI support before the Tier 1 adapter, auth model,
+  unsafe-argument policy, docs, tests, and live certification evidence land
+- treating Copilot cloud agent, IDE extensions, or host-native Copilot CLI
+  execution as equivalent to a Workcell Tier 1 provider adapter
 - treating Linux or Windows `compat` support as strict parity
 - treating Raspberry Pi as an enterprise host default
 - automatic backend fallback

--- a/docs/adapter-control-planes.md
+++ b/docs/adapter-control-planes.md
@@ -24,11 +24,27 @@ adapter baseline.
 | Claude | `settings.json`, rendered `CLAUDE.md`, `.mcp.json`, auth mirrors, optional API key helper | the reviewed Bash hook is defense in depth; MCP defaults are empty |
 | Gemini | `settings.json`, rendered `GEMINI.md`, `.env`, `oauth_creds.json`, `projects.json`, `trustedFolders.json` | `breakglass` restores Gemini's own folder-trust prompt; `gcloud_adc` is supplemental to Vertex config in `gemini_env` |
 
-Shared cross-provider state can also seed:
+## Planned Copilot CLI control plane
+
+GitHub Copilot CLI is planned as the next Tier 1 provider adapter. It is not
+seeded by current releases. Before support is claimed, the Copilot adapter must
+own a session-local `COPILOT_HOME`, `COPILOT_CACHE_HOME`, `~/.copilot`
+settings, permissions, sessions, logs, plugin state, hooks, MCP/LSP config,
+and any imported instruction files.
+
+The future adapter must reject host `~/.copilot`, keychain access, `GH_TOKEN`,
+`GITHUB_TOKEN`, ambient GitHub CLI fallback, unreviewed plugin or MCP
+expansion, remote-control sharing, and provider auto-update state as implicit
+Tier 1 inputs.
+
+Shared cross-provider state can also seed the current supported adapters:
 
 - `~/.config/gh/config.yml`
 - `~/.config/gh/hosts.yml`
 - `~/.ssh/*`
+
+That GitHub CLI state must not become a Copilot safe-path auth input unless a
+separate reviewed Copilot path explicitly allows it.
 
 ## Instruction layering
 
@@ -49,6 +65,11 @@ control plane masked on the safe path.
 |---|---|---|---|
 | `--agent-autonomy yolo` | `--ask-for-approval never` | `--permission-mode bypassPermissions` | `--approval-mode yolo` |
 | `--agent-autonomy prompt` | `--ask-for-approval on-request` | `--permission-mode default` | `--approval-mode default` |
+
+Copilot autonomy mapping is intentionally absent until the adapter lands. The
+planned implementation must map prompt mode to Copilot's normal approval flow
+and yolo mode only to reviewed tool/path/URL permissions inside the Workcell
+runtime, while blocking user-supplied flags that silently widen trust.
 
 Unsafe provider-native attempts to override those managed flags are blocked on
 the managed path.
@@ -92,6 +113,17 @@ boundary and does not cover non-Bash Claude tools.
 Workcell seeds Gemini's trusted-folders state for `/workspace` on the managed
 path so masked ephemeral sessions do not force a restart-based trust prompt.
 `breakglass` restores Gemini's own folder-trust flow.
+
+### Copilot trust and permissions
+
+Copilot support must treat permissive CLI options, saved permissions, remote
+control, plugins, hooks, MCP/LSP config, and repository-local Copilot settings
+as managed control-plane inputs. Current releases do not import or trust those
+paths for Copilot because `--agent copilot` is not implemented.
+
+Future strict-mode support must also scrub Copilot telemetry, OpenTelemetry,
+and content-capture environment variables by default; any opt-in path must be
+lower assurance, acknowledged, audited, and tested.
 
 ## MCP posture
 

--- a/docs/enterprise-rollout.md
+++ b/docs/enterprise-rollout.md
@@ -92,11 +92,24 @@ Current caveats:
   fail-closed until a supported export path exists
 - `gcloud_adc` is supplemental to Vertex config, not a standalone Gemini auth
   mode
+- GitHub Copilot CLI is planned for Tier 1 parity but is not supported today;
+  do not distribute host `~/.copilot`, keychain exports, `GH_TOKEN`,
+  `GITHUB_TOKEN`, ambient `gh` auth, or broad GitHub tokens as Workcell inputs
 
 See [injection-policy.md](injection-policy.md) for the current by-provider auth
 maturity summary and
 [provider-bootstrap-matrix.md](provider-bootstrap-matrix.md) for the explicit
 repo-required versus manual bootstrap tiers.
+
+The Copilot enterprise rollout gate must document organization policy and
+license prerequisites, token ownership, audit expectations, telemetry/content
+capture posture, and the exact staged-token handoff before any team treats
+Copilot as supported.
+
+Future strict-mode Copilot support must default-deny Copilot telemetry,
+OpenTelemetry, and content-capture environment variables. Any content-capture
+enablement must be lower assurance, explicitly acknowledged, audited, and
+covered by deterministic tests.
 
 ### 4. Scope shared GitHub and SSH inputs deliberately
 

--- a/docs/examples/injection-policy.toml
+++ b/docs/examples/injection-policy.toml
@@ -23,10 +23,12 @@ materialization = "ephemeral"
 
 [credentials.github_hosts]
 source = "/Users/example/.config/gh/hosts.yml"
+# Copilot CLI is intentionally omitted until its adapter support lands.
 providers = ["codex", "claude", "gemini"]
 
 [credentials.github_config]
 source = "/Users/example/.config/gh/config.yml"
+# Copilot CLI is intentionally omitted until its adapter support lands.
 providers = ["codex", "claude", "gemini"]
 
 [ssh]
@@ -34,6 +36,7 @@ enabled = true
 config = "/Users/example/.ssh/config"
 known_hosts = "/Users/example/.ssh/known_hosts"
 identities = ["/Users/example/.ssh/id_workcell"]
+# Copilot CLI is intentionally omitted until its adapter support lands.
 providers = ["codex", "claude", "gemini"]
 modes = ["strict", "development", "build"]
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,6 +85,10 @@ workcell auth set \
   --source /Users/example/.config/workcell/gemini.env
 ```
 
+GitHub Copilot CLI is not a supported agent yet. Do not configure
+`--agent copilot`, `copilot_github_token`, or host `~/.copilot` state until the
+Copilot adapter support phase lands with matching docs and certification.
+
 Check the host-side view at any time:
 
 ```bash
@@ -132,6 +136,10 @@ workcell --agent codex --agent-autonomy prompt --workspace /path/to/repo
 - [Codex quickstart](examples/quickstart-codex.md)
 - [Claude quickstart](examples/quickstart-claude.md)
 - [Gemini quickstart](examples/quickstart-gemini.md)
+
+There is no Copilot quickstart in current releases. Copilot CLI is a planned
+Tier 1 parity provider and will get a quickstart only when support is
+implemented and certified.
 
 For team rollout patterns on today's local-first product, see
 [Enterprise rollout today](enterprise-rollout.md).

--- a/docs/host-expansion-readiness.md
+++ b/docs/host-expansion-readiness.md
@@ -26,11 +26,13 @@ or `preview` without becoming broadly supported.
 
 ## Candidate Scope
 
-Phase 13 may evaluate Linux `amd64` `local_compat` as the next narrow candidate.
-That evaluation must select one distro/runtime matrix before implying Linux
-operator support. If that selected matrix cannot preserve Workcell's support
-boundary, the phase must record the blocker instead of substituting a different
-runtime silently.
+The roadmap now places GitHub Copilot CLI Tier 1 provider parity before the
+Linux host-expansion slice. Phase 13 remains the next runtime-target candidate
+after that provider-parity work and may evaluate Linux `amd64` `local_compat`
+as a narrow candidate. That evaluation must select one distro/runtime matrix
+before implying Linux operator support. If that selected matrix cannot preserve
+Workcell's support boundary, the phase must record the blocker instead of
+substituting a different runtime silently.
 
 Later host tracks remain separate:
 

--- a/docs/implement-first-delivery-plan.md
+++ b/docs/implement-first-delivery-plan.md
@@ -237,7 +237,8 @@ Completion record:
 
 ## Later Phase Handoff
 
-Before Phase 13 begins implementation, assign distinct owner lanes:
+Before the Copilot provider-parity phase or the later Phase 13 runtime-target
+candidate begins implementation, assign distinct owner lanes:
 
 - EM:
   support-boundary owner for rollout scope, preview/GA decisions, and rollback
@@ -262,7 +263,9 @@ Before Phase 13 begins implementation, assign distinct owner lanes:
    later phase lands rather than as a cleanup pass
 4. treat Phase 10 through 12 docs as fixed gates for managed-workstation,
    enterprise-evidence, and host-expansion work
-5. leave later raw `remote_vm`, managed-workstation provider delivery, and host
+5. complete the Copilot CLI provider-parity phase before resuming Linux
+   host-expansion implementation
+6. leave later raw `remote_vm`, managed-workstation provider delivery, and host
    promotion to later runtime-target program phases once these prerequisites and
    owner handoffs are done
 

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -78,6 +78,14 @@ current bootstrap tiers, handoffs, and evidence.
 | Claude | `claude_auth`, `claude_api_key`, `claude_mcp` | shared GitHub CLI and SSH inputs via policy as needed | the built-in `claude-macos-keychain` resolver can record intent but remains fail-closed until a supported export path exists |
 | Gemini | `gemini_env`, `gemini_oauth` | `gemini_projects` as a supplemental project registry input, `gcloud_adc` as a supplemental Vertex input, plus shared GitHub CLI and SSH inputs via policy as needed | `gemini_projects` and `gcloud_adc` are not standalone Gemini auth modes |
 
+GitHub Copilot CLI is planned for Tier 1 parity but is not a launch-ready
+provider today. The planned path must use explicit staged token material, likely
+`copilot_github_token`, and session-local `COPILOT_HOME` /
+`COPILOT_CACHE_HOME` state. It must not pass through host `~/.copilot`, host
+keychains, `GH_TOKEN`, `GITHUB_TOKEN`, ambient `gh auth token`, arbitrary BYOK
+provider env, or whole-home state. The managed child should see only the
+Workcell-staged `COPILOT_GITHUB_TOKEN` on the supported path.
+
 ## Credential keys
 
 | Key | Session target | Notes |
@@ -93,6 +101,10 @@ current bootstrap tiers, handoffs, and evidence.
 | `github_hosts` | `~/.config/gh/hosts.yml` | shared GitHub CLI auth; prefer scoped nested tables |
 | `github_config` | `~/.config/gh/config.yml` | shared GitHub CLI config; prefer scoped nested tables |
 
+`copilot_github_token` is a planned credential key, not a supported key in
+current releases. It must not appear in operator policy until the Copilot
+adapter, validation, and docs land.
+
 ## Instruction precedence
 
 Provider docs are rendered in this order:
@@ -103,6 +115,11 @@ Provider docs are rendered in this order:
 4. `documents.common`
 5. provider-specific document fragment
 
+The planned Copilot adapter must separately define how `AGENTS.md`,
+`.github/copilot-instructions.md`, `.github/instructions/**`, and
+`.github/copilot/settings*.json` are imported, masked, or rejected. Current
+releases do not provide Copilot-specific instruction layering.
+
 ## Deliberate limits
 
 - no arbitrary environment-variable secret injection on the safe path
@@ -111,6 +128,12 @@ Provider docs are rendered in this order:
 - no `SSH_AUTH_SOCK` forwarding
 - no assumption that one process inside the session is isolated from another
   process in the same session
+- no host `~/.copilot`, keychain, `GH_TOKEN`, `GITHUB_TOKEN`, ambient
+  `gh auth token`, or broad Copilot token state passthrough on the future
+  Copilot path
+- no Copilot telemetry, OpenTelemetry, or content-capture environment variables
+  in future `strict` mode unless a lower-assurance acknowledged path and
+  deterministic tests are added
 
 ## Recommended usage
 

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -15,6 +15,9 @@ On the managed path, Workcell does not pass through:
 - host provider-home state such as `~/.codex`, `~/.claude`, or `~/.gemini`
 
 Reusable auth enters the session only through explicit injection-policy inputs.
+The planned GitHub Copilot CLI adapter must preserve the same invariant for
+host `~/.copilot`, host keychains, `GH_TOKEN`, `GITHUB_TOKEN`, and ambient
+`gh auth token` fallback. Current releases do not support `--agent copilot`.
 
 ## 2. Writes stay inside the intended workspace
 
@@ -28,6 +31,11 @@ Repo-local control-plane files such as `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`,
 `.codex/`, `.claude/`, and `.gemini/` are masked on the safe path and imported
 into provider homes as reviewed inputs. The workspace should not be able to
 quietly take over the runtime control plane.
+
+The planned Copilot adapter must explicitly account for Copilot-specific repo
+control-plane files such as `.github/copilot-instructions.md`,
+`.github/instructions/**`, and `.github/copilot/settings*.json` before it can
+claim support.
 
 ## 4. Network posture is explicit
 
@@ -58,6 +66,7 @@ Examples:
 - `--allow-arbitrary-command`
 - `breakglass`
 - host-side debug or transcript capture
+- any future Copilot telemetry, OpenTelemetry, or content-capture enablement
 
 Workcell records those choices in launch or runtime state instead of implying
 they are equivalent to the default path.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -46,6 +46,8 @@ Before publish, release preflight reruns:
 - authoritative-source verification of the GitHub-hosted Apple Silicon macOS
   release install runner labels
 - upstream pinned Codex, Claude, and Gemini release verification
+- GitHub Copilot CLI upstream pin verification after Copilot becomes a
+  supported adapter
 - reviewed upstream pin verification across providers, Linux base images,
   Linux toolchains, and release-build helper pins
 - release-bundle install/uninstall and Homebrew install/uninstall verification

--- a/docs/provider-bootstrap-matrix.md
+++ b/docs/provider-bootstrap-matrix.md
@@ -29,6 +29,10 @@ These tiers describe the Workcell bootstrap and staging contract. Live
 provider-authenticated UX remains the separate manual provider-e2e lane unless
 the evidence explicitly says otherwise.
 
+Roadmap-only provider entries are called out separately. They are not accepted
+by `workcell auth`, `workcell --auth-status`, or `workcell why` until the
+matching adapter and evidence land.
+
 ## Current Matrix
 
 | Provider | Auth path | Bootstrap path | Support | Evidence | Notes |
@@ -42,6 +46,22 @@ the evidence explicitly says otherwise.
 | Gemini | direct staged `gemini_oauth` | `direct-staged` | `repo-required` | `tests/scenarios/shared/test-auth-status.sh` | reviewed cached Gemini OAuth path |
 | Gemini | direct staged `gemini_projects` supplement | `project-registry-supplement` | `manual` | `tests/scenarios/shared/test-auth-status.sh`, `internal/authpolicy/manage_test.go` | reviewed Gemini project registry input; not a standalone auth mode |
 | Gemini | direct staged `gcloud_adc` supplement | `vertex-supplement` | `manual` | `scripts/verify-invariants.sh`, `docs/examples/gemini-vertex-setup.md` | supplemental Vertex input only; not a standalone Gemini auth mode |
+
+## Planned Copilot CLI Bootstrap Track
+
+GitHub Copilot CLI is the next provider-parity track, but it has no supported
+bootstrap row yet. Before it can join the current matrix, Workcell must add an
+explicit staged token credential such as `copilot_github_token`, export it only
+to the managed Copilot child process as `COPILOT_GITHUB_TOKEN`, and prevent
+host `~/.copilot`, host keychains, `GH_TOKEN`, `GITHUB_TOKEN`, ambient
+`gh auth token`, or whole-home state from becoming implicit inputs.
+
+The Copilot bootstrap row is supportable only after deterministic auth-status,
+policy, bootstrap-summary, control-plane seeding, and unsafe-argument tests
+exist. Those tests must prove Copilot auth fallback fails closed outside the
+Workcell-staged `COPILOT_GITHUB_TOKEN` path. The row also needs live provider
+certification proving a non-destructive `copilot -p` launch with staged
+credentials.
 
 ## Remote Target Bootstrap
 
@@ -71,3 +91,6 @@ The bootstrap summary fields also report the remaining operator handoff:
 - [Quickstart: Claude](examples/quickstart-claude.md)
 - [Quickstart: Gemini](examples/quickstart-gemini.md)
 - [Gemini Vertex AI setup](examples/gemini-vertex-setup.md)
+
+There is no Copilot quickstart until Copilot CLI support lands with matching
+adapter, auth, and certification evidence.

--- a/docs/provider-matrix.md
+++ b/docs/provider-matrix.md
@@ -11,6 +11,25 @@ through a native control-plane mapping.
 | Claude | Claude Code CLI | `~/.claude/settings.json`, rendered `CLAUDE.md`, `.mcp.json`, auth mirrors, reviewed Bash hook | `claude_auth`, `claude_api_key`, `claude_mcp` | direct staged `claude_auth` and `claude_api_key` are supported; the built-in macOS resolver scaffold remains fail-closed |
 | Gemini | Gemini CLI | `~/.gemini/settings.json`, rendered `GEMINI.md`, `.env`, OAuth creds, `projects.json`, trusted folders | `gemini_env`, `gemini_oauth`, `gemini_projects`, `gcloud_adc` | Gemini's own sandbox is not the Tier 1 boundary here; `gcloud_adc` is supplemental to Vertex config |
 
+## Planned provider parity
+
+| Provider | Planned Tier 1 surface | Planned managed control plane | Planned auth input | Support status |
+|---|---|---|---|---|
+| GitHub Copilot CLI | `workcell --agent copilot --workspace ...` | session-local `COPILOT_HOME`, `COPILOT_CACHE_HOME`, `~/.copilot` config, permissions, sessions, logs, plugins, hooks, MCP/LSP state, and reviewed instruction imports | explicit staged token such as `copilot_github_token`, exported only to the managed child as `COPILOT_GITHUB_TOKEN` | roadmap parity track; not current support |
+
+Copilot support must land with the same evidence bar as the current providers:
+adapter baseline, auth/bootstrap explainability, unsafe-argument rejection,
+workspace control-plane masking, quickstart, scenario coverage, and live
+provider certification. Host `~/.copilot`, host keychains, `GH_TOKEN`,
+`GITHUB_TOKEN`, ambient GitHub CLI auth, and whole-home passthrough are not
+acceptable Tier 1 inputs.
+
+GitHub documents Copilot CLI as a terminal agent with interactive and
+programmatic modes, environment-token auth, configurable `COPILOT_HOME`, and
+permissive tool flags such as `--allow-all` and `--yolo`. Workcell treats
+those product surfaces as implementation inputs that must be mapped or blocked
+before support is claimed.
+
 For provider auth maturity and rollout caveats, see
 [docs/injection-policy.md](injection-policy.md) and
 [docs/provider-bootstrap-matrix.md](provider-bootstrap-matrix.md).
@@ -21,6 +40,11 @@ For provider auth maturity and rollout caveats, see
 - Tier 2: GUI or IDE surface is only a client to that same bounded runtime
 - Tier 3: host-native GUI, cloud, or web-only guidance with no claim of
   equivalent local isolation
+
+Copilot cloud agent, IDE extensions, and host-native Copilot CLI execution are
+Tier 3 unless a future integration makes them clients of the same bounded
+Workcell session plane. The planned support target is the local Copilot CLI
+adapter running inside Tier 1.
 
 Do not force one provider's control model onto another. Keep one shared
 boundary and one thin adapter per product.

--- a/docs/runtime-target-expansion-plan.md
+++ b/docs/runtime-target-expansion-plan.md
@@ -170,8 +170,8 @@ Current repo status:
 - Gate 7 is implemented
 - Gate 8 is implemented
 - Gate 9 is implemented
-- the next active slice is the Linux `amd64` `local_compat` certification
-  candidate from the roadmap
+- the roadmap now inserts GitHub Copilot CLI Tier 1 provider parity before the
+  Linux `amd64` `local_compat` certification candidate resumes
 
 ### Gate 3: compatibility target certified
 

--- a/docs/runtime-target-phase-plan.md
+++ b/docs/runtime-target-phase-plan.md
@@ -34,8 +34,10 @@ Current repo status:
 - Phase 10 is implemented as the managed workstation contract and discovery gate
 - Phase 11 is implemented as the enterprise evidence baseline
 - Phase 12 is implemented as the host-expansion readiness gate
-- Phase 13 is the next active slice: Linux `amd64` `local_compat` certification
-  candidate
+- the roadmap now inserts GitHub Copilot CLI Tier 1 adapter parity before the
+  Linux host-expansion slice resumes
+- Phase 13 remains the next runtime-target slice: Linux `amd64`
+  `local_compat` certification candidate
 - later phases remain planning targets until their code and evidence land
 
 ## Phase Completion Contract
@@ -548,7 +550,9 @@ Phase 12 completion record:
 - [`docs/host-expansion-readiness.md`](host-expansion-readiness.md) records the
   support tiers, candidate scope, promotion criteria, and fail-closed diagnostic
   expectations
-- Phase 13 is the next active slice and may evaluate a narrow Linux `amd64`
-  `local_compat` certification candidate
+- the roadmap now places the GitHub Copilot CLI provider-parity phase before
+  Phase 13 runtime-target implementation work resumes
+- Phase 13 remains queued to evaluate a narrow Linux `amd64` `local_compat`
+  certification candidate
 - no Linux, Windows, Linux `arm64`, Raspberry Pi, or strict non-macOS support
   claim is shipped in this phase

--- a/docs/scenario-gaps.md
+++ b/docs/scenario-gaps.md
@@ -19,6 +19,14 @@ local use, but it requires a real macOS+Colima environment and live provider
 credentials and is not run in CI. Not every documented auth path has full
 automated end-to-end coverage across all providers.
 
+### GitHub Copilot CLI provider parity
+
+Copilot CLI is the next planned Tier 1 provider adapter, but current releases
+do not include `--agent copilot`, Copilot auth staging, a quickstart, scenario
+evidence, or live provider certification. The support claim remains blocked
+until deterministic tests and a live non-destructive `copilot -p` certification
+land with the adapter.
+
 ### Lower-assurance transition coverage
 
 Some downgrade paths are validated statically or by smoke tests but still need
@@ -46,9 +54,17 @@ more explicit end-to-end scenarios, especially:
 - more end-to-end coverage for Vertex plus `gcloud_adc`
 - more coverage for `breakglass` folder-trust restoration
 
+### Copilot
+
+- provider adapter, auth, bootstrap, unsafe-argument, and control-plane seeding
+  coverage after implementation starts
+- live `copilot -p` certification with staged credentials before any support
+  claim
+
 ## Why these gaps remain acceptable for now
 
 The core repo-required path is covered by invariants, smoke tests, deterministic
 repo validation, reproducibility checks, and tagged release preflight. The open
 gaps are mostly at the edges: live-provider auth, local macOS proof, and
-explicit lower-assurance transitions.
+explicit lower-assurance transitions. Copilot is different: it is a planned
+provider-parity track and remains unsupported until the adapter evidence lands.

--- a/docs/use-case-matrix.md
+++ b/docs/use-case-matrix.md
@@ -31,6 +31,7 @@ Workcell workflows.
 | GitHub attestations on tagged releases | tested at release time | `release.yml` publish job |
 | full macOS Colima boundary proof | gap | local certification lane exists, but it is still not repo-required proof |
 | exhaustive live-provider auth UX across all providers | gap | manual provider-e2e path exists, but automation is partial |
+| GitHub Copilot CLI Tier 1 provider parity | planned gap | roadmap and provider docs record the target support bar; no adapter, auth key, quickstart, scenario evidence, or live certification exists yet |
 
 ## Notes
 
@@ -40,4 +41,5 @@ reproducibility, signed publication, and the host-side operator plane. The
 most mature host-side operator surfaces are auth/policy inspection plus
 session inventory, detached control, delete, timeline, export, and
 isolated-workspace remediation. The biggest remaining gaps are local macOS
-boundary proof and deeper end-to-end live-provider coverage.
+boundary proof, deeper end-to-end live-provider coverage, and the planned
+Copilot CLI adapter parity phase.

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -41,6 +41,9 @@ Use these anchors when checking release-facing claims:
   enterprise evidence, and host expansion:
   `scripts/verify-requirements-coverage.sh`,
   `scripts/verify-operator-contract.sh`
+- Copilot CLI provider-parity roadmap traceability:
+  `ROADMAP.md`, `docs/provider-matrix.md`,
+  `docs/provider-bootstrap-matrix.md`
 - Claude hook coverage: `claude-swe/hook-parametric`
 - supported GitHub-hosted macOS release window:
   `scripts/verify-github-macos-release-test-runners.sh`
@@ -109,6 +112,12 @@ Today that certification tier includes:
   `remote_vm/gcp-vm/compat` preview boundary against a reviewed
   IAP-reachable Compute Engine target without an external NAT IP
 
+The planned Copilot CLI adapter must add live provider certification before it
+claims support. That certification should prove a non-destructive `copilot -p`
+run with staged credentials inside the managed runtime and must stay separate
+from repo-required validation unless it can run deterministically without live
+provider credentials.
+
 Remote VM live smoke remains certification-only as well, but it is currently a
 provider-e2e preview gate documented in
 [`docs/aws-ec2-ssm-preview.md`](aws-ec2-ssm-preview.md) and
@@ -142,6 +151,9 @@ when the repo does not add a dedicated new scenario for each page.
 | `docs/provider-bootstrap-matrix.md` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-policy-commands.sh`, `tests/scenarios/shared/test-codex-resolver-launcher.sh`, `tests/scenarios/shared/test-claude-resolver-launcher.sh` |
 | `docs/examples/enterprise-claude-setup.md` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-policy-commands.sh`, `tests/scenarios/shared/test-publish-pr-dry-run.sh` |
 
+There is no Copilot quickstart row until the Copilot adapter, credential path,
+scenario evidence, and live certification land.
+
 ## Manual authenticated smoke
 
 `./scripts/provider-e2e.sh` is the reviewed path for provider-authenticated
@@ -154,6 +166,8 @@ Use it when you need to verify:
 - provider-specific auth selection
 - injected MCP or project-registry behavior
 - provider UX that only shows up with a live account
+- future Copilot CLI behavior that depends on a live staged
+  `COPILOT_GITHUB_TOKEN`
 
 ## GitHub CI vs local boundary proof
 

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -325,8 +325,8 @@ docs = [
 ]
 
 [nonfunctional.NFR-007]
-title = "Target expansion gate discipline"
-summary = "Workcell records managed-workstation and host-expansion gates with explicit support boundaries, evidence expectations, and no backend or host support promotion until proof lands in the same change."
+title = "Target and provider expansion gate discipline"
+summary = "Workcell records managed-workstation, host-expansion, and provider-parity gates with explicit support boundaries, evidence expectations, and no backend, host, or provider support promotion until proof lands in the same change."
 evidence = [
   "scripts/verify-requirements-coverage.sh",
   "scripts/verify-operator-contract.sh",
@@ -334,6 +334,13 @@ evidence = [
 ]
 docs = [
   "ROADMAP.md",
+  "docs/provider-matrix.md",
+  "docs/provider-bootstrap-matrix.md",
+  "docs/injection-policy.md",
+  "docs/adapter-control-planes.md",
+  "docs/enterprise-rollout.md",
+  "docs/provenance.md",
+  "docs/invariants.md",
   "docs/runtime-target-phase-plan.md",
   "docs/runtime-target-expansion-plan.md",
   "docs/implement-first-delivery-plan.md",


### PR DESCRIPTION
## Summary
- Commit GitHub Copilot CLI as the next Tier 1 provider-parity track.
- Keep current support claims limited to Codex, Claude Code, and Gemini.
- Add Copilot security, auth fallback, telemetry/content-capture, release-preflight, and certification gates across roadmap and provider-facing docs.

## Validation
- `bash ./scripts/verify-operator-contract.sh`
- `bash ./scripts/verify-requirements-coverage.sh`
- `bash ./scripts/check-dead-code.sh`
- `bash ./scripts/check-public-repo-hygiene.sh`
- `bash ./scripts/validate-repo.sh`
- `./scripts/pre-merge.sh --profile pr-parity`

## Review
- Product review: no actionable findings.
- Enterprise/security review: findings addressed and follow-up review resolved.
- Docs/contract release review: findings addressed and follow-up review resolved.
- Maintainer/adapter review: no actionable findings.
