### PR TITLE
^R D3: final simple-check sweep to Go (16 checks, 6 subcommands + orphan-helper cleanup)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -123,6 +123,12 @@ func subcommands() []subcommand {
 		{"workcell-doc-scan-go-vcs", "ROOT_DIR", 1, 1, cmdWorkcellDocScanGoVcs},
 		{"workcell-smoke-chown-tar", "ROOT_DIR", 1, 1, cmdWorkcellSmokeChownTar},
 		{"workcell-dualstack-apply-plan", "ROOT_DIR", 1, 1, cmdWorkcellDualStackApplyPlan},
+		{"workcell-publish-base-refcheck", "ROOT_DIR", 1, 1, cmdWorkcellPublishBaseRefcheck},
+		{"workcell-runtime-security-posture", "ROOT_DIR", 1, 1, cmdWorkcellRuntimeSecurityPosture},
+		{"workcell-smoke-apt-broker-probe", "ROOT_DIR", 1, 1, cmdWorkcellSmokeAptBrokerProbe},
+		{"workcell-copilot-token-handoff-cleanup", "ROOT_DIR", 1, 1, cmdWorkcellCopilotTokenHandoffCleanup},
+		{"workcell-provider-token-unlink", "ROOT_DIR", 1, 1, cmdWorkcellProviderTokenUnlink},
+		{"workcell-validate-repo-scenario-refs", "ROOT_DIR", 1, 1, cmdWorkcellValidateRepoScenarioRefs},
 	}
 }
 
