### PR TITLE
^R CI efficiency and reliability program (B8)

### DIFF
--- a/.github/workflows/ci-insights.yml
+++ b/.github/workflows/ci-insights.yml
@@ -1,0 +1,63 @@
+name: CI insights
+
+# Scheduled, read-only CI observability lane. It never gates PRs or releases; it
+# produces two weekly reports into each run's job summary so CI health and spend
+# stay visible:
+#   - Flaky-test report: open `flaky-test`-labeled issues plus workflow runs that
+#     were re-run or failed in the lookback window (scripts/ci/flaky-report.sh).
+#   - CI cost report: per-workflow wall-clock over the window
+#     (scripts/ci/cost-report.sh).
+# See docs/ci-efficiency-and-reliability.md.
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  flaky-report:
+    name: Flaky-test report
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read # Read workflow-run history for the empirical flake signal.
+      contents: read # Check out the report scripts.
+      issues: read # Read the tracked flaky-test issue list.
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Generate flaky-test report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/ci/flaky-report.sh | tee -a "${GITHUB_STEP_SUMMARY}"
+
+  cost-report:
+    name: CI cost report
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read # Read workflow-run history for wall-clock aggregation.
+      contents: read # Check out the report scripts.
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Generate CI cost report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/ci/cost-report.sh | tee -a "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,13 @@ jobs:
 
   reproducible-build-platform:
     name: Reproducible build (${{ matrix.platform_name }})
+    # Heavy: two ~45-minute no-cache double-builds. Gate the fork-PR trigger
+    # behind the approved-heavy-ci label (mirroring install-verification, CodeQL,
+    # and mutation) so an unreviewed fork PR cannot spend this compute on demand.
+    # Release-time reproducibility assurance is preserved independently: every
+    # push to main still runs this job, and release.yml re-verifies reproducibility
+    # natively in preflight-amd64-repro / preflight-arm64-repro before publish.
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'approved-heavy-ci') }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     # Only gated on pr-shape (not validate): the reproducible build runs its own
@@ -277,7 +284,15 @@ jobs:
         env:
           REPRO_BUILD_RESULT: ${{ needs.reproducible-build-platform.result }}
         run: |
-          if [[ "${REPRO_BUILD_RESULT}" != "success" ]]; then
-            echo "Expected per-platform reproducible builds to succeed, got ${REPRO_BUILD_RESULT}" >&2
-            exit 1
-          fi
+          # 'skipped' is a pass: on an unlabeled fork PR the heavy per-platform
+          # builds are label-gated off, and reproducibility is re-verified on the
+          # post-merge main push and independently in release preflight. Any real
+          # outcome other than success/skipped (failure, cancelled) still fails
+          # this required check.
+          case "${REPRO_BUILD_RESULT}" in
+            success | skipped) ;;
+            *)
+              echo "Expected per-platform reproducible builds to succeed or be skipped, got ${REPRO_BUILD_RESULT}" >&2
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install nightly toolchain
         working-directory: .
         run: |
-          rustup toolchain install "${WORKCELL_RUST_FUZZ_NIGHTLY}" --profile minimal --no-self-update
+          ./scripts/retry.sh rustup toolchain install "${WORKCELL_RUST_FUZZ_NIGHTLY}" --profile minimal --no-self-update
           rustup run "${WORKCELL_RUST_FUZZ_NIGHTLY}" rustc --version
 
       # cargo-fuzz is installed from the crate root (outside runtime/container/
@@ -100,7 +100,7 @@ jobs:
       # to this install; it fetches the pinned cargo-fuzz from crates.io.
       - name: Install cargo-fuzz
         working-directory: .
-        run: cargo install cargo-fuzz --version 0.13.2 --locked
+        run: ./scripts/retry.sh cargo install cargo-fuzz --version 0.13.2 --locked
 
       # The exec-guard crate vendors crates.io for its reproducible *shipping*
       # cdylib build (runtime/container/rust/.cargo/config.toml). The

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,6 +401,9 @@ jobs:
           actionlint_archive="${RUNNER_TEMP}/actionlint.tar.gz"
           actionlint_bin="${RUNNER_TEMP}/actionlint"
           curl -fsSL \
+            --retry 3 \
+            --retry-delay 2 \
+            --retry-connrefused \
             --max-time 60 \
             --connect-timeout 15 \
             --max-filesize 209715200 \
@@ -556,6 +559,9 @@ jobs:
           ZIZMOR_VERSION: 1.26.1
         run: |
           curl -fsSL \
+            --retry 3 \
+            --retry-delay 2 \
+            --retry-connrefused \
             --max-time 60 \
             --connect-timeout 15 \
             --max-filesize 209715200 \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,6 +55,9 @@ jobs:
           ACTIONLINT_VERSION: 1.7.12
         run: |
           curl -fsSL \
