### PR TITLE
.r D4: extract launcher egress-endpoint assembly into scripts/lib/launcher/

### DIFF
--- a/docs/launcher-contract.md
+++ b/docs/launcher-contract.md
@@ -349,3 +349,71 @@ Runs `workcell-colimautil` on the host. Identical structure to `go_hostutil()`
 (`ensure_go_run_env`, forwarding `GOPATH`/`GOMODCACHE`/`GOCACHE` from
 `${ROOT_DIR}` via `run_clean_host_command_in_dir`), targeting
 `./cmd/workcell-colimautil` instead.
+
+## Egress-endpoint assembly (`egress-endpoints.sh`)
+
+`scripts/lib/launcher/egress-endpoints.sh` computes the per-session network
+egress allowlist and translates it into the container runtime's `--add-host`
+arguments. It maps each provider, remote-VM broker, and injected credential to
+its fixed `host:port` endpoint set, deduplicates and deny-subtracts the combined
+list through the `workcell-hostutil` Go helper, fails closed when a deny rule
+empties the allowlist, labels whether the launch actually enforces the
+allowlist, and resolves the surviving endpoints into `--add-host` runtime args.
+Every helper depends only on `csv_contains_value` (defined in
+`scripts/workcell`), `go_hostutil` (`scripts/lib/launcher/go-hostutil.sh`, sourced
+before this module), the read-only launch-state globals `AGENT`,
+`INJECTION_CREDENTIAL_KEYS`, `NETWORK_POLICY`, and `TARGET_BACKEND`, and the
+`RUNTIME_NETWORK_ARGS` array `build_runtime_host_aliases` populates — all defined
+before the first call site in the main launch path — which makes the module
+self-contained.
+
+### `provider_endpoints()`
+
+Prints the space-separated `host:port` egress set a provider requires
+(`codex`, `claude`, `copilot`, `gemini`). Returns `1` for any unrecognised
+provider so the caller sees no endpoints.
+
+### `target_broker_endpoints()`
+
+Prints the space-separated `host:port` control-plane endpoints a remote-VM
+broker backend requires (`aws-ec2-ssm`, `gcp-vm`). Returns `0` (empty) for every
+other target, including the local `colima` and `docker-desktop` backends.
+
+### `credential_extra_endpoints()`
+
+Prints additional endpoints implied by the injected credential set
+(`INJECTION_CREDENTIAL_KEYS`): GitHub host/config credentials add the GitHub web
+and raw-content hosts, and — only when `AGENT` is `gemini` — Google OAuth/ADC
+credentials add the Google identity and AI-platform hosts. Prints nothing when
+no credential implies extra egress.
+
+### `dedupe_endpoint_list()` / `subtract_endpoint_list()`
+
+Thin wrappers over the `workcell-hostutil helper` sub-commands
+`dedupe-endpoints` and `subtract-endpoints`. `dedupe_endpoint_list` collapses the
+combined allow set to unique endpoints preserving order; `subtract_endpoint_list`
+removes every endpoint in the deny list from the allow list, preserving allow
+order. Deny always wins over allow, and the subtraction only ever tightens the
+allowlist — it can never add an endpoint or change `NETWORK_POLICY`.
+
+### `fail_empty_egress_after_deny()`
+
+Aborts fail-closed (`exit 1`) with an actionable diagnostic when
+`[network].deny_endpoints` has removed every computed endpoint on the enforced
+colima allowlist path, so a zero-egress session never launches. Called for both
+the `bootstrap` and `session` phases.
+
+### `egress_enforcement_label()`
+
+Prints `allowlist` only when the launch actually enforces the per-session
+default-deny allowlist — `TARGET_BACKEND` is `colima` **and** `NETWORK_POLICY` is
+`allowlist` — and `none` for every other target, making the parity gap explicit
+on the launch summary.
+
+### `build_runtime_host_aliases()`
+
+Resets and repopulates the `RUNTIME_NETWORK_ARGS` array. On the `allowlist`
+policy it resolves the supplied endpoint list to IPs via
+`workcell-hostutil helper resolve-endpoints` and appends one `--add-host
+host:ip` argument per resolved address (bracketing IPv6 literals); on any other
+policy it leaves `RUNTIME_NETWORK_ARGS` empty and returns.

