### PR TITLE
Add fail-closed Copilot adapter scaffold

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -9,6 +9,10 @@ Current adapters:
 - `claude/`
 - `gemini/`
 
+Planned fail-closed scaffolds:
+
+- `copilot/`
+
 Adapter rules:
 
 - keep the adapter thin
@@ -19,8 +23,9 @@ Adapter rules:
 ## Adding a new provider
 
 Per-provider Go tables (credential keys, container paths, reserved
-targets) live in `internal/adapters/data.go` — adding a new provider is
-a single row append to the `providers` slice plus the per-provider
-config tree under `adapters/<name>/`. There is no longer a per-provider
-Go sub-package; see `internal/adapters/adapters.go` for the public API
-that the injection, policy, and runtime paths consume.
+targets) live in `internal/adapters/data.go` — promoting a planned provider is
+a single row append to the `providers` slice plus the per-provider config tree
+under `adapters/<name>/`. There is no longer a per-provider Go sub-package; see
+`internal/adapters/adapters.go` for the public API that the injection, policy,
+and runtime paths consume. A provider directory without a registry row is only a
+fail-closed scaffold.

--- a/adapters/copilot/README.md
+++ b/adapters/copilot/README.md
@@ -1,0 +1,18 @@
+# GitHub Copilot CLI Adapter
+
+This adapter directory is a fail-closed planning scaffold. Workcell recognizes
+`copilot` as the planned GitHub Copilot CLI provider id, but it does not install,
+prepare, authenticate, or launch Copilot yet.
+
+Support promotion requires the same review unit to add:
+
+- a pinned Copilot CLI install path with provenance evidence
+- explicit `COPILOT_HOME` and cache-state handling under `/state/agent-home`
+- a staged `COPILOT_GITHUB_TOKEN` or equivalent reviewed auth handoff that does
+  not mount host GitHub CLI state, host homes, or provider caches
+- provider-native unsafe-flag rejection in the Workcell wrapper
+- deterministic dry-run and scenario coverage
+- a live provider certification run before any supported Tier 1 matrix claim
+
+Until those gates land, `workcell --agent copilot` exits before runtime
+preparation with an unsupported-provider diagnostic.

--- a/docs/provider-matrix.md
+++ b/docs/provider-matrix.md
@@ -15,7 +15,7 @@ through a native control-plane mapping.
 
 | Provider | Planned Tier 1 surface | Planned managed control plane | Planned auth input | Support status |
 |---|---|---|---|---|
-| GitHub Copilot CLI | `workcell --agent copilot --workspace ...` | session-local `COPILOT_HOME`, `COPILOT_CACHE_HOME`, `~/.copilot` config, permissions, sessions, logs, plugins, hooks, MCP/LSP state, and reviewed instruction imports | explicit staged token such as `copilot_github_token`, exported only to the managed child as `COPILOT_GITHUB_TOKEN` | roadmap parity track; not current support |
+| GitHub Copilot CLI | `workcell --agent copilot --workspace ...` | session-local `COPILOT_HOME`, `COPILOT_CACHE_HOME`, `~/.copilot` config, permissions, sessions, logs, plugins, hooks, MCP/LSP state, and reviewed instruction imports | explicit staged token such as `copilot_github_token`, exported only to the managed child as `COPILOT_GITHUB_TOKEN` | fail-closed scaffold; not current support |
 
 The current sequencing plan for the Copilot parity track is
 [docs/copilot-linux-local-compat-plan.md](copilot-linux-local-compat-plan.md).

--- a/internal/providerid/doc.go
+++ b/internal/providerid/doc.go
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Omkhar Arasaratnam
 
-// Package providerid is the canonical source of the supported provider id
-// strings (Claude, Codex, Gemini today; Copilot is a roadmap addition).
+// Package providerid is the canonical source of provider id strings. Claude,
+// Codex, and Gemini are supported today; Copilot is a planned fail-closed id
+// until its runtime adapter and certification evidence land.
 //
 // Before this package existed, "claude" / "codex" / "gemini" were spelled as
 // raw string literals in 70+ sites across internal/ and cmd/, with three

