### PR TITLE
Add markdown link and orphan CI check (E4)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,9 @@ on:
       - "man/**"
       - "policy/**"
       - "runtime/**"
+      - "scripts/check-doc-links.sh"
+      - "scripts/check-doc-support-matrix-fields.sh"
+      - "scripts/ci/job-docs.sh"
       - "verify/**"
       - "workflows/**"
   pull_request:
@@ -43,6 +46,9 @@ on:
       - "man/**"
       - "policy/**"
       - "runtime/**"
+      - "scripts/check-doc-links.sh"
+      - "scripts/check-doc-support-matrix-fields.sh"
+      - "scripts/ci/job-docs.sh"
       - "verify/**"
       - "workflows/**"
   workflow_dispatch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - ".codespellrc"
+      - "**/*.md"
       - "CHANGELOG.md"
       - "CODE_OF_CONDUCT.md"
       - "CONTRIBUTING.md"
@@ -31,6 +32,7 @@ on:
       - main
     paths:
       - ".codespellrc"
+      - "**/*.md"
       - "CHANGELOG.md"
       - "CODE_OF_CONDUCT.md"
       - "CONTRIBUTING.md"

--- a/docs/examples/quickstart-claude.md
+++ b/docs/examples/quickstart-claude.md
@@ -125,6 +125,7 @@ workcell auth set \
 
 ## Further reading
 
+- [docs/examples/enterprise-claude-setup.md](enterprise-claude-setup.md)
 - [docs/injection-policy.md](../injection-policy.md)
 - [docs/provider-bootstrap-matrix.md](../provider-bootstrap-matrix.md)
 - [docs/adapter-control-planes.md](../adapter-control-planes.md)

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -275,6 +275,7 @@
       ],
       "workflow_path_globs": {
         "pull_request": [
+          "**/*.md",
           ".codespellrc",
           "AGENTS.md",
           "CHANGELOG.md",
@@ -298,6 +299,7 @@
           "workflows/**"
         ],
         "push": [
+          "**/*.md",
           ".codespellrc",
           "AGENTS.md",
           "CHANGELOG.md",

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -291,6 +291,9 @@
           "man/**",
           "policy/**",
           "runtime/**",
+          "scripts/check-doc-links.sh",
+          "scripts/check-doc-support-matrix-fields.sh",
+          "scripts/ci/job-docs.sh",
           "verify/**",
           "workflows/**"
         ],
@@ -311,6 +314,9 @@
           "man/**",
           "policy/**",
           "runtime/**",
+          "scripts/check-doc-links.sh",
+          "scripts/check-doc-support-matrix-fields.sh",
+          "scripts/ci/job-docs.sh",
           "verify/**",
           "workflows/**"
         ]

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -54,11 +54,16 @@ for f in "${md_files[@]}"; do
       note "broken link: ${f} -> ${target} (missing ${resolved})"
       continue
     fi
-    # The target exists; require it to stay within the repository checkout so a
-    # traversal such as ../../etc/passwd cannot pass by matching a host file.
-    canon="$(cd "$(dirname "${resolved}")" && pwd -P)/$(basename "${resolved}")"
+    # The target exists; canonicalize it fully (resolving any trailing ..) and
+    # require it to stay within the repository checkout so a traversal such as
+    # ../../etc/passwd or ../../.. cannot pass by matching a host path.
+    if [[ -d "${resolved}" ]]; then
+      canon="$(cd "${resolved}" && pwd -P)"
+    else
+      canon="$(cd "$(dirname "${resolved}")" && pwd -P)/$(basename "${resolved}")"
+    fi
     case "${canon}" in
