### PR TITLE
^R D3: migrate scripts/workcell bootstrap egress-endpoint invariants from verify-invariants.sh to Go

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -99,6 +99,7 @@ func subcommands() []subcommand {
 		{"workcell-config-safety", "ROOT_DIR", 1, 1, cmdWorkcellConfigSafety},
 		{"workcell-runtime-invariants", "ROOT_DIR", 1, 1, cmdWorkcellRuntimeInvariants},
 		{"workcell-managed-profile-staging", "ROOT_DIR", 1, 1, cmdWorkcellManagedProfileStaging},
+		{"workcell-bootstrap-egress", "ROOT_DIR", 1, 1, cmdWorkcellBootstrapEgress},
 	}
 }
 
@@ -535,4 +536,12 @@ func cmdWorkcellRuntimeInvariants(args []string) error {
 // shell's original stderr message for the first violated invariant.
 func cmdWorkcellManagedProfileStaging(args []string) error {
 	return workcellhardening.CheckManagedProfileStaging(args[0])
+}
+
+// cmdWorkcellBootstrapEgress runs the nine bootstrap egress-endpoint
+// checks migrated out of scripts/verify-invariants.sh; it fails (exit 1
+// via die()) with the shell's original stderr message for the first
+// violated invariant.
+func cmdWorkcellBootstrapEgress(args []string) error {
+	return workcellhardening.CheckBootstrapEgress(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -675,12 +675,27 @@ func (c check) holds(text string) bool {
 	case kindAbsent:
 		return !strings.Contains(text, c.pattern)
 	case kindRegexAbsent:
-		return !regexp.MustCompile(c.pattern).MatchString(text)
+		return !regexMatchesAnyLine(c.pattern, text)
 	case kindRegexPresent:
-		return regexp.MustCompile(c.pattern).MatchString(text)
+		return regexMatchesAnyLine(c.pattern, text)
 	default:
 		return false
 	}
+}
+
+// regexMatchesAnyLine reports whether pattern matches any single line of text,
+// emulating ripgrep's default line-oriented matching: without `--multiline`, an
+// `rg` match cannot cross a line terminator, so a negated class like `[^.]+`
+// never spans a newline. Matching whole-file would let such a class consume `\n`
+// and diverge from the migrated `rg -q` probe.
+func regexMatchesAnyLine(pattern, text string) bool {
+	re := regexp.MustCompile(pattern)
+	for _, line := range strings.Split(text, "\n") {
+		if re.MatchString(line) {
+			return true
+		}
+	}
+	return false
 }
 
 // firstLine returns text up to (but excluding) the first newline,

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -16,6 +16,12 @@
 // (the three scripts/workcell checks between the runtime-invariants group
 // and the WORKCELL_COLIMA_TIMEOUT_HARNESS fixture) via
 // CheckManagedProfileStaging; see managedProfileStagingChecks.
+// It also re-implements the adjacent bootstrap egress-endpoint block (the
+// nine checks between the colima-egress-allowlist COLIMA_HOME pin check and
+// the per-Dockerfile snapshot CA-bundle loop) via CheckBootstrapEgress;
+// see bootstrapEgressChecks.  Eight of those read scripts/workcell; the
+// Copilot-release-URL-override probe reads runtime/container/Dockerfile via
+// the per-check targetFile field.
 //
 // Each invariant pins one property of the host launcher scripts/workcell:
 // that run_host_colima restores the real host HOME, that the shebang
@@ -55,9 +61,16 @@ import (
 )
 
 // launcherRelPath is the repo-relative path to the host launcher every
-// check inspects.  The shell hard-coded ${ROOT_DIR}/scripts/workcell for
-// each of head/grep/rg/function_block_contains_fixed.
+// check inspects by default.  The shell hard-coded
+// ${ROOT_DIR}/scripts/workcell for each of
+// head/grep/rg/function_block_contains_fixed.
 const launcherRelPath = "scripts/workcell"
+
+// dockerfileRelPath is the repo-relative path to the runtime container
+// Dockerfile.  Only the bootstrap-egress Copilot-release-URL-override
+// invariant reads this file instead of scripts/workcell; every other
+// check leaves check.targetFile empty and so defaults to launcherRelPath.
+const dockerfileRelPath = "runtime/container/Dockerfile"
 
 // checkKind selects how a check's pattern is matched against the launcher
 // contents.
@@ -96,13 +109,21 @@ const (
 )
 
 // check is one hardening invariant: how to match, what to match, which
-// function to scope to (kindFunctionBlock only), and the exact stderr
-// message the shell emitted on violation.
+// function to scope to (kindFunctionBlock only), which repo-relative file
+// to read (empty means launcherRelPath), and the exact stderr message the
+// shell emitted on violation.
 type check struct {
 	kind         checkKind
 	functionName string
 	pattern      string
 	message      string
+	// targetFile is the repo-relative file this check reads.  An empty
+	// value defaults to launcherRelPath (scripts/workcell), so every
+	// existing check keeps its original read target unchanged; only the
+	// bootstrap-egress Copilot-release-URL-override invariant sets it (to
+	// dockerfileRelPath), mirroring the shell probe that ran `rg` against
+	// ${ROOT_DIR}/runtime/container/Dockerfile instead of scripts/workcell.
+	targetFile string
 }
 
 // checks lists the eleven invariants in the same order as the former
@@ -181,22 +202,39 @@ func Check(rootDir string) error {
 	return evaluate(rootDir, checks)
 }
 
-// evaluate reads scripts/workcell under rootDir and returns the first
-// violated check's message (as an error), or nil when all hold.  A
-// missing or unreadable launcher is treated as empty content, exactly as
-// the shell behaved: head/grep/rg/function_block_contains_fixed and
-// negated `rg -q` on a missing file all produce no match, so affirmative
-// (kindPresent/kindFunctionBlock/kindFirstLineRegex) checks fail while
-// negative (kindAbsent/kindRegexAbsent) checks pass.
+// evaluate reads each check's target file under rootDir (defaulting to
+// scripts/workcell) and returns the first violated check's message (as an
+// error), or nil when all hold.  Distinct target files are read at most
+// once and cached, so a group that mixes scripts/workcell and
+// runtime/container/Dockerfile probes reads each file a single time.
+//
+// A missing or unreadable target file is treated as empty content,
+// exactly as the shell behaved: head/grep/rg/function_block_contains_fixed
+// and negated `rg -q` on a missing file all produce no match, so
+// affirmative (kindPresent/kindRegexPresent/kindFunctionBlock/
+// kindFirstLineRegex) checks fail while negative
+// (kindAbsent/kindRegexAbsent/kindFunctionBlockAbsent) checks pass.
 func evaluate(rootDir string, cs []check) error {
-	content, err := os.ReadFile(filepath.Join(rootDir, launcherRelPath))
-	if err != nil {
-		content = nil
+	cache := make(map[string]string)
+	readTarget := func(rel string) string {
+		if text, ok := cache[rel]; ok {
+			return text
+		}
+		content, err := os.ReadFile(filepath.Join(rootDir, rel))
+		if err != nil {
+			content = nil
+		}
+		text := string(content)
+		cache[rel] = text
+		return text
 	}
-	text := string(content)
 
 	for _, c := range cs {
-		if !c.holds(text) {
+		rel := c.targetFile
+		if rel == "" {
+			rel = launcherRelPath
+		}
+		if !c.holds(readTarget(rel)) {
 			return errors.New(c.message)
 		}
 	}
@@ -518,6 +556,107 @@ var managedProfileStagingChecks = []check{
 // 1).
 func CheckManagedProfileStaging(rootDir string) error {
 	return evaluate(rootDir, managedProfileStagingChecks)
+}
+
+// bootstrapEgressChecks lists the nine bootstrap egress-endpoint
+// invariants in the same order as the former inline block in
+// scripts/verify-invariants.sh (the block between the
+// colima-egress-allowlist COLIMA_HOME pin check and the per-Dockerfile
+// snapshot CA-bundle loop), so a reviewer can diff the two one-to-one.
+//
+// Eight probes read scripts/workcell (the default target); the
+// Copilot-release-URL-override probe reads runtime/container/Dockerfile
+// (targetFile: dockerfileRelPath), mirroring the one shell `rg` that ran
+// against the Dockerfile rather than the launcher.
+//
+// Matching semantics mirror the shell exactly:
+//   - The seven fixed-string probes had every rg metacharacter escaped
+//     (`snapshot\.debian\.org:443`, `resolve_copilot_release_url\(\)`,
+//     `--build-arg "COPILOT_RELEASE_URL=\$\{copilot_release_url\}"`, ...),
+//     so they reduce to fixed-string containment: kindPresent for the
+//     affirmative `rg -q`, kindAbsent for the two negated guards
+//     (static.rust-lang.org:443 and snapshot.debian.org:80 present are
+//     violations).
+//   - The R2 blob-storage probe is a genuine regex — its `[^.]+` is a
+//     one-or-more-non-dot subdomain wildcard — so it is kindRegexPresent
+//     with the pattern verbatim.  RE2 matches the same hosts as rg (e.g.
+//     docker-images-prod.abc123.r2.cloudflarestorage.com:443).
+//   - The Dockerfile Copilot-release probe anchored `^ARG` to a line
+//     start; rg is line-based, so in Go it is a kindRegexPresent with a
+//     multiline `(?m)^ARG COPILOT_RELEASE_URL=` pattern that anchors to any
+//     line start of the Dockerfile.
+var bootstrapEgressChecks = []check{
+	{
+		kind:    kindPresent,
+		pattern: "snapshot.debian.org:443",
+		message: "Expected scripts/workcell bootstrap endpoints to allow snapshot.debian.org",
+	},
+	{
+		kind:    kindPresent,
+		pattern: "snapshot-cloudflare.debian.org:443",
+		message: "Expected scripts/workcell bootstrap endpoints to allow the snapshot-cloudflare.debian.org CDN mirror",
+	},
+	{
+		// kindAbsent: an unused static.rust-lang.org egress entry is a
+		// violation (present → exit 1).
+		kind:    kindAbsent,
+		pattern: "static.rust-lang.org:443",
+		message: "Expected scripts/workcell bootstrap endpoints to avoid unused static.rust-lang.org egress",
+	},
+	{
+		// kindRegexPresent: the `[^.]+` subdomain wildcard is a genuine
+		// regex, so this matches as a regex rather than a fixed string.
+		kind:    kindRegexPresent,
+		pattern: `docker-images-prod\.[^.]+\.r2\.cloudflarestorage\.com:443`,
+		message: "Expected scripts/workcell bootstrap endpoints to allow Docker blob storage on Cloudflare R2",
+	},
+	{
+		kind:    kindPresent,
+		pattern: "production.cloudfront.docker.com:443",
+		message: "Expected scripts/workcell bootstrap endpoints to allow Docker blob storage on CloudFront",
+	},
+	{
+		// kindRegexPresent against runtime/container/Dockerfile: the shell's
+		// line-anchored `^ARG COPILOT_RELEASE_URL=` becomes a multiline
+		// `(?m)^ARG ...` so `^` anchors to any Dockerfile line start.
+		kind:       kindRegexPresent,
+		pattern:    `(?m)^ARG COPILOT_RELEASE_URL=`,
+		message:    "Expected runtime Dockerfile to accept a host-resolved Copilot release URL override",
+		targetFile: dockerfileRelPath,
+	},
+	{
+		// kindPresent: the shell's `resolve_copilot_release_url\(\)` escaped
+		// its parens, so it is fixed-string containment of the literal
+		// `resolve_copilot_release_url()`.
+		kind:    kindPresent,
+		pattern: "resolve_copilot_release_url()",
+		message: "Expected scripts/workcell to resolve Copilot release URLs on the host before runtime builds",
+	},
+	{
+		// kindPresent: the shell's
+		// `--build-arg "COPILOT_RELEASE_URL=\$\{copilot_release_url\}"`
+		// escaped every metacharacter, so it is fixed-string containment of
+		// the literal --build-arg invocation.
+		kind:    kindPresent,
+		pattern: `--build-arg "COPILOT_RELEASE_URL=${copilot_release_url}"`,
+		message: "Expected scripts/workcell runtime builds to pass host-resolved Copilot release URLs into Docker",
+	},
+	{
+		// kindAbsent: an unused snapshot.debian.org:80 (plaintext) egress
+		// entry is a violation (present → exit 1).
+		kind:    kindAbsent,
+		pattern: "snapshot.debian.org:80",
+		message: "Expected scripts/workcell bootstrap endpoints to avoid unused snapshot.debian.org:80 egress",
+	},
+}
+
+// CheckBootstrapEgress runs the nine bootstrap egress-endpoint invariants
+// against the repo rooted at rootDir, in the shell's original order.  It
+// returns nil when every invariant holds (the shell's exit 0), or an error
+// whose message equals the shell's stderr for the first violated invariant
+// (the shell's exit 1).
+func CheckBootstrapEgress(rootDir string) error {
+	return evaluate(rootDir, bootstrapEgressChecks)
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -836,3 +836,16 @@ func TestExtractNamedFunctionBlock(t *testing.T) {
 		t.Fatalf("extractNamedFunctionBlock for a missing function should be empty")
 	}
 }
+
+func TestRegexMatchesAnyLineIsLineBounded(t *testing.T) {
+	// A negated char class must not consume a newline, mirroring ripgrep's
+	// default (non-multiline) behaviour — otherwise a broken cross-line R2
+	// endpoint would spuriously match.
+	pat := `docker-images-prod\.[^.]+\.r2\.cloudflarestorage\.com:443`
+	if !regexMatchesAnyLine(pat, "docker-images-prod.abc123.r2.cloudflarestorage.com:443") {
+		t.Fatalf("expected a valid single-line R2 endpoint to match")
+	}
+	if regexMatchesAnyLine(pat, "docker-images-prod.\n.r2.cloudflarestorage.com:443") {
+		t.Fatalf("a cross-newline R2 endpoint must NOT match (rg is line-oriented)")
+	}
+}

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -612,6 +612,212 @@ func TestCheckManagedProfileStaging(t *testing.T) {
 	}
 }
 
+// bootstrapEgressHappyLauncher is a minimal scripts/workcell that
+// satisfies the eight launcher-scoped bootstrap egress invariants: both
+// Debian snapshot mirrors and both Docker blob-storage CDNs on :443, no
+// unused static.rust-lang.org:443 or snapshot.debian.org:80 egress, the
+// resolve_copilot_release_url helper, and the --build-arg pass-through.
+// Individual negative cases mutate one property of this baseline.
+const bootstrapEgressHappyLauncher = `#!/bin/bash
+set -euo pipefail
+
+bootstrap_egress_endpoints() {
+  cat <<'EOF'
+snapshot.debian.org:443
+snapshot-cloudflare.debian.org:443
+docker-images-prod.abc123.r2.cloudflarestorage.com:443
+production.cloudfront.docker.com:443
+EOF
+}
+
+resolve_copilot_release_url() {
+  : resolve on host
+}
+
+runtime_build() {
+  buildx_cmd build --build-arg "COPILOT_RELEASE_URL=${copilot_release_url}" .
+}
+`
+
+// bootstrapEgressHappyDockerfile is a minimal runtime/container/Dockerfile
+// that satisfies the one Dockerfile-scoped invariant: a line-anchored
+// `ARG COPILOT_RELEASE_URL=` override.
+const bootstrapEgressHappyDockerfile = `# syntax=docker/dockerfile:1
+FROM debian:trixie-slim
+ARG COPILOT_RELEASE_URL=https://example.invalid/copilot.tar.gz
+RUN : install
+`
+
+// writeBootstrapRepo materializes a fake repo with scripts/workcell set to
+// launcher and runtime/container/Dockerfile set to dockerfile; a body of ""
+// means "do not create that file" (unreadable-target case).
+func writeBootstrapRepo(t *testing.T, launcher, dockerfile string) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, body string) {
+		if body == "" {
+			return
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(launcherRelPath, launcher)
+	write(dockerfileRelPath, dockerfile)
+	return root
+}
+
+func TestCheckBootstrapEgress(t *testing.T) {
+	tests := []struct {
+		name       string
+		launcher   string
+		dockerfile string
+		wantErr    string // "" means expect success
+	}{
+		{
+			name:       "happy path all invariants hold",
+			launcher:   bootstrapEgressHappyLauncher,
+			dockerfile: bootstrapEgressHappyDockerfile,
+		},
+		{
+			// kindPresent: the snapshot.debian.org:443 endpoint removed.
+			name:       "missing snapshot.debian.org endpoint",
+			launcher:   strings.Replace(bootstrapEgressHappyLauncher, "snapshot.debian.org:443\n", "", 1),
+			dockerfile: bootstrapEgressHappyDockerfile,
+			wantErr:    "Expected scripts/workcell bootstrap endpoints to allow snapshot.debian.org",
+		},
+		{
+			// kindPresent: the snapshot-cloudflare mirror removed.
+			name:       "missing snapshot-cloudflare mirror",
+			launcher:   strings.Replace(bootstrapEgressHappyLauncher, "snapshot-cloudflare.debian.org:443\n", "", 1),
+			dockerfile: bootstrapEgressHappyDockerfile,
+			wantErr:    "Expected scripts/workcell bootstrap endpoints to allow the snapshot-cloudflare.debian.org CDN mirror",
+		},
+		{
+			// kindAbsent: an unused static.rust-lang.org:443 egress entry is a
+			// violation.
+			name:       "static.rust-lang.org egress present",
+			launcher:   bootstrapEgressHappyLauncher + "static.rust-lang.org:443\n",
+			dockerfile: bootstrapEgressHappyDockerfile,
+			wantErr:    "Expected scripts/workcell bootstrap endpoints to avoid unused static.rust-lang.org egress",
+		},
+		{
+			// kindRegexPresent: the R2 host removed entirely.
+			name:       "missing R2 blob-storage host",
+			launcher:   strings.Replace(bootstrapEgressHappyLauncher, "docker-images-prod.abc123.r2.cloudflarestorage.com:443\n", "", 1),
+			dockerfile: bootstrapEgressHappyDockerfile,
+			wantErr:    "Expected scripts/workcell bootstrap endpoints to allow Docker blob storage on Cloudflare R2",
+		},
+		{
+			// kindRegexPresent semantics: the `[^.]+` subdomain wildcard spans
+			// exactly one dotless segment, so a host with an extra dotted
+			// segment (docker-images-prod.a.b.r2...) does NOT match and the
+			// check fails, pinning that the wildcard is not `.*`.
+			name:       "R2 host with dotted subdomain does not match",
+			launcher:   strings.Replace(bootstrapEgressHappyLauncher, "docker-images-prod.abc123.r2.cloudflarestorage.com:443", "docker-images-prod.a.b.r2.cloudflarestorage.com:443", 1),
+			dockerfile: bootstrapEgressHappyDockerfile,
+			wantErr:    "Expected scripts/workcell bootstrap endpoints to allow Docker blob storage on Cloudflare R2",
+		},
+		{
+			// kindRegexPresent negative control: a single dotless subdomain
+			// segment other than abc123 still matches, so the invariant holds.
+			name:       "R2 host with different single subdomain still matches",
+			launcher:   strings.Replace(bootstrapEgressHappyLauncher, "docker-images-prod.abc123.r2.cloudflarestorage.com:443", "docker-images-prod.xyz789.r2.cloudflarestorage.com:443", 1),
+			dockerfile: bootstrapEgressHappyDockerfile,
+		},
+		{
+			// kindPresent: the CloudFront blob-storage host removed.
+			name:       "missing CloudFront blob-storage host",
+			launcher:   strings.Replace(bootstrapEgressHappyLauncher, "production.cloudfront.docker.com:443\n", "", 1),
+			dockerfile: bootstrapEgressHappyDockerfile,
+			wantErr:    "Expected scripts/workcell bootstrap endpoints to allow Docker blob storage on CloudFront",
+		},
+		{
+			// kindRegexPresent against the Dockerfile: the ARG override line
+			// removed.
+			name:       "missing Dockerfile ARG override",
+			launcher:   bootstrapEgressHappyLauncher,
+			dockerfile: strings.Replace(bootstrapEgressHappyDockerfile, "ARG COPILOT_RELEASE_URL=https://example.invalid/copilot.tar.gz\n", "", 1),
+			wantErr:    "Expected runtime Dockerfile to accept a host-resolved Copilot release URL override",
+		},
+		{
+			// kindRegexPresent multiline anchoring: the ARG text appears in the
+			// Dockerfile but NOT at a line start (embedded in a RUN echo), so
+			// the `(?m)^ARG ...` anchor must still fail.
+			name:     "Dockerfile ARG text not at line start",
+			launcher: bootstrapEgressHappyLauncher,
+			dockerfile: "# syntax=docker/dockerfile:1\nFROM debian:trixie-slim\n" +
+				"RUN echo \"ARG COPILOT_RELEASE_URL=set-at-runtime\"\n",
+			wantErr: "Expected runtime Dockerfile to accept a host-resolved Copilot release URL override",
+		},
+		{
+			// A missing Dockerfile is empty content: the launcher-scoped checks
+			// pass but the Dockerfile-scoped ARG regex fails, mirroring `rg -q`
+			// returning non-zero on a missing file.  Exercises the per-check
+			// target-file read against a distinct absent file.
+			name:       "missing Dockerfile",
+			launcher:   bootstrapEgressHappyLauncher,
+			dockerfile: "",
+			wantErr:    "Expected runtime Dockerfile to accept a host-resolved Copilot release URL override",
+		},
+		{
+			// kindPresent: the resolve_copilot_release_url helper removed.
+			name:       "missing resolve_copilot_release_url helper",
+			launcher:   strings.Replace(bootstrapEgressHappyLauncher, "resolve_copilot_release_url()", "resolve_other()", 1),
+			dockerfile: bootstrapEgressHappyDockerfile,
+			wantErr:    "Expected scripts/workcell to resolve Copilot release URLs on the host before runtime builds",
+		},
+		{
+			// kindPresent: the --build-arg Copilot release URL pass-through
+			// removed.
+			name:       "missing Copilot release URL build-arg",
+			launcher:   strings.Replace(bootstrapEgressHappyLauncher, `--build-arg "COPILOT_RELEASE_URL=${copilot_release_url}"`, `--build-arg "OTHER=${copilot_release_url}"`, 1),
+			dockerfile: bootstrapEgressHappyDockerfile,
+			wantErr:    "Expected scripts/workcell runtime builds to pass host-resolved Copilot release URLs into Docker",
+		},
+		{
+			// kindAbsent: an unused snapshot.debian.org:80 (plaintext) egress
+			// entry is a violation, even though snapshot.debian.org:443 remains.
+			name:       "snapshot.debian.org:80 egress present",
+			launcher:   bootstrapEgressHappyLauncher + "snapshot.debian.org:80\n",
+			dockerfile: bootstrapEgressHappyDockerfile,
+			wantErr:    "Expected scripts/workcell bootstrap endpoints to avoid unused snapshot.debian.org:80 egress",
+		},
+		{
+			// A missing launcher is empty content: the negative checks pass and
+			// the first affirmative check (snapshot.debian.org:443) fires,
+			// mirroring `rg -q` returning non-zero on a missing file.
+			name:       "missing launcher",
+			launcher:   "",
+			dockerfile: bootstrapEgressHappyDockerfile,
+			wantErr:    "Expected scripts/workcell bootstrap endpoints to allow snapshot.debian.org",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeBootstrapRepo(t, tc.launcher, tc.dockerfile)
+			err := CheckBootstrapEgress(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckBootstrapEgress() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckBootstrapEgress() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckBootstrapEgress() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 // TestExtractNamedFunctionBlock pins the sed-range extraction semantics
 // the run_host_colima check depends on: the block runs from the `NAME()`
 // opening line through the first line beginning with `}` (inclusive), and

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2969,48 +2969,22 @@ if ! rg -q 'COLIMA_HOME="\$\{colima_home\}"' "${ROOT_DIR}/scripts/colima-egress-
   exit 1
 fi
 
-if ! rg -q 'snapshot\.debian\.org:443' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell bootstrap endpoints to allow snapshot.debian.org" >&2
-  exit 1
-fi
-
-if ! rg -q 'snapshot-cloudflare\.debian\.org:443' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell bootstrap endpoints to allow the snapshot-cloudflare.debian.org CDN mirror" >&2
-  exit 1
-fi
-
-if rg -q 'static\.rust-lang\.org:443' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell bootstrap endpoints to avoid unused static.rust-lang.org egress" >&2
-  exit 1
-fi
-
-if ! rg -q 'docker-images-prod\.[^.]+\.r2\.cloudflarestorage\.com:443' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell bootstrap endpoints to allow Docker blob storage on Cloudflare R2" >&2
-  exit 1
-fi
-
-if ! rg -q 'production\.cloudfront\.docker\.com:443' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell bootstrap endpoints to allow Docker blob storage on CloudFront" >&2
-  exit 1
-fi
-
-if ! rg -q '^ARG COPILOT_RELEASE_URL=' "${ROOT_DIR}/runtime/container/Dockerfile"; then
-  echo "Expected runtime Dockerfile to accept a host-resolved Copilot release URL override" >&2
-  exit 1
-fi
-if ! rg -q 'resolve_copilot_release_url\(\)' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to resolve Copilot release URLs on the host before runtime builds" >&2
-  exit 1
-fi
-if ! rg -q -- '--build-arg "COPILOT_RELEASE_URL=\$\{copilot_release_url\}"' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell runtime builds to pass host-resolved Copilot release URLs into Docker" >&2
-  exit 1
-fi
-
-if rg -q 'snapshot\.debian\.org:80' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell bootstrap endpoints to avoid unused snapshot.debian.org:80 egress" >&2
-  exit 1
-fi
+# Assert the bootstrap egress-endpoint invariants: scripts/workcell allows
+# the two Debian snapshot mirrors and the two Docker blob-storage CDNs
+# (Cloudflare R2 and CloudFront) on :443, avoids the unused
+# static.rust-lang.org:443 and snapshot.debian.org:80 egress entries, and
+# wires the host-resolved Copilot release URL override (the runtime
+# Dockerfile ARG, the resolve_copilot_release_url helper, and the
+# --build-arg pass-through).  Migrated to Go (D3): internal/workcellhardening
+# behind the workcell-citools workcell-bootstrap-egress subcommand preserves
+# the exact exit codes and stderr messages of the former inline rg block,
+# including the fixed-string matching semantics (seven metacharacter-free
+# probes), the genuine R2 subdomain-wildcard regex, and the line-anchored
+# Dockerfile ARG regex read from runtime/container/Dockerfile.  `|| exit 1`
+# matches the former inline block's `exit 1` on a violated invariant: it
+# handles the failure so the top-level ERR trap does not fire and append trap
+# diagnostics, preserving the exact failure stderr surface.
+go_verify_citools workcell-bootstrap-egress "${ROOT_DIR}" || exit 1
 
 for dockerfile in \
   "${ROOT_DIR}/runtime/container/Dockerfile" \


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 6 of N.** Follows #398-#402. Migrates the 9 bootstrap egress-endpoint invariant checks (the Debian snapshot + CDN-mirror allowlist, Docker R2/CloudFront blob storage, and Copilot release-URL plumbing).

## What
- **`internal/workcellhardening`**: new `CheckBootstrapEgress(rootDir)` reusing the shared `evaluate()` + kinds. Adds a per-check **`targetFile`** field (empty → `scripts/workcell`), so one check can target `runtime/container/Dockerfile`; `evaluate` reads each target file once (cached). All four existing `Check*` groups are behavior-unchanged (empty targetFile), confirmed by the full existing test suite still passing.
- **`cmd/workcell-citools`**: new `workcell-bootstrap-egress` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-bootstrap-egress "${ROOT_DIR}" || exit 1`.

## Parity (identical pass/fail)
Two genuine regexes: the R2 host `docker-images-prod\.[^.]+\.r2\.cloudflarestorage\.com:443` (verbatim; a test proves a dotted subdomain fails since `[^.]+` is one dotless segment) and the Dockerfile `(?m)^ARG COPILOT_RELEASE_URL=` (multiline-anchored; test proves a line-start `ARG` passes but a mid-line embed fails). The other 7 are fixed strings unescaped byte-exact. Verified: real repo → exit 0; crafted violations diffed against a verbatim copy of the original `rg` block → byte-identical stderr + exit codes.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...` (existing tests pass post-struct-change; new table-driven suite per check), `shellcheck -x`, `shfmt -d` — all green. 4 files / 444 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)