### PR TITLE
^r Dedup TOML/SSH-identity rendering in authresolve/injection

### DIFF
--- a/internal/authresolve/resolve_policy_render.go
+++ b/internal/authresolve/resolve_policy_render.go
@@ -93,27 +93,11 @@ documents:
 	if ssh, ok := policy["ssh"].(map[string]any); ok && len(ssh) > 0 {
 		lines = append(lines, "")
 		lines = append(lines, "[ssh]")
-		ordered := []string{"enabled", "config", "known_hosts", "identities", "providers", "modes", "allow_unsafe_config"}
-		seen := map[string]struct{}{}
-		for _, key := range ordered {
-			if value, ok := ssh[key]; ok {
-				rendered, err := renderTOMLValue(value)
-				if err != nil {
-					return "", err
-				}
-				lines = append(lines, key+" = "+rendered)
-				seen[key] = struct{}{}
-			}
-		}
-		for _, key := range sortedKeys(ssh) {
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			rendered, err := renderTOMLValue(ssh[key])
-			if err != nil {
-				return "", err
-			}
-			lines = append(lines, key+" = "+rendered)
+		var renderErr error
+		lines, renderErr = renderOrderedThenSorted(lines, ssh,
+			[]string{"enabled", "config", "known_hosts", "identities", "providers", "modes", "allow_unsafe_config"})
+		if renderErr != nil {
+			return "", renderErr
 		}
 	}
 
@@ -125,32 +109,46 @@ documents:
 			}
 			lines = append(lines, "")
 			lines = append(lines, "[[copies]]")
-			ordered := []string{"source", "target", "classification", "providers", "modes"}
-			seen := map[string]struct{}{}
-			for _, key := range ordered {
-				if value, ok := entryMap[key]; ok {
-					rendered, err := renderTOMLValue(value)
-					if err != nil {
-						return "", err
-					}
-					lines = append(lines, key+" = "+rendered)
-					seen[key] = struct{}{}
-				}
-			}
-			for _, key := range sortedKeys(entryMap) {
-				if _, ok := seen[key]; ok {
-					continue
-				}
-				rendered, err := renderTOMLValue(entryMap[key])
-				if err != nil {
-					return "", err
-				}
-				lines = append(lines, key+" = "+rendered)
+			var renderErr error
+			lines, renderErr = renderOrderedThenSorted(lines, entryMap,
+				[]string{"source", "target", "classification", "providers", "modes"})
+			if renderErr != nil {
+				return "", renderErr
 			}
 		}
 	}
 
 	return strings.Join(lines, "\n") + "\n", nil
+}
+
+// renderOrderedThenSorted appends "key = value" TOML lines for m: first the
+// keys listed in ordered (when present in m), then any remaining keys in
+// sorted order. It returns the extended lines slice.
+func renderOrderedThenSorted(lines []string, m map[string]any, ordered []string) ([]string, error) {
+	seen := map[string]struct{}{}
+	for _, key := range ordered {
+		value, ok := m[key]
+		if !ok {
+			continue
+		}
+		rendered, err := renderTOMLValue(value)
+		if err != nil {
+			return nil, err
+		}
+		lines = append(lines, key+" = "+rendered)
+		seen[key] = struct{}{}
+	}
+	for _, key := range sortedKeys(m) {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		rendered, err := renderTOMLValue(m[key])
+		if err != nil {
+			return nil, err
+		}
+		lines = append(lines, key+" = "+rendered)
+	}
+	return lines, nil
 }
 
 func renderTOMLValue(value any) (string, error) {

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -297,24 +297,22 @@ func effectivePolicySHA256(
 				"sha256":     hash,
 			}
 		}
-		if identities, ok := renderedSSH["identities"].([]map[string]any); ok {
-			renderedIdentities := make([]map[string]any, 0, len(identities))
-			for _, entry := range identities {
-				hash, err := pathMaterialSHA256(Path(entry["source"].(string)))
-				if err != nil {
-					return "", fmt.Errorf("hash ssh identity %v: %w", entry["target_name"], err)
-				}
-				renderedIdentities = append(renderedIdentities, map[string]any{
-					"mount_path":  entry["mount_path"],
-					"sha256":      hash,
-					"target_name": entry["target_name"],
-				})
+		var identityEntries []map[string]any
+		identitiesFound := false
+		switch v := renderedSSH["identities"].(type) {
+		case []map[string]any:
+			identitiesFound = true
+			identityEntries = v
+		case []any:
+			identitiesFound = true
+			identityEntries = make([]map[string]any, 0, len(v))
+			for _, rawEntry := range v {
+				identityEntries = append(identityEntries, rawEntry.(map[string]any))
 			}
-			ssh["identities"] = renderedIdentities
-		} else if identities, ok := renderedSSH["identities"].([]any); ok {
-			renderedIdentities := make([]map[string]any, 0, len(identities))
-			for _, rawEntry := range identities {
-				entry := rawEntry.(map[string]any)
+		}
+		if identitiesFound {
+			renderedIdentities := make([]map[string]any, 0, len(identityEntries))
+			for _, entry := range identityEntries {
 				hash, err := pathMaterialSHA256(Path(entry["source"].(string)))
 				if err != nil {
 					return "", fmt.Errorf("hash ssh identity %v: %w", entry["target_name"], err)


### PR DESCRIPTION
## Summary

Behavior-preserving `/simplify` dedup in two `internal/` rendering paths
(no runtime behavior change; `go test ./internal/...` green, 0 FAILs).

### `authresolve/resolve_policy_render.go`
- Extract `renderOrderedThenSorted` for the identical "emit the keys in a
  fixed `ordered` list, then any remaining keys in sorted order" loop shared
  by the `[ssh]` and `[[copies]]` policy-render blocks. Same output lines.

### `injection/render_injection_bundle.go`
- Collapse the two identical SSH-identity hashing branches
  (`[]map[string]any` and `[]any`) onto a single loop by normalizing the
  input form first. A `found` flag preserves the original type-assertion
  semantics exactly, including the typed-nil-slice edge (type matches →
  empty result still written).

## Validation
- `go build ./internal/...`, `go vet`, `gofmt -l` clean.
- `go test ./internal/...` exit 0, 0 FAILs.
- `scripts/pre-merge.sh --profile pr-parity` passed (validate +
  container-smoke + reproducible-build amd64), 0 failures.

Neither file is control-plane-manifest-tracked (Go source under `internal/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
