### PR TITLE
^F Add exec-guard syscall-shim performance baselines (C5)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,71 @@
+name: Bench
+
+# Optional, non-PR-blocking microbenchmark lane for the workcell_exec_guard
+# LD_PRELOAD shim (runtime/container/rust). It builds the exec-guard cdylib,
+# then times the guard's ALLOW-path classification overhead on the interposed
+# exec/spawn family calls against the unhooked libc baseline
+# (scripts/bench/run-exec-guard-bench.sh), repeating the measurement across two
+# runs to demonstrate the numbers are stable. Results are printed to the job log
+# and uploaded as an artifact; the reviewed baseline numbers and methodology
+# live in docs/syscall-shim-benchmarks.md. This lane is scheduled and on-demand
+# only -- it never runs on the PR path.
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  exec-guard-bench:
+    name: exec-guard bench
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Build the shipping cdylib from its committed vendored sources (offline,
+      # locked). rustup honors the crate's rust-toolchain.toml pin, so the guard
+      # is built with the same reviewed toolchain the release image uses. --lib
+      # builds only the library targets, producing libworkcell_exec_guard.so.
+      - name: Build the exec-guard cdylib
+        working-directory: runtime/container/rust
+        run: |
+          rustup show >/dev/null
+          cargo build --release --locked --offline --lib
+
+      # Two full measurement passes (WORKCELL_BENCH_RUNS=2) so the cross-run
+      # stability of the hooked-median numbers is visible in the log and the
+      # uploaded report -- the C5 validation gate.
+      - name: Run exec-guard microbenchmark
+        env:
+          WORKCELL_BENCH_ITERATIONS: "5000"
+          WORKCELL_BENCH_WARMUP: "500"
+          WORKCELL_BENCH_RUNS: "2"
+          WORKCELL_BENCH_OUTPUT: exec-guard-bench-results.md
+        run: ./scripts/bench/run-exec-guard-bench.sh
+
+      # Persist the Markdown report before the runner workspace is discarded so
+      # the measured numbers can be reviewed and transcribed into
+      # docs/syscall-shim-benchmarks.md.
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: exec-guard-bench-results
+          path: exec-guard-bench-results.md
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,6 +14,14 @@ on:
   schedule:
     - cron: "0 8 * * 1"
   workflow_dispatch:
+  # TEMPORARY (C5, will be removed before merge): run on this PR to produce the
+  # first reviewed baseline numbers, since workflow_dispatch cannot target a
+  # workflow that is not yet on the default branch.
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/bench.yml"
+      - "scripts/bench/**"
 
 permissions: {}
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,14 +14,6 @@ on:
   schedule:
     - cron: "0 8 * * 1"
   workflow_dispatch:
-  # TEMPORARY (C5, removed before merge): re-measure on this PR after the
-  # methodology fix, since workflow_dispatch cannot target a workflow not yet on
-  # the default branch.
-  pull_request:
-    branches: [main]
-    paths:
-      - ".github/workflows/bench.yml"
-      - "scripts/bench/**"
 
 permissions: {}
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,6 +14,14 @@ on:
   schedule:
     - cron: "0 8 * * 1"
   workflow_dispatch:
+  # TEMPORARY (C5, removed before merge): re-measure on this PR after the
+  # methodology fix, since workflow_dispatch cannot target a workflow not yet on
+  # the default branch.
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/bench.yml"
+      - "scripts/bench/**"
 
 permissions: {}
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,14 +14,6 @@ on:
   schedule:
     - cron: "0 8 * * 1"
   workflow_dispatch:
-  # TEMPORARY (C5, will be removed before merge): run on this PR to produce the
-  # first reviewed baseline numbers, since workflow_dispatch cannot target a
-  # workflow that is not yet on the default branch.
-  pull_request:
-    branches: [main]
-    paths:
-      - ".github/workflows/bench.yml"
-      - "scripts/bench/**"
 
 permissions: {}
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -38,6 +38,7 @@ adds the matching `approved-large-certified-adapter` PR label.
 | `pin-hygiene.yml` | scheduled re-validation of pinned inputs plus upstream refresh drift across providers, Linux base images, toolchains, and release-build pins |
 | `mutation.yml` | weekly-cron, manual, and `approved-heavy-ci`-gated lane that runs the mutation-score gate in the validator image via `scripts/ci/job-mutation.sh` and `scripts/ci/run-mutation-in-validator.sh` (GitHub-only; the same gate also runs locally in the release-preflight validate profile) |
 | `fuzz.yml` | weekly-cron and manual lane that spends an extended, time-bounded budget fuzzing the Go parser targets whose seed corpora already run as regression tests on every PR; see [fuzzing.md](fuzzing.md) |
+| `bench.yml` | optional weekly-cron and manual lane that builds the exec-guard cdylib and times the LD_PRELOAD shim's allow-path classification overhead against the unhooked libc baseline across two runs; not on the PR path; see [syscall-shim-benchmarks.md](syscall-shim-benchmarks.md) |
 | `upstream-refresh.yml` | scheduled and manual candidate generation for reviewed upstream pins, with later signed host-side PR publication |
 | `hosted-controls.yml` | drift detection for GitHub-hosted controls that live outside git |
 | `release.yml` | tagged release preflight, publication, signatures, SBOMs, manifests, and attestations |

--- a/docs/retention-policy.md
+++ b/docs/retention-policy.md
@@ -19,6 +19,7 @@ policy for readability.
 
 | Workflow | Artifact | retention-days |
 |---|---|---|
+| bench.yml | exec-guard-bench-results | 14 |
 | ci.yml | workcell-ci-install-candidate | 7 |
 | fuzz.yml | fuzz-reproducers | 14 |
 | fuzz.yml | rust-fuzz-reproducers | 14 |
@@ -40,6 +41,13 @@ policy for readability.
   because every file in it is also published as a permanent GitHub Release
   asset in the next step, so a long-lived workflow-artifact copy would be pure
   redundant storage.
+- **`bench.yml` — 14 days.** The `exec-guard-bench-results` upload is the
+  Markdown report from a scheduled or on-demand microbenchmark run (the
+  exec-guard allow-path overhead and its cross-run stability). It is triage and
+  transcription evidence, not integrity provenance: the durable copy is the
+  reviewed baseline in [syscall-shim-benchmarks.md](syscall-shim-benchmarks.md).
+  Fourteen days spans the weekly cadence with margin, matching the sibling
+  `fuzz.yml` evidence artifacts.
 - **`ci.yml` — 7 days.** The CI install candidate is a transient
   per-PR/per-push build; it is only useful while the change is in flight, and
   the durable release evidence is produced by `release.yml`.

--- a/docs/syscall-shim-benchmarks.md
+++ b/docs/syscall-shim-benchmarks.md
@@ -9,8 +9,8 @@ forwards -- and the methodology and rerun steps behind those numbers.
 The numbers are produced by the optional `bench.yml` GitHub lane on Linux, not
 on the macOS development host: the shim reads `/proc` and interposes the
 glibc/musl symbols, so its overhead only exists on Linux. The results table
-below is therefore seeded with **placeholders** until a lane run fills it in
-(see [Filling in the numbers](#filling-in-the-numbers)).
+below holds the measured values from that lane; rerun it to refresh them (see
+[Filling in the numbers](#filling-in-the-numbers)).
 
 ## What the guard hooks, and what the harness measures
 
@@ -76,26 +76,29 @@ Variance is controlled by:
 
 ## Results
 
-**Status: placeholders -- to be filled from a `bench.yml` lane run.** These are
-not measured numbers. Do not cite them until replaced (see below).
+**Status: measured on the `bench.yml` lane** (`ubuntu-latest` GitHub-hosted
+runner, release cdylib, glibc). These are shared-runner relative overheads, not
+absolute guarantees; re-measure on the target host for absolute figures. The
+guard adds ~440us (~76%) per `exec*` launch and ~205us (~42%) per `posix_spawn`
+on the allow path, dominated by the classification of the resolved target.
 
 ### Allow-path overhead (median of 5000 samples, 2 runs)
 
 | Mode | Unhooked median (ns) | Hooked median (ns) | Delta (ns) | Delta (%) |
 |---|---|---|---|---|
-| `execve` | TODO | TODO | TODO | TODO |
-| `execv` | TODO | TODO | TODO | TODO |
-| `execvp` | TODO | TODO | TODO | TODO |
-| `posix_spawn` | TODO | TODO | TODO | TODO |
+| `execve` | 575336 | 1015989 | 440653 | 76.6 |
+| `execv` | 570947 | 1009646 | 438699 | 76.8 |
+| `execvp` | 573745 | 1013812 | 440067 | 76.7 |
+| `posix_spawn` | 486236 | 691238 | 205002 | 42.2 |
 
 ### Cross-run stability (hooked median)
 
 | Mode | Min (ns) | Max (ns) | Spread (ns) | Spread (%) |
 |---|---|---|---|---|
-| `execve` | TODO | TODO | TODO | TODO |
-| `execv` | TODO | TODO | TODO | TODO |
-| `execvp` | TODO | TODO | TODO | TODO |
-| `posix_spawn` | TODO | TODO | TODO | TODO |
+| `execve` | 1015989 | 1019361 | 3372 | 0.3 |
+| `execv` | 1009497 | 1009646 | 149 | 0.0 |
+| `execvp` | 1013812 | 1016247 | 2435 | 0.2 |
+| `posix_spawn` | 691238 | 693251 | 2013 | 0.3 |
 
 ## Filling in the numbers
 

--- a/docs/syscall-shim-benchmarks.md
+++ b/docs/syscall-shim-benchmarks.md
@@ -89,29 +89,30 @@ Variance is controlled by:
 
 ## Results
 
-**Status: being re-measured on the `bench.yml` lane** after the methodology fix
-that scrubs `LD_PRELOAD` from measured children and makes `execvp` use `PATH`
-search; the tables below are refreshed from that run. Numbers are shared-runner
-relative overheads, not absolute guarantees; re-measure on the target host for
-absolute figures.
+**Status: measured on the `bench.yml` lane** (`ubuntu-latest` GitHub-hosted
+runner, release cdylib, glibc). Numbers are shared-runner relative overheads, not
+absolute guarantees; re-measure on the target host for absolute figures. On the
+allow path the guard's classification adds ~265us (~48%) per `exec*` launch and
+~57us (~12%) per `posix_spawn`; a real container additionally pays the amortized
+per-child cost of loading the preloaded `.so` into each launched process.
 
 ### Allow-path overhead (median of 5000 samples, 2 runs)
 
 | Mode | Unhooked median (ns) | Hooked median (ns) | Delta (ns) | Delta (%) |
 |---|---|---|---|---|
-| `execve` | 575336 | 1015989 | 440653 | 76.6 |
-| `execv` | 570947 | 1009646 | 438699 | 76.8 |
-| `execvp` | 573745 | 1013812 | 440067 | 76.7 |
-| `posix_spawn` | 486236 | 691238 | 205002 | 42.2 |
+| `execve` | 553855 | 818320 | 264465 | 47.7 |
+| `execv` | 551629 | 818568 | 266939 | 48.4 |
+| `execvp` | 565185 | 827073 | 261888 | 46.3 |
+| `posix_spawn` | 467863 | 524429 | 56566 | 12.1 |
 
 ### Cross-run stability (hooked median)
 
 | Mode | Min (ns) | Max (ns) | Spread (ns) | Spread (%) |
 |---|---|---|---|---|
-| `execve` | 1015989 | 1019361 | 3372 | 0.3 |
-| `execv` | 1009497 | 1009646 | 149 | 0.0 |
-| `execvp` | 1013812 | 1016247 | 2435 | 0.2 |
-| `posix_spawn` | 691238 | 693251 | 2013 | 0.3 |
+| `execve` | 818320 | 826893 | 8573 | 1.0 |
+| `execv` | 815793 | 818568 | 2775 | 0.3 |
+| `execvp` | 824098 | 827073 | 2975 | 0.4 |
+| `posix_spawn` | 524429 | 524850 | 421 | 0.1 |
 
 ## Filling in the numbers
 

--- a/docs/syscall-shim-benchmarks.md
+++ b/docs/syscall-shim-benchmarks.md
@@ -107,10 +107,9 @@ on the allow path, dominated by the classification of the resolved target.
 2. Download the `exec-guard-bench-results` artifact (or read the job log): it is
    the Markdown report the driver emits, including both per-run tables and the
    cross-run stability table.
-3. Transcribe the two runs' medians into the tables above, replacing every
-   `TODO`, and confirm the stability spread is small (single-digit percent) --
-   that is the evidence the lane produces stable numbers across two runs.
-4. Remove the placeholder status note once the tables hold measured values.
+3. Transcribe the two runs' medians into the tables above, and confirm the
+   stability spread stays small (single-digit percent) -- that is the evidence
+   the lane produces stable numbers across two runs.
 
 ## Rerunning locally (Linux only)
 

--- a/docs/syscall-shim-benchmarks.md
+++ b/docs/syscall-shim-benchmarks.md
@@ -50,6 +50,19 @@ mode -- once unhooked (plain libc) and once with `LD_PRELOAD` set to the built
 `libworkcell_exec_guard.so` -- and reports the delta. The same fork/exec/wait
 structure is on both sides, so the delta isolates the guard's added latency.
 
+The harness removes `LD_PRELOAD` from the environment (via `unsetenv`) before the
+measured launches. The guard is already resident in the harness from its own
+startup, so its hooks still fire and classify every launch; scrubbing the
+variable only stops each measured child from **re-loading** the `.so`. Without
+this, every hooked sample would also charge the dynamic loader's one-time cost of
+mapping the preload into the short-lived `/bin/true` child, and the delta would
+be a mix of classifier cost and per-child loader cost. The published numbers are
+therefore the guard's **classification** overhead; a real container additionally
+pays that per-launch loader cost, amortized over each child's lifetime. The
+`execvp` mode launches a **bare** command name against a controlled `PATH` (the
+driver sets `PATH` so the target's directory resolves it) so it exercises the
+guard's `PATH`-search resolution rather than an absolute-path fast path.
+
 Variance is controlled by:
 
 - **Warmup.** `WORKCELL_BENCH_WARMUP` samples run and are discarded before
@@ -76,11 +89,11 @@ Variance is controlled by:
 
 ## Results
 
-**Status: measured on the `bench.yml` lane** (`ubuntu-latest` GitHub-hosted
-runner, release cdylib, glibc). These are shared-runner relative overheads, not
-absolute guarantees; re-measure on the target host for absolute figures. The
-guard adds ~440us (~76%) per `exec*` launch and ~205us (~42%) per `posix_spawn`
-on the allow path, dominated by the classification of the resolved target.
+**Status: being re-measured on the `bench.yml` lane** after the methodology fix
+that scrubs `LD_PRELOAD` from measured children and makes `execvp` use `PATH`
+search; the tables below are refreshed from that run. Numbers are shared-runner
+relative overheads, not absolute guarantees; re-measure on the target host for
+absolute figures.
 
 ### Allow-path overhead (median of 5000 samples, 2 runs)
 

--- a/docs/syscall-shim-benchmarks.md
+++ b/docs/syscall-shim-benchmarks.md
@@ -1,0 +1,139 @@
+# Syscall-shim performance baselines
+
+The `workcell_exec_guard` LD_PRELOAD shim (`runtime/container/rust/src/lib.rs`)
+interposes the libc exec/spawn family and classifies every launch before
+forwarding it to the real entry point. This page records the added latency that
+classification costs on the **allow path** -- a launch the guard permits and
+forwards -- and the methodology and rerun steps behind those numbers.
+
+The numbers are produced by the optional `bench.yml` GitHub lane on Linux, not
+on the macOS development host: the shim reads `/proc` and interposes the
+glibc/musl symbols, so its overhead only exists on Linux. The results table
+below is therefore seeded with **placeholders** until a lane run fills it in
+(see [Filling in the numbers](#filling-in-the-numbers)).
+
+## What the guard hooks, and what the harness measures
+
+The shim exports and interposes these libc symbols (`#[no_mangle]` entries in
+`runtime/container/rust/src/lib.rs`):
+
+- `execve`, `execv`, `execvp`, `execvpe`
+- `execveat`, `fexecve`
+- `posix_spawn`, `posix_spawnp`
+- `syscall` (via an assembly trampoline that re-dispatches `SYS_execve` /
+  `SYS_execveat` back through the hooked `execve` / `execveat`)
+
+The microbenchmark exercises four representative entry points that span the two
+distinct overhead shapes:
+
+| Harness mode | Interposed symbol | Overhead shape |
+|---|---|---|
+| `execve` | `execve` | classification runs in the forked child (cold per launch) |
+| `execv` | `execv` | as above; reads `environ` rather than an explicit `envp` |
+| `execvp` | `execvp` | as above, plus `PATH` search resolution |
+| `posix_spawn` | `posix_spawn` | classification runs in the calling process (warm, cached signatures) |
+
+`execveat` / `fexecve` / `posix_spawnp` share the same classifier code paths as
+the sampled entry points, so they are covered transitively rather than sampled
+separately.
+
+## Methodology
+
+The harness (`scripts/bench/exec-guard-bench.c`) launches a benign target
+(`/bin/true`) that the guard classifies as "not protected" and forwards, so
+every sample runs the classifier to completion on the allow path -- it measures
+classification cost, not a blocked-exec early return. Each sample is one
+`fork` + exec + `wait` (for the `exec*` modes) or one `posix_spawn` + `wait`.
+
+The driver (`scripts/bench/run-exec-guard-bench.sh`) runs the harness twice per
+mode -- once unhooked (plain libc) and once with `LD_PRELOAD` set to the built
+`libworkcell_exec_guard.so` -- and reports the delta. The same fork/exec/wait
+structure is on both sides, so the delta isolates the guard's added latency.
+
+Variance is controlled by:
+
+- **Warmup.** `WORKCELL_BENCH_WARMUP` samples run and are discarded before
+  measurement, so first-touch loader and page-cache costs are excluded.
+- **Volume.** `WORKCELL_BENCH_ITERATIONS` measured samples per mode (5000 in the
+  lane), reported as **median** (robust to scheduler outliers) alongside mean,
+  p90, and standard deviation.
+- **Repetition.** `WORKCELL_BENCH_RUNS` full passes (2 in the lane). The driver
+  prints a cross-run stability table so the run-to-run spread of the hooked
+  median is visible -- this is the C5 validation gate.
+
+### Runner caveats
+
+- Numbers are **relative overheads on a shared CI runner**, not absolute
+  hardware figures; treat the delta (and its percentage), not the absolute
+  medians, as the portable signal.
+- For the `exec*` modes the classifier runs in the freshly forked child, so its
+  `OnceLock` signature caches start cold each launch; for `posix_spawn` it runs
+  in the long-lived driver process, so the caches are warm after the first call.
+  The two overhead columns are expected to differ for this reason.
+- On a stock runner `/proc/1/environ` is not readable, so the guard fails closed
+  to the strict profile (`current_mode_blocks_mutable_native_exec` returns
+  `true`). This matches the container's strict-profile default.
+
+## Results
+
+**Status: placeholders -- to be filled from a `bench.yml` lane run.** These are
+not measured numbers. Do not cite them until replaced (see below).
+
+### Allow-path overhead (median of 5000 samples, 2 runs)
+
+| Mode | Unhooked median (ns) | Hooked median (ns) | Delta (ns) | Delta (%) |
+|---|---|---|---|---|
+| `execve` | TODO | TODO | TODO | TODO |
+| `execv` | TODO | TODO | TODO | TODO |
+| `execvp` | TODO | TODO | TODO | TODO |
+| `posix_spawn` | TODO | TODO | TODO | TODO |
+
+### Cross-run stability (hooked median)
+
+| Mode | Min (ns) | Max (ns) | Spread (ns) | Spread (%) |
+|---|---|---|---|---|
+| `execve` | TODO | TODO | TODO | TODO |
+| `execv` | TODO | TODO | TODO | TODO |
+| `execvp` | TODO | TODO | TODO | TODO |
+| `posix_spawn` | TODO | TODO | TODO | TODO |
+
+## Filling in the numbers
+
+1. Trigger the lane: run the **Bench** workflow (`bench.yml`) via
+   `workflow_dispatch`, or wait for its weekly schedule.
+2. Download the `exec-guard-bench-results` artifact (or read the job log): it is
+   the Markdown report the driver emits, including both per-run tables and the
+   cross-run stability table.
+3. Transcribe the two runs' medians into the tables above, replacing every
+   `TODO`, and confirm the stability spread is small (single-digit percent) --
+   that is the evidence the lane produces stable numbers across two runs.
+4. Remove the placeholder status note once the tables hold measured values.
+
+## Rerunning locally (Linux only)
+
+From the repository root on a Linux host:
+
+```sh
+# Build the exec-guard cdylib (offline, from vendored sources).
+(cd runtime/container/rust && cargo build --release --locked --offline --lib)
+
+# Run the benchmark (defaults: 3000 iterations, 300 warmup, 2 runs, /bin/true).
+./scripts/bench/run-exec-guard-bench.sh
+```
+
+Tunable via environment: `WORKCELL_BENCH_ITERATIONS`, `WORKCELL_BENCH_WARMUP`,
+`WORKCELL_BENCH_RUNS`, `WORKCELL_BENCH_TARGET`, `WORKCELL_EXEC_GUARD_SO`, and
+`WORKCELL_BENCH_OUTPUT` (write the Markdown report to a file).
+
+On macOS the driver compiles and runs the **unhooked baseline only** and says
+so: `DYLD_INSERT_LIBRARIES` semantics differ and the Linux-only guard logic does
+not apply, so hooked numbers must come from Linux.
+
+## Where this fits
+
+The lane is registered in `policy/workflow-lane-policy.json` and reflected in
+`policy/workflow-lanes.json`; the artifact retention is in
+`policy/retention-policy.json` and mirrored in
+[retention-policy.md](retention-policy.md). See
+[github-workflows.md](github-workflows.md) for the full workflow inventory and
+[fuzzing.md](fuzzing.md) for the sibling scheduled exec-guard lane.

--- a/policy/retention-policy.json
+++ b/policy/retention-policy.json
@@ -1,6 +1,9 @@
 {
   "version": 1,
   "artifacts": {
+    "bench.yml": {
+      "exec-guard-bench-results": 14
+    },
     "ci.yml": {
       "workcell-ci-install-candidate": 7
     },

--- a/policy/workflow-lane-policy.json
+++ b/policy/workflow-lane-policy.json
@@ -1,6 +1,11 @@
 {
   "version": 1,
   "lanes": {
+    "bench.yml/exec-guard-bench": {
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "optional exec-guard microbenchmark lane; it builds the cdylib and times the LD_PRELOAD shim's classification overhead on Linux, which the macOS host baseline cannot mirror, so the reviewed numbers come from this scheduled/on-demand GitHub lane"
+    },
     "ci.yml/container-smoke": {
       "profiles": ["repo-core", "pr-parity", "release-preflight"],
       "authority": "repo-core",

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -9,9 +9,16 @@
       "job_id": "exec-guard-bench",
       "job_name": "exec-guard bench",
       "workflow_events": [
+        "pull_request",
         "schedule",
         "workflow_dispatch"
       ],
+      "workflow_path_globs": {
+        "pull_request": [
+          ".github/workflows/bench.yml",
+          "scripts/bench/**"
+        ]
+      },
       "authority": "github-only",
       "local_mode": "none",
       "github_only_reason": "optional exec-guard microbenchmark lane; it builds the cdylib and times the LD_PRELOAD shim's classification overhead on Linux, which the macOS host baseline cannot mirror, so the reviewed numbers come from this scheduled/on-demand GitHub lane"

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -3,6 +3,20 @@
   "policy": "policy/workflow-lane-policy.json",
   "lanes": [
     {
+      "id": "bench.yml/exec-guard-bench",
+      "workflow_path": ".github/workflows/bench.yml",
+      "workflow_name": "Bench",
+      "job_id": "exec-guard-bench",
+      "job_name": "exec-guard bench",
+      "workflow_events": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "optional exec-guard microbenchmark lane; it builds the cdylib and times the LD_PRELOAD shim's classification overhead on Linux, which the macOS host baseline cannot mirror, so the reviewed numbers come from this scheduled/on-demand GitHub lane"
+    },
+    {
       "id": "ci.yml/container-smoke",
       "workflow_path": ".github/workflows/ci.yml",
       "workflow_name": "CI",

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -9,16 +9,9 @@
       "job_id": "exec-guard-bench",
       "job_name": "exec-guard bench",
       "workflow_events": [
-        "pull_request",
         "schedule",
         "workflow_dispatch"
       ],
-      "workflow_path_globs": {
-        "pull_request": [
-          ".github/workflows/bench.yml",
-          "scripts/bench/**"
-        ]
-      },
       "authority": "github-only",
       "local_mode": "none",
       "github_only_reason": "optional exec-guard microbenchmark lane; it builds the cdylib and times the LD_PRELOAD shim's classification overhead on Linux, which the macOS host baseline cannot mirror, so the reviewed numbers come from this scheduled/on-demand GitHub lane"

--- a/scripts/bench/exec-guard-bench.c
+++ b/scripts/bench/exec-guard-bench.c
@@ -1,0 +1,235 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Omkhar Arasaratnam
+ *
+ * exec-guard-bench: a minimal, dependency-free microbenchmark harness for the
+ * workcell_exec_guard LD_PRELOAD shim (runtime/container/rust/src/lib.rs).
+ *
+ * It times the ALLOW path of one interposed exec/spawn family call against a
+ * benign target (default /bin/true) that the guard classifies as "not
+ * protected" and forwards to the real libc entry point. Running the same
+ * harness twice -- once with LD_PRELOAD pointed at the built cdylib and once
+ * without -- isolates the classification overhead the guard adds per call.
+ *
+ * The harness itself is OS-neutral and compiles on Linux and macOS, but the
+ * LD_PRELOAD interposition it measures is Linux-only (the guard reads /proc and
+ * hooks the glibc/musl symbols). On macOS only the unhooked baseline is
+ * meaningful. See docs/syscall-shim-benchmarks.md.
+ *
+ * Usage:
+ *   exec-guard-bench <mode> <iterations> <warmup> <target>
+ *     mode        one of: execve execv execvp posix_spawn
+ *     iterations  measured samples (each = one fork+exec+wait / spawn+wait)
+ *     warmup      discarded warmup samples run before measurement
+ *     target      benign executable to launch (e.g. /bin/true)
+ *
+ * Output (one line, key=value pairs, all times in nanoseconds):
+ *   mode=<mode> n=<count> mean_ns=<m> median_ns=<md> p90_ns=<p> \
+ *     stddev_ns=<s> min_ns=<lo> max_ns=<hi>
+ *
+ * Any failed launch (non-zero child exit or spawn/exec error) aborts with a
+ * non-zero status and no numbers, so a blocked exec can never masquerade as a
+ * measurement.
+ */
+
+#include <errno.h>
+#include <math.h>
+#include <spawn.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#if defined(__APPLE__)
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
+#else
+extern char **environ;
+#endif
+
+enum mode {
+    MODE_EXECVE,
+    MODE_EXECV,
+    MODE_EXECVP,
+    MODE_POSIX_SPAWN,
+};
+
+static int parse_mode(const char *name, enum mode *out) {
+    if (strcmp(name, "execve") == 0) {
+        *out = MODE_EXECVE;
+    } else if (strcmp(name, "execv") == 0) {
+        *out = MODE_EXECV;
+    } else if (strcmp(name, "execvp") == 0) {
+        *out = MODE_EXECVP;
+    } else if (strcmp(name, "posix_spawn") == 0) {
+        *out = MODE_POSIX_SPAWN;
+    } else {
+        return -1;
+    }
+    return 0;
+}
+
+static int64_t now_ns(void) {
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        perror("clock_gettime");
+        exit(EXIT_FAILURE);
+    }
+    return (int64_t)ts.tv_sec * 1000000000LL + (int64_t)ts.tv_nsec;
+}
+
+/* Launch the target once via the selected family call and wait for it.
+ * Returns 0 on a clean exit(0) child, -1 otherwise. */
+static int launch_once(enum mode mode, const char *target, char *const argv[]) {
+    if (mode == MODE_POSIX_SPAWN) {
+        pid_t pid = 0;
+        int rc = posix_spawn(&pid, target, NULL, NULL, argv, environ);
+        if (rc != 0) {
+            errno = rc;
+            perror("posix_spawn");
+            return -1;
+        }
+        int status = 0;
+        if (waitpid(pid, &status, 0) < 0) {
+            perror("waitpid");
+            return -1;
+        }
+        return (WIFEXITED(status) && WEXITSTATUS(status) == 0) ? 0 : -1;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        return -1;
+    }
+    if (pid == 0) {
+        switch (mode) {
+        case MODE_EXECVE:
+            execve(target, argv, environ);
+            break;
+        case MODE_EXECV:
+            execv(target, argv);
+            break;
+        case MODE_EXECVP:
+            execvp(target, argv);
+            break;
+        default:
+            break;
+        }
+        /* Only reached if exec failed (e.g. a blocked launch). */
+        _exit(127);
+    }
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0) {
+        perror("waitpid");
+        return -1;
+    }
+    return (WIFEXITED(status) && WEXITSTATUS(status) == 0) ? 0 : -1;
+}
+
+static int cmp_i64(const void *a, const void *b) {
+    int64_t x = *(const int64_t *)a;
+    int64_t y = *(const int64_t *)b;
+    if (x < y) {
+        return -1;
+    }
+    if (x > y) {
+        return 1;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc != 5) {
+        fprintf(stderr,
+                "usage: %s <execve|execv|execvp|posix_spawn> <iterations> "
+                "<warmup> <target>\n",
+                argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    enum mode mode;
+    if (parse_mode(argv[1], &mode) != 0) {
+        fprintf(stderr, "unknown mode: %s\n", argv[1]);
+        return EXIT_FAILURE;
+    }
+
+    char *end = NULL;
+    long iterations = strtol(argv[2], &end, 10);
+    if (*end != '\0' || iterations <= 0) {
+        fprintf(stderr, "invalid iterations: %s\n", argv[2]);
+        return EXIT_FAILURE;
+    }
+    long warmup = strtol(argv[3], &end, 10);
+    if (*end != '\0' || warmup < 0) {
+        fprintf(stderr, "invalid warmup: %s\n", argv[3]);
+        return EXIT_FAILURE;
+    }
+    const char *target = argv[4];
+
+    /* argv[0] carries the target basename so execvp PATH search (bare names)
+     * and absolute launches both present a conventional argv to the guard. */
+    const char *base = strrchr(target, '/');
+    base = base != NULL ? base + 1 : target;
+    char *const child_argv[] = {(char *)base, NULL};
+
+    for (long i = 0; i < warmup; i++) {
+        if (launch_once(mode, target, child_argv) != 0) {
+            fprintf(stderr, "warmup launch failed for target %s\n", target);
+            return EXIT_FAILURE;
+        }
+    }
+
+    int64_t *samples = calloc((size_t)iterations, sizeof(int64_t));
+    if (samples == NULL) {
+        perror("calloc");
+        return EXIT_FAILURE;
+    }
+
+    for (long i = 0; i < iterations; i++) {
+        int64_t start = now_ns();
+        int rc = launch_once(mode, target, child_argv);
+        int64_t elapsed = now_ns() - start;
+        if (rc != 0) {
+            fprintf(stderr, "measured launch failed for target %s\n", target);
+            free(samples);
+            return EXIT_FAILURE;
+        }
+        samples[i] = elapsed;
+    }
+
+    long double sum = 0.0L;
+    long double sum_sq = 0.0L;
+    for (long i = 0; i < iterations; i++) {
+        long double v = (long double)samples[i];
+        sum += v;
+        sum_sq += v * v;
+    }
+    long double mean = sum / (long double)iterations;
+    long double variance = sum_sq / (long double)iterations - mean * mean;
+    if (variance < 0.0L) {
+        variance = 0.0L;
+    }
+    long double stddev = sqrtl(variance);
+
+    qsort(samples, (size_t)iterations, sizeof(int64_t), cmp_i64);
+    int64_t median = samples[iterations / 2];
+    long p90_index = (iterations * 9) / 10;
+    if (p90_index >= iterations) {
+        p90_index = iterations - 1;
+    }
+    int64_t p90 = samples[p90_index];
+    int64_t min = samples[0];
+    int64_t max = samples[iterations - 1];
+
+    printf("mode=%s n=%ld mean_ns=%.0Lf median_ns=%lld p90_ns=%lld "
+           "stddev_ns=%.0Lf min_ns=%lld max_ns=%lld\n",
+           argv[1], iterations, mean, (long long)median, (long long)p90, stddev,
+           (long long)min, (long long)max);
+
+    free(samples);
+    return EXIT_SUCCESS;
+}

--- a/scripts/bench/exec-guard-bench.c
+++ b/scripts/bench/exec-guard-bench.c
@@ -121,7 +121,10 @@ static int launch_once(enum mode mode, const char *target, char *const argv[]) {
             execv(target, argv);
             break;
         case MODE_EXECVP:
-            execvp(target, argv);
+            /* Exec the BARE command name (argv[0]), not the absolute target, so
+             * execvp -- and the guard's own resolver -- exercise PATH search.
+             * The caller sets a PATH that resolves this name. */
+            execvp(argv[0], argv);
             break;
         default:
             break;
@@ -183,6 +186,15 @@ int main(int argc, char **argv) {
     const char *base = strrchr(target, '/');
     base = base != NULL ? base + 1 : target;
     char *const child_argv[] = {(char *)base, NULL};
+
+    /* The guard is already resident in THIS process (loaded via LD_PRELOAD at
+     * our own startup), so its exec/spawn hooks still fire after this. Removing
+     * LD_PRELOAD from the environment the measured children inherit stops each
+     * child from re-loading the .so, so the hooked-vs-unhooked delta isolates
+     * the guard's classification cost rather than also charging every child the
+     * dynamic loader's one-time cost of mapping the preload. This is a no-op for
+     * the unhooked baseline (LD_PRELOAD is unset there). */
+    unsetenv("LD_PRELOAD");
 
     for (long i = 0; i < warmup; i++) {
         if (launch_once(mode, target, child_argv) != 0) {

--- a/scripts/bench/exec-guard-bench.c
+++ b/scripts/bench/exec-guard-bench.c
@@ -31,6 +31,14 @@
  * measurement.
  */
 
+/* CLOCK_MONOTONIC/clock_gettime and posix_spawn are POSIX; glibc hides them
+ * under strict -std=c11 unless a feature-test macro is set (macOS exposes them
+ * by default, and this macro would hide _NSGetEnviron there, so scope it to
+ * non-Apple). Must precede every system header. */
+#if !defined(__APPLE__)
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <errno.h>
 #include <math.h>
 #include <spawn.h>

--- a/scripts/bench/run-exec-guard-bench.sh
+++ b/scripts/bench/run-exec-guard-bench.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+#
+# run-exec-guard-bench.sh -- drive the exec-guard microbenchmark.
+#
+# Compiles scripts/bench/exec-guard-bench.c and, for each interposed exec/spawn
+# family call, times the guard's ALLOW path (LD_PRELOAD of the built cdylib)
+# against the unhooked libc baseline. The delta is the classification overhead
+# the workcell_exec_guard shim adds per launch. The full measurement is repeated
+# for WORKCELL_BENCH_RUNS passes so a reviewer can confirm the numbers are
+# stable across runs (the C5 validation gate).
+#
+# The LD_PRELOAD interposition is Linux-only; on any other OS the driver runs
+# the unhooked baseline only and says so. See docs/syscall-shim-benchmarks.md.
+#
+# Configuration (all optional, via environment):
+#   WORKCELL_BENCH_ITERATIONS  measured samples per call (default 3000)
+#   WORKCELL_BENCH_WARMUP      discarded warmup samples (default 300)
+#   WORKCELL_BENCH_RUNS        full measurement passes (default 2)
+#   WORKCELL_BENCH_TARGET      benign launch target (default /bin/true)
+#   WORKCELL_EXEC_GUARD_SO     path to the built cdylib
+#   WORKCELL_BENCH_OUTPUT      also write the Markdown report to this file
+#   CC                         C compiler (default cc)
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.."
+ROOT_DIR="$(cd "${ROOT_DIR}" && pwd)"
+
+MODES="execve execv execvp posix_spawn"
+ITERATIONS="${WORKCELL_BENCH_ITERATIONS:-3000}"
+WARMUP="${WORKCELL_BENCH_WARMUP:-300}"
+RUNS="${WORKCELL_BENCH_RUNS:-2}"
+SO_PATH="${WORKCELL_EXEC_GUARD_SO:-${ROOT_DIR}/runtime/container/rust/target/release/libworkcell_exec_guard.so}"
+OUTPUT_PATH="${WORKCELL_BENCH_OUTPUT:-}"
+CC_BIN="${CC:-cc}"
+
+TARGET="${WORKCELL_BENCH_TARGET:-}"
+if [ -z "${TARGET}" ]; then
+  if [ -x /bin/true ]; then
+    TARGET=/bin/true
+  elif [ -x /usr/bin/true ]; then
+    TARGET=/usr/bin/true
+  else
+    echo "run-exec-guard-bench: no /bin/true or /usr/bin/true target found" >&2
+    exit 1
+  fi
+fi
+
+OS="$(uname -s)"
+HOOKED=1
+if [ "${OS}" != "Linux" ]; then
+  HOOKED=0
+  echo "run-exec-guard-bench: ${OS} is not Linux; the exec-guard LD_PRELOAD shim" \
+    "is Linux-only, running the unhooked baseline only" >&2
+fi
+
+if [ "${HOOKED}" -eq 1 ] && [ ! -f "${SO_PATH}" ]; then
+  echo "run-exec-guard-bench: exec-guard cdylib not found: ${SO_PATH}" >&2
+  echo "  build it first: (cd runtime/container/rust && cargo build --release)" >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/exec-guard-bench.XXXXXX")"
+trap 'rm -rf "${WORKDIR}"' EXIT
+BIN="${WORKDIR}/exec-guard-bench"
+REPORT="${WORKDIR}/report.md"
+
+"${CC_BIN}" -O2 -std=c11 -Wall -Wextra \
+  -o "${BIN}" "${ROOT_DIR}/scripts/bench/exec-guard-bench.c" -lm
+
+# Extract an integer key=value field from a harness output line.
+field() {
+  printf '%s\n' "$1" | sed -n "s/.*[[:space:]]$2=\([0-9]*\).*/\1/p"
+}
+
+run_bench() {
+  # $1 mode, $2 preload flag (0/1)
+  if [ "$2" -eq 1 ]; then
+    LD_PRELOAD="${SO_PATH}" "${BIN}" "$1" "${ITERATIONS}" "${WARMUP}" "${TARGET}"
+  else
+    "${BIN}" "$1" "${ITERATIONS}" "${WARMUP}" "${TARGET}"
+  fi
+}
+
+{
+  echo "# exec-guard microbenchmark results"
+  echo
+  echo "- date (UTC): $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  echo "- host: $(uname -srm)"
+  echo "- online CPUs: $(getconf _NPROCESSORS_ONLN 2>/dev/null || echo unknown)"
+  echo "- target: ${TARGET}"
+  echo "- iterations: ${ITERATIONS} (warmup ${WARMUP}) x ${RUNS} run(s)"
+  if [ "${HOOKED}" -eq 1 ]; then
+    echo "- cdylib: ${SO_PATH}"
+  else
+    echo "- cdylib: (skipped; non-Linux baseline only)"
+  fi
+  echo
+} >"${REPORT}"
+
+run_index=1
+while [ "${run_index}" -le "${RUNS}" ]; do
+  run_file="${WORKDIR}/run-${run_index}"
+  : >"${run_file}"
+
+  {
+    echo "## Run ${run_index}"
+    echo
+    echo "| Mode | Unhooked median (ns) | Hooked median (ns) | Delta (ns) | Delta (%) | Unhooked stddev (ns) | Hooked stddev (ns) |"
+    echo "|---|---|---|---|---|---|---|"
+  } >>"${REPORT}"
+
+  for mode in ${MODES}; do
+    base_line="$(run_bench "${mode}" 0)"
+    base_med="$(field "${base_line}" median_ns)"
+    base_std="$(field "${base_line}" stddev_ns)"
+
+    if [ "${HOOKED}" -eq 1 ]; then
+      hook_line="$(run_bench "${mode}" 1)"
+      hook_med="$(field "${hook_line}" median_ns)"
+      hook_std="$(field "${hook_line}" stddev_ns)"
+      delta="$(awk -v h="${hook_med}" -v b="${base_med}" 'BEGIN{printf "%d", h-b}')"
+      pct="$(awk -v h="${hook_med}" -v b="${base_med}" \
+        'BEGIN{ if (b>0) printf "%.1f", (h-b)*100.0/b; else printf "n/a" }')"
+    else
+      hook_med="n/a"
+      hook_std="n/a"
+      delta="n/a"
+      pct="n/a"
+    fi
+
+    printf '| %s | %s | %s | %s | %s | %s | %s |\n' \
+      "${mode}" "${base_med}" "${hook_med}" "${delta}" "${pct}" \
+      "${base_std}" "${hook_std}" >>"${REPORT}"
+    printf '%s %s %s\n' "${mode}" "${base_med}" "${hook_med}" >>"${run_file}"
+  done
+
+  echo >>"${REPORT}"
+  run_index=$((run_index + 1))
+done
+
+# Cross-run stability summary: for each mode, the spread of the hooked median
+# across all runs, as a percentage of the smallest run's median.
+if [ "${HOOKED}" -eq 1 ] && [ "${RUNS}" -ge 2 ]; then
+  {
+    echo "## Cross-run stability (hooked median)"
+    echo
+    echo "| Mode | Min (ns) | Max (ns) | Spread (ns) | Spread (%) |"
+    echo "|---|---|---|---|---|"
+  } >>"${REPORT}"
+
+  all_runs="${WORKDIR}/all-runs"
+  cat "${WORKDIR}"/run-* >"${all_runs}"
+  awk '
+    { m=$1; h=$3
+      if (!(m in seen)) { order[++n]=m; seen[m]=1; min[m]=h; max[m]=h }
+      if (h<min[m]) min[m]=h
+      if (h>max[m]) max[m]=h }
+    END { for (i=1; i<=n; i++) { m=order[i]; s=max[m]-min[m];
+            p=(min[m]>0)?s*100.0/min[m]:0;
+            printf "| %s | %d | %d | %d | %.1f |\n", m, min[m], max[m], s, p } }
+  ' "${all_runs}" >>"${REPORT}"
+  echo >>"${REPORT}"
+fi
+
+cat "${REPORT}"
+if [ -n "${OUTPUT_PATH}" ]; then
+  cp "${REPORT}" "${OUTPUT_PATH}"
+  echo "run-exec-guard-bench: report written to ${OUTPUT_PATH}" >&2
+fi

--- a/scripts/bench/run-exec-guard-bench.sh
+++ b/scripts/bench/run-exec-guard-bench.sh
@@ -72,12 +72,18 @@ field() {
   printf '%s\n' "$1" | sed -n "s/.*[[:space:]]$2=\([0-9]*\).*/\1/p"
 }
 
+# A controlled PATH whose first entry holds the target, so the execvp mode's
+# bare-name launch resolves deterministically (and exercises PATH search) rather
+# than depending on the ambient PATH.
+TARGET_DIR="$(cd "$(dirname "${TARGET}")" && pwd)"
+BENCH_PATH="${TARGET_DIR}:/usr/bin:/bin"
+
 run_bench() {
   # $1 mode, $2 preload flag (0/1)
   if [ "$2" -eq 1 ]; then
-    LD_PRELOAD="${SO_PATH}" "${BIN}" "$1" "${ITERATIONS}" "${WARMUP}" "${TARGET}"
+    PATH="${BENCH_PATH}" LD_PRELOAD="${SO_PATH}" "${BIN}" "$1" "${ITERATIONS}" "${WARMUP}" "${TARGET}"
   else
-    "${BIN}" "$1" "${ITERATIONS}" "${WARMUP}" "${TARGET}"
+    PATH="${BENCH_PATH}" "${BIN}" "$1" "${ITERATIONS}" "${WARMUP}" "${TARGET}"
   fi
 }
 

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -131,6 +131,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/check-public-contract.sh"
   "${ROOT_DIR}/scripts/build-and-test.sh"
   "${ROOT_DIR}/scripts/ci-plan.sh"
+  "${ROOT_DIR}/scripts/bench/run-exec-guard-bench.sh"
   "${ROOT_DIR}/scripts/workcell"
   "${ROOT_DIR}/scripts/check-workflows.sh"
   "${ROOT_DIR}/scripts/ci/build-validator-image.sh"


### PR DESCRIPTION
Implements **C5: Syscall-Shim Performance Baselines**.

## What
A dependency-free C microbenchmark (`scripts/bench/exec-guard-bench.c`) + shell driver (`scripts/bench/run-exec-guard-bench.sh`) that time the exec-guard's **allow path** for the interposed `execve`/`execv`/`execvp`/`posix_spawn` family against a benign target (`/bin/true`), `LD_PRELOAD`-ing the built cdylib vs the unhooked libc baseline. The delta is the guard's per-call classification overhead. Any failed launch aborts with no numbers, so a blocked exec can never masquerade as a measurement.

## Optional lane
`.github/workflows/bench.yml` (workflow_dispatch + weekly schedule, non-PR-blocking) builds the cdylib offline from vendored sources, runs the driver with two full passes (the stability gate), and uploads `exec-guard-bench-results`. Registered in `policy/workflow-lane-policy.json` / `policy/workflow-lanes.json` / `policy/retention-policy.json` (+ docs mirror).

## Numbers
The LD_PRELOAD interposition is **Linux-only**, so the reviewed hooked-vs-unhooked numbers come from the `bench.yml` lane, not a local run. `docs/syscall-shim-benchmarks.md` currently carries **explicit placeholders** ("not measured numbers, do not cite until replaced"); I will dispatch the lane and transcribe the two-run results before this merges.

## Validation
Harness compiles+runs the baseline on darwin (verified); shellcheck/shfmt/bash -n, `check-workflows.sh` (actionlint+zizmor+lane+retention), doc-links, markdownlint, and the Rust crate's `cargo test`/clippy/fmt all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)