### PR TITLE
^F A5 (1/2): host-side audit-seal library — hash-chain verify + per-host signing (Sigstore-independent)

### DIFF
--- a/internal/host/auditseal/auditseal.go
+++ b/internal/host/auditseal/auditseal.go
@@ -161,13 +161,24 @@ type chainRecord struct {
 	prevDigest   string
 	recordDigest string
 	args         []string
-	sessionMatch bool
 }
 
-// recomputeSessionHead reads the authoritative audit log, verifies the hash
-// chain from the first record up to and including the last record bearing
-// sessionID, and returns that record's digest (the session head). Records after
-// the head are not this session's responsibility and are not inspected.
+// recomputeSessionHead reads the authoritative audit log and returns the digest
+// of this session's head — the last record bearing sessionID — after verifying
+// the hash chain from the first record up to and including that head.
+//
+// Scoping (do not fail on unrelated later records): membership is found with a
+// tolerant scan, and the chain is verified only over the records up to and
+// including this session's head. A torn, legacy, or duplicate-key line written
+// by a LATER, unrelated session — anything after this session's head — never
+// affects this session's verdict. Records before the head (including other
+// sessions' interleaved records) ARE verified, because the chain digest links
+// globally and this session's head integrity depends on them.
+//
+// Every record in the verified range is decoded strictly (ocsf
+// DecodeAuditLineStrict): a duplicate key or a bare non-key=value token fails
+// closed, so an appended forged token cannot leave the recomputed digest
+// unchanged.
 func recomputeSessionHead(auditLogPath, targetProvider, sessionID string) (string, error) {
 	data, err := os.ReadFile(auditLogPath)
 	if err != nil {
@@ -176,16 +187,31 @@ func recomputeSessionHead(auditLogPath, targetProvider, sessionID string) (strin
 		}
 		return "", err
 	}
-	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
 
-	records := make([]chainRecord, 0, len(lines))
-	lastMatch := -1
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
+	raw := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	lines := make([]string, 0, len(raw))
+	for _, line := range raw {
+		if line = strings.TrimSpace(line); line != "" {
+			lines = append(lines, line)
 		}
-		fields, err := ocsf.DecodeAuditLine(line, targetProvider)
+	}
+
+	// Pass 1: tolerant membership scan to locate this session's head index.
+	lastMatch := -1
+	for i, line := range lines {
+		if lineHasSessionID(line, sessionID) {
+			lastMatch = i
+		}
+	}
+	if lastMatch < 0 {
+		return "", fmt.Errorf("auditseal: no audit records for session %s", sessionID)
+	}
+
+	// Pass 2: strict chain verification over records 0..lastMatch only.
+	expectedPrev := ""
+	head := ""
+	for i := 0; i <= lastMatch; i++ {
+		fields, err := ocsf.DecodeAuditLineStrict(lines[i], targetProvider)
 		if err != nil {
 			return "", fmt.Errorf("auditseal: %w", err)
 		}
@@ -200,27 +226,11 @@ func recomputeSessionHead(auditLogPath, targetProvider, sessionID string) (strin
 				rec.recordDigest = f.Value
 			default:
 				rec.args = append(rec.args, f.Key+"="+f.Value)
-				if f.Key == "session_id" && f.Value == sessionID {
-					rec.sessionMatch = true
-				}
 			}
 		}
 		if rec.recordDigest == "" {
-			return "", errors.New("auditseal: audit record missing record_digest")
+			return "", fmt.Errorf("auditseal: audit chain broken at record %d: missing record_digest", i)
 		}
-		if rec.sessionMatch {
-			lastMatch = len(records)
-		}
-		records = append(records, rec)
-	}
-
-	if lastMatch < 0 {
-		return "", fmt.Errorf("auditseal: no audit records for session %s", sessionID)
-	}
-
-	expectedPrev := ""
-	for i := 0; i <= lastMatch; i++ {
-		rec := records[i]
 		want := hoststate.AuditRecordDigest(rec.prevDigest, rec.timestamp, rec.args)
 		if want != rec.recordDigest {
 			return "", fmt.Errorf("auditseal: audit chain broken at record %d: recomputed digest does not match stored record_digest", i)
@@ -229,8 +239,26 @@ func recomputeSessionHead(auditLogPath, targetProvider, sessionID string) (strin
 			return "", fmt.Errorf("auditseal: audit chain broken at record %d: prev_digest does not link to the previous record", i)
 		}
 		expectedPrev = rec.recordDigest
+		head = rec.recordDigest
 	}
-	return records[lastMatch].recordDigest, nil
+	return head, nil
+}
+
+// lineHasSessionID reports whether a raw audit line carries session_id=<id>. It
+// is deliberately tolerant (whitespace split, no error path) so that a torn or
+// duplicate-key line belonging to some OTHER session cannot make this session's
+// verification fail during the membership scan; strict decoding is applied only
+// to the records that are actually chain-verified. A session id never contains
+// whitespace, so its token survives the split intact regardless of how a
+// neighbouring escaped value tokenizes. Mirrors sessions.auditLineHasSessionID.
+func lineHasSessionID(line, sessionID string) bool {
+	for _, field := range strings.Fields(line) {
+		key, value, ok := strings.Cut(field, "=")
+		if ok && key == "session_id" && value == sessionID {
+			return true
+		}
+	}
+	return false
 }
 
 // loadOrCreateSigningKey returns the per-host ECDSA P-256 signing key under dir,