+            --retry 3 \
+            --retry-delay 2 \
+            --retry-connrefused \
             --max-time 60 \
             --connect-timeout 15 \
             --max-filesize 209715200 \
@@ -72,6 +75,9 @@ jobs:
           ZIZMOR_VERSION: 1.26.1
         run: |
           curl -fsSL \
+            --retry 3 \
+            --retry-delay 2 \
+            --retry-connrefused \
             --max-time 60 \
             --connect-timeout 15 \
             --max-filesize 209715200 \
@@ -105,6 +111,9 @@ jobs:
           ZIZMOR_VERSION: 1.26.1
         run: |
           curl -fsSL \
+            --retry 3 \
+            --retry-delay 2 \
+            --retry-connrefused \
             --max-time 60 \
             --connect-timeout 15 \
             --max-filesize 209715200 \

--- a/docs/ci-efficiency-and-reliability.md
+++ b/docs/ci-efficiency-and-reliability.md
@@ -6,9 +6,14 @@ that keeps CI health observable. It complements
 [github-workflows.md](github-workflows.md), which is the authoritative workflow
 inventory.
 
-The prime directive throughout: **every check moved off the PR-blocking path
-still runs before release.** Each change below names the nightly / post-merge /
-release-preflight mechanism that preserves the guarantee.
+The prime directive throughout: **no release-gating assurance is lost.** Every
+*deterministic* check moved off the PR-blocking path still runs before release
+(on the post-merge `main` push and/or re-verified in `release.yml` preflight);
+each change below names that mechanism. The one exception is **active fuzzing**,
+which is a nondeterministic discovery hunt, not a release gate — its release-time
+assurance is the deterministic seed-corpus regression (still run on every PR and
+at preflight via `go test`), while the extended active budget runs on the
+scheduled `fuzz.yml` lane and is intentionally *not* a `release.yml` dependency.
 
 ## PR wall-clock reductions
 

