### PR TITLE
^F Add known-audit-field allowlist for safe OCSF unmapped keys

### DIFF
--- a/internal/ocsf/auditfields_test.go
+++ b/internal/ocsf/auditfields_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package ocsf
+
+import "testing"
+
+// TestKnownAuditFieldsCoversWriterKeys pins the allowlist against the audit-field
+// names the writers actually emit. The OCSF mapping turns ONLY these into typed
+// audit.<key> properties; any other key is bucketed under a single redacted
+// property, so a tampered audit line cannot make a secret-shaped key into a JSON
+// property name. If a writer gains a new field, add it here (a missing entry
+// degrades safely to the redacted bucket rather than leaking).
+func TestKnownAuditFieldsCoversWriterKeys(t *testing.T) {
+	// A representative subset the launcher + apple-container writers emit on
+	// every record; the mapping depends on these being recognized.
+	expected := []string{
+		"event", "session_id", "timestamp", "ts",
+		"target_kind", "target_provider", "target_id",
+		"exit_status", "workspace", "workspace_origin",
+		"record_digest", "prev_digest",
+	}
+	for _, k := range expected {
+		if _, ok := knownAuditFields[k]; !ok {
+			t.Errorf("knownAuditFields is missing writer-emitted key %q", k)
+		}
+	}
+	// A tampered/secret-shaped key must NOT be in the allowlist (so it routes to
+	// the redacted bucket instead of becoming a typed property name).
+	for _, k := range []string{"ghp_ExampleToken", "/Users/op/.ssh/id_rsa", ""} {
+		if _, ok := knownAuditFields[k]; ok {
+			t.Errorf("knownAuditFields unexpectedly allowlists untrusted key %q", k)
+		}
+	}
+}

