### PR TITLE
^F Support-bundle collector + leak-proof + golden (G2, 2/3)

### DIFF
--- a/internal/supportbundle/bundle.go
+++ b/internal/supportbundle/bundle.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package supportbundle
+
+import (
+	"encoding/json"
+	"runtime"
+	"time"
+)
+
+// SchemaVersion versions the bundle JSON shape. Bump it on any field
+// addition/rename/removal so consumers and the golden test can gate on it.
+const SchemaVersion = "1"
+
+// toolName is the stable tool identifier embedded in the bundle.
+const toolName = "workcell support-bundle"
+
+// Config carries every host input the collector needs. Injecting these (rather
+// than reading process env directly) keeps collection hermetic and golden tests
+// reproducible.
+type Config struct {
+	// RepoRoot is the workcell checkout / install root (ROOT_DIR).
+	RepoRoot string
+	// LauncherPath is the absolute path to the scripts/workcell launcher.
+	LauncherPath string
+	// RealHome is the operator home directory used for redaction and to
+	// locate the user injection policy.
+	RealHome string
+	// WorkcellStateRoot and ColimaStateRoot are the two durable state roots
+	// (WORKCELL_STATE_ROOT, COLIMA_STATE_ROOT).
+	WorkcellStateRoot string
+	ColimaStateRoot   string
+	// HostOS and HostArch describe the host; empty falls back to the build's
+	// runtime.GOOS / runtime.GOARCH.
+	HostOS   string
+	HostArch string
+	// Now is the bundle timestamp. A zero value is treated as unset and the
+	// generated_at field is emitted as the empty string (golden tests pin it).
+	Now time.Time
+}
+
+// Section is embedded by every evidence-class section so collection can
+// degrade gracefully: a missing source flips Available and appends a Gap
+// rather than aborting the whole bundle.
+type Section struct {
+	Available bool     `json:"available"`
+	Gaps      []string `json:"gaps"`
+}
+
+func (s *Section) note(gap string) {
+	s.Gaps = append(s.Gaps, gap)
+}
+
+// RedactionInfo self-describes the guarantees the bundle was produced under.
+type RedactionInfo struct {
+	PolicyVersion string   `json:"policy_version"`
+	Rules         []string `json:"rules"`
+}
+
+// Bundle is the deterministic support-bundle document. Field order here is the
+// on-disk JSON order; every slice inside is sorted at collection time.
+type Bundle struct {
+	SchemaVersion string           `json:"schema_version"`
+	Tool          string           `json:"tool"`
+	GeneratedAt   string           `json:"generated_at"`
+	Redaction     RedactionInfo    `json:"redaction"`
+	Install       InstallSection   `json:"install"`
+	Policy        PolicySection    `json:"policy"`
+	Target        TargetSection    `json:"target"`
+	Providers     ProvidersSection `json:"providers"`
+	Sessions      SessionsSection  `json:"sessions"`
+	AuditPointers AuditSection     `json:"audit_pointers"`
+}
+
+// Collect assembles a redacted bundle from cfg. It never returns an error for a
+// missing evidence source — those become section gaps — so an operator on a
+// half-installed host still gets a shareable bundle.
+func Collect(cfg Config) Bundle {
+	r := NewRedactor(cfg.RealHome)
+
+	generatedAt := ""
+	if !cfg.Now.IsZero() {
+		generatedAt = cfg.Now.UTC().Format(time.RFC3339)
+	}
+
+	hostOS := cfg.HostOS
+	if hostOS == "" {
+		hostOS = runtime.GOOS
+	}
+	hostArch := cfg.HostArch
+	if hostArch == "" {
+		hostArch = runtime.GOARCH
+	}
+
+	return Bundle{
+		SchemaVersion: SchemaVersion,
+		Tool:          toolName,
+		GeneratedAt:   generatedAt,
+		Redaction: RedactionInfo{
+			PolicyVersion: RedactionPolicyVersion,
+			Rules:         RedactionRules(),
+		},
+		Install:       collectInstall(cfg, r, hostOS, hostArch),
+		Policy:        collectPolicy(cfg, r),
+		Target:        collectTarget(cfg, r),
+		Providers:     collectProviders(cfg, r),
+		Sessions:      collectSessions(cfg, r),
+		AuditPointers: collectAuditPointers(cfg, r),
+	}
+}
+
+// JSON renders the bundle as indented, deterministic JSON with a trailing
+// newline. Go marshals struct fields in declaration order and every embedded
+// slice is pre-sorted, so identical inputs yield byte-identical output.
+func (b Bundle) JSON() ([]byte, error) {
+	out, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(out, '\n'), nil
+}

