### PR TITLE
^R D3: migrate static jq -e adapter-settings invariants to Go (kindJSONExprEval, 4 checks)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -131,6 +131,9 @@ func subcommands() []subcommand {
 		{"workcell-validate-repo-scenario-refs", "ROOT_DIR", 1, 1, cmdWorkcellValidateRepoScenarioRefs},
 		{"workcell-precommit-hook-exec", "ROOT_DIR", 1, 1, cmdWorkcellPrecommitHookExec},
 		{"workcell-docs-examples-dir", "ROOT_DIR", 1, 1, cmdWorkcellDocsExamplesDir},
+		{"workcell-claude-mcp-project-servers", "SETTINGS_PATH", 1, 1, cmdWorkcellClaudeMcpProjectServers},
+		{"workcell-claude-managed-bypass", "ROOT_DIR", 1, 1, cmdWorkcellClaudeManagedBypass},
+		{"workcell-gemini-settings-guards", "ROOT_DIR", 1, 1, cmdWorkcellGeminiSettingsGuards},
 	}
 }
 
@@ -837,4 +840,31 @@ func cmdWorkcellPrecommitHookExec(args []string) error {
 // original stderr message when the invariant is violated.
 func cmdWorkcellDocsExamplesDir(args []string) error {
 	return workcellhardening.CheckDocsExamplesDir(args[0])
+}
+
+// cmdWorkcellClaudeMcpProjectServers runs the single `jq -e`
+// project-MCP-servers check migrated out of the scripts/verify-invariants.sh
+// settings_path loop; unlike the other workcell-* subcommands it takes the
+// settings FILE path (the loop calls it once per claude settings file, in
+// place), and it fails (exit 1 via die()) with the shell's original per-file
+// stderr message (the file's basename plus the fixed suffix) when the invariant
+// is violated.
+func cmdWorkcellClaudeMcpProjectServers(args []string) error {
+	return workcellhardening.CheckClaudeMcpProjectServers(args[0])
+}
+
+// cmdWorkcellClaudeManagedBypass runs the single Claude managed-settings
+// bypass-permissions `jq -e` check migrated out of scripts/verify-invariants.sh;
+// it fails (exit 1 via die()) with the shell's original stderr message when the
+// invariant is violated.
+func cmdWorkcellClaudeManagedBypass(args []string) error {
+	return workcellhardening.CheckClaudeManagedBypass(args[0])
+}
+
+// cmdWorkcellGeminiSettingsGuards runs the two Gemini adapter-settings `jq -e`
+// checks (folder-trust disabled, interactive-shell disabled) migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the shell's
+// original stderr message for the first violated invariant.
+func cmdWorkcellGeminiSettingsGuards(args []string) error {
+	return workcellhardening.CheckGeminiSettingsGuards(args[0])
 }

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -53,9 +53,11 @@
 package workcellhardening
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"syscall"
@@ -367,6 +369,25 @@ const (
 	// mirrors Bash `-x` via syscall.Access(path, X_OK) — the same access(2)
 	// primitive Bash uses — rather than reading content or inspecting mode bits.
 	kindExecutable
+	// kindJSONExprEval requires the jq comparison expression
+	// `<jsonPath> == <jsonExpectedRaw>` to evaluate TRUE against the target file
+	// parsed as JSON, mirroring a NEGATED `jq -e` guard
+	// (`if ! jq -e '<path> == <literal>' FILE; then ... exit 1`).  jq -e exits 0
+	// when its last output is neither false nor null and non-zero otherwise, and
+	// for a `==` expression the sole output is always the boolean true/false, so
+	// the invariant holds iff the comparison is true.  Equality is jq's
+	// TYPE-AWARE `==`: jsonExpectedRaw is parsed as its own JSON literal (a string
+	// `"allow"`, a boolean `false`/`true`, or a number) and compared to the leaf
+	// at jsonPath by both JSON type and value, so `.x == false` holds only for the
+	// JSON boolean false — never the string "false".  A leaf that is missing or an
+	// explicit null renders as JSON null (jq indexing an absent/null key yields
+	// null, no error), which never equals a scalar literal → violation.  A file
+	// that is not valid JSON, or a path that indexes a non-object scalar/array
+	// with a string key, mirrors jq's error exit (non-zero) under the `if !`
+	// guard → violation.  Unlike the string-rendering kinds this parses the file
+	// as structured JSON (encoding/json) and navigates the dotted object path via
+	// navigateJSONPath rather than matching text.
+	kindJSONExprEval
 )
 
 // check is one hardening invariant: how to match, what to match, which
@@ -402,6 +423,16 @@ type check struct {
 	// filesystem kinds never read the path as content, so leaving targetFile
 	// empty for them does not trigger a launcherRelPath read.
 	targetPath string
+	// jsonPath is the dotted JSON object path a kindJSONExprEval check navigates
+	// (e.g. ".security.folderTrust.enabled"), mirroring the left-hand side of the
+	// migrated `jq -e '<path> == <literal>'` expression.  It is used only by
+	// kindJSONExprEval (every other kind matches text).
+	jsonPath string
+	// jsonExpectedRaw is the right-hand JSON literal of a kindJSONExprEval check,
+	// verbatim as it appeared in the jq expression (`"allow"`, `false`, `true`, or
+	// a number).  holds parses it as its own JSON value so the comparison is
+	// jq-typed; it is used only by kindJSONExprEval.
+	jsonExpectedRaw string
 	// messageIncludesTargetPath, when true, appends the absolute target path
 	// (rootDir + "/" + targetPath) to message when evaluate builds the
 	// violation error, mirroring a shell message that interpolated the full
@@ -4086,6 +4117,106 @@ func CheckDocsExamplesDir(rootDir string) error {
 	return evaluate(rootDir, docsExamplesDirChecks)
 }
 
+// claudeManagedSettingsRelPath is the repo-relative path to the Claude adapter
+// managed-settings file.  The claude-managed-bypass check reads it for its
+// bypass-permissions invariant, mirroring the shell `jq -e` probe that ran
+// against ${ROOT_DIR}/adapters/claude/managed-settings.json.
+const claudeManagedSettingsRelPath = "adapters/claude/managed-settings.json"
+
+// geminiSettingsRelPath is the repo-relative path to the Gemini adapter
+// settings file.  The gemini-settings-guards block reads it for its
+// folder-trust and interactive-shell invariants, mirroring the shell `jq -e`
+// probes that ran against ${ROOT_DIR}/adapters/gemini/.gemini/settings.json.
+const geminiSettingsRelPath = "adapters/gemini/.gemini/settings.json"
+
+// CheckClaudeMcpProjectServers runs the single `jq -e` project-MCP-servers
+// invariant migrated out of the scripts/verify-invariants.sh settings_path loop
+// (the `.enableAllProjectMcpServers == false` guard).  Unlike the other
+// migrated groups this takes the settings FILE path directly (the shell iterated
+// the loop over ${ROOT_DIR}/adapters/claude/.claude/settings.json and
+// ${ROOT_DIR}/adapters/claude/managed-settings.json, calling this once per file
+// in place), so the caller passes each path and the per-file `$(basename …)`
+// message is preserved by prefixing filepath.Base of the given path.  It returns
+// nil when the field is the JSON boolean false (the shell's exit 0), or an error
+// whose message equals the shell's stderr for that file (the shell's exit 1),
+// including when the file is missing or not valid JSON (jq's non-zero exit under
+// the `if !` guard).
+func CheckClaudeMcpProjectServers(settingsPath string) error {
+	text := ""
+	if content, err := os.ReadFile(settingsPath); err == nil {
+		text = string(content)
+	}
+	c := check{
+		kind:            kindJSONExprEval,
+		jsonPath:        ".enableAllProjectMcpServers",
+		jsonExpectedRaw: "false",
+	}
+	if !c.holds(text, "") {
+		return errors.New(filepath.Base(settingsPath) + " settings must disable auto-enabled project MCP servers")
+	}
+	return nil
+}
+
+// claudeManagedBypassChecks holds the single Claude managed-settings
+// bypass-permissions invariant migrated out of scripts/verify-invariants.sh (the
+// `if ! jq -e '.disableBypassPermissionsMode == "allow"'` guard).  It is a
+// kindJSONExprEval check whose RHS literal is the JSON string "allow".
+var claudeManagedBypassChecks = []check{
+	{
+		kind:            kindJSONExprEval,
+		targetFile:      claudeManagedSettingsRelPath,
+		jsonPath:        ".disableBypassPermissionsMode",
+		jsonExpectedRaw: `"allow"`,
+		message:         "Claude managed settings must allow bypass-permissions mode under the external Workcell boundary",
+	},
+}
+
+// CheckClaudeManagedBypass runs the single Claude managed-settings
+// bypass-permissions invariant against the repo rooted at rootDir.  It returns
+// nil when .disableBypassPermissionsMode is the JSON string "allow" (the shell's
+// exit 0), or an error whose message equals the shell's stderr (the shell's exit
+// 1).
+func CheckClaudeManagedBypass(rootDir string) error {
+	return evaluate(rootDir, claudeManagedBypassChecks)
+}
+
+// geminiSettingsGuardChecks holds the two contiguous Gemini adapter-settings
+// invariants migrated out of scripts/verify-invariants.sh (the
+// `.security.folderTrust.enabled == false` and
+// `.tools.shell.enableInteractiveShell == false` `jq -e` guards), in the shell's
+// original order.  Both are kindJSONExprEval checks whose RHS literal is the JSON
+// boolean false, so each holds only when the field is boolean false — never the
+// string "false".  The deferred Gemini guards that surround them in the shell
+// (`.tools.allowed == []`, `.mcp.allowed == []`, the `.security.auth.selectedType`
+// truthiness probe, and the `.advanced.excludedEnvVars | type == "array"` pipe)
+// remain inline in bash, so this group is wired only across the two contiguous
+// migratable checks.
+var geminiSettingsGuardChecks = []check{
+	{
+		kind:            kindJSONExprEval,
+		targetFile:      geminiSettingsRelPath,
+		jsonPath:        ".security.folderTrust.enabled",
+		jsonExpectedRaw: "false",
+		message:         "Gemini adapter must disable Gemini folder trust inside the managed runtime",
+	},
+	{
+		kind:            kindJSONExprEval,
+		targetFile:      geminiSettingsRelPath,
+		jsonPath:        ".tools.shell.enableInteractiveShell",
+		jsonExpectedRaw: "false",
+		message:         "Gemini adapter must disable interactive shell mode",
+	},
+}
+
+// CheckGeminiSettingsGuards runs the two Gemini adapter-settings invariants
+// against the repo rooted at rootDir, in the shell's original order.  It returns
+// nil when both fields are the JSON boolean false (the shell's exit 0), or an
+// error whose message equals the shell's stderr for the first violated invariant
+// (the shell's exit 1).
+func CheckGeminiSettingsGuards(rootDir string) error {
+	return evaluate(rootDir, geminiSettingsGuardChecks)
+}
+
 // violationMessage returns the stderr string the shell emitted for a violated
 // check.  For most checks this is the static message; filesystem checks that
 // interpolated the absolute ${ROOT_DIR}/<path> into their shell message set
@@ -4161,9 +4292,70 @@ func (c check) holds(text, rootDir string) bool {
 		return !regexMatchesAnyLine(c.pattern, text)
 	case kindRegexPresent:
 		return regexMatchesAnyLine(c.pattern, text)
+	case kindJSONExprEval:
+		// Mirror `jq -e '<jsonPath> == <jsonExpectedRaw>' FILE`: parse the file as
+		// JSON, navigate the dotted object path, and compare the leaf to the RHS
+		// literal with jq's type-aware equality.  Any jq-error condition (invalid
+		// JSON, or indexing a non-object scalar/array) maps to a non-zero jq exit
+		// under the `if !` guard, i.e. the invariant does not hold.
+		var root interface{}
+		if err := json.Unmarshal([]byte(text), &root); err != nil {
+			return false
+		}
+		leaf, ok := navigateJSONPath(root, c.jsonPath)
+		if !ok {
+			return false
+		}
+		var expected interface{}
+		if err := json.Unmarshal([]byte(c.jsonExpectedRaw), &expected); err != nil {
+			return false
+		}
+		// Both leaf and expected come from encoding/json, so numbers are float64,
+		// strings are string, booleans are bool, and null is nil; reflect.DeepEqual
+		// then reproduces jq's typed `==` (a string never equals a boolean, and
+		// 1 == 1.0 because both decode to float64).
+		return reflect.DeepEqual(leaf, expected)
 	default:
 		return false
 	}
+}
+
+// navigateJSONPath walks the dotted object path (e.g. ".a.b.c") from root,
+// mirroring jq's traversal for the object-path subset used by the migrated
+// `jq -e` checks.  It returns (leaf, true) for a resolved value — including nil
+// for a missing key or an explicit null, because jq indexes an absent-or-null
+// value as null rather than erroring — and (nil, false) only when a segment
+// indexes a non-object scalar or array with a string key, which jq treats as an
+// error (non-zero exit).  A leading "." is stripped and "." (or "") returns root
+// unchanged.
+func navigateJSONPath(root interface{}, path string) (interface{}, bool) {
+	current := root
+	for _, key := range splitJSONPath(path) {
+		switch v := current.(type) {
+		case map[string]interface{}:
+			// An absent key yields the zero value nil, i.e. jq null.
+			current = v[key]
+		case nil:
+			// jq: `null | .key` → null, no error.
+			current = nil
+		default:
+			// A string, number, boolean, or array indexed with a string key is a
+			// jq error → non-zero exit → violation.
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+// splitJSONPath splits a dotted jq object path into its keys, dropping the
+// leading dot.  "." and "" yield no keys (the whole document).  It supports only
+// the simple identifier form (`.a.b.c`) that the migrated checks use.
+func splitJSONPath(path string) []string {
+	trimmed := strings.TrimPrefix(path, ".")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, ".")
 }
 
 // regexMatchesAnyLine reports whether pattern matches any single line of text,

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -5,6 +5,7 @@ package workcellhardening
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -6206,5 +6207,265 @@ func TestCheckDocsExamplesDirRealRepo(t *testing.T) {
 	}
 	if err := CheckDocsExamplesDir(repoRoot); err != nil {
 		t.Fatalf("CheckDocsExamplesDir(real repo) = %v, want nil", err)
+	}
+}
+
+// --- kindJSONExprEval + jq -e adapter-settings migration (D3) ---
+
+// jsonExprCheck builds a bare kindJSONExprEval check for the holds() unit tests.
+func jsonExprCheck(path, expectedRaw string) check {
+	return check{kind: kindJSONExprEval, jsonPath: path, jsonExpectedRaw: expectedRaw}
+}
+
+// TestJSONExprEvalHolds exercises kindJSONExprEval's jq-typed `==` semantics
+// directly: string equality, boolean equality that must reject the string
+// "false", numeric equality, nested paths, missing-key/explicit-null rendering
+// as jq null (never equal to a scalar), and invalid-JSON / non-object-index
+// error cases that mirror jq's non-zero exit.
+func TestJSONExprEvalHolds(t *testing.T) {
+	const doc = `{
+		"str": "allow",
+		"boolFalse": false,
+		"boolTrue": true,
+		"num": 5,
+		"strFalse": "false",
+		"nullField": null,
+		"nested": {"deep": {"enabled": false}},
+		"scalar": "x"
+	}`
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+		want     bool
+	}{
+		{"string match", ".str", `"allow"`, true},
+		{"string mismatch", ".str", `"deny"`, false},
+		{"bool false match", ".boolFalse", "false", true},
+		{"bool false does not match string false", ".strFalse", "false", false},
+		{"string false vs string false matches", ".strFalse", `"false"`, true},
+		{"bool true match", ".boolTrue", "true", true},
+		{"bool true mismatch against false", ".boolTrue", "false", false},
+		{"number match", ".num", "5", true},
+		{"number match float form", ".num", "5.0", true},
+		{"number mismatch", ".num", "6", false},
+		{"nested path match", ".nested.deep.enabled", "false", true},
+		{"missing key renders null not equal to false", ".missing", "false", false},
+		{"missing key not equal to null literal string", ".missing", `"null"`, false},
+		{"explicit null not equal to false", ".nullField", "false", false},
+		{"missing nested under missing parent", ".missing.child", "false", false},
+		{"indexing a scalar with a key is a jq error", ".scalar.child", `"x"`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := jsonExprCheck(tt.path, tt.expected).holds(doc, "")
+			if got != tt.want {
+				t.Fatalf("holds(%s == %s) = %v, want %v", tt.path, tt.expected, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestJSONExprEvalInvalidJSON asserts an unparseable target file is a violation,
+// mirroring jq's error exit under the `if !` guard.
+func TestJSONExprEvalInvalidJSON(t *testing.T) {
+	if jsonExprCheck(".str", `"allow"`).holds("{not valid json", "") {
+		t.Fatal("holds() on invalid JSON = true, want false (jq error → violation)")
+	}
+	if jsonExprCheck(".str", `"allow"`).holds("", "") {
+		t.Fatal("holds() on empty file = true, want false (jq error → violation)")
+	}
+}
+
+// TestJSONExprEvalDifferentialJQ pins kindJSONExprEval's holds() to the real
+// `jq -e 'EXPR' FILE` exit code across a matrix of documents and expressions, so
+// any drift from jq's typed `==` fails here.  Skipped if jq is unavailable.
+func TestJSONExprEvalDifferentialJQ(t *testing.T) {
+	jqPath, err := exec.LookPath("jq")
+	if err != nil {
+		t.Skip("jq not installed; skipping differential parity test")
+	}
+	docs := []string{
+		`{"x":"allow"}`,
+		`{"x":false}`,
+		`{"x":"false"}`,
+		`{"x":true}`,
+		`{"x":5}`,
+		`{"x":null}`,
+		`{"y":1}`,
+		`{"a":{"b":false}}`,
+	}
+	exprs := []struct{ path, expectedRaw string }{
+		{".x", `"allow"`},
+		{".x", "false"},
+		{".x", "true"},
+		{".x", "5"},
+		{".a.b", "false"},
+		{".missing", "false"},
+	}
+	for _, doc := range docs {
+		for _, e := range exprs {
+			name := doc + " | " + e.path + "==" + e.expectedRaw
+			t.Run(name, func(t *testing.T) {
+				f := filepath.Join(t.TempDir(), "d.json")
+				if err := os.WriteFile(f, []byte(doc), 0o644); err != nil {
+					t.Fatalf("write fixture: %v", err)
+				}
+				cmd := exec.Command(jqPath, "-e", e.path+" == "+e.expectedRaw, f)
+				runErr := cmd.Run()
+				jqTruthy := runErr == nil // jq -e exit 0 ⇔ expression true
+				got := jsonExprCheck(e.path, e.expectedRaw).holds(doc, "")
+				if got != jqTruthy {
+					t.Fatalf("holds()=%v but jq -e truthy=%v for %s", got, jqTruthy, name)
+				}
+			})
+		}
+	}
+}
+
+// writeAdapterSettingsRepo writes a rootDir seeded with the two adapter settings
+// files the migrated jq -e groups read, from the provided JSON bodies.
+func writeAdapterSettingsRepo(t *testing.T, claudeManaged, gemini string) string {
+	t.Helper()
+	root := t.TempDir()
+	files := map[string]string{
+		claudeManagedSettingsRelPath: claudeManaged,
+		geminiSettingsRelPath:        gemini,
+	}
+	for rel, body := range files {
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	return root
+}
+
+const happyClaudeManaged = `{"disableBypassPermissionsMode":"allow"}`
+const happyGeminiSettings = `{"security":{"folderTrust":{"enabled":false}},"tools":{"shell":{"enableInteractiveShell":false}}}`
+
+func TestCheckClaudeManagedBypass(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{"happy path", happyClaudeManaged, ""},
+		{"wrong string value", `{"disableBypassPermissionsMode":"deny"}`, "Claude managed settings must allow bypass-permissions mode under the external Workcell boundary"},
+		{"missing field", `{}`, "Claude managed settings must allow bypass-permissions mode under the external Workcell boundary"},
+		{"boolean not string", `{"disableBypassPermissionsMode":true}`, "Claude managed settings must allow bypass-permissions mode under the external Workcell boundary"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := writeAdapterSettingsRepo(t, tt.body, happyGeminiSettings)
+			assertCheckErr(t, "CheckClaudeManagedBypass", CheckClaudeManagedBypass(root), tt.wantErr)
+		})
+	}
+}
+
+func TestCheckGeminiSettingsGuards(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{"happy path", happyGeminiSettings, ""},
+		{"folder trust enabled", `{"security":{"folderTrust":{"enabled":true}},"tools":{"shell":{"enableInteractiveShell":false}}}`, "Gemini adapter must disable Gemini folder trust inside the managed runtime"},
+		{"folder trust string false rejected", `{"security":{"folderTrust":{"enabled":"false"}},"tools":{"shell":{"enableInteractiveShell":false}}}`, "Gemini adapter must disable Gemini folder trust inside the managed runtime"},
+		{"folder trust missing", `{"tools":{"shell":{"enableInteractiveShell":false}}}`, "Gemini adapter must disable Gemini folder trust inside the managed runtime"},
+		{"interactive shell enabled", `{"security":{"folderTrust":{"enabled":false}},"tools":{"shell":{"enableInteractiveShell":true}}}`, "Gemini adapter must disable interactive shell mode"},
+		{"interactive shell missing", `{"security":{"folderTrust":{"enabled":false}},"tools":{"shell":{}}}`, "Gemini adapter must disable interactive shell mode"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := writeAdapterSettingsRepo(t, happyClaudeManaged, tt.body)
+			assertCheckErr(t, "CheckGeminiSettingsGuards", CheckGeminiSettingsGuards(root), tt.wantErr)
+		})
+	}
+}
+
+func TestCheckClaudeMcpProjectServers(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		fileName string
+		wantErr  string
+	}{
+		{"happy managed", `{"enableAllProjectMcpServers":false}`, "managed-settings.json", ""},
+		{"happy user settings", `{"enableAllProjectMcpServers":false}`, "settings.json", ""},
+		{"true is a violation", `{"enableAllProjectMcpServers":true}`, "settings.json", "settings.json settings must disable auto-enabled project MCP servers"},
+		{"missing field", `{}`, "managed-settings.json", "managed-settings.json settings must disable auto-enabled project MCP servers"},
+		{"basename preserved for nested path", `{"enableAllProjectMcpServers":true}`, "managed-settings.json", "managed-settings.json settings must disable auto-enabled project MCP servers"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, tt.fileName)
+			if err := os.WriteFile(path, []byte(tt.body), 0o644); err != nil {
+				t.Fatalf("write %s: %v", path, err)
+			}
+			assertCheckErr(t, "CheckClaudeMcpProjectServers", CheckClaudeMcpProjectServers(path), tt.wantErr)
+		})
+	}
+}
+
+// TestCheckClaudeMcpProjectServersMissingFile asserts a missing file is a
+// violation with the basename-prefixed message (jq errors on a missing file →
+// non-zero exit → the `if !` guard fires).
+func TestCheckClaudeMcpProjectServersMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	assertCheckErr(t, "CheckClaudeMcpProjectServers", CheckClaudeMcpProjectServers(path),
+		"settings.json settings must disable auto-enabled project MCP servers")
+}
+
+// TestAdapterSettingsChecksCount guards the migrated check counts so an
+// accidental add/drop is caught.
+func TestAdapterSettingsChecksCount(t *testing.T) {
+	if got := len(claudeManagedBypassChecks); got != 1 {
+		t.Fatalf("claudeManagedBypassChecks has %d checks, want 1", got)
+	}
+	if got := len(geminiSettingsGuardChecks); got != 2 {
+		t.Fatalf("geminiSettingsGuardChecks has %d checks, want 2", got)
+	}
+}
+
+// TestAdapterSettingsChecksRealRepo asserts the real adapter settings files in
+// this repository satisfy all migrated jq -e invariants — the guard against a
+// mis-transcribed path, message, or RHS literal.
+func TestAdapterSettingsChecksRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, claudeManagedSettingsRelPath)); err != nil {
+		t.Skipf("real %s not found: %v", claudeManagedSettingsRelPath, err)
+	}
+	if err := CheckClaudeManagedBypass(repoRoot); err != nil {
+		t.Fatalf("CheckClaudeManagedBypass(real repo) = %v, want nil", err)
+	}
+	if err := CheckGeminiSettingsGuards(repoRoot); err != nil {
+		t.Fatalf("CheckGeminiSettingsGuards(real repo) = %v, want nil", err)
+	}
+	for _, rel := range []string{"adapters/claude/.claude/settings.json", claudeManagedSettingsRelPath} {
+		if err := CheckClaudeMcpProjectServers(filepath.Join(repoRoot, rel)); err != nil {
+			t.Fatalf("CheckClaudeMcpProjectServers(real %s) = %v, want nil", rel, err)
+		}
+	}
+}
+
+// assertCheckErr fails unless got matches the wantErr expectation ("" = nil).
+func assertCheckErr(t *testing.T, label string, got error, wantErr string) {
+	t.Helper()
+	if wantErr == "" {
+		if got != nil {
+			t.Fatalf("%s = %v, want nil", label, got)
+		}
+		return
+	}
+	if got == nil {
+		t.Fatalf("%s = nil, want error %q", label, wantErr)
+	}
+	if got.Error() != wantErr {
+		t.Fatalf("%s = %q, want %q", label, got.Error(), wantErr)
 	}
 }

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -7836,19 +7836,13 @@ fi
 for settings_path in \
   "${ROOT_DIR}/adapters/claude/.claude/settings.json" \
   "${ROOT_DIR}/adapters/claude/managed-settings.json"; do
