### PR TITLE
^F Add Antigravity fail-closed scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Workcell runs coding agents inside a bounded local runtime on Apple Silicon
 macOS: a dedicated Colima VM plus a hardened container inside that VM. It ships
 Tier 1 adapters for Codex, Claude Code, and Gemini that seed each provider's
 native control plane without pretending provider config is the security
-boundary. GitHub Copilot CLI is the next committed Tier 1 provider-parity
-track, but current releases do not support `--agent copilot`.
+boundary. GitHub Copilot CLI is the next committed provider-parity track, and
+Google Antigravity CLI is a queued follow-on; current releases do not support
+`--agent copilot` or `--agent antigravity`.
 
 This project is for teams that want local agent velocity without turning the
 host home directory, keychain, provider state, or local sockets into the trust
@@ -48,11 +49,12 @@ boundary.
   preview-only `remote_vm/aws-ec2-ssm/compat` and
   `remote_vm/gcp-vm/compat` broker plans, and their live smokes remain
   certification-only
-- CLI surfaces for Codex, Claude, and Gemini plus host-side detached session
-  control and inspection commands
-- GitHub Copilot CLI is planned for the same Tier 1 adapter support bar as the
-  current providers; it is not launch-ready until the adapter, auth path,
-  quickstart, deterministic evidence, and live certification land together
+- CLI surfaces for Codex, Claude, and upstream-served Gemini auth modes plus
+  host-side detached session control and inspection commands
+- GitHub Copilot CLI is the next planned provider-parity track, with Google
+  Antigravity CLI queued behind the same evidence bar; neither is launch-ready
+  until its adapter, auth path, quickstart, deterministic evidence, and live
+  certification land together
 - GitHub-hosted CI verifies repo shape, reproducibility, release posture, and
   secretless runtime behavior
 - GitHub-hosted CI verifies bundle install/uninstall and Homebrew
@@ -206,10 +208,10 @@ Workcell can stage:
 It does not support whole-home passthrough, arbitrary environment-variable
 secret injection, or host socket forwarding on the safe path.
 
-Copilot CLI credentials and `~/.copilot` state are not supported inputs yet.
-The planned Copilot adapter must use an explicit staged credential, session-local
-Copilot home and cache paths, and reviewed GitHub-token handling before it can
-join the supported provider set.
+Copilot and Antigravity credentials and provider-home state are not supported
+inputs yet. Their planned adapters must use explicit staged credentials,
+session-local home and cache paths, and reviewed provider-auth handling before
+they can join the supported provider set.
 
 See [docs/injection-policy.md](docs/injection-policy.md) and
 [docs/examples/injection-policy.toml](docs/examples/injection-policy.toml).
@@ -229,6 +231,7 @@ Planned provider parity:
 | Provider | Target surface | Required before support |
 |---|---|---|
 | GitHub Copilot CLI | planned Tier 1 CLI adapter; not current support | `--agent copilot`, explicit token staging, session-local `COPILOT_HOME` and `COPILOT_CACHE_HOME`, unsafe-argument policy, quickstart, deterministic tests, and live `copilot -p` certification |
+| Google Antigravity CLI | planned Tier 1 CLI adapter; not current support | `--agent antigravity`, official install provenance, explicit Google auth staging, session-local provider home/cache, unsafe-argument policy, quickstart, deterministic tests, and live provider certification |
 
 GUI and IDE surfaces are lower assurance unless they act only as clients to
 the same bounded runtime.
@@ -383,8 +386,8 @@ Tagged releases are rebuilt and verified before publication. The release path:
   targets the newest two GitHub-hosted Apple Silicon macOS runner labels
 - refuses to publish if any reviewed provider, Linux base image, Linux
   toolchain, or release-build pin is behind the latest tracked upstream
-- adds Copilot upstream pin verification only after Copilot becomes a supported
-  provider adapter
+- adds Copilot or Antigravity upstream pin verification as part of provider
+  promotion, before any support claim
 - publishes from the archived source bundle rather than the live checkout
 - gates publication on bundle and Homebrew install verification on
   GitHub-hosted Apple Silicon `macos-26` and `macos-15`
@@ -446,8 +449,8 @@ See [docs/provenance.md](docs/provenance.md) and
 - `runtime/`: VM and container boundary implementation
 - `policy/`: shared contract layer and hosted-control policy
 - `adapters/`: provider-native baselines for Codex, Claude, and Gemini, plus
