### PR TITLE
^F A5 (2/2): workcell session verify + session-stop signing hook + trust-model doc

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -99,6 +99,10 @@ func run(args []string) error {
 		return cmdHelperSessionStopCli(args[1:])
 	case "session-timeline-cli":
 		return cmdHelperSessionTimelineCli(args[1:])
+	case "session-verify-cli":
+		return cmdHelperSessionVerifyCli(args[1:])
+	case "session-sign-head":
+		return cmdHelperSessionSignHead(args[1:])
 	case "support-bundle-cli":
 		return cmdHelperSupportBundleCli(args[1:])
 	case "support-bundle-usage":
@@ -370,6 +374,14 @@ func cmdHelperSessionTimelineCli(args []string) error {
 
 func cmdHelperSessionLogsCli(args []string) error {
 	return sessionctl.LogsMain(args)
+}
+
+func cmdHelperSessionVerifyCli(args []string) error {
+	return sessionctl.VerifyMain(args)
+}
+
+func cmdHelperSessionSignHead(args []string) error {
+	return sessionctl.SignHeadMain(args)
 }
 
 func cmdHelperSessionAttachCli(args []string) error {
@@ -1013,7 +1025,7 @@ func parsePrepareBundleArgs(args []string) (*injection.PrepareBundleOptions, err
 // already do); previously these returned plain errors and collapsed to the
 // exit-1 fallback, an intra-binary inconsistency (D8).
 func usage() error {
-	return &cliexit.ExitCodeError{Code: 2, Message: "usage: workcell-hostutil <path|release|helper|launcher|policy|resolve-credentials|pty-transcript|auth-cli|auth-usage|policy-cli|policy-usage|publish-pr-cli|publish-pr-usage|session-usage|session-attach-cli|session-delete-cli|session-dispatch-cli|session-logs-cli|session-monitor-cli|session-send-cli|session-stop-cli|session-timeline-cli|support-bundle-cli|support-bundle-usage> [args...]"}
+	return &cliexit.ExitCodeError{Code: 2, Message: "usage: workcell-hostutil <path|release|helper|launcher|policy|resolve-credentials|pty-transcript|auth-cli|auth-usage|policy-cli|policy-usage|publish-pr-cli|publish-pr-usage|session-usage|session-attach-cli|session-delete-cli|session-dispatch-cli|session-logs-cli|session-monitor-cli|session-send-cli|session-stop-cli|session-timeline-cli|session-verify-cli|session-sign-head|support-bundle-cli|support-bundle-usage> [args...]"}
 }
 
 func pathUsage() error {

--- a/docs/enterprise-evidence-baseline.md
+++ b/docs/enterprise-evidence-baseline.md
@@ -29,6 +29,11 @@ Current audit and session evidence is host-local:
 - audit records are append-only text records with timestamps, event fields,
   assurance data, and chained record digests
 - launched sessions write durable JSON records under the same target-state root
+- session audit-chain heads are signed host-side, and
+  `workcell session verify` recomputes the chain from the authoritative log and
+  checks that signature — see
+  [signed-session-audit-records.md](signed-session-audit-records.md) for the
+  format and trust model (boundary/host-signed, not agent-signed)
 - `workcell session timeline` filters audit records for one session
 - `workcell session export` bundles a session record with matching audit records
 - durable session records intentionally survive `workcell --gc`

--- a/docs/signed-session-audit-records.md
+++ b/docs/signed-session-audit-records.md
@@ -1,0 +1,129 @@
+# Signed Session Audit Records
+
+Workcell session audit records form a tamper-evident hash chain whose head is
+signed host-side. `workcell session verify --id SESSION_ID` recomputes the chain
+from the authoritative durable log and verifies that signature, so a reviewer
+outside the agent can detect tampering. This document specifies the record
+format, the signing and verification model, and — explicitly — what the model
+does and does not protect.
+
+## Hash-chain format
+
+Every audit record is appended to a per-profile log under Workcell-owned target
+state, for example:
+
+```text
+~/.local/state/workcell/targets/<target-kind>/<provider>/<profile>/workcell.audit.log
+```
+
+`scripts/workcell`'s `append_audit_record_to_path` writes each record as
+whitespace-delimited `key=value` tokens:
+
+```text
+timestamp=<ts> <event fields...> [prev_digest=<hex>] record_digest=<hex>
+```
+
+- `timestamp` is a UTC RFC 3339 second-resolution stamp.
+- The event fields are the record payload (for example
+  `event=exit session_id=<id> exit_status=0 ...`). Every session record carries
+  `session_id=<id>`.
+- `record_digest` chains the record to its predecessor:
+
+  ```text
+  record_digest = SHA-256( prev_digest \x00 timestamp \x00 arg0 \x00 arg1 ... )
+  ```
+
+  computed by `hoststate.AuditRecordDigest`, where the args are the event-field
+  tokens in write order and `prev_digest` is the previous record's
+  `record_digest` (empty for the first record in the log).
+- `prev_digest` is omitted on the first record and present on every subsequent
+  record.
+
+Because each digest folds in the previous digest, altering, reordering, or
+dropping any record changes every downstream digest — a standard tamper-evident
+chain. The **head** of a session is the `record_digest` of the last log record
+carrying that session's `session_id`.
+
+## Seal (host-side signature)
+
+When the runtime boundary finalizes a session (`finalize_session_audit`, after
+the terminal audit record is appended and the durable record is written),
+Workcell signs the session head:
+
+- **Key.** A per-host ECDSA P-256 key (the curve cosign uses by default) is
+  generated on first use under `~/.local/state/workcell/signing/` — directory
+  mode `0700`, private key `signing.key` mode `0600`. If that directory cannot
+  be created and confined to owner-only access, signing fails closed rather than
+  sign with an insecurely stored key.
+- **Signed message.** A domain-separated message binding the session id to the
+  recomputed head is signed, so a signature cannot be replayed onto a different
+  session or a different chain state.
+- **Seal file.** The signature is stored beside the durable session record as
+  `<session-id>.audit-sig` (host-owned, mode `0600`). It records the seal
+  version, session id, head digest, signing key id, algorithm, and the
+  base64 signature. Only the version, session id, key id, algorithm, and
+  signature are load-bearing; the head digest is informational because
+  verification always recomputes the head from the authoritative log.
+- **Public key.** The public half is written to
+  `~/.local/state/workcell/signing/<key-id>.pub` (PKIX PEM), where `<key-id>` is
+  a SHA-256 fingerprint prefix of the public key. `session verify` pins the
+  signature to the key id named in the seal.
+
+This is a boundary/host signature, **not** an agent signature: the operator host
+signs on the trusted side of the runtime boundary, so the agent inside the
+sandbox never holds the signing key and cannot forge a seal.
+
+## Verification
+
+`workcell session verify --id SESSION_ID` is read-only and fail-closed:
+
+1. Locate the durable session record and its authoritative audit log.
+2. Read the seal beside the record. A session with no seal fails closed.
+3. Recompute the hash chain over the authoritative log from the first record up
+   to and including the session head, rejecting any record that carries a
+   duplicate key (the same fail-closed rule the OCSF export applies).
+4. Verify the seal signature over the **recomputed** head using the pinned
+   public key named by the seal.
+
+Exit codes: `0` verified, `1` verification failed (tamper, or a missing or
+invalid seal), `2` usage error. Output is passed through the shared support
+bundle redactor (the [G2](../SUPPORT.md) rule-set), so no secret leaks.
+
+### Key rotation
+
+To rotate, an operator removes (or moves aside) `signing.key`; the next signing
+run generates a fresh key with a new key id. Old public keys are retained under
+the signing directory, so seals produced by an earlier key still verify against
+their recorded key id.
+
+## Trust model
+
+**Detected.** Any modification to the persisted audit records at or before a
+session's signed head:
+
+- a flipped byte in any record field or digest;
+- a reordered or dropped record (chain linkage breaks or the head changes);
+- a forged duplicate key on a record;
+- an exported or copied log presented in place of the authoritative one (the
+  copy is not the persisted record the seal was computed over);
+- any session presented without a valid host seal.
+
+**Not defended.** This is boundary integrity, not host compromise resistance:
+
+- A host-root attacker who can read `signing.key` can re-sign a tampered chain.
+  The seal proves the records were signed by a holder of the per-host key, not
+  that the host itself was never compromised.
+- The signing key protects records against parties **without** that key
+  (the sandboxed agent, a lower-privilege process, offline tampering of the log
+  or an exported copy) — not against the key holder.
+- Verification confirms integrity and host-side provenance; it is not an
+  identity attestation of a remote signer (contrast the release-artifact keyless
+  Sigstore flow in [provenance.md](provenance.md), whose trust anchor is a CI
+  workflow identity that does not exist at session runtime).
+
+## Coordination with OCSF export
+
+Signing adds a sidecar file and does not modify the audit log or the durable
+session record, so `workcell session export --format ocsf` is unchanged: signed
+sessions export exactly as before, and the export's own duplicate-key and
+cross-session fail-closed rules continue to apply.

--- a/docs/signed-session-audit-records.md
+++ b/docs/signed-session-audit-records.md
@@ -44,6 +44,21 @@ dropping any record changes every downstream digest — a standard tamper-eviden
 chain. The **head** of a session is the `record_digest` of the last log record
 carrying that session's `session_id`.
 
+### Append serialization invariant
+
+The chain is linear only if appends are serialized: an appender reads the
+current tail's `record_digest` as the new record's `prev_digest`, so two
+concurrent detached-session control paths (`start`/`send`/`stop`) that read the
+same tail and both append would fork the chain and make verification reject a
+legitimate later record. `append_audit_record_to_path` therefore holds an
+exclusive per-log lock across the read-tail-plus-append critical section. The
+lock is the repo's atomic, crash-safe `acquire-profile-lock` primitive (an
+atomic `mkdir`+`rename` whose owner PID lets a crashed holder be reclaimed)
+applied to a `<audit-log>.lock` directory, so no external `flock(1)` is required
+— it is absent on the macOS host. The critical section is short, so contention
+uses a bounded ~1s backoff; on exhaustion the appender fails closed (skips the
+record) rather than fork the chain. Single-writer behavior is unchanged.
+
 ## Seal (host-side signature)
 
 When the runtime boundary finalizes a session (`finalize_session_audit`, after
@@ -120,6 +135,19 @@ session's signed head:
   identity attestation of a remote signer (contrast the release-artifact keyless
   Sigstore flow in [provenance.md](provenance.md), whose trust anchor is a CI
   workflow identity that does not exist at session runtime).
+
+## Provider coverage
+
+Signing covers providers whose audit records form a digest chain — the
+bash-launcher backends (colima, docker-desktop, aws-ec2-ssm, gcp-vm) whose
+session lifecycle is finalized by `finalize_session_audit`. The preview-only,
+launch-blocked `apple-container` target writes plain lifecycle audit lines
+without `prev_digest`/`record_digest`, so there is no chain to seal: such
+sessions are **unsigned**, and `workcell session verify` reports them
+fail-closed with a clear "no signable digest chain" reason. Signing the
+apple-container lifecycle (its own finalize path) is a documented follow-up; it
+is intentionally out of scope here rather than sealed with an unverifiable
+signature.
 
 ## Coordination with OCSF export
 

--- a/internal/sessionctl/dispatch.go
+++ b/internal/sessionctl/dispatch.go
@@ -67,7 +67,7 @@ func dispatchMain(args []string, stdout io.Writer) error {
 // `monitor` is the internal supervisor verb that `session start`
 // invokes against itself, not a user-facing subcommand — `man
 // workcell.1` and `README.md` document the user surface as
-// start|attach|send|stop|list|show|delete|logs|timeline|diff|export.
+// start|attach|send|stop|list|show|delete|logs|timeline|diff|export|verify.
 // A fresh slice is returned on every call so callers may mutate it
 // freely.
 func CanonicalSubcommands() []string {
@@ -83,6 +83,7 @@ func CanonicalSubcommands() []string {
 		"timeline",
 		"diff",
 		"export",
+		"verify",
 		"monitor",
 	}
 }

--- a/internal/sessionctl/dispatch_test.go
+++ b/internal/sessionctl/dispatch_test.go
@@ -27,6 +27,7 @@ func TestResolveSessionSubcommandAcceptsCanonical(t *testing.T) {
 		"timeline",
 		"diff",
 		"export",
+		"verify",
 		"monitor",
 	}
 	for _, name := range cases {
@@ -92,6 +93,7 @@ func TestDispatchMainEmitsCanonicalRoute(t *testing.T) {
 		"timeline": "subcommand=timeline\n",
 		"diff":     "subcommand=diff\n",
 		"export":   "subcommand=export\n",
+		"verify":   "subcommand=verify\n",
 		"monitor":  "subcommand=monitor\n",
 	}
 	for name, want := range cases {

--- a/internal/sessionctl/signhead.go
+++ b/internal/sessionctl/signhead.go
@@ -4,6 +4,7 @@
 package sessionctl
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -60,6 +61,13 @@ func SignHeadMain(args []string) error {
 
 	seal, err := auditseal.SignSessionHead(signingDir, auditLog, provider, sessionID, signedAt)
 	if err != nil {
+		if errors.Is(err, auditseal.ErrUnsupportedAuditChain) {
+			// A provider with no digest chain (e.g. the preview-only
+			// apple-container target) is scoped out of signing: leave the
+			// session unsigned rather than emit a seal that can never verify.
+			// `session verify` reports it as unsigned, fail-closed.
+			return nil
+		}
 		return err
 	}
 	return auditseal.WriteSeal(auditseal.SealPathForRecord(recordPath), seal)

--- a/internal/sessionctl/signhead.go
+++ b/internal/sessionctl/signhead.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/omkhar/workcell/internal/cliexit"
+	"github.com/omkhar/workcell/internal/host/auditseal"
+)
+
+// SignHeadMain implements the host-side signing hook invoked from
+// scripts/workcell's finalize_session_audit after the terminal audit record is
+// appended and the durable session record is finalized. It recomputes the
+// session's audit-chain head from the authoritative log and writes a signed
+// seal beside the durable record.
+//
+// It is deliberately NOT fatal to session teardown: signing failures are
+// surfaced to the caller (which logs a warning and continues) so a signing
+// problem never wedges container cleanup. The absence of a valid seal makes
+// `session verify` fail closed, which is the correct fail-closed posture.
+//
+// Flags (all required except --signed-at):
+//
+//	--signing-dir=DIR      per-host signing key/pubkey directory
+//	--audit-log=PATH       authoritative profile audit log
+//	--session-id=ID        session whose head is signed
+//	--record-path=PATH     durable session record (the seal is written beside it)
+//	--provider=NAME        target provider (selects the audit-line decoder)
+//	--signed-at=RFC3339    signature timestamp (defaults to now, UTC)
+func SignHeadMain(args []string) error {
+	var signingDir, auditLog, sessionID, recordPath, provider, signedAt string
+	for _, arg := range args {
+		switch {
+		case strings.HasPrefix(arg, "--signing-dir="):
+			signingDir = strings.TrimPrefix(arg, "--signing-dir=")
+		case strings.HasPrefix(arg, "--audit-log="):
+			auditLog = strings.TrimPrefix(arg, "--audit-log=")
+		case strings.HasPrefix(arg, "--session-id="):
+			sessionID = strings.TrimPrefix(arg, "--session-id=")
+		case strings.HasPrefix(arg, "--record-path="):
+			recordPath = strings.TrimPrefix(arg, "--record-path=")
+		case strings.HasPrefix(arg, "--provider="):
+			provider = strings.TrimPrefix(arg, "--provider=")
+		case strings.HasPrefix(arg, "--signed-at="):
+			signedAt = strings.TrimPrefix(arg, "--signed-at=")
+		default:
+			return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("Unsupported workcell session sign-head option: %s", arg)}
+		}
+	}
+	if signingDir == "" || auditLog == "" || sessionID == "" || recordPath == "" {
+		return &cliexit.ExitCodeError{Code: 2, Message: "session sign-head requires --signing-dir, --audit-log, --session-id, and --record-path."}
+	}
+	if signedAt == "" {
+		signedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	seal, err := auditseal.SignSessionHead(signingDir, auditLog, provider, sessionID, signedAt)
+	if err != nil {
+		return err
+	}
+	return auditseal.WriteSeal(auditseal.SealPathForRecord(recordPath), seal)
+}

--- a/internal/sessionctl/signhead_test.go
+++ b/internal/sessionctl/signhead_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/host/auditseal"
+)
+
+// TestSignHeadSkipsNoChainProvider proves the signing hook leaves an
+// apple-container-style session (audit records with no record_digest) unsigned
+// rather than erroring or writing a seal that could never verify.
+func TestSignHeadSkipsNoChainProvider(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "workcell.audit.log")
+	if err := os.WriteFile(logPath, []byte(strings.Join([]string{
+		"timestamp=2026-07-08T00:00:00Z session_id=session-ac event=session_started v=1",
+		"timestamp=2026-07-08T00:00:01Z session_id=session-ac event=session_finished v=1",
+	}, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	recordPath := filepath.Join(tmp, "session-ac.json")
+
+	if err := SignHeadMain([]string{
+		"--signing-dir=" + filepath.Join(tmp, "signing"),
+		"--audit-log=" + logPath,
+		"--session-id=session-ac",
+		"--record-path=" + recordPath,
+		"--provider=apple-container",
+	}); err != nil {
+		t.Fatalf("sign-head on a no-chain provider must be a clean no-op, got %v", err)
+	}
+	if _, err := os.Stat(auditseal.SealPathForRecord(recordPath)); !os.IsNotExist(err) {
+		t.Fatalf("no seal must be written for a no-chain provider (stat err=%v)", err)
+	}
+}

--- a/internal/sessionctl/usage.go
+++ b/internal/sessionctl/usage.go
@@ -16,6 +16,7 @@ const usageText = `Usage: workcell session start [launch-options] [-- provider-a
        workcell session timeline --id SESSION_ID
        workcell session diff --id SESSION_ID [--output PATH]
        workcell session export --id SESSION_ID [--format json|ocsf] [--output PATH]
+       workcell session verify --id SESSION_ID
 
 Commands:
   start
@@ -71,6 +72,9 @@ Commands:
                               (one Application Lifecycle event per line, redacted)
     --output PATH             Write the exported bundle to PATH instead of stdout
 
+  verify
+    --id SESSION_ID           Verify a session's signed, tamper-evident audit records
+
 Notes:
   - session commands run on the host and do not start the Workcell runtime.
   - records are durable host-side metadata for detached, completed, or aborted launches.
@@ -87,6 +91,10 @@ Notes:
     payloads (the detached session message) are not exported: their content is
     replaced with a fixed placeholder since regex redaction cannot sanitize
     arbitrary prose.
+  - ` + "`" + `session verify` + "`" + ` recomputes the session's audit hash-chain from the durable
+    profile log and verifies the host-side signature over the chain head. It is
+    read-only and fails closed on any tampered, reordered, dropped, or unsigned
+    record. Signing is boundary/host-side, not agent-side.
   - ` + "`" + `session delete` + "`" + ` never rewrites the shared profile audit log.
   - ` + "`" + `session delete` + "`" + ` cleans only explicitly recorded session-owned artifacts and
     refuses running sessions or running session containers.

--- a/internal/sessionctl/usage_test.go
+++ b/internal/sessionctl/usage_test.go
@@ -23,6 +23,7 @@ func TestUsageTextListsAllSubcommands(t *testing.T) {
 		"workcell session timeline",
 		"workcell session diff",
 		"workcell session export",
+		"workcell session verify",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("UsageText() missing %q", want)

--- a/internal/sessionctl/verify.go
+++ b/internal/sessionctl/verify.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/cliexit"
+	"github.com/omkhar/workcell/internal/host/auditseal"
+	"github.com/omkhar/workcell/internal/host/sessions"
+	"github.com/omkhar/workcell/internal/host/stateroot"
+	"github.com/omkhar/workcell/internal/supportbundle"
+)
+
+// VerifyMain implements `workcell session verify --id SESSION_ID`: it recomputes
+// the session's audit hash-chain from the AUTHORITATIVE durable profile log and
+// verifies the host-side signature over the chain head. It is fail-closed —
+// any tamper (flipped byte, reorder, drop, duplicate key), a missing or
+// mismatched signature, or an unknown signing key exits non-zero. Output is
+// passed through the shared G2 support-bundle redactor so no secret leaks.
+//
+// Exit codes mirror the sibling read-only subcommands: 2 for usage errors, 1
+// for a failed verification (tamper or missing/invalid seal), 0 when a genuine
+// session verifies.
+func VerifyMain(args []string) error {
+	return verifyMain(args, os.Stdout)
+}
+
+func verifyMain(args []string, stdout io.Writer) error {
+	roots, rest := stateroot.ConsumeRootArgs(args)
+	sessionID, signingDir, realHome, showHelp, err := parseVerifyArgs(rest)
+	if err != nil {
+		return err
+	}
+	if showHelp {
+		fmt.Fprint(stdout, UsageText())
+		return nil
+	}
+	if sessionID == "" {
+		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session verify requires --id."}
+	}
+	if signingDir == "" {
+		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session verify requires --signing-dir."}
+	}
+
+	redactor := supportbundle.NewRedactor(realHome)
+
+	roots, lookupErr := rootsOrLookup(roots)
+	if lookupErr != nil {
+		return lookupErr
+	}
+	record, recordPath, err := sessions.FindSessionRecordWithPathInRoots(roots, sessionID)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("No session record found for %s.", redactor.String(sessionID))}
+		}
+		return err
+	}
+	if record.AuditLogPath == "" {
+		return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("Session %s has no recorded audit log to verify.", redactor.String(sessionID))}
+	}
+
+	sealPath := auditseal.SealPathForRecord(recordPath)
+	seal, err := auditseal.ReadSeal(sealPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("Session %s is not signed (no audit seal); verification fails closed.", redactor.String(sessionID))}
+		}
+		return &cliexit.ExitCodeError{Code: 1, Message: redactor.String(err.Error())}
+	}
+
+	head, err := auditseal.VerifySessionSeal(signingDir, record.AuditLogPath, record.TargetProvider, sessionID, seal)
+	if err != nil {
+		return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("Session %s FAILED audit verification: %s", redactor.String(sessionID), redactor.String(err.Error()))}
+	}
+
+	fmt.Fprintf(stdout, "session_verify=verified\n")
+	fmt.Fprintf(stdout, "session_id=%s\n", redactor.String(sessionID))
+	fmt.Fprintf(stdout, "key_id=%s\n", redactor.String(seal.KeyID))
+	fmt.Fprintf(stdout, "head_digest=%s\n", redactor.String(head))
+	return nil
+}
+
+func parseVerifyArgs(args []string) (sessionID, signingDir, realHome string, showHelp bool, err error) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--id":
+			value, next, perr := optionValueOrErrorStrict(args, i, "--id")
+			if perr != nil {
+				return "", "", "", false, perr
+			}
+			sessionID = value
+			i = next
+		case strings.HasPrefix(arg, "--signing-dir="):
+			signingDir = strings.TrimPrefix(arg, "--signing-dir=")
+		case strings.HasPrefix(arg, "--real-home="):
+			realHome = strings.TrimPrefix(arg, "--real-home=")
+		case arg == "-h", arg == "--help":
+			showHelp = true
+		default:
+			return "", "", "", false, unsupportedOption("session verify", arg)
+		}
+	}
+	return sessionID, signingDir, realHome, showHelp, nil
+}

--- a/internal/sessionctl/verify.go
+++ b/internal/sessionctl/verify.go
@@ -69,6 +69,9 @@ func verifyMain(args []string, stdout io.Writer) error {
 	seal, err := auditseal.ReadSeal(sealPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			if !auditseal.HasSignableChain(record.AuditLogPath, record.TargetProvider, sessionID) {
+				return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("Session %s uses a provider whose audit records have no signable digest chain (apple-container is preview-only); verification fails closed.", redactor.String(sessionID))}
+			}
 			return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("Session %s is not signed (no audit seal); verification fails closed.", redactor.String(sessionID))}
 		}
 		return &cliexit.ExitCodeError{Code: 1, Message: redactor.String(err.Error())}

--- a/internal/sessionctl/verify_test.go
+++ b/internal/sessionctl/verify_test.go
@@ -131,6 +131,55 @@ func TestVerifyCLIFailsClosedWhenUnsigned(t *testing.T) {
 	assertExitCode(t, err, 1)
 }
 
+func TestVerifyCLIFailsClosedForNoChainProvider(t *testing.T) {
+	root := t.TempDir()
+	signingDir := filepath.Join(t.TempDir(), "signing")
+	sessionID := "session-ac"
+
+	logPath := filepath.Join(root, "wcl-fixture", "sessions", "workcell.audit.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// apple-container-style lifecycle lines: no record_digest, no chain.
+	if err := os.WriteFile(logPath, []byte(strings.Join([]string{
+		"timestamp=2026-07-08T00:00:00Z session_id=session-ac event=session_started v=1",
+		"timestamp=2026-07-08T00:00:01Z session_id=session-ac event=session_finished v=1",
+	}, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	recordPath := filepath.Join(root, "wcl-fixture", "sessions", sessionID+".json")
+	if err := sessions.WriteSessionRecord(recordPath, map[string]string{
+		"session_id":      sessionID,
+		"profile":         "wcl-fixture",
+		"target_provider": "apple-container",
+		"agent":           "codex",
+		"mode":            "strict",
+		"status":          "exited",
+		"workspace":       "/tmp/workspace",
+		"started_at":      "2026-07-08T00:00:00Z",
+		"finished_at":     "2026-07-08T00:00:09Z",
+		"exit_status":     "0",
+		"final_assurance": "managed-mutable",
+		"audit_log_path":  logPath,
+	}); err != nil {
+		t.Fatalf("write record: %v", err)
+	}
+
+	var buf bytes.Buffer
+	err := verifyMain([]string{
+		"--root=" + root,
+		"--id", sessionID,
+		"--signing-dir=" + signingDir,
+		"--real-home=/nonexistent",
+	}, &buf)
+	assertExitCode(t, err, 1)
+	var ec *cliexit.ExitCodeError
+	errors.As(err, &ec)
+	if !strings.Contains(ec.Message, "no signable digest chain") {
+		t.Fatalf("expected the no-signable-chain reason, got %q", ec.Message)
+	}
+}
+
 func TestVerifyCLIMissingIDIsUsageError(t *testing.T) {
 	var buf bytes.Buffer
 	err := verifyMain([]string{"--signing-dir=/tmp/x"}, &buf)

--- a/internal/sessionctl/verify_test.go
+++ b/internal/sessionctl/verify_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/cliexit"
+	"github.com/omkhar/workcell/internal/host/hoststate"
+	"github.com/omkhar/workcell/internal/host/sessions"
+)
+
+// verifyFixture lays a genuine, signed session on disk and returns the state
+// root, signing dir, session id, and the durable audit-log path so a test can
+// tamper it. The record uses the legacy `<root>/<profile>/sessions` layout that
+// sessions discovery accepts.
+func verifyFixture(t *testing.T) (root, signingDir, sessionID, logPath string) {
+	t.Helper()
+	root = t.TempDir()
+	signingDir = filepath.Join(t.TempDir(), "signing")
+	sessionID = "session-1"
+
+	logPath = filepath.Join(root, "wcl-fixture", "sessions", "workcell.audit.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Two-record genuine chain for the session.
+	lines := []string{}
+	prev := ""
+	for i, args := range [][]string{
+		{"session_id=" + sessionID, "event=launch"},
+		{"session_id=" + sessionID, "event=exit", "exit_status=0"},
+	} {
+		ts := "2026-07-08T00:00:0" + string(rune('0'+i)) + "Z"
+		digest := hoststate.AuditRecordDigest(prev, ts, args)
+		line := "timestamp=" + ts + " " + strings.Join(args, " ")
+		if prev != "" {
+			line += " prev_digest=" + prev
+		}
+		line += " record_digest=" + digest
+		lines = append(lines, line)
+		prev = digest
+	}
+	if err := os.WriteFile(logPath, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	recordPath := filepath.Join(root, "wcl-fixture", "sessions", sessionID+".json")
+	if err := sessions.WriteSessionRecord(recordPath, map[string]string{
+		"session_id":      sessionID,
+		"profile":         "wcl-fixture",
+		"target_provider": "colima",
+		"agent":           "codex",
+		"mode":            "strict",
+		"status":          "exited",
+		"workspace":       "/tmp/workspace",
+		"started_at":      "2026-07-08T00:00:00Z",
+		"finished_at":     "2026-07-08T00:00:09Z",
+		"exit_status":     "0",
+		"final_assurance": "managed-mutable",
+		"audit_log_path":  logPath,
+	}); err != nil {
+		t.Fatalf("write record: %v", err)
+	}
+
+	if err := SignHeadMain([]string{
+		"--signing-dir=" + signingDir,
+		"--audit-log=" + logPath,
+		"--session-id=" + sessionID,
+		"--record-path=" + recordPath,
+		"--provider=colima",
+		"--signed-at=2026-07-08T00:00:09Z",
+	}); err != nil {
+		t.Fatalf("SignHeadMain: %v", err)
+	}
+	return root, signingDir, sessionID, logPath
+}
+
+func runVerify(t *testing.T, root, signingDir, sessionID string) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	err := verifyMain([]string{
+		"--root=" + root,
+		"--id", sessionID,
+		"--signing-dir=" + signingDir,
+		"--real-home=/nonexistent",
+	}, &buf)
+	return buf.String(), err
+}
+
+func TestVerifyCLIGenuineSessionPasses(t *testing.T) {
+	root, signingDir, sessionID, _ := verifyFixture(t)
+	out, err := runVerify(t, root, signingDir, sessionID)
+	if err != nil {
+		t.Fatalf("genuine verify failed: %v", err)
+	}
+	if !strings.Contains(out, "session_verify=verified") {
+		t.Fatalf("expected verified output, got %q", out)
+	}
+}
+
+func TestVerifyCLIFailsClosedOnTamper(t *testing.T) {
+	root, signingDir, sessionID, logPath := verifyFixture(t)
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	tampered := strings.Replace(string(data), "event=launch", "event=xaunch", 1)
+	if err := os.WriteFile(logPath, []byte(tampered), 0o600); err != nil {
+		t.Fatalf("write tampered: %v", err)
+	}
+	_, err = runVerify(t, root, signingDir, sessionID)
+	assertExitCode(t, err, 1)
+}
+
+func TestVerifyCLIFailsClosedWhenUnsigned(t *testing.T) {
+	root, signingDir, sessionID, _ := verifyFixture(t)
+	// Remove the seal sidecar: an unsigned session must fail closed.
+	recordPath := filepath.Join(root, "wcl-fixture", "sessions", sessionID+".json")
+	sealPath := strings.TrimSuffix(recordPath, ".json") + ".audit-sig"
+	if err := os.Remove(sealPath); err != nil {
+		t.Fatalf("remove seal: %v", err)
+	}
+	_, err := runVerify(t, root, signingDir, sessionID)
+	assertExitCode(t, err, 1)
+}
+
+func TestVerifyCLIMissingIDIsUsageError(t *testing.T) {
+	var buf bytes.Buffer
+	err := verifyMain([]string{"--signing-dir=/tmp/x"}, &buf)
+	assertExitCode(t, err, 2)
+}
+
+func TestVerifyCLIUnknownFlagIsUsageError(t *testing.T) {
+	var buf bytes.Buffer
+	err := verifyMain([]string{"--id", "x", "--signing-dir=/tmp/x", "--bogus"}, &buf)
+	assertExitCode(t, err, 2)
+}
+
+func assertExitCode(t *testing.T, err error, want int) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected exit code %d, got nil error", want)
+	}
+	var ec *cliexit.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected ExitCodeError, got %v", err)
+	}
+	if ec.Code != want {
+		t.Fatalf("exit code = %d, want %d", ec.Code, want)
+	}
+}

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -9,7 +9,7 @@ workcell \- bounded runtime launcher for coding agents
 [\fIoptions\fR]
 .br
 .B workcell session
-\fIstart|attach|send|stop|list|show|delete|logs|timeline|diff|export\fR [\fIoptions\fR]
+\fIstart|attach|send|stop|list|show|delete|logs|timeline|diff|export|verify\fR [\fIoptions\fR]
 .br
 .B workcell auth
 \fIinit|set|unset|status\fR [\fIoptions\fR]
@@ -41,7 +41,7 @@ as the exec-capable temporary directory via
 .BR TMPDIR .
 The supported host platform is Apple Silicon macOS.
 .TP
-.B workcell session start|attach|send|stop|list|show|delete|logs|timeline|diff|export
+.B workcell session start|attach|send|stop|list|show|delete|logs|timeline|diff|export|verify
 Launch, control, inspect, diff, export, and delete durable detached sessions
 without starting a second Workcell runtime. Detached sessions default to an
 isolated clean git clone of the selected workspace, while the host-side
@@ -66,6 +66,15 @@ by the same rule-set as
 and free-form operator payloads (the detached-session message) are withheld
 entirely \(em their content is replaced with a fixed placeholder because regex
 redaction cannot sanitize arbitrary prose.
+.B workcell session verify
+.RB ( --id
+.IR SESSION_ID )
+recomputes the session's audit hash-chain from the authoritative durable profile
+log and verifies the host-side signature over the chain head. It is read-only
+and fails closed on any tampered, reordered, dropped, duplicate-key, or unsigned
+record. The signature is boundary/host-signed, not agent-signed; see
+.B docs/signed-session-audit-records.md
+for the trust model.
 .TP
 .B workcell policy show|validate|diff
 Inspect the merged host-side injection policy without starting the runtime.

--- a/policy/operator-contract.toml
+++ b/policy/operator-contract.toml
@@ -296,6 +296,16 @@ evidence = ["tests/scenarios/shared/test-session-commands.sh"]
 requirements = ["functional.FR-007"]
 target_state = "retain"
 
+[workflows.session_verify]
+title = "Verify signed session audit records"
+support = "supported"
+canonical = "workcell session verify --id SESSION_ID"
+discoverability = ["subcommand-help:session"]
+docs = ["man/workcell.1"]
+evidence = ["internal/sessionctl/verify_test.go", "internal/host/auditseal/auditseal_test.go"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
 [workflows.session_delete]
 title = "Delete durable detached session"
 support = "supported"

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -153,12 +153,15 @@ workflows = [
   "session_timeline",
   "session_diff",
   "session_export",
+  "session_verify",
   "session_delete",
 ]
 evidence = [
   "tests/scenarios/shared/test-copilot-session-dry-run.sh",
   "tests/scenarios/shared/test-session-commands.sh",
   "internal/host/sessions/sessions_test.go",
+  "internal/sessionctl/verify_test.go",
+  "internal/host/auditseal/auditseal_test.go",
 ]
 docs = [
   "README.md",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "6bc62d7cdc1ff17f40d4cdb323339b78f279be302e9aa6c7192afd51328cca59"
+      "sha256": "9a01c30d9cd37a347487259d7d0a251771fa8327bca36ef6bd77b56ede93dbea"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "9a01c30d9cd37a347487259d7d0a251771fa8327bca36ef6bd77b56ede93dbea"
+      "sha256": "a5e04fff9496034b0b87c057c5287d88492a87c71c736335a876a6f814011e73"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -2599,29 +2599,80 @@ append_audit_record() {
   append_audit_record_to_path "${audit_path}" "$@"
 }
 
+# acquire_audit_log_lock serializes audit-log appends. The hash chain reads the
+# current tail's record_digest as the next record's prev_digest, so two
+# concurrent detached-session control paths (start/send/stop) racing the
+# read+append would fork the chain and make the verifier reject a legitimate
+# later record. This reuses the atomic, crash-safe profile-lock primitive
+# (acquire-profile-lock + profile-lock-is-stale: an atomic mkdir-rename lock
+# whose owner PID lets a crashed holder be reclaimed) on a per-log lock dir, so
+# no external flock(1) is required (it is absent on the macOS host). The critical
+# section is short, so it uses a ~1s bounded backoff (50 x 20ms) mirroring the
+# Go AppleContainer audit lock; on exhaustion it fails closed (no append) rather
+# than fork the chain.
+acquire_audit_log_lock() {
+  local lock_dir="$1"
+  local attempts=0
+  local acquired_state=""
+  local stale_state=""
+
+  mkdir -p "$(dirname "${lock_dir}")"
+  while true; do
+    if ! acquired_state="$(go_hostutil helper acquire-profile-lock "${lock_dir}" "$$")"; then
+      return 1
+    fi
+    if [[ "${acquired_state}" == "1" ]]; then
+      return 0
+    fi
+    if stale_state="$(profile_lock_is_stale "${lock_dir}")" && [[ "${stale_state}" == "1" ]]; then
+      rm -rf "${lock_dir}"
+      continue
+    fi
+    attempts=$((attempts + 1))
+    if [[ "${attempts}" -ge 50 ]]; then
+      return 1
+    fi
+    sleep 0.02
+  done
+}
+
 append_audit_record_to_path() {
   local audit_path="$1"
   shift
-  local timestamp
-  local prev_digest=""
-  local record_digest=""
+  local lock_dir=""
+  local rc=0
 
   mkdir -p "$(dirname "${audit_path}")"
   umask 077
   touch "${audit_path}"
   chmod 0600 "${audit_path}" 2>/dev/null || true
-  timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-  if [[ -s "${audit_path}" ]]; then
-    prev_digest="$(sed -n 's/.*record_digest=\([^ ]*\).*/\1/p' "${audit_path}" | tail -n1)"
+
+  lock_dir="${audit_path}.lock"
+  if ! acquire_audit_log_lock "${lock_dir}"; then
+    echo "Workcell: warning: could not acquire audit-log lock for ${audit_path}; skipped a record to keep the chain linear." >&2
+    return 1
   fi
-  record_digest="$(audit_record_digest "${prev_digest}" "${timestamp}" "$@")"
-  {
-    printf 'timestamp=%q ' "${timestamp}"
-    printf '%q ' "$@"
-    [[ -n "${prev_digest}" ]] && printf 'prev_digest=%q ' "${prev_digest}"
-    printf 'record_digest=%q ' "${record_digest}"
-    printf '\n'
-  } >>"${audit_path}"
+  # Run the read-prev-digest + append critical section under the lock, releasing
+  # on every path (including a set -e abort inside the subshell).
+  (
+    local timestamp
+    local prev_digest=""
+    local record_digest=""
+    timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    if [[ -s "${audit_path}" ]]; then
+      prev_digest="$(sed -n 's/.*record_digest=\([^ ]*\).*/\1/p' "${audit_path}" | tail -n1)"
+    fi
+    record_digest="$(audit_record_digest "${prev_digest}" "${timestamp}" "$@")"
+    {
+      printf 'timestamp=%q ' "${timestamp}"
+      printf '%q ' "$@"
+      [[ -n "${prev_digest}" ]] && printf 'prev_digest=%q ' "${prev_digest}"
+      printf 'record_digest=%q ' "${record_digest}"
+      printf '\n'
+    } >>"${audit_path}"
+  ) || rc=$?
+  rm -rf "${lock_dir}" 2>/dev/null || true
+  return "${rc}"
 }
 
 maybe_fail_after_profile_refresh_for_tests() {

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -168,7 +168,7 @@ usage() {
   cat <<'EOF'
 Usage: workcell [options] [-- provider-args...]
        workcell publish-pr [options]
-       workcell session <start|attach|send|stop|list|show|delete|logs|timeline|diff|export> [options]
+       workcell session <start|attach|send|stop|list|show|delete|logs|timeline|diff|export|verify> [options]
        workcell auth <init|set|unset|status> [options]
        workcell policy <show|validate|diff> [options]
        workcell why --credential KEY --agent NAME [options]
@@ -3106,7 +3106,36 @@ finalize_session_audit() {
   fi
   append_exit_audit_record "${profile}" "${execution_path}" "${exit_status}" "${final_assurance}" "${downgraded}"
   write_session_record_final "${final_status}" "${exit_status}" "${final_assurance}"
+  sign_session_audit_head "${profile}"
   FINAL_SESSION_ASSURANCE="${final_assurance}"
+}
+
+# sign_session_audit_head signs the head of this session's audit hash-chain
+# host-side (A5). It is best-effort with respect to teardown: a signing failure
+# is warned and swallowed so it never wedges container cleanup, and an unsigned
+# session simply fails `session verify` closed. Signing itself is fail-closed in
+# the Go helper (it refuses to sign with an insecurely stored key).
+sign_session_audit_head() {
+  local profile="$1"
+  local audit_path=""
+  local target_provider=""
+
+  [[ "${SESSION_RECORD_FINALIZED}" -eq 1 ]] || return 0
+  [[ -n "${SESSION_RECORD_PATH}" ]] || return 0
+  [[ -n "${SESSION_ID}" ]] || return 0
+
+  audit_path="$(profile_audit_log_path "${profile}")"
+  [[ -s "${audit_path}" ]] || return 0
+  target_provider="$(target_provider_for_profile_state "${profile}")"
+
+  if ! go_hostutil session-sign-head \
+    "--signing-dir=${WORKCELL_STATE_ROOT}/signing" \
+    "--audit-log=${audit_path}" \
+    "--session-id=${SESSION_ID}" \
+    "--record-path=${SESSION_RECORD_PATH}" \
+    "--provider=${target_provider}" 2>/dev/null; then
+    echo "Workcell: warning: could not sign session audit head for ${SESSION_ID}; session verify will report it unsigned." >&2
+  fi
 }
 
 write_profile_image_marker() {
@@ -4224,6 +4253,15 @@ session_timeline_main() {
   exit $?
 }
 
+session_verify_main() {
+  collect_session_lookup_roots || exit 1
+  run_go_hostutil_preserve_exit session-verify-cli "${SESSION_LOOKUP_ROOTS[@]}" \
+    "--signing-dir=${WORKCELL_STATE_ROOT}/signing" \
+    "--real-home=${REAL_HOME}" \
+    "$@"
+  exit $?
+}
+
 session_monitor_main() {
   local plan=""
   local monitor_cli_status=0
@@ -4446,6 +4484,9 @@ session_main() {
       ;;
     timeline)
       session_timeline_main "$@"
+      ;;
+    verify)
+      session_verify_main "$@"
       ;;
     diff)
       while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
**Roadmap A5 (2 of 2) — the wiring.** Stacks on #a5a (`a5a/auditseal`); base will retarget to main once PR1 merges. Wires the tested `internal/host/auditseal` library into the product:

- **`workcell session verify --id`** — recomputes the chain over the AUTHORITATIVE durable log (verify-from-authoritative, filtered by `session_id`), rejects duplicate keys, then verifies the head signature over the RECOMPUTED head against the pinned per-host public key. Fail-closed exit codes (0 ok / 1 tamper|unsigned / 2 usage), output G2-redacted. Mirrors `session logs` structure; registered in `dispatch.go`, routed in `scripts/workcell`.
- **Session-stop signing hook** — `finalize_session_audit` signs the session's chain head via a `workcell-hostutil` helper; seal stored beside the durable record (`<id>.audit-sig`, 0600). Signing is non-fatal to teardown; an unsigned session verifies as fail-closed.
- **Lockstep** — `usage.go` + `man/workcell.1` + `policy/operator-contract.toml` + `policy/requirements.toml` + regenerated `control-plane-manifest.json`.
- **Trust-model doc** (`docs/signed-session-audit-records.md`) — boundary/host-signed, not agent-signed; detects offline/exported/reorder/drop/dup-key/sandbox tampering + unsigned sessions; explicitly does NOT defend a host-root attacker who can read `signing.key` and re-sign. F1 OCSF export unchanged (sidecar-only).

## CLI tests
Genuine session PASSES; tampered → exit 1; unsigned → exit 1; missing `--id`/unknown flag → exit 2.

## Known follow-up
The signing hook covers the bash-launcher `finalize_session_audit` lifecycle. The apple-container separate finalize path is NOT yet wired to sign — those sessions currently verify as unsigned (fail-closed). Tracked as a fast-follow.

check-pr-shape (vs a5a): 568 lines — PASS. Builds+tests green on top of a5a; operator-contract/public-contract/manifest/doc-links/shellcheck/shfmt/markdownlint/codespell all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)