### PR TITLE
Record criterion 6/7 amendments: defer B2 and E6 post-1.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,9 +143,17 @@ improvement tracks below; `G` items are the 1.0 contract-and-operations track.
    plus an explicit recorded scope decision instead of a support claim.
 5. Operations: install, upgrade, uninstall, rollback, `--gc`, and support
    bundles (G2) are proven end to end on the release matrix (G3).
-6. Release assurance: dual-control releases (B2), mutation-score gating
-   (B3), and SLSA L3 gaps closed or explicitly dispositioned (B1) are in
-   place. **[Amended 2026-07-09, recorded maintainer decision:]** the automated
+6. Release assurance: mutation-score gating (B3) and SLSA L3 gaps closed or
+   explicitly dispositioned (B1) are in place. **[Amended 2026-07-09, recorded
+   maintainer decision:]** dual-control releases (B2) are **deferred to
+   post-1.0** because Workcell has no second trusted maintainer today. For
+   1.0, the documented single-maintainer controls in
+   [`docs/releasing.md`](docs/releasing.md) are the compensating release
+   control: signed commits, protected `main` with strict CI, required release
+   approval, admin-merge audit trail, and public single-maintainer release
+   comments recording the version, exact head SHA, timestamp, and merge path.
+   Tradeoff recorded honestly: 1.0 has no independent second approver.
+   **[Amended 2026-07-09, recorded maintainer decision:]** the automated
    real-boundary certification lane (B6, a self-hosted Apple-Silicon CI runner)
    and the OpenSSF Best Practices badge (B7 part 1) are **deferred to post-1.0**
    — no funding or hosting for a self-hosted runner is available, and the B7
@@ -156,9 +164,15 @@ improvement tracks below; `G` items are the 1.0 contract-and-operations track.
    live Colima/Apple-Silicon boundary is exercised by the maintainer locally,
    not continuously in hosted CI (which runs only a Docker smoke lane on a
    `ubuntu-latest` runner).
-7. Adoption surface: tiered docs (E1), architecture diagrams (E2), a
-   rendered docs site with demos and reproducible benchmarks (E6), and the
-   support-tier and diagnostics guides (E3) are live.
+7. Adoption surface: tiered docs (E1), architecture diagrams (E2), and the
+   support-tier and diagnostics guides (E3) are live. **[Amended 2026-07-09,
+   recorded maintainer decision:]** the rendered docs site with demos and
+   externally published reproducible benchmarks (E6) is **deferred to post-1.0**.
+   1.0 ships with in-repo markdown docs; C2 benchmark numbers are still captured
+   and published in
+   [`docs/session-startup-benchmarks.md`](docs/session-startup-benchmarks.md)
+   during Batch 3 local-operator certification. Tradeoff recorded honestly:
+   1.0 ships without the external rendered site or demo package.
 8. Readiness review: a cross-lens 1.0 gate review (G4) — product,
    enterprise/security, adapter-maintainer, validation, docs/contract, and
    release lenses — records no unresolved P0/P1 findings, and every support
@@ -168,11 +182,17 @@ The G4 evidence package and its go/no-go checklist live in
 [`docs/1.0-readiness-review-draft.md`](docs/1.0-readiness-review-draft.md); the
 B6 (item 6) real-boundary certification lane disposition options are in
 [`docs/b6-disposition-options-draft.md`](docs/b6-disposition-options-draft.md).
-**Recorded maintainer decisions (2026-07-09):** B6 — defer the automated
-Apple-Silicon runner (no funding); certify both boundaries by the local-operator
-discipline on the maintainer's host (criterion 6, amended above). B7 — defer the
-third-party boundary audit and OpenSSF badge to post-1.0 (criterion 2, amended
-above). See the readiness review for the recorded G4 checklist state.
+**Recorded maintainer decisions (2026-07-09):** B2 — defer dual-control
+releases because no second trusted maintainer exists; use the single-maintainer
+controls in [`docs/releasing.md`](docs/releasing.md) for 1.0 (criterion 6,
+amended above). B6 — defer the automated Apple-Silicon runner (no funding);
+certify both boundaries by the local-operator discipline on the maintainer's
+host (criterion 6, amended above). B7 — defer the third-party boundary audit and
+OpenSSF badge to post-1.0 (criterion 2, amended above). E6 — defer the rendered
+docs site, demos, and external benchmark publication; 1.0 ships with in-repo
+markdown docs while C2 benchmark numbers are captured and published through
+Batch 3 local-operator certification (criterion 7, amended above). See the
+readiness review for the recorded G4 checklist state.
 
 ### Milestone Train
 
