### PR TITLE
Dedup metadatautil/injection helpers; drop unused param

### DIFF
--- a/internal/injection/extract_direct_mounts.go
+++ b/internal/injection/extract_direct_mounts.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"sort"
 
 	"github.com/omkhar/workcell/internal/pathutil"
@@ -56,10 +55,10 @@ func RunExtractDirectMounts(manifestPath, mountSpecPath string) error {
 		return err
 	}
 
-	if err := writePrettyJSON(resolvedManifestPath, manifest, 0o600); err != nil {
+	if err := writeIndentedJSON(resolvedManifestPath, manifest, 0o600); err != nil {
 		return err
 	}
-	if err := writePrettyJSON(resolvedMountSpecPath, directMounts, 0o600); err != nil {
+	if err := writeIndentedJSON(resolvedMountSpecPath, directMounts, 0o600); err != nil {
 		return err
 	}
 	return nil
@@ -73,7 +72,7 @@ func collectDirectMounts(manifest map[string]any) ([]DirectMount, error) {
 		if err != nil {
 			return nil, err
 		}
-		for _, key := range sortedMapKeys(credentials) {
+		for _, key := range sortedKeys(credentials) {
 			entry, err := asObjectMap(credentials[key], "credentials."+key)
 			if err != nil {
 				return nil, err
@@ -172,18 +171,6 @@ func loadJSONObject(path string) (map[string]any, error) {
 	return manifest, nil
 }
 
-func writePrettyJSON(path string, value any, mode os.FileMode) error {
-	data, err := json.MarshalIndent(value, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	if err := os.WriteFile(path, data, mode); err != nil {
-		return err
-	}
-	return os.Chmod(path, mode)
-}
-
 func asObjectMap(value any, label string) (map[string]any, error) {
 	if value == nil {
 		return nil, fmt.Errorf("%s must be a JSON object", label)
@@ -204,15 +191,6 @@ func asArray(value any, label string) ([]any, error) {
 		return nil, fmt.Errorf("%s must be a JSON array", label)
 	}
 	return array, nil
-}
-
-func sortedMapKeys(values map[string]any) []string {
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-	return keys
 }
 
 func resolveAbsPath(raw string) (string, error) {

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -185,7 +185,7 @@ func RunRenderInjectionBundle(policyPath, agent, mode, outputRoot, policyMetadat
 			"policy_entrypoint":   policyEntrypoint,
 			"policy_sha256":       policySHA,
 			"policy_sources":      policySources,
-			"credential_keys":     sortedStringKeysMap(renderedCredentials),
+			"credential_keys":     sortedKeys(renderedCredentials),
 			"extra_endpoints":     deriveCredentialExtraEndpoints(renderedCredentials),
 			"secret_copy_targets": secretCopyTargets(renderedCopies),
 			"ssh_enabled":         len(renderedSSH) > 0,
@@ -452,7 +452,7 @@ func renderCopies(policy map[string]any, outputRoot, policyDir Path, agent, mode
 		relpath := fmt.Sprintf("copies/%d", copyIndex)
 		mountPath := directMountRoot + "/copies/" + strconv.Itoa(copyIndex)
 		copyIndex++
-		fileMode, dirMode, err := classificationModes(classification, sourceValue.IsDir())
+		fileMode, dirMode, err := classificationModes(classification)
 		if err != nil {
 			return nil, err
 		}
@@ -651,7 +651,7 @@ func renderCredentials(policy map[string]any, policyDir Path, agent, mode string
 	}
 
 	rendered := map[string]map[string]string{}
-	for _, key := range sortedSetKeys(relevant) {
+	for _, key := range sortedKeys(relevant) {
 		rawValue, ok := credentials[key]
 		if !ok || rawValue == nil {
 			continue
@@ -1324,7 +1324,7 @@ func validateGeminiEnvFile(source Path) (map[string]any, error) {
 			}
 			return map[string]any{
 				"selected_auth_type": "vertex-ai",
-				"extra_endpoints":    sortedSetKeys(endpoints),
+				"extra_endpoints":    sortedKeys(endpoints),
 			}, nil
 		}
 		return nil, fmt.Errorf("gemini auth env file %s enables GOOGLE_GENAI_USE_VERTEXAI=true without either GOOGLE_API_KEY or both GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION", source)
@@ -1468,7 +1468,7 @@ func deriveCredentialExtraEndpoints(renderedCredentials map[string]map[string]st
 			}
 		}
 	}
-	return sortedSetKeys(endpoints)
+	return sortedKeys(endpoints)
 }
 
 func effectivePolicySHA256(
@@ -1480,7 +1480,7 @@ func effectivePolicySHA256(
 	renderedSSH map[string]any,
 ) (string, error) {
 	documents := map[string]string{}
-	for _, key := range sortedStringKeys(renderedDocuments) {
+	for _, key := range sortedKeys(renderedDocuments) {
 		hash, err := pathMaterialSHA256(outputRoot.Join(renderedDocuments[key]))
 		if err != nil {
 			return "", fmt.Errorf("hash document %q: %w", key, err)
@@ -1521,7 +1521,7 @@ func effectivePolicySHA256(
 		})
 	}
 	credentials := map[string]map[string]any{}
-	for _, key := range sortedStringKeysMap(renderedCredentials) {
+	for _, key := range sortedKeys(renderedCredentials) {
 		value := renderedCredentials[key]
 		hash, err := pathMaterialSHA256(Path(value["source"]))
 		if err != nil {
@@ -1948,7 +1948,7 @@ func targetIsReserved(candidate string) bool {
 	return false
 }
 
-func classificationModes(classification string, isDir bool) (string, string, error) {
+func classificationModes(classification string) (string, string, error) {
 	if _, ok := supportedClassifications[classification]; !ok {
 		return "", "", fmt.Errorf("unsupported injection classification: %s", classification)
 	}
@@ -1971,25 +1971,7 @@ func secretCopyTargets(renderedCopies []map[string]any) []string {
 	return targets
 }
 
-func sortedStringKeys(values map[string]string) []string {
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-	return keys
-}
-
-func sortedStringKeysMap(values map[string]map[string]string) []string {
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-	return keys
-}
-
-func sortedSetKeys(values map[string]struct{}) []string {
+func sortedKeys[V any](values map[string]V) []string {
 	keys := make([]string, 0, len(values))
 	for key := range values {
 		keys = append(keys, key)

--- a/internal/metadatautil/hostedcontrols.go
+++ b/internal/metadatautil/hostedcontrols.go
@@ -101,7 +101,7 @@ func WorkflowEnvironments(policy map[string]any, policyPath string) (map[string]
 
 		requiredSecrets := []string{}
 		if rawSecrets, ok := entry["required_secrets"]; ok {
-			secrets, present, err := mustStringSlice(rawSecrets)
+			secrets, present, err := MustStringSlice(rawSecrets)
 			if err != nil {
 				return nil, fmt.Errorf("%s workflow_environment.%s.required_secrets: %w", policyPath, environmentName, err)
 			}
@@ -131,7 +131,7 @@ func WorkflowEnvironments(policy map[string]any, policyPath string) (map[string]
 		deploymentBranches := []string{}
 		hasDeploymentBranches := false
 		if rawDeploymentBranches, ok := entry["deployment_branches"]; ok {
-			branches, present, err := mustStringSlice(rawDeploymentBranches)
+			branches, present, err := MustStringSlice(rawDeploymentBranches)
 			if err != nil {
 				return nil, fmt.Errorf("%s workflow_environment.%s.deployment_branches: %w", policyPath, environmentName, err)
 			}
@@ -150,7 +150,7 @@ func WorkflowEnvironments(policy map[string]any, policyPath string) (map[string]
 		deploymentTags := []string{}
 		hasDeploymentTags := false
 		if rawDeploymentTags, ok := entry["deployment_tags"]; ok {
-			tags, present, err := mustStringSlice(rawDeploymentTags)
+			tags, present, err := MustStringSlice(rawDeploymentTags)
 			if err != nil {
 				return nil, fmt.Errorf("%s workflow_environment.%s.deployment_tags: %w", policyPath, environmentName, err)
 			}
@@ -894,7 +894,7 @@ func requireStringSliceTable(root map[string]any, tableName, key, sourcePath str
 	if !ok {
 		return nil, fmt.Errorf("%s must define %s.%s as a non-empty array", sourcePath, tableName, key)
 	}
-	values, ok, err := mustStringSlice(table[key])
+	values, ok, err := MustStringSlice(table[key])
 	if err != nil {
 		return nil, err
 	}
@@ -907,22 +907,6 @@ func requireStringSliceTable(root map[string]any, tableName, key, sourcePath str
 		}
 	}
 	return values, nil
-}
-
-func mustStringSlice(value any) ([]string, bool, error) {
-	raw, ok := value.([]any)
-	if !ok {
-		return nil, false, nil
-	}
-	result := make([]string, 0, len(raw))
-	for _, item := range raw {
-		s, ok := item.(string)
-		if !ok {
-			return nil, false, errors.New("array value must contain only strings")
-		}
-		result = append(result, s)
-	}
-	return result, true, nil
 }
 
 // readJSONFile / writeJSONFile live in core.go.

--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -40,7 +40,7 @@ type PinnedInputsConfig struct {
 }
 
 // readText, isHexDigest, hexDigestPattern live in core.go.
-// mustStringSlice and requireStringSliceTable live in hostedcontrols.go
+// requireStringSliceTable lives in hostedcontrols.go
 // (canonical post-collapse; same package-internal symbols all consumers share).
 
 func CheckPinnedInputs(cfg PinnedInputsConfig) error {

--- a/internal/metadatautil/requirements.go
+++ b/internal/metadatautil/requirements.go
@@ -145,7 +145,7 @@ func validateRequirementTable(rootDir, requirementsPath, category, id string, ta
 		referencedDocs[canonicalPath] = struct{}{}
 	}
 
-	workflows, err := optionalRequirementWorkflows(table)
+	workflows, err := optionalStringSlice(table, "workflows")
 	if err != nil {
 		return fmt.Errorf("%s requirement %s workflows: %w", requirementsPath, id, err)
 	}
@@ -155,26 +155,6 @@ func validateRequirementTable(rootDir, requirementsPath, category, id string, ta
 		}
 	}
 	return nil
-}
-
-func optionalRequirementWorkflows(table map[string]any) ([]string, error) {
-	value, ok := table["workflows"]
-	if !ok {
-		return nil, nil
-	}
-	workflows, found, err := MustStringSlice(value)
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		return nil, fmt.Errorf("must be an array of strings")
-	}
-	for _, workflowID := range workflows {
-		if strings.TrimSpace(workflowID) == "" {
-			return nil, fmt.Errorf("entries may not be empty")
-		}
-	}
-	return workflows, nil
 }
 
 func requiredReleaseFacingDocs(rootDir string) ([]string, error) {

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -369,4 +369,4 @@ func ValidateUpstreamRefreshWorkflow(workflowText string) error {
 }
 
 // readText lives in core.go.
-// mustStringSlice and requireStringSliceTable live in hostedcontrols.go.
+// requireStringSliceTable lives in hostedcontrols.go.


### PR DESCRIPTION
## Summary

Codebase-wide `/simplify` batch 2 — behavior-preserving dedup (bodies verified byte-identical):

**metadatautil**
- Drop `mustStringSlice` (identical to exported `MustStringSlice` in toml.go); repoint 4 callers
- Drop `optionalRequirementWorkflows` (identical to `optionalStringSlice(table,"workflows")`); repoint caller
- Trim stale pointer comments in `pinnedinputs.go` / `workflows.go`

**injection**
- Drop `writePrettyJSON` (identical to `writeIndentedJSON`); repoint 2 callers
- Unify `sortedStringKeys` / `sortedStringKeysMap` / `sortedSetKeys` / `sortedMapKeys` into one generic `sortedKeys[V any]`; update 7 call sites; drop now-unused `slices` import
- Drop never-read `isDir` param from `classificationModes`

No behavior change. 6 files, +19/−95.

## Validation (local)
- `gofmt -l` clean · `go build ./...` ✓ · `go vet` ✓ · `go test ./internal/metadatautil/... ./internal/injection/...` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)