### PR TITLE
^R D3: migrate host-gate/trusted-Docker rg-loop invariants to Go (61 checks, 3 subcommands)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -134,6 +134,9 @@ func subcommands() []subcommand {
 		{"workcell-claude-mcp-project-servers", "SETTINGS_PATH", 1, 1, cmdWorkcellClaudeMcpProjectServers},
 		{"workcell-claude-managed-bypass", "ROOT_DIR", 1, 1, cmdWorkcellClaudeManagedBypass},
 		{"workcell-gemini-settings-guards", "ROOT_DIR", 1, 1, cmdWorkcellGeminiSettingsGuards},
+		{"workcell-hostgate-entrypoint-sanitize", "ROOT_DIR", 1, 1, cmdWorkcellHostGateEntrypointSanitize},
+		{"workcell-precommit-upstream-pin-gate", "ROOT_DIR", 1, 1, cmdWorkcellPrecommitUpstreamPinGate},
+		{"workcell-trusted-docker-client-rg", "ROOT_DIR", 1, 1, cmdWorkcellTrustedDockerClientRg},
 	}
 }
 
@@ -697,6 +700,32 @@ func cmdWorkcellValidatorWritableState(args []string) error {
 // first violated invariant.
 func cmdWorkcellHostutilEgressRg(args []string) error {
 	return workcellhardening.CheckHostutilEgressRg(args[0])
+}
+
+// cmdWorkcellHostGateEntrypointSanitize runs the forty-four host-gate entrypoint
+// checks (an absolute privileged Bash shebang and an entrypoint self-sanitize
+// probe for each of the twenty-two HOST_GATE_SCRIPTS) migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the shell's
+// original stderr message for the first violated invariant.
+func cmdWorkcellHostGateEntrypointSanitize(args []string) error {
+	return workcellhardening.CheckHostGateEntrypointSanitize(args[0])
+}
+
+// cmdWorkcellPrecommitUpstreamPinGate runs the single repo pre-commit hook
+// upstream-pin-gate check migrated out of scripts/verify-invariants.sh; it fails
+// (exit 1 via die()) with the shell's original stderr message when the hook does
+// not gate commits on pending pinned upstream updates.
+func cmdWorkcellPrecommitUpstreamPinGate(args []string) error {
+	return workcellhardening.CheckPrecommitUpstreamPinGate(args[0])
+}
+
+// cmdWorkcellTrustedDockerClientRg runs the sixteen trusted-Docker-client checks
+// (source-helper, seed-client-state, drop-caller-HOME, and buildx-trusted-path
+// probes across four release/build scripts) migrated out of
+// scripts/verify-invariants.sh; it fails (exit 1 via die()) with the shell's
+// original stderr message for the first violated invariant.
+func cmdWorkcellTrustedDockerClientRg(args []string) error {
+	return workcellhardening.CheckTrustedDockerClientRg(args[0])
 }
 
 // cmdWorkcellDockerfilePins runs the thirty dockerfile-pin checks

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -4271,6 +4271,195 @@ func CheckGeminiSettingsGuards(rootDir string) error {
 	return evaluate(rootDir, geminiSettingsGuardChecks)
 }
 
+// hostGateScriptRelPaths lists, in the HOST_GATE_SCRIPTS array's order, the
+// twenty-two host-gate scripts that must carry an absolute privileged Bash
+// shebang and self-sanitize their host entrypoint before running release or
+// boundary checks.  The shell array elements were "${ROOT_DIR}/<relpath>", so
+// each element rendered the ABSOLUTE path once ${ROOT_DIR} expanded; the
+// repo-relative form here is both the read target (targetFile) and the tail of
+// the reconstructed absolute message path.
+var hostGateScriptRelPaths = []string{
+	"scripts/build-and-test.sh",
+	"scripts/check-pinned-inputs.sh",
+	"scripts/check-public-contract.sh",
+	"scripts/container-smoke.sh",
+	"scripts/generate-build-input-manifest.sh",
+	"scripts/generate-control-plane-manifest.sh",
+	"scripts/generate-builder-environment-manifest.sh",
+	"scripts/generate-release-checksums.sh",
+	"scripts/publish-provider-bump-pr.sh",
+	"scripts/publish-upstream-refresh-pr.sh",
+	"scripts/update-upstream-pins.sh",
+	"scripts/update-provider-pins.sh",
+	"scripts/publish-github-release.sh",
+	"scripts/verify-build-input-manifest.sh",
+	"scripts/verify-control-plane-manifest.sh",
+	"scripts/verify-github-macos-release-test-runners.sh",
+	"scripts/verify-release-bundle.sh",
+	"scripts/verify-reproducible-build.sh",
+	"scripts/verify-upstream-claude-release.sh",
+	"scripts/verify-upstream-codex-release.sh",
+	"scripts/verify-upstream-copilot-release.sh",
+	"scripts/verify-upstream-gemini-release.sh",
+}
+
+// hostGateEntrypointSanitizeChecks builds the forty-four host-gate entrypoint
+// invariants for the repo rooted at rootDir, in the shell's original order.  The
+// migrated `for script in "${HOST_GATE_SCRIPTS[@]}"` loop body ran two ordered
+// checks per iteration, so for each script (in array order) this emits the
+// first-line shebang check followed by the entrypoint self-sanitize check,
+// preserving the loop's per-iteration first-violation order exactly.
+//
+//   - The shebang probe was `head -n 1 "${script}" | grep -q '^#!/bin/bash -p$'`,
+//     an anchored first-line regex → kindFirstLineRegex with the pattern verbatim
+//     (no active metacharacters besides the anchors).
+//   - The entrypoint probe was `rg -q 'WORKCELL_SANITIZED_ENTRYPOINT|trusted-entrypoint\.sh'`,
+//     a genuine `|` alternation (the `\.` matches a literal dot) → kindRegexPresent
+//     with the pattern verbatim, matched per line for rg parity.
+//
+// The shell echoes interpolated ${script}, whose value was the array element
+// "${ROOT_DIR}/<relpath>" — i.e. the ABSOLUTE path once ${ROOT_DIR} expands.  Each
+// message is therefore constructed as "Expected " + rootDir + "/" + relpath + " ...",
+// using literal string concatenation (not filepath.Join) to reproduce the shell's
+// byte-exact rendering.  The read target stays the repo-relative path via
+// targetFile, so evaluate reads the same file the message names.
+func hostGateEntrypointSanitizeChecks(rootDir string) []check {
+	cs := make([]check, 0, len(hostGateScriptRelPaths)*2)
+	for _, rel := range hostGateScriptRelPaths {
+		script := rootDir + "/" + rel
+		cs = append(cs,
+			check{
+				kind:       kindFirstLineRegex,
+				pattern:    `^#!/bin/bash -p$`,
+				message:    "Expected " + script + " to use an absolute privileged Bash shebang before self-sanitizing its host entrypoint",
+				targetFile: rel,
+			},
+			check{
+				kind:       kindRegexPresent,
+				pattern:    `WORKCELL_SANITIZED_ENTRYPOINT|trusted-entrypoint\.sh`,
+				message:    "Expected " + script + " to self-sanitize its host entrypoint before running release or boundary checks",
+				targetFile: rel,
+			},
+		)
+	}
+	return cs
+}
+
+// CheckHostGateEntrypointSanitize runs the forty-four host-gate entrypoint
+// invariants (an absolute privileged Bash shebang and an entrypoint
+// self-sanitize probe for each of the twenty-two HOST_GATE_SCRIPTS) against the
+// repo rooted at rootDir, in the shell's original order.  It returns nil when
+// every invariant holds (the shell's exit 0), or an error whose message equals
+// the shell's stderr for the first violated invariant (the shell's exit 1).
+func CheckHostGateEntrypointSanitize(rootDir string) error {
+	return evaluate(rootDir, hostGateEntrypointSanitizeChecks(rootDir))
+}
+
+// precommitUpstreamPinGateChecks holds the single repo pre-commit hook invariant
+// migrated out of scripts/verify-invariants.sh (the lone
+// `if ! rg -q 'scripts/update-upstream-pins\.sh" --check' "${REPO_PRECOMMIT_HOOK}"`
+// guard, where REPO_PRECOMMIT_HOOK="${ROOT_DIR}/.githooks/pre-commit").  The
+// shell message interpolated no path, so it is a static kindRegexPresent check
+// whose pattern's only metacharacter (`\.`) is an escaped literal dot; the
+// pattern is kept verbatim and matched per line for rg parity.
+var precommitUpstreamPinGateChecks = []check{
+	{
+		kind:       kindRegexPresent,
+		pattern:    `scripts/update-upstream-pins\.sh" --check`,
+		message:    "Expected repo pre-commit hook to gate commits on pending pinned upstream updates",
+		targetFile: ".githooks/pre-commit",
+	},
+}
+
+// CheckPrecommitUpstreamPinGate runs the single repo pre-commit hook
+// upstream-pin-gate invariant against the repo rooted at rootDir.  It returns nil
+// when the hook gates commits on pending pinned upstream updates (the shell's
+// exit 0), or an error whose message equals the shell's stderr (the shell's exit
+// 1).
+func CheckPrecommitUpstreamPinGate(rootDir string) error {
+	return evaluate(rootDir, precommitUpstreamPinGateChecks)
+}
+
+// trustedDockerClientScriptRelPaths lists, in the shell loops' order, the four
+// scripts that must source the trusted Docker client helper, seed a trusted
+// client state, drop the caller HOME across their sanitized entrypoint re-exec,
+// and invoke buildx through the trusted absolute plugin path.  The shell loop
+// elements were "${ROOT_DIR}/<relpath>", so each rendered the ABSOLUTE path once
+// ${ROOT_DIR} expanded.
+var trustedDockerClientScriptRelPaths = []string{
+	"scripts/container-smoke.sh",
+	"scripts/generate-builder-environment-manifest.sh",
+	"scripts/verify-release-bundle.sh",
+	"scripts/verify-reproducible-build.sh",
+}
+
+// trustedDockerClientRgChecks builds the sixteen trusted-Docker-client
+// invariants for the repo rooted at rootDir, in the shell's original order: the
+// first `for script` loop's three ordered `! rg -q` probes (source the helper,
+// seed trusted client state, drop caller HOME) for each script, followed by the
+// second `for script` loop's single `! rg -q 'buildx_cmd '` probe for each
+// script.  Splitting into two loops (rather than four probes per script)
+// reproduces the shell's first-violation ordering exactly.
+//
+// Every pattern is kept verbatim as a regex and matched per line for rg parity:
+// the source-helper probe escapes `\$ \{ \} \.` to match the literal
+// `$ { } .`, while the setup / HOME / buildx probes are metacharacter-free and
+// so reduce to fixed-string matching under regexMatchesAnyLine.
+//
+// The shell echoes interpolated ${script}, whose value was the loop element
+// "${ROOT_DIR}/<relpath>" — the ABSOLUTE path once ${ROOT_DIR} expands.  Each
+// message is therefore constructed as "Expected " + rootDir + "/" + relpath + " ...",
+// using literal string concatenation (not filepath.Join) to reproduce the
+// shell's byte-exact rendering.  The read target stays the repo-relative path via
+// targetFile, so evaluate reads the same file the message names.
+func trustedDockerClientRgChecks(rootDir string) []check {
+	cs := make([]check, 0, len(trustedDockerClientScriptRelPaths)*4)
+	for _, rel := range trustedDockerClientScriptRelPaths {
+		script := rootDir + "/" + rel
+		cs = append(cs,
+			check{
+				kind:       kindRegexPresent,
+				pattern:    `source "\$\{ROOT_DIR\}/scripts/lib/trusted-docker-client\.sh"`,
+				message:    "Expected " + script + " to source the trusted Docker client helper",
+				targetFile: rel,
+			},
+			check{
+				kind:       kindRegexPresent,
+				pattern:    `setup_workcell_trusted_docker_client`,
+				message:    "Expected " + script + " to seed a trusted Docker client state before using Docker",
+				targetFile: rel,
+			},
+			check{
+				kind:       kindRegexPresent,
+				pattern:    `HOME=/tmp`,
+				message:    "Expected " + script + " to stop preserving caller HOME across its sanitized entrypoint re-exec",
+				targetFile: rel,
+			},
+		)
+	}
+	for _, rel := range trustedDockerClientScriptRelPaths {
+		script := rootDir + "/" + rel
+		cs = append(cs, check{
+			kind:       kindRegexPresent,
+			pattern:    `buildx_cmd `,
+			message:    "Expected " + script + " to invoke buildx through the trusted absolute plugin path",
+			targetFile: rel,
+		})
+	}
+	return cs
+}
+
+// CheckTrustedDockerClientRg runs the sixteen trusted-Docker-client invariants
+// (source-helper, seed-client-state, drop-caller-HOME, and buildx-trusted-path
+// probes across container-smoke.sh, generate-builder-environment-manifest.sh,
+// verify-release-bundle.sh and verify-reproducible-build.sh) against the repo
+// rooted at rootDir, in the shell's original order.  It returns nil when every
+// invariant holds (the shell's exit 0), or an error whose message equals the
+// shell's stderr for the first violated invariant (the shell's exit 1).
+func CheckTrustedDockerClientRg(rootDir string) error {
+	return evaluate(rootDir, trustedDockerClientRgChecks(rootDir))
+}
+
 // violationMessage returns the stderr string the shell emitted for a violated
 // check.  For most checks this is the static message; filesystem checks that
 // interpolated the absolute ${ROOT_DIR}/<path> into their shell message set

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -6509,3 +6509,428 @@ func assertCheckErr(t *testing.T, label string, got error, wantErr string) {
 		t.Fatalf("%s = %q, want %q", label, got.Error(), wantErr)
 	}
 }
