### PR TITLE
Document and enforce unsafe-code safety invariants (A4)

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -59,6 +59,10 @@ published provenance story.
 For how these controls map to the OWASP Top 10 for Agentic Applications
 (2026), see [owasp-agentic-mapping.md](owasp-agentic-mapping.md).
 
+The Rust `unsafe` surface behind the exec/syscall interception boundary is
+inventoried, with its soundness invariants and a reviewer checklist, in
+[unsafe-code-audit-checklist.md](unsafe-code-audit-checklist.md).
+
 ## Residual risks
 
 - the full macOS boundary is still a local exercise, not a GitHub-hosted

--- a/docs/unsafe-code-audit-checklist.md
+++ b/docs/unsafe-code-audit-checklist.md
@@ -15,6 +15,10 @@ libc, or an external security audit.
   `runtime/container/rust/Cargo.toml`, checked by
   `cargo clippy --all-targets --locked --offline -- -D warnings` in
   `scripts/validate-repo.sh`. A new undocumented `unsafe` block fails CI.
+- That clippy lint does not cover `unsafe extern "C" {` blocks, so
+  `scripts/validate-repo.sh` additionally requires a preceding `// SAFETY:`
+  comment on every `unsafe extern` block. A new undocumented FFI declaration
+  fails CI too.
 - `#![deny(unsafe_op_in_unsafe_fn)]` (`lib.rs`) forces every operation inside an
   `unsafe fn` into an explicit `unsafe {}` block, so no unsafe operation is
   implicitly covered by the function signature.

--- a/docs/unsafe-code-audit-checklist.md
+++ b/docs/unsafe-code-audit-checklist.md
@@ -1,0 +1,69 @@
+# Unsafe-Code Pre-Audit Checklist
+
+Workcell's security boundary depends on a small, deliberately contained body of
+Rust `unsafe` code: the container-side exec/syscall interception shim
+(`runtime/container/rust/src/lib.rs`) and the launcher binaries
+(`runtime/container/rust/src/bin/`). This checklist is the pre-audit reference
+for reviewing that surface — before a release, a dependency bump that touches
+libc, or an external security audit.
+
+## Enforcement in place
+
+- Every `unsafe {}` block carries a `// SAFETY:` comment stating the invariant
+  that makes it sound. This is enforced by
+  `undocumented_unsafe_blocks = "deny"` in
+  `runtime/container/rust/Cargo.toml`, checked by
+  `cargo clippy --all-targets --locked --offline -- -D warnings` in
+  `scripts/validate-repo.sh`. A new undocumented `unsafe` block fails CI.
+- `#![deny(unsafe_op_in_unsafe_fn)]` (`lib.rs`) forces every operation inside an
+  `unsafe fn` into an explicit `unsafe {}` block, so no unsafe operation is
+  implicitly covered by the function signature.
+
+## Unsafe surface inventory
+
+The unsafe code falls into a few invariant classes. An auditor should confirm
+each block still belongs to its class and that the class invariant holds.
+
+| Class | What it does | Invariant to confirm |
+|---|---|---|
+| Niladic syscalls (`getpid`, `getppid`, `fork`) | no-argument syscalls | no preconditions; return value handled |
+| C-string ABI reads (`CStr::from_ptr`, `*ptr.add`) | reading intercepted `argv`/`envp`/path pointers | pointer is null-checked and points to a NUL-terminated string / NUL-sentinel array per the exec ABI |
+| `static mut environ` reads | reading libc's global env when no `envp` given | read in the calling thread with no concurrent `setenv`/`putenv` |
+| `dlsym(RTLD_NEXT)` + `transmute_copy` | resolving the next-chain libc symbol into a fn pointer | `T` is a pointer-sized `extern "C"` fn whose ABI matches the named symbol |
+| Syscall trampoline (`workcell_syscall_shim`) | entered from hand-written `global_asm!` | asm preserves the `syscall(long, ...)` ABI; per-number arg meanings |
+| LD_PRELOAD interposers + tail forwards | intercept then forward original args to real libc | args obey the interposed function's C ABI; forwarded unmodified |
+| Env mutation (`env::set_var`/`remove_var`) | Rust 2024 unsafe env writes | runs single-threaded before any thread/child spawns |
+| Signal-handler `kill` / `sigaction` setup | async-signal-safe teardown | only async-signal-safe calls; PID read via atomic |
+
+## High-scrutiny items (subtle invariants — review these first)
+
+1. **`workcell_syscall_shim` (`lib.rs`)** — safety is upheld by the
+   `global_asm!` trampoline, not by any Rust caller, and it reads all six
+   register args regardless of the variadic count. A change to the asm or to the
+   per-syscall arg handling must be re-audited against the kernel ABI.
+2. **`load_symbol` `transmute_copy` (`lib.rs`)** — `transmute_copy` skips the
+   size check; soundness rests on every instantiation of `T` being a
+   pointer-sized `extern "C"` fn pointer matching the named C symbol. Adding a
+   new interposer means adding a matching `Fn` type alias + `c"name"` pair.
+3. **`static mut environ` reads** — a shared mutable global; sound only absent
+   concurrent `setenv`/`putenv`, consistent with libc `getenv` semantics.
+4. **`env::set_var`/`remove_var` in the launchers** — the "no data race"
+   invariant holds only if these run before any thread is spawned. Confirm caller
+   ordering; note the default multithreaded test runner is the weak spot for the
+   `#[cfg(test)]` uses.
+
+## Pre-audit checklist
+
+- [ ] `cargo clippy … -D warnings` is green (zero `undocumented_unsafe_blocks`).
+- [ ] `#![deny(unsafe_op_in_unsafe_fn)]` is still present in `lib.rs`.
+- [ ] Every `unsafe {}` block's `// SAFETY:` comment still matches the code it
+      guards (no block was edited without updating its invariant).
+- [ ] No new `unsafe` construct falls outside the classes above; if it does, it
+      is documented and added to this inventory.
+- [ ] The high-scrutiny items are unchanged, or their changes were re-audited
+      against the relevant ABI (kernel syscall, libc symbol, signal-safety).
+- [ ] Any new LD_PRELOAD interposer pairs a `c"symbol"` literal with a matching
+      `extern "C" fn` type alias, and forwards the caller's original arguments
+      unmodified.
+- [ ] `libc` crate version bumps are reviewed for changed signatures on the
+      intercepted symbols.

