### PR TITLE
^R D3: migrate validator-env/dispatch loop invariants to Go (13 checks)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -116,6 +116,7 @@ func subcommands() []subcommand {
 		{"workcell-validator-writable-state", "ROOT_DIR", 1, 1, cmdWorkcellValidatorWritableState},
 		{"workcell-hostutil-egress-rg", "ROOT_DIR", 1, 1, cmdWorkcellHostutilEgressRg},
 		{"workcell-dockerfile-pins", "ROOT_DIR", 1, 1, cmdWorkcellDockerfilePins},
+		{"workcell-validator-dispatch-loops", "ROOT_DIR", 1, 1, cmdWorkcellValidatorDispatchLoops},
 	}
 }
 
@@ -688,4 +689,13 @@ func cmdWorkcellHostutilEgressRg(args []string) error {
 // original stderr message for the first violated invariant.
 func cmdWorkcellDockerfilePins(args []string) error {
 	return workcellhardening.CheckDockerfilePins(args[0])
+}
+
+// cmdWorkcellValidatorDispatchLoops runs the thirteen validator-dispatch checks
+// (validator Dockerfile ENV pins, validate-repo Cargo-target externalization,
+// and CI-dispatch entrypoint wiring) migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the shell's
+// original stderr message for the first violated invariant.
+func cmdWorkcellValidatorDispatchLoops(args []string) error {
+	return workcellhardening.CheckValidatorDispatchLoops(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -218,6 +218,29 @@ const claudeGuardBashRelPath = "adapters/claude/hooks/guard-bash.sh"
 // `grep -Fq -- FIELD scripts/workcell runtime/container/assurance.sh`.
 const assuranceRelPath = "runtime/container/assurance.sh"
 
+// validateRepoRelPath is the repo-relative path to the in-validator repo
+// validation script.  The validator-dispatch block reads this file (via the
+// per-check targetFile field) for its Cargo-target externalization invariant,
+// mirroring the shell `grep -Fq` probes that ran against
+// ${ROOT_DIR}/scripts/validate-repo.sh.
+const validateRepoRelPath = "scripts/validate-repo.sh"
+
+// ciWorkflowRelPath, docsWorkflowRelPath, and mutationWorkflowRelPath are the
+// repo-relative paths to the three lane workflows the validator-dispatch block's
+// dispatch loop probes (via the per-check targetFile field), mirroring the shell
+// `grep -Fq --` probes that ran against ${ROOT_DIR}/.github/workflows/ci.yml,
+// docs.yml, and mutation.yml.
+const ciWorkflowRelPath = ".github/workflows/ci.yml"
+const docsWorkflowRelPath = ".github/workflows/docs.yml"
+const mutationWorkflowRelPath = ".github/workflows/mutation.yml"
+
+// preMergeRelPath is the repo-relative path to the pre-merge helper.  The
+// validator-dispatch block's dispatch loop reads this file twice (via the
+// per-check targetFile field) for its job-validate and job-docs dispatch
+// invariants, mirroring the shell `grep -Fq --` probes that ran against
+// ${ROOT_DIR}/scripts/pre-merge.sh.
+const preMergeRelPath = "scripts/pre-merge.sh"
+
 // checkKind selects how a check's pattern is matched against the launcher
 // contents.
 type checkKind int
@@ -3199,6 +3222,109 @@ func dockerfilePinsChecks(rootDir string) []check {
 // shell's stderr for the first violated invariant (the shell's exit 1).
 func CheckDockerfilePins(rootDir string) error {
 	return evaluate(rootDir, dockerfilePinsChecks(rootDir))
+}
+
+// validatorEnvPinNeedles lists, in the shell for-loop's order, the six ENV pins
+// the validator Dockerfile must carry so its default nonroot writable state
+// lives under /home/workcell.  Each was a fixed `grep -Fq "${required}"` literal
+// in the migrated `for required in ...; do` loop.
+var validatorEnvPinNeedles = []string{
+	"ENV HOME=/home/workcell",
+	"ENV XDG_CACHE_HOME=/home/workcell/.cache",
+	"ENV GOCACHE=/home/workcell/.cache/go-build",
+	"ENV GOMODCACHE=/home/workcell/.cache/go-mod",
+	"ENV CARGO_TARGET_DIR=/home/workcell/.cache/cargo-target",
+	"ENV TMPDIR=/home/workcell/.tmp",
+}
+
+// dispatchSpec pairs one dispatch-loop target file with the fixed `grep -Fq --`
+// needle that file must contain.  The shell `for dispatch_check in ...` loop
+// carried each pair as a single "FILE:NEEDLE" element split on its first colon;
+// preserving the slice order keeps first-violation parity.
+type dispatchSpec struct {
+	relPath string
+	needle  string
+}
+
+// validatorDispatchSpecs lists the five dispatch-loop probes in the shell
+// loop's order.  Each element's file path was ${ROOT_DIR}/<relPath> (the shell
+// split "${dispatch_check%%:*}"), and its needle was the loop's
+// "${dispatch_check#*:}"; both scripts/pre-merge.sh entries reuse preMergeRelPath
+// with distinct needles, mirroring the two pre-merge dispatch probes.
+var validatorDispatchSpecs = []dispatchSpec{
+	{ciWorkflowRelPath, "./scripts/ci/job-validate.sh --profile pr-parity"},
+	{docsWorkflowRelPath, "./scripts/ci/job-docs.sh"},
+	{mutationWorkflowRelPath, "./scripts/ci/job-mutation.sh"},
+	{preMergeRelPath, "scripts/ci/job-validate.sh"},
+	{preMergeRelPath, "scripts/ci/job-docs.sh"},
+}
+
+// validatorDispatchLoopsChecks builds the thirteen validator-dispatch invariants
+// for the repo rooted at rootDir, in the shell's original order: the six
+// validator-Dockerfile ENV-pin probes, the two validate-repo Cargo-target
+// externalization probes, then the five CI-dispatch probes.
+//
+// Two of the three migrated blocks echoed the loop's file variable, whose value
+// was ${ROOT_DIR}/<relpath> — i.e. the ABSOLUTE path once ${ROOT_DIR} expands.
+// Those messages are therefore constructed dynamically as
+// "Expected " + rootDir + "/" + relpath + " ...", using literal string
+// concatenation (not filepath.Join) to reproduce the shell's byte-exact
+// rendering.  The read target stays the repo-relative path via targetFile, so
+// evaluate reads the same file the message names.
+//
+// The validate-repo probe was one shell `if` guarding two `! grep -Fq` probes
+// joined by `||` under a single fixed message; it is expressed here as two
+// ordered kindPresent checks sharing that message, which is behaviourally
+// identical (either missing probe yields the same stderr and exit 1).
+func validatorDispatchLoopsChecks(rootDir string) []check {
+	cs := make([]check, 0, len(validatorEnvPinNeedles)+2+len(validatorDispatchSpecs))
+
+	validatorDF := rootDir + "/" + validatorDockerfileRelPath
+	for _, needle := range validatorEnvPinNeedles {
+		cs = append(cs, check{
+			kind:       kindPresent,
+			pattern:    needle,
+			message:    "Expected " + validatorDF + " to pin its default nonroot writable state under /home/workcell (" + needle + ")",
+			targetFile: validatorDockerfileRelPath,
+		})
+	}
+
+	const validateRepoMsg = "Expected scripts/validate-repo.sh to externalize Cargo target writes under the Workcell-owned validation cache"
+	cs = append(cs,
+		check{
+			kind:       kindPresent,
+			pattern:    `WORKCELL_VALIDATE_CACHE_HOME="${WORKCELL_VALIDATE_CACHE_HOME:-${XDG_CACHE_HOME}/workcell/validate}"`,
+			message:    validateRepoMsg,
+			targetFile: validateRepoRelPath,
+		},
+		check{
+			kind:       kindPresent,
+			pattern:    `CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${WORKCELL_VALIDATE_CACHE_HOME}/cargo-target}"`,
+			message:    validateRepoMsg,
+			targetFile: validateRepoRelPath,
+		},
+	)
+
+	for _, spec := range validatorDispatchSpecs {
+		df := rootDir + "/" + spec.relPath
+		cs = append(cs, check{
+			kind:       kindPresent,
+			pattern:    spec.needle,
+			message:    "Expected " + df + " to dispatch validator parity through the shared CI entrypoints (" + spec.needle + ")",
+			targetFile: spec.relPath,
+		})
+	}
+
+	return cs
+}
+
+// CheckValidatorDispatchLoops runs the thirteen validator-dispatch invariants
+// against the repo rooted at rootDir, in the shell's original order.  It returns
+// nil when every invariant holds (the shell's exit 0), or an error whose message
+// equals the shell's stderr for the first violated invariant (the shell's exit
+// 1).
+func CheckValidatorDispatchLoops(rootDir string) error {
+	return evaluate(rootDir, validatorDispatchLoopsChecks(rootDir))
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -4655,3 +4655,162 @@ func TestCheckDockerfilePinsRealRepo(t *testing.T) {
 		t.Fatalf("CheckDockerfilePins(real repo) = %v, want nil", err)
 	}
 }
+
+// validatorDispatchLoopsHappyFiles returns the six-file fixture map that
+// satisfies all thirteen validator-dispatch invariants: the validator Dockerfile
+// carries every ENV pin, scripts/validate-repo.sh carries both Cargo-target
+// externalization needles, and each dispatch target file carries its needle
+// (scripts/pre-merge.sh carries both of its needles).  Needle bodies are built
+// from the exported slices so the fixture stays in lockstep with the migration.
+func validatorDispatchLoopsHappyFiles() map[string]string {
+	return map[string]string{
+		validatorDockerfileRelPath: "FROM debian\n" + strings.Join(validatorEnvPinNeedles, "\n") + "\n",
+		validateRepoRelPath: "#!/usr/bin/env bash\n" +
+			`WORKCELL_VALIDATE_CACHE_HOME="${WORKCELL_VALIDATE_CACHE_HOME:-${XDG_CACHE_HOME}/workcell/validate}"` + "\n" +
+			`CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${WORKCELL_VALIDATE_CACHE_HOME}/cargo-target}"` + "\n",
+		ciWorkflowRelPath:       "steps:\n  - run: ./scripts/ci/job-validate.sh --profile pr-parity\n",
+		docsWorkflowRelPath:     "steps:\n  - run: ./scripts/ci/job-docs.sh\n",
+		mutationWorkflowRelPath: "steps:\n  - run: ./scripts/ci/job-mutation.sh\n",
+		preMergeRelPath:         "#!/usr/bin/env bash\nscripts/ci/job-validate.sh\nscripts/ci/job-docs.sh\n",
+	}
+}
+
+func TestCheckValidatorDispatchLoops(t *testing.T) {
+	root := t.TempDir()
+
+	tests := []struct {
+		name    string
+		mutate  func(files map[string]string)
+		wantErr string // "" means expect success; absolute-path messages use the shared root
+	}{
+		{
+			name:   "happy path all invariants hold",
+			mutate: func(map[string]string) {},
+		},
+		{
+			// ENV-pin loop: the first needle removed from the validator
+			// Dockerfile fails with the interpolated absolute-path message.
+			name: "validator Dockerfile missing HOME pin",
+			mutate: func(files map[string]string) {
+				files[validatorDockerfileRelPath] = strings.Replace(files[validatorDockerfileRelPath], "ENV HOME=/home/workcell\n", "", 1)
+			},
+			wantErr: "Expected " + root + "/" + validatorDockerfileRelPath + " to pin its default nonroot writable state under /home/workcell (ENV HOME=/home/workcell)",
+		},
+		{
+			// ENV-pin loop: a middle needle removed fires with its own message,
+			// proving the per-needle interpolation.
+			name: "validator Dockerfile missing GOMODCACHE pin",
+			mutate: func(files map[string]string) {
+				files[validatorDockerfileRelPath] = strings.Replace(files[validatorDockerfileRelPath], "ENV GOMODCACHE=/home/workcell/.cache/go-mod\n", "", 1)
+			},
+			wantErr: "Expected " + root + "/" + validatorDockerfileRelPath + " to pin its default nonroot writable state under /home/workcell (ENV GOMODCACHE=/home/workcell/.cache/go-mod)",
+		},
+		{
+			// A missing validator Dockerfile is empty content: the first
+			// affirmative ENV pin fails, mirroring grep on a missing file.
+			name: "validator Dockerfile missing",
+			mutate: func(files map[string]string) {
+				files[validatorDockerfileRelPath] = ""
+			},
+			wantErr: "Expected " + root + "/" + validatorDockerfileRelPath + " to pin its default nonroot writable state under /home/workcell (ENV HOME=/home/workcell)",
+		},
+		{
+			// validate-repo || guard: the first probe (cache-home) removed fires
+			// the shared message.
+			name: "validate-repo missing cache-home probe",
+			mutate: func(files map[string]string) {
+				files[validateRepoRelPath] = strings.Replace(files[validateRepoRelPath], `WORKCELL_VALIDATE_CACHE_HOME="${WORKCELL_VALIDATE_CACHE_HOME:-${XDG_CACHE_HOME}/workcell/validate}"`+"\n", "", 1)
+			},
+			wantErr: "Expected scripts/validate-repo.sh to externalize Cargo target writes under the Workcell-owned validation cache",
+		},
+		{
+			// validate-repo || guard: the second probe (cargo-target) removed
+			// fires the same shared message, proving either missing probe yields
+			// identical stderr.
+			name: "validate-repo missing cargo-target probe",
+			mutate: func(files map[string]string) {
+				files[validateRepoRelPath] = strings.Replace(files[validateRepoRelPath], `CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${WORKCELL_VALIDATE_CACHE_HOME}/cargo-target}"`+"\n", "", 1)
+			},
+			wantErr: "Expected scripts/validate-repo.sh to externalize Cargo target writes under the Workcell-owned validation cache",
+		},
+		{
+			// dispatch loop: the ci.yml needle removed fires with the
+			// interpolated absolute-path + needle message.
+			name: "ci workflow missing dispatch needle",
+			mutate: func(files map[string]string) {
+				files[ciWorkflowRelPath] = "steps:\n  - run: echo noop\n"
+			},
+			wantErr: "Expected " + root + "/" + ciWorkflowRelPath + " to dispatch validator parity through the shared CI entrypoints (./scripts/ci/job-validate.sh --profile pr-parity)",
+		},
+		{
+			// dispatch loop: the second pre-merge needle (job-docs) removed while
+			// the first (job-validate) stays fires the job-docs message, proving
+			// both same-file probes are distinct checks.
+			name: "pre-merge missing job-docs dispatch needle",
+			mutate: func(files map[string]string) {
+				files[preMergeRelPath] = "#!/usr/bin/env bash\nscripts/ci/job-validate.sh\n"
+			},
+			wantErr: "Expected " + root + "/" + preMergeRelPath + " to dispatch validator parity through the shared CI entrypoints (scripts/ci/job-docs.sh)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			files := validatorDispatchLoopsHappyFiles()
+			tc.mutate(files)
+			for rel, body := range files {
+				path := filepath.Join(root, rel)
+				if body == "" {
+					os.Remove(path)
+					continue
+				}
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+				}
+				if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+					t.Fatalf("write %s: %v", path, err)
+				}
+			}
+			err := CheckValidatorDispatchLoops(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckValidatorDispatchLoops() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckValidatorDispatchLoops() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckValidatorDispatchLoops() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckValidatorDispatchLoopsCount asserts the generated check list contains
+// exactly thirteen invariants: six validator-Dockerfile ENV pins, two
+// validate-repo Cargo-target probes, and five CI-dispatch probes.
+func TestCheckValidatorDispatchLoopsCount(t *testing.T) {
+	got := len(validatorDispatchLoopsChecks("/repo"))
+	const want = 13
+	if got != want {
+		t.Fatalf("validatorDispatchLoopsChecks(...) has %d checks, want %d", got, want)
+	}
+}
+
+// TestCheckValidatorDispatchLoopsRealRepo asserts that the real
+// tools/validator/Dockerfile, scripts/validate-repo.sh, the three lane
+// workflows, and scripts/pre-merge.sh in this repository satisfy all thirteen
+// validator-dispatch invariants.  This is the key guard against a
+// mis-transcribed needle or a wrong target file: if any Go pattern diverges from
+// the actual file contents, this test fails with the guard's stderr message.
+func TestCheckValidatorDispatchLoopsRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, validatorDockerfileRelPath)); err != nil {
+		t.Skipf("real tools/validator/Dockerfile not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckValidatorDispatchLoops(repoRoot); err != nil {
+		t.Fatalf("CheckValidatorDispatchLoops(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2935,39 +2935,7 @@ go_verify_citools workcell-bootstrap-egress "${ROOT_DIR}" || exit 1
 # surface.
 go_verify_citools workcell-dockerfile-pins "${ROOT_DIR}" || exit 1
 
-validator_dockerfile="${ROOT_DIR}/tools/validator/Dockerfile"
-for required in \
-  'ENV HOME=/home/workcell' \
-  'ENV XDG_CACHE_HOME=/home/workcell/.cache' \
-  'ENV GOCACHE=/home/workcell/.cache/go-build' \
-  'ENV GOMODCACHE=/home/workcell/.cache/go-mod' \
-  'ENV CARGO_TARGET_DIR=/home/workcell/.cache/cargo-target' \
-  'ENV TMPDIR=/home/workcell/.tmp'; do
-  if ! grep -Fq "${required}" "${validator_dockerfile}"; then
-    echo "Expected ${validator_dockerfile} to pin its default nonroot writable state under /home/workcell (${required})" >&2
-    exit 1
-  fi
-done
-
-if ! grep -Fq "WORKCELL_VALIDATE_CACHE_HOME=\"\${WORKCELL_VALIDATE_CACHE_HOME:-\${XDG_CACHE_HOME}/workcell/validate}\"" "${ROOT_DIR}/scripts/validate-repo.sh" ||
-  ! grep -Fq "CARGO_TARGET_DIR=\"\${CARGO_TARGET_DIR:-\${WORKCELL_VALIDATE_CACHE_HOME}/cargo-target}\"" "${ROOT_DIR}/scripts/validate-repo.sh"; then
-  echo "Expected scripts/validate-repo.sh to externalize Cargo target writes under the Workcell-owned validation cache" >&2
-  exit 1
-fi
-
-for dispatch_check in \
-  "${ROOT_DIR}/.github/workflows/ci.yml:./scripts/ci/job-validate.sh --profile pr-parity" \
-  "${ROOT_DIR}/.github/workflows/docs.yml:./scripts/ci/job-docs.sh" \
-  "${ROOT_DIR}/.github/workflows/mutation.yml:./scripts/ci/job-mutation.sh" \
-  "${ROOT_DIR}/scripts/pre-merge.sh:scripts/ci/job-validate.sh" \
-  "${ROOT_DIR}/scripts/pre-merge.sh:scripts/ci/job-docs.sh"; do
-  dispatch_file="${dispatch_check%%:*}"
-  dispatch_required="${dispatch_check#*:}"
-  if ! grep -Fq -- "${dispatch_required}" "${dispatch_file}"; then
-    echo "Expected ${dispatch_file} to dispatch validator parity through the shared CI entrypoints (${dispatch_required})" >&2
-    exit 1
-  fi
-done
+go_verify_citools workcell-validator-dispatch-loops "${ROOT_DIR}" || exit 1
 
 for caller in \
   "${ROOT_DIR}/scripts/ci/run-validate-in-validator.sh" \


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 23 of N.** Follows #398-#419. Migrates 13 validator-env / dispatch invariant checks (former lines 2938-2970).

## What
- **`internal/workcellhardening`**: new `CheckValidatorDispatchLoops(rootDir)` reusing `kindPresent` (no new kinds). 13 checks: 6 ENV-pins → `tools/validator/Dockerfile`, 2 validate-repo cache-dir `||` probes → `scripts/validate-repo.sh`, 5 dispatch checks → `ci.yml`/`docs.yml`/`mutation.yml`/`pre-merge.sh`.
- **`cmd/workcell-citools`**: new `workcell-validator-dispatch-loops` subcommand.
- **`scripts/verify-invariants.sh`**: block replaced by `go_verify_citools workcell-validator-dispatch-loops "${ROOT_DIR}" || exit 1`. Bounded above by the merged `workcell-dockerfile-pins` dispatch; stopped before the nested `for caller … for required` loop (5×10=50 checks — deferred to its own increment).

## Wrinkles handled (parity)
- **Variable file-paths** `${validator_dockerfile}` (→ `tools/validator/Dockerfile`, assignment removed) and `${dispatch_file}` (5 `path:needle` entries split to literals) resolved + verified.
- ENV-pin/dispatch messages echo the absolute `${ROOT_DIR}/…` path → reconstructed byte-exact via `rootDir + "/" + rel`; validate-repo message static.

Real repo → exit 0; 5 crafted violations → exit 1 byte-identical (diffed vs extracted original block). Real-repo assertion + count=13 guard.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 329 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)