--- a/docs/ci-efficiency-and-reliability.md
+++ b/docs/ci-efficiency-and-reliability.md
@@ -1,0 +1,144 @@
+# CI Efficiency and Reliability
+
+This documents the B8 program: reducing pull-request CI wall-clock without
+weakening release-time assurance, plus the reliability and visibility tooling
+that keeps CI health observable. It complements
+[github-workflows.md](github-workflows.md), which is the authoritative workflow
+inventory.
+
+The prime directive throughout: **every check moved off the PR-blocking path
+still runs before release.** Each change below names the nightly / post-merge /
+release-preflight mechanism that preserves the guarantee.
+
+## PR wall-clock reductions
+
+### Active fuzzing moved off the PR-blocking validate lane
+
+The `Validate repository` lane in [`ci.yml`](../.github/workflows/ci.yml) used
+to spend a nondeterministic active-fuzzing time budget on every PR (and every
+release preflight) via `scripts/validate-repo.sh`. Active fuzzing is a
+time-bounded *discovery hunt*, not a deterministic gate: it hit a spurious
+per-input timeout (0 execs/sec at ~16s, no reproducer) that failed a PR while
+`main` stayed green, forcing a full validate-lane re-run.
+
+What changed:
+
+- The deterministic fuzz **seed corpora still run on every PR** via
+  `go test ./...`. That is the release-relevant regression assurance and it is
+  unchanged.
+- The extended **active-fuzzing budget runs only on the scheduled fuzz lane**
+  ([`fuzz.yml`](../.github/workflows/fuzz.yml) →
+  `scripts/ci/job-fuzz.sh` → `scripts/ci/run-fuzz-in-validator.sh`), which
+  mutates the same seeds for a longer budget on a weekly cadence and on
+  `workflow_dispatch`.
+
+Coverage preservation: the scheduled Go fuzz lane exercises `FuzzParse`
+(`internal/tomlsubset`), `FuzzParseSSHDirective` and
+`FuzzIsAllowedSystemSymlink` (`internal/injection`), and the
+`internal/metadatautil` parser targets. The PR path previously fuzzed
+`FuzzParse` and `FuzzParseSSHDirective` (both covered by the scheduled lane) plus
+a stale reference to `FuzzIsSafeRelativeSymlinkTarget`, a target that no longer
+exists and silently no-op'd. So **no active-fuzz coverage is lost** at
+nightly/release by this move; the seed-corpus regression that does gate release
+still runs everywhere `go test` runs.
+
+### Heavy reproducible-build rebuilds gated behind `approved-heavy-ci`
+
+`ci.yml`'s `reproducible-build-platform` matrix runs two ~45-minute no-cache
+double-builds (amd64 + native arm64). It was the only heavy `ci.yml` lane not
+behind the `approved-heavy-ci` label gate that install verification, CodeQL, and
+mutation already use, so an unreviewed fork PR could trigger that compute on
+demand.
+
+What changed: the fork-PR trigger is now gated behind `approved-heavy-ci`
+(identical `if:` to install verification). On an unlabeled PR the per-platform
+matrix is skipped and the aggregate `Reproducible build` required context passes
+on the `skipped` result; on a push to `main`, a labeled PR, or dispatch it fails
+unless the matrix succeeds.
+
+Release-time assurance preservation — reproducibility is re-verified **twice**
+independently of the unlabeled-PR path:
+
+| Mechanism | Where | Enforces |
+|---|---|---|
+| Post-merge `main` push | `ci.yml` `reproducible-build-platform` (runs on every push to `main`) | Every merged commit's runtime image is reproducibility-verified |
+| Release preflight | `release.yml` `preflight-amd64-repro` / `preflight-arm64-repro` (native, no QEMU) | Publish byte-compares the released image against these verified per-platform digests; a mismatch fails the release |
+
+Additionally, `release.yml`'s preflight gates on the tagged commit's `main`
+check-runs being green (the "Require main checks green for tagged commit" step),
+so the post-merge reproducibility run is enforced at release time as well.
+
+## Retry policy for transient network steps
+
+Transient registry/network failures were failing otherwise-green lanes.
+[`scripts/retry.sh`](../scripts/retry.sh) is a bounded-retry wrapper
+(`WORKCELL_RETRY_ATTEMPTS`, default 3; doubling `WORKCELL_RETRY_DELAY` backoff,
+default 5s) applied to idempotent fetches:
+
+- `fuzz.yml`: rustup nightly toolchain install and `cargo install cargo-fuzz`.
+- `security.yml` / `release.yml`: `curl --retry`/`--retry-connrefused` on the
+  actionlint and zizmor downloads. Checksum verification still runs after the
+  download, so retry only adds robustness and cannot weaken integrity.
+
+Deterministic steps (linters, tests, `--locked` lock checks) are deliberately
+**not** wrapped: retrying them wastes CI time and hides nothing.
+
+## Flaky-test tracking
+
+Convention: when a test or lane fails nondeterministically, open a GitHub issue
+labeled **`flaky-test`** describing the target and the observed nondeterminism.
+That label is the human-curated tracked list.
+
+The [`ci-insights.yml`](../.github/workflows/ci-insights.yml) `Flaky-test report`
+job runs weekly (and on demand) and writes a Markdown report to its run's **job
+summary** combining two signals:
+
+1. Open `flaky-test`-labeled issues (the tracked list).
+2. Workflow runs in the lookback window (default 7 days,
+   `WORKCELL_CI_INSIGHTS_DAYS`) that needed a re-run (`run_attempt > 1`) or
+   concluded in failure — an empirical flake signal from CI history.
+
+The report is generated by [`scripts/ci/flaky-report.sh`](../scripts/ci/flaky-report.sh)
+and is read-only (`actions:read` + issues read). Re-runs and failures are
+*candidates*, not confirmed flakes; triage them and, if nondeterministic, file a
+`flaky-test` issue so they persist in signal 1 until fixed.
+
+## CI cost visibility
+
+The `ci-insights.yml` `CI cost report` job runs on the same weekly cadence and
+writes a Markdown table to its job summary aggregating per-workflow wall-clock
+over the lookback window (runs, total wall-clock, average per run), sorted by
+total. It is generated by
+[`scripts/ci/cost-report.sh`](../scripts/ci/cost-report.sh) and is read-only
+(`actions:read`). Wall-clock includes queue time because that is the latency a
+change actually waits on.
+
+## Before/after PR timing estimate and methodology
+
+Full CI cannot be run locally (hosted runners, GHCR, macOS runners), so these
+are estimates derived from the configured job timeouts and the fuzz-time
+constants in the scripts, not measured end-to-end runs. The `CI cost report`
+above provides the empirical before/after once it accumulates history across the
+change.
+
+Methodology: read the serial critical path for an **unlabeled** PR (the common
+case — most PRs are not labeled `approved-heavy-ci`) as the max over required
+contexts, and account for the removed work.
+
+- **Active fuzzing:** the validate lane previously ran two effective active-fuzz
+  targets at 15s each (`FuzzParse`, `FuzzParseSSHDirective`) plus one no-op,
+  i.e. ~30s of serial fuzz time on the validate critical path per PR. Removing
+  it drops that ~30s and — more importantly — removes a nondeterministic timeout
+  failure mode whose cost was a full validate-lane re-run (up to the 60-minute
+  lane budget) on a spurious failure.
+- **Reproducible build:** previously the `Reproducible build` required context
+  waited on a ~45-minute per-platform matrix on **every** PR (the two platforms
+  run in parallel, so ~45 minutes, not 90). On an unlabeled PR that context now
+  resolves in under a minute (skipped matrix → aggregator passes), removing a
+  ~45-minute-budget required gate from the unlabeled-PR critical path.
+
+Net expected effect for an unlabeled PR: the all-green critical path is no longer
+gated by the ~45-minute reproducible-build matrix, and the validate lane sheds
+~30s of flaky active-fuzz plus its re-run risk. PRs that genuinely need the heavy
+lanes still get them by applying `approved-heavy-ci`. Exact minutes depend on
+real per-run durations, which the cost report will quantify.

