### PR TITLE
Architectural review iteration 2: close low findings

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ What you expected to happen.
 - OS: [e.g. macOS 15.4]
 - Workcell version: [e.g. v0.5.0 or commit SHA]
 - Provider: [Codex / Claude / Gemini]
-- Mode: [strict / build / breakglass]
+- Mode: [strict / development / build / breakglass]
 - Docker version: `docker --version`
 - Colima version (macOS only): `colima version`
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,6 +80,26 @@ updates:
         patterns:
           - "*"
 
+  - package-ecosystem: "npm"
+    directory: "/tools/markdownlint"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "10:15"
+      timezone: "America/Toronto"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+      - "npm"
+    groups:
+      markdownlint:
+        patterns:
+          - "*"
+
   # Cargo updates are handled by the reviewed upstream refresh path because the
   # runtime Rust build is vendored and must remain reproducible with
   # cargo --locked --offline. Re-enable Dependabot for Cargo only after adding

--- a/.github/workflows/upstream-refresh.yml
+++ b/.github/workflows/upstream-refresh.yml
@@ -27,6 +27,7 @@ jobs:
     timeout-minutes: 20
     environment:
       name: upstream-refresh
+      url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
     permissions:
       contents: read # Read the reviewed tree to compute the candidate bundle.
       issues: write # Update the rolling tracking issue with the latest candidate status.

--- a/README.md
+++ b/README.md
@@ -445,8 +445,9 @@ See [docs/provenance.md](docs/provenance.md) and
 
 - `runtime/`: VM and container boundary implementation
 - `policy/`: shared contract layer and hosted-control policy
-- `adapters/`: provider-native baselines for Codex, Claude, and Gemini; the
-  Copilot baseline joins here only when its adapter support lands
+- `adapters/`: provider-native baselines for Codex, Claude, and Gemini, plus
+  the fail-closed Copilot planning scaffold (`adapters/copilot/` is not a
+  baseline until its adapter support lands)
 - `cmd/`: host-side and runtime-side Go entrypoints (the `workcell-*` binaries)
 - `internal/`: shared Go packages backing the `cmd/` binaries
 - `scripts/`: launcher, validation, release, audit, and bootstrap entrypoints

--- a/cmd/workcell-colimautil/main_test.go
+++ b/cmd/workcell-colimautil/main_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunRejectsMissingSubcommand(t *testing.T) {
+	err := run(nil)
+	if err == nil || !strings.Contains(err.Error(), "usage:") {
+		t.Fatalf("run(nil) = %v, want usage error", err)
+	}
+}
+
+func TestRunRejectsUnknownSubcommand(t *testing.T) {
+	err := run([]string{"unknown-subcommand"})
+	if err == nil || !strings.Contains(err.Error(), "usage:") {
+		t.Fatalf("run(unknown) = %v, want usage error", err)
+	}
+}
+
+func TestRunRejectsWrongArity(t *testing.T) {
+	for _, args := range [][]string{
+		{"validate-runtime-mounts", "only-one"},
+		{"validate-profile-config", "a", "b"},
+	} {
+		err := run(args)
+		if err == nil || !strings.Contains(err.Error(), "usage:") {
+			t.Fatalf("run(%v) = %v, want usage error", args, err)
+		}
+	}
+}

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -27,10 +27,14 @@ separate action.
 
 ## 3. Repo policy must not silently widen trust
 
