### PR TITLE
Architectural review iteration 3: fail-closed release gate and verified quickstart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,9 +244,31 @@ jobs:
           # tagged commit show failures or unfinished work.  Tag-ancestry
           # alone is not enough: a tag pushed before main CI completes, or
           # against a red main, must not produce a release.
+          # Fail closed when nothing has registered yet: a tag pushed inside
+          # the registration window would otherwise see zero check-runs and
+          # sail through both filters below. GitHub Actions check suites for
+          # main-push workflows register at event delivery, so an empty set
+          # means main CI has not started for this commit. Scope to the
+          # github-actions app on main: third-party app suites (for example
+          # kusari-inspector) can sit queued forever on main commits.
+          suites="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-suites" \
+            --paginate \
+            --jq '[.check_suites[] | select(.app.slug == "github-actions" and .head_branch == "main")]')"
+          if [[ "$(jq 'length' <<<"${suites}")" -eq 0 ]]; then
+            echo "Tagged commit ${GITHUB_SHA} has no registered main workflow check suites yet." >&2
+            echo "Wait for main checks to register and finish before re-running this release." >&2
+            exit 1
+          fi
+          incomplete_suites="$(jq -r '.[] | select(.status != "completed") | "check suite \(.id) (\(.status))"' <<<"${suites}")"
+          if [[ -n "${incomplete_suites}" ]]; then
+            echo "Tagged commit ${GITHUB_SHA} has main workflow check suites not yet completed:" >&2
+            printf '%s\n' "${incomplete_suites}" >&2
+            echo "Wait for main checks to finish before re-running this release." >&2
+            exit 1
+          fi
           failed="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs" \
             --paginate \
-            --jq '.check_runs[] | select(.status == "completed" and (.conclusion | IN("failure","cancelled","timed_out","action_required"))) | "\(.name) (\(.conclusion))"')"
+            --jq '.check_runs[] | select(.status == "completed" and (.conclusion | IN("failure","cancelled","timed_out","action_required","stale"))) | "\(.name) (\(.conclusion))"')"
           if [[ -n "${failed}" ]]; then
             echo "Tagged commit ${GITHUB_SHA} has failed required checks:" >&2
             printf '%s\n' "${failed}" >&2

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,14 +11,22 @@ GitHub-hosted Apple Silicon `macos-26` and `macos-15`.
 
 ### Option A: verified release bundle
 
-Download a tagged release bundle from GitHub Releases, unpack it, and run the
-installer:
+Download a tagged release bundle plus `SHA256SUMS` and
+`SHA256SUMS.sigstore.json` from GitHub Releases, verify the bundle, then
+unpack it and run the installer:
 
 ```bash
+cosign verify-blob SHA256SUMS \
+  --bundle SHA256SUMS.sigstore.json \
+  --certificate-identity-regexp 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+sha256sum -c SHA256SUMS --ignore-missing
 tar -xzf workcell-vX.Y.Z.tar.gz
 cd workcell-vX.Y.Z
 ./scripts/install.sh
 ```
+
+See [docs/provenance.md](provenance.md) for the full verification contract.
 
 On supported macOS hosts, the installer uses Homebrew to install only the
 missing required packages (`colima`, `docker`, `gh`, `git`, `go`). Use
@@ -32,8 +40,18 @@ installs the same reviewed tree into Homebrew-managed `libexec`:
 
 ```bash
 curl -LO https://github.com/omkhar/workcell/releases/download/vX.Y.Z/workcell.rb
+curl -LO https://github.com/omkhar/workcell/releases/download/vX.Y.Z/SHA256SUMS
+curl -LO https://github.com/omkhar/workcell/releases/download/vX.Y.Z/SHA256SUMS.sigstore.json
+cosign verify-blob SHA256SUMS \
+  --bundle SHA256SUMS.sigstore.json \
+  --certificate-identity-regexp 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+sha256sum -c SHA256SUMS --ignore-missing
 brew install --formula ./workcell.rb
 ```
