### PR TITLE
^r Dedup process-liveness and not-found checks in launcher/transcript

### DIFF
--- a/internal/host/launcher/launcher.go
+++ b/internal/host/launcher/launcher.go
@@ -75,24 +75,38 @@ func ProfileLockIsStale(lockDir string) (bool, error) {
 		return false, fmt.Errorf("profile lock owner metadata is incomplete: %s", ownerPath)
 	}
 
-	if err := syscall.Kill(owner.PID, 0); err != nil {
-		if errors.Is(err, syscall.ESRCH) {
-			return true, nil
-		}
+	alive, err := pidAlive(owner.PID)
+	if err != nil {
 		return false, err
+	}
+	if !alive {
+		return true, nil
 	}
 
 	observed, err := ProcessStartTime(owner.PID)
 	if err != nil {
-		if killErr := syscall.Kill(owner.PID, 0); killErr != nil {
-			if errors.Is(killErr, syscall.ESRCH) {
-				return true, nil
-			}
+		alive, killErr := pidAlive(owner.PID)
+		if killErr != nil {
 			return false, killErr
+		}
+		if !alive {
+			return true, nil
 		}
 		return false, err
 	}
 	return observed != owner.Started, nil
+}
+
+// pidAlive reports whether signal 0 reaches pid. A missing process (ESRCH)
+// returns (false, nil); any other Kill error is surfaced.
+func pidAlive(pid int) (bool, error) {
+	if err := syscall.Kill(pid, 0); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func AcquireProfileLock(lockDir string, pid int) (bool, error) {

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -222,15 +222,19 @@ func exitCodeFromWaitStatus(status int) int {
 	return 1
 }
 
+func isNotFoundError(err error) bool {
+	return errors.Is(err, syscall.ENOENT) || errors.Is(err, exec.ErrNotFound)
+}
+
 func exitCodeFromSpawnError(err error) int {
-	if errors.Is(err, syscall.ENOENT) || errors.Is(err, exec.ErrNotFound) {
+	if isNotFoundError(err) {
 		return 127
 	}
 	return 126
 }
 
 func spawnErrorText(err error) string {
-	if errors.Is(err, syscall.ENOENT) || errors.Is(err, exec.ErrNotFound) {
+	if isNotFoundError(err) {
 		return "No such file or directory"
 	}
 	return err.Error()
@@ -256,7 +260,7 @@ func spawnErrno(err error) int {
 	if errors.As(err, &errno) {
 		return int(errno)
 	}
-	if errors.Is(err, syscall.ENOENT) || errors.Is(err, exec.ErrNotFound) {
+	if isNotFoundError(err) {
 		return int(syscall.ENOENT)
 	}
 	return 1


### PR DESCRIPTION
## Summary

Behavior-preserving `/simplify` dedup in two `internal/` packages
(no runtime behavior change; `go test ./internal/...` exit 0, 0 FAILs).

### `host/launcher/launcher.go`
- Extract `pidAlive` for the two inline `syscall.Kill(pid, 0)` + `ESRCH`
  classifications in `ProfileLockIsStale`. The `(false, nil)` "missing
  process" result preserves every original branch: ESRCH → stale lock
  (`true, nil`), other Kill error → surfaced, alive → fall through.

### `transcript/transcript.go`
- Extract `isNotFoundError` for the
  `errors.Is(ENOENT) || errors.Is(exec.ErrNotFound)` check repeated in
  `exitCodeFromSpawnError`, `spawnErrorText`, and `spawnErrno`.

## Validation
- `go build ./internal/...`, `go vet`, `gofmt -l` clean.
- `go test ./internal/...` exit 0, 0 FAILs.
- `scripts/pre-merge.sh --profile pr-parity` passed (validate +
  container-smoke + reproducible-build amd64), 0 failures. The
  host-launcher-invariants validate step exercises `ProfileLockIsStale`.

Neither file is control-plane-manifest-tracked (Go source under `internal/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
