### PR TITLE
^f Support-bundle redaction core (G2, 1/3)

### DIFF
--- a/internal/supportbundle/doc.go
+++ b/internal/supportbundle/doc.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package supportbundle implements `workcell support-bundle`, the host-side
+// diagnostics collector (roadmap item G2).
+//
+// It gathers six evidence classes needed to diagnose install, policy, target,
+// provider, and runtime failures:
+//
+//   - install:        launcher presence/path, repo root, host os/arch, version
+//   - policy:         repo policy inventory + user injection-policy presence
+//   - target:         state-root layout, colima profile directories/markers
+//   - providers:      per-provider adapter presence + credential container path
+//   - sessions:       durable session-record summaries (never workspace bodies)
+//   - audit_pointers: audit-log path metadata (path/size/mtime; never content)
+//
+// The bundle is a single deterministic JSON document: struct field order is
+// stable, every slice is sorted, and the only time-varying field
+// (generated_at) is injected through Config so golden tests are hermetic.
+//
+// Redaction is the security core (see redact.go). The collector NEVER reads
+// credential-file contents, workspace files, or log bodies — it records paths,
+// presence, and metadata only. As defense-in-depth every collected string is
+// additionally passed through the secret redactor before it enters the bundle.
+package supportbundle

--- a/internal/supportbundle/redact.go
+++ b/internal/supportbundle/redact.go
@@ -56,6 +56,9 @@ var (
 	awsKeyRe         = regexp.MustCompile(`(?:AKIA|ASIA)[0-9A-Z]{16}`)
 	openaiKeyRe      = regexp.MustCompile(`sk-[A-Za-z0-9_-]{20,}`)
 	googleKeyRe      = regexp.MustCompile(`AIza[0-9A-Za-z_-]{20,}`)
+	// Google OAuth access tokens (ya29.) from Gemini / gcloud ADC flows; the repo
+	// classifies these as credentials in metadatautil.credentialPatterns.
+	googleOAuthRe = regexp.MustCompile(`ya29\.[0-9A-Za-z_-]+`)
 )
 
 type secretReplacer struct {
@@ -75,6 +78,7 @@ var secretReplacers = []secretReplacer{
 	{awsKeyRe, "[REDACTED-TOKEN]"},
 	{openaiKeyRe, "[REDACTED-TOKEN]"},
 	{googleKeyRe, "[REDACTED-TOKEN]"},
+	{googleOAuthRe, "[REDACTED-TOKEN]"},
 	{jwtRe, "[REDACTED-JWT]"},
 }
 

--- a/internal/supportbundle/redact.go
+++ b/internal/supportbundle/redact.go
@@ -40,7 +40,11 @@ var (
 	// keyValueSecretRe masks the value after a secret-named key. The key name
 	// must strongly indicate a secret; bare "auth" is intentionally excluded
 	// so diagnostic fields like auth_status stay legible.
-	keyValueSecretRe = regexp.MustCompile(`(?i)((?:password|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|session[_-]?key|credential)"?\s*[:=]\s*)("?)([^\s"',]+)`)
+	// The value alternates over a double-quoted string (which may contain
+	// spaces), a single-quoted string, or a bare unquoted token, so quoted
+	// passphrases like password="two words" or password='hunter2' are masked as
+	// a whole rather than partially or skipped.
+	keyValueSecretRe = regexp.MustCompile(`(?i)((?:password|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|session[_-]?key|credential)"?\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s"',]+)`)
 	jwtRe            = regexp.MustCompile(`eyJ[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]*`)
 	githubTokenRe    = regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,255}`)
 	githubPatRe      = regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,255}`)
@@ -92,7 +96,7 @@ func (r Redactor) String(s string) string {
 		s = strings.ReplaceAll(s, r.Home, "~")
 	}
 	// Secret-named key=value first so the whole value is masked as a unit.
-	s = keyValueSecretRe.ReplaceAllString(s, `${1}${2}[REDACTED]`)
+	s = keyValueSecretRe.ReplaceAllString(s, `${1}[REDACTED]`)
 	for _, sr := range secretReplacers {
 		s = sr.re.ReplaceAllString(s, sr.repl)
 	}

--- a/internal/supportbundle/redact.go
+++ b/internal/supportbundle/redact.go
@@ -52,7 +52,7 @@ var (
 	jwtRe            = regexp.MustCompile(`eyJ[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]*`)
 	githubTokenRe    = regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,255}`)
 	githubPatRe      = regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,255}`)
