### PR TITLE
Release v0.11.2 — repoint mutation harness anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Releases.
 
 ## Unreleased
 
+## v0.11.2 - 2026-06-15
+
+Supersedes v0.11.1, which was tagged but never published: its release-preflight
+mutation gate failed because the mutation-test harness anchors still pointed at
+pre-split source locations. This patch repoints them and carries the full
+v0.11.0/v0.11.1 content below.
+
+### Fixed
+
+- repoint the `internal/mutation` harness source anchors to the current
+  injection/metadatautil layout: `validateAllowedKeys`, `targetIsReserved`,
+  and the secret-permission check moved into `render_credentials.go`,
+  `render_documents_copies.go`, and `render_validation.go` during the injection
+  package split, and the operator-contract evidence check was hoisted — so the
+  release-preflight mutation gate matches the shipped source again.
+
 ## v0.11.1 - 2026-06-15
 
 Supersedes v0.11.0, which was tagged but never published: its release-preflight

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -35,14 +35,14 @@ func goCmd(args ...string) commandSpec {
 
 var goHelperMutations = []mutationCase{
 	{
-		relativePath: "internal/injection/render_injection_bundle.go",
+		relativePath: "internal/injection/render_documents_copies.go",
 		original:     `if targetIsReserved(candidate) {`,
 		replacement:  `if false && targetIsReserved(candidate) {`,
 		label:        "reserved target protection",
 		command:      goCmd("test", "./internal/injection"),
 	},
 	{
-		relativePath: "internal/injection/render_injection_bundle.go",
+		relativePath: "internal/injection/render_credentials.go",
 		original: strings.Join([]string{
 			`if err := validateAllowedKeys(credentials, mapKeysSet([]string{`,
 			`		"codex_auth",`,
@@ -61,7 +61,7 @@ var goHelperMutations = []mutationCase{
 		command: goCmd("test", "./internal/injection"),
 	},
 	{
-		relativePath: "internal/injection/render_injection_bundle.go",
+		relativePath: "internal/injection/render_validation.go",
 		original:     `if info.Mode().Perm()&0o077 != 0 {`,
 		replacement:  `if false && info.Mode().Perm()&0o077 != 0 {`,
 		label:        "secret permission hygiene",
@@ -97,8 +97,8 @@ var goHelperMutations = []mutationCase{
 	},
 	{
 		relativePath: "internal/metadatautil/operator_contract.go",
-		original:     `if isPublicWorkflowTier(workflow.Support) && len(workflow.Evidence) == 0 {`,
-		replacement:  `if false && isPublicWorkflowTier(workflow.Support) && len(workflow.Evidence) == 0 {`,
+		original:     `if len(workflow.Evidence) == 0 {`,
+		replacement:  `if false && len(workflow.Evidence) == 0 {`,
 		label:        "workflow evidence requirement",
 		command:      goCmd("test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"),
 	},


### PR DESCRIPTION
## Release v0.11.2 (re-cut of v0.11.1)

The v0.11.1 tag was pushed but **never published**: its `release.yml`
preflight `Validate repository` step failed on the **mutation gate** with
"mutation anchor not found". The mutation harness anchors in
`internal/mutation/runner.go` still pointed at pre-split source locations.
Per the runbook, the failed tag is not reused — this re-cuts as v0.11.2.

### Fix
Repoint four anchors to the current source layout (mutations and their
catch-tests unchanged, so coverage is preserved):
- `validateAllowedKeys(...)` → `render_credentials.go`
- `targetIsReserved(...)` → `render_documents_copies.go`
- secret-permission check → `render_validation.go`
- operator-contract evidence check → hoisted form `if len(workflow.Evidence) == 0`

Root cause: the `internal/injection` package split (pre-existing) moved three
anchored snippets, and this cycle's `operator_contract.go` refactor hoisted the
fourth. The pr-parity local lane (`job-validate.sh`) does **not** run the
mutation harness — only `validate-repo.sh` / release-preflight does — so the
drift surfaced only at release time.

### Verification
- `./scripts/run-mutation-tests.sh` (the harness release-preflight runs) passes
  locally: exit 0, **0** anchor-not-found, **0** surviving mutations.
- `scripts/pre-merge.sh --profile pr-parity` passed (validate + container-smoke
  + reproducible-build amd64), 0 failures.

Carries the full v0.11.0/v0.11.1 content; see the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
