### PR TITLE
Preserve refresh publication validation

### DIFF
--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "55cfee2e22657249e6074cdbaaca7303280dfde66874cd9b0a7efac8da2edc4c"
+      "sha256": "6810c253f0c572b6801fa47dbe3a7ce06e60fa0f20b33932ff26f9b3e218fc75"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/publish-upstream-refresh-pr.sh
+++ b/scripts/publish-upstream-refresh-pr.sh
@@ -25,6 +25,8 @@ signed draft PR through the repo-local parity-enforcing publication wrapper.
 Run this from a clean worktree. The disposable publication workspace is created
 from the latest available tip of the selected base branch, not the caller's
 current feature branch HEAD.
+The disposable publication workspace is placed under the repository git
+directory so local Docker parity jobs can mount it on macOS Colima hosts.
 EOF
 }
 
@@ -66,6 +68,22 @@ compute_patch_sha256() {
   local patch_path="$1"
   shasum -a 256 "${patch_path}" | awk '{print $1}'
 }
+
+make_repo_local_temp_dir() {
+  local purpose="$1"
+  local git_dir=""
+  local temp_parent=""
+
+  git_dir="$(git -C "${ROOT_DIR}" rev-parse --absolute-git-dir)"
+  temp_parent="${git_dir}/workcell-tmp"
+  mkdir -p "${temp_parent}"
+  mktemp -d "${temp_parent}/${purpose}.XXXXXX"
+}
+
+if [[ "${1:-}" == "--self-temp-root-probe" ]]; then
+  make_repo_local_temp_dir "workcell-upstream-refresh-probe"
+  exit 0
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -155,7 +173,7 @@ if [[ "${run_path}" != ".github/workflows/upstream-refresh.yml"* ]]; then
 fi
 
 artifact_root="$(mktemp -d "${TMPDIR:-/tmp}/workcell-upstream-refresh-artifact.XXXXXX")"
-worktree_root="$(mktemp -d "${TMPDIR:-/tmp}/workcell-upstream-refresh.XXXXXX")"
+worktree_root="$(make_repo_local_temp_dir "workcell-upstream-refresh")"
 title_file="$(mktemp "${TMPDIR:-/tmp}/workcell-upstream-refresh-title.XXXXXX")"
 body_file="$(mktemp "${TMPDIR:-/tmp}/workcell-upstream-refresh-body.XXXXXX.md")"
 commit_file="$(mktemp "${TMPDIR:-/tmp}/workcell-upstream-refresh-commit.XXXXXX.txt")"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2444,6 +2444,15 @@ WORKCELL_REFRESH_HARNESS="${BARRIER_VERIFY_ROOT}/workcell-refresh-harness.sh"
 } >"${WORKCELL_REFRESH_HARNESS}"
 bash "${WORKCELL_REFRESH_HARNESS}"
 
+WORKCELL_RUNTIME_IMAGE_REFRESH_CACHE_HARNESS="${BARRIER_VERIFY_ROOT}/workcell-runtime-image-refresh-cache-harness.sh"
+{
+  printf 'set -euo pipefail\n'
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" remember_profile_runtime_image_for_refresh
+  printf '\n'
+  cat "${ROOT_DIR}/verify/invariants/harnesses/process-colima/workcell-runtime-image-refresh-cache.sh"
+} >"${WORKCELL_RUNTIME_IMAGE_REFRESH_CACHE_HARNESS}"
+bash "${WORKCELL_RUNTIME_IMAGE_REFRESH_CACHE_HARNESS}"
+
 WORKCELL_START_RETRY_HARNESS="${BARRIER_VERIFY_ROOT}/workcell-start-retry-harness.sh"
 {
   printf 'set -euo pipefail\n'
@@ -2554,6 +2563,22 @@ for script in "${HOST_GATE_SCRIPTS[@]}"; do
     exit 1
   fi
 done
+
+publish_temp_probe="$("${ROOT_DIR}/scripts/publish-upstream-refresh-pr.sh" --self-temp-root-probe)"
+publish_git_dir="$(git -C "${ROOT_DIR}" rev-parse --absolute-git-dir)"
+if [[ ! -d "${publish_temp_probe}" ]]; then
+  echo "Expected upstream refresh publisher temp-root probe to create a directory" >&2
+  exit 1
+fi
+case "${publish_temp_probe}" in
+  "${publish_git_dir}"/workcell-tmp/workcell-upstream-refresh-probe.*) ;;
+  *)
+    echo "Expected upstream refresh publisher to create disposable PR worktrees under the repository git directory" >&2
+    echo "Found: ${publish_temp_probe}" >&2
+    exit 1
+    ;;
+esac
+rm -rf "${publish_temp_probe}"
 
 if [[ ! -x "${REPO_PRECOMMIT_HOOK}" ]]; then
   echo "Expected executable repo pre-commit hook: ${REPO_PRECOMMIT_HOOK}" >&2

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -3235,11 +3235,15 @@ remember_profile_runtime_image_for_refresh() {
   PROFILE_REFRESH_EXPECTED_SOURCE_DATE_EPOCH=""
   recorded_image_id="$(profile_image_marker_value "${profile}" image_id || true)"
   [[ -n "${recorded_image_id}" ]] || return 0
+  recorded_source_date_epoch="$(profile_image_marker_value "${profile}" source_date_epoch || true)"
   live_image_id="$(current_profile_image_id "${profile}")"
   if [[ -n "${live_image_id}" ]] && [[ "${live_image_id}" != "${recorded_image_id}" ]]; then
     return 0
   fi
-  recorded_source_date_epoch="$(profile_image_marker_value "${profile}" source_date_epoch || true)"
+  if ! profile_runtime_image_cache_matches "${profile}" "${recorded_image_id}" "${recorded_source_date_epoch}"; then
+    [[ -n "${live_image_id}" ]] || return 0
+    cache_profile_runtime_image "${profile}" "${recorded_image_id}" || return 0
+  fi
   PROFILE_REFRESH_EXPECTED_IMAGE_ID="${recorded_image_id}"
   PROFILE_REFRESH_EXPECTED_SOURCE_DATE_EPOCH="${recorded_source_date_epoch}"
 }