-	slackTokenRe     = regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`)
+	slackTokenRe     = regexp.MustCompile(`(?:xox[baprs]|xapp)-[A-Za-z0-9-]{10,}`)
 	awsKeyRe         = regexp.MustCompile(`(?:AKIA|ASIA)[0-9A-Z]{16}`)
 	openaiKeyRe      = regexp.MustCompile(`sk-[A-Za-z0-9_-]{20,}`)
 	googleKeyRe      = regexp.MustCompile(`AIza[0-9A-Za-z_-]{20,}`)
@@ -64,8 +64,10 @@ type secretReplacer struct {
 }
 
 // secretReplacers with a static replacement string (no capture groups).
+// pemPrivateKeyRe is NOT here: it runs before the key=value rule in String()
+// because a PEM block spans spaces/newlines that the key=value value group would
+// otherwise truncate.
 var secretReplacers = []secretReplacer{
-	{pemPrivateKeyRe, "[REDACTED-PRIVATE-KEY]"},
 	{bearerRe, "Bearer [REDACTED]"},
 	{githubTokenRe, "[REDACTED-TOKEN]"},
 	{githubPatRe, "[REDACTED-TOKEN]"},
@@ -99,7 +101,11 @@ func (r Redactor) String(s string) string {
 	if r.Home != "" {
 		s = strings.ReplaceAll(s, r.Home, "~")
 	}
-	// Secret-named key=value first so the whole value is masked as a unit.
+	// PEM private-key blocks first: they span spaces and newlines, so the
+	// key=value rule below would truncate the header (e.g. private_key=-----BEGIN
+	// ...) and defeat pemPrivateKeyRe if it ran afterward.
+	s = pemPrivateKeyRe.ReplaceAllString(s, "[REDACTED-PRIVATE-KEY]")
+	// Secret-named key=value next so the whole value is masked as a unit.
 	s = keyValueSecretRe.ReplaceAllString(s, `${1}[REDACTED]`)
 	for _, sr := range secretReplacers {
 		s = sr.re.ReplaceAllString(s, sr.repl)

--- a/internal/supportbundle/redact.go
+++ b/internal/supportbundle/redact.go
@@ -48,11 +48,11 @@ var (
 	// diagnostic fields stay legible.
 	// Values: a double- or single-quoted string (honoring backslash escapes, so
 	// password="abc\"def" is masked whole) or a bare unquoted token.
-	keyValueSecretRe = regexp.MustCompile(`(?i)((?:[a-z0-9_.-]*(?:password|passwd|passphrase|secret|token|credential)[a-z0-9_.-]*|(?:api|access|private|session)[_-]?key)"?\s*[:=]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s"',]+)`)
+	keyValueSecretRe = regexp.MustCompile(`(?i)((?:[a-z0-9_.-]*(?:password|passwd|passphrase|secret|token|credential)[a-z0-9_.-]*|(?:api|access|private|session)[_-]?key)\\?"?\s*[:=]\s*)(\\"(?:\\.|[^"\\])*\\"|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s"',]+)`)
 	jwtRe            = regexp.MustCompile(`eyJ[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]*`)
 	githubTokenRe    = regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,255}`)
 	githubPatRe      = regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,255}`)
-	slackTokenRe     = regexp.MustCompile(`(?:xox[baprs]|xapp)-[A-Za-z0-9-]{10,}`)
+	slackTokenRe     = regexp.MustCompile(`(?:(?:xox[baprs]|xapp|xwfp)-|xoxe[.-])[A-Za-z0-9._-]{10,}`)
 	awsKeyRe         = regexp.MustCompile(`(?:AKIA|ASIA)[0-9A-Z]{16}`)
 	openaiKeyRe      = regexp.MustCompile(`sk-[A-Za-z0-9_-]{20,}`)
 	googleKeyRe      = regexp.MustCompile(`AIza[0-9A-Za-z_-]{20,}`)

--- a/internal/supportbundle/redact.go
+++ b/internal/supportbundle/redact.go
@@ -48,7 +48,7 @@ var (
 	// diagnostic fields stay legible.
 	// Values: a double- or single-quoted string (honoring backslash escapes, so
 	// password="abc\"def" is masked whole) or a bare unquoted token.
-	keyValueSecretRe = regexp.MustCompile(`(?i)((?:[a-z0-9_.-]*(?:password|passwd|passphrase|secret|token|credential)[a-z0-9_.-]*|(?:api|access|private|session)[_-]?key)\\?"?\s*[:=]\s*)(\\"(?:\\.|[^"\\])*\\"|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s"',]+)`)
+	keyValueSecretRe = regexp.MustCompile(`(?i)((?:[a-z0-9_.-]*(?:password|passwd|passphrase|secret|token|credential)[a-z0-9_.-]*|(?:api|access|private|session)[_-]?key)\\?['"]?\s*[:=]\s*)(\\"(?:\\.|[^"\\])*\\"|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s"',]+)`)
 	jwtRe            = regexp.MustCompile(`eyJ[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]*`)
 	githubTokenRe    = regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,255}`)
 	githubPatRe      = regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,255}`)
