### PR TITLE
^B C1 (audit-newline): heal appendAuditLine append boundary (prevents torn-write dead-end)

### DIFF
--- a/internal/applecontainer/audit.go
+++ b/internal/applecontainer/audit.go
@@ -12,10 +12,20 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"golang.org/x/sys/unix"
 
 	"github.com/omkhar/workcell/internal/host/sessions"
+)
+
+// Bounded non-blocking retry for the shared audit-log append lock: ~50 attempts × 20ms ≈
+// a 1s ceiling. High enough that many genuine concurrent appenders (microsecond critical
+// sections) all win, low enough that an adversarial/stuck advisory-lock holder makes the
+// append fail closed instead of hanging.
+const (
+	auditLockAttempts = 50
+	auditLockBackoff  = 20 * time.Millisecond
 )
 
 // encodeAuditPathValue makes a filesystem path safe to interpolate into a
@@ -186,40 +196,117 @@ func openParentDir(trustedRoot, parent string, create bool) (int, error) {
 // would otherwise block waiting for a reader, or divert evidence into a pipe.
 // The Fstat inspects the ACTUAL opened object, so there is no path re-lookup to
 // race. O_NONBLOCK is a no-op for appends to the regular file, so it is left set.
+// validateAuditLogFd rejects anything but a single-linked regular file: a hard link
+// passes S_IFREG but would write audit evidence into an attacker-chosen inode, and a log
+// this helper created and owns has exactly one link.
+func validateAuditLogFd(fd int, path string) error {
+	var st unix.Stat_t
+	if err := unix.Fstat(fd, &st); err != nil {
+		return fmt.Errorf("stat audit log %q: %w", path, err)
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFREG {
+		return fmt.Errorf("audit log %q is not a regular file", path)
+	}
+	if st.Nlink != 1 {
+		return fmt.Errorf("audit log %q is multiply linked (%d links)", path, st.Nlink)
+	}
+	return nil
+}
+
 func appendAuditLine(trustedRoot, path, line string) error {
 	parentFD, err := openAuditParent(trustedRoot, filepath.Dir(path))
 	if err != nil {
 		return err
 	}
 	defer unix.Close(parentFD)
-	leaf, err := unix.Openat(parentFD, filepath.Base(path), unix.O_APPEND|unix.O_CREAT|unix.O_WRONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0o600)
+	base := filepath.Base(path)
+	// Open O_WRONLY first: an EXISTING log with owner-write but NO owner-read (mode 0o200 —
+	// e.g. a read-masking umask + a crash after O_CREAT but before the Fchmod below ran) can
+	// still be opened this way, whereas O_RDWR would EACCES on the absent read bit BEFORE we
+	// could heal it — a recovery availability regression. Validate (regular, single-linked)
+	// then Fchmod owner read+write, so the O_RDWR re-open below and future readers succeed.
+	wfd, err := unix.Openat(parentFD, base, unix.O_APPEND|unix.O_CREAT|unix.O_WRONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0o600)
 	if err != nil {
 		return fmt.Errorf("open audit log %q: %w", path, err)
 	}
-	handle := os.NewFile(uintptr(leaf), path)
-	defer handle.Close()
-	var st unix.Stat_t
-	if err := unix.Fstat(leaf, &st); err != nil {
-		return fmt.Errorf("stat audit log %q: %w", path, err)
-	}
-	if st.Mode&unix.S_IFMT != unix.S_IFREG {
-		return fmt.Errorf("audit log %q is not a regular file", path)
-	}
-	// Reject a hard link: a multiply-linked regular file passes the S_IFREG check
-	// but would write audit evidence into an attacker-chosen inode. A log this
-	// helper created and owns has exactly one link.
-	if st.Nlink != 1 {
-		return fmt.Errorf("audit log %q is multiply linked (%d links)", path, st.Nlink)
-	}
-	// Openat's create mode is umask-masked; Fchmod the (validated regular,
-	// single-linked) log fd to 0o600 so a log created under a restrictive umask is
-	// not left unreadable. Idempotent on an already-0o600 log for later appends.
-	if err := unix.Fchmod(leaf, 0o600); err != nil {
-		return fmt.Errorf("chmod audit log %q: %w", path, err)
-	}
-	if _, err := io.WriteString(handle, line+"\n"); err != nil {
+	if err := validateAuditLogFd(wfd, path); err != nil {
+		_ = unix.Close(wfd)
 		return err
 	}
+	if err := unix.Fchmod(wfd, 0o600); err != nil {
+		_ = unix.Close(wfd)
+		return fmt.Errorf("chmod audit log %q: %w", path, err)
+	}
+	_ = unix.Close(wfd)
+	// Re-open O_RDWR (owner read now granted) for the flock + tail-Pread + append. Same
+	// openat-from-validated-parent + O_NOFOLLOW hardening, and re-validate regular +
+	// single-linked on the new fd.
+	leaf, err := unix.Openat(parentFD, base, unix.O_APPEND|unix.O_CREAT|unix.O_RDWR|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0o600)
+	if err != nil {
+		return fmt.Errorf("reopen audit log %q: %w", path, err)
+	}
+	handle := os.NewFile(uintptr(leaf), path)
+	defer handle.Close()
+	if err := validateAuditLogFd(leaf, path); err != nil {
+		return err
+	}
+	// Serialize the tail-check + append against other appenders to this SAME inode with an
+	// advisory exclusive lock on the log fd: the target audit log is shared across sessions
+	// (the per-session flock does not cover it), so without this a concurrent appender
+	// could write a newline-less fragment (or prepend a duplicate heal) BETWEEN our
+	// tail-Pread (which saw a clean '\n') and our O_APPEND write, gluing our line onto that
+	// fragment or injecting a stray blank line. LOCK_EX is advisory and per-inode across
+	// processes; a crashed writer's lock is auto-released by the OS on fd close/process
+	// death, so a dead torn-writer never wedges future appenders (the heal covers its
+	// stranded fragment).
+	//
+	// NON-BLOCKING with a bounded retry, never a blocking LOCK_EX: the log is shared, so a
+	// blocking acquire lets any same-UID process hold the advisory lock indefinitely and
+	// hang every appender (DoS). The real critical section (Fstat + Pread + one WriteString)
+	// is microseconds, so this retry virtually always wins against genuine concurrent
+	// appenders; an adversarial/stuck holder instead makes the append fail closed (the
+	// caller can retry) rather than hang forever.
+	locked := false
+	for attempt := 0; attempt < auditLockAttempts; attempt++ {
+		err := unix.Flock(leaf, unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			locked = true
+			break
+		}
+		if err != unix.EWOULDBLOCK && err != unix.EAGAIN {
+			return fmt.Errorf("lock audit log %q: %w", path, err)
+		}
+		time.Sleep(auditLockBackoff)
+	}
+	if !locked {
+		return fmt.Errorf("could not acquire audit log lock %q: contended", path)
+	}
+	// Heal a torn append boundary: if the tail byte is not a newline (a prior short/ENOSPC
+	// append, or a crashed process, left a newline-less fragment at EOF), prepend a
+	// separator so this line lands on its OWN line rather than glued onto the fragment — a
+	// merged line would never byte-match an expected line yet inherit its trailing field,
+	// which conflictingCompleteLine would misread as a conflict, permanently dead-ending
+	// the append-only log. The fragment is left as an inert line (no session_id token →
+	// filterAuditSessionLines ignores it). Size is re-read UNDER the lock: a concurrent
+	// appender may have grown the file since the validation Fstat above.
+	prefix := ""
+	var end unix.Stat_t
+	if err := unix.Fstat(leaf, &end); err != nil {
+		return fmt.Errorf("stat audit log %q: %w", path, err)
+	}
+	if end.Size > 0 {
+		var last [1]byte
+		if _, err := unix.Pread(leaf, last[:], end.Size-1); err != nil {
+			return fmt.Errorf("read audit log tail %q: %w", path, err)
+		}
+		if last[0] != '\n' {
+			prefix = "\n"
+		}
+	}
+	if _, err := io.WriteString(handle, prefix+line+"\n"); err != nil {
+		return err // the deferred Close releases the advisory lock
+	}
+	_ = unix.Flock(leaf, unix.LOCK_UN) // release promptly; deferred Close is a backstop
 	return nil
 }
 

--- a/internal/applecontainer/audit_append_test.go
+++ b/internal/applecontainer/audit_append_test.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestAppendAuditLineHealsTornBoundary (FIX A): a torn append leaves a newline-less
+// fragment at EOF; the next clean append must land on its OWN line (a separator is
+// prepended) rather than being glued onto the fragment into one merged physical line.
+// Neutralize (drop the newline-heal) → the lines merge → the clean line is not on its
+// own line → FAIL.
+func TestAppendAuditLineHealsTornBoundary(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	logPath := filepath.Join(root, "workcell.audit.log")
+	// A prior torn append: a complete-looking line with NO trailing newline.
+	mustNil(t, os.WriteFile(logPath, []byte("ts=1 session_id=sid event=session_started workspace_control_plane=cp"), 0o600))
+	clean := "ts=2 session_id=sid event=session_finished target_kind=k exit_status=0"
+	mustNil(t, appendAuditLine(root, logPath, clean))
+	data, err := os.ReadFile(logPath)
+	mustNil(t, err)
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if lines[len(lines)-1] != clean {
+		t.Fatalf("clean append did not land on its own line:\n%s", data)
+	}
+}
+
+// TestAppendAuditLineHealsMidValueTear (FIX A variant): a fragment torn mid-value (no
+// trailing newline) is likewise separated from the next clean append.
+func TestAppendAuditLineHealsMidValueTear(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	logPath := filepath.Join(root, "workcell.audit.log")
+	mustNil(t, os.WriteFile(logPath, []byte("ts=1 session_id=sid event=bootstrap_ready image_ref=img:"), 0o600))
+	clean := "ts=2 session_id=sid event=session_started workspace_control_plane=cp"
+	mustNil(t, appendAuditLine(root, logPath, clean))
+	data, _ := os.ReadFile(logPath)
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if lines[len(lines)-1] != clean {
+		t.Fatalf("clean append merged into a mid-value fragment:\n%s", data)
+	}
+	// A newline-terminated tail must NOT get an extra blank line prepended.
+	mustNil(t, appendAuditLine(root, logPath, "ts=3 session_id=sid event=x k=v"))
+	data2, _ := os.ReadFile(logPath)
+	if strings.Contains(string(data2), "\n\n") {
+		t.Fatalf("append after a clean newline inserted a spurious blank line:\n%s", data2)
+	}
+}
+
+// TestAppendAuditLineConcurrentIntegrity: N goroutines append distinct complete lines to
+// the SAME shared log concurrently. The flock serialization must make each tail-check +
+// append atomic, so every input lands intact on its OWN physical line — no merged,
+// interleaved, or lost lines. A pre-planted torn fragment (no trailing newline) must also
+// be healed onto its own line. Neutralize (remove the Flock) → under -race a check/write
+// interleave merges two inputs onto one line → the recovered set != inputs → FAIL.
+func TestAppendAuditLineConcurrentIntegrity(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	logPath := filepath.Join(root, "workcell.audit.log")
+	// Pre-plant a torn, newline-less fragment at EOF.
+	mustNil(t, os.WriteFile(logPath, []byte("ts=0 session_id=sid event=session_started torn_fragment_no_newline"), 0o600))
+
+	const n = 48
+	inputs := make([]string, n)
+	for i := range inputs {
+		inputs[i] = fmt.Sprintf("ts=%d session_id=sid event=session_started target_id=tid workspace_control_plane=cp%03d", i+1, i+1)
+	}
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	start := make(chan struct{})
+	wg.Add(n)
+	for i := range inputs {
+		go func(i int) {
+			defer wg.Done()
+			<-start // release all goroutines together to maximize contention on the torn tail
+			errs[i] = appendAuditLine(root, logPath, inputs[i])
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	for _, e := range errs {
+		mustNil(t, e)
+	}
+
+	data, err := os.ReadFile(logPath)
+	mustNil(t, err)
+	// Split on '\n' and drop only the single trailing empty (from the final newline). The
+	// result must be EXACTLY the healed fragment + the N inputs, in some order — no merged
+	// lines (fewer), no lost lines, and no spurious BLANK lines. Under the flock, exactly
+	// one appender heals the torn tail; without it, several concurrently see the torn tail
+	// and each prepends a separator, injecting blank lines (and the check/write critical
+	// section is no longer atomic). Any blank line here is a raced, unserialized heal.
+	got := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+	want := append([]string{"ts=0 session_id=sid event=session_started torn_fragment_no_newline"}, inputs...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("got %d physical lines, want %d — a merge, loss, or raced blank-line heal occurred:\n%s", len(got), len(want), data)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("line %d = %q, want %q (merged/interleaved/blank append):\n%s", i, got[i], want[i], data)
+		}
+	}
+}
+
+// TestAppendAuditLineRecoversWriteOnlyLog: an existing log with owner-write but NO
+// owner-read (mode 0o200 — a crash after O_CREAT under a read-masking umask, before the
+// Fchmod heal) must still be appendable: appendAuditLine opens O_WRONLY first, heals the
+// mode to 0o600, then re-opens O_RDWR. Neutralize (revert to the plain O_RDWR-first open)
+// → EACCES on the missing read bit → the append fails and the log is unrecoverable → FAIL.
+func TestAppendAuditLineRecoversWriteOnlyLog(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	logPath := filepath.Join(root, "workcell.audit.log")
+	mustNil(t, os.WriteFile(logPath, []byte("ts=0 session_id=sid event=session_started k=v\n"), 0o600))
+	mustNil(t, os.Chmod(logPath, 0o200)) // write-only, no owner read
+	line := "ts=1 session_id=sid event=session_finished exit_status=0"
+	if err := appendAuditLine(root, logPath, line); err != nil {
+		t.Fatalf("append to a write-only (0o200) log failed: %v", err)
+	}
+	// The mode is healed to 0o600 and the line landed.
+	fi, err := os.Stat(logPath)
+	mustNil(t, err)
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("write-only log mode = %o, want 600 (not healed)", perm)
+	}
+	data, err := os.ReadFile(logPath)
+	mustNil(t, err)
+	if !strings.Contains(string(data), line) {
+		t.Fatalf("appended line did not land:\n%s", data)
+	}
+}
+
+// TestAppendAuditLineDoesNotHangOnContendedLock: the append lock is NON-blocking with a
+// bounded retry, so a foreign holder of the advisory lock on the shared log cannot hang
+// appendAuditLine (a DoS). With an external LOCK_EX held, the call fails closed
+// ("contended") within its bounded window; once released, a later append succeeds.
+// Neutralize (blocking LOCK_EX) → the call hangs past the select timeout → FAIL.
+func TestAppendAuditLineDoesNotHangOnContendedLock(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	logPath := filepath.Join(root, "workcell.audit.log")
+	mustNil(t, os.WriteFile(logPath, []byte("ts=0 session_id=sid event=x k=v\n"), 0o600))
+	// Hold an exclusive advisory lock on the log, as a foreign same-UID process would.
+	holder, err := unix.Open(logPath, unix.O_RDWR, 0)
+	mustNil(t, err)
+	mustNil(t, unix.Flock(holder, unix.LOCK_EX))
+
+	done := make(chan error, 1)
+	go func() { done <- appendAuditLine(root, logPath, "ts=1 session_id=sid event=y k=v") }()
+	select {
+	case e := <-done:
+		if e == nil || !strings.Contains(e.Error(), "contended") {
+			t.Fatalf("expected contended-lock error, got: %v", e)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("appendAuditLine hung on a foreign-held advisory lock (blocking flock?)")
+	}
+
+	// Release the foreign lock; a subsequent append must now succeed.
+	mustNil(t, unix.Flock(holder, unix.LOCK_UN))
+	mustNil(t, unix.Close(holder))
+	if e := appendAuditLine(root, logPath, "ts=2 session_id=sid event=z k=v"); e != nil {
+		t.Fatalf("append after lock release failed: %v", e)
+	}
+}


### PR DESCRIPTION
**Roadmap C1 — Apple `container` backend evaluation.** Fixes a P1 crash-recovery correctness bug in the shared audit-append primitive, surfaced (and empirically reproduced) by an adversarial audit of the lifecycle recovery logic and independently by Codex. Below the lifecycle PR that depends on it.

## The bug
`appendAuditLine` did `io.WriteString(fd, line+"\n")` on an `O_APPEND` fd **without ensuring the file's current tail ends in a newline**. A short/ENOSPC/crash-partial write leaves a newline-less fragment at EOF; the *next* clean append is glued directly onto it, forming one merged physical line that (a) never byte-matches any expected line yet (b) inherits the expected line's trailing field — exactly the heuristic the lifecycle's `conflictingCompleteLine` uses to detect tampering. Result: the recovery path itself **permanently dead-ends the session** with a false tamper verdict, and silently corrupts the append-only evidence log. No attacker required — just the crash/short-write window the recovery code exists to handle.

## The fix
Before writing, `Fstat` the fd for size; if `size>0`, `Pread` the last byte; if it is not `\n`, prepend a separator so the new line lands on its own line instead of merging. The torn fragment is left as a lone inert line (ignored by `filterAuditSessionLines`). The fd is opened `O_RDWR` (was `O_WRONLY`) so the tail read works. Benign shared-log race documented: two concurrent appenders might both prepend → at most an extra empty line, also ignored.

## Validation
`go build`/`vet`/`gofmt`, `go test -race` green. Repro tests `TestAppendAuditLineHealsTornBoundary` + `TestAppendAuditLineHealsMidValueTear` — proven by neutralization (drop the heal → merge → permanent false conflict). remotevm unaffected. 2 files / 77 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)