@@ -185,10 +205,10 @@ live in
 |---|---|---|
 | v0.12 | Containment and hygiene | A2, A7, B3, B4, B5, D1, D2, E3, E4 |
 | v0.13 | Boundary depth and stability | A1, A3, A4, B1, C5, D8, E1, E2, F3, G1 (inventory) |
-| v0.14 | Platform, speed, and adoption | C1, C2, B8, B9, D3 (start), D4, E5, E6, E7, G2, Antigravity Tier 1 adapter track |
-| v0.15 | Enterprise evidence and release assurance | A5, A6, B2, C3, D5, D7, F1, G3 |
+| v0.14 | Platform, speed, and adoption | C1, C2, B8, B9, D3 (start), D4, E5, E7, G2, Antigravity Tier 1 adapter track |
+| v0.15 | Enterprise evidence and release assurance | A5, A6, C3, D5, D7, F1, G3 |
 | v1.0-rc | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
-| post-1.0 | Reach expansion | Phases 13–19 remainder, C4, B6 (automated real-boundary lane), B7 (badge + audit completion), F2 |
+| post-1.0 | Reach expansion | Phases 13–19 remainder, C4, B2 (dual-control releases), B6 (automated real-boundary lane), B7 (badge + audit completion), E6 (rendered docs site + external demos), F2 |
 
 Phase 13 (Linux `amd64` `local_compat` certification candidate) may land
 before or after 1.0 depending on certification evidence; it does not gate
@@ -478,7 +498,9 @@ the remaining gaps between that posture and the level enterprises will ask a
 security-boundary product to prove.
 
 - **B1 (now, M):** SLSA v1.0 gap analysis published in the provenance docs
-- **B2 (next, M):** dual-control release approval before 1.0
+- **B2 (post-1.0, M):** dual-control release approval — deferred by the
+  2026-07-09 criterion-6 amendment because no second trusted maintainer exists;
+  1.0 uses the documented single-maintainer controls in `docs/releasing.md`
 - **B3 (now, M):** scheduled mutation-score lane with published score and
   baseline regression gate, beyond today's release-preflight-only run
 - **B4 (now, S):** centralized tool pins and a permitted-GitHub-actions
@@ -548,8 +570,9 @@ monolithic Rust interception library, a 8,910-line launcher script, a
   labels, freshness markers
 - **E5 (next, M):** injection-policy annotated schema with complete
   per-provider examples
-- **E6 (next, M):** adoption growth kit — docs site, terminal demos, Homebrew
-  tap, isolation-model architecture post backed by benchmarks
+- **E6 (post-1.0, M):** adoption growth kit — docs site, terminal demos,
+  Homebrew tap, isolation-model architecture post backed by benchmarks;
+  deferred by the 2026-07-09 criterion-7 amendment
 - **E7 (next, S):** contributor runbook depth and substantive adapter READMEs
 
 ### Track F: Enterprise And Standards Alignment

--- a/docs/1.0-readiness-review-draft.md
+++ b/docs/1.0-readiness-review-draft.md
@@ -121,7 +121,16 @@ Grounded in `ROADMAP.md` Non-Goals plus verification of what is on `main`:
   deferred post-1.0 pending the B6 certification lane.
 - **Antigravity is fail-closed scaffold**, not a support claim. 1.0 may ship
   with the scaffold plus a recorded scope decision (ROADMAP criterion 4).
