### PR TITLE
^R D3: migrate copilot prefix-scrub + token-handoff invariants to Go (29 checks)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -105,6 +105,7 @@ func subcommands() []subcommand {
 		{"workcell-publish-pr-shadow", "ROOT_DIR", 1, 1, cmdWorkcellPublishPrShadow},
 		{"workcell-shadow-enum-egress", "ROOT_DIR", 1, 1, cmdWorkcellShadowEnumEgress},
 		{"workcell-home-seed-provider-wrapper", "ROOT_DIR", 1, 1, cmdWorkcellHomeSeedProviderWrapper},
+		{"workcell-copilot-token-handoff", "ROOT_DIR", 1, 1, cmdWorkcellCopilotTokenHandoff},
 	}
 }
 
@@ -589,4 +590,12 @@ func cmdWorkcellShadowEnumEgress(args []string) error {
 // original stderr message for the first violated invariant.
 func cmdWorkcellHomeSeedProviderWrapper(args []string) error {
 	return workcellhardening.CheckHomeSeedProviderWrapper(args[0])
+}
+
+// cmdWorkcellCopilotTokenHandoff runs the twenty-nine Copilot prefix-scrub /
+// token-handoff checks migrated out of scripts/verify-invariants.sh; it fails
+// (exit 1 via die()) with the shell's original stderr message for the first
+// violated invariant.
+func cmdWorkcellCopilotTokenHandoff(args []string) error {
+	return workcellhardening.CheckCopilotTokenHandoff(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -98,6 +98,14 @@ const providerWrapperRelPath = "runtime/container/provider-wrapper.sh"
 // ${ROOT_DIR}/runtime/container/development-wrapper.sh.
 const developmentWrapperRelPath = "runtime/container/development-wrapper.sh"
 
+// containerSmokeRelPath is the repo-relative path to the container smoke
+// harness.  Only the Copilot-token-handoff leaf-permission guard reads this
+// file (via the per-check targetFile field) for its
+// stage_copilot_token_handoff_dir chmod probes, mirroring the shell
+// function_block_contains_fixed probes that ran against
+// ${ROOT_DIR}/scripts/container-smoke.sh.
+const containerSmokeRelPath = "scripts/container-smoke.sh"
+
 // checkKind selects how a check's pattern is matched against the launcher
 // contents.
 type checkKind int
@@ -1106,6 +1114,235 @@ func homeSeedProviderWrapperChecks() []check {
 // first violated invariant (the shell's exit 1).
 func CheckHomeSeedProviderWrapper(rootDir string) error {
 	return evaluate(rootDir, homeSeedProviderWrapperChecks())
+}
+
+// copilotTokenHandoffChecks returns the twenty-nine Copilot prefix-scrub /
+// token-handoff invariants in the same order as the former inline block in
+// scripts/verify-invariants.sh (the block between the
+// home-seed-provider-wrapper subcommand and the internal/host/hoststate
+// stale-cleanup guard), so a reviewer can diff the two one-to-one.
+//
+// The first eight checks migrate the shell's `for copilot_wrapper in
+// provider-wrapper.sh development-wrapper.sh; do ...; done` loop, which ran
+// four prefix-scrub probes per wrapper.  The shell looped wrapper-outer,
+// probe-inner, so the checks are emitted wrapper-major (provider's four
+// probes, then development's four) to reproduce the shell's first-failure
+// stderr exactly.  Two probes are affirmative (`if ! grep -Fq` → the prefix
+// scrub must be present → kindPresent); two are negated (`if grep -Fq` → a
+// duplicate OIDC/experiment loop present is a violation → kindAbsent).  Each
+// message interpolates basename(wrapper) exactly as the shell's
+// `$(basename "${copilot_wrapper}")` did.  Every needle is a double-quoted
+// shell literal whose only escape is `\$`→`$`, reproduced byte-exact.
+//
+// The two-file COPILOT_HOME guard was one shell `if grep -Fq NEEDLE
+// provider-wrapper.sh home-control-plane.sh; then ... exit 1` — a negated
+// probe across TWO files (present in EITHER is a violation).  It is expressed
+// here as two ordered kindAbsent checks (absent from provider-wrapper.sh,
+// then absent from home-control-plane.sh) sharing the one message, which is
+// behaviourally identical: either file containing the needle makes the
+// first-matching check fail with that shared stderr.
+//
+// The remaining guards mirror the shell exactly.  Each multi-probe `||`
+// guard (several `grep -Fq` / function_block_contains_fixed probes joined by
+// `||` under one message) becomes an ordered run of checks sharing that
+// message, which is behaviourally identical (any probe failing yields the
+// same stderr and exit 1).  Affirmative `if ! grep -Fq` probes are
+// kindPresent; affirmative `if ! function_block_contains_fixed` probes are
+// kindFunctionBlock (grep -Fq fixed-string containment inside the named
+// block); every needle is metacharacter-free after unescaping the shell
+// quoting (`\$`→`$`, `\"`→`"`), so each is fixed-string containment against
+// the per-check targetFile.
+func copilotTokenHandoffChecks() []check {
+	var cs []check
+	// Guard 1: the copilot_wrapper prefix-scrub loop (wrapper-outer,
+	// probe-inner).
+	for _, rel := range []string{providerWrapperRelPath, developmentWrapperRelPath} {
+		base := filepath.Base(rel)
+		cs = append(cs,
+			check{
+				kind:       kindPresent,
+				pattern:    "${!COPILOT_@}",
+				message:    "Expected " + base + " to scrub unknown future Copilot env variables by prefix",
+				targetFile: rel,
+			},
+			check{
+				kind:       kindPresent,
+				pattern:    "${!GITHUB_COPILOT_@}",
+				message:    "Expected " + base + " to scrub unknown future GitHub Copilot env variables by prefix",
+				targetFile: rel,
+			},
+			check{
+				// kindAbsent: a duplicate OIDC token loop present is a violation.
+				kind:       kindAbsent,
+				pattern:    "${!GITHUB_COPILOT_OIDC_MCP_TOKEN@}",
+				message:    base + " must rely on the GITHUB_COPILOT_ prefix scrub instead of a duplicate OIDC token loop",
+				targetFile: rel,
+			},
+			check{
+				// kindAbsent: a duplicate experiment loop present is a violation.
+				kind:       kindAbsent,
+				pattern:    "${!COPILOT_EXP_@}",
+				message:    base + " must rely on the COPILOT_ prefix scrub instead of a duplicate experiment loop",
+				targetFile: rel,
+			},
+		)
+	}
+	cs = append(cs, []check{
+		// Guard 2: the two-file COPILOT_HOME token-copy guard (negated grep
+		// across provider-wrapper.sh then home-control-plane.sh).
+		{
+			kind:       kindAbsent,
+			pattern:    "${COPILOT_HOME}/workcell-token",
+			message:    "Copilot auth token must not be copied into COPILOT_HOME",
+			targetFile: providerWrapperRelPath,
+		},
+		{
+			kind:       kindAbsent,
+			pattern:    "${COPILOT_HOME}/workcell-token",
+			message:    "Copilot auth token must not be copied into COPILOT_HOME",
+			targetFile: homeControlPlaneRelPath,
+		},
+		// Guard 3: launcher prepares the host-mounted token handoff.
+		{
+			kind:    kindPresent,
+			pattern: `prepare_copilot_token_handoff_mount "$@"`,
+			message: "Expected launcher to prepare a host-mounted Copilot token handoff before docker run",
+		},
+		// Guard 4: launcher removes the Copilot token direct mounts.
+		{
+			kind:    kindPresent,
+			pattern: `DIRECT_SOURCE_MOUNTS=("${filtered_mounts[@]}")`,
+			message: "Expected launcher to remove Copilot token direct mounts after host-side handoff preparation",
+		},
+		// Guard 5: host and runtime Copilot auth classifiers share the no-auth
+		// subcommand helper (five function-block probes across scripts/workcell
+		// and provider-wrapper.sh, sharing one message).
+		{
+			kind:         kindFunctionBlock,
+			functionName: "copilot_no_auth_invocation",
+			pattern:      `-h | --help | -v | --version | help | version | completion)`,
+			message:      "Expected host and runtime Copilot auth classifiers to share the no-auth subcommand helper",
+		},
+		{
+			kind:         kindFunctionBlock,
+			functionName: "copilot_no_auth_invocation",
+			pattern:      `-h | --help | -v | --version | help | version | completion)`,
+			message:      "Expected host and runtime Copilot auth classifiers to share the no-auth subcommand helper",
+			targetFile:   providerWrapperRelPath,
+		},
+		{
+			kind:         kindFunctionBlock,
+			functionName: "copilot_host_invocation_requires_auth",
+			pattern:      `if copilot_no_auth_invocation "$@"; then`,
+			message:      "Expected host and runtime Copilot auth classifiers to share the no-auth subcommand helper",
+		},
+		{
+			kind:         kindFunctionBlock,
+			functionName: "fail_fast_for_missing_copilot_auth",
+			pattern:      `if copilot_no_auth_invocation "$@"; then`,
+			message:      "Expected host and runtime Copilot auth classifiers to share the no-auth subcommand helper",
+		},
+		{
+			kind:         kindFunctionBlock,
+			functionName: "copilot_invocation_requires_auth",
+			pattern:      `if copilot_no_auth_invocation "$@"; then`,
+			message:      "Expected host and runtime Copilot auth classifiers to share the no-auth subcommand helper",
+			targetFile:   providerWrapperRelPath,
+		},
+		// Guard 6: token handoff directory lives in the dedicated writable
+		// Colima handoff root (two whole-file grep probes sharing one message).
+		{
+			kind:    kindPresent,
+			pattern: "workcell-token-handoff",
+			message: "Expected Copilot token handoff directory to live in the dedicated writable Colima handoff root",
+		},
+		{
+			kind:    kindPresent,
+			pattern: `COPILOT_TOKEN_HANDOFF_DIR="$(mktemp -d "${token_handoff_parent}/copilot-token-handoff.XXXXXX")"`,
+			message: "Expected Copilot token handoff directory to live in the dedicated writable Colima handoff root",
+		},
+		// Guard 7: token handoff writes re-check the guarded Colima handoff
+		// root at the write site (three function-block probes in
+		// prepare_copilot_token_handoff_mount sharing one message).
+		{
+			kind:         kindFunctionBlock,
+			functionName: "prepare_copilot_token_handoff_mount",
+			pattern:      `token_handoff_parent="$(default_copilot_token_handoff_parent)" || exit $?`,
+			message:      "Expected Copilot token handoff writes to re-check the guarded Colima handoff root at the write site",
+		},
+		{
+			kind:         kindFunctionBlock,
+			functionName: "prepare_copilot_token_handoff_mount",
+			pattern:      `chmod 0700 "${token_handoff_parent}"`,
+			message:      "Expected Copilot token handoff writes to re-check the guarded Colima handoff root at the write site",
+		},
+		{
+			kind:         kindFunctionBlock,
+			functionName: "prepare_copilot_token_handoff_mount",
+			pattern:      `reject_symlinked_colima_staging_cache_roots || exit $?`,
+			message:      "Expected Copilot token handoff writes to re-check the guarded Colima handoff root at the write site",
+		},
+		// Guard 8: token handoff leaf permissions support cap-dropped container
+		// root (four function-block probes: two in scripts/workcell's
+		// prepare_copilot_token_handoff_mount, two in container-smoke.sh's
+		// stage_copilot_token_handoff_dir, sharing one message).
+		{
+			kind:         kindFunctionBlock,
+			functionName: "prepare_copilot_token_handoff_mount",
+			pattern:      `chmod 0733 "${COPILOT_TOKEN_HANDOFF_DIR}"`,
+			message:      "Expected Copilot token handoff leaf permissions to support cap-dropped container root without exposing parent traversal",
+		},
+		{
+			kind:         kindFunctionBlock,
+			functionName: "prepare_copilot_token_handoff_mount",
+			pattern:      `chmod 0444 "${COPILOT_TOKEN_HANDOFF_FILE}"`,
+			message:      "Expected Copilot token handoff leaf permissions to support cap-dropped container root without exposing parent traversal",
+		},
+		{
+			kind:         kindFunctionBlock,
+			functionName: "stage_copilot_token_handoff_dir",
+			pattern:      `chmod 0733 "${token_handoff_dir}"`,
+			message:      "Expected Copilot token handoff leaf permissions to support cap-dropped container root without exposing parent traversal",
+			targetFile:   containerSmokeRelPath,
+		},
+		{
+			kind:         kindFunctionBlock,
+			functionName: "stage_copilot_token_handoff_dir",
+			pattern:      `chmod 0444 "${token_handoff_file}"`,
+			message:      "Expected Copilot token handoff leaf permissions to support cap-dropped container root without exposing parent traversal",
+			targetFile:   containerSmokeRelPath,
+		},
+		// Guard 9: detached launches wait for the wrapper-side consumed marker
+		// (two whole-file grep probes sharing one message).
+		{
+			kind:    kindPresent,
+			pattern: `COPILOT_TOKEN_HANDOFF_CONSUMED_FILE="${COPILOT_TOKEN_HANDOFF_DIR}/copilot-token-consumed"`,
+			message: "Expected detached Copilot launches to wait for the wrapper-side token consumed marker",
+		},
+		{
+			kind:    kindPresent,
+			pattern: `while [[ ! -e "${COPILOT_TOKEN_HANDOFF_CONSUMED_FILE}" ]]; do`,
+			message: "Expected detached Copilot launches to wait for the wrapper-side token consumed marker",
+		},
+		// Guard 10: token handoff removes the staged token copy from the mounted
+		// injection bundle (one function-block probe).
+		{
+			kind:         kindFunctionBlock,
+			functionName: "prepare_copilot_token_handoff_mount",
+			pattern:      `rm -f -- "${source_path}"`,
+			message:      "Expected Copilot token handoff to remove the staged token copy from the mounted injection bundle",
+		},
+	}...)
+	return cs
+}
+
+// CheckCopilotTokenHandoff runs the twenty-nine Copilot prefix-scrub /
+// token-handoff invariants against the repo rooted at rootDir, in the shell's
+// original order.  It returns nil when every invariant holds (the shell's exit
+// 0), or an error whose message equals the shell's stderr for the first
+// violated invariant (the shell's exit 1).
+func CheckCopilotTokenHandoff(rootDir string) error {
+	return evaluate(rootDir, copilotTokenHandoffChecks())
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -1617,3 +1617,335 @@ func TestCheckHomeSeedProviderWrapperRealRepo(t *testing.T) {
 		t.Fatalf("CheckHomeSeedProviderWrapper(real repo) = %v, want nil", err)
 	}
 }
+
+// copilotHandoffHappyLauncher is a minimal but structurally faithful
+// scripts/workcell satisfying every scripts/workcell-targeted Copilot
+// token-handoff invariant: the three no-auth classifier function blocks, the
+// prepare_copilot_token_handoff_mount write-site re-check + leaf-permission +
+// staged-copy-removal probes, the whole-file handoff-dir mktemp + token-handoff
+// marker probes, and the DIRECT_SOURCE_MOUNTS / prepare "$@" launcher wiring.
+const copilotHandoffHappyLauncher = `#!/usr/bin/env bash
+set -euo pipefail
+copilot_no_auth_invocation() {
+  case "$1" in
+  -h | --help | -v | --version | help | version | completion)
+    return 0 ;;
+  esac
+  return 1
+}
+copilot_host_invocation_requires_auth() {
+  if copilot_no_auth_invocation "$@"; then
+    return 1
+  fi
+}
+fail_fast_for_missing_copilot_auth() {
+  if copilot_no_auth_invocation "$@"; then
+    return 0
+  fi
+}
+prepare_copilot_token_handoff_mount() {
+  token_handoff_parent="$(default_copilot_token_handoff_parent)" || exit $?
+  chmod 0700 "${token_handoff_parent}"
+  reject_symlinked_colima_staging_cache_roots || exit $?
+  COPILOT_TOKEN_HANDOFF_DIR="$(mktemp -d "${token_handoff_parent}/copilot-token-handoff.XXXXXX")"
+  chmod 0733 "${COPILOT_TOKEN_HANDOFF_DIR}"
+  chmod 0444 "${COPILOT_TOKEN_HANDOFF_FILE}"
+  rm -f -- "${source_path}"
+}
+main() {
+  prepare_copilot_token_handoff_mount "$@"
+  DIRECT_SOURCE_MOUNTS=("${filtered_mounts[@]}")
+  : "workcell-token-handoff"
+  COPILOT_TOKEN_HANDOFF_CONSUMED_FILE="${COPILOT_TOKEN_HANDOFF_DIR}/copilot-token-consumed"
+  while [[ ! -e "${COPILOT_TOKEN_HANDOFF_CONSUMED_FILE}" ]]; do
+    sleep 1
+  done
+}
+`
+
+// copilotHandoffHappyProvider is a minimal runtime/container/provider-wrapper.sh
+// satisfying the four provider prefix-scrub probes (two present, two absent),
+// the negated COPILOT_HOME token-copy guard, and the two shared no-auth
+// classifier function blocks.
+const copilotHandoffHappyProvider = `#!/usr/bin/env bash
+set -euo pipefail
+unset "${!COPILOT_@}"
+unset "${!GITHUB_COPILOT_@}"
+copilot_no_auth_invocation() {
+  case "$1" in
+  -h | --help | -v | --version | help | version | completion)
+    return 0 ;;
+  esac
+  return 1
+}
+copilot_invocation_requires_auth() {
+  if copilot_no_auth_invocation "$@"; then
+    return 0
+  fi
+}
+`
+
+// copilotHandoffHappyDevelopment is a minimal
+// runtime/container/development-wrapper.sh satisfying the four development
+// prefix-scrub probes (the only invariants that read this second wrapper).
+const copilotHandoffHappyDevelopment = `#!/usr/bin/env bash
+set -euo pipefail
+unset "${!COPILOT_@}"
+unset "${!GITHUB_COPILOT_@}"
+`
+
+// copilotHandoffHappyHome is a minimal runtime/container/home-control-plane.sh
+// that satisfies the negated COPILOT_HOME token-copy guard (the needle is
+// absent).
+const copilotHandoffHappyHome = `#!/usr/bin/env bash
+set -euo pipefail
+: "home control plane"
+`
+
+// copilotHandoffHappySmoke is a minimal scripts/container-smoke.sh satisfying
+// the two stage_copilot_token_handoff_dir leaf-permission probes.
+const copilotHandoffHappySmoke = `#!/usr/bin/env bash
+set -euo pipefail
+stage_copilot_token_handoff_dir() {
+  chmod 0733 "${token_handoff_dir}"
+  chmod 0444 "${token_handoff_file}"
+}
+`
+
+// writeCopilotHandoffRepo materializes a fake repo with the five files this
+// group reads set to the given bodies; a body of "" means "do not create that
+// file" (unreadable-target case).
+func writeCopilotHandoffRepo(t *testing.T, launcher, provider, development, home, smoke string) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, body string) {
+		if body == "" {
+			return
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(launcherRelPath, launcher)
+	write(providerWrapperRelPath, provider)
+	write(developmentWrapperRelPath, development)
+	write(homeControlPlaneRelPath, home)
+	write(containerSmokeRelPath, smoke)
+	return root
+}
+
+func TestCheckCopilotTokenHandoff(t *testing.T) {
+	tests := []struct {
+		name        string
+		launcher    string
+		provider    string
+		development string
+		home        string
+		smoke       string
+		wantErr     string // "" means expect success
+	}{
+		{
+			name:        "happy path all invariants hold",
+			launcher:    copilotHandoffHappyLauncher,
+			provider:    copilotHandoffHappyProvider,
+			development: copilotHandoffHappyDevelopment,
+			home:        copilotHandoffHappyHome,
+			smoke:       copilotHandoffHappySmoke,
+		},
+		{
+			// Guard 1, provider probe A (kindPresent): the COPILOT_ prefix scrub
+			// removed from provider-wrapper.sh; message names that wrapper.
+			name:        "provider missing COPILOT prefix scrub",
+			launcher:    copilotHandoffHappyLauncher,
+			provider:    strings.Replace(copilotHandoffHappyProvider, `unset "${!COPILOT_@}"`, "true", 1),
+			development: copilotHandoffHappyDevelopment,
+			home:        copilotHandoffHappyHome,
+			smoke:       copilotHandoffHappySmoke,
+			wantErr:     "Expected provider-wrapper.sh to scrub unknown future Copilot env variables by prefix",
+		},
+		{
+			// Guard 1, provider probe C (kindAbsent): a duplicate OIDC token loop
+			// present in provider-wrapper.sh is a violation.
+			name:        "provider reintroduces duplicate OIDC loop",
+			launcher:    copilotHandoffHappyLauncher,
+			provider:    copilotHandoffHappyProvider + "unset \"${!GITHUB_COPILOT_OIDC_MCP_TOKEN@}\"\n",
+			development: copilotHandoffHappyDevelopment,
+			home:        copilotHandoffHappyHome,
+			smoke:       copilotHandoffHappySmoke,
+			wantErr:     "provider-wrapper.sh must rely on the GITHUB_COPILOT_ prefix scrub instead of a duplicate OIDC token loop",
+		},
+		{
+			// Guard 1, development side: the GitHub Copilot prefix scrub removed
+			// from development-wrapper.sh only; the four provider probes and the
+			// provider side of the loop pass first, proving wrapper-major ordering.
+			name:        "development missing GitHub Copilot prefix scrub",
+			launcher:    copilotHandoffHappyLauncher,
+			provider:    copilotHandoffHappyProvider,
+			development: strings.Replace(copilotHandoffHappyDevelopment, `unset "${!GITHUB_COPILOT_@}"`, "true", 1),
+			home:        copilotHandoffHappyHome,
+			smoke:       copilotHandoffHappySmoke,
+			wantErr:     "Expected development-wrapper.sh to scrub unknown future GitHub Copilot env variables by prefix",
+		},
+		{
+			// Guard 2, first file (provider-wrapper.sh): the token-copy needle
+			// present is a violation.
+			name:        "provider copies token into COPILOT_HOME",
+			launcher:    copilotHandoffHappyLauncher,
+			provider:    copilotHandoffHappyProvider + "cp token \"${COPILOT_HOME}/workcell-token\"\n",
+			development: copilotHandoffHappyDevelopment,
+			home:        copilotHandoffHappyHome,
+			smoke:       copilotHandoffHappySmoke,
+			wantErr:     "Copilot auth token must not be copied into COPILOT_HOME",
+		},
+		{
+			// Guard 2, second file (home-control-plane.sh): provider is clean, so
+			// the first Guard-2 check passes and the home-control-plane check fires,
+			// proving the two-file ordering (provider before home).
+			name:        "home control plane copies token into COPILOT_HOME",
+			launcher:    copilotHandoffHappyLauncher,
+			provider:    copilotHandoffHappyProvider,
+			development: copilotHandoffHappyDevelopment,
+			home:        copilotHandoffHappyHome + "cp token \"${COPILOT_HOME}/workcell-token\"\n",
+			smoke:       copilotHandoffHappySmoke,
+			wantErr:     "Copilot auth token must not be copied into COPILOT_HOME",
+		},
+		{
+			// Guard 3 (kindPresent, scripts/workcell): the prepare "$@" call removed.
+			name:        "launcher missing prepare token handoff call",
+			launcher:    strings.Replace(copilotHandoffHappyLauncher, `prepare_copilot_token_handoff_mount "$@"`, "true", 1),
+			provider:    copilotHandoffHappyProvider,
+			development: copilotHandoffHappyDevelopment,
+			home:        copilotHandoffHappyHome,
+			smoke:       copilotHandoffHappySmoke,
+			wantErr:     "Expected launcher to prepare a host-mounted Copilot token handoff before docker run",
+		},
+		{
+			// Guard 5, scripts/workcell function-block probe: the no-auth subcommand
+			// case removed from copilot_no_auth_invocation.
+			name:        "launcher no-auth classifier missing shared helper",
+			launcher:    strings.Replace(copilotHandoffHappyLauncher, `-h | --help | -v | --version | help | version | completion)`, `-h)`, 1),
+			provider:    copilotHandoffHappyProvider,
+			development: copilotHandoffHappyDevelopment,
+			home:        copilotHandoffHappyHome,
+			smoke:       copilotHandoffHappySmoke,
+			wantErr:     "Expected host and runtime Copilot auth classifiers to share the no-auth subcommand helper",
+		},
+		{
+			// Guard 5, provider-wrapper.sh function-block probe: the shared helper
+			// call removed from copilot_invocation_requires_auth.
+			name:        "provider auth classifier missing shared helper",
+			launcher:    copilotHandoffHappyLauncher,
+			provider:    strings.Replace(copilotHandoffHappyProvider, `if copilot_no_auth_invocation "$@"; then`, "if false; then", 1),
+			development: copilotHandoffHappyDevelopment,
+			home:        copilotHandoffHappyHome,
+			smoke:       copilotHandoffHappySmoke,
+			wantErr:     "Expected host and runtime Copilot auth classifiers to share the no-auth subcommand helper",
+		},
+		{
+			// Guard 7, prepare_copilot_token_handoff_mount function-block probe: the
+			// write-site symlink re-check removed.
+			name:        "launcher missing write-site staging re-check",
+			launcher:    strings.Replace(copilotHandoffHappyLauncher, "reject_symlinked_colima_staging_cache_roots || exit $?", "true", 1),
+			provider:    copilotHandoffHappyProvider,
+			development: copilotHandoffHappyDevelopment,
+			home:        copilotHandoffHappyHome,
+			smoke:       copilotHandoffHappySmoke,
+			wantErr:     "Expected Copilot token handoff writes to re-check the guarded Colima handoff root at the write site",
+		},
+		{
+			// Guard 8, container-smoke.sh function-block probe (a different target
+			// file): the leaf-file chmod removed from stage_copilot_token_handoff_dir.
+			name:        "container smoke missing token leaf permission",
+			launcher:    copilotHandoffHappyLauncher,
+			provider:    copilotHandoffHappyProvider,
+			development: copilotHandoffHappyDevelopment,
+			home:        copilotHandoffHappyHome,
+			smoke:       strings.Replace(copilotHandoffHappySmoke, `chmod 0444 "${token_handoff_file}"`, "true", 1),
+			wantErr:     "Expected Copilot token handoff leaf permissions to support cap-dropped container root without exposing parent traversal",
+		},
+		{
+			// Guard 9 (kindPresent, scripts/workcell): the consumed-marker wait loop
+			// removed.
+			name:        "launcher missing consumed marker wait",
+			launcher:    strings.Replace(copilotHandoffHappyLauncher, `while [[ ! -e "${COPILOT_TOKEN_HANDOFF_CONSUMED_FILE}" ]]; do`, "while false; do", 1),
+			provider:    copilotHandoffHappyProvider,
+			development: copilotHandoffHappyDevelopment,
+			home:        copilotHandoffHappyHome,
+			smoke:       copilotHandoffHappySmoke,
+			wantErr:     "Expected detached Copilot launches to wait for the wrapper-side token consumed marker",
+		},
+		{
+			// Guard 10, prepare_copilot_token_handoff_mount function-block probe: the
+			// staged-copy removal removed.
+			name:        "launcher missing staged token copy removal",
+			launcher:    strings.Replace(copilotHandoffHappyLauncher, `rm -f -- "${source_path}"`, "true", 1),
+			provider:    copilotHandoffHappyProvider,
+			development: copilotHandoffHappyDevelopment,
+			home:        copilotHandoffHappyHome,
+			smoke:       copilotHandoffHappySmoke,
+			wantErr:     "Expected Copilot token handoff to remove the staged token copy from the mounted injection bundle",
+		},
+		{
+			// A missing scripts/workcell is empty content: Guard 1 (wrappers) and
+			// Guard 2 pass, then Guard 3 (the first scripts/workcell probe) fails.
+			name:        "missing launcher",
+			launcher:    "",
+			provider:    copilotHandoffHappyProvider,
+			development: copilotHandoffHappyDevelopment,
+			home:        copilotHandoffHappyHome,
+			smoke:       copilotHandoffHappySmoke,
+			wantErr:     "Expected launcher to prepare a host-mounted Copilot token handoff before docker run",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeCopilotHandoffRepo(t, tc.launcher, tc.provider, tc.development, tc.home, tc.smoke)
+			err := CheckCopilotTokenHandoff(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckCopilotTokenHandoff() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckCopilotTokenHandoff() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckCopilotTokenHandoff() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckCopilotTokenHandoffCount asserts the generated check list contains
+// exactly twenty-nine invariants (eight prefix-scrub loop checks + twenty-one
+// remaining probes), guarding against an accidentally truncated loop or block.
+func TestCheckCopilotTokenHandoffCount(t *testing.T) {
+	got := len(copilotTokenHandoffChecks())
+	const want = 29
+	if got != want {
+		t.Fatalf("copilotTokenHandoffChecks() has %d checks, want %d", got, want)
+	}
+}
+
+// TestCheckCopilotTokenHandoffRealRepo asserts that the real scripts/workcell,
+// provider-wrapper.sh, development-wrapper.sh, home-control-plane.sh, and
+// container-smoke.sh in this repository satisfy all twenty-nine Copilot
+// token-handoff invariants.  This is the key guard against a mis-transcribed
+// needle or target file: if any Go pattern is not a byte-exact substring of the
+// actual file (or the wrong file), this test fails with the guard's stderr
+// message.
+func TestCheckCopilotTokenHandoffRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, launcherRelPath)); err != nil {
+		t.Skipf("real scripts/workcell not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckCopilotTokenHandoff(repoRoot); err != nil {
+		t.Fatalf("CheckCopilotTokenHandoff(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -8237,77 +8237,7 @@ rm -f "${GEMINI_AUTH_SELECTION_HARNESS}"
 rm -f "${GEMINI_AUTH_SELECTION_STDOUT}" "${GEMINI_AUTH_SELECTION_STDERR}"
 
 go_verify_citools workcell-home-seed-provider-wrapper "${ROOT_DIR}" || exit 1
-for copilot_wrapper in \
-  "${ROOT_DIR}/runtime/container/provider-wrapper.sh" \
-  "${ROOT_DIR}/runtime/container/development-wrapper.sh"; do
-  if ! grep -Fq "\${!COPILOT_@}" "${copilot_wrapper}"; then
-    echo "Expected $(basename "${copilot_wrapper}") to scrub unknown future Copilot env variables by prefix" >&2
-    exit 1
-  fi
-  if ! grep -Fq "\${!GITHUB_COPILOT_@}" "${copilot_wrapper}"; then
-    echo "Expected $(basename "${copilot_wrapper}") to scrub unknown future GitHub Copilot env variables by prefix" >&2
-    exit 1
-  fi
-  if grep -Fq "\${!GITHUB_COPILOT_OIDC_MCP_TOKEN@}" "${copilot_wrapper}"; then
-    echo "$(basename "${copilot_wrapper}") must rely on the GITHUB_COPILOT_ prefix scrub instead of a duplicate OIDC token loop" >&2
-    exit 1
-  fi
-  if grep -Fq "\${!COPILOT_EXP_@}" "${copilot_wrapper}"; then
-    echo "$(basename "${copilot_wrapper}") must rely on the COPILOT_ prefix scrub instead of a duplicate experiment loop" >&2
-    exit 1
-  fi
-done
-if grep -Fq "\${COPILOT_HOME}/workcell-token" "${ROOT_DIR}/runtime/container/provider-wrapper.sh" "${ROOT_DIR}/runtime/container/home-control-plane.sh"; then
-  echo "Copilot auth token must not be copied into COPILOT_HOME" >&2
-  exit 1
-fi
-if ! grep -Fq 'prepare_copilot_token_handoff_mount "$@"' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected launcher to prepare a host-mounted Copilot token handoff before docker run" >&2
-  exit 1
-fi
-if ! grep -Fq "DIRECT_SOURCE_MOUNTS=(\"\${filtered_mounts[@]}\")" "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected launcher to remove Copilot token direct mounts after host-side handoff preparation" >&2
-  exit 1
-fi
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "copilot_no_auth_invocation" '-h | --help | -v | --version | help | version | completion)' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/runtime/container/provider-wrapper.sh" "copilot_no_auth_invocation" '-h | --help | -v | --version | help | version | completion)' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "copilot_host_invocation_requires_auth" 'if copilot_no_auth_invocation "$@"; then' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "fail_fast_for_missing_copilot_auth" 'if copilot_no_auth_invocation "$@"; then' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/runtime/container/provider-wrapper.sh" "copilot_invocation_requires_auth" 'if copilot_no_auth_invocation "$@"; then'; then
-  echo "Expected host and runtime Copilot auth classifiers to share the no-auth subcommand helper" >&2
-  exit 1
-fi
-# shellcheck disable=SC2016
-if ! grep -Fq 'workcell-token-handoff' "${ROOT_DIR}/scripts/workcell" ||
-  ! grep -Fq 'COPILOT_TOKEN_HANDOFF_DIR="$(mktemp -d "${token_handoff_parent}/copilot-token-handoff.XXXXXX")"' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected Copilot token handoff directory to live in the dedicated writable Colima handoff root" >&2
-  exit 1
-fi
-# shellcheck disable=SC2016
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "prepare_copilot_token_handoff_mount" 'token_handoff_parent="$(default_copilot_token_handoff_parent)" || exit $?' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "prepare_copilot_token_handoff_mount" 'chmod 0700 "${token_handoff_parent}"' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "prepare_copilot_token_handoff_mount" 'reject_symlinked_colima_staging_cache_roots || exit $?'; then
-  echo "Expected Copilot token handoff writes to re-check the guarded Colima handoff root at the write site" >&2
-  exit 1
-fi
-# shellcheck disable=SC2016
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "prepare_copilot_token_handoff_mount" 'chmod 0733 "${COPILOT_TOKEN_HANDOFF_DIR}"' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "prepare_copilot_token_handoff_mount" 'chmod 0444 "${COPILOT_TOKEN_HANDOFF_FILE}"' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/container-smoke.sh" "stage_copilot_token_handoff_dir" 'chmod 0733 "${token_handoff_dir}"' ||
-  ! function_block_contains_fixed "${ROOT_DIR}/scripts/container-smoke.sh" "stage_copilot_token_handoff_dir" 'chmod 0444 "${token_handoff_file}"'; then
-  echo "Expected Copilot token handoff leaf permissions to support cap-dropped container root without exposing parent traversal" >&2
-  exit 1
-fi
-# shellcheck disable=SC2016
-if ! grep -Fq 'COPILOT_TOKEN_HANDOFF_CONSUMED_FILE="${COPILOT_TOKEN_HANDOFF_DIR}/copilot-token-consumed"' "${ROOT_DIR}/scripts/workcell" ||
-  ! grep -Fq 'while [[ ! -e "${COPILOT_TOKEN_HANDOFF_CONSUMED_FILE}" ]]; do' "${ROOT_DIR}/scripts/workcell"; then
-  echo "Expected detached Copilot launches to wait for the wrapper-side token consumed marker" >&2
-  exit 1
-fi
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "prepare_copilot_token_handoff_mount" "rm -f -- \"\${source_path}\""; then
-  echo "Expected Copilot token handoff to remove the staged token copy from the mounted injection bundle" >&2
-  exit 1
-fi
+go_verify_citools workcell-copilot-token-handoff "${ROOT_DIR}" || exit 1
 if ! grep -Fq 'copilotStandaloneTokenHandoffName' "${ROOT_DIR}/internal/host/hoststate/hoststate.go" ||
   ! grep -Fq 'copilotTokenHandoffBundleName' "${ROOT_DIR}/internal/host/hoststate/hoststate.go" ||
   ! grep -Fq 'removeCopilotTokenHandoffArtifacts' "${ROOT_DIR}/internal/host/hoststate/hoststate.go"; then


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 12 of N (larger batch).** Follows #398-#408. Migrates 29 copilot prefix-scrub + token-handoff invariant checks (former lines 8240-8310), replacing a 71-line shell block.

## What
- **`internal/workcellhardening`**: new `CheckCopilotTokenHandoff(rootDir)` reusing `evaluate()` + existing kinds + `targetFile` (no new kinds). 29 checks across `scripts/workcell` (×15), `provider-wrapper.sh` (×7), `development-wrapper.sh` (×4), `home-control-plane.sh` (×1), `container-smoke.sh` (×2).
- **`cmd/workcell-citools`**: new `workcell-copilot-token-handoff` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-copilot-token-handoff "${ROOT_DIR}" || exit 1`. Stopped at line 8310 (topical seam; next guard reads a Go source file).

## Wrinkles handled (parity)
- **copilot_wrapper loop**: 2 wrappers × 4 probes emitted wrapper-major to match the shell's first-failure order; probes A/B `kindPresent`, C/D (duplicate OIDC/EXP loops) `kindAbsent`; `basename` interpolated into each message.
- **Two-file grep** (token must not reach `COPILOT_HOME`): two ordered `kindAbsent` checks over the two files sharing the one message.
- **Multi-probe `||` guards**: ordered checks sharing each guard's message, spanning different files via per-check `targetFile` (incl. `function_block_contains_fixed` → `kindFunctionBlock`).

All needles unescaped byte-exact and verified as substrings of their real files; real repo → exit 0. Crafted violations across every category → exit 1 byte-identical. Real-repo assertion + a count=29 guard protect transcription.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...` (table-driven, 12 failing fixtures + real-repo assertion), `shellcheck -x`, `shfmt -d` — all green. 4 files / 650 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)