### PR TITLE
Add repository readiness gate

### DIFF
--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -100,7 +100,8 @@ If the task is release-bound, also read:
   gate differently once a PR leaves draft.
 - If the task includes merging, re-check review surfaces immediately before
   merge, then follow merged `main` workflows until all repo-owned lanes are
-  green.
+  green. Scope hosted polling to the PR head SHA or merge SHA; historical
+  scheduled failures are triage inputs, not blockers for an unrelated SHA.
 - Do not accept failing repo-owned tests, checks, or workflows as acceptable
   residue. Fix them or explicitly change the claimed guarantee in the same
   review unit.
@@ -122,6 +123,10 @@ If the task is release-bound, also read:
    `./scripts/workcell publish-pr` path for explicit lower-assurance
    non-`main` exceptions or other repo-approved special cases.
 7. Follow repo-owned checks to completion.
+   Prefer required-check polling for merge gating:
+   `gh pr checks <pr-number> --repo <owner/repo> --required --watch`. Use the
+   full check list only as an advisory sweep so skipped non-required lanes do
+   not obscure the merge decision.
 8. If a repo-owned check fails:
    - inspect the failing GitHub Actions logs or PR checks
    - fix the underlying issue locally
@@ -137,7 +142,10 @@ If the task is release-bound, also read:
 12. If merge is part of the task, repeat the review sweep immediately before
     merge, merge, then follow merged `main` workflows until repo-owned lanes
     are green.
-13. If the task exposed a reusable PR-lifecycle or hosted-validation lesson,
+13. After merge follow-up, run the aggregate repository readiness gate:
+    `./scripts/check-repo-readiness.sh --repo <owner/repo> --base main`. Use
+    `--watch` when CI or maintenance workflows are still active.
+14. If the task exposed a reusable PR-lifecycle or hosted-validation lesson,
     update the relevant repo-local instructions in the same change stream or a
     separate follow-on PR.
 
@@ -163,3 +171,5 @@ Do not call PR work complete while any of these remain true:
 - repo-owned checks are still red or unreviewed
 - review surfaces still contain actionable findings
 - merged `main` workflows still show repo-owned failures for a merge task
+- `./scripts/check-repo-readiness.sh --base main` reports blocked after a
+  merge-everything or cleanup task

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -395,7 +395,8 @@ comments are addressed.
 Useful commands:
 
 ```sh
-gh pr checks <pr-number> --repo "${REPO}" --watch
+gh pr checks <pr-number> --repo "${REPO}" --required --watch
+gh pr checks <pr-number> --repo "${REPO}"
 gh pr view <pr-number> --repo "${REPO}" --comments
 ```
 
@@ -446,10 +447,11 @@ Example:
 
 ```sh
 gh run list --repo "${REPO}" --commit <main-commit-sha>
+./scripts/check-repo-readiness.sh --repo "${REPO}" --base main --watch
 ```
 
 Proceed only when every required workflow on the merge commit has completed
-successfully.
+successfully and the repository readiness gate reports `repo_readiness=ready`.
 
 Refresh the local repository so the merged `main` commit is present locally
 before tagging:

--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -348,7 +348,7 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err := CheckProviderBumpPolicy(cfg.ProviderBumpPolicyPath, cfg.RuntimeDockerfilePath, cfg.ProvidersPackageJSONPath); err != nil {
 		return err
 	}
