### PR TITLE
Add mutation-score baseline gate (B3 core)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -89,6 +89,7 @@ func subcommands() []subcommand {
 		{"validate-operator-contract", "ROOT_DIR CONTRACT_PATH REQUIREMENTS_PATH", 3, 3, cmdValidateOperatorContract},
 		{"scan-credential-patterns", "ROOT_DIR", 1, 1, cmdScanCredentialPatterns},
 		{"run-mutation-tests", "", 0, 0, cmdRunMutationTests},
+		{"mutation-score", "POLICY_PATH", 1, 1, cmdMutationScore},
 		{"tree-compare", "LEFT_ROOT RIGHT_ROOT", 2, 2, cmdTreeCompare},
 	}
 }
@@ -433,6 +434,29 @@ func cmdRunMutationTests(_ []string) error {
 		return err
 	}
 	return mutation.Run(root)
+}
+
+// cmdMutationScore runs the mutation harness, prints the score (so a wrapper can
+// surface it in a CI job summary), and fails when the score drops below the
+// reviewed baseline in POLICY_PATH.
+func cmdMutationScore(args []string) error {
+	root, err := citoolsRepoRoot()
+	if err != nil {
+		return err
+	}
+	policy, err := mutation.LoadScorePolicy(args[0])
+	if err != nil {
+		return err
+	}
+	result, err := mutation.RunScored(root)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("mutation score: %.2f%% (%d/%d killed)\n", result.Score(), result.Killed, result.Total)
+	if len(result.Survivors) > 0 {
+		fmt.Printf("surviving mutants: %s\n", strings.Join(result.Survivors, ", "))
+	}
+	return mutation.CheckScore(result, policy)
 }
 
 // citoolsRepoRoot returns the repo root by walking two `..`

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -282,6 +282,12 @@ Useful commands:
 ./scripts/verify-scenario-coverage.sh
 ```
 
+Release preflight also runs `./scripts/verify-mutation-score.sh`, which executes
+the mutation harness and fails when the mutation score drops below the reviewed
+baseline in [`policy/mutation-score-policy.json`](../policy/mutation-score-policy.json)
+(currently 100%: every mutant is caught). A drop is a diff a reviewer must
+approve, so a release cannot silently regress the mutation safety net.
+
 When a release touches the local runtime boundary or launch path, also run the
 local certification lane on a machine that has the live runtime prerequisites:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -285,8 +285,10 @@ Useful commands:
 Release preflight also runs `./scripts/verify-mutation-score.sh`, which executes
 the mutation harness and fails when the mutation score drops below the reviewed
 baseline in [`policy/mutation-score-policy.json`](../policy/mutation-score-policy.json)
-(currently 100%: every mutant is caught). A drop is a diff a reviewer must
-approve, so a release cannot silently regress the mutation safety net.
+(currently 100%: every mutant is caught). The policy also pins the reviewed
+mutant count (`expected_mutants`), so the score cannot be met by shrinking the
+mutant set. A drop in either is a diff a reviewer must approve, so a release
+cannot silently regress the mutation safety net.
 
 When a release touches the local runtime boundary or launch path, also run the
 local certification lane on a machine that has the live runtime prerequisites:

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -4,6 +4,7 @@
 package mutation
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -12,7 +13,23 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
+	"time"
 )
+
+const defaultMutantTimeout = 10 * time.Minute
+
+// mutantTimeout bounds a single mutant's scoped test run so one hung mutant
+// cannot consume the whole (CI-gated) mutation lane. Overridable via
+// WORKCELL_MUTANT_TIMEOUT (a Go duration such as "15m") for slow/loaded runners.
+func mutantTimeout() time.Duration {
+	if raw := os.Getenv("WORKCELL_MUTANT_TIMEOUT"); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultMutantTimeout
+}
 
 type mutationCase struct {
 	relativePath string
@@ -134,25 +151,63 @@ var rustMutations = []mutationCase{
 	},
 }
 
+// Result summarizes a mutation run: how many mutants were killed (the scoped
+// test suite failed, as it should) out of the total attempted, plus the labels
+// of any survivors (mutants the tests failed to catch).
+type Result struct {
+	Killed    int
+	Total     int
+	Survivors []string
+}
+
+// Score returns the percentage of mutants killed, or 0 when no mutants ran.
+func (r Result) Score() float64 {
+	if r.Total == 0 {
+		return 0
+	}
+	return float64(r.Killed) / float64(r.Total) * 100
+}
+
+// Run executes every mutation case and returns an error if any mutant survived
+// or the harness failed. It is the strict all-or-nothing variant (any survivor
+// fails), intentionally independent of the reviewed baseline policy that
+// CheckScore applies; callers wanting the baseline gate use RunScored +
+// CheckScore instead.
 func Run(repoRoot string) error {
-	if err := runGoHelperMutations(repoRoot); err != nil {
-		return err
+	result, err := RunScored(repoRoot)
+	if len(result.Survivors) > 0 {
+		err = errors.Join(err, fmt.Errorf("mutation coverage did not catch: %s", strings.Join(result.Survivors, ", ")))
 	}
-	if err := runRustGuardMutations(repoRoot); err != nil {
-		return err
+	return err
+}
+
+// RunScored executes every mutation case and reports the kill counts. A non-nil
+// error indicates a harness failure (a mutant that could not be evaluated), not
+// a surviving mutant; survivors are reported in Result.Survivors.
+func RunScored(repoRoot string) (Result, error) {
+	goKilled, goTotal, goSurvivors, goErr := runGoHelperMutations(repoRoot)
+	rustKilled, rustTotal, rustSurvivors, rustErr := runRustGuardMutations(repoRoot)
+	survivors := make([]string, 0, len(goSurvivors)+len(rustSurvivors))
+	survivors = append(survivors, goSurvivors...)
+	survivors = append(survivors, rustSurvivors...)
+	result := Result{
+		Killed:    goKilled + rustKilled,
+		Total:     goTotal + rustTotal,
+		Survivors: survivors,
 	}
-	return nil
+	return result, errors.Join(goErr, rustErr)
 }
 
 // runGoHelperMutations runs all Go mutation cases in parallel. Each case
 // operates in its own isolated temp directory so there is no shared state.
-func runGoHelperMutations(repoRoot string) error {
+func runGoHelperMutations(repoRoot string) (killed, total int, survivors []string, err error) {
 	type result struct {
 		label string
 		err   error
 		pass  bool // true means mutation was NOT caught (test passed when it should fail)
 	}
 
+	total = len(goHelperMutations)
 	results := make(chan result, len(goHelperMutations))
 	var wg sync.WaitGroup
 
@@ -191,7 +246,6 @@ func runGoHelperMutations(repoRoot string) error {
 	wg.Wait()
 	close(results)
 
-	var failures []string
 	var harnessErrors []error
 	for r := range results {
 		if r.err != nil {
@@ -199,24 +253,24 @@ func runGoHelperMutations(repoRoot string) error {
 			continue
 		}
 		if r.pass {
-			failures = append(failures, r.label)
+			survivors = append(survivors, r.label)
+		} else {
+			killed++
 		}
 	}
-	if len(failures) > 0 {
-		harnessErrors = append(harnessErrors, fmt.Errorf("go helper mutation coverage did not catch: %s", strings.Join(failures, ", ")))
-	}
-	return errors.Join(harnessErrors...)
+	return killed, total, survivors, errors.Join(harnessErrors...)
 }
 
 // runRustGuardMutations runs all Rust mutation cases in parallel. Each case
 // operates in its own isolated temp directory so there is no shared state.
-func runRustGuardMutations(repoRoot string) error {
+func runRustGuardMutations(repoRoot string) (killed, total int, survivors []string, err error) {
 	type result struct {
 		label string
 		err   error
 		pass  bool
 	}
 
+	total = len(rustMutations)
 	results := make(chan result, len(rustMutations))
 	var wg sync.WaitGroup
 
@@ -259,7 +313,6 @@ func runRustGuardMutations(repoRoot string) error {
 	wg.Wait()
 	close(results)
 
-	var failures []string
 	var harnessErrors []error
 	for r := range results {
 		if r.err != nil {
@@ -267,13 +320,12 @@ func runRustGuardMutations(repoRoot string) error {
 			continue
 		}
 		if r.pass {
-			failures = append(failures, r.label)
+			survivors = append(survivors, r.label)
+		} else {
+			killed++
 		}
 	}
-	if len(failures) > 0 {
-		harnessErrors = append(harnessErrors, fmt.Errorf("rust mutation coverage did not catch: %s", strings.Join(failures, ", ")))
-	}
-	return errors.Join(harnessErrors...)
+	return killed, total, survivors, errors.Join(harnessErrors...)
 }
 
 type commandSpec struct {
@@ -283,7 +335,10 @@ type commandSpec struct {
 }
 
 func runCommand(cwd string, spec commandSpec) (int, error) {
-	cmd := exec.Command(spec.Path, spec.Args...)
+	timeout := mutantTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, spec.Path, spec.Args...)
 	cmd.Dir = cwd
 	if spec.Env != nil {
 		env := os.Environ()
@@ -294,9 +349,23 @@ func runCommand(cwd string, spec commandSpec) (int, error) {
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	// Put the child in its own process group and, on timeout, kill the whole
+	// group so a hung `go test`/`cargo test` cannot orphan its compiled test
+	// binary (a grandchild) that would keep burning CI resources.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 10 * time.Second
 	err := cmd.Run()
 	if err == nil {
 		return 0, nil
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return 0, fmt.Errorf("mutation command timed out after %s: %s %s", timeout, spec.Path, strings.Join(spec.Args, " "))
 	}
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {

--- a/internal/mutation/score.go
+++ b/internal/mutation/score.go
@@ -18,9 +18,15 @@ import (
 // BaselineScore is compared as a float, so it must be an exactly achievable
 // fraction of the mutant count to avoid rounding surprises; 100.0 (kill every
 // mutant) is the recommended and current value.
+//
+// ExpectedMutants pins the reviewed size of the mutant set. Without it, a
+// percentage baseline could be met by shrinking the set (removing a mutant so
+// 13/13 still scores 100%); requiring an exact count makes any change to the
+// mutant set a reviewed policy diff.
 type ScorePolicy struct {
-	Version       int     `json:"version"`
-	BaselineScore float64 `json:"baseline_score"`
+	Version         int     `json:"version"`
+	BaselineScore   float64 `json:"baseline_score"`
+	ExpectedMutants int     `json:"expected_mutants"`
 }
 
 // LoadScorePolicy reads and validates a version-1 mutation-score policy. It
@@ -34,8 +40,9 @@ func LoadScorePolicy(path string) (ScorePolicy, error) {
 	}
 	// Pointers distinguish "field absent" from "field set to zero".
 	var raw struct {
-		Version       *int     `json:"version"`
-		BaselineScore *float64 `json:"baseline_score"`
+		Version         *int     `json:"version"`
+		BaselineScore   *float64 `json:"baseline_score"`
+		ExpectedMutants *int     `json:"expected_mutants"`
 	}
 	dec := json.NewDecoder(bytes.NewReader(content))
 	dec.DisallowUnknownFields()
@@ -54,12 +61,18 @@ func LoadScorePolicy(path string) (ScorePolicy, error) {
 	if raw.BaselineScore == nil {
 		return ScorePolicy{}, fmt.Errorf("%s must set baseline_score", path)
 	}
-	policy := ScorePolicy{Version: *raw.Version, BaselineScore: *raw.BaselineScore}
+	if raw.ExpectedMutants == nil {
+		return ScorePolicy{}, fmt.Errorf("%s must set expected_mutants", path)
+	}
+	policy := ScorePolicy{Version: *raw.Version, BaselineScore: *raw.BaselineScore, ExpectedMutants: *raw.ExpectedMutants}
 	if policy.Version != 1 {
 		return ScorePolicy{}, fmt.Errorf("%s must use version 1", path)
 	}
 	if policy.BaselineScore < 0 || policy.BaselineScore > 100 {
 		return ScorePolicy{}, fmt.Errorf("%s baseline_score must be between 0 and 100, got %.2f", path, policy.BaselineScore)
+	}
+	if policy.ExpectedMutants <= 0 {
+		return ScorePolicy{}, fmt.Errorf("%s expected_mutants must be positive, got %d", path, policy.ExpectedMutants)
 	}
 	return policy, nil
 }
@@ -69,6 +82,12 @@ func LoadScorePolicy(path string) (ScorePolicy, error) {
 func CheckScore(result Result, policy ScorePolicy) error {
 	if result.Total == 0 {
 		return fmt.Errorf("no mutants were evaluated")
+	}
+	// The mutant set must match the reviewed size so the score cannot be met by
+	// shrinking the set (removing a mutant to keep 100%).
+	if result.Total != policy.ExpectedMutants {
+		return fmt.Errorf("mutant set changed: policy expects %d mutants, harness ran %d (update the reviewed policy)",
+			policy.ExpectedMutants, result.Total)
 	}
 	// Fail closed if the run is incomplete (a mutant errored and was neither
 	// killed nor recorded as a survivor). This makes "an incomplete run can

--- a/internal/mutation/score.go
+++ b/internal/mutation/score.go
@@ -4,6 +4,7 @@
 package mutation
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -21,16 +22,32 @@ type ScorePolicy struct {
 	BaselineScore float64 `json:"baseline_score"`
 }
 
-// LoadScorePolicy reads and validates a version-1 mutation-score policy.
+// LoadScorePolicy reads and validates a version-1 mutation-score policy. It
+// rejects unknown fields and a missing baseline_score so a typo (for example
+// `baseline-score`) or omission cannot silently leave the gate at an effective
+// 0% baseline that would let surviving mutants pass.
 func LoadScorePolicy(path string) (ScorePolicy, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return ScorePolicy{}, err
 	}
-	var policy ScorePolicy
-	if err := json.Unmarshal(content, &policy); err != nil {
+	// Pointers distinguish "field absent" from "field set to zero".
+	var raw struct {
+		Version       *int     `json:"version"`
+		BaselineScore *float64 `json:"baseline_score"`
+	}
+	dec := json.NewDecoder(bytes.NewReader(content))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&raw); err != nil {
 		return ScorePolicy{}, fmt.Errorf("%s: %w", path, err)
 	}
+	if raw.Version == nil {
+		return ScorePolicy{}, fmt.Errorf("%s must set version", path)
+	}
+	if raw.BaselineScore == nil {
+		return ScorePolicy{}, fmt.Errorf("%s must set baseline_score", path)
+	}
+	policy := ScorePolicy{Version: *raw.Version, BaselineScore: *raw.BaselineScore}
 	if policy.Version != 1 {
 		return ScorePolicy{}, fmt.Errorf("%s must use version 1", path)
 	}

--- a/internal/mutation/score.go
+++ b/internal/mutation/score.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -40,6 +41,12 @@ func LoadScorePolicy(path string) (ScorePolicy, error) {
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&raw); err != nil {
 		return ScorePolicy{}, fmt.Errorf("%s: %w", path, err)
+	}
+	// Reject trailing content so a policy with two top-level values (for example
+	// a stale baseline followed by the reviewed one) cannot silently gate on the
+	// first object.
+	if err := dec.Decode(new(json.RawMessage)); err != io.EOF {
+		return ScorePolicy{}, fmt.Errorf("%s must contain a single JSON object", path)
 	}
 	if raw.Version == nil {
 		return ScorePolicy{}, fmt.Errorf("%s must set version", path)

--- a/internal/mutation/score.go
+++ b/internal/mutation/score.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package mutation
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// ScorePolicy is the reviewed baseline for the mutation score. A drop below
+// BaselineScore is a diff a reviewer must approve, so the mutation safety net
+// cannot silently regress.
+//
+// BaselineScore is compared as a float, so it must be an exactly achievable
+// fraction of the mutant count to avoid rounding surprises; 100.0 (kill every
+// mutant) is the recommended and current value.
+type ScorePolicy struct {
+	Version       int     `json:"version"`
+	BaselineScore float64 `json:"baseline_score"`
+}
+
+// LoadScorePolicy reads and validates a version-1 mutation-score policy.
+func LoadScorePolicy(path string) (ScorePolicy, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return ScorePolicy{}, err
+	}
+	var policy ScorePolicy
+	if err := json.Unmarshal(content, &policy); err != nil {
+		return ScorePolicy{}, fmt.Errorf("%s: %w", path, err)
+	}
+	if policy.Version != 1 {
+		return ScorePolicy{}, fmt.Errorf("%s must use version 1", path)
+	}
+	if policy.BaselineScore < 0 || policy.BaselineScore > 100 {
+		return ScorePolicy{}, fmt.Errorf("%s baseline_score must be between 0 and 100, got %.2f", path, policy.BaselineScore)
+	}
+	return policy, nil
+}
+
+// CheckScore returns an error when the result's score is below the policy
+// baseline. It reports the surviving mutants so a regression is diagnosable.
+func CheckScore(result Result, policy ScorePolicy) error {
+	if result.Total == 0 {
+		return fmt.Errorf("no mutants were evaluated")
+	}
+	// Fail closed if the run is incomplete (a mutant errored and was neither
+	// killed nor recorded as a survivor). This makes "an incomplete run can
+	// never be scored" an enforced invariant rather than a caller convention.
+	if result.Killed+len(result.Survivors) != result.Total {
+		return fmt.Errorf("incomplete mutation run: %d killed + %d survivors != %d total (harness error?)",
+			result.Killed, len(result.Survivors), result.Total)
+	}
+	score := result.Score()
+	if score < policy.BaselineScore {
+		msg := fmt.Sprintf("mutation score %.2f%% (%d/%d killed) is below the baseline %.2f%%",
+			score, result.Killed, result.Total, policy.BaselineScore)
+		if len(result.Survivors) > 0 {
+			msg += fmt.Sprintf("; survivors: %v", result.Survivors)
+		}
+		return fmt.Errorf("%s", msg)
+	}
+	return nil
+}

--- a/internal/mutation/score_test.go
+++ b/internal/mutation/score_test.go
@@ -95,4 +95,15 @@ func TestLoadScorePolicy(t *testing.T) {
 	if _, err := LoadScorePolicy(outOfRange); err == nil || !strings.Contains(err.Error(), "between 0 and 100") {
 		t.Fatalf("expected range error, got: %v", err)
 	}
+
+	// A typo in the key must not silently default the baseline to 0%.
+	typo := write("typo.json", `{"version":1,"baseline-score":100}`)
+	if _, err := LoadScorePolicy(typo); err == nil {
+		t.Fatal("expected error for unknown field baseline-score")
+	}
+
+	missing := write("missing.json", `{"version":1}`)
+	if _, err := LoadScorePolicy(missing); err == nil || !strings.Contains(err.Error(), "baseline_score") {
+		t.Fatalf("expected missing-baseline error, got: %v", err)
+	}
 }

--- a/internal/mutation/score_test.go
+++ b/internal/mutation/score_test.go
@@ -106,4 +106,10 @@ func TestLoadScorePolicy(t *testing.T) {
 	if _, err := LoadScorePolicy(missing); err == nil || !strings.Contains(err.Error(), "baseline_score") {
 		t.Fatalf("expected missing-baseline error, got: %v", err)
 	}
+
+	// Two top-level objects must not silently gate on the first (stale) one.
+	trailing := write("trailing.json", `{"version":1,"baseline_score":50}{"version":1,"baseline_score":100}`)
+	if _, err := LoadScorePolicy(trailing); err == nil || !strings.Contains(err.Error(), "single JSON object") {
+		t.Fatalf("expected trailing-content error, got: %v", err)
+	}
 }

--- a/internal/mutation/score_test.go
+++ b/internal/mutation/score_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package mutation
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResultScore(t *testing.T) {
+	cases := []struct {
+		name   string
+		result Result
+		want   float64
+	}{
+		{"all killed", Result{Killed: 14, Total: 14}, 100},
+		{"one survivor", Result{Killed: 13, Total: 14}, 13.0 / 14.0 * 100},
+		{"empty", Result{Killed: 0, Total: 0}, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.result.Score(); got != tc.want {
+				t.Fatalf("Score() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckScorePassesAtBaseline(t *testing.T) {
+	err := CheckScore(Result{Killed: 14, Total: 14}, ScorePolicy{Version: 1, BaselineScore: 100})
+	if err != nil {
+		t.Fatalf("expected pass at baseline, got: %v", err)
+	}
+}
+
+// TestCheckScoreTripsOnSurvivor is the deliberate mutant-survival dry run: a
+// single survivor drops the score below baseline and must trip the gate.
+func TestCheckScoreTripsOnSurvivor(t *testing.T) {
+	err := CheckScore(
+		Result{Killed: 13, Total: 14, Survivors: []string{"go/injection/example"}},
+		ScorePolicy{Version: 1, BaselineScore: 100},
+	)
+	if err == nil {
+		t.Fatal("expected the gate to trip on a surviving mutant, got nil")
+	}
+	if !strings.Contains(err.Error(), "below the baseline") || !strings.Contains(err.Error(), "go/injection/example") {
+		t.Fatalf("expected below-baseline error naming the survivor, got: %v", err)
+	}
+}
+
+func TestCheckScoreRejectsEmptyRun(t *testing.T) {
+	if err := CheckScore(Result{}, ScorePolicy{Version: 1, BaselineScore: 100}); err == nil {
+		t.Fatal("expected error when no mutants were evaluated")
+	}
+}
+
+// TestCheckScoreRejectsIncompleteRun proves the fail-closed invariant: a result
+// where a mutant errored (killed+survivors < total) must not be scored, even
+// though killed/total alone would look like a passing 13/13.
+func TestCheckScoreRejectsIncompleteRun(t *testing.T) {
+	err := CheckScore(Result{Killed: 13, Total: 14}, ScorePolicy{Version: 1, BaselineScore: 100})
+	if err == nil || !strings.Contains(err.Error(), "incomplete mutation run") {
+		t.Fatalf("expected incomplete-run error, got: %v", err)
+	}
+}
+
+func TestLoadScorePolicy(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		return p
+	}
+
+	valid := write("valid.json", `{"version":1,"baseline_score":100.0}`)
+	policy, err := LoadScorePolicy(valid)
+	if err != nil {
+		t.Fatalf("valid policy: %v", err)
+	}
+	if policy.BaselineScore != 100 {
+		t.Fatalf("baseline = %v, want 100", policy.BaselineScore)
+	}
+
+	badVersion := write("badver.json", `{"version":2,"baseline_score":100}`)
+	if _, err := LoadScorePolicy(badVersion); err == nil || !strings.Contains(err.Error(), "version 1") {
+		t.Fatalf("expected version error, got: %v", err)
+	}
+
+	outOfRange := write("range.json", `{"version":1,"baseline_score":150}`)
+	if _, err := LoadScorePolicy(outOfRange); err == nil || !strings.Contains(err.Error(), "between 0 and 100") {
+		t.Fatalf("expected range error, got: %v", err)
+	}
+}

--- a/internal/mutation/score_test.go
+++ b/internal/mutation/score_test.go
@@ -30,7 +30,7 @@ func TestResultScore(t *testing.T) {
 }
 
 func TestCheckScorePassesAtBaseline(t *testing.T) {
-	err := CheckScore(Result{Killed: 14, Total: 14}, ScorePolicy{Version: 1, BaselineScore: 100})
+	err := CheckScore(Result{Killed: 14, Total: 14}, ScorePolicy{Version: 1, BaselineScore: 100, ExpectedMutants: 14})
 	if err != nil {
 		t.Fatalf("expected pass at baseline, got: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestCheckScorePassesAtBaseline(t *testing.T) {
 func TestCheckScoreTripsOnSurvivor(t *testing.T) {
 	err := CheckScore(
 		Result{Killed: 13, Total: 14, Survivors: []string{"go/injection/example"}},
-		ScorePolicy{Version: 1, BaselineScore: 100},
+		ScorePolicy{Version: 1, BaselineScore: 100, ExpectedMutants: 14},
 	)
 	if err == nil {
 		t.Fatal("expected the gate to trip on a surviving mutant, got nil")
@@ -52,7 +52,7 @@ func TestCheckScoreTripsOnSurvivor(t *testing.T) {
 }
 
 func TestCheckScoreRejectsEmptyRun(t *testing.T) {
-	if err := CheckScore(Result{}, ScorePolicy{Version: 1, BaselineScore: 100}); err == nil {
+	if err := CheckScore(Result{}, ScorePolicy{Version: 1, BaselineScore: 100, ExpectedMutants: 14}); err == nil {
 		t.Fatal("expected error when no mutants were evaluated")
 	}
 }
@@ -61,9 +61,19 @@ func TestCheckScoreRejectsEmptyRun(t *testing.T) {
 // where a mutant errored (killed+survivors < total) must not be scored, even
 // though killed/total alone would look like a passing 13/13.
 func TestCheckScoreRejectsIncompleteRun(t *testing.T) {
-	err := CheckScore(Result{Killed: 13, Total: 14}, ScorePolicy{Version: 1, BaselineScore: 100})
+	err := CheckScore(Result{Killed: 13, Total: 14}, ScorePolicy{Version: 1, BaselineScore: 100, ExpectedMutants: 14})
 	if err == nil || !strings.Contains(err.Error(), "incomplete mutation run") {
 		t.Fatalf("expected incomplete-run error, got: %v", err)
+	}
+}
+
+// TestCheckScoreDetectsShrunkMutantSet proves a percentage baseline cannot be
+// met by removing a mutant: 13/13 killed is still 100%, but the reviewed set is
+// 14, so the gate must trip.
+func TestCheckScoreDetectsShrunkMutantSet(t *testing.T) {
+	err := CheckScore(Result{Killed: 13, Total: 13}, ScorePolicy{Version: 1, BaselineScore: 100, ExpectedMutants: 14})
+	if err == nil || !strings.Contains(err.Error(), "mutant set changed") {
+		t.Fatalf("expected mutant-set-changed error, got: %v", err)
 	}
 }
 
@@ -77,7 +87,7 @@ func TestLoadScorePolicy(t *testing.T) {
 		return p
 	}
 
-	valid := write("valid.json", `{"version":1,"baseline_score":100.0}`)
+	valid := write("valid.json", `{"version":1,"baseline_score":100.0,"expected_mutants":14}`)
 	policy, err := LoadScorePolicy(valid)
 	if err != nil {
 		t.Fatalf("valid policy: %v", err)
@@ -86,12 +96,12 @@ func TestLoadScorePolicy(t *testing.T) {
 		t.Fatalf("baseline = %v, want 100", policy.BaselineScore)
 	}
 
-	badVersion := write("badver.json", `{"version":2,"baseline_score":100}`)
+	badVersion := write("badver.json", `{"version":2,"baseline_score":100,"expected_mutants":14}`)
 	if _, err := LoadScorePolicy(badVersion); err == nil || !strings.Contains(err.Error(), "version 1") {
 		t.Fatalf("expected version error, got: %v", err)
 	}
 
-	outOfRange := write("range.json", `{"version":1,"baseline_score":150}`)
+	outOfRange := write("range.json", `{"version":1,"baseline_score":150,"expected_mutants":14}`)
 	if _, err := LoadScorePolicy(outOfRange); err == nil || !strings.Contains(err.Error(), "between 0 and 100") {
 		t.Fatalf("expected range error, got: %v", err)
 	}
@@ -105,6 +115,11 @@ func TestLoadScorePolicy(t *testing.T) {
 	missing := write("missing.json", `{"version":1}`)
 	if _, err := LoadScorePolicy(missing); err == nil || !strings.Contains(err.Error(), "baseline_score") {
 		t.Fatalf("expected missing-baseline error, got: %v", err)
+	}
+
+	missingCount := write("missingcount.json", `{"version":1,"baseline_score":100}`)
+	if _, err := LoadScorePolicy(missingCount); err == nil || !strings.Contains(err.Error(), "expected_mutants") {
+		t.Fatalf("expected missing-expected_mutants error, got: %v", err)
 	}
 
 	// Two top-level objects must not silently gate on the first (stale) one.

--- a/policy/mutation-score-policy.json
+++ b/policy/mutation-score-policy.json
@@ -1,4 +1,5 @@
 {
   "version": 1,
-  "baseline_score": 100.0
+  "baseline_score": 100.0,
+  "expected_mutants": 14
 }

--- a/policy/mutation-score-policy.json
+++ b/policy/mutation-score-policy.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "baseline_score": 100.0
+}

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -176,6 +176,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/update-provider-pins.sh"
   "${ROOT_DIR}/scripts/verify-coverage.sh"
   "${ROOT_DIR}/scripts/verify-github-hosted-controls.sh"
+  "${ROOT_DIR}/scripts/verify-mutation-score.sh"
   "${ROOT_DIR}/scripts/validate-repo.sh"
   "${ROOT_DIR}/scripts/verify-build-input-manifest.sh"
   "${ROOT_DIR}/scripts/verify-upstream-claude-release.sh"
@@ -384,7 +385,7 @@ fi
 )
 
 if [[ "${VALIDATION_PROFILE}" == "release-preflight" ]]; then
-  "${ROOT_DIR}/scripts/run-mutation-tests.sh"
+  "${ROOT_DIR}/scripts/verify-mutation-score.sh"
   "${ROOT_DIR}/scripts/verify-coverage.sh"
 fi
 

--- a/scripts/verify-mutation-score.sh
+++ b/scripts/verify-mutation-score.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# Run the mutation harness and fail when the mutation score drops below the
+# reviewed baseline in policy/mutation-score-policy.json. Used by the
+# release-preflight validation profile so a release cannot regress the mutation
+# safety net.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+(
+  cd "${ROOT_DIR}"
+  go run ./cmd/workcell-citools mutation-score policy/mutation-score-policy.json
+)


### PR DESCRIPTION
# Summary

Lands the core of ROADMAP item **B3** (Mutation Testing Gated In CI) per
[`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md):

