### PR TITLE
^r D3: backfill real-repo assertions for the early workcellhardening groups (tests only)

### DIFF
--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -287,6 +287,16 @@ func TestCheckConfigSafety(t *testing.T) {
 	}
 }
 
+func TestCheckConfigSafetyRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, launcherRelPath)); err != nil {
+		t.Skipf("real scripts/workcell not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckConfigSafety(repoRoot); err != nil {
+		t.Fatalf("CheckConfigSafety(real repo) = %v, want nil", err)
+	}
+}
+
 // runtimeHappyLauncher is a minimal scripts/workcell that satisfies all
 // ten runtime/gc invariants: the trusted Docker client seed, no
 // DOCKER_CONFIG pin to the real host home, the buildx_cmd invocation, a
@@ -465,6 +475,16 @@ func TestCheckRuntimeInvariants(t *testing.T) {
 	}
 }
 
+func TestCheckRuntimeInvariantsRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, launcherRelPath)); err != nil {
+		t.Skipf("real scripts/workcell not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckRuntimeInvariants(repoRoot); err != nil {
+		t.Fatalf("CheckRuntimeInvariants(real repo) = %v, want nil", err)
+	}
+}
+
 // managedProfileStagingHappyLauncher is a minimal scripts/workcell that
 // satisfies all three managed-profile staging/cleanup invariants: a
 // start_managed_profile body mounting all three staging cache roots (with
@@ -610,6 +630,16 @@ func TestCheckManagedProfileStaging(t *testing.T) {
 				t.Fatalf("CheckManagedProfileStaging() error = %q, want %q", err.Error(), tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestCheckManagedProfileStagingRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, launcherRelPath)); err != nil {
+		t.Skipf("real scripts/workcell not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckManagedProfileStaging(repoRoot); err != nil {
+		t.Fatalf("CheckManagedProfileStaging(real repo) = %v, want nil", err)
 	}
 }
 
@@ -816,6 +846,16 @@ func TestCheckBootstrapEgress(t *testing.T) {
 				t.Fatalf("CheckBootstrapEgress() error = %q, want %q", err.Error(), tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestCheckBootstrapEgressRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, launcherRelPath)); err != nil {
+		t.Skipf("real scripts/workcell not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckBootstrapEgress(repoRoot); err != nil {
+		t.Fatalf("CheckBootstrapEgress(real repo) = %v, want nil", err)
 	}
 }
 


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — test-coverage backfill.** Completes the follow-up the refreshed package doc (#427) flagged: giving every migrated group a real-repo assertion.

## What
Adds 4 `TestCheckXxxRealRepo` tests for the earliest groups that predated the pattern and had only synthetic fixtures:
- `TestCheckConfigSafetyRealRepo`
- `TestCheckRuntimeInvariantsRealRepo`
- `TestCheckManagedProfileStagingRealRepo`
- `TestCheckBootstrapEgripts…` → `TestCheckBootstrapEgressRealRepo`

Each follows the existing pattern (`repoRoot := filepath.Join("..","..")`, a `scripts/workcell` stat/skip guard, then assert the check returns nil against the real tree). The three jq-e adapter-settings groups (`CheckClaudeManagedBypass`, `CheckGeminiSettingsGuards`, `CheckClaudeMcpProjectServers`) were already covered by the combined `TestAdapterSettingsChecksRealRepo`, so no new tests were needed there.

**Coverage: all 38 `CheckXxx` functions now have a real-repo assertion** (35 individually-named + 1 combined covering 3), so a mistranscribed needle/path in any group is caught by CI.

## Scope
**Tests only** — `workcellhardening.go` and `main.go` unchanged; no behaviour change.

## Validation
`go build`/`vet`/`gofmt`, `go test -run RealRepo` (4 new PASS), full `go test ./...` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)