-	if _, _, err := requireRegex(runtimeDockerfile, `curl -fsSL "https://storage\.googleapis\.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/\$\{CLAUDE_VERSION\}/\$\{CLAUDE_PLATFORM\}/claude"`, "Claude native release download URL", cfg.RuntimeDockerfilePath); err != nil {
+	if _, _, err := requireRegex(runtimeDockerfile, `curl --ipv4 -fsSL "https://storage\.googleapis\.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/\$\{CLAUDE_VERSION\}/\$\{CLAUDE_PLATFORM\}/claude"`, "Claude native release download URL", cfg.RuntimeDockerfilePath); err != nil {
 		return err
 	}
 	if _, match, err := requireRegex(runtimeDockerfile, `(?m)^\s*arm64\)\s+\\\s*CLAUDE_PLATFORM="([^"]+)";\s+\\\s*CLAUDE_SHA256="([0-9a-f]{64})";`, "arm64 Claude mapping", cfg.RuntimeDockerfilePath); err != nil {

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -76,6 +76,25 @@ RUN fetch_snapshot_bootstrap_package() { \
   && printf 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/%s trixie-updates main\n' "${DEBIAN_SNAPSHOT}" >> /etc/apt/sources.list \
   && printf 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/%s trixie-security main\n' "${DEBIAN_SNAPSHOT}" >> /etc/apt/sources.list \
   && printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99workcell-snapshot \
+  && apt_indexes_have_runtime_packages() { \
+       apt-cache show --no-all-versions \
+       bash \
+       bubblewrap \
+       ca-certificates \
+       curl \
+       fd-find \
+       git \
+       jq \
+       less \
+       openssh-client \
+       passwd \
+       procps \
+       ripgrep \
+       sudo \
+       unzip \
+       util-linux \
+       xz-utils >/dev/null; \
+     } \
   && install_runtime_packages() { \
        DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        bash \
@@ -96,12 +115,13 @@ RUN fetch_snapshot_bootstrap_package() { \
        xz-utils \
        && return 0; \
      } \
-  && for attempt in 1 2 3; do \
+  && for attempt in 1 2 3 4 5; do \
        if DEBIAN_FRONTEND=noninteractive apt-get update \
+         && apt_indexes_have_runtime_packages \
          && install_runtime_packages; then \
          break; \
        fi; \
-       if [[ "${attempt}" -eq 3 ]]; then \
+       if [[ "${attempt}" -eq 5 ]]; then \
          exit 1; \
        fi; \
        rm -rf /var/lib/apt/lists/*; \
@@ -205,18 +225,24 @@ COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo
 COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup
 
 # hadolint ignore=DL3008
-RUN install_runtime_builder_packages() { \
+RUN apt_indexes_have_runtime_builder_packages() { \
+      apt-cache show --no-all-versions \
+      gcc \
+      libc6-dev >/dev/null; \
+    } \
+  && install_runtime_builder_packages() { \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       gcc \
       libc6-dev \
       && return 0; \
     } \
-  && for attempt in 1 2 3; do \
+  && for attempt in 1 2 3 4 5; do \
        if DEBIAN_FRONTEND=noninteractive apt-get update \
+         && apt_indexes_have_runtime_builder_packages \
          && install_runtime_builder_packages; then \
          break; \
        fi; \
-       if [[ "${attempt}" -eq 3 ]]; then \
+       if [[ "${attempt}" -eq 5 ]]; then \
          exit 1; \
        fi; \
        rm -rf /var/lib/apt/lists/*; \
@@ -266,11 +292,11 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
       exit 1; \
       ;; \
   esac \
-  && curl -fsSL "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${CLAUDE_VERSION}/${CLAUDE_PLATFORM}/claude" \
-    --retry 5 \
+  && curl --ipv4 -fsSL "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${CLAUDE_VERSION}/${CLAUDE_PLATFORM}/claude" \
+    --retry 8 \
     --retry-all-errors \
     --retry-delay 5 \
-    --connect-timeout 20 \
+    --connect-timeout 30 \
     -o /tmp/claude \
   && echo "${CLAUDE_SHA256}  /tmp/claude" | sha256sum -c - \
   && install -m 0755 /tmp/claude /usr/local/libexec/workcell/real/claude \
@@ -303,18 +329,18 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
       ;; \
   esac \
   && if [[ -n "${CODEX_RELEASE_URL}" ]]; then \
-       curl -fsSL "${CODEX_RELEASE_URL}" \
-         --retry 5 \
+       curl --ipv4 -fsSL "${CODEX_RELEASE_URL}" \
+         --retry 8 \
          --retry-all-errors \
          --retry-delay 5 \
-         --connect-timeout 20 \
+         --connect-timeout 30 \
          -o /tmp/codex.tar.gz; \
      else \
-       curl -fsSL "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-${CODEX_ARCH}.tar.gz" \
-         --retry 5 \
+       curl --ipv4 -fsSL "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-${CODEX_ARCH}.tar.gz" \
+         --retry 8 \
          --retry-all-errors \
          --retry-delay 5 \
-         --connect-timeout 20 \
+         --connect-timeout 30 \
          -o /tmp/codex.tar.gz; \
      fi \
   && echo "${CODEX_SHA256}  /tmp/codex.tar.gz" | sha256sum -c - \

--- a/scripts/check-repo-readiness.sh
+++ b/scripts/check-repo-readiness.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO=""
+BASE_BRANCH="main"
+OUTPUT_FORMAT="text"
+WATCH=0
+TIMEOUT_SECONDS=2700
+POLL_SECONDS=30
+FETCH=1
+
+BLOCKERS=()
+REPO_READINESS="blocked"
+LOCAL_STATUS=""
+LOCAL_HEAD=""
+LOCAL_BASE_OID=""
+REMOTE_MAIN_SHA=""
+LOCAL_BRANCHES=""
+REMOTE_HEADS=""
+OPEN_PRS=0
+DEPENDABOT_OPEN=0
+CODE_SCANNING_OPEN=0
+SECRET_SCANNING_OPEN=0
+CHECK_RUNS_TOTAL=0
+CHECK_RUNS_INCOMPLETE=0
+CHECK_RUNS_FAILING=0
+ACTIVE_RUNS=0
+TRACKER_ISSUE=""
+TRACKER_STATE=""
+TRACKER_CURRENT="false"
+
+usage() {
+  cat <<'EOF'
+Usage: check-repo-readiness.sh [options]
+
+Read-only host-side readiness gate for Workcell repository follow-up.
+
+Options:
+  --repo OWNER/REPO       GitHub repository (default: gh repo view)
+  --base BRANCH           Base branch to audit (default: main)
+  --format text|json      Output format (default: text)
+  --watch                 Poll until ready or timeout
+  --timeout DURATION      Watch timeout, e.g. 45m or 2700s (default: 45m)
+  --poll DURATION         Watch poll interval (default: 30s)
+  --no-fetch              Do not fetch/prune origin before local checks
+  -h, --help              Show this help
+EOF
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required tool: $1" >&2
+    exit 1
+  }
+}
+
+parse_duration_seconds() {
+  local value="$1"
+
+  case "${value}" in
+    *m)
+      value="${value%m}"
+      [[ "${value}" =~ ^[0-9]+$ ]] || {
+        echo "Invalid duration: $1" >&2
+        exit 2
+      }
+      printf '%s\n' "$((value * 60))"
+      ;;
+    *s)
+      value="${value%s}"
+      [[ "${value}" =~ ^[0-9]+$ ]] || {
+        echo "Invalid duration: $1" >&2
+        exit 2
+      }
+      printf '%s\n' "${value}"
+      ;;
+    *)
+      [[ "${value}" =~ ^[0-9]+$ ]] || {
+        echo "Invalid duration: $1" >&2
+        exit 2
+      }
+      printf '%s\n' "${value}"
+      ;;
+  esac
+}
+
+json_array_from_values() {
+  if (($# == 0)); then
+    jq -n '[]'
+    return 0
+  fi
+  printf '%s\n' "$@" | jq -R . | jq -s .
+}
+
+add_blocker() {
+  BLOCKERS+=("$1")
+}
+
+alert_count() {
+  local path="$1"
+
+  gh api --paginate "${path}?state=open&per_page=100" | jq -s 'add | length'
+}
+
+active_run_count() {
+  local status=""
+  local runs_json="[]"
+  local status_json=""
+
+  for status in queued in_progress waiting requested pending; do
+    status_json="$(gh run list --repo "${REPO}" --status "${status}" --limit 100 \
+      --json databaseId,name,headBranch,headSha,status,conclusion,createdAt,url)"
+    runs_json="$(jq -s 'add' <(printf '%s\n' "${runs_json}") <(printf '%s\n' "${status_json}"))"
+  done
+
+  jq 'unique_by(.databaseId) | length' <<<"${runs_json}"
+}
+
+collect_once() {
+  local check_runs_json=""
+  local tracker_count=0
+  local tracker_body=""
+  local unexpected_local_branches=""
+  local unexpected_remote_heads=""
+
+  BLOCKERS=()
+  LOCAL_STATUS="$(git -C "${ROOT_DIR}" status --short --branch)"
+  if [[ "${FETCH}" -eq 1 ]]; then
+    git -C "${ROOT_DIR}" fetch origin --prune >/dev/null
+  fi
+
+  LOCAL_HEAD="$(git -C "${ROOT_DIR}" rev-parse HEAD)"
+  LOCAL_BASE_OID="$(git -C "${ROOT_DIR}" rev-parse "refs/remotes/origin/${BASE_BRANCH}")"
+  REMOTE_MAIN_SHA="$(gh api "repos/${REPO}/commits/${BASE_BRANCH}" --jq .sha)"
+  LOCAL_BRANCHES="$(git -C "${ROOT_DIR}" branch --format='%(refname:short)')"
+  REMOTE_HEADS="$(git -C "${ROOT_DIR}" ls-remote --heads origin)"
+
+  if [[ "${LOCAL_STATUS}" != "## ${BASE_BRANCH}...origin/${BASE_BRANCH}" ]]; then
+    add_blocker "local checkout is not clean on ${BASE_BRANCH} tracking origin/${BASE_BRANCH}"
+  fi
+  if [[ "${LOCAL_HEAD}" != "${REMOTE_MAIN_SHA}" || "${LOCAL_BASE_OID}" != "${REMOTE_MAIN_SHA}" ]]; then
+    add_blocker "local ${BASE_BRANCH} and origin/${BASE_BRANCH} are not at hosted ${BASE_BRANCH} ${REMOTE_MAIN_SHA}"
+  fi
+
+  unexpected_local_branches="$(awk -v base="${BASE_BRANCH}" '$0 != base {print}' <<<"${LOCAL_BRANCHES}")"
+  if [[ -n "${unexpected_local_branches}" ]]; then
+    add_blocker "unexpected local branches remain"
+  fi
+  unexpected_remote_heads="$(awk -v base="refs/heads/${BASE_BRANCH}" '$2 != base {print}' <<<"${REMOTE_HEADS}")"
+  if [[ -n "${unexpected_remote_heads}" ]]; then
+    add_blocker "unexpected remote branches remain"
+  fi
+
+  OPEN_PRS="$(gh pr list --repo "${REPO}" --state open --limit 100 --json number --jq 'length')"
+  [[ "${OPEN_PRS}" == "0" ]] || add_blocker "open pull requests remain"
+
+  DEPENDABOT_OPEN="$(alert_count "repos/${REPO}/dependabot/alerts")"
+  CODE_SCANNING_OPEN="$(alert_count "repos/${REPO}/code-scanning/alerts")"
+  SECRET_SCANNING_OPEN="$(alert_count "repos/${REPO}/secret-scanning/alerts")"
+  [[ "${DEPENDABOT_OPEN}" == "0" ]] || add_blocker "open Dependabot alerts remain"
+  [[ "${CODE_SCANNING_OPEN}" == "0" ]] || add_blocker "open code scanning alerts remain"
+  [[ "${SECRET_SCANNING_OPEN}" == "0" ]] || add_blocker "open secret scanning alerts remain"
+
+  check_runs_json="$(gh api "repos/${REPO}/commits/${REMOTE_MAIN_SHA}/check-runs?per_page=100")"
+  CHECK_RUNS_TOTAL="$(jq '.total_count' <<<"${check_runs_json}")"
+  if [[ "${CHECK_RUNS_TOTAL}" -gt 100 ]]; then
+    add_blocker "current main has more than 100 check runs; readiness script needs pagination"
+  fi
+  CHECK_RUNS_INCOMPLETE="$(jq '[.check_runs[] | select(.status != "completed")] | length' <<<"${check_runs_json}")"
+  CHECK_RUNS_FAILING="$(jq '[.check_runs[] | select(.status == "completed" and (.conclusion | IN("success","skipped","neutral") | not))] | length' <<<"${check_runs_json}")"
+  [[ "${CHECK_RUNS_INCOMPLETE}" == "0" ]] || add_blocker "current main has incomplete check runs"
+  [[ "${CHECK_RUNS_FAILING}" == "0" ]] || add_blocker "current main has failing check runs"
+
+  ACTIVE_RUNS="$(active_run_count)"
+  [[ "${ACTIVE_RUNS}" == "0" ]] || add_blocker "queued, pending, waiting, requested, or in-progress workflow runs remain"
+
+  tracker_count="$(gh issue list --repo "${REPO}" --state all --label upstream-refresh-candidate --limit 10 --json number --jq 'length')"
+  if [[ "${tracker_count}" != "1" ]]; then
+    TRACKER_ISSUE=""
+    TRACKER_STATE=""
+    TRACKER_CURRENT="false"
+    add_blocker "expected exactly one upstream refresh tracker issue"
+  else
+    TRACKER_ISSUE="$(gh issue list --repo "${REPO}" --state all --label upstream-refresh-candidate --limit 10 --json number --jq '.[0].number')"
+    tracker_json="$(gh issue view "${TRACKER_ISSUE}" --repo "${REPO}" --json state,body)"
+    TRACKER_STATE="$(jq -r '.state' <<<"${tracker_json}")"
+    tracker_body="$(jq -r '.body' <<<"${tracker_json}")"
+    if grep -Fq "${REMOTE_MAIN_SHA}" <<<"${tracker_body}"; then
+      TRACKER_CURRENT="true"
+    else
+      TRACKER_CURRENT="false"
+      add_blocker "upstream refresh tracker does not reference current main"
+    fi
+  fi
+
+  if ((${#BLOCKERS[@]} == 0)); then
+    REPO_READINESS="ready"
+  else
+    REPO_READINESS="blocked"
+  fi
+}
+
+emit_result() {
+  local blockers_json=""
+
+  case "${OUTPUT_FORMAT}" in
+    text)
+      printf 'repo_readiness=%s\n' "${REPO_READINESS}"
+      printf 'repo=%s\n' "${REPO}"
+      printf 'base=%s\n' "${BASE_BRANCH}"
+      printf 'main_sha=%s\n' "${REMOTE_MAIN_SHA}"
+      printf 'open_prs=%s\n' "${OPEN_PRS}"
+      printf 'security_alerts=%s\n' "$((DEPENDABOT_OPEN + CODE_SCANNING_OPEN + SECRET_SCANNING_OPEN))"
+      printf 'check_runs_total=%s\n' "${CHECK_RUNS_TOTAL}"
+      printf 'check_runs_incomplete=%s\n' "${CHECK_RUNS_INCOMPLETE}"
+      printf 'check_runs_failing=%s\n' "${CHECK_RUNS_FAILING}"
+      printf 'active_runs=%s\n' "${ACTIVE_RUNS}"
+      printf 'upstream_refresh_tracker=%s\n' "${TRACKER_CURRENT}"
+      printf 'local_status=%s\n' "${LOCAL_STATUS}"
+      if ((${#BLOCKERS[@]} > 0)); then
+        printf 'blockers:\n'
+        printf -- '- %s\n' "${BLOCKERS[@]}"
+      fi
+      ;;
+    json)
+      blockers_json="$(json_array_from_values "${BLOCKERS[@]}")"
+      jq -n \
+        --arg readiness "${REPO_READINESS}" \
+        --arg repo "${REPO}" \
+        --arg base "${BASE_BRANCH}" \
+        --arg main_sha "${REMOTE_MAIN_SHA}" \
+        --arg local_status "${LOCAL_STATUS}" \
+        --arg tracker_issue "${TRACKER_ISSUE}" \
+        --arg tracker_state "${TRACKER_STATE}" \
+        --argjson open_prs "${OPEN_PRS}" \
+        --argjson dependabot_open "${DEPENDABOT_OPEN}" \
+        --argjson code_scanning_open "${CODE_SCANNING_OPEN}" \
+        --argjson secret_scanning_open "${SECRET_SCANNING_OPEN}" \
+        --argjson check_runs_total "${CHECK_RUNS_TOTAL}" \
+        --argjson check_runs_incomplete "${CHECK_RUNS_INCOMPLETE}" \
+        --argjson check_runs_failing "${CHECK_RUNS_FAILING}" \
+        --argjson active_runs "${ACTIVE_RUNS}" \
+        --argjson tracker_current "${TRACKER_CURRENT}" \
+        --argjson blockers "${blockers_json}" \
+        '{
+          repo_readiness: $readiness,
+          repo: $repo,
+          base: $base,
+          main_sha: $main_sha,
+          open_prs: $open_prs,
+          security_alerts: {
+            dependabot: $dependabot_open,
+            code_scanning: $code_scanning_open,
+            secret_scanning: $secret_scanning_open
+          },
+          check_runs: {
+            total: $check_runs_total,
+            incomplete: $check_runs_incomplete,
+            failing: $check_runs_failing
+          },
+          active_runs: $active_runs,
+          upstream_refresh_tracker: {
+            issue: $tracker_issue,
+            state: $tracker_state,
+            current: $tracker_current
+          },
+          local_status: $local_status,
+          blockers: $blockers
+        }'
+      ;;
+    *)
+      echo "Unsupported output format: ${OUTPUT_FORMAT}" >&2
+      exit 2
+      ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="${2:-}"
+      [[ -n "${REPO}" ]] || {
+        echo "--repo requires OWNER/REPO" >&2
+        exit 2
+      }
+      shift 2
+      ;;
+    --base)
+      BASE_BRANCH="${2:-}"
+      [[ -n "${BASE_BRANCH}" ]] || {
+        echo "--base requires a branch" >&2
+        exit 2
+      }
+      shift 2
+      ;;
+    --format)
+      OUTPUT_FORMAT="${2:-}"
+      [[ -n "${OUTPUT_FORMAT}" ]] || {
+        echo "--format requires text or json" >&2
+        exit 2
+      }
+      shift 2
+      ;;
+    --watch)
+      WATCH=1
+      shift
+      ;;
+    --timeout)
+      TIMEOUT_SECONDS="$(parse_duration_seconds "${2:-}")"
+      shift 2
+      ;;
+    --poll)
+      POLL_SECONDS="$(parse_duration_seconds "${2:-}")"
+      shift 2
+      ;;
+    --no-fetch)
+      FETCH=0
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_tool gh
+require_tool git
+require_tool jq
+require_tool shasum
+
+case "${OUTPUT_FORMAT}" in
+  text | json) ;;
+  *)
+    echo "Unsupported output format: ${OUTPUT_FORMAT}" >&2
+    exit 2
+    ;;
+esac
+
+if [[ -z "${REPO}" ]]; then
+  REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+fi
+
+if [[ "${BASE_BRANCH}" != "main" ]]; then
+  echo "Only main-based repository readiness is supported by default." >&2
+  exit 2
+fi
+
+deadline="$(($(date +%s) + TIMEOUT_SECONDS))"
+while true; do
+  collect_once
+  if [[ "${REPO_READINESS}" == "ready" || "${WATCH}" -eq 0 ]]; then
+    break
+  fi
+  if [[ "$(date +%s)" -ge "${deadline}" ]]; then
+    break
+  fi
+  echo "repo_readiness=${REPO_READINESS}; sleeping ${POLL_SECONDS}s" >&2
+  sleep "${POLL_SECONDS}"
+done
+
+emit_result
+[[ "${REPO_READINESS}" == "ready" ]]

--- a/scripts/pre-merge.sh
+++ b/scripts/pre-merge.sh
@@ -14,8 +14,14 @@ ALLOW_DIRTY=0
 LOCAL_SNAPSHOT_MODE=""
 LOCAL_INCLUDE_UNTRACKED=0
 LOCAL_KEEP_DIR=0
+PARITY_SNAPSHOT="worktree"
 ORIGINAL_ARGS=("$@")
 LABELS=()
+PARITY_START_TREE_OID=""
+PARITY_START_HEAD_OID=""
+PARITY_START_STATUS_SHA256=""
+PARITY_BASE_REF=""
+PARITY_BASE_OID=""
 
 usage() {
   cat <<EOF
@@ -33,6 +39,8 @@ Options:
   --local-snapshot <mode>   Run from a disposable snapshot: head, index, worktree
   --local-include-untracked Include untracked files with --local-snapshot worktree
   --keep-local-dir          Preserve the local snapshot directory after exit
+  --parity-snapshot <mode>  Publish snapshot recorded in pr-parity evidence:
+                            index or worktree (default: worktree)
   --rebuild-validator       Rebuild the local validator image before validation
   --skip-release-bundle     Skip verify-release-bundle.sh in shared validate runs
   --skip-repro              Skip verify-reproducible-build.sh when selected
@@ -156,6 +164,56 @@ compute_publish_snapshot_tree() {
   printf '%s\n' "${tree_oid}"
 }
 
+compute_worktree_status_sha256() {
+  git -C "${ROOT_DIR}" status --short --untracked-files=all | shasum -a 256 | awk '{print $1}'
+}
+
+resolve_base_ref_for_evidence() {
+  if git -C "${ROOT_DIR}" rev-parse --verify --quiet "refs/remotes/origin/${BASE_BRANCH}" >/dev/null; then
+    printf 'refs/remotes/origin/%s\n' "${BASE_BRANCH}"
+    return 0
+  fi
+  if git -C "${ROOT_DIR}" rev-parse --verify --quiet "refs/heads/${BASE_BRANCH}" >/dev/null; then
+    printf 'refs/heads/%s\n' "${BASE_BRANCH}"
+    return 0
+  fi
+  printf ''
+}
+
+capture_pr_parity_start_state() {
+  [[ "${PROFILE}" == "pr-parity" ]] || return 0
+
+  PARITY_START_TREE_OID="$(compute_publish_snapshot_tree "${PARITY_SNAPSHOT}")"
+  PARITY_START_HEAD_OID="$(git -C "${ROOT_DIR}" rev-parse HEAD)"
+  PARITY_START_STATUS_SHA256="$(compute_worktree_status_sha256)"
+  PARITY_BASE_REF="$(resolve_base_ref_for_evidence)"
+  if [[ -n "${PARITY_BASE_REF}" ]]; then
+    PARITY_BASE_OID="$(git -C "${ROOT_DIR}" rev-parse --verify "${PARITY_BASE_REF}")"
+  fi
+}
+
+verify_pr_parity_end_state() {
+  local end_tree_oid=""
+  local end_head_oid=""
+  local end_status_sha256=""
+
+  [[ "${PROFILE}" == "pr-parity" ]] || return 0
+
+  end_tree_oid="$(compute_publish_snapshot_tree "${PARITY_SNAPSHOT}")"
+  end_head_oid="$(git -C "${ROOT_DIR}" rev-parse HEAD)"
+  end_status_sha256="$(compute_worktree_status_sha256)"
+
+  if [[ "${end_tree_oid}" != "${PARITY_START_TREE_OID}" ||
+    "${end_head_oid}" != "${PARITY_START_HEAD_OID}" ||
+    "${end_status_sha256}" != "${PARITY_START_STATUS_SHA256}" ]]; then
+    echo "pre-merge validation changed the publishable tree; refusing to write PR-parity evidence." >&2
+    echo "Start head=${PARITY_START_HEAD_OID} tree=${PARITY_START_TREE_OID} status_sha256=${PARITY_START_STATUS_SHA256}" >&2
+    echo "End   head=${end_head_oid} tree=${end_tree_oid} status_sha256=${end_status_sha256}" >&2
+    echo "Inspect the worktree, keep only intentional changes, then rerun validation." >&2
+    exit 2
+  fi
+}
+
 collect_selected_scripts() {
   local plan_json="$1"
 
@@ -188,7 +246,8 @@ write_pr_parity_evidence() {
   local tmp_path=""
   local labels_json="[]"
 
-  tree_oid="$(compute_publish_snapshot_tree worktree)"
+  verify_pr_parity_end_state
+  tree_oid="${PARITY_START_TREE_OID}"
   evidence_dir="$(parity_evidence_dir)"
   evidence_path="${evidence_dir}/pr-parity.json"
   tmp_path="${evidence_path}.tmp"
@@ -201,7 +260,12 @@ write_pr_parity_evidence() {
     --arg profile "${PROFILE}" \
     --arg event "${PLANNER_EVENT}" \
     --arg base "${BASE_BRANCH}" \
+    --arg base_ref "${PARITY_BASE_REF}" \
+    --arg base_oid "${PARITY_BASE_OID}" \
+    --arg head_oid "${PARITY_START_HEAD_OID}" \
+    --arg snapshot "${PARITY_SNAPSHOT}" \
     --arg tree_oid "${tree_oid}" \
+    --arg status_sha256 "${PARITY_START_STATUS_SHA256}" \
     --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --argjson labels "${labels_json}" \
     --argjson plan "${plan_json}" \
@@ -210,8 +274,13 @@ write_pr_parity_evidence() {
       profile: $profile,
       event: $event,
       base_branch: $base,
+      base_ref: $base_ref,
+      base_oid: $base_oid,
+      head_oid: $head_oid,
+      snapshot: $snapshot,
       labels: $labels,
       tree_oid: $tree_oid,
+      status_sha256: $status_sha256,
       generated_at: $generated_at,
       plan: $plan
     }' >"${tmp_path}"
@@ -349,6 +418,15 @@ while [[ $# -gt 0 ]]; do
       LOCAL_KEEP_DIR=1
       shift
       ;;
+    --parity-snapshot)
+      PARITY_SNAPSHOT="${2-}"
+      [[ -n "${PARITY_SNAPSHOT}" ]] || {
+        echo "Option --parity-snapshot requires a value." >&2
+        usage >&2
+        exit 2
+      }
+      shift 2
+      ;;
     --rebuild-validator)
       REBUILD_VALIDATOR=1
       shift
@@ -377,6 +455,14 @@ case "${PROFILE}" in
   repo-core | pr-parity | release-preflight) ;;
   *)
     echo "Unsupported pre-merge profile: ${PROFILE}" >&2
+    exit 2
+    ;;
+esac
+
+case "${PARITY_SNAPSHOT}" in
+  index | worktree) ;;
+  *)
+    echo "Unsupported parity snapshot: ${PARITY_SNAPSHOT}" >&2
     exit 2
     ;;
 esac
@@ -412,6 +498,7 @@ echo "${plan_json}" | jq -r '
   ] | .[]
 '
 
+capture_pr_parity_start_state
 execute_plan "${plan_json}"
 
 if [[ "${PROFILE}" == "pr-parity" ]]; then

--- a/scripts/repo-publish-pr.sh
+++ b/scripts/repo-publish-pr.sh
@@ -93,6 +93,32 @@ compute_snapshot_tree() {
   printf '%s\n' "${tree_oid}"
 }
 
+compute_worktree_status_sha256() {
+  local workspace="$1"
+
+  "${HOST_GIT_BIN}" -C "${workspace}" status --short --untracked-files=all | shasum -a 256 | awk '{print $1}'
+}
+
+resolve_current_base_ref() {
+  local workspace="$1"
+  local base_branch="$2"
+
+  if "${HOST_GIT_BIN}" -C "${workspace}" remote get-url origin >/dev/null 2>&1; then
+    "${HOST_GIT_BIN}" -C "${workspace}" fetch --no-tags --prune origin "+refs/heads/${base_branch}:refs/remotes/origin/${base_branch}" >/dev/null
+    if "${HOST_GIT_BIN}" -C "${workspace}" rev-parse --verify --quiet "refs/remotes/origin/${base_branch}" >/dev/null; then
+      printf 'refs/remotes/origin/%s\n' "${base_branch}"
+      return 0
+    fi
+  fi
+  if "${HOST_GIT_BIN}" -C "${workspace}" rev-parse --verify --quiet "refs/heads/${base_branch}" >/dev/null; then
+    printf 'refs/heads/%s\n' "${base_branch}"
+    return 0
+  fi
+
+  echo "Could not resolve base branch for parity verification: ${base_branch}" >&2
+  exit 2
+}
+
 verify_pr_parity_evidence() {
   local workspace="$1"
   local snapshot_mode="$2"
@@ -100,6 +126,10 @@ verify_pr_parity_evidence() {
   local evidence_dir=""
   local evidence_path=""
   local expected_tree=""
+  local expected_head=""
+  local expected_status_sha256=""
+  local base_ref=""
+  local base_oid=""
 
   evidence_dir="$("${HOST_GIT_BIN}" -C "${workspace}" rev-parse --absolute-git-dir)/workcell-parity"
   evidence_path="${evidence_dir}/pr-parity.json"
@@ -108,19 +138,34 @@ verify_pr_parity_evidence() {
     echo "Run ./scripts/pre-merge.sh --profile pr-parity first, or use --allow-parity-override with a reason." >&2
     exit 2
   fi
+  base_ref="$(resolve_current_base_ref "${workspace}" "${base_branch}")"
+  base_oid="$("${HOST_GIT_BIN}" -C "${workspace}" rev-parse --verify "${base_ref}")"
   expected_tree="$(compute_snapshot_tree "${workspace}" "${snapshot_mode}")"
+  expected_head="$("${HOST_GIT_BIN}" -C "${workspace}" rev-parse HEAD)"
+  expected_status_sha256="$(compute_worktree_status_sha256 "${workspace}")"
 
+  # shellcheck disable=SC2016
   "${HOST_JQ_BIN}" -e \
     --arg base "${base_branch}" \
+    --arg base_ref "${base_ref}" \
+    --arg base_oid "${base_oid}" \
+    --arg head_oid "${expected_head}" \
+    --arg snapshot "${snapshot_mode}" \
     --arg tree_oid "${expected_tree}" \
+    --arg status_sha256 "${expected_status_sha256}" \
     '
       .version == 1 and
       .profile == "pr-parity" and
       .base_branch == $base and
-      .tree_oid == $tree_oid
+      .base_ref == $base_ref and
+      .base_oid == $base_oid and
+      .head_oid == $head_oid and
+      .snapshot == $snapshot and
+      .tree_oid == $tree_oid and
+      .status_sha256 == $status_sha256
     ' "${evidence_path}" >/dev/null || {
     echo "Local PR-parity evidence does not match the tree being published." >&2
-    echo "Expected base=${base_branch} tree_oid=${expected_tree}." >&2
+    echo "Expected base=${base_branch} base_oid=${base_oid} head_oid=${expected_head} snapshot=${snapshot_mode} tree_oid=${expected_tree}." >&2
     echo "Re-run ./scripts/pre-merge.sh --profile pr-parity before publishing, or use --allow-parity-override with a reason." >&2
     exit 2
   }

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -126,6 +126,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/check-dead-code.sh"
   "${ROOT_DIR}/scripts/check-public-repo-hygiene.sh"
   "${ROOT_DIR}/scripts/check-pr-shape.sh"
+  "${ROOT_DIR}/scripts/check-repo-readiness.sh"
   "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
   "${ROOT_DIR}/scripts/build-and-test.sh"
   "${ROOT_DIR}/scripts/ci-plan.sh"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -5022,19 +5022,54 @@ case "${1-}" in
   log)
     printf '%s\n' "${WORKCELL_FAKE_GIT_EPOCH:-1700000000}"
     ;;
-  rev-parse)
-    if [[ "${2-}" == "--absolute-git-dir" ]]; then
-      printf '%s/.git\n' "${WORKCELL_FAKE_GIT_ROOT}"
-    else
-      echo "unexpected rev-parse invocation: $*" >&2
-      exit 1
-    fi
+	  rev-parse)
+	    if [[ "${2-}" == "--absolute-git-dir" ]]; then
+	      printf '%s/.git\n' "${WORKCELL_FAKE_GIT_ROOT}"
+	    elif [[ "${2-}" == "HEAD" ]]; then
+	      printf '%s\n' "${WORKCELL_FAKE_GIT_HEAD_OID:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
+	    elif [[ "${2-}" == "--verify" && "${3-}" == "--quiet" ]]; then
+	      case "${4-}" in
+	        refs/remotes/origin/main | refs/heads/main)
+	          printf '%s\n' "${WORKCELL_FAKE_GIT_BASE_OID:-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb}"
+	          ;;
+	        *)
+	          exit 1
+	          ;;
+	      esac
+	    elif [[ "${2-}" == "--verify" ]]; then
+	      case "${3-}" in
+	        refs/remotes/origin/main | refs/heads/main)
+	          printf '%s\n' "${WORKCELL_FAKE_GIT_BASE_OID:-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb}"
+	          ;;
+	        *)
+	          echo "unexpected rev-parse --verify invocation: $*" >&2
+	          exit 1
+	          ;;
+	      esac
+	    else
+	      echo "unexpected rev-parse invocation: $*" >&2
+	      exit 1
+	    fi
     ;;
   read-tree)
     ;;
-  write-tree)
-    printf '%s\n' "${WORKCELL_FAKE_GIT_TREE_OID:-deadbeefdeadbeefdeadbeefdeadbeefdeadbeef}"
-    ;;
+	  write-tree)
+	    if [[ -n "${WORKCELL_FAKE_GIT_TREE_SEQUENCE:-}" ]]; then
+	      sequence_index_path="${WORKCELL_FAKE_GIT_ROOT}/.git/workcell-fake-tree-sequence-index"
+	      sequence_index="0"
+	      if [[ -f "${sequence_index_path}" ]]; then
+	        sequence_index="$(cat "${sequence_index_path}")"
+	      fi
+	      mapfile -t sequence_values <<<"${WORKCELL_FAKE_GIT_TREE_SEQUENCE}"
+	      if [[ "${sequence_index}" -ge "${#sequence_values[@]}" ]]; then
+	        sequence_index="$((${#sequence_values[@]} - 1))"
+	      fi
+	      printf '%s\n' "${sequence_values[sequence_index]}"
+	      printf '%s\n' "$((sequence_index + 1))" >"${sequence_index_path}"
+	    else
+	      printf '%s\n' "${WORKCELL_FAKE_GIT_TREE_OID:-deadbeefdeadbeefdeadbeefdeadbeefdeadbeef}"
+	    fi
+	    ;;
   archive)
     tar -C "${WORKCELL_FAKE_GIT_ROOT}" -cf - scripts tests tools
     ;;
@@ -5132,9 +5167,33 @@ for expected in \
   'verify-reproducible-build.sh env WORKCELL_REPRO_PLATFORMS=linux/arm64'; do
   grep -q "${expected}" "${PREMERGE_LOG}"
 done
-for expected in '"profile": "pr-parity"' '"base_branch": "main"' '"tree_oid": "1111111111111111111111111111111111111111"'; do
+for expected in \
+  '"profile": "pr-parity"' \
+  '"base_branch": "main"' \
+  '"base_ref": "refs/remotes/origin/main"' \
+  '"base_oid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' \
+  '"head_oid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' \
+  '"snapshot": "worktree"' \
+  '"tree_oid": "1111111111111111111111111111111111111111"' \
+  '"status_sha256":'; do
   grep -q "${expected}" "${PREMERGE_HARNESS_ROOT}/.git/workcell-parity/pr-parity.json"
 done
+
+rm -f "${PREMERGE_HARNESS_ROOT}/.git/workcell-parity/pr-parity.json" \
+  "${PREMERGE_HARNESS_ROOT}/.git/workcell-fake-tree-sequence-index"
+: >"${PREMERGE_LOG}"
+if PATH="${PREMERGE_FAKEBIN}:${PATH}" \
+  PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
+  WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
+  WORKCELL_FAKE_GIT_TREE_SEQUENCE=$'3333333333333333333333333333333333333333\n4444444444444444444444444444444444444444' \
+  "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
+  --allow-dirty >/tmp/workcell-premerge-mutated-tree.out 2>&1; then
+  echo "Expected pre-merge to refuse evidence when validation changes the publishable tree" >&2
+  exit 1
+fi
+grep -q 'validation changed the publishable tree' /tmp/workcell-premerge-mutated-tree.out
+test ! -f "${PREMERGE_HARNESS_ROOT}/.git/workcell-parity/pr-parity.json"
 
 : >"${PREMERGE_LOG}"
 if PATH="${PREMERGE_FAKEBIN}:${PATH}" \

--- a/tests/scenarios/shared/test-publish-pr-dry-run.sh
+++ b/tests/scenarios/shared/test-publish-pr-dry-run.sh
@@ -24,6 +24,12 @@ compute_worktree_tree_oid() {
   printf '%s\n' "${tree_oid}"
 }
 
+compute_worktree_status_sha256() {
+  local repo_root="$1"
+
+  git -C "${repo_root}" status --short --untracked-files=all | shasum -a 256 | awk '{print $1}'
+}
+
 FIXTURE="${TMP_DIR}/publish-pr-fixture"
 ORIGIN="${TMP_DIR}/publish-pr-origin.git"
 SHA256_FIXTURE="${TMP_DIR}/publish-pr-sha256-fixture"
@@ -299,12 +305,20 @@ test "${mismatched_parity_rc}" -eq 2
 grep -q 'Local PR-parity evidence does not match the tree being published' <<<"${mismatched_parity_output}"
 
 current_tree_oid="$(compute_worktree_tree_oid "${FIXTURE}")"
+current_head_oid="$(git -C "${FIXTURE}" rev-parse HEAD)"
+current_base_oid="$(git -C "${FIXTURE}" rev-parse refs/remotes/origin/main)"
+current_status_sha256="$(compute_worktree_status_sha256 "${FIXTURE}")"
 cat >"$(git -C "${FIXTURE}" rev-parse --absolute-git-dir)/workcell-parity/pr-parity.json" <<EOF
 {
   "version": 1,
   "profile": "pr-parity",
   "base_branch": "main",
-  "tree_oid": "${current_tree_oid}"
+  "base_ref": "refs/remotes/origin/main",
+  "base_oid": "${current_base_oid}",
+  "head_oid": "${current_head_oid}",
+  "snapshot": "worktree",
+  "tree_oid": "${current_tree_oid}",
+  "status_sha256": "${current_status_sha256}"
 }
 EOF
 wrapper_dry_run="$("${ROOT_DIR}/scripts/repo-publish-pr.sh" \


### PR DESCRIPTION
## Summary
- add a host-side repository readiness gate for post-merge/main cleanup checks
- harden PR parity evidence against stale bases and validation-mutated trees
- document required-check polling and post-merge readiness follow-up
- harden runtime image fetch retries after local parity exposed cold rebuild network flakes

## Validation
- scripts/lint-dockerfiles.sh
- scripts/verify-build-input-manifest.sh
- go test ./internal/metadatautil
- ./scripts/pre-merge.sh --profile pr-parity