-  if ! jq -e '.enableAllProjectMcpServers == false' "${settings_path}" >/dev/null; then
-    echo "$(basename "${settings_path}") settings must disable auto-enabled project MCP servers" >&2
-    exit 1
-  fi
+  go_verify_citools workcell-claude-mcp-project-servers "${settings_path}" || exit 1
   if ! jq -e '.hooks.PreToolUse[0].hooks[0].command == "/opt/workcell/adapters/claude/hooks/guard-bash.sh"' "${settings_path}" >/dev/null; then
     echo "$(basename "${settings_path}") settings must use the managed guard-bash.sh hook" >&2
     exit 1
   fi
 done
-if ! jq -e '.disableBypassPermissionsMode == "allow"' "${ROOT_DIR}/adapters/claude/managed-settings.json" >/dev/null; then
-  echo "Claude managed settings must allow bypass-permissions mode under the external Workcell boundary" >&2
-  exit 1
-fi
+go_verify_citools workcell-claude-managed-bypass "${ROOT_DIR}" || exit 1
 if ! jq -e '.tools.allowed == []' "${ROOT_DIR}/adapters/gemini/.gemini/settings.json" >/dev/null; then
   echo "Gemini adapter must not seed allowed tools" >&2
   exit 1
@@ -7861,14 +7855,7 @@ if jq -e '.security.auth.selectedType' "${ROOT_DIR}/adapters/gemini/.gemini/sett
   echo "Gemini adapter baseline must not hardcode a selected auth type" >&2
   exit 1
 fi