-- **B2 dual-control release approval:** not found on `main`.
+- **B2 dual-control releases:** deferred to post-1.0 by recorded maintainer
+  decision (2026-07-09) — single-maintainer releases are the current mode.
+  Compensating controls (signed commits, protected main, admin-merge audit
+  trail, public single-maintainer release comments) are documented in
+  `docs/releasing.md` and sufficient for 1.0.
+- **E6 rendered docs site and external demos:** deferred to post-1.0 by recorded
+  maintainer decision (2026-07-09) — 1.0 ships with in-repo markdown docs. C2
+  benchmark numbers must still be captured and published in
+  `docs/session-startup-benchmarks.md` during Batch 3 local-operator
+  certification (live-host capture, not placeholder).
 - **B6 real-boundary certification lane:** **deferred to post-1.0 by recorded
   maintainer decision (2026-07-09)** — no funding/hosting for a self-hosted
   Apple-Silicon runner. Criterion 6 is amended accordingly (see `ROADMAP.md`);
@@ -169,17 +178,27 @@ the maintainer records the outcome.
 - [ ] **Platform** strict + compat certified on the release matrix; C1 decision
       recorded (done); C2 latency numbers captured/published; C3 parallel
       sessions verified on the strict path (criterion 3).
+- [ ] **Adoption surface** — tiered docs (E1, merged), architecture diagrams
+      (E2, merged), and support guides (E3, merged) are the 1.0 gate. **E6 is
+      DEFERRED to post-1.0 (2026-07-09 maintainer decision)** — 1.0 ships with
+      in-repo markdown docs; C2 benchmark numbers must still be published to
+      `docs/session-startup-benchmarks.md` via local-operator certification
+      during Batch 3. See the amended criterion 7 in `ROADMAP.md`.
 - [ ] **Operations** G2 proven; G3 day-two lifecycle proven end-to-end on the
       release matrix (criterion 5). G3's CI-automatable core is merged, but the
       full-matrix proof has a recorded local-operator-certification remainder
       (verified install against a real published release, live `--gc`, live
       launch) — confirm that remainder is certified/accepted before sign-off,
       not just the CI core.
-- [ ] **Release assurance** — B2 dual-control, B3 gating, and B1 SLSA L3 gaps
-      closed or explicitly dispositioned (criterion 6, amended). The B7 OpenSSF
-      badge is no longer a 1.0 gate item — deferred to post-1.0 with the B7 track
-      (2026-07-09 amendment). Note: only the SLSA gaps carry the
-      explicit-disposition allowance.
+- [ ] **Release assurance** — B3 mutation-score gating and B1 SLSA L3 gaps must
+      be closed or explicitly dispositioned (criterion 6). **B2 dual-control
+      releases and B7 OpenSSF badge are deferred to post-1.0** (2026-07-09
+      amendments): B2 because single-maintainer is the current reality
+      (compensating controls documented in `docs/releasing.md`), and B7 with the
+      boundary audit deferral (criterion 2). B6 automated real-boundary lane is
+      also deferred (see the B6 row below); local-operator certification replaces
+      it. The disposition allowances are: B1 SLSA gaps, B2 single-maintainer
+      controls, and B6 local-operator controls.
 - [x] **B6 real-boundary lane — criterion 6 AMENDED (2026-07-09)**. Recorded
       maintainer decision: defer the automated Apple-Silicon runner (no
       funding/hosting) and, in its place, require local-operator certification of

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -50,7 +50,8 @@ The milestone ordering answers the current landscape directly:
 - upstream retires Gemini CLI personal-account tiers in June 2026 →
   the Antigravity Tier 1 adapter track runs inside the 1.0 window (v0.14)
 - enterprises evaluate against OWASP agentic guidance, SIEM-ready export,
-  and SLSA levels → A7, F1, B1/B2 sit on the critical path
+  and SLSA levels → A7, F1, and B1 sit on the 1.0 critical path; B2 is
+  deferred post-1.0 under the 2026-07-09 criterion-6 amendment
 - container-in-sandbox (C4) stays post-1.0: it is a differentiator response,
   not a 1.0 gate, and must not risk the outer boundary
 
