### PR TITLE
^R Extract shared PolicySource type into internal/injectionpolicy (closes #274)

### DIFF
--- a/internal/authpolicy/policy.go
+++ b/internal/authpolicy/policy.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/omkhar/workcell/internal/injectionpolicy"
 	"github.com/omkhar/workcell/internal/pathutil"
 	"github.com/omkhar/workcell/internal/providerid"
 	"github.com/omkhar/workcell/internal/rootio"
@@ -86,10 +87,12 @@ func init() {
 	}
 }
 
-type PolicySource struct {
-	Path   string
-	SHA256 string
-}
+// PolicySource is an alias for injectionpolicy.PolicySource — the
+// canonical cross-package type.  The injectionpolicy form carries
+// json tags (path/sha256); this package was using the bare uppercase
+// SHA256 form before unification.  Call sites that used `.SHA256`
+// must be renamed to `.Sha256` for the alias to compile.
+type PolicySource = injectionpolicy.PolicySource
 
 func die(message string) error {
 	return fmt.Errorf("%s", message)
@@ -369,7 +372,7 @@ func compositePolicySHA256(policySources []PolicySource) string {
 		b.WriteString("{'path': ")
 		b.WriteString(pythonReprString(source.Path))
 		b.WriteString(", 'sha256': ")
-		b.WriteString(pythonReprString(source.SHA256))
+		b.WriteString(pythonReprString(source.Sha256))
 		b.WriteByte('}')
 	}
 	b.WriteByte(']')
@@ -636,7 +639,7 @@ func loadPolicyBundleWithState(policyPath string, entrypointRoot string, activeS
 	}
 	policySources = append(policySources, PolicySource{
 		Path:   logicalPath,
-		SHA256: sourceSHA,
+		Sha256: sourceSHA,
 	})
 	return merged, policySources, nil
 }

--- a/internal/authresolve/resolve_credential_sources.go
+++ b/internal/authresolve/resolve_credential_sources.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/omkhar/workcell/internal/cliexit"
+	"github.com/omkhar/workcell/internal/injectionpolicy"
 	"github.com/omkhar/workcell/internal/providerid"
 	"github.com/omkhar/workcell/internal/rootio"
 	"github.com/omkhar/workcell/internal/secretfile"
@@ -109,11 +110,10 @@ var (
 	}()
 )
 
-// PolicySource is the per-policy-file metadata this resolver emits.
-type PolicySource struct {
-	Path   string `json:"path"`
-	Sha256 string `json:"sha256"`
-}
+// PolicySource is an alias for injectionpolicy.PolicySource — the
+// canonical cross-package type.  Kept exported here for callers that
+// have always imported it as authresolve.PolicySource.
+type PolicySource = injectionpolicy.PolicySource
 
 type config struct {
 	policyPath     string

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -21,6 +21,7 @@ import (
 	"syscall"
 
 	"github.com/omkhar/workcell/internal/adapters"
+	"github.com/omkhar/workcell/internal/injectionpolicy"
 	"github.com/omkhar/workcell/internal/pathutil"
 	"github.com/omkhar/workcell/internal/providerid"
 	"github.com/omkhar/workcell/internal/tomlsubset"
@@ -109,10 +110,11 @@ var (
 	}
 )
 
-type PolicySource struct {
-	Path   string `json:"path"`
-	Sha256 string `json:"sha256"`
-}
+// PolicySource is an alias for injectionpolicy.PolicySource — the
+// canonical cross-package type.  Kept exported here for callers that
+// have always imported it as injection.PolicySource; new code should
+// reach for injectionpolicy.PolicySource directly.
+type PolicySource = injectionpolicy.PolicySource
 
 func ValidateRenderAgentMode(agent, mode string) error {
 	if _, ok := supportedAgents[agent]; !ok {

--- a/internal/injectionpolicy/types.go
+++ b/internal/injectionpolicy/types.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package injectionpolicy holds the types and helpers shared across
+// the workcell injection-policy engines (internal/authpolicy,
+// internal/authresolve, internal/injection).  Historically each
+// package maintained its own copy of PolicySource and a handful of
+// load/parse helpers; drift between the copies caused at least one
+// silent-empty-hash regression (see commit 2d4c27f in PR #267).  This
+// package is the single source of truth for the cross-package types.
+//
+// Per-package implementations of policy loading, validation, and
+// bundle rendering remain in their own packages — they have subtle
+// differences (e.g. Path-typed paths in internal/injection vs raw
+// strings in internal/authpolicy) that are not load-bearing enough
+// to force a full unification yet.  An issue tracks the follow-up
+// function-dedup work; this package is the type-level first step.
+package injectionpolicy
+
+// PolicySource is the per-policy-file metadata that every
+// injection-policy reader emits.  Field names + JSON tags here are
+// the canonical form; package-local types in authpolicy/injection/
+// authresolve must alias this type rather than re-declare it.
+type PolicySource struct {
+	// Path is the logical (entrypoint-relative when known, otherwise
+	// absolute) path of the policy file.
+	Path string `json:"path"`
+	// Sha256 is the "sha256:<hex>" content digest of the policy file.
+	// The "sha256:" prefix is part of the value; downstream consumers
+	// rely on the prefix to distinguish the digest from a bare hex
+	// string.
+	Sha256 string `json:"sha256"`
+}


### PR DESCRIPTION
## Summary

Closes #274 (first step). The \`PolicySource\` struct lived in three places with subtly different field names:

| Package | Definition |
|---|---|
| \`internal/authpolicy\` | \`Path string; SHA256 string\` (no JSON tags) |
| \`internal/injection\` | \`Path string \`json:"path"\`; Sha256 string \`json:"sha256"\`\` |
| \`internal/authresolve\` | \`Path string \`json:"path"\`; Sha256 string \`json:"sha256"\`\` |

Drift between the three had already caused a silent-empty-hash regression (fixed in PR #267). The \`authpolicy\` form's uppercase \`SHA256\` field meant emitting a manifest from authpolicy and from injection produced JSON with different keys.

## Changes

- **New** \`internal/injectionpolicy/types.go\` with the canonical \`PolicySource\` (\`Path string + Sha256 string + json tags\`).
- \`authpolicy.PolicySource\`, \`injection.PolicySource\`, \`authresolve.PolicySource\` are now \`type PolicySource = injectionpolicy.PolicySource\` aliases — callers outside each package keep their existing import paths.
- In \`authpolicy/policy.go\`: \`source.SHA256\` → \`source.Sha256\` (2 call sites), \`SHA256: sourceSHA\` → \`Sha256: sourceSHA\` (1 call site).

## Why this isn't the full closure of #274

The issue also calls out 9 duplicate functions (\`validateSourcePath\`, \`expandHostPath\`, \`requirePathWithin\`, \`parseTOMLSubset\`, \`extractCopiesBlocks\`, \`readCopiesBlock\`, \`selectedFor\`, \`loadPolicyBundle\` + recursive variant). Those have subtle behavior differences between authpolicy (raw \`string\` paths) and injection (typed \`Path\`) that need careful reconciliation; lifting them now risks behavior change.

This PR is the no-risk type-level consolidation that forces all three packages to commit to one wire format. The function dedup will follow as a separate review unit. **Issue #274 stays open** until the functions are extracted too.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` green
- [ ] CI verify-invariants and pr-parity lanes

🤖 Generated with [Claude Code](https://claude.com/claude-code)