### PR TITLE
Simplify: provider-policy Codex/Claude arg validators (behavior-preserving)

### DIFF
--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -226,7 +226,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "8b3f0bd99130eba820cb76e28aa3d6727aecba35c0a6b3aa03844e2d9dab690a"
+      "sha256": "544eda9e9eba3756fd4d7a968a33d4e1f9de11c5a966267d1f0d3468d0bf8f69"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -45,14 +45,19 @@ reject_unsafe_codex_args() {
   local expect_value=""
   local arg
   local saw_command=0
+  local allowed_profile=""
 
   provider_policy_allows_breakglass && return 0
+
+  # The effective profile is a session property (depends only on WORKCELL_MODE),
+  # so resolve it once instead of forking a subshell per --profile occurrence.
+  allowed_profile="$(effective_codex_profile)"
 
   for arg in "$@"; do
     if [[ -n "${expect_value}" ]]; then
       case "${expect_value}" in
         profile)
-          [[ "${arg}" != "$(effective_codex_profile)" ]] && workcell_die "Workcell blocked unsafe Codex override: --profile"
+          [[ "${arg}" != "${allowed_profile}" ]] && workcell_die "Workcell blocked unsafe Codex override: --profile"
           ;;
         cd)
           workcell_die "Workcell blocked unsafe Codex override: --cd"
@@ -100,7 +105,7 @@ reject_unsafe_codex_args() {
         workcell_die "Workcell blocked unsafe Codex override: --cd"
         ;;
       --profile=*)
-        [[ "${arg#--profile=}" != "$(effective_codex_profile)" ]] && workcell_die "Workcell blocked unsafe Codex override: --profile"
+        [[ "${arg#--profile=}" != "${allowed_profile}" ]] && workcell_die "Workcell blocked unsafe Codex override: --profile"
         ;;
       -s | --sandbox)
         expect_value="sandbox"
@@ -139,10 +144,7 @@ reject_unsafe_claude_args() {
       --dangerously-skip-permissions | --allow-dangerously-skip-permissions | --add-dir | --allowedTools | --mcp-config | --plugin-dir | --settings | --setting-sources | --system-prompt | --append-system-prompt)
         workcell_die "Workcell blocked unsafe Claude override: ${arg}"
         ;;
-      --permission-mode)
-        workcell_die "Workcell blocked Claude autonomy override: use the host workcell --agent-autonomy option instead."
-        ;;
-      --permission-mode=*)
+      --permission-mode | --permission-mode=*)
         workcell_die "Workcell blocked Claude autonomy override: use the host workcell --agent-autonomy option instead."
         ;;
       --add-dir=* | --allowedTools=* | --mcp-config=* | --plugin-dir=* | --settings=* | --setting-sources=* | --system-prompt=* | --append-system-prompt=*)


### PR DESCRIPTION
## Summary

A `/simplify` cleanup of the per-launch provider arg validators in
`runtime/container/provider-policy.sh`. Two behavior-preserving changes:

- `reject_unsafe_codex_args` resolved `effective_codex_profile` via a `$(...)`
  subshell on **every** `--profile`/`-p` occurrence, though it's a
  session-invariant value. Hoist it to one local resolved once after the
  breakglass guard, used by both the spaced and `=`-form profile checks.
- `reject_unsafe_claude_args` had two byte-identical `--permission-mode` arms
  (spaced + `=`-form) with the same die message; merged into one pattern.

## Validation

- A subshell-free unit matrix confirms every rejection is unchanged: Codex
  `--profile` (allowed-vs-foreign, both spellings), `--cd`, `--sandbox
  danger-full-access`, `--config sandbox_mode`, `--search`,
  `-a`/`--ask-for-approval`, nested `app-server`, and Claude `--permission-mode`
  (both spellings) + `--dangerously-skip-permissions`.
- Local `pre-merge.sh --profile pr-parity` passed (validate, container-smoke
  incl. the Codex/Claude nested-override rejection tests, reproducible build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
