### PR TITLE
^D Document the OCSF-mapped session export in the evidence baseline (F1 follow-up)

### DIFF
--- a/docs/enterprise-evidence-baseline.md
+++ b/docs/enterprise-evidence-baseline.md
@@ -36,7 +36,40 @@ Current audit and session evidence is host-local:
   session-owned artifacts, but it does not rewrite the shared profile audit log
 
 Retention remains operator or organization owned. Workcell does not yet provide
-centralized retention policy, SIEM export, or fleet inventory.
+a centralized retention policy or fleet inventory. SIEM ingestion is served by
+the OCSF-mapped export below (an export format, not a hosted pipeline or
+retention service).
+
+### OCSF-Mapped Export
+
+`workcell session export --format ocsf` renders a session and its audit
+lifecycle records as [OCSF](https://schema.ocsf.io/) 1.3.0 JSON Lines — one
+**Application Lifecycle** event (`category_uid` 6, `class_uid` 6002) per line —
+so a SIEM can ingest Workcell session evidence without a bespoke parser. The
+default `--format json` bundle is unchanged.
+
+- **Events.** One summary event for the session record (finished → `activity_id`
+  4 Stop, live → 3 Start), then one event per audit record (started/launch →
+  Start, finished/exit → Stop, else → 99 Other). `metadata.version` is the OCSF
+  schema version (`1.3.0`); `metadata.mapping_version` is the Workcell
+  field→OCSF mapping version (`2` for this multi-event stream) so consumers can
+  gate parsers on either axis independently.
+- **Redaction.** Every field is passed through the shared support-bundle
+  redactor (the same rule-set as [G2 support bundles](../SUPPORT.md)) before it
+  enters an event; there is no un-redacted output path. That redactor masks
+  credentials and tokens and rewrites the operator home prefix to `~` — it does
+  NOT scrub arbitrary non-home paths, so operational metadata such as
+  `session.workspace` or `session.git_branch` (e.g. `/tmp/project`) is retained
+  as-is beyond the home rewrite. Because that regex redaction cannot sanitize
+  arbitrary prose, any operator/agent FREE-FORM payload — the `argv` session
+  message and any unexpected/tampered audit key or value — is instead
+  HARD-REDACTED to a fixed placeholder rather than emitted, so a credential in
+  prose or split-CLI form cannot reach the export even though it evades the
+  regex rules.
+- **Tamper resistance.** A tampered audit line with a duplicate identity key
+  fails the export closed (no forged event); a record whose decoded `session_id`
+  does not match the exported session is dropped (no cross-session
+  attribution); a torn crash fragment maps to Unknown, not Success.
 
 ## Known Gaps
 


### PR DESCRIPTION
Docs-only fast-follow to the completed F1 OCSF export (session events #461 + audit events #462; decoder primitives #457/#459/#460).

Narrows the SIEM claim (retention + fleet inventory remain not-yet; SIEM ingestion is served by the OCSF export — a FORMAT, not a hosted pipeline) and adds an **OCSF-Mapped Export** subsection to `docs/enterprise-evidence-baseline.md` describing the shipped feature: the multi-event Application Lifecycle stream (class 6002), the two version axes (metadata.version 1.3.0 + mapping_version 2), the total-redaction guarantee (bounded fields typed, all free-form payloads hard-redacted), and the tamper resistance (dup-key fail-closed, decoded-session-id validation, torn-record → Unknown).

This is the evidence-map narrative deferred when F1 PR1 was split to fit the 1200-line cap; the flag's contract lockstep (man/operator-contract/help) shipped with the code. doc-links + markdownlint + codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)