### PR TITLE
^R D3: migrate scenario/manifest filesystem checks to Go + drop orphaned regex helper

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -131,6 +131,7 @@ func subcommands() []subcommand {
 		{"workcell-validate-repo-scenario-refs", "ROOT_DIR", 1, 1, cmdWorkcellValidateRepoScenarioRefs},
 		{"workcell-precommit-hook-exec", "ROOT_DIR", 1, 1, cmdWorkcellPrecommitHookExec},
 		{"workcell-docs-examples-dir", "ROOT_DIR", 1, 1, cmdWorkcellDocsExamplesDir},
+		{"workcell-scenario-scripts-present", "ROOT_DIR", 1, 1, cmdWorkcellScenarioScriptsPresent},
 		{"workcell-claude-mcp-project-servers", "SETTINGS_PATH", 1, 1, cmdWorkcellClaudeMcpProjectServers},
 		{"workcell-claude-managed-bypass", "ROOT_DIR", 1, 1, cmdWorkcellClaudeManagedBypass},
 		{"workcell-gemini-settings-guards", "ROOT_DIR", 1, 1, cmdWorkcellGeminiSettingsGuards},
@@ -869,6 +870,17 @@ func cmdWorkcellPrecommitHookExec(args []string) error {
 // original stderr message when the invariant is violated.
 func cmdWorkcellDocsExamplesDir(args []string) error {
 	return workcellhardening.CheckDocsExamplesDir(args[0])
+}
+
+// cmdWorkcellScenarioScriptsPresent runs the four scenario-harness filesystem
+// checks (${ROOT_DIR}/tests/scenarios/manifest.json must exist as a regular
+// file, and the three scenario scripts under ${ROOT_DIR}/scripts must exist and
+// be executable) migrated out of scripts/verify-invariants.sh; it fails (exit 1
+// via die()) with the shell's original stderr message for the first violated
+// invariant (the manifest's static message, or the scenario-script prefix plus
+// the absolute script path).
+func cmdWorkcellScenarioScriptsPresent(args []string) error {
+	return workcellhardening.CheckScenarioScriptsPresent(args[0])
 }
 
 // cmdWorkcellClaudeMcpProjectServers runs the single `jq -e`

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -51,8 +51,9 @@
 //   - Line-count threshold (`[[ "$(grep -Fc NEEDLE f)" -lt N ]]`, counting
 //     matching LINES): kindCountAtLeast with minCount.
 //   - Filesystem state (no content read): kindDirExists (`[[ -d ]]`, os.Stat +
-//     IsDir) and kindExecutable (`[[ -x ]]`, syscall.Access with X_OK — the
-//     same access(2) primitive Bash's -x uses).
+//     IsDir), kindExecutable (`[[ -x ]]`, syscall.Access with X_OK — the
+//     same access(2) primitive Bash's -x uses), and kindFileExists (`[[ -f ]]`,
+//     os.Stat + Mode().IsRegular()).
 //   - Typed JSON expression (`jq -e '.a.b == <literal>'` on a static file):
 //     kindJSONExprEval, comparing with jq's type-aware == (see
 //     navigateJSONPath).
@@ -82,13 +83,9 @@
 // (1) Still-migratable static checks not yet ported — these CAN move here in
 // future increments and should not be read as "done":
 //
-//   - `head`/`rg`/`grep -Fq` helper loops over repo files (for example the
-//     host-gate script loop and the trusted-Docker client loops).
 //   - `jq -e` guards over STATIC settings files whose expressions go beyond
 //     `.<path> == <scalar>` (array equality `== []`, index `[0]`, truthiness,
 //     and `| type`), which need richer kindJSONExprEval support.
-//   - filesystem guards embedded in shell `for` loops (for example a
-//     `[[ ! -x "${scenario_script}" ]]` scan over a computed script list).
 //
 // (2) Checks that are NOT expressible as a static-file invariant and are
 // intentionally left in bash:
@@ -423,6 +420,16 @@ const (
 	// mirrors Bash `-x` via syscall.Access(path, X_OK) — the same access(2)
 	// primitive Bash uses — rather than reading content or inspecting mode bits.
 	kindExecutable
+	// kindFileExists requires the repo-relative path targetPath to be an
+	// existing REGULAR file under rootDir, mirroring
+	// `if [[ ! -f "${ROOT_DIR}/PATH" ]]` (a missing path, a directory, or any
+	// other non-regular file is a violation → exit 1).  Like kindDirExists /
+	// kindExecutable this is a FILESYSTEM check: evaluate stats
+	// filepath.Join(rootDir, targetPath) and holds requires os.Stat to succeed
+	// AND info.Mode().IsRegular() — the same "regular file" predicate Bash's -f
+	// uses (which, unlike -e, rejects directories) — rather than reading the
+	// path as file content.
+	kindFileExists
 	// kindJSONExprEval requires the jq comparison expression
 	// `<jsonPath> == <jsonExpectedRaw>` to evaluate TRUE against the target file
 	// parsed as JSON, mirroring a NEGATED `jq -e` guard
@@ -472,10 +479,10 @@ type check struct {
 	// the shell's `grep -Fc ... -lt N` count guard.
 	minCount int
 	// targetPath is the repo-relative path a filesystem check (kindDirExists /
-	// kindExecutable) stats under rootDir.  It is used only by those two kinds
-	// (every other kind reads file content via targetFile / targetFiles); the
-	// filesystem kinds never read the path as content, so leaving targetFile
-	// empty for them does not trigger a launcherRelPath read.
+	// kindExecutable / kindFileExists) stats under rootDir.  It is used only by
+	// those three kinds (every other kind reads file content via targetFile /
+	// targetFiles); the filesystem kinds never read the path as content, so
+	// leaving targetFile empty for them does not trigger a launcherRelPath read.
 	targetPath string
 	// jsonPath is the dotted JSON object path a kindJSONExprEval check navigates
 	// (e.g. ".security.folderTrust.enabled"), mirroring the left-hand side of the
@@ -586,9 +593,10 @@ func Check(rootDir string) error {
 // (kindAbsent/kindRegexAbsent/kindFunctionBlockAbsent/
 // kindFunctionBlockRegexAbsent) checks pass.
 //
-// The filesystem kinds (kindDirExists/kindExecutable) do not read content:
-// evaluate stats rootDir/targetPath, mirroring the shell's `[[ ! -d ]]` /
-// `[[ ! -x ]]` tests, so a missing path is a violation for both.
+// The filesystem kinds (kindDirExists/kindExecutable/kindFileExists) do not
+// read content: evaluate stats rootDir/targetPath, mirroring the shell's
+// `[[ ! -d ]]` / `[[ ! -x ]]` / `[[ ! -f ]]` tests, so a missing path is a
+// violation for all three.
 func evaluate(rootDir string, cs []check) error {
 	cache := make(map[string]string)
 	readTarget := func(rel string) string {
@@ -621,10 +629,11 @@ func evaluate(rootDir string, cs []check) error {
 			}
 			continue
 		}
-		if c.kind == kindDirExists || c.kind == kindExecutable {
+		if c.kind == kindDirExists || c.kind == kindExecutable || c.kind == kindFileExists {
 			// Filesystem kinds stat rootDir/targetPath instead of reading a
-			// file's content, mirroring the shell's `[[ ! -d ]]` / `[[ ! -x ]]`
-			// path tests; holds ignores the (empty) text argument for them.
+			// file's content, mirroring the shell's `[[ ! -d ]]` / `[[ ! -x ]]` /
+			// `[[ ! -f ]]` path tests; holds ignores the (empty) text argument
+			// for them.
 			if !c.holds("", rootDir) {
 				return errors.New(c.violationMessage(rootDir))
 			}
@@ -4171,6 +4180,58 @@ func CheckDocsExamplesDir(rootDir string) error {
 	return evaluate(rootDir, docsExamplesDirChecks)
 }
 
+// scenarioScriptsPresentChecks holds the four contiguous scenario-harness
+// filesystem invariants migrated out of scripts/verify-invariants.sh, in the
+// shell's original order.  The first is the lone
+// `if [[ ! -f "${ROOT_DIR}/tests/scenarios/manifest.json" ]]` guard (a
+// kindFileExists check that stats rootDir/tests/scenarios/manifest.json; the
+// shell message was a static "tests/scenarios/manifest.json must exist" with no
+// path interpolation).  The remaining three are the static
+// `for scenario_script in ...; do [[ ! -x "${scenario_script}" ]]; done` loop
+// over the three scenario scripts (kindExecutable checks); the shell message
+// interpolated the absolute ${scenario_script} (`${ROOT_DIR}/<path>`), so
+// messageIncludesTargetPath appends rootDir + "/" + targetPath to reproduce it
+// byte-for-byte.  The `jq -e` PreToolUse-hook guard that immediately follows the
+// loop in the shell (an array/pipe expression) stays inline in bash, so this
+// group is wired only across the four contiguous filesystem checks.
+var scenarioScriptsPresentChecks = []check{
+	{
+		kind:       kindFileExists,
+		targetPath: "tests/scenarios/manifest.json",
+		message:    "tests/scenarios/manifest.json must exist",
+	},
+	{
+		kind:                      kindExecutable,
+		targetPath:                "scripts/run-scenario-tests.sh",
+		message:                   "Expected executable scenario script: ",
+		messageIncludesTargetPath: true,
+	},
+	{
+		kind:                      kindExecutable,
+		targetPath:                "scripts/verify-scenario-coverage.sh",
+		message:                   "Expected executable scenario script: ",
+		messageIncludesTargetPath: true,
+	},
+	{
+		kind:                      kindExecutable,
+		targetPath:                "scripts/verify-control-plane-parity.sh",
+		message:                   "Expected executable scenario script: ",
+		messageIncludesTargetPath: true,
+	},
+}
+
+// CheckScenarioScriptsPresent runs the four scenario-harness filesystem
+// invariants (the tests/scenarios/manifest.json regular-file check plus the
+// three executable scenario-script checks) against the repo rooted at rootDir,
+// in the shell's original order.  It returns nil when every invariant holds (the
+// shell's exit 0), or an error whose message equals the shell's stderr for the
+// first violated invariant (the shell's exit 1) — for the manifest check the
+// static message, and for a scenario-script check the fixed prefix plus the
+// absolute ${ROOT_DIR}/<path> script path.
+func CheckScenarioScriptsPresent(rootDir string) error {
+	return evaluate(rootDir, scenarioScriptsPresentChecks)
+}
+
 // claudeManagedSettingsRelPath is the repo-relative path to the Claude adapter
 // managed-settings file.  The claude-managed-bypass check reads it for its
 // bypass-permissions invariant, mirroring the shell `jq -e` probe that ran
@@ -4475,7 +4536,8 @@ func (c check) violationMessage(rootDir string) string {
 
 // holds reports whether the invariant is satisfied.  Content kinds inspect
 // text (the target file's contents); filesystem kinds (kindDirExists /
-// kindExecutable) ignore text and stat rootDir/targetPath instead.
+// kindExecutable / kindFileExists) ignore text and stat rootDir/targetPath
+// instead.
 func (c check) holds(text, rootDir string) bool {
 	switch c.kind {
 	case kindFunctionBlock:
@@ -4506,6 +4568,13 @@ func (c check) holds(text, rootDir string) bool {
 		// syscall.Access rather than inspecting Mode() bits. A missing path
 		// yields ENOENT, so this correctly returns false.
 		return syscall.Access(filepath.Join(rootDir, c.targetPath), 0x1) == nil
+	case kindFileExists:
+		// `[[ ! -f "${ROOT_DIR}/PATH" ]]`: holds only when the path exists and
+		// is a regular file. Bash `-f` (unlike `-e`) rejects directories and
+		// other special files, so mirror it with info.Mode().IsRegular(); a
+		// missing path yields an error and correctly returns false.
+		info, err := os.Stat(filepath.Join(rootDir, c.targetPath))
+		return err == nil && info.Mode().IsRegular()
 	case kindGoFunctionBlock:
 		block := extractGoFunctionBlock(text, c.functionName)
 		return strings.Contains(block, c.pattern)

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -6250,6 +6250,151 @@ func TestCheckDocsExamplesDirRealRepo(t *testing.T) {
 	}
 }
 
+// --- D3 file sweep: scenario-scripts-present subcommand ---
+
+// TestKindFileExists exercises kindFileExists's holds() directly: an existing
+// regular file holds (true); a missing path or a directory (not a regular file)
+// is a violation (holds=false), mirroring Bash `[[ -f ]]`.
+func TestKindFileExists(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "regular"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "adir"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"regular file present", "regular", true},
+		{"path missing", "missing", false},
+		{"path is a directory not a regular file", "adir", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := check{kind: kindFileExists, targetPath: tc.path}
+			if got := c.holds("", root); got != tc.want {
+				t.Fatalf("holds()=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// scenarioScriptsRelPaths are the four repo-relative paths the group checks, in
+// the shell's original order (manifest first, then the three scenario scripts).
+var scenarioScriptsRelPaths = []string{
+	"tests/scenarios/manifest.json",
+	"scripts/run-scenario-tests.sh",
+	"scripts/verify-scenario-coverage.sh",
+	"scripts/verify-control-plane-parity.sh",
+}
+
+// writeScenarioHarness populates root with a valid scenario harness: a regular
+// manifest.json plus the three executable scenario scripts.
+func writeScenarioHarness(t *testing.T, root string) {
+	t.Helper()
+	manifest := filepath.Join(root, "tests/scenarios/manifest.json")
+	if err := os.MkdirAll(filepath.Dir(manifest), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(manifest, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "scripts"), 0o755); err != nil {
+		t.Fatalf("mkdir scripts: %v", err)
+	}
+	for _, rel := range scenarioScriptsRelPaths[1:] {
+		if err := os.WriteFile(filepath.Join(root, rel), []byte("#!/bin/bash\n"), 0o755); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+}
+
+func TestCheckScenarioScriptsPresent(t *testing.T) {
+	t.Run("full harness holds", func(t *testing.T) {
+		root := t.TempDir()
+		writeScenarioHarness(t, root)
+		if err := CheckScenarioScriptsPresent(root); err != nil {
+			t.Fatalf("CheckScenarioScriptsPresent() = %v, want nil", err)
+		}
+	})
+	t.Run("missing manifest fails with static message", func(t *testing.T) {
+		root := t.TempDir()
+		writeScenarioHarness(t, root)
+		if err := os.Remove(filepath.Join(root, "tests/scenarios/manifest.json")); err != nil {
+			t.Fatalf("remove: %v", err)
+		}
+		err := CheckScenarioScriptsPresent(root)
+		if err == nil || err.Error() != "tests/scenarios/manifest.json must exist" {
+			t.Fatalf("CheckScenarioScriptsPresent() = %v, want %q", err, "tests/scenarios/manifest.json must exist")
+		}
+	})
+	t.Run("manifest that is a directory fails", func(t *testing.T) {
+		root := t.TempDir()
+		writeScenarioHarness(t, root)
+		manifest := filepath.Join(root, "tests/scenarios/manifest.json")
+		if err := os.Remove(manifest); err != nil {
+			t.Fatalf("remove: %v", err)
+		}
+		if err := os.MkdirAll(manifest, 0o755); err != nil {
+			t.Fatalf("mkdir manifest dir: %v", err)
+		}
+		err := CheckScenarioScriptsPresent(root)
+		if err == nil || err.Error() != "tests/scenarios/manifest.json must exist" {
+			t.Fatalf("CheckScenarioScriptsPresent() = %v, want %q", err, "tests/scenarios/manifest.json must exist")
+		}
+	})
+	// Each scenario script, when non-executable or missing, must fail with the
+	// prefix plus the ABSOLUTE ${ROOT_DIR}/<path> script path, byte-for-byte.
+	for _, rel := range scenarioScriptsRelPaths[1:] {
+		rel := rel
+		t.Run("non-executable "+rel+" fails with absolute path", func(t *testing.T) {
+			root := t.TempDir()
+			writeScenarioHarness(t, root)
+			if err := os.Chmod(filepath.Join(root, rel), 0o644); err != nil {
+				t.Fatalf("chmod: %v", err)
+			}
+			wantMsg := "Expected executable scenario script: " + root + "/" + rel
+			err := CheckScenarioScriptsPresent(root)
+			if err == nil || err.Error() != wantMsg {
+				t.Fatalf("CheckScenarioScriptsPresent() = %v, want %q", err, wantMsg)
+			}
+		})
+		t.Run("missing "+rel+" fails with absolute path", func(t *testing.T) {
+			root := t.TempDir()
+			writeScenarioHarness(t, root)
+			if err := os.Remove(filepath.Join(root, rel)); err != nil {
+				t.Fatalf("remove: %v", err)
+			}
+			wantMsg := "Expected executable scenario script: " + root + "/" + rel
+			err := CheckScenarioScriptsPresent(root)
+			if err == nil || err.Error() != wantMsg {
+				t.Fatalf("CheckScenarioScriptsPresent() = %v, want %q", err, wantMsg)
+			}
+		})
+	}
+}
+
+func TestCheckScenarioScriptsPresentCount(t *testing.T) {
+	if got, want := len(scenarioScriptsPresentChecks), 4; got != want {
+		t.Fatalf("scenarioScriptsPresentChecks has %d checks, want %d", got, want)
+	}
+}
+
+func TestCheckScenarioScriptsPresentRealRepo(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	for _, rel := range scenarioScriptsRelPaths {
+		if _, err := os.Stat(filepath.Join(repoRoot, rel)); err != nil {
+			t.Skipf("real %s not found at %s: %v", rel, repoRoot, err)
+		}
+	}
+	if err := CheckScenarioScriptsPresent(repoRoot); err != nil {
+		t.Fatalf("CheckScenarioScriptsPresent(real repo) = %v, want nil", err)
+	}
+}
+
 // --- kindJSONExprEval + jq -e adapter-settings migration (D3) ---
 
 // jsonExprCheck builds a bare kindJSONExprEval check for the holds() unit tests.

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -83,23 +83,6 @@ host_path_within_root() {
   [[ "${candidate_cmp}" == "${root_cmp}" ]] || [[ "${candidate_cmp}" == "${root_cmp}/"* ]]
 }
 
-extract_named_function_block() {
-  local file_path="$1"
-  local function_name="$2"
-
-  sed -n "/^${function_name}()/,/^}/p" "${file_path}"
-}
-
-function_block_contains_regex() {
-  local file_path="$1"
-  local function_name="$2"
-  local regex="$3"
-  local block_text=""
-
-  block_text="$(extract_named_function_block "${file_path}" "${function_name}")"
-  grep -q -- "${regex}" <<<"${block_text}"
-}
-
 script_supports_command_flag() {
   local script_help=""
 
@@ -7988,20 +7971,17 @@ if rg -n '/Users/example/\.(codex|config/(gh|gcloud)|ssh)(/|")|/Users/example/Li
   exit 1
 fi
 
-if [[ ! -f "${ROOT_DIR}/tests/scenarios/manifest.json" ]]; then
-  echo "tests/scenarios/manifest.json must exist" >&2
-  exit 1
-fi
-
-for scenario_script in \
-  "${ROOT_DIR}/scripts/run-scenario-tests.sh" \
-  "${ROOT_DIR}/scripts/verify-scenario-coverage.sh" \
-  "${ROOT_DIR}/scripts/verify-control-plane-parity.sh"; do
-  if [[ ! -x "${scenario_script}" ]]; then
-    echo "Expected executable scenario script: ${scenario_script}" >&2
-    exit 1
-  fi
-done
+# Assert the scenario harness is present: tests/scenarios/manifest.json exists
+# as a regular file, and the three scenario scripts exist and are executable.
+# Migrated to Go (D3): internal/workcellhardening behind the workcell-citools
+# workcell-scenario-scripts-present subcommand preserves the exact exit codes and
+# stderr messages of the former inline `[[ ! -f ]]` manifest guard (a
+# kindFileExists filesystem check) and the `for scenario_script in ...; do
+# [[ ! -x "${scenario_script}" ]]; done` loop (three kindExecutable checks whose
+# message interpolates the absolute ${ROOT_DIR}/<path> script path).  `|| exit 1`
+# matches the former guards' `exit 1`.  The following guard-bash.sh PreToolUse
+# `jq -e` array/pipe check stays inline.
+go_verify_citools workcell-scenario-scripts-present "${ROOT_DIR}" || exit 1
 
 if ! jq -e '[.hooks.PreToolUse[]?.hooks[0].command? // empty] | any(type == "string" and endswith("guard-bash.sh"))' "${ROOT_DIR}/adapters/claude/managed-settings.json" >/dev/null; then
   echo "guard-bash.sh hook must be registered in managed-settings.json PreToolUse" >&2


### PR DESCRIPTION
**D3 (migrate verify-invariants.sh to Go) — cleanup + last static filesystem checks.** After the static rg/grep migration completed, three small items remained.

## What
- **New kind `kindFileExists`** (`[[ -f PATH ]]`: `os.Stat` + `Mode().IsRegular()` — rejects dirs/missing, unlike `-e`).
- **`workcell-scenario-scripts-present`** (`CheckScenarioScriptsPresent`, 4 checks): the `tests/scenarios/manifest.json` `-f` check (message literal `tests/scenarios/manifest.json must exist`) + the static 3-script `-x` loop (`run-scenario-tests.sh`, `verify-scenario-coverage.sh`, `verify-control-plane-parity.sh`) → `kindExecutable` with the absolute-path message. Wired in place; the following `jq -e` array/pipe check stays inline.
- **Removed the orphaned `function_block_contains_regex()` shell helper** (0 callers — its last caller, clear_rules, migrated in #28) **and its now-orphaned `extract_named_function_block()`** (function_block_contains_regex was its only remaining caller). `bash -n`/shellcheck confirm no broken references.
- **Doc tweak**: package "Scope and residual" group (1) — removed the host-gate/trusted-Docker rg-loop bullet (migrated) and the filesystem-guard-in-loop bullet (scenario `-x` now migrated); added `kindFileExists` to the kinds list.

## Parity / validation
Real repo → exit 0; crafted violations (missing manifest, non-exec script) → exit 1 byte-identical. `kindFileExists` direct test (file→pass, missing/dir→fail) + real-repo assertion + count guard. `go build`/`vet`/`gofmt`, full `go test ./...`, `bash -n`, `shellcheck -x`, `shfmt -d` — all green. 4 files / 302 lines.

## Residual after this (documented, non-static)
5 array/pipe `jq -e` expressions, runtime integration-test harnesses (execute scripts), awk helper functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)