### PR TITLE
^D Docs/naming fixes: --ui, mode map, Copilot status, package docs (sethify findings)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,6 +228,23 @@ Adapters should stay thin. A new or changed adapter should:
 See [workflows/adapter-porting.md](workflows/adapter-porting.md) for the
 porting checklist.
 
+## Package naming
+
+For new internal Go packages, name by role rather than suffix:
+`canonicalpath`, `secretfile`, `transcript`, `injection`. Avoid the
+`*util`, `*helper`, `*manager`, `*handler` suffixes that the
+[Go style guide](https://go.dev/wiki/CodeReviewComments#package-names)
+flags as opaque — they hide what the package is for and become magnets
+for unrelated helpers over time.
+
+The repo carries some pre-existing `*util` packages (`pathutil`,
+`metadatautil`, `runtimeutil`, `colimautil`) and corresponding binary
+names (`cmd/workcell-hostutil`, `cmd/workcell-runtimeutil`,
+`cmd/workcell-citools`, `cmd/workcell-colimautil`). These are not
+retargeted for rename in place — the binary names appear in
+`policy/host-support-matrix.tsv`, audit logs, install paths, and PR
+review surfaces. The rule applies to new packages only.
+
 ## Project docs
 
 - [GOVERNANCE.md](GOVERNANCE.md)

--- a/README.md
+++ b/README.md
@@ -243,13 +243,21 @@ Workcell uses two terms throughout the docs:
 - `Tier 1`: a provider CLI running fully inside the bounded Workcell runtime
 - `strict`: the default managed Tier 1 runtime mode
 
-| Path | Intended use | Key properties |
+`--mode` selects one of four lanes:
+
+| `--mode` | Intended use | Key properties |
 |---|---|---|
 | `strict` | default provider lane | bounded VM plus container, reviewed network posture, repo control-plane masking, provider-focused entrypoint, `--agent-autonomy yolo` by default |
-| `strict --container-mutability readonly` | strongest managed lane | package-manager writes blocked; no package-mutation downgrade |
 | `development` | managed interactive development lane | same boundary and masking as `strict`, managed non-provider command execution, broader dependency egress, visibly lower assurance than `strict` |
 | `build` | image preparation and dependency refresh | broader egress for rebuild and preparation work |
 | `breakglass` | explicit higher-trust debugging path | requires `--ack-breakglass`; visibly lower assurance |
+
+`--container-mutability` is orthogonal to `--mode`: `ephemeral` (the
+default) allows package-manager mutations and labels the session
+`managed-mutable`, while `readonly` blocks package-manager writes and
+gives the strongest managed posture available — `--mode strict
+--container-mutability readonly` is the lane to pick when no
+lower-assurance downgrade is acceptable.
 
 Other defaults that matter:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -323,7 +323,7 @@ Exit gates:
   bundle flows before broad enterprise rollout
 - add centralized policy administration, inventory, and analytics only after
   local export and signed policy distribution are proven
-- preserve-boundary IDE and GUI entrypoints must be clients of the session
+- preserved-boundary IDE and GUI entrypoints must be clients of the session
   plane, not alternate execution paths
 
 ## Non-Goals

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -15,3 +15,12 @@ Adapter rules:
 - prefer native provider config over wrapper-only policy
 - do not claim the adapter is the primary boundary
 - keep lower-assurance GUI or IDE paths clearly separate from Tier 1 CLI paths
+
+## Adding a new provider
+
+Per-provider Go tables (credential keys, container paths, reserved
+targets) live in `internal/adapters/data.go` — adding a new provider is
+a single row append to the `providers` slice plus the per-provider
+config tree under `adapters/<name>/`. There is no longer a per-provider
+Go sub-package; see `internal/adapters/adapters.go` for the public API
+that the injection, policy, and runtime paths consume.

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -7,8 +7,10 @@ Adapter layout (paths relative to `adapters/codex/`):
   session-local Codex home as `~/.codex/config.toml`
 - `.codex/AGENTS.md`: managed agent guidance seeded into the session-local
   Codex home
-- `.codex/rules/`: managed execpolicy rules seeded into the session-local
-  Codex home
+- `.codex/rules/default.rules`: managed Codex execpolicy ruleset seeded
+  into the session-local Codex home. Workcell currently ships one
+  ruleset; the directory shape exists so future overlays can drop in
+  alongside `default.rules`.
 - `.codex/agents/`: managed sub-agent guidance
 - `managed_config.toml`: workcell-side managed-mode TOML consumed by the
   launcher

--- a/docs/scenario-gaps.md
+++ b/docs/scenario-gaps.md
@@ -19,14 +19,6 @@ local use, but it requires a real macOS+Colima environment and live provider
 credentials and is not run in CI. Not every documented auth path has full
 automated end-to-end coverage across all providers.
 
-### GitHub Copilot CLI provider parity
-
-Copilot CLI is the next planned Tier 1 provider adapter, but current releases
-do not include `--agent copilot`, Copilot auth staging, a quickstart, scenario
-evidence, or live provider certification. The support claim remains blocked
-until deterministic tests and a live non-destructive `copilot -p` certification
-land with the adapter.
-
 ### Lower-assurance transition coverage
 
 Some downgrade paths are validated statically or by smoke tests but still need

--- a/internal/cliexit/exit_code_error.go
+++ b/internal/cliexit/exit_code_error.go
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Omkhar Arasaratnam
 
-// Package cliexit is the canonical exit-code error type used by all
-// workcell Go CLI translations. Each translated bash main returns
-// ExitCodeError when the wrapper main() should propagate a specific
-// exit code; cmd/workcell-hostutil/main.go (and the sibling umbrella
-// binaries) match it with errors.As and propagate the Code.
+// Package cliexit carries an explicit os.Exit code through Go's error
+// chain so a wrapper main() can preserve a specific exit code instead
+// of always returning 1.  Originally introduced for the bash→Go CLI
+// translation work (each translated main returns ExitCodeError so the
+// shell-level contract survives), now the canonical exit-code type
+// for every workcell Go CLI — including binaries (cmd/workcell-citools)
+// that have no bash predecessor.
 package cliexit
 
 import "errors"

--- a/internal/host/release/doc.go
+++ b/internal/host/release/doc.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package release carries the GitHub release publication helpers
+// (create payload, metadata, asset name encoding, bundle manifest)
+// that the host-side `workcell-hostutil release` subcommands invoke.
+// The release workflow itself lives in .github/workflows/release.yml;
+// this package is the Go-side shape of the payloads it produces.
+package release

--- a/internal/host/sessions/doc.go
+++ b/internal/host/sessions/doc.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package sessions defines the on-disk record format and lookup
+// helpers for durable detached Workcell sessions.  The CLI surface
+// that consumes these records lives in internal/sessionctl; this
+// package owns the file/JSON layout, the StateDirs convention for
+// where sessions live on disk, and the helpers that read/write a
+// single session record.
+package sessions

--- a/internal/host/stateroot/doc.go
+++ b/internal/host/stateroot/doc.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package stateroot resolves and validates the durable workcell
+// state-root directory layout (the parent of session-record files,
+// audit dirs, profile lock dirs, and injection bundle caches).  It
+// keeps the path-derivation contract in one place so cleanup paths
+// (internal/host/hoststate) and the live launch path agree on which
+// directories to touch.
+package stateroot

--- a/internal/host/supportmatrix/doc.go
+++ b/internal/host/supportmatrix/doc.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package supportmatrix carries the host-side support tier
+// classification: which macOS versions are tested vs preview, which
+// CPU architectures and Colima versions are supported, and the policy
+// entries that policy/host-support-matrix.tsv expresses.  The launch
+// path uses this to fail-fast on unsupported hosts and to decide
+// which assurance label a session entry record should carry.
+package supportmatrix

--- a/internal/metadatautil/doc.go
+++ b/internal/metadatautil/doc.go
@@ -1,5 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Omkhar Arasaratnam
 
-// Package metadatautil validates and manages repository metadata artifacts.
+// Package metadatautil carries the validators and contract-shape
+// helpers for the repository-owned metadata artifacts that CI and
+// release lanes consume.  It groups several related but distinct
+// surfaces:
+//
+//   - provider-bumps:        policy/provider-bumps.toml cool-off contract
+//   - workflow-lanes:        per-lane validate/release matrix shape
+//   - coverage:              repo coverage metadata
+//   - operator-contract:     repo-owned operator-action shape
+//   - reproducible-build:    build-input manifest contract
+//   - requirements:          adapter requirements shape
+//   - validation-tools:      validator-image tooling pins
+//   - workflow-validation:   GitHub workflow shape pins
+//
+// Some related surfaces have already been extracted into sibling
+// packages (hostedcontrols/, pinnedinputs/, workflows/); the rest
+// remain here for now.  The package's `*util` suffix predates the
+// project's "name by role" convention — see CONTRIBUTING.md for the
+// guidance on new package names.
 package metadatautil

--- a/internal/providerid/doc.go
+++ b/internal/providerid/doc.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package providerid is the canonical source of supported provider
+// id strings (Codex, Claude, Gemini today; Copilot is a roadmap
+// addition).  Every other package that needs a provider name
+// imports the constants here rather than redeclaring them, so
+// adding or renaming a provider is a single-package edit.
+package providerid

--- a/internal/publishpr/doc.go
+++ b/internal/publishpr/doc.go
@@ -1,35 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Omkhar Arasaratnam
 
-// Package publishpr carries the `workcell publish-pr` user interface
-// that historically lived in scripts/workcell as the publish_pr_*
-// bash functions.  The package owns four concerns:
+// Package publishpr carries the `workcell publish-pr` user interface.
+// It owns four concerns:
 //
 //   - UsageText: the help banner emitted on -h / --help and on usage
 //     errors.
 //
 //   - Argument parsing and validation: ParseArgs walks the publish-pr
-//     option vector with the same diagnostics the bash function did;
-//     ValidateSnapshotName, ValidateBranchName, and ValidateBaseName
-//     mirror the validate_publish_* bash helpers; LoadTextArg reconciles
-//     inline vs --*-file inputs; Preflight bundles the validators with
-//     base-mode downgrade and text-arg loading into one pass.
-//     RepoOwnedChecksExpected mirrors publish_pr_repo_owned_checks_expected
-//     so the dry-run output keeps byte-identical literals.
+//     option vector; ValidateSnapshotName, ValidateBranchName, and
+//     ValidateBaseName check inputs; LoadTextArg reconciles inline vs
+//     --*-file inputs; Preflight bundles validators with base-mode
+//     downgrade and text-arg loading into one pass.
+//     RepoOwnedChecksExpected returns the byte-identical literals the
+//     dry-run output expects.
 //
 //   - Host execution layer: BashContext + RunPublishHostCommandInDir +
-//     the resolved git/gh wrappers (runCleanGit, etc.) drive the host-
-//     side process control under the env -i sandbox.  IsTrustedHostToolPath,
+//     the resolved git/gh wrappers (runCleanGit, etc.) drive host-side
+//     process control under an env -i sandbox.  IsTrustedHostToolPath,
 //     CanonicalizeHostToolPath, ResolveHostTool, and
-//     ResolveExistingExecutableOrDie own the trusted-PATH allowlist
-//     that scripts/workcell::is_trusted_host_tool_path enforces.
+//     ResolveExistingExecutableOrDie own the trusted-PATH allowlist.
 //
-//   - Dry-run emission: EmitCommand + bashQuote replicate the
+//   - Dry-run emission: EmitCommand + bashQuote produce the
 //     `printf %q` shape that
-//     tests/scenarios/shared/test-publish-pr-dry-run.sh greps for.
+//     tests/scenarios/shared/test-publish-pr-dry-run.sh asserts on.
 //
 // PublishPRMain wires the four concerns together as the entry point
-// for the top-level `workcell-hostutil publish-pr-cli` subcommand;
-// scripts/workcell publish_pr_main is the thin shim that forwards
-// bash-side globals as --bash-* flags.
+// for the top-level `workcell-hostutil publish-pr-cli` subcommand.
 package publishpr

--- a/internal/sessionctl/dispatch.go
+++ b/internal/sessionctl/dispatch.go
@@ -59,12 +59,16 @@ func dispatchMain(args []string, stdout io.Writer) error {
 	return shellproto.WriteField(stdout, "subcommand", resolved)
 }
 
-// CanonicalSubcommands returns the ordered list of user-facing
-// `workcell session` subcommand tokens.  The order matches the bash
-// session_main case statement in scripts/workcell so usage prose, the
-// bash dispatcher, and the Go dispatcher all agree on a single
-// authoritative ordering.  A fresh slice is returned on every call so
-// callers may mutate it freely.
+// CanonicalSubcommands returns the ordered list of `workcell session`
+// dispatch tokens.  The order matches the bash session_main case
+// statement in scripts/workcell so usage prose, the bash dispatcher,
+// and the Go dispatcher all agree on a single authoritative ordering.
+// `monitor` is the internal supervisor verb that `session start`
+// invokes against itself, not a user-facing subcommand — `man
+// workcell.1` and `README.md` document the user surface as
+// start|attach|send|stop|list|show|delete|logs|timeline|diff|export.
+// A fresh slice is returned on every call so callers may mutate it
+// freely.
 func CanonicalSubcommands() []string {
 	return []string{
 		"start",

--- a/internal/sessionctl/doc.go
+++ b/internal/sessionctl/doc.go
@@ -36,10 +36,11 @@
 //
 // DispatchMain is the Go translation of the session_main dispatcher
 // case statement.  It uses CanonicalSubcommands() as the single
-// authoritative list of user-facing subcommand tokens (start, attach,
-// send, stop, list, show, delete, logs, timeline, diff, export,
-// monitor) so the dispatch table, usage prose, and any future tooling
-// share one source of truth.
+// authoritative ordering of dispatch tokens (start, attach, send,
+// stop, list, show, delete, logs, timeline, diff, export, monitor).
+// The user-facing surface documented in man/workcell.1 and README.md
+// is the first eleven tokens; `monitor` is the internal supervisor
+// verb that `start` invokes against itself.
 //
 // The host-side session-record schema and lookup helpers stay in the
 // neighbouring internal/host/sessions package (different concern: that

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -232,10 +232,12 @@ Ignore
 .I ~/.config/workcell/injection-policy.toml
 for this launch even if it exists.
 .TP
-.B --ui cli|gui
-Select the surface to launch. Only
-.BR cli
-is currently implemented as a preserved-boundary path.
+.B --ui cli
+Select the surface to launch. Current releases only accept
+.BR cli ;
+the
+.BR gui
+value is a planned roadmap surface and is not yet implemented.
 .TP
 .B --mode strict|development|build|breakglass
 Select the runtime profile. The default is


### PR DESCRIPTION
## Summary

Documentation and naming fixes from the sethify documentation/naming review. Two focused commits, no behavior change.

- \`5cc48f3\` ^d **Internal package doc comments** — five new \`doc.go\` files for previously-undocumented internal packages (\`internal/host/sessions\`, \`release\`, \`stateroot\`, \`supportmatrix\`, \`internal/providerid\`). Expanded prose for \`internal/metadatautil\`, \`internal/cliexit\`, \`internal/publishpr\`, and \`internal/sessionctl\`. Drops stale "bash translation" framing where the migration is no longer accurate (\`cliexit\` is used by binaries with no bash predecessor). \`sessionctl.CanonicalSubcommands\` comment now correctly notes \`monitor\` is internal, not user-facing.

- \`e883f6d\` ^D **User-facing docs and naming**:
  - \`man/workcell.1\`: restrict \`--ui\` to \`cli\`; mark \`gui\` as roadmap-only (was documented but rejected at runtime).
  - \`README.md\` "Mode map": four \`--mode\` rows instead of conflating \`--container-mutability\` with the enum; \`--container-mutability\` documented as orthogonal.
  - \`ROADMAP.md\`: \`preserve-boundary\` → \`preserved-boundary\` (3/4 docs already used the latter).
  - \`docs/scenario-gaps.md\`: remove Copilot from "Highest-value gaps" — ROADMAP and use-case-matrix already classify it as a planned gap with no current support claim.
  - \`adapters/codex/README.md\`: spell out that \`.codex/rules/\` ships one \`default.rules\` file today, not a tree.
  - \`adapters/README.md\`: pointer to \`internal/adapters/data.go\` for Go-side registration.
  - \`CONTRIBUTING.md\`: new "Package naming" subsection — name by role for new packages; existing \`*util\` packages are not retargeted for in-place rename.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` green
- [ ] CI Docs lane (man-page diff, markdownlint, codespell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)