### PR TITLE
A5 PR-A: keystore — per-host signing key management for audit seals

### DIFF
--- a/internal/host/keystore/keystore.go
+++ b/internal/host/keystore/keystore.go
@@ -1,0 +1,566 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package keystore manages the per-host ECDSA P-256 key used to sign A5 session
+// audit seals: generating, loading, and hardening the private key and its
+// public sidecar under an owner-secured signing directory. It is a distinct
+// concern from the audit-chain recompute and sign/verify in package auditseal,
+// which consumes LoadOrCreateSigningKey and LoadPublicKey.
+//
+// The ENTIRE operation is anchored to one validated directory fd. The signing
+// dir is opened O_NOFOLLOW|O_DIRECTORY and fstat-validated (real dir, owner euid,
+// 0700), then every key/pub read and write is performed with *at syscalls
+// relative to that fd (openat/renameat/linkat/unlinkat). So a same-parent
+// attacker who swaps the dir for a symlink after validation cannot redirect any
+// read or write to an attacker-chosen directory: the object validated is the
+// object used. Files opened for content are additionally O_NOFOLLOW (no symlink
+// at the leaf) and fstat-checked (regular file, owner euid, mode) on the fd read.
+package keystore
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const signingKeyBasename = "signing.key"
+
+// fsyncDir is the directory-durability fsync, indirected (with a phase label
+// tests can key on) so a test can inject a writeback failure at a specific phase
+// and confirm the publish fails closed. Production ignores the label.
+var fsyncDir = func(fd int, label string) error { return unix.Fsync(fd) }
+
+// requireNonBlankDir rejects an empty or whitespace-only signing directory, so a
+// blank dir fails closed rather than being cleaned to "." (the current working
+// directory). Shared by both entry points so the guard cannot drift.
+func requireNonBlankDir(dir string) error {
+	if strings.TrimSpace(dir) == "" {
+		return errors.New("keystore: signing directory is required")
+	}
+	return nil
+}
+
+// LoadOrCreateSigningKey returns the per-host ECDSA P-256 signing key under dir,
+// generating it on first use (dir 0700, key 0600, fail-closed if unsecurable;
+// keyID is the hex SHA-256 prefix of the PKIX public key). The key is published
+// atomically (temp file linked into place relative to the validated dir fd); the
+// create-race loser adopts the winner.
+func LoadOrCreateSigningKey(dir string) (*ecdsa.PrivateKey, string, error) {
+	if err := requireNonBlankDir(dir); err != nil {
+		return nil, "", err
+	}
+	dirFile, err := ensureSecureDir(dir)
+	if err != nil {
+		return nil, "", err
+	}
+	defer dirFile.Close()
+	dirFd := int(dirFile.Fd())
+
+	// Fast path: adopt an existing key. Fstatat (no-follow) relative to the fd.
+	if _, err := fstatatNoFollow(dirFd, signingKeyBasename); err == nil {
+		return adoptSigningKey(dirFd)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, "", err
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, "", fmt.Errorf("keystore: generate key: %w", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, "", fmt.Errorf("keystore: marshal key: %w", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+
+	// Publish atomically, all relative to the validated dir fd. Linkat fails
+	// EEXIST if a concurrent signer already created signing.key; then adopt it.
+	tmpName, err := writeTempAt(dirFd, signingKeyBasename, pemBytes, 0o600)
+	if err != nil {
+		return nil, "", err
+	}
+	linkErr := unix.Linkat(dirFd, tmpName, dirFd, signingKeyBasename, 0)
+	_ = unix.Unlinkat(dirFd, tmpName, 0)
+	if linkErr != nil {
+		if errors.Is(linkErr, os.ErrExist) {
+			return adoptSigningKey(dirFd)
+		}
+		return nil, "", linkErr
+	}
+	// Fsync the directory to durably record the new signing.key entry; a
+	// writeback failure here (ENOSPC/EIO) means the key may not survive a crash,
+	// so fail rather than hand back a keyID that would end up in seals verifying
+	// against a key that is not on disk.
+	if err := fsyncDir(dirFd, "signing.key"); err != nil {
+		return nil, "", fmt.Errorf("keystore: fsync signing directory after publishing signing.key: %w", err)
+	}
+
+	keyID, err := publicKeyID(&key.PublicKey)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := ensurePublicKey(dirFd, keyID, &key.PublicKey); err != nil {
+		return nil, "", err
+	}
+	return key, keyID, nil
+}
+
+// adoptSigningKey reads+parses the existing private key relative to the validated
+// dir fd, derives its key id, and ensures a matching secure public key file.
+func adoptSigningKey(dirFd int) (*ecdsa.PrivateKey, string, error) {
+	data, err := readAtSecure(dirFd, signingKeyBasename, 0o077)
+	if err != nil {
+		return nil, "", err
+	}
+	key, err := parsePrivateKey(data)
+	if err != nil {
+		return nil, "", err
+	}
+	keyID, err := publicKeyID(&key.PublicKey)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := ensurePublicKey(dirFd, keyID, &key.PublicKey); err != nil {
+		return nil, "", err
+	}
+	return key, keyID, nil
+}
+
+// ensureSecureDir creates dir if absent and returns an OPEN, validated directory
+// fd (real dir, owner euid, 0700). Callers keep it open and perform every
+// key/pub read/write via *at relative to it, so the operation is anchored to the
+// directory this validated — never a path that can be swapped. The caller closes
+// the returned fd.
+func ensureSecureDir(dir string) (*os.File, error) {
+	// Strip a trailing separator BEFORE the O_NOFOLLOW open: with a trailing slash
+	// (a configured `.../signing/`) the kernel resolves a final-component symlink
+	// before O_NOFOLLOW takes effect, so a symlinked dir would be accepted. Clean
+	// leaves the real dir name as the final component.
+	dir = filepath.Clean(dir)
+	// Create the dir (and any missing parents) atomically. os.Mkdir is atomic; a
+	// symlink (or anything else) already at the dir name makes it fail EEXIST,
+	// which we treat as "exists, verify below" — never adopt a name we did not
+	// create without an fd check.
+	if err := os.Mkdir(dir, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+		if parent := filepath.Dir(dir); parent != dir {
+			if merr := os.MkdirAll(parent, 0o700); merr != nil {
+				return nil, merr
+			}
+			if merr := os.Mkdir(dir, 0o700); merr != nil && !errors.Is(merr, os.ErrExist) {
+				return nil, merr
+			}
+		} else {
+			return nil, err
+		}
+	}
+	f, err := openSecureDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	st, err := fstatFd(int(f.Fd()))
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if uint32(st.Mode)&0o077 != 0 {
+		// Repair drifted perms via fchmod ON THE FD (the opened dir, not a name).
+		if cerr := f.Chmod(0o700); cerr != nil {
+			_ = f.Close()
+			return nil, cerr
+		}
+		if st, err = fstatFd(int(f.Fd())); err != nil {
+			_ = f.Close()
+			return nil, err
+		}
+	}
+	if err := checkStat(dir, &st, true, 0o077); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	// Durability of the directory ENTRIES. Walk UP from the validated dir fd,
+	// fsyncing every ancestor to the filesystem root. The walk is fd-anchored:
+	// each step is openat(fd, "..") on the previously opened dir fd, so ".."
+	// resolves the REAL parent hardlink and is immune to symlinked path
+	// components (a path-string re-traversal would fail O_NOFOLLOW at a symlinked
+	// ancestor and wrongly skip the real directory behind it, which may hold a
+	// freshly created child entry). This does NOT depend on WHO created each level
+	// (L144/L160/L199/L210): a concurrent first-use winner may not have fsynced yet
+	// (or may fail), so this caller fsyncs the whole chain itself — fsync is
+	// idempotent, so re-syncing already-durable ancestors is harmless. The root is
+	// detected by a dev+ino fixpoint (openat("..") returns the same inode). No
+	// caller returns a keyID before the whole ancestor chain to dir is durable;
+	// any fsync failure fails the call closed. If a level's openat("..") fails
+	// (e.g. an ancestor we cannot open O_RDONLY to fsync), the walk stops
+	// best-effort — that is NOT the symlink case, which ".." handles correctly.
+	if err := fsyncAncestorChain(int(f.Fd())); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
+// fsyncAncestorChain fsyncs dirFd's parent, grandparent, ... up to the
+// filesystem root, walking fd-anchored via openat(fd, "..") from the validated
+// dir fd so no swappable or symlinked path string is ever re-traversed. The root
+// is detected by a device+inode fixpoint. A fsync failure is propagated; an
+// openat("..") failure stops the walk best-effort (not the symlink case).
+func fsyncAncestorChain(dirFd int) error {
+	cur := dirFd
+	ownCur := false // whether we opened cur ourselves (and must close it)
+	closeCur := func() {
+		if ownCur {
+			_ = unix.Close(cur)
+		}
+	}
+	for {
+		pfd, err := unix.Openat(cur, "..", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+		if err != nil {
+			closeCur()
+			return nil // best-effort stop (cannot open ancestor; not a symlink)
+		}
+		atRoot, ferr := sameDirInode(cur, pfd)
+		if ferr != nil {
+			_ = unix.Close(pfd)
+			closeCur()
+			return ferr
+		}
+		if syncErr := fsyncDir(pfd, "ancestor"); syncErr != nil {
+			_ = unix.Close(pfd)
+			closeCur()
+			return fmt.Errorf("keystore: fsync ancestor directory: %w", syncErr)
+		}
+		closeCur()
+		if atRoot {
+			_ = unix.Close(pfd)
+			return nil
+		}
+		cur, ownCur = pfd, true
+	}
+}
+
+// sameDirInode reports whether fd and parentFd refer to the same directory
+// (device + inode), i.e. we have reached the filesystem root where ".." is self.
+func sameDirInode(fd, parentFd int) (bool, error) {
+	var a, b unix.Stat_t
+	if err := unix.Fstat(fd, &a); err != nil {
+		return false, err
+	}
+	if err := unix.Fstat(parentFd, &b); err != nil {
+		return false, err
+	}
+	return a.Dev == b.Dev && a.Ino == b.Ino, nil
+}
+
+// openSecureDir opens dir as a directory fd, failing on a symlink (O_NOFOLLOW)
+// or a non-directory (O_DIRECTORY) at the final component.
+func openSecureDir(dir string) (*os.File, error) {
+	f, err := os.OpenFile(dir, os.O_RDONLY|unix.O_NOFOLLOW|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, fmt.Errorf("keystore: %s is a symlink; refusing to trust the key store", dir)
+		}
+		if errors.Is(err, unix.ENOTDIR) {
+			return nil, fmt.Errorf("keystore: %s is not a directory; refusing to trust the key store", dir)
+		}
+		return nil, err
+	}
+	return f, nil
+}
+
+// fstatFd fstats an open fd, always via unix.Fstat so it returns a *unix.Stat_t
+// on both darwin and linux. os.File.Stat().Sys() is *syscall.Stat_t on Linux (not
+// *unix.Stat_t), so a type assertion to *unix.Stat_t silently fails there and any
+// owner check keyed on it never runs — hence the direct fstat.
+func fstatFd(fd int) (unix.Stat_t, error) {
+	var st unix.Stat_t
+	err := unix.Fstat(fd, &st)
+	return st, err
+}
+
+// checkStat enforces, on a fstat result, that the object is the expected kind (a
+// regular file or a directory), owned by the current euid, and its perm bits set
+// none of maxOther. Reads mode/uid straight from unix.Stat_t so the owner check
+// runs on every platform. st.Mode is uint16 on darwin / uint32 on linux; widen
+// before masking.
+func checkStat(name string, st *unix.Stat_t, wantDir bool, maxOther os.FileMode) error {
+	mode := uint32(st.Mode)
+	if wantDir {
+		if mode&uint32(unix.S_IFMT) != uint32(unix.S_IFDIR) {
+			return fmt.Errorf("keystore: %s is not a directory; refusing to trust the key store", name)
+		}
+	} else if mode&uint32(unix.S_IFMT) != uint32(unix.S_IFREG) {
+		return fmt.Errorf("keystore: %s is not a regular file; refusing to trust the key store", name)
+	}
+	if mode&uint32(maxOther) != 0 {
+		return fmt.Errorf("keystore: %s has insecure permissions %#o; refusing to trust the key store", name, mode&0o777)
+	}
+	if st.Uid != uint32(os.Geteuid()) {
+		return fmt.Errorf("keystore: %s is not owned by the current user; refusing to trust the key store", name)
+	}
+	return nil
+}
+
+// ensurePublicKey makes sure <keyID>.pub (relative to dirFd) exists, holds
+// exactly the derived key, and is stored securely; an absent, corrupt,
+// mismatched, or insecure file is rewritten atomically from the private key —
+// all anchored to the validated dir fd.
+func ensurePublicKey(dirFd int, keyID string, pub *ecdsa.PublicKey) error {
+	name := keyID + ".pub"
+	// Only a securely-stored (regular, owner-owned, non-symlink, not group/world-
+	// writable) .pub with correct content is reused; anything else falls through
+	// to an atomic rewrite, so a suspect sidecar is never trusted.
+	if data, err := readAtSecure(dirFd, name, 0o022); err == nil {
+		if existing, perr := parsePublicKeyPEM(data); perr == nil && pub.Equal(existing) {
+			// Durability of the reuse path: a prior publish may have renamed this
+			// .pub into place but then failed its directory fsync (returning an
+			// error). This next successful call would otherwise reuse it and return
+			// success without any fsync, so the sidecar could stay non-durable. Fsync
+			// the directory now (and propagate a failure) so reuse also guarantees
+			// durability.
+			if ferr := fsyncDir(dirFd, "pub-reuse"); ferr != nil {
+				return fmt.Errorf("keystore: fsync signing directory for existing %s: %w", name, ferr)
+			}
+			return nil
+		}
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return fmt.Errorf("keystore: marshal public key: %w", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	tmpName, err := writeTempAt(dirFd, name, pemBytes, 0o644)
+	if err != nil {
+		return err
+	}
+	if err := unix.Renameat(dirFd, tmpName, dirFd, name); err != nil {
+		_ = unix.Unlinkat(dirFd, tmpName, 0)
+		return err
+	}
+	// Fsync the directory so the new .pub entry is durable; propagate a writeback
+	// failure so a keyID is never returned for a sidecar that may be lost on a
+	// crash (verification of those sessions would then fail closed).
+	if err := fsyncDir(dirFd, "pub"); err != nil {
+		return fmt.Errorf("keystore: fsync signing directory after publishing %s: %w", name, err)
+	}
+	return nil
+}
+
+// LoadPublicKey returns the pinned public key <keyID>.pub under dir. It opens and
+// fstat-validates the directory fd, then reads the .pub relative to that fd, so
+// verification is anchored to the validated directory and cannot be redirected
+// by a post-validation swap of the dir or the .pub name.
+func LoadPublicKey(dir, keyID string) (*ecdsa.PublicKey, error) {
+	// Guard parity with LoadOrCreateSigningKey: a blank dir must fail closed, not
+	// be cleaned to "." and read a .pub from the current working directory.
+	if err := requireNonBlankDir(dir); err != nil {
+		return nil, err
+	}
+	if err := validateKeyID(keyID); err != nil {
+		return nil, err
+	}
+	dirFile, err := openValidatedDir(dir, 0o077)
+	if err != nil {
+		return nil, err
+	}
+	defer dirFile.Close()
+
+	data, err := readAtSecure(int(dirFile.Fd()), keyID+".pub", 0o022)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("keystore: no pinned public key %s (session was not signed by this host)", keyID)
+		}
+		return nil, err
+	}
+	pub, err := parsePublicKeyPEM(data)
+	if err != nil {
+		return nil, fmt.Errorf("keystore: public key %s: %w", keyID, err)
+	}
+	// Bind the sidecar to the key id it is filed under: recompute the fingerprint
+	// of the loaded key and require it equals keyID, so a stale/corrupt/planted
+	// .pub under a valid key-id filename cannot make signatures verify against the
+	// WRONG key.
+	gotID, err := publicKeyID(pub)
+	if err != nil {
+		return nil, err
+	}
+	if gotID != keyID {
+		return nil, fmt.Errorf("keystore: public key %s does not bind to its key id (content fingerprints as %s); refusing to trust the key store", keyID, gotID)
+	}
+	return pub, nil
+}
+
+// openValidatedDir opens dir O_NOFOLLOW|O_DIRECTORY and fstat-validates it (real
+// dir, owner euid, perms), returning the open fd for *at operations.
+func openValidatedDir(dir string, maxOther os.FileMode) (*os.File, error) {
+	// Strip a trailing separator so O_NOFOLLOW applies to the real final component.
+	dir = filepath.Clean(dir)
+	f, err := openSecureDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	st, err := fstatFd(int(f.Fd()))
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if err := checkStat(dir, &st, true, maxOther); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
+// fstatatNoFollow reports the mode of name relative to dirFd without following a
+// final-component symlink; a missing name is os.ErrNotExist.
+func fstatatNoFollow(dirFd int, name string) (unix.Stat_t, error) {
+	var st unix.Stat_t
+	if err := unix.Fstatat(dirFd, name, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return st, err
+	}
+	return st, nil
+}
+
+// openReadAtSecure opens name relative to dirFd for reading and validates the
+// OPEN FD (regular file, owner euid, no perm bit in maxOther). O_NOFOLLOW refuses
+// a symlink at the leaf; O_NONBLOCK means a FIFO opens immediately and is then
+// rejected by the fstat. The object validated is the object read.
+func openReadAtSecure(dirFd int, name string, maxOther os.FileMode) (*os.File, error) {
+	fd, err := unix.Openat(dirFd, name, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, fmt.Errorf("keystore: %s is a symlink; refusing to trust the key store", name)
+		}
+		return nil, err
+	}
+	f := os.NewFile(uintptr(fd), name)
+	st, err := fstatFd(int(f.Fd()))
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if err := checkStat(name, &st, false, maxOther); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
+func readAtSecure(dirFd int, name string, maxOther os.FileMode) ([]byte, error) {
+	f, err := openReadAtSecure(dirFd, name, maxOther)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(f)
+}
+
+// writeTempAt creates a fresh temp file relative to dirFd (O_CREAT|O_EXCL|
+// O_NOFOLLOW), writes+fsyncs it, and returns its name for a relative
+// linkat/renameat. It cleans up the temp on any error. The name is unpredictable
+// (random suffix) so it cannot be pre-created by an attacker.
+func writeTempAt(dirFd int, prefix string, data []byte, perm os.FileMode) (string, error) {
+	var rnd [8]byte
+	if _, err := rand.Read(rnd[:]); err != nil {
+		return "", err
+	}
+	tmpName := prefix + "." + hex.EncodeToString(rnd[:]) + ".tmp"
+	fd, err := unix.Openat(dirFd, tmpName, unix.O_CREAT|unix.O_EXCL|unix.O_WRONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, uint32(perm))
+	if err != nil {
+		return "", err
+	}
+	f := os.NewFile(uintptr(fd), tmpName)
+	fail := func(e error) (string, error) {
+		_ = f.Close()
+		_ = unix.Unlinkat(dirFd, tmpName, 0)
+		return "", e
+	}
+	// O_CREAT honours umask, so fchmod to the exact perm on the fd.
+	if err := f.Chmod(perm); err != nil {
+		return fail(err)
+	}
+	if _, err := f.Write(data); err != nil {
+		return fail(err)
+	}
+	if err := f.Sync(); err != nil {
+		return fail(err)
+	}
+	if err := f.Close(); err != nil {
+		_ = unix.Unlinkat(dirFd, tmpName, 0)
+		return "", err
+	}
+	return tmpName, nil
+}
+
+func parsePublicKeyPEM(data []byte) (*ecdsa.PublicKey, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("not valid PEM")
+	}
+	pubAny, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	pub, ok := pubAny.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, errors.New("not an ECDSA key")
+	}
+	if pub.Curve != elliptic.P256() {
+		return nil, errors.New("not a P-256 key")
+	}
+	return pub, nil
+}
+
+// validateKeyID guards the key-file lookup against path traversal (a key id is lowercase hex).
+func validateKeyID(keyID string) error {
+	if keyID == "" {
+		return errors.New("keystore: empty key id")
+	}
+	for _, r := range keyID {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return fmt.Errorf("keystore: invalid key id %q", keyID)
+		}
+	}
+	return nil
+}
+
+func publicKeyID(pub *ecdsa.PublicKey) (string, error) {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", fmt.Errorf("keystore: marshal public key: %w", err)
+	}
+	sum := sha256.Sum256(der)
+	return hex.EncodeToString(sum[:16]), nil
+}
+
+func parsePrivateKey(data []byte) (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("keystore: signing key is not valid PEM")
+	}
+	keyAny, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("keystore: parse signing key: %w", err)
+	}
+	key, ok := keyAny.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("keystore: signing key is not an ECDSA key")
+	}
+	if key.Curve != elliptic.P256() {
+		// The contract and generated keys are P-256; a valid ECDSA key on a
+		// different curve (e.g. P-384) must not be adopted.
+		return nil, errors.New("keystore: signing key is not a P-256 key")
+	}
+	return key, nil
+}

