### PR TITLE
^r Dedup repeated helpers across authpolicy/publishpr/sessionctl

### DIFF
--- a/internal/authpolicy/bootstrap.go
+++ b/internal/authpolicy/bootstrap.go
@@ -258,26 +258,22 @@ func bootstrapNextStepForReadiness(readiness, nextStep string) string {
 	return nextStep
 }
 
-func printBootstrapSummary(stdout io.Writer, summary bootstrapSummary) {
+func printBootstrapSummaryWithPrefix(stdout io.Writer, summary bootstrapSummary, prefix string) {
 	if summary.path == "" {
 		return
 	}
-	fmt.Fprintln(stdout, "provider_bootstrap_state="+summary.state)
-	fmt.Fprintln(stdout, "provider_bootstrap_path="+summary.path)
-	fmt.Fprintln(stdout, "provider_bootstrap_support="+summary.support)
-	fmt.Fprintln(stdout, "provider_bootstrap_handoff="+summary.handoff)
-	fmt.Fprintln(stdout, "provider_bootstrap_doc="+summary.doc)
-	fmt.Fprintln(stdout, "provider_bootstrap_next_step="+summary.nextStep)
+	fmt.Fprintln(stdout, prefix+"state="+summary.state)
+	fmt.Fprintln(stdout, prefix+"path="+summary.path)
+	fmt.Fprintln(stdout, prefix+"support="+summary.support)
+	fmt.Fprintln(stdout, prefix+"handoff="+summary.handoff)
+	fmt.Fprintln(stdout, prefix+"doc="+summary.doc)
+	fmt.Fprintln(stdout, prefix+"next_step="+summary.nextStep)
+}
+
+func printBootstrapSummary(stdout io.Writer, summary bootstrapSummary) {
+	printBootstrapSummaryWithPrefix(stdout, summary, "provider_bootstrap_")
 }
 
 func printCredentialBootstrapSummary(stdout io.Writer, summary bootstrapSummary) {
-	if summary.path == "" {
-		return
-	}
-	fmt.Fprintln(stdout, "bootstrap_state="+summary.state)
-	fmt.Fprintln(stdout, "bootstrap_path="+summary.path)
-	fmt.Fprintln(stdout, "bootstrap_support="+summary.support)
-	fmt.Fprintln(stdout, "bootstrap_handoff="+summary.handoff)
-	fmt.Fprintln(stdout, "bootstrap_doc="+summary.doc)
-	fmt.Fprintln(stdout, "bootstrap_next_step="+summary.nextStep)
+	printBootstrapSummaryWithPrefix(stdout, summary, "bootstrap_")
 }

--- a/internal/publishpr/host_exec.go
+++ b/internal/publishpr/host_exec.go
@@ -83,7 +83,7 @@ func IsTrustedHostToolPath(candidate string, ctx *BashContext) bool {
 		}
 	}
 	for _, prefix := range trustedHostToolPrefixes {
-		if candidate == prefix || strings.HasPrefix(candidate, prefix+"/") {
+		if hasDirPrefix(candidate, prefix) {
 			return true
 		}
 	}

--- a/internal/sessionctl/attach.go
+++ b/internal/sessionctl/attach.go
@@ -70,12 +70,9 @@ func attachMain(args []string, stdout, stderr io.Writer) error {
 		return err
 	}
 
-	if len(roots) == 0 {
-		envRoots, lookupErr := stateroot.LookupRoots()
-		if lookupErr != nil {
-			return lookupErr
-		}
-		roots = envRoots
+	roots, lookupErr := rootsOrLookup(roots)
+	if lookupErr != nil {
+		return lookupErr
 	}
 	record, err := sessions.FindSessionRecordInRoots(roots, sessionID)
 	if err != nil {

--- a/internal/sessionctl/dispatch.go
+++ b/internal/sessionctl/dispatch.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 
 	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/shellproto"
@@ -99,10 +100,8 @@ func resolveSessionSubcommand(subcommand string) (string, error) {
 	case "", "-h", "--help":
 		return "usage", nil
 	}
-	for _, name := range CanonicalSubcommands() {
-		if subcommand == name {
-			return subcommand, nil
-		}
+	if slices.Contains(CanonicalSubcommands(), subcommand) {
+		return subcommand, nil
 	}
 	return "", &cliexit.ExitCodeError{
 		Code:    2,

--- a/internal/sessionctl/logs.go
+++ b/internal/sessionctl/logs.go
@@ -44,12 +44,9 @@ func logsMain(args []string, stdout io.Writer) error {
 		return err
 	}
 
-	if len(roots) == 0 {
-		envRoots, lookupErr := stateroot.LookupRoots()
-		if lookupErr != nil {
-			return lookupErr
-		}
-		roots = envRoots
+	roots, lookupErr := rootsOrLookup(roots)
+	if lookupErr != nil {
+		return lookupErr
 	}
 	record, err := sessions.FindSessionRecordInRoots(roots, sessionID)
 	if err != nil {

--- a/internal/sessionctl/parsehelpers.go
+++ b/internal/sessionctl/parsehelpers.go
@@ -8,7 +8,18 @@ import (
 	"strings"
 
 	"github.com/omkhar/workcell/internal/cliexit"
+	"github.com/omkhar/workcell/internal/host/stateroot"
 )
+
+// rootsOrLookup returns roots unchanged when non-empty, otherwise falls back
+// to the environment-derived roots via stateroot.LookupRoots. The session
+// subcommands (stop, attach, timeline, logs) share this resolution step.
+func rootsOrLookup(roots []string) ([]string, error) {
+	if len(roots) > 0 {
+		return roots, nil
+	}
+	return stateroot.LookupRoots()
+}
 
 // optionValueOrError reads args[i+1] as the value for the args[i] flag.
 // It returns the value, the new index (i+1), and a *cliexit.ExitCodeError

--- a/internal/sessionctl/stop.go
+++ b/internal/sessionctl/stop.go
@@ -78,12 +78,9 @@ func stopMain(args []string, stdout, stderr io.Writer) error {
 		return err
 	}
 
-	if len(roots) == 0 {
-		envRoots, lookupErr := stateroot.LookupRoots()
-		if lookupErr != nil {
-			return lookupErr
-		}
-		roots = envRoots
+	roots, lookupErr := rootsOrLookup(roots)
+	if lookupErr != nil {
+		return lookupErr
 	}
 	record, err := sessions.FindSessionRecordInRoots(roots, sessionID)
 	if err != nil {

--- a/internal/sessionctl/timeline.go
+++ b/internal/sessionctl/timeline.go
@@ -35,12 +35,9 @@ func TimelineMain(args []string) error {
 		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session timeline requires --id."}
 	}
 
-	if len(roots) == 0 {
-		envRoots, lookupErr := stateroot.LookupRoots()
-		if lookupErr != nil {
-			return lookupErr
-		}
-		roots = envRoots
+	roots, lookupErr := rootsOrLookup(roots)
+	if lookupErr != nil {
+		return lookupErr
 	}
 	lines, err := sessions.SessionTimelineRecordsInRoots(roots, sessionID)
 	if err != nil {


### PR DESCRIPTION
## Summary

Behavior-preserving `/simplify` dedup across three `internal/` Go packages
(no runtime behavior change; `go test ./internal/...` green).

### `sessionctl`
- Extract `rootsOrLookup` in `parsehelpers.go` for the byte-identical
  `len(roots)==0 → stateroot.LookupRoots()` fallback shared by
  stop/attach/timeline/logs (4 call sites).
- Collapse the `CanonicalSubcommands()` membership loop in `dispatch.go`
  to `slices.Contains`.

### `authpolicy`
- Fold the identical-but-for-prefix `printBootstrapSummary` and
  `printCredentialBootstrapSummary` onto a shared
  `printBootstrapSummaryWithPrefix`, keeping both named entry points
  (same exact output lines).

### `publishpr`
- Call the existing `hasDirPrefix` helper in `isTrustedHostTool` instead
  of re-inlining its `candidate==prefix || HasPrefix(prefix+"/")` condition.

## Validation
- `go build ./internal/...`, `go vet`, `gofmt -l` clean.
- `go test ./internal/...` green (incl. sessionctl/authpolicy/publishpr).
- `scripts/pre-merge.sh --profile pr-parity` passed (validate +
  container-smoke + reproducible-build amd64), 0 failures. The
  `shared/session-commands` scenario exercises the sessionctl change.

None of the files are control-plane-manifest-tracked (Go source under `internal/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
