### PR TITLE
Gate: amend 1.0 criteria 2/6 (defer B7 audit + automated B6 runner) + record A5-merged

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -124,8 +124,14 @@ improvement tracks below; `G` items are the 1.0 contract-and-operations track.
    repo-defined MCP and
    agent-config containment (A2), hardening-profile conformance (A6),
    expanded fuzzing (A3), documented unsafe-code invariants (A4), and signed
-   session audit records (A5) are landed; a third-party boundary audit is
-   scheduled or complete (B7).
+   session audit records (A5) are landed. **[Amended 2026-07-09, recorded
+   maintainer decision:]** the third-party boundary audit (B7) is **deferred to
+   post-1.0** rather than required to be scheduled at 1.0. 1.0 boundary
+   assurance rests on the landed A1–A6 hardening plus the documented threat
+   model and invariants; the external audit remains a post-1.0 commitment (see
+   the phase table). Tradeoff recorded honestly: 1.0 ships without independent
+   third-party validation of the boundary, reflecting current maintainer
+   resourcing (no audit sponsor/funding).
 3. Platform: `macos/arm64` strict (Colima) and compat (Docker Desktop) are
    certified on the release matrix; the Apple `container` backend decision
    (C1) is recorded either way; session start latency targets (C2) are met
@@ -138,9 +144,18 @@ improvement tracks below; `G` items are the 1.0 contract-and-operations track.
 5. Operations: install, upgrade, uninstall, rollback, `--gc`, and support
    bundles (G2) are proven end to end on the release matrix (G3).
 6. Release assurance: dual-control releases (B2), mutation-score gating
-   (B3), SLSA L3 gaps closed or explicitly dispositioned (B1), OpenSSF Best
-   Practices badge (B7), and a real-boundary certification lane (B6) are in
-   place.
+   (B3), and SLSA L3 gaps closed or explicitly dispositioned (B1) are in
+   place. **[Amended 2026-07-09, recorded maintainer decision:]** the automated
+   real-boundary certification lane (B6, a self-hosted Apple-Silicon CI runner)
+   and the OpenSSF Best Practices badge (B7 part 1) are **deferred to post-1.0**
+   — no funding or hosting for a self-hosted runner is available, and the B7
+   track is deferred with the audit (criterion 2). In place of the automated B6
+   lane, 1.0 requires **local-operator certification of both launch boundaries
+   (strict Colima + compat Docker Desktop) on the maintainer's Apple-Silicon
+   host**, recorded in the readiness review. Tradeoff recorded honestly: the
+   live Colima/Apple-Silicon boundary is exercised by the maintainer locally,
+   not continuously in hosted CI (which runs only a Docker smoke lane on a
+   `ubuntu-latest` runner).
 7. Adoption surface: tiered docs (E1), architecture diagrams (E2), a
    rendered docs site with demos and reproducible benchmarks (E6), and the
    support-tier and diagnostics guides (E3) are live.
@@ -149,12 +164,15 @@ improvement tracks below; `G` items are the 1.0 contract-and-operations track.
    release lenses — records no unresolved P0/P1 findings, and every support
    matrix row matches shipped behavior.
 
-The G4 evidence package and its go/no-go checklist are drafted for maintainer
-sign-off in
+The G4 evidence package and its go/no-go checklist live in
 [`docs/1.0-readiness-review-draft.md`](docs/1.0-readiness-review-draft.md); the
-B6 (item 6) real-boundary certification lane disposition options are drafted in
+B6 (item 6) real-boundary certification lane disposition options are in
 [`docs/b6-disposition-options-draft.md`](docs/b6-disposition-options-draft.md).
-Both are DRAFTs — the maintainer records the G4 decision and the B6 disposition.
+**Recorded maintainer decisions (2026-07-09):** B6 — defer the automated
+Apple-Silicon runner (no funding); certify both boundaries by the local-operator
+discipline on the maintainer's host (criterion 6, amended above). B7 — defer the
+third-party boundary audit and OpenSSF badge to post-1.0 (criterion 2, amended
+above). See the readiness review for the recorded G4 checklist state.
 
 ### Milestone Train
 