@@ -238,6 +266,11 @@ func recomputeSessionHead(auditLogPath, targetProvider, sessionID string) (strin
 // the private key is written 0600; if the directory cannot be secured the call
 // fails closed rather than sign with an insecurely stored key. The returned
 // keyID is the hex SHA-256 prefix of the PKIX-encoded public key.
+//
+// The private key is published atomically (write a temp file, then link it into
+// place) so a concurrent reader never observes a partial PEM: on a fresh host
+// two sessions may sign at once, and the loser of the create race adopts the
+// winner's complete key rather than reading an empty file.
 func loadOrCreateSigningKey(dir string) (*ecdsa.PrivateKey, string, error) {
 	if strings.TrimSpace(dir) == "" {
 		return nil, "", errors.New("auditseal: signing directory is required")
@@ -248,18 +281,7 @@ func loadOrCreateSigningKey(dir string) (*ecdsa.PrivateKey, string, error) {
 	keyPath := filepath.Join(dir, signingKeyBasename)
 
 	if data, err := os.ReadFile(keyPath); err == nil {
-		key, kerr := parsePrivateKey(data)
-		if kerr != nil {
-			return nil, "", kerr
-		}
-		keyID, kerr := publicKeyID(&key.PublicKey)
-		if kerr != nil {
-			return nil, "", kerr
-		}
-		if kerr := writePublicKeyIfAbsent(dir, keyID, &key.PublicKey); kerr != nil {
-			return nil, "", kerr
-		}
-		return key, keyID, nil
+		return adoptSigningKey(dir, data)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, "", err
 	}
@@ -273,31 +295,49 @@ func loadOrCreateSigningKey(dir string) (*ecdsa.PrivateKey, string, error) {
 		return nil, "", fmt.Errorf("auditseal: marshal key: %w", err)
 	}
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
-	// O_EXCL so two concurrent signers cannot clobber each other's key; the
-	// loser re-reads the winner's key.
-	f, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+
+	// Publish the complete key atomically. os.Link fails with ErrExist if a
+	// concurrent signer already created signing.key, in which case we adopt that
+	// (complete) key instead of racing to overwrite it.
+	tmpPath, err := writeTempFile(dir, signingKeyBasename, pemBytes, 0o600)
 	if err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return loadOrCreateSigningKey(dir)
-		}
 		return nil, "", err
 	}
-	writeErr := func() error {
-		defer f.Close()
-		if _, werr := f.Write(pemBytes); werr != nil {
-			return werr
+	linkErr := os.Link(tmpPath, keyPath)
+	_ = os.Remove(tmpPath)
+	if linkErr != nil {
+		if errors.Is(linkErr, os.ErrExist) {
+			data, rerr := os.ReadFile(keyPath)
+			if rerr != nil {
+				return nil, "", rerr
+			}
+			return adoptSigningKey(dir, data)
 		}
-		return f.Sync()
-	}()
-	if writeErr != nil {
-		_ = os.Remove(keyPath)
-		return nil, "", writeErr
+		return nil, "", linkErr
+	}
+
+	keyID, err := publicKeyID(&key.PublicKey)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := ensurePublicKey(dir, keyID, &key.PublicKey); err != nil {
+		return nil, "", err
+	}
+	return key, keyID, nil
+}
+
+// adoptSigningKey parses an existing private key PEM, derives its key id, and
+// makes sure the matching public key file exists and is valid before returning.
+func adoptSigningKey(dir string, data []byte) (*ecdsa.PrivateKey, string, error) {
+	key, err := parsePrivateKey(data)
+	if err != nil {
+		return nil, "", err
 	}
 	keyID, err := publicKeyID(&key.PublicKey)
 	if err != nil {
 		return nil, "", err
 	}
-	if err := writePublicKeyIfAbsent(dir, keyID, &key.PublicKey); err != nil {
+	if err := ensurePublicKey(dir, keyID, &key.PublicKey); err != nil {
 		return nil, "", err
 	}
 	return key, keyID, nil
@@ -322,10 +362,19 @@ func ensureSecureDir(dir string) error {
 	return nil
 }
 
-func writePublicKeyIfAbsent(dir, keyID string, pub *ecdsa.PublicKey) error {
+// ensurePublicKey makes sure <keyID>.pub exists AND holds exactly the public
+// key derived from the private key. A file that merely exists is not trusted: a
+// prior run that crashed mid-write could leave a truncated or wrong .pub, which
+// would make verification fail against seals this host itself produced. If the
+// file is absent, unparsable, or does not match, it is (re)written atomically
+// from the private key's public half.
+func ensurePublicKey(dir, keyID string, pub *ecdsa.PublicKey) error {
 	path := publicKeyPath(dir, keyID)
-	if _, err := os.Stat(path); err == nil {
-		return nil
+	if data, err := os.ReadFile(path); err == nil {
+		if existing, perr := parsePublicKeyPEM(data); perr == nil && pub.Equal(existing) {
+			return nil
+		}
+		// Present but corrupt or mismatched: repair it below.
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
@@ -334,7 +383,46 @@ func writePublicKeyIfAbsent(dir, keyID string, pub *ecdsa.PublicKey) error {
 		return fmt.Errorf("auditseal: marshal public key: %w", err)
 	}
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
-	return os.WriteFile(path, pemBytes, 0o644)
+	tmpPath, err := writeTempFile(dir, keyID+".pub", pemBytes, 0o644)
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+// writeTempFile writes data to a fresh temp file in dir with the given mode,
+// fsyncs it, and returns its path. Callers publish it into place with os.Link or
+// os.Rename so a concurrent reader of the final path never sees partial bytes.
+func writeTempFile(dir, prefix string, data []byte, perm os.FileMode) (string, error) {
+	f, err := os.CreateTemp(dir, prefix+".*.tmp")
+	if err != nil {
+		return "", err
+	}
+	tmpPath := f.Name()
+	if err := f.Chmod(perm); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	return tmpPath, nil
 }
 
 func loadPublicKey(dir, keyID string) (*ecdsa.PublicKey, error) {
@@ -348,17 +436,25 @@ func loadPublicKey(dir, keyID string) (*ecdsa.PublicKey, error) {
 		}
 		return nil, err
 	}
+	pub, err := parsePublicKeyPEM(data)
+	if err != nil {
+		return nil, fmt.Errorf("auditseal: public key %s: %w", keyID, err)
+	}
+	return pub, nil
+}
+
+func parsePublicKeyPEM(data []byte) (*ecdsa.PublicKey, error) {
 	block, _ := pem.Decode(data)
 	if block == nil {
-		return nil, fmt.Errorf("auditseal: public key %s is not valid PEM", keyID)
+		return nil, errors.New("not valid PEM")
 	}
 	pubAny, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
-		return nil, fmt.Errorf("auditseal: parse public key %s: %w", keyID, err)
+		return nil, err
 	}
 	pub, ok := pubAny.(*ecdsa.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("auditseal: public key %s is not an ECDSA key", keyID)
+		return nil, errors.New("not an ECDSA key")
 	}
 	return pub, nil
 }

--- a/internal/host/auditseal/auditseal.go
+++ b/internal/host/auditseal/auditseal.go
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package auditseal implements A5 "Signed Session Audit Records": it signs the
+// head of a session's existing audit hash-chain host-side and verifies it back
+// from the authoritative durable log.
+//
+// # Hash chain (formalized, not reinvented)
+//
+// scripts/workcell's append_audit_record_to_path already writes a tamper-evident
+// chain: every record line carries prev_digest and record_digest, where
+//
+//	record_digest = SHA256( prev_digest \x00 timestamp \x00 arg0 \x00 arg1 ... )
+//
+// (hoststate.AuditRecordDigest) and prev_digest is the previous record's
+// record_digest. The HEAD of a session is the record_digest of the LAST log
+// record that carries session_id=<id>.
+//
+// # Seal (this package)
+//
+// SignSessionHead recomputes the chain over the AUTHORITATIVE profile audit log,
+// derives the session HEAD, and signs a domain-separated message binding the
+// session id to that head with a per-host ECDSA P-256 key (the curve cosign uses
+// by default). VerifySessionSeal recomputes the chain and HEAD the same way and
+// verifies the signature over the RECOMPUTED head — it never trusts a head value
+// carried in the seal file — so any tamper (a flipped byte, a reordered, dropped,
+// or duplicate-key record) changes a recomputed digest, breaks chain linkage, or
+// changes the head and fails verification closed.
+//
+// # Trust model
+//
+// This is a boundary/host signature, not an agent signature: the operator host
+// signs the chain head after the runtime boundary finalizes the session record.
+// It detects tampering by any party that lacks the per-host private key. It does
+// NOT defend against a host-root attacker who can read signing.key and re-sign.
+// See docs/signed-session-audit-records.md.
+package auditseal
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/host/hoststate"
+	"github.com/omkhar/workcell/internal/ocsf"
+)
+
+// Algorithm is the fixed signature algorithm identifier recorded in every seal.
+const Algorithm = "ecdsa-p256-sha256"
+
+// sealVersion is the on-disk seal schema version so a future format change can
+// be gated by consumers.
+const sealVersion = 1
+
+// signingKeyBasename is the per-host private key file under the signing dir.
+const signingKeyBasename = "signing.key"
+
+// Seal is the durable, host-owned signature over a session's audit-chain head.
+// It is stored beside the session record as <record>.audit-sig.json. Only
+// Version, SessionID, KeyID, Algorithm, and Signature are load-bearing for
+// verification; HeadDigest and SignedAt are informational (verification always
+// recomputes the head from the authoritative log).
+type Seal struct {
+	Version    int    `json:"version"`
+	SessionID  string `json:"session_id"`
+	HeadDigest string `json:"head_digest"`
+	KeyID      string `json:"key_id"`
+	Algorithm  string `json:"algorithm"`
+	Signature  string `json:"signature"`
+	SignedAt   string `json:"signed_at,omitempty"`
+}
+
+// signedMessage is the exact byte sequence signed and verified. It is domain
+// separated and binds the session id to the recomputed head so a signature
+// cannot be replayed onto a different session or a different chain state.
+func signedMessage(sessionID, head string) []byte {
+	return []byte(fmt.Sprintf("workcell-session-audit-seal\nv%d\n%s\n%s\n", sealVersion, sessionID, head))
+}
+
+// SignSessionHead recomputes the chain over auditLogPath, derives the session
+// head, loads (or creates) the per-host signing key under signingDir, and
+// returns a Seal signing that head. signedAt is recorded verbatim.
+func SignSessionHead(signingDir, auditLogPath, targetProvider, sessionID, signedAt string) (Seal, error) {
+	if strings.TrimSpace(sessionID) == "" {
+		return Seal{}, errors.New("auditseal: session id is required")
+	}
+	head, err := recomputeSessionHead(auditLogPath, targetProvider, sessionID)
+	if err != nil {
+		return Seal{}, err
+	}
+	key, keyID, err := loadOrCreateSigningKey(signingDir)
+	if err != nil {
+		return Seal{}, err
+	}
+	digest := sha256.Sum256(signedMessage(sessionID, head))
+	sig, err := ecdsa.SignASN1(rand.Reader, key, digest[:])
+	if err != nil {
+		return Seal{}, fmt.Errorf("auditseal: sign: %w", err)
+	}
+	return Seal{
+		Version:    sealVersion,
+		SessionID:  sessionID,
+		HeadDigest: head,
+		KeyID:      keyID,
+		Algorithm:  Algorithm,
+		Signature:  base64.StdEncoding.EncodeToString(sig),
+		SignedAt:   signedAt,
+	}, nil
+}
+
+// VerifySessionSeal recomputes the chain and head from the authoritative log
+// and verifies seal.Signature over the RECOMPUTED head using the pinned public
+// key named by seal.KeyID under signingDir. It is fail-closed: any parse error,
+// chain break, head mismatch, unknown key, or signature mismatch is an error.
+// On success it returns the authoritative recomputed head (never the head value
+// carried in the seal, which is only informational) so callers report a value
+// the signature actually covers.
+func VerifySessionSeal(signingDir, auditLogPath, targetProvider, sessionID string, seal Seal) (string, error) {
+	if seal.Version != sealVersion {
+		return "", fmt.Errorf("auditseal: unsupported seal version %d", seal.Version)
+	}
+	if seal.Algorithm != Algorithm {
+		return "", fmt.Errorf("auditseal: unsupported seal algorithm %q", seal.Algorithm)
+	}
+	if seal.SessionID != sessionID {
+		return "", fmt.Errorf("auditseal: seal session id %q does not match %q", seal.SessionID, sessionID)
+	}
+	sig, err := base64.StdEncoding.DecodeString(seal.Signature)
+	if err != nil {
+		return "", fmt.Errorf("auditseal: decode signature: %w", err)
+	}
+	head, err := recomputeSessionHead(auditLogPath, targetProvider, sessionID)
+	if err != nil {
+		return "", err
+	}
+	pub, err := loadPublicKey(signingDir, seal.KeyID)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(signedMessage(sessionID, head))
+	if !ecdsa.VerifyASN1(pub, digest[:], sig) {
+		return "", errors.New("auditseal: signature does not verify against the pinned host key")
+	}
+	return head, nil
+}
+
+// chainRecord is one parsed audit line reduced to the fields the chain digest is
+// computed over, plus the stored digests.
+type chainRecord struct {
+	timestamp    string
+	prevDigest   string
+	recordDigest string
+	args         []string
+	sessionMatch bool
+}
+
+// recomputeSessionHead reads the authoritative audit log, verifies the hash
+// chain from the first record up to and including the last record bearing
+// sessionID, and returns that record's digest (the session head). Records after
+// the head are not this session's responsibility and are not inspected.
+func recomputeSessionHead(auditLogPath, targetProvider, sessionID string) (string, error) {
+	data, err := os.ReadFile(auditLogPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("auditseal: no audit log for session %s", sessionID)
+		}
+		return "", err
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+
+	records := make([]chainRecord, 0, len(lines))
+	lastMatch := -1
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields, err := ocsf.DecodeAuditLine(line, targetProvider)
+		if err != nil {
+			return "", fmt.Errorf("auditseal: %w", err)
+		}
+		rec := chainRecord{}
+		for _, f := range fields {
+			switch f.Key {
+			case "timestamp":
+				rec.timestamp = f.Value
+			case "prev_digest":
+				rec.prevDigest = f.Value
+			case "record_digest":
+				rec.recordDigest = f.Value
+			default:
+				rec.args = append(rec.args, f.Key+"="+f.Value)
+				if f.Key == "session_id" && f.Value == sessionID {
+					rec.sessionMatch = true
+				}
+			}
+		}
+		if rec.recordDigest == "" {
+			return "", errors.New("auditseal: audit record missing record_digest")
+		}
+		if rec.sessionMatch {
+			lastMatch = len(records)
+		}
+		records = append(records, rec)
+	}
+
+	if lastMatch < 0 {
+		return "", fmt.Errorf("auditseal: no audit records for session %s", sessionID)
+	}
+
+	expectedPrev := ""
+	for i := 0; i <= lastMatch; i++ {
+		rec := records[i]
+		want := hoststate.AuditRecordDigest(rec.prevDigest, rec.timestamp, rec.args)
+		if want != rec.recordDigest {
+			return "", fmt.Errorf("auditseal: audit chain broken at record %d: recomputed digest does not match stored record_digest", i)
+		}
+		if rec.prevDigest != expectedPrev {
+			return "", fmt.Errorf("auditseal: audit chain broken at record %d: prev_digest does not link to the previous record", i)
+		}
+		expectedPrev = rec.recordDigest
+	}
+	return records[lastMatch].recordDigest, nil
+}
+
+// loadOrCreateSigningKey returns the per-host ECDSA P-256 signing key under dir,
+// generating it on first use. The directory is created and hardened to 0700 and
+// the private key is written 0600; if the directory cannot be secured the call
+// fails closed rather than sign with an insecurely stored key. The returned
+// keyID is the hex SHA-256 prefix of the PKIX-encoded public key.
+func loadOrCreateSigningKey(dir string) (*ecdsa.PrivateKey, string, error) {
+	if strings.TrimSpace(dir) == "" {
+		return nil, "", errors.New("auditseal: signing directory is required")
+	}
+	if err := ensureSecureDir(dir); err != nil {
+		return nil, "", err
+	}
+	keyPath := filepath.Join(dir, signingKeyBasename)
+
+	if data, err := os.ReadFile(keyPath); err == nil {
+		key, kerr := parsePrivateKey(data)
+		if kerr != nil {
+			return nil, "", kerr
+		}
+		keyID, kerr := publicKeyID(&key.PublicKey)
+		if kerr != nil {
+			return nil, "", kerr
+		}
+		if kerr := writePublicKeyIfAbsent(dir, keyID, &key.PublicKey); kerr != nil {
+			return nil, "", kerr
+		}
+		return key, keyID, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, "", err
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, "", fmt.Errorf("auditseal: generate key: %w", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, "", fmt.Errorf("auditseal: marshal key: %w", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	// O_EXCL so two concurrent signers cannot clobber each other's key; the
+	// loser re-reads the winner's key.
+	f, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return loadOrCreateSigningKey(dir)
+		}
+		return nil, "", err
+	}
+	writeErr := func() error {
+		defer f.Close()
+		if _, werr := f.Write(pemBytes); werr != nil {
+			return werr
+		}
+		return f.Sync()
+	}()
+	if writeErr != nil {
+		_ = os.Remove(keyPath)
+		return nil, "", writeErr
+	}
+	keyID, err := publicKeyID(&key.PublicKey)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := writePublicKeyIfAbsent(dir, keyID, &key.PublicKey); err != nil {
+		return nil, "", err
+	}
+	return key, keyID, nil
+}
+
+// ensureSecureDir creates dir if needed and enforces 0700 ownership-only perms,
+// failing closed if the mode cannot be tightened.
+func ensureSecureDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return err
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return err
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("auditseal: signing directory %s is not private (mode %o)", dir, info.Mode().Perm())
+	}
+	return nil
+}
+
+func writePublicKeyIfAbsent(dir, keyID string, pub *ecdsa.PublicKey) error {
+	path := publicKeyPath(dir, keyID)
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return fmt.Errorf("auditseal: marshal public key: %w", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	return os.WriteFile(path, pemBytes, 0o644)
+}
+
+func loadPublicKey(dir, keyID string) (*ecdsa.PublicKey, error) {
+	if err := validateKeyID(keyID); err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(publicKeyPath(dir, keyID))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("auditseal: no pinned public key %s (session was not signed by this host)", keyID)
+		}
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("auditseal: public key %s is not valid PEM", keyID)
+	}
+	pubAny, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("auditseal: parse public key %s: %w", keyID, err)
+	}
+	pub, ok := pubAny.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("auditseal: public key %s is not an ECDSA key", keyID)
+	}
+	return pub, nil
+}
+
+// validateKeyID guards the on-disk key file lookup against path traversal: a key
+// id is always a lowercase hex fingerprint.
+func validateKeyID(keyID string) error {
+	if keyID == "" {
+		return errors.New("auditseal: empty key id")
+	}
+	for _, r := range keyID {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return fmt.Errorf("auditseal: invalid key id %q", keyID)
+		}
+	}
+	return nil
+}
+
+func publicKeyPath(dir, keyID string) string {
+	return filepath.Join(dir, keyID+".pub")
+}
+
+func publicKeyID(pub *ecdsa.PublicKey) (string, error) {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", fmt.Errorf("auditseal: marshal public key: %w", err)
+	}
+	sum := sha256.Sum256(der)
+	return hex.EncodeToString(sum[:16]), nil
+}
+
+func parsePrivateKey(data []byte) (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("auditseal: signing key is not valid PEM")
+	}
+	keyAny, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("auditseal: parse signing key: %w", err)
+	}
+	key, ok := keyAny.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("auditseal: signing key is not an ECDSA key")
+	}
+	return key, nil
+}