--- a/runtime/container/rust/Cargo.toml
+++ b/runtime/container/rust/Cargo.toml
@@ -18,9 +18,10 @@ path = "src/bin/workcell-launcher.rs"
 libc = "0.2.177"
 
 [lints.clippy]
-# A4: every `unsafe {}` block (and unsafe extern block) must carry a `// SAFETY:`
-# comment stating the invariant that makes it sound. This is a restriction lint
-# (allow by default), enabled here as the enforcement for the unsafe-code audit.
+# A4: every `unsafe {}` block must carry a `// SAFETY:` comment stating the
+# invariant that makes it sound. This is a restriction lint (allow by default),
+# enabled here as the enforcement for the unsafe-code audit. Note this lint does
+# NOT cover `unsafe extern` blocks; those are guarded in scripts/validate-repo.sh.
 undocumented_unsafe_blocks = "deny"
 
 [profile.release]

--- a/runtime/container/rust/Cargo.toml
+++ b/runtime/container/rust/Cargo.toml
@@ -17,6 +17,12 @@ path = "src/bin/workcell-launcher.rs"
 [dependencies]
 libc = "0.2.177"
 
+[lints.clippy]
+# A4: every `unsafe {}` block (and unsafe extern block) must carry a `// SAFETY:`
+# comment stating the invariant that makes it sound. This is a restriction lint
+# (allow by default), enabled here as the enforcement for the unsafe-code audit.
+undocumented_unsafe_blocks = "deny"
+
 [profile.release]
 codegen-units = 1
 lto = true

--- a/runtime/container/rust/src/bin/common/launcher_common.rs
+++ b/runtime/container/rust/src/bin/common/launcher_common.rs
@@ -9,6 +9,7 @@ use std::os::unix::ffi::OsStrExt;
 #[cfg(not(test))]
 use std::sync::atomic::{AtomicI32, Ordering};
 
+// SAFETY: matches libc's process-global char **environ; reads assume no concurrent setenv/putenv mutation.
 unsafe extern "C" {
     static mut environ: *mut *mut c_char;
 }
