### PR TITLE
public-node-guard: compute isProtectedProviderFile once in maybeBlock

### DIFF
--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -214,7 +214,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/public-node-guard.mjs",
       "runtime_path": "/usr/local/libexec/workcell/public-node-guard.mjs",
-      "sha256": "cb2e3f78a4529469498700a0220463db025204a1e8b61cae014f7a3631231cc7"
+      "sha256": "3e5e1114876f4014c0a21cd849f0444b0cfb79dc2e80d799a68c11a44503160d"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/public-node-guard.mjs
+++ b/runtime/container/public-node-guard.mjs
@@ -701,17 +701,19 @@ function maybeBlock(filePath) {
     return;
   }
 
+  const isProtected = isProtectedProviderFile(filePath);
+
   if (
     filePath !== SELF_GUARD_PATH &&
     !isWithinWorkspace(filePath) &&
-    !isProtectedProviderFile(filePath)
+    !isProtected
   ) {
     throw new Error(
       'Workcell blocked public node execution outside the mounted workspace.',
     );
   }
 
-  if (isProtectedProviderFile(filePath)) {
+  if (isProtected) {
     throw new Error(
       'Workcell blocked provider package execution via public node.',
     );


### PR DESCRIPTION
Codebase-wide `/simplify` (security-adjacent, reviewed). `maybeBlock` evaluated `isProtectedProviderFile(filePath)` twice; hoist to a single `const` reused by both guard branches. Control flow identical; single evaluation narrows (not widens) the redundant FS-stat window. Regenerated `control-plane-manifest.json` for the new file hash.

Validation: `node --check` ✓ · `verify-control-plane-manifest.sh` ✓ · behavior-preserving (security-neutral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)