### PR TITLE
CI: persist validator Go/Cargo build cache across runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,25 @@ jobs:
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
           version: ${{ env.WORKCELL_BUILDX_VERSION }}
 
+      # Persist the validator's Go/Cargo build+test artifacts across runs to cut
+      # the from-cold compile cost inside the validate container.  Keyed on the
+      # dependency lockfiles so a toolchain/dep change is a clean miss.  GitHub
+      # scopes caches per-branch (a PR cannot poison main's cache), and the
+      # cached artifacts are content-addressed (Go) / fingerprinted (Cargo), so
+      # a stale entry forces a rebuild, never a wrong pass.  The
+      # reproducible-build job is separate and stays --no-cache.
+      - name: Restore validator build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.temp }}/workcell-validator-home/.cache
+          key: validate-buildcache-${{ runner.os }}-${{ hashFiles('go.sum', 'runtime/container/rust/Cargo.lock') }}
+          restore-keys: |
+            validate-buildcache-${{ runner.os }}-
+
       - name: Validate repository
         env:
           WORKCELL_VALIDATOR_IMAGE: workcell-validator:${{ github.sha }}
+          WORKCELL_VALIDATOR_HOST_HOME_DIR: ${{ runner.temp }}/workcell-validator-home
           WORKCELL_VALIDATOR_BUILDX_CACHE_MODE: gha
           # Segregate the gha cache scope: PR runs write to a PR-keyed
           # scope, push-to-main writes to validator-main.  build-validator-image.sh

--- a/scripts/ci/run-validate-in-validator.sh
+++ b/scripts/ci/run-validate-in-validator.sh
@@ -38,6 +38,25 @@ validator_tmp="${validator_home}/.tmp"
 
 setup_workcell_ci_docker
 
+# Optional persistent build cache: when WORKCELL_VALIDATOR_HOST_HOME_DIR is set
+# (CI restores its .cache subdir via actions/cache), bind-mount it as the
+# validator HOME so Go/Cargo build artifacts under ${validator_cache} survive
+# across runs.  We mount the home dir itself (not just .cache) because mounting
+# a subdir would make Docker create the home as root, blocking the unprivileged
+# container user from creating sibling .tmp.  The host dir is created by — and
+# therefore owned by — the same uid the container runs as, so the user can
+# write.  Default (env unset) keeps the run byte-identical to the ephemeral
+# behavior the other callers rely on.  Only incremental build/test artifacts are
+# persisted (content-addressed by Go, fingerprinted by Cargo — a stale entry is
+# a rebuild, never a wrong pass); the reproducible-build job is separate and
+# stays --no-cache.
+host_home_mount=()
+host_home_dir="${WORKCELL_VALIDATOR_HOST_HOME_DIR:-}"
+if [[ -n "${host_home_dir}" ]]; then
+  mkdir -p "${host_home_dir}"
+  host_home_mount=(-v "${host_home_dir}:${validator_home}")
+fi
+
 # shellcheck disable=SC2016
 workcell_ci_docker run --rm \
   --user "${validator_uid}:${validator_gid}" \
@@ -50,6 +69,7 @@ workcell_ci_docker run --rm \
   -e GOMODCACHE="${validator_cache}/go-mod" \
   -e CARGO_TARGET_DIR="${validator_cache}/cargo-target" \
   -e TMPDIR="${validator_tmp}" \
+  "${host_home_mount[@]}" \
   -v "${WORKSPACE}:/workspace" \
   -w /workspace \
   "${VALIDATOR_IMAGE}" \


### PR DESCRIPTION
## Summary

Optimization #2 of the CI/deploy series. The `Validate repository` job (~11m, the CI gating critical path after PR #306) recompiles Go + Rust from cold every run because the validator container's cache dirs are ephemeral. This persists them across runs.

- `ci.yml`: restore a host dir via `actions/cache` (SHA-pinned v5.0.5), keyed on `go.sum` + `runtime/container/rust/Cargo.lock`, passed to the validate step as `WORKCELL_VALIDATOR_HOST_CACHE_DIR`.
- `run-validate-in-validator.sh`: bind-mount that dir over `${validator_cache}` **only when the env var is set**; the default path is byte-identical to today (other callers unaffected).

## ⚠️ Empirical validation in progress

Cache savings only appear on a **warm** run. This PR's first CI run is **cold** (populates the cache, slightly slower from the save). I'll trigger a second run to measure warm savings and post the cold-vs-warm numbers here. **If warm savings aren't meaningful net of cache I/O, I'll close this PR** — per the repo's "empirical evidence, not guesses" rule.

## Invariant safety

- The four `-e GOCACHE/GOMODCACHE/CARGO_TARGET_DIR/XDG_CACHE_HOME` lines + `mkdir` that `verify-invariants.sh` asserts are kept **byte-identical** (verified locally).
- Reproducible-build job is separate and stays `--no-cache` + double-build.
- GitHub scopes caches per-branch (a PR cannot poison main's cache); Go cache is content-addressed, Cargo fingerprinted — a stale entry rebuilds, never mis-serves a pass.
- Cached artifacts are build/test intermediates, never shipped.

## Posture note

This introduces caching into the **validation** pipeline (previously clean-from-cold). It's correctness-preserving, but it is a posture change worth your explicit call — flagging for review rather than auto-merging.

## Testing

Local: `verify-invariants.sh`, `actionlint`, `zizmor` (auditor), `shellcheck`, `check-pinned-inputs.sh`, `verify-workflow-lanes.sh`, `go test ./internal/metadatautil/...`, full `pre-merge.sh --profile pr-parity` (exercises the default unmounted path).