-if ! jq -e '.security.folderTrust.enabled == false' "${ROOT_DIR}/adapters/gemini/.gemini/settings.json" >/dev/null; then
-  echo "Gemini adapter must disable Gemini folder trust inside the managed runtime" >&2
-  exit 1
-fi
-if ! jq -e '.tools.shell.enableInteractiveShell == false' "${ROOT_DIR}/adapters/gemini/.gemini/settings.json" >/dev/null; then
-  echo "Gemini adapter must disable interactive shell mode" >&2
-  exit 1
-fi
+go_verify_citools workcell-gemini-settings-guards "${ROOT_DIR}" || exit 1
 if ! jq -e '.advanced.excludedEnvVars | type == "array"' "${ROOT_DIR}/adapters/gemini/.gemini/settings.json" >/dev/null; then
   echo "Gemini adapter must exclude sensitive environment variables" >&2
   exit 1


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — increment 29 of N.** Follows #398-#425. Adds `kindJSONExprEval` and migrates the static-file `jq -e` adapter-settings checks.

## Context (empirical re-scope)
The `jq -r '.a.b == "x"'` field-equals checks were investigated first and found to **all read runtime `mktemp -d` fixture dirs** (generated mid-script by `render_injection_bundle`) — architecturally un-migratable to the static-file evaluator, and a kind with zero consumers would be forbidden dead code. So this migrates the genuinely-static target: the `jq -e` adapter-settings guards.

