### PR TITLE
CI: parallelize reproducible-build and container-smoke with validate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,10 @@ jobs:
     name: Container smoke
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: validate
+    # Only gated on pr-shape (not validate): container smoke builds and runs the
+    # runtime image independently and consumes no validate output, so running it
+    # in parallel with validate removes it from the gating critical path.
+    needs: pr-shape
     permissions:
       contents: read
     steps:
@@ -224,7 +227,11 @@ jobs:
     name: Reproducible build (${{ matrix.platform_name }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
-    needs: validate
+    # Only gated on pr-shape (not validate): the reproducible build runs its own
+    # checkout + buildx + no-cache double-build and consumes no validate output,
+    # so running it in parallel with validate removes ~5m of serialization from
+    # the gating critical path.
+    needs: pr-shape
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
## Summary

First of a series of vetted CI/deploy optimizations (from an adversarial review of all workflows). This one is the zero-invariant-risk win.

`reproducible-build-platform` and `container-smoke` declared `needs: validate` but consume **no** validate output — each runs its own checkout + buildx + script. The edge was pure serialization, forcing ~5m of reproducible-build and ~4m of container-smoke to wait behind the 11m `validate` job on the gating critical path.

Switch both to `needs: pr-shape` so they run **in parallel** with `validate`. `install-verification` keeps `needs: validate` (it genuinely downloads the validate-produced install-candidate artifact).

## Effect

CI gating path: `validate(11m) + repro(~5m)` serial → `max(validate 11m, repro ~5m, smoke ~4m)` ≈ **11m** — about **4.7m (~30%)** off the common green path. Same total compute, de-serialized.

The only behavioral change: repro/smoke now also run on a red PR (a few wasted runner-minutes in exchange for parallelism on the green path).

## Invariant safety

- No validation coverage change: same jobs, same checks, same **required check names**.
- Reproducible build keeps `--no-cache` + serial double-build.
- `workflow-lanes.json` records no dependency edges → **no lane-manifest regen**.
- `pinnedinputs.go` asserts only the repro job's `runs-on`/`strategy` (after the `needs:` line) — untouched.

## Testing

Local: `actionlint`, `go test ./internal/metadatautil/...`, `check-pinned-inputs.sh`, `verify-workflow-lanes.sh` (no lanes.json diff), full `pre-merge.sh --profile pr-parity`.
