### PR TITLE
^R D3: migrate 4 scattered simple-check clusters to Go (20 checks, 4 subcommands)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -119,6 +119,10 @@ func subcommands() []subcommand {
 		{"workcell-validator-dispatch-loops", "ROOT_DIR", 1, 1, cmdWorkcellValidatorDispatchLoops},
 		{"workcell-caller-required-contracts", "ROOT_DIR", 1, 1, cmdWorkcellCallerRequiredContracts},
 		{"workcell-fnblock-goblock-gitenv", "ROOT_DIR", 1, 1, cmdWorkcellFnBlockGoBlockGitEnv},
+		{"workcell-buildx-builder-trust", "ROOT_DIR", 1, 1, cmdWorkcellBuildxBuilderTrust},
+		{"workcell-doc-scan-go-vcs", "ROOT_DIR", 1, 1, cmdWorkcellDocScanGoVcs},
+		{"workcell-smoke-chown-tar", "ROOT_DIR", 1, 1, cmdWorkcellSmokeChownTar},
+		{"workcell-dualstack-apply-plan", "ROOT_DIR", 1, 1, cmdWorkcellDualStackApplyPlan},
 	}
 }
 
@@ -718,4 +722,40 @@ func cmdWorkcellCallerRequiredContracts(args []string) error {
 // original stderr message for the first violated invariant.
 func cmdWorkcellFnBlockGoBlockGitEnv(args []string) error {
 	return workcellhardening.CheckFnBlockGoBlockGitEnv(args[0])
+}
+
+// cmdWorkcellBuildxBuilderTrust runs the eight buildx-builder-trust checks
+// (deterministic release builder, disposable validator-image cleanup across the
+// local lanes, reproducible-build builder teardown, trusted Buildx endpoint /
+// Docker-context resolution, and the colima-egress COLIMA_HOME pin) migrated out
+// of scripts/verify-invariants.sh; it fails (exit 1 via die()) with the shell's
+// original stderr message for the first violated invariant.
+func cmdWorkcellBuildxBuilderTrust(args []string) error {
+	return workcellhardening.CheckBuildxBuilderTrust(args[0])
+}
+
+// cmdWorkcellDocScanGoVcs runs the two doc-scan / Go-VCS-stamping checks
+// (validate-repo venv-prune and go-run-env buildvcs disablement) migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the shell's
+// original stderr message for the first violated invariant.
+func cmdWorkcellDocScanGoVcs(args []string) error {
+	return workcellhardening.CheckDocScanGoVcs(args[0])
+}
+
+// cmdWorkcellSmokeChownTar runs the three container-smoke chown/tar checks (no
+// raw recursive chown, no tar-based staging or extraction) migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the shell's
+// original stderr message for the first violated invariant.
+func cmdWorkcellSmokeChownTar(args []string) error {
+	return workcellhardening.CheckSmokeChownTar(args[0])
+}
+
+// cmdWorkcellDualStackApplyPlan runs the seven dual-stack allowlist-apply-plan
+// checks (guarded apply path, ip6tables preflight, clear-plan render helper, and
+// the render_allowlist_apply_plan clear-plan/VM-resolution/no-host-resolution
+// function-block invariants) migrated out of scripts/verify-invariants.sh; it
+// fails (exit 1 via die()) with the shell's original stderr message for the first
+// violated invariant.
+func cmdWorkcellDualStackApplyPlan(args []string) error {
+	return workcellhardening.CheckDualStackApplyPlan(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -3502,6 +3502,282 @@ func CheckFnBlockGoBlockGitEnv(rootDir string) error {
 	return evaluate(rootDir, fnBlockGoBlockGitEnvChecks())
 }
 
+// jobDocsRelPath is the repo-relative path to the docs CI lane.  Only the
+// buildx-builder-trust validator-image-cleanup invariant reads this file (via
+// the per-check targetFile field), mirroring the shell `rg -q` that ran against
+// ${ROOT_DIR}/scripts/ci/job-docs.sh.
+const jobDocsRelPath = "scripts/ci/job-docs.sh"
+
+// goRunEnvRelPath is the repo-relative path to the Go run-env helper.  Only the
+// doc-scan-go-vcs Go-VCS-stamping invariant reads this file (via the per-check
+// targetFile field), mirroring the shell `grep -Fq` that ran against
+// ${ROOT_DIR}/scripts/lib/go-run-env.sh.
+const goRunEnvRelPath = "scripts/lib/go-run-env.sh"
+
+// buildxBuilderTrustChecks lists the eight buildx-builder-trust invariants in
+// the same order as the former inline block in scripts/verify-invariants.sh
+// (the block between the buildx_cmd trusted-plugin loop and the
+// colima-egress-allowlist COLIMA_HOME pin check that immediately precedes the
+// already-migrated workcell-bootstrap-egress call), so a reviewer can diff the
+// two one-to-one.
+//
+// Every probe was an affirmative whole-file `rg -q` and every rg pattern is
+// metacharacter-free after unescaping (the trusted-docker-client probes escape
+// `\( \)` and `\$ \{ \}`; the others carry no active metacharacters), so each
+// reduces to fixed-string containment (kindPresent).
+//
+// The validator-image-cleanup guard was one shell `if` joining three `rg -q`
+// probes with `||` under a single message (WORKCELL_KEEP_VALIDATOR_IMAGE in
+// build-and-test.sh, cleanup_workcell_validator_image in job-validate.sh and
+// job-docs.sh); it is expressed here as three ordered kindPresent checks sharing
+// that message, which is behaviourally identical (any missing probe yields the
+// same stderr and exit 1).  Each check reads its own target file via the
+// per-check targetFile field.
+var buildxBuilderTrustChecks = []check{
+	{
+		kind:       kindPresent,
+		pattern:    `BUILDX_BUILDER="workcell-release-`,
+		message:    "Expected verify-release-bundle.sh to choose a deterministic context-scoped Buildx builder by default",
+		targetFile: verifyReleaseBundleRelPath,
+	},
+	{
+		// kindPresent (first probe of the validator-image-cleanup guard).
+		kind:       kindPresent,
+		pattern:    "WORKCELL_KEEP_VALIDATOR_IMAGE",
+		message:    "Expected local validator lanes to remove disposable validator images unless explicitly retained",
+		targetFile: buildAndTestRelPath,
+	},
+	{
+		// kindPresent (second probe): shares the guard's message.
+		kind:       kindPresent,
+		pattern:    "cleanup_workcell_validator_image",
+		message:    "Expected local validator lanes to remove disposable validator images unless explicitly retained",
+		targetFile: jobValidateRelPath,
+	},
+	{
+		// kindPresent (third probe): shares the guard's message.
+		kind:       kindPresent,
+		pattern:    "cleanup_workcell_validator_image",
+		message:    "Expected local validator lanes to remove disposable validator images unless explicitly retained",
+		targetFile: jobDocsRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    "WORKCELL_REPRO_OWNS_BUILDER",
+		message:    "Expected reproducible-build validation to remove its default Workcell-owned Buildx builder on exit",
+		targetFile: verifyReproducibleBuildRelPath,
+	},
+	{
+		// kindPresent: the shell's `buildx_expected_endpoints\(\)` escaped its
+		// parens, so it is fixed-string containment of the literal
+		// `buildx_expected_endpoints()`.
+		kind:       kindPresent,
+		pattern:    "buildx_expected_endpoints()",
+		message:    "Expected trusted-docker-client.sh to compute accepted Buildx endpoints from the active Docker context or host",
+		targetFile: trustedDockerClientRelPath,
+	},
+	{
+		// kindPresent: the shell's
+		// `docker context inspect "\$\{DOCKER_CONTEXT_NAME\}" --format` escaped
+		// every metacharacter, so it is fixed-string containment of the literal
+		// invocation.
+		kind:       kindPresent,
+		pattern:    `docker context inspect "${DOCKER_CONTEXT_NAME}" --format`,
+		message:    "Expected trusted-docker-client.sh to resolve Docker context host URIs when validating existing Buildx builders",
+		targetFile: trustedDockerClientRelPath,
+	},
+	{
+		// kindPresent: the shell's `COLIMA_HOME="\$\{colima_home\}"` escaped every
+		// metacharacter, so it is fixed-string containment of the literal
+		// assignment.
+		kind:       kindPresent,
+		pattern:    `COLIMA_HOME="${colima_home}"`,
+		message:    "Expected scripts/colima-egress-allowlist.sh to pin COLIMA_HOME while operating on Lima state",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+}
+
+// CheckBuildxBuilderTrust runs the eight buildx-builder-trust invariants against
+// the repo rooted at rootDir, in the shell's original order.  It returns nil when
+// every invariant holds (the shell's exit 0), or an error whose message equals
+// the shell's stderr for the first violated invariant (the shell's exit 1).
+func CheckBuildxBuilderTrust(rootDir string) error {
+	return evaluate(rootDir, buildxBuilderTrustChecks)
+}
+
+// docScanGoVcsChecks lists the two doc-scan / Go-VCS-stamping invariants in the
+// same order as the contiguous inline pair in scripts/verify-invariants.sh (the
+// two grep -Fq probes between the already-migrated workcell-git-index-shadow call
+// and the go_cache_root ensure_go_run_env exec block).  Only this contiguous pair
+// is migrated: the go_cache_root exec/`case $(uname -s)` block and the
+// publishpr.ValidateBaseName go_function_block probe that follow it stay inline in
+// the shell to preserve first-failure order (the exec block is not a simple
+// grep/rg check, so bundling across it would not be byte-exact).
+//
+// Both probes were fixed-string `grep -Fq` (the venv-prune needle carries a `${}`
+// the shell passed literally; the go-vcs needle escaped its `"` and `$`), so each
+// is kindPresent.  Each reads its own target file via the per-check targetFile
+// field.
+var docScanGoVcsChecks = []check{
+	{
+		kind:       kindPresent,
+		pattern:    `-path "${ROOT_DIR}/.venv" -prune -o`,
+		message:    "Expected validate-repo.sh to prune repo-local virtualenv content from documentation scans",
+		targetFile: validateRepoRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    `build -buildvcs=false -o "${output_path}"`,
+		message:    "Expected build_go_tool_in_repo to disable Go VCS stamping in untrusted repos",
+		targetFile: goRunEnvRelPath,
+	},
+}
+
+// CheckDocScanGoVcs runs the two doc-scan / Go-VCS-stamping invariants against
+// the repo rooted at rootDir, in the shell's original order.  It returns nil when
+// every invariant holds (the shell's exit 0), or an error whose message equals
+// the shell's stderr for the first violated invariant (the shell's exit 1).
+func CheckDocScanGoVcs(rootDir string) error {
+	return evaluate(rootDir, docScanGoVcsChecks)
+}
+
+// smokeChownTarChecks lists the three container-smoke chown/tar invariants in the
+// same order as the former inline block in scripts/verify-invariants.sh (the
+// block between the container-smoke --self-entrypoint-probe exec fixture and the
+// container-smoke --self-test-host-path-hardening exec fixture), so a reviewer can
+// diff the two one-to-one.
+//
+// All three were NEGATED `if rg -q PATTERN; then ... exit 1` guards (a match is a
+// violation), and every rg pattern is metacharacter-free after unescaping (the
+// chown and tar-create probes escape `\$ \{ \}`; `tar -xf -` carries no active
+// metacharacters), so each reduces to negated fixed-string containment
+// (kindAbsent).  All three read scripts/container-smoke.sh via the per-check
+// targetFile field.
+var smokeChownTarChecks = []check{
+	{
+		kind:       kindAbsent,
+		pattern:    `chown -R "${HOST_UID}:${HOST_GID}" "${target_path}"`,
+		message:    "Expected scripts/container-smoke.sh to avoid raw recursive chown on host-managed paths",
+		targetFile: containerSmokeRelPath,
+	},
+	{
+		kind:       kindAbsent,
+		pattern:    `tar --null -T "${path_list_filtered}" -cf -`,
+		message:    "Expected scripts/container-smoke.sh to avoid tar-based smoke workspace staging",
+		targetFile: containerSmokeRelPath,
+	},
+	{
+		kind:       kindAbsent,
+		pattern:    "tar -xf -",
+		message:    "Expected scripts/container-smoke.sh to avoid tar-based extraction for smoke workspace staging",
+		targetFile: containerSmokeRelPath,
+	},
+}
+
+// CheckSmokeChownTar runs the three container-smoke chown/tar invariants against
+// the repo rooted at rootDir, in the shell's original order.  It returns nil when
+// every invariant holds (the shell's exit 0), or an error whose message equals
+// the shell's stderr for the first violated invariant (the shell's exit 1).
+func CheckSmokeChownTar(rootDir string) error {
+	return evaluate(rootDir, smokeChownTarChecks)
+}
+
+// dualStackApplyPlanChecks lists the seven dual-stack allowlist-apply-plan
+// invariants in the same order as the contiguous inline run in
+// scripts/verify-invariants.sh (the run between the bracketed-IPv6-literal
+// egress-plan exec probes and the NEGATED render_allowlist_apply_plan
+// clear_rules function-block-regex guard).  Only this contiguous run of seven is
+// migrated: the immediately following guard negates a GENUINE regex
+// (`^[[:space:]]*clear_rules$`) inside a function block, for which no
+// function-block-regex-absent kind exists, and the run_in_vm awk-ordering block
+// after it is not a simple grep/rg check; both stay inline to preserve
+// first-failure order.
+//
+// All seven read scripts/colima-egress-allowlist.sh via the per-check targetFile
+// field.  Matching semantics mirror the shell exactly:
+//   - The two whole-file affirmative `rg -q` probes escaped every metacharacter
+//     (`run_in_vm "\$\(render_allowlist_apply_plan\)"`) or carried none
+//     (`if ! type ip6tables >/dev/null 2>&1; then`), so they are fixed-string
+//     containment (kindPresent).
+//   - The render_clear_plan definition probe anchored `^render_clear_plan\(\)`
+//     to a line start with escaped parens, so it is a genuine (line-anchored)
+//     regex (kindRegexPresent) whose `\(\)` matches literal `()`.
+//   - The three affirmative function_block_contains_regex probes scope to
+//     render_allowlist_apply_plan (kindFunctionBlockRegex); their patterns
+//     (render_clear_plan, resolve_vm_endpoint_ips, getent ahosts) are
+//     metacharacter-free, so they behave like fixed-string containment today but
+//     keep genuine-regex semantics for parity with `grep -q`.
+//   - The NEGATED function_block_contains_regex probe for render_allowlist_plan
+//     has a metacharacter-free pattern, so its `grep -q` reduces to fixed-string
+//     containment; a match inside the block is a violation, expressed as
+//     kindFunctionBlockAbsent.
+var dualStackApplyPlanChecks = []check{
+	{
+		kind:       kindPresent,
+		pattern:    `run_in_vm "$(render_allowlist_apply_plan)"`,
+		message:    "Expected dual-stack allowlist apply path to use the guarded apply plan",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    "if ! type ip6tables >/dev/null 2>&1; then",
+		message:    "Expected dual-stack allowlist apply plan to preflight ip6tables before rewriting rules",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	{
+		// kindRegexPresent: the shell's line-anchored `^render_clear_plan\(\)`
+		// keeps its `^` anchor; regexMatchesAnyLine anchors it to each line's
+		// start (rg's line-oriented default), and `\(\)` matches literal `()`.
+		kind:       kindRegexPresent,
+		pattern:    `^render_clear_plan\(\)`,
+		message:    "Expected dual-stack allowlist helper to render clear rules in the VM apply plan",
+		targetFile: colimaEgressAllowlistRelPath,
+	},
+	{
+		kind:         kindFunctionBlockRegex,
+		functionName: "render_allowlist_apply_plan",
+		pattern:      "render_clear_plan",
+		message:      "Expected dual-stack allowlist apply plan to include render_clear_plan",
+		targetFile:   colimaEgressAllowlistRelPath,
+	},
+	{
+		kind:         kindFunctionBlockRegex,
+		functionName: "render_allowlist_apply_plan",
+		pattern:      "resolve_vm_endpoint_ips",
+		message:      "Expected dual-stack allowlist apply plan to resolve hostnames inside the VM before applying rules",
+		targetFile:   colimaEgressAllowlistRelPath,
+	},
+	{
+		kind:         kindFunctionBlockRegex,
+		functionName: "render_allowlist_apply_plan",
+		pattern:      "getent ahosts",
+		message:      "Expected dual-stack allowlist apply plan to use VM DNS results for hostname endpoints",
+		targetFile:   colimaEgressAllowlistRelPath,
+	},
+	{
+		// kindFunctionBlockAbsent: the shell's negated
+		// function_block_contains_regex has a metacharacter-free pattern, so
+		// `grep -q` reduces to fixed-string containment; a match inside the
+		// render_allowlist_apply_plan block is a violation.  render_allowlist_plan
+		// is not a substring of the block's render_allowlist_apply_plan opening
+		// line, so the block name cannot false-match.
+		kind:         kindFunctionBlockAbsent,
+		functionName: "render_allowlist_apply_plan",
+		pattern:      "render_allowlist_plan",
+		message:      "Expected dual-stack allowlist apply plan to avoid host-resolved endpoint rules",
+		targetFile:   colimaEgressAllowlistRelPath,
+	},
+}
+
+// CheckDualStackApplyPlan runs the seven dual-stack allowlist-apply-plan
+// invariants against the repo rooted at rootDir, in the shell's original order.
+// It returns nil when every invariant holds (the shell's exit 0), or an error
+// whose message equals the shell's stderr for the first violated invariant (the
+// shell's exit 1).
+func CheckDualStackApplyPlan(rootDir string) error {
+	return evaluate(rootDir, dualStackApplyPlanChecks)
+}
+
 // holds reports whether the invariant is satisfied by the launcher text.
 func (c check) holds(text string) bool {
 	switch c.kind {

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -5191,3 +5191,378 @@ func TestExtractGoFunctionBlock(t *testing.T) {
 		})
 	}
 }
+
+// --- D3 simple-clusters sweep: buildx-builder-trust ---
+
+// buildxBuilderTrustHappyFiles returns the six-file fixture map that satisfies
+// all eight buildx-builder-trust invariants.
+func buildxBuilderTrustHappyFiles() map[string]string {
+	return map[string]string{
+		verifyReleaseBundleRelPath:     "#!/usr/bin/env bash\nBUILDX_BUILDER=\"workcell-release-${ctx}\"\n",
+		buildAndTestRelPath:            "#!/usr/bin/env bash\n: \"${WORKCELL_KEEP_VALIDATOR_IMAGE:-}\"\n",
+		jobValidateRelPath:             "#!/usr/bin/env bash\ncleanup_workcell_validator_image\n",
+		jobDocsRelPath:                 "#!/usr/bin/env bash\ncleanup_workcell_validator_image\n",
+		verifyReproducibleBuildRelPath: "#!/usr/bin/env bash\n: \"${WORKCELL_REPRO_OWNS_BUILDER:-}\"\n",
+		trustedDockerClientRelPath:     "#!/usr/bin/env bash\nbuildx_expected_endpoints() { :; }\ndocker context inspect \"${DOCKER_CONTEXT_NAME}\" --format '{{.x}}'\n",
+		colimaEgressAllowlistRelPath:   "#!/usr/bin/env bash\nCOLIMA_HOME=\"${colima_home}\"\n",
+	}
+}
+
+func TestCheckBuildxBuilderTrust(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(files map[string]string)
+		wantErr string
+	}{
+		{name: "happy path all invariants hold", mutate: func(map[string]string) {}},
+		{
+			name: "release builder needle missing",
+			mutate: func(f map[string]string) {
+				f[verifyReleaseBundleRelPath] = strings.Replace(f[verifyReleaseBundleRelPath], `BUILDX_BUILDER="workcell-release-`, `BUILDX_BUILDER="other-`, 1)
+			},
+			wantErr: "Expected verify-release-bundle.sh to choose a deterministic context-scoped Buildx builder by default",
+		},
+		{
+			name: "keep-validator-image needle missing",
+			mutate: func(f map[string]string) {
+				f[buildAndTestRelPath] = strings.Replace(f[buildAndTestRelPath], "WORKCELL_KEEP_VALIDATOR_IMAGE", "X", 1)
+			},
+			wantErr: "Expected local validator lanes to remove disposable validator images unless explicitly retained",
+		},
+		{
+			name: "job-validate cleanup needle missing",
+			mutate: func(f map[string]string) {
+				f[jobValidateRelPath] = strings.Replace(f[jobValidateRelPath], "cleanup_workcell_validator_image", "X", 1)
+			},
+			wantErr: "Expected local validator lanes to remove disposable validator images unless explicitly retained",
+		},
+		{
+			name: "job-docs cleanup needle missing",
+			mutate: func(f map[string]string) {
+				f[jobDocsRelPath] = strings.Replace(f[jobDocsRelPath], "cleanup_workcell_validator_image", "X", 1)
+			},
+			wantErr: "Expected local validator lanes to remove disposable validator images unless explicitly retained",
+		},
+		{
+			name: "repro-owns-builder needle missing",
+			mutate: func(f map[string]string) {
+				f[verifyReproducibleBuildRelPath] = strings.Replace(f[verifyReproducibleBuildRelPath], "WORKCELL_REPRO_OWNS_BUILDER", "X", 1)
+			},
+			wantErr: "Expected reproducible-build validation to remove its default Workcell-owned Buildx builder on exit",
+		},
+		{
+			name: "buildx-expected-endpoints needle missing",
+			mutate: func(f map[string]string) {
+				f[trustedDockerClientRelPath] = strings.Replace(f[trustedDockerClientRelPath], "buildx_expected_endpoints()", "renamed()", 1)
+			},
+			wantErr: "Expected trusted-docker-client.sh to compute accepted Buildx endpoints from the active Docker context or host",
+		},
+		{
+			name: "docker-context-inspect needle missing",
+			mutate: func(f map[string]string) {
+				f[trustedDockerClientRelPath] = strings.Replace(f[trustedDockerClientRelPath], `docker context inspect "${DOCKER_CONTEXT_NAME}" --format`, "X", 1)
+			},
+			wantErr: "Expected trusted-docker-client.sh to resolve Docker context host URIs when validating existing Buildx builders",
+		},
+		{
+			name: "colima-home pin needle missing",
+			mutate: func(f map[string]string) {
+				f[colimaEgressAllowlistRelPath] = strings.Replace(f[colimaEgressAllowlistRelPath], `COLIMA_HOME="${colima_home}"`, "X", 1)
+			},
+			wantErr: "Expected scripts/colima-egress-allowlist.sh to pin COLIMA_HOME while operating on Lima state",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := buildxBuilderTrustHappyFiles()
+			tt.mutate(files)
+			root := writeFnBlockGoBlockGitEnvRepo(t, files)
+			err := CheckBuildxBuilderTrust(root)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckBuildxBuilderTrust() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("CheckBuildxBuilderTrust() = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckBuildxBuilderTrustCount(t *testing.T) {
+	if got, want := len(buildxBuilderTrustChecks), 8; got != want {
+		t.Fatalf("buildxBuilderTrustChecks has %d checks, want %d", got, want)
+	}
+}
+
+func TestCheckBuildxBuilderTrustRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, verifyReleaseBundleRelPath)); err != nil {
+		t.Skipf("real scripts/verify-release-bundle.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckBuildxBuilderTrust(repoRoot); err != nil {
+		t.Fatalf("CheckBuildxBuilderTrust(real repo) = %v, want nil", err)
+	}
+}
+
+// --- D3 simple-clusters sweep: doc-scan / go-vcs ---
+
+func docScanGoVcsHappyFiles() map[string]string {
+	return map[string]string{
+		validateRepoRelPath: "#!/usr/bin/env bash\nfind . -path \"${ROOT_DIR}/.venv\" -prune -o -print\n",
+		goRunEnvRelPath:     "#!/usr/bin/env bash\ngo build -buildvcs=false -o \"${output_path}\" ./cmd\n",
+	}
+}
+
+func TestCheckDocScanGoVcs(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(files map[string]string)
+		wantErr string
+	}{
+		{name: "happy path all invariants hold", mutate: func(map[string]string) {}},
+		{
+			name: "venv-prune needle missing",
+			mutate: func(f map[string]string) {
+				f[validateRepoRelPath] = strings.Replace(f[validateRepoRelPath], `-path "${ROOT_DIR}/.venv" -prune -o`, "-print", 1)
+			},
+			wantErr: "Expected validate-repo.sh to prune repo-local virtualenv content from documentation scans",
+		},
+		{
+			name: "buildvcs needle missing",
+			mutate: func(f map[string]string) {
+				f[goRunEnvRelPath] = strings.Replace(f[goRunEnvRelPath], `build -buildvcs=false -o "${output_path}"`, "build -o out", 1)
+			},
+			wantErr: "Expected build_go_tool_in_repo to disable Go VCS stamping in untrusted repos",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := docScanGoVcsHappyFiles()
+			tt.mutate(files)
+			root := writeFnBlockGoBlockGitEnvRepo(t, files)
+			err := CheckDocScanGoVcs(root)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckDocScanGoVcs() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("CheckDocScanGoVcs() = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckDocScanGoVcsCount(t *testing.T) {
+	if got, want := len(docScanGoVcsChecks), 2; got != want {
+		t.Fatalf("docScanGoVcsChecks has %d checks, want %d", got, want)
+	}
+}
+
+func TestCheckDocScanGoVcsRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, validateRepoRelPath)); err != nil {
+		t.Skipf("real scripts/validate-repo.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckDocScanGoVcs(repoRoot); err != nil {
+		t.Fatalf("CheckDocScanGoVcs(real repo) = %v, want nil", err)
+	}
+}
+
+// --- D3 simple-clusters sweep: container-smoke chown/tar ---
+
+// smokeChownTarHappyFiles returns a container-smoke.sh fixture that contains
+// NONE of the three forbidden constructs, so all three absence invariants hold.
+func smokeChownTarHappyFiles() map[string]string {
+	return map[string]string{
+		containerSmokeRelPath: "#!/usr/bin/env bash\nstage_workspace_via_cp\n",
+	}
+}
+
+func TestCheckSmokeChownTar(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(files map[string]string)
+		wantErr string
+	}{
+		{name: "happy path all invariants hold", mutate: func(map[string]string) {}},
+		{
+			name: "raw recursive chown present",
+			mutate: func(f map[string]string) {
+				f[containerSmokeRelPath] += "chown -R \"${HOST_UID}:${HOST_GID}\" \"${target_path}\"\n"
+			},
+			wantErr: "Expected scripts/container-smoke.sh to avoid raw recursive chown on host-managed paths",
+		},
+		{
+			name: "tar-based staging present",
+			mutate: func(f map[string]string) {
+				f[containerSmokeRelPath] += "tar --null -T \"${path_list_filtered}\" -cf -\n"
+			},
+			wantErr: "Expected scripts/container-smoke.sh to avoid tar-based smoke workspace staging",
+		},
+		{
+			name: "tar-based extraction present",
+			mutate: func(f map[string]string) {
+				f[containerSmokeRelPath] += "tar -xf -\n"
+			},
+			wantErr: "Expected scripts/container-smoke.sh to avoid tar-based extraction for smoke workspace staging",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := smokeChownTarHappyFiles()
+			tt.mutate(files)
+			root := writeFnBlockGoBlockGitEnvRepo(t, files)
+			err := CheckSmokeChownTar(root)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckSmokeChownTar() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("CheckSmokeChownTar() = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckSmokeChownTarCount(t *testing.T) {
+	if got, want := len(smokeChownTarChecks), 3; got != want {
+		t.Fatalf("smokeChownTarChecks has %d checks, want %d", got, want)
+	}
+}
+
+func TestCheckSmokeChownTarRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, containerSmokeRelPath)); err != nil {
+		t.Skipf("real scripts/container-smoke.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckSmokeChownTar(repoRoot); err != nil {
+		t.Fatalf("CheckSmokeChownTar(real repo) = %v, want nil", err)
+	}
+}
+
+// --- D3 simple-clusters sweep: dual-stack allowlist apply plan ---
+
+// dualStackApplyPlanHappyFiles returns a colima-egress-allowlist.sh fixture that
+// satisfies all seven dual-stack allowlist-apply-plan invariants: a line-anchored
+// render_clear_plan definition, a render_allowlist_apply_plan block that renders
+// the clear plan, resolves endpoint IPs in the VM (getent ahosts) and never calls
+// render_allowlist_plan, an ip6tables preflight, and the guarded run_in_vm apply.
+func dualStackApplyPlanHappyFiles() map[string]string {
+	body := "#!/usr/bin/env bash\n" +
+		"render_clear_plan() {\n" +
+		"  echo clear\n" +
+		"}\n" +
+		"render_allowlist_apply_plan() {\n" +
+		"  local plan\n" +
+		"  plan=\"$(render_clear_plan)\"\n" +
+		"  resolve_vm_endpoint_ips \"${endpoints}\"\n" +
+		"  getent ahosts \"${host}\"\n" +
+		"}\n" +
+		"apply_allowlist() {\n" +
+		"  if ! type ip6tables >/dev/null 2>&1; then\n" +
+		"    return 1\n" +
+		"  fi\n" +
+		"  run_in_vm \"$(render_allowlist_apply_plan)\"\n" +
+		"}\n"
+	return map[string]string{colimaEgressAllowlistRelPath: body}
+}
+
+func TestCheckDualStackApplyPlan(t *testing.T) {
+	rel := colimaEgressAllowlistRelPath
+	tests := []struct {
+		name    string
+		mutate  func(files map[string]string)
+		wantErr string
+	}{
+		{name: "happy path all invariants hold", mutate: func(map[string]string) {}},
+		{
+			name: "guarded apply path missing",
+			mutate: func(f map[string]string) {
+				f[rel] = strings.Replace(f[rel], `run_in_vm "$(render_allowlist_apply_plan)"`, "direct_apply", 1)
+			},
+			wantErr: "Expected dual-stack allowlist apply path to use the guarded apply plan",
+		},
+		{
+			name: "ip6tables preflight missing",
+			mutate: func(f map[string]string) {
+				f[rel] = strings.Replace(f[rel], "if ! type ip6tables >/dev/null 2>&1; then", "if false; then", 1)
+			},
+			wantErr: "Expected dual-stack allowlist apply plan to preflight ip6tables before rewriting rules",
+		},
+		{
+			name: "render_clear_plan definition missing",
+			mutate: func(f map[string]string) {
+				f[rel] = strings.Replace(f[rel], "render_clear_plan() {", "xrender_clear_plan() {", 1)
+			},
+			wantErr: "Expected dual-stack allowlist helper to render clear rules in the VM apply plan",
+		},
+		{
+			name: "in-block render_clear_plan call missing",
+			mutate: func(f map[string]string) {
+				f[rel] = strings.Replace(f[rel], `plan="$(render_clear_plan)"`, `plan="$(render_empty)"`, 1)
+			},
+			wantErr: "Expected dual-stack allowlist apply plan to include render_clear_plan",
+		},
+		{
+			name: "resolve_vm_endpoint_ips missing",
+			mutate: func(f map[string]string) {
+				f[rel] = strings.Replace(f[rel], `resolve_vm_endpoint_ips "${endpoints}"`, "noop", 1)
+			},
+			wantErr: "Expected dual-stack allowlist apply plan to resolve hostnames inside the VM before applying rules",
+		},
+		{
+			name: "getent ahosts missing",
+			mutate: func(f map[string]string) {
+				f[rel] = strings.Replace(f[rel], `getent ahosts "${host}"`, "noop", 1)
+			},
+			wantErr: "Expected dual-stack allowlist apply plan to use VM DNS results for hostname endpoints",
+		},
+		{
+			name: "host-resolved render_allowlist_plan present in block",
+			mutate: func(f map[string]string) {
+				f[rel] = strings.Replace(f[rel], `getent ahosts "${host}"`, "getent ahosts \"${host}\"\n  render_allowlist_plan", 1)
+			},
+			wantErr: "Expected dual-stack allowlist apply plan to avoid host-resolved endpoint rules",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := dualStackApplyPlanHappyFiles()
+			tt.mutate(files)
+			root := writeFnBlockGoBlockGitEnvRepo(t, files)
+			err := CheckDualStackApplyPlan(root)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckDualStackApplyPlan() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("CheckDualStackApplyPlan() = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckDualStackApplyPlanCount(t *testing.T) {
+	if got, want := len(dualStackApplyPlanChecks), 7; got != want {
+		t.Fatalf("dualStackApplyPlanChecks has %d checks, want %d", got, want)
+	}
+}
+
+func TestCheckDualStackApplyPlanRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, colimaEgressAllowlistRelPath)); err != nil {
+		t.Skipf("real scripts/colima-egress-allowlist.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckDualStackApplyPlan(repoRoot); err != nil {
+		t.Fatalf("CheckDualStackApplyPlan(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2870,37 +2870,19 @@ for script in \
   fi
 done
 
-if ! rg -q 'BUILDX_BUILDER="workcell-release-' "${ROOT_DIR}/scripts/verify-release-bundle.sh"; then
-  echo "Expected verify-release-bundle.sh to choose a deterministic context-scoped Buildx builder by default" >&2
-  exit 1
-fi
-
-if ! rg -q 'WORKCELL_KEEP_VALIDATOR_IMAGE' "${ROOT_DIR}/scripts/build-and-test.sh" ||
-  ! rg -q 'cleanup_workcell_validator_image' "${ROOT_DIR}/scripts/ci/job-validate.sh" ||
-  ! rg -q 'cleanup_workcell_validator_image' "${ROOT_DIR}/scripts/ci/job-docs.sh"; then
-  echo "Expected local validator lanes to remove disposable validator images unless explicitly retained" >&2
-  exit 1
-fi
-
-if ! rg -q 'WORKCELL_REPRO_OWNS_BUILDER' "${ROOT_DIR}/scripts/verify-reproducible-build.sh"; then
-  echo "Expected reproducible-build validation to remove its default Workcell-owned Buildx builder on exit" >&2
-  exit 1
-fi
-
-if ! rg -q 'buildx_expected_endpoints\(\)' "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"; then
-  echo "Expected trusted-docker-client.sh to compute accepted Buildx endpoints from the active Docker context or host" >&2
-  exit 1
-fi
-
-if ! rg -q 'docker context inspect "\$\{DOCKER_CONTEXT_NAME\}" --format' "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"; then
-  echo "Expected trusted-docker-client.sh to resolve Docker context host URIs when validating existing Buildx builders" >&2
-  exit 1
-fi
-
-if ! rg -q 'COLIMA_HOME="\$\{colima_home\}"' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Expected scripts/colima-egress-allowlist.sh to pin COLIMA_HOME while operating on Lima state" >&2
-  exit 1
-fi
+# Assert the buildx-builder-trust invariants: verify-release-bundle.sh picks a
+# deterministic context-scoped Buildx builder, the local validator lanes remove
+# disposable validator images unless retained, reproducible-build validation tears
+# down its default Workcell-owned builder, trusted-docker-client.sh computes and
+# resolves accepted Buildx endpoints from the Docker context, and
+# colima-egress-allowlist.sh pins COLIMA_HOME while operating on Lima state.
+# Migrated to Go (D3): internal/workcellhardening behind the workcell-citools
+# workcell-buildx-builder-trust subcommand preserves the exact exit codes and
+# stderr messages of the former inline rg block (eight fixed-string presence
+# probes, including the three-probe validator-image-cleanup `||` guard that shares
+# one message across build-and-test.sh, job-validate.sh and job-docs.sh).
+# `|| exit 1` matches the former inline block's `exit 1` on a violated invariant.
+go_verify_citools workcell-buildx-builder-trust "${ROOT_DIR}" || exit 1
 
 # Assert the bootstrap egress-endpoint invariants: scripts/workcell allows
 # the two Debian snapshot mirrors and the two Docker blob-storage CDNs
@@ -2947,16 +2929,17 @@ go_verify_citools workcell-fnblock-goblock-gitenv "${ROOT_DIR}" || exit 1
 
 go_verify_citools workcell-git-index-shadow "${ROOT_DIR}" || exit 1
 
-# shellcheck disable=SC2016
-if ! grep -Fq -- '-path "${ROOT_DIR}/.venv" -prune -o' "${ROOT_DIR}/scripts/validate-repo.sh"; then
-  echo "Expected validate-repo.sh to prune repo-local virtualenv content from documentation scans" >&2
-  exit 1
-fi
-
-if ! grep -Fq "build -buildvcs=false -o \"\${output_path}\"" "${ROOT_DIR}/scripts/lib/go-run-env.sh"; then
-  echo "Expected build_go_tool_in_repo to disable Go VCS stamping in untrusted repos" >&2
-  exit 1
-fi
+# Assert the doc-scan / Go-VCS-stamping invariants: validate-repo.sh prunes
+# repo-local virtualenv content from documentation scans, and build_go_tool_in_repo
+# (scripts/lib/go-run-env.sh) disables Go VCS stamping in untrusted repos.
+# Migrated to Go (D3): internal/workcellhardening behind the workcell-citools
+# workcell-doc-scan-go-vcs subcommand preserves the exact exit codes and stderr
+# messages of the former inline grep -Fq pair (two fixed-string presence probes).
+# Only this contiguous pair is migrated; the following go_cache_root
+# ensure_go_run_env exec block and the publishpr.ValidateBaseName
+# go_function_block probe stay inline to preserve first-failure order.  `|| exit 1`
+# matches the former inline block's `exit 1` on a violated invariant.
+go_verify_citools workcell-doc-scan-go-vcs "${ROOT_DIR}" || exit 1
 
 go_cache_root_expected=""
 case "$(uname -s)" in
@@ -3618,18 +3601,14 @@ if [[ -e "${CONTAINER_SMOKE_PATH_MARKER}" ]]; then
   exit 1
 fi
 
-if rg -q 'chown -R "\$\{HOST_UID\}:\$\{HOST_GID\}" "\$\{target_path\}"' "${ROOT_DIR}/scripts/container-smoke.sh"; then
-  echo "Expected scripts/container-smoke.sh to avoid raw recursive chown on host-managed paths" >&2
-  exit 1
-fi
-if rg -q 'tar --null -T "\$\{path_list_filtered\}" -cf -' "${ROOT_DIR}/scripts/container-smoke.sh"; then
-  echo "Expected scripts/container-smoke.sh to avoid tar-based smoke workspace staging" >&2
-  exit 1
-fi
-if rg -q 'tar -xf -' "${ROOT_DIR}/scripts/container-smoke.sh"; then
-  echo "Expected scripts/container-smoke.sh to avoid tar-based extraction for smoke workspace staging" >&2
-  exit 1
-fi
+# Assert the container-smoke chown/tar invariants on scripts/container-smoke.sh:
+# no raw recursive chown on host-managed paths, and no tar-based smoke workspace
+# staging or extraction.  Migrated to Go (D3): internal/workcellhardening behind
+# the workcell-citools workcell-smoke-chown-tar subcommand preserves the exact
+# exit codes and stderr messages of the former inline negated rg block (three
+# fixed-string absence probes).  `|| exit 1` matches the former inline block's
+# `exit 1` on a violated invariant.
+go_verify_citools workcell-smoke-chown-tar "${ROOT_DIR}" || exit 1
 
 if ! "${ROOT_DIR}/scripts/container-smoke.sh" --self-test-host-path-hardening \
   >/tmp/workcell-container-smoke-host-path-hardening.out 2>&1; then
@@ -3725,34 +3704,22 @@ if ! echo "${EGRESS_PLAN_IPV6_LITERAL}" | grep -q 'iptables -A WORKCELL_EGRESS -
   echo "Expected bracketed IPv6 literal endpoints to still default-drop IPv4 traffic" >&2
   exit 1
 fi
-if ! rg -q 'run_in_vm "\$\(render_allowlist_apply_plan\)"' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Expected dual-stack allowlist apply path to use the guarded apply plan" >&2
-  exit 1
-fi
-if ! rg -q 'if ! type ip6tables >/dev/null 2>&1; then' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Expected dual-stack allowlist apply plan to preflight ip6tables before rewriting rules" >&2
-  exit 1
-fi
-if ! rg -q '^render_clear_plan\(\)' "${ROOT_DIR}/scripts/colima-egress-allowlist.sh"; then
-  echo "Expected dual-stack allowlist helper to render clear rules in the VM apply plan" >&2
-  exit 1
-fi
-if ! function_block_contains_regex "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" "render_allowlist_apply_plan" 'render_clear_plan'; then
-  echo "Expected dual-stack allowlist apply plan to include render_clear_plan" >&2
-  exit 1
-fi
-if ! function_block_contains_regex "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" "render_allowlist_apply_plan" 'resolve_vm_endpoint_ips'; then
-  echo "Expected dual-stack allowlist apply plan to resolve hostnames inside the VM before applying rules" >&2
-  exit 1
-fi
-if ! function_block_contains_regex "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" "render_allowlist_apply_plan" 'getent ahosts'; then
-  echo "Expected dual-stack allowlist apply plan to use VM DNS results for hostname endpoints" >&2
-  exit 1
-fi
-if function_block_contains_regex "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" "render_allowlist_apply_plan" 'render_allowlist_plan'; then
-  echo "Expected dual-stack allowlist apply plan to avoid host-resolved endpoint rules" >&2
-  exit 1
-fi
+# Assert the dual-stack allowlist-apply-plan invariants on
+# scripts/colima-egress-allowlist.sh: the guarded apply path runs the guarded
+# plan, the plan preflights ip6tables and renders a clear-rules helper, and
+# render_allowlist_apply_plan renders the clear plan, resolves endpoint IPs inside
+# the VM (getent ahosts) and avoids host-resolved endpoint rules.  Migrated to Go
+# (D3): internal/workcellhardening behind the workcell-citools
+# workcell-dualstack-apply-plan subcommand preserves the exact exit codes and
+# stderr messages of the former inline rg / function_block_contains_regex block,
+# including the two fixed-string rg probes, the line-anchored render_clear_plan
+# definition regex, the three affirmative function-block regex probes, and the
+# negated (metacharacter-free) render_allowlist_plan function-block probe.  The
+# following clear_rules guard (a negated function-block GENUINE regex) and the
+# run_in_vm awk-ordering block stay inline to preserve first-failure order.
+# `|| exit 1` matches the former inline block's `exit 1` on a violated invariant.
+go_verify_citools workcell-dualstack-apply-plan "${ROOT_DIR}" || exit 1
+
 if function_block_contains_regex "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" "render_allowlist_apply_plan" '^[[:space:]]*clear_rules$'; then
   echo "Expected dual-stack allowlist apply plan to avoid invoking clear_rules during render" >&2
   exit 1


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 26 of N (multi-cluster sweep).** Follows #398-#422. Migrates 4 scattered simple-check clusters in one PR, each as its own subcommand wired at its exact position (preserving first-failure order per the lesson from #422).

## Clusters (20 checks)
1. **`workcell-buildx-builder-trust`** `CheckBuildxBuilderTrust` (8, `kindPresent`) — deterministic buildx builder + validator-image-cleanup across verify-release-bundle/build-and-test/job-validate/job-docs/verify-reproducible-build/trusted-docker-client/colima-egress.
2. **`workcell-doc-scan-go-vcs`** `CheckDocScanGoVcs` (2, `kindPresent`) — validate-repo venv-prune + go-run-env buildvcs (the pair left inline by #422, now migrated as their own subcommand **after** the git-index-shadow call — order preserved).
3. **`workcell-smoke-chown-tar`** `CheckSmokeChownTar` (3, `kindAbsent`) — container-smoke raw-recursive-chown guards.
4. **`workcell-dualstack-apply-plan`** `CheckDualStackApplyPlan` (7: present/regex/function-block/function-block-absent) — colima-egress guarded dual-stack apply plan.

## Ordering discipline
Clusters 2 and 4 are **split** where a non-simple check (a `case`/`env -i` exec block; a genuine-regex negated `function_block_contains_regex` with no matching kind, and a `run_in_vm` awk block) intervenes — those stay inline in bash. Only the maximal contiguous simple run in each cluster is migrated. No reordering.

## Follow-up noted
A `function-block-regex-absent` kind is needed to migrate the `^[[:space:]]*clear_rules$` negated function-block-regex check (left inline) — a future increment.

## Parity / validation
Each subcommand on real repo → exit 0; per-subcommand crafted violations → exit 1 byte-identical first-failure messages; per-subcommand real-repo assertion + count guard. `go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 820 lines. No new kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)