### PR TITLE
Add workcell --version (changelog-derived, rc-suffix aware)

### DIFF
--- a/internal/supportbundle/changelog_version_test.go
+++ b/internal/supportbundle/changelog_version_test.go
@@ -17,6 +17,14 @@ func TestChangelogVersionCapturesPreReleaseSuffix(t *testing.T) {
 	if got := changelogVersion(root); got != "v1.0.0-rc.1" {
 		t.Fatalf("changelogVersion = %q, want %q", got, "v1.0.0-rc.1")
 	}
+
+	hyphenRoot := t.TempDir()
+	mustWrite(t, hyphenRoot+"/CHANGELOG.md",
+		"# Changelog\n\n## Unreleased\n\n## v2.0.0-rc-1 - 2026-08-01\n")
+
+	if got := changelogVersion(hyphenRoot); got != "v2.0.0-rc-1" {
+		t.Fatalf("changelogVersion = %q, want %q", got, "v2.0.0-rc-1")
+	}
 }
 
 func TestChangelogVersionFirstReleaseHeadingWins(t *testing.T) {

--- a/internal/supportbundle/changelog_version_test.go
+++ b/internal/supportbundle/changelog_version_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package supportbundle
+
+import (
+	"testing"
+)
+
+func TestChangelogVersionCapturesPreReleaseSuffix(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWrite(t, root+"/CHANGELOG.md",
+		"# Changelog\n\n## Unreleased\n\n## v1.0.0-rc.1 - 2026-07-09\n\n## v0.11.2 - 2026-06-15\n")
+
+	if got := changelogVersion(root); got != "v1.0.0-rc.1" {
+		t.Fatalf("changelogVersion = %q, want %q", got, "v1.0.0-rc.1")
+	}
+}
+
+func TestChangelogVersionFirstReleaseHeadingWins(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWrite(t, root+"/CHANGELOG.md",
+		"# Changelog\n\n## Unreleased\n\n## v0.11.2 - 2026-06-15\n\n## v0.11.1 - 2026-06-15\n")
+
+	if got := changelogVersion(root); got != "v0.11.2" {
+		t.Fatalf("changelogVersion = %q, want %q", got, "v0.11.2")
+	}
+}

--- a/internal/supportbundle/collect.go
+++ b/internal/supportbundle/collect.go
@@ -35,7 +35,7 @@ var providerOrder = []string{
 // changelogVersionRe matches a released `## vX.Y.Z ...` CHANGELOG heading,
 // including semver pre-release suffixes (`## vX.Y.Z-rc.1 ...`), so a release
 // candidate never reports itself as the final release.
-var changelogVersionRe = regexp.MustCompile(`^##\s+(v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?)`)
+var changelogVersionRe = regexp.MustCompile(`^##\s+(v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)`)
 
 // InstallSection captures whether Workcell is installed and on what host.
 type InstallSection struct {

--- a/internal/supportbundle/collect.go
+++ b/internal/supportbundle/collect.go
@@ -32,8 +32,10 @@ var providerOrder = []string{
 	providerid.Antigravity,
 }
 
-// changelogVersionRe matches a released `## vX.Y.Z ...` CHANGELOG heading.
-var changelogVersionRe = regexp.MustCompile(`^##\s+(v[0-9]+\.[0-9]+\.[0-9]+)`)
+// changelogVersionRe matches a released `## vX.Y.Z ...` CHANGELOG heading,
+// including semver pre-release suffixes (`## vX.Y.Z-rc.1 ...`), so a release
+// candidate never reports itself as the final release.
+var changelogVersionRe = regexp.MustCompile(`^##\s+(v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?)`)
 
 // InstallSection captures whether Workcell is installed and on what host.
 type InstallSection struct {

--- a/internal/testkit/workcell_version_test.go
+++ b/internal/testkit/workcell_version_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestWorkcellVersionFlagReadsFirstChangelogVersion(t *testing.T) {
+	t.Parallel()
+
+	changelog := "# Changelog\n\n## Unreleased\n\n## v9.8.7 - 2099-01-01\n\n## v9.9.9 - 2099-02-01\n"
+	workcellPath := writeWorkcellVersionFixture(t, &changelog)
+
+	got := runWorkcellVersion(t, workcellPath)
+	if got != "workcell v9.8.7\n" {
+		t.Fatalf("workcell --version output = %q, want %q", got, "workcell v9.8.7\n")
+	}
+}
+
+func TestWorkcellVersionFlagCapturesPreReleaseSuffix(t *testing.T) {
+	t.Parallel()
+
+	changelog := "# Changelog\n\n## Unreleased\n\n## v1.2.3-rc.1 - 2099-01-01\n\n## v1.2.2 - 2098-12-01\n"
+	workcellPath := writeWorkcellVersionFixture(t, &changelog)
+
+	got := runWorkcellVersion(t, workcellPath)
+	if got != "workcell v1.2.3-rc.1\n" {
+		t.Fatalf("workcell --version output = %q, want %q", got, "workcell v1.2.3-rc.1\n")
+	}
+}
+
+func TestWorkcellVersionFlagReportsUnknownWhenChangelogMissing(t *testing.T) {
+	t.Parallel()
+
+	workcellPath := writeWorkcellVersionFixture(t, nil)
+
+	got := runWorkcellVersion(t, workcellPath)
+	if got != "workcell unknown\n" {
+		t.Fatalf("workcell --version output = %q, want %q", got, "workcell unknown\n")
+	}
+}
+
+func TestWorkcellVersionFlagReportsUnknownWithoutVersionHeading(t *testing.T) {
+	t.Parallel()
+
+	changelog := "# Changelog\n\n## Unreleased\n\n### Changed\n\n- no released version yet\n"
+	workcellPath := writeWorkcellVersionFixture(t, &changelog)
+
+	got := runWorkcellVersion(t, workcellPath)
+	if got != "workcell unknown\n" {
+		t.Fatalf("workcell --version output = %q, want %q", got, "workcell unknown\n")
+	}
+}
+
+func writeWorkcellVersionFixture(tb testing.TB, changelog *string) string {
+	tb.Helper()
+	if runtime.GOOS == "windows" {
+		tb.Skip("scripts/workcell is a POSIX shell entrypoint")
+	}
+
+	sourceRoot := repoRoot(tb)
+	fixtureRoot := tb.TempDir()
+	fixtureScriptsDir := filepath.Join(fixtureRoot, "scripts")
+	if err := os.MkdirAll(fixtureScriptsDir, 0o755); err != nil {
+		tb.Fatal(err)
+	}
+
+	sourceWorkcellPath := filepath.Join(sourceRoot, "scripts", "workcell")
+	launcher, err := os.ReadFile(sourceWorkcellPath)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	fixtureWorkcellPath := filepath.Join(fixtureScriptsDir, "workcell")
+	if err := os.WriteFile(fixtureWorkcellPath, launcher, 0o755); err != nil {
+		tb.Fatal(err)
+	}
+
+	if err := os.Symlink(filepath.Join(sourceRoot, "scripts", "lib"), filepath.Join(fixtureScriptsDir, "lib")); err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(sourceRoot, "runtime"), filepath.Join(fixtureRoot, "runtime")); err != nil {
+		tb.Fatal(err)
+	}
+
+	if changelog != nil {
+		if err := os.WriteFile(filepath.Join(fixtureRoot, "CHANGELOG.md"), []byte(*changelog), 0o644); err != nil {
+			tb.Fatal(err)
+		}
+	}
+
+	return fixtureWorkcellPath
+}
+
+func runWorkcellVersion(tb testing.TB, workcellPath string) string {
+	tb.Helper()
+
+	cmd := exec.Command(workcellPath, "--version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		tb.Fatalf("%s --version failed: %v\n%s", workcellPath, err, output)
+	}
+	return string(output)
+}

--- a/internal/testkit/workcell_version_test.go
+++ b/internal/testkit/workcell_version_test.go
@@ -33,6 +33,13 @@ func TestWorkcellVersionFlagCapturesPreReleaseSuffix(t *testing.T) {
 	if got != "workcell v1.2.3-rc.1\n" {
 		t.Fatalf("workcell --version output = %q, want %q", got, "workcell v1.2.3-rc.1\n")
 	}
+
+	hyphenated := "# Changelog\n\n## Unreleased\n\n## v2.0.0-rc-1 - 2099-03-01\n"
+	hyphenPath := writeWorkcellVersionFixture(t, &hyphenated)
+
+	if got := runWorkcellVersion(t, hyphenPath); got != "workcell v2.0.0-rc-1\n" {
+		t.Fatalf("workcell --version output = %q, want %q", got, "workcell v2.0.0-rc-1\n")
+	}
 }
 
 func TestWorkcellVersionFlagReportsUnknownWhenChangelogMissing(t *testing.T) {

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -515,6 +515,9 @@ repo-owned PR validation or merge gating. Pair with
 to name the target. This is the only supported way to publish against a
 stacked-review or feature-branch base.
 .TP
+.B --version
+Print Workcell version and exit.
+.TP
 .B -h, --help
 Show usage information.
 .SH PROFILES

--- a/man/workcell.1
+++ b/man/workcell.1
@@ -516,7 +516,9 @@ to name the target. This is the only supported way to publish against a
 stacked-review or feature-branch base.
 .TP
 .B --version
-Print Workcell version and exit.
+Print Workcell version and exit. On hosts without the Go toolchain at a
+trusted path, pass it as the first argument; after other options it requires
+a fully provisioned host.
 .TP
 .B -h, --help
 Show usage information.

--- a/policy/operator-contract.toml
+++ b/policy/operator-contract.toml
@@ -381,6 +381,16 @@ evidence = ["scripts/verify-invariants.sh", "tests/scenarios/shared/test-session
 requirements = ["functional.FR-006"]
 target_state = "retain"
 
+[workflows.print_version]
+title = "Print Workcell version"
+support = "supported"
+canonical = "--version"
+discoverability = ["top-level-help", "manpage"]
+docs = ["man/workcell.1"]
+evidence = ["tests/scenarios/shared/test-install-lifecycle.sh", "tests/scenarios/shared/test-assurance-dry-run.sh"]
+requirements = ["functional.FR-006"]
+target_state = "retain"
+
 [workflows.support_bundle]
 title = "Host-side support bundle"
 support = "supported"

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -110,11 +110,14 @@ workflows = [
   "launch_logs",
   "launch_auth_status",
   "launch_gc",
+  "print_version",
   "support_bundle",
 ]
 evidence = [
   "scripts/verify-invariants.sh",
   "internal/testkit/validation_entrypoints_test.go",
+  "tests/scenarios/shared/test-install-lifecycle.sh",
+  "tests/scenarios/shared/test-assurance-dry-run.sh",
   "tests/scenarios/shared/test-policy-commands.sh",
   "internal/authpolicy/manage_test.go",
   "tests/scenarios/shared/test-auth-commands.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "85f0865e75057255752b6431b72bcf53c01e9376d6307c39baaebedb62e026db"
+      "sha256": "f4a4ae0a997daacc5fc1255da58befd8369a10556cdd110eeaf06a6f67b65794"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "8d4e9a8caab55edc99900413baf449238dff19d15ed3ede79142676535024ffd"
+      "sha256": "87d13db9690768c1d0b6dace1b9d4addaad9c8792ccca64aff8602781ccfdc4b"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "87d13db9690768c1d0b6dace1b9d4addaad9c8792ccca64aff8602781ccfdc4b"
+      "sha256": "97bc79d947f5a5637035a3b1e52db2814b685ce4f141c70afacd3ca9044fe3b0"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "f4a4ae0a997daacc5fc1255da58befd8369a10556cdd110eeaf06a6f67b65794"
+      "sha256": "8d4e9a8caab55edc99900413baf449238dff19d15ed3ede79142676535024ffd"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/install-workcell.sh
+++ b/scripts/install-workcell.sh
@@ -204,7 +204,7 @@ chmod 0700 "\${DEBUG_DIR}" 2>/dev/null || true
 
 for ARG in "\$@"; do
   case "\${ARG}" in
-    --auth-status | --doctor | --gc | --help | --inspect | --logs | --prepare-only | -h | auth-status | doctor | gc | help | inspect | logs | publish-pr | support-bundle)
+    --auth-status | --doctor | --gc | --help | --inspect | --logs | --prepare-only | --version | -h | auth-status | doctor | gc | help | inspect | logs | publish-pr | support-bundle)
       SKIP_AUTO_DEBUG=1
       ;;
     session)

--- a/scripts/install-workcell.sh
+++ b/scripts/install-workcell.sh
@@ -202,9 +202,17 @@ declare -a EXTRA_ARGS=()
 mkdir -p "\${DEBUG_DIR}"
 chmod 0700 "\${DEBUG_DIR}" 2>/dev/null || true
 
+# --version is positional: only a FIRST-argument --version is the operator
+# version query (matching the launcher's toolchain-free early handler).  A
+# --version elsewhere in argv can be a provider argument value (for example
+# --agent-arg --version), which must keep the automatic debug flags.
+if [[ "\${1:-}" == "--version" ]]; then
+  SKIP_AUTO_DEBUG=1
+fi
+
 for ARG in "\$@"; do
   case "\${ARG}" in
-    --auth-status | --doctor | --gc | --help | --inspect | --logs | --prepare-only | --version | -h | auth-status | doctor | gc | help | inspect | logs | publish-pr | support-bundle)
+    --auth-status | --doctor | --gc | --help | --inspect | --logs | --prepare-only | -h | auth-status | doctor | gc | help | inspect | logs | publish-pr | support-bundle)
       SKIP_AUTO_DEBUG=1
       ;;
     session)

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -8397,6 +8397,13 @@ while [[ $# -gt 0 ]]; do
       DRY_RUN=1
       shift
       ;;
+    --version)
+      # Also handled before module sourcing (see the early ROOT_DIR handler)
+      # so the bare form stays toolchain-free; this case keeps --version
+      # honored after other global options on fully provisioned hosts.
+      printf 'workcell %s\n' "$(changelog_version "${ROOT_DIR}")"
+      exit 0
+      ;;
     -h | --help)
       usage
       exit 0

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -87,6 +87,15 @@ changelog_version() {
 }
 
 ROOT_DIR="$(cd -P "$(dirname "$(resolve_self_path)")/.." && pwd)"
