### PR TITLE
^F A5 (1/3): ocsf strict audit-line decode primitives (bare-token + dup-key reject, decoded session_id claim)

### DIFF
--- a/internal/ocsf/auditline.go
+++ b/internal/ocsf/auditline.go
@@ -289,7 +289,12 @@ func splitQuotedTokens(line string) ([]string, error) {
 		case r == '$' && i+1 < len(runes) && runes[i+1] == '\'':
 			decoded, next, err := decodeAnsiC(runes, i+2)
 			if err != nil {
-				return nil, err
+				// Return the tokens completed BEFORE the malformed field so a
+				// caller that only needs the delimited fields parsed so far (e.g.
+				// AuditLineClaimsSession checking for a session_id field token that
+				// preceded the corruption) can act on them. decodeAuditLine still
+				// treats any error as fail-closed and discards these.
+				return tokens, err
 			}
 			cur.WriteString(decoded)
 			inToken = true

--- a/internal/ocsf/decode.go
+++ b/internal/ocsf/decode.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package ocsf
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/applecontainer"
+)
+
+// AuditField is one ordered key/value pair decoded from an audit line. It is
+// the exported view of the package-internal auditField so that the A5 audit
+// hash-chain verifier (internal/host/auditseal) can reuse this package's
+// hardened, dup-key-rejecting tokenizer instead of reimplementing the bash
+// `printf %q` and percent-path decoders.
+type AuditField struct {
+	Key   string
+	Value string
+}
+
+// DecodeAuditLineStrict tokenizes a single durable audit line into ordered,
+// un-escaped key/value fields, selecting the on-disk encoding from the session's
+// target provider exactly as the OCSF export does (auditEncodingForProvider),
+// and rejecting a record that carries a duplicate key (fail-closed) so a
+// tampered line such as `session_id=A session_id=B` is detected. It adds one
+// extra fail-closed rule for tamper detection over the OCSF export's tolerant
+// reader: it REJECTS a record that carries a bare (non key=value) token rather
+// than silently dropping it. The export intentionally tolerates torn crash lines
+// by skipping bare tokens (decodeAuditLine), but a tamper-evidence verifier must
+// not — a writer never emits a bare token, so an appended one such as
+// `... FORGED` is tampering. Because the record digest is computed only over the
+// key=value args, a dropped bare token would otherwise leave the recomputed
+// digest unchanged and let the forged line verify. Order is preserved so a
+// caller can reconstruct the exact digest input the writer hashed.
+func DecodeAuditLineStrict(line, targetProvider string) ([]AuditField, error) {
+	enc := auditEncodingForProvider(targetProvider)
+	var tokens []string
+	if enc == encodingPercentPath {
+		tokens = strings.Fields(line)
+	} else {
+		var err error
+		tokens, err = splitQuotedTokens(line)
+		if err != nil {
+			return nil, err
+		}
+	}
+	fields := make([]AuditField, 0, len(tokens))
+	seen := make(map[string]struct{}, len(tokens))
+	for _, tok := range tokens {
+		key, value, ok := strings.Cut(tok, "=")
+		if !ok {
+			return nil, fmt.Errorf("audit record has bare token %q (no key=value)", tok)
+		}
+		if _, dup := seen[key]; dup {
+			return nil, fmt.Errorf("audit record has duplicate key %q", key)
+		}
+		seen[key] = struct{}{}
+		if enc == encodingPercentPath {
+			if _, isPath := percentEncodedAuditFields[key]; isPath {
+				value = applecontainer.DecodeAuditPathValue(value)
+			}
+		}
+		fields = append(fields, AuditField{Key: key, Value: value})
+	}
+	return fields, nil
+}
+
+// AuditLineClaimsSession reports whether an audit line carries a session_id
+// TOKEN equal to sessionID, using the provider's proper tokenizer so a bash-%q
+// argv value cannot forge a claim (its `\ ` spaces stay inside one argv token,
+// never a session_id token). It tolerates bare/duplicate tokens and never errors
+// — a structural claim test, paired by callers with DecodeAuditLineStrict to
+// decide member-vs-tamper for a claiming line.
+func AuditLineClaimsSession(line, targetProvider, sessionID string) bool {
+	var tokens []string
+	if auditEncodingForProvider(targetProvider) == encodingPercentPath {
+		tokens = strings.Fields(line)
+	} else {
+		toks, err := splitQuotedTokens(line)
+		if err != nil {
+			return false
+		}
+		tokens = toks
+	}
+	for _, tok := range tokens {
+		if k, v, ok := strings.Cut(tok, "="); ok && k == "session_id" && v == sessionID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ocsf/decode.go
+++ b/internal/ocsf/decode.go
@@ -70,19 +70,24 @@ func DecodeAuditLineStrict(line, targetProvider string) ([]AuditField, error) {
 // AuditLineClaimsSession reports whether an audit line carries a session_id
 // TOKEN equal to sessionID, using the provider's proper tokenizer so a bash-%q
 // argv value cannot forge a claim (its `\ ` spaces stay inside one argv token,
-// never a session_id token). It tolerates bare/duplicate tokens and never errors
-// — a structural claim test, paired by callers with DecodeAuditLineStrict to
-// decide member-vs-tamper for a claiming line.
+// never a session_id token). It tolerates bare/duplicate tokens — a structural
+// claim test, paired by callers with DecodeAuditLineStrict to decide
+// member-vs-tamper for a claiming line.
+//
+// A tokenizer error (a malformed quoted field) does NOT erase a matching
+// session_id FIELD token seen BEFORE it: splitQuotedTokens returns the fields it
+// completed before failing, so a corrupted record for the target session still
+// claims (and is then passed to strict decode to fail closed) rather than being
+// misclassified as an unrelated non-member. A match found only AFTER the error
+// point cannot exist (there are no completed tokens past it), and an
+// argv-embedded session_id remains a single argv token, never a claim.
 func AuditLineClaimsSession(line, targetProvider, sessionID string) bool {
 	var tokens []string
 	if auditEncodingForProvider(targetProvider) == encodingPercentPath {
 		tokens = strings.Fields(line)
 	} else {
-		toks, err := splitQuotedTokens(line)
-		if err != nil {
-			return false
-		}
-		tokens = toks
+		// Ignore the error: use whatever fields were completed before it.
+		tokens, _ = splitQuotedTokens(line)
 	}
 	for _, tok := range tokens {
 		if k, v, ok := strings.Cut(tok, "="); ok && k == "session_id" && v == sessionID {

--- a/internal/ocsf/decode.go
+++ b/internal/ocsf/decode.go
@@ -96,3 +96,19 @@ func AuditLineClaimsSession(line, targetProvider, sessionID string) bool {
 	}
 	return false
 }
+
+// AuditLineTokenizable reports whether an audit line can be split into tokens by
+// the provider's tokenizer. The genuine writer always emits tokenizable lines
+// (it closes every bash ANSI-C `$'...'` block), so an UNtokenizable line — one
+// whose quoting is corrupt, e.g. `event=$'unterminated` before session_id — is
+// tamper or damage, not a legitimate record. Its fields, including session_id,
+// are unreadable, so it cannot be attributed to a session; callers fail closed
+// on it rather than silently drop it as a non-member. The percent-path encoding
+// splits on whitespace and is always tokenizable.
+func AuditLineTokenizable(line, targetProvider string) bool {
+	if auditEncodingForProvider(targetProvider) == encodingPercentPath {
+		return true
+	}
+	_, err := splitQuotedTokens(line)
+	return err == nil
+}

--- a/internal/ocsf/decode_test.go
+++ b/internal/ocsf/decode_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package ocsf
+
+import "testing"
+
+func TestDecodeAuditLineStrictAcceptsGenuineRecord(t *testing.T) {
+	fields, err := DecodeAuditLineStrict("timestamp=t session_id=s event=exit record_digest=d", "colima")
+	if err != nil {
+		t.Fatalf("genuine record must decode: %v", err)
+	}
+	if len(fields) != 4 || fields[1].Key != "session_id" || fields[1].Value != "s" {
+		t.Fatalf("unexpected fields: %+v", fields)
+	}
+}
+
+func TestDecodeAuditLineStrictRejectsBareToken(t *testing.T) {
+	if _, err := DecodeAuditLineStrict("timestamp=t session_id=s FORGED record_digest=d", "colima"); err == nil {
+		t.Fatal("bare token must be rejected")
+	}
+}
+
+func TestDecodeAuditLineStrictRejectsDuplicateKey(t *testing.T) {
+	if _, err := DecodeAuditLineStrict("timestamp=t session_id=a session_id=b record_digest=d", "colima"); err == nil {
+		t.Fatal("duplicate key must be rejected")
+	}
+}
+
+func TestAuditLineClaimsSessionMatchesRealToken(t *testing.T) {
+	if !AuditLineClaimsSession("timestamp=t session_id=sess-A event=exit record_digest=d", "colima", "sess-A") {
+		t.Fatal("a genuine session_id token must claim the session")
+	}
+	if AuditLineClaimsSession("timestamp=t session_id=sess-A event=exit record_digest=d", "colima", "sess-B") {
+		t.Fatal("must not claim a different session")
+	}
+}
+
+func TestAuditLineClaimsSessionIgnoresArgvSpoof(t *testing.T) {
+	// A session-B record whose bash-%q argv splits to a fake session_id=sess-A
+	// token under a raw scan must NOT claim sess-A: the tokenizer rejoins argv.
+	spoof := `timestamp=t session_id=sess-B event=command argv=run\ session_id=sess-A\ now record_digest=d`
+	if AuditLineClaimsSession(spoof, "colima", "sess-A") {
+		t.Fatal("an argv substring must not forge a session claim")
+	}
+	if !AuditLineClaimsSession(spoof, "colima", "sess-B") {
+		t.Fatal("the record's true session_id token must claim")
+	}
+}
+
+func TestAuditLineClaimsSessionToleratesBareToken(t *testing.T) {
+	// A malformed line (bare token) that carries a genuine session_id token still
+	// structurally claims the session, so callers can treat it as tamper.
+	if !AuditLineClaimsSession("timestamp=t session_id=sess-A event=exit FORGED", "colima", "sess-A") {
+		t.Fatal("a bare-token line with a real session_id token must still claim")
+	}
+}
+
+func TestDecodeAuditLineStrictRejectsBareTokenPercentProvider(t *testing.T) {
+	// The AppleContainer percent-path provider tokenizes on whitespace; a bare
+	// token must still be rejected under that encoding.
+	if _, err := DecodeAuditLineStrict("timestamp=t session_id=s FORGED record_digest=d", "apple-container"); err == nil {
+		t.Fatal("bare token must be rejected under percent-path encoding")
+	}
+}

--- a/internal/ocsf/decode_test.go
+++ b/internal/ocsf/decode_test.go
@@ -71,6 +71,21 @@ func TestAuditLineClaimsSessionArgvSpoofWithMalformedTailStaysNonMember(t *testi
 	}
 }
 
+func TestAuditLineTokenizable(t *testing.T) {
+	if !AuditLineTokenizable("timestamp=t event=launch session_id=sess-A record_digest=d", "colima") {
+		t.Fatal("a genuine bash-quoted line must be tokenizable")
+	}
+	// A malformed event field BEFORE session_id makes the whole line untokenizable
+	// (the writer never emits an unterminated ANSI-C block).
+	if AuditLineTokenizable(`timestamp=t event=$'unterminated session_id=sess-A`, "colima") {
+		t.Fatal("an unterminated ANSI-C block must be untokenizable")
+	}
+	// The percent-path encoding splits on whitespace and never errors.
+	if !AuditLineTokenizable(`timestamp=t event=$'unterminated session_id=sess-A`, "apple-container") {
+		t.Fatal("percent-path encoding is always tokenizable")
+	}
+}
+
 func TestAuditLineClaimsSessionToleratesBareToken(t *testing.T) {
 	// A malformed line (bare token) that carries a genuine session_id token still
 	// structurally claims the session, so callers can treat it as tamper.

--- a/internal/ocsf/decode_test.go
+++ b/internal/ocsf/decode_test.go
@@ -48,6 +48,29 @@ func TestAuditLineClaimsSessionIgnoresArgvSpoof(t *testing.T) {
 	}
 }
 
+func TestAuditLineClaimsSessionLatchesClaimBeforeTokenizerError(t *testing.T) {
+	// A matching session_id FIELD token BEFORE a malformed quoted field must
+	// still claim, so a corrupted target-session record reaches the tamper path
+	// instead of being dropped as unrelated. Pre-fix returned false.
+	line := `timestamp=t session_id=sess-A note=$'unterminated`
+	if !AuditLineClaimsSession(line, "colima", "sess-A") {
+		t.Fatal("a session_id field token before a tokenizer error must still claim")
+	}
+}
+
+func TestAuditLineClaimsSessionArgvSpoofWithMalformedTailStaysNonMember(t *testing.T) {
+	// The session_id appears only inside an argv value (one token); the record's
+	// real session_id is sess-B and a later field is malformed. Must NOT claim
+	// sess-A (no L280 regression), but must still claim its true sess-B.
+	line := `timestamp=t session_id=sess-B argv=hello\ session_id=sess-A note=$'unterminated`
+	if AuditLineClaimsSession(line, "colima", "sess-A") {
+		t.Fatal("an argv-embedded session_id must not claim, even with a malformed tail")
+	}
+	if !AuditLineClaimsSession(line, "colima", "sess-B") {
+		t.Fatal("the real session_id field before the error must claim")
+	}
+}
+
 func TestAuditLineClaimsSessionToleratesBareToken(t *testing.T) {
 	// A malformed line (bare token) that carries a genuine session_id token still
 	// structurally claims the session, so callers can treat it as tamper.


### PR DESCRIPTION
First of the A5 signed-session-audit stack (split from #466 to fit the 1200-line reviewer cap). The `internal/ocsf` strict-decode primitives the auditseal library (PR 2/3) consumes:
- **DecodeAuditLineStrict** — rejects bare (non key=value) tokens AND duplicate keys, so a tampered line that appends a bare token (e.g. `FORGED`) can't rebuild an identical digest (closes the P1 tamper hole from the original review).
- **AuditLineClaimsSession** — decodes then matches the session_id FIELD, so a spoofed `session_id=<id>` planted in another record's free-form argv is not mis-attributed (the F1 L408 class), and a malformed line that structurally claims a session is distinguishable from an unrelated one.
Both unit-tested (argv-spoof-safe + dup-key, both bash-%q and apple-container encodings). Honest layering: audit-line decoders live with the OCSF on-disk format; the crypto/chain library consumes them. 158 lines. dead-code clean (test callers reachable), EXACT CI validators zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)