### PR TITLE
^R D4: extract trusted host-command execution into scripts/lib/launcher/host-exec.sh

### DIFF
--- a/docs/launcher-contract.md
+++ b/docs/launcher-contract.md
@@ -71,3 +71,40 @@ its value verbatim:
 These variables are reserved for the validation harness. The launcher scrubs
 them from the host process environment unless the sanitized-entrypoint marker
 is set, so they cannot be smuggled in by an operator to spoof the detected host.
+
+## Trusted host-command execution (`host-exec.sh`)
+
+`scripts/lib/launcher/host-exec.sh` resolves fixed, trusted host tools and runs
+host commands under a sanitised environment. Every helper depends only on
+`env`/`cd` builtins, the readonly `TRUSTED_HOST_PATH`, `REAL_HOME` (used with a
+fallback), and `resolve_workcell_real_home` (from
+`scripts/lib/trusted-docker-client.sh`) — no other launcher function — which
+makes the module self-contained.
+
+### `resolve_fixed_host_tool()`
+
+Resolves a trusted host tool from an allowlist of absolute candidate paths.
+Called as `resolve_fixed_host_tool <name> <candidate>...`; prints the first
+candidate that is executable (`-x`) and returns `0`. If no candidate is
+executable it prints `Missing trusted host tool: <name>` to stderr and exits
+`1`. Only fixed, caller-supplied absolute paths are considered, so the resolved
+binary never depends on a `PATH` search.
+
+### `run_clean_host_command()`
+
+Runs a host command under a sanitised environment. With no arguments it is a
+no-op returning `0`. Otherwise it resolves the host home (`REAL_HOME`, falling
+back to `resolve_workcell_real_home`, then `/` if neither is a directory),
+`cd`s into that home, and execs the command via `env -i` with only
+`PATH="${TRUSTED_HOST_PATH}"`, `HOME`, and `LC_ALL=C`/`LANG=C` set. The command
+runs in a subshell so the launcher's own working directory and environment are
+unaffected, and the command's exit status is propagated.
+
+### `run_clean_host_command_in_dir()`
+
+Same sanitised `env -i` execution as `run_clean_host_command()`, but runs the
+command from a caller-supplied working directory. Called as
+`run_clean_host_command_in_dir <dir> <cmd>...`. If `<dir>` is not a directory it
+prints `Missing host working directory: <dir>` to stderr and exits `2`. With no
+command arguments it is a no-op returning `0`. `HOME` resolution and the pinned
+`PATH`/locale are identical to `run_clean_host_command()`.

