### PR TITLE
^F C3 (2/2): container-level non-interference proof for parallel isolated sessions

### DIFF
--- a/docs/safe-path-expectations.md
+++ b/docs/safe-path-expectations.md
@@ -109,6 +109,32 @@ a session on its own VM. The `--parallel` inventory emits one stable `key=value`
 field per line (the same space-safe idiom as `workcell session show --text`), so
 a parser recovers each value—including a workspace path containing spaces—as the
 remainder of its line after the first `=`.
+The 1.0 parallel-session isolation model is container-level: two same-repo
+isolated sessions run as distinct containers sharing one Colima VM. The session
+id deterministically derives two of the per-session boundaries—the isolated clone
+path (`<repo>/.git/workcell-sessions/<session-id>/repo`) and the git branch
+(`workcell/session-<session-id>`)—so two distinct session ids on one source repo
+always resolve to distinct clone paths and distinct branches. The live container
+name is NOT session-id-derived: it is assigned a random suffix at launch
+(`workcell-<agent>-<mode>-repo-<random>`), which makes concurrent containers
+distinct without depending on the session id.
+Proven vs deferred, kept honest:
+
+- CI-PROVEN (this PR, host-side, no Colima): for two distinct session ids on the
+  same repo, the derivations produce distinct isolated clone paths and distinct
+  branches, and clone-level write-invisibility holds (a write in clone A does not
+  appear in clone B). The session-commands scenario runs the real clone/branch
+  derivations directly and asserts both, needing only git—no live runtime.
+- LOCAL-OPERATOR-CERTIFICATION (deferred, needs Apple Silicon + Colima): the LIVE
+  two-container concurrent launch plus runtime cross-container non-interference (a
+  write inside session A's running container is invisible inside session B's).
+  This runtime container isolation is the boundary Workcell relies on generally,
+  but this PR's automated evidence covers only the clone/branch layer; the live
+  layer is certified locally because hosted CI has no Colima VM to launch
+  containers in.
+
+The shared VM/kernel is not proven distinct here; pass a distinct
+`--colima-profile` to place a session on its own VM.
 `workcell session show --text` renders stable key=value lines for the same
 target-aware record, and `workcell session start|send|stop` emit stable
 key=value summaries so host-side detached control stays scriptable.

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -571,6 +571,81 @@ grep -q '^sessions_dir='"${TARGET_STATE_DIR}/sessions"'$' <<<"${state_path_outpu
 grep -q '^audit_log='"${TARGET_STATE_DIR}/workcell.audit.log"'$' <<<"${state_path_output}"
 grep -q '^lock_dir='"${WORKCELL_STATE_ROOT}/locks/local_vm/colima/${PROFILE}.lock"'$' <<<"${state_path_output}"
 
