### PR TITLE
Document the Rust/Go/shell language-boundary doctrine (D1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,3 +169,9 @@ the runtime boundary or explicit security guarantees in the name of convenience.
 - Keep one shared boundary and many thin adapters. Do not hide provider
   differences behind a fake universal abstraction.
 - Prefer small scripts and plain configuration over framework-heavy machinery.
+- Language boundaries: Rust is for the runtime syscall-interception shim and its
+  exec guards; Go is for host- and runtime-side policy, state, and orchestration
+  logic and the `workcell-*` tools; shell is thin glue that detects the host,
+  scrubs the environment, dispatches to the Go tools, and launches the runtime.
+  New logic defaults to Go. Growing a shell script past glue, or adding Rust
+  outside the shim, needs an explicit justification in the same change.


### PR DESCRIPTION
# Summary

Lands ROADMAP item **D1** — the language-boundary doctrine — per
[`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md).

Adds one bullet to the **Change discipline** section of `AGENTS.md`: Rust is for
the runtime syscall-interception shim and its exec guards; Go is for host- and
runtime-side policy, state, and orchestration logic and the `workcell-*` tools;
shell is thin glue. New logic defaults to Go; growing a shell script past glue,
or adding Rust outside the shim, needs explicit justification.

This matches the repository's actual split (Rust `runtime/container/rust/src`,
Go `cmd/workcell-*`, the shell launcher as glue) and makes the later Track D
consolidation items (shared shell library, launcher/orchestration migration)
directional rather than ad hoc.

## Support-claim impact

None. Working-agreement documentation only.

## Validation

- `codespell` and repo `markdownlint` clean; the merged docs-link checker passes
- `./scripts/pre-merge.sh --profile pr-parity` before publication