-  the fail-closed Copilot planning scaffold (`adapters/copilot/` is not a
-  baseline until its adapter support lands)
+  fail-closed Copilot and Antigravity planning scaffolds (their directories are
+  not baselines until adapter support lands)
 - `cmd/`: host-side and runtime-side Go entrypoints (the `workcell-*` binaries)
 - `internal/`: shared Go packages backing the `cmd/` binaries
 - `scripts/`: launcher, validation, release, audit, and bootstrap entrypoints

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,9 +17,9 @@ guidance, and live certification evidence land together.
 Authoritative provider support status remains in
 [`docs/provider-matrix.md`](docs/provider-matrix.md). Codex, Claude Code, and
 Gemini are the supported Tier 1 provider adapters today. GitHub Copilot CLI is
-the next committed provider-parity track, but it is not a support claim
-until its adapter, auth path, docs, deterministic evidence, and live
-certification land together.
+the next committed provider-parity phase, and Google Antigravity CLI is a
+queued follow-on track. Neither is a support claim until its adapter, auth path,
+docs, deterministic evidence, and live certification land together.
 
 The active delivery shape lives in
 [`docs/implement-first-delivery-plan.md`](docs/implement-first-delivery-plan.md).
@@ -63,9 +63,10 @@ The deterministic phase breakdown lives in
 - Phases 10 through 12 are now implemented as contract, evidence, and readiness
   gates. They do not add a managed-workstation backend, Linux support, Windows
   support, or any new launch target.
-- GitHub Copilot CLI is planned as the next Tier 1 provider adapter. Current
-  releases do not support `--agent copilot`, Copilot credential keys, or a
-  Copilot quickstart.
+- GitHub Copilot CLI is planned as the next provider adapter, and Google
+  Antigravity CLI is queued as the follow-on track. Current releases do not
+  support `--agent copilot`, `--agent antigravity`, their credential keys, or
+  matching quickstarts.
 - Upstream retires Gemini CLI for the free, Pro, and Ultra personal-account
   login tiers on June 18, 2026 in favor of the closed-source Antigravity
   CLI; Gemini Code Assist Standard/Enterprise licenses and paid Gemini API

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -11,6 +11,7 @@ Current adapters:
 
 Planned fail-closed scaffolds:
 
+- `antigravity/`
 - `copilot/`
 
 Adapter rules:

--- a/adapters/antigravity/README.md
+++ b/adapters/antigravity/README.md
@@ -1,0 +1,18 @@
+# Google Antigravity CLI Adapter
+
+This adapter directory is a fail-closed planning scaffold. Workcell recognizes
+`antigravity` as a planned Google Antigravity CLI provider id, but it does not
+install, prepare, authenticate, or launch Antigravity yet.
+
+Support promotion requires the same review unit to add:
+
+- an official pinned Antigravity CLI install path with provenance evidence
+- explicit Antigravity home and cache-state handling under `/state/agent-home`
+- a staged Google auth handoff that does not mount host Google account state,
+  browser profiles, keychains, host homes, or provider caches
+- provider-native unsafe-flag rejection in the Workcell wrapper
+- deterministic dry-run and scenario coverage
+- a live provider certification run before any supported Tier 1 matrix claim
+
+Until those gates land, `workcell --agent antigravity` exits before runtime
+preparation with an unsupported-provider diagnostic.

--- a/adapters/gemini/README.md
+++ b/adapters/gemini/README.md
@@ -18,5 +18,6 @@ Key points:
   sandbox is optional and not the Tier 1 boundary here
 - repo-local `.gemini/` content stays masked on the safe path
 - `gemini_env`, `gemini_oauth`, `gemini_projects`, and `gcloud_adc` cover the
-  supported long-lived auth and project-state paths
+  supported long-lived auth and project-state paths for upstream-served Gemini
+  auth modes; see `docs/provider-matrix.md` for the Gemini retirement caveat
 - `breakglass` restores Gemini's own folder-trust prompt behavior

--- a/docs/adapter-control-planes.md
+++ b/docs/adapter-control-planes.md
@@ -24,7 +24,7 @@ adapter baseline.
 | Claude | `settings.json`, rendered `CLAUDE.md`, `.mcp.json`, auth mirrors, optional API key helper | the reviewed Bash hook is defense in depth; MCP defaults are empty |
 | Gemini | `settings.json`, rendered `GEMINI.md`, `.env`, `oauth_creds.json`, `projects.json`, `trustedFolders.json` | `breakglass` restores Gemini's own folder-trust prompt; `gcloud_adc` is supplemental to Vertex config in `gemini_env` |
 
-## Planned Copilot CLI control plane
+## Planned provider control planes
 
 GitHub Copilot CLI is planned as the next Tier 1 provider adapter. It is not
 seeded by current releases. Before support is claimed, the Copilot adapter must
@@ -46,6 +46,13 @@ Shared cross-provider state can also seed the current supported adapters:
 That GitHub CLI state must not become a Copilot safe-path auth input unless a
 separate reviewed Copilot path explicitly allows it.
 
