### PR TITLE
Add 1.0 program: roadmap improvement tracks and implementation plan

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,8 +101,9 @@ does not gate 1.0.
 The competitive context shaping this bar: microVM-per-session runtimes with
 warm starts and per-session egress allowlists are now the mainstream
 comparison point; OS-level sandbox competitors have shipped bypass CVEs;
-repo-defined MCP servers are a proven one-keypress RCE class across all four
-currently supported provider CLIs; and enterprises evaluate agent runtimes
+repo-defined MCP servers are a proven one-keypress RCE class across three of
+the four currently supported provider CLIs; and enterprises evaluate agent
+runtimes
 against OWASP agentic guidance, SIEM-ready audit export, and SLSA supply-chain
 levels. Workcell's 1.0 bar leans into its differentiators — the strongest
 local boundary, staged credentials, host-side signing, signed evidence, and
@@ -416,8 +417,10 @@ expectations — lives in
 ### Track A: Boundary Depth And Agent-Threat Defenses
 
 The external threat picture moved fast in 2025–2026: one-keypress RCE via
-repo-defined MCP servers across all four supported provider CLIs (TrustFall),
-prompt injection through PR titles and comments (CVE-2025-66032), recurring
+repo-defined MCP servers across three of the four supported provider CLIs —
+Claude Code, Gemini CLI, and Copilot CLI (the TrustFall disclosure; Codex CLI
+was not in the disclosed set), prompt injection through PR titles and
+comments against agent PR-review integrations, recurring
 npm worm campaigns (Shai-Hulud and successors), and sandbox-bypass CVEs in
 OS-level sandboxes (Seatbelt/bubblewrap). Workcell's VM-plus-container
 boundary and staged-credential model match the containment doctrine the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -428,57 +428,21 @@ OS-level sandboxes (Seatbelt/bubblewrap). Workcell's VM-plus-container
 boundary and staged-credential model match the containment doctrine the
 strongest vendors now publish; these items deepen that lead.
 
-- **A1 (now, M): Egress policy depth and target parity.** Strict Colima
-  launches already enforce default-deny, per-session egress allowlisting:
-  the strict profile sets `NETWORK_POLICY=allowlist`, the launcher computes
-  per-session `ALLOW_ENDPOINTS`, VM-level enforcement applies them, and the
-  endpoints are printed and recorded in the session audit. A1 is the delta
-  on top of that shipped control: an operator-facing policy surface for
-  reviewed per-session allowlist extensions and tightenings, a published
-  policy artifact documenting the mechanism (with A6), evaluation of
-  domain/DNS-level and proxy-based filtering for finer-grained control, and
-  explicit parity labeling for targets where allowlist enforcement does not
-  apply. Egress allowlisting is the control every adjacent runtime now
-  treats as core, and NSA MCP guidance recommends filtering outgoing
-  proxies; Workcell should surface and extend the control it already ships
-  rather than build a duplicate lane.
-- **A2 (now, M): Repo-defined MCP and agent-config containment.** Extend
-  workspace control-plane masking into an explicit reviewed policy for
-  repo-local MCP server definitions, tool configs, and instruction files:
-  deny by default in `strict`, require explicit per-path acknowledgement to
-  enable, and record the decision in the session record. This addresses the
-  TrustFall class (agent CLIs auto-executing project-defined MCP servers) and
-  MCP supply-chain vectors (postmark-mcp).
-- **A3 (now, M): Fuzzing expansion and continuous fuzzing.** Only two Go fuzz
-  targets exist (`internal/injection`, `internal/tomlsubset`) and the Rust
-  syscall-interception library has none. Add fuzz targets for the Rust shim's
-  path validation, environment filtering, and Git-config parsing; add Go fuzz
-  targets for workflow-YAML, provider-manifest, and pinned-inputs parsing;
-  then wire the corpus into continuous fuzzing (OSS-Fuzz or a scheduled CI
-  lane).
-- **A4 (now, S): Unsafe-code safety documentation.** The Rust runtime library
-  (`runtime/container/rust/src/lib.rs`) carries roughly 60 `unsafe` blocks
-  with minimal inline safety justification. Adopt the standard-library
-  `SAFETY:` comment convention on every unsafe block and add a pre-audit
-  checklist so a future third-party audit starts from documented invariants.
-- **A5 (next, M): Signed, tamper-evident session audit records.** Workcell
-  already keeps publication and signing on the host; extend the same trust
-  model to session evidence: hash-chain session audit logs and sign the chain
-  head with the existing Sigstore tooling so audit records are verifiable
-  from outside the agent. This is emerging in the ecosystem as
-  boundary-signed "action receipts" and directly strengthens the Phase 17
-  export story.
-- **A6 (next, M): Documented syscall and filesystem hardening profile.**
-  Publish the runtime container's expected seccomp posture, capability set,
-  read-only-rootfs expectations, and outbound-endpoint inventory as reviewed
-  policy artifacts with a deterministic conformance check, rather than
-  leaving them implicit in image build files.
-- **A7 (now, S): OWASP Agentic Top 10 control mapping.** Publish a docs page
-  mapping Workcell controls to the OWASP Top 10 for Agentic Applications 2026
-  (ASI01–ASI10): staged credentials → ASI03, VM boundary → ASI05,
-  control-plane masking → ASI04, session records → observability. This
-  converts the security posture into the checklist vocabulary buyers and
-  reviewers now use, and feeds the Phase 11 evidence packet.
+- **A1 (now, M):** egress policy depth and target parity — document, extend,
+  and parity-label the shipped strict default-deny allowlist rather than
+  build a duplicate lane
+- **A2 (now, M):** repo-defined MCP and agent-config containment,
+  deny-by-default in `strict` with acknowledged, audited exceptions
+- **A3 (now, M):** fuzzing expansion across the Rust shim and Go parsers,
+  wired into continuous fuzzing
+- **A4 (now, S):** `SAFETY:` documentation for every unsafe Rust block plus a
+  pre-audit checklist
+- **A5 (next, M):** signed, tamper-evident session audit records verifiable
+  from outside the agent
+- **A6 (next, M):** documented syscall/filesystem hardening profile with a
+  deterministic conformance check
+- **A7 (now, S):** OWASP Agentic Top 10 control mapping feeding the Phase 11
+  evidence packet
 
 ### Track B: Supply Chain And Release Assurance
 
@@ -488,86 +452,36 @@ keyless Sigstore signing, SBOMs, and GitHub attestations. These items close
 the remaining gaps between that posture and the level enterprises will ask a
 security-boundary product to prove.
 
-- **B1 (now, M): SLSA v1.0 gap analysis.** Audit the release path against
-  SLSA Build L3 and publish the gap matrix (hermeticity status, builder
-  hardening, two-person review) in `docs/provenance.md`, including which gaps
-  are structural to the single-maintainer model and what closes them.
-- **B2 (next, M): Dual-control release approval.** `docs/releasing.md`
-  honestly discloses single-maintainer mode as lower assurance. Before 1.0,
-  add a second release approver, require two approvals on the release
-  environment, and document the emergency bypass. This is the single largest
-  step toward SLSA L3 and OpenSSF expectations.
-- **B3 (now, M): Mutation testing gated in CI.** Mutation tests currently run
-  only inside the release-preflight `validate-repo.sh` profile, with no
-  scheduled or PR-time lane on `main`, no published score, and no baseline
-  regression gate, so mutation coverage can silently degrade between
-  releases. Add a scheduled or `approved-heavy-ci` mutation lane, publish the
-  score, and block release when coverage degrades below the recorded
-  baseline.
-- **B4 (now, S): Centralized tool pins and action allowlist.** Tool pins
-  (actionlint, zizmor, syft, cosign, buildx) are correct but scattered across
-  workflow env blocks. Centralize them in a reviewed policy file with
-  integrity hashes, add a permitted-actions allowlist check, and validate
-  both in pre-commit and release preflight.
-- **B5 (now, S): Audit-trail retention policy.** Artifact retention is 5–7
-  days across workflows, which is thin for incident response. Document a
-  retention policy, extend release-evidence artifacts to 30–90 days, and
-  document how to query GitHub attestations and the Rekor log after artifact
-  expiry.
-- **B6 (next, L): Real-boundary certification lane in CI.** The macOS Colima
-  boundary is still a local operator exercise because GitHub-hosted runners
-  cannot prove it. Evaluate a self-hosted Apple Silicon runner (or a macOS CI
-  service) as a scheduled certification lane that actually launches the
-  strict Colima path, treating the runner itself as lower-trust
-  infrastructure per a documented CI threat model.
-- **B7 (now, S → later, L): OpenSSF badge, then third-party audit.** Register
-  for the OpenSSF Best Practices badge and add it plus the Scorecard badge to
-  the README (`scorecard.yml` already runs weekly). Post-1.0, pursue a funded
-  third-party audit of the boundary; for a security-boundary product, "who
-  audited the boundary" is the credibility question none of the local-tier
-  competitors can answer either.
-- **B8 (next, M): CI efficiency and reliability program.** Split expensive
-  reproducibility checks into a nightly lane on `main` with release preflight
-  consuming the result, add retry policy for transient artifact/network
-  failures, track flaky tests explicitly, and add CI cost visibility so
-  coverage-versus-cost tradeoffs are deliberate.
-- **B9 (next, M): CI/CD threat model.** Publish `docs/ci-threat-model.md`
-  covering secrets handling and rotation, runner trust tiers, attestation
-  verification assumptions, and the signing-compromise incident-response
-  plan. Complements Phase 11 and gates B6.
+- **B1 (now, M):** SLSA v1.0 gap analysis published in the provenance docs
+- **B2 (next, M):** dual-control release approval before 1.0
+- **B3 (now, M):** scheduled mutation-score lane with published score and
+  baseline regression gate, beyond today's release-preflight-only run
+- **B4 (now, S):** centralized tool pins and a permitted-GitHub-actions
+  allowlist check
+- **B5 (now, S):** audit-trail retention policy with extended
+  release-evidence retention and post-expiry attestation/Rekor guidance
+- **B6 (next, L):** real-boundary certification lane on Apple Silicon runner
+  infrastructure, gated on the CI threat model
+- **B7 (now, S → later, L):** OpenSSF Best Practices badge now; funded
+  third-party boundary audit post-1.0
+- **B8 (next, M):** CI efficiency and reliability program — nightly
+  reproducibility split, retries, flake tracking, cost visibility
+- **B9 (next, M):** CI/CD threat model covering secrets, runner trust tiers,
+  attestation assumptions, and signing-compromise response
 
 ### Track C: Runtime Platform Evolution
 
