### PR TITLE
Harden host and runtime boundary checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Workcell uses two terms throughout the docs:
 | `strict` | default provider lane | bounded VM plus container, reviewed network posture, repo control-plane masking, provider-focused entrypoint, `--agent-autonomy yolo` by default |
 | `development` | managed interactive development lane | same boundary and masking as `strict`, managed non-provider command execution, broader dependency egress, visibly lower assurance than `strict` |
 | `build` | image preparation and dependency refresh | broader egress for rebuild and preparation work |
-| `breakglass` | explicit higher-trust debugging path | requires `--ack-breakglass`; visibly lower assurance |
+| `breakglass` | explicit higher-trust debugging path | requires `--ack-breakglass=YYYY-MM-DD` using today's UTC date; visibly lower assurance |
 
 `--container-mutability` is orthogonal to `--mode`: `ephemeral` (the
 default) allows package-manager mutations and labels the session

--- a/adapters/claude/hooks/guard-bash.sh
+++ b/adapters/claude/hooks/guard-bash.sh
@@ -336,8 +336,8 @@ if grep_command '(^|[[:space:]'"'"'";|&])(eval)([[:space:]'"'"'";|&]|$)' ||
   fail "Do not use eval or shell variable expansion from the Claude Bash tool inside Workcell."
 fi
 
-if grep_dequoted_command '(^|[^[:alnum:]_./-])(codex|claude|gemini|/usr/local/libexec/workcell/core/codex|/usr/local/libexec/workcell/core/claude|/usr/local/libexec/workcell/core/gemini|/usr/local/libexec/workcell/real/codex|/usr/local/libexec/workcell/real/claude|/opt/workcell/providers/node_modules/\.bin/gemini|/opt/workcell/providers/node_modules/@google/gemini-cli/bundle/gemini\.js)([^[:alnum:]_./-]|$)' ||
-  grep_deescaped_command '(^|[^[:alnum:]_./-])(codex|claude|gemini|/usr/local/libexec/workcell/core/codex|/usr/local/libexec/workcell/core/claude|/usr/local/libexec/workcell/core/gemini|/usr/local/libexec/workcell/real/codex|/usr/local/libexec/workcell/real/claude|/opt/workcell/providers/node_modules/\.bin/gemini|/opt/workcell/providers/node_modules/@google/gemini-cli/bundle/gemini\.js)([^[:alnum:]_./-]|$)'; then
+if grep_dequoted_command '(^|[^[:alnum:]_./-])(codex|claude|gemini|/usr/local/libexec/workcell/core/codex|/usr/local/libexec/workcell/core/claude|/usr/local/libexec/workcell/core/gemini|/usr/local/libexec/workcell/provider-wrapper\.sh|/usr/local/libexec/workcell/real/codex|/usr/local/libexec/workcell/real/claude|/opt/workcell/providers/node_modules/\.bin/gemini|/opt/workcell/providers/node_modules/@google/gemini-cli/bundle/gemini\.js)([^[:alnum:]_./-]|$)' ||
+  grep_deescaped_command '(^|[^[:alnum:]_./-])(codex|claude|gemini|/usr/local/libexec/workcell/core/codex|/usr/local/libexec/workcell/core/claude|/usr/local/libexec/workcell/core/gemini|/usr/local/libexec/workcell/provider-wrapper\.sh|/usr/local/libexec/workcell/real/codex|/usr/local/libexec/workcell/real/claude|/opt/workcell/providers/node_modules/\.bin/gemini|/opt/workcell/providers/node_modules/@google/gemini-cli/bundle/gemini\.js)([^[:alnum:]_./-]|$)'; then
   fail "Do not launch nested coding-agent CLIs from the Claude Bash tool inside Workcell."
 fi
 

--- a/adapters/codex/managed_config.toml
+++ b/adapters/codex/managed_config.toml
@@ -73,7 +73,7 @@ decision = "forbidden"
 justification = "Do not bypass git hooks with --no-verify from Workcell."
 
 [[rules.prefix_rules]]
-pattern = [{ any_of = ["codex", "claude", "gemini", "/usr/local/libexec/workcell/core/codex", "/usr/local/libexec/workcell/core/claude", "/usr/local/libexec/workcell/core/gemini", "/usr/local/libexec/workcell/real/codex", "/usr/local/libexec/workcell/real/claude", "/opt/workcell/providers/node_modules/.bin/gemini"] }]
+pattern = [{ any_of = ["codex", "claude", "gemini", "/usr/local/libexec/workcell/provider-wrapper.sh", "/usr/local/libexec/workcell/core/codex", "/usr/local/libexec/workcell/core/claude", "/usr/local/libexec/workcell/core/gemini", "/usr/local/libexec/workcell/real/codex", "/usr/local/libexec/workcell/real/claude", "/opt/workcell/providers/node_modules/.bin/gemini"] }]
 decision = "forbidden"
 justification = "Do not launch nested coding-agent CLIs or bypass Workcell provider mediation from inside Codex."
 

--- a/docs/examples/quickstart-codex.md
+++ b/docs/examples/quickstart-codex.md
@@ -114,7 +114,7 @@ workcell --agent codex --mode development --workspace /path/to/repo -- bash -lc 
 Breakglass:
 
 ```bash
-workcell --agent codex --mode breakglass --ack-breakglass --workspace /path/to/repo
+workcell --agent codex --mode breakglass --ack-breakglass=YYYY-MM-DD --workspace /path/to/repo
 ```
 
 ## 6. Publish on the host

