### PR TITLE
Bump Claude Code to 2.1.175

### DIFF
--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -200,7 +200,7 @@ FROM runtime-base AS runtime-builder
 # from the public release bucket, verify the per-platform checksums in the
 # corresponding manifest.json, update CLAUDE_VERSION, and refresh the
 # CLAUDE_SHA256 values below.
-ARG CLAUDE_VERSION=2.1.170
+ARG CLAUDE_VERSION=2.1.175
 # OpenAI Codex CLI version and SHA256 checksums for each architecture.
 # Workcell follows the stable npm channel and matching non-prerelease Rust
 # release after the cool-off in policy/provider-bumps.toml. To update
@@ -281,11 +281,11 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
   && case "${TARGET_ARCH}" in \
     arm64) \
       CLAUDE_PLATFORM="linux-arm64"; \
-      CLAUDE_SHA256="1bb9d032440a75532f7dd4cafbc687f220aaf16c63eba17e192dfbec2f04bd25"; \
+      CLAUDE_SHA256="360f1f6f43ec26d9bb6e20e487bf44b753d9b8407e89e74bfeeb79707399f435"; \
       ;; \
     amd64) \
       CLAUDE_PLATFORM="linux-x64"; \
-      CLAUDE_SHA256="849e007277a0442ab27570d3e3d6d43787507946590e8dd1947e5a39b7081f9e"; \
+      CLAUDE_SHA256="4fc72fa6090c9a03f1850e1b1ccb3d6806bf802b67e3cb9dc5f2ced4b7ed5ca1"; \
       ;; \
     *) \
       echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; \


### PR DESCRIPTION
## Summary

Advance the pinned Claude Code native binary from **2.1.170 → 2.1.175**, the
latest stable release that has cleared the reviewed **12h provider-bump
cool-off** (`policy/provider-bumps.toml`).

## Cool-off note (addresses Codex P2)

2.1.177 (published 2026-06-13 01:04Z) and 2.1.176 (2026-06-12 19:45Z) are still
inside the 12h cool-off window, so the normal provider-bump workflow would skip
them. 2.1.175 (2026-06-12 02:10Z, ~27h old) is the latest eligible release and
is pinned here. The newer releases can be picked up in a later bump once they
clear the cool-off.

## Changes

- `runtime/container/Dockerfile`: `CLAUDE_VERSION=2.1.175`
- Refreshed per-architecture `CLAUDE_SHA256` digests from the 2.1.175
  `manifest.json`:
  - linux-arm64 `360f1f6f43ec26d9bb6e20e487bf44b753d9b8407e89e74bfeeb79707399f435`
  - linux-x64 `4fc72fa6090c9a03f1850e1b1ccb3d6806bf802b67e3cb9dc5f2ced4b7ed5ca1`

## Validation

- `scripts/verify-upstream-claude-release.sh` passes (digests verified against
  the upstream manifest).
- Local `pre-merge.sh --profile pr-parity` passed (image rebuild, validate,
  container-smoke, reproducible build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