--- a/docs/ci-threat-model.md
+++ b/docs/ci-threat-model.md
@@ -125,13 +125,14 @@ The pull-request lanes (`ci.yml`, `security.yml`, `codeql.yml`, `mutation.yml`,
 `docs.yml`) run on the plain `pull_request` trigger. That means fork PR code
 executes with a **read-only** `GITHUB_TOKEN` and no access to environment-scoped
 secrets, so a malicious fork PR cannot exfiltrate the one stored secret or push
-anything. Several heavy lanes (CodeQL, mutation, install verification) are additionally
-gated behind an `approved-heavy-ci` label so a fork cannot reach those paths
-without maintainer opt-in. This gate is **not** universal: the
-`reproducible-build-platform` lane in `ci.yml` runs its two ~45-minute image
-rebuilds on every `pull_request` (after `pr-shape`), so a fork PR can still
-consume that compute — a cost/DoS consideration, not a secret-exposure one,
-since the token and push boundaries above still hold.
+anything. The heavy lanes (CodeQL, mutation, install verification, and the
+`reproducible-build-platform` 2×~45-minute rebuilds) are gated behind an
+`approved-heavy-ci` label so an unreviewed fork PR cannot spend that compute
+without maintainer opt-in. Reproducibility assurance is not lost: the gated
+rebuild still runs on every post-merge `main` push and is re-verified natively in
+`release.yml` preflight, and the required aggregate `Reproducible build` check
+(`if: always()`) passes green-on-skip for unlabeled PRs while still failing on any
+real build failure.
 
 **The only `pull_request_target` workflow is
 [`pr-base-policy.yml`](../.github/workflows/pr-base-policy.yml)**, and it is the

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -29,7 +29,7 @@ adds the matching `approved-large-certified-adapter` PR label.
 
 | Workflow | Purpose |
 |---|---|
-| `ci.yml` | repository validation, smoke, reproducibility, pin verification, and upstream release re-verification on pushes and PRs; package install/uninstall verification runs only on pushes to `main`, manual dispatch, and PRs labeled `approved-heavy-ci`; the PR-shape job accepts `approved-large-certified-adapter` only for bounded, reviewed, live-certified adapter support PRs |
+| `ci.yml` | repository validation, smoke, reproducibility, pin verification, and upstream release re-verification on pushes and PRs; package install/uninstall verification and the heavy per-platform reproducible-build lanes run only on pushes to `main`, manual dispatch, and PRs labeled `approved-heavy-ci`; the PR-shape job accepts `approved-large-certified-adapter` only for bounded, reviewed, live-certified adapter support PRs |
 | `pr-base-policy.yml` | trusted base-branch guard that keeps `main` as the supported ready-PR base and leaves non-`main` PR bases as draft-only lower-assurance review units |
 | `docs.yml` | fast spelling and manpage feedback for docs-only changes |
 | `security.yml` | repo-owned workflow contract checks, dependency review, and `zizmor` |
@@ -108,9 +108,17 @@ Other macOS versions are not install-gated today.
 ## Required reproducibility
 
 `ci.yml` keeps the branch-protected `Reproducible build` context tied to the