--- a/internal/ocsf/auditfields_test.go
+++ b/internal/ocsf/auditfields_test.go
@@ -19,6 +19,9 @@ func TestKnownAuditFieldsCoversWriterKeys(t *testing.T) {
 		"target_kind", "target_provider", "target_id",
 		"exit_status", "workspace", "workspace_origin",
 		"record_digest", "prev_digest",
+		// v is the apple-container schema-version sentinel (" v=1"), on every
+		// apple-container audit line — must be typed, not redacted-bucketed.
+		"v",
 	}
 	for _, k := range expected {
 		if _, ok := knownAuditFields[k]; !ok {
@@ -26,10 +29,17 @@ func TestKnownAuditFieldsCoversWriterKeys(t *testing.T) {
 		}
 	}
 	// A tampered/secret-shaped key must NOT be in the allowlist (so it routes to
-	// the redacted bucket instead of becoming a typed property name).
-	for _, k := range []string{"ghp_ExampleToken", "/Users/op/.ssh/id_rsa", ""} {
+	// the redacted bucket instead of becoming a typed property name). The git_*
+	// names are SessionRecord fields / safe-git alias guards, NOT audit-line keys,
+	// so allowlisting them would let a tampered `git_dir=secret` audit line become
+	// a typed (unredacted) property — they must stay OUT.
+	for _, k := range []string{
+		"ghp_ExampleToken", "/Users/op/.ssh/id_rsa", "",
+		"git_dir", "git_work_tree", "git_common_dir", "git_exec_path",
+		"git_branch", "git_head", "git_base",
+	} {
 		if _, ok := knownAuditFields[k]; ok {
-			t.Errorf("knownAuditFields unexpectedly allowlists untrusted key %q", k)
+			t.Errorf("knownAuditFields unexpectedly allowlists untrusted/non-audit key %q", k)
 		}
 	}
 }

--- a/internal/ocsf/auditfields_test.go
+++ b/internal/ocsf/auditfields_test.go
@@ -12,13 +12,26 @@ import "testing"
 // property name. If a writer gains a new field, add it here (a missing entry
 // degrades safely to the redacted bucket rather than leaking).
 func TestKnownAuditFieldsCoversWriterKeys(t *testing.T) {
-	// A representative subset the launcher + apple-container writers emit on
-	// every record; the mapping depends on these being recognized.
+	// A representative subset the launcher + apple-container writers emit; the
+	// mapping depends on these being recognized. Covers all five emit paths:
+	// the bash function bodies (launch/exit/assurance_change/session_control),
+	// the framing wrapper, the append_session_control_audit_record CALL-SITE
+	// inline keys, the apple-container Go writers, and the schema sentinel.
 	expected := []string{
-		"event", "session_id", "timestamp", "ts",
-		"target_kind", "target_provider", "target_id",
-		"exit_status", "workspace", "workspace_origin",
-		"record_digest", "prev_digest",
+		// bash bodies + framing wrapper (append_audit_record_to_path).
+		"event", "session_id", "timestamp",
+		"exit_status", "workspace", "record_digest", "prev_digest",
+		// assurance_change is the only body that emits reason=package-mutation.
+		"reason",
+		// append_session_control_audit_record CALL-SITE inline keys: these are
+		// audit-line keys even though they live at the call site, not the body.
+		"source", "command", "argv", "force", "transport_status",
+		"final_assurance", "stdin_mode", "container_name",
+		// apple-container Go writers (recovery.go / target_session.go).
+		"ts", "target_kind", "target_provider", "target_id",
+		"workspace_origin", "materialization_id", "access_model",
+		"bootstrap_id", "image_ref", "runtime_api", "status",
+		"workspace_transport", "workspace_control_plane",
 		// v is the apple-container schema-version sentinel (" v=1"), on every
 		// apple-container audit line — must be typed, not redacted-bucketed.
 		"v",
@@ -33,10 +46,25 @@ func TestKnownAuditFieldsCoversWriterKeys(t *testing.T) {
 	// names are SessionRecord fields / safe-git alias guards, NOT audit-line keys,
 	// so allowlisting them would let a tampered `git_dir=secret` audit line become
 	// a typed (unredacted) property — they must stay OUT.
+	//
+	// The remaining names are SessionRecord-ONLY fields: they are written solely
+	// by write_session_record (go_hostutil session-record-write), never reach the
+	// audit log, and so must NOT be typed audit properties. audit_log_path/
+	// debug_log_path/file_trace_log_path/transcript_log_path/session_audit_dir/
+	// target_assurance_class/workspace_root/worktree_path/monitor_pid are record
+	// path/metadata fields; current_assurance/initial_assurance/live_status/
+	// observed_at/started_at/finished_at are record status/timestamp fields
+	// (started_at/finished_at are the ts= VALUE alias on apple-container lines,
+	// not a key). prepare is only echoed to stderr, never an audit record.
 	for _, k := range []string{
 		"ghp_ExampleToken", "/Users/op/.ssh/id_rsa", "",
 		"git_dir", "git_work_tree", "git_common_dir", "git_exec_path",
 		"git_branch", "git_head", "git_base",
+		"audit_log_path", "debug_log_path", "file_trace_log_path",
+		"transcript_log_path", "session_audit_dir", "target_assurance_class",
+		"workspace_root", "worktree_path", "monitor_pid",
+		"current_assurance", "initial_assurance", "live_status",
+		"observed_at", "started_at", "finished_at", "prepare",
 	} {
 		if _, ok := knownAuditFields[k]; ok {
 			t.Errorf("knownAuditFields unexpectedly allowlists untrusted/non-audit key %q", k)

--- a/internal/ocsf/auditline.go
+++ b/internal/ocsf/auditline.go
@@ -74,17 +74,23 @@ func auditEncodingForProvider(provider string) auditEncoding {
 // could carry a secret-shaped key) is bucketed under one fixed redacted property
 // instead of becoming a JSON property name of its own.
 //
-// Derived from the writers, not hand-curated — regenerate with:
+// Derived from the AUDIT writers only, not hand-curated. Regenerate from the
+// bash audit-append functions (NOT all of scripts/workcell — the whole file also
+// contains write_session_record's git_branch/git_head/git_base SessionRecord
+// fields and the core.*/git_* alias-guard substrings at ~6775-6778, none of
+// which are audit-line keys) plus the apple-container Go writers:
 //
-//	{ grep -hoE '"[a-z_0-9]+=' scripts/workcell | sed 's/"//;s/=//';
+//	{ awk '/^append_(launch|exit|session_control)_audit_record\(\)/{f=1} f&&/^}/{f=0}
+//	      f' scripts/workcell | grep -hoE '"[a-z_0-9]+=' | sed 's/"//;s/=//';
 //	  grep -hoE '[a-z_]+=%s' internal/applecontainer/recovery.go \
 //	    internal/applecontainer/target_session.go | sed 's/=%s//';
-//	  printf 'timestamp\nts\nprev_digest\nrecord_digest\nmaterialization_id\naccess_model\nbootstrap_id\nimage_ref\n'; } |
+//	  printf 'timestamp\nts\nprev_digest\nrecord_digest\nmaterialization_id\naccess_model\nbootstrap_id\nimage_ref\nv\n'; } |
 //	  sort -u | grep -vE '^(0|1)$'
 //
 // (the last printf adds the framing keys the append_audit_record_to_path wrapper
-// and the Go writers stamp on every record). A new legitimate writer key that is
-// not yet listed degrades safely to the redacted bucket, not a leak.
+// stamps plus the apple-container schema sentinel `v` from auditLineSentinel).
+// A new legitimate writer key not yet listed degrades safely to the redacted
+// bucket, not a leak.
 var knownAuditFields = map[string]struct{}{
 	"access_model":                          {},
 	"agent":                                 {},
@@ -117,13 +123,6 @@ var knownAuditFields = map[string]struct{}{
 	"final_assurance":                    {},
 	"finished_at":                        {},
 	"force":                              {},
-	"git_base":                           {},
-	"git_branch":                         {},
-	"git_common_dir":                     {},
-	"git_dir":                            {},
-	"git_exec_path":                      {},
-	"git_head":                           {},
-	"git_work_tree":                      {},
 	"github_auth_present":                {},
 	"image_ref":                          {},
 	"initial_assurance":                  {},
@@ -171,12 +170,16 @@ var knownAuditFields = map[string]struct{}{
 	"transport_status":                   {},
 	"ts":                                 {},
 	"ui":                                 {},
-	"workspace":                          {},
-	"workspace_control_plane":            {},
-	"workspace_origin":                   {},
-	"workspace_root":                     {},
-	"workspace_transport":                {},
-	"worktree_path":                      {},
+	// v is the AppleContainer schema-version sentinel (auditLineSentinel = " v=1"
+	// in internal/applecontainer/session_helpers.go), appended to EVERY rendered
+	// apple-container audit line — a legitimate field, not a tampered key.
+	"v":                       {},
+	"workspace":               {},
+	"workspace_control_plane": {},
+	"workspace_origin":        {},
+	"workspace_root":          {},
+	"workspace_transport":     {},
+	"worktree_path":           {},
 }
 
 // auditField is one ordered key/value pair decoded from an audit record.

--- a/internal/ocsf/auditline.go
+++ b/internal/ocsf/auditline.go
@@ -68,6 +68,117 @@ func auditEncodingForProvider(provider string) auditEncoding {
 	return encodingBashQuote
 }
 
+// knownAuditFields is the set of audit field NAMES the writers actually emit.
+// The OCSF mapping only turns these into typed `audit.<key>` unmapped
+// properties; any other key (an audit line is mutable text, so a tampered record
+// could carry a secret-shaped key) is bucketed under one fixed redacted property
+// instead of becoming a JSON property name of its own.
+//
+// Derived from the writers, not hand-curated — regenerate with:
+//
+//	{ grep -hoE '"[a-z_0-9]+=' scripts/workcell | sed 's/"//;s/=//';
+//	  grep -hoE '[a-z_]+=%s' internal/applecontainer/recovery.go \
+//	    internal/applecontainer/target_session.go | sed 's/=%s//';
+//	  printf 'timestamp\nts\nprev_digest\nrecord_digest\nmaterialization_id\naccess_model\nbootstrap_id\nimage_ref\n'; } |
+//	  sort -u | grep -vE '^(0|1)$'
+//
+// (the last printf adds the framing keys the append_audit_record_to_path wrapper
+// and the Go writers stamp on every record). A new legitimate writer key that is
+// not yet listed degrades safely to the redacted bucket, not a leak.
+var knownAuditFields = map[string]struct{}{
+	"access_model":                          {},
+	"agent":                                 {},
+	"agent_autonomy":                        {},
+	"argv":                                  {},
+	"audit_log_path":                        {},
+	"autonomy_assurance":                    {},
+	"bootstrap_applied":                     {},
+	"bootstrap_endpoints":                   {},
+	"bootstrap_id":                          {},
+	"cache_assurance":                       {},
+	"cache_profile":                         {},
+	"codex_rules_assurance_configured":      {},
+	"codex_rules_assurance_effective_final": {},
+	"codex_rules_assurance_effective_initial":  {},
+	"codex_rules_mutability_configured":        {},
+	"codex_rules_mutability_effective_final":   {},
+	"codex_rules_mutability_effective_initial": {},
+	"command":                            {},
+	"container_assurance":                {},
+	"container_name":                     {},
+	"current_assurance":                  {},
+	"debug_log_enabled":                  {},
+	"debug_log_path":                     {},
+	"endpoints":                          {},
+	"event":                              {},
+	"execution_path":                     {},
+	"exit_status":                        {},
+	"file_trace_log_path":                {},
+	"final_assurance":                    {},
+	"finished_at":                        {},
+	"force":                              {},
+	"git_base":                           {},
+	"git_branch":                         {},
+	"git_common_dir":                     {},
+	"git_dir":                            {},
+	"git_exec_path":                      {},
+	"git_head":                           {},
+	"git_work_tree":                      {},
+	"github_auth_present":                {},
+	"image_ref":                          {},
+	"initial_assurance":                  {},
+	"injection_credential_keys":          {},
+	"injection_policy_sha256":            {},
+	"injection_secret_copy_targets":      {},
+	"injection_ssh_enabled":              {},
+	"live_status":                        {},
+	"log_level":                          {},
+	"materialization_id":                 {},
+	"mode":                               {},
+	"monitor_pid":                        {},
+	"network_policy":                     {},
+	"observability_assurance":            {},
+	"observed_at":                        {},
+	"package_mutation_downgraded":        {},
+	"prepare":                            {},
+	"prev_digest":                        {},
+	"profile":                            {},
+	"provider_auth_mode":                 {},
+	"provider_auth_modes":                {},
+	"provider_native_sandbox_configured": {},
+	"provider_native_sandbox_effective":  {},
+	"provider_native_sandbox_reason":     {},
+	"reason":                             {},
+	"record_digest":                      {},
+	"runtime_api":                        {},
+	"session_assurance_final":            {},
+	"session_assurance_initial":          {},
+	"session_audit_dir":                  {},
+	"session_id":                         {},
+	"shared_auth_modes":                  {},
+	"source":                             {},
+	"ssh_config_assurance":               {},
+	"started_at":                         {},
+	"status":                             {},
+	"stdin_mode":                         {},
+	"target_assurance_class":             {},
+	"target_id":                          {},
+	"target_kind":                        {},
+	"target_provider":                    {},
+	"timestamp":                          {},
+	"transcript_log_path":                {},
+	"transcript_logging":                 {},
+	"transport_status":                   {},
+	"ts":                                 {},
+	"ui":                                 {},
+	"workspace":                          {},
+	"workspace_control_plane":            {},
+	"workspace_origin":                   {},
+	"workspace_root":                     {},
+	"workspace_transport":                {},
+	"worktree_path":                      {},
+}
+
 // auditField is one ordered key/value pair decoded from an audit record.
 type auditField struct {
 	key   string

--- a/internal/ocsf/auditline.go
+++ b/internal/ocsf/auditline.go
@@ -74,29 +74,44 @@ func auditEncodingForProvider(provider string) auditEncoding {
 // could carry a secret-shaped key) is bucketed under one fixed redacted property
 // instead of becoming a JSON property name of its own.
 //
-// Derived from the AUDIT writers only, not hand-curated. Regenerate from the
-// bash audit-append functions (NOT all of scripts/workcell — the whole file also
-// contains write_session_record's git_branch/git_head/git_base SessionRecord
-// fields and the core.*/git_* alias-guard substrings at ~6775-6778, none of
-// which are audit-line keys) plus the apple-container Go writers:
+// Derived from the AUDIT writers only, not hand-curated — the audit LOG, never
+// the session RECORD. write_session_record (go_hostutil session-record-write)
+// emits SessionRecord-only fields that LOOK like audit keys (audit_log_path,
+// debug_log_path, file_trace_log_path, transcript_log_path, session_audit_dir,
+// target_assurance_class, workspace_root, worktree_path, monitor_pid,
+// current_assurance/initial_assurance, live_status, observed_at, started_at,
+// finished_at) but never reach the audit log, so they are EXCLUDED; the
+// core.*/git_* alias-guard substrings (~6775-6778) and git_branch/git_head/
+// git_base are not audit-line keys either.
 //
-//	{ awk '/^append_(launch|exit|session_control)_audit_record\(\)/{f=1} f&&/^}/{f=0}
-//	      f' scripts/workcell | grep -hoE '"[a-z_0-9]+=' | sed 's/"//;s/=//';
-//	  grep -hoE '[a-z_]+=%s' internal/applecontainer/recovery.go \
-//	    internal/applecontainer/target_session.go | sed 's/=%s//';
-//	  printf 'timestamp\nts\nprev_digest\nrecord_digest\nmaterialization_id\naccess_model\nbootstrap_id\nimage_ref\nv\n'; } |
-//	  sort -u | grep -vE '^(0|1)$'
+// The audit-line keys come from FOUR bash append_*_audit_record function bodies
+// (launch, exit, assurance_change, session_control), the EVENT-SPECIFIC inline
+// key=value args passed at every append_session_control_audit_record CALL SITE
+// (source/stdin_mode/container_name/command/argv/force/exit_status/
+// final_assurance/transport_status), the framing keys the
+// append_audit_record_to_path wrapper stamps on every record (timestamp/
+// prev_digest/record_digest), the apple-container Go writers, and the
+// apple-container schema sentinel `v` (auditLineSentinel = " v=1"). Regenerate:
 //
-// (the last printf adds the framing keys the append_audit_record_to_path wrapper
-// stamps plus the apple-container schema sentinel `v` from auditLineSentinel).
-// A new legitimate writer key not yet listed degrades safely to the redacted
-// bucket, not a leak.
+//	{ awk '/^append_(launch|exit|assurance_change|session_control)_audit_record\(\)/{f=1}
+//	       f&&/^}/{f=0} f' scripts/workcell |
+//	    grep -hoE '"[a-z_0-9]+=' | sed 's/"//;s/=//';
+//	  awk '/[[:space:]]append_session_control_audit_record /{c=1}
+//	       c{print} c&&!/\\$/{c=0}' scripts/workcell |
+//	    grep -hoE '"[a-z_0-9]+=' | sed 's/"//;s/=//';
+//	  grep -hoE '[a-z_0-9]+=%s' \
+//	    internal/applecontainer/recovery.go internal/applecontainer/target_session.go |
+//	    sed 's/=%s//';
+//	  printf 'timestamp\nprev_digest\nrecord_digest\nv\n'; } | sort -u
+//
+// (`event` comes from the bash bodies; the apple-container writers emit it as a
+// literal so it is not matched by =%s but is already covered.) A new legitimate
+// writer key not yet listed degrades safely to the redacted bucket, not a leak.
 var knownAuditFields = map[string]struct{}{
 	"access_model":                          {},
 	"agent":                                 {},
 	"agent_autonomy":                        {},
 	"argv":                                  {},
-	"audit_log_path":                        {},
 	"autonomy_assurance":                    {},
 	"bootstrap_applied":                     {},
 	"bootstrap_endpoints":                   {},
@@ -112,34 +127,25 @@ var knownAuditFields = map[string]struct{}{
 	"command":                            {},
 	"container_assurance":                {},
 	"container_name":                     {},
-	"current_assurance":                  {},
 	"debug_log_enabled":                  {},
-	"debug_log_path":                     {},
 	"endpoints":                          {},
 	"event":                              {},
 	"execution_path":                     {},
 	"exit_status":                        {},
-	"file_trace_log_path":                {},
 	"final_assurance":                    {},
-	"finished_at":                        {},
 	"force":                              {},
 	"github_auth_present":                {},
 	"image_ref":                          {},
-	"initial_assurance":                  {},
 	"injection_credential_keys":          {},
 	"injection_policy_sha256":            {},
 	"injection_secret_copy_targets":      {},
 	"injection_ssh_enabled":              {},
-	"live_status":                        {},
 	"log_level":                          {},
 	"materialization_id":                 {},
 	"mode":                               {},
-	"monitor_pid":                        {},
 	"network_policy":                     {},
 	"observability_assurance":            {},
-	"observed_at":                        {},
 	"package_mutation_downgraded":        {},
-	"prepare":                            {},
 	"prev_digest":                        {},
 	"profile":                            {},
 	"provider_auth_mode":                 {},
@@ -152,20 +158,16 @@ var knownAuditFields = map[string]struct{}{
 	"runtime_api":                        {},
 	"session_assurance_final":            {},
 	"session_assurance_initial":          {},
-	"session_audit_dir":                  {},
 	"session_id":                         {},
 	"shared_auth_modes":                  {},
 	"source":                             {},
 	"ssh_config_assurance":               {},
-	"started_at":                         {},
 	"status":                             {},
 	"stdin_mode":                         {},
-	"target_assurance_class":             {},
 	"target_id":                          {},
 	"target_kind":                        {},
 	"target_provider":                    {},
 	"timestamp":                          {},
-	"transcript_log_path":                {},
 	"transcript_logging":                 {},
 	"transport_status":                   {},
 	"ts":                                 {},
@@ -177,9 +179,7 @@ var knownAuditFields = map[string]struct{}{
 	"workspace":               {},
 	"workspace_control_plane": {},
 	"workspace_origin":        {},
-	"workspace_root":          {},
 	"workspace_transport":     {},
-	"worktree_path":           {},
 }
 
 // auditField is one ordered key/value pair decoded from an audit record.


### PR DESCRIPTION
Foundation for **F1 OCSF export** (#456), split out to keep each PR under the size cap.

Audit records are parsed from mutable text and arbitrary non-duplicate keys are accepted, so a tampered line like `session_id=s ghp_TOKEN=x` could make a secret-shaped field **name** into a JSON property. `knownAuditFields` is the set of field names the writers actually emit (`scripts/workcell` `append_*` records + `internal/applecontainer` Go writer + framing keys), derived from the writers (regeneration documented on the var).

The OCSF mapping (F1) turns **only** these into typed `audit.<key>` properties; any other key is bucketed under one fixed **redacted** property, so a secret can never become a property name and a new legitimate writer key degrades safely to the bucket rather than leaking.

Test pins the allowlist against writer keys and asserts untrusted keys (`ghp_…`, a home path, empty) are NOT allowlisted. `go test ./internal/ocsf/` + `go vet` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)