### PR TITLE
^R D3: migrate nested caller×required validator-isolation invariants to Go (50 checks)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -117,6 +117,7 @@ func subcommands() []subcommand {
 		{"workcell-hostutil-egress-rg", "ROOT_DIR", 1, 1, cmdWorkcellHostutilEgressRg},
 		{"workcell-dockerfile-pins", "ROOT_DIR", 1, 1, cmdWorkcellDockerfilePins},
 		{"workcell-validator-dispatch-loops", "ROOT_DIR", 1, 1, cmdWorkcellValidatorDispatchLoops},
+		{"workcell-caller-required-contracts", "ROOT_DIR", 1, 1, cmdWorkcellCallerRequiredContracts},
 	}
 }
 
@@ -698,4 +699,13 @@ func cmdWorkcellDockerfilePins(args []string) error {
 // original stderr message for the first violated invariant.
 func cmdWorkcellValidatorDispatchLoops(args []string) error {
 	return workcellhardening.CheckValidatorDispatchLoops(args[0])
+}
+
+// cmdWorkcellCallerRequiredContracts runs the fifty caller-required checks (five
+// CI caller files × ten UID/GID-and-isolated-writable-state needles) migrated
+// out of scripts/verify-invariants.sh; it fails (exit 1 via die()) with the
+// shell's original stderr message for the first violated (caller, required)
+// pair.
+func cmdWorkcellCallerRequiredContracts(args []string) error {
+	return workcellhardening.CheckCallerRequiredContracts(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -241,6 +241,18 @@ const mutationWorkflowRelPath = ".github/workflows/mutation.yml"
 // ${ROOT_DIR}/scripts/pre-merge.sh.
 const preMergeRelPath = "scripts/pre-merge.sh"
 
+// runValidateInValidatorRelPath, runDocsInValidatorRelPath, and
+// runMutationInValidatorRelPath are the repo-relative paths to the three
+// in-validator lane launchers.  The caller-required-contracts block reads them
+// (via the per-check targetFile field) as the first three callers of its nested
+// caller×required loop, mirroring the shell `grep -Fq --` probes that ran
+// against ${ROOT_DIR}/scripts/ci/run-validate-in-validator.sh,
+// run-docs-in-validator.sh, and run-mutation-in-validator.sh.  (jobValidateRelPath
+// and releaseWorkflowRelPath cover the remaining two callers.)
+const runValidateInValidatorRelPath = "scripts/ci/run-validate-in-validator.sh"
+const runDocsInValidatorRelPath = "scripts/ci/run-docs-in-validator.sh"
+const runMutationInValidatorRelPath = "scripts/ci/run-mutation-in-validator.sh"
+
 // checkKind selects how a check's pattern is matched against the launcher
 // contents.
 type checkKind int
@@ -3325,6 +3337,75 @@ func validatorDispatchLoopsChecks(rootDir string) []check {
 // 1).
 func CheckValidatorDispatchLoops(rootDir string) error {
 	return evaluate(rootDir, validatorDispatchLoopsChecks(rootDir))
+}
+
+// callerRequiredContractsCallers lists, in the shell outer for-loop's order, the
+// five caller files that must each launch validator work under an explicit
+// caller UID/GID with isolated writable state.  The shell iterated
+// `for caller in "${ROOT_DIR}/<path>" ...`, so each caller's value was the
+// ABSOLUTE ${ROOT_DIR}/<relPath>; the repo-relative path here is both the
+// per-check read target (via targetFile) and the tail the message reconstructs.
+var callerRequiredContractsCallers = []string{
+	runValidateInValidatorRelPath,
+	runDocsInValidatorRelPath,
+	runMutationInValidatorRelPath,
+	jobValidateRelPath,
+	releaseWorkflowRelPath,
+}
+
+// callerRequiredContractsNeedles lists, in the shell inner for-loop's order, the
+// ten fixed strings each caller must contain.  Each was a fixed
+// `grep -Fq -- "${required}"` literal in the migrated `for required in ...; do`
+// loop; the shell's `\"`/`\$`/`\${` escapes render to the literal `"`/`$`/`${`
+// bytes captured here as Go raw strings.
+var callerRequiredContractsNeedles = []string{
+	`validator_uid="$(id -u)"`,
+	`validator_gid="$(id -g)"`,
+	`--user "${validator_uid}:${validator_gid}"`,
+	`-e HOME="${validator_home}"`,
+	`-e XDG_CACHE_HOME="${validator_cache}"`,
+	`-e GOCACHE="${validator_cache}/go-build"`,
+	`-e GOMODCACHE="${validator_cache}/go-mod"`,
+	`-e CARGO_TARGET_DIR="${validator_cache}/cargo-target"`,
+	`-e TMPDIR="${validator_tmp}"`,
+	`mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${GOCACHE}" "${GOMODCACHE}" "${CARGO_TARGET_DIR}" "${TMPDIR}"`,
+}
+
+// callerRequiredContractsChecks builds the fifty caller-required invariants for
+// the repo rooted at rootDir by iterating the caller list (outer) over the
+// required-needle list (inner), exactly mirroring the shell's nested
+// `for caller in ...; do for required in ...; do` order so the first violated
+// (caller, required) pair matches the shell's first-failure exit.
+//
+// The shell echoed `${caller}`, whose value was ${ROOT_DIR}/<relPath> — i.e. the
+// ABSOLUTE path once ${ROOT_DIR} expands.  The message is therefore constructed
+// as "Expected " + rootDir + "/" + relPath + " ... (" + needle + ")" using
+// literal string concatenation (not filepath.Join) to reproduce the shell's
+// byte-exact rendering, while the read target stays the repo-relative path via
+// targetFile so evaluate reads the same file the message names.
+func callerRequiredContractsChecks(rootDir string) []check {
+	cs := make([]check, 0, len(callerRequiredContractsCallers)*len(callerRequiredContractsNeedles))
+	for _, rel := range callerRequiredContractsCallers {
+		caller := rootDir + "/" + rel
+		for _, needle := range callerRequiredContractsNeedles {
+			cs = append(cs, check{
+				kind:       kindPresent,
+				pattern:    needle,
+				message:    "Expected " + caller + " to launch validator work under an explicit caller UID/GID with isolated writable state (" + needle + ")",
+				targetFile: rel,
+			})
+		}
+	}
+	return cs
+}
+
+// CheckCallerRequiredContracts runs the fifty caller-required invariants against
+// the repo rooted at rootDir, in the shell's original caller-outer/required-inner
+// order.  It returns nil when every invariant holds (the shell's exit 0), or an
+// error whose message equals the shell's stderr for the first violated (caller,
+// required) pair (the shell's exit 1).
+func CheckCallerRequiredContracts(rootDir string) error {
+	return evaluate(rootDir, callerRequiredContractsChecks(rootDir))
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -4814,3 +4814,139 @@ func TestCheckValidatorDispatchLoopsRealRepo(t *testing.T) {
 		t.Fatalf("CheckValidatorDispatchLoops(real repo) = %v, want nil", err)
 	}
 }
+
+// callerRequiredContractsHappyFiles returns the five-file fixture map that
+// satisfies all fifty caller-required invariants: every caller file carries all
+// ten required needles (joined by newlines so grep-style containment holds).
+// Needle bodies are built from the exported slices so the fixture stays in
+// lockstep with the migration.
+func callerRequiredContractsHappyFiles() map[string]string {
+	files := make(map[string]string, len(callerRequiredContractsCallers))
+	body := "#!/usr/bin/env bash\n" + strings.Join(callerRequiredContractsNeedles, "\n") + "\n"
+	for _, rel := range callerRequiredContractsCallers {
+		files[rel] = body
+	}
+	return files
+}
+
+func TestCheckCallerRequiredContracts(t *testing.T) {
+	root := t.TempDir()
+
+	tests := []struct {
+		name    string
+		mutate  func(files map[string]string)
+		wantErr string // "" means expect success; absolute-path messages use the shared root
+	}{
+		{
+			name:   "happy path all invariants hold",
+			mutate: func(map[string]string) {},
+		},
+		{
+			// Outer=first caller, inner=first needle: removing the UID needle from
+			// the first caller fires the interpolated absolute-path + needle
+			// message, proving caller-outer/needle-inner interpolation.
+			name: "first caller missing UID needle",
+			mutate: func(files map[string]string) {
+				files[runValidateInValidatorRelPath] = strings.Replace(files[runValidateInValidatorRelPath], `validator_uid="$(id -u)"`+"\n", "", 1)
+			},
+			wantErr: "Expected " + root + "/" + runValidateInValidatorRelPath + " to launch validator work under an explicit caller UID/GID with isolated writable state (validator_uid=\"$(id -u)\")",
+		},
+		{
+			// A middle caller missing a middle needle: proves the loop advances
+			// through earlier callers/needles before firing.
+			name: "third caller missing GOCACHE needle",
+			mutate: func(files map[string]string) {
+				files[runMutationInValidatorRelPath] = strings.Replace(files[runMutationInValidatorRelPath], `-e GOCACHE="${validator_cache}/go-build"`+"\n", "", 1)
+			},
+			wantErr: "Expected " + root + "/" + runMutationInValidatorRelPath + " to launch validator work under an explicit caller UID/GID with isolated writable state (-e GOCACHE=\"${validator_cache}/go-build\")",
+		},
+		{
+			// The last caller (release.yml) missing the last needle (mkdir -p):
+			// the final (caller, required) pair fires, proving the full traversal.
+			name: "release workflow missing mkdir needle",
+			mutate: func(files map[string]string) {
+				files[releaseWorkflowRelPath] = strings.Replace(files[releaseWorkflowRelPath], `mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${GOCACHE}" "${GOMODCACHE}" "${CARGO_TARGET_DIR}" "${TMPDIR}"`+"\n", "", 1)
+			},
+			wantErr: "Expected " + root + "/" + releaseWorkflowRelPath + " to launch validator work under an explicit caller UID/GID with isolated writable state (mkdir -p \"${HOME}\" \"${XDG_CACHE_HOME}\" \"${GOCACHE}\" \"${GOMODCACHE}\" \"${CARGO_TARGET_DIR}\" \"${TMPDIR}\")",
+		},
+		{
+			// caller-outer ordering: when the FIRST caller is entirely missing
+			// (empty content) its first needle fires before any later caller runs,
+			// even though a later caller is also broken.
+			name: "first caller missing wins over later caller",
+			mutate: func(files map[string]string) {
+				files[runValidateInValidatorRelPath] = ""
+				files[jobValidateRelPath] = "#!/usr/bin/env bash\n"
+			},
+			wantErr: "Expected " + root + "/" + runValidateInValidatorRelPath + " to launch validator work under an explicit caller UID/GID with isolated writable state (validator_uid=\"$(id -u)\")",
+		},
+		{
+			// needle-inner ordering within a single caller: an EARLIER needle
+			// missing wins over a later one in the same file.
+			name: "earlier needle wins within a caller",
+			mutate: func(files map[string]string) {
+				files[runDocsInValidatorRelPath] = strings.Replace(files[runDocsInValidatorRelPath], `validator_gid="$(id -g)"`+"\n", "", 1)
+				files[runDocsInValidatorRelPath] = strings.Replace(files[runDocsInValidatorRelPath], `-e TMPDIR="${validator_tmp}"`+"\n", "", 1)
+			},
+			wantErr: "Expected " + root + "/" + runDocsInValidatorRelPath + " to launch validator work under an explicit caller UID/GID with isolated writable state (validator_gid=\"$(id -g)\")",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			files := callerRequiredContractsHappyFiles()
+			tc.mutate(files)
+			for rel, body := range files {
+				path := filepath.Join(root, rel)
+				if body == "" {
+					os.Remove(path)
+					continue
+				}
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+				}
+				if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+					t.Fatalf("write %s: %v", path, err)
+				}
+			}
+			err := CheckCallerRequiredContracts(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckCallerRequiredContracts() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckCallerRequiredContracts() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckCallerRequiredContracts() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckCallerRequiredContractsCount asserts the generated check list contains
+// exactly fifty invariants: five caller files × ten required needles.
+func TestCheckCallerRequiredContractsCount(t *testing.T) {
+	got := len(callerRequiredContractsChecks("/repo"))
+	const want = 50
+	if got != want {
+		t.Fatalf("callerRequiredContractsChecks(...) has %d checks, want %d", got, want)
+	}
+}
+
+// TestCheckCallerRequiredContractsRealRepo asserts that the five real caller
+// files in this repository satisfy all fifty caller-required invariants.  This is
+// the key guard against a mis-transcribed needle or a wrong target file: if any
+// Go needle diverges from the actual file contents, this test fails with the
+// guard's stderr message.
+func TestCheckCallerRequiredContractsRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, runValidateInValidatorRelPath)); err != nil {
+		t.Skipf("real scripts/ci/run-validate-in-validator.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckCallerRequiredContracts(repoRoot); err != nil {
+		t.Fatalf("CheckCallerRequiredContracts(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2937,29 +2937,7 @@ go_verify_citools workcell-dockerfile-pins "${ROOT_DIR}" || exit 1
 
 go_verify_citools workcell-validator-dispatch-loops "${ROOT_DIR}" || exit 1
 
-for caller in \
-  "${ROOT_DIR}/scripts/ci/run-validate-in-validator.sh" \
-  "${ROOT_DIR}/scripts/ci/run-docs-in-validator.sh" \
-  "${ROOT_DIR}/scripts/ci/run-mutation-in-validator.sh" \
-  "${ROOT_DIR}/scripts/ci/job-validate.sh" \
-  "${ROOT_DIR}/.github/workflows/release.yml"; do
-  for required in \
-    "validator_uid=\"\$(id -u)\"" \
-    "validator_gid=\"\$(id -g)\"" \
-    "--user \"\${validator_uid}:\${validator_gid}\"" \
-    "-e HOME=\"\${validator_home}\"" \
-    "-e XDG_CACHE_HOME=\"\${validator_cache}\"" \
-    "-e GOCACHE=\"\${validator_cache}/go-build\"" \
-    "-e GOMODCACHE=\"\${validator_cache}/go-mod\"" \
-    "-e CARGO_TARGET_DIR=\"\${validator_cache}/cargo-target\"" \
-    "-e TMPDIR=\"\${validator_tmp}\"" \
-    "mkdir -p \"\${HOME}\" \"\${XDG_CACHE_HOME}\" \"\${GOCACHE}\" \"\${GOMODCACHE}\" \"\${CARGO_TARGET_DIR}\" \"\${TMPDIR}\""; do
-    if ! grep -Fq -- "${required}" "${caller}"; then
-      echo "Expected ${caller} to launch validator work under an explicit caller UID/GID with isolated writable state (${required})" >&2
-      exit 1
-    fi
-  done
-done
+go_verify_citools workcell-caller-required-contracts "${ROOT_DIR}" || exit 1
 
 go_verify_citools workcell-validator-writable-state "${ROOT_DIR}" || exit 1
 


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 24 of N (larger batch).** Follows #398-#420. Migrates the nested caller×required loop (former lines 2940-2962) — every validator-launching caller must run validator work under an explicit caller UID/GID with isolated writable state.

## What
- **`internal/workcellhardening`**: new `CheckCallerRequiredContracts(rootDir)` reusing `kindPresent` (no new kinds). **50 checks** built via a Go nested loop: 5 callers × 10 needles, caller-outer/required-inner order.
  - Callers: `run-validate-in-validator.sh`, `run-docs-in-validator.sh`, `run-mutation-in-validator.sh`, `ci/job-validate.sh`, `.github/workflows/release.yml`.
  - Needles: `validator_uid/gid`, `--user`, `-e HOME/XDG_CACHE_HOME/GOCACHE/GOMODCACHE/CARGO_TARGET_DIR/TMPDIR`, and the `mkdir -p` line.
- **`cmd/workcell-citools`**: new `workcell-caller-required-contracts` subcommand.
- **`scripts/verify-invariants.sh`**: nested loop replaced by `go_verify_citools workcell-caller-required-contracts "${ROOT_DIR}" || exit 1`. Stopped at the loop's outer `done` (next is `function_block_contains_regex validate_colima_profile`).

## Parity
The echoed `${caller}` is the absolute `${ROOT_DIR}/<rel>` path → reconstructed as `rootDir + "/" + rel + " to launch validator work … (" + needle + ")"`, verified byte-exact against the extracted original loop across all 5 callers (5/5 diff match). Real repo → exit 0; real-repo assertion + count=50 guard.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 251 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)