### PR TITLE
Keep Debian refreshes bootstrap-buildable

### DIFF
--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -553,6 +553,10 @@ func TestUpdateUpstreamPinsRefreshesReviewedSources(t *testing.T) {
 		"docker buildx imagetools inspect",
 		"https://snapshot.debian.org/archive/debian/",
 		"https://snapshot.debian.org/archive/debian-security/",
+		"debian_snapshot_has_bootstrap_packages",
+		"openssl_3.5.5-1~deb13u1_amd64.deb",
+		"openssl_3.5.5-1~deb13u1_arm64.deb",
+		"ca-certificates_20250419_all.deb",
 		"scripts/check-pinned-inputs.sh",
 		"UPSTREAM_REFRESH_WORKFLOW_PATH",
 		"current_upstream_refresh_cosign_version",
@@ -569,6 +573,82 @@ func TestUpdateUpstreamPinsRefreshesReviewedSources(t *testing.T) {
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("actionlint checksum path in %s does not contain %q", scriptPath, want)
+		}
+	}
+}
+
+func TestLatestDebianSnapshotRequiresBootstrapPackages(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "update-upstream-pins.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(content)
+
+	curlLogPath := filepath.Join(t.TempDir(), "curl.log")
+	code, output := runBashProbe(t, `set -euo pipefail
+`+extractShellFunction(t, script, "latest_debian_snapshot")+`
+`+extractShellFunction(t, script, "debian_snapshot_has_bootstrap_packages")+`
+
+date_stamp_for_offset() {
+  case "$1" in
+    0) printf '%s\n' 20260526T000000Z ;;
+    1) printf '%s\n' 20260525T000000Z ;;
+    2) printf '%s\n' 20260524T000000Z ;;
+    3) printf '%s\n' 20260523T000000Z ;;
+    4) printf '%s\n' 20260522T000000Z ;;
+    5) printf '%s\n' 20260521T000000Z ;;
+    6) printf '%s\n' 20260520T000000Z ;;
+    7) printf '%s\n' 20260519T000000Z ;;
+    8) printf '%s\n' 20260518T000000Z ;;
+    *) printf '%s\n' 20260517T000000Z ;;
+  esac
+}
+
+curl() {
+  local url="${*: -1}"
+  printf '%s\n' "${url}" >>"${WORKCELL_CURL_LOG}"
+  case "${url}" in
+    */dists/trixie/Release | */dists/trixie-updates/Release | */dists/trixie-security/Release)
+      return 0
+      ;;
+    */20260518T000000Z/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb | \
+    */20260518T000000Z/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_arm64.deb | \
+    */20260518T000000Z/pool/main/c/ca-certificates/ca-certificates_20250419_all.deb)
+      return 0
+      ;;
+    */pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb | \
+    */pool/main/o/openssl/openssl_3.5.5-1~deb13u1_arm64.deb | \
+    */pool/main/c/ca-certificates/ca-certificates_20250419_all.deb)
+      return 22
+      ;;
+  esac
+  return 1
+}
+
+latest_debian_snapshot
+`, map[string]string{"WORKCELL_CURL_LOG": curlLogPath})
+	if code != 0 {
+		t.Fatalf("probe exit code = %d output=%q", code, output)
+	}
+	if got := strings.TrimSpace(output); got != "20260518T000000Z" {
+		t.Fatalf("latest_debian_snapshot = %q, want 20260518T000000Z", got)
+	}
+
+	curlLog, err := os.ReadFile(curlLogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"https://snapshot.debian.org/archive/debian/20260526T000000Z/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb",
+		"https://snapshot.debian.org/archive/debian/20260518T000000Z/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb",
+		"https://snapshot.debian.org/archive/debian/20260518T000000Z/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_arm64.deb",
+		"https://snapshot.debian.org/archive/debian/20260518T000000Z/pool/main/c/ca-certificates/ca-certificates_20250419_all.deb",
+	} {
+		if !strings.Contains(string(curlLog), want) {
+			t.Fatalf("curl log does not contain %q; log=%s", want, curlLog)
 		}
 	}
 }
@@ -593,4 +673,23 @@ func TestPreMergeChecksPinnedUpstreams(t *testing.T) {
 			t.Fatalf("%s does not contain %q", scriptPath, want)
 		}
 	}