+
+// hostGateSanitizeHappyBody is a minimal host-gate script body that satisfies
+// both per-script invariants: an absolute privileged Bash shebang on line 1 and
+// the entrypoint self-sanitize sentinel on a later line.
+const hostGateSanitizeHappyBody = "#!/bin/bash -p\nWORKCELL_SANITIZED_ENTRYPOINT=1\n"
+
+// writeHostGateEntrypointRepo writes every HOST_GATE_SCRIPTS path under a fresh
+// temp root with the happy body, applying overrides by repo-relative path: a
+// non-empty override replaces that script's body, and an empty-string override
+// omits the file entirely (an empty-content / missing-file case).
+func writeHostGateEntrypointRepo(t *testing.T, overrides map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, rel := range hostGateScriptRelPaths {
+		body := hostGateSanitizeHappyBody
+		if o, ok := overrides[rel]; ok {
+			body = o
+		}
+		if body == "" {
+			continue
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	return root
+}
+
+func TestCheckHostGateEntrypointSanitize(t *testing.T) {
+	const (
+		shebangSuffix    = " to use an absolute privileged Bash shebang before self-sanitizing its host entrypoint"
+		sanitizeSuffix   = " to self-sanitize its host entrypoint before running release or boundary checks"
+		firstScript      = "scripts/build-and-test.sh"
+		secondScript     = "scripts/check-pinned-inputs.sh"
+		fourthScript     = "scripts/container-smoke.sh"
+		lateScript       = "scripts/verify-release-bundle.sh"
+		noShebangBody    = "#!/bin/bash\nWORKCELL_SANITIZED_ENTRYPOINT=1\n"
+		noSentinelBody   = "#!/bin/bash -p\n# no sanitize sentinel here\n"
+		bothBrokenBody   = "#!/bin/bash\n# no sanitize sentinel here\n"
+		shebangSecondLn  = "# comment\n#!/bin/bash -p\nWORKCELL_SANITIZED_ENTRYPOINT=1\n"
+		trustedEntryBody = "#!/bin/bash -p\nexec ./scripts/lib/trusted-entrypoint.sh\n"
+	)
+	tests := []struct {
+		name       string
+		overrides  map[string]string
+		wantRel    string // "" means expect success
+		wantSuffix string
+	}{
+		{name: "happy path all invariants hold"},
+		{
+			name:       "trusted-entrypoint alternative satisfies sentinel",
+			overrides:  map[string]string{firstScript: trustedEntryBody},
+			wantSuffix: "", // the trusted-entrypoint.sh alternation half holds
+		},
+		{
+			// kindFirstLineRegex: a non-privileged shebang fails the anchored probe.
+			name:       "first script non-privileged shebang",
+			overrides:  map[string]string{firstScript: noShebangBody},
+			wantRel:    firstScript,
+			wantSuffix: shebangSuffix,
+		},
+		{
+			// kindRegexPresent: a good shebang but no self-sanitize sentinel.
+			name:       "first script missing entrypoint sentinel",
+			overrides:  map[string]string{firstScript: noSentinelBody},
+			wantRel:    firstScript,
+			wantSuffix: sanitizeSuffix,
+		},
+		{
+			// Per-script order: the shebang check precedes the sentinel check, so a
+			// script failing both yields the shebang message.
+			name:       "first script fails both shebang wins",
+			overrides:  map[string]string{firstScript: bothBrokenBody},
+			wantRel:    firstScript,
+			wantSuffix: shebangSuffix,
+		},
+		{
+			// firstLineRegex reads only line 1: a privileged shebang on line 2 does
+			// not satisfy the probe.
+			name:       "privileged shebang only on second line",
+			overrides:  map[string]string{firstScript: shebangSecondLn},
+			wantRel:    firstScript,
+			wantSuffix: shebangSuffix,
+		},
+		{
+			// Array order: an earlier bad script wins over a later bad one.
+			name: "earlier script wins over later",
+			overrides: map[string]string{
+				secondScript: noShebangBody,
+				lateScript:   noSentinelBody,
+			},
+			wantRel:    secondScript,
+			wantSuffix: shebangSuffix,
+		},
+		{
+			// A later script's sentinel failure fires once earlier scripts pass.
+			name:       "fourth script missing sentinel",
+			overrides:  map[string]string{fourthScript: noSentinelBody},
+			wantRel:    fourthScript,
+			wantSuffix: sanitizeSuffix,
+		},
+		{
+			// A missing file is empty content: the shebang probe fails first.
+			name:       "first script missing file",
+			overrides:  map[string]string{firstScript: ""},
+			wantRel:    firstScript,
+			wantSuffix: shebangSuffix,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeHostGateEntrypointRepo(t, tc.overrides)
+			err := CheckHostGateEntrypointSanitize(root)
+			if tc.wantRel == "" {
+				if err != nil {
+					t.Fatalf("CheckHostGateEntrypointSanitize() = %v, want nil", err)
+				}
+				return
+			}
+			want := "Expected " + root + "/" + tc.wantRel + tc.wantSuffix
+			if err == nil {
+				t.Fatalf("CheckHostGateEntrypointSanitize() = nil, want error %q", want)
+			}
+			if err.Error() != want {
+				t.Fatalf("CheckHostGateEntrypointSanitize() error = %q, want %q", err.Error(), want)
+			}
+		})
+	}
+}
+
+// TestCheckHostGateEntrypointSanitizeCount asserts the generated list contains
+// exactly forty-four checks: a shebang plus an entrypoint probe for each of the
+// twenty-two HOST_GATE_SCRIPTS.
+func TestCheckHostGateEntrypointSanitizeCount(t *testing.T) {
+	got := len(hostGateEntrypointSanitizeChecks("/repo"))
+	const want = 44
+	if got != want {
+		t.Fatalf("hostGateEntrypointSanitizeChecks(...) has %d checks, want %d", got, want)
+	}
+	if len(hostGateScriptRelPaths) != 22 {
+		t.Fatalf("hostGateScriptRelPaths has %d paths, want 22", len(hostGateScriptRelPaths))
+	}
+}
+
+// TestCheckHostGateEntrypointSanitizeLineParity proves the entrypoint alternation
+// is a genuine regex matched per line: each alternative matches within a single
+// line, and the `\.` matches a literal dot only (not an arbitrary character).
+func TestCheckHostGateEntrypointSanitizeLineParity(t *testing.T) {
+	pat := `WORKCELL_SANITIZED_ENTRYPOINT|trusted-entrypoint\.sh`
+	if !regexMatchesAnyLine(pat, "export WORKCELL_SANITIZED_ENTRYPOINT=1") {
+		t.Fatalf("expected the sentinel alternative to match")
+	}
+	if !regexMatchesAnyLine(pat, "exec ./scripts/lib/trusted-entrypoint.sh") {
+		t.Fatalf("expected the trusted-entrypoint.sh alternative to match")
+	}
+	if regexMatchesAnyLine(pat, "exec ./scripts/lib/trusted-entrypointXsh") {
+		t.Fatalf(`\. must match a literal dot only, not an arbitrary character`)
+	}
+}
+
+// TestCheckHostGateEntrypointSanitizeRealRepo asserts every real HOST_GATE_SCRIPTS
+// file in this repository satisfies both per-script invariants. This is the key
+// guard against a mis-transcribed pattern or a wrong target file.
+func TestCheckHostGateEntrypointSanitizeRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, hostGateScriptRelPaths[0])); err != nil {
+		t.Skipf("real %s not found at %s: %v", hostGateScriptRelPaths[0], repoRoot, err)
+	}
+	if err := CheckHostGateEntrypointSanitize(repoRoot); err != nil {
+		t.Fatalf("CheckHostGateEntrypointSanitize(real repo) = %v, want nil", err)
+	}
+}
+
+// writePrecommitUpstreamPinGateRepo writes .githooks/pre-commit with the given
+// body under a fresh temp root; an empty body omits the file entirely.
+func writePrecommitUpstreamPinGateRepo(t *testing.T, body string) string {
+	t.Helper()
+	root := t.TempDir()
+	if body == "" {
+		return root
+	}
+	path := filepath.Join(root, ".githooks", "pre-commit")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return root
+}
+
+func TestCheckPrecommitUpstreamPinGate(t *testing.T) {
+	const wantErr = "Expected repo pre-commit hook to gate commits on pending pinned upstream updates"
+	happy := "#!/bin/bash\n\"${ROOT_DIR}/scripts/update-upstream-pins.sh\" --check\n"
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{name: "happy path pattern present", body: happy},
+		{
+			name:    "missing --check gate",
+			body:    "#!/bin/bash\n\"${ROOT_DIR}/scripts/update-upstream-pins.sh\" --apply\n",
+			wantErr: wantErr,
+		},
+		{
+			name:    "missing hook file",
+			body:    "",
+			wantErr: wantErr,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writePrecommitUpstreamPinGateRepo(t, tc.body)
+			err := CheckPrecommitUpstreamPinGate(root)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckPrecommitUpstreamPinGate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckPrecommitUpstreamPinGate() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CheckPrecommitUpstreamPinGate() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckPrecommitUpstreamPinGateCount(t *testing.T) {
+	got := len(precommitUpstreamPinGateChecks)
+	const want = 1
+	if got != want {
+		t.Fatalf("precommitUpstreamPinGateChecks has %d checks, want %d", got, want)
+	}
+}
+
+// TestCheckPrecommitUpstreamPinGateLineParity proves the pattern's `\.` is a
+// literal dot and that the probe matches within a single line (rg parity): a
+// pattern split across a newline must not match.
+func TestCheckPrecommitUpstreamPinGateLineParity(t *testing.T) {
+	pat := `scripts/update-upstream-pins\.sh" --check`
+	if !regexMatchesAnyLine(pat, `run "scripts/update-upstream-pins.sh" --check now`) {
+		t.Fatalf("expected the intact --check gate line to match")
+	}
+	if regexMatchesAnyLine(pat, "scripts/update-upstream-pins.sh\"\n--check") {
+		t.Fatalf("a gate split across a newline must NOT match (rg is line-oriented)")
+	}
+	if regexMatchesAnyLine(pat, `scripts/update-upstream-pinsXsh" --check`) {
+		t.Fatalf(`\. must match a literal dot only, not an arbitrary character`)
+	}
+}
+
+func TestCheckPrecommitUpstreamPinGateRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, ".githooks", "pre-commit")); err != nil {
+		t.Skipf("real .githooks/pre-commit not found at %s: %v", repoRoot, err)
+	}
+	if err := CheckPrecommitUpstreamPinGate(repoRoot); err != nil {
+		t.Fatalf("CheckPrecommitUpstreamPinGate(real repo) = %v, want nil", err)
+	}
+}
+
+// trustedDockerClientHappyBody satisfies all four per-script probes: it sources
+// the helper, seeds the client state, drops caller HOME, and invokes buildx via
+// the trusted plugin path.
+const trustedDockerClientHappyBody = "source \"${ROOT_DIR}/scripts/lib/trusted-docker-client.sh\"\n" +
+	"setup_workcell_trusted_docker_client\n" +
+	"HOME=/tmp exec ./sanitized-reexec\n" +
+	"buildx_cmd build .\n"
+
+// writeTrustedDockerClientRepo writes every trusted-Docker-client script under a
+// fresh temp root with the happy body, applying overrides by repo-relative path:
+// a non-empty override replaces the body, an empty-string override omits the file.
+func writeTrustedDockerClientRepo(t *testing.T, overrides map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, rel := range trustedDockerClientScriptRelPaths {
+		body := trustedDockerClientHappyBody
+		if o, ok := overrides[rel]; ok {
+			body = o
+		}
+		if body == "" {
+			continue
+		}
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	return root
+}
+
+func TestCheckTrustedDockerClientRg(t *testing.T) {
+	const (
+		sourceSuffix = " to source the trusted Docker client helper"
+		setupSuffix  = " to seed a trusted Docker client state before using Docker"
+		homeSuffix   = " to stop preserving caller HOME across its sanitized entrypoint re-exec"
+		buildxSuffix = " to invoke buildx through the trusted absolute plugin path"
+		firstScript  = "scripts/container-smoke.sh"
+		secondScript = "scripts/generate-builder-environment-manifest.sh"
+	)
+	drop := func(rel, needle string) map[string]string {
+		return map[string]string{rel: strings.Replace(trustedDockerClientHappyBody, needle, "# removed\n", 1)}
+	}
+	tests := []struct {
+		name       string
+		overrides  map[string]string
+		wantRel    string
+		wantSuffix string
+	}{
+		{name: "happy path all invariants hold"},
+		{
+			name:       "first script missing source helper",
+			overrides:  drop(firstScript, "source \"${ROOT_DIR}/scripts/lib/trusted-docker-client.sh\"\n"),
+			wantRel:    firstScript,
+			wantSuffix: sourceSuffix,
+		},
+		{
+			name:       "first script missing setup call",
+			overrides:  drop(firstScript, "setup_workcell_trusted_docker_client\n"),
+			wantRel:    firstScript,
+			wantSuffix: setupSuffix,
+		},
+		{
+			name:       "first script missing HOME drop",
+			overrides:  drop(firstScript, "HOME=/tmp exec ./sanitized-reexec\n"),
+			wantRel:    firstScript,
+			wantSuffix: homeSuffix,
+		},
+		{
+			name:       "first script missing buildx invocation",
+			overrides:  drop(firstScript, "buildx_cmd build .\n"),
+			wantRel:    firstScript,
+			wantSuffix: buildxSuffix,
+		},
+		{
+			// Loop order: the first loop's three probes run for every script before
+			// the second loop's buildx probe, so a first-script buildx failure loses
+			// to a second-script source failure.
+			name: "loop1 across scripts precedes loop2",
+			overrides: map[string]string{
+				firstScript:  strings.Replace(trustedDockerClientHappyBody, "buildx_cmd build .\n", "# removed\n", 1),
+				secondScript: strings.Replace(trustedDockerClientHappyBody, "source \"${ROOT_DIR}/scripts/lib/trusted-docker-client.sh\"\n", "# removed\n", 1),
+			},
+			wantRel:    secondScript,
+			wantSuffix: sourceSuffix,
+		},
+		{
+			// A missing file is empty content: the first (source) probe fails.
+			name:       "first script missing file",
+			overrides:  map[string]string{firstScript: ""},
+			wantRel:    firstScript,
+			wantSuffix: sourceSuffix,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeTrustedDockerClientRepo(t, tc.overrides)
+			err := CheckTrustedDockerClientRg(root)
+			if tc.wantRel == "" {
+				if err != nil {
+					t.Fatalf("CheckTrustedDockerClientRg() = %v, want nil", err)
+				}
+				return
+			}
+			want := "Expected " + root + "/" + tc.wantRel + tc.wantSuffix
+			if err == nil {
+				t.Fatalf("CheckTrustedDockerClientRg() = nil, want error %q", want)
+			}
+			if err.Error() != want {
+				t.Fatalf("CheckTrustedDockerClientRg() error = %q, want %q", err.Error(), want)
+			}
+		})
+	}
+}
+
+// TestCheckTrustedDockerClientRgCount asserts sixteen checks: three loop-one
+// probes plus one loop-two buildx probe for each of the four scripts.
+func TestCheckTrustedDockerClientRgCount(t *testing.T) {
+	got := len(trustedDockerClientRgChecks("/repo"))
+	const want = 16
+	if got != want {
+		t.Fatalf("trustedDockerClientRgChecks(...) has %d checks, want %d", got, want)
+	}
+	if len(trustedDockerClientScriptRelPaths) != 4 {
+		t.Fatalf("trustedDockerClientScriptRelPaths has %d paths, want 4", len(trustedDockerClientScriptRelPaths))
+	}
+}
+
+// TestCheckTrustedDockerClientRgLineParity proves the source-helper probe's
+// escaped `\$ \{ \} \.` match the literal `$ { } .` within a single line, and
+// that a match split across a newline does not hold (rg is line-oriented).
+func TestCheckTrustedDockerClientRgLineParity(t *testing.T) {
+	pat := `source "\$\{ROOT_DIR\}/scripts/lib/trusted-docker-client\.sh"`
+	if !regexMatchesAnyLine(pat, `source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"`) {
+		t.Fatalf("expected the intact source-helper line to match")
+	}
+	if regexMatchesAnyLine(pat, "source \"${ROOT_DIR}/scripts/lib/\ntrusted-docker-client.sh\"") {
+		t.Fatalf("a source-helper line split across a newline must NOT match (rg is line-oriented)")
+	}
+	if regexMatchesAnyLine(pat, `source "XYROOT_DIRZ/scripts/lib/trusted-docker-client.sh"`) {
+		t.Fatalf(`escaped ${...} must match the literal $ { } characters only`)
+	}
+}
+
+func TestCheckTrustedDockerClientRgRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRoot, trustedDockerClientScriptRelPaths[0])); err != nil {
+		t.Skipf("real %s not found at %s: %v", trustedDockerClientScriptRelPaths[0], repoRoot, err)
+	}
+	if err := CheckTrustedDockerClientRg(repoRoot); err != nil {
+		t.Fatalf("CheckTrustedDockerClientRg(real repo) = %v, want nil", err)
+	}
+}

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2721,16 +2721,19 @@ bash "${WORKCELL_RUNTIME_BUILD_RETRY_HARNESS}"
 
 go_verify_citools workcell-hostutil-egress-rg "${ROOT_DIR}" || exit 1
 
