### PR TITLE
^R D3: migrate scripts/workcell publish-pr/shadow-mount invariants to Go

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -102,6 +102,7 @@ func subcommands() []subcommand {
 		{"workcell-bootstrap-egress", "ROOT_DIR", 1, 1, cmdWorkcellBootstrapEgress},
 		{"workcell-bootstrap-audit", "ROOT_DIR", 1, 1, cmdWorkcellBootstrapAudit},
 		{"workcell-git-index-shadow", "ROOT_DIR", 1, 1, cmdWorkcellGitIndexShadow},
+		{"workcell-publish-pr-shadow", "ROOT_DIR", 1, 1, cmdWorkcellPublishPrShadow},
 	}
 }
 
@@ -562,4 +563,12 @@ func cmdWorkcellBootstrapAudit(args []string) error {
 // invariant.
 func cmdWorkcellGitIndexShadow(args []string) error {
 	return workcellhardening.CheckGitIndexShadow(args[0])
+}
+
+// cmdWorkcellPublishPrShadow runs the four scripts/workcell publish-PR /
+// shadow-mount checks migrated out of scripts/verify-invariants.sh; it fails
+// (exit 1 via die()) with the shell's original stderr message for the first
+// violated invariant.
+func cmdWorkcellPublishPrShadow(args []string) error {
+	return workcellhardening.CheckPublishPrShadowMounts(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -789,6 +789,73 @@ func CheckGitIndexShadow(rootDir string) error {
 	return evaluate(rootDir, gitIndexShadowChecks)
 }
 
+// publishPrShadowMountChecks lists the four scripts/workcell publish-PR /
+// shadow-mount invariants in the same order as the former inline block in
+// scripts/verify-invariants.sh (the block between the
+// publishpr.ValidateBaseName checkRefFormat check and the
+// prepare_workspace_control_plane_shadow `find ... -name .git` check), so a
+// reviewer can diff the two one-to-one.
+//
+// All four are block-scoped to a named function body, mirroring the shell's
+// function_block_contains_regex / function_block_contains_fixed helpers (both
+// use extract_named_function_block, i.e. `sed -n '/^NAME()/,/^}/p'`):
+//
+//   - The two kindFunctionBlockRegex checks migrate
+//     function_block_contains_regex (`grep -q` — a genuine regex).  The
+//     core.hooksPath probe's `.` characters are regex any-char metacharacters
+//     (as `grep`/`rg` would treat them), so the pattern is used verbatim as a
+//     regex.  The --no-verify probe is metacharacter-free, but it is kept a
+//     regex kind for fidelity with the shell's function_block_contains_regex.
+//   - The two kindFunctionBlock checks migrate function_block_contains_fixed
+//     (`grep -Fq` — fixed-string containment).  The add_shadow_git_config_mount
+//     needle is the literal `! -L "${source_path}"` (the shell wrote it as
+//     "! -L \"\${source_path}\""), matched as a fixed string.
+var publishPrShadowMountChecks = []check{
+	{
+		// kindFunctionBlockRegex: the `.` chars in core.hooksPath=/dev/null are
+		// regex any-char metacharacters, used verbatim as in the shell's
+		// function_block_contains_regex (`grep -q`).
+		kind:         kindFunctionBlockRegex,
+		functionName: "publish_pr_main",
+		pattern:      "core.hooksPath=/dev/null",
+		message:      "Expected publish_pr_main to disable repo hooks for host-side publish git commands",
+	},
+	{
+		// kindFunctionBlockRegex: metacharacter-free, but kept a regex kind for
+		// fidelity with the shell's function_block_contains_regex.
+		kind:         kindFunctionBlockRegex,
+		functionName: "publish_pr_main",
+		pattern:      "--no-verify",
+		message:      "Expected publish_pr_main to bypass repo hooks explicitly on host-side commit and push",
+	},
+	{
+		// kindFunctionBlock (function_block_contains_fixed): fixed-string
+		// containment of the symlink-free copy helper.
+		kind:         kindFunctionBlock,
+		functionName: "add_shadow_git_hooks_mount",
+		pattern:      "copy_tree_without_symlinks",
+		message:      "Expected add_shadow_git_hooks_mount to avoid copying symlinked hook content into the readonly shadow",
+	},
+	{
+		// kindFunctionBlock (function_block_contains_fixed): the shell needle
+		// "! -L \"\${source_path}\"" is the literal `! -L "${source_path}"`,
+		// matched as a fixed string.
+		kind:         kindFunctionBlock,
+		functionName: "add_shadow_git_config_mount",
+		pattern:      `! -L "${source_path}"`,
+		message:      "Expected add_shadow_git_config_mount to ignore symlinked git config files",
+	},
+}
+
+// CheckPublishPrShadowMounts runs the four scripts/workcell publish-PR /
+// shadow-mount invariants against the repo rooted at rootDir, in the shell's
+// original order.  It returns nil when every invariant holds (the shell's exit
+// 0), or an error whose message equals the shell's stderr for the first
+// violated invariant (the shell's exit 1).
+func CheckPublishPrShadowMounts(rootDir string) error {
+	return evaluate(rootDir, publishPrShadowMountChecks)
+}
+
 // holds reports whether the invariant is satisfied by the launcher text.
 func (c check) holds(text string) bool {
 	switch c.kind {

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -1055,6 +1055,125 @@ func TestCheckGitIndexShadowRealRepo(t *testing.T) {
 	}
 }
 
+// publishPrShadowHappyLauncher is a minimal scripts/workcell that satisfies
+// all four publish-PR / shadow-mount invariants: the core.hooksPath and
+// --no-verify regex checks inside publish_pr_main, the symlink-free copy helper
+// inside add_shadow_git_hooks_mount, and the symlink guard inside
+// add_shadow_git_config_mount.  Individual negative cases mutate one property
+// of this baseline.
+const publishPrShadowHappyLauncher = `#!/bin/bash
+set -euo pipefail
+
+publish_pr_main() {
+  git -c core.hooksPath=/dev/null commit --no-verify -m "publish"
+  git -c core.hooksPath=/dev/null push --no-verify
+}
+
+add_shadow_git_hooks_mount() {
+  local source_path="$1" source="$2"
+  copy_tree_without_symlinks "${source_path}" "${source}"
+}
+
+add_shadow_git_config_mount() {
+  local source_path="$1"
+  if [[ -f "${source_path}" && ! -L "${source_path}" ]]; then
+    return 0
+  fi
+}
+`
+
+func TestCheckPublishPrShadowMounts(t *testing.T) {
+	tests := []struct {
+		name     string
+		launcher string
+		wantErr  string // "" means expect success
+	}{
+		{
+			name:     "happy path all invariants hold",
+			launcher: publishPrShadowHappyLauncher,
+		},
+		{
+			// kindFunctionBlockRegex: the repo-hooks disable removed.
+			name:     "missing core.hooksPath disable",
+			launcher: strings.Replace(publishPrShadowHappyLauncher, "core.hooksPath=/dev/null", "core.editor=true", 2),
+			wantErr:  "Expected publish_pr_main to disable repo hooks for host-side publish git commands",
+		},
+		{
+			// kindFunctionBlockRegex: the explicit hook bypass removed.
+			name:     "missing --no-verify bypass",
+			launcher: strings.Replace(publishPrShadowHappyLauncher, "--no-verify", "--verbose", 2),
+			wantErr:  "Expected publish_pr_main to bypass repo hooks explicitly on host-side commit and push",
+		},
+		{
+			// kindFunctionBlock: the symlink-free copy helper removed.
+			name:     "missing symlink-free hooks copy",
+			launcher: strings.Replace(publishPrShadowHappyLauncher, "copy_tree_without_symlinks", "cp -r", 1),
+			wantErr:  "Expected add_shadow_git_hooks_mount to avoid copying symlinked hook content into the readonly shadow",
+		},
+		{
+			// kindFunctionBlock: the symlinked-config guard removed.
+			name:     "missing symlinked git config guard",
+			launcher: strings.Replace(publishPrShadowHappyLauncher, `! -L "${source_path}"`, `-e "${source_path}"`, 1),
+			wantErr:  "Expected add_shadow_git_config_mount to ignore symlinked git config files",
+		},
+		{
+			// Scoping proof: the core.hooksPath needle present in a DIFFERENT
+			// function body does not satisfy the publish_pr_main check, because
+			// extract_named_function_block scopes to the named function.  Here the
+			// needle is removed from publish_pr_main and reintroduced in an
+			// unrelated helper.
+			name: "core.hooksPath only in a different function",
+			launcher: strings.Replace(
+				strings.Replace(publishPrShadowHappyLauncher, "core.hooksPath=/dev/null", "core.editor=true", 2),
+				"set -euo pipefail",
+				"set -euo pipefail\n\nunrelated_helper() {\n  git -c core.hooksPath=/dev/null status\n}",
+				1,
+			),
+			wantErr: "Expected publish_pr_main to disable repo hooks for host-side publish git commands",
+		},
+		{
+			// A missing launcher is empty content: the first affirmative check
+			// (core.hooksPath disable) fires, mirroring function_block_contains_regex
+			// returning non-zero on a missing file.
+			name:     "missing launcher",
+			launcher: "",
+			wantErr:  "Expected publish_pr_main to disable repo hooks for host-side publish git commands",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeLauncher(t, tc.launcher)
+			err := CheckPublishPrShadowMounts(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckPublishPrShadowMounts() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckPublishPrShadowMounts() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckPublishPrShadowMounts() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckPublishPrShadowMountsRealRepo asserts that the real scripts/workcell
+// in this repository satisfies all four publish-PR / shadow-mount invariants,
+// guarding against a mis-transcribed needle or function name.
+func TestCheckPublishPrShadowMountsRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, launcherRelPath)); err != nil {
+		t.Skipf("real scripts/workcell not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckPublishPrShadowMounts(repoRoot); err != nil {
+		t.Fatalf("CheckPublishPrShadowMounts(real repo) = %v, want nil", err)
+	}
+}
+
 // TestExtractNamedFunctionBlock pins the sed-range extraction semantics
 // the run_host_colima check depends on: the block runs from the `NAME()`
 // opening line through the first line beginning with `}` (inclusive), and

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3229,25 +3229,7 @@ if ! go_function_block_contains_fixed "${ROOT_DIR}/internal/publishpr/publish_pr
   exit 1
 fi
 
-if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "publish_pr_main" 'core.hooksPath=/dev/null'; then
-  echo "Expected publish_pr_main to disable repo hooks for host-side publish git commands" >&2
-  exit 1
-fi
-
-if ! function_block_contains_regex "${ROOT_DIR}/scripts/workcell" "publish_pr_main" '--no-verify'; then
-  echo "Expected publish_pr_main to bypass repo hooks explicitly on host-side commit and push" >&2
-  exit 1
-fi
-
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "add_shadow_git_hooks_mount" "copy_tree_without_symlinks"; then
-  echo "Expected add_shadow_git_hooks_mount to avoid copying symlinked hook content into the readonly shadow" >&2
-  exit 1
-fi
-
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "add_shadow_git_config_mount" "! -L \"\${source_path}\""; then
-  echo "Expected add_shadow_git_config_mount to ignore symlinked git config files" >&2
-  exit 1
-fi
+go_verify_citools workcell-publish-pr-shadow "${ROOT_DIR}" || exit 1
 
 if ! grep -Fq "find \"\${workspace}\" -type d -name .git -prune -print0" "${ROOT_DIR}/scripts/workcell"; then
   echo "Expected prepare_workspace_control_plane_shadow to enumerate only real .git directories" >&2


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 9 of N.** Follows #398-#405. Migrates the 4 publish-pr / shadow-mount function-block invariant checks (publish_pr_main disables repo hooks via `core.hooksPath=/dev/null` + `--no-verify`; the shadow hook/config mounts avoid copying/following symlinks).

## What
- **`internal/workcellhardening`**: new `CheckPublishPrShadowMounts(rootDir)` — 2 `kindFunctionBlockRegex` + 2 `kindFunctionBlock` checks scoped to `publish_pr_main`, `add_shadow_git_hooks_mount`, `add_shadow_git_config_mount`. No new kinds.
- **`cmd/workcell-citools`**: new `workcell-publish-pr-shadow` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-publish-pr-shadow "${ROOT_DIR}" || exit 1`. Shell helpers retained (other checks use them).

## Parity (identical pass/fail)
`core.hooksPath=/dev/null` kept as a genuine regex (the `.` are any-char, matching `rg`/`grep`); the `add_shadow_git_config_mount` needle unescapes to the literal `! -L "${source_path}"`. Verified byte-identical against the reconstructed shell helpers: real repo → exit 0; 3 crafted violations → exit 1 identical messages; plus a cross-function scoping test + a real-repo assertion.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 215 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)