### PR TITLE
^R D3: migrate adapter-rule/guard-bash invariants to Go (18 checks, +count-at-least kind)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -111,6 +111,7 @@ func subcommands() []subcommand {
 		{"workcell-copilot-policy-wrapper", "ROOT_DIR", 1, 1, cmdWorkcellCopilotPolicyWrapper},
 		{"workcell-copilot-unsafe-flags", "ROOT_DIR", 1, 1, cmdWorkcellCopilotUnsafeFlags},
 		{"workcell-copilot-release-verify", "ROOT_DIR", 1, 1, cmdWorkcellCopilotReleaseVerify},
+		{"workcell-adapter-rule-guard-bash", "ROOT_DIR", 1, 1, cmdWorkcellAdapterRuleGuardBash},
 	}
 }
 
@@ -642,4 +643,12 @@ func cmdWorkcellCopilotUnsafeFlags(args []string) error {
 // invariant.
 func cmdWorkcellCopilotReleaseVerify(args []string) error {
 	return workcellhardening.CheckCopilotReleaseVerify(args[0])
+}
+
+// cmdWorkcellAdapterRuleGuardBash runs the eighteen adapter-rule / Bash-guard
+// checks migrated out of scripts/verify-invariants.sh; it fails (exit 1 via
+// die()) with the shell's original stderr message for the first violated
+// invariant.
+func cmdWorkcellAdapterRuleGuardBash(args []string) error {
+	return workcellhardening.CheckAdapterRuleGuardBash(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -180,6 +180,22 @@ const jobValidateRelPath = "scripts/ci/job-validate.sh"
 // ${ROOT_DIR}/.github/workflows/release.yml.
 const releaseWorkflowRelPath = ".github/workflows/release.yml"
 
+// codexManagedConfigRelPath and codexRequirementsRelPath are the repo-relative
+// paths to the two Codex adapter rule files.  The adapter-rule/guard-bash block
+// reads both (via the per-check targetFile field) for its provider-mediation
+// bypass-path invariants, mirroring the shell `grep -Fq` probes that ran against
+// ${ROOT_DIR}/adapters/codex/managed_config.toml and
+// ${ROOT_DIR}/adapters/codex/requirements.toml in the codex_rule_file loop.
+const codexManagedConfigRelPath = "adapters/codex/managed_config.toml"
+const codexRequirementsRelPath = "adapters/codex/requirements.toml"
+
+// claudeGuardBashRelPath is the repo-relative path to the Claude adapter Bash
+// guard hook.  The adapter-rule/guard-bash block reads this file (via the
+// per-check targetFile field) for its provider-mediation and home
+// control-plane bypass-path invariants, mirroring the shell `grep -Fq` probes
+// that ran against ${ROOT_DIR}/adapters/claude/hooks/guard-bash.sh.
+const claudeGuardBashRelPath = "adapters/claude/hooks/guard-bash.sh"
+
 // checkKind selects how a check's pattern is matched against the launcher
 // contents.
 type checkKind int
@@ -230,6 +246,14 @@ const (
 	// Unlike kindPresent's single targetFile, evaluate ORs the per-file
 	// containment predicate (holds) across every path in targetFiles.
 	kindPresentInAnyFile
+	// kindCountAtLeast requires the fixed string (pattern) to appear on AT
+	// LEAST minCount lines of the target file, mirroring the shell's
+	// `if [[ "$(grep -Fc 'NEEDLE' file)" -lt N ]]; then ... exit 1`.  As with
+	// `grep -Fc`, matching is line-oriented: holds counts how many lines
+	// CONTAIN the fixed needle (a line with two occurrences still counts
+	// once), not the total number of occurrences, and the check is violated
+	// (returns the message) when that line count is < minCount.
+	kindCountAtLeast
 )
 
 // check is one hardening invariant: how to match, what to match, which
@@ -254,6 +278,11 @@ type check struct {
 	// across these paths, mirroring the shell's multi-file
 	// `grep -Fq -- NEEDLE f1 f2`.
 	targetFiles []string
+	// minCount is the minimum number of lines of the target file that must
+	// contain pattern for a kindCountAtLeast check to hold.  It is used only
+	// by kindCountAtLeast (every other kind ignores it), mirroring the N in
+	// the shell's `grep -Fc ... -lt N` count guard.
+	minCount int
 }
 
 // checks lists the eleven invariants in the same order as the former
@@ -2432,6 +2461,151 @@ func CheckCopilotReleaseVerify(rootDir string) error {
 	return evaluate(rootDir, copilotReleaseVerifyChecks())
 }
 
+// adapterRuleGuardBashChecks lists the eighteen adapter-rule / Bash-guard
+// invariants in the same order as the former inline block in
+// scripts/verify-invariants.sh (the block starting at the release.yml
+// native-help count guard, through the codex_rule_file loop, and ending with
+// the Claude Bash guard checks), so a reviewer can diff the two one-to-one.
+//
+// The block reads four files via the per-check targetFile field:
+// .github/workflows/release.yml (the native-help count guard),
+// adapters/codex/managed_config.toml and adapters/codex/requirements.toml (the
+// codex_rule_file loop), and adapters/claude/hooks/guard-bash.sh (the Bash
+// guard checks).
+//
+// Two shell constructs are flattened into ordered checks sharing one message,
+// exactly as in the earlier groups:
+//
+//   - Each codex_rule_file probe-3 and the guard-bash multi-path probe were a
+//     single shell `if` guarding several `grep -Fq` probes joined by `||`
+//     (every needle must be present); each is expressed here as two/four
+//     ordered kindPresent checks sharing that probe's message, which is
+//     behaviourally identical (any missing needle yields the same stderr and
+//     exit 1 before later checks run).
+//   - The `if grep -Fq '@anthropic-ai/claude-code/cli.js'; then ... exit 1`
+//     probes (present is a violation) become kindAbsent checks.
+//
+// The codex_rule_file loop ran the same four probes against managed_config.toml
+// then requirements.toml, interpolating basename(file) into each message; the
+// file-outer / probe-inner order is preserved here.  The guard-bash
+// provider-wrapper needle is the regex-escaped `provider-wrapper\.sh` (a literal
+// backslash-dot, byte-for-byte as it appears inside the guard's regex), unlike
+// the codex loop's unescaped `provider-wrapper.sh`; the `\\.copilot` and
+// `copilot\.md` needles are likewise copied byte-exact from the guard regex.
+func adapterRuleGuardBashChecks() []check {
+	const guardBypassMessage = "Expected Claude Bash guard to block Copilot provider and home control-plane bypass paths"
+	cs := []check{
+		// Release-workflow native-help count guard: the native help-mode needle
+		// must appear on at least two lines (the amd64 and arm64 lanes).
+		{
+			kind:       kindCountAtLeast,
+			pattern:    "WORKCELL_COPILOT_RELEASE_HELP_MODE: native",
+			minCount:   2,
+			message:    "Expected release workflow to force native Copilot release help verification for amd64 and arm64 lanes",
+			targetFile: releaseWorkflowRelPath,
+		},
+	}
+	// codex_rule_file loop: the same four probes against each rule file, with
+	// basename(file) interpolated into every message.  Probe 3 (the Copilot
+	// mediation-bypass guard) was a two-needle `||` and is two ordered
+	// kindPresent checks sharing one message.
+	for _, f := range []struct{ path, base string }{
+		{codexManagedConfigRelPath, "managed_config.toml"},
+		{codexRequirementsRelPath, "requirements.toml"},
+	} {
+		cs = append(cs,
+			check{
+				kind:       kindPresent,
+				pattern:    "/usr/local/libexec/workcell/provider-wrapper.sh",
+				message:    "Expected " + f.base + " to block direct provider-wrapper launches",
+				targetFile: f.path,
+			},
+			check{
+				kind:       kindPresent,
+				pattern:    "/usr/local/libexec/workcell/real/claude",
+				message:    "Expected " + f.base + " to block the native Claude binary path",
+				targetFile: f.path,
+			},
+			check{
+				kind:       kindPresent,
+				pattern:    "/usr/local/libexec/workcell/core/copilot",
+				message:    "Expected " + f.base + " to block Copilot provider mediation bypass paths",
+				targetFile: f.path,
+			},
+			check{
+				kind:       kindPresent,
+				pattern:    "/usr/local/libexec/workcell/real/copilot",
+				message:    "Expected " + f.base + " to block Copilot provider mediation bypass paths",
+				targetFile: f.path,
+			},
+			check{
+				kind:       kindAbsent,
+				pattern:    "@anthropic-ai/claude-code/cli.js",
+				message:    f.base + " should not reference the removed Claude npm entrypoint",
+				targetFile: f.path,
+			},
+		)
+	}
+	// Claude Bash guard checks.  The provider-wrapper needle carries the
+	// literal backslash-dot from the guard's regex; the multi-path probe (four
+	// needles under one `||` guard) becomes four ordered kindPresent checks
+	// sharing guardBypassMessage.
+	cs = append(cs,
+		check{
+			kind:       kindPresent,
+			pattern:    `/usr/local/libexec/workcell/provider-wrapper\.sh`,
+			message:    "Expected Claude Bash guard to block direct provider-wrapper launches",
+			targetFile: claudeGuardBashRelPath,
+		},
+		check{
+			kind:       kindPresent,
+			pattern:    "/usr/local/libexec/workcell/real/claude",
+			message:    "Expected Claude Bash guard to block direct native Claude binary launches",
+			targetFile: claudeGuardBashRelPath,
+		},
+		check{
+			kind:       kindPresent,
+			pattern:    "/usr/local/libexec/workcell/core/copilot",
+			message:    guardBypassMessage,
+			targetFile: claudeGuardBashRelPath,
+		},
+		check{
+			kind:       kindPresent,
+			pattern:    "/usr/local/libexec/workcell/real/copilot",
+			message:    guardBypassMessage,
+			targetFile: claudeGuardBashRelPath,
+		},
+		check{
+			kind:       kindPresent,
+			pattern:    `\\.copilot`,
+			message:    guardBypassMessage,
+			targetFile: claudeGuardBashRelPath,
+		},
+		check{
+			kind:       kindPresent,
+			pattern:    `copilot\.md`,
+			message:    guardBypassMessage,
+			targetFile: claudeGuardBashRelPath,
+		},
+		check{
+			kind:       kindAbsent,
+			pattern:    "@anthropic-ai/claude-code/cli.js",
+			message:    "Claude Bash guard should not reference the removed Claude npm entrypoint",
+			targetFile: claudeGuardBashRelPath,
+		},
+	)
+	return cs
+}
+
+// CheckAdapterRuleGuardBash runs the eighteen adapter-rule / Bash-guard
+// invariants against the repo rooted at rootDir, in the shell's original order.
+// It returns nil when every invariant holds (the shell's exit 0), or an error
+// whose message equals the shell's stderr for the first violated invariant (the
+// shell's exit 1).
+func CheckAdapterRuleGuardBash(rootDir string) error {
+	return evaluate(rootDir, adapterRuleGuardBashChecks())
+}
+
 // holds reports whether the invariant is satisfied by the launcher text.
 func (c check) holds(text string) bool {
 	switch c.kind {
@@ -2453,6 +2627,17 @@ func (c check) holds(text string) bool {
 		// ORs this across every path in targetFiles to reproduce grep's
 		// multi-file OR semantics.
 		return strings.Contains(text, c.pattern)
+	case kindCountAtLeast:
+		// Mirror `grep -Fc`: count how many LINES contain the fixed needle
+		// (a line with multiple occurrences still counts once), and hold only
+		// when that line count is at least minCount.
+		count := 0
+		for _, line := range strings.Split(text, "\n") {
+			if strings.Contains(line, c.pattern) {
+				count++
+			}
+		}
+		return count >= c.minCount
 	case kindAbsent:
 		return !strings.Contains(text, c.pattern)
 	case kindRegexAbsent:

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -3593,3 +3593,255 @@ func TestCheckCopilotReleaseVerifyRealRepo(t *testing.T) {
 		t.Fatalf("CheckCopilotReleaseVerify(real repo) = %v, want nil", err)
 	}
 }
+
+// adapterRuleGuardBashHappyReleaseYML is a minimal .github/workflows/release.yml
+// with the native help-mode needle on exactly two lines (the amd64 and arm64
+// lanes), satisfying the kindCountAtLeast(2) guard.
+const adapterRuleGuardBashHappyReleaseYML = `name: release
+jobs:
+  preflight-amd64:
+    env:
+      WORKCELL_COPILOT_RELEASE_HELP_MODE: native
+  preflight-arm64:
+    env:
+      WORKCELL_COPILOT_RELEASE_HELP_MODE: native
+`
+
+// adapterRuleGuardBashHappyCodexRule is a minimal Codex rule file (used for both
+// managed_config.toml and requirements.toml) containing the four required
+// bypass-path needles and NOT the removed npm entrypoint.
+const adapterRuleGuardBashHappyCodexRule = `# codex rule
+deny = [
+  "/usr/local/libexec/workcell/provider-wrapper.sh",
+  "/usr/local/libexec/workcell/real/claude",
+  "/usr/local/libexec/workcell/core/copilot",
+  "/usr/local/libexec/workcell/real/copilot",
+]
+`
+
+// adapterRuleGuardBashHappyGuard is a minimal adapters/claude/hooks/guard-bash.sh
+// containing the regex-escaped provider-wrapper needle (literal backslash-dot),
+// the two Copilot provider paths, the escaped home-control-plane needles
+// (`\\.copilot`, `copilot\.md`), and NOT the removed npm entrypoint.
+const adapterRuleGuardBashHappyGuard = `#!/usr/bin/env bash
+blocked_regex="/usr/local/libexec/workcell/provider-wrapper\.sh"
+blocked_regex+="|/usr/local/libexec/workcell/real/claude"
+blocked_regex+="|/usr/local/libexec/workcell/core/copilot"
+blocked_regex+="|/usr/local/libexec/workcell/real/copilot"
+home_control_regex="(~|/state/agent-home)/(\\.claude|\\.copilot|\\.gemini)"
+doc_regex="copilot\.md"
+`
+
+// writeAdapterRuleGuardBashRepo materializes a fake repo with the four files
+// this group reads set to the given bodies; a body of "" means "do not create
+// that file" (unreadable-target case).
+func writeAdapterRuleGuardBashRepo(t *testing.T, releaseYML, managedConfig, requirements, guardBash string) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, body string) {
+		if body == "" {
+			return
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(releaseWorkflowRelPath, releaseYML)
+	write(codexManagedConfigRelPath, managedConfig)
+	write(codexRequirementsRelPath, requirements)
+	write(claudeGuardBashRelPath, guardBash)
+	return root
+}
+
+func TestCheckAdapterRuleGuardBash(t *testing.T) {
+	tests := []struct {
+		name          string
+		releaseYML    string
+		managedConfig string
+		requirements  string
+		guardBash     string
+		wantErr       string // "" means expect success
+	}{
+		{
+			name:          "happy path all invariants hold",
+			releaseYML:    adapterRuleGuardBashHappyReleaseYML,
+			managedConfig: adapterRuleGuardBashHappyCodexRule,
+			requirements:  adapterRuleGuardBashHappyCodexRule,
+			guardBash:     adapterRuleGuardBashHappyGuard,
+		},
+		{
+			// kindCountAtLeast: zero native lines fails the count guard.
+			name:          "release yml zero native lines fails count",
+			releaseYML:    strings.ReplaceAll(adapterRuleGuardBashHappyReleaseYML, "WORKCELL_COPILOT_RELEASE_HELP_MODE: native", "WORKCELL_COPILOT_RELEASE_HELP_MODE: docker"),
+			managedConfig: adapterRuleGuardBashHappyCodexRule,
+			requirements:  adapterRuleGuardBashHappyCodexRule,
+			guardBash:     adapterRuleGuardBashHappyGuard,
+			wantErr:       "Expected release workflow to force native Copilot release help verification for amd64 and arm64 lanes",
+		},
+		{
+			// kindCountAtLeast: one native line fails the count guard (< 2).
+			name:          "release yml one native line fails count",
+			releaseYML:    strings.Replace(adapterRuleGuardBashHappyReleaseYML, "WORKCELL_COPILOT_RELEASE_HELP_MODE: native", "WORKCELL_COPILOT_RELEASE_HELP_MODE: docker", 1),
+			managedConfig: adapterRuleGuardBashHappyCodexRule,
+			requirements:  adapterRuleGuardBashHappyCodexRule,
+			guardBash:     adapterRuleGuardBashHappyGuard,
+			wantErr:       "Expected release workflow to force native Copilot release help verification for amd64 and arm64 lanes",
+		},
+		{
+			// kindCountAtLeast line semantics: two occurrences on ONE line count
+			// as one matching line (grep -Fc counts LINES, not occurrences), so
+			// this still fails the minCount(2) guard.
+			name:          "release yml two occurrences on one line fails count",
+			releaseYML:    "name: release\nenv: WORKCELL_COPILOT_RELEASE_HELP_MODE: native WORKCELL_COPILOT_RELEASE_HELP_MODE: native\n",
+			managedConfig: adapterRuleGuardBashHappyCodexRule,
+			requirements:  adapterRuleGuardBashHappyCodexRule,
+			guardBash:     adapterRuleGuardBashHappyGuard,
+			wantErr:       "Expected release workflow to force native Copilot release help verification for amd64 and arm64 lanes",
+		},
+		{
+			// kindCountAtLeast: three native lines satisfies the count guard.
+			name:          "release yml three native lines passes count",
+			releaseYML:    adapterRuleGuardBashHappyReleaseYML + "      WORKCELL_COPILOT_RELEASE_HELP_MODE: native\n",
+			managedConfig: adapterRuleGuardBashHappyCodexRule,
+			requirements:  adapterRuleGuardBashHappyCodexRule,
+			guardBash:     adapterRuleGuardBashHappyGuard,
+		},
+		{
+			// codex_rule_file loop, managed_config.toml, probe 1.
+			name:          "managed_config missing provider-wrapper path",
+			releaseYML:    adapterRuleGuardBashHappyReleaseYML,
+			managedConfig: strings.Replace(adapterRuleGuardBashHappyCodexRule, "/usr/local/libexec/workcell/provider-wrapper.sh", "/other/path", 1),
+			requirements:  adapterRuleGuardBashHappyCodexRule,
+			guardBash:     adapterRuleGuardBashHappyGuard,
+			wantErr:       "Expected managed_config.toml to block direct provider-wrapper launches",
+		},
+		{
+			// codex_rule_file loop, managed_config.toml, probe 3 (second needle):
+			// proves the two-needle probe shares one message.
+			name:          "managed_config missing real copilot path",
+			releaseYML:    adapterRuleGuardBashHappyReleaseYML,
+			managedConfig: strings.Replace(adapterRuleGuardBashHappyCodexRule, "/usr/local/libexec/workcell/real/copilot", "/other/copilot", 1),
+			requirements:  adapterRuleGuardBashHappyCodexRule,
+			guardBash:     adapterRuleGuardBashHappyGuard,
+			wantErr:       "Expected managed_config.toml to block Copilot provider mediation bypass paths",
+		},
+		{
+			// codex_rule_file loop, managed_config.toml, probe 4 (negated cli.js).
+			name:          "managed_config references removed npm entrypoint",
+			releaseYML:    adapterRuleGuardBashHappyReleaseYML,
+			managedConfig: adapterRuleGuardBashHappyCodexRule + "allow = [\"@anthropic-ai/claude-code/cli.js\"]\n",
+			requirements:  adapterRuleGuardBashHappyCodexRule,
+			guardBash:     adapterRuleGuardBashHappyGuard,
+			wantErr:       "managed_config.toml should not reference the removed Claude npm entrypoint",
+		},
+		{
+			// codex_rule_file loop, requirements.toml, probe 2: proves the loop
+			// runs the same probes against the second file with its basename.
+			name:          "requirements missing native claude path",
+			releaseYML:    adapterRuleGuardBashHappyReleaseYML,
+			managedConfig: adapterRuleGuardBashHappyCodexRule,
+			requirements:  strings.Replace(adapterRuleGuardBashHappyCodexRule, "/usr/local/libexec/workcell/real/claude", "/other/claude", 1),
+			guardBash:     adapterRuleGuardBashHappyGuard,
+			wantErr:       "Expected requirements.toml to block the native Claude binary path",
+		},
+		{
+			// guard-bash.sh: the regex-escaped provider-wrapper needle carries a
+			// literal backslash-dot; removing it fails this probe.
+			name:          "guard missing escaped provider-wrapper needle",
+			releaseYML:    adapterRuleGuardBashHappyReleaseYML,
+			managedConfig: adapterRuleGuardBashHappyCodexRule,
+			requirements:  adapterRuleGuardBashHappyCodexRule,
+			guardBash:     strings.Replace(adapterRuleGuardBashHappyGuard, `/usr/local/libexec/workcell/provider-wrapper\.sh`, "/other/wrapper", 1),
+			wantErr:       "Expected Claude Bash guard to block direct provider-wrapper launches",
+		},
+		{
+			// guard-bash.sh multi-path probe: the `\\.copilot` home-control needle
+			// (two literal backslashes) shares guardBypassMessage.
+			name:          "guard missing double-backslash copilot needle",
+			releaseYML:    adapterRuleGuardBashHappyReleaseYML,
+			managedConfig: adapterRuleGuardBashHappyCodexRule,
+			requirements:  adapterRuleGuardBashHappyCodexRule,
+			guardBash:     strings.Replace(adapterRuleGuardBashHappyGuard, `\\.copilot`, `\\.other`, 1),
+			wantErr:       "Expected Claude Bash guard to block Copilot provider and home control-plane bypass paths",
+		},
+		{
+			// guard-bash.sh multi-path probe: the `copilot\.md` needle shares the
+			// same message.
+			name:          "guard missing copilot md needle",
+			releaseYML:    adapterRuleGuardBashHappyReleaseYML,
+			managedConfig: adapterRuleGuardBashHappyCodexRule,
+			requirements:  adapterRuleGuardBashHappyCodexRule,
+			guardBash:     strings.Replace(adapterRuleGuardBashHappyGuard, `copilot\.md`, `other\.md`, 1),
+			wantErr:       "Expected Claude Bash guard to block Copilot provider and home control-plane bypass paths",
+		},
+		{
+			// guard-bash.sh: negated cli.js check (present is a violation).
+			name:          "guard references removed npm entrypoint",
+			releaseYML:    adapterRuleGuardBashHappyReleaseYML,
+			managedConfig: adapterRuleGuardBashHappyCodexRule,
+			requirements:  adapterRuleGuardBashHappyCodexRule,
+			guardBash:     adapterRuleGuardBashHappyGuard + "legacy=\"@anthropic-ai/claude-code/cli.js\"\n",
+			wantErr:       "Claude Bash guard should not reference the removed Claude npm entrypoint",
+		},
+		{
+			// A missing release.yml is empty content: zero native lines, so the
+			// first (count) check fails.
+			name:          "missing release yml",
+			releaseYML:    "",
+			managedConfig: adapterRuleGuardBashHappyCodexRule,
+			requirements:  adapterRuleGuardBashHappyCodexRule,
+			guardBash:     adapterRuleGuardBashHappyGuard,
+			wantErr:       "Expected release workflow to force native Copilot release help verification for amd64 and arm64 lanes",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeAdapterRuleGuardBashRepo(t, tc.releaseYML, tc.managedConfig, tc.requirements, tc.guardBash)
+			err := CheckAdapterRuleGuardBash(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckAdapterRuleGuardBash() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckAdapterRuleGuardBash() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckAdapterRuleGuardBash() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckAdapterRuleGuardBashCount asserts the check list contains exactly
+// eighteen invariants, guarding against an accidentally truncated or duplicated
+// migration of the shell block.
+func TestCheckAdapterRuleGuardBashCount(t *testing.T) {
+	got := len(adapterRuleGuardBashChecks())
+	const want = 18
+	if got != want {
+		t.Fatalf("adapterRuleGuardBashChecks() has %d checks, want %d", got, want)
+	}
+}
+
+// TestCheckAdapterRuleGuardBashRealRepo asserts that the real release.yml, the
+// two Codex rule files, and guard-bash.sh in this repository satisfy all
+// eighteen adapter-rule / Bash-guard invariants.  This is the key guard against
+// a mis-transcribed needle or a wrong target file: if any Go pattern is not a
+// byte-exact substring of the actual file (or the wrong file), this test fails
+// with the guard's stderr message.
+func TestCheckAdapterRuleGuardBashRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, claudeGuardBashRelPath)); err != nil {
+		t.Skipf("real guard-bash.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckAdapterRuleGuardBash(repoRoot); err != nil {
+		t.Fatalf("CheckAdapterRuleGuardBash(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -8253,50 +8253,7 @@ fi
 go_verify_citools workcell-copilot-policy-wrapper "${ROOT_DIR}" || exit 1
 go_verify_citools workcell-copilot-unsafe-flags "${ROOT_DIR}" || exit 1
 go_verify_citools workcell-copilot-release-verify "${ROOT_DIR}" || exit 1
-if [[ "$(grep -Fc 'WORKCELL_COPILOT_RELEASE_HELP_MODE: native' "${ROOT_DIR}/.github/workflows/release.yml")" -lt 2 ]]; then
-  echo "Expected release workflow to force native Copilot release help verification for amd64 and arm64 lanes" >&2
-  exit 1
-fi
-for codex_rule_file in \
-  "${ROOT_DIR}/adapters/codex/managed_config.toml" \
-  "${ROOT_DIR}/adapters/codex/requirements.toml"; do
-  if ! grep -Fq '/usr/local/libexec/workcell/provider-wrapper.sh' "${codex_rule_file}"; then
-    echo "Expected $(basename "${codex_rule_file}") to block direct provider-wrapper launches" >&2
-    exit 1
-  fi
-  if ! grep -Fq '/usr/local/libexec/workcell/real/claude' "${codex_rule_file}"; then
-    echo "Expected $(basename "${codex_rule_file}") to block the native Claude binary path" >&2
-    exit 1
-  fi
-  if ! grep -Fq '/usr/local/libexec/workcell/core/copilot' "${codex_rule_file}" ||
-    ! grep -Fq '/usr/local/libexec/workcell/real/copilot' "${codex_rule_file}"; then
-    echo "Expected $(basename "${codex_rule_file}") to block Copilot provider mediation bypass paths" >&2
-    exit 1
-  fi
-  if grep -Fq '@anthropic-ai/claude-code/cli.js' "${codex_rule_file}"; then
-    echo "$(basename "${codex_rule_file}") should not reference the removed Claude npm entrypoint" >&2
-    exit 1
-  fi
-done
-if ! grep -Fq '/usr/local/libexec/workcell/provider-wrapper\.sh' "${ROOT_DIR}/adapters/claude/hooks/guard-bash.sh"; then
-  echo "Expected Claude Bash guard to block direct provider-wrapper launches" >&2
-  exit 1
-fi
-if ! grep -Fq '/usr/local/libexec/workcell/real/claude' "${ROOT_DIR}/adapters/claude/hooks/guard-bash.sh"; then
-  echo "Expected Claude Bash guard to block direct native Claude binary launches" >&2
-  exit 1
-fi
-if ! grep -Fq '/usr/local/libexec/workcell/core/copilot' "${ROOT_DIR}/adapters/claude/hooks/guard-bash.sh" ||
-  ! grep -Fq '/usr/local/libexec/workcell/real/copilot' "${ROOT_DIR}/adapters/claude/hooks/guard-bash.sh" ||
-  ! grep -Fq '\\.copilot' "${ROOT_DIR}/adapters/claude/hooks/guard-bash.sh" ||
-  ! grep -Fq 'copilot\.md' "${ROOT_DIR}/adapters/claude/hooks/guard-bash.sh"; then
-  echo "Expected Claude Bash guard to block Copilot provider and home control-plane bypass paths" >&2
-  exit 1
-fi
-if grep -Fq '@anthropic-ai/claude-code/cli.js' "${ROOT_DIR}/adapters/claude/hooks/guard-bash.sh"; then
-  echo "Claude Bash guard should not reference the removed Claude npm entrypoint" >&2
-  exit 1
-fi
+go_verify_citools workcell-adapter-rule-guard-bash "${ROOT_DIR}" || exit 1
 
 if ! awk '
   /^[[:space:]]*acquire_profile_lock "\$\{COLIMA_PROFILE\}"$/ { seen_lock = 1; next }


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 18 of N (larger batch).** Follows #398-#414. Migrates 18 adapter-rule / guard-bash invariant checks (former lines 8256-8299).

## What
- **`internal/workcellhardening`**: new `CheckAdapterRuleGuardBash(rootDir)`. 18 checks: 1 `kindCountAtLeast` (release.yml), 10 codex-rule loop (`managed_config.toml`/`requirements.toml` × [3 present incl. a 2-needle `||`, 1 absent], basename messages), 7 guard-bash.sh (present + a 4-needle `||` + a negated `cli.js` absent).
- **New kind `kindCountAtLeast` + `minCount int`**: mirrors `[[ "$(grep -Fc NEEDLE file)" -lt N ]]`. `grep -Fc` counts matching **lines**, so it counts lines containing the needle (two occurrences on one line count once) and fails when `< minCount`. Tested explicitly: 0/1 line → fail, 2-on-one-line → fail (proves line-not-occurrence counting), 2/3 lines → pass.
- **`cmd/workcell-citools`**: new `workcell-adapter-rule-guard-bash` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-adapter-rule-guard-bash "${ROOT_DIR}" || exit 1`. Stopped at 8301 (the following `awk`/`sed` ordered-subsequence matchers need dedicated kinds — a later increment).

## Parity
Literal-backslash needles (`provider-wrapper\.sh`, `\\.copilot`, `copilot\.md`) copied byte-exact as Go raw strings and verified as `grep -Fq` substrings. Real repo → exit 0; 7 crafted violations → exit 1 byte-identical. Real-repo assertion + count=18 guard.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 491 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)