-for script in "${HOST_GATE_SCRIPTS[@]}"; do
-  if ! head -n 1 "${script}" | grep -q '^#!/bin/bash -p$'; then
-    echo "Expected ${script} to use an absolute privileged Bash shebang before self-sanitizing its host entrypoint" >&2
-    exit 1
-  fi
-  if ! rg -q 'WORKCELL_SANITIZED_ENTRYPOINT|trusted-entrypoint\.sh' "${script}"; then
-    echo "Expected ${script} to self-sanitize its host entrypoint before running release or boundary checks" >&2
-    exit 1
-  fi
-done
+# Assert every host-gate script carries an absolute privileged Bash shebang and
+# self-sanitizes its host entrypoint before running release or boundary checks.
+# Migrated to Go (D3): internal/workcellhardening behind the workcell-citools
+# workcell-hostgate-entrypoint-sanitize subcommand preserves the exact exit codes
+# and stderr messages of the former inline `for script in "${HOST_GATE_SCRIPTS[@]}"`
+# loop, including its per-iteration order (the first-line shebang check, a
+# kindFirstLineRegex `^#!/bin/bash -p$` probe, then the entrypoint self-sanitize
+# check, a kindRegexPresent `WORKCELL_SANITIZED_ENTRYPOINT|trusted-entrypoint\.sh`
+# alternation matched per line for rg parity) and the ${script}-interpolated
+# messages (rendered as the absolute "${ROOT_DIR}/..." path exactly as the shell
+# loop variable held each HOST_GATE_SCRIPTS element).  `|| exit 1` matches the
+# former loop's `exit 1` on a violated invariant.
+go_verify_citools workcell-hostgate-entrypoint-sanitize "${ROOT_DIR}" || exit 1
 
 publish_temp_probe="$("${ROOT_DIR}/scripts/publish-upstream-refresh-pr.sh" --self-temp-root-probe)"
 publish_git_dir="$(git -C "${ROOT_DIR}" rev-parse --absolute-git-dir)"