+# Handle --version before sourcing any launcher module: printing the changelog
+# version must never require Go, Docker, or Colima on the host.  Later modules
+# resolve host tools at source time (go-hostutil.sh aborts on a missing
+# trusted-path go), so this early exit is what keeps `workcell --version`
+# usable on a bare operator host (P1 review finding on the --version PR).
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'workcell %s\n' "$(changelog_version "${ROOT_DIR}")"
+  exit 0
+fi
 # shellcheck source=/dev/null
 source "${ROOT_DIR}/runtime/container/assurance.sh"
 # shellcheck source=/dev/null
@@ -8387,10 +8396,6 @@ while [[ $# -gt 0 ]]; do
     --dry-run)
       DRY_RUN=1
       shift
-      ;;
-    --version)
-      printf 'workcell %s\n' "$(changelog_version "${ROOT_DIR}")"
-      exit 0
       ;;
     -h | --help)
       usage

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -53,6 +53,39 @@ resolve_self_path() {
   printf '%s\n' "${source_path}"
 }
 
+# changelog_version extracts the first ## vX.Y.Z heading from CHANGELOG.md,
+# including semver pre-release suffixes (## vX.Y.Z-rc.1) so a release candidate
+# never reports itself as the final release, matching the same logic as
+# internal/supportbundle/collect.go's changelogVersion(). Returns the version
+# string (e.g., v0.11.2 or v1.0.0-rc.1) or "unknown" if the file is missing,
+# unreadable, or contains no matching heading; never fails.
+changelog_version() {
+  local repo_root="${1:-}"
+  local changelog_path
+
+  if [[ -z "${repo_root}" ]]; then
+    printf 'unknown\n'
+    return 0
+  fi
+
+  changelog_path="${repo_root}/CHANGELOG.md"
+  if [[ ! -f "${changelog_path}" || ! -r "${changelog_path}" ]]; then
+    printf 'unknown\n'
+    return 0
+  fi
+
+  local line
+  while IFS= read -r line; do
+    if [[ "${line}" =~ ^##[[:space:]]+(v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?) ]]; then
+      printf '%s\n' "${BASH_REMATCH[1]}"
+      return 0
+    fi
+  done <"${changelog_path}"
+
+  printf 'unknown\n'
+  return 0
+}
+
 ROOT_DIR="$(cd -P "$(dirname "$(resolve_self_path)")/.." && pwd)"
 # shellcheck source=/dev/null
 source "${ROOT_DIR}/runtime/container/assurance.sh"
@@ -228,6 +261,7 @@ Options:
   --vm-disk GIB                 Colima VM disk in GiB (default: profile value)
   --rebuild                     Rebuild the runtime image before launch
   --dry-run                     Print the selected runtime command and exit
+  --version                     Print Workcell version and exit
   -h, --help                    Show this help text
   --ack-control-plane-vcs       Required with --allow-control-plane-vcs
   --ack-repo-mcp=YYYY-MM-DD      Dated acknowledgement required with --allow-repo-mcp
@@ -8353,6 +8387,10 @@ while [[ $# -gt 0 ]]; do
     --dry-run)
       DRY_RUN=1
       shift
+      ;;
+    --version)
+      printf 'workcell %s\n' "$(changelog_version "${ROOT_DIR}")"
+      exit 0
       ;;
     -h | --help)
       usage

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -76,7 +76,7 @@ changelog_version() {
 
   local line
   while IFS= read -r line; do
-    if [[ "${line}" =~ ^##[[:space:]]+(v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?) ]]; then
+    if [[ "${line}" =~ ^##[[:space:]]+(v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?) ]]; then
       printf '%s\n' "${BASH_REMATCH[1]}"
       return 0
     fi

--- a/tests/scenarios/manifest.json
+++ b/tests/scenarios/manifest.json
@@ -228,7 +228,7 @@
     },
     {
       "id": "shared/install-lifecycle",
-      "description": "Day-two install lifecycle mechanics in a sandboxed HOME that touches no real host state: install links the launcher, upgrade-in-place repoints it with no duplicate or orphaned link, rollback repoints back, and the --gc cleanup contract (function-level, injected sandbox root) reaps Workcell-owned stale scratch while preserving unrelated files; real /tmp and state-root sentinels prove nothing outside the sandbox is touched",
+      "description": "Day-two install lifecycle mechanics in a sandboxed HOME that touches no real host state: install links the launcher, upgrade-in-place repoints it with no duplicate or orphaned link, rollback repoints back, the --gc cleanup contract (function-level, injected sandbox root) reaps Workcell-owned stale scratch while preserving unrelated files, and the changelog-derived --version contract (function-level, sandboxed fixtures) returns real versions for source and installed-layout roots while malformed or missing changelogs return unknown; real /tmp and state-root sentinels prove nothing outside the sandbox is touched",
       "lane": "secretless",
       "platform": "any",
       "manual": false,

--- a/tests/scenarios/shared/test-assurance-dry-run.sh
+++ b/tests/scenarios/shared/test-assurance-dry-run.sh
@@ -377,7 +377,7 @@ fi
 grep -q 'unsupported keys' "${TMP_DIR}/network-weaken.stderr"
 
 version_output="$(HOME="${HOME_DIR}" XDG_CONFIG_HOME="${HOME_DIR}/.config" "${ROOT_DIR}/scripts/workcell" --version)"
-if [[ ! "${version_output}" =~ ^workcell\ v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+if [[ ! "${version_output}" =~ ^workcell\ v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
   echo "unexpected --version output: ${version_output}" >&2
   exit 1
 fi

--- a/tests/scenarios/shared/test-assurance-dry-run.sh
+++ b/tests/scenarios/shared/test-assurance-dry-run.sh
@@ -376,4 +376,10 @@ if [[ "${weaken_rc}" -eq 0 ]]; then
 fi
 grep -q 'unsupported keys' "${TMP_DIR}/network-weaken.stderr"
 
+version_output="$(HOME="${HOME_DIR}" XDG_CONFIG_HOME="${HOME_DIR}/.config" "${ROOT_DIR}/scripts/workcell" --version)"
+if [[ ! "${version_output}" =~ ^workcell\ v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+  echo "unexpected --version output: ${version_output}" >&2
+  exit 1
+fi
+
 echo "Assurance dry-run scenario passed"

--- a/tests/scenarios/shared/test-install-lifecycle.sh
+++ b/tests/scenarios/shared/test-install-lifecycle.sh
@@ -25,6 +25,7 @@ TMP_DIR="$(cd "${TMP_DIR}" && pwd -P)"
 # only self-contained function definitions, so it can live in the sandbox and
 # needs no relative-source resolution.
 FUNCTIONS_COPY="${TMP_DIR}/gc-cleanup-fns.sh"
+CHANGELOG_FUNCTIONS_COPY="${TMP_DIR}/changelog-version-fns.sh"
 
 cleanup() {
   rm -rf "${TMP_DIR}"
@@ -171,6 +172,64 @@ gc_fn_output="$(
 grep -q '^gc-cleanup-done$' <<<"${gc_fn_output}" || fail "--gc cleanup contract did not run"
 [[ ! -e "${GC_FN_ROOT}/workcell-docker.stale-fixture" ]] || fail "gc cleanup did not reap injected Workcell-owned stale scratch"
 [[ -f "${GC_FN_ROOT}/unrelated-keep.txt" ]] || fail "gc cleanup reaped an unrelated (non-Workcell) file"
+
+# ---------------------------------------------------------------------------
+# `workcell --version` changelog CONTRACT at the function level with injected
+# roots. We extract ONLY changelog_version and source just that helper, not the
+# whole launcher, so the version parser can be exercised against sandboxed
+# source, installed-layout, missing-changelog, and malformed-changelog roots.
+# ---------------------------------------------------------------------------
+sed -n '/^changelog_version() {/,/^}/p' "${ROOT_DIR}/scripts/workcell" >"${CHANGELOG_FUNCTIONS_COPY}"
+grep -q '^changelog_version() {' "${CHANGELOG_FUNCTIONS_COPY}" ||
+  fail "could not extract changelog_version from the launcher (renamed?)"
+
+source_checkout_version="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    changelog_version "$2"
+  ' _ "${CHANGELOG_FUNCTIONS_COPY}" "${ROOT_DIR}"
+)"
+[[ "${source_checkout_version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]] ||
+  fail "source checkout changelog version was not semver: ${source_checkout_version}"
+
+BUNDLE_ROOT="${TMP_DIR}/bundle-root"
+mkdir -p "${BUNDLE_ROOT}"
+cp "${ROOT_DIR}/CHANGELOG.md" "${BUNDLE_ROOT}/CHANGELOG.md"
+installed_layout_version="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    changelog_version "$2"
+  ' _ "${CHANGELOG_FUNCTIONS_COPY}" "${BUNDLE_ROOT}"
+)"
+[[ "${installed_layout_version}" == "${source_checkout_version}" ]] ||
+  fail "installed-layout changelog version ${installed_layout_version} did not match source checkout ${source_checkout_version}"
+
+MISSING_CHANGELOG_ROOT="${TMP_DIR}/missing-changelog-root"
+mkdir -p "${MISSING_CHANGELOG_ROOT}"
+missing_changelog_version="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    changelog_version "$2"
+  ' _ "${CHANGELOG_FUNCTIONS_COPY}" "${MISSING_CHANGELOG_ROOT}"
+)"
+[[ "${missing_changelog_version}" == "unknown" ]] ||
+  fail "missing changelog returned ${missing_changelog_version}, want unknown"
+
+MALFORMED_CHANGELOG_ROOT="${TMP_DIR}/malformed-changelog-root"
+mkdir -p "${MALFORMED_CHANGELOG_ROOT}"
+printf '## Unreleased\n\n## Version 0.11.2\n' >"${MALFORMED_CHANGELOG_ROOT}/CHANGELOG.md"
+malformed_changelog_version="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    changelog_version "$2"
+  ' _ "${CHANGELOG_FUNCTIONS_COPY}" "${MALFORMED_CHANGELOG_ROOT}"
+)"
+[[ "${malformed_changelog_version}" == "unknown" ]] ||
+  fail "malformed changelog returned ${malformed_changelog_version}, want unknown"
 
 # ---------------------------------------------------------------------------
 # Real-state containment proof: nothing above touched the real host.

--- a/tests/scenarios/shared/test-install-lifecycle.sh
+++ b/tests/scenarios/shared/test-install-lifecycle.sh
@@ -190,7 +190,7 @@ source_checkout_version="$(
     changelog_version "$2"
   ' _ "${CHANGELOG_FUNCTIONS_COPY}" "${ROOT_DIR}"
 )"
-[[ "${source_checkout_version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]] ||
+[[ "${source_checkout_version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] ||
   fail "source checkout changelog version was not semver: ${source_checkout_version}"
 
 BUNDLE_ROOT="${TMP_DIR}/bundle-root"


### PR DESCRIPTION
## Summary
- Add a minimal `workcell --version` top-level flag (maintainer decision 2026-07-09, landing inside the 1.0 frozen contract surface).
- Version is changelog-derived via the same first-`## vX.Y.Z`-heading rule the support bundle uses (`internal/supportbundle/collect.go`), so the two version sources cannot disagree; prints `workcell unknown` (exit 0, never fails) when CHANGELOG.md is absent, unreadable, or has no release heading.
- Both regexes (Go and bash) capture semver pre-release suffixes (`v1.0.0-rc.1`), so the upcoming release candidate reports itself as the rc — never overstated as the final release.
- Verified the installed layout ships CHANGELOG.md (git-archive bundle, symlink launcher resolves ROOT_DIR to the bundle root), so installed copies report a real version.
- Lockstep surfaces updated: `--help` text, `man/workcell.1`, `policy/operator-contract.toml` (`[workflows.print_version]`), `policy/requirements.toml` (FR-006), control-plane manifest regenerated.

## Tests
- `tests/scenarios/shared/test-install-lifecycle.sh`: source-checkout semver assert, installed-layout parity with source, missing-changelog → `unknown`, malformed-heading → `unknown`.
- `tests/scenarios/shared/test-assurance-dry-run.sh`: live launcher `--version` output shape + exit 0.
- `internal/testkit/workcell_version_test.go`: end-to-end launcher runs against fixture roots (first-heading-wins, missing, no-heading).

## Validation
- ./scripts/pre-merge.sh --profile pr-parity
- Full go test ./... green; shellcheck/shfmt/bash -n clean; verify-operator-contract, check-public-contract, verify-scenario-coverage, verify-requirements-coverage, verify-control-plane-manifest all pass.

## Review
- Draft for the Codex review loop.
