### PR TITLE
Centralize CI tool pins into reviewed policy (B4b)

### DIFF
--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -123,6 +123,15 @@ proves the integrity of a specific ref; the allowlist restricts which action
 publishers may run at all, so introducing a new action — even a correctly
 pinned one — requires a reviewed change to that policy.
 
+The CI/release tool pins (cosign, buildx, buildkit, QEMU, syft, actionlint,
+zizmor) have a reviewed chokepoint in
+[`policy/tool-pins.toml`](../policy/tool-pins.toml). The values still live inline
+in the workflows; `check-pinned-inputs` asserts every workflow copy equals the
+policy, and `scripts/update-upstream-pins.sh` rewrites the workflows and the
+policy together on a bump. The policy is the human-reviewed record kept in
+lockstep with the workflows, so a pin can never move without a reviewed diff to
+that file.
+
 `ci.yml` and `docs.yml` use the same explicit nonroot validator contract when
 they bind-mount the repository: the workflow computes the caller UID/GID,
 passes isolated writable roots, and creates those paths inside the validator

--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -1261,26 +1261,26 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err != nil {
 		return err
 	}
-	_, securityActionlintVersionMatch, err := requireRegex(securityWorkflow, `(?m)^\s*ACTIONLINT_VERSION:\s*([0-9]+\.[0-9]+\.[0-9]+)\s*$`, "security actionlint version", ".github/workflows/security.yml")
+	securityActionlintVersion, err := requireUniformWorkflowEnv(securityWorkflow, "ACTIONLINT_VERSION", `[0-9]+\.[0-9]+\.[0-9]+`, "security actionlint version", ".github/workflows/security.yml")
 	if err != nil {
 		return err
 	}
-	_, releaseActionlintVersionMatch, err := requireRegex(releaseWorkflow, `(?m)^\s*ACTIONLINT_VERSION:\s*([0-9]+\.[0-9]+\.[0-9]+)\s*$`, "release actionlint version", ".github/workflows/release.yml")
+	releaseActionlintVersion, err := requireUniformWorkflowEnv(releaseWorkflow, "ACTIONLINT_VERSION", `[0-9]+\.[0-9]+\.[0-9]+`, "release actionlint version", ".github/workflows/release.yml")
 	if err != nil {
 		return err
 	}
