### PR TITLE
Upgrade Codex to 0.139.0 with profile-v2 config migration

### DIFF
--- a/adapters/codex/.codex/breakglass.config.toml
+++ b/adapters/codex/.codex/breakglass.config.toml
@@ -1,0 +1,9 @@
+#:schema https://developers.openai.com/codex/config-schema.json
+
+# Codex profile-v2 layer for the Workcell `breakglass` mode. Selected with
+# `--profile breakglass` and layered on top of `config.toml`. Keep aligned with
+# the matching `[profiles.breakglass]` baseline documented in managed_config.toml.
+
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
+web_search = "disabled"

--- a/adapters/codex/.codex/build.config.toml
+++ b/adapters/codex/.codex/build.config.toml
@@ -1,0 +1,9 @@
+#:schema https://developers.openai.com/codex/config-schema.json
+
+# Codex profile-v2 layer for the Workcell `build` mode. Selected with
+# `--profile build` and layered on top of `config.toml`. Keep aligned with the
+# matching `[profiles.build]` baseline documented in managed_config.toml.
+
+sandbox_mode = "workspace-write"
+approval_policy = "never"
+web_search = "disabled"

--- a/adapters/codex/.codex/config.toml
+++ b/adapters/codex/.codex/config.toml
@@ -2,8 +2,13 @@
 
 # Repo-local Codex defaults for the Workcell runtime. Keep this file usable as a
 # standalone `.codex/config.toml` after copying it into a workspace.
+#
+# Codex 0.134+ uses the layered profile-v2 model. This base config is layered
+# under the per-profile `<name>.config.toml` files (strict/development/build/
+# breakglass) that the runtime selects with `--profile`. The base deliberately
+# does NOT set sandbox_mode or approval_policy: every sandbox/approval decision
+# is profile-scoped, so the floor cannot be widened from the base config.
 
-profile = "strict"
 analytics.enabled = false
 history.persistence = "none"
 web_search = "disabled"
@@ -42,23 +47,3 @@ network_access = false
 # Codex's unified exec path currently fails inside Workcell managed mode with
 # "Failed to create unified exec process: Operation not permitted".
 unified_exec = false
-
-[profiles.strict]
-sandbox_mode = "workspace-write"
-approval_policy = "on-request"
-web_search = "disabled"
-
-[profiles.development]
-sandbox_mode = "workspace-write"
-approval_policy = "on-request"
-web_search = "disabled"
-
-[profiles.build]
-sandbox_mode = "workspace-write"
-approval_policy = "never"
-web_search = "disabled"
-
-[profiles.breakglass]
-sandbox_mode = "danger-full-access"
-approval_policy = "never"
-web_search = "disabled"

--- a/adapters/codex/.codex/development.config.toml
+++ b/adapters/codex/.codex/development.config.toml
@@ -1,0 +1,9 @@
+#:schema https://developers.openai.com/codex/config-schema.json
+
+# Codex profile-v2 layer for the Workcell `development` mode. Selected with
+# `--profile development` and layered on top of `config.toml`. Keep aligned with
+# the matching `[profiles.development]` baseline documented in managed_config.toml.
+
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"
+web_search = "disabled"

--- a/adapters/codex/.codex/strict.config.toml
+++ b/adapters/codex/.codex/strict.config.toml
@@ -1,0 +1,9 @@
+#:schema https://developers.openai.com/codex/config-schema.json
+
+# Codex profile-v2 layer for the Workcell `strict` mode. Selected with
+# `--profile strict` and layered on top of `config.toml`. Keep aligned with the
+# matching `[profiles.strict]` baseline documented in managed_config.toml.
+
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"
+web_search = "disabled"

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -3,8 +3,13 @@
 The Codex adapter maps the shared Workcell boundary into Codex-native controls.
 Adapter layout (paths relative to `adapters/codex/`):
 
-- `.codex/config.toml`: managed Codex configuration template seeded into the
-  session-local Codex home as `~/.codex/config.toml`
+- `.codex/config.toml`: managed Codex base configuration template seeded into
+  the session-local Codex home as `~/.codex/config.toml`
+- `.codex/{strict,development,build,breakglass}.config.toml`: Codex 0.134+
+  profile-v2 layer files. The launcher selects one with `--profile <name>`,
+  and Codex layers it on top of the base `config.toml`. Each layer carries the
+  per-profile `sandbox_mode`/`approval_policy`; the base config sets no sandbox
+  mode so every sandbox decision is profile-scoped.
 - `.codex/AGENTS.md`: managed agent guidance seeded into the session-local
   Codex home
 - `.codex/rules/default.rules`: managed Codex execpolicy ruleset seeded

--- a/adapters/codex/managed_config.toml
+++ b/adapters/codex/managed_config.toml
@@ -3,11 +3,19 @@
 # Admin-managed baseline for the Workcell Codex adapter. Keep this aligned with
 # the repo-local adapter config so the default local experience and the managed
 # deployment do not drift.
+#
+# Codex 0.134+ uses the layered profile-v2 model: this baseline mirrors the base
+# `.codex/config.toml`, and the per-profile layers live in the separate
+# `<name>.config.toml` files selected with `--profile`. For reference, the four
+# Workcell profile layers are:
+#   strict       sandbox_mode = "workspace-write"      approval_policy = "on-request"
+#   development  sandbox_mode = "workspace-write"      approval_policy = "on-request"
+#   build        sandbox_mode = "workspace-write"      approval_policy = "never"
+#   breakglass   sandbox_mode = "danger-full-access"   approval_policy = "never"
 
 analytics.enabled = false
 history.persistence = "none"
 web_search = "disabled"
-profile = "strict"
 
 [shell_environment_policy]
 inherit = "core"
@@ -41,26 +49,6 @@ network_access = false
 # Codex's unified exec path currently fails inside Workcell managed mode with
 # "Failed to create unified exec process: Operation not permitted".
 unified_exec = false
