### PR TITLE
.r D5: extract git-policy module from rust lib.rs (ABI-preserved)

### DIFF
--- a/internal/gitconfigblocklist/gitconfigblocklist.go
+++ b/internal/gitconfigblocklist/gitconfigblocklist.go
@@ -13,7 +13,7 @@
 //
 //   - scripts/workcell                      (host launcher)
 //   - runtime/container/bin/git             (in-container git wrapper)
-//   - runtime/container/rust/src/lib.rs     (LD_PRELOAD exec guard)
+//   - runtime/container/rust/src/gitpolicy.rs (LD_PRELOAD exec guard)
 //
 // The check reads the TOML `keys = [ ... ]` array and the
 // `[[prefix_suffix_patterns]]` tables and asserts every key (as a fixed
@@ -43,7 +43,7 @@ const tomlRelPath = "policy/git-config-blocklist.toml"
 var enforcerRelPaths = []string{
 	"scripts/workcell",
 	"runtime/container/bin/git",
-	"runtime/container/rust/src/lib.rs",
+	"runtime/container/rust/src/gitpolicy.rs",
 }
 
 // Check runs the git-config blocklist parity invariant against the repo

--- a/internal/gitconfigblocklist/gitconfigblocklist_test.go
+++ b/internal/gitconfigblocklist/gitconfigblocklist_test.go
@@ -121,13 +121,13 @@ func TestCheck(t *testing.T) {
 				// All enforcers have the key "core.askpass" and the prefix
 				// "credential." but the last one lacks the ".helper" suffix.
 				m := map[string]string{
-					"scripts/workcell":                  "core.askpass credential. .helper\n",
-					"runtime/container/bin/git":         "core.askpass credential. .helper\n",
-					"runtime/container/rust/src/lib.rs": "core.askpass credential. nohelper\n",
+					"scripts/workcell":                        "core.askpass credential. .helper\n",
+					"runtime/container/bin/git":               "core.askpass credential. .helper\n",
+					"runtime/container/rust/src/gitpolicy.rs": "core.askpass credential. nohelper\n",
 				}
 				return m
 			}(),
