### PR TITLE
^F Add per-writer encoding selection to the audit-line decoder (internal/ocsf)

### DIFF
--- a/internal/applecontainer/audit.go
+++ b/internal/applecontainer/audit.go
@@ -50,6 +50,15 @@ func encodeAuditPathValue(value string) string {
 	return b.String()
 }
 
+// DecodeAuditPathValue is the exported canonical decoder for audit path values
+// this package writes with encodeAuditPathValue. Cross-package readers (the OCSF
+// export in internal/ocsf) reuse it to recover the exact original path from a
+// percent-encoded AppleContainer audit field, so a literal backslash in a legal
+// POSIX path survives instead of being mis-read as a shell escape.
+func DecodeAuditPathValue(value string) string {
+	return decodeAuditPathValue(value)
+}
+
 func decodeAuditPathValue(value string) string {
 	var b strings.Builder
 	for i := 0; i < len(value); {

--- a/internal/ocsf/auditline.go
+++ b/internal/ocsf/auditline.go
@@ -6,25 +6,67 @@ package ocsf
 import (
 	"fmt"
 	"strings"
+
+	"github.com/omkhar/workcell/internal/applecontainer"
 )
 
-// Audit records are written by scripts/workcell's append_audit_record_to_path
-// with bash `printf '%q '` per token, so a value containing spaces or control
-// bytes is escaped (spaces → `\ `, newlines → the ANSI-C `$'...'` form). The
-// launch record's `endpoints=` field is a SPACE-DELIMITED allowlist
-// (ALLOW_ENDPOINTS in scripts/workcell), so a naive strings.Fields split would
-// truncate it at the first space. The repo's authoritative encoder is
-// bashQuote in internal/publishpr/host_exec.go (documented as the bash-3.2 form
-// scripts/workcell runs under); no matching decoder existed because the other
-// audit readers (auditLineEvent, auditLineHasSessionID) only inspect the
-// space-free event/session_id keys. decodeAuditLine is the exact inverse of
-// that encoder and is validated against real `bash printf %q` in the tests.
+// Audit records are written by TWO different encoders depending on which target
+// ran the session, and each session's log is written by exactly one of them (the
+// bash launcher's backends — colima/docker-desktop/aws-ec2-ssm/gcp-vm — never
+// share a log with the Go AppleContainer target). F1 selects the decoder per
+// session by the record's target_provider (auditEncodingForProvider):
 //
-// NOTE: this reverses the bash `%q` encoding only. Path values written by the
-// Go audit writer's percent-encoding (encodeAuditPathValue in
-// internal/applecontainer/audit.go) pass through as literals — they are a
-// separate writer's concern and out of F1's scope; conflating the two would
-// risk double-decoding.
+//   - encodingBashQuote — scripts/workcell's append_audit_record_to_path writes
+//     each token with bash `printf '%q '`, so a value with spaces or control
+//     bytes is escaped (spaces → `\ `, newlines → the ANSI-C `$'...'` form). The
+//     launch record's `endpoints=` field is a SPACE-DELIMITED allowlist
+//     (ALLOW_ENDPOINTS), so a naive strings.Fields split would truncate it at the
+//     first space. The authoritative encoder is bashQuote in
+//     internal/publishpr/host_exec.go; splitQuotedTokens is its exact inverse and
+//     is validated against real `bash printf %q` in the tests.
+//   - encodingPercentPath — internal/applecontainer writes plain Sprintf lines
+//     (single-space delimited) and percent-encodes only its path fields via
+//     encodeAuditPathValue (spaces → %20), leaving a literal backslash in a legal
+//     POSIX path UNCHANGED. Running such a line through the `%q` decoder would
+//     treat `\` as an escape and DROP it (`/tmp/a\b` → `/tmp/ab`), corrupting the
+//     workspace evidence. This path tokenizes with strings.Fields and percent-
+//     decodes the encoded fields via the canonical applecontainer.DecodeAuditPathValue.
+//
+// If the source cannot be identified as AppleContainer, the bash `%q` decoder is
+// used (the launcher backends are the common case); the percent decoder is only
+// selected on the unambiguous apple-container provider.
+
+// auditEncoding selects which on-disk audit encoding a record uses.
+type auditEncoding int
+
+const (
+	// encodingBashQuote is scripts/workcell's bash `printf %q` encoding.
+	encodingBashQuote auditEncoding = iota
+	// encodingPercentPath is internal/applecontainer's percent-encoded path form.
+	encodingPercentPath
+)
+
+// percentEncodedAuditFields are the audit field keys the AppleContainer writer
+// percent-encodes (encodeAuditPathValue in internal/applecontainer/recovery.go).
+// Only these are percent-decoded on read-back; every other field is raw Sprintf,
+// so decoding it could corrupt a legitimate literal `%` — keep the inverse exact.
+var percentEncodedAuditFields = map[string]struct{}{
+	"workspace":        {},
+	"workspace_origin": {},
+}
+
+// auditEncodingForProvider selects the audit decoder for a session from its
+// record's target_provider. The Go AppleContainer target (provider
+// "apple-container") writes percent-encoded path fields; every launcher backend
+// writes bash `%q`. The apple-container match is exact and drift-proof (the
+// canonical provider constant), and the safe default for anything else is the
+// bash `%q` decoder.
+func auditEncodingForProvider(provider string) auditEncoding {
+	if strings.TrimSpace(provider) == applecontainer.Provider {
+		return encodingPercentPath
+	}
+	return encodingBashQuote
+}
 
 // auditField is one ordered key/value pair decoded from an audit record.
 type auditField struct {
@@ -32,16 +74,26 @@ type auditField struct {
 	value string
 }
 
-// decodeAuditLine tokenizes a `%q`-encoded audit line into ordered, un-escaped
-// key/value fields. It REJECTS a record that carries a duplicate key
-// (fail-closed): a tampered line such as `session_id=A session_id=B` must be
-// detected rather than silently mapped to first- or last-wins, because the OCSF
-// export is evidence. Tokens without an '=' are tolerated and skipped, matching
-// the existing readers' tolerance for torn crash lines.
-func decodeAuditLine(line string) ([]auditField, error) {
-	tokens, err := splitQuotedTokens(line)
-	if err != nil {
-		return nil, err
+// decodeAuditLine tokenizes an audit line into ordered, un-escaped key/value
+// fields using the encoding the session's writer produced. It REJECTS a record
+// that carries a duplicate key (fail-closed) under either encoding: a tampered
+// line such as `session_id=A session_id=B` must be detected rather than silently
+// mapped to first- or last-wins, because the OCSF export is evidence. Tokens
+// without an '=' are tolerated and skipped, matching the existing readers'
+// tolerance for torn crash lines.
+func decodeAuditLine(line string, enc auditEncoding) ([]auditField, error) {
+	var tokens []string
+	if enc == encodingPercentPath {
+		// Percent-encoded lines never carry an unescaped space (spaces become
+		// %20), so plain whitespace splitting is a faithful tokenizer and a
+		// literal backslash in a path is preserved verbatim.
+		tokens = strings.Fields(line)
+	} else {
+		var err error
+		tokens, err = splitQuotedTokens(line)
+		if err != nil {
+			return nil, err
+		}
 	}
 	fields := make([]auditField, 0, len(tokens))
 	seen := make(map[string]struct{}, len(tokens))
@@ -54,6 +106,11 @@ func decodeAuditLine(line string) ([]auditField, error) {
 			return nil, fmt.Errorf("audit record has duplicate key %q", key)
 		}
 		seen[key] = struct{}{}
+		if enc == encodingPercentPath {
+			if _, isPath := percentEncodedAuditFields[key]; isPath {
+				value = applecontainer.DecodeAuditPathValue(value)
+			}
+		}
 		fields = append(fields, auditField{key: key, value: value})
 	}
 	return fields, nil

--- a/internal/ocsf/auditline_test.go
+++ b/internal/ocsf/auditline_test.go
@@ -7,7 +7,96 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/applecontainer"
 )
+
+func fieldMap(fields []auditField) map[string]string {
+	m := make(map[string]string, len(fields))
+	for _, f := range fields {
+		m[f.key] = f.value
+	}
+	return m
+}
+
+// TestAuditEncodingForProvider proves the decoder is selected from the session's
+// writer: only the apple-container provider selects the percent decoder; every
+// launcher backend (and an unknown/empty provider) uses the bash %q decoder.
+func TestAuditEncodingForProvider(t *testing.T) {
+	if got := auditEncodingForProvider(applecontainer.Provider); got != encodingPercentPath {
+		t.Errorf("apple-container provider should select percent decoding, got %v", got)
+	}
+	for _, p := range []string{"colima", "docker-desktop", "aws-ec2-ssm", "gcp-vm", "", "unknown"} {
+		if got := auditEncodingForProvider(p); got != encodingBashQuote {
+			t.Errorf("provider %q should select bash %%q decoding, got %v", p, got)
+		}
+	}
+}
+
+// TestDecodeAuditLinePercentPreservesBackslash is the load-bearing regression:
+// an AppleContainer record with a literal backslash in a POSIX path must survive
+// intact under the percent decoder, and the OLD unconditional %q decoder is
+// proven to CORRUPT it (dropping the backslash) — so per-writer selection is
+// what preserves the evidence.
+func TestDecodeAuditLinePercentPreservesBackslash(t *testing.T) {
+	// The AppleContainer writer leaves a literal backslash unchanged
+	// (encodeAuditPathValue only percent-encodes %, ctrl, space, high bytes).
+	line := `ts=2026-07-05T11:00:00Z session_id=s event=workspace_materialized target_provider=apple-container workspace_origin=/tmp/src workspace=/tmp/a\b`
+
+	fields, err := decodeAuditLine(line, encodingPercentPath)
+	if err != nil {
+		t.Fatalf("decodeAuditLine percent: %v", err)
+	}
+	if got := fieldMap(fields)["workspace"]; got != `/tmp/a\b` {
+		t.Fatalf("percent decoder must preserve the backslash: got %q want %q", got, `/tmp/a\b`)
+	}
+
+	// Load-bearing: the bash %q decoder corrupts the same value (drops the \).
+	corrupt, err := decodeAuditLine(line, encodingBashQuote)
+	if err != nil {
+		t.Fatalf("decodeAuditLine bashquote: %v", err)
+	}
+	if got := fieldMap(corrupt)["workspace"]; got != "/tmp/ab" {
+		t.Fatalf("expected the %%q decoder to corrupt the backslash path to /tmp/ab (proving selection matters), got %q", got)
+	}
+}
+
+// TestDecodeAuditLinePercentDecodesSpace proves a space in an AppleContainer path
+// (encoded as %20) round-trips back to a real space through the canonical
+// applecontainer decoder.
+func TestDecodeAuditLinePercentDecodesSpace(t *testing.T) {
+	line := `event=workspace_materialized target_provider=apple-container workspace=/tmp/a%20b`
+	fields, err := decodeAuditLine(line, encodingPercentPath)
+	if err != nil {
+		t.Fatalf("decodeAuditLine percent: %v", err)
+	}
+	if got := fieldMap(fields)["workspace"]; got != "/tmp/a b" {
+		t.Fatalf("percent %%20 not decoded to space: got %q", got)
+	}
+}
+
+// TestDecodeAuditLinePercentRejectsDuplicateKey proves dup-key rejection is kept
+// for the percent writer too.
+func TestDecodeAuditLinePercentRejectsDuplicateKey(t *testing.T) {
+	line := `event=workspace_materialized session_id=A session_id=B workspace=/tmp/x`
+	if _, err := decodeAuditLine(line, encodingPercentPath); err == nil {
+		t.Fatal("expected duplicate-key rejection under percent decoding")
+	}
+}
+
+// TestDecodeAuditLinePercentLeavesRawFieldsUntouched proves only the encoded
+// path fields are percent-decoded; a raw field carrying a literal % is not
+// corrupted.
+func TestDecodeAuditLinePercentLeavesRawFieldsUntouched(t *testing.T) {
+	line := `event=workspace_materialized target_provider=apple-container image_ref=repo/name%2Ffoo workspace=/tmp/x`
+	fields, err := decodeAuditLine(line, encodingPercentPath)
+	if err != nil {
+		t.Fatalf("decodeAuditLine percent: %v", err)
+	}
+	if got := fieldMap(fields)["image_ref"]; got != "repo/name%2Ffoo" {
+		t.Fatalf("raw non-path field must not be percent-decoded: got %q", got)
+	}
+}
 
 // bashQuoteToken encodes s exactly as scripts/workcell does — via the real
 // `bash printf %q` that writes the audit records — so the round-trip test is
@@ -49,7 +138,7 @@ func TestDecodeAuditLineRoundTripBash(t *testing.T) {
 	}
 	line := strings.Join(tokens, " ")
 
-	fields, err := decodeAuditLine(line)
+	fields, err := decodeAuditLine(line, encodingBashQuote)
 	if err != nil {
 		t.Fatalf("decodeAuditLine: %v\nline=%q", err, line)
 	}
@@ -76,7 +165,7 @@ func TestDecodeAnsiCOctalBytes(t *testing.T) {
 		`$'\342\200\223'`:     "–", // en dash
 	}
 	for enc, want := range cases {
-		fields, err := decodeAuditLine("k=" + enc)
+		fields, err := decodeAuditLine("k="+enc, encodingBashQuote)
 		if err != nil {
 			t.Fatalf("decodeAuditLine(%q): %v", enc, err)
 		}
@@ -101,7 +190,7 @@ func TestDecodeAuditLineRoundTripBashUTF8LocaleC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bash printf %%q under LC_ALL=C: %v", err)
 	}
-	fields, err := decodeAuditLine("field=" + string(out))
+	fields, err := decodeAuditLine("field="+string(out), encodingBashQuote)
 	if err != nil {
 		t.Fatalf("decodeAuditLine: %v\ntoken=%q", err, out)
 	}
@@ -122,7 +211,7 @@ func TestDecodeAnsiCNamedControlEscapesRoundTripBash(t *testing.T) {
 	if !ok {
 		t.Skip("bash not available for authoritative round-trip")
 	}
-	fields, err := decodeAuditLine(q)
+	fields, err := decodeAuditLine(q, encodingBashQuote)
 	if err != nil {
 		t.Fatalf("decodeAuditLine: %v\ntoken=%q", err, q)
 	}
@@ -150,7 +239,7 @@ func TestDecodeAnsiCNamedControlEscapes(t *testing.T) {
 		`$'\v'`: "\v",
 	}
 	for enc, want := range cases {
-		fields, err := decodeAuditLine("k=" + enc)
+		fields, err := decodeAuditLine("k="+enc, encodingBashQuote)
 		if err != nil {
 			t.Fatalf("decodeAuditLine(%q): %v", enc, err)
 		}
@@ -165,7 +254,7 @@ func TestDecodeAnsiCNamedControlEscapes(t *testing.T) {
 // the value is not truncated at the first space.
 func TestDecodeAuditLineSpacedValueDeterministic(t *testing.T) {
 	line := `event=launch endpoints=a:443\ b:443\ c:443 exit_status=0`
-	fields, err := decodeAuditLine(line)
+	fields, err := decodeAuditLine(line, encodingBashQuote)
 	if err != nil {
 		t.Fatalf("decodeAuditLine: %v", err)
 	}
@@ -189,7 +278,7 @@ func TestDecodeAuditLineRejectsDuplicateKey(t *testing.T) {
 		"event=launch event=exit session_id=A",
 		"a=1 b=2 a=3",
 	} {
-		if _, err := decodeAuditLine(line); err == nil {
+		if _, err := decodeAuditLine(line, encodingBashQuote); err == nil {
 			t.Errorf("expected duplicate-key rejection for %q, got nil error", line)
 		}
 	}
@@ -198,7 +287,7 @@ func TestDecodeAuditLineRejectsDuplicateKey(t *testing.T) {
 // TestDecodeAuditLineTolueratesTornToken keeps the existing readers' tolerance
 // for a torn crash line: a token without '=' is skipped, not an error.
 func TestDecodeAuditLineToleratesTornToken(t *testing.T) {
-	fields, err := decodeAuditLine("event=launch torn_fragment_no_newline session_id=A")
+	fields, err := decodeAuditLine("event=launch torn_fragment_no_newline session_id=A", encodingBashQuote)
 	if err != nil {
 		t.Fatalf("torn token should be tolerated, got %v", err)
 	}
@@ -214,7 +303,7 @@ func TestDecodeAuditLineToleratesTornToken(t *testing.T) {
 // TestDecodeAnsiCNewline proves the ANSI-C $'...' form (how bash %q encodes a
 // newline-bearing value) round-trips to a real newline.
 func TestDecodeAnsiCNewline(t *testing.T) {
-	fields, err := decodeAuditLine(`event=launch note=$'line1\nline2'`)
+	fields, err := decodeAuditLine(`event=launch note=$'line1\nline2'`, encodingBashQuote)
 	if err != nil {
 		t.Fatalf("decodeAuditLine: %v", err)
 	}
@@ -229,7 +318,7 @@ func TestDecodeAnsiCNewline(t *testing.T) {
 
 // TestDecodeAnsiCUnterminated fails closed on a corrupt $'...' block.
 func TestDecodeAnsiCUnterminated(t *testing.T) {
-	if _, err := decodeAuditLine(`event=launch note=$'oops`); err == nil {
+	if _, err := decodeAuditLine(`event=launch note=$'oops`, encodingBashQuote); err == nil {
 		t.Fatal("expected error on unterminated $'...' block")
 	}
 }


### PR DESCRIPTION
Foundation for the **F1 OCSF export** (#456), split out to keep each PR under the size cap (it consumes this selection).

The audit log has **two** on-disk encoders:
- `scripts/workcell` writes tokens with bash `printf %q` (all launcher backends: colima/docker-desktop/aws-ec2-ssm/gcp-vm).
- `internal/applecontainer` writes plain `Sprintf` lines and percent-encodes **only** its path fields via `encodeAuditPathValue` — a literal backslash in a POSIX path (`/tmp/a\b`) is emitted **unchanged**.

Decoding an apple-container record with the `%q` decoder dropped backslashes (`/tmp/a\b` → `/tmp/ab`), corrupting the path evidence (this is the F1 L369 finding).

- `decodeAuditLine` now takes an `auditEncoding`; `auditEncodingForProvider(provider)` selects **percent** decoding **only** on the unambiguous `apple-container` provider (never a launcher backend, so the two encoders never share a log), bash `%q` as the safe default.
- Only the AppleContainer-encoded path fields are percent-decoded, so a raw `%` in a `%q` record isn't corrupted.
- Exports the canonical inverse as `applecontainer.DecodeAuditPathValue` (thin wrapper over the existing unexported decoder — reused, not reimplemented).
- Dup-key rejection + full ANSI-C/octal `%q` handling unchanged.

Tests: backslash-preserved apple-container decode with a **control** proving `%q` corrupts it; `%q` spaces/named/octal unchanged; dup-key rejection under both encodings. `go test ./internal/ocsf/ ./internal/applecontainer/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)