### PR TITLE
providerid: derive IsValid from AllProviders; single package doc

### DIFF
--- a/internal/providerid/doc.go
+++ b/internal/providerid/doc.go
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Omkhar Arasaratnam
 
-// Package providerid is the canonical source of supported provider
-// id strings (Codex, Claude, Gemini today; Copilot is a roadmap
-// addition).  Every other package that needs a provider name
-// imports the constants here rather than redeclaring them, so
-// adding or renaming a provider is a single-package edit.
+// Package providerid is the canonical source of the supported provider id
+// strings (Claude, Codex, Gemini today; Copilot is a roadmap addition).
+//
+// Before this package existed, "claude" / "codex" / "gemini" were spelled as
+// raw string literals in 70+ sites across internal/ and cmd/, with three
+// different orderings of AllProviders.  Adding a provider was an N-file
+// refactor and silent drift between sites was easy.  Every other package now
+// imports the constants here rather than redeclaring them; use the named
+// constants instead of raw strings, and iterate AllProviders to keep the
+// per-provider order stable.
 package providerid

--- a/internal/providerid/providerid.go
+++ b/internal/providerid/providerid.go
@@ -1,17 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Omkhar Arasaratnam
 
-// Package providerid holds the canonical string identifiers for the
-// per-provider adapters Workcell supports.
-//
-// Before this package existed, "claude" / "codex" / "gemini" were spelled as
-// raw string literals in 70+ sites across internal/ and cmd/, with three
-// different orderings of AllProviders.  Adding a fourth provider was an
-// N-file refactor and silent drift between sites was easy.
-//
-// Use the named constants instead of raw strings; iterate AllProviders to
-// keep the per-provider order stable.
 package providerid
+
+import "slices"
 
 const (
 	// Claude is the Anthropic Claude Code provider identifier.
@@ -29,9 +21,5 @@ var AllProviders = []string{Claude, Codex, Gemini}
 
 // IsValid reports whether s names a supported provider.
 func IsValid(s string) bool {
-	switch s {
-	case Claude, Codex, Gemini:
-		return true
-	}
-	return false
+	return slices.Contains(AllProviders, s)
 }


### PR DESCRIPTION
## Summary

Codebase-wide `/simplify` batch 3 (providerid, low-risk):

- `IsValid` now scans `AllProviders` (`slices.Contains`) instead of a hardcoded `Claude/Codex/Gemini` switch — `AllProviders` becomes the single source of truth.
- Consolidate the two competing `// Package providerid` doc comments into `doc.go`.

No behavior change (identical provider set).

## Validation (local)
- `gofmt -l` clean · `go build ./...` ✓ · `go vet` ✓ · `go test ./internal/providerid/... ./internal/adapters/...` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)