@@ -49,12 +50,14 @@ impl fmt::Display for NulArgumentError {
 pub fn sanitize_env() {
     for key in SANITIZED_ENV_KEYS {
         // Rust 2024 makes process-global env mutation unsafe.
+        // SAFETY: called during single-threaded launcher startup before any thread or child is spawned; no concurrent env access.
         unsafe { env::remove_var(key) };
     }
 }
 
 pub fn set_env_var(key: &str, value: &str) {
     // Rust 2024 makes process-global env mutation unsafe.
+    // SAFETY: single-threaded startup env mutation; no other thread can be reading the environment.
     unsafe { env::set_var(key, value) };
 }
 
@@ -92,6 +95,7 @@ pub fn exec_request(exec_args: &[CString], script_path: &str) -> i32 {
     let mut argv: Vec<*const c_char> = exec_args.iter().map(|arg| arg.as_ptr()).collect();
     argv.push(std::ptr::null());
 
+    // SAFETY: exec_args is a live non-empty Vec<CString> backing the NULL-terminated argv; environ is libc-initialized; single-threaded.
     let rc = unsafe { libc::execve(exec_args[0].as_ptr(), argv.as_ptr(), environ.cast()) };
     let errno = std::io::Error::last_os_error()
         .raw_os_error()
@@ -108,6 +112,7 @@ pub fn exec_request(exec_args: &[CString], script_path: &str) -> i32 {
 extern "C" fn forward_signal_to_managed_child(signal: libc::c_int) {
     let pid = MANAGED_CHILD_PID.load(Ordering::SeqCst);
     if pid > 0 {
+        // SAFETY: kill() is async-signal-safe; pid>0 read via SeqCst atomic; a stale pid yields harmless ESRCH.
         unsafe {
             libc::kill(pid, signal);
         }
@@ -117,11 +122,13 @@ extern "C" fn forward_signal_to_managed_child(signal: libc::c_int) {
 #[cfg(not(test))]
 fn install_signal_forwarding() {
     for signal in [libc::SIGINT, libc::SIGTERM] {
+        // SAFETY: libc::sigaction is a repr(C) POD; all-zeroes is a valid initial value.
         let mut action: libc::sigaction = unsafe { std::mem::zeroed() };
         // Linux libc exposes the sa_handler/sa_sigaction union as this field;
         // SA_SIGINFO stays clear so the kernel treats it as a one-arg handler.
         action.sa_sigaction = forward_signal_to_managed_child as *const () as libc::sighandler_t;
         action.sa_flags = 0;
+        // SAFETY: &action/&mut sa_mask are valid; handler is a real extern "C" fn with SA_SIGINFO clear (one-arg ABI); null oldact is allowed.
         unsafe {
             libc::sigemptyset(&mut action.sa_mask);
             libc::sigaction(signal, &action, std::ptr::null_mut());
@@ -132,6 +139,7 @@ fn install_signal_forwarding() {
 #[cfg(not(test))]
 pub fn spawn_and_wait_request(exec_args: &[CString], script_path: &str) -> i32 {
     install_signal_forwarding();
+    // SAFETY: fork() takes no arguments; child/parent dispatched on the returned pid.
     let pid = unsafe { libc::fork() };
     if pid < 0 {
         let errno = std::io::Error::last_os_error()
@@ -150,6 +158,7 @@ pub fn spawn_and_wait_request(exec_args: &[CString], script_path: &str) -> i32 {
         let mut argv: Vec<*const c_char> = exec_args.iter().map(|arg| arg.as_ptr()).collect();
         argv.push(std::ptr::null());
 
+        // SAFETY: in the forked child; exec_args backs the NULL-terminated argv, environ is libc's env; execve is async-signal-safe.
         let rc = unsafe { libc::execve(exec_args[0].as_ptr(), argv.as_ptr(), environ.cast()) };
         let errno = std::io::Error::last_os_error()
             .raw_os_error()
@@ -158,12 +167,14 @@ pub fn spawn_and_wait_request(exec_args: &[CString], script_path: &str) -> i32 {
         if rc != 0 {
             eprintln!("{}", format_exec_error(script_path, errno));
         }
+        // SAFETY: _exit() is async-signal-safe and terminates the failed child without running at-exit handlers.
         unsafe { libc::_exit(exit_code_for_errno(errno)) };
     }
 
     MANAGED_CHILD_PID.store(pid, Ordering::SeqCst);
     loop {
         let mut status = 0;
+        // SAFETY: waitpid writes only through the valid &mut status int; pid is the live child from fork().
         let waited = unsafe { libc::waitpid(pid, &mut status, 0) };
         if waited < 0 {
             let errno = std::io::Error::last_os_error()

--- a/runtime/container/rust/src/bin/workcell-launcher.rs
+++ b/runtime/container/rust/src/bin/workcell-launcher.rs
@@ -104,10 +104,12 @@ fn build_exec_args(
 
 #[cfg(target_os = "linux")]
 fn current_execfn() -> Option<OsString> {
+    // SAFETY: getauxval(AT_EXECFN) has no preconditions; returns 0 when absent (checked below).
     let value = unsafe { libc::getauxval(libc::AT_EXECFN) };
     if value == 0 {
         return None;
     }
+    // SAFETY: value is non-zero (checked), a kernel-provided NUL-terminated C string valid for the process lifetime.
     let c_value = unsafe { std::ffi::CStr::from_ptr(value as *const libc::c_char) };
     Some(OsStr::from_bytes(c_value.to_bytes()).to_owned())
 }
@@ -468,6 +470,7 @@ mod tests {
         launcher_common::set_env_var("WORKCELL_COPILOT_AUTH_REQUIRED", "maybe");
         assert_eq!(copilot_auth_required_for_pid1("workcell-entrypoint"), None);
 
+        // SAFETY: test-only env cleanup; the test does not run concurrently with other environment access.
         unsafe { env::remove_var("WORKCELL_COPILOT_AUTH_REQUIRED") };
     }
 

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -19,6 +19,7 @@ use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::sync::OnceLock;
 
+// SAFETY: matches libc's process-global char **environ; reads assume no concurrent setenv/putenv mutation.
 unsafe extern "C" {
     static mut environ: *mut *mut c_char;
 }
@@ -252,12 +253,14 @@ fn path_is_current_process_fd_path(path: &str) -> Option<c_int> {
         ["proc", "self", "fd", fd] => fd.parse::<c_int>().ok(),
         ["proc", "thread-self", "fd", fd] => fd.parse::<c_int>().ok(),
         ["proc", pid, "fd", fd]
+            // SAFETY: getpid() is a niladic syscall with no preconditions and no invalid return.
             if parse_nonnegative_long(pid) == Some(unsafe { libc::getpid() as i64 }) =>
         {
             fd.parse::<c_int>().ok()
         }
         ["proc", "self", "task", _tid, "fd", fd] => fd.parse::<c_int>().ok(),
         ["proc", pid, "task", _tid, "fd", fd]
+            // SAFETY: getpid() is a niladic syscall with no preconditions and no invalid return.
             if parse_nonnegative_long(pid) == Some(unsafe { libc::getpid() as i64 }) =>
         {
             fd.parse::<c_int>().ok()
@@ -298,10 +301,12 @@ fn collect_cstring_array(ptr: *const *const c_char) -> Vec<String> {
 
     let mut index = 0usize;
     loop {
+        // SAFETY: ptr is a non-null, NUL-sentinel-terminated char** (exec ABI / libc environ); index walks up to the sentinel checked below.
         let current = unsafe { *ptr.add(index) };
         if current.is_null() {
             break;
         }
+        // SAFETY: current is a valid NUL-terminated C string element of the exec argv/envp/environ array.
         let entry = unsafe { CStr::from_ptr(current) }
             .to_string_lossy()
             .into_owned();
@@ -313,6 +318,7 @@ fn collect_cstring_array(ptr: *const *const c_char) -> Vec<String> {
 
 fn effective_env_ptr(envp: *const *const c_char) -> *const *const c_char {
     if envp.is_null() {
+        // SAFETY: environ is libc-initialized; read in the calling thread with no concurrent setenv/putenv.
         unsafe { environ.cast() }
     } else {
         envp
@@ -338,6 +344,7 @@ fn resolve_command_via_path_value(command: &str, path_value: Option<&str>) -> Op
             continue;
         };
 
+        // SAFETY: cstring is a live NUL-terminated CString valid for the call; access only reads the path.
         let executable = unsafe { libc::access(cstring.as_ptr(), libc::X_OK) == 0 };
         if !executable {
             continue;
@@ -653,6 +660,7 @@ fn approved_wrapper_requires_native_launcher_parent(wrapper: ApprovedWrapper) ->
 }
 
 fn current_process_parent_is_approved_native_launcher() -> bool {
+    // SAFETY: getppid() is a niladic syscall with no preconditions.
     let parent_pid = unsafe { libc::getppid() };
     if parent_pid < 1 {
         return false;
@@ -1429,6 +1437,7 @@ fn env_has_unsafe_git_override(env_entries: &[String]) -> bool {
 }
 
 fn report(message: &str) {
+    // SAFETY: message is a live &str valid for len bytes (write is read-only); errno_location() returns libc's valid errno slot.
     unsafe {
         libc::write(
             libc::STDERR_FILENO,
@@ -1441,11 +1450,13 @@ fn report(message: &str) {
 
 #[cfg(target_os = "linux")]
 unsafe fn errno_location() -> *mut c_int {
+    // SAFETY: __errno_location() takes no arguments and always returns a valid per-thread errno pointer.
     unsafe { libc::__errno_location() }
 }
 
 #[cfg(target_os = "macos")]
 unsafe fn errno_location() -> *mut c_int {
+    // SAFETY: __error() takes no arguments and always returns a valid per-thread errno pointer.
     unsafe { libc::__error() }
 }
 
@@ -1472,44 +1483,55 @@ fn report_workcell_launcher_loader_env_block() {
 }
 
 unsafe fn load_symbol<T: Copy>(name: &CStr) -> T {
+    // SAFETY: name is a valid NUL-terminated c-string literal; dlsym reads it and returns the RTLD_NEXT symbol address or null.
     let symbol = unsafe { libc::dlsym(libc::RTLD_NEXT, name.as_ptr().cast()) };
     assert!(!symbol.is_null(), "missing required symbol {:?}", name);
+    // SAFETY: symbol is non-null (asserted) and pointer-sized; T is a same-width extern "C" fn pointer, so reinterpreting the address is valid on POSIX.
     unsafe { mem::transmute_copy(&symbol) }
 }
 
 fn execve_fn() -> ExecveFn {
+    // SAFETY: c"execve" is a valid C-string literal and matches the ExecveFn ABI resolved into this OnceLock.
     *EXECVE_FN.get_or_init(|| unsafe { load_symbol(c"execve") })
 }
 
 fn execv_fn() -> ExecvFn {
+    // SAFETY: c"execv" is a valid C-string literal and matches the ExecvFn ABI resolved into this OnceLock.
     *EXECV_FN.get_or_init(|| unsafe { load_symbol(c"execv") })
 }
 
 fn execvp_fn() -> ExecvpFn {
+    // SAFETY: c"execvp" is a valid C-string literal and matches the ExecvpFn ABI resolved into this OnceLock.
     *EXECVP_FN.get_or_init(|| unsafe { load_symbol(c"execvp") })
 }
 
 fn execvpe_fn() -> ExecvpeFn {
+    // SAFETY: c"execvpe" is a valid C-string literal and matches the ExecvpeFn ABI resolved into this OnceLock.
     *EXECVPE_FN.get_or_init(|| unsafe { load_symbol(c"execvpe") })
 }
 
 fn execveat_fn() -> ExecveatFn {
+    // SAFETY: c"execveat" is a valid C-string literal and matches the ExecveatFn ABI resolved into this OnceLock.
     *EXECVEAT_FN.get_or_init(|| unsafe { load_symbol(c"execveat") })
 }
 
 fn fexecve_fn() -> FexecveFn {
+    // SAFETY: c"fexecve" is a valid C-string literal and matches the FexecveFn ABI resolved into this OnceLock.
     *FEXECVE_FN.get_or_init(|| unsafe { load_symbol(c"fexecve") })
 }
 
 fn posix_spawn_fn() -> PosixSpawnFn {
+    // SAFETY: c"posix_spawn" is a valid C-string literal and matches the PosixSpawnFn ABI resolved into this OnceLock.
     *POSIX_SPAWN_FN.get_or_init(|| unsafe { load_symbol(c"posix_spawn") })
 }
 
 fn posix_spawnp_fn() -> PosixSpawnpFn {
+    // SAFETY: c"posix_spawnp" is a valid C-string literal and matches the PosixSpawnpFn ABI resolved into this OnceLock.
     *POSIX_SPAWNP_FN.get_or_init(|| unsafe { load_symbol(c"posix_spawnp") })
 }
 
 fn real_syscall_fn() -> SyscallFn {
+    // SAFETY: c"syscall" is a valid C-string literal and matches the SyscallFn ABI resolved into this OnceLock.
     *REAL_SYSCALL_FN.get_or_init(|| unsafe { load_symbol(c"syscall") })
 }
 
@@ -1517,6 +1539,7 @@ fn c_path_string(path: *const c_char) -> String {
     if path.is_null() {
         String::new()
     } else {
+        // SAFETY: path is non-null (checked above) and a NUL-terminated C string from the exec ABI.
         unsafe { CStr::from_ptr(path) }
             .to_string_lossy()
             .into_owned()
@@ -1547,9 +1570,11 @@ fn is_git_execveat_target(dirfd: c_int, pathname: &str, flags: c_int) -> bool {
         return false;
     };
     let mut stat_buf = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: c_path is a live NUL-terminated CString; stat_buf.as_mut_ptr() is a valid writable stat buffer for fstatat.
     if unsafe { libc::fstatat(dirfd, c_path.as_ptr(), stat_buf.as_mut_ptr(), 0) } != 0 {
         return false;
     }
+    // SAFETY: fstatat returned 0, so the kernel fully initialized stat_buf.
     let stat_buf = unsafe { stat_buf.assume_init() };
 
     let Some(signature) = stat_signature_from_stat(&stat_buf) else {
@@ -1572,6 +1597,7 @@ pub unsafe extern "C" fn workcell_syscall_shim(
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     {
         if number == SYS_EXECVE {
+            // SAFETY: number==SYS_execve, so arg1..arg3 are the (path, argv, envp) pointers of the execve ABI.
             return unsafe {
                 execve(
                     arg1 as *const c_char,
@@ -1581,6 +1607,7 @@ pub unsafe extern "C" fn workcell_syscall_shim(
             };
         }
         if number == SYS_EXECVEAT {
+            // SAFETY: number==SYS_execveat, so arg1..arg5 are (dirfd, pathname, argv, envp, flags) per the execveat ABI.
             return unsafe {
                 execveat(
                     arg1 as c_int,
@@ -1593,6 +1620,7 @@ pub unsafe extern "C" fn workcell_syscall_shim(
         }
     }
 
+    // SAFETY: forwards the original syscall number and its 6 register args unchanged to the real libc syscall().
     unsafe { real_syscall_fn()(number, arg1, arg2, arg3, arg4, arg5, arg6) }
 }
 
@@ -1627,6 +1655,7 @@ pub unsafe extern "C" fn execve(
         return -1;
     }
 
+    // SAFETY: forwards the caller's original, unmodified execve arguments to the real libc execve resolved via RTLD_NEXT.
     unsafe { execve_fn()(path, argv, envp) }
 }
 
@@ -1634,6 +1663,7 @@ pub unsafe extern "C" fn execve(
 pub unsafe extern "C" fn execv(path: *const c_char, argv: *const *const c_char) -> c_int {
     let path_string = c_path_string(path);
     let args = collect_cstring_array(argv);
+    // SAFETY: environ is libc-initialized; read in the calling thread with no concurrent setenv/putenv.
     let env_entries = collect_cstring_array(unsafe { environ.cast() });
 
     if should_block_workcell_launcher_loader_env(&path_string, &env_entries) {
@@ -1657,6 +1687,7 @@ pub unsafe extern "C" fn execv(path: *const c_char, argv: *const *const c_char) 
         return -1;
     }
 
+    // SAFETY: forwards the caller's original, unmodified execv arguments to the real libc execv resolved via RTLD_NEXT.
     unsafe { execv_fn()(path, argv) }
 }
 
@@ -1664,6 +1695,7 @@ pub unsafe extern "C" fn execv(path: *const c_char, argv: *const *const c_char) 
 pub unsafe extern "C" fn execvp(file: *const c_char, argv: *const *const c_char) -> c_int {
     let file_string = c_path_string(file);
     let args = collect_cstring_array(argv);
+    // SAFETY: environ is libc-initialized; read in the calling thread with no concurrent setenv/putenv.
     let env_entries = collect_cstring_array(unsafe { environ.cast() });
     let effective_path = resolve_exec_search_target(&file_string, &env_entries);
 
@@ -1688,6 +1720,7 @@ pub unsafe extern "C" fn execvp(file: *const c_char, argv: *const *const c_char)
         return -1;
     }
 
+    // SAFETY: forwards the caller's original, unmodified execvp arguments to the real libc execvp resolved via RTLD_NEXT.
     unsafe { execvp_fn()(file, argv) }
 }
 
@@ -1723,6 +1756,7 @@ pub unsafe extern "C" fn execvpe(
         return -1;
     }
 
+    // SAFETY: forwards the caller's original, unmodified execvpe arguments to the real libc execvpe resolved via RTLD_NEXT.
     unsafe { execvpe_fn()(file, argv, envp) }
 }
 
@@ -1769,6 +1803,7 @@ pub unsafe extern "C" fn execveat(
         let mut native_launcher_target = false;
 
         if let Ok(c_path) = CString::new(pathname_string.as_bytes()) {
+            // SAFETY: c_path is a live NUL-terminated CString; assume_init runs only on fstatat==0; candidate_fd (O_CLOEXEC) is owned, checked >=0, and closed exactly once after use.
             unsafe {
                 let mut stat_buf = MaybeUninit::<libc::stat>::uninit();
                 if libc::fstatat(dirfd, c_path.as_ptr(), stat_buf.as_mut_ptr(), 0) == 0
@@ -1850,6 +1885,7 @@ pub unsafe extern "C" fn execveat(
         return -1;
     }
 
+    // SAFETY: forwards the caller's original, unmodified execveat arguments to the real libc execveat resolved via RTLD_NEXT.
     unsafe { execveat_fn()(dirfd, pathname, argv, envp, flags) }
 }
 
@@ -1893,6 +1929,7 @@ pub unsafe extern "C" fn fexecve(
         return -1;
     }
 
+    // SAFETY: forwards the caller's original, unmodified fexecve arguments to the real libc fexecve resolved via RTLD_NEXT.
     unsafe { fexecve_fn()(fd, argv, envp) }
 }
 
@@ -1930,6 +1967,7 @@ pub unsafe extern "C" fn posix_spawn(
         return libc::EPERM;
     }
 
+    // SAFETY: forwards the caller's original, unmodified posix_spawn arguments to the real libc posix_spawn resolved via RTLD_NEXT.
     unsafe { posix_spawn_fn()(pid, path, file_actions, attrp, argv, envp) }
 }
 
@@ -1968,6 +2006,7 @@ pub unsafe extern "C" fn posix_spawnp(
         return libc::EPERM;
     }
 
+    // SAFETY: forwards the caller's original, unmodified posix_spawnp arguments to the real libc posix_spawnp resolved via RTLD_NEXT.
     unsafe { posix_spawnp_fn()(pid, file, file_actions, attrp, argv, envp) }
 }
 
@@ -2110,6 +2149,7 @@ mod tests {
         );
         assert_eq!(path_is_current_process_fd_path("/proc/self/fd/9"), Some(9));
         assert_eq!(
+            // SAFETY: getpid() has no preconditions (test-only).
             path_is_current_process_fd_path(&format!("/proc/{}/fd/4", unsafe { libc::getpid() })),
             Some(4)
         );

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -386,6 +386,16 @@ fi
   cargo test --locked --offline
 )
 
+# A4: clippy::undocumented_unsafe_blocks enforces `// SAFETY:` on `unsafe {}`
+# blocks but NOT on `unsafe extern "C" {` blocks. Guard those explicitly so a new
+# undocumented FFI declaration also fails CI.
+while IFS=: read -r extern_file extern_line _; do
+  if ! sed -n "$((extern_line - 1))p" "${extern_file}" | grep -q '// SAFETY:'; then
+    echo "unsafe extern block missing a preceding // SAFETY: comment at ${extern_file}:${extern_line}" >&2
+    exit 1
+  fi
+done < <(grep -rnE 'unsafe extern "C" \{' "${ROOT_DIR}/runtime/container/rust/src")
+
 if [[ "${VALIDATION_PROFILE}" == "release-preflight" ]]; then
   "${ROOT_DIR}/scripts/verify-mutation-score.sh"
   "${ROOT_DIR}/scripts/verify-coverage.sh"

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -387,14 +387,18 @@ fi
 )
 
 # A4: clippy::undocumented_unsafe_blocks enforces `// SAFETY:` on `unsafe {}`
-# blocks but NOT on `unsafe extern "C" {` blocks. Guard those explicitly so a new
-# undocumented FFI declaration also fails CI.
+# blocks but NOT on `unsafe extern` blocks. Guard those explicitly so a new
+# undocumented FFI declaration also fails CI. The pattern matches any ABI form of
+# the block opener (`unsafe extern {`, `unsafe extern "C" {`,
+# `unsafe extern "system" {`, ...) while excluding `unsafe extern "…" fn`
+# declarations and type aliases, which end in `fn`/`(` rather than `{`.
+# rustfmt (enforced above) keeps each block opener on a single line.
 while IFS=: read -r extern_file extern_line _; do
   if ! sed -n "$((extern_line - 1))p" "${extern_file}" | grep -q '// SAFETY:'; then
     echo "unsafe extern block missing a preceding // SAFETY: comment at ${extern_file}:${extern_line}" >&2
     exit 1
   fi
-done < <(grep -rnE 'unsafe extern "C" \{' "${ROOT_DIR}/runtime/container/rust/src")
+done < <(grep -rnE 'unsafe extern( +"[^"]*")? *\{' "${ROOT_DIR}/runtime/container/rust/src")
 
 if [[ "${VALIDATION_PROFILE}" == "release-preflight" ]]; then
   "${ROOT_DIR}/scripts/verify-mutation-score.sh"


### PR DESCRIPTION
# Summary

Implements ROADMAP item **A4 (Unsafe-Code Safety Documentation)** per
[`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md):

- **`// SAFETY:` on every `unsafe {}` block** in the Rust exec/syscall
  interception shim (`runtime/container/rust/src/lib.rs`) and the launcher
  binaries — 54 comments, each stating the invariant that makes the block sound
  (niladic syscalls, C-string ABI reads, `static mut environ`, `dlsym`+transmute,
  the `global_asm!` syscall trampoline, LD_PRELOAD interposer forwards, single-
  threaded env mutation, async-signal-safe signal handling).
- **Enforcement:** `undocumented_unsafe_blocks = "deny"` in
  `runtime/container/rust/Cargo.toml`, checked by the existing
  `cargo clippy … -D warnings` in `scripts/validate-repo.sh`. A new undocumented
  `unsafe` block now fails CI.
- **Pre-audit checklist:** `docs/unsafe-code-audit-checklist.md` inventories the
  unsafe surface by invariant class, calls out the 4 high-scrutiny items, and
  gives a reviewer checklist; linked from the threat model.

The code changes are **comment- and config-only** — no logic touched.

## Support-claim impact

None. Documents and enforces existing behavior; adds a CI lint gate.

## Validation

- `cargo clippy --all-targets --locked --offline -- -D warnings` → 0
  `undocumented_unsafe_blocks`, 0 other warnings (locally on macOS **and** in the
  validator's **linux** build, which compiles the `#[cfg(target_os="linux")]`
  blocks macOS cannot)
- `cargo build` + `cargo test` (29 tests) green — no behavioral change
- the 4 subtle invariants (asm trampoline, `transmute_copy`, `static mut environ`,
  env-mutation threading) were adversarially reviewed against the code
  (confirmed: no `thread::spawn` in the launchers, `assume_init` only on
  `fstatat==0`)
- doc-links / markdownlint / codespell green
- `./scripts/pre-merge.sh --profile pr-parity` passed