--- a/verify/invariants/harnesses/process-colima/workcell-runtime-image-refresh-cache.sh
+++ b/verify/invariants/harnesses/process-colima/workcell-runtime-image-refresh-cache.sh
@@ -1,0 +1,74 @@
+# shellcheck shell=bash disable=SC2034
+PROFILE_REFRESH_EXPECTED_IMAGE_ID=""
+PROFILE_REFRESH_EXPECTED_SOURCE_DATE_EPOCH=""
+MARKER_IMAGE="sha256:prepared"
+MARKER_SOURCE_DATE_EPOCH="12345"
+LIVE_IMAGE="${MARKER_IMAGE}"
+CACHE_MATCHES=0
+CACHE_CALLS=0
+CACHE_STATUS=0
+
+profile_image_marker_value() {
+  case "$2" in
+    image_id)
+      printf '%s\n' "${MARKER_IMAGE}"
+      ;;
+    source_date_epoch)
+      printf '%s\n' "${MARKER_SOURCE_DATE_EPOCH}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+current_profile_image_id() {
+  printf '%s\n' "${LIVE_IMAGE}"
+}
+
+profile_runtime_image_cache_matches() {
+  [[ "$1" == "refresh-cache-fixture" ]]
+  [[ "$2" == "${MARKER_IMAGE}" ]]
+  [[ "$3" == "${MARKER_SOURCE_DATE_EPOCH}" ]]
+  [[ "${CACHE_MATCHES}" -eq 1 ]]
+}
+
+cache_profile_runtime_image() {
+  CACHE_CALLS=$((CACHE_CALLS + 1))
+  [[ "$1" == "refresh-cache-fixture" ]]
+  [[ "$2" == "${MARKER_IMAGE}" ]]
+  return "${CACHE_STATUS}"
+}
+
+remember_profile_runtime_image_for_refresh "refresh-cache-fixture"
+[[ "${CACHE_CALLS}" -eq 1 ]]
+[[ "${PROFILE_REFRESH_EXPECTED_IMAGE_ID}" == "${MARKER_IMAGE}" ]]
+[[ "${PROFILE_REFRESH_EXPECTED_SOURCE_DATE_EPOCH}" == "${MARKER_SOURCE_DATE_EPOCH}" ]]
+
+CACHE_CALLS=0
+CACHE_MATCHES=1
+PROFILE_REFRESH_EXPECTED_IMAGE_ID=""
+PROFILE_REFRESH_EXPECTED_SOURCE_DATE_EPOCH=""
+remember_profile_runtime_image_for_refresh "refresh-cache-fixture"
+[[ "${CACHE_CALLS}" -eq 0 ]]
+[[ "${PROFILE_REFRESH_EXPECTED_IMAGE_ID}" == "${MARKER_IMAGE}" ]]
+[[ "${PROFILE_REFRESH_EXPECTED_SOURCE_DATE_EPOCH}" == "${MARKER_SOURCE_DATE_EPOCH}" ]]
+
+CACHE_CALLS=0
+CACHE_MATCHES=0
+LIVE_IMAGE=""
+PROFILE_REFRESH_EXPECTED_IMAGE_ID=""
+PROFILE_REFRESH_EXPECTED_SOURCE_DATE_EPOCH=""
+remember_profile_runtime_image_for_refresh "refresh-cache-fixture"
+[[ "${CACHE_CALLS}" -eq 0 ]]
+[[ -z "${PROFILE_REFRESH_EXPECTED_IMAGE_ID}" ]]
+[[ -z "${PROFILE_REFRESH_EXPECTED_SOURCE_DATE_EPOCH}" ]]
+
+CACHE_CALLS=0
+LIVE_IMAGE="sha256:other"
+PROFILE_REFRESH_EXPECTED_IMAGE_ID=""
+PROFILE_REFRESH_EXPECTED_SOURCE_DATE_EPOCH=""
+remember_profile_runtime_image_for_refresh "refresh-cache-fixture"
+[[ "${CACHE_CALLS}" -eq 0 ]]
+[[ -z "${PROFILE_REFRESH_EXPECTED_IMAGE_ID}" ]]
+[[ -z "${PROFILE_REFRESH_EXPECTED_SOURCE_DATE_EPOCH}" ]]


### PR DESCRIPTION
## Summary
- place upstream-refresh publication worktrees under the repository git directory so Colima-backed parity jobs can mount them
- preserve prepared runtime image cache metadata before managed profile refreshes and add a regression harness
- regenerate the control-plane manifest for the Workcell script change

## Validation
- ./scripts/verify-invariants.sh
- ./scripts/pre-merge.sh --profile pr-parity --allow-dirty
- staged tree matched .git/workcell-parity/pr-parity.json