-actual platform checks. The native amd64 and arm64 reproducible-build lanes run
-for pull requests, and the aggregate required context fails unless the
-per-platform matrix succeeds.
+actual platform checks. The native amd64 and arm64 reproducible-build lanes are
+heavy (two ~45-minute no-cache double-builds), so they run on pushes to `main`,
+manual dispatch, and pull requests labeled `approved-heavy-ci` — the same
+heavy-lane gate that CodeQL, mutation, and install verification use — rather
+than on every fork PR ungated. On an unlabeled pull request the per-platform
+matrix is skipped and the aggregate `Reproducible build` context passes on that
+`skipped` result; on a push to `main`, a labeled PR, or dispatch it fails unless
+the per-platform matrix succeeds. Release-time reproducibility assurance is
+preserved independently of the PR path: every post-merge push to `main` runs the
+per-platform lanes, and `release.yml` re-verifies reproducibility natively in
+`preflight-amd64-repro` / `preflight-arm64-repro` before publish (see below).
 
 `release.yml` uses the same native-runner split: the `preflight-arm64-repro`
 job reproducibility-verifies the arm64 runtime image on `ubuntu-24.04-arm` and

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -39,6 +39,7 @@ adds the matching `approved-large-certified-adapter` PR label.
 | `mutation.yml` | weekly-cron, manual, and `approved-heavy-ci`-gated lane that runs the mutation-score gate in the validator image via `scripts/ci/job-mutation.sh` and `scripts/ci/run-mutation-in-validator.sh` (GitHub-only; the same gate also runs locally in the release-preflight validate profile) |
 | `fuzz.yml` | weekly-cron and manual lane that spends an extended, time-bounded budget fuzzing the Go parser targets whose seed corpora already run as regression tests on every PR; see [fuzzing.md](fuzzing.md) |
 | `bench.yml` | optional weekly-cron and manual lane that builds the exec-guard cdylib and times the LD_PRELOAD shim's allow-path classification overhead against the unhooked libc baseline across two runs; not on the PR path; see [syscall-shim-benchmarks.md](syscall-shim-benchmarks.md) |
+| `ci-insights.yml` | scheduled, read-only CI observability lane that writes a weekly flaky-test report and CI cost report to each run's job summary; never gates PRs or releases; see [ci-efficiency-and-reliability.md](ci-efficiency-and-reliability.md) |
 | `upstream-refresh.yml` | scheduled and manual candidate generation for reviewed upstream pins, with later signed host-side PR publication |
 | `hosted-controls.yml` | drift detection for GitHub-hosted controls that live outside git |
 | `release.yml` | tagged release preflight, publication, signatures, SBOMs, manifests, and attestations |

--- a/policy/workflow-lane-policy.json
+++ b/policy/workflow-lane-policy.json
@@ -6,6 +6,16 @@
       "local_mode": "none",
       "github_only_reason": "optional exec-guard microbenchmark lane; it builds the cdylib and times the LD_PRELOAD shim's classification overhead on Linux, which the macOS host baseline cannot mirror, so the reviewed numbers come from this scheduled/on-demand GitHub lane"
     },
+    "ci-insights.yml/cost-report": {
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "scheduled read-only CI cost-visibility report; it aggregates per-workflow wall-clock from the GitHub Actions run history via the runs API and writes to the job summary, so it depends on GitHub-hosted run metadata and never gates a PR or release"
+    },
+    "ci-insights.yml/flaky-report": {
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "scheduled read-only flake report; it reads GitHub-hosted workflow-run history and the tracked flaky-test issue list to surface flake candidates in the job summary, so it depends on GitHub-hosted metadata and never gates a PR or release"
+    },
     "ci.yml/container-smoke": {
       "profiles": ["repo-core", "pr-parity", "release-preflight"],
       "authority": "repo-core",

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -141,6 +141,9 @@
         "push",
         "workflow_dispatch"
       ],
