### PR TITLE
Polish Copilot CLI roadmap docs after review

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,9 @@ assignees: ''
 
 ## Describe the bug
 
-A clear description of what the bug is.
+A clear description of what the bug is. For docs or planning issues about a
+roadmap-only provider track (such as the planned GitHub Copilot CLI parity),
+open a feature request instead and reference `docs/scenario-gaps.md`.
 
 ## To reproduce
 
@@ -26,7 +28,7 @@ What you expected to happen.
 
 - OS: [e.g. macOS 15.4]
 - Workcell version: [e.g. v0.5.0 or commit SHA]
-- Provider: [Codex / Claude / Gemini; use "Copilot CLI roadmap" only for planned-support docs issues]
+- Provider: [Codex / Claude / Gemini]
 - Mode: [strict / build / breakglass]
 - Docker version: `docker --version`
 - Colima version (macOS only): `colima version`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ guidance, and live certification evidence land together.
 Authoritative provider support status remains in
 [`docs/provider-matrix.md`](docs/provider-matrix.md). Codex, Claude Code, and
 Gemini are the supported Tier 1 provider adapters today. GitHub Copilot CLI is
-now the next committed provider-parity track, but it is not a support claim
+the next committed provider-parity track, but it is not a support claim
 until its adapter, auth path, docs, deterministic evidence, and live
 certification land together.
 

--- a/docs/examples/injection-policy.toml
+++ b/docs/examples/injection-policy.toml
@@ -7,6 +7,9 @@ codex = "/Users/example/.config/workcell/codex-extra.md"
 claude = "/Users/example/.config/workcell/claude-extra.md"
 gemini = "/Users/example/.config/workcell/gemini-extra.md"
 
+# Copilot CLI is intentionally omitted from every `providers` list below
+# until its adapter support lands.
+
 [credentials]
 codex_auth = "/Users/example/.codex/auth.json"
 claude_api_key = "/Users/example/.config/workcell/claude-api-key.txt"
@@ -23,12 +26,10 @@ materialization = "ephemeral"
 
 [credentials.github_hosts]
 source = "/Users/example/.config/gh/hosts.yml"
-# Copilot CLI is intentionally omitted until its adapter support lands.
 providers = ["codex", "claude", "gemini"]
 
 [credentials.github_config]
 source = "/Users/example/.config/gh/config.yml"
-# Copilot CLI is intentionally omitted until its adapter support lands.
 providers = ["codex", "claude", "gemini"]
 
 [ssh]
@@ -36,7 +37,6 @@ enabled = true
 config = "/Users/example/.ssh/config"
 known_hosts = "/Users/example/.ssh/known_hosts"
 identities = ["/Users/example/.ssh/id_workcell"]
-# Copilot CLI is intentionally omitted until its adapter support lands.
 providers = ["codex", "claude", "gemini"]
 modes = ["strict", "development", "build"]
 

--- a/docs/host-expansion-readiness.md
+++ b/docs/host-expansion-readiness.md
@@ -26,7 +26,7 @@ or `preview` without becoming broadly supported.
 
 ## Candidate Scope
 
-The roadmap now places GitHub Copilot CLI Tier 1 provider parity before the
+The roadmap sequences GitHub Copilot CLI Tier 1 provider parity before the
 Linux host-expansion slice. Phase 13 remains the next runtime-target candidate
 after that provider-parity work and may evaluate Linux `amd64` `local_compat`
 as a narrow candidate. That evaluation must select one distro/runtime matrix

--- a/docs/runtime-target-expansion-plan.md
+++ b/docs/runtime-target-expansion-plan.md
@@ -170,7 +170,7 @@ Current repo status:
 - Gate 7 is implemented
 - Gate 8 is implemented
 - Gate 9 is implemented
-- the roadmap now inserts GitHub Copilot CLI Tier 1 provider parity before the
+- the roadmap sequences GitHub Copilot CLI Tier 1 provider parity before the
   Linux `amd64` `local_compat` certification candidate resumes
 
 ### Gate 3: compatibility target certified

--- a/docs/runtime-target-phase-plan.md
+++ b/docs/runtime-target-phase-plan.md
@@ -34,7 +34,7 @@ Current repo status:
 - Phase 10 is implemented as the managed workstation contract and discovery gate
 - Phase 11 is implemented as the enterprise evidence baseline
 - Phase 12 is implemented as the host-expansion readiness gate
-- the roadmap now inserts GitHub Copilot CLI Tier 1 adapter parity before the
+- the roadmap sequences GitHub Copilot CLI Tier 1 adapter parity before the
   Linux host-expansion slice resumes
 - Phase 13 remains the next runtime-target slice: Linux `amd64`
   `local_compat` certification candidate
@@ -550,7 +550,7 @@ Phase 12 completion record:
 - [`docs/host-expansion-readiness.md`](host-expansion-readiness.md) records the
   support tiers, candidate scope, promotion criteria, and fail-closed diagnostic
   expectations
-- the roadmap now places the GitHub Copilot CLI provider-parity phase before
+- the roadmap sequences the GitHub Copilot CLI provider-parity phase before
   Phase 13 runtime-target implementation work resumes
 - Phase 13 remains queued to evaluate a narrow Linux `amd64` `local_compat`
   certification candidate

--- a/docs/use-case-matrix.md
+++ b/docs/use-case-matrix.md
@@ -8,6 +8,7 @@ Workcell workflows.
 - `tested`: covered by repo validation, invariants, smoke, or scenario tests
 - `doc-only`: documented and intentionally supported, but not deeply automated
 - `gap`: recognized coverage gap tracked in `docs/scenario-gaps.md`
+- `planned gap`: roadmap target with no current implementation, tracked in `docs/scenario-gaps.md`
 
 ## Matrix
 


### PR DESCRIPTION
## Summary

Address review findings on #264 (Copilot CLI Tier 1 parity roadmap).

- Define `planned gap` status in the `docs/use-case-matrix.md` legend — the prior PR introduced a matrix row using that value without listing it in the legend.
- Drop the `Copilot CLI roadmap` value from the `bug_report.md` Provider enum (Copilot is not a supported provider); add a one-line pointer directing roadmap-only docs issues to feature requests + `docs/scenario-gaps.md`.
- Unify the roadmap-ordering verb to **sequences** across `host-expansion-readiness.md`, `runtime-target-expansion-plan.md`, `runtime-target-phase-plan.md` (×2), and `ROADMAP.md`. Previously the same statement used four different verbs (`now places`, `now inserts` ×2, `now places`).
- Strip "now" PR-narration ("the roadmap now…") that read as "as of this PR" rather than describing the system.
- Consolidate the triplicate `# Copilot CLI is intentionally omitted…` comment in `docs/examples/injection-policy.toml` into a single section header above `[credentials]`.

No behavior change. The TOML example file's `providers = [...]` arrays are byte-identical to before.

## Test plan

- [x] `scripts/verify-requirements-coverage.sh` — green
- [x] `scripts/verify-coverage.sh` — green
- [x] `scripts/verify-invariants.sh` — green
- [ ] CI pr-parity lanes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)