### PR TITLE
Release v0.11.1 — refresh release pins (Claude 2.1.177, rust runtime image)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Releases.
 
 ## Unreleased
 
+## v0.11.1 - 2026-06-15
+
+Supersedes v0.11.0, which was tagged but never published: its release-preflight
+aborted on the pin-freshness gate because the latest reviewed track had moved on.
+This patch refreshes those pins and re-cuts the release; it carries the full
+v0.11.0 content below plus the refresh.
+
+### Changed
+
+- bump Claude Code to `2.1.177` (from the v0.11.0 `2.1.175` pin) and refresh the
+  rust runtime toolchain image to the current reviewed `rust:1.96.0-slim-trixie`
+  digest, so the release matches the latest reviewed upstream track.
+
 ## v0.11.0 - 2026-06-15
 
 ### Added

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -11,7 +11,7 @@ ARG SOURCE_DATE_EPOCH=0
 # To update: choose a newer snapshot date at https://snapshot.debian.org/,
 # verify packages are available, update this value, and re-run verify-reproducible-build.sh.
 ARG DEBIAN_SNAPSHOT=20260518T000000Z
-ARG RUST_TOOLCHAIN_IMAGE=rust:1.96.0-slim-trixie@sha256:26abcef3d79b8d890c4ceb17093154573e1f6479cf6dd7c1450043b8458350f6
+ARG RUST_TOOLCHAIN_IMAGE=rust:1.96.0-slim-trixie@sha256:3b05f7c617a200c41c3506097f0d15fc193a1c93bfd8f141007b47cac8f95d3c
 
 FROM ${RUST_TOOLCHAIN_IMAGE} AS rust-toolchain
 
@@ -200,7 +200,7 @@ FROM runtime-base AS runtime-builder
 # from the public release bucket, verify the per-platform checksums in the
 # corresponding manifest.json, update CLAUDE_VERSION, and refresh the
 # CLAUDE_SHA256 values below.
-ARG CLAUDE_VERSION=2.1.175
+ARG CLAUDE_VERSION=2.1.177
 # OpenAI Codex CLI version and SHA256 checksums for each architecture.
 # Workcell follows the stable npm channel and matching non-prerelease Rust
 # release after the cool-off in policy/provider-bumps.toml. The runtime
@@ -282,11 +282,11 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
   && case "${TARGET_ARCH}" in \
     arm64) \
       CLAUDE_PLATFORM="linux-arm64"; \
-      CLAUDE_SHA256="360f1f6f43ec26d9bb6e20e487bf44b753d9b8407e89e74bfeeb79707399f435"; \
+      CLAUDE_SHA256="baf3926dc166215772f959e367da9784ff4c75157aaafe4524fdc79ebff984b1"; \
       ;; \
     amd64) \
       CLAUDE_PLATFORM="linux-x64"; \
-      CLAUDE_SHA256="4fc72fa6090c9a03f1850e1b1ccb3d6806bf802b67e3cb9dc5f2ced4b7ed5ca1"; \
+      CLAUDE_SHA256="ff41753634b20c869ef6a32a20863521b33d4186ac0d6a49379ab48a48395ee7"; \
       ;; \
     *) \
       echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; \


### PR DESCRIPTION
## Release v0.11.1 (re-cut of v0.11.0)

The v0.11.0 release tag was pushed but **never published**: its
`release.yml` preflight aborted on the "Require pinned upstreams to match the
latest reviewed track" gate, because the reviewed upstream track moved during
the release window. Per the release runbook, the failed tag is not reused —
this re-cuts the release as v0.11.1 with refreshed pins.

### Pin refresh
- **Claude Code 2.1.175 → 2.1.177** (now past the 12h cool-off; verified
  per-arch SHA256s).
- **rust runtime toolchain image** → current reviewed `rust:1.96.0-slim-trixie`
  digest.

`./scripts/update-upstream-pins.sh --check` now passes. All other pins were
already up to date.

v0.11.1 carries the full v0.11.0 content (Codex 0.139 + profile-v2, Node 24,
Copilot scaffold, native arm64 builds, security hardening, the refactor sweep)
plus this refresh; see the CHANGELOG for both entries.

### Validation
`scripts/pre-merge.sh --profile pr-parity` passed (validate + container-smoke +
reproducible-build amd64, rebuilding with Claude 2.1.177 and the new rust
image), 0 failures. Docs job + codespell + hadolint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
