### PR TITLE
^R D3: migrate hostutil/entrypoint/colima-egress rg invariants to Go (21 checks)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -114,6 +114,7 @@ func subcommands() []subcommand {
 		{"workcell-adapter-rule-guard-bash", "ROOT_DIR", 1, 1, cmdWorkcellAdapterRuleGuardBash},
 		{"workcell-inspect-assurance-loops", "ROOT_DIR", 1, 1, cmdWorkcellInspectAssuranceLoops},
 		{"workcell-validator-writable-state", "ROOT_DIR", 1, 1, cmdWorkcellValidatorWritableState},
+		{"workcell-hostutil-egress-rg", "ROOT_DIR", 1, 1, cmdWorkcellHostutilEgressRg},
 	}
 }
 
@@ -669,4 +670,12 @@ func cmdWorkcellInspectAssuranceLoops(args []string) error {
 // original stderr message for the first violated invariant.
 func cmdWorkcellValidatorWritableState(args []string) error {
 	return workcellhardening.CheckValidatorWritableState(args[0])
+}
+
+// cmdWorkcellHostutilEgressRg runs the twenty-one hostutil / entrypoint /
+// colima-egress `rg` checks migrated out of scripts/verify-invariants.sh; it
+// fails (exit 1 via die()) with the shell's original stderr message for the
+// first violated invariant.
+func cmdWorkcellHostutilEgressRg(args []string) error {
+	return workcellhardening.CheckHostutilEgressRg(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -130,8 +130,16 @@ const workcellLauncherRustRelPath = "runtime/container/rust/src/bin/workcell-lau
 // entrypoint.  The Copilot-docker-run group reads this file (via the per-check
 // targetFile field) for its token-handoff staging / self-reexec / mapped-user
 // invariants, mirroring the shell probes that ran against
-// ${ROOT_DIR}/runtime/container/entrypoint.sh.
+// ${ROOT_DIR}/runtime/container/entrypoint.sh.  The hostutil/egress-rg block
+// also reads it for its Codex --cd / AGENT_NAME / file-trace-trap invariants.
 const entrypointRelPath = "runtime/container/entrypoint.sh"
+
+// goHostutilRelPath is the repo-relative path to the host launcher's Go
+// bootstrap helper.  Only the hostutil/egress-rg block reads this file (via the
+// per-check targetFile field) for its scrubbed-environment bootstrap-Go
+// invariants, mirroring the shell `rg` probes that ran against
+// ${ROOT_DIR}/scripts/lib/launcher/go-hostutil.sh.
+const goHostutilRelPath = "scripts/lib/launcher/go-hostutil.sh"
 
 // runtimeUserRelPath is the repo-relative path to the runtime user helper.
 // Only the Copilot-docker-run runtime-state-path invariant reads this file (via
@@ -2893,6 +2901,202 @@ func validatorWritableStateChecks() []check {
 // violated invariant (the shell's exit 1).
 func CheckValidatorWritableState(rootDir string) error {
 	return evaluate(rootDir, validatorWritableStateChecks())
+}
+
+// hostutilEgressRgChecks lists the twenty-one hostutil / entrypoint /
+// colima-egress `rg` invariants in the same order as the former inline block in
+// scripts/verify-invariants.sh (the contiguous run of `rg`/`head`+`grep`
+// guards between the runtime-build-retry harness and the HOST_GATE_SCRIPTS
+// self-sanitizing loop), so a reviewer can diff the two one-to-one.  The block
+// ends at that HOST_GATE_SCRIPTS `for` loop, which iterates a dynamic array of
+// scripts rather than one fixed file and so falls outside the single-file
+// `rg`/`grep` shape migrated here.
+//
+// Every probe is an `rg -q` regex (line-oriented, matched per line via
+// regexMatchesAnyLine for `rg` parity), except the colima-egress shebang probe
+// which is a `head -n1 ... | grep -q '^...$'` first-line anchored regex
+// (kindFirstLineRegex).  Matching semantics mirror the shell exactly:
+//
+//   - Affirmative `if ! rg -q P` guards → kindRegexPresent (P must match).
+//   - Negated `if rg -q P; then ... exit 1` guards → kindRegexAbsent (P
+//     matching is a violation).  These are the two entrypoint probes
+//     (`set -- codex --cd `, `AGENT_NAME="\$\{AGENT_NAME:-codex\}"`) and the
+//     colima-egress PATH-trust probe.
+//
+// Unlike the earlier metacharacter-free blocks migrated as fixed-string
+// kindPresent/kindAbsent, these patterns are kept verbatim as regexes:
+//
+//   - The escaped-literal patterns (`"\$\{ROOT_DIR\}"`, `GOPATH="\$\{GOPATH\}"`,
+//     `"\$@"`, `AGENT_NAME="\$\{AGENT_NAME:-codex\}"`, `DYLD_\*`, ...) use the
+//     rg regex escapes `\$ \{ \} \*` to match the literal `$ { } *`; Go's
+//     regexp interprets the same escapes, so the pattern is used byte-for-byte.
+//   - The colima-egress PATH-trust probe `command -v|type -P|which ` is a
+//     genuine alternation (the `|` are real regex OR), so it is a true regex
+//     kindRegexAbsent (present is a violation).
+//
+// Three former shell `if` guards each joined several `! rg -q` probes with `||`
+// under a single message (the go-hostutil bootstrap-Go guard, the
+// entrypoint file-trace-trap guard, and the colima-egress Go-runtime guard);
+// they are expressed here as ordered kindRegexPresent checks sharing that
+// message, which is behaviourally identical (any missing probe yields the same
+// stderr and exit 1 as the corresponding shell `if`).
+//
+// Target files: five probes read scripts/lib/launcher/go-hostutil.sh, four read
+// runtime/container/entrypoint.sh, and twelve read
+// scripts/colima-egress-allowlist.sh (all via the per-check targetFile field).
+var hostutilEgressRgChecks = []check{
+	// Guard 1: go-hostutil.sh invokes the bootstrap Go helper from the repo
+	// root under a scrubbed environment with explicit Go caches (five ordered
+	// `! rg -q` probes sharing one message).
+	{
+		kind:       kindRegexPresent,
+		pattern:    `run_clean_host_command_in_dir "\$\{ROOT_DIR\}" env`,
+		message:    "Expected scripts/lib/launcher/go-hostutil.sh to invoke the bootstrap Go helper from the repo root under a scrubbed environment with explicit Go caches",
+		targetFile: goHostutilRelPath,
+	},
+	{
+		kind:       kindRegexPresent,
+		pattern:    `GOPATH="\$\{GOPATH\}"`,
+		message:    "Expected scripts/lib/launcher/go-hostutil.sh to invoke the bootstrap Go helper from the repo root under a scrubbed environment with explicit Go caches",
+		targetFile: goHostutilRelPath,
+	},
+	{
+		kind:       kindRegexPresent,
+		pattern:    `GOMODCACHE="\$\{GOMODCACHE\}"`,
+		message:    "Expected scripts/lib/launcher/go-hostutil.sh to invoke the bootstrap Go helper from the repo root under a scrubbed environment with explicit Go caches",
+		targetFile: goHostutilRelPath,
+	},
+	{
+		kind:       kindRegexPresent,
+		pattern:    `GOCACHE="\$\{GOCACHE\}"`,
+		message:    "Expected scripts/lib/launcher/go-hostutil.sh to invoke the bootstrap Go helper from the repo root under a scrubbed environment with explicit Go caches",
+		targetFile: goHostutilRelPath,
+	},
+	{
+		kind:       kindRegexPresent,
+		pattern:    `"\$\{HOST_GO_BIN\}" run ./cmd/workcell-hostutil "\$@"`,
+		message:    "Expected scripts/lib/launcher/go-hostutil.sh to invoke the bootstrap Go helper from the repo root under a scrubbed environment with explicit Go caches",
+		targetFile: goHostutilRelPath,
+	},
+	// entrypoint.sh must not inject a blocked default Codex --cd override
+	// (negated `if rg -q ...` → present is a violation).
+	{
+		kind:       kindRegexAbsent,
+		pattern:    `set -- codex --cd `,
+		message:    "runtime/container/entrypoint.sh still injects a blocked default Codex --cd override",
+		targetFile: entrypointRelPath,
+	},
+	// entrypoint.sh must not default AGENT_NAME to codex (negated `if rg -q`;
+	// the pattern escapes `$ { }` to match the literal assignment).
+	{
+		kind:       kindRegexAbsent,
+		pattern:    `AGENT_NAME="\$\{AGENT_NAME:-codex\}"`,
+		message:    "runtime/container/entrypoint.sh still defaults AGENT_NAME to codex",
+		targetFile: entrypointRelPath,
+	},
+	// Guard: entrypoint.sh traps INT/TERM and finalizes file-trace shutdown
+	// before exit (two ordered `! rg -q` probes sharing one message).
+	{
+		kind:       kindRegexPresent,
+		pattern:    `trap 'workcell_run_command_with_file_trace_signal INT' INT`,
+		message:    "Expected runtime/container/entrypoint.sh to trap INT/TERM and finalize file-trace shutdown before exit",
+		targetFile: entrypointRelPath,
+	},
+	{
+		kind:       kindRegexPresent,
+		pattern:    `trap 'workcell_run_command_with_file_trace_signal TERM' TERM`,
+		message:    "Expected runtime/container/entrypoint.sh to trap INT/TERM and finalize file-trace shutdown before exit",
+		targetFile: entrypointRelPath,
+	},
+	// colima-egress-allowlist.sh must not trust PATH for executed host tools
+	// (negated `if rg -q`; `command -v|type -P|which ` is a genuine
+	// alternation, so present is a violation via kindRegexAbsent).
+	{
+		kind:       kindRegexAbsent,
+		pattern:    `command -v|type -P|which `,
+		message:    "scripts/colima-egress-allowlist.sh still trusts PATH for executed host tools",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	{
+		kind:       kindRegexPresent,
+		pattern:    `REAL_HOME=`,
+		message:    "Expected scripts/colima-egress-allowlist.sh to derive the real host home independently of caller HOME",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	// First-line anchored regex mirroring `head -n1 ... | grep -q '^...$'`.
+	{
+		kind:       kindFirstLineRegex,
+		pattern:    `^#!/usr/bin/env -S -i PATH=.* BASH_ENV= ENV= /bin/bash$`,
+		message:    "Expected scripts/colima-egress-allowlist.sh to use env -S -i with an absolute /bin/bash and cleared host environment",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	{
+		kind:       kindRegexPresent,
+		pattern:    `scrub_host_process_env`,
+		message:    "Expected scripts/colima-egress-allowlist.sh to scrub hostile host process environment before host tool lookup",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	{
+		kind:       kindRegexPresent,
+		pattern:    `unset PERL5OPT PERL5LIB PERLLIB PERL_MB_OPT PERL_MM_OPT`,
+		message:    "Expected scripts/colima-egress-allowlist.sh to scrub hostile Perl environment before host tool lookup",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	{
+		// `DYLD_\*` escapes the `*`, matching the literal `DYLD_*`.
+		kind:       kindRegexPresent,
+		pattern:    `DYLD_\*`,
+		message:    "Expected scripts/colima-egress-allowlist.sh to scrub DYLD_* variables before host tool lookup",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	{
+		kind:       kindRegexPresent,
+		pattern:    `is_trusted_host_tool_path`,
+		message:    "Expected scripts/colima-egress-allowlist.sh to canonicalize and trust-check host tool paths",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	// Guard: colima-egress-allowlist.sh invokes Go runtime helpers under a
+	// scrubbed environment with explicit Go caches (five ordered `! rg -q`
+	// probes sharing one message).
+	{
+		kind:       kindRegexPresent,
+		pattern:    `run_clean_repo_command env`,
+		message:    "Expected scripts/colima-egress-allowlist.sh to invoke Go runtime helpers under a scrubbed environment with explicit Go caches",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	{
+		kind:       kindRegexPresent,
+		pattern:    `GOPATH="\$\{GOPATH\}"`,
+		message:    "Expected scripts/colima-egress-allowlist.sh to invoke Go runtime helpers under a scrubbed environment with explicit Go caches",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	{
+		kind:       kindRegexPresent,
+		pattern:    `GOMODCACHE="\$\{GOMODCACHE\}"`,
+		message:    "Expected scripts/colima-egress-allowlist.sh to invoke Go runtime helpers under a scrubbed environment with explicit Go caches",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	{
+		kind:       kindRegexPresent,
+		pattern:    `GOCACHE="\$\{GOCACHE\}"`,
+		message:    "Expected scripts/colima-egress-allowlist.sh to invoke Go runtime helpers under a scrubbed environment with explicit Go caches",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	{
+		kind:       kindRegexPresent,
+		pattern:    `"\$\{GO_BIN\}" run ./cmd/workcell-runtimeutil "\$@"`,
+		message:    "Expected scripts/colima-egress-allowlist.sh to invoke Go runtime helpers under a scrubbed environment with explicit Go caches",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+}
+
+// CheckHostutilEgressRg runs the twenty-one hostutil / entrypoint /
+// colima-egress `rg` invariants against the repo rooted at rootDir, in the
+// shell's original order.  It returns nil when every invariant holds (the
+// shell's exit 0), or an error whose message equals the shell's stderr for the
+// first violated invariant (the shell's exit 1).
+func CheckHostutilEgressRg(rootDir string) error {
+	return evaluate(rootDir, hostutilEgressRgChecks)
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -4201,3 +4201,258 @@ func TestCheckValidatorWritableStateRealRepo(t *testing.T) {
 		t.Fatalf("CheckValidatorWritableState(real repo) = %v, want nil", err)
 	}
 }
+
+// hostutilEgressRgHappyGoHostutil is a minimal scripts/lib/launcher/go-hostutil.sh
+// satisfying all five bootstrap-Go invariants: the escaped-literal patterns match
+// the literal ${ROOT_DIR}/${GOPATH}/${HOST_GO_BIN}/"$@" tokens.
+const hostutilEgressRgHappyGoHostutil = `#!/bin/bash
+set -euo pipefail
+run_clean_host_command_in_dir "${ROOT_DIR}" env \
+  GOPATH="${GOPATH}" \
+  GOMODCACHE="${GOMODCACHE}" \
+  GOCACHE="${GOCACHE}" \
+  "${HOST_GO_BIN}" run ./cmd/workcell-hostutil "$@"
+`
+
+// hostutilEgressRgHappyEntrypoint is a minimal runtime/container/entrypoint.sh
+// satisfying the four entrypoint invariants: it does NOT inject a default Codex
+// --cd override or default AGENT_NAME to codex, and it traps INT/TERM.
+const hostutilEgressRgHappyEntrypoint = `#!/bin/bash
+set -euo pipefail
+trap 'workcell_run_command_with_file_trace_signal INT' INT
+trap 'workcell_run_command_with_file_trace_signal TERM' TERM
+`
+
+// hostutilEgressRgHappyColima is a minimal scripts/colima-egress-allowlist.sh
+// satisfying all twelve colima-egress invariants: the first line is the cleared
+// env -S -i shebang, it does not trust PATH (no command -v/type -P/which ), and
+// it scrubs the environment before invoking the Go runtime helper.
+const hostutilEgressRgHappyColima = `#!/usr/bin/env -S -i PATH=/usr/bin BASH_ENV= ENV= /bin/bash
+set -euo pipefail
+REAL_HOME=/Users/real
+scrub_host_process_env
+unset PERL5OPT PERL5LIB PERLLIB PERL_MB_OPT PERL_MM_OPT
+unset DYLD_*
+is_trusted_host_tool_path
+run_clean_repo_command env \
+  GOPATH="${GOPATH}" \
+  GOMODCACHE="${GOMODCACHE}" \
+  GOCACHE="${GOCACHE}" \
+  "${GO_BIN}" run ./cmd/workcell-runtimeutil "$@"
+`
+
+// writeHostutilEgressRgRepo materializes a fake repo with the three target files
+// set to their respective bodies; a body of "" means "do not create that file"
+// (unreadable-target case).
+func writeHostutilEgressRgRepo(t *testing.T, goHostutil, entrypoint, colima string) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, body string) {
+		if body == "" {
+			return
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(goHostutilRelPath, goHostutil)
+	write(entrypointRelPath, entrypoint)
+	write(colimaEgressAllowlistRelPath, colima)
+	return root
+}
+
+func TestCheckHostutilEgressRg(t *testing.T) {
+	tests := []struct {
+		name       string
+		goHostutil string
+		entrypoint string
+		colima     string
+		wantErr    string // "" means expect success
+	}{
+		{
+			name:       "happy path all invariants hold",
+			goHostutil: hostutilEgressRgHappyGoHostutil,
+			entrypoint: hostutilEgressRgHappyEntrypoint,
+			colima:     hostutilEgressRgHappyColima,
+		},
+		{
+			// kindRegexPresent, escaped-literal ${ROOT_DIR} pattern: the bootstrap
+			// invocation removed.
+			name:       "go-hostutil missing scrubbed bootstrap invocation",
+			goHostutil: strings.Replace(hostutilEgressRgHappyGoHostutil, `run_clean_host_command_in_dir "${ROOT_DIR}" env`, `run_clean_host_command_in_dir env`, 1),
+			entrypoint: hostutilEgressRgHappyEntrypoint,
+			colima:     hostutilEgressRgHappyColima,
+			wantErr:    "Expected scripts/lib/launcher/go-hostutil.sh to invoke the bootstrap Go helper from the repo root under a scrubbed environment with explicit Go caches",
+		},
+		{
+			// kindRegexPresent, escaped-literal "$@" pattern (fifth probe of the
+			// shared-message guard): the HOST_GO_BIN run line removed.
+			name:       "go-hostutil missing HOST_GO_BIN run",
+			goHostutil: strings.Replace(hostutilEgressRgHappyGoHostutil, `"${HOST_GO_BIN}" run ./cmd/workcell-hostutil "$@"`, `go run ./cmd/workcell-hostutil "$@"`, 1),
+			entrypoint: hostutilEgressRgHappyEntrypoint,
+			colima:     hostutilEgressRgHappyColima,
+			wantErr:    "Expected scripts/lib/launcher/go-hostutil.sh to invoke the bootstrap Go helper from the repo root under a scrubbed environment with explicit Go caches",
+		},
+		{
+			// kindRegexAbsent: a default Codex --cd override present is a violation.
+			name:       "entrypoint injects default codex --cd override",
+			goHostutil: hostutilEgressRgHappyGoHostutil,
+			entrypoint: hostutilEgressRgHappyEntrypoint + "set -- codex --cd /work\n",
+			colima:     hostutilEgressRgHappyColima,
+			wantErr:    "runtime/container/entrypoint.sh still injects a blocked default Codex --cd override",
+		},
+		{
+			// kindRegexAbsent, escaped-literal pattern: AGENT_NAME defaulting to
+			// codex present is a violation.
+			name:       "entrypoint defaults AGENT_NAME to codex",
+			goHostutil: hostutilEgressRgHappyGoHostutil,
+			entrypoint: hostutilEgressRgHappyEntrypoint + `AGENT_NAME="${AGENT_NAME:-codex}"` + "\n",
+			colima:     hostutilEgressRgHappyColima,
+			wantErr:    "runtime/container/entrypoint.sh still defaults AGENT_NAME to codex",
+		},
+		{
+			// kindRegexPresent (first probe of the trap guard): INT trap removed.
+			name:       "entrypoint missing INT trap",
+			goHostutil: hostutilEgressRgHappyGoHostutil,
+			entrypoint: strings.Replace(hostutilEgressRgHappyEntrypoint, `trap 'workcell_run_command_with_file_trace_signal INT' INT`, `trap - INT`, 1),
+			colima:     hostutilEgressRgHappyColima,
+			wantErr:    "Expected runtime/container/entrypoint.sh to trap INT/TERM and finalize file-trace shutdown before exit",
+		},
+		{
+			// kindRegexAbsent, GENUINE `|` alternation: any of command -v / type -P
+			// / which present means PATH is trusted (a violation).
+			name:       "colima trusts PATH via command -v",
+			goHostutil: hostutilEgressRgHappyGoHostutil,
+			entrypoint: hostutilEgressRgHappyEntrypoint,
+			colima:     hostutilEgressRgHappyColima + "tool=$(command -v git)\n",
+			wantErr:    "scripts/colima-egress-allowlist.sh still trusts PATH for executed host tools",
+		},
+		{
+			// kindRegexAbsent, third alternative of the `|` guard: `which ` present
+			// is likewise a violation, proving the alternation is a real regex.
+			name:       "colima trusts PATH via which",
+			goHostutil: hostutilEgressRgHappyGoHostutil,
+			entrypoint: hostutilEgressRgHappyEntrypoint,
+			colima:     hostutilEgressRgHappyColima + "tool=$(which git)\n",
+			wantErr:    "scripts/colima-egress-allowlist.sh still trusts PATH for executed host tools",
+		},
+		{
+			// kindFirstLineRegex: a non-cleared shebang fails the anchored
+			// first-line probe.
+			name:       "colima non-cleared shebang",
+			goHostutil: hostutilEgressRgHappyGoHostutil,
+			entrypoint: hostutilEgressRgHappyEntrypoint,
+			colima:     strings.Replace(hostutilEgressRgHappyColima, "#!/usr/bin/env -S -i PATH=/usr/bin BASH_ENV= ENV= /bin/bash", "#!/bin/bash", 1),
+			wantErr:    "Expected scripts/colima-egress-allowlist.sh to use env -S -i with an absolute /bin/bash and cleared host environment",
+		},
+		{
+			// kindRegexPresent, escaped-literal DYLD_\* pattern: the DYLD_* scrub
+			// removed.
+			name:       "colima missing DYLD scrub",
+			goHostutil: hostutilEgressRgHappyGoHostutil,
+			entrypoint: hostutilEgressRgHappyEntrypoint,
+			colima:     strings.Replace(hostutilEgressRgHappyColima, "unset DYLD_*", "unset OTHER", 1),
+			wantErr:    "Expected scripts/colima-egress-allowlist.sh to scrub DYLD_* variables before host tool lookup",
+		},
+		{
+			// kindRegexPresent (fifth probe of the Go-runtime guard): the runtimeutil
+			// run line removed.
+			name:       "colima missing Go runtime invocation",
+			goHostutil: hostutilEgressRgHappyGoHostutil,
+			entrypoint: hostutilEgressRgHappyEntrypoint,
+			colima:     strings.Replace(hostutilEgressRgHappyColima, `"${GO_BIN}" run ./cmd/workcell-runtimeutil "$@"`, `go run ./cmd/workcell-runtimeutil "$@"`, 1),
+			wantErr:    "Expected scripts/colima-egress-allowlist.sh to invoke Go runtime helpers under a scrubbed environment with explicit Go caches",
+		},
+		{
+			// A missing go-hostutil.sh is empty content: the first affirmative probe
+			// fails, mirroring `rg -q` returning non-zero on a missing file.
+			name:       "missing go-hostutil",
+			goHostutil: "",
+			entrypoint: hostutilEgressRgHappyEntrypoint,
+			colima:     hostutilEgressRgHappyColima,
+			wantErr:    "Expected scripts/lib/launcher/go-hostutil.sh to invoke the bootstrap Go helper from the repo root under a scrubbed environment with explicit Go caches",
+		},
+		{
+			// A missing entrypoint.sh is empty content: the two kindRegexAbsent
+			// probes pass on empty content, but the affirmative trap probe fails,
+			// mirroring `rg -q` returning non-zero on a missing file.
+			name:       "missing entrypoint",
+			goHostutil: hostutilEgressRgHappyGoHostutil,
+			entrypoint: "",
+			colima:     hostutilEgressRgHappyColima,
+			wantErr:    "Expected runtime/container/entrypoint.sh to trap INT/TERM and finalize file-trace shutdown before exit",
+		},
+		{
+			// A missing colima helper is empty content: the launcher/entrypoint
+			// probes pass, the kindRegexAbsent PATH-trust probe passes, but the
+			// affirmative REAL_HOME probe fails.
+			name:       "missing colima helper",
+			goHostutil: hostutilEgressRgHappyGoHostutil,
+			entrypoint: hostutilEgressRgHappyEntrypoint,
+			colima:     "",
+			wantErr:    "Expected scripts/colima-egress-allowlist.sh to derive the real host home independently of caller HOME",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeHostutilEgressRgRepo(t, tc.goHostutil, tc.entrypoint, tc.colima)
+			err := CheckHostutilEgressRg(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckHostutilEgressRg() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckHostutilEgressRg() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckHostutilEgressRg() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckHostutilEgressRgCount(t *testing.T) {
+	got := len(hostutilEgressRgChecks)
+	const want = 21
+	if got != want {
+		t.Fatalf("hostutilEgressRgChecks has %d checks, want %d", got, want)
+	}
+}
+
+// TestCheckHostutilEgressRgLineParity proves the per-line evaluator does not let
+// an escaped-literal pattern match across a newline: the HOST_GO_BIN run pattern
+// matches its intact single line but must NOT match when split by a newline,
+// mirroring ripgrep's default (non-multiline) behaviour.
+func TestCheckHostutilEgressRgLineParity(t *testing.T) {
+	pat := `"\$\{HOST_GO_BIN\}" run ./cmd/workcell-hostutil "\$@"`
+	if !regexMatchesAnyLine(pat, `"${HOST_GO_BIN}" run ./cmd/workcell-hostutil "$@"`) {
+		t.Fatalf("expected the intact HOST_GO_BIN run line to match")
+	}
+	if regexMatchesAnyLine(pat, "\"${HOST_GO_BIN}\" run ./cmd/workcell-hostutil\n\"$@\"") {
+		t.Fatalf("a HOST_GO_BIN run split across a newline must NOT match (rg is line-oriented)")
+	}
+}
+
+// TestCheckHostutilEgressRgRealRepo asserts that the real
+// scripts/lib/launcher/go-hostutil.sh, runtime/container/entrypoint.sh, and
+// scripts/colima-egress-allowlist.sh in this repository satisfy all twenty-one
+// hostutil / entrypoint / colima-egress invariants.  This is the key guard
+// against a mis-transcribed regex or a wrong target file: if any Go pattern
+// diverges from the actual file contents, this test fails with the guard's
+// stderr message.
+func TestCheckHostutilEgressRgRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, goHostutilRelPath)); err != nil {
+		t.Skipf("real scripts/lib/launcher/go-hostutil.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckHostutilEgressRg(repoRoot); err != nil {
+		t.Fatalf("CheckHostutilEgressRg(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2761,74 +2761,7 @@ WORKCELL_RUNTIME_BUILD_RETRY_HARNESS="${BARRIER_VERIFY_ROOT}/workcell-runtime-bu
 } >"${WORKCELL_RUNTIME_BUILD_RETRY_HARNESS}"
 bash "${WORKCELL_RUNTIME_BUILD_RETRY_HARNESS}"
 
-if ! rg -q 'run_clean_host_command_in_dir "\$\{ROOT_DIR\}" env' "${ROOT_DIR}/scripts/lib/launcher/go-hostutil.sh" ||
-  ! rg -q 'GOPATH="\$\{GOPATH\}"' "${ROOT_DIR}/scripts/lib/launcher/go-hostutil.sh" ||
-  ! rg -q 'GOMODCACHE="\$\{GOMODCACHE\}"' "${ROOT_DIR}/scripts/lib/launcher/go-hostutil.sh" ||
-  ! rg -q 'GOCACHE="\$\{GOCACHE\}"' "${ROOT_DIR}/scripts/lib/launcher/go-hostutil.sh" ||
-  ! rg -q '"\$\{HOST_GO_BIN\}" run ./cmd/workcell-hostutil "\$@"' "${ROOT_DIR}/scripts/lib/launcher/go-hostutil.sh"; then
-  echo "Expected scripts/lib/launcher/go-hostutil.sh to invoke the bootstrap Go helper from the repo root under a scrubbed environment with explicit Go caches" >&2
-  exit 1
-fi
-
-if rg -q 'set -- codex --cd ' "${ROOT_DIR}/runtime/container/entrypoint.sh"; then
-  echo "runtime/container/entrypoint.sh still injects a blocked default Codex --cd override" >&2
-  exit 1
-fi
-
-if rg -q 'AGENT_NAME="\$\{AGENT_NAME:-codex\}"' "${ROOT_DIR}/runtime/container/entrypoint.sh"; then
-  echo "runtime/container/entrypoint.sh still defaults AGENT_NAME to codex" >&2
-  exit 1
-fi
-
-if ! rg -q "trap 'workcell_run_command_with_file_trace_signal INT' INT" "${ROOT_DIR}/runtime/container/entrypoint.sh" ||
-  ! rg -q "trap 'workcell_run_command_with_file_trace_signal TERM' TERM" "${ROOT_DIR}/runtime/container/entrypoint.sh"; then
-  echo "Expected runtime/container/entrypoint.sh to trap INT/TERM and finalize file-trace shutdown before exit" >&2
-  exit 1
-fi
-
-if rg -q 'command -v|type -P|which ' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "scripts/colima-egress-allowlist.sh still trusts PATH for executed host tools" >&2
-  exit 1
-fi
-
-if ! rg -q 'REAL_HOME=' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Expected scripts/colima-egress-allowlist.sh to derive the real host home independently of caller HOME" >&2
-  exit 1
-fi
-
-if ! head -n 1 "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" | grep -q '^#!/usr/bin/env -S -i PATH=.* BASH_ENV= ENV= /bin/bash$'; then
-  echo "Expected scripts/colima-egress-allowlist.sh to use env -S -i with an absolute /bin/bash and cleared host environment" >&2
-  exit 1
-fi
-
-if ! rg -q 'scrub_host_process_env' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Expected scripts/colima-egress-allowlist.sh to scrub hostile host process environment before host tool lookup" >&2
-  exit 1
-fi
-
-if ! rg -q 'unset PERL5OPT PERL5LIB PERLLIB PERL_MB_OPT PERL_MM_OPT' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Expected scripts/colima-egress-allowlist.sh to scrub hostile Perl environment before host tool lookup" >&2
-  exit 1
-fi
-
-if ! rg -q 'DYLD_\*' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Expected scripts/colima-egress-allowlist.sh to scrub DYLD_* variables before host tool lookup" >&2
-  exit 1
-fi
-
-if ! rg -q 'is_trusted_host_tool_path' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Expected scripts/colima-egress-allowlist.sh to canonicalize and trust-check host tool paths" >&2
-  exit 1
-fi
-
-if ! rg -q 'run_clean_repo_command env' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" ||
-  ! rg -q 'GOPATH="\$\{GOPATH\}"' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" ||
-  ! rg -q 'GOMODCACHE="\$\{GOMODCACHE\}"' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" ||
-  ! rg -q 'GOCACHE="\$\{GOCACHE\}"' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" ||
-  ! rg -q '"\$\{GO_BIN\}" run ./cmd/workcell-runtimeutil "\$@"' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Expected scripts/colima-egress-allowlist.sh to invoke Go runtime helpers under a scrubbed environment with explicit Go caches" >&2
-  exit 1
-fi
+go_verify_citools workcell-hostutil-egress-rg "${ROOT_DIR}" || exit 1
 
 for script in "${HOST_GATE_SCRIPTS[@]}"; do
   if ! head -n 1 "${script}" | grep -q '^#!/bin/bash -p$'; then


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 21 of N (larger batch).** Follows #398-#417. Migrates 21 `rg`-based invariant checks (former lines 2764-2831) across host-go-util cache pinning, entrypoint trap signals, and colima-egress PATH/env scrubbing.

## What
- **`internal/workcellhardening`**: new `CheckHostutilEgressRg(rootDir)` reusing existing regex kinds (no new kinds). 21 checks: `go-hostutil.sh` (×5), `entrypoint.sh` (×4), `colima-egress-allowlist.sh` (×12).
- **`cmd/workcell-citools`**: new `workcell-hostutil-egress-rg` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-hostutil-egress-rg "${ROOT_DIR}" || exit 1`. Stopped before the `HOST_GATE_SCRIPTS` dynamic-array loop.

## Regex handling (rg parity)
Each `rg -q` migrated as `kindRegexPresent`/`kindRegexAbsent` (or `kindFirstLineRegex` for the `head -n1 | grep -q '^…$'` shebang), pattern verbatim, evaluated **per-line** (ripgrep line semantics). Escaped-literal patterns (`"\$\{ROOT_DIR\}"`, `GOPATH="\$\{GOPATH\}"`, `DYLD_\*`, …) keep their regex escapes (Go `regexp` reads them identically); `command -v|type -P|which ` is genuine `|` alternation (negated PATH-trust guard → absent). Multi-probe `||` guards → ordered checks sharing one message.

## Parity
Real repo → exit 0; 5 crafted violations → exit 1 byte-identical. Line-parity test confirms a pattern matches its intact line but not across a newline. Real-repo assertion + count=21 guard.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 539 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)