### PR TITLE
Add maintained architecture diagrams (E2)

### DIFF
--- a/docs/enterprise-evidence-baseline.md
+++ b/docs/enterprise-evidence-baseline.md
@@ -13,7 +13,7 @@ support claims.
 
 | Area | Current source |
 |---|---|
-| Architecture and data flow | [workcell-system-design.md](workcell-system-design.md), [invariants.md](invariants.md), [adapter-control-planes.md](adapter-control-planes.md) |
+| Architecture and data flow | [workcell-system-design.md](workcell-system-design.md) (with boundary-stack, policy-to-injection, and control-plane masking diagrams), [invariants.md](invariants.md), [adapter-control-planes.md](adapter-control-planes.md) |
 | Runtime and target boundaries | [remote-vm-contract.md](remote-vm-contract.md), [managed-workstation-contract.md](managed-workstation-contract.md), [host-expansion-readiness.md](host-expansion-readiness.md), [policy/host-support-matrix.tsv](../policy/host-support-matrix.tsv) |
 | Threat model and non-protections | [threat-model.md](threat-model.md), [invariants.md](invariants.md), [enterprise-rollout.md](enterprise-rollout.md) |
 | Validation evidence | [validation-scenarios.md](validation-scenarios.md), [requirements-validation.md](requirements-validation.md), [use-case-matrix.md](use-case-matrix.md) |

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -118,6 +118,21 @@ The supported safe path is two-tier:
 1. a dedicated Colima VM on the host
 2. a hardened agent container inside that VM
 
+```mermaid
+flowchart TB
+    subgraph host["macOS host — control plane"]
+        cli["workcell CLI + host-side helpers"]
+        subgraph vm["Dedicated Colima VM"]
+            subgraph ctr["Hardened agent container<br/>no-new-privileges · cap-drop ALL · pids-limit<br/>tmpfs /tmp /run /state"]
+                provider["Provider agent<br/>Codex / Claude / Copilot / Gemini"]
+                ws["/workspace<br/>selected mount"]
+                provider --- ws
+            end
+        end
+    end
+    cli --> vm --> ctr
+```
+
 The container launch path applies controls such as:
 
 - Docker `--init` for launches that do not require PID 1 environment scrubbing
@@ -162,6 +177,16 @@ For tracked files, the shadow path can materialize content from the git index
 instead of live mutable workspace state. That narrows the gap between what the
 operator reviewed and what the runtime consumes.
 
+```mermaid
+flowchart LR
+    subgraph repo["Repo-local control plane — mutable workspace"]
+        files["AGENTS.md · CLAUDE.md · GEMINI.md<br/>.mcp.json · .codex/ · .claude/ · .gemini/<br/>mutable git hooks + config"]
+    end
+    idx["git index<br/>tracked files"] -. materialize .-> mask
+    files --> mask["Masked / shadowed<br/>by Workcell"]
+    mask --> home["Managed provider home<br/>reviewed inputs"]
+```
+
 ### 5. Injection and Credential Flow
 
 Workcell's supported path for credentials, shared GitHub state, SSH material,
@@ -174,6 +199,16 @@ The flow is:
 3. render a staged injection bundle and manifest
 4. mount the staged bundle into controlled runtime paths
 5. reseed the managed provider home from approved sources
+
+```mermaid
+flowchart TD
+    policy["Injection policy<br/>loaded on host"] --> resolve["Resolve credential sources<br/>+ selector scope"]
+    resolve --> render["Render staged bundle<br/>+ manifest"]
+    render --> mount["Mount bundle into<br/>controlled runtime paths"]
+    mount --> reseed["Reseed managed<br/>provider home"]
+    reseed --> agent["Provider agent"]
+    guard["Secrets classified + staged ·<br/>target paths enumerated ·<br/>reserved provider-home paths protected"] -. governs .-> render
+```
 
 Important properties of the current implementation:
 

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -170,11 +170,13 @@ Repo-local control-plane paths such as:
 - `.gemini/`
 - mutable git hook and config paths
 
