### PR TITLE
Fix upstream refresh and bootstrap network resilience

### DIFF
--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -544,6 +544,10 @@ func TestUpdateUpstreamPinsRefreshesReviewedSources(t *testing.T) {
 		"https://api.github.com/repos/sigstore/cosign/releases/latest",
 		"https://api.github.com/repos/anchore/syft/releases/latest",
 		"https://api.github.com/repos/rhysd/actionlint/releases/latest",
+		"Accept: application/octet-stream",
+		"github_release_asset_api_url",
+		`-D "${headers_file}"`,
+		`curl -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "${location}"`,
 		"https://api.github.com/repos/hadolint/hadolint/releases/latest",
 		"hub.docker.com/v2/repositories/tonistiigi/binfmt/tags",
 		"docker buildx imagetools inspect",
@@ -556,6 +560,15 @@ func TestUpdateUpstreamPinsRefreshesReviewedSources(t *testing.T) {
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("%s does not contain %q", scriptPath, want)
+		}
+	}
+
+	for _, want := range []string{
+		`actionlint_checksums_url="$(github_release_asset_api_url "${actionlint_release_json}" "actionlint_${target_actionlint_version}_checksums.txt")"`,
+		`github_release_asset_get "${actionlint_checksums_url}" |`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("actionlint checksum path in %s does not contain %q", scriptPath, want)
 		}
 	}
 }

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -32,7 +32,17 @@ ENV npm_config_update_notifier=false
 RUN fetch_snapshot_bootstrap_package() { \
       local url="$1"; \
       local output="$2"; \
-      node -e 'const fs = require("fs"); (async () => { const [url, output] = process.argv.slice(1); const response = await fetch(url); if (!response.ok) { throw new Error("unexpected status " + response.status + " for " + url); } const file = fs.createWriteStream(output); for await (const chunk of response.body) { file.write(chunk); } file.end(); await new Promise((resolve, reject) => { file.on("finish", resolve); file.on("error", reject); }); })().catch((error) => { console.error(error.stack || error); process.exit(1); });' "${url}" "${output}"; \
+      local attempt=""; \
+      for attempt in 1 2 3; do \
+        if node -e 'const fs = require("fs"); (async () => { const [url, output] = process.argv.slice(1); const response = await fetch(url); if (!response.ok) { throw new Error("unexpected status " + response.status + " for " + url); } const file = fs.createWriteStream(output); for await (const chunk of response.body) { file.write(chunk); } file.end(); await new Promise((resolve, reject) => { file.on("finish", resolve); file.on("error", reject); }); })().catch((error) => { console.error(error.stack || error); process.exit(1); });' "${url}" "${output}"; then \
+          return 0; \
+        fi; \
+        rm -f "${output}"; \
+        if [[ "${attempt}" -eq 3 ]]; then \
+          return 1; \
+        fi; \
+        sleep "$((attempt * 5))"; \
+      done; \
     } \
   && bootstrap_snapshot_tls() { \
        local openssl_url="" openssl_sha256="" ca_url="" ca_sha256=""; \
@@ -52,11 +62,12 @@ RUN fetch_snapshot_bootstrap_package() { \
        esac; \
        ca_url="https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/pool/main/c/ca-certificates/ca-certificates_20250419_all.deb"; \
        ca_sha256="ef590f89563aa4b46c8260d49d1cea0fc1b181d19e8df3782694706adf05c184"; \
-       fetch_snapshot_bootstrap_package "${openssl_url}" /tmp/workcell-bootstrap-openssl.deb; \
-       echo "${openssl_sha256}  /tmp/workcell-bootstrap-openssl.deb" | sha256sum -c -; \
-       fetch_snapshot_bootstrap_package "${ca_url}" /tmp/workcell-bootstrap-ca-certificates.deb; \
-       echo "${ca_sha256}  /tmp/workcell-bootstrap-ca-certificates.deb" | sha256sum -c -; \
-       dpkg -i /tmp/workcell-bootstrap-openssl.deb /tmp/workcell-bootstrap-ca-certificates.deb; \
+       fetch_snapshot_bootstrap_package "${openssl_url}" /tmp/workcell-bootstrap-openssl.deb \
+       && echo "${openssl_sha256}  /tmp/workcell-bootstrap-openssl.deb" | sha256sum -c - \
+       && fetch_snapshot_bootstrap_package "${ca_url}" /tmp/workcell-bootstrap-ca-certificates.deb \
+       && echo "${ca_sha256}  /tmp/workcell-bootstrap-ca-certificates.deb" | sha256sum -c - \
+       && dpkg -i /tmp/workcell-bootstrap-openssl.deb /tmp/workcell-bootstrap-ca-certificates.deb \
+       || return 1; \
        rm -f /tmp/workcell-bootstrap-openssl.deb /tmp/workcell-bootstrap-ca-certificates.deb; \
      } \
   && bootstrap_snapshot_tls \

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "9eca99faf0c4ecf0ec675c4f2d6f3397211d89e4f78982d714e9f9df9e21c076"
+      "sha256": "61936307498106949c07beefec894657d63cab8986f0c9d6b0a47cfe6c7409a0"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/colima-egress-allowlist.sh
+++ b/scripts/colima-egress-allowlist.sh
@@ -230,6 +230,15 @@ validate_endpoint() {
   fi
 }
 
+validate_endpoints() {
+  local endpoints="$1"
+  local endpoint=""
+
+  for endpoint in ${endpoints}; do
+    validate_endpoint "${endpoint}"
+  done
+}
+
 resolve_ips() {
   local host="$1"
   go_runtimeutil resolve-ips "${host}"
@@ -365,9 +374,7 @@ build_allowlist_rules() {
     "sudo ip6tables -A WORKCELL_EGRESS6 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT"
   )
 
-  for endpoint in ${endpoints}; do
-    validate_endpoint "${endpoint}"
-  done
+  validate_endpoints "${endpoints}"
 
   initialize_host_tools
 
@@ -420,7 +427,96 @@ fi
 sudo ip6tables -L WORKCELL_EGRESS6 >/dev/null 2>&1 || true
 EOF
   render_clear_plan
-  render_allowlist_plan
+  cat <<'EOF'
+sudo iptables -N WORKCELL_EGRESS 2>/dev/null || true
+sudo iptables -F WORKCELL_EGRESS
+sudo iptables -C DOCKER-USER -j WORKCELL_EGRESS 2>/dev/null || sudo iptables -I DOCKER-USER 1 -j WORKCELL_EGRESS
+sudo iptables -A WORKCELL_EGRESS -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+sudo ip6tables -N WORKCELL_EGRESS6 2>/dev/null || true
+sudo ip6tables -F WORKCELL_EGRESS6
+sudo ip6tables -C DOCKER-USER -j WORKCELL_EGRESS6 2>/dev/null || sudo ip6tables -I DOCKER-USER 1 -j WORKCELL_EGRESS6
+sudo ip6tables -A WORKCELL_EGRESS6 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+resolve_vm_endpoint_ips() {
+  local host="$1"
+  local ip=""
+  local rest=""
+
+  if ! type getent >/dev/null 2>&1; then
+    echo "Missing required VM resolver: getent" >&2
+    return 1
+  fi
+
+  if getent ahosts "${host}" 2>/dev/null | while read -r ip rest; do
+    [[ -n "${ip}" ]] || continue
+    printf '%s\n' "${ip}"
+  done; then
+    return 0
+  fi
+
+  getent hosts "${host}" 2>/dev/null | while read -r ip rest; do
+    [[ -n "${ip}" ]] || continue
+    printf '%s\n' "${ip}"
+  done
+}
+
+add_vm_endpoint_rules() {
+  local endpoint="$1"
+  local host=""
+  local port=""
+  local ip=""
+  local resolved_any=0
+
+  if [[ "${endpoint}" =~ ^\[([0-9A-Fa-f:.]+)\]:([0-9]{1,5})$ ]]; then
+    host="[${BASH_REMATCH[1]}]"
+    port="${BASH_REMATCH[2]}"
+  elif [[ "${endpoint}" =~ ^([^:]+):([0-9]{1,5})$ ]]; then
+    host="${BASH_REMATCH[1]}"
+    port="${BASH_REMATCH[2]}"
+  else
+    echo "Invalid endpoint host: ${endpoint}" >&2
+    exit 1
+  fi
+
+  if [[ "${host}" == \[*\] ]]; then
+    sudo ip6tables -A WORKCELL_EGRESS6 -p tcp -d "${host:1:${#host}-2}" --dport "${port}" -j ACCEPT
+    return 0
+  fi
+  if [[ "${host}" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+    sudo iptables -A WORKCELL_EGRESS -p tcp -d "${host}" --dport "${port}" -j ACCEPT
+    return 0
+  fi
+
+  while IFS= read -r ip; do
+    [[ -n "${ip}" ]] || continue
+    if [[ "${ip}" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+      sudo iptables -A WORKCELL_EGRESS -p tcp -d "${ip}" --dport "${port}" -j ACCEPT
+      resolved_any=1
+      continue
+    fi
+    if [[ "${ip}" == *:* ]]; then
+      sudo ip6tables -A WORKCELL_EGRESS6 -p tcp -d "${ip}" --dport "${port}" -j ACCEPT
+      resolved_any=1
+      continue
+    fi
+    echo "Resolver returned invalid IP address: ${ip}" >&2
+    exit 1
+  done < <(resolve_vm_endpoint_ips "${host}")
+
+  if [[ "${resolved_any}" -ne 1 ]]; then
+    echo "Resolver returned no IP addresses for: ${host}" >&2
+    exit 1
+  fi
+}
+EOF
+  printf 'WORKCELL_ENDPOINTS=%q\n' "${ENDPOINTS}"
+  cat <<'EOF'
+for endpoint in ${WORKCELL_ENDPOINTS}; do
+  add_vm_endpoint_rules "${endpoint}"
+done
+sudo iptables -A WORKCELL_EGRESS -j DROP
+sudo ip6tables -A WORKCELL_EGRESS6 -j DROP
+EOF
 }
 
 case "${COMMAND}" in
@@ -442,7 +538,7 @@ case "${COMMAND}" in
       echo "Missing endpoint list for apply" >&2
       exit 1
     }
-    build_allowlist_rules "${ENDPOINTS}"
+    validate_endpoints "${ENDPOINTS}"
     run_in_vm "$(render_allowlist_apply_plan)"
     ;;
   *)

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -100,6 +100,62 @@ github_release_asset_url() {
   printf '%s\n' "${asset_url}"
 }
 
+github_release_asset_api_url() {
+  local release_json="$1"
+  local asset_name="$2"
+  local asset_url
+  asset_url="$(jq -r --arg asset_name "${asset_name}" '.assets[] | select(.name == $asset_name) | .url' <<<"${release_json}")"
+  if [[ -z "${asset_url}" || "${asset_url}" == "null" ]]; then
+    echo "Unable to resolve release asset ${asset_name}" >&2
+    exit 1
+  fi
+  printf '%s\n' "${asset_url}"
+}
+
+github_release_asset_get() {
+  local url="$1"
+  local token="${WORKCELL_GITHUB_API_TOKEN:-${GITHUB_TOKEN:-}}"
+  local body_file=""
+  local headers_file=""
+  local location=""
+  local status=""
+
+  if [[ -n "${token}" ]]; then
+    headers_file="$(mktemp "${TMPDIR:-/tmp}/workcell-release-asset-headers.XXXXXX")"
+    body_file="$(mktemp "${TMPDIR:-/tmp}/workcell-release-asset-body.XXXXXX")"
+    trap 'rm -f "${headers_file}" "${body_file}"' RETURN
+
+    status="$(curl -fsS "${CURL_CHECKSUM_GUARDS[@]}" \
+      -D "${headers_file}" \
+      -o "${body_file}" \
+      -w '%{http_code}' \
+      -H "Accept: application/octet-stream" \
+      -H "Authorization: Bearer ${token}" \
+      "${url}")"
+    case "${status}" in
+      200)
+        cat "${body_file}"
+        ;;
+      3??)
+        location="$(sed -n 's/^[Ll][Oo][Cc][Aa][Tt][Ii][Oo][Nn]:[[:space:]]*//p' "${headers_file}" | tail -n 1 | tr -d '\r')"
+        if [[ -z "${location}" ]]; then
+          echo "GitHub release asset redirect did not include a Location header: ${url}" >&2
+          exit 1
+        fi
+        curl -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "${location}"
+        ;;
+      *)
+        echo "Unexpected GitHub release asset response ${status}: ${url}" >&2
+        exit 1
+        ;;
+    esac
+    rm -f "${headers_file}" "${body_file}"
+    trap - RETURN
+    return 0
+  fi
+  curl -fsSL "${CURL_CHECKSUM_GUARDS[@]}" -H "Accept: application/octet-stream" "${url}"
+}
+
 github_tag_commit_sha() {
   local repo="$1"
   local tag="$2"
@@ -366,9 +422,9 @@ target_syft_version="$(jq -r '.tag_name' <<<"${syft_release_json}")"
 
 actionlint_release_json="$(github_api_get 'https://api.github.com/repos/rhysd/actionlint/releases/latest')"
 target_actionlint_version="$(jq -r '.tag_name | sub("^v"; "")' <<<"${actionlint_release_json}")"
-actionlint_checksums_url="$(github_release_asset_url "${actionlint_release_json}" "actionlint_${target_actionlint_version}_checksums.txt")"
+actionlint_checksums_url="$(github_release_asset_api_url "${actionlint_release_json}" "actionlint_${target_actionlint_version}_checksums.txt")"
 target_actionlint_sha="$(
-  curl -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "${actionlint_checksums_url}" |
+  github_release_asset_get "${actionlint_checksums_url}" |
     awk '/actionlint_'"${target_actionlint_version}"'_linux_amd64\.tar\.gz$/ { print $1; exit }'
 )"
 

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2706,6 +2706,20 @@ for dockerfile in \
     echo "Expected ${dockerfile} to pin apt HTTPS timeout for snapshot fetch resilience" >&2
     exit 1
   fi
