### PR TITLE
Add support-tier docs and support-matrix field-parity check (E3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,8 @@ See [docs/provenance.md](docs/provenance.md) and
 | Topic | File |
 |---|---|
 | Getting started | [docs/getting-started.md](docs/getting-started.md) |
+| Support tiers | [docs/support-tiers.md](docs/support-tiers.md) |
+| Diagnostics and support matrix | [docs/diagnostics-and-support-matrix.md](docs/diagnostics-and-support-matrix.md) |
 | Security invariants | [docs/invariants.md](docs/invariants.md) |
 | Threat model | [docs/threat-model.md](docs/threat-model.md) |
 | Provider matrix | [docs/provider-matrix.md](docs/provider-matrix.md) |

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -15,7 +15,10 @@
 - if auth is involved, run `workcell auth status --agent <provider>` and
   `workcell --agent <provider> --auth-status --workspace /path/to/repo`
 - compare the reported `support_matrix_*` lines with
-  [policy/host-support-matrix.tsv](policy/host-support-matrix.tsv)
+  [policy/host-support-matrix.tsv](policy/host-support-matrix.tsv), using
+  [docs/diagnostics-and-support-matrix.md](docs/diagnostics-and-support-matrix.md)
+  to interpret each field and [docs/support-tiers.md](docs/support-tiers.md)
+  for the tier and status vocabulary
 - capture the exact command, provider, mode, and host environment
 
 ## Include this context

--- a/docs/diagnostics-and-support-matrix.md
+++ b/docs/diagnostics-and-support-matrix.md
@@ -1,0 +1,49 @@
+# Diagnostics and the support matrix
+
+`workcell --doctor` and `workcell --inspect` emit host and
+`support_matrix_*` key=value lines derived from
+[`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv). This
+page explains each field and how an operator should act on the resolved row.
+
+## Emitted fields
+
+<!-- support-matrix-fields:begin -->
+| Field | Meaning |
+|---|---|
+| `host_os` | Detected host operating system (for example `macos`, `linux`). |
+| `host_arch` | Detected host CPU architecture (for example `arm64`, `amd64`). |
+| `host_distro` | Detected Linux distribution ID, or `none` off Linux. |
+| `host_distro_version` | Detected Linux distribution version, or `none` off Linux. |
+| `support_matrix_status` | Row status for the resolved host and target: `supported`, `preview-only`, `validation-host-only`, or `unsupported`. |
+| `support_matrix_launch` | Whether operator launch is `allowed` or `blocked` for the resolved combination. |
+| `support_matrix_evidence` | Evidence tier backing the row: `certification-only`, `repo-required`, `manual-only`, or `none`. |
+| `support_matrix_validation_lane` | Named validation lane for the row, or `none`. |
+| `support_matrix_reason` | Human-readable reason string for the resolved status. |
+<!-- support-matrix-fields:end -->
+
+The matrix `target_kind`, `target_provider`, and `target_assurance_class`
+columns are not emitted as `--doctor`/`--inspect` fields; read them from the
+matched row in
+[`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv).
+
+## Triage decision tree
+
+1. If `support_matrix_launch=allowed`:
+   - With `support_matrix_status=supported`, proceed only for the resolved row and only with the evidence its `support_matrix_evidence` names (for current supported rows this is `certification-only`) as recorded in `policy/host-support-matrix.tsv`.
+   - With any other status, treat the row as inconsistent for operator launch, stop, and follow `support_matrix_reason`.
+2. If `support_matrix_launch=blocked`:
+   - With `support_matrix_status=preview-only`, treat the row as preview or certification-only. It is not an operator launch host.
+   - With `support_matrix_status=validation-host-only`, use the host only for the named validation lane, such as `trusted-linux-amd64-validator`.
+   - With `support_matrix_status=unsupported`, do not launch. Read `support_matrix_reason` for the unsupported boundary.
+   - With any other status, follow the blocked launch decision first and do not treat the row as supported.
+
+## No implicit support claim
+
+No tier, assurance class, or status confers a support claim on its own.
+Supported launch paths still require the live certification evidence recorded in
+[`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv).
+
+For the vocabulary behind each value, see
+[`docs/support-tiers.md`](support-tiers.md). The canonical source for the
+resolved matrix row is
+[`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv).

--- a/docs/diagnostics-and-support-matrix.md
+++ b/docs/diagnostics-and-support-matrix.md
@@ -21,10 +21,10 @@ page explains each field and how an operator should act on the resolved row.
 | `support_matrix_reason` | Human-readable reason string for the resolved status. |
 <!-- support-matrix-fields:end -->
 
-The matrix `target_kind`, `target_provider`, and `target_assurance_class`
-columns are not emitted as `--doctor`/`--inspect` fields; read them from the
-matched row in
-[`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv).
+`--inspect` and `--doctor` also print additional launch-state fields,
+including `target_kind`, `target_provider`, and `target_assurance_class` for
+the selected target. Use those to confirm which non-default target was
+resolved.
 
 ## Triage decision tree
 

--- a/docs/support-tiers.md
+++ b/docs/support-tiers.md
@@ -1,0 +1,80 @@
+# Support tiers and status vocabulary
+
+This page defines the support vocabulary used across the README, ROADMAP,
+`--doctor`, and `--inspect`. The canonical source for host, target, provider,
+launch, evidence, and validation-lane claims is
+[`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv).
+
+## Status
+
+| Value | Meaning |
+|---|---|
+| `supported` | The matrix row is reviewed for an operator launch path when paired with the row's launch and evidence fields. This value does not create a support claim by itself. |
+| `preview-only` | The row is documented for preview or certification-only work. It is not a supported operator launch claim, and the row's launch field still controls whether Workcell may start anything. |
+| `validation-host-only` | The row is usable only for the named validation lane. It is not an operator launch host. |
+| `unsupported` | The host and target combination is not a supported Workcell combination. Operators should follow the row reason instead of launching. |
+
+## Target assurance class
+
+| Value | Meaning |
+|---|---|
+| `strict` | The target is intended for the stricter Workcell runtime boundary, such as the dedicated local VM path. The assurance class alone does not confer support. |
+| `compat` | The target is a compatibility or lower-assurance path. It must stay explicitly labeled and still depends on the matrix row for launch and evidence. |
+
+## Launch
+
+| Value | Meaning |
+|---|---|
+| `allowed` | Workcell may proceed with operator launch for the resolved row, subject to the row's status and required evidence. |
+| `blocked` | Workcell must not proceed with operator launch for the resolved row. The row reason explains the boundary. |
+
+## Evidence
+
+| Value | Meaning |
+|---|---|
+| `certification-only` | The row depends on live certification evidence recorded for that matrix entry. This is not replaced by the status or assurance class. |
+| `repo-required` | The row depends on repository-owned validation evidence rather than an operator launch claim. |
+| `manual-only` | The row depends on manual verification recorded for that matrix entry rather than automated or repository-owned evidence. |
+| `none` | The row has no supporting evidence claim. It must not be treated as supported. |
+
+## Validation lane
+
+| Value | Meaning |
+|---|---|
+| `none` | The row is not assigned to a named validation lane. |
+| `trusted-linux-amd64-validator` | The row is assigned to the trusted Linux amd64 validation lane and is not an operator launch host unless another matrix row says so. |
+
+## Target kind
+
+| Value | Meaning |
+|---|---|
+| `local_vm` | A local VM target kind. The current examples include the Colima strict path. |
+| `local_compat` | A local compatibility target kind. The current examples include the Docker Desktop compat path. |
+| `remote_vm` | A remote VM target kind. The current macOS examples for AWS EC2 SSM and GCP VM are `preview-only`; the same providers resolve to other statuses on other hosts per the matrix. |
+
+## Current matrix examples
+
+| host_os | host_arch | target_kind | target_provider | target_assurance_class | status | launch | evidence | validation_lane |
+|---|---|---|---|---|---|---|---|---|
+| `macos` | `arm64` | `local_vm` | `colima` | `strict` | `supported` | `allowed` | `certification-only` | `none` |
+| `macos` | `arm64` | `local_compat` | `docker-desktop` | `compat` | `supported` | `allowed` | `certification-only` | `none` |
+| `macos` | `arm64` | `remote_vm` | `aws-ec2-ssm` | `compat` | `preview-only` | `blocked` | `certification-only` | `none` |
+| `macos` | `arm64` | `remote_vm` | `gcp-vm` | `compat` | `preview-only` | `blocked` | `certification-only` | `none` |
+| `linux` | `amd64` | `local_vm` | `colima` | `strict` | `validation-host-only` | `blocked` | `repo-required` | `trusted-linux-amd64-validator` |
+| `linux` | `amd64` | `local_compat` | `docker-desktop` | `compat` | `unsupported` | `blocked` | `none` | `none` |
+
+- On macOS arm64 with the Colima `local_vm` strict target, the operator sees an allowed, certification-only launch path for the reviewed local VM row.
+- On macOS arm64 with the Docker Desktop `local_compat` compat target, the operator sees an allowed, certification-only launch path for the reviewed compatibility row.
+- On macOS arm64 with the AWS EC2 SSM `remote_vm` compat target, the operator sees a preview-only row with launch blocked for certification-only preview work.
+- On macOS arm64 with the GCP VM `remote_vm` compat target, the operator sees a preview-only row with launch blocked for certification-only preview work.
+- On Linux amd64 with the Colima `local_vm` strict target, the operator sees a validation-host-only row for the trusted Linux amd64 validator with launch blocked.
+- On Linux amd64 with the Docker Desktop `local_compat` compat target, the operator sees an unsupported row with launch blocked and no evidence claim.
+
+## No implicit support claim
+
+No tier, assurance class, or status confers a support claim on its own.
+Supported launch paths still require the live certification evidence recorded in
+[`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv).
+
+For the emitted `--doctor` and `--inspect` lines, see
+[`docs/diagnostics-and-support-matrix.md`](diagnostics-and-support-matrix.md).

--- a/scripts/check-doc-support-matrix-fields.sh
+++ b/scripts/check-doc-support-matrix-fields.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# Assert that the support-matrix metadata field names documented in
+# docs/diagnostics-and-support-matrix.md exactly match the field names emitted
+# by BOTH the Go emitter (internal/host/supportmatrix/supportmatrix.go
+# MetadataLines) and the shell emitter (scripts/workcell
+# print_support_matrix_state). Binding the doc to both emitters keeps the
+# operator-facing diagnostics guide aligned with the code and also fails if the
+# two emitters expose different field-name sets.
+#
+# Scope is deliberately field NAMES only: emission order, emitted values, and
+# tier-word coverage in the prose are not checked here.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+GO_FILE="${ROOT_DIR}/internal/host/supportmatrix/supportmatrix.go"
+SH_FILE="${ROOT_DIR}/scripts/workcell"
+DOC_FILE="${ROOT_DIR}/docs/diagnostics-and-support-matrix.md"
+
+fail() {
+  echo "check-doc-support-matrix-fields: $*" >&2
+  exit 1
+}
+
+for f in "${GO_FILE}" "${SH_FILE}" "${DOC_FILE}"; do
+  [[ -f "${f}" ]] || fail "missing required file: ${f#"${ROOT_DIR}/"}"
+done
+
+# Field names emitted by Go MetadataLines(), scoped to that function body.
+go_fields="$(
+  awk '/^func MetadataLines\(/{f=1} f{print} f&&/^}/{exit}' "${GO_FILE}" \
+    | grep -oE '"[a-z0-9_]+=%s"' \
+    | sed -E 's/"([a-z0-9_]+)=%s"/\1/' \
+    | sort -u
+)"
+
+# Field names printed by the shell print_support_matrix_state(), scoped to it.
+sh_fields="$(
+  awk '/^print_support_matrix_state\(\) \{/{f=1} f{print} f&&/^}/{exit}' "${SH_FILE}" \
+    | grep -oE "'[a-z0-9_]+=%s" \
+    | sed -E "s/'([a-z0-9_]+)=%s/\1/" \
+    | sort -u
+)"
+
+# Field names documented between the machine-checked markers in the doc. Only
+# the first table cell of each row is the field-name column; backticked value
+# examples in the meaning column are intentionally ignored. The backtick is
+# sourced from a variable so the extraction patterns stay in double quotes.
+bt='`'
+doc_fields="$(
+  awk '/<!-- support-matrix-fields:begin -->/{f=1;next} /<!-- support-matrix-fields:end -->/{f=0} f' "${DOC_FILE}" \
+    | grep -oE "^\\| ${bt}[a-z0-9_]+${bt}" \
+    | sed -E "s/^\\| ${bt}([a-z0-9_]+)${bt}/\\1/" \
+    | sort -u
+)"
+
+[[ -n "${go_fields}" ]] || fail "extracted no fields from Go MetadataLines()"
+[[ -n "${sh_fields}" ]] || fail "extracted no fields from shell print_support_matrix_state()"
+[[ -n "${doc_fields}" ]] || fail "extracted no fields from ${DOC_FILE#"${ROOT_DIR}/"} (are the support-matrix-fields markers present?)"
+
+report_diff() {
+  local label_a="$1" set_a="$2" label_b="$3" set_b="$4"
+  local only_a only_b
+  only_a="$(comm -23 <(printf '%s\n' "${set_a}") <(printf '%s\n' "${set_b}") | tr '\n' ' ')"
+  only_b="$(comm -13 <(printf '%s\n' "${set_a}") <(printf '%s\n' "${set_b}") | tr '\n' ' ')"
+  [[ -n "${only_a// }" ]] && echo "  only in ${label_a}: ${only_a}" >&2
+  [[ -n "${only_b// }" ]] && echo "  only in ${label_b}: ${only_b}" >&2
+}
+
+if [[ "${go_fields}" != "${sh_fields}" ]]; then
+  echo "check-doc-support-matrix-fields: Go and shell emitters disagree" >&2
+  report_diff "Go" "${go_fields}" "shell" "${sh_fields}"
+  exit 1
+fi
+
+if [[ "${doc_fields}" != "${go_fields}" ]]; then
+  echo "check-doc-support-matrix-fields: documented fields differ from the emitted fields" >&2
+  report_diff "doc" "${doc_fields}" "code" "${go_fields}"
+  exit 1
+fi
+
+field_count="$(printf '%s\n' "${go_fields}" | grep -c .)"
+echo "check-doc-support-matrix-fields: OK (${field_count} field names match across Go emitter, shell emitter, and doc)"

--- a/scripts/ci/job-docs.sh
+++ b/scripts/ci/job-docs.sh
@@ -18,6 +18,9 @@ trap cleanup EXIT
 echo "[ci/docs] pinned input policy"
 "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
 
+echo "[ci/docs] support-matrix field parity"
+"${ROOT_DIR}/scripts/check-doc-support-matrix-fields.sh"
+
 echo "[ci/docs] validator image build"
 VALIDATOR_IMAGE="$("${ROOT_DIR}/scripts/ci/build-validator-image.sh")"
 export WORKCELL_VALIDATOR_IMAGE="${VALIDATOR_IMAGE}"


### PR DESCRIPTION
# Summary

Lands ROADMAP item **E3** (support-tier legend and diagnostics guide) with a
durable executable invariant, per
[`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md):

- **`docs/support-tiers.md`** — defines the support vocabulary
  (`status`, `target_assurance_class`, `launch`, `evidence`,
  `validation_lane`, `target_kind`) exactly as encoded in
  `policy/host-support-matrix.tsv`, with the current matrix example rows and a
  prominent "no implicit support claim" note.
- **`docs/diagnostics-and-support-matrix.md`** — explains every
  `--doctor`/`--inspect` `support_matrix_*`/`host_*` field and a triage
  decision tree keyed on `support_matrix_launch` + `support_matrix_status`.
- **`scripts/check-doc-support-matrix-fields.sh`** — a new deterministic
  invariant asserting the documented field-name set is exactly equal to the
  field names emitted by BOTH the Go emitter
  (`internal/host/supportmatrix/supportmatrix.go` `MetadataLines`) and the
  shell emitter (`scripts/workcell` `print_support_matrix_state`). It also
  fails if those two emitters ever diverge from each other.
- Wired into the docs CI lane (`scripts/ci/job-docs.sh`) as a host-side,
  no-Docker, fail-fast step.
- `README.md` docs map and `SUPPORT.md` link both new docs.

## Support-claim impact

None. The docs mirror `policy/host-support-matrix.tsv` exactly and state
explicitly that no tier, assurance class, or status confers a support claim
without the live certification evidence recorded in the matrix. No runtime,
boundary, credential, or policy-enforcement code is touched.

## Validation

- `scripts/check-doc-support-matrix-fields.sh` exits 0 (9 fields in lockstep
  across Go, shell, and doc); negative controls confirm it fails on doc drift
  and on Go-vs-shell emitter drift
- `shellcheck` clean on the new script; `codespell` and repo `markdownlint`
  clean on all changed files; 0 broken relative doc links
- `./scripts/pre-merge.sh --profile pr-parity` before publication
