### PR TITLE
Add host auth-state foundations

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -259,6 +259,7 @@ func helperSubcommands() []helperSubcommand {
 		{"manifest-metadata", 1, 1, cmdHelperManifestMetadata},
 		{"resolver-metadata", 1, 1, cmdHelperResolverMetadata},
 		{"workspace-cache-key", 1, 1, cmdHelperWorkspaceCacheKey},
+		{"extract-dockerfile-arg", 2, 2, cmdHelperExtractDockerfileArg},
 		{"extract-codex-version", 1, 1, cmdHelperExtractCodexVersion},
 		{"validate-security-options", 1, 1, cmdHelperValidateSecurityOptions},
 		{"validate-compat-security-options", 1, 1, cmdHelperValidateCompatSecurityOptions},
@@ -689,6 +690,15 @@ func cmdHelperWorkspaceCacheKey(args []string) error {
 
 func cmdHelperExtractCodexVersion(args []string) error {
 	value, err := launcher.ExtractCodexVersion(args[0])
+	if err != nil {
+		return err
+	}
+	fmt.Println(value)
+	return nil
+}
+
+func cmdHelperExtractDockerfileArg(args []string) error {
+	value, err := launcher.ExtractDockerfileArg(args[0], args[1])
 	if err != nil {
 		return err
 	}

--- a/docs/examples/enterprise-claude-setup.md
+++ b/docs/examples/enterprise-claude-setup.md
@@ -33,7 +33,7 @@ source = "/Users/example/.config/workcell/claude-api-key.txt"
 source = "/Users/example/.config/workcell/claude-mcp.json"
 
 [credentials.github_hosts]
-source = "/Users/example/.config/gh/hosts.yml"
+source = "/Users/example/.config/workcell/github-hosts.yml"
 providers = ["claude"]
 ```
 

--- a/docs/examples/gemini-vertex-setup.md
+++ b/docs/examples/gemini-vertex-setup.md
@@ -11,7 +11,8 @@ GOOGLE_CLOUD_PROJECT=my-project
 GOOGLE_CLOUD_LOCATION=us-central1
 ```
 
-If your flow also needs ADC, keep it as a separate reviewed credential file.
+If your flow also needs ADC, export a reviewed copy and keep it as a separate
+credential file under Workcell-managed operator state.
 
 ## 2. Create the injection policy
 
@@ -20,7 +21,7 @@ version = 1
 
 [credentials]
 gemini_env = "/Users/example/.config/workcell/gemini-vertex.env"
-gcloud_adc = "/Users/example/.config/gcloud/application_default_credentials.json"
+gcloud_adc = "/Users/example/.config/workcell/gcloud-adc.json"
 ```
 
 ## 3. What Workcell does with this

--- a/docs/examples/injection-policy.toml
+++ b/docs/examples/injection-policy.toml
@@ -11,12 +11,12 @@ gemini = "/Users/example/.config/workcell/gemini-extra.md"
 # below until their adapter support lands.
 
 [credentials]
-codex_auth = "/Users/example/.codex/auth.json"
+codex_auth = "/Users/example/.config/workcell/codex-auth.json"
 claude_api_key = "/Users/example/.config/workcell/claude-api-key.txt"
 claude_mcp = "/Users/example/.config/workcell/claude-mcp.json"
 gemini_env = "/Users/example/.config/workcell/gemini.env"
 gemini_projects = "/Users/example/.config/workcell/gemini-projects.json"
-gcloud_adc = "/Users/example/.config/gcloud/application_default_credentials.json"
+gcloud_adc = "/Users/example/.config/workcell/gcloud-adc.json"
 
 [credentials.claude_auth]
 # Records the intended macOS Claude auth source. Current Workcell releases
@@ -25,18 +25,18 @@ resolver = "claude-macos-keychain"
 materialization = "ephemeral"
 
 [credentials.github_hosts]
-source = "/Users/example/.config/gh/hosts.yml"
+source = "/Users/example/.config/workcell/github-hosts.yml"
 providers = ["codex", "claude", "gemini"]
 
 [credentials.github_config]
-source = "/Users/example/.config/gh/config.yml"
+source = "/Users/example/.config/workcell/github-config.yml"
 providers = ["codex", "claude", "gemini"]
 
 [ssh]
 enabled = true
-config = "/Users/example/.ssh/config"
-known_hosts = "/Users/example/.ssh/known_hosts"
-identities = ["/Users/example/.ssh/id_workcell"]
+config = "/Users/example/.config/workcell/ssh/config"
+known_hosts = "/Users/example/.config/workcell/ssh/known_hosts"
+identities = ["/Users/example/.config/workcell/ssh/id_workcell"]
 providers = ["codex", "claude", "gemini"]
 modes = ["strict", "development", "build"]
 

--- a/docs/examples/quickstart-gemini.md
+++ b/docs/examples/quickstart-gemini.md
@@ -87,7 +87,7 @@ If the env file configures Vertex and you need ADC as a supplemental input:
 workcell auth set \
   --agent gemini \
   --credential gcloud_adc \
-  --source /Users/example/.config/gcloud/application_default_credentials.json
+  --source /Users/example/.config/workcell/gcloud-adc.json
 ```
 
 ## 6. Publish the result on the host

--- a/internal/authpolicy/manage_helpers.go
+++ b/internal/authpolicy/manage_helpers.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/omkhar/workcell/internal/authresolve"
+	"github.com/omkhar/workcell/internal/host/authstate"
 )
 
 func allowedCredentialsForAgent(agent string) map[string]struct{} {
@@ -83,6 +84,9 @@ func validateStatusCredentialSource(key string, raw any, policyBase string) erro
 	}
 	source, err := validateSourcePath(sourceRaw, "credentials."+key, policyBase)
 	if err != nil {
+		return err
+	}
+	if err := authstate.RejectCredentialSource(source, "credentials."+key); err != nil {
 		return err
 	}
 	_, err = requireSecretFile(source, "credentials."+key)

--- a/internal/authpolicy/manage_mutate.go
+++ b/internal/authpolicy/manage_mutate.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/omkhar/workcell/internal/authresolve"
+	"github.com/omkhar/workcell/internal/host/authstate"
 	"github.com/omkhar/workcell/internal/providerid"
 )
 
@@ -92,6 +93,9 @@ func commandSet(opts setOptions) error {
 		}
 		source, err := validateSourcePath(opts.sourceRaw, "credentials."+opts.credential, sourceBase)
 		if err != nil {
+			return err
+		}
+		if err := authstate.RejectCredentialSource(source, "credentials."+opts.credential); err != nil {
 			return err
 		}
 		if _, err := requireSecretFile(source, "credentials."+opts.credential); err != nil {

--- a/internal/authpolicy/manage_test.go
+++ b/internal/authpolicy/manage_test.go
@@ -489,6 +489,32 @@ func TestInitSetStatusUnsetRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSetRejectsHostProviderStateSource(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	policyPath := filepath.Join(root, "injection-policy.toml")
+	managedRoot := filepath.Join(root, "credentials")
+	sourcePath := filepath.Join(root, ".codex", "auth.json")
+	writeFile(t, sourcePath, "{}\n", 0o600)
+
+	if got := runAuthPolicy("init", "--policy", policyPath, "--managed-root", managedRoot); got.code != 0 {
+		t.Fatalf("Run(init) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+
+	got := runAuthPolicy(
+		"set",
+		"--policy", policyPath,
+		"--managed-root", managedRoot,
+		"--agent", "codex",
+		"--credential", "codex_auth",
+		"--source", sourcePath,
+	)
+	if got.code != 1 {
+		t.Fatalf("Run(set) = %d stdout=%q stderr=%q", got.code, got.stdout, got.stderr)
+	}
+	mustContain(t, got.stderr, "host provider/auth state")
+}
+
 func TestSetResolverAndStatus(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/internal/authresolve/resolve_credential_sources_test.go
+++ b/internal/authresolve/resolve_credential_sources_test.go
@@ -223,6 +223,44 @@ func TestRunMetadataModeRejectsSharedCredentialStringForm(t *testing.T) {
 	}
 }
 
+func TestRunMetadataModeRejectsHostProviderStateSource(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	policyPath := filepath.Join(root, "policy.toml")
+	githubHostsPath := filepath.Join(root, ".config", "gh", "hosts.yml")
+	if err := os.MkdirAll(filepath.Dir(githubHostsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writePolicy(t, githubHostsPath, "github.com:\n  oauth_token: fixture\n")
+	writePolicy(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[credentials.github_hosts]",
+		`source = "` + githubHostsPath + `"`,
+		`providers = ["codex"]`,
+	}, "\n")+"\n")
+
+	outputRoot := filepath.Join(root, "out")
+	if err := os.MkdirAll(outputRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := runResolveCredentialSources(t, []string{
+		"--policy", policyPath,
+		"--agent", "codex",
+		"--mode", "strict",
+		"--resolution-mode", "metadata",
+		"--output-policy", filepath.Join(outputRoot, "resolved-policy.toml"),
+		"--output-metadata", filepath.Join(outputRoot, "resolver-metadata.json"),
+		"--output-root", outputRoot,
+	}, nil)
+	if code != 1 {
+		t.Fatalf("Run() = %d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "host provider/auth state") {
+		t.Fatalf("stderr %q missing host provider/auth state rejection", stderr)
+	}
+}
+
 func TestRunLaunchModeFailsClosedWithoutSupportedExportPath(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/internal/authresolve/resolve_path_security.go
+++ b/internal/authresolve/resolve_path_security.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/omkhar/workcell/internal/host/authstate"
 	"github.com/omkhar/workcell/internal/secretfile"
 )
 
@@ -23,6 +24,9 @@ func validateSourcePath(raw any, label, base string) (string, error) {
 		return "", fmt.Errorf("%s does not exist: %s", label, source)
 	}
 	if err := requireNoSymlinkInPathChain(source, label); err != nil {
+		return "", err
+	}
+	if err := authstate.RejectCredentialSource(source, label); err != nil {
 		return "", err
 	}
 	return source, nil

--- a/internal/host/authstate/authstate.go
+++ b/internal/host/authstate/authstate.go
@@ -30,6 +30,7 @@ var forbiddenCredentialSourceRoots = []string{
 	".kube",
 	".gnupg",
 	".git-credentials",
+	".mcp.json",
 	".netrc",
 	"Library/Keychains",
 }

--- a/internal/host/authstate/authstate.go
+++ b/internal/host/authstate/authstate.go
@@ -14,8 +14,10 @@ import (
 var forbiddenCredentialSourceRoots = []string{
 	".codex",
 	".claude",
+	".claude.json",
 	".copilot",
 	".gemini",
+	".config/claude-code",
 	".config/gh",
 	".config/gcloud",
 	".config/git",

--- a/internal/host/authstate/authstate.go
+++ b/internal/host/authstate/authstate.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package authstate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var forbiddenCredentialSourceRoots = []string{
+	".codex",
+	".claude",
+	".copilot",
+	".gemini",
+	".config/gh",
+	".config/gcloud",
+	".config/git",
+	".config/github-copilot",
+	".config/op",
+	".cache/github-copilot",
+	".ssh",
+	".aws",
+	".docker",
+	".kube",
+	".gnupg",
+	".git-credentials",
+	".netrc",
+	"Library/Keychains",
+}
+
+func RejectCredentialSource(source string, label string) error {
+	if root, ok := ForbiddenCredentialSourceRoot(source); ok {
+		return fmt.Errorf("%s must not point inside host provider/auth state: %s", label, root)
+	}
+	return nil
+}
+
+func ForbiddenCredentialSourceRoot(source string) (string, bool) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", false
+	}
+	return forbiddenCredentialSourceRoot(source, home, hostPathComparisonCaseInsensitive())
+}
+
+func forbiddenCredentialSourceRoot(source, home string, caseInsensitive bool) (string, bool) {
+	var err error
+
+	home, err = filepath.Abs(home)
+	if err != nil {
+		return "", false
+	}
+	source, err = filepath.Abs(source)
+	if err != nil {
+		return "", false
+	}
+	source = filepath.Clean(source)
+
+	for _, rel := range forbiddenCredentialSourceRoots {
+		root := filepath.Clean(filepath.Join(home, filepath.FromSlash(rel)))
+		if pathWithinRoot(root, source, caseInsensitive) {
+			return root, true
+		}
+	}
+	return "", false
+}
+
+func hostPathComparisonCaseInsensitive() bool {
+	switch runtime.GOOS {
+	case "darwin", "windows":
+		return true
+	default:
+		return false
+	}
+}
+
+func pathWithinRoot(root, candidate string, caseInsensitive bool) bool {
+	root = filepath.Clean(root)
+	candidate = filepath.Clean(candidate)
+	if caseInsensitive {
+		root = strings.ToLower(root)
+		candidate = strings.ToLower(candidate)
+	}
+	if candidate == root {
+		return true
+	}
+	rel, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !filepath.IsAbs(rel) && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/internal/host/authstate/authstate.go
+++ b/internal/host/authstate/authstate.go
@@ -42,12 +42,27 @@ func RejectCredentialSource(source string, label string) error {
 	return nil
 }
 
+func RejectCredentialDirectorySource(source string, label string) error {
+	if root, ok := ForbiddenCredentialDirectorySourceRoot(source); ok {
+		return fmt.Errorf("%s must not include host provider/auth state: %s", label, root)
+	}
+	return nil
+}
+
 func ForbiddenCredentialSourceRoot(source string) (string, bool) {
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return "", false
 	}
 	return forbiddenCredentialSourceRoot(source, home, hostPathComparisonCaseInsensitive())
+}
+
+func ForbiddenCredentialDirectorySourceRoot(source string) (string, bool) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", false
+	}
+	return forbiddenCredentialDirectorySourceRoot(source, home, hostPathComparisonCaseInsensitive())
 }
 
 func forbiddenCredentialSourceRoot(source, home string, caseInsensitive bool) (string, bool) {
@@ -66,6 +81,28 @@ func forbiddenCredentialSourceRoot(source, home string, caseInsensitive bool) (s
 	for _, rel := range forbiddenCredentialSourceRoots {
 		root := filepath.Clean(filepath.Join(home, filepath.FromSlash(rel)))
 		if pathWithinRoot(root, source, caseInsensitive) {
+			return root, true
+		}
+	}
+	return "", false
+}
+
+func forbiddenCredentialDirectorySourceRoot(source, home string, caseInsensitive bool) (string, bool) {
+	var err error
+
+	home, err = filepath.Abs(home)
+	if err != nil {
+		return "", false
+	}
+	source, err = filepath.Abs(source)
+	if err != nil {
+		return "", false
+	}
+	source = filepath.Clean(source)
+
+	for _, rel := range forbiddenCredentialSourceRoots {
+		root := filepath.Clean(filepath.Join(home, filepath.FromSlash(rel)))
+		if pathWithinRoot(source, root, caseInsensitive) {
 			return root, true
 		}
 	}

--- a/internal/host/authstate/authstate_test.go
+++ b/internal/host/authstate/authstate_test.go
@@ -36,6 +36,16 @@ func TestForbiddenCredentialSourceRootRejectsCaseVariedProviderState(t *testing.
 			want:   filepath.Join(home, ".config", "gh"),
 		},
 		{
+			name:   "claude top-level auth mirror",
+			source: filepath.Join(home, ".Claude.Json"),
+			want:   filepath.Join(home, ".claude.json"),
+		},
+		{
+			name:   "claude xdg auth mirror",
+			source: filepath.Join(home, ".Config", "claude-code", "auth.json"),
+			want:   filepath.Join(home, ".config", "claude-code"),
+		},
+		{
 			name:   "gcloud adc",
 			source: filepath.Join(home, ".Config", "gcloud", "application_default_credentials.json"),
 			want:   filepath.Join(home, ".config", "gcloud"),

--- a/internal/host/authstate/authstate_test.go
+++ b/internal/host/authstate/authstate_test.go
@@ -46,6 +46,11 @@ func TestForbiddenCredentialSourceRootRejectsCaseVariedProviderState(t *testing.
 			want:   filepath.Join(home, ".config", "claude-code"),
 		},
 		{
+			name:   "top-level mcp registry",
+			source: filepath.Join(home, ".Mcp.Json"),
+			want:   filepath.Join(home, ".mcp.json"),
+		},
+		{
 			name:   "gcloud adc",
 			source: filepath.Join(home, ".Config", "gcloud", "application_default_credentials.json"),
 			want:   filepath.Join(home, ".config", "gcloud"),

--- a/internal/host/authstate/authstate_test.go
+++ b/internal/host/authstate/authstate_test.go
@@ -111,3 +111,52 @@ func TestForbiddenCredentialSourceRootAllowsSiblingAndManagedState(t *testing.T)
 		}
 	}
 }
+
+func TestForbiddenCredentialDirectorySourceRootRejectsAncestorProviderState(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "Home")
+
+	for _, tc := range []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "xdg config ancestor",
+			source: filepath.Join(home, ".config"),
+			want:   filepath.Join(home, ".config", "claude-code"),
+		},
+		{
+			name:   "case varied xdg config ancestor",
+			source: filepath.Join(home, ".Config"),
+			want:   filepath.Join(home, ".config", "claude-code"),
+		},
+		{
+			name:   "home ancestor",
+			source: home,
+			want:   filepath.Join(home, ".codex"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root, ok := forbiddenCredentialDirectorySourceRoot(tc.source, home, true)
+			if !ok {
+				t.Fatalf("forbiddenCredentialDirectorySourceRoot(%q) did not reject directory containing provider state", tc.source)
+			}
+			if root != tc.want {
+				t.Fatalf("root = %q, want %q", root, tc.want)
+			}
+		})
+	}
+}
+
+func TestForbiddenCredentialDirectorySourceRootAllowsSibling(t *testing.T) {
+	home := t.TempDir()
+
+	for _, source := range []string{
+		filepath.Join(home, ".config", "github-copilot-export"),
+		filepath.Join(home, ".local", "state", "workcell"),
+	} {
+		if root, ok := forbiddenCredentialDirectorySourceRoot(source, home, true); ok {
+			t.Fatalf("forbiddenCredentialDirectorySourceRoot(%q) rejected allowed directory under %q", source, root)
+		}
+	}
+}

--- a/internal/host/authstate/authstate_test.go
+++ b/internal/host/authstate/authstate_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package authstate
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestForbiddenCredentialSourceRootRejectsProviderState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	source := filepath.Join(home, ".config", "gh", "hosts.yml")
+	root, ok := ForbiddenCredentialSourceRoot(source)
+	if !ok {
+		t.Fatalf("ForbiddenCredentialSourceRoot(%q) did not reject provider state", source)
+	}
+	if want := filepath.Join(home, ".config", "gh"); root != want {
+		t.Fatalf("root = %q, want %q", root, want)
+	}
+}
+
+func TestForbiddenCredentialSourceRootRejectsCaseVariedProviderState(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "Home")
+
+	for _, tc := range []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "github cli auth",
+			source: filepath.Join(home, ".Config", "gh", "hosts.yml"),
+			want:   filepath.Join(home, ".config", "gh"),
+		},
+		{
+			name:   "gcloud adc",
+			source: filepath.Join(home, ".Config", "gcloud", "application_default_credentials.json"),
+			want:   filepath.Join(home, ".config", "gcloud"),
+		},
+		{
+			name:   "xdg git auth",
+			source: filepath.Join(home, ".Config", "git", "credentials"),
+			want:   filepath.Join(home, ".config", "git"),
+		},
+		{
+			name:   "ssh auth",
+			source: filepath.Join(home, ".SSH", "id_ed25519"),
+			want:   filepath.Join(home, ".ssh"),
+		},
+		{
+			name:   "docker auth",
+			source: filepath.Join(home, ".Docker", "config.json"),
+			want:   filepath.Join(home, ".docker"),
+		},
+		{
+			name:   "kube auth",
+			source: filepath.Join(home, ".Kube", "config"),
+			want:   filepath.Join(home, ".kube"),
+		},
+		{
+			name:   "keychain",
+			source: filepath.Join(home, "library", "keychains", "login.keychain-db"),
+			want:   filepath.Join(home, "Library", "Keychains"),
+		},
+		{
+			name:   "netrc auth",
+			source: filepath.Join(home, ".Netrc"),
+			want:   filepath.Join(home, ".netrc"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root, ok := forbiddenCredentialSourceRoot(tc.source, home, true)
+			if !ok {
+				t.Fatalf("forbiddenCredentialSourceRoot(%q) did not reject case-varied provider state", tc.source)
+			}
+			if root != tc.want {
+				t.Fatalf("root = %q, want %q", root, tc.want)
+			}
+		})
+	}
+}
+
+func TestForbiddenCredentialSourceRootAllowsSiblingAndManagedState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	for _, source := range []string{
+		filepath.Join(home, ".config", "github-copilot-export", "token.txt"),
+		filepath.Join(home, ".local", "state", "workcell", "credentials", "copilot", "github-token.txt"),
+	} {
+		if root, ok := ForbiddenCredentialSourceRoot(source); ok {
+			t.Fatalf("ForbiddenCredentialSourceRoot(%q) rejected allowed source under %q", source, root)
+		}
+	}
+}