-      "${ROOT_DIR}"/*) : ;;
+      "${ROOT_DIR}"|"${ROOT_DIR}"/*) : ;;
       *) note "link escapes repository: ${f} -> ${target}" ;;
     esac
   done < <(

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -59,20 +59,22 @@ for f in "${md_files[@]}"; do
 done
 
 # --- Orphan docs/ check -----------------------------------------------------
-# A docs/*.md page is an orphan when its basename appears in no other tracked
-# (non-vendored) file: a markdown link, a script, the manpage, or a workflow all
-# count as a referrer. Index-style pages are referenced widely, so this stays
-# quiet on a healthy tree. Fails closed but distinguishes "no match" from a real
-# git error so an operational failure is not mistaken for an orphan storm.
+# A docs/*.md page is an orphan when no other tracked markdown file contains a
+# navigable link to it. A plain-text or code-span mention (in a scenario table,
+# a manifest, or a script) does not count: it does not let a reader reach the
+# page. Index-style pages are linked widely, so this stays quiet on a healthy
+# tree. Fails closed but distinguishes "no match" from a real git error so an
+# operational failure is not mistaken for an orphan storm.
 while IFS= read -r doc; do
   base="$(basename "${doc}")"
+  base_re="$(printf '%s' "${base}" | sed 's/\./\\./g')"
   set +e
-  git grep -qF "${base}" -- . ":!${doc}" "${vendor_pathspecs[@]}"
+  git grep -qE "\]\([^)]*${base_re}[)#]" -- '*.md' ":!${doc}" "${vendor_pathspecs[@]}"
   rc=$?
   set -e
   case "${rc}" in
     0) : ;;
-    1) note "orphan doc: ${doc} is referenced by no other tracked file" ;;
+    1) note "orphan doc: ${doc} is linked from no other tracked markdown file" ;;
     *) echo "check-doc-links: git grep failed (rc=${rc}) while scanning for ${base}" >&2; exit "${rc}" ;;
   esac
 done < <(git ls-files 'docs/*.md')

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -2,7 +2,9 @@
 # Offline Markdown integrity check over tracked docs: fails on broken intra-repo
 # relative links and on orphaned docs/ pages that nothing navigably links to. No
 # network calls and no dependencies beyond git, awk, sed, and grep so it can run
-# host-side in the docs CI lane.
+# host-side in the docs CI lane. Kept bash-3.2 compatible (no mapfile, no
+# associative arrays) because the host baseline is macOS /bin/bash 3.2; see
+# scripts/lib/shellproto.sh.
 #
 # Scope (intentional limits, documented so they read as choices, not gaps):
 # - Only space-free inline links of the form [text](target) are checked;
@@ -12,10 +14,8 @@
 # - Relative targets are resolved the way GitHub renders them: relative to the
 #   linking file's own directory, and are required to stay inside the repo.
 # - Heading-anchor (#fragment) validation is out of scope: reproducing GitHub's
-#   slug algorithm offline (duplicate headings, punctuation, inline HTML) is
-#   error-prone and would risk false failures on valid links. Target existence
-#   is the robust, high-value core; anchor validation can be added later behind
-#   its own evidence.
+#   slug algorithm offline is error-prone and would risk false failures on valid
+#   links. Target existence is the robust, high-value core.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
@@ -25,18 +25,23 @@ bt='`'
 failures=0
 note() { echo "check-doc-links: $*" >&2; failures=$((failures + 1)); }
 
+# Referrer index: one "linker<TAB>canonical-target" line per navigable link,
+# keyed by resolved absolute path so distinct files that share a basename are
+# never confused. A temp file keeps this bash-3.2 compatible.
+link_records="$(mktemp "${TMPDIR:-/tmp}/check-doc-links.XXXXXX")"
+trap 'rm -f "${link_records}"' EXIT
+
 # Vendored and generated trees are not our docs; exclude the same paths the
 # docs spelling job and .codespellrc skip. Test fixtures (testdata/) are also
 # excluded: they simulate external content, not documentation.
 excluded='^(runtime/container/rust/vendor|runtime/container/providers/node_modules|runtime/container/rust/target|dist|tmp)/|(^|/)testdata/'
-mapfile -t md_files < <(git ls-files '*.md' | grep -vE "${excluded}" || true)
 
-# Records, per link-target basename, the markdown files that navigably link it.
-# Populated from fence- and inline-code-stripped content in the link loop so the
-# orphan check below reuses the same view of who links whom.
-declare -A linked_by
+md_files=()
+while IFS= read -r mf; do
+  [[ -n "${mf}" ]] && md_files+=("${mf}")
+done < <(git ls-files '*.md' | grep -vE "${excluded}" || true)
 
-# --- Broken relative-link check ---------------------------------------------
+# --- Broken relative-link check + referrer index ----------------------------
 for f in "${md_files[@]}"; do
   dir="$(dirname "${f}")"
   while IFS= read -r target; do
@@ -47,17 +52,15 @@ for f in "${md_files[@]}"; do
     # Drop any #fragment; only the path portion is validated.
     path="${target%%#*}"
     [[ -n "${path}" ]] || continue
-    # Record this navigable link for the orphan check.
-    linked_by["$(basename "${path}")"]+=" ${f}"
     resolved="${dir}/${path}"
     # GitHub resolves relative links against the linking file's directory only.
     if [[ ! -e "${resolved}" ]]; then
       note "broken link: ${f} -> ${target} (missing ${resolved})"
       continue
     fi
-    # The target exists; canonicalize it fully (resolving any trailing ..) and
-    # require it to stay within the repository checkout so a traversal such as
-    # ../../etc/passwd or ../../.. cannot pass by matching a host path.
+    # Canonicalize fully (resolving any trailing ..) and require the target to
+    # stay within the repository checkout so a traversal such as ../../etc/passwd
+    # or ../../.. cannot pass by matching a host path.
     if [[ -d "${resolved}" ]]; then
       canon="$(cd "${resolved}" && pwd -P)"
     else
@@ -65,8 +68,9 @@ for f in "${md_files[@]}"; do
     fi
     case "${canon}" in
       "${ROOT_DIR}"|"${ROOT_DIR}"/*) : ;;
-      *) note "link escapes repository: ${f} -> ${target}" ;;
+      *) note "link escapes repository: ${f} -> ${target}"; continue ;;
     esac
+    printf '%s\t%s\n' "${f}" "${canon}" >> "${link_records}"
   done < <(
     # Strip fenced code blocks, then inline code spans, so example markdown
     # (fenced or `inline`) is not treated as a navigable link.
@@ -79,21 +83,14 @@ done
 
 # --- Orphan docs/ check -----------------------------------------------------
 # A docs/*.md page is an orphan when no other tracked markdown file navigably
-# links to it. A plain-text or code-span mention, or a link that only appears
-# inside a fenced or inline code sample, does not count: it does not let a
-# reader reach the page. Membership is taken from linked_by, populated above
-# from the same fence- and code-span-stripped scan used for broken-link
-# detection, so both checks agree on what a navigable link is.
+# links to it. Matching is by canonical path, so a page is not treated as
+# referenced merely because some unrelated file shares its basename.
 while IFS= read -r doc; do
-  base="$(basename "${doc}")"
-  others=0
-  for referrer in ${linked_by["${base}"]:-}; do
-    if [[ "${referrer}" != "${doc}" ]]; then
-      others=1
-      break
-    fi
-  done
-  if [[ "${others}" -eq 0 ]]; then
+  doc_canon="${ROOT_DIR}/${doc}"
+  if awk -F'\t' -v t="${doc_canon}" -v self="${doc}" \
+      '$2==t && $1!=self {found=1} END{exit found?0:1}' "${link_records}"; then
+    : # navigably linked from another markdown file
+  else
     note "orphan doc: ${doc} is linked from no other tracked markdown file"
   fi
 done < <(git ls-files 'docs/*.md')

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
 # Offline Markdown integrity check over tracked docs: fails on broken intra-repo
-# relative links and on orphaned docs/ pages that nothing references. No network
-# calls and no dependencies beyond git, awk, sed, and grep so it can run
+# relative links and on orphaned docs/ pages that nothing navigably links to. No
+# network calls and no dependencies beyond git, awk, sed, and grep so it can run
 # host-side in the docs CI lane.
 #
 # Scope (intentional limits, documented so they read as choices, not gaps):
 # - Only space-free inline links of the form [text](target) are checked;
-#   links inside fenced code blocks are skipped, and reference-style
-#   definitions ([text][ref]) and inline-HTML links are not validated.
+#   links inside fenced code blocks and inline `code` spans are skipped, and
+#   reference-style definitions ([text][ref]) and inline-HTML links are not
+#   validated.
 # - Relative targets are resolved the way GitHub renders them: relative to the
-#   linking file's own directory only.
+#   linking file's own directory, and are required to stay inside the repo.
 # - Heading-anchor (#fragment) validation is out of scope: reproducing GitHub's
 #   slug algorithm offline (duplicate headings, punctuation, inline HTML) is
 #   error-prone and would risk false failures on valid links. Target existence
@@ -17,9 +18,10 @@
 #   its own evidence.
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "${ROOT_DIR}"
 
+bt='`'
 failures=0
 note() { echo "check-doc-links: $*" >&2; failures=$((failures + 1)); }
 
@@ -29,9 +31,8 @@ excluded='^(runtime/container/rust/vendor|runtime/container/providers/node_modul
 mapfile -t md_files < <(git ls-files '*.md' | grep -vE "${excluded}" || true)
 
 # Records, per link-target basename, the markdown files that navigably link it.
-# Populated from fence-stripped content in the link loop so the orphan check
-# below reuses the same view of who links whom (a link inside a code fence is
-# not a navigable reference and must not keep a page out of the orphan set).
+# Populated from fence- and inline-code-stripped content in the link loop so the
+# orphan check below reuses the same view of who links whom.
 declare -A linked_by
 
 # --- Broken relative-link check ---------------------------------------------
@@ -45,15 +46,26 @@ for f in "${md_files[@]}"; do
     # Drop any #fragment; only the path portion is validated.
     path="${target%%#*}"
     [[ -n "${path}" ]] || continue
-    # Record this navigable link (fence-stripped) for the orphan check.
+    # Record this navigable link for the orphan check.
     linked_by["$(basename "${path}")"]+=" ${f}"
+    resolved="${dir}/${path}"
     # GitHub resolves relative links against the linking file's directory only.
-    if [[ ! -e "${dir}/${path}" ]]; then
-      note "broken link: ${f} -> ${target} (missing ${dir}/${path})"
+    if [[ ! -e "${resolved}" ]]; then
+      note "broken link: ${f} -> ${target} (missing ${resolved})"
+      continue
     fi
+    # The target exists; require it to stay within the repository checkout so a
+    # traversal such as ../../etc/passwd cannot pass by matching a host file.
+    canon="$(cd "$(dirname "${resolved}")" && pwd -P)/$(basename "${resolved}")"
+    case "${canon}" in
+      "${ROOT_DIR}"/*) : ;;
+      *) note "link escapes repository: ${f} -> ${target}" ;;
+    esac
   done < <(
-    # Strip fenced code blocks so example markdown inside ``` is not scanned.
+    # Strip fenced code blocks, then inline code spans, so example markdown
+    # (fenced or `inline`) is not treated as a navigable link.
     awk '/^[[:space:]]*```/{fence=!fence; next} !fence' "${f}" \
+      | sed -E "s/${bt}[^${bt}]*${bt}//g" \
       | grep -oE '\]\([^) ]+\)' \
       | sed -E 's/^\]\(//; s/\)$//' || true
   )
@@ -62,11 +74,10 @@ done
 # --- Orphan docs/ check -----------------------------------------------------
 # A docs/*.md page is an orphan when no other tracked markdown file navigably
 # links to it. A plain-text or code-span mention, or a link that only appears
-# inside a fenced code sample, does not count: it does not let a reader reach
-# the page. Membership is taken from linked_by, populated above from the same
-# fence-stripped scan used for broken-link detection, so both checks agree on
-# what a navigable link is. Index-style pages are linked widely, so this stays
-# quiet on a healthy tree.
+# inside a fenced or inline code sample, does not count: it does not let a
+# reader reach the page. Membership is taken from linked_by, populated above
+# from the same fence- and code-span-stripped scan used for broken-link
+# detection, so both checks agree on what a navigable link is.
 while IFS= read -r doc; do
   base="$(basename "${doc}")"
   others=0

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -26,8 +26,9 @@ failures=0
 note() { echo "check-doc-links: $*" >&2; failures=$((failures + 1)); }
 
 # Vendored and generated trees are not our docs; exclude the same paths the
-# docs spelling job and .codespellrc skip.
-excluded='^(runtime/container/rust/vendor|runtime/container/providers/node_modules|runtime/container/rust/target|dist|tmp)/'
+# docs spelling job and .codespellrc skip. Test fixtures (testdata/) are also
+# excluded: they simulate external content, not documentation.
+excluded='^(runtime/container/rust/vendor|runtime/container/providers/node_modules|runtime/container/rust/target|dist|tmp)/|(^|/)testdata/'
 mapfile -t md_files < <(git ls-files '*.md' | grep -vE "${excluded}" || true)
 
 # Records, per link-target basename, the markdown files that navigably link it.

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# Offline Markdown integrity check over tracked docs: fails on broken intra-repo
+# relative links and on orphaned docs/ pages that nothing references. No network
+# calls and no dependencies beyond git, awk, sed, and grep so it can run
+# host-side in the docs CI lane.
+#
+# Scope (intentional limits, documented so they read as choices, not gaps):
+# - Only space-free inline links of the form [text](target) are checked;
+#   links inside fenced code blocks are skipped, and reference-style
+#   definitions ([text][ref]) and inline-HTML links are not validated.
+# - Relative targets are resolved the way GitHub renders them: relative to the
+#   linking file's own directory only.
+# - Heading-anchor (#fragment) validation is out of scope: reproducing GitHub's
+#   slug algorithm offline (duplicate headings, punctuation, inline HTML) is
+#   error-prone and would risk false failures on valid links. Target existence
+#   is the robust, high-value core; anchor validation can be added later behind
+#   its own evidence.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+failures=0
+note() { echo "check-doc-links: $*" >&2; failures=$((failures + 1)); }
+
+# Vendored and generated trees are not our docs; exclude the same paths the
+# docs spelling job and .codespellrc skip.
+excluded='^(runtime/container/rust/vendor|runtime/container/providers/node_modules|runtime/container/rust/target|dist|tmp)/'
+vendor_pathspecs=(
+  ':!runtime/container/rust/vendor'
+  ':!runtime/container/providers/node_modules'
+  ':!runtime/container/rust/target'
+  ':!dist'
+  ':!tmp'
+)
+mapfile -t md_files < <(git ls-files '*.md' | grep -vE "${excluded}" || true)
+
+# --- Broken relative-link check ---------------------------------------------
+for f in "${md_files[@]}"; do
+  dir="$(dirname "${f}")"
+  while IFS= read -r target; do
+    [[ -n "${target}" ]] || continue
+    case "${target}" in
+      http://*|https://*|mailto:*|tel:*|'#'*) continue ;;
+    esac
+    # Drop any #fragment; only the path portion is validated.
+    path="${target%%#*}"
+    [[ -n "${path}" ]] || continue
+    # GitHub resolves relative links against the linking file's directory only.
+    if [[ ! -e "${dir}/${path}" ]]; then
+      note "broken link: ${f} -> ${target} (missing ${dir}/${path})"
+    fi
+  done < <(
+    # Strip fenced code blocks so example markdown inside ``` is not scanned.
+    awk '/^[[:space:]]*```/{fence=!fence; next} !fence' "${f}" \
+      | grep -oE '\]\([^) ]+\)' \
+      | sed -E 's/^\]\(//; s/\)$//' || true
+  )
+done
+
+# --- Orphan docs/ check -----------------------------------------------------
+# A docs/*.md page is an orphan when its basename appears in no other tracked
+# (non-vendored) file: a markdown link, a script, the manpage, or a workflow all
+# count as a referrer. Index-style pages are referenced widely, so this stays
+# quiet on a healthy tree. Fails closed but distinguishes "no match" from a real
+# git error so an operational failure is not mistaken for an orphan storm.
+while IFS= read -r doc; do
+  base="$(basename "${doc}")"
+  set +e
+  git grep -qF "${base}" -- . ":!${doc}" "${vendor_pathspecs[@]}"
+  rc=$?
+  set -e
+  case "${rc}" in
+    0) : ;;
+    1) note "orphan doc: ${doc} is referenced by no other tracked file" ;;
+    *) echo "check-doc-links: git grep failed (rc=${rc}) while scanning for ${base}" >&2; exit "${rc}" ;;
+  esac
+done < <(git ls-files 'docs/*.md')
+
+if [[ "${failures}" -gt 0 ]]; then
+  echo "check-doc-links: FAILED with ${failures} issue(s)" >&2
+  exit 1
+fi
+echo "check-doc-links: OK (${#md_files[@]} markdown files; relative links and docs/ orphans clean)"

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -26,14 +26,13 @@ note() { echo "check-doc-links: $*" >&2; failures=$((failures + 1)); }
 # Vendored and generated trees are not our docs; exclude the same paths the
 # docs spelling job and .codespellrc skip.
 excluded='^(runtime/container/rust/vendor|runtime/container/providers/node_modules|runtime/container/rust/target|dist|tmp)/'
-vendor_pathspecs=(
-  ':!runtime/container/rust/vendor'
-  ':!runtime/container/providers/node_modules'
-  ':!runtime/container/rust/target'
-  ':!dist'
-  ':!tmp'
-)
 mapfile -t md_files < <(git ls-files '*.md' | grep -vE "${excluded}" || true)
+
+# Records, per link-target basename, the markdown files that navigably link it.
+# Populated from fence-stripped content in the link loop so the orphan check
+# below reuses the same view of who links whom (a link inside a code fence is
+# not a navigable reference and must not keep a page out of the orphan set).
+declare -A linked_by
 
 # --- Broken relative-link check ---------------------------------------------
 for f in "${md_files[@]}"; do
@@ -46,6 +45,8 @@ for f in "${md_files[@]}"; do
     # Drop any #fragment; only the path portion is validated.
     path="${target%%#*}"
     [[ -n "${path}" ]] || continue
+    # Record this navigable link (fence-stripped) for the orphan check.
+    linked_by["$(basename "${path}")"]+=" ${f}"
     # GitHub resolves relative links against the linking file's directory only.
     if [[ ! -e "${dir}/${path}" ]]; then
       note "broken link: ${f} -> ${target} (missing ${dir}/${path})"
@@ -59,24 +60,25 @@ for f in "${md_files[@]}"; do
 done
 
 # --- Orphan docs/ check -----------------------------------------------------
-# A docs/*.md page is an orphan when no other tracked markdown file contains a
-# navigable link to it. A plain-text or code-span mention (in a scenario table,
-# a manifest, or a script) does not count: it does not let a reader reach the
-# page. Index-style pages are linked widely, so this stays quiet on a healthy
-# tree. Fails closed but distinguishes "no match" from a real git error so an
-# operational failure is not mistaken for an orphan storm.
+# A docs/*.md page is an orphan when no other tracked markdown file navigably
+# links to it. A plain-text or code-span mention, or a link that only appears
+# inside a fenced code sample, does not count: it does not let a reader reach
+# the page. Membership is taken from linked_by, populated above from the same
+# fence-stripped scan used for broken-link detection, so both checks agree on
+# what a navigable link is. Index-style pages are linked widely, so this stays
+# quiet on a healthy tree.
 while IFS= read -r doc; do
   base="$(basename "${doc}")"
-  base_re="$(printf '%s' "${base}" | sed 's/\./\\./g')"
-  set +e
-  git grep -qE "\]\([^)]*${base_re}[)#]" -- '*.md' ":!${doc}" "${vendor_pathspecs[@]}"
-  rc=$?
-  set -e
-  case "${rc}" in
-    0) : ;;
-    1) note "orphan doc: ${doc} is linked from no other tracked markdown file" ;;
-    *) echo "check-doc-links: git grep failed (rc=${rc}) while scanning for ${base}" >&2; exit "${rc}" ;;
-  esac
+  others=0
+  for referrer in ${linked_by["${base}"]:-}; do
+    if [[ "${referrer}" != "${doc}" ]]; then
+      others=1
+      break
+    fi
+  done
+  if [[ "${others}" -eq 0 ]]; then
+    note "orphan doc: ${doc} is linked from no other tracked markdown file"
+  fi
 done < <(git ls-files 'docs/*.md')
 
 if [[ "${failures}" -gt 0 ]]; then

--- a/scripts/ci/job-docs.sh
+++ b/scripts/ci/job-docs.sh
@@ -21,6 +21,9 @@ echo "[ci/docs] pinned input policy"
 echo "[ci/docs] support-matrix field parity"
 "${ROOT_DIR}/scripts/check-doc-support-matrix-fields.sh"
 
+echo "[ci/docs] markdown link and orphan check"
+"${ROOT_DIR}/scripts/check-doc-links.sh"
+
 echo "[ci/docs] validator image build"
 VALIDATOR_IMAGE="$("${ROOT_DIR}/scripts/ci/build-validator-image.sh")"
 export WORKCELL_VALIDATOR_IMAGE="${VALIDATOR_IMAGE}"


### PR DESCRIPTION
# Summary

Lands ROADMAP item **E4** (docs CI depth) as an executable invariant, per
[`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md):

- **`scripts/check-doc-links.sh`** — offline, dependency-light checker that
  fails on (a) broken intra-repo **relative markdown links** and (b)
  **orphaned `docs/*.md`** pages that no other tracked markdown file
  **navigably links to** (a plain-text or code-span mention does not count —
  it does not let a reader reach the page). It excludes the vendored/generated
  trees the docs spelling job and `.codespellrc` already skip.
- Wired into the docs CI lane (`scripts/ci/job-docs.sh`) host-side, before the
  Docker validator build (fail-fast, no Docker needed).

**Scope:** this delivers the executable link + orphan invariant — the durable
core of ROADMAP E4. The softer E4 elements (planning-doc status labels and
per-doc freshness markers) are a tracked follow-up, not part of this PR.

**Intentional limits (documented in the script header):** heading-anchor
(`#fragment`) validation is out of scope — reproducing GitHub's slug algorithm
offline is error-prone and was observed to false-fail valid links such as
`ROADMAP.md#path-to-10`; only space-free inline `[text](target)` links are
checked; links inside fenced code blocks and reference-style definitions are
skipped. Relative targets resolve against the linking file's own directory, the
way GitHub renders them.

**Review hardening (from an internal adversarial pass):** relative-link
resolution was tightened to dir-relative only (a root-relative fallback would
have silently accepted links that 404 on GitHub); fenced code blocks are
stripped before extraction to avoid false failures on example markdown; the
orphan check requires a **navigable markdown link** (a code-span or manifest
mention does not count) and distinguishes "no match" from a real `git grep`
error so an operational failure is never misreported as an orphan. Applying the
stricter orphan definition surfaced one genuine gap —
`docs/examples/enterprise-claude-setup.md` was reachable by no reader-facing
link — now fixed by linking it from `docs/examples/quickstart-claude.md`
(mirroring how `gemini-vertex-setup.md` is linked from its quickstart). Each
fix is covered by a negative control.

## Support-claim impact

None. CI/docs tooling only — no runtime, boundary, credential, or
policy-enforcement code is touched.

## Validation

- Passes on the current tree (78 markdown files; 0 broken links, 0 orphans)
- Negative controls confirm it fails on a broken relative link and on a tracked
  orphan doc, each with a clear message
- `shellcheck` clean on the new script; `codespell` clean; `./scripts/pre-merge.sh
  --profile pr-parity` before publication