+  if ! rg -q 'for attempt in 1 2 3; do' "${dockerfile}" ||
+    ! rg -q 'rm -f "\$\{output\}";' "${dockerfile}" ||
+    ! rg -q 'sleep "\$\(\(attempt \* 5\)\)";' "${dockerfile}"; then
+    echo "Expected ${dockerfile} snapshot TLS bootstrap downloads to retry and discard partial packages" >&2
+    exit 1
+  fi
+  if ! rg -q 'fetch_snapshot_bootstrap_package "\$\{openssl_url\}" /tmp/workcell-bootstrap-openssl\.deb' "${dockerfile}" ||
+    ! rg -q '&& echo "\$\{openssl_sha256\}  /tmp/workcell-bootstrap-openssl\.deb" \| sha256sum -c -' "${dockerfile}" ||
+    ! rg -q '&& fetch_snapshot_bootstrap_package "\$\{ca_url\}" /tmp/workcell-bootstrap-ca-certificates\.deb' "${dockerfile}" ||
+    ! rg -q '&& echo "\$\{ca_sha256\}  /tmp/workcell-bootstrap-ca-certificates\.deb" \| sha256sum -c -' "${dockerfile}" ||
+    ! rg -q '&& dpkg -i /tmp/workcell-bootstrap-openssl\.deb /tmp/workcell-bootstrap-ca-certificates\.deb' "${dockerfile}"; then
+    echo "Expected ${dockerfile} snapshot TLS bootstrap to fail closed across download, checksum, and dpkg steps" >&2
+    exit 1
+  fi
 done
 
 for dockerfile in \

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2669,6 +2669,11 @@ if ! rg -q 'docker-images-prod\.[^.]+\.r2\.cloudflarestorage\.com:443' "${ROOT_D
   exit 1
 fi
 
