### PR TITLE
^R D3: migrate validator writable-state isolation invariants to Go (23 checks)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -113,6 +113,7 @@ func subcommands() []subcommand {
 		{"workcell-copilot-release-verify", "ROOT_DIR", 1, 1, cmdWorkcellCopilotReleaseVerify},
 		{"workcell-adapter-rule-guard-bash", "ROOT_DIR", 1, 1, cmdWorkcellAdapterRuleGuardBash},
 		{"workcell-inspect-assurance-loops", "ROOT_DIR", 1, 1, cmdWorkcellInspectAssuranceLoops},
+		{"workcell-validator-writable-state", "ROOT_DIR", 1, 1, cmdWorkcellValidatorWritableState},
 	}
 }
 
@@ -660,4 +661,12 @@ func cmdWorkcellAdapterRuleGuardBash(args []string) error {
 // first violated invariant.
 func cmdWorkcellInspectAssuranceLoops(args []string) error {
 	return workcellhardening.CheckInspectAssuranceLoops(args[0])
+}
+
+// cmdWorkcellValidatorWritableState runs the twenty-three validator
+// writable-state isolation checks migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the shell's
+// original stderr message for the first violated invariant.
+func cmdWorkcellValidatorWritableState(args []string) error {
+	return workcellhardening.CheckValidatorWritableState(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -2732,6 +2732,169 @@ func CheckInspectAssuranceLoops(rootDir string) error {
 	return evaluate(rootDir, inspectAssuranceLoopsChecks())
 }
 
+// buildAndTestRelPath is the repo-relative path to the build-and-test
+// driver.  The validator-writable-state block reads this file (via the
+// per-check targetFile field) for its --docker caller-UID/GID isolation
+// probes, mirroring the shell `grep -Fq` loop that ran against
+// ${ROOT_DIR}/scripts/build-and-test.sh.
+const buildAndTestRelPath = "scripts/build-and-test.sh"
+
+// trustedDockerClientRelPath is the repo-relative path to the trusted
+// Docker client helper.  Only the validator-writable-state isolated-home
+// probe reads this file (via the per-check targetFile field), mirroring the
+// shell `grep -Fq` that ran against
+// ${ROOT_DIR}/scripts/lib/trusted-docker-client.sh.
+const trustedDockerClientRelPath = "scripts/lib/trusted-docker-client.sh"
+
+// verifyReleaseBundleRelPath is the repo-relative path to the release-bundle
+// verifier.  The validator-writable-state block reads this file (via the
+// per-check targetFile field) for its caller-UID/GID isolation probes and its
+// mounted-repo-write-avoidance probe, mirroring the shell `grep -Fq` loop and
+// guard that ran against ${ROOT_DIR}/scripts/verify-release-bundle.sh.
+const verifyReleaseBundleRelPath = "scripts/verify-release-bundle.sh"
+
+// verifyBuildInputManifestRelPath is the repo-relative path to the
+// build-input-manifest verifier.  Only the validator-writable-state
+// mounted-repo-write-avoidance probe reads this file (via the per-check
+// targetFile field), mirroring the shell `grep -Fq` guard that ran against
+// ${ROOT_DIR}/scripts/verify-build-input-manifest.sh.
+const verifyBuildInputManifestRelPath = "scripts/verify-build-input-manifest.sh"
+
+// verifyControlPlaneManifestRelPath is the repo-relative path to the
+// control-plane-manifest verifier.  Only the validator-writable-state
+// mounted-repo-write-avoidance probe reads this file (via the per-check
+// targetFile field), mirroring the shell `grep -Fq` guard that ran against
+// ${ROOT_DIR}/scripts/verify-control-plane-manifest.sh.
+const verifyControlPlaneManifestRelPath = "scripts/verify-control-plane-manifest.sh"
+
+// verifyReproducibleBuildRelPath is the repo-relative path to the
+// reproducible-build verifier.  Only the validator-writable-state
+// mounted-repo-write-avoidance probe reads this file (via the per-check
+// targetFile field), mirroring the shell `grep -Fq` guard that ran against
+// ${ROOT_DIR}/scripts/verify-reproducible-build.sh.
+const verifyReproducibleBuildRelPath = "scripts/verify-reproducible-build.sh"
+
+// buildAndTestValidatorIsolationNeedles lists the ten fixed-string snippets
+// the shell's `for required in ...; do grep -Fq -- "${required}"
+// scripts/build-and-test.sh; done` loop asserted are present, in the shell's
+// verbatim order.  Each needle reproduces the shell double-quoted literal
+// byte-exact (`\$`→`$`, `\"`→`"`, `\${...}`→`${...}`).
+var buildAndTestValidatorIsolationNeedles = []string{
+	"WORKCELL_BUILD_AND_TEST_VALIDATOR_UID=",
+	"WORKCELL_BUILD_AND_TEST_VALIDATOR_GID=",
+	`--user "${WORKCELL_BUILD_AND_TEST_VALIDATOR_UID}:${WORKCELL_BUILD_AND_TEST_VALIDATOR_GID}"`,
+	`-e HOME="${WORKCELL_BUILD_AND_TEST_VALIDATOR_HOME}"`,
+	`-e XDG_CACHE_HOME="${WORKCELL_BUILD_AND_TEST_VALIDATOR_CACHE}"`,
+	`-e GOCACHE="${WORKCELL_BUILD_AND_TEST_VALIDATOR_CACHE}/go-build"`,
+	`-e GOMODCACHE="${WORKCELL_BUILD_AND_TEST_VALIDATOR_CACHE}/go-mod"`,
+	`-e CARGO_TARGET_DIR="${WORKCELL_BUILD_AND_TEST_VALIDATOR_CACHE}/cargo-target"`,
+	`-e TMPDIR="${WORKCELL_BUILD_AND_TEST_VALIDATOR_TMP}"`,
+	`mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${GOCACHE}" "${GOMODCACHE}" "${CARGO_TARGET_DIR}" "${TMPDIR}"`,
+}
+
+// releaseBundleValidatorIsolationNeedles lists the eight fixed-string snippets
+// the shell's `for required in ...; do grep -Fq -- "${required}"
+// scripts/verify-release-bundle.sh; done` loop asserted are present, in the
+// shell's verbatim order.  Each needle reproduces the shell double-quoted
+// literal byte-exact.
+var releaseBundleValidatorIsolationNeedles = []string{
+	`--user "${validator_uid}:${validator_gid}"`,
+	`-e HOME="${validator_home}"`,
+	`-e XDG_CACHE_HOME="${validator_cache_root}"`,
+	`-e GOCACHE="${validator_cache_root}/go-build"`,
+	`-e GOMODCACHE="${validator_cache_root}/go-mod"`,
+	`-e CARGO_TARGET_DIR="${validator_cache_root}/cargo-target"`,
+	`-e TMPDIR="${validator_tmpdir}"`,
+	`mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${GOCACHE}" "${GOMODCACHE}" "${CARGO_TARGET_DIR}" "${TMPDIR}"`,
+}
+
+// validatorWritableStateChecks returns the twenty-three validator
+// writable-state isolation invariants in the same order as the former inline
+// block in scripts/verify-invariants.sh (the block between the
+// build-and-test.sh caller-UID/GID loop's predecessor — the
+// verify-release-bundle.sh validator loop — and the
+// go_verify_citools workcell-bootstrap-audit dispatch), so a reviewer can diff
+// the two one-to-one.
+//
+// The block asserts that validator work runs under an explicit caller UID/GID
+// with isolated writable state, and that the manifest/bundle verifiers avoid
+// writing under the mounted repo:
+//
+//   - The ten build-and-test.sh probes and eight verify-release-bundle.sh
+//     probes came from two `for required in ...; do grep -Fq -- "${required}"
+//     FILE; done` loops whose stderr interpolated the needle into a shared
+//     per-file message; because every needle is a fixed `grep -Fq` literal,
+//     each check is kindPresent with the message computed verbatim as the
+//     shell's "Expected ... isolated writable state (${required})".
+//   - The trusted-docker-client.sh isolated-home probe is a single affirmative
+//     `grep -Fq` (kindPresent) with a fixed message.
+//   - The four mounted-repo-write-avoidance probes are NEGATED `grep -Fq`
+//     guards (`if grep -Fq X FILE; then ... exit 1`): the literal
+//     `${ROOT_DIR}/tmp/workcell-*` temp-root snippet present in the target is a
+//     violation, so each is kindAbsent (the `${` `}` are matched literally, as
+//     grep -Fq does).
+func validatorWritableStateChecks() []check {
+	cs := make([]check, 0, len(buildAndTestValidatorIsolationNeedles)+1+len(releaseBundleValidatorIsolationNeedles)+4)
+	for _, needle := range buildAndTestValidatorIsolationNeedles {
+		cs = append(cs, check{
+			kind:       kindPresent,
+			pattern:    needle,
+			message:    "Expected scripts/build-and-test.sh --docker to launch validator work under an explicit caller UID/GID with isolated writable state (" + needle + ")",
+			targetFile: buildAndTestRelPath,
+		})
+	}
+	cs = append(cs, check{
+		kind:       kindPresent,
+		pattern:    `fallback_home="${fallback_parent%/}/workcell-home-${uid}"`,
+		message:    "Expected trusted-docker-client.sh to synthesize an isolated home for passwd-less caller UIDs",
+		targetFile: trustedDockerClientRelPath,
+	})
+	for _, needle := range releaseBundleValidatorIsolationNeedles {
+		cs = append(cs, check{
+			kind:       kindPresent,
+			pattern:    needle,
+			message:    "Expected scripts/verify-release-bundle.sh to build bundles in the validator under an explicit caller UID/GID with isolated writable state (" + needle + ")",
+			targetFile: verifyReleaseBundleRelPath,
+		})
+	}
+	cs = append(cs,
+		check{
+			kind:       kindAbsent,
+			pattern:    "${ROOT_DIR}/tmp/workcell-build-input-nested",
+			message:    "Expected verify-build-input-manifest.sh nested-source checks to avoid writing under the mounted repo",
+			targetFile: verifyBuildInputManifestRelPath,
+		},
+		check{
+			kind:       kindAbsent,
+			pattern:    "${ROOT_DIR}/tmp/workcell-control-plane-nested",
+			message:    "Expected verify-control-plane-manifest.sh nested-source checks to avoid writing under the mounted repo",
+			targetFile: verifyControlPlaneManifestRelPath,
+		},
+		check{
+			kind:       kindAbsent,
+			pattern:    "${ROOT_DIR}/tmp/workcell-release-bundle",
+			message:    "Expected verify-release-bundle.sh temp roots to avoid writing under the mounted repo",
+			targetFile: verifyReleaseBundleRelPath,
+		},
+		check{
+			kind:       kindAbsent,
+			pattern:    "${ROOT_DIR}/tmp/workcell-repro",
+			message:    "Expected verify-reproducible-build.sh OCI exports to avoid writing under the mounted repo",
+			targetFile: verifyReproducibleBuildRelPath,
+		},
+	)
+	return cs
+}
+
+// CheckValidatorWritableState runs the twenty-three validator writable-state
+// isolation invariants against the repo rooted at rootDir, in the shell's
+// original order.  It returns nil when every invariant holds (the shell's exit
+// 0), or an error whose message equals the shell's stderr for the first
+// violated invariant (the shell's exit 1).
+func CheckValidatorWritableState(rootDir string) error {
+	return evaluate(rootDir, validatorWritableStateChecks())
+}
+
 // holds reports whether the invariant is satisfied by the launcher text.
 func (c check) holds(text string) bool {
 	switch c.kind {

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -4019,3 +4019,185 @@ func TestCheckInspectAssuranceLoopsRealRepo(t *testing.T) {
 		t.Fatalf("CheckInspectAssuranceLoops(real repo) = %v, want nil", err)
 	}
 }
+
+// writeValidatorWritableStateRepo materializes a fake repo populated with the
+// six target files the validator-writable-state block reads.  A body of ""
+// means "do not create the file" (unreadable-file case).
+func writeValidatorWritableStateRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, body := range files {
+		if body == "" {
+			continue
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	return root
+}
+
+// validatorWritableStateHappyFiles returns the six-file fixture map that
+// satisfies all twenty-three invariants: each file that carries affirmative
+// grep -Fq needles contains every one of them, and none of the four files
+// contains its forbidden ${ROOT_DIR}/tmp/workcell-* temp-root snippet.  The
+// needle bodies are built from the exported needle slices so the fixture stays
+// in lockstep with the migration.
+func validatorWritableStateHappyFiles() map[string]string {
+	return map[string]string{
+		buildAndTestRelPath:               "#!/usr/bin/env bash\n" + strings.Join(buildAndTestValidatorIsolationNeedles, "\n") + "\n",
+		trustedDockerClientRelPath:        "#!/usr/bin/env bash\n" + `fallback_home="${fallback_parent%/}/workcell-home-${uid}"` + "\n",
+		verifyReleaseBundleRelPath:        "#!/usr/bin/env bash\n" + strings.Join(releaseBundleValidatorIsolationNeedles, "\n") + "\n",
+		verifyBuildInputManifestRelPath:   "#!/usr/bin/env bash\n",
+		verifyControlPlaneManifestRelPath: "#!/usr/bin/env bash\n",
+		verifyReproducibleBuildRelPath:    "#!/usr/bin/env bash\n",
+	}
+}
+
+func TestCheckValidatorWritableState(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(files map[string]string)
+		wantErr string // "" means expect success
+	}{
+		{
+			name:   "happy path all invariants hold",
+			mutate: func(map[string]string) {},
+		},
+		{
+			// build-and-test loop: a removed needle fails with the interpolated
+			// per-needle message (first needle).
+			name: "build-and-test missing UID needle",
+			mutate: func(files map[string]string) {
+				files[buildAndTestRelPath] = strings.Replace(files[buildAndTestRelPath], "WORKCELL_BUILD_AND_TEST_VALIDATOR_UID=\n", "", 1)
+			},
+			wantErr: "Expected scripts/build-and-test.sh --docker to launch validator work under an explicit caller UID/GID with isolated writable state (WORKCELL_BUILD_AND_TEST_VALIDATOR_UID=)",
+		},
+		{
+			// build-and-test loop: the last needle (the mkdir line) removed fails
+			// with its interpolated message.
+			name: "build-and-test missing mkdir needle",
+			mutate: func(files map[string]string) {
+				files[buildAndTestRelPath] = strings.Replace(files[buildAndTestRelPath], `mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${GOCACHE}" "${GOMODCACHE}" "${CARGO_TARGET_DIR}" "${TMPDIR}"`, "", 1)
+			},
+			wantErr: `Expected scripts/build-and-test.sh --docker to launch validator work under an explicit caller UID/GID with isolated writable state (mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${GOCACHE}" "${GOMODCACHE}" "${CARGO_TARGET_DIR}" "${TMPDIR}")`,
+		},
+		{
+			// A missing scripts/build-and-test.sh is empty content: the first
+			// affirmative needle fails.
+			name: "build-and-test file missing",
+			mutate: func(files map[string]string) {
+				files[buildAndTestRelPath] = ""
+			},
+			wantErr: "Expected scripts/build-and-test.sh --docker to launch validator work under an explicit caller UID/GID with isolated writable state (WORKCELL_BUILD_AND_TEST_VALIDATOR_UID=)",
+		},
+		{
+			// trusted-docker-client isolated-home probe: removed needle fails with
+			// the fixed message.
+			name: "trusted-docker-client missing isolated home",
+			mutate: func(files map[string]string) {
+				files[trustedDockerClientRelPath] = "#!/usr/bin/env bash\n"
+			},
+			wantErr: "Expected trusted-docker-client.sh to synthesize an isolated home for passwd-less caller UIDs",
+		},
+		{
+			// verify-release-bundle loop: a removed needle fails with the
+			// interpolated per-needle message.
+			name: "verify-release-bundle missing validator user needle",
+			mutate: func(files map[string]string) {
+				files[verifyReleaseBundleRelPath] = strings.Replace(files[verifyReleaseBundleRelPath], `--user "${validator_uid}:${validator_gid}"`, "", 1)
+			},
+			wantErr: `Expected scripts/verify-release-bundle.sh to build bundles in the validator under an explicit caller UID/GID with isolated writable state (--user "${validator_uid}:${validator_gid}")`,
+		},
+		{
+			// build-input-manifest mounted-repo-write guard: the forbidden
+			// temp-root snippet present is a violation.
+			name: "verify-build-input-manifest writes under mounted repo",
+			mutate: func(files map[string]string) {
+				files[verifyBuildInputManifestRelPath] += "tmp=\"${ROOT_DIR}/tmp/workcell-build-input-nested\"\n"
+			},
+			wantErr: "Expected verify-build-input-manifest.sh nested-source checks to avoid writing under the mounted repo",
+		},
+		{
+			// control-plane-manifest mounted-repo-write guard.
+			name: "verify-control-plane-manifest writes under mounted repo",
+			mutate: func(files map[string]string) {
+				files[verifyControlPlaneManifestRelPath] += "tmp=\"${ROOT_DIR}/tmp/workcell-control-plane-nested\"\n"
+			},
+			wantErr: "Expected verify-control-plane-manifest.sh nested-source checks to avoid writing under the mounted repo",
+		},
+		{
+			// release-bundle mounted-repo-write guard: the same file also carries
+			// the eight affirmative needles, which remain satisfied, so the
+			// negated temp-root guard is what fires.
+			name: "verify-release-bundle writes under mounted repo",
+			mutate: func(files map[string]string) {
+				files[verifyReleaseBundleRelPath] += "tmp=\"${ROOT_DIR}/tmp/workcell-release-bundle\"\n"
+			},
+			wantErr: "Expected verify-release-bundle.sh temp roots to avoid writing under the mounted repo",
+		},
+		{
+			// reproducible-build mounted-repo-write guard.
+			name: "verify-reproducible-build writes under mounted repo",
+			mutate: func(files map[string]string) {
+				files[verifyReproducibleBuildRelPath] += "tmp=\"${ROOT_DIR}/tmp/workcell-repro\"\n"
+			},
+			wantErr: "Expected verify-reproducible-build.sh OCI exports to avoid writing under the mounted repo",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			files := validatorWritableStateHappyFiles()
+			tc.mutate(files)
+			root := writeValidatorWritableStateRepo(t, files)
+			err := CheckValidatorWritableState(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckValidatorWritableState() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckValidatorWritableState() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckValidatorWritableState() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckValidatorWritableStateCount asserts the generated check list contains
+// exactly twenty-three invariants, guarding against an accidentally truncated or
+// duplicated migration of the two loops, the isolated-home probe, and the four
+// mounted-repo-write guards.
+func TestCheckValidatorWritableStateCount(t *testing.T) {
+	got := len(validatorWritableStateChecks())
+	const want = 23
+	if got != want {
+		t.Fatalf("validatorWritableStateChecks() has %d checks, want %d", got, want)
+	}
+}
+
+// TestCheckValidatorWritableStateRealRepo asserts that the real
+// scripts/build-and-test.sh, scripts/lib/trusted-docker-client.sh,
+// scripts/verify-release-bundle.sh, scripts/verify-build-input-manifest.sh,
+// scripts/verify-control-plane-manifest.sh, and scripts/verify-reproducible-build.sh
+// in this repository satisfy all twenty-three validator writable-state
+// invariants.  This is the key guard against a mis-transcribed needle or a wrong
+// target file: if any Go pattern diverges from the actual file contents, this
+// test fails with the guard's stderr message.
+func TestCheckValidatorWritableStateRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, buildAndTestRelPath)); err != nil {
+		t.Skipf("real scripts/build-and-test.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckValidatorWritableState(repoRoot); err != nil {
+		t.Fatalf("CheckValidatorWritableState(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3096,62 +3096,7 @@ for caller in \
   done
 done
 
-for required in \
-  "WORKCELL_BUILD_AND_TEST_VALIDATOR_UID=" \
-  "WORKCELL_BUILD_AND_TEST_VALIDATOR_GID=" \
-  "--user \"\${WORKCELL_BUILD_AND_TEST_VALIDATOR_UID}:\${WORKCELL_BUILD_AND_TEST_VALIDATOR_GID}\"" \
-  "-e HOME=\"\${WORKCELL_BUILD_AND_TEST_VALIDATOR_HOME}\"" \
-  "-e XDG_CACHE_HOME=\"\${WORKCELL_BUILD_AND_TEST_VALIDATOR_CACHE}\"" \
-  "-e GOCACHE=\"\${WORKCELL_BUILD_AND_TEST_VALIDATOR_CACHE}/go-build\"" \
-  "-e GOMODCACHE=\"\${WORKCELL_BUILD_AND_TEST_VALIDATOR_CACHE}/go-mod\"" \
-  "-e CARGO_TARGET_DIR=\"\${WORKCELL_BUILD_AND_TEST_VALIDATOR_CACHE}/cargo-target\"" \
-  "-e TMPDIR=\"\${WORKCELL_BUILD_AND_TEST_VALIDATOR_TMP}\"" \
-  "mkdir -p \"\${HOME}\" \"\${XDG_CACHE_HOME}\" \"\${GOCACHE}\" \"\${GOMODCACHE}\" \"\${CARGO_TARGET_DIR}\" \"\${TMPDIR}\""; do
-  if ! grep -Fq -- "${required}" "${ROOT_DIR}/scripts/build-and-test.sh"; then
-    echo "Expected scripts/build-and-test.sh --docker to launch validator work under an explicit caller UID/GID with isolated writable state (${required})" >&2
-    exit 1
-  fi
-done
-
-if ! grep -Fq "fallback_home=\"\${fallback_parent%/}/workcell-home-\${uid}\"" "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"; then
-  echo "Expected trusted-docker-client.sh to synthesize an isolated home for passwd-less caller UIDs" >&2
-  exit 1
-fi
-
-for required in \
-  "--user \"\${validator_uid}:\${validator_gid}\"" \
-  "-e HOME=\"\${validator_home}\"" \
-  "-e XDG_CACHE_HOME=\"\${validator_cache_root}\"" \
-  "-e GOCACHE=\"\${validator_cache_root}/go-build\"" \
-  "-e GOMODCACHE=\"\${validator_cache_root}/go-mod\"" \
-  "-e CARGO_TARGET_DIR=\"\${validator_cache_root}/cargo-target\"" \
-  "-e TMPDIR=\"\${validator_tmpdir}\"" \
-  "mkdir -p \"\${HOME}\" \"\${XDG_CACHE_HOME}\" \"\${GOCACHE}\" \"\${GOMODCACHE}\" \"\${CARGO_TARGET_DIR}\" \"\${TMPDIR}\""; do
-  if ! grep -Fq -- "${required}" "${ROOT_DIR}/scripts/verify-release-bundle.sh"; then
-    echo "Expected scripts/verify-release-bundle.sh to build bundles in the validator under an explicit caller UID/GID with isolated writable state (${required})" >&2
-    exit 1
-  fi
-done
-
-if grep -Fq "\${ROOT_DIR}/tmp/workcell-build-input-nested" "${ROOT_DIR}/scripts/verify-build-input-manifest.sh"; then
-  echo "Expected verify-build-input-manifest.sh nested-source checks to avoid writing under the mounted repo" >&2
-  exit 1
-fi
-
-if grep -Fq "\${ROOT_DIR}/tmp/workcell-control-plane-nested" "${ROOT_DIR}/scripts/verify-control-plane-manifest.sh"; then
-  echo "Expected verify-control-plane-manifest.sh nested-source checks to avoid writing under the mounted repo" >&2
-  exit 1
-fi
-
-if grep -Fq "\${ROOT_DIR}/tmp/workcell-release-bundle" "${ROOT_DIR}/scripts/verify-release-bundle.sh"; then
-  echo "Expected verify-release-bundle.sh temp roots to avoid writing under the mounted repo" >&2
-  exit 1
-fi
-
-if grep -Fq "\${ROOT_DIR}/tmp/workcell-repro" "${ROOT_DIR}/scripts/verify-reproducible-build.sh"; then
-  echo "Expected verify-reproducible-build.sh OCI exports to avoid writing under the mounted repo" >&2
-  exit 1
-fi
+go_verify_citools workcell-validator-writable-state "${ROOT_DIR}" || exit 1
 
 go_verify_citools workcell-bootstrap-audit "${ROOT_DIR}" || exit 1
 


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 20 of N (larger batch).** Follows #398-#416. Migrates 23 validator writable-state isolation invariant checks (former lines 3099-3154) — validator work must run under an explicit caller UID/GID with isolated writable state, and the manifest/bundle verifiers must not write under the mounted repo.

## What
- **`internal/workcellhardening`**: new `CheckValidatorWritableState(rootDir)` reusing existing kinds (no new kinds). 23 checks across 6 files via `targetFile`: `build-and-test.sh` (×10 loop), `lib/trusted-docker-client.sh` (×1), `verify-release-bundle.sh` (×8 loop + 1 `kindAbsent` temp-root guard), `verify-build-input-manifest.sh` / `verify-control-plane-manifest.sh` / `verify-reproducible-build.sh` (×1 `kindAbsent` each). The four negated `if grep -Fq X; then exit 1` temp-root guards → `kindAbsent`.
- **`cmd/workcell-citools`**: new `workcell-validator-writable-state` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-validator-writable-state "${ROOT_DIR}" || exit 1`. Bounded by the preceding nested caller/required loop (excluded — too large to bundle) and the already-migrated bootstrap-audit dispatch at 3156.

## Parity
All needles byte-exact `grep -Fq` fixed strings. Real repo → exit 0; 5 crafted violations → exit 1 byte-identical. Real-repo assertion + count=23 guard; loop needles exported so fixtures stay in lockstep.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 411 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)