### PR TITLE
^R D3: migrate scripts/workcell git-index/shadow function-block invariants to Go

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -101,6 +101,7 @@ func subcommands() []subcommand {
 		{"workcell-managed-profile-staging", "ROOT_DIR", 1, 1, cmdWorkcellManagedProfileStaging},
 		{"workcell-bootstrap-egress", "ROOT_DIR", 1, 1, cmdWorkcellBootstrapEgress},
 		{"workcell-bootstrap-audit", "ROOT_DIR", 1, 1, cmdWorkcellBootstrapAudit},
+		{"workcell-git-index-shadow", "ROOT_DIR", 1, 1, cmdWorkcellGitIndexShadow},
 	}
 }
 
@@ -553,4 +554,12 @@ func cmdWorkcellBootstrapEgress(args []string) error {
 // shell's original stderr message for the first violated invariant.
 func cmdWorkcellBootstrapAudit(args []string) error {
 	return workcellhardening.CheckBootstrapAuditMetadata(args[0])
+}
+
+// cmdWorkcellGitIndexShadow runs the five scripts/workcell git-index shadow
+// checks migrated out of scripts/verify-invariants.sh; it fails (exit 1 via
+// die()) with the shell's original stderr message for the first violated
+// invariant.
+func cmdWorkcellGitIndexShadow(args []string) error {
+	return workcellhardening.CheckGitIndexShadow(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -106,6 +106,14 @@ const (
 	// active metacharacter (e.g. a trailing `.` meaning any char), unlike
 	// kindPresent's fixed-string containment.
 	kindRegexPresent
+	// kindFunctionBlockRegex requires the regexp pattern to match inside the
+	// top-level bash function body named functionName, mirroring
+	// function_block_contains_regex (sed-range extraction + `grep -q` regex,
+	// NOT `grep -Fq`).  Unlike kindFunctionBlock's fixed-string containment,
+	// the pattern is a genuine regular expression, matched per-line within the
+	// extracted block via regexMatchesAnyLine for `grep`/`rg` line-oriented
+	// parity.
+	kindFunctionBlockRegex
 )
 
 // check is one hardening invariant: how to match, what to match, which
@@ -715,6 +723,72 @@ func CheckBootstrapAuditMetadata(rootDir string) error {
 	return evaluate(rootDir, bootstrapAuditMetadataChecks)
 }
 
+// gitIndexShadowChecks lists the five scripts/workcell git-index shadow
+// invariants in the same order as the former inline block in
+// scripts/verify-invariants.sh (the block between the runtime/container/bin/git
+// object-store-redirection loop and the validate-repo.sh virtualenv-prune
+// check), so a reviewer can diff the two one-to-one.
+//
+// All five are block-scoped to a named function body, mirroring the shell's
+// function_block_contains_regex / function_block_contains_fixed helpers (both
+// use extract_named_function_block, i.e. `sed -n '/^NAME()/,/^}/p'`):
+//
+//   - The three kindFunctionBlockRegex checks migrate
+//     function_block_contains_regex (`grep -q` — a genuine regex).  Their
+//     patterns (cat-file blob, failed to read tracked blob,
+//     git_config_key_is_blocked) contain no active regex metacharacters, so
+//     they behave like fixed-string containment today, but the kind is a
+//     genuine regex for correctness under future patterns.
+//   - The two kindFunctionBlock checks migrate function_block_contains_fixed
+//     (`grep -Fq` — fixed-string containment).  The git_index_populate_shadow_dir
+//     needle `*/../*` contains `*` which grep -Fq treats literally, so it is a
+//     fixed-string containment of the literal `*/../*`.
+var gitIndexShadowChecks = []check{
+	{
+		kind:         kindFunctionBlockRegex,
+		functionName: "git_index_materialize_regular_file",
+		pattern:      "cat-file blob",
+		message:      "Expected git_index_materialize_regular_file to materialize tracked blobs without checkout-index",
+	},
+	{
+		kind:         kindFunctionBlockRegex,
+		functionName: "git_index_materialize_regular_file",
+		pattern:      "failed to read tracked blob",
+		message:      "Expected git_index_materialize_regular_file to fail closed when a tracked control-plane blob is unreadable",
+	},
+	{
+		// kindFunctionBlock (function_block_contains_fixed): fixed-string
+		// containment of the literal partial-file cleanup.
+		kind:         kindFunctionBlock,
+		functionName: "git_index_materialize_regular_file",
+		pattern:      `rm -f "${destination_path}"`,
+		message:      "Expected git_index_materialize_regular_file to remove partially materialized files after blob read failures",
+	},
+	{
+		// kindFunctionBlock (function_block_contains_fixed): `grep -Fq` treats
+		// the `*` in `*/../*` literally, so this is fixed-string containment.
+		kind:         kindFunctionBlock,
+		functionName: "git_index_populate_shadow_dir",
+		pattern:      "*/../*",
+		message:      "Expected git_index_populate_shadow_dir to reject unsafe index paths before shadow materialization",
+	},
+	{
+		kind:         kindFunctionBlockRegex,
+		functionName: "sanitize_shadowed_git_config",
+		pattern:      "git_config_key_is_blocked",
+		message:      "Expected sanitize_shadowed_git_config to reuse the shared blocked git-config key matcher",
+	},
+}
+
+// CheckGitIndexShadow runs the five scripts/workcell git-index shadow
+// invariants against the repo rooted at rootDir, in the shell's original
+// order.  It returns nil when every invariant holds (the shell's exit 0), or
+// an error whose message equals the shell's stderr for the first violated
+// invariant (the shell's exit 1).
+func CheckGitIndexShadow(rootDir string) error {
+	return evaluate(rootDir, gitIndexShadowChecks)
+}
+
 // holds reports whether the invariant is satisfied by the launcher text.
 func (c check) holds(text string) bool {
 	switch c.kind {
@@ -724,6 +798,9 @@ func (c check) holds(text string) bool {
 	case kindFunctionBlockAbsent:
 		block := extractNamedFunctionBlock(text, c.functionName)
 		return !strings.Contains(block, c.pattern)
+	case kindFunctionBlockRegex:
+		block := extractNamedFunctionBlock(text, c.functionName)
+		return regexMatchesAnyLine(c.pattern, block)
 	case kindFirstLineRegex:
 		return regexp.MustCompile(c.pattern).MatchString(firstLine(text))
 	case kindPresent:

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -922,6 +922,139 @@ func TestCheckBootstrapAuditMetadataRealRepo(t *testing.T) {
 	}
 }
 
+// gitIndexShadowHappyLauncher is a minimal scripts/workcell that satisfies
+// all five git-index shadow invariants: the two regex checks and the
+// partial-file cleanup inside git_index_materialize_regular_file, the unsafe
+// index-path rejection inside git_index_populate_shadow_dir, and the shared
+// blocked-key matcher reuse inside sanitize_shadowed_git_config.  Individual
+// negative cases mutate one property of this baseline.
+const gitIndexShadowHappyLauncher = `#!/bin/bash
+set -euo pipefail
+
+git_index_materialize_regular_file() {
+  local workspace="$1" oid="$2" destination_path="$3" relative_path="$4"
+  if ! run_clean_host_command git -C "${workspace}" cat-file blob "${oid}" >"${destination_path}"; then
+    rm -f "${destination_path}"
+    echo "Workcell blocked shadow materialization: failed to read tracked blob ${oid} for ${relative_path}" >&2
+    return 1
+  fi
+}
+
+git_index_populate_shadow_dir() {
+  local index_path="$1"
+  case "${index_path}" in
+    '' | /* | */../* | ../* | */..)
+      return 1
+      ;;
+  esac
+}
+
+sanitize_shadowed_git_config() {
+  local key="$1"
+  if git_config_key_is_blocked "${key}"; then
+    return 1
+  fi
+}
+`
+
+func TestCheckGitIndexShadow(t *testing.T) {
+	tests := []struct {
+		name     string
+		launcher string
+		wantErr  string // "" means expect success
+	}{
+		{
+			name:     "happy path all invariants hold",
+			launcher: gitIndexShadowHappyLauncher,
+		},
+		{
+			// kindFunctionBlockRegex: the cat-file blob materialization removed.
+			name:     "missing cat-file blob",
+			launcher: strings.Replace(gitIndexShadowHappyLauncher, "cat-file blob", "checkout-index", 1),
+			wantErr:  "Expected git_index_materialize_regular_file to materialize tracked blobs without checkout-index",
+		},
+		{
+			// kindFunctionBlockRegex: the fail-closed message removed.
+			name:     "missing failed to read tracked blob",
+			launcher: strings.Replace(gitIndexShadowHappyLauncher, "failed to read tracked blob", "read tracked blob", 1),
+			wantErr:  "Expected git_index_materialize_regular_file to fail closed when a tracked control-plane blob is unreadable",
+		},
+		{
+			// kindFunctionBlock: the partial-file cleanup removed.
+			name:     "missing partial-file cleanup",
+			launcher: strings.Replace(gitIndexShadowHappyLauncher, `rm -f "${destination_path}"`, `true`, 1),
+			wantErr:  "Expected git_index_materialize_regular_file to remove partially materialized files after blob read failures",
+		},
+		{
+			// kindFunctionBlock: the unsafe index-path rejection removed.
+			name:     "missing unsafe index path rejection",
+			launcher: strings.Replace(gitIndexShadowHappyLauncher, `*/../*`, `*/ok/*`, 1),
+			wantErr:  "Expected git_index_populate_shadow_dir to reject unsafe index paths before shadow materialization",
+		},
+		{
+			// kindFunctionBlockRegex: the shared blocked-key matcher reuse removed.
+			name:     "missing shared blocked-key matcher",
+			launcher: strings.Replace(gitIndexShadowHappyLauncher, "git_config_key_is_blocked", "always_false", 2),
+			wantErr:  "Expected sanitize_shadowed_git_config to reuse the shared blocked git-config key matcher",
+		},
+		{
+			// Scoping proof: the cat-file blob needle present in a DIFFERENT
+			// function body does not satisfy the git_index_materialize_regular_file
+			// check, because extract_named_function_block scopes to the named
+			// function.  Here the needle is moved out of
+			// git_index_materialize_regular_file into an unrelated helper.
+			name: "cat-file blob only in a different function",
+			launcher: strings.Replace(
+				strings.Replace(gitIndexShadowHappyLauncher, "cat-file blob", "checkout-index", 1),
+				"set -euo pipefail",
+				"set -euo pipefail\n\nunrelated_helper() {\n  git cat-file blob HEAD\n}",
+				1,
+			),
+			wantErr: "Expected git_index_materialize_regular_file to materialize tracked blobs without checkout-index",
+		},
+		{
+			// A missing launcher is empty content: the first affirmative check
+			// (cat-file blob) fires, mirroring function_block_contains_regex
+			// returning non-zero on a missing file.
+			name:     "missing launcher",
+			launcher: "",
+			wantErr:  "Expected git_index_materialize_regular_file to materialize tracked blobs without checkout-index",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeLauncher(t, tc.launcher)
+			err := CheckGitIndexShadow(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckGitIndexShadow() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckGitIndexShadow() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckGitIndexShadow() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckGitIndexShadowRealRepo asserts that the real scripts/workcell in
+// this repository satisfies all five git-index shadow invariants, guarding
+// against a mis-transcribed needle or function name.
+func TestCheckGitIndexShadowRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, launcherRelPath)); err != nil {
+		t.Skipf("real scripts/workcell not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckGitIndexShadow(repoRoot); err != nil {
+		t.Fatalf("CheckGitIndexShadow(real repo) = %v, want nil", err)
+	}
+}
+
 // TestExtractNamedFunctionBlock pins the sed-range extraction semantics
 // the run_host_colima check depends on: the block runs from the `NAME()`
 // opening line through the first line beginning with `}` (inclusive), and

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3182,31 +3182,7 @@ for _git_env_var in GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_IN
   fi
 done
 
-if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "git_index_materialize_regular_file" 'cat-file blob'; then
-  echo "Expected git_index_materialize_regular_file to materialize tracked blobs without checkout-index" >&2
-  exit 1
-fi
-
-if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "git_index_materialize_regular_file" 'failed to read tracked blob'; then
-  echo "Expected git_index_materialize_regular_file to fail closed when a tracked control-plane blob is unreadable" >&2
-  exit 1
-fi
-
-# shellcheck disable=SC2016
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "git_index_materialize_regular_file" 'rm -f "${destination_path}"'; then
-  echo "Expected git_index_materialize_regular_file to remove partially materialized files after blob read failures" >&2
-  exit 1
-fi
-
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "git_index_populate_shadow_dir" '*/../*'; then
-  echo "Expected git_index_populate_shadow_dir to reject unsafe index paths before shadow materialization" >&2
-  exit 1
-fi
-
-if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "sanitize_shadowed_git_config" 'git_config_key_is_blocked'; then
-  echo "Expected sanitize_shadowed_git_config to reuse the shared blocked git-config key matcher" >&2
-  exit 1
-fi
+go_verify_citools workcell-git-index-shadow "${ROOT_DIR}" || exit 1
 
 # shellcheck disable=SC2016
 if ! grep -Fq -- '-path "${ROOT_DIR}/.venv" -prune -o' "${ROOT_DIR}/scripts/validate-repo.sh"; then


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 8 of N.** Follows #398-#404. Migrates the 5 git-index/shadow function-block invariant checks (tracked-blob materialization, fail-closed unreadable-blob handling, partial-file cleanup, unsafe-index-path rejection, and shared blocked-git-config-key reuse).

## What
- **`internal/workcellhardening`**: new `CheckGitIndexShadow(rootDir)` — 3 regex + 2 fixed function-block checks scoped to `git_index_materialize_regular_file`, `git_index_populate_shadow_dir`, and `sanitize_shadowed_git_config`.
- **New kind `kindFunctionBlockRegex`**: mirrors the shell's `function_block_contains_regex()` (extract the named function body via the same `sed`-range extraction, then `grep -q` a **regex** — not `grep -Fq`). Implemented by composing `extractNamedFunctionBlock` with the existing per-line `regexMatchesAnyLine` (ripgrep/grep line parity). The two `_fixed` checks keep `kindFunctionBlock` (`*/../*` is literal under `grep -Fq`).
- **`cmd/workcell-citools`**: new `workcell-git-index-shadow` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-git-index-shadow "${ROOT_DIR}" || exit 1`. The `function_block_contains_regex`/`_fixed` shell helpers remain (still used by ~25 other checks).

## Parity (identical pass/fail)
Verified byte-identical against the original shell helpers: real repo → exit 0; crafted violations (break `cat-file blob`, `*/../*`, `git_config_key_is_blocked`) → exit 1 with byte-identical messages; plus a scoping test proving a needle in a *different* function doesn't satisfy the check.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 245 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)