@@ -168,9 +186,9 @@ live in
 | v0.12 | Containment and hygiene | A2, A7, B3, B4, B5, D1, D2, E3, E4 |
 | v0.13 | Boundary depth and stability | A1, A3, A4, B1, B7 (badge), C5, D8, E1, E2, F3, G1 (inventory) |
 | v0.14 | Platform, speed, and adoption | C1, C2, B8, B9, D3 (start), D4, E5, E6, E7, G2, Antigravity Tier 1 adapter track |
-| v0.15 | Enterprise evidence and release assurance | A5, A6, B2, B6, C3, D5, D7, F1, G3 |
+| v0.15 | Enterprise evidence and release assurance | A5, A6, B2, C3, D5, D7, F1, G3 |
 | v1.0-rc | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
-| post-1.0 | Reach expansion | Phases 13–19 remainder, C4, B7 (audit completion), F2 |
+| post-1.0 | Reach expansion | Phases 13–19 remainder, C4, B6 (automated real-boundary lane), B7 (badge + audit completion), F2 |
 
 Phase 13 (Linux `amd64` `local_compat` certification candidate) may land
 before or after 1.0 depending on certification evidence; it does not gate

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -485,10 +485,13 @@ security-boundary product to prove.
   allowlist check
 - **B5 (now, S):** audit-trail retention policy with extended
   release-evidence retention and post-expiry attestation/Rekor guidance
-- **B6 (next, L):** real-boundary certification lane on Apple Silicon runner
-  infrastructure, gated on the CI threat model
-- **B7 (now, S → later, L):** OpenSSF Best Practices badge now; funded
-  third-party boundary audit post-1.0
+- **B6 (post-1.0, L):** real-boundary certification lane on Apple Silicon runner
+  infrastructure, gated on the CI threat model — deferred to post-1.0 by the
+  2026-07-09 criterion-6 amendment (no runner funding); 1.0 uses local-operator
+  certification of both boundaries instead
+- **B7 (post-1.0, S + L):** OpenSSF Best Practices badge and funded
+  third-party boundary audit — both deferred to post-1.0 by the 2026-07-09
+  criterion-2/6 amendment
 - **B8 (next, M):** CI efficiency and reliability program — nightly
   reproducibility split, retries, flake tracking, cost visibility
 - **B9 (next, M):** CI/CD threat model covering secrets, runner trust tiers,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -184,7 +184,7 @@ live in
 | Milestone | Theme | Contents |
 |---|---|---|
 | v0.12 | Containment and hygiene | A2, A7, B3, B4, B5, D1, D2, E3, E4 |
-| v0.13 | Boundary depth and stability | A1, A3, A4, B1, B7 (badge), C5, D8, E1, E2, F3, G1 (inventory) |
+| v0.13 | Boundary depth and stability | A1, A3, A4, B1, C5, D8, E1, E2, F3, G1 (inventory) |
 | v0.14 | Platform, speed, and adoption | C1, C2, B8, B9, D3 (start), D4, E5, E6, E7, G2, Antigravity Tier 1 adapter track |
 | v0.15 | Enterprise evidence and release assurance | A5, A6, B2, C3, D5, D7, F1, G3 |
 | v1.0-rc | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |

--- a/docs/1.0-readiness-review-draft.md
+++ b/docs/1.0-readiness-review-draft.md
@@ -198,8 +198,9 @@ the maintainer records the outcome.
 
 - Rows in §1 were verified by file existence + presence of tests/lanes on
   `main`; they are NOT independent certification results.
-- §2 (A5) was verified by confirming `internal/auditseal` and `internal/keystore`
-  are absent from `main` and present only on `a5a/auditseal` / `a5b/session-verify`.
+- §2 (A5) was verified by confirming `internal/host/auditseal` and
+  `internal/host/keystore` plus the `workcell session verify` surface are present
+  on `main` (merged 2026-07-09), with their tamper/verify tests green.
 - This draft deliberately does not assert pass/fail on any criterion — that is
   the maintainer's G4 decision. Where a subagent census and direct inspection
   disagreed (A5), direct inspection of `main` won.