-- **C1 (next, L): Apple `container` backend evaluation (macOS 26+).** Apple's
-  Containerization framework reached 1.0.0 in June 2026: one lightweight VM
-  per container on Virtualization.framework with sub-second boot and a frozen
-  1.0 API, Apple Silicon only, macOS 26 baseline. Evaluate it as an
-  additional target (`local_vm/apple-container`) with per-session VM
-  isolation — a stronger and lighter boundary than one shared Colima VM.
-  Colima remains the reviewed default for macOS below 26; promotion follows
-  the same support-matrix gates as every other target.
-- **C2 (next, M): Session start latency program.** Startup latency is the
-  most-benchmarked axis in the 2026 sandbox ecosystem (hosted competitors
-  advertise sub-second starts; local competitors ship cached project
-  images). Add prebaked per-project image caching and an optional kept-warm
-  VM lane under existing cache-profile labeling, and publish reproducible
-  startup benchmarks so the cost of the stronger boundary is measured, not
-  assumed.
-- **C3 (later, L): Native parallel sessions.** The 2026 unit of agent work is
-  one agent per git worktree, branch, and isolated environment; orchestrator
-  UIs currently supply their own weak isolation. Support N concurrent
-  sessions per repo natively (worktree-aware workspace handling, per-session
-  runtime, session-record linkage) so orchestrators can sit on top of
-  Workcell as the strong substrate instead of competing with it.
-- **C4 (later, L): Container tooling inside the boundary.** Agents routinely
-  need to build and run containers for tests; one major competitor markets
-  container-in-sandbox as its headline differentiator. Investigate a
-  rootless or nested container lane inside the bounded runtime, labeled at
-  the appropriate assurance tier, without weakening the outer boundary.
-- **C5 (now, S): Syscall-shim performance baselines.** The LD_PRELOAD
-  interception library has no published overhead numbers. Add
-  microbenchmarks for the hooked exec/spawn paths and record baselines so
-  future changes and competitive comparisons are empirical.
+- **C1 (next, L):** Apple `container` backend evaluation (macOS 26+) as
+  `local_vm/apple-container` with a recorded go/no-go; Colima stays the
+  reviewed default below macOS 26
+- **C2 (next, M):** session start latency program with cached images, an
+  optional kept-warm lane, and published reproducible benchmarks
+- **C3 (next, L):** native parallel sessions — one agent per worktree,
+  branch, and isolated runtime, with session-record linkage
+- **C4 (later, L):** container tooling inside the boundary as an explicit
+  labeled lane that never weakens the outer boundary
+- **C5 (now, S):** syscall-shim performance baselines for the hooked
+  exec/spawn paths
 
 ### Track D: Code Health And Consolidation
 
@@ -577,122 +491,57 @@ monolithic Rust interception library, a 8,910-line launcher script, a
 9,131-line `verify-invariants.sh`, and widespread helper duplication across
 120 shell scripts (for example, 25 separate `cleanup()` definitions).
 
-- **D1 (now, S): Language-boundary doctrine.** Document the intended
-  separation: Rust only for syscall interception and exec guards, Go for all
-  policy, state, and orchestration logic, shell only as thin glue. New logic
-  defaults to Go; large shell growth requires justification. This makes the
-  remaining items directional rather than ad hoc.
-- **D2 (now, M): Shared shell library.** Extract the duplicated `cleanup`,
-  `require_tool`, `die`, JSON, and resolver helpers into `scripts/lib/`
-  shared sources, and add a shellcheck lane (including SC2154) over all 120
-  scripts.
-- **D3 (next, L): Migrate the largest orchestration scripts to Go.**
-  `verify-invariants.sh` (9,131 lines, 57 functions) and
-  `container-smoke.sh` (4,570 lines) are de facto integration-test
-  orchestrators written in bash. Reimplement them incrementally as Go
-  commands under the existing `cmd/` pattern for structured errors,
-  parallelism, and unit-testability, keeping scenario parity via the
-  existing manifests.
-- **D4 (next, M): Modularize the launcher.** Split `scripts/workcell`
-  (8,910 lines, 354 functions) into sourced modules (host detection,
-  environment scrubbing, wrapper assembly, dispatch) and document the
-  launcher contract (required tools, environment expectations, exit codes,
-  test override flags).
-- **D5 (next, L): Modularize the Rust interception library.** Split
-  `lib.rs` into focused modules (syscall shim, git policy, runtime
-  protection, path validation) so security policy is reviewable separately
-  from FFI mechanics; pairs with A3 fuzzing and A4 safety docs.
-- **D6 (later, M): Split oversized Go validators.** `pinnedinputs.go`
-  (1,546 lines) validates many unrelated formats; split per-format
-  (docker, node, rust, workflows, python) with focused tests. Same pattern
-  for the largest dispatcher mains.
-- **D7 (next, M): Deepen test kinds.** Add property-based tests for the
-  session lifecycle state machine (attach/detach/timeout idempotency, signal
-  races), Go benchmarks for validation and session hot paths, and a bats (or
-  equivalent) unit lane for shared shell helpers. Complements the mutation
-  lane in B3.
-- **D8 (now, S): Stability contracts.** Document which internal Go APIs and
-  which CLI flags/output lines are stable versus experimental ahead of 1.0,
-  and unify the exit-code contract across the Rust launcher, Go binaries,
-  and shell entrypoints.
+- **D1 (now, S):** language-boundary doctrine — Rust for the shim, Go for
+  logic, shell as thin glue
+- **D2 (now, M):** shared shell helper library plus a shellcheck lane over
+  all scripts
+- **D3 (next, L):** migrate the `verify-invariants` and `container-smoke`
+  orchestration from bash to Go, keeping scenario parity
+- **D4 (next, M):** modularize the launcher and document its contract
+- **D5 (next, L):** modularize the Rust interception library into focused
+  modules
+- **D6 (later, M):** split oversized Go validators per format
+- **D7 (next, M):** property-based session-lifecycle tests, Go benchmarks,
+  and a shell unit-test lane
+- **D8 (now, S):** stability contracts for internal APIs, CLI surfaces, and
+  a unified exit-code contract
 
 ### Track E: Documentation And Adoption
 
-- **E1 (now, M): Tiered documentation entry points.** The README is 500+
-  lines mixing a 5-minute path with deep reference material. Restructure
-  around three labeled paths (open-source operator, enterprise evaluator,
-  contributor), move the operator command reference and long tables into
-  dedicated docs, and keep the README as orientation plus the 5-minute path.
-- **E2 (now, M): Architecture diagrams.** `docs/workcell-system-design.md`
-  is text-only. Add maintained Mermaid diagrams for the host/VM/container/
-  provider boundary stack, the policy-to-injection trust flow, and
-  control-plane seeding/masking. The Phase 11 evidence packet names these as
-  expected artifacts.
-- **E3 (now, S): Support-tier legend and diagnostics guide.** Publish one
-  page defining `strict`, `compat`, `preview`, `certification candidate`,
-  `experimental`, and `unsupported` with current examples, and one page
-  explaining `--doctor`/`--inspect` output fields (`support_matrix_*`) with a
-  triage decision tree.
-- **E4 (now, S): Docs CI depth.** Add intra-repo link checking and orphan
-  detection to `docs.yml`, add status labels (active/planning/historical) to
-  planning docs, and add last-verified release markers to time-sensitive
-  docs (threat model, invariants, provider matrix).
-- **E5 (next, M): Injection-policy schema documentation.** Expand
-  `docs/injection-policy.md` with an annotated schema (each key: type,
-  required/optional, provider applicability) and complete per-provider
-  example policies, including the multi-provider single-host pattern.
-- **E6 (next, M): Adoption growth kit.** Publish a rendered docs site, add
-  asciinema terminal demos to the README and quickstarts, ship a Homebrew
-  tap alongside the formula asset, and write the "why a VM boundary"
-  architecture post with reproducible benchmarks (C2/C5) so Workcell appears
-  in the 2026 sandbox comparisons on its own evidence. Every winning
-  comparable pairs an isolation-model manifesto with embeddable demos.
-- **E7 (next, S): Contributor runbook depth.** Give adapter READMEs real
-  content (auth methods, managed control-plane files, what the adapter
-  does), and add worked contributor examples (add a credential type, extend
-  an adapter) with the invariants/threat-model checklist each touches.
+- **E1 (now, M):** tiered documentation entry points and a slimmer README
+- **E2 (now, M):** maintained architecture diagrams in the system design doc
+- **E3 (now, S):** support-tier legend and a `--doctor`/`--inspect`
+  diagnostics interpretation guide
+- **E4 (now, S):** docs CI depth — link checking, orphan detection, status
+  labels, freshness markers
+- **E5 (next, M):** injection-policy annotated schema with complete
+  per-provider examples
+- **E6 (next, M):** adoption growth kit — docs site, terminal demos, Homebrew
+  tap, isolation-model architecture post backed by benchmarks
+- **E7 (next, S):** contributor runbook depth and substantive adapter READMEs
 
 ### Track F: Enterprise And Standards Alignment
 
-- **F1 (next, M): OCSF-mapped audit export.** Emit session records in an
-  OCSF-mapped JSONL form for SIEM interop; the OWASP Agent Observability
-  Standard already defines agent-trace-to-OCSF mappings. This is the concrete
-  format decision inside Phase 17 rather than a new phase.
-- **F2 (later, M): Per-session identity groundwork.** IETF and NIST drafts
-  converge on SPIFFE-style workload identity for agent authorization and
-  audit. Stamp session records with a stable trust-domain session identifier
-  now so Phase 15 identity work and the managed-workstation track inherit
-  compatible records.
-- **F3 (now, S): Standards watchlist.** Track the MCP 2026 spec line (OAuth
-  alignment, registry, Server Cards), OWASP agentic guidance, and agent
-  identity drafts in a short reviewed doc so adapter and policy decisions
-  cite current standards instead of rediscovering them per PR.
+- **F1 (next, M):** OCSF-mapped audit export — the concrete Phase 17 format
+  decision
+- **F2 (later, M):** SPIFFE-style per-session identity groundwork feeding
+  Phase 15
+- **F3 (now, S):** standards watchlist (MCP spec line, OWASP agentic
+  guidance, agent-identity drafts) with a review cadence
 
 ### Track G: 1.0 Contract And Operations
 
 These items exist specifically to make 1.0 a truthful claim: a frozen public
 contract and proven day-two operations.
 
-- **G1 (next, M): Public contract freeze and deprecation policy.** Inventory
-  the public operator surface (CLI flags, stable output lines, exit codes,
-  injection-policy schema, session-record and export formats), version each
-  schema, publish the semantic-versioning and deprecation policy, and bring
-  the manpage and CLI reference to completeness for the frozen surface. The
-  inventory lands early; the freeze is the 1.0-rc act.
-- **G2 (next, M): Support bundle command.** Ship a `workcell support-bundle`
-  flow that collects the evidence needed to diagnose install, policy, target,
-  provider, and runtime failures with documented redaction rules — the
-  operator-facing half of the Phase 17 export story.
-- **G3 (next, M): Install lifecycle proof.** Prove install, upgrade,
-  uninstall, rollback, and `--gc` end to end on the release matrix as
-  repeatable evidence, including upgrade-in-place across one minor version
-  and config/schema compatibility reads.
-- **G4 (later, S): 1.0 readiness gate review.** A recorded cross-lens review
-  (product, enterprise/security, adapter-maintainer, validation,
-  docs/contract, release) against the 1.0 release criteria, with every
-  support-matrix row verified against shipped behavior and all scope
-  decisions (for example an Antigravity certification deferral) recorded
-  explicitly.
+- **G1 (next, M):** public contract inventory, freeze, and deprecation
+  policy — inventory early, freeze at 1.0-rc
+- **G2 (next, M):** `workcell support-bundle` command with documented
+  redaction rules
+- **G3 (next, M):** install lifecycle proof — install, upgrade, uninstall,
+  rollback, and `--gc` as repeatable evidence
+- **G4 (later, S):** recorded cross-lens 1.0 readiness gate review with all
+  scope decisions explicit
 
 ### Sequencing Summary
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,6 +27,11 @@ The longer-lived runtime-target and deployment-reach program lives in
 [`docs/runtime-target-expansion-plan.md`](docs/runtime-target-expansion-plan.md).
 The deterministic phase breakdown lives in
 [`docs/runtime-target-phase-plan.md`](docs/runtime-target-phase-plan.md).
