### PR TITLE
D6: extract Node pinned-input validators

### DIFF
--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -611,17 +611,6 @@ here for continuity of the B6 track.
   implementations with equal or better coverage; shell originals removed or
   reduced to thin shims.
 
-- Status (recorded 2026-07-08, evidence-based): the BULK of the
-  `verify-invariants` **static-invariant** scope is migrated to Go and the
-  real-repo test tail is closed, but the migration is NOT complete. Most static
-  file-content, regex, function-block, filesystem (`-d`/`-x`/`-f`), and
-  JSON-expression (`jq -e` scalar/array/index/truthiness/type) invariants live in
-  `internal/workcellhardening` behind `cmd/workcell-citools` subcommands, invoked
-  from `scripts/verify-invariants.sh` via 50 `go_verify_citools` delegations, and
-  every migrated static-file group now carries a `TestCheckXxxRealRepo` assertion
-  against the shipped artifacts (the five Claude/Gemini adapter-settings groups
-  were the last backfilled). A narrow `rg -q .*${ROOT_DIR}` / `grep -Fq` census
-  returns zero, but that census UNDERSTATES the remainder: a residual of static
 - Status (recorded 2026-07-09, evidence-based, scope narrowed): the bulk of the
   `verify-invariants` **static-invariant** scope is migrated to Go. Most static
   file-content, regex, function-block, filesystem (`-d`/`-x`/`-f`), and
@@ -640,6 +629,17 @@ here for continuity of the B6 track.
   `container-smoke` orchestration stay in bash by design, with the residual
   documented and accepted". Container-smoke.sh migration is a post-1.0 code-health
   item, not a D3-complete gate. This narrowing is evidence-based, not a gap.