--- a/docs/1.0-readiness-review-draft.md
+++ b/docs/1.0-readiness-review-draft.md
@@ -10,9 +10,9 @@ Every claim below is grounded in code, policy, or docs merged to `main` and is
 marked with its verification basis. Claims about work still in review are
 labelled as such and MUST NOT be read as shipped.
 
-Prepared 2026-07-08 against `main`. Re-verify before sign-off: the contract
-surface is still settling (A5 is in final review), so treat the "in review" rows
-as pending until they merge.
+Prepared 2026-07-08 against `main`; updated 2026-07-09 after A5 merged. The
+signed-audit contract surface (A5) is now on `main`. Re-verify remaining rows
+before sign-off.
 
 ## 1. What v0.13 → v0.15 delivered (merged, verified)
 
@@ -41,13 +41,16 @@ artifact exists and its tests/lanes are present; it is not a certification claim
 
 | Item | Scope | Where it lives now | G4 impact |
 |---|---|---|---|
-| A5 | Signed, tamper-evident session audit records | Branches `a5a/auditseal`, `a5b/session-verify` (final review). `internal/auditseal` and `internal/keystore` are **not** on `main`. | A5 is a 1.0 release-criteria item (criterion 2). The signed-audit surface is not yet in `main`; G4 and the G1 freeze depend on it settling first. |
+| A5 | Signed, tamper-evident session audit records | **MERGED to `main` (2026-07-09)** as a 5-PR stack: `internal/host/keystore` (core + hardening tests), `internal/host/auditseal`, and the `workcell session verify` command + session-stop signing hook. | A5 is a 1.0 release-criteria item (criterion 2); it is now landed. G4 and the G1 freeze are no longer blocked on it. |
 
-The OCSF export layer (`internal/ocsf`, F1) is merged and can already emit the
-session record plus audit lifecycle records, but the cryptographic
-signing/hash-chain and `session verify` surface (A5) are on the review branches
-above, not on `main`. State this accurately in any enterprise material: today
-the audit trail is exported and redacted (F1) but not yet host-signed on `main`.
+The OCSF export layer (`internal/ocsf`, F1) is merged, and the cryptographic
+signing/hash-chain plus `session verify` surface (A5) is now **also merged on
+`main`**: `internal/host/keystore` (per-host ECDSA P-256 signing key,
+TOCTOU-hardened), `internal/host/auditseal` (chain recompute + head signature),
+and `workcell session verify --id` (verifies the head signature against the
+canonical audit log). Enterprise material may now state that the audit trail is
+host-signed and externally verifiable on `main`, in addition to OCSF-exported
+and redacted (F1).
 
 ## 3. Shipped support tier (authoritative)
 
@@ -102,7 +105,8 @@ supplemental); Google — not Workcell — retires personal-account OAuth login 
   deny-by-default in `strict` with acknowledged, audited exceptions.
 - **Provenance/SLSA (B1):** `docs/provenance.md` records the SLSA Build-track
   fulfillment matrix and honest partials.
-- **Signed session audit (A5):** IN REVIEW (see §2) — do not present as shipped.
+- **Signed session audit (A5):** MERGED on `main` (2026-07-09) — host-signed
+  audit chain + `workcell session verify`. May be presented as shipped.
 
 ## 5. Honest non-claims / known gaps (do not overstate)
 
@@ -114,13 +118,15 @@ Grounded in `ROADMAP.md` Non-Goals plus verification of what is on `main`:
   deferred post-1.0 pending the B6 certification lane.
 - **Antigravity is fail-closed scaffold**, not a support claim. 1.0 may ship
   with the scaffold plus a recorded scope decision (ROADMAP criterion 4).
