### PR TITLE
^R D3: migrate scripts/workcell shadow-enumeration + egress-ip6tables invariants to Go

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -103,6 +103,7 @@ func subcommands() []subcommand {
 		{"workcell-bootstrap-audit", "ROOT_DIR", 1, 1, cmdWorkcellBootstrapAudit},
 		{"workcell-git-index-shadow", "ROOT_DIR", 1, 1, cmdWorkcellGitIndexShadow},
 		{"workcell-publish-pr-shadow", "ROOT_DIR", 1, 1, cmdWorkcellPublishPrShadow},
+		{"workcell-shadow-enum-egress", "ROOT_DIR", 1, 1, cmdWorkcellShadowEnumEgress},
 	}
 }
 
@@ -571,4 +572,12 @@ func cmdWorkcellGitIndexShadow(args []string) error {
 // violated invariant.
 func cmdWorkcellPublishPrShadow(args []string) error {
 	return workcellhardening.CheckPublishPrShadowMounts(args[0])
+}
+
+// cmdWorkcellShadowEnumEgress runs the seven scripts/workcell shadow-enumeration
+// / IPv6-egress checks migrated out of scripts/verify-invariants.sh; it fails
+// (exit 1 via die()) with the shell's original stderr message for the first
+// violated invariant.
+func cmdWorkcellShadowEnumEgress(args []string) error {
+	return workcellhardening.CheckShadowEnumEgress(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -72,6 +72,13 @@ const launcherRelPath = "scripts/workcell"
 // check leaves check.targetFile empty and so defaults to launcherRelPath.
 const dockerfileRelPath = "runtime/container/Dockerfile"
 
+// colimaEgressAllowlistRelPath is the repo-relative path to the Colima
+// egress-allowlist helper.  Only the two shadow-enum-egress IPv6 invariants
+// read this file instead of scripts/workcell (via the per-check targetFile
+// field), mirroring the two shell `rg` probes that ran against
+// ${ROOT_DIR}/scripts/colima-egress-allowlist.sh.
+const colimaEgressAllowlistRelPath = "scripts/colima-egress-allowlist.sh"
+
 // checkKind selects how a check's pattern is matched against the launcher
 // contents.
 type checkKind int
@@ -854,6 +861,91 @@ var publishPrShadowMountChecks = []check{
 // violated invariant (the shell's exit 1).
 func CheckPublishPrShadowMounts(rootDir string) error {
 	return evaluate(rootDir, publishPrShadowMountChecks)
+}
+
+// shadowEnumEgressChecks lists the seven shadow-enumeration / IPv6-egress
+// invariants in the same order as the former inline block in
+// scripts/verify-invariants.sh (the block between the publish-PR /
+// shadow-mount group and the hostile-BASH_ENV runtime fixture), so a
+// reviewer can diff the two one-to-one.
+//
+// The first five are whole-file `grep -Fq` fixed-string containment probes
+// against scripts/workcell (the default target).  The last four of those
+// five came from a `for needle in ...; do grep -Fq -- "${needle}" ...; done`
+// loop whose stderr interpolated the needle into the message; because every
+// needle is a fixed single-quoted shell literal (backslashes and parens are
+// literal, matched by `grep -Fq`), each message is computed here verbatim as
+// "Expected prepare_workspace_control_plane_shadow to match snippet: " +
+// needle.
+//
+// The final two probes read scripts/colima-egress-allowlist.sh (via
+// targetFile), mirroring the two shell `rg` probes that ran against that
+// helper: the disable_ipv6=1 probe is NEGATED (present is a violation →
+// kindAbsent) and the ip6tables-support message probe is affirmative
+// (kindPresent).  Both rg patterns are metacharacter-free, so they reduce to
+// fixed-string containment.
+var shadowEnumEgressChecks = []check{
+	{
+		// kindPresent: the shell's `grep -Fq "find \"\${workspace}\" -type d
+		// -name .git -prune -print0"` is fixed-string containment of the
+		// literal .git enumeration.
+		kind:    kindPresent,
+		pattern: `find "${workspace}" -type d -name .git -prune -print0`,
+		message: "Expected prepare_workspace_control_plane_shadow to enumerate only real .git directories",
+	},
+	{
+		// Needle 1 of the former loop: the single-quoted shell literal
+		// `find "${workspace}/${git_rel}/modules" \` (trailing backslash is a
+		// literal character matched by grep -Fq).
+		kind:    kindPresent,
+		pattern: `find "${workspace}/${git_rel}/modules" \`,
+		message: `Expected prepare_workspace_control_plane_shadow to match snippet: find "${workspace}/${git_rel}/modules" \`,
+	},
+	{
+		// Needle 2 of the former loop.
+		kind:    kindPresent,
+		pattern: `-type l \) -name hooks`,
+		message: `Expected prepare_workspace_control_plane_shadow to match snippet: -type l \) -name hooks`,
+	},
+	{
+		// Needle 3 of the former loop.
+		kind:    kindPresent,
+		pattern: `-type l \) \( -name config -o -name config.worktree \)`,
+		message: `Expected prepare_workspace_control_plane_shadow to match snippet: -type l \) \( -name config -o -name config.worktree \)`,
+	},
+	{
+		// Needle 4 of the former loop.
+		kind:    kindPresent,
+		pattern: `-type l \) -name worktrees`,
+		message: `Expected prepare_workspace_control_plane_shadow to match snippet: -type l \) -name worktrees`,
+	},
+	{
+		// kindAbsent against scripts/colima-egress-allowlist.sh: silently
+		// disabling IPv6 as an allowlist-enforcement fallback is a violation
+		// (present → exit 1).
+		kind:       kindAbsent,
+		pattern:    "disable_ipv6=1",
+		message:    "Workcell should not silently disable IPv6 as a fallback for allowlist enforcement",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	{
+		// kindPresent against scripts/colima-egress-allowlist.sh: the helper
+		// must fail closed when dual-stack allowlist enforcement is
+		// unavailable.
+		kind:       kindPresent,
+		pattern:    "requires ip6tables support to enforce dual-stack allowlist egress policy",
+		message:    "Expected allowlist egress helper to fail closed when dual-stack allowlist enforcement is unavailable",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+}
+
+// CheckShadowEnumEgress runs the seven shadow-enumeration / IPv6-egress
+// invariants against the repo rooted at rootDir, in the shell's original
+// order.  It returns nil when every invariant holds (the shell's exit 0), or
+// an error whose message equals the shell's stderr for the first violated
+// invariant (the shell's exit 1).
+func CheckShadowEnumEgress(rootDir string) error {
+	return evaluate(rootDir, shadowEnumEgressChecks)
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -1174,6 +1174,185 @@ func TestCheckPublishPrShadowMountsRealRepo(t *testing.T) {
 	}
 }
 
+// shadowEnumEgressHappyLauncher is a minimal scripts/workcell that satisfies
+// the five launcher-scoped shadow-enumeration invariants: the whole-file .git
+// enumeration and all four submodule find-snippet needles.  Individual
+// negative cases mutate one property of this baseline.  The needles are
+// reproduced here byte-for-byte from scripts/workcell so a mis-transcription
+// is caught by both the negative cases and TestCheckShadowEnumEgressRealRepo.
+const shadowEnumEgressHappyLauncher = `#!/bin/bash
+set -euo pipefail
+
+prepare_workspace_control_plane_shadow() {
+  find "${workspace}" -type d -name .git -prune -print0
+  find "${workspace}/${git_rel}/modules" \
+    \( -type f -o -type l \) -name hooks \
+    -o \( -type f -o -type l \) \( -name config -o -name config.worktree \) \
+    -o \( -type f -o -type l \) -name worktrees
+}
+`
+
+// shadowEnumEgressHappyColima is a minimal scripts/colima-egress-allowlist.sh
+// that satisfies the two IPv6-egress invariants: it does not silently disable
+// IPv6 and it emits the ip6tables fail-closed message.  Individual negative
+// cases mutate one property of this baseline.
+const shadowEnumEgressHappyColima = `#!/bin/bash
+set -euo pipefail
+
+enforce_allowlist() {
+  if ! have_ip6tables; then
+    echo "requires ip6tables support to enforce dual-stack allowlist egress policy" >&2
+    return 1
+  fi
+}
+`
+
+// writeShadowEnumEgressRepo materializes a fake repo with scripts/workcell set
+// to launcher and scripts/colima-egress-allowlist.sh set to colima; a body of
+// "" means "do not create that file" (unreadable-target case).
+func writeShadowEnumEgressRepo(t *testing.T, launcher, colima string) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, body string) {
+		if body == "" {
+			return
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(launcherRelPath, launcher)
+	write(colimaEgressAllowlistRelPath, colima)
+	return root
+}
+
+func TestCheckShadowEnumEgress(t *testing.T) {
+	tests := []struct {
+		name     string
+		launcher string
+		colima   string
+		wantErr  string // "" means expect success
+	}{
+		{
+			name:     "happy path all invariants hold",
+			launcher: shadowEnumEgressHappyLauncher,
+			colima:   shadowEnumEgressHappyColima,
+		},
+		{
+			// kindPresent: the whole-file .git enumeration removed.
+			name:     "missing git enumeration",
+			launcher: strings.Replace(shadowEnumEgressHappyLauncher, `find "${workspace}" -type d -name .git -prune -print0`, `find "${workspace}" -print0`, 1),
+			colima:   shadowEnumEgressHappyColima,
+			wantErr:  "Expected prepare_workspace_control_plane_shadow to enumerate only real .git directories",
+		},
+		{
+			// kindPresent (needle 1): the modules find snippet removed.  The
+			// wantErr proves the dynamic loop message text is preserved verbatim.
+			name:     "missing modules find needle",
+			launcher: strings.Replace(shadowEnumEgressHappyLauncher, `find "${workspace}/${git_rel}/modules" \`, `find "${workspace}/other" \`, 1),
+			colima:   shadowEnumEgressHappyColima,
+			wantErr:  `Expected prepare_workspace_control_plane_shadow to match snippet: find "${workspace}/${git_rel}/modules" \`,
+		},
+		{
+			// kindPresent (needle 2): the hooks find snippet removed.
+			name:     "missing hooks needle",
+			launcher: strings.Replace(shadowEnumEgressHappyLauncher, `-type l \) -name hooks`, `-type l \) -name other`, 1),
+			colima:   shadowEnumEgressHappyColima,
+			wantErr:  `Expected prepare_workspace_control_plane_shadow to match snippet: -type l \) -name hooks`,
+		},
+		{
+			// kindPresent (needle 3): the config/config.worktree find snippet
+			// removed.
+			name:     "missing config needle",
+			launcher: strings.Replace(shadowEnumEgressHappyLauncher, `-type l \) \( -name config -o -name config.worktree \)`, `-type l \) \( -name other \)`, 1),
+			colima:   shadowEnumEgressHappyColima,
+			wantErr:  `Expected prepare_workspace_control_plane_shadow to match snippet: -type l \) \( -name config -o -name config.worktree \)`,
+		},
+		{
+			// kindPresent (needle 4): the worktrees find snippet removed.
+			name:     "missing worktrees needle",
+			launcher: strings.Replace(shadowEnumEgressHappyLauncher, `-type l \) -name worktrees`, `-type l \) -name other`, 1),
+			colima:   shadowEnumEgressHappyColima,
+			wantErr:  `Expected prepare_workspace_control_plane_shadow to match snippet: -type l \) -name worktrees`,
+		},
+		{
+			// kindAbsent against the colima helper: silently disabling IPv6 as a
+			// fallback is a violation (present → exit 1).
+			name:     "disable_ipv6 fallback present",
+			launcher: shadowEnumEgressHappyLauncher,
+			colima:   shadowEnumEgressHappyColima + "\ndisable_ipv6=1\n",
+			wantErr:  "Workcell should not silently disable IPv6 as a fallback for allowlist enforcement",
+		},
+		{
+			// kindPresent against the colima helper: the ip6tables fail-closed
+			// message removed.
+			name:     "missing ip6tables fail-closed message",
+			launcher: shadowEnumEgressHappyLauncher,
+			colima:   strings.Replace(shadowEnumEgressHappyColima, "requires ip6tables support to enforce dual-stack allowlist egress policy", "requires something else", 1),
+			wantErr:  "Expected allowlist egress helper to fail closed when dual-stack allowlist enforcement is unavailable",
+		},
+		{
+			// A missing launcher is empty content: the four whole-file needles
+			// (and the .git enumeration) fail, so the first affirmative check
+			// fires, mirroring `grep -Fq` returning non-zero on a missing file.
+			name:     "missing launcher",
+			launcher: "",
+			colima:   shadowEnumEgressHappyColima,
+			wantErr:  "Expected prepare_workspace_control_plane_shadow to enumerate only real .git directories",
+		},
+		{
+			// A missing colima helper is empty content: the launcher-scoped
+			// checks pass, the kindAbsent disable_ipv6 probe passes, but the
+			// affirmative ip6tables message probe fails, mirroring `rg -q`
+			// returning non-zero on a missing file.  Exercises the per-check
+			// target-file read against a distinct absent file.
+			name:     "missing colima helper",
+			launcher: shadowEnumEgressHappyLauncher,
+			colima:   "",
+			wantErr:  "Expected allowlist egress helper to fail closed when dual-stack allowlist enforcement is unavailable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeShadowEnumEgressRepo(t, tc.launcher, tc.colima)
+			err := CheckShadowEnumEgress(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckShadowEnumEgress() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckShadowEnumEgress() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckShadowEnumEgress() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckShadowEnumEgressRealRepo asserts that the real scripts/workcell and
+// scripts/colima-egress-allowlist.sh in this repository satisfy all seven
+// shadow-enumeration / IPv6-egress invariants.  This is the key guard against a
+// mis-transcribed find-snippet needle or colima-helper path: if any Go pattern
+// is not a byte-exact substring of the actual file, this test fails with the
+// guard's stderr message.
+func TestCheckShadowEnumEgressRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, launcherRelPath)); err != nil {
+		t.Skipf("real scripts/workcell not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckShadowEnumEgress(repoRoot); err != nil {
+		t.Fatalf("CheckShadowEnumEgress(real repo) = %v, want nil", err)
+	}
+}
+
 // TestExtractNamedFunctionBlock pins the sed-range extraction semantics
 // the run_host_colima check depends on: the block runs from the `NAME()`
 // opening line through the first line beginning with `}` (inclusive), and

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3231,31 +3231,7 @@ fi
 
 go_verify_citools workcell-publish-pr-shadow "${ROOT_DIR}" || exit 1
 
-if ! grep -Fq "find \"\${workspace}\" -type d -name .git -prune -print0" "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected prepare_workspace_control_plane_shadow to enumerate only real .git directories" >&2
-  exit 1
-fi
-# shellcheck disable=SC1003,SC2016
-for needle in \
-  'find "${workspace}/${git_rel}/modules" \' \
-  '-type l \) -name hooks' \
-  '-type l \) \( -name config -o -name config.worktree \)' \
-  '-type l \) -name worktrees'; do
-  if ! grep -Fq -- "${needle}" "${ROOT_DIR}/scripts/workcell"; then
-    echo "Expected prepare_workspace_control_plane_shadow to match snippet: ${needle}" >&2
-    exit 1
-  fi
-done
-
-if rg -q 'disable_ipv6=1' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Workcell should not silently disable IPv6 as a fallback for allowlist enforcement" >&2
-  exit 1
-fi
-
-if ! rg -q 'requires ip6tables support to enforce dual-stack allowlist egress policy' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Expected allowlist egress helper to fail closed when dual-stack allowlist enforcement is unavailable" >&2
-  exit 1
-fi
+go_verify_citools workcell-shadow-enum-egress "${ROOT_DIR}" || exit 1
 
 HOST_BASH_ENV_PAYLOAD="${BARRIER_VERIFY_ROOT}/bashenv.sh"
 HOST_BASH_ENV_MARKER="${BARRIER_VERIFY_ROOT}/bashenv-ran"


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 10 of N.** Follows #398-#406. Migrates 7 checks: the real-`.git`-only shadow enumeration guard, the 4-snippet `prepare_workspace_control_plane_shadow` needle loop, and 2 `colima-egress-allowlist.sh` egress checks (no silent IPv6 disable; fail-closed on missing dual-stack ip6tables).

## What
- **`internal/workcellhardening`**: new `CheckShadowEnumEgress(rootDir)` reusing `evaluate()` + `kindPresent`/`kindAbsent` + the `targetFile` field (no new kinds). The 4 loop needles become 4 `kindPresent` checks each with its computed `... match snippet: <needle>` message (needles copied byte-exact, backslashes/parens literal); the 2 colima checks use `targetFile: "scripts/colima-egress-allowlist.sh"` (one `kindAbsent` for `disable_ipv6=1`).
- **`cmd/workcell-citools`**: new `workcell-shadow-enum-egress` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-shadow-enum-egress "${ROOT_DIR}" || exit 1`. (Stopped before the following `BASH_ENV` runtime integration test — not migrated.)

## Parity (identical pass/fail)
Real repo → exit 0 (proves all 5 launcher needles + the colima path are byte-exact). Crafted violations — a broken loop needle (confirming the dynamic message text), `disable_ipv6=1` present, broken `.git` enumeration, missing ip6tables message — → exit 1 byte-identical. Plus a real-repo assertion test.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 306 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)