-			wantErr: "git-config blocklist prefix+suffix pattern 'credential.*.helper' missing in %ROOT%/runtime/container/rust/src/lib.rs",
+			wantErr: "git-config blocklist prefix+suffix pattern 'credential.*.helper' missing in %ROOT%/runtime/container/rust/src/gitpolicy.rs",
 		},
 		{
 			name:    "empty keys",

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -144,7 +144,7 @@ var rustMutations = []mutationCase{
 		label:        "root-prefix matcher",
 	},
 	{
-		relativePath: "runtime/container/rust/src/lib.rs",
+		relativePath: "runtime/container/rust/src/gitpolicy.rs",
 		original:     `            | "core.fsmonitor"` + "\n",
 		replacement:  ``,
 		label:        "core.fsmonitor git-config blocking",

--- a/policy/git-config-blocklist.toml
+++ b/policy/git-config-blocklist.toml
@@ -12,7 +12,7 @@
 #     bash case statement in git_config_key_is_blocked() — drops keys
 #     via early-exit at the wrapper level.
 #
-#   - runtime/container/rust/src/lib.rs
+#   - runtime/container/rust/src/gitpolicy.rs
 #     git_config_key_is_blocked() — blocks at exec syscall interception
 #     inside libworkcell_exec_guard.so.
 #

--- a/runtime/container/rust/src/gitpolicy.rs
+++ b/runtime/container/rust/src/gitpolicy.rs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//! Git control-plane policy: pure argument, inline-config, and environment
+//! classification for the exec guard. These functions decide whether a `git`
+//! invocation carries an unsafe control-plane override (config keys, path
+//! overrides, `--no-verify`, or ambient `GIT_*`/editor/pager environment). They
+//! hold no `unsafe` code and no ABI surface; the interposed exec functions in
+//! `lib.rs` call into them.
+
+use crate::is_git_path;
+
+pub(crate) fn git_config_key_has_prefix_and_suffix(key: &str, prefix: &str, suffix: &str) -> bool {
+    // `prefix`/`suffix` are ASCII, so slice with char-boundary-safe `get`: a git
+    // config key with a multibyte character straddling the byte offset returns
+    // `None` (correctly no match) instead of panicking on a non-boundary index.
+    key.len() > prefix.len() + suffix.len()
+        && key
+            .get(..prefix.len())
+            .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
+        && key
+            .get(key.len() - suffix.len()..)
+            .is_some_and(|tail| tail.eq_ignore_ascii_case(suffix))
+}
+
+pub(crate) fn git_config_key_is_blocked(key: &str) -> bool {
+    matches!(
+        key.to_ascii_lowercase().as_str(),
+        "core.askpass"
+            | "core.editor"
+            | "core.fsmonitor"
+            | "core.hookspath"
+            | "core.pager"
+            | "core.sshcommand"
+            | "core.worktree"
+            | "credential.helper"
+            | "diff.external"
+            | "include.path"
+            | "sequence.editor"
+    ) || git_config_key_has_prefix_and_suffix(key, "credential.", ".helper")
+        || git_config_key_has_prefix_and_suffix(key, "includeif.", ".path")
+        || (key.len() > 6
+            && key
+                .get(..6)
+                .is_some_and(|head| head.eq_ignore_ascii_case("pager.")))
+}
+
+pub(crate) fn git_config_spec_is_blocked(spec: &str) -> bool {
+    let key = spec.split_once('=').map(|(key, _)| key).unwrap_or(spec);
+    let value = spec.split_once('=').map(|(_, value)| value);
+    if let Some(value) = value
+        && git_config_spec_value_is_explicit_safe(key, value)
+    {
+        return false;
+    }
+    !key.is_empty() && git_config_key_is_blocked(key)
+}
+
+pub(crate) fn git_config_spec_value_is_explicit_safe(key: &str, value: &str) -> bool {
+    key.eq_ignore_ascii_case("core.fsmonitor")
+        && matches!(
+            value.to_ascii_lowercase().as_str(),
+            "" | "false" | "0" | "no" | "off"
+        )
+}
+
+#[cfg(test)]
+pub(crate) fn should_block(path: &str, args: &[String]) -> bool {
+    should_block_reason(path, args).is_some()
+}
+
+pub(crate) fn should_block_reason(path: &str, args: &[String]) -> Option<&'static str> {
+    if !is_git_path(path) || args.is_empty() {
+        return None;
+    }
+
+    let mut saw_commit = false;
+    let mut expect_config_arg = false;
+    let mut expect_path_override_arg: Option<GitPathOverrideKind> = None;
+    let mut expect_chdir_arg = false;
+
+    for arg in args.iter().skip(1) {
+        if expect_chdir_arg {
+            expect_chdir_arg = false;
+            continue;
+        }
+
+        if let Some(kind) = expect_path_override_arg.take() {
+            if !git_path_override_is_allowed(kind, arg) {
+                return Some(git_path_override_reason(kind));
+            }
+            continue;
+        }
+
+        if expect_config_arg {
+            expect_config_arg = false;
+            if git_config_spec_is_blocked(arg) {
+                return Some("unsafe-inline-config");
+            }
+            continue;
+        }
+
+        if arg == "--" {
+            break;
+        }
+        if saw_commit && git_commit_short_arg_invokes_no_verify(arg) {
+            return Some("unsafe-commit-short-no-verify");
+        }
+
+        match arg.as_str() {
+            "-c" | "--config-env" => {
+                expect_config_arg = true;
+                continue;
+            }
+            "-C" => {
+                expect_chdir_arg = true;
+                continue;
+            }
+            "--exec-path" => return Some("unsafe-exec-path"),
+            "--no-verify" => return Some("unsafe-no-verify"),
+            "--git-dir" => {
+                expect_path_override_arg = Some(GitPathOverrideKind::GitDir);
+                continue;
+            }
+            "--work-tree" => {
+                expect_path_override_arg = Some(GitPathOverrideKind::WorkTree);
+                continue;
+            }
+            "commit" => saw_commit = true,
+            _ => {}
+        }
+
+        if let Some(spec) = arg.strip_prefix("--config-env=")
+            && git_config_spec_is_blocked(spec)
+        {
+            return Some("unsafe-config-env");
+        }
+        if arg.starts_with("--exec-path=") {
+            return Some("unsafe-exec-path");
+        }
+        if let Some(value) = arg.strip_prefix("--git-dir=")
+            && !git_path_override_is_allowed(GitPathOverrideKind::GitDir, value)
+        {
+            return Some("unsafe-git-dir");
+        }
+        if let Some(value) = arg.strip_prefix("--work-tree=")
+            && !git_path_override_is_allowed(GitPathOverrideKind::WorkTree, value)
+        {
+            return Some("unsafe-work-tree");
+        }
+    }
+
+    None
+}
+
+#[derive(Clone, Copy)]
+enum GitPathOverrideKind {
+    GitDir,
+    WorkTree,
+}
+
+fn git_path_override_reason(kind: GitPathOverrideKind) -> &'static str {
+    match kind {
+        GitPathOverrideKind::GitDir => "unsafe-git-dir",
+        GitPathOverrideKind::WorkTree => "unsafe-work-tree",
+    }
+}
+
+fn git_path_override_is_allowed(kind: GitPathOverrideKind, value: &str) -> bool {
+    let value = value.trim_end_matches('/');
+    match kind {
+        GitPathOverrideKind::GitDir => value == "/workspace/.git",
+        GitPathOverrideKind::WorkTree => value == "/workspace",
+    }
+}
+
+pub(crate) fn git_commit_short_arg_invokes_no_verify(arg: &str) -> bool {
+    if !arg.starts_with('-') || arg.starts_with("--") || arg.len() <= 1 {
+        return false;
+    }
+
+    for ch in arg[1..].chars() {
+        match ch {
+            'n' => return true,
+            'm' | 'F' | 'C' | 'c' | 't' | 'u' | 'S' => return false,
+            _ => {}
+        }
+    }
+
+    false
+}
+
+pub(crate) fn env_has_unsafe_git_override(env_entries: &[String]) -> bool {
+    let mut count = 0usize;
+
+    for entry in env_entries {
+        // Inline argv config may disable fsmonitor with explicit false-ish
+        // values, but env-sourced Git config stays fail-closed because it is
+        // inherited ambiently.
+        if let Some(value) = entry.strip_prefix("GIT_CONFIG_PARAMETERS=") {
+            let lower = value.to_ascii_lowercase();
+            if lower.contains("core.askpass")
+                || lower.contains("core.editor")
+                || lower.contains("core.fsmonitor")
+                || lower.contains("core.hookspath")
+                || lower.contains("core.pager")
+                || lower.contains("core.sshcommand")
+                || lower.contains("core.worktree")
+                || lower.contains("credential.helper")
+                || lower.contains("diff.external")
+                || lower.contains("include.path")
+                || lower.contains("includeif.")
+                || lower.contains("pager.")
+                || lower.contains("sequence.editor")
+            {
+                return true;
+            }
+        }
+
+        if entry.starts_with("GIT_DIR=")
+            || entry.starts_with("GIT_WORK_TREE=")
+            || entry.starts_with("GIT_COMMON_DIR=")
+            || entry.starts_with("GIT_EXEC_PATH=")
+            || entry.starts_with("GIT_OBJECT_DIRECTORY=")
+            || entry.starts_with("GIT_ALTERNATE_OBJECT_DIRECTORIES=")
+            || entry.starts_with("GIT_INDEX_FILE=")
+            || entry.starts_with("GIT_ASKPASS=")
+            || entry.starts_with("GIT_EDITOR=")
+            || entry.starts_with("GIT_EXTERNAL_DIFF=")
+            || entry.starts_with("GIT_CONFIG_SYSTEM=")
+            || entry.starts_with("GIT_PAGER=")
+            || entry.starts_with("GIT_SEQUENCE_EDITOR=")
+            || entry.starts_with("GIT_SSH=")
+            || entry.starts_with("GIT_SSH_COMMAND=")
+            || entry.starts_with("SSH_ASKPASS=")
+            || entry.starts_with("EDITOR=")
+            || entry.starts_with("PAGER=")
+            || entry.starts_with("VISUAL=")
+        {
+            return true;
+        }
+
+        if let Some(value) = entry.strip_prefix("GIT_CONFIG_GLOBAL=")
+            && value != "/dev/null"
+        {
+            return true;
+        }
+
+        if let Some(value) = entry.strip_prefix("GIT_CONFIG_NOSYSTEM=")
+            && value != "1"
+        {
+            return true;
+        }
+
+        if let Some(value) = entry.strip_prefix("GIT_CONFIG_COUNT=") {
+            count = value.parse::<usize>().unwrap_or(0);
+        }
+    }
+
+    if count == 0 {
+        return false;
+    }
+
+    env_entries.iter().any(|entry| {
+        entry
+            .strip_prefix("GIT_CONFIG_KEY_")
+            .and_then(|value| value.split_once('=').map(|(_, key)| key))
+            .is_some_and(git_config_key_is_blocked)
+    })
+}

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -19,6 +19,9 @@ use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::sync::OnceLock;
 