--- a/internal/host/keystore/keystore_test.go
+++ b/internal/host/keystore/keystore_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package keystore
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestSigningKeyIsStableAndRotates(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "signing")
+	_, id1, err := LoadOrCreateSigningKey(dir)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	_, id2, err := LoadOrCreateSigningKey(dir)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if id1 != id2 {
+		t.Fatalf("key id must be stable across loads: %s != %s", id1, id2)
+	}
+	// Rotation: remove the private key; a new key with a new id is generated and
+	// the old public key is retained so historical seals still verify.
+	if err := os.Remove(filepath.Join(dir, signingKeyBasename)); err != nil {
+		t.Fatalf("remove key: %v", err)
+	}
+	_, id3, err := LoadOrCreateSigningKey(dir)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if id3 == id1 {
+		t.Fatal("rotated key must have a new id")
+	}
+	if _, err := os.Stat(filepath.Join(dir, id1+".pub")); err != nil {
+		t.Fatalf("old public key must be retained after rotation: %v", err)
+	}
+}
+
+// TestLoadFailsOnInsecureExistingKey: a drifted-perms signing.key is refused, never repaired.
+func TestLoadFailsOnInsecureExistingKey(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "signing")
+	if _, _, err := LoadOrCreateSigningKey(dir); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := os.Chmod(filepath.Join(dir, signingKeyBasename), 0o644); err != nil {
+		t.Fatalf("chmod key: %v", err)
+	}
+	if _, _, err := LoadOrCreateSigningKey(dir); err == nil || !strings.Contains(err.Error(), "insecure permissions") {
+		t.Fatalf("insecure existing key must fail closed, got %v", err)
+	}
+}
+
+// withFsyncPhaseFailure makes fsyncDir fail with EIO at the given phase label
+// ("parent", "ancestor", "signing.key", "pub", "pub-reuse"); other phases pass
+// through. It returns a restore func so a test can inject, assert, restore, and
+// inject again — robust to how many ancestor dirs the temp path has.
+func withFsyncPhaseFailure(phase string) (restore func()) {
+	orig := fsyncDir
+	fsyncDir = func(fd int, label string) error {
+		if label == phase {
+			return unix.EIO
+		}
+		return orig(fd, label)
+	}
+	return func() { fsyncDir = orig }
+}
+
+// TestPublishFailsOnParentFsyncError (L144): the ancestor-chain fsync (whose
+// first level is dir's immediate parent) must fail the call closed on a
+// writeback failure, so no keyID is returned before dir's entry is durable.
+func TestPublishFailsOnParentFsyncError(t *testing.T) {
+	defer withFsyncPhaseFailure("ancestor")()
+	if _, _, err := LoadOrCreateSigningKey(filepath.Join(t.TempDir(), "signing")); err == nil ||
+		!strings.Contains(err.Error(), "fsync ancestor directory") {
+		t.Fatalf("ancestor (parent) fsync failure on dir creation must fail closed, got %v", err)
+	}
+}
+
+// TestRejectsNonP256Key (L558): a valid ECDSA signing.key on a different curve
+// (P-384) must not be adopted — the contract and generated keys are P-256. A
+// P-256 store still works.
+func TestRejectsNonP256Key(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "signing")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Plant a P-384 private key as signing.key.
+	k384, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen p384: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(k384)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if err := os.WriteFile(filepath.Join(dir, signingKeyBasename), pemBytes, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	if _, _, err := LoadOrCreateSigningKey(dir); err == nil || !strings.Contains(err.Error(), "not a P-256 key") {
+		t.Fatalf("a P-384 signing.key must fail closed, got %v", err)
+	}
+
+	// A P-256 store works.
+	dir2 := filepath.Join(t.TempDir(), "signing")
+	if _, keyID, err := LoadOrCreateSigningKey(dir2); err != nil {
+		t.Fatalf("P-256 store must work: %v", err)
+	} else if _, err := LoadPublicKey(dir2, keyID); err != nil {
+		t.Fatalf("LoadPublicKey P-256 must work: %v", err)
+	}
+}
+
+// TestBlankDirGuardParity (L285): both entry points reject a blank/whitespace dir
+// (fail closed) rather than cleaning it to "." (the current working directory).
+func TestBlankDirGuardParity(t *testing.T) {
+	for _, d := range []string{"", "   "} {
+		if _, _, err := LoadOrCreateSigningKey(d); err == nil || !strings.Contains(err.Error(), "signing directory is required") {
+			t.Fatalf("LoadOrCreateSigningKey(%q) must fail closed, got %v", d, err)
+		}
+		if _, err := LoadPublicKey(d, "00000000000000000000000000000000"); err == nil || !strings.Contains(err.Error(), "signing directory is required") {
+			t.Fatalf("LoadPublicKey(%q) must fail closed, got %v", d, err)
+		}
+	}
+	// A non-blank store still works end to end.
+	dir := filepath.Join(t.TempDir(), "signing")
+	_, keyID, err := LoadOrCreateSigningKey(dir)
+	if err != nil {
+		t.Fatalf("non-blank dir must work: %v", err)
+	}
+	if _, err := LoadPublicKey(dir, keyID); err != nil {
+		t.Fatalf("LoadPublicKey on a real store must work: %v", err)
+	}
+}


