### PR TITLE
^B Revert defaults block from scorecard.yml (main-CI fix)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,9 +10,12 @@ on:
 
 permissions: {}
 
-defaults:
-  run:
-    shell: bash --noprofile --norc -euo pipefail {0}
+# Note: scorecard.yml intentionally does NOT carry a workflow-level
+# `defaults:` block.  The ossf/scorecard-action rejects workflows with
+# global env vars or `defaults`
+# (https://github.com/ossf/scorecard-action#workflow-restrictions), so
+# the strict-bash defaults that every other workflow uses cannot be
+# applied here.  Steps that need strict mode must set it inline.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Caught immediately after PR #268 merged to main: the new \`defaults:\` block in scorecard.yml broke the ossf/scorecard-action workflow verification with:

\`\`\`
workflow verification failed: workflow contains global env vars or defaults,
see https://github.com/ossf/scorecard-action#workflow-restrictions
\`\`\`

Per [scorecard-action restrictions](https://github.com/ossf/scorecard-action#workflow-restrictions), scorecard.yml must not have a workflow-level \`defaults:\` block.

## Fix

Revert scorecard.yml to no defaults. Every other workflow keeps its strict-bash defaults. Adds an inline comment explaining the exception.

## Test plan
- [x] actionlint clean
- [ ] CI Scorecard lane passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)