@@ -2758,10 +2761,16 @@ rm -rf "${publish_temp_probe}"
 # guard's `exit 1` on a non-executable hook.  The following pre-commit hook rg /
 # fixture checks stay inline.
 go_verify_citools workcell-precommit-hook-exec "${ROOT_DIR}" || exit 1
-if ! rg -q 'scripts/update-upstream-pins\.sh" --check' "${REPO_PRECOMMIT_HOOK}"; then
-  echo "Expected repo pre-commit hook to gate commits on pending pinned upstream updates" >&2
-  exit 1
-fi
+# Assert the repo pre-commit hook gates commits on pending pinned upstream
+# updates.  Migrated to Go (D3): internal/workcellhardening behind the
+# workcell-citools workcell-precommit-upstream-pin-gate subcommand preserves the
+# exact exit code and stderr message of the former inline
+# `if ! rg -q 'scripts/update-upstream-pins\.sh" --check' "${REPO_PRECOMMIT_HOOK}"`
+# guard (a kindRegexPresent probe whose only metacharacter, `\.`, is an escaped
+# literal dot, read per line for rg parity from ${ROOT_DIR}/.githooks/pre-commit).
+# `|| exit 1` matches the former guard's `exit 1`.  The following pre-commit hook
+# fixture checks stay inline.
+go_verify_citools workcell-precommit-upstream-pin-gate "${ROOT_DIR}" || exit 1
 
 PRECOMMIT_FIXTURE_ROOT="$(mktemp -d)"
 mkdir -p "${PRECOMMIT_FIXTURE_ROOT}/.githooks" "${PRECOMMIT_FIXTURE_ROOT}/scripts"
