### PR TITLE
^R D3: migrate scripts/workcell runtime/gc invariants from verify-invariants.sh to Go

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -97,6 +97,7 @@ func subcommands() []subcommand {
 		{"git-config-blocklist-parity", "ROOT_DIR", 1, 1, cmdGitConfigBlocklistParity},
 		{"workcell-hardening-invariants", "ROOT_DIR", 1, 1, cmdWorkcellHardeningInvariants},
 		{"workcell-config-safety", "ROOT_DIR", 1, 1, cmdWorkcellConfigSafety},
+		{"workcell-runtime-invariants", "ROOT_DIR", 1, 1, cmdWorkcellRuntimeInvariants},
 	}
 }
 
@@ -517,4 +518,12 @@ func cmdWorkcellHardeningInvariants(args []string) error {
 // violated invariant.
 func cmdWorkcellConfigSafety(args []string) error {
 	return workcellhardening.CheckConfigSafety(args[0])
+}
+
+// cmdWorkcellRuntimeInvariants runs the ten scripts/workcell runtime/gc
+// checks migrated out of scripts/verify-invariants.sh; it fails (exit 1
+// via die()) with the shell's original stderr message for the first
+// violated invariant.
+func cmdWorkcellRuntimeInvariants(args []string) error {
+	return workcellhardening.CheckRuntimeInvariants(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -8,6 +8,10 @@
 // fixtures).  It also re-implements the adjacent config-safety block (the
 // four scripts/workcell checks between the check_file loop and
 // toml_section_assignments) via CheckConfigSafety; see configSafetyChecks.
+// It also re-implements the adjacent runtime/gc block (the ten
+// scripts/workcell checks between the SSH-collision check and the
+// start_managed_profile mount function-block group) via
+// CheckRuntimeInvariants; see runtimeInvariantChecks.
 //
 // Each invariant pins one property of the host launcher scripts/workcell:
 // that run_host_colima restores the real host HOME, that the shebang
@@ -60,6 +64,11 @@ const (
 	// the top-level bash function body named functionName, mirroring
 	// function_block_contains_fixed (sed-range extraction + grep -Fq).
 	kindFunctionBlock checkKind = iota
+	// kindFunctionBlockAbsent requires needle (a fixed string) NOT to
+	// appear inside the top-level bash function body named functionName,
+	// mirroring a negated `function_block_contains_fixed` under a `||`
+	// guard (present inside the block is a violation → exit 1).
+	kindFunctionBlockAbsent
 	// kindFirstLineRegex requires the launcher's first line to match the
 	// anchored regex, mirroring `head -n1 ... | grep -q '^...$'`.
 	kindFirstLineRegex
@@ -246,12 +255,131 @@ func CheckConfigSafety(rootDir string) error {
 	return evaluate(rootDir, configSafetyChecks)
 }
 
+// runtimeInvariantChecks lists the ten scripts/workcell runtime/gc
+// invariants in the same order as the former inline block in
+// scripts/verify-invariants.sh (the block between the SSH-collision check
+// and the start_managed_profile mount function-block group), so a
+// reviewer can diff the two one-to-one.
+//
+// Every `rg` pattern in this block is metacharacter-free after
+// unescaping (the DOCKER_CONFIG probe escapes every `$ { } .`, and the
+// `--self-*-probe` / `strict mode …` / `go_colimautil …` probes contain
+// no active regex metacharacters), so each reduces to fixed-string
+// containment — kindPresent for affirmative `rg -q`, kindAbsent for the
+// negated DOCKER_CONFIG guard.
+//
+// The runtime_build_codex_arch guard was one shell `if` joining three
+// function_block_contains_fixed probes with `||` under a single message:
+// the first two are affirmative (musl assets must be present) and the
+// third is NEGATED (a gnu asset present is a violation).  It is expressed
+// here as two kindFunctionBlock checks plus one kindFunctionBlockAbsent
+// check sharing that message, which is behaviourally identical (any of
+// the three failing yields the same stderr and exit 1).
+//
+// Two other guards each joined two affirmative `rg -q` probes with `||`
+// under one message (the --gc runtime-image/temp cleanup pair); they are
+// expressed as two ordered kindPresent checks sharing that message, which
+// is behaviourally identical (either missing probe yields the same
+// stderr and exit 1).
+var runtimeInvariantChecks = []check{
+	{
+		kind:    kindPresent,
+		pattern: "setup_workcell_trusted_docker_client",
+		message: "Expected scripts/workcell to seed a trusted Docker client state before host Docker use",
+	},
+	{
+		// kindAbsent: the shell's rg pattern
+		// `DOCKER_CONFIG="\$\{REAL_HOME\}/\.docker"` escapes every
+		// metacharacter, so it is fixed-string containment of the literal
+		// assignment (present is a violation).
+		kind:    kindAbsent,
+		pattern: `DOCKER_CONFIG="${REAL_HOME}/.docker"`,
+		message: "scripts/workcell still pins DOCKER_CONFIG to the real host home",
+	},
+	{
+		kind:    kindPresent,
+		pattern: "buildx_cmd build",
+		message: "Expected scripts/workcell to invoke buildx through the trusted absolute plugin path",
+	},
+	{
+		// kindFunctionBlock (musl aarch64 asset must be present).
+		kind:         kindFunctionBlock,
+		functionName: "runtime_build_codex_arch",
+		pattern:      "aarch64-unknown-linux-musl",
+		message:      "Expected scripts/workcell Codex release probe to resolve musl release assets",
+	},
+	{
+		// kindFunctionBlock (musl x86_64 asset must be present).
+		kind:         kindFunctionBlock,
+		functionName: "runtime_build_codex_arch",
+		pattern:      "x86_64-unknown-linux-musl",
+		message:      "Expected scripts/workcell Codex release probe to resolve musl release assets",
+	},
+	{
+		// kindFunctionBlockAbsent (the NEGATED sub-condition): a gnu asset
+		// inside the block is a violation.  Shares the pair's message.
+		kind:         kindFunctionBlockAbsent,
+		functionName: "runtime_build_codex_arch",
+		pattern:      "unknown-linux-gnu",
+		message:      "Expected scripts/workcell Codex release probe to resolve musl release assets",
+	},
+	{
+		kind:    kindPresent,
+		pattern: "--self-docker-probe",
+		message: "Expected scripts/workcell to expose a hidden self-docker probe for invariant testing",
+	},
+	{
+		// kindPresent (first half of the --gc cleanup guard).
+		kind:    kindPresent,
+		pattern: "prune_runtime_image_cache_dir",
+		message: "Expected scripts/workcell --gc to cover bounded runtime-image cache and Workcell-owned temp cleanup",
+	},
+	{
+		// kindPresent (second half): shares the first half's message.
+		kind:    kindPresent,
+		pattern: "cleanup_workcell_temp_root",
+		message: "Expected scripts/workcell --gc to cover bounded runtime-image cache and Workcell-owned temp cleanup",
+	},
+	{
+		kind:    kindPresent,
+		pattern: "--self-staging-probe",
+		message: "Expected scripts/workcell to expose a hidden staging probe for invariant testing",
+	},
+	{
+		kind:    kindPresent,
+		pattern: "strict mode requires --prepare when you explicitly request --rebuild.",
+		message: "Expected scripts/workcell to reject explicit strict-mode image rebuild requests",
+	},
+	{
+		kind:    kindPresent,
+		pattern: "go_colimautil validate-profile-config",
+		message: "Expected scripts/workcell to validate managed Colima config through the dedicated Go helper",
+	},
+	{
+		kind:    kindPresent,
+		pattern: "go_colimautil validate-runtime-mounts",
+		message: "Expected scripts/workcell to validate managed Lima mounts through the dedicated Go helper",
+	},
+}
+
+// CheckRuntimeInvariants runs the ten scripts/workcell runtime/gc
+// invariants against the repo rooted at rootDir, in the shell's original
+// order.  It returns nil when every invariant holds (the shell's exit 0),
+// or an error whose message equals the shell's stderr for the first
+// violated invariant (the shell's exit 1).
+func CheckRuntimeInvariants(rootDir string) error {
+	return evaluate(rootDir, runtimeInvariantChecks)
+}
+
 // holds reports whether the invariant is satisfied by the launcher text.
 func (c check) holds(text string) bool {
 	switch c.kind {
 	case kindFunctionBlock:
 		block := extractNamedFunctionBlock(text, c.functionName)
 		return strings.Contains(block, c.pattern)
+	case kindFunctionBlockAbsent:
+		block := extractNamedFunctionBlock(text, c.functionName)
+		return !strings.Contains(block, c.pattern)
 	case kindFirstLineRegex:
 		return regexp.MustCompile(c.pattern).MatchString(firstLine(text))
 	case kindPresent:

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -84,6 +84,11 @@ const (
 	// alternation with active metacharacters), unlike kindAbsent's
 	// fixed-string containment.
 	kindRegexAbsent
+	// kindRegexPresent requires the regexp pattern to match somewhere in the
+	// launcher, mirroring an affirmative `rg -q REGEX` whose REGEX contains an
+	// active metacharacter (e.g. a trailing `.` meaning any char), unlike
+	// kindPresent's fixed-string containment.
+	kindRegexPresent
 )
 
 // check is one hardening invariant: how to match, what to match, which
@@ -346,7 +351,9 @@ var runtimeInvariantChecks = []check{
 		message: "Expected scripts/workcell to expose a hidden staging probe for invariant testing",
 	},
 	{
-		kind:    kindPresent,
+		// rg treats the trailing `.` as "any char", so match it as a regex for
+		// exact `rg -q` parity (the only active metacharacter in the pattern).
+		kind:    kindRegexPresent,
 		pattern: "strict mode requires --prepare when you explicitly request --rebuild.",
 		message: "Expected scripts/workcell to reject explicit strict-mode image rebuild requests",
 	},
@@ -388,6 +395,8 @@ func (c check) holds(text string) bool {
 		return !strings.Contains(text, c.pattern)
 	case kindRegexAbsent:
 		return !regexp.MustCompile(c.pattern).MatchString(text)
+	case kindRegexPresent:
+		return regexp.MustCompile(c.pattern).MatchString(text)
 	default:
 		return false
 	}

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -286,6 +286,184 @@ func TestCheckConfigSafety(t *testing.T) {
 	}
 }
 
+// runtimeHappyLauncher is a minimal scripts/workcell that satisfies all
+// ten runtime/gc invariants: the trusted Docker client seed, no
+// DOCKER_CONFIG pin to the real host home, the buildx_cmd invocation, a
+// runtime_build_codex_arch body resolving both musl assets (and no gnu
+// asset), both hidden probes, both --gc cleanup helpers, the strict-mode
+// rebuild rejection, and both go_colimautil validators.  Individual
+// negative cases mutate one property of this baseline.
+const runtimeHappyLauncher = `#!/bin/bash
+set -euo pipefail
+
+setup_workcell_trusted_docker_client() {
+  DOCKER_CONFIG="${TRUSTED_DOCKER_CONFIG}"
+}
+
+runtime_build_image() {
+  buildx_cmd build --tag workcell/runtime .
+}
+
+runtime_build_codex_arch() {
+  case "${server_arch}" in
+    arm64 | aarch64) printf 'aarch64-unknown-linux-musl\n' ;;
+    amd64 | x86_64) printf 'x86_64-unknown-linux-musl\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+handle_flags() {
+  case "$1" in
+    --self-docker-probe) run_self_docker_probe ;;
+    --self-staging-probe) run_self_staging_probe ;;
+  esac
+}
+
+gc() {
+  prune_runtime_image_cache_dir
+  cleanup_workcell_temp_root
+}
+
+reject_rebuild() {
+  die "strict mode requires --prepare when you explicitly request --rebuild."
+}
+
+validate_managed_config() {
+  go_colimautil validate-profile-config "${config}"
+  go_colimautil validate-runtime-mounts "${config}"
+}
+`
+
+func TestCheckRuntimeInvariants(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string // "" means expect success
+	}{
+		{
+			name: "happy path all invariants hold",
+			body: runtimeHappyLauncher,
+		},
+		{
+			// kindPresent: trusted Docker client seed removed.
+			name:    "missing trusted Docker client seed",
+			body:    strings.Replace(runtimeHappyLauncher, "setup_workcell_trusted_docker_client", "setup_other", 1),
+			wantErr: "Expected scripts/workcell to seed a trusted Docker client state before host Docker use",
+		},
+		{
+			// kindAbsent: pinning DOCKER_CONFIG to the real host home is a
+			// violation.
+			name:    "DOCKER_CONFIG pinned to real home present",
+			body:    runtimeHappyLauncher + "\nDOCKER_CONFIG=\"${REAL_HOME}/.docker\"\n",
+			wantErr: "scripts/workcell still pins DOCKER_CONFIG to the real host home",
+		},
+		{
+			// kindPresent: buildx_cmd build removed.
+			name:    "missing buildx_cmd build",
+			body:    strings.Replace(runtimeHappyLauncher, "buildx_cmd build", "buildx build", 1),
+			wantErr: "Expected scripts/workcell to invoke buildx through the trusted absolute plugin path",
+		},
+		{
+			// kindFunctionBlock: aarch64 musl asset removed from the block.
+			name:    "missing aarch64 musl asset",
+			body:    strings.Replace(runtimeHappyLauncher, "aarch64-unknown-linux-musl", "aarch64-unknown-linux-foo", 1),
+			wantErr: "Expected scripts/workcell Codex release probe to resolve musl release assets",
+		},
+		{
+			// kindFunctionBlock: x86_64 musl asset removed from the block.
+			name:    "missing x86_64 musl asset",
+			body:    strings.Replace(runtimeHappyLauncher, "x86_64-unknown-linux-musl", "x86_64-unknown-linux-foo", 1),
+			wantErr: "Expected scripts/workcell Codex release probe to resolve musl release assets",
+		},
+		{
+			// kindFunctionBlockAbsent (the NEGATED sub-condition): a gnu asset
+			// inside the block is a violation even though both musl assets
+			// remain present.
+			name:    "gnu asset present in codex arch block",
+			body:    strings.Replace(runtimeHappyLauncher, "*) return 1 ;;", "*) printf 'x86_64-unknown-linux-gnu\\n'; return 1 ;;", 1),
+			wantErr: "Expected scripts/workcell Codex release probe to resolve musl release assets",
+		},
+		{
+			// kindFunctionBlockAbsent scoping: a gnu asset OUTSIDE the
+			// runtime_build_codex_arch body must NOT trip the block-scoped
+			// negative check, so the invariant still holds.
+			name: "gnu asset only outside codex arch block",
+			body: runtimeHappyLauncher + "\ncomment_note() { : 'x86_64-unknown-linux-gnu'; }\n",
+		},
+		{
+			// kindPresent: hidden self-docker probe removed.
+			name:    "missing self-docker probe",
+			body:    strings.Replace(runtimeHappyLauncher, "--self-docker-probe", "--self-docker-off", 1),
+			wantErr: "Expected scripts/workcell to expose a hidden self-docker probe for invariant testing",
+		},
+		{
+			// kindPresent (first half of --gc guard): runtime-image cache prune
+			// helper removed.
+			name:    "missing runtime image cache prune",
+			body:    strings.Replace(runtimeHappyLauncher, "prune_runtime_image_cache_dir", "prune_other", 1),
+			wantErr: "Expected scripts/workcell --gc to cover bounded runtime-image cache and Workcell-owned temp cleanup",
+		},
+		{
+			// kindPresent (second half of --gc guard): temp-root cleanup helper
+			// removed.
+			name:    "missing temp root cleanup",
+			body:    strings.Replace(runtimeHappyLauncher, "cleanup_workcell_temp_root", "cleanup_other", 1),
+			wantErr: "Expected scripts/workcell --gc to cover bounded runtime-image cache and Workcell-owned temp cleanup",
+		},
+		{
+			// kindPresent: hidden self-staging probe removed.
+			name:    "missing self-staging probe",
+			body:    strings.Replace(runtimeHappyLauncher, "--self-staging-probe", "--self-staging-off", 1),
+			wantErr: "Expected scripts/workcell to expose a hidden staging probe for invariant testing",
+		},
+		{
+			// kindPresent: strict-mode rebuild rejection message removed.
+			name:    "missing strict-mode rebuild rejection",
+			body:    strings.Replace(runtimeHappyLauncher, "strict mode requires --prepare when you explicitly request --rebuild.", "strict mode message changed", 1),
+			wantErr: "Expected scripts/workcell to reject explicit strict-mode image rebuild requests",
+		},
+		{
+			// kindPresent: profile-config validator removed.
+			name:    "missing validate-profile-config",
+			body:    strings.Replace(runtimeHappyLauncher, "go_colimautil validate-profile-config", "go_colimautil validate-other", 1),
+			wantErr: "Expected scripts/workcell to validate managed Colima config through the dedicated Go helper",
+		},
+		{
+			// kindPresent: runtime-mounts validator removed.
+			name:    "missing validate-runtime-mounts",
+			body:    strings.Replace(runtimeHappyLauncher, "go_colimautil validate-runtime-mounts", "go_colimautil validate-other-mounts", 1),
+			wantErr: "Expected scripts/workcell to validate managed Lima mounts through the dedicated Go helper",
+		},
+		{
+			// A missing launcher is empty content: the negative checks pass and
+			// the first affirmative check (trusted Docker client seed) fires,
+			// mirroring `rg -q` returning non-zero on a missing file.
+			name:    "missing launcher",
+			body:    "",
+			wantErr: "Expected scripts/workcell to seed a trusted Docker client state before host Docker use",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeLauncher(t, tc.body)
+			err := CheckRuntimeInvariants(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckRuntimeInvariants() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckRuntimeInvariants() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckRuntimeInvariants() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 // TestExtractNamedFunctionBlock pins the sed-range extraction semantics
 // the run_host_colima check depends on: the block runs from the `NAME()`
 // opening line through the first line beginning with `}` (inclusive), and

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2644,58 +2644,23 @@ if ! grep -q 'reserved SSH file' /tmp/workcell-injection-bad-ssh.out; then
   exit 1
 fi
 
-if ! rg -q 'setup_workcell_trusted_docker_client' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to seed a trusted Docker client state before host Docker use" >&2
-  exit 1
-fi
-
-if rg -q 'DOCKER_CONFIG="\$\{REAL_HOME\}/\.docker"' "${ROOT_DIR}/scripts/workcell"; then
-  echo "scripts/workcell still pins DOCKER_CONFIG to the real host home" >&2
-  exit 1
-fi
-
-if ! rg -q 'buildx_cmd build' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to invoke buildx through the trusted absolute plugin path" >&2
-  exit 1
-fi
-
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "runtime_build_codex_arch" "aarch64-unknown-linux-musl" ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "runtime_build_codex_arch" "x86_64-unknown-linux-musl" ||
-  function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "runtime_build_codex_arch" "unknown-linux-gnu"; then
-  echo "Expected scripts/workcell Codex release probe to resolve musl release assets" >&2
-  exit 1
-fi
-
-if ! rg -q -- '--self-docker-probe' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to expose a hidden self-docker probe for invariant testing" >&2
-  exit 1
-fi
-
-if ! rg -q 'prune_runtime_image_cache_dir' "${ROOT_DIR}/scripts/workcell" ||
-  ! rg -q 'cleanup_workcell_temp_root' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell --gc to cover bounded runtime-image cache and Workcell-owned temp cleanup" >&2
-  exit 1
-fi
-
-if ! rg -q -- '--self-staging-probe' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to expose a hidden staging probe for invariant testing" >&2
-  exit 1
-fi
-
-if ! rg -q 'strict mode requires --prepare when you explicitly request --rebuild.' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to reject explicit strict-mode image rebuild requests" >&2
-  exit 1
-fi
-
-if ! rg -q 'go_colimautil validate-profile-config' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to validate managed Colima config through the dedicated Go helper" >&2
-  exit 1
-fi
-
-if ! rg -q 'go_colimautil validate-runtime-mounts' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to validate managed Lima mounts through the dedicated Go helper" >&2
-  exit 1
-fi
+# scripts/workcell runtime/gc invariants: the trusted Docker client seed
+# precedes host Docker use, DOCKER_CONFIG is not pinned to the real host
+# home, buildx runs through the trusted absolute plugin path, the Codex
+# release probe resolves musl (not gnu) assets, the hidden self-docker /
+# self-staging probes exist, --gc covers the bounded runtime-image cache
+# and Workcell-owned temp cleanup, explicit strict-mode image rebuilds are
+# rejected, and managed Colima config / Lima mounts validate through the
+# dedicated Go helpers.  Migrated to Go (D3): internal/workcellhardening
+# behind the workcell-citools workcell-runtime-invariants subcommand
+# preserves the exact exit codes and stderr messages of the former inline
+# rg / function_block_contains_fixed block, including the fixed-string
+# matching semantics (every pattern is metacharacter-free after
+# unescaping) and the negated runtime_build_codex_arch gnu sub-condition.
+# `|| exit 1` matches the former inline block's `exit 1` on a violated
+# invariant: it handles the failure so the top-level ERR trap does not fire and
+# append trap diagnostics, preserving the exact failure stderr surface.
+go_verify_citools workcell-runtime-invariants "${ROOT_DIR}" || exit 1
 if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "start_managed_profile" 'workcell-host-inputs' ||
   ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "start_managed_profile" 'workcell-shadow' ||
   ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "start_managed_profile" 'workcell-token-handoff' ||


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 4 of N.** Follows #398/#399/#400. Migrates the 10 `scripts/workcell` runtime/gc invariant checks (trusted-docker-client seed, DOCKER_CONFIG, buildx, the `runtime_build_codex_arch` musl-arch group, the self-docker/staging probes, the `--gc` cleanup pair, strict-mode-rebuild rejection, and the two `go_colimautil` validators).

## What
- **`internal/workcellhardening`**: new `CheckRuntimeInvariants(rootDir)` reusing the shared `evaluate()` + existing kinds. Adds two kinds: `kindFunctionBlockAbsent` (for the negated `runtime_build_codex_arch` sub-condition — `unknown-linux-gnu` present inside the block is a violation) and `kindRegexPresent` (symmetric with `kindRegexAbsent`).
- **`cmd/workcell-citools`**: new `workcell-runtime-invariants` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-runtime-invariants "${ROOT_DIR}" || exit 1` at the same location.

## Parity (identical pass/fail)
The `runtime_build_codex_arch` group (2 present + 1 negated function-block probe under one message) is expressed as ordered checks sharing that message — a test proves `unknown-linux-gnu` *inside* the block fails while *outside* the block passes (scoping guard). The strict-mode `--rebuild.` pattern is matched as a **regex** (`rg` treats the trailing `.` as any-char); every other pattern is metachar-free after unescaping → fixed-string. Verified: real repo → exit 0; crafted violations (DOCKER_CONFIG pinned, buildx removed, gnu-in-block) → exit 1 byte-identical.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...` (table-driven, fixture per check + scoping guard), `shellcheck -x`, `shfmt -d` — all green. 4 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)