@@ -104,13 +104,24 @@ func NewRedactor(home string) Redactor {
 		// Boundary = a path separator, end-of-string, or a delimiter that cannot
 		// continue a filename (whitespace/quote/structural punctuation). "." "-"
 		// "_" and alphanumerics are excluded because they can extend a component.
-		r.homeRe = regexp.MustCompile(regexp.QuoteMeta(home) + `(/|[\s"':;,=)\]}]|$)`)
+		r.homeRe = regexp.MustCompile(regexp.QuoteMeta(home) + `(/|[\s"':;,=)\]}\\]|$)`)
 	}
 	return r
 }
 
 // String applies the full redaction pipeline: home rewrite, then the
 // secret-named key=value rule, then every single-token pattern.
+//
+// This pattern masking is DEFENSE IN DEPTH, not the primary guarantee. The
+// support bundle's primary protection is collect-by-construction: it never reads
+// credential-file contents, workspace files, or log bodies — only structured,
+// enumerated metadata (paths, presence, sizes, enums) — so secrets do not enter
+// the bundle to begin with (see the collector and redactionRules). The patterns
+// here backstop the few free-form strings that remain (paths, error text). They
+// cover the common secret formats and quoting/escaping forms, but a regex over
+// arbitrarily-escaped free-form text cannot be exhaustive; do not rely on this
+// layer alone for a field that could carry adversarially-encoded secrets — keep
+// such a field out of the bundle at the collector instead.
 func (r Redactor) String(s string) string {
 	if s == "" {
 		return s

--- a/internal/supportbundle/redact.go
+++ b/internal/supportbundle/redact.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package supportbundle
+
+import (
+	"regexp"
+	"strings"
+)
+
+// RedactionPolicyVersion versions the documented redaction rule-set. Bump it
+// whenever a rule in redactionRules (or the patterns below) changes so a bundle
+// self-describes the guarantees it was produced under.
+const RedactionPolicyVersion = "1"
+
+// redactionRules is the human-readable rule-set embedded in every bundle and
+// mirrored in SUPPORT.md. Each string is one guarantee the collector upholds.
+var redactionRules = []string{
+	"credential file contents are never read; only path, presence, and size/mtime metadata are recorded",
+	"workspace and agent output are never collected; log bodies are referenced by pointer only",
+	"token, key, password, secret, and credential material is masked by pattern (JWT, GitHub/OpenAI/Google/AWS/Slack tokens, PEM private keys, Bearer headers) and by secret-named key=value pairs",
+	"the operator home-directory prefix is rewritten to ~ so the local username never leaks through paths",
+	"only structured, enumerated diagnostic fields are emitted; no raw environment dumps or command output blobs",
+}
+
+// RedactionRules returns a copy of the documented redaction rule-set.
+func RedactionRules() []string {
+	out := make([]string, len(redactionRules))
+	copy(out, redactionRules)
+	return out
+}
+
+// The token/secret patterns. Order in secretReplacers is load-bearing: the
+// multi-line PEM block and the secret-named key=value rule run before the
+// single-token formats so a `token=ghp_...` value is masked as a unit and the
+// residue never re-matches a narrower rule.
+var (
+	pemPrivateKeyRe = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`)
+	bearerRe        = regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._~+/-]+=*`)
+	// keyValueSecretRe masks the value after a secret-named key. The key name
+	// must strongly indicate a secret; bare "auth" is intentionally excluded
+	// so diagnostic fields like auth_status stay legible.
+	keyValueSecretRe = regexp.MustCompile(`(?i)((?:password|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|session[_-]?key|credential)"?\s*[:=]\s*)("?)([^\s"',]+)`)
+	jwtRe            = regexp.MustCompile(`eyJ[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]*`)
+	githubTokenRe    = regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,255}`)
+	githubPatRe      = regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,255}`)
+	slackTokenRe     = regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`)
+	awsKeyRe         = regexp.MustCompile(`(?:AKIA|ASIA)[0-9A-Z]{16}`)
+	openaiKeyRe      = regexp.MustCompile(`sk-[A-Za-z0-9_-]{20,}`)
+	googleKeyRe      = regexp.MustCompile(`AIza[0-9A-Za-z_-]{20,}`)
+)
+
+type secretReplacer struct {
+	re   *regexp.Regexp
+	repl string
+}
+
+// secretReplacers with a static replacement string (no capture groups).
+var secretReplacers = []secretReplacer{
+	{pemPrivateKeyRe, "[REDACTED-PRIVATE-KEY]"},
+	{bearerRe, "Bearer [REDACTED]"},
+	{githubTokenRe, "[REDACTED-TOKEN]"},
+	{githubPatRe, "[REDACTED-TOKEN]"},
+	{slackTokenRe, "[REDACTED-TOKEN]"},
+	{awsKeyRe, "[REDACTED-TOKEN]"},
+	{openaiKeyRe, "[REDACTED-TOKEN]"},
+	{googleKeyRe, "[REDACTED-TOKEN]"},
+	{jwtRe, "[REDACTED-JWT]"},
+}
+
+// Redactor rewrites home-directory prefixes and masks secret material. A zero
+// Redactor (empty home) still masks every secret pattern; only the home
+// rewrite is skipped when Home is empty.
+type Redactor struct {
+	// Home is the absolute operator home directory; every occurrence is
+	// rewritten to "~" before secret masking runs.
+	Home string
+}
+
+// NewRedactor returns a Redactor rooted at home.
+func NewRedactor(home string) Redactor {
+	return Redactor{Home: strings.TrimRight(home, "/")}
+}
+
+// String applies the full redaction pipeline: home rewrite, then the
+// secret-named key=value rule, then every single-token pattern.
+func (r Redactor) String(s string) string {
+	if s == "" {
+		return s
+	}
+	if r.Home != "" {
+		s = strings.ReplaceAll(s, r.Home, "~")
+	}
+	// Secret-named key=value first so the whole value is masked as a unit.
+	s = keyValueSecretRe.ReplaceAllString(s, `${1}${2}[REDACTED]`)
+	for _, sr := range secretReplacers {
+		s = sr.re.ReplaceAllString(s, sr.repl)
+	}
+	return s
+}
+
+// Strings redacts each element of in, returning a new slice.
+func (r Redactor) Strings(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = r.String(s)
+	}
+	return out
+}

--- a/internal/supportbundle/redact.go
+++ b/internal/supportbundle/redact.go
@@ -40,11 +40,15 @@ var (
 	// keyValueSecretRe masks the value after a secret-named key. The key name
 	// must strongly indicate a secret; bare "auth" is intentionally excluded
 	// so diagnostic fields like auth_status stay legible.
-	// The value alternates over a double-quoted string (which may contain
-	// spaces), a single-quoted string, or a bare unquoted token, so quoted
-	// passphrases like password="two words" or password='hunter2' are masked as
-	// a whole rather than partially or skipped.
-	keyValueSecretRe = regexp.MustCompile(`(?i)((?:password|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|session[_-]?key|credential)"?\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s"',]+)`)
+	// Key names: the secret-bearing stems (password/secret/token/credential/
+	// passphrase) may appear anywhere in the identifier, so compound names like
+	// secret_key, SECRET_KEY_BASE, or app_password_field match; plus the explicit
+	// *_key forms whose stem is not itself secret-named. Bare "auth" and generic
+	// "*_key" (e.g. public_key, cache_key) are deliberately excluded so
+	// diagnostic fields stay legible.
+	// Values: a double- or single-quoted string (honoring backslash escapes, so
+	// password="abc\"def" is masked whole) or a bare unquoted token.
+	keyValueSecretRe = regexp.MustCompile(`(?i)((?:[a-z0-9_.-]*(?:password|passwd|passphrase|secret|token|credential)[a-z0-9_.-]*|(?:api|access|private|session)[_-]?key)"?\s*[:=]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s"',]+)`)
 	jwtRe            = regexp.MustCompile(`eyJ[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]*`)
 	githubTokenRe    = regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,255}`)
 	githubPatRe      = regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,255}`)

