### PR TITLE
Harden GitHub API redirect authentication

### DIFF
--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -544,6 +544,7 @@ func TestUpdateUpstreamPinsRefreshesReviewedSources(t *testing.T) {
 		"https://api.github.com/repos/sigstore/cosign/releases/latest",
 		"https://api.github.com/repos/anchore/syft/releases/latest",
 		"https://api.github.com/repos/rhysd/actionlint/releases/latest",
+		`--oauth2-bearer "${token}"`,
 		"Accept: application/octet-stream",
 		"github_release_asset_api_url",
 		`-D "${headers_file}"`,
@@ -574,6 +575,11 @@ func TestUpdateUpstreamPinsRefreshesReviewedSources(t *testing.T) {
 		if !strings.Contains(script, want) {
 			t.Fatalf("actionlint checksum path in %s does not contain %q", scriptPath, want)
 		}
+	}
+
+	githubAPIGet := extractShellFunction(t, script, "github_api_get")
+	if strings.Contains(githubAPIGet, `-H "Authorization: Bearer ${token}"`) {
+		t.Fatalf("github_api_get in %s must not follow redirects with a custom GitHub Authorization header", scriptPath)
 	}
 }
 

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -77,7 +77,7 @@ github_api_get() {
   if [[ -n "${token}" ]]; then
     curl -fsSL "${CURL_API_GUARDS[@]}" \
       -H "Accept: application/vnd.github+json" \
-      -H "Authorization: Bearer ${token}" \
+      --oauth2-bearer "${token}" \
       "${url}"
     return
   fi


### PR DESCRIPTION
## Summary

- use curl bearer auth for GitHub API requests instead of a custom Authorization header
- keep release-asset redirect handling unauthenticated on redirected asset hosts
- add a regression guard for the upstream pin updater helper

## Validation

- `bash -n scripts/update-upstream-pins.sh scripts/publish-github-release.sh`
- `shellcheck -x scripts/update-upstream-pins.sh scripts/publish-github-release.sh`
- `go test ./internal/testkit ./internal/metadatautil`
- `WORKCELL_GITHUB_API_TOKEN="$(gh auth token)" ./scripts/update-upstream-pins.sh --check`
- `./scripts/pre-merge.sh --profile pr-parity --allow-dirty`

## Security notes

This closes the remaining lower-risk redirect/auth pattern in the generic GitHub API helper. The actionlint release-asset path already separates the authenticated API request from the unauthenticated redirected asset download.