+if ! rg -q 'production\.cloudfront\.docker\.com:443' "${ROOT_DIR}/scripts/workcell"; then
+  echo "Expected scripts/workcell bootstrap endpoints to allow Docker blob storage on CloudFront" >&2
+  exit 1
+fi
+
 if rg -q 'snapshot\.debian\.org:80' "${ROOT_DIR}/scripts/workcell"; then
   echo "Expected scripts/workcell bootstrap endpoints to avoid unused snapshot.debian.org:80 egress" >&2
   exit 1

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3738,6 +3738,18 @@ if ! function_block_contains_regex "${ROOT_DIR}/scripts/colima-egress-allowlist.
   echo "Expected dual-stack allowlist apply plan to include render_clear_plan" >&2
   exit 1
 fi
+if ! function_block_contains_regex "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" "render_allowlist_apply_plan" 'resolve_vm_endpoint_ips'; then
+  echo "Expected dual-stack allowlist apply plan to resolve hostnames inside the VM before applying rules" >&2
+  exit 1
+fi
+if ! function_block_contains_regex "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" "render_allowlist_apply_plan" 'getent ahosts'; then
+  echo "Expected dual-stack allowlist apply plan to use VM DNS results for hostname endpoints" >&2
+  exit 1
+fi
+if function_block_contains_regex "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" "render_allowlist_apply_plan" 'render_allowlist_plan'; then
+  echo "Expected dual-stack allowlist apply plan to avoid host-resolved endpoint rules" >&2
+  exit 1
+fi
 if function_block_contains_regex "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" "render_allowlist_apply_plan" '^[[:space:]]*clear_rules$'; then
   echo "Expected dual-stack allowlist apply plan to avoid invoking clear_rules during render" >&2
   exit 1