--- a/internal/supportbundle/redact.go
+++ b/internal/supportbundle/redact.go
@@ -86,14 +86,27 @@ var secretReplacers = []secretReplacer{
 // Redactor (empty home) still masks every secret pattern; only the home
 // rewrite is skipped when Home is empty.
 type Redactor struct {
-	// Home is the absolute operator home directory; every occurrence is
-	// rewritten to "~" before secret masking runs.
+	// Home is the absolute operator home directory; each occurrence at a path
+	// boundary is rewritten to "~" before secret masking runs.
 	Home string
+	// homeRe matches Home only at a component boundary (followed by a path
+	// separator, end-of-string, or a non-path delimiter) so a home that is a
+	// string prefix of a longer component (Home=/Users/al vs /Users/alice) is
+	// not corrupted into ~ice. nil when Home is empty.
+	homeRe *regexp.Regexp
 }
 
 // NewRedactor returns a Redactor rooted at home.
 func NewRedactor(home string) Redactor {
-	return Redactor{Home: strings.TrimRight(home, "/")}
+	home = strings.TrimRight(home, "/")
+	r := Redactor{Home: home}
+	if home != "" {
+		// Boundary = a path separator, end-of-string, or a delimiter that cannot
+		// continue a filename (whitespace/quote/structural punctuation). "." "-"
+		// "_" and alphanumerics are excluded because they can extend a component.
+		r.homeRe = regexp.MustCompile(regexp.QuoteMeta(home) + `(/|[\s"':;,=)\]}]|$)`)
+	}
+	return r
 }
 
 // String applies the full redaction pipeline: home rewrite, then the
@@ -102,8 +115,8 @@ func (r Redactor) String(s string) string {
 	if s == "" {
 		return s
 	}
-	if r.Home != "" {
-		s = strings.ReplaceAll(s, r.Home, "~")
+	if r.homeRe != nil {
+		s = r.homeRe.ReplaceAllString(s, "~$1")
 	}
 	// PEM private-key blocks first: they span spaces and newlines, so the
 	// key=value rule below would truncate the header (e.g. private_key=-----BEGIN

--- a/internal/supportbundle/redact_test.go
+++ b/internal/supportbundle/redact_test.go
@@ -26,6 +26,7 @@ var knownSecrets = []struct {
 	{"aws access key", "AKIA" + "IOSFODNN7EXAMPLE"},
 	{"aws session key", "ASIA" + "IOSFODNN7EXAMPLE"},
 	{"slack token", "xoxb-" + "1234567890-abcdefghijklmnop"},
+	{"slack app token", "xapp-" + "1-A012B345C-6789012345-abcdef0123456789"},
 	{"jwt", "eyJhbGciOiJIUzI1NiJ9." + "eyJzdWIiOiIxMjM0NSJ9.abcDEF-_1234567890xyz"},
 }
 
@@ -58,6 +59,21 @@ func TestRedactorMasksPEMPrivateKey(t *testing.T) {
 	}
 	if !strings.Contains(out, "[REDACTED-PRIVATE-KEY]") {
 		t.Fatalf("expected private-key marker, got %q", out)
+	}
+}
+
+// TestRedactorMasksPEMInSecretAssignment guards the ordering fix: a PEM block as
+// the value of a secret-named key must be redacted whole, not truncated at the
+// first space by the key=value rule (which would leave the key body/trailer).
+func TestRedactorMasksPEMInSecretAssignment(t *testing.T) {
+	r := NewRedactor("")
+	pem := "-----BEGIN RSA PRIVATE KEY-----\n" + "MIIEpAIBAAKCAQEA0secretkeymaterial\n" + "-----END RSA PRIVATE KEY-----"
+	out := r.String("private_key=" + pem)
+	if strings.Contains(out, "secretkeymaterial") || strings.Contains(out, "PRIVATE KEY") {
+		t.Fatalf("PEM body leaked from secret assignment: %q", out)
+	}
+	if !strings.Contains(out, "[REDACTED") {
+		t.Fatalf("expected redaction marker, got %q", out)
 	}
 }
 

--- a/internal/supportbundle/redact_test.go
+++ b/internal/supportbundle/redact_test.go
@@ -118,6 +118,9 @@ func TestRedactorMasksSecretNamedKeyValues(t *testing.T) {
 		// shell/JSON-escaped OUTER quotes on the value and the key.
 		{`password=\"escapedvalsecret\"`, []string{"escapedvalsecret"}},
 		{`{\"password\":\"jsonescsecret\"}`, []string{"jsonescsecret"}},
+		// single-quoted mapping keys (Python/YAML-ish dumps).
+		{`{'password':'singlequotekeysecret'}`, []string{"singlequotekeysecret"}},
+		{`'api_key': 'singlequoteapisecret'`, []string{"singlequoteapisecret"}},
 	}
 	for _, tc := range cases {
 		out := r.String(tc.in)
@@ -173,12 +176,13 @@ func TestRedactorHomeTrailingSlashNormalized(t *testing.T) {
 func TestRedactorHomePrefixBoundary(t *testing.T) {
 	r := NewRedactor("/Users/al")
 	cases := map[string]string{
-		"/Users/alice/.colima/x": "/Users/alice/.colima/x", // different user: untouched
-		"/Users/al/.colima/x":    "~/.colima/x",            // exact home + separator
-		"/Users/al":              "~",                      // exact home at end
-		"cwd=/Users/al done":     "cwd=~ done",             // home at a whitespace boundary
-		`"/Users/al"`:            `"~"`,                    // home at a quote boundary
-		"/Users/al.config":       "/Users/al.config",       // "." can continue a component: untouched
+		"/Users/alice/.colima/x":   "/Users/alice/.colima/x", // different user: untouched
+		"/Users/al/.colima/x":      "~/.colima/x",            // exact home + separator
+		"/Users/al":                "~",                      // exact home at end
+		"cwd=/Users/al done":       "cwd=~ done",             // home at a whitespace boundary
+		`"/Users/al"`:              `"~"`,                    // home at a quote boundary
+		"/Users/al.config":         "/Users/al.config",       // "." can continue a component: untouched
+		`{\"home\":\"/Users/al\"}`: `{\"home\":\"~\"}`,       // exact home before an escaped quote
 	}
 	for in, want := range cases {
 		if got := r.String(in); got != want {

--- a/internal/supportbundle/redact_test.go
+++ b/internal/supportbundle/redact_test.go
@@ -74,20 +74,30 @@ func TestRedactorMasksBearer(t *testing.T) {
 
 func TestRedactorMasksSecretNamedKeyValues(t *testing.T) {
 	r := NewRedactor("")
-	cases := []string{
-		"password=hunter2trailing",
-		"api_key: myplaintextapikeyvalue",
-		"client_secret = s3cr3tvalueforclient",
-		`"session_key":"abcdef012345sessionvalue"`,
+	// Each case pairs an input with the sensitive fragments that must not survive.
+	// The single-quoted and spaced double-quoted forms are regressions for a
+	// value group that previously skipped quoted values or masked only the first
+	// word of a quoted passphrase.
+	cases := []struct {
+		in    string
+		leaks []string
+	}{
+		{"password=hunter2trailing", []string{"hunter2trailing"}},
+		{"api_key: myplaintextapikeyvalue", []string{"myplaintextapikeyvalue"}},
+		{"client_secret = s3cr3tvalueforclient", []string{"s3cr3tvalueforclient"}},
+		{`"session_key":"abcdef012345sessionvalue"`, []string{"abcdef012345sessionvalue"}},
+		{"password='hunter2single'", []string{"hunter2single"}},
+		{`password="two words here"`, []string{"two words here", "words here", "words"}},
+		{"token='multi word secret'", []string{"multi word secret", "word secret", "secret"}},
 	}
-	for _, in := range cases {
-		out := r.String(in)
+	for _, tc := range cases {
+		out := r.String(tc.in)
 		if !strings.Contains(out, "[REDACTED]") {
-			t.Fatalf("expected redaction of %q, got %q", in, out)
+			t.Fatalf("expected redaction of %q, got %q", tc.in, out)
 		}
-		for _, leak := range []string{"hunter2trailing", "myplaintextapikeyvalue", "s3cr3tvalueforclient", "abcdef012345sessionvalue"} {
+		for _, leak := range tc.leaks {
 			if strings.Contains(out, leak) {
-				t.Fatalf("secret value leaked from %q: %q", in, out)
+				t.Fatalf("secret value leaked from %q: %q", tc.in, out)
 			}
 		}
 	}

--- a/internal/supportbundle/redact_test.go
+++ b/internal/supportbundle/redact_test.go
@@ -27,6 +27,8 @@ var knownSecrets = []struct {
 	{"aws session key", "ASIA" + "IOSFODNN7EXAMPLE"},
 	{"slack token", "xoxb-" + "1234567890-abcdefghijklmnop"},
 	{"slack app token", "xapp-" + "1-A012B345C-6789012345-abcdef0123456789"},
+	{"slack workflow token", "xwfp-" + "0123456789.abcdef0123456789"},
+	{"slack rotation token", "xoxe." + "xoxp-1-0123456789abcdef0123456789"},
 	{"jwt", "eyJhbGciOiJIUzI1NiJ9." + "eyJzdWIiOiIxMjM0NSJ9.abcDEF-_1234567890xyz"},
 }
 
@@ -112,6 +114,9 @@ func TestRedactorMasksSecretNamedKeyValues(t *testing.T) {
 		{"refresh_token=refreshsecretvalue", []string{"refreshsecretvalue"}},
 		// escaped quote inside a quoted value must not leak the suffix.
 		{`password="abc\"defsecret"`, []string{"defsecret", `abc\"defsecret`}},
+		// shell/JSON-escaped OUTER quotes on the value and the key.
+		{`password=\"escapedvalsecret\"`, []string{"escapedvalsecret"}},
+		{`{\"password\":\"jsonescsecret\"}`, []string{"jsonescsecret"}},
 	}
 	for _, tc := range cases {
 		out := r.String(tc.in)

--- a/internal/supportbundle/redact_test.go
+++ b/internal/supportbundle/redact_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package supportbundle
+
+import (
+	"strings"
+	"testing"
+)
+
+// knownSecrets are representative live-credential shapes. Every redaction path
+// in the package is proven against this table so a regression that lets any
+// one through fails a test rather than shipping a leak.
+var knownSecrets = []struct {
+	name   string
+	secret string
+}{
+	// Each fixture is assembled from fragments so the full token shape never
+	// appears as a literal in source (GitHub push protection scans committed
+	// literals); the concatenated runtime value still exercises each pattern.
+	{"github classic token", "ghp_" + "0123456789abcdefghijklmnopqrstuvwx"},
+	{"github oauth token", "gho_" + "0123456789abcdefghijklmnopqrstuvwx"},
+	{"github pat", "github_pat_" + "11ABCDEFG0abcdefghijkl_mnopqrstuvwxyz0123456789ABCDEFGHIJ"},
+	{"openai key", "sk-" + "proj-abcdefghijklmnopqrstuvwxyz0123456789ABCD"},
+	{"google api key", "AIza" + "SyA1234567890abcdefghijklmnopqrstuv"},
+	{"aws access key", "AKIA" + "IOSFODNN7EXAMPLE"},
+	{"aws session key", "ASIA" + "IOSFODNN7EXAMPLE"},
+	{"slack token", "xoxb-" + "1234567890-abcdefghijklmnop"},
+	{"jwt", "eyJhbGciOiJIUzI1NiJ9." + "eyJzdWIiOiIxMjM0NSJ9.abcDEF-_1234567890xyz"},
+}
+
+func TestRedactorMasksKnownSecrets(t *testing.T) {
+	r := NewRedactor("/Users/operator")
+	for _, tc := range knownSecrets {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, wrapper := range []string{
+				"%s",
+				"value is %s here",
+				"token=%s",
+				`{"credential":"%s"}`,
+			} {
+				in := strings.Replace(wrapper, "%s", tc.secret, 1)
+				out := r.String(in)
+				if strings.Contains(out, tc.secret) {
+					t.Fatalf("secret leaked: input %q produced %q", in, out)
+				}
+			}
+		})
+	}
+}
+
+func TestRedactorMasksPEMPrivateKey(t *testing.T) {
+	r := NewRedactor("")
+	pem := "-----BEGIN RSA PRIVATE KEY-----\n" + "MIIEpAIBAAKCAQEA0secretkeymaterial\n" + "-----END RSA PRIVATE KEY-----"
+	out := r.String("here is a key " + pem + " trailing")
+	if strings.Contains(out, "secretkeymaterial") {
+		t.Fatalf("private key material leaked: %q", out)
+	}
+	if !strings.Contains(out, "[REDACTED-PRIVATE-KEY]") {
+		t.Fatalf("expected private-key marker, got %q", out)
+	}
+}
+
+func TestRedactorMasksBearer(t *testing.T) {
+	r := NewRedactor("")
+	out := r.String("Authorization: Bearer abc.DEF-secret_token123")
+	if strings.Contains(out, "secret_token123") {
+		t.Fatalf("bearer token leaked: %q", out)
+	}
+	if !strings.Contains(out, "Bearer [REDACTED]") {
+		t.Fatalf("expected bearer marker, got %q", out)
+	}
+}
+
+func TestRedactorMasksSecretNamedKeyValues(t *testing.T) {
+	r := NewRedactor("")
+	cases := []string{
+		"password=hunter2trailing",
+		"api_key: myplaintextapikeyvalue",
+		"client_secret = s3cr3tvalueforclient",
+		`"session_key":"abcdef012345sessionvalue"`,
+	}
+	for _, in := range cases {
+		out := r.String(in)
+		if !strings.Contains(out, "[REDACTED]") {
+			t.Fatalf("expected redaction of %q, got %q", in, out)
+		}
+		for _, leak := range []string{"hunter2trailing", "myplaintextapikeyvalue", "s3cr3tvalueforclient", "abcdef012345sessionvalue"} {
+			if strings.Contains(out, leak) {
+				t.Fatalf("secret value leaked from %q: %q", in, out)
+			}
+		}
+	}
+}
+
+func TestRedactorRewritesHome(t *testing.T) {
+	r := NewRedactor("/Users/operator")
+	out := r.String("/Users/operator/.local/state/workcell/x")
+	if strings.Contains(out, "operator") {
+		t.Fatalf("home username leaked: %q", out)
+	}
+	if out != "~/.local/state/workcell/x" {
+		t.Fatalf("home rewrite = %q, want ~/.local/state/workcell/x", out)
+	}
+}
+
+func TestRedactorHomeTrailingSlashNormalized(t *testing.T) {
+	r := NewRedactor("/Users/operator/")
+	if got := r.String("/Users/operator/x"); got != "~/x" {
+		t.Fatalf("home rewrite with trailing slash = %q, want ~/x", got)
+	}
+}
+
+// TestRedactorPreservesDiagnosticText guards against over-redaction: fields
+// that matter for diagnosis (sha digests, enum values, ordinary paths) must
+// survive so the bundle stays useful.
+func TestRedactorPreservesDiagnosticText(t *testing.T) {
+	r := NewRedactor("/Users/operator")
+	keep := []string{
+		"sha256:3b1c9e0f2a4d5b6c7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d",
+		"auth_status=none",
+		"colima",
+		"target_kind=vm",
+		"~/.colima/wcl-strict",
+	}
+	for _, in := range keep {
+		if got := r.String(in); got != in {
+			t.Fatalf("diagnostic text over-redacted: %q became %q", in, got)
+		}
+	}
+}
+
+func TestRedactorEmptyString(t *testing.T) {
+	if got := NewRedactor("/Users/operator").String(""); got != "" {
+		t.Fatalf("empty string became %q", got)
+	}
+}
+
+func TestRedactorStrings(t *testing.T) {
+	r := NewRedactor("/Users/operator")
+	in := []string{"/Users/operator/x", "ghp_" + "0123456789abcdefghijklmnopqrstuvwx"}
+	out := r.Strings(in)
+	if out[0] != "~/x" {
+		t.Fatalf("Strings[0] = %q", out[0])
+	}
+	if strings.Contains(out[1], "ghp_") {
+		t.Fatalf("Strings did not redact token: %q", out[1])
+	}
+	if r.Strings(nil) != nil {
+		t.Fatalf("Strings(nil) should be nil")
+	}
+}

--- a/internal/supportbundle/redact_test.go
+++ b/internal/supportbundle/redact_test.go
@@ -89,6 +89,13 @@ func TestRedactorMasksSecretNamedKeyValues(t *testing.T) {
 		{"password='hunter2single'", []string{"hunter2single"}},
 		{`password="two words here"`, []string{"two words here", "words here", "words"}},
 		{"token='multi word secret'", []string{"multi word secret", "word secret", "secret"}},
+		// secret-bearing stem anywhere in the key name (common env/config fields).
+		{"secret_key=plainsecretvalue", []string{"plainsecretvalue"}},
+		{"SECRET_KEY_BASE=basesecretvalue", []string{"basesecretvalue"}},
+		{"app_password_field: fieldsecretvalue", []string{"fieldsecretvalue"}},
+		{"refresh_token=refreshsecretvalue", []string{"refreshsecretvalue"}},
+		// escaped quote inside a quoted value must not leak the suffix.
+		{`password="abc\"defsecret"`, []string{"defsecret", `abc\"defsecret`}},
 	}
 	for _, tc := range cases {
 		out := r.String(tc.in)
@@ -99,6 +106,23 @@ func TestRedactorMasksSecretNamedKeyValues(t *testing.T) {
 			if strings.Contains(out, leak) {
 				t.Fatalf("secret value leaked from %q: %q", tc.in, out)
 			}
+		}
+	}
+}
+
+func TestRedactorKeepsNonSecretFieldsLegible(t *testing.T) {
+	r := NewRedactor("")
+	// These key names are not secret-bearing; their values must survive so
+	// diagnostics stay readable (no over-redaction from the broadened rule).
+	legible := []string{
+		"auth_status=ok",
+		"public_key=id-abc123",
+		"cache_key=warm",
+		"sort_key=ascending",
+	}
+	for _, in := range legible {
+		if out := r.String(in); strings.Contains(out, "[REDACTED]") {
+			t.Fatalf("over-redacted a non-secret field %q -> %q", in, out)
 		}
 	}
 }

--- a/internal/supportbundle/redact_test.go
+++ b/internal/supportbundle/redact_test.go
@@ -167,6 +167,26 @@ func TestRedactorHomeTrailingSlashNormalized(t *testing.T) {
 	}
 }
 
+// TestRedactorHomePrefixBoundary guards the component-boundary fix: a home that
+// is a string prefix of a longer component must not be rewritten mid-component
+// (which would corrupt the path and leak the suffix of another local username).
+func TestRedactorHomePrefixBoundary(t *testing.T) {
+	r := NewRedactor("/Users/al")
+	cases := map[string]string{
+		"/Users/alice/.colima/x": "/Users/alice/.colima/x", // different user: untouched
+		"/Users/al/.colima/x":    "~/.colima/x",            // exact home + separator
+		"/Users/al":              "~",                      // exact home at end
+		"cwd=/Users/al done":     "cwd=~ done",             // home at a whitespace boundary
+		`"/Users/al"`:            `"~"`,                    // home at a quote boundary
+		"/Users/al.config":       "/Users/al.config",       // "." can continue a component: untouched
+	}
+	for in, want := range cases {
+		if got := r.String(in); got != want {
+			t.Fatalf("home boundary: String(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 // TestRedactorPreservesDiagnosticText guards against over-redaction: fields
 // that matter for diagnosis (sha digests, enum values, ordinary paths) must
 // survive so the bundle stays useful.

--- a/internal/supportbundle/redact_test.go
+++ b/internal/supportbundle/redact_test.go
@@ -23,6 +23,7 @@ var knownSecrets = []struct {
 	{"github pat", "github_pat_" + "11ABCDEFG0abcdefghijkl_mnopqrstuvwxyz0123456789ABCDEFGHIJ"},
 	{"openai key", "sk-" + "proj-abcdefghijklmnopqrstuvwxyz0123456789ABCD"},
 	{"google api key", "AIza" + "SyA1234567890abcdefghijklmnopqrstuv"},
+	{"google oauth token", "ya29." + "a0AbCdEf1234567890_-abcdefghijklmnop"},
 	{"aws access key", "AKIA" + "IOSFODNN7EXAMPLE"},
 	{"aws session key", "ASIA" + "IOSFODNN7EXAMPLE"},
 	{"slack token", "xoxb-" + "1234567890-abcdefghijklmnop"},


### PR DESCRIPTION
**G2: Support Bundle Command — part 1 of 3** (split for PR-shape limits). This lands the self-contained, tested redaction core first; the collector (part 2) and the `workcell support-bundle` CLI + docs (part 3) follow on top.

## What
`internal/supportbundle/redact.go` — the redaction layer for the forthcoming support bundle. Masks secrets (JWTs, GitHub/OpenAI/Google/AWS/Slack tokens, PEM private keys, `Bearer` headers, secret-named `key=value`) and rewrites the operator home prefix to `~` so no username or credential material can reach a bundle.

## Tests
`redact_test.go` proves each pattern is masked plus an over-redaction guard (sha digests / enum values survive). Test fixtures assemble secret shapes from fragments at runtime so no literal token appears in source (GitHub push protection) while still exercising every pattern.

Leaf library, no caller yet — builds + `go test ./internal/supportbundle/` green, `go vet` clean, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)