+# C3 container-level non-interference proof (CI-automatable, no Colima).
+# The 1.0 parallel-session isolation model is CONTAINER-LEVEL: two isolated
+# sessions on the SAME source repo run as distinct containers in one shared
+# Colima VM. The container-level identity boundary is derived DETERMINISTICALLY
+# from the session id: the isolated clone path and the git branch. This exercises
+# the REAL derivation functions (isolated_session_workspace_path and
+# create_isolated_session_workspace) for two distinct session ids against ONE
+# source repo and asserts that same-repo siblings never collide at the
+# clone/branch level, and that a write in one clone is invisible in the other.
+# The LIVE two-container concurrent launch + runtime cross-container
+# non-interference needs Apple Silicon + Colima and is recorded as
+# local-operator-certification in docs/safe-path-expectations.md.
+NONINTERFERENCE_SOURCE="${TMP_DIR}/noninterference-source"
+mkdir -p "${NONINTERFERENCE_SOURCE}"
+git -C "${NONINTERFERENCE_SOURCE}" init -q
+git -C "${NONINTERFERENCE_SOURCE}" config user.name "Workcell Test"
+git -C "${NONINTERFERENCE_SOURCE}" config user.email "workcell@example.com"
+printf 'seed\n' >"${NONINTERFERENCE_SOURCE}/README.md"
+git -C "${NONINTERFERENCE_SOURCE}" add README.md
+git -C "${NONINTERFERENCE_SOURCE}" commit -q -m 'initial'
+NONINTERFERENCE_SESSION_A="20260408T150000Z-aaaa1111-$$"
+NONINTERFERENCE_SESSION_B="20260408T150000Z-bbbb2222-$$"
+noninterference_output="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    HOST_GIT_BIN="$(resolve_host_tool git /usr/bin/git /opt/homebrew/bin/git /usr/local/bin/git)"
+    SOURCE_WORKSPACE="$2"
+    SESSION_A="$3"
+    SESSION_B="$4"
+    # Deterministic path derivation: distinct session ids on the same source
+    # repo must resolve to distinct isolated clone paths.
+    path_a="$(isolated_session_workspace_path "${SOURCE_WORKSPACE}" "${SESSION_A}")"
+    path_b="$(isolated_session_workspace_path "${SOURCE_WORKSPACE}" "${SESSION_B}")"
+    printf "path_a=%s\n" "${path_a}"
+    printf "path_b=%s\n" "${path_b}"
+    # Real isolated clones (git only, no Colima): each materializes its own
+    # working tree on its own branch workcell/session-<id>.
+    clone_a="$(create_isolated_session_workspace "${SOURCE_WORKSPACE}" "${SESSION_A}")"
+    clone_b="$(create_isolated_session_workspace "${SOURCE_WORKSPACE}" "${SESSION_B}")"
+    printf "clone_a=%s\n" "${clone_a}"
+    printf "clone_b=%s\n" "${clone_b}"
+    printf "branch_a=%s\n" "$(run_workspace_safe_git_command_in_dir "${clone_a}" branch --show-current)"
+    printf "branch_b=%s\n" "$(run_workspace_safe_git_command_in_dir "${clone_b}" branch --show-current)"
+    # Runtime non-interference at the clone level: a write in clone A must not
+    # appear in clone B (distinct working trees, no shared mutable state).
+    printf "clone-a-only\n" >"${clone_a}/noninterference-marker.txt"
+    if [[ -e "${clone_b}/noninterference-marker.txt" ]]; then
+      printf "cross_clone_visible=1\n"
+    else
+      printf "cross_clone_visible=0\n"
+    fi
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${NONINTERFERENCE_SOURCE}" "${NONINTERFERENCE_SESSION_A}" "${NONINTERFERENCE_SESSION_B}"
+)"
+noninterference_path_a="$(sed -n 's/^path_a=//p' <<<"${noninterference_output}")"
+noninterference_path_b="$(sed -n 's/^path_b=//p' <<<"${noninterference_output}")"
+noninterference_branch_a="$(sed -n 's/^branch_a=//p' <<<"${noninterference_output}")"
+noninterference_branch_b="$(sed -n 's/^branch_b=//p' <<<"${noninterference_output}")"
+grep -q "^path_a=${NONINTERFERENCE_SOURCE}/.git/workcell-sessions/${NONINTERFERENCE_SESSION_A}/repo$" <<<"${noninterference_output}"
+grep -q "^path_b=${NONINTERFERENCE_SOURCE}/.git/workcell-sessions/${NONINTERFERENCE_SESSION_B}/repo$" <<<"${noninterference_output}"
+if [[ "${noninterference_path_a}" == "${noninterference_path_b}" ]]; then
+  echo "isolated clone paths collided for distinct same-repo sessions" >&2
+  exit 1
+fi
+grep -q "^clone_a=${NONINTERFERENCE_SOURCE}/.git/workcell-sessions/${NONINTERFERENCE_SESSION_A}/repo$" <<<"${noninterference_output}"
+grep -q "^clone_b=${NONINTERFERENCE_SOURCE}/.git/workcell-sessions/${NONINTERFERENCE_SESSION_B}/repo$" <<<"${noninterference_output}"
+grep -q "^branch_a=workcell/session-${NONINTERFERENCE_SESSION_A}$" <<<"${noninterference_output}"
+grep -q "^branch_b=workcell/session-${NONINTERFERENCE_SESSION_B}$" <<<"${noninterference_output}"
+if [[ "${noninterference_branch_a}" == "${noninterference_branch_b}" ]]; then
+  echo "isolated session branches collided for distinct same-repo sessions" >&2
+  exit 1
+fi
+grep -q '^cross_clone_visible=0$' <<<"${noninterference_output}"
+
 if [[ "${detached_launch_blocked}" -eq 0 ]]; then
   detached_start_custom_state_output="$(
     XDG_STATE_HOME="${custom_state_home}" \


### PR DESCRIPTION
**Roadmap C3 — completes the parallel-sessions track.** Increment-1 (#469) added the `session list --parallel` inventory + honest shared-VM docs. This adds the non-interference PROOF for the maintainer-confirmed 1.0 isolation model (CONTAINER-LEVEL: same-repo isolated siblings run as distinct containers in one shared Colima VM).

Gap it closes: the existing hostutil test fed *hardcoded* distinct branches/worktrees and only proved the `--parallel` *rendering*; it never proved the *derivations* produce distinct values.

- **CI-automatable (no Colima)** — a scenario assertion in `tests/scenarios/shared/test-session-commands.sh` exercises the REAL derivation functions (`isolated_session_workspace_path`, `create_isolated_session_workspace`) for two distinct session ids against ONE clean source repo (git only, via the established `WORKCELL_FUNCTIONS_COPY` strip): asserts DISTINCT isolated clone paths, DISTINCT `workcell/session-<id>` branches, and that a write in clone A is INVISIBLE in clone B. Load-bearing: forcing the two session ids equal makes the scenario fail (mutation-verified).
- **Local-operator-certification remainder** — the LIVE two-container concurrent launch + runtime cross-container non-interference needs Apple Silicon + Colima; recorded honestly in `docs/safe-path-expectations.md` (hosted CI has no Colima VM), not faked.

No launcher behavior change (`scripts/workcell` untouched → no manifest/operator-contract regen). SessionRecord contract + OCSF drift-guard preserved. 92 insertions, 2 files. EXACT CI validators all zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)