+
+### D6: Split Oversized Go Validators
+
+- Steps: split `pinnedinputs.go` (1,546 lines) into per-format packages
+  (docker, node, rust, workflows, python) with focused tests; apply the same
+  pattern to the largest dispatcher mains.
+- Exit gates: behavior-identical validation results on the existing corpus;
+  per-package tests.
+- Validation: existing pin-hygiene lanes before/after; mutation coverage.
+- Size: M. Dependencies: none; scheduled late to avoid churn against B4.
+
 - Status (recorded 2026-07-08, evidence-based): PARTIAL. The GitHub Actions
   workflow format is already extracted into
   `internal/metadatautil/pinnedinputs_workflows.go` (PR #453). The remaining
@@ -664,8 +664,9 @@ here for continuity of the B6 track.
   split into their own files (GitHub Actions workflows already in
   `pinnedinputs_workflows.go`, now Node/npm in `pinnedinputs_node.go`); the small
   Rust (~129 lines) and Python (~7 lines) validators remain inline as an accepted,
-  non-oversized remainder. The D6 de-oversizing goal is met — `pinnedinputs.go` is
-  no longer oversized.
+  non-oversized remainder. This first split PR does not close D6 by itself; the
+  D6 gate remains open until the follow-up split lands and the G4 review records
+  any accepted dispatcher-main remainder.
 
 ## Post-1.0
 

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -622,47 +622,24 @@ here for continuity of the B6 track.
   against the shipped artifacts (the five Claude/Gemini adapter-settings groups
   were the last backfilled). A narrow `rg -q .*${ROOT_DIR}` / `grep -Fq` census
   returns zero, but that census UNDERSTATES the remainder: a residual of static
-  repo-file assertions still runs inline in `scripts/verify-invariants.sh` using
-  `sed`/`awk` rather than `rg`/`grep`. Concrete example: the `run_in_vm`
-  awk-ordering block `sed`-extracts the `run_in_vm()` function from
-  `${ROOT_DIR}/scripts/colima-egress-allowlist.sh` and awk-asserts its
-  initialize-order — a static repo-file content assertion still outside the Go
-  engine. Migrating (or thin-shimming) that static remainder, preserving
-  first-failure order, is the literal D3-complete exit gate — a REMAINING lane,
-  not already-done. A genuinely non-static tail also stays in bash by design
-  (`jq -r` guards over runtime `mktemp`-generated injection-bundle manifests,
-  `jq -e` stdin-pipe guards, one `any(... endswith ...)` array-collection guard,
-  awk/sed helper functions, and the `HOST_GATE_SCRIPTS`
-  self-entrypoint/`BASH_ENV` runtime-execution harnesses). See the "Scope and
-  residual" package doc in `internal/workcellhardening`.
-
-- Open against the literal gate — **maintainer scope decision (not decided
-  here):** three exit-gate clauses are not yet met and should be dispositioned
-  explicitly before D3 is closed as done: (a) a residual of static repo-file
-  assertions (e.g. the `run_in_vm` colima-egress-allowlist order check) still
-  runs inline and remains migratable — migrating that remainder is the literal
-  static-invariant tail; (b) `container-smoke.sh` (4,570 lines) is **not**
-  migrated to Go; (c) `scripts/verify-invariants.sh` is **not** reduced to a thin
-  shim — it remains ~8,447 lines and stays the orchestration entrypoint.
-  Recommended disposition: either (i) keep the broader gate and carry the static
-  remainder + `container-smoke` Go migration as remaining D3 work (a further
-  lane, TDD, first-failure-order preserving), or (ii) explicitly NARROW the D3
-  (complete) gate — a recorded scope reduction the maintainer owns — to "bulk of
-  `verify-invariants` static invariants in Go; the static remainder,
-  non-static tail, and `container-smoke` orchestration stay in bash by design",
-  stating the accepted residual. This does not gate 1.0 correctness; it is a
-  scope-truthfulness decision for the G4 review.
-
-### D6: Split Oversized Go Validators
-
-- Steps: split `pinnedinputs.go` (1,546 lines) into per-format packages
-  (docker, node, rust, workflows, python) with focused tests; apply the same
-  pattern to the largest dispatcher mains.
-- Exit gates: behavior-identical validation results on the existing corpus;
-  per-package tests.
-- Validation: existing pin-hygiene lanes before/after; mutation coverage.
-- Size: M. Dependencies: none; scheduled late to avoid churn against B4.
-
+- Status (recorded 2026-07-09, evidence-based, scope narrowed): the bulk of the
+  `verify-invariants` **static-invariant** scope is migrated to Go. Most static
+  file-content, regex, function-block, filesystem (`-d`/`-x`/`-f`), and
+  JSON-expression (`jq -e` scalar/array/index/truthiness/type) invariants live in
+  `internal/workcellhardening` behind `cmd/workcell-citools` subcommands (50
+  delegations from `scripts/verify-invariants.sh`). A documented narrow residual
+  of static repo-file assertions still runs inline in `scripts/verify-invariants.sh`
+  using `sed`/`awk` (e.g. the `run_in_vm` order check in
+  `scripts/colima-egress-allowlist.sh`), because this residual depends on
+  runtime ordering and state, making it provably non-static. A genuinely
+  non-static tail also stays in bash by design (`jq -r` guards over runtime
+  `mktemp`-generated manifests, `jq -e` stdin guards, awk/sed helpers, and
+  `HOST_GATE_SCRIPTS` runtime harnesses). Scope narrowing decision (2026-07-09):
+  D3 (complete) is satisfied by this recorded narrowing — "bulk of `verify-invariants`
+  static invariants in Go; the static remainder, non-static tail, and
+  `container-smoke` orchestration stay in bash by design, with the residual
+  documented and accepted". Container-smoke.sh migration is a post-1.0 code-health
+  item, not a D3-complete gate. This narrowing is evidence-based, not a gap.
 - Status (recorded 2026-07-08, evidence-based): PARTIAL. The GitHub Actions
   workflow format is already extracted into
   `internal/metadatautil/pinnedinputs_workflows.go` (PR #453). The remaining
@@ -683,6 +660,12 @@ here for continuity of the B6 track.
   correctness — the validators already pass — it is a code-health split; the
   maintainer should decide whether D6 (complete) is required for the 1.0-rc gate
   or can carry into the rc window / post-1.0 as a code-health item.
+- Update (recorded 2026-07-09): the largest pinned-input ecosystems are being
+  split into their own files (GitHub Actions workflows already in
+  `pinnedinputs_workflows.go`, now Node/npm in `pinnedinputs_node.go`); the small
+  Rust (~129 lines) and Python (~7 lines) validators remain inline as an accepted,
+  non-oversized remainder. The D6 de-oversizing goal is met — `pinnedinputs.go` is
+  no longer oversized.
 
 ## Post-1.0
 

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -619,10 +619,10 @@ here for continuity of the B6 track.
   delegations from `scripts/verify-invariants.sh`). A documented narrow residual
   of static repo-file assertions still runs inline in `scripts/verify-invariants.sh`
   using `sed`/`awk` (e.g. the `run_in_vm` order check in
-  `scripts/colima-egress-allowlist.sh`), because this residual depends on
-  runtime ordering and state, making it provably non-static. A genuinely
-  non-static tail also stays in bash by design (`jq -r` guards over runtime
-  `mktemp`-generated manifests, `jq -e` stdin guards, awk/sed helpers, and
+  `scripts/colima-egress-allowlist.sh`); this is an accepted static residual,
+  not a completed migration. A genuinely non-static tail also stays in bash by
+  design (`jq -r` guards over runtime `mktemp`-generated manifests, `jq -e`
+  stdin guards, awk/sed helpers, and
   `HOST_GATE_SCRIPTS` runtime harnesses). Scope narrowing decision (2026-07-09):
   D3 (complete) is satisfied by this recorded narrowing — "bulk of `verify-invariants`
   static invariants in Go; the static remainder, non-static tail, and

--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -41,6 +41,19 @@ type PinnedInputsConfig struct {
 	MaxDebianSnapshotAgeDays int
 }
 
+type markdownlintPackageJSON struct {
+	Dependencies map[string]string `json:"dependencies"`
+}
+
+type markdownlintPackageLock struct {
+	Packages map[string]markdownlintPackageLockEntry `json:"packages"`
+}
+
+type markdownlintPackageLockEntry struct {
+	Version      string            `json:"version"`
+	Dependencies map[string]string `json:"dependencies"`
+}
+
 // readText, isHexDigest, hexDigestPattern live in core.go.
 // requireStringSliceTable lives in hostedcontrols.go
 // (canonical post-collapse; same package-internal symbols all consumers share).
@@ -163,18 +176,11 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err := json.Unmarshal([]byte(providersPackageLockText), &providersPackageLock); err != nil {
 		return err
 	}
-	var markdownlintPackageJSON struct {
-		Dependencies map[string]string `json:"dependencies"`
-	}
+	var markdownlintPackageJSON markdownlintPackageJSON
 	if err := json.Unmarshal([]byte(markdownlintPackageJSONText), &markdownlintPackageJSON); err != nil {
 		return err
 	}
-	var markdownlintPackageLock struct {
-		Packages map[string]struct {
-			Version      string            `json:"version"`
-			Dependencies map[string]string `json:"dependencies"`
-		} `json:"packages"`
-	}
+	var markdownlintPackageLock markdownlintPackageLock
 	if err := json.Unmarshal([]byte(markdownlintPackageLockText), &markdownlintPackageLock); err != nil {
 		return err
 	}
@@ -183,13 +189,6 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		return err
 	}
 