+}
+
+func extractShellFunction(tb testing.TB, script, name string) string {
+	tb.Helper()
+
+	start := strings.Index(script, name+"() {")
+	if start < 0 {
+		tb.Fatalf("script does not contain shell function %s", name)
+	}
+	lines := strings.Split(script[start:], "\n")
+	var extracted []string
+	for i, line := range lines {
+		extracted = append(extracted, line)
+		if i > 0 && strings.TrimSpace(line) == "}" {
+			return strings.Join(extracted, "\n")
+		}
+	}
+	tb.Fatalf("script shell function %s has no closing brace", name)
+	return ""
 }

--- a/scripts/ci/job-validate.sh
+++ b/scripts/ci/job-validate.sh
@@ -92,16 +92,9 @@ echo "[ci/validate] upstream Gemini release"
 
 if [[ "${PROFILE}" == "release-preflight" ]]; then
   # Pinned-upstream-refresh status: only on the release-preflight
-  # profile.  The intent was to also run this on pr-parity so a
-  # contributor who set WORKCELL_SKIP_UPSTREAM_REFRESH_PRECOMMIT=1 to
-  # bypass the local hook would still get caught before merge, but
-  # update-upstream-pins.sh does not currently rewrite the Dockerfile
-  # bootstrap openssl URL+SHA when DEBIAN_SNAPSHOT advances — the
-  # `--apply` half of the same tool produces a non-buildable Dockerfile
-  # under that drift, so gating PRs on `--check` would block routine
-  # work whenever snapshot drift exists.  The weekly pin-hygiene.yml
-  # cron lane stays as the primary drift-detection surface until
-  # update-upstream-pins.sh handles the bootstrap pins atomically.
+  # profile.  Routine PRs rely on the weekly pin-hygiene.yml cron lane
+  # for drift detection so unrelated reviews are not blocked by external
+  # upstream movement.
   echo "[ci/validate] pinned upstream refresh status"
   "${ROOT_DIR}/scripts/update-upstream-pins.sh" --check
 fi

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -321,13 +321,29 @@ latest_debian_snapshot() {
     stamp="$(date_stamp_for_offset "${offset}")"
     if curl -fsSI "https://snapshot.debian.org/archive/debian/${stamp}/dists/trixie/Release" >/dev/null &&
       curl -fsSI "https://snapshot.debian.org/archive/debian/${stamp}/dists/trixie-updates/Release" >/dev/null &&
-      curl -fsSI "https://snapshot.debian.org/archive/debian-security/${stamp}/dists/trixie-security/Release" >/dev/null; then
+      curl -fsSI "https://snapshot.debian.org/archive/debian-security/${stamp}/dists/trixie-security/Release" >/dev/null &&
+      debian_snapshot_has_bootstrap_packages "${stamp}"; then
       printf '%s\n' "${stamp}"
       return
     fi
   done
-  echo "Unable to resolve a recent Debian snapshot for trixie/trixie-updates/trixie-security" >&2
+  echo "Unable to resolve a recent Debian snapshot for trixie/trixie-updates/trixie-security with bootstrap packages" >&2
   exit 1
+}
+
+debian_snapshot_has_bootstrap_packages() {
+  local stamp="$1"
+  local base="https://snapshot.debian.org/archive/debian/${stamp}"
+  local path
+
+  for path in \
+    "pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb" \
+    "pool/main/o/openssl/openssl_3.5.5-1~deb13u1_arm64.deb" \
+    "pool/main/c/ca-certificates/ca-certificates_20250419_all.deb"; do
+    if ! curl -fsSI "${base}/${path}" >/dev/null 2>&1; then
+      return 1
+    fi
+  done
 }
 
 semver_patch_zero() {


### PR DESCRIPTION
## Summary
- require Debian snapshots to have the hard-coded bootstrap OpenSSL and ca-certificates packages before refresh selection
- add a functional regression test that skips snapshots missing those packages
- update the release-preflight pin-hygiene comment now that refreshes stay bootstrap-buildable

## Validation
- bash -n scripts/update-upstream-pins.sh scripts/ci/job-validate.sh
- shellcheck -x scripts/update-upstream-pins.sh scripts/ci/job-validate.sh
- go test ./internal/testkit
- ./scripts/update-upstream-pins.sh --check (expected drift rc=1; selected 20260518T000000Z and stderr empty)
- ./scripts/pre-merge.sh --profile pr-parity