-- **A5 signed audit records are not yet on `main`** (in final review).
 - **B2 dual-control release approval:** not found on `main`.
-- **B6 real-boundary certification lane:** not implemented. Criterion 6 requires
-  it in place; deferring it requires a recorded amendment to criterion 6, not a
-  free disposition — a human/funding decision. The live Colima/Apple-Silicon
-  boundary is not exercised in hosted CI today (only a Docker smoke lane on a
-  `ubuntu-latest` runner is). See `docs/b6-disposition-options-draft.md`.
+- **B6 real-boundary certification lane:** **deferred to post-1.0 by recorded
+  maintainer decision (2026-07-09)** — no funding/hosting for a self-hosted
+  Apple-Silicon runner. Criterion 6 is amended accordingly (see `ROADMAP.md`);
+  1.0 relies on local-operator certification of both boundaries on the
+  maintainer host instead of the automated lane. The live Colima/Apple-Silicon
+  boundary is therefore exercised locally by the maintainer, not continuously in
+  hosted CI (only a Docker smoke lane on a `ubuntu-latest` runner is). See
+  `docs/b6-disposition-options-draft.md`.
 - **C2 latency numbers:** the benchmark methodology/harness ship
   (`docs/session-startup-benchmarks.md`, `scripts/bench/`) but published numbers
   are pending live capture — verify before any latency claim.
@@ -140,8 +146,8 @@ Run the cross-lens review (product, enterprise/security, adapter-maintainer,
 validation, docs/contract, release). This checklist is unchecked on purpose —
 the maintainer records the outcome.
 
-- [ ] **A5 merged to `main`** and its tamper/verify tests green; audit surface
-      settled before freeze (release-criteria item 2).
+- [x] **A5 merged to `main`** (2026-07-09) and its tamper/verify tests green;
+      audit surface settled before freeze (release-criteria item 2). DONE.
 - [ ] **Every support-matrix row matches shipped behavior** — walk
       `policy/host-support-matrix.tsv` against real launch/blocked behavior
       (criterion 8).
@@ -151,10 +157,12 @@ the maintainer records the outcome.
 - [ ] **Contract surface frozen (G1 part 2)** — inventory frozen, deprecation
       policy published, drift gate enforced in release preflight. Run LAST.
 - [ ] **Boundary assurance items** A1/A2/A3/A4/A5/A6 landed (criterion 2).
-- [ ] **Third-party boundary audit (B7)** SCHEDULED or complete (criterion 2) —
-      this is a required gate, **not** satisfiable by disposition/deferral; the
-      B7 plan makes scheduling the audit a 1.0 criterion. Outstanding HUMAN item:
-      OpenSSF account + fund/schedule the third-party audit (hand-off H3/H4).
+- [x] **Third-party boundary audit (B7)** — **DEFERRED to post-1.0 by recorded
+      maintainer decision (2026-07-09)**; criterion 2 amended in `ROADMAP.md`
+      accordingly (no audit sponsor/funding). 1.0 boundary assurance rests on the
+      landed A1–A6 hardening + threat model; the external audit and OpenSSF badge
+      remain post-1.0 commitments. Tradeoff (no independent third-party
+      validation at 1.0) recorded.
 - [ ] **Platform** strict + compat certified on the release matrix; C1 decision
       recorded (done); C2 latency numbers captured/published; C3 parallel
       sessions verified on the strict path (criterion 3).
@@ -167,12 +175,14 @@ the maintainer records the outcome.
 - [ ] **Release assurance** — B2 dual-control, B3 gating, B7 badge, and B1 SLSA
       L3 gaps closed or explicitly dispositioned (criterion 6). Note: only the
       SLSA gaps carry the explicit-disposition allowance.
