### PR TITLE
Add distro-scoped host support matrix fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ boundary.
   GitHub-hosted Linux runners cannot prove it
 - the canonical host support boundary lives in
   [policy/host-support-matrix.tsv](policy/host-support-matrix.tsv), and
-  `--doctor` / `--inspect` emit matching `support_matrix_*` lines
+  `--doctor` / `--inspect` emit matching host and `support_matrix_*` lines
 - Workcell does not yet ship a centralized enterprise policy, inventory, or
   analytics plane; team rollout today relies on distributing reviewed
   host-side files

--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -266,7 +266,7 @@ func helperSubcommands() []helperSubcommand {
 		{"canonicalize-tool-path", 1, 1, cmdHelperCanonicalizeToolPath},
 		{"dedupe-endpoints", 1, 1, cmdHelperDedupeEndpoints},
 		{"resolve-endpoints", 1, 1, cmdHelperResolveEndpoints},
-		{"support-matrix-eval", 6, 6, cmdHelperSupportMatrixEval},
+		{"support-matrix-eval", 8, 8, cmdHelperSupportMatrixEval},
 		{"profile-path", 1, -1, cmdHelperProfilePath},
 		// PR 23.4 — injection bundle preparation moved into Go.
 		{"injection-stage-direct-mounts", 2, 2, cmdHelperInjectionStageDirectMounts},
@@ -737,9 +737,11 @@ func cmdHelperSupportMatrixEval(args []string) error {
 	result, err := supportmatrix.Evaluate(args[0], supportmatrix.Query{
 		HostOS:               args[1],
 		HostArch:             args[2],
-		TargetKind:           args[3],
-		TargetProvider:       args[4],
-		TargetAssuranceClass: args[5],
+		HostDistro:           args[3],
+		HostDistroVersion:    args[4],
+		TargetKind:           args[5],
+		TargetProvider:       args[6],
+		TargetAssuranceClass: args[7],
 	})
 	if err != nil {
 		return err

--- a/docs/copilot-linux-local-compat-plan.md
+++ b/docs/copilot-linux-local-compat-plan.md
@@ -108,9 +108,10 @@ Initial candidate rows should preserve this shape:
 | Fedora Workstation/Server | `amd64` | `local_compat` | selected compatible runtime | `compat` | unsupported until separately reviewed |
 | Arch Linux | `amd64` | `local_compat` | selected compatible runtime | `compat` | unsupported until separately reviewed |
 
-The machine-readable matrix currently lacks distro/version columns. If Linux
-candidate rows need distro scoping, add that schema deliberately with parser
-tests and docs rather than encoding distro names only in free-form reasons.
+The machine-readable matrix now includes `host_distro` and
+`host_distro_version` columns. Current Linux rows use `any` wildcards and keep
+launch blocked; future candidate rows can be narrowed to exact Debian stable,
+Ubuntu LTS, Fedora, or Arch versions before any live certification claim.
 
 ## Pre-Signing Gates
 

--- a/docs/host-expansion-readiness.md
+++ b/docs/host-expansion-readiness.md
@@ -54,8 +54,8 @@ Later host tracks remain separate:
 
 Any future host promotion must land atomically with:
 
-- a canonical host-support matrix row for the exact host, architecture, target
-  kind, provider, and assurance class
+- a canonical host-support matrix row for the exact host OS, architecture,
+  distro, distro version, target kind, provider, and assurance class
 - fail-closed `doctor`, `inspect`, and launch diagnostics outside that row
 - install, uninstall, upgrade, rollback, and support-bundle guidance
 - deterministic repo-required tests for selection, unsupported combinations, and
@@ -74,6 +74,7 @@ Unsupported host combinations must remain blocked by default. Diagnostics should
 show:
 
 - selected host OS and architecture
+- selected Linux distro and distro version, or `none` for non-Linux hosts
 - target kind, provider, and assurance class
 - support-matrix status and reason
 - whether evidence is repo-required, locally mirrored, certification-only, or

--- a/internal/host/supportmatrix/doc.go
+++ b/internal/host/supportmatrix/doc.go
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Omkhar Arasaratnam
 
-// Package supportmatrix carries the host-side support tier
-// classification: which macOS versions are tested vs preview, which
-// CPU architectures and Colima versions are supported, and the policy
-// entries that policy/host-support-matrix.tsv expresses.  The launch
-// path uses this to fail-fast on unsupported hosts and to decide
-// which assurance label a session entry record should carry.
+// Package supportmatrix carries the host-side support tier classification:
+// which host OS, architecture, distro, distro version, runtime target, and
+// assurance combinations policy/host-support-matrix.tsv expresses. The launch
+// path uses this to fail-fast on unsupported hosts and to decide which
+// assurance label a session entry record should carry.
 package supportmatrix

--- a/internal/host/supportmatrix/supportmatrix.go
+++ b/internal/host/supportmatrix/supportmatrix.go
@@ -13,6 +13,8 @@ import (
 type Query struct {
 	HostOS               string
 	HostArch             string
+	HostDistro           string
+	HostDistroVersion    string
 	TargetKind           string
 	TargetProvider       string
 	TargetAssuranceClass string
@@ -21,6 +23,8 @@ type Query struct {
 type Result struct {
 	HostOS               string
 	HostArch             string
+	HostDistro           string
+	HostDistroVersion    string
 	TargetKind           string
 	TargetProvider       string
 	TargetAssuranceClass string
@@ -34,6 +38,8 @@ type Result struct {
 var columns = []string{
 	"host_os",
 	"host_arch",
+	"host_distro",
+	"host_distro_version",
 	"target_kind",
 	"target_provider",
 	"target_assurance_class",
@@ -76,7 +82,7 @@ func Evaluate(path string, query Query) (Result, error) {
 			return result, err
 		}
 		if entry.matches(query) {
-			return entry, nil
+			return entry.withQueryHost(query), nil
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -92,6 +98,8 @@ func MetadataLines(result Result) []string {
 	return []string{
 		fmt.Sprintf("host_os=%s", result.HostOS),
 		fmt.Sprintf("host_arch=%s", result.HostArch),
+		fmt.Sprintf("host_distro=%s", result.HostDistro),
+		fmt.Sprintf("host_distro_version=%s", result.HostDistroVersion),
 		fmt.Sprintf("support_matrix_status=%s", result.Status),
 		fmt.Sprintf("support_matrix_launch=%s", result.Launch),
 		fmt.Sprintf("support_matrix_evidence=%s", result.Evidence),
@@ -103,6 +111,8 @@ func MetadataLines(result Result) []string {
 func normalizeQuery(query Query) Query {
 	query.HostOS = strings.TrimSpace(query.HostOS)
 	query.HostArch = strings.TrimSpace(query.HostArch)
+	query.HostDistro = strings.TrimSpace(query.HostDistro)
+	query.HostDistroVersion = strings.TrimSpace(query.HostDistroVersion)
 	query.TargetKind = strings.TrimSpace(query.TargetKind)
 	query.TargetProvider = strings.TrimSpace(query.TargetProvider)
 	query.TargetAssuranceClass = strings.TrimSpace(query.TargetAssuranceClass)
@@ -113,6 +123,8 @@ func defaultResult(query Query) Result {
 	return Result{
 		HostOS:               query.HostOS,
 		HostArch:             query.HostArch,
+		HostDistro:           query.HostDistro,
+		HostDistroVersion:    query.HostDistroVersion,
 		TargetKind:           query.TargetKind,
 		TargetProvider:       query.TargetProvider,
 		TargetAssuranceClass: query.TargetAssuranceClass,
@@ -144,14 +156,16 @@ func parseEntry(path string, lineNo int, fields []string) (Result, error) {
 	entry := Result{
 		HostOS:               strings.TrimSpace(fields[0]),
 		HostArch:             strings.TrimSpace(fields[1]),
-		TargetKind:           strings.TrimSpace(fields[2]),
-		TargetProvider:       strings.TrimSpace(fields[3]),
-		TargetAssuranceClass: strings.TrimSpace(fields[4]),
-		Status:               strings.TrimSpace(fields[5]),
-		Launch:               strings.TrimSpace(fields[6]),
-		Evidence:             strings.TrimSpace(fields[7]),
-		ValidationLane:       strings.TrimSpace(fields[8]),
-		Reason:               strings.TrimSpace(fields[9]),
+		HostDistro:           strings.TrimSpace(fields[2]),
+		HostDistroVersion:    strings.TrimSpace(fields[3]),
+		TargetKind:           strings.TrimSpace(fields[4]),
+		TargetProvider:       strings.TrimSpace(fields[5]),
+		TargetAssuranceClass: strings.TrimSpace(fields[6]),
+		Status:               strings.TrimSpace(fields[7]),
+		Launch:               strings.TrimSpace(fields[8]),
+		Evidence:             strings.TrimSpace(fields[9]),
+		ValidationLane:       strings.TrimSpace(fields[10]),
+		Reason:               strings.TrimSpace(fields[11]),
 	}
 
 	for _, pair := range []struct {
@@ -160,6 +174,8 @@ func parseEntry(path string, lineNo int, fields []string) (Result, error) {
 	}{
 		{name: "host_os", value: entry.HostOS},
 		{name: "host_arch", value: entry.HostArch},
+		{name: "host_distro", value: entry.HostDistro},
+		{name: "host_distro_version", value: entry.HostDistroVersion},
 		{name: "target_kind", value: entry.TargetKind},
 		{name: "target_provider", value: entry.TargetProvider},
 		{name: "target_assurance_class", value: entry.TargetAssuranceClass},
@@ -202,9 +218,23 @@ func parseEntry(path string, lineNo int, fields []string) (Result, error) {
 }
 
 func (entry Result) matches(query Query) bool {
-	return entry.HostOS == query.HostOS &&
-		entry.HostArch == query.HostArch &&
+	return matrixFieldMatches(entry.HostOS, query.HostOS) &&
+		matrixFieldMatches(entry.HostArch, query.HostArch) &&
+		matrixFieldMatches(entry.HostDistro, query.HostDistro) &&
+		matrixFieldMatches(entry.HostDistroVersion, query.HostDistroVersion) &&
 		entry.TargetKind == query.TargetKind &&
 		entry.TargetProvider == query.TargetProvider &&
 		entry.TargetAssuranceClass == query.TargetAssuranceClass
+}
+
+func matrixFieldMatches(rowValue, queryValue string) bool {
+	return rowValue == "any" || rowValue == queryValue
+}
+
+func (entry Result) withQueryHost(query Query) Result {
+	entry.HostOS = query.HostOS
+	entry.HostArch = query.HostArch
+	entry.HostDistro = query.HostDistro
+	entry.HostDistroVersion = query.HostDistroVersion
+	return entry
 }

--- a/internal/host/supportmatrix/supportmatrix_test.go
+++ b/internal/host/supportmatrix/supportmatrix_test.go
@@ -17,6 +17,8 @@ func TestEvaluateMatchesReviewedRow(t *testing.T) {
 	result, err := Evaluate(path, Query{
 		HostOS:               "macos",
 		HostArch:             "arm64",
+		HostDistro:           "none",
+		HostDistroVersion:    "none",
 		TargetKind:           "local_vm",
 		TargetProvider:       "colima",
 		TargetAssuranceClass: "strict",
@@ -45,6 +47,8 @@ func TestEvaluateReturnsValidationHostLane(t *testing.T) {
 	result, err := Evaluate(path, Query{
 		HostOS:               "linux",
 		HostArch:             "amd64",
+		HostDistro:           "debian",
+		HostDistroVersion:    "13",
 		TargetKind:           "local_vm",
 		TargetProvider:       "colima",
 		TargetAssuranceClass: "strict",
@@ -64,6 +68,9 @@ func TestEvaluateReturnsValidationHostLane(t *testing.T) {
 	if result.ValidationLane != "trusted-linux-amd64-validator" {
 		t.Fatalf("validation_lane = %q, want trusted-linux-amd64-validator", result.ValidationLane)
 	}
+	if result.HostDistro != "debian" || result.HostDistroVersion != "13" {
+		t.Fatalf("host distro = %q/%q, want debian/13", result.HostDistro, result.HostDistroVersion)
+	}
 }
 
 func TestEvaluateReturnsPreviewOnlyRow(t *testing.T) {
@@ -78,6 +85,8 @@ func TestEvaluateReturnsPreviewOnlyRow(t *testing.T) {
 			result, err := Evaluate(path, Query{
 				HostOS:               "macos",
 				HostArch:             "arm64",
+				HostDistro:           "none",
+				HostDistroVersion:    "none",
 				TargetKind:           "remote_vm",
 				TargetProvider:       provider,
 				TargetAssuranceClass: "compat",
@@ -108,6 +117,8 @@ func TestEvaluateDefaultsToUnsupported(t *testing.T) {
 	result, err := Evaluate(path, Query{
 		HostOS:               "windows",
 		HostArch:             "amd64",
+		HostDistro:           "none",
+		HostDistroVersion:    "none",
 		TargetKind:           "local_vm",
 		TargetProvider:       "colima",
 		TargetAssuranceClass: "strict",
@@ -138,8 +149,8 @@ func TestEvaluateRejectsInvalidRows(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "host-support-matrix.tsv")
 	if err := os.WriteFile(path, []byte(strings.Join([]string{
-		"host_os\thost_arch\ttarget_kind\ttarget_provider\ttarget_assurance_class\tstatus\tlaunch\tevidence\tvalidation_lane\treason",
-		"linux\tamd64\tlocal_vm\tcolima\tstrict\tvalidation-host-only\tblocked\trepo-required\tnone\tbad-row",
+		"host_os\thost_arch\thost_distro\thost_distro_version\ttarget_kind\ttarget_provider\ttarget_assurance_class\tstatus\tlaunch\tevidence\tvalidation_lane\treason",
+		"linux\tamd64\tany\tany\tlocal_vm\tcolima\tstrict\tvalidation-host-only\tblocked\trepo-required\tnone\tbad-row",
 	}, "\n")+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -147,6 +158,8 @@ func TestEvaluateRejectsInvalidRows(t *testing.T) {
 	_, err := Evaluate(path, Query{
 		HostOS:               "linux",
 		HostArch:             "amd64",
+		HostDistro:           "debian",
+		HostDistroVersion:    "13",
 		TargetKind:           "local_vm",
 		TargetProvider:       "colima",
 		TargetAssuranceClass: "strict",
@@ -163,11 +176,11 @@ func writeSupportMatrixFixture(t *testing.T) string {
 	path := filepath.Join(dir, "host-support-matrix.tsv")
 	content := strings.Join([]string{
 		"# reviewed host support matrix fixture",
-		"host_os\thost_arch\ttarget_kind\ttarget_provider\ttarget_assurance_class\tstatus\tlaunch\tevidence\tvalidation_lane\treason",
-		"macos\tarm64\tlocal_vm\tcolima\tstrict\tsupported\tallowed\tcertification-only\tnone\tapple-silicon-macos-reviewed-launch-host",
-		"macos\tarm64\tremote_vm\taws-ec2-ssm\tcompat\tpreview-only\tblocked\tcertification-only\tnone\tapple-silicon-macos-aws-ec2-ssm-preview-certification-only",
-		"macos\tarm64\tremote_vm\tgcp-vm\tcompat\tpreview-only\tblocked\tcertification-only\tnone\tapple-silicon-macos-gcp-vm-preview-certification-only",
-		"linux\tamd64\tlocal_vm\tcolima\tstrict\tvalidation-host-only\tblocked\trepo-required\ttrusted-linux-amd64-validator\ttrusted-linux-amd64-validation-host-only",
+		"host_os\thost_arch\thost_distro\thost_distro_version\ttarget_kind\ttarget_provider\ttarget_assurance_class\tstatus\tlaunch\tevidence\tvalidation_lane\treason",
+		"macos\tarm64\tnone\tnone\tlocal_vm\tcolima\tstrict\tsupported\tallowed\tcertification-only\tnone\tapple-silicon-macos-reviewed-launch-host",
+		"macos\tarm64\tnone\tnone\tremote_vm\taws-ec2-ssm\tcompat\tpreview-only\tblocked\tcertification-only\tnone\tapple-silicon-macos-aws-ec2-ssm-preview-certification-only",
+		"macos\tarm64\tnone\tnone\tremote_vm\tgcp-vm\tcompat\tpreview-only\tblocked\tcertification-only\tnone\tapple-silicon-macos-gcp-vm-preview-certification-only",
+		"linux\tamd64\tany\tany\tlocal_vm\tcolima\tstrict\tvalidation-host-only\tblocked\trepo-required\ttrusted-linux-amd64-validator\ttrusted-linux-amd64-validation-host-only",
 	}, "\n") + "\n"
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)

--- a/policy/host-support-matrix.tsv
+++ b/policy/host-support-matrix.tsv
@@ -1,22 +1,22 @@
 # Canonical reviewed host support matrix for Workcell launch and validation lanes.
-host_os	host_arch	target_kind	target_provider	target_assurance_class	status	launch	evidence	validation_lane	reason
-macos	arm64	local_vm	colima	strict	supported	allowed	certification-only	none	apple-silicon-macos-reviewed-launch-host
-macos	arm64	local_compat	docker-desktop	compat	supported	allowed	certification-only	none	apple-silicon-macos-docker-desktop-compat-reviewed-launch-host
-macos	arm64	remote_vm	aws-ec2-ssm	compat	preview-only	blocked	certification-only	none	apple-silicon-macos-aws-ec2-ssm-preview-certification-only
-macos	arm64	remote_vm	gcp-vm	compat	preview-only	blocked	certification-only	none	apple-silicon-macos-gcp-vm-preview-certification-only
-linux	amd64	local_vm	colima	strict	validation-host-only	blocked	repo-required	trusted-linux-amd64-validator	trusted-linux-amd64-validation-host-only
-linux	amd64	local_compat	docker-desktop	compat	unsupported	blocked	none	none	linux-docker-desktop-hosts-not-yet-reviewed
-linux	amd64	remote_vm	aws-ec2-ssm	compat	validation-host-only	blocked	repo-required	trusted-linux-amd64-validator	trusted-linux-amd64-aws-ec2-ssm-deterministic-preview
-linux	amd64	remote_vm	gcp-vm	compat	validation-host-only	blocked	repo-required	trusted-linux-amd64-validator	trusted-linux-amd64-gcp-vm-deterministic-preview
-linux	arm64	local_vm	colima	strict	unsupported	blocked	none	none	linux-arm64-hosts-not-yet-reviewed
-linux	arm64	local_compat	docker-desktop	compat	unsupported	blocked	none	none	linux-arm64-docker-desktop-hosts-not-yet-reviewed
-linux	arm64	remote_vm	aws-ec2-ssm	compat	unsupported	blocked	none	none	linux-arm64-aws-ec2-ssm-hosts-not-yet-reviewed
-linux	arm64	remote_vm	gcp-vm	compat	unsupported	blocked	none	none	linux-arm64-gcp-vm-hosts-not-yet-reviewed
-windows	amd64	local_vm	colima	strict	unsupported	blocked	none	none	windows-hosts-not-yet-reviewed
-windows	amd64	local_compat	docker-desktop	compat	unsupported	blocked	none	none	windows-docker-desktop-hosts-not-yet-reviewed
-windows	amd64	remote_vm	aws-ec2-ssm	compat	unsupported	blocked	none	none	windows-aws-ec2-ssm-hosts-not-yet-reviewed
-windows	amd64	remote_vm	gcp-vm	compat	unsupported	blocked	none	none	windows-gcp-vm-hosts-not-yet-reviewed
-windows	arm64	local_vm	colima	strict	unsupported	blocked	none	none	windows-hosts-not-yet-reviewed
-windows	arm64	local_compat	docker-desktop	compat	unsupported	blocked	none	none	windows-arm64-docker-desktop-hosts-not-yet-reviewed
-windows	arm64	remote_vm	aws-ec2-ssm	compat	unsupported	blocked	none	none	windows-arm64-aws-ec2-ssm-hosts-not-yet-reviewed
-windows	arm64	remote_vm	gcp-vm	compat	unsupported	blocked	none	none	windows-arm64-gcp-vm-hosts-not-yet-reviewed
+host_os	host_arch	host_distro	host_distro_version	target_kind	target_provider	target_assurance_class	status	launch	evidence	validation_lane	reason
+macos	arm64	none	none	local_vm	colima	strict	supported	allowed	certification-only	none	apple-silicon-macos-reviewed-launch-host
+macos	arm64	none	none	local_compat	docker-desktop	compat	supported	allowed	certification-only	none	apple-silicon-macos-docker-desktop-compat-reviewed-launch-host
+macos	arm64	none	none	remote_vm	aws-ec2-ssm	compat	preview-only	blocked	certification-only	none	apple-silicon-macos-aws-ec2-ssm-preview-certification-only
+macos	arm64	none	none	remote_vm	gcp-vm	compat	preview-only	blocked	certification-only	none	apple-silicon-macos-gcp-vm-preview-certification-only
+linux	amd64	any	any	local_vm	colima	strict	validation-host-only	blocked	repo-required	trusted-linux-amd64-validator	trusted-linux-amd64-validation-host-only
+linux	amd64	any	any	local_compat	docker-desktop	compat	unsupported	blocked	none	none	linux-docker-desktop-hosts-not-yet-reviewed
+linux	amd64	any	any	remote_vm	aws-ec2-ssm	compat	validation-host-only	blocked	repo-required	trusted-linux-amd64-validator	trusted-linux-amd64-aws-ec2-ssm-deterministic-preview
+linux	amd64	any	any	remote_vm	gcp-vm	compat	validation-host-only	blocked	repo-required	trusted-linux-amd64-validator	trusted-linux-amd64-gcp-vm-deterministic-preview
+linux	arm64	any	any	local_vm	colima	strict	unsupported	blocked	none	none	linux-arm64-hosts-not-yet-reviewed
+linux	arm64	any	any	local_compat	docker-desktop	compat	unsupported	blocked	none	none	linux-arm64-docker-desktop-hosts-not-yet-reviewed
+linux	arm64	any	any	remote_vm	aws-ec2-ssm	compat	unsupported	blocked	none	none	linux-arm64-aws-ec2-ssm-hosts-not-yet-reviewed
+linux	arm64	any	any	remote_vm	gcp-vm	compat	unsupported	blocked	none	none	linux-arm64-gcp-vm-hosts-not-yet-reviewed
+windows	amd64	none	none	local_vm	colima	strict	unsupported	blocked	none	none	windows-hosts-not-yet-reviewed
+windows	amd64	none	none	local_compat	docker-desktop	compat	unsupported	blocked	none	none	windows-docker-desktop-hosts-not-yet-reviewed
+windows	amd64	none	none	remote_vm	aws-ec2-ssm	compat	unsupported	blocked	none	none	windows-aws-ec2-ssm-hosts-not-yet-reviewed
+windows	amd64	none	none	remote_vm	gcp-vm	compat	unsupported	blocked	none	none	windows-gcp-vm-hosts-not-yet-reviewed
+windows	arm64	none	none	local_vm	colima	strict	unsupported	blocked	none	none	windows-hosts-not-yet-reviewed
+windows	arm64	none	none	local_compat	docker-desktop	compat	unsupported	blocked	none	none	windows-arm64-docker-desktop-hosts-not-yet-reviewed
+windows	arm64	none	none	remote_vm	aws-ec2-ssm	compat	unsupported	blocked	none	none	windows-arm64-aws-ec2-ssm-hosts-not-yet-reviewed
+windows	arm64	none	none	remote_vm	gcp-vm	compat	unsupported	blocked	none	none	windows-arm64-gcp-vm-hosts-not-yet-reviewed

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "48db57df9276fc8e0440a1a5031b1d9efc39d36d93fa7831363dac3527b4a3fb"
+      "sha256": "6aa65fa01844e6993eb03b32ad80ab67bf80c445454b02d2264f534f6f4668a0"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -181,6 +181,38 @@ detected_verify_host_arch() {
   esac
 }
 
+detected_verify_host_distro() {
+  local host_distro=""
+
+  if [[ "$(detected_verify_host_os)" != "linux" ]]; then
+    printf 'none\n'
+    return 0
+  fi
+  if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    host_distro="${ID:-}"
+  fi
+  [[ -n "${host_distro}" ]] || host_distro="unknown"
+  printf '%s\n' "$(printf '%s' "${host_distro}" | tr '[:upper:]' '[:lower:]')"
+}
+
+detected_verify_host_distro_version() {
+  local host_distro_version=""
+
+  if [[ "$(detected_verify_host_os)" != "linux" ]]; then
+    printf 'none\n'
+    return 0
+  fi
+  if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    host_distro_version="${VERSION_ID:-${VERSION_CODENAME:-}}"
+  fi
+  [[ -n "${host_distro_version}" ]] || host_distro_version="unknown"
+  printf '%s\n' "$(printf '%s' "${host_distro_version}" | tr '[:upper:]' '[:lower:]')"
+}
+
 HOST_GATE_SCRIPTS=(
   "${ROOT_DIR}/scripts/build-and-test.sh"
   "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
@@ -243,6 +275,8 @@ ROOT_STRICT_SUPPORT_OUTPUT="$(
     "${ROOT_DIR}/policy/host-support-matrix.tsv" \
     "$(detected_verify_host_os)" \
     "$(detected_verify_host_arch)" \
+    "$(detected_verify_host_distro)" \
+    "$(detected_verify_host_distro_version)" \
     local_vm \
     colima \
     strict
@@ -250,6 +284,8 @@ ROOT_STRICT_SUPPORT_OUTPUT="$(
 if grep -q '^support_matrix_launch=blocked$' <<<"${ROOT_STRICT_SUPPORT_OUTPUT}"; then
   export WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS="macos"
   export WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH="arm64"
+  export WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO="none"
+  export WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION="none"
 fi
 
 run_workcell_verify() {
@@ -260,11 +296,17 @@ run_workcell_verify() {
   done
   [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS:-}" ]] && cmd+=(WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS="${WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS}")
   [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH:-}" ]] && cmd+=(WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH="${WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH}")
+  [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO:-}" ]] && cmd+=(WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO="${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO}")
+  [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION:-}" ]] && cmd+=(WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION="${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION}")
   "${cmd[@]}" /bin/bash -p "${ROOT_DIR}/scripts/workcell" "$@"
 }
 
 run_workcell_real_host() {
-  env -u WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS -u WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH "${ROOT_DIR}/scripts/workcell" "$@"
+  env -u WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS \
+    -u WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH \
+    -u WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO \
+    -u WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION \
+    "${ROOT_DIR}/scripts/workcell" "$@"
 }
 
 delete_verify_colima_profile() {

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -76,6 +76,52 @@ detected_host_arch() {
   esac
 }
 
+detected_host_distro() {
+  local host_distro=""
+
+  if [[ "${WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT:-0}" == "1" ]] && [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO:-}" ]]; then
+    printf '%s\n' "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO}"
+    return 0
+  fi
+
+  if [[ "$(detected_host_os)" != "linux" ]]; then
+    printf 'none\n'
+    return 0
+  fi
+  if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    host_distro="${ID:-}"
+  fi
+  if [[ -z "${host_distro}" ]]; then
+    host_distro="unknown"
+  fi
+  printf '%s\n' "$(printf '%s' "${host_distro}" | tr '[:upper:]' '[:lower:]')"
+}
+
+detected_host_distro_version() {
+  local host_distro_version=""
+
+  if [[ "${WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT:-0}" == "1" ]] && [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION:-}" ]]; then
+    printf '%s\n' "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION}"
+    return 0
+  fi
+
+  if [[ "$(detected_host_os)" != "linux" ]]; then
+    printf 'none\n'
+    return 0
+  fi
+  if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    host_distro_version="${VERSION_ID:-${VERSION_CODENAME:-}}"
+  fi
+  if [[ -z "${host_distro_version}" ]]; then
+    host_distro_version="unknown"
+  fi
+  printf '%s\n' "$(printf '%s' "${host_distro_version}" | tr '[:upper:]' '[:lower:]')"
+}
+
 resolve_self_path() {
   local source_path="${BASH_SOURCE[0]}"
   local source_dir=""
@@ -283,6 +329,8 @@ SESSION_ID=""
 SESSION_RECORD_PATH=""
 SUPPORT_MATRIX_HOST_OS=""
 SUPPORT_MATRIX_HOST_ARCH=""
+SUPPORT_MATRIX_HOST_DISTRO=""
+SUPPORT_MATRIX_HOST_DISTRO_VERSION=""
 SUPPORT_MATRIX_STATUS=""
 SUPPORT_MATRIX_LAUNCH=""
 SUPPORT_MATRIX_EVIDENCE=""
@@ -2089,12 +2137,16 @@ refresh_support_matrix_state() {
     "${WORKCELL_HOST_SUPPORT_MATRIX_PATH}" \
     "$(detected_host_os)" \
     "$(detected_host_arch)" \
+    "$(detected_host_distro)" \
+    "$(detected_host_distro_version)" \
     "$(current_target_kind)" \
     "$(current_target_provider)" \
     "$(current_target_assurance_class)")"
 
   SUPPORT_MATRIX_HOST_OS=""
   SUPPORT_MATRIX_HOST_ARCH=""
+  SUPPORT_MATRIX_HOST_DISTRO=""
+  SUPPORT_MATRIX_HOST_DISTRO_VERSION=""
   SUPPORT_MATRIX_STATUS=""
   SUPPORT_MATRIX_LAUNCH=""
   SUPPORT_MATRIX_EVIDENCE=""
@@ -2104,6 +2156,8 @@ refresh_support_matrix_state() {
   shellproto_assign_globals "${metadata}" \
     host_os:SUPPORT_MATRIX_HOST_OS \
     host_arch:SUPPORT_MATRIX_HOST_ARCH \
+    host_distro:SUPPORT_MATRIX_HOST_DISTRO \
+    host_distro_version:SUPPORT_MATRIX_HOST_DISTRO_VERSION \
     support_matrix_status:SUPPORT_MATRIX_STATUS \
     support_matrix_launch:SUPPORT_MATRIX_LAUNCH \
     support_matrix_evidence:SUPPORT_MATRIX_EVIDENCE \
@@ -2112,6 +2166,8 @@ refresh_support_matrix_state() {
 
   [[ -n "${SUPPORT_MATRIX_HOST_OS}" ]] || SUPPORT_MATRIX_HOST_OS="$(detected_host_os)"
   [[ -n "${SUPPORT_MATRIX_HOST_ARCH}" ]] || SUPPORT_MATRIX_HOST_ARCH="$(detected_host_arch)"
+  [[ -n "${SUPPORT_MATRIX_HOST_DISTRO}" ]] || SUPPORT_MATRIX_HOST_DISTRO="$(detected_host_distro)"
+  [[ -n "${SUPPORT_MATRIX_HOST_DISTRO_VERSION}" ]] || SUPPORT_MATRIX_HOST_DISTRO_VERSION="$(detected_host_distro_version)"
   [[ -n "${SUPPORT_MATRIX_STATUS}" ]] || SUPPORT_MATRIX_STATUS="unsupported"
   [[ -n "${SUPPORT_MATRIX_LAUNCH}" ]] || SUPPORT_MATRIX_LAUNCH="blocked"
   [[ -n "${SUPPORT_MATRIX_EVIDENCE}" ]] || SUPPORT_MATRIX_EVIDENCE="none"
@@ -2122,6 +2178,8 @@ refresh_support_matrix_state() {
 print_support_matrix_state() {
   printf 'host_os=%s\n' "${SUPPORT_MATRIX_HOST_OS}"
   printf 'host_arch=%s\n' "${SUPPORT_MATRIX_HOST_ARCH}"
+  printf 'host_distro=%s\n' "${SUPPORT_MATRIX_HOST_DISTRO}"
+  printf 'host_distro_version=%s\n' "${SUPPORT_MATRIX_HOST_DISTRO_VERSION}"
   printf 'support_matrix_status=%s\n' "${SUPPORT_MATRIX_STATUS}"
   printf 'support_matrix_launch=%s\n' "${SUPPORT_MATRIX_LAUNCH}"
   printf 'support_matrix_evidence=%s\n' "${SUPPORT_MATRIX_EVIDENCE}"
@@ -2187,7 +2245,7 @@ fail_for_unsupported_launch_target() {
     return 0
   fi
 
-  echo "Workcell launch is not supported for ${SUPPORT_MATRIX_HOST_OS}/${SUPPORT_MATRIX_HOST_ARCH} on target $(current_target_kind)/$(current_target_provider)/$(current_target_assurance_class)." >&2
+  echo "Workcell launch is not supported for ${SUPPORT_MATRIX_HOST_OS}/${SUPPORT_MATRIX_HOST_ARCH}/${SUPPORT_MATRIX_HOST_DISTRO}/${SUPPORT_MATRIX_HOST_DISTRO_VERSION} on target $(current_target_kind)/$(current_target_provider)/$(current_target_assurance_class)." >&2
   if [[ "${SUPPORT_MATRIX_STATUS}" == "validation-host-only" ]] && [[ "${SUPPORT_MATRIX_VALIDATION_LANE}" != "none" ]]; then
     echo "This combination is reserved for the reviewed validation-host lane: ${SUPPORT_MATRIX_VALIDATION_LANE}." >&2
   fi

--- a/tests/scenarios/shared/test-compat-target-dry-run.sh
+++ b/tests/scenarios/shared/test-compat-target-dry-run.sh
@@ -48,11 +48,15 @@ run_with_support_override() {
   local label="$1"
   local host_os="$2"
   local host_arch="$3"
-  shift 3
+  local host_distro="$4"
+  local host_distro_version="$5"
+  shift 5
   HOME="${HOME_DIR}" XDG_CONFIG_HOME="${HOME_DIR}/.config" \
     WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT=1 \
     WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS="${host_os}" \
     WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH="${host_arch}" \
+    WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO="${host_distro}" \
+    WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION="${host_distro_version}" \
     /bin/bash -p "${ROOT_DIR}/scripts/workcell" \
     "$@" \
     --workspace "${WORKSPACE}" \
@@ -65,12 +69,16 @@ run_with_support_override_expect_failure() {
   local label="$2"
   local host_os="$3"
   local host_arch="$4"
-  shift 4
+  local host_distro="$5"
+  local host_distro_version="$6"
+  shift 6
   set +e
   HOME="${HOME_DIR}" XDG_CONFIG_HOME="${HOME_DIR}/.config" \
     WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT=1 \
     WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS="${host_os}" \
     WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH="${host_arch}" \
+    WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO="${host_distro}" \
+    WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION="${host_distro_version}" \
     /bin/bash -p "${ROOT_DIR}/scripts/workcell" \
     "$@" \
     --workspace "${WORKSPACE}" \
@@ -91,6 +99,8 @@ run_with_support_override \
   "compat-doctor-supported" \
   macos \
   arm64 \
+  none \
+  none \
   --target docker-desktop \
   --agent codex \
   --doctor
@@ -98,6 +108,8 @@ grep -q '^target_kind=local_compat$' "${TMP_DIR}/compat-doctor-supported.stdout"
 grep -q '^target_provider=docker-desktop$' "${TMP_DIR}/compat-doctor-supported.stdout"
 grep -q '^target_id=desktop-linux$' "${TMP_DIR}/compat-doctor-supported.stdout"
 grep -q '^target_assurance_class=compat$' "${TMP_DIR}/compat-doctor-supported.stdout"
+grep -q '^host_distro=none$' "${TMP_DIR}/compat-doctor-supported.stdout"
+grep -q '^host_distro_version=none$' "${TMP_DIR}/compat-doctor-supported.stdout"
 grep -q '^support_matrix_status=supported$' "${TMP_DIR}/compat-doctor-supported.stdout"
 grep -q '^support_matrix_launch=allowed$' "${TMP_DIR}/compat-doctor-supported.stdout"
 grep -q '^support_matrix_reason=apple-silicon-macos-docker-desktop-compat-reviewed-launch-host$' "${TMP_DIR}/compat-doctor-supported.stdout"
@@ -122,6 +134,8 @@ run_with_support_override \
   "compat-dry-run-supported" \
   macos \
   arm64 \
+  none \
+  none \
   --target docker-desktop \
   --agent codex \
   --dry-run
@@ -133,6 +147,8 @@ if [[ "${EXPECTED_ALLOWED_MISSING}" == "none" ]]; then
     "compat-dry-run-supported-no-path-docker" \
     macos \
     arm64 \
+    none \
+    none \
     --target docker-desktop \
     --agent codex \
     --dry-run
@@ -144,11 +160,15 @@ run_with_support_override \
   "compat-doctor-blocked" \
   linux \
   arm64 \
+  debian \
+  13 \
   --target docker-desktop \
   --agent codex \
   --doctor
 grep -q '^support_matrix_status=unsupported$' "${TMP_DIR}/compat-doctor-blocked.stdout"
 grep -q '^support_matrix_launch=blocked$' "${TMP_DIR}/compat-doctor-blocked.stdout"
+grep -q '^host_distro=debian$' "${TMP_DIR}/compat-doctor-blocked.stdout"
+grep -q '^host_distro_version=13$' "${TMP_DIR}/compat-doctor-blocked.stdout"
 grep -q '^doctor_recommended_next=use-supported-host$' "${TMP_DIR}/compat-doctor-blocked.stdout"
 
 run_with_support_override_expect_failure \
@@ -156,10 +176,13 @@ run_with_support_override_expect_failure \
   "compat-dry-run-blocked" \
   linux \
   arm64 \
+  debian \
+  13 \
   --target docker-desktop \
   --agent codex \
   --dry-run
 grep -q 'Workcell launch is not supported' "${TMP_DIR}/compat-dry-run-blocked.stderr"
+grep -q 'linux/arm64/debian/13' "${TMP_DIR}/compat-dry-run-blocked.stderr"
 grep -q 'local_compat/docker-desktop/compat' "${TMP_DIR}/compat-dry-run-blocked.stderr"
 grep -q 'Docker Desktop target remains a lower-assurance compat path' "${TMP_DIR}/compat-dry-run-blocked.stderr"
 


### PR DESCRIPTION
## Summary
- add distro and distro-version columns to the host support matrix schema
- emit distro-scoped host metadata in doctor, inspect, and unsupported-launch diagnostics
- keep Linux local_compat blocked while enabling exact future distro/version candidate rows

## Validation
- ./scripts/pre-merge.sh --profile pr-parity
