### PR TITLE
Clarify repo publication wrapper discipline

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,21 @@ Other defaults that matter:
 
 Useful operator flows:
 
+For changes to this repository, publish main-based PRs through the repo wrapper
+after fresh local parity evidence:
+
+```bash
+./scripts/pre-merge.sh --profile pr-parity
+./scripts/repo-publish-pr.sh --workspace /path/to/repo --branch feature/name \
+  --title-file /tmp/pr-title.txt \
+  --body-file /tmp/pr-body.md \
+  --commit-message-file /tmp/commit-message.txt
+```
+
+`workcell publish-pr` is the lower-level host-side helper. Use it directly for
+operator repositories that do not carry Workcell's repo-local parity wrapper,
+or for the explicitly lower-assurance non-`main` draft path.
+
 Use `--target colima|docker-desktop|aws-ec2-ssm|gcp-vm` to select the managed
 runtime backend.
 
@@ -328,6 +343,7 @@ workcell --gc
 ./scripts/update-upstream-pins.sh --check
 ./scripts/publish-provider-bump-pr.sh
 workcell --logs audit --colima-profile wcl-...
+# Lower-level host publication helper for repositories without a repo wrapper.
 workcell publish-pr --workspace /path/to/repo --branch feature/name \
   --title-file /tmp/pr-title.txt \
   --body-file /tmp/pr-body.md \

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -491,6 +491,41 @@ func TestPublishProviderBumpPRRequiresCleanWorktree(t *testing.T) {
 	}
 }
 
+func TestReadmeDocumentsRepoPublishWrapperBeforeLowerLevelHelper(t *testing.T) {
+	t.Parallel()
+
+	readmePath := filepath.Join(repoRoot(t), "README.md")
+	content, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	readme := string(content)
+
+	wrapper := "./scripts/repo-publish-pr.sh --workspace /path/to/repo"
+	lowerLevel := "workcell publish-pr --workspace /path/to/repo --branch feature/name"
+	wrapperIndex := strings.Index(readme, wrapper)
+	lowerLevelIndex := strings.Index(readme, lowerLevel)
+	if wrapperIndex < 0 {
+		t.Fatalf("%s must document the repo-local publish wrapper", readmePath)
+	}
+	if lowerLevelIndex < 0 {
+		t.Fatalf("%s must document the lower-level publish-pr helper", readmePath)
+	}
+	if wrapperIndex > lowerLevelIndex {
+		t.Fatalf("%s must introduce the repo-local wrapper before the lower-level helper", readmePath)
+	}
+	for _, want := range []string{
+		"./scripts/pre-merge.sh --profile pr-parity",
+		"`workcell publish-pr` is the lower-level host-side helper",
+		"operator repositories that do not carry Workcell's repo-local parity wrapper",
+		"explicitly lower-assurance non-`main` draft path",
+	} {
+		if !strings.Contains(readme, want) {
+			t.Fatalf("%s does not contain %q", readmePath, want)
+		}
+	}
+}
+
 func TestPublishUpstreamRefreshPRRequiresCleanWorktree(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- documents that Workcell repository PRs should use `./scripts/repo-publish-pr.sh` after fresh `pr-parity`
- keeps `workcell publish-pr` framed as the lower-level host helper for repositories without the repo wrapper or explicit lower-assurance non-main drafts
- adds a small README ordering invariant so the wrapper guidance remains visible before the lower-level helper example

## Validation
- `go test ./internal/testkit`
- `bash ./scripts/verify-operator-contract.sh`
- `bash ./scripts/verify-requirements-coverage.sh`
- `bash ./scripts/check-dead-code.sh`
- `bash ./scripts/check-public-repo-hygiene.sh`
- `bash ./tests/scenarios/shared/test-publish-pr-dry-run.sh` (skips trusted host-bin fixture on this Linux host)
- `./scripts/pre-merge.sh --profile pr-parity`

## Notes
- Vulnerability-validation tranche WCV-PUBLISH-001 closed as a non-advisory workflow-discipline gap: direct `workcell publish-pr` still emits signed-range and PR-shape gates, while the repo wrapper adds local `pr-parity` enforcement for this repository.