-are masked or shadowed by Workcell over the workspace. Of these, only the
-provider documentation files — `AGENTS.md` plus the active provider's own file
-(`CLAUDE.md` or `GEMINI.md`) — are additionally imported into the managed
-provider home as reviewed inputs; the remaining paths are neutralized in the
-workspace but not reseeded into the provider home.
+are masked or shadowed by Workcell over the workspace. Of these, the provider
+documentation files may additionally be imported into the managed provider home
+as reviewed inputs, and which files are imported depends on the adapter: Codex
+imports `AGENTS.md`; Claude and Gemini import `AGENTS.md` plus their own file
+(`CLAUDE.md` or `GEMINI.md`); Copilot imports none, because its custom-instruction
+surface is intentionally disabled. The remaining control-plane paths are
+neutralized in the workspace but not reseeded into the provider home.
 
 For tracked files, the shadow path can materialize content from the git index
 instead of live mutable workspace state. That narrows the gap between what the
@@ -189,7 +191,7 @@ flowchart LR
     idx["git index<br/>tracked files"] -. materialize .-> mask
     docs --> mask["Masked / shadowed<br/>over /workspace"]
     other --> mask
-    docs --> home["Imported into managed provider home<br/>as reviewed inputs<br/>AGENTS.md + the active provider doc"]
+    docs -. "Codex/Claude/Gemini only<br/>(Copilot imports none)" .-> home["Imported into managed provider home<br/>as reviewed inputs"]
 ```
 
 ### 5. Injection and Credential Flow

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -170,8 +170,11 @@ Repo-local control-plane paths such as:
 - `.gemini/`
 - mutable git hook and config paths
 
-are masked or shadowed by Workcell and then imported into the managed provider
-home as reviewed inputs.
+are masked or shadowed by Workcell over the workspace. Of these, only the
+provider documentation files — `AGENTS.md` plus the active provider's own file
+(`CLAUDE.md` or `GEMINI.md`) — are additionally imported into the managed
+provider home as reviewed inputs; the remaining paths are neutralized in the
+workspace but not reseeded into the provider home.
 
 For tracked files, the shadow path can materialize content from the git index
 instead of live mutable workspace state. That narrows the gap between what the
@@ -180,11 +183,13 @@ operator reviewed and what the runtime consumes.
 ```mermaid
 flowchart LR
     subgraph repo["Repo-local control plane — mutable workspace"]
-        files["AGENTS.md · CLAUDE.md · GEMINI.md<br/>.mcp.json · .codex/ · .claude/ · .gemini/<br/>mutable git hooks + config"]
+        docs["AGENTS.md · CLAUDE.md · GEMINI.md<br/>provider docs"]
+        other[".mcp.json · .codex/ · .claude/ · .gemini/<br/>mutable git hooks + config"]
     end
     idx["git index<br/>tracked files"] -. materialize .-> mask
-    files --> mask["Masked / shadowed<br/>by Workcell"]
-    mask --> home["Managed provider home<br/>reviewed inputs"]
+    docs --> mask["Masked / shadowed<br/>over /workspace"]
+    other --> mask
+    docs --> home["Imported into managed provider home<br/>as reviewed inputs<br/>AGENTS.md + the active provider doc"]
 ```
 
 ### 5. Injection and Credential Flow


### PR DESCRIPTION
# Summary

Implements ROADMAP item **E2 (Architecture Diagrams)** per
[`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md):
three maintained Mermaid diagrams in
[`docs/workcell-system-design.md`](docs/workcell-system-design.md), each grounded
in the section it accompanies:

- **Boundary stack** (§3) — macOS host → dedicated Colima VM → hardened agent
  container (no-new-privileges, cap-drop ALL, pids-limit, tmpfs) → provider agent
  + `/workspace` mount.
- **Control-plane seeding/masking** (§4) — repo-local control-plane files masked/
  shadowed by Workcell (tracked files materialized from the git index) into the
  managed provider home as reviewed inputs.
- **Policy-to-injection trust flow** (§5) — injection policy → resolve credential
  sources → render staged bundle + manifest → mount into controlled runtime paths
  → reseed provider home, governed by explicit classification and enumerated paths.

Referenced from the enterprise evidence baseline.

## Support-claim impact

None. Documentation only.

## Validation

- all three diagrams **render**, verified with `mermaid-cli` 11.16.0 (each → SVG)
- doc-links / markdownlint / codespell green
- `./scripts/pre-merge.sh --profile pr-parity` passed
