### PR TITLE
trusted-docker-client: dedup duplicated registry CA blocks

### DIFF
--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "repo_path": "scripts/lib/trusted-docker-client.sh",
-      "sha256": "cc7ae4af8703361a675b3e262808938de85f65870002151c48760bf7f5aade71"
+      "sha256": "f1835ea3f4291c13134e803568f8b9ead5d7b7eff162c0550223f8873e6fb1f1"
     }
   ],
   "runtime_artifacts": [

--- a/scripts/lib/trusted-docker-client.sh
+++ b/scripts/lib/trusted-docker-client.sh
@@ -355,6 +355,25 @@ buildx_builder_matches_context() {
   return 1
 }
 
+# emit_registry_ca_block prints a buildkitd `[registry."<name>"]` block whose
+# `ca` array lists the prepared ca_paths from the calling scope. Both Docker Hub
+# registry aliases share identical CA wiring, so they reuse this emitter.
+emit_registry_ca_block() {
+  local registry_name="$1"
+  local first=1
+  local cert_file=""
+  printf '[registry."%s"]\n' "${registry_name}"
+  printf '  ca = ['
+  for cert_file in "${ca_paths[@]}"; do
+    if [[ "${first}" -eq 0 ]]; then
+      printf ', '
+    fi
+    first=0
+    printf '"%s"' "${cert_file}"
+  done
+  printf ']\n'
+}
+
 prepare_workcell_buildkitd_config() {
   local config_path=""
   local cert_root=""
@@ -390,28 +409,8 @@ prepare_workcell_buildkitd_config() {
   fi
 
   {
-    printf '[registry."docker.io"]\n'
-    printf '  ca = ['
-    local first=1
-    for cert_file in "${ca_paths[@]}"; do
-      if [[ "${first}" -eq 0 ]]; then
-        printf ', '
-      fi
-      first=0
-      printf '"%s"' "${cert_file}"
-    done
-    printf ']\n'
-    printf '[registry."registry-1.docker.io"]\n'
-    printf '  ca = ['
-    first=1
-    for cert_file in "${ca_paths[@]}"; do
-      if [[ "${first}" -eq 0 ]]; then
-        printf ', '
-      fi
-      first=0
-      printf '"%s"' "${cert_file}"
-    done
-    printf ']\n'
+    emit_registry_ca_block 'docker.io'
+    emit_registry_ca_block 'registry-1.docker.io'
   } >"${config_path}"
 
   printf '%s\n' "${config_path}"


### PR DESCRIPTION
Codebase-wide `/simplify` (security-adjacent, reviewed). `prepare_workcell_buildkitd_config` emitted two byte-identical `[registry."…"]` CA blocks (docker.io + registry-1.docker.io). Extract `emit_registry_ca_block(registry_name)` and reuse for both. Output **verified byte-identical** via a functional check. Regenerated `control-plane-manifest.json`.

(Skipped the proposed `note_attempt` dedup — it would rely on dynamic-scope mutation of a caller local, making the selector subtler rather than simpler.)

Validation: `shellcheck` ✓ · `verify-control-plane-manifest.sh` ✓ · functional emit output identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)