-
-[profiles.strict]
-sandbox_mode = "workspace-write"
-approval_policy = "on-request"
-web_search = "disabled"
-
-[profiles.development]
-sandbox_mode = "workspace-write"
-approval_policy = "on-request"
-web_search = "disabled"
-
-[profiles.build]
-sandbox_mode = "workspace-write"
-approval_policy = "never"
-web_search = "disabled"
-
-[profiles.breakglass]
-sandbox_mode = "danger-full-access"
-approval_policy = "never"
-web_search = "disabled"
 
 [[rules.prefix_rules]]
 pattern = [{ any_of = ["git", "/usr/bin/git", "/usr/local/libexec/workcell/git", "/usr/local/libexec/workcell/core/git", "/usr/local/libexec/workcell/real/git"] }, { token = "commit" }, { any_of = ["--no-verify", "-n"] }]

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -252,6 +252,25 @@ Workcell reinforces this with command wrappers such as:
 The result is defense in depth below prompt files, shell aliases, and
 provider-native settings.
 
+The exec guard is a libc interposer registered in `/etc/ld.so.preload` (and
+re-exported as `LD_PRELOAD` by every wrapper), so it is loaded into the
+process that *calls* `exec`, not the process being launched. It therefore
+mediates a launch regardless of whether the launched binary is dynamically
+or statically linked — a wrapper or shell that invokes a static provider
+binary is still guarded, and a static provider invoked as a protected
+runtime is still blocked. The one linkage-dependent residual is a fully
+static process making its *own* `exec` call: such a process never consults
+`/etc/ld.so.preload`, so the interposer is absent inside it and its direct
+`exec` of a mutable `/workspace` or `/state` binary would not be intercepted
+by this layer (the provider's own sandbox and the VM/container boundary
+remain in force). Because providers are now packaged as static musl
+binaries, a fully linkage-independent backstop — kernel-enforced `noexec`
+on `/workspace` for the strict path, extending the existing `/tmp noexec`
+control, optionally paired with a seccomp `execve` filter — is the tracked
+hardening for this layer; it changes the macOS Colima runtime mount set and
+so must land with the host-side live certification rather than as a
+repo-only change.
+
 ### 9. Thin Provider Adapters
 
 Provider integration remains intentionally thin and explicit:

--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -476,8 +476,12 @@ func GenerateControlPlaneManifest(rootDir, outputPath string) error {
 		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/agents/apple_platform_boundary.md", RuntimePath: "/opt/workcell/adapters/codex/.codex/agents/apple_platform_boundary.md"},
 		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/agents/distinguished_security.md", RuntimePath: "/opt/workcell/adapters/codex/.codex/agents/distinguished_security.md"},
 		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/agents/openai_codex_platform.md", RuntimePath: "/opt/workcell/adapters/codex/.codex/agents/openai_codex_platform.md"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/breakglass.config.toml", RuntimePath: "/opt/workcell/adapters/codex/.codex/breakglass.config.toml"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/build.config.toml", RuntimePath: "/opt/workcell/adapters/codex/.codex/build.config.toml"},
 		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/config.toml", RuntimePath: "/opt/workcell/adapters/codex/.codex/config.toml"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/development.config.toml", RuntimePath: "/opt/workcell/adapters/codex/.codex/development.config.toml"},
 		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/rules/default.rules", RuntimePath: "/opt/workcell/adapters/codex/.codex/rules/default.rules"},
+		{Kind: "adapter-baseline", RepoPath: "adapters/codex/.codex/strict.config.toml", RuntimePath: "/opt/workcell/adapters/codex/.codex/strict.config.toml"},
 		{Kind: "adapter-baseline", RepoPath: "adapters/codex/managed_config.toml", RuntimePath: "/opt/workcell/adapters/codex/managed_config.toml"},
 		{Kind: "adapter-baseline", RepoPath: "adapters/codex/mcp/config.toml", RuntimePath: "/opt/workcell/adapters/codex/mcp/config.toml"},
 		{Kind: "adapter-baseline", RepoPath: "adapters/codex/requirements.toml", RuntimePath: "/opt/workcell/adapters/codex/requirements.toml"},