@@ -60,10 +61,10 @@ The milestone ordering answers the current landscape directly:
 |---|---|---|
 | v0.12 | Containment and hygiene | A2, A7, B3, B4, B5, D1, D2, E3, E4 |
 | v0.13 | Boundary depth and stability | A1, A3, A4, B1, C5, D8, E1, E2, F3, G1 (inventory) |
-| v0.14 | Platform, speed, and adoption | C1, C2, B8, B9, D3 (start), D4, E5, E6, E7, G2, Antigravity Tier 1 adapter track |
-| v0.15 | Enterprise evidence and release assurance | A5, A6, B2, C3, D5, D7, F1, G3 |
+| v0.14 | Platform, speed, and adoption | C1, C2, B8, B9, D3 (start), D4, E5, E7, G2, Antigravity Tier 1 adapter track |
+| v0.15 | Enterprise evidence and release assurance | A5, A6, C3, D5, D7, F1, G3 |
 | v1.0-rc | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
-| post-1.0 | Reach expansion | Phases 13–19 remainder, C4, B6 (automated real-boundary lane), B7 (badge + audit completion), F2 |
+| post-1.0 | Reach expansion | Phases 13–19 remainder, C4, B2 (dual-control releases), B6 (automated real-boundary lane), B7 (badge + audit completion), E6 (rendered docs site + external demos), F2 |
 
 Items inside a milestone are independently shippable and individually
 reviewable. Later-milestone items may start early when nothing earlier gates
@@ -413,6 +414,11 @@ isolation would be a stronger and lighter boundary than one shared Colima VM.
 
 ### E6: Adoption Growth Kit
 
+**Deferred to post-1.0 (2026-07-09 criterion-7 amendment).** 1.0 ships with
+in-repo markdown docs; C2 benchmark numbers remain required in
+`docs/session-startup-benchmarks.md` during Batch 3 local-operator
+certification. This detail section stays here for continuity of the E6 track.
+
 - Steps: publish a rendered docs site from the existing markdown; record
   asciinema demos for the 5-minute path and one provider quickstart; ship a
   Homebrew tap alongside the formula asset; write the "why a VM boundary"
@@ -482,6 +488,11 @@ shortcut to the Tier 1 evidence bar.
 - Size: M. Dependencies: A1 design informs the endpoint inventory.
 
 ### B2: Dual-Control Release Approval
+
+**Deferred to post-1.0 (2026-07-09 criterion-6 amendment).** Workcell has no
+second trusted maintainer today; 1.0 uses the single-maintainer compensating
+controls documented in `docs/releasing.md` instead. This detail section stays
+here for continuity of the B2 track.
 
 - Steps: add a second release approver identity; require two approvals on
   the release environment; update `docs/releasing.md` including the


### PR DESCRIPTION
## Summary
- Record the 2026-07-09 maintainer decisions amending 1.0 release criteria 6 and 7 in ROADMAP.md, mirroring the B6/B7 amendment pattern:
  - B2 dual-control releases deferred post-1.0 (no second trusted maintainer exists); the documented single-maintainer controls in docs/releasing.md are the compensating release control for 1.0.
  - E6 rendered docs site, demos, and external benchmark publication deferred post-1.0; 1.0 ships in-repo markdown docs, and C2 benchmark numbers must still be captured and published in docs/session-startup-benchmarks.md during Batch 3 local-operator certification.
- Add the previously missing criterion-7 "Adoption surface" row to the §6 go/no-go checklist so no criterion is unlisted at G4 sign-off.
- Sync the milestone table, recorded-decisions paragraph, readiness-review non-claims/§6 rows, and the E6/B2 track sections in the implementation plan.

## Validation
- ./scripts/pre-merge.sh --profile pr-parity
- markdownlint, check-doc-links.sh, codespell clean; cross-reference sweep of every E6/B2/criterion-6/criterion-7 mention.

## Review
- Draft for the Codex review loop.