-Repo-local control-plane files such as `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`,
-`.codex/`, `.claude/`, and `.gemini/` are masked on the safe path and imported
-into provider homes as reviewed inputs. The workspace should not be able to
-quietly take over the runtime control plane.
+Repo-local control-plane files are masked on the safe path and imported into
+provider homes as reviewed inputs. The masked set is the provider files
+`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `.mcp.json`; the provider and IDE
+directories `.codex/`, `.claude/`, `.gemini/`, `.vscode/`, `.idea/`,
+`.cursor/`, and `.zed/`; and git execution-control paths (`hooks`, `config`,
+`config.worktree`, and `worktrees` for the workspace repo and its
+submodules). The workspace should not be able to quietly take over the
+runtime control plane.
 
 The planned Copilot adapter must explicitly account for Copilot-specific repo
 control-plane files such as `.github/copilot-instructions.md`,

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -60,7 +60,9 @@ state:
 - `./scripts/build-and-test.sh` (host-native by default; `--docker` reruns repo validation inside the pinned CI validator container from a disposable snapshot)
 - `./scripts/container-smoke.sh`
 - `./scripts/verify-invariants.sh`
-- `./scripts/verify-release-bundle.sh`
+- `./scripts/verify-release-bundle.sh` (release-preflight only: it runs in
+  the `release-preflight` validate profile and in `release.yml`, not in the
+  standard PR lane)
 - `./scripts/verify-reproducible-build.sh`
 - `./scripts/pre-merge.sh` profiles:
   - `repo-core` for deterministic repo-required validation

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -98,9 +98,11 @@ packages under [`internal/`](../internal):
   rendering and validation
 - [`internal/host/launcher`](../internal/host/launcher), [`internal/host/sessions`](../internal/host/sessions),
   [`internal/host/hoststate`](../internal/host/hoststate), [`internal/host/release`](../internal/host/release),
+  [`internal/host/stateroot`](../internal/host/stateroot),
   [`internal/host/supportmatrix`](../internal/host/supportmatrix): host-side
   utility subpackages (path canonicalization, colima/profile-lock, session
-  records, mount/audit state, GitHub release helpers, support matrix)
+  records, mount/audit state, GitHub release helpers, Workcell-owned
+  target-state roots, support matrix)
 - [`internal/metadatautil`](../internal/metadatautil): metadata and validation
   helpers used by repo checks and release posture
 - [`internal/runtimeutil`](../internal/runtimeutil): runtime-related utility

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "01dee821a80be76254d7e80b4e9320dab2aabd27fa2ab929dfdcb957842ec7ac"
+      "sha256": "dcb859992b8066a58b55014fd723d3e30fe2d3e42220079ece0f61e4cb2c81f8"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",
@@ -214,7 +214,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/public-node-guard.mjs",
       "runtime_path": "/usr/local/libexec/workcell/public-node-guard.mjs",
-      "sha256": "3e5e1114876f4014c0a21cd849f0444b0cfb79dc2e80d799a68c11a44503160d"
+      "sha256": "fbf630abe855c8d1f6a2c19caf09c874ef0a7af0977b2c55b805e974a40eb3f3"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/public-node-guard.mjs
+++ b/runtime/container/public-node-guard.mjs
@@ -1,3 +1,7 @@
+// Defense-in-depth only: this guard hardens provider-package integrity for
+// already-trusted launch paths. It is not a security boundary — the VM plus
+// hardened container is. Code already running in the workspace can import
+// modules without re-triggering these hooks.
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -434,7 +434,7 @@ Options:
   --debug-log PATH              Persist launcher stderr and captured build output to PATH
   --file-trace-log PATH         Persist session file transaction trace to PATH
   --audit-transcript PATH       Persist full interactive terminal transcript to PATH
-  --ui cli|gui                  Surface to launch (default: cli)
+  --ui cli|gui                  Surface to launch (default: cli; gui is not implemented and fails closed)
   --mode strict|development|build|breakglass
                                 Runtime profile (default: strict)
   --doctor                      Validate host/workspace/profile state and print remediation

--- a/verify/invariants/expected-controls.md
+++ b/verify/invariants/expected-controls.md
@@ -16,6 +16,7 @@
 ## Codex controls
 
 - `strict` uses `workspace-write`
+- `development` uses `workspace-write`
 - `build` uses `workspace-write`
 - `breakglass` uses `danger-full-access`
 - web search stays disabled in all shipped profiles
@@ -23,6 +24,7 @@
 ## Network controls
 
 - `strict` applies the base egress allowlist
+- `development` applies the expanded development egress allowlist
 - `build` applies the expanded egress allowlist
 - allowlist modes program reviewed IPv4 and, when available, IPv6 destination
   allowlists; if IPv6 enforcement is unavailable, Workcell fails closed instead

--- a/workflows/go-porting.md
+++ b/workflows/go-porting.md
@@ -1,5 +1,8 @@
 # Go Porting Workflow
 
+Status: this migration is complete and no repo-owned Python remains. The
+workflow is retained as the reference pattern for future language ports.
+
 This workflow defines the compatibility-first migration path for replacing
 repo-owned Python with Go on the experimental branch.
 

--- a/workflows/python-to-go-migration.md
+++ b/workflows/python-to-go-migration.md
@@ -1,5 +1,8 @@
 # Python To Go Migration Workflow
 
+Status: this migration is complete and no repo-owned Python remains. The
+workflow is retained as the reference pattern for future language ports.
+
 Use this workflow when porting repo-owned Python helpers to Go.
 
 ## Goal


### PR DESCRIPTION
## Summary

Closes out the low findings from architectural-review iteration 2 (two fresh sweeps after #319: under-covered surfaces + an adversarial pass on the in-container runtime; both reported zero high findings).

- **Doc accuracy**: enumerate the full masked control-plane set in `docs/invariants.md` (`.mcp.json`, IDE dirs, git execution-control paths); add the supported `development` mode to `verify/invariants/expected-controls.md` and the bug-report template; label `verify-release-bundle.sh` as release-preflight-only; note the Copilot fail-closed scaffold in the README layout; add `internal/host/stateroot` to the system-design package list; mark the completed Python→Go porting guides as retained references; `--ui` usage text now says gui fails closed; `public-node-guard.mjs` carries an explicit non-boundary defense-in-depth note (with the mechanical control-plane manifest regen).
- **Automation config**: Dependabot npm lane for `tools/markdownlint` (was manual-only); `url:` audit field on the upstream-refresh environment, matching release.yml.
- **Tests**: dispatcher tests for `workcell-colimautil`, the only cmd binary without a `main_test.go`.

## Validation

- `./scripts/pre-merge.sh --profile pr-parity` green locally
- go tests, shellcheck, codespell, check-workflows (actionlint+zizmor), control-plane manifest verification all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
