### PR TITLE
^F workcell support-bundle command + audit hardening (G2, 3/3)

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -71,7 +71,8 @@ Every value is produced under these rules (also embedded in each bundle under
   environment dumps or command-output blobs
 
 The output shape is deterministic (stable field order, sorted lists), so two
-bundles from the same host state are byte-identical and easy to diff.
+bundles from the same host state differ only in the `generated_at` timestamp
+and are easy to diff.
 
 ### Sharing it safely
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -21,6 +21,65 @@
   for the tier and status vocabulary
 - capture the exact command, provider, mode, and host environment
 
+## Generate a support bundle
+
+`workcell support-bundle` collects a single, redacted JSON diagnostics document
+covering the evidence needed to triage install, policy, target, provider, and
+runtime failures. It runs entirely host-side and never starts the runtime.
+
+```sh
+workcell support-bundle --output ~/workcell-support-bundle.json
+```
+
+Without `--output` the bundle is written to stdout so it can be piped or
+inspected directly.
+
+### What it collects
+
+- **install**: launcher path/presence, repo root, host OS/arch, and version
+- **policy**: repo policy-file inventory (names only) and whether a user
+  injection policy and hosted-controls policy are present
+- **target**: state-root layout and per-profile Colima directory state
+  (config/lima presence); live VM status is intentionally not collected, so run
+  `workcell --agent <provider> --doctor` for live target state
+- **providers**: per-provider adapter presence, support tier, and credential
+  **key names** (never values)
+- **sessions**: durable session-record summaries (status, target, workspace
+  path) — never workspace or agent output
+- **audit_pointers**: audit-log path, presence, size, and mtime — never log
+  contents
+
+Each section degrades gracefully: a missing source is recorded as a `gaps`
+entry rather than failing the whole bundle.
+
+### Redaction guarantees
+
+The bundle is designed to be safe to attach to a public issue or discussion.
+Every value is produced under these rules (also embedded in each bundle under
+`redaction`):
+
+- credential file **contents are never read** — only path, presence, and
+  size/mtime metadata are recorded
+- workspace and agent output are **never collected**; log bodies are referenced
+  by pointer only
+- token, key, password, secret, and credential material is masked by pattern
+  (JWT, GitHub/OpenAI/Google/AWS/Slack tokens, PEM private keys, `Bearer`
+  headers) and by secret-named `key=value` pairs
+- the operator home-directory prefix is rewritten to `~` so the local username
+  never leaks through paths
+- only structured, enumerated diagnostic fields are emitted; there are no raw
+  environment dumps or command-output blobs
+
+The output shape is deterministic (stable field order, sorted lists), so two
+bundles from the same host state are byte-identical and easy to diff.
+
+### Sharing it safely
+
+- the bundle is redacted by construction, but skim it once before sharing
+- attach it to the GitHub issue or discussion, or paste the relevant section
+- for anything that looks like it exposed a secret, use
+  [SECURITY.md](SECURITY.md) instead of a public issue
+
 ## Include this context
 
 - Workcell version or commit SHA

--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/omkhar/workcell/internal/injection"
 	"github.com/omkhar/workcell/internal/publishpr"
 	"github.com/omkhar/workcell/internal/sessionctl"
+	"github.com/omkhar/workcell/internal/supportbundle"
 	"github.com/omkhar/workcell/internal/transcript"
 )
 
@@ -97,9 +98,22 @@ func run(args []string) error {
 		return cmdHelperSessionStopCli(args[1:])
 	case "session-timeline-cli":
 		return cmdHelperSessionTimelineCli(args[1:])
+	case "support-bundle-cli":
+		return cmdHelperSupportBundleCli(args[1:])
+	case "support-bundle-usage":
+		return cmdHelperSupportBundleUsage(args[1:])
 	default:
 		return usage()
 	}
+}
+
+func cmdHelperSupportBundleCli(args []string) error {
+	return supportbundle.Run(args, os.Stdout, os.Stderr)
+}
+
+func cmdHelperSupportBundleUsage(_ []string) error {
+	fmt.Print(supportbundle.UsageText())
+	return nil
 }
 
 // runHostutilPolicy dispatches the absorbed workcell-manage-injection-policy
