### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,67 @@ Releases.
 
 ## Unreleased
 
+## v0.11.0 - 2026-06-15
+
+### Added
+
+- upgrade the Codex CLI to `0.139.0`, switch to the musl static artifact, and
+  migrate managed Codex configuration to the profile-v2 layered model (a base
+  `config.toml` plus per-profile `strict`/`development`/`build`/`breakglass`
+  `<name>.config.toml` files applied with `--profile`), with the managed GUI
+  app-server sandbox mode injected by the provider wrapper.
+- bump Claude Code to `2.1.175` and Gemini CLI to `0.46.0`.
+- migrate the runtime and validator base images to Node 24 LTS.
+- add a fail-closed Copilot adapter scaffold and distro-scoped host
+  support-matrix fields.
+- build the native arm64 release image on a native runner and split the
+  release preflight into parallel amd64-reproducibility and container-smoke
+  jobs.
+
+### Changed
+
+- thin the public shell entrypoints and internal surfaces through a large set
+  of behavior-preserving refactors across the Codex provider wrapper, the
+  provider-policy argument validators, and the `metadatautil`, `authpolicy`,
+  `authresolve`, `injection`, `sessionctl`, `publishpr`, host `launcher`, and
+  `transcript` packages.
+
+### Fixed
+
+- close the glued `-c` Codex hook-bypass gap and align the nested-CLI rules.
+- fail the release gate closed on unregistered or stale required `main` checks.
+- enforce BuildKit/buildx pin parity across `docs.yml` and the validator-image
+  fallback.
+- harden host and runtime boundary checks, including physical remote-VM
+  symlink resolution and `0600` rewritten-manifest permissions.
+
+### Documentation
+
+- document the exec guard's process-linkage model and noexec hardening, record
+  the Gemini enterprise-license-only auth posture, make the quickstart verify
+  release assets, and correct CI trigger wording.
+
+## v0.10.7 - 2026-05-29
+
+### Added
+
+- add a repository readiness gate for maintainer-facing workflow hardening.
+
+### Changed
+
+- remove dead bash and Go helpers and dedup runtime wrappers, execveat loader
+  classification, registry CA blocks, and `publishpr`/`hostutil`/`providerid`
+  helpers across many internal surfaces.
+- extract the shared `PolicySource` type into `internal/injectionpolicy`.
+
+### Fixed
+
+- harden runtime image fetch retries and build recovery, keep GitHub API auth
+  host-bound, preserve refresh publication validation, keep Debian refreshes
+  bootstrap-buildable, resolve Colima egress hosts inside the VM, fail closed
+  on snapshot TLS bootstrap errors, allow Docker CloudFront blobs in bootstrap
+  policy, and fetch actionlint checksums through the asset API.
+
 ## v0.10.6 - 2026-05-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,10 @@ Releases.
 ### Documentation
 
 - document the exec guard's process-linkage model and noexec hardening, record
-  the Gemini enterprise-license-only auth posture, make the quickstart verify
-  release assets, and correct CI trigger wording.
+  the reviewed auth-input-scoped Gemini posture (Code Assist Standard/Enterprise
+  licenses and paid API keys; upstream retires only the personal-account OAuth
+  login), make the quickstart verify release assets, and correct CI trigger
+  wording.
 
 ## v0.10.7 - 2026-05-29
 


### PR DESCRIPTION
## Release v0.11.0

Cuts the v0.11.0 release covering all of `v0.10.7..HEAD` (90 commits).
This PR is CHANGELOG-only — the repo has no in-tree version constant; the
release is tag-driven via `release.yml` once this lands on green `main`.

### Highlights

**Added**
- Codex CLI `0.139.0`: musl static artifact + profile-v2 layered config model
  (base `config.toml` + per-profile `strict`/`development`/`build`/`breakglass`
  files via `--profile`); managed GUI app-server sandbox injected by the wrapper.
- Claude Code `2.1.175`, Gemini CLI `0.46.0`.
- Node 24 LTS runtime + validator base images.
- Fail-closed Copilot adapter scaffold; distro-scoped host support-matrix fields.
- Native arm64 release image build; parallel amd64-repro + container-smoke preflight.

**Fixed / Security**
- Closed the glued `-c` Codex hook-bypass gap; aligned nested-CLI rules.
- Release gate fails closed on unregistered/stale required `main` checks.
- BuildKit/buildx pin parity across `docs.yml` and the validator-image fallback.
- Host/runtime boundary hardening (physical remote-VM symlink resolution, 0600 manifests).

**Changed**
- Behavior-preserving internal refactor sweep across the Codex wrapper,
  provider-policy validators, and the metadatautil/authpolicy/authresolve/
  injection/sessionctl/publishpr/launcher/transcript packages.

Also backfills the previously undocumented `v0.10.7` changelog entry.

### Release path
Single-maintainer mode. After merge on green `main`, a signed `v0.11.0` tag
triggers `release.yml`; the `release` environment is approved by the maintainer
after preflight + install verification are green.

### Validation
`scripts/pre-merge.sh --profile pr-parity` passed (validate + container-smoke +
reproducible-build amd64), 0 failures. Docs job + codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