--- a/internal/providerid/providerid.go
+++ b/internal/providerid/providerid.go
@@ -10,6 +10,10 @@ const (
 	Claude = "claude"
 	// Codex is the OpenAI Codex provider identifier.
 	Codex = "codex"
+	// Copilot is the GitHub Copilot CLI provider identifier. It is a
+	// planned fail-closed adapter, not a member of AllProviders until
+	// runtime support and certification evidence land.
+	Copilot = "copilot"
 	// Gemini is the Google Gemini provider identifier.
 	Gemini = "gemini"
 )

--- a/internal/providerid/providerid_test.go
+++ b/internal/providerid/providerid_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package providerid
+
+import "testing"
+
+func TestCopilotRemainsPlannedUntilCertified(t *testing.T) {
+	if Copilot != "copilot" {
+		t.Fatalf("Copilot = %q, want copilot", Copilot)
+	}
+	if IsValid(Copilot) {
+		t.Fatal("Copilot must stay out of the supported-provider set until runtime support and certification land")
+	}
+}

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -57,6 +57,11 @@ credential.
 .TP
 .B --agent codex|claude|gemini
 Select the provider to run. This option is required.
+The
+.B copilot
+provider id is recognized only as a planned fail-closed adapter; current
+releases exit before runtime preparation because no Copilot runtime, auth
+handoff, or live certification evidence is shipped.
 .TP
 .B --agent-autonomy yolo|prompt
 Select the provider approval posture. The default is

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "6810c253f0c572b6801fa47dbe3a7ce06e60fa0f20b33932ff26f9b3e218fc75"
+      "sha256": "48db57df9276fc8e0440a1a5031b1d9efc39d36d93fa7831363dac3527b4a3fb"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -4031,6 +4031,13 @@ fi
 grep -q "Option --agent is required." /tmp/workcell-missing-agent.out
 grep -q '^Usage: workcell' /tmp/workcell-missing-agent.out
 
+if "${ROOT_DIR}/scripts/workcell" --agent copilot --dry-run >/tmp/workcell-copilot-fail-closed.out 2>&1; then
+  echo "Expected planned Copilot adapter to fail closed until runtime support and certification land" >&2
+  exit 1
+fi
+grep -q "GitHub Copilot CLI is a planned Workcell Tier 1 adapter, but it is not supported yet." /tmp/workcell-copilot-fail-closed.out
+grep -q "No Copilot runtime, auth handoff, or live certification evidence is shipped in this build." /tmp/workcell-copilot-fail-closed.out
+
 STRICT_PREFLIGHT_WORKSPACE="${BARRIER_VERIFY_ROOT}/strict-preflight-workspace"
 mkdir -p "${STRICT_PREFLIGHT_WORKSPACE}"
 printf '# marker\n' >"${STRICT_PREFLIGHT_WORKSPACE}/AGENTS.md"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -339,6 +339,7 @@ Usage: workcell [options] [-- provider-args...]
 
 Options:
   --agent codex|claude|gemini   Provider to run (required)
+                              copilot is recognized as planned but unsupported
   --agent-autonomy yolo|prompt  Provider approval posture (default: yolo)
   --agent-arg VALUE             Additional provider argv to append (repeatable)
   --target colima|docker-desktop|aws-ec2-ssm|gcp-vm
@@ -7815,6 +7816,11 @@ fi
 if [[ -n "${AGENT}" ]]; then
   case "${AGENT}" in
     codex | claude | gemini) ;;
+    copilot)
+      echo "GitHub Copilot CLI is a planned Workcell Tier 1 adapter, but it is not supported yet." >&2
+      echo "No Copilot runtime, auth handoff, or live certification evidence is shipped in this build." >&2
+      exit 2
+      ;;
     *)
       echo "Unsupported agent: ${AGENT}" >&2
       exit 2


### PR DESCRIPTION
## Summary
- recognize copilot as a planned provider id while keeping it outside supported provider validation
- add a fail-closed dry-run gate before runtime preparation or launch
- document the unsupported scaffold and promotion gates across adapter docs, matrix, manpage, and invariants

## Validation
- ./scripts/pre-merge.sh --profile pr-parity