@@ -998,7 +1012,7 @@ func parsePrepareBundleArgs(args []string) (*injection.PrepareBundleOptions, err
 // already do); previously these returned plain errors and collapsed to the
 // exit-1 fallback, an intra-binary inconsistency (D8).
 func usage() error {
-	return &cliexit.ExitCodeError{Code: 2, Message: "usage: workcell-hostutil <path|release|helper|launcher|policy|resolve-credentials|pty-transcript|auth-cli|auth-usage|policy-cli|policy-usage|publish-pr-cli|publish-pr-usage|session-usage|session-attach-cli|session-delete-cli|session-dispatch-cli|session-logs-cli|session-monitor-cli|session-send-cli|session-stop-cli|session-timeline-cli> [args...]"}
+	return &cliexit.ExitCodeError{Code: 2, Message: "usage: workcell-hostutil <path|release|helper|launcher|policy|resolve-credentials|pty-transcript|auth-cli|auth-usage|policy-cli|policy-usage|publish-pr-cli|publish-pr-usage|session-usage|session-attach-cli|session-delete-cli|session-dispatch-cli|session-logs-cli|session-monitor-cli|session-send-cli|session-stop-cli|session-timeline-cli|support-bundle-cli|support-bundle-usage> [args...]"}
 }
 
 func pathUsage() error {

--- a/internal/supportbundle/collect.go
+++ b/internal/supportbundle/collect.go
@@ -400,13 +400,32 @@ func collectAuditPointers(cfg Config, r Redactor) AuditSection {
 }
 
 // pathUnderRoots reports whether p is exactly, or a descendant of, one of roots.
+// Both sides are canonicalized first so a value like <root>/../.ssh/id_rsa (or a
+// symlink under a root) cannot slip through the prefix check.
 func pathUnderRoots(p string, roots []string) bool {
+	cp := canonicalPath(p)
 	for _, root := range roots {
-		if root != "" && (p == root || strings.HasPrefix(p, root+string(filepath.Separator))) {
+		if root == "" {
+			continue
+		}
+		cr := canonicalPath(root)
+		if cp == cr || strings.HasPrefix(cp, cr+string(filepath.Separator)) {
 			return true
 		}
 	}
 	return false
+}
+
+// canonicalPath absolutizes p, resolves symlinks when it exists, and otherwise
+// cleans it (collapsing ".." traversal) so string-prefix comparisons are sound.
+func canonicalPath(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		p = abs
+	}
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	return filepath.Clean(p)
 }
 
 func stateRoots(cfg Config) []string {

--- a/internal/supportbundle/collect.go
+++ b/internal/supportbundle/collect.go
@@ -336,7 +336,7 @@ func collectSessions(cfg Config, r Redactor) SessionsSection {
 			Mode:            r.String(rec.Mode),
 			StartedAt:       r.String(rec.StartedAt),
 			Workspace:       r.String(rec.Workspace),
-			AuditLogPresent: rec.AuditLogPath != "" && fileExists(rec.AuditLogPath),
+			AuditLogPresent: rec.AuditLogPath != "" && pathUnderRoots(rec.AuditLogPath, roots) && fileExists(rec.AuditLogPath),
 		})
 	}
 	return s

--- a/internal/supportbundle/collect.go
+++ b/internal/supportbundle/collect.go
@@ -371,6 +371,12 @@ func collectAuditPointers(cfg Config, r Redactor) AuditSection {
 		return s
 	}
 	s.Available = true
+	// Newest-first and capped like the session summaries so a long-lived host
+	// cannot produce an unbounded bundle of stale pointers.
+	sort.Slice(records, func(i, j int) bool { return records[i].SessionID > records[j].SessionID })
+	if len(records) > maxSessionSummaries {
+		records = records[:maxSessionSummaries]
+	}
 	for _, rec := range records {
 		if rec.AuditLogPath == "" {
 			continue
@@ -379,15 +385,28 @@ func collectAuditPointers(cfg Config, r Redactor) AuditSection {
 			SessionID: r.String(rec.SessionID),
 			Path:      r.String(rec.AuditLogPath),
 		}
-		if info, statErr := os.Stat(rec.AuditLogPath); statErr == nil && !info.IsDir() {
-			ptr.Present = true
-			ptr.SizeBytes = info.Size()
-			ptr.ModifiedAt = info.ModTime().UTC().Format(time.RFC3339)
+		// Only stat a path under a discovered state root: a malformed record
+		// could aim audit_log_path at an unrelated file (e.g. ~/.ssh/id_rsa).
+		if pathUnderRoots(rec.AuditLogPath, roots) {
+			if info, statErr := os.Stat(rec.AuditLogPath); statErr == nil && !info.IsDir() {
+				ptr.Present = true
+				ptr.SizeBytes = info.Size()
+				ptr.ModifiedAt = info.ModTime().UTC().Format(time.RFC3339)
+			}
 		}
 		s.Pointers = append(s.Pointers, ptr)
 	}
-	sort.Slice(s.Pointers, func(i, j int) bool { return s.Pointers[i].SessionID < s.Pointers[j].SessionID })
 	return s
+}
+
+// pathUnderRoots reports whether p is exactly, or a descendant of, one of roots.
+func pathUnderRoots(p string, roots []string) bool {
+	for _, root := range roots {
+		if root != "" && (p == root || strings.HasPrefix(p, root+string(filepath.Separator))) {
+			return true
+		}
+	}
+	return false
 }
 
 func stateRoots(cfg Config) []string {

--- a/internal/supportbundle/collect.go
+++ b/internal/supportbundle/collect.go
@@ -311,10 +311,10 @@ func collectSessions(cfg Config, r Redactor) SessionsSection {
 	}
 	sort.Slice(s.StatusCounts, func(i, j int) bool { return s.StatusCounts[i].Status < s.StatusCounts[j].Status })
 
-	// Newest-first: session IDs are timestamp-prefixed, so descending order keeps
-	// the most recent sessions (the ones most likely under investigation) when
-	// truncating, and is deterministic for the golden shape.
-	sort.Slice(records, func(i, j int) bool { return records[i].SessionID > records[j].SessionID })
+	// ListSessionRecordsInRoots already returns records newest-first by StartedAt
+	// (deterministically), so truncation keeps the most recent sessions — the
+	// ones most likely under investigation — without a fragile re-sort on session
+	// IDs, which need not be timestamp-ordered.
 	limit := len(records)
 	if limit > maxSessionSummaries {
 		limit = maxSessionSummaries
@@ -371,9 +371,8 @@ func collectAuditPointers(cfg Config, r Redactor) AuditSection {
 		return s
 	}
 	s.Available = true
-	// Newest-first and capped like the session summaries so a long-lived host
-	// cannot produce an unbounded bundle of stale pointers.
-	sort.Slice(records, func(i, j int) bool { return records[i].SessionID > records[j].SessionID })
+	// records are already newest-first by StartedAt; cap to the recent window so
+	// a long-lived host cannot produce an unbounded bundle of stale pointers.
 	if len(records) > maxSessionSummaries {
 		records = records[:maxSessionSummaries]
 	}

--- a/internal/supportbundle/collect_test.go
+++ b/internal/supportbundle/collect_test.go
@@ -49,9 +49,16 @@ func TestCollectAuditPointersSkipsOutOfStatePaths(t *testing.T) {
 		rec := sessions.SessionRecord{Version: 1, SessionID: fmt.Sprintf("sess-evil%d", i), Profile: "wcl-strict", TargetKind: "vm", TargetProvider: "colima", TargetID: "default", TargetAssuranceClass: "strict", RuntimeAPI: "docker", WorkspaceTransport: "direct", Agent: "codex", Mode: "strict", Status: "running", Workspace: cfg.RepoRoot, StartedAt: "2026-07-04T09:00:00Z", AuditLogPath: p}
 		writeSessionRecord(t, dir, rec.SessionID+".json", rec)
 	}
-	for _, ptr := range Collect(cfg).AuditPointers.Pointers {
+	b := Collect(cfg)
+	for _, ptr := range b.AuditPointers.Pointers {
 		if strings.HasPrefix(ptr.SessionID, "sess-evil") && ptr.Present {
-			t.Fatalf("statted an out-of-state audit path (session %s)", ptr.SessionID)
+			t.Fatalf("statted an out-of-state audit path (pointer %s)", ptr.SessionID)
+		}
+	}
+	// The session summary's audit_log_present must not probe the file either.
+	for _, s := range b.Sessions.Sessions {
+		if strings.HasPrefix(s.SessionID, "sess-evil") && s.AuditLogPresent {
+			t.Fatalf("session summary probed an out-of-state audit path (%s)", s.SessionID)
 		}
 	}
 }

--- a/internal/supportbundle/collect_test.go
+++ b/internal/supportbundle/collect_test.go
@@ -39,14 +39,19 @@ func TestCollectSessionsKeepsNewestOnTruncation(t *testing.T) {
 // file metadata (presence/size/mtime) recorded.
 func TestCollectAuditPointersSkipsOutOfStatePaths(t *testing.T) {
 	cfg := buildFixture(t, fixtureOptions{sessionStatus: "running"})
-	outside := filepath.Join(t.TempDir(), "id_rsa")
-	mustWrite(t, outside, "PRIVATE")
+	ssh := filepath.Join(cfg.RealHome, ".ssh")
+	mustMkdir(t, ssh)
+	mustWrite(t, filepath.Join(ssh, "id_rsa"), "PRIVATE")
 	dir := filepath.Join(cfg.ColimaStateRoot, "wcl-strict")
-	rec := sessions.SessionRecord{Version: 1, SessionID: "sess-evil", Profile: "wcl-strict", TargetKind: "vm", TargetProvider: "colima", TargetID: "default", TargetAssuranceClass: "strict", RuntimeAPI: "docker", WorkspaceTransport: "direct", Agent: "codex", Mode: "strict", Status: "running", Workspace: cfg.RepoRoot, StartedAt: "2026-07-04T09:00:00Z", AuditLogPath: outside}
-	writeSessionRecord(t, dir, "sess-evil.json", rec)
-	for _, p := range Collect(cfg).AuditPointers.Pointers {
-		if p.SessionID == "sess-evil" && p.Present {
-			t.Fatalf("statted an out-of-state audit path %q", outside)
+	// Directly outside the state tree, and via a ".." traversal that textually
+	// starts under a state root; both must be refused before statting.
+	for i, p := range []string{filepath.Join(ssh, "id_rsa"), filepath.Join(cfg.ColimaStateRoot, "..", ".ssh", "id_rsa")} {
+		rec := sessions.SessionRecord{Version: 1, SessionID: fmt.Sprintf("sess-evil%d", i), Profile: "wcl-strict", TargetKind: "vm", TargetProvider: "colima", TargetID: "default", TargetAssuranceClass: "strict", RuntimeAPI: "docker", WorkspaceTransport: "direct", Agent: "codex", Mode: "strict", Status: "running", Workspace: cfg.RepoRoot, StartedAt: "2026-07-04T09:00:00Z", AuditLogPath: p}
+		writeSessionRecord(t, dir, rec.SessionID+".json", rec)
+	}
+	for _, ptr := range Collect(cfg).AuditPointers.Pointers {
+		if strings.HasPrefix(ptr.SessionID, "sess-evil") && ptr.Present {
+			t.Fatalf("statted an out-of-state audit path (session %s)", ptr.SessionID)
 		}
 	}
 }

--- a/internal/supportbundle/collect_test.go
+++ b/internal/supportbundle/collect_test.go
@@ -4,9 +4,52 @@
 package supportbundle
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/host/sessions"
 )
+
+// TestCollectSessionsKeepsNewestOnTruncation guards the truncation-order fix:
+// past maxSessionSummaries records the bundle must keep the NEWEST sessions
+// (timestamp-prefixed IDs), not the oldest, so the session under investigation
+// is present.
+func TestCollectSessionsKeepsNewestOnTruncation(t *testing.T) {
+	cfg := buildFixture(t, fixtureOptions{sessionStatus: "running"})
+	dir := filepath.Join(cfg.ColimaStateRoot, "wcl-strict")
+	rec := sessions.SessionRecord{Version: 1, Profile: "wcl-strict", TargetKind: "vm", TargetProvider: "colima", TargetID: "default", TargetAssuranceClass: "strict", RuntimeAPI: "docker", WorkspaceTransport: "direct", Agent: "codex", Mode: "strict", Status: "running", Workspace: cfg.RepoRoot, StartedAt: "2026-07-04T09:00:00Z"}
+	total := maxSessionSummaries + 5
+	for i := 1; i <= total; i++ {
+		rec.SessionID = fmt.Sprintf("sess-2026%06d", i) // zero-padded: lexicographic == chronological
+		writeSessionRecord(t, dir, rec.SessionID+".json", rec)
+	}
+	out, err := Collect(cfg).JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	if r := string(out); !strings.Contains(r, fmt.Sprintf("sess-2026%06d", total)) || strings.Contains(r, fmt.Sprintf("sess-2026%06d", 1)) {
+		t.Fatalf("truncation kept the wrong sessions (want newest, dropped oldest)")
+	}
+}
+
+// TestCollectAuditPointersSkipsOutOfStatePaths guards the audit-path fix: a
+// record whose audit_log_path points outside the state tree must not have its
+// file metadata (presence/size/mtime) recorded.
+func TestCollectAuditPointersSkipsOutOfStatePaths(t *testing.T) {
+	cfg := buildFixture(t, fixtureOptions{sessionStatus: "running"})
+	outside := filepath.Join(t.TempDir(), "id_rsa")
+	mustWrite(t, outside, "PRIVATE")
+	dir := filepath.Join(cfg.ColimaStateRoot, "wcl-strict")
+	rec := sessions.SessionRecord{Version: 1, SessionID: "sess-evil", Profile: "wcl-strict", TargetKind: "vm", TargetProvider: "colima", TargetID: "default", TargetAssuranceClass: "strict", RuntimeAPI: "docker", WorkspaceTransport: "direct", Agent: "codex", Mode: "strict", Status: "running", Workspace: cfg.RepoRoot, StartedAt: "2026-07-04T09:00:00Z", AuditLogPath: outside}
+	writeSessionRecord(t, dir, "sess-evil.json", rec)
+	for _, p := range Collect(cfg).AuditPointers.Pointers {
+		if p.SessionID == "sess-evil" && p.Present {
+			t.Fatalf("statted an out-of-state audit path %q", outside)
+		}
+	}
+}
 
 // The scenario tests below cover one failure class each (install, policy,
 // target, provider, runtime) and assert the bundle carries the evidence a

--- a/internal/supportbundle/collect_test.go
+++ b/internal/supportbundle/collect_test.go
@@ -14,23 +14,28 @@ import (
 
 // TestCollectSessionsKeepsNewestOnTruncation guards the truncation-order fix:
 // past maxSessionSummaries records the bundle must keep the NEWEST sessions
-// (timestamp-prefixed IDs), not the oldest, so the session under investigation
-// is present.
+// (by StartedAt), not the oldest, so the session under investigation is present.
 func TestCollectSessionsKeepsNewestOnTruncation(t *testing.T) {
 	cfg := buildFixture(t, fixtureOptions{sessionStatus: "running"})
 	dir := filepath.Join(cfg.ColimaStateRoot, "wcl-strict")
-	rec := sessions.SessionRecord{Version: 1, Profile: "wcl-strict", TargetKind: "vm", TargetProvider: "colima", TargetID: "default", TargetAssuranceClass: "strict", RuntimeAPI: "docker", WorkspaceTransport: "direct", Agent: "codex", Mode: "strict", Status: "running", Workspace: cfg.RepoRoot, StartedAt: "2026-07-04T09:00:00Z"}
+	rec := sessions.SessionRecord{Version: 1, Profile: "wcl-strict", TargetKind: "vm", TargetProvider: "colima", TargetID: "default", TargetAssuranceClass: "strict", RuntimeAPI: "docker", WorkspaceTransport: "direct", Agent: "codex", Mode: "strict", Status: "running", Workspace: cfg.RepoRoot}
 	total := maxSessionSummaries + 5
+	// IDs are deliberately NOT timestamp-ordered: the record with the newest
+	// StartedAt gets the lexicographically smallest ID, so a sort on session ID
+	// would drop it. Truncation must key off StartedAt (newest-first).
 	for i := 1; i <= total; i++ {
-		rec.SessionID = fmt.Sprintf("sess-2026%06d", i) // zero-padded: lexicographic == chronological
-		writeSessionRecord(t, dir, rec.SessionID+".json", rec)
+		rec.SessionID = fmt.Sprintf("sess-id-%06d", total-i)     // decreasing with time
+		rec.StartedAt = fmt.Sprintf("2026-07-04T09:%02d:00Z", i) // increasing
+		writeSessionRecord(t, dir, fmt.Sprintf("s%03d.json", i), rec)
 	}
+	newest := fmt.Sprintf("sess-id-%06d", 0)       // i == total: latest StartedAt
+	oldest := fmt.Sprintf("sess-id-%06d", total-1) // i == 1: earliest StartedAt
 	out, err := Collect(cfg).JSON()
 	if err != nil {
 		t.Fatalf("JSON: %v", err)
 	}
-	if r := string(out); !strings.Contains(r, fmt.Sprintf("sess-2026%06d", total)) || strings.Contains(r, fmt.Sprintf("sess-2026%06d", 1)) {
-		t.Fatalf("truncation kept the wrong sessions (want newest, dropped oldest)")
+	if r := string(out); !strings.Contains(r, newest) || strings.Contains(r, oldest) {
+		t.Fatalf("truncation did not key off StartedAt (want %s kept, %s dropped)", newest, oldest)
 	}
 }
 

--- a/internal/supportbundle/run.go
+++ b/internal/supportbundle/run.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -50,6 +51,7 @@ hand; each falls back to the matching environment/default when omitted:
 func Run(args []string, stdout, stderr io.Writer) error {
 	cfg := Config{Now: time.Now()}
 	output := ""
+	outputSet := false
 
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -62,9 +64,9 @@ func Run(args []string, stdout, stderr io.Writer) error {
 			if !ok {
 				return usageError("--output requires a value")
 			}
-			output, i = value, next
+			output, i, outputSet = value, next, true
 		case strings.HasPrefix(arg, "--output="):
-			output = strings.TrimPrefix(arg, "--output=")
+			output, outputSet = strings.TrimPrefix(arg, "--output="), true
 		default:
 			key, value, hasEq := strings.Cut(arg, "=")
 			if !hasEq {
@@ -82,7 +84,10 @@ func Run(args []string, stdout, stderr io.Writer) error {
 		}
 	}
 
-	if output != "" && strings.TrimSpace(output) == "" {
+	// An explicitly supplied but empty --output is a usage error, not a silent
+	// fall-through to stdout that would dump the private bundle where automation
+	// expected a file.
+	if outputSet && strings.TrimSpace(output) == "" {
 		return usageError("--output path may not be blank")
 	}
 
@@ -91,21 +96,39 @@ func Run(args []string, stdout, stderr io.Writer) error {
 		return err
 	}
 
-	if output == "" {
+	if !outputSet {
 		_, err := stdout.Write(rendered)
 		return err
 	}
-	if err := os.WriteFile(output, rendered, 0o600); err != nil {
-		return err
-	}
-	// os.WriteFile keeps an existing file's mode, so enforce 0600 explicitly: an
-	// already-present group/world-readable target must not leave the diagnostics
-	// bundle readable to other local users.
-	if err := os.Chmod(output, 0o600); err != nil {
+	if err := writeBundleFile(output, rendered); err != nil {
 		return err
 	}
 	fmt.Fprintf(stdout, "wrote support bundle to %s\n", output)
 	return nil
+}
+
+// writeBundleFile writes the bundle to a sibling 0600 temp file and renames it
+// into place, so the diagnostics are never briefly readable under a pre-existing
+// target's looser mode (the file is created 0600 and only then made visible).
+func writeBundleFile(output string, rendered []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(output), ".support-bundle-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(rendered); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, output)
 }
 
 func applyContextFlag(cfg *Config, key, value string) error {

--- a/internal/supportbundle/run.go
+++ b/internal/supportbundle/run.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package supportbundle
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/omkhar/workcell/internal/cliexit"
+)
+
+// UsageText is the `workcell support-bundle --help` body. It names the
+// canonical `workcell support-bundle` syntax so the operator-contract
+// discoverability check can find it.
+func UsageText() string {
+	return `Usage: workcell support-bundle [options]
+
+Collect a redacted host-side diagnostics bundle (install, policy, target,
+provider, session, and audit-pointer evidence) as a single JSON document.
+
+The bundle never contains credential material or workspace/agent content:
+credential files are recorded by path and presence only, log bodies by
+pointer only, and every string is passed through a secret redactor. See
+SUPPORT.md for the full redaction guarantees before sharing a bundle.
+
+Options:
+  --output PATH   Write the bundle to PATH (default: stdout)
+  -h, --help      Show this help text
+
+The following options are supplied by the launcher and are not usually set by
+hand; each falls back to the matching environment/default when omitted:
+  --repo-root DIR            Workcell install/checkout root
+  --launcher PATH            Path to the scripts/workcell launcher
+  --real-home DIR            Operator home directory (redaction root)
+  --workcell-state-root DIR  WORKCELL_STATE_ROOT
+  --colima-state-root DIR    COLIMA_STATE_ROOT
+  --host-os NAME             Host OS label
+  --host-arch NAME           Host architecture label
+`
+}
+
+// Run is the `workcell support-bundle` entry point. It parses flags, collects a
+// redacted bundle from the host context, and writes deterministic JSON to
+// stdout or --output. Usage/validation failures return a Code-2
+// cliexit.ExitCodeError to match the launcher's exit-code contract.
+func Run(args []string, stdout, stderr io.Writer) error {
+	cfg := Config{Now: time.Now()}
+	output := ""
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-h" || arg == "--help":
+			fmt.Fprint(stdout, UsageText())
+			return nil
+		case arg == "--output":
+			value, next, ok := takeValue(args, i)
+			if !ok {
+				return usageError("--output requires a value")
+			}
+			output, i = value, next
+		case strings.HasPrefix(arg, "--output="):
+			output = strings.TrimPrefix(arg, "--output=")
+		default:
+			key, value, hasEq := strings.Cut(arg, "=")
+			if !hasEq {
+				var next int
+				var ok bool
+				value, next, ok = takeValue(args, i)
+				if !ok {
+					return usageError(fmt.Sprintf("%s requires a value", key))
+				}
+				i = next
+			}
+			if err := applyContextFlag(&cfg, key, value); err != nil {
+				return err
+			}
+		}
+	}
+
+	if output != "" && strings.TrimSpace(output) == "" {
+		return usageError("--output path may not be blank")
+	}
+
+	rendered, err := Collect(cfg).JSON()
+	if err != nil {
+		return err
+	}
+
+	if output == "" {
+		_, err := stdout.Write(rendered)
+		return err
+	}
+	if err := os.WriteFile(output, rendered, 0o600); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "wrote support bundle to %s\n", output)
+	return nil
+}
+
+func applyContextFlag(cfg *Config, key, value string) error {
+	switch key {
+	case "--repo-root":
+		cfg.RepoRoot = value
+	case "--launcher":
+		cfg.LauncherPath = value
+	case "--real-home":
+		cfg.RealHome = value
+	case "--workcell-state-root":
+		cfg.WorkcellStateRoot = value
+	case "--colima-state-root":
+		cfg.ColimaStateRoot = value
+	case "--host-os":
+		cfg.HostOS = value
+	case "--host-arch":
+		cfg.HostArch = value
+	default:
+		return usageError(fmt.Sprintf("unknown option: %s", key))
+	}
+	return nil
+}
+
+// takeValue returns the value following args[i] as a separate token, the new
+// index, and whether a value was available.
+func takeValue(args []string, i int) (string, int, bool) {
+	if i+1 >= len(args) {
+		return "", i, false
+	}
+	return args[i+1], i + 1, true
+}
+
+func usageError(msg string) error {
+	return &cliexit.ExitCodeError{Code: 2, Message: msg}
+}

--- a/internal/supportbundle/run.go
+++ b/internal/supportbundle/run.go
@@ -98,6 +98,12 @@ func Run(args []string, stdout, stderr io.Writer) error {
 	if err := os.WriteFile(output, rendered, 0o600); err != nil {
 		return err
 	}
+	// os.WriteFile keeps an existing file's mode, so enforce 0600 explicitly: an
+	// already-present group/world-readable target must not leave the diagnostics
+	// bundle readable to other local users.
+	if err := os.Chmod(output, 0o600); err != nil {
+		return err
+	}
 	fmt.Fprintf(stdout, "wrote support bundle to %s\n", output)
 	return nil
 }

--- a/internal/supportbundle/run_test.go
+++ b/internal/supportbundle/run_test.go
@@ -115,6 +115,17 @@ func TestRunMissingValueIsUsageError(t *testing.T) {
 	assertUsageError(t, err)
 }
 
+// TestRunEmptyOutputIsUsageError guards that an explicitly empty --output is a
+// usage error, not a silent fall-through that dumps the private bundle to stdout.
+func TestRunEmptyOutputIsUsageError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := Run([]string{"--output="}, &stdout, &stderr)
+	assertUsageError(t, err)
+	if stdout.Len() > 0 {
+		t.Fatalf("empty --output dumped bundle to stdout: %q", stdout.String())
+	}
+}
+
 func assertUsageError(t *testing.T, err error) {
 	t.Helper()
 	var ec *cliexit.ExitCodeError

--- a/internal/supportbundle/run_test.go
+++ b/internal/supportbundle/run_test.go
@@ -115,6 +115,23 @@ func TestRunMissingValueIsUsageError(t *testing.T) {
 	assertUsageError(t, err)
 }
 
+// TestRunContextIsLastWins guards the assumption the launcher relies on: trusted
+// context appended after the operator's args wins, so a user-supplied duplicate
+// (e.g. --real-home) cannot override the real redaction root.
+func TestRunContextIsLastWins(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := Run([]string{"--host-os=attacker", "--host-os=darwin"}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	var b Bundle
+	if err := json.Unmarshal(stdout.Bytes(), &b); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if b.Install.HostOS != "darwin" {
+		t.Fatalf("last --host-os did not win: got %q, want darwin", b.Install.HostOS)
+	}
+}
+
 // TestRunEmptyOutputIsUsageError guards that an explicitly empty --output is a
 // usage error, not a silent fall-through that dumps the private bundle to stdout.
 func TestRunEmptyOutputIsUsageError(t *testing.T) {

--- a/internal/supportbundle/run_test.go
+++ b/internal/supportbundle/run_test.go
@@ -70,6 +70,27 @@ func TestRunOutputFile(t *testing.T) {
 	}
 }
 
+// TestRunOutputTightensExistingMode guards that overwriting a pre-existing,
+// group/world-readable target still yields a 0600 bundle (os.WriteFile keeps the
+// existing mode, so the explicit chmod is load-bearing).
+func TestRunOutputTightensExistingMode(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "bundle.json")
+	if err := os.WriteFile(out, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := Run([]string{"--output", out}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run(--output): %v", err)
+	}
+	info, err := os.Stat(out)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("overwritten bundle perms = %v, want 0600", perm)
+	}
+}
+
 func TestRunOutputEqualsForm(t *testing.T) {
 	dir := t.TempDir()
 	out := filepath.Join(dir, "b.json")

--- a/internal/supportbundle/run_test.go
+++ b/internal/supportbundle/run_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package supportbundle
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/cliexit"
+)
+
+func TestRunHelp(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := Run([]string{"--help"}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run(--help): %v", err)
+	}
+	if !strings.Contains(stdout.String(), "workcell support-bundle") {
+		t.Fatalf("help missing canonical syntax:\n%s", stdout.String())
+	}
+}
+
+func TestRunStdoutEmitsValidJSON(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := Run([]string{"--host-os", "darwin", "--host-arch", "arm64"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	var b Bundle
+	if err := json.Unmarshal(stdout.Bytes(), &b); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout.String())
+	}
+	if b.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema_version = %q", b.SchemaVersion)
+	}
+	if b.Install.HostOS != "darwin" {
+		t.Fatalf("host os flag not applied: %q", b.Install.HostOS)
+	}
+}
+
+func TestRunOutputFile(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "bundle.json")
+	var stdout, stderr bytes.Buffer
+	if err := Run([]string{"--output", out}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run(--output): %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var b Bundle
+	if err := json.Unmarshal(data, &b); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	if !strings.Contains(stdout.String(), out) {
+		t.Fatalf("expected confirmation on stdout, got %q", stdout.String())
+	}
+	info, err := os.Stat(out)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("bundle file perms = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestRunOutputEqualsForm(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "b.json")
+	var stdout, stderr bytes.Buffer
+	if err := Run([]string{"--output=" + out}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run(--output=): %v", err)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("output not written: %v", err)
+	}
+}
+
+func TestRunUnknownFlagIsUsageError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := Run([]string{"--bogus", "x"}, &stdout, &stderr)
+	assertUsageError(t, err)
+}
+
+func TestRunMissingValueIsUsageError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := Run([]string{"--output"}, &stdout, &stderr)
+	assertUsageError(t, err)
+}
+
+func assertUsageError(t *testing.T, err error) {
+	t.Helper()
+	var ec *cliexit.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected ExitCodeError, got %v", err)
+	}
+	if ec.Code != 2 {
+		t.Fatalf("exit code = %d, want 2", ec.Code)
+	}
+}

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -324,6 +324,9 @@ func TestInstallWorkcellDebugWrapperSkipsSessionCommands(t *testing.T) {
 	for _, want := range []string{
 		"session)",
 		"SKIP_AUTO_DEBUG=1",
+		// The support-bundle diagnostics command emits clean JSON on stdout
+		// and must not have --debug-log/--rebuild injected by the wrapper.
+		"support-bundle)",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("%s does not contain %q", scriptPath, want)

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -19,6 +19,9 @@ workcell \- bounded runtime launcher for coding agents
 .br
 .B workcell why
 --credential \fIKEY\fR --agent \fINAME\fR [\fIoptions\fR]
+.br
+.B workcell support-bundle
+[\fIoptions\fR]
 .SH DESCRIPTION
 .B workcell
 starts the selected coding agent inside a bounded local runtime with explicit
@@ -53,6 +56,17 @@ Explain why a credential is selected, filtered, or still only configured for a
 specific agent and mode without starting the runtime. The output also includes
 bootstrap path, support tier, and next-step fields for the selected
 credential.
+.TP
+.B workcell support-bundle
+Collect a redacted host-side diagnostics bundle (install, policy, target,
+provider, session, and audit-pointer evidence) as a single deterministic JSON
+document, without starting the runtime. Credential material and workspace or
+agent content are never included; see
+.B SUPPORT.md
+for the redaction guarantees. Use
+.B --output
+.I PATH
+to write the bundle to a file instead of standard output.
 .SH OPTIONS
 .TP
 .B --agent codex|claude|copilot|gemini

--- a/policy/operator-contract.toml
+++ b/policy/operator-contract.toml
@@ -371,6 +371,20 @@ evidence = ["scripts/verify-invariants.sh", "tests/scenarios/shared/test-session
 requirements = ["functional.FR-006"]
 target_state = "retain"
 
+[workflows.support_bundle]
+title = "Host-side support bundle"
+support = "supported"
+canonical = "workcell support-bundle"
+discoverability = ["top-level-help", "subcommand-help:support-bundle", "manpage"]
+docs = ["SUPPORT.md", "man/workcell.1"]
+evidence = [
+  "internal/supportbundle/leak_test.go",
+  "internal/supportbundle/bundle_test.go",
+  "internal/supportbundle/collect_test.go",
+]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
 [workflows.cache_profile_standard]
 title = "Opt-in persistent cache plane"
 support = "supported"

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -110,6 +110,7 @@ workflows = [
   "launch_logs",
   "launch_auth_status",
   "launch_gc",
+  "support_bundle",
 ]
 evidence = [
   "scripts/verify-invariants.sh",
@@ -122,6 +123,9 @@ evidence = [
   "tests/scenarios/shared/test-agent-launch-smoke.sh",
   "tests/scenarios/shared/test-docker-desktop-launch-smoke.sh",
   "tests/scenarios/shared/test-session-commands.sh",
+  "internal/supportbundle/leak_test.go",
+  "internal/supportbundle/bundle_test.go",
+  "internal/supportbundle/collect_test.go",
 ]
 docs = [
   "README.md",
@@ -130,6 +134,7 @@ docs = [
   "docs/injection-policy.md",
   "docs/provider-bootstrap-matrix.md",
   "docs/validation-scenarios.md",
+  "SUPPORT.md",
 ]
 
 [functional.FR-007]

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "134aa488bec0a5f75b7dbe595e37d550d5706c17ef8af02af9d4cbdfb0f9fb6a"
+      "sha256": "a26c3cb56a7b82855a6cd5a5ec197814854a8e2bebc101a13bf6b02a1d7fa22b"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "89716eb667469a15036541edd1857b79452911312aba1e4a8decb92a4caa3e19"
+      "sha256": "134aa488bec0a5f75b7dbe595e37d550d5706c17ef8af02af9d4cbdfb0f9fb6a"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/install-workcell.sh
+++ b/scripts/install-workcell.sh
@@ -204,7 +204,7 @@ chmod 0700 "\${DEBUG_DIR}" 2>/dev/null || true
 
 for ARG in "\$@"; do
   case "\${ARG}" in
-    --auth-status | --doctor | --gc | --help | --inspect | --logs | --prepare-only | -h | auth-status | doctor | gc | help | inspect | logs | publish-pr)
+    --auth-status | --doctor | --gc | --help | --inspect | --logs | --prepare-only | -h | auth-status | doctor | gc | help | inspect | logs | publish-pr | support-bundle)
       SKIP_AUTO_DEBUG=1
       ;;
     session)

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -3709,15 +3709,18 @@ support_bundle_main() {
         ;;
     esac
   done
+  # Trusted launcher context comes AFTER the operator's args so a user-supplied
+  # duplicate (e.g. --real-home /tmp) cannot override the real redaction root:
+  # supportbundle.Run is last-wins, so the trusted values here take precedence.
   run_go_hostutil_preserve_exit support-bundle-cli \
+    "${args[@]}" \
     "--repo-root=${ROOT_DIR}" \
     "--launcher=${BASH_SOURCE[0]}" \
     "--real-home=${REAL_HOME}" \
     "--workcell-state-root=${WORKCELL_STATE_ROOT:-}" \
     "--colima-state-root=${COLIMA_STATE_ROOT:-}" \
     "--host-os=$(detected_host_os)" \
-    "--host-arch=$(detected_host_arch)" \
-    "${args[@]}" || rc=$?
+    "--host-arch=$(detected_host_arch)" || rc=$?
   exit "${rc}"
 }
 

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -3677,7 +3677,31 @@ session_usage() {
 # run_go_hostutil_preserve_exit recovers the child's real exit code from its
 # "exit status N" trailer so usage failures keep their code-2 contract.
 support_bundle_main() {
-  local rc=0
+  local rc=0 invocation_pwd="${PWD}"
+  # The helper runs from ROOT_DIR, so absolutize a relative --output against the
+  # operator's current directory before delegating; otherwise the bundle would
+  # be written into (or fail against) the install checkout instead of their cwd.
+  local -a args=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --output=*)
+        local val="${1#--output=}"
+        [[ -n "${val}" && "${val}" != /* ]] && val="${invocation_pwd}/${val}"
+        args+=("--output=${val}")
+        shift
+        ;;
+      --output)
+        local val="${2:-}"
+        [[ -n "${val}" && "${val}" != /* ]] && val="${invocation_pwd}/${val}"
+        args+=("--output" "${val}")
+        shift 2
+        ;;
+      *)
+        args+=("$1")
+        shift
+        ;;
+    esac
+  done
   run_go_hostutil_preserve_exit support-bundle-cli \
     "--repo-root=${ROOT_DIR}" \
     "--launcher=${BASH_SOURCE[0]}" \
@@ -3686,7 +3710,7 @@ support_bundle_main() {
     "--colima-state-root=${COLIMA_STATE_ROOT:-}" \
     "--host-os=$(detected_host_os)" \
     "--host-arch=$(detected_host_arch)" \
-    "$@" || rc=$?
+    "${args[@]}" || rc=$?
   exit "${rc}"
 }
 

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -3691,17 +3691,17 @@ support_bundle_main() {
         shift
         ;;
       --output)
+        # Reject a trailing --output here (exit 2): passing the bare flag through
+        # would let it swallow an appended trusted-context flag as its value.
         if [[ $# -lt 2 ]]; then
-          # No value: pass the bare flag through so the Go parser emits the
-          # documented usage error (exit 2) rather than set -e aborting shift 2.
-          args+=("$1")
-          shift
-        else
-          local val="$2"
-          [[ -n "${val}" && "${val}" != /* ]] && val="${invocation_pwd}/${val}"
-          args+=("--output" "${val}")
-          shift 2
+          echo "Option --output requires a value." >&2
+          usage >&2
+          exit 2
         fi
+        local val="$2"
+        [[ -n "${val}" && "${val}" != /* ]] && val="${invocation_pwd}/${val}"
+        args+=("--output" "${val}")
+        shift 2
         ;;
       *)
         args+=("$1")

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -3703,6 +3703,17 @@ support_bundle_main() {
         args+=("--output" "${val}")
         shift 2
         ;;
+      --repo-root | --repo-root=* | --launcher | --launcher=* | \
+        --real-home | --real-home=* | --workcell-state-root | --workcell-state-root=* | \
+        --colima-state-root | --colima-state-root=* | --host-os | --host-os=* | \
+        --host-arch | --host-arch=*)
+        # These context flags are supplied by the launcher itself; a user-supplied
+        # copy could corrupt the redaction root (or, left dangling, swallow the
+        # trusted flag appended below as its value). Reject them outright.
+        echo "Option ${1%%=*} is set by the launcher and cannot be passed on the command line." >&2
+        usage >&2
+        exit 2
+        ;;
       *)
         args+=("$1")
         shift

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -3691,10 +3691,17 @@ support_bundle_main() {
         shift
         ;;
       --output)
-        local val="${2:-}"
-        [[ -n "${val}" && "${val}" != /* ]] && val="${invocation_pwd}/${val}"
-        args+=("--output" "${val}")
-        shift 2
+        if [[ $# -lt 2 ]]; then
+          # No value: pass the bare flag through so the Go parser emits the
+          # documented usage error (exit 2) rather than set -e aborting shift 2.
+          args+=("$1")
+          shift
+        else
+          local val="$2"
+          [[ -n "${val}" && "${val}" != /* ]] && val="${invocation_pwd}/${val}"
+          args+=("--output" "${val}")
+          shift 2
+        fi
         ;;
       *)
         args+=("$1")

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -415,6 +415,7 @@ Usage: workcell [options] [-- provider-args...]
        workcell auth <init|set|unset|status> [options]
        workcell policy <show|validate|diff> [options]
        workcell why --credential KEY --agent NAME [options]
+       workcell support-bundle [options]
 
 Options:
   --agent codex|claude|copilot|gemini
@@ -533,6 +534,7 @@ Workflows:
     workcell publish-pr --workspace /path/to/repo --branch feature/name \
       --title-file /path/to/pr-title.txt --body-file /path/to/pr-body.md \
       --commit-message-file /path/to/commit-message.txt
+    workcell support-bundle --output /path/to/workcell-support-bundle.json
     workcell gc
 
 Workcell launches the selected provider directly inside the bounded runtime.
@@ -3667,6 +3669,25 @@ publish_pr_main() {
 
 session_usage() {
   go_hostutil session-usage
+}
+
+# support_bundle_main collects the host-side diagnostics bundle (roadmap G2).
+# All host context is forwarded on argv because go_hostutil routes through
+# run_clean_host_command (env -i); the Go collector never reads process env.
+# run_go_hostutil_preserve_exit recovers the child's real exit code from its
+# "exit status N" trailer so usage failures keep their code-2 contract.
+support_bundle_main() {
+  local rc=0
+  run_go_hostutil_preserve_exit support-bundle-cli \
+    "--repo-root=${ROOT_DIR}" \
+    "--launcher=${BASH_SOURCE[0]}" \
+    "--real-home=${REAL_HOME}" \
+    "--workcell-state-root=${WORKCELL_STATE_ROOT:-}" \
+    "--colima-state-root=${COLIMA_STATE_ROOT:-}" \
+    "--host-os=$(detected_host_os)" \
+    "--host-arch=$(detected_host_arch)" \
+    "$@" || rc=$?
+  exit "${rc}"
 }
 
 session_git_metadata_lines() {
@@ -7915,6 +7936,11 @@ fi
 if [[ "${1:-}" == "why" ]]; then
   shift
   why_main "$@"
+fi
+
+if [[ "${1:-}" == "support-bundle" ]]; then
+  shift
+  support_bundle_main "$@"
 fi
 
 if [[ $# -gt 0 ]]; then


### PR DESCRIPTION
**G2: Support Bundle Command — part 3 of 3 (final).** Wires the user-facing command on top of the merged redaction core (PR-1) and collector (PR-2), and lands the two audit fixes + truncation test deferred from PR-2 for shape budget.

## What
- **`workcell support-bundle`**: launcher dispatch (`support_bundle_main`), `cmd/workcell-hostutil` entrypoints, `run.go` orchestration, `operator-contract.toml` + manpage + `SUPPORT.md`.
- **Deferred collector fixes (from PR-2's review)**: (a) `audit_log_path` is validated to resolve under a discovered state root before its file metadata is statted — a malformed/hand-edited record can no longer make the bundle probe `~/.ssh/id_rsa`; (b) audit pointers are capped to the newest-first recent window like the session summaries, bounding bundle size on long-lived hosts.
- **Deferred tests**: the bulk-truncation regression (>50 sessions → newest kept) and an out-of-state-audit-path test.

## Validation
`go test ./...`, shellcheck/shfmt on `scripts/workcell`, `verify-operator-contract.sh`, markdownlint (SUPPORT.md), doc-links — all green. 455 lines / 12 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)