### PR TITLE
Remove dead code: unused exit1, ptyNameBufferSize, redundant loop copy

### DIFF
--- a/internal/authpolicy/auth_main.go
+++ b/internal/authpolicy/auth_main.go
@@ -18,10 +18,6 @@ func exit2(format string, args ...any) error {
 	return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf(format, args...)}
 }
 
-func exit1(format string, args ...any) error {
-	return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf(format, args...)}
-}
-
 // AuthMain implements `workcell auth <subcommand>`, the Go translation
 // of the bash auth_main function in scripts/workcell. The user-visible
 // CLI surface is kept byte-identical: argument parsing, the four

--- a/internal/host/release/release.go
+++ b/internal/host/release/release.go
@@ -81,7 +81,6 @@ func WriteGitHubReleaseMetadata(releaseJSONPath string, assetPaths []string, out
 	uploadURL, _, _ := strings.Cut(resp.UploadURL, "{")
 	assetIDs := make(map[string]*int64, len(resp.Assets))
 	for _, asset := range resp.Assets {
-		asset := asset
 		assetIDs[asset.Name] = asset.ID
 	}
 

--- a/internal/transcript/pty_linux.go
+++ b/internal/transcript/pty_linux.go
@@ -16,8 +16,6 @@ import (
 	"unsafe"
 )
 
-const ptyNameBufferSize = 128
-
 func openPTY() (*os.File, string, error) {
 	masterFD, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|syscall.O_CLOEXEC, 0)
 	if err != nil {


### PR DESCRIPTION
## Summary

Codebase-wide `/simplify` batch 1 (lowest-risk: dead-code removal). All verified unused via grep + passing tests.

- `internal/authpolicy/auth_main.go` — drop unused `exit1` helper (zero callers; `exit2` is the only one used)
- `internal/transcript/pty_linux.go` — drop unused `ptyNameBufferSize` const (Linux builds the name from `TIOCGPTN`; darwin keeps its own copy)
- `internal/host/release/release.go` — drop redundant `asset := asset` loop-var copy, obsolete under Go 1.22+ loop semantics (go.mod is go 1.26.0)

No behavior change.

## Validation (local)

- `gofmt -l` clean
- `go build ./...` ✓
- `go vet ./internal/host/release/... ./internal/authpolicy/... ./internal/transcript/...` ✓
- `go test` ✓ for all three affected packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)