--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -470,6 +470,7 @@ func GenerateControlPlaneManifest(rootDir, outputPath string) error {
 		"scripts/lib/launcher/host-detect.sh",
 		"scripts/lib/launcher/host-exec.sh",
 		"scripts/lib/launcher/go-hostutil.sh",
+		"scripts/lib/launcher/egress-endpoints.sh",
 		"scripts/lib/render_injection_bundle",
 		"scripts/lib/sessionctl-shim.sh",
 		"scripts/lib/shellproto.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "6e9c2fa71b8b1c5f971a710c9e4e33769bcf2210a61ab2c8f1420caebeedf002"
+      "sha256": "2fc60cf2a577ab237799301fa2452614df016486f4b29d4e0834304430a9330c"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",
@@ -23,6 +23,10 @@
     {
       "repo_path": "scripts/lib/launcher/go-hostutil.sh",
       "sha256": "775d3dd6e5d946229d6eb38ccfcc36f6a89711662c4fcd2df9d097a8741e0116"
+    },
+    {
+      "repo_path": "scripts/lib/launcher/egress-endpoints.sh",
+      "sha256": "c2f135454657eeb47f23163002aebf1bfdb68bf61ffca929ef7bc2dfbcc4ccb7"
     },
     {
       "repo_path": "scripts/lib/render_injection_bundle",

--- a/scripts/dev-quick-check.sh
+++ b/scripts/dev-quick-check.sh
@@ -53,6 +53,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/lib/launcher/host-detect.sh"
   "${ROOT_DIR}/scripts/lib/launcher/host-exec.sh"
   "${ROOT_DIR}/scripts/lib/launcher/go-hostutil.sh"
+  "${ROOT_DIR}/scripts/lib/launcher/egress-endpoints.sh"
   "${ROOT_DIR}/scripts/lib/manage_injection_policy"
   "${ROOT_DIR}/scripts/lib/pty_transcript"
   "${ROOT_DIR}/scripts/lib/render_injection_bundle"

--- a/scripts/lib/launcher/egress-endpoints.sh
+++ b/scripts/lib/launcher/egress-endpoints.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# shellcheck shell=bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Omkhar Arasaratnam
+#
+# scripts/lib/launcher/egress-endpoints.sh — egress-endpoint assembly module
+# extracted from scripts/workcell as the next increment of the launcher
+# decomposition (roadmap item D4, "wrapper assembly").  These helpers compute
+# the per-session network egress allowlist and translate it into the container
+# runtime's `--add-host` arguments: they map each provider/target/credential to
+# its fixed set of `host:port` endpoints, dedupe and deny-subtract the combined
+# list (via the workcell-hostutil Go helper), fail closed when a deny rule
+# empties the allowlist, label whether the launch actually enforces the
+# allowlist, and resolve the surviving endpoints into `--add-host` runtime
+# args.  They depend only on `csv_contains_value` (defined in scripts/workcell),
+# `go_hostutil` (scripts/lib/launcher/go-hostutil.sh, sourced before this
+# module), the read-only launch-state globals `AGENT`,
+# `INJECTION_CREDENTIAL_KEYS`, `NETWORK_POLICY`, and `TARGET_BACKEND`, and the
+# `RUNTIME_NETWORK_ARGS` array `build_runtime_host_aliases` populates — every
+# dependency is defined before the first call site in the main launch path — so
+# they are a self-contained, behaviour-preserving unit.  See
+# docs/launcher-contract.md for the module contract.
+
+provider_endpoints() {
+  case "$1" in
+    codex)
+      echo "api.openai.com:443 auth.openai.com:443 chatgpt.com:443"
+      ;;
+    claude)
+      echo "api.anthropic.com:443 claude.ai:443 console.anthropic.com:443"
+      ;;
+    copilot)
+      echo "api.githubcopilot.com:443 api.individual.githubcopilot.com:443 api.github.com:443 github.com:443"
+      ;;
+    gemini)
+      echo "generativelanguage.googleapis.com:443 ai.google.dev:443"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+target_broker_endpoints() {
+  case "$1" in
+    aws-ec2-ssm)
+      echo "ec2.amazonaws.com:443 ssm.amazonaws.com:443 ssmmessages.amazonaws.com:443 ec2messages.amazonaws.com:443"
+      ;;
+    gcp-vm)
+      echo "compute.googleapis.com:443 iap.googleapis.com:443 oslogin.googleapis.com:443"
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+credential_extra_endpoints() {
+  local credential_keys="${INJECTION_CREDENTIAL_KEYS:-}"
+  local -a endpoints=()
+
+  if csv_contains_value "${credential_keys}" "github_hosts" || csv_contains_value "${credential_keys}" "github_config"; then
+    endpoints+=(
+      github.com:443
+      api.github.com:443
+      objects.githubusercontent.com:443
+      raw.githubusercontent.com:443
+    )
+  fi
+
+  if [[ "${AGENT}" == "gemini" ]]; then
+    if csv_contains_value "${credential_keys}" "gemini_oauth" || csv_contains_value "${credential_keys}" "gcloud_adc"; then
+      endpoints+=(
+        accounts.google.com:443
+        oauth2.googleapis.com:443
+        sts.googleapis.com:443
+        aiplatform.googleapis.com:443
+      )
+    fi
+  fi
+
+  if ((${#endpoints[@]} == 0)); then
+    return 0
+  fi
+
+  printf '%s\n' "${endpoints[*]}"
+}
+
+dedupe_endpoint_list() {
+  go_hostutil helper dedupe-endpoints "$1"
+}
+
+# subtract_endpoint_list removes every endpoint in the second (deny) list from
+# the first (allow) list, preserving allow order. Deny wins over allow: an
+# operator-declared [network].deny_endpoints entry is removed from the computed
+# allowlist even when a provider needs it. This only ever TIGHTENS the
+# allowlist; it can never add an endpoint or change NETWORK_POLICY.
+subtract_endpoint_list() {
+  go_hostutil helper subtract-endpoints "$1" "$2"
+}
+
+# fail_empty_egress_after_deny aborts fail-closed when [network].deny_endpoints
+# removed every computed endpoint on the enforced colima allowlist path: a
+# zero-egress session cannot reach any provider, so report an actionable
+# diagnostic instead of the helper's low-level empty-list error. The launch does
+# not proceed, so no unbounded egress is ever installed.
+fail_empty_egress_after_deny() {
+  local phase="$1"
+  echo "workcell: injection-policy [network].deny_endpoints removed every ${phase} egress endpoint on the strict colima allowlist path." >&2
+  echo "  A session with no allowed egress cannot reach any provider or registry." >&2
+  echo "  Remove a deny_endpoints entry, or add the required host:port to allow_endpoints." >&2
+  exit 1
+}
+
+# egress_enforcement_label reports whether the launch actually enforces the
+# per-session default-deny allowlist. Only the colima target applies the
+# iptables/ip6tables DOCKER-USER allowlist (scripts/colima-egress-allowlist.sh),
+# and only when NETWORK_POLICY=allowlist. Every other target (docker-desktop,
+# aws-ec2-ssm, gcp-vm) relies on its own network controls, so this prints
+# 'none' to make the parity gap explicit on the launch summary.
+egress_enforcement_label() {
+  if [[ "${TARGET_BACKEND}" == "colima" ]] && [[ "${NETWORK_POLICY}" == "allowlist" ]]; then
+    printf 'allowlist\n'
+  else
+    printf 'none\n'
+  fi
+}
+
+build_runtime_host_aliases() {
+  local endpoint_list="$1"
+  local host=""
+  local ip=""
+
+  RUNTIME_NETWORK_ARGS=()
+  [[ "${NETWORK_POLICY}" == "allowlist" ]] || return 0
+
+  while IFS=$'\t' read -r host ip; do
+    [[ -n "${host}" ]] || continue
+    if [[ "${ip}" == *:* ]]; then
+      RUNTIME_NETWORK_ARGS+=(--add-host "${host}:[${ip}]")
+    else
+      RUNTIME_NETWORK_ARGS+=(--add-host "${host}:${ip}")
+    fi
+  done < <(go_hostutil helper resolve-endpoints "${endpoint_list}")
+
+}

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -158,6 +158,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/lib/launcher/host-detect.sh"
   "${ROOT_DIR}/scripts/lib/launcher/host-exec.sh"
   "${ROOT_DIR}/scripts/lib/launcher/go-hostutil.sh"
+  "${ROOT_DIR}/scripts/lib/launcher/egress-endpoints.sh"
   "${ROOT_DIR}/scripts/lib/trusted-entrypoint.sh"
   "${ROOT_DIR}/scripts/lib/manage_injection_policy"
   "${ROOT_DIR}/scripts/lib/pty_transcript"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -83,6 +83,12 @@ esac
 # see internal/testkit/security_boundary_test.go).
 # shellcheck source=/dev/null
 source "${ROOT_DIR}/scripts/lib/launcher/go-hostutil.sh"
+# Egress-endpoint assembly helpers. Sourced here (function definitions only, no
+# top-level execution) so every helper is defined before its first call in the
+# main launch path; they call csv_contains_value and go_hostutil, which are
+# likewise defined before any launch-time invocation.
+# shellcheck source=/dev/null
+source "${ROOT_DIR}/scripts/lib/launcher/egress-endpoints.sh"
 
 HOST_GIT_BIN=""
 HOST_COLIMA_BIN=""
@@ -6747,130 +6753,6 @@ if [[ "${1:-}" == "--self-docker-probe" ]]; then
   echo "workcell-docker-probe-ok"
   exit 0
 fi
-
-provider_endpoints() {
-  case "$1" in
-    codex)
-      echo "api.openai.com:443 auth.openai.com:443 chatgpt.com:443"
-      ;;
-    claude)
-      echo "api.anthropic.com:443 claude.ai:443 console.anthropic.com:443"
-      ;;
-    copilot)
-      echo "api.githubcopilot.com:443 api.individual.githubcopilot.com:443 api.github.com:443 github.com:443"
-      ;;
-    gemini)
-      echo "generativelanguage.googleapis.com:443 ai.google.dev:443"
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
-target_broker_endpoints() {
-  case "$1" in
-    aws-ec2-ssm)
-      echo "ec2.amazonaws.com:443 ssm.amazonaws.com:443 ssmmessages.amazonaws.com:443 ec2messages.amazonaws.com:443"
-      ;;
-    gcp-vm)
-      echo "compute.googleapis.com:443 iap.googleapis.com:443 oslogin.googleapis.com:443"
-      ;;
-    *)
-      return 0
-      ;;
-  esac
-}
-
-credential_extra_endpoints() {
-  local credential_keys="${INJECTION_CREDENTIAL_KEYS:-}"
-  local -a endpoints=()
-
-  if csv_contains_value "${credential_keys}" "github_hosts" || csv_contains_value "${credential_keys}" "github_config"; then
-    endpoints+=(
-      github.com:443
-      api.github.com:443
-      objects.githubusercontent.com:443
-      raw.githubusercontent.com:443
-    )
-  fi
-
-  if [[ "${AGENT}" == "gemini" ]]; then
-    if csv_contains_value "${credential_keys}" "gemini_oauth" || csv_contains_value "${credential_keys}" "gcloud_adc"; then
-      endpoints+=(
-        accounts.google.com:443
-        oauth2.googleapis.com:443
-        sts.googleapis.com:443
-        aiplatform.googleapis.com:443
-      )
-    fi
-  fi
-
-  if ((${#endpoints[@]} == 0)); then
-    return 0
-  fi
-
-  printf '%s\n' "${endpoints[*]}"
-}
-
-dedupe_endpoint_list() {
-  go_hostutil helper dedupe-endpoints "$1"
-}
-
-# subtract_endpoint_list removes every endpoint in the second (deny) list from
-# the first (allow) list, preserving allow order. Deny wins over allow: an
-# operator-declared [network].deny_endpoints entry is removed from the computed
-# allowlist even when a provider needs it. This only ever TIGHTENS the
-# allowlist; it can never add an endpoint or change NETWORK_POLICY.
-subtract_endpoint_list() {
-  go_hostutil helper subtract-endpoints "$1" "$2"
-}
-
-# fail_empty_egress_after_deny aborts fail-closed when [network].deny_endpoints
-# removed every computed endpoint on the enforced colima allowlist path: a
-# zero-egress session cannot reach any provider, so report an actionable
-# diagnostic instead of the helper's low-level empty-list error. The launch does
-# not proceed, so no unbounded egress is ever installed.
-fail_empty_egress_after_deny() {
-  local phase="$1"
-  echo "workcell: injection-policy [network].deny_endpoints removed every ${phase} egress endpoint on the strict colima allowlist path." >&2
-  echo "  A session with no allowed egress cannot reach any provider or registry." >&2
-  echo "  Remove a deny_endpoints entry, or add the required host:port to allow_endpoints." >&2
-  exit 1
-}
-
-# egress_enforcement_label reports whether the launch actually enforces the
-# per-session default-deny allowlist. Only the colima target applies the
-# iptables/ip6tables DOCKER-USER allowlist (scripts/colima-egress-allowlist.sh),
-# and only when NETWORK_POLICY=allowlist. Every other target (docker-desktop,
-# aws-ec2-ssm, gcp-vm) relies on its own network controls, so this prints
-# 'none' to make the parity gap explicit on the launch summary.
-egress_enforcement_label() {
-  if [[ "${TARGET_BACKEND}" == "colima" ]] && [[ "${NETWORK_POLICY}" == "allowlist" ]]; then
-    printf 'allowlist\n'
-  else
-    printf 'none\n'
-  fi
-}
-
-build_runtime_host_aliases() {
-  local endpoint_list="$1"
-  local host=""
-  local ip=""
-
-  RUNTIME_NETWORK_ARGS=()
-  [[ "${NETWORK_POLICY}" == "allowlist" ]] || return 0
-
-  while IFS=$'\t' read -r host ip; do
-    [[ -n "${host}" ]] || continue
-    if [[ "${ip}" == *:* ]]; then
-      RUNTIME_NETWORK_ARGS+=(--add-host "${host}:[${ip}]")
-    else
-      RUNTIME_NETWORK_ARGS+=(--add-host "${host}:${ip}")
-    fi
-  done < <(go_hostutil helper resolve-endpoints "${endpoint_list}")
-
-}
 
 git_alias_value_is_blocked() {
   local alias_body="$1"


### PR DESCRIPTION
**Roadmap D4 — Modularize the launcher.** Extracts the egress-endpoint assembly cluster (8 functions: provider_endpoints, target_broker_endpoints, credential_extra_endpoints, dedupe/subtract_endpoint_list, fail_empty_egress_after_deny, egress_enforcement_label, build_runtime_host_aliases) from the 8,797-line `scripts/workcell` into a new `scripts/lib/launcher/egress-endpoints.sh`, following the existing lib-module pattern. **Behavior-identical** — pure relocation of a contiguous, tightly-bounded block (deps: csv_contains_value, go_hostutil, 4 read-only launch globals, RUNTIME_NETWORK_ARGS).

Chosen over the other candidates by coupling analysis: environment-scrubbing is called before ROOT_DIR resolution (startup-ordering coupled); dispatch is top-level orchestration bound to nearly every global. This block was the cleanest boundary.

## Behavior-identical proof
- Moved function bodies **byte-identical** to the removed block (diff-verified).
- `scripts/workcell --dry-run` across 7 provider/target combos (copilot/claude/gemini/codex on colima; copilot/aws-ec2-ssm; claude/gcp-vm; codex/docker-desktop) **byte-identical** before/after (normalizing only live-DNS IPs + random session suffixes).
- All 5 repo dry-run scenario scripts pass.

## Sizes / manifest
`scripts/workcell` 8797→8679; new module 146 lines. Added the module to the control-plane host-artifact list (internal/metadatautil/core.go), regenerated control-plane-manifest.json, `verify-control-plane-manifest.sh` passes. Added to shellcheck/shfmt lists + a launcher-contract.md module section.

## Validation
shellcheck -x, shfmt, verify-control-plane-manifest.sh, verify-operator-contract.sh, go build, go test (metadatautil/testkit/workcellhardening) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)