### PR TITLE
execveat: reuse classify_loader_target / loader_targets_mutable_native_exec

### DIFF
--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -1350,22 +1350,12 @@ pub unsafe extern "C" fn execveat(
                 }
             }
 
-            if protected_target == ProtectedRuntime::None
-                && is_dynamic_loader_path(&pathname_string)
-                && args.get(1).is_some()
-            {
-                protected_target = args
-                    .get(1)
-                    .map(|target| classify_protected_runtime_path(target))
-                    .unwrap_or(ProtectedRuntime::None);
+            if protected_target == ProtectedRuntime::None {
+                protected_target = classify_loader_target(&pathname_string, &args);
             }
-            if !mutable_native_target
-                && is_dynamic_loader_path(&pathname_string)
-                && args.get(1).is_some()
-            {
-                mutable_native_target = args
-                    .get(1)
-                    .is_some_and(|target| path_is_mutable_native_exec(target));
+            if !mutable_native_target {
+                mutable_native_target =
+                    loader_targets_mutable_native_exec(&pathname_string, &args);
             }
 
             (


### PR DESCRIPTION
Codebase-wide `/simplify` (exec-guard, security-sensitive). The `execveat` shim inline-reimplemented the dynamic-loader target checks that `classify_loader_target` and `loader_targets_mutable_native_exec` already provide (the `execve` path already uses them via `should_block_protected_runtime_exec`). Call the helpers instead.

**Behavior-identical** (verified by case analysis): both helpers return `None`/`false` in exactly the cases the inline guards skipped (non-loader path, or absent `args[1]`).

**Deferred** for dedicated adversarial review: the broader `first_exec_block_reason` enum collapsing the per-shim block dispatch across all exec syscall shims — too high-stakes for a sweep.

> Note: this host's rustc (1.94) is below the crate's pinned 1.96, so build/test/clippy + the Rust **mutation tests** that exercise these guards run in CI rather than locally. Gating merge on CI-green for this one.