### PR TITLE
Preserve file modes in upstream-pins refresh rewrites

### DIFF
--- a/internal/testkit/workcell_version_test.go
+++ b/internal/testkit/workcell_version_test.go
@@ -12,8 +12,10 @@ import (
 )
 
 func TestWorkcellVersionFlagReadsFirstChangelogVersion(t *testing.T) {
-	t.Parallel()
-
+	// Intentionally serial: writes-then-execs the launcher fixture on disk.
+	// Running these in parallel races against the Linux kernel's ETXTBSY
+	// check when concurrent goroutines exec freshly-written executables
+	// (observed as a pre-merge flake in the validator container).
 	changelog := "# Changelog\n\n## Unreleased\n\n## v9.8.7 - 2099-01-01\n\n## v9.9.9 - 2099-02-01\n"
 	workcellPath := writeWorkcellVersionFixture(t, &changelog)
 
@@ -24,8 +26,7 @@ func TestWorkcellVersionFlagReadsFirstChangelogVersion(t *testing.T) {
 }
 
 func TestWorkcellVersionFlagCapturesPreReleaseSuffix(t *testing.T) {
-	t.Parallel()
-
+	// Serial — see ETXTBSY note on TestWorkcellVersionFlagReadsFirstChangelogVersion.
 	changelog := "# Changelog\n\n## Unreleased\n\n## v1.2.3-rc.1 - 2099-01-01\n\n## v1.2.2 - 2098-12-01\n"
 	workcellPath := writeWorkcellVersionFixture(t, &changelog)
 
@@ -43,8 +44,7 @@ func TestWorkcellVersionFlagCapturesPreReleaseSuffix(t *testing.T) {
 }
 
 func TestWorkcellVersionFlagReportsUnknownWhenChangelogMissing(t *testing.T) {
-	t.Parallel()
-
+	// Serial — see ETXTBSY note on TestWorkcellVersionFlagReadsFirstChangelogVersion.
 	workcellPath := writeWorkcellVersionFixture(t, nil)
 
 	got := runWorkcellVersion(t, workcellPath)
@@ -54,8 +54,7 @@ func TestWorkcellVersionFlagReportsUnknownWhenChangelogMissing(t *testing.T) {
 }
 
 func TestWorkcellVersionFlagReportsUnknownWithoutVersionHeading(t *testing.T) {
-	t.Parallel()
-
+	// Serial — see ETXTBSY note on TestWorkcellVersionFlagReadsFirstChangelogVersion.
 	changelog := "# Changelog\n\n## Unreleased\n\n### Changed\n\n- no released version yet\n"
 	workcellPath := writeWorkcellVersionFixture(t, &changelog)
 

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -314,6 +314,28 @@ extract_workflow_env_value() {
   ' "${file}"
 }
 
+file_mode_octal() {
+  local path="$1"
+
+  if stat -f '%Lp' "${path}" >/dev/null 2>&1; then
+    stat -f '%Lp' "${path}"
+  else
+    stat -c '%a' "${path}"
+  fi
+}
+
+# replace_tmp_over_file atomically replaces file with tmp while keeping the
+# original file mode (mktemp files are 0600; a bare mv strips the executable
+# bit from rewritten scripts and ships a spurious mode-only diff, while a
+# write-through would leave the target truncated on an interrupted write).
+replace_tmp_over_file() {
+  local tmp="$1"
+  local file="$2"
+
+  chmod "$(file_mode_octal "${file}")" "${tmp}"
+  mv "${tmp}" "${file}"
+}
+
 replace_line_with_prefix() {
   local file="$1"
   local prefix="$2"
@@ -338,11 +360,7 @@ replace_line_with_prefix() {
     echo "Unable to replace ${prefix} in ${file}" >&2
     exit 1
   fi
-  # Write through the existing inode instead of mv so the target keeps its
-  # mode (mktemp files are 0600; an mv here strips the executable bit from
-  # rewritten scripts and ships a spurious mode-only diff in the candidate).
-  cat "${tmp}" >"${file}"
-  rm -f "${tmp}"
+  replace_tmp_over_file "${tmp}" "${file}"
 }
 
 replace_all_lines_with_prefix() {
@@ -369,11 +387,7 @@ replace_all_lines_with_prefix() {
     echo "Failed to update ${prefix} in ${file}" >&2
     exit 1
   fi
-  # Write through the existing inode instead of mv so the target keeps its
-  # mode (mktemp files are 0600; an mv here strips the executable bit from
-  # rewritten scripts and ships a spurious mode-only diff in the candidate).
-  cat "${tmp}" >"${file}"
-  rm -f "${tmp}"
+  replace_tmp_over_file "${tmp}" "${file}"
 }
 
 replace_line_after_marker_with_prefix() {
@@ -407,11 +421,7 @@ replace_line_after_marker_with_prefix() {
     echo "Unable to replace ${prefix} after ${marker} in ${file}" >&2
     exit 1
   fi
-  # Write through the existing inode instead of mv so the target keeps its
-  # mode (mktemp files are 0600; an mv here strips the executable bit from
-  # rewritten scripts and ships a spurious mode-only diff in the candidate).
-  cat "${tmp}" >"${file}"
-  rm -f "${tmp}"
+  replace_tmp_over_file "${tmp}" "${file}"
 }
 
 date_stamp_for_offset() {

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -338,7 +338,11 @@ replace_line_with_prefix() {
     echo "Unable to replace ${prefix} in ${file}" >&2
     exit 1
   fi
-  mv "${tmp}" "${file}"
+  # Write through the existing inode instead of mv so the target keeps its
+  # mode (mktemp files are 0600; an mv here strips the executable bit from
+  # rewritten scripts and ships a spurious mode-only diff in the candidate).
+  cat "${tmp}" >"${file}"
+  rm -f "${tmp}"
 }
 
 replace_all_lines_with_prefix() {
@@ -365,7 +369,11 @@ replace_all_lines_with_prefix() {
     echo "Failed to update ${prefix} in ${file}" >&2
     exit 1
   fi
-  mv "${tmp}" "${file}"
+  # Write through the existing inode instead of mv so the target keeps its
+  # mode (mktemp files are 0600; an mv here strips the executable bit from
+  # rewritten scripts and ships a spurious mode-only diff in the candidate).
+  cat "${tmp}" >"${file}"
+  rm -f "${tmp}"
 }
 
 replace_line_after_marker_with_prefix() {
@@ -399,7 +407,11 @@ replace_line_after_marker_with_prefix() {
     echo "Unable to replace ${prefix} after ${marker} in ${file}" >&2
     exit 1
   fi
-  mv "${tmp}" "${file}"
+  # Write through the existing inode instead of mv so the target keeps its
+  # mode (mktemp files are 0600; an mv here strips the executable bit from
+  # rewritten scripts and ships a spurious mode-only diff in the candidate).
+  cat "${tmp}" >"${file}"
+  rm -f "${tmp}"
 }
 
 date_stamp_for_offset() {


### PR DESCRIPTION
## Summary
- Preserve file modes when the upstream-pins refresh rewrites files: the `replace_*_with_prefix` helpers moved a 0600 `mktemp` file over the target, stripping the executable bit from rewritten scripts. Today's refresh candidate (run 29059468102) carried a spurious `100755→100644` mode-only diff on `scripts/ci/build-validator-image.sh` (zero content change), which failed the refresh-PR parity run with `Permission denied` (exit 126). The helpers now write through the existing inode and remove the tmp file.
- Supporting: serialize the `workcell --version` testkit fixtures — the write-then-exec pattern races the Linux ETXTBSY check under `t.Parallel` (mirrors the existing `colima_test.go` serial pattern); this flaked the first parity run of this PR.

## Validation
- ./scripts/pre-merge.sh --profile pr-parity
- Empirical: `replace_line_with_prefix` on a 0755 fixture keeps mode 755 and replaces the pinned line (pre-fix: 600).
- `go test ./internal/testkit -count=3` green; bash -n / shellcheck -x / shfmt clean.
- No automated test lane added for the mode fix: `update-upstream-pins.sh` executes at top level with no sourcing seam, and adding a lib-only guard to the release-critical pins path for test purposes is riskier than the three-line fix — recorded here for review.

## Review
- Draft for the Codex review loop.