+Google Antigravity CLI is also a planned fail-closed adapter. Before support is
+claimed, the Antigravity adapter must pin official CLI provenance, own
+session-local provider home/cache/settings state, and explicitly map or block
+subagents, plugins, MCP, sandbox settings, permissions, hooks, and any shared
+desktop/IDE state. Host Google account caches, browser profiles, keychains,
+host homes, and provider caches must not become implicit Tier 1 inputs.
+
 ## Instruction layering
 
 Provider docs are rendered in this order:
@@ -66,10 +73,11 @@ control plane masked on the safe path.
 | `--agent-autonomy yolo` | `--ask-for-approval never` | `--permission-mode bypassPermissions` | `--approval-mode yolo` |
 | `--agent-autonomy prompt` | `--ask-for-approval on-request` | `--permission-mode default` | `--approval-mode default` |
 
-Copilot autonomy mapping is intentionally absent until the adapter lands. The
-planned implementation must map prompt mode to Copilot's normal approval flow
-and yolo mode only to reviewed tool/path/URL permissions inside the Workcell
-runtime, while blocking user-supplied flags that silently widen trust.
+Copilot and Antigravity autonomy mappings are intentionally absent until their
+adapters land. The planned implementations must map prompt mode to each
+provider's normal approval flow and yolo mode only to reviewed permissions
+inside the Workcell runtime, while blocking user-supplied flags that silently
+widen trust.
 
 Unsafe provider-native attempts to override those managed flags are blocked on
 the managed path.
@@ -114,14 +122,19 @@ Workcell seeds Gemini's trusted-folders state for `/workspace` on the managed
 path so masked ephemeral sessions do not force a restart-based trust prompt.
 `breakglass` restores Gemini's own folder-trust flow.
 
-### Copilot trust and permissions
+### Planned provider trust and permissions
 
 Copilot support must treat permissive CLI options, saved permissions, remote
 control, plugins, hooks, MCP/LSP config, and repository-local Copilot settings
 as managed control-plane inputs. Current releases do not import or trust those
-paths for Copilot because `--agent copilot` is not implemented.
+paths because `--agent copilot` is not implemented.
 
-Future strict-mode support must also scrub Copilot telemetry, OpenTelemetry,
+Antigravity support must do the same once official CLI provenance identifies
+its settings, permission, plugin, MCP, hook, and instruction surfaces. Current
+releases do not import or trust those paths because `--agent antigravity` is
+not implemented.
+
+Future strict-mode support must also scrub provider telemetry, OpenTelemetry,
 and content-capture environment variables by default; any opt-in path must be
 lower assurance, acknowledged, audited, and tested.
 

--- a/docs/enterprise-rollout.md
+++ b/docs/enterprise-rollout.md
@@ -92,24 +92,25 @@ Current caveats:
   fail-closed until a supported export path exists
 - `gcloud_adc` is supplemental to Vertex config, not a standalone Gemini auth
   mode
-- GitHub Copilot CLI is planned for Tier 1 parity but is not supported today;
-  do not distribute host `~/.copilot`, keychain exports, `GH_TOKEN`,
-  `GITHUB_TOKEN`, ambient `gh` auth, or broad GitHub tokens as Workcell inputs
+- GitHub Copilot CLI and Google Antigravity CLI are planned for provider parity
+  but are not supported today; do not distribute their host provider homes,
+  keychain/browser exports, ambient CLI auth, or broad provider tokens as
+  Workcell inputs
 
 See [injection-policy.md](injection-policy.md) for the current by-provider auth
 maturity summary and
 [provider-bootstrap-matrix.md](provider-bootstrap-matrix.md) for the explicit
 repo-required versus manual bootstrap tiers.
 
-The Copilot enterprise rollout gate must document organization policy and
-license prerequisites, token ownership, audit expectations, telemetry/content
-capture posture, and the exact staged-token handoff before any team treats
-Copilot as supported.
+The Copilot and Antigravity enterprise rollout gates must document organization
+policy and license prerequisites, token ownership, audit expectations,
+telemetry/content-capture posture, and the exact staged-token handoff before
+any team treats either provider as supported.
 
-Future strict-mode Copilot support must default-deny Copilot telemetry,
-OpenTelemetry, and content-capture environment variables. Any content-capture
-enablement must be lower assurance, explicitly acknowledged, audited, and
-covered by deterministic tests.
+Future strict-mode Copilot and Antigravity support must default-deny provider
+telemetry, OpenTelemetry, and content-capture environment variables. Any
+content-capture enablement must be lower assurance, explicitly acknowledged,
+audited, and covered by deterministic tests.
 
 ### 4. Scope shared GitHub and SSH inputs deliberately
 