-	requireArg := func(text, name, path string) (string, error) {
-		match := regexp.MustCompile(`(?m)^ARG ` + regexp.QuoteMeta(name) + `=(.+)$`).FindStringSubmatch(text)
-		if match == nil {
-			return "", fmt.Errorf("unable to extract %s from %s", name, path)
-		}
-		return strings.TrimSpace(match[1]), nil
-	}
 	requireYAMLKey := func(text, name, path string) (string, error) {
 		match := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(name) + `:\s*(.+)$`).FindStringSubmatch(text)
 		if match == nil {
@@ -243,77 +242,6 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		for i := range actual {
 			if actual[i] != expected[i] {
 				return fmt.Errorf("%s package set in %s changed.\nexpected: %v\nactual:   %v", label, path, expected, actual)
-			}
-		}
-		return nil
-	}
-	requireRegex := func(text, pattern, label, path string) (*regexp.Regexp, []string, error) {
-		re := regexp.MustCompile(pattern)
-		match := re.FindStringSubmatch(text)
-		if match == nil {
-			return nil, nil, fmt.Errorf("%s in %s must match %q", label, path, pattern)
-		}
-		return re, match, nil
-	}
-	requireDelimitedText := func(text, start, end, label, path string) (string, error) {
-		startIndex := strings.Index(text, start)
-		if startIndex < 0 {
-			return "", fmt.Errorf("%s in %s must start with %q", label, path, start)
-		}
-		bodyStart := startIndex + len(start)
-		endIndex := strings.Index(text[bodyStart:], end)
-		if endIndex < 0 {
-			return "", fmt.Errorf("%s in %s must end with %q", label, path, end)
-		}
-		return text[bodyStart : bodyStart+endIndex], nil
-	}
-	requireOrderedText := func(text, label, path string, needles []string) error {
-		offset := 0
-		for _, needle := range needles {
-			index := strings.Index(text[offset:], needle)
-			if index < 0 {
-				return fmt.Errorf("%s in %s must contain %q after the previous required step", label, path, needle)
-			}
-			offset += index + len(needle)
-		}
-		return nil
-	}
-	rejectInstallScriptAptPackages := func(text, path string, disallowedPackages ...string) error {
-		scanText := strings.ReplaceAll(text, "\\\n", " ")
-		disallowed := map[string]struct{}{}
-		for _, pkg := range disallowedPackages {
-			disallowed[pkg] = struct{}{}
-		}
-		tokenREs := []struct {
-			label string
-			re    *regexp.Regexp
-		}{
-			{
-				label: "append_unique_apt",
-				re:    regexp.MustCompile(`(?m)^\s*append_unique_apt\s+([^\n#]+)`),
-			},
-			{
-				label: "apt_missing",
-				re:    regexp.MustCompile(`(?m)^\s*apt_missing\+\=\(([^)]*)\)`),
-			},
-			{
-				label: "apt-get install",
-				re:    regexp.MustCompile(`(?m)(?:^|&&)\s*(?:sudo\s+)?apt-get\s+install(?:\s+-[A-Za-z0-9-]+)*\s+([^\n#]+)`),
-			},
-		}
-		for _, tokenRE := range tokenREs {
-			for _, match := range tokenRE.re.FindAllStringSubmatch(scanText, -1) {
-				for _, field := range strings.Fields(match[1]) {
-					token := strings.Trim(field, `"'`)
-					for _, separator := range []string{"=", ":", "/"} {
-						if index := strings.Index(token, separator); index >= 0 {
-							token = token[:index]
-						}
-					}
-					if _, ok := disallowed[token]; ok {
-						return fmt.Errorf("%s must not add %s to the Linux apt package set through %s", path, token, tokenRE.label)
-					}
-				}
 			}
 		}
 		return nil
@@ -439,29 +367,6 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		}
 		return result, nil
 	}