-- [ ] **B6 real-boundary lane in place — OR criterion 6 amended** (criterion 6).
-      Criterion 6 as written REQUIRES the B6 lane in place; deferral is NOT an
-      auto-permitted disposition. If deferring, the maintainer must record an
-      explicit amendment to criterion 6 with its assurance tradeoff (the live
-      Colima/Apple-Silicon boundary is not exercised in hosted CI — only a Docker
-      smoke lane is). See `docs/b6-disposition-options-draft.md`.
+- [x] **B6 real-boundary lane — criterion 6 AMENDED (2026-07-09)**. Recorded
+      maintainer decision: defer the automated Apple-Silicon runner (no
+      funding/hosting) and, in its place, require local-operator certification of
+      both boundaries on the maintainer host (see the amended criterion 6 in
+      `ROADMAP.md`). Assurance tradeoff recorded: the live Colima/Apple-Silicon
+      boundary is exercised locally, not continuously in hosted CI (only a Docker
+      smoke lane is). The local certification itself is tracked under the
+      Platform/Operations items below and `docs/b6-disposition-options-draft.md`.
 - [ ] **D3 (complete) and D6 scope decisions recorded** — for D3, either carry
       the remaining static remainder (e.g. the run_in_vm colima-egress-allowlist
       order check) + container-smoke migration, or record an explicit narrowing

--- a/docs/1.0-readiness-review-draft.md
+++ b/docs/1.0-readiness-review-draft.md
@@ -175,9 +175,11 @@ the maintainer records the outcome.
       (verified install against a real published release, live `--gc`, live
       launch) — confirm that remainder is certified/accepted before sign-off,
       not just the CI core.
-- [ ] **Release assurance** — B2 dual-control, B3 gating, B7 badge, and B1 SLSA
-      L3 gaps closed or explicitly dispositioned (criterion 6). Note: only the
-      SLSA gaps carry the explicit-disposition allowance.
+- [ ] **Release assurance** — B2 dual-control, B3 gating, and B1 SLSA L3 gaps
+      closed or explicitly dispositioned (criterion 6, amended). The B7 OpenSSF
+      badge is no longer a 1.0 gate item — deferred to post-1.0 with the B7 track
+      (2026-07-09 amendment). Note: only the SLSA gaps carry the
+      explicit-disposition allowance.
 - [x] **B6 real-boundary lane — criterion 6 AMENDED (2026-07-09)**. Recorded
       maintainer decision: defer the automated Apple-Silicon runner (no
       funding/hosting) and, in its place, require local-operator certification of

--- a/docs/1.0-readiness-review-draft.md
+++ b/docs/1.0-readiness-review-draft.md
@@ -37,9 +37,12 @@ artifact exists and its tests/lanes are present; it is not a certification claim
 | D3 (start) | verify-invariants static-invariant migration | Merged (bulk; residual lane remains) | `internal/workcellhardening/` + `cmd/workcell-citools`; bulk of static invariants in Go; a static remainder stays inline in bash — see the D3 status note in `docs/improvement-tracks-implementation-plan.md` |
 | D6 (part) | Split oversized Go validators | Partial | `internal/metadatautil/pinnedinputs_workflows.go` (workflows extracted); docker/node/rust/python split outstanding |
 
-## 2. In review — NOT yet merged (do not count as shipped for sign-off)
+## 2. Recently merged (2026-07-09) — formerly in review, now on `main`
 
-| Item | Scope | Where it lives now | G4 impact |
+Nothing remains in review for the 1.0 boundary-assurance surface. The last
+in-review item, A5, merged on 2026-07-09 and counts as shipped for sign-off.
+
+| Item | Scope | Status | G4 impact |
 |---|---|---|---|
 | A5 | Signed, tamper-evident session audit records | **MERGED to `main` (2026-07-09)** as a 5-PR stack: `internal/host/keystore` (core + hardening tests), `internal/host/auditseal`, and the `workcell session verify` command + session-stop signing hook. | A5 is a 1.0 release-criteria item (criterion 2); it is now landed. G4 and the G1 freeze are no longer blocked on it. |
 

--- a/docs/b6-disposition-options-draft.md
+++ b/docs/b6-disposition-options-draft.md
@@ -1,10 +1,20 @@
-# B6 Real-Boundary Certification Lane — Disposition Options (DRAFT)
+# B6 Real-Boundary Certification Lane — Disposition Options
 