@@ -2804,35 +2813,23 @@ chmod 0755 "${PRECOMMIT_FIXTURE_ROOT}/scripts/update-upstream-pins.sh"
 HOME="${PRECOMMIT_FIXTURE_ROOT}" "${PRECOMMIT_FIXTURE_ROOT}/.githooks/pre-commit" >/tmp/workcell-precommit-ok.out 2>&1
 rm -rf "${PRECOMMIT_FIXTURE_ROOT}"
 
-for script in \
-  "${ROOT_DIR}/scripts/container-smoke.sh" \
-  "${ROOT_DIR}/scripts/generate-builder-environment-manifest.sh" \
-  "${ROOT_DIR}/scripts/verify-release-bundle.sh" \
-  "${ROOT_DIR}/scripts/verify-reproducible-build.sh"; do
-  if ! rg -q 'source "\$\{ROOT_DIR\}/scripts/lib/trusted-docker-client\.sh"' "${script}"; then
-    echo "Expected ${script} to source the trusted Docker client helper" >&2
-    exit 1
-  fi
-  if ! rg -q 'setup_workcell_trusted_docker_client' "${script}"; then
-    echo "Expected ${script} to seed a trusted Docker client state before using Docker" >&2
-    exit 1
-  fi
-  if ! rg -q 'HOME=/tmp' "${script}"; then
-    echo "Expected ${script} to stop preserving caller HOME across its sanitized entrypoint re-exec" >&2
-    exit 1
-  fi
-done
-
-for script in \
-  "${ROOT_DIR}/scripts/container-smoke.sh" \
-  "${ROOT_DIR}/scripts/generate-builder-environment-manifest.sh" \
-  "${ROOT_DIR}/scripts/verify-release-bundle.sh" \
-  "${ROOT_DIR}/scripts/verify-reproducible-build.sh"; do
-  if ! rg -q 'buildx_cmd ' "${script}"; then
-    echo "Expected ${script} to invoke buildx through the trusted absolute plugin path" >&2
-    exit 1
-  fi
-done
+# Assert the trusted-Docker-client invariants across container-smoke.sh,
+# generate-builder-environment-manifest.sh, verify-release-bundle.sh and
+# verify-reproducible-build.sh: each sources the trusted Docker client helper,
+# seeds a trusted client state before using Docker, drops the caller HOME across
+# its sanitized entrypoint re-exec, and invokes buildx through the trusted
+# absolute plugin path.  Migrated to Go (D3): internal/workcellhardening behind
+# the workcell-citools workcell-trusted-docker-client-rg subcommand preserves the
+# exact exit codes and stderr messages of the former inline `for script` rg loops,
+# in their original order (the first loop's three ordered probes — source helper,
+# seed client state, drop caller HOME — per script, then the second loop's single
+# buildx probe per script), including the per-line (rg-parity) regex matching of
+# each pattern (the source-helper probe escapes `\$ \{ \} \.` to match literals;
+# the setup / HOME / buildx probes are metacharacter-free) and the
+# ${script}-interpolated messages (rendered as the absolute "${ROOT_DIR}/..." path
+# exactly as the shell loop variable held it).  `|| exit 1` matches the former
+# loops' `exit 1` on a violated invariant.
+go_verify_citools workcell-trusted-docker-client-rg "${ROOT_DIR}" || exit 1
 
 # Assert the buildx-builder-trust invariants: verify-release-bundle.sh picks a
 # deterministic context-scoped Buildx builder, the local validator lanes remove


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — static-tail increment.** Migrates the host-gate / trusted-Docker / buildx `rg`-loop invariants the D3 doc-review surfaced as still-in-scope (former lines ~2724-2834), split into 3 subcommands wired at their positions (non-contiguous — separated by inline non-migratable blocks; ordering preserved).

