### PR TITLE
^R D3: migrate scripts/workcell hardening invariants from verify-invariants.sh to Go

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/omkhar/workcell/internal/mutation"
 	"github.com/omkhar/workcell/internal/paritytree"
 	"github.com/omkhar/workcell/internal/scenarios"
+	"github.com/omkhar/workcell/internal/workcellhardening"
 )
 
 func die(err error) {
@@ -94,6 +95,7 @@ func subcommands() []subcommand {
 		{"mutation-score", "POLICY_PATH", 1, 1, cmdMutationScore},
 		{"tree-compare", "LEFT_ROOT RIGHT_ROOT", 2, 2, cmdTreeCompare},
 		{"git-config-blocklist-parity", "ROOT_DIR", 1, 1, cmdGitConfigBlocklistParity},
+		{"workcell-hardening-invariants", "ROOT_DIR", 1, 1, cmdWorkcellHardeningInvariants},
 	}
 }
 
@@ -498,4 +500,12 @@ func cmdTreeCompare(args []string) error {
 // TOML key or prefix/suffix pattern is missing from any enforcer.
 func cmdGitConfigBlocklistParity(args []string) error {
 	return gitconfigblocklist.Check(args[0])
+}
+
+// cmdWorkcellHardeningInvariants runs the eleven scripts/workcell
+// hardening-invariant checks migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the
+// shell's original stderr message for the first violated invariant.
+func cmdWorkcellHardeningInvariants(args []string) error {
+	return workcellhardening.Check(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package workcellhardening re-implements the contiguous block of
+// scripts/workcell hardening-invariant checks that previously lived
+// inline in scripts/verify-invariants.sh (the eleven checks between the
+// codex-managed-config tmpdir cleanup and the install-deps barrier
+// fixtures).
+//
+// Each invariant pins one property of the host launcher scripts/workcell:
+// that run_host_colima restores the real host HOME, that the shebang
+// clears the host environment, that the process/Perl/DYLD/Docker
+// environment scrubbers are present, that Perl-backed shasum is absent,
+// and that the trusted Docker client / shellproto / sessionctl-shim
+// helpers are sourced.
+//
+// This is a behaviour-preserving migration of the shell block: the file
+// read target, the fixed-string vs. regex matching semantics, the exit
+// codes, and the stderr messages match the original
+// function_block_contains_fixed / head+grep / rg implementation.  The
+// per-check matching semantics were chosen to faithfully mirror the
+// shell:
+//
+//   - The run_host_colima check reuses function_block_contains_fixed's
+//     sed-range extraction (see extractNamedFunctionBlock) followed by a
+//     grep -Fq fixed-string containment.
+//   - The shebang check applies an anchored regex to the FIRST line only,
+//     mirroring `head -n1 ... | grep -q '^...$'`.
+//   - The scrub/unset/DYLD/shasum checks use `rg` patterns that contain
+//     no active regex metacharacters (DYLD_\* is a literal `DYLD_*`), so
+//     they are fixed-string containment checks; shasum is negative
+//     (present is a violation).
+//   - The three `source "${ROOT_DIR}/scripts/lib/....sh"` checks use `rg`
+//     patterns whose metacharacters are all escaped (\$ \{ \} \.), so
+//     they too reduce to fixed-string containment on the literal source
+//     line.
+package workcellhardening
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// launcherRelPath is the repo-relative path to the host launcher every
+// check inspects.  The shell hard-coded ${ROOT_DIR}/scripts/workcell for
+// each of head/grep/rg/function_block_contains_fixed.
+const launcherRelPath = "scripts/workcell"
+
+// checkKind selects how a check's pattern is matched against the launcher
+// contents.
+type checkKind int
+
+const (
+	// kindFunctionBlock requires needle (a fixed string) to appear inside
+	// the top-level bash function body named functionName, mirroring
+	// function_block_contains_fixed (sed-range extraction + grep -Fq).
+	kindFunctionBlock checkKind = iota
+	// kindFirstLineRegex requires the launcher's first line to match the
+	// anchored regex, mirroring `head -n1 ... | grep -q '^...$'`.
+	kindFirstLineRegex
+	// kindPresent requires the fixed string to appear anywhere in the
+	// launcher, mirroring an affirmative `rg -q FIXED`.
+	kindPresent
+	// kindAbsent requires the fixed string NOT to appear anywhere in the
+	// launcher, mirroring a negative `if rg -q FIXED; then ... exit 1`.
+	kindAbsent
+)
+
+// check is one hardening invariant: how to match, what to match, which
+// function to scope to (kindFunctionBlock only), and the exact stderr
+// message the shell emitted on violation.
+type check struct {
+	kind         checkKind
+	functionName string
+	pattern      string
+	message      string
+}
+
+// checks lists the eleven invariants in the same order as the former
+// inline block in scripts/verify-invariants.sh, so a reviewer can diff
+// the two one-to-one.
+var checks = []check{
+	{
+		kind:         kindFunctionBlock,
+		functionName: "run_host_colima",
+		pattern:      `HOME="${REAL_HOME}"`,
+		message:      "Expected run_host_colima to restore the real host HOME instead of the Docker client sandbox home",
+	},
+	{
+		kind:    kindFirstLineRegex,
+		pattern: `^#!/usr/bin/env -S -i PATH=.* BASH_ENV= ENV= /bin/bash$`,
+		message: "Expected scripts/workcell to use env -S -i with an absolute /bin/bash and cleared host environment",
+	},
+	{
+		kind:    kindPresent,
+		pattern: "scrub_host_process_env",
+		message: "Expected scripts/workcell to scrub hostile host process environment before host tool lookup",
+	},
+	{
+		kind:    kindPresent,
+		pattern: "unset PERL5OPT PERL5LIB PERLLIB PERL_MB_OPT PERL_MM_OPT",
+		message: "Expected scripts/workcell to scrub hostile Perl environment before host tool lookup",
+	},
+	{
+		kind:    kindPresent,
+		pattern: "DYLD_*",
+		message: "Expected scripts/workcell to scrub DYLD_* variables before host tool lookup",
+	},
+	{
+		kind:    kindAbsent,
+		pattern: "shasum -a 256",
+		message: "scripts/workcell still uses Perl-backed shasum for profile hashing",
+	},
+	{
+		kind:    kindPresent,
+		pattern: "unset DOCKER_CONTEXT",
+		message: "Expected scripts/workcell to scrub caller Docker context overrides before binding the managed daemon",
+	},
+	{
+		kind:    kindPresent,
+		pattern: "unset DOCKER_CLI_PLUGIN_EXTRA_DIRS",
+		message: "Expected scripts/workcell to scrub caller Docker CLI plugin overrides",
+	},
+	{
+		kind:    kindPresent,
+		pattern: `source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"`,
+		message: "Expected scripts/workcell to source the trusted Docker client helper",
+	},
+	{
+		kind:    kindPresent,
+		pattern: `source "${ROOT_DIR}/scripts/lib/shellproto.sh"`,
+		message: "Expected scripts/workcell to source the shellproto helper",
+	},
+	{
+		kind:    kindPresent,
+		pattern: `source "${ROOT_DIR}/scripts/lib/sessionctl-shim.sh"`,
+		message: "Expected scripts/workcell to source the sessionctl shim helper",
+	},
+}
+
+// Check runs the eleven scripts/workcell hardening invariants against the
+// repo rooted at rootDir, in the shell's original order.  It returns nil
+// when every invariant holds (the shell's exit 0), or an error whose
+// message equals the shell's stderr for the first violated invariant (the
+// shell's exit 1).
+//
+// A missing or unreadable scripts/workcell is treated as empty content,
+// exactly as the shell behaved: head/grep/rg/function_block_contains_fixed
+// all produce no match on a missing file, so the first affirmative check
+// (run_host_colima's HOME restore) fails with its message.
+func Check(rootDir string) error {
+	content, err := os.ReadFile(filepath.Join(rootDir, launcherRelPath))
+	if err != nil {
+		content = nil
+	}
+	text := string(content)
+
+	for _, c := range checks {
+		if !c.holds(text) {
+			return errors.New(c.message)
+		}
+	}
+	return nil
+}
+
+// holds reports whether the invariant is satisfied by the launcher text.
+func (c check) holds(text string) bool {
+	switch c.kind {
+	case kindFunctionBlock:
+		block := extractNamedFunctionBlock(text, c.functionName)
+		return strings.Contains(block, c.pattern)
+	case kindFirstLineRegex:
+		return regexp.MustCompile(c.pattern).MatchString(firstLine(text))
+	case kindPresent:
+		return strings.Contains(text, c.pattern)
+	case kindAbsent:
+		return !strings.Contains(text, c.pattern)
+	default:
+		return false
+	}
+}
+
+// firstLine returns text up to (but excluding) the first newline,
+// mirroring the single line that `head -n1` feeds to grep.
+func firstLine(text string) string {
+	if i := strings.IndexByte(text, '\n'); i >= 0 {
+		return text[:i]
+	}
+	return text
+}
+
+// extractNamedFunctionBlock replicates the shell's
+// extract_named_function_block, i.e. `sed -n '/^NAME()/,/^}/p'`: it
+// returns the lines from the first line beginning with `NAME()` through
+// the next line beginning with `}` (both inclusive).  As in sed, the
+// closing `^}` pattern is only tested on lines after the opening line, and
+// the range re-triggers if a later `NAME()` line appears, so every such
+// range is concatenated.  The result feeds a grep -Fq fixed-string check.
+func extractNamedFunctionBlock(text, name string) string {
+	openPrefix := name + "()"
+	var out []string
+	inBlock := false
+	for _, line := range strings.Split(text, "\n") {
+		if !inBlock {
+			if strings.HasPrefix(line, openPrefix) {
+				inBlock = true
+				out = append(out, line)
+			}
+			continue
+		}
+		out = append(out, line)
+		if strings.HasPrefix(line, "}") {
+			inBlock = false
+		}
+	}
+	return strings.Join(out, "\n")
+}

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package workcellhardening
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// happyLauncher is a minimal but structurally faithful scripts/workcell:
+// it satisfies all eleven invariants (the correct shebang on line 1, the
+// run_host_colima HOME restore inside the function body, every scrub /
+// unset / source substring, and no Perl-backed shasum).  Individual
+// negative cases mutate one property of this baseline.
+const happyLauncher = `#!/usr/bin/env -S -i PATH=/opt/homebrew/bin:/usr/bin:/bin BASH_ENV= ENV= /bin/bash
+set -euo pipefail
+
+scrub_host_process_env() {
+  unset PERL5OPT PERL5LIB PERLLIB PERL_MB_OPT PERL_MM_OPT
+  for var in $(compgen -v); do
+    case "${var}" in
+      DYLD_*) unset "${var}" ;;
+    esac
+  done
+  unset DOCKER_CONTEXT
+  unset DOCKER_CLI_PLUGIN_EXTRA_DIRS
+}
+
+source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
+source "${ROOT_DIR}/scripts/lib/shellproto.sh"
+source "${ROOT_DIR}/scripts/lib/sessionctl-shim.sh"
+
+run_host_colima() {
+  HOME="${REAL_HOME}" COLIMA_HOME="${COLIMA_STATE_ROOT}" "${HOST_COLIMA_BIN}" "$@"
+}
+`
+
+// writeLauncher materializes a fake repo with scripts/workcell set to the
+// given body; a body of "" means "do not create the file" (unreadable
+// launcher case).
+func writeLauncher(t *testing.T, body string) string {
+	t.Helper()
+	root := t.TempDir()
+	if body == "" {
+		return root
+	}
+	path := filepath.Join(root, launcherRelPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return root
+}
+
+func TestCheck(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string // "" means expect success
+	}{
+		{
+			name: "happy path all invariants hold",
+			body: happyLauncher,
+		},
+		{
+			// kindFunctionBlock: run_host_colima body lacks the HOME restore.
+			name:    "run_host_colima missing HOME restore",
+			body:    strings.Replace(happyLauncher, `HOME="${REAL_HOME}" `, "", 1),
+			wantErr: "Expected run_host_colima to restore the real host HOME instead of the Docker client sandbox home",
+		},
+		{
+			// kindFunctionBlock scoping: the HOME restore text exists in the
+			// file but OUTSIDE the run_host_colima body, so the block-scoped
+			// check must still fail (guards against the whole-file match the
+			// migration was designed to prevent).
+			name: "HOME restore only outside run_host_colima body",
+			body: strings.Replace(happyLauncher, `HOME="${REAL_HOME}" `, "", 1) +
+				"\ndecoy() {\n  HOME=\"${REAL_HOME}\" true\n}\n",
+			wantErr: "Expected run_host_colima to restore the real host HOME instead of the Docker client sandbox home",
+		},
+		{
+			// kindFirstLineRegex: wrong shebang on line 1.
+			name:    "wrong shebang",
+			body:    strings.Replace(happyLauncher, "#!/usr/bin/env -S -i PATH=/opt/homebrew/bin:/usr/bin:/bin BASH_ENV= ENV= /bin/bash", "#!/bin/bash", 1),
+			wantErr: "Expected scripts/workcell to use env -S -i with an absolute /bin/bash and cleared host environment",
+		},
+		{
+			// kindFirstLineRegex anchoring: the correct shebang appears, but
+			// not on the FIRST line, so the anchored line-1 check must fail.
+			name:    "correct shebang not on first line",
+			body:    "#!/bin/bash\n" + happyLauncher,
+			wantErr: "Expected scripts/workcell to use env -S -i with an absolute /bin/bash and cleared host environment",
+		},
+		{
+			// kindPresent: scrub_host_process_env removed.
+			name:    "missing scrub_host_process_env",
+			body:    strings.Replace(happyLauncher, "scrub_host_process_env", "some_other_name", 1),
+			wantErr: "Expected scripts/workcell to scrub hostile host process environment before host tool lookup",
+		},
+		{
+			// kindPresent: Perl unset line removed.
+			name:    "missing Perl scrub",
+			body:    strings.Replace(happyLauncher, "unset PERL5OPT PERL5LIB PERLLIB PERL_MB_OPT PERL_MM_OPT\n", "", 1),
+			wantErr: "Expected scripts/workcell to scrub hostile Perl environment before host tool lookup",
+		},
+		{
+			// kindPresent: literal DYLD_* removed.
+			name:    "missing DYLD scrub",
+			body:    strings.Replace(happyLauncher, "DYLD_*", "OTHER_", 1),
+			wantErr: "Expected scripts/workcell to scrub DYLD_* variables before host tool lookup",
+		},
+		{
+			// kindAbsent: Perl-backed shasum present is a violation.
+			name:    "shasum present",
+			body:    happyLauncher + "\nprofile_hash() { shasum -a 256 \"$1\"; }\n",
+			wantErr: "scripts/workcell still uses Perl-backed shasum for profile hashing",
+		},
+		{
+			// kindPresent: DOCKER_CONTEXT unset removed.
+			name:    "missing DOCKER_CONTEXT scrub",
+			body:    strings.Replace(happyLauncher, "unset DOCKER_CONTEXT\n", "", 1),
+			wantErr: "Expected scripts/workcell to scrub caller Docker context overrides before binding the managed daemon",
+		},
+		{
+			// kindPresent: DOCKER_CLI_PLUGIN_EXTRA_DIRS unset removed.
+			name:    "missing DOCKER_CLI_PLUGIN_EXTRA_DIRS scrub",
+			body:    strings.Replace(happyLauncher, "unset DOCKER_CLI_PLUGIN_EXTRA_DIRS\n", "", 1),
+			wantErr: "Expected scripts/workcell to scrub caller Docker CLI plugin overrides",
+		},
+		{
+			// kindPresent (source line): trusted-docker-client source removed.
+			name:    "missing trusted-docker-client source",
+			body:    strings.Replace(happyLauncher, `source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"`+"\n", "", 1),
+			wantErr: "Expected scripts/workcell to source the trusted Docker client helper",
+		},
+		{
+			// kindPresent (source line): shellproto source removed.
+			name:    "missing shellproto source",
+			body:    strings.Replace(happyLauncher, `source "${ROOT_DIR}/scripts/lib/shellproto.sh"`+"\n", "", 1),
+			wantErr: "Expected scripts/workcell to source the shellproto helper",
+		},
+		{
+			// kindPresent (source line): sessionctl-shim source removed.
+			name:    "missing sessionctl-shim source",
+			body:    strings.Replace(happyLauncher, `source "${ROOT_DIR}/scripts/lib/sessionctl-shim.sh"`+"\n", "", 1),
+			wantErr: "Expected scripts/workcell to source the sessionctl shim helper",
+		},
+		{
+			// A missing launcher is treated as empty content, so the first
+			// affirmative check (run_host_colima HOME restore) fires.
+			name:    "unreadable launcher",
+			body:    "",
+			wantErr: "Expected run_host_colima to restore the real host HOME instead of the Docker client sandbox home",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeLauncher(t, tc.body)
+			err := Check(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Check() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Check() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("Check() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestExtractNamedFunctionBlock pins the sed-range extraction semantics
+// the run_host_colima check depends on: the block runs from the `NAME()`
+// opening line through the first line beginning with `}` (inclusive), and
+// text after the closing brace is excluded.
+func TestExtractNamedFunctionBlock(t *testing.T) {
+	src := "before\nfoo() {\n  body_line\n}\nafter_foo() {\n  other\n}\n"
+	got := extractNamedFunctionBlock(src, "foo")
+	want := "foo() {\n  body_line\n}"
+	if got != want {
+		t.Fatalf("extractNamedFunctionBlock = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "other") {
+		t.Fatalf("extractNamedFunctionBlock leaked text past the closing brace: %q", got)
+	}
+	if extractNamedFunctionBlock(src, "absent") != "" {
+		t.Fatalf("extractNamedFunctionBlock for a missing function should be empty")
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1486,60 +1486,20 @@ fi
 
 rm -rf "${codex_managed_config_tmpdir}"
 
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "run_host_colima" "HOME=\"\${REAL_HOME}\""; then
-  echo "Expected run_host_colima to restore the real host HOME instead of the Docker client sandbox home" >&2
-  exit 1
-fi
-
-if ! head -n 1 "${ROOT_DIR}/scripts/workcell" | grep -q '^#!/usr/bin/env -S -i PATH=.* BASH_ENV= ENV= /bin/bash$'; then
-  echo "Expected scripts/workcell to use env -S -i with an absolute /bin/bash and cleared host environment" >&2
-  exit 1
-fi
-
-if ! rg -q 'scrub_host_process_env' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to scrub hostile host process environment before host tool lookup" >&2
-  exit 1
-fi
-
-if ! rg -q 'unset PERL5OPT PERL5LIB PERLLIB PERL_MB_OPT PERL_MM_OPT' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to scrub hostile Perl environment before host tool lookup" >&2
-  exit 1
-fi
-
-if ! rg -q 'DYLD_\*' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to scrub DYLD_* variables before host tool lookup" >&2
-  exit 1
-fi
-
-if rg -q 'shasum -a 256' "${ROOT_DIR}/scripts/workcell"; then
-  echo "scripts/workcell still uses Perl-backed shasum for profile hashing" >&2
-  exit 1
-fi
-
-if ! rg -q 'unset DOCKER_CONTEXT' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to scrub caller Docker context overrides before binding the managed daemon" >&2
-  exit 1
-fi
-
-if ! rg -q 'unset DOCKER_CLI_PLUGIN_EXTRA_DIRS' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to scrub caller Docker CLI plugin overrides" >&2
-  exit 1
-fi
-
-if ! rg -q 'source "\$\{ROOT_DIR\}/scripts/lib/trusted-docker-client\.sh"' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to source the trusted Docker client helper" >&2
-  exit 1
-fi
-
-if ! rg -q 'source "\$\{ROOT_DIR\}/scripts/lib/shellproto\.sh"' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to source the shellproto helper" >&2
-  exit 1
-fi
-
-if ! rg -q 'source "\$\{ROOT_DIR\}/scripts/lib/sessionctl-shim\.sh"' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to source the sessionctl shim helper" >&2
-  exit 1
-fi
+# scripts/workcell host-launcher hardening invariants: run_host_colima
+# restores the real host HOME, the shebang clears the host environment,
+# the process/Perl/DYLD/Docker environment scrubbers are present,
+# Perl-backed shasum is absent, and the trusted Docker client /
+# shellproto / sessionctl-shim helpers are sourced.  Migrated to Go
+# (D3): internal/workcellhardening behind the workcell-citools
+# workcell-hardening-invariants subcommand preserves the exact exit
+# codes and stderr messages of the former inline function_block /
+# head+grep / rg block, including the fixed-string vs. anchored-regex
+# matching semantics per check.
+# `|| exit 1` matches the former inline block's `exit 1` on a violated
+# invariant: it handles the failure so the top-level ERR trap does not fire and
+# append trap diagnostics, preserving the exact failure stderr surface.
+go_verify_citools workcell-hardening-invariants "${ROOT_DIR}" || exit 1
 
 INSTALL_DEPS_VERIFY_BIN="${BARRIER_VERIFY_ROOT}/install-deps-bin"
 INSTALL_DEPS_LOG="${BARRIER_VERIFY_ROOT}/install-deps-brew.log"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -185,7 +185,16 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
 
 go_verify_citools() {
-  run_go_in_repo "${ROOT_DIR}" run ./cmd/workcell-citools "$@"
+  # `go run` appends its own `exit status N` trailer to stderr when the compiled
+  # binary exits non-zero (see `go help run`). Strip just that trailer line so a
+  # failed migrated check's stderr matches the former inline shell checks exactly
+  # (D3 parity), while preserving the binary's real exit code.
+  local citools_stderr citools_rc=0
+  citools_stderr="$(mktemp "${TMPDIR:-/tmp}/workcell-citools-stderr.XXXXXX")"
+  run_go_in_repo "${ROOT_DIR}" run ./cmd/workcell-citools "$@" 2>"${citools_stderr}" || citools_rc=$?
+  grep -vE '^exit status [0-9]+$' "${citools_stderr}" >&2 || true
+  rm -f "${citools_stderr}"
+  return "${citools_rc}"
 }
 
 go_verify_hostutil() {


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 2 of N.** Follows #398 (git-blocklist parity, merged). Migrates the contiguous block of 11 `scripts/workcell` hardening-invariant checks (former lines 1489-1542).

## What
- **New `internal/workcellhardening`** package: `Check(rootDir)` runs the 11 checks (in the shell's order) against one read of `scripts/workcell`, returning the first violation's exact stderr message — the `run_host_colima` HOME-restore (scoped to the function body), the `env -S -i` shebang, `scrub_host_process_env`, the Perl/DYLD scrubs, the `unset DOCKER_CONTEXT`/`DOCKER_CLI_PLUGIN_EXTRA_DIRS` scrubs, the trusted source-helpers, and the negative `shasum -a 256` check.
- **`cmd/workcell-citools`**: new `workcell-hardening-invariants ROOT_DIR` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-hardening-invariants "${ROOT_DIR}" || exit 1` (the `|| exit 1` ERR-trap guard from #398's review, applied from the start).

## Parity (identical pass/fail)
Behavior-preserving. `function_block_contains_fixed` is replicated as `extractNamedFunctionBlock` (matches `sed -n '/^NAME()/,/^}/p'` + `grep -Fq`), with a test proving the HOME-restore appearing *outside* `run_host_colima` still fails. Matching semantics analyzed per check: only the shebang is a real (anchored, line-1) regex; every other `rg` pattern is metachar-free after unescaping (`DYLD_\*`→literal `DYLD_*`, the `source "\$\{...\}"` lines→literal), so fixed-string `strings.Contains` is provably equivalent to `rg`. Verified: real repo → exit 0; crafted violations (missing scrub, wrong shebang, present shasum, out-of-body HOME) → exit 1 with byte-identical messages.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...` (table-driven, one fixture per check kind), `shellcheck -x`, `shfmt -d` — all green. 4 files / 497 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)