### PR TITLE
^R D3: migrate scripts/workcell managed-profile staging invariants from verify-invariants.sh to Go

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -98,6 +98,7 @@ func subcommands() []subcommand {
 		{"workcell-hardening-invariants", "ROOT_DIR", 1, 1, cmdWorkcellHardeningInvariants},
 		{"workcell-config-safety", "ROOT_DIR", 1, 1, cmdWorkcellConfigSafety},
 		{"workcell-runtime-invariants", "ROOT_DIR", 1, 1, cmdWorkcellRuntimeInvariants},
+		{"workcell-managed-profile-staging", "ROOT_DIR", 1, 1, cmdWorkcellManagedProfileStaging},
 	}
 }
 
@@ -526,4 +527,12 @@ func cmdWorkcellConfigSafety(args []string) error {
 // violated invariant.
 func cmdWorkcellRuntimeInvariants(args []string) error {
 	return workcellhardening.CheckRuntimeInvariants(args[0])
+}
+
+// cmdWorkcellManagedProfileStaging runs the three scripts/workcell
+// managed-profile staging/cleanup checks migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the
+// shell's original stderr message for the first violated invariant.
+func cmdWorkcellManagedProfileStaging(args []string) error {
+	return workcellhardening.CheckManagedProfileStaging(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -12,6 +12,10 @@
 // scripts/workcell checks between the SSH-collision check and the
 // start_managed_profile mount function-block group) via
 // CheckRuntimeInvariants; see runtimeInvariantChecks.
+// It also re-implements the adjacent managed-profile staging/cleanup block
+// (the three scripts/workcell checks between the runtime-invariants group
+// and the WORKCELL_COLIMA_TIMEOUT_HARNESS fixture) via
+// CheckManagedProfileStaging; see managedProfileStagingChecks.
 //
 // Each invariant pins one property of the host launcher scripts/workcell:
 // that run_host_colima restores the real host HOME, that the shebang
@@ -376,6 +380,144 @@ var runtimeInvariantChecks = []check{
 // violated invariant (the shell's exit 1).
 func CheckRuntimeInvariants(rootDir string) error {
 	return evaluate(rootDir, runtimeInvariantChecks)
+}
+
+// managedProfileStagingChecks lists the three scripts/workcell
+// managed-profile staging/cleanup invariants in the same order as the
+// former inline block in scripts/verify-invariants.sh (the block between
+// the runtime-invariants group and the WORKCELL_COLIMA_TIMEOUT_HARNESS
+// fixture), so a reviewer can diff the two one-to-one.
+//
+// Each of the three former shell `if` guards joined several
+// function_block_contains_fixed / `rg -q` probes with `||` under a single
+// message; they are expressed here as ordered checks sharing that message,
+// which is behaviourally identical (any probe failing yields the same
+// stderr and exit 1 as the corresponding shell `if`).  Every probe is
+// metacharacter-free after unescaping, so each is fixed-string
+// containment: kindFunctionBlock for the block-scoped
+// function_block_contains_fixed probes, kindPresent for the affirmative
+// `rg -q`, and kindAbsent for the negated `rg -q` (present is a
+// violation).
+//
+// The scoping of each block-scoped probe mirrors the shell's second
+// argument to function_block_contains_fixed: the mount and
+// staging-cache-root probes scope to start_managed_profile; the
+// staging-cache-root probes also scope to prepare_injection_bundle and
+// prepare_workspace_control_plane_shadow; and the fail-closed cleanup
+// probes scope to cleanup_default_injection_bundles.
+var managedProfileStagingChecks = []check{
+	// Guard 1: managed Colima launch mounts all three staging cache roots
+	// (host-inputs, shadow, token-handoff) with the reviewed access modes.
+	{
+		kind:         kindFunctionBlock,
+		functionName: "start_managed_profile",
+		pattern:      "workcell-host-inputs",
+		message:      "Expected managed Colima launch to mount Workcell staging cache roots with reviewed access modes",
+	},
+	{
+		kind:         kindFunctionBlock,
+		functionName: "start_managed_profile",
+		pattern:      "workcell-shadow",
+		message:      "Expected managed Colima launch to mount Workcell staging cache roots with reviewed access modes",
+	},
+	{
+		kind:         kindFunctionBlock,
+		functionName: "start_managed_profile",
+		pattern:      "workcell-token-handoff",
+		message:      "Expected managed Colima launch to mount Workcell staging cache roots with reviewed access modes",
+	},
+	{
+		kind:         kindFunctionBlock,
+		functionName: "start_managed_profile",
+		pattern:      `--mount "${host_inputs_root}"`,
+		message:      "Expected managed Colima launch to mount Workcell staging cache roots with reviewed access modes",
+	},
+	{
+		kind:         kindFunctionBlock,
+		functionName: "start_managed_profile",
+		pattern:      `--mount "${shadow_root}"`,
+		message:      "Expected managed Colima launch to mount Workcell staging cache roots with reviewed access modes",
+	},
+	{
+		kind:         kindFunctionBlock,
+		functionName: "start_managed_profile",
+		pattern:      `--mount "${token_handoff_root}:w"`,
+		message:      "Expected managed Colima launch to mount Workcell staging cache roots with reviewed access modes",
+	},
+	// Guard 2: staging cache roots reject symlinked host components before
+	// staging or mounting.  The reject_symlinked_colima_staging_cache_roots
+	// probe is a whole-file `rg -q` (kindPresent); the three
+	// prepare_colima_staging_cache_roots probes are block-scoped to the
+	// three functions that must call it before staging or mounting.
+	{
+		kind:    kindPresent,
+		pattern: "reject_symlinked_colima_staging_cache_roots",
+		message: "Expected Workcell staging cache roots to reject symlinked host components before staging or mounting",
+	},
+	{
+		kind:         kindFunctionBlock,
+		functionName: "prepare_injection_bundle",
+		pattern:      "prepare_colima_staging_cache_roots",
+		message:      "Expected Workcell staging cache roots to reject symlinked host components before staging or mounting",
+	},
+	{
+		kind:         kindFunctionBlock,
+		functionName: "prepare_workspace_control_plane_shadow",
+		pattern:      "prepare_colima_staging_cache_roots",
+		message:      "Expected Workcell staging cache roots to reject symlinked host components before staging or mounting",
+	},
+	{
+		kind:         kindFunctionBlock,
+		functionName: "start_managed_profile",
+		pattern:      "prepare_colima_staging_cache_roots",
+		message:      "Expected Workcell staging cache roots to reject symlinked host components before staging or mounting",
+	},
+	// Guard 3: stale injection cleanup fails closed when the default bundle
+	// parent is rejected.  The bare
+	// `cleanup_stale_injection_bundles "$(default_injection_bundle_parent)"`
+	// call (unbraced command substitution, no fail-closed capture) is a
+	// violation, so it is a negated `rg -q` (kindAbsent: present → exit 1);
+	// the four fail-closed probes are block-scoped to
+	// cleanup_default_injection_bundles.
+	{
+		kind:    kindAbsent,
+		pattern: `cleanup_stale_injection_bundles "$(default_injection_bundle_parent)"`,
+		message: "Expected stale injection cleanup to fail closed when the default bundle parent is rejected",
+	},
+	{
+		kind:         kindFunctionBlock,
+		functionName: "cleanup_default_injection_bundles",
+		pattern:      `bundle_parent="$(default_injection_bundle_parent)" || return $?`,
+		message:      "Expected stale injection cleanup to fail closed when the default bundle parent is rejected",
+	},
+	{
+		kind:         kindFunctionBlock,
+		functionName: "cleanup_default_injection_bundles",
+		pattern:      `token_handoff_parent="$(default_copilot_token_handoff_parent)" || return $?`,
+		message:      "Expected stale injection cleanup to fail closed when the default bundle parent is rejected",
+	},
+	{
+		kind:         kindFunctionBlock,
+		functionName: "cleanup_default_injection_bundles",
+		pattern:      `cleanup_stale_injection_bundles "${bundle_parent}"`,
+		message:      "Expected stale injection cleanup to fail closed when the default bundle parent is rejected",
+	},
+	{
+		kind:         kindFunctionBlock,
+		functionName: "cleanup_default_injection_bundles",
+		pattern:      `cleanup_stale_injection_bundles "${token_handoff_parent}"`,
+		message:      "Expected stale injection cleanup to fail closed when the default bundle parent is rejected",
+	},
+}
+
+// CheckManagedProfileStaging runs the three scripts/workcell
+// managed-profile staging/cleanup invariants against the repo rooted at
+// rootDir, in the shell's original order.  It returns nil when every
+// invariant holds (the shell's exit 0), or an error whose message equals
+// the shell's stderr for the first violated invariant (the shell's exit
+// 1).
+func CheckManagedProfileStaging(rootDir string) error {
+	return evaluate(rootDir, managedProfileStagingChecks)
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -464,6 +464,154 @@ func TestCheckRuntimeInvariants(t *testing.T) {
 	}
 }
 
+// managedProfileStagingHappyLauncher is a minimal scripts/workcell that
+// satisfies all three managed-profile staging/cleanup invariants: a
+// start_managed_profile body mounting all three staging cache roots (with
+// the staging-cache-root reject call), a top-level
+// reject_symlinked_colima_staging_cache_roots definition, the
+// prepare_colima_staging_cache_roots call inside the three preparing
+// functions, no bare unbraced default-parent cleanup call, and a
+// cleanup_default_injection_bundles body that captures both parents
+// fail-closed before cleaning them.  Individual negative cases mutate one
+// property of this baseline.
+const managedProfileStagingHappyLauncher = `#!/bin/bash
+set -euo pipefail
+
+reject_symlinked_colima_staging_cache_roots() {
+  : reject symlinks
+}
+
+prepare_injection_bundle() {
+  prepare_colima_staging_cache_roots
+}
+
+prepare_workspace_control_plane_shadow() {
+  prepare_colima_staging_cache_roots
+}
+
+start_managed_profile() {
+  prepare_colima_staging_cache_roots
+  host_inputs_root="${cache}/workcell-host-inputs"
+  shadow_root="${cache}/workcell-shadow"
+  token_handoff_root="${cache}/workcell-token-handoff"
+  colima start \
+    --mount "${host_inputs_root}" \
+    --mount "${shadow_root}" \
+    --mount "${token_handoff_root}:w"
+}
+
+cleanup_default_injection_bundles() {
+  local bundle_parent token_handoff_parent
+  bundle_parent="$(default_injection_bundle_parent)" || return $?
+  token_handoff_parent="$(default_copilot_token_handoff_parent)" || return $?
+  cleanup_stale_injection_bundles "${bundle_parent}"
+  cleanup_stale_injection_bundles "${token_handoff_parent}"
+}
+`
+
+func TestCheckManagedProfileStaging(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string // "" means expect success
+	}{
+		{
+			name: "happy path all invariants hold",
+			body: managedProfileStagingHappyLauncher,
+		},
+		{
+			// kindFunctionBlock: host-inputs mount root removed from the
+			// start_managed_profile body (guard 1).
+			name:    "missing host-inputs mount root",
+			body:    strings.Replace(managedProfileStagingHappyLauncher, `--mount "${host_inputs_root}" \`+"\n", "", 1),
+			wantErr: "Expected managed Colima launch to mount Workcell staging cache roots with reviewed access modes",
+		},
+		{
+			// kindFunctionBlock: token-handoff write mount removed (guard 1).
+			name:    "missing token-handoff write mount",
+			body:    strings.Replace(managedProfileStagingHappyLauncher, `--mount "${token_handoff_root}:w"`, `--mount "${token_handoff_root}"`, 1),
+			wantErr: "Expected managed Colima launch to mount Workcell staging cache roots with reviewed access modes",
+		},
+		{
+			// kindFunctionBlock scoping: the workcell-shadow cache-root name
+			// exists in the file but OUTSIDE start_managed_profile, so the
+			// block-scoped guard must still fail.
+			name: "shadow root only outside start_managed_profile body",
+			body: strings.Replace(managedProfileStagingHappyLauncher, `  shadow_root="${cache}/workcell-shadow"`+"\n", "", 1) +
+				"\ndecoy() {\n  echo workcell-shadow\n}\n",
+			wantErr: "Expected managed Colima launch to mount Workcell staging cache roots with reviewed access modes",
+		},
+		{
+			// kindPresent: the reject_symlinked_colima_staging_cache_roots
+			// helper removed entirely (guard 2, whole-file probe).
+			name:    "missing reject_symlinked helper",
+			body:    strings.Replace(managedProfileStagingHappyLauncher, "reject_symlinked_colima_staging_cache_roots", "reject_other", 2),
+			wantErr: "Expected Workcell staging cache roots to reject symlinked host components before staging or mounting",
+		},
+		{
+			// kindFunctionBlock: prepare_colima_staging_cache_roots call removed
+			// from prepare_injection_bundle (guard 2), while the other functions
+			// keep theirs.
+			name: "missing staging-cache-root call in prepare_injection_bundle",
+			body: strings.Replace(managedProfileStagingHappyLauncher,
+				"prepare_injection_bundle() {\n  prepare_colima_staging_cache_roots\n}",
+				"prepare_injection_bundle() {\n  :\n}", 1),
+			wantErr: "Expected Workcell staging cache roots to reject symlinked host components before staging or mounting",
+		},
+		{
+			// kindAbsent: a bare unbraced default-parent cleanup call is a
+			// violation (guard 3), even though every fail-closed probe remains.
+			name:    "bare default-parent cleanup call present",
+			body:    managedProfileStagingHappyLauncher + "\ncleanup_stale_injection_bundles \"$(default_injection_bundle_parent)\"\n",
+			wantErr: "Expected stale injection cleanup to fail closed when the default bundle parent is rejected",
+		},
+		{
+			// kindFunctionBlock: the fail-closed bundle_parent capture removed
+			// from cleanup_default_injection_bundles (guard 3).
+			name:    "missing fail-closed bundle_parent capture",
+			body:    strings.Replace(managedProfileStagingHappyLauncher, `  bundle_parent="$(default_injection_bundle_parent)" || return $?`+"\n", "", 1),
+			wantErr: "Expected stale injection cleanup to fail closed when the default bundle parent is rejected",
+		},
+		{
+			// kindFunctionBlock scoping: the fail-closed token-handoff capture
+			// exists OUTSIDE cleanup_default_injection_bundles, so the
+			// block-scoped guard must still fail.
+			name: "token-handoff capture only outside cleanup function",
+			body: strings.Replace(managedProfileStagingHappyLauncher,
+				`  token_handoff_parent="$(default_copilot_token_handoff_parent)" || return $?`+"\n", "", 1) +
+				"\ndecoy() {\n  token_handoff_parent=\"$(default_copilot_token_handoff_parent)\" || return $?\n}\n",
+			wantErr: "Expected stale injection cleanup to fail closed when the default bundle parent is rejected",
+		},
+		{
+			// A missing launcher is empty content: the negative (kindAbsent)
+			// guard-3 probe passes but the first affirmative check (guard 1's
+			// host-inputs mount) fires, mirroring the shell's first `if`.
+			name:    "missing launcher",
+			body:    "",
+			wantErr: "Expected managed Colima launch to mount Workcell staging cache roots with reviewed access modes",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeLauncher(t, tc.body)
+			err := CheckManagedProfileStaging(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckManagedProfileStaging() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckManagedProfileStaging() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckManagedProfileStaging() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 // TestExtractNamedFunctionBlock pins the sed-range extraction semantics
 // the run_host_colima check depends on: the block runs from the `NAME()`
 // opening line through the first line beginning with `}` (inclusive), and

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2661,30 +2661,21 @@ fi
 # invariant: it handles the failure so the top-level ERR trap does not fire and
 # append trap diagnostics, preserving the exact failure stderr surface.
 go_verify_citools workcell-runtime-invariants "${ROOT_DIR}" || exit 1
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "start_managed_profile" 'workcell-host-inputs' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "start_managed_profile" 'workcell-shadow' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "start_managed_profile" 'workcell-token-handoff' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "start_managed_profile" "--mount \"\${host_inputs_root}\"" ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "start_managed_profile" "--mount \"\${shadow_root}\"" ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "start_managed_profile" "--mount \"\${token_handoff_root}:w\""; then
-  echo "Expected managed Colima launch to mount Workcell staging cache roots with reviewed access modes" >&2
-  exit 1
-fi
-if ! rg -q 'reject_symlinked_colima_staging_cache_roots' "${ROOT_DIR}/scripts/workcell" ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "prepare_injection_bundle" 'prepare_colima_staging_cache_roots' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "prepare_workspace_control_plane_shadow" 'prepare_colima_staging_cache_roots' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "start_managed_profile" 'prepare_colima_staging_cache_roots'; then
-  echo "Expected Workcell staging cache roots to reject symlinked host components before staging or mounting" >&2
-  exit 1
-fi
-if rg -q 'cleanup_stale_injection_bundles "\$\(default_injection_bundle_parent\)"' "${ROOT_DIR}/scripts/workcell" ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "cleanup_default_injection_bundles" "bundle_parent=\"\$(default_injection_bundle_parent)\" || return \$?" ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "cleanup_default_injection_bundles" "token_handoff_parent=\"\$(default_copilot_token_handoff_parent)\" || return \$?" ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "cleanup_default_injection_bundles" "cleanup_stale_injection_bundles \"\${bundle_parent}\"" ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "cleanup_default_injection_bundles" "cleanup_stale_injection_bundles \"\${token_handoff_parent}\""; then
-  echo "Expected stale injection cleanup to fail closed when the default bundle parent is rejected" >&2
-  exit 1
-fi
+# Assert the managed-profile staging/cleanup invariants: managed Colima
+# launch mounts all three staging cache roots (host-inputs, shadow,
+# token-handoff) with the reviewed access modes, the staging cache roots
+# reject symlinked host components before staging or mounting, and stale
+# injection cleanup fails closed when the default bundle parent is
+# rejected.  Migrated to Go (D3): internal/workcellhardening behind the
+# workcell-citools workcell-managed-profile-staging subcommand preserves
+# the exact exit codes and stderr messages of the former inline
+# function_block_contains_fixed / rg block, including the fixed-string
+# matching semantics (every pattern is metacharacter-free after
+# unescaping) and the negated bare-parent cleanup sub-condition.
+# `|| exit 1` matches the former inline block's `exit 1` on a violated
+# invariant: it handles the failure so the top-level ERR trap does not fire and
+# append trap diagnostics, preserving the exact failure stderr surface.
+go_verify_citools workcell-managed-profile-staging "${ROOT_DIR}" || exit 1
 
 WORKCELL_COLIMA_TIMEOUT_HARNESS="${BARRIER_VERIFY_ROOT}/workcell-colima-timeout-harness.sh"
 {


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 5 of N.** Follows #398/#399/#400/#401. Migrates the 3 managed-profile staging/mount/cleanup invariant checks (15 probes total).

## What
- **`internal/workcellhardening`**: new `CheckManagedProfileStaging(rootDir)` reusing the shared `evaluate()` + existing kinds only (`kindFunctionBlock`, `kindPresent`, `kindAbsent` — no new kinds). The 3 guards: `start_managed_profile` mounts the staging cache roots with reviewed access modes; staging roots reject symlinked host components (across `prepare_injection_bundle`/`prepare_workspace_control_plane_shadow`/`start_managed_profile`); and stale injection cleanup fails closed on a rejected bundle parent (`cleanup_default_injection_bundles`).
- **`cmd/workcell-citools`**: new `workcell-managed-profile-staging` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-managed-profile-staging "${ROOT_DIR}" || exit 1` at the same location.

## Parity (identical pass/fail)
Every `function_block_contains_fixed` needle was unescaped **byte-exact** from the shell (e.g. `--mount "${host_inputs_root}"`, `bundle_parent="$(default_injection_bundle_parent)" || return $?`) and verified present via `grep -Fq`; the two whole-file `rg` probes stay whole-file (guard-2 affirmative, guard-3 negated-present). 15 checks ordered to match the 3 sequential shell `if`s, so the first failure emits the same message. Verified with a parity harness reconstructing the original shell block: real repo → exit 0; crafted violations (missing `--mount`, missing `prepare_colima_staging_cache_roots`, bare `cleanup_stale_injection_bundles`) → exit 1 byte-identical, plus block-scoping tests.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 338 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)