### PR TITLE
Add reviewed GitHub Actions allowlist (B4 core)

### DIFF
--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -115,6 +115,14 @@ feeds its digests into the preflight manifest, while the amd64 image is verified
 natively in `preflight`. `check-pinned-inputs` rejects any reintroduction of
 `docker/setup-qemu-action` into the release workflow.
 
+`check-pinned-inputs` also gates the GitHub Actions supply chain: every `uses:`
+must be pinned by full commit SHA, and its `owner/repo` must appear in the
+reviewed allowlist
+[`policy/allowed-actions.toml`](../policy/allowed-actions.toml). SHA-pinning
+proves the integrity of a specific ref; the allowlist restricts which action
+publishers may run at all, so introducing a new action — even a correctly
+pinned one — requires a reviewed change to that policy.
+
 `ci.yml` and `docs.yml` use the same explicit nonroot validator contract when
 they bind-mount the repository: the workflow computes the caller UID/GID,
 passes isolated writable roots, and creates those paths inside the validator

--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -21,10 +21,15 @@ var (
 	aptInstallPattern     = regexp.MustCompile(`apt-get install -y --no-install-recommends(?s:(.*?))&&`)
 	// pinnedReleaseTagPattern matches an exact vMAJOR.MINOR.PATCH release tag.
 	pinnedReleaseTagPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
-	// workflowUsesPattern and commitShaPattern scan workflow `uses:` refs for a
-	// pinned 40-hex commit SHA; both run inside the per-workflow scan loop.
-	workflowUsesPattern = regexp.MustCompile(`(?m)^\s*-\s+uses:\s+([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)@([^\s#]+)`)
-	commitShaPattern    = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	// usesLinePattern matches EVERY workflow `uses:` line — whether `uses:` is the
+	// first step key (`- uses:`) or a later key (a step led by `- name:`/`- if:`).
+	// actionRefPattern then requires the captured reference to be a pinned
+	// owner/repo action; anything else (docker://, local ./, unpinned, malformed)
+	// is rejected by default, so the scan is default-deny rather than only
+	// inspecting refs that already look well-formed.
+	usesLinePattern  = regexp.MustCompile(`(?m)^\s*(?:-\s+)?uses:\s*(\S+)`)
+	actionRefPattern = regexp.MustCompile(`^([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*)@([^\s#]+)$`)
+	commitShaPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
 )
 
 type PinnedInputsConfig struct {
@@ -49,8 +54,37 @@ type PinnedInputsConfig struct {
 // requireStringSliceTable lives in hostedcontrols.go
 // (canonical post-collapse; same package-internal symbols all consumers share).
 
+// loadAllowedActions reads the reviewed GitHub Actions allowlist as a set of
+// permitted owner/repo identities.
+func loadAllowedActions(path string) (map[string]bool, error) {
+	text, err := readText(path)
+	if err != nil {
+		return nil, err
+	}
+	root, err := tomlsubset.Parse(text, path)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := requireStringSliceTable(root, "actions", "allowed", path)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("%s must list at least one allowed action", path)
+	}
+	allowed := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		allowed[entry] = true
+	}
+	return allowed, nil
+}
+
 func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(cfg.RuntimeDockerfilePath), "..", ".."))
+	allowedActions, err := loadAllowedActions(filepath.Join(repoRoot, "policy", "allowed-actions.toml"))
+	if err != nil {
+		return err
+	}
 	goModPath := filepath.Join(repoRoot, "go.mod")
 	cargoManifestPath := filepath.Join(repoRoot, "runtime", "container", "rust", "Cargo.toml")
 	installDevToolsScriptPath := filepath.Join(repoRoot, "scripts", "install-dev-tools.sh")
@@ -927,7 +961,7 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err := requirePinnedBaseImage(ciBuildkitImage, "WORKCELL_BUILDKIT_IMAGE", ".github/workflows/ci.yml"); err != nil {
 		return err
 	}