--- a/docs/examples/injection-policy.toml
+++ b/docs/examples/injection-policy.toml
@@ -7,8 +7,8 @@ codex = "/Users/example/.config/workcell/codex-extra.md"
 claude = "/Users/example/.config/workcell/claude-extra.md"
 gemini = "/Users/example/.config/workcell/gemini-extra.md"
 
-# Copilot CLI is intentionally omitted from every `providers` list below
-# until its adapter support lands.
+# Copilot and Antigravity are intentionally omitted from every `providers` list
+# below until their adapter support lands.
 
 [credentials]
 codex_auth = "/Users/example/.codex/auth.json"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,9 +103,10 @@ workcell auth set \
   --source /Users/example/.config/workcell/gemini.env
 ```
 
-GitHub Copilot CLI is not a supported agent yet. Do not configure
-`--agent copilot`, `copilot_github_token`, or host `~/.copilot` state until the
-Copilot adapter support phase lands with matching docs and certification.
+GitHub Copilot CLI and Google Antigravity CLI are not supported agents yet. Do
+not configure `--agent copilot`, `--agent antigravity`, planned credential keys,
+or host provider-home state until the matching adapter support phase lands with
+docs and certification.
 
 Check the host-side view at any time:
 
@@ -155,9 +156,8 @@ workcell --agent codex --agent-autonomy prompt --workspace /path/to/repo
 - [Claude quickstart](examples/quickstart-claude.md)
 - [Gemini quickstart](examples/quickstart-gemini.md)
 
-There is no Copilot quickstart in current releases. Copilot CLI is a planned
-Tier 1 parity provider and will get a quickstart only when support is
-implemented and certified.
+There is no Copilot or Antigravity quickstart in current releases. Each planned
+provider will get a quickstart only when support is implemented and certified.
 
 For team rollout patterns on today's local-first product, see
 [Enterprise rollout today](enterprise-rollout.md).

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -86,6 +86,12 @@ keychains, `GH_TOKEN`, `GITHUB_TOKEN`, ambient `gh auth token`, arbitrary BYOK
 provider env, or whole-home state. The managed child should see only the
 Workcell-staged `COPILOT_GITHUB_TOKEN` on the supported path.
 
+Google Antigravity CLI is also planned, but not launch-ready. Its future path
+must first pin official install and auth provenance, then stage only reviewed
+Google auth material into session-local provider state. Host Google account
+caches, browser profiles, keychains, host homes, and provider caches are not
+acceptable implicit safe-path inputs.
+
 ## Credential keys
 
 | Key | Session target | Notes |
@@ -101,9 +107,9 @@ Workcell-staged `COPILOT_GITHUB_TOKEN` on the supported path.
 | `github_hosts` | `~/.config/gh/hosts.yml` | shared GitHub CLI auth; prefer scoped nested tables |
 | `github_config` | `~/.config/gh/config.yml` | shared GitHub CLI config; prefer scoped nested tables |
 
-`copilot_github_token` is a planned credential key, not a supported key in
-current releases. It must not appear in operator policy until the Copilot
-adapter, validation, and docs land.
+`copilot_github_token` and any future Antigravity credential keys are planned,
+not supported keys in current releases. They must not appear in operator policy
+until the matching adapter, validation, and docs land.
 
 ## Instruction precedence
 
@@ -117,8 +123,10 @@ Provider docs are rendered in this order:
 
 The planned Copilot adapter must separately define how `AGENTS.md`,
 `.github/copilot-instructions.md`, `.github/instructions/**`, and
-`.github/copilot/settings*.json` are imported, masked, or rejected. Current
-releases do not provide Copilot-specific instruction layering.
+`.github/copilot/settings*.json` are imported, masked, or rejected. The planned
+Antigravity adapter must do the same once official CLI provenance identifies
+its instruction, settings, plugin, MCP, and hook files. Current releases do not
+provide provider-specific instruction layering for those planned adapters.
 
 ## Deliberate limits
 
@@ -128,12 +136,11 @@ releases do not provide Copilot-specific instruction layering.
 - no `SSH_AUTH_SOCK` forwarding
 - no assumption that one process inside the session is isolated from another
   process in the same session
-- no host `~/.copilot`, keychain, `GH_TOKEN`, `GITHUB_TOKEN`, ambient
-  `gh auth token`, or broad Copilot token state passthrough on the future
-  Copilot path
-- no Copilot telemetry, OpenTelemetry, or content-capture environment variables
-  in future `strict` mode unless a lower-assurance acknowledged path and
-  deterministic tests are added
+- no host provider-home, keychain, browser-profile, ambient CLI auth, or broad
+  provider token state passthrough on future Copilot or Antigravity paths
+- no provider telemetry, OpenTelemetry, or content-capture environment
+  variables in future `strict` mode unless a lower-assurance acknowledged path
+  and deterministic tests are added
 
 ## Recommended usage
 

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -17,7 +17,10 @@ On the managed path, Workcell does not pass through:
 Reusable auth enters the session only through explicit injection-policy inputs.
 The planned GitHub Copilot CLI adapter must preserve the same invariant for
 host `~/.copilot`, host keychains, `GH_TOKEN`, `GITHUB_TOKEN`, and ambient
-`gh auth token` fallback. Current releases do not support `--agent copilot`.
+`gh auth token` fallback. The planned Google Antigravity CLI adapter must
+preserve it for host Google account caches, browser profiles, keychains, host
+homes, and provider caches. Current releases do not support `--agent copilot`
+or `--agent antigravity`.
 
 ## 2. Writes stay inside the intended workspace
 
@@ -39,7 +42,9 @@ runtime control plane.
 The planned Copilot adapter must explicitly account for Copilot-specific repo
 control-plane files such as `.github/copilot-instructions.md`,
 `.github/instructions/**`, and `.github/copilot/settings*.json` before it can
-claim support.
+claim support. The planned Antigravity adapter must do the same for
+Antigravity-specific settings, plugin, MCP, hook, and instruction files before
+it can claim support.
 
 ## 4. Network posture is explicit
 

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -46,8 +46,8 @@ Before publish, release preflight reruns:
 - authoritative-source verification of the GitHub-hosted Apple Silicon macOS
   release install runner labels
 - upstream pinned Codex, Claude, and Gemini release verification
-- GitHub Copilot CLI upstream pin verification after Copilot becomes a
-  supported adapter
+- GitHub Copilot CLI and Google Antigravity CLI upstream pin verification as
+  part of provider promotion, before any support claim
 - reviewed upstream pin verification across providers, Linux base images,
   Linux toolchains, and release-build helper pins
 - release-bundle install/uninstall and Homebrew install/uninstall verification

--- a/docs/provider-bootstrap-matrix.md
+++ b/docs/provider-bootstrap-matrix.md
@@ -63,6 +63,19 @@ Workcell-staged `COPILOT_GITHUB_TOKEN` path. The row also needs live provider
 certification proving a non-destructive `copilot -p` launch with staged
 credentials.
 
+## Planned Antigravity CLI Bootstrap Track
+
+Google Antigravity CLI is a planned fail-closed provider track, but it has no
+supported bootstrap row yet. Before it can join the current matrix, Workcell
+must pin the official install and auth model, add explicit staged Google auth
+material, and prevent host Google account state, browser profiles, keychains,
+host homes, and provider caches from becoming implicit inputs.
+
+The Antigravity bootstrap row is supportable only after deterministic
+auth-status, policy, bootstrap-summary, control-plane seeding, and
+unsafe-argument tests exist, plus live provider certification with staged
+credentials inside the managed runtime.
+
 ## Remote Target Bootstrap
 
 Preview remote targets also carry an explicit host-side bootstrap contract.
@@ -92,5 +105,5 @@ The bootstrap summary fields also report the remaining operator handoff:
 - [Quickstart: Gemini](examples/quickstart-gemini.md)
 - [Gemini Vertex AI setup](examples/gemini-vertex-setup.md)
 
-There is no Copilot quickstart until Copilot CLI support lands with matching
-adapter, auth, and certification evidence.
+There is no Copilot or Antigravity quickstart until the matching CLI support
+lands with adapter, auth, and certification evidence.

--- a/docs/provider-matrix.md
+++ b/docs/provider-matrix.md
@@ -36,6 +36,7 @@ provider; sequencing is tracked in [ROADMAP.md](../ROADMAP.md).
 | Provider | Planned Tier 1 surface | Planned managed control plane | Planned auth input | Support status |
 |---|---|---|---|---|
 | GitHub Copilot CLI | `workcell --agent copilot --workspace ...` | session-local `COPILOT_HOME`, `COPILOT_CACHE_HOME`, `~/.copilot` config, permissions, sessions, logs, plugins, hooks, MCP/LSP state, and reviewed instruction imports | explicit staged token such as `copilot_github_token`, exported only to the managed child as `COPILOT_GITHUB_TOKEN` | fail-closed scaffold; not current support |
+| Google Antigravity CLI | `workcell --agent antigravity --workspace ...` | session-local provider home/cache, settings, permissions, subagents, plugins, MCP, sandbox state, hooks, and reviewed instruction imports once official CLI provenance is pinned | explicit staged Google auth material, exact key names still pending official install/auth implementation | fail-closed scaffold; not current support |
 
 The current sequencing plan for the Copilot parity track is
 [docs/copilot-linux-local-compat-plan.md](copilot-linux-local-compat-plan.md).
@@ -54,6 +55,11 @@ permissive tool flags such as `--allow-all` and `--yolo`. Workcell treats
 those product surfaces as implementation inputs that must be mapped or blocked
 before support is claimed.
 
+Antigravity support must first pin an official install and auth path from
+Google, then land the same adapter, auth/bootstrap, unsafe-argument,
+control-plane masking, quickstart, scenario, and live-certification evidence
+before any Tier 1 support claim.
+
 For provider auth maturity and rollout caveats, see
 [docs/injection-policy.md](injection-policy.md) and
 [docs/provider-bootstrap-matrix.md](provider-bootstrap-matrix.md).
@@ -65,10 +71,10 @@ For provider auth maturity and rollout caveats, see
 - Tier 3: host-native GUI, cloud, or web-only guidance with no claim of
   equivalent local isolation
 
-Copilot cloud agent, IDE extensions, and host-native Copilot CLI execution are
-Tier 3 unless a future integration makes them clients of the same bounded
-Workcell session plane. The planned support target is the local Copilot CLI
-adapter running inside Tier 1.
+Copilot cloud agent, Copilot IDE extensions, Antigravity desktop or IDE
+surfaces, and host-native provider CLI execution are Tier 3 unless a future
+integration makes them clients of the same bounded Workcell session plane. The
+planned support target is each local provider CLI adapter running inside Tier 1.
 
 Do not force one provider's control model onto another. Keep one shared
 boundary and one thin adapter per product.

--- a/docs/scenario-gaps.md
+++ b/docs/scenario-gaps.md
@@ -46,17 +46,17 @@ more explicit end-to-end scenarios, especially:
 - more end-to-end coverage for Vertex plus `gcloud_adc`
 - more coverage for `breakglass` folder-trust restoration
 
-### Copilot
+### Planned provider adapters
 
-- provider adapter, auth, bootstrap, unsafe-argument, and control-plane seeding
-  coverage after implementation starts
-- live `copilot -p` certification with staged credentials before any support
-  claim
+- Copilot and Antigravity adapter, auth, bootstrap, unsafe-argument, and
+  control-plane seeding coverage after implementation starts
+- live staged-credential certification before any support claim
 
 ## Why these gaps remain acceptable for now
 
 The core repo-required path is covered by invariants, smoke tests, deterministic
 repo validation, reproducibility checks, and tagged release preflight. The open
 gaps are mostly at the edges: live-provider auth, local macOS proof, and
-explicit lower-assurance transitions. Copilot is different: it is a planned
-provider-parity track and remains unsupported until the adapter evidence lands.
+explicit lower-assurance transitions. Copilot and Antigravity are different:
+they are planned provider-parity tracks and remain unsupported until their
+adapter evidence lands.

--- a/docs/use-case-matrix.md
+++ b/docs/use-case-matrix.md
@@ -32,7 +32,7 @@ Workcell workflows.
 | GitHub attestations on tagged releases | tested at release time | `release.yml` publish job |
 | full macOS Colima boundary proof | gap | local certification lane exists, but it is still not repo-required proof |
 | exhaustive live-provider auth UX across all providers | gap | manual provider-e2e path exists, but automation is partial |
-| GitHub Copilot CLI Tier 1 provider parity | planned gap | roadmap and provider docs record the target support bar; no adapter, auth key, quickstart, scenario evidence, or live certification exists yet |
+| GitHub Copilot CLI and Google Antigravity CLI provider parity | planned gap | roadmap and provider docs record the target support bar; no adapter, auth key, quickstart, scenario evidence, or live certification exists yet |
 
 ## Notes
 
@@ -43,4 +43,4 @@ most mature host-side operator surfaces are auth/policy inspection plus
 session inventory, detached control, delete, timeline, export, and
 isolated-workspace remediation. The biggest remaining gaps are local macOS
 boundary proof, deeper end-to-end live-provider coverage, and the planned
-Copilot CLI adapter parity phase.
+Copilot and Antigravity adapter parity phases.

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -41,7 +41,7 @@ Use these anchors when checking release-facing claims:
   enterprise evidence, and host expansion:
   `scripts/verify-requirements-coverage.sh`,
   `scripts/verify-operator-contract.sh`
-- Copilot CLI provider-parity roadmap traceability:
+- planned provider-parity roadmap traceability:
   `ROADMAP.md`, `docs/provider-matrix.md`,
   `docs/provider-bootstrap-matrix.md`
 - Claude hook coverage: `claude-swe/hook-parametric`
@@ -114,11 +114,11 @@ Today that certification tier includes:
   `remote_vm/gcp-vm/compat` preview boundary against a reviewed
   IAP-reachable Compute Engine target without an external NAT IP
 
-The planned Copilot CLI adapter must add live provider certification before it
-claims support. That certification should prove a non-destructive `copilot -p`
-run with staged credentials inside the managed runtime and must stay separate
-from repo-required validation unless it can run deterministically without live
-provider credentials.
+The planned Copilot and Antigravity CLI adapters must add live provider
+certification before they claim support. Certification should prove a
+non-destructive provider prompt run with staged credentials inside the managed
+runtime and must stay separate from repo-required validation unless it can run
+deterministically without live provider credentials.
 
 Remote VM live smoke remains certification-only as well, but it is currently a
 provider-e2e preview gate documented in
@@ -153,8 +153,8 @@ when the repo does not add a dedicated new scenario for each page.
 | `docs/provider-bootstrap-matrix.md` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-policy-commands.sh`, `tests/scenarios/shared/test-codex-resolver-launcher.sh`, `tests/scenarios/shared/test-claude-resolver-launcher.sh` |
 | `docs/examples/enterprise-claude-setup.md` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-policy-commands.sh`, `tests/scenarios/shared/test-publish-pr-dry-run.sh` |
 
-There is no Copilot quickstart row until the Copilot adapter, credential path,
-scenario evidence, and live certification land.
+There is no Copilot or Antigravity quickstart row until the matching adapter,
+credential path, scenario evidence, and live certification land.
 
 ## Manual authenticated smoke
 
@@ -168,8 +168,8 @@ Use it when you need to verify:
 - provider-specific auth selection
 - injected MCP or project-registry behavior
 - provider UX that only shows up with a live account
-- future Copilot CLI behavior that depends on a live staged
-  `COPILOT_GITHUB_TOKEN`
+- future Copilot or Antigravity CLI behavior that depends on live staged
+  provider credentials
 
 ## GitHub CI vs local boundary proof
 

--- a/internal/adapters/data.go
+++ b/internal/adapters/data.go
@@ -6,8 +6,8 @@ package adapters
 import "github.com/omkhar/workcell/internal/providerid"
 
 // providerTables is the per-adapter data shape consumed by the injection
-// and policy paths.  When a new provider lands (e.g. Copilot per ROADMAP)
-// it adds a row to providers below; no new package is required.
+// and policy paths.  When a planned provider lands per ROADMAP, it adds a row
+// to providers below; no new package is required.
 type providerTables struct {
 	credentialKeys           []string
 	credentialContainerPaths map[string]string

--- a/internal/providerid/doc.go
+++ b/internal/providerid/doc.go
@@ -2,8 +2,8 @@
 // Copyright 2026 Omkhar Arasaratnam
 
 // Package providerid is the canonical source of provider id strings. Claude,
-// Codex, and Gemini are supported today; Copilot is a planned fail-closed id
-// until its runtime adapter and certification evidence land.
+// Codex, and Gemini are supported today; Antigravity and Copilot are planned
+// fail-closed ids until their runtime adapters and certification evidence land.
 //
 // Before this package existed, "claude" / "codex" / "gemini" were spelled as
 // raw string literals in 70+ sites across internal/ and cmd/, with three

--- a/internal/providerid/providerid.go
+++ b/internal/providerid/providerid.go
@@ -10,6 +10,10 @@ const (
 	Claude = "claude"
 	// Codex is the OpenAI Codex provider identifier.
 	Codex = "codex"
+	// Antigravity is the Google Antigravity CLI provider identifier. It is a
+	// planned fail-closed adapter, not a member of AllProviders until
+	// runtime support and certification evidence land.
+	Antigravity = "antigravity"
 	// Copilot is the GitHub Copilot CLI provider identifier. It is a
 	// planned fail-closed adapter, not a member of AllProviders until
 	// runtime support and certification evidence land.

--- a/internal/providerid/providerid_test.go
+++ b/internal/providerid/providerid_test.go
@@ -5,11 +5,20 @@ package providerid
 
 import "testing"
 
-func TestCopilotRemainsPlannedUntilCertified(t *testing.T) {
-	if Copilot != "copilot" {
-		t.Fatalf("Copilot = %q, want copilot", Copilot)
-	}
-	if IsValid(Copilot) {
-		t.Fatal("Copilot must stay out of the supported-provider set until runtime support and certification land")
+func TestPlannedProvidersRemainUnsupportedUntilCertified(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "Antigravity", got: Antigravity, want: "antigravity"},
+		{name: "Copilot", got: Copilot, want: "copilot"},
+	} {
+		if tc.got != tc.want {
+			t.Fatalf("%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+		if IsValid(tc.got) {
+			t.Fatalf("%s must stay out of the supported-provider set until runtime support and certification land", tc.name)
+		}
 	}
 }

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -59,8 +59,10 @@ credential.
 Select the provider to run. This option is required.
 The
 .B copilot
-provider id is recognized only as a planned fail-closed adapter; current
-releases exit before runtime preparation because no Copilot runtime, auth
+and
+.B antigravity
+provider ids are recognized only as planned fail-closed adapters; current
+releases exit before runtime preparation because no matching runtime, auth
 handoff, or live certification evidence is shipped.
 .TP
 .B --agent-autonomy yolo|prompt

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "2b081073fe6f5acbc35c8530ca190321cf24e89b3cad05e02a0edcbe6abd27cf"
+      "sha256": "7fdd4ca334ed627fca41ccccc0063fc637baee7121744a7c01226673885680db"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -4143,11 +4143,15 @@ fi
 grep -q "Option --agent is required." /tmp/workcell-missing-agent.out
 grep -q '^Usage: workcell' /tmp/workcell-missing-agent.out
 
-if "${ROOT_DIR}/scripts/workcell" --agent copilot --dry-run >/tmp/workcell-copilot-fail-closed.out 2>&1; then
-  echo "Expected planned Copilot adapter to fail closed until runtime support and certification land" >&2
-  exit 1
-fi
-grep -q "GitHub Copilot CLI is a planned Workcell Tier 1 adapter, but it is not supported yet." /tmp/workcell-copilot-fail-closed.out
+for planned_agent in antigravity copilot; do
+  if "${ROOT_DIR}/scripts/workcell" --agent "${planned_agent}" --dry-run >"/tmp/workcell-${planned_agent}-fail-closed.out" 2>&1; then
+    echo "Expected planned ${planned_agent} adapter to fail closed until runtime support and certification land" >&2
+    exit 1
+  fi
+done
+grep -q "Google Antigravity CLI is a planned Workcell provider adapter, but it is not supported yet." /tmp/workcell-antigravity-fail-closed.out
+grep -q "No Antigravity runtime, auth handoff, or live certification evidence is shipped in this build." /tmp/workcell-antigravity-fail-closed.out
+grep -q "GitHub Copilot CLI is a planned Workcell provider adapter, but it is not supported yet." /tmp/workcell-copilot-fail-closed.out
 grep -q "No Copilot runtime, auth handoff, or live certification evidence is shipped in this build." /tmp/workcell-copilot-fail-closed.out
 
 STRICT_PREFLIGHT_WORKSPACE="${BARRIER_VERIFY_ROOT}/strict-preflight-workspace"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -417,7 +417,7 @@ Usage: workcell [options] [-- provider-args...]
 
 Options:
   --agent codex|claude|gemini   Provider to run (required)
-                              copilot is recognized as planned but unsupported
+                              copilot and antigravity are recognized as planned but unsupported
   --agent-autonomy yolo|prompt  Provider approval posture (default: yolo)
   --agent-arg VALUE             Additional provider argv to append (repeatable)
   --target colima|docker-desktop|aws-ec2-ssm|gcp-vm
@@ -7707,9 +7707,19 @@ fi
 if [[ -n "${AGENT}" ]]; then
   case "${AGENT}" in
     codex | claude | gemini) ;;
-    copilot)
-      echo "GitHub Copilot CLI is a planned Workcell Tier 1 adapter, but it is not supported yet." >&2
-      echo "No Copilot runtime, auth handoff, or live certification evidence is shipped in this build." >&2
+    antigravity | copilot)
+      case "${AGENT}" in
+        antigravity)
+          planned_provider_name="Google Antigravity CLI"
+          planned_runtime_name="Antigravity"
+          ;;
+        copilot)
+          planned_provider_name="GitHub Copilot CLI"
+          planned_runtime_name="Copilot"
+          ;;
+      esac
+      echo "${planned_provider_name} is a planned Workcell provider adapter, but it is not supported yet." >&2
+      echo "No ${planned_runtime_name} runtime, auth handoff, or live certification evidence is shipped in this build." >&2
       exit 2
       ;;
     *)


### PR DESCRIPTION
## Summary

- add `antigravity` as a planned fail-closed provider id without adding it to supported-provider registries, auth maps, runtime wrappers, operator contract, or scenario manifests
- generalize the planned-provider wrapper diagnostic for Copilot and Antigravity while keeping both unsupported
- update public docs, adapter planning docs, invariants, manpage, and control-plane manifest so future provider promotion requires adapter support and live certification evidence first

## Validation

- `bash ./scripts/dev-quick-check.sh`
- `bash ./scripts/verify-invariants.sh`
- `./scripts/pre-merge.sh --profile pr-parity`
- direct `./scripts/workcell --agent antigravity --dry-run` and `--agent copilot --dry-run` fail-closed probes
- four Codex subagent adversarial/simplify review passes clean

## Notes

Claude CLI review was attempted but local Claude authentication still returns `API Error: 401 Invalid authentication credentials`; no token material was printed or committed.
