### PR TITLE
^R D3: migrate copilot-policy provider-wrapper invariants to Go (22 checks)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -108,6 +108,7 @@ func subcommands() []subcommand {
 		{"workcell-copilot-token-handoff", "ROOT_DIR", 1, 1, cmdWorkcellCopilotTokenHandoff},
 		{"workcell-copilot-docker-run", "ROOT_DIR", 1, 1, cmdWorkcellCopilotDockerRun},
 		{"workcell-provider-launcher-authority", "ROOT_DIR", 1, 1, cmdWorkcellProviderLauncherAuthority},
+		{"workcell-copilot-policy-wrapper", "ROOT_DIR", 1, 1, cmdWorkcellCopilotPolicyWrapper},
 	}
 }
 
@@ -616,4 +617,12 @@ func cmdWorkcellCopilotDockerRun(args []string) error {
 // invariant.
 func cmdWorkcellProviderLauncherAuthority(args []string) error {
 	return workcellhardening.CheckProviderLauncherAuthority(args[0])
+}
+
+// cmdWorkcellCopilotPolicyWrapper runs the twenty-two Copilot-policy-wrapper
+// checks migrated out of scripts/verify-invariants.sh; it fails (exit 1 via
+// die()) with the shell's original stderr message for the first violated
+// invariant.
+func cmdWorkcellCopilotPolicyWrapper(args []string) error {
+	return workcellhardening.CheckCopilotPolicyWrapper(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -146,6 +146,13 @@ const runtimeUserRelPath = "runtime/container/runtime-user.sh"
 // ${ROOT_DIR}/runtime/container/rust/src/lib.rs.
 const rustLibRelPath = "runtime/container/rust/src/lib.rs"
 
+// providerPolicyRelPath is the repo-relative path to the runtime provider
+// policy helper.  The Copilot-policy-wrapper block reads this file (via the
+// per-check targetFile field) for its native-lifecycle-command and
+// prompt/short-option gating invariants, mirroring the shell probes that ran
+// against ${ROOT_DIR}/runtime/container/provider-policy.sh.
+const providerPolicyRelPath = "runtime/container/provider-policy.sh"
+
 // checkKind selects how a check's pattern is matched against the launcher
 // contents.
 type checkKind int
@@ -1809,6 +1816,205 @@ func providerLauncherAuthorityChecks() []check {
 // shell's exit 1).
 func CheckProviderLauncherAuthority(rootDir string) error {
 	return evaluate(rootDir, providerLauncherAuthorityChecks())
+}
+
+// copilotPolicyWrapperChecks lists the twenty-two Copilot-policy-wrapper
+// invariants in the same order as the former inline block in
+// scripts/verify-invariants.sh (the block between the pinned-native-Claude-exec
+// `rm -f -- "${token_file}"` guard's successor `unset
+// WORKCELL_COPILOT_GITHUB_TOKEN` probe and the `for unsafe_copilot_flag` loop),
+// so a reviewer can diff the two one-to-one.
+//
+// The block reads three files via the per-check targetFile field: the runtime
+// provider wrapper (runtime/container/provider-wrapper.sh), the runtime provider
+// policy helper (runtime/container/provider-policy.sh), and the container smoke
+// harness (scripts/container-smoke.sh).  Every probe is a whole-file `grep -Fq`
+// fixed-string containment except one negated `grep -Eq` (kindRegexAbsent), so
+// each is kindPresent for the affirmative probes and kindAbsent for the two
+// negated fixed-string guards.
+//
+// The negated shell-tool grant guard is a genuine `grep -Eq` regular expression
+// (`--available-tools=[^"]*(shell|bash|run|exec)`), NOT a fixed string, so it is
+// kindRegexAbsent (a match is a violation → exit 1).
+//
+// Two former shell `if` guards each joined two `grep -Fq` probes with `||` under
+// a single message; they are expressed here as ordered checks sharing that
+// message, which is behaviourally identical (the first failing probe yields the
+// same stderr and exit 1 as the shell `if`):
+//   - the all-tools/all-paths guard, whose two probes are BOTH negated (either
+//     `--allow-all-tools` or `--allow-all-paths` present is a violation),
+//     matched here as two ordered kindAbsent checks sharing one message.  The
+//     shell short-circuits `grep A || grep B` to A-then-B, which the ordered
+//     checks reproduce.
+//
+// Two former shell `if ! grep A || ! grep B || ...` guards each joined multiple
+// affirmative probes across provider-policy.sh and container-smoke.sh under a
+// single message; they are expressed here as ordered kindPresent checks sharing
+// that message (the attached-prompt guard's four probes and the bundled
+// short-option guard's three probes), which is behaviourally identical (the
+// first missing probe yields the same stderr and exit 1).
+//
+// The double-quoted shell needles reproduce their literals byte-exact after
+// unescaping (`\"`→`"`, `\$`→`$`, `\\`→ a single trailing `\`), so the pinned
+// Copilot exec line keeps its trailing backslash and the `${arg}` /
+// `${copilot_github_token}` needles keep their literal parameter-expansion text.
+var copilotPolicyWrapperChecks = []check{
+	{
+		kind:       kindPresent,
+		pattern:    "unset WORKCELL_COPILOT_GITHUB_TOKEN",
+		message:    "Expected provider wrapper to discard the host-side Copilot token handoff variable before exec",
+		targetFile: providerWrapperRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    "unset WORKCELL_COPILOT_TOKEN_FILE",
+		message:    "Expected provider wrapper to discard the Copilot token handoff path before exec",
+		targetFile: providerWrapperRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    `COPILOT_GITHUB_TOKEN="${copilot_github_token}"`,
+		message:    "Expected provider wrapper to expose Copilot auth only as COPILOT_GITHUB_TOKEN to the managed child",
+		targetFile: providerWrapperRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    "COPILOT_ENABLE_HTTP2=false",
+		message:    "Expected provider wrapper to pin Copilot HTTP/2 off on the managed path",
+		targetFile: providerWrapperRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    "--secret-env-vars=GH_TOKEN,GITHUB_TOKEN,COPILOT_GITHUB_TOKEN",
+		message:    "Expected provider wrapper to declare Copilot/GitHub token env as provider secrets",
+		targetFile: providerWrapperRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    "--disallow-temp-dir",
+		message:    "Expected provider wrapper to deny Copilot temp-dir access on the managed path",
+		targetFile: providerWrapperRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    `"--available-tools=view,create,edit,apply_patch,grep,glob"`,
+		message:    "Expected provider wrapper to keep Copilot prompt/yolo tool grants shell-free",
+		targetFile: providerWrapperRelPath,
+	},
+	{
+		// kindRegexAbsent: the shell's `grep -Eq --
+		// '--available-tools=[^"]*(shell|bash|run|exec)'` is a genuine ERE, not
+		// a fixed string, so it must NOT match (present is a violation → exit 1).
+		kind:       kindRegexAbsent,
+		pattern:    `--available-tools=[^"]*(shell|bash|run|exec)`,
+		message:    "Provider wrapper must not grant Copilot shell-like tools on the safe path",
+		targetFile: providerWrapperRelPath,
+	},
+	// All-tools/all-paths guard (first probe, NEGATED): shares the pair's message.
+	{
+		kind:       kindAbsent,
+		pattern:    "--allow-all-tools",
+		message:    "Provider wrapper must not grant Copilot all tools or all paths on the safe path",
+		targetFile: providerWrapperRelPath,
+	},
+	// All-tools/all-paths guard (second probe, NEGATED): shares the pair's message.
+	{
+		kind:       kindAbsent,
+		pattern:    "--allow-all-paths",
+		message:    "Provider wrapper must not grant Copilot all tools or all paths on the safe path",
+		targetFile: providerWrapperRelPath,
+	},
+	{
+		// Pinned native Copilot exec line (trailing backslash preserved).
+		kind:       kindPresent,
+		pattern:    `exec /usr/local/libexec/workcell/real/copilot \`,
+		message:    "Expected provider wrapper to launch the pinned native Copilot binary",
+		targetFile: providerWrapperRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    `Workcell blocked Claude lifecycle command: ${arg}`,
+		message:    "Expected provider policy to reject native Claude lifecycle commands that bypass the pinned image",
+		targetFile: providerPolicyRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    `Workcell blocked Copilot lifecycle/control-plane command: ${arg}`,
+		message:    "Expected provider policy to reject native Copilot lifecycle/control-plane commands",
+		targetFile: providerPolicyRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    "-p | --prompt)",
+		message:    "Expected provider policy to treat only Copilot -p/--prompt as value-taking prompt flags",
+		targetFile: providerPolicyRelPath,
+	},
+	// Attached-prompt guard (first probe): shares the group's message.
+	{
+		kind:       kindPresent,
+		pattern:    `attached_prompt_value="${arg:2}"`,
+		message:    "Expected provider policy and smoke coverage to reject attached dash-prefixed Copilot prompt values",
+		targetFile: providerPolicyRelPath,
+	},
+	// Attached-prompt guard (second probe): shares the group's message.
+	{
+		kind:       kindPresent,
+		pattern:    `attached_prompt_value="${arg#--prompt=}"`,
+		message:    "Expected provider policy and smoke coverage to reject attached dash-prefixed Copilot prompt values",
+		targetFile: providerPolicyRelPath,
+	},
+	// Attached-prompt guard (third probe, container-smoke.sh): shares the message.
+	{
+		kind:       kindPresent,
+		pattern:    "workcell-copilot-policy-attached-short-prompt-allow-tool.out",
+		message:    "Expected provider policy and smoke coverage to reject attached dash-prefixed Copilot prompt values",
+		targetFile: containerSmokeRelPath,
+	},
+	// Attached-prompt guard (fourth probe, container-smoke.sh): shares the message.
+	{
+		kind:       kindPresent,
+		pattern:    "workcell-copilot-policy-attached-long-prompt-allow-tool.out",
+		message:    "Expected provider policy and smoke coverage to reject attached dash-prefixed Copilot prompt values",
+		targetFile: containerSmokeRelPath,
+	},
+	// Bundled-short-option guard (first probe): shares the group's message.
+	{
+		kind:       kindPresent,
+		pattern:    "-[!-]?*)",
+		message:    "Expected provider policy and smoke coverage to reject bundled Copilot short options",
+		targetFile: providerPolicyRelPath,
+	},
+	// Bundled-short-option guard (second probe): shares the group's message.
+	{
+		kind:       kindPresent,
+		pattern:    `Workcell blocked bundled Copilot short options: ${arg}`,
+		message:    "Expected provider policy and smoke coverage to reject bundled Copilot short options",
+		targetFile: providerPolicyRelPath,
+	},
+	// Bundled-short-option guard (third probe, container-smoke.sh): shares the message.
+	{
+		kind:       kindPresent,
+		pattern:    "workcell-copilot-policy-bundled-short-options.out",
+		message:    "Expected provider policy and smoke coverage to reject bundled Copilot short options",
+		targetFile: containerSmokeRelPath,
+	},
+	{
+		// kindAbsent: the shell's `if grep -Fq -- '-p | --prompt | -i |
+		// --interactive)' ...; then ... exit 1` is a negated fixed-string guard
+		// (treating -i/--interactive as a prompt alias present is a violation).
+		kind:       kindAbsent,
+		pattern:    "-p | --prompt | -i | --interactive)",
+		message:    "Expected provider policy not to treat Copilot -i/--interactive as prompt aliases",
+		targetFile: providerPolicyRelPath,
+	},
+}
+
+// CheckCopilotPolicyWrapper runs the twenty-two Copilot-policy-wrapper invariants
+// against the repo rooted at rootDir, in the shell's original order.  It returns
+// nil when every invariant holds (the shell's exit 0), or an error whose message
+// equals the shell's stderr for the first violated invariant (the shell's exit 1).
+func CheckCopilotPolicyWrapper(rootDir string) error {
+	return evaluate(rootDir, copilotPolicyWrapperChecks)
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -2666,3 +2666,354 @@ func TestCheckProviderLauncherAuthorityRealRepo(t *testing.T) {
 		t.Fatalf("CheckProviderLauncherAuthority(real repo) = %v, want nil", err)
 	}
 }
+
+// copilotPolicyWrapperHappyProviderWrapper is a minimal but structurally
+// faithful runtime/container/provider-wrapper.sh: it contains every affirmative
+// provider-wrapper needle (the two token-handoff env scrubs, the managed
+// COPILOT_GITHUB_TOKEN export, the HTTP/2 pin, the secret-env/temp-dir/available
+// tools flags, and the pinned Copilot exec line with its trailing backslash) and
+// NEITHER the two negated fixed-string needles (no --allow-all-tools, no
+// --allow-all-paths) NOR any shell-like --available-tools grant (so the negated
+// grep -Eq guard also holds).
+const copilotPolicyWrapperHappyProviderWrapper = `#!/usr/bin/env bash
+set -euo pipefail
+unset WORKCELL_COPILOT_GITHUB_TOKEN
+unset WORKCELL_COPILOT_TOKEN_FILE
+COPILOT_GITHUB_TOKEN="${copilot_github_token}" \
+COPILOT_ENABLE_HTTP2=false \
+exec /usr/local/libexec/workcell/real/copilot \
+  --secret-env-vars=GH_TOKEN,GITHUB_TOKEN,COPILOT_GITHUB_TOKEN \
+  --disallow-temp-dir \
+  "--available-tools=view,create,edit,apply_patch,grep,glob"
+`
+
+// copilotPolicyWrapperHappyProviderPolicy is a minimal but structurally faithful
+// runtime/container/provider-policy.sh: it contains every affirmative policy
+// needle (the two blocked-lifecycle messages, the -p/--prompt case label, the two
+// attached-prompt value extractions, the bundled-short-option case label, and the
+// bundled-short-option blocked message) and NOT the -i/--interactive prompt-alias
+// case label.
+const copilotPolicyWrapperHappyProviderPolicy = `#!/usr/bin/env bash
+copilot_policy() {
+  case "${arg}" in
+  -p | --prompt)
+    attached_prompt_value="${arg:2}"
+    attached_prompt_value="${arg#--prompt=}"
+    ;;
+  -[!-]?*)
+    workcell_die "Workcell blocked bundled Copilot short options: ${arg}"
+    ;;
+  esac
+  workcell_die "Workcell blocked Claude lifecycle command: ${arg}"
+  workcell_die "Workcell blocked Copilot lifecycle/control-plane command: ${arg}"
+}
+`
+
+// copilotPolicyWrapperHappySmoke is a minimal but structurally faithful
+// scripts/container-smoke.sh: it contains the three container-smoke needles for
+// the attached-prompt and bundled-short-option guards.
+const copilotPolicyWrapperHappySmoke = `#!/usr/bin/env bash
+run_case workcell-copilot-policy-attached-short-prompt-allow-tool.out
+run_case workcell-copilot-policy-attached-long-prompt-allow-tool.out
+run_case workcell-copilot-policy-bundled-short-options.out
+`
+
+// writeCopilotPolicyWrapperRepo materializes a fake repo with the three files
+// this group reads set to the given bodies; a body of "" means "do not create
+// that file" (unreadable-target case).
+func writeCopilotPolicyWrapperRepo(t *testing.T, providerWrapper, providerPolicy, smoke string) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, body string) {
+		if body == "" {
+			return
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(providerWrapperRelPath, providerWrapper)
+	write(providerPolicyRelPath, providerPolicy)
+	write(containerSmokeRelPath, smoke)
+	return root
+}
+
+func TestCheckCopilotPolicyWrapper(t *testing.T) {
+	tests := []struct {
+		name            string
+		providerWrapper string
+		providerPolicy  string
+		smoke           string
+		wantErr         string // "" means expect success
+	}{
+		{
+			name:            "happy path all invariants hold",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           copilotPolicyWrapperHappySmoke,
+		},
+		{
+			// Check 1 (kindPresent, provider-wrapper.sh).
+			name:            "provider wrapper keeps host-side github token env",
+			providerWrapper: strings.Replace(copilotPolicyWrapperHappyProviderWrapper, "unset WORKCELL_COPILOT_GITHUB_TOKEN", "unset OTHER", 1),
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider wrapper to discard the host-side Copilot token handoff variable before exec",
+		},
+		{
+			// Check 2 (kindPresent, provider-wrapper.sh).
+			name:            "provider wrapper keeps token file path env",
+			providerWrapper: strings.Replace(copilotPolicyWrapperHappyProviderWrapper, "unset WORKCELL_COPILOT_TOKEN_FILE", "unset OTHER", 1),
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider wrapper to discard the Copilot token handoff path before exec",
+		},
+		{
+			// Check 3 (kindPresent, provider-wrapper.sh — escaped ${...} needle).
+			name:            "provider wrapper missing managed COPILOT_GITHUB_TOKEN export",
+			providerWrapper: strings.Replace(copilotPolicyWrapperHappyProviderWrapper, `COPILOT_GITHUB_TOKEN="${copilot_github_token}"`, `COPILOT_GITHUB_TOKEN="x"`, 1),
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider wrapper to expose Copilot auth only as COPILOT_GITHUB_TOKEN to the managed child",
+		},
+		{
+			// Check 4 (kindPresent, provider-wrapper.sh).
+			name:            "provider wrapper missing http2 pin",
+			providerWrapper: strings.Replace(copilotPolicyWrapperHappyProviderWrapper, "COPILOT_ENABLE_HTTP2=false", "COPILOT_ENABLE_HTTP2=true", 1),
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider wrapper to pin Copilot HTTP/2 off on the managed path",
+		},
+		{
+			// Check 5 (kindPresent, provider-wrapper.sh).
+			name:            "provider wrapper missing secret-env-vars",
+			providerWrapper: strings.Replace(copilotPolicyWrapperHappyProviderWrapper, "--secret-env-vars=GH_TOKEN,GITHUB_TOKEN,COPILOT_GITHUB_TOKEN", "--secret-env-vars=NONE", 1),
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider wrapper to declare Copilot/GitHub token env as provider secrets",
+		},
+		{
+			// Check 6 (kindPresent, provider-wrapper.sh).
+			name:            "provider wrapper missing disallow-temp-dir",
+			providerWrapper: strings.Replace(copilotPolicyWrapperHappyProviderWrapper, "--disallow-temp-dir", "--allow-temp-dir", 1),
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider wrapper to deny Copilot temp-dir access on the managed path",
+		},
+		{
+			// Check 7 (kindPresent, provider-wrapper.sh — quoted needle).
+			name:            "provider wrapper missing shell-free available-tools grant",
+			providerWrapper: strings.Replace(copilotPolicyWrapperHappyProviderWrapper, `"--available-tools=view,create,edit,apply_patch,grep,glob"`, `"--available-tools=view"`, 1),
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider wrapper to keep Copilot prompt/yolo tool grants shell-free",
+		},
+		{
+			// Check 8 (kindRegexAbsent, provider-wrapper.sh): an unquoted
+			// available-tools value granting a shell-like tool is a violation.
+			name:            "provider wrapper grants shell-like available tool",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper + "\n--available-tools=view,shell\n",
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Provider wrapper must not grant Copilot shell-like tools on the safe path",
+		},
+		{
+			// Check 9a (kindAbsent, provider-wrapper.sh — first probe of the
+			// all-tools/all-paths guard).
+			name:            "provider wrapper grants all tools",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper + "\n  --allow-all-tools\n",
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Provider wrapper must not grant Copilot all tools or all paths on the safe path",
+		},
+		{
+			// Check 9b (kindAbsent, provider-wrapper.sh — second probe): proves the
+			// two ordered probes share one message.
+			name:            "provider wrapper grants all paths",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper + "\n  --allow-all-paths\n",
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Provider wrapper must not grant Copilot all tools or all paths on the safe path",
+		},
+		{
+			// Check 10 (kindPresent, provider-wrapper.sh — trailing backslash):
+			// drop the trailing backslash so the fixed-string containment fails.
+			name:            "provider wrapper missing pinned copilot exec",
+			providerWrapper: strings.Replace(copilotPolicyWrapperHappyProviderWrapper, `real/copilot \`, `real/copilot`, 1),
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider wrapper to launch the pinned native Copilot binary",
+		},
+		{
+			// Check 11 (kindPresent, provider-policy.sh — ${arg} needle).
+			name:            "provider policy missing claude lifecycle block",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  strings.Replace(copilotPolicyWrapperHappyProviderPolicy, "Workcell blocked Claude lifecycle command: ${arg}", "blocked", 1),
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider policy to reject native Claude lifecycle commands that bypass the pinned image",
+		},
+		{
+			// Check 12 (kindPresent, provider-policy.sh).
+			name:            "provider policy missing copilot lifecycle block",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  strings.Replace(copilotPolicyWrapperHappyProviderPolicy, "Workcell blocked Copilot lifecycle/control-plane command: ${arg}", "blocked", 1),
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider policy to reject native Copilot lifecycle/control-plane commands",
+		},
+		{
+			// Check 13 (kindPresent, provider-policy.sh).
+			name:            "provider policy missing prompt case label",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  strings.Replace(copilotPolicyWrapperHappyProviderPolicy, "-p | --prompt)", "-x)", 1),
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider policy to treat only Copilot -p/--prompt as value-taking prompt flags",
+		},
+		{
+			// Check 14a (kindPresent, provider-policy.sh — first probe of the
+			// attached-prompt guard).
+			name:            "provider policy missing short attached-prompt extraction",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  strings.Replace(copilotPolicyWrapperHappyProviderPolicy, `attached_prompt_value="${arg:2}"`, `attached_prompt_value="x"`, 1),
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider policy and smoke coverage to reject attached dash-prefixed Copilot prompt values",
+		},
+		{
+			// Check 14b (kindPresent, provider-policy.sh — second probe).
+			name:            "provider policy missing long attached-prompt extraction",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  strings.Replace(copilotPolicyWrapperHappyProviderPolicy, `attached_prompt_value="${arg#--prompt=}"`, `attached_prompt_value="y"`, 1),
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider policy and smoke coverage to reject attached dash-prefixed Copilot prompt values",
+		},
+		{
+			// Check 14c (kindPresent, container-smoke.sh — third probe): proves the
+			// guard reads the smoke harness and shares one message.
+			name:            "smoke missing short attached-prompt coverage",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           strings.Replace(copilotPolicyWrapperHappySmoke, "workcell-copilot-policy-attached-short-prompt-allow-tool.out", "other.out", 1),
+			wantErr:         "Expected provider policy and smoke coverage to reject attached dash-prefixed Copilot prompt values",
+		},
+		{
+			// Check 14d (kindPresent, container-smoke.sh — fourth probe).
+			name:            "smoke missing long attached-prompt coverage",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           strings.Replace(copilotPolicyWrapperHappySmoke, "workcell-copilot-policy-attached-long-prompt-allow-tool.out", "other.out", 1),
+			wantErr:         "Expected provider policy and smoke coverage to reject attached dash-prefixed Copilot prompt values",
+		},
+		{
+			// Check 15a (kindPresent, provider-policy.sh — first probe of the
+			// bundled-short-option guard).
+			name:            "provider policy missing bundled short-option case label",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  strings.Replace(copilotPolicyWrapperHappyProviderPolicy, "-[!-]?*)", "-z)", 1),
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider policy and smoke coverage to reject bundled Copilot short options",
+		},
+		{
+			// Check 15b (kindPresent, provider-policy.sh — second probe).
+			name:            "provider policy missing bundled short-option block",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  strings.Replace(copilotPolicyWrapperHappyProviderPolicy, "Workcell blocked bundled Copilot short options: ${arg}", "blocked", 1),
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider policy and smoke coverage to reject bundled Copilot short options",
+		},
+		{
+			// Check 15c (kindPresent, container-smoke.sh — third probe).
+			name:            "smoke missing bundled short-option coverage",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           strings.Replace(copilotPolicyWrapperHappySmoke, "workcell-copilot-policy-bundled-short-options.out", "other.out", 1),
+			wantErr:         "Expected provider policy and smoke coverage to reject bundled Copilot short options",
+		},
+		{
+			// Check 16 (kindAbsent, provider-policy.sh): treating -i/--interactive
+			// as a prompt alias present is a violation.
+			name:            "provider policy treats interactive as prompt alias",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy + "\n  -p | --prompt | -i | --interactive)\n",
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider policy not to treat Copilot -i/--interactive as prompt aliases",
+		},
+		{
+			// A missing provider-wrapper.sh is empty content: the first affirmative
+			// provider-wrapper probe (the github-token env scrub) fails.
+			name:            "missing provider wrapper",
+			providerWrapper: "",
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider wrapper to discard the host-side Copilot token handoff variable before exec",
+		},
+		{
+			// A missing provider-policy.sh is empty content: the first policy probe
+			// (the Claude lifecycle block) fails after every provider-wrapper probe
+			// holds.
+			name:            "missing provider policy",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  "",
+			smoke:           copilotPolicyWrapperHappySmoke,
+			wantErr:         "Expected provider policy to reject native Claude lifecycle commands that bypass the pinned image",
+		},
+		{
+			// A missing container-smoke.sh is empty content: the first smoke probe
+			// (the attached short-prompt coverage) fails after the wrapper and the
+			// two policy attached-prompt probes hold.
+			name:            "missing container smoke",
+			providerWrapper: copilotPolicyWrapperHappyProviderWrapper,
+			providerPolicy:  copilotPolicyWrapperHappyProviderPolicy,
+			smoke:           "",
+			wantErr:         "Expected provider policy and smoke coverage to reject attached dash-prefixed Copilot prompt values",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeCopilotPolicyWrapperRepo(t, tc.providerWrapper, tc.providerPolicy, tc.smoke)
+			err := CheckCopilotPolicyWrapper(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckCopilotPolicyWrapper() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckCopilotPolicyWrapper() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckCopilotPolicyWrapper() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckCopilotPolicyWrapperCount asserts the check list contains exactly
+// twenty-two invariants, guarding against an accidentally truncated or
+// duplicated migration of the shell block.
+func TestCheckCopilotPolicyWrapperCount(t *testing.T) {
+	got := len(copilotPolicyWrapperChecks)
+	const want = 22
+	if got != want {
+		t.Fatalf("copilotPolicyWrapperChecks has %d checks, want %d", got, want)
+	}
+}
+
+// TestCheckCopilotPolicyWrapperRealRepo asserts that the real provider-wrapper.sh,
+// provider-policy.sh, and container-smoke.sh in this repository satisfy all
+// twenty-two Copilot-policy-wrapper invariants.  This is the key guard against a
+// mis-transcribed needle or a wrong target file: if any Go pattern is not a
+// byte-exact substring of the actual file (or the wrong file), this test fails
+// with the guard's stderr message.
+func TestCheckCopilotPolicyWrapperRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, providerWrapperRelPath)); err != nil {
+		t.Skipf("real provider-wrapper.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckCopilotPolicyWrapper(repoRoot); err != nil {
+		t.Fatalf("CheckCopilotPolicyWrapper(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -8250,76 +8250,7 @@ if ! grep -Fq "rm -f -- \"\${token_file}\"" "${ROOT_DIR}/runtime/container/provi
   echo "Expected provider wrapper to unlink the runtime Copilot token handoff file before managed exec" >&2
   exit 1
 fi
-if ! grep -Fq 'unset WORKCELL_COPILOT_GITHUB_TOKEN' "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Expected provider wrapper to discard the host-side Copilot token handoff variable before exec" >&2
-  exit 1
-fi
-if ! grep -Fq 'unset WORKCELL_COPILOT_TOKEN_FILE' "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Expected provider wrapper to discard the Copilot token handoff path before exec" >&2
-  exit 1
-fi
-if ! grep -Fq "COPILOT_GITHUB_TOKEN=\"\${copilot_github_token}\"" "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Expected provider wrapper to expose Copilot auth only as COPILOT_GITHUB_TOKEN to the managed child" >&2
-  exit 1
-fi
-if ! grep -Fq 'COPILOT_ENABLE_HTTP2=false' "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Expected provider wrapper to pin Copilot HTTP/2 off on the managed path" >&2
-  exit 1
-fi
-if ! grep -Fq -- '--secret-env-vars=GH_TOKEN,GITHUB_TOKEN,COPILOT_GITHUB_TOKEN' "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Expected provider wrapper to declare Copilot/GitHub token env as provider secrets" >&2
-  exit 1
-fi
-if ! grep -Fq -- '--disallow-temp-dir' "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Expected provider wrapper to deny Copilot temp-dir access on the managed path" >&2
-  exit 1
-fi
-if ! grep -Fq -- '"--available-tools=view,create,edit,apply_patch,grep,glob"' "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Expected provider wrapper to keep Copilot prompt/yolo tool grants shell-free" >&2
-  exit 1
-fi
-if grep -Eq -- '--available-tools=[^"]*(shell|bash|run|exec)' "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Provider wrapper must not grant Copilot shell-like tools on the safe path" >&2
-  exit 1
-fi
-if grep -Fq -- '--allow-all-tools' "${ROOT_DIR}/runtime/container/provider-wrapper.sh" ||
-  grep -Fq -- '--allow-all-paths' "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Provider wrapper must not grant Copilot all tools or all paths on the safe path" >&2
-  exit 1
-fi
-if ! grep -Fq "exec /usr/local/libexec/workcell/real/copilot \\" "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Expected provider wrapper to launch the pinned native Copilot binary" >&2
-  exit 1
-fi
-if ! grep -Fq "Workcell blocked Claude lifecycle command: \${arg}" "${ROOT_DIR}/runtime/container/provider-policy.sh"; then
-  echo "Expected provider policy to reject native Claude lifecycle commands that bypass the pinned image" >&2
-  exit 1
-fi
-if ! grep -Fq "Workcell blocked Copilot lifecycle/control-plane command: \${arg}" "${ROOT_DIR}/runtime/container/provider-policy.sh"; then
-  echo "Expected provider policy to reject native Copilot lifecycle/control-plane commands" >&2
-  exit 1
-fi
-if ! grep -Fq -- '-p | --prompt)' "${ROOT_DIR}/runtime/container/provider-policy.sh"; then
-  echo "Expected provider policy to treat only Copilot -p/--prompt as value-taking prompt flags" >&2
-  exit 1
-fi
-if ! grep -Fq "attached_prompt_value=\"\${arg:2}\"" "${ROOT_DIR}/runtime/container/provider-policy.sh" ||
-  ! grep -Fq "attached_prompt_value=\"\${arg#--prompt=}\"" "${ROOT_DIR}/runtime/container/provider-policy.sh" ||
-  ! grep -Fq 'workcell-copilot-policy-attached-short-prompt-allow-tool.out' "${ROOT_DIR}/scripts/container-smoke.sh" ||
-  ! grep -Fq 'workcell-copilot-policy-attached-long-prompt-allow-tool.out' "${ROOT_DIR}/scripts/container-smoke.sh"; then
-  echo "Expected provider policy and smoke coverage to reject attached dash-prefixed Copilot prompt values" >&2
-  exit 1
-fi
-if ! grep -Fq -- '-[!-]?*)' "${ROOT_DIR}/runtime/container/provider-policy.sh" ||
-  ! grep -Fq "Workcell blocked bundled Copilot short options: \${arg}" "${ROOT_DIR}/runtime/container/provider-policy.sh" ||
-  ! grep -Fq 'workcell-copilot-policy-bundled-short-options.out' "${ROOT_DIR}/scripts/container-smoke.sh"; then
-  echo "Expected provider policy and smoke coverage to reject bundled Copilot short options" >&2
-  exit 1
-fi
-if grep -Fq -- '-p | --prompt | -i | --interactive)' "${ROOT_DIR}/runtime/container/provider-policy.sh"; then
-  echo "Expected provider policy not to treat Copilot -i/--interactive as prompt aliases" >&2
-  exit 1
-fi
+go_verify_citools workcell-copilot-policy-wrapper "${ROOT_DIR}" || exit 1
 for unsafe_copilot_flag in \
   '--config-dir' \
   '--allow-tool' \


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 15 of N (larger batch).** Follows #398-#411. Migrates 22 copilot-policy invariant checks (former lines 8253-8322), replacing a 70-line shell block.

## What
- **`internal/workcellhardening`**: new `CheckCopilotPolicyWrapper(rootDir)` reusing `evaluate()` + existing kinds + `targetFile` (no new kinds). 22 checks across `provider-wrapper.sh` (×11), `provider-policy.sh` (×8), `container-smoke.sh` (×3). Kinds: 18 `kindPresent`, 3 `kindAbsent` (the `--allow-all-tools`/`--allow-all-paths` and `-p|--prompt|-i|--interactive` negated guards), 1 `kindRegexAbsent` (the `grep -Eq -- '--available-tools=[^"]*(shell|bash|run|exec)'` guard).
- **`cmd/workcell-citools`**: new `workcell-copilot-policy-wrapper` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-copilot-policy-wrapper "${ROOT_DIR}" || exit 1`. Stopped at 8322 (line 8323 begins the 16-item `unsafe_copilot_flag` loop — next increment).

## Parity (identical pass/fail)
Multi-probe `||` guards → ordered checks sharing one message; the `grep -Eq` guard as `kindRegexAbsent` (per-line). All 22 needles pre-verified byte-exact via `grep -Fq`. Real repo → exit 0; 6 crafted violations (negated guards, regex shell-tool guard, multi-probe smoke coverage, interactive-alias guard, a policy needle) → exit 1 byte-identical. Real-repo assertion guards transcription.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 637 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)