--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -468,6 +468,7 @@ func GenerateControlPlaneManifest(rootDir, outputPath string) error {
 		"scripts/check-publish-commit-signatures.sh",
 		"scripts/lib/extract_direct_mounts",
 		"scripts/lib/launcher/host-detect.sh",
+		"scripts/lib/launcher/host-exec.sh",
 		"scripts/lib/render_injection_bundle",
 		"scripts/lib/sessionctl-shim.sh",
 		"scripts/lib/shellproto.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "b637943a4c428a591afe37647358cf8af9fdd54d091c5d1254a9986354b57fe5"
+      "sha256": "8cad3d7c2f99071a346a478a45915c6a3ff2997c94133c6c8384e3893b79eec3"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",
@@ -15,6 +15,10 @@
     {
       "repo_path": "scripts/lib/launcher/host-detect.sh",
       "sha256": "318ac47025849d41e98b775e8d0d4209ae4ba80e1eeebfa393244ebc24d36fbe"
+    },
+    {
+      "repo_path": "scripts/lib/launcher/host-exec.sh",
+      "sha256": "475bfcf95c6e3d20631ba2aacd43261fa116323191b1898a47afbf35c96fbd50"
     },
     {
       "repo_path": "scripts/lib/render_injection_bundle",

--- a/scripts/dev-quick-check.sh
+++ b/scripts/dev-quick-check.sh
@@ -51,6 +51,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/lib/extract_direct_mounts"
   "${ROOT_DIR}/scripts/lib/go-run-env.sh"
   "${ROOT_DIR}/scripts/lib/launcher/host-detect.sh"
+  "${ROOT_DIR}/scripts/lib/launcher/host-exec.sh"
   "${ROOT_DIR}/scripts/lib/manage_injection_policy"
   "${ROOT_DIR}/scripts/lib/pty_transcript"
   "${ROOT_DIR}/scripts/lib/render_injection_bundle"

--- a/scripts/lib/launcher/host-exec.sh
+++ b/scripts/lib/launcher/host-exec.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# shellcheck shell=bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Omkhar Arasaratnam
+#
+# scripts/lib/launcher/host-exec.sh — trusted host-command-execution
+# module extracted from scripts/workcell as the next increment of the
+# launcher decomposition (roadmap item D4).  These helpers resolve a
+# fixed, trusted host tool from an allowlist of absolute paths and run
+# host commands under a sanitised environment (env -i with a pinned
+# PATH/HOME and C locale), optionally from a caller-supplied working
+# directory.  They depend only on env/cd builtins, the readonly
+# TRUSTED_HOST_PATH, REAL_HOME (used with a fallback), and
+# resolve_workcell_real_home (provided by scripts/lib/trusted-docker-client.sh)
+# — no other launcher function — so they are a self-contained,
+# behaviour-preserving unit.  See docs/launcher-contract.md for the
+# module contract.
+
+resolve_fixed_host_tool() {
+  local name="$1"
+  shift
+  local candidate
+
+  for candidate in "$@"; do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  echo "Missing trusted host tool: ${name}" >&2
+  exit 1
+}
+
+run_clean_host_command() {
+  local home="${REAL_HOME:-}"
+
+  [[ "$#" -gt 0 ]] || return 0
+  if [[ -z "${home}" ]]; then
+    home="$(resolve_workcell_real_home 2>/dev/null || true)"
+  fi
+  if [[ ! -d "${home}" ]]; then
+    home="/"
+  fi
+
+  (
+    cd "${home}" &&
+      env -i \
+        PATH="${TRUSTED_HOST_PATH}" \
+        HOME="${home}" \
+        LC_ALL=C \
+        LANG=C \
+        "$@"
+  )
+}
+
+run_clean_host_command_in_dir() {
+  local dir="$1"
+  local home="${REAL_HOME:-}"
+
+  shift
+  [[ "$#" -gt 0 ]] || return 0
+  if [[ ! -d "${dir}" ]]; then
+    echo "Missing host working directory: ${dir}" >&2
+    exit 2
+  fi
+  if [[ -z "${home}" ]]; then
+    home="$(resolve_workcell_real_home 2>/dev/null || true)"
+  fi
+  if [[ ! -d "${home}" ]]; then
+    home="/"
+  fi
+
+  (
+    cd "${dir}" &&
+      env -i \
+        PATH="${TRUSTED_HOST_PATH}" \
+        HOME="${home}" \
+        LC_ALL=C \
+        LANG=C \
+        "$@"
+  )
+}

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -156,6 +156,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/lib/extract_direct_mounts"
   "${ROOT_DIR}/scripts/lib/go-run-env.sh"
   "${ROOT_DIR}/scripts/lib/launcher/host-detect.sh"
+  "${ROOT_DIR}/scripts/lib/launcher/host-exec.sh"
   "${ROOT_DIR}/scripts/lib/trusted-entrypoint.sh"
   "${ROOT_DIR}/scripts/lib/manage_injection_policy"
   "${ROOT_DIR}/scripts/lib/pty_transcript"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -66,72 +66,8 @@ source "${ROOT_DIR}/scripts/lib/shellproto.sh"
 source "${ROOT_DIR}/scripts/lib/sessionctl-shim.sh"
 # shellcheck source=/dev/null
 source "${ROOT_DIR}/scripts/lib/launcher/host-detect.sh"
-resolve_fixed_host_tool() {
-  local name="$1"
-  shift
-  local candidate
-
-  for candidate in "$@"; do
-    if [[ -x "${candidate}" ]]; then
-      printf '%s\n' "${candidate}"
-      return 0
-    fi
-  done
-
-  echo "Missing trusted host tool: ${name}" >&2
-  exit 1
-}
-
-run_clean_host_command() {
-  local home="${REAL_HOME:-}"
-
-  [[ "$#" -gt 0 ]] || return 0
-  if [[ -z "${home}" ]]; then
-    home="$(resolve_workcell_real_home 2>/dev/null || true)"
-  fi
-  if [[ ! -d "${home}" ]]; then
-    home="/"
-  fi
-
-  (
-    cd "${home}" &&
-      env -i \
-        PATH="${TRUSTED_HOST_PATH}" \
-        HOME="${home}" \
-        LC_ALL=C \
-        LANG=C \
-        "$@"
-  )
-}
-
-run_clean_host_command_in_dir() {
-  local dir="$1"
-  local home="${REAL_HOME:-}"
-
-  shift
-  [[ "$#" -gt 0 ]] || return 0
-  if [[ ! -d "${dir}" ]]; then
-    echo "Missing host working directory: ${dir}" >&2
-    exit 2
-  fi
-  if [[ -z "${home}" ]]; then
-    home="$(resolve_workcell_real_home 2>/dev/null || true)"
-  fi
-  if [[ ! -d "${home}" ]]; then
-    home="/"
-  fi
-
-  (
-    cd "${dir}" &&
-      env -i \
-        PATH="${TRUSTED_HOST_PATH}" \
-        HOME="${home}" \
-        LC_ALL=C \
-        LANG=C \
-        "$@"
-  )
-}
-
+# shellcheck source=/dev/null
+source "${ROOT_DIR}/scripts/lib/launcher/host-exec.sh"
 HOST_GO_BIN="$(resolve_fixed_host_tool go /opt/homebrew/bin/go /usr/local/go/bin/go /usr/local/bin/go /usr/bin/go)"
 REAL_HOME="$(resolve_workcell_real_home)"
 case "$(uname -s 2>/dev/null || true)" in


### PR DESCRIPTION
**D4 (modularize the launcher) — increment 2 of N.** Follows #394 (host-detection module, merged). Extracts the trusted-host-command-execution primitives from the 9k-line `scripts/workcell` into a sourced module.

## What
- **New module** `scripts/lib/launcher/host-exec.sh`: `resolve_fixed_host_tool`, `run_clean_host_command`, `run_clean_host_command_in_dir` moved **verbatim** (byte-identical, md5-confirmed) from `scripts/workcell`. Contiguous block; nothing left behind. Dependencies (`TRUSTED_HOST_PATH`, `resolve_workcell_real_home` from the already-sourced `trusted-docker-client.sh`) resolve before the source line; first call site is after it.
- `scripts/workcell`: block deleted + one `source …/host-exec.sh` line.
- **`internal/metadatautil/core.go`**: added the module to `hostArtifacts` so it's inside the signed control-plane manifest (the provenance step Codex flagged on #394); manifest regenerated.
- Registered in the `shell_files` gates (`validate-repo.sh`, `dev-quick-check.sh`); added its contract section to `docs/launcher-contract.md`.

## Behavior-preserving
Pure move, zero logic change — the extracted functions are byte-identical (md5 match) and sourcing + calling returns identical results.

## Validation
`shellcheck -x`, `shfmt -d`, `bash -n scripts/workcell`, `go build`/`go test ./internal/metadatautil`, control-plane manifest verify, markdownlint — all green. 197 lines / 7 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)