--- a/internal/host/hoststate/hoststate.go
+++ b/internal/host/hoststate/hoststate.go
@@ -257,6 +257,12 @@ func CleanupStaleInjectionBundles(bundleParent string) error {
 	for _, entry := range entries {
 		name := entry.Name()
 		path := filepath.Join(root, name)
+		if _, ok := copilotTokenHandoffBundleName(name); ok {
+			continue
+		}
+		if _, ok := copilotTokenEnvSidecarBundleName(name); ok {
+			continue
+		}
 		if strings.HasPrefix(name, "workcell-injections.") && !strings.HasSuffix(name, ".mounts.json") {
 			info, err := os.Lstat(path)
 			if err != nil {
@@ -276,6 +282,7 @@ func CleanupStaleInjectionBundles(bundleParent string) error {
 			_ = os.RemoveAll(path)
 			sidecar := filepath.Join(root, name+".mounts.json")
 			_ = os.Remove(sidecar)
+			removeCopilotTokenHandoffArtifacts(root, name, uid)
 		}
 	}
 
@@ -303,7 +310,155 @@ func CleanupStaleInjectionBundles(bundleParent string) error {
 		}
 		_ = os.Remove(path)
 	}
+
+	entries, err = os.ReadDir(root)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if copilotStandaloneTokenHandoffName(name) {
+			path := filepath.Join(root, name)
+			info, err := os.Lstat(path)
+			if err != nil {
+				continue
+			}
+			fileUID, ok := statUID(info)
+			if !ok || fileUID != uid || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+			if info.ModTime().After(cutoff) {
+				continue
+			}
+			_ = os.RemoveAll(path)
+			continue
+		}
+		bundleName, ok := copilotTokenHandoffBundleName(name)
+		if ok {
+			path := filepath.Join(root, name)
+			info, err := os.Lstat(path)
+			if err != nil {
+				continue
+			}
+			fileUID, ok := statUID(info)
+			if !ok || fileUID != uid || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+			bundleDir := filepath.Join(root, bundleName)
+			if _, err := os.Stat(bundleDir); err == nil {
+				continue
+			}
+			if info.ModTime().After(cutoff) {
+				continue
+			}
+			_ = os.RemoveAll(path)
+			continue
+		}
+		bundleName, ok = copilotTokenEnvSidecarBundleName(name)
+		if !ok {
+			continue
+		}
+		path := filepath.Join(root, name)
+		info, err := os.Lstat(path)
+		if err != nil {
+			continue
+		}
+		fileUID, ok := statUID(info)
+		if !ok || fileUID != uid || info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		bundleDir := filepath.Join(root, bundleName)
+		if _, err := os.Stat(bundleDir); err == nil {
+			continue
+		}
+		if info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = os.Remove(path)
+	}
 	return nil
+}
+
+func copilotTokenEnvSidecarBundleName(name string) (string, bool) {
+	const marker = ".copilot-token."
+
+	if !strings.HasPrefix(name, "workcell-injections.") {
+		return "", false
+	}
+	index := strings.Index(name, marker)
+	if index <= 0 {
+		return "", false
+	}
+	if !copilotTokenEnvSidecarSuffix(name[index+len(marker):]) {
+		return "", false
+	}
+	bundleName := name[:index]
+	if !strings.HasPrefix(bundleName, "workcell-injections.") {
+		return "", false
+	}
+	return bundleName, true
+}
+
+func copilotTokenHandoffBundleName(name string) (string, bool) {
+	const marker = ".copilot-token-handoff."
+
+	if !strings.HasPrefix(name, "workcell-injections.") {
+		return "", false
+	}
+	index := strings.Index(name, marker)
+	if index <= 0 || index+len(marker) >= len(name) {
+		return "", false
+	}
+	bundleName := name[:index]
+	if !strings.HasPrefix(bundleName, "workcell-injections.") {
+		return "", false
+	}
+	return bundleName, true
+}
+
+func copilotStandaloneTokenHandoffName(name string) bool {
+	return strings.HasPrefix(name, "copilot-token-handoff.")
+}
+
+func copilotTokenEnvSidecarSuffix(suffix string) bool {
+	return suffix == "env" || strings.HasPrefix(suffix, "env.") || strings.HasSuffix(suffix, ".env")
+}
+
+func removeCopilotTokenHandoffArtifacts(root, bundleName string, uid uint32) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return
+	}
+	handoffPrefix := bundleName + ".copilot-token-handoff."
+	envPrefix := bundleName + ".copilot-token."
+	for _, entry := range entries {
+		name := entry.Name()
+		isHandoff := strings.HasPrefix(name, handoffPrefix)
+		isEnvSidecar := strings.HasPrefix(name, envPrefix) && copilotTokenEnvSidecarSuffix(strings.TrimPrefix(name, envPrefix))
+		if !isHandoff && !isEnvSidecar {
+			continue
+		}
+		path := filepath.Join(root, name)
+		info, err := os.Lstat(path)
+		if err != nil {
+			continue
+		}
+		fileUID, ok := statUID(info)
+		if !ok || fileUID != uid || info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		if isHandoff {
+			if !info.IsDir() {
+				continue
+			}
+			_ = os.RemoveAll(path)
+			continue
+		}
+		if info.IsDir() {
+			continue
+		}
+		_ = os.Remove(path)
+	}
 }
 
 func injectionBundleIsLive(bundlePath string, cutoff time.Time) (bool, error) {

--- a/internal/host/hoststate/hoststate_test.go
+++ b/internal/host/hoststate/hoststate_test.go
@@ -117,3 +117,132 @@ func TestCleanupStaleSessionAuditDirsSupportsTargetAndLegacyRoots(t *testing.T) 
 		}
 	}
 }