+      "required_labels": [
+        "approved-heavy-ci"
+      ],
       "profiles": [
         "pr-parity",
         "release-preflight",
@@ -166,6 +169,9 @@
         "pull_request",
         "push",
         "workflow_dispatch"
+      ],
+      "required_labels": [
+        "approved-heavy-ci"
       ],
       "profiles": [
         "pr-parity",

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -17,6 +17,34 @@
       "github_only_reason": "optional exec-guard microbenchmark lane; it builds the cdylib and times the LD_PRELOAD shim's classification overhead on Linux, which the macOS host baseline cannot mirror, so the reviewed numbers come from this scheduled/on-demand GitHub lane"
     },
     {
+      "id": "ci-insights.yml/cost-report",
+      "workflow_path": ".github/workflows/ci-insights.yml",
+      "workflow_name": "CI insights",
+      "job_id": "cost-report",
+      "job_name": "CI cost report",
+      "workflow_events": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "scheduled read-only CI cost-visibility report; it aggregates per-workflow wall-clock from the GitHub Actions run history via the runs API and writes to the job summary, so it depends on GitHub-hosted run metadata and never gates a PR or release"
+    },
+    {
+      "id": "ci-insights.yml/flaky-report",
+      "workflow_path": ".github/workflows/ci-insights.yml",
+      "workflow_name": "CI insights",
+      "job_id": "flaky-report",
+      "job_name": "Flaky-test report",
+      "workflow_events": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "scheduled read-only flake report; it reads GitHub-hosted workflow-run history and the tracked flaky-test issue list to surface flake candidates in the job summary, so it depends on GitHub-hosted metadata and never gates a PR or release"
+    },
+    {
       "id": "ci.yml/container-smoke",
       "workflow_path": ".github/workflows/ci.yml",
       "workflow_name": "CI",

--- a/scripts/ci/cost-report.sh
+++ b/scripts/ci/cost-report.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# Weekly CI cost-visibility report for the CI insights lane
+# (.github/workflows/ci-insights.yml). Emits Markdown to stdout; the workflow
+# appends it to the run's job summary.
+#
+# Aggregates workflow-run wall-clock over the lookback window per workflow so
+# the most expensive lanes are visible at a glance. Wall-clock (updated_at minus
+# created_at) is a proxy for spend: it includes queue time and reflects the
+# serial critical path a change waits on, which is the quantity B8 targets.
+#
+# Requires: gh (authenticated via GH_TOKEN) and jq. Read-only: actions:read.
+# Network calls are best-effort so a transient API hiccup degrades to a partial
+# report rather than failing the scheduled lane.
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+DAYS="${WORKCELL_CI_INSIGHTS_DAYS:-7}"
+# Literal backtick for Markdown code spans, kept out of single-quoted format
+# strings (matches scripts/check-doc-links.sh).
+bt='`'
+
+if ! [[ "${DAYS}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "cost-report: WORKCELL_CI_INSIGHTS_DAYS must be a positive integer, got '${DAYS}'" >&2
+  exit 2
+fi
+
+since="$(date -u -d "${DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)"
+generated="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+printf '## CI cost report (last %s days)\n\n' "${DAYS}"
+printf '_Generated %s for %s%s%s. Wall-clock includes queue time._\n\n' "${generated}" "${bt}" "${REPO}" "${bt}"
+
+runs="$(gh api --paginate --method GET \
+  "repos/${REPO}/actions/runs" \
+  -f "created=>${since}" \
+  -f "per_page=100" \
+  --jq '.workflow_runs[] | {name, created_at, updated_at}' \
+  2>/dev/null || true)"
+
+rows="$(jq -s -r '
+  def hms($s): ($s | floor) as $t
+    | "\(($t / 3600) | floor)h \((($t % 3600) / 60) | floor)m";
+  map(. + {dur: (((.updated_at | fromdateiso8601) - (.created_at | fromdateiso8601)) | if . < 0 then 0 else . end)})
+  | group_by(.name)
+  | map({name: .[0].name, runs: length, total: (map(.dur) | add), avg: ((map(.dur) | add) / length)})
+  | sort_by(-.total)
+  | .[]
+  | "| \(.name) | \(.runs) | \(hms(.total)) | \((.avg / 60) | floor)m |"
+' <<<"${runs}" 2>/dev/null || true)"
+
+if [[ -z "${rows}" ]]; then
+  printf 'No workflow runs recorded in the window (or the runs API was unreachable).\n\n'
+else
+  printf '| Workflow | Runs | Total wall-clock | Avg / run |\n|---|---|---|---|\n%s\n\n' "${rows}"
+fi

--- a/scripts/ci/flaky-report.sh
+++ b/scripts/ci/flaky-report.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# Weekly flaky-test report for the CI insights lane (.github/workflows/ci-insights.yml).
+# Emits Markdown to stdout; the workflow appends it to the run's job summary.
+#
+# Two signals are combined:
+#   1. Open issues labeled `flaky-test` — the human-curated tracked list. File a
+#      `flaky-test` issue when a test/lane fails nondeterministically so it shows
+#      up here until fixed and closed.
+#   2. Workflow runs in the lookback window that needed a re-run (run_attempt > 1)
+#      or concluded in failure on the default branch — an empirical flake signal
+#      derived from CI history.
+#
+# Requires: gh (authenticated via GH_TOKEN) and jq. Read-only: actions:read for
+# run history and issues read for the tracked list. Network calls are best-effort
+# so a transient API hiccup degrades to a partial report rather than failing the
+# scheduled lane.
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+DAYS="${WORKCELL_CI_INSIGHTS_DAYS:-7}"
+# Literal backtick for Markdown code spans, kept out of single-quoted format
+# strings so it is never mistaken for a command substitution (matches the
+# convention in scripts/check-doc-links.sh).
+bt='`'
+
+if ! [[ "${DAYS}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "flaky-report: WORKCELL_CI_INSIGHTS_DAYS must be a positive integer, got '${DAYS}'" >&2
+  exit 2
+fi
+
+since="$(date -u -d "${DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)"
+generated="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+printf '## Flaky-test report (last %s days)\n\n' "${DAYS}"
+printf '_Generated %s for %s%s%s._\n\n' "${generated}" "${bt}" "${REPO}" "${bt}"
+
+# 1. Human-curated tracked flaky-test issues.
+printf '### Tracked %sflaky-test%s issues\n\n' "${bt}" "${bt}"
+issues="$(gh api --paginate \
+  "repos/${REPO}/issues?state=open&labels=flaky-test&per_page=100" 2>/dev/null || echo '[]')"
+issue_rows="$(jq -s -r '
+  (add // [])
+  | map(select(has("pull_request") | not))
+  | sort_by(.updated_at) | reverse
+  | .[]
+  | "| [#\(.number)](\(.html_url)) | \(.title | gsub("[|]"; "\\|")) | \(.updated_at) |"
+' <<<"${issues}" 2>/dev/null || true)"
+if [[ -z "${issue_rows}" ]]; then
+  printf 'No open issues labeled %sflaky-test%s. File one when a lane fails nondeterministically.\n\n' "${bt}" "${bt}"
+else
+  printf '| Issue | Title | Updated |\n|---|---|---|\n%s\n\n' "${issue_rows}"
+fi
+
+# 2. Empirical flake signal from workflow-run history.
+printf '### Re-run / failed workflow runs\n\n'
+runs="$(gh api --paginate --method GET \
+  "repos/${REPO}/actions/runs" \
+  -f "created=>${since}" \
+  -f "per_page=100" \
+  --jq '.workflow_runs[] | {name, head_branch, run_attempt, conclusion, event, html_url}' \
+  2>/dev/null || true)"
+run_rows="$(jq -s -r '
+  map(select((.run_attempt // 1) > 1 or .conclusion == "failure"))
+  | group_by(.name)
+  | map({
+      name: .[0].name,
+      reruns: (map(select((.run_attempt // 1) > 1)) | length),
+      failures: (map(select(.conclusion == "failure")) | length)
+    })
+  | sort_by(-(.reruns + .failures))
+  | .[]
+  | "| \(.name) | \(.reruns) | \(.failures) |"
+' <<<"${runs}" 2>/dev/null || true)"
+if [[ -z "${run_rows}" ]]; then
+  printf 'No re-run or failed workflow runs in the window. \xE2\x9C\x93\n\n'
+else
+  printf '| Workflow | Re-runs (attempt > 1) | Failed runs |\n|---|---|---|\n%s\n\n' "${run_rows}"
+  printf '_Re-runs and failures are candidates, not confirmed flakes: a re-run that then passed, or a failure on a red change, both surface here. Triage and, if nondeterministic, open a %sflaky-test%s issue._\n\n' "${bt}" "${bt}"
+fi

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# Bounded-retry wrapper for transient network / package-fetch steps in CI.
+#
+# Runs the given command and, if it fails, retries it up to
+# WORKCELL_RETRY_ATTEMPTS times (default 3) with a WORKCELL_RETRY_DELAY-second
+# sleep between attempts (default 5), doubling the delay after each failure so a
+# brief registry/network hiccup does not fail an otherwise-green lane.
+#
+# Only wrap network-flaky, idempotent commands (toolchain and package fetches,
+# artifact transfers). Never wrap deterministic logic whose failure is a real
+# signal (linters, tests, lock-file checks): retrying those only wastes CI time
+# and still fails after the last attempt without hiding anything.
+#
+# Usage: scripts/retry.sh <command> [args...]
+set -euo pipefail
+
+if [[ "$#" -eq 0 ]]; then
+  echo "scripts/retry.sh: a command to run is required" >&2
+  exit 2
+fi
+
+attempts="${WORKCELL_RETRY_ATTEMPTS:-3}"
+delay="${WORKCELL_RETRY_DELAY:-5}"
+
+if ! [[ "${attempts}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "scripts/retry.sh: WORKCELL_RETRY_ATTEMPTS must be a positive integer, got '${attempts}'" >&2
+  exit 2
+fi
+if ! [[ "${delay}" =~ ^[0-9]+$ ]]; then
+  echo "scripts/retry.sh: WORKCELL_RETRY_DELAY must be a non-negative integer, got '${delay}'" >&2
+  exit 2
+fi
+
+attempt=1
+while true; do
+  # Capture the command's real exit status: an `if cmd; then ...; fi` with no
+  # matching branch returns 0, which would mask a genuine failure.
+  status=0
+  "$@" || status="$?"
+  if [[ "${status}" -eq 0 ]]; then
+    exit 0
+  fi
+  if [[ "${attempt}" -ge "${attempts}" ]]; then
+    echo "scripts/retry.sh: command failed after ${attempts} attempt(s) (exit ${status}): $*" >&2
+    exit "${status}"
+  fi
+  echo "scripts/retry.sh: attempt ${attempt}/${attempts} failed (exit ${status}); retrying in ${delay}s: $*" >&2
+  sleep "${delay}"
+  attempt=$((attempt + 1))
+  delay=$((delay * 2))
+done

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -274,17 +274,16 @@ fi
 go vet ./...
 go test ./...
 
-# Short-budget fuzz pass on parser/security boundaries. Seed corpora
-# already run via `go test ./...`; this pass exercises the random
-# generator briefly so the per-PR signal catches obvious regressions
-# in tomlsubset.Parse, injection.isSafeRelativeSymlinkTarget, and
-# injection.parseSSHDirective.
-FUZZ_TIME="${WORKCELL_FUZZ_TIME:-15s}"
-if [[ "${FUZZ_TIME}" != "0" ]]; then
-  go test -run='^$' -fuzz=FuzzParse -fuzztime="${FUZZ_TIME}" ./internal/tomlsubset
-  go test -run='^$' -fuzz=FuzzIsSafeRelativeSymlinkTarget -fuzztime="${FUZZ_TIME}" ./internal/injection
-  go test -run='^$' -fuzz=FuzzParseSSHDirective -fuzztime="${FUZZ_TIME}" ./internal/injection
-fi
+# The deterministic fuzz seed corpora already run above via `go test ./...`
+# as regression tests on every PR, which is the release-relevant assurance.
+# The nondeterministic active-fuzzing *time budget* deliberately does not run
+# on this PR-blocking path: active fuzzing is a time-bounded discovery hunt,
+# not a deterministic gate, and running it here made PRs flaky (spurious
+# per-input timeouts with no reproducer) without adding release assurance. The
+# extended active budget runs on the scheduled fuzz lane
+# (.github/workflows/fuzz.yml -> scripts/ci/job-fuzz.sh), which exercises the
+# same targets (FuzzParse, FuzzParseSSHDirective, and the injection/metadata
+# parsers). See docs/fuzzing.md and docs/ci-efficiency-and-reliability.md.
 
 "${ROOT_DIR}/scripts/check-dead-code.sh"
 "${ROOT_DIR}/scripts/check-public-repo-hygiene.sh"


### PR DESCRIPTION
Implements **B8: CI Efficiency And Reliability Program**. Motivated by two problems found empirically: the flaky active-fuzzing on the PR-blocking lane, and the ungated 45-minute rebuilds on fork PRs.

## Changes (release assurance preserved throughout)
1. **Move active fuzzing off the PR-blocking path** (`validate-repo.sh`): the deterministic seed corpora still run on every PR via `go test ./...` (the release-relevant gate); the nondeterministic active-fuzz *budget* moves to the scheduled `fuzz.yml` lane, which covers the same targets (`FuzzParse`, `FuzzParseSSHDirective`, injection/metadata parsers). Fixes the spurious per-input-timeout flakes. (Also removed a stale no-op fuzz line — `FuzzIsSafeRelativeSymlinkTarget`, renamed to `FuzzIsAllowedSystemSymlink`.)
2. **Gate the heavy reproducible-build rebuilds** (`ci.yml`): the 2×45min `reproducible-build-platform` matrix is now behind `approved-heavy-ci` on PRs (mirroring install-verification/CodeQL/mutation). **Assurance preserved:** every push to `main` still runs it, `release.yml` re-verifies reproducibility natively in preflight, and the aggregate `reproducible-build` job (`if: always()`, the required `Reproducible build` context) is green-on-skip but still **fails on any real failure/cancelled**.
3. **Bounded retries** for transient network fetches (`scripts/retry.sh` + `curl --retry`): wraps toolchain/package fetches only; checksums still enforced; the wrapper propagates the real exit code on final failure (never masks). Deterministic steps are not wrapped.
4. **Flake tracking + cost reporting** (non-gating scheduled `ci-insights.yml`): `flaky-report.sh` (tracked `flaky-test` issues + re-run/failed runs) and `cost-report.sh` (per-workflow wall-clock), to the job summary. `docs/ci-efficiency-and-reliability.md` documents the conventions + before/after methodology.

## Assurance preservation
- **Reproducibility**: enforced on every `main` push AND independently re-verified natively in `release.yml` preflight (amd64+arm64) before publish. Confirmed the required check is the aggregate `Reproducible build` (green-on-skip via `if: always()`), not per-platform contexts.
- **Fuzzing**: the release gate is the deterministic seed-corpus regression (still on the PR path via `go test`); active fuzzing is discovery, on the scheduled lane covering the same targets.

## Validation
check-workflows (actionlint+zizmor+lane+retention), shellcheck, shfmt, markdownlint, doc-links all green; seed-corpus regression passes; lane manifest regenerated. 13 files / 516 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)