### PR TITLE
Harden runtime build retry recovery

### DIFF
--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -33,12 +33,12 @@ RUN fetch_snapshot_bootstrap_package() { \
       local url="$1"; \
       local output="$2"; \
       local attempt=""; \
-      for attempt in 1 2 3; do \
-        if node -e 'const fs = require("fs"); (async () => { const [url, output] = process.argv.slice(1); const response = await fetch(url); if (!response.ok) { throw new Error("unexpected status " + response.status + " for " + url); } const file = fs.createWriteStream(output); for await (const chunk of response.body) { file.write(chunk); } file.end(); await new Promise((resolve, reject) => { file.on("finish", resolve); file.on("error", reject); }); })().catch((error) => { console.error(error.stack || error); process.exit(1); });' "${url}" "${output}"; then \
+      for attempt in 1 2 3 4 5 6 7 8; do \
+        if node --dns-result-order=ipv4first -e 'const fs = require("fs"); (async () => { const [url, output] = process.argv.slice(1); const response = await fetch(url); if (!response.ok) { throw new Error("unexpected status " + response.status + " for " + url); } const file = fs.createWriteStream(output); for await (const chunk of response.body) { file.write(chunk); } file.end(); await new Promise((resolve, reject) => { file.on("finish", resolve); file.on("error", reject); }); })().catch((error) => { console.error(error.stack || error); process.exit(1); });' "${url}" "${output}"; then \
           return 0; \
         fi; \
         rm -f "${output}"; \
-        if [[ "${attempt}" -eq 3 ]]; then \
+        if [[ "${attempt}" -eq 8 ]]; then \
           return 1; \
         fi; \
         sleep "$((attempt * 5))"; \

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "61936307498106949c07beefec894657d63cab8986f0c9d6b0a47cfe6c7409a0"
+      "sha256": "55cfee2e22657249e6074cdbaaca7303280dfde66874cd9b0a7efac8da2edc4c"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2462,6 +2462,19 @@ WORKCELL_START_TIMEOUT_CLEANUP_HARNESS="${BARRIER_VERIFY_ROOT}/workcell-start-ti
 } >"${WORKCELL_START_TIMEOUT_CLEANUP_HARNESS}"
 bash "${WORKCELL_START_TIMEOUT_CLEANUP_HARNESS}"
 
