### PR TITLE
Add a standards watchlist (F3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ See [docs/provenance.md](docs/provenance.md) and
 | Changelog | [CHANGELOG.md](CHANGELOG.md) |
 | Security reporting | [SECURITY.md](SECURITY.md) |
 | Stability and exit-code contract | [docs/stability-contract.md](docs/stability-contract.md) |
+| Standards watchlist | [docs/standards-watchlist.md](docs/standards-watchlist.md) |
 
 ## Repository layout
 

--- a/docs/standards-watchlist.md
+++ b/docs/standards-watchlist.md
@@ -1,0 +1,31 @@
+# Standards Watchlist
+
+Workcell tracks a small set of external standards that shape how coding agents
+are configured, secured, and identified. This is a living reference: it records
+each standard's current status and what to watch, so the project's controls and
+docs stay aligned as the standards move.
+
+- **Owner:** the maintainer (see [MAINTAINERS.md](../MAINTAINERS.md)).
+- **Review cadence:** quarterly, or sooner when a tracked standard publishes a
+  new version.
+- **Last reviewed:** 2026-07-04.
+- **Next review due:** 2026-10-04.
+
+## Watchlist
+
+| Standard | Body | Status at last review | Canonical source | Why it matters to Workcell | What to watch |
+|---|---|---|---|---|---|
+| Model Context Protocol (MCP) | Agentic AI Foundation (Linux Foundation); originated at Anthropic | Date-revisioned spec (e.g. `2025-11-25`); donated to the Linux Foundation's Agentic AI Foundation in December 2025 | <https://modelcontextprotocol.io/specification> | Workcell injects MCP server/config surfaces for providers; auth and transport changes affect what the runtime must contain and validate | new spec revisions; OAuth/OIDC auth alignment; transport changes; the SEP (Specification Enhancement Proposal) process and any working-group split |
+| OWASP Top 10 for Agentic Applications | OWASP GenAI Security Initiative | 2026 edition (ASI01–ASI10), released December 2025 | <https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/> | Workcell's control coverage is mapped against it in [owasp-agentic-mapping.md](owasp-agentic-mapping.md); a new edition would change that mapping | the next edition and its cadence; changes to ASI03 (agent identity); divergence from the separate LLM Top 10 |
+| Agent identity and authentication | IETF (individual drafts; no adopted working group yet) | Multiple active individual drafts building on OAuth 2.0, SPIFFE, and WIMSE rather than a new protocol; no formal IETF working group as of this review | <https://datatracker.ietf.org/> | Bears on how Workcell would attest and authenticate an agent's actions beyond human OAuth; informs ASI03 posture | formation of an IETF working group; convergence of the competing drafts; adoption of OAuth extensions or WIMSE for agent-to-service auth |
+
+## Notes
+
+- The OWASP entry is the authoritative input to Workcell's agentic-security
+  control mapping; keep it and [owasp-agentic-mapping.md](owasp-agentic-mapping.md)
+  in step when the edition changes.
+- The agent-identity line is deliberately conservative: the space is still
+  pre-standardization (competing IETF drafts, no adopted working group), so
+  Workcell tracks it without committing to any one draft.
+- Version numbers and dates above reflect the last-reviewed date; confirm the
+  canonical sources at each review rather than trusting this snapshot.

--- a/docs/standards-watchlist.md
+++ b/docs/standards-watchlist.md
@@ -17,15 +17,16 @@ docs stay aligned as the standards move.
 |---|---|---|---|---|---|
 | Model Context Protocol (MCP) | Agentic AI Foundation (Linux Foundation); originated at Anthropic | Date-revisioned spec (e.g. `2025-11-25`); donated to the Linux Foundation's Agentic AI Foundation in December 2025 | <https://modelcontextprotocol.io/specification> | Workcell injects MCP server/config surfaces for providers; auth and transport changes affect what the runtime must contain and validate | new spec revisions; OAuth/OIDC auth alignment; transport changes; the SEP (Specification Enhancement Proposal) process and any working-group split |
 | OWASP Top 10 for Agentic Applications | OWASP GenAI Security Initiative | 2026 edition (ASI01–ASI10), released December 2025 | <https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/> | Workcell's control coverage is mapped against it in [owasp-agentic-mapping.md](owasp-agentic-mapping.md); a new edition would change that mapping | the next edition and its cadence; changes to ASI03 (agent identity); divergence from the separate LLM Top 10 |
-| Agent identity and authentication | IETF (individual drafts; no adopted working group yet) | Multiple active individual drafts building on OAuth 2.0, SPIFFE, and WIMSE rather than a new protocol; no formal IETF working group as of this review | <https://datatracker.ietf.org/> | Bears on how Workcell would attest and authenticate an agent's actions beyond human OAuth; informs ASI03 posture | formation of an IETF working group; convergence of the competing drafts; adoption of OAuth extensions or WIMSE for agent-to-service auth |
+| Agent identity and authentication | IETF WIMSE working group, plus individual drafts | Active work in the IETF **WIMSE** WG (Workload Identity in Multi-System Environments), which covers workload/agent identity and carries agent-specific drafts (e.g. WIMSE applicability to AI agents, cross-organizational delegation); complemented by individual drafts building on OAuth 2.0, SPIFFE, and WIMSE. A dedicated agent-identity protocol is still emerging. | <https://datatracker.ietf.org/wg/wimse/> | Bears on how Workcell would attest and authenticate an agent's actions beyond human OAuth; informs ASI03 posture | WIMSE WG documents (esp. the AI-agent applicability and delegation drafts) advancing toward RFC; adoption of OAuth extensions for agent-to-service auth |
 
 ## Notes
 
 - The OWASP entry is the authoritative input to Workcell's agentic-security
   control mapping; keep it and [owasp-agentic-mapping.md](owasp-agentic-mapping.md)
   in step when the edition changes.
-- The agent-identity line is deliberately conservative: the space is still
-  pre-standardization (competing IETF drafts, no adopted working group), so
-  Workcell tracks it without committing to any one draft.
+- The agent-identity line is deliberately conservative: the active venue is the
+  IETF WIMSE working group, but a dedicated agent-identity protocol is still
+  emerging (multiple drafts building on OAuth 2.0, SPIFFE, and WIMSE), so
+  Workcell tracks WIMSE without committing to any one draft.
 - Version numbers and dates above reflect the last-reviewed date; confirm the
   canonical sources at each review rather than trusting this snapshot.


### PR DESCRIPTION
# Summary

Implements ROADMAP item **F3 (Standards Watchlist)** per
[`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md):
a short reviewed [`docs/standards-watchlist.md`](docs/standards-watchlist.md)
tracking the standards that shape how Workcell configures, secures, and
identifies coding agents.

- Tracks three lines: the **MCP spec** (date-revisioned; now under the Linux
  Foundation Agentic AI Foundation), the **OWASP Top 10 for Agentic Applications**
  (2026), and **agent-identity IETF drafts** (still pre-standardization).
- Each entry has status, canonical source, why it matters to Workcell, and what
  to watch. The OWASP row cross-links
  [`owasp-agentic-mapping.md`](docs/owasp-agentic-mapping.md).
- Records an **owner** (the maintainer), a **quarterly review cadence**, and a
  **next-review date** (2026-10-04) — the exit gate.
- Entries are deliberately conservative snapshots (dated to the last review),
  with a note to reconfirm the sources each review rather than trusting the
  snapshot.

## Support-claim impact

None. Documentation only.

## Validation

- doc-links / markdownlint / codespell green; internal cross-links resolve
- `./scripts/pre-merge.sh --profile pr-parity` passed
