### PR TITLE
^R D3: migrate copilot upstream-release-verify invariants to Go (24 checks)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -110,6 +110,7 @@ func subcommands() []subcommand {
 		{"workcell-provider-launcher-authority", "ROOT_DIR", 1, 1, cmdWorkcellProviderLauncherAuthority},
 		{"workcell-copilot-policy-wrapper", "ROOT_DIR", 1, 1, cmdWorkcellCopilotPolicyWrapper},
 		{"workcell-copilot-unsafe-flags", "ROOT_DIR", 1, 1, cmdWorkcellCopilotUnsafeFlags},
+		{"workcell-copilot-release-verify", "ROOT_DIR", 1, 1, cmdWorkcellCopilotReleaseVerify},
 	}
 }
 
@@ -633,4 +634,12 @@ func cmdWorkcellCopilotPolicyWrapper(args []string) error {
 // with the shell's original stderr message for the first violated invariant.
 func cmdWorkcellCopilotUnsafeFlags(args []string) error {
 	return workcellhardening.CheckCopilotUnsafeFlags(args[0])
+}
+
+// cmdWorkcellCopilotReleaseVerify runs the twenty-four Copilot upstream-release
+// verifier checks migrated out of scripts/verify-invariants.sh; it fails (exit 1
+// via die()) with the shell's original stderr message for the first violated
+// invariant.
+func cmdWorkcellCopilotReleaseVerify(args []string) error {
+	return workcellhardening.CheckCopilotReleaseVerify(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -153,6 +153,33 @@ const rustLibRelPath = "runtime/container/rust/src/lib.rs"
 // against ${ROOT_DIR}/runtime/container/provider-policy.sh.
 const providerPolicyRelPath = "runtime/container/provider-policy.sh"
 
+// verifyUpstreamCopilotReleaseRelPath is the repo-relative path to the Copilot
+// upstream-release verifier.  The Copilot-release-verify block reads this file
+// (via the per-check targetFile field) for its help-mode / checksum-path /
+// whole-flag-match invariants and its managed-flag loop, mirroring the shell
+// `grep -Fq` probes that ran against
+// ${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh.
+const verifyUpstreamCopilotReleaseRelPath = "scripts/verify-upstream-copilot-release.sh"
+
+// updateProviderPinsRelPath is the repo-relative path to the provider-pin bump
+// script.  Only the Copilot-release-verify checksum-only invariant reads this
+// file (via the per-check targetFile field), mirroring the shell `grep -Fq`
+// that ran against ${ROOT_DIR}/scripts/update-provider-pins.sh.
+const updateProviderPinsRelPath = "scripts/update-provider-pins.sh"
+
+// jobValidateRelPath is the repo-relative path to the routine CI validate job.
+// Only the Copilot-release-verify checksum-only invariant reads this file (via
+// the per-check targetFile field), mirroring the shell `grep -Fq` that ran
+// against ${ROOT_DIR}/scripts/ci/job-validate.sh.
+const jobValidateRelPath = "scripts/ci/job-validate.sh"
+
+// releaseWorkflowRelPath is the repo-relative path to the release workflow.
+// The Copilot-release-verify block reads this file (via the per-check
+// targetFile field) for its docker/arm64 release-help invariants, mirroring the
+// shell `grep -Fq` probes that ran against
+// ${ROOT_DIR}/.github/workflows/release.yml.
+const releaseWorkflowRelPath = ".github/workflows/release.yml"
+
 // checkKind selects how a check's pattern is matched against the launcher
 // contents.
 type checkKind int
@@ -2225,6 +2252,184 @@ func copilotUnsafeFlagsChecks() []check {
 // 1).
 func CheckCopilotUnsafeFlags(rootDir string) error {
 	return evaluate(rootDir, copilotUnsafeFlagsChecks())
+}
+
+// copilotReleaseHelpFlags lists the eleven managed Copilot flags the shell's
+// `for copilot_release_help_flag in ...` loop asserted the upstream-release
+// verifier requires.  Order matches the shell verbatim so the generated checks
+// reproduce the shell's first-failure stderr exactly.  Every flag is a fixed
+// single-quoted shell literal, matched by `grep -Fq --`.
+var copilotReleaseHelpFlags = []string{
+	"--allow-tool",
+	"--available-tools",
+	"--disable-builtin-mcps",
+	"--disallow-temp-dir",
+	"--log-dir",
+	"--no-ask-user",
+	"--no-auto-update",
+	"--no-custom-instructions",
+	"--no-remote",
+	"--no-remote-export",
+	"--secret-env-vars",
+}
+
+// copilotReleaseVerifyChecks returns the twenty-four Copilot upstream-release
+// verifier invariants in the same order as the former inline block in
+// scripts/verify-invariants.sh (the block between the copilot-unsafe-flags
+// `go_verify_citools` call and the release-workflow native-help-count guard),
+// so a reviewer can diff the two one-to-one.
+//
+// The block reads four files via the per-check targetFile field: the Copilot
+// upstream-release verifier (scripts/verify-upstream-copilot-release.sh), the
+// provider-pin bump script (scripts/update-provider-pins.sh), the routine CI
+// validate job (scripts/ci/job-validate.sh), and the release workflow
+// (.github/workflows/release.yml).  Every probe is a whole-file `grep -Fq`
+// fixed-string containment (kindPresent); every needle is metacharacter-free
+// under `grep -Fq` (fixed-string search), so each is fixed-string containment.
+//
+// Matching semantics mirror the shell exactly:
+//   - The help-mode guard was one shell `if` joining six `! grep -Fq` probes
+//     with `||` under a single message; it is expressed here as six ordered
+//     kindPresent checks sharing that message, which is behaviourally identical
+//     (the first missing probe yields the same stderr and exit 1 as the shell
+//     `if`).  The sixth needle was written with shell double-quote escaping
+//     (`\"`→`"`, `\$`→`$`); it is a `grep -Fq` fixed-string search of the
+//     literal `grep -Eq -- "(^|[^[:alnum:]_-])${flag}([^[:alnum:]_-]|$)"`
+//     (the embedded regex metacharacters are matched literally, not as a regex,
+//     because `grep -Fq` treats the whole needle as a fixed string).
+//   - The managed-flag loop ran `! grep -Fq -- "${copilot_release_help_flag}"`;
+//     each item is a kindPresent check whose message interpolates the flag
+//     exactly as the shell's `echo "... ${copilot_release_help_flag}"` did.
+//   - The checksum-only guard was one shell `if` joining two `! grep -Fq`
+//     probes for the SAME resolved variable needle against two files
+//     (update-provider-pins.sh AND job-validate.sh) with `||` under a single
+//     message; it is expressed here as two ordered kindPresent checks (one per
+//     file) sharing that message, which is behaviourally identical.  The needle
+//     resolves the shell `copilot_checksum_verify_needle` assignment to the
+//     concrete literal `WORKCELL_COPILOT_RELEASE_HELP_MODE=checksum
+//     "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh"` (shell
+//     double-quote escaping `\"`→`"`, `\$`→`$`).
+//   - The container-smoke release-help guard (two probes) and the arm64
+//     release-help guard (three probes) each joined their `! grep -Fq` probes
+//     with `||` under a single message against .github/workflows/release.yml;
+//     they are expressed here as ordered kindPresent checks sharing that
+//     message.
+func copilotReleaseVerifyChecks() []check {
+	const helpModeMessage = "Expected Copilot upstream release verifier to track native/Docker help probes separately, support checksum-only paths, and match whole safety flags"
+	cs := []check{
+		// Help-mode guard (six ordered probes sharing one message).
+		{
+			kind:       kindPresent,
+			pattern:    `COPILOT_HELP_MODE="${WORKCELL_COPILOT_RELEASE_HELP_MODE:-auto}"`,
+			message:    helpModeMessage,
+			targetFile: verifyUpstreamCopilotReleaseRelPath,
+		},
+		{
+			kind:       kindPresent,
+			pattern:    "COPILOT_NATIVE_HELP_DONE=0",
+			message:    helpModeMessage,
+			targetFile: verifyUpstreamCopilotReleaseRelPath,
+		},
+		{
+			kind:       kindPresent,
+			pattern:    "COPILOT_DOCKER_HELP_DONE=0",
+			message:    helpModeMessage,
+			targetFile: verifyUpstreamCopilotReleaseRelPath,
+		},
+		{
+			kind:       kindPresent,
+			pattern:    "auto | native | docker | checksum)",
+			message:    helpModeMessage,
+			targetFile: verifyUpstreamCopilotReleaseRelPath,
+		},
+		{
+			kind:       kindPresent,
+			pattern:    `[[ "${COPILOT_HELP_MODE}" == "checksum" ]] && return 0`,
+			message:    helpModeMessage,
+			targetFile: verifyUpstreamCopilotReleaseRelPath,
+		},
+		{
+			// kindPresent: `grep -Fq` fixed-string search of the literal
+			// whole-flag matcher; the embedded ERE metacharacters are matched
+			// literally because grep -Fq treats the whole needle as a fixed
+			// string.  The shell needle unescaped `\"`→`"` and `\$`→`$`.
+			kind:       kindPresent,
+			pattern:    `grep -Eq -- "(^|[^[:alnum:]_-])${flag}([^[:alnum:]_-]|$)"`,
+			message:    helpModeMessage,
+			targetFile: verifyUpstreamCopilotReleaseRelPath,
+		},
+	}
+	// The managed-flag loop (eleven fixed flags required by the verifier).
+	for _, flag := range copilotReleaseHelpFlags {
+		cs = append(cs, check{
+			kind:       kindPresent,
+			pattern:    flag,
+			message:    "Expected Copilot upstream release verifier to require managed flag: " + flag,
+			targetFile: verifyUpstreamCopilotReleaseRelPath,
+		})
+	}
+	const checksumNeedle = `WORKCELL_COPILOT_RELEASE_HELP_MODE=checksum "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh"`
+	const checksumMessage = "Expected provider bump and routine validate paths to use checksum-only Copilot release verification before smoke images exist"
+	const smokeMessage = "Expected release container-smoke job to force Copilot release help verification inside the runtime image"
+	const arm64Message = "Expected release workflow to verify Copilot release help inside an arm64 runtime image before publication"
+	cs = append(cs,
+		// Checksum-only guard (same needle in two files, sharing one message).
+		check{
+			kind:       kindPresent,
+			pattern:    checksumNeedle,
+			message:    checksumMessage,
+			targetFile: updateProviderPinsRelPath,
+		},
+		check{
+			kind:       kindPresent,
+			pattern:    checksumNeedle,
+			message:    checksumMessage,
+			targetFile: jobValidateRelPath,
+		},
+		// Container-smoke release-help guard (two release.yml probes sharing one
+		// message).
+		check{
+			kind:       kindPresent,
+			pattern:    "WORKCELL_COPILOT_RELEASE_HELP_MODE: docker",
+			message:    smokeMessage,
+			targetFile: releaseWorkflowRelPath,
+		},
+		check{
+			kind:       kindPresent,
+			pattern:    "WORKCELL_COPILOT_RELEASE_HELP_IMAGE: workcell:smoke",
+			message:    smokeMessage,
+			targetFile: releaseWorkflowRelPath,
+		},
+		// Arm64 release-help guard (three release.yml probes sharing one message).
+		check{
+			kind:       kindPresent,
+			pattern:    "preflight-arm64-copilot-runtime:",
+			message:    arm64Message,
+			targetFile: releaseWorkflowRelPath,
+		},
+		check{
+			kind:       kindPresent,
+			pattern:    "WORKCELL_COPILOT_RELEASE_HELP_IMAGE: workcell:copilot-arm64-smoke",
+			message:    arm64Message,
+			targetFile: releaseWorkflowRelPath,
+		},
+		check{
+			kind:       kindPresent,
+			pattern:    "preflight-arm64-copilot-runtime",
+			message:    arm64Message,
+			targetFile: releaseWorkflowRelPath,
+		},
+	)
+	return cs
+}
+
+// CheckCopilotReleaseVerify runs the twenty-four Copilot upstream-release
+// verifier invariants against the repo rooted at rootDir, in the shell's
+// original order.  It returns nil when every invariant holds (the shell's exit
+// 0), or an error whose message equals the shell's stderr for the first
+// violated invariant (the shell's exit 1).
+func CheckCopilotReleaseVerify(rootDir string) error {
+	return evaluate(rootDir, copilotReleaseVerifyChecks())
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -3360,3 +3360,236 @@ func TestCheckCopilotUnsafeFlagsRealRepo(t *testing.T) {
 		t.Fatalf("CheckCopilotUnsafeFlags(real repo) = %v, want nil", err)
 	}
 }
+
+// copilotReleaseVerifyHappyVerifier is a minimal but structurally faithful
+// scripts/verify-upstream-copilot-release.sh: it contains all six help-mode
+// needles (including the escaped whole-flag `grep -Eq` matcher, matched here as
+// a fixed string) and all eleven managed flags.
+const copilotReleaseVerifyHappyVerifier = `#!/usr/bin/env bash
+COPILOT_HELP_MODE="${WORKCELL_COPILOT_RELEASE_HELP_MODE:-auto}"
+COPILOT_NATIVE_HELP_DONE=0
+COPILOT_DOCKER_HELP_DONE=0
+copilot_help_mode() {
+  case "${COPILOT_HELP_MODE}" in
+  auto | native | docker | checksum) ;;
+  esac
+  [[ "${COPILOT_HELP_MODE}" == "checksum" ]] && return 0
+}
+copilot_flag_present() {
+  grep -Eq -- "(^|[^[:alnum:]_-])${flag}([^[:alnum:]_-]|$)" <<<"${help_output}"
+}
+MANAGED_FLAGS=(
+  --allow-tool
+  --available-tools
+  --disable-builtin-mcps
+  --disallow-temp-dir
+  --log-dir
+  --no-ask-user
+  --no-auto-update
+  --no-custom-instructions
+  --no-remote
+  --no-remote-export
+  --secret-env-vars
+)
+`
+
+// copilotReleaseVerifyHappyUpdatePins is a minimal but structurally faithful
+// scripts/update-provider-pins.sh containing the checksum-only verify needle.
+const copilotReleaseVerifyHappyUpdatePins = `#!/usr/bin/env bash
+WORKCELL_COPILOT_RELEASE_HELP_MODE=checksum "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh"
+`
+
+// copilotReleaseVerifyHappyJobValidate is a minimal but structurally faithful
+// scripts/ci/job-validate.sh containing the checksum-only verify needle.
+const copilotReleaseVerifyHappyJobValidate = `#!/usr/bin/env bash
+WORKCELL_COPILOT_RELEASE_HELP_MODE=checksum "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh"
+`
+
+// copilotReleaseVerifyHappyReleaseYML is a minimal but structurally faithful
+// .github/workflows/release.yml containing the docker/smoke and arm64 release-
+// help needles.
+const copilotReleaseVerifyHappyReleaseYML = `name: release
+jobs:
+  container-smoke:
+    env:
+      WORKCELL_COPILOT_RELEASE_HELP_MODE: docker
+      WORKCELL_COPILOT_RELEASE_HELP_IMAGE: workcell:smoke
+  preflight-arm64-copilot-runtime:
+    env:
+      WORKCELL_COPILOT_RELEASE_HELP_IMAGE: workcell:copilot-arm64-smoke
+`
+
+// writeCopilotReleaseVerifyRepo materializes a fake repo with the four files
+// this group reads set to the given bodies; a body of "" means "do not create
+// that file" (unreadable-target case).
+func writeCopilotReleaseVerifyRepo(t *testing.T, verifier, updatePins, jobValidate, releaseYML string) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, body string) {
+		if body == "" {
+			return
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(verifyUpstreamCopilotReleaseRelPath, verifier)
+	write(updateProviderPinsRelPath, updatePins)
+	write(jobValidateRelPath, jobValidate)
+	write(releaseWorkflowRelPath, releaseYML)
+	return root
+}
+
+func TestCheckCopilotReleaseVerify(t *testing.T) {
+	tests := []struct {
+		name        string
+		verifier    string
+		updatePins  string
+		jobValidate string
+		releaseYML  string
+		wantErr     string // "" means expect success
+	}{
+		{
+			name:        "happy path all invariants hold",
+			verifier:    copilotReleaseVerifyHappyVerifier,
+			updatePins:  copilotReleaseVerifyHappyUpdatePins,
+			jobValidate: copilotReleaseVerifyHappyJobValidate,
+			releaseYML:  copilotReleaseVerifyHappyReleaseYML,
+		},
+		{
+			// Help-mode guard (first probe): shares the group message.
+			name:        "verifier missing help-mode default",
+			verifier:    strings.Replace(copilotReleaseVerifyHappyVerifier, `COPILOT_HELP_MODE="${WORKCELL_COPILOT_RELEASE_HELP_MODE:-auto}"`, "COPILOT_HELP_MODE=auto", 1),
+			updatePins:  copilotReleaseVerifyHappyUpdatePins,
+			jobValidate: copilotReleaseVerifyHappyJobValidate,
+			releaseYML:  copilotReleaseVerifyHappyReleaseYML,
+			wantErr:     "Expected Copilot upstream release verifier to track native/Docker help probes separately, support checksum-only paths, and match whole safety flags",
+		},
+		{
+			// Help-mode guard (sixth probe): the escaped whole-flag `grep -Eq`
+			// matcher, matched as a fixed string.
+			name:        "verifier missing whole-flag grep -Eq matcher",
+			verifier:    strings.Replace(copilotReleaseVerifyHappyVerifier, `grep -Eq -- "(^|[^[:alnum:]_-])${flag}([^[:alnum:]_-]|$)"`, "grep -Fq -- \"${flag}\"", 1),
+			updatePins:  copilotReleaseVerifyHappyUpdatePins,
+			jobValidate: copilotReleaseVerifyHappyJobValidate,
+			releaseYML:  copilotReleaseVerifyHappyReleaseYML,
+			wantErr:     "Expected Copilot upstream release verifier to track native/Docker help probes separately, support checksum-only paths, and match whole safety flags",
+		},
+		{
+			// Managed-flag loop item (kindPresent, interpolated message).
+			name:        "verifier missing managed flag",
+			verifier:    strings.Replace(copilotReleaseVerifyHappyVerifier, "--allow-tool", "--other-flag", 1),
+			updatePins:  copilotReleaseVerifyHappyUpdatePins,
+			jobValidate: copilotReleaseVerifyHappyJobValidate,
+			releaseYML:  copilotReleaseVerifyHappyReleaseYML,
+			wantErr:     "Expected Copilot upstream release verifier to require managed flag: --allow-tool",
+		},
+		{
+			// Checksum-only guard (first probe, update-provider-pins.sh).
+			name:        "update-provider-pins missing checksum needle",
+			verifier:    copilotReleaseVerifyHappyVerifier,
+			updatePins:  strings.Replace(copilotReleaseVerifyHappyUpdatePins, "WORKCELL_COPILOT_RELEASE_HELP_MODE=checksum", "WORKCELL_COPILOT_RELEASE_HELP_MODE=docker", 1),
+			jobValidate: copilotReleaseVerifyHappyJobValidate,
+			releaseYML:  copilotReleaseVerifyHappyReleaseYML,
+			wantErr:     "Expected provider bump and routine validate paths to use checksum-only Copilot release verification before smoke images exist",
+		},
+		{
+			// Checksum-only guard (second probe, job-validate.sh): proves the two
+			// ordered probes share one message.
+			name:        "job-validate missing checksum needle",
+			verifier:    copilotReleaseVerifyHappyVerifier,
+			updatePins:  copilotReleaseVerifyHappyUpdatePins,
+			jobValidate: strings.Replace(copilotReleaseVerifyHappyJobValidate, "WORKCELL_COPILOT_RELEASE_HELP_MODE=checksum", "WORKCELL_COPILOT_RELEASE_HELP_MODE=docker", 1),
+			releaseYML:  copilotReleaseVerifyHappyReleaseYML,
+			wantErr:     "Expected provider bump and routine validate paths to use checksum-only Copilot release verification before smoke images exist",
+		},
+		{
+			// Container-smoke guard (first probe, release.yml).
+			name:        "release yml missing docker help mode",
+			verifier:    copilotReleaseVerifyHappyVerifier,
+			updatePins:  copilotReleaseVerifyHappyUpdatePins,
+			jobValidate: copilotReleaseVerifyHappyJobValidate,
+			releaseYML:  strings.Replace(copilotReleaseVerifyHappyReleaseYML, "WORKCELL_COPILOT_RELEASE_HELP_MODE: docker", "WORKCELL_COPILOT_RELEASE_HELP_MODE: native", 1),
+			wantErr:     "Expected release container-smoke job to force Copilot release help verification inside the runtime image",
+		},
+		{
+			// Container-smoke guard (second probe, release.yml): shares the message.
+			name:        "release yml missing smoke help image",
+			verifier:    copilotReleaseVerifyHappyVerifier,
+			updatePins:  copilotReleaseVerifyHappyUpdatePins,
+			jobValidate: copilotReleaseVerifyHappyJobValidate,
+			releaseYML:  strings.Replace(copilotReleaseVerifyHappyReleaseYML, "WORKCELL_COPILOT_RELEASE_HELP_IMAGE: workcell:smoke", "WORKCELL_COPILOT_RELEASE_HELP_IMAGE: workcell:other", 1),
+			wantErr:     "Expected release container-smoke job to force Copilot release help verification inside the runtime image",
+		},
+		{
+			// Arm64 guard (second probe, release.yml): the arm64 smoke image.
+			name:        "release yml missing arm64 help image",
+			verifier:    copilotReleaseVerifyHappyVerifier,
+			updatePins:  copilotReleaseVerifyHappyUpdatePins,
+			jobValidate: copilotReleaseVerifyHappyJobValidate,
+			releaseYML:  strings.Replace(copilotReleaseVerifyHappyReleaseYML, "WORKCELL_COPILOT_RELEASE_HELP_IMAGE: workcell:copilot-arm64-smoke", "WORKCELL_COPILOT_RELEASE_HELP_IMAGE: workcell:other-arm64", 1),
+			wantErr:     "Expected release workflow to verify Copilot release help inside an arm64 runtime image before publication",
+		},
+		{
+			// A missing verifier file is empty content: the first help-mode probe
+			// fails.
+			name:        "missing verifier file",
+			verifier:    "",
+			updatePins:  copilotReleaseVerifyHappyUpdatePins,
+			jobValidate: copilotReleaseVerifyHappyJobValidate,
+			releaseYML:  copilotReleaseVerifyHappyReleaseYML,
+			wantErr:     "Expected Copilot upstream release verifier to track native/Docker help probes separately, support checksum-only paths, and match whole safety flags",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeCopilotReleaseVerifyRepo(t, tc.verifier, tc.updatePins, tc.jobValidate, tc.releaseYML)
+			err := CheckCopilotReleaseVerify(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckCopilotReleaseVerify() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckCopilotReleaseVerify() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckCopilotReleaseVerify() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckCopilotReleaseVerifyCount asserts the check list contains exactly
+// twenty-four invariants, guarding against an accidentally truncated or
+// duplicated migration of the shell block.
+func TestCheckCopilotReleaseVerifyCount(t *testing.T) {
+	got := len(copilotReleaseVerifyChecks())
+	const want = 24
+	if got != want {
+		t.Fatalf("copilotReleaseVerifyChecks() has %d checks, want %d", got, want)
+	}
+}
+
+// TestCheckCopilotReleaseVerifyRealRepo asserts that the real
+// verify-upstream-copilot-release.sh, update-provider-pins.sh, job-validate.sh,
+// and release.yml in this repository satisfy all twenty-four Copilot
+// upstream-release verifier invariants.  This is the key guard against a
+// mis-transcribed needle or a wrong target file: if any Go pattern is not a
+// byte-exact substring of the actual file (or the wrong file), this test fails
+// with the guard's stderr message.
+func TestCheckCopilotReleaseVerifyRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, verifyUpstreamCopilotReleaseRelPath)); err != nil {
+		t.Skipf("real verify-upstream-copilot-release.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckCopilotReleaseVerify(repoRoot); err != nil {
+		t.Fatalf("CheckCopilotReleaseVerify(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -8252,50 +8252,7 @@ if ! grep -Fq "rm -f -- \"\${token_file}\"" "${ROOT_DIR}/runtime/container/provi
 fi
 go_verify_citools workcell-copilot-policy-wrapper "${ROOT_DIR}" || exit 1
 go_verify_citools workcell-copilot-unsafe-flags "${ROOT_DIR}" || exit 1
-# shellcheck disable=SC2016
-if ! grep -Fq 'COPILOT_HELP_MODE="${WORKCELL_COPILOT_RELEASE_HELP_MODE:-auto}"' "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh" ||
-  ! grep -Fq 'COPILOT_NATIVE_HELP_DONE=0' "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh" ||
-  ! grep -Fq 'COPILOT_DOCKER_HELP_DONE=0' "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh" ||
-  ! grep -Fq 'auto | native | docker | checksum)' "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh" ||
-  ! grep -Fq '[[ "${COPILOT_HELP_MODE}" == "checksum" ]] && return 0' "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh" ||
-  ! grep -Fq "grep -Eq -- \"(^|[^[:alnum:]_-])\${flag}([^[:alnum:]_-]|\$)\"" "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh"; then
-  echo "Expected Copilot upstream release verifier to track native/Docker help probes separately, support checksum-only paths, and match whole safety flags" >&2
-  exit 1
-fi
-for copilot_release_help_flag in \
-  '--allow-tool' \
-  '--available-tools' \
-  '--disable-builtin-mcps' \
-  '--disallow-temp-dir' \
-  '--log-dir' \
-  '--no-ask-user' \
-  '--no-auto-update' \
-  '--no-custom-instructions' \
-  '--no-remote' \
-  '--no-remote-export' \
-  '--secret-env-vars'; do
-  if ! grep -Fq -- "${copilot_release_help_flag}" "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh"; then
-    echo "Expected Copilot upstream release verifier to require managed flag: ${copilot_release_help_flag}" >&2
-    exit 1
-  fi
-done
-copilot_checksum_verify_needle="WORKCELL_COPILOT_RELEASE_HELP_MODE=checksum \"\${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh\""
-if ! grep -Fq "${copilot_checksum_verify_needle}" "${ROOT_DIR}/scripts/update-provider-pins.sh" ||
-  ! grep -Fq "${copilot_checksum_verify_needle}" "${ROOT_DIR}/scripts/ci/job-validate.sh"; then
-  echo "Expected provider bump and routine validate paths to use checksum-only Copilot release verification before smoke images exist" >&2
-  exit 1
-fi
-if ! grep -Fq 'WORKCELL_COPILOT_RELEASE_HELP_MODE: docker' "${ROOT_DIR}/.github/workflows/release.yml" ||
-  ! grep -Fq 'WORKCELL_COPILOT_RELEASE_HELP_IMAGE: workcell:smoke' "${ROOT_DIR}/.github/workflows/release.yml"; then
-  echo "Expected release container-smoke job to force Copilot release help verification inside the runtime image" >&2
-  exit 1
-fi
-if ! grep -Fq 'preflight-arm64-copilot-runtime:' "${ROOT_DIR}/.github/workflows/release.yml" ||
-  ! grep -Fq 'WORKCELL_COPILOT_RELEASE_HELP_IMAGE: workcell:copilot-arm64-smoke' "${ROOT_DIR}/.github/workflows/release.yml" ||
-  ! grep -Fq 'preflight-arm64-copilot-runtime' "${ROOT_DIR}/.github/workflows/release.yml"; then
-  echo "Expected release workflow to verify Copilot release help inside an arm64 runtime image before publication" >&2
-  exit 1
-fi
+go_verify_citools workcell-copilot-release-verify "${ROOT_DIR}" || exit 1
 if [[ "$(grep -Fc 'WORKCELL_COPILOT_RELEASE_HELP_MODE: native' "${ROOT_DIR}/.github/workflows/release.yml")" -lt 2 ]]; then
   echo "Expected release workflow to force native Copilot release help verification for amd64 and arm64 lanes" >&2
   exit 1


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 17 of N (larger batch).** Follows #398-#413. Migrates 24 copilot upstream-release-verify invariant checks (former lines 8255-8298).

## What
- **`internal/workcellhardening`**: new `CheckCopilotReleaseVerify(rootDir)` reusing `evaluate()` + `kindPresent` (no new kinds). 24 checks across 4 files: `scripts/verify-upstream-copilot-release.sh` (help-mode guard ×6 + managed-flag loop ×11), `scripts/update-provider-pins.sh` + `scripts/ci/job-validate.sh` (checksum-only guard ×2, AND across both files), `.github/workflows/release.yml` (container-smoke ×2 + arm64 ×3).
- **`cmd/workcell-citools`**: new `workcell-copilot-release-verify` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-copilot-release-verify "${ROOT_DIR}" || exit 1`. Stopped at 8299 (a `grep -Fc … -lt 2` count comparison — not a containment check, deferred to a later kind).

## Wrinkles handled (parity)
- **Variable needle** `copilot_checksum_verify_needle` resolved to its literal (`WORKCELL_COPILOT_RELEASE_HELP_MODE=checksum "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh"`), confirmed in both files, assignment removed.
- **Escaped `grep -Eq` needle** (`grep -Eq -- "(^|[^[:alnum:]_-])${flag}([^[:alnum:]_-]|$)"`) is a `grep -Fq` fixed search → `kindPresent` via Go raw string.
- Multi-probe `||` guards → ordered checks sharing one message; the managed-flag loop → one check per item.

Real repo → exit 0 (proves resolved needles + paths). 6 crafted violations → exit 1 byte-identical. Real-repo assertion + count=24 guard.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 492 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)