--- a/internal/supportbundle/bundle_test.go
+++ b/internal/supportbundle/bundle_test.go
@@ -36,7 +36,16 @@ type fixtureOptions struct {
 	sessionStatus     string // when "", no session record is written
 	sessionLiveStatus string
 	sessionWorkspace  string // overrides the session workspace field
+	sessionProfile    string // overrides the session profile field
+	sessionID         string // overrides the session ID field
 	writeAuditLog     bool
+}
+
+func firstNonEmpty(v, fallback string) string {
+	if v != "" {
+		return v
+	}
+	return fallback
 }
 
 func buildFixture(t *testing.T, opts fixtureOptions) Config {
@@ -112,8 +121,8 @@ func buildFixture(t *testing.T, opts fixtureOptions) Config {
 		}
 		rec := sessions.SessionRecord{
 			Version:              1,
-			SessionID:            "sess-abc123",
-			Profile:              "wcl-strict",
+			SessionID:            firstNonEmpty(opts.sessionID, "sess-abc123"),
+			Profile:              firstNonEmpty(opts.sessionProfile, "wcl-strict"),
 			TargetKind:           "vm",
 			TargetProvider:       "colima",
 			TargetID:             "default",

--- a/internal/supportbundle/bundle_test.go
+++ b/internal/supportbundle/bundle_test.go
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package supportbundle
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/omkhar/workcell/internal/host/sessions"
+)
+
+var updateGolden = flag.Bool("update-golden", false, "rewrite testdata golden files")
+
+// fixedNow is the injected bundle timestamp; pinning it keeps golden output
+// stable across runs.
+var fixedNow = time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+
+// fixedAuditMTime is the audit-log modification time set on fixture files so
+// the collected modified_at field is deterministic.
+var fixedAuditMTime = time.Date(2026, 7, 4, 9, 30, 0, 0, time.UTC)
+
+// buildFixture materializes a complete host layout under a temp home so every
+// absolute path redacts to a stable ~-relative string. It returns a Config
+// pointing at the fixture. Options let scenario tests perturb one class.
+type fixtureOptions struct {
+	omitLauncher      bool
+	omitPolicyDir     bool
+	omitColimaConfig  bool     // create the profile dir without colima.yaml
+	omitAdapters      []string // adapter dirs to skip creating
+	userInjection     bool
+	sessionStatus     string // when "", no session record is written
+	sessionLiveStatus string
+	sessionWorkspace  string // overrides the session workspace field
+	writeAuditLog     bool
+}
+
+func buildFixture(t *testing.T, opts fixtureOptions) Config {
+	t.Helper()
+	home := t.TempDir()
+	repoRoot := filepath.Join(home, "src", "workcell")
+	mustMkdir(t, repoRoot)
+
+	// Install artifacts.
+	launcher := filepath.Join(repoRoot, "scripts", "workcell")
+	if !opts.omitLauncher {
+		mustWrite(t, launcher, "#!/bin/bash\n")
+	}
+	mustWrite(t, filepath.Join(repoRoot, "CHANGELOG.md"),
+		"# Changelog\n\n## Unreleased\n\n## v0.11.2 - 2026-06-15\n\n## v0.11.1 - 2026-06-15\n")
+
+	// Policy inventory.
+	if !opts.omitPolicyDir {
+		policyDir := filepath.Join(repoRoot, "policy")
+		mustWrite(t, filepath.Join(policyDir, "allowed-actions.toml"), "x = 1\n")
+		mustWrite(t, filepath.Join(policyDir, "github-hosted-controls.toml"), "x = 1\n")
+		mustWrite(t, filepath.Join(policyDir, "requirements.toml"), "version = 1\n")
+		mustWrite(t, filepath.Join(policyDir, "host-support-matrix.tsv"), "os\tarch\n")
+		mustWrite(t, filepath.Join(policyDir, "notes.md"), "ignored\n") // non-policy ext, skipped
+	}
+
+	// Adapter directories.
+	skip := map[string]bool{}
+	for _, name := range opts.omitAdapters {
+		skip[name] = true
+	}
+	for _, name := range []string{"claude", "codex", "copilot", "gemini", "antigravity"} {
+		if skip[name] {
+			continue
+		}
+		mustMkdir(t, filepath.Join(repoRoot, "adapters", name))
+	}
+
+	// User injection policy (presence only).
+	if opts.userInjection {
+		mustWrite(t, filepath.Join(home, ".config", "workcell", "injection-policy.toml"),
+			"version = 1\n# token=ghp_"+"0123456789abcdefghijklmnopqrstuvwx should never leak\n")
+	}
+
+	// State roots.
+	workcellStateRoot := filepath.Join(home, ".local", "state", "workcell")
+	mustMkdir(t, workcellStateRoot)
+	colimaStateRoot := filepath.Join(home, ".colima")
+	profileDir := filepath.Join(colimaStateRoot, "wcl-strict")
+	mustMkdir(t, profileDir)
+	if !opts.omitColimaConfig {
+		mustWrite(t, filepath.Join(profileDir, "colima.yaml"), "cpu: 4\n")
+	}
+	mustMkdir(t, filepath.Join(colimaStateRoot, "_lima", "colima-wcl-strict"))
+	mustMkdir(t, filepath.Join(colimaStateRoot, "_disks")) // underscore-prefixed, skipped
+
+	cfg := Config{
+		RepoRoot:          repoRoot,
+		LauncherPath:      launcher,
+		RealHome:          home,
+		WorkcellStateRoot: workcellStateRoot,
+		ColimaStateRoot:   colimaStateRoot,
+		HostOS:            "darwin",
+		HostArch:          "arm64",
+		Now:               fixedNow,
+	}
+
+	if opts.sessionStatus != "" {
+		auditLog := filepath.Join(profileDir, "workcell.audit.log")
+		workspace := repoRoot
+		if opts.sessionWorkspace != "" {
+			workspace = opts.sessionWorkspace
+		}
+		rec := sessions.SessionRecord{
+			Version:              1,
+			SessionID:            "sess-abc123",
+			Profile:              "wcl-strict",
+			TargetKind:           "vm",
+			TargetProvider:       "colima",
+			TargetID:             "default",
+			TargetAssuranceClass: "strict",
+			RuntimeAPI:           "docker",
+			WorkspaceTransport:   "direct",
+			Agent:                "codex",
+			Mode:                 "strict",
+			Status:               opts.sessionStatus,
+			LiveStatus:           opts.sessionLiveStatus,
+			Workspace:            workspace,
+			AuditLogPath:         auditLog,
+			StartedAt:            "2026-07-04T09:00:00Z",
+		}
+		writeSessionRecord(t, profileDir, "sess-abc123.json", rec)
+		if opts.writeAuditLog {
+			mustWrite(t, auditLog, "AUDIT RECORD BODY token=ghp_"+"0123456789abcdefghijklmnopqrstuvwx\n")
+			if err := os.Chtimes(auditLog, fixedAuditMTime, fixedAuditMTime); err != nil {
+				t.Fatalf("chtimes audit log: %v", err)
+			}
+		}
+	}
+
+	return cfg
+}
+
+func writeSessionRecord(t *testing.T, profileDir, name string, rec sessions.SessionRecord) {
+	t.Helper()
+	sessionsDir := filepath.Join(profileDir, "sessions")
+	mustMkdir(t, sessionsDir)
+	data, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal session record: %v", err)
+	}
+	mustWrite(t, filepath.Join(sessionsDir, name), string(data))
+}
+
+func mustMkdir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	mustMkdir(t, filepath.Dir(path))
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestGoldenBundleShape pins the full deterministic bundle shape. Because the
+// fixture lives under a temp home and every path is redacted to ~-relative,
+// the output is byte-stable across machines. Regenerate with:
+//
+//	go test ./internal/supportbundle -run TestGoldenBundleShape -update-golden
+func TestGoldenBundleShape(t *testing.T) {
+	cfg := buildFixture(t, fixtureOptions{
+		userInjection:     true,
+		sessionStatus:     "running",
+		sessionLiveStatus: "running",
+		writeAuditLog:     true,
+	})
+
+	got, err := Collect(cfg).JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+
+	goldenPath := filepath.Join("testdata", "golden-bundle.json")
+	if *updateGolden {
+		mustWrite(t, goldenPath, string(got))
+		t.Logf("updated %s", goldenPath)
+		return
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden: %v (run with -update-golden to create)", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("bundle shape drift.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// TestBundleDeterministic proves repeated collection is byte-identical.
+func TestBundleDeterministic(t *testing.T) {
+	cfg := buildFixture(t, fixtureOptions{sessionStatus: "exited", writeAuditLog: true})
+	first, err := Collect(cfg).JSON()
+	if err != nil {
+		t.Fatalf("first JSON: %v", err)
+	}
+	second, err := Collect(cfg).JSON()
+	if err != nil {
+		t.Fatalf("second JSON: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("collection not deterministic")
+	}
+}
+
+// TestBundleSchemaAndRedactionMetadata asserts the self-describing header.
+func TestBundleSchemaAndRedactionMetadata(t *testing.T) {
+	b := Collect(buildFixture(t, fixtureOptions{}))
+	if b.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema_version = %q", b.SchemaVersion)
+	}
+	if b.Tool != toolName {
+		t.Fatalf("tool = %q", b.Tool)
+	}
+	if b.GeneratedAt != "2026-07-05T12:00:00Z" {
+		t.Fatalf("generated_at = %q", b.GeneratedAt)
+	}
+	if b.Redaction.PolicyVersion != RedactionPolicyVersion {
+		t.Fatalf("redaction policy version = %q", b.Redaction.PolicyVersion)
+	}
+	if len(b.Redaction.Rules) != len(redactionRules) {
+		t.Fatalf("redaction rules count = %d", len(b.Redaction.Rules))
+	}
+}
+
+// TestBundleZeroNow omits generated_at when Now is unset.
+func TestBundleZeroNow(t *testing.T) {
+	cfg := buildFixture(t, fixtureOptions{})
+	cfg.Now = time.Time{}
+	if b := Collect(cfg); b.GeneratedAt != "" {
+		t.Fatalf("generated_at = %q, want empty", b.GeneratedAt)
+	}
+}

--- a/internal/supportbundle/collect.go
+++ b/internal/supportbundle/collect.go
@@ -107,7 +107,7 @@ func collectPolicy(cfg Config, r Redactor) PolicySection {
 
 	s := PolicySection{
 		RepoPolicyDir:              r.String(policyDir),
-		RepoPolicyFiles:            listPolicyFiles(policyDir),
+		RepoPolicyFiles:            r.Strings(listPolicyFiles(policyDir)),
 		UserInjectionPolicyPath:    r.String(userPolicy),
 		UserInjectionPolicyPresent: userPolicy != "" && fileExists(userPolicy),
 		HostedControlsPresent:      policyDir != "" && fileExists(filepath.Join(policyDir, "github-hosted-controls.toml")),

--- a/internal/supportbundle/collect.go
+++ b/internal/supportbundle/collect.go
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package supportbundle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/omkhar/workcell/internal/adapters"
+	"github.com/omkhar/workcell/internal/host/hoststate"
+	"github.com/omkhar/workcell/internal/host/sessions"
+	"github.com/omkhar/workcell/internal/providerid"
+)
+
+// maxSessionSummaries caps how many session summaries a bundle carries so a
+// long-lived host cannot balloon the document; Truncated records the overflow.
+const maxSessionSummaries = 50
+
+// providerOrder is the stable provider iteration order: the supported adapters
+// followed by the planned antigravity scaffold.
+var providerOrder = []string{
+	providerid.Claude,
+	providerid.Codex,
+	providerid.Copilot,
+	providerid.Gemini,
+	providerid.Antigravity,
+}
+
+// changelogVersionRe matches a released `## vX.Y.Z ...` CHANGELOG heading.
+var changelogVersionRe = regexp.MustCompile(`^##\s+(v[0-9]+\.[0-9]+\.[0-9]+)`)
+
+// InstallSection captures whether Workcell is installed and on what host.
+type InstallSection struct {
+	Section
+	LauncherPath    string `json:"launcher_path"`
+	LauncherPresent bool   `json:"launcher_present"`
+	RepoRoot        string `json:"repo_root"`
+	RepoRootPresent bool   `json:"repo_root_present"`
+	Version         string `json:"version"`
+	HostOS          string `json:"host_os"`
+	HostArch        string `json:"host_arch"`
+}
+
+func collectInstall(cfg Config, r Redactor, hostOS, hostArch string) InstallSection {
+	s := InstallSection{
+		LauncherPath:    r.String(cfg.LauncherPath),
+		LauncherPresent: fileExists(cfg.LauncherPath),
+		RepoRoot:        r.String(cfg.RepoRoot),
+		RepoRootPresent: dirExists(cfg.RepoRoot),
+		Version:         changelogVersion(cfg.RepoRoot),
+		HostOS:          hostOS,
+		HostArch:        hostArch,
+	}
+	s.Available = s.LauncherPresent
+	if !s.LauncherPresent {
+		s.note("launcher not found at reported path; install may be incomplete")
+	}
+	if !s.RepoRootPresent {
+		s.note("repo root not found; version could not be resolved")
+	}
+	return s
+}
+
+func changelogVersion(repoRoot string) string {
+	if repoRoot == "" {
+		return "unknown"
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot, "CHANGELOG.md"))
+	if err != nil {
+		return "unknown"
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if m := changelogVersionRe.FindStringSubmatch(line); m != nil {
+			return m[1]
+		}
+	}
+	return "unknown"
+}
+
+// PolicySection inventories repo policy artifacts and the user injection policy.
+// It records presence only; policy files are listed by name and the user
+// injection policy body is never read (it may reference credential sources).
+type PolicySection struct {
+	Section
+	RepoPolicyDir              string   `json:"repo_policy_dir"`
+	RepoPolicyFiles            []string `json:"repo_policy_files"`
+	UserInjectionPolicyPath    string   `json:"user_injection_policy_path"`
+	UserInjectionPolicyPresent bool     `json:"user_injection_policy_present"`
+	HostedControlsPresent      bool     `json:"hosted_controls_present"`
+}
+
+func collectPolicy(cfg Config, r Redactor) PolicySection {
+	policyDir := ""
+	if cfg.RepoRoot != "" {
+		policyDir = filepath.Join(cfg.RepoRoot, "policy")
+	}
+	userPolicy := ""
+	if cfg.RealHome != "" {
+		userPolicy = filepath.Join(cfg.RealHome, ".config", "workcell", "injection-policy.toml")
+	}
+
+	s := PolicySection{
+		RepoPolicyDir:              r.String(policyDir),
+		RepoPolicyFiles:            listPolicyFiles(policyDir),
+		UserInjectionPolicyPath:    r.String(userPolicy),
+		UserInjectionPolicyPresent: userPolicy != "" && fileExists(userPolicy),
+		HostedControlsPresent:      policyDir != "" && fileExists(filepath.Join(policyDir, "github-hosted-controls.toml")),
+	}
+	s.Available = len(s.RepoPolicyFiles) > 0
+	if !s.Available {
+		s.note("repo policy directory missing or empty")
+	}
+	return s
+}
+
+func listPolicyFiles(policyDir string) []string {
+	if policyDir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(policyDir)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(e.Name()))
+		if ext == ".toml" || ext == ".json" || ext == ".tsv" {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TargetProfile is one colima profile's filesystem-observable state.
+type TargetProfile struct {
+	Name                string `json:"name"`
+	Dir                 string `json:"dir"`
+	ColimaConfigPresent bool   `json:"colima_config_present"`
+	LimaDirPresent      bool   `json:"lima_dir_present"`
+}
+
+// TargetSection captures runtime-target state that is observable on the host
+// filesystem. It deliberately does NOT invoke colima/lima so the bundle stays
+// deterministic and side-effect free; live VM status is a documented gap.
+type TargetSection struct {
+	Section
+	WorkcellStateRoot        string          `json:"workcell_state_root"`
+	WorkcellStateRootPresent bool            `json:"workcell_state_root_present"`
+	ColimaStateRoot          string          `json:"colima_state_root"`
+	ColimaStateRootPresent   bool            `json:"colima_state_root_present"`
+	ColimaProfiles           []TargetProfile `json:"colima_profiles"`
+}
+
+func collectTarget(cfg Config, r Redactor) TargetSection {
+	s := TargetSection{
+		WorkcellStateRoot:        r.String(cfg.WorkcellStateRoot),
+		WorkcellStateRootPresent: dirExists(cfg.WorkcellStateRoot),
+		ColimaStateRoot:          r.String(cfg.ColimaStateRoot),
+		ColimaStateRootPresent:   dirExists(cfg.ColimaStateRoot),
+	}
+	s.ColimaProfiles = collectColimaProfiles(cfg, r, &s.Section)
+	s.Available = s.WorkcellStateRootPresent || s.ColimaStateRootPresent
+	if !s.Available {
+		s.note("no state roots present on host; target has not been provisioned")
+	}
+	s.note("live colima/VM status is not collected; run `workcell --doctor` for live target state")
+	return s
+}
+
+func collectColimaProfiles(cfg Config, r Redactor, sec *Section) []TargetProfile {
+	root := cfg.ColimaStateRoot
+	if !dirExists(root) {
+		return nil
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		sec.note(fmt.Sprintf("colima state root unreadable: %v", r.String(err.Error())))
+		return nil
+	}
+	var profiles []TargetProfile
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), "_") || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		profile := e.Name()
+		configPath, cfgErr := hoststate.ProfileColimaConfigPath(root, profile)
+		limaDir, limaErr := hoststate.ProfileLimaDir(root, profile)
+		if cfgErr != nil || limaErr != nil {
+			// A directory whose name fails profile validation is not a
+			// managed profile; record it as a bare entry without probing.
+			profiles = append(profiles, TargetProfile{Name: profile, Dir: r.String(filepath.Join(root, profile))})
+			continue
+		}
+		profiles = append(profiles, TargetProfile{
+			Name:                profile,
+			Dir:                 r.String(filepath.Join(root, profile)),
+			ColimaConfigPresent: fileExists(configPath),
+			LimaDirPresent:      dirExists(limaDir),
+		})
+	}
+	sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name < profiles[j].Name })
+	return profiles
+}
+
+// ProviderSummary is one provider's compiled-in facts plus adapter presence.
+type ProviderSummary struct {
+	ID                string   `json:"id"`
+	Supported         bool     `json:"supported"`
+	AdapterDirPresent bool     `json:"adapter_dir_present"`
+	CredentialKeys    []string `json:"credential_keys"`
+}
+
+// ProvidersSection summarizes each provider's bootstrap surface. Credential
+// KEY NAMES are non-secret and useful for diagnosis; credential VALUES are
+// never touched.
+type ProvidersSection struct {
+	Section
+	Providers []ProviderSummary `json:"providers"`
+}
+
+func collectProviders(cfg Config, _ Redactor) ProvidersSection {
+	scoped := adapters.AgentScopedCredentialKeys()
+	s := ProvidersSection{}
+	for _, id := range providerOrder {
+		adapterDir := ""
+		if cfg.RepoRoot != "" {
+			adapterDir = filepath.Join(cfg.RepoRoot, "adapters", id)
+		}
+		var keys []string
+		for key := range scoped[id] {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		s.Providers = append(s.Providers, ProviderSummary{
+			ID:                id,
+			Supported:         providerid.IsValid(id),
+			AdapterDirPresent: adapterDir != "" && dirExists(adapterDir),
+			CredentialKeys:    keys,
+		})
+	}
+	s.Available = len(s.Providers) > 0
+	return s
+}
+
+// SessionSummary is the redacted, body-free view of one durable session record.
+type SessionSummary struct {
+	SessionID       string `json:"session_id"`
+	Status          string `json:"status"`
+	LiveStatus      string `json:"live_status"`
+	Profile         string `json:"profile"`
+	TargetKind      string `json:"target_kind"`
+	TargetProvider  string `json:"target_provider"`
+	Agent           string `json:"agent"`
+	Mode            string `json:"mode"`
+	StartedAt       string `json:"started_at"`
+	Workspace       string `json:"workspace"`
+	AuditLogPresent bool   `json:"audit_log_present"`
+}
+
+// StatusCount is a session count for one status value.
+type StatusCount struct {
+	Status string `json:"status"`
+	Count  int    `json:"count"`
+}
+
+// SessionsSection summarizes durable session records. It never emits workspace
+// bodies, transcripts, or audit content — only enumerated metadata fields.
+type SessionsSection struct {
+	Section
+	Total        int              `json:"total"`
+	StatusCounts []StatusCount    `json:"status_counts"`
+	Sessions     []SessionSummary `json:"sessions"`
+	Truncated    bool             `json:"truncated"`
+}
+
+func collectSessions(cfg Config, r Redactor) SessionsSection {
+	s := SessionsSection{}
+	roots := stateRoots(cfg)
+	if len(roots) == 0 {
+		s.note("no state roots configured; session metadata unavailable")
+		return s
+	}
+	records, err := sessions.ListSessionRecordsInRoots(roots, sessions.SessionListOptions{})
+	if err != nil {
+		s.note(fmt.Sprintf("session enumeration failed: %v", r.String(err.Error())))
+		return s
+	}
+	s.Available = true
+	s.Total = len(records)
+
+	counts := map[string]int{}
+	for _, rec := range records {
+		status := rec.Status
+		if status == "" {
+			status = "unknown"
+		}
+		counts[status]++
+	}
+	for status, count := range counts {
+		s.StatusCounts = append(s.StatusCounts, StatusCount{Status: status, Count: count})
+	}
+	sort.Slice(s.StatusCounts, func(i, j int) bool { return s.StatusCounts[i].Status < s.StatusCounts[j].Status })
+
+	sort.Slice(records, func(i, j int) bool { return records[i].SessionID < records[j].SessionID })
+	limit := len(records)
+	if limit > maxSessionSummaries {
+		limit = maxSessionSummaries
+		s.Truncated = true
+		s.note(fmt.Sprintf("session summaries truncated to %d of %d records", maxSessionSummaries, len(records)))
+	}
+	for _, rec := range records[:limit] {
+		s.Sessions = append(s.Sessions, SessionSummary{
+			SessionID:       rec.SessionID,
+			Status:          rec.Status,
+			LiveStatus:      rec.LiveStatus,
+			Profile:         rec.Profile,
+			TargetKind:      rec.TargetKind,
+			TargetProvider:  rec.TargetProvider,
+			Agent:           rec.Agent,
+			Mode:            rec.Mode,
+			StartedAt:       rec.StartedAt,
+			Workspace:       r.String(rec.Workspace),
+			AuditLogPresent: rec.AuditLogPath != "" && fileExists(rec.AuditLogPath),
+		})
+	}
+	return s
+}
+
+// AuditPointer references an audit log by path + metadata; never its content.
+type AuditPointer struct {
+	SessionID  string `json:"session_id"`
+	Path       string `json:"path"`
+	Present    bool   `json:"present"`
+	SizeBytes  int64  `json:"size_bytes"`
+	ModifiedAt string `json:"modified_at"`
+}
+
+// AuditSection lists audit-log pointers for durable sessions. Bodies are never
+// read; only path, presence, size, and mtime are recorded.
+type AuditSection struct {
+	Section
+	Pointers []AuditPointer `json:"pointers"`
+}
+
+func collectAuditPointers(cfg Config, r Redactor) AuditSection {
+	s := AuditSection{}
+	roots := stateRoots(cfg)
+	if len(roots) == 0 {
+		s.note("no state roots configured; audit pointers unavailable")
+		return s
+	}
+	records, err := sessions.ListSessionRecordsInRoots(roots, sessions.SessionListOptions{})
+	if err != nil {
+		s.note(fmt.Sprintf("session enumeration failed: %v", r.String(err.Error())))
+		return s
+	}
+	s.Available = true
+	for _, rec := range records {
+		if rec.AuditLogPath == "" {
+			continue
+		}
+		ptr := AuditPointer{
+			SessionID: rec.SessionID,
+			Path:      r.String(rec.AuditLogPath),
+		}
+		if info, statErr := os.Stat(rec.AuditLogPath); statErr == nil && !info.IsDir() {
+			ptr.Present = true
+			ptr.SizeBytes = info.Size()
+			ptr.ModifiedAt = info.ModTime().UTC().Format(time.RFC3339)
+		}
+		s.Pointers = append(s.Pointers, ptr)
+	}
+	sort.Slice(s.Pointers, func(i, j int) bool { return s.Pointers[i].SessionID < s.Pointers[j].SessionID })
+	return s
+}
+
+func stateRoots(cfg Config) []string {
+	var roots []string
+	if cfg.WorkcellStateRoot != "" {
+		roots = append(roots, cfg.WorkcellStateRoot)
+	}
+	if cfg.ColimaStateRoot != "" {
+		roots = append(roots, cfg.ColimaStateRoot)
+	}
+	return roots
+}
+
+func fileExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func dirExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/supportbundle/collect.go
+++ b/internal/supportbundle/collect.go
@@ -198,11 +198,11 @@ func collectColimaProfiles(cfg Config, r Redactor, sec *Section) []TargetProfile
 		if cfgErr != nil || limaErr != nil {
 			// A directory whose name fails profile validation is not a
 			// managed profile; record it as a bare entry without probing.
-			profiles = append(profiles, TargetProfile{Name: profile, Dir: r.String(filepath.Join(root, profile))})
+			profiles = append(profiles, TargetProfile{Name: r.String(profile), Dir: r.String(filepath.Join(root, profile))})
 			continue
 		}
 		profiles = append(profiles, TargetProfile{
-			Name:                profile,
+			Name:                r.String(profile),
 			Dir:                 r.String(filepath.Join(root, profile)),
 			ColimaConfigPresent: fileExists(configPath),
 			LimaDirPresent:      dirExists(limaDir),
@@ -320,10 +320,10 @@ func collectSessions(cfg Config, r Redactor) SessionsSection {
 	}
 	for _, rec := range records[:limit] {
 		s.Sessions = append(s.Sessions, SessionSummary{
-			SessionID:       rec.SessionID,
+			SessionID:       r.String(rec.SessionID),
 			Status:          rec.Status,
 			LiveStatus:      rec.LiveStatus,
-			Profile:         rec.Profile,
+			Profile:         r.String(rec.Profile),
 			TargetKind:      rec.TargetKind,
 			TargetProvider:  rec.TargetProvider,
 			Agent:           rec.Agent,
@@ -370,7 +370,7 @@ func collectAuditPointers(cfg Config, r Redactor) AuditSection {
 			continue
 		}
 		ptr := AuditPointer{
-			SessionID: rec.SessionID,
+			SessionID: r.String(rec.SessionID),
 			Path:      r.String(rec.AuditLogPath),
 		}
 		if info, statErr := os.Stat(rec.AuditLogPath); statErr == nil && !info.IsDir() {

--- a/internal/supportbundle/collect.go
+++ b/internal/supportbundle/collect.go
@@ -307,11 +307,14 @@ func collectSessions(cfg Config, r Redactor) SessionsSection {
 		counts[status]++
 	}
 	for status, count := range counts {
-		s.StatusCounts = append(s.StatusCounts, StatusCount{Status: status, Count: count})
+		s.StatusCounts = append(s.StatusCounts, StatusCount{Status: r.String(status), Count: count})
 	}
 	sort.Slice(s.StatusCounts, func(i, j int) bool { return s.StatusCounts[i].Status < s.StatusCounts[j].Status })
 
-	sort.Slice(records, func(i, j int) bool { return records[i].SessionID < records[j].SessionID })
+	// Newest-first: session IDs are timestamp-prefixed, so descending order keeps
+	// the most recent sessions (the ones most likely under investigation) when
+	// truncating, and is deterministic for the golden shape.
+	sort.Slice(records, func(i, j int) bool { return records[i].SessionID > records[j].SessionID })
 	limit := len(records)
 	if limit > maxSessionSummaries {
 		limit = maxSessionSummaries
@@ -319,16 +322,19 @@ func collectSessions(cfg Config, r Redactor) SessionsSection {
 		s.note(fmt.Sprintf("session summaries truncated to %d of %d records", maxSessionSummaries, len(records)))
 	}
 	for _, rec := range records[:limit] {
+		// Every string field goes through the redactor: validateSessionRecord
+		// only rejects newlines, so a hand-edited/malformed durable record could
+		// carry token-shaped text in any of these fields.
 		s.Sessions = append(s.Sessions, SessionSummary{
 			SessionID:       r.String(rec.SessionID),
-			Status:          rec.Status,
-			LiveStatus:      rec.LiveStatus,
+			Status:          r.String(rec.Status),
+			LiveStatus:      r.String(rec.LiveStatus),
 			Profile:         r.String(rec.Profile),
-			TargetKind:      rec.TargetKind,
-			TargetProvider:  rec.TargetProvider,
-			Agent:           rec.Agent,
-			Mode:            rec.Mode,
-			StartedAt:       rec.StartedAt,
+			TargetKind:      r.String(rec.TargetKind),
+			TargetProvider:  r.String(rec.TargetProvider),
+			Agent:           r.String(rec.Agent),
+			Mode:            r.String(rec.Mode),
+			StartedAt:       r.String(rec.StartedAt),
 			Workspace:       r.String(rec.Workspace),
 			AuditLogPresent: rec.AuditLogPath != "" && fileExists(rec.AuditLogPath),
 		})

--- a/internal/supportbundle/collect_test.go
+++ b/internal/supportbundle/collect_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package supportbundle
+
+import (
+	"strings"
+	"testing"
+)
+
+// The scenario tests below cover one failure class each (install, policy,
+// target, provider, runtime) and assert the bundle carries the evidence a
+// supporter needs to diagnose that class.
+
+// Install failure: the launcher is absent. The bundle must flag it yet still
+// carry host + repo context.
+func TestScenarioInstallFailure(t *testing.T) {
+	b := Collect(buildFixture(t, fixtureOptions{omitLauncher: true}))
+	if b.Install.Available {
+		t.Fatalf("install section should be unavailable when launcher missing")
+	}
+	if b.Install.LauncherPresent {
+		t.Fatalf("launcher_present should be false")
+	}
+	if !hasGap(b.Install.Gaps, "launcher not found") {
+		t.Fatalf("expected launcher gap, got %v", b.Install.Gaps)
+	}
+	if b.Install.HostOS != "darwin" || b.Install.HostArch != "arm64" {
+		t.Fatalf("host os/arch not carried: %q/%q", b.Install.HostOS, b.Install.HostArch)
+	}
+	if !b.Install.RepoRootPresent {
+		t.Fatalf("repo root context should still be carried")
+	}
+}
+
+// Policy failure: the repo policy directory is missing. Section flags it.
+func TestScenarioPolicyFailureMissingDir(t *testing.T) {
+	b := Collect(buildFixture(t, fixtureOptions{omitPolicyDir: true}))
+	if b.Policy.Available {
+		t.Fatalf("policy section should be unavailable when policy dir missing")
+	}
+	if len(b.Policy.RepoPolicyFiles) != 0 {
+		t.Fatalf("expected no policy files, got %v", b.Policy.RepoPolicyFiles)
+	}
+	if !hasGap(b.Policy.Gaps, "repo policy directory missing") {
+		t.Fatalf("expected policy gap, got %v", b.Policy.Gaps)
+	}
+}
+
+// Policy diagnosis: a custom user injection policy is present. The bundle
+// records its presence and path (never its body).
+func TestScenarioPolicyUserInjectionPresent(t *testing.T) {
+	b := Collect(buildFixture(t, fixtureOptions{userInjection: true}))
+	if !b.Policy.UserInjectionPolicyPresent {
+		t.Fatalf("user injection policy presence not recorded")
+	}
+	if !strings.HasSuffix(b.Policy.UserInjectionPolicyPath, "injection-policy.toml") {
+		t.Fatalf("injection policy path = %q", b.Policy.UserInjectionPolicyPath)
+	}
+	if !b.Policy.HostedControlsPresent {
+		t.Fatalf("hosted controls presence not recorded")
+	}
+}
+
+// Target failure: a colima profile directory exists but its config is missing
+// (a broken/partial profile). The bundle surfaces the mismatch.
+func TestScenarioTargetBrokenProfile(t *testing.T) {
+	b := Collect(buildFixture(t, fixtureOptions{omitColimaConfig: true}))
+	if len(b.Target.ColimaProfiles) != 1 {
+		t.Fatalf("expected one profile, got %d", len(b.Target.ColimaProfiles))
+	}
+	p := b.Target.ColimaProfiles[0]
+	if p.Name != "wcl-strict" {
+		t.Fatalf("profile name = %q", p.Name)
+	}
+	if p.ColimaConfigPresent {
+		t.Fatalf("colima_config_present should be false for a broken profile")
+	}
+	if !p.LimaDirPresent {
+		t.Fatalf("lima_dir_present should be true")
+	}
+}
+
+// Provider failure: adapter directories are missing for two providers.
+func TestScenarioProviderMissingAdapters(t *testing.T) {
+	b := Collect(buildFixture(t, fixtureOptions{omitAdapters: []string{"gemini", "antigravity"}}))
+	present := map[string]bool{}
+	for _, p := range b.Providers.Providers {
+		present[p.ID] = p.AdapterDirPresent
+	}
+	if present["codex"] != true {
+		t.Fatalf("codex adapter should be present")
+	}
+	if present["gemini"] != false {
+		t.Fatalf("gemini adapter should be reported missing")
+	}
+	if present["antigravity"] != false {
+		t.Fatalf("antigravity adapter should be reported missing")
+	}
+	// Supported tier is compiled-in and independent of adapter dir presence.
+	for _, p := range b.Providers.Providers {
+		if p.ID == "antigravity" && p.Supported {
+			t.Fatalf("antigravity must not be a supported provider")
+		}
+		if p.ID == "codex" && !p.Supported {
+			t.Fatalf("codex must be a supported provider")
+		}
+	}
+}
+
+// Runtime failure: a live session with a retained audit log. The bundle
+// carries the live status and an audit pointer (path/size/mtime, no body).
+func TestScenarioRuntimeLiveSession(t *testing.T) {
+	b := Collect(buildFixture(t, fixtureOptions{
+		sessionStatus:     "running",
+		sessionLiveStatus: "running",
+		writeAuditLog:     true,
+	}))
+	if b.Sessions.Total != 1 {
+		t.Fatalf("expected one session, got %d", b.Sessions.Total)
+	}
+	s := b.Sessions.Sessions[0]
+	if s.LiveStatus != "running" || s.Status != "running" {
+		t.Fatalf("live status not carried: %+v", s)
+	}
+	if !s.AuditLogPresent {
+		t.Fatalf("audit_log_present should be true")
+	}
+	if len(b.AuditPointers.Pointers) != 1 {
+		t.Fatalf("expected one audit pointer, got %d", len(b.AuditPointers.Pointers))
+	}
+	ptr := b.AuditPointers.Pointers[0]
+	if !ptr.Present || ptr.SizeBytes == 0 || ptr.ModifiedAt == "" {
+		t.Fatalf("audit pointer metadata incomplete: %+v", ptr)
+	}
+}
+
+// TestSectionsDegradeWithoutStateRoots proves collection never crashes when
+// nothing is provisioned.
+func TestSectionsDegradeWithoutStateRoots(t *testing.T) {
+	b := Collect(Config{}) // entirely empty config
+	if b.Sessions.Available {
+		t.Fatalf("sessions should be unavailable")
+	}
+	if !hasGap(b.Sessions.Gaps, "no state roots") {
+		t.Fatalf("expected sessions gap, got %v", b.Sessions.Gaps)
+	}
+	if b.AuditPointers.Available {
+		t.Fatalf("audit pointers should be unavailable")
+	}
+	if b.Install.Version != "unknown" {
+		t.Fatalf("version should be unknown, got %q", b.Install.Version)
+	}
+}
+
+func hasGap(gaps []string, substr string) bool {
+	for _, g := range gaps {
+		if strings.Contains(g, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/supportbundle/leak_test.go
+++ b/internal/supportbundle/leak_test.go
@@ -26,6 +26,10 @@ func TestNoSecretLeaksThroughPipeline(t *testing.T) {
 		sessionStatus:    "running",
 		writeAuditLog:    true,
 		sessionWorkspace: "/srv/repos/" + ghToken + "-project",
+		// User-influenceable identifiers (e.g. --colima-profile) can carry
+		// token-shaped text; they must be redacted before marshaling too.
+		sessionProfile: ghToken + "-profile",
+		sessionID:      "sess-" + ghToken,
 	})
 
 	out, err := Collect(cfg).JSON()

--- a/internal/supportbundle/leak_test.go
+++ b/internal/supportbundle/leak_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package supportbundle
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNoSecretLeaksThroughPipeline is the G2 exit-gate proof: known secrets and
+// the operator home/username are seeded into real collected fields (a session
+// workspace path, an audit-log body, a user injection-policy body) and the
+// fully marshaled bundle is asserted to contain none of them.
+func TestNoSecretLeaksThroughPipeline(t *testing.T) {
+	// Assembled from fragments so the literal token shape never appears in
+	// source (GitHub push protection); the runtime value still exercises the
+	// leak-detection pipeline.
+	const ghToken = "ghp_" + "0123456789abcdefghijklmnopqrstuvwx"
+
+	// The session workspace path carries a live-token-shaped segment; the
+	// audit-log body (never read) and the user injection policy body (never
+	// read) also carry the token in the fixture.
+	cfg := buildFixture(t, fixtureOptions{
+		userInjection:    true,
+		sessionStatus:    "running",
+		writeAuditLog:    true,
+		sessionWorkspace: "/srv/repos/" + ghToken + "-project",
+	})
+
+	out, err := Collect(cfg).JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	rendered := string(out)
+
+	if strings.Contains(rendered, ghToken) {
+		t.Fatalf("github token leaked into bundle:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "AUDIT RECORD BODY") {
+		t.Fatalf("audit log body content leaked into bundle")
+	}
+	// The audit-log body byte count is fine to expose; assert the pointer
+	// carries metadata but not content.
+	if !strings.Contains(rendered, "\"size_bytes\":") {
+		t.Fatalf("audit pointer should carry size metadata")
+	}
+
+	// The fixture's real home is a temp dir; its final path segment is the
+	// username-equivalent. Every occurrence must have been rewritten to ~.
+	homeBase := lastSegment(cfg.RealHome)
+	if homeBase != "" && strings.Contains(rendered, cfg.RealHome) {
+		t.Fatalf("absolute home path leaked into bundle")
+	}
+	if !strings.Contains(rendered, "~/") {
+		t.Fatalf("expected home-relative paths in bundle")
+	}
+	// The redacted workspace must show a masked token, not the raw value.
+	if !strings.Contains(rendered, "[REDACTED-TOKEN]") {
+		t.Fatalf("expected redaction marker for the workspace token")
+	}
+}
+
+// TestEverySecretPatternSurvivesMarshaling feeds each known-secret shape into a
+// session workspace field and asserts marshaled output never contains it. This
+// exercises the collector+marshal path (not just the unit redactor).
+func TestEverySecretPatternSurvivesMarshaling(t *testing.T) {
+	for _, tc := range knownSecrets {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := buildFixture(t, fixtureOptions{
+				sessionStatus:    "exited",
+				sessionWorkspace: "/srv/" + tc.secret + "/x",
+			})
+			out, err := Collect(cfg).JSON()
+			if err != nil {
+				t.Fatalf("JSON: %v", err)
+			}
+			if strings.Contains(string(out), tc.secret) {
+				t.Fatalf("secret %q (%s) leaked into bundle", tc.secret, tc.name)
+			}
+		})
+	}
+}
+
+func lastSegment(p string) string {
+	p = strings.TrimRight(p, "/")
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}

--- a/internal/supportbundle/testdata/golden-bundle.json
+++ b/internal/supportbundle/testdata/golden-bundle.json
@@ -1,0 +1,147 @@
+{
+  "schema_version": "1",
+  "tool": "workcell support-bundle",
+  "generated_at": "2026-07-05T12:00:00Z",
+  "redaction": {
+    "policy_version": "1",
+    "rules": [
+      "credential file contents are never read; only path, presence, and size/mtime metadata are recorded",
+      "workspace and agent output are never collected; log bodies are referenced by pointer only",
+      "token, key, password, secret, and credential material is masked by pattern (JWT, GitHub/OpenAI/Google/AWS/Slack tokens, PEM private keys, Bearer headers) and by secret-named key=value pairs",
+      "the operator home-directory prefix is rewritten to ~ so the local username never leaks through paths",
+      "only structured, enumerated diagnostic fields are emitted; no raw environment dumps or command output blobs"
+    ]
+  },
+  "install": {
+    "available": true,
+    "gaps": null,
+    "launcher_path": "~/src/workcell/scripts/workcell",
+    "launcher_present": true,
+    "repo_root": "~/src/workcell",
+    "repo_root_present": true,
+    "version": "v0.11.2",
+    "host_os": "darwin",
+    "host_arch": "arm64"
+  },
+  "policy": {
+    "available": true,
+    "gaps": null,
+    "repo_policy_dir": "~/src/workcell/policy",
+    "repo_policy_files": [
+      "allowed-actions.toml",
+      "github-hosted-controls.toml",
+      "host-support-matrix.tsv",
+      "requirements.toml"
+    ],
+    "user_injection_policy_path": "~/.config/workcell/injection-policy.toml",
+    "user_injection_policy_present": true,
+    "hosted_controls_present": true
+  },
+  "target": {
+    "available": true,
+    "gaps": [
+      "live colima/VM status is not collected; run `workcell --doctor` for live target state"
+    ],
+    "workcell_state_root": "~/.local/state/workcell",
+    "workcell_state_root_present": true,
+    "colima_state_root": "~/.colima",
+    "colima_state_root_present": true,
+    "colima_profiles": [
+      {
+        "name": "wcl-strict",
+        "dir": "~/.colima/wcl-strict",
+        "colima_config_present": true,
+        "lima_dir_present": true
+      }
+    ]
+  },
+  "providers": {
+    "available": true,
+    "gaps": null,
+    "providers": [
+      {
+        "id": "claude",
+        "supported": true,
+        "adapter_dir_present": true,
+        "credential_keys": [
+          "claude_api_key",
+          "claude_auth",
+          "claude_mcp"
+        ]
+      },
+      {
+        "id": "codex",
+        "supported": true,
+        "adapter_dir_present": true,
+        "credential_keys": [
+          "codex_auth"
+        ]
+      },
+      {
+        "id": "copilot",
+        "supported": true,
+        "adapter_dir_present": true,
+        "credential_keys": [
+          "copilot_github_token"
+        ]
+      },
+      {
+        "id": "gemini",
+        "supported": true,
+        "adapter_dir_present": true,
+        "credential_keys": [
+          "gcloud_adc",
+          "gemini_env",
+          "gemini_oauth",
+          "gemini_projects"
+        ]
+      },
+      {
+        "id": "antigravity",
+        "supported": false,
+        "adapter_dir_present": true,
+        "credential_keys": null
+      }
+    ]
+  },
+  "sessions": {
+    "available": true,
+    "gaps": null,
+    "total": 1,
+    "status_counts": [
+      {
+        "status": "running",
+        "count": 1
+      }
+    ],
+    "sessions": [
+      {
+        "session_id": "sess-abc123",
+        "status": "running",
+        "live_status": "running",
+        "profile": "wcl-strict",
+        "target_kind": "vm",
+        "target_provider": "colima",
+        "agent": "codex",
+        "mode": "strict",
+        "started_at": "2026-07-04T09:00:00Z",
+        "workspace": "~/src/workcell",
+        "audit_log_present": true
+      }
+    ],
+    "truncated": false
+  },
+  "audit_pointers": {
+    "available": true,
+    "gaps": null,
+    "pointers": [
+      {
+        "session_id": "sess-abc123",
+        "path": "~/.colima/wcl-strict/workcell.audit.log",
+        "present": true,
+        "size_bytes": 63,
+        "modified_at": "2026-07-04T09:30:00Z"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
**G2: Support Bundle Command — part 2 of 3.** Builds on the merged redaction core (PR-1); the `workcell support-bundle` CLI + docs follow in part 3.

## What
`internal/supportbundle/{collect,bundle}.go` — the host-side collector. It gathers the six evidence classes (install, policy, target, providers, sessions, audit-pointers) as **structured metadata only** — never reading credential-file contents, workspace files, or log bodies (collect-by-construction) — and runs every field through the merged redaction backstop. Deterministic single-JSON shape.

## Tests (the security exit-gate)
- `leak_test.go` — seeds known secrets into **real collected fields** (session workspace path, audit-log body, injection-policy body) and asserts none survive the full collect + marshal pipeline.
- `bundle_test.go` — `TestGoldenBundleShape` pins the deterministic shape (temp home → stable `~` paths, fixed clock); `TestBundleDeterministic` asserts byte-stability.
- `collect_test.go` — one scenario per failure class (install/policy/target/provider/runtime).

`go test ./internal/supportbundle/` green (incl. golden + leak-proof), `go vet` clean. Token fixtures are assembled from fragments so no literal secret appears in source (push protection). 1180 lines, 0 binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)