## New kind `kindJSONExprEval`
Mirrors a negated `jq -e '<path> == <literal>' FILE` guard with jq's **type-aware `==`**: the RHS is parsed as JSON (`"allow"`→string, `false`→bool, number→float64) and compared by value. Fidelity: `.x == false` holds only for JSON boolean false (never string `"false"`); missing/null → violation; invalid JSON / non-object index → jq's error-exit → violation. Verified by an 8×6 **differential test that shells out to real `jq -e`** and asserts `holds()` matches jq's exit code.

## Migrated (4 checks / 3 subcommands, static repo JSON)
- `workcell-claude-mcp-project-servers` — `.enableAllProjectMcpServers == false` (per-file inside the existing `settings_path` loop; deferred `[0]` hook check stays as the loop's 2nd check)
- `workcell-claude-managed-bypass` — `.disableBypassPermissionsMode == "allow"` (managed-settings.json)
- `workcell-gemini-settings-guards` — `.security.folderTrust.enabled == false` + `.tools.shell.enableInteractiveShell == false`

Wired in place (7839/7845/7858) preserving exact order among the deferred jq-e checks (`== []`, `[0]`, truthiness, `| type`, and the 5 stdin-pipe codex checks all stay inline).

## Parity / validation
Real repo → each subcommand exit 0; crafted mutations → exit 1 byte-identical. Differential-vs-jq + semantics tests + per-subcommand real-repo assertions + count guards. `go build`/`vet`/`gofmt`, full `go test ./...`, `shellcheck -x`, `shfmt -d`, `bash -n` — all green. 4 files / 502 lines.

## Remaining (documented residual, planning)
`jq -e`: 11 (array/pipe/truthiness/stdin-pipe), `jq -r`: 26 (runtime mktemp fixtures), `awk`: 13 (toml/df helper functions) — genuinely non-static-invariant procedural bash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)