### PR DESCRIPTION
Part of A5 (signed session audit seals). First PR in a 4-PR stack.

Manages the per-host ECDSA **P-256** key used to sign A5 session audit seals: generate, load, and harden the private key and its public sidecar under an owner-secured (0700) signing directory. Distinct concern from the audit-chain recompute + sign/verify in package `auditseal` (stacked PR-B), which consumes `LoadOrCreateSigningKey`/`LoadPublicKey`.

**Containment.** The whole operation is anchored to one validated directory fd: the signing dir is opened `O_NOFOLLOW|O_DIRECTORY` and fstat-validated (real dir, owner euid, 0700 via `unix.Fstat`), then every key/pub read and write is an `*at` syscall relative to that fd (`openat`/`renameat`/`linkat`/`unlinkat`), so a post-validation dir swap cannot redirect any read or write. Content files are `O_NOFOLLOW` + fstat-checked (regular file, owner euid, mode). Keys are **refused** (never repaired) if insecure/symlink/non-regular/wrong-owner/wrong-curve; the public sidecar is repaired atomically from the private key and bound to its key-id filename. Directory entries are made durable by fsyncing the dir and **its full ancestor chain**, independent of who won a first-use race.

**Core tests** here: key gen + stability + rotation, P-256 curve enforcement, one perms refusal, one durability (parent fsync) case, blank-dir guard. Dead-code clean standalone. The exhaustive hardening matrix (perms/symlink/FIFO/TOCTOU/durability/racers) is stacked test-only PR-A2.

Stack:
- **PR-A (this)** a5k1/keystore-core → main
- PR-A2 a5k2/keystore-hardening-tests → a5k1 (test-only)
- PR-B a5a2/auditseal-lib → a5k1
- PR-C a5b2/session-verify → a5a2

🤖 Generated with [Claude Code](https://claude.com/claude-code)