--- a/internal/testkit/security_boundary_test.go
+++ b/internal/testkit/security_boundary_test.go
@@ -71,20 +71,24 @@ func TestHomeControlPlaneRejectsManagedDirectoryTargets(t *testing.T) {
 		t.Run(filepath.Base(target), func(t *testing.T) {
 			t.Parallel()
 
-			code, output := runBashProbe(t, `set -euo pipefail
-source() {
-  if [[ "$1" == "/usr/local/libexec/workcell/assurance.sh" ]]; then
-    return 0
-  fi
-  builtin source "$@"
-}
-builtin source "`+scriptPath+`"
-if workcell_target_is_allowed "`+target+`"; then
-  printf 'allowed\n'
-else
-  printf 'blocked\n'
-fi
-`, nil)
+			probe := fmt.Sprintf(
+				"set -euo pipefail\n"+
+					"source() {\n"+
+					"  if [[ \"$1\" == \"/usr/local/libexec/workcell/assurance.sh\" ]]; then\n"+
+					"    return 0\n"+
+					"  fi\n"+
+					"  builtin source \"$@\"\n"+
+					"}\n"+
+					"builtin source %q\n"+
+					"if workcell_target_is_allowed %q; then\n"+
+					"  printf 'allowed\\n'\n"+
+					"else\n"+
+					"  printf 'blocked\\n'\n"+
+					"fi\n",
+				scriptPath,
+				target,
+			)
+			code, output := runBashProbe(t, probe, nil)
 			if code != 0 {
 				t.Fatalf("probe exit code = %d output=%q", code, output)
 			}
@@ -95,6 +99,46 @@ fi
 	}
 }
 
+func TestHomeControlPlaneRejectsTraversalTargets(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(repoRoot(t), "runtime", "container", "home-control-plane.sh")
+	for _, target := range []string{
+		"/state/injected/../../state/agent-home/.codex/config.toml",
+		"/state/agent-home/../agent-home/.claude.json",
+		"/state/injected/./copy.txt",
+	} {
+		target := target
+		t.Run(strings.ReplaceAll(target, "/", "_"), func(t *testing.T) {
+			t.Parallel()
+
+			probe := fmt.Sprintf(
+				"set -euo pipefail\n"+
+					"source() {\n"+
+					"  if [[ \"$1\" == \"/usr/local/libexec/workcell/assurance.sh\" ]]; then\n"+
+					"    return 0\n"+
+					"  fi\n"+
+					"  builtin source \"$@\"\n"+
+					"}\n"+
+					"builtin source %q\n"+
+					"if workcell_target_is_allowed %q; then\n"+
+					"  printf 'allowed\\n'\n"+
+					"else\n"+
+					"  printf 'blocked\\n'\n"+
+					"fi\n",
+				scriptPath,
+				target,
+			)
+			code, output := runBashProbe(t, probe, nil)
+			if code != 0 {
+				t.Fatalf("probe exit code = %d output=%q", code, output)
+			}
+			if strings.TrimSpace(output) != "blocked" {
+				t.Fatalf("target %s unexpectedly allowed: %q", target, output)
+			}
+		})
+	}
+}
 func TestResolveWorkcellRealHomeRejectsWorkspaceOverride(t *testing.T) {
 	t.Parallel()
 
@@ -104,11 +148,8 @@ func TestResolveWorkcellRealHomeRejectsWorkspaceOverride(t *testing.T) {
 		t.Fatal(err)
 	}
 	scriptPath := filepath.Join(repoRoot(t), "scripts", "lib", "trusted-docker-client.sh")
-	code, output := runBashProbe(t, `set -euo pipefail
-ROOT_DIR="`+workspace+`"
-source "`+scriptPath+`"
-resolve_workcell_real_home
-`, map[string]string{
+	probe := fmt.Sprintf("set -euo pipefail\nROOT_DIR=%q\nsource %q\nresolve_workcell_real_home\n", workspace, scriptPath)
+	code, output := runBashProbe(t, probe, map[string]string{
 		"HOME":                      t.TempDir(),
 		"WORKCELL_DOCKER_REAL_HOME": overrideHome,
 	})

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -266,15 +266,16 @@ this also implies
 .B --prepare
 because the recreated profile starts empty.
 .TP
-.B --ack-breakglass
+.B --ack-breakglass=YYYY-MM-DD
 Required with
 .B --mode breakglass
-to make the higher-trust path explicit.
+to make the higher-trust path explicit. The date must be today's UTC date.
 .TP
-.B --ack-arbitrary-command
+.B --ack-arbitrary-command=YYYY-MM-DD
 Required with
 .B --allow-arbitrary-command
 to make lower-assurance boundary-debugging command passthrough explicit.
+The date must be today's UTC date.
 .TP
 .B --ack-control-plane-vcs
 Required with
@@ -467,7 +468,7 @@ Still inside the Workcell VM plus container boundary, but with unrestricted
 network access. The managed entrypoint does not auto-inject unsafe provider
 flags; any adapter-specific high-trust launch is a lower-assurance direct
 provider path. This profile requires
-.BR --ack-breakglass .
+.BR --ack-breakglass=YYYY-MM-DD .
 .SH NODE SURFACE
 The public
 .B node

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "6aa65fa01844e6993eb03b32ad80ab67bf80c445454b02d2264f534f6f4668a0"
+      "sha256": "c44c0237ccd42943a5bc4d3ac312e90c2c2c8447b6418226ccd9ef8c842669cf"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",
@@ -46,7 +46,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/claude/hooks/guard-bash.sh",
       "runtime_path": "/opt/workcell/adapters/claude/hooks/guard-bash.sh",
-      "sha256": "9cdcc856603fd87128d0afe273b3de4c53061915c04d6b31e6babdd1d2b4fdc1"
+      "sha256": "6821e692bd48cf2b6d58e7b8378cd6ef5c916364af30dff1723b54c8c2053de4"
     },
     {
       "kind": "adapter-baseline",
@@ -106,7 +106,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/codex/managed_config.toml",
       "runtime_path": "/opt/workcell/adapters/codex/managed_config.toml",
-      "sha256": "eeb453c5725a8ec6f5832d4a197e24c13dcf27a3abdd8108766b5d6883177430"
+      "sha256": "9b8303fb0a8cf9ba7d8cecbe95e0cfd1fa5021683b5e58e050235484120b35d2"
     },
     {
       "kind": "adapter-baseline",
@@ -190,7 +190,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/home-control-plane.sh",
       "runtime_path": "/usr/local/libexec/workcell/home-control-plane.sh",
-      "sha256": "bcd846dd6cd23e87732c3b636e6d4aa41beddf042493907c1c0791018bf9e5d3"
+      "sha256": "d85cf3335c4207a5b9ac5bd705341e9d2b4940dcb9364ae26d3ba13a510c224e"
     },
     {
       "kind": "runtime-control-plane",
@@ -208,7 +208,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-wrapper.sh",
-      "sha256": "bf0627a4f90d6bfd9a118e5d66254bc8e7d3e61f98b0c25552b98148c102ddac"
+      "sha256": "3d66b1db78536c0462be0bccb22a5c262fee07d63057cc84988030e15a1d1ece"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -1141,6 +1141,12 @@ workcell_target_is_allowed() {
   local target_path="$1"
 
   case "${target_path}" in
+    *"/../"* | *"/.." | *"/./"* | *"/.")
+      return 1
+      ;;
+  esac
+
+  case "${target_path}" in
     /state/agent-home | /state/agent-home/* | /state/injected | /state/injected/*) ;;
     *)
       return 1
@@ -1359,6 +1365,11 @@ workcell_apply_manifest_ssh() {
 
   while IFS=$'\x1f' read -r row_source row_mount_path row_target_name; do
     [[ -n "${row_source}${row_mount_path}" ]] || continue
+    case "${row_target_name}" in
+      "" | "." | ".." | */* | *\\*)
+        workcell_die "Workcell SSH identity target name is not allowed: ${row_target_name}"
+        ;;
+    esac
     workcell_reset_session_target "${HOME}/.ssh/${row_target_name}" "SSH identity"
     cp "$(workcell_resolve_manifest_input_path "${row_source}" "${row_mount_path}")" "${HOME}/.ssh/${row_target_name}"
     chmod 0600 "${HOME}/.ssh/${row_target_name}"

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -54,6 +54,24 @@ sanitize_provider_env() {
   export PATH="${TRUSTED_PATH}"
 }
 
+require_managed_provider_launch() {
+  case "${AGENT_NAME}" in
+    codex | claude | gemini) ;;
+    *)
+      workcell_die "Unsupported provider wrapper target: ${AGENT_NAME}"
+      ;;
+  esac
+
+  if [[ "${AGENT_NAME}" == "codex" && "${1:-}" == "execpolicy" ]]; then
+    return 0
+  fi
+
+  if [[ "${WORKCELL_PROVIDER_LAUNCHER_AUTHORITY:-0}" != "1" ]]; then
+    workcell_die "Workcell blocked direct provider wrapper execution."
+  fi
+  unset WORKCELL_PROVIDER_LAUNCHER_AUTHORITY
+}
+
 emit_codex_rules_mutability_notice() {
   local configured_mutability=""
   local effective_mutability=""
@@ -98,6 +116,7 @@ mkdir -p "${TMPDIR}"
 if workcell_should_reexec_as_runtime_user; then
   workcell_reexec_as_runtime_user /usr/local/libexec/workcell/provider-wrapper.sh "$@"
 fi
+require_managed_provider_launch "$@"
 seed_agent_home "${AGENT_NAME}"
 emit_session_assurance_notice
 emit_codex_rules_mutability_notice

--- a/runtime/container/rust/src/bin/workcell-launcher.rs
+++ b/runtime/container/rust/src/bin/workcell-launcher.rs
@@ -85,6 +85,9 @@ fn main() {
 
     launcher_common::sanitize_env();
     launcher_common::set_env_var("WORKCELL_LAUNCH_TARGET", request.target_name);
+    if request.script_path == "/usr/local/libexec/workcell/provider-wrapper.sh" {
+        launcher_common::set_env_var("WORKCELL_PROVIDER_LAUNCHER_AUTHORITY", "1");
+    }
     process::exit(launcher_common::exec_request(
         &request.exec_args,
         request.script_path,

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2602,11 +2602,24 @@ EOF
   cat <<'EOF' >/tmp/workcell-wrapper-bashenv.sh
 exec env -u LD_PRELOAD /usr/local/libexec/workcell/real/codex --version
 EOF
-  if BASH_ENV=/tmp/workcell-wrapper-bashenv.sh bash /usr/local/libexec/workcell/provider-wrapper.sh >/tmp/provider-wrapper-bashenv.out 2>&1; then
+  set +e
+  BASH_ENV=/tmp/workcell-wrapper-bashenv.sh bash /usr/local/libexec/workcell/provider-wrapper.sh >/tmp/provider-wrapper-bashenv.out 2>&1
+  provider_wrapper_bashenv_status=$?
+  set -e
+  if [[ "${provider_wrapper_bashenv_status}" -eq 0 ]]; then
     echo "expected explicit bash launch of provider wrapper with hostile BASH_ENV to fail" >&2
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/provider-wrapper-bashenv.out
+  set +e
+  WORKCELL_LAUNCH_TARGET=codex bash /usr/local/libexec/workcell/provider-wrapper.sh >/tmp/provider-wrapper-direct.out 2>&1
+  provider_wrapper_direct_status=$?
+  set -e
+  if [[ "${provider_wrapper_direct_status}" -eq 0 ]]; then
+    echo "expected explicit bash launch of provider wrapper to fail" >&2
+    exit 1
+  fi
+  grep -q "Workcell blocked direct provider wrapper execution." /tmp/provider-wrapper-direct.out
   cat <<'EOF' >/tmp/workcell-development-wrapper-bashenv.sh
 exec env -u LD_PRELOAD /usr/local/libexec/workcell/real/codex --version
 EOF

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -288,6 +288,21 @@ if grep -q '^support_matrix_launch=blocked$' <<<"${ROOT_STRICT_SUPPORT_OUTPUT}";
   export WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION="none"
 fi
 
+if grep -q '^support_matrix_launch=blocked$' <<<"${ROOT_STRICT_SUPPORT_OUTPUT}"; then
+  SUPPORT_OVERRIDE_SPOOF_EXIT=0
+  WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT=1 \
+    WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS=macos \
+    WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH=arm64 \
+    WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO=none \
+    WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION=none \
+    /bin/bash -c 'sleep 0.1 & /bin/bash -p "$1" --agent codex --workspace "$2" --no-default-injection-policy --dry-run; wait' \
+    _ "${ROOT_DIR}/scripts/workcell" "${ROOT_DIR}" >/tmp/workcell-support-override-spoof.out 2>&1 || SUPPORT_OVERRIDE_SPOOF_EXIT=$?
+  if [[ "${SUPPORT_OVERRIDE_SPOOF_EXIT}" -eq 0 ]] && grep -q '^docker run ' /tmp/workcell-support-override-spoof.out; then
+    echo "Expected support-matrix test override spoof to stay blocked outside approved validation harnesses" >&2
+    exit 1
+  fi
+fi
+
 run_workcell_verify() {
   local -a cmd=(/usr/bin/env -i PATH="${TRUSTED_HOST_PATH}" BASH_ENV= ENV= WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT=1)
   while [[ $# -gt 0 ]] && [[ "$1" == *=* ]]; do
@@ -1896,15 +1911,16 @@ INJECTION_DOCTOR_OUTPUT="$(run_workcell_real_host \
   --no-default-injection-policy \
   --injection-policy "${INJECTION_POLICY_FIXTURE_ROOT}/policy.toml" \
   --doctor)"
-set +e
-INJECTION_DRY_RUN_OUTPUT="$(run_workcell_real_host \
+if INJECTION_DRY_RUN_OUTPUT="$(run_workcell_real_host \
   --agent codex \
   --workspace "${ROOT_DIR}" \
   --no-default-injection-policy \
   --injection-policy "${INJECTION_POLICY_FIXTURE_ROOT}/policy.toml" \
-  --dry-run 2>&1)"
-INJECTION_DRY_RUN_STATUS=$?
-set -e
+  --dry-run 2>&1)"; then
+  INJECTION_DRY_RUN_STATUS=0
+else
+  INJECTION_DRY_RUN_STATUS=$?
+fi
 
 INJECTION_LAUNCH_BLOCKED=0
 if grep -q '^support_matrix_launch=blocked$' <<<"${INJECTION_DOCTOR_OUTPUT}"; then
@@ -1970,14 +1986,15 @@ printf '999999\n' >"${STALE_INJECTION_BUNDLE}/owner.pid"
 printf 'stale-secret\n' >"${STALE_INJECTION_BUNDLE}/stale.txt"
 printf '[{"source":"/tmp/stale-secret","mount_path":"/opt/workcell/host-inputs/credentials/stale"}]\n' >"${STALE_INJECTION_SIDECAR}"
 touch -t 202001010000 "${STALE_INJECTION_BUNDLE}" "${STALE_INJECTION_BUNDLE}/owner.pid" "${STALE_INJECTION_BUNDLE}/stale.txt" "${STALE_INJECTION_SIDECAR}"
-set +e
-run_workcell_real_host \
+if run_workcell_real_host \
   --agent codex \
   --workspace "${ROOT_DIR}" \
   --no-default-injection-policy \
-  --dry-run >/tmp/workcell-no-policy-dry-run.out 2>&1
-NO_POLICY_DRY_RUN_STATUS=$?
-set -e
+  --dry-run >/tmp/workcell-no-policy-dry-run.out 2>&1; then
+  NO_POLICY_DRY_RUN_STATUS=0
+else
+  NO_POLICY_DRY_RUN_STATUS=$?
+fi
 
 if [[ "${INJECTION_LAUNCH_BLOCKED}" -eq 1 ]]; then
   if [[ "${NO_POLICY_DRY_RUN_STATUS}" -ne 2 ]]; then
@@ -6114,13 +6131,26 @@ if run_workcell_verify --agent codex --workspace "${REAL_HOME}" --dry-run >/dev/
   exit 1
 fi
 
-if "${ROOT_DIR}/scripts/workcell" --agent codex --mode breakglass --dry-run >/dev/null 2>&1; then
-  echo "Expected breakglass acknowledgement requirement" >&2
+PROVIDER_HOME_FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/workcell-provider-home.XXXXXX")"
+mkdir -p "${PROVIDER_HOME_FIXTURE}/home/.codex"
+printf 'provider home marker\n' >"${PROVIDER_HOME_FIXTURE}/home/.codex/AGENTS.md"
+if run_workcell_verify \
+  HOME="${PROVIDER_HOME_FIXTURE}/home" \
+  XDG_CONFIG_HOME="${PROVIDER_HOME_FIXTURE}/home/.config" \
+  --agent codex \
+  --workspace "${PROVIDER_HOME_FIXTURE}/home/.codex" \
+  --allow-nongit-workspace \
+  --no-default-injection-policy \
+  --dry-run >/tmp/workcell-provider-home-workspace.out 2>&1; then
+  echo "Expected provider-home workspace rejection" >&2
+  rm -rf "${PROVIDER_HOME_FIXTURE}"
   exit 1
 fi
+grep -q 'Refusing sensitive workspace mount' /tmp/workcell-provider-home-workspace.out
+rm -rf "${PROVIDER_HOME_FIXTURE}"
 
-if ! run_workcell_verify --agent codex --mode breakglass --ack-breakglass --dry-run >/dev/null 2>&1; then
-  echo "Expected acknowledged breakglass dry-run to succeed" >&2
+if "${ROOT_DIR}/scripts/workcell" --agent codex --mode breakglass --dry-run >/dev/null 2>&1; then
+  echo "Expected breakglass acknowledgement requirement" >&2
   exit 1
 fi
 
@@ -6148,8 +6178,8 @@ fi
 rm -f "${ACK_BREAKGLASS_STALE_STDERR_FILE}"
 
 ACK_BREAKGLASS_BARE_OUTPUT="$(run_workcell_verify --agent codex --mode breakglass --ack-breakglass --dry-run 2>&1 >/dev/null || true)"
-if ! grep -q -- '--ack-breakglass accepted without a date acknowledgement' <<<"${ACK_BREAKGLASS_BARE_OUTPUT}"; then
-  echo "Expected bare --ack-breakglass to print a deprecation warning" >&2
+if ! grep -q -- '--ack-breakglass requires a date acknowledgement' <<<"${ACK_BREAKGLASS_BARE_OUTPUT}"; then
+  echo "Expected bare --ack-breakglass to fail with a date acknowledgement requirement" >&2
   exit 1
 fi
 
@@ -6180,7 +6210,7 @@ if ! grep -q -- '--ack-arbitrary-command=1999-01-01 does not match today' "${ACK
 fi
 rm -f "${ACK_ARBITRARY_STALE_STDERR_FILE}"
 
-ARBITRARY_DRY_RUN_OUTPUT="$(run_workcell_verify --agent codex --prepare --allow-arbitrary-command --ack-arbitrary-command --dry-run -- bash -lc true 2>/dev/null)"
+ARBITRARY_DRY_RUN_OUTPUT="$(run_workcell_verify --agent codex --prepare --allow-arbitrary-command "--ack-arbitrary-command=${ACK_BREAKGLASS_TODAY_UTC}" --dry-run -- bash -lc true 2>/dev/null)"
 if [[ -z "${ARBITRARY_DRY_RUN_OUTPUT}" ]]; then
   echo "Expected acknowledged arbitrary command dry-run to succeed" >&2
   exit 1
@@ -6512,7 +6542,7 @@ EOF
       --debug-log "${DETACHED_SESSION_DEBUG_LOG}" \
       --file-trace-log "${DETACHED_SESSION_FILE_TRACE_LOG}" \
       --allow-arbitrary-command \
-      --ack-arbitrary-command \
+      "--ack-arbitrary-command=${ACK_BREAKGLASS_TODAY_UTC}" \
       -- /bin/bash -lc "${DETACHED_SESSION_WORKER_COMMAND}" -- "${DETACHED_SESSION_SOURCE_SENTINEL_REL}" >"${DETACHED_SESSION_START_OUT}" 2>&1; then
       echo "Expected detached session start to succeed against the live runtime" >&2
       cat "${DETACHED_SESSION_START_OUT}" >&2
@@ -6771,7 +6801,7 @@ EOF
       --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
       --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
       --allow-arbitrary-command \
-      --ack-arbitrary-command \
+      "--ack-arbitrary-command=${ACK_BREAKGLASS_TODAY_UTC}" \
       -- /bin/bash -lc "${PACKAGE_MUTATION_AUDIT_COMMAND}"; then
       echo "Expected package-mutation audit verification run to succeed" >&2
       exit 1
@@ -6810,7 +6840,7 @@ EOF
       --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
       --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
       --allow-arbitrary-command \
-      --ack-arbitrary-command \
+      "--ack-arbitrary-command=${ACK_BREAKGLASS_TODAY_UTC}" \
       -- /bin/bash -lc "${PACKAGE_MUTATION_FAILURE_COMMAND}"; then
       echo "Expected package-mutation failure propagation verification run to succeed" >&2
       exit 1
@@ -6836,7 +6866,7 @@ EOF
       --injection-policy "${AUTH_STATUS_ROOT}/policy.toml" \
       --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
       --allow-arbitrary-command \
-      --ack-arbitrary-command \
+      "--ack-arbitrary-command=${ACK_BREAKGLASS_TODAY_UTC}" \
       -- /bin/bash -lc 'test -f /opt/workcell/host-injections/manifest.json && grep -q "Repository Working Agreement" /workspace/AGENTS.md && test ! -d /workspace/AGENTS.md'; then
       echo "Expected live launcher run to stage an injection manifest and mount the tracked workspace AGENTS.md snapshot as a file" >&2
       exit 1
@@ -7046,7 +7076,7 @@ if run_workcell_verify --agent codex --workspace "${WORKTREE_LINKED}" --dry-run 
 fi
 grep -q 'This workspace is a linked worktree' /tmp/workcell-linked-worktree.out
 grep -q 'create a standard clone at the same location instead' /tmp/workcell-linked-worktree.out
-grep -q 'pass --mode breakglass --ack-breakglass to proceed with a linked worktree' /tmp/workcell-linked-worktree.out
+grep -q 'pass --mode breakglass --ack-breakglass=YYYY-MM-DD to proceed with a linked worktree' /tmp/workcell-linked-worktree.out
 
 REDIRECTED_ROOT="${BARRIER_VERIFY_ROOT}/redirected-root"
 REDIRECTED_REPO="${REDIRECTED_ROOT}/repo"
@@ -7590,6 +7620,14 @@ if ! grep -Fq 'unset DISABLE_AUTOUPDATER' "${ROOT_DIR}/runtime/container/provide
   echo "Expected provider wrapper to discard caller-supplied DISABLE_AUTOUPDATER" >&2
   exit 1
 fi
+if ! grep -Fq 'WORKCELL_PROVIDER_LAUNCHER_AUTHORITY' "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
+  echo "Expected provider wrapper to require the managed launcher authority marker" >&2
+  exit 1
+fi
+if ! grep -Fq 'WORKCELL_PROVIDER_LAUNCHER_AUTHORITY' "${ROOT_DIR}/runtime/container/rust/src/bin/workcell-launcher.rs"; then
+  echo "Expected workcell-launcher to set the provider-wrapper authority marker" >&2
+  exit 1
+fi
 for gemini_sandbox_env in \
   'unset GEMINI_SANDBOX' \
   'unset GEMINI_SANDBOX_IMAGE' \
@@ -7620,12 +7658,20 @@ if ! grep -Fq "Workcell blocked Claude lifecycle command: \${arg}" "${ROOT_DIR}/
   echo "Expected provider policy to reject native Claude lifecycle commands that bypass the pinned image" >&2
   exit 1
 fi
+if ! grep -Fq '/usr/local/libexec/workcell/provider-wrapper.sh' "${ROOT_DIR}/adapters/codex/managed_config.toml"; then
+  echo "Expected Codex managed rules to block direct provider-wrapper launches" >&2
+  exit 1
+fi
 if ! grep -Fq '/usr/local/libexec/workcell/real/claude' "${ROOT_DIR}/adapters/codex/managed_config.toml"; then
   echo "Expected Codex managed rules to block the native Claude binary path" >&2
   exit 1
 fi
 if grep -Fq '@anthropic-ai/claude-code/cli.js' "${ROOT_DIR}/adapters/codex/managed_config.toml"; then
   echo "Codex managed rules should not reference the removed Claude npm entrypoint" >&2
+  exit 1
+fi
+if ! grep -Fq '/usr/local/libexec/workcell/provider-wrapper\.sh' "${ROOT_DIR}/adapters/claude/hooks/guard-bash.sh"; then
+  echo "Expected Claude Bash guard to block direct provider-wrapper launches" >&2
   exit 1
 fi
 if ! grep -Fq '/usr/local/libexec/workcell/real/claude' "${ROOT_DIR}/adapters/claude/hooks/guard-bash.sh"; then

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -10,6 +10,12 @@ scrub_host_process_env() {
 
   unset BASH_ENV ENV
   unset WORKCELL_TEST_FAIL_AFTER_PROFILE_REFRESH
+  if [[ "${WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
+    unset WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS
+    unset WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH
+    unset WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO
+    unset WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION
+  fi
   unset PYTHONPATH PYTHONHOME PYTHONSAFEPATH PYTHONSTARTUP
   unset RUBYOPT RUBYLIB GEM_HOME GEM_PATH
   unset PERL5OPT PERL5LIB PERLLIB PERL_MB_OPT PERL_MM_OPT
@@ -26,13 +32,30 @@ scrub_host_process_env() {
 
 scrub_host_process_env
 
+support_matrix_host_override_allowed() {
+  local parent_cmdline=""
+
+  [[ "${WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT:-0}" == "1" ]] || return 1
+  [[ -r "/proc/${PPID}/cmdline" ]] || return 1
+  parent_cmdline="$(tr '\0' ' ' <"/proc/${PPID}/cmdline" 2>/dev/null || true)"
+  case "${parent_cmdline}" in
+    *"scripts/verify-invariants.sh"* | \
+      *"tests/scenarios/shared/test-compat-target-dry-run.sh"* | \
+      *"tests/scenarios/shared/test-gcp-remote-vm-dry-run.sh"* | \
+      *"tests/scenarios/shared/test-aws-remote-vm-dry-run.sh"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 detected_host_os() {
   local host_os=""
 
   # verify-invariants uses a reserved harness-only host override so Linux
   # validation runners can still exercise launch assembly without weakening the
   # real operator-facing support boundary.
-  if [[ "${WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT:-0}" == "1" ]] && [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS:-}" ]]; then
+  if support_matrix_host_override_allowed && [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS:-}" ]]; then
     printf '%s\n' "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS}"
     return 0
   fi
@@ -57,7 +80,7 @@ detected_host_os() {
 detected_host_arch() {
   local host_arch=""
 
-  if [[ "${WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT:-0}" == "1" ]] && [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH:-}" ]]; then
+  if support_matrix_host_override_allowed && [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH:-}" ]]; then
     printf '%s\n' "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH}"
     return 0
   fi
@@ -79,7 +102,7 @@ detected_host_arch() {
 detected_host_distro() {
   local host_distro=""
 
-  if [[ "${WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT:-0}" == "1" ]] && [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO:-}" ]]; then
+  if support_matrix_host_override_allowed && [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO:-}" ]]; then
     printf '%s\n' "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO}"
     return 0
   fi
@@ -102,7 +125,7 @@ detected_host_distro() {
 detected_host_distro_version() {
   local host_distro_version=""
 
-  if [[ "${WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT:-0}" == "1" ]] && [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION:-}" ]]; then
+  if support_matrix_host_override_allowed && [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION:-}" ]]; then
     printf '%s\n' "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION}"
     return 0
   fi
@@ -420,14 +443,11 @@ Options:
   --prepare-only                Seed or refresh the prepared runtime image, then exit without launching
   --repair-profile              Delete a conflicting unmanaged Colima profile before launch
                                 (implies --prepare on strict)
-  --ack-breakglass[=YYYY-MM-DD] Required with --mode breakglass; bare form
-                                accepted with a deprecation warning, the
-                                dated form requires today's UTC date
+  --ack-breakglass=YYYY-MM-DD   Required with --mode breakglass; date must be
+                                today's UTC date
   --ack-arbitrary-command[=YYYY-MM-DD]
-                                Required with --allow-arbitrary-command;
-                                bare form accepted with a deprecation
-                                warning, the dated form requires today's
-                                UTC date
+                                Required with --allow-arbitrary-command; date
+                                must be today's UTC date
   --workspace PATH              Workspace to mount (default: current directory)
   --session-workspace direct|isolated
                                 Detached session workspace flow for session start
@@ -1760,7 +1780,7 @@ validate_isolated_session_workspace_source() {
     echo "Refusing git workspace with admin state outside the mounted workspace: ${source_workspace}" >&2
     echo "This workspace is a linked worktree: its .git file points to a .git directory outside the mounted path." >&2
     echo "To use this workspace on the safe path, create a standard clone at the same location instead." >&2
-    echo "Alternatively, pass --mode breakglass --ack-breakglass to proceed with a linked worktree." >&2
+    echo "Alternatively, pass --mode breakglass --ack-breakglass=YYYY-MM-DD to proceed with a linked worktree." >&2
     exit 2
   fi
   if workspace_git_has_worktree_changes "${source_workspace}"; then
@@ -5573,6 +5593,9 @@ workspace_is_sensitive() {
     "${REAL_HOME}/.ssh"
     "${REAL_HOME}/.aws"
     "${REAL_HOME}/.azure"
+    "${REAL_HOME}/.codex"
+    "${REAL_HOME}/.claude"
+    "${REAL_HOME}/.gemini"
     "${REAL_HOME}/.config"
     "${REAL_HOME}/.docker"
     "${REAL_HOME}/.npm"
@@ -5587,6 +5610,9 @@ workspace_is_sensitive() {
   )
   real_home_lower="$(lower_ascii "${REAL_HOME}")"
   local sensitive_regexes=(
+    '(^|.*/)\.codex($|/)'
+    '(^|.*/)\.claude($|/)'
+    '(^|.*/)\.gemini($|/)'
     "^${real_home_lower}/library/application support/google/chrome"
     "^${real_home_lower}/library/application support/google/chrome beta"
     "^${real_home_lower}/library/application support/chromium"
@@ -5649,7 +5675,7 @@ validate_workspace() {
       if [[ "${SESSION_DETACHED:-0}" -eq 1 ]] && [[ "$(effective_session_workspace_mode)" == "isolated" ]]; then
         echo "Next step: rerun with --session-workspace direct if you want to use the current workspace in place." >&2
       fi
-      echo "Alternatively, pass --mode breakglass --ack-breakglass to proceed with a linked worktree." >&2
+      echo "Alternatively, pass --mode breakglass --ack-breakglass=YYYY-MM-DD to proceed with a linked worktree." >&2
       exit 2
     fi
     return
@@ -5679,8 +5705,10 @@ validate_ack_token() {
   local today
 
   if [[ -z "${token}" ]]; then
-    echo "Warning: ${flag_name} accepted without a date acknowledgement; prefer ${flag_name}=YYYY-MM-DD (today's UTC date)." >&2
-    return 0
+    today="$(date -u +%Y-%m-%d)"
+    echo "${flag_name} requires a date acknowledgement." >&2
+    echo "Re-issue with ${flag_name}=${today} when you still intend to bypass the boundary." >&2
+    exit 2
   fi
   today="$(date -u +%Y-%m-%d)"
   if [[ "${token}" != "${today}" ]]; then

--- a/tests/scenarios/shared/test-assurance-dry-run.sh
+++ b/tests/scenarios/shared/test-assurance-dry-run.sh
@@ -11,6 +11,7 @@ trap cleanup EXIT
 
 HOME_DIR="${TMP_DIR}/home"
 WORKSPACE="${TMP_DIR}/workspace"
+ACK_TODAY_UTC="$(date -u +%Y-%m-%d)"
 mkdir -p "${HOME_DIR}/.config" "${WORKSPACE}"
 git -C "${WORKSPACE}" init -q
 printf 'scenario workspace\n' >"${WORKSPACE}/README.md"
@@ -158,9 +159,9 @@ fi
 if [[ "${launch_blocked}" -eq 1 ]]; then
   run_dry_run_expect_launch_blocked "prompt-codex" --agent codex --agent-autonomy prompt --agent-arg --version
   run_dry_run_expect_launch_blocked "development-codex" --agent codex --mode development --agent-arg --version
-  run_dry_run_expect_launch_blocked "breakglass-codex" --agent codex --mode breakglass --ack-breakglass
+  run_dry_run_expect_launch_blocked "breakglass-codex" --agent codex --mode breakglass "--ack-breakglass=${ACK_TODAY_UTC}"
   run_dry_run_expect_launch_blocked "readonly-codex" --agent codex --container-mutability readonly
-  run_dry_run_expect_launch_blocked "arbitrary-command-codex" --agent codex --allow-arbitrary-command --ack-arbitrary-command -- bash -lc true
+  run_dry_run_expect_launch_blocked "arbitrary-command-codex" --agent codex --allow-arbitrary-command "--ack-arbitrary-command=${ACK_TODAY_UTC}" -- bash -lc true
   run_dry_run_expect_launch_blocked "control-plane-vcs-codex" --agent codex --allow-control-plane-vcs --ack-control-plane-vcs
   echo "Assurance dry-run scenario passed"
   exit 0
@@ -215,7 +216,7 @@ run_dry_run_expect_failure 2 "breakglass-noack" --agent codex --mode breakglass
 grep -q '^breakglass mode requires --ack-breakglass\.$' "${TMP_DIR}/breakglass-noack.stderr"
 
 for agent in codex claude gemini; do
-  run_dry_run "breakglass-${agent}" --agent "${agent}" --mode breakglass --ack-breakglass
+  run_dry_run "breakglass-${agent}" --agent "${agent}" --mode breakglass "--ack-breakglass=${ACK_TODAY_UTC}"
   grep -q "^profile=.* mode=breakglass agent=${agent} " "${TMP_DIR}/breakglass-${agent}.stderr"
   grep -q '^workspace_control_plane=unmasked$' "${TMP_DIR}/breakglass-${agent}.stderr"
   grep -q '^network_policy=unrestricted ' "${TMP_DIR}/breakglass-${agent}.stderr"
@@ -260,7 +261,7 @@ for agent in codex claude gemini; do
     "${ROOT_DIR}/scripts/workcell" \
     --agent "${agent}" \
     --allow-arbitrary-command \
-    --ack-arbitrary-command \
+    "--ack-arbitrary-command=${ACK_TODAY_UTC}" \
     --workspace "${WORKSPACE}" \
     --no-default-injection-policy \
     --dry-run \

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -19,6 +19,7 @@ CLI_SESSION_FIXTURE_IMAGE="workcell-session-cli-fixture:test-$$"
 CLI_SESSION_FIXTURE_BUILD_DIR="${TMP_DIR}/session-cli-fixture-build"
 WORKCELL_FUNCTIONS_COPY="${ROOT_DIR}/scripts/.workcell-test-functions-$$"
 HOST_DOCKER_BIN=""
+ACK_TODAY_UTC="$(date -u +%Y-%m-%d)"
 
 resolve_host_docker_bin() {
   local candidate=""
@@ -458,7 +459,7 @@ run_detached_start_dry_run() {
     --workspace "${workspace_path}" \
     --no-default-injection-policy \
     --allow-arbitrary-command \
-    --ack-arbitrary-command \
+    "--ack-arbitrary-command=${ACK_TODAY_UTC}" \
     "$@" \
     --dry-run \
     -- /bin/true
@@ -535,7 +536,7 @@ if [[ "${detached_launch_blocked}" -eq 0 ]]; then
   grep -q "Refusing git workspace with admin state outside the mounted workspace: ${LINKED_WORKTREE_PATH}" <<<"${linked_isolated_output}"
   grep -q 'This workspace is a linked worktree: its .git file points to a .git directory outside the mounted path\.' <<<"${linked_isolated_output}"
   grep -q 'To use this workspace on the safe path, create a standard clone at the same location instead\.' <<<"${linked_isolated_output}"
-  grep -q 'Alternatively, pass --mode breakglass --ack-breakglass to proceed with a linked worktree\.' <<<"${linked_isolated_output}"
+  grep -q 'Alternatively, pass --mode breakglass --ack-breakglass=YYYY-MM-DD to proceed with a linked worktree\.' <<<"${linked_isolated_output}"
 fi
 
 sed '/^if \[\[ \$# -gt 0 \]\]; then$/,$d' "${ROOT_DIR}/scripts/workcell" >"${WORKCELL_FUNCTIONS_COPY}"
@@ -567,7 +568,7 @@ if [[ "${detached_launch_blocked}" -eq 0 ]]; then
       --workspace "${DETACHED_START_WORKSPACE}" \
       --no-default-injection-policy \
       --allow-arbitrary-command \
-      --ack-arbitrary-command \
+      "--ack-arbitrary-command=${ACK_TODAY_UTC}" \
       --dry-run \
       -- /bin/true 2>&1
   )"


### PR DESCRIPTION
## Summary

This PR closes the first vulnerability-validation boundary-hardening batch. It tightens harness-only support-matrix overrides, rejects provider control-plane workspace roots, requires dated lower-assurance acknowledgements, blocks direct provider-wrapper execution through managed provider policy and wrapper checks, and rejects traversal-style home-control-plane targets.

## Validation

- ./scripts/pre-merge.sh --profile pr-parity
- git verify-commit HEAD

## Notes

The provider wrapper keeps a narrow Codex execpolicy exception for local policy queries; normal provider launches still go through the managed launcher. Async reviewer list is empty in policy/reviewer-identities.toml.