## What (61 checks, no new kinds — reuses kindFirstLineRegex/kindRegexPresent)
- **`workcell-hostgate-entrypoint-sanitize`** (44) — the `HOST_GATE_SCRIPTS` loop: 22 scripts × (shebang `^#!/bin/bash -p$` first-line + entrypoint `WORKCELL_SANITIZED_ENTRYPOINT|trusted-entrypoint\.sh` regex). The array resolved to a static 22-path list.
- **`workcell-precommit-upstream-pin-gate`** (1) — `.githooks/pre-commit` upstream-pin `--check` probe.
- **`workcell-trusted-docker-client-rg`** (16) — 4 scripts × 3 trusted-docker-client probes + 4 × 1 buildx_cmd probe (two-loop order preserved).

## Parity
`${script}` renders the absolute `${ROOT_DIR}/…` path (array elements are `"${ROOT_DIR}/…"`) → reconstructed byte-exact via `rootDir + "/" + rel`. `|`-alternation and escaped-literal patterns kept verbatim (per-line rg parity). Real repo → each subcommand exit 0; crafted violations diffed vs the extracted original loops → byte-identical (incl. cross-loop ordering). `HOST_GATE_SCRIPTS`/`REPO_PRECOMMIT_HOOK` retained (still used by other loops/fixtures).

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...` (per-subcommand table + ordering + line-parity + real-repo assertion + count guards), `shellcheck -x`, `shfmt -d` — all green. 4 files / 726 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)