+mod gitpolicy;
+use gitpolicy::{env_has_unsafe_git_override, should_block_reason};
+
 // SAFETY: matches libc's process-global char **environ; reads assume no concurrent setenv/putenv mutation.
 unsafe extern "C" {
     static mut environ: *mut *mut c_char;
@@ -1162,60 +1165,6 @@ fn resolve_exec_search_target(file: &str, env_entries: &[String]) -> String {
         .unwrap_or_else(|| file.to_owned())
 }
 
-fn git_config_key_has_prefix_and_suffix(key: &str, prefix: &str, suffix: &str) -> bool {
-    // `prefix`/`suffix` are ASCII, so slice with char-boundary-safe `get`: a git
-    // config key with a multibyte character straddling the byte offset returns
-    // `None` (correctly no match) instead of panicking on a non-boundary index.
-    key.len() > prefix.len() + suffix.len()
-        && key
-            .get(..prefix.len())
-            .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
-        && key
-            .get(key.len() - suffix.len()..)
-            .is_some_and(|tail| tail.eq_ignore_ascii_case(suffix))
-}
-
-fn git_config_key_is_blocked(key: &str) -> bool {
-    matches!(
-        key.to_ascii_lowercase().as_str(),
-        "core.askpass"
-            | "core.editor"
-            | "core.fsmonitor"
-            | "core.hookspath"
-            | "core.pager"
-            | "core.sshcommand"
-            | "core.worktree"
-            | "credential.helper"
-            | "diff.external"
-            | "include.path"
-            | "sequence.editor"
-    ) || git_config_key_has_prefix_and_suffix(key, "credential.", ".helper")
-        || git_config_key_has_prefix_and_suffix(key, "includeif.", ".path")
-        || (key.len() > 6
-            && key
-                .get(..6)
-                .is_some_and(|head| head.eq_ignore_ascii_case("pager.")))
-}
-
-fn git_config_spec_is_blocked(spec: &str) -> bool {
-    let key = spec.split_once('=').map(|(key, _)| key).unwrap_or(spec);
-    let value = spec.split_once('=').map(|(_, value)| value);
-    if let Some(value) = value
-        && git_config_spec_value_is_explicit_safe(key, value)
-    {
-        return false;
-    }
-    !key.is_empty() && git_config_key_is_blocked(key)
-}
-
-fn git_config_spec_value_is_explicit_safe(key: &str, value: &str) -> bool {
-    key.eq_ignore_ascii_case("core.fsmonitor")
-        && matches!(
-            value.to_ascii_lowercase().as_str(),
-            "" | "false" | "0" | "no" | "off"
-        )
-}
-
 fn stat_matches_protected_git(candidate: &StatSignature) -> bool {
     protected_git_signatures()
         .iter()
@@ -1239,211 +1188,6 @@ fn is_git_path(path: &str) -> bool {
         .ok()
         .map(|metadata| stat_matches_protected_git(&metadata_signature_from_metadata(&metadata)))
         .unwrap_or(false)
-}
-
-#[cfg(test)]
-fn should_block(path: &str, args: &[String]) -> bool {
-    should_block_reason(path, args).is_some()
-}
-
-fn should_block_reason(path: &str, args: &[String]) -> Option<&'static str> {
-    if !is_git_path(path) || args.is_empty() {
-        return None;
-    }
-
-    let mut saw_commit = false;
-    let mut expect_config_arg = false;
-    let mut expect_path_override_arg: Option<GitPathOverrideKind> = None;
-    let mut expect_chdir_arg = false;
-
-    for arg in args.iter().skip(1) {
-        if expect_chdir_arg {
-            expect_chdir_arg = false;
-            continue;
-        }
-
-        if let Some(kind) = expect_path_override_arg.take() {
-            if !git_path_override_is_allowed(kind, arg) {
-                return Some(git_path_override_reason(kind));
-            }
-            continue;
-        }
-
-        if expect_config_arg {
-            expect_config_arg = false;
-            if git_config_spec_is_blocked(arg) {
-                return Some("unsafe-inline-config");
-            }
-            continue;
-        }
-
-        if arg == "--" {
-            break;
-        }
-        if saw_commit && git_commit_short_arg_invokes_no_verify(arg) {
-            return Some("unsafe-commit-short-no-verify");
-        }
-
-        match arg.as_str() {
-            "-c" | "--config-env" => {
-                expect_config_arg = true;
-                continue;
-            }
-            "-C" => {
-                expect_chdir_arg = true;
-                continue;
-            }
-            "--exec-path" => return Some("unsafe-exec-path"),
-            "--no-verify" => return Some("unsafe-no-verify"),
-            "--git-dir" => {
-                expect_path_override_arg = Some(GitPathOverrideKind::GitDir);
-                continue;
-            }
-            "--work-tree" => {
-                expect_path_override_arg = Some(GitPathOverrideKind::WorkTree);
-                continue;
-            }
-            "commit" => saw_commit = true,
-            _ => {}
-        }
-
-        if let Some(spec) = arg.strip_prefix("--config-env=")
-            && git_config_spec_is_blocked(spec)
-        {
-            return Some("unsafe-config-env");
-        }
-        if arg.starts_with("--exec-path=") {
-            return Some("unsafe-exec-path");
-        }
-        if let Some(value) = arg.strip_prefix("--git-dir=")
-            && !git_path_override_is_allowed(GitPathOverrideKind::GitDir, value)
-        {
-            return Some("unsafe-git-dir");
-        }
-        if let Some(value) = arg.strip_prefix("--work-tree=")
-            && !git_path_override_is_allowed(GitPathOverrideKind::WorkTree, value)
-        {
-            return Some("unsafe-work-tree");
-        }
-    }
-
-    None
-}
-
-#[derive(Clone, Copy)]
-enum GitPathOverrideKind {
-    GitDir,
-    WorkTree,
-}
-
-fn git_path_override_reason(kind: GitPathOverrideKind) -> &'static str {
-    match kind {
-        GitPathOverrideKind::GitDir => "unsafe-git-dir",
-        GitPathOverrideKind::WorkTree => "unsafe-work-tree",
-    }
-}
-
-fn git_path_override_is_allowed(kind: GitPathOverrideKind, value: &str) -> bool {
-    let value = value.trim_end_matches('/');
-    match kind {
-        GitPathOverrideKind::GitDir => value == "/workspace/.git",
-        GitPathOverrideKind::WorkTree => value == "/workspace",
-    }
-}
-
-fn git_commit_short_arg_invokes_no_verify(arg: &str) -> bool {
-    if !arg.starts_with('-') || arg.starts_with("--") || arg.len() <= 1 {
-        return false;
-    }
-
-    for ch in arg[1..].chars() {
-        match ch {
-            'n' => return true,
-            'm' | 'F' | 'C' | 'c' | 't' | 'u' | 'S' => return false,
-            _ => {}
-        }
-    }
-
-    false
-}
-
-fn env_has_unsafe_git_override(env_entries: &[String]) -> bool {
-    let mut count = 0usize;
-
-    for entry in env_entries {
-        // Inline argv config may disable fsmonitor with explicit false-ish
-        // values, but env-sourced Git config stays fail-closed because it is
-        // inherited ambiently.
-        if let Some(value) = entry.strip_prefix("GIT_CONFIG_PARAMETERS=") {
-            let lower = value.to_ascii_lowercase();
-            if lower.contains("core.askpass")
-                || lower.contains("core.editor")
-                || lower.contains("core.fsmonitor")
-                || lower.contains("core.hookspath")
-                || lower.contains("core.pager")
-                || lower.contains("core.sshcommand")
-                || lower.contains("core.worktree")
-                || lower.contains("credential.helper")
-                || lower.contains("diff.external")
-                || lower.contains("include.path")
-                || lower.contains("includeif.")
-                || lower.contains("pager.")
-                || lower.contains("sequence.editor")
-            {
-                return true;
-            }
-        }
-
-        if entry.starts_with("GIT_DIR=")
-            || entry.starts_with("GIT_WORK_TREE=")
-            || entry.starts_with("GIT_COMMON_DIR=")
-            || entry.starts_with("GIT_EXEC_PATH=")
-            || entry.starts_with("GIT_OBJECT_DIRECTORY=")
-            || entry.starts_with("GIT_ALTERNATE_OBJECT_DIRECTORIES=")
-            || entry.starts_with("GIT_INDEX_FILE=")
-            || entry.starts_with("GIT_ASKPASS=")
-            || entry.starts_with("GIT_EDITOR=")
-            || entry.starts_with("GIT_EXTERNAL_DIFF=")
-            || entry.starts_with("GIT_CONFIG_SYSTEM=")
-            || entry.starts_with("GIT_PAGER=")
-            || entry.starts_with("GIT_SEQUENCE_EDITOR=")
-            || entry.starts_with("GIT_SSH=")
-            || entry.starts_with("GIT_SSH_COMMAND=")
-            || entry.starts_with("SSH_ASKPASS=")
-            || entry.starts_with("EDITOR=")
-            || entry.starts_with("PAGER=")
-            || entry.starts_with("VISUAL=")
-        {
-            return true;
-        }
-
-        if let Some(value) = entry.strip_prefix("GIT_CONFIG_GLOBAL=")
-            && value != "/dev/null"
-        {
-            return true;
-        }
-
-        if let Some(value) = entry.strip_prefix("GIT_CONFIG_NOSYSTEM=")
-            && value != "1"
-        {
-            return true;
-        }
-
-        if let Some(value) = entry.strip_prefix("GIT_CONFIG_COUNT=") {
-            count = value.parse::<usize>().unwrap_or(0);
-        }
-    }
-
-    if count == 0 {
-        return false;
-    }
-
-    env_entries.iter().any(|entry| {
-        entry
-            .strip_prefix("GIT_CONFIG_KEY_")
-            .and_then(|value| value.split_once('=').map(|(_, key)| key))
-            .is_some_and(git_config_key_is_blocked)
-    })
 }
 
 fn report(message: &str) {
@@ -2065,28 +1809,29 @@ pub mod fuzz_api {
 
     /// Fuzz `env_has_unsafe_git_override`.
     pub fn env_has_unsafe_git_override(env_entries: &[String]) -> bool {
-        super::env_has_unsafe_git_override(env_entries)
+        crate::gitpolicy::env_has_unsafe_git_override(env_entries)
     }
 
     /// Fuzz `git_config_spec_is_blocked`.
     pub fn git_config_spec_is_blocked(spec: &str) -> bool {
-        super::git_config_spec_is_blocked(spec)
+        crate::gitpolicy::git_config_spec_is_blocked(spec)
     }
 
     /// Fuzz `git_config_key_is_blocked`.
     pub fn git_config_key_is_blocked(key: &str) -> bool {
-        super::git_config_key_is_blocked(key)
+        crate::gitpolicy::git_config_key_is_blocked(key)
     }
 
     /// Fuzz `git_config_spec_value_is_explicit_safe`.
     pub fn git_config_spec_value_is_explicit_safe(key: &str, value: &str) -> bool {
-        super::git_config_spec_value_is_explicit_safe(key, value)
+        crate::gitpolicy::git_config_spec_value_is_explicit_safe(key, value)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gitpolicy::*;
     use std::os::unix::fs::symlink;
     use std::path::PathBuf;
     use std::process;


### PR DESCRIPTION
**Roadmap D5 — Split the Rust lib.rs into focused modules.** `runtime/container/rust/src/lib.rs` was a genuine 2,421-line monolith (an LD_PRELOAD/syscall-interposition shim, cdylib+rlib). This extracts the **git-policy** module — the one cleanly-separable, unsafe-free cut — into `runtime/container/rust/src/gitpolicy.rs` (~270 lines): config-key/spec blocking, `should_block_reason` argument scanner, git-dir/work-tree overrides, commit no-verify detection, ambient `GIT_*`/editor/pager override detection. **Pure relocation** — logic byte-identical (incl. the char-boundary-safe slicing that fixed a prior fuzz-found panic); `is_git_path` stat-identity stays in lib.rs with the stat-signature group (referenced via `crate::is_git_path`).

## ABI + behavior preserved (load-bearing for a preload shim)
- **Exported symbol set UNCHANGED** — `nm -gU` on the built cdylib before vs after is identical (9 symbols: execve/execv/execvp/execvpe/execveat/fexecve/posix_spawn/posix_spawnp/workcell_syscall_shim; diff empty). The shim ABI fns were not touched.
- **A4** stays green: gitpolicy has zero unsafe; clippy `undocumented_unsafe_blocks = deny` clean; the validate-repo.sh unsafe-extern guard passes.
- **A3** fuzz `fuzz_api` wrapper names/signatures unchanged; compiles under `--cfg fuzzing`.
- `cargo build/test/clippy -D warnings/fmt --check` all clean; 12 lib tests pass.

## Partial split (1 of ~5 modules) + follow-up sequence
A full split is ~4,000 diff lines (over the 1,200 gate) + needs careful pub(crate) threading across the runtime-protection↔path-validation↔shim web. Follow-ups, each independently reviewable: (1) runtime_protection, (2) pathvalidation, (3) wrappers, (4) shim (holds the ABI symbols) last. This PR: 2 files / 541 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)