### PR TITLE
^D Operator boundary-incident response runbook (GAP-2)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,6 +53,14 @@ the three enforcement points (`scripts/workcell`,
 Adding a key requires editing the TOML and updating each enforcer in
 the same PR.
 
+## Operator incident response
+
+If you are an operator responding to a suspected runtime boundary breach — an
+agent escaping the session, host credential exposure, or workspace tampering —
+follow the [operator boundary-incident response runbook](docs/incident-response.md)
+to contain, preserve evidence, collect a redacted support bundle, and escalate
+through the reporting channel above.
+
 ## CI/CD threat model
 
 The [CI/CD threat model](docs/ci-threat-model.md) covers the build and release

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -81,6 +81,15 @@ and are easy to diff.
 - for anything that looks like it exposed a secret, use
   [SECURITY.md](SECURITY.md) instead of a public issue
 
+## Suspected boundary breach
+
+If you suspect a runtime boundary breach — an agent escaping the session, host
+credential exposure, or workspace/control-plane tampering — do not open a public
+issue. Follow the
+[operator boundary-incident response runbook](docs/incident-response.md), which
+uses this support bundle to collect evidence and escalates through
+[SECURITY.md](SECURITY.md).
+
 ## Include this context
 
 - Workcell version or commit SHA

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -162,7 +162,8 @@ Per-session evidence, for the specific `SESSION_ID`(s) from step 2:
 - `workcell session export --id SESSION_ID --output PATH` — the record plus all
   matching audit records as one JSON bundle (written `0600`).
 - `workcell session diff --id SESSION_ID --output PATH` — the workspace change
-  set against the clean launch base.
+  set against the clean launch base: a `[status]` file list plus a `[diff]`
+  section of raw file contents. The raw contents are sensitive (see step 6).
 - `workcell session logs --id SESSION_ID --kind audit` — prints the **entire
   profile-wide** `workcell.audit.log` resolved from the session's record, not a
   per-session slice: it is shared by every session in the profile, so you see all
@@ -202,25 +203,41 @@ suspected boundary breach in a public issue. Expect acknowledgment within
 sandbox escapes and secret exposure are prioritized
 ([`SECURITY.md`](../SECURITY.md#response)).
 
-Include:
+Include (redaction-safe by default):
 
 - the redacted `workcell-support-bundle.json` from step 4;
-- the exported session record(s), timeline, and diff for the affected
-  `SESSION_ID`(s);
+- the exported session record(s) and timeline for the affected `SESSION_ID`(s);
+- from `workcell session diff`, the **`[status]` summary only** — the list of
+  changed and untracked files (`git status --short`) — plus, if useful, file
+  counts and hashes. This is metadata about *which* files changed, not their
+  contents;
 - the observed signal, severity, provider, mode, host OS, and the exact commands
   run.
+
+Review and redact before sharing (may contain secrets/proprietary content):
+
+- The `[diff]` section of `workcell session diff` output. It is a full
+  `git diff` of raw workspace file contents (`render_session_diff_bundle` in
+  `scripts/workcell` runs `git diff --no-ext-diff --no-textconv` against the
+  launch base), so a compromised session that wrote secrets or changed
+  proprietary files puts that content directly into the diff. Treat it like the
+  `debug`/`file-trace`/`transcript` logs: raw workspace content that must be
+  reviewed and redacted by the operator before it crosses the trust boundary
+  into a report.
 
 Do **not** include:
 
 - secrets, credential values, or `.env`-style material;
 - raw workspace content or full agent transcripts unless specifically requested
-  — the `debug`/`file-trace`/`transcript` logs are the ones most likely to carry
-  it.
+  — the `session diff` `[diff]` body and the `debug`/`file-trace`/`transcript`
+  logs are the ones most likely to carry it.
 
 The support bundle is redacted by construction, but **skim it once before
-sharing** ([`SUPPORT.md`](../SUPPORT.md#sharing-it-safely)). If any artifact you
-were about to attach looks like it exposed a secret, keep it out of the report
-body and describe it to the maintainer over the private advisory instead.
+sharing** ([`SUPPORT.md`](../SUPPORT.md#sharing-it-safely)). The session diff and
+lower-assurance logs are **not** redacted — review them yourself first. If any
+artifact you were about to attach looks like it exposed a secret, keep it out of
+the report body and describe it to the maintainer over the private advisory
+instead.
 
 [pvr]: https://github.com/omkhar/workcell/security/advisories/new
 

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -70,9 +70,10 @@ investigate.
    and workspace transport, or `--json` to script it) shows every recorded
    session with its live status, profile, and id.
 2. **Stop a detached session.** `workcell session stop --id SESSION_ID` performs
-   a graceful stop; add `--force` to force-remove (kill) the container instead.
-   This works only for **detached** sessions started with
-   `workcell session start`.
+   a graceful stop (`docker stop`); add `--force` to kill it immediately
+   (`docker kill`) instead. Either way the container is stopped, not removed, so
+   it stays available as evidence. This works only for **detached** sessions
+   started with `workcell session start`.
 3. **Stop a foreground session.** An interactive `workcell` launch has no
    `session stop` handle. Terminate the launcher process; the runtime container
    is ephemeral by default (`--container-mutability ephemeral`) and does not
@@ -101,8 +102,15 @@ investigate.
      VM, so this halt is safe to do before collecting.
    - **`local_compat` / Docker Desktop (compat, lower assurance).** The isolation
      boundary is the Docker Desktop container/context, not a Workcell-dedicated
-     VM, so there is no `colima stop` to run; `workcell session stop --id
-     SESSION_ID --force` (kill/remove the container) is the boundary teardown.
+     VM, so there is no `colima stop` to run. `workcell session stop --id
+     SESSION_ID --force` force-**stops** the session by killing its container
+     (`--force` selects `docker kill` over the graceful `docker stop` —
+     `internal/sessionctl/stop.go:33,116-117`); this contains the breach but
+     leaves the **stopped container in place**, which is what you want — preserve
+     it as evidence. It does **not** remove the container. Removing it is a
+     separate Recover step (`workcell session delete`, which needs the Docker
+     socket and a terminal status — see step 7 — or a manual `docker rm`), done
+     only after evidence is collected.
    Do **not** delete the profile, VM, or container yet — teardown is step 7,
    after evidence is collected. The `remote_vm` preview targets (`aws-ec2-ssm`,
    `gcp-vm`) are `preview-only` with `launch=blocked` in the matrix, so no live

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -86,14 +86,29 @@ investigate.
    persist after the launch exits.
 4. **Halt the target's isolation boundary (defense in depth).** Stopping the
    session (steps 2-3) stops its container; the general principle for a fuller
-   halt is then to bring down the target's isolation boundary. That command is
-   **target-specific**, so first confirm which target the **suspect session**
-   used. Read it from that session's record — `workcell session show --id
-   SESSION_ID` (or `workcell session list --verbose`) reports the record's
-   `target_kind` and `target_provider`. Do not use `--inspect` for this: it
-   prints your *current* launch options, not the suspect session's target. At 1.0
-   the operator-reachable targets on the supported macOS arm64 host are the two
-   `launch=allowed` rows in
+   halt is then to bring down the target's isolation boundary.
+
+   **First, wait for the session to finalize (detached sessions).** For a
+   detached session, `workcell session stop` returns as soon as it issues the
+   stop — it writes `status=stopping` and does **not** wait
+   (`scripts/workcell:3894-3897`). The session monitor then finalizes the durable
+   record and audit log (and only then removes the container) asynchronously
+   (`session_monitor_main`, `scripts/workcell:4222-4228`). If you halt the Colima
+   VM (or stop Docker Desktop) while the status is still `stopping`, you interrupt
+   the monitor mid-finalization and the durable evidence may be captured
+   incompletely. So after `session stop`, **poll `workcell session show --id
+   SESSION_ID` (or `session list --verbose`) until the status is terminal**
+   (`stopped`, `exited`, `failed`, or `aborted` — `session_is_terminal_status`,
+   `scripts/workcell:3909-3918`), which confirms the monitor has finalized the
+   durable record and audit, **before** halting the boundary below.
+
+   The boundary-halt command is **target-specific**, so confirm which target the
+   **suspect session** used. Read it from that session's record — `workcell
+   session show --id SESSION_ID` (or `workcell session list --verbose`) reports
+   the record's `target_kind` and `target_provider`. Do not use `--inspect` for
+   this: it prints your *current* launch options, not the suspect session's
+   target. At 1.0 the operator-reachable targets on the supported macOS arm64 host
+   are the two `launch=allowed` rows in
    [`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv):
    - **`local_vm` / Colima (the default, strict target).** All sessions for a
      profile run inside one dedicated Colima VM. Take the profile from the session

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -95,14 +95,20 @@ root (defaults from the
 
 - session records:
   `~/.local/state/workcell/targets/local_vm/colima/<profile>/sessions/<session_id>.json`
-- audit log:
+- audit log (profile-wide, shared by all sessions in the profile):
   `~/.local/state/workcell/targets/local_vm/colima/<profile>/workcell.audit.log`
 - legacy records (compatibility reads):
   `~/.colima/<profile>/sessions/<session_id>.json`
+- legacy profile-wide audit log (a profile-level file **outside** `sessions/`):
+  `~/.colima/<profile>/workcell.audit.log`
 
-The state-root location follows `WORKCELL_STATE_ROOT` (default
-`${XDG_STATE_HOME:-~/.local/state}/workcell`) and `COLIMA_STATE_ROOT` (default
-`~/.colima`) if those are set in the operator's environment.
+The Workcell target-state root follows `WORKCELL_STATE_ROOT` (default
+`${XDG_STATE_HOME:-~/.local/state}/workcell`), which an operator can override in
+the environment. The Colima state root is **not** operator-overridable: the
+launcher unconditionally resets `COLIMA_STATE_ROOT` to `~/.colima`
+(`scripts/workcell` sets `COLIMA_STATE_ROOT="${REAL_HOME}/.colima"`), so the
+legacy Colima path is always under `~/.colima/<profile>/` regardless of any
+`COLIMA_STATE_ROOT` you export.
 
 - **Do not garbage-collect before you collect.** `workcell --gc` (alias
   `workcell gc`) deliberately deletes transient `session-audit.*` scratch, temp
@@ -112,9 +118,13 @@ The state-root location follows `WORKCELL_STATE_ROOT` (default
 - **Do not `session delete`.** `workcell session delete` removes the durable
   record and stopped-session artifacts. Defer it to recovery (step 7).
 - **Snapshot the state root.** Copy the profile's target-state directory
-  (records + `workcell.audit.log`) and any legacy `~/.colima/<profile>/sessions/`
-  records to read-only storage before further action, so the on-disk evidence is
-  preserved even if later steps mutate host state.
+  (session records + the profile-wide `workcell.audit.log`) **and** any legacy
+  files under `~/.colima/<profile>/` — both the legacy `sessions/` records and
+  the legacy profile-level `~/.colima/<profile>/workcell.audit.log`, since a
+  legacy record can point its `audit_log_path` at that profile-level file
+  outside `sessions/`. Copy all of them to read-only storage before further
+  action, so the on-disk evidence is preserved even if later steps mutate host
+  state.
 
 Note: workflow-artifact retention in
 [retention-policy.md](retention-policy.md) governs **CI/release** artifacts, not
@@ -153,8 +163,12 @@ Per-session evidence, for the specific `SESSION_ID`(s) from step 2:
   matching audit records as one JSON bundle (written `0600`).
 - `workcell session diff --id SESSION_ID --output PATH` — the workspace change
   set against the clean launch base.
-- `workcell session logs --id SESSION_ID --kind audit` — the retained audit log
-  for the session. The `debug`, `file-trace`, and `transcript` kinds exist only
+- `workcell session logs --id SESSION_ID --kind audit` — prints the **entire
+  profile-wide** `workcell.audit.log` resolved from the session's record, not a
+  per-session slice: it is shared by every session in the profile, so you see all
+  sessions' events, which is useful for cross-session correlation around the
+  suspect session. Use `session timeline` (above) when you want only the suspect
+  session's entries. The `debug`, `file-trace`, and `transcript` kinds exist only
   when those lower-assurance host logs were explicitly enabled at launch, and may
   contain workspace or agent output — treat them as sensitive (see step 6).
 
@@ -232,11 +246,11 @@ Only after evidence is collected and reported:
   compromised VM: it only deletes an *unmanaged* profile (one that pre-exists
   without Workcell ownership metadata) as a launch-time conflict repair, and does
   nothing to a Workcell-managed profile. To fully reset a suspect profile, delete
-  it through Colima's own CLI — `colima delete -p <profile> --force` (align
-  `COLIMA_HOME` with `COLIMA_STATE_ROOT` if you set a non-default one) — then a
-  fresh `workcell` launch recreates a clean managed profile from the reviewed
-  image. Because the strict runtime container is ephemeral, a clean relaunch
-  otherwise starts from the reviewed image already.
+  it through Colima's own CLI — `colima delete -p <profile> --force` (the
+  launcher pins the Colima home to `~/.colima`, so run it against that home) —
+  then a fresh `workcell` launch recreates a clean managed profile from the
+  reviewed image. Because the strict runtime container is ephemeral, a clean
+  relaunch otherwise starts from the reviewed image already.
 - **Close the loop.** If the incident revealed a genuine boundary weakness (not
   just an expected lower-assurance mode), it belongs in the private advisory so a
   fix and regression test can follow — see the coordinated-disclosure model in

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -335,10 +335,14 @@ Only after evidence is collected and reported:
 - **Tear down the compromised session.** `workcell session delete --id
   SESSION_ID` removes the durable record and stopped-session artifacts (use
   `--dry-run` first to preview the cleanup). It has two preconditions: the
-  session must be in a terminal status (exited, failed, or stopped — stop it
-  first, per step 2), and cleaning the session **container** needs the target's
-  Docker socket available (`profile_docker_transport_available`,
-  `scripts/workcell:1649-1675`). Where that socket comes from is target-specific:
+  session must be in a terminal status — `stopped`, `exited`, `failed`, or
+  `aborted` (`session_is_terminal_status`, `scripts/workcell:3909-3918`); stop it
+  first, per step 2. (A foreground/attached session that exited before it
+  finalized is recorded as `aborted` (`scripts/workcell:975-978`) and is
+  delete-able.) The second precondition is that cleaning the session
+  **container** needs the target's Docker socket available
+  (`profile_docker_transport_available`, `scripts/workcell:1649-1675`). Where that
+  socket comes from is target-specific:
   - **`local_vm` / Colima:** the socket is the Colima VM's Docker socket
     (`scripts/workcell:1657-1660`), so it is available only while the VM is
     running. If you halted the VM in step 2.4, restart it with

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -201,9 +201,11 @@ Per-session evidence, for the specific `SESSION_ID`(s) from step 2:
 
 - `workcell session show --id SESSION_ID [--text]` — the full durable record.
 - `workcell session timeline --id SESSION_ID` — the session-specific audit
-  trail.
+  trail. Audit records can include raw `session send` message text, so treat this
+  as sensitive (see step 6).
 - `workcell session export --id SESSION_ID --output PATH` — the record plus all
-  matching audit records as one JSON bundle (written `0600`).
+  matching audit records as one JSON bundle (written `0600`). The bundled audit
+  records carry the same raw message text (see step 6).
 - `workcell session diff --id SESSION_ID --output PATH` — the workspace change
   set against the clean launch base: a `[status]` file list plus a `[diff]`
   section of raw file contents. The raw contents are sensitive (see step 6).
@@ -249,7 +251,8 @@ sandbox escapes and secret exposure are prioritized
 Include (redaction-safe by default):
 
 - the redacted `workcell-support-bundle.json` from step 4;
-- the exported session record(s) and timeline for the affected `SESSION_ID`(s);
+- the durable session record(s) for the affected `SESSION_ID`(s) — the
+  structured metadata from `workcell session show`;
 - from `workcell session diff`, the **`[status]` summary only** — the list of
   changed and untracked files (`git status --short`) — plus, if useful, file
   counts and hashes. This is metadata about *which* files changed, not their
@@ -263,24 +266,34 @@ Review and redact before sharing (may contain secrets/proprietary content):
   `git diff` of raw workspace file contents (`render_session_diff_bundle` in
   `scripts/workcell` runs `git diff --no-ext-diff --no-textconv` against the
   launch base), so a compromised session that wrote secrets or changed
-  proprietary files puts that content directly into the diff. Treat it like the
-  `debug`/`file-trace`/`transcript` logs: raw workspace content that must be
-  reviewed and redacted by the operator before it crosses the trust boundary
-  into a report.
+  proprietary files puts that content directly into the diff.
+- The **audit log and anything that reads it** — `workcell session timeline`,
+  `workcell session logs --id SESSION_ID --kind audit`, and the audit records
+  bundled by `workcell session export`. When a detached session was steered with
+  `workcell session send`, the launcher writes the **raw message text** into the
+  audit log as `argv=<message>` (`scripts/workcell:3739-3742`), so the timeline,
+  the audit log, and the exported audit records can contain raw operator/agent
+  message content — including secrets or sensitive data an operator typed.
+
+Treat all of these like the `debug`/`file-trace`/`transcript` logs: raw content
+that must be reviewed and redacted by the operator before it crosses the trust
+boundary into a report.
 
 Do **not** include:
 
 - secrets, credential values, or `.env`-style material;
-- raw workspace content or full agent transcripts unless specifically requested
-  — the `session diff` `[diff]` body and the `debug`/`file-trace`/`transcript`
-  logs are the ones most likely to carry it.
+- raw workspace content, raw audit/timeline message text, or full agent
+  transcripts unless specifically requested — the `session diff` `[diff]` body,
+  the audit log / timeline / `session logs --kind audit` (raw `session send`
+  messages), and the `debug`/`file-trace`/`transcript` logs are the ones most
+  likely to carry it.
 
 The support bundle is redacted by construction, but **skim it once before
-sharing** ([`SUPPORT.md`](../SUPPORT.md#sharing-it-safely)). The session diff and
-lower-assurance logs are **not** redacted — review them yourself first. If any
-artifact you were about to attach looks like it exposed a secret, keep it out of
-the report body and describe it to the maintainer over the private advisory
-instead.
+sharing** ([`SUPPORT.md`](../SUPPORT.md#sharing-it-safely)). The session diff,
+the audit log / timeline / exported audit records, and the lower-assurance logs
+are **not** redacted — review them yourself first. If any artifact you were about
+to attach looks like it exposed a secret, keep it out of the report body and
+describe it to the maintainer over the private advisory instead.
 
 [pvr]: https://github.com/omkhar/workcell/security/advisories/new
 

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -321,14 +321,24 @@ Only after evidence is collected and reported:
   SESSION_ID` removes the durable record and stopped-session artifacts (use
   `--dry-run` first to preview the cleanup). It has two preconditions: the
   session must be in a terminal status (exited, failed, or stopped — stop it
-  first, per step 2), and cleaning the session **container** needs the profile's
-  Docker socket available, i.e. the Colima VM running. If you halted the VM in
-  step 2.4, normal `session delete` refuses container cleanup and tells you to
-  retry with the socket available; in that state either restart the VM
-  (`COLIMA_HOME=~/.colima colima start -p <profile>`) and delete, or pass
-  `--record-only` to remove just the durable record (keeping container/log
-  artifacts), or remove the preserved state-root files by hand after evidence
-  collection.
+  first, per step 2), and cleaning the session **container** needs the target's
+  Docker socket available (`profile_docker_transport_available`,
+  `scripts/workcell:1649-1675`). Where that socket comes from is target-specific:
+  - **`local_vm` / Colima:** the socket is the Colima VM's Docker socket
+    (`scripts/workcell:1657-1660`), so it is available only while the VM is
+    running. If you halted the VM in step 2.4, restart it with
+    `COLIMA_HOME=~/.colima colima start -p <profile>`, then delete.
+  - **`local_compat` / Docker Desktop:** the socket is a healthy Docker Desktop
+    context reached through the host `docker` binary (`scripts/workcell:1661-1670`),
+    so it is available only while **Docker Desktop itself is running** — ensure
+    the Docker Desktop app/daemon is up, then delete. Do not run `colima start`
+    for this target; Docker Desktop does not use Colima.
+
+  Until the socket is available, normal `session delete` refuses container
+  cleanup and tells you to retry with the socket available; in that state either
+  bring the socket up as above, or pass `--record-only` to remove just the
+  durable record (keeping container/log artifacts), or remove the preserved
+  state-root files by hand after evidence collection.
 - **Reset a suspect Colima profile.** `--repair-profile` is **not** a reset for a
   compromised VM: it only deletes an *unmanaged* profile (one that pre-exists
   without Workcell ownership metadata) as a launch-time conflict repair, and does

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -71,9 +71,15 @@ investigate.
    session with its live status, profile, and id.
 2. **Stop a detached session.** `workcell session stop --id SESSION_ID` performs
    a graceful stop (`docker stop`); add `--force` to kill it immediately
-   (`docker kill`) instead. Either way the container is stopped, not removed, so
-   it stays available as evidence. This works only for **detached** sessions
-   started with `workcell session start`.
+   (`docker kill`) instead. Stop itself does not remove the container, but do
+   **not** rely on the container as evidence: for a detached session the live
+   session monitor reacts to the container exit by capturing its in-container
+   audit/file-trace state, finalizing the durable session record and audit log,
+   and then removing the container (`docker rm -f`) —
+   `session_monitor_main` at `scripts/workcell:4225-4228`. The evidence that
+   survives is the **durable state-root** (record, profile audit log, captured
+   logs), which you collect in step 4 — not the container. This works only for
+   **detached** sessions started with `workcell session start`.
 3. **Stop a foreground session.** An interactive `workcell` launch has no
    `session stop` handle. Terminate the launcher process; the runtime container
    is ephemeral by default (`--container-mutability ephemeral`) and does not
@@ -105,12 +111,11 @@ investigate.
      VM, so there is no `colima stop` to run. `workcell session stop --id
      SESSION_ID --force` force-**stops** the session by killing its container
      (`--force` selects `docker kill` over the graceful `docker stop` —
-     `internal/sessionctl/stop.go:33,116-117`); this contains the breach but
-     leaves the **stopped container in place**, which is what you want — preserve
-     it as evidence. It does **not** remove the container. Removing it is a
-     separate Recover step (`workcell session delete`, which needs the Docker
-     socket and a terminal status — see step 7 — or a manual `docker rm`), done
-     only after evidence is collected.
+     `internal/sessionctl/stop.go:33,116-117`), which contains the breach. As in
+     step 2, `stop` itself does not `docker rm` the container, but the live
+     monitor finalizes the durable record/audit and then removes it, so treat the
+     durable state-root artifacts (collected in step 4) as the evidence rather
+     than the container.
    Do **not** delete the profile, VM, or container yet — teardown is step 7,
    after evidence is collected. The `remote_vm` preview targets (`aws-ec2-ssm`,
    `gcp-vm`) are `preview-only` with `launch=blocked` in the matrix, so no live

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -80,16 +80,22 @@ investigate.
 4. **Halt the target's isolation boundary (defense in depth).** Stopping the
    session (steps 2-3) stops its container; the general principle for a fuller
    halt is then to bring down the target's isolation boundary. That command is
-   **target-specific**, so first confirm which target the session used
-   (`workcell session list --verbose`, or `--inspect` for `target_kind` /
-   `target_provider`), then act on it. At 1.0 the operator-reachable targets on
-   the supported macOS arm64 host are the two `launch=allowed` rows in
+   **target-specific**, so first confirm which target the **suspect session**
+   used. Read it from that session's record — `workcell session show --id
+   SESSION_ID` (or `workcell session list --verbose`) reports the record's
+   `target_kind` and `target_provider`. Do not use `--inspect` for this: it
+   prints your *current* launch options, not the suspect session's target. At 1.0
+   the operator-reachable targets on the supported macOS arm64 host are the two
+   `launch=allowed` rows in
    [`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv):
    - **`local_vm` / Colima (the default, strict target).** All sessions for a
-     profile run inside one dedicated Colima VM. Identify the profile from
-     `workcell session list` or `--inspect`, then stop that VM through Colima
-     directly (`colima stop -p <profile>`) to halt all execution on it. Note:
-     stopping the VM removes the profile's Docker socket, so a later
+     profile run inside one dedicated Colima VM. Take the profile from the session
+     record (`workcell session show --id SESSION_ID`), then stop that VM through
+     Colima directly. Pin the Colima home so you hit the same VM the launcher
+     created — the launcher always invokes Colima with `COLIMA_HOME=~/.colima`
+     (`scripts/workcell:620-632`, `run_host_colima`) — so run
+     `COLIMA_HOME=~/.colima colima stop -p <profile>` to halt all execution on it.
+     Note: stopping the VM removes the profile's Docker socket, so a later
      `workcell session delete` cannot clean container artifacts until the VM is
      running again (see step 7). Host-side collection in step 4 does not need the
      VM, so this halt is safe to do before collecting.
@@ -108,8 +114,9 @@ investigate.
 
 Durable session state lives on the host under the Workcell-owned target-state
 root, and the path is **target-aware**. Identify the target first — the same
-`workcell session list --verbose` / `--inspect` `target_kind` and
-`target_provider` you used in step 2 — then preserve that target's tree.
+`target_kind` and `target_provider` from the suspect session's record
+(`workcell session show --id SESSION_ID`, or `workcell session list --verbose`)
+you read in step 2 — then preserve that target's tree.
 
 The general layout (`internal/host/hoststate/profilepaths.go`
 `ProfileTargetStateDir` /`ProfileSessionsDirPath` / `ProfileAuditLogPath`) is
@@ -292,16 +299,18 @@ Only after evidence is collected and reported:
   Docker socket available, i.e. the Colima VM running. If you halted the VM in
   step 2.4, normal `session delete` refuses container cleanup and tells you to
   retry with the socket available; in that state either restart the VM
-  (`colima start -p <profile>`) and delete, or pass `--record-only` to remove
-  just the durable record (keeping container/log artifacts), or remove the
-  preserved state-root files by hand after evidence collection.
+  (`COLIMA_HOME=~/.colima colima start -p <profile>`) and delete, or pass
+  `--record-only` to remove just the durable record (keeping container/log
+  artifacts), or remove the preserved state-root files by hand after evidence
+  collection.
 - **Reset a suspect Colima profile.** `--repair-profile` is **not** a reset for a
   compromised VM: it only deletes an *unmanaged* profile (one that pre-exists
   without Workcell ownership metadata) as a launch-time conflict repair, and does
   nothing to a Workcell-managed profile. To fully reset a suspect profile, delete
-  it through Colima's own CLI — `colima delete -p <profile> --force` (the
-  launcher pins the Colima home to `~/.colima`, so run it against that home) —
-  then a fresh `workcell` launch recreates a clean managed profile from the
+  it through Colima's own CLI, pinning the same home the launcher uses so you hit
+  the Workcell VM — `COLIMA_HOME=~/.colima colima delete -p <profile> --force`
+  (`scripts/workcell:620-632`) — then a fresh `workcell` launch recreates a clean
+  managed profile from the
   reviewed image. Because the strict runtime container is ephemeral, a clean
   relaunch otherwise starts from the reviewed image already.
 - **Close the loop.** If the incident revealed a genuine boundary weakness (not

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -107,24 +107,42 @@ investigate.
 ## 3. Preserve evidence
 
 Durable session state lives on the host under the Workcell-owned target-state
-root (defaults from the
-[session supervisor design](workcell-session-supervisor-design.md#data-model)):
+root, and the path is **target-aware**. Identify the target first — the same
+`workcell session list --verbose` / `--inspect` `target_kind` and
+`target_provider` you used in step 2 — then preserve that target's tree.
+
+The general layout (`internal/host/hoststate/profilepaths.go`
+`ProfileTargetStateDir` /`ProfileSessionsDirPath` / `ProfileAuditLogPath`) is
+`<target-state-root>/<target_kind>/<target_provider>/<profile>/`, where the
+target-state root is `${WORKCELL_STATE_ROOT}/targets` and `WORKCELL_STATE_ROOT`
+defaults to `${XDG_STATE_HOME:-~/.local/state}/workcell` (`scripts/workcell:91-92`):
 
 - session records:
-  `~/.local/state/workcell/targets/local_vm/colima/<profile>/sessions/<session_id>.json`
+  `.../<target_kind>/<target_provider>/<profile>/sessions/<session_id>.json`
 - audit log (profile-wide, shared by all sessions in the profile):
-  `~/.local/state/workcell/targets/local_vm/colima/<profile>/workcell.audit.log`
-- legacy records (compatibility reads):
-  `~/.colima/<profile>/sessions/<session_id>.json`
+  `.../<target_kind>/<target_provider>/<profile>/workcell.audit.log`
+
+For the two operator-reachable targets at 1.0 this resolves to:
+
+- **`local_vm` / Colima (default, strict):**
+  `~/.local/state/workcell/targets/local_vm/colima/<profile>/{sessions/,workcell.audit.log}`
+- **`local_compat` / Docker Desktop (compat):**
+  `~/.local/state/workcell/targets/local_compat/docker-desktop/<profile>/{sessions/,workcell.audit.log}`
+
+The Colima target additionally has a **legacy** tree that compatibility reads
+still accept, and Docker Desktop does **not** (`LegacyProfileSessionsDirPath` /
+`LegacyProfileAuditLogPath` are keyed on the Colima state root):
+
+- legacy records: `~/.colima/<profile>/sessions/<session_id>.json`
 - legacy profile-wide audit log (a profile-level file **outside** `sessions/`):
   `~/.colima/<profile>/workcell.audit.log`
 
-The Workcell target-state root follows `WORKCELL_STATE_ROOT` (default
-`${XDG_STATE_HOME:-~/.local/state}/workcell`), which an operator can override in
-the environment. The Colima state root is **not** operator-overridable: the
+`WORKCELL_STATE_ROOT` is operator-overridable, so if it is set in your
+environment the `targets/...` tree lives under that root instead of
+`~/.local/state/workcell`. The Colima legacy tree is **not** overridable: the
 launcher unconditionally resets `COLIMA_STATE_ROOT` to `~/.colima`
-(`scripts/workcell` sets `COLIMA_STATE_ROOT="${REAL_HOME}/.colima"`), so the
-legacy Colima path is always under `~/.colima/<profile>/` regardless of any
+(`scripts/workcell:90`, `COLIMA_STATE_ROOT="${REAL_HOME}/.colima"`), so the
+legacy Colima path is always `~/.colima/<profile>/` regardless of any
 `COLIMA_STATE_ROOT` you export.
 
 - **Do not garbage-collect before you collect.** `workcell --gc` (alias
@@ -134,14 +152,15 @@ legacy Colima path is always under `~/.colima/<profile>/` regardless of any
   destroys evidence. Do not run it until collection is complete.
 - **Do not `session delete`.** `workcell session delete` removes the durable
   record and stopped-session artifacts. Defer it to recovery (step 7).
-- **Snapshot the state root.** Copy the profile's target-state directory
-  (session records + the profile-wide `workcell.audit.log`) **and** any legacy
-  files under `~/.colima/<profile>/` — both the legacy `sessions/` records and
-  the legacy profile-level `~/.colima/<profile>/workcell.audit.log`, since a
-  legacy record can point its `audit_log_path` at that profile-level file
-  outside `sessions/`. Copy all of them to read-only storage before further
-  action, so the on-disk evidence is preserved even if later steps mutate host
-  state.
+- **Snapshot the state root.** Copy your target's profile directory
+  (`.../<target_kind>/<target_provider>/<profile>/`) whole — session records plus
+  the profile-wide `workcell.audit.log`. For the **Colima** target, also copy the
+  legacy tree under `~/.colima/<profile>/` — both the legacy `sessions/` records
+  and the legacy profile-level `~/.colima/<profile>/workcell.audit.log`, since a
+  legacy record can point its `audit_log_path` at that profile-level file outside
+  `sessions/` (the Docker Desktop target has no legacy tree). Copy all of them to
+  read-only storage before further action, so the on-disk evidence is preserved
+  even if later steps mutate host state.
 
 Note: workflow-artifact retention in
 [retention-policy.md](retention-policy.md) governs **CI/release** artifacts, not

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -77,15 +77,32 @@ investigate.
    `session stop` handle. Terminate the launcher process; the runtime container
    is ephemeral by default (`--container-mutability ephemeral`) and does not
    persist after the launch exits.
-4. **Halt everything on a profile (defense in depth).** All sessions for a
-   profile run inside one dedicated Colima VM. Identify the profile from
-   `workcell session list` or `--inspect`, then stop that VM through Colima
-   directly (`colima stop -p <profile>`) to halt all execution on it. Do **not**
-   delete the profile or VM yet — teardown is step 7, after evidence is
-   collected. Note: stopping the VM removes the profile's Docker socket, so a
-   later `workcell session delete` cannot clean container artifacts until the VM
-   is running again (see step 7). Host-side collection in step 4 does not need
-   the VM, so this halt is safe to do before collecting.
+4. **Halt the target's isolation boundary (defense in depth).** Stopping the
+   session (steps 2-3) stops its container; the general principle for a fuller
+   halt is then to bring down the target's isolation boundary. That command is
+   **target-specific**, so first confirm which target the session used
+   (`workcell session list --verbose`, or `--inspect` for `target_kind` /
+   `target_provider`), then act on it. At 1.0 the operator-reachable targets on
+   the supported macOS arm64 host are the two `launch=allowed` rows in
+   [`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv):
+   - **`local_vm` / Colima (the default, strict target).** All sessions for a
+     profile run inside one dedicated Colima VM. Identify the profile from
+     `workcell session list` or `--inspect`, then stop that VM through Colima
+     directly (`colima stop -p <profile>`) to halt all execution on it. Note:
+     stopping the VM removes the profile's Docker socket, so a later
+     `workcell session delete` cannot clean container artifacts until the VM is
+     running again (see step 7). Host-side collection in step 4 does not need the
+     VM, so this halt is safe to do before collecting.
+   - **`local_compat` / Docker Desktop (compat, lower assurance).** The isolation
+     boundary is the Docker Desktop container/context, not a Workcell-dedicated
+     VM, so there is no `colima stop` to run; `workcell session stop --id
+     SESSION_ID --force` (kill/remove the container) is the boundary teardown.
+   Do **not** delete the profile, VM, or container yet — teardown is step 7,
+   after evidence is collected. The `remote_vm` preview targets (`aws-ec2-ssm`,
+   `gcp-vm`) are `preview-only` with `launch=blocked` in the matrix, so no live
+   operator session runs on them at 1.0 and they are out of scope here; if you
+   ever tear down a preview broker, follow that target's own teardown, not
+   `colima stop`.
 
 ## 3. Preserve evidence
 

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -82,7 +82,10 @@ investigate.
    `workcell session list` or `--inspect`, then stop that VM through Colima
    directly (`colima stop -p <profile>`) to halt all execution on it. Do **not**
    delete the profile or VM yet — teardown is step 7, after evidence is
-   collected.
+   collected. Note: stopping the VM removes the profile's Docker socket, so a
+   later `workcell session delete` cannot clean container artifacts until the VM
+   is running again (see step 7). Host-side collection in step 4 does not need
+   the VM, so this halt is safe to do before collecting.
 
 ## 3. Preserve evidence
 
@@ -214,13 +217,26 @@ Only after evidence is collected and reported:
 - **Rotate exposed credentials.** If any host secret could have been read,
   rotate it at the source, then re-stage it with `workcell auth unset` /
   `workcell auth set` and confirm with `workcell auth status --agent <provider>`.
-- **Tear down the compromised session.** With the session stopped and evidence
-  preserved, `workcell session delete --id SESSION_ID` removes the record and
-  stopped-session artifacts (use `--dry-run` first to preview the cleanup).
-- **Reset the runtime.** Because the strict runtime container is ephemeral, a
-  clean relaunch starts from the reviewed image. If the Colima profile is
-  suspect, `workcell --repair-profile ...` deletes a conflicting profile before
-  the next launch.
+- **Tear down the compromised session.** `workcell session delete --id
+  SESSION_ID` removes the durable record and stopped-session artifacts (use
+  `--dry-run` first to preview the cleanup). It has two preconditions: the
+  session must be in a terminal status (exited, failed, or stopped — stop it
+  first, per step 2), and cleaning the session **container** needs the profile's
+  Docker socket available, i.e. the Colima VM running. If you halted the VM in
+  step 2.4, normal `session delete` refuses container cleanup and tells you to
+  retry with the socket available; in that state either restart the VM
+  (`colima start -p <profile>`) and delete, or pass `--record-only` to remove
+  just the durable record (keeping container/log artifacts), or remove the
+  preserved state-root files by hand after evidence collection.
+- **Reset a suspect Colima profile.** `--repair-profile` is **not** a reset for a
+  compromised VM: it only deletes an *unmanaged* profile (one that pre-exists
+  without Workcell ownership metadata) as a launch-time conflict repair, and does
+  nothing to a Workcell-managed profile. To fully reset a suspect profile, delete
+  it through Colima's own CLI — `colima delete -p <profile> --force` (align
+  `COLIMA_HOME` with `COLIMA_STATE_ROOT` if you set a non-default one) — then a
+  fresh `workcell` launch recreates a clean managed profile from the reviewed
+  image. Because the strict runtime container is ephemeral, a clean relaunch
+  otherwise starts from the reviewed image already.
 - **Close the loop.** If the incident revealed a genuine boundary weakness (not
   just an expected lower-assurance mode), it belongs in the private advisory so a
   fix and regression test can follow — see the coordinated-disclosure model in

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -1,0 +1,242 @@
+# Operator Boundary-Incident Response Runbook
+
+This runbook is for an **operator** who suspects a **runtime boundary breach**
+on a Workcell host: an agent escaping the session boundary, host credential
+exposure, or workspace/control-plane tampering. It is the operational companion
+to the [runtime-boundary threat model](threat-model.md); the
+[CI/CD threat model](ci-threat-model.md) covers the separate
+signing-compromise case (build and release pipeline), not a live session.
+
+This runbook **stitches together shipped tooling** — it introduces no new
+commands. Every command below exists today unless it is explicitly marked as
+roadmapped. Work top to bottom: **detect, contain, preserve, collect, verify,
+report, recover.** When time is short, the order that matters most is
+**contain, then preserve before collect** — never clean or garbage-collect
+before evidence is off the box.
+
+## 0. Scope
+
+Use this runbook for a suspected violation of a runtime trust boundary defined
+in the [threat model](threat-model.md#trust-boundaries), for example:
+
+- reads of host secrets outside the documented boundary (credential exposure)
+- writes outside the intended workspace without explicit `breakglass`, or
+  unmanaged host socket/credential passthrough (agent escape)
+- repo-local control-plane files replacing reviewed provider baselines, or
+  silent trust widening through repo content (workspace/control-plane tamper)
+
+These mirror the **in-scope** reports in [`SECURITY.md`](../SECURITY.md#in-scope).
+For anything in the build/release pipeline, use the
+[signing-compromise runbook](ci-threat-model.md#signing-compromise-incident-response)
+instead.
+
+## 1. Detect and triage
+
+Signals that a session may have crossed a boundary:
+
+- **Assurance downgrade.** Each session record carries an initial, current, and
+  final assurance state (see the
+  [session supervisor design](workcell-session-supervisor-design.md#data-model)).
+  A session that *ended lower-assurance* (for example a warning that
+  package-manager mutations ran as root inside the container) is a triage signal,
+  not proof, but it warrants review.
+- **Unexpected workspace changes.** `workcell session diff --id SESSION_ID`
+  renders the current workspace against the clean git base recorded at launch. It
+  is read-only and fails closed if it cannot trust the comparison. Unexpected
+  edits — especially to control-plane files (agent config, MCP config, git
+  config) — are a tamper signal.
+- **Boundary/egress anomalies.** Unexpected outbound behavior on the managed
+  Colima path, or host secrets/sockets that should never have been reachable
+  (see the [threat model controls](threat-model.md#controls)).
+- **Live host state.** `workcell --agent <provider> --doctor` and
+  `workcell --agent <provider> --inspect` report resolved profile, target, and
+  launch/assurance state; use
+  [diagnostics-and-support-matrix.md](diagnostics-and-support-matrix.md) to read
+  the fields.
+
+**Severity.** Treat host **secret exposure** and confirmed **sandbox escape**
+(a write outside the workspace without `breakglass`, or host socket/credential
+passthrough) as **critical** — these are the cases
+[`SECURITY.md`](../SECURITY.md#response) prioritizes. Treat workspace/control-plane
+tamper without confirmed host reach as **high**. If in doubt, escalate at the
+higher severity and let the assessment downgrade it.
+
+## 2. Contain
+
+Stop the affected session(s) and halt further agent execution before you
+investigate.
+
+1. **Inventory sessions.** `workcell session list` (add `--verbose` for target
+   and workspace transport, or `--json` to script it) shows every recorded
+   session with its live status, profile, and id.
+2. **Stop a detached session.** `workcell session stop --id SESSION_ID` performs
+   a graceful stop; add `--force` to force-remove (kill) the container instead.
+   This works only for **detached** sessions started with
+   `workcell session start`.
+3. **Stop a foreground session.** An interactive `workcell` launch has no
+   `session stop` handle. Terminate the launcher process; the runtime container
+   is ephemeral by default (`--container-mutability ephemeral`) and does not
+   persist after the launch exits.
+4. **Halt everything on a profile (defense in depth).** All sessions for a
+   profile run inside one dedicated Colima VM. Identify the profile from
+   `workcell session list` or `--inspect`, then stop that VM through Colima
+   directly (`colima stop -p <profile>`) to halt all execution on it. Do **not**
+   delete the profile or VM yet — teardown is step 7, after evidence is
+   collected.
+
+## 3. Preserve evidence
+
+Durable session state lives on the host under the Workcell-owned target-state
+root (defaults from the
+[session supervisor design](workcell-session-supervisor-design.md#data-model)):
+
+- session records:
+  `~/.local/state/workcell/targets/local_vm/colima/<profile>/sessions/<session_id>.json`
+- audit log:
+  `~/.local/state/workcell/targets/local_vm/colima/<profile>/workcell.audit.log`
+- legacy records (compatibility reads):
+  `~/.colima/<profile>/sessions/<session_id>.json`
+
+The state-root location follows `WORKCELL_STATE_ROOT` (default
+`${XDG_STATE_HOME:-~/.local/state}/workcell`) and `COLIMA_STATE_ROOT` (default
+`~/.colima`) if those are set in the operator's environment.
+
+- **Do not garbage-collect before you collect.** `workcell --gc` (alias
+  `workcell gc`) deliberately deletes transient `session-audit.*` scratch, temp
+  scratch, and runtime-image cache residue. Durable session records survive gc,
+  but the transient audit scratch does not — running gc during an incident
+  destroys evidence. Do not run it until collection is complete.
+- **Do not `session delete`.** `workcell session delete` removes the durable
+  record and stopped-session artifacts. Defer it to recovery (step 7).
+- **Snapshot the state root.** Copy the profile's target-state directory
+  (records + `workcell.audit.log`) and any legacy `~/.colima/<profile>/sessions/`
+  records to read-only storage before further action, so the on-disk evidence is
+  preserved even if later steps mutate host state.
+
+Note: workflow-artifact retention in
+[retention-policy.md](retention-policy.md) governs **CI/release** artifacts, not
+these host-side session state roots; host evidence is preserved by the operator,
+not by a retention timer.
+
+## 4. Collect
+
+Capture a redacted, shareable diagnostics snapshot with the support bundle
+(roadmap item G2, shipped):
+
+```sh
+workcell support-bundle --output ~/workcell-support-bundle.json
+```
+
+It runs entirely host-side and never starts the runtime. It collects install
+state, the policy-file inventory, target/state-root layout, per-provider adapter
+presence and credential **key names** (never values), durable session-record
+summaries, and **audit pointers** (audit-log path, presence, size, and mtime —
+never log contents). See [`SUPPORT.md`](../SUPPORT.md#what-it-collects) for the
+full field list.
+
+**Redaction guarantees** (also embedded in each bundle under `redaction`, and
+documented in [`SUPPORT.md`](../SUPPORT.md#redaction-guarantees)): credential
+file contents are never read; workspace and agent output are never collected;
+token/key/password/secret/credential material is masked by pattern and by
+secret-named `key=value` pairs; and the operator home-directory prefix is
+rewritten to `~`. The output shape is deterministic, so two bundles diff cleanly.
+
+Per-session evidence, for the specific `SESSION_ID`(s) from step 2:
+
+- `workcell session show --id SESSION_ID [--text]` — the full durable record.
+- `workcell session timeline --id SESSION_ID` — the session-specific audit
+  trail.
+- `workcell session export --id SESSION_ID --output PATH` — the record plus all
+  matching audit records as one JSON bundle (written `0600`).
+- `workcell session diff --id SESSION_ID --output PATH` — the workspace change
+  set against the clean launch base.
+- `workcell session logs --id SESSION_ID --kind audit` — the retained audit log
+  for the session. The `debug`, `file-trace`, and `transcript` kinds exist only
+  when those lower-assurance host logs were explicitly enabled at launch, and may
+  contain workspace or agent output — treat them as sensitive (see step 6).
+
+## 5. Verify evidence integrity
+
+**What exists today.** Session audit records are host-owned records in the
+target audit log; the launcher, not the agent, writes them (the host owns the
+trusted control plane — see the
+[session supervisor design](workcell-session-supervisor-design.md#why-this-shape)).
+`workcell session export` bundles the records that match a session id, and the
+support bundle records the audit log's size and mtime under `audit_pointers`, so
+you can detect truncation or replacement of the durable log against a preserved
+snapshot (step 3). Cross-check the exported records, the timeline, and the
+preserved `workcell.audit.log` for consistency.
+
+**What does not exist yet.** There is **no cryptographic hash-chain
+verification** of session audit records today. Signed, tamper-evident audit
+records with external verification tooling are **roadmapped as A5**
+(["Signed Session Audit Records", milestone v0.15](../ROADMAP.md#track-a-boundary-depth-and-agent-threat-defenses)) —
+a `workcell session verify`-style command is planned there but is **not
+shipped**. Until A5 lands, integrity is host-preservation plus consistency
+cross-checks, not signature verification. Do not represent current audit records
+as cryptographically tamper-proof.
+
+## 6. Report
+
+Escalate through the private channel in [`SECURITY.md`](../SECURITY.md#reporting):
+open a [GitHub Private Vulnerability Report][pvr]. **Do not** disclose a
+suspected boundary breach in a public issue. Expect acknowledgment within
+**5 business days** and an initial assessment within **10 business days**;
+sandbox escapes and secret exposure are prioritized
+([`SECURITY.md`](../SECURITY.md#response)).
+
+Include:
+
+- the redacted `workcell-support-bundle.json` from step 4;
+- the exported session record(s), timeline, and diff for the affected
+  `SESSION_ID`(s);
+- the observed signal, severity, provider, mode, host OS, and the exact commands
+  run.
+
+Do **not** include:
+
+- secrets, credential values, or `.env`-style material;
+- raw workspace content or full agent transcripts unless specifically requested
+  — the `debug`/`file-trace`/`transcript` logs are the ones most likely to carry
+  it.
+
+The support bundle is redacted by construction, but **skim it once before
+sharing** ([`SUPPORT.md`](../SUPPORT.md#sharing-it-safely)). If any artifact you
+were about to attach looks like it exposed a secret, keep it out of the report
+body and describe it to the maintainer over the private advisory instead.
+
+[pvr]: https://github.com/omkhar/workcell/security/advisories/new
+
+## 7. Recover
+
+Only after evidence is collected and reported:
+
+- **Rotate exposed credentials.** If any host secret could have been read,
+  rotate it at the source, then re-stage it with `workcell auth unset` /
+  `workcell auth set` and confirm with `workcell auth status --agent <provider>`.
+- **Tear down the compromised session.** With the session stopped and evidence
+  preserved, `workcell session delete --id SESSION_ID` removes the record and
+  stopped-session artifacts (use `--dry-run` first to preview the cleanup).
+- **Reset the runtime.** Because the strict runtime container is ephemeral, a
+  clean relaunch starts from the reviewed image. If the Colima profile is
+  suspect, `workcell --repair-profile ...` deletes a conflicting profile before
+  the next launch.
+- **Close the loop.** If the incident revealed a genuine boundary weakness (not
+  just an expected lower-assurance mode), it belongs in the private advisory so a
+  fix and regression test can follow — see the coordinated-disclosure model in
+  [`SECURITY.md`](../SECURITY.md#disclosure).
+
+## References
+
+- [Runtime-boundary threat model](threat-model.md) — assets, trust boundaries,
+  and controls this runbook responds to
+- [`SECURITY.md`](../SECURITY.md) — reporting channel, SLAs, and scope
+- [`SUPPORT.md`](../SUPPORT.md) — the `workcell support-bundle` field list and
+  redaction guarantees
+- [Session supervisor design](workcell-session-supervisor-design.md) — durable
+  session records, state-root paths, and the host-owned audit model
+- [Support tiers and status vocabulary](support-tiers.md) and
+  [diagnostics and the support matrix](diagnostics-and-support-matrix.md)
+- [CI/CD threat model](ci-threat-model.md) — the separate signing-compromise
+  incident runbook
+- [`ROADMAP.md`](../ROADMAP.md) — A5 signed session audit records (roadmapped)

--- a/docs/support-tiers.md
+++ b/docs/support-tiers.md
@@ -78,3 +78,5 @@ Supported launch paths still require the live certification evidence recorded in
 
 For the emitted `--doctor` and `--inspect` lines, see
 [`docs/diagnostics-and-support-matrix.md`](diagnostics-and-support-matrix.md).
+For a suspected runtime boundary breach rather than a support question, follow
+the [operator boundary-incident response runbook](incident-response.md).


### PR DESCRIPTION
**1.0 readiness gap (GAP-2, MUST).** Workcell has a CI/signing-compromise runbook (`docs/ci-threat-model.md`) and a researcher-facing `SECURITY.md`, but nothing told an **operator** what to do on a *suspected boundary breach* (agent escape, credential exposure, workspace tamper). This adds `docs/incident-response.md` — an operator runbook that **stitches shipped tooling** (introduces no new capability): detect/triage → contain (`session stop --force`, foreground teardown, VM halt) → preserve evidence (state-root paths, do-not-gc) → collect (`workcell support-bundle`) → verify integrity (what exists today; signed hash-chain arrives with A5) → report (SECURITY.md PVR channel) → recover.

Every cited command/flag/path verified against `scripts/workcell` / `internal/sessionctl` / docs; A5 `session verify` explicitly marked roadmapped. Cross-linked from `SUPPORT.md`, `docs/support-tiers.md`, `SECURITY.md`. Closes the operator-runbook gap the G4 enterprise/security lens will ask about.

## Validation
`scripts/check-doc-links.sh` (95 files, no broken links/orphans), `markdownlint`, `codespell` all clean. Docs-only; 4 files / +261 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)