### PR TITLE
Remove dead bash helpers (shasum precondition, workcell_die, reject_if_protected_provider_path)

### DIFF
--- a/runtime/container/bin/node
+++ b/runtime/container/bin/node
@@ -79,13 +79,6 @@ is_protected_provider_script() {
   return 1
 }
 
-reject_if_protected_provider_path() {
-  if is_protected_provider_script "${1:-}"; then
-    echo "Workcell blocked direct provider script execution via node." >&2
-    exit 2
-  fi
-}
-
 reject_dynamic_node_option() {
   echo "Workcell blocked dynamic Node code-loading option outside provider wrappers." >&2
   exit 2

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -196,7 +196,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/bin/node",
       "runtime_path": "/usr/local/libexec/workcell/node-wrapper.sh",
-      "sha256": "536ee344d5bf93bcb51473fb8daef08f1019d06f50016e34c28ee00d8ad1e132"
+      "sha256": "24676fb4b7d78fc5cc22ee634ef856b12e1d1fe1b6d90da3c39387d2d4d1527a"
     },
     {
       "kind": "runtime-control-plane",

--- a/scripts/check-repo-readiness.sh
+++ b/scripts/check-repo-readiness.sh
@@ -333,7 +333,6 @@ done
 require_tool gh
 require_tool git
 require_tool jq
-require_tool shasum
 
 case "${OUTPUT_FORMAT}" in
   text | json) ;;

--- a/verify/invariants/harnesses/gemini-auth-selection.sh
+++ b/verify/invariants/harnesses/gemini-auth-selection.sh
@@ -6,11 +6,6 @@ set -x
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
-workcell_die() {
-  printf '%s\n' "$*" >&2
-  exit 1
-}
-
 expect_fatal_function_failure() {
   local stdout_path="$1"
   local stderr_path="$2"


### PR DESCRIPTION
## Summary

Codebase-wide `/simplify` — confirmed-dead bash helper removals (all verified zero-callers via repo-wide grep):

- `scripts/check-repo-readiness.sh`: drop `require_tool shasum` (script uses only gh/git/jq).
- `verify/invariants/harnesses/gemini-auth-selection.sh`: drop unused `workcell_die`.
- `runtime/container/bin/node`: drop `reject_if_protected_provider_path` — **security-reviewed**: no callers repo-wide, `bin/node` is not sourced anywhere, and the live `SCRIPT_PATH` guard already calls `is_protected_provider_script` directly, so the exec-protection behavior is unchanged.

No behavior change.

## Validation (local)
- `shellcheck` clean on all three (the harness SC2148 is pre-existing — that file has no shebang; passes with `-s bash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)