### PR TITLE
^F Add %q audit-line decoder with dup-key rejection (internal/ocsf)

### DIFF
--- a/internal/ocsf/auditline.go
+++ b/internal/ocsf/auditline.go
@@ -166,7 +166,11 @@ func decodeAnsiC(runes []rune, start int) (string, int, error) {
 			default:
 				if isOctal(n) && i+3 < len(runes) && isOctal(runes[i+2]) && isOctal(runes[i+3]) {
 					val := (int(n)-'0')*64 + (int(runes[i+2])-'0')*8 + (int(runes[i+3]) - '0')
-					b.WriteRune(rune(val))
+					// Octal escapes are raw BYTES, not runes: under LC_ALL=C bash %q
+					// emits a non-ASCII value as one \ooo per UTF-8 byte (é → \303\251).
+					// WriteByte reassembles the original multibyte sequence; WriteRune
+					// would re-encode each byte 0xC3/0xA9 as its own rune ("Ã©").
+					b.WriteByte(byte(val))
 					i += 4
 				} else {
 					b.WriteRune(n)

--- a/internal/ocsf/auditline.go
+++ b/internal/ocsf/auditline.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package ocsf
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Audit records are written by scripts/workcell's append_audit_record_to_path
+// with bash `printf '%q '` per token, so a value containing spaces or control
+// bytes is escaped (spaces → `\ `, newlines → the ANSI-C `$'...'` form). The
+// launch record's `endpoints=` field is a SPACE-DELIMITED allowlist
+// (ALLOW_ENDPOINTS in scripts/workcell), so a naive strings.Fields split would
+// truncate it at the first space. The repo's authoritative encoder is
+// bashQuote in internal/publishpr/host_exec.go (documented as the bash-3.2 form
+// scripts/workcell runs under); no matching decoder existed because the other
+// audit readers (auditLineEvent, auditLineHasSessionID) only inspect the
+// space-free event/session_id keys. decodeAuditLine is the exact inverse of
+// that encoder and is validated against real `bash printf %q` in the tests.
+//
+// NOTE: this reverses the bash `%q` encoding only. Path values written by the
+// Go audit writer's percent-encoding (encodeAuditPathValue in
+// internal/applecontainer/audit.go) pass through as literals — they are a
+// separate writer's concern and out of F1's scope; conflating the two would
+// risk double-decoding.
+
+// auditField is one ordered key/value pair decoded from an audit record.
+type auditField struct {
+	key   string
+	value string
+}
+
+// decodeAuditLine tokenizes a `%q`-encoded audit line into ordered, un-escaped
+// key/value fields. It REJECTS a record that carries a duplicate key
+// (fail-closed): a tampered line such as `session_id=A session_id=B` must be
+// detected rather than silently mapped to first- or last-wins, because the OCSF
+// export is evidence. Tokens without an '=' are tolerated and skipped, matching
+// the existing readers' tolerance for torn crash lines.
+func decodeAuditLine(line string) ([]auditField, error) {
+	tokens, err := splitQuotedTokens(line)
+	if err != nil {
+		return nil, err
+	}
+	fields := make([]auditField, 0, len(tokens))
+	seen := make(map[string]struct{}, len(tokens))
+	for _, tok := range tokens {
+		key, value, ok := strings.Cut(tok, "=")
+		if !ok {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			return nil, fmt.Errorf("audit record has duplicate key %q", key)
+		}
+		seen[key] = struct{}{}
+		fields = append(fields, auditField{key: key, value: value})
+	}
+	return fields, nil
+}
+
+// splitQuotedTokens splits a bash `%q`-encoded line into decoded tokens,
+// breaking on UNESCAPED whitespace. Backslash escapes the next rune literally
+// (so `\ ` is a non-splitting space); `$'...'` is decoded as an ANSI-C block;
+// the bare two-single-quote empty-string form yields an empty token. It is the inverse of
+// bashQuote.
+func splitQuotedTokens(line string) ([]string, error) {
+	var (
+		tokens  []string
+		cur     strings.Builder
+		inToken bool
+	)
+	runes := []rune(line)
+	for i := 0; i < len(runes); {
+		r := runes[i]
+		switch {
+		case r == ' ' || r == '\t':
+			if inToken {
+				tokens = append(tokens, cur.String())
+				cur.Reset()
+				inToken = false
+			}
+			i++
+		case r == '\\':
+			inToken = true
+			if i+1 >= len(runes) {
+				// Trailing backslash on a torn line: keep it literally.
+				cur.WriteRune('\\')
+				i++
+				continue
+			}
+			cur.WriteRune(runes[i+1])
+			i += 2
+		case r == '$' && i+1 < len(runes) && runes[i+1] == '\'':
+			decoded, next, err := decodeAnsiC(runes, i+2)
+			if err != nil {
+				return nil, err
+			}
+			cur.WriteString(decoded)
+			inToken = true
+			i = next
+		case r == '\'' && i+1 < len(runes) && runes[i+1] == '\'':
+			// bash `%q` empty-string form: an empty token.
+			inToken = true
+			i += 2
+		default:
+			cur.WriteRune(r)
+			inToken = true
+			i++
+		}
+	}
+	if inToken {
+		tokens = append(tokens, cur.String())
+	}
+	return tokens, nil
+}
+
+// decodeAnsiC decodes the body of a bash ANSI-C `$'...'` block starting at
+// runes[start], returning the decoded string and the index just past the
+// closing quote. It handles the escapes bashQuote emits: \n \t \r \\ \' and the
+// three-digit octal \ooo used for other non-printable bytes. An unterminated
+// block is an error (a corrupt record), keeping decode fail-closed.
+func decodeAnsiC(runes []rune, start int) (string, int, error) {
+	var b strings.Builder
+	for i := start; i < len(runes); {
+		r := runes[i]
+		if r == '\'' {
+			return b.String(), i + 1, nil
+		}
+		if r == '\\' && i+1 < len(runes) {
+			n := runes[i+1]
+			switch n {
+			case 'n':
+				b.WriteRune('\n')
+				i += 2
+			case 't':
+				b.WriteRune('\t')
+				i += 2
+			case 'r':
+				b.WriteRune('\r')
+				i += 2
+			case '\\':
+				b.WriteRune('\\')
+				i += 2
+			case '\'':
+				b.WriteRune('\'')
+				i += 2
+			default:
+				if isOctal(n) && i+3 < len(runes) && isOctal(runes[i+2]) && isOctal(runes[i+3]) {
+					val := (int(n)-'0')*64 + (int(runes[i+2])-'0')*8 + (int(runes[i+3]) - '0')
+					b.WriteRune(rune(val))
+					i += 4
+				} else {
+					b.WriteRune(n)
+					i += 2
+				}
+			}
+			continue
+		}
+		b.WriteRune(r)
+		i++
+	}
+	return "", 0, fmt.Errorf("unterminated $'...' quote in audit record")
+}
+
+func isOctal(r rune) bool { return r >= '0' && r <= '7' }

--- a/internal/ocsf/auditline.go
+++ b/internal/ocsf/auditline.go
@@ -117,9 +117,12 @@ func splitQuotedTokens(line string) ([]string, error) {
 
 // decodeAnsiC decodes the body of a bash ANSI-C `$'...'` block starting at
 // runes[start], returning the decoded string and the index just past the
-// closing quote. It handles the escapes bashQuote emits: \n \t \r \\ \' and the
-// three-digit octal \ooo used for other non-printable bytes. An unterminated
-// block is an error (a corrupt record), keeping decode fail-closed.
+// closing quote. It handles the ANSI-C escapes bash `%q` emits for control
+// bytes: the named forms \a \b \e \f \n \r \t \v, the literal \\ and \', and the
+// three-digit octal \ooo used for any other non-printable byte. (Without the
+// named-control cases, a byte such as BEL would arrive as `$'\a'` and decode to
+// the literal letter "a", silently corrupting the exported evidence.) An
+// unterminated block is an error (a corrupt record), keeping decode fail-closed.
 func decodeAnsiC(runes []rune, start int) (string, int, error) {
 	var b strings.Builder
 	for i := start; i < len(runes); {
@@ -130,14 +133,29 @@ func decodeAnsiC(runes []rune, start int) (string, int, error) {
 		if r == '\\' && i+1 < len(runes) {
 			n := runes[i+1]
 			switch n {
+			case 'a':
+				b.WriteRune('\a') // BEL 0x07
+				i += 2
+			case 'b':
+				b.WriteRune('\b') // BS 0x08
+				i += 2
+			case 'e', 'E':
+				b.WriteRune('\x1b') // ESC 0x1b (bash emits \e; \E accepted too)
+				i += 2
+			case 'f':
+				b.WriteRune('\f') // FF 0x0c
+				i += 2
 			case 'n':
 				b.WriteRune('\n')
+				i += 2
+			case 'r':
+				b.WriteRune('\r')
 				i += 2
 			case 't':
 				b.WriteRune('\t')
 				i += 2
-			case 'r':
-				b.WriteRune('\r')
+			case 'v':
+				b.WriteRune('\v') // VT 0x0b
 				i += 2
 			case '\\':
 				b.WriteRune('\\')

--- a/internal/ocsf/auditline_test.go
+++ b/internal/ocsf/auditline_test.go
@@ -64,6 +64,56 @@ func TestDecodeAuditLineRoundTripBash(t *testing.T) {
 	}
 }
 
+// TestDecodeAnsiCNamedControlEscapesRoundTripBash proves every ANSI-C named
+// control escape that bash `%q` emits (\a \b \e \f \n \r \t \v) round-trips to
+// its real byte, not the literal letter. bash %q renders these control bytes in
+// the $'...' named form, so without the named-escape cases BEL would decode to
+// "a" and silently corrupt the exported evidence.
+func TestDecodeAnsiCNamedControlEscapesRoundTripBash(t *testing.T) {
+	// One value per named control byte bash %q emits in named form.
+	value := "x\ay\bz\x1bp\fq\nr\rs\tt\vu"
+	q, ok := bashQuoteToken(t, "note="+value)
+	if !ok {
+		t.Skip("bash not available for authoritative round-trip")
+	}
+	fields, err := decodeAuditLine(q)
+	if err != nil {
+		t.Fatalf("decodeAuditLine: %v\ntoken=%q", err, q)
+	}
+	if len(fields) != 1 || fields[0].key != "note" {
+		t.Fatalf("decoded %+v, want one note field (token=%q)", fields, q)
+	}
+	if fields[0].value != value {
+		t.Errorf("control-byte value decoded %q, want %q (token=%q)", fields[0].value, value, q)
+	}
+}
+
+// TestDecodeAnsiCNamedControlEscapes decodes each named control escape directly
+// (independent of a local bash) so the mapping is pinned even where bash is
+// absent.
+func TestDecodeAnsiCNamedControlEscapes(t *testing.T) {
+	cases := map[string]string{
+		`$'\a'`: "\a",
+		`$'\b'`: "\b",
+		`$'\e'`: "\x1b",
+		`$'\E'`: "\x1b",
+		`$'\f'`: "\f",
+		`$'\n'`: "\n",
+		`$'\r'`: "\r",
+		`$'\t'`: "\t",
+		`$'\v'`: "\v",
+	}
+	for enc, want := range cases {
+		fields, err := decodeAuditLine("k=" + enc)
+		if err != nil {
+			t.Fatalf("decodeAuditLine(%q): %v", enc, err)
+		}
+		if len(fields) != 1 || fields[0].value != want {
+			t.Errorf("decode %q: got %+v, want value %q", enc, fields, want)
+		}
+	}
+}
+
 // TestDecodeAuditLineSpacedValueDeterministic pins the concrete escaped form of
 // a space-delimited endpoints allowlist (independent of a local bash), proving
 // the value is not truncated at the first space.

--- a/internal/ocsf/auditline_test.go
+++ b/internal/ocsf/auditline_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package ocsf
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// bashQuoteToken encodes s exactly as scripts/workcell does — via the real
+// `bash printf %q` that writes the audit records — so the round-trip test is
+// validated against the authoritative encoder, not a reimplementation.
+func bashQuoteToken(t *testing.T, s string) (string, bool) {
+	t.Helper()
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		return "", false
+	}
+	out, err := exec.Command(bash, "-c", `printf '%q' "$1"`, "_", s).Output()
+	if err != nil {
+		t.Fatalf("bash printf %%q failed for %q: %v", s, err)
+	}
+	return string(out), true
+}
+
+// TestDecodeAuditLineRoundTripBash proves decodeAuditLine is the exact inverse
+// of the real `bash printf %q` audit encoder for values containing spaces, tabs,
+// and shell metacharacters — the cases a naive strings.Fields split corrupts.
+func TestDecodeAuditLineRoundTripBash(t *testing.T) {
+	cases := map[string]string{
+		"event":       "launch",
+		"session_id":  "sess-1",
+		"endpoints":   "api.anthropic.com:443 registry-1.docker.io:443 github.com:443",
+		"argv":        "run the tests",
+		"note":        "a\tb\tc",
+		"weird":       `quote'and"dollar$brace{}`,
+		"empty_after": "",
+	}
+
+	var tokens []string
+	for _, k := range []string{"event", "session_id", "endpoints", "argv", "note", "weird", "empty_after"} {
+		q, ok := bashQuoteToken(t, k+"="+cases[k])
+		if !ok {
+			t.Skip("bash not available for authoritative round-trip")
+		}
+		tokens = append(tokens, q)
+	}
+	line := strings.Join(tokens, " ")
+
+	fields, err := decodeAuditLine(line)
+	if err != nil {
+		t.Fatalf("decodeAuditLine: %v\nline=%q", err, line)
+	}
+	got := make(map[string]string, len(fields))
+	for _, f := range fields {
+		got[f.key] = f.value
+	}
+	for k, want := range cases {
+		if got[k] != want {
+			t.Errorf("field %q: decoded %q, want %q (line=%q)", k, got[k], want, line)
+		}
+	}
+}
+
+// TestDecodeAuditLineSpacedValueDeterministic pins the concrete escaped form of
+// a space-delimited endpoints allowlist (independent of a local bash), proving
+// the value is not truncated at the first space.
+func TestDecodeAuditLineSpacedValueDeterministic(t *testing.T) {
+	line := `event=launch endpoints=a:443\ b:443\ c:443 exit_status=0`
+	fields, err := decodeAuditLine(line)
+	if err != nil {
+		t.Fatalf("decodeAuditLine: %v", err)
+	}
+	got := make(map[string]string, len(fields))
+	for _, f := range fields {
+		got[f.key] = f.value
+	}
+	if got["endpoints"] != "a:443 b:443 c:443" {
+		t.Fatalf("spaced endpoints truncated: got %q want %q", got["endpoints"], "a:443 b:443 c:443")
+	}
+	if got["exit_status"] != "0" {
+		t.Fatalf("trailing field after a spaced value was lost: got %q", got["exit_status"])
+	}
+}
+
+// TestDecodeAuditLineRejectsDuplicateKey is the C1 dup-key defense: a tampered
+// record with a repeated key is rejected fail-closed, not silently first/last.
+func TestDecodeAuditLineRejectsDuplicateKey(t *testing.T) {
+	for _, line := range []string{
+		"session_id=A session_id=B event=launch",
+		"event=launch event=exit session_id=A",
+		"a=1 b=2 a=3",
+	} {
+		if _, err := decodeAuditLine(line); err == nil {
+			t.Errorf("expected duplicate-key rejection for %q, got nil error", line)
+		}
+	}
+}
+
+// TestDecodeAuditLineTolueratesTornToken keeps the existing readers' tolerance
+// for a torn crash line: a token without '=' is skipped, not an error.
+func TestDecodeAuditLineToleratesTornToken(t *testing.T) {
+	fields, err := decodeAuditLine("event=launch torn_fragment_no_newline session_id=A")
+	if err != nil {
+		t.Fatalf("torn token should be tolerated, got %v", err)
+	}
+	got := make(map[string]string, len(fields))
+	for _, f := range fields {
+		got[f.key] = f.value
+	}
+	if got["event"] != "launch" || got["session_id"] != "A" {
+		t.Fatalf("torn token disrupted parsing: %+v", got)
+	}
+}
+
+// TestDecodeAnsiCNewline proves the ANSI-C $'...' form (how bash %q encodes a
+// newline-bearing value) round-trips to a real newline.
+func TestDecodeAnsiCNewline(t *testing.T) {
+	fields, err := decodeAuditLine(`event=launch note=$'line1\nline2'`)
+	if err != nil {
+		t.Fatalf("decodeAuditLine: %v", err)
+	}
+	got := make(map[string]string, len(fields))
+	for _, f := range fields {
+		got[f.key] = f.value
+	}
+	if got["note"] != "line1\nline2" {
+		t.Fatalf("ANSI-C newline not decoded: got %q", got["note"])
+	}
+}
+
+// TestDecodeAnsiCUnterminated fails closed on a corrupt $'...' block.
+func TestDecodeAnsiCUnterminated(t *testing.T) {
+	if _, err := decodeAuditLine(`event=launch note=$'oops`); err == nil {
+		t.Fatal("expected error on unterminated $'...' block")
+	}
+}

--- a/internal/ocsf/auditline_test.go
+++ b/internal/ocsf/auditline_test.go
@@ -64,6 +64,52 @@ func TestDecodeAuditLineRoundTripBash(t *testing.T) {
 	}
 }
 
+// TestDecodeAnsiCOctalBytes proves octal escapes decode as raw BYTES: a UTF-8
+// multibyte value that bash %q under LC_ALL=C emits as a per-byte octal sequence
+// (é → \303\251, 😀 → \360\237\230\200) must reassemble to the original string,
+// not one rune per byte.
+func TestDecodeAnsiCOctalBytes(t *testing.T) {
+	cases := map[string]string{
+		`$'\303\251'`:         "é",
+		`$'caf\303\251'`:      "café",
+		`$'\360\237\230\200'`: "😀",
+		`$'\342\200\223'`:     "–", // en dash
+	}
+	for enc, want := range cases {
+		fields, err := decodeAuditLine("k=" + enc)
+		if err != nil {
+			t.Fatalf("decodeAuditLine(%q): %v", enc, err)
+		}
+		if len(fields) != 1 || fields[0].value != want {
+			t.Errorf("decode %q: got %+v, want value %q", enc, fields, want)
+		}
+	}
+}
+
+// TestDecodeAuditLineRoundTripBashUTF8LocaleC proves a non-ASCII value round-trips
+// through the real `bash printf %q` run under LC_ALL=C — the session-start locale
+// (scripts/workcell) under which bash emits octal per-byte escapes.
+func TestDecodeAuditLineRoundTripBashUTF8LocaleC(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available for authoritative round-trip")
+	}
+	const value = "workspace=/home/dev/café/naïve-😀"
+	cmd := exec.Command(bash, "-c", `printf '%q' "$1"`, "_", value)
+	cmd.Env = append(cmd.Environ(), "LC_ALL=C", "LANG=C")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("bash printf %%q under LC_ALL=C: %v", err)
+	}
+	fields, err := decodeAuditLine("field=" + string(out))
+	if err != nil {
+		t.Fatalf("decodeAuditLine: %v\ntoken=%q", err, out)
+	}
+	if len(fields) != 1 || fields[0].value != value {
+		t.Errorf("LC_ALL=C round-trip: decoded %+v, want value %q (token=%q)", fields, value, out)
+	}
+}
+
 // TestDecodeAnsiCNamedControlEscapesRoundTripBash proves every ANSI-C named
 // control escape that bash `%q` emits (\a \b \e \f \n \r \t \v) round-trips to
 // its real byte, not the literal letter. bash %q renders these control bytes in


### PR DESCRIPTION
Foundation for **F1 OCSF export** (#456), split out to keep each PR under the size cap.

Adds `decodeAuditLine` — the exact inverse of the repo's authoritative bash `printf %q` audit-record encoder (`bashQuote`, `internal/publishpr/host_exec.go`):
- **`%q` decode:** audit values with spaces/newlines (a space-delimited `ALLOW_ENDPOINTS` allowlist, `argv=hello\ world`) decode to their real value instead of being truncated at the first space by a naive `strings.Fields` split. Un-escapes `\<space>`, ANSI-C `$'…'`, octal.
- **Dup-key rejection (C1 pattern):** a tampered `session_id=A session_id=B` line is refused fail-closed — not silently first/last-wins. Applied to audit *evidence*, so stricter than the first-wins readers is correct.
- **Verified from the authoritative writer:** `TestDecodeAuditLineRoundTripBash` validates against real `bash printf %q` output — not a reimplementation.

Tests: round-trip-vs-bash, deterministic spaced-value decode, ANSI-C newline, unterminated-`$'` fail-closed, torn-token tolerance, dup-key rejection. `go test ./internal/ocsf/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)