+
+The formula pins the bundle digest, so `brew` re-verifies the downloaded tree
+against the reviewed release at install time.
 
 The formula declares `colima`, `docker`, `gh`, `git`, and `go` as explicit
 dependencies.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,7 +20,7 @@ cosign verify-blob SHA256SUMS \
   --bundle SHA256SUMS.sigstore.json \
   --certificate-identity-regexp 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
-sha256sum -c SHA256SUMS --ignore-missing
+shasum -a 256 --ignore-missing -c SHA256SUMS
 tar -xzf workcell-vX.Y.Z.tar.gz
 cd workcell-vX.Y.Z
 ./scripts/install.sh
@@ -46,7 +46,7 @@ cosign verify-blob SHA256SUMS \
   --bundle SHA256SUMS.sigstore.json \
   --certificate-identity-regexp 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
-sha256sum -c SHA256SUMS --ignore-missing
+shasum -a 256 --ignore-missing -c SHA256SUMS
 brew install --formula ./workcell.rb
 ```
 

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -72,11 +72,13 @@ GitHub-independent check.
 
 ## GitHub attestation path
 
-The canonical upstream repo also publishes GitHub attestations when the
-reviewed hosted controls allow it. That posture is tracked through two
-repository variables:
+The canonical upstream repo publishes GitHub attestations fail-closed: every
+release attests its artifacts unless the opt-out is set. That posture is
+tracked through two repository variables:
 
-- `WORKCELL_ENABLE_GITHUB_ATTESTATIONS=true` requests GitHub attestations
+- `WORKCELL_RELEASE_NO_ATTEST=true` is the explicit opt-out; when unset,
+  releases attest (the earlier `WORKCELL_ENABLE_GITHUB_ATTESTATIONS` opt-in
+  was removed because a missing toggle silently produced unattested releases)
 - `WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS=true` is only allowed when the
   repository is private/internal and the GitHub plan actually supports private
   artifact attestations

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -81,8 +81,8 @@ shift
 require_tool curl
 
 for path in "$@"; do
-  [[ -s "${path}" ]] || {
-    echo "Missing or empty release asset: ${path}" >&2
+  [[ -f "${path}" && -s "${path}" ]] || {
+    echo "Missing, empty, or non-file release asset: ${path}" >&2
     exit 1
   }
 done

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -81,8 +81,8 @@ shift
 require_tool curl
 
 for path in "$@"; do
-  [[ -f "${path}" ]] || {
-    echo "Missing release asset: ${path}" >&2
+  [[ -s "${path}" ]] || {
+    echo "Missing or empty release asset: ${path}" >&2
     exit 1
   }
 done


### PR DESCRIPTION
## Summary

Architectural-review iteration 3 (deep adversarial passes on the release/signing pipeline and host-side internals + network egress; both reported **zero high findings**). This PR fixes the two mediums and two lows the release-pipeline pass surfaced:

- **Release gate fail-closed**: the green-main gate passed a tagged commit with zero registered check-runs (tag pushed inside the registration window) and let `stale` conclusions through. Now requires at least one *completed* `github-actions` check suite on `main` for the tagged commit before consulting check-runs (third-party suites like kusari-inspector sit `queued` forever on main and are excluded — verified empirically), and `stale` joins the failing conclusion set.
- **Quickstart actually verifies**: "Option A: verified release bundle" never verified anything; both install options now include the `cosign verify-blob` + `sha256sum -c` steps from the provenance contract.
- **provenance.md attestation toggle**: documented the removed `WORKCELL_ENABLE_GITHUB_ATTESTATIONS` opt-in; now describes the current fail-closed `WORKCELL_RELEASE_NO_ATTEST` opt-out.
- **Zero-byte assets**: `publish-github-release.sh` now rejects empty release assets (`-s` instead of `-f`).

Verified sound in this iteration (no changes needed): all signed artifacts are built in the signing job with fail-closed digest-equality handoffs; keyless cosign identities are effectively exact; egress enforcement is VM-side iptables with the documented IPv6 fail-closed behavior implemented; host publication is argv-only with hooks disabled; every credential read routes through the secretfile gate.

## Validation

- `./scripts/pre-merge.sh --profile pr-parity` green locally
- actionlint + zizmor (check-workflows), shellcheck, codespell, check-pinned-inputs all pass
- Check-suite shape verified against real main commits before changing the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