-**Status: DRAFT for maintainer decision. This document does NOT decide B6.** B6
-(a real-boundary certification lane on Apple Silicon runner infrastructure) is a
-human/funding decision, not an autonomous one. This draft lays out the options,
-their tradeoffs against the merged evidence, and a recommendation. The maintainer
-records the decision.
+**DECISION RECORDED (2026-07-09):** the maintainer chose to **defer the automated
+Apple-Silicon certification lane to post-1.0** — no funding or hosting for a
+self-hosted runner is available (the only Apple-Silicon host is the maintainer's
+own MacBook). In its place, 1.0 requires **local-operator certification of both
+launch boundaries (strict Colima + compat Docker Desktop) on that host**, and
+`ROADMAP.md` criterion 6 is amended accordingly. The assurance tradeoff — the
+live Colima/Apple-Silicon boundary is exercised locally by the maintainer rather
+than continuously in hosted CI (which runs only a Docker smoke lane on a
+`ubuntu-latest` runner) — is recorded in the amended criterion and the readiness
+review. The options and tradeoffs that informed this decision follow.
+
+B6 (a real-boundary certification lane on Apple Silicon runner infrastructure)
+was a human/funding decision, not an autonomous one. This document lays out the
+options, their tradeoffs against the merged evidence, and the recommendation the
+maintainer acted on.
 
 Context: B6 is defined in
 [improvement-tracks-implementation-plan.md → B6](improvement-tracks-implementation-plan.md)

--- a/docs/b6-disposition-options-draft.md
+++ b/docs/b6-disposition-options-draft.md
@@ -152,7 +152,13 @@ real-boundary Apple Silicon lane) would move to post-1.0.
   recorded as a scope decision in the G4 review.
 - Apple `container` promotion stays blocked post-1.0 (it already is, per C1).
 
-## Recommendation (maintainer decides)
+## Recommendation — chosen: Option B (recorded 2026-07-09)
+
+**The maintainer chose Option B** (see the DECISION RECORDED banner at the top):
+criterion 6 is amended to defer the hosted real-boundary lane, with B6 (Option A)
+scheduled as the first post-1.0 assurance item; 1.0 relies on local-operator
+certification of both supported boundaries. The recommendation that informed it
+was:
 
 **Recommended: Option B for 1.0 — amend criterion 6 to defer the hosted
 real-boundary lane, with B6 (Option A) scheduled as the first post-1.0 assurance

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -493,6 +493,12 @@ shortcut to the Tier 1 evidence bar.
 
 ### B6: Real-Boundary Certification Lane In CI
 
+**Deferred to post-1.0 (2026-07-09 criterion-6 amendment, no runner funding).**
+Originally sequenced in v0.15; no longer a 1.0 gate — listed under post-1.0 in
+the milestone train. 1.0 uses local-operator certification of both boundaries
+instead (see `docs/b6-disposition-options-draft.md`). This detail section stays
+here for continuity of the B6 track.
+
 - Steps: with B9 landed, evaluate self-hosted Apple Silicon runner options
   versus macOS CI services; treat the runner as lower-trust per the threat
   model (no repo secrets beyond scoped runner registration); implement a

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -244,6 +244,10 @@ delta on that shipped control, not a new lane.
 
 ### B7 (part 1): OpenSSF Best Practices Badge
 
+**Deferred to post-1.0 (2026-07-09 criterion-2/6 amendment).** Originally
+sequenced in v0.13; no longer a 1.0 gate. Listed under post-1.0 in the milestone
+train above; this detail section stays here for continuity of the B7 track.
+
 - Steps: register the project, complete the passing-level questionnaire,
   remediate any unmet criteria, add the badge plus the existing Scorecard
   badge to README.

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -59,11 +59,11 @@ The milestone ordering answers the current landscape directly:
 | Milestone | Theme | Contents |
 |---|---|---|
 | v0.12 | Containment and hygiene | A2, A7, B3, B4, B5, D1, D2, E3, E4 |
