### PR TITLE
^R D3: migrate scripts/workcell config-safety checks from verify-invariants.sh to Go

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -96,6 +96,7 @@ func subcommands() []subcommand {
 		{"tree-compare", "LEFT_ROOT RIGHT_ROOT", 2, 2, cmdTreeCompare},
 		{"git-config-blocklist-parity", "ROOT_DIR", 1, 1, cmdGitConfigBlocklistParity},
 		{"workcell-hardening-invariants", "ROOT_DIR", 1, 1, cmdWorkcellHardeningInvariants},
+		{"workcell-config-safety", "ROOT_DIR", 1, 1, cmdWorkcellConfigSafety},
 	}
 }
 
@@ -508,4 +509,12 @@ func cmdGitConfigBlocklistParity(args []string) error {
 // shell's original stderr message for the first violated invariant.
 func cmdWorkcellHardeningInvariants(args []string) error {
 	return workcellhardening.Check(args[0])
+}
+
+// cmdWorkcellConfigSafety runs the four scripts/workcell config-safety
+// checks migrated out of scripts/verify-invariants.sh; it fails (exit 1
+// via die()) with the shell's original stderr message for the first
+// violated invariant.
+func cmdWorkcellConfigSafety(args []string) error {
+	return workcellhardening.CheckConfigSafety(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -5,7 +5,9 @@
 // scripts/workcell hardening-invariant checks that previously lived
 // inline in scripts/verify-invariants.sh (the eleven checks between the
 // codex-managed-config tmpdir cleanup and the install-deps barrier
-// fixtures).
+// fixtures).  It also re-implements the adjacent config-safety block (the
+// four scripts/workcell checks between the check_file loop and
+// toml_section_assignments) via CheckConfigSafety; see configSafetyChecks.
 //
 // Each invariant pins one property of the host launcher scripts/workcell:
 // that run_host_colima restores the real host HOME, that the shebang
@@ -67,6 +69,12 @@ const (
 	// kindAbsent requires the fixed string NOT to appear anywhere in the
 	// launcher, mirroring a negative `if rg -q FIXED; then ... exit 1`.
 	kindAbsent
+	// kindRegexAbsent requires the regexp pattern NOT to match anywhere in
+	// the launcher, mirroring a negative `if rg -q REGEX; then ... exit 1`
+	// whose REGEX is a genuine regular expression (an unanchored
+	// alternation with active metacharacters), unlike kindAbsent's
+	// fixed-string containment.
+	kindRegexAbsent
 )
 
 // check is one hardening invariant: how to match, what to match, which
@@ -152,18 +160,90 @@ var checks = []check{
 // all produce no match on a missing file, so the first affirmative check
 // (run_host_colima's HOME restore) fails with its message.
 func Check(rootDir string) error {
+	return evaluate(rootDir, checks)
+}
+
+// evaluate reads scripts/workcell under rootDir and returns the first
+// violated check's message (as an error), or nil when all hold.  A
+// missing or unreadable launcher is treated as empty content, exactly as
+// the shell behaved: head/grep/rg/function_block_contains_fixed and
+// negated `rg -q` on a missing file all produce no match, so affirmative
+// (kindPresent/kindFunctionBlock/kindFirstLineRegex) checks fail while
+// negative (kindAbsent/kindRegexAbsent) checks pass.
+func evaluate(rootDir string, cs []check) error {
 	content, err := os.ReadFile(filepath.Join(rootDir, launcherRelPath))
 	if err != nil {
 		content = nil
 	}
 	text := string(content)
 
-	for _, c := range checks {
+	for _, c := range cs {
 		if !c.holds(text) {
 			return errors.New(c.message)
 		}
 	}
 	return nil
+}
+
+// configSafetyChecks lists the four scripts/workcell config-safety
+// invariants in the same order as the former inline block in
+// scripts/verify-invariants.sh (the block between the check_file loop and
+// toml_section_assignments), so a reviewer can diff the two one-to-one.
+//
+// The Colima state-root invariant was one shell `if` guarding two
+// `rg -q` fixed-string probes joined by `||` under a single message; it
+// is expressed here as two ordered kindPresent checks sharing that
+// message, which is behaviourally identical (either missing probe yields
+// the same stderr and exit 1, before the REAL_HOME check runs).
+var configSafetyChecks = []check{
+	{
+		// kindRegexAbsent: the shell's `rg -q
+		// 'WORKCELL_TEST_HARNESS|WORKCELL_(GIT|COLIMA|DOCKER|RUBY)_BIN='`
+		// is a genuine unanchored alternation, not a fixed string, so it
+		// must NOT match (present is a violation → exit 1).
+		kind:    kindRegexAbsent,
+		pattern: `WORKCELL_TEST_HARNESS|WORKCELL_(GIT|COLIMA|DOCKER|RUBY)_BIN=`,
+		message: "Unexpected test-harness host tool override support remains in scripts/workcell",
+	},
+	{
+		// kindAbsent: the shell's `rg -q 'YAML\.load_file'` has its only
+		// metacharacter (`\.`) escaped to a literal dot, so it reduces to
+		// fixed-string containment of `YAML.load_file` (present is a
+		// violation).
+		kind:    kindAbsent,
+		pattern: "YAML.load_file",
+		message: "scripts/workcell still uses unsafe YAML.load_file parsing for managed profile validation",
+	},
+	{
+		// kindPresent (first half of the Colima state-root guard).
+		kind:    kindPresent,
+		pattern: "COLIMA_STATE_ROOT=",
+		message: "Expected scripts/workcell to pin Colima state operations to one COLIMA_HOME root",
+	},
+	{
+		// kindPresent (second half): the shell's rg pattern
+		// `COLIMA_HOME="\$\{COLIMA_STATE_ROOT\}"` escapes every
+		// metacharacter, so it is fixed-string containment of the literal
+		// assignment.  Shares the first half's message.
+		kind:    kindPresent,
+		pattern: `COLIMA_HOME="${COLIMA_STATE_ROOT}"`,
+		message: "Expected scripts/workcell to pin Colima state operations to one COLIMA_HOME root",
+	},
+	{
+		// kindPresent: `rg -q 'REAL_HOME='` fixed-string containment.
+		kind:    kindPresent,
+		pattern: "REAL_HOME=",
+		message: "Expected scripts/workcell to derive the real host home independently of caller HOME",
+	},
+}
+
+// CheckConfigSafety runs the four scripts/workcell config-safety
+// invariants against the repo rooted at rootDir, in the shell's original
+// order.  It returns nil when every invariant holds (the shell's exit 0),
+// or an error whose message equals the shell's stderr for the first
+// violated invariant (the shell's exit 1).
+func CheckConfigSafety(rootDir string) error {
+	return evaluate(rootDir, configSafetyChecks)
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.
@@ -178,6 +258,8 @@ func (c check) holds(text string) bool {
 		return strings.Contains(text, c.pattern)
 	case kindAbsent:
 		return !strings.Contains(text, c.pattern)
+	case kindRegexAbsent:
+		return !regexp.MustCompile(c.pattern).MatchString(text)
 	default:
 		return false
 	}

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -179,6 +179,113 @@ func TestCheck(t *testing.T) {
 	}
 }
 
+// configSafetyHappyLauncher is a minimal scripts/workcell that satisfies
+// all four config-safety invariants: no test-harness host tool override
+// support, no unsafe YAML.load_file parsing, both the COLIMA_STATE_ROOT
+// assignment and the COLIMA_HOME pin, and a REAL_HOME assignment.
+// Individual negative cases mutate one property of this baseline.
+const configSafetyHappyLauncher = `#!/bin/bash
+set -euo pipefail
+REAL_HOME="$(host_real_home)"
+COLIMA_STATE_ROOT="${REAL_HOME}/.workcell/colima"
+run_host_colima() {
+  COLIMA_HOME="${COLIMA_STATE_ROOT}" "${HOST_COLIMA_BIN}" "$@"
+}
+`
+
+func TestCheckConfigSafety(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string // "" means expect success
+	}{
+		{
+			name: "happy path all invariants hold",
+			body: configSafetyHappyLauncher,
+		},
+		{
+			// kindRegexAbsent: WORKCELL_DOCKER_BIN= present trips check #1.
+			name:    "WORKCELL_DOCKER_BIN override present",
+			body:    configSafetyHappyLauncher + "\nWORKCELL_DOCKER_BIN=/usr/bin/docker\n",
+			wantErr: "Unexpected test-harness host tool override support remains in scripts/workcell",
+		},
+		{
+			// kindRegexAbsent: bare WORKCELL_TEST_HARNESS (no `=`) also trips.
+			name:    "WORKCELL_TEST_HARNESS present",
+			body:    configSafetyHappyLauncher + "\nif [ -n \"${WORKCELL_TEST_HARNESS:-}\" ]; then :; fi\n",
+			wantErr: "Unexpected test-harness host tool override support remains in scripts/workcell",
+		},
+		{
+			// kindRegexAbsent: WORKCELL_GIT_BIN= (alternation branch) trips.
+			name:    "WORKCELL_GIT_BIN override present",
+			body:    configSafetyHappyLauncher + "\nWORKCELL_GIT_BIN=/usr/bin/git\n",
+			wantErr: "Unexpected test-harness host tool override support remains in scripts/workcell",
+		},
+		{
+			// kindRegexAbsent negative: an unrelated WORKCELL_*_BIN= that is
+			// NOT one of GIT/COLIMA/DOCKER/RUBY must NOT trip the regex, so
+			// the check still passes.  This pins that the alternation group is
+			// respected rather than matching any WORKCELL_*_BIN=.
+			name: "unrelated WORKCELL_FOO_BIN does not trip regex",
+			body: configSafetyHappyLauncher + "\nWORKCELL_FOO_BIN=/usr/bin/foo\n",
+		},
+		{
+			// kindAbsent: unsafe YAML.load_file present trips check #2.
+			name:    "YAML.load_file present",
+			body:    configSafetyHappyLauncher + "\nprofile = YAML.load_file(path)\n",
+			wantErr: "scripts/workcell still uses unsafe YAML.load_file parsing for managed profile validation",
+		},
+		{
+			// kindPresent: the COLIMA_HOME pin removed (COLIMA_STATE_ROOT
+			// assignment still present) fails the second half of the guard
+			// with the shared message.
+			name:    "missing COLIMA_HOME pin",
+			body:    strings.Replace(configSafetyHappyLauncher, `COLIMA_HOME="${COLIMA_STATE_ROOT}" `, "", 1),
+			wantErr: "Expected scripts/workcell to pin Colima state operations to one COLIMA_HOME root",
+		},
+		{
+			// kindPresent: the COLIMA_STATE_ROOT assignment removed fails the
+			// first half of the guard with the same shared message.
+			name:    "missing COLIMA_STATE_ROOT assignment",
+			body:    strings.Replace(configSafetyHappyLauncher, "COLIMA_STATE_ROOT=", "STATE_ROOT=", 1),
+			wantErr: "Expected scripts/workcell to pin Colima state operations to one COLIMA_HOME root",
+		},
+		{
+			// kindPresent: the REAL_HOME assignment removed fails check #4.
+			name:    "missing REAL_HOME",
+			body:    strings.Replace(configSafetyHappyLauncher, "REAL_HOME=", "HOME_DIR=", 1),
+			wantErr: "Expected scripts/workcell to derive the real host home independently of caller HOME",
+		},
+		{
+			// A missing launcher is empty content: the negative checks pass
+			// and the first affirmative check (COLIMA_STATE_ROOT pin) fires,
+			// mirroring `rg -q` returning non-zero on a missing file.
+			name:    "missing launcher",
+			body:    "",
+			wantErr: "Expected scripts/workcell to pin Colima state operations to one COLIMA_HOME root",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeLauncher(t, tc.body)
+			err := CheckConfigSafety(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckConfigSafety() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckConfigSafety() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckConfigSafety() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 // TestExtractNamedFunctionBlock pins the sed-range extraction semantics
 // the run_host_colima check depends on: the block runs from the `NAME()`
 // opening line through the first line beginning with `}` (inclusive), and

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -900,25 +900,18 @@ for file in \
   check_file "${file}"
 done
 
-if rg -q 'WORKCELL_TEST_HARNESS|WORKCELL_(GIT|COLIMA|DOCKER|RUBY)_BIN=' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Unexpected test-harness host tool override support remains in scripts/workcell" >&2
-  exit 1
-fi
-
-if rg -q 'YAML\.load_file' "${ROOT_DIR}/scripts/workcell"; then
-  echo "scripts/workcell still uses unsafe YAML.load_file parsing for managed profile validation" >&2
-  exit 1
-fi
-
-if ! rg -q 'COLIMA_STATE_ROOT=' "${ROOT_DIR}/scripts/workcell" || ! rg -q 'COLIMA_HOME="\$\{COLIMA_STATE_ROOT\}"' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to pin Colima state operations to one COLIMA_HOME root" >&2
-  exit 1
-fi
-
-if ! rg -q 'REAL_HOME=' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to derive the real host home independently of caller HOME" >&2
-  exit 1
-fi
+# scripts/workcell config-safety invariants: no test-harness host tool
+# override support remains, no unsafe YAML.load_file profile parsing, the
+# Colima state operations are pinned to one COLIMA_HOME root, and the real
+# host home is derived independently of the caller's HOME.  Migrated to Go
+# (D3): internal/workcellhardening.CheckConfigSafety behind the
+# workcell-citools workcell-config-safety subcommand preserves the exact
+# exit codes and stderr messages of the former inline rg block, including
+# the genuine-regex vs. fixed-string matching semantics per check.
+# `|| exit 1` matches the former inline block's `exit 1` on a violated
+# invariant: it handles the failure so the top-level ERR trap does not fire and
+# append trap diagnostics, preserving the exact failure stderr surface.
+go_verify_citools workcell-config-safety "${ROOT_DIR}" || exit 1
 
 toml_section_assignments() {
   local file="$1"


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 3 of N.** Follows #398 (git-blocklist) and #399 (workcell hardening). Migrates the 4 `scripts/workcell` config-safety checks (former lines 894-912).

## What
- **`internal/workcellhardening`**: new `CheckConfigSafety(rootDir)` reusing the data-driven check machinery (extracted a shared `evaluate()` helper; existing `Check` + its tests unchanged). The 4 checks: no test-harness host-tool overrides (`WORKCELL_TEST_HARNESS|WORKCELL_(GIT|COLIMA|DOCKER|RUBY)_BIN=`), no unsafe `YAML.load_file`, Colima state pinned to one `COLIMA_HOME` root, and `REAL_HOME` derivation present.
- **`cmd/workcell-citools`**: new `workcell-config-safety` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-config-safety "${ROOT_DIR}" || exit 1`, wired at the same location (order unchanged).

## Parity (identical pass/fail)
Check #1 is a genuine regex — added a `kindRegexAbsent` kind (`regexp` match = violation), compiled verbatim; RE2 is equivalent to `rg`'s Rust regex here (alternation + group, no newline-sensitive metacharacters). Verified `WORKCELL_DOCKER_BIN=`/`WORKCELL_TEST_HARNESS`/`WORKCELL_GIT_BIN=` trip it while `WORKCELL_FOO_BIN=` does not. Checks #2-4 are fixed-string. Verified: real repo → exit 0; crafted violations → exit 1 with byte-identical messages (the `go run` trailer is stripped by `go_verify_citools` per #399).

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...` (table-driven, fixture per check + the negative-regex assertion), `shellcheck -x`, `shfmt -d` — all green. 4 files / 233 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)