+WORKCELL_RUNTIME_BUILD_RETRY_HARNESS="${BARRIER_VERIFY_ROOT}/workcell-runtime-build-retry-harness.sh"
+{
+  printf 'set -euo pipefail\n'
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" write_latest_log_pointer
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" record_validated_profile_state
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" run_runtime_image_build_with_retries
+  printf '\n'
+  cat "${ROOT_DIR}/verify/invariants/harnesses/process-colima/workcell-runtime-build-retry.sh"
+} >"${WORKCELL_RUNTIME_BUILD_RETRY_HARNESS}"
+bash "${WORKCELL_RUNTIME_BUILD_RETRY_HARNESS}"
+
 if ! rg -q 'run_clean_host_command_in_dir "\$\{ROOT_DIR\}" env' "${ROOT_DIR}/scripts/workcell" ||
   ! rg -q 'GOPATH="\$\{GOPATH\}"' "${ROOT_DIR}/scripts/workcell" ||
   ! rg -q 'GOMODCACHE="\$\{GOMODCACHE\}"' "${ROOT_DIR}/scripts/workcell" ||

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -945,6 +945,7 @@ refresh_managed_profile() {
   local message="$1"
 
   echo "${message}" >&2
+  PROFILE_VALIDATED=0
   remember_profile_runtime_image_for_refresh "${COLIMA_PROFILE}"
   stash_profile_audit_log "${COLIMA_PROFILE}"
   reap_stale_profile_processes "${COLIMA_PROFILE}"
@@ -964,6 +965,17 @@ refresh_managed_profile() {
   PROFILE_PREEXISTED=0
   PROFILE_MARKER_WORKSPACE=""
   PROFILE_RUNNING=0
+}
+
+record_validated_profile_state() {
+  mkdir -p "$(profile_target_state_dir "${COLIMA_PROFILE}")" || return
+  restore_profile_audit_log "${COLIMA_PROFILE}" || return
+  ensure_session_audit_state || return
+  printf '%s\n' "${PROFILE_WORKSPACE_ROOT}" >"${PROFILE_MARKER}" || return
+  write_latest_log_pointer "${COLIMA_PROFILE}" debug "${DEBUG_LOG_PATH}" || return
+  write_latest_log_pointer "${COLIMA_PROFILE}" file-trace "${FILE_TRACE_LOG_PATH}" || return
+  write_latest_log_pointer "${COLIMA_PROFILE}" transcript "${AUDIT_TRANSCRIPT_PATH}" || return
+  PROFILE_VALIDATED=1
 }
 
 sanitize_host_docker_env() {
@@ -6143,7 +6155,7 @@ run_runtime_image_build_with_retries() {
   local build_source_date_epoch="$1"
   local build_status=0
   local attempt=1
-  local max_attempts=3
+  local max_attempts=5
   local codex_release_url=""
   local safe_builder_context=""
   local -a build_cmd=()
@@ -6160,6 +6172,7 @@ run_runtime_image_build_with_retries() {
       echo "Retrying the runtime image build for profile ${COLIMA_PROFILE} (attempt ${attempt}/${max_attempts})." >&2
       case "${TARGET_BACKEND}" in
         colima)
+          refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} after a failed runtime image build." || return 2
           start_managed_profile || build_status=$?
           if [[ "${build_status}" -eq 0 ]] &&
             ! validate_colima_profile "${COLIMA_PROFILE}" "${PROFILE_WORKSPACE_ROOT:-${WORKSPACE}}"; then
@@ -6169,6 +6182,9 @@ run_runtime_image_build_with_retries() {
               ! validate_colima_profile "${COLIMA_PROFILE}" "${PROFILE_WORKSPACE_ROOT:-${WORKSPACE}}"; then
               build_status=2
             fi
+          fi
+          if [[ "${build_status}" -eq 0 ]]; then
+            record_validated_profile_state
           fi
           ;;
         docker-desktop)
@@ -8305,14 +8321,7 @@ if [[ "${TARGET_BACKEND}" == "colima" ]]; then
     fi
   fi
 fi
-mkdir -p "$(profile_target_state_dir "${COLIMA_PROFILE}")"
-restore_profile_audit_log "${COLIMA_PROFILE}"
-ensure_session_audit_state
-printf '%s\n' "${PROFILE_WORKSPACE_ROOT}" >"${PROFILE_MARKER}"
-PROFILE_VALIDATED=1
-write_latest_log_pointer "${COLIMA_PROFILE}" debug "${DEBUG_LOG_PATH}"
-write_latest_log_pointer "${COLIMA_PROFILE}" file-trace "${FILE_TRACE_LOG_PATH}"
-write_latest_log_pointer "${COLIMA_PROFILE}" transcript "${AUDIT_TRANSCRIPT_PATH}"
+record_validated_profile_state
 
 if [[ "${TARGET_BACKEND}" == "colima" ]]; then
   export DOCKER_HOST="unix://${COLIMA_STATE_ROOT}/${COLIMA_PROFILE}/docker.sock"

--- a/tools/validator/Dockerfile
+++ b/tools/validator/Dockerfile
@@ -42,12 +42,12 @@ RUN fetch_snapshot_bootstrap_package() { \
       local url="$1"; \
       local output="$2"; \
       local attempt=""; \
-      for attempt in 1 2 3; do \
-        if node -e 'const fs = require("fs"); (async () => { const [url, output] = process.argv.slice(1); const response = await fetch(url); if (!response.ok) { throw new Error("unexpected status " + response.status + " for " + url); } const file = fs.createWriteStream(output); for await (const chunk of response.body) { file.write(chunk); } file.end(); await new Promise((resolve, reject) => { file.on("finish", resolve); file.on("error", reject); }); })().catch((error) => { console.error(error.stack || error); process.exit(1); });' "${url}" "${output}"; then \
+      for attempt in 1 2 3 4 5 6 7 8; do \
+        if node --dns-result-order=ipv4first -e 'const fs = require("fs"); (async () => { const [url, output] = process.argv.slice(1); const response = await fetch(url); if (!response.ok) { throw new Error("unexpected status " + response.status + " for " + url); } const file = fs.createWriteStream(output); for await (const chunk of response.body) { file.write(chunk); } file.end(); await new Promise((resolve, reject) => { file.on("finish", resolve); file.on("error", reject); }); })().catch((error) => { console.error(error.stack || error); process.exit(1); });' "${url}" "${output}"; then \
           return 0; \
         fi; \
         rm -f "${output}"; \
-        if [[ "${attempt}" -eq 3 ]]; then \
+        if [[ "${attempt}" -eq 8 ]]; then \
           return 1; \
         fi; \
         sleep "$((attempt * 5))"; \

--- a/verify/invariants/harnesses/process-colima/workcell-refresh.sh
+++ b/verify/invariants/harnesses/process-colima/workcell-refresh.sh
@@ -1,9 +1,11 @@
+# shellcheck shell=bash
 ROOT="$(mktemp -d)"
 COLIMA_PROFILE="refresh-fixture"
 PROFILE_WAS_REFRESHED=0
 PROFILE_PREEXISTED=1
 PROFILE_MARKER_WORKSPACE="bound"
 PROFILE_RUNNING=1
+PROFILE_VALIDATED=1
 
 stash_profile_audit_log() { :; }
 remember_profile_runtime_image_for_refresh() { :; }
@@ -29,3 +31,4 @@ refresh_managed_profile "refreshing fixture profile"
 [[ "${PROFILE_PREEXISTED}" -eq 0 ]]
 [[ -z "${PROFILE_MARKER_WORKSPACE}" ]]
 [[ "${PROFILE_RUNNING}" -eq 0 ]]
+[[ "${PROFILE_VALIDATED}" -eq 0 ]]

--- a/verify/invariants/harnesses/process-colima/workcell-runtime-build-retry.sh
+++ b/verify/invariants/harnesses/process-colima/workcell-runtime-build-retry.sh
@@ -1,0 +1,86 @@
+# shellcheck shell=bash disable=SC2034
+ROOT="$(mktemp -d)"
+COLIMA_PROFILE="runtime-build-retry-fixture"
+TARGET_BACKEND="colima"
+NETWORK_POLICY="disabled"
+BOOTSTRAP_ENDPOINTS=""
+SOURCE_DATE_EPOCH=1
+IMAGE_TAG="workcell-runtime:test"
+ROOT_DIR="${ROOT}/repo"
+WORKSPACE="${ROOT}/workspace"
+PROFILE_WORKSPACE_ROOT="${WORKSPACE}"
+PROFILE_MARKER="${ROOT}/state-${COLIMA_PROFILE}/workspace-root"
+DEBUG_LOG_PATH="${ROOT}/debug.log"
+FILE_TRACE_LOG_PATH="${ROOT}/file-trace.log"
+AUDIT_TRANSCRIPT_PATH="${ROOT}/transcript.log"
+SESSION_AUDIT_DIR="${ROOT}/session-audit"
+SESSION_AUDIT_STATE_FILE="${SESSION_AUDIT_DIR}/session-assurance"
+PROFILE_VALIDATED=1
+PROFILE_RUNNING=1
+REFRESH_COUNT=0
+START_COUNT=0
+VALIDATE_COUNT=0
+BUILD_COUNT=0
+SECURITY_COUNT=0
+SLEEP_COUNT=0
+RESTORE_COUNT=0
+ENSURE_AUDIT_COUNT=0
+
+mkdir -p "$(dirname "${PROFILE_MARKER}")" "${ROOT_DIR}" "${WORKSPACE}" "${SESSION_AUDIT_DIR}"
+printf 'stale\n' >"${PROFILE_MARKER}"
+
+profile_target_state_dir() { printf '%s/state-%s\n' "${ROOT}" "$1"; }
+profile_latest_log_pointer_path() { printf '%s/pointers/%s-%s\n' "${ROOT}" "$1" "$2"; }
+resolve_host_output_candidate() { printf '%s\n' "$1"; }
+restore_profile_audit_log() {
+  RESTORE_COUNT=$((RESTORE_COUNT + 1))
+}
+ensure_session_audit_state() {
+  ENSURE_AUDIT_COUNT=$((ENSURE_AUDIT_COUNT + 1))
+  mkdir -p "${SESSION_AUDIT_DIR}"
+  rm -f "${SESSION_AUDIT_STATE_FILE}"
+}
+resolve_codex_release_url() { return 0; }
+refresh_managed_profile() {
+  REFRESH_COUNT=$((REFRESH_COUNT + 1))
+  PROFILE_VALIDATED=0
+  rm -f "${PROFILE_MARKER}"
+}
+start_managed_profile() {
+  START_COUNT=$((START_COUNT + 1))
+  PROFILE_RUNNING=1
+}
+validate_colima_profile() {
+  VALIDATE_COUNT=$((VALIDATE_COUNT + 1))
+  return 0
+}
+validate_runtime_security_posture() {
+  SECURITY_COUNT=$((SECURITY_COUNT + 1))
+}
+ensure_workcell_selected_builder() { :; }
+buildx_cmd() { :; }
+run_command_with_debug_log() {
+  BUILD_COUNT=$((BUILD_COUNT + 1))
+  if [[ "${BUILD_COUNT}" -eq 1 ]]; then
+    return 37
+  fi
+  return 0
+}
+sleep() {
+  SLEEP_COUNT=$((SLEEP_COUNT + 1))
+}
+
+run_runtime_image_build_with_retries "${SOURCE_DATE_EPOCH}"
+[[ "${BUILD_COUNT}" -eq 2 ]]
+[[ "${REFRESH_COUNT}" -eq 1 ]]
+[[ "${START_COUNT}" -eq 1 ]]
+[[ "${VALIDATE_COUNT}" -eq 1 ]]
+[[ "${RESTORE_COUNT}" -eq 1 ]]
+[[ "${ENSURE_AUDIT_COUNT}" -eq 1 ]]
+[[ "${SECURITY_COUNT}" -eq 1 ]]
+[[ "${SLEEP_COUNT}" -eq 1 ]]
+[[ "${PROFILE_VALIDATED}" -eq 1 ]]
+[[ "$(cat "${PROFILE_MARKER}")" == "${PROFILE_WORKSPACE_ROOT}" ]]
+[[ -f "${ROOT}/pointers/${COLIMA_PROFILE}-debug" ]]
+[[ -f "${ROOT}/pointers/${COLIMA_PROFILE}-file-trace" ]]
+[[ -f "${ROOT}/pointers/${COLIMA_PROFILE}-transcript" ]]


### PR DESCRIPTION
## Summary
- refresh and revalidate the managed Colima profile before retrying failed runtime image builds
- re-record validated audit, marker, and latest-log state after retry recovery succeeds
- broaden snapshot bootstrap fetch retries and add a focused invariant harness for the retry path

## Validation
- ./scripts/pre-merge.sh --profile pr-parity --allow-dirty
- ./scripts/workcell --gc
- git diff --cached --check
- bash -n scripts/workcell scripts/verify-invariants.sh verify/invariants/harnesses/process-colima/workcell-refresh.sh verify/invariants/harnesses/process-colima/workcell-runtime-build-retry.sh
- ./scripts/verify-control-plane-manifest.sh

## Notes
- Published as a draft for the normal comment/check sweep.
- The signed commit intentionally skipped only the upstream-refresh pre-commit gate because pending pin refresh is a separate known review unit to run after this lands.