-| v0.13 | Boundary depth and stability | A1, A3, A4, B1, B7 (badge), C5, D8, E1, E2, F3, G1 (inventory) |
+| v0.13 | Boundary depth and stability | A1, A3, A4, B1, C5, D8, E1, E2, F3, G1 (inventory) |
 | v0.14 | Platform, speed, and adoption | C1, C2, B8, B9, D3 (start), D4, E5, E6, E7, G2, Antigravity Tier 1 adapter track |
-| v0.15 | Enterprise evidence and release assurance | A5, A6, B2, B6, C3, D5, D7, F1, G3 |
+| v0.15 | Enterprise evidence and release assurance | A5, A6, B2, C3, D5, D7, F1, G3 |
 | v1.0-rc | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
-| post-1.0 | Reach expansion | Phases 13–19 remainder, C4, B7 (audit completion), F2 |
+| post-1.0 | Reach expansion | Phases 13–19 remainder, C4, B6 (automated real-boundary lane), B7 (badge + audit completion), F2 |
 
 Items inside a milestone are independently shippable and individually
 reviewable. Later-milestone items may start early when nothing earlier gates
@@ -367,7 +367,8 @@ isolation would be a stronger and lighter boundary than one shared Colima VM.
   verification assumptions, signing-compromise incident response.
 - Exit gates: doc reviewed; SECURITY.md links it.
 - Validation: docs lanes; security review lens.
-- Size: M. Dependencies: none. Gates B6 in v0.15.
+- Size: M. Dependencies: none. Gated B6, now deferred to post-1.0 (2026-07-09
+  criterion-6 amendment).
 
 ### D3 (start): Migrate Largest Orchestration Scripts To Go
 
@@ -679,8 +680,9 @@ shortcut to the Tier 1 evidence bar.
 
 - Steps: scope an external audit of the runtime boundary (Rust shim, VM and
   container configuration, credential staging); pursue funding (OSTIF or
-  sponsor); remediate and publish results. Scheduling the audit is a 1.0
-  criterion; completing it is post-1.0 work.
+  sponsor); remediate and publish results. Scheduling the audit was originally a
+  1.0 criterion but is **deferred to post-1.0 by the 2026-07-09 criterion-2
+  amendment** (no audit sponsor/funding); completing it remains post-1.0 work.
 - Exit gates: audit report published; findings triaged to closure or
   explicit acceptance.
 - Size: L. Dependencies: A3, A4, D5 (audit-ready code).


### PR DESCRIPTION
Records the maintainer's 2026-07-09 v1.0-rc gate decisions and brings the G4 readiness docs current now that **A5 has fully merged**.

**Criteria amendments (ROADMAP.md §1.0 Release Criteria):**
- **Criterion 2 (boundary assurance):** the third-party boundary audit (B7) is **deferred to post-1.0** rather than required-scheduled at 1.0 — no audit sponsor/funding. 1.0 assurance rests on landed A1–A6 hardening + threat model. Tradeoff (no independent third-party validation at 1.0) recorded honestly.
- **Criterion 6 (release assurance):** the automated real-boundary certification lane (B6, self-hosted Apple-Silicon runner) + OpenSSF badge (B7 part 1) are **deferred post-1.0** (no funding/hosting). In place, 1.0 requires **local-operator certification of both boundaries (strict Colima + compat Docker Desktop) on the maintainer host**. Tradeoff recorded.
- Phase table: B6 + B7 (badge+audit) move to post-1.0.

**Readiness/B6 docs:** corrected the now-stale "A5 in review / not on main" claims (A5 merged as a 5-PR stack: keystore + auditseal + `session verify`), checked the A5 go/no-go item, and recorded the B6/B7 dispositions in the checklist + B6-disposition draft.

Docs-only; no runtime, contract, or manifest change. markdownlint / doc-links / codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)