-	if securityActionlintVersionMatch[1] != releaseActionlintVersionMatch[1] {
+	if securityActionlintVersion != releaseActionlintVersion {
 		return errors.New("ACTIONLINT_VERSION must match between .github/workflows/security.yml and .github/workflows/release.yml")
 	}
-	_, securityActionlintSHAMatch, err := requireRegex(securityWorkflow, `(?m)^\s*ACTIONLINT_SHA256:\s*([0-9a-f]{64})\s*$`, "security actionlint sha", ".github/workflows/security.yml")
+	securityActionlintSHA, err := requireUniformWorkflowEnv(securityWorkflow, "ACTIONLINT_SHA256", `[0-9a-f]{64}`, "security actionlint sha", ".github/workflows/security.yml")
 	if err != nil {
 		return err
 	}
-	_, releaseActionlintSHAMatch, err := requireRegex(releaseWorkflow, `(?m)^\s*ACTIONLINT_SHA256:\s*([0-9a-f]{64})\s*$`, "release actionlint sha", ".github/workflows/release.yml")
+	releaseActionlintSHA, err := requireUniformWorkflowEnv(releaseWorkflow, "ACTIONLINT_SHA256", `[0-9a-f]{64}`, "release actionlint sha", ".github/workflows/release.yml")
 	if err != nil {
 		return err
 	}
-	if securityActionlintSHAMatch[1] != releaseActionlintSHAMatch[1] {
+	if securityActionlintSHA != releaseActionlintSHA {
 		return errors.New("ACTIONLINT_SHA256 must match between .github/workflows/security.yml and .github/workflows/release.yml")
 	}
 	securityZizmorVersion, err := requireUniformWorkflowEnv(securityWorkflow, "ZIZMOR_VERSION", `[0-9]+\.[0-9]+\.[0-9]+`, "security zizmor version", ".github/workflows/security.yml")
@@ -1319,8 +1319,8 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		{"WORKCELL_BUILDKIT_IMAGE", ciBuildkitImage, pins.Buildkit},
 		{"WORKCELL_QEMU_IMAGE", ciQEMUImage, pins.QEMU},
 		{"WORKCELL_SYFT_VERSION", releaseSyftVersion, pins.Syft},
-		{"ACTIONLINT_VERSION", securityActionlintVersionMatch[1], pins.ActionlintVersion},
-		{"ACTIONLINT_SHA256", securityActionlintSHAMatch[1], pins.ActionlintSHA256},
+		{"ACTIONLINT_VERSION", securityActionlintVersion, pins.ActionlintVersion},
+		{"ACTIONLINT_SHA256", securityActionlintSHA, pins.ActionlintSHA256},
 		{"ZIZMOR_VERSION", securityZizmorVersion, pins.ZizmorVersion},
 		{"ZIZMOR_SHA256", securityZizmorSHA, pins.ZizmorSHA256},
 	} {

--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -95,6 +95,66 @@ func extractWorkflowUses(workflowText string) ([]string, error) {
 	return refs, nil
 }
 
+// toolPins is the reviewed canonical set of CI/release tool pins that are
+// otherwise duplicated inline across workflows.
+type toolPins struct {
+	Cosign            string
+	Buildx            string
+	Buildkit          string
+	QEMU              string
+	Syft              string
+	ActionlintVersion string
+	ActionlintSHA256  string
+	ZizmorVersion     string
+	ZizmorSHA256      string
+}
+
+// loadToolPins reads policy/tool-pins.toml and requires every pin to be present.
+func loadToolPins(path string) (toolPins, error) {
+	text, err := readText(path)
+	if err != nil {
+		return toolPins{}, err
+	}
+	root, err := tomlsubset.Parse(text, path)
+	if err != nil {
+		return toolPins{}, err
+	}
+	table, ok := root["tool_pins"].(map[string]any)
+	if !ok {
+		return toolPins{}, fmt.Errorf("%s must define a [tool_pins] table", path)
+	}
+	var pins toolPins
+	fields := []struct {
+		key string
+		dst *string
+	}{
+		{"cosign", &pins.Cosign},
+		{"buildx", &pins.Buildx},
+		{"buildkit", &pins.Buildkit},
+		{"qemu", &pins.QEMU},
+		{"syft", &pins.Syft},
+		{"actionlint_version", &pins.ActionlintVersion},
+		{"actionlint_sha256", &pins.ActionlintSHA256},
+		{"zizmor_version", &pins.ZizmorVersion},
+		{"zizmor_sha256", &pins.ZizmorSHA256},
+	}
+	known := make(map[string]bool, len(fields))
+	for _, field := range fields {
+		known[field.key] = true
+		value, ok := MustString(table[field.key])
+		if !ok || strings.TrimSpace(value) == "" {
+			return toolPins{}, fmt.Errorf("%s [tool_pins] must set a non-empty %s", path, field.key)
+		}
+		*field.dst = value
+	}
+	for key := range table {
+		if !known[key] {
+			return toolPins{}, fmt.Errorf("%s [tool_pins] has an unknown key %q", path, key)
+		}
+	}
+	return pins, nil
+}
+
 // loadAllowedActions reads the reviewed GitHub Actions allowlist as a set of
 // permitted owner/repo identities.
 func loadAllowedActions(path string) (map[string]bool, error) {
@@ -125,6 +185,19 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	allowedActions, err := loadAllowedActions(filepath.Join(repoRoot, "policy", "allowed-actions.toml"))
 	if err != nil {
 		return err
+	}
+	pins, err := loadToolPins(filepath.Join(repoRoot, "policy", "tool-pins.toml"))
+	if err != nil {
+		return err
+	}
+	// requirePolicyPin binds a workflow's canonical tool pin to policy/tool-pins.toml
+	// so bumping a tool is a reviewed change to that one file. The existing
+	// cross-file asserts then keep every other workflow copy in lockstep.
+	requirePolicyPin := func(name, actual, policyValue string) error {
+		if actual != policyValue {
+			return fmt.Errorf("%s pin %q does not match policy/tool-pins.toml %q; the workflow and the policy must stay in lockstep (scripts/update-upstream-pins.sh rewrites both)", name, actual, policyValue)
+		}
+		return nil
 	}
 	goModPath := filepath.Join(repoRoot, "go.mod")
 	cargoManifestPath := filepath.Join(repoRoot, "runtime", "container", "rust", "Cargo.toml")
@@ -1231,6 +1304,29 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	}
 	if securityZizmorSHA != releaseZizmorSHA {
 		return errors.New("ZIZMOR_SHA256 must match between .github/workflows/security.yml and .github/workflows/release.yml")
+	}
+	// Bind each tool's canonical workflow value to policy/tool-pins.toml. Run
+	// after the cross-file asserts above so a workflow-vs-workflow mismatch is
+	// reported as such; this catches the case where every workflow copy agrees
+	// but drifts from the reviewed policy.
+	for _, check := range []struct {
+		name        string
+		actual      string
+		policyValue string
+	}{
+		{"WORKCELL_COSIGN_VERSION", ciCosignVersion, pins.Cosign},
+		{"WORKCELL_BUILDX_VERSION", ciBuildxVersion, pins.Buildx},
+		{"WORKCELL_BUILDKIT_IMAGE", ciBuildkitImage, pins.Buildkit},
+		{"WORKCELL_QEMU_IMAGE", ciQEMUImage, pins.QEMU},
+		{"WORKCELL_SYFT_VERSION", releaseSyftVersion, pins.Syft},
+		{"ACTIONLINT_VERSION", securityActionlintVersionMatch[1], pins.ActionlintVersion},
+		{"ACTIONLINT_SHA256", securityActionlintSHAMatch[1], pins.ActionlintSHA256},
+		{"ZIZMOR_VERSION", securityZizmorVersion, pins.ZizmorVersion},
+		{"ZIZMOR_SHA256", securityZizmorSHA, pins.ZizmorSHA256},
+	} {
+		if err := requirePolicyPin(check.name, check.actual, check.policyValue); err != nil {
+			return err
+		}
 	}
 	for _, workflow := range []struct {
 		text string

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -72,6 +72,7 @@ func writePinnedInputsFixture(tb testing.TB) metadatautil.PinnedInputsConfig {
 		"policy/github-hosted-controls.toml",
 		"policy/provider-bumps.toml",
 		"policy/allowed-actions.toml",
+		"policy/tool-pins.toml",
 		"runtime/container/Dockerfile",
 		"runtime/container/providers/package.json",
 		"runtime/container/providers/package-lock.json",
@@ -514,6 +515,51 @@ func TestCheckPinnedInputsRejectsOffAllowlistAction(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "allowlist") || !strings.Contains(err.Error(), "evilorg/evil-action") {
 		t.Fatalf("metadatautil.CheckPinnedInputs() error = %v, want off-allowlist rejection", err)
+	}
+}
+
+func TestCheckPinnedInputsRejectsToolPinPolicyDrift(t *testing.T) {
+	t.Parallel()
+
+	// Cover a plain version pin, an image pin (special chars), and a
+	// regex-extracted pin, so every binding shape is exercised.
+	cases := []struct {
+		name string
+		from string
+		to   string
+	}{
+		{"cosign", `cosign = "v3.1.1"`, `cosign = "v9.9.9"`},
+		{"buildkit-image", "@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f", "@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+		{"zizmor-sha", `zizmor_sha256 = "8556289a64e7aaf2400cd516f61a471aa91c5902cc56ad96a82fd12f90c2ef73"`, `zizmor_sha256 = "0000000000000000000000000000000000000000000000000000000000000000"`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := writePinnedInputsFixture(t)
+			toolPinsPath := filepath.Join(filepath.Dir(cfg.ProviderBumpPolicyPath), "tool-pins.toml")
+			rewriteFile(t, toolPinsPath, func(content string) string {
+				return strings.Replace(content, tc.from, tc.to, 1)
+			})
+			err := metadatautil.CheckPinnedInputs(cfg)
+			if err == nil || !strings.Contains(err.Error(), "does not match policy/tool-pins.toml") {
+				t.Fatalf("metadatautil.CheckPinnedInputs() error = %v, want tool-pin policy drift rejection", err)
+			}
+		})
+	}
+}
+
+func TestCheckPinnedInputsRejectsUnknownToolPinKey(t *testing.T) {
+	t.Parallel()
+
+	cfg := writePinnedInputsFixture(t)
+	toolPinsPath := filepath.Join(filepath.Dir(cfg.ProviderBumpPolicyPath), "tool-pins.toml")
+	rewriteFile(t, toolPinsPath, func(content string) string {
+		return strings.Replace(content, "[tool_pins]", "[tool_pins]\nbogus = \"x\"", 1)
+	})
+	err := metadatautil.CheckPinnedInputs(cfg)
+	if err == nil || !strings.Contains(err.Error(), "unknown key") {
+		t.Fatalf("metadatautil.CheckPinnedInputs() error = %v, want unknown-key rejection", err)
 	}
 }
 

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -522,24 +522,21 @@ func TestCheckPinnedInputsRejectsToolPinPolicyDrift(t *testing.T) {
 	t.Parallel()
 
 	// Cover a plain version pin, an image pin (special chars), and a
-	// regex-extracted pin, so every binding shape is exercised.
-	cases := []struct {
-		name string
-		from string
-		to   string
-	}{
-		{"cosign", `cosign = "v3.1.1"`, `cosign = "v9.9.9"`},
-		{"buildkit-image", "@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f", "@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
-		{"zizmor-sha", `zizmor_sha256 = "8556289a64e7aaf2400cd516f61a471aa91c5902cc56ad96a82fd12f90c2ef73"`, `zizmor_sha256 = "0000000000000000000000000000000000000000000000000000000000000000"`},
-	}
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+	// regex-extracted pin. The mutation is derived from whatever value the
+	// fixture holds, so a routine pin bump does not require editing this test.
+	for _, key := range []string{"cosign", "buildkit", "zizmor_sha256"} {
+		key := key
+		t.Run(key, func(t *testing.T) {
 			t.Parallel()
 			cfg := writePinnedInputsFixture(t)
 			toolPinsPath := filepath.Join(filepath.Dir(cfg.ProviderBumpPolicyPath), "tool-pins.toml")
+			pattern := regexp.MustCompile(`(?m)^(` + regexp.QuoteMeta(key) + ` = )"[^"]*"`)
 			rewriteFile(t, toolPinsPath, func(content string) string {
-				return strings.Replace(content, tc.from, tc.to, 1)
+				updated := pattern.ReplaceAllString(content, `${1}"policy-drift-sentinel"`)
+				if updated == content {
+					t.Fatalf("fixture policy/tool-pins.toml has no %q pin to mutate", key)
+				}
+				return updated
 			})
 			err := metadatautil.CheckPinnedInputs(cfg)
 			if err == nil || !strings.Contains(err.Error(), "does not match policy/tool-pins.toml") {

--- a/policy/tool-pins.toml
+++ b/policy/tool-pins.toml
@@ -1,0 +1,18 @@
+# Reviewed chokepoint for the CI/release tool pins. The pin values also live
+# inline in the workflows; `check-pinned-inputs` asserts every workflow copy
+# equals the value here, and `scripts/update-upstream-pins.sh` rewrites the
+# workflows and this file together on a bump. This is the human-reviewed record
+# of the intended pins, kept in lockstep with the workflows — not a single
+# source that replaces the inline values. Values are stored exactly as they
+# appear in the workflow env (actionlint/zizmor versions have no leading `v`).
+
+[tool_pins]
+cosign = "v3.1.1"
+buildx = "v0.35.0"
+buildkit = "moby/buildkit:buildx-stable-1@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f"
+qemu = "tonistiigi/binfmt:qemu-v10.2.3-68@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0"
+syft = "v1.46.0"
+actionlint_version = "1.7.12"
+actionlint_sha256 = "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+zizmor_version = "1.26.1"
+zizmor_sha256 = "8556289a64e7aaf2400cd516f61a471aa91c5902cc56ad96a82fd12f90c2ef73"

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -51,6 +51,7 @@ PIN_HYGIENE_WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/pin-hygiene.yml"
 RELEASE_WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/release.yml"
 SECURITY_WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/security.yml"
 UPSTREAM_REFRESH_WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/upstream-refresh.yml"
+TOOL_PINS_POLICY_PATH="${ROOT_DIR}/policy/tool-pins.toml"
 
 mode="summary"
 
@@ -786,6 +787,18 @@ replace_line_with_prefix "${SECURITY_WORKFLOW_PATH}" '          ACTIONLINT_SHA25
 replace_line_with_prefix "${SECURITY_WORKFLOW_PATH}" '          ACTIONLINT_VERSION:' "          ACTIONLINT_VERSION: ${target_actionlint_version}"
 replace_all_lines_with_prefix "${SECURITY_WORKFLOW_PATH}" '          ZIZMOR_SHA256:' "          ZIZMOR_SHA256: ${target_zizmor_sha}"
 replace_all_lines_with_prefix "${SECURITY_WORKFLOW_PATH}" '          ZIZMOR_VERSION:' "          ZIZMOR_VERSION: ${target_zizmor_version}"
+
+# Keep the reviewed canonical pin policy in lockstep with the workflow edits,
+# before check-pinned-inputs (below) asserts the two agree.
+replace_line_with_prefix "${TOOL_PINS_POLICY_PATH}" 'cosign = ' "cosign = \"${target_cosign_version}\""
+replace_line_with_prefix "${TOOL_PINS_POLICY_PATH}" 'buildx = ' "buildx = \"${target_buildx_version}\""
+replace_line_with_prefix "${TOOL_PINS_POLICY_PATH}" 'buildkit = ' "buildkit = \"${target_buildkit_image}\""
+replace_line_with_prefix "${TOOL_PINS_POLICY_PATH}" 'qemu = ' "qemu = \"${target_qemu_image}\""
+replace_line_with_prefix "${TOOL_PINS_POLICY_PATH}" 'syft = ' "syft = \"${target_syft_version}\""
+replace_line_with_prefix "${TOOL_PINS_POLICY_PATH}" 'actionlint_version = ' "actionlint_version = \"${target_actionlint_version}\""
+replace_line_with_prefix "${TOOL_PINS_POLICY_PATH}" 'actionlint_sha256 = ' "actionlint_sha256 = \"${target_actionlint_sha}\""
+replace_line_with_prefix "${TOOL_PINS_POLICY_PATH}" 'zizmor_version = ' "zizmor_version = \"${target_zizmor_version}\""
+replace_line_with_prefix "${TOOL_PINS_POLICY_PATH}" 'zizmor_sha256 = ' "zizmor_sha256 = \"${target_zizmor_sha}\""
 
 "${ROOT_DIR}/scripts/update-provider-pins.sh" --apply
 "${ROOT_DIR}/scripts/check-pinned-inputs.sh"


### PR DESCRIPTION
# Summary

Completes ROADMAP item **B4** (the pin-centralization half; the action allowlist
half landed in #370) per [`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md):

- **`policy/tool-pins.toml`** — one reviewed canonical source for the 7 CI/release
  tool pins (cosign, buildx, buildkit, QEMU, syft, actionlint, zizmor) that were
  otherwise duplicated inline across workflows.
- **`check-pinned-inputs`** now asserts each tool's canonical workflow value
  matches the policy (after the existing cross-file consistency asserts, which
  transitively keep every other workflow copy in lockstep). **syft gains
  consistency coverage it did not have before.** Bumping a tool is now a reviewed
  change to one file.
- **`scripts/update-upstream-pins.sh`** rewrites the policy alongside the
  workflows (before its own `check-pinned-inputs` self-check), so the automated
  bump path stays consistent.

## Support-claim impact

None. CI supply-chain validation, a policy file, and docs only.

## Validation

- new tool-pin policy-drift test; full `internal/metadatautil` suite green
  (existing cross-file mismatch tests preserved — policy block runs after them)
- `check-pinned-inputs` passes on the real repo (policy matches current pins);
  control-plane-lockstep, `validate-toml`, docs-link, `shellcheck`, `codespell`,
  `markdownlint` all pass
- `./scripts/pre-merge.sh --profile pr-parity` before publication
