### PR TITLE
^F C1: Apple container backend evaluation + recorded go/no-go (macOS 26)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -471,9 +471,13 @@ security-boundary product to prove.
 
 ### Track C: Runtime Platform Evolution
 
-- **C1 (next, L):** Apple `container` backend evaluation (macOS 26+) as
-  `local_vm/apple-container` with a recorded go/no-go; Colima stays the
-  reviewed default below macOS 26
+- **C1 (evaluated, L):** Apple `container` backend evaluation (macOS 26+) as
+  `local_vm/apple-container` — **recorded go/no-go: GO on the evaluation
+  (per-session VM, sub-second boot, confirmed on macOS 26.5.1);
+  `preview-only`/`blocked` and support-invisible; Colima stays the reviewed
+  default (and the only option below macOS 26); promotion to a supported
+  backend deferred post-1.0 pending the B6 certification lane.** See
+  [docs/apple-container-evaluation.md](docs/apple-container-evaluation.md)
 - **C2 (next, M):** session start latency program with cached images, an
   optional kept-warm lane, and published reproducible benchmarks
 - **C3 (next, L):** native parallel sessions — one agent per worktree,

--- a/docs/apple-container-evaluation.md
+++ b/docs/apple-container-evaluation.md
@@ -1,0 +1,108 @@
+# Apple `container` backend evaluation (C1)
+
+This page records the roadmap **C1** evaluation of Apple's `container` runtime as
+a `local_vm/apple-container` target for Workcell, and the go/no-go promotion
+decision. Per the roadmap, the 1.0 gate is the *recorded decision*, not a shipped
+backend: Colima stays the reviewed default, and Apple `container` is
+support-invisible (preview-only, launch-blocked) until the full support-matrix
+launch and certification gates pass.
+
+The spike lives in [`internal/applecontainer`](../internal/applecontainer); the
+support-matrix row is in [`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv).
+
+## Context
+
+Apple's Containerization framework reached 1.0.0 (June 2026): one lightweight VM
+per container on Virtualization.framework, a frozen 1.0 API, Apple Silicon only,
+macOS 26 baseline. The hypothesis was that per-session VM isolation would be a
+stronger and lighter boundary than one shared Colima VM.
+
+## Methodology
+
+Two independent validation modes, mirroring the existing `remotevm` target
+pattern:
+
+1. **Deterministic conformance harness.** A local-VM `Contract` (its own type —
+   Apple `container` is local and direct, so it does not reuse `remotevm`'s
+   remote/brokered contract) plus a deterministic `AppleContainerTarget` driven
+   through the session lifecycle (`workspace_materialized` → `bootstrap_ready` →
+   `session_started` → `session_finished`). Runs on any host in CI.
+2. **Live local exercise.** A `ProbeAppleContainer` helper that shells out to the
+   real `container` CLI on a macOS 26 host, measures warm boot latency, and reads
+   per-VM isolation properties. Skips (sentinel `ErrAppleContainerUnavailable`)
+   when the CLI is absent or the service is stopped, so non-macOS-26/CI hosts are
+   unaffected.
+
+Evaluation host: macOS 26.5.1 (Darwin 25.5.0), Apple Silicon, Apple `container`
+1.0.0, kata guest kernel 6.18.15.
+
+## Results
+
+### Conformance
+
+`AppleContainerTarget` passes the local-VM session-lifecycle contract
+(materialize → bootstrap → start → finish, all four required audit events, and
+the `running` → `exited` status transition). The contract's `Validate()`
+fail-closes on remote/brokered values, so a local target cannot be
+mis-declared as remote.
+
+### Live boundary properties (macOS 26 host)
+
+| Property | Apple `container` (observed) |
+|---|---|
+| Warm boot latency | **sub-second** — 843 ms fastest, ~857 ms median (idle host, 3 samples) |
+| Guest kernel | own Linux kernel **6.18.15** (host is Darwin 25.5.0) |
+| Hostname / init | unique per-run UUID hostname; own pid 1 |
+| Network | own VM NIC `eth0` on `192.168.64.0/24` (not a shared bridge) |
+| Root filesystem | own ext4 block device (`/dev/vd*`) |
+
+Every isolation property confirms the model: **one lightweight VM per
+container**, each with its own kernel, network stack, and block device.
+
+### Boundary comparison versus Colima
+
+| | Apple `container` | Colima (current default) |
+|---|---|---|
+| VM model | **one VM per container/session** | **one shared VM** for all sessions |
+| Kernel isolation | per-session kernel | all sessions share one kernel |
+| Cold start | sub-second per container | tens of seconds for the shared VM's first boot |
+| Host support | Apple Silicon + macOS 26 only | macOS (reviewed), Linux amd64 (validator) |
+| API maturity | frozen 1.0 (new) | mature |
+
+Apple `container` provides a strictly stronger session boundary (per-session VM
+vs shared VM) at a lighter cost (sub-second boot), validating the hypothesis.
+
+## Caveats
+
+- **Apple Silicon + macOS 26 only.** Nothing below macOS 26; `RequireMacOS26()`
+  fail-closes on lower versions and non-macOS.
+- **1.0 API is new** (June 2026) — less field-hardened than Colima.
+- **First-run setup** requires a kata guest kernel
+  (`container system kernel set --recommended`) and a running system service.
+- **Boot latency is CPU-contention-sensitive**: sub-second on an idle host, but
+  2–7 s under a saturated host. The always-run probe test therefore asserts
+  isolation plus a robust lightweight-VM ceiling (an order of magnitude under
+  Colima cold boot) and logs the real median; the literal sub-second assertion
+  is an opt-in serial test (`WORKCELL_APPLECONTAINER_STRICT_BOOT=1`).
+
+## Fail-closed behavior
+
+`RequireMacOS26()` (`internal/applecontainer/guard.go`) refuses the
+`apple-container` target on macOS below 26 and on non-macOS, so the backend
+cannot be selected where its per-session-VM guarantees do not hold.
+
+## Decision: go (preview-only), Colima stays the default for 1.0
+
+**Recorded go/no-go: GO on the evaluation; promotion deferred.** Apple
+`container` is validated as a superior local boundary on macOS 26, and is
+recorded in the support matrix as `local_vm/apple-container`,
+`per-session-vm`, **`preview-only` / `blocked`** — support-invisible, evaluation
+only. Colima remains the reviewed default local backend (including on macOS below
+26, where Apple `container` is unavailable).
+
+Promotion to a `supported` / `launch-allowed` backend is **deferred beyond
+1.0**, gated on: a real-boundary certification lane on an Apple-Silicon macOS 26
+runner (roadmap B6), the full host-support-matrix launch gates, and broader
+field validation of the 1.0 API. The 1.0 deliverable is this recorded evaluation
+and decision, plus the conformance spike and fail-closed guard — not a shipped
+backend.

--- a/internal/applecontainer/conformance.go
+++ b/internal/applecontainer/conformance.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/host/sessions"
+	"github.com/omkhar/workcell/internal/providerid"
+)
+
+// ConformanceCase parameterizes a single deterministic lifecycle run.
+type ConformanceCase struct {
+	StateRoot         string
+	TargetID          string
+	MaterializationID string
+	BootstrapID       string
+	SessionID         string
+	Agent             string
+	Mode              string
+	ImageRef          string
+	StartedAt         string
+	FinishedAt        string
+	ExitStatus        string
+	SourceWorkspace   string
+}
+
+// ConformanceResult is the aggregate output of a successful lifecycle run.
+type ConformanceResult struct {
+	Materialization MaterializeResult
+	Bootstrap       BootstrapResult
+	Started         SessionResult
+	Finished        SessionResult
+	Exported        sessions.SessionExport
+}
+
+// DefaultConformanceCase returns a canonical case for the given state root and
+// source workspace.
+func DefaultConformanceCase(stateRoot, sourceWorkspace string) ConformanceCase {
+	return ConformanceCase{
+		StateRoot:         stateRoot,
+		TargetID:          "apple-container-target",
+		MaterializationID: "fixture-materialization",
+		BootstrapID:       "fixture-bootstrap",
+		SessionID:         "fixture-session",
+		Agent:             providerid.Codex,
+		Mode:              "strict",
+		ImageRef:          "workcell-applecontainer:test",
+		StartedAt:         "2026-06-01T00:00:00Z",
+		FinishedAt:        "2026-06-01T00:15:00Z",
+		ExitStatus:        "0",
+		SourceWorkspace:   sourceWorkspace,
+	}
+}
+
+// RunConformance drives target through the full session lifecycle and verifies
+// it honors the local-VM contract: manifest values, session record transitions,
+// the exported final status, and the required audit events in order.
+func RunConformance(ctx context.Context, target ConformanceTarget, contract Contract, c ConformanceCase) (ConformanceResult, error) {
+	if err := contract.Validate(); err != nil {
+		return ConformanceResult{}, err
+	}
+	materialization, err := target.MaterializeWorkspace(ctx, MaterializeRequest{
+		StateRoot:         c.StateRoot,
+		TargetID:          c.TargetID,
+		MaterializationID: c.MaterializationID,
+		SourceWorkspace:   c.SourceWorkspace,
+	})
+	if err != nil {
+		return ConformanceResult{}, err
+	}
+	if err := validateMaterialization(contract, materialization, c.SourceWorkspace); err != nil {
+		return ConformanceResult{}, err
+	}
+	bootstrap, err := target.BootstrapTarget(ctx, BootstrapRequest{
+		StateRoot:   c.StateRoot,
+		TargetID:    c.TargetID,
+		BootstrapID: c.BootstrapID,
+		ImageRef:    c.ImageRef,
+	})
+	if err != nil {
+		return ConformanceResult{}, err
+	}
+	if err := validateBootstrap(contract, bootstrap, c); err != nil {
+		return ConformanceResult{}, err
+	}
+	started, err := target.StartSession(ctx, StartSessionRequest{
+		SessionID:       c.SessionID,
+		Agent:           c.Agent,
+		Mode:            c.Mode,
+		StartedAt:       c.StartedAt,
+		Materialization: materialization,
+		Bootstrap:       bootstrap,
+	})
+	if err != nil {
+		return ConformanceResult{}, err
+	}
+	if err := validateStartedSession(contract, started, materialization, bootstrap, c); err != nil {
+		return ConformanceResult{}, err
+	}
+	finished, err := target.FinishSession(ctx, FinishSessionRequest{
+		Started:    started,
+		FinishedAt: c.FinishedAt,
+		ExitStatus: c.ExitStatus,
+	})
+	if err != nil {
+		return ConformanceResult{}, err
+	}
+	if err := validateFinishedSession(contract, finished, c); err != nil {
+		return ConformanceResult{}, err
+	}
+	records, err := sessions.ListSessionRecordsInRoots([]string{c.StateRoot}, sessions.SessionListOptions{})
+	if err != nil {
+		return ConformanceResult{}, err
+	}
+	if len(records) != 1 {
+		return ConformanceResult{}, fmt.Errorf("ListSessionRecordsInRoots() len = %d, want 1", len(records))
+	}
+	if got := sessions.SessionTargetSummary(records[0]); got != fmt.Sprintf("%s/%s/%s", contract.TargetKind, contract.TargetProvider, c.TargetID) {
+		return ConformanceResult{}, fmt.Errorf("SessionTargetSummary() = %q", got)
+	}
+	exported, err := sessions.ExportSessionRecordInRoots([]string{c.StateRoot}, c.SessionID)
+	if err != nil {
+		return ConformanceResult{}, err
+	}
+	if exported.Session.Status != contract.Session.FinalStatus {
+		return ConformanceResult{}, fmt.Errorf("exported final status = %q, want %q", exported.Session.Status, contract.Session.FinalStatus)
+	}
+	if len(exported.AuditRecords) != len(contract.RequiredAuditEvents) {
+		return ConformanceResult{}, fmt.Errorf("exported audit record len = %d, want %d", len(exported.AuditRecords), len(contract.RequiredAuditEvents))
+	}
+	for idx, want := range contract.RequiredAuditEvents {
+		if !strings.Contains(exported.AuditRecords[idx], "event="+want) {
+			return ConformanceResult{}, fmt.Errorf("audit record %d = %q, want event=%s", idx, exported.AuditRecords[idx], want)
+		}
+	}
+	return ConformanceResult{
+		Materialization: materialization,
+		Bootstrap:       bootstrap,
+		Started:         started,
+		Finished:        finished,
+		Exported:        exported,
+	}, nil
+}
+
+func validateMaterialization(contract Contract, result MaterializeResult, sourceWorkspace string) error {
+	if result.Manifest.TargetKind != contract.TargetKind {
+		return fmt.Errorf("materialization target_kind = %q, want %q", result.Manifest.TargetKind, contract.TargetKind)
+	}
+	if result.Manifest.WorkspaceTransport != contract.WorkspaceTransport {
+		return fmt.Errorf("materialization workspace_transport = %q, want %q", result.Manifest.WorkspaceTransport, contract.WorkspaceTransport)
+	}
+	if result.Manifest.SourceWorkspace != sourceWorkspace {
+		return fmt.Errorf("materialization source_workspace = %q, want %q", result.Manifest.SourceWorkspace, sourceWorkspace)
+	}
+	if _, err := os.Stat(filepath.Join(result.MaterializedWorkspace, ".git")); !os.IsNotExist(err) {
+		return fmt.Errorf("materialized workspace must not contain .git")
+	}
+	mirrorRoot, err := os.MkdirTemp("", "workcell-applecontainer-compare.")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(mirrorRoot)
+	entries, err := copyWorkspaceTree(sourceWorkspace, filepath.Join(mirrorRoot, "workspace"), contract.WorkspaceMaterialization.ExcludedPaths)
+	if err != nil {
+		return err
+	}
+	if !slices.EqualFunc(entries, result.Manifest.Entries, func(a, b WorkspaceEntry) bool {
+		return a.Path == b.Path && a.Kind == b.Kind && a.Mode == b.Mode && a.SHA256 == b.SHA256 && a.LinkTarget == b.LinkTarget
+	}) {
+		return fmt.Errorf("materialization manifest entries do not match copied workspace")
+	}
+	return nil
+}
+
+func validateBootstrap(contract Contract, bootstrap BootstrapResult, c ConformanceCase) error {
+	if bootstrap.Manifest.TargetID != c.TargetID {
+		return fmt.Errorf("bootstrap target_id = %q, want %q", bootstrap.Manifest.TargetID, c.TargetID)
+	}
+	if bootstrap.Manifest.TargetAssuranceClass != contract.TargetAssuranceClass {
+		return fmt.Errorf("bootstrap target_assurance_class = %q, want %q", bootstrap.Manifest.TargetAssuranceClass, contract.TargetAssuranceClass)
+	}
+	if bootstrap.Manifest.SupportBoundary != contract.SupportBoundary {
+		return fmt.Errorf("bootstrap support_boundary = %q, want %q", bootstrap.Manifest.SupportBoundary, contract.SupportBoundary)
+	}
+	if bootstrap.Manifest.AccessModel != contract.AccessModel {
+		return fmt.Errorf("bootstrap access_model = %q, want %q", bootstrap.Manifest.AccessModel, contract.AccessModel)
+	}
+	if bootstrap.Manifest.ImageRef != c.ImageRef {
+		return fmt.Errorf("bootstrap image_ref = %q, want %q", bootstrap.Manifest.ImageRef, c.ImageRef)
+	}
+	return nil
+}
+
+func validateStartedSession(contract Contract, session SessionResult, materialization MaterializeResult, bootstrap BootstrapResult, c ConformanceCase) error {
+	record := session.Record
+	for _, pair := range []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "target_kind", got: record.TargetKind, want: contract.TargetKind},
+		{name: "target_provider", got: record.TargetProvider, want: contract.TargetProvider},
+		{name: "target_id", got: record.TargetID, want: c.TargetID},
+		{name: "target_assurance_class", got: record.TargetAssuranceClass, want: contract.TargetAssuranceClass},
+		{name: "runtime_api", got: record.RuntimeAPI, want: contract.RuntimeAPI},
+		{name: "workspace_transport", got: record.WorkspaceTransport, want: contract.WorkspaceTransport},
+		{name: "workspace", got: record.Workspace, want: materialization.MaterializedWorkspace},
+		{name: "workspace_origin", got: record.WorkspaceOrigin, want: c.SourceWorkspace},
+		{name: "workspace_control_plane", got: record.WorkspaceControlPlane, want: contract.Session.WorkspaceControlPlane},
+		{name: "audit_log_path", got: record.AuditLogPath, want: bootstrap.AuditLogPath},
+		{name: "status", got: record.Status, want: contract.Session.StartStatus},
+	} {
+		if pair.got != pair.want {
+			return fmt.Errorf("started session %s = %q, want %q", pair.name, pair.got, pair.want)
+		}
+	}
+	return nil
+}
+
+func validateFinishedSession(contract Contract, session SessionResult, c ConformanceCase) error {
+	record := session.Record
+	if record.Status != contract.Session.FinalStatus {
+		return fmt.Errorf("finished session status = %q, want %q", record.Status, contract.Session.FinalStatus)
+	}
+	if record.FinishedAt != c.FinishedAt {
+		return fmt.Errorf("finished session finished_at = %q, want %q", record.FinishedAt, c.FinishedAt)
+	}
+	if record.ExitStatus != c.ExitStatus {
+		return fmt.Errorf("finished session exit_status = %q, want %q", record.ExitStatus, c.ExitStatus)
+	}
+	if record.FinalAssurance != contract.Session.Assurance {
+		return fmt.Errorf("finished session final_assurance = %q, want %q", record.FinalAssurance, contract.Session.Assurance)
+	}
+	return nil
+}

--- a/internal/applecontainer/conformance_test.go
+++ b/internal/applecontainer/conformance_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAppleContainerTargetPassesConformance(t *testing.T) {
+	t.Parallel()
+
+	stateRoot := t.TempDir()
+	sourceWorkspace := writeSampleWorkspace(t)
+
+	target, err := NewAppleContainerTarget(Contract{})
+	if err != nil {
+		t.Fatalf("NewAppleContainerTarget() error = %v", err)
+	}
+	contract := DefaultContract()
+	c := DefaultConformanceCase(stateRoot, sourceWorkspace)
+
+	result, err := RunConformance(context.Background(), target, contract, c)
+	if err != nil {
+		t.Fatalf("RunConformance() error = %v", err)
+	}
+
+	if result.Exported.Session.Status != contract.Session.FinalStatus {
+		t.Fatalf("final status = %q, want %q", result.Exported.Session.Status, contract.Session.FinalStatus)
+	}
+	if got, want := len(result.Exported.AuditRecords), len(contract.RequiredAuditEvents); got != want {
+		t.Fatalf("audit records = %d, want %d", got, want)
+	}
+	if result.Started.Record.TargetProvider != Provider {
+		t.Fatalf("session target_provider = %q, want %q", result.Started.Record.TargetProvider, Provider)
+	}
+	if result.Finished.Record.FinalAssurance != contract.Session.Assurance {
+		t.Fatalf("final_assurance = %q, want %q", result.Finished.Record.FinalAssurance, contract.Session.Assurance)
+	}
+	// The materialized workspace must not carry .git (local-materialization audit).
+	if _, err := os.Stat(filepath.Join(result.Materialization.MaterializedWorkspace, ".git")); !os.IsNotExist(err) {
+		t.Fatalf("materialized workspace unexpectedly contains .git")
+	}
+}
+
+func TestRunConformanceRejectsRemoteContract(t *testing.T) {
+	t.Parallel()
+
+	stateRoot := t.TempDir()
+	sourceWorkspace := writeSampleWorkspace(t)
+	target, err := NewAppleContainerTarget(Contract{})
+	if err != nil {
+		t.Fatalf("NewAppleContainerTarget() error = %v", err)
+	}
+	bad := DefaultContract()
+	bad.AccessModel = "brokered"
+
+	if _, err := RunConformance(context.Background(), target, bad, DefaultConformanceCase(stateRoot, sourceWorkspace)); err == nil {
+		t.Fatalf("RunConformance() with brokered access = nil, want error")
+	}
+}
+
+func writeSampleWorkspace(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".git", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("# sample\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}

--- a/internal/applecontainer/contract.go
+++ b/internal/applecontainer/contract.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package applecontainer holds the roadmap C1 evaluation spike for the Apple
+// `container` runtime (macOS 26+). It is deliberately self-contained: it does
+// NOT reuse internal/remotevm's remote-VM Contract, whose Validate() hardcodes
+// brokered, remote-materialization semantics that are wrong for a local
+// per-session VM. Apple `container` boots one lightweight Virtualization.framework
+// VM per container (its own Linux kernel, hostname, NIC and block device), so the
+// contract here describes a LOCAL VM with direct (non-brokered) access and local
+// workspace materialization while still asserting the same session-lifecycle
+// audit events and status transitions the remote-VM contract requires.
+package applecontainer
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+const (
+	// TargetKind classifies the Apple `container` target as a local VM, matching
+	// the policy/host-support-matrix.tsv target_kind column.
+	TargetKind = "local_vm"
+	// Provider is the canonical support-matrix provider slug for Apple container.
+	Provider = "apple-container"
+	// AssuranceClass names the per-session-VM assurance tier: unlike Colima's one
+	// shared VM kernel for all sessions, every session gets its own VM boundary.
+	AssuranceClass = "per-session-vm"
+	// SupportBoundary keeps C1 support-invisible: it is an evaluation preview.
+	SupportBoundary = "preview-only"
+	// RuntimeAPI is the local `container` CLI, not a brokered remote transport.
+	RuntimeAPI = "local-cli"
+	// WorkspaceTransport materializes the workspace on the local host filesystem.
+	WorkspaceTransport = "local-materialization"
+	// AccessModel is direct: the session talks to a local VM, not through a broker.
+	AccessModel = "direct"
+
+	MaterializationMode  = "explicit"
+	MaterializationFile  = "materialization.json"
+	MaterializedWorktree = "workspace"
+	BootstrapFile        = "bootstrap.json"
+	// WorkspaceControl records that the host drives the local workspace directly.
+	WorkspaceControl   = "host-local"
+	SessionStartStatus = "running"
+	SessionFinalStatus = "exited"
+	SessionAssurance   = "per-session-vm-preview-direct"
+)
+
+var requiredAuditEvents = []string{
+	"workspace_materialized",
+	"bootstrap_ready",
+	"session_started",
+	"session_finished",
+}
+
+// RequiredAuditEvents returns a copy of the audit events every conformant Apple
+// container session must emit, in lifecycle order.
+func RequiredAuditEvents() []string {
+	return append([]string(nil), requiredAuditEvents...)
+}
+
+// Contract is the local-VM conformance contract for the Apple `container`
+// backend. It is a distinct type from remotevm.Contract on purpose.
+type Contract struct {
+	Version                  int                          `json:"version"`
+	TargetKind               string                       `json:"target_kind"`
+	TargetProvider           string                       `json:"target_provider"`
+	TargetAssuranceClass     string                       `json:"target_assurance_class"`
+	SupportBoundary          string                       `json:"support_boundary"`
+	RuntimeAPI               string                       `json:"runtime_api"`
+	WorkspaceTransport       string                       `json:"workspace_transport"`
+	AccessModel              string                       `json:"access_model"`
+	WorkspaceMaterialization WorkspaceMaterializationSpec `json:"workspace_materialization"`
+	Bootstrap                BootstrapSpec                `json:"bootstrap"`
+	Session                  SessionSpec                  `json:"session"`
+	RequiredAuditEvents      []string                     `json:"required_audit_events"`
+}
+
+type WorkspaceMaterializationSpec struct {
+	Mode          string   `json:"mode"`
+	ManifestName  string   `json:"manifest_name"`
+	WorkspaceDir  string   `json:"workspace_dir"`
+	ExcludedPaths []string `json:"excluded_paths"`
+}
+
+type BootstrapSpec struct {
+	ManifestName string `json:"manifest_name"`
+}
+
+type SessionSpec struct {
+	WorkspaceControlPlane string `json:"workspace_control_plane"`
+	StartStatus           string `json:"start_status"`
+	FinalStatus           string `json:"final_status"`
+	Assurance             string `json:"assurance"`
+}
+
+// DefaultContract returns the canonical Apple-container local-VM contract.
+func DefaultContract() Contract {
+	return Contract{
+		Version:              1,
+		TargetKind:           TargetKind,
+		TargetProvider:       Provider,
+		TargetAssuranceClass: AssuranceClass,
+		SupportBoundary:      SupportBoundary,
+		RuntimeAPI:           RuntimeAPI,
+		WorkspaceTransport:   WorkspaceTransport,
+		AccessModel:          AccessModel,
+		WorkspaceMaterialization: WorkspaceMaterializationSpec{
+			Mode:          MaterializationMode,
+			ManifestName:  MaterializationFile,
+			WorkspaceDir:  MaterializedWorktree,
+			ExcludedPaths: []string{".git"},
+		},
+		Bootstrap: BootstrapSpec{
+			ManifestName: BootstrapFile,
+		},
+		Session: SessionSpec{
+			WorkspaceControlPlane: WorkspaceControl,
+			StartStatus:           SessionStartStatus,
+			FinalStatus:           SessionFinalStatus,
+			Assurance:             SessionAssurance,
+		},
+		RequiredAuditEvents: RequiredAuditEvents(),
+	}
+}
+
+// Validate fails closed unless the contract exactly describes the local-VM
+// Apple-container semantics. It intentionally rejects brokered/remote values so
+// a remote-VM contract cannot masquerade as an Apple-container one.
+func (c Contract) Validate() error {
+	if c.Version != 1 {
+		return fmt.Errorf("unsupported apple-container contract version %d", c.Version)
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "target_kind", value: c.TargetKind, want: TargetKind},
+		{name: "target_provider", value: c.TargetProvider, want: Provider},
+		{name: "target_assurance_class", value: c.TargetAssuranceClass, want: AssuranceClass},
+		{name: "support_boundary", value: c.SupportBoundary, want: SupportBoundary},
+		{name: "runtime_api", value: c.RuntimeAPI, want: RuntimeAPI},
+		{name: "workspace_transport", value: c.WorkspaceTransport, want: WorkspaceTransport},
+		{name: "access_model", value: c.AccessModel, want: AccessModel},
+		{name: "workspace_materialization.mode", value: c.WorkspaceMaterialization.Mode, want: MaterializationMode},
+		{name: "workspace_materialization.manifest_name", value: c.WorkspaceMaterialization.ManifestName, want: MaterializationFile},
+		{name: "workspace_materialization.workspace_dir", value: c.WorkspaceMaterialization.WorkspaceDir, want: MaterializedWorktree},
+		{name: "bootstrap.manifest_name", value: c.Bootstrap.ManifestName, want: BootstrapFile},
+		{name: "session.workspace_control_plane", value: c.Session.WorkspaceControlPlane, want: WorkspaceControl},
+		{name: "session.start_status", value: c.Session.StartStatus, want: SessionStartStatus},
+		{name: "session.final_status", value: c.Session.FinalStatus, want: SessionFinalStatus},
+		{name: "session.assurance", value: c.Session.Assurance, want: SessionAssurance},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("%s may not be empty", field.name)
+		}
+		if field.value != field.want {
+			return fmt.Errorf("%s must be %q, got %q", field.name, field.want, field.value)
+		}
+	}
+	if !slices.Equal(c.WorkspaceMaterialization.ExcludedPaths, []string{".git"}) {
+		return fmt.Errorf("workspace_materialization.excluded_paths must be [\".git\"]")
+	}
+	if !slices.Equal(c.RequiredAuditEvents, requiredAuditEvents) {
+		return fmt.Errorf("required_audit_events must be %v", requiredAuditEvents)
+	}
+	return nil
+}

--- a/internal/applecontainer/contract_test.go
+++ b/internal/applecontainer/contract_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultContractValidates(t *testing.T) {
+	t.Parallel()
+
+	contract := DefaultContract()
+	if err := contract.Validate(); err != nil {
+		t.Fatalf("DefaultContract().Validate() error = %v", err)
+	}
+	if contract.TargetKind != "local_vm" {
+		t.Fatalf("target_kind = %q, want local_vm", contract.TargetKind)
+	}
+	if contract.TargetProvider != "apple-container" {
+		t.Fatalf("target_provider = %q, want apple-container", contract.TargetProvider)
+	}
+	if contract.AccessModel != "direct" {
+		t.Fatalf("access_model = %q, want direct (non-brokered)", contract.AccessModel)
+	}
+	if contract.WorkspaceTransport != "local-materialization" {
+		t.Fatalf("workspace_transport = %q, want local-materialization", contract.WorkspaceTransport)
+	}
+}
+
+func TestContractValidateRejectsRemoteValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		mutate  func(*Contract)
+		wantSub string
+	}{
+		{
+			name:    "brokered access is a remote-VM value",
+			mutate:  func(c *Contract) { c.AccessModel = "brokered" },
+			wantSub: "access_model",
+		},
+		{
+			name:    "remote_vm target kind rejected",
+			mutate:  func(c *Contract) { c.TargetKind = "remote_vm" },
+			wantSub: "target_kind",
+		},
+		{
+			name:    "remote materialization transport rejected",
+			mutate:  func(c *Contract) { c.WorkspaceTransport = "remote-materialization" },
+			wantSub: "workspace_transport",
+		},
+		{
+			name:    "wrong version rejected",
+			mutate:  func(c *Contract) { c.Version = 2 },
+			wantSub: "version",
+		},
+		{
+			name:    "excluded paths must be .git",
+			mutate:  func(c *Contract) { c.WorkspaceMaterialization.ExcludedPaths = nil },
+			wantSub: "excluded_paths",
+		},
+		{
+			name:    "audit events must match lifecycle",
+			mutate:  func(c *Contract) { c.RequiredAuditEvents = []string{"session_started"} },
+			wantSub: "required_audit_events",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			contract := DefaultContract()
+			tc.mutate(&contract)
+			err := contract.Validate()
+			if err == nil {
+				t.Fatalf("Validate() error = nil, want error containing %q", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("Validate() error = %v, want substring %q", err, tc.wantSub)
+			}
+		})
+	}
+}

--- a/internal/applecontainer/guard.go
+++ b/internal/applecontainer/guard.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// MinimumMajorVersion is the lowest macOS major version the Apple `container`
+// backend targets. C1 fails closed below it.
+const MinimumMajorVersion = 26
+
+// RequireMacOS26 fails closed unless the host is macOS 26 or newer. It is the
+// exit gate for the Apple-container evaluation: on any other OS, or on macOS
+// below 26, it returns an error rather than proceeding.
+func RequireMacOS26() error {
+	return requireMacOS26(runtime.GOOS, swVersProductVersion)
+}
+
+// requireMacOS26 is the testable core of RequireMacOS26: goos is the runtime OS
+// and productVersion reports the macOS product version string (e.g. "26.5.1").
+func requireMacOS26(goos string, productVersion func() (string, error)) error {
+	if goos != "darwin" {
+		return fmt.Errorf("apple container requires macOS %d+, host OS is %q", MinimumMajorVersion, goos)
+	}
+	version, err := productVersion()
+	if err != nil {
+		return fmt.Errorf("apple container requires macOS %d+: %w", MinimumMajorVersion, err)
+	}
+	major, err := majorVersion(version)
+	if err != nil {
+		return fmt.Errorf("apple container requires macOS %d+: %w", MinimumMajorVersion, err)
+	}
+	if major < MinimumMajorVersion {
+		return fmt.Errorf("apple container requires macOS %d+, host is macOS %s", MinimumMajorVersion, version)
+	}
+	return nil
+}
+
+// majorVersion parses the leading integer of a dotted version string.
+func majorVersion(version string) (int, error) {
+	trimmed := strings.TrimSpace(version)
+	if trimmed == "" {
+		return 0, fmt.Errorf("empty macOS product version")
+	}
+	head, _, _ := strings.Cut(trimmed, ".")
+	major, err := strconv.Atoi(strings.TrimSpace(head))
+	if err != nil {
+		return 0, fmt.Errorf("unparseable macOS product version %q", version)
+	}
+	return major, nil
+}
+
+// swVersProductVersion shells out to `sw_vers -productVersion`.
+func swVersProductVersion() (string, error) {
+	out, err := exec.Command("sw_vers", "-productVersion").Output()
+	if err != nil {
+		return "", fmt.Errorf("sw_vers -productVersion: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/applecontainer/guard_test.go
+++ b/internal/applecontainer/guard_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRequireMacOS26(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		goos    string
+		version string
+		verErr  error
+		wantErr bool
+	}{
+		{name: "macos 26 ok", goos: "darwin", version: "26.5.1", wantErr: false},
+		{name: "macos 27 ok", goos: "darwin", version: "27.0", wantErr: false},
+		{name: "macos 25 fails", goos: "darwin", version: "25.5.0", wantErr: true},
+		{name: "macos 15 fails", goos: "darwin", version: "15.4", wantErr: true},
+		{name: "linux fails", goos: "linux", version: "26.0", wantErr: true},
+		{name: "windows fails", goos: "windows", version: "26.0", wantErr: true},
+		{name: "unparseable version fails", goos: "darwin", version: "sequoia", wantErr: true},
+		{name: "sw_vers error fails", goos: "darwin", verErr: fmt.Errorf("boom"), wantErr: true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := requireMacOS26(tc.goos, func() (string, error) {
+				return tc.version, tc.verErr
+			})
+			if tc.wantErr && err == nil {
+				t.Fatalf("requireMacOS26(%q, %q) = nil, want error", tc.goos, tc.version)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("requireMacOS26(%q, %q) = %v, want nil", tc.goos, tc.version, err)
+			}
+		})
+	}
+}

--- a/internal/applecontainer/probe.go
+++ b/internal/applecontainer/probe.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ErrAppleContainerUnavailable is the skip sentinel returned by
+// ProbeAppleContainer when the `container` CLI is absent or its system service
+// is not running. Callers (and CI on non-macOS-26 hosts) should treat it as a
+// graceful skip, not a failure.
+var ErrAppleContainerUnavailable = errors.New("apple container runtime unavailable")
+
+// probeImage is the small Linux image booted to exercise per-VM isolation.
+const probeImage = "alpine"
+
+// bootSampleCount is the number of warm timed boots taken for latency evidence.
+const bootSampleCount = 3
+
+// Evidence is the structured result of a live Apple-container probe.
+type Evidence struct {
+	Available        bool            `json:"available"`
+	ContainerVersion string          `json:"container_version"`
+	BootSamples      []time.Duration `json:"boot_samples"`
+	MedianBoot       time.Duration   `json:"median_boot"`
+	GuestKernel      string          `json:"guest_kernel"`
+	GuestHostname    string          `json:"guest_hostname"`
+	HostKernel       string          `json:"host_kernel"`
+	HostHostname     string          `json:"host_hostname"`
+	PerVMKernel      bool            `json:"per_vm_kernel"`
+	PerVMHostname    bool            `json:"per_vm_hostname"`
+	PerVMNIC         bool            `json:"per_vm_nic"`
+	PerVMBlockDevice bool            `json:"per_vm_block_device"`
+	Raw              string          `json:"raw"`
+}
+
+var (
+	inetRE       = regexp.MustCompile(`inet\s+192\.168\.64\.\d+`)
+	rootMountRE  = regexp.MustCompile(`/dev/vd\w+\s+on\s+/\s+type\s+ext4`)
+	kernelLineRE = regexp.MustCompile(`^\d+\.\d+\.\d+`)
+)
+
+// ProbeAppleContainer shells out to the live `container` CLI to gather boot
+// latency and per-VM isolation evidence. It returns ErrAppleContainerUnavailable
+// (wrapped) when the runtime is absent or its service is stopped, so it skips
+// gracefully on hosts without Apple container.
+func ProbeAppleContainer(ctx context.Context) (Evidence, error) {
+	bin, err := exec.LookPath("container")
+	if err != nil {
+		return Evidence{}, fmt.Errorf("%w: container CLI not found in PATH", ErrAppleContainerUnavailable)
+	}
+
+	statusOut, err := runContainer(ctx, bin, "system", "status")
+	if err != nil || !strings.Contains(statusOut, "running") {
+		return Evidence{}, fmt.Errorf("%w: `container system status` did not report running", ErrAppleContainerUnavailable)
+	}
+
+	evidence := Evidence{Available: true}
+	evidence.ContainerVersion = containerVersion(ctx, bin)
+	evidence.HostKernel = hostKernel()
+	evidence.HostHostname, _ = os.Hostname()
+
+	// Warm the image+kernel cache so boot samples measure steady-state latency
+	// rather than a one-off image fetch.
+	if _, err := runContainer(ctx, bin, "run", "--rm", probeImage, "true"); err != nil {
+		return Evidence{}, fmt.Errorf("warm-up `container run` failed: %w", err)
+	}
+
+	for i := 0; i < bootSampleCount; i++ {
+		start := time.Now()
+		if _, err := runContainer(ctx, bin, "run", "--rm", probeImage, "true"); err != nil {
+			return Evidence{}, fmt.Errorf("boot sample `container run` failed: %w", err)
+		}
+		evidence.BootSamples = append(evidence.BootSamples, time.Since(start))
+	}
+	evidence.MedianBoot = medianDuration(evidence.BootSamples)
+
+	inspect, err := runContainer(ctx, bin, "run", "--rm", probeImage, "sh", "-c",
+		"uname -r; echo HOSTNAME=$(hostname); ip addr; echo ---MOUNT---; mount")
+	if err != nil {
+		return Evidence{}, fmt.Errorf("inspection `container run` failed: %w", err)
+	}
+	evidence.Raw = inspect
+	populateIsolation(&evidence, inspect)
+
+	return evidence, nil
+}
+
+// populateIsolation parses one inspection run's stdout into the isolation
+// booleans and guest identity fields.
+func populateIsolation(evidence *Evidence, inspect string) {
+	lines := strings.Split(inspect, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		switch {
+		case evidence.GuestKernel == "" && kernelLineRE.MatchString(line):
+			evidence.GuestKernel = line
+		case strings.HasPrefix(line, "HOSTNAME="):
+			evidence.GuestHostname = strings.TrimPrefix(line, "HOSTNAME=")
+		}
+	}
+	// A guest kernel that differs from the macOS host kernel proves the container
+	// ran its own Linux kernel rather than sharing the host's.
+	evidence.PerVMKernel = evidence.GuestKernel != "" && evidence.GuestKernel != evidence.HostKernel
+	evidence.PerVMHostname = evidence.GuestHostname != "" && evidence.GuestHostname != evidence.HostHostname
+	evidence.PerVMNIC = inetRE.MatchString(inspect)
+	evidence.PerVMBlockDevice = rootMountRE.MatchString(inspect)
+}
+
+func containerVersion(ctx context.Context, bin string) string {
+	out, err := runContainer(ctx, bin, "--version")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(strings.SplitN(out, "\n", 2)[0])
+}
+
+// runContainer runs the container CLI and returns its stdout. Progress output is
+// written by the CLI to stderr and is intentionally discarded.
+func runContainer(ctx context.Context, bin string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, bin, args...)
+	out, err := cmd.Output()
+	return string(out), err
+}
+
+func hostKernel() string {
+	out, err := exec.Command("uname", "-r").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func medianDuration(samples []time.Duration) time.Duration {
+	if len(samples) == 0 {
+		return 0
+	}
+	sorted := append([]time.Duration(nil), samples...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	return sorted[len(sorted)/2]
+}

--- a/internal/applecontainer/probe_test.go
+++ b/internal/applecontainer/probe_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+// lightweightVMBootCeiling is a robust upper bound proving the per-container
+// lightweight-VM model. Steady-state warm boot on an idle macOS 26 host is
+// sub-second (~0.77s, see the strict test below), but wall-clock boot inflates
+// under the CPU contention of a parallel `go test ./...` run. The ceiling stays
+// an order of magnitude below Colima's shared-VM cold boot (tens of seconds)
+// while remaining non-flaky under that contention.
+const lightweightVMBootCeiling = 15 * time.Second
+
+func TestProbeAppleContainer(t *testing.T) {
+	// Not parallel: booting VMs is resource-sensitive.
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	evidence, err := ProbeAppleContainer(ctx)
+	if errors.Is(err, ErrAppleContainerUnavailable) {
+		t.Skipf("apple container unavailable, skipping live probe: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("ProbeAppleContainer() error = %v", err)
+	}
+
+	if !evidence.Available {
+		t.Fatalf("evidence.Available = false, want true")
+	}
+	if len(evidence.BootSamples) == 0 {
+		t.Fatalf("no boot samples captured")
+	}
+	if evidence.MedianBoot <= 0 || evidence.MedianBoot >= lightweightVMBootCeiling {
+		t.Fatalf("median boot = %v, want positive and < %v (lightweight per-container VM)", evidence.MedianBoot, lightweightVMBootCeiling)
+	}
+	if !evidence.PerVMKernel {
+		t.Fatalf("PerVMKernel = false (guest kernel %q, host kernel %q), want own Linux kernel", evidence.GuestKernel, evidence.HostKernel)
+	}
+	if !evidence.PerVMHostname {
+		t.Fatalf("PerVMHostname = false (guest %q, host %q), want per-VM hostname", evidence.GuestHostname, evidence.HostHostname)
+	}
+	if !evidence.PerVMNIC {
+		t.Fatalf("PerVMNIC = false, want own VM NIC (192.168.64.x); raw:\n%s", evidence.Raw)
+	}
+	if !evidence.PerVMBlockDevice {
+		t.Fatalf("PerVMBlockDevice = false, want ext4 /dev/vd* rootfs; raw:\n%s", evidence.Raw)
+	}
+	t.Logf("apple container %s: median boot %v (min %v) over %d samples; guest kernel %s (host %s); guest hostname %s",
+		evidence.ContainerVersion, evidence.MedianBoot, minDuration(evidence.BootSamples), len(evidence.BootSamples), evidence.GuestKernel, evidence.HostKernel, evidence.GuestHostname)
+}
+
+// TestProbeAppleContainerSubSecondBoot asserts the sub-second steady-state boot
+// claim. It is opt-in (set WORKCELL_APPLECONTAINER_STRICT_BOOT=1) and meant to
+// run serially on an otherwise-idle host, since wall-clock boot latency is
+// dominated by host CPU contention and would flake inside a parallel suite.
+func TestProbeAppleContainerSubSecondBoot(t *testing.T) {
+	if os.Getenv("WORKCELL_APPLECONTAINER_STRICT_BOOT") == "" {
+		t.Skip("set WORKCELL_APPLECONTAINER_STRICT_BOOT=1 to assert sub-second boot on an idle host")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	evidence, err := ProbeAppleContainer(ctx)
+	if errors.Is(err, ErrAppleContainerUnavailable) {
+		t.Skipf("apple container unavailable: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("ProbeAppleContainer() error = %v", err)
+	}
+	best := minDuration(evidence.BootSamples)
+	if best <= 0 || best >= time.Second {
+		t.Fatalf("fastest warm boot = %v, want sub-second", best)
+	}
+	t.Logf("sub-second boot confirmed: fastest warm boot %v, median %v", best, evidence.MedianBoot)
+}
+
+func minDuration(samples []time.Duration) time.Duration {
+	if len(samples) == 0 {
+		return 0
+	}
+	best := samples[0]
+	for _, s := range samples[1:] {
+		if s < best {
+			best = s
+		}
+	}
+	return best
+}

--- a/internal/applecontainer/target.go
+++ b/internal/applecontainer/target.go
@@ -1,0 +1,511 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/host/sessions"
+)
+
+// WorkspaceEntry is one materialized workspace path recorded in the manifest.
+type WorkspaceEntry struct {
+	Path       string      `json:"path"`
+	Kind       string      `json:"kind"`
+	Mode       fs.FileMode `json:"mode"`
+	SHA256     string      `json:"sha256,omitempty"`
+	LinkTarget string      `json:"link_target,omitempty"`
+}
+
+// WorkspaceManifest records a local materialization of the source workspace.
+type WorkspaceManifest struct {
+	Version               int              `json:"version"`
+	TargetKind            string           `json:"target_kind"`
+	TargetProvider        string           `json:"target_provider"`
+	TargetID              string           `json:"target_id"`
+	WorkspaceTransport    string           `json:"workspace_transport"`
+	SourceWorkspace       string           `json:"source_workspace"`
+	MaterializationID     string           `json:"materialization_id"`
+	MaterializedWorkspace string           `json:"materialized_workspace"`
+	ExcludedPaths         []string         `json:"excluded_paths"`
+	Entries               []WorkspaceEntry `json:"entries"`
+}
+
+// BootstrapManifest records the per-session VM bootstrap parameters.
+type BootstrapManifest struct {
+	Version              int    `json:"version"`
+	TargetKind           string `json:"target_kind"`
+	TargetProvider       string `json:"target_provider"`
+	TargetID             string `json:"target_id"`
+	TargetAssuranceClass string `json:"target_assurance_class"`
+	SupportBoundary      string `json:"support_boundary"`
+	RuntimeAPI           string `json:"runtime_api"`
+	AccessModel          string `json:"access_model"`
+	BootstrapID          string `json:"bootstrap_id"`
+	ImageRef             string `json:"image_ref"`
+}
+
+type MaterializeRequest struct {
+	StateRoot         string
+	TargetID          string
+	MaterializationID string
+	SourceWorkspace   string
+}
+
+type MaterializeResult struct {
+	TargetRoot            string
+	MaterializationRoot   string
+	ManifestPath          string
+	MaterializedWorkspace string
+	Manifest              WorkspaceManifest
+}
+
+type BootstrapRequest struct {
+	StateRoot   string
+	TargetID    string
+	BootstrapID string
+	ImageRef    string
+}
+
+type BootstrapResult struct {
+	TargetRoot   string
+	ManifestPath string
+	AuditLogPath string
+	Manifest     BootstrapManifest
+}
+
+type StartSessionRequest struct {
+	SessionID       string
+	Agent           string
+	Mode            string
+	StartedAt       string
+	Materialization MaterializeResult
+	Bootstrap       BootstrapResult
+}
+
+type FinishSessionRequest struct {
+	Started    SessionResult
+	FinishedAt string
+	ExitStatus string
+}
+
+type SessionResult struct {
+	Record       sessions.SessionRecord
+	RecordPath   string
+	AuditLogPath string
+}
+
+// ConformanceTarget is the session-lifecycle interface the conformance harness
+// drives. It mirrors the four-phase remote-VM lifecycle but with local-VM types.
+type ConformanceTarget interface {
+	MaterializeWorkspace(context.Context, MaterializeRequest) (MaterializeResult, error)
+	BootstrapTarget(context.Context, BootstrapRequest) (BootstrapResult, error)
+	StartSession(context.Context, StartSessionRequest) (SessionResult, error)
+	FinishSession(context.Context, FinishSessionRequest) (SessionResult, error)
+}
+
+// AppleContainerTarget is a deterministic, filesystem-backed implementation of
+// the lifecycle used to prove contract conformance without booting a live VM.
+type AppleContainerTarget struct {
+	Contract Contract
+}
+
+// NewAppleContainerTarget builds a deterministic target from the given contract,
+// defaulting to DefaultContract() for the zero value.
+func NewAppleContainerTarget(contract Contract) (AppleContainerTarget, error) {
+	if contract.Version == 0 &&
+		contract.TargetKind == "" &&
+		contract.TargetProvider == "" &&
+		contract.TargetAssuranceClass == "" {
+		contract = DefaultContract()
+	}
+	if err := contract.Validate(); err != nil {
+		return AppleContainerTarget{}, err
+	}
+	return AppleContainerTarget{Contract: contract}, nil
+}
+
+func (t AppleContainerTarget) MaterializeWorkspace(_ context.Context, req MaterializeRequest) (MaterializeResult, error) {
+	if strings.TrimSpace(req.StateRoot) == "" {
+		return MaterializeResult{}, fmt.Errorf("state root is required")
+	}
+	targetProvider, err := statePathSegment("target provider", t.Contract.TargetProvider)
+	if err != nil {
+		return MaterializeResult{}, err
+	}
+	targetID, err := statePathSegment("target id", req.TargetID)
+	if err != nil {
+		return MaterializeResult{}, err
+	}
+	materializationID, err := statePathSegment("materialization id", req.MaterializationID)
+	if err != nil {
+		return MaterializeResult{}, err
+	}
+	if strings.TrimSpace(req.SourceWorkspace) == "" {
+		return MaterializeResult{}, fmt.Errorf("source workspace is required")
+	}
+	root := targetRoot(req.StateRoot, t.Contract.TargetKind, targetProvider, targetID)
+	materializationRoot := filepath.Join(root, "materializations", materializationID)
+	workspaceRoot := filepath.Join(materializationRoot, t.Contract.WorkspaceMaterialization.WorkspaceDir)
+	manifestPath := filepath.Join(materializationRoot, t.Contract.WorkspaceMaterialization.ManifestName)
+	if err := os.RemoveAll(materializationRoot); err != nil {
+		return MaterializeResult{}, err
+	}
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		return MaterializeResult{}, err
+	}
+	entries, err := copyWorkspaceTree(req.SourceWorkspace, workspaceRoot, t.Contract.WorkspaceMaterialization.ExcludedPaths)
+	if err != nil {
+		return MaterializeResult{}, err
+	}
+	manifest := WorkspaceManifest{
+		Version:               1,
+		TargetKind:            t.Contract.TargetKind,
+		TargetProvider:        t.Contract.TargetProvider,
+		TargetID:              targetID,
+		WorkspaceTransport:    t.Contract.WorkspaceTransport,
+		SourceWorkspace:       req.SourceWorkspace,
+		MaterializationID:     materializationID,
+		MaterializedWorkspace: workspaceRoot,
+		ExcludedPaths:         append([]string(nil), t.Contract.WorkspaceMaterialization.ExcludedPaths...),
+		Entries:               entries,
+	}
+	if err := writeJSON(manifestPath, manifest); err != nil {
+		return MaterializeResult{}, err
+	}
+	return MaterializeResult{
+		TargetRoot:            root,
+		MaterializationRoot:   materializationRoot,
+		ManifestPath:          manifestPath,
+		MaterializedWorkspace: workspaceRoot,
+		Manifest:              manifest,
+	}, nil
+}
+
+func (t AppleContainerTarget) BootstrapTarget(_ context.Context, req BootstrapRequest) (BootstrapResult, error) {
+	if strings.TrimSpace(req.StateRoot) == "" {
+		return BootstrapResult{}, fmt.Errorf("state root is required")
+	}
+	targetProvider, err := statePathSegment("target provider", t.Contract.TargetProvider)
+	if err != nil {
+		return BootstrapResult{}, err
+	}
+	targetID, err := statePathSegment("target id", req.TargetID)
+	if err != nil {
+		return BootstrapResult{}, err
+	}
+	if strings.TrimSpace(req.BootstrapID) == "" {
+		return BootstrapResult{}, fmt.Errorf("bootstrap id is required")
+	}
+	if strings.TrimSpace(req.ImageRef) == "" {
+		return BootstrapResult{}, fmt.Errorf("image ref is required")
+	}
+	root := targetRoot(req.StateRoot, t.Contract.TargetKind, targetProvider, targetID)
+	bootstrapRoot := filepath.Join(root, "bootstrap")
+	if err := os.MkdirAll(bootstrapRoot, 0o755); err != nil {
+		return BootstrapResult{}, err
+	}
+	manifestPath := filepath.Join(bootstrapRoot, t.Contract.Bootstrap.ManifestName)
+	manifest := BootstrapManifest{
+		Version:              1,
+		TargetKind:           t.Contract.TargetKind,
+		TargetProvider:       t.Contract.TargetProvider,
+		TargetID:             targetID,
+		TargetAssuranceClass: t.Contract.TargetAssuranceClass,
+		SupportBoundary:      t.Contract.SupportBoundary,
+		RuntimeAPI:           t.Contract.RuntimeAPI,
+		AccessModel:          t.Contract.AccessModel,
+		BootstrapID:          req.BootstrapID,
+		ImageRef:             req.ImageRef,
+	}
+	if err := writeJSON(manifestPath, manifest); err != nil {
+		return BootstrapResult{}, err
+	}
+	return BootstrapResult{
+		TargetRoot:   root,
+		ManifestPath: manifestPath,
+		AuditLogPath: filepath.Join(root, "workcell.audit.log"),
+		Manifest:     manifest,
+	}, nil
+}
+
+func (t AppleContainerTarget) StartSession(_ context.Context, req StartSessionRequest) (SessionResult, error) {
+	sessionID, err := statePathSegment("session id", req.SessionID)
+	if err != nil {
+		return SessionResult{}, err
+	}
+	if strings.TrimSpace(req.Agent) == "" {
+		return SessionResult{}, fmt.Errorf("agent is required")
+	}
+	if strings.TrimSpace(req.Mode) == "" {
+		return SessionResult{}, fmt.Errorf("mode is required")
+	}
+	if strings.TrimSpace(req.StartedAt) == "" {
+		return SessionResult{}, fmt.Errorf("started at is required")
+	}
+	if _, err := os.Stat(req.Materialization.ManifestPath); err != nil {
+		return SessionResult{}, err
+	}
+	if _, err := os.Stat(req.Bootstrap.ManifestPath); err != nil {
+		return SessionResult{}, err
+	}
+	recordPath := filepath.Join(req.Bootstrap.TargetRoot, "sessions", sessionID+".json")
+	record := sessions.SessionRecord{
+		Version:               1,
+		SessionID:             sessionID,
+		Profile:               req.Bootstrap.Manifest.TargetID,
+		TargetKind:            t.Contract.TargetKind,
+		TargetProvider:        t.Contract.TargetProvider,
+		TargetID:              req.Bootstrap.Manifest.TargetID,
+		TargetAssuranceClass:  t.Contract.TargetAssuranceClass,
+		RuntimeAPI:            t.Contract.RuntimeAPI,
+		WorkspaceTransport:    t.Contract.WorkspaceTransport,
+		Agent:                 req.Agent,
+		Mode:                  req.Mode,
+		Status:                t.Contract.Session.StartStatus,
+		Workspace:             req.Materialization.MaterializedWorkspace,
+		WorkspaceOrigin:       req.Materialization.Manifest.SourceWorkspace,
+		WorkspaceRoot:         req.Materialization.MaterializedWorkspace,
+		WorktreePath:          req.Materialization.MaterializedWorkspace,
+		AuditLogPath:          req.Bootstrap.AuditLogPath,
+		StartedAt:             req.StartedAt,
+		ObservedAt:            req.StartedAt,
+		InitialAssurance:      t.Contract.Session.Assurance,
+		CurrentAssurance:      t.Contract.Session.Assurance,
+		WorkspaceControlPlane: t.Contract.Session.WorkspaceControlPlane,
+	}
+	if err := sessions.WriteSessionRecord(recordPath, map[string]string{
+		"session_id":              record.SessionID,
+		"profile":                 record.Profile,
+		"target_kind":             record.TargetKind,
+		"target_provider":         record.TargetProvider,
+		"target_id":               record.TargetID,
+		"target_assurance_class":  record.TargetAssuranceClass,
+		"runtime_api":             record.RuntimeAPI,
+		"workspace_transport":     record.WorkspaceTransport,
+		"agent":                   record.Agent,
+		"mode":                    record.Mode,
+		"status":                  record.Status,
+		"workspace":               record.Workspace,
+		"workspace_origin":        record.WorkspaceOrigin,
+		"workspace_root":          record.WorkspaceRoot,
+		"worktree_path":           record.WorktreePath,
+		"audit_log_path":          record.AuditLogPath,
+		"started_at":              record.StartedAt,
+		"observed_at":             record.ObservedAt,
+		"initial_assurance":       record.InitialAssurance,
+		"current_assurance":       record.CurrentAssurance,
+		"workspace_control_plane": record.WorkspaceControlPlane,
+	}); err != nil {
+		return SessionResult{}, err
+	}
+	for _, line := range []string{
+		fmt.Sprintf("ts=%s session_id=%s event=workspace_materialized target_kind=%s target_provider=%s target_id=%s workspace_transport=%s materialization_id=%s workspace_origin=%s workspace=%s", req.StartedAt, sessionID, t.Contract.TargetKind, t.Contract.TargetProvider, req.Bootstrap.Manifest.TargetID, t.Contract.WorkspaceTransport, req.Materialization.Manifest.MaterializationID, req.Materialization.Manifest.SourceWorkspace, req.Materialization.MaterializedWorkspace),
+		fmt.Sprintf("ts=%s session_id=%s event=bootstrap_ready target_kind=%s target_provider=%s target_id=%s runtime_api=%s access_model=%s bootstrap_id=%s image_ref=%s", req.StartedAt, sessionID, t.Contract.TargetKind, t.Contract.TargetProvider, req.Bootstrap.Manifest.TargetID, t.Contract.RuntimeAPI, t.Contract.AccessModel, req.Bootstrap.Manifest.BootstrapID, req.Bootstrap.Manifest.ImageRef),
+		fmt.Sprintf("ts=%s session_id=%s event=session_started target_kind=%s target_provider=%s target_id=%s status=%s workspace_control_plane=%s", req.StartedAt, sessionID, t.Contract.TargetKind, t.Contract.TargetProvider, req.Bootstrap.Manifest.TargetID, t.Contract.Session.StartStatus, t.Contract.Session.WorkspaceControlPlane),
+	} {
+		if err := appendAuditLine(req.Bootstrap.AuditLogPath, line); err != nil {
+			return SessionResult{}, err
+		}
+	}
+	record, err = sessions.ReadSessionRecord(recordPath)
+	if err != nil {
+		return SessionResult{}, err
+	}
+	return SessionResult{Record: record, RecordPath: recordPath, AuditLogPath: req.Bootstrap.AuditLogPath}, nil
+}
+
+func (t AppleContainerTarget) FinishSession(_ context.Context, req FinishSessionRequest) (SessionResult, error) {
+	if strings.TrimSpace(req.FinishedAt) == "" {
+		return SessionResult{}, fmt.Errorf("finished at is required")
+	}
+	if strings.TrimSpace(req.ExitStatus) == "" {
+		return SessionResult{}, fmt.Errorf("exit status is required")
+	}
+	if req.Started.RecordPath == "" {
+		return SessionResult{}, fmt.Errorf("started session record path is required")
+	}
+	if err := sessions.WriteSessionRecord(req.Started.RecordPath, map[string]string{
+		"status":            t.Contract.Session.FinalStatus,
+		"live_status":       "stopped",
+		"observed_at":       req.FinishedAt,
+		"finished_at":       req.FinishedAt,
+		"exit_status":       req.ExitStatus,
+		"final_assurance":   t.Contract.Session.Assurance,
+		"current_assurance": t.Contract.Session.Assurance,
+	}); err != nil {
+		return SessionResult{}, err
+	}
+	if err := appendAuditLine(req.Started.AuditLogPath, fmt.Sprintf("ts=%s session_id=%s event=session_finished target_kind=%s target_provider=%s target_id=%s status=%s exit_status=%s", req.FinishedAt, req.Started.Record.SessionID, t.Contract.TargetKind, t.Contract.TargetProvider, req.Started.Record.TargetID, t.Contract.Session.FinalStatus, req.ExitStatus)); err != nil {
+		return SessionResult{}, err
+	}
+	record, err := sessions.ReadSessionRecord(req.Started.RecordPath)
+	if err != nil {
+		return SessionResult{}, err
+	}
+	return SessionResult{Record: record, RecordPath: req.Started.RecordPath, AuditLogPath: req.Started.AuditLogPath}, nil
+}
+
+func targetRoot(stateRoot, targetKind, targetProvider, targetID string) string {
+	return filepath.Join(stateRoot, "targets", targetKind, targetProvider, targetID)
+}
+
+func statePathSegment(label, value string) (string, error) {
+	if strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("%s is required", label)
+	}
+	if strings.TrimSpace(value) != value {
+		return "", fmt.Errorf("%s must not contain leading or trailing whitespace", label)
+	}
+	if value == "." || value == ".." || filepath.IsAbs(value) || strings.ContainsAny(value, `/\`) {
+		return "", fmt.Errorf("%s must be a single path segment", label)
+	}
+	return value, nil
+}
+
+// copyWorkspaceTree copies sourceRoot into destRoot, excluding the configured
+// paths, and returns a sorted manifest of the copied entries. Symlinks that are
+// absolute or escape the workspace (lexically or after kernel resolution) fail
+// closed so materialization cannot smuggle non-workspace content into the VM.
+func copyWorkspaceTree(sourceRoot, destRoot string, excluded []string) ([]WorkspaceEntry, error) {
+	entries := make([]WorkspaceEntry, 0)
+	resolvedRoot, err := filepath.EvalSymlinks(sourceRoot)
+	if err != nil {
+		return nil, err
+	}
+	err = filepath.WalkDir(sourceRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == sourceRoot {
+			return nil
+		}
+		rel, err := filepath.Rel(sourceRoot, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if isExcludedPath(rel, excluded) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		destPath := filepath.Join(destRoot, filepath.FromSlash(rel))
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			if filepath.IsAbs(target) {
+				return fmt.Errorf("workspace symlink %s targets an absolute path: %s", rel, target)
+			}
+			resolved := filepath.ToSlash(filepath.Clean(filepath.Join(filepath.Dir(filepath.FromSlash(rel)), target)))
+			if resolved == ".." || strings.HasPrefix(resolved, "../") {
+				return fmt.Errorf("workspace symlink %s escapes the workspace: %s", rel, target)
+			}
+			physical, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				return fmt.Errorf("workspace symlink %s does not resolve inside the workspace: %v", rel, err)
+			}
+			if physical != resolvedRoot && !strings.HasPrefix(physical, resolvedRoot+string(filepath.Separator)) {
+				return fmt.Errorf("workspace symlink %s escapes the workspace: %s", rel, target)
+			}
+			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+				return err
+			}
+			if err := os.Symlink(target, destPath); err != nil {
+				return err
+			}
+			entries = append(entries, WorkspaceEntry{Path: rel, Kind: "symlink", Mode: info.Mode(), LinkTarget: target})
+		case info.IsDir():
+			if err := os.MkdirAll(destPath, info.Mode().Perm()); err != nil {
+				return err
+			}
+			entries = append(entries, WorkspaceEntry{Path: rel, Kind: "dir", Mode: info.Mode()})
+		case info.Mode().IsRegular():
+			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+				return err
+			}
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(destPath, content, info.Mode().Perm()); err != nil {
+				return err
+			}
+			sum := sha256.Sum256(content)
+			entries = append(entries, WorkspaceEntry{
+				Path:   rel,
+				Kind:   "file",
+				Mode:   info.Mode(),
+				SHA256: hex.EncodeToString(sum[:]),
+			})
+		default:
+			return fmt.Errorf("unsupported workspace entry kind for %s", rel)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+	return entries, nil
+}
+
+func isExcludedPath(rel string, excluded []string) bool {
+	for _, item := range excluded {
+		if rel == item || strings.HasPrefix(rel, item+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func writeJSON(path string, value any) error {
+	content, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	content = append(content, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
+}
+
+func appendAuditLine(path, line string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	handle, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer handle.Close()
+	if _, err := io.WriteString(handle, line+"\n"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/host/supportmatrix/supportmatrix_test.go
+++ b/internal/host/supportmatrix/supportmatrix_test.go
@@ -110,6 +110,58 @@ func TestEvaluateReturnsPreviewOnlyRow(t *testing.T) {
 	}
 }
 
+func TestEvaluateReturnsAppleContainerPreviewRow(t *testing.T) {
+	t.Parallel()
+
+	// Assert against BOTH the fixture and the real reviewed policy file so the
+	// C1 apple-container evaluation row stays parseable and support-invisible.
+	for _, path := range []string{writeSupportMatrixFixture(t), realPolicyMatrixPath(t)} {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := Evaluate(path, Query{
+				HostOS:               "macos",
+				HostArch:             "arm64",
+				HostDistro:           "none",
+				HostDistroVersion:    "none",
+				TargetKind:           "local_vm",
+				TargetProvider:       "apple-container",
+				TargetAssuranceClass: "per-session-vm",
+			})
+			if err != nil {
+				t.Fatalf("Evaluate() error = %v", err)
+			}
+			if result.Status != "preview-only" {
+				t.Fatalf("status = %q, want preview-only", result.Status)
+			}
+			if result.Launch != "blocked" {
+				t.Fatalf("launch = %q, want blocked", result.Launch)
+			}
+			if result.Evidence != "certification-only" {
+				t.Fatalf("evidence = %q, want certification-only", result.Evidence)
+			}
+			if result.ValidationLane != "none" {
+				t.Fatalf("validation_lane = %q, want none", result.ValidationLane)
+			}
+			if result.Reason != "apple-silicon-macos-26-apple-container-evaluation-preview" {
+				t.Fatalf("reason = %q, want apple-silicon-macos-26-apple-container-evaluation-preview", result.Reason)
+			}
+		})
+	}
+}
+
+func realPolicyMatrixPath(t *testing.T) string {
+	t.Helper()
+
+	// Test cwd is the package directory: internal/host/supportmatrix.
+	path := filepath.Join("..", "..", "..", "policy", "host-support-matrix.tsv")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("locating reviewed support matrix: %v", err)
+	}
+	return path
+}
+
 func TestEvaluateDefaultsToUnsupported(t *testing.T) {
 	t.Parallel()
 
@@ -180,6 +232,7 @@ func writeSupportMatrixFixture(t *testing.T) string {
 		"macos\tarm64\tnone\tnone\tlocal_vm\tcolima\tstrict\tsupported\tallowed\tcertification-only\tnone\tapple-silicon-macos-reviewed-launch-host",
 		"macos\tarm64\tnone\tnone\tremote_vm\taws-ec2-ssm\tcompat\tpreview-only\tblocked\tcertification-only\tnone\tapple-silicon-macos-aws-ec2-ssm-preview-certification-only",
 		"macos\tarm64\tnone\tnone\tremote_vm\tgcp-vm\tcompat\tpreview-only\tblocked\tcertification-only\tnone\tapple-silicon-macos-gcp-vm-preview-certification-only",
+		"macos\tarm64\tnone\tnone\tlocal_vm\tapple-container\tper-session-vm\tpreview-only\tblocked\tcertification-only\tnone\tapple-silicon-macos-26-apple-container-evaluation-preview",
 		"linux\tamd64\tany\tany\tlocal_vm\tcolima\tstrict\tvalidation-host-only\tblocked\trepo-required\ttrusted-linux-amd64-validator\ttrusted-linux-amd64-validation-host-only",
 	}, "\n") + "\n"
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {

--- a/policy/host-support-matrix.tsv
+++ b/policy/host-support-matrix.tsv
@@ -4,6 +4,7 @@ macos	arm64	none	none	local_vm	colima	strict	supported	allowed	certification-onl
 macos	arm64	none	none	local_compat	docker-desktop	compat	supported	allowed	certification-only	none	apple-silicon-macos-docker-desktop-compat-reviewed-launch-host
 macos	arm64	none	none	remote_vm	aws-ec2-ssm	compat	preview-only	blocked	certification-only	none	apple-silicon-macos-aws-ec2-ssm-preview-certification-only
 macos	arm64	none	none	remote_vm	gcp-vm	compat	preview-only	blocked	certification-only	none	apple-silicon-macos-gcp-vm-preview-certification-only
+macos	arm64	none	none	local_vm	apple-container	per-session-vm	preview-only	blocked	certification-only	none	apple-silicon-macos-26-apple-container-evaluation-preview
 linux	amd64	any	any	local_vm	colima	strict	validation-host-only	blocked	repo-required	trusted-linux-amd64-validator	trusted-linux-amd64-validation-host-only
 linux	amd64	any	any	local_compat	docker-desktop	compat	unsupported	blocked	none	none	linux-docker-desktop-hosts-not-yet-reviewed
 linux	amd64	any	any	remote_vm	aws-ec2-ssm	compat	validation-host-only	blocked	repo-required	trusted-linux-amd64-validator	trusted-linux-amd64-aws-ec2-ssm-deterministic-preview


### PR DESCRIPTION
**Roadmap C1 — Apple `container` backend evaluation (macOS 26+).** C1's 1.0 gate is a *recorded evaluation + go/no-go decision*, not a shipped backend. This delivers the spike, the deterministic conformance, the live-exercise evidence, the fail-closed guard, the support-matrix row, and the recorded decision.

## Spike — `internal/applecontainer` (self-contained; does NOT reuse remotevm's remote contract)
- **contract.go** — local-VM `Contract` (`target_kind=local_vm`, `provider=apple-container`, `assurance=per-session-vm`, `access_model=direct`, `local-materialization`) with a `Validate()` that fail-closes on remote/brokered values.
- **target.go** — deterministic `AppleContainerTarget` implementing the 4-method session lifecycle (materialize/bootstrap/start/finish), mirroring `remotevm.FakeTarget` (incl. symlink-escape hardening), reusing only `internal/host/sessions`.
- **conformance.go** — self-contained lifecycle/audit-event conformance runner (remotevm untouched).
- **probe.go** — `ProbeAppleContainer` live probe: shells `container`, measures warm boot latency, reads per-VM kernel/hostname/NIC/blockdev; skips (`ErrAppleContainerUnavailable`) when unavailable so CI/non-macOS-26 hosts are unaffected.
- **guard.go** — `RequireMacOS26()` fail-closed (macOS<26 and non-macOS refused). C1 exit gate.
- **support matrix** — `policy/host-support-matrix.tsv` row `macos arm64 … local_vm apple-container per-session-vm preview-only blocked …` (support-invisible; evaluation only), covered by a supportmatrix parse test.

## Evidence (this host, macOS 26.5.1, Apple container 1.0.0)
Sub-second per-container boot (**843 ms fastest, ~857 ms median**, idle); own Linux kernel **6.18.15** (host Darwin 25.5.0), own hostname UUID, own VM NIC `192.168.64.x`, own ext4 block device — one lightweight VM per container. Stronger boundary than Colima's single shared VM.

## Decision (recorded in ROADMAP + docs/apple-container-evaluation.md)
**GO on the evaluation; promotion deferred.** `preview-only`/`blocked`, support-invisible; Colima stays the reviewed default (and the only option below macOS 26); promotion to a supported backend deferred post-1.0 pending the B6 certification lane.

## Validation
`go build`/`vet`/`gofmt`, full `go test ./...` (deterministic conformance + `RequireMacOS26` table + live probe running on this host + support-matrix parse), `check-doc-support-matrix-fields.sh`, `check-doc-links` — all green. Did not run `verify-invariants.sh` (needs a booted Colima VM) — hence the honest `!F` on the spike commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)