### PR TITLE
Audit hosted release controls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,11 @@ jobs:
         run: |
           [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]
 
+      - name: Verify release tag signature
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/check-release-tag-signature.sh --github-repo "${GITHUB_REPOSITORY}" --repo-root "${GITHUB_WORKSPACE}" --tag "${GITHUB_REF_NAME}"
+
       - name: Verify GitHub-hosted controls
         env:
           WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"
@@ -440,12 +445,28 @@ jobs:
       - name: Run actionlint
         run: actionlint
 
-      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
-        with:
-          advanced-security: false
-          inputs: .github/workflows
-          persona: auditor
-          version: 1.25.2
+      - name: Install zizmor
+        env:
+          ZIZMOR_SHA256: aa1facd105f0d83fe5c55b1adcd9d7417de5d83aa27471f91dc0b66cf3803577
+          ZIZMOR_VERSION: 1.25.2
+        run: |
+          curl -fsSL \
+            --max-time 60 \
+            --connect-timeout 15 \
+            -o zizmor.tar.gz \
+            "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+          echo "${ZIZMOR_SHA256}  zizmor.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/bin"
+          tar -xzf zizmor.tar.gz -C "${RUNNER_TEMP}/bin" zizmor
+          chmod 0755 "${RUNNER_TEMP}/bin/zizmor"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Run GitHub Actions security analysis
+        run: |
+          zizmor \
+            --persona auditor \
+            --config .github/zizmor.yml \
+            .github/workflows
 
       - name: Assemble reproducible-build preflight manifest
         # The amd64 and arm64 runtime images are now built and
@@ -683,6 +704,11 @@ jobs:
       - name: Validate release tag name
         run: |
           [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]
+
+      - name: Verify release tag signature
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/check-release-tag-signature.sh --github-repo "${GITHUB_REPOSITORY}" --repo-root "${GITHUB_WORKSPACE}" --tag "${GITHUB_REF_NAME}"
 
       - id: source_date
         name: Compute source date epoch

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -97,17 +97,41 @@ jobs:
         with:
           persist-credentials: false
 
-      - id: zizmor
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
-        with:
-          advanced-security: ${{ !github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_ZIZMOR_SARIF == 'true' }}
-          inputs: .github/workflows
-          persona: auditor
-          version: 1.25.2
+      - name: Install zizmor
+        env:
+          ZIZMOR_SHA256: aa1facd105f0d83fe5c55b1adcd9d7417de5d83aa27471f91dc0b66cf3803577
+          ZIZMOR_VERSION: 1.25.2
+        run: |
+          curl -fsSL \
+            --max-time 60 \
+            --connect-timeout 15 \
+            -o zizmor.tar.gz \
+            "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+          echo "${ZIZMOR_SHA256}  zizmor.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/bin"
+          tar -xzf zizmor.tar.gz -C "${RUNNER_TEMP}/bin" zizmor
+          chmod 0755 "${RUNNER_TEMP}/bin/zizmor"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Run GitHub Actions security analysis
+        run: |
+          zizmor \
+            --persona auditor \
+            --config .github/zizmor.yml \
+            .github/workflows
+
+      - name: Generate zizmor SARIF
+        if: ${{ !github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_ZIZMOR_SARIF == 'true' }}
+        run: |
+          zizmor \
+            --persona auditor \
+            --config .github/zizmor.yml \
+            --format sarif \
+            .github/workflows >"${RUNNER_TEMP}/zizmor.sarif"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_ZIZMOR_SARIF == 'true' }}
         with:
           name: zizmor-sarif
-          path: ${{ steps.zizmor.outputs.output-file }}
+          path: ${{ runner.temp }}/zizmor.sarif
           retention-days: 5

--- a/internal/metadatautil/hostedcontrols.go
+++ b/internal/metadatautil/hostedcontrols.go
@@ -30,6 +30,46 @@ type WorkflowEnvironmentPolicy struct {
 	HasDeploymentTags     bool
 }
 
