### PR TITLE
Architectural review iteration 6: close completeness-sweep mediums

### DIFF
--- a/adapters/claude/hooks/guard-bash.sh
+++ b/adapters/claude/hooks/guard-bash.sh
@@ -291,7 +291,7 @@ mcp_home_control_regex="(^|[[:space:]'\";|&])(~|\$home|/state/agent-home)/\\.mcp
 if grep_command '(^|[^[:alnum:]_./-])(git|/usr/bin/git|/usr/local/libexec/workcell/git|/usr/local/libexec/workcell/core/git|/usr/local/libexec/workcell/real/git)([^[:alnum:]_./-]|$)'; then
   if [[ "${command_lower}" == *"--no-verify"* ]] ||
     grep_command '(^|[[:space:]'"'"'";|&])commit.*[[:space:]'"'"'";|&]-n([[:space:]'"'"'";|&]|$)' ||
-    grep_command '(^|[[:space:]'"'"'";|&])-c[[:space:]]+(core\.hookspath|core\.worktree|include\.path|includeif\.[^=[:space:]]+\.path)=' ||
+    grep_command '(^|[[:space:]'"'"'";|&])-c[[:space:]]*(core\.hookspath|core\.worktree|include\.path|includeif\.[^=[:space:]]+\.path)=' ||
     grep_command '--config-env=(core\.hookspath|core\.worktree|include\.path|includeif\.[^=[:space:]]+\.path)=' ||
     grep_command '(^|[[:space:]'"'"'";|&])(git_config_(count|key_[0-9]+|value_[0-9]+|parameters)|git_dir|git_work_tree|git_common_dir)=' ||
     grep_command '(^|[[:space:]'"'"'";|&])--git-dir(=|[[:space:]'"'"'";|&])' ||

