### PR TITLE
^r Dedup metadatautil contract/hosted-controls helpers

### DIFF
--- a/internal/metadatautil/hostedcontrols.go
+++ b/internal/metadatautil/hostedcontrols.go
@@ -354,6 +354,18 @@ func UnexpectedEnvironmentSecretNames(actual map[string]struct{}, expected []str
 	return unexpected
 }
 
+func rejectReleaseAdminBypass(releaseEnv, adminBypassRule map[string]any, repo string) error {
+	if bypass, _ := releaseEnv["can_admins_bypass"].(bool); bypass {
+		return fmt.Errorf("release environment on %s must not allow administrator bypass", repo)
+	}
+	if adminBypassRule != nil {
+		if enabled, _ := adminBypassRule["enabled"].(bool); enabled {
+			return fmt.Errorf("release environment on %s must not allow administrator bypass", repo)
+		}
+	}
+	return nil
+}
+
 func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 	var repoMeta map[string]any
 	if err := readJSONFile(filepath.Join(tmpDir, "repo.json"), &repoMeta); err != nil {
@@ -868,13 +880,8 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		if !hasReviewer {
 			return fmt.Errorf("release environment on %s must define at least one reviewer", repo)
 		}
-		if bypass, _ := releaseEnv["can_admins_bypass"].(bool); bypass {
-			return fmt.Errorf("release environment on %s must not allow administrator bypass", repo)
-		}
-		if adminBypassRule != nil {
-			if enabled, _ := adminBypassRule["enabled"].(bool); enabled {
-				return fmt.Errorf("release environment on %s must not allow administrator bypass", repo)
-			}
+		if err := rejectReleaseAdminBypass(releaseEnv, adminBypassRule, repo); err != nil {
+			return err
 		}
 	case "plan-limited-private":
 		if private, _ := repoMeta["private"].(bool); !private {
@@ -908,13 +915,8 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		if !hasReviewer {
 			return fmt.Errorf("release environment on %s must define at least one reviewer in single-owner-public mode", repo)
 		}
-		if bypass, _ := releaseEnv["can_admins_bypass"].(bool); bypass {
-			return fmt.Errorf("release environment on %s must not allow administrator bypass", repo)
-		}
-		if adminBypassRule != nil {
-			if enabled, _ := adminBypassRule["enabled"].(bool); enabled {
-				return fmt.Errorf("release environment on %s must not allow administrator bypass", repo)
-			}
+		if err := rejectReleaseAdminBypass(releaseEnv, adminBypassRule, repo); err != nil {
+			return err
 		}
 	default:
 		if private, _ := repoMeta["private"].(bool); !private {

--- a/internal/metadatautil/operator_contract.go
+++ b/internal/metadatautil/operator_contract.go
@@ -6,6 +6,7 @@ package metadatautil
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -81,14 +82,16 @@ func ValidateOperatorContract(rootDir, contractPath, requirementsPath string) er
 
 	for _, workflowID := range workflowIDs {
 		workflow := contract.Workflows[workflowID]
-		if isPublicWorkflowTier(workflow.Support) && len(workflow.Requirements) == 0 {
-			return fmt.Errorf("%s workflow %s must cite at least one requirement", contractPath, workflowID)
-		}
-		if isPublicWorkflowTier(workflow.Support) && len(workflow.Docs) == 0 {
-			return fmt.Errorf("%s workflow %s must cite at least one documentation path", contractPath, workflowID)
-		}
-		if isPublicWorkflowTier(workflow.Support) && len(workflow.Evidence) == 0 {
-			return fmt.Errorf("%s workflow %s must cite at least one evidence path", contractPath, workflowID)
+		if isPublicWorkflowTier(workflow.Support) {
+			if len(workflow.Requirements) == 0 {
+				return fmt.Errorf("%s workflow %s must cite at least one requirement", contractPath, workflowID)
+			}
+			if len(workflow.Docs) == 0 {
+				return fmt.Errorf("%s workflow %s must cite at least one documentation path", contractPath, workflowID)
+			}
+			if len(workflow.Evidence) == 0 {
+				return fmt.Errorf("%s workflow %s must cite at least one evidence path", contractPath, workflowID)
+			}
 		}
 
 		requirementDocs := map[string]struct{}{}
@@ -101,8 +104,8 @@ func ValidateOperatorContract(rootDir, contractPath, requirementsPath string) er
 			if _, ok := declared.Workflows[workflowID]; !ok {
 				return fmt.Errorf("%s workflow %s must appear in %s requirement %s workflows array", contractPath, workflowID, requirementsPath, requirementID)
 			}
-			mergePathSets(requirementDocs, declared.Docs)
-			mergePathSets(requirementEvidence, declared.Evidence)
+			maps.Copy(requirementDocs, declared.Docs)
+			maps.Copy(requirementEvidence, declared.Evidence)
 			publicWorkflowCovered[workflowID] = struct{}{}
 		}
 
@@ -571,12 +574,6 @@ func loadRequirementTraceability(rootDir, requirementsPath string) (map[string]r
 		}
 	}
 	return refs, nil
-}
-
-func mergePathSets(destination, source map[string]struct{}) {
-	for path := range source {
-		destination[path] = struct{}{}
-	}
 }
 
 func validateWorkflowPathReferences(rootDir, contractPath, requirementsPath, workflowID, field string, paths []string, requirementPaths map[string]struct{}) error {


### PR DESCRIPTION
## Summary

Behavior-preserving `/simplify` cleanups in `internal/metadatautil` (no
runtime behavior change; `go test ./internal/metadatautil` green).

### `operator_contract.go`
- Hoist the three `isPublicWorkflowTier(workflow.Support)` guards into a
  single conditional block — same checks, same error messages, same order.
- Replace the single-use `mergePathSets` helper with `maps.Copy` at both
  call sites and drop the helper.

### `hostedcontrols.go`
- Extract `rejectReleaseAdminBypass` for the two byte-identical
  `can_admins_bypass` / `admin_bypass` guard blocks in the `review-gated`
  and `single-owner-public` release modes.

## Validation
- `gofmt` clean, `go vet ./internal/metadatautil` clean, `go test
  ./internal/metadatautil` ok.
- `scripts/pre-merge.sh --profile pr-parity` passed (validate +
  container-smoke + reproducible-build amd64), 0 failures.

Files are not control-plane-manifest-tracked (Go source under `internal/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
