### PR TITLE
^R D3: migrate dockerfile-pin rg invariants to Go (30 checks)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -115,6 +115,7 @@ func subcommands() []subcommand {
 		{"workcell-inspect-assurance-loops", "ROOT_DIR", 1, 1, cmdWorkcellInspectAssuranceLoops},
 		{"workcell-validator-writable-state", "ROOT_DIR", 1, 1, cmdWorkcellValidatorWritableState},
 		{"workcell-hostutil-egress-rg", "ROOT_DIR", 1, 1, cmdWorkcellHostutilEgressRg},
+		{"workcell-dockerfile-pins", "ROOT_DIR", 1, 1, cmdWorkcellDockerfilePins},
 	}
 }
 
@@ -678,4 +679,13 @@ func cmdWorkcellValidatorWritableState(args []string) error {
 // first violated invariant.
 func cmdWorkcellHostutilEgressRg(args []string) error {
 	return workcellhardening.CheckHostutilEgressRg(args[0])
+}
+
+// cmdWorkcellDockerfilePins runs the thirty dockerfile-pin checks
+// (snapshot-TLS-bootstrap package/apt pins and unprivileged-USER defaults across
+// runtime/container/Dockerfile and tools/validator/Dockerfile) migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the shell's
+// original stderr message for the first violated invariant.
+func cmdWorkcellDockerfilePins(args []string) error {
+	return workcellhardening.CheckDockerfilePins(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -72,6 +72,13 @@ const launcherRelPath = "scripts/workcell"
 // check leaves check.targetFile empty and so defaults to launcherRelPath.
 const dockerfileRelPath = "runtime/container/Dockerfile"
 
+// validatorDockerfileRelPath is the repo-relative path to the validator image
+// Dockerfile.  The dockerfile-pins block reads it alongside dockerfileRelPath
+// (via the per-check targetFile field) for its snapshot-TLS-bootstrap pin and
+// unprivileged-USER invariants, mirroring the shell `rg` probes that iterated
+// ${ROOT_DIR}/runtime/container/Dockerfile and ${ROOT_DIR}/tools/validator/Dockerfile.
+const validatorDockerfileRelPath = "tools/validator/Dockerfile"
+
 // colimaEgressAllowlistRelPath is the repo-relative path to the Colima
 // egress-allowlist helper.  Only the two shadow-enum-egress IPv6 invariants
 // read this file instead of scripts/workcell (via the per-check targetFile
@@ -3097,6 +3104,101 @@ var hostutilEgressRgChecks = []check{
 // first violated invariant (the shell's exit 1).
 func CheckHostutilEgressRg(rootDir string) error {
 	return evaluate(rootDir, hostutilEgressRgChecks)
+}
+
+// dockerfilePinRelPaths lists, in the shell loop's order, the two Dockerfiles
+// whose snapshot-TLS-bootstrap pins and unprivileged-USER default the migrated
+// block asserts: runtime/container/Dockerfile then tools/validator/Dockerfile.
+// Both shell `for dockerfile in ...; do ...; done` loops iterated exactly this
+// fixed pair, so preserving the order keeps first-violation parity.
+var dockerfilePinRelPaths = []string{dockerfileRelPath, validatorDockerfileRelPath}
+
+// dockerfilePinSpec pairs one `rg -q` pattern with the tail of the shell's echo
+// message (everything after "Expected ${dockerfile} ").  The pinInner guards
+// that joined several `! rg -q` probes with `||` under one message are expressed
+// as consecutive specs sharing the same messageSuffix, mirroring the shell (any
+// missing probe yields the same stderr and exit 1 as the corresponding `if`).
+type dockerfilePinSpec struct {
+	pattern       string
+	messageSuffix string
+}
+
+// dockerfilePinSpecs lists the fourteen per-Dockerfile snapshot-TLS-bootstrap
+// pin probes in the same order as the former inline `for dockerfile` loop in
+// scripts/verify-invariants.sh, so a reviewer can diff the two one-to-one.
+//
+// Every probe is an `rg -q` regex (line-oriented, matched per line via
+// regexMatchesAnyLine for `rg` parity), kept verbatim as a regex: the
+// escaped-literal patterns (`ca-certificates_20250419_all\.deb`,
+// `rm -f "\$\{output\}";`, `sleep "\$\(\(attempt \* 5\)\)";`, `\| sha256sum`,
+// ...) use the rg regex escapes `\. \$ \{ \} \( \) \* \|` to match the literal
+// chars; Go's regexp interprets the same escapes, so each pattern is used
+// byte-for-byte.
+//
+// The last eight specs form the two `||`-joined guards: three
+// retry/discard-partial probes sharing one message, then five fail-closed
+// download/checksum/dpkg probes sharing another.
+var dockerfilePinSpecs = []dockerfilePinSpec{
+	{`ca-certificates_20250419_all\.deb`, "to pin a snapshot CA bundle bootstrap package before HTTPS apt"},
+	{`openssl_3\.5\.5-1~deb13u1_amd64\.deb`, "to pin the amd64 snapshot OpenSSL bootstrap package before HTTPS apt"},
+	{`openssl_3\.5\.5-1~deb13u1_arm64\.deb`, "to pin the arm64 snapshot OpenSSL bootstrap package before HTTPS apt"},
+	{`Acquire::Retries "5";`, "to pin apt retry count for snapshot fetch resilience"},
+	{`Acquire::http::Timeout "30";`, "to pin apt HTTP timeout for snapshot fetch resilience"},
+	{`Acquire::https::Timeout "30";`, "to pin apt HTTPS timeout for snapshot fetch resilience"},
+	{`for attempt in 1 2 3; do`, "snapshot TLS bootstrap downloads to retry and discard partial packages"},
+	{`rm -f "\$\{output\}";`, "snapshot TLS bootstrap downloads to retry and discard partial packages"},
+	{`sleep "\$\(\(attempt \* 5\)\)";`, "snapshot TLS bootstrap downloads to retry and discard partial packages"},
+	{`fetch_snapshot_bootstrap_package "\$\{openssl_url\}" /tmp/workcell-bootstrap-openssl\.deb`, "snapshot TLS bootstrap to fail closed across download, checksum, and dpkg steps"},
+	{`&& echo "\$\{openssl_sha256\}  /tmp/workcell-bootstrap-openssl\.deb" \| sha256sum -c -`, "snapshot TLS bootstrap to fail closed across download, checksum, and dpkg steps"},
+	{`&& fetch_snapshot_bootstrap_package "\$\{ca_url\}" /tmp/workcell-bootstrap-ca-certificates\.deb`, "snapshot TLS bootstrap to fail closed across download, checksum, and dpkg steps"},
+	{`&& echo "\$\{ca_sha256\}  /tmp/workcell-bootstrap-ca-certificates\.deb" \| sha256sum -c -`, "snapshot TLS bootstrap to fail closed across download, checksum, and dpkg steps"},
+	{`&& dpkg -i /tmp/workcell-bootstrap-openssl\.deb /tmp/workcell-bootstrap-ca-certificates\.deb`, "snapshot TLS bootstrap to fail closed across download, checksum, and dpkg steps"},
+}
+
+// dockerfilePinsChecks builds the thirty dockerfile-pin invariants for the repo
+// rooted at rootDir, in the shell's original order: the fourteen
+// snapshot-TLS-bootstrap pins for each Dockerfile (first loop, both Dockerfiles)
+// followed by the unprivileged-USER default for each Dockerfile (second loop,
+// both Dockerfiles).
+//
+// The shell echoes interpolated the loop variable ${dockerfile}, whose value was
+// the array element "${ROOT_DIR}/<relpath>" — i.e. the ABSOLUTE path once
+// ${ROOT_DIR} expands.  Each message is therefore constructed dynamically here as
+// "Expected " + rootDir + "/" + relpath + " " + suffix, using literal string
+// concatenation (not filepath.Join) to reproduce the shell's byte-exact
+// rendering.  The read target stays the repo-relative path via targetFile, so
+// evaluate reads the same file the message names.
+func dockerfilePinsChecks(rootDir string) []check {
+	cs := make([]check, 0, len(dockerfilePinRelPaths)*(len(dockerfilePinSpecs)+1))
+	for _, rel := range dockerfilePinRelPaths {
+		df := rootDir + "/" + rel
+		for _, spec := range dockerfilePinSpecs {
+			cs = append(cs, check{
+				kind:       kindRegexPresent,
+				pattern:    spec.pattern,
+				message:    "Expected " + df + " " + spec.messageSuffix,
+				targetFile: rel,
+			})
+		}
+	}
+	for _, rel := range dockerfilePinRelPaths {
+		df := rootDir + "/" + rel
+		cs = append(cs, check{
+			kind:       kindRegexPresent,
+			pattern:    `^USER workcell$`,
+			message:    "Expected " + df + " to default to the named unprivileged workcell user",
+			targetFile: rel,
+		})
+	}
+	return cs
+}
+
+// CheckDockerfilePins runs the thirty dockerfile-pin invariants against the repo
+// rooted at rootDir, in the shell's original order.  It returns nil when every
+// invariant holds (the shell's exit 0), or an error whose message equals the
+// shell's stderr for the first violated invariant (the shell's exit 1).
+func CheckDockerfilePins(rootDir string) error {
+	return evaluate(rootDir, dockerfilePinsChecks(rootDir))
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -4456,3 +4456,202 @@ func TestCheckHostutilEgressRgRealRepo(t *testing.T) {
 		t.Fatalf("CheckHostutilEgressRg(real repo) = %v, want nil", err)
 	}
 }
+
+// dockerfilePinsHappyBody is a minimal but structurally faithful Dockerfile
+// that satisfies all fifteen per-Dockerfile dockerfile-pin invariants: it pins
+// the snapshot CA bundle / amd64+arm64 OpenSSL bootstrap packages, the apt
+// retry/timeout settings, the retry-and-discard TLS bootstrap download loop, the
+// fail-closed download/checksum/dpkg chain, and the unprivileged `USER workcell`
+// default.  Each snippet sits on its own physical line so the per-line evaluator
+// (regexMatchesAnyLine, `rg` parity) matches it exactly as ripgrep would.  Both
+// fixture Dockerfiles use this baseline; individual negative cases mutate one
+// property of one file.
+const dockerfilePinsHappyBody = `FROM debian:trixie-slim
+ARG CA_DEB=ca-certificates_20250419_all.deb
+ARG OPENSSL_AMD64=openssl_3.5.5-1~deb13u1_amd64.deb
+ARG OPENSSL_ARM64=openssl_3.5.5-1~deb13u1_arm64.deb
+RUN echo 'Acquire::Retries "5";' >>/etc/apt/apt.conf
+RUN echo 'Acquire::http::Timeout "30";' >>/etc/apt/apt.conf
+RUN echo 'Acquire::https::Timeout "30";' >>/etc/apt/apt.conf
+RUN for attempt in 1 2 3; do \
+      rm -f "${output}"; \
+      sleep "$((attempt * 5))"; \
+    done
+RUN fetch_snapshot_bootstrap_package "${openssl_url}" /tmp/workcell-bootstrap-openssl.deb \
+    && echo "${openssl_sha256}  /tmp/workcell-bootstrap-openssl.deb" | sha256sum -c - \
+    && fetch_snapshot_bootstrap_package "${ca_url}" /tmp/workcell-bootstrap-ca-certificates.deb \
+    && echo "${ca_sha256}  /tmp/workcell-bootstrap-ca-certificates.deb" | sha256sum -c - \
+    && dpkg -i /tmp/workcell-bootstrap-openssl.deb /tmp/workcell-bootstrap-ca-certificates.deb
+USER workcell
+`
+
+func writeDockerfilePinsRepo(t *testing.T, runtimeDF, validatorDF string) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, body string) {
+		if body == "" {
+			return
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(dockerfileRelPath, runtimeDF)
+	write(validatorDockerfileRelPath, validatorDF)
+	return root
+}
+
+func TestCheckDockerfilePins(t *testing.T) {
+	tests := []struct {
+		name        string
+		runtimeDF   string
+		validatorDF string
+		wantRel     string // "" means expect success
+		wantSuffix  string
+	}{
+		{
+			name:        "happy path all invariants hold",
+			runtimeDF:   dockerfilePinsHappyBody,
+			validatorDF: dockerfilePinsHappyBody,
+		},
+		{
+			// CA-pin probe missing from the runtime Dockerfile (first probe of
+			// the first Dockerfile → first violation).
+			name:        "runtime missing CA bundle pin",
+			runtimeDF:   strings.Replace(dockerfilePinsHappyBody, "ca-certificates_20250419_all.deb", "ca-certificates_OLD_all.deb", 1),
+			validatorDF: dockerfilePinsHappyBody,
+			wantRel:     dockerfileRelPath,
+			wantSuffix:  "to pin a snapshot CA bundle bootstrap package before HTTPS apt",
+		},
+		{
+			// arm64 OpenSSL pin missing from the validator Dockerfile: the runtime
+			// Dockerfile passes entirely first, then the validator's third probe
+			// fires, proving the Dockerfile-outer order.
+			name:        "validator missing arm64 OpenSSL pin",
+			runtimeDF:   dockerfilePinsHappyBody,
+			validatorDF: strings.Replace(dockerfilePinsHappyBody, "openssl_3.5.5-1~deb13u1_arm64.deb", "openssl_OLD_arm64.deb", 1),
+			wantRel:     validatorDockerfileRelPath,
+			wantSuffix:  "to pin the arm64 snapshot OpenSSL bootstrap package before HTTPS apt",
+		},
+		{
+			// apt HTTPS timeout pin missing from the runtime Dockerfile.
+			name:        "runtime missing apt HTTPS timeout",
+			runtimeDF:   strings.Replace(dockerfilePinsHappyBody, `Acquire::https::Timeout "30";`, "", 1),
+			validatorDF: dockerfilePinsHappyBody,
+			wantRel:     dockerfileRelPath,
+			wantSuffix:  "to pin apt HTTPS timeout for snapshot fetch resilience",
+		},
+		{
+			// retry/discard shared-message guard: the sleep probe removed from the
+			// validator Dockerfile yields the guard's shared message.
+			name:        "validator missing retry sleep",
+			runtimeDF:   dockerfilePinsHappyBody,
+			validatorDF: strings.Replace(dockerfilePinsHappyBody, `sleep "$((attempt * 5))";`, "", 1),
+			wantRel:     validatorDockerfileRelPath,
+			wantSuffix:  "snapshot TLS bootstrap downloads to retry and discard partial packages",
+		},
+		{
+			// fail-closed shared-message guard: the dpkg probe broken in the
+			// runtime Dockerfile yields the guard's shared message.
+			name:        "runtime broken fail-closed dpkg step",
+			runtimeDF:   strings.Replace(dockerfilePinsHappyBody, "dpkg -i /tmp/workcell-bootstrap-openssl.deb", "dpkgBROKEN -i /tmp/workcell-bootstrap-openssl.deb", 1),
+			validatorDF: dockerfilePinsHappyBody,
+			wantRel:     dockerfileRelPath,
+			wantSuffix:  "snapshot TLS bootstrap to fail closed across download, checksum, and dpkg steps",
+		},
+		{
+			// USER-default probe (second loop) missing from the validator
+			// Dockerfile: every pin probe passes for both Dockerfiles, then the
+			// validator's USER probe (last check) fires.
+			name:        "validator missing unprivileged USER default",
+			runtimeDF:   dockerfilePinsHappyBody,
+			validatorDF: strings.Replace(dockerfilePinsHappyBody, "USER workcell", "USER root", 1),
+			wantRel:     validatorDockerfileRelPath,
+			wantSuffix:  "to default to the named unprivileged workcell user",
+		},
+		{
+			// A missing runtime Dockerfile is empty content: its first probe fails,
+			// mirroring `rg -q` returning non-zero on a missing file.
+			name:        "runtime Dockerfile missing",
+			runtimeDF:   "",
+			validatorDF: dockerfilePinsHappyBody,
+			wantRel:     dockerfileRelPath,
+			wantSuffix:  "to pin a snapshot CA bundle bootstrap package before HTTPS apt",
+		},
+		{
+			// Both Dockerfiles broken: the runtime CA pin (first check overall)
+			// wins over the validator USER pin, proving the runtime-before-validator
+			// ordering.
+			name:        "both broken runtime wins",
+			runtimeDF:   strings.Replace(dockerfilePinsHappyBody, "ca-certificates_20250419_all.deb", "ca-certificates_OLD_all.deb", 1),
+			validatorDF: strings.Replace(dockerfilePinsHappyBody, "USER workcell", "USER root", 1),
+			wantRel:     dockerfileRelPath,
+			wantSuffix:  "to pin a snapshot CA bundle bootstrap package before HTTPS apt",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeDockerfilePinsRepo(t, tc.runtimeDF, tc.validatorDF)
+			err := CheckDockerfilePins(root)
+			if tc.wantRel == "" {
+				if err != nil {
+					t.Fatalf("CheckDockerfilePins() = %v, want nil", err)
+				}
+				return
+			}
+			want := "Expected " + root + "/" + tc.wantRel + " " + tc.wantSuffix
+			if err == nil {
+				t.Fatalf("CheckDockerfilePins() = nil, want error %q", want)
+			}
+			if err.Error() != want {
+				t.Fatalf("CheckDockerfilePins() error = %q, want %q", err.Error(), want)
+			}
+		})
+	}
+}
+
+// TestCheckDockerfilePinsCount asserts the generated check list contains exactly
+// thirty checks: fourteen snapshot-TLS-bootstrap pins plus one USER-default per
+// Dockerfile, across two Dockerfiles.
+func TestCheckDockerfilePinsCount(t *testing.T) {
+	got := len(dockerfilePinsChecks("/repo"))
+	const want = 30
+	if got != want {
+		t.Fatalf("dockerfilePinsChecks(...) has %d checks, want %d", got, want)
+	}
+}
+
+// TestCheckDockerfilePinsLineParity proves the per-line evaluator does not let an
+// escaped-literal fail-closed pattern match across a newline: the dpkg probe
+// matches its intact single line but must NOT match when split by a newline,
+// mirroring ripgrep's default (non-multiline) behaviour.
+func TestCheckDockerfilePinsLineParity(t *testing.T) {
+	pat := `&& dpkg -i /tmp/workcell-bootstrap-openssl\.deb /tmp/workcell-bootstrap-ca-certificates\.deb`
+	if !regexMatchesAnyLine(pat, "&& dpkg -i /tmp/workcell-bootstrap-openssl.deb /tmp/workcell-bootstrap-ca-certificates.deb") {
+		t.Fatalf("expected the intact dpkg fail-closed line to match")
+	}
+	if regexMatchesAnyLine(pat, "&& dpkg -i /tmp/workcell-bootstrap-openssl.deb\n/tmp/workcell-bootstrap-ca-certificates.deb") {
+		t.Fatalf("a dpkg step split across a newline must NOT match (rg is line-oriented)")
+	}
+}
+
+// TestCheckDockerfilePinsRealRepo asserts that the real
+// runtime/container/Dockerfile and tools/validator/Dockerfile in this repository
+// satisfy all thirty dockerfile-pin invariants.  This is the key guard against a
+// mis-transcribed regex or a wrong target file: if any Go pattern diverges from
+// the actual Dockerfile contents, this test fails with the guard's stderr
+// message.
+func TestCheckDockerfilePinsRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, dockerfileRelPath)); err != nil {
+		t.Skipf("real runtime/container/Dockerfile not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckDockerfilePins(repoRoot); err != nil {
+		t.Fatalf("CheckDockerfilePins(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2919,57 +2919,21 @@ fi
 # diagnostics, preserving the exact failure stderr surface.
 go_verify_citools workcell-bootstrap-egress "${ROOT_DIR}" || exit 1
 
-for dockerfile in \
-  "${ROOT_DIR}/runtime/container/Dockerfile" \
-  "${ROOT_DIR}/tools/validator/Dockerfile"; do
-  if ! rg -q 'ca-certificates_20250419_all\.deb' "${dockerfile}"; then
-    echo "Expected ${dockerfile} to pin a snapshot CA bundle bootstrap package before HTTPS apt" >&2
-    exit 1
-  fi
-  if ! rg -q 'openssl_3\.5\.5-1~deb13u1_amd64\.deb' "${dockerfile}"; then
-    echo "Expected ${dockerfile} to pin the amd64 snapshot OpenSSL bootstrap package before HTTPS apt" >&2
-    exit 1
-  fi
-  if ! rg -q 'openssl_3\.5\.5-1~deb13u1_arm64\.deb' "${dockerfile}"; then
-    echo "Expected ${dockerfile} to pin the arm64 snapshot OpenSSL bootstrap package before HTTPS apt" >&2
-    exit 1
-  fi
-  if ! rg -q 'Acquire::Retries "5";' "${dockerfile}"; then
-    echo "Expected ${dockerfile} to pin apt retry count for snapshot fetch resilience" >&2
-    exit 1
-  fi
-  if ! rg -q 'Acquire::http::Timeout "30";' "${dockerfile}"; then
-    echo "Expected ${dockerfile} to pin apt HTTP timeout for snapshot fetch resilience" >&2
-    exit 1
-  fi
-  if ! rg -q 'Acquire::https::Timeout "30";' "${dockerfile}"; then
-    echo "Expected ${dockerfile} to pin apt HTTPS timeout for snapshot fetch resilience" >&2
-    exit 1
-  fi
-  if ! rg -q 'for attempt in 1 2 3; do' "${dockerfile}" ||
-    ! rg -q 'rm -f "\$\{output\}";' "${dockerfile}" ||
-    ! rg -q 'sleep "\$\(\(attempt \* 5\)\)";' "${dockerfile}"; then
-    echo "Expected ${dockerfile} snapshot TLS bootstrap downloads to retry and discard partial packages" >&2
-    exit 1
-  fi
-  if ! rg -q 'fetch_snapshot_bootstrap_package "\$\{openssl_url\}" /tmp/workcell-bootstrap-openssl\.deb' "${dockerfile}" ||
-    ! rg -q '&& echo "\$\{openssl_sha256\}  /tmp/workcell-bootstrap-openssl\.deb" \| sha256sum -c -' "${dockerfile}" ||
-    ! rg -q '&& fetch_snapshot_bootstrap_package "\$\{ca_url\}" /tmp/workcell-bootstrap-ca-certificates\.deb' "${dockerfile}" ||
-    ! rg -q '&& echo "\$\{ca_sha256\}  /tmp/workcell-bootstrap-ca-certificates\.deb" \| sha256sum -c -' "${dockerfile}" ||
-    ! rg -q '&& dpkg -i /tmp/workcell-bootstrap-openssl\.deb /tmp/workcell-bootstrap-ca-certificates\.deb' "${dockerfile}"; then
-    echo "Expected ${dockerfile} snapshot TLS bootstrap to fail closed across download, checksum, and dpkg steps" >&2
-    exit 1
-  fi
-done
-
-for dockerfile in \
-  "${ROOT_DIR}/runtime/container/Dockerfile" \
-  "${ROOT_DIR}/tools/validator/Dockerfile"; do
-  if ! rg -q '^USER workcell$' "${dockerfile}"; then
-    echo "Expected ${dockerfile} to default to the named unprivileged workcell user" >&2
-    exit 1
-  fi
-done
+# Assert the dockerfile-pin invariants across runtime/container/Dockerfile and
+# tools/validator/Dockerfile: each pins the snapshot CA bundle / amd64+arm64
+# OpenSSL bootstrap packages, the apt retry/timeout settings, the retry-and-
+# discard TLS bootstrap download loop, the fail-closed download/checksum/dpkg
+# chain, and the unprivileged `USER workcell` default.  Migrated to Go (D3):
+# internal/workcellhardening behind the workcell-citools workcell-dockerfile-pins
+# subcommand preserves the exact exit codes and stderr messages of the former
+# inline `for dockerfile` rg loops, including the per-line (`rg`-parity) regex
+# matching of every escaped-literal pattern and the ${dockerfile}-interpolated
+# messages (rendered as the absolute "${ROOT_DIR}/..." path exactly as the shell
+# loop variable held it).  `|| exit 1` matches the former inline block's `exit 1`
+# on a violated invariant: it handles the failure so the top-level ERR trap does
+# not fire and append trap diagnostics, preserving the exact failure stderr
+# surface.
+go_verify_citools workcell-dockerfile-pins "${ROOT_DIR}" || exit 1
 
 validator_dockerfile="${ROOT_DIR}/tools/validator/Dockerfile"
 for required in \


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 22 of N (larger batch).** Follows #398-#418. Migrates 30 dockerfile-pin invariant checks (former lines 2922-2972) — the two `for dockerfile in runtime/container/Dockerfile tools/validator/Dockerfile` rg loops pinning apt/ca-cert/openssl versions + apt retry/timeout + USER default.

## What
- **`internal/workcellhardening`**: new `CheckDockerfilePins(rootDir)` reusing `kindRegexPresent` (no new kinds). 30 checks = 2 Dockerfiles × (14 pins + USER default), in shell order, patterns verbatim (per-line).
- **`cmd/workcell-citools`**: new `workcell-dockerfile-pins` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-dockerfile-pins "${ROOT_DIR}" || exit 1`. Bounded above by the already-migrated `workcell-bootstrap-egress` call; stopped at 30 (the next `for required` grep loop reads a different file with a 2-var message — next increment).

## Parity note (absolute-path messages)
The shell loop variable holds `"${ROOT_DIR}/<relpath>"`, so its echoed message contains the **absolute** path. Messages are built as `"Expected " + rootDir + "/" + relpath + " " + suffix` (literal concatenation, matching the shell byte-for-byte); `targetFile` keeps the repo-relative path for reading. Verified byte-exact against the extracted original loop across 10 mutated fixtures (both Dockerfiles, every pin category, retry-discard/fail-closed guards, USER default) — identical exit codes + messages.

## Validation
Real repo → exit 0; real-repo assertion + count=30 + line-parity guards. `go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 377 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)