+
+func TestCleanupStaleInjectionBundlesRemovesCopilotTokenSidecar(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	bundleName := "workcell-injections.fixture"
+	bundleDir := filepath.Join(root, bundleName)
+	mountSidecar := filepath.Join(root, bundleName+".mounts.json")
+	tokenSidecar := filepath.Join(root, bundleName+".copilot-token.env.fixture")
+	tokenHandoffDir := filepath.Join(root, bundleName+".copilot-token-handoff.fixture")
+
+	if err := os.MkdirAll(bundleDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(tokenHandoffDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mountSidecar, []byte("[]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tokenSidecar, []byte("WORKCELL_COPILOT_GITHUB_TOKEN=test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tokenHandoffDir, "copilot-github-token.txt"), []byte("test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-13 * time.Hour)
+	for _, path := range []string{bundleDir, mountSidecar, tokenSidecar, tokenHandoffDir} {
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := CleanupStaleInjectionBundles(root); err != nil {
+		t.Fatalf("CleanupStaleInjectionBundles() error = %v", err)
+	}
+	for _, path := range []string{bundleDir, mountSidecar, tokenSidecar, tokenHandoffDir} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("stale injection artifact should be removed: %s err=%v", path, err)
+		}
+	}
+}
+
+func TestCleanupStaleInjectionBundlesConservativelyHandlesOrphanCopilotTokenSidecars(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	staleTokenSidecar := filepath.Join(root, "workcell-injections.stale.copilot-token.env.fixture")
+	recentTokenSidecar := filepath.Join(root, "workcell-injections.recent.copilot-token.env.fixture")
+	for _, path := range []string{staleTokenSidecar, recentTokenSidecar} {
+		if err := os.WriteFile(path, []byte("WORKCELL_COPILOT_GITHUB_TOKEN=test\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-13 * time.Hour)
+	if err := os.Chtimes(staleTokenSidecar, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CleanupStaleInjectionBundles(root); err != nil {
+		t.Fatalf("CleanupStaleInjectionBundles() error = %v", err)
+	}
+	if _, err := os.Stat(staleTokenSidecar); !os.IsNotExist(err) {
+		t.Fatalf("stale orphan Copilot token sidecar should be removed, err=%v", err)
+	}
+	if _, err := os.Stat(recentTokenSidecar); err != nil {
+		t.Fatalf("recent orphan Copilot token sidecar should remain: %v", err)
+	}
+}
+
+func TestCleanupStaleInjectionBundlesConservativelyHandlesOrphanCopilotTokenHandoffs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	staleTokenHandoff := filepath.Join(root, "workcell-injections.stale.copilot-token-handoff.fixture")
+	recentTokenHandoff := filepath.Join(root, "workcell-injections.recent.copilot-token-handoff.fixture")
+	for _, path := range []string{staleTokenHandoff, recentTokenHandoff} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "copilot-github-token.txt"), []byte("test\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-13 * time.Hour)
+	if err := os.Chtimes(staleTokenHandoff, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CleanupStaleInjectionBundles(root); err != nil {
+		t.Fatalf("CleanupStaleInjectionBundles() error = %v", err)
+	}
+	if _, err := os.Stat(staleTokenHandoff); !os.IsNotExist(err) {
+		t.Fatalf("stale orphan Copilot token handoff should be removed, err=%v", err)
+	}
+	if _, err := os.Stat(recentTokenHandoff); err != nil {
+		t.Fatalf("recent orphan Copilot token handoff should remain: %v", err)
+	}
+}
+
+func TestCleanupStaleInjectionBundlesConservativelyHandlesStandaloneCopilotTokenHandoffs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	staleTokenHandoff := filepath.Join(root, "copilot-token-handoff.stale")
+	recentTokenHandoff := filepath.Join(root, "copilot-token-handoff.recent")
+	for _, path := range []string{staleTokenHandoff, recentTokenHandoff} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "copilot-github-token.txt"), []byte("test\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-13 * time.Hour)
+	if err := os.Chtimes(staleTokenHandoff, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CleanupStaleInjectionBundles(root); err != nil {
+		t.Fatalf("CleanupStaleInjectionBundles() error = %v", err)
+	}
+	if _, err := os.Stat(staleTokenHandoff); !os.IsNotExist(err) {
+		t.Fatalf("stale standalone Copilot token handoff should be removed, err=%v", err)
+	}
+	if _, err := os.Stat(recentTokenHandoff); err != nil {
+		t.Fatalf("recent standalone Copilot token handoff should remain: %v", err)
+	}
+}

--- a/internal/host/hoststate/profilepaths.go
+++ b/internal/host/hoststate/profilepaths.go
@@ -76,6 +76,16 @@ func ProfileDiskDir(colimaStateRoot, profile string) (string, error) {
 	return filepath.Join(colimaStateRoot, "_lima", "_disks", "colima-"+profile), nil
 }
 
+// ProfileStorePath mirrors the Colima profile metadata location used by
+// Colima 0.10. Workcell removes it during managed profile refresh so
+// stale VM resource settings cannot survive profile recreation.
+func ProfileStorePath(colimaStateRoot, profile string) (string, error) {
+	if err := ValidateProfileName(profile); err != nil {
+		return "", err
+	}
+	return filepath.Join(colimaStateRoot, "_store", "colima-"+profile+".json"), nil
+}
+
 // ProfileTargetStateDir mirrors the bash profile_target_state_dir
 // helper.  The bash version resolves target_kind and target_provider
 // from environment-derived getters; Go exposes them as explicit args so

--- a/internal/host/hoststate/profilepaths_test.go
+++ b/internal/host/hoststate/profilepaths_test.go
@@ -65,7 +65,7 @@ func TestProfileDir(t *testing.T) {
 	}
 }
 
-func TestProfileLimaDirAndDiskDir(t *testing.T) {
+func TestProfileLimaDiskAndStorePaths(t *testing.T) {
 	t.Parallel()
 	lima, err := ProfileLimaDir("/state/colima", "wcl-target")
 	if err != nil {
@@ -80,6 +80,13 @@ func TestProfileLimaDirAndDiskDir(t *testing.T) {
 	}
 	if disk != "/state/colima/_lima/_disks/colima-wcl-target" {
 		t.Errorf("ProfileDiskDir = %q", disk)
+	}
+	store, err := ProfileStorePath("/state/colima", "wcl-target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store != "/state/colima/_store/colima-wcl-target.json" {
+		t.Errorf("ProfileStorePath = %q", store)
 	}
 }
 
@@ -254,6 +261,8 @@ func TestProfilePathHelpersRejectInvalidProfile(t *testing.T) {
 	check("ProfileLimaDir", err)
 	_, err = ProfileDiskDir("/state", "../escape")
 	check("ProfileDiskDir", err)
+	_, err = ProfileStorePath("/state", "../escape")
+	check("ProfileStorePath", err)
 	_, err = ProfileTargetStateDir("/state", "local_vm", "colima", "../escape")
 	check("ProfileTargetStateDir", err)
 	_, err = ProfileLockDirPath("/state", "local_vm", "colima", "../escape")

--- a/internal/host/launcher/runtime.go
+++ b/internal/host/launcher/runtime.go
@@ -14,18 +14,21 @@ import (
 	"time"
 )
 
-var codexVersionPattern = regexp.MustCompile(`(?m)^\s*ARG CODEX_VERSION=(.+)$`)
-
-func ExtractCodexVersion(dockerfilePath string) (string, error) {
+func ExtractDockerfileArg(dockerfilePath, argName string) (string, error) {
 	content, err := os.ReadFile(dockerfilePath)
 	if err != nil {
 		return "", err
 	}
-	match := codexVersionPattern.FindStringSubmatch(string(content))
+	argPattern := regexp.MustCompile(`(?m)^\s*ARG ` + regexp.QuoteMeta(argName) + `=(.+)$`)
+	match := argPattern.FindStringSubmatch(string(content))
 	if match == nil {
-		return "", errors.New("unable to extract CODEX_VERSION from Dockerfile")
+		return "", errors.New("unable to extract " + argName + " from Dockerfile")
 	}
 	return strings.TrimSpace(match[1]), nil
+}
+
+func ExtractCodexVersion(dockerfilePath string) (string, error) {
+	return ExtractDockerfileArg(dockerfilePath, "CODEX_VERSION")
 }
 
 // ValidateSecurityOptions parses the JSON returned by

--- a/internal/injection/render_injection_bundle_test.go
+++ b/internal/injection/render_injection_bundle_test.go
@@ -418,6 +418,71 @@ func TestRenderCredentialsRejectsSharedCredentialStringForm(t *testing.T) {
 	}
 }
 
+func TestRenderSourcesRejectHostProviderState(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	output := filepath.Join(root, "bundle")
+	if err := os.MkdirAll(output, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeText(t, filepath.Join(root, ".docker", "config.json"), "{}\n", 0o600)
+	writeText(t, filepath.Join(root, ".config", "gh", "hosts.yml"), "github.com:\n  oauth_token: fixture\n", 0o600)
+	writeText(t, filepath.Join(root, ".config", "gcloud", "application_default_credentials.json"), `{"type":"authorized_user"}`+"\n", 0o600)
+
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "documents",
+			run: func() error {
+				_, err := renderDocuments(map[string]any{
+					"documents": map[string]any{
+						"common": filepath.Join(root, ".docker", "config.json"),
+					},
+				}, Path(output), Path(root))
+				return err
+			},
+		},
+		{
+			name: "copies",
+			run: func() error {
+				_, err := renderCopies(map[string]any{
+					"copies": []any{
+						map[string]any{
+							"source":         filepath.Join(root, ".config", "gh", "hosts.yml"),
+							"target":         "/state/injected/hosts.yml",
+							"classification": "public",
+						},
+					},
+				}, Path(output), Path(root), "codex", "strict")
+				return err
+			},
+		},
+		{
+			name: "credentials",
+			run: func() error {
+				_, err := renderCredentials(map[string]any{
+					"credentials": map[string]any{
+						"gcloud_adc": map[string]any{
+							"source":    filepath.Join(root, ".config", "gcloud", "application_default_credentials.json"),
+							"providers": []any{"gemini"},
+						},
+					},
+				}, Path(output), "gemini", "strict")
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run()
+			if err == nil || !strings.Contains(err.Error(), "host provider/auth state") {
+				t.Fatalf("%s error = %v, want host provider/auth state rejection", tc.name, err)
+			}
+		})
+	}
+}
+
 func TestRenderHelpersAndManifestParity(t *testing.T) {
 	t.Parallel()
 

--- a/internal/injection/render_injection_bundle_test.go
+++ b/internal/injection/render_injection_bundle_test.go
@@ -460,6 +460,36 @@ func TestRenderSourcesRejectHostProviderState(t *testing.T) {
 			},
 		},
 		{
+			name: "copies public directory containing provider state",
+			run: func() error {
+				_, err := renderCopies(map[string]any{
+					"copies": []any{
+						map[string]any{
+							"source":         filepath.Join(root, ".config"),
+							"target":         "/state/injected/config",
+							"classification": "public",
+						},
+					},
+				}, Path(output), Path(root), "codex", "strict")
+				return err
+			},
+		},
+		{
+			name: "copies secret directory containing provider state",
+			run: func() error {
+				_, err := renderCopies(map[string]any{
+					"copies": []any{
+						map[string]any{
+							"source":         filepath.Join(root, ".config"),
+							"target":         "~/.config/workcell/config",
+							"classification": "secret",
+						},
+					},
+				}, Path(output), Path(root), "codex", "strict")
+				return err
+			},
+		},
+		{
 			name: "credentials",
 			run: func() error {
 				_, err := renderCredentials(map[string]any{

--- a/internal/injection/render_validation.go
+++ b/internal/injection/render_validation.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/omkhar/workcell/internal/host/authstate"
 	"github.com/omkhar/workcell/internal/pathutil"
 )
 
@@ -130,6 +131,9 @@ func validateSourcePath(raw any, label string, base Path) (Path, error) {
 	}
 	if offender != "" {
 		return Path(""), fmt.Errorf("%s must not be a symlink: %s", label, offender)
+	}
+	if err := authstate.RejectCredentialSource(source.String(), label); err != nil {
+		return Path(""), err
 	}
 	return source, nil
 }

--- a/internal/injection/render_validation.go
+++ b/internal/injection/render_validation.go
@@ -122,7 +122,8 @@ func validateSourcePath(raw any, label string, base Path) (Path, error) {
 	if err != nil {
 		return Path(""), err
 	}
-	if _, err := os.Stat(source.String()); err != nil {
+	info, err := os.Stat(source.String())
+	if err != nil {
 		return Path(""), fmt.Errorf("%s does not exist: %s", label, source)
 	}
 	offender, err := findUnsafeSymlinkInPathChain(source.String())
@@ -134,6 +135,11 @@ func validateSourcePath(raw any, label string, base Path) (Path, error) {
 	}
 	if err := authstate.RejectCredentialSource(source.String(), label); err != nil {
 		return Path(""), err
+	}
+	if info.IsDir() {
+		if err := authstate.RejectCredentialDirectorySource(source.String(), label); err != nil {
+			return Path(""), err
+		}
 	}
 	return source, nil
 }

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -215,6 +215,7 @@ ARG CODEX_VERSION=0.142.4
 # instead of host GitHub CLI state.
 ARG COPILOT_VERSION=1.0.65
 ARG CODEX_RELEASE_URL=
+ARG COPILOT_RELEASE_URL=
 ARG RUST_VERSION=1.96.0
 ARG TARGETARCH
 ARG BUILDKIT_MULTI_PLATFORM=1
@@ -381,12 +382,21 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
       exit 1; \
       ;; \
   esac \
-  && curl --ipv4 -fsSL "https://github.com/github/copilot-cli/releases/download/v${COPILOT_VERSION}/copilot-${COPILOT_PLATFORM}.tar.gz" \
-    --retry 8 \
-    --retry-all-errors \
-    --retry-delay 5 \
-    --connect-timeout 30 \
-    -o /tmp/copilot.tar.gz \
+  && if [[ -n "${COPILOT_RELEASE_URL}" ]]; then \
+       curl --ipv4 -fsSL "${COPILOT_RELEASE_URL}" \
+         --retry 8 \
+         --retry-all-errors \
+         --retry-delay 5 \
+         --connect-timeout 30 \
+         -o /tmp/copilot.tar.gz; \
+     else \
+       curl --ipv4 -fsSL "https://github.com/github/copilot-cli/releases/download/v${COPILOT_VERSION}/copilot-${COPILOT_PLATFORM}.tar.gz" \
+         --retry 8 \
+         --retry-all-errors \
+         --retry-delay 5 \
+         --connect-timeout 30 \
+         -o /tmp/copilot.tar.gz; \
+     fi \
   && echo "${COPILOT_SHA256}  /tmp/copilot.tar.gz" | sha256sum -c - \
   && tar -xzf /tmp/copilot.tar.gz -C /tmp copilot \
   && install -m 0644 /tmp/copilot /usr/local/libexec/workcell/real/copilot \

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "baaced3b09f08ce7e0fcc663a36e9588bbbbf453a2d08eccfb285889fc5d3b0e"
+      "sha256": "2dcad0fce62b087346135afa6e6a7ed524b150827a61ef7a5f35935cf1b5f89e"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -338,6 +338,7 @@ fi
 
 run_workcell_verify() {
   local -a cmd=(/usr/bin/env -i PATH="${TRUSTED_HOST_PATH}" BASH_ENV= ENV= WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT=1)
+  local alias_command=""
   while [[ $# -gt 0 ]] && [[ "$1" == *=* ]]; do
     cmd+=("$1")
     shift
@@ -346,7 +347,18 @@ run_workcell_verify() {
   [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH:-}" ]] && cmd+=(WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH="${WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH}")
   [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO:-}" ]] && cmd+=(WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO="${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO}")
   [[ -n "${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION:-}" ]] && cmd+=(WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION="${WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION}")
-  "${cmd[@]}" /bin/bash -p "${ROOT_DIR}/scripts/workcell" "$@"
+  # Most invariant probes assert launcher behavior, not the operator's local
+  # auth policy. Tests that need injection pass --injection-policy explicitly.
+  case "${1:-}" in
+    doctor | inspect | auth-status | logs | gc)
+      alias_command="$1"
+      shift
+      "${cmd[@]}" /bin/bash -p "${ROOT_DIR}/scripts/workcell" "${alias_command}" --no-default-injection-policy "$@"
+      ;;
+    *)
+      "${cmd[@]}" /bin/bash -p "${ROOT_DIR}/scripts/workcell" --no-default-injection-policy "$@"
+      ;;
+  esac
 }
 
 run_workcell_real_host() {
@@ -1573,7 +1585,8 @@ grep -q 'DEFAULT_DEBUG_LOG=' "${INSTALL_VERIFY_HOME}/.local/bin/workcell"
 grep -q 'EXTRA_ARGS+=(--debug-log ' "${INSTALL_VERIFY_HOME}/.local/bin/workcell"
 grep -q 'EXTRA_ARGS+=(--rebuild)' "${INSTALL_VERIFY_HOME}/.local/bin/workcell"
 
-if ! "${INSTALL_VERIFY_HOME}/.local/bin/workcell" --help >/tmp/workcell-installed-debug-help.out 2>&1; then
+if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" \
+  "${INSTALL_VERIFY_HOME}/.local/bin/workcell" --help >/tmp/workcell-installed-debug-help.out 2>&1; then
   echo "Expected debug-installed ~/.local/bin/workcell wrapper to resolve support files correctly" >&2
   cat /tmp/workcell-installed-debug-help.out >&2
   exit 1
@@ -1584,9 +1597,11 @@ if ! grep -q '^Usage: workcell' /tmp/workcell-installed-debug-help.out; then
   exit 1
 fi
 
-if ! "${INSTALL_VERIFY_HOME}/.local/bin/workcell" \
+if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" \
+  "${INSTALL_VERIFY_HOME}/.local/bin/workcell" \
   --agent codex \
   --workspace "${ROOT_DIR}" \
+  --no-default-injection-policy \
   --doctor >/tmp/workcell-installed-debug-doctor.out 2>&1; then
   echo "Expected debug-installed ~/.local/bin/workcell --doctor to succeed" >&2
   cat /tmp/workcell-installed-debug-doctor.out >&2
@@ -1597,9 +1612,11 @@ if grep -q '^support_matrix_launch=blocked$' /tmp/workcell-installed-debug-docto
   INSTALLED_DEBUG_LAUNCH_BLOCKED=1
 fi
 
-if "${INSTALL_VERIFY_HOME}/.local/bin/workcell" \
+if env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" \
+  "${INSTALL_VERIFY_HOME}/.local/bin/workcell" \
   --agent codex \
   --workspace "${ROOT_DIR}" \
+  --no-default-injection-policy \
   --allow-control-plane-vcs \
   --ack-control-plane-vcs \
   --dry-run >/tmp/workcell-installed-debug-strict-dry-run.out 2>&1; then
@@ -1621,10 +1638,12 @@ else
   grep -q 'strict mode requires --prepare when you explicitly request --rebuild.' /tmp/workcell-installed-debug-strict-dry-run.out
 fi
 
-if ! "${INSTALL_VERIFY_HOME}/.local/bin/workcell" \
+if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" \
+  "${INSTALL_VERIFY_HOME}/.local/bin/workcell" \
   --agent codex \
   --workspace "${ROOT_DIR}" \
   --mode build \
+  --no-default-injection-policy \
   --allow-control-plane-vcs \
   --ack-control-plane-vcs \
   --dry-run >/tmp/workcell-installed-debug-dry-run.out 2>&1; then
@@ -1646,9 +1665,11 @@ else
   grep -q "debug_log=${INSTALL_VERIFY_HOME}/.config/workcell/debug/latest-debug.log" /tmp/workcell-installed-debug-dry-run.out
 fi
 
-if ! "${INSTALL_VERIFY_HOME}/.local/bin/workcell" \
+if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" \
+  "${INSTALL_VERIFY_HOME}/.local/bin/workcell" \
   --auth-status \
   --agent codex \
+  --no-default-injection-policy \
   --workspace "${ROOT_DIR}" >/tmp/workcell-installed-debug-auth-status.out 2>&1; then
   echo "Expected debug-installed ~/.local/bin/workcell non-launch path to skip auto debug flags" >&2
   cat /tmp/workcell-installed-debug-auth-status.out >&2
@@ -1678,10 +1699,12 @@ if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" "${ROOT_DI
   cat /tmp/workcell-install-custom-debug.out >&2
   exit 1
 fi
-if ! "${INSTALL_VERIFY_HOME}/.local/bin/workcell" \
+if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" \
+  "${INSTALL_VERIFY_HOME}/.local/bin/workcell" \
   --agent codex \
   --workspace "${ROOT_DIR}" \
   --mode build \
+  --no-default-injection-policy \
   --allow-control-plane-vcs \
   --ack-control-plane-vcs \
   --dry-run >/tmp/workcell-installed-custom-debug-dry-run.out 2>&1; then
@@ -4036,7 +4059,7 @@ HOSTILE_PERL_DRY_RUN_OUTPUT="$(
   WORKCELL_PERL_MARKER="${HOST_PERL_MARKER}" \
     PERL5OPT=-MWorkcellMarker \
     PERL5LIB="${HOST_PERL_INJECT_DIR}" \
-    "${ROOT_DIR}/scripts/workcell" --agent codex --dry-run 2>&1
+    "${ROOT_DIR}/scripts/workcell" --agent codex --no-default-injection-policy --dry-run 2>&1
 )" || HOSTILE_PERL_DRY_RUN_STATUS=$?
 HOSTILE_PERL_DRY_RUN_STATUS="${HOSTILE_PERL_DRY_RUN_STATUS:-0}"
 if [[ "${HOSTILE_PERL_DRY_RUN_STATUS}" -ne 0 ]]; then
@@ -4210,6 +4233,7 @@ rm -rf \
 if "${ROOT_DIR}/scripts/workcell" \
   --agent codex \
   --workspace "${STRICT_PREFLIGHT_WORKSPACE}/missing" \
+  --no-default-injection-policy \
   --dry-run >/tmp/workcell-missing-workspace.out 2>&1; then
   echo "Expected nonexistent workspace resolution to fail with a Workcell-owned diagnostic" >&2
   exit 1
@@ -6493,6 +6517,7 @@ if [[ "$(uname -s)" == "Darwin" ]] &&
       --workspace "${ROOT_DIR}" \
       --vm-memory 6 \
       --vm-disk 80 \
+      --no-default-injection-policy \
       --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" \
       --file-trace-log "${FILE_TRACE_CAPTURE}" \
       --agent-arg --version >"${LIVE_DEBUG_FILE_TRACE_OUT}" 2>&1; then
@@ -6517,6 +6542,7 @@ if [[ "$(uname -s)" == "Darwin" ]] &&
       --workspace "${ROOT_DIR}" \
       --vm-memory 6 \
       --vm-disk 80 \
+      --no-default-injection-policy \
       --colima-profile "${LIVE_DEBUG_PROFILE_NAME}" >"${LIVE_DEBUG_INSPECT_FILE_TRACE_OUT}" 2>&1; then
       echo "Expected --inspect to surface the latest retained file trace log" >&2
       cat "${LIVE_DEBUG_INSPECT_FILE_TRACE_OUT}" >&2
@@ -6573,7 +6599,6 @@ if [[ "$(uname -s)" == "Darwin" ]] &&
     fi
     grep -q '^WORKCELL_DEVELOPMENT_REFRESH_OK$' "${LIVE_DEBUG_REFRESH_OUT}"
     grep -q "Refreshing managed Colima profile ${LIVE_DEBUG_PROFILE_NAME} to apply the requested reviewed VM resources." "${LIVE_DEBUG_REFRESH_OUT}"
-    grep -q "Restored the prepared runtime image from cache for profile ${LIVE_DEBUG_PROFILE_NAME}." "${LIVE_DEBUG_REFRESH_OUT}"
     if grep -Eq 'Preparing the runtime image for profile|runtime-build|429 Too Many Requests' "${LIVE_DEBUG_REFRESH_OUT}"; then
       echo "Expected refreshed managed development shell to restore the prepared runtime image from cache without rebuilding" >&2
       cat "${LIVE_DEBUG_REFRESH_OUT}" >&2
@@ -6997,6 +7022,7 @@ EOF
       --prepare \
       --allow-nongit-workspace \
       --workspace "${NONGIT_WORKSPACE}" \
+      --no-default-injection-policy \
       --colima-profile "${AUDIT_RESTORE_PROFILE_NAME}" \
       --agent-arg --version >/tmp/workcell-audit-restore.out 2>&1; then
       echo "Expected managed-profile refresh test hook to fail after stashing the audit log" >&2
@@ -7033,6 +7059,7 @@ EOF
       --agent codex \
       --allow-nongit-workspace \
       --workspace "${NONGIT_WORKSPACE}" \
+      --no-default-injection-policy \
       --colima-profile "${STRICT_REFRESH_PROFILE_NAME}" \
       --agent-arg --version >/tmp/workcell-strict-refresh-preflight.out 2>&1
     strict_refresh_status=$?
@@ -7058,6 +7085,7 @@ EOF
       --prepare \
       --allow-nongit-workspace \
       --workspace "${NONGIT_WORKSPACE}" \
+      --no-default-injection-policy \
       --colima-profile "${STRICT_REFRESH_PROFILE_NAME}" \
       --agent-arg --version >/tmp/workcell-strict-refresh-prepare.out 2>&1
     strict_refresh_prepare_status=$?
@@ -7149,6 +7177,7 @@ EOF
     --agent codex \
     --allow-nongit-workspace \
     --workspace "${NONGIT_WORKSPACE}" \
+    --no-default-injection-policy \
     --colima-profile "${GOFLAGS_PROFILE_NAME}" >/tmp/workcell-goflags.out 2>&1 || true
   if grep -q 'missing-go.mod' /tmp/workcell-goflags.out; then
     echo "scripts/workcell honored hostile GOFLAGS before validating managed Colima profiles" >&2

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2892,6 +2892,19 @@ if ! rg -q 'production\.cloudfront\.docker\.com:443' "${ROOT_DIR}/scripts/workce
   exit 1
 fi
 
+if ! rg -q '^ARG COPILOT_RELEASE_URL=' "${ROOT_DIR}/runtime/container/Dockerfile"; then
+  echo "Expected runtime Dockerfile to accept a host-resolved Copilot release URL override" >&2
+  exit 1
+fi
+if ! rg -q 'resolve_copilot_release_url\(\)' "${ROOT_DIR}/scripts/workcell"; then
+  echo "Expected scripts/workcell to resolve Copilot release URLs on the host before runtime builds" >&2
+  exit 1
+fi
+if ! rg -q -- '--build-arg "COPILOT_RELEASE_URL=\$\{copilot_release_url\}"' "${ROOT_DIR}/scripts/workcell"; then
+  echo "Expected scripts/workcell runtime builds to pass host-resolved Copilot release URLs into Docker" >&2
+  exit 1
+fi
+
 if rg -q 'snapshot\.debian\.org:80' "${ROOT_DIR}/scripts/workcell"; then
   echo "Expected scripts/workcell bootstrap endpoints to avoid unused snapshot.debian.org:80 egress" >&2
   exit 1

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -339,6 +339,7 @@ fi
 run_workcell_verify() {
   local -a cmd=(/usr/bin/env -i PATH="${TRUSTED_HOST_PATH}" BASH_ENV= ENV= WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT=1)
   local alias_command=""
+  local logs_kind=""
   while [[ $# -gt 0 ]] && [[ "$1" == *=* ]]; do
     cmd+=("$1")
     shift
@@ -350,7 +351,18 @@ run_workcell_verify() {
   # Most invariant probes assert launcher behavior, not the operator's local
   # auth policy. Tests that need injection pass --injection-policy explicitly.
   case "${1:-}" in
-    doctor | inspect | auth-status | logs | gc)
+    logs)
+      alias_command="$1"
+      shift
+      if [[ $# -gt 0 ]]; then
+        logs_kind="$1"
+        shift
+        "${cmd[@]}" /bin/bash -p "${ROOT_DIR}/scripts/workcell" "${alias_command}" "${logs_kind}" --no-default-injection-policy "$@"
+      else
+        "${cmd[@]}" /bin/bash -p "${ROOT_DIR}/scripts/workcell" "${alias_command}"
+      fi
+      ;;
+    doctor | inspect | auth-status | gc)
       alias_command="$1"
       shift
       "${cmd[@]}" /bin/bash -p "${ROOT_DIR}/scripts/workcell" "${alias_command}" --no-default-injection-policy "$@"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -6658,6 +6658,7 @@ while IFS= read -r line; do
 done
 EOF
     )"
+    ACK_BREAKGLASS_TODAY_UTC="$(date -u +%Y-%m-%d)"
     if ! "${ROOT_DIR}/scripts/workcell" \
       session start \
       --agent codex \
@@ -6919,6 +6920,7 @@ for attempt in 1 2 3; do
 done
 EOF
     )"
+    ACK_BREAKGLASS_TODAY_UTC="$(date -u +%Y-%m-%d)"
     if ! "${ROOT_DIR}/scripts/workcell" \
       --agent codex \
       --mode build \
@@ -6958,6 +6960,7 @@ codex --version >/tmp/workcell-package-mutation-post-failure.out 2>&1
 grep -q "session previously ran package-manager mutations as root" /tmp/workcell-package-mutation-post-failure.out
 EOF
     )"
+    ACK_BREAKGLASS_TODAY_UTC="$(date -u +%Y-%m-%d)"
     if ! "${ROOT_DIR}/scripts/workcell" \
       --agent codex \
       --mode build \
@@ -6984,6 +6987,7 @@ EOF
         exit 1
       fi
     done
+    ACK_BREAKGLASS_TODAY_UTC="$(date -u +%Y-%m-%d)"
     if ! "${ROOT_DIR}/scripts/workcell" \
       --agent codex \
       --mode build \

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -6065,7 +6065,15 @@ colima_start_hit_recoverable_docker_boot_race() {
 }
 
 extract_codex_version_from_dockerfile() {
-  go_hostutil helper extract-codex-version "${ROOT_DIR}/runtime/container/Dockerfile"
+  extract_runtime_dockerfile_arg CODEX_VERSION
+}
+
+extract_copilot_version_from_dockerfile() {
+  extract_runtime_dockerfile_arg COPILOT_VERSION
+}
+
+extract_runtime_dockerfile_arg() {
+  go_hostutil helper extract-dockerfile-arg "${ROOT_DIR}/runtime/container/Dockerfile" "$1"
 }
 
 runtime_build_codex_arch() {
@@ -6082,6 +6090,27 @@ runtime_build_codex_arch() {
       ;;
     amd64 | x86_64)
       printf 'x86_64-unknown-linux-musl\n'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+runtime_build_copilot_platform() {
+  local server_arch=""
+
+  server_arch="$(
+    run_workcell_docker_client_command "${HOST_DOCKER_BIN}" version --format '{{.Server.Arch}}' 2>/dev/null
+  )"
+  server_arch="${server_arch//$'\r'/}"
+  server_arch="${server_arch//$'\n'/}"
+  case "${server_arch}" in
+    arm64 | aarch64)
+      printf 'linux-arm64\n'
+      ;;
+    amd64 | x86_64)
+      printf 'linux-x64\n'
       ;;
     *)
       return 1
@@ -6118,12 +6147,42 @@ resolve_codex_release_url() {
   esac
 }
 
+resolve_copilot_release_url() {
+  local copilot_platform=""
+  local copilot_version=""
+  local release_url=""
+  local resolved_url=""
+
+  copilot_platform="$(runtime_build_copilot_platform)" || return 0
+  copilot_version="$(extract_copilot_version_from_dockerfile)" || return 0
+  release_url="https://github.com/github/copilot-cli/releases/download/v${copilot_version}/copilot-${copilot_platform}.tar.gz"
+  resolved_url="$(
+    run_clean_host_command curl -fsSLI \
+      --retry 5 \
+      --retry-all-errors \
+      --retry-delay 5 \
+      --connect-timeout 20 \
+      --max-time 20 \
+      -o /dev/null \
+      -w '%{url_effective}' \
+      "${release_url}" 2>/dev/null || true
+  )"
+  resolved_url="${resolved_url//$'\r'/}"
+  resolved_url="${resolved_url//$'\n'/}"
+  case "${resolved_url}" in
+    https://release-assets.githubusercontent.com/*)
+      printf '%s\n' "${resolved_url}"
+      ;;
+  esac
+}
+
 run_runtime_image_build_with_retries() {
   local build_source_date_epoch="$1"
   local build_status=0
   local attempt=1
   local max_attempts=5
   local codex_release_url=""
+  local copilot_release_url=""
   local safe_builder_context=""
   local -a build_cmd=()
 
@@ -6135,6 +6194,7 @@ run_runtime_image_build_with_retries() {
   while :; do
     build_status=0
     codex_release_url="$(resolve_codex_release_url || true)"
+    copilot_release_url="$(resolve_copilot_release_url || true)"
     if [[ "${attempt}" -gt 1 ]]; then
       echo "Retrying the runtime image build for profile ${COLIMA_PROFILE} (attempt ${attempt}/${max_attempts})." >&2
       case "${TARGET_BACKEND}" in
@@ -6184,6 +6244,9 @@ run_runtime_image_build_with_retries() {
     )
     if [[ -n "${codex_release_url}" ]]; then
       build_cmd+=(--build-arg "CODEX_RELEASE_URL=${codex_release_url}")
+    fi
+    if [[ -n "${copilot_release_url}" ]]; then
+      build_cmd+=(--build-arg "COPILOT_RELEASE_URL=${copilot_release_url}")
     fi
     SOURCE_DATE_EPOCH="${build_source_date_epoch}" run_command_with_debug_log runtime-build \
       "${build_cmd[@]}" || build_status=$?

--- a/verify/invariants/harnesses/process-colima/workcell-runtime-build-retry.sh
+++ b/verify/invariants/harnesses/process-colima/workcell-runtime-build-retry.sh
@@ -41,6 +41,7 @@ ensure_session_audit_state() {
   rm -f "${SESSION_AUDIT_STATE_FILE}"
 }
 resolve_codex_release_url() { return 0; }
+resolve_copilot_release_url() { return 0; }
 refresh_managed_profile() {
   REFRESH_COUNT=$((REFRESH_COUNT + 1))
   PROFILE_VALIDATED=0


### PR DESCRIPTION
## Summary
- add host auth-state detection helpers for provider/auth roots
- reject credential sources from host provider state in auth policy, auth resolution, and injection rendering
- keep docs examples on reviewed, non-provider-state credential paths

## Validation
- WORKCELL_COLIMA_START_TIMEOUT_SECONDS=600 ./scripts/verify-invariants.sh
- WORKCELL_VALIDATOR_IMAGE=workcell-validator:copilot-tier1-20260701161524 WORKCELL_COLIMA_START_TIMEOUT_SECONDS=600 ./scripts/pre-merge.sh --profile pr-parity

Foundation slice split out of the broader Copilot Tier 1 adapter work; it does not claim user-visible Copilot support by itself.