@@ -3760,12 +3772,22 @@ if ! "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" \
   echo "Expected dual-stack allowlist apply path to succeed under the test VM capture hook" >&2
   exit 1
 fi
-if ! grep -q 'sudo iptables -A WORKCELL_EGRESS -p tcp -d 127.0.0.1 --dport 443 -j ACCEPT' "${RUN_IN_VM_CAPTURE_DIR}/apply-default.script"; then
-  echo "Expected captured dual-stack apply script to include the IPv4 allowlist rule" >&2
+if ! grep -Fq 'WORKCELL_ENDPOINTS=127.0.0.1:443\ \[::1\]:443' "${RUN_IN_VM_CAPTURE_DIR}/apply-default.script"; then
+  echo "Expected captured dual-stack apply script to preserve the endpoint list for VM-side resolution" >&2
   exit 1
 fi
-if ! grep -q 'sudo ip6tables -A WORKCELL_EGRESS6 -p tcp -d ::1 --dport 443 -j ACCEPT' "${RUN_IN_VM_CAPTURE_DIR}/apply-default.script"; then
-  echo "Expected captured dual-stack apply script to include the IPv6 allowlist rule" >&2
+if ! grep -Fq 'resolve_vm_endpoint_ips()' "${RUN_IN_VM_CAPTURE_DIR}/apply-default.script"; then
+  echo "Expected captured dual-stack apply script to include the VM-side hostname resolver" >&2
+  exit 1
+fi
+# shellcheck disable=SC2016
+if ! grep -Fq 'sudo iptables -A WORKCELL_EGRESS -p tcp -d "${host}" --dport "${port}" -j ACCEPT' "${RUN_IN_VM_CAPTURE_DIR}/apply-default.script"; then
+  echo "Expected captured dual-stack apply script to preserve IPv4 literal allowlist handling" >&2
+  exit 1
+fi
+# shellcheck disable=SC2016
+if ! grep -Fq 'sudo ip6tables -A WORKCELL_EGRESS6 -p tcp -d "${host:1:${#host}-2}" --dport "${port}" -j ACCEPT' "${RUN_IN_VM_CAPTURE_DIR}/apply-default.script"; then
+  echo "Expected captured dual-stack apply script to preserve IPv6 literal allowlist handling" >&2
   exit 1
 fi
 if ! grep -q "COLIMA_HOME=${REAL_HOME}/.colima" "${RUN_IN_VM_CAPTURE_DIR}/apply-default.env"; then

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -7338,7 +7338,7 @@ prepare_workspace_control_plane_shadow() {
 }
 
 bootstrap_endpoints() {
-  echo "auth.docker.io:443 docker.io:443 index.docker.io:443 registry-1.docker.io:443 production.cloudflare.docker.com:443 docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443 github.com:443 objects.githubusercontent.com:443 release-assets.githubusercontent.com:443 registry.npmjs.org:443 storage.googleapis.com:443 snapshot.debian.org:443"
+  echo "auth.docker.io:443 docker.io:443 index.docker.io:443 registry-1.docker.io:443 production.cloudflare.docker.com:443 production.cloudfront.docker.com:443 docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443 github.com:443 objects.githubusercontent.com:443 release-assets.githubusercontent.com:443 registry.npmjs.org:443 storage.googleapis.com:443 snapshot.debian.org:443"
 }
 
 AGENT=""

