### PR TITLE
^R D3: migrate home-seeding + provider-wrapper env-scrub invariants to Go (57 checks)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -104,6 +104,7 @@ func subcommands() []subcommand {
 		{"workcell-git-index-shadow", "ROOT_DIR", 1, 1, cmdWorkcellGitIndexShadow},
 		{"workcell-publish-pr-shadow", "ROOT_DIR", 1, 1, cmdWorkcellPublishPrShadow},
 		{"workcell-shadow-enum-egress", "ROOT_DIR", 1, 1, cmdWorkcellShadowEnumEgress},
+		{"workcell-home-seed-provider-wrapper", "ROOT_DIR", 1, 1, cmdWorkcellHomeSeedProviderWrapper},
 	}
 }
 
@@ -580,4 +581,12 @@ func cmdWorkcellPublishPrShadow(args []string) error {
 // violated invariant.
 func cmdWorkcellShadowEnumEgress(args []string) error {
 	return workcellhardening.CheckShadowEnumEgress(args[0])
+}
+
+// cmdWorkcellHomeSeedProviderWrapper runs the fifty-seven home-seeding /
+// provider-wrapper env-scrub checks migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the shell's
+// original stderr message for the first violated invariant.
+func cmdWorkcellHomeSeedProviderWrapper(args []string) error {
+	return workcellhardening.CheckHomeSeedProviderWrapper(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -79,6 +79,25 @@ const dockerfileRelPath = "runtime/container/Dockerfile"
 // ${ROOT_DIR}/scripts/colima-egress-allowlist.sh.
 const colimaEgressAllowlistRelPath = "scripts/colima-egress-allowlist.sh"
 
+// homeControlPlaneRelPath is the repo-relative path to the runtime home
+// control-plane seeding script.  The home-seed/provider-wrapper block reads
+// this file (via the per-check targetFile field) for its Gemini/Claude home
+// seeding invariants, mirroring the shell probes that ran against
+// ${ROOT_DIR}/runtime/container/home-control-plane.sh.
+const homeControlPlaneRelPath = "runtime/container/home-control-plane.sh"
+
+// providerWrapperRelPath is the repo-relative path to the runtime provider
+// wrapper.  The home-seed/provider-wrapper block reads this file for its
+// env-scrub invariants, mirroring the shell probes that ran against
+// ${ROOT_DIR}/runtime/container/provider-wrapper.sh.
+const providerWrapperRelPath = "runtime/container/provider-wrapper.sh"
+
+// developmentWrapperRelPath is the repo-relative path to the runtime
+// development wrapper.  Only the copilot_env scrub loop reads this file (as
+// the loop's second wrapper), mirroring the shell probes that ran against
+// ${ROOT_DIR}/runtime/container/development-wrapper.sh.
+const developmentWrapperRelPath = "runtime/container/development-wrapper.sh"
+
 // checkKind selects how a check's pattern is matched against the launcher
 // contents.
 type checkKind int
@@ -946,6 +965,147 @@ var shadowEnumEgressChecks = []check{
 // invariant (the shell's exit 1).
 func CheckShadowEnumEgress(rootDir string) error {
 	return evaluate(rootDir, shadowEnumEgressChecks)
+}
+
+// copilotAmbientEnvKnobs lists the twenty-four Copilot/GitHub ambient env
+// variables that the shell's `for copilot_env in ...` loop asserted each
+// runtime wrapper scrubs.  Order matches the shell verbatim so the generated
+// checks reproduce the shell's first-failure stderr exactly.
+var copilotAmbientEnvKnobs = []string{
+	"unset GH_CONFIG_DIR",
+	"unset GH_HOST",
+	"unset GH_TOKEN",
+	"unset GITHUB_TOKEN",
+	"unset OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT",
+	"unset PLAIN_DIFF",
+	"unset USE_BUILTIN_RIPGREP",
+	"unset OTEL_EXPORTER_OTLP_ENDPOINT",
+	"unset OTEL_EXPORTER_OTLP_HEADERS",
+	"unset OTEL_EXPORTER_OTLP_PROTOCOL",
+	"unset OTEL_EXPORTER_OTLP_TIMEOUT",
+	"unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+	"unset OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+	"unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+	"unset OTEL_EXPORTER_OTLP_TRACES_TIMEOUT",
+	"unset OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+	"unset OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+	"unset OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+	"unset OTEL_EXPORTER_OTLP_METRICS_TIMEOUT",
+	"unset OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+	"unset OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+	"unset OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+	"unset OTEL_EXPORTER_OTLP_LOGS_TIMEOUT",
+	"unset OTEL_RESOURCE_ATTRIBUTES",
+}
+
+// homeSeedProviderWrapperChecks returns the fifty-seven home-seeding /
+// provider-wrapper env-scrub invariants in the same order as the former
+// inline block in scripts/verify-invariants.sh (the block between the
+// Gemini-auth-selection harness cleanup and the Copilot-prefix-scrub `for`
+// loop), so a reviewer can diff the two one-to-one.
+//
+// The nine leading probes are whole-file `grep -Fq` / `rg -q` checks:
+//   - The trustedFolders probe's shell `rg -q 'trustedFolders\.json'` escapes
+//     its only metacharacter (`\.`), so it reduces to fixed-string
+//     containment of the literal `trustedFolders.json` (kindPresent).
+//   - Five `grep -Fq` Gemini/Claude home-seeding probes and two affirmative
+//     `grep -Fq` provider-wrapper unset probes are fixed-string containment
+//     (kindPresent); their needles reproduce the shell double-quoted literals
+//     byte-exact (`\"`→`"`, `\$`→`$`, including the `|| true` suffix).
+//   - The `export HOME CODEX_HOME CLAUDE_CONFIG_DIR ...` probe is a NEGATED
+//     `grep -Fq` (present is a violation → kindAbsent).
+//
+// The forty-eight trailing checks migrate the shell's nested
+// `for copilot_env in ...; do for copilot_wrapper in ...; do
+// grep -Fq -- "${copilot_env}" "${copilot_wrapper}"; done; done` loop.  The
+// outer loop is the env knob (copilotAmbientEnvKnobs) and the inner loop is
+// the wrapper (provider-wrapper.sh then development-wrapper.sh), so the checks
+// are emitted knob-major to reproduce the shell's first-failure order.  Each
+// message interpolates basename(wrapper) and the knob exactly as the shell's
+// `echo "Expected $(basename "${copilot_wrapper}") to scrub Copilot/GitHub
+// ambient env knob: ${copilot_env}"` did; every knob is a fixed-string
+// `grep -Fq` needle (kindPresent) read from the per-check targetFile.
+func homeSeedProviderWrapperChecks() []check {
+	cs := []check{
+		{
+			// kindPresent: the shell's `rg -q 'trustedFolders\.json'` escapes
+			// its only metacharacter, so it is fixed-string containment.
+			kind:       kindPresent,
+			pattern:    "trustedFolders.json",
+			message:    "Expected Gemini home seeding to provision trustedFolders.json",
+			targetFile: homeControlPlaneRelPath,
+		},
+		{
+			kind:       kindPresent,
+			pattern:    `workcell_reset_session_target "${HOME}/.gemini/settings.json" "Gemini settings"`,
+			message:    "Expected Gemini home seeding to reset settings.json through workcell_reset_session_target",
+			targetFile: homeControlPlaneRelPath,
+		},
+		{
+			kind:       kindPresent,
+			pattern:    `workcell_set_gemini_tool_sandbox "${HOME}/.gemini/settings.json" false`,
+			message:    "Expected Gemini home seeding to pin the nested sandbox setting explicitly",
+			targetFile: homeControlPlaneRelPath,
+		},
+		{
+			kind:       kindPresent,
+			pattern:    `workcell_copy_manifest_credential_file claude_auth "${HOME}/.claude/.credentials.json" || true`,
+			message:    "Expected Claude home seeding to copy auth into .claude/.credentials.json",
+			targetFile: homeControlPlaneRelPath,
+		},
+		{
+			kind:       kindPresent,
+			pattern:    `workcell_copy_manifest_credential_file claude_auth "${HOME}/.claude/.claude.json" || true`,
+			message:    "Expected Claude home seeding to copy auth into .claude/.claude.json",
+			targetFile: homeControlPlaneRelPath,
+		},
+		{
+			kind:       kindPresent,
+			pattern:    `workcell_copy_manifest_credential_file claude_auth "${HOME}/.claude.json" || true`,
+			message:    "Expected Claude home seeding to copy auth into .claude.json",
+			targetFile: homeControlPlaneRelPath,
+		},
+		{
+			kind:       kindPresent,
+			pattern:    "unset CLAUDE_CONFIG_DIR",
+			message:    "Expected provider wrapper to discard caller-supplied CLAUDE_CONFIG_DIR",
+			targetFile: providerWrapperRelPath,
+		},
+		{
+			// kindAbsent: exporting CLAUDE_CONFIG_DIR for non-Claude launches is
+			// a violation (present → exit 1).
+			kind:       kindAbsent,
+			pattern:    "export HOME CODEX_HOME CLAUDE_CONFIG_DIR TMPDIR WORKCELL_MODE CODEX_PROFILE WORKCELL_AGENT_AUTONOMY WORKCELL_CONTAINER_MUTABILITY",
+			message:    "Provider wrapper should not export CLAUDE_CONFIG_DIR for non-Claude launches",
+			targetFile: providerWrapperRelPath,
+		},
+		{
+			kind:       kindPresent,
+			pattern:    "unset DISABLE_AUTOUPDATER",
+			message:    "Expected provider wrapper to discard caller-supplied DISABLE_AUTOUPDATER",
+			targetFile: providerWrapperRelPath,
+		},
+	}
+	for _, knob := range copilotAmbientEnvKnobs {
+		for _, rel := range []string{providerWrapperRelPath, developmentWrapperRelPath} {
+			cs = append(cs, check{
+				kind:       kindPresent,
+				pattern:    knob,
+				message:    "Expected " + filepath.Base(rel) + " to scrub Copilot/GitHub ambient env knob: " + knob,
+				targetFile: rel,
+			})
+		}
+	}
+	return cs
+}
+
+// CheckHomeSeedProviderWrapper runs the fifty-seven home-seeding /
+// provider-wrapper env-scrub invariants against the repo rooted at rootDir, in
+// the shell's original order.  It returns nil when every invariant holds (the
+// shell's exit 0), or an error whose message equals the shell's stderr for the
+// first violated invariant (the shell's exit 1).
+func CheckHomeSeedProviderWrapper(rootDir string) error {
+	return evaluate(rootDir, homeSeedProviderWrapperChecks())
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -1384,3 +1384,236 @@ func TestRegexMatchesAnyLineIsLineBounded(t *testing.T) {
 		t.Fatalf("a cross-newline R2 endpoint must NOT match (rg is line-oriented)")
 	}
 }
+
+// homeSeedHappyHomeControlPlane is a minimal runtime/container/home-control-plane.sh
+// that satisfies all six leading home-seeding invariants.
+const homeSeedHappyHomeControlPlane = `#!/usr/bin/env bash
+set -euo pipefail
+workcell_seed_gemini_home() {
+  : "${HOME}/.gemini/trustedFolders.json"
+  workcell_reset_session_target "${HOME}/.gemini/settings.json" "Gemini settings"
+  workcell_set_gemini_tool_sandbox "${HOME}/.gemini/settings.json" false
+}
+workcell_seed_claude_home() {
+  workcell_copy_manifest_credential_file claude_auth "${HOME}/.claude/.credentials.json" || true
+  workcell_copy_manifest_credential_file claude_auth "${HOME}/.claude/.claude.json" || true
+  workcell_copy_manifest_credential_file claude_auth "${HOME}/.claude.json" || true
+}
+`
+
+// homeSeedHappyProviderWrapper returns a minimal
+// runtime/container/provider-wrapper.sh satisfying the two affirmative unset
+// probes, the negated export probe (the export line is absent), and every
+// copilot_env knob.  The knobs come from the package var so the fixture cannot
+// drift out of sync with the checks.
+func homeSeedHappyProviderWrapper() string {
+	return "#!/usr/bin/env bash\nset -euo pipefail\nunset CLAUDE_CONFIG_DIR\nunset DISABLE_AUTOUPDATER\n" +
+		strings.Join(copilotAmbientEnvKnobs, "\n") + "\n"
+}
+
+// homeSeedHappyDevelopmentWrapper returns a minimal
+// runtime/container/development-wrapper.sh satisfying every copilot_env knob
+// (the only invariants that read this second wrapper).
+func homeSeedHappyDevelopmentWrapper() string {
+	return "#!/usr/bin/env bash\nset -euo pipefail\n" +
+		strings.Join(copilotAmbientEnvKnobs, "\n") + "\n"
+}
+
+// writeHomeSeedProviderWrapperRepo materializes a fake repo with the three
+// wrapper files set to the given bodies; a body of "" means "do not create
+// that file" (unreadable-target case).
+func writeHomeSeedProviderWrapperRepo(t *testing.T, home, provider, development string) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, body string) {
+		if body == "" {
+			return
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(homeControlPlaneRelPath, home)
+	write(providerWrapperRelPath, provider)
+	write(developmentWrapperRelPath, development)
+	return root
+}
+
+func TestCheckHomeSeedProviderWrapper(t *testing.T) {
+	firstKnob := copilotAmbientEnvKnobs[0]                            // unset GH_CONFIG_DIR
+	lastKnob := copilotAmbientEnvKnobs[len(copilotAmbientEnvKnobs)-1] // unset OTEL_RESOURCE_ATTRIBUTES
+	exportLine := "export HOME CODEX_HOME CLAUDE_CONFIG_DIR TMPDIR WORKCELL_MODE CODEX_PROFILE WORKCELL_AGENT_AUTONOMY WORKCELL_CONTAINER_MUTABILITY"
+
+	tests := []struct {
+		name        string
+		home        string
+		provider    string
+		development string
+		wantErr     string // "" means expect success
+	}{
+		{
+			name:        "happy path all invariants hold",
+			home:        homeSeedHappyHomeControlPlane,
+			provider:    homeSeedHappyProviderWrapper(),
+			development: homeSeedHappyDevelopmentWrapper(),
+		},
+		{
+			// kindPresent (home-control-plane): trustedFolders.json removed.
+			name:        "missing trustedFolders provisioning",
+			home:        strings.Replace(homeSeedHappyHomeControlPlane, "trustedFolders.json", "otherFolders.json", 1),
+			provider:    homeSeedHappyProviderWrapper(),
+			development: homeSeedHappyDevelopmentWrapper(),
+			wantErr:     "Expected Gemini home seeding to provision trustedFolders.json",
+		},
+		{
+			// kindPresent (home-control-plane): the settings reset needle removed.
+			name:        "missing settings reset",
+			home:        strings.Replace(homeSeedHappyHomeControlPlane, `workcell_reset_session_target "${HOME}/.gemini/settings.json" "Gemini settings"`, "true", 1),
+			provider:    homeSeedHappyProviderWrapper(),
+			development: homeSeedHappyDevelopmentWrapper(),
+			wantErr:     "Expected Gemini home seeding to reset settings.json through workcell_reset_session_target",
+		},
+		{
+			// kindPresent (home-control-plane): the .credentials.json copy removed.
+			name:        "missing claude credentials copy",
+			home:        strings.Replace(homeSeedHappyHomeControlPlane, `workcell_copy_manifest_credential_file claude_auth "${HOME}/.claude/.credentials.json" || true`, "true", 1),
+			provider:    homeSeedHappyProviderWrapper(),
+			development: homeSeedHappyDevelopmentWrapper(),
+			wantErr:     "Expected Claude home seeding to copy auth into .claude/.credentials.json",
+		},
+		{
+			// kindPresent (provider-wrapper): the CLAUDE_CONFIG_DIR scrub removed.
+			name:        "missing CLAUDE_CONFIG_DIR scrub",
+			home:        homeSeedHappyHomeControlPlane,
+			provider:    strings.Replace(homeSeedHappyProviderWrapper(), "unset CLAUDE_CONFIG_DIR", "true", 1),
+			development: homeSeedHappyDevelopmentWrapper(),
+			wantErr:     "Expected provider wrapper to discard caller-supplied CLAUDE_CONFIG_DIR",
+		},
+		{
+			// kindAbsent (provider-wrapper): exporting CLAUDE_CONFIG_DIR for
+			// non-Claude launches is a violation (present → exit 1).
+			name:        "forbidden CLAUDE_CONFIG_DIR export present",
+			home:        homeSeedHappyHomeControlPlane,
+			provider:    homeSeedHappyProviderWrapper() + exportLine + "\n",
+			development: homeSeedHappyDevelopmentWrapper(),
+			wantErr:     "Provider wrapper should not export CLAUDE_CONFIG_DIR for non-Claude launches",
+		},
+		{
+			// kindPresent (provider-wrapper): the DISABLE_AUTOUPDATER scrub removed.
+			name:        "missing DISABLE_AUTOUPDATER scrub",
+			home:        homeSeedHappyHomeControlPlane,
+			provider:    strings.Replace(homeSeedHappyProviderWrapper(), "unset DISABLE_AUTOUPDATER", "true", 1),
+			development: homeSeedHappyDevelopmentWrapper(),
+			wantErr:     "Expected provider wrapper to discard caller-supplied DISABLE_AUTOUPDATER",
+		},
+		{
+			// copilot_env loop, provider-wrapper side: the first knob removed from
+			// provider-wrapper.sh; the dynamic message names that wrapper + knob.
+			name:        "first knob missing from provider wrapper",
+			home:        homeSeedHappyHomeControlPlane,
+			provider:    strings.Replace(homeSeedHappyProviderWrapper(), firstKnob+"\n", "", 1),
+			development: homeSeedHappyDevelopmentWrapper(),
+			wantErr:     "Expected provider-wrapper.sh to scrub Copilot/GitHub ambient env knob: " + firstKnob,
+		},
+		{
+			// copilot_env loop, development-wrapper side: the first knob removed
+			// from development-wrapper.sh only; the provider probe for that knob
+			// passes first, then the development probe fails, proving the inner
+			// wrapper ordering (provider before development).
+			name:        "first knob missing from development wrapper",
+			home:        homeSeedHappyHomeControlPlane,
+			provider:    homeSeedHappyProviderWrapper(),
+			development: strings.Replace(homeSeedHappyDevelopmentWrapper(), firstKnob+"\n", "", 1),
+			wantErr:     "Expected development-wrapper.sh to scrub Copilot/GitHub ambient env knob: " + firstKnob,
+		},
+		{
+			// copilot_env loop: a trailing knob removed from provider-wrapper.sh,
+			// proving the loop covers the full list, not just the head.
+			name:        "last knob missing from provider wrapper",
+			home:        homeSeedHappyHomeControlPlane,
+			provider:    strings.Replace(homeSeedHappyProviderWrapper(), lastKnob+"\n", "", 1),
+			development: homeSeedHappyDevelopmentWrapper(),
+			wantErr:     "Expected provider-wrapper.sh to scrub Copilot/GitHub ambient env knob: " + lastKnob,
+		},
+		{
+			// A missing home-control-plane.sh is empty content: the first
+			// affirmative check (trustedFolders) fires, mirroring `rg -q`
+			// returning non-zero on a missing file.
+			name:        "missing home control plane",
+			home:        "",
+			provider:    homeSeedHappyProviderWrapper(),
+			development: homeSeedHappyDevelopmentWrapper(),
+			wantErr:     "Expected Gemini home seeding to provision trustedFolders.json",
+		},
+		{
+			// A missing provider-wrapper.sh is empty content: the six
+			// home-control-plane checks pass, then the first provider probe
+			// (CLAUDE_CONFIG_DIR scrub) fails.
+			name:        "missing provider wrapper",
+			home:        homeSeedHappyHomeControlPlane,
+			provider:    "",
+			development: homeSeedHappyDevelopmentWrapper(),
+			wantErr:     "Expected provider wrapper to discard caller-supplied CLAUDE_CONFIG_DIR",
+		},
+		{
+			// A missing development-wrapper.sh is empty content: every single
+			// probe and the provider side of the first knob pass, then the
+			// development side of the first knob fails.
+			name:        "missing development wrapper",
+			home:        homeSeedHappyHomeControlPlane,
+			provider:    homeSeedHappyProviderWrapper(),
+			development: "",
+			wantErr:     "Expected development-wrapper.sh to scrub Copilot/GitHub ambient env knob: " + firstKnob,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeHomeSeedProviderWrapperRepo(t, tc.home, tc.provider, tc.development)
+			err := CheckHomeSeedProviderWrapper(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckHomeSeedProviderWrapper() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckHomeSeedProviderWrapper() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckHomeSeedProviderWrapper() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckHomeSeedProviderWrapperCoversAllKnobs asserts the generated check
+// list contains exactly nine leading probes plus two checks per copilot_env
+// knob (one per wrapper), guarding against an accidentally truncated loop.
+func TestCheckHomeSeedProviderWrapperCoversAllKnobs(t *testing.T) {
+	got := len(homeSeedProviderWrapperChecks())
+	want := 9 + 2*len(copilotAmbientEnvKnobs)
+	if got != want {
+		t.Fatalf("homeSeedProviderWrapperChecks() has %d checks, want %d", got, want)
+	}
+}
+
+// TestCheckHomeSeedProviderWrapperRealRepo asserts that the real
+// home-control-plane.sh, provider-wrapper.sh, and development-wrapper.sh in
+// this repository satisfy all fifty-seven home-seeding / provider-wrapper
+// invariants.  This is the key guard against a mis-transcribed needle or a
+// mis-typed knob: if any Go pattern is not a byte-exact substring of the
+// actual file, this test fails with the guard's stderr message.
+func TestCheckHomeSeedProviderWrapperRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, homeControlPlaneRelPath)); err != nil {
+		t.Skipf("real home-control-plane.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckHomeSeedProviderWrapper(repoRoot); err != nil {
+		t.Fatalf("CheckHomeSeedProviderWrapper(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -8236,76 +8236,7 @@ GEMINI_AUTH_SELECTION_STDERR="$(mktemp)"
 rm -f "${GEMINI_AUTH_SELECTION_HARNESS}"
 rm -f "${GEMINI_AUTH_SELECTION_STDOUT}" "${GEMINI_AUTH_SELECTION_STDERR}"
 
-if ! rg -q 'trustedFolders\.json' "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
-  echo "Expected Gemini home seeding to provision trustedFolders.json" >&2
-  exit 1
-fi
-if ! grep -Fq "workcell_reset_session_target \"\${HOME}/.gemini/settings.json\" \"Gemini settings\"" "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
-  echo "Expected Gemini home seeding to reset settings.json through workcell_reset_session_target" >&2
-  exit 1
-fi
-if ! grep -Fq "workcell_set_gemini_tool_sandbox \"\${HOME}/.gemini/settings.json\" false" "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
-  echo "Expected Gemini home seeding to pin the nested sandbox setting explicitly" >&2
-  exit 1
-fi
-if ! grep -Fq "workcell_copy_manifest_credential_file claude_auth \"\${HOME}/.claude/.credentials.json\" || true" "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
-  echo "Expected Claude home seeding to copy auth into .claude/.credentials.json" >&2
-  exit 1
-fi
-if ! grep -Fq "workcell_copy_manifest_credential_file claude_auth \"\${HOME}/.claude/.claude.json\" || true" "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
-  echo "Expected Claude home seeding to copy auth into .claude/.claude.json" >&2
-  exit 1
-fi
-if ! grep -Fq "workcell_copy_manifest_credential_file claude_auth \"\${HOME}/.claude.json\" || true" "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
-  echo "Expected Claude home seeding to copy auth into .claude.json" >&2
-  exit 1
-fi
-if ! grep -Fq 'unset CLAUDE_CONFIG_DIR' "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Expected provider wrapper to discard caller-supplied CLAUDE_CONFIG_DIR" >&2
-  exit 1
-fi
-if grep -Fq 'export HOME CODEX_HOME CLAUDE_CONFIG_DIR TMPDIR WORKCELL_MODE CODEX_PROFILE WORKCELL_AGENT_AUTONOMY WORKCELL_CONTAINER_MUTABILITY' "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Provider wrapper should not export CLAUDE_CONFIG_DIR for non-Claude launches" >&2
-  exit 1
-fi
-if ! grep -Fq 'unset DISABLE_AUTOUPDATER' "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Expected provider wrapper to discard caller-supplied DISABLE_AUTOUPDATER" >&2
-  exit 1
-fi
-for copilot_env in \
-  'unset GH_CONFIG_DIR' \
-  'unset GH_HOST' \
-  'unset GH_TOKEN' \
-  'unset GITHUB_TOKEN' \
-  'unset OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT' \
-  'unset PLAIN_DIFF' \
-  'unset USE_BUILTIN_RIPGREP' \
-  'unset OTEL_EXPORTER_OTLP_ENDPOINT' \
-  'unset OTEL_EXPORTER_OTLP_HEADERS' \
-  'unset OTEL_EXPORTER_OTLP_PROTOCOL' \
-  'unset OTEL_EXPORTER_OTLP_TIMEOUT' \
-  'unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT' \
-  'unset OTEL_EXPORTER_OTLP_TRACES_HEADERS' \
-  'unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL' \
-  'unset OTEL_EXPORTER_OTLP_TRACES_TIMEOUT' \
-  'unset OTEL_EXPORTER_OTLP_METRICS_ENDPOINT' \
-  'unset OTEL_EXPORTER_OTLP_METRICS_HEADERS' \
-  'unset OTEL_EXPORTER_OTLP_METRICS_PROTOCOL' \
-  'unset OTEL_EXPORTER_OTLP_METRICS_TIMEOUT' \
-  'unset OTEL_EXPORTER_OTLP_LOGS_ENDPOINT' \
-  'unset OTEL_EXPORTER_OTLP_LOGS_HEADERS' \
-  'unset OTEL_EXPORTER_OTLP_LOGS_PROTOCOL' \
-  'unset OTEL_EXPORTER_OTLP_LOGS_TIMEOUT' \
-  'unset OTEL_RESOURCE_ATTRIBUTES'; do
-  for copilot_wrapper in \
-    "${ROOT_DIR}/runtime/container/provider-wrapper.sh" \
-    "${ROOT_DIR}/runtime/container/development-wrapper.sh"; do
-    if ! grep -Fq -- "${copilot_env}" "${copilot_wrapper}"; then
-      echo "Expected $(basename "${copilot_wrapper}") to scrub Copilot/GitHub ambient env knob: ${copilot_env}" >&2
-      exit 1
-    fi
-  done
-done
+go_verify_citools workcell-home-seed-provider-wrapper "${ROOT_DIR}" || exit 1
 for copilot_wrapper in \
   "${ROOT_DIR}/runtime/container/provider-wrapper.sh" \
   "${ROOT_DIR}/runtime/container/development-wrapper.sh"; do


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 11 of N (larger batch).** Follows #398-#407. Migrates 57 home-seeding / provider-wrapper env-scrub invariant checks (former lines 8239-8308), replacing a 70-line shell block with one Go call.

## What
- **`internal/workcellhardening`**: new `CheckHomeSeedProviderWrapper(rootDir)` reusing `evaluate()` + `kindPresent`/`kindAbsent` + the `targetFile` field (no new kinds). Covers:
  - **6** `runtime/container/home-control-plane.sh` — Gemini/Claude home seeding (`trustedFolders.json`, settings reset, tool-sandbox pin, 3 Claude credential copies).
  - **3** `runtime/container/provider-wrapper.sh` — `unset CLAUDE_CONFIG_DIR` (present), the forbidden `export ... CLAUDE_CONFIG_DIR ...` (`kindAbsent`), `unset DISABLE_AUTOUPDATER`.
  - **48** the `copilot_env` scrub loop = 24 env knobs × 2 wrappers (`provider-wrapper.sh` + `development-wrapper.sh`), emitted knob-major to preserve the shell's first-failure order; each message interpolates the wrapper basename + knob.
- **`cmd/workcell-citools`**: new `workcell-home-seed-provider-wrapper` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-home-seed-provider-wrapper "${ROOT_DIR}" || exit 1`. Stopped at the loop boundary (next `for copilot_wrapper` loop is a separate follow-up).

## Parity (identical pass/fail)
All 57 needles unescaped byte-exact and verified as substrings of the real files; real repo → exit 0 (proves needles + 3 file paths). Crafted violations across both files + both loop sides → exit 1 byte-identical messages. Real-repo assertion test guards transcription.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 473 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)