### PR TITLE
^R D3: migrate copilot unsafe-flag invariants to Go (31 checks, +present-in-any-file kind)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -109,6 +109,7 @@ func subcommands() []subcommand {
 		{"workcell-copilot-docker-run", "ROOT_DIR", 1, 1, cmdWorkcellCopilotDockerRun},
 		{"workcell-provider-launcher-authority", "ROOT_DIR", 1, 1, cmdWorkcellProviderLauncherAuthority},
 		{"workcell-copilot-policy-wrapper", "ROOT_DIR", 1, 1, cmdWorkcellCopilotPolicyWrapper},
+		{"workcell-copilot-unsafe-flags", "ROOT_DIR", 1, 1, cmdWorkcellCopilotUnsafeFlags},
 	}
 }
 
@@ -625,4 +626,11 @@ func cmdWorkcellProviderLauncherAuthority(args []string) error {
 // invariant.
 func cmdWorkcellCopilotPolicyWrapper(args []string) error {
 	return workcellhardening.CheckCopilotPolicyWrapper(args[0])
+}
+
+// cmdWorkcellCopilotUnsafeFlags runs the thirty-one Copilot-unsafe-flag checks
+// migrated out of scripts/verify-invariants.sh; it fails (exit 1 via die())
+// with the shell's original stderr message for the first violated invariant.
+func cmdWorkcellCopilotUnsafeFlags(args []string) error {
+	return workcellhardening.CheckCopilotUnsafeFlags(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -195,6 +195,14 @@ const (
 	// extracted block via regexMatchesAnyLine for `grep`/`rg` line-oriented
 	// parity.
 	kindFunctionBlockRegex
+	// kindPresentInAnyFile requires the fixed string to appear in AT LEAST ONE
+	// of the files listed in targetFiles, mirroring `grep -Fq -- NEEDLE f1 f2`
+	// under a negated `if !` guard: grep scans every file and, with -q, exits 0
+	// as soon as the needle is found in ANY of them, so `! grep` (the
+	// violation) fires only when the needle is absent from ALL listed files.
+	// Unlike kindPresent's single targetFile, evaluate ORs the per-file
+	// containment predicate (holds) across every path in targetFiles.
+	kindPresentInAnyFile
 )
 
 // check is one hardening invariant: how to match, what to match, which
@@ -213,6 +221,12 @@ type check struct {
 	// dockerfileRelPath), mirroring the shell probe that ran `rg` against
 	// ${ROOT_DIR}/runtime/container/Dockerfile instead of scripts/workcell.
 	targetFile string
+	// targetFiles lists the repo-relative files a kindPresentInAnyFile check
+	// reads.  It is used only by kindPresentInAnyFile (every other kind reads a
+	// single file via targetFile); evaluate ORs the containment predicate
+	// across these paths, mirroring the shell's multi-file
+	// `grep -Fq -- NEEDLE f1 f2`.
+	targetFiles []string
 }
 
 // checks lists the eleven invariants in the same order as the former
@@ -319,6 +333,22 @@ func evaluate(rootDir string, cs []check) error {
 	}
 
 	for _, c := range cs {
+		if c.kind == kindPresentInAnyFile {
+			// Mirror `grep -Fq -- NEEDLE f1 f2`: the check holds when the
+			// per-file containment predicate (holds) is true for ANY listed
+			// file, and is violated only when it is false for every file.
+			satisfied := false
+			for _, rel := range c.targetFiles {
+				if c.holds(readTarget(rel)) {
+					satisfied = true
+					break
+				}
+			}
+			if !satisfied {
+				return errors.New(c.message)
+			}
+			continue
+		}
 		rel := c.targetFile
 		if rel == "" {
 			rel = launcherRelPath
@@ -2017,6 +2047,186 @@ func CheckCopilotPolicyWrapper(rootDir string) error {
 	return evaluate(rootDir, copilotPolicyWrapperChecks)
 }
 
+// copilotUnsafeLongFlags lists the sixteen fixed Copilot flags the shell's
+// `for unsafe_copilot_flag in ...` loop asserted the provider policy rejects.
+// Order matches the shell verbatim so the generated checks reproduce the
+// shell's first-failure stderr exactly.  Every flag is a fixed single-quoted
+// shell literal, matched by `grep -Fq`.
+var copilotUnsafeLongFlags = []string{
+	"--config-dir",
+	"--allow-tool",
+	"--allow-all-tools",
+	"--allow-all-mcp-server-instructions",
+	"--available-tools",
+	"--secret-env-vars",
+	"--no-auto-update",
+	"--no-remote",
+	"--no-remote-export",
+	"--disable-builtin-mcps",
+	"--disallow-temp-dir",
+	"--dynamic-retrieval",
+	"--interactive",
+	"--no-bash-env",
+	"--plan",
+	"--worktree",
+}
+
+// copilotUnsafeAttachedShortForms lists the five Copilot attached short-flag
+// forms the shell's `for unsafe_copilot_short_form in ...` loop asserted the
+// provider policy rejects.  `grep -Fq` treats the `?` and `*` glob characters
+// as LITERAL, so each is a fixed string (e.g. the literal `-c?*`), not a glob;
+// order matches the shell verbatim.
+var copilotUnsafeAttachedShortForms = []string{
+	"-c?*",
+	"-i?*",
+	"-a?*",
+	"-A?*",
+	"-w?*",
+}
+
+// copilotUnsafeBareShortForms lists the two Copilot bare short-flag case
+// snippets the shell's `for unsafe_copilot_bare_short in ...` loop asserted are
+// rejected and smoke-tested.  Each is a fixed single-quoted shell literal
+// (including its spaces, pipes, parens, and trailing `)`), matched by
+// `grep -Fq` across BOTH scripts/container-smoke.sh and
+// runtime/container/provider-policy.sh (a multi-file OR: present in either file
+// satisfies the check).  Order matches the shell verbatim.
+var copilotUnsafeBareShortForms = []string{
+	"copilot_short_flag in -C -i -n -r -w",
+	"-C | -i | -n | -r | -w)",
+}
+
+// copilotUnsafeFlagsChecks returns the thirty-one Copilot-unsafe-flag
+// invariants in the same order as the former inline block in
+// scripts/verify-invariants.sh (the block between the copilot-policy-wrapper
+// `go_verify_citools` call and the Copilot upstream-release-verifier
+// `# shellcheck disable=SC2016` group), so a reviewer can diff the two
+// one-to-one.
+//
+// The block reads six files via the per-check targetFile / targetFiles fields:
+// the runtime provider policy (runtime/container/provider-policy.sh), the
+// container smoke harness (scripts/container-smoke.sh), the runtime provider
+// wrapper (runtime/container/provider-wrapper.sh), the runtime development
+// wrapper (runtime/container/development-wrapper.sh), the exec-guard Rust
+// library (runtime/container/rust/src/lib.rs), and the shared launcher_common.rs
+// helper.
+//
+// Matching semantics mirror the shell exactly:
+//   - The three `for` loops each ran `grep -Fq -- NEEDLE ...`.  The first two
+//     loops probe a single file (provider-policy.sh), so each item is a
+//     kindPresent check whose message interpolates the loop variable exactly as
+//     the shell's `echo "... ${unsafe_copilot_flag}"` /
+//     `${unsafe_copilot_short_form}` did.  Every needle is fixed-string
+//     containment: `grep -Fq` treats the `?`/`*` glob characters in the short
+//     forms as literal.
+//   - The third loop ran `grep -Fq -- NEEDLE container-smoke.sh
+//     provider-policy.sh` — a multi-file grep whose `! grep` guard fails only
+//     when the needle is absent from BOTH files.  Each item is therefore a
+//     kindPresentInAnyFile check over those two files, sharing the loop's
+//     interpolated message.
+//   - The eight trailing guards are single-file `! grep -Fq NEEDLE file` probes
+//     (kindPresent, per-check targetFile).  Two former shell `if` guards each
+//     joined two `grep -Fq` probes with `||` under one message (the exec-guard
+//     wrapper-specific pair, both against rust/src/lib.rs; the forged-auth pair,
+//     against launcher_common.rs then container-smoke.sh); they are expressed as
+//     ordered kindPresent checks sharing that message, which is behaviourally
+//     identical (the first missing probe yields the same stderr and exit 1).
+func copilotUnsafeFlagsChecks() []check {
+	var cs []check
+	// Loop 1: sixteen fixed unsafe long flags rejected by provider-policy.sh.
+	for _, flag := range copilotUnsafeLongFlags {
+		cs = append(cs, check{
+			kind:       kindPresent,
+			pattern:    flag,
+			message:    "Expected provider policy to reject Copilot unsafe flag: " + flag,
+			targetFile: providerPolicyRelPath,
+		})
+	}
+	// Loop 2: five attached short-flag forms rejected by provider-policy.sh.
+	for _, form := range copilotUnsafeAttachedShortForms {
+		cs = append(cs, check{
+			kind:       kindPresent,
+			pattern:    form,
+			message:    "Expected provider policy to reject Copilot attached unsafe short flag: " + form,
+			targetFile: providerPolicyRelPath,
+		})
+	}
+	// Loop 3: two bare short-flag snippets present in container-smoke.sh OR
+	// provider-policy.sh (multi-file grep OR).
+	for _, form := range copilotUnsafeBareShortForms {
+		cs = append(cs, check{
+			kind:        kindPresentInAnyFile,
+			pattern:     form,
+			message:     "Expected Copilot bare unsafe short flags to be rejected and smoke-tested: " + form,
+			targetFiles: []string{containerSmokeRelPath, providerPolicyRelPath},
+		})
+	}
+	cs = append(cs,
+		check{
+			kind:       kindPresent,
+			pattern:    "reject_unsafe_copilot_args",
+			message:    "Expected provider wrapper to re-check Copilot argv before launch",
+			targetFile: providerWrapperRelPath,
+		},
+		check{
+			kind:       kindPresent,
+			pattern:    `reject_protected_runtime_arguments "$@"`,
+			message:    "Expected development wrapper to reject loader-mediated protected runtime targets before exec",
+			targetFile: developmentWrapperRelPath,
+		},
+		check{
+			kind:       kindPresent,
+			pattern:    "development-wrapper-copilot-loader",
+			message:    "Expected container smoke to cover development-wrapper loader-mediated Copilot execution",
+			targetFile: containerSmokeRelPath,
+		},
+		check{
+			kind:       kindPresent,
+			pattern:    "workcell-copilot-real-copy",
+			message:    "Expected container smoke to cover development-wrapper execution of copied protected Copilot payloads",
+			targetFile: containerSmokeRelPath,
+		},
+		// Exec-guard wrapper-specific pair (first probe): shares the pair's message.
+		check{
+			kind:       kindPresent,
+			pattern:    "ApprovedWrapper::Development | ApprovedWrapper::None => false",
+			message:    "Expected exec guard to keep protected runtime authorization wrapper-specific",
+			targetFile: rustLibRelPath,
+		},
+		// Exec-guard wrapper-specific pair (second probe): shares the pair's message.
+		check{
+			kind:       kindPresent,
+			pattern:    "approved_wrapper_allows_runtime",
+			message:    "Expected exec guard to keep protected runtime authorization wrapper-specific",
+			targetFile: rustLibRelPath,
+		},
+		// Forged-auth pair (first probe, launcher_common.rs): shares the pair's message.
+		check{
+			kind:       kindPresent,
+			pattern:    "WORKCELL_COPILOT_GITHUB_TOKEN",
+			message:    "Expected launcher and smoke coverage to reject forged Copilot auth env",
+			targetFile: launcherCommonRustRelPath,
+		},
+		// Forged-auth pair (second probe, container-smoke.sh): shares the pair's message.
+		check{
+			kind:       kindPresent,
+			pattern:    "forged-copilot-token",
+			message:    "Expected launcher and smoke coverage to reject forged Copilot auth env",
+			targetFile: containerSmokeRelPath,
+		},
+	)
+	return cs
+}
+
+// CheckCopilotUnsafeFlags runs the thirty-one Copilot-unsafe-flag invariants
+// against the repo rooted at rootDir, in the shell's original order.  It returns
+// nil when every invariant holds (the shell's exit 0), or an error whose message
+// equals the shell's stderr for the first violated invariant (the shell's exit
+// 1).
+func CheckCopilotUnsafeFlags(rootDir string) error {
+	return evaluate(rootDir, copilotUnsafeFlagsChecks())
+}
+
 // holds reports whether the invariant is satisfied by the launcher text.
 func (c check) holds(text string) bool {
 	switch c.kind {
@@ -2032,6 +2242,11 @@ func (c check) holds(text string) bool {
 	case kindFirstLineRegex:
 		return regexp.MustCompile(c.pattern).MatchString(firstLine(text))
 	case kindPresent:
+		return strings.Contains(text, c.pattern)
+	case kindPresentInAnyFile:
+		// Per-file containment predicate for a single listed file; evaluate
+		// ORs this across every path in targetFiles to reproduce grep's
+		// multi-file OR semantics.
 		return strings.Contains(text, c.pattern)
 	case kindAbsent:
 		return !strings.Contains(text, c.pattern)

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -3017,3 +3017,346 @@ func TestCheckCopilotPolicyWrapperRealRepo(t *testing.T) {
 		t.Fatalf("CheckCopilotPolicyWrapper(real repo) = %v, want nil", err)
 	}
 }
+
+// copilotUnsafeFlagsHappyProviderPolicy is a minimal but structurally faithful
+// runtime/container/provider-policy.sh: it contains all sixteen unsafe long
+// flags, all five attached short-flag forms (with the `?*` glob characters as
+// literal text, matched by grep -Fq), and the second bare short-flag snippet
+// `-C | -i | -n | -r | -w)` (the FIRST bare snippet lives in the smoke harness,
+// so the two loop-3 items are deliberately split across the two files to prove
+// the OR across them is real).
+const copilotUnsafeFlagsHappyProviderPolicy = `#!/usr/bin/env bash
+copilot_policy() {
+  case "${arg}" in
+  --config-dir | --allow-tool | --allow-all-tools | --allow-all-mcp-server-instructions) ;;
+  --available-tools | --secret-env-vars | --no-auto-update | --no-remote | --no-remote-export) ;;
+  --disable-builtin-mcps | --disallow-temp-dir | --dynamic-retrieval | --interactive) ;;
+  --no-bash-env | --plan | --worktree) ;;
+  -c?* | -i?* | -a?* | -A?* | -w?*) ;;
+  -C | -i | -n | -r | -w) ;;
+  esac
+}
+`
+
+// copilotUnsafeFlagsHappySmoke is a minimal but structurally faithful
+// scripts/container-smoke.sh: it contains the FIRST bare short-flag snippet
+// `copilot_short_flag in -C -i -n -r -w` (its only home; provider-policy.sh has
+// the second), the development-wrapper loader coverage needles, and the
+// forged-auth smoke needle.
+const copilotUnsafeFlagsHappySmoke = `#!/usr/bin/env bash
+# copilot_short_flag in -C -i -n -r -w
+run_case development-wrapper-copilot-loader.out
+run_case workcell-copilot-real-copy.out
+run_case forged-copilot-token.out
+`
+
+// copilotUnsafeFlagsHappyProviderWrapper is a minimal but structurally faithful
+// runtime/container/provider-wrapper.sh containing the argv re-check needle.
+const copilotUnsafeFlagsHappyProviderWrapper = `#!/usr/bin/env bash
+reject_unsafe_copilot_args "$@"
+`
+
+// copilotUnsafeFlagsHappyDevelopmentWrapper is a minimal but structurally
+// faithful runtime/container/development-wrapper.sh containing the protected
+// runtime target rejection needle.
+const copilotUnsafeFlagsHappyDevelopmentWrapper = `#!/usr/bin/env bash
+reject_protected_runtime_arguments "$@"
+`
+
+// copilotUnsafeFlagsHappyRustLib is a minimal but structurally faithful
+// runtime/container/rust/src/lib.rs containing both exec-guard needles.
+const copilotUnsafeFlagsHappyRustLib = `pub fn approved_wrapper_allows_runtime(w: ApprovedWrapper) -> bool {
+    match w {
+        ApprovedWrapper::Development | ApprovedWrapper::None => false,
+        _ => true,
+    }
+}
+`
+
+// copilotUnsafeFlagsHappyLauncherCommon is a minimal but structurally faithful
+// runtime/container/rust/src/bin/common/launcher_common.rs containing the
+// forged-auth env needle.
+const copilotUnsafeFlagsHappyLauncherCommon = `pub const COPILOT_TOKEN_ENV: &str = "WORKCELL_COPILOT_GITHUB_TOKEN";
+`
+
+// writeCopilotUnsafeFlagsRepo materializes a fake repo with the six files this
+// group reads set to the given bodies; a body of "" means "do not create that
+// file" (unreadable-target case).
+func writeCopilotUnsafeFlagsRepo(t *testing.T, providerPolicy, smoke, providerWrapper, developmentWrapper, rustLib, launcherCommon string) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, body string) {
+		if body == "" {
+			return
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(providerPolicyRelPath, providerPolicy)
+	write(containerSmokeRelPath, smoke)
+	write(providerWrapperRelPath, providerWrapper)
+	write(developmentWrapperRelPath, developmentWrapper)
+	write(rustLibRelPath, rustLib)
+	write(launcherCommonRustRelPath, launcherCommon)
+	return root
+}
+
+func TestCheckCopilotUnsafeFlags(t *testing.T) {
+	tests := []struct {
+		name               string
+		providerPolicy     string
+		smoke              string
+		providerWrapper    string
+		developmentWrapper string
+		rustLib            string
+		launcherCommon     string
+		wantErr            string // "" means expect success
+	}{
+		{
+			name:               "happy path all invariants hold",
+			providerPolicy:     copilotUnsafeFlagsHappyProviderPolicy,
+			smoke:              copilotUnsafeFlagsHappySmoke,
+			providerWrapper:    copilotUnsafeFlagsHappyProviderWrapper,
+			developmentWrapper: copilotUnsafeFlagsHappyDevelopmentWrapper,
+			rustLib:            copilotUnsafeFlagsHappyRustLib,
+			launcherCommon:     copilotUnsafeFlagsHappyLauncherCommon,
+		},
+		{
+			// Loop 1 (kindPresent, provider-policy.sh — first flag).
+			name:               "provider policy missing first unsafe long flag",
+			providerPolicy:     strings.Replace(copilotUnsafeFlagsHappyProviderPolicy, "--config-dir", "--other", 1),
+			smoke:              copilotUnsafeFlagsHappySmoke,
+			providerWrapper:    copilotUnsafeFlagsHappyProviderWrapper,
+			developmentWrapper: copilotUnsafeFlagsHappyDevelopmentWrapper,
+			rustLib:            copilotUnsafeFlagsHappyRustLib,
+			launcherCommon:     copilotUnsafeFlagsHappyLauncherCommon,
+			wantErr:            "Expected provider policy to reject Copilot unsafe flag: --config-dir",
+		},
+		{
+			// Loop 1 (kindPresent, provider-policy.sh — last flag).
+			name:               "provider policy missing last unsafe long flag",
+			providerPolicy:     strings.Replace(copilotUnsafeFlagsHappyProviderPolicy, "--worktree", "--other", 1),
+			smoke:              copilotUnsafeFlagsHappySmoke,
+			providerWrapper:    copilotUnsafeFlagsHappyProviderWrapper,
+			developmentWrapper: copilotUnsafeFlagsHappyDevelopmentWrapper,
+			rustLib:            copilotUnsafeFlagsHappyRustLib,
+			launcherCommon:     copilotUnsafeFlagsHappyLauncherCommon,
+			wantErr:            "Expected provider policy to reject Copilot unsafe flag: --worktree",
+		},
+		{
+			// Loop 2 (kindPresent, provider-policy.sh — literal `?*` short form).
+			name:               "provider policy missing attached short form",
+			providerPolicy:     strings.Replace(copilotUnsafeFlagsHappyProviderPolicy, "-a?*", "-a", 1),
+			smoke:              copilotUnsafeFlagsHappySmoke,
+			providerWrapper:    copilotUnsafeFlagsHappyProviderWrapper,
+			developmentWrapper: copilotUnsafeFlagsHappyDevelopmentWrapper,
+			rustLib:            copilotUnsafeFlagsHappyRustLib,
+			launcherCommon:     copilotUnsafeFlagsHappyLauncherCommon,
+			wantErr:            "Expected provider policy to reject Copilot attached unsafe short flag: -a?*",
+		},
+		{
+			// Loop 3 (kindPresentInAnyFile): the first bare snippet lives only in the
+			// smoke harness, so removing it there (it is absent from the policy) makes
+			// it absent from BOTH files → violation.
+			name:               "bare short flag absent from both files",
+			providerPolicy:     copilotUnsafeFlagsHappyProviderPolicy,
+			smoke:              strings.Replace(copilotUnsafeFlagsHappySmoke, "copilot_short_flag in -C -i -n -r -w", "other", 1),
+			providerWrapper:    copilotUnsafeFlagsHappyProviderWrapper,
+			developmentWrapper: copilotUnsafeFlagsHappyDevelopmentWrapper,
+			rustLib:            copilotUnsafeFlagsHappyRustLib,
+			launcherCommon:     copilotUnsafeFlagsHappyLauncherCommon,
+			wantErr:            "Expected Copilot bare unsafe short flags to be rejected and smoke-tested: copilot_short_flag in -C -i -n -r -w",
+		},
+		{
+			// Guard (kindPresent, provider-wrapper.sh).
+			name:               "provider wrapper missing argv re-check",
+			providerPolicy:     copilotUnsafeFlagsHappyProviderPolicy,
+			smoke:              copilotUnsafeFlagsHappySmoke,
+			providerWrapper:    strings.Replace(copilotUnsafeFlagsHappyProviderWrapper, "reject_unsafe_copilot_args", "other", 1),
+			developmentWrapper: copilotUnsafeFlagsHappyDevelopmentWrapper,
+			rustLib:            copilotUnsafeFlagsHappyRustLib,
+			launcherCommon:     copilotUnsafeFlagsHappyLauncherCommon,
+			wantErr:            "Expected provider wrapper to re-check Copilot argv before launch",
+		},
+		{
+			// Guard (kindPresent, development-wrapper.sh).
+			name:               "development wrapper missing protected target rejection",
+			providerPolicy:     copilotUnsafeFlagsHappyProviderPolicy,
+			smoke:              copilotUnsafeFlagsHappySmoke,
+			providerWrapper:    copilotUnsafeFlagsHappyProviderWrapper,
+			developmentWrapper: strings.Replace(copilotUnsafeFlagsHappyDevelopmentWrapper, `reject_protected_runtime_arguments "$@"`, "other", 1),
+			rustLib:            copilotUnsafeFlagsHappyRustLib,
+			launcherCommon:     copilotUnsafeFlagsHappyLauncherCommon,
+			wantErr:            "Expected development wrapper to reject loader-mediated protected runtime targets before exec",
+		},
+		{
+			// Guard (kindPresent, container-smoke.sh).
+			name:               "smoke missing development-wrapper loader coverage",
+			providerPolicy:     copilotUnsafeFlagsHappyProviderPolicy,
+			smoke:              strings.Replace(copilotUnsafeFlagsHappySmoke, "development-wrapper-copilot-loader", "other", 1),
+			providerWrapper:    copilotUnsafeFlagsHappyProviderWrapper,
+			developmentWrapper: copilotUnsafeFlagsHappyDevelopmentWrapper,
+			rustLib:            copilotUnsafeFlagsHappyRustLib,
+			launcherCommon:     copilotUnsafeFlagsHappyLauncherCommon,
+			wantErr:            "Expected container smoke to cover development-wrapper loader-mediated Copilot execution",
+		},
+		{
+			// Multi-probe guard (first probe): exec-guard wrapper-specific pair,
+			// rust/src/lib.rs.
+			name:               "exec guard missing wrapper-specific match arm",
+			providerPolicy:     copilotUnsafeFlagsHappyProviderPolicy,
+			smoke:              copilotUnsafeFlagsHappySmoke,
+			providerWrapper:    copilotUnsafeFlagsHappyProviderWrapper,
+			developmentWrapper: copilotUnsafeFlagsHappyDevelopmentWrapper,
+			rustLib:            strings.Replace(copilotUnsafeFlagsHappyRustLib, "ApprovedWrapper::Development | ApprovedWrapper::None => false", "_ => false", 1),
+			launcherCommon:     copilotUnsafeFlagsHappyLauncherCommon,
+			wantErr:            "Expected exec guard to keep protected runtime authorization wrapper-specific",
+		},
+		{
+			// Multi-probe guard (second probe): proves the two ordered probes share
+			// one message.
+			name:               "exec guard missing runtime authorization helper",
+			providerPolicy:     copilotUnsafeFlagsHappyProviderPolicy,
+			smoke:              copilotUnsafeFlagsHappySmoke,
+			providerWrapper:    copilotUnsafeFlagsHappyProviderWrapper,
+			developmentWrapper: copilotUnsafeFlagsHappyDevelopmentWrapper,
+			rustLib:            strings.Replace(copilotUnsafeFlagsHappyRustLib, "approved_wrapper_allows_runtime", "other_helper", 1),
+			launcherCommon:     copilotUnsafeFlagsHappyLauncherCommon,
+			wantErr:            "Expected exec guard to keep protected runtime authorization wrapper-specific",
+		},
+		{
+			// Multi-probe guard (first probe): forged-auth pair, launcher_common.rs.
+			name:               "launcher missing forged auth env token",
+			providerPolicy:     copilotUnsafeFlagsHappyProviderPolicy,
+			smoke:              copilotUnsafeFlagsHappySmoke,
+			providerWrapper:    copilotUnsafeFlagsHappyProviderWrapper,
+			developmentWrapper: copilotUnsafeFlagsHappyDevelopmentWrapper,
+			rustLib:            copilotUnsafeFlagsHappyRustLib,
+			launcherCommon:     strings.Replace(copilotUnsafeFlagsHappyLauncherCommon, "WORKCELL_COPILOT_GITHUB_TOKEN", "OTHER_TOKEN", 1),
+			wantErr:            "Expected launcher and smoke coverage to reject forged Copilot auth env",
+		},
+		{
+			// Multi-probe guard (second probe, container-smoke.sh): shares the message.
+			name:               "smoke missing forged auth coverage",
+			providerPolicy:     copilotUnsafeFlagsHappyProviderPolicy,
+			smoke:              strings.Replace(copilotUnsafeFlagsHappySmoke, "forged-copilot-token", "other", 1),
+			providerWrapper:    copilotUnsafeFlagsHappyProviderWrapper,
+			developmentWrapper: copilotUnsafeFlagsHappyDevelopmentWrapper,
+			rustLib:            copilotUnsafeFlagsHappyRustLib,
+			launcherCommon:     copilotUnsafeFlagsHappyLauncherCommon,
+			wantErr:            "Expected launcher and smoke coverage to reject forged Copilot auth env",
+		},
+		{
+			// A missing provider-policy.sh is empty content: the first loop-1 probe
+			// fails (the --config-dir flag).
+			name:               "missing provider policy",
+			providerPolicy:     "",
+			smoke:              copilotUnsafeFlagsHappySmoke,
+			providerWrapper:    copilotUnsafeFlagsHappyProviderWrapper,
+			developmentWrapper: copilotUnsafeFlagsHappyDevelopmentWrapper,
+			rustLib:            copilotUnsafeFlagsHappyRustLib,
+			launcherCommon:     copilotUnsafeFlagsHappyLauncherCommon,
+			wantErr:            "Expected provider policy to reject Copilot unsafe flag: --config-dir",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeCopilotUnsafeFlagsRepo(t, tc.providerPolicy, tc.smoke, tc.providerWrapper, tc.developmentWrapper, tc.rustLib, tc.launcherCommon)
+			err := CheckCopilotUnsafeFlags(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckCopilotUnsafeFlags() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckCopilotUnsafeFlags() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckCopilotUnsafeFlags() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckCopilotUnsafeFlagsBareShortFormOrSemantics exercises the new
+// kindPresentInAnyFile OR semantics directly against the loop-3 first bare
+// short-flag snippet: it must hold when the snippet is present in the smoke
+// harness only, when present in the provider policy only, and must fail only
+// when absent from BOTH files — mirroring `grep -Fq -- NEEDLE f1 f2`.
+func TestCheckCopilotUnsafeFlagsBareShortFormOrSemantics(t *testing.T) {
+	const snippet = "copilot_short_flag in -C -i -n -r -w"
+	// A policy body that still satisfies every non-loop-3 policy probe but does
+	// NOT contain the first bare snippet by default (the happy policy already
+	// omits it; the second bare snippet stays present so loop-3 item 2 holds).
+	policyWithout := copilotUnsafeFlagsHappyProviderPolicy
+	policyWith := copilotUnsafeFlagsHappyProviderPolicy + "\n  # " + snippet + "\n"
+	// A smoke body that satisfies every non-loop-3 smoke probe but omits the
+	// first bare snippet.
+	smokeWithout := strings.Replace(copilotUnsafeFlagsHappySmoke, snippet, "placeholder", 1)
+	smokeWith := copilotUnsafeFlagsHappySmoke
+
+	cases := []struct {
+		name    string
+		policy  string
+		smoke   string
+		wantErr bool
+	}{
+		{name: "present in smoke (file1) only", policy: policyWithout, smoke: smokeWith, wantErr: false},
+		{name: "present in policy (file2) only", policy: policyWith, smoke: smokeWithout, wantErr: false},
+		{name: "absent from both", policy: policyWithout, smoke: smokeWithout, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeCopilotUnsafeFlagsRepo(t, tc.policy, tc.smoke, copilotUnsafeFlagsHappyProviderWrapper, copilotUnsafeFlagsHappyDevelopmentWrapper, copilotUnsafeFlagsHappyRustLib, copilotUnsafeFlagsHappyLauncherCommon)
+			err := CheckCopilotUnsafeFlags(root)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("CheckCopilotUnsafeFlags() = nil, want OR-semantics violation")
+				}
+				want := "Expected Copilot bare unsafe short flags to be rejected and smoke-tested: " + snippet
+				if err.Error() != want {
+					t.Fatalf("CheckCopilotUnsafeFlags() error = %q, want %q", err.Error(), want)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CheckCopilotUnsafeFlags() = %v, want nil (needle present in one file)", err)
+			}
+		})
+	}
+}
+
+// TestCheckCopilotUnsafeFlagsCount asserts the check list contains exactly
+// thirty-one invariants, guarding against an accidentally truncated or
+// duplicated migration of the shell block.
+func TestCheckCopilotUnsafeFlagsCount(t *testing.T) {
+	got := len(copilotUnsafeFlagsChecks())
+	const want = 31
+	if got != want {
+		t.Fatalf("copilotUnsafeFlagsChecks() has %d checks, want %d", got, want)
+	}
+}
+
+// TestCheckCopilotUnsafeFlagsRealRepo asserts that the real provider-policy.sh,
+// container-smoke.sh, provider-wrapper.sh, development-wrapper.sh, lib.rs, and
+// launcher_common.rs in this repository satisfy all thirty-one
+// Copilot-unsafe-flag invariants.  This is the key guard against a
+// mis-transcribed needle or a wrong target file: if any Go pattern is not a
+// byte-exact substring of the actual file (or the wrong file), this test fails
+// with the guard's stderr message.
+func TestCheckCopilotUnsafeFlagsRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, providerPolicyRelPath)); err != nil {
+		t.Skipf("real provider-policy.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckCopilotUnsafeFlags(repoRoot); err != nil {
+		t.Fatalf("CheckCopilotUnsafeFlags(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -8251,73 +8251,7 @@ if ! grep -Fq "rm -f -- \"\${token_file}\"" "${ROOT_DIR}/runtime/container/provi
   exit 1
 fi
 go_verify_citools workcell-copilot-policy-wrapper "${ROOT_DIR}" || exit 1
-for unsafe_copilot_flag in \
-  '--config-dir' \
-  '--allow-tool' \
-  '--allow-all-tools' \
-  '--allow-all-mcp-server-instructions' \
-  '--available-tools' \
-  '--secret-env-vars' \
-  '--no-auto-update' \
-  '--no-remote' \
-  '--no-remote-export' \
-  '--disable-builtin-mcps' \
-  '--disallow-temp-dir' \
-  '--dynamic-retrieval' \
-  '--interactive' \
-  '--no-bash-env' \
-  '--plan' \
-  '--worktree'; do
-  if ! grep -Fq -- "${unsafe_copilot_flag}" "${ROOT_DIR}/runtime/container/provider-policy.sh"; then
-    echo "Expected provider policy to reject Copilot unsafe flag: ${unsafe_copilot_flag}" >&2
-    exit 1
-  fi
-done
-for unsafe_copilot_short_form in \
-  '-c?*' \
-  '-i?*' \
-  '-a?*' \
-  '-A?*' \
-  '-w?*'; do
-  if ! grep -Fq -- "${unsafe_copilot_short_form}" "${ROOT_DIR}/runtime/container/provider-policy.sh"; then
-    echo "Expected provider policy to reject Copilot attached unsafe short flag: ${unsafe_copilot_short_form}" >&2
-    exit 1
-  fi
-done
-for unsafe_copilot_bare_short in \
-  'copilot_short_flag in -C -i -n -r -w' \
-  '-C | -i | -n | -r | -w)'; do
-  if ! grep -Fq -- "${unsafe_copilot_bare_short}" "${ROOT_DIR}/scripts/container-smoke.sh" "${ROOT_DIR}/runtime/container/provider-policy.sh"; then
-    echo "Expected Copilot bare unsafe short flags to be rejected and smoke-tested: ${unsafe_copilot_bare_short}" >&2
-    exit 1
-  fi
-done
-if ! grep -Fq 'reject_unsafe_copilot_args' "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Expected provider wrapper to re-check Copilot argv before launch" >&2
-  exit 1
-fi
-if ! grep -Fq 'reject_protected_runtime_arguments "$@"' "${ROOT_DIR}/runtime/container/development-wrapper.sh"; then
-  echo "Expected development wrapper to reject loader-mediated protected runtime targets before exec" >&2
-  exit 1
-fi
-if ! grep -Fq 'development-wrapper-copilot-loader' "${ROOT_DIR}/scripts/container-smoke.sh"; then
-  echo "Expected container smoke to cover development-wrapper loader-mediated Copilot execution" >&2
-  exit 1
-fi
-if ! grep -Fq 'workcell-copilot-real-copy' "${ROOT_DIR}/scripts/container-smoke.sh"; then
-  echo "Expected container smoke to cover development-wrapper execution of copied protected Copilot payloads" >&2
-  exit 1
-fi
-if ! grep -Fq 'ApprovedWrapper::Development | ApprovedWrapper::None => false' "${ROOT_DIR}/runtime/container/rust/src/lib.rs" ||
-  ! grep -Fq 'approved_wrapper_allows_runtime' "${ROOT_DIR}/runtime/container/rust/src/lib.rs"; then
-  echo "Expected exec guard to keep protected runtime authorization wrapper-specific" >&2
-  exit 1
-fi
-if ! grep -Fq 'WORKCELL_COPILOT_GITHUB_TOKEN' "${ROOT_DIR}/runtime/container/rust/src/bin/common/launcher_common.rs" ||
-  ! grep -Fq 'forged-copilot-token' "${ROOT_DIR}/scripts/container-smoke.sh"; then
-  echo "Expected launcher and smoke coverage to reject forged Copilot auth env" >&2
-  exit 1
-fi
+go_verify_citools workcell-copilot-unsafe-flags "${ROOT_DIR}" || exit 1
 # shellcheck disable=SC2016
 if ! grep -Fq 'COPILOT_HELP_MODE="${WORKCELL_COPILOT_RELEASE_HELP_MODE:-auto}"' "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh" ||
   ! grep -Fq 'COPILOT_NATIVE_HELP_DONE=0' "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh" ||


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 16 of N (larger batch).** Follows #398-#412. Migrates 31 copilot unsafe-flag invariant checks (former lines 8254-8320) — three fixed-list loops + eight following guards.

## What
- **`internal/workcellhardening`**: new `CheckCopilotUnsafeFlags(rootDir)`. Loop 1 (16 `--` flags) + loop 2 (5 literal `?*` short forms) → `kindPresent` on `provider-policy.sh`; loop 3 (2 bare-short items) → the new `kindPresentInAnyFile`; 8 trailing guards across provider-wrapper.sh, development-wrapper.sh, container-smoke.sh, `rust/src/lib.rs`, launcher_common.rs (two `||` multi-probe guards → ordered checks sharing one message).
- **New kind `kindPresentInAnyFile` + `targetFiles []string`**: mirrors `grep -Fq -- NEEDLE f1 f2` under `if !` — passes if the needle is in ANY listed file, fails only when absent from ALL. (Distinct from the earlier absent-from-all two-file grep.) OR-semantics tested explicitly: present-in-file1-only → pass, file2-only → pass, absent-from-both → fail; the real repo naturally splits loop-3's two items across the two files, so the real-repo pass depends on the OR being correct.
- **`cmd/workcell-citools`**: new `workcell-copilot-unsafe-flags` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-copilot-unsafe-flags "${ROOT_DIR}" || exit 1`. Stopped at 8320 (next block reads a new file + a `grep -Fc … -lt 2` count check).

## Parity
All 31 needles pre-verified byte-exact (`?*` short forms are literal under `grep -F`). Real repo → exit 0; 6 crafted violations → exit 1 byte-identical stderr. Real-repo assertion + count=31 guard.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...` (13+3+count+real-repo cases), `shellcheck -x`, `shfmt -d` — all green. 4 files / 634 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)