--- a/tools/validator/Dockerfile
+++ b/tools/validator/Dockerfile
@@ -41,7 +41,17 @@ ENV RUSTUP_HOME=/usr/local/rustup
 RUN fetch_snapshot_bootstrap_package() { \
       local url="$1"; \
       local output="$2"; \
-      node -e 'const fs = require("fs"); (async () => { const [url, output] = process.argv.slice(1); const response = await fetch(url); if (!response.ok) { throw new Error("unexpected status " + response.status + " for " + url); } const file = fs.createWriteStream(output); for await (const chunk of response.body) { file.write(chunk); } file.end(); await new Promise((resolve, reject) => { file.on("finish", resolve); file.on("error", reject); }); })().catch((error) => { console.error(error.stack || error); process.exit(1); });' "${url}" "${output}"; \
+      local attempt=""; \
+      for attempt in 1 2 3; do \
+        if node -e 'const fs = require("fs"); (async () => { const [url, output] = process.argv.slice(1); const response = await fetch(url); if (!response.ok) { throw new Error("unexpected status " + response.status + " for " + url); } const file = fs.createWriteStream(output); for await (const chunk of response.body) { file.write(chunk); } file.end(); await new Promise((resolve, reject) => { file.on("finish", resolve); file.on("error", reject); }); })().catch((error) => { console.error(error.stack || error); process.exit(1); });' "${url}" "${output}"; then \
+          return 0; \
+        fi; \
+        rm -f "${output}"; \
+        if [[ "${attempt}" -eq 3 ]]; then \
+          return 1; \
+        fi; \
+        sleep "$((attempt * 5))"; \
+      done; \
     } \
   && bootstrap_snapshot_tls() { \
        local openssl_url="" openssl_sha256="" ca_url="" ca_sha256=""; \
@@ -61,11 +71,12 @@ RUN fetch_snapshot_bootstrap_package() { \
        esac; \
        ca_url="https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/pool/main/c/ca-certificates/ca-certificates_20250419_all.deb"; \
        ca_sha256="ef590f89563aa4b46c8260d49d1cea0fc1b181d19e8df3782694706adf05c184"; \
-       fetch_snapshot_bootstrap_package "${openssl_url}" /tmp/workcell-bootstrap-openssl.deb; \
-       echo "${openssl_sha256}  /tmp/workcell-bootstrap-openssl.deb" | sha256sum -c -; \
-       fetch_snapshot_bootstrap_package "${ca_url}" /tmp/workcell-bootstrap-ca-certificates.deb; \
-       echo "${ca_sha256}  /tmp/workcell-bootstrap-ca-certificates.deb" | sha256sum -c -; \
-       dpkg -i /tmp/workcell-bootstrap-openssl.deb /tmp/workcell-bootstrap-ca-certificates.deb; \
+       fetch_snapshot_bootstrap_package "${openssl_url}" /tmp/workcell-bootstrap-openssl.deb \
+       && echo "${openssl_sha256}  /tmp/workcell-bootstrap-openssl.deb" | sha256sum -c - \
+       && fetch_snapshot_bootstrap_package "${ca_url}" /tmp/workcell-bootstrap-ca-certificates.deb \
+       && echo "${ca_sha256}  /tmp/workcell-bootstrap-ca-certificates.deb" | sha256sum -c - \
+       && dpkg -i /tmp/workcell-bootstrap-openssl.deb /tmp/workcell-bootstrap-ca-certificates.deb \
+       || return 1; \
        rm -f /tmp/workcell-bootstrap-openssl.deb /tmp/workcell-bootstrap-ca-certificates.deb; \
      } \
   && bootstrap_snapshot_tls \


### PR DESCRIPTION
## Summary
- fetch actionlint release checksums through the GitHub release asset API without forwarding authorization across redirected asset hosts
- include Docker CloudFront bootstrap blobs in the allowlist and regenerated control-plane manifest
- make snapshot TLS bootstrap package fetching retry and fail closed
- resolve hostname bootstrap egress inside the Colima VM before programming allowlist rules

## Validation
- bash -n scripts/colima-egress-allowlist.sh scripts/verify-invariants.sh scripts/workcell
- shellcheck -x scripts/colima-egress-allowlist.sh scripts/verify-invariants.sh
- ./scripts/verify-control-plane-manifest.sh
- ./scripts/workcell --gc
- ./scripts/pre-merge.sh --profile pr-parity