+type ActionsPolicy struct {
+	AllowOnlyPinnedVerifiedOrExplicitlyTrustedActions bool
+	DefaultWorkflowTokenPermissions                   string
+}
+
+type ReleaseAssetsPolicy struct {
+	ImmutableGitHubReleases bool
+}
+
+func GitHubActionsPolicy(policy map[string]any, policyPath string) (ActionsPolicy, error) {
+	rawPolicy, ok := policy["actions_policy"].(map[string]any)
+	if !ok {
+		return ActionsPolicy{}, fmt.Errorf("%s must define actions_policy as an explicit hosted-control table", policyPath)
+	}
+	allowOnlyPinned, ok := rawPolicy["allow_only_pinned_verified_or_explicitly_trusted_actions"].(bool)
+	if !ok || !allowOnlyPinned {
+		return ActionsPolicy{}, fmt.Errorf("%s must set actions_policy.allow_only_pinned_verified_or_explicitly_trusted_actions = true", policyPath)
+	}
+	defaultWorkflowTokenPermissions, ok := rawPolicy["default_workflow_token_permissions"].(string)
+	if !ok || defaultWorkflowTokenPermissions != "read" {
+		return ActionsPolicy{}, fmt.Errorf("%s must set actions_policy.default_workflow_token_permissions = \"read\"", policyPath)
+	}
+	return ActionsPolicy{
+		AllowOnlyPinnedVerifiedOrExplicitlyTrustedActions: allowOnlyPinned,
+		DefaultWorkflowTokenPermissions:                   defaultWorkflowTokenPermissions,
+	}, nil
+}
+
+func ReleaseAssets(policy map[string]any, policyPath string) (ReleaseAssetsPolicy, error) {
+	rawPolicy, ok := policy["release_assets"].(map[string]any)
+	if !ok {
+		return ReleaseAssetsPolicy{}, fmt.Errorf("%s must define release_assets as an explicit hosted-control table", policyPath)
+	}
+	immutableReleases, ok := rawPolicy["immutable_github_releases"].(bool)
+	if !ok || !immutableReleases {
+		return ReleaseAssetsPolicy{}, fmt.Errorf("%s must set release_assets.immutable_github_releases = true", policyPath)
+	}
+	return ReleaseAssetsPolicy{ImmutableGitHubReleases: immutableReleases}, nil
+}
+
 func RepositoryVariables(policy map[string]any, policyPath string) (map[string]any, error) {
 	expectedRepoVariables, ok := policy["repository_variables"].(map[string]any)
 	if !ok {
@@ -323,6 +363,18 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 	if err := readJSONFile(filepath.Join(tmpDir, "actions-permissions.json"), &actionsPermissions); err != nil {
 		return err
 	}
+	var selectedActions map[string]any
+	if err := readJSONFile(filepath.Join(tmpDir, "actions-selected-actions.json"), &selectedActions); err != nil {
+		return err
+	}
+	var workflowPermissions map[string]any
+	if err := readJSONFile(filepath.Join(tmpDir, "actions-workflow-permissions.json"), &workflowPermissions); err != nil {
+		return err
+	}
+	var immutableReleases map[string]any
+	if err := readJSONFile(filepath.Join(tmpDir, "immutable-releases.json"), &immutableReleases); err != nil {
+		return err
+	}
 	var actionsVariables map[string]any
 	if err := readJSONFile(filepath.Join(tmpDir, "actions-variables.json"), &actionsVariables); err != nil {
 		return err
@@ -395,6 +447,14 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 	if releaseMode != "review-gated" && releaseMode != "single-owner-public" && releaseMode != "single-owner-private" && releaseMode != "plan-limited-private" {
 		return fmt.Errorf("%s must set release_environment.mode to 'review-gated', 'single-owner-public', 'single-owner-private', or 'plan-limited-private'", policyPath)
 	}
+	actionsPolicy, err := GitHubActionsPolicy(policy, policyPath)
+	if err != nil {
+		return err
+	}
+	releaseAssetsPolicy, err := ReleaseAssets(policy, policyPath)
+	if err != nil {
+		return err
+	}
 	expectedContexts, err := requireStringSliceTable(policy, "required_status_checks", "contexts", policyPath)
 	if err != nil {
 		return err
@@ -416,6 +476,39 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 	}
 	if required, _ := actionsPermissions["sha_pinning_required"].(bool); !required {
 		return fmt.Errorf("GitHub Actions SHA pinning must be required on %s", repo)
+	}
+	if actionsPolicy.AllowOnlyPinnedVerifiedOrExplicitlyTrustedActions {
+		if allowedActions, _ := actionsPermissions["allowed_actions"].(string); allowedActions != "selected" {
+			return fmt.Errorf("GitHub Actions on %s must restrict allowed_actions to selected", repo)
+		}
+		if githubOwnedAllowed, _ := selectedActions["github_owned_allowed"].(bool); !githubOwnedAllowed {
+			return fmt.Errorf("GitHub Actions selected policy on %s must allow GitHub-owned actions", repo)
+		}
+		if verifiedAllowed, _ := selectedActions["verified_allowed"].(bool); !verifiedAllowed {
+			return fmt.Errorf("GitHub Actions selected policy on %s must allow verified creator actions", repo)
+		}
+		patternsAllowed, _ := selectedActions["patterns_allowed"].([]any)
+		unexpectedPatterns := make([]string, 0)
+		for _, raw := range patternsAllowed {
+			if pattern, _ := raw.(string); pattern != "" {
+				unexpectedPatterns = append(unexpectedPatterns, pattern)
+			}
+		}
+		slices.Sort(unexpectedPatterns)
+		if len(unexpectedPatterns) > 0 {
+			return fmt.Errorf("GitHub Actions selected policy on %s must not allow unreviewed action patterns: %s", repo, strings.Join(unexpectedPatterns, ", "))
+		}
+	}
+	if actual, _ := workflowPermissions["default_workflow_permissions"].(string); actual != actionsPolicy.DefaultWorkflowTokenPermissions {
+		return fmt.Errorf("GitHub Actions default workflow token permissions on %s must be %q", repo, actionsPolicy.DefaultWorkflowTokenPermissions)
+	}
+	if canApprove, _ := workflowPermissions["can_approve_pull_request_reviews"].(bool); canApprove {
+		return fmt.Errorf("GitHub Actions workflow token on %s must not be allowed to approve pull requests", repo)
+	}
+	if releaseAssetsPolicy.ImmutableGitHubReleases {
+		if enabled, _ := immutableReleases["enabled"].(bool); !enabled {
+			return fmt.Errorf("immutable GitHub releases must be enabled on %s", repo)
+		}
 	}
 
 	activeRulesets := make([]map[string]any, 0)

--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -199,6 +199,24 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		}
 		return re, match, nil
 	}
+	requireUniformWorkflowEnv := func(text, key, valuePattern, label, path string) (string, error) {
+		lineRE := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(key) + `:\s*(\S+)\s*$`)
+		valueRE := regexp.MustCompile(`^` + valuePattern + `$`)
+		matches := lineRE.FindAllStringSubmatch(text, -1)
+		if len(matches) == 0 {
+			return "", fmt.Errorf("%s in %s must define %s", label, path, key)
+		}
+		value := matches[0][1]
+		for _, match := range matches {
+			if !valueRE.MatchString(match[1]) {
+				return "", fmt.Errorf("%s in %s must match %q", label, path, valuePattern)
+			}
+			if match[1] != value {
+				return "", fmt.Errorf("%s in %s must use one reviewed value for %s", label, path, key)
+			}
+		}
+		return value, nil
+	}
 	requireActionRef := func(text, action, path string) (string, error) {
 		re := regexp.MustCompile(regexp.QuoteMeta(action) + `@([0-9a-f]{40})`)
 		matches := re.FindAllStringSubmatch(text, -1)
@@ -804,37 +822,22 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if securityActionlintSHAMatch[1] != releaseActionlintSHAMatch[1] {
 		return errors.New("ACTIONLINT_SHA256 must match between .github/workflows/security.yml and .github/workflows/release.yml")
 	}
-	_, securityZizmorVersionMatch, err := requireRegex(securityWorkflow, `(?m)^\s*ZIZMOR_VERSION:\s*([0-9]+\.[0-9]+\.[0-9]+)\s*$`, "security zizmor version", ".github/workflows/security.yml")
+	securityZizmorVersion, err := requireUniformWorkflowEnv(securityWorkflow, "ZIZMOR_VERSION", `[0-9]+\.[0-9]+\.[0-9]+`, "security zizmor version", ".github/workflows/security.yml")
 	if err != nil {
 		return err
 	}
-	if _, _, err := requireRegex(securityWorkflow, `(?m)^\s*ZIZMOR_SHA256:\s*([0-9a-f]{64})\s*$`, "security zizmor sha", ".github/workflows/security.yml"); err != nil {
+	if _, err := requireUniformWorkflowEnv(securityWorkflow, "ZIZMOR_SHA256", `[0-9a-f]{64}`, "security zizmor sha", ".github/workflows/security.yml"); err != nil {
 		return err
 	}
-	_, securityZizmorActionVersionMatch, err := requireRegex(securityWorkflow, `(?m)^\s*version:\s*([0-9]+\.[0-9]+\.[0-9]+)\s*$`, "security zizmor action version", ".github/workflows/security.yml")
+	releaseZizmorVersion, err := requireUniformWorkflowEnv(releaseWorkflow, "ZIZMOR_VERSION", `[0-9]+\.[0-9]+\.[0-9]+`, "release zizmor version", ".github/workflows/release.yml")
 	if err != nil {
 		return err
 	}
-	if securityZizmorVersionMatch[1] != securityZizmorActionVersionMatch[1] {
-		return errors.New("ZIZMOR_VERSION must match the zizmor-action version in .github/workflows/security.yml")
-	}
-	_, releaseZizmorActionVersionMatch, err := requireRegex(releaseWorkflow, `(?s)zizmorcore/zizmor-action@[0-9a-f]{40}\s*#\s*v[0-9]+\.[0-9]+\.[0-9]+.*?\n\s*version:\s*([0-9]+\.[0-9]+\.[0-9]+)\s*\n`, "release zizmor action version", ".github/workflows/release.yml")
-	if err != nil {
+	if _, err := requireUniformWorkflowEnv(releaseWorkflow, "ZIZMOR_SHA256", `[0-9a-f]{64}`, "release zizmor sha", ".github/workflows/release.yml"); err != nil {
 		return err
 	}
-	if securityZizmorVersionMatch[1] != releaseZizmorActionVersionMatch[1] {
-		return errors.New("ZIZMOR_VERSION must match the release workflow zizmor-action version")
-	}
-	securityZizmorActionRef, err := requireActionRef(securityWorkflow, "zizmorcore/zizmor-action", ".github/workflows/security.yml")
-	if err != nil {
-		return err
-	}
-	releaseZizmorActionRef, err := requireActionRef(releaseWorkflow, "zizmorcore/zizmor-action", ".github/workflows/release.yml")
-	if err != nil {
-		return err
-	}
-	if securityZizmorActionRef != releaseZizmorActionRef {
-		return errors.New("zizmorcore/zizmor-action must use the same reviewed commit SHA in .github/workflows/security.yml and .github/workflows/release.yml")
+	if securityZizmorVersion != releaseZizmorVersion {
+		return errors.New("ZIZMOR_VERSION must match between .github/workflows/security.yml and .github/workflows/release.yml")
 	}
 	for _, workflow := range []struct {
 		text string
@@ -852,14 +855,20 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		if !strings.Contains(workflow.text, "--connect-timeout 15") {
 			return fmt.Errorf("%s must bound actionlint download connect time", workflow.path)
 		}
+		if !strings.Contains(workflow.text, "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz") {
+			return fmt.Errorf("%s must derive the zizmor archive URL from ZIZMOR_VERSION", workflow.path)
+		}
+		if !strings.Contains(workflow.text, `echo "${ZIZMOR_SHA256}  zizmor.tar.gz" | sha256sum -c -`) {
+			return fmt.Errorf("%s must verify the pinned zizmor archive digest", workflow.path)
+		}
+		if !strings.Contains(workflow.text, `tar -xzf zizmor.tar.gz -C "${RUNNER_TEMP}/bin" zizmor`) {
+			return fmt.Errorf("%s must install the pinned zizmor binary archive", workflow.path)
+		}
 	}
 	for _, needle := range []string{
 		"github.event_name == 'workflow_dispatch' && github.ref_name != 'main'",
 		"base-ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || '' }}",
 		"head-ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || '' }}",
-		"https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz",
-		`echo "${ZIZMOR_SHA256}  zizmor.tar.gz" | sha256sum -c -`,
-		`tar -xzf zizmor.tar.gz -C "${RUNNER_TEMP}/bin" zizmor`,
 		"./scripts/check-workflows.sh",
 	} {
 		if !strings.Contains(securityWorkflow, needle) {
@@ -953,6 +962,9 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	}
 	if !strings.Contains(releaseWorkflow, "./scripts/publish-github-release.sh") {
 		return errors.New(".github/workflows/release.yml must publish assets through the reviewed repo-local GitHub Release API script")
+	}
+	if count := strings.Count(releaseWorkflow, "./scripts/check-release-tag-signature.sh --github-repo"); count != 2 {
+		return fmt.Errorf(".github/workflows/release.yml must verify release tag signatures in preflight and publish jobs, found %d checks", count)
 	}
 	for _, needle := range []string{
 		`run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
@@ -1057,6 +1069,12 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if releaseMode != "review-gated" && releaseMode != "single-owner-public" && releaseMode != "single-owner-private" && releaseMode != "plan-limited-private" {
 		return errors.New("policy/github-hosted-controls.toml must set release_environment.mode to 'review-gated', 'single-owner-public', 'single-owner-private', or 'plan-limited-private'")
 	}
+	if _, err := GitHubActionsPolicy(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
+		return err
+	}
+	if _, err := ReleaseAssets(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
+		return err
+	}
 	if err := ValidateCanonicalRepositoryVariables(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
 		return err
 	}
@@ -1065,6 +1083,9 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	}
 	for _, needle := range []string{
 		"gh api --paginate \"repos/${REPO}/actions/variables?per_page=100\"",
+		"repos/${REPO}/actions/permissions/selected-actions",
+		"repos/${REPO}/actions/permissions/workflow",
+		"repos/${REPO}/immutable-releases",
 		"jq -s '{total_count: (map(.total_count // 0) | max // 0), variables: (map(.variables // []) | add)}'",
 		"gh api --paginate \"repos/${REPO}/environments?per_page=100\"",
 		`list-hosted-control-environments "${POLICY_PATH}"`,

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -130,6 +130,13 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 		"[required_status_checks]",
 		`contexts = ["Allowed PR base", "Validate repository"]`,
 		"",
+		"[actions_policy]",
+		"allow_only_pinned_verified_or_explicitly_trusted_actions = true",
+		`default_workflow_token_permissions = "read"`,
+		"",
+		"[release_assets]",
+		"immutable_github_releases = true",
+		"",
 		"[repository_variables]",
 		`WORKCELL_RELEASE_NO_ATTEST = "false"`,
 		`WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = "false"`,
@@ -158,7 +165,21 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 	}
 	actionsPermissions := map[string]any{
 		"enabled":              true,
+		"allowed_actions":      "selected",
 		"sha_pinning_required": true,
+	}
+	selectedActions := map[string]any{
+		"github_owned_allowed": true,
+		"verified_allowed":     true,
+		"patterns_allowed":     []any{},
+	}
+	workflowPermissions := map[string]any{
+		"default_workflow_permissions":     "read",
+		"can_approve_pull_request_reviews": false,
+	}
+	immutableReleases := map[string]any{
+		"enabled":           true,
+		"enforced_by_owner": false,
 	}
 	actionsVariables := map[string]any{
 		"variables": []map[string]any{
@@ -346,6 +367,9 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 	}{
 		{"repo.json", repoJSON},
 		{"actions-permissions.json", actionsPermissions},
+		{"actions-selected-actions.json", selectedActions},
+		{"actions-workflow-permissions.json", workflowPermissions},
+		{"immutable-releases.json", immutableReleases},
 		{"actions-variables.json", actionsVariables},
 		{"environments.json", environmentsIndex},
 		{"collaborators-direct.json", directCollaborators},
@@ -447,14 +471,14 @@ func TestCheckPinnedInputsRejectsZizmorVersionMismatch(t *testing.T) {
 	cfg := writePinnedInputsFixture(t)
 	securityWorkflowPath := filepath.Join(cfg.WorkflowsDir, "security.yml")
 	rewriteFile(t, securityWorkflowPath, func(content string) string {
-		return strings.Replace(content, "version: 1.25.2", "version: 1.25.1", 1)
+		return strings.Replace(content, "ZIZMOR_VERSION: 1.25.2", "ZIZMOR_VERSION: 1.25.1", 1)
 	})
 
 	err := metadatautil.CheckPinnedInputs(cfg)
 	if err == nil {
 		t.Fatal("metadatautil.CheckPinnedInputs() unexpectedly accepted mismatched zizmor versions")
 	}
-	if !strings.Contains(err.Error(), "ZIZMOR_VERSION must match") {
+	if !strings.Contains(err.Error(), "one reviewed value for ZIZMOR_VERSION") {
 		t.Fatalf("metadatautil.CheckPinnedInputs() error = %v, want zizmor version mismatch rejection", err)
 	}
 }
@@ -465,33 +489,33 @@ func TestCheckPinnedInputsRejectsReleaseZizmorVersionMismatch(t *testing.T) {
 	cfg := writePinnedInputsFixture(t)
 	releaseWorkflowPath := filepath.Join(cfg.WorkflowsDir, "release.yml")
 	rewriteFile(t, releaseWorkflowPath, func(content string) string {
-		return strings.Replace(content, "version: 1.25.2", "version: 1.25.1", 1)
+		return strings.Replace(content, "ZIZMOR_VERSION: 1.25.2", "ZIZMOR_VERSION: 1.25.1", 1)
 	})
 
 	err := metadatautil.CheckPinnedInputs(cfg)
 	if err == nil {
 		t.Fatal("metadatautil.CheckPinnedInputs() unexpectedly accepted a release workflow zizmor version mismatch")
 	}
-	if !strings.Contains(err.Error(), "release workflow zizmor-action version") {
+	if !strings.Contains(err.Error(), "ZIZMOR_VERSION must match") {
 		t.Fatalf("metadatautil.CheckPinnedInputs() error = %v, want release zizmor version mismatch rejection", err)
 	}
 }
 
-func TestCheckPinnedInputsRejectsZizmorActionRefMismatch(t *testing.T) {
+func TestCheckPinnedInputsRejectsReleaseZizmorDigestMismatch(t *testing.T) {
 	t.Parallel()
 
 	cfg := writePinnedInputsFixture(t)
 	releaseWorkflowPath := filepath.Join(cfg.WorkflowsDir, "release.yml")
 	rewriteFile(t, releaseWorkflowPath, func(content string) string {
-		return strings.Replace(content, "zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d", "zizmorcore/zizmor-action@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1)
+		return strings.Replace(content, "ZIZMOR_SHA256: aa1facd105f0d83fe5c55b1adcd9d7417de5d83aa27471f91dc0b66cf3803577", "ZIZMOR_SHA256: deadbeef", 1)
 	})
 
 	err := metadatautil.CheckPinnedInputs(cfg)
 	if err == nil {
-		t.Fatal("metadatautil.CheckPinnedInputs() unexpectedly accepted a zizmor-action ref mismatch")
+		t.Fatal("metadatautil.CheckPinnedInputs() unexpectedly accepted a release workflow zizmor digest mismatch")
 	}
-	if !strings.Contains(err.Error(), "zizmorcore/zizmor-action must use the same reviewed commit SHA") {
-		t.Fatalf("metadatautil.CheckPinnedInputs() error = %v, want zizmor-action ref mismatch rejection", err)
+	if !strings.Contains(err.Error(), "release zizmor sha") {
+		t.Fatalf("metadatautil.CheckPinnedInputs() error = %v, want release zizmor digest rejection", err)
 	}
 }
 
@@ -572,6 +596,106 @@ func TestVerifyGitHubHostedControlsRejectsReviewGatedRulesetWithoutCodeOwnerRevi
 	}
 	if !strings.Contains(err.Error(), "must require code owner review") {
 		t.Fatalf("metadatautil.VerifyGitHubHostedControls() error = %v, want code-owner rejection", err)
+	}
+}
+
+func TestVerifyGitHubHostedControlsRejectsAllActionsAllowed(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, policyPath := writeHostedControlsFixture(t, "review-gated", "review-gated", []map[string]any{
+		{
+			"login": "omkhar",
+			"permissions": map[string]any{
+				"admin": true,
+			},
+		},
+	})
+
+	rewriteFile(t, filepath.Join(tmpDir, "actions-permissions.json"), func(content string) string {
+		return strings.Replace(content, `"allowed_actions": "selected"`, `"allowed_actions": "all"`, 1)
+	})
+
+	err := metadatautil.VerifyGitHubHostedControls(tmpDir, "omkhar/workcell", policyPath)
+	if err == nil {
+		t.Fatal("metadatautil.VerifyGitHubHostedControls() unexpectedly accepted all Actions")
+	}
+	if !strings.Contains(err.Error(), "must restrict allowed_actions to selected") {
+		t.Fatalf("metadatautil.VerifyGitHubHostedControls() error = %v, want selected-actions rejection", err)
+	}
+}
+
+func TestVerifyGitHubHostedControlsRejectsPermissiveWorkflowToken(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, policyPath := writeHostedControlsFixture(t, "review-gated", "review-gated", []map[string]any{
+		{
+			"login": "omkhar",
+			"permissions": map[string]any{
+				"admin": true,
+			},
+		},
+	})
+
+	rewriteFile(t, filepath.Join(tmpDir, "actions-workflow-permissions.json"), func(content string) string {
+		return strings.Replace(content, `"default_workflow_permissions": "read"`, `"default_workflow_permissions": "write"`, 1)
+	})
+
+	err := metadatautil.VerifyGitHubHostedControls(tmpDir, "omkhar/workcell", policyPath)
+	if err == nil {
+		t.Fatal("metadatautil.VerifyGitHubHostedControls() unexpectedly accepted write workflow token permissions")
+	}
+	if !strings.Contains(err.Error(), `must be "read"`) {
+		t.Fatalf("metadatautil.VerifyGitHubHostedControls() error = %v, want workflow-token rejection", err)
+	}
+}
+
+func TestVerifyGitHubHostedControlsRejectsWorkflowTokenPRApproval(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, policyPath := writeHostedControlsFixture(t, "review-gated", "review-gated", []map[string]any{
+		{
+			"login": "omkhar",
+			"permissions": map[string]any{
+				"admin": true,
+			},
+		},
+	})
+
+	rewriteFile(t, filepath.Join(tmpDir, "actions-workflow-permissions.json"), func(content string) string {
+		return strings.Replace(content, `"can_approve_pull_request_reviews": false`, `"can_approve_pull_request_reviews": true`, 1)
+	})
+
+	err := metadatautil.VerifyGitHubHostedControls(tmpDir, "omkhar/workcell", policyPath)
+	if err == nil {
+		t.Fatal("metadatautil.VerifyGitHubHostedControls() unexpectedly accepted workflow token PR approval")
+	}
+	if !strings.Contains(err.Error(), "must not be allowed to approve pull requests") {
+		t.Fatalf("metadatautil.VerifyGitHubHostedControls() error = %v, want workflow-token approval rejection", err)
+	}
+}
+
+func TestVerifyGitHubHostedControlsRejectsMutableGitHubReleases(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, policyPath := writeHostedControlsFixture(t, "review-gated", "review-gated", []map[string]any{
+		{
+			"login": "omkhar",
+			"permissions": map[string]any{
+				"admin": true,
+			},
+		},
+	})
+
+	rewriteFile(t, filepath.Join(tmpDir, "immutable-releases.json"), func(content string) string {
+		return strings.Replace(content, `"enabled": true`, `"enabled": false`, 1)
+	})
+
+	err := metadatautil.VerifyGitHubHostedControls(tmpDir, "omkhar/workcell", policyPath)
+	if err == nil {
+		t.Fatal("metadatautil.VerifyGitHubHostedControls() unexpectedly accepted mutable GitHub releases")
+	}
+	if !strings.Contains(err.Error(), "immutable GitHub releases must be enabled") {
+		t.Fatalf("metadatautil.VerifyGitHubHostedControls() error = %v, want immutable-release rejection", err)
 	}
 }
 

--- a/scripts/check-release-tag-signature.sh
+++ b/scripts/check-release-tag-signature.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+REPO_ROOT=""
+TAG_REF=""
+TRUSTED_HOST_PATH=""
+HOST_GIT_BIN=""
+REAL_HOME="${HOME:-/}"
+
+build_trusted_host_path() {
+  local dir=""
+  local path=""
+
+  for dir in /opt/homebrew/bin /usr/local/bin /usr/bin /bin /usr/sbin /sbin; do
+    [[ -d "${dir}" ]] || continue
+    if [[ -z "${path}" ]]; then
+      path="${dir}"
+    else
+      path="${path}:${dir}"
+    fi
+  done
+  printf '%s\n' "${path}"
+}
+
+resolve_fixed_host_tool() {
+  local name="$1"
+  shift
+  local candidate=""
+
+  for candidate in "$@"; do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  echo "Missing trusted host tool: ${name}" >&2
+  exit 1
+}
+
+run_clean_host_command_in_dir() {
+  local dir="$1"
+  local home="${REAL_HOME}"
+  local -a env_args=()
+
+  shift
+  [[ "$#" -gt 0 ]] || return 0
+  if [[ ! -d "${dir}" ]]; then
+    echo "Missing host working directory: ${dir}" >&2
+    exit 2
+  fi
+  if [[ ! -d "${home}" ]]; then
+    home="/"
+  fi
+
+  env_args=(
+    PATH="${TRUSTED_HOST_PATH}"
+    HOME="${home}"
+    LC_ALL=C
+    LANG=C
+  )
+
+  [[ -n "${GNUPGHOME:-}" ]] && env_args+=("GNUPGHOME=${GNUPGHOME}")
+  [[ -n "${GPG_TTY:-}" ]] && env_args+=("GPG_TTY=${GPG_TTY}")
+  [[ -n "${XDG_CONFIG_HOME:-}" ]] && env_args+=("XDG_CONFIG_HOME=${XDG_CONFIG_HOME}")
+  [[ -n "${XDG_STATE_HOME:-}" ]] && env_args+=("XDG_STATE_HOME=${XDG_STATE_HOME}")
+  [[ -n "${XDG_CACHE_HOME:-}" ]] && env_args+=("XDG_CACHE_HOME=${XDG_CACHE_HOME}")
+  [[ -n "${XDG_DATA_HOME:-}" ]] && env_args+=("XDG_DATA_HOME=${XDG_DATA_HOME}")
+  [[ -n "${XDG_RUNTIME_DIR:-}" ]] && env_args+=("XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}")
+
+  (
+    cd "${dir}" &&
+      env -i \
+        "${env_args[@]}" \
+        "$@"
+  )
+}
+
+usage() {
+  cat <<'EOF'
+Usage: check-release-tag-signature.sh --repo-root PATH --tag TAG
+
+Options:
+  --repo-root PATH   Repository whose release tag should be verified
+  --tag TAG          Tag name or ref to verify
+  --git-bin PATH     Trusted Git executable to use
+  --github-repo REPO Verify the tag through GitHub's tag-object verification API
+  -h, --help         Show this help text
+EOF
+}
+
+option_value_or_die() {
+  local flag="$1"
+  local value="${2:-}"
+
+  if [[ -z "${value}" ]]; then
+    echo "${flag} requires a value." >&2
+    exit 2
+  fi
+  printf '%s\n' "${value}"
+}
+
+verify_github_tag_signature() {
+  local repo="$1"
+  local tag_ref="$2"
+  local ref_json=""
+  local tag_json=""
+  local object_type=""
+  local object_sha=""
+  local verified=""
+  local reason=""
+
+  command -v gh >/dev/null 2>&1 || {
+    echo "Missing trusted host tool: gh" >&2
+    exit 1
+  }
+
+  tag_ref="${tag_ref#refs/tags/}"
+  ref_json="$(gh api "repos/${repo}/git/ref/tags/${tag_ref}")"
+  object_type="$(jq -r '.object.type // empty' <<<"${ref_json}")"
+  object_sha="$(jq -r '.object.sha // empty' <<<"${ref_json}")"
+  if [[ "${object_type}" != "tag" || -z "${object_sha}" ]]; then
+    echo "Release tag ${tag_ref} on ${repo} must be an annotated signed tag object." >&2
+    exit 2
+  fi
+
+  tag_json="$(gh api "repos/${repo}/git/tags/${object_sha}")"
+  verified="$(jq -r '.verification.verified // false' <<<"${tag_json}")"
+  reason="$(jq -r '.verification.reason // "unknown"' <<<"${tag_json}")"
+  if [[ "${verified}" != "true" || "${reason}" != "valid" ]]; then
+    echo "release workflow requires a GitHub-verified signed tag; ${tag_ref} verification reason is ${reason}." >&2
+    exit 2
+  fi
+
+  printf 'Release tag signature check passed: tag=%s verifier=github\n' "${tag_ref}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      REPO_ROOT="$(option_value_or_die "$1" "${2-}")"
+      shift 2
+      ;;
+    --tag)
+      TAG_REF="$(option_value_or_die "$1" "${2-}")"
+      shift 2
+      ;;
+    --git-bin)
+      HOST_GIT_BIN="$(option_value_or_die "$1" "${2-}")"
+      shift 2
+      ;;
+    --github-repo)
+      GITHUB_REPOSITORY="$(option_value_or_die "$1" "${2-}")"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unsupported check-release-tag-signature option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${REPO_ROOT}" ]]; then
+  echo "check-release-tag-signature requires --repo-root." >&2
+  exit 2
+fi
+if [[ -z "${TAG_REF}" ]]; then
+  echo "check-release-tag-signature requires --tag." >&2
+  exit 2
+fi
+
+if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+  verify_github_tag_signature "${GITHUB_REPOSITORY}" "${TAG_REF}"
+  exit 0
+fi
+
+TRUSTED_HOST_PATH="$(build_trusted_host_path)"
+if [[ -n "${HOST_GIT_BIN}" ]]; then
+  if [[ "${HOST_GIT_BIN}" != /* ]] || [[ ! -x "${HOST_GIT_BIN}" ]]; then
+    echo "--git-bin must point to an absolute executable path: ${HOST_GIT_BIN}" >&2
+    exit 2
+  fi
+else
+  HOST_GIT_BIN="$(resolve_fixed_host_tool git /opt/homebrew/bin/git /usr/local/bin/git /usr/bin/git /bin/git)"
+fi
+if [[ ! -d "${REAL_HOME}" ]]; then
+  REAL_HOME="/"
+fi
+
+REPO_ROOT="$(cd "${REPO_ROOT}" && pwd -P)"
+if ! run_clean_host_command_in_dir "${REPO_ROOT}" "${HOST_GIT_BIN}" rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "check-release-tag-signature requires a git worktree: ${REPO_ROOT}" >&2
+  exit 2
+fi
+
+tag_object="$(run_clean_host_command_in_dir "${REPO_ROOT}" "${HOST_GIT_BIN}" rev-parse --verify --quiet "${TAG_REF}^{tag}" || true)"
+if [[ -z "${tag_object}" ]]; then
+  echo "Release tag ${TAG_REF} must be an annotated signed tag object." >&2
+  exit 2
+fi
+
+verify_log="$(mktemp "${TMPDIR:-/tmp}/workcell-release-tag.XXXXXX")"
+
+cleanup() {
+  rm -f "${verify_log}"
+}
+trap cleanup EXIT
+
+if ! run_clean_host_command_in_dir "${REPO_ROOT}" "${HOST_GIT_BIN}" --no-replace-objects verify-tag "${tag_object}" >/dev/null 2>"${verify_log}"; then
+  echo "release workflow requires a verifiable signed tag; unable to verify ${TAG_REF}." >&2
+  if [[ -s "${verify_log}" ]]; then
+    sed 's/^/  /' "${verify_log}" >&2
+  fi
+  exit 2
+fi
+
+printf 'Release tag signature check passed: tag=%s\n' "${TAG_REF}"

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -209,33 +209,6 @@ extract_workflow_env_value() {
   awk -v key="${key}:" '$1 == key { print $2; exit }' "${file}"
 }
 
-extract_action_ref() {
-  local file="$1"
-  local action="$2"
-  awk -v needle="uses: ${action}@" '
-    index($0, needle) > 0 {
-      sub(".*" needle, "", $0)
-      sub(/[[:space:]]+#.*/, "", $0)
-      print
-      exit
-    }
-  ' "${file}"
-}
-
-extract_zizmor_action_version_input() {
-  local file="$1"
-  awk '
-    /uses:[[:space:]]*zizmorcore\/zizmor-action@/ {
-      in_zizmor = 1
-      next
-    }
-    in_zizmor && /^[[:space:]]*version:/ {
-      print $2
-      exit
-    }
-  ' "${file}"
-}
-
 replace_line_with_prefix() {
   local file="$1"
   local prefix="$2"
@@ -456,10 +429,6 @@ target_zizmor_sha="$(
     shasum -a 256 |
     awk '{ print $1 }'
 )"
-zizmor_action_release_json="$(github_api_get 'https://api.github.com/repos/zizmorcore/zizmor-action/releases/latest')"
-target_zizmor_action_version="$(jq -r '.tag_name' <<<"${zizmor_action_release_json}")"
-target_zizmor_action_sha="$(github_tag_commit_sha 'zizmorcore/zizmor-action' "${target_zizmor_action_version}")"
-
 current_runtime_base="$(extract_dockerfile_arg "${RUNTIME_DOCKERFILE_PATH}" NODE_BASE_IMAGE)"
 current_validator_base="$(extract_dockerfile_arg "${VALIDATOR_DOCKERFILE_PATH}" VALIDATOR_BASE_IMAGE)"
 current_runtime_snapshot="$(extract_dockerfile_arg "${RUNTIME_DOCKERFILE_PATH}" DEBIAN_SNAPSHOT)"
@@ -489,9 +458,8 @@ current_actionlint_version="$(extract_workflow_env_value "${SECURITY_WORKFLOW_PA
 current_actionlint_sha="$(extract_workflow_env_value "${SECURITY_WORKFLOW_PATH}" ACTIONLINT_SHA256)"
 current_zizmor_version="$(extract_workflow_env_value "${SECURITY_WORKFLOW_PATH}" ZIZMOR_VERSION)"
 current_zizmor_sha="$(extract_workflow_env_value "${SECURITY_WORKFLOW_PATH}" ZIZMOR_SHA256)"
-current_security_zizmor_action_ref="$(extract_action_ref "${SECURITY_WORKFLOW_PATH}" 'zizmorcore/zizmor-action')"
-current_release_zizmor_action_ref="$(extract_action_ref "${RELEASE_WORKFLOW_PATH}" 'zizmorcore/zizmor-action')"
-current_release_zizmor_version="$(extract_zizmor_action_version_input "${RELEASE_WORKFLOW_PATH}")"
+current_release_zizmor_version="$(extract_workflow_env_value "${RELEASE_WORKFLOW_PATH}" ZIZMOR_VERSION)"
+current_release_zizmor_sha="$(extract_workflow_env_value "${RELEASE_WORKFLOW_PATH}" ZIZMOR_SHA256)"
 
 runtime_base_track="${current_runtime_base%@*}"
 validator_base_track="${current_validator_base%@*}"
@@ -548,9 +516,8 @@ for current_target_pair in \
   "${current_actionlint_sha}|${target_actionlint_sha}" \
   "${current_zizmor_version}|${target_zizmor_version}" \
   "${current_zizmor_sha}|${target_zizmor_sha}" \
-  "${current_security_zizmor_action_ref}|${target_zizmor_action_sha}" \
-  "${current_release_zizmor_action_ref}|${target_zizmor_action_sha}" \
-  "${current_release_zizmor_version}|${target_zizmor_version}"; do
+  "${current_release_zizmor_version}|${target_zizmor_version}" \
+  "${current_release_zizmor_sha}|${target_zizmor_sha}"; do
   current_value="${current_target_pair%%|*}"
   target_value="${current_target_pair#*|}"
   if [[ "${current_value}" != "${target_value}" ]]; then
@@ -592,9 +559,8 @@ print_summary() {
   print_summary_line "syft-version" "${current_syft_version}" "${target_syft_version}"
   print_summary_line "actionlint-version" "${current_actionlint_version}" "${target_actionlint_version}"
   print_summary_line "zizmor-version" "${current_zizmor_version}" "${target_zizmor_version}"
-  print_summary_line "security-zizmor-action" "${current_security_zizmor_action_ref}" "${target_zizmor_action_sha}"
-  print_summary_line "release-zizmor-action" "${current_release_zizmor_action_ref}" "${target_zizmor_action_sha}"
   print_summary_line "release-zizmor-version" "${current_release_zizmor_version}" "${target_zizmor_version}"
+  print_summary_line "release-zizmor-sha" "${current_release_zizmor_sha}" "${target_zizmor_sha}"
   printf '%s\n' "${provider_summary}"
 }
 
@@ -655,15 +621,13 @@ replace_line_with_prefix "${RELEASE_WORKFLOW_PATH}" '  WORKCELL_QEMU_IMAGE:' "  
 replace_line_with_prefix "${RELEASE_WORKFLOW_PATH}" '  WORKCELL_SYFT_VERSION:' "  WORKCELL_SYFT_VERSION: ${target_syft_version}"
 replace_line_with_prefix "${RELEASE_WORKFLOW_PATH}" '          ACTIONLINT_SHA256:' "          ACTIONLINT_SHA256: ${target_actionlint_sha}"
 replace_line_with_prefix "${RELEASE_WORKFLOW_PATH}" '          ACTIONLINT_VERSION:' "          ACTIONLINT_VERSION: ${target_actionlint_version}"
-replace_line_with_prefix "${RELEASE_WORKFLOW_PATH}" '      - uses: zizmorcore/zizmor-action@' "      - uses: zizmorcore/zizmor-action@${target_zizmor_action_sha} # ${target_zizmor_action_version}"
-replace_line_after_marker_with_prefix "${RELEASE_WORKFLOW_PATH}" 'zizmorcore/zizmor-action@' '          version:' "          version: ${target_zizmor_version}"
+replace_line_with_prefix "${RELEASE_WORKFLOW_PATH}" '          ZIZMOR_SHA256:' "          ZIZMOR_SHA256: ${target_zizmor_sha}"
+replace_line_with_prefix "${RELEASE_WORKFLOW_PATH}" '          ZIZMOR_VERSION:' "          ZIZMOR_VERSION: ${target_zizmor_version}"
 
 replace_line_with_prefix "${SECURITY_WORKFLOW_PATH}" '          ACTIONLINT_SHA256:' "          ACTIONLINT_SHA256: ${target_actionlint_sha}"
 replace_line_with_prefix "${SECURITY_WORKFLOW_PATH}" '          ACTIONLINT_VERSION:' "          ACTIONLINT_VERSION: ${target_actionlint_version}"
 replace_line_with_prefix "${SECURITY_WORKFLOW_PATH}" '          ZIZMOR_SHA256:' "          ZIZMOR_SHA256: ${target_zizmor_sha}"
 replace_line_with_prefix "${SECURITY_WORKFLOW_PATH}" '          ZIZMOR_VERSION:' "          ZIZMOR_VERSION: ${target_zizmor_version}"
-replace_line_with_prefix "${SECURITY_WORKFLOW_PATH}" '        uses: zizmorcore/zizmor-action@' "        uses: zizmorcore/zizmor-action@${target_zizmor_action_sha} # ${target_zizmor_action_version}"
-replace_line_after_marker_with_prefix "${SECURITY_WORKFLOW_PATH}" 'zizmorcore/zizmor-action@' '          version:' "          version: ${target_zizmor_version}"
 
 "${ROOT_DIR}/scripts/update-provider-pins.sh" --apply
 "${ROOT_DIR}/scripts/check-pinned-inputs.sh"

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -167,6 +167,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/pre-merge.sh"
   "${ROOT_DIR}/scripts/provider-e2e.sh"
   "${ROOT_DIR}/scripts/publish-github-release.sh"
+  "${ROOT_DIR}/scripts/check-release-tag-signature.sh"
   "${ROOT_DIR}/scripts/publish-provider-bump-pr.sh"
   "${ROOT_DIR}/scripts/publish-upstream-refresh-pr.sh"
   "${ROOT_DIR}/scripts/run-hosted-controls-audit.sh"

--- a/scripts/verify-github-hosted-controls.sh
+++ b/scripts/verify-github-hosted-controls.sh
@@ -36,6 +36,18 @@ build_go_tool_in_repo "${ROOT_DIR}" "${CITOOLS_BIN}" ./cmd/workcell-citools
 
 gh api "repos/${REPO}" >"${TMP_DIR}/repo.json"
 gh api "repos/${REPO}/actions/permissions" >"${TMP_DIR}/actions-permissions.json"
+if gh api "repos/${REPO}/actions/permissions/selected-actions" >"${TMP_DIR}/actions-selected-actions.json" 2>"${TMP_DIR}/actions-selected-actions.err"; then
+  :
+else
+  status="$(jq -r '.status // empty' "${TMP_DIR}/actions-selected-actions.json" 2>/dev/null || true)"
+  if [[ "${status}" != "409" ]]; then
+    cat "${TMP_DIR}/actions-selected-actions.err" >&2
+    cat "${TMP_DIR}/actions-selected-actions.json" >&2
+    exit 1
+  fi
+fi
+gh api "repos/${REPO}/actions/permissions/workflow" >"${TMP_DIR}/actions-workflow-permissions.json"
+gh api "repos/${REPO}/immutable-releases" >"${TMP_DIR}/immutable-releases.json"
 gh api --paginate "repos/${REPO}/actions/variables?per_page=100" |
   jq -s '{total_count: (map(.total_count // 0) | max // 0), variables: (map(.variables // []) | add)}' >"${TMP_DIR}/actions-variables.json"
 gh api "repos/${REPO}/collaborators?affiliation=direct&per_page=100" >"${TMP_DIR}/collaborators-direct.json"

--- a/tests/scenarios/shared/test-publish-github-release.sh
+++ b/tests/scenarios/shared/test-publish-github-release.sh
@@ -2,6 +2,17 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-release-scenario.XXXXXX")"
+FIXTURE="${TMP_DIR}/repo"
+ALLOWED_SIGNERS="${TMP_DIR}/allowed_signers"
+SSH_VERIFY_PROGRAM="${TMP_DIR}/ssh-verify"
+HOST_XDG_CONFIG_HOME="${TMP_DIR}/xdg-config"
+HOST_HOME="${TMP_DIR}/home"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
 
 draft_ok_output="$("${ROOT_DIR}/scripts/publish-github-release.sh" --self-release-state-probe v9.9.9 true false)"
 grep -Fx 'publish-github-release-state-ok' <<<"${draft_ok_output}" >/dev/null
@@ -19,5 +30,79 @@ published_immutable_rc=$?
 set -e
 test "${published_immutable_rc}" -eq 1
 grep -F 'GitHub release v9.9.9 is already published and immutable; asset uploads are no longer allowed.' <<<"${published_immutable_output}" >/dev/null
+
+mkdir -p "${FIXTURE}" "${HOST_HOME}" "${HOST_XDG_CONFIG_HOME}/git"
+export HOME="${HOST_HOME}"
+export USER="workcell-scenario"
+export LOGNAME="workcell-scenario"
+git_cmd() {
+  HOME="${HOST_HOME}" XDG_CONFIG_HOME="${HOST_XDG_CONFIG_HOME}" git "$@"
+}
+
+git_cmd init -q "${FIXTURE}"
+git_cmd -C "${FIXTURE}" config user.name "Workcell Scenario"
+git_cmd -C "${FIXTURE}" config user.email "workcell-scenario@example.com"
+printf 'workcell-scenario@example.com namespaces="git" ' >"${ALLOWED_SIGNERS}"
+printf '%s\n' 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' >>"${ALLOWED_SIGNERS}"
+cat >"${SSH_VERIFY_PROGRAM}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case " $* " in
+  *' -Y find-principals '*)
+    printf '%s\n' 'workcell-scenario@example.com'
+    ;;
+  *' -Y verify '*)
+    printf '%s\n' 'Good "git" signature for workcell-scenario@example.com with ED25519 key SHA256:workcell-scenario'
+    ;;
+  *)
+    echo "unexpected ssh verification invocation: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod 0755 "${SSH_VERIFY_PROGRAM}"
+cat >"${HOST_XDG_CONFIG_HOME}/git/config" <<EOF
+[gpg]
+	format = ssh
+[gpg "ssh"]
+	allowedSignersFile = ${ALLOWED_SIGNERS}
+	program = ${SSH_VERIFY_PROGRAM}
+EOF
+git_cmd -C "${FIXTURE}" config gpg.format ssh
+git_cmd -C "${FIXTURE}" config gpg.ssh.allowedSignersFile "${ALLOWED_SIGNERS}"
+git_cmd -C "${FIXTURE}" config gpg.ssh.program "${SSH_VERIFY_PROGRAM}"
+
+printf 'release\n' >"${FIXTURE}/tracked.txt"
+git_cmd -C "${FIXTURE}" add tracked.txt
+git_cmd -C "${FIXTURE}" -c commit.gpgsign=false commit -q -m init
+commit_sha="$(git_cmd -C "${FIXTURE}" rev-parse HEAD)"
+cat >"${TMP_DIR}/signed-tag.txt" <<EOF
+object ${commit_sha}
+type commit
+tag v9.9.9
+tagger Workcell Scenario <workcell-scenario@example.com> 0 +0000
+
+v9.9.9
+-----BEGIN SSH SIGNATURE-----
+U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAABnNoYTUxMgAAAAAAAAAGc2lnbmVyAAAAAAAAAAAAAAA=
+-----END SSH SIGNATURE-----
+EOF
+tag_sha="$(git_cmd -C "${FIXTURE}" mktag <"${TMP_DIR}/signed-tag.txt")"
+git_cmd -C "${FIXTURE}" update-ref refs/tags/v9.9.9 "${tag_sha}"
+HOME="${HOST_HOME}" XDG_CONFIG_HOME="${HOST_XDG_CONFIG_HOME}" "${ROOT_DIR}/scripts/check-release-tag-signature.sh" \
+  --repo-root "${FIXTURE}" \
+  --tag v9.9.9 >/dev/null
+
+git_cmd -C "${FIXTURE}" -c tag.gpgSign=false tag v9.9.10
+set +e
+unsigned_tag_output="$(HOME="${HOST_HOME}" XDG_CONFIG_HOME="${HOST_XDG_CONFIG_HOME}" "${ROOT_DIR}/scripts/check-release-tag-signature.sh" \
+  --repo-root "${FIXTURE}" \
+  --tag v9.9.10 2>&1)"
+unsigned_tag_rc=$?
+set -e
+test "${unsigned_tag_rc}" -eq 2
+grep -F 'must be an annotated signed tag object' <<<"${unsigned_tag_output}" >/dev/null
 
 echo "publish-github-release policy scenario passed"


### PR DESCRIPTION
## Summary
- audit hosted immutable-release and Actions policy state directly
- require release tag signature verification in release preflight and publish jobs
- add hosted-control regressions and publish-release tag signature scenario coverage

## Validation
- ./scripts/pre-merge.sh --profile pr-parity
- ./scripts/verify-github-hosted-controls.sh omkhar/workcell
- go test ./internal/metadatautil -count=1
- ./scripts/check-pinned-inputs.sh
- bash tests/scenarios/shared/test-publish-github-release.sh