### PR TITLE
Stability contracts: unify the exit-code contract and document it (D8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ See [docs/provenance.md](docs/provenance.md) and
 | Roadmap | [ROADMAP.md](ROADMAP.md) |
 | Changelog | [CHANGELOG.md](CHANGELOG.md) |
 | Security reporting | [SECURITY.md](SECURITY.md) |
+| Stability and exit-code contract | [docs/stability-contract.md](docs/stability-contract.md) |
 
 ## Repository layout
 

--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -102,7 +102,9 @@ func subcommands() []subcommand {
 
 func main() {
 	if len(os.Args) < 2 {
-		die(rootUsageError(""))
+		// A missing top-level command is a usage error (exit 2), matching
+		// the wrong-arity path below and the other workcell Go CLIs (D8).
+		dieUsage(rootUsageError(""))
 	}
 	// scenario-manifest preserves the bash contract of distinct exit
 	// codes for usage (2) vs. runtime (1) errors that
@@ -132,7 +134,8 @@ func main() {
 		}
 		return
 	}
-	die(rootUsageError(os.Args[1]))
+	// An unknown top-level command is a usage error (exit 2).
+	dieUsage(rootUsageError(os.Args[1]))
 }
 
 func rootUsageError(badCommand string) error {

--- a/cmd/workcell-citools/main_test.go
+++ b/cmd/workcell-citools/main_test.go
@@ -32,6 +32,39 @@ func TestWrongArityExitsWithUsageCode(t *testing.T) {
 	}
 }
 
+func TestNoArgsExitsWithUsageCode(t *testing.T) {
+	assertCitoolsUsageExit(t)
+}
+
+func TestUnknownCommandExitsWithUsageCode(t *testing.T) {
+	assertCitoolsUsageExit(t, "definitely-not-a-subcommand")
+}
+
+// assertCitoolsUsageExit runs the binary (via the helper-process trick) with
+// the given argv tail and asserts a usage exit (code 2 + "usage:" on stderr).
+func assertCitoolsUsageExit(t *testing.T, argv ...string) {
+	t.Helper()
+	runArgs := append([]string{"-test.run=TestCitoolsHelperProcess", "--"}, argv...)
+	cmd := exec.Command(os.Args[0], runArgs...)
+	cmd.Env = append(os.Environ(), "WORKCELL_CITOOLS_HELPER_PROCESS=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("workcell-citools %v exited 0, want usage error", argv)
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("cmd.Run() error = %T %v, want ExitError", err, err)
+	}
+	if exitErr.ExitCode() != 2 {
+		t.Fatalf("exit code = %d, want 2; stderr=%q", exitErr.ExitCode(), stderr.String())
+	}
+	if s := stderr.String(); !strings.Contains(s, "usage:") && !strings.Contains(s, "unknown command") {
+		t.Fatalf("stderr = %q, want usage or unknown-command text", s)
+	}
+}
+
 func TestCitoolsHelperProcess(t *testing.T) {
 	if os.Getenv("WORKCELL_CITOOLS_HELPER_PROCESS") != "1" {
 		return

--- a/cmd/workcell-colimautil/main.go
+++ b/cmd/workcell-colimautil/main.go
@@ -4,14 +4,26 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/colimautil"
 )
 
 func main() {
 	if err := run(os.Args[1:]); err != nil {
+		// Honor the canonical cliexit.ExitCodeError so usage errors exit
+		// 2 (matching workcell-citools/-hostutil/-runtimeutil) instead of
+		// collapsing every failure to 1.
+		var ec *cliexit.ExitCodeError
+		if errors.As(err, &ec) {
+			if msg := ec.Error(); msg != "" {
+				fmt.Fprintln(os.Stderr, msg)
+			}
+			os.Exit(ec.Code)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -39,5 +51,5 @@ func run(args []string) error {
 }
 
 func usage() error {
-	return fmt.Errorf("usage: workcell-colimautil <validate-runtime-mounts|validate-profile-config> [args...]")
+	return &cliexit.ExitCodeError{Code: 2, Message: "usage: workcell-colimautil <validate-runtime-mounts|validate-profile-config> [args...]"}
 }

--- a/cmd/workcell-colimautil/main_test.go
+++ b/cmd/workcell-colimautil/main_test.go
@@ -4,8 +4,13 @@
 package main
 
 import (
+	"bytes"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/cliexit"
 )
 
 func TestRunRejectsMissingSubcommand(t *testing.T) {
@@ -13,6 +18,43 @@ func TestRunRejectsMissingSubcommand(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "usage:") {
 		t.Fatalf("run(nil) = %v, want usage error", err)
 	}
+	if ec, ok := cliexit.IsExitCodeError(err); !ok || ec.Code != 2 {
+		t.Fatalf("run(nil) exit code = %v (ok=%v), want ExitCodeError{Code:2}", err, ok)
+	}
+}
+
+// TestUsageExitsWithCode2 pins the D8 exit-code contract at the process level:
+// a usage error exits 2, matching the other workcell Go CLIs.
+func TestUsageExitsWithCode2(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestColimautilHelperProcess", "--")
+	cmd.Env = append(os.Environ(), "WORKCELL_COLIMAUTIL_HELPER_PROCESS=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("cmd.Run() error = %T %v, want ExitError", err, err)
+	}
+	if exitErr.ExitCode() != 2 {
+		t.Fatalf("exit code = %d, want 2; stderr=%q", exitErr.ExitCode(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Fatalf("stderr = %q, want usage text", stderr.String())
+	}
+}
+
+func TestColimautilHelperProcess(t *testing.T) {
+	if os.Getenv("WORKCELL_COLIMAUTIL_HELPER_PROCESS") != "1" {
+		return
+	}
+	for i, arg := range os.Args {
+		if arg == "--" {
+			os.Args = append([]string{"workcell-colimautil"}, os.Args[i+1:]...)
+			main()
+			os.Exit(0)
+		}
+	}
+	os.Exit(2)
 }
 
 func TestRunRejectsUnknownSubcommand(t *testing.T) {

--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -986,16 +986,21 @@ func parsePrepareBundleArgs(args []string) (*injection.PrepareBundleOptions, err
 	return opts, nil
 }
 
+// The top-level and per-group usage helpers return an ExitCodeError with
+// Code 2 so usage/precondition failures exit 2 across every workcell Go CLI
+// (workcell-citools, -runtimeutil, and the delegated -hostutil subcommands
+// already do); previously these returned plain errors and collapsed to the
+// exit-1 fallback, an intra-binary inconsistency (D8).
 func usage() error {
-	return fmt.Errorf("usage: workcell-hostutil <path|release|helper|launcher|policy|resolve-credentials|pty-transcript|auth-cli|auth-usage|policy-cli|policy-usage|publish-pr-cli|publish-pr-usage|session-usage|session-attach-cli|session-delete-cli|session-dispatch-cli|session-logs-cli|session-monitor-cli|session-send-cli|session-stop-cli|session-timeline-cli> [args...]")
+	return &cliexit.ExitCodeError{Code: 2, Message: "usage: workcell-hostutil <path|release|helper|launcher|policy|resolve-credentials|pty-transcript|auth-cli|auth-usage|policy-cli|policy-usage|publish-pr-cli|publish-pr-usage|session-usage|session-attach-cli|session-delete-cli|session-dispatch-cli|session-logs-cli|session-monitor-cli|session-send-cli|session-stop-cli|session-timeline-cli> [args...]"}
 }
 
 func pathUsage() error {
-	return fmt.Errorf("usage: workcell-hostutil path <home|resolve> [--base DIR] [PATH]")
+	return &cliexit.ExitCodeError{Code: 2, Message: "usage: workcell-hostutil path <home|resolve> [--base DIR] [PATH]"}
 }
 
 func releaseUsage() error {
-	return fmt.Errorf("usage: workcell-hostutil release <create-payload|metadata|encode-name|bundle-manifest> [args...]")
+	return &cliexit.ExitCodeError{Code: 2, Message: "usage: workcell-hostutil release <create-payload|metadata|encode-name|bundle-manifest> [args...]"}
 }
 
 func helperUsage() error {
@@ -1004,7 +1009,7 @@ func helperUsage() error {
 	for _, sub := range subs {
 		names = append(names, sub.name)
 	}
-	return fmt.Errorf("usage: workcell-hostutil helper <%s> [args...]", strings.Join(names, "|"))
+	return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("usage: workcell-hostutil helper <%s> [args...]", strings.Join(names, "|"))}
 }
 
 func parseSessionRoots(args []string) ([]string, []string, error) {

--- a/cmd/workcell-hostutil/main_test.go
+++ b/cmd/workcell-hostutil/main_test.go
@@ -10,9 +10,33 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/host/hoststate"
 	"github.com/omkhar/workcell/internal/host/sessions"
 )
+
+// TestUsageReturnsExitCode2 pins the D8 exit-code contract: top-level usage
+// errors (missing/unknown command, and the per-group path/release/helper
+// usage) carry ExitCodeError{Code:2} so main() exits 2, matching the other
+// workcell Go CLIs. Previously these returned plain errors and exited 1.
+func TestUsageReturnsExitCode2(t *testing.T) {
+	for _, args := range [][]string{
+		nil,
+		{"definitely-not-a-subcommand"},
+		{"path"},
+		{"release"},
+		{"helper"},
+	} {
+		err := run(args)
+		ec, ok := cliexit.IsExitCodeError(err)
+		if !ok || ec.Code != 2 {
+			t.Fatalf("run(%v) = %v (ok=%v), want ExitCodeError{Code:2}", args, err, ok)
+		}
+		if !strings.Contains(ec.Error(), "usage:") {
+			t.Fatalf("run(%v) message = %q, want usage text", args, ec.Error())
+		}
+	}
+}
 
 func TestRunHelperSessionTimeline(t *testing.T) {
 	colimaRoot := t.TempDir()

--- a/cmd/workcell-runtimeutil/main_test.go
+++ b/cmd/workcell-runtimeutil/main_test.go
@@ -5,9 +5,26 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 )
+
+// TestUsageReturnsCode2 pins the D8 exit-code contract: a missing or unknown
+// top-level command is a usage error and returns 2, matching the other
+// workcell Go CLIs.
+func TestUsageReturnsCode2(t *testing.T) {
+	t.Parallel()
+	for _, args := range [][]string{nil, {"definitely-not-a-subcommand"}} {
+		var stderr bytes.Buffer
+		if code := run(args, io.Discard, &stderr); code != 2 {
+			t.Fatalf("run(%v) = %d, want 2; stderr=%q", args, code, stderr.String())
+		}
+		if s := stderr.String(); !strings.Contains(s, "usage:") && !strings.Contains(s, "unknown command") {
+			t.Fatalf("run(%v) stderr = %q, want usage or unknown-command text", args, s)
+		}
+	}
+}
 
 // These tests cover the render-injection-bundle subcommand absorbed
 // from the former workcell-render-injection-bundle binary.  They

--- a/docs/stability-contract.md
+++ b/docs/stability-contract.md
@@ -1,0 +1,96 @@
+# Stability Contract
+
+This document records which parts of Workcell's surface are stable ahead of
+1.0, and the exit-code contract shared across the Rust launcher, the Go
+binaries, and the shell entrypoint. It is the pre-1.0 compatibility reference;
+G1 extends it into the versioned 1.0 contract.
+
+"Stable" means the shape is not expected to change without a deprecation note.
+"Experimental" means it may change or be removed. Absence from this document is
+not a stability promise.
+
+## Exit-code contract
+
+The canonical convention across every entrypoint:
+
+| Code | Meaning |
+|------|---------|
+| 0 | success |
+| 2 | usage / precondition error (missing or unknown command, wrong arity, bad option, unmet precondition) |
+| 1 | runtime error (an operation attempted and failed) |
+| 3 | colima profile status: no matching profile (`workcell-hostutil colima-status`) |
+| 124 | colima operation timed out (mirrors GNU `timeout`) |
+| 126 | launcher: fail-closed policy block, or target not executable (`EACCES`) |
+| 127 | launcher: target not found (`ENOENT`) |
+| 128+N | launcher: supervised child terminated by signal N |
+| 0–255 | launcher: passthrough of the supervised child's own exit status |
+
+Per surface:
+
+- **Go binaries** (`workcell-citools`, `workcell-hostutil`, `workcell-colimautil`,
+  `workcell-runtimeutil`): usage/precondition errors exit **2**, runtime errors
+  exit **1**. The exit code is carried through the error chain by
+  `internal/cliexit.ExitCodeError{Code}`. Deterministic exit-code tests live in
+  each binary's `main_test.go`.
+- **Shell entrypoint** (`scripts/workcell`): usage/precondition failures exit
+  **2** (the dominant convention); a small set of host-precondition failures
+  exit **1** (see the recorded exception below). Runs under `set -euo pipefail`.
+- **Rust launcher** (`workcell-launcher`): fail-closed authorization refusals and
+  non-executable targets exit **126**; missing targets exit **127**; a supervised
+  child's exit status or signal (`128+N`) is passed through unchanged.
+
+### Recorded intentional exceptions
+
+These are deliberate and are documented rather than "fixed", because changing
+them would break existing shell↔Go parity or the launcher's fail-closed
+posture:
+
+- **Launcher 126 is overloaded** — it covers both a fail-closed policy block and
+  an exec `EACCES` (not executable). Both match the shell convention that 126
+  means "command found but not runnable". A caller distinguishes them by the
+  launcher's stderr diagnostic, not the code.
+- **Shell 1-vs-2 split for host preconditions** — "missing trusted host tool"
+  exits **1** while "missing host working directory" exits **2**. This split is
+  frozen for byte-for-byte parity with the Go translations
+  (`internal/publishpr/host_exec.go`) and is guarded by `internal/testkit`'s
+  bash↔Go parity harness.
+
+## CLI stability
+
+The user-facing CLI is `scripts/workcell`. Stable surface:
+
+- Core flags: `--agent`, `--target`, `--mode`, `--workspace`, `--agent-autonomy`,
+  `--dry-run`, `--prepare` / `--prepare-only`, and the introspection flags
+  `--doctor` / `--inspect` / `--logs` / `--auth-status` / `--gc`.
+- Subcommands: `publish-pr`; `session <start|attach|send|stop|list|show|delete|logs|timeline|diff|export>`;
+  `auth <init|set|unset|status>`; `policy <show|validate|diff>`; `why`.
+
+Experimental or explicitly gated (may change; already marked in `--help`):
+
+- `--agent antigravity` (recognized as planned but unsupported).
+- `--ui gui` (not implemented; fails closed).
+- preview targets `aws-ec2-ssm` and `gcp-vm`.
+- `--mode breakglass` (gated behind a dated `--ack-breakglass`),
+  `--allow-arbitrary-command` (behind `--ack-arbitrary-command`), and
+  `--allow-control-plane-vcs` (behind `--ack-control-plane-vcs`).
+
+## Stable machine-readable output
+
+These lines are consumed by tests, CI, or other tooling and are treated as
+contract-like `key=value` / structured output:
+
+- session `show` metadata: `target_kind=`, `target_provider=`, `workspace=`,
+  `assurance=`, and peers.
+- support matrix: `host_os=`, `host_arch=`, `support_matrix_status=`.
+- `publish_pr_url=` (from `publish-pr`).
+- `mutation score: NN.NN% (k/t killed)` and `surviving mutants: …`.
+- audit digest lines: `record_digest=`, `prev_digest=`.
+- `scenario-manifest` TSV rows (tab-delimited).
+
+## Internal Go APIs
+
+All Go code lives under `internal/`, so it is not importable outside the module;
+"stable" here means a stable intra-module contract. The most depended-upon is
+`internal/cliexit` (the exit-code carrier used by every CLI). Treat other
+`internal/` package APIs as implementation detail that may change with their
+callers.

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -762,8 +762,33 @@ or
 .B gemini
 for the corresponding provider.
 .SH EXIT STATUS
-The command exits non-zero on validation failures, unsupported modes, missing
-dependencies, or runtime launch errors.
+.TP
+.B 0
+Success.
+.TP
+.B 2
+Usage or precondition error: missing or unknown command, wrong arity, bad
+option, or an unmet precondition.
+.TP
+.B 1
+Runtime error: an operation was attempted and failed.
+.TP
+.B 124
+A colima operation timed out.
+.TP
+.B 126
+The launcher refused a fail-closed policy block, or the target is not
+executable.
+.TP
+.B 127
+The launcher could not find the target.
+.TP
+.B 128+N
+A supervised child was terminated by signal N.
+.PP
+Other codes are passed through unchanged from a supervised child. The full
+cross-surface exit-code convention is documented in
+.I docs/stability-contract.md .
 .SH SEE ALSO
 .BR colima (1),
 .BR docker (1)


### PR DESCRIPTION
# Summary

Implements ROADMAP item **D8 (Stability Contracts)** per
[`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md):

- **Unified the usage exit code to 2** across all four Go CLIs. `workcell-colimautil`
  and `workcell-hostutil` top-level usage errors, and `workcell-citools` no-args /
  unknown-command, previously exited **1** while wrong-arity and the other binaries
  exited **2**. All now route through `cliexit.ExitCodeError{Code: 2}`.
- **Deterministic exit-code tests** added to all four binaries' `main_test.go`
  (process-level for colimautil/citools, `run()`-level for hostutil/runtimeutil).
- **`docs/stability-contract.md`** documents the cross-surface exit-code convention
  (Rust launcher / Go binaries / shell), the stable-vs-experimental CLI flags and
  subcommands, and the stable machine-readable output lines. It **records** the two
  intentional exceptions rather than "fixing" them: the launcher's overloaded 126
  (fail-closed policy block / not-executable) and the shell 1-vs-2 host-precondition
  split (frozen for bash↔Go parity).
- **`man/workcell.1` EXIT STATUS** enriched with the actual codes; linked from README.

## Support-claim impact

None. Normalizes an exit code and documents the existing contract; no new surface.

## Validation

- exit codes verified behaviorally from the built binaries (all usage paths → 2)
- `go test ./...` green; no caller or test depends on the old exit-1 usage behavior
  (grep-verified: no `$? -eq 1` callers, no parity-harness coverage of umbrella usage)
- doc-links / markdownlint / codespell green
- `./scripts/pre-merge.sh --profile pr-parity` passed
