### PR TITLE
Build the arm64 release image on a native runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,10 +71,60 @@ jobs:
       - if: ${{ !github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_CODE_SCANNING == 'true' }}
         uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
 
+  preflight-arm64-repro:
+    name: Release reproducible image (arm64)
+    # Build and reproducibility-verify the linux/arm64 runtime image on a
+    # native arm64 runner instead of QEMU emulation.  The amd64 lane stays in
+    # the main `preflight` job (native on ubuntu-latest); this job feeds its
+    # verified arm64 image/config digests back via job outputs so preflight can
+    # assemble the combined runtime manifest that publish checks against.  This
+    # mirrors the already-reviewed native arm64 lane in ci.yml.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    outputs:
+      image_manifest_digest: ${{ steps.repro.outputs.image_manifest_digest }}
+      config_digest: ${{ steps.repro.outputs.config_digest }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: source_date
+        name: Compute source date epoch
+        run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          cache-binary: false
+          driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
+          version: ${{ env.WORKCELL_BUILDX_VERSION }}
+
+      - id: repro
+        name: Verify reproducible arm64 runtime image
+        env:
+          WORKCELL_REPRO_PLATFORMS: linux/arm64
+          WORKCELL_REPRO_MANIFEST_PATH: dist/workcell-runtime-arm64.json
+          SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
+        run: |
+          ./scripts/verify-reproducible-build.sh
+          manifest_digest="$(jq -r '.platforms["linux/arm64"].image_manifest_digest' dist/workcell-runtime-arm64.json)"
+          config_digest="$(jq -r '.platforms["linux/arm64"].config_digest' dist/workcell-runtime-arm64.json)"
+          if [[ "${manifest_digest}" != sha256:* || "${config_digest}" != sha256:* ]]; then
+            echo "Malformed arm64 reproducible-build digests: manifest=${manifest_digest} config=${config_digest}" >&2
+            exit 1
+          fi
+          echo "image_manifest_digest=${manifest_digest}" >> "${GITHUB_OUTPUT}"
+          echo "config_digest=${config_digest}" >> "${GITHUB_OUTPUT}"
+
   preflight:
     name: Release preflight
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    needs:
+      - preflight-arm64-repro
     environment:
       name: hosted-controls-audit
     permissions:
@@ -224,11 +274,6 @@ jobs:
             -t "workcell-validator:${GITHUB_SHA}" \
             .
 
-      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-        with:
-          cache-image: false
-          image: ${{ env.WORKCELL_QEMU_IMAGE }}
-
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           cache-binary: false
@@ -345,9 +390,31 @@ jobs:
 
       - name: Verify reproducible runtime image
         env:
+          # Build/verify the amd64 image natively here; the arm64 image is
+          # built and verified on a native arm64 runner in the
+          # preflight-arm64-repro job and merged in below.
+          WORKCELL_REPRO_PLATFORMS: linux/amd64
           WORKCELL_REPRO_MANIFEST_PATH: dist/workcell-runtime-preflight.json
           SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
         run: ./scripts/verify-reproducible-build.sh
+
+      - name: Merge native arm64 reproducible-build digests into preflight manifest
+        env:
+          ARM64_MANIFEST_DIGEST: ${{ needs.preflight-arm64-repro.outputs.image_manifest_digest }}
+          ARM64_CONFIG_DIGEST: ${{ needs.preflight-arm64-repro.outputs.config_digest }}
+        run: |
+          if [[ "${ARM64_MANIFEST_DIGEST}" != sha256:* || "${ARM64_CONFIG_DIGEST}" != sha256:* ]]; then
+            echo "Missing or malformed native arm64 reproducible-build digests from preflight-arm64-repro job" >&2
+            echo "manifest=${ARM64_MANIFEST_DIGEST} config=${ARM64_CONFIG_DIGEST}" >&2
+            exit 1
+          fi
+          merged="$(mktemp)"
+          jq \
+            --arg manifest "${ARM64_MANIFEST_DIGEST}" \
+            --arg config "${ARM64_CONFIG_DIGEST}" \
+            '.platforms["linux/arm64"] = {image_manifest_digest: $manifest, config_digest: $config}' \
+            dist/workcell-runtime-preflight.json > "${merged}"
+          mv "${merged}" dist/workcell-runtime-preflight.json
 
       - name: Upload preflight binding manifests
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -452,6 +519,69 @@ jobs:
           brew cleanup workcell >/dev/null 2>&1 || true
           brew untap "${tap_name}" >/dev/null 2>&1 || true
 
+  build-arm64-image:
+    name: Build native arm64 release image
+    # Build and push the linux/arm64 runtime image by digest on a native arm64
+    # runner (no QEMU).  The amd64 image is still built inside the publish
+    # `release` job (native on ubuntu-latest); publish consumes this job's
+    # pushed-by-digest output to assemble the multi-arch manifest.  Gated on the
+    # `release` environment so no image is pushed to GHCR before the same human
+    # approval that gates publication, matching the existing release gate.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    needs:
+      - codeql-preflight
+      - preflight
+      - install-verification
+    environment:
+      name: release
+      url: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+    permissions:
+      contents: read
+      packages: write # Push the arm64 image (by digest) to GitHub Container Registry.
+    outputs:
+      digest: ${{ steps.build_arm64.outputs.digest }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: source_date
+        name: Compute source date epoch
+        run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          cache-binary: false
+          driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
+          version: ${{ env.WORKCELL_BUILDX_VERSION }}
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - id: build_arm64
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
+        with:
+          build-args: |
+            BUILDKIT_MULTI_PLATFORM=1
+            SOURCE_DATE_EPOCH=${{ steps.source_date.outputs.epoch }}
+          # Build from the checked-out tree (same context the native
+          # preflight-arm64-repro reproducibility check uses), so the published
+          # arm64 digest matches the preflight manifest exactly.
+          context: .
+          file: runtime/container/Dockerfile
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true,rewrite-timestamp=true
+          platforms: linux/arm64
+          provenance: mode=max
+          sbom: true
+          tags: ${{ env.IMAGE_NAME }}
+
   release:
     name: Publish release artifacts
     runs-on: ubuntu-latest
@@ -460,6 +590,7 @@ jobs:
       - codeql-preflight
       - preflight
       - install-verification
+      - build-arm64-image
     environment:
       name: release
       url: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
@@ -488,11 +619,6 @@ jobs:
       - id: source_date
         name: Compute source date epoch
         run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
-
-      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-        with:
-          cache-image: false
-          image: ${{ env.WORKCELL_QEMU_IMAGE }}
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
@@ -669,26 +795,10 @@ jobs:
           sbom: true
           tags: ${{ env.IMAGE_NAME }}
 
-      - id: build_arm64
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        env:
-          SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
-        with:
-          build-args: |
-            BUILDKIT_MULTI_PLATFORM=1
-            SOURCE_DATE_EPOCH=${{ steps.source_date.outputs.epoch }}
-          context: dist/release-source
-          file: dist/release-source/runtime/container/Dockerfile
-          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true,rewrite-timestamp=true
-          platforms: linux/arm64
-          provenance: mode=max
-          sbom: true
-          tags: ${{ env.IMAGE_NAME }}
-
       - name: Verify published platform digests match preflight
         env:
           AMD64_DIGEST: ${{ steps.build_amd64.outputs.digest }}
-          ARM64_DIGEST: ${{ steps.build_arm64.outputs.digest }}
+          ARM64_DIGEST: ${{ needs.build-arm64-image.outputs.digest }}
         run: |
           set -euo pipefail
 
@@ -774,7 +884,7 @@ jobs:
         name: Publish deterministic multi-arch manifest
         env:
           AMD64_DIGEST: ${{ steps.build_amd64.outputs.digest }}
-          ARM64_DIGEST: ${{ steps.build_arm64.outputs.digest }}
+          ARM64_DIGEST: ${{ needs.build-arm64-image.outputs.digest }}
         run: |
           refs=(
             "${IMAGE_NAME}@${AMD64_DIGEST}"

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -51,6 +51,12 @@ repo-local `./scripts/repo-publish-pr.sh` publication gate.
 - it runs a release-scoped CodeQL matrix so Go uses `autobuild` while Rust and
   JavaScript keep buildless scanning
 - it binds publish outputs to preflight results before signing
+- it builds and reproducibility-verifies the `linux/arm64` runtime image on a
+  native `ubuntu-24.04-arm` runner instead of QEMU emulation, matching `ci.yml`;
+  the amd64 image stays native on `ubuntu-latest`, and publish assembles the
+  multi-arch manifest from both native digests after the preflight digest match
+- the native arm64 build/push job is gated on the same `release` environment as
+  publish, so no image reaches GHCR before the release approval
 - it refuses to publish when provider pins, Linux base images, Linux toolchains,
   or release-build pins lag the latest tracked upstream versions
 - it signs release assets with keyless Sigstore/Cosign
@@ -95,6 +101,12 @@ Other macOS versions are not install-gated today.
 actual platform checks. The native amd64 and arm64 reproducible-build lanes run
 for pull requests, and the aggregate required context fails unless the
 per-platform matrix succeeds.
+
+`release.yml` uses the same native-runner split: the `preflight-arm64-repro`
+job reproducibility-verifies the arm64 runtime image on `ubuntu-24.04-arm` and
+feeds its digests into the preflight manifest, while the amd64 image is verified
+natively in `preflight`. `check-pinned-inputs` rejects any reintroduction of
+`docker/setup-qemu-action` into the release workflow.
 
 `ci.yml` and `docs.yml` use the same explicit nonroot validator contract when
 they bind-mount the repository: the workflow computes the caller UID/GID,

--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -759,8 +759,11 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if !strings.Contains(releaseWorkflow, "cache-binary: false") {
 		return errors.New("the publishing release workflow must not cache the Buildx binary")
 	}
-	if !strings.Contains(releaseWorkflow, "cache-image: false") {
-		return errors.New("the publishing release workflow must not cache the QEMU helper image")
+	if strings.Contains(releaseWorkflow, "docker/setup-qemu-action@") {
+		return errors.New(".github/workflows/release.yml must not configure QEMU now that arm64 release builds use a native runner")
+	}
+	if !strings.Contains(releaseWorkflow, "runs-on: ubuntu-24.04-arm") {
+		return errors.New(".github/workflows/release.yml must build the arm64 release image on a native ubuntu-24.04-arm runner")
 	}
 	releaseSyftVersion, err := requireYAMLKey(releaseWorkflow, "WORKCELL_SYFT_VERSION", ".github/workflows/release.yml")
 	if err != nil {

--- a/policy/workflow-lane-policy.json
+++ b/policy/workflow-lane-policy.json
@@ -98,6 +98,12 @@
       "local_mode": "none",
       "github_only_reason": "pull_request_target metadata policy remains GitHub-only"
     },
+    "release.yml/build-arm64-image": {
+      "profiles": ["release-preflight"],
+      "authority": "release-only",
+      "local_mode": "none",
+      "github_only_reason": "native arm64 release image build and GHCR push remain GitHub-only and gated on the release environment"
+    },
     "release.yml/codeql-preflight[build-mode=autobuild,language=go]": {
       "profiles": ["release-preflight"],
       "authority": "release-only",
@@ -133,6 +139,12 @@
       "authority": "release-only",
       "local_mode": "none",
       "github_only_reason": "release preflight binds hosted controls, artifacts, and release-only permissions"
+    },
+    "release.yml/preflight-arm64-repro": {
+      "profiles": ["release-preflight"],
+      "authority": "release-only",
+      "local_mode": "none",
+      "github_only_reason": "release reproducibility verification of the native arm64 image binds release-only artifacts and runs on a native arm64 runner"
     },
     "release.yml/release": {
       "profiles": ["release-preflight"],

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -377,6 +377,22 @@
       "github_only_reason": "pull_request_target metadata policy remains GitHub-only"
     },
     {
+      "id": "release.yml/build-arm64-image",
+      "workflow_path": ".github/workflows/release.yml",
+      "workflow_name": "Release",
+      "job_id": "build-arm64-image",
+      "job_name": "Build native arm64 release image",
+      "workflow_events": [
+        "push"
+      ],
+      "profiles": [
+        "release-preflight"
+      ],
+      "authority": "release-only",
+      "local_mode": "none",
+      "github_only_reason": "native arm64 release image build and GHCR push remain GitHub-only and gated on the release environment"
+    },
+    {
       "id": "release.yml/codeql-preflight[build-mode=autobuild,language=go]",
       "workflow_path": ".github/workflows/release.yml",
       "workflow_name": "Release",
@@ -491,6 +507,22 @@
       "authority": "release-only",
       "local_mode": "none",
       "github_only_reason": "release preflight binds hosted controls, artifacts, and release-only permissions"
+    },
+    {
+      "id": "release.yml/preflight-arm64-repro",
+      "workflow_path": ".github/workflows/release.yml",
+      "workflow_name": "Release",
+      "job_id": "preflight-arm64-repro",
+      "job_name": "Release reproducible image (arm64)",
+      "workflow_events": [
+        "push"
+      ],
+      "profiles": [
+        "release-preflight"
+      ],
+      "authority": "release-only",
+      "local_mode": "none",
+      "github_only_reason": "release reproducibility verification of the native arm64 image binds release-only artifacts and runs on a native arm64 runner"
     },
     {
       "id": "release.yml/release",


### PR DESCRIPTION
## Summary

Replace QEMU emulation for the `linux/arm64` release image with native
`ubuntu-24.04-arm` runners, completing the CI→release native-arm migration the
maintainer already scaffolded (the pinned-inputs policy already forbids QEMU in
`ci.yml`; this extends the same treatment to `release.yml`).

QEMU arm64 emulation is the long pole of the release build (~5–10× slower than
native and the slowest step on every release run); native runners are GA and
free for public repos.

## What changed

- **`preflight-arm64-repro`** (new, native arm64, ungated): reproducibility-verifies
  the arm64 runtime image via `verify-reproducible-build.sh` and exports its
  image/config digests as job outputs. `preflight` now builds amd64 natively and
  merges the arm64 digests into the combined `workcell-runtime-preflight.json`.
- **`build-arm64-image`** (new, native arm64, gated on the `release` environment):
  builds and pushes the arm64 image by digest; `release` consumes that digest to
  assemble the multi-arch manifest. Gating preserves the invariant that **no
  image reaches GHCR before the release approval**.
- Drop `docker/setup-qemu-action` from both `preflight` and `release` (the amd64
  lanes were already native).
- **pinned-inputs policy**: replace the now-obsolete `cache-image: false` QEMU
  rule with a rule rejecting `docker/setup-qemu-action` in `release.yml` and
  requiring a native `ubuntu-24.04-arm` lane — mirroring the existing `ci.yml`
  rule.
- **workflow-lane policy**: register the two new release-only lanes and
  regenerate `policy/workflow-lanes.json`.
- Document the native arm64 release lanes.

## Correctness / why this is safe

- The cross-job per-platform digest match reuses the **exact equivalence already
  proven for amd64** today (preflight builds via `verify-reproducible-build.sh`
  OCI export with `provenance=false,sbom=false`; publish builds via
  `build-push-action` image export with `provenance=mode=max,sbom=true`; the
  per-platform `image_manifest_digest`/`config_digest` already match across that
  difference — attestation manifests are filtered out).
- Native arm64 reproducibility is **already proven in `ci.yml`** (the
  `reproducible-build-platform` matrix builds the same image twice on
  `ubuntu-24.04-arm` and asserts identical digests).
- Both the arm64 reproducibility check and the arm64 publish build use the
  **same checked-out context**, so the expected (preflight) and actual
  (published) arm64 digests are produced identically.
- The change is **fail-closed**: the existing *"Verify published platform
  digests match preflight"* gate aborts the release on any mismatch.

## Testing

`release.yml` only runs on tag push, so the end-to-end digest match is exercised
on the **first tagged release after merge** (fail-closed). Everything else was
validated locally:

- `go build/vet/test ./...`
- `actionlint` (all workflows), `zizmor --persona auditor`
- `scripts/check-pinned-inputs.sh` (real workflows)
- `scripts/verify-workflow-lanes.sh`
- `scripts/pre-merge.sh --profile pr-parity`
- `codespell`, `markdownlint`

## Note for the first release

On the first release tag after this merges, the `release` environment may
surface **two** pending-deployment approvals (the new `build-arm64-image` job
and `release`), since the arm64 build is gated to keep GHCR pushes behind the
release approval.