--- a/internal/host/auditseal/auditseal.go
+++ b/internal/host/auditseal/auditseal.go
@@ -5,35 +5,19 @@
 // head of a session's existing audit hash-chain host-side and verifies it back
 // from the authoritative durable log.
 //
-// # Hash chain (formalized, not reinvented)
+// scripts/workcell already writes a tamper-evident chain where each record's
+// record_digest = SHA256(prev_digest \x00 timestamp \x00 args...)
+// (hoststate.AuditRecordDigest) links to the previous record's digest; the head
+// of a session is the record_digest of the last record carrying session_id=<id>.
+// SignSessionHead signs a domain-separated session-id+head message with a
+// per-host ECDSA P-256 key (the curve cosign uses); VerifySessionSeal recomputes
+// the chain and head and verifies the signature over the RECOMPUTED head (never
+// a head carried in the seal), so any tamper fails closed.
 //
-// scripts/workcell's append_audit_record_to_path already writes a tamper-evident
-// chain: every record line carries prev_digest and record_digest, where
-//
-//	record_digest = SHA256( prev_digest \x00 timestamp \x00 arg0 \x00 arg1 ... )
-//
-// (hoststate.AuditRecordDigest) and prev_digest is the previous record's
-// record_digest. The HEAD of a session is the record_digest of the LAST log
-// record that carries session_id=<id>.
-//
-// # Seal (this package)
-//
-// SignSessionHead recomputes the chain over the AUTHORITATIVE profile audit log,
-// derives the session HEAD, and signs a domain-separated message binding the
-// session id to that head with a per-host ECDSA P-256 key (the curve cosign uses
-// by default). VerifySessionSeal recomputes the chain and HEAD the same way and
-// verifies the signature over the RECOMPUTED head — it never trusts a head value
-// carried in the seal file — so any tamper (a flipped byte, a reordered, dropped,
-// or duplicate-key record) changes a recomputed digest, breaks chain linkage, or
-// changes the head and fails verification closed.
-//
-// # Trust model
-//
-// This is a boundary/host signature, not an agent signature: the operator host
-// signs the chain head after the runtime boundary finalizes the session record.
-// It detects tampering by any party that lacks the per-host private key. It does
-// NOT defend against a host-root attacker who can read signing.key and re-sign.
-// See docs/signed-session-audit-records.md.
+// This is a boundary/host signature, not an agent signature: it detects tamper
+// by any party lacking the per-host key, but does NOT defend a host-root
+// attacker who can read signing.key and re-sign. See
+// docs/signed-session-audit-records.md.
 package auditseal
 
 import (
@@ -66,12 +50,10 @@ const sealVersion = 1
 const signingKeyBasename = "signing.key"
 
 // ErrUnsupportedAuditChain reports that a session's audit records carry no
-// digest chain (no record_digest), so there is nothing to sign or verify. The
-// preview-only, launch-blocked apple-container target writes plain lifecycle
-// lines without prev_digest/record_digest; such sessions are scoped OUT of
-// signing cleanly rather than emitting a seal that could never verify. Callers
-// treat it as "unsigned — provider audit chain unsupported": the signing hook
-// skips it, and `session verify` fails closed with that reason.
+// digest chain (no record_digest), so there is nothing to sign or verify — the
+// preview-only apple-container target writes plain lifecycle lines. Callers
+// treat it as "unsigned": the signing hook skips it and `session verify` fails
+// closed with that reason, rather than emitting a seal that can never verify.
 var ErrUnsupportedAuditChain = errors.New("auditseal: session audit records have no digest chain (provider audit chain unsupported)")
 
 // Seal is the durable, host-owned signature over a session's audit-chain head.
@@ -174,20 +156,14 @@ type chainRecord struct {
 
 // recomputeSessionHead reads the authoritative audit log and returns the digest
 // of this session's head — the last record bearing sessionID — after verifying
-// the hash chain from the first record up to and including that head.
+// the chain from the first record up to and including that head.
 //
-// Scoping (do not fail on unrelated later records): membership is found with a
-// tolerant scan, and the chain is verified only over the records up to and
-// including this session's head. A torn, legacy, or duplicate-key line written
-// by a LATER, unrelated session — anything after this session's head — never
-// affects this session's verdict. Records before the head (including other
-// sessions' interleaved records) ARE verified, because the chain digest links
-// globally and this session's head integrity depends on them.
-//
-// Every record in the verified range is decoded strictly (ocsf
-// DecodeAuditLineStrict): a duplicate key or a bare non-key=value token fails
-// closed, so an appended forged token cannot leave the recomputed digest
-// unchanged.
+// Scoping: the chain is verified only over records up to this session's head, so
+// a torn/legacy/duplicate-key line from a LATER unrelated session never affects
+// this session; records before the head (including interleaved other-session
+// records) ARE verified since the digest links globally. Every verified record
+// is decoded strictly (DecodeAuditLineStrict): a duplicate key or bare token
+// fails closed, so an appended forged token cannot leave the digest unchanged.
 func recomputeSessionHead(auditLogPath, targetProvider, sessionID string) (string, error) {
 	data, err := os.ReadFile(auditLogPath)
 	if err != nil {
@@ -205,10 +181,11 @@ func recomputeSessionHead(auditLogPath, targetProvider, sessionID string) (strin
 		}
 	}
 
-	// Pass 1: tolerant membership scan to locate this session's head index.
+	// Pass 1: locate this session's head via lineHasSessionID, which matches the
+	// DECODED session_id field (see its doc for why a raw scan is unsafe).
 	lastMatch := -1
 	for i, line := range lines {
-		if lineHasSessionID(line, sessionID) {
+		if lineHasSessionID(line, targetProvider, sessionID) {
 			lastMatch = i
 		}
 	}
@@ -216,12 +193,10 @@ func recomputeSessionHead(auditLogPath, targetProvider, sessionID string) (strin
 		return "", fmt.Errorf("auditseal: no audit records for session %s", sessionID)
 	}
 
-	// No-chain provider guard: if this session's head record carries no
-	// record_digest, the provider does not produce a digest chain (e.g. the
-	// preview-only apple-container target). Report it cleanly as unsupported
-	// rather than falling into the mandatory-record_digest error below with a
-	// confusing "chain broken" message. A decode error here is genuine tamper
-	// (bare/duplicate token) and is surfaced as such.
+	// No-chain provider guard: if this session's head record has no
+	// record_digest, the provider produces no digest chain (apple-container);
+	// report it as unsupported rather than a confusing "chain broken" error. A
+	// decode error here is genuine tamper and is surfaced as such.
 	headFields, err := ocsf.DecodeAuditLineStrict(lines[lastMatch], targetProvider)
 	if err != nil {
 		return "", fmt.Errorf("auditseal: %w", err)
@@ -267,18 +242,20 @@ func recomputeSessionHead(auditLogPath, targetProvider, sessionID string) (strin
 	return head, nil
 }
 
-// lineHasSessionID reports whether a raw audit line carries session_id=<id>. It
-// is deliberately tolerant (whitespace split, no error path) so that a torn or
-// duplicate-key line belonging to some OTHER session cannot make this session's
-// verification fail during the membership scan; strict decoding is applied only
-// to the records that are actually chain-verified. A session id never contains
-// whitespace, so its token survives the split intact regardless of how a
-// neighbouring escaped value tokenizes. Mirrors sessions.auditLineHasSessionID.
-func lineHasSessionID(line, sessionID string) bool {
-	for _, field := range strings.Fields(line) {
-		key, value, ok := strings.Cut(field, "=")
-		if ok && key == "session_id" && value == sessionID {
-			return true
+// lineHasSessionID reports whether an audit line's DECODED session_id field
+// equals sessionID. Decoding with the strict tokenizer means free-form content —
+// notably a `session send` argv whose bash-%q `\ ` spaces would split into a
+// fake session_id token under a raw scan — stays a single argv value and cannot
+// forge membership. A line that fails to decode (torn/duplicate-key, perhaps
+// another session's) is a non-member and never fails this session's scan.
+func lineHasSessionID(line, targetProvider, sessionID string) bool {
+	fields, err := ocsf.DecodeAuditLineStrict(line, targetProvider)
+	if err != nil {
+		return false
+	}
+	for _, f := range fields {
+		if f.Key == "session_id" {
+			return f.Value == sessionID
 		}
 	}
 	return false
@@ -294,26 +271,20 @@ func auditFieldsHaveKey(fields []ocsf.AuditField, key string) bool {
 }
 
 // HasSignableChain reports whether a session's audit records form a signable
-// digest chain. It returns false only for a provider that produces no chain at
-// all (ErrUnsupportedAuditChain, e.g. apple-container); a present-but-broken
-// chain still counts as "has a chain" (true) so callers describe it as a signed
-// vs unsigned question rather than an unsupported-provider one. Callers use this
-// only to choose a clear human message; the security verdict is the signature.
+// digest chain; it returns false only for a no-chain provider
+// (ErrUnsupportedAuditChain, e.g. apple-container). Callers use it only to
+// choose a clear human message; the security verdict is the signature.
 func HasSignableChain(auditLogPath, targetProvider, sessionID string) bool {
 	_, err := recomputeSessionHead(auditLogPath, targetProvider, sessionID)
 	return !errors.Is(err, ErrUnsupportedAuditChain)
 }
 
 // loadOrCreateSigningKey returns the per-host ECDSA P-256 signing key under dir,
-// generating it on first use. The directory is created and hardened to 0700 and
-// the private key is written 0600; if the directory cannot be secured the call
-// fails closed rather than sign with an insecurely stored key. The returned
-// keyID is the hex SHA-256 prefix of the PKIX-encoded public key.
-//
-// The private key is published atomically (write a temp file, then link it into
-// place) so a concurrent reader never observes a partial PEM: on a fresh host
-// two sessions may sign at once, and the loser of the create race adopts the
-// winner's complete key rather than reading an empty file.
+// generating it on first use. The dir is hardened to 0700 and the key written
+// 0600; if the dir cannot be secured the call fails closed. keyID is the hex
+// SHA-256 prefix of the PKIX public key. The key is published atomically (temp
+// file then os.Link) so a concurrent reader never sees a partial PEM; the create
+// race loser adopts the winner's complete key.
 func loadOrCreateSigningKey(dir string) (*ecdsa.PrivateKey, string, error) {
 	if strings.TrimSpace(dir) == "" {
 		return nil, "", errors.New("auditseal: signing directory is required")

--- a/internal/host/auditseal/auditseal.go
+++ b/internal/host/auditseal/auditseal.go
@@ -65,6 +65,15 @@ const sealVersion = 1
 // signingKeyBasename is the per-host private key file under the signing dir.
 const signingKeyBasename = "signing.key"
 
+// ErrUnsupportedAuditChain reports that a session's audit records carry no
+// digest chain (no record_digest), so there is nothing to sign or verify. The
+// preview-only, launch-blocked apple-container target writes plain lifecycle
+// lines without prev_digest/record_digest; such sessions are scoped OUT of
+// signing cleanly rather than emitting a seal that could never verify. Callers
+// treat it as "unsigned — provider audit chain unsupported": the signing hook
+// skips it, and `session verify` fails closed with that reason.
+var ErrUnsupportedAuditChain = errors.New("auditseal: session audit records have no digest chain (provider audit chain unsupported)")
+
 // Seal is the durable, host-owned signature over a session's audit-chain head.
 // It is stored beside the session record as <record>.audit-sig.json. Only
 // Version, SessionID, KeyID, Algorithm, and Signature are load-bearing for
@@ -207,6 +216,20 @@ func recomputeSessionHead(auditLogPath, targetProvider, sessionID string) (strin
 		return "", fmt.Errorf("auditseal: no audit records for session %s", sessionID)
 	}
 
+	// No-chain provider guard: if this session's head record carries no
+	// record_digest, the provider does not produce a digest chain (e.g. the
+	// preview-only apple-container target). Report it cleanly as unsupported
+	// rather than falling into the mandatory-record_digest error below with a
+	// confusing "chain broken" message. A decode error here is genuine tamper
+	// (bare/duplicate token) and is surfaced as such.
+	headFields, err := ocsf.DecodeAuditLineStrict(lines[lastMatch], targetProvider)
+	if err != nil {
+		return "", fmt.Errorf("auditseal: %w", err)
+	}
+	if !auditFieldsHaveKey(headFields, "record_digest") {
+		return "", ErrUnsupportedAuditChain
+	}
+
 	// Pass 2: strict chain verification over records 0..lastMatch only.
 	expectedPrev := ""
 	head := ""
@@ -259,6 +282,26 @@ func lineHasSessionID(line, sessionID string) bool {
 		}
 	}
 	return false
+}
+
+func auditFieldsHaveKey(fields []ocsf.AuditField, key string) bool {
+	for _, f := range fields {
+		if f.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// HasSignableChain reports whether a session's audit records form a signable
+// digest chain. It returns false only for a provider that produces no chain at
+// all (ErrUnsupportedAuditChain, e.g. apple-container); a present-but-broken
+// chain still counts as "has a chain" (true) so callers describe it as a signed
+// vs unsigned question rather than an unsupported-provider one. Callers use this
+// only to choose a clear human message; the security verdict is the signature.
+func HasSignableChain(auditLogPath, targetProvider, sessionID string) bool {
+	_, err := recomputeSessionHead(auditLogPath, targetProvider, sessionID)
+	return !errors.Is(err, ErrUnsupportedAuditChain)
 }
 
 // loadOrCreateSigningKey returns the per-host ECDSA P-256 signing key under dir,

--- a/internal/host/auditseal/auditseal_test.go
+++ b/internal/host/auditseal/auditseal_test.go
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package auditseal
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/host/hoststate"
+)
+
+// record is a synthetic audit line for tests. Values are kept simple ASCII so
+// bash `printf %q` is the identity encoding and the on-disk line is exactly the
+// space-joined key=value form scripts/workcell's append_audit_record_to_path
+// writes.
+type record struct {
+	session string
+	args    []string
+}
+
+// buildLog renders records into a single global hash chain identical in shape to
+// append_audit_record_to_path: `timestamp=.. <args..> [prev_digest=..]
+// record_digest=..`, with each record's prev_digest linking to the previous
+// record's digest. Every record carries session_id=<session>.
+func buildLog(t *testing.T, records []record) []string {
+	t.Helper()
+	lines := make([]string, 0, len(records))
+	prev := ""
+	for i, r := range records {
+		ts := "2026-07-08T00:00:0" + string(rune('0'+i%10)) + "Z"
+		args := append([]string{"session_id=" + r.session}, r.args...)
+		digest := hoststate.AuditRecordDigest(prev, ts, args)
+		var b strings.Builder
+		b.WriteString("timestamp=" + ts)
+		for _, a := range args {
+			b.WriteString(" " + a)
+		}
+		if prev != "" {
+			b.WriteString(" prev_digest=" + prev)
+		}
+		b.WriteString(" record_digest=" + digest)
+		lines = append(lines, b.String())
+		prev = digest
+	}
+	return lines
+}
+
+func writeLog(t *testing.T, dir string, lines []string) string {
+	t.Helper()
+	path := filepath.Join(dir, "workcell.audit.log")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	return path
+}
+
+func genuineLog(t *testing.T) []record {
+	t.Helper()
+	return []record{
+		{session: "sess-A", args: []string{"event=launch"}},
+		{session: "sess-B", args: []string{"event=launch"}}, // interleaved other session
+		{session: "sess-A", args: []string{"event=assurance_change", "final=lower"}},
+		{session: "sess-A", args: []string{"event=exit", "exit_status=0"}},
+	}
+}
+
+func signGenuine(t *testing.T, records []record, session string) (signingDir, logPath string, seal Seal) {
+	t.Helper()
+	tmp := t.TempDir()
+	signingDir = filepath.Join(tmp, "signing")
+	logPath = writeLog(t, tmp, buildLog(t, records))
+	seal, err := SignSessionHead(signingDir, logPath, "colima", session, "2026-07-08T00:00:09Z")
+	if err != nil {
+		t.Fatalf("SignSessionHead: %v", err)
+	}
+	return signingDir, logPath, seal
+}
+
+func TestSignVerifyGenuineSessionPasses(t *testing.T) {
+	signingDir, logPath, seal := signGenuine(t, genuineLog(t), "sess-A")
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err != nil {
+		t.Fatalf("genuine session must verify, got %v", err)
+	}
+}
+
+func TestVerifyFailsOnFlippedByte(t *testing.T) {
+	signingDir, tmp := "", t.TempDir()
+	signingDir = filepath.Join(tmp, "signing")
+	lines := buildLog(t, genuineLog(t))
+	logPath := writeLog(t, tmp, lines)
+	seal, err := SignSessionHead(signingDir, logPath, "colima", "sess-A", "t")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	// Flip a byte in the first session-A record's value (exit_status stays intact
+	// elsewhere): change "event=launch" -> "event=xaunch" on line 0.
+	tampered := make([]string, len(lines))
+	copy(tampered, lines)
+	tampered[0] = strings.Replace(tampered[0], "event=launch", "event=xaunch", 1)
+	writeLog(t, tmp, tampered)
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err == nil {
+		t.Fatal("flipped byte must fail verification")
+	}
+}
+
+func TestVerifyFailsOnReorder(t *testing.T) {
+	signingDir, tmp := "", t.TempDir()
+	signingDir = filepath.Join(tmp, "signing")
+	lines := buildLog(t, genuineLog(t))
+	logPath := writeLog(t, tmp, lines)
+	seal, err := SignSessionHead(signingDir, logPath, "colima", "sess-A", "t")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	tampered := []string{lines[1], lines[0], lines[2], lines[3]} // swap first two
+	writeLog(t, tmp, tampered)
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err == nil {
+		t.Fatal("reorder must fail verification")
+	}
+}
+
+func TestVerifyFailsOnDroppedMiddleRecord(t *testing.T) {
+	signingDir, tmp := "", t.TempDir()
+	signingDir = filepath.Join(tmp, "signing")
+	lines := buildLog(t, genuineLog(t))
+	logPath := writeLog(t, tmp, lines)
+	seal, err := SignSessionHead(signingDir, logPath, "colima", "sess-A", "t")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	tampered := []string{lines[0], lines[1], lines[3]} // drop record 2 (assurance_change)
+	writeLog(t, tmp, tampered)
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err == nil {
+		t.Fatal("dropped middle record must fail verification")
+	}
+}
+
+func TestVerifyFailsOnDroppedHeadRecord(t *testing.T) {
+	signingDir, tmp := "", t.TempDir()
+	signingDir = filepath.Join(tmp, "signing")
+	lines := buildLog(t, genuineLog(t))
+	logPath := writeLog(t, tmp, lines)
+	seal, err := SignSessionHead(signingDir, logPath, "colima", "sess-A", "t")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	tampered := []string{lines[0], lines[1], lines[2]} // drop the exit head record
+	writeLog(t, tmp, tampered)
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err == nil {
+		t.Fatal("dropped head record must fail verification")
+	}
+}
+
+func TestVerifyFailsOnDuplicateKey(t *testing.T) {
+	signingDir, tmp := "", t.TempDir()
+	signingDir = filepath.Join(tmp, "signing")
+	lines := buildLog(t, genuineLog(t))
+	logPath := writeLog(t, tmp, lines)
+	seal, err := SignSessionHead(signingDir, logPath, "colima", "sess-A", "t")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	tampered := make([]string, len(lines))
+	copy(tampered, lines)
+	// Forge a second session_id on the head record.
+	tampered[3] = strings.Replace(tampered[3], "record_digest=", "session_id=sess-A record_digest=", 1)
+	writeLog(t, tmp, tampered)
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err == nil {
+		t.Fatal("duplicate key must fail verification")
+	}
+}
+
+func TestVerifyFailsWithWrongKey(t *testing.T) {
+	signingDir, logPath, seal := signGenuine(t, genuineLog(t), "sess-A")
+	// Overwrite the pinned public key with a different, unrelated key of the same
+	// id: generate a second key in a scratch dir, then copy its .pub over the
+	// original key id file. Verification must fail because the signature was made
+	// by the original private key.
+	scratch := filepath.Join(t.TempDir(), "other")
+	if _, _, err := loadOrCreateSigningKey(scratch); err != nil {
+		t.Fatalf("scratch key: %v", err)
+	}
+	otherPub := findPub(t, scratch)
+	dst := filepath.Join(signingDir, seal.KeyID+".pub")
+	data, err := os.ReadFile(otherPub)
+	if err != nil {
+		t.Fatalf("read other pub: %v", err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		t.Fatalf("overwrite pub: %v", err)
+	}
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err == nil {
+		t.Fatal("wrong public key must fail verification")
+	}
+}
+
+func TestVerifyFailsWhenSealSessionMismatch(t *testing.T) {
+	signingDir, logPath, seal := signGenuine(t, genuineLog(t), "sess-A")
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-B", seal); err == nil {
+		t.Fatal("seal for a different session must fail verification")
+	}
+}
+
+func TestVerifyFailsWhenPublicKeyMissing(t *testing.T) {
+	signingDir, logPath, seal := signGenuine(t, genuineLog(t), "sess-A")
+	if err := os.Remove(filepath.Join(signingDir, seal.KeyID+".pub")); err != nil {
+		t.Fatalf("remove pub: %v", err)
+	}
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err == nil {
+		t.Fatal("missing pinned public key must fail verification")
+	}
+}
+
+func TestVerifyIgnoresTamperAfterHead(t *testing.T) {
+	// A record that appears AFTER this session's head belongs to a later session
+	// and is not covered by this seal; tampering it must not fail this session.
+	records := append(genuineLog(t), record{session: "sess-C", args: []string{"event=launch"}})
+	tmp := t.TempDir()
+	signingDir := filepath.Join(tmp, "signing")
+	lines := buildLog(t, records)
+	logPath := writeLog(t, tmp, lines)
+	seal, err := SignSessionHead(signingDir, logPath, "colima", "sess-A", "t")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	tampered := make([]string, len(lines))
+	copy(tampered, lines)
+	tampered[4] = strings.Replace(tampered[4], "event=launch", "event=xaunch", 1)
+	writeLog(t, tmp, tampered)
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err != nil {
+		t.Fatalf("tamper after session head must not fail this session, got %v", err)
+	}
+}
+
+func TestSigningKeyIsStableAndRotates(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "signing")
+	_, id1, err := loadOrCreateSigningKey(dir)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	_, id2, err := loadOrCreateSigningKey(dir)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if id1 != id2 {
+		t.Fatalf("key id must be stable across loads: %s != %s", id1, id2)
+	}
+	// Rotation: remove the private key; a new key with a new id is generated and
+	// the old public key is retained so historical seals still verify.
+	if err := os.Remove(filepath.Join(dir, signingKeyBasename)); err != nil {
+		t.Fatalf("remove key: %v", err)
+	}
+	_, id3, err := loadOrCreateSigningKey(dir)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if id3 == id1 {
+		t.Fatal("rotated key must have a new id")
+	}
+	if _, err := os.Stat(filepath.Join(dir, id1+".pub")); err != nil {
+		t.Fatalf("old public key must be retained after rotation: %v", err)
+	}
+}
+
+func TestSealSidecarRoundTrip(t *testing.T) {
+	_, _, seal := signGenuine(t, genuineLog(t), "sess-A")
+	path := SealPathForRecord(filepath.Join(t.TempDir(), "sess-A.json"))
+	if !strings.HasSuffix(path, "sess-A.audit-sig") {
+		t.Fatalf("unexpected sidecar path %s", path)
+	}
+	if err := WriteSeal(path, seal); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := ReadSeal(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got != seal {
+		t.Fatalf("round trip mismatch: %+v != %+v", got, seal)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("seal must be owner-only, got %o", info.Mode().Perm())
+	}
+}
+
+func findPub(t *testing.T, dir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".pub") {
+			return filepath.Join(dir, e.Name())
+		}
+	}
+	t.Fatalf("no .pub in %s", dir)
+	return ""
+}

--- a/internal/host/auditseal/auditseal_test.go
+++ b/internal/host/auditseal/auditseal_test.go
@@ -97,8 +97,7 @@ func TestVerifyFailsOnFlippedByte(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
-	// Flip a byte in the first session-A record's value (exit_status stays intact
-	// elsewhere): change "event=launch" -> "event=xaunch" on line 0.
+	// Flip a byte in the first session-A record: "event=launch" -> "event=xaunch".
 	tampered := make([]string, len(lines))
 	copy(tampered, lines)
 	tampered[0] = strings.Replace(tampered[0], "event=launch", "event=xaunch", 1)
@@ -177,10 +176,8 @@ func TestVerifyFailsOnDuplicateKey(t *testing.T) {
 
 func TestVerifyFailsWithWrongKey(t *testing.T) {
 	signingDir, logPath, seal := signGenuine(t, genuineLog(t), "sess-A")
-	// Overwrite the pinned public key with a different, unrelated key of the same
-	// id: generate a second key in a scratch dir, then copy its .pub over the
-	// original key id file. Verification must fail because the signature was made
-	// by the original private key.
+	// Overwrite the pinned .pub with an unrelated key's public half: verification
+	// must fail because the signature was made by the original private key.
 	scratch := filepath.Join(t.TempDir(), "other")
 	if _, _, err := loadOrCreateSigningKey(scratch); err != nil {
 		t.Fatalf("scratch key: %v", err)
@@ -292,10 +289,8 @@ func TestSealSidecarRoundTrip(t *testing.T) {
 	}
 }
 
-// TestVerifyFailsOnAppendedBareToken is the P1 tamper-hole regression: the OCSF
-// tolerant tokenizer drops bare (non key=value) tokens, so an appended one would
-// otherwise rebuild the same args and the same digest. Strict decoding must
-// reject it.
+// TestVerifyFailsOnAppendedBareToken is the P1 tamper-hole regression: strict
+// decoding must reject a bare (non key=value) token the tolerant tokenizer drops.
 func TestVerifyFailsOnAppendedBareToken(t *testing.T) {
 	tmp := t.TempDir()
 	signingDir := filepath.Join(tmp, "signing")
@@ -316,8 +311,8 @@ func TestVerifyFailsOnAppendedBareToken(t *testing.T) {
 }
 
 // TestVerifyIgnoresUnrelatedLaterTornRecord proves a torn/legacy line and a
-// later, unrelated session's record appended AFTER this session's head do not
-// make this session's verification fail (they are outside its verified range).
+// later unrelated session's record appended AFTER this session's head do not
+// fail this session (they are outside its verified range).
 func TestVerifyIgnoresUnrelatedLaterTornRecord(t *testing.T) {
 	tmp := t.TempDir()
 	signingDir := filepath.Join(tmp, "signing")
@@ -344,9 +339,8 @@ func TestVerifyIgnoresUnrelatedLaterTornRecord(t *testing.T) {
 	}
 }
 
-// TestConcurrentKeyGenerationIsAtomic proves the temp+link publish never exposes
-// a partial key: concurrent first-time signers all converge on one complete key
-// and leave no temp file behind.
+// TestConcurrentKeyGenerationIsAtomic proves concurrent first-time signers all
+// converge on one complete key (never a partial PEM) with no temp file left.
 func TestConcurrentKeyGenerationIsAtomic(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "signing")
 	const n = 8
@@ -389,8 +383,8 @@ func TestConcurrentKeyGenerationIsAtomic(t *testing.T) {
 	}
 }
 
-// TestVerifyRepairsCorruptPublicKey proves a truncated <keyID>.pub left by a
-// crashed run is repaired on the next sign, so seals verify again.
+// TestVerifyRepairsCorruptPublicKey proves a truncated <keyID>.pub is repaired
+// on the next sign, so seals verify again.
 func TestVerifyRepairsCorruptPublicKey(t *testing.T) {
 	signingDir, logPath, seal := signGenuine(t, genuineLog(t), "sess-A")
 	pubPath := filepath.Join(signingDir, seal.KeyID+".pub")
@@ -410,11 +404,9 @@ func TestVerifyRepairsCorruptPublicKey(t *testing.T) {
 	}
 }
 
-// TestSignUnsupportedForNoChainProvider proves a session whose audit records
-// carry no digest chain (the apple-container preview target writes plain
-// lifecycle lines without record_digest) is scoped out of signing cleanly: a
-// typed ErrUnsupportedAuditChain, not a confusing chain-broken error or an
-// unverifiable seal.
+// TestSignUnsupportedForNoChainProvider proves a no-chain session (apple-container
+// writes lifecycle lines without record_digest) is scoped out of signing with a
+// typed ErrUnsupportedAuditChain, not a chain-broken error or an unverifiable seal.
 func TestSignUnsupportedForNoChainProvider(t *testing.T) {
 	tmp := t.TempDir()
 	signingDir := filepath.Join(tmp, "signing")
@@ -436,6 +428,44 @@ func TestSignUnsupportedForNoChainProvider(t *testing.T) {
 	}
 	if _, err := VerifySessionSeal(signingDir2, logPath2, "colima", "sess-A", seal); err != nil {
 		t.Fatalf("chain provider must still verify, got %v", err)
+	}
+}
+
+// TestVerifyIgnoresSpoofedSessionIDInLaterArgv proves membership uses the
+// DECODED session_id: a later session-B `session send` whose bash-%q argv
+// contains `session_id=sess-A` must not hijack session A's head. Load-bearing —
+// a raw strings.Fields scan would split the escaped argv and match the spoof.
+func TestVerifyIgnoresSpoofedSessionIDInLaterArgv(t *testing.T) {
+	tmp := t.TempDir()
+	signingDir := filepath.Join(tmp, "signing")
+	lines := buildLog(t, []record{
+		{session: "sess-A", args: []string{"event=launch"}},
+		{session: "sess-A", args: []string{"event=exit", "exit_status=0"}},
+	})
+	// A genuine session-B control record whose argv bash-%q encodes to a `\ `
+	// space, so a raw field scan sees a fake `session_id=sess-A` token.
+	spoof := `timestamp=2026-07-08T00:00:05Z session_id=sess-B event=command ` +
+		`argv=run\ session_id=sess-A\ now record_digest=ffffffff`
+	lines = append(lines, spoof)
+	logPath := writeLog(t, tmp, lines)
+
+	// The raw hazard exists (guards the regression), but decoded membership excludes it.
+	if !strings.Contains(spoof, "session_id=sess-A") {
+		t.Fatal("spoof must contain a raw session_id=sess-A token")
+	}
+	if lineHasSessionID(spoof, "colima", "sess-A") {
+		t.Fatal("decoded membership must not match a spoofed argv session_id")
+	}
+	if !lineHasSessionID(spoof, "colima", "sess-B") {
+		t.Fatal("decoded membership must match the record's true session_id")
+	}
+
+	seal, err := SignSessionHead(signingDir, logPath, "colima", "sess-A", "t")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err != nil {
+		t.Fatalf("a later spoofed argv session_id must not hijack session A's head: %v", err)
 	}
 }
 

--- a/internal/host/auditseal/auditseal_test.go
+++ b/internal/host/auditseal/auditseal_test.go
@@ -4,6 +4,7 @@
 package auditseal
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -406,6 +407,35 @@ func TestVerifyRepairsCorruptPublicKey(t *testing.T) {
 	}
 	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err != nil {
 		t.Fatalf("verification must pass after public key repair, got %v", err)
+	}
+}
+
+// TestSignUnsupportedForNoChainProvider proves a session whose audit records
+// carry no digest chain (the apple-container preview target writes plain
+// lifecycle lines without record_digest) is scoped out of signing cleanly: a
+// typed ErrUnsupportedAuditChain, not a confusing chain-broken error or an
+// unverifiable seal.
+func TestSignUnsupportedForNoChainProvider(t *testing.T) {
+	tmp := t.TempDir()
+	signingDir := filepath.Join(tmp, "signing")
+	logPath := writeLog(t, tmp, []string{
+		"timestamp=2026-07-08T00:00:00Z session_id=sess-X event=session_started v=1",
+		"timestamp=2026-07-08T00:00:01Z session_id=sess-X event=session_finished v=1",
+	})
+	if _, err := SignSessionHead(signingDir, logPath, "apple-container", "sess-X", "t"); !errors.Is(err, ErrUnsupportedAuditChain) {
+		t.Fatalf("no-chain provider sign must return ErrUnsupportedAuditChain, got %v", err)
+	}
+	if HasSignableChain(logPath, "apple-container", "sess-X") {
+		t.Fatal("no-chain provider must not report a signable chain")
+	}
+
+	// A genuine chain provider is still signable and verifies.
+	signingDir2, logPath2, seal := signGenuine(t, genuineLog(t), "sess-A")
+	if !HasSignableChain(logPath2, "colima", "sess-A") {
+		t.Fatal("chain provider must report a signable chain")
+	}
+	if _, err := VerifySessionSeal(signingDir2, logPath2, "colima", "sess-A", seal); err != nil {
+		t.Fatalf("chain provider must still verify, got %v", err)
 	}
 }
 

--- a/internal/host/auditseal/auditseal_test.go
+++ b/internal/host/auditseal/auditseal_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/omkhar/workcell/internal/host/hoststate"
@@ -287,6 +288,124 @@ func TestSealSidecarRoundTrip(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("seal must be owner-only, got %o", info.Mode().Perm())
+	}
+}
+
+// TestVerifyFailsOnAppendedBareToken is the P1 tamper-hole regression: the OCSF
+// tolerant tokenizer drops bare (non key=value) tokens, so an appended one would
+// otherwise rebuild the same args and the same digest. Strict decoding must
+// reject it.
+func TestVerifyFailsOnAppendedBareToken(t *testing.T) {
+	tmp := t.TempDir()
+	signingDir := filepath.Join(tmp, "signing")
+	lines := buildLog(t, genuineLog(t))
+	logPath := writeLog(t, tmp, lines)
+	seal, err := SignSessionHead(signingDir, logPath, "colima", "sess-A", "t")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	// Append a bare token to the session-A head record (the exit line, index 3).
+	tampered := make([]string, len(lines))
+	copy(tampered, lines)
+	tampered[3] = tampered[3] + " FORGED"
+	writeLog(t, tmp, tampered)
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err == nil {
+		t.Fatal("appended bare token must fail verification")
+	}
+}
+
+// TestVerifyIgnoresUnrelatedLaterTornRecord proves a torn/legacy line and a
+// later, unrelated session's record appended AFTER this session's head do not
+// make this session's verification fail (they are outside its verified range).
+func TestVerifyIgnoresUnrelatedLaterTornRecord(t *testing.T) {
+	tmp := t.TempDir()
+	signingDir := filepath.Join(tmp, "signing")
+	// Session A only, sealed at its head.
+	lines := buildLog(t, []record{
+		{session: "sess-A", args: []string{"event=launch"}},
+		{session: "sess-A", args: []string{"event=exit", "exit_status=0"}},
+	})
+	logPath := writeLog(t, tmp, lines)
+	seal, err := SignSessionHead(signingDir, logPath, "colima", "sess-A", "t")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	// A later session appends a torn/legacy line (no record_digest) and a valid
+	// session-B record. Neither belongs to A, and both are after A's head.
+	appended := append([]string{}, lines...)
+	appended = append(appended,
+		"timestamp=2026-07-08T00:00:05Z session_id=sess-B event=legacy_no_digest",
+		"timestamp=2026-07-08T00:00:06Z session_id=sess-B event=exit record_digest=deadbeef",
+	)
+	writeLog(t, tmp, appended)
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err != nil {
+		t.Fatalf("unrelated later records must not fail session A, got %v", err)
+	}
+}
+
+// TestConcurrentKeyGenerationIsAtomic proves the temp+link publish never exposes
+// a partial key: concurrent first-time signers all converge on one complete key
+// and leave no temp file behind.
+func TestConcurrentKeyGenerationIsAtomic(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "signing")
+	const n = 8
+	ids := make([]string, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_, id, err := loadOrCreateSigningKey(dir)
+			ids[i], errs[i] = id, err
+		}(i)
+	}
+	wg.Wait()
+	for i := 0; i < n; i++ {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d: %v", i, errs[i])
+		}
+		if ids[i] != ids[0] {
+			t.Fatalf("goroutines disagree on key id: %s != %s", ids[i], ids[0])
+		}
+	}
+	// The published key parses (never a partial PEM) and no temp files remain.
+	data, err := os.ReadFile(filepath.Join(dir, signingKeyBasename))
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	if _, err := parsePrivateKey(data); err != nil {
+		t.Fatalf("published key must parse: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Fatalf("leftover temp file %s", e.Name())
+		}
+	}
+}
+
+// TestVerifyRepairsCorruptPublicKey proves a truncated <keyID>.pub left by a
+// crashed run is repaired on the next sign, so seals verify again.
+func TestVerifyRepairsCorruptPublicKey(t *testing.T) {
+	signingDir, logPath, seal := signGenuine(t, genuineLog(t), "sess-A")
+	pubPath := filepath.Join(signingDir, seal.KeyID+".pub")
+	if err := os.WriteFile(pubPath, []byte("-----BEGIN PUBLIC KEY-----\ntruncat"), 0o644); err != nil {
+		t.Fatalf("corrupt pub: %v", err)
+	}
+	// Corrupt .pub must not verify yet.
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err == nil {
+		t.Fatal("corrupt public key must fail verification before repair")
+	}
+	// Next sign repairs the public key from the private key.
+	if _, err := SignSessionHead(signingDir, logPath, "colima", "sess-A", "t2"); err != nil {
+		t.Fatalf("re-sign: %v", err)
+	}
+	if _, err := VerifySessionSeal(signingDir, logPath, "colima", "sess-A", seal); err != nil {
+		t.Fatalf("verification must pass after public key repair, got %v", err)
 	}
 }
 

--- a/internal/host/auditseal/sealio.go
+++ b/internal/host/auditseal/sealio.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package auditseal
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SealPathForRecord returns the seal sidecar path for a durable session record
+// path. The seal lives beside the record (host-owned) so `session verify` finds
+// it from the same location the record was discovered. The sidecar deliberately
+// does NOT end in ".json" so it is not itself mistaken for a session record by
+// the sessions discovery glob (which reads every "*.json" as a record); its
+// contents are still JSON.
+//
+//	.../<session-id>.json      -> .../<session-id>.audit-sig
+func SealPathForRecord(recordPath string) string {
+	base := recordPath
+	if strings.HasSuffix(base, ".json") {
+		base = strings.TrimSuffix(base, ".json")
+	}
+	return base + ".audit-sig"
+}
+
+// WriteSeal writes seal to path as pretty JSON with owner-only permissions,
+// replacing any existing seal atomically.
+func WriteSeal(path string, seal Seal) error {
+	data, err := json.MarshalIndent(seal, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	remove := true
+	defer func() {
+		if remove {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	remove = false
+	return os.Chmod(path, 0o600)
+}
+
+// ReadSeal parses a seal sidecar from path with strict JSON decoding so an
+// unexpected field or trailing content is rejected rather than silently ignored.
+func ReadSeal(path string) (Seal, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Seal{}, err
+	}
+	var seal Seal
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&seal); err != nil {
+		return Seal{}, fmt.Errorf("auditseal: decode seal %s: %w", path, err)
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return Seal{}, fmt.Errorf("auditseal: seal %s has unexpected trailing content", path)
+	}
+	return seal, nil
+}

--- a/internal/ocsf/decode.go
+++ b/internal/ocsf/decode.go
@@ -3,6 +3,13 @@
 
 package ocsf
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/applecontainer"
+)
+
 // AuditField is one ordered key/value pair decoded from an audit line. It is
 // the exported view of the package-internal auditField so that the A5 audit
 // hash-chain verifier (internal/host/auditseal) can reuse this package's
@@ -13,21 +20,49 @@ type AuditField struct {
 	Value string
 }
 
-// DecodeAuditLine tokenizes a single durable audit line into ordered,
-// un-escaped key/value fields, selecting the on-disk encoding from the
-// session's target provider exactly as the OCSF export does
-// (auditEncodingForProvider). It REJECTS a record that carries a duplicate key
-// (fail-closed) so a tampered line such as `session_id=A session_id=B` is
-// detected rather than silently collapsed. Order is preserved so a caller can
-// reconstruct the exact digest input the writer hashed.
-func DecodeAuditLine(line, targetProvider string) ([]AuditField, error) {
-	fields, err := decodeAuditLine(line, auditEncodingForProvider(targetProvider))
-	if err != nil {
-		return nil, err
+// DecodeAuditLineStrict tokenizes a single durable audit line into ordered,
+// un-escaped key/value fields, selecting the on-disk encoding from the session's
+// target provider exactly as the OCSF export does (auditEncodingForProvider),
+// and rejecting a record that carries a duplicate key (fail-closed) so a
+// tampered line such as `session_id=A session_id=B` is detected. It adds one
+// extra fail-closed rule for tamper detection over the OCSF export's tolerant
+// reader: it REJECTS a record that carries a bare (non key=value) token rather
+// than silently dropping it. The export intentionally tolerates torn crash lines
+// by skipping bare tokens (decodeAuditLine), but a tamper-evidence verifier must
+// not — a writer never emits a bare token, so an appended one such as
+// `... FORGED` is tampering. Because the record digest is computed only over the
+// key=value args, a dropped bare token would otherwise leave the recomputed
+// digest unchanged and let the forged line verify. Order is preserved so a
+// caller can reconstruct the exact digest input the writer hashed.
+func DecodeAuditLineStrict(line, targetProvider string) ([]AuditField, error) {
+	enc := auditEncodingForProvider(targetProvider)
+	var tokens []string
+	if enc == encodingPercentPath {
+		tokens = strings.Fields(line)
+	} else {
+		var err error
+		tokens, err = splitQuotedTokens(line)
+		if err != nil {
+			return nil, err
+		}
 	}
-	out := make([]AuditField, len(fields))
-	for i, f := range fields {
-		out[i] = AuditField{Key: f.key, Value: f.value}
+	fields := make([]AuditField, 0, len(tokens))
+	seen := make(map[string]struct{}, len(tokens))
+	for _, tok := range tokens {
+		key, value, ok := strings.Cut(tok, "=")
+		if !ok {
+			return nil, fmt.Errorf("audit record has bare token %q (no key=value)", tok)
+		}
+		if _, dup := seen[key]; dup {
+			return nil, fmt.Errorf("audit record has duplicate key %q", key)
+		}
+		seen[key] = struct{}{}
+		if enc == encodingPercentPath {
+			if _, isPath := percentEncodedAuditFields[key]; isPath {
+				value = applecontainer.DecodeAuditPathValue(value)
+			}
+		}
+		fields = append(fields, AuditField{Key: key, Value: value})
 	}
-	return out, nil
+	return fields, nil
 }

--- a/internal/ocsf/decode.go
+++ b/internal/ocsf/decode.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package ocsf
+
+// AuditField is one ordered key/value pair decoded from an audit line. It is
+// the exported view of the package-internal auditField so that the A5 audit
+// hash-chain verifier (internal/host/auditseal) can reuse this package's
+// hardened, dup-key-rejecting tokenizer instead of reimplementing the bash
+// `printf %q` and percent-path decoders.
+type AuditField struct {
+	Key   string
+	Value string
+}
+
+// DecodeAuditLine tokenizes a single durable audit line into ordered,
+// un-escaped key/value fields, selecting the on-disk encoding from the
+// session's target provider exactly as the OCSF export does
+// (auditEncodingForProvider). It REJECTS a record that carries a duplicate key
+// (fail-closed) so a tampered line such as `session_id=A session_id=B` is
+// detected rather than silently collapsed. Order is preserved so a caller can
+// reconstruct the exact digest input the writer hashed.
+func DecodeAuditLine(line, targetProvider string) ([]AuditField, error) {
+	fields, err := decodeAuditLine(line, auditEncodingForProvider(targetProvider))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AuditField, len(fields))
+	for i, f := range fields {
+		out[i] = AuditField{Key: f.key, Value: f.value}
+	}
+	return out, nil
+}

--- a/internal/ocsf/decode_test.go
+++ b/internal/ocsf/decode_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package ocsf
+
+import "testing"
+
+func TestDecodeAuditLineStrictAcceptsGenuineRecord(t *testing.T) {
+	fields, err := DecodeAuditLineStrict("timestamp=t session_id=s event=exit record_digest=d", "colima")
+	if err != nil {
+		t.Fatalf("genuine record must decode: %v", err)
+	}
+	if len(fields) != 4 || fields[1].Key != "session_id" || fields[1].Value != "s" {
+		t.Fatalf("unexpected fields: %+v", fields)
+	}
+}
+
+func TestDecodeAuditLineStrictRejectsBareToken(t *testing.T) {
+	if _, err := DecodeAuditLineStrict("timestamp=t session_id=s FORGED record_digest=d", "colima"); err == nil {
+		t.Fatal("bare token must be rejected")
+	}
+}
+
+func TestDecodeAuditLineStrictRejectsDuplicateKey(t *testing.T) {
+	if _, err := DecodeAuditLineStrict("timestamp=t session_id=a session_id=b record_digest=d", "colima"); err == nil {
+		t.Fatal("duplicate key must be rejected")
+	}
+}
+
+func TestDecodeAuditLineStrictRejectsBareTokenPercentProvider(t *testing.T) {
+	// The AppleContainer percent-path provider tokenizes on whitespace; a bare
+	// token must still be rejected under that encoding.
+	if _, err := DecodeAuditLineStrict("timestamp=t session_id=s FORGED record_digest=d", "apple-container"); err == nil {
+		t.Fatal("bare token must be rejected under percent-path encoding")
+	}
+}


### PR DESCRIPTION
**Roadmap A5 (1 of 2) — Signed Session Audit Records: the crypto/chain library.** Trust model approved by the maintainer: **local per-host signing key** (the repo's existing Sigstore usage is CI-workflow keyless with GitHub ambient OIDC — it cannot sign unattended at session runtime on a host, so it does not transfer; documented in PR2's trust-model doc).

This PR is the self-contained, fully-tested `internal/host/auditseal` package — no CLI, no launcher hook yet (that's PR2 #a5b). It:
- recomputes the existing audit hash-chain (`hoststate.AuditRecordDigest` — `SHA256(join("\x00",[prev,ts,args...]))`) over a session's records up to the HEAD (last `record_digest` for the `session_id`), rejecting duplicate keys (reuses the `internal/ocsf` decode discipline);
- manages a per-host ECDSA P-256 key under Workcell state (generate on first use, dir 0700 / key 0600, fail-closed if it can't be secured; retains old public keys across rotation);
- signs a domain-separated `session_id`+head message; verifies over the **recomputed** head (never a seal's claimed head);
- reads/writes the seal sidecar.

## Tests (load-bearing, all pass)
Tamper classes each FAIL verification: flip-byte, reorder, drop-middle, drop-head, duplicate-key; plus wrong-key, seal/session mismatch, missing pinned key. Genuine session PASSES; tamper-after-head is out of scope (proven). Key stability + rotation + seal round-trip perms covered.

check-pr-shape: 836 lines, 1 area — PASS. go build/vet/test -race green standalone; gofmt/shellcheck/shfmt/codespell zero. PR2 (`a5b/session-verify`) wires this into `workcell session verify` + the session-stop hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)