+Cross-cutting engineering, security-depth, and adoption improvements from the
+2026-07 repository review live in
+[Engineering And Ecosystem Improvement Tracks](#engineering-and-ecosystem-improvement-tracks)
+below. The release program that sequences those tracks, the remaining feature
+work, and the 1.0 criteria lives in [Path To 1.0](#path-to-10) below.
 
 ## Product Direction
 
@@ -81,6 +86,85 @@ The deterministic phase breakdown lives in
   input to those modes rather than a standalone path), and an Antigravity
   adapter is a committed follow-on provider-parity track behind the same
   Tier 1 evidence bar (see [docs/provider-matrix.md](docs/provider-matrix.md)).
+
+## Path To 1.0
+
+Workcell 1.0 is a contract-stability and assurance claim, not a
+platform-reach claim. 1.0 means: the public operator contract is frozen under
+semantic versioning, the reviewed macOS boundary is certified and audit-ready,
+the supported provider set covers the current agent ecosystem, day-two
+operations are proven, and the release path meets the supply-chain bar
+enterprise buyers require. Platform expansion — Linux operator hosts, Windows,
+managed workstations — continues after 1.0 through the phase gates below and
+does not gate 1.0.
+
+The competitive context shaping this bar: microVM-per-session runtimes with
+warm starts and per-session egress allowlists are now the mainstream
+comparison point; OS-level sandbox competitors have shipped bypass CVEs;
+repo-defined MCP servers are a proven one-keypress RCE class across all four
+currently supported provider CLIs; and enterprises evaluate agent runtimes
+against OWASP agentic guidance, SIEM-ready audit export, and SLSA supply-chain
+levels. Workcell's 1.0 bar leans into its differentiators — the strongest
+local boundary, staged credentials, host-side signing, signed evidence, and
+honest support labels — while closing the speed, parallelism, and egress-policy
+gaps competitors treat as table stakes.
+
+### 1.0 Release Criteria
+
+1.0 ships when all of the following hold. Item identifiers refer to the
+improvement tracks below; `G` items are the 1.0 contract-and-operations track.
+
+1. Contract stability: CLI flags and stable output lines, exit codes, the
+   injection-policy schema, and session-record and export formats are
+   versioned, frozen, and covered by a published deprecation policy (G1); the
+   manpage and CLI reference are complete for the frozen surface.
+2. Boundary assurance: per-session egress policy (A1), repo-defined MCP and
+   agent-config containment (A2), hardening-profile conformance (A6),
+   expanded fuzzing (A3), documented unsafe-code invariants (A4), and signed
+   session audit records (A5) are landed; a third-party boundary audit is
+   scheduled or complete (B7).
+3. Platform: `macos/arm64` strict (Colima) and compat (Docker Desktop) are
+   certified on the release matrix; the Apple `container` backend decision
+   (C1) is recorded either way; session start latency targets (C2) are met
+   and published; native parallel sessions (C3) work on the strict path.
+4. Providers: the Tier 1 set covers the current agent ecosystem — Codex,
+   Claude Code, GitHub Copilot CLI, Gemini, and Google Antigravity CLI —
+   each through the same Tier 1 evidence bar. If upstream instability blocks
+   Antigravity live certification, 1.0 may ship with the fail-closed scaffold
+   plus an explicit recorded scope decision instead of a support claim.
+5. Operations: install, upgrade, uninstall, rollback, `--gc`, and support
+   bundles (G2) are proven end to end on the release matrix (G3).
+6. Release assurance: dual-control releases (B2), mutation-score gating
+   (B3), SLSA L3 gaps closed or explicitly dispositioned (B1), OpenSSF Best
+   Practices badge (B7), and a real-boundary certification lane (B6) are in
+   place.
+7. Adoption surface: tiered docs (E1), architecture diagrams (E2), a
+   rendered docs site with demos and reproducible benchmarks (E6), and the
+   support-tier and diagnostics guides (E3) are live.
+8. Readiness review: a cross-lens 1.0 gate review (G4) — product,
+   enterprise/security, adapter-maintainer, validation, docs/contract, and
+   release lenses — records no unresolved P0/P1 findings, and every support
+   matrix row matches shipped behavior.
+
+### Milestone Train
+
+Milestones are sequencing buckets on the existing release cadence; versions
+are indicative and may split. Per-item steps, exit gates, and dependencies
+live in
+[`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md).
+
+| Milestone | Theme | Contents |
+|---|---|---|
+| v0.12 | Containment and hygiene | A2, A7, B3, B4, B5, D1, D2, E3, E4 |
+| v0.13 | Boundary depth and stability | A1, A3, A4, B1, B7 (badge), C5, D8, E1, E2, F3, G1 (inventory) |
+| v0.14 | Platform, speed, and adoption | C1, C2, B8, B9, D3 (start), D4, E5, E6, E7, G2, Antigravity Tier 1 adapter track |
+| v0.15 | Enterprise evidence and release assurance | A5, A6, B2, B6, C3, D5, D7, F1, G3 |
+| v1.0-rc | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
+| post-1.0 | Reach expansion | Phases 13–19 remainder, C4, B7 (audit completion), F2 |
+
+Phase 13 (Linux `amd64` `local_compat` certification candidate) may land
+before or after 1.0 depending on certification evidence; it does not gate
+1.0 and 1.0 creates no Linux claim.
 
 ## Next Provider And Target Phases
 
@@ -310,6 +394,300 @@ Exit gates:
   inbound public SSH on the reviewed path
 - AWS, GCP, and Azure expectations are compared across identity, private
   networking, tags, quotas, costs, logs, key management, and data residency
+
+## Engineering And Ecosystem Improvement Tracks
+
+Recorded 2026-07-03 from a full review of the repository (documentation,
+Rust/Go/shell source, tests, CI, and release workflows) combined with external
+research on the 2025–2026 agent-sandboxing ecosystem, competing runtimes,
+disclosed agent-CLI vulnerabilities, and emerging enterprise standards. These
+tracks are direction and sequencing, not support claims. Every item lands
+under the same evidence bar as the phases above: docs, deterministic tests,
+diagnostics, and (where applicable) live certification travel with the change.
+
+Horizons: `now` (next one to three releases), `next` (after the current
+provider and target phases stabilize), `later` (post-1.0 or gated on earlier
+items). Sizes: S/M/L. Milestone assignment for every item lives in the
+[Milestone Train](#milestone-train) under Path To 1.0, and the per-item
+implementation plan — steps, exit gates, dependencies, and validation
+expectations — lives in
+[`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md).
+
+### Track A: Boundary Depth And Agent-Threat Defenses
+
+The external threat picture moved fast in 2025–2026: one-keypress RCE via
+repo-defined MCP servers across all four supported provider CLIs (TrustFall),
+prompt injection through PR titles and comments (CVE-2025-66032), recurring
+npm worm campaigns (Shai-Hulud and successors), and sandbox-bypass CVEs in
+OS-level sandboxes (Seatbelt/bubblewrap). Workcell's VM-plus-container
+boundary and staged-credential model match the containment doctrine the
+strongest vendors now publish; these items deepen that lead.
+
+- **A1 (now, L): Per-session network egress policy.** Add a default-deny
+  egress lane with explicit domain allowlists as first-class per-session
+  policy, enforced outside the agent process (proxy or VM-level filtering),
+  with the allowlist recorded in the session record. Egress allowlisting is
+  the control every adjacent runtime now treats as core, and NSA MCP guidance
+  recommends filtering outgoing proxies for external MCP connections. Today
+  the strict lane has a reviewed network posture but no operator-visible
+  per-session allowlist artifact.
+- **A2 (now, M): Repo-defined MCP and agent-config containment.** Extend
+  workspace control-plane masking into an explicit reviewed policy for
+  repo-local MCP server definitions, tool configs, and instruction files:
+  deny by default in `strict`, require explicit per-path acknowledgement to
+  enable, and record the decision in the session record. This addresses the
+  TrustFall class (agent CLIs auto-executing project-defined MCP servers) and
+  MCP supply-chain vectors (postmark-mcp).
+- **A3 (now, M): Fuzzing expansion and continuous fuzzing.** Only two Go fuzz
+  targets exist (`internal/injection`, `internal/tomlsubset`) and the Rust
+  syscall-interception library has none. Add fuzz targets for the Rust shim's
+  path validation, environment filtering, and Git-config parsing; add Go fuzz
+  targets for workflow-YAML, provider-manifest, and pinned-inputs parsing;
+  then wire the corpus into continuous fuzzing (OSS-Fuzz or a scheduled CI
+  lane).
+- **A4 (now, S): Unsafe-code safety documentation.** The Rust runtime library
+  (`runtime/container/rust/src/lib.rs`) carries roughly 60 `unsafe` blocks
+  with minimal inline safety justification. Adopt the standard-library
+  `SAFETY:` comment convention on every unsafe block and add a pre-audit
+  checklist so a future third-party audit starts from documented invariants.
+- **A5 (next, M): Signed, tamper-evident session audit records.** Workcell
+  already keeps publication and signing on the host; extend the same trust
+  model to session evidence: hash-chain session audit logs and sign the chain
+  head with the existing Sigstore tooling so audit records are verifiable
+  from outside the agent. This is emerging in the ecosystem as
+  boundary-signed "action receipts" and directly strengthens the Phase 17
+  export story.
+- **A6 (next, M): Documented syscall and filesystem hardening profile.**
+  Publish the runtime container's expected seccomp posture, capability set,
+  read-only-rootfs expectations, and outbound-endpoint inventory as reviewed
+  policy artifacts with a deterministic conformance check, rather than
+  leaving them implicit in image build files.
+- **A7 (now, S): OWASP Agentic Top 10 control mapping.** Publish a docs page
+  mapping Workcell controls to the OWASP Top 10 for Agentic Applications 2026
+  (ASI01–ASI10): staged credentials → ASI03, VM boundary → ASI05,
+  control-plane masking → ASI04, session records → observability. This
+  converts the security posture into the checklist vocabulary buyers and
+  reviewers now use, and feeds the Phase 11 evidence packet.
+
+### Track B: Supply Chain And Release Assurance
+
+CI is already strong: all 72 action references SHA-pinned, workflows start
+from `permissions: {}`, reproducible builds verified on amd64 and arm64,
+keyless Sigstore signing, SBOMs, and GitHub attestations. These items close
+the remaining gaps between that posture and the level enterprises will ask a
+security-boundary product to prove.
+
+- **B1 (now, M): SLSA v1.0 gap analysis.** Audit the release path against
+  SLSA Build L3 and publish the gap matrix (hermeticity status, builder
+  hardening, two-person review) in `docs/provenance.md`, including which gaps
+  are structural to the single-maintainer model and what closes them.
+- **B2 (next, M): Dual-control release approval.** `docs/releasing.md`
+  honestly discloses single-maintainer mode as lower assurance. Before 1.0,
+  add a second release approver, require two approvals on the release
+  environment, and document the emergency bypass. This is the single largest
+  step toward SLSA L3 and OpenSSF expectations.
+- **B3 (now, M): Mutation testing gated in CI.** `scripts/run-mutation-tests.sh`
+  exists but no workflow invokes it, so mutation coverage can silently
+  regress. Add a scheduled or `approved-heavy-ci` mutation lane, publish the
+  score, and block release when coverage degrades below the recorded
+  baseline.
+- **B4 (now, S): Centralized tool pins and action allowlist.** Tool pins
+  (actionlint, zizmor, syft, cosign, buildx) are correct but scattered across
+  workflow env blocks. Centralize them in a reviewed policy file with
+  integrity hashes, add a permitted-actions allowlist check, and validate
+  both in pre-commit and release preflight.
+- **B5 (now, S): Audit-trail retention policy.** Artifact retention is 5–7
+  days across workflows, which is thin for incident response. Document a
+  retention policy, extend release-evidence artifacts to 30–90 days, and
+  document how to query GitHub attestations and the Rekor log after artifact
+  expiry.
+- **B6 (next, L): Real-boundary certification lane in CI.** The macOS Colima
+  boundary is still a local operator exercise because GitHub-hosted runners
+  cannot prove it. Evaluate a self-hosted Apple Silicon runner (or a macOS CI
+  service) as a scheduled certification lane that actually launches the
+  strict Colima path, treating the runner itself as lower-trust
+  infrastructure per a documented CI threat model.
+- **B7 (now, S → later, L): OpenSSF badge, then third-party audit.** Register
+  for the OpenSSF Best Practices badge and add it plus the Scorecard badge to
+  the README (`scorecard.yml` already runs weekly). Post-1.0, pursue a funded
+  third-party audit of the boundary; for a security-boundary product, "who
+  audited the boundary" is the credibility question none of the local-tier
+  competitors can answer either.
+- **B8 (next, M): CI efficiency and reliability program.** Split expensive
+  reproducibility checks into a nightly lane on `main` with release preflight
+  consuming the result, add retry policy for transient artifact/network
+  failures, track flaky tests explicitly, and add CI cost visibility so
+  coverage-versus-cost tradeoffs are deliberate.
+- **B9 (next, M): CI/CD threat model.** Publish `docs/ci-threat-model.md`
+  covering secrets handling and rotation, runner trust tiers, attestation
+  verification assumptions, and the signing-compromise incident-response
+  plan. Complements Phase 11 and gates B6.
+
+### Track C: Runtime Platform Evolution
+
+- **C1 (next, L): Apple `container` backend evaluation (macOS 26+).** Apple's
+  Containerization framework reached 1.0.0 in June 2026: one lightweight VM
+  per container on Virtualization.framework with sub-second boot and a frozen
+  1.0 API, Apple Silicon only, macOS 26 baseline. Evaluate it as an
+  additional target (`local_vm/apple-container`) with per-session VM
+  isolation — a stronger and lighter boundary than one shared Colima VM.
+  Colima remains the reviewed default for macOS below 26; promotion follows
+  the same support-matrix gates as every other target.
+- **C2 (next, M): Session start latency program.** Startup latency is the
+  most-benchmarked axis in the 2026 sandbox ecosystem (hosted competitors
+  advertise sub-second starts; local competitors ship cached project
+  images). Add prebaked per-project image caching and an optional kept-warm
+  VM lane under existing cache-profile labeling, and publish reproducible
+  startup benchmarks so the cost of the stronger boundary is measured, not
+  assumed.
+- **C3 (later, L): Native parallel sessions.** The 2026 unit of agent work is
+  one agent per git worktree, branch, and isolated environment; orchestrator
+  UIs currently supply their own weak isolation. Support N concurrent
+  sessions per repo natively (worktree-aware workspace handling, per-session
+  runtime, session-record linkage) so orchestrators can sit on top of
+  Workcell as the strong substrate instead of competing with it.
+- **C4 (later, L): Container tooling inside the boundary.** Agents routinely
+  need to build and run containers for tests; one major competitor markets
+  container-in-sandbox as its headline differentiator. Investigate a
+  rootless or nested container lane inside the bounded runtime, labeled at
+  the appropriate assurance tier, without weakening the outer boundary.
+- **C5 (now, S): Syscall-shim performance baselines.** The LD_PRELOAD
+  interception library has no published overhead numbers. Add
+  microbenchmarks for the hooked exec/spawn paths and record baselines so
+  future changes and competitive comparisons are empirical.
+
+### Track D: Code Health And Consolidation
+
+The Go tree is in good shape (28.8k source lines, 82% test-to-code ratio,
+three direct dependencies). The concentration risks are a 2,288-line
+monolithic Rust interception library, a 8,910-line launcher script, a
+9,131-line `verify-invariants.sh`, and widespread helper duplication across
+120 shell scripts (for example, 25 separate `cleanup()` definitions).
+
+- **D1 (now, S): Language-boundary doctrine.** Document the intended
+  separation: Rust only for syscall interception and exec guards, Go for all
+  policy, state, and orchestration logic, shell only as thin glue. New logic
+  defaults to Go; large shell growth requires justification. This makes the
+  remaining items directional rather than ad hoc.
+- **D2 (now, M): Shared shell library.** Extract the duplicated `cleanup`,
+  `require_tool`, `die`, JSON, and resolver helpers into `scripts/lib/`
+  shared sources, and add a shellcheck lane (including SC2154) over all 120
+  scripts.
+- **D3 (next, L): Migrate the largest orchestration scripts to Go.**
+  `verify-invariants.sh` (9,131 lines, 57 functions) and
+  `container-smoke.sh` (4,570 lines) are de facto integration-test
+  orchestrators written in bash. Reimplement them incrementally as Go
+  commands under the existing `cmd/` pattern for structured errors,
+  parallelism, and unit-testability, keeping scenario parity via the
+  existing manifests.
+- **D4 (next, M): Modularize the launcher.** Split `scripts/workcell`
+  (8,910 lines, 354 functions) into sourced modules (host detection,
+  environment scrubbing, wrapper assembly, dispatch) and document the
+  launcher contract (required tools, environment expectations, exit codes,
+  test override flags).
+- **D5 (next, L): Modularize the Rust interception library.** Split
+  `lib.rs` into focused modules (syscall shim, git policy, runtime
+  protection, path validation) so security policy is reviewable separately
+  from FFI mechanics; pairs with A3 fuzzing and A4 safety docs.
+- **D6 (later, M): Split oversized Go validators.** `pinnedinputs.go`
+  (1,546 lines) validates many unrelated formats; split per-format
+  (docker, node, rust, workflows, python) with focused tests. Same pattern
+  for the largest dispatcher mains.
+- **D7 (next, M): Deepen test kinds.** Add property-based tests for the
+  session lifecycle state machine (attach/detach/timeout idempotency, signal
+  races), Go benchmarks for validation and session hot paths, and a bats (or
+  equivalent) unit lane for shared shell helpers. Complements the mutation
+  lane in B3.
+- **D8 (now, S): Stability contracts.** Document which internal Go APIs and
+  which CLI flags/output lines are stable versus experimental ahead of 1.0,
+  and unify the exit-code contract across the Rust launcher, Go binaries,
+  and shell entrypoints.
+
+### Track E: Documentation And Adoption
+
+- **E1 (now, M): Tiered documentation entry points.** The README is 500+
+  lines mixing a 5-minute path with deep reference material. Restructure
+  around three labeled paths (open-source operator, enterprise evaluator,
+  contributor), move the operator command reference and long tables into
+  dedicated docs, and keep the README as orientation plus the 5-minute path.
+- **E2 (now, M): Architecture diagrams.** `docs/workcell-system-design.md`
+  is text-only. Add maintained Mermaid diagrams for the host/VM/container/
+  provider boundary stack, the policy-to-injection trust flow, and
+  control-plane seeding/masking. The Phase 11 evidence packet names these as
+  expected artifacts.
+- **E3 (now, S): Support-tier legend and diagnostics guide.** Publish one
+  page defining `strict`, `compat`, `preview`, `certification candidate`,
+  `experimental`, and `unsupported` with current examples, and one page
+  explaining `--doctor`/`--inspect` output fields (`support_matrix_*`) with a
+  triage decision tree.
+- **E4 (now, S): Docs CI depth.** Add intra-repo link checking and orphan
+  detection to `docs.yml`, add status labels (active/planning/historical) to
+  planning docs, and add last-verified release markers to time-sensitive
+  docs (threat model, invariants, provider matrix).
+- **E5 (next, M): Injection-policy schema documentation.** Expand
+  `docs/injection-policy.md` with an annotated schema (each key: type,
+  required/optional, provider applicability) and complete per-provider
+  example policies, including the multi-provider single-host pattern.
+- **E6 (next, M): Adoption growth kit.** Publish a rendered docs site, add
+  asciinema terminal demos to the README and quickstarts, ship a Homebrew
+  tap alongside the formula asset, and write the "why a VM boundary"
+  architecture post with reproducible benchmarks (C2/C5) so Workcell appears
+  in the 2026 sandbox comparisons on its own evidence. Every winning
+  comparable pairs an isolation-model manifesto with embeddable demos.
+- **E7 (next, S): Contributor runbook depth.** Give adapter READMEs real
+  content (auth methods, managed control-plane files, what the adapter
+  does), and add worked contributor examples (add a credential type, extend
+  an adapter) with the invariants/threat-model checklist each touches.
+
+### Track F: Enterprise And Standards Alignment
+
+- **F1 (next, M): OCSF-mapped audit export.** Emit session records in an
+  OCSF-mapped JSONL form for SIEM interop; the OWASP Agent Observability
+  Standard already defines agent-trace-to-OCSF mappings. This is the concrete
+  format decision inside Phase 17 rather than a new phase.
+- **F2 (later, M): Per-session identity groundwork.** IETF and NIST drafts
+  converge on SPIFFE-style workload identity for agent authorization and
+  audit. Stamp session records with a stable trust-domain session identifier
+  now so Phase 15 identity work and the managed-workstation track inherit
+  compatible records.
+- **F3 (now, S): Standards watchlist.** Track the MCP 2026 spec line (OAuth
+  alignment, registry, Server Cards), OWASP agentic guidance, and agent
+  identity drafts in a short reviewed doc so adapter and policy decisions
+  cite current standards instead of rediscovering them per PR.
+
+### Track G: 1.0 Contract And Operations
+
+These items exist specifically to make 1.0 a truthful claim: a frozen public
+contract and proven day-two operations.
+
+- **G1 (next, M): Public contract freeze and deprecation policy.** Inventory
+  the public operator surface (CLI flags, stable output lines, exit codes,
+  injection-policy schema, session-record and export formats), version each
+  schema, publish the semantic-versioning and deprecation policy, and bring
+  the manpage and CLI reference to completeness for the frozen surface. The
+  inventory lands early; the freeze is the 1.0-rc act.
+- **G2 (next, M): Support bundle command.** Ship a `workcell support-bundle`
+  flow that collects the evidence needed to diagnose install, policy, target,
+  provider, and runtime failures with documented redaction rules — the
+  operator-facing half of the Phase 17 export story.
+- **G3 (next, M): Install lifecycle proof.** Prove install, upgrade,
+  uninstall, rollback, and `--gc` end to end on the release matrix as
+  repeatable evidence, including upgrade-in-place across one minor version
+  and config/schema compatibility reads.
+- **G4 (later, S): 1.0 readiness gate review.** A recorded cross-lens review
+  (product, enterprise/security, adapter-maintainer, validation,
+  docs/contract, release) against the 1.0 release criteria, with every
+  support-matrix row verified against shipped behavior and all scope
+  decisions (for example an Antigravity certification deferral) recorded
+  explicitly.
+
+### Sequencing Summary
+
+Sequencing for all tracks now lives in the
+[Milestone Train](#milestone-train) under Path To 1.0. The v0.12 milestone
+(A2, A7, B3, B4, B5, D1, D2, E3, E4) is the suggested first slice: high
+impact, small-to-medium effort, no new support claims, and each item is
+independently shippable.
 
 ## Adoption Workstreams
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -489,9 +489,11 @@ security-boundary product to prove.
   add a second release approver, require two approvals on the release
   environment, and document the emergency bypass. This is the single largest
   step toward SLSA L3 and OpenSSF expectations.
-- **B3 (now, M): Mutation testing gated in CI.** `scripts/run-mutation-tests.sh`
-  exists but no workflow invokes it, so mutation coverage can silently
-  regress. Add a scheduled or `approved-heavy-ci` mutation lane, publish the
+- **B3 (now, M): Mutation testing gated in CI.** Mutation tests currently run
+  only inside the release-preflight `validate-repo.sh` profile, with no
+  scheduled or PR-time lane on `main`, no published score, and no baseline
+  regression gate, so mutation coverage can silently degrade between
+  releases. Add a scheduled or `approved-heavy-ci` mutation lane, publish the
   score, and block release when coverage degrades below the recorded
   baseline.
 - **B4 (now, S): Centralized tool pins and action allowlist.** Tool pins

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -107,8 +107,9 @@ runtimes
 against OWASP agentic guidance, SIEM-ready audit export, and SLSA supply-chain
 levels. Workcell's 1.0 bar leans into its differentiators — the strongest
 local boundary, staged credentials, host-side signing, signed evidence, and
-honest support labels — while closing the speed, parallelism, and egress-policy
-gaps competitors treat as table stakes.
+honest support labels — while closing the speed and parallelism gaps
+competitors treat as table stakes and surfacing controls it already ships,
+such as per-session egress allowlisting.
 
 ### 1.0 Release Criteria
 
@@ -119,7 +120,8 @@ improvement tracks below; `G` items are the 1.0 contract-and-operations track.
    injection-policy schema, and session-record and export formats are
    versioned, frozen, and covered by a published deprecation policy (G1); the
    manpage and CLI reference are complete for the frozen surface.
-2. Boundary assurance: per-session egress policy (A1), repo-defined MCP and
+2. Boundary assurance: egress policy depth and target parity (A1),
+   repo-defined MCP and
    agent-config containment (A2), hardening-profile conformance (A6),
    expanded fuzzing (A3), documented unsafe-code invariants (A4), and signed
    session audit records (A5) are landed; a third-party boundary audit is
@@ -426,14 +428,20 @@ OS-level sandboxes (Seatbelt/bubblewrap). Workcell's VM-plus-container
 boundary and staged-credential model match the containment doctrine the
 strongest vendors now publish; these items deepen that lead.
 
-- **A1 (now, L): Per-session network egress policy.** Add a default-deny
-  egress lane with explicit domain allowlists as first-class per-session
-  policy, enforced outside the agent process (proxy or VM-level filtering),
-  with the allowlist recorded in the session record. Egress allowlisting is
-  the control every adjacent runtime now treats as core, and NSA MCP guidance
-  recommends filtering outgoing proxies for external MCP connections. Today
-  the strict lane has a reviewed network posture but no operator-visible
-  per-session allowlist artifact.
+- **A1 (now, M): Egress policy depth and target parity.** Strict Colima
+  launches already enforce default-deny, per-session egress allowlisting:
+  the strict profile sets `NETWORK_POLICY=allowlist`, the launcher computes
+  per-session `ALLOW_ENDPOINTS`, VM-level enforcement applies them, and the
+  endpoints are printed and recorded in the session audit. A1 is the delta
+  on top of that shipped control: an operator-facing policy surface for
+  reviewed per-session allowlist extensions and tightenings, a published
+  policy artifact documenting the mechanism (with A6), evaluation of
+  domain/DNS-level and proxy-based filtering for finer-grained control, and
+  explicit parity labeling for targets where allowlist enforcement does not
+  apply. Egress allowlisting is the control every adjacent runtime now
+  treats as core, and NSA MCP guidance recommends filtering outgoing
+  proxies; Workcell should surface and extend the control it already ships
+  rather than build a duplicate lane.
 - **A2 (now, M): Repo-defined MCP and agent-config containment.** Extend
   workspace control-plane masking into an explicit reviewed policy for
   repo-local MCP server definitions, tool configs, and instruction files:

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -318,6 +318,11 @@ delta on that shipped control, not a new lane.
 
 ### C1: Apple `container` Backend Evaluation (macOS 26+)
 
+Context: Apple's Containerization framework reached 1.0.0 in June 2026 — one
+lightweight VM per container on Virtualization.framework, sub-second boot, a
+frozen 1.0 API, Apple Silicon only, macOS 26 baseline. Per-session VM
+isolation would be a stronger and lighter boundary than one shared Colima VM.
+
 - Steps: spike behind the existing target-kind contract as
   `local_vm/apple-container`; map lifecycle, mounts, networking, and
   diagnostics onto the shared conformance harness; measure boundary

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -101,9 +101,10 @@ them.
 ### B3: Mutation Testing Gated In CI
 
 - Steps: add a scheduled and `approved-heavy-ci` mutation lane invoking the
-  existing `scripts/run-mutation-tests.sh` path; record the current score as
-  the baseline in a reviewed policy file; fail the lane when the score drops
-  below baseline; surface the score in the job summary.
+  existing `scripts/run-mutation-tests.sh` path (today mutation tests run
+  only inside the release-preflight `validate-repo.sh` profile); record the
+  current score as the baseline in a reviewed policy file; fail the lane when
+  the score drops below baseline; surface the score in the job summary.
 - Exit gates: lane green on `main`; baseline file reviewed; release preflight
   refuses when the recorded baseline regresses.
 - Validation: deliberate mutant-survival dry run proves the gate trips.

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -40,7 +40,9 @@ The milestone ordering answers the current landscape directly:
   of the four supported provider CLIs (Claude Code, Gemini CLI, Copilot CLI
   per the TrustFall disclosure) → A2 lands first (v0.12)
 - per-session egress allowlists are table stakes in every adjacent runtime
-  and in national-agency MCP guidance → A1 is the headline of v0.13
+  and in national-agency MCP guidance; strict Colima launches already enforce
+  default-deny allowlisting → A1 (v0.13) documents, extends, and brings
+  target parity to that shipped control instead of building a duplicate lane
 - microVM-per-session backends with warm starts are the mainstream
   comparison point → C1/C2 anchor v0.14
 - parallel worktree-per-agent sessions are the 2026 unit of agent work →
@@ -183,22 +185,29 @@ them.
 
 ## Milestone v0.13: Boundary Depth And Stability
 
-### A1: Per-Session Network Egress Policy
+### A1: Egress Policy Depth And Target Parity
 
-- Steps: design review first — enforcement point options (VM-level filtering
-  versus a proxy outside the agent process), policy schema (per-session
-  domain allowlist, default-deny in `strict`), and session-record fields;
-  implement behind a reviewed policy surface with fail-closed diagnostics;
-  record the effective allowlist in the session record; document operator
-  workflow and rollback.
-- Exit gates: deterministic tests prove default-deny and allowlisted flows;
-  scenario coverage for blocked/allowed egress; docs (injection policy,
-  invariants, threat model) updated; no weakening of existing posture when
-  the feature is off.
+Strict Colima launches already enforce default-deny, per-session egress
+allowlisting (`runtime/profiles/strict.env` sets `NETWORK_POLICY=allowlist`;
+the launcher computes per-session `ALLOW_ENDPOINTS`, applies them through the
+VM-level egress helper, and prints and audits the endpoint set). A1 is the
+delta on that shipped control, not a new lane.
+
+- Steps: document the shipped mechanism as a reviewed policy artifact
+  alongside A6; design review for the delta — an operator-facing
+  injection-policy surface for reviewed per-session allowlist extensions and
+  tightenings, domain/DNS-level and proxy-based filtering options for
+  finer-grained control, and enforcement-parity labeling for targets where
+  the allowlist helper does not apply; implement the reviewed delta with
+  fail-closed diagnostics.
+- Exit gates: the shipped mechanism is documented and covered by
+  deterministic tests (blocked/allowed flows, audited endpoint recording);
+  operator extensions flow through the reviewed policy path; targets without
+  allowlist enforcement are explicitly labeled; docs (injection policy,
+  invariants, threat model) updated; no weakening of the shipped default.
 - Validation: unit plus scenario tests; live boundary exercise on the strict
-  path before any support-visible claim.
-- Size: L. Dependencies: design review; A6 profiles help but are not
-  blocking.
+  path for the delta before any support-visible claim.
+- Size: M. Dependencies: design review; coordinates with A6 artifacts.
 
 ### A3: Fuzzing Expansion And Continuous Fuzzing
 

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -36,8 +36,9 @@ Milestone Train; versions are indicative and may split.
 
 The milestone ordering answers the current landscape directly:
 
-- repo-defined MCP servers are a proven one-keypress RCE class across all
-  four supported provider CLIs → A2 lands first (v0.12)
+- repo-defined MCP servers are a proven one-keypress RCE class across three
+  of the four supported provider CLIs (Claude Code, Gemini CLI, Copilot CLI
+  per the TrustFall disclosure) → A2 lands first (v0.12)
 - per-session egress allowlists are table stakes in every adjacent runtime
   and in national-agency MCP guidance → A1 is the headline of v0.13
 - microVM-per-session backends with warm starts are the mainstream

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -1,0 +1,665 @@
+# Improvement Tracks Implementation Plan
+
+This document turns the
+[Path To 1.0](../ROADMAP.md#path-to-10) program and its
+[Engineering And Ecosystem Improvement Tracks](../ROADMAP.md#engineering-and-ecosystem-improvement-tracks)
+into a concrete, milestone-based implementation plan. The tracks came from
+the 2026-07 repository review (documentation, Rust/Go/shell source, tests,
+CI, release workflows) plus external research on the 2025–2026
+agent-sandboxing ecosystem. This plan records sequencing, per-item
+implementation shape, exit gates, and validation expectations. It creates no
+support claims; every support-visible change still lands through the
+host-support matrix, provider matrix, and certification gates.
+
+Track and item identifiers (`A1`, `B3`, `G1`, ...) refer to the roadmap
+tracks and stay stable across both documents. Milestones match the roadmap's
+Milestone Train; versions are indicative and may split.
+
+## Principles
+
+- tests first: every code-bearing item starts by writing the failing
+  deterministic test or check that defines done
+- one review unit per item or sub-item; no bundling unrelated tracks into one
+  PR
+- docs, contract surfaces, and validation evidence land in the same change as
+  the behavior they describe
+- refactors (Track D) must be behavior-preserving and proven by the existing
+  test surface before and after
+- security-depth items (Track A) fail closed by default; any relaxation is an
+  explicit labeled lower-assurance path
+- nothing in this plan weakens the VM-plus-container boundary, staged
+  credential model, or host-side publication rules
+- 1.0 is a truth claim: no milestone content ships a support label ahead of
+  its evidence
+
+## Competitive Drivers
+
+The milestone ordering answers the current landscape directly:
+
+- repo-defined MCP servers are a proven one-keypress RCE class across all
+  four supported provider CLIs → A2 lands first (v0.12)
+- per-session egress allowlists are table stakes in every adjacent runtime
+  and in national-agency MCP guidance → A1 is the headline of v0.13
+- microVM-per-session backends with warm starts are the mainstream
+  comparison point → C1/C2 anchor v0.14
+- parallel worktree-per-agent sessions are the 2026 unit of agent work →
+  C3 is in 1.0 scope (v0.15), not a post-1.0 idea
+- upstream retires Gemini CLI personal-account tiers in June 2026 →
+  the Antigravity Tier 1 adapter track runs inside the 1.0 window (v0.14)
+- enterprises evaluate against OWASP agentic guidance, SIEM-ready export,
+  and SLSA levels → A7, F1, B1/B2 sit on the critical path
+- container-in-sandbox (C4) stays post-1.0: it is a differentiator response,
+  not a 1.0 gate, and must not risk the outer boundary
+
+## Delivery Model
+
+| Milestone | Theme | Contents |
+|---|---|---|
+| v0.12 | Containment and hygiene | A2, A7, B3, B4, B5, D1, D2, E3, E4 |
+| v0.13 | Boundary depth and stability | A1, A3, A4, B1, B7 (badge), C5, D8, E1, E2, F3, G1 (inventory) |
+| v0.14 | Platform, speed, and adoption | C1, C2, B8, B9, D3 (start), D4, E5, E6, E7, G2, Antigravity Tier 1 adapter track |
+| v0.15 | Enterprise evidence and release assurance | A5, A6, B2, B6, C3, D5, D7, F1, G3 |
+| v1.0-rc | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
+| post-1.0 | Reach expansion | Phases 13–19 remainder, C4, B7 (audit completion), F2 |
+
+Items inside a milestone are independently shippable and individually
+reviewable. Later-milestone items may start early when nothing earlier gates
+them.
+
+## Milestone v0.12: Containment And Hygiene
+
+### A2: Repo-Defined MCP And Agent-Config Containment
+
+- Steps: inventory repo-local MCP/tool-config/instruction surfaces per
+  provider (Codex, Claude, Copilot, Gemini) from the adapter control-plane
+  docs; extend workspace control-plane masking policy to classify each
+  surface as `deny`, `mask`, or `ack-required`; implement `strict`-mode
+  deny-by-default for repo-defined MCP server definitions; add an explicit
+  per-path acknowledgement input on the reviewed policy path; record the
+  decision in the session record.
+- Exit gates: deterministic tests prove repo-local MCP config cannot reach
+  the provider process in `strict` without acknowledgement; masking tables in
+  [`adapter-control-planes.md`](adapter-control-planes.md) updated; scenario
+  manifest parity holds; injection-policy docs describe the new keys.
+- Validation: unit tests per adapter surface, one scenario per provider,
+  mutation coverage over the new policy branch points.
+- Size: M. Dependencies: none.
+
+### A7: OWASP Agentic Top 10 Control Mapping
+
+- Steps: write `docs/owasp-agentic-mapping.md` mapping each Workcell control
+  to ASI01–ASI10 (staged credentials → ASI03, control-plane masking → ASI04,
+  VM boundary → ASI05, session records → observability), including explicit
+  non-coverage rows; link from the threat model and the enterprise evidence
+  baseline.
+- Exit gates: every ASI row states covered/partial/not-covered with the
+  enforcing mechanism or gap named; docs lint and link checks pass.
+- Validation: docs lanes; review lens from the threat-model owner.
+- Size: S. Dependencies: none.
+
+### B3: Mutation Testing Gated In CI
+
+- Steps: add a scheduled and `approved-heavy-ci` mutation lane invoking the
+  existing `scripts/run-mutation-tests.sh` path; record the current score as
+  the baseline in a reviewed policy file; fail the lane when the score drops
+  below baseline; surface the score in the job summary.
+- Exit gates: lane green on `main`; baseline file reviewed; release preflight
+  refuses when the recorded baseline regresses.
+- Validation: deliberate mutant-survival dry run proves the gate trips.
+- Size: M. Dependencies: none. Land before the Track D refactors so the
+  refactors inherit a scored safety net.
+
+### B4: Centralized Tool Pins And Action Allowlist
+
+- Steps: create a reviewed policy file holding tool pins (actionlint, zizmor,
+  syft, cosign, buildx, buildkit, QEMU) with integrity hashes; refactor
+  workflows to consume the central values; add a permitted-actions allowlist
+  and a checker that every workflow `uses:` entry matches it; wire both into
+  pre-commit and release preflight.
+- Exit gates: no workflow carries an inline unpinned or off-allowlist tool;
+  checker fails on a seeded violation; pin-hygiene lane covers the new file.
+- Validation: negative-test the checker; full CI pass.
+- Size: S. Dependencies: none.
+
+### B5: Audit-Trail Retention Policy
+
+- Steps: write `docs/retention-policy.md` recording artifact retention per
+  workflow with justification; extend release-evidence artifact retention to
+  90 days; document how to query GitHub attestations and the Rekor
+  transparency log after artifact expiry.
+- Exit gates: retention values in workflows match the documented policy; a
+  drift check compares them.
+- Validation: docs lanes plus the drift check.
+- Size: S. Dependencies: none.
+
+### D1: Language-Boundary Doctrine
+
+- Steps: add a language-boundary section to `AGENTS.md` (or a referenced
+  standalone doc): Rust only for syscall interception and exec guards, Go for
+  policy/state/orchestration logic, shell only as thin glue; new logic
+  defaults to Go; shell growth beyond glue requires stated justification.
+- Exit gates: doctrine reviewed and linked from contributor docs.
+- Validation: docs lanes.
+- Size: S. Dependencies: none. Gates D2–D6 direction.
+
+### D2: Shared Shell Library And Shellcheck Lane
+
+- Steps: extract duplicated `cleanup`, `require_tool`, `die`, JSON, and
+  resolver helpers into `scripts/lib/` shared sources; convert call sites
+  incrementally (one reviewable batch per PR); add a shellcheck lane at
+  warning severity (including SC2154) over `scripts/`.
+- Exit gates: duplicate helper definitions reduced to the shared sources;
+  shellcheck lane green; scenario suite unchanged before/after each batch.
+- Validation: existing scenario and smoke suites per batch; shellcheck in CI.
+- Size: M. Dependencies: D1.
+
+### E3: Support-Tier Legend And Diagnostics Guide
+
+- Steps: write `docs/support-tiers.md` defining `strict`, `compat`,
+  `preview`, `certification candidate`, `experimental`, and `unsupported`
+  with current examples from the host-support matrix; write
+  `docs/diagnostics-and-support-matrix.md` explaining `--doctor`/`--inspect`
+  fields (`support_matrix_*`) with a triage decision tree; link both from
+  README and SUPPORT.
+- Exit gates: every tier word used in README/ROADMAP resolves to one
+  definition; diagnostics fields in the guide match the emitting code.
+- Validation: docs lanes; a deterministic check that documented
+  `support_matrix_*` field names match the code-emitted set.
+- Size: S. Dependencies: none.
+
+### E4: Docs CI Depth
+
+- Steps: add intra-repo markdown link checking and orphan detection to the
+  docs workflow; add status labels (active/planning/historical) to planning
+  docs; add last-verified release markers to the threat model, invariants,
+  and provider matrix; document the local docs-validation command in
+  CONTRIBUTING.
+- Exit gates: link checker fails on a seeded broken link; every `docs/*.md`
+  is either linked from an index/README or explicitly labeled.
+- Validation: docs workflow green with the new checks.
+- Size: S. Dependencies: none. Unblocks confidence for E1 restructuring.
+
+## Milestone v0.13: Boundary Depth And Stability
+
+### A1: Per-Session Network Egress Policy
+
+- Steps: design review first — enforcement point options (VM-level filtering
+  versus a proxy outside the agent process), policy schema (per-session
+  domain allowlist, default-deny in `strict`), and session-record fields;
+  implement behind a reviewed policy surface with fail-closed diagnostics;
+  record the effective allowlist in the session record; document operator
+  workflow and rollback.
+- Exit gates: deterministic tests prove default-deny and allowlisted flows;
+  scenario coverage for blocked/allowed egress; docs (injection policy,
+  invariants, threat model) updated; no weakening of existing posture when
+  the feature is off.
+- Validation: unit plus scenario tests; live boundary exercise on the strict
+  path before any support-visible claim.
+- Size: L. Dependencies: design review; A6 profiles help but are not
+  blocking.
+
+### A3: Fuzzing Expansion And Continuous Fuzzing
+
+- Steps: add Rust fuzz targets (path validation, environment filtering,
+  Git-config parsing) using `cargo-fuzz`; add Go fuzz targets
+  (workflow-YAML, provider-manifest, pinned-inputs parsing); seed corpora
+  from real repo configs; add a scheduled CI fuzz lane with time budget;
+  evaluate OSS-Fuzz onboarding once targets are stable.
+- Exit gates: each named parser has a fuzz target and checked-in corpus; the
+  scheduled lane runs green; crash triage workflow documented.
+- Validation: seeded-crash dry run proves the lane reports failures.
+- Size: M. Dependencies: none (D5 later refactors keep targets intact).
+
+### A4: Unsafe-Code Safety Documentation
+
+- Steps: add `SAFETY:` comments to every `unsafe` block in
+  `runtime/container/rust/src/lib.rs` and binaries, stating the invariant
+  that makes the block sound; add a lint/check that rejects new undocumented
+  unsafe blocks; write the pre-audit checklist.
+- Exit gates: zero undocumented unsafe blocks; check enforced in CI.
+- Validation: Rust build and test lanes; negative-test the check.
+- Size: S. Dependencies: none. Pairs with D5.
+
+### B1: SLSA v1.0 Gap Analysis
+
+- Steps: audit the release path against SLSA Build L1–L3; publish the gap
+  matrix in [`provenance.md`](provenance.md) (hermeticity, builder hardening,
+  two-person review), marking which gaps are structural to single-maintainer
+  mode and what closes each.
+- Exit gates: every SLSA L3 requirement has a status and, where unmet, a
+  named path or explicit non-goal.
+- Validation: docs lanes; release-owner review lens.
+- Size: M. Dependencies: none. Feeds B2 and Phase 11 evidence.
+
+### B7 (part 1): OpenSSF Best Practices Badge
+
+- Steps: register the project, complete the passing-level questionnaire,
+  remediate any unmet criteria, add the badge plus the existing Scorecard
+  badge to README.
+- Exit gates: passing badge live; criteria answers recorded.
+- Validation: badge status page.
+- Size: S. Dependencies: none.
+
+### C5: Syscall-Shim Performance Baselines
+
+- Steps: add microbenchmarks for hooked exec/spawn/posix_spawn paths versus
+  unhooked baseline; record results in a reviewed benchmarks doc; wire an
+  optional benchmark lane.
+- Exit gates: baseline numbers published with methodology; rerun instructions
+  documented.
+- Validation: benchmark lane produces stable numbers across two runs.
+- Size: S. Dependencies: none. Feeds C2 and E6 benchmarking claims.
+
+### D8: Stability Contracts
+
+- Steps: document which internal Go APIs and CLI flags/output lines are
+  stable versus experimental ahead of 1.0; unify and document the exit-code
+  contract across the Rust launcher, Go binaries, and shell entrypoints.
+- Exit gates: contract doc reviewed; any exit-code mismatches found during
+  the audit are fixed or explicitly recorded.
+- Validation: deterministic exit-code tests for documented paths.
+- Size: S. Dependencies: none. Direct input to G1.
+
+### E1: Tiered Documentation Entry Points
+
+- Steps: restructure README around three labeled paths (open-source
+  operator, enterprise evaluator, contributor); extract the operator command
+  reference and long tables into dedicated docs; keep README as orientation
+  plus the 5-minute path.
+- Exit gates: README materially shorter; no content lost (moved, not
+  deleted); link checks pass; quickstart path unchanged or improved.
+- Validation: docs lanes with E4 checks.
+- Size: M. Dependencies: E4 (link checking) strongly preferred first.
+
+### E2: Architecture Diagrams
+
+- Steps: add maintained Mermaid diagrams to
+  [`workcell-system-design.md`](workcell-system-design.md): boundary stack
+  (host/VM/container/provider), policy-to-injection trust flow, control-plane
+  seeding/masking; reference from the enterprise evidence baseline.
+- Exit gates: diagrams render on GitHub; sources live in the repo; evidence
+  baseline links them.
+- Validation: docs lanes; visual review.
+- Size: M. Dependencies: none.
+
+### F3: Standards Watchlist
+
+- Steps: write a short reviewed doc tracking the MCP spec line, OWASP
+  agentic guidance, and agent-identity drafts, with owner and review cadence.
+- Exit gates: doc exists with current entries and next-review date.
+- Validation: docs lanes.
+- Size: S. Dependencies: none.
+
+### G1 (part 1): Public Contract Inventory
+
+- Steps: enumerate the public operator surface — CLI flags, stable output
+  lines (`support_matrix_*`, `provider_bootstrap_*`, session key=value
+  summaries), exit codes, injection-policy schema keys, session-record and
+  export formats — into a versioned contract document; classify each entry
+  stable/experimental/deprecated; reconcile the manpage and CLI reference
+  against the inventory.
+- Exit gates: inventory complete and reviewed; every documented surface has
+  a deterministic test or check referencing it; manpage gaps filed or fixed.
+- Validation: contract-to-code drift check in CI.
+- Size: M. Dependencies: D8. The freeze itself is G1 part 2 at v1.0-rc.
+
+## Milestone v0.14: Platform, Speed, And Adoption
+
+### C1: Apple `container` Backend Evaluation (macOS 26+)
+
+- Steps: spike behind the existing target-kind contract as
+  `local_vm/apple-container`; map lifecycle, mounts, networking, and
+  diagnostics onto the shared conformance harness; measure boundary
+  properties versus Colima (per-session VM, boot latency); record the
+  evaluation and a go/no-go promotion decision; ship nothing support-visible
+  until the full support-matrix gates pass.
+- Exit gates: written evaluation with conformance results; explicit
+  fail-closed behavior on macOS below 26; promotion decision recorded in the
+  roadmap.
+- Validation: deterministic conformance harness; live local exercise.
+- Size: L. Dependencies: none technically; C2 benefits from it. The 1.0 gate
+  is the recorded decision, not a shipped backend.
+
+### C2: Session Start Latency Program
+
+- Steps: measure and publish the current cold/warm start breakdown; add
+  prebaked per-project image caching under the existing cache-profile
+  labeling; evaluate a kept-warm VM lane as an explicit labeled mode;
+  publish reproducible startup benchmarks; set and record the 1.0 latency
+  target.
+- Exit gates: measured improvement recorded; no new unlabeled assurance
+  downgrade; benchmark methodology published; 1.0 target met or re-scoped
+  with rationale.
+- Validation: benchmark lane; scenario coverage for cache-profile behavior.
+- Size: M. Dependencies: C5 methodology; C1 informs the ceiling.
+
+### B8: CI Efficiency And Reliability Program
+
+- Steps: move expensive reproducibility checks to a nightly lane on `main`
+  with release preflight consuming the recorded result; add retry policy for
+  transient artifact/network steps; add flaky-test tracking (label plus
+  weekly report); add CI cost visibility reporting.
+- Exit gates: PR wall-clock reduced without losing release-time assurance;
+  flake report exists; cost report exists.
+- Validation: before/after CI timing evidence.
+- Size: M. Dependencies: none.
+
+### B9: CI/CD Threat Model
+
+- Steps: write `docs/ci-threat-model.md`: secrets handling and rotation,
+  runner trust tiers (GitHub-hosted versus self-hosted), attestation
+  verification assumptions, signing-compromise incident response.
+- Exit gates: doc reviewed; SECURITY.md links it.
+- Validation: docs lanes; security review lens.
+- Size: M. Dependencies: none. Gates B6 in v0.15.
+
+### D3 (start): Migrate Largest Orchestration Scripts To Go
+
+- Steps: reimplement `verify-invariants.sh` (9,131 lines) and
+  `container-smoke.sh` (4,570 lines) incrementally as Go commands under
+  `cmd/`, one check-group per PR, keeping scenario parity via existing
+  manifests; retire shell paths only when their Go replacements have equal or
+  better coverage.
+- Exit gates: per batch — identical pass/fail behavior on the scenario
+  corpus; final (v1.0-rc) — shell originals removed or reduced to thin
+  shims.
+- Validation: side-by-side runs during migration; mutation coverage on the
+  Go replacements.
+- Size: L. Dependencies: D1; D2 reduces churn first; B3 baseline in place.
+
+### D4: Modularize The Launcher
+
+- Steps: split `scripts/workcell` (8,910 lines) into sourced modules (host
+  detection, environment scrubbing, wrapper assembly, dispatch); write
+  `docs/launcher-contract.md` (required tools, environment expectations,
+  exit codes, test override flags).
+- Exit gates: behavior-identical on the scenario suite; contract doc matches
+  implementation.
+- Validation: scenario suite before/after; bats coverage for extracted
+  modules (D7).
+- Size: M. Dependencies: D1, D2.
+
+### E5: Injection-Policy Schema Documentation
+
+- Steps: expand [`injection-policy.md`](injection-policy.md) with an
+  annotated schema (each key: type, required/optional, provider
+  applicability) and complete per-provider example policies including the
+  multi-provider single-host pattern; add a check that documented keys match
+  the parser's accepted set.
+- Exit gates: schema doc complete; drift check green.
+- Validation: docs lanes plus the drift check.
+- Size: M. Dependencies: A2 adds keys — document them together; feeds G1.
+
+### E6: Adoption Growth Kit
+
+- Steps: publish a rendered docs site from the existing markdown; record
+  asciinema demos for the 5-minute path and one provider quickstart; ship a
+  Homebrew tap alongside the formula asset; write the "why a VM boundary"
+  architecture post backed by C5/C2 benchmark numbers.
+- Exit gates: site live; demos embedded; tap installable; post published
+  with reproducible benchmark methodology.
+- Validation: install-from-tap verification lane; docs lanes.
+- Size: M. Dependencies: C5 (numbers), E1 (structure) first.
+
+### E7: Contributor Runbook Depth
+
+- Steps: give adapter READMEs real content (auth methods, managed
+  control-plane files, adapter behavior summary); add worked contributor
+  examples (add a credential type, extend an adapter) with the
+  invariants/threat-model checklist each touches.
+- Exit gates: no stub adapter README remains; examples verified by following
+  them.
+- Validation: docs lanes; dry-run of one worked example.
+- Size: S. Dependencies: none.
+
+### G2: Support Bundle Command
+
+- Steps: design the `workcell support-bundle` collection set (install state,
+  policy view, target diagnostics, provider bootstrap summaries, session
+  metadata, recent audit pointers) with documented redaction rules; implement
+  host-side with deterministic output shape; document the operator flow in
+  SUPPORT.md.
+- Exit gates: bundle contains the evidence needed to diagnose install,
+  policy, target, provider, and runtime failures; redaction tests prove no
+  credential material or workspace content leaks; docs updated.
+- Validation: unit tests over collection and redaction; golden-file bundle
+  shape; one scenario per failure class.
+- Size: M. Dependencies: none; coordinates with F1 field naming.
+
+### Provider Parity: Google Antigravity CLI Tier 1 Adapter
+
+Runs as the already-committed provider-parity track under its existing exit
+gates (adapter, pinned install/auth provenance, explicit Google auth staging,
+session-local provider home/cache, unsafe-argument policy, quickstart,
+deterministic tests, live provider certification). This plan adds only
+sequencing: the track runs inside the 1.0 window starting v0.14, and its
+outcome — support claim or explicitly recorded deferral — is a G4 input. No
+shortcut to the Tier 1 evidence bar.
+
+## Milestone v0.15: Enterprise Evidence And Release Assurance
+
+### A5: Signed Session Audit Records
+
+- Steps: design the hash-chain format for session audit logs; sign chain
+  heads host-side with existing Sigstore tooling; add verification tooling
+  (`workcell session verify` shape decided at design review); document the
+  trust model (boundary-signed, not agent-signed).
+- Exit gates: tamper on any record breaks verification in tests; export
+  format versioned; docs updated.
+- Validation: unit tests over chain/verify; scenario for tamper detection.
+- Size: M. Dependencies: F1 format decisions coordinated.
+
+### A6: Documented Syscall And Filesystem Hardening Profile
+
+- Steps: extract the runtime container's effective seccomp posture,
+  capability set, and rootfs expectations into reviewed policy artifacts;
+  publish the outbound-endpoint inventory; add a deterministic conformance
+  check comparing artifacts to the built image.
+- Exit gates: conformance check green in CI and release preflight; docs
+  reference the artifacts.
+- Validation: negative-test the conformance check.
+- Size: M. Dependencies: A1 design informs the endpoint inventory.
+
+### B2: Dual-Control Release Approval
+
+- Steps: add a second release approver identity; require two approvals on
+  the release environment; update `docs/releasing.md` including the
+  emergency bypass and its audit trail.
+- Exit gates: hosted controls enforce two approvals; releasing doc updated;
+  hosted-controls audit lane verifies the setting.
+- Validation: hosted-controls workflow assertions.
+- Size: M. Dependencies: a second trusted maintainer; B1 recommended first.
+
+### B6: Real-Boundary Certification Lane In CI
+
+- Steps: with B9 landed, evaluate self-hosted Apple Silicon runner options
+  versus macOS CI services; treat the runner as lower-trust per the threat
+  model (no repo secrets beyond scoped runner registration); implement a
+  scheduled lane that launches the strict Colima path and runs the
+  certification smoke; document runner lifecycle.
+- Exit gates: scheduled lane exercises a real strict launch; failure alerts
+  actionable; threat model covers the runner.
+- Validation: the lane itself plus induced-failure drill.
+- Size: L. Dependencies: B9.
+
+### C3: Native Parallel Sessions
+
+- Steps: design review (may start during v0.14) for worktree-aware workspace
+  handling (one agent per worktree/branch/isolated runtime); extend session
+  records with linkage across parallel sessions; define per-session resource
+  and identity boundaries; implement launch/inventory/diff flows for N
+  concurrent sessions per repo.
+- Exit gates: two concurrent sessions on one repo cannot interfere
+  (deterministic tests); session tooling renders parallel topology; docs
+  updated; works on the strict path.
+- Validation: scenario coverage including conflict cases; live exercise.
+- Size: L. Dependencies: C2 (latency makes parallel viable); C1 decision
+  helps (per-session VMs).
+
+### D5: Modularize The Rust Interception Library
+
+- Steps: split `lib.rs` (2,288 lines) into focused modules (syscall shim,
+  git policy, runtime protection, path validation) preserving the exported
+  ABI; keep A3 fuzz targets and A4 safety docs green through the refactor.
+- Exit gates: no behavior change on runtime test surface; module boundaries
+  documented; unsafe-block documentation preserved.
+- Validation: full runtime test suite plus fuzz corpus replay before/after.
+- Size: L. Dependencies: A3, A4 first (safety net before refactor).
+
+### D7: Deepen Test Kinds
+
+- Steps: add property-based tests for the session lifecycle state machine
+  (attach/detach/timeout idempotency, signal races); add Go benchmarks for
+  validation and session hot paths; add a bats (or equivalent) unit lane for
+  shared shell helpers from D2.
+- Exit gates: new lanes green in CI; at least one previously untested
+  interleaving covered.
+- Validation: the lanes themselves; mutation score movement (B3).
+- Size: M. Dependencies: D2 for the shell portion; extends to C3's parallel
+  session states.
+
+### F1: OCSF-Mapped Audit Export
+
+- Steps: map session-record fields to OCSF classes per the OWASP Agent
+  Observability Standard; add an OCSF JSONL export mode to
+  `workcell session export`; document redaction rules and privacy
+  boundaries; version the mapping.
+- Exit gates: exported events validate against the OCSF schema; redaction
+  tests pass; Phase 17 docs reference the format.
+- Validation: schema-validation tests; golden-file exports.
+- Size: M. Dependencies: A5 coordinated (signed records should export
+  cleanly); shares redaction rules with G2.
+
+### G3: Install Lifecycle Proof
+
+- Steps: define the day-two evidence set — install, upgrade-in-place across
+  one minor version, uninstall, rollback, `--gc` — on the release matrix;
+  add config/schema compatibility reads where upgrades cross versioned
+  formats; automate what GitHub-hosted macOS runners can prove and record
+  the local-operator remainder as certification evidence.
+- Exit gates: each lifecycle operation has repeatable evidence; upgrade and
+  rollback leave no orphaned Workcell-owned state; docs match behavior.
+- Validation: CI install-matrix lanes extended with upgrade/rollback;
+  scenario coverage for state cleanup.
+- Size: M. Dependencies: G1 inventory (formats must be versioned to prove
+  compatibility).
+
+## Milestone v1.0-rc: Freeze And Gate
+
+### G1 (part 2): Contract Freeze And Deprecation Policy
+
+- Steps: publish the semantic-versioning and deprecation policy; mark the
+  inventoried surface frozen; convert the contract-to-code drift check into
+  a release gate; declare experimental surfaces explicitly.
+- Exit gates: every stable surface is versioned, tested, and documented in
+  the manpage/CLI reference; deprecation policy published; drift gate
+  enforced in release preflight.
+- Validation: contract drift gate; release preflight dry run.
+- Size: M. Dependencies: G1 part 1, D8, E5.
+
+### G4: 1.0 Readiness Gate Review
+
+- Steps: run the cross-lens review (product, enterprise/security,
+  adapter-maintainer, validation, docs/contract, release) against the 1.0
+  release criteria in the roadmap; verify every host-support and provider
+  matrix row against shipped behavior; record all scope decisions (for
+  example an Antigravity certification deferral) explicitly; file and burn
+  down any P0/P1 findings.
+- Exit gates: no unresolved P0/P1 findings; matrices verified; scope
+  decisions recorded; criteria checklist complete with evidence links.
+- Validation: the recorded review itself.
+- Size: S (review) over the rc period. Dependencies: everything above.
+
+### D3 (complete): Orchestration Migration Finished
+
+- Exit gates: `verify-invariants` and `container-smoke` fully served by Go
+  implementations with equal or better coverage; shell originals removed or
+  reduced to thin shims.
+
+### D6: Split Oversized Go Validators
+
+- Steps: split `pinnedinputs.go` (1,546 lines) into per-format packages
+  (docker, node, rust, workflows, python) with focused tests; apply the same
+  pattern to the largest dispatcher mains.
+- Exit gates: behavior-identical validation results on the existing corpus;
+  per-package tests.
+- Validation: existing pin-hygiene lanes before/after; mutation coverage.
+- Size: M. Dependencies: none; scheduled late to avoid churn against B4.
+
+## Post-1.0
+
+### B7 (part 2): Third-Party Boundary Audit
+
+- Steps: scope an external audit of the runtime boundary (Rust shim, VM and
+  container configuration, credential staging); pursue funding (OSTIF or
+  sponsor); remediate and publish results. Scheduling the audit is a 1.0
+  criterion; completing it is post-1.0 work.
+- Exit gates: audit report published; findings triaged to closure or
+  explicit acceptance.
+- Size: L. Dependencies: A3, A4, D5 (audit-ready code).
+
+### C4: Container Tooling Inside The Boundary
+
+- Steps: investigate rootless or nested container execution inside the
+  bounded runtime; document the assurance impact; if viable, ship as an
+  explicit labeled lane, never as a silent capability of `strict`.
+- Exit gates: written investigation with a go/no-go; any shipped lane has
+  its own tier label, diagnostics, and scenario evidence.
+- Validation: boundary tests proving the outer VM/container posture is
+  unchanged when the lane is off.
+- Size: L. Dependencies: C1 evaluation informs the mechanism.
+
+### F2: Per-Session Identity Groundwork
+
+- Steps: define a stable trust-domain session identifier (SPIFFE-style URI
+  shape) and stamp it into session records and exports; keep it local-first
+  (no hosted control plane); document how Phase 15 identity work consumes
+  it.
+- Exit gates: identifier present and stable across session lifecycle;
+  export formats (F1) carry it; docs updated.
+- Validation: unit tests over identifier stability; export golden files.
+- Size: M. Dependencies: F1.
+
+### Roadmap Phases 13–19
+
+Linux `amd64` promotion (Phase 13), Linux `arm64`/Raspberry Pi (Phase 14),
+identity and access (Phase 15), signed policy bundles (Phase 16), fleet
+inventory and audit export beyond F1 (Phase 17), the regulated-team proof
+harness and Windows investigation (Phase 18), and the managed-workstation
+preview plus Azure (Phase 19) continue under their existing exit gates.
+Phase 13 may land before 1.0 if its certification evidence arrives, but it
+does not gate 1.0.
+
+## Dependency Summary
+
+- D1 → D2 → D3/D4; A3 + A4 → D5; D2 → D7 (shell portion)
+- B9 → B6; B1 → B2; B3 baseline before D3/D5 refactors land
+- C5 → C2 → C3; C1 decision informs C2/C3/C4
+- E4 → E1 → E6; A2 → E5; D8 → G1 (inventory) → G1 (freeze); E5 → G1 (freeze)
+- G1 (inventory) → G3; A5 ↔ F1 coordinated; F1 → F2; G2 ↔ F1 redaction rules
+- A3/A4/D5 → B7 (part 2); everything → G4
+
+## Verification Model
+
+- every code-bearing item lands tests-first with unit, integration, and —
+  where the touched packages already carry it — mutation coverage
+- refactor items (D2–D6) require identical behavior on the existing scenario
+  corpus before and after, per batch
+- security items (A1, A2, A5, A6) require fail-closed negative tests and
+  threat-model/invariants updates in the same change
+- CI items (B3, B4, B6, B8) require a seeded-failure drill proving the gate
+  actually trips
+- operations items (G2, G3) require redaction/negative tests and repeatable
+  lifecycle evidence, not one-off manual runs
+- support-visible changes (C1 promotion, C3, C4 lanes, Antigravity support)
+  additionally require the standard support-matrix, diagnostics, docs,
+  rollback, and live certification package before any claim
+- the 1.0 claim itself requires the G4 gate review with recorded evidence
+
+## Status Tracking
+
+Track progress by item identifier in PR titles and the changelog. When an
+item completes, record the delivered evidence next to its roadmap entry;
+when an item is dropped or reshaped, update both this plan and the roadmap
+section in the same change. Milestone reassignment is a normal, recorded
+event; silently skipping a 1.0 criterion is not.


### PR DESCRIPTION
# Summary

Documentation-only change recording the 2026-07 repository review and the
resulting 1.0 release program:

- Adds a **Path To 1.0** section to `ROADMAP.md`: what 1.0 means
  (contract-stability and assurance, not platform reach), eight release
  criteria, a milestone train (v0.12 → v1.0-rc → post-1.0), and the explicit
  statement that Linux/Windows/managed-workstation expansion continues after
  1.0 without gating it.
- Adds an **Engineering And Ecosystem Improvement Tracks** section to
  `ROADMAP.md`: seven tracks (boundary depth, supply chain and release
  assurance, runtime platform evolution, code health, documentation and
  adoption, enterprise and standards alignment, and 1.0
  contract-and-operations), 43 identified items with horizon and size.
- Adds `docs/improvement-tracks-implementation-plan.md`: a milestone-based
  implementation plan with per-item steps, exit gates, dependencies,
  validation expectations, competitive drivers, a dependency summary, and a
  verification model.

Inputs: a full review of repository documentation, Rust/Go/shell source,
tests, and CI/release workflows, combined with external research on the
2025–2026 agent-sandboxing ecosystem (competing runtimes, disclosed
agent-CLI vulnerability classes, emerging enterprise and standards
expectations, OSS adoption patterns).

## Support-claim impact

None. Both documents record direction and sequencing only. Support
boundaries, provider tiers, and certification gates are unchanged; the new
sections state this explicitly and route every support-visible item through
the existing matrix and certification gates. The Antigravity adapter track
keeps its existing Tier 1 evidence bar; the 1.0 criteria allow an explicit
recorded deferral rather than a shortcut.

## Validation

- `codespell` clean on both files
- repo `markdownlint` config clean on both files
- `./scripts/pre-merge.sh --profile pr-parity` fresh local parity evidence
  before publication
