### PR TITLE
Dedup config-home path; reuse scenarios key helpers

### DIFF
--- a/internal/authpolicy/auth_main.go
+++ b/internal/authpolicy/auth_main.go
@@ -78,20 +78,20 @@ func consumeBaseArg(args []string) (base string, rest []string) {
 	return "", args
 }
 
-func defaultInjectionPolicyPath() string {
+func configHome() string {
 	home, err := launcher.RealHome()
 	if err != nil || home == "" {
 		home, _ = os.UserHomeDir()
 	}
-	return home + "/.config/workcell/injection-policy.toml"
+	return home + "/.config/workcell"
+}
+
+func defaultInjectionPolicyPath() string {
+	return configHome() + "/injection-policy.toml"
 }
 
 func defaultManagedCredentialsRoot() string {
-	home, err := launcher.RealHome()
-	if err != nil || home == "" {
-		home, _ = os.UserHomeDir()
-	}
-	return home + "/.config/workcell/credentials"
+	return configHome() + "/credentials"
 }
 
 // rawOptionValueOrDie mirrors scripts/workcell raw_option_value_or_die:

--- a/internal/scenarios/scenario_manifest.go
+++ b/internal/scenarios/scenario_manifest.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -163,7 +164,7 @@ func LoadScenarios(manifestPath string) ([]Scenario, error) {
 			if err != nil {
 				return nil, err
 			}
-			if _, ok := validProviders[providerName]; !ok {
+			if !containsKey(validProviders, providerName) {
 				return nil, fmt.Errorf(
 					"scenario %s: provider must be one of: %s",
 					scenarioID,
@@ -262,12 +263,7 @@ func containsKey(values map[string]struct{}, key string) bool {
 }
 
 func sortedKeys(values map[string]struct{}) []string {
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-	return keys
+	return slices.Sorted(maps.Keys(values))
 }
 
 func isPersonaValid(persona string) bool {


### PR DESCRIPTION
## Summary

Codebase-wide `/simplify` batch 4a (safe caller-side cleanups; the more involved sessionctl/cmd/publishpr/remotevm/mutation findings are being verified separately):

- **authpolicy**: extract `configHome()` so `defaultInjectionPolicyPath` and `defaultManagedCredentialsRoot` share the identical `RealHome()`→`UserHomeDir()` fallback instead of duplicating it.
- **scenarios**: use the existing `containsKey` helper for the provider-validity check (matches the three sibling validations); express `sortedKeys` as `slices.Sorted(maps.Keys(values))`.

No behavior change.

## Validation (local)
- `gofmt -l` clean · `go build ./...` ✓ · `go vet` ✓ · `go test ./internal/authpolicy/... ./internal/scenarios/...` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)