@@ -756,8 +760,8 @@ func GenerateBuildInputManifest(
 		arch string
 		name string
 	}{
-		{arch: "arm64", name: "aarch64-unknown-linux-gnu"},
-		{arch: "amd64", name: "x86_64-unknown-linux-gnu"},
+		{arch: "arm64", name: "aarch64-unknown-linux-musl"},
+		{arch: "amd64", name: "x86_64-unknown-linux-musl"},
 	} {
 		sha, err := ExtractCodexSHA(dockerfilePath, target.arch)
 		if err != nil {

--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -391,13 +391,13 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	}
 	if _, match, err := requireRegex(runtimeDockerfile, `(?m)^\s*arm64\)\s+\\(?:\s*CLAUDE_[A-Z0-9_]+="[^"]+";\s+\\)*\s*CODEX_ARCH="([^"]+)";\s+\\\s*CODEX_SHA256="([0-9a-f]{64})";`, "arm64 Codex mapping", cfg.RuntimeDockerfilePath); err != nil {
 		return err
-	} else if match[1] != "aarch64-unknown-linux-gnu" {
-		return fmt.Errorf("arm64 Codex mapping in %s must use aarch64-unknown-linux-gnu", cfg.RuntimeDockerfilePath)
+	} else if match[1] != "aarch64-unknown-linux-musl" {
+		return fmt.Errorf("arm64 Codex mapping in %s must use aarch64-unknown-linux-musl", cfg.RuntimeDockerfilePath)
 	}
 	if _, match, err := requireRegex(runtimeDockerfile, `(?m)^\s*amd64\)\s+\\(?:\s*CLAUDE_[A-Z0-9_]+="[^"]+";\s+\\)*\s*CODEX_ARCH="([^"]+)";\s+\\\s*CODEX_SHA256="([0-9a-f]{64})";`, "amd64 Codex mapping", cfg.RuntimeDockerfilePath); err != nil {
 		return err
-	} else if match[1] != "x86_64-unknown-linux-gnu" {
-		return fmt.Errorf("amd64 Codex mapping in %s must use x86_64-unknown-linux-gnu", cfg.RuntimeDockerfilePath)
+	} else if match[1] != "x86_64-unknown-linux-musl" {
+		return fmt.Errorf("amd64 Codex mapping in %s must use x86_64-unknown-linux-musl", cfg.RuntimeDockerfilePath)
 	}
 	if len(runtimeInstallBlocks) != 2 {
 		return fmt.Errorf("runtime/container/Dockerfile must contain exactly two apt install blocks (runtime base and runtime builder)")

--- a/internal/metadatautil/provider_bumps.go
+++ b/internal/metadatautil/provider_bumps.go
@@ -54,8 +54,8 @@ var (
 	codexVersionLinePattern      = regexp.MustCompile(`(?m)^ARG CODEX_VERSION=.*$`)
 	claudeArmChecksumLinePattern = regexp.MustCompile(`(?ms)(arm64\)\s+\\\s*CLAUDE_PLATFORM="linux-arm64";\s+\\\s*CLAUDE_SHA256=")[0-9a-f]{64}(";)`)
 	claudeAmdChecksumLinePattern = regexp.MustCompile(`(?ms)(amd64\)\s+\\\s*CLAUDE_PLATFORM="linux-x64";\s+\\\s*CLAUDE_SHA256=")[0-9a-f]{64}(";)`)
-	codexArmChecksumLinePattern  = regexp.MustCompile(`(?ms)(arm64\)\s+\\\s*CODEX_ARCH="aarch64-unknown-linux-gnu";\s+\\\s*CODEX_SHA256=")[0-9a-f]{64}(";)`)
-	codexAmdChecksumLinePattern  = regexp.MustCompile(`(?ms)(amd64\)\s+\\\s*CODEX_ARCH="x86_64-unknown-linux-gnu";\s+\\\s*CODEX_SHA256=")[0-9a-f]{64}(";)`)
+	codexArmChecksumLinePattern  = regexp.MustCompile(`(?ms)(arm64\)\s+\\\s*CODEX_ARCH="aarch64-unknown-linux-musl";\s+\\\s*CODEX_SHA256=")[0-9a-f]{64}(";)`)
+	codexAmdChecksumLinePattern  = regexp.MustCompile(`(?ms)(amd64\)\s+\\\s*CODEX_ARCH="x86_64-unknown-linux-musl";\s+\\\s*CODEX_SHA256=")[0-9a-f]{64}(";)`)
 )
 
 type ProviderBumpPolicy struct {
@@ -426,8 +426,8 @@ func selectCodexStable(currentVersion string, cutoff time.Time, maxVersion strin
 			skipped = appendSkippedProviderRelease(skipped, candidate, "GitHub release is marked prerelease")
 			continue
 		}
-		armDigest, armErr := releaseAssetDigest(release, "codex-aarch64-unknown-linux-gnu.tar.gz")
-		amdDigest, amdErr := releaseAssetDigest(release, "codex-x86_64-unknown-linux-gnu.tar.gz")
+		armDigest, armErr := releaseAssetDigest(release, "codex-aarch64-unknown-linux-musl.tar.gz")
+		amdDigest, amdErr := releaseAssetDigest(release, "codex-x86_64-unknown-linux-musl.tar.gz")
 		if armErr != nil || amdErr != nil {
 			if (armErr == nil || errors.Is(armErr, errReleaseAssetNotFound)) && (amdErr == nil || errors.Is(amdErr, errReleaseAssetNotFound)) {
 				reasons := make([]string, 0, 2)
@@ -437,7 +437,7 @@ func selectCodexStable(currentVersion string, cutoff time.Time, maxVersion strin
 				if amdErr != nil {
 					reasons = append(reasons, amdErr.Error())
 				}
-				skipped = appendSkippedProviderRelease(skipped, candidate, "missing supported GNU Linux release assets: "+strings.Join(reasons, "; "))
+				skipped = appendSkippedProviderRelease(skipped, candidate, "missing supported musl Linux release assets: "+strings.Join(reasons, "; "))
 				continue
 			}
 			reasons := make([]string, 0, 2)
@@ -447,7 +447,7 @@ func selectCodexStable(currentVersion string, cutoff time.Time, maxVersion strin
 			if amdErr != nil {
 				reasons = append(reasons, amdErr.Error())
 			}
-			return ProviderBumpSelection{}, fmt.Errorf("codex release %s has invalid GNU Linux asset metadata: %s", candidate.Raw, strings.Join(reasons, "; "))
+			return ProviderBumpSelection{}, fmt.Errorf("codex release %s has invalid musl Linux asset metadata: %s", candidate.Raw, strings.Join(reasons, "; "))
 		}
 		return ProviderBumpSelection{
 			Channel:         "stable",

--- a/internal/metadatautil/provider_bumps_test.go
+++ b/internal/metadatautil/provider_bumps_test.go
@@ -77,11 +77,11 @@ func TestPlanProviderBumpsSelectsNewestStableVersionsPastCooloff(t *testing.T) {
   "prerelease": false,
   "assets": [
     {
-      "name": "codex-aarch64-unknown-linux-gnu.tar.gz",
+      "name": "codex-aarch64-unknown-linux-musl.tar.gz",
       "digest": "sha256:9f9c1241d39783384313975723475020dfbe1bd7b023c22b04816168159f8fd7"
     },
     {
-      "name": "codex-x86_64-unknown-linux-gnu.tar.gz",
+      "name": "codex-x86_64-unknown-linux-musl.tar.gz",
       "digest": "sha256:526b0d64ecf3d11c89d1d476deff3002ff2c2f728ef6f8f874f8d1a9d92e6e6b"
     }
   ]
@@ -216,7 +216,7 @@ func TestSelectCodexStableHonorsMaxVersionAndReportsSkippedRelease(t *testing.T)
 	}
 }
 
-func TestSelectCodexStableSkipsMissingGNUReleaseAssetsAndSelectsNextCompatible(t *testing.T) {
+func TestSelectCodexStableSkipsMissingMuslReleaseAssetsAndSelectsNextCompatible(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/codex-registry":
@@ -237,7 +237,7 @@ func TestSelectCodexStableSkipsMissingGNUReleaseAssetsAndSelectsNextCompatible(t
   "prerelease": false,
   "assets": [
     {
-      "name": "codex-aarch64-unknown-linux-musl.tar.gz",
+      "name": "codex-aarch64-unknown-linux-gnu.tar.gz",
       "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     }
   ]
@@ -249,11 +249,11 @@ func TestSelectCodexStableSkipsMissingGNUReleaseAssetsAndSelectsNextCompatible(t
   "prerelease": false,
   "assets": [
     {
-      "name": "codex-aarch64-unknown-linux-gnu.tar.gz",
+      "name": "codex-aarch64-unknown-linux-musl.tar.gz",
       "digest": "sha256:9f9c1241d39783384313975723475020dfbe1bd7b023c22b04816168159f8fd7"
     },
     {
-      "name": "codex-x86_64-unknown-linux-gnu.tar.gz",
+      "name": "codex-x86_64-unknown-linux-musl.tar.gz",
       "digest": "sha256:526b0d64ecf3d11c89d1d476deff3002ff2c2f728ef6f8f874f8d1a9d92e6e6b"
     }
   ]
@@ -284,8 +284,8 @@ func TestSelectCodexStableSkipsMissingGNUReleaseAssetsAndSelectsNextCompatible(t
 	if len(selection.SkippedReleases) != 1 {
 		t.Fatalf("SkippedReleases length = %d, want 1", len(selection.SkippedReleases))
 	}
-	if skipped := selection.SkippedReleases[0]; skipped.Version != "0.129.0" || !strings.Contains(skipped.Reason, "missing supported GNU Linux release assets") {
-		t.Fatalf("SkippedReleases[0] = %#v, want missing GNU asset skip", skipped)
+	if skipped := selection.SkippedReleases[0]; skipped.Version != "0.129.0" || !strings.Contains(skipped.Reason, "missing supported musl Linux release assets") {
+		t.Fatalf("SkippedReleases[0] = %#v, want missing musl asset skip", skipped)
 	}
 }
 
@@ -341,11 +341,11 @@ func TestSelectCodexStableRejectsMalformedReleaseDigest(t *testing.T) {
   "prerelease": false,
   "assets": [
     {
-      "name": "codex-aarch64-unknown-linux-gnu.tar.gz",
+      "name": "codex-aarch64-unknown-linux-musl.tar.gz",
       "digest": "sha256:not-a-digest"
     },
     {
-      "name": "codex-x86_64-unknown-linux-gnu.tar.gz",
+      "name": "codex-x86_64-unknown-linux-musl.tar.gz",
       "digest": "sha256:526b0d64ecf3d11c89d1d476deff3002ff2c2f728ef6f8f874f8d1a9d92e6e6b"
     }
   ]
@@ -364,7 +364,7 @@ func TestSelectCodexStableRejectsMalformedReleaseDigest(t *testing.T) {
 	if err == nil {
 		t.Fatal("selectCodexStable() unexpectedly succeeded")
 	}
-	if !strings.Contains(err.Error(), "invalid GNU Linux asset metadata") {
+	if !strings.Contains(err.Error(), "invalid musl Linux asset metadata") {
 		t.Fatalf("selectCodexStable() error = %v, want malformed digest rejection", err)
 	}
 }
@@ -1369,11 +1369,11 @@ func TestApplyProviderBumpPlanRewritesPinnedVersions(t *testing.T) {
 		"esac",
 		"RUN case \"${TARGET_ARCH}\" in \\",
 		"  arm64) \\",
-		"    CODEX_ARCH=\"aarch64-unknown-linux-gnu\"; \\",
+		"    CODEX_ARCH=\"aarch64-unknown-linux-musl\"; \\",
 		"    CODEX_SHA256=\"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"; \\",
 		"    ;;",
 		"  amd64) \\",
-		"    CODEX_ARCH=\"x86_64-unknown-linux-gnu\"; \\",
+		"    CODEX_ARCH=\"x86_64-unknown-linux-musl\"; \\",
 		"    CODEX_SHA256=\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"; \\",
 		"    ;;",
 		"esac",

--- a/internal/testkit/codex_workspace_write_test.go
+++ b/internal/testkit/codex_workspace_write_test.go
@@ -13,40 +13,49 @@ import (
 func TestCodexManagedConfigKeepsWorkspaceWriteOutsideBreakglass(t *testing.T) {
 	t.Parallel()
 
-	configPath := filepath.Join(repoRoot(t), "adapters", "codex", ".codex", "config.toml")
-	managedConfigPath := filepath.Join(repoRoot(t), "adapters", "codex", "managed_config.toml")
-	requirementsPath := filepath.Join(repoRoot(t), "adapters", "codex", "requirements.toml")
-	config, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatal(err)
+	codexDir := filepath.Join(repoRoot(t), "adapters", "codex")
+	requirementsPath := filepath.Join(codexDir, "requirements.toml")
+
+	// Codex 0.134+ profile-v2: each profile is a separate layer file. The
+	// sandbox_mode floor must stay workspace-write everywhere except the
+	// explicit breakglass layer.
+	for name, wantSandbox := range map[string]string{
+		"strict":      "workspace-write",
+		"development": "workspace-write",
+		"build":       "workspace-write",
+		"breakglass":  "danger-full-access",
+	} {
+		layerPath := filepath.Join(codexDir, ".codex", name+".config.toml")
+		layer, err := os.ReadFile(layerPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := "sandbox_mode = \"" + wantSandbox + "\""
+		if !strings.Contains(string(layer), want) {
+			t.Fatalf("%s does not contain %q", layerPath, want)
+		}
 	}
-	managedConfig, err := os.ReadFile(managedConfigPath)
-	if err != nil {
-		t.Fatal(err)
+
+	// The base configs must not reintroduce inline profile tables; profile
+	// selection and sandbox mode now come only from the layer files above.
+	for _, base := range []string{
+		filepath.Join(codexDir, ".codex", "config.toml"),
+		filepath.Join(codexDir, "managed_config.toml"),
+	} {
+		raw, err := os.ReadFile(base)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(raw), "[profiles.") {
+			t.Fatalf("%s must not inline [profiles.*] tables under profile-v2", base)
+		}
 	}
+
 	requirements, err := os.ReadFile(requirementsPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	for path, raw := range map[string]string{
-		configPath:        string(config),
-		managedConfigPath: string(managedConfig),
-	} {
-		for _, want := range []string{
-			"[profiles.strict]\nsandbox_mode = \"workspace-write\"",
-			"[profiles.development]\nsandbox_mode = \"workspace-write\"",
-			"[profiles.build]\nsandbox_mode = \"workspace-write\"",
-			"[profiles.breakglass]\nsandbox_mode = \"danger-full-access\"",
-		} {
-			if !strings.Contains(raw, want) {
-				t.Fatalf("%s does not contain %q", path, want)
-			}
-		}
-	}
-
-	requirementsText := string(requirements)
-	if !strings.Contains(requirementsText, `allowed_sandbox_modes = ["workspace-write", "danger-full-access"]`) {
+	if !strings.Contains(string(requirements), `allowed_sandbox_modes = ["workspace-write", "danger-full-access"]`) {
 		t.Fatalf("%s does not allow managed workspace-write mode", requirementsPath)
 	}
 }

--- a/policy/provider-bumps.toml
+++ b/policy/provider-bumps.toml
@@ -3,10 +3,11 @@ cooloff_hours = 12
 
 [provider.codex]
 channel = "stable"
-# Reviewed holdback: newer Codex npm stable releases currently lack the GNU
-# Linux release assets that the runtime verifier consumes. Revisit this ceiling
-# when the runtime switches to the reviewed musl artifact path.
-max_version = "0.125.0"
+# The runtime consumes the reviewed musl Linux release assets (which carry
+# sigstore bundles), resolving the earlier GNU-asset holdback. The adapter
+# config uses the layered --profile-v2 model (base config.toml plus per-profile
+# `<name>.config.toml` files), so there is no profile-model ceiling; the normal
+# stable channel and cool-off govern Codex.
 
 [provider.claude]
 channel = "stable"

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -203,11 +203,12 @@ FROM runtime-base AS runtime-builder
 ARG CLAUDE_VERSION=2.1.175
 # OpenAI Codex CLI version and SHA256 checksums for each architecture.
 # Workcell follows the stable npm channel and matching non-prerelease Rust
-# release after the cool-off in policy/provider-bumps.toml. To update
-# manually, resolve the eligible stable version, verify the GitHub release
-# asset digests for both Linux tarballs, and refresh the CODEX_SHA256 values
-# for arm64 and amd64 below.
-ARG CODEX_VERSION=0.125.0
+# release after the cool-off in policy/provider-bumps.toml. The runtime
+# consumes the statically linked musl Linux tarballs (which carry sigstore
+# bundles); to update manually, resolve the eligible stable version, verify
+# the GitHub release asset digests for both musl Linux tarballs, and refresh
+# the CODEX_SHA256 values for arm64 and amd64 below.
+ARG CODEX_VERSION=0.139.0
 ARG CODEX_RELEASE_URL=
 ARG RUST_VERSION=1.96.0
 ARG TARGETARCH
@@ -316,12 +317,12 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
      fi \
   && case "${TARGET_ARCH}" in \
     arm64) \
-      CODEX_ARCH="aarch64-unknown-linux-gnu"; \
-      CODEX_SHA256="2d076527fd7578656f1b8790650adc9344a7429980b3998941156ab6a06156e6"; \
+      CODEX_ARCH="aarch64-unknown-linux-musl"; \
+      CODEX_SHA256="2b7407643e0e74c525d84347c9eecec4b3d275af0382142ac42216508bb0b2a2"; \
       ;; \
     amd64) \
-      CODEX_ARCH="x86_64-unknown-linux-gnu"; \
-      CODEX_SHA256="522bc0b9b8ab31f3a8f1fc4878abd4e83b116a6c1bcfc7717d2fe036f54cd4be"; \
+      CODEX_ARCH="x86_64-unknown-linux-musl"; \
+      CODEX_SHA256="12ebf70df41dc831061862912ab5e7eacdd112bb17e8ce9b2098cb3d92180081"; \
       ;; \
     *) \
       echo "Unsupported TARGETARCH: ${TARGET_ARCH}" >&2; \

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -92,9 +92,27 @@
     },
     {
       "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/.codex/breakglass.config.toml",
+      "runtime_path": "/opt/workcell/adapters/codex/.codex/breakglass.config.toml",
+      "sha256": "e82254b4d93ace201599e3b3bc753945cf49fd624c31741d8e8060011d0b4494"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/.codex/build.config.toml",
+      "runtime_path": "/opt/workcell/adapters/codex/.codex/build.config.toml",
+      "sha256": "66e9d8588059c30cdb6919940c7c04e2c02a63a9194db3236da1a7c2f51b4852"
+    },
+    {
+      "kind": "adapter-baseline",
       "repo_path": "adapters/codex/.codex/config.toml",
       "runtime_path": "/opt/workcell/adapters/codex/.codex/config.toml",
-      "sha256": "9a5fa873da71d3f216ee393a8ce19c7e9f9eef309a6aa641afdaff2e8c18bf95"
+      "sha256": "2fd96ca2373277b47e92a62bbfcd29c4e4d30369f08f97f3e368b559b3488ed5"
+    },
+    {
+      "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/.codex/development.config.toml",
+      "runtime_path": "/opt/workcell/adapters/codex/.codex/development.config.toml",
+      "sha256": "f09b8d2fe10241da9894e81fe5148510e11f2119e157f13cee11f33a8b8e2628"
     },
     {
       "kind": "adapter-baseline",
@@ -104,9 +122,15 @@
     },
     {
       "kind": "adapter-baseline",
+      "repo_path": "adapters/codex/.codex/strict.config.toml",
+      "runtime_path": "/opt/workcell/adapters/codex/.codex/strict.config.toml",
+      "sha256": "e371b19fa1d6f141e7a533160b07e93ce3d776f47a69553ac2a0b835f991c91f"
+    },
+    {
+      "kind": "adapter-baseline",
       "repo_path": "adapters/codex/managed_config.toml",
       "runtime_path": "/opt/workcell/adapters/codex/managed_config.toml",
-      "sha256": "9b8303fb0a8cf9ba7d8cecbe95e0cfd1fa5021683b5e58e050235484120b35d2"
+      "sha256": "7f0837ef0e85493c1f51c026f16ce1defbf521c1f6945900e27913fcf61fc340"
     },
     {
       "kind": "adapter-baseline",
@@ -190,7 +214,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/home-control-plane.sh",
       "runtime_path": "/usr/local/libexec/workcell/home-control-plane.sh",
-      "sha256": "d85cf3335c4207a5b9ac5bd705341e9d2b4940dcb9364ae26d3ba13a510c224e"
+      "sha256": "461c87309ae6be940e9ec1afadf3025d8fb1135e94c645bff23af71421f44c61"
     },
     {
       "kind": "runtime-control-plane",
@@ -208,7 +232,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-wrapper.sh",
-      "sha256": "3d66b1db78536c0462be0bccb22a5c262fee07d63057cc84988030e15a1d1ece"
+      "sha256": "bd5cb8e61aa3925e9d88033aef43e452231f0393e9e92655ae84ca2e2e609bff"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -1385,6 +1385,14 @@ seed_codex_home() {
   workcell_render_provider_doc "${ADAPTER_ROOT}/codex/.codex/AGENTS.md" "${CODEX_HOME}/AGENTS.md" codex
   workcell_copy_control_plane_file "${ADAPTER_ROOT}/codex/.codex/config.toml" "${CODEX_HOME}/config.toml" 0600
   workcell_assert_session_regular_writable_file "${CODEX_HOME}/config.toml" "Codex config"
+  local codex_profile=""
+  for codex_profile in strict development build breakglass; do
+    workcell_copy_control_plane_file \
+      "${ADAPTER_ROOT}/codex/.codex/${codex_profile}.config.toml" \
+      "${CODEX_HOME}/${codex_profile}.config.toml" 0600
+    workcell_assert_session_regular_writable_file \
+      "${CODEX_HOME}/${codex_profile}.config.toml" "Codex ${codex_profile} profile"
+  done
   workcell_link_control_plane_path "${ADAPTER_ROOT}/codex/managed_config.toml" "${CODEX_HOME}/managed_config.toml"
   workcell_link_control_plane_path "${ADAPTER_ROOT}/codex/requirements.toml" "${CODEX_HOME}/requirements.toml"
   workcell_link_control_plane_path "${ADAPTER_ROOT}/codex/.codex/agents" "${CODEX_HOME}/agents"

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -142,6 +142,106 @@ codex_args_include_profile() {
   return 1
 }
 
+# Codex 0.134+ rejects the global --profile flag on non-runtime subcommands
+# (e.g. `codex features`, `codex login`): it only applies to the runtime
+# commands and `codex mcp`. Return success only when the managed --profile
+# injection is valid, i.e. the invocation resolves to a runtime subcommand,
+# the default TUI (a bare prompt with no subcommand), or a short-circuit
+# global flag like --version/--help that Codex accepts alongside --profile.
+# Global value-taking flags are consumed so the real subcommand token is found.
+codex_managed_profile_applies() {
+  local arg="" skip_value=0
+  for arg in "$@"; do
+    if [[ "${skip_value}" -eq 1 ]]; then
+      skip_value=0
+      continue
+    fi
+    case "${arg}" in
+      --)
+        # Everything after -- is the prompt; default TUI runtime.
+        return 0
+        ;;
+      -c | --config | -m | --model | -i | --image | -C | --cd | \
+        -a | --ask-for-approval | -s | --sandbox | -p | --profile)
+        skip_value=1
+        ;;
+      --*=* | -*)
+        # Boolean global flag or =-form value flag; keep scanning.
+        ;;
+      e | exec | review | resume | archive | unarchive | fork | mcp | sandbox)
+        # Runtime subcommands (and the `e` alias for exec) that accept --profile.
+        return 0
+        ;;
+      *)
+        # First positional that is not a runtime subcommand: either a
+        # non-runtime subcommand (login/features/...) that rejects --profile,
+        # or a bare prompt for the default TUI runtime. Treat a recognized
+        # non-runtime subcommand (including its aliases, e.g. `a` for apply and
+        # `cloud-tasks` for cloud) as rejecting; anything else is the default
+        # TUI prompt and accepts the profile.
+        case "${arg}" in
+          login | logout | plugin | mcp-server | app-server | remote-control | \
+            completion | update | doctor | apply | a | cloud | cloud-tasks | \
+            exec-server | execpolicy | features | help | debug)
+            return 1
+            ;;
+          *)
+            return 0
+            ;;
+        esac
+        ;;
+    esac
+  done
+  # No subcommand token: default TUI runtime, profile applies.
+  return 0
+}
+
+# Map the active Workcell Codex profile to its sandbox_mode. Mirrors the
+# sandbox_mode in the per-profile `<name>.config.toml` layer files; anything
+# other than breakglass uses the workspace-write floor.
+codex_profile_sandbox_mode() {
+  case "${CODEX_PROFILE}" in
+    breakglass) printf 'danger-full-access\n' ;;
+    *) printf 'workspace-write\n' ;;
+  esac
+}
+
+# Codex 0.139 rejects --profile on `app-server` (the managed GUI backend), so
+# codex_managed_profile_applies skips profile injection there. app-server does
+# honor `-c` root config overrides, so emit the per-mode sandbox_mode override
+# on stdout (one arg per line) to give GUI sessions the same sandbox layer the
+# CLI gets from its profile. The approval policy still comes from the injected
+# --ask-for-approval autonomy flag, which app-server accepts. Emits nothing when
+# the invocation is not app-server.
+codex_app_server_sandbox_args() {
+  local arg="" skip_value=0 subcommand=""
+  for arg in "$@"; do
+    if [[ "${skip_value}" -eq 1 ]]; then
+      skip_value=0
+      continue
+    fi
+    case "${arg}" in
+      --)
+        break
+        ;;
+      -c | --config | -m | --model | -i | --image | -C | --cd | \
+        -a | --ask-for-approval | -s | --sandbox | -p | --profile)
+        skip_value=1
+        ;;
+      --*=* | -*) ;;
+      *)
+        subcommand="${arg}"
+        break
+        ;;
+    esac
+  done
+  case "${subcommand}" in
+    app | app-server)
+      printf '%s\n' "-c" "sandbox_mode=\"$(codex_profile_sandbox_mode)\""
+      ;;
+  esac
+}
+
 sanitize_gemini_sandbox_env() {
   unset GEMINI_SANDBOX
   unset GEMINI_SANDBOX_IMAGE
@@ -209,11 +309,13 @@ esac
 case "${AGENT_NAME}" in
   codex)
     declare -a MANAGED_CODEX_PROFILE_ARGS=()
-    if ! codex_args_include_profile "$@"; then
+    if ! codex_args_include_profile "$@" && codex_managed_profile_applies "$@"; then
       MANAGED_CODEX_PROFILE_ARGS=(--profile "${CODEX_PROFILE}")
     fi
+    declare -a MANAGED_CODEX_APP_SERVER_ARGS=()
+    mapfile -t MANAGED_CODEX_APP_SERVER_ARGS < <(codex_app_server_sandbox_args "$@")
     reject_unsafe_codex_args "$@"
-    exec /usr/local/libexec/workcell/real/codex "${MANAGED_CODEX_PROFILE_ARGS[@]}" "${MANAGED_AUTONOMY_ARGS[@]}" "$@"
+    exec /usr/local/libexec/workcell/real/codex "${MANAGED_CODEX_PROFILE_ARGS[@]}" "${MANAGED_CODEX_APP_SERVER_ARGS[@]}" "${MANAGED_AUTONOMY_ARGS[@]}" "$@"
     ;;
   claude)
     reject_unsafe_claude_args "$@"

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2472,6 +2472,13 @@ run_container codex bash -lc "$(
     test ! -L "$CODEX_HOME/config.toml"
     test -w "$CODEX_HOME/config.toml"
     cmp "$CODEX_HOME/config.toml" /opt/workcell/adapters/codex/.codex/config.toml
+    for codex_profile in strict development build breakglass; do
+      test -f "$CODEX_HOME/${codex_profile}.config.toml"
+      test ! -L "$CODEX_HOME/${codex_profile}.config.toml"
+      test -w "$CODEX_HOME/${codex_profile}.config.toml"
+      cmp "$CODEX_HOME/${codex_profile}.config.toml" \
+        "/opt/workcell/adapters/codex/.codex/${codex_profile}.config.toml"
+    done
     codex features list >/tmp/codex-features.out 2>/tmp/codex-features.err
     assert_codex_stderr_clean /tmp/codex-features.err
     grep -Eq "^unified_exec[[:space:]]+stable[[:space:]]+false$" /tmp/codex-features.out

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1181,7 +1181,11 @@ require_toml_section_absent() {
 verify_codex_managed_config_invariants() {
   local file="$1"
 
-  require_toml_assignment "${file}" "" "profile" '"strict"' || return 1
+  # Codex 0.134+ profile-v2: the base config must not select or inline a
+  # profile. Profile selection is supplied by the runtime wrapper via
+  # `--profile`, and the per-profile layers live in separate
+  # `<name>.config.toml` files validated by verify_codex_profile_layer_invariants.
+  require_toml_key_absent "${file}" "" "profile" || return 1
   require_toml_key_absent "${file}" "" "sandbox" || return 1
   require_toml_key_absent "${file}" "" "sandbox_mode" || return 1
   require_toml_key_absent "${file}" "" "sandbox_permissions" || return 1
@@ -1198,40 +1202,39 @@ verify_codex_managed_config_invariants() {
   require_toml_exact_keys "${file}" "features" "unified_exec" || return 1
   require_toml_assignment "${file}" "features" "unified_exec" "false" || return 1
 
-  require_toml_exact_keys "${file}" "profiles.strict" \
-    "approval_policy" \
-    "sandbox_mode" \
-    "web_search" || return 1
-  require_toml_assignment "${file}" "profiles.strict" "sandbox_mode" '"workspace-write"' || return 1
-  require_toml_assignment "${file}" "profiles.strict" "approval_policy" '"on-request"' || return 1
-  require_toml_assignment "${file}" "profiles.strict" "web_search" '"disabled"' || return 1
-  require_toml_section_absent "${file}" "profiles.strict.sandbox_workspace_write" || return 1
+  # The base config must carry no inline `[profiles...]` tables (dotted-path
+  # form). Quoted single-segment section names with literal dots normalize to a
+  # backslash-escaped form and remain distinct, so they do not trip this guard.
+  if toml_section_names "${file}" | grep -Eq '^profiles(\.|$)'; then
+    echo "Expected ${file} not to define any [profiles...] section; profile-v2 uses separate <name>.config.toml layers" >&2
+    return 1
+  fi
+}
 
-  require_toml_exact_keys "${file}" "profiles.development" \
-    "approval_policy" \
-    "sandbox_mode" \
-    "web_search" || return 1
-  require_toml_assignment "${file}" "profiles.development" "sandbox_mode" '"workspace-write"' || return 1
-  require_toml_assignment "${file}" "profiles.development" "approval_policy" '"on-request"' || return 1
-  require_toml_assignment "${file}" "profiles.development" "web_search" '"disabled"' || return 1
-  require_toml_section_absent "${file}" "profiles.development.sandbox_workspace_write" || return 1
+# Validate one Codex profile-v2 layer file (strict/development/build/breakglass).
+# A layer is a flat key set: exactly approval_policy, sandbox_mode, web_search,
+# with no nested profile selection and no sections (a `[sandbox_workspace_write]`
+# override inside a layer could widen network access, so it is rejected).
+verify_codex_profile_layer_invariants() {
+  local file="$1"
+  local expected_sandbox_mode="$2"
+  local expected_approval_policy="$3"
+  local sections=""
 
-  require_toml_exact_keys "${file}" "profiles.build" \
+  require_toml_key_absent "${file}" "" "profile" || return 1
+  require_toml_exact_keys "${file}" "" \
     "approval_policy" \
     "sandbox_mode" \
     "web_search" || return 1
-  require_toml_assignment "${file}" "profiles.build" "sandbox_mode" '"workspace-write"' || return 1
-  require_toml_assignment "${file}" "profiles.build" "approval_policy" '"never"' || return 1
-  require_toml_assignment "${file}" "profiles.build" "web_search" '"disabled"' || return 1
-  require_toml_section_absent "${file}" "profiles.build.sandbox_workspace_write" || return 1
+  require_toml_assignment "${file}" "" "sandbox_mode" "${expected_sandbox_mode}" || return 1
+  require_toml_assignment "${file}" "" "approval_policy" "${expected_approval_policy}" || return 1
+  require_toml_assignment "${file}" "" "web_search" '"disabled"' || return 1
 
-  require_toml_exact_keys "${file}" "profiles.breakglass" \
-    "approval_policy" \
-    "sandbox_mode" \
-    "web_search" || return 1
-  require_toml_assignment "${file}" "profiles.breakglass" "sandbox_mode" '"danger-full-access"' || return 1
-  require_toml_assignment "${file}" "profiles.breakglass" "approval_policy" '"never"' || return 1
-  require_toml_assignment "${file}" "profiles.breakglass" "web_search" '"disabled"' || return 1
+  sections="$(toml_section_names "${file}")" || return 1
+  if [[ -n "${sections}" ]]; then
+    echo "Expected ${file} to contain no [sections]; a profile-v2 layer is a flat key set" >&2
+    return 1
+  fi
 }
 
 assert_codex_managed_config_rejected() {
@@ -1246,8 +1249,13 @@ assert_codex_managed_config_rejected() {
 
 CODEX_CONFIG="${ROOT_DIR}/adapters/codex/.codex/config.toml"
 CODEX_MANAGED_CONFIG="${ROOT_DIR}/adapters/codex/managed_config.toml"
+CODEX_PROFILE_DIR="${ROOT_DIR}/adapters/codex/.codex"
 verify_codex_managed_config_invariants "${CODEX_CONFIG}" || exit 1
 verify_codex_managed_config_invariants "${CODEX_MANAGED_CONFIG}" || exit 1
+verify_codex_profile_layer_invariants "${CODEX_PROFILE_DIR}/strict.config.toml" '"workspace-write"' '"on-request"' || exit 1
+verify_codex_profile_layer_invariants "${CODEX_PROFILE_DIR}/development.config.toml" '"workspace-write"' '"on-request"' || exit 1
+verify_codex_profile_layer_invariants "${CODEX_PROFILE_DIR}/build.config.toml" '"workspace-write"' '"never"' || exit 1
+verify_codex_profile_layer_invariants "${CODEX_PROFILE_DIR}/breakglass.config.toml" '"danger-full-access"' '"never"' || exit 1
 require_toml_assignment \
   "${ROOT_DIR}/adapters/codex/requirements.toml" \
   "" \
@@ -1263,7 +1271,7 @@ quoted_key_config="${codex_managed_config_tmpdir}/quoted-key.toml"
 awk '
   {
     print
-    if ($0 == "profile = \"strict\"") {
+    if ($0 == "web_search = \"disabled\"") {
       print "\"approval_policy\" = \"never\""
     }
   }
@@ -1274,7 +1282,7 @@ escaped_key_config="${codex_managed_config_tmpdir}/escaped-key.toml"
 awk '
   {
     print
-    if ($0 == "profile = \"strict\"") {
+    if ($0 == "web_search = \"disabled\"") {
       print "\"approval\\u005fpolicy\" = \"never\""
     }
   }
@@ -1295,7 +1303,7 @@ invalid_escape_key_config="${codex_managed_config_tmpdir}/invalid-escape-key.tom
 awk '
   {
     print
-    if ($0 == "profile = \"strict\"") {
+    if ($0 == "web_search = \"disabled\"") {
       print "\"approval\\u00ZZpolicy\" = \"never\""
     }
   }

--- a/scripts/verify-upstream-codex-release.sh
+++ b/scripts/verify-upstream-codex-release.sh
@@ -74,7 +74,7 @@ require_tool tar
 CODEX_VERSION="$(extract_codex_version)"
 WORKFLOW_IDENTITY="https://github.com/openai/codex/.github/workflows/rust-release.yml@refs/tags/rust-v${CODEX_VERSION}"
 
-verify_asset arm64 aarch64-unknown-linux-gnu "$(extract_codex_sha arm64)"
-verify_asset amd64 x86_64-unknown-linux-gnu "$(extract_codex_sha amd64)"
+verify_asset arm64 aarch64-unknown-linux-musl "$(extract_codex_sha arm64)"
+verify_asset amd64 x86_64-unknown-linux-musl "$(extract_codex_sha amd64)"
 
 echo "Workcell upstream Codex release verification passed."


### PR DESCRIPTION
## Summary

Upgrade the Codex provider to the latest stable release **0.139.0** (from
0.125.0). This requires two coupled changes that must land together:

1. **musl artifact** — recent Codex stable releases ship only the statically
   linked musl Linux tarballs, so the Dockerfile, bump resolver, upstream
   verifier, build-input manifest, and pinned-inputs mapping all retarget the
   musl assets.
2. **profile-v2 config migration** — Codex 0.134.0 removed the legacy
   single-profile config model (top-level `profile = "..."` + inline
   `[profiles.*]` tables). The adapter now uses the layered profile-v2 model.

## Profile-v2 migration

- Base `.codex/config.toml` / `managed_config.toml` keep only base settings and
  deliberately set **no** `sandbox_mode`/`approval_policy` — every sandbox
  decision is profile-scoped.
- Four layer files `{strict,development,build,breakglass}.config.toml` carry the
  per-profile `sandbox_mode`/`approval_policy`, are seeded into the session
  Codex home, and are tracked in the control-plane manifest.
- The wrapper injects the managed `--profile` only on runtime subcommands
  (0.139 rejects the global flag on non-runtime subcommands such as
  `execpolicy`, `features`, `login`); `--version`/`--help` and the default TUI
  still receive it.
- `verify-invariants` is reworked into a base-config guard (no profile
  selection, no inline profile tables, evasion-resistant against
  quoted/escaped-key and dotted-section injection) plus a per-layer guard (flat
  key set, no `sandbox_workspace_write` widening). The workspace-write testkit
  test is updated and container-smoke gains per-layer seeding assertions.

Also includes a doc note on the exec guard's process-linkage model under static
musl binaries.

## Validation

- Local `pre-merge.sh --profile pr-parity` passed end-to-end: image rebuild,
  validate (incl. the reworked security invariants), container-smoke (incl.
  `codex execpolicy check` and the profile-layer seeding checks), and
  reproducible build.
- 0.139 musl binary verified to load each migrated profile layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
