### PR TITLE
^R D3: migrate inspect/assurance grep-loop invariants to Go (25 checks)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -112,6 +112,7 @@ func subcommands() []subcommand {
 		{"workcell-copilot-unsafe-flags", "ROOT_DIR", 1, 1, cmdWorkcellCopilotUnsafeFlags},
 		{"workcell-copilot-release-verify", "ROOT_DIR", 1, 1, cmdWorkcellCopilotReleaseVerify},
 		{"workcell-adapter-rule-guard-bash", "ROOT_DIR", 1, 1, cmdWorkcellAdapterRuleGuardBash},
+		{"workcell-inspect-assurance-loops", "ROOT_DIR", 1, 1, cmdWorkcellInspectAssuranceLoops},
 	}
 }
 
@@ -651,4 +652,12 @@ func cmdWorkcellCopilotReleaseVerify(args []string) error {
 // invariant.
 func cmdWorkcellAdapterRuleGuardBash(args []string) error {
 	return workcellhardening.CheckAdapterRuleGuardBash(args[0])
+}
+
+// cmdWorkcellInspectAssuranceLoops runs the twenty-five --inspect /
+// session-assurance checks migrated out of scripts/verify-invariants.sh; it
+// fails (exit 1 via die()) with the shell's original stderr message for the
+// first violated invariant.
+func cmdWorkcellInspectAssuranceLoops(args []string) error {
+	return workcellhardening.CheckInspectAssuranceLoops(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -196,6 +196,13 @@ const codexRequirementsRelPath = "adapters/codex/requirements.toml"
 // that ran against ${ROOT_DIR}/adapters/claude/hooks/guard-bash.sh.
 const claudeGuardBashRelPath = "adapters/claude/hooks/guard-bash.sh"
 
+// assuranceRelPath is the repo-relative path to the in-container session
+// assurance script.  The inspect-assurance-loops block's audit-log-field loop
+// reads this file alongside scripts/workcell (via the kindPresentInAnyFile
+// targetFiles field), mirroring the shell's multi-file
+// `grep -Fq -- FIELD scripts/workcell runtime/container/assurance.sh`.
+const assuranceRelPath = "runtime/container/assurance.sh"
+
 // checkKind selects how a check's pattern is matched against the launcher
 // contents.
 type checkKind int
@@ -2604,6 +2611,125 @@ func adapterRuleGuardBashChecks() []check {
 // shell's exit 1).
 func CheckAdapterRuleGuardBash(rootDir string) error {
 	return evaluate(rootDir, adapterRuleGuardBashChecks())
+}
+
+// inspectMountViewNeedles are the five workcell mount-view validation snippets
+// the shell's first `for needle in ...` loop required in scripts/workcell via
+// `grep -Fq -- "${needle}" "${ROOT_DIR}/scripts/workcell"`.  Each is fixed-string
+// containment (some carry `()` or `${...}` treated literally by `grep -F`).
+var inspectMountViewNeedles = []string{
+	"workspace_runtime_probe_path()",
+	"validate_colima_runtime_workspace_view()",
+	`validate_colima_runtime_workspace_view "${profile}" "${workspace}"`,
+	"Refreshing managed Colima profile ${COLIMA_PROFILE} because the running VM is not exposing the expected workspace contents.",
+	"Refreshing managed Colima profile ${COLIMA_PROFILE} because the started VM did not expose the expected workspace view.",
+}
+
+// inspectEgressSafeCwdNeedles are the three egress-helper safe-cwd snippets the
+// shell's second loop required in scripts/colima-egress-allowlist.sh via
+// `grep -Fq -- "${needle}" "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"`.
+var inspectEgressSafeCwdNeedles = []string{
+	`cd "${home}" &&`,
+	"cd / &&",
+	"LIMA_WORKDIR=/",
+}
+
+// inspectContractTokens are the eight --inspect contract tokens the shell's
+// `for token in ...` loop required in scripts/workcell via
+// `grep -Fq -- "${token}" "${ROOT_DIR}/scripts/workcell"`.
+var inspectContractTokens = []string{
+	"--inspect",
+	"print_inspect_state",
+	"provider_native_sandbox_configured",
+	"provider_native_sandbox_effective",
+	"provider_native_sandbox_reason",
+	"codex",
+	"claude",
+	"gemini",
+}
+
+// inspectAuditLogFields are the nine audit-log fields the shell's `for field in
+// ...` loop required in scripts/workcell OR runtime/container/assurance.sh.  Its
+// guard `! grep -Fq -- "$field" workcell && ! grep -Fq -- "$field" assurance.sh`
+// fails only when the field is absent from BOTH files, so each maps to a
+// kindPresentInAnyFile check over those two files.
+var inspectAuditLogFields = []string{
+	"workspace",
+	"network_policy",
+	"session_assurance_initial",
+	"provider_native_sandbox_configured",
+	"provider_native_sandbox_effective",
+	"provider_native_sandbox_reason",
+	"codex",
+	"claude",
+	"gemini",
+}
+
+// inspectAssuranceLoopsChecks lists the twenty-five --inspect / session-assurance
+// invariants in the same order as the four contiguous `for` loops they were
+// migrated from in scripts/verify-invariants.sh, so a reviewer can diff the two
+// one-to-one.
+//
+// Matching semantics mirror the shell exactly:
+//   - Loop 1 (mount-view) and Loop 3 (--inspect contract tokens) each ran
+//     `grep -Fq -- NEEDLE scripts/workcell`, so every item is a kindPresent
+//     check (default targetFile scripts/workcell) whose message interpolates the
+//     loop variable exactly as the shell's `echo` did.
+//   - Loop 2 (egress safe-cwd) ran `grep -Fq -- NEEDLE
+//     scripts/colima-egress-allowlist.sh`, so each item is a kindPresent check
+//     with targetFile colimaEgressAllowlistRelPath.
+//   - Loop 4 (audit-log field) ran `! grep -Fq FIELD workcell && ! grep -Fq
+//     FIELD assurance.sh` — a violation only when the field is absent from BOTH
+//     files — so each item is a kindPresentInAnyFile check over those two files.
+//
+// Every needle is fixed-string containment (`grep -Fq`), so glob/regex
+// metacharacters in the items are matched literally.
+func inspectAssuranceLoopsChecks() []check {
+	var cs []check
+	// Loop 1: mount-view validation snippets in scripts/workcell.
+	for _, needle := range inspectMountViewNeedles {
+		cs = append(cs, check{
+			kind:    kindPresent,
+			pattern: needle,
+			message: "Expected workcell mount-view validation snippet missing: " + needle,
+		})
+	}
+	// Loop 2: safe-cwd snippets in scripts/colima-egress-allowlist.sh.
+	for _, needle := range inspectEgressSafeCwdNeedles {
+		cs = append(cs, check{
+			kind:       kindPresent,
+			pattern:    needle,
+			message:    "Expected egress helper safe-cwd snippet missing: " + needle,
+			targetFile: colimaEgressAllowlistRelPath,
+		})
+	}
+	// Loop 3: --inspect contract tokens in scripts/workcell.
+	for _, token := range inspectContractTokens {
+		cs = append(cs, check{
+			kind:    kindPresent,
+			pattern: token,
+			message: "Expected workcell to contain --inspect contract token: " + token,
+		})
+	}
+	// Loop 4: audit-log fields present in scripts/workcell OR assurance.sh.
+	for _, field := range inspectAuditLogFields {
+		cs = append(cs, check{
+			kind:        kindPresentInAnyFile,
+			pattern:     field,
+			message:     "Expected audit log field referenced in control scripts: " + field,
+			targetFiles: []string{launcherRelPath, assuranceRelPath},
+		})
+	}
+	return cs
+}
+
+// CheckInspectAssuranceLoops runs the twenty-five --inspect / session-assurance
+// invariants against the repo rooted at rootDir, in the shell's original order.
+// It returns nil when every invariant holds (the shell's exit 0), or an error
+// whose message equals the shell's stderr for the first violated invariant (the
+// shell's exit 1).
+func CheckInspectAssuranceLoops(rootDir string) error {
+	return evaluate(rootDir, inspectAssuranceLoopsChecks())
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -3845,3 +3845,177 @@ func TestCheckAdapterRuleGuardBashRealRepo(t *testing.T) {
 		t.Fatalf("CheckAdapterRuleGuardBash(real repo) = %v, want nil", err)
 	}
 }
+
+// inspectAssuranceHappyWorkcell is a minimal scripts/workcell containing every
+// needle the mount-view loop, the --inspect contract-token loop, and the
+// audit-log-field loop require, so all three pass with an empty assurance.sh.
+const inspectAssuranceHappyWorkcell = `#!/usr/bin/env bash
+workspace_runtime_probe_path() { :; }
+validate_colima_runtime_workspace_view() { :; }
+validate_colima_runtime_workspace_view "${profile}" "${workspace}"
+# Refreshing managed Colima profile ${COLIMA_PROFILE} because the running VM is not exposing the expected workspace contents.
+# Refreshing managed Colima profile ${COLIMA_PROFILE} because the started VM did not expose the expected workspace view.
+workcell --inspect
+print_inspect_state
+provider_native_sandbox_configured
+provider_native_sandbox_effective
+provider_native_sandbox_reason
+codex claude gemini
+network_policy
+session_assurance_initial
+`
+
+// inspectAssuranceHappyColima is a minimal scripts/colima-egress-allowlist.sh
+// containing the three safe-cwd snippets the second loop requires.
+const inspectAssuranceHappyColima = `#!/usr/bin/env bash
+cd "${home}" &&
+cd / &&
+LIMA_WORKDIR=/
+`
+
+// writeInspectAssuranceRepo materializes a fake repo with the three files this
+// group reads set to the given bodies; a body of "" means "do not create that
+// file" (unreadable-target case).
+func writeInspectAssuranceRepo(t *testing.T, workcell, colima, assurance string) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, body string) {
+		if body == "" {
+			return
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(launcherRelPath, workcell)
+	write(colimaEgressAllowlistRelPath, colima)
+	write(assuranceRelPath, assurance)
+	return root
+}
+
+func TestCheckInspectAssuranceLoops(t *testing.T) {
+	tests := []struct {
+		name      string
+		workcell  string
+		colima    string
+		assurance string
+		wantErr   string // "" means expect success
+	}{
+		{
+			name:      "happy path all invariants hold",
+			workcell:  inspectAssuranceHappyWorkcell,
+			colima:    inspectAssuranceHappyColima,
+			assurance: "#!/usr/bin/env bash\n",
+		},
+		{
+			// Loop 1 (mount-view): a removed snippet fails with the interpolated
+			// needle message.
+			name:      "workcell missing mount-view snippet",
+			workcell:  strings.Replace(inspectAssuranceHappyWorkcell, "workspace_runtime_probe_path()", "", 1),
+			colima:    inspectAssuranceHappyColima,
+			assurance: "#!/usr/bin/env bash\n",
+			wantErr:   "Expected workcell mount-view validation snippet missing: workspace_runtime_probe_path()",
+		},
+		{
+			// Loop 2 (egress safe-cwd): a removed snippet in the colima helper
+			// fails; the item carries `/` matched literally by grep -F.
+			name:      "colima helper missing safe-cwd snippet",
+			workcell:  inspectAssuranceHappyWorkcell,
+			colima:    strings.Replace(inspectAssuranceHappyColima, "LIMA_WORKDIR=/", "", 1),
+			assurance: "#!/usr/bin/env bash\n",
+			wantErr:   "Expected egress helper safe-cwd snippet missing: LIMA_WORKDIR=/",
+		},
+		{
+			// Loop 3 (--inspect contract tokens): a removed token in workcell fails.
+			name:      "workcell missing --inspect contract token",
+			workcell:  strings.Replace(inspectAssuranceHappyWorkcell, "print_inspect_state", "", 1),
+			colima:    inspectAssuranceHappyColima,
+			assurance: "#!/usr/bin/env bash\n",
+			wantErr:   "Expected workcell to contain --inspect contract token: print_inspect_state",
+		},
+		{
+			// Loop 4 (audit-log field) present-in-any: present in workcell only →
+			// pass (assurance.sh does not mention it).
+			name:      "audit field present in workcell only passes",
+			workcell:  inspectAssuranceHappyWorkcell,
+			colima:    inspectAssuranceHappyColima,
+			assurance: "#!/usr/bin/env bash\n",
+		},
+		{
+			// Loop 4 present-in-any: present in assurance.sh only → pass (the
+			// field is removed from workcell but the OR is satisfied by assurance).
+			name:      "audit field present in assurance only passes",
+			workcell:  strings.Replace(inspectAssuranceHappyWorkcell, "network_policy", "", 1),
+			colima:    inspectAssuranceHappyColima,
+			assurance: "#!/usr/bin/env bash\nnetwork_policy\n",
+		},
+		{
+			// Loop 4 present-in-any: absent from BOTH files → fail with the
+			// interpolated field message.
+			name:      "audit field absent from both files fails",
+			workcell:  strings.Replace(inspectAssuranceHappyWorkcell, "network_policy", "", 1),
+			colima:    inspectAssuranceHappyColima,
+			assurance: "#!/usr/bin/env bash\n",
+			wantErr:   "Expected audit log field referenced in control scripts: network_policy",
+		},
+		{
+			// A missing scripts/workcell is empty content: the first mount-view
+			// kindPresent check fails.
+			name:      "missing workcell file",
+			workcell:  "",
+			colima:    inspectAssuranceHappyColima,
+			assurance: "#!/usr/bin/env bash\n",
+			wantErr:   "Expected workcell mount-view validation snippet missing: workspace_runtime_probe_path()",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeInspectAssuranceRepo(t, tc.workcell, tc.colima, tc.assurance)
+			err := CheckInspectAssuranceLoops(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckInspectAssuranceLoops() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckInspectAssuranceLoops() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckInspectAssuranceLoops() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckInspectAssuranceLoopsCount asserts the check list contains exactly
+// twenty-five invariants, guarding against an accidentally truncated or
+// duplicated migration of the four shell loops.
+func TestCheckInspectAssuranceLoopsCount(t *testing.T) {
+	got := len(inspectAssuranceLoopsChecks())
+	const want = 25
+	if got != want {
+		t.Fatalf("inspectAssuranceLoopsChecks() has %d checks, want %d", got, want)
+	}
+}
+
+// TestCheckInspectAssuranceLoopsRealRepo asserts that the real scripts/workcell,
+// scripts/colima-egress-allowlist.sh, and runtime/container/assurance.sh in this
+// repository satisfy all twenty-five --inspect / session-assurance invariants.
+// This is the key guard against a mis-transcribed needle or a wrong target file:
+// if any Go pattern is not a byte-exact substring of the actual file(s), this
+// test fails with the guard's stderr message.
+func TestCheckInspectAssuranceLoopsRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, launcherRelPath)); err != nil {
+		t.Skipf("real scripts/workcell not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckInspectAssuranceLoops(repoRoot); err != nil {
+		t.Fatalf("CheckInspectAssuranceLoops(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -8286,40 +8286,18 @@ if ! sed -n '/^acquire_profile_lock()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | a
   exit 1
 fi
 
-# shellcheck disable=SC2016
-for needle in \
-  'workspace_runtime_probe_path()' \
-  'validate_colima_runtime_workspace_view()' \
-  'validate_colima_runtime_workspace_view "${profile}" "${workspace}"' \
-  'Refreshing managed Colima profile ${COLIMA_PROFILE} because the running VM is not exposing the expected workspace contents.' \
-  'Refreshing managed Colima profile ${COLIMA_PROFILE} because the started VM did not expose the expected workspace view.'; do
-  if ! grep -Fq -- "${needle}" "${ROOT_DIR}/scripts/workcell"; then
-    echo "Expected workcell mount-view validation snippet missing: ${needle}" >&2
-    exit 1
-  fi
-done
-
-# shellcheck disable=SC2016
-for needle in 'cd "${home}" &&' 'cd / &&' 'LIMA_WORKDIR=/'; do
-  if ! grep -Fq -- "${needle}" "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-    echo "Expected egress helper safe-cwd snippet missing: ${needle}" >&2
-    exit 1
-  fi
-done
-
-for token in '--inspect' 'print_inspect_state' 'provider_native_sandbox_configured' 'provider_native_sandbox_effective' 'provider_native_sandbox_reason' 'codex' 'claude' 'gemini'; do
-  if ! grep -Fq -- "${token}" "${ROOT_DIR}/scripts/workcell"; then
-    echo "Expected workcell to contain --inspect contract token: ${token}" >&2
-    exit 1
-  fi
-done
-
-for field in workspace network_policy session_assurance_initial provider_native_sandbox_configured provider_native_sandbox_effective provider_native_sandbox_reason codex claude gemini; do
-  if ! grep -Fq -- "${field}" "${ROOT_DIR}/scripts/workcell" && ! grep -Fq -- "${field}" "${ROOT_DIR}/runtime/container/assurance.sh"; then
-    echo "Expected audit log field referenced in control scripts: ${field}" >&2
-    exit 1
-  fi
-done
+# The four contiguous grep-based loops that asserted the workcell mount-view
+# validation snippets, the colima-egress-allowlist safe-cwd snippets, the
+# --inspect contract tokens (all in scripts/workcell), and the audit-log fields
+# (present in scripts/workcell OR runtime/container/assurance.sh) were migrated
+# to Go (D3): internal/workcellhardening behind the workcell-citools
+# workcell-inspect-assurance-loops subcommand preserves the exact exit codes and
+# stderr messages of the former inline grep loops (the field loop is a
+# kindPresentInAnyFile check over both files, mirroring the `! grep && ! grep`
+# absent-from-BOTH guard).  `|| exit 1` matches the former loops' `exit 1` on a
+# violated invariant: it handles the failure so the top-level ERR trap does not
+# fire and append trap diagnostics, preserving the exact failure stderr surface.
+go_verify_citools workcell-inspect-assurance-loops "${ROOT_DIR}" || exit 1
 
 if [[ ! -d "${ROOT_DIR}/docs/examples" ]]; then
   echo "docs/examples/ must exist" >&2


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 19 of N (larger batch).** Follows #398-#415. Migrates 25 inspect/assurance invariant checks (former lines 8289-8322) — four contiguous grep-based `for` loops.

## What
- **`internal/workcellhardening`**: new `CheckInspectAssuranceLoops(rootDir)` reusing existing kinds (no new kinds):
  - Loop 1 — 5 mount-view snippets → `kindPresent`, `scripts/workcell`.
  - Loop 2 — 3 egress safe-cwd snippets → `kindPresent`, `scripts/colima-egress-allowlist.sh`.
  - Loop 3 — 8 `--inspect` contract tokens → `kindPresent`, `scripts/workcell`.
  - Loop 4 — 9 audit-log fields → `kindPresentInAnyFile` over `scripts/workcell` OR `runtime/container/assurance.sh` (mirrors `! grep -Fq -- FIELD f1 f2`).
- **`cmd/workcell-citools`**: new `workcell-inspect-assurance-loops` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-inspect-assurance-loops "${ROOT_DIR}" || exit 1`.

## Scope note
The two `awk` / `sed`+`awk` ordered-subsequence blocks just above (profile-lock state matchers) are **intentionally left in bash** — they need a dedicated ordered-subsequence kind (a later increment). Stopped at 8324 (a `[[ ! -d docs/examples ]]` directory test + `rg`/`jq` checks — not simple grep).

## Parity
All needles byte-exact `grep -Fq` substrings. Real repo → exit 0; crafted violations per loop → exit 1 byte-identical; the field present-in-any OR verified (present in only one of the two files → pass). Real-repo assertion + count=25 guard.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 355 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)