-	for _, workflowPath := range mustGlob(filepath.Join(cfg.WorkflowsDir, "*.yml")) {
+	for _, workflowPath := range workflowYAMLFiles(cfg.WorkflowsDir) {
 		workflowText, err := readText(workflowPath)
 		if err != nil {
 			return err
@@ -1380,7 +1414,7 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
 		}
 	}
-	for _, workflowPath := range mustGlob(filepath.Join(cfg.WorkflowsDir, "*.yml")) {
+	for _, workflowPath := range workflowYAMLFiles(cfg.WorkflowsDir) {
 		workflowText, err := readText(workflowPath)
 		if err != nil {
 			return err
@@ -1396,9 +1430,19 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		if regexp.MustCompile(`secrets\.[A-Z0-9_]*(?:PAT|PERSONAL_ACCESS_TOKEN)\b|GH_PAT\b|PERSONAL_ACCESS_TOKEN\b`).MatchString(workflowText) {
 			return fmt.Errorf("%s must not contain long-lived personal access tokens", workflowPath)
 		}
-		for _, match := range workflowUsesPattern.FindAllStringSubmatch(workflowText, -1) {
-			if !commitShaPattern.MatchString(match[2]) {
-				return fmt.Errorf("%s must pin GitHub Actions by full commit SHA; found %s@%s", workflowPath, match[1], match[2])
+		for _, usesLine := range usesLinePattern.FindAllStringSubmatch(workflowText, -1) {
+			ref := usesLine[1]
+			action := actionRefPattern.FindStringSubmatch(ref)
+			if action == nil {
+				return fmt.Errorf("%s has an unsupported uses: reference %q; only pinned owner/repo actions are permitted (no docker:// or local ./ actions)", workflowPath, ref)
+			}
+			if !commitShaPattern.MatchString(action[2]) {
+				return fmt.Errorf("%s must pin GitHub Actions by full commit SHA; found %s@%s", workflowPath, action[1], action[2])
+			}
+			segments := strings.SplitN(action[1], "/", 3)
+			ownerRepo := segments[0] + "/" + segments[1]
+			if !allowedActions[ownerRepo] {
+				return fmt.Errorf("%s uses action %q which is not in the reviewed allowlist policy/allowed-actions.toml", workflowPath, ownerRepo)
 			}
 		}
 	}
@@ -1543,4 +1587,10 @@ func mustGlob(pattern string) []string {
 		panic(err)
 	}
 	return matches
+}
+
+// workflowYAMLFiles returns every workflow file, covering both `.yml` and
+// `.yaml` (GitHub executes either), so a `.yaml` workflow cannot dodge the scan.
+func workflowYAMLFiles(dir string) []string {
+	return append(mustGlob(filepath.Join(dir, "*.yml")), mustGlob(filepath.Join(dir, "*.yaml"))...)
 }

--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -21,13 +22,10 @@ var (
 	aptInstallPattern     = regexp.MustCompile(`apt-get install -y --no-install-recommends(?s:(.*?))&&`)
 	// pinnedReleaseTagPattern matches an exact vMAJOR.MINOR.PATCH release tag.
 	pinnedReleaseTagPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
-	// usesLinePattern matches EVERY workflow `uses:` line — whether `uses:` is the
-	// first step key (`- uses:`) or a later key (a step led by `- name:`/`- if:`).
-	// actionRefPattern then requires the captured reference to be a pinned
-	// owner/repo action; anything else (docker://, local ./, unpinned, malformed)
-	// is rejected by default, so the scan is default-deny rather than only
-	// inspecting refs that already look well-formed.
-	usesLinePattern  = regexp.MustCompile(`(?m)^\s*(?:-\s+)?uses:\s*(\S+)`)
+	// Every `uses:` reference is extracted by parsing the workflow YAML (see
+	// extractWorkflowUses), then validated here: actionRefPattern requires a
+	// pinned owner/repo action; anything else (docker://, local ./, unpinned,
+	// malformed) is rejected by default, so the scan is default-deny.
 	actionRefPattern = regexp.MustCompile(`^([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*)@([^\s#]+)$`)
 	commitShaPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
 )
@@ -53,6 +51,49 @@ type PinnedInputsConfig struct {
 // readText, isHexDigest, hexDigestPattern live in core.go.
 // requireStringSliceTable lives in hostedcontrols.go
 // (canonical post-collapse; same package-internal symbols all consumers share).
+
+type usesScanWorkflow struct {
+	Jobs map[string]usesScanJob `yaml:"jobs"`
+}
+
+type usesScanJob struct {
+	Uses  string         `yaml:"uses"`
+	Steps []usesScanStep `yaml:"steps"`
+}
+
+type usesScanStep struct {
+	Uses string `yaml:"uses"`
+}
+
+// extractWorkflowUses parses a workflow and returns every `uses:` reference
+// (job-level reusable-workflow calls and step-level actions), in deterministic
+// order. Parsing the YAML — rather than scanning raw lines — means quoted keys
+// (`"uses":`), dash-less step keys, and odd spacing all resolve to the same
+// `uses` field, so no textual form can slip an action past the allowlist.
+func extractWorkflowUses(workflowText string) ([]string, error) {
+	var doc usesScanWorkflow
+	if err := yaml.Unmarshal([]byte(workflowText), &doc); err != nil {
+		return nil, err
+	}
+	jobNames := make([]string, 0, len(doc.Jobs))
+	for name := range doc.Jobs {
+		jobNames = append(jobNames, name)
+	}
+	sort.Strings(jobNames)
+	var refs []string
+	for _, name := range jobNames {
+		job := doc.Jobs[name]
+		if strings.TrimSpace(job.Uses) != "" {
+			refs = append(refs, job.Uses)
+		}
+		for _, step := range job.Steps {
+			if strings.TrimSpace(step.Uses) != "" {
+				refs = append(refs, step.Uses)
+			}
+		}
+	}
+	return refs, nil
+}
 
 // loadAllowedActions reads the reviewed GitHub Actions allowlist as a set of
 // permitted owner/repo identities.
@@ -1430,8 +1471,11 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		if regexp.MustCompile(`secrets\.[A-Z0-9_]*(?:PAT|PERSONAL_ACCESS_TOKEN)\b|GH_PAT\b|PERSONAL_ACCESS_TOKEN\b`).MatchString(workflowText) {
 			return fmt.Errorf("%s must not contain long-lived personal access tokens", workflowPath)
 		}
-		for _, usesLine := range usesLinePattern.FindAllStringSubmatch(workflowText, -1) {
-			ref := usesLine[1]
+		usesRefs, err := extractWorkflowUses(workflowText)
+		if err != nil {
+			return fmt.Errorf("%s: %w", workflowPath, err)
+		}
+		for _, ref := range usesRefs {
 			action := actionRefPattern.FindStringSubmatch(ref)
 			if action == nil {
 				return fmt.Errorf("%s has an unsupported uses: reference %q; only pinned owner/repo actions are permitted (no docker:// or local ./ actions)", workflowPath, ref)

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -71,12 +71,15 @@ func writePinnedInputsFixture(tb testing.TB) metadatautil.PinnedInputsConfig {
 		"adapters/codex/mcp/config.toml",
 		"policy/github-hosted-controls.toml",
 		"policy/provider-bumps.toml",
+		"policy/allowed-actions.toml",
 		"runtime/container/Dockerfile",
 		"runtime/container/providers/package.json",
 		"runtime/container/providers/package-lock.json",
 		"runtime/container/rust/Cargo.toml",
 		"runtime/container/rust/rust-toolchain.toml",
 		"scripts/ci/build-validator-image.sh",
+		"scripts/ci/job-pin-hygiene.sh",
+		"scripts/ci/job-validate.sh",
 		"scripts/install-dev-tools.sh",
 		"scripts/verify-github-hosted-controls.sh",
 		"tools/markdownlint/package.json",
@@ -488,6 +491,43 @@ func TestCheckPinnedInputsRejectsDocsBuildxVersionDrift(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "WORKCELL_BUILDX_VERSION") || !strings.Contains(err.Error(), "docs.yml") {
 		t.Fatalf("metadatautil.CheckPinnedInputs() error = %v, want docs.yml buildx drift rejection", err)
+	}
+}
+
+func TestCheckPinnedInputsRejectsOffAllowlistAction(t *testing.T) {
+	t.Parallel()
+
+	cfg := writePinnedInputsFixture(t)
+	// Inject a DASH-LESS `uses:` line (as if it were a second key of a step led
+	// by `- name:`), which the scan must cover — not only `- uses:` first-key
+	// steps. SHA-shaped so it passes the pin check and reaches the allowlist check.
+	rewriteFile(t, filepath.Join(cfg.WorkflowsDir, "ci.yml"), func(content string) string {
+		return strings.Replace(content,
+			"\n      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+			"\n      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0\n        uses: evilorg/evil-action@0000000000000000000000000000000000000000",
+			1)
+	})
+
+	err := metadatautil.CheckPinnedInputs(cfg)
+	if err == nil {
+		t.Fatal("metadatautil.CheckPinnedInputs() unexpectedly accepted a dash-less off-allowlist action")
+	}
+	if !strings.Contains(err.Error(), "allowlist") || !strings.Contains(err.Error(), "evilorg/evil-action") {
+		t.Fatalf("metadatautil.CheckPinnedInputs() error = %v, want off-allowlist rejection", err)
+	}
+}
+
+func TestCheckPinnedInputsRejectsUnsupportedUsesForm(t *testing.T) {
+	t.Parallel()
+
+	cfg := writePinnedInputsFixture(t)
+	rewriteFile(t, filepath.Join(cfg.WorkflowsDir, "ci.yml"), func(content string) string {
+		return strings.Replace(content, "- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0", "- uses: docker://ghcr.io/evil/image:latest", 1)
+	})
+
+	err := metadatautil.CheckPinnedInputs(cfg)
+	if err == nil || !strings.Contains(err.Error(), "unsupported uses:") {
+		t.Fatalf("metadatautil.CheckPinnedInputs() error = %v, want unsupported-uses rejection", err)
 	}
 }
 

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -498,13 +498,13 @@ func TestCheckPinnedInputsRejectsOffAllowlistAction(t *testing.T) {
 	t.Parallel()
 
 	cfg := writePinnedInputsFixture(t)
-	// Inject a DASH-LESS `uses:` line (as if it were a second key of a step led
-	// by `- name:`), which the scan must cover — not only `- uses:` first-key
-	// steps. SHA-shaped so it passes the pin check and reaches the allowlist check.
+	// Use a QUOTED step key (`- "uses":`), which GitHub treats as the `uses` key
+	// but a raw-line scan would miss. Parsing the YAML must still catch it.
+	// SHA-shaped so it passes the pin check and reaches the allowlist check.
 	rewriteFile(t, filepath.Join(cfg.WorkflowsDir, "ci.yml"), func(content string) string {
 		return strings.Replace(content,
-			"\n      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-			"\n      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0\n        uses: evilorg/evil-action@0000000000000000000000000000000000000000",
+			"- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+			`- "uses": evilorg/evil-action@0000000000000000000000000000000000000000`,
 			1)
 	})
 

--- a/policy/allowed-actions.toml
+++ b/policy/allowed-actions.toml
@@ -1,0 +1,29 @@
+# Reviewed allowlist of GitHub Actions permitted in `.github/workflows/*.yml`.
+#
+# Every `uses: <owner>/<repo>[/<subpath>]@<sha>` in a workflow must have its
+# `<owner>/<repo>` listed here. This is additive to the existing requirement
+# that every action be pinned by full commit SHA (enforced by
+# `workcell-citools check-pinned-inputs`): SHA-pinning proves integrity of a
+# ref, while this allowlist restricts *which* actions may appear at all, so a
+# new (even correctly-pinned) action cannot be introduced without a reviewed
+# change to this file.
+#
+# Adding an entry is a deliberate supply-chain decision: the action's publisher
+# is now trusted to run in Workcell's CI with whatever permissions the calling
+# job grants.
+
+[actions]
+allowed = [
+  "actions/attest",
+  "actions/checkout",
+  "actions/dependency-review-action",
+  "actions/download-artifact",
+  "actions/upload-artifact",
+  "anchore/sbom-action",
+  "docker/build-push-action",
+  "docker/login-action",
+  "docker/setup-buildx-action",
+  "github/codeql-action",
+  "ossf/scorecard-action",
+  "sigstore/cosign-installer",
+]


### PR DESCRIPTION
# Summary

Lands the highest-value half of ROADMAP item **B4** (Centralized Tool Pins And
Action Allowlist) per [`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md):

- **`policy/allowed-actions.toml`** — a reviewed allowlist of the 12 GitHub
  Actions `owner/repo` identities permitted in workflows.
- **`internal/metadatautil/pinnedinputs.go`** — `check-pinned-inputs` now
  rejects any `uses:` whose `owner/repo` is not on the allowlist, in addition to
  the existing full-commit-SHA requirement. SHA-pinning proves ref integrity;
  the allowlist restricts *which* publishers may run at all, so a new (even
  correctly pinned) action cannot be introduced without a reviewed policy diff.
- The `uses:` scan pattern was extended to also match 3-segment actions
  (`github/codeql-action/analyze`, `anchore/sbom-action/download-syft`), which
  the old pattern skipped — so those are now SHA-checked and allowlist-checked
  too (closing a pre-existing gap). No workflow YAML changed.

## Scope note

This is B4's action-allowlist half. The tool-pin **centralization** (moving the
duplicated actionlint/zizmor/cosign/buildx/... pins into a canonical policy file)
is a larger, separately-reviewable change deferred to **B4b**; the pins are
already cross-checked for drift by `check-pinned-inputs` today.

## Support-claim impact

None. CI supply-chain validation and docs only.

## Validation

- new negative test: an off-allowlist (but SHA-pinned) action is rejected; full
  `CheckPinnedInputs` suite green; `go vet`/`gofmt` clean
- `check-pinned-inputs`, `check-workflows`, control-plane-lockstep invariant,
  `validate-toml`, docs-link, markdownlint, codespell all pass
- `./scripts/pre-merge.sh --profile pr-parity` before publication