- **`internal/mutation/runner.go`** — the harness now reports kill counts:
  `Result{Killed,Total,Survivors}` + `Score()`, `RunScored()`. `Run()` keeps its
  original all-or-nothing contract. Adds a 10-minute per-mutant timeout so one
  hung mutant cannot stall a gated run.
- **`internal/mutation/score.go`** + **`workcell-citools mutation-score`** —
  loads a reviewed baseline, runs the harness, prints the score (`100.00%
  (14/14 killed)`), and fails when the score is below baseline.
- **`policy/mutation-score-policy.json`** — reviewed baseline (currently 100%:
  all 14 mutants are caught). A drop is a diff a reviewer must approve.
- **`scripts/verify-mutation-score.sh`** — the **release-preflight** profile now
  runs this baseline gate (replacing the raw run-mutation-tests call), so a
  release refuses when the mutation score regresses.

## Scope note

This PR lands two of B3's three exit gates — the **reviewed baseline file** and
**release preflight refuses on regression** — reusing the existing
release-preflight toolchain. The third gate, a **scheduled + `approved-heavy-ci`
CI lane**, is deferred to a focused follow-up (**B3b**) because it must run the
Go+Rust harness inside the validator image (the Rust vendor/offline wiring is
image-specific), which is a larger, separately-reviewable change.

## Support-claim impact

None. Test-infrastructure and CI-gating only.

## Validation

- 6 Go unit tests including a deliberate mutant-survival dry run that proves the
  gate trips below baseline; `go vet`/`gofmt`/full package tests clean
- the real harness confirms the baseline: `mutation score: 100.00% (14/14 killed)`
- `shellcheck` clean; `./scripts/pre-merge.sh --profile pr-parity` before publication