--- a/adapters/codex/.codex/rules/default.rules
+++ b/adapters/codex/.codex/rules/default.rules
@@ -135,7 +135,7 @@ prefix_rule(
 )
 
 prefix_rule(
-    pattern = [["codex", "claude", "gemini", "/usr/local/libexec/workcell/core/codex", "/usr/local/libexec/workcell/core/claude", "/usr/local/libexec/workcell/core/gemini", "/usr/local/libexec/workcell/real/codex", "/usr/local/libexec/workcell/real/claude", "/opt/workcell/providers/node_modules/.bin/gemini"]],
+    pattern = [["codex", "claude", "gemini", "/usr/local/libexec/workcell/provider-wrapper.sh", "/usr/local/libexec/workcell/core/codex", "/usr/local/libexec/workcell/core/claude", "/usr/local/libexec/workcell/core/gemini", "/usr/local/libexec/workcell/real/codex", "/usr/local/libexec/workcell/real/claude", "/opt/workcell/providers/node_modules/.bin/gemini"]],
     decision = "forbidden",
     justification = "Do not launch nested coding-agent CLIs or bypass Workcell provider mediation from inside Codex.",
     match = [
@@ -149,10 +149,10 @@ prefix_rule(
 )
 
 prefix_rule(
-    pattern = ["node", ["/opt/workcell/providers/node_modules/@google/gemini-cli/dist/index.js"]],
+    pattern = ["node", ["/opt/workcell/providers/node_modules/@google/gemini-cli/bundle/gemini.js"]],
     decision = "forbidden",
     justification = "Do not launch nested coding-agent CLIs or bypass Workcell provider mediation from inside Codex.",
     match = [
-        "node /opt/workcell/providers/node_modules/@google/gemini-cli/dist/index.js --yolo",
+        "node /opt/workcell/providers/node_modules/@google/gemini-cli/bundle/gemini.js --yolo",
     ],
 )

--- a/adapters/codex/requirements.toml
+++ b/adapters/codex/requirements.toml
@@ -61,7 +61,7 @@ decision = "forbidden"
 justification = "Do not bypass git hooks with --no-verify from Workcell."
 
 [[rules.prefix_rules]]
-pattern = [{ any_of = ["codex", "claude", "gemini", "/usr/local/libexec/workcell/core/codex", "/usr/local/libexec/workcell/core/claude", "/usr/local/libexec/workcell/core/gemini", "/usr/local/libexec/workcell/real/codex", "/usr/local/libexec/workcell/real/claude", "/opt/workcell/providers/node_modules/.bin/gemini"] }]
+pattern = [{ any_of = ["codex", "claude", "gemini", "/usr/local/libexec/workcell/provider-wrapper.sh", "/usr/local/libexec/workcell/core/codex", "/usr/local/libexec/workcell/core/claude", "/usr/local/libexec/workcell/core/gemini", "/usr/local/libexec/workcell/real/codex", "/usr/local/libexec/workcell/real/claude", "/opt/workcell/providers/node_modules/.bin/gemini"] }]
 decision = "forbidden"
 justification = "Do not launch nested coding-agent CLIs or bypass Workcell provider mediation from inside Codex."
 

--- a/internal/remotevm/fake_target.go
+++ b/internal/remotevm/fake_target.go
@@ -396,6 +396,16 @@ func copyWorkspaceTree(sourceRoot, destRoot string, excluded []string) ([]Worksp
 			if err != nil {
 				return err
 			}
+			// The remote-vm contract promises host-auditable materialization:
+			// a symlink that resolves outside the materialized workspace would
+			// smuggle non-workspace content past that audit, so fail closed.
+			if filepath.IsAbs(target) {
+				return fmt.Errorf("workspace symlink %s targets an absolute path: %s", rel, target)
+			}
+			resolved := filepath.ToSlash(filepath.Clean(filepath.Join(filepath.Dir(filepath.FromSlash(rel)), target)))
+			if resolved == ".." || strings.HasPrefix(resolved, "../") {
+				return fmt.Errorf("workspace symlink %s escapes the workspace: %s", rel, target)
+			}
 			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 				return err
 			}
@@ -458,7 +468,7 @@ func writeJSON(path string, value any) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(path, content, 0o644)
+	return os.WriteFile(path, content, 0o600)
 }
 
 func appendAuditLine(path, line string) error {

--- a/internal/remotevm/fake_target.go
+++ b/internal/remotevm/fake_target.go
@@ -484,7 +484,13 @@ func writeJSON(path string, value any) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(path, content, 0o600)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		return err
+	}
+	// WriteFile's mode only applies at creation; a manifest rewritten over an
+	// existing file (for example a re-bootstrapped target) keeps its old
+	// permissions otherwise.
+	return os.Chmod(path, 0o600)
 }
 
 func appendAuditLine(path, line string) error {

--- a/internal/remotevm/fake_target.go
+++ b/internal/remotevm/fake_target.go
@@ -367,7 +367,11 @@ func statePathSegment(label, value string) (string, error) {
 
 func copyWorkspaceTree(sourceRoot, destRoot string, excluded []string) ([]WorkspaceEntry, error) {
 	entries := make([]WorkspaceEntry, 0)
-	err := filepath.WalkDir(sourceRoot, func(path string, d fs.DirEntry, walkErr error) error {
+	resolvedRoot, err := filepath.EvalSymlinks(sourceRoot)
+	if err != nil {
+		return nil, err
+	}
+	err = filepath.WalkDir(sourceRoot, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -404,6 +408,18 @@ func copyWorkspaceTree(sourceRoot, destRoot string, excluded []string) ([]Worksp
 			}
 			resolved := filepath.ToSlash(filepath.Clean(filepath.Join(filepath.Dir(filepath.FromSlash(rel)), target)))
 			if resolved == ".." || strings.HasPrefix(resolved, "../") {
+				return fmt.Errorf("workspace symlink %s escapes the workspace: %s", rel, target)
+			}
+			// The lexical check above is evadable through symlink chains
+			// (an in-workspace link to a parent directory re-routes a later
+			// ".." through the kernel), so also require the kernel-resolved
+			// target to stay inside the resolved workspace root. Dangling
+			// links fail closed.
+			physical, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				return fmt.Errorf("workspace symlink %s does not resolve inside the workspace: %v", rel, err)
+			}
+			if physical != resolvedRoot && !strings.HasPrefix(physical, resolvedRoot+string(filepath.Separator)) {
 				return fmt.Errorf("workspace symlink %s escapes the workspace: %s", rel, target)
 			}
 			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {

--- a/internal/remotevm/fake_target_test.go
+++ b/internal/remotevm/fake_target_test.go
@@ -174,3 +174,63 @@ func TestFakeTargetRejectsPathTraversalSessionID(t *testing.T) {
 		t.Fatalf("StartSession() error = %v, want session id rejection", err)
 	}
 }
+
+func TestFakeTargetMaterializeWorkspaceRejectsEscapingSymlinks(t *testing.T) {
+	t.Parallel()
+
+	target, err := NewFakeTarget(DefaultContract())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, linkTarget := range map[string]string{
+		"absolute": "/etc/passwd",
+		"relative": "../../outside",
+	} {
+		tempWorkspace := t.TempDir()
+		if err := os.WriteFile(filepath.Join(tempWorkspace, "keep.txt"), []byte("ok\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(linkTarget, filepath.Join(tempWorkspace, "escape")); err != nil {
+			t.Fatal(err)
+		}
+		_, err := target.MaterializeWorkspace(context.Background(), MaterializeRequest{
+			StateRoot:         t.TempDir(),
+			TargetID:          "fake-remote-target",
+			MaterializationID: "symlink-escape-" + name,
+			SourceWorkspace:   tempWorkspace,
+		})
+		if err == nil || !strings.Contains(err.Error(), "symlink") {
+			t.Fatalf("%s: expected symlink escape rejection, got %v", name, err)
+		}
+	}
+}
+
+func TestFakeTargetMaterializeWorkspaceKeepsInternalSymlinks(t *testing.T) {
+	t.Parallel()
+
+	target, err := NewFakeTarget(DefaultContract())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tempWorkspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempWorkspace, "real.txt"), []byte("ok\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real.txt", filepath.Join(tempWorkspace, "alias")); err != nil {
+		t.Fatal(err)
+	}
+	result, err := target.MaterializeWorkspace(context.Background(), MaterializeRequest{
+		StateRoot:         t.TempDir(),
+		TargetID:          "fake-remote-target",
+		MaterializationID: "symlink-internal",
+		SourceWorkspace:   tempWorkspace,
+	})
+	if err != nil {
+		t.Fatalf("internal symlink unexpectedly rejected: %v", err)
+	}
+	linked, err := os.Readlink(filepath.Join(result.MaterializedWorkspace, "alias"))
+	if err != nil || linked != "real.txt" {
+		t.Fatalf("alias = %q, %v; want real.txt", linked, err)
+	}
+}

--- a/internal/remotevm/fake_target_test.go
+++ b/internal/remotevm/fake_target_test.go
@@ -234,3 +234,39 @@ func TestFakeTargetMaterializeWorkspaceKeepsInternalSymlinks(t *testing.T) {
 		t.Fatalf("alias = %q, %v; want real.txt", linked, err)
 	}
 }
+
+func TestFakeTargetMaterializeWorkspaceRejectsSymlinkChainEscape(t *testing.T) {
+	t.Parallel()
+
+	target, err := NewFakeTarget(DefaultContract())
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "ws")
+	if err := os.MkdirAll(filepath.Join(workspace, "dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "secret.txt"), []byte("outside\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// dir/up resolves to the workspace root (legal on its own), but a second
+	// link routed through it re-routes ".." past the lexical check; the
+	// kernel resolves escape to parent/secret.txt, outside the workspace.
+	if err := os.Symlink("..", filepath.Join(workspace, "dir", "up")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("dir/up/../secret.txt", filepath.Join(workspace, "escape")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = target.MaterializeWorkspace(context.Background(), MaterializeRequest{
+		StateRoot:         t.TempDir(),
+		TargetID:          "fake-remote-target",
+		MaterializationID: "symlink-chain-escape",
+		SourceWorkspace:   workspace,
+	})
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink chain escape rejection, got %v", err)
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "repo_path": "scripts/lib/trusted-docker-client.sh",
-      "sha256": "f1835ea3f4291c13134e803568f8b9ead5d7b7eff162c0550223f8873e6fb1f1"
+      "sha256": "89cd4ca9b5ad710522f9182a896545e36bee46280b8b299873deed775e385250"
     }
   ],
   "runtime_artifacts": [
@@ -46,7 +46,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/claude/hooks/guard-bash.sh",
       "runtime_path": "/opt/workcell/adapters/claude/hooks/guard-bash.sh",
-      "sha256": "6821e692bd48cf2b6d58e7b8378cd6ef5c916364af30dff1723b54c8c2053de4"
+      "sha256": "9bca2ae76b97cec2c390cf4e06a24418cf9b526dc04f559ca6ec10bbdb94d24d"
     },
     {
       "kind": "adapter-baseline",
@@ -100,7 +100,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/codex/.codex/rules/default.rules",
       "runtime_path": "/opt/workcell/adapters/codex/.codex/rules/default.rules",
-      "sha256": "f935a387b1d33424dc90260006f20fd8e2a3c7736edeb6cad05d5172c065ee2d"
+      "sha256": "36216ff78322664d49b759e905ac82b92dc90e75f89fba470c73b12aebf462be"
     },
     {
       "kind": "adapter-baseline",
@@ -118,7 +118,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/codex/requirements.toml",
       "runtime_path": "/opt/workcell/adapters/codex/requirements.toml",
-      "sha256": "6848ce9b85adfdb165a0609d0d7fc61cb8aad2ac4fb36a4b75670646f808666c"
+      "sha256": "35933deda8336c7984a9707fa0a995ffd99b5597263674dbd468692425aa058b"
     },
     {
       "kind": "adapter-baseline",

--- a/scripts/lib/trusted-docker-client.sh
+++ b/scripts/lib/trusted-docker-client.sh
@@ -57,8 +57,20 @@ discover_workcell_real_home() {
       fallback_parent="/tmp"
     fi
     fallback_home="${fallback_parent%/}/workcell-home-${uid}"
+    # The path is intentionally stable so validator build caches survive
+    # across runs, but on a shared host another user could pre-plant a
+    # symlink or directory here; refuse anything that is not a real
+    # directory owned by the current uid.
+    if [[ -L "${fallback_home}" ]]; then
+      echo "Refusing synthetic home: ${fallback_home} is a symlink." >&2
+      return 1
+    fi
     mkdir -p "${fallback_home}"
     chmod 0700 "${fallback_home}" 2>/dev/null || true
+    if [[ -L "${fallback_home}" ]] || [[ ! -d "${fallback_home}" ]] || [[ ! -O "${fallback_home}" ]]; then
+      echo "Refusing synthetic home: ${fallback_home} is not a directory owned by uid ${uid}." >&2
+      return 1
+    fi
     printf 'synthetic\t%s\n' "${fallback_home}"
     return 0
   fi

--- a/tests/scenarios/claude-swe/blocked-git-commands.txt
+++ b/tests/scenarios/claude-swe/blocked-git-commands.txt
@@ -8,3 +8,4 @@ git push origin main
 git push origin master
 git rebase --no-verify
 git merge --no-verify
+git -ccore.hookspath=/tmp/evil commit -m x


### PR DESCRIPTION
## Summary

Iteration 6 of the architectural review: a completeness-critic sweep over every surface the prior five iterations had not examined (rootio, shellproto, cliexit, scenarios, host/launcher, hoststate, colimautil depth, remotevm, scripts/lib, adapter hooks/rules, profiles) found **no high findings** and four mediums — all fixed here:

- **Glued `-c` hook-bypass gap**: the Claude bash-hook guard required whitespace after `-c`, so `git -ccore.hookspath=…` evaded it; regex fixed and the glued form added to the blocked-commands fixture (red→green).
- **Codex nested-CLI rules drift**: `default.rules` forbade the nonexistent `dist/index.js` Gemini path instead of the installed `bundle/gemini.js`, and omitted `provider-wrapper.sh` which managed_config forbids; `default.rules` and `requirements.toml` aligned with the managed config (control-plane parity verifies).
- **Planted synthetic-home**: `trusted-docker-client.sh`'s stable `/tmp/workcell-home-UID` fallback honored pre-planted symlinks/foreign dirs on shared hosts; now refuses anything that isn't an owned real directory (stable path kept for validator build caches).
- **Remote-vm symlink escape** (preview-only, zero production reachability): materialization copied symlinks verbatim, so absolute/`../` targets escaped the contract's host-auditable workspace; escaping targets now fail closed with tests covering rejection and legitimate internal symlinks; manifest written 0600.

All guards touched are documented defense-in-depth or preview paths — the VM+container boundary is unchanged.

## Validation

- `./scripts/pre-merge.sh --profile pr-parity` green locally
- Hook parametric tests (11 blocked / 5 permitted), remotevm tests incl. two new symlink cases, shellcheck, control-plane manifest + parity, pinned inputs all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
