### PR TITLE
^R D3: migrate scripts/workcell bootstrap-audit-metadata invariants from verify-invariants.sh to Go

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -100,6 +100,7 @@ func subcommands() []subcommand {
 		{"workcell-runtime-invariants", "ROOT_DIR", 1, 1, cmdWorkcellRuntimeInvariants},
 		{"workcell-managed-profile-staging", "ROOT_DIR", 1, 1, cmdWorkcellManagedProfileStaging},
 		{"workcell-bootstrap-egress", "ROOT_DIR", 1, 1, cmdWorkcellBootstrapEgress},
+		{"workcell-bootstrap-audit", "ROOT_DIR", 1, 1, cmdWorkcellBootstrapAudit},
 	}
 }
 
@@ -544,4 +545,12 @@ func cmdWorkcellManagedProfileStaging(args []string) error {
 // violated invariant.
 func cmdWorkcellBootstrapEgress(args []string) error {
 	return workcellhardening.CheckBootstrapEgress(args[0])
+}
+
+// cmdWorkcellBootstrapAudit runs the two scripts/workcell
+// bootstrap-audit-metadata checks migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the
+// shell's original stderr message for the first violated invariant.
+func cmdWorkcellBootstrapAudit(args []string) error {
+	return workcellhardening.CheckBootstrapAuditMetadata(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -685,7 +685,7 @@ var bootstrapAuditMetadataChecks = []check{
 		// kindPresent (first half of the audit-record guard): the
 		// bootstrap_applied field.
 		kind:    kindPresent,
-		pattern: "bootstrap_applied=${BOOTSTRAP_APPLIED}",
+		pattern: `"bootstrap_applied=${BOOTSTRAP_APPLIED}"`,
 		message: "Expected scripts/workcell audit records to include bootstrap network metadata",
 	},
 	{
@@ -694,7 +694,7 @@ var bootstrapAuditMetadataChecks = []check{
 		// of the literal command substitution.  Shares the first half's
 		// message.
 		kind:    kindPresent,
-		pattern: `bootstrap_endpoints=$([[ "${BOOTSTRAP_APPLIED}" -eq 1 ]] && printf '%s' "${BOOTSTRAP_ENDPOINTS}" || printf '')`,
+		pattern: `"bootstrap_endpoints=$([[ "${BOOTSTRAP_APPLIED}" -eq 1 ]] && printf '%s' "${BOOTSTRAP_ENDPOINTS}" || printf '')"`,
 		message: "Expected scripts/workcell audit records to include bootstrap network metadata",
 	},
 	{

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -659,6 +659,62 @@ func CheckBootstrapEgress(rootDir string) error {
 	return evaluate(rootDir, bootstrapEgressChecks)
 }
 
+// bootstrapAuditMetadataChecks lists the two scripts/workcell
+// bootstrap-audit-metadata invariants in the same order as the former
+// inline block in scripts/verify-invariants.sh (the block between the
+// verify-reproducible-build.sh OCI-export check and the
+// validate_colima_profile function-block group), so a reviewer can diff the
+// two one-to-one.
+//
+// The audit-record guard was one shell `if` joining two `rg -q` probes with
+// `||` under a single message; it is expressed here as two ordered
+// kindPresent checks sharing that message, which is behaviourally identical
+// (either missing probe yields the same stderr and exit 1, before the
+// bootstrap-policy check runs).  Both rg patterns escape every
+// metacharacter (`\$ \{ \} \( \[ \] \| \)`), so they reduce to fixed-string
+// containment of the literal audit-record fields (bootstrap_applied and
+// bootstrap_endpoints) emitted by scripts/workcell; the second field's
+// literal command substitution is reproduced verbatim in the check pattern
+// below.
+//
+// The bootstrap-policy guard's rg pattern
+// `bootstrap_policy=allowlist endpoints=%s` has no active metacharacters, so
+// it too is fixed-string containment.
+var bootstrapAuditMetadataChecks = []check{
+	{
+		// kindPresent (first half of the audit-record guard): the
+		// bootstrap_applied field.
+		kind:    kindPresent,
+		pattern: "bootstrap_applied=${BOOTSTRAP_APPLIED}",
+		message: "Expected scripts/workcell audit records to include bootstrap network metadata",
+	},
+	{
+		// kindPresent (second half): the bootstrap_endpoints field.  The rg
+		// pattern escaped `$ ( [ ] | )`, so this is fixed-string containment
+		// of the literal command substitution.  Shares the first half's
+		// message.
+		kind:    kindPresent,
+		pattern: `bootstrap_endpoints=$([[ "${BOOTSTRAP_APPLIED}" -eq 1 ]] && printf '%s' "${BOOTSTRAP_ENDPOINTS}" || printf '')`,
+		message: "Expected scripts/workcell audit records to include bootstrap network metadata",
+	},
+	{
+		// kindPresent: the temporary bootstrap network policy activation
+		// announcement.
+		kind:    kindPresent,
+		pattern: "bootstrap_policy=allowlist endpoints=%s",
+		message: "Expected scripts/workcell to announce temporary bootstrap network policy activation",
+	},
+}
+
+// CheckBootstrapAuditMetadata runs the two scripts/workcell
+// bootstrap-audit-metadata invariants against the repo rooted at rootDir, in
+// the shell's original order.  It returns nil when every invariant holds
+// (the shell's exit 0), or an error whose message equals the shell's stderr
+// for the first violated invariant (the shell's exit 1).
+func CheckBootstrapAuditMetadata(rootDir string) error {
+	return evaluate(rootDir, bootstrapAuditMetadataChecks)
+}
+
 // holds reports whether the invariant is satisfied by the launcher text.
 func (c check) holds(text string) bool {
 	switch c.kind {

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -863,6 +863,14 @@ func TestCheckBootstrapAuditMetadata(t *testing.T) {
 			wantErr:  "Expected scripts/workcell audit records to include bootstrap network metadata",
 		},
 		{
+			// The audit field must be QUOTED: dropping the leading `"` (which the
+			// old `rg` pattern required) leaves an unquoted command substitution
+			// that word-splits the endpoint list — the check must still fail.
+			name:     "unquoted bootstrap_endpoints field",
+			launcher: strings.Replace(bootstrapAuditHappyLauncher, `"bootstrap_endpoints=$(`, `bootstrap_endpoints=$(`, 1),
+			wantErr:  "Expected scripts/workcell audit records to include bootstrap network metadata",
+		},
+		{
 			// kindPresent: the bootstrap-policy activation announcement removed.
 			name:     "missing bootstrap policy announcement",
 			launcher: strings.Replace(bootstrapAuditHappyLauncher, "bootstrap_policy=allowlist endpoints=%s", "bootstrap_policy=off endpoints=%s", 1),

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -818,6 +818,102 @@ func TestCheckBootstrapEgress(t *testing.T) {
 	}
 }
 
+// bootstrapAuditHappyLauncher is a minimal scripts/workcell that satisfies
+// all three bootstrap-audit-metadata invariants: the two audit-record
+// fields (bootstrap_applied and bootstrap_endpoints) and the temporary
+// bootstrap network policy activation announcement.  Individual negative
+// cases mutate one property of this baseline.  Literal B (the
+// bootstrap_endpoints field) is reproduced here byte-for-byte from
+// scripts/workcell so a mis-transcription is caught by both the negative
+// cases and TestCheckBootstrapAuditMetadataRealRepo.
+const bootstrapAuditHappyLauncher = `#!/bin/bash
+set -euo pipefail
+
+write_audit_record() {
+  emit_record \
+    "bootstrap_applied=${BOOTSTRAP_APPLIED}" \
+    "bootstrap_endpoints=$([[ "${BOOTSTRAP_APPLIED}" -eq 1 ]] && printf '%s' "${BOOTSTRAP_ENDPOINTS}" || printf '')"
+}
+
+announce_bootstrap_policy() {
+  printf 'bootstrap_policy=allowlist endpoints=%s\n' "${BOOTSTRAP_ENDPOINTS}" >&2
+}
+`
+
+func TestCheckBootstrapAuditMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		launcher string
+		wantErr  string // "" means expect success
+	}{
+		{
+			name:     "happy path all invariants hold",
+			launcher: bootstrapAuditHappyLauncher,
+		},
+		{
+			// kindPresent (Literal A): the bootstrap_applied audit field removed.
+			name:     "missing bootstrap_applied field",
+			launcher: strings.Replace(bootstrapAuditHappyLauncher, `"bootstrap_applied=${BOOTSTRAP_APPLIED}"`, `"other_applied=${BOOTSTRAP_APPLIED}"`, 1),
+			wantErr:  "Expected scripts/workcell audit records to include bootstrap network metadata",
+		},
+		{
+			// kindPresent (Literal B): the bootstrap_endpoints audit field removed.
+			name:     "missing bootstrap_endpoints field",
+			launcher: strings.Replace(bootstrapAuditHappyLauncher, `bootstrap_endpoints=$([[ "${BOOTSTRAP_APPLIED}" -eq 1 ]] && printf '%s' "${BOOTSTRAP_ENDPOINTS}" || printf '')`, `bootstrap_endpoints=`, 1),
+			wantErr:  "Expected scripts/workcell audit records to include bootstrap network metadata",
+		},
+		{
+			// kindPresent: the bootstrap-policy activation announcement removed.
+			name:     "missing bootstrap policy announcement",
+			launcher: strings.Replace(bootstrapAuditHappyLauncher, "bootstrap_policy=allowlist endpoints=%s", "bootstrap_policy=off endpoints=%s", 1),
+			wantErr:  "Expected scripts/workcell to announce temporary bootstrap network policy activation",
+		},
+		{
+			// A missing launcher is empty content: the first affirmative check
+			// (bootstrap_applied) fires, mirroring `rg -q` returning non-zero on a
+			// missing file.
+			name:     "missing launcher",
+			launcher: "",
+			wantErr:  "Expected scripts/workcell audit records to include bootstrap network metadata",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeBootstrapRepo(t, tc.launcher, "")
+			err := CheckBootstrapAuditMetadata(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckBootstrapAuditMetadata() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckBootstrapAuditMetadata() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckBootstrapAuditMetadata() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckBootstrapAuditMetadataRealRepo asserts that the real
+// scripts/workcell in this repository satisfies all three
+// bootstrap-audit-metadata invariants.  This is the key guard against a
+// mis-transcribed Literal B: if the Go pattern is not a byte-exact
+// substring of the actual audit record, this test fails with the guard's
+// stderr message.
+func TestCheckBootstrapAuditMetadataRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, launcherRelPath)); err != nil {
+		t.Skipf("real scripts/workcell not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckBootstrapAuditMetadata(repoRoot); err != nil {
+		t.Fatalf("CheckBootstrapAuditMetadata(real repo) = %v, want nil", err)
+	}
+}
+
 // TestExtractNamedFunctionBlock pins the sed-range extraction semantics
 // the run_host_colima check depends on: the block runs from the `NAME()`
 // opening line through the first line beginning with `}` (inclusive), and

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3153,16 +3153,7 @@ if grep -Fq "\${ROOT_DIR}/tmp/workcell-repro" "${ROOT_DIR}/scripts/verify-reprod
   exit 1
 fi
 
-if ! rg -q '"bootstrap_applied=\$\{BOOTSTRAP_APPLIED\}"' "${ROOT_DIR}/scripts/workcell" ||
-  ! rg -q '"bootstrap_endpoints=\$\(\[\[ "\$\{BOOTSTRAP_APPLIED\}" -eq 1 \]\] && printf '\''%s'\'' "\$\{BOOTSTRAP_ENDPOINTS\}" \|\| printf '\'''\''\)"' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell audit records to include bootstrap network metadata" >&2
-  exit 1
-fi
-
-if ! rg -q 'bootstrap_policy=allowlist endpoints=%s' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected scripts/workcell to announce temporary bootstrap network policy activation" >&2
-  exit 1
-fi
+go_verify_citools workcell-bootstrap-audit "${ROOT_DIR}" || exit 1
 
 if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "validate_colima_profile" 'validate_colima_profile_config'; then
   echo "Expected validate_colima_profile to re-check the managed Colima config before reusing a running profile" >&2


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 7 of N.** Follows #398-#403. Migrates the 2 bootstrap-audit-metadata invariant checks (that the launcher's audit records include the bootstrap network metadata + policy-activation announcement).

## What
- **`internal/workcellhardening`**: new `CheckBootstrapAuditMetadata(rootDir)` — three ordered `kindPresent` checks reusing `evaluate()`. Guard 1 (`||`-joined) requires both `bootstrap_applied=${BOOTSTRAP_APPLIED}` and the `bootstrap_endpoints=$([[ ... ]] && printf ... || printf '')` audit-field literals; guard 2 requires `bootstrap_policy=allowlist endpoints=%s`.
- **`cmd/workcell-citools`**: new `workcell-bootstrap-audit` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-bootstrap-audit "${ROOT_DIR}" || exit 1`.

## Parity (identical pass/fail)
The gnarly `bootstrap_endpoints=…` pattern is fully-escaped in the shell (`\$ \( \[ \] \| \)`), i.e. a fixed string — transcribed byte-exact and confirmed via `grep -F` (single match) + a real-repo assertion test; the real repo exiting 0 is itself the proof it's byte-exact. Verified: real repo → exit 0; crafted violations → exit 1 byte-identical messages.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...` (existing tests pass; new suite incl. a real-repo assertion), `shellcheck -x`, `shfmt -d` — all green. 4 files / 172 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)