@@ -758,4 +764,58 @@ func cmdWorkcellSmokeChownTar(args []string) error {
 // violated invariant.
 func cmdWorkcellDualStackApplyPlan(args []string) error {
 	return workcellhardening.CheckDualStackApplyPlan(args[0])
+}
+
+// cmdWorkcellPublishBaseRefcheck runs the single publish-pr base-name check
+// (publishpr.ValidateBaseName validates the --base branch name through
+// checkRefFormat) migrated out of scripts/verify-invariants.sh; it fails (exit 1
+// via die()) with the shell's original stderr message when the invariant is
+// violated.
+func cmdWorkcellPublishBaseRefcheck(args []string) error {
+	return workcellhardening.CheckPublishBaseRefcheck(args[0])
+}
+
+// cmdWorkcellRuntimeSecurityPosture runs the two validate_runtime_security_posture
+// checks (daemon SecurityOptions and Docker Desktop compat SecurityOptions are
+// validated through the go_hostutil helper subcommands) migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the shell's
+// original stderr message for the first violated invariant.
+func cmdWorkcellRuntimeSecurityPosture(args []string) error {
+	return workcellhardening.CheckRuntimeSecurityPosture(args[0])
+}
+
+// cmdWorkcellSmokeAptBrokerProbe runs the six container-smoke apt-broker
+// slow-wait checks (scripts/container-smoke.sh keeps the Linux runtime
+// apt-broker slow-wait probe strings) migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the shell's
+// original stderr message for the first violated invariant.
+func cmdWorkcellSmokeAptBrokerProbe(args []string) error {
+	return workcellhardening.CheckSmokeAptBrokerProbe(args[0])
+}
+
+// cmdWorkcellCopilotTokenHandoffCleanup runs the three Copilot token-handoff
+// cleanup checks (hoststate.go covers stale Copilot token handoff directories in
+// host cleanup) migrated out of scripts/verify-invariants.sh; it fails (exit 1
+// via die()) with the shell's original stderr message for the first violated
+// invariant.
+func cmdWorkcellCopilotTokenHandoffCleanup(args []string) error {
+	return workcellhardening.CheckCopilotTokenHandoffCleanup(args[0])
+}
+
+// cmdWorkcellProviderTokenUnlink runs the single provider-wrapper token-unlink
+// check (the provider wrapper unlinks the runtime Copilot token handoff file
+// before managed exec) migrated out of scripts/verify-invariants.sh; it fails
+// (exit 1 via die()) with the shell's original stderr message when the invariant
+// is violated.
+func cmdWorkcellProviderTokenUnlink(args []string) error {
+	return workcellhardening.CheckProviderTokenUnlink(args[0])
+}
+
+// cmdWorkcellValidateRepoScenarioRefs runs the three scenario-script reference
+// checks (scripts/validate-repo.sh references the scenario-test / coverage /
+// control-plane-parity scripts) migrated out of scripts/verify-invariants.sh; it
+// fails (exit 1 via die()) with the shell's original stderr message for the first
+// violated invariant.
+func cmdWorkcellValidateRepoScenarioRefs(args []string) error {
+	return workcellhardening.CheckValidateRepoScenarioRefs(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -260,6 +260,13 @@ const runMutationInValidatorRelPath = "scripts/ci/run-mutation-in-validator.sh"
 // `go_function_block_contains_fixed ${ROOT_DIR}/internal/publishpr/host_exec.go`.
 const hostExecRelPath = "internal/publishpr/host_exec.go"
 
+// publishPrMainRelPath is the repo-relative path to the Go publish-pr owner
+// that inherited validate_publish_base_name from scripts/workcell.  The
+// publish-base-refcheck block reads this file (via the per-check targetFile
+// field) for its kindGoFunctionBlock probe, mirroring the shell
+// `go_function_block_contains_fixed ${ROOT_DIR}/internal/publishpr/publish_pr_main.go`.
+const publishPrMainRelPath = "internal/publishpr/publish_pr_main.go"
+
 // containerBinGitRelPath is the repo-relative path to the in-container git
 // shim.  The fnblock-goblock-gitenv block reads this file (via the per-check
 // targetFile field) for its three git-env object-store-redirection pins,
@@ -3776,6 +3783,195 @@ var dualStackApplyPlanChecks = []check{
 // shell's exit 1).
 func CheckDualStackApplyPlan(rootDir string) error {
 	return evaluate(rootDir, dualStackApplyPlanChecks)
+}
+
+// publishBaseRefcheckChecks holds the single publish-pr base-name invariant
+// migrated out of scripts/verify-invariants.sh (the lone
+// go_function_block_contains_fixed probe sitting between the ensure_go_run_env
+// cache-root exec block and the workcell-publish-pr-shadow group).  It mirrors
+// the shell's go_function_block_contains_fixed helper (awk function-body
+// extraction with comment stripping, then `grep -Fq`), scoping the fixed-string
+// containment to internal/publishpr/publish_pr_main.go's ValidateBaseName body
+// so the needle cannot be satisfied by unrelated text or a comment.
+var publishBaseRefcheckChecks = []check{
+	{
+		kind:         kindGoFunctionBlock,
+		functionName: "ValidateBaseName",
+		pattern:      "!checkRefFormat(base)",
+		message:      "Expected publishpr.ValidateBaseName to validate the publish-pr --base branch name through checkRefFormat",
+		targetFile:   publishPrMainRelPath,
+	},
+}
+
+// CheckPublishBaseRefcheck runs the single publish-pr base-name invariant
+// against the repo rooted at rootDir.  It returns nil when the invariant holds
+// (the shell's exit 0), or an error whose message equals the shell's stderr for
+// the violated invariant (the shell's exit 1).
+func CheckPublishBaseRefcheck(rootDir string) error {
+	return evaluate(rootDir, publishBaseRefcheckChecks)
+}
+
+// runtimeSecurityPostureChecks lists the two validate_runtime_security_posture
+// invariants in the same order as the contiguous inline pair in
+// scripts/verify-invariants.sh (the pair between the go_verify_hostutil
+// security-option exec fixtures and the prompt-autonomy dry-run exec block).
+// Both migrate function_block_contains_fixed (`grep -Fq` fixed-string
+// containment) scoped to the validate_runtime_security_posture body in
+// scripts/workcell (the default target), so each is a kindFunctionBlock probe.
+var runtimeSecurityPostureChecks = []check{
+	{
+		kind:         kindFunctionBlock,
+		functionName: "validate_runtime_security_posture",
+		pattern:      "go_hostutil helper validate-security-options",
+		message:      "Expected validate_runtime_security_posture to validate daemon SecurityOptions through the helper subcommand",
+	},
+	{
+		kind:         kindFunctionBlock,
+		functionName: "validate_runtime_security_posture",
+		pattern:      "go_hostutil helper validate-compat-security-options",
+		message:      "Expected validate_runtime_security_posture to validate Docker Desktop compat daemon SecurityOptions through the compat helper subcommand",
+	},
+}
+
+// CheckRuntimeSecurityPosture runs the two validate_runtime_security_posture
+// invariants against the repo rooted at rootDir, in the shell's original order.
+// It returns nil when every invariant holds (the shell's exit 0), or an error
+// whose message equals the shell's stderr for the first violated invariant (the
+// shell's exit 1).
+func CheckRuntimeSecurityPosture(rootDir string) error {
+	return evaluate(rootDir, runtimeSecurityPostureChecks)
+}
+
+// smokeAptBrokerProbeChecks lists the six container-smoke apt-broker slow-wait
+// invariants in the same order as the former inline
+// `for required in ...; do grep -Fq -- "${required}" container-smoke.sh; done`
+// loop in scripts/verify-invariants.sh.  Each iteration was a fixed-string
+// presence probe whose stderr interpolated the needle into the message, so each
+// message is computed here verbatim as
+// "Expected scripts/container-smoke.sh to keep the Linux runtime apt-broker
+// slow-wait probe (" + needle + ")".  All six read scripts/container-smoke.sh
+// via the per-check targetFile field.
+var smokeAptBrokerProbeChecks = func() []check {
+	needles := []string{
+		"slow_apt_helper=/state/tmp/workcell-slow-apt-helper.sh",
+		"/bin/bash /usr/local/libexec/workcell/apt-broker.sh",
+		"sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get update",
+		"slow-apt-helper-ok",
+		"expected sudo-wrapper to wait for a slow apt broker request by default",
+		"expected default apt broker waits to avoid timing out slow requests",
+	}
+	cs := make([]check, 0, len(needles))
+	for _, needle := range needles {
+		cs = append(cs, check{
+			kind:       kindPresent,
+			pattern:    needle,
+			message:    "Expected scripts/container-smoke.sh to keep the Linux runtime apt-broker slow-wait probe (" + needle + ")",
+			targetFile: containerSmokeRelPath,
+		})
+	}
+	return cs
+}()
+
+// CheckSmokeAptBrokerProbe runs the six container-smoke apt-broker slow-wait
+// invariants against the repo rooted at rootDir, in the shell's original order.
+// It returns nil when every invariant holds (the shell's exit 0), or an error
+// whose message equals the shell's stderr for the first violated invariant (the
+// shell's exit 1).
+func CheckSmokeAptBrokerProbe(rootDir string) error {
+	return evaluate(rootDir, smokeAptBrokerProbeChecks)
+}
+
+// copilotTokenHandoffCleanupChecks lists the three Copilot token-handoff cleanup
+// invariants migrated out of scripts/verify-invariants.sh.  They came from one
+// multi-probe `if ! grep -Fq A || ! grep -Fq B || ! grep -Fq C; then ... exit 1`
+// guard against internal/host/hoststate/hoststate.go, so they are three ordered
+// kindPresent probes sharing the guard's single stderr message; ordering them
+// preserves the shell's first-failure (short-circuit) behavior.
+var copilotTokenHandoffCleanupChecks = []check{
+	{
+		kind:       kindPresent,
+		pattern:    "copilotStandaloneTokenHandoffName",
+		message:    "Expected stale Copilot token handoff directories to be covered by host cleanup",
+		targetFile: hoststateRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    "copilotTokenHandoffBundleName",
+		message:    "Expected stale Copilot token handoff directories to be covered by host cleanup",
+		targetFile: hoststateRelPath,
+	},
+	{
+		kind:       kindPresent,
+		pattern:    "removeCopilotTokenHandoffArtifacts",
+		message:    "Expected stale Copilot token handoff directories to be covered by host cleanup",
+		targetFile: hoststateRelPath,
+	},
+}
+
+// CheckCopilotTokenHandoffCleanup runs the three Copilot token-handoff cleanup
+// invariants against the repo rooted at rootDir, in the shell's original order.
+// It returns nil when every invariant holds (the shell's exit 0), or an error
+// whose message equals the shell's stderr for the first violated invariant (the
+// shell's exit 1).
+func CheckCopilotTokenHandoffCleanup(rootDir string) error {
+	return evaluate(rootDir, copilotTokenHandoffCleanupChecks)
+}
+
+// providerTokenUnlinkChecks holds the single provider-wrapper token-unlink
+// invariant migrated out of scripts/verify-invariants.sh (the lone `grep -Fq`
+// probe between the workcell-provider-launcher-authority group and the
+// workcell-copilot-policy-wrapper group).  The shell needle
+// "rm -f -- \"\${token_file}\"" is the literal `rm -f -- "${token_file}"`,
+// matched as a fixed string against runtime/container/provider-wrapper.sh.
+var providerTokenUnlinkChecks = []check{
+	{
+		kind:       kindPresent,
+		pattern:    `rm -f -- "${token_file}"`,
+		message:    "Expected provider wrapper to unlink the runtime Copilot token handoff file before managed exec",
+		targetFile: providerWrapperRelPath,
+	},
+}
+
+// CheckProviderTokenUnlink runs the single provider-wrapper token-unlink
+// invariant against the repo rooted at rootDir.  It returns nil when the
+// invariant holds (the shell's exit 0), or an error whose message equals the
+// shell's stderr for the violated invariant (the shell's exit 1).
+func CheckProviderTokenUnlink(rootDir string) error {
+	return evaluate(rootDir, providerTokenUnlinkChecks)
+}
+
+// validateRepoScenarioRefsChecks lists the three scenario-script reference
+// invariants migrated out of scripts/verify-invariants.sh (the former
+// `for scenario_script_basename in ...; do grep -Fq -- "${basename}"
+// validate-repo.sh; done` loop).  Each iteration was a fixed-string presence
+// probe whose stderr interpolated the basename into the message, so each message
+// is computed here verbatim as "validate-repo.sh must reference " + basename.
+// All three read scripts/validate-repo.sh via the per-check targetFile field.
+var validateRepoScenarioRefsChecks = func() []check {
+	basenames := []string{
+		"run-scenario-tests.sh",
+		"verify-scenario-coverage.sh",
+		"verify-control-plane-parity.sh",
+	}
+	cs := make([]check, 0, len(basenames))
+	for _, basename := range basenames {
+		cs = append(cs, check{
+			kind:       kindPresent,
+			pattern:    basename,
+			message:    "validate-repo.sh must reference " + basename,
+			targetFile: validateRepoRelPath,
+		})
+	}
+	return cs
+}()
+
+// CheckValidateRepoScenarioRefs runs the three scenario-script reference
+// invariants against the repo rooted at rootDir, in the shell's original order.
+// It returns nil when every invariant holds (the shell's exit 0), or an error
+// whose message equals the shell's stderr for the first violated invariant (the
+// shell's exit 1).
+func CheckValidateRepoScenarioRefs(rootDir string) error {
+	return evaluate(rootDir, validateRepoScenarioRefsChecks)
 }
 
 // holds reports whether the invariant is satisfied by the launcher text.

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -5566,3 +5566,424 @@ func TestCheckDualStackApplyPlanRealRepo(t *testing.T) {
 		t.Fatalf("CheckDualStackApplyPlan(real repo) = %v, want nil", err)
 	}
 }
+
+// --- D3 final simple sweep: publish-pr base-name refcheck (goblock) ---
+
+// publishBaseRefcheckHappyFiles returns a publish_pr_main.go fixture whose
+// ValidateBaseName body carries the !checkRefFormat(base) needle, so the single
+// goblock invariant holds.
+func publishBaseRefcheckHappyFiles() map[string]string {
+	return map[string]string{
+		publishPrMainRelPath: "package publishpr\n\n" +
+			"func ValidateBaseName(base string, allowNonMainBase bool, checkRefFormat CheckRefFormatFunc) error {\n" +
+			"\tif checkRefFormat != nil && !checkRefFormat(base) {\n" +
+			"\t\treturn errInvalidBase\n" +
+			"\t}\n" +
+			"\treturn nil\n" +
+			"}\n",
+	}
+}
+
+func TestCheckPublishBaseRefcheck(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(files map[string]string)
+		wantErr string
+	}{
+		{name: "happy path invariant holds", mutate: func(map[string]string) {}},
+		{
+			name: "checkRefFormat call missing from body",
+			mutate: func(f map[string]string) {
+				f[publishPrMainRelPath] = strings.Replace(f[publishPrMainRelPath], "!checkRefFormat(base)", "false", 1)
+			},
+			wantErr: "Expected publishpr.ValidateBaseName to validate the publish-pr --base branch name through checkRefFormat",
+		},
+		{
+			name: "needle only in a comment inside the body",
+			mutate: func(f map[string]string) {
+				f[publishPrMainRelPath] = strings.Replace(f[publishPrMainRelPath], "\tif checkRefFormat != nil && !checkRefFormat(base) {", "\t// !checkRefFormat(base)\n\tif false {", 1)
+			},
+			wantErr: "Expected publishpr.ValidateBaseName to validate the publish-pr --base branch name through checkRefFormat",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := publishBaseRefcheckHappyFiles()
+			tt.mutate(files)
+			root := writeFnBlockGoBlockGitEnvRepo(t, files)
+			err := CheckPublishBaseRefcheck(root)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckPublishBaseRefcheck() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("CheckPublishBaseRefcheck() = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckPublishBaseRefcheckCount(t *testing.T) {
+	if got, want := len(publishBaseRefcheckChecks), 1; got != want {
+		t.Fatalf("publishBaseRefcheckChecks has %d checks, want %d", got, want)
+	}
+}
+
+func TestCheckPublishBaseRefcheckRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, publishPrMainRelPath)); err != nil {
+		t.Skipf("real internal/publishpr/publish_pr_main.go not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckPublishBaseRefcheck(repoRoot); err != nil {
+		t.Fatalf("CheckPublishBaseRefcheck(real repo) = %v, want nil", err)
+	}
+}
+
+// --- D3 final simple sweep: validate_runtime_security_posture (fnblock) ---
+
+// runtimeSecurityPostureHappyFiles returns a scripts/workcell fixture whose
+// validate_runtime_security_posture body carries both go_hostutil helper needles,
+// so the two fnblock invariants hold.
+func runtimeSecurityPostureHappyFiles() map[string]string {
+	return map[string]string{
+		launcherRelPath: "#!/usr/bin/env bash\n" +
+			"validate_runtime_security_posture() {\n" +
+			"  go_hostutil helper validate-security-options \"$@\"\n" +
+			"  go_hostutil helper validate-compat-security-options \"$@\"\n" +
+			"}\n",
+	}
+}
+
+func TestCheckRuntimeSecurityPosture(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(files map[string]string)
+		wantErr string
+	}{
+		{name: "happy path all invariants hold", mutate: func(map[string]string) {}},
+		{
+			name: "security-options needle missing",
+			mutate: func(f map[string]string) {
+				f[launcherRelPath] = strings.Replace(f[launcherRelPath], "  go_hostutil helper validate-security-options \"$@\"\n", "", 1)
+			},
+			wantErr: "Expected validate_runtime_security_posture to validate daemon SecurityOptions through the helper subcommand",
+		},
+		{
+			name: "compat-security-options needle missing",
+			mutate: func(f map[string]string) {
+				f[launcherRelPath] = strings.Replace(f[launcherRelPath], "  go_hostutil helper validate-compat-security-options \"$@\"\n", "", 1)
+			},
+			wantErr: "Expected validate_runtime_security_posture to validate Docker Desktop compat daemon SecurityOptions through the compat helper subcommand",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := runtimeSecurityPostureHappyFiles()
+			tt.mutate(files)
+			root := writeFnBlockGoBlockGitEnvRepo(t, files)
+			err := CheckRuntimeSecurityPosture(root)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckRuntimeSecurityPosture() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("CheckRuntimeSecurityPosture() = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckRuntimeSecurityPostureCount(t *testing.T) {
+	if got, want := len(runtimeSecurityPostureChecks), 2; got != want {
+		t.Fatalf("runtimeSecurityPostureChecks has %d checks, want %d", got, want)
+	}
+}
+
+func TestCheckRuntimeSecurityPostureRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, launcherRelPath)); err != nil {
+		t.Skipf("real scripts/workcell not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckRuntimeSecurityPosture(repoRoot); err != nil {
+		t.Fatalf("CheckRuntimeSecurityPosture(real repo) = %v, want nil", err)
+	}
+}
+
+// --- D3 final simple sweep: container-smoke apt-broker slow-wait probe ---
+
+// smokeAptBrokerProbeHappyFiles returns a container-smoke.sh fixture that carries
+// all six apt-broker slow-wait probe strings, so all six invariants hold.
+func smokeAptBrokerProbeHappyFiles() map[string]string {
+	return map[string]string{
+		containerSmokeRelPath: "#!/usr/bin/env bash\n" +
+			"slow_apt_helper=/state/tmp/workcell-slow-apt-helper.sh\n" +
+			"/bin/bash /usr/local/libexec/workcell/apt-broker.sh\n" +
+			"sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get update\n" +
+			"echo slow-apt-helper-ok\n" +
+			"# expected sudo-wrapper to wait for a slow apt broker request by default\n" +
+			"# expected default apt broker waits to avoid timing out slow requests\n",
+	}
+}
+
+func TestCheckSmokeAptBrokerProbe(t *testing.T) {
+	tests := []struct {
+		name    string
+		needle  string
+		wantErr string
+	}{
+		{name: "happy path all invariants hold"},
+		{
+			name:    "slow-apt-helper path probe missing",
+			needle:  "slow_apt_helper=/state/tmp/workcell-slow-apt-helper.sh",
+			wantErr: "Expected scripts/container-smoke.sh to keep the Linux runtime apt-broker slow-wait probe (slow_apt_helper=/state/tmp/workcell-slow-apt-helper.sh)",
+		},
+		{
+			name:    "apt-broker invocation probe missing",
+			needle:  "/bin/bash /usr/local/libexec/workcell/apt-broker.sh",
+			wantErr: "Expected scripts/container-smoke.sh to keep the Linux runtime apt-broker slow-wait probe (/bin/bash /usr/local/libexec/workcell/apt-broker.sh)",
+		},
+		{
+			name:    "apt-helper update probe missing",
+			needle:  "sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get update",
+			wantErr: "Expected scripts/container-smoke.sh to keep the Linux runtime apt-broker slow-wait probe (sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get update)",
+		},
+		{
+			name:    "slow-apt-helper-ok probe missing",
+			needle:  "slow-apt-helper-ok",
+			wantErr: "Expected scripts/container-smoke.sh to keep the Linux runtime apt-broker slow-wait probe (slow-apt-helper-ok)",
+		},
+		{
+			name:    "sudo-wrapper wait probe missing",
+			needle:  "expected sudo-wrapper to wait for a slow apt broker request by default",
+			wantErr: "Expected scripts/container-smoke.sh to keep the Linux runtime apt-broker slow-wait probe (expected sudo-wrapper to wait for a slow apt broker request by default)",
+		},
+		{
+			name:    "default broker wait probe missing",
+			needle:  "expected default apt broker waits to avoid timing out slow requests",
+			wantErr: "Expected scripts/container-smoke.sh to keep the Linux runtime apt-broker slow-wait probe (expected default apt broker waits to avoid timing out slow requests)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := smokeAptBrokerProbeHappyFiles()
+			if tt.needle != "" {
+				files[containerSmokeRelPath] = strings.Replace(files[containerSmokeRelPath], tt.needle, "", 1)
+			}
+			root := writeFnBlockGoBlockGitEnvRepo(t, files)
+			err := CheckSmokeAptBrokerProbe(root)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckSmokeAptBrokerProbe() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("CheckSmokeAptBrokerProbe() = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckSmokeAptBrokerProbeCount(t *testing.T) {
+	if got, want := len(smokeAptBrokerProbeChecks), 6; got != want {
+		t.Fatalf("smokeAptBrokerProbeChecks has %d checks, want %d", got, want)
+	}
+}
+
+func TestCheckSmokeAptBrokerProbeRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, containerSmokeRelPath)); err != nil {
+		t.Skipf("real scripts/container-smoke.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckSmokeAptBrokerProbe(repoRoot); err != nil {
+		t.Fatalf("CheckSmokeAptBrokerProbe(real repo) = %v, want nil", err)
+	}
+}
+
+// --- D3 final simple sweep: Copilot token-handoff cleanup (hoststate) ---
+
+// copilotTokenHandoffCleanupHappyFiles returns a hoststate.go fixture carrying
+// all three Copilot token-handoff cleanup identifiers, so all three invariants
+// hold.
+func copilotTokenHandoffCleanupHappyFiles() map[string]string {
+	return map[string]string{
+		hoststateRelPath: "package hoststate\n\n" +
+			"const copilotStandaloneTokenHandoffName = \"copilot-standalone-token-handoff\"\n" +
+			"const copilotTokenHandoffBundleName = \"copilot-token-handoff\"\n" +
+			"func removeCopilotTokenHandoffArtifacts() error { return nil }\n",
+	}
+}
+
+func TestCheckCopilotTokenHandoffCleanup(t *testing.T) {
+	tests := []struct {
+		name    string
+		needle  string
+		wantErr string
+	}{
+		{name: "happy path all invariants hold"},
+		{name: "standalone handoff name missing", needle: "copilotStandaloneTokenHandoffName", wantErr: "Expected stale Copilot token handoff directories to be covered by host cleanup"},
+		{name: "bundle name missing", needle: "copilotTokenHandoffBundleName", wantErr: "Expected stale Copilot token handoff directories to be covered by host cleanup"},
+		{name: "removal helper missing", needle: "removeCopilotTokenHandoffArtifacts", wantErr: "Expected stale Copilot token handoff directories to be covered by host cleanup"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := copilotTokenHandoffCleanupHappyFiles()
+			if tt.needle != "" {
+				files[hoststateRelPath] = strings.Replace(files[hoststateRelPath], tt.needle, "renamed", 1)
+			}
+			root := writeFnBlockGoBlockGitEnvRepo(t, files)
+			err := CheckCopilotTokenHandoffCleanup(root)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckCopilotTokenHandoffCleanup() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("CheckCopilotTokenHandoffCleanup() = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckCopilotTokenHandoffCleanupCount(t *testing.T) {
+	if got, want := len(copilotTokenHandoffCleanupChecks), 3; got != want {
+		t.Fatalf("copilotTokenHandoffCleanupChecks has %d checks, want %d", got, want)
+	}
+}
+
+func TestCheckCopilotTokenHandoffCleanupRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, hoststateRelPath)); err != nil {
+		t.Skipf("real internal/host/hoststate/hoststate.go not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckCopilotTokenHandoffCleanup(repoRoot); err != nil {
+		t.Fatalf("CheckCopilotTokenHandoffCleanup(real repo) = %v, want nil", err)
+	}
+}
+
+// --- D3 final simple sweep: provider-wrapper token unlink ---
+
+// providerTokenUnlinkHappyFiles returns a provider-wrapper.sh fixture carrying
+// the token-unlink needle, so the single invariant holds.
+func providerTokenUnlinkHappyFiles() map[string]string {
+	return map[string]string{
+		providerWrapperRelPath: "#!/usr/bin/env bash\n" +
+			"rm -f -- \"${token_file}\" || workcell_die \"could not remove\"\n",
+	}
+}
+
+func TestCheckProviderTokenUnlink(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(files map[string]string)
+		wantErr string
+	}{
+		{name: "happy path invariant holds", mutate: func(map[string]string) {}},
+		{
+			name: "token unlink needle missing",
+			mutate: func(f map[string]string) {
+				f[providerWrapperRelPath] = strings.Replace(f[providerWrapperRelPath], "rm -f -- \"${token_file}\"", "true", 1)
+			},
+			wantErr: "Expected provider wrapper to unlink the runtime Copilot token handoff file before managed exec",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := providerTokenUnlinkHappyFiles()
+			tt.mutate(files)
+			root := writeFnBlockGoBlockGitEnvRepo(t, files)
+			err := CheckProviderTokenUnlink(root)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckProviderTokenUnlink() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("CheckProviderTokenUnlink() = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckProviderTokenUnlinkCount(t *testing.T) {
+	if got, want := len(providerTokenUnlinkChecks), 1; got != want {
+		t.Fatalf("providerTokenUnlinkChecks has %d checks, want %d", got, want)
+	}
+}
+
+func TestCheckProviderTokenUnlinkRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, providerWrapperRelPath)); err != nil {
+		t.Skipf("real runtime/container/provider-wrapper.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckProviderTokenUnlink(repoRoot); err != nil {
+		t.Fatalf("CheckProviderTokenUnlink(real repo) = %v, want nil", err)
+	}
+}
+
+// --- D3 final simple sweep: validate-repo scenario-script references ---
+
+// validateRepoScenarioRefsHappyFiles returns a validate-repo.sh fixture that
+// references all three scenario scripts, so all three invariants hold.
+func validateRepoScenarioRefsHappyFiles() map[string]string {
+	return map[string]string{
+		validateRepoRelPath: "#!/usr/bin/env bash\n" +
+			"run-scenario-tests.sh\n" +
+			"verify-scenario-coverage.sh\n" +
+			"verify-control-plane-parity.sh\n",
+	}
+}
+
+func TestCheckValidateRepoScenarioRefs(t *testing.T) {
+	tests := []struct {
+		name    string
+		needle  string
+		wantErr string
+	}{
+		{name: "happy path all invariants hold"},
+		{name: "run-scenario-tests reference missing", needle: "run-scenario-tests.sh", wantErr: "validate-repo.sh must reference run-scenario-tests.sh"},
+		{name: "verify-scenario-coverage reference missing", needle: "verify-scenario-coverage.sh", wantErr: "validate-repo.sh must reference verify-scenario-coverage.sh"},
+		{name: "verify-control-plane-parity reference missing", needle: "verify-control-plane-parity.sh", wantErr: "validate-repo.sh must reference verify-control-plane-parity.sh"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := validateRepoScenarioRefsHappyFiles()
+			if tt.needle != "" {
+				files[validateRepoRelPath] = strings.Replace(files[validateRepoRelPath], tt.needle, "", 1)
+			}
+			root := writeFnBlockGoBlockGitEnvRepo(t, files)
+			err := CheckValidateRepoScenarioRefs(root)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckValidateRepoScenarioRefs() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("CheckValidateRepoScenarioRefs() = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckValidateRepoScenarioRefsCount(t *testing.T) {
+	if got, want := len(validateRepoScenarioRefsChecks), 3; got != want {
+		t.Fatalf("validateRepoScenarioRefsChecks has %d checks, want %d", got, want)
+	}
+}
+
+func TestCheckValidateRepoScenarioRefsRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, validateRepoRelPath)); err != nil {
+		t.Skipf("real scripts/validate-repo.sh not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckValidateRepoScenarioRefs(repoRoot); err != nil {
+		t.Fatalf("CheckValidateRepoScenarioRefs(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -100,48 +100,6 @@ function_block_contains_regex() {
   grep -q -- "${regex}" <<<"${block_text}"
 }
 
-function_block_contains_fixed() {
-  local file_path="$1"
-  local function_name="$2"
-  local needle="$3"
-  local block_text=""
-
-  block_text="$(extract_named_function_block "${file_path}" "${function_name}")"
-  grep -Fq -- "${needle}" <<<"${block_text}"
-}
-
-# Scope a fixed-string assertion to one top-level Go function body, so an
-# invariant migrated from bash to Go cannot be satisfied by the same text
-# appearing in an unrelated helper elsewhere in the file or in a comment
-# (// line comments and /* */ block comments, including multi-line block
-# comments, are stripped before matching).
-go_function_block_contains_fixed() {
-  local file_path="$1"
-  local function_name="$2"
-  local needle="$3"
-
-  awk -v fn="func ${function_name}(" '
-    index($0, fn) == 1 { in_block = 1 }
-    in_block {
-      line = $0
-      if (in_comment) {
-        if (sub(/^.*\*\//, "", line)) {
-          in_comment = 0
-        } else {
-          line = ""
-        }
-      }
-      gsub(/\/\*[^*]*\*\//, "", line)
-      if (sub(/\/\*.*$/, "", line)) {
-        in_comment = 1
-      }
-      sub(/\/\/.*$/, "", line)
-      print line
-    }
-    in_block && $0 == "}" { exit }
-  ' "${file_path}" | grep -Fq -- "${needle}"
-}
-
 script_supports_command_flag() {
   local script_help=""
 
@@ -2969,11 +2927,12 @@ fi
 
 # validate_publish_base_name migrated to Go (publishpr.ValidateBaseName);
 # assert the Go owner still rejects base names that fail the trusted git
-# check-ref-format hook (the call itself, not just the signature).
-if ! go_function_block_contains_fixed "${ROOT_DIR}/internal/publishpr/publish_pr_main.go" "ValidateBaseName" '!checkRefFormat(base)'; then
-  echo "Expected publishpr.ValidateBaseName to validate the publish-pr --base branch name through checkRefFormat" >&2
-  exit 1
-fi
+# check-ref-format hook (the call itself, not just the signature).  Migrated to
+# Go (D3): internal/workcellhardening behind the workcell-citools
+# workcell-publish-base-refcheck subcommand preserves the exact exit code and
+# stderr message of the former inline go_function_block_contains_fixed probe.
+# `|| exit 1` matches the former inline block's `exit 1` on a violated invariant.
+go_verify_citools workcell-publish-base-refcheck "${ROOT_DIR}" || exit 1
 
 go_verify_citools workcell-publish-pr-shadow "${ROOT_DIR}" || exit 1
 
@@ -5521,14 +5480,14 @@ if go_verify_hostutil helper validate-container-security-options '["no-new-privi
   echo "Expected helper validate-container-security-options to reject seccomp=unconfined" >&2
   exit 1
 fi
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "validate_runtime_security_posture" "go_hostutil helper validate-security-options"; then
-  echo "Expected validate_runtime_security_posture to validate daemon SecurityOptions through the helper subcommand" >&2
-  exit 1
-fi
-if ! function_block_contains_fixed "${ROOT_DIR}/scripts/workcell" "validate_runtime_security_posture" "go_hostutil helper validate-compat-security-options"; then
-  echo "Expected validate_runtime_security_posture to validate Docker Desktop compat daemon SecurityOptions through the compat helper subcommand" >&2
-  exit 1
-fi
+# Assert validate_runtime_security_posture validates daemon SecurityOptions and
+# Docker Desktop compat SecurityOptions through the go_hostutil helper
+# subcommands.  Migrated to Go (D3): internal/workcellhardening behind the
+# workcell-citools workcell-runtime-security-posture subcommand preserves the
+# exact exit codes and stderr messages of the former inline
+# function_block_contains_fixed pair (two fixed-string function-body probes).
+# `|| exit 1` matches the former inline block's `exit 1` on a violated invariant.
+go_verify_citools workcell-runtime-security-posture "${ROOT_DIR}" || exit 1
 
 if ! run_workcell_verify \
   --agent codex \
@@ -7032,18 +6991,14 @@ EOF
       echo "Expected package-mutation failure propagation verification run to succeed" >&2
       exit 1
     fi
-    for required in \
-      'slow_apt_helper=/state/tmp/workcell-slow-apt-helper.sh' \
-      '/bin/bash /usr/local/libexec/workcell/apt-broker.sh' \
-      'sudo -n /usr/local/libexec/workcell/apt-helper.sh apt-get update' \
-      'slow-apt-helper-ok' \
-      'expected sudo-wrapper to wait for a slow apt broker request by default' \
-      'expected default apt broker waits to avoid timing out slow requests'; do
-      if ! grep -Fq -- "${required}" "${ROOT_DIR}/scripts/container-smoke.sh"; then
-        echo "Expected scripts/container-smoke.sh to keep the Linux runtime apt-broker slow-wait probe (${required})" >&2
-        exit 1
-      fi
-    done
+    # Assert scripts/container-smoke.sh keeps the Linux runtime apt-broker
+    # slow-wait probe strings.  Migrated to Go (D3): internal/workcellhardening
+    # behind the workcell-citools workcell-smoke-apt-broker-probe subcommand
+    # preserves the exact exit codes and stderr messages of the former inline
+    # `for required in ...; do grep -Fq -- "${required}" ...; done` loop (six
+    # fixed-string presence probes).  `|| exit 1` matches the former loop's
+    # `exit 1` on a violated invariant.
+    go_verify_citools workcell-smoke-apt-broker-probe "${ROOT_DIR}" || exit 1
     ACK_BREAKGLASS_TODAY_UTC="$(date -u +%Y-%m-%d)"
     if ! run_workcell_verify \
       --agent codex \
@@ -7968,18 +7923,21 @@ rm -f "${GEMINI_AUTH_SELECTION_STDOUT}" "${GEMINI_AUTH_SELECTION_STDERR}"
 
 go_verify_citools workcell-home-seed-provider-wrapper "${ROOT_DIR}" || exit 1
 go_verify_citools workcell-copilot-token-handoff "${ROOT_DIR}" || exit 1
-if ! grep -Fq 'copilotStandaloneTokenHandoffName' "${ROOT_DIR}/internal/host/hoststate/hoststate.go" ||
-  ! grep -Fq 'copilotTokenHandoffBundleName' "${ROOT_DIR}/internal/host/hoststate/hoststate.go" ||
-  ! grep -Fq 'removeCopilotTokenHandoffArtifacts' "${ROOT_DIR}/internal/host/hoststate/hoststate.go"; then
-  echo "Expected stale Copilot token handoff directories to be covered by host cleanup" >&2
-  exit 1
-fi
+# Assert stale Copilot token handoff directories are covered by host cleanup in
+# internal/host/hoststate/hoststate.go.  Migrated to Go (D3):
+# internal/workcellhardening behind the workcell-citools
+# workcell-copilot-token-handoff-cleanup subcommand preserves the exact exit
+# code and stderr message of the former inline three-probe `grep -Fq` guard.
+# `|| exit 1` matches the former inline block's `exit 1` on a violated invariant.
+go_verify_citools workcell-copilot-token-handoff-cleanup "${ROOT_DIR}" || exit 1
 go_verify_citools workcell-copilot-docker-run "${ROOT_DIR}" || exit 1
 go_verify_citools workcell-provider-launcher-authority "${ROOT_DIR}" || exit 1
-if ! grep -Fq "rm -f -- \"\${token_file}\"" "${ROOT_DIR}/runtime/container/provider-wrapper.sh"; then
-  echo "Expected provider wrapper to unlink the runtime Copilot token handoff file before managed exec" >&2
-  exit 1
-fi
+# Assert the provider wrapper unlinks the runtime Copilot token handoff file
+# before managed exec.  Migrated to Go (D3): internal/workcellhardening behind
+# the workcell-citools workcell-provider-token-unlink subcommand preserves the
+# exact exit code and stderr message of the former inline `grep -Fq` probe.
+# `|| exit 1` matches the former inline block's `exit 1` on a violated invariant.
+go_verify_citools workcell-provider-token-unlink "${ROOT_DIR}" || exit 1
 go_verify_citools workcell-copilot-policy-wrapper "${ROOT_DIR}" || exit 1
 go_verify_citools workcell-copilot-unsafe-flags "${ROOT_DIR}" || exit 1
 go_verify_citools workcell-copilot-release-verify "${ROOT_DIR}" || exit 1
@@ -8058,15 +8016,14 @@ if ! jq -e '[.hooks.PreToolUse[]?.hooks[0].command? // empty] | any(type == "str
   exit 1
 fi
 
-for scenario_script_basename in \
-  "run-scenario-tests.sh" \
-  "verify-scenario-coverage.sh" \
-  "verify-control-plane-parity.sh"; do
-  if ! grep -Fq -- "${scenario_script_basename}" "${ROOT_DIR}/scripts/validate-repo.sh"; then
-    echo "validate-repo.sh must reference ${scenario_script_basename}" >&2
-    exit 1
-  fi
-done
+# Assert scripts/validate-repo.sh references the scenario-test / coverage /
+# control-plane-parity scripts.  Migrated to Go (D3): internal/workcellhardening
+# behind the workcell-citools workcell-validate-repo-scenario-refs subcommand
+# preserves the exact exit codes and stderr messages of the former inline
+# `for scenario_script_basename in ...; do grep -Fq -- "${basename}" ...; done`
+# loop (three fixed-string presence probes).  `|| exit 1` matches the former
+# loop's `exit 1` on a violated invariant.
+go_verify_citools workcell-validate-repo-scenario-refs "${ROOT_DIR}" || exit 1
 
 # Concrete control-plane lockstep invariant: every policy/ file must be
 # mentioned in a user-facing doc surface so additions stay operator-visible.


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 27 of N (final simple sweep).** Follows #398-#423. Migrates the remaining small simple-check clusters, cleans up now-orphaned shell helpers, and leaves the genuinely-complex tail for follow-ups.

## What
**6 new subcommands / 16 checks:**
- `workcell-publish-base-refcheck` (1 goblock, `publish_pr_main.go`)
- `workcell-runtime-security-posture` (2 fnblock, `scripts/workcell`)
- `workcell-smoke-apt-broker-probe` (6 present, `container-smoke.sh`)
- `workcell-copilot-token-handoff-cleanup` (3 present, `hoststate.go`) + `workcell-provider-token-unlink` (1, `provider-wrapper.sh`) — cluster split around an in-place `go_verify_citools` call (ordering rule)
- `workcell-validate-repo-scenario-refs` (3 present, `validate-repo.sh`)

**Cleanup:** removed the now-orphaned `function_block_contains_fixed` and `go_function_block_contains_fixed` shell helper definitions (their last callers were migrated; verified zero remaining non-comment invocations). `function_block_contains_regex` retained — still used by the deferred `clear_rules` check.

## Deferred
- **cluster `clear_rules`** (negated `function_block_contains_regex` with genuine regex `^[[:space:]]*clear_rules$`) needs a new `kindFunctionBlockRegexAbsent` — left inline, next increment.

## Parity / validation
Each of the 6 subcommands on real repo → exit 0; per-subcommand crafted violation → exit 1 byte-identical first-failure message; real-repo assertion + count guard each. `go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d`, `bash -n` — all green. 4 files / 806 lines. No new kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)