### PR TITLE
^F A5 (3/3): workcell session verify + session-stop signing hook + trust-model doc

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -99,6 +99,10 @@ func run(args []string) error {
 		return cmdHelperSessionStopCli(args[1:])
 	case "session-timeline-cli":
 		return cmdHelperSessionTimelineCli(args[1:])
+	case "session-verify-cli":
+		return cmdHelperSessionVerifyCli(args[1:])
+	case "session-sign-head":
+		return cmdHelperSessionSignHead(args[1:])
 	case "support-bundle-cli":
 		return cmdHelperSupportBundleCli(args[1:])
 	case "support-bundle-usage":
@@ -370,6 +374,14 @@ func cmdHelperSessionTimelineCli(args []string) error {
 
 func cmdHelperSessionLogsCli(args []string) error {
 	return sessionctl.LogsMain(args)
+}
+
+func cmdHelperSessionVerifyCli(args []string) error {
+	return sessionctl.VerifyMain(args)
+}
+
+func cmdHelperSessionSignHead(args []string) error {
+	return sessionctl.SignHeadMain(args)
 }
 
 func cmdHelperSessionAttachCli(args []string) error {
@@ -1013,7 +1025,7 @@ func parsePrepareBundleArgs(args []string) (*injection.PrepareBundleOptions, err
 // already do); previously these returned plain errors and collapsed to the
 // exit-1 fallback, an intra-binary inconsistency (D8).
 func usage() error {
-	return &cliexit.ExitCodeError{Code: 2, Message: "usage: workcell-hostutil <path|release|helper|launcher|policy|resolve-credentials|pty-transcript|auth-cli|auth-usage|policy-cli|policy-usage|publish-pr-cli|publish-pr-usage|session-usage|session-attach-cli|session-delete-cli|session-dispatch-cli|session-logs-cli|session-monitor-cli|session-send-cli|session-stop-cli|session-timeline-cli|support-bundle-cli|support-bundle-usage> [args...]"}
+	return &cliexit.ExitCodeError{Code: 2, Message: "usage: workcell-hostutil <path|release|helper|launcher|policy|resolve-credentials|pty-transcript|auth-cli|auth-usage|policy-cli|policy-usage|publish-pr-cli|publish-pr-usage|session-usage|session-attach-cli|session-delete-cli|session-dispatch-cli|session-logs-cli|session-monitor-cli|session-send-cli|session-stop-cli|session-timeline-cli|session-verify-cli|session-sign-head|support-bundle-cli|support-bundle-usage> [args...]"}
 }
 
 func pathUsage() error {

--- a/docs/enterprise-evidence-baseline.md
+++ b/docs/enterprise-evidence-baseline.md
@@ -29,6 +29,11 @@ Current audit and session evidence is host-local:
 - audit records are append-only text records with timestamps, event fields,
   assurance data, and chained record digests
 - launched sessions write durable JSON records under the same target-state root
+- session audit-chain heads are signed host-side, and
+  `workcell session verify` recomputes the chain from the authoritative log and
+  checks that signature — see
+  [signed-session-audit-records.md](signed-session-audit-records.md) for the
+  format and trust model (boundary/host-signed, not agent-signed)
 - `workcell session timeline` filters audit records for one session
 - `workcell session export` bundles a session record with matching audit records
 - durable session records intentionally survive `workcell --gc`

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -258,12 +258,26 @@ you can detect truncation or replacement of the durable log against a preserved
 snapshot (step 3). Cross-check the exported records, the timeline, and the
 preserved `workcell.audit.log` for consistency.
 
-**What does not exist yet.** There is **no cryptographic hash-chain
-verification** of session audit records today. Signed, tamper-evident audit
-records with external verification tooling are **roadmapped as A5**
-(["Signed Session Audit Records", milestone v0.15](../ROADMAP.md#track-a-boundary-depth-and-agent-threat-defenses)) —
-a `workcell session verify`-style command is planned there but is **not
-shipped**. Until A5 lands, integrity is host-preservation plus consistency
+**Cryptographic verification (A5).** Session audit records now form a signed,
+tamper-evident hash chain, and `workcell session verify --id SESSION_ID`
+recomputes that chain from the **authoritative** durable profile log and verifies
+the host-side signature over the chain head against the per-host signing key
+(["Signed Session Audit Records"](../ROADMAP.md#track-a-boundary-depth-and-agent-threat-defenses)).
+As a responder, run it against the suspect session: a `session_verify=verified`
+result means the audit chain is intact and its head is signed by this host's key,
+so the recorded events have not been altered offline. It fails closed (non-zero,
+no `verified`) on any tamper the chain detects — a flipped byte, a reordered,
+dropped, or duplicated record, an appended container-side line, an
+exported/copied log substituted for the real one, or a missing/mismatched seal.
+It does **not** defend against an attacker with host root who re-signs a rewritten
+chain with the host key (out of scope per the A5 threat model), so pair a
+`verified` result with the host-preservation and consistency cross-checks above
+rather than treating it as proof the host itself was not compromised.
+
+**What still relies on preservation.** For providers whose audit records carry no
+digest chain (e.g. the preview-only apple-container target), `session verify`
+fails closed as unsupported rather than asserting integrity; there, and for the
+host-root case above, integrity is host-preservation plus consistency
 cross-checks, not signature verification. Do not represent current audit records
 as cryptographically tamper-proof.
 

--- a/docs/safe-path-expectations.md
+++ b/docs/safe-path-expectations.md
@@ -62,6 +62,7 @@ workcell session logs --id 20260408T120000Z-1a2b3c4d --kind audit
 workcell session timeline --id 20260408T120000Z-1a2b3c4d
 workcell session diff --id 20260408T120000Z-1a2b3c4d
 workcell session export --id 20260408T120000Z-1a2b3c4d --output /tmp/workcell-session.json
+workcell session verify --id 20260408T120000Z-1a2b3c4d
 workcell policy show
 workcell policy diff
 workcell why --agent codex --mode strict --credential codex_auth

--- a/docs/signed-session-audit-records.md
+++ b/docs/signed-session-audit-records.md
@@ -1,0 +1,175 @@
+# Signed Session Audit Records
+
+Workcell session audit records form a tamper-evident hash chain whose head is
+signed host-side. `workcell session verify --id SESSION_ID` recomputes the chain
+from the authoritative durable log and verifies that signature, so a reviewer
+outside the agent can detect tampering. This document specifies the record
+format, the signing and verification model, and — explicitly — what the model
+does and does not protect.
+
+## Hash-chain format
+
+Every audit record is appended to a per-profile log under Workcell-owned target
+state, for example:
+
+```text
+~/.local/state/workcell/targets/<target-kind>/<provider>/<profile>/workcell.audit.log
+```
+
+`scripts/workcell`'s `append_audit_record_to_path` writes each record as
+whitespace-delimited `key=value` tokens:
+
+```text
+timestamp=<ts> <event fields...> [prev_digest=<hex>] record_digest=<hex>
+```
+
+- `timestamp` is a UTC RFC 3339 second-resolution stamp.
+- The event fields are the record payload (for example
+  `event=exit session_id=<id> exit_status=0 ...`). Every session record carries
+  `session_id=<id>`.
+- `record_digest` chains the record to its predecessor:
+
+  ```text
+  record_digest = SHA-256( prev_digest \x00 timestamp \x00 arg0 \x00 arg1 ... )
+  ```
+
+  computed by `hoststate.AuditRecordDigest`, where the args are the event-field
+  tokens in write order and `prev_digest` is the previous record's
+  `record_digest` (empty for the first record in the log).
+- `prev_digest` is omitted on the first record and present on every subsequent
+  record.
+
+Because each digest folds in the previous digest, altering, reordering, or
+dropping any record changes every downstream digest — a standard tamper-evident
+chain. The **head** of a session is the `record_digest` of the last log record
+carrying that session's `session_id`.
+
+### Append serialization invariant
+
+The chain is linear only if appends are serialized: an appender reads the
+current tail's `record_digest` as the new record's `prev_digest`, so two
+concurrent detached-session control paths (`start`/`send`/`stop`) that read the
+same tail and both append would fork the chain and make verification reject a
+legitimate later record. `append_audit_record_to_path` therefore holds an
+exclusive per-log lock across the read-tail-plus-append critical section. The
+lock is the repo's atomic, crash-safe `acquire-profile-lock` primitive (an
+atomic `mkdir`+`rename` whose owner PID lets a crashed holder be reclaimed)
+applied to a `<audit-log>.lock` directory, so no external `flock(1)` is required
+— it is absent on the macOS host. The critical section is short but includes a
+cold `go` digest computation, so a waiter uses a bounded ~30s backoff (1500 ×
+20ms) to reliably outlast an in-progress append; on exhaustion (a genuinely
+stuck holder) the appender fails closed (skips the record) rather than fork the
+chain. Single-writer behavior is unchanged.
+
+## Seal (host-side signature)
+
+When the runtime boundary finalizes a session (`finalize_session_audit`, after
+the terminal audit record is appended and the durable record is written),
+Workcell signs the session head:
+
+- **Key.** A per-host ECDSA P-256 key (the curve cosign uses by default) is
+  generated on first use under `~/.local/state/workcell/signing/` — directory
+  mode `0700`, private key `signing.key` mode `0600`. If that directory cannot
+  be created and confined to owner-only access, signing fails closed rather than
+  sign with an insecurely stored key.
+- **Signed message.** A domain-separated message binding the session id to the
+  recomputed head is signed, so a signature cannot be replayed onto a different
+  session or a different chain state.
+- **Seal file.** The signature is stored beside the durable session record as
+  `<session-id>.audit-sig` (host-owned, mode `0600`). It records the seal
+  version, session id, head digest, signing key id, algorithm, and the
+  base64 signature. Only the version, session id, key id, algorithm, and
+  signature are load-bearing; the head digest is informational because
+  verification always recomputes the head from the authoritative log.
+- **Public key.** The public half is written to
+  `~/.local/state/workcell/signing/<key-id>.pub` (PKIX PEM), where `<key-id>` is
+  a SHA-256 fingerprint prefix of the public key. `session verify` pins the
+  signature to the key id named in the seal.
+
+This is a boundary/host signature, **not** an agent signature: the operator host
+signs on the trusted side of the runtime boundary, so the agent inside the
+sandbox never holds the signing key and cannot forge a seal.
+
+## Verification
+
+`workcell session verify --id SESSION_ID` is read-only and fail-closed:
+
+1. Locate the durable session record and its authoritative audit log.
+2. Read the seal beside the record. A session with no seal fails closed.
+3. Recompute the hash chain over the authoritative log from the first record up
+   to and including the session head, rejecting any record that carries a
+   duplicate key (the same fail-closed rule the OCSF export applies).
+4. Verify the seal signature over the **recomputed** head using the pinned
+   public key named by the seal.
+
+Exit codes: `0` verified, `1` verification failed (tamper, or a missing or
+invalid seal), `2` usage error. Output is passed through the shared support
+bundle redactor (the [G2](../SUPPORT.md) rule-set), so no secret leaks.
+
+### Corrupt (untokenizable) records
+
+The writer emits `event=` before `session_id=`, so a malformed field can make a
+record untokenizable before its `session_id` is reachable — and such a line
+cannot be attributed to a session at all. The genuine writer never emits an
+untokenizable record (it closes every bash ANSI-C `$'…'` block), so verification
+treats any untokenizable line as corruption or tamper and **fails closed**,
+rather than silently dropping an unreadable, appended same-session record as an
+unrelated non-member. A legitimate other-session record — even a torn/legacy
+line missing `record_digest` — still tokenizes and is attributed by its
+`session_id`, so it does not fail an unrelated session. The one accepted
+tradeoff is that a rare crash-truncation inside an ANSI-C block anywhere in the
+shared profile log fails verification for sessions reading it; that is the
+correct fail-closed posture for tamper-evident audit (a reviewer must
+investigate a log that cannot be parsed).
+
+### Key rotation
+
+To rotate, an operator removes (or moves aside) `signing.key`; the next signing
+run generates a fresh key with a new key id. Old public keys are retained under
+the signing directory, so seals produced by an earlier key still verify against
+their recorded key id.
+
+## Trust model
+
+**Detected.** Any modification to the persisted audit records at or before a
+session's signed head:
+
+- a flipped byte in any record field or digest;
+- a reordered or dropped record (chain linkage breaks or the head changes);
+- a forged duplicate key on a record;
+- an exported or copied log presented in place of the authoritative one (the
+  copy is not the persisted record the seal was computed over);
+- any session presented without a valid host seal.
+
+**Not defended.** This is boundary integrity, not host compromise resistance:
+
+- A host-root attacker who can read `signing.key` can re-sign a tampered chain.
+  The seal proves the records were signed by a holder of the per-host key, not
+  that the host itself was never compromised.
+- The signing key protects records against parties **without** that key
+  (the sandboxed agent, a lower-privilege process, offline tampering of the log
+  or an exported copy) — not against the key holder.
+- Verification confirms integrity and host-side provenance; it is not an
+  identity attestation of a remote signer (contrast the release-artifact keyless
+  Sigstore flow in [provenance.md](provenance.md), whose trust anchor is a CI
+  workflow identity that does not exist at session runtime).
+
+## Provider coverage
+
+Signing covers providers whose audit records form a digest chain — the
+bash-launcher backends (colima, docker-desktop, aws-ec2-ssm, gcp-vm) whose
+session lifecycle is finalized by `finalize_session_audit`. The preview-only,
+launch-blocked `apple-container` target writes plain lifecycle audit lines
+without `prev_digest`/`record_digest`, so there is no chain to seal: such
+sessions are **unsigned**, and `workcell session verify` reports them
+fail-closed with a clear "no signable digest chain" reason. Signing the
+apple-container lifecycle (its own finalize path) is a documented follow-up; it
+is intentionally out of scope here rather than sealed with an unverifiable
+signature.
+
+## Coordination with OCSF export
+
+Signing adds a sidecar file and does not modify the audit log or the durable
+session record, so `workcell session export --format ocsf` is unchanged: signed
+sessions export exactly as before, and the export's own duplicate-key and
+cross-session fail-closed rules continue to apply.

--- a/docs/stability-contract.md
+++ b/docs/stability-contract.md
@@ -116,6 +116,9 @@ The full stable output-line prefix set enforced by `policy/public-contract.toml`
 | `record_digest=` | `scripts/workcell` |
 | `prev_digest=` | `scripts/workcell` |
 | `egress_enforcement=` | `scripts/workcell` |
+| `session_verify=` | `internal/sessionctl` (`session verify`) |
+| `key_id=` | `internal/sessionctl` (`session verify`) |
+| `head_digest=` | `internal/sessionctl` (`session verify`) |
 
 The complete set of `key=` prefixes in the `session show --text` summary is
 enforced separately, by set-equality against `SessionShowLines`

--- a/docs/workcell-session-supervisor-design.md
+++ b/docs/workcell-session-supervisor-design.md
@@ -25,6 +25,7 @@ host-side inventory, observability, and detached-control commands:
 - `workcell session timeline --id ...`
 - `workcell session diff --id ...`
 - `workcell session export --id ...`
+- `workcell session verify --id ...`
 - `workcell session start`
 - `workcell session attach`
 - `workcell session send`

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -371,6 +371,7 @@ surface includes:
 - `workcell session timeline`
 - `workcell session diff`
 - `workcell session export`
+- `workcell session verify`
 
 The supported operator inventory is maintained in
 [`policy/operator-contract.toml`](../policy/operator-contract.toml). This

--- a/internal/metadatautil/public_contract_test.go
+++ b/internal/metadatautil/public_contract_test.go
@@ -88,8 +88,8 @@ func TestCheckPublicContractRejectsMissingSessionRecordField(t *testing.T) {
 func TestCheckPublicContractRejectsBogusOutputPrefix(t *testing.T) {
 	root := publicContractRepoRoot(t)
 	contractPath := mutatedContractCopy(t, root,
-		`"egress_enforcement="]`,
-		`"egress_enforcement=", "totally_bogus_prefix_zz="]`,
+		`"head_digest="]`,
+		`"head_digest=", "totally_bogus_prefix_zz="]`,
 	)
 
 	err := CheckPublicContract(root, contractPath)

--- a/internal/sessionctl/dispatch.go
+++ b/internal/sessionctl/dispatch.go
@@ -67,7 +67,7 @@ func dispatchMain(args []string, stdout io.Writer) error {
 // `monitor` is the internal supervisor verb that `session start`
 // invokes against itself, not a user-facing subcommand — `man
 // workcell.1` and `README.md` document the user surface as
-// start|attach|send|stop|list|show|delete|logs|timeline|diff|export.
+// start|attach|send|stop|list|show|delete|logs|timeline|diff|export|verify.
 // A fresh slice is returned on every call so callers may mutate it
 // freely.
 func CanonicalSubcommands() []string {
@@ -83,6 +83,7 @@ func CanonicalSubcommands() []string {
 		"timeline",
 		"diff",
 		"export",
+		"verify",
 		"monitor",
 	}
 }

--- a/internal/sessionctl/dispatch_test.go
+++ b/internal/sessionctl/dispatch_test.go
@@ -27,6 +27,7 @@ func TestResolveSessionSubcommandAcceptsCanonical(t *testing.T) {
 		"timeline",
 		"diff",
 		"export",
+		"verify",
 		"monitor",
 	}
 	for _, name := range cases {
@@ -92,6 +93,7 @@ func TestDispatchMainEmitsCanonicalRoute(t *testing.T) {
 		"timeline": "subcommand=timeline\n",
 		"diff":     "subcommand=diff\n",
 		"export":   "subcommand=export\n",
+		"verify":   "subcommand=verify\n",
 		"monitor":  "subcommand=monitor\n",
 	}
 	for name, want := range cases {

--- a/internal/sessionctl/signhead.go
+++ b/internal/sessionctl/signhead.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/omkhar/workcell/internal/cliexit"
+	"github.com/omkhar/workcell/internal/host/auditseal"
+)
+
+// SignHeadMain implements the host-side signing hook invoked from
+// scripts/workcell's finalize_session_audit after the terminal audit record is
+// appended and the durable session record is finalized. It recomputes the
+// session's audit-chain head from the authoritative log and writes a signed
+// seal beside the durable record.
+//
+// It is deliberately NOT fatal to session teardown: signing failures are
+// surfaced to the caller (which logs a warning and continues) so a signing
+// problem never wedges container cleanup. The absence of a valid seal makes
+// `session verify` fail closed, which is the correct fail-closed posture.
+//
+// Flags (all required except --signed-at):
+//
+//	--signing-dir=DIR      per-host signing key/pubkey directory
+//	--audit-log=PATH       authoritative profile audit log
+//	--session-id=ID        session whose head is signed
+//	--record-path=PATH     durable session record (the seal is written beside it)
+//	--provider=NAME        target provider (selects the audit-line decoder)
+//	--signed-at=RFC3339    signature timestamp (defaults to now, UTC)
+func SignHeadMain(args []string) error {
+	var signingDir, auditLog, sessionID, recordPath, provider, signedAt string
+	for _, arg := range args {
+		switch {
+		case strings.HasPrefix(arg, "--signing-dir="):
+			signingDir = strings.TrimPrefix(arg, "--signing-dir=")
+		case strings.HasPrefix(arg, "--audit-log="):
+			auditLog = strings.TrimPrefix(arg, "--audit-log=")
+		case strings.HasPrefix(arg, "--session-id="):
+			sessionID = strings.TrimPrefix(arg, "--session-id=")
+		case strings.HasPrefix(arg, "--record-path="):
+			recordPath = strings.TrimPrefix(arg, "--record-path=")
+		case strings.HasPrefix(arg, "--provider="):
+			provider = strings.TrimPrefix(arg, "--provider=")
+		case strings.HasPrefix(arg, "--signed-at="):
+			signedAt = strings.TrimPrefix(arg, "--signed-at=")
+		default:
+			return &cliexit.ExitCodeError{Code: 2, Message: fmt.Sprintf("Unsupported workcell session sign-head option: %s", arg)}
+		}
+	}
+	if signingDir == "" || auditLog == "" || sessionID == "" || recordPath == "" {
+		return &cliexit.ExitCodeError{Code: 2, Message: "session sign-head requires --signing-dir, --audit-log, --session-id, and --record-path."}
+	}
+	if signedAt == "" {
+		signedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	seal, err := auditseal.SignSessionHead(signingDir, auditLog, provider, sessionID, signedAt)
+	if err != nil {
+		if errors.Is(err, auditseal.ErrUnsupportedAuditChain) {
+			// A provider with no digest chain (e.g. the preview-only
+			// apple-container target) is scoped out of signing: leave the
+			// session unsigned rather than emit a seal that can never verify.
+			// `session verify` reports it as unsigned, fail-closed.
+			return nil
+		}
+		return err
+	}
+	return auditseal.WriteSeal(auditseal.SealPathForRecord(recordPath), seal)
+}

--- a/internal/sessionctl/signhead_test.go
+++ b/internal/sessionctl/signhead_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/host/auditseal"
+)
+
+// TestSignHeadSkipsNoChainProvider proves the signing hook leaves an
+// apple-container-style session (audit records with no record_digest) unsigned
+// rather than erroring or writing a seal that could never verify.
+func TestSignHeadSkipsNoChainProvider(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "workcell.audit.log")
+	if err := os.WriteFile(logPath, []byte(strings.Join([]string{
+		"timestamp=2026-07-08T00:00:00Z session_id=session-ac event=session_started v=1",
+		"timestamp=2026-07-08T00:00:01Z session_id=session-ac event=session_finished v=1",
+	}, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	recordPath := filepath.Join(tmp, "session-ac.json")
+
+	if err := SignHeadMain([]string{
+		"--signing-dir=" + filepath.Join(tmp, "signing"),
+		"--audit-log=" + logPath,
+		"--session-id=session-ac",
+		"--record-path=" + recordPath,
+		"--provider=apple-container",
+	}); err != nil {
+		t.Fatalf("sign-head on a no-chain provider must be a clean no-op, got %v", err)
+	}
+	if _, err := os.Stat(auditseal.SealPathForRecord(recordPath)); !os.IsNotExist(err) {
+		t.Fatalf("no seal must be written for a no-chain provider (stat err=%v)", err)
+	}
+}

--- a/internal/sessionctl/usage.go
+++ b/internal/sessionctl/usage.go
@@ -16,6 +16,7 @@ const usageText = `Usage: workcell session start [launch-options] [-- provider-a
        workcell session timeline --id SESSION_ID
        workcell session diff --id SESSION_ID [--output PATH]
        workcell session export --id SESSION_ID [--format json|ocsf] [--output PATH]
+       workcell session verify --id SESSION_ID
 
 Commands:
   start
@@ -73,6 +74,9 @@ Commands:
                               (one Application Lifecycle event per line, redacted)
     --output PATH             Write the exported bundle to PATH instead of stdout
 
+  verify
+    --id SESSION_ID           Verify a session's signed, tamper-evident audit records
+
 Notes:
   - session commands run on the host and do not start the Workcell runtime.
   - records are durable host-side metadata for detached, completed, or aborted launches.
@@ -89,6 +93,10 @@ Notes:
     payloads (the detached session message) are not exported: their content is
     replaced with a fixed placeholder since regex redaction cannot sanitize
     arbitrary prose.
+  - ` + "`" + `session verify` + "`" + ` recomputes the session's audit hash-chain from the durable
+    profile log and verifies the host-side signature over the chain head. It is
+    read-only and fails closed on any tampered, reordered, dropped, or unsigned
+    record. Signing is boundary/host-side, not agent-side.
   - ` + "`" + `session delete` + "`" + ` never rewrites the shared profile audit log.
   - ` + "`" + `session delete` + "`" + ` cleans only explicitly recorded session-owned artifacts and
     refuses running sessions or running session containers.

--- a/internal/sessionctl/usage_test.go
+++ b/internal/sessionctl/usage_test.go
@@ -23,6 +23,7 @@ func TestUsageTextListsAllSubcommands(t *testing.T) {
 		"workcell session timeline",
 		"workcell session diff",
 		"workcell session export",
+		"workcell session verify",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("UsageText() missing %q", want)

--- a/internal/sessionctl/verify.go
+++ b/internal/sessionctl/verify.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessionctl
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/cliexit"
+	"github.com/omkhar/workcell/internal/host/auditseal"
+	"github.com/omkhar/workcell/internal/host/sessions"
+	"github.com/omkhar/workcell/internal/host/stateroot"
+	"github.com/omkhar/workcell/internal/supportbundle"
+)
+
+// VerifyMain implements `workcell session verify --id SESSION_ID`: it recomputes
+// the session's audit hash-chain from the AUTHORITATIVE durable profile log and
+// verifies the host-side signature over the chain head. It is fail-closed —
+// any tamper (flipped byte, reorder, drop, duplicate key), a missing or
+// mismatched signature, or an unknown signing key exits non-zero. Output is
+// passed through the shared G2 support-bundle redactor so no secret leaks.
+//
+// Exit codes mirror the sibling read-only subcommands: 2 for usage errors, 1
+// for a failed verification (tamper or missing/invalid seal), 0 when a genuine
+// session verifies.
+func VerifyMain(args []string) error {
+	return verifyMain(args, os.Stdout)
+}
+
+func verifyMain(args []string, stdout io.Writer) error {
+	roots, rest := stateroot.ConsumeRootArgs(args)
+	sessionID, signingDir, realHome, showHelp, err := parseVerifyArgs(rest)
+	if err != nil {
+		return err
+	}
+	if showHelp {
+		fmt.Fprint(stdout, UsageText())
+		return nil
+	}
+	if sessionID == "" {
+		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session verify requires --id."}
+	}
+	if signingDir == "" {
+		return &cliexit.ExitCodeError{Code: 2, Message: "workcell session verify requires --signing-dir."}
+	}
+
+	redactor := supportbundle.NewRedactor(realHome)
+
+	roots, lookupErr := rootsOrLookup(roots)
+	if lookupErr != nil {
+		return lookupErr
+	}
+	record, recordPath, err := sessions.FindSessionRecordWithPathInRoots(roots, sessionID)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("No session record found for %s.", redactor.String(sessionID))}
+		}
+		// A malformed or unreadable record surfaces the absolute record path in the
+		// lower-layer error; redact it (home prefix → ~, credentials masked) like
+		// every other message here so verify honors its support-bundle-redacted
+		// output contract even on the damaged-record paths operators inspect.
+		return &cliexit.ExitCodeError{Code: 1, Message: redactor.String(fmt.Sprintf("Failed to read session record for %s: %v", sessionID, err))}
+	}
+	if record.AuditLogPath == "" {
+		return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("Session %s has no recorded audit log to verify.", redactor.String(sessionID))}
+	}
+
+	// Derive the audit log path CANONICALLY from the trusted on-disk record
+	// location, never from the free-form record.AuditLogPath field. recordPath is
+	// where the profile-scoped lookup actually found the record —
+	// <root>/targets/<kind>/<provider>/<profile>/sessions/<id>.json (or the legacy
+	// <root>/<profile>/sessions/<id>.json) — so its grandparent is the profile
+	// state dir, exactly where profile_audit_log_path/the signer place
+	// workcell.audit.log. Recomputing the signed head over this canonical log
+	// (not an attacker-supplied path) closes the offline tamper hole where a
+	// rewritten AuditLogPath points verification at a pristine copy while the real
+	// log is modified. This derivation is layout-agnostic (modern and legacy).
+	canonicalAuditLog := filepath.Join(filepath.Dir(filepath.Dir(recordPath)), "workcell.audit.log")
+	// Defense in depth: a record whose recorded path disagrees with its own
+	// profile location is itself tampered — reject it fail-closed rather than
+	// silently verifying against the canonical log.
+	if filepath.Clean(record.AuditLogPath) != canonicalAuditLog {
+		return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("Session %s FAILED audit verification: recorded audit log path does not match the profile's canonical location.", redactor.String(sessionID))}
+	}
+
+	sealPath := auditseal.SealPathForRecord(recordPath)
+	seal, err := auditseal.ReadSeal(sealPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if !auditseal.HasSignableChain(canonicalAuditLog, record.TargetProvider, sessionID) {
+				return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("Session %s uses a provider whose audit records have no signable digest chain (apple-container is preview-only); verification fails closed.", redactor.String(sessionID))}
+			}
+			return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("Session %s is not signed (no audit seal); verification fails closed.", redactor.String(sessionID))}
+		}
+		return &cliexit.ExitCodeError{Code: 1, Message: redactor.String(err.Error())}
+	}
+
+	head, err := auditseal.VerifySessionSeal(signingDir, canonicalAuditLog, record.TargetProvider, sessionID, seal)
+	if err != nil {
+		return &cliexit.ExitCodeError{Code: 1, Message: fmt.Sprintf("Session %s FAILED audit verification: %s", redactor.String(sessionID), redactor.String(err.Error()))}
+	}
+
+	fmt.Fprintf(stdout, "session_verify=verified\n")
+	fmt.Fprintf(stdout, "session_id=%s\n", redactor.String(sessionID))
+	fmt.Fprintf(stdout, "key_id=%s\n", redactor.String(seal.KeyID))
+	fmt.Fprintf(stdout, "head_digest=%s\n", redactor.String(head))
+	return nil
+}
+
+func parseVerifyArgs(args []string) (sessionID, signingDir, realHome string, showHelp bool, err error) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--id":
+			value, next, perr := optionValueOrErrorStrict(args, i, "--id")
+			if perr != nil {
+				return "", "", "", false, perr
+			}
+			sessionID = value
+			i = next
+		case strings.HasPrefix(arg, "--signing-dir="):
+			signingDir = strings.TrimPrefix(arg, "--signing-dir=")
+		case strings.HasPrefix(arg, "--real-home="):
+			realHome = strings.TrimPrefix(arg, "--real-home=")
+		case arg == "-h", arg == "--help":
+			showHelp = true
+		default:
+			return "", "", "", false, unsupportedOption("session verify", arg)
+		}
+	}
+	return sessionID, signingDir, realHome, showHelp, nil
+}

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -9,7 +9,7 @@ workcell \- bounded runtime launcher for coding agents
 [\fIoptions\fR]
 .br
 .B workcell session
-\fIstart|attach|send|stop|list|show|delete|logs|timeline|diff|export\fR [\fIoptions\fR]
+\fIstart|attach|send|stop|list|show|delete|logs|timeline|diff|export|verify\fR [\fIoptions\fR]
 .br
 .B workcell auth
 \fIinit|set|unset|status\fR [\fIoptions\fR]
@@ -41,7 +41,7 @@ as the exec-capable temporary directory via
 .BR TMPDIR .
 The supported host platform is Apple Silicon macOS.
 .TP
-.B workcell session start|attach|send|stop|list|show|delete|logs|timeline|diff|export
+.B workcell session start|attach|send|stop|list|show|delete|logs|timeline|diff|export|verify
 Launch, control, inspect, diff, export, and delete durable detached sessions
 without starting a second Workcell runtime. Detached sessions default to an
 isolated clean git clone of the selected workspace, while the host-side
@@ -66,6 +66,15 @@ by the same rule-set as
 and free-form operator payloads (the detached-session message) are withheld
 entirely \(em their content is replaced with a fixed placeholder because regex
 redaction cannot sanitize arbitrary prose.
+.B workcell session verify
+.RB ( --id
+.IR SESSION_ID )
+recomputes the session's audit hash-chain from the authoritative durable profile
+log and verifies the host-side signature over the chain head. It is read-only
+and fails closed on any tampered, reordered, dropped, duplicate-key, or unsigned
+record. The signature is boundary/host-signed, not agent-signed; see
+.B docs/signed-session-audit-records.md
+for the trust model.
 .TP
 .B workcell policy show|validate|diff
 Inspect the merged host-side injection policy without starting the runtime.

--- a/policy/operator-contract.toml
+++ b/policy/operator-contract.toml
@@ -296,6 +296,16 @@ evidence = ["tests/scenarios/shared/test-session-commands.sh"]
 requirements = ["functional.FR-007"]
 target_state = "retain"
 
+[workflows.session_verify]
+title = "Verify signed session audit records"
+support = "supported"
+canonical = "workcell session verify --id SESSION_ID"
+discoverability = ["subcommand-help:session"]
+docs = ["man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-session-commands.sh", "internal/host/auditseal/auditseal_test.go"]
+requirements = ["functional.FR-007"]
+target_state = "retain"
+
 [workflows.session_delete]
 title = "Delete durable detached session"
 support = "supported"

--- a/policy/public-contract.toml
+++ b/policy/public-contract.toml
@@ -24,7 +24,7 @@ codes = ["0", "1", "2", "3", "124", "126", "127", "128"]
 # Stable key=value / prefixed output lines consumed by tests, CI, or other
 # tooling. See docs/stability-contract.md "Stable machine-readable output".
 [output_lines]
-prefixes = ["host_os=", "host_arch=", "support_matrix_status=", "provider_bootstrap_", "target_kind=", "target_provider=", "workspace=", "assurance=", "publish_pr_url=", "mutation score:", "surviving mutants:", "record_digest=", "prev_digest=", "egress_enforcement="]
+prefixes = ["host_os=", "host_arch=", "support_matrix_status=", "provider_bootstrap_", "target_kind=", "target_provider=", "workspace=", "assurance=", "publish_pr_url=", "mutation score:", "surviving mutants:", "record_digest=", "prev_digest=", "egress_enforcement=", "session_verify=", "key_id=", "head_digest="]
 
 # The json tags of internal/host/sessions/sessions.go's SessionRecord and
 # SessionExport structs.

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -153,12 +153,14 @@ workflows = [
   "session_timeline",
   "session_diff",
   "session_export",
+  "session_verify",
   "session_delete",
 ]
 evidence = [
   "tests/scenarios/shared/test-copilot-session-dry-run.sh",
   "tests/scenarios/shared/test-session-commands.sh",
   "internal/host/sessions/sessions_test.go",
+  "internal/host/auditseal/auditseal_test.go",
 ]
 docs = [
   "README.md",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "85ff183a94e44231f18883ae0b7afa81c6ca78b91ac7524abdf18aca426c218b"
+      "sha256": "85f0865e75057255752b6431b72bcf53c01e9376d6307c39baaebedb62e026db"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -168,7 +168,7 @@ usage() {
   cat <<'EOF'
 Usage: workcell [options] [-- provider-args...]
        workcell publish-pr [options]
-       workcell session <start|attach|send|stop|list|show|delete|logs|timeline|diff|export> [options]
+       workcell session <start|attach|send|stop|list|show|delete|logs|timeline|diff|export|verify> [options]
        workcell auth <init|set|unset|status> [options]
        workcell policy <show|validate|diff> [options]
        workcell why --credential KEY --agent NAME [options]
@@ -2599,29 +2599,98 @@ append_audit_record() {
   append_audit_record_to_path "${audit_path}" "$@"
 }
 
+# acquire_audit_log_lock serializes audit-log appends. The hash chain reads the
+# current tail's record_digest as the next record's prev_digest, so two
+# concurrent detached-session control paths (start/send/stop) racing the
+# read+append would fork the chain and make the verifier reject a legitimate
+# later record. This reuses the atomic, crash-safe profile-lock primitive
+# (acquire-profile-lock + profile-lock-is-stale: an atomic mkdir-rename lock
+# whose owner PID lets a crashed holder be reclaimed) on a per-log lock dir, so
+# no external flock(1) is required (it is absent on the macOS host). The lock
+# HOLDER computes the record digest via go_hostutil, which routes through
+# `go run` and can take several seconds to compile the child on a cold/busy host;
+# a waiter must reliably outlast that or it would skip a legitimate terminal
+# audit/signing record and break the chain. So it uses a ~30s bounded backoff
+# (1500 x 20ms). Genuine exhaustion at ~30s means a real anomaly (a stuck
+# holder), not normal cold-start latency; there it fails closed (no append)
+# rather than fork the chain.
+acquire_audit_log_lock() {
+  local lock_dir="$1"
+  local attempts=0
+  local acquired_state=""
+  local stale_state=""
+  # Record the ACTUAL holder process so profile_lock_is_stale can reclaim the lock
+  # when that process dies. append_audit_record_to_path and the signer can take
+  # this lock from inside a backgrounded ( ) subshell, where $$ is still the parent
+  # launcher PID, not the worker that does the cleanup rm -rf. BASHPID is the
+  # current process's own PID on bash 4+; the macOS host runs under /bin/bash 3.2
+  # which lacks BASHPID, so fall back to $$ there (${BASHPID:-$$}) — no unbound
+  # error under set -u, and on the host every audit-lock holder is a top-level
+  # process (launch shell, detached-monitor process, session-stop/-control command)
+  # whose $$ IS the real holder, so reclaim still works. This MUST be captured here
+  # in the holder's own context, NOT inside the go_hostutil "$( )" below: BASHPID
+  # inside a command substitution is that transient subshell's PID (already dead by
+  # the stale check). (acquire_profile_lock deliberately keeps $$: its owner is the
+  # top-level launch shell for the whole session.)
+  local holder_pid="${BASHPID:-$$}"
+
+  mkdir -p "$(dirname "${lock_dir}")"
+  while true; do
+    if ! acquired_state="$(go_hostutil helper acquire-profile-lock "${lock_dir}" "${holder_pid}")"; then
+      return 1
+    fi
+    if [[ "${acquired_state}" == "1" ]]; then
+      return 0
+    fi
+    if stale_state="$(profile_lock_is_stale "${lock_dir}")" && [[ "${stale_state}" == "1" ]]; then
+      rm -rf "${lock_dir}"
+      continue
+    fi
+    attempts=$((attempts + 1))
+    if [[ "${attempts}" -ge 1500 ]]; then
+      return 1
+    fi
+    sleep 0.02
+  done
+}
+
 append_audit_record_to_path() {
   local audit_path="$1"
   shift
-  local timestamp
-  local prev_digest=""
-  local record_digest=""
+  local lock_dir=""
+  local rc=0
 
   mkdir -p "$(dirname "${audit_path}")"
   umask 077
   touch "${audit_path}"
   chmod 0600 "${audit_path}" 2>/dev/null || true
-  timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-  if [[ -s "${audit_path}" ]]; then
-    prev_digest="$(sed -n 's/.*record_digest=\([^ ]*\).*/\1/p' "${audit_path}" | tail -n1)"
+
+  lock_dir="${audit_path}.lock"
+  if ! acquire_audit_log_lock "${lock_dir}"; then
+    echo "Workcell: warning: could not acquire audit-log lock for ${audit_path}; skipped a record to keep the chain linear." >&2
+    return 1
   fi
-  record_digest="$(audit_record_digest "${prev_digest}" "${timestamp}" "$@")"
-  {
-    printf 'timestamp=%q ' "${timestamp}"
-    printf '%q ' "$@"
-    [[ -n "${prev_digest}" ]] && printf 'prev_digest=%q ' "${prev_digest}"
-    printf 'record_digest=%q ' "${record_digest}"
-    printf '\n'
-  } >>"${audit_path}"
+  # Run the read-prev-digest + append critical section under the lock, releasing
+  # on every path (including a set -e abort inside the subshell).
+  (
+    local timestamp
+    local prev_digest=""
+    local record_digest=""
+    timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    if [[ -s "${audit_path}" ]]; then
+      prev_digest="$(sed -n 's/.*record_digest=\([^ ]*\).*/\1/p' "${audit_path}" | tail -n1)"
+    fi
+    record_digest="$(audit_record_digest "${prev_digest}" "${timestamp}" "$@")"
+    {
+      printf 'timestamp=%q ' "${timestamp}"
+      printf '%q ' "$@"
+      [[ -n "${prev_digest}" ]] && printf 'prev_digest=%q ' "${prev_digest}"
+      printf 'record_digest=%q ' "${record_digest}"
+      printf '\n'
+    } >>"${audit_path}"
+  ) || rc=$?
+  rm -rf "${lock_dir}" 2>/dev/null || true
+  return "${rc}"
 }
 
 maybe_fail_after_profile_refresh_for_tests() {
@@ -3106,7 +3175,77 @@ finalize_session_audit() {
   fi
   append_exit_audit_record "${profile}" "${execution_path}" "${exit_status}" "${final_assurance}" "${downgraded}"
   write_session_record_final "${final_status}" "${exit_status}" "${final_assurance}"
+  sign_session_audit_head "${profile}"
   FINAL_SESSION_ASSURANCE="${final_assurance}"
+}
+
+# sign_session_audit_head signs the head of this session's audit hash-chain
+# host-side (A5). It is best-effort with respect to teardown: a signing failure
+# is warned and swallowed so it never wedges container cleanup, and an unsigned
+# session simply fails `session verify` closed. Signing itself is fail-closed in
+# the Go helper (it refuses to sign with an insecurely stored key).
+sign_session_audit_head() {
+  local profile="$1"
+
+  [[ "${SESSION_RECORD_FINALIZED}" -eq 1 ]] || return 0
+  sign_session_audit_head_explicit "${profile}" "${SESSION_ID}" "${SESSION_RECORD_PATH}"
+}
+
+# sign_session_audit_head_explicit signs a specific session's audit-chain head
+# given its profile, id, and durable record path, rather than the launch-path
+# globals sign_session_audit_head wraps. The detached stop-fallback path (monitor
+# no longer live) finalizes via session_write_stop_requested_terminal_record and
+# never runs finalize_session_audit, so it calls this directly — otherwise a
+# legitimately-stopped session would have no .audit-sig and `session verify`
+# would report it unsigned (a false negative). Best-effort like its wrapper: a
+# signing failure is warned and swallowed so it never wedges teardown.
+sign_session_audit_head_explicit() {
+  local profile="$1"
+  local session_id="$2"
+  local record_path="$3"
+  local audit_path=""
+  local target_provider=""
+  local lock_dir=""
+
+  [[ -n "${session_id}" ]] || return 0
+  [[ -n "${record_path}" ]] || return 0
+
+  # Recompute the head over the SAME audit log `workcell session verify` derives
+  # canonically: the grandparent of the durable record path + workcell.audit.log.
+  # For a modern session (<root>/targets/<kind>/<provider>/<profile>/sessions/
+  # <id>.json) this equals profile_audit_log_path; for a LEGACY session
+  # (<root>/<profile>/sessions/<id>.json) it is <root>/<profile>/workcell.audit.log
+  # — the log its records were actually appended to. Using profile_audit_log_path
+  # unconditionally would sign the (empty/wrong) target-state log for a legacy
+  # session, so verify (which reads the legacy log) would reject a genuine seal.
+  # Deriving it the same way as verify makes signer == verifier for every layout.
+  audit_path="$(dirname "$(dirname "${record_path}")")/workcell.audit.log"
+  [[ -s "${audit_path}" ]] || return 0
+  target_provider="$(target_provider_for_profile_state "${profile}")"
+
+  # Serialize the signer's READ against concurrent appends. A record is written by
+  # append_audit_record_to_path with multiple non-atomic printfs under
+  # <audit-log>.lock; a signer reading the log without that lock could observe a
+  # partially-appended (torn) record, so SignSessionHead would error and this
+  # best-effort caller would skip the seal, leaving a completed session
+  # unverifiable. Take the SAME lock (same dir, ~30s wait budget, stale reclaim)
+  # so the head is recomputed over a complete chain, and release on EVERY path.
+  # All callers invoke the signer AFTER the append helper has released this lock,
+  # so acquiring fresh here never self-deadlocks.
+  lock_dir="${audit_path}.lock"
+  if ! acquire_audit_log_lock "${lock_dir}"; then
+    echo "Workcell: warning: could not acquire audit-log lock to sign ${session_id}; session verify will report it unsigned." >&2
+    return 0
+  fi
+  if ! go_hostutil session-sign-head \
+    "--signing-dir=${WORKCELL_STATE_ROOT}/signing" \
+    "--audit-log=${audit_path}" \
+    "--session-id=${session_id}" \
+    "--record-path=${record_path}" \
+    "--provider=${target_provider}" 2>/dev/null; then
+    echo "Workcell: warning: could not sign session audit head for ${session_id}; session verify will report it unsigned." >&2
+  fi
+  rm -rf "${lock_dir}" 2>/dev/null || true
 }
 
 write_profile_image_marker() {
@@ -3844,6 +3983,7 @@ session_stop_main() {
         "exit_status=${stop_exit_status}" \
         "final_assurance=${SESSION_META_CURRENT_ASSURANCE:-managed-mutable}"
       session_write_stop_requested_terminal_record "${record_path}" "${stop_exit_status}" || exit 1
+      sign_session_audit_head_explicit "${SESSION_META_PROFILE}" "${session_id}" "${record_path}"
       load_session_runtime_metadata "${session_id}"
       printf 'session_id=%s\n' "${session_id}"
       printf 'stop_requested=1\n'
@@ -3860,6 +4000,19 @@ session_stop_main() {
       printf 'live_status=%s\n' "${SESSION_META_LIVE_STATUS:-${SESSION_META_STATUS:-}}"
       printf 'control_mode=detached\n'
       emit_loaded_session_control_summary
+      # Seal-missing recheck (same TOCTOU coverage as the terminal path below):
+      # this already-stopped/live-monitor branch returns without falling through to
+      # that recheck, so if the monitor wrote the terminal record but exited before
+      # its finalize_session_audit signing step, sign here. Gate on the seal's
+      # absence (idempotent — a monitor that already signed is not double-signed)
+      # and only when the record is terminal.
+      case "${SESSION_META_LIVE_STATUS:-${SESSION_META_STATUS}}" in
+        stopped | exited | failed | aborted)
+          if [[ ! -e "${record_path%.json}.audit-sig" ]]; then
+            sign_session_audit_head_explicit "${SESSION_META_PROFILE}" "${session_id}" "${record_path}"
+          fi
+          ;;
+      esac
       return 0
     fi
     echo "session stop requires a detached session that is still running: ${session_id}" >&2
@@ -3904,6 +4057,11 @@ session_stop_main() {
       if [[ "${SESSION_META_STATUS}" == "failed" ]]; then
         stop_exit_status="$(session_container_exit_code "${SESSION_META_PROFILE}" "${SESSION_META_CONTAINER_NAME}")"
         session_write_stop_requested_terminal_record "${record_path}" "${stop_exit_status}"
+        # Sign only when the monitor is not live; a live monitor still owns
+        # finalize_session_audit signing, so signing here would double-sign.
+        if ! session_monitor_pid_is_live; then
+          sign_session_audit_head_explicit "${SESSION_META_PROFILE}" "${session_id}" "${record_path}"
+        fi
         load_session_runtime_metadata "${session_id}"
       fi
       ;;
@@ -3918,10 +4076,27 @@ session_stop_main() {
           "exit_status=${stop_exit_status}" \
           "final_assurance=${SESSION_META_CURRENT_ASSURANCE:-managed-mutable}"
         session_write_stop_requested_terminal_record "${record_path}" "${stop_exit_status}"
+        sign_session_audit_head_explicit "${SESSION_META_PROFILE}" "${session_id}" "${record_path}"
         load_session_runtime_metadata "${session_id}"
         ;;
     esac
   fi
+  # Seal-missing recheck (TOCTOU coverage): once the record is terminal, guarantee
+  # it is sealed even if the monitor was observed live at the checks above but
+  # exited in the window before its finalize_session_audit signing step (the
+  # monitor-dead fallback branch above no-ops for an already-terminal record, so
+  # nothing else would sign it). Gate on the SEAL's presence, not on monitor
+  # liveness: sign only when the .audit-sig sidecar is absent, so a live monitor
+  # that already signed (happy path) or a fallback branch above that signed is not
+  # double-signed and a re-run is a no-op. The signer helper is itself the
+  # no-chain fail-closed no-op and holds the audit-log lock during its read.
+  case "${SESSION_META_LIVE_STATUS:-${SESSION_META_STATUS}}" in
+    stopped | exited | failed | aborted)
+      if [[ ! -e "${record_path%.json}.audit-sig" ]]; then
+        sign_session_audit_head_explicit "${SESSION_META_PROFILE}" "${session_id}" "${record_path}"
+      fi
+      ;;
+  esac
   case "${SESSION_META_LIVE_STATUS:-${SESSION_META_STATUS}}" in
     stopped | exited | failed | aborted)
       session_clear_stop_request_marker || exit 1
@@ -4012,6 +4187,8 @@ session_delete_main() {
   local remove_file_trace_log=0
   local remove_session_audit_dir=0
   local remove_transcript_log=0
+  local remove_audit_seal=0
+  local audit_seal_path=""
   local session_audit_dir=""
   local -a removed=()
   local -a kept=()
@@ -4147,6 +4324,19 @@ session_delete_main() {
       missing+=("transcript_log")
     fi
   fi
+  # The .audit-sig seal (host signature over the session's audit-chain head) sits
+  # beside the durable record and is session-owned evidence, so it is removed with
+  # the full delete and KEPT under --record-only (which preserves artifacts).
+  audit_seal_path="${record_path%.json}.audit-sig"
+  if [[ -e "${audit_seal_path}" ]]; then
+    if [[ "${record_only}" -eq 1 ]]; then
+      kept+=("audit_seal")
+    else
+      remove_audit_seal=1
+      planned_remove+=("audit_seal")
+    fi
+  fi
+
   if [[ "${#planned_remove[@]}" -eq 0 ]]; then
     planned_remove=("record")
   else
@@ -4195,6 +4385,12 @@ session_delete_main() {
       exit 1
     }
   fi
+  if [[ "${remove_audit_seal}" -eq 1 ]]; then
+    rm -f -- "${audit_seal_path}" || {
+      echo "session delete failed to remove the recorded audit_seal artifact: ${session_id}" >&2
+      exit 1
+    }
+  fi
   rm -f "${record_path}" || {
     echo "session delete failed to remove the durable session record: ${session_id}" >&2
     exit 1
@@ -4221,6 +4417,44 @@ session_logs_main() {
 session_timeline_main() {
   collect_session_lookup_roots || exit 1
   run_go_hostutil_preserve_exit session-timeline-cli "${SESSION_LOOKUP_ROOTS[@]}" "$@"
+  exit $?
+}
+
+session_verify_main() {
+  local -a args=()
+  # --root, --signing-dir, and --real-home are trusted-context flags this wrapper
+  # supplies from host-derived values (the session lookup roots prepended below,
+  # the host-owned signing key dir, and the OCSF redaction root). A user-supplied
+  # copy would redirect what verify treats as authoritative:
+  #   --root=DIR   sits in the leading --root= run that ConsumeRootArgs consumes
+  #                (user args follow the trusted roots), so it would add an
+  #                attacker-controlled state root and let a host-signed COPY under
+  #                that path verify instead of the Workcell-owned state.
+  #   --signing-dir/--real-home are last-wins in parseVerifyArgs, so a copy could
+  #                point verification at an attacker key dir.
+  # Reject all of them from user input outright (defense in depth: --signing-dir/
+  # --real-home are also appended AFTER "$@" so trusted context still wins). Both
+  # --flag=VALUE and bare --flag forms are rejected; the bare form would otherwise
+  # swallow an appended trusted flag as its value. Legitimate HOST config (the
+  # WORKCELL_STATE_ROOT/COLIMA_STATE_ROOT env that DERIVES the trusted roots)
+  # stays honored — only a per-invocation CLI override is refused.
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --root | --root=* | --signing-dir | --signing-dir=* | --real-home | --real-home=*)
+        echo "workcell: ${1%%=*} is not a user-configurable option for session verify." >&2
+        exit 2
+        ;;
+      *)
+        args+=("$1")
+        shift
+        ;;
+    esac
+  done
+  collect_session_lookup_roots || exit 1
+  run_go_hostutil_preserve_exit session-verify-cli "${SESSION_LOOKUP_ROOTS[@]}" \
+    "${args[@]}" \
+    "--signing-dir=${WORKCELL_STATE_ROOT}/signing" \
+    "--real-home=${REAL_HOME}"
   exit $?
 }
 
@@ -4456,6 +4690,9 @@ session_main() {
       ;;
     timeline)
       session_timeline_main "$@"
+      ;;
+    verify)
+      session_verify_main "$@"
       ;;
     diff)
       while [[ $# -gt 0 ]]; do

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -746,6 +746,318 @@ grep -q '^target-audit-line$' <<<"${merged_audit_migration_output}"
   exit 1
 }
 
+# Concurrency guard: append_audit_record_to_path serializes the read-prev-digest
+# + append critical section under acquire_audit_log_lock so concurrent session
+# control paths (e.g. an async monitor exit-record racing session-control) cannot
+# each seed the same prev_digest and fork the hash chain. Drive N writers at one
+# log in parallel and assert the resulting chain is a single unbroken line: every
+# record links to the previous record_digest with no duplicate digests. Without
+# the lock each writer would read the same tail and fork, breaking the link.
+CONCURRENT_AUDIT_LOG="${TMP_DIR}/concurrent-audit/workcell.audit.log"
+concurrent_audit_writers="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    audit_path="$2"
+    for i in $(seq 1 8); do
+      append_audit_record_to_path "${audit_path}" event=e-"${i}" session_id=concurrent >/dev/null 2>&1 &
+    done
+    wait
+    printf "wrote=%s\n" "$(wc -l <"${audit_path}" | tr -d " ")"
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${CONCURRENT_AUDIT_LOG}"
+)"
+grep -q '^wrote=8$' <<<"${concurrent_audit_writers}" || {
+  echo "concurrent audit appends did not all land (${concurrent_audit_writers})" >&2
+  exit 1
+}
+awk '
+  {
+    d = ""; p = "";
+    for (i = 1; i <= NF; i++) {
+      if ($i ~ /^record_digest=/) { sub(/^record_digest=/, "", $i); d = $i }
+      if ($i ~ /^prev_digest=/) { sub(/^prev_digest=/, "", $i); p = $i }
+    }
+    if (d == "") { printf "audit chain line %d missing record_digest\n", NR > "/dev/stderr"; bad = 1 }
+    if (NR > 1 && p != prev) { printf "audit chain forked at line %d (prev_digest not linked)\n", NR > "/dev/stderr"; bad = 1 }
+    if (seen[d]++) { printf "audit chain duplicated digest at line %d\n", NR > "/dev/stderr"; bad = 1 }
+    prev = d
+  }
+  END { if (bad) exit 1 }
+' "${CONCURRENT_AUDIT_LOG}" || {
+  echo "concurrent audit appends forked the hash chain" >&2
+  exit 1
+}
+
+# Subshell-holder stale reclaim: the audit-log lock records the holder as
+# ${BASHPID} (the real process), not $$. append_audit_record_to_path and the
+# signer take this lock from inside $()/backgrounded ( ) subshells; if such a
+# worker is killed before its cleanup rm -rf, a later append must see the dead
+# holder and reclaim the lock. Simulate exactly that: a backgrounded subshell
+# (BASHPID != parent $$) acquires the lock and is killed uncleanly, then assert a
+# subsequent append RECLAIMS the stale lock and appends quickly — not that it
+# waits out the ~30s budget. (With $$, the killed subshell would record the still
+# live parent PID, the lock would never look stale, and this append would time
+# out and skip.)
+RECLAIM_LOG="${TMP_DIR}/reclaim-audit/workcell.audit.log"
+reclaim_output="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    audit_path="$2"
+    lock_dir="${audit_path}.lock"
+    mkdir -p "$(dirname "${audit_path}")"
+    append_audit_record_to_path "${audit_path}" event=one session_id=reclaim >/dev/null
+    # Backgrounded subshell acquires the lock (BASHPID != parent $$) then is killed
+    # -9 before releasing it.
+    ( acquire_audit_log_lock "${lock_dir}"; sleep 60 ) &
+    holder_pid=$!
+    for _ in $(seq 1 200); do [[ -e "${lock_dir}" ]] && break; sleep 0.02; done
+    kill -9 "${holder_pid}" 2>/dev/null || true
+    wait "${holder_pid}" 2>/dev/null || true
+    start="$(date +%s)"
+    if append_audit_record_to_path "${audit_path}" event=two session_id=reclaim >/dev/null 2>&1; then
+      second="appended"
+    else
+      second="skipped"
+    fi
+    end="$(date +%s)"
+    printf "second=%s\n" "${second}"
+    printf "waited=%s\n" "$((end - start))"
+    printf "lines=%s\n" "$(wc -l <"${audit_path}" | tr -d " ")"
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${RECLAIM_LOG}"
+)"
+grep -q '^second=appended$' <<<"${reclaim_output}" || {
+  echo "append behind a dead subshell holder did not reclaim the stale lock: ${reclaim_output}" >&2
+  exit 1
+}
+grep -q '^lines=2$' <<<"${reclaim_output}" || {
+  echo "reclaim append did not land (chain missing a record): ${reclaim_output}" >&2
+  exit 1
+}
+reclaim_waited="$(sed -n 's/^waited=//p' <<<"${reclaim_output}")"
+[[ "${reclaim_waited}" -le 15 ]] || {
+  echo "reclaim took ${reclaim_waited}s — the lock was not detected stale (holder recorded as \$\$, not BASHPID)" >&2
+  exit 1
+}
+
+# Stop-fallback signing: a detached session finalized via the host-stop-fallback
+# path (monitor no longer live) writes its terminal record WITHOUT running
+# finalize_session_audit, so sign_session_audit_head_explicit is the only thing
+# that produces the .audit-sig sidecar on that path. Drive the helper directly
+# with a fixture chain + record and assert (1) the sidecar is created next to the
+# record, and (2) with no audit-log chain the helper is a fail-closed no-op
+# (guard), so it never claims to sign a session with no chain. (The seal's
+# cryptographic validity and `session verify` end-to-end are covered by the Go
+# signhead/auditseal tests and the detached-lifecycle scenario below.)
+STOP_FALLBACK_FIXTURE="${TMP_DIR}/stop-fallback-sign"
+stop_fallback_sign_output="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    FIXTURE_ROOT="$2"
+    COLIMA_STATE_ROOT="${FIXTURE_ROOT}/colima"
+    WORKCELL_STATE_ROOT="${FIXTURE_ROOT}/workcell"
+    WORKCELL_TARGET_STATE_ROOT="${WORKCELL_STATE_ROOT}/targets"
+    PROFILE_NAME="stop-fallback-fixture"
+    SESSION_ID="stop-fallback-session"
+    # Pin the provider to a chained one so the head is signable.
+    SESSION_META_PROFILE="${PROFILE_NAME}"
+    SESSION_META_TARGET_PROVIDER="colima"
+    AUDIT_LOG="$(profile_audit_log_path "${PROFILE_NAME}")"
+    RECORD_PATH="$(profile_sessions_dir_path "${PROFILE_NAME}")/${SESSION_ID}.json"
+    mkdir -p "$(dirname "${RECORD_PATH}")"
+    printf "{\"session_id\":\"%s\"}\n" "${SESSION_ID}" >"${RECORD_PATH}"
+    # Build a genuine 2-record chain for the session via the real append path.
+    append_audit_record_to_path "${AUDIT_LOG}" event=launch session_id="${SESSION_ID}" >/dev/null
+    append_audit_record_to_path "${AUDIT_LOG}" event=exit session_id="${SESSION_ID}" source=host-stop-fallback >/dev/null
+    sign_session_audit_head_explicit "${PROFILE_NAME}" "${SESSION_ID}" "${RECORD_PATH}"
+    printf "seal_exists=%s\n" "$([[ -s "${RECORD_PATH%.json}.audit-sig" ]] && echo 1 || echo 0)"
+    # Negative control: a profile with no audit-log chain must yield NO seal.
+    EMPTY_RECORD="$(profile_sessions_dir_path "empty-fixture")/empty.json"
+    mkdir -p "$(dirname "${EMPTY_RECORD}")"
+    printf "{}\n" >"${EMPTY_RECORD}"
+    sign_session_audit_head_explicit "empty-fixture" "empty-session" "${EMPTY_RECORD}"
+    printf "empty_seal_exists=%s\n" "$([[ -e "${EMPTY_RECORD%.json}.audit-sig" ]] && echo 1 || echo 0)"
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${STOP_FALLBACK_FIXTURE}"
+)"
+grep -q '^seal_exists=1$' <<<"${stop_fallback_sign_output}" || {
+  echo "stop-fallback path did not create a .audit-sig sidecar: ${stop_fallback_sign_output}" >&2
+  exit 1
+}
+grep -q '^empty_seal_exists=0$' <<<"${stop_fallback_sign_output}" || {
+  echo "stop-fallback signing must be a no-op when there is no audit chain: ${stop_fallback_sign_output}" >&2
+  exit 1
+}
+
+# Legacy-layout signer==verifier invariant: a LEGACY detached session's record
+# lives at <root>/<profile>/sessions/<id>.json and its records are appended to
+# <root>/<profile>/workcell.audit.log. The signer must recompute the head over
+# THAT log (grandparent-of-record), not profile_audit_log_path's newer
+# target-state log, so the seal it writes verifies. This asserts (1) the signer
+# derives the same canonical path `session verify` uses, and (2) the resulting
+# seal passes `session-verify-cli` for the legacy layout.
+LEGACY_SIGN_ROOT="${TMP_DIR}/legacy-sign"
+legacy_sign_verify_output="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    ROOT="$2"
+    WORKCELL_STATE_ROOT="${ROOT}/wstate"
+    SIGNING_DIR="${WORKCELL_STATE_ROOT}/signing"
+    PROFILE="wcl-legacy"
+    SID="legacy-sess"
+    SESSION_META_PROFILE="${PROFILE}"
+    SESSION_META_TARGET_PROVIDER="colima"
+    PROFILE_DIR="${ROOT}/${PROFILE}"
+    RECORD_PATH="${PROFILE_DIR}/sessions/${SID}.json"
+    LEGACY_LOG="${PROFILE_DIR}/workcell.audit.log"
+    mkdir -p "$(dirname "${RECORD_PATH}")"
+    append_audit_record_to_path "${LEGACY_LOG}" event=launch session_id="${SID}" >/dev/null
+    append_audit_record_to_path "${LEGACY_LOG}" event=exit session_id="${SID}" source=host-stop-fallback >/dev/null
+    printf "{\"version\":1,\"session_id\":\"%s\",\"profile\":\"%s\",\"target_provider\":\"colima\",\"agent\":\"codex\",\"mode\":\"strict\",\"status\":\"exited\",\"workspace\":\"/tmp/ws\",\"started_at\":\"2026-07-08T00:00:00Z\",\"finished_at\":\"2026-07-08T00:00:09Z\",\"exit_status\":\"0\",\"final_assurance\":\"managed-mutable\",\"audit_log_path\":\"%s\"}\n" "${SID}" "${PROFILE}" "${LEGACY_LOG}" >"${RECORD_PATH}"
+    # The signer must derive the SAME path verify derives (grandparent-of-record).
+    signer_path="$(dirname "$(dirname "${RECORD_PATH}")")/workcell.audit.log"
+    printf "signer_matches_legacy_log=%s\n" "$([[ "${signer_path}" == "${LEGACY_LOG}" ]] && echo 1 || echo 0)"
+    sign_session_audit_head_explicit "${PROFILE}" "${SID}" "${RECORD_PATH}"
+    printf "seal_exists=%s\n" "$([[ -s "${RECORD_PATH%.json}.audit-sig" ]] && echo 1 || echo 0)"
+    # Capture verify output BEFORE grepping: piping straight into `grep -q` under
+    # `set -o pipefail` is racy — grep -q exits on the first match (the leading
+    # `session_verify=verified` line) and closes the pipe, so the verifier can take
+    # SIGPIPE writing its remaining lines and exit non-zero, which pipefail then
+    # surfaces as a failed pipeline even though verification succeeded.
+    legacy_verify_out="$(go_hostutil session-verify-cli --root="${ROOT}" --id "${SID}" \
+      "--signing-dir=${SIGNING_DIR}" --real-home=/nonexistent 2>/dev/null || true)"
+    if grep -q "^session_verify=verified$" <<<"${legacy_verify_out}"; then
+      printf "verified=1\n"
+    else
+      printf "verified=0\n"
+    fi
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${LEGACY_SIGN_ROOT}"
+)"
+grep -q '^signer_matches_legacy_log=1$' <<<"${legacy_sign_verify_output}" || {
+  echo "signer path does not equal the legacy canonical log: ${legacy_sign_verify_output}" >&2
+  exit 1
+}
+grep -q '^seal_exists=1$' <<<"${legacy_sign_verify_output}" || {
+  echo "legacy session was not signed over its legacy log: ${legacy_sign_verify_output}" >&2
+  exit 1
+}
+grep -q '^verified=1$' <<<"${legacy_sign_verify_output}" || {
+  echo "legacy session seal did not verify (signer/verifier log mismatch): ${legacy_sign_verify_output}" >&2
+  exit 1
+}
+
+# Stop-path seal-missing recheck (TOCTOU): if the monitor is observed live when
+# session_stop_main checks, but exits before its own finalize signing, the
+# session would be left unsigned (the monitor-dead fallback no-ops for an
+# already-terminal record). session_stop_main now rechecks for a MISSING seal on
+# a terminal record and signs regardless of monitor liveness. Drive the race with
+# the monitor mocked always-live and no seal written: stop must seal it and it
+# must verify. Idempotent case: a terminal record that already has a seal is not
+# re-signed.
+STOP_RECHECK_ROOT="${TMP_DIR}/stop-recheck"
+for stop_recheck_mode in race idem; do
+  stop_recheck_output="$(
+    bash -lc '
+      set -euo pipefail
+      source "$1"
+      trap - EXIT
+      ROOT="$2"
+      MODE="$3"
+      WORKCELL_STATE_ROOT="${ROOT}/wstate"
+      SIGNING_DIR="${WORKCELL_STATE_ROOT}/signing"
+      PROFILE="wcl-stop-recheck"
+      SID="stop-recheck-sess"
+      PROFILE_DIR="${ROOT}/${PROFILE}"
+      RECORD_PATH="${PROFILE_DIR}/sessions/${SID}.json"
+      AUDIT_LOG="${PROFILE_DIR}/workcell.audit.log"
+      PHASE_FILE="${ROOT}/phase"
+      mkdir -p "$(dirname "${RECORD_PATH}")"
+      printf "pre\n" >"${PHASE_FILE}"
+      append_audit_record_to_path "${AUDIT_LOG}" event=launch session_id="${SID}" >/dev/null
+      append_audit_record_to_path "${AUDIT_LOG}" event=exit session_id="${SID}" >/dev/null
+      write_record() {
+        printf "{\"version\":1,\"session_id\":\"%s\",\"profile\":\"%s\",\"target_provider\":\"colima\",\"agent\":\"codex\",\"mode\":\"strict\",\"status\":\"%s\",\"live_status\":\"%s\",\"container_name\":\"c-race\",\"workspace\":\"/tmp/ws\",\"started_at\":\"2026-07-08T00:00:00Z\",\"finished_at\":\"2026-07-08T00:00:09Z\",\"exit_status\":\"0\",\"final_assurance\":\"managed-mutable\",\"audit_log_path\":\"%s\"}\n" "${SID}" "${PROFILE}" "$1" "$2" "${AUDIT_LOG}" >"${RECORD_PATH}"
+      }
+      write_record running running
+      SEAL_PATH="${RECORD_PATH%.json}.audit-sig"
+      if [[ "${MODE}" == "idem" ]]; then
+        # Simulate the live monitor having already signed.
+        SESSION_META_TARGET_PROVIDER=colima
+        sign_session_audit_head_explicit "${PROFILE}" "${SID}" "${RECORD_PATH}"
+        cp "${SEAL_PATH}" "${ROOT}/seal.before"
+      fi
+      # Mocks that route session_stop_main through the running -> stop -> terminal
+      # path with the monitor reported LIVE at every check (the race window).
+      exit() { return "${1:-0}"; }
+      session_run_cli_with_roots() { printf "session_id=%s\nforce=0\nprofile=%s\ncontainer_name=c-race\n" "${SID}" "${PROFILE}"; }
+      resolve_host_tool() { printf "/bin/false\n"; }
+      sanitize_host_docker_env() { :; }
+      load_session_runtime_metadata() {
+        SESSION_META_PROFILE="${PROFILE}"
+        SESSION_META_CONTAINER_NAME="c-race"
+        SESSION_META_RECORD_PATH="${RECORD_PATH}"
+        SESSION_META_CURRENT_ASSURANCE="managed-mutable"
+        SESSION_META_MONITOR_PID="4242"
+        SESSION_META_TARGET_PROVIDER="colima"
+        if [[ "$(<"${PHASE_FILE}")" == "pre" ]]; then
+          SESSION_META_STATUS="running"
+          SESSION_META_LIVE_STATUS="running"
+        else
+          SESSION_META_STATUS="exited"
+          SESSION_META_LIVE_STATUS="stopped"
+        fi
+      }
+      session_container_live_state() { [[ "$(<"${PHASE_FILE}")" == "pre" ]] && printf "running\n" || printf "stopped\n"; }
+      session_monitor_pid_is_live() { return 0; }
+      session_record_stop_request_marker() { return 0; }
+      session_clear_stop_request_marker() { return 0; }
+      append_session_control_audit_record() { :; }
+      session_write_stop_requested_terminal_record() { :; }
+      session_container_exit_code() { printf "0\n"; }
+      emit_loaded_session_control_summary() { :; }
+      # The stop transport "finalizes" the record to terminal (as the monitor
+      # would) but writes NO seal, then the monitor is gone.
+      run_profile_docker_command() {
+        shift
+        case "$1" in
+          stop | kill)
+            printf "post\n" >"${PHASE_FILE}"
+            write_record exited stopped
+            ;;
+          *) return 0 ;;
+        esac
+      }
+      session_stop_main --id "${SID}" >/dev/null 2>&1
+      printf "seal=%s\n" "$([[ -e "${SEAL_PATH}" ]] && echo 1 || echo 0)"
+      verify_out="$(go_hostutil session-verify-cli --root="${ROOT}" --id "${SID}" \
+        "--signing-dir=${SIGNING_DIR}" --real-home=/nonexistent 2>/dev/null || true)"
+      if grep -q "^session_verify=verified$" <<<"${verify_out}"; then printf "verified=1\n"; else printf "verified=0\n"; fi
+      if [[ "${MODE}" == "idem" ]]; then
+        cmp -s "${ROOT}/seal.before" "${SEAL_PATH}" && printf "unchanged=1\n" || printf "unchanged=0\n"
+      fi
+    ' _ "${WORKCELL_FUNCTIONS_COPY}" "${STOP_RECHECK_ROOT}.${stop_recheck_mode}" "${stop_recheck_mode}"
+  )"
+  grep -q '^seal=1$' <<<"${stop_recheck_output}" || {
+    echo "stop-recheck (${stop_recheck_mode}) did not seal a terminal session: ${stop_recheck_output}" >&2
+    exit 1
+  }
+  grep -q '^verified=1$' <<<"${stop_recheck_output}" || {
+    echo "stop-recheck (${stop_recheck_mode}) seal did not verify: ${stop_recheck_output}" >&2
+    exit 1
+  }
+  if [[ "${stop_recheck_mode}" == "idem" ]]; then
+    grep -q '^unchanged=1$' <<<"${stop_recheck_output}" || {
+      echo "stop-recheck idempotence broken: an already-sealed session was re-signed: ${stop_recheck_output}" >&2
+      exit 1
+    }
+  fi
+done
+
 monitor_env_output="$(
   bash -lc '
     set -euo pipefail
@@ -1923,10 +2235,12 @@ session_delete_cleanup_output="$(
     FILE_TRACE_LOG="${PROFILE_DIR}/detached.file-trace.log"
     TRANSCRIPT_LOG="${PROFILE_DIR}/detached.transcript.log"
     SESSION_AUDIT_DIR="${PROFILE_DIR}/session-audit.detached-fixture"
+    AUDIT_SEAL_PATH="${RECORD_PATH%.json}.audit-sig"
     mkdir -p "${PROFILE_DIR}/sessions"
     : >"${RECORD_FILE}"
     : >"${PROFILE_DIR}/docker.sock"
     mkdir -p "${SESSION_AUDIT_DIR}"
+    printf "{\"version\":1}\n" >"${AUDIT_SEAL_PATH}"
     cat >"${RECORD_PATH}" <<EOF_JSON
 {
   "version": 1,
@@ -1980,11 +2294,12 @@ EOF_JSON
     test ! -e "${FILE_TRACE_LOG}"
     test ! -e "${SESSION_AUDIT_DIR}"
     test ! -e "${TRANSCRIPT_LOG}"
+    test ! -e "${AUDIT_SEAL_PATH}"
   ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_DELETE_CLEANUP_ROOT}" "${SESSION_DELETE_CLEANUP_RECORD}"
 )"
 grep -q '^session_id=detached-fixture$' <<<"${session_delete_cleanup_output}"
 grep -q '^deleted=1$' <<<"${session_delete_cleanup_output}"
-grep -q '^removed=record,container,session_audit_dir,debug_log,file_trace_log,transcript_log$' <<<"${session_delete_cleanup_output}"
+grep -q '^removed=record,container,session_audit_dir,debug_log,file_trace_log,transcript_log,audit_seal$' <<<"${session_delete_cleanup_output}"
 grep -q '^kept=none$' <<<"${session_delete_cleanup_output}"
 grep -q '^missing=none$' <<<"${session_delete_cleanup_output}"
 grep -q '^unavailable=none$' <<<"${session_delete_cleanup_output}"
@@ -2048,9 +2363,11 @@ session_delete_record_only_output="$(
     FILE_TRACE_LOG="${PROFILE_DIR}/detached.file-trace.log"
     TRANSCRIPT_LOG="${PROFILE_DIR}/detached.transcript.log"
     SESSION_AUDIT_DIR="${PROFILE_DIR}/session-audit.detached-fixture"
+    AUDIT_SEAL_PATH="${RECORD_PATH%.json}.audit-sig"
     mkdir -p "${PROFILE_DIR}/sessions"
     : >"${RECORD_FILE}"
     mkdir -p "${SESSION_AUDIT_DIR}"
+    printf "{\"version\":1}\n" >"${AUDIT_SEAL_PATH}"
     cat >"${RECORD_PATH}" <<EOF_JSON
 {
   "version": 1,
@@ -2097,12 +2414,13 @@ EOF_JSON
     test -e "${FILE_TRACE_LOG}"
     test -e "${SESSION_AUDIT_DIR}"
     test -e "${TRANSCRIPT_LOG}"
+    test -e "${AUDIT_SEAL_PATH}"
   ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_DELETE_RECORD_ONLY_ROOT}" "${SESSION_DELETE_RECORD_ONLY_RECORD}"
 )"
 grep -q '^deleted=1$' <<<"${session_delete_record_only_output}"
 grep -q '^record_only=1$' <<<"${session_delete_record_only_output}"
 grep -q '^removed=record$' <<<"${session_delete_record_only_output}"
-grep -q '^kept=container,session_audit_dir,debug_log,file_trace_log,transcript_log$' <<<"${session_delete_record_only_output}"
+grep -q '^kept=container,session_audit_dir,debug_log,file_trace_log,transcript_log,audit_seal$' <<<"${session_delete_record_only_output}"
 grep -q '^unavailable=none$' <<<"${session_delete_record_only_output}"
 if [[ -s "${SESSION_DELETE_RECORD_ONLY_RECORD}" ]]; then
   echo "session delete --record-only unexpectedly touched Docker resolution or transport" >&2
@@ -2124,9 +2442,11 @@ session_delete_dry_run_output="$(
     FILE_TRACE_LOG="${PROFILE_DIR}/detached.file-trace.log"
     TRANSCRIPT_LOG="${PROFILE_DIR}/detached.transcript.log"
     SESSION_AUDIT_DIR="${PROFILE_DIR}/session-audit.detached-fixture"
+    AUDIT_SEAL_PATH="${RECORD_PATH%.json}.audit-sig"
     mkdir -p "${PROFILE_DIR}/sessions"
     : >"${PROFILE_DIR}/docker.sock"
     mkdir -p "${SESSION_AUDIT_DIR}"
+    printf "{\"version\":1}\n" >"${AUDIT_SEAL_PATH}"
     cat >"${RECORD_PATH}" <<EOF_JSON
 {
   "version": 1,
@@ -2177,11 +2497,12 @@ EOF_JSON
     test -e "${FILE_TRACE_LOG}"
     test -e "${SESSION_AUDIT_DIR}"
     test -e "${TRANSCRIPT_LOG}"
+    test -e "${AUDIT_SEAL_PATH}"
   ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_DELETE_DRY_RUN_ROOT}" "${SESSION_DELETE_DRY_RUN_RECORD}"
 )"
 grep -q '^deleted=0$' <<<"${session_delete_dry_run_output}"
 grep -q '^dry_run=1$' <<<"${session_delete_dry_run_output}"
-grep -q '^would_remove=record,container,session_audit_dir,debug_log,file_trace_log,transcript_log$' <<<"${session_delete_dry_run_output}"
+grep -q '^would_remove=record,container,session_audit_dir,debug_log,file_trace_log,transcript_log,audit_seal$' <<<"${session_delete_dry_run_output}"
 if grep -q '^transport|wcl-detached-fixture|rm -f ' "${SESSION_DELETE_DRY_RUN_RECORD}"; then
   echo "session delete --dry-run unexpectedly removed a container" >&2
   exit 1
@@ -2361,7 +2682,7 @@ EOF_JSON
 grep -q '^attach_output=attached$' <<<"${session_lifecycle_output}"
 grep -q '^send_output=session_id=detached-lifecycle|sent_bytes=7|status=running|live_status=running|control_mode=detached|target_kind=local_vm|target_provider=colima|target_id=wcl-detached-lifecycle|target_summary=local_vm/colima/wcl-detached-lifecycle|target_assurance_class=strict|runtime_api=docker|workspace_transport=workspace-mount|workspace='"${WORKSPACE_A}"'|display_workspace='"${WORKSPACE_A}"'|workspace_origin='"${WORKSPACE_A}"'|display_worktree='"${WORKSPACE_A}"'|worktree_path='"${WORKSPACE_A}"'|display_git_branch=none|git_branch=|assurance=managed-mutable|$' <<<"${session_lifecycle_output}"
 grep -q '^stop_output=session_id=detached-lifecycle|stop_requested=1|status=exited|live_status=stopped|control_mode=detached|target_kind=local_vm|target_provider=colima|target_id=wcl-detached-lifecycle|target_summary=local_vm/colima/wcl-detached-lifecycle|target_assurance_class=strict|runtime_api=docker|workspace_transport=workspace-mount|workspace='"${WORKSPACE_A}"'|display_workspace='"${WORKSPACE_A}"'|workspace_origin='"${WORKSPACE_A}"'|display_worktree='"${WORKSPACE_A}"'|worktree_path='"${WORKSPACE_A}"'|display_git_branch=none|git_branch=|assurance=managed-mutable|$' <<<"${session_lifecycle_output}"
-grep -q '^delete_output=session_id=detached-lifecycle|deleted=1|record_only=0|dry_run=0|removed=record,container,session_audit_dir,debug_log,file_trace_log,transcript_log|kept=none|missing=none|unavailable=none|$' <<<"${session_lifecycle_output}"
+grep -q '^delete_output=session_id=detached-lifecycle|deleted=1|record_only=0|dry_run=0|removed=record,container,session_audit_dir,debug_log,file_trace_log,transcript_log,audit_seal|kept=none|missing=none|unavailable=none|$' <<<"${session_lifecycle_output}"
 test -f "${SESSION_LIFECYCLE_AUDIT_LOG}"
 grep -q '^transport|wcl-detached-lifecycle|attach --no-stdin workcell-session-fixture$' "${SESSION_LIFECYCLE_RECORD}"
 grep -q '^transport|wcl-detached-lifecycle|exec --user ' "${SESSION_LIFECYCLE_RECORD}"
@@ -2665,6 +2986,34 @@ PY
     }
     grep -q "session attach requires a detached session that is still running: ${SESSION_ID}" <<<"${dead_attach_stderr}"
 
+    # The stop-fallback path (monitor was killed above) must still sign the
+    # session head, so `session verify` passes on this genuinely-stopped session
+    # instead of failing it closed as unsigned.
+    test -s "${SESSIONS_DIR}/${SESSION_ID}.audit-sig"
+    verify_stopped="$("${ROOT_DIR}/scripts/workcell" session verify --id "${SESSION_ID}")"
+    grep -q "^session_verify=verified$" <<<"${verify_stopped}"
+    grep -q "^session_id=${SESSION_ID}$" <<<"${verify_stopped}"
+
+    # Trust boundary: the host-owned --signing-dir must not be user-overridable.
+    # A forged .audit-sig under an attacker-controlled key dir must never be
+    # accepted, so a user-supplied --signing-dir is rejected (exit 2) BEFORE the
+    # helper runs and never reports "verified".
+    EVIL_SIGNING_DIR="${PROFILE_DIR}/evil-signing"
+    mkdir -p "${EVIL_SIGNING_DIR}"
+    set +e
+    verify_evil_output="$("${ROOT_DIR}/scripts/workcell" session verify --id "${SESSION_ID}" --signing-dir "${EVIL_SIGNING_DIR}" 2>&1)"
+    verify_evil_rc="$?"
+    set -e
+    [[ "${verify_evil_rc}" -eq 2 ]] || {
+      echo "user-supplied --signing-dir was not rejected (rc=${verify_evil_rc})" >&2
+      exit 1
+    }
+    grep -q "signing-dir is not a user-configurable option" <<<"${verify_evil_output}"
+    if grep -q "session_verify=verified" <<<"${verify_evil_output}"; then
+      echo "rejected verify with forged --signing-dir still reported verified" >&2
+      exit 1
+    fi
+
     delete_output="$("${ROOT_DIR}/scripts/workcell" session delete --id "${SESSION_ID}")"
     grep -q "event=command session_id=${SESSION_ID} source=host-cli command=session-send argv=resume" "${AUDIT_LOG}"
     grep -q "event=stop-request session_id=${SESSION_ID}" "${AUDIT_LOG}"
@@ -2689,7 +3038,7 @@ PY
     grep -q '^cli_stdin_payload=resume$' <<<"${cli_lifecycle_output}"
     grep -Eq '^cli_send_output=session_id=cli-life-[0-9]+[|]sent_bytes=7[|]status=running[|]live_status=running[|]control_mode=detached[|]target_kind=local_vm[|]target_provider=colima[|]target_id=wcl-cli-life-[0-9]+[|]target_summary=local_vm/colima/wcl-cli-life-[0-9]+[|]target_assurance_class=strict[|]runtime_api=docker[|]workspace_transport=isolated-worktree-mount[|]workspace=.*/workcell-cli-lifecycle-workspace\.[^|]+[|]display_workspace=.*/workcell-cli-lifecycle-workspace\.[^|]+[|]workspace_origin=.*/workcell-cli-lifecycle-workspace\.[^|]+[|]display_worktree=.*/workcell-cli-lifecycle-workspace\.[^|]+/.git/workcell-sessions/cli-life-[0-9]+/repo[|]worktree_path=.*/workcell-cli-lifecycle-workspace\.[^|]+/.git/workcell-sessions/cli-life-[0-9]+/repo[|]display_git_branch=none[|]git_branch=[|]assurance=managed-mutable[|]$' <<<"${cli_lifecycle_output}"
     grep -Eq '^cli_stop_output=session_id=cli-life-[0-9]+[|]stop_requested=1[|]status=exited[|]live_status=stopped[|]control_mode=detached[|]target_kind=local_vm[|]target_provider=colima[|]target_id=wcl-cli-life-[0-9]+[|]target_summary=local_vm/colima/wcl-cli-life-[0-9]+[|]target_assurance_class=strict[|]runtime_api=docker[|]workspace_transport=isolated-worktree-mount[|]workspace=.*/workcell-cli-lifecycle-workspace\.[^|]+[|]display_workspace=.*/workcell-cli-lifecycle-workspace\.[^|]+[|]workspace_origin=.*/workcell-cli-lifecycle-workspace\.[^|]+[|]display_worktree=.*/workcell-cli-lifecycle-workspace\.[^|]+/.git/workcell-sessions/cli-life-[0-9]+/repo[|]worktree_path=.*/workcell-cli-lifecycle-workspace\.[^|]+/.git/workcell-sessions/cli-life-[0-9]+/repo[|]display_git_branch=none[|]git_branch=[|]assurance=managed-mutable[|]$' <<<"${cli_lifecycle_output}"
-    grep -q '^cli_delete_output=session_id=cli-life-[0-9]\+|deleted=1|record_only=0|dry_run=0|removed=record,container,session_audit_dir,debug_log,file_trace_log,transcript_log|kept=none|missing=none|unavailable=none|$' <<<"${cli_lifecycle_output}"
+    grep -q '^cli_delete_output=session_id=cli-life-[0-9]\+|deleted=1|record_only=0|dry_run=0|removed=record,container,session_audit_dir,debug_log,file_trace_log,transcript_log,audit_seal|kept=none|missing=none|unavailable=none|$' <<<"${cli_lifecycle_output}"
   else
     echo "Skipping public CLI detached workload integration: no healthy Docker context available" >&2
   fi


### PR DESCRIPTION
Third of the A5 stack (stacks on PR 2/3; base retargets to main as parents merge). Wires the auditseal library into the product: `workcell session verify --id` (recompute chain over the authoritative durable log, dup-key reject, verify head signature over the recomputed head, fail-closed 0/1/2, G2-redacted); the session-stop signing hook (finalize_session_audit); L240 audit-append flock serialization (via the atomic acquire-profile-lock primitive — no flock(1), absent on macOS); full dispatch/usage/man/operator-contract/manifest lockstep; trust-model doc (boundary/host-signed, detects offline/exported/reorder/drop/dup-key/malformed tampering, NOT host-root re-sign; apple-container unsigned fail-closed follow-up + the audit-append serialization invariant). 776 lines, validators zero. Draft until parents merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)