### PR TITLE
runtime wrappers: hoist shared env pin/sanitize into runtime-user.sh

### DIFF
--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -172,7 +172,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/development-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/development-wrapper.sh",
-      "sha256": "26bf6e4b9655169b405593d72bd38637dee2a76001b996b4f4ebbc0c81f30341"
+      "sha256": "0763f412aededb21d9853eaa916571d5ae021c9f8c0e3f50efea29746909658e"
     },
     {
       "kind": "runtime-control-plane",
@@ -208,7 +208,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-wrapper.sh",
-      "sha256": "bf0627a4f90d6bfd9a118e5d66254bc8e7d3e61f98b0c25552b98148c102ddac"
+      "sha256": "b3e827b33cf233816c12d4b95aaef5a97f59e09b78ad1d015e7d9e7ed536f6b4"
     },
     {
       "kind": "runtime-control-plane",
@@ -220,7 +220,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/runtime-user.sh",
       "runtime_path": "/usr/local/libexec/workcell/runtime-user.sh",
-      "sha256": "093867eac3baa96f6e8b58073dc2c88d06d2cab64545a50d5276e78a45d665f4"
+      "sha256": "290cf45e860da1887e29ba78109927d84d37ce6a0fbf929bfbb84a2f9d193034"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/development-wrapper.sh
+++ b/runtime/container/development-wrapper.sh
@@ -2,60 +2,12 @@
 set -euo pipefail
 
 AGENT_NAME="${AGENT_NAME:-${WORKCELL_LAUNCH_TARGET:-}}"
-TRUSTED_PATH="/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
 export WORKCELL_WRAPPER_CONTEXT=1
 export ADAPTER_ROOT="/opt/workcell/adapters"
 
 workcell_die() {
   echo "$*" >&2
   exit 2
-}
-
-pin_runtime_env() {
-  local state_mode=""
-  local state_profile=""
-  local state_autonomy=""
-  local state_mutability=""
-  local pid1_mode=""
-  local pid1_profile=""
-  local pid1_autonomy=""
-  local pid1_mutability=""
-
-  HOME=/state/agent-home
-  CODEX_HOME="${HOME}/.codex"
-  TMPDIR=/state/tmp
-  state_mode="$(workcell_runtime_state_value WORKCELL_MODE || true)"
-  state_profile="$(workcell_runtime_state_value CODEX_PROFILE || true)"
-  state_autonomy="$(workcell_runtime_state_value WORKCELL_AGENT_AUTONOMY || true)"
-  state_mutability="$(workcell_runtime_state_value WORKCELL_CONTAINER_MUTABILITY || true)"
-  pid1_mode="$(workcell_pid1_env_value WORKCELL_MODE || true)"
-  pid1_profile="$(workcell_pid1_env_value CODEX_PROFILE || true)"
-  pid1_autonomy="$(workcell_pid1_env_value WORKCELL_AGENT_AUTONOMY || true)"
-  pid1_mutability="$(workcell_pid1_env_value WORKCELL_CONTAINER_MUTABILITY || true)"
-  WORKCELL_MODE="${state_mode:-${pid1_mode:-strict}}"
-  CODEX_PROFILE="${state_profile:-${pid1_profile:-${WORKCELL_MODE}}}"
-  WORKCELL_AGENT_AUTONOMY="${state_autonomy:-${pid1_autonomy:-yolo}}"
-  WORKCELL_CONTAINER_MUTABILITY="${state_mutability:-${pid1_mutability:-ephemeral}}"
-  export HOME CODEX_HOME TMPDIR WORKCELL_MODE CODEX_PROFILE WORKCELL_AGENT_AUTONOMY WORKCELL_CONTAINER_MUTABILITY
-}
-
-sanitize_development_env() {
-  unset BASH_ENV
-  unset ENV
-  unset CLAUDE_CONFIG_DIR
-  unset DISABLE_AUTOUPDATER
-  unset NODE_OPTIONS
-  unset NODE_PATH
-  unset NODE_EXTRA_CA_CERTS
-  unset npm_config_userconfig
-  unset NPM_CONFIG_USERCONFIG
-  unset LD_AUDIT
-  unset LD_LIBRARY_PATH
-  unset SSL_CERT_FILE
-  unset SSL_CERT_DIR
-  workcell_sanitize_git_runtime_env
-  export LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so
-  export PATH="${TRUSTED_PATH}"
 }
 
 # shellcheck source=runtime/container/assurance.sh
@@ -111,8 +63,8 @@ reject_protected_runtime_launch() {
   fi
 }
 
-sanitize_development_env
-pin_runtime_env
+workcell_sanitize_runtime_env
+workcell_pin_runtime_env
 mkdir -p "${TMPDIR}"
 if workcell_should_reexec_as_runtime_user; then
   workcell_reexec_as_runtime_user /usr/local/libexec/workcell/development-wrapper.sh "$@"

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -2,57 +2,8 @@
 set -euo pipefail
 
 AGENT_NAME="${WORKCELL_LAUNCH_TARGET:-${0##*/}}"
-TRUSTED_PATH="/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
 export WORKCELL_WRAPPER_CONTEXT=1
 export ADAPTER_ROOT="/opt/workcell/adapters"
-
-pin_runtime_env() {
-  local state_mode=""
-  local state_profile=""
-  local state_autonomy=""
-  local state_mutability=""
-  local pid1_mode=""
-  local pid1_profile=""
-  local pid1_autonomy=""
-  local pid1_mutability=""
-
-  HOME=/state/agent-home
-  CODEX_HOME="${HOME}/.codex"
-  TMPDIR=/state/tmp
-  state_mode="$(workcell_runtime_state_value WORKCELL_MODE || true)"
-  state_profile="$(workcell_runtime_state_value CODEX_PROFILE || true)"
-  state_autonomy="$(workcell_runtime_state_value WORKCELL_AGENT_AUTONOMY || true)"
-  state_mutability="$(workcell_runtime_state_value WORKCELL_CONTAINER_MUTABILITY || true)"
-  pid1_mode="$(workcell_pid1_env_value WORKCELL_MODE || true)"
-  pid1_profile="$(workcell_pid1_env_value CODEX_PROFILE || true)"
-  pid1_autonomy="$(workcell_pid1_env_value WORKCELL_AGENT_AUTONOMY || true)"
-  pid1_mutability="$(workcell_pid1_env_value WORKCELL_CONTAINER_MUTABILITY || true)"
-  WORKCELL_MODE="${state_mode:-${pid1_mode:-strict}}"
-  CODEX_PROFILE="${state_profile:-${pid1_profile:-${WORKCELL_MODE}}}"
-  WORKCELL_AGENT_AUTONOMY="${state_autonomy:-${pid1_autonomy:-yolo}}"
-  WORKCELL_CONTAINER_MUTABILITY="${state_mutability:-${pid1_mutability:-ephemeral}}"
-  export HOME CODEX_HOME TMPDIR WORKCELL_MODE CODEX_PROFILE WORKCELL_AGENT_AUTONOMY WORKCELL_CONTAINER_MUTABILITY
-}
-
-sanitize_provider_env() {
-  unset BASH_ENV
-  unset ENV
-  unset CLAUDE_CONFIG_DIR
-  unset DISABLE_AUTOUPDATER
-  unset NODE_OPTIONS
-  unset NODE_PATH
-  unset NODE_EXTRA_CA_CERTS
-  unset npm_config_userconfig
-  unset NPM_CONFIG_USERCONFIG
-  unset LD_AUDIT
-  unset LD_LIBRARY_PATH
-  unset SSL_CERT_FILE
-  unset SSL_CERT_DIR
-  workcell_sanitize_git_runtime_env
-  export NODE_NO_WARNINGS=1
-  export LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so
-  export PATH="${TRUSTED_PATH}"
-}
 
 emit_codex_rules_mutability_notice() {
   local configured_mutability=""
@@ -92,8 +43,9 @@ source /usr/local/libexec/workcell/home-control-plane.sh
 # shellcheck source=runtime/container/runtime-user.sh
 source /usr/local/libexec/workcell/runtime-user.sh
 
-sanitize_provider_env
-pin_runtime_env
+workcell_sanitize_runtime_env
+export NODE_NO_WARNINGS=1
+workcell_pin_runtime_env
 mkdir -p "${TMPDIR}"
 if workcell_should_reexec_as_runtime_user; then
   workcell_reexec_as_runtime_user /usr/local/libexec/workcell/provider-wrapper.sh "$@"

--- a/runtime/container/runtime-user.sh
+++ b/runtime/container/runtime-user.sh
@@ -392,3 +392,60 @@ workcell_reexec_as_runtime_user() {
 
   exec setpriv --reuid "${uid}" --regid "${gid}" --init-groups "${command_argv[@]}"
 }
+
+# workcell_pin_runtime_env resolves and exports the canonical runtime
+# environment: HOME/CODEX_HOME/TMPDIR plus mode/profile/autonomy/mutability
+# taken from runtime state, falling back to the pid1 environment and then to
+# the strict/yolo/ephemeral defaults. Shared verbatim by the development and
+# provider wrappers.
+workcell_pin_runtime_env() {
+  local state_mode=""
+  local state_profile=""
+  local state_autonomy=""
+  local state_mutability=""
+  local pid1_mode=""
+  local pid1_profile=""
+  local pid1_autonomy=""
+  local pid1_mutability=""
+
+  HOME=/state/agent-home
+  CODEX_HOME="${HOME}/.codex"
+  TMPDIR=/state/tmp
+  state_mode="$(workcell_runtime_state_value WORKCELL_MODE || true)"
+  state_profile="$(workcell_runtime_state_value CODEX_PROFILE || true)"
+  state_autonomy="$(workcell_runtime_state_value WORKCELL_AGENT_AUTONOMY || true)"
+  state_mutability="$(workcell_runtime_state_value WORKCELL_CONTAINER_MUTABILITY || true)"
+  pid1_mode="$(workcell_pid1_env_value WORKCELL_MODE || true)"
+  pid1_profile="$(workcell_pid1_env_value CODEX_PROFILE || true)"
+  pid1_autonomy="$(workcell_pid1_env_value WORKCELL_AGENT_AUTONOMY || true)"
+  pid1_mutability="$(workcell_pid1_env_value WORKCELL_CONTAINER_MUTABILITY || true)"
+  WORKCELL_MODE="${state_mode:-${pid1_mode:-strict}}"
+  CODEX_PROFILE="${state_profile:-${pid1_profile:-${WORKCELL_MODE}}}"
+  WORKCELL_AGENT_AUTONOMY="${state_autonomy:-${pid1_autonomy:-yolo}}"
+  WORKCELL_CONTAINER_MUTABILITY="${state_mutability:-${pid1_mutability:-ephemeral}}"
+  export HOME CODEX_HOME TMPDIR WORKCELL_MODE CODEX_PROFILE WORKCELL_AGENT_AUTONOMY WORKCELL_CONTAINER_MUTABILITY
+}
+
+# workcell_sanitize_runtime_env strips inherited loader/node/npm/TLS
+# environment, applies the git runtime sanitization, and pins LD_PRELOAD plus
+# the trusted PATH. The provider wrapper additionally exports
+# NODE_NO_WARNINGS=1 after calling this.
+workcell_sanitize_runtime_env() {
+  local trusted_path="/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
+  unset BASH_ENV
+  unset ENV
+  unset CLAUDE_CONFIG_DIR
+  unset DISABLE_AUTOUPDATER
+  unset NODE_OPTIONS
+  unset NODE_PATH
+  unset NODE_EXTRA_CA_CERTS
+  unset npm_config_userconfig
+  unset NPM_CONFIG_USERCONFIG
+  unset LD_AUDIT
+  unset LD_LIBRARY_PATH
+  unset SSL_CERT_FILE
+  unset SSL_CERT_DIR
+  workcell_sanitize_git_runtime_env
+  export LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so
+  export PATH="${trusted_path}"
+}


### PR DESCRIPTION
Codebase-wide `/simplify` (env-sanitization boundary, security-reviewed). Both wrappers defined byte-identical `pin_runtime_env` and near-identical `sanitize_*_env` (only diff: provider's `NODE_NO_WARNINGS=1`). Hoist into `runtime-user.sh` as `workcell_pin_runtime_env` + `workcell_sanitize_runtime_env`; provider exports `NODE_NO_WARNINGS=1` after sanitizing; `TRUSTED_PATH` becomes a function-local. Net −39 lines. Regenerated control-plane manifest.

**Security review: no regression** — runtime env byte-equivalent (13 unsets, git-sanitize, LD_PRELOAD, trusted PATH all identical; provider-only NODE_NO_WARNINGS; order/timing preserved; TRUSTED_PATH not exported).

Validation: `shellcheck` clean (×3) · `verify-control-plane-manifest.sh` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)