### PR TITLE
^d Fix orphaned docs/session-startup-benchmarks.md (docs CI green)

### DIFF
--- a/docs/syscall-shim-benchmarks.md
+++ b/docs/syscall-shim-benchmarks.md
@@ -4,7 +4,9 @@ The `workcell_exec_guard` LD_PRELOAD shim (`runtime/container/rust/src/lib.rs`)
 interposes the libc exec/spawn family and classifies every launch before
 forwarding it to the real entry point. This page records the added latency that
 classification costs on the **allow path** -- a launch the guard permits and
-forwards -- and the methodology and rerun steps behind those numbers.
+forwards -- and the methodology and rerun steps behind those numbers. Its
+sibling page, [session-startup-benchmarks.md](session-startup-benchmarks.md),
+records the **C2** session-start latency baselines.
 
 The numbers are produced by the optional `bench.yml` GitHub lane on Linux, not
 on the macOS development host: the shim reads `/proc` and interposes the


### PR DESCRIPTION
`docs/session-startup-benchmarks.md` (the C2 session-start latency baselines) is orphaned — no tracked markdown links to it — so `scripts/check-doc-links.sh` fails (`orphan doc: ... linked from no other tracked markdown file`). This is a **pre-existing** gap on `main` (the docs CI lane flags it independently of any recent change; verified failing on the prior main commit).

Fix: add the reciprocal sibling cross-link from `syscall-shim-benchmarks.md` (C5) — which `session-startup-benchmarks.md` already references as its sibling — so the C2 page is navigably reachable.

`scripts/check-doc-links.sh` → **OK (95 markdown files; relative links and docs/ orphans clean)**.

Docs-only: one navigable cross-link, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)