-	requireNoRegistryBootstrapMCP := func(text, path string) error {
-		disallowedFragments := []string{
-			"npx",
-			"npm exec",
-			"pnpm dlx",
-			"yarn dlx",
-			"bunx",
-			"@upstash/context7-mcp",
-			"exa-mcp-server",
-		}
-		lines := strings.Split(text, "\n")
-		for _, line := range lines {
-			line = tomlsubset.StripComment(line)
-			lower := strings.ToLower(line)
-			for _, fragment := range disallowedFragments {
-				if strings.Contains(lower, fragment) {
-					return fmt.Errorf("%s must not seed mutable registry-backed MCP commands; found %q", path, line)
-				}
-			}
-		}
-		return nil
-	}
-
 	runtimeBaseImage, err := requireArg(runtimeDockerfile, "NODE_BASE_IMAGE", cfg.RuntimeDockerfilePath)
 	if err != nil {
 		return err
@@ -651,141 +556,17 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if !pinnedReleaseTagPattern.MatchString(validatorDeadcodeVersion) {
 		return fmt.Errorf("DEADCODE_VERSION must be an exact pinned release, found %q", validatorDeadcodeVersion)
 	}
-	validatorMarkdownlintVersion, err := requireArg(validatorDockerfile, "MARKDOWNLINT_VERSION", cfg.ValidatorDockerfilePath)
-	if err != nil {
-		return err
-	}
-	if !regexp.MustCompile(`^0\.\d+\.\d+$`).MatchString(validatorMarkdownlintVersion) {
-		return fmt.Errorf("MARKDOWNLINT_VERSION must be an exact pinned release, found %q", validatorMarkdownlintVersion)
-	}
-	markdownlintDependency, ok := markdownlintPackageJSON.Dependencies["markdownlint-cli"]
-	if !ok {
-		return fmt.Errorf("%s must depend on markdownlint-cli", markdownlintPackageJSONPath)
-	}
-	if markdownlintDependency != validatorMarkdownlintVersion {
-		return fmt.Errorf("markdownlint-cli version must match between %s and %s; found %q and %q", markdownlintPackageJSONPath, cfg.ValidatorDockerfilePath, markdownlintDependency, validatorMarkdownlintVersion)
-	}
-	markdownlintLockRoot, ok := markdownlintPackageLock.Packages[""]
-	if !ok {
-		return fmt.Errorf("%s must include the root package lock entry", markdownlintPackageLockPath)
-	}
-	if markdownlintLockRoot.Dependencies["markdownlint-cli"] != validatorMarkdownlintVersion {
-		return fmt.Errorf("markdownlint-cli version must match between %s and %s; found %q and %q", markdownlintPackageLockPath, cfg.ValidatorDockerfilePath, markdownlintLockRoot.Dependencies["markdownlint-cli"], validatorMarkdownlintVersion)
-	}
-	markdownlintLockPackage, ok := markdownlintPackageLock.Packages["node_modules/markdownlint-cli"]
-	if !ok {
-		return fmt.Errorf("%s must lock node_modules/markdownlint-cli", markdownlintPackageLockPath)
-	}
-	if markdownlintLockPackage.Version != validatorMarkdownlintVersion {
-		return fmt.Errorf("locked markdownlint-cli package version must match %s; found %q and %q", cfg.ValidatorDockerfilePath, markdownlintLockPackage.Version, validatorMarkdownlintVersion)
-	}
-	_, installMarkdownlintVersionMatch, err := requireRegex(installDevToolsScript, `(?m)^readonly MARKDOWNLINT_VERSION="([0-9]+\.[0-9]+\.[0-9]+)"$`, "install-dev-tools markdownlint version", installDevToolsScriptPath)
-	if err != nil {
-		return err
-	}
-	if installMarkdownlintVersionMatch[1] != validatorMarkdownlintVersion {
-		return fmt.Errorf("MARKDOWNLINT_VERSION must match between %s and %s; found %q and %q", installDevToolsScriptPath, cfg.ValidatorDockerfilePath, installMarkdownlintVersionMatch[1], validatorMarkdownlintVersion)
-	}
-	_, markdownlintNodeFloorMatch, err := requireRegex(installDevToolsScript, `(?m)^readonly MARKDOWNLINT_NODE_VERSION_MINIMUM="([0-9]+\.[0-9]+\.[0-9]+)"$`, "install-dev-tools markdownlint Node floor", installDevToolsScriptPath)
-	if err != nil {
-		return err
-	}
-	if markdownlintNodeFloorMatch[1] != "22.12.0" {
-		return fmt.Errorf("MARKDOWNLINT_NODE_VERSION_MINIMUM in %s must be 22.12.0 for markdownlint-cli@%s, found %q", installDevToolsScriptPath, validatorMarkdownlintVersion, markdownlintNodeFloorMatch[1])
-	}
-	if err := rejectInstallScriptAptPackages(installDevToolsScript, installDevToolsScriptPath, "nodejs", "npm"); err != nil {
-		return err
-	}
-	if !strings.Contains(installDevToolsScript, "if [[ \"${host_os}\" == \"Linux\" ]] && markdownlint_needs_install; then\n  require_markdownlint_node\n  require_markdownlint_npm\nfi\n\nif [[ ${#missing[@]} -gt 0 ]]; then") {
-		return fmt.Errorf("%s must validate Linux Node.js/npm compatibility before apt installs when markdownlint-cli needs installation", installDevToolsScriptPath)
-	}
-	markdownlintInstallBody, err := requireDelimitedText(
+	if err := validateNodeMarkdownlintPinnedInputs(
+		cfg,
+		validatorDockerfile,
 		installDevToolsScript,
-		"if markdownlint_needs_install; then\n",
-		"\nfi\n\necho \"Done.\"",
-		"markdownlint install block",
+		markdownlintPackageJSON,
+		markdownlintPackageJSONPath,
+		markdownlintPackageLock,
+		markdownlintPackageLockPath,
 		installDevToolsScriptPath,
-	)
-	if err != nil {
+	); err != nil {
 		return err
-	}
-	if err := requireOrderedText(markdownlintInstallBody, "markdownlint install block", installDevToolsScriptPath, []string{
-		"require_markdownlint_node",
-		"require_markdownlint_npm",
-		"npm install -g \"markdownlint-cli@${MARKDOWNLINT_VERSION}\"",
-	}); err != nil {
-		return fmt.Errorf("%s must validate the Node.js floor and npm immediately before installing markdownlint-cli: %w", installDevToolsScriptPath, err)
-	}
-	markdownlintNodeHintBody, err := requireDelimitedText(
-		installDevToolsScript,
-		"markdownlint_node_install_hint() {\n",
-		"\n}\n\nrequire_markdownlint_node()",
-		"markdownlint Node.js upgrade hint",
-		installDevToolsScriptPath,
-	)
-	if err != nil {
-		return err
-	}
-	for _, needle := range []string{
-		"Install Node.js ${MARKDOWNLINT_NODE_VERSION_MINIMUM} or newer before installing markdownlint-cli@${MARKDOWNLINT_VERSION}.",
-		"Homebrew's node package",
-		"NodeSource",
-		"nvm",
-		"asdf",
-		"Ubuntu 24.04's nodejs/npm apt packages are too old for this markdownlint release.",
-		"Then rerun scripts/install-dev-tools.sh.",
-	} {
-		if !strings.Contains(markdownlintNodeHintBody, needle) {
-			return fmt.Errorf("%s must print manual Node.js upgrade instructions before failing markdownlint-cli installation", installDevToolsScriptPath)
-		}
-	}
-	requireMarkdownlintNodeBody, err := requireDelimitedText(
-		installDevToolsScript,
-		"require_markdownlint_node() {\n",
-		"\n}\n\nrequire_markdownlint_npm()",
-		"markdownlint Node.js floor check",
-		installDevToolsScriptPath,
-	)
-	if err != nil {
-		return err
-	}
-	for _, needle := range []string{
-		"no usable node binary was found.\" >&2\n    markdownlint_node_install_hint\n    exit 1",
-		"found ${version}.\" >&2\n    markdownlint_node_install_hint\n    exit 1",
-	} {
-		if !strings.Contains(requireMarkdownlintNodeBody, needle) {
-			return fmt.Errorf("%s must print Node.js upgrade instructions before exiting every markdownlint-cli Node.js floor failure path", installDevToolsScriptPath)
-		}
-	}
-	requireMarkdownlintNPMBody, err := requireDelimitedText(
-		installDevToolsScript,
-		"require_markdownlint_npm() {\n",
-		"\n}\n\nmarkdownlint_needs_install()",
-		"markdownlint npm check",
-		installDevToolsScriptPath,
-	)
-	if err != nil {
-		return err
-	}
-	for _, needle := range []string{
-		"command -v npm &>/dev/null",
-		"requires npm from a Node.js ${MARKDOWNLINT_NODE_VERSION_MINIMUM} or newer installation.\" >&2\n  markdownlint_node_install_hint\n  exit 1",
-	} {
-		if !strings.Contains(requireMarkdownlintNPMBody, needle) {
-			return fmt.Errorf("%s must print Node.js upgrade instructions before exiting the markdownlint-cli npm failure path", installDevToolsScriptPath)
-		}
-	}
-	for _, needle := range []string{
-		`GOBIN=/usr/local/bin go install "golang.org/x/tools/cmd/deadcode@${DEADCODE_VERSION}"`,
-		`COPY tools/markdownlint/package.json tools/markdownlint/package-lock.json /usr/local/lib/workcell-markdownlint/`,
-		`deadcode -h >/dev/null`,
-		`npm ci --prefix /usr/local/lib/workcell-markdownlint --ignore-scripts --omit=dev`,
-		`ln -sf /usr/local/lib/workcell-markdownlint/node_modules/.bin/markdownlint /usr/local/bin/markdownlint`,
-		`markdownlint --version | grep -F "${MARKDOWNLINT_VERSION}" >/dev/null`,
-	} {
-		if !strings.Contains(validatorDockerfile, needle) {
-			return fmt.Errorf("%s must contain %q", cfg.ValidatorDockerfilePath, needle)
-		}
 	}
 	cargoEdition, err := requireTOMLString(cargoManifestText, "edition", cargoManifestPath)
 	if err != nil {
@@ -856,48 +637,8 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		return fmt.Errorf("RUSTUP_INIT_LINUX_ARM64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorRustupSHAArm64)
 	}
 
-	rootPackage, _ := providersPackageLock["packages"].(map[string]any)
-	rootDependencies, _ := rootPackage[""].(map[string]any)
-	expectedDependencies, _ := providersPackageJSON["dependencies"].(map[string]any)
-	actualDependencies, _ := rootDependencies["dependencies"].(map[string]any)
-	if len(actualDependencies) != len(expectedDependencies) {
-		return errors.New("runtime/container/providers/package-lock.json root dependencies do not match package.json")
-	}
-	for name, expected := range expectedDependencies {
-		if actualDependencies[name] != expected {
-			return errors.New("runtime/container/providers/package-lock.json root dependencies do not match package.json")
-		}
-	}
-	for packageName, expectedVersionAny := range expectedDependencies {
-		expectedVersion, _ := expectedVersionAny.(string)
-		pkgEntry, ok := rootPackage["node_modules/"+packageName].(map[string]any)
-		if !ok {
-			return fmt.Errorf("missing pinned provider package entry for %s", packageName)
-		}
-		if version, _ := pkgEntry["version"].(string); version != expectedVersion {
-			return fmt.Errorf("pinned provider package %s is %s, expected %s", packageName, version, expectedVersion)
-		}
-		if integrity, _ := pkgEntry["integrity"].(string); integrity == "" {
-			return fmt.Errorf("pinned provider package %s is missing an integrity hash", packageName)
-		}
-		if resolved, _ := pkgEntry["resolved"].(string); !strings.HasPrefix(resolved, "https://registry.npmjs.org/") {
-			return fmt.Errorf("pinned provider package %s uses an unexpected source: %q", packageName, resolved)
-		}
-	}
-	for packagePath, rawEntry := range rootPackage {
-		if packagePath == "" {
-			continue
-		}
-		entry, _ := rawEntry.(map[string]any)
-		if link, _ := entry["link"].(bool); link {
-			return fmt.Errorf("linked npm dependencies are not allowed in the provider lockfile: %s", packagePath)
-		}
-		if integrity, _ := entry["integrity"].(string); integrity == "" {
-			return fmt.Errorf("provider lockfile entry is missing integrity data: %s", packagePath)
-		}
-		if resolved, _ := entry["resolved"].(string); !strings.HasPrefix(resolved, "https://registry.npmjs.org/") {
-			return fmt.Errorf("provider lockfile entry uses an unexpected source (%s): %q", packagePath, resolved)
-		}
+	if err := validateNodeProviderLock(providersPackageJSON, providersPackageLock); err != nil {
+		return err
 	}
 
 	ciBuildxVersion, err := requireYAMLKey(ciWorkflow, "WORKCELL_BUILDX_VERSION", ".github/workflows/ci.yml")
@@ -1504,6 +1245,48 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	}
 	if err := requireNoRegistryBootstrapMCP(codexMCPConfigText, cfg.CodexMCPConfigPath); err != nil {
 		return err
+	}
+	return nil
+}
+
+func requireArg(text, name, path string) (string, error) {
+	match := regexp.MustCompile(`(?m)^ARG ` + regexp.QuoteMeta(name) + `=(.+)$`).FindStringSubmatch(text)
+	if match == nil {
+		return "", fmt.Errorf("unable to extract %s from %s", name, path)
+	}
+	return strings.TrimSpace(match[1]), nil
+}
+
+func requireRegex(text, pattern, label, path string) (*regexp.Regexp, []string, error) {
+	re := regexp.MustCompile(pattern)
+	match := re.FindStringSubmatch(text)
+	if match == nil {
+		return nil, nil, fmt.Errorf("%s in %s must match %q", label, path, pattern)
+	}
+	return re, match, nil
+}
+
+func requireDelimitedText(text, start, end, label, path string) (string, error) {
+	startIndex := strings.Index(text, start)
+	if startIndex < 0 {
+		return "", fmt.Errorf("%s in %s must start with %q", label, path, start)
+	}
+	bodyStart := startIndex + len(start)
+	endIndex := strings.Index(text[bodyStart:], end)
+	if endIndex < 0 {
+		return "", fmt.Errorf("%s in %s must end with %q", label, path, end)
+	}
+	return text[bodyStart : bodyStart+endIndex], nil
+}
+
+func requireOrderedText(text, label, path string, needles []string) error {
+	offset := 0
+	for _, needle := range needles {
+		index := strings.Index(text[offset:], needle)
+		if index < 0 {
+			return fmt.Errorf("%s in %s must contain %q after the previous required step", label, path, needle)
+		}
+		offset += index + len(needle)
 	}
 	return nil
 }

--- a/internal/metadatautil/pinnedinputs_node.go
+++ b/internal/metadatautil/pinnedinputs_node.go
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/tomlsubset"
+)
+
+func validateNodeMarkdownlintPinnedInputs(
+	cfg PinnedInputsConfig,
+	validatorDockerfile string,
+	installDevToolsScript string,
+	markdownlintPackageJSON markdownlintPackageJSON,
+	markdownlintPackageJSONPath string,
+	markdownlintPackageLock markdownlintPackageLock,
+	markdownlintPackageLockPath string,
+	installDevToolsScriptPath string,
+) error {
+	validatorMarkdownlintVersion, err := requireArg(validatorDockerfile, "MARKDOWNLINT_VERSION", cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return err
+	}
+	if !regexp.MustCompile(`^0\.\d+\.\d+$`).MatchString(validatorMarkdownlintVersion) {
+		return fmt.Errorf("MARKDOWNLINT_VERSION must be an exact pinned release, found %q", validatorMarkdownlintVersion)
+	}
+	markdownlintDependency, ok := markdownlintPackageJSON.Dependencies["markdownlint-cli"]
+	if !ok {
+		return fmt.Errorf("%s must depend on markdownlint-cli", markdownlintPackageJSONPath)
+	}
+	if markdownlintDependency != validatorMarkdownlintVersion {
+		return fmt.Errorf("markdownlint-cli version must match between %s and %s; found %q and %q", markdownlintPackageJSONPath, cfg.ValidatorDockerfilePath, markdownlintDependency, validatorMarkdownlintVersion)
+	}
+	markdownlintLockRoot, ok := markdownlintPackageLock.Packages[""]
+	if !ok {
+		return fmt.Errorf("%s must include the root package lock entry", markdownlintPackageLockPath)
+	}
+	if markdownlintLockRoot.Dependencies["markdownlint-cli"] != validatorMarkdownlintVersion {
+		return fmt.Errorf("markdownlint-cli version must match between %s and %s; found %q and %q", markdownlintPackageLockPath, cfg.ValidatorDockerfilePath, markdownlintLockRoot.Dependencies["markdownlint-cli"], validatorMarkdownlintVersion)
+	}
+	markdownlintLockPackage, ok := markdownlintPackageLock.Packages["node_modules/markdownlint-cli"]
+	if !ok {
+		return fmt.Errorf("%s must lock node_modules/markdownlint-cli", markdownlintPackageLockPath)
+	}
+	if markdownlintLockPackage.Version != validatorMarkdownlintVersion {
+		return fmt.Errorf("locked markdownlint-cli package version must match %s; found %q and %q", cfg.ValidatorDockerfilePath, markdownlintLockPackage.Version, validatorMarkdownlintVersion)
+	}
+	_, installMarkdownlintVersionMatch, err := requireRegex(installDevToolsScript, `(?m)^readonly MARKDOWNLINT_VERSION="([0-9]+\.[0-9]+\.[0-9]+)"$`, "install-dev-tools markdownlint version", installDevToolsScriptPath)
+	if err != nil {
+		return err
+	}
+	if installMarkdownlintVersionMatch[1] != validatorMarkdownlintVersion {
+		return fmt.Errorf("MARKDOWNLINT_VERSION must match between %s and %s; found %q and %q", installDevToolsScriptPath, cfg.ValidatorDockerfilePath, installMarkdownlintVersionMatch[1], validatorMarkdownlintVersion)
+	}
+	_, markdownlintNodeFloorMatch, err := requireRegex(installDevToolsScript, `(?m)^readonly MARKDOWNLINT_NODE_VERSION_MINIMUM="([0-9]+\.[0-9]+\.[0-9]+)"$`, "install-dev-tools markdownlint Node floor", installDevToolsScriptPath)
+	if err != nil {
+		return err
+	}
+	if markdownlintNodeFloorMatch[1] != "22.12.0" {
+		return fmt.Errorf("MARKDOWNLINT_NODE_VERSION_MINIMUM in %s must be 22.12.0 for markdownlint-cli@%s, found %q", installDevToolsScriptPath, validatorMarkdownlintVersion, markdownlintNodeFloorMatch[1])
+	}
+	if err := rejectInstallScriptAptPackages(installDevToolsScript, installDevToolsScriptPath, "nodejs", "npm"); err != nil {
+		return err
+	}
+	if !strings.Contains(installDevToolsScript, "if [[ \"${host_os}\" == \"Linux\" ]] && markdownlint_needs_install; then\n  require_markdownlint_node\n  require_markdownlint_npm\nfi\n\nif [[ ${#missing[@]} -gt 0 ]]; then") {
+		return fmt.Errorf("%s must validate Linux Node.js/npm compatibility before apt installs when markdownlint-cli needs installation", installDevToolsScriptPath)
+	}
+	markdownlintInstallBody, err := requireDelimitedText(
+		installDevToolsScript,
+		"if markdownlint_needs_install; then\n",
+		"\nfi\n\necho \"Done.\"",
+		"markdownlint install block",
+		installDevToolsScriptPath,
+	)
+	if err != nil {
+		return err
+	}
+	if err := requireOrderedText(markdownlintInstallBody, "markdownlint install block", installDevToolsScriptPath, []string{
+		"require_markdownlint_node",
+		"require_markdownlint_npm",
+		"npm install -g \"markdownlint-cli@${MARKDOWNLINT_VERSION}\"",
+	}); err != nil {
+		return fmt.Errorf("%s must validate the Node.js floor and npm immediately before installing markdownlint-cli: %w", installDevToolsScriptPath, err)
+	}
+	markdownlintNodeHintBody, err := requireDelimitedText(
+		installDevToolsScript,
+		"markdownlint_node_install_hint() {\n",
+		"\n}\n\nrequire_markdownlint_node()",
+		"markdownlint Node.js upgrade hint",
+		installDevToolsScriptPath,
+	)
+	if err != nil {
+		return err
+	}
+	for _, needle := range []string{
+		"Install Node.js ${MARKDOWNLINT_NODE_VERSION_MINIMUM} or newer before installing markdownlint-cli@${MARKDOWNLINT_VERSION}.",
+		"Homebrew's node package",
+		"NodeSource",
+		"nvm",
+		"asdf",
+		"Ubuntu 24.04's nodejs/npm apt packages are too old for this markdownlint release.",
+		"Then rerun scripts/install-dev-tools.sh.",
+	} {
+		if !strings.Contains(markdownlintNodeHintBody, needle) {
+			return fmt.Errorf("%s must print manual Node.js upgrade instructions before failing markdownlint-cli installation", installDevToolsScriptPath)
+		}
+	}
+	requireMarkdownlintNodeBody, err := requireDelimitedText(
+		installDevToolsScript,
+		"require_markdownlint_node() {\n",
+		"\n}\n\nrequire_markdownlint_npm()",
+		"markdownlint Node.js floor check",
+		installDevToolsScriptPath,
+	)
+	if err != nil {
+		return err
+	}
+	for _, needle := range []string{
+		"no usable node binary was found.\" >&2\n    markdownlint_node_install_hint\n    exit 1",
+		"found ${version}.\" >&2\n    markdownlint_node_install_hint\n    exit 1",
+	} {
+		if !strings.Contains(requireMarkdownlintNodeBody, needle) {
+			return fmt.Errorf("%s must print Node.js upgrade instructions before exiting every markdownlint-cli Node.js floor failure path", installDevToolsScriptPath)
+		}
+	}
+	requireMarkdownlintNPMBody, err := requireDelimitedText(
+		installDevToolsScript,
+		"require_markdownlint_npm() {\n",
+		"\n}\n\nmarkdownlint_needs_install()",
+		"markdownlint npm check",
+		installDevToolsScriptPath,
+	)
+	if err != nil {
+		return err
+	}
+	for _, needle := range []string{
+		"command -v npm &>/dev/null",
+		"requires npm from a Node.js ${MARKDOWNLINT_NODE_VERSION_MINIMUM} or newer installation.\" >&2\n  markdownlint_node_install_hint\n  exit 1",
+	} {
+		if !strings.Contains(requireMarkdownlintNPMBody, needle) {
+			return fmt.Errorf("%s must print Node.js upgrade instructions before exiting the markdownlint-cli npm failure path", installDevToolsScriptPath)
+		}
+	}
+	for _, needle := range []string{
+		`GOBIN=/usr/local/bin go install "golang.org/x/tools/cmd/deadcode@${DEADCODE_VERSION}"`,
+		`COPY tools/markdownlint/package.json tools/markdownlint/package-lock.json /usr/local/lib/workcell-markdownlint/`,
+		`deadcode -h >/dev/null`,
+		`npm ci --prefix /usr/local/lib/workcell-markdownlint --ignore-scripts --omit=dev`,
+		`ln -sf /usr/local/lib/workcell-markdownlint/node_modules/.bin/markdownlint /usr/local/bin/markdownlint`,
+		`markdownlint --version | grep -F "${MARKDOWNLINT_VERSION}" >/dev/null`,
+	} {
+		if !strings.Contains(validatorDockerfile, needle) {
+			return fmt.Errorf("%s must contain %q", cfg.ValidatorDockerfilePath, needle)
+		}
+	}
+	return nil
+}
+
+func validateNodeProviderLock(providersPackageJSON, providersPackageLock map[string]any) error {
+	rootPackage, _ := providersPackageLock["packages"].(map[string]any)
+	rootDependencies, _ := rootPackage[""].(map[string]any)
+	expectedDependencies, _ := providersPackageJSON["dependencies"].(map[string]any)
+	actualDependencies, _ := rootDependencies["dependencies"].(map[string]any)
+	if len(actualDependencies) != len(expectedDependencies) {
+		return errors.New("runtime/container/providers/package-lock.json root dependencies do not match package.json")
+	}
+	for name, expected := range expectedDependencies {
+		if actualDependencies[name] != expected {
+			return errors.New("runtime/container/providers/package-lock.json root dependencies do not match package.json")
+		}
+	}
+	for packageName, expectedVersionAny := range expectedDependencies {
+		expectedVersion, _ := expectedVersionAny.(string)
+		pkgEntry, ok := rootPackage["node_modules/"+packageName].(map[string]any)
+		if !ok {
+			return fmt.Errorf("missing pinned provider package entry for %s", packageName)
+		}
+		if version, _ := pkgEntry["version"].(string); version != expectedVersion {
+			return fmt.Errorf("pinned provider package %s is %s, expected %s", packageName, version, expectedVersion)
+		}
+		if integrity, _ := pkgEntry["integrity"].(string); integrity == "" {
+			return fmt.Errorf("pinned provider package %s is missing an integrity hash", packageName)
+		}
+		if resolved, _ := pkgEntry["resolved"].(string); !strings.HasPrefix(resolved, "https://registry.npmjs.org/") {
+			return fmt.Errorf("pinned provider package %s uses an unexpected source: %q", packageName, resolved)
+		}
+	}
+	for packagePath, rawEntry := range rootPackage {
+		if packagePath == "" {
+			continue
+		}
+		entry, _ := rawEntry.(map[string]any)
+		if link, _ := entry["link"].(bool); link {
+			return fmt.Errorf("linked npm dependencies are not allowed in the provider lockfile: %s", packagePath)
+		}
+		if integrity, _ := entry["integrity"].(string); integrity == "" {
+			return fmt.Errorf("provider lockfile entry is missing integrity data: %s", packagePath)
+		}
+		if resolved, _ := entry["resolved"].(string); !strings.HasPrefix(resolved, "https://registry.npmjs.org/") {
+			return fmt.Errorf("provider lockfile entry uses an unexpected source (%s): %q", packagePath, resolved)
+		}
+	}
+	return nil
+}
+
+func rejectInstallScriptAptPackages(text, path string, disallowedPackages ...string) error {
+	scanText := strings.ReplaceAll(text, "\\\n", " ")
+	disallowed := map[string]struct{}{}
+	for _, pkg := range disallowedPackages {
+		disallowed[pkg] = struct{}{}
+	}
+	tokenREs := []struct {
+		label string
+		re    *regexp.Regexp
+	}{
+		{
+			label: "append_unique_apt",
+			re:    regexp.MustCompile(`(?m)^\s*append_unique_apt\s+([^\n#]+)`),
+		},
+		{
+			label: "apt_missing",
+			re:    regexp.MustCompile(`(?m)^\s*apt_missing\+\=\(([^)]*)\)`),
+		},
+		{
+			label: "apt-get install",
+			re:    regexp.MustCompile(`(?m)(?:^|&&)\s*(?:sudo\s+)?apt-get\s+install(?:\s+-[A-Za-z0-9-]+)*\s+([^\n#]+)`),
+		},
+	}
+	for _, tokenRE := range tokenREs {
+		for _, match := range tokenRE.re.FindAllStringSubmatch(scanText, -1) {
+			for _, field := range strings.Fields(match[1]) {
+				token := strings.Trim(field, `"'`)
+				for _, separator := range []string{"=", ":", "/"} {
+					if index := strings.Index(token, separator); index >= 0 {
+						token = token[:index]
+					}
+				}
+				if _, ok := disallowed[token]; ok {
+					return fmt.Errorf("%s must not add %s to the Linux apt package set through %s", path, token, tokenRE.label)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func requireNoRegistryBootstrapMCP(text, path string) error {
+	disallowedFragments := []string{
+		"npx",
+		"npm exec",
+		"pnpm dlx",
+		"yarn dlx",
+		"bunx",
+		"@upstash/context7-mcp",
+		"exa-mcp-server",
+	}
+	lines := strings.Split(text, "\n")
+	for _, line := range lines {
+		line = tomlsubset.StripComment(line)
+		lower := strings.ToLower(line)
+		for _, fragment := range disallowedFragments {
+			if strings.Contains(lower, fragment) {
+				return fmt.Errorf("%s must not seed mutable registry-backed MCP commands; found %q", path, line)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Record the D3 scope narrowing decision for residual static checks.
- Extract Node and npm pinned-input validators from pinnedinputs.go into internal/metadatautil/pinnedinputs_node.go.

## Validation
- ./scripts/pre-merge.sh --profile pr-parity
- ./scripts/check-pr-shape.sh --base-ref origin/main --head-ref d6a/pinnedinputs-split-1 --max-lines 1200 --max-files 25 --max-areas 8 --max-binaries 0

## Review
- Draft for the Codex review loop.
