### PR TITLE
Refactor Codex adapter subcommand gate to deny-by-default allowlist

### DIFF
--- a/adapters/codex/.codex/config.toml
+++ b/adapters/codex/.codex/config.toml
@@ -47,3 +47,10 @@ network_access = false
 # Codex's unified exec path currently fails inside Workcell managed mode with
 # "Failed to create unified exec process: Operation not permitted".
 unified_exec = false
+# Defense in depth for the 0.143+ plugin/marketplace surface: even though the
+# provider policy rejects the `plugin` subcommand outright, pin the plugin
+# feature flags off in the runtime baseline so no config layer can silently
+# reintroduce remote marketplace fetch/install or plugin sharing.
+plugins = false
+plugin_sharing = false
+remote_plugin = false

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -55,16 +55,27 @@ In-container reserved session targets: `~/.codex/{config.toml,auth.json,`
   copy only in explicit lower-assurance cases (see
   [../../docs/adapter-control-planes.md](../../docs/adapter-control-planes.md#codex-rules-mutability)).
 - Unsafe-argument policy (`reject_unsafe_codex_args` in
-  `runtime/container/provider-policy.sh`): the wrapper blocks
-  `--dangerously-bypass-approvals-and-sandbox`, `--full-auto`, `-a`/
-  `--ask-for-approval`, `--add-dir`, `--search`, `--remote`, `--enable`/
-  `--disable`, `--cd`, `--sandbox danger-full-access`, reserved `--config`
-  overrides, off-mode `--profile` values, and `app`/`app-server`/`cloud`/`mcp`/
-  `sandbox` subcommands outside the managed GUI path. These are rejected in
-  **every** mode including `breakglass`: `provider-wrapper.sh` re-checks arguments
-  (`WORKCELL_WRAPPER_CONTEXT=1`), so `container-smoke.sh` confirms breakglass
-  overrides still fail. Breakglass raises the sandbox floor, not the unsafe-flag
-  policy.
+  `runtime/container/provider-policy.sh`): **subcommands are deny-by-default**
+  over the pinned Codex subcommand namespace — only the read-only/session
+  surface is permitted (exec, review, login/logout, completion, doctor, apply,
+  resume, fork, archive/unarchive/delete, help, debug, execpolicy, `features
+  list`); everything else is rejected (plugin, remote-control, exec-server,
+  mcp*, cloud*, responses-api-proxy, stdio-to-uds, update, sandbox, `features
+  enable`/`disable`, and any unclassified/new subcommand). `app-server` is the
+  managed GUI backend and is permitted only as the bare no-arg launch; an
+  unknown first token is Codex prompt text. The classified set is pinned to the
+  version by
+  [`tests/fixtures/codex-subcommands.txt`](../../tests/fixtures/codex-subcommands.txt)
+  (a `CODEX_VERSION` bump fails CI until it is regenerated). The wrapper also
+  blocks `--yolo`/`--dangerously-bypass-*`, autonomy/network flags
+  (`--full-auto`, `-a`, `--add-dir`, `--search`, `--remote`, `--enable`,
+  `--disable`, `--cd`, `--sandbox danger-full-access`), off-mode `--profile`
+  values, and reserved `-c`/`--config` overrides of guarded namespaces
+  (features/plugins/marketplaces/mcp/hooks/sandbox/approval, incl. glued,
+  quoted/escaped, inline-table, and `profiles.<name>.<key>` spellings). All are
+  rejected in **every** mode including `breakglass` (`provider-wrapper.sh`
+  re-checks with `WORKCELL_WRAPPER_CONTEXT=1`); breakglass raises the sandbox
+  floor, not the unsafe-argument policy.
 - Final branch publication stays on the host through `workcell publish-pr`, not
   from inside the container session.
 

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -58,10 +58,10 @@ In-container reserved session targets: `~/.codex/{config.toml,auth.json,`
   `runtime/container/provider-policy.sh`): **subcommands are deny-by-default**
   over the pinned Codex subcommand namespace — only the read-only/session
   surface is permitted (exec, review, login/logout, completion, doctor, apply,
-  resume, fork, archive/unarchive/delete, help, debug, execpolicy, `features
+  resume, fork, archive/unarchive/delete, help, execpolicy, `features
   list`); everything else is rejected (plugin, remote-control, exec-server,
-  mcp*, cloud*, responses-api-proxy, stdio-to-uds, update, sandbox, `features
-  enable`/`disable`, and any unclassified/new subcommand). `app-server` is the
+  mcp*, cloud*, responses-api-proxy, stdio-to-uds, update, sandbox, debug,
+  `features enable`/`disable`, and any unclassified/new subcommand). `app-server` is the
   managed GUI backend and is permitted only as the bare no-arg launch; an
   unknown first token is Codex prompt text. The classified set is pinned to the
   version by

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -68,8 +68,9 @@ In-container reserved session targets: `~/.codex/{config.toml,auth.json,`
   [`tests/fixtures/codex-subcommands.txt`](../../tests/fixtures/codex-subcommands.txt)
   (a `CODEX_VERSION` bump fails CI until it is regenerated). The wrapper also
   blocks `--yolo`/`--dangerously-bypass-*`, autonomy/network flags
-  (`--full-auto`, `-a`, `--add-dir`, `--search`, `--remote`, `--enable`,
-  `--disable`, `--cd`, `--sandbox danger-full-access`), off-mode `--profile`
+  (`--full-auto`, `-a`, `--add-dir`, `--search`, `--remote`,
+  `--remote-auth-token-env`, `--enable`, `--disable`, `--cd`,
+  `--sandbox danger-full-access`), off-mode `--profile`
   values, and reserved `-c`/`--config` overrides of guarded namespaces
   (features/plugins/marketplaces/mcp/hooks/sandbox/approval, incl. glued,
   quoted/escaped, inline-table, and `profiles.<name>.<key>` spellings). All are

--- a/adapters/codex/managed_config.toml
+++ b/adapters/codex/managed_config.toml
@@ -49,6 +49,13 @@ network_access = false
 # Codex's unified exec path currently fails inside Workcell managed mode with
 # "Failed to create unified exec process: Operation not permitted".
 unified_exec = false
+# Defense in depth for the 0.143+ plugin/marketplace surface: even though the
+# provider policy rejects the `plugin` subcommand outright, pin the plugin
+# feature flags off in the managed baseline so no config layer can silently
+# reintroduce remote marketplace fetch/install or plugin sharing.
+plugins = false
+plugin_sharing = false
+remote_plugin = false
 
 [[rules.prefix_rules]]
 pattern = [{ any_of = ["git", "/usr/bin/git", "/usr/local/libexec/workcell/git", "/usr/local/libexec/workcell/core/git", "/usr/local/libexec/workcell/real/git"] }, { token = "commit" }, { any_of = ["--no-verify", "-n"] }]

--- a/adapters/codex/requirements.toml
+++ b/adapters/codex/requirements.toml
@@ -11,6 +11,13 @@ allowed_web_search_modes = ["disabled"]
 
 [features]
 unified_exec = false
+# Kept in lockstep with .codex/config.toml and managed_config.toml: pin the
+# 0.143+ plugin/marketplace feature flags off so the managed baseline cannot
+# fetch/install remote plugins or share them (defense in depth for the plugin
+# subcommand fence in runtime/container/provider-policy.sh).
+plugins = false
+plugin_sharing = false
+remote_plugin = false
 
 # No MCP identities are seeded in the managed baseline. Enable only pinned,
 # repo-reviewed local commands or immutable container/image references.

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -248,7 +248,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "fcceb9ce375c4b5a151bac00ae68f0185a1e820c595817f320131fa4040bcfec"
+      "sha256": "992699b568a03004a2325751bd2f0534005ff34a61a69976a89fdba91464fbfe"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -248,13 +248,13 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "4de759d469f979266fd19e8b01a8ab8e0a9dbf7a0a529fa6830359dc6e18d415"
+      "sha256": "957d1fc8c3f226d04c1dd7407607e20e3c2bc1375eff0dedca44af1cf08d43f9"
     },
     {
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-wrapper.sh",
-      "sha256": "238413de89496156e21e709bf083be4de8efbe13f7f113e04609a365b600f15d"
+      "sha256": "bdccf6057d7b72e0da90dff5c2629ce5e1a4b501051d5976363140a392ea83c4"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -248,7 +248,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "d4ba2626394903d053864b3802c80b6e3aba97298d12a0a6d2783d2f102344fc"
+      "sha256": "4de759d469f979266fd19e8b01a8ab8e0a9dbf7a0a529fa6830359dc6e18d415"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -248,7 +248,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "4705becae86f6c0d1d446202ac7cc5e07f478a547b5c73c9c1c1169f808d884c"
+      "sha256": "bf320e3e08e907e09401b12a5df9c624cf4da50c9be90d8122d47dbf12395109"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -248,7 +248,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "992699b568a03004a2325751bd2f0534005ff34a61a69976a89fdba91464fbfe"
+      "sha256": "e3f9bcc8c6b4b2f29d0c715aa071583891de5635b62446744261f0eb589579bd"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -122,7 +122,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/codex/.codex/config.toml",
       "runtime_path": "/opt/workcell/adapters/codex/.codex/config.toml",
-      "sha256": "2fd96ca2373277b47e92a62bbfcd29c4e4d30369f08f97f3e368b559b3488ed5"
+      "sha256": "294e979a29a7023c3e0be229feebaf24a394f6d33ab9f25bacbc3a4b169e9ed3"
     },
     {
       "kind": "adapter-baseline",
@@ -146,7 +146,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/codex/managed_config.toml",
       "runtime_path": "/opt/workcell/adapters/codex/managed_config.toml",
-      "sha256": "c893bda9d799981ef7604581e26bdd45cf0254ce72550fe7112bc25563bd7fce"
+      "sha256": "3c26a72b7f15ebd8eae2263721e52ddf94d8ae2a4036aa824b77ae57934fa996"
     },
     {
       "kind": "adapter-baseline",
@@ -158,7 +158,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/codex/requirements.toml",
       "runtime_path": "/opt/workcell/adapters/codex/requirements.toml",
-      "sha256": "e4dce7bcb8f06c546c3e55d8f8f6509e3ff0f597cfb68bc36c47d5f86ffae295"
+      "sha256": "16eaf696e8c920575c09d5616c4f77cc1110853abfa8b1f0a3075cd03c568ffd"
     },
     {
       "kind": "adapter-baseline",
@@ -248,13 +248,13 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "afb18a7bb018e97c3b6f324077c2eddf84d51311466813610a02198064405544"
+      "sha256": "d4ba2626394903d053864b3802c80b6e3aba97298d12a0a6d2783d2f102344fc"
     },
     {
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-wrapper.sh",
-      "sha256": "d4ee3849e5a8873bf729f14c591ef34c382c522e5bb20421fd512c433cf957d8"
+      "sha256": "238413de89496156e21e709bf083be4de8efbe13f7f113e04609a365b600f15d"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -248,7 +248,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "bf320e3e08e907e09401b12a5df9c624cf4da50c9be90d8122d47dbf12395109"
+      "sha256": "2364cd6271cceb56562f5b8887325d3c0163fb556d4324a4e58cee8da3229891"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -248,7 +248,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "df8159afb03f299386686badc1b66e05788e520712eaedd6312bfaa590464b44"
+      "sha256": "b4076287784e94e765cea48d42476e6b9542d3a2ce68cfe929fbe9cc071b9da1"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -248,7 +248,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "a04570d86b814f5341d2245b3616d32c272d68ff167af9bc8bb8f9b136dd1a23"
+      "sha256": "fcceb9ce375c4b5a151bac00ae68f0185a1e820c595817f320131fa4040bcfec"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -248,7 +248,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "2364cd6271cceb56562f5b8887325d3c0163fb556d4324a4e58cee8da3229891"
+      "sha256": "df8159afb03f299386686badc1b66e05788e520712eaedd6312bfaa590464b44"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -248,7 +248,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "957d1fc8c3f226d04c1dd7407607e20e3c2bc1375eff0dedca44af1cf08d43f9"
+      "sha256": "4705becae86f6c0d1d446202ac7cc5e07f478a547b5c73c9c1c1169f808d884c"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -248,7 +248,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "b4076287784e94e765cea48d42476e6b9542d3a2ce68cfe929fbe9cc071b9da1"
+      "sha256": "a04570d86b814f5341d2245b3616d32c272d68ff167af9bc8bb8f9b136dd1a23"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -255,7 +255,7 @@ reject_unsafe_codex_args() {
       case "${arg}" in
         exec | e | review | login | logout | completion | doctor | \
           apply | a | resume | fork | archive | unarchive | delete | \
-          help | debug | execpolicy)
+          help | execpolicy)
           continue
           ;;
         features)
@@ -280,9 +280,12 @@ reject_unsafe_codex_args() {
         # on every UI. Enumerated against 0.142.4 so ALLOW ∪ GUI-gated ∪ DENY equals the
         # complete subcommand list (the fixture completeness check enforces this).
         # Control-plane, daemon, marketplace, sandbox-escape, and self-update surfaces
-        # the managed session must never reach.
+        # the managed session must never reach. `debug` is denied too: its
+        # second-level subcommands are not read-only (`debug app-server` reaches the
+        # app-server test client, `debug clear-memories` mutates local memory), and the
+        # managed path never uses it.
         plugin | remote-control | exec-server | mcp | mcp-server | cloud | \
-          cloud-tasks | responses-api-proxy | stdio-to-uds | sandbox | update)
+          cloud-tasks | responses-api-proxy | stdio-to-uds | sandbox | update | debug)
           # cloud-tasks is the 0.142.4 alias of `cloud`; responses-api-proxy and stdio-to-
           # uds are HIDDEN daemon/bridge subcommands the clap enum still dispatches.
           # `update` is not a 0.142.4 variant (lands in 0.143); kept forward-compat and

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -123,6 +123,18 @@ codex_config_override_is_blocked() {
   return 1
 }
 
+# Guard checks shared by the space-separated and attached/glued short-flag forms so
+# `-p val`/`-pval`/`--profile=val` (and the sandbox pair) apply the IDENTICAL check and
+# emit BYTE-IDENTICAL deny messages (tests + operators grep them). Each takes the raw
+# value plus the resolved allowed profile.
+codex_reject_unsafe_profile_value() {
+  [[ "$1" != "$2" ]] && workcell_die "Workcell blocked unsafe Codex override: --profile"
+}
+
+codex_reject_unsafe_sandbox_value() {
+  [[ "$1" == "danger-full-access" ]] && workcell_die "Workcell blocked unsafe Codex override: remove danger-full-access outside breakglass."
+}
+
 # Value-taking global Codex flags must be consumed before first-subcommand detection,
 # or their VALUE would be mistaken for the command token (`--model gpt-5 plugin` would
 # treat gpt-5 as the command). Keep in lockstep with codex_first_subcommand in
@@ -145,13 +157,13 @@ reject_unsafe_codex_args() {
     if [[ -n "${expect_value}" ]]; then
       case "${expect_value}" in
         profile)
-          [[ "${arg}" != "${allowed_profile}" ]] && workcell_die "Workcell blocked unsafe Codex override: --profile"
+          codex_reject_unsafe_profile_value "${arg}" "${allowed_profile}"
           ;;
         cd)
           workcell_die "Workcell blocked unsafe Codex override: --cd"
           ;;
         sandbox)
-          [[ "${arg}" == "danger-full-access" ]] && workcell_die "Workcell blocked unsafe Codex override: remove danger-full-access outside breakglass."
+          codex_reject_unsafe_sandbox_value "${arg}"
           ;;
         config)
           codex_config_override_is_blocked "${arg}" && workcell_die "Workcell blocked unsafe Codex config override: ${arg%%=*}"
@@ -290,6 +302,24 @@ reject_unsafe_codex_args() {
       --dangerously-bypass-* | --yolo | --yolo=* | --search | --add-dir | --remote | --remote-auth-token-env | --full-auto | -a | --ask-for-approval | --enable | --disable)
         workcell_die "Workcell blocked unsafe Codex override: ${arg}"
         ;;
+      # ATTACHED/GLUED short value-flags (Codex P1 review). Codex (clap) also accepts a
+      # short flag glued to its value (`-pval`/`-sval`/`-Cval`/`-aval`); without these the
+      # glued form falls through as an unrecognized token and is FORWARDED, so
+      # `-pbreakglass`/`-sdanger-full-access`/`-anever`/`-C/state` bypass the guards the
+      # space-separated forms apply. Placed BEFORE the exact-token cases and matched by
+      # exact letter (case-sensitive: `-C?*` never catches `-c?*`), so they shadow nothing.
+      -a?*)
+        workcell_die "Workcell blocked unsafe Codex override: ${arg}"
+        ;;
+      -C?*)
+        workcell_die "Workcell blocked unsafe Codex override: --cd"
+        ;;
+      -p?*)
+        codex_reject_unsafe_profile_value "${arg#-p}" "${allowed_profile}"
+        ;;
+      -s?*)
+        codex_reject_unsafe_sandbox_value "${arg#-s}"
+        ;;
       -p | --profile)
         expect_value="profile"
         ;;
@@ -313,7 +343,7 @@ reject_unsafe_codex_args() {
         workcell_die "Workcell blocked unsafe Codex override: --cd"
         ;;
       --profile=*)
-        [[ "${arg#--profile=}" != "${allowed_profile}" ]] && workcell_die "Workcell blocked unsafe Codex override: --profile"
+        codex_reject_unsafe_profile_value "${arg#--profile=}" "${allowed_profile}"
         ;;
       -s | --sandbox)
         expect_value="sandbox"

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -5,9 +5,8 @@ workcell_die() {
   exit 2
 }
 
-# Only the PID 1 entrypoint path may honor breakglass-style provider flags.
-# provider-wrapper.sh always exports WORKCELL_WRAPPER_CONTEXT=1 so nested
-# launches cannot re-enable those overrides after the entrypoint policy check.
+# Only the PID 1 entrypoint may honor breakglass overrides. provider-wrapper.sh
+# exports WORKCELL_WRAPPER_CONTEXT=1 so nested launches cannot re-enable them.
 provider_policy_allows_breakglass() {
   [[ "${WORKCELL_WRAPPER_CONTEXT:-0}" != "1" ]] &&
     [[ "$$" -eq 1 ]] &&
@@ -28,24 +27,18 @@ effective_codex_profile() {
 }
 
 # Normalize a Codex `-c key=value` KEY so equivalent TOML spellings collapse to
-# one canonical form before the blocklist match: valid TOML lets a dotted key be
-# quoted per segment (features."remote_plugin"), single-quoted (features.'x'), or
-# padded with whitespace around the dots (features . plugins). Without this,
-# those spellings would slip past every case pattern below — including the
-# pre-existing mcp/sandbox/profile blocks. Only the KEY (before the first `=`) is
-# normalized; the value is never touched. Segments are split on `.`, trimmed, and
-# stripped of ONE matching pair of surrounding double or single quotes. If any
-# quote character survives (unbalanced or a quoted segment that itself contained a
-# `.` and was split apart), the key is malformed/adversarial and we FAIL CLOSED —
-# returning it as blocked rather than guessing its intent.
+# one canonical lowercase form before the blocklist match. TOML lets a dotted key
+# quote each segment (features."remote_plugin", features.'x') or pad the dots with
+# whitespace (features . plugins); without normalizing, those slip past every case
+# below. Only the KEY (before the first `=`) is touched: split on `.`, trim, strip
+# ONE surrounding quote pair per segment. Any residual quote (e.g. a quoted
+# segment that held a `.` and got split apart) FAILS CLOSED as blocked.
 #
 # We deliberately do NOT decode TOML basic-string escapes (a spec parser turns
 # `"\u0072emote_plugin"` into `remote_plugin`, `"\u0061pproval_policy"` into
-# `approval_policy`, etc.). Re-implementing TOML unescaping in bash would be
-# error-prone, so any backslash surviving in a segment is treated as
-# malformed/adversarial and FAILS CLOSED — the same posture as a residual quote.
-# Bare/quoted keys in the real blocklist never contain backslashes, so this only
-# rejects escape-obfuscated keys. Emits the canonical lowercase key on stdout.
+# `approval_policy`). Re-implementing TOML unescaping in bash is error-prone, so
+# any surviving backslash also FAILS CLOSED. Real blocklist keys never contain
+# backslashes, so this only rejects obfuscated keys. Emits the canonical key.
 codex_normalize_config_key() {
   local key="${1%%=*}"
   local -a segments=()
@@ -79,14 +72,12 @@ codex_normalize_config_key() {
   printf '%s\n' "${normalized,,}"
 }
 
-# Match a NORMALIZED (canonical, lowercase) Codex config key against the
-# top-level guarded-namespace blocklist. Split out from
-# codex_config_override_is_blocked so the profile-scoped path can re-test the
-# post-prefix remainder against the SAME set: a Codex profile-v2 layer
-# (`[profiles.<name>.…]`) can set ANY config key, so every key that is dangerous
-# at top level (features.remote_plugin, plugins.*, marketplaces.*, mcp*, hooks*,
-# sandbox_*, approval_policy, web_search, shell_environment_policy*, …) is
-# equally dangerous scoped under a profile. Returns 0 (guarded) / 1 (not).
+# Match a NORMALIZED (canonical, lowercase) Codex config key against the top-level
+# guarded-namespace blocklist. Split out from codex_config_override_is_blocked so
+# the profile-scoped path can re-test the post-prefix remainder against the SAME
+# set: a Codex profile-v2 layer (`[profiles.<name>.…]`) can set ANY key, so every
+# key dangerous at top level is equally dangerous scoped under a profile. Returns
+# 0 (guarded) / 1 (not).
 codex_config_key_is_guarded() {
   case "$1" in
     profile | sandbox | sandbox_mode | sandbox_permissions | web_search | approval_policy | project_doc_fallback_filenames | project_root_markers | mcp* | plugins | plugins.* | marketplaces | marketplaces.* | hooks | hooks.* | features.plugins | features.plugin_sharing | features.plugin_hooks | features.remote_plugin | features.remote_control | shell_environment_policy | shell_environment_policy.* | sandbox_workspace_write | sandbox_workspace_write.*)
@@ -107,34 +98,27 @@ codex_config_override_is_blocked() {
   # Top-level guarded key (features.remote_plugin, plugins.*, mcp*, hooks*, …).
   codex_config_key_is_guarded "${key_lower}" && return 0
 
-  # Profile-scoped override: a Codex profile-v2 layer `[profiles.<name>.<rest>]`
-  # can set any config key, so `profiles.<name>.features.remote_plugin`,
-  # `profiles.<name>.plugins.*`, `profiles.<name>.mcp_servers.*`, etc. re-enable
-  # the same surfaces the bare `features.*`/`plugins.*`/… blocks reject. The
-  # normalizer guarantees `<name>` is exactly ONE dotted segment (a `.` inside a
-  # quoted profile name fails closed as `__workcell_malformed__`, caught above),
-  # so strip the `profiles.<name>.` prefix and re-test the REMAINDER against the
-  # SAME top-level blocklist — DRY, and it stays correct if that blocklist ever
-  # changes. `profiles` / `profiles.<name>` with no remainder falls through to
-  # the inline-table guard below.
+  # Profile-scoped override: a profile-v2 layer `[profiles.<name>.<rest>]` can set
+  # any key, so `profiles.<name>.features.remote_plugin` etc. re-enable surfaces
+  # the bare blocks reject. The normalizer guarantees `<name>` is exactly ONE
+  # segment (a `.` in a quoted name fails closed above), so strip the
+  # `profiles.<name>.` prefix and re-test the REMAINDER against the SAME blocklist.
+  # `profiles` / `profiles.<name>` with no remainder falls through to the inline-
+  # table guard below.
   if [[ "${key_lower}" == profiles.?*.?* ]]; then
     local profile_remainder="${key_lower#profiles.}"
     profile_remainder="${profile_remainder#*.}"
     codex_config_key_is_guarded "${profile_remainder}" && return 0
   fi
 
-  # Codex parses a `-c` value as TOML, so an inline TABLE smuggles blocked child
-  # keys under a parent that is not itself blocked above — e.g.
-  # `features={remote_plugin=true}` or `profiles={foo={sandbox_mode="danger-full-access"}}`
-  # normalize to the bare parent (`features` / `profiles`), which no case matches.
-  # When the value (everything after the first `=`, whitespace-trimmed) is an
-  # inline table (begins with `{`), block it for every guarded namespace parent:
-  # such a table can set any of the banned children. The managed baseline owns
-  # these tables, so there is no legitimate `-c` whole-table override. Scalar
-  # values (no leading `{`, e.g. model=..., history.persistence="none") are
-  # untouched. Guarded parents cover both the gap namespaces (features, profiles,
-  # profiles.<name>) and the ones already blocked bare above (kept here so the
-  # guard stays robust if a bare-parent case is ever narrowed).
+  # Codex parses a `-c` value as TOML, so an inline TABLE smuggles blocked children
+  # under an unblocked parent — `features={remote_plugin=true}` normalizes to the
+  # bare `features`, which no case matches. When the value (after the first `=`,
+  # trimmed) begins with `{`, block it for every guarded-namespace parent: such a
+  # table can set any banned child, and the managed baseline owns these tables so
+  # no legitimate `-c` whole-table override exists. Scalar values (no leading `{`)
+  # are untouched. Parents cover the gap namespaces and the bare-blocked ones (kept
+  # so the guard survives a later narrowing of a bare-parent case).
   if [[ "${value}" == *=* ]]; then
     local raw_value="${value#*=}"
     raw_value="${raw_value#"${raw_value%%[![:space:]]*}"}"
@@ -151,11 +135,10 @@ codex_config_override_is_blocked() {
 }
 
 # Value-taking global Codex flags must be consumed before first-subcommand
-# detection, or their VALUE would be mistaken for the first command token and
-# the subcommand blocklist below would never run (e.g. `--model gpt-5 plugin`
-# would treat gpt-5 as the command). Keep the set of value-taking globals in
-# this loop in lockstep with codex_first_subcommand in
-# runtime/container/provider-wrapper.sh.
+# detection, or their VALUE would be mistaken for the command token and the
+# subcommand blocklist below would never run (`--model gpt-5 plugin` would treat
+# gpt-5 as the command). Keep the value-taking globals here in lockstep with
+# codex_first_subcommand in runtime/container/provider-wrapper.sh.
 reject_unsafe_codex_args() {
   local expect_value=""
   local arg
@@ -167,8 +150,7 @@ reject_unsafe_codex_args() {
 
   provider_policy_allows_breakglass && return 0
 
-  # The effective profile is a session property (depends only on WORKCELL_MODE),
-  # so resolve it once instead of forking a subshell per --profile occurrence.
+  # Session property (WORKCELL_MODE only): resolve once, not per --profile.
   allowed_profile="$(effective_codex_profile)"
 
   for arg in "$@"; do
@@ -191,44 +173,29 @@ reject_unsafe_codex_args() {
       continue
     fi
 
-    # A bare `--` ends option/subcommand parsing: every following token is
-    # literal prompt text that Codex forwards to the interactive/exec session,
-    # never a flag or subcommand (verified: `codex -- plugin` starts the TUI
-    # with prompt "plugin" rather than dispatching the plugin subcommand). Stop
-    # here so the blocklists do not over-reject a prompt that begins with words
-    # like `plugin`/`mcp`. This mirrors codex_first_subcommand in
-    # runtime/container/provider-wrapper.sh, which returns at `--`. Flag and
-    # value checks BEFORE `--` have already run, so dangerous flags are still
-    # rejected; only post-`--` prompt text is exempt.
+    # A bare `--` ends option/subcommand parsing: every following token is literal
+    # prompt text Codex forwards to the session, never a flag/subcommand (verified:
+    # `codex -- plugin` starts the TUI with prompt "plugin"). Stop here so the
+    # blocklists do not over-reject a prompt beginning with `plugin`/`mcp`. Mirrors
+    # codex_first_subcommand, which also returns at `--`. Flag/value checks BEFORE
+    # `--` have already run, so only post-`--` prompt text is exempt.
     if [[ "${arg}" == "--" ]]; then
       break
     fi
 
-    # After the first subcommand `app-server` is permitted (GUI path only; the
-    # CLI path already died on the bare token above), scan its remaining args for
-    # the app-server control surface and DENY it. The managed GUI launch is
-    # exactly `codex app-server` with NO trailing user args (entrypoint.sh sets
-    # `set -- codex app-server`); the sandbox/approval flags the managed path
-    # needs (`-c sandbox_mode=…`, `--ask-for-approval …`) are PREPENDED by
-    # provider-wrapper.sh AFTER this check, so they never appear in this argv and
-    # need no allowance here. Pinned Codex 0.142.4 (openai/codex tag
-    # rust-v0.142.4, codex-rs/cli/src/main.rs) hides a `--remote-control` flag on
-    # AppServerCommand and exposes an AppServerSubcommand enum
-    # (daemon, proxy, generate-ts, generate-json-schema,
-    # generate-internal-json-schema) plus an AppServerDaemonSubcommand enum
-    # (bootstrap, start, restart, enable-remote-control, disable-remote-control,
-    # stop, version, pid-update-loop). `codex app-server daemon
-    # enable-remote-control`, `codex app-server --remote-control`, and
-    # `codex app-server daemon bootstrap --remote-control` all reach the
-    # remote-control surface the standalone `remote-control` subcommand deny is
-    # meant to block. Deny the KNOWN-dangerous surface explicitly (the hidden
-    # `--remote-control` flag and every app-server/daemon subcommand token) rather
-    # than allowlisting flags: the managed launch carries no trailing args, so an
-    # empty scan permits it while every control token dies. Post-`--` prompt text
-    # is already exempted by the `--` break above. This block only REJECTS and
-    # never `continue`s, so a non-control token (e.g. `-c features.remote_plugin=…`
-    # smuggled after `app-server`) still falls through to the global flag/config
-    # checks below and is caught by codex_config_override_is_blocked.
+    # After the permitted `app-server` subcommand (GUI path only), scan its args
+    # for the control surface and DENY it. The managed GUI launch is exactly
+    # `codex app-server` with NO trailing user args; the sandbox/approval flags it
+    # needs are PREPENDED by provider-wrapper.sh AFTER this check. Pinned Codex
+    # 0.142.4 (codex-rs/cli/src/main.rs) hides a `--remote-control` flag plus
+    # AppServerSubcommand (daemon, proxy, generate-*) and AppServerDaemonSubcommand
+    # (bootstrap, start, restart, enable/disable-remote-control, stop, version,
+    # pid-update-loop) enums that all reach the remote-control surface the
+    # standalone `remote-control` deny blocks. Deny the known control tokens
+    # explicitly rather than allowlisting flags: the managed launch has no trailing
+    # args, so an empty scan permits it while every control token dies. This block
+    # only REJECTS (never `continue`s), so a smuggled `-c …` after `app-server`
+    # still falls through to the config check below.
     if [[ "${saw_app_server}" -eq 1 ]]; then
       case "${arg}" in
         --remote-control | --remote-control=*)
@@ -242,14 +209,11 @@ reject_unsafe_codex_args() {
       esac
     fi
 
-    # After the first subcommand `features`, its ACTION token (enable/disable/
-    # list) is the next bare token. `features enable/disable <name>` persistently
-    # writes features.<name>=true/false into the writable CODEX_HOME/config.toml
-    # (equivalent to the blocked `-c features.<name>=…`), re-enabling e.g.
-    # plugins/remote_plugin for the in-TUI browser, so both mutating actions are
-    # blocked. `features list` is a read-only inspect (used by the managed
-    # validation path) and stays permitted; the managed baseline sets features
-    # declaratively in config, so it never needs the imperative toggle.
+    # After the `features` subcommand, its ACTION token is the next bare token.
+    # `features enable/disable <name>` persistently writes features.<name> into the
+    # writable config.toml (equivalent to the blocked `-c features.<name>=…`), so
+    # both mutating actions are blocked. `features list` is a read-only inspect and
+    # stays permitted; the managed baseline sets features declaratively.
     if [[ "${expect_features_action}" -eq 1 ]] && [[ "${arg}" != -* ]]; then
       expect_features_action=0
       case "${arg}" in
@@ -262,42 +226,27 @@ reject_unsafe_codex_args() {
 
     if [[ "${saw_command}" -eq 0 ]] && [[ "${arg}" != -* ]]; then
       saw_command=1
-      # DENY-BY-DEFAULT over the SUBCOMMAND NAMESPACE. Codex's CLI contract is
-      # `codex [OPTIONS] [PROMPT]` OR `codex [OPTIONS] <COMMAND> [ARGS]`: the
-      # first bare token is a SUBCOMMAND iff it exactly matches one of Codex's
-      # known subcommand names, otherwise it is literal PROMPT text that Codex
-      # forwards to the session (empirically on pinned 0.142.4:
-      # `codex "fix tests" --version` prints the version and exits 0, treating
-      # "fix tests" as the prompt, never as a command). So we partition Codex's
-      # COMPLETE subcommand set into an ALLOW set (permit — classified safe) and
-      # a DENY set (die — dangerous/unsupported); a token in NEITHER set is not a
-      # subcommand at all and is permitted as prompt text, exactly as Codex
-      # treats it. This preserves the bare-prompt invocation
-      # `workcell --agent codex --agent-arg "fix tests"` (Codex P2 review) while
-      # still denying every known-dangerous subcommand by exact token.
+      # DENY-BY-DEFAULT over the SUBCOMMAND NAMESPACE. Codex's contract is
+      # `codex [OPTIONS] [PROMPT]` OR `codex [OPTIONS] <COMMAND> [ARGS]`: the first
+      # bare token is a SUBCOMMAND iff it exactly matches a known name, else it is
+      # literal PROMPT text (verified on 0.142.4: `codex "fix tests" --version`
+      # prints the version, treating "fix tests" as the prompt). So partition the
+      # COMPLETE subcommand set into ALLOW (permit — classified safe) and DENY (die
+      # — dangerous); a token in NEITHER is prompt text, permitted as Codex treats
+      # it. This preserves the bare-prompt invocation (Codex P2 review) while
+      # denying every known-dangerous subcommand by exact token.
       #
-      # ALLOW (read-only/session surface, verified against the pinned runtime
-      # Codex 0.142.4 `codex --help`): exec + its `e` alias, review, login,
-      # logout, completion, doctor, apply + its `a` alias, resume, fork, archive,
-      # unarchive, delete, help, debug. These take a fixed image and only read
-      # state or drive an in-session/session-management flow. `execpolicy` is a
-      # hidden (not in `--help`) but real subcommand present in the pinned
-      # runtime Codex: it is a pure read-only command classifier
-      # (`codex execpolicy check --rules … <cmd>` returns a JSON allow/prompt/
-      # forbid decision, mutating nothing) that the managed prompt-autonomy path
-      # and verify-invariants both invoke — it MUST stay permitted or the
-      # session-rule enforcement breaks (empirically: omitting it fails
-      # container-smoke's execpolicy checks). Exact-token discipline (NOT globs)
-      # keeps the fence tight: `exec` != `exec-server`, `mcp` != `mcp-server`,
-      # so the daemon variants stay denied. Keep this list in lockstep with the
-      # non-runtime set in codex_managed_profile_applies, the value-taking
-      # globals in codex_first_subcommand (runtime/container/provider-wrapper.sh;
-      # same first-token detection), and the classified subcommand fixture
-      # tests/fixtures/codex-subcommands.txt (verify-invariants asserts the
-      # pinned Codex's full subcommand list is fully partitioned into this ALLOW
-      # set plus the DENY set below, so a future pin that adds an UNCLASSIFIED
-      # subcommand — which would otherwise leak through as prompt text — fails
-      # CI until a human classifies it).
+      # ALLOW (read-only/session surface, verified against 0.142.4 `--help`): exec
+      # +`e`, review, login, logout, completion, doctor, apply +`a`, resume, fork,
+      # archive, unarchive, delete, help, debug. `execpolicy` is hidden but real: a
+      # pure read-only command classifier the managed autonomy path and
+      # verify-invariants invoke — it MUST stay permitted or session-rule
+      # enforcement breaks. Exact-token discipline (NOT globs) keeps the fence
+      # tight: `exec` != `exec-server`, `mcp` != `mcp-server`. Keep in lockstep
+      # with codex_managed_profile_applies, codex_first_subcommand, and the fixture
+      # tests/fixtures/codex-subcommands.txt (verify-invariants asserts the full
+      # subcommand list partitions into this ALLOW set plus the DENY set below, so
+      # a future pin adding an UNCLASSIFIED subcommand fails CI until classified).
       case "${arg}" in
         exec | e | review | login | logout | completion | doctor | \
           apply | a | resume | fork | archive | unarchive | delete | \
@@ -305,75 +254,56 @@ reject_unsafe_codex_args() {
           continue
           ;;
         features)
-          # `features` bare and `features list` are read-only inspects and stay
-          # permitted; arm the action check so the next bare token (enable/
-          # disable) is caught and denied by the block above.
+          # `features`/`features list` are read-only inspects; arm the action
+          # check so the next bare token (enable/disable) is denied above.
           expect_features_action=1
           continue
           ;;
         app | app-server)
-          # app-server is the managed GUI backend Workcell launches (see
-          # entrypoint.sh), so it is permitted ONLY under AGENT_UI=gui; on the
-          # CLI path it is not a supported surface and is denied. (`app` is not a
-          # subcommand on pinned 0.142.4 but is kept GUI-gated here for the same
-          # class so a later pin that reintroduces it stays covered.) The GUI
-          # gate is scoped to these two tokens; every DENY-set subcommand below
-          # is denied on every UI, so an in-container AGENT_UI=gui override
-          # cannot smuggle in plugin/mcp/remote-control the way a GUI-gated
-          # blocklist once let it.
+          # app-server is the managed GUI backend, permitted ONLY under
+          # AGENT_UI=gui; on the CLI path it is denied. (`app` is not a 0.142.4
+          # subcommand but is GUI-gated for the same class if a later pin
+          # reintroduces it.) The gate is scoped to these two tokens; every DENY
+          # subcommand below is denied on every UI, so an AGENT_UI=gui override
+          # cannot smuggle in plugin/mcp/remote-control.
           [[ "${AGENT_UI:-cli}" != "gui" ]] &&
             workcell_die "Workcell blocked unsupported Codex CLI subcommand outside the managed GUI path: ${arg}"
-          # Permitted on the GUI path: arm the app-server surface scan so every
-          # subsequent arg is checked against the app-server control surface
-          # (--remote-control flag + app-server/daemon subcommand tokens) by the
-          # block near the top of the loop.
+          # Arm the app-server surface scan (block near the top of the loop).
           saw_app_server=1
           continue
           ;;
-        # DENY set — every known-dangerous/unsupported Codex subcommand, denied
-        # by EXACT token on every UI. Enumerated against pinned 0.142.4 so that
-        # ALLOW ∪ GUI-gated ∪ DENY equals the complete subcommand list (the
-        # fixture completeness check enforces this). These are the control-plane,
-        # daemon, marketplace, sandbox-escape, and self-update surfaces that the
-        # managed session must never reach.
+        # DENY set — every known-dangerous/unsupported subcommand, denied by EXACT
+        # token on every UI. Enumerated against 0.142.4 so ALLOW ∪ GUI-gated ∪ DENY
+        # equals the complete subcommand list (the fixture completeness check
+        # enforces this). Control-plane, daemon, marketplace, sandbox-escape, and
+        # self-update surfaces the managed session must never reach.
         plugin | remote-control | exec-server | mcp | mcp-server | cloud | \
           cloud-tasks | responses-api-proxy | stdio-to-uds | sandbox | update)
-          # cloud-tasks is the pinned-0.142.4 alias of `cloud` (the hosted
-          # control-plane surface); responses-api-proxy and stdio-to-uds are
-          # HIDDEN (not in `codex --help`) daemon/bridge subcommands the pinned
-          # clap Subcommand enum still dispatches on — all denied by exact token
-          # on every UI. `update` is not a 0.142.4 variant (it lands in 0.143);
-          # it is kept here as harmless forward-compat and is intentionally
-          # absent from tests/fixtures/codex-subcommands.txt (that fixture lists
-          # only real 0.142.4 tokens), which the completeness check tolerates
-          # because it only asserts fixture ⊆ classified, not equality.
+          # cloud-tasks is the 0.142.4 alias of `cloud`; responses-api-proxy and
+          # stdio-to-uds are HIDDEN daemon/bridge subcommands the clap enum still
+          # dispatches. `update` is not a 0.142.4 variant (lands in 0.143); kept as
+          # forward-compat and intentionally absent from the fixture, which the
+          # completeness check tolerates (it asserts fixture ⊆ classified only).
           workcell_die "Workcell blocked unsupported Codex CLI subcommand: ${arg}"
           ;;
       esac
       # Not a known subcommand (neither ALLOW, GUI-gated, nor DENY): it is PROMPT
-      # text, so permit it exactly as Codex would. `saw_command=1` above stops
-      # any later bare token from being re-checked as a subcommand — Codex only
-      # dispatches on the FIRST bare token, and everything after a prompt is
-      # prompt/argument data. Deny-by-default safety is preserved because the
-      # fixture completeness check guarantees no UNCLASSIFIED subcommand exists to
-      # fall through here undetected.
+      # text, permitted as Codex would. `saw_command=1` stops any later bare token
+      # from being re-checked — Codex dispatches only on the FIRST bare token.
+      # Deny-by-default holds because the fixture completeness check guarantees no
+      # UNCLASSIFIED subcommand falls through here undetected.
       continue
     fi
 
     case "${arg}" in
-      # Every Codex `--dangerously-bypass-*` flag is DANGEROUS by codex's own docs
-      # (0.143 adds --dangerously-bypass-hook-trust alongside the existing
-      # --dangerously-bypass-approvals-and-sandbox); none is valid in managed
-      # mode. Glob-match the whole bypass family so future dangerously-bypass
-      # flags are covered without a code change (also catches any
-      # `--dangerously-bypass-*=value` form). Scope is `--dangerously-bypass-*`,
-      # NOT `--dangerously-*`, so it does not swallow non-codex tokens like
-      # Claude's `--dangerously-skip-permissions` when they appear as data passed
-      # to `codex execpolicy check <command…>`. Keep the remaining explicit unsafe
-      # flags in the same case/message. --yolo is Codex's documented alias for
-      # --dangerously-bypass-approvals-and-sandbox (it is a hidden alias, so the
-      # --dangerously-bypass-* glob does not reach it — block the alias and its
-      # =value form explicitly).
+      # Every `--dangerously-bypass-*` flag is DANGEROUS (0.143 adds
+      # --dangerously-bypass-hook-trust); glob-match the whole family (incl.
+      # `=value`) so future bypass flags are covered without a code change. Scope
+      # is `--dangerously-bypass-*`, NOT `--dangerously-*`, so it does not swallow
+      # Claude's `--dangerously-skip-permissions` passed as data to `codex
+      # execpolicy check`. --yolo is Codex's hidden alias for
+      # --dangerously-bypass-approvals-and-sandbox (the glob does not reach a
+      # hidden alias, so block it and its =value form explicitly).
       --dangerously-bypass-* | --yolo | --yolo=* | --search | --add-dir | --remote | --full-auto | -a | --ask-for-approval | --enable | --disable)
         workcell_die "Workcell blocked unsafe Codex override: ${arg}"
         ;;
@@ -384,12 +314,10 @@ reject_unsafe_codex_args() {
         expect_value="cd"
         ;;
       -m | --model | -i | --image | --local-provider | --remote-auth-token-env)
-        # Permitted value-taking globals: consume the value so it is never
-        # mistaken for the first subcommand (see the function comment). The other
-        # value-taking globals (-c/--config, -C/--cd, -s/--sandbox, -p/--profile)
-        # are consumed by their own cases above, and --add-dir/--remote/--enable/
-        # --disable/-a/--ask-for-approval die on sight before their value is
-        # reached, so no value-taking global can desync subcommand detection.
+        # Permitted value-taking globals: consume the value so it is never mistaken
+        # for the first subcommand. The other value-taking globals are consumed by
+        # their own cases above, and the unsafe ones die on sight before their
+        # value is reached, so none can desync subcommand detection.
         expect_value="safe"
         ;;
       --ask-for-approval=*)
@@ -417,15 +345,12 @@ reject_unsafe_codex_args() {
         codex_config_override_is_blocked "${arg#--config=}" && workcell_die "Workcell blocked unsafe Codex config override: ${arg#--config=}"
         ;;
       -c?*)
-        # Short config flag glued to its value: Codex accepts both `-cKEY=VALUE`
-        # (`-cfeatures.remote_plugin=true`) and `-c=KEY=VALUE` (the `=` is clap's
-        # short-flag value separator, so `-c=model=x` carries value `model=x`).
-        # Without this case the attached form skipped the blocklist entirely —
-        # only separate `-c <value>` and `--config=<value>` were routed — letting
-        # `-cfeatures.remote_plugin=true` / `-cfeatures={remote_plugin=true}`
-        # re-enable the very surfaces this gate pins off (Codex P1 review). Strip
-        # the `-c` prefix and one optional leading `=`, then run the SAME
-        # codex_config_override_is_blocked check as the other config forms.
+        # Short config flag glued to its value: Codex accepts `-cKEY=VALUE` and
+        # `-c=KEY=VALUE` (clap's short-flag `=` separator). Without this case the
+        # attached form skipped the blocklist entirely (only `-c <value>` and
+        # `--config=<value>` were routed), letting `-cfeatures.remote_plugin=true`
+        # re-enable pinned-off surfaces (Codex P1 review). Strip the `-c` prefix
+        # and one optional `=`, then run the SAME check as the other config forms.
         codex_config_value="${arg#-c}"
         codex_config_value="${codex_config_value#=}"
         codex_config_override_is_blocked "${codex_config_value}" &&

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -194,29 +194,47 @@ reject_unsafe_codex_args() {
       workcell_die "Workcell blocked unsupported Codex app-server argument: ${arg} (only the managed no-arg app-server launch is permitted)"
     fi
 
+    # After the `features` subcommand, its ACTION token is the next bare token.
+    # `features enable/disable <name>` persistently writes features.<name> into the
+    # writable config.toml (equivalent to the blocked `-c features.<name>=…`), so
+    # both mutating actions are blocked. `features list` is a read-only inspect and
+    # stays permitted; the managed baseline sets features declaratively. This runs
+    # BEFORE the `--` break: a bare `--` MUST NOT let the pending action slip past
+    # the deny — while armed, a `--` is skipped WITHOUT disarming so the following
+    # token (enable/disable/list) is still classified. `codex features` has no
+    # `[PROMPT]` positional (usage: `features [OPTIONS] <COMMAND>`), so a post-`--`
+    # token is a subcommand slot, never prompt text; pinned 0.142.4 clap-errors on
+    # `features -- enable` today, but honoring the pending action here denies the
+    # mutating actions across a `--` even if a future pin dispatches the subcommand
+    # after `--` (as app-server's optional `[COMMAND]` already does).
+    if [[ "${expect_features_action}" -eq 1 ]]; then
+      # A `--` while armed is NOT the action and MUST NOT trip the general `--`
+      # break below: skip it, stay armed, and keep scanning for the action token.
+      if [[ "${arg}" == "--" ]]; then
+        continue
+      fi
+      # A flag (e.g. `features --json`) is a `features` option, not the action, so
+      # leave the arm intact and fall through to the flag/value cases below.
+      if [[ "${arg}" != -* ]]; then
+        expect_features_action=0
+        case "${arg}" in
+          enable | disable)
+            workcell_die "Workcell blocked unsupported Codex CLI subcommand: features ${arg}"
+            ;;
+        esac
+        continue
+      fi
+    fi
+
     # A bare `--` ends option/subcommand parsing: every following token is literal
     # prompt text Codex forwards to the session, never a flag/subcommand (verified:
     # `codex -- plugin` starts the TUI with prompt "plugin"). Stop here so the
     # blocklists do not over-reject a prompt beginning with `plugin`/`mcp`. Mirrors
     # codex_first_subcommand, which also returns at `--`. Flag/value checks BEFORE
-    # `--` have already run, so only post-`--` prompt text is exempt.
+    # `--` have already run, so only post-`--` prompt text is exempt. Not reached
+    # while a features action is pending (handled above).
     if [[ "${arg}" == "--" ]]; then
       break
-    fi
-
-    # After the `features` subcommand, its ACTION token is the next bare token.
-    # `features enable/disable <name>` persistently writes features.<name> into the
-    # writable config.toml (equivalent to the blocked `-c features.<name>=…`), so
-    # both mutating actions are blocked. `features list` is a read-only inspect and
-    # stays permitted; the managed baseline sets features declaratively.
-    if [[ "${expect_features_action}" -eq 1 ]] && [[ "${arg}" != -* ]]; then
-      expect_features_action=0
-      case "${arg}" in
-        enable | disable)
-          workcell_die "Workcell blocked unsupported Codex CLI subcommand: features ${arg}"
-          ;;
-      esac
-      continue
     fi
 
     if [[ "${saw_command}" -eq 0 ]] && [[ "${arg}" != -* ]]; then

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -27,25 +27,111 @@ effective_codex_profile() {
   esac
 }
 
+# Normalize a Codex `-c key=value` KEY so equivalent TOML spellings collapse to
+# one canonical form before the blocklist match: valid TOML lets a dotted key be
+# quoted per segment (features."remote_plugin"), single-quoted (features.'x'), or
+# padded with whitespace around the dots (features . plugins). Without this,
+# those spellings would slip past every case pattern below — including the
+# pre-existing mcp/sandbox/profile blocks. Only the KEY (before the first `=`) is
+# normalized; the value is never touched. Segments are split on `.`, trimmed, and
+# stripped of ONE matching pair of surrounding double or single quotes. If any
+# quote character survives (unbalanced or a quoted segment that itself contained a
+# `.` and was split apart), the key is malformed/adversarial and we FAIL CLOSED —
+# returning it as blocked rather than guessing its intent.
+#
+# We deliberately do NOT decode TOML basic-string escapes (a spec parser turns
+# `"\u0072emote_plugin"` into `remote_plugin`, `"\u0061pproval_policy"` into
+# `approval_policy`, etc.). Re-implementing TOML unescaping in bash would be
+# error-prone, so any backslash surviving in a segment is treated as
+# malformed/adversarial and FAILS CLOSED — the same posture as a residual quote.
+# Bare/quoted keys in the real blocklist never contain backslashes, so this only
+# rejects escape-obfuscated keys. Emits the canonical lowercase key on stdout.
+codex_normalize_config_key() {
+  local key="${1%%=*}"
+  local -a segments=()
+  local segment normalized="" first=1
+  local backslash=$'\\'
+  local IFS='.'
+  read -r -a segments <<<"${key}"
+  for segment in "${segments[@]}"; do
+    # Trim surrounding whitespace (handles `features . plugins`).
+    segment="${segment#"${segment%%[![:space:]]*}"}"
+    segment="${segment%"${segment##*[![:space:]]}"}"
+    # Strip one matching pair of surrounding quotes.
+    if [[ ${#segment} -ge 2 && "${segment:0:1}" == '"' && "${segment: -1}" == '"' ]]; then
+      segment="${segment:1:${#segment}-2}"
+    elif [[ ${#segment} -ge 2 && "${segment:0:1}" == "'" && "${segment: -1}" == "'" ]]; then
+      segment="${segment:1:${#segment}-2}"
+    fi
+    # Any residual quote, or any backslash (TOML escape we refuse to decode),
+    # => malformed/adversarial => fail closed.
+    if [[ "${segment}" == *'"'* || "${segment}" == *"'"* || "${segment}" == *"${backslash}"* ]]; then
+      printf '%s\n' '__workcell_malformed__'
+      return 0
+    fi
+    if [[ "${first}" -eq 1 ]]; then
+      normalized="${segment}"
+      first=0
+    else
+      normalized="${normalized}.${segment}"
+    fi
+  done
+  printf '%s\n' "${normalized,,}"
+}
+
 codex_config_override_is_blocked() {
   local value="$1"
-  local key="${value%%=*}"
-  local key_lower="${key,,}"
+  local key_lower
+  key_lower="$(codex_normalize_config_key "${value}")"
+
+  # Fail-closed sentinel for keys that stayed malformed after normalization.
+  [[ "${key_lower}" == "__workcell_malformed__" ]] && return 0
 
   case "${key_lower}" in
-    profile | sandbox | sandbox_mode | sandbox_permissions | web_search | approval_policy | project_doc_fallback_filenames | project_root_markers | mcp* | shell_environment_policy | shell_environment_policy.* | sandbox_workspace_write | sandbox_workspace_write.* | profiles.*.sandbox_mode | profiles.*.approval_policy | profiles.*.web_search | profiles.*.shell_environment_policy | profiles.*.shell_environment_policy.* | profiles.*.sandbox_workspace_write | profiles.*.sandbox_workspace_write.*)
+    profile | sandbox | sandbox_mode | sandbox_permissions | web_search | approval_policy | project_doc_fallback_filenames | project_root_markers | mcp* | plugins | plugins.* | marketplaces | marketplaces.* | hooks | hooks.* | features.plugins | features.plugin_sharing | features.plugin_hooks | features.remote_plugin | features.remote_control | shell_environment_policy | shell_environment_policy.* | sandbox_workspace_write | sandbox_workspace_write.* | profiles.*.sandbox_mode | profiles.*.approval_policy | profiles.*.web_search | profiles.*.shell_environment_policy | profiles.*.shell_environment_policy.* | profiles.*.sandbox_workspace_write | profiles.*.sandbox_workspace_write.*)
       return 0
       ;;
   esac
 
+  # Codex parses a `-c` value as TOML, so an inline TABLE smuggles blocked child
+  # keys under a parent that is not itself blocked above — e.g.
+  # `features={remote_plugin=true}` or `profiles={foo={sandbox_mode="danger-full-access"}}`
+  # normalize to the bare parent (`features` / `profiles`), which no case matches.
+  # When the value (everything after the first `=`, whitespace-trimmed) is an
+  # inline table (begins with `{`), block it for every guarded namespace parent:
+  # such a table can set any of the banned children. The managed baseline owns
+  # these tables, so there is no legitimate `-c` whole-table override. Scalar
+  # values (no leading `{`, e.g. model=..., history.persistence="none") are
+  # untouched. Guarded parents cover both the gap namespaces (features, profiles,
+  # profiles.<name>) and the ones already blocked bare above (kept here so the
+  # guard stays robust if a bare-parent case is ever narrowed).
+  if [[ "${value}" == *=* ]]; then
+    local raw_value="${value#*=}"
+    raw_value="${raw_value#"${raw_value%%[![:space:]]*}"}"
+    if [[ "${raw_value}" == '{'* ]]; then
+      case "${key_lower}" in
+        features | plugins | marketplaces | mcp* | hooks | profiles | profiles.* | shell_environment_policy | sandbox_workspace_write)
+          return 0
+          ;;
+      esac
+    fi
+  fi
+
   return 1
 }
 
+# Value-taking global Codex flags must be consumed before first-subcommand
+# detection, or their VALUE would be mistaken for the first command token and
+# the subcommand blocklist below would never run (e.g. `--model gpt-5 plugin`
+# would treat gpt-5 as the command). Keep the set of value-taking globals in
+# this loop in lockstep with codex_first_subcommand in
+# runtime/container/provider-wrapper.sh.
 reject_unsafe_codex_args() {
   local expect_value=""
   local arg
   local saw_command=0
   local allowed_profile=""
+  local expect_features_action=0
 
   provider_policy_allows_breakglass && return 0
 
@@ -73,27 +159,126 @@ reject_unsafe_codex_args() {
       continue
     fi
 
-    if [[ "${saw_command}" -eq 0 ]] && [[ "${arg}" != -* ]]; then
-      saw_command=1
-      if [[ "${AGENT_UI:-cli}" != "gui" ]]; then
-        case "${arg}" in
-          app | app-server | cloud | mcp | sandbox)
-            workcell_die "Workcell blocked unsupported Codex CLI subcommand outside the managed GUI path: ${arg}"
-            ;;
-        esac
-      fi
+    # A bare `--` ends option/subcommand parsing: every following token is
+    # literal prompt text that Codex forwards to the interactive/exec session,
+    # never a flag or subcommand (verified: `codex -- plugin` starts the TUI
+    # with prompt "plugin" rather than dispatching the plugin subcommand). Stop
+    # here so the blocklists do not over-reject a prompt that begins with words
+    # like `plugin`/`mcp`. This mirrors codex_first_subcommand in
+    # runtime/container/provider-wrapper.sh, which returns at `--`. Flag and
+    # value checks BEFORE `--` have already run, so dangerous flags are still
+    # rejected; only post-`--` prompt text is exempt.
+    if [[ "${arg}" == "--" ]]; then
+      break
+    fi
+
+    # After the first subcommand `features`, its ACTION token (enable/disable/
+    # list) is the next bare token. `features enable/disable <name>` persistently
+    # writes features.<name>=true/false into the writable CODEX_HOME/config.toml
+    # (equivalent to the blocked `-c features.<name>=…`), re-enabling e.g.
+    # plugins/remote_plugin for the in-TUI browser, so both mutating actions are
+    # blocked. `features list` is a read-only inspect (used by the managed
+    # validation path) and stays permitted; the managed baseline sets features
+    # declaratively in config, so it never needs the imperative toggle.
+    if [[ "${expect_features_action}" -eq 1 ]] && [[ "${arg}" != -* ]]; then
+      expect_features_action=0
+      case "${arg}" in
+        enable | disable)
+          workcell_die "Workcell blocked unsupported Codex CLI subcommand: features ${arg}"
+          ;;
+      esac
       continue
     fi
 
+    if [[ "${saw_command}" -eq 0 ]] && [[ "${arg}" != -* ]]; then
+      saw_command=1
+      # DENY-BY-DEFAULT subcommand gate. The first bare token is Codex's
+      # subcommand; permit it ONLY if it is on the classified-safe ALLOWLIST
+      # below, otherwise die. This replaces the historical blocklist that every
+      # CLI version bump silently reopened (a new dangerous subcommand shipped
+      # unlisted was permitted until someone noticed); with an allowlist, any
+      # new AND any unknown subcommand is denied until explicitly vetted.
+      #
+      # The permit set is the read-only/session surface verified against real
+      # `codex --help` (0.144): exec + its `e` alias, review, login, logout,
+      # completion, doctor, apply + its `a` alias, resume, fork, archive,
+      # unarchive, delete, help, debug. These take a fixed image and only read
+      # state or drive an in-session/session-management flow. `execpolicy` is a
+      # hidden (not in `--help`) but real subcommand present in the pinned
+      # runtime Codex: it is a pure read-only command classifier
+      # (`codex execpolicy check --rules … <cmd>` returns a JSON allow/prompt/
+      # forbid decision, mutating nothing) that the managed prompt-autonomy path
+      # and verify-invariants both invoke — it MUST stay permitted or the
+      # session-rule enforcement breaks (empirically: omitting it fails
+      # container-smoke's execpolicy checks). Exact-token discipline (NOT globs)
+      # keeps the fence tight: `exec` != `exec-server`, `mcp` != `mcp-server`,
+      # so the daemon variants stay denied. Keep this list in lockstep with the
+      # non-runtime set in codex_managed_profile_applies and the value-taking
+      # globals in codex_first_subcommand
+      # (runtime/container/provider-wrapper.sh; same first-token detection).
+      case "${arg}" in
+        exec | e | review | login | logout | completion | doctor | \
+          apply | a | resume | fork | archive | unarchive | delete | \
+          help | debug | execpolicy)
+          continue
+          ;;
+        features)
+          # `features` bare and `features list` are read-only inspects and stay
+          # permitted; arm the action check so the next bare token (enable/
+          # disable) is caught and denied by the block above.
+          expect_features_action=1
+          continue
+          ;;
+        app | app-server)
+          # app-server is the managed GUI backend Workcell launches (see
+          # entrypoint.sh), so it is permitted ONLY under AGENT_UI=gui; on the
+          # CLI path it is not a supported surface and is denied. The GUI gate is
+          # scoped to these two tokens; every other non-allowlisted subcommand is
+          # denied on every UI (below), so an in-container AGENT_UI=gui override
+          # cannot smuggle in plugin/mcp/remote-control the way a GUI-gated
+          # blocklist once let it.
+          [[ "${AGENT_UI:-cli}" != "gui" ]] &&
+            workcell_die "Workcell blocked unsupported Codex CLI subcommand outside the managed GUI path: ${arg}"
+          continue
+          ;;
+      esac
+      # Everything not on the allowlist above (plugin, remote-control,
+      # exec-server, mcp, mcp-server, cloud, sandbox, update, and any unknown or
+      # future subcommand) is denied — deny-by-default.
+      workcell_die "Workcell blocked unsupported Codex CLI subcommand: ${arg}"
+    fi
+
     case "${arg}" in
-      --dangerously-bypass-approvals-and-sandbox | --search | --add-dir | --remote | --full-auto | -a | --ask-for-approval | --enable | --disable)
+      # Every Codex `--dangerously-bypass-*` flag is DANGEROUS by codex's own docs
+      # (0.143 adds --dangerously-bypass-hook-trust alongside the existing
+      # --dangerously-bypass-approvals-and-sandbox); none is valid in managed
+      # mode. Glob-match the whole bypass family so future dangerously-bypass
+      # flags are covered without a code change (also catches any
+      # `--dangerously-bypass-*=value` form). Scope is `--dangerously-bypass-*`,
+      # NOT `--dangerously-*`, so it does not swallow non-codex tokens like
+      # Claude's `--dangerously-skip-permissions` when they appear as data passed
+      # to `codex execpolicy check <command…>`. Keep the remaining explicit unsafe
+      # flags in the same case/message. --yolo is Codex's documented alias for
+      # --dangerously-bypass-approvals-and-sandbox (it is a hidden alias, so the
+      # --dangerously-bypass-* glob does not reach it — block the alias and its
+      # =value form explicitly).
+      --dangerously-bypass-* | --yolo | --yolo=* | --search | --add-dir | --remote | --full-auto | -a | --ask-for-approval | --enable | --disable)
         workcell_die "Workcell blocked unsafe Codex override: ${arg}"
         ;;
       -p | --profile)
         expect_value="profile"
         ;;
-      --cd)
+      -C | --cd)
         expect_value="cd"
+        ;;
+      -m | --model | -i | --image | --local-provider | --remote-auth-token-env)
+        # Permitted value-taking globals: consume the value so it is never
+        # mistaken for the first subcommand (see the function comment). The other
+        # value-taking globals (-c/--config, -C/--cd, -s/--sandbox, -p/--profile)
+        # are consumed by their own cases above, and --add-dir/--remote/--enable/
+        # --disable/-a/--ask-for-approval die on sight before their value is
+        # reached, so no value-taking global can desync subcommand detection.
+        expect_value="safe"
         ;;
       --ask-for-approval=*)
         workcell_die "Workcell blocked unsafe Codex override: --ask-for-approval"

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -128,11 +128,18 @@ codex_config_override_is_blocked() {
 # emit BYTE-IDENTICAL deny messages (tests + operators grep them). Each takes the raw
 # value plus the resolved allowed profile.
 codex_reject_unsafe_profile_value() {
-  [[ "$1" != "$2" ]] && workcell_die "Workcell blocked unsafe Codex override: --profile"
+  # Strip a leading `=`: clap accepts the short-with-equals form (`-p=VALUE`),
+  # so the glued `-p?*` case passes `=VALUE`; the space-separated and
+  # `--profile=` callers pass a bare value (no-op here).
+  local value="${1#=}"
+  [[ "${value}" != "$2" ]] && workcell_die "Workcell blocked unsafe Codex override: --profile"
 }
 
 codex_reject_unsafe_sandbox_value() {
-  [[ "$1" == "danger-full-access" ]] && workcell_die "Workcell blocked unsafe Codex override: remove danger-full-access outside breakglass."
+  # Strip a leading `=` for the short-with-equals form (`-s=danger-full-access`);
+  # space-separated and `--sandbox=` callers pass a bare value (no-op here).
+  local value="${1#=}"
+  [[ "${value}" == "danger-full-access" ]] && workcell_die "Workcell blocked unsafe Codex override: remove danger-full-access outside breakglass."
 }
 
 # Value-taking global Codex flags must be consumed before first-subcommand detection,

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -173,6 +173,27 @@ reject_unsafe_codex_args() {
       continue
     fi
 
+    # DENY-BY-DEFAULT after the permitted `app-server` subcommand (GUI path only):
+    # ANY user token following `app-server` dies, full stop. The managed GUI launch
+    # is EXACTLY `codex app-server` with NO trailing user args (entrypoint.sh sets
+    # `set -- codex app-server`); the sandbox/approval flags it needs are PREPENDED
+    # by provider-wrapper.sh AFTER this check, so they never appear in the argv
+    # scanned here. Thus a legitimate managed launch reaches this function as bare
+    # `app-server` with zero trailing tokens. A token denylist over pinned Codex
+    # 0.142.4 leaked: AppServerCommand also accepts `--listen ws://IP:PORT` (opens a
+    # listening socket), `--stdio`, `--strict-config`, `--analytics-default-enabled`,
+    # `-c …`, plus AppServerSubcommand/AppServerDaemonSubcommand control tokens —
+    # every one reachable via an AGENT_UI=gui override. Rejecting ANY token instead
+    # of enumerating them is stricter, simpler, and covers future flags without a
+    # hand-maintained list. This check runs BEFORE the `--` break below because
+    # `codex app-server` has NO `[PROMPT]` positional (usage: `app-server [OPTIONS]
+    # [COMMAND]`; `app-server -- foo` is parsed as the unrecognized subcommand
+    # `foo`, not prompt text), so a post-`--` token is still not the managed shape
+    # and must die too.
+    if [[ "${saw_app_server}" -eq 1 ]]; then
+      workcell_die "Workcell blocked unsupported Codex app-server argument: ${arg} (only the managed no-arg app-server launch is permitted)"
+    fi
+
     # A bare `--` ends option/subcommand parsing: every following token is literal
     # prompt text Codex forwards to the session, never a flag/subcommand (verified:
     # `codex -- plugin` starts the TUI with prompt "plugin"). Stop here so the
@@ -181,32 +202,6 @@ reject_unsafe_codex_args() {
     # `--` have already run, so only post-`--` prompt text is exempt.
     if [[ "${arg}" == "--" ]]; then
       break
-    fi
-
-    # After the permitted `app-server` subcommand (GUI path only), scan its args
-    # for the control surface and DENY it. The managed GUI launch is exactly
-    # `codex app-server` with NO trailing user args; the sandbox/approval flags it
-    # needs are PREPENDED by provider-wrapper.sh AFTER this check. Pinned Codex
-    # 0.142.4 (codex-rs/cli/src/main.rs) hides a `--remote-control` flag plus
-    # AppServerSubcommand (daemon, proxy, generate-*) and AppServerDaemonSubcommand
-    # (bootstrap, start, restart, enable/disable-remote-control, stop, version,
-    # pid-update-loop) enums that all reach the remote-control surface the
-    # standalone `remote-control` deny blocks. Deny the known control tokens
-    # explicitly rather than allowlisting flags: the managed launch has no trailing
-    # args, so an empty scan permits it while every control token dies. This block
-    # only REJECTS (never `continue`s), so a smuggled `-c …` after `app-server`
-    # still falls through to the config check below.
-    if [[ "${saw_app_server}" -eq 1 ]]; then
-      case "${arg}" in
-        --remote-control | --remote-control=*)
-          workcell_die "Workcell blocked unsafe Codex app-server override: --remote-control"
-          ;;
-        daemon | proxy | generate-ts | generate-json-schema | generate-internal-json-schema | \
-          bootstrap | start | restart | enable-remote-control | disable-remote-control | \
-          stop | version | pid-update-loop)
-          workcell_die "Workcell blocked unsupported Codex app-server subcommand: ${arg}"
-          ;;
-      esac
     fi
 
     # After the `features` subcommand, its ACTION token is the next bare token.

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -132,6 +132,7 @@ reject_unsafe_codex_args() {
   local saw_command=0
   local allowed_profile=""
   local expect_features_action=0
+  local codex_config_value=""
 
   provider_policy_allows_breakglass && return 0
 
@@ -192,16 +193,23 @@ reject_unsafe_codex_args() {
 
     if [[ "${saw_command}" -eq 0 ]] && [[ "${arg}" != -* ]]; then
       saw_command=1
-      # DENY-BY-DEFAULT subcommand gate. The first bare token is Codex's
-      # subcommand; permit it ONLY if it is on the classified-safe ALLOWLIST
-      # below, otherwise die. This replaces the historical blocklist that every
-      # CLI version bump silently reopened (a new dangerous subcommand shipped
-      # unlisted was permitted until someone noticed); with an allowlist, any
-      # new AND any unknown subcommand is denied until explicitly vetted.
+      # DENY-BY-DEFAULT over the SUBCOMMAND NAMESPACE. Codex's CLI contract is
+      # `codex [OPTIONS] [PROMPT]` OR `codex [OPTIONS] <COMMAND> [ARGS]`: the
+      # first bare token is a SUBCOMMAND iff it exactly matches one of Codex's
+      # known subcommand names, otherwise it is literal PROMPT text that Codex
+      # forwards to the session (empirically on pinned 0.142.4:
+      # `codex "fix tests" --version` prints the version and exits 0, treating
+      # "fix tests" as the prompt, never as a command). So we partition Codex's
+      # COMPLETE subcommand set into an ALLOW set (permit — classified safe) and
+      # a DENY set (die — dangerous/unsupported); a token in NEITHER set is not a
+      # subcommand at all and is permitted as prompt text, exactly as Codex
+      # treats it. This preserves the bare-prompt invocation
+      # `workcell --agent codex --agent-arg "fix tests"` (Codex P2 review) while
+      # still denying every known-dangerous subcommand by exact token.
       #
-      # The permit set is the read-only/session surface verified against real
-      # `codex --help` (0.144): exec + its `e` alias, review, login, logout,
-      # completion, doctor, apply + its `a` alias, resume, fork, archive,
+      # ALLOW (read-only/session surface, verified against the pinned runtime
+      # Codex 0.142.4 `codex --help`): exec + its `e` alias, review, login,
+      # logout, completion, doctor, apply + its `a` alias, resume, fork, archive,
       # unarchive, delete, help, debug. These take a fixed image and only read
       # state or drive an in-session/session-management flow. `execpolicy` is a
       # hidden (not in `--help`) but real subcommand present in the pinned
@@ -213,9 +221,14 @@ reject_unsafe_codex_args() {
       # container-smoke's execpolicy checks). Exact-token discipline (NOT globs)
       # keeps the fence tight: `exec` != `exec-server`, `mcp` != `mcp-server`,
       # so the daemon variants stay denied. Keep this list in lockstep with the
-      # non-runtime set in codex_managed_profile_applies and the value-taking
-      # globals in codex_first_subcommand
-      # (runtime/container/provider-wrapper.sh; same first-token detection).
+      # non-runtime set in codex_managed_profile_applies, the value-taking
+      # globals in codex_first_subcommand (runtime/container/provider-wrapper.sh;
+      # same first-token detection), and the classified subcommand fixture
+      # tests/fixtures/codex-subcommands.txt (verify-invariants asserts the
+      # pinned Codex's full subcommand list is fully partitioned into this ALLOW
+      # set plus the DENY set below, so a future pin that adds an UNCLASSIFIED
+      # subcommand — which would otherwise leak through as prompt text — fails
+      # CI until a human classifies it).
       case "${arg}" in
         exec | e | review | login | logout | completion | doctor | \
           apply | a | resume | fork | archive | unarchive | delete | \
@@ -232,20 +245,36 @@ reject_unsafe_codex_args() {
         app | app-server)
           # app-server is the managed GUI backend Workcell launches (see
           # entrypoint.sh), so it is permitted ONLY under AGENT_UI=gui; on the
-          # CLI path it is not a supported surface and is denied. The GUI gate is
-          # scoped to these two tokens; every other non-allowlisted subcommand is
-          # denied on every UI (below), so an in-container AGENT_UI=gui override
+          # CLI path it is not a supported surface and is denied. (`app` is not a
+          # subcommand on pinned 0.142.4 but is kept GUI-gated here for the same
+          # class so a later pin that reintroduces it stays covered.) The GUI
+          # gate is scoped to these two tokens; every DENY-set subcommand below
+          # is denied on every UI, so an in-container AGENT_UI=gui override
           # cannot smuggle in plugin/mcp/remote-control the way a GUI-gated
           # blocklist once let it.
           [[ "${AGENT_UI:-cli}" != "gui" ]] &&
             workcell_die "Workcell blocked unsupported Codex CLI subcommand outside the managed GUI path: ${arg}"
           continue
           ;;
+        # DENY set — every known-dangerous/unsupported Codex subcommand, denied
+        # by EXACT token on every UI. Enumerated against pinned 0.142.4 so that
+        # ALLOW ∪ GUI-gated ∪ DENY equals the complete subcommand list (the
+        # fixture completeness check enforces this). These are the control-plane,
+        # daemon, marketplace, sandbox-escape, and self-update surfaces that the
+        # managed session must never reach.
+        plugin | remote-control | exec-server | mcp | mcp-server | cloud | \
+          sandbox | update)
+          workcell_die "Workcell blocked unsupported Codex CLI subcommand: ${arg}"
+          ;;
       esac
-      # Everything not on the allowlist above (plugin, remote-control,
-      # exec-server, mcp, mcp-server, cloud, sandbox, update, and any unknown or
-      # future subcommand) is denied — deny-by-default.
-      workcell_die "Workcell blocked unsupported Codex CLI subcommand: ${arg}"
+      # Not a known subcommand (neither ALLOW, GUI-gated, nor DENY): it is PROMPT
+      # text, so permit it exactly as Codex would. `saw_command=1` above stops
+      # any later bare token from being re-checked as a subcommand — Codex only
+      # dispatches on the FIRST bare token, and everything after a prompt is
+      # prompt/argument data. Deny-by-default safety is preserved because the
+      # fixture completeness check guarantees no UNCLASSIFIED subcommand exists to
+      # fall through here undetected.
+      continue
     fi
 
     case "${arg}" in
@@ -303,6 +332,21 @@ reject_unsafe_codex_args() {
         ;;
       --config=*)
         codex_config_override_is_blocked "${arg#--config=}" && workcell_die "Workcell blocked unsafe Codex config override: ${arg#--config=}"
+        ;;
+      -c?*)
+        # Short config flag glued to its value: Codex accepts both `-cKEY=VALUE`
+        # (`-cfeatures.remote_plugin=true`) and `-c=KEY=VALUE` (the `=` is clap's
+        # short-flag value separator, so `-c=model=x` carries value `model=x`).
+        # Without this case the attached form skipped the blocklist entirely —
+        # only separate `-c <value>` and `--config=<value>` were routed — letting
+        # `-cfeatures.remote_plugin=true` / `-cfeatures={remote_plugin=true}`
+        # re-enable the very surfaces this gate pins off (Codex P1 review). Strip
+        # the `-c` prefix and one optional leading `=`, then run the SAME
+        # codex_config_override_is_blocked check as the other config forms.
+        codex_config_value="${arg#-c}"
+        codex_config_value="${codex_config_value#=}"
+        codex_config_override_is_blocked "${codex_config_value}" &&
+          workcell_die "Workcell blocked unsafe Codex config override: ${codex_config_value}"
         ;;
     esac
   done

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -263,7 +263,16 @@ reject_unsafe_codex_args() {
         # daemon, marketplace, sandbox-escape, and self-update surfaces that the
         # managed session must never reach.
         plugin | remote-control | exec-server | mcp | mcp-server | cloud | \
-          sandbox | update)
+          cloud-tasks | responses-api-proxy | stdio-to-uds | sandbox | update)
+          # cloud-tasks is the pinned-0.142.4 alias of `cloud` (the hosted
+          # control-plane surface); responses-api-proxy and stdio-to-uds are
+          # HIDDEN (not in `codex --help`) daemon/bridge subcommands the pinned
+          # clap Subcommand enum still dispatches on — all denied by exact token
+          # on every UI. `update` is not a 0.142.4 variant (it lands in 0.143);
+          # it is kept here as harmless forward-compat and is intentionally
+          # absent from tests/fixtures/codex-subcommands.txt (that fixture lists
+          # only real 0.142.4 tokens), which the completeness check tolerates
+          # because it only asserts fixture ⊆ classified, not equality.
           workcell_die "Workcell blocked unsupported Codex CLI subcommand: ${arg}"
           ;;
       esac

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -79,6 +79,23 @@ codex_normalize_config_key() {
   printf '%s\n' "${normalized,,}"
 }
 
+# Match a NORMALIZED (canonical, lowercase) Codex config key against the
+# top-level guarded-namespace blocklist. Split out from
+# codex_config_override_is_blocked so the profile-scoped path can re-test the
+# post-prefix remainder against the SAME set: a Codex profile-v2 layer
+# (`[profiles.<name>.…]`) can set ANY config key, so every key that is dangerous
+# at top level (features.remote_plugin, plugins.*, marketplaces.*, mcp*, hooks*,
+# sandbox_*, approval_policy, web_search, shell_environment_policy*, …) is
+# equally dangerous scoped under a profile. Returns 0 (guarded) / 1 (not).
+codex_config_key_is_guarded() {
+  case "$1" in
+    profile | sandbox | sandbox_mode | sandbox_permissions | web_search | approval_policy | project_doc_fallback_filenames | project_root_markers | mcp* | plugins | plugins.* | marketplaces | marketplaces.* | hooks | hooks.* | features.plugins | features.plugin_sharing | features.plugin_hooks | features.remote_plugin | features.remote_control | shell_environment_policy | shell_environment_policy.* | sandbox_workspace_write | sandbox_workspace_write.*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 codex_config_override_is_blocked() {
   local value="$1"
   local key_lower
@@ -87,11 +104,24 @@ codex_config_override_is_blocked() {
   # Fail-closed sentinel for keys that stayed malformed after normalization.
   [[ "${key_lower}" == "__workcell_malformed__" ]] && return 0
 
-  case "${key_lower}" in
-    profile | sandbox | sandbox_mode | sandbox_permissions | web_search | approval_policy | project_doc_fallback_filenames | project_root_markers | mcp* | plugins | plugins.* | marketplaces | marketplaces.* | hooks | hooks.* | features.plugins | features.plugin_sharing | features.plugin_hooks | features.remote_plugin | features.remote_control | shell_environment_policy | shell_environment_policy.* | sandbox_workspace_write | sandbox_workspace_write.* | profiles.*.sandbox_mode | profiles.*.approval_policy | profiles.*.web_search | profiles.*.shell_environment_policy | profiles.*.shell_environment_policy.* | profiles.*.sandbox_workspace_write | profiles.*.sandbox_workspace_write.*)
-      return 0
-      ;;
-  esac
+  # Top-level guarded key (features.remote_plugin, plugins.*, mcp*, hooks*, …).
+  codex_config_key_is_guarded "${key_lower}" && return 0
+
+  # Profile-scoped override: a Codex profile-v2 layer `[profiles.<name>.<rest>]`
+  # can set any config key, so `profiles.<name>.features.remote_plugin`,
+  # `profiles.<name>.plugins.*`, `profiles.<name>.mcp_servers.*`, etc. re-enable
+  # the same surfaces the bare `features.*`/`plugins.*`/… blocks reject. The
+  # normalizer guarantees `<name>` is exactly ONE dotted segment (a `.` inside a
+  # quoted profile name fails closed as `__workcell_malformed__`, caught above),
+  # so strip the `profiles.<name>.` prefix and re-test the REMAINDER against the
+  # SAME top-level blocklist — DRY, and it stays correct if that blocklist ever
+  # changes. `profiles` / `profiles.<name>` with no remainder falls through to
+  # the inline-table guard below.
+  if [[ "${key_lower}" == profiles.?*.?* ]]; then
+    local profile_remainder="${key_lower#profiles.}"
+    profile_remainder="${profile_remainder#*.}"
+    codex_config_key_is_guarded "${profile_remainder}" && return 0
+  fi
 
   # Codex parses a `-c` value as TOML, so an inline TABLE smuggles blocked child
   # keys under a parent that is not itself blocked above — e.g.

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -133,6 +133,7 @@ reject_unsafe_codex_args() {
   local allowed_profile=""
   local expect_features_action=0
   local codex_config_value=""
+  local saw_app_server=0
 
   provider_policy_allows_breakglass && return 0
 
@@ -171,6 +172,44 @@ reject_unsafe_codex_args() {
     # rejected; only post-`--` prompt text is exempt.
     if [[ "${arg}" == "--" ]]; then
       break
+    fi
+
+    # After the first subcommand `app-server` is permitted (GUI path only; the
+    # CLI path already died on the bare token above), scan its remaining args for
+    # the app-server control surface and DENY it. The managed GUI launch is
+    # exactly `codex app-server` with NO trailing user args (entrypoint.sh sets
+    # `set -- codex app-server`); the sandbox/approval flags the managed path
+    # needs (`-c sandbox_mode=…`, `--ask-for-approval …`) are PREPENDED by
+    # provider-wrapper.sh AFTER this check, so they never appear in this argv and
+    # need no allowance here. Pinned Codex 0.142.4 (openai/codex tag
+    # rust-v0.142.4, codex-rs/cli/src/main.rs) hides a `--remote-control` flag on
+    # AppServerCommand and exposes an AppServerSubcommand enum
+    # (daemon, proxy, generate-ts, generate-json-schema,
+    # generate-internal-json-schema) plus an AppServerDaemonSubcommand enum
+    # (bootstrap, start, restart, enable-remote-control, disable-remote-control,
+    # stop, version, pid-update-loop). `codex app-server daemon
+    # enable-remote-control`, `codex app-server --remote-control`, and
+    # `codex app-server daemon bootstrap --remote-control` all reach the
+    # remote-control surface the standalone `remote-control` subcommand deny is
+    # meant to block. Deny the KNOWN-dangerous surface explicitly (the hidden
+    # `--remote-control` flag and every app-server/daemon subcommand token) rather
+    # than allowlisting flags: the managed launch carries no trailing args, so an
+    # empty scan permits it while every control token dies. Post-`--` prompt text
+    # is already exempted by the `--` break above. This block only REJECTS and
+    # never `continue`s, so a non-control token (e.g. `-c features.remote_plugin=…`
+    # smuggled after `app-server`) still falls through to the global flag/config
+    # checks below and is caught by codex_config_override_is_blocked.
+    if [[ "${saw_app_server}" -eq 1 ]]; then
+      case "${arg}" in
+        --remote-control | --remote-control=*)
+          workcell_die "Workcell blocked unsafe Codex app-server override: --remote-control"
+          ;;
+        daemon | proxy | generate-ts | generate-json-schema | generate-internal-json-schema | \
+          bootstrap | start | restart | enable-remote-control | disable-remote-control | \
+          stop | version | pid-update-loop)
+          workcell_die "Workcell blocked unsupported Codex app-server subcommand: ${arg}"
+          ;;
+      esac
     fi
 
     # After the first subcommand `features`, its ACTION token (enable/disable/
@@ -254,6 +293,11 @@ reject_unsafe_codex_args() {
           # blocklist once let it.
           [[ "${AGENT_UI:-cli}" != "gui" ]] &&
             workcell_die "Workcell blocked unsupported Codex CLI subcommand outside the managed GUI path: ${arg}"
+          # Permitted on the GUI path: arm the app-server surface scan so every
+          # subsequent arg is checked against the app-server control surface
+          # (--remote-control flag + app-server/daemon subcommand tokens) by the
+          # block near the top of the loop.
+          saw_app_server=1
           continue
           ;;
         # DENY set — every known-dangerous/unsupported Codex subcommand, denied

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -26,19 +26,12 @@ effective_codex_profile() {
   esac
 }
 
-# Normalize a Codex `-c key=value` KEY so equivalent TOML spellings collapse to
-# one canonical lowercase form before the blocklist match. TOML lets a dotted key
-# quote each segment (features."remote_plugin", features.'x') or pad the dots with
-# whitespace (features . plugins); without normalizing, those slip past every case
-# below. Only the KEY (before the first `=`) is touched: split on `.`, trim, strip
-# ONE surrounding quote pair per segment. Any residual quote (e.g. a quoted
-# segment that held a `.` and got split apart) FAILS CLOSED as blocked.
-#
-# We deliberately do NOT decode TOML basic-string escapes (a spec parser turns
-# `"\u0072emote_plugin"` into `remote_plugin`, `"\u0061pproval_policy"` into
-# `approval_policy`). Re-implementing TOML unescaping in bash is error-prone, so
-# any surviving backslash also FAILS CLOSED. Real blocklist keys never contain
-# backslashes, so this only rejects obfuscated keys. Emits the canonical key.
+# Canonicalize a Codex `-c key=value` KEY (before the first `=`) so equivalent TOML
+# spellings collapse to one lowercase form before the blocklist match: split on `.`,
+# trim whitespace (`features . plugins`), strip ONE surrounding quote pair per segment
+# (`features."remote_plugin"`). Any residual quote or backslash (a TOML basic-string
+# escape we refuse to decode in bash) FAILS CLOSED — real blocklist keys never contain
+# them, so this only rejects obfuscated keys. Emits the canonical key.
 codex_normalize_config_key() {
   local key="${1%%=*}"
   local -a segments=()
@@ -72,12 +65,11 @@ codex_normalize_config_key() {
   printf '%s\n' "${normalized,,}"
 }
 
-# Match a NORMALIZED (canonical, lowercase) Codex config key against the top-level
-# guarded-namespace blocklist. Split out from codex_config_override_is_blocked so
-# the profile-scoped path can re-test the post-prefix remainder against the SAME
-# set: a Codex profile-v2 layer (`[profiles.<name>.…]`) can set ANY key, so every
-# key dangerous at top level is equally dangerous scoped under a profile. Returns
-# 0 (guarded) / 1 (not).
+# Match a NORMALIZED (lowercase) Codex config key against the guarded-namespace
+# blocklist. Split out so the profile-scoped path can re-test the post-prefix
+# remainder against the SAME set: a profile-v2 layer (`[profiles.<name>.…]`) can
+# set any key, so every key dangerous at top level is equally dangerous scoped
+# under a profile. Returns 0 (guarded) / 1 (not).
 codex_config_key_is_guarded() {
   case "$1" in
     profile | sandbox | sandbox_mode | sandbox_permissions | web_search | approval_policy | project_doc_fallback_filenames | project_root_markers | mcp* | plugins | plugins.* | marketplaces | marketplaces.* | hooks | hooks.* | features.plugins | features.plugin_sharing | features.plugin_hooks | features.remote_plugin | features.remote_control | shell_environment_policy | shell_environment_policy.* | sandbox_workspace_write | sandbox_workspace_write.*)
@@ -98,13 +90,11 @@ codex_config_override_is_blocked() {
   # Top-level guarded key (features.remote_plugin, plugins.*, mcp*, hooks*, …).
   codex_config_key_is_guarded "${key_lower}" && return 0
 
-  # Profile-scoped override: a profile-v2 layer `[profiles.<name>.<rest>]` can set
-  # any key, so `profiles.<name>.features.remote_plugin` etc. re-enable surfaces
-  # the bare blocks reject. The normalizer guarantees `<name>` is exactly ONE
-  # segment (a `.` in a quoted name fails closed above), so strip the
-  # `profiles.<name>.` prefix and re-test the REMAINDER against the SAME blocklist.
-  # `profiles` / `profiles.<name>` with no remainder falls through to the inline-
-  # table guard below.
+  # Profile-scoped override: `[profiles.<name>.<rest>]` can set any key, re-enabling
+  # surfaces the bare blocks reject. The normalizer guarantees `<name>` is exactly ONE
+  # segment (a `.` in a quoted name fails closed above), so strip `profiles.<name>.`
+  # and re-test the REMAINDER against the SAME blocklist. `profiles`/`profiles.<name>`
+  # with no remainder falls through to the inline-table guard below.
   if [[ "${key_lower}" == profiles.?*.?* ]]; then
     local profile_remainder="${key_lower#profiles.}"
     profile_remainder="${profile_remainder#*.}"
@@ -112,13 +102,12 @@ codex_config_override_is_blocked() {
   fi
 
   # Codex parses a `-c` value as TOML, so an inline TABLE smuggles blocked children
-  # under an unblocked parent — `features={remote_plugin=true}` normalizes to the
-  # bare `features`, which no case matches. When the value (after the first `=`,
-  # trimmed) begins with `{`, block it for every guarded-namespace parent: such a
-  # table can set any banned child, and the managed baseline owns these tables so
-  # no legitimate `-c` whole-table override exists. Scalar values (no leading `{`)
-  # are untouched. Parents cover the gap namespaces and the bare-blocked ones (kept
-  # so the guard survives a later narrowing of a bare-parent case).
+  # under an unblocked parent: `features={remote_plugin=true}` normalizes to bare
+  # `features`, which no case matches. When the value (after the first `=`, trimmed)
+  # begins with `{`, block it for every guarded-namespace parent — the managed baseline
+  # owns these tables, so no legitimate whole-table `-c` override exists. Scalar values
+  # (no leading `{`) are untouched. Parents cover the gap namespaces plus the bare-
+  # blocked ones (kept so the guard survives a later narrowing of a bare-parent case).
   if [[ "${value}" == *=* ]]; then
     local raw_value="${value#*=}"
     raw_value="${raw_value#"${raw_value%%[![:space:]]*}"}"
@@ -134,11 +123,10 @@ codex_config_override_is_blocked() {
   return 1
 }
 
-# Value-taking global Codex flags must be consumed before first-subcommand
-# detection, or their VALUE would be mistaken for the command token and the
-# subcommand blocklist below would never run (`--model gpt-5 plugin` would treat
-# gpt-5 as the command). Keep the value-taking globals here in lockstep with
-# codex_first_subcommand in runtime/container/provider-wrapper.sh.
+# Value-taking global Codex flags must be consumed before first-subcommand detection,
+# or their VALUE would be mistaken for the command token (`--model gpt-5 plugin` would
+# treat gpt-5 as the command). Keep in lockstep with codex_first_subcommand in
+# runtime/container/provider-wrapper.sh.
 reject_unsafe_codex_args() {
   local expect_value=""
   local arg
@@ -173,40 +161,30 @@ reject_unsafe_codex_args() {
       continue
     fi
 
-    # DENY-BY-DEFAULT after the permitted `app-server` subcommand (GUI path only):
-    # ANY user token following `app-server` dies, full stop. The managed GUI launch
-    # is EXACTLY `codex app-server` with NO trailing user args (entrypoint.sh sets
-    # `set -- codex app-server`); the sandbox/approval flags it needs are PREPENDED
-    # by provider-wrapper.sh AFTER this check, so they never appear in the argv
-    # scanned here. Thus a legitimate managed launch reaches this function as bare
-    # `app-server` with zero trailing tokens. A token denylist over pinned Codex
-    # 0.142.4 leaked: AppServerCommand also accepts `--listen ws://IP:PORT` (opens a
-    # listening socket), `--stdio`, `--strict-config`, `--analytics-default-enabled`,
-    # `-c …`, plus AppServerSubcommand/AppServerDaemonSubcommand control tokens —
-    # every one reachable via an AGENT_UI=gui override. Rejecting ANY token instead
-    # of enumerating them is stricter, simpler, and covers future flags without a
-    # hand-maintained list. This check runs BEFORE the `--` break below because
-    # `codex app-server` has NO `[PROMPT]` positional (usage: `app-server [OPTIONS]
-    # [COMMAND]`; `app-server -- foo` is parsed as the unrecognized subcommand
-    # `foo`, not prompt text), so a post-`--` token is still not the managed shape
-    # and must die too.
+    # DENY-BY-DEFAULT after the permitted `app-server` subcommand (GUI path only): ANY
+    # user token following `app-server` dies. The managed GUI launch is EXACTLY bare
+    # `codex app-server` with NO trailing user args (entrypoint.sh sets `set -- codex
+    # app-server`; the sandbox/approval flags it needs are PREPENDED by provider-
+    # wrapper.sh AFTER this check, so they never appear here). A token denylist over
+    # pinned 0.142.4 leaked `--listen ws://IP:PORT` (a listening socket), `--stdio`,
+    # `-c …`, and AppServer{,Daemon}Subcommand control tokens — all reachable via an
+    # AGENT_UI=gui override. Rejecting ANY token is stricter, simpler, and future-proof.
+    # Runs BEFORE the `--` break: `app-server` has no `[PROMPT]` positional (usage:
+    # `app-server [OPTIONS] [COMMAND]`), so a post-`--` token is still not the managed
+    # shape and must die too.
     if [[ "${saw_app_server}" -eq 1 ]]; then
       workcell_die "Workcell blocked unsupported Codex app-server argument: ${arg} (only the managed no-arg app-server launch is permitted)"
     fi
 
     # After the `features` subcommand, its ACTION token is the next bare token.
     # `features enable/disable <name>` persistently writes features.<name> into the
-    # writable config.toml (equivalent to the blocked `-c features.<name>=…`), so
-    # both mutating actions are blocked. `features list` is a read-only inspect and
-    # stays permitted; the managed baseline sets features declaratively. This runs
-    # BEFORE the `--` break: a bare `--` MUST NOT let the pending action slip past
-    # the deny — while armed, a `--` is skipped WITHOUT disarming so the following
-    # token (enable/disable/list) is still classified. `codex features` has no
-    # `[PROMPT]` positional (usage: `features [OPTIONS] <COMMAND>`), so a post-`--`
-    # token is a subcommand slot, never prompt text; pinned 0.142.4 clap-errors on
-    # `features -- enable` today, but honoring the pending action here denies the
-    # mutating actions across a `--` even if a future pin dispatches the subcommand
-    # after `--` (as app-server's optional `[COMMAND]` already does).
+    # writable config.toml (equivalent to the blocked `-c features.<name>=…`), so both
+    # mutating actions are blocked; `features list` is a read-only inspect and stays
+    # permitted. Runs BEFORE the `--` break: while armed a bare `--` is skipped WITHOUT
+    # disarming, so the following action token is still classified — denying the mutating
+    # actions across a `--` even if a future pin dispatches the subcommand after `--`
+    # (as app-server's optional `[COMMAND]` already does; pinned 0.142.4 clap-errors on
+    # `features -- enable` today).
     if [[ "${expect_features_action}" -eq 1 ]]; then
       # A `--` while armed is NOT the action and MUST NOT trip the general `--`
       # break below: skip it, stay armed, and keep scanning for the action token.
@@ -226,40 +204,35 @@ reject_unsafe_codex_args() {
       fi
     fi
 
-    # A bare `--` ends option/subcommand parsing: every following token is literal
-    # prompt text Codex forwards to the session, never a flag/subcommand (verified:
-    # `codex -- plugin` starts the TUI with prompt "plugin"). Stop here so the
-    # blocklists do not over-reject a prompt beginning with `plugin`/`mcp`. Mirrors
-    # codex_first_subcommand, which also returns at `--`. Flag/value checks BEFORE
-    # `--` have already run, so only post-`--` prompt text is exempt. Not reached
-    # while a features action is pending (handled above).
+    # A bare `--` ends option/subcommand parsing: every following token is literal prompt
+    # text Codex forwards (verified: `codex -- plugin` starts the TUI with prompt
+    # "plugin"). Stop here so the blocklists do not over-reject a prompt beginning with
+    # `plugin`/`mcp`. Mirrors codex_first_subcommand, which also returns at `--`. Flag/
+    # value checks before `--` have already run; only post-`--` prompt text is exempt.
+    # Not reached while a features action is pending (handled above).
     if [[ "${arg}" == "--" ]]; then
       break
     fi
 
     if [[ "${saw_command}" -eq 0 ]] && [[ "${arg}" != -* ]]; then
       saw_command=1
-      # DENY-BY-DEFAULT over the SUBCOMMAND NAMESPACE. Codex's contract is
-      # `codex [OPTIONS] [PROMPT]` OR `codex [OPTIONS] <COMMAND> [ARGS]`: the first
-      # bare token is a SUBCOMMAND iff it exactly matches a known name, else it is
-      # literal PROMPT text (verified on 0.142.4: `codex "fix tests" --version`
-      # prints the version, treating "fix tests" as the prompt). So partition the
-      # COMPLETE subcommand set into ALLOW (permit — classified safe) and DENY (die
-      # — dangerous); a token in NEITHER is prompt text, permitted as Codex treats
-      # it. This preserves the bare-prompt invocation (Codex P2 review) while
-      # denying every known-dangerous subcommand by exact token.
+      # DENY-BY-DEFAULT over the SUBCOMMAND NAMESPACE. Codex's contract is `codex
+      # [OPTIONS] [PROMPT]` OR `codex [OPTIONS] <COMMAND> [ARGS]`: the first bare token is
+      # a SUBCOMMAND iff it exactly matches a known name, else it is literal PROMPT text
+      # (verified 0.142.4: `codex "fix tests" --version` prints the version). So partition
+      # the COMPLETE subcommand set into ALLOW (permit) and DENY (die); a token in NEITHER
+      # is prompt text, permitted as Codex treats it — preserving the bare-prompt
+      # invocation (Codex P2 review) while denying every dangerous subcommand by exact
+      # token.
       #
-      # ALLOW (read-only/session surface, verified against 0.142.4 `--help`): exec
-      # +`e`, review, login, logout, completion, doctor, apply +`a`, resume, fork,
-      # archive, unarchive, delete, help, debug. `execpolicy` is hidden but real: a
-      # pure read-only command classifier the managed autonomy path and
-      # verify-invariants invoke — it MUST stay permitted or session-rule
-      # enforcement breaks. Exact-token discipline (NOT globs) keeps the fence
-      # tight: `exec` != `exec-server`, `mcp` != `mcp-server`. Keep in lockstep
-      # with codex_managed_profile_applies, codex_first_subcommand, and the fixture
-      # tests/fixtures/codex-subcommands.txt (verify-invariants asserts the full
-      # subcommand list partitions into this ALLOW set plus the DENY set below, so
-      # a future pin adding an UNCLASSIFIED subcommand fails CI until classified).
+      # ALLOW (read-only/session surface, verified against 0.142.4 `--help`); `execpolicy`
+      # is hidden but real — a read-only command classifier the managed autonomy path and
+      # verify-invariants invoke, so it MUST stay permitted. Exact-token discipline (NOT
+      # globs) keeps the fence tight: `exec` != `exec-server`, `mcp` != `mcp-server`. Keep
+      # in lockstep with codex_managed_profile_applies, codex_first_subcommand, and the
+      # fixture tests/fixtures/codex-subcommands.txt (verify-invariants asserts the full
+      # subcommand list partitions into this ALLOW set plus the DENY set below, so a
+      # future pin adding an UNCLASSIFIED subcommand fails CI until classified).
       case "${arg}" in
         exec | e | review | login | logout | completion | doctor | \
           apply | a | resume | fork | archive | unarchive | delete | \
@@ -267,57 +240,54 @@ reject_unsafe_codex_args() {
           continue
           ;;
         features)
-          # `features`/`features list` are read-only inspects; arm the action
-          # check so the next bare token (enable/disable) is denied above.
+          # `features`/`features list` are read-only inspects; arm the action check so
+          # the next bare token (enable/disable) is denied above.
           expect_features_action=1
           continue
           ;;
         app | app-server)
-          # app-server is the managed GUI backend, permitted ONLY under
-          # AGENT_UI=gui; on the CLI path it is denied. (`app` is not a 0.142.4
-          # subcommand but is GUI-gated for the same class if a later pin
-          # reintroduces it.) The gate is scoped to these two tokens; every DENY
-          # subcommand below is denied on every UI, so an AGENT_UI=gui override
-          # cannot smuggle in plugin/mcp/remote-control.
+          # app-server is the managed GUI backend, permitted ONLY under AGENT_UI=gui;
+          # on the CLI path it is denied. (`app` is not a 0.142.4 subcommand but is GUI-
+          # gated for the same class if a later pin reintroduces it.) The gate is scoped
+          # to these two tokens; every DENY subcommand below is denied on every UI, so an
+          # AGENT_UI=gui override cannot smuggle in plugin/mcp/remote-control.
           [[ "${AGENT_UI:-cli}" != "gui" ]] &&
             workcell_die "Workcell blocked unsupported Codex CLI subcommand outside the managed GUI path: ${arg}"
           # Arm the app-server surface scan (block near the top of the loop).
           saw_app_server=1
           continue
           ;;
-        # DENY set — every known-dangerous/unsupported subcommand, denied by EXACT
-        # token on every UI. Enumerated against 0.142.4 so ALLOW ∪ GUI-gated ∪ DENY
-        # equals the complete subcommand list (the fixture completeness check
-        # enforces this). Control-plane, daemon, marketplace, sandbox-escape, and
-        # self-update surfaces the managed session must never reach.
+        # DENY set — every known-dangerous/unsupported subcommand, denied by EXACT token
+        # on every UI. Enumerated against 0.142.4 so ALLOW ∪ GUI-gated ∪ DENY equals the
+        # complete subcommand list (the fixture completeness check enforces this).
+        # Control-plane, daemon, marketplace, sandbox-escape, and self-update surfaces
+        # the managed session must never reach.
         plugin | remote-control | exec-server | mcp | mcp-server | cloud | \
           cloud-tasks | responses-api-proxy | stdio-to-uds | sandbox | update)
-          # cloud-tasks is the 0.142.4 alias of `cloud`; responses-api-proxy and
-          # stdio-to-uds are HIDDEN daemon/bridge subcommands the clap enum still
-          # dispatches. `update` is not a 0.142.4 variant (lands in 0.143); kept as
-          # forward-compat and intentionally absent from the fixture, which the
-          # completeness check tolerates (it asserts fixture ⊆ classified only).
+          # cloud-tasks is the 0.142.4 alias of `cloud`; responses-api-proxy and stdio-to-
+          # uds are HIDDEN daemon/bridge subcommands the clap enum still dispatches.
+          # `update` is not a 0.142.4 variant (lands in 0.143); kept forward-compat and
+          # absent from the fixture (the completeness check asserts fixture ⊆ classified).
           workcell_die "Workcell blocked unsupported Codex CLI subcommand: ${arg}"
           ;;
       esac
-      # Not a known subcommand (neither ALLOW, GUI-gated, nor DENY): it is PROMPT
-      # text, permitted as Codex would. `saw_command=1` stops any later bare token
-      # from being re-checked — Codex dispatches only on the FIRST bare token.
-      # Deny-by-default holds because the fixture completeness check guarantees no
-      # UNCLASSIFIED subcommand falls through here undetected.
+      # Not a known subcommand (neither ALLOW, GUI-gated, nor DENY): it is PROMPT text,
+      # permitted as Codex would. `saw_command=1` stops any later bare token from being
+      # re-checked — Codex dispatches only on the FIRST bare token. Deny-by-default holds
+      # because the fixture completeness check guarantees no UNCLASSIFIED subcommand
+      # falls through here undetected.
       continue
     fi
 
     case "${arg}" in
-      # Every `--dangerously-bypass-*` flag is DANGEROUS (0.143 adds
-      # --dangerously-bypass-hook-trust); glob-match the whole family (incl.
-      # `=value`) so future bypass flags are covered without a code change. Scope
-      # is `--dangerously-bypass-*`, NOT `--dangerously-*`, so it does not swallow
-      # Claude's `--dangerously-skip-permissions` passed as data to `codex
-      # execpolicy check`. --yolo is Codex's hidden alias for
-      # --dangerously-bypass-approvals-and-sandbox (the glob does not reach a
-      # hidden alias, so block it and its =value form explicitly).
-      --dangerously-bypass-* | --yolo | --yolo=* | --search | --add-dir | --remote | --full-auto | -a | --ask-for-approval | --enable | --disable)
+      # Every `--dangerously-bypass-*` flag is DANGEROUS (0.143 adds --dangerously-bypass-
+      # hook-trust); glob the whole family (incl. `=value`) so future bypass flags need no
+      # code change. Scope is `--dangerously-bypass-*`, NOT `--dangerously-*`, so it does
+      # not swallow Claude's `--dangerously-skip-permissions` passed as data to `codex
+      # execpolicy check`. --yolo is Codex's hidden alias for --dangerously-bypass-
+      # approvals-and-sandbox (the glob does not reach a hidden alias, so block it and its
+      # =value form explicitly).
+      --dangerously-bypass-* | --yolo | --yolo=* | --search | --add-dir | --remote | --remote-auth-token-env | --full-auto | -a | --ask-for-approval | --enable | --disable)
         workcell_die "Workcell blocked unsafe Codex override: ${arg}"
         ;;
       -p | --profile)
@@ -326,17 +296,17 @@ reject_unsafe_codex_args() {
       -C | --cd)
         expect_value="cd"
         ;;
-      -m | --model | -i | --image | --local-provider | --remote-auth-token-env)
-        # Permitted value-taking globals: consume the value so it is never mistaken
-        # for the first subcommand. The other value-taking globals are consumed by
-        # their own cases above, and the unsafe ones die on sight before their
-        # value is reached, so none can desync subcommand detection.
+      -m | --model | -i | --image | --local-provider)
+        # Permitted value-taking globals: consume the value so it is never mistaken for
+        # the first subcommand. The other value-taking globals are consumed by their own
+        # cases above, and the unsafe ones die on sight before their value is reached, so
+        # none can desync subcommand detection.
         expect_value="safe"
         ;;
       --ask-for-approval=*)
         workcell_die "Workcell blocked unsafe Codex override: --ask-for-approval"
         ;;
-      --add-dir=* | --remote=* | --enable=* | --disable=*)
+      --add-dir=* | --remote=* | --remote-auth-token-env=* | --enable=* | --disable=*)
         workcell_die "Workcell blocked unsafe Codex override: ${arg%%=*}"
         ;;
       --cd=*)
@@ -358,12 +328,11 @@ reject_unsafe_codex_args() {
         codex_config_override_is_blocked "${arg#--config=}" && workcell_die "Workcell blocked unsafe Codex config override: ${arg#--config=}"
         ;;
       -c?*)
-        # Short config flag glued to its value: Codex accepts `-cKEY=VALUE` and
-        # `-c=KEY=VALUE` (clap's short-flag `=` separator). Without this case the
-        # attached form skipped the blocklist entirely (only `-c <value>` and
-        # `--config=<value>` were routed), letting `-cfeatures.remote_plugin=true`
-        # re-enable pinned-off surfaces (Codex P1 review). Strip the `-c` prefix
-        # and one optional `=`, then run the SAME check as the other config forms.
+        # Short config flag glued to its value: Codex accepts `-cKEY=VALUE` and `-c=KEY=
+        # VALUE` (clap's short-flag `=` separator). Without this case the attached form
+        # skipped the blocklist (only `-c <value>` and `--config=<value>` were routed),
+        # letting `-cfeatures.remote_plugin=true` re-enable pinned-off surfaces (Codex P1
+        # review). Strip the `-c` prefix and one optional `=`, then run the SAME check.
         codex_config_value="${arg#-c}"
         codex_config_value="${codex_config_value#=}"
         codex_config_override_is_blocked "${codex_config_value}" &&

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -186,6 +186,17 @@ codex_args_include_profile() {
     if [[ "${expect_value}" -eq 1 ]]; then
       return 0
     fi
+    # A bare `--` ends option parsing: every following token is literal PROMPT
+    # text, never an operator flag (e.g. `codex -- --profile breakglass` passes
+    # "--profile breakglass" to the session as the prompt). Stop here so a
+    # post-`--` `--profile` is NOT mistaken for an operator-supplied profile —
+    # otherwise managed-profile injection would be skipped and the sandbox/
+    # approval contract dropped. This mirrors codex_first_subcommand (above) and
+    # reject_unsafe_codex_args (runtime/container/provider-policy.sh), which both
+    # return/break at `--`.
+    if [[ "${arg}" == "--" ]]; then
+      return 1
+    fi
     case "${arg}" in
       -p | --profile)
         expect_value=1

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -203,8 +203,13 @@ codex_args_include_profile() {
 # (empty for the default TUI: no subcommand, a bare prompt, or everything after
 # `--`). Global value-taking flags consume their value so the real subcommand
 # token is found, and `--*=*`/boolean flags (e.g. --version/--help) are skipped.
-# Both managed-injection decisions below classify this single token, so the
-# Codex global-flag table lives in exactly one place.
+# Both managed-injection decisions below classify this single token.
+# This list must cover EVERY value-taking top-level Codex global (from
+# `codex --help`), and stay in lockstep with reject_unsafe_codex_args
+# (runtime/container/provider-policy.sh): the policy must likewise consume or
+# reject each of these values before its first-subcommand blocklist, or a flag
+# value would be mistaken for the command token (e.g.
+# `codex --local-provider ollama plugin`).
 codex_first_subcommand() {
   CODEX_FIRST_SUBCOMMAND=""
   local arg="" skip_value=0
@@ -218,7 +223,9 @@ codex_first_subcommand() {
         return 0
         ;;
       -c | --config | -m | --model | -i | --image | -C | --cd | \
-        -a | --ask-for-approval | -s | --sandbox | -p | --profile)
+        -a | --ask-for-approval | -s | --sandbox | -p | --profile | \
+        --add-dir | --remote | --remote-auth-token-env | --local-provider | \
+        --enable | --disable)
         skip_value=1
         ;;
       --*=* | -*) ;;

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2621,6 +2621,12 @@ assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the glued
 
 assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the glued -C/state working-directory override" "Workcell blocked unsafe Codex override: --cd" -C/state --version
 
+# Short-with-equals form (`-p=VALUE`/`-s=VALUE`) is valid clap syntax too, so the
+# guarded value-flags strip a leading `=` before checking (Codex P1 review).
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the short-equals -p=breakglass profile override" "Workcell blocked unsafe Codex override: --profile" -p=breakglass --version
+
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the short-equals -s=danger-full-access sandbox override" "Workcell blocked unsafe Codex override: remove danger-full-access outside breakglass." -s=danger-full-access --version
+
 # Long `--flag=value` glued forms of the same guarded flags are denied too.
 assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the --profile=breakglass override" "Workcell blocked unsafe Codex override: --profile" --profile=breakglass --version
 

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2495,8 +2495,7 @@ fi
 grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-app-server.out
 
 # The app-server remote-control surface is denied on the CLI path too (bare
-# app-server is already denied outside the managed GUI path, so the daemon
-# enable-remote-control action never even reaches its own scan here).
+# app-server is already denied outside the managed GUI path).
 if run_entrypoint codex codex app-server daemon enable-remote-control >/tmp/workcell-entrypoint-codex-app-server-daemon.out 2>&1; then
   echo "expected Workcell entrypoint to reject the Codex app-server daemon remote-control surface on the CLI path" >&2
   exit 1
@@ -2515,9 +2514,8 @@ if run_entrypoint codex codex remote-control pair >/tmp/workcell-entrypoint-code
 fi
 grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-remote-control.out
 
-# exec-server is the experimental standalone exec daemon, not the managed GUI
-# backend, so it is blocked unconditionally. The exact-token match must not catch
-# the legitimate `exec` subcommand.
+# exec-server is the experimental standalone exec daemon (not the managed GUI
+# backend), blocked unconditionally; the exact-token match must not catch `exec`.
 if run_entrypoint codex codex exec-server >/tmp/workcell-entrypoint-codex-exec-server.out 2>&1; then
   echo "expected Workcell entrypoint to reject the Codex exec-server daemon subcommand" >&2
   exit 1
@@ -2557,13 +2555,12 @@ grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entryp
 run_entrypoint codex codex exec --help >/dev/null
 run_entrypoint codex codex features list >/dev/null
 
-# ALLOWLIST PERMIT COVERAGE. Every classified-safe read-only/session subcommand
-# on the deny-by-default allowlist (verified against real `codex --help` 0.144)
-# must pass the gate. `<sub> --help` prints Codex's own help and exits 0, so a
-# clean exit proves the token was permitted AND reached Codex. `help` does not
-# accept `--help`, so it is proven via the block-message-absent pattern below.
-# execpolicy is a hidden (not in top-level `--help`) but real read-only command
-# classifier the managed autonomy path invokes; it must stay on the allowlist.
+# ALLOWLIST PERMIT COVERAGE. Every classified-safe subcommand on the deny-by-
+# default allowlist must pass the gate: `<sub> --help` prints Codex's help and
+# exits 0, so a clean exit proves the token was permitted AND reached Codex.
+# `help` does not accept `--help`, so it uses the block-message-absent pattern
+# below. execpolicy is a hidden but real read-only classifier the managed
+# autonomy path invokes; it must stay on the allowlist.
 for codex_allowed_sub in e review login logout completion doctor apply a resume fork archive unarchive delete debug execpolicy; do
   run_entrypoint codex codex "${codex_allowed_sub}" --help >/dev/null
 done
@@ -2588,12 +2585,10 @@ for codex_denied_sub in cloud cloud-tasks responses-api-proxy stdio-to-uds sandb
   grep -q "Workcell blocked unsupported Codex CLI subcommand" "${codex_deny_out}"
 done
 
-# BARE-PROMPT PRESERVATION (Codex P2 review). Codex's contract is
-# `codex [OPTIONS] [PROMPT]`: a first bare token that is NOT a known subcommand
-# is PROMPT text, which the gate must permit (an earlier deny-by-default-over-
-# all-tokens draft wrongly rejected the prompt's first word). A made-up token
-# that is not a Codex subcommand must therefore PASS the gate as a prompt, not
-# die. `--version` short-circuits Codex after the gate so the run exits 0.
+# BARE-PROMPT PRESERVATION (Codex P2 review). In `codex [OPTIONS] [PROMPT]`, a
+# first bare token that is NOT a known subcommand is PROMPT text the gate must
+# permit (an earlier deny-over-all-tokens draft wrongly rejected it). A made-up
+# token must PASS as a prompt; `--version` short-circuits Codex so it exits 0.
 for codex_prompt_token in frobnicate some-new-daemon; do
   codex_prompt_out="/tmp/workcell-entrypoint-codex-prompt-${codex_prompt_token}.out"
   run_entrypoint codex codex "${codex_prompt_token}" --version >"${codex_prompt_out}" 2>&1 || true
@@ -2616,14 +2611,12 @@ if grep -q "Workcell blocked" "${codex_bare_prompt_out}"; then
 fi
 grep -q "codex-cli" "${codex_bare_prompt_out}"
 
-# A permitted subcommand behind a value-taking global still passes the gate
-# (the global's value is consumed, not mistaken for the command token), while a
-# denied one behind the same global is still denied (covered above for plugin).
+# A permitted subcommand behind a value-taking global still passes the gate (the
+# global's value is consumed, not mistaken for the command token).
 run_entrypoint codex codex --model gpt-5 exec --help >/dev/null
 # app/app-server are GUI-gated: denied on the CLI path (run_entrypoint pins
-# AGENT_UI=cli), so the CLI-path deny is covered here; the AGENT_UI=gui PERMIT
-# path is exercised in the nested-container block below, where AGENT_UI is not
-# pinned at the wrapper boundary.
+# AGENT_UI=cli); the AGENT_UI=gui PERMIT path is exercised in the nested-container
+# block below, where AGENT_UI is not pinned at the wrapper boundary.
 if run_entrypoint codex codex app >/tmp/workcell-entrypoint-codex-app-cli.out 2>&1; then
   echo "expected Workcell entrypoint to reject the Codex app subcommand on the CLI path" >&2
   exit 1

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2547,18 +2547,46 @@ if grep -q "Workcell blocked" "${codex_help_permit_out}"; then
   exit 1
 fi
 
-# DENY-BY-DEFAULT REGRESSION LOCK. The whole point of the allowlist refactor:
-# a subcommand that is not on the permit set is denied even if it is unknown to
-# this policy — including MADE-UP future tokens a later CLI bump might add. A
-# blocklist would have silently permitted these; the allowlist denies them.
-for codex_denied_sub in frobnicate some-new-daemon cloud sandbox mcp; do
+# DENY-SET REGRESSION LOCK. Every KNOWN-dangerous Codex subcommand is denied by
+# exact token on the CLI path — deny-by-default over the classified subcommand
+# namespace. These are real pinned-Codex subcommands (not prompt text), so the
+# gate must reject them.
+for codex_denied_sub in cloud sandbox mcp plugin remote-control exec-server mcp-server update; do
   codex_deny_out="/tmp/workcell-entrypoint-codex-denydefault-${codex_denied_sub}.out"
   if run_entrypoint codex codex "${codex_denied_sub}" >"${codex_deny_out}" 2>&1; then
-    echo "expected the deny-by-default gate to reject the non-allowlisted subcommand: ${codex_denied_sub}" >&2
+    echo "expected the deny-set gate to reject the dangerous subcommand: ${codex_denied_sub}" >&2
     exit 1
   fi
   grep -q "Workcell blocked unsupported Codex CLI subcommand" "${codex_deny_out}"
 done
+
+# BARE-PROMPT PRESERVATION (Codex P2 review). Codex's contract is
+# `codex [OPTIONS] [PROMPT]`: a first bare token that is NOT a known subcommand
+# is PROMPT text, which the gate must permit (an earlier deny-by-default-over-
+# all-tokens draft wrongly rejected the prompt's first word). A made-up token
+# that is not a Codex subcommand must therefore PASS the gate as a prompt, not
+# die. `--version` short-circuits Codex after the gate so the run exits 0.
+for codex_prompt_token in frobnicate some-new-daemon; do
+  codex_prompt_out="/tmp/workcell-entrypoint-codex-prompt-${codex_prompt_token}.out"
+  run_entrypoint codex codex "${codex_prompt_token}" --version >"${codex_prompt_out}" 2>&1 || true
+  if grep -q "Workcell blocked" "${codex_prompt_out}"; then
+    echo "expected a non-subcommand first token to pass the gate as prompt text: ${codex_prompt_token}" >&2
+    cat "${codex_prompt_out}" >&2
+    exit 1
+  fi
+done
+
+# A multi-word bare prompt (the real `--agent-arg "fix tests"` shape) must also
+# pass: only the FIRST bare token is ever a candidate subcommand, and "fix" is
+# not one, so the whole prompt is forwarded to Codex.
+codex_bare_prompt_out="/tmp/workcell-entrypoint-codex-bare-prompt.out"
+run_entrypoint codex codex "fix tests" --version >"${codex_bare_prompt_out}" 2>&1 || true
+if grep -q "Workcell blocked" "${codex_bare_prompt_out}"; then
+  echo 'expected the bare-prompt invocation codex "fix tests" to pass the deny-by-default gate' >&2
+  cat "${codex_bare_prompt_out}" >&2
+  exit 1
+fi
+grep -q "codex-cli" "${codex_bare_prompt_out}"
 
 # A permitted subcommand behind a value-taking global still passes the gate
 # (the global's value is consumed, not mistaken for the command token), while a
@@ -2730,10 +2758,42 @@ if run_entrypoint codex codex --config 'hooks={trust=false}' --version >/tmp/wor
 fi
 grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-hooks-table.out
 
+# ATTACHED SHORT `-c` CONFIG OVERRIDES (Codex P1 review). Codex accepts the short
+# config flag glued to its value (`-cKEY=VALUE`) and with clap's `=` separator
+# (`-c=KEY=VALUE`); before the fix only separate `-c <value>` and `--config=…`
+# were routed through the blocklist, so a glued form re-enabled the pinned-off
+# surfaces. The gate must run the SAME config blocker on the attached remainder.
+if run_entrypoint codex codex -cfeatures.remote_plugin=true --version >/tmp/workcell-entrypoint-codex-attached-c-scalar.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the glued -cfeatures.remote_plugin override" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-attached-c-scalar.out
+
+if run_entrypoint codex codex '-cfeatures={remote_plugin=true}' --version >/tmp/workcell-entrypoint-codex-attached-c-table.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the glued -cfeatures={...} inline-table override" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-attached-c-table.out
+
+if run_entrypoint codex codex -c=features.plugins=true --version >/tmp/workcell-entrypoint-codex-attached-c-eq.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the -c=KEY=VALUE (clap separator) plugins override" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-attached-c-eq.out
+
+if run_entrypoint codex codex --config=features.plugins=true --version >/tmp/workcell-entrypoint-codex-config-eq-plugins.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the --config=features.plugins override" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-eq-plugins.out
+
 # A benign, genuinely-permitted -c override must still pass (model is not on the
 # security-boundary blocklist); a scalar value on a non-guarded key is not an
-# inline table, so the table guard leaves it untouched.
+# inline table, so the table guard leaves it untouched. Both the separate and the
+# glued (`-cmodel=…`) forms of a permitted key must pass — the attached-`-c` fix
+# only blocks GUARDED keys, never a benign one.
 run_entrypoint codex codex --config 'model=gpt-5-codex' --version >/dev/null
+run_entrypoint codex codex -cmodel=gpt-5-codex --version >/dev/null
 run_entrypoint codex codex --config 'history.persistence="none"' --version >/dev/null
 
 # A backslash in the VALUE (not the key) must not trip the escape guard: only the
@@ -3459,19 +3519,27 @@ test -f "$CODEX_HOME/config.toml"
       exit 1
     fi
     grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-remote-auth-mcp.out
-    # DENY-BY-DEFAULT regression lock: a MADE-UP future subcommand that this
-    # policy has never heard of must be denied — the allowlist rejects anything
-    # off the permit set, so a later CLI bump cannot silently reopen a hole.
-    if codex frobnicate >/tmp/codex-nested-frobnicate.out 2>&1; then
-      echo "expected the deny-by-default gate to reject the unknown future subcommand frobnicate" >&2
+    # BARE-PROMPT PRESERVATION (Codex P2 review): a first bare token that is NOT
+    # a known Codex subcommand is PROMPT text and must pass the gate, not die.
+    # `--version` short-circuits Codex after the gate so the run exits 0.
+    codex frobnicate --version >/tmp/codex-nested-frobnicate.out 2>&1 || true
+    if grep -q "Workcell blocked" /tmp/codex-nested-frobnicate.out; then
+      echo "expected a non-subcommand first token to pass the gate as prompt text: frobnicate" >&2
+      cat /tmp/codex-nested-frobnicate.out >&2
       exit 1
     fi
-    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-frobnicate.out
-    if codex some-new-daemon >/tmp/codex-nested-newdaemon.out 2>&1; then
-      echo "expected the deny-by-default gate to reject the unknown future subcommand some-new-daemon" >&2
+    codex "fix tests" --version >/tmp/codex-nested-newdaemon.out 2>&1 || true
+    if grep -q "Workcell blocked" /tmp/codex-nested-newdaemon.out; then
+      echo "expected the multi-word bare prompt codex fix-tests to pass the gate" >&2
+      cat /tmp/codex-nested-newdaemon.out >&2
       exit 1
     fi
-    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-newdaemon.out
+    # Known-dangerous subcommands remain denied by exact token on the CLI path.
+    if codex plugin >/tmp/codex-nested-cli-plugin-deny.out 2>&1; then
+      echo "expected the deny-set gate to reject the plugin subcommand" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-cli-plugin-deny.out
     # cloud/sandbox are no longer GUI-gated: they are off the allowlist, so they
     # are denied on every UI (including AGENT_UI=gui).
     if AGENT_UI=gui codex cloud >/tmp/codex-nested-gui-cloud.out 2>&1; then

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2443,147 +2443,85 @@ if ! run_entrypoint_with_profile codex development bash -lc '
   exit 1
 fi
 
-if run_entrypoint codex codex --search >/tmp/workcell-entrypoint-codex-search.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex web search outside breakglass" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-search.out
+# Assert a Codex entrypoint invocation is DENIED: run `codex codex <args>`, expect a
+# non-zero exit, and require the block MESSAGE pattern in its combined output. Collapses
+# the repeated if/echo/exit/grep BLOCK boilerplate; MESSAGE and PATTERN are byte-identical
+# to the inline forms.
+assert_codex_entrypoint_denied() {
+  local expectation_message="$1" block_pattern="$2"
+  shift 2
+  local deny_out
+  deny_out="$(mktemp "${TMPDIR:-/tmp}/workcell-codex-deny.XXXXXX")"
+  if run_entrypoint codex codex "$@" >"${deny_out}" 2>&1; then
+    echo "${expectation_message}" >&2
+    exit 1
+  fi
+  grep -q "${block_pattern}" "${deny_out}"
+}
 
-if run_entrypoint codex codex --dangerously-bypass-approvals-and-sandbox >/tmp/workcell-entrypoint-codex-danger.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex dangerous override outside breakglass" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-danger.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex web search outside breakglass" "Workcell blocked unsafe Codex override" --search
 
-# The whole --dangerously-* family is blocked (0.143 adds hook-trust); the glob
-# also future-proofs against new dangerously-flags.
-if run_entrypoint codex codex --dangerously-bypass-hook-trust --version >/tmp/workcell-entrypoint-codex-danger-hook-trust.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the Codex dangerous hook-trust bypass" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-danger-hook-trust.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex dangerous override outside breakglass" "Workcell blocked unsafe Codex override" --dangerously-bypass-approvals-and-sandbox
 
-if run_entrypoint codex codex --dangerously-bypass-future-badness --version >/tmp/workcell-entrypoint-codex-danger-future.out 2>&1; then
-  echo "expected Workcell entrypoint to reject any Codex --dangerously-bypass-* flag via the glob" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-danger-future.out
+# The whole --dangerously-bypass-* family is blocked (0.143 adds hook-trust) via a
+# future-proofing glob.
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex dangerous hook-trust bypass" "Workcell blocked unsafe Codex override" --dangerously-bypass-hook-trust --version
+
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject any Codex --dangerously-bypass-* flag via the glob" "Workcell blocked unsafe Codex override" --dangerously-bypass-future-badness --version
 
 # --yolo is Codex's hidden alias for --dangerously-bypass-approvals-and-sandbox.
-if run_entrypoint codex codex --yolo --version >/tmp/workcell-entrypoint-codex-yolo.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the Codex --yolo bypass alias" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-yolo.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex --yolo bypass alias" "Workcell blocked unsafe Codex override" --yolo --version
 
-if run_entrypoint codex codex -a never --version >/tmp/workcell-entrypoint-codex-approval.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex approval overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-approval.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex approval overrides" "Workcell blocked unsafe Codex override" -a never --version
 
-if run_entrypoint codex codex --full-auto --version >/tmp/workcell-entrypoint-codex-full-auto.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex full-auto overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-full-auto.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex full-auto overrides" "Workcell blocked unsafe Codex override" --full-auto --version
 
-if run_entrypoint codex codex app-server >/tmp/workcell-entrypoint-codex-app-server.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex GUI subcommands on the CLI surface" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-app-server.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex GUI subcommands on the CLI surface" "Workcell blocked unsupported Codex CLI subcommand" app-server
 
 # The app-server remote-control surface is denied on the CLI path too (bare
 # app-server is already denied outside the managed GUI path).
-if run_entrypoint codex codex app-server daemon enable-remote-control >/tmp/workcell-entrypoint-codex-app-server-daemon.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the Codex app-server daemon remote-control surface on the CLI path" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-app-server-daemon.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex app-server daemon remote-control surface on the CLI path" "Workcell blocked unsupported Codex CLI subcommand" app-server daemon enable-remote-control
 
-if run_entrypoint codex codex plugin list >/tmp/workcell-entrypoint-codex-plugin.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the Codex plugin marketplace/install surface" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-plugin.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex plugin marketplace/install surface" "Workcell blocked unsupported Codex CLI subcommand" plugin list
 
-if run_entrypoint codex codex remote-control pair >/tmp/workcell-entrypoint-codex-remote-control.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the Codex remote-control app-server pairing surface" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-remote-control.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex remote-control app-server pairing surface" "Workcell blocked unsupported Codex CLI subcommand" remote-control pair
 
 # exec-server is the experimental standalone exec daemon (not the managed GUI
 # backend), blocked unconditionally; the exact-token match must not catch `exec`.
-if run_entrypoint codex codex exec-server >/tmp/workcell-entrypoint-codex-exec-server.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the Codex exec-server daemon subcommand" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-exec-server.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex exec-server daemon subcommand" "Workcell blocked unsupported Codex CLI subcommand" exec-server
 
 # mcp-server (Codex-as-an-MCP-server daemon) and update (self-update that would
 # defeat the pinned image) are blocked unconditionally, same class as exec-server.
-if run_entrypoint codex codex mcp-server >/tmp/workcell-entrypoint-codex-mcp-server.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the Codex mcp-server daemon subcommand" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-mcp-server.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex mcp-server daemon subcommand" "Workcell blocked unsupported Codex CLI subcommand" mcp-server
 
-if run_entrypoint codex codex update >/tmp/workcell-entrypoint-codex-update.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the Codex self-update subcommand" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-update.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex self-update subcommand" "Workcell blocked unsupported Codex CLI subcommand" update
 
 # features enable/disable persistently write config.toml; both are blocked while
 # the read-only `features list` and the `exec` subcommand stay permitted.
-if run_entrypoint codex codex features enable plugins >/tmp/workcell-entrypoint-codex-features-enable.out 2>&1; then
-  echo "expected Workcell entrypoint to reject persistent Codex feature enable" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-features-enable.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject persistent Codex feature enable" "Workcell blocked unsupported Codex CLI subcommand" features enable plugins
 
-if run_entrypoint codex codex features disable unified_exec >/tmp/workcell-entrypoint-codex-features-disable.out 2>&1; then
-  echo "expected Workcell entrypoint to reject persistent Codex feature disable" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-features-disable.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject persistent Codex feature disable" "Workcell blocked unsupported Codex CLI subcommand" features disable unified_exec
 
 # A `--` before the features action must not let the mutating action slip past
 # the deny (P1 review finding): the pending features-action check takes
 # precedence over the general `--` break, so both orderings are still denied.
-if run_entrypoint codex codex features -- enable plugins >/tmp/workcell-entrypoint-codex-features-dd-enable.out 2>&1; then
-  echo "expected Workcell entrypoint to reject features -- enable plugins across the --" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-features-dd-enable.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject features -- enable plugins across the --" "Workcell blocked unsupported Codex CLI subcommand" features -- enable plugins
 
-if run_entrypoint codex codex features -- disable unified_exec >/tmp/workcell-entrypoint-codex-features-dd-disable.out 2>&1; then
-  echo "expected Workcell entrypoint to reject features -- disable unified_exec across the --" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-features-dd-disable.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject features -- disable unified_exec across the --" "Workcell blocked unsupported Codex CLI subcommand" features -- disable unified_exec
 
-if run_entrypoint codex codex features enable -- plugins >/tmp/workcell-entrypoint-codex-features-enable-dd.out 2>&1; then
-  echo "expected Workcell entrypoint to reject features enable -- plugins" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-features-enable-dd.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject features enable -- plugins" "Workcell blocked unsupported Codex CLI subcommand" features enable -- plugins
 
-# The exec-server/features exact-token blocks must not catch the legitimate
-# `exec` runtime subcommand or the read-only `features list`. The normal prompt
-# `--` break (when NOT expecting a features action) is exercised by the nested
-# `codex -- plugin`/`codex -- frobnicate` permit cases below.
+# The exec-server/features exact-token blocks must not catch the legitimate `exec`
+# runtime subcommand or the read-only `features list`. The normal prompt `--` break
+# (when NOT expecting a features action) is exercised by the permit cases below.
 run_entrypoint codex codex exec --help >/dev/null
 run_entrypoint codex codex features list >/dev/null
 
-# ALLOWLIST PERMIT COVERAGE. Every classified-safe subcommand on the deny-by-
-# default allowlist must pass the gate: `<sub> --help` prints Codex's help and
-# exits 0, so a clean exit proves the token was permitted AND reached Codex.
-# `help` does not accept `--help`, so it uses the block-message-absent pattern
-# below. execpolicy is a hidden but real read-only classifier the managed
-# autonomy path invokes; it must stay on the allowlist.
+# ALLOWLIST PERMIT COVERAGE. Every classified-safe subcommand must pass the gate:
+# `<sub> --help` prints Codex's help and exits 0, so a clean exit proves the token was
+# permitted AND reached Codex. `help` does not accept `--help`, so it uses the block-
+# message-absent pattern below. execpolicy is a hidden but real read-only classifier
+# the managed autonomy path invokes; it must stay on the allowlist.
 for codex_allowed_sub in e review login logout completion doctor apply a resume fork archive unarchive delete debug execpolicy; do
   run_entrypoint codex codex "${codex_allowed_sub}" --help >/dev/null
 done
@@ -2595,10 +2533,9 @@ if grep -q "Workcell blocked" "${codex_help_permit_out}"; then
   exit 1
 fi
 
-# DENY-SET REGRESSION LOCK. Every KNOWN-dangerous Codex subcommand is denied by
-# exact token on the CLI path — deny-by-default over the classified subcommand
-# namespace. These are real pinned-Codex subcommands (not prompt text), so the
-# gate must reject them.
+# DENY-SET REGRESSION LOCK. Every KNOWN-dangerous Codex subcommand is denied by exact
+# token on the CLI path. These are real pinned-Codex subcommands (not prompt text), so
+# the gate must reject them.
 for codex_denied_sub in cloud cloud-tasks responses-api-proxy stdio-to-uds sandbox mcp plugin remote-control exec-server mcp-server update; do
   codex_deny_out="/tmp/workcell-entrypoint-codex-denydefault-${codex_denied_sub}.out"
   if run_entrypoint codex codex "${codex_denied_sub}" >"${codex_deny_out}" 2>&1; then
@@ -2608,10 +2545,10 @@ for codex_denied_sub in cloud cloud-tasks responses-api-proxy stdio-to-uds sandb
   grep -q "Workcell blocked unsupported Codex CLI subcommand" "${codex_deny_out}"
 done
 
-# BARE-PROMPT PRESERVATION (Codex P2 review). In `codex [OPTIONS] [PROMPT]`, a
-# first bare token that is NOT a known subcommand is PROMPT text the gate must
-# permit (an earlier deny-over-all-tokens draft wrongly rejected it). A made-up
-# token must PASS as a prompt; `--version` short-circuits Codex so it exits 0.
+# BARE-PROMPT PRESERVATION (Codex P2 review). In `codex [OPTIONS] [PROMPT]`, a first
+# bare token that is NOT a known subcommand is PROMPT text the gate must permit (an
+# earlier deny-over-all-tokens draft wrongly rejected it). A made-up token must PASS as
+# a prompt; `--version` short-circuits Codex so it exits 0.
 for codex_prompt_token in frobnicate some-new-daemon; do
   codex_prompt_out="/tmp/workcell-entrypoint-codex-prompt-${codex_prompt_token}.out"
   run_entrypoint codex codex "${codex_prompt_token}" --version >"${codex_prompt_out}" 2>&1 || true
@@ -2639,259 +2576,121 @@ grep -q "codex-cli" "${codex_bare_prompt_out}"
 run_entrypoint codex codex --model gpt-5 exec --help >/dev/null
 # app/app-server are GUI-gated: denied on the CLI path (run_entrypoint pins
 # AGENT_UI=cli); the AGENT_UI=gui PERMIT path is exercised in the nested-container
-# block below, where AGENT_UI is not pinned at the wrapper boundary.
-if run_entrypoint codex codex app >/tmp/workcell-entrypoint-codex-app-cli.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the Codex app subcommand on the CLI path" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand outside the managed GUI path" /tmp/workcell-entrypoint-codex-app-cli.out
+# block below.
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex app subcommand on the CLI path" "Workcell blocked unsupported Codex CLI subcommand outside the managed GUI path" app
 
 # Value-taking global flags must not desynchronize first-subcommand detection:
 # the flag's value is not a command token, so the blocklist still applies.
-if run_entrypoint codex codex --model gpt-5 plugin list >/tmp/workcell-entrypoint-codex-model-plugin.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the Codex plugin surface behind value-taking globals" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-model-plugin.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex plugin surface behind value-taking globals" "Workcell blocked unsupported Codex CLI subcommand" --model gpt-5 plugin list
 
-if run_entrypoint codex codex --model gpt-5 remote-control pair >/tmp/workcell-entrypoint-codex-model-remote-control.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the Codex remote-control surface behind value-taking globals" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-model-remote-control.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex remote-control surface behind value-taking globals" "Workcell blocked unsupported Codex CLI subcommand" --model gpt-5 remote-control pair
 
-if run_entrypoint codex codex --model gpt-5 mcp list >/tmp/workcell-entrypoint-codex-model-mcp.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the Codex mcp surface behind value-taking globals" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-model-mcp.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex mcp surface behind value-taking globals" "Workcell blocked unsupported Codex CLI subcommand" --model gpt-5 mcp list
 
 # --local-provider is another value-taking global; its value must not be
 # mistaken for the subcommand token.
-if run_entrypoint codex codex --local-provider ollama plugin list >/tmp/workcell-entrypoint-codex-local-provider-plugin.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the plugin surface behind the --local-provider global" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-local-provider-plugin.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the plugin surface behind the --local-provider global" "Workcell blocked unsupported Codex CLI subcommand" --local-provider ollama plugin list
 
 run_entrypoint codex codex --model gpt-5 --version >/dev/null
 
-if run_entrypoint codex codex --profile breakglass --version >/tmp/workcell-entrypoint-codex-profile.out 2>&1; then
-  echo "expected Workcell entrypoint to reject operator-supplied Codex profiles" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-profile.out
+# --remote-auth-token-env names the env var holding the bearer token sent to a remote
+# app-server websocket (a remote-auth surface, like --remote); both the bare and glued
+# forms are denied. --local-provider (a LOCAL model provider) stays permitted.
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex --remote-auth-token-env remote-auth surface" "Workcell blocked unsafe Codex override" --remote-auth-token-env FOO --version
 
-if run_entrypoint codex codex --cd /state --version >/tmp/workcell-entrypoint-codex-cd.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex working-directory overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-cd.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the glued Codex --remote-auth-token-env=FOO override" "Workcell blocked unsafe Codex override" --remote-auth-token-env=FOO --version
 
-if run_entrypoint codex codex --config profile=breakglass --version >/tmp/workcell-entrypoint-codex-config-profile.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex profile config overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile.out
+run_entrypoint codex codex --local-provider ollama exec --help >/dev/null
 
-if run_entrypoint codex codex --config sandbox_workspace_write.network_access=true --version >/tmp/workcell-entrypoint-codex-config-network.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex network_access config overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-network.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject operator-supplied Codex profiles" "Workcell blocked unsafe Codex override" --profile breakglass --version
 
-if run_entrypoint codex codex --config sandbox_workspace_write.writable_roots=/state --version >/tmp/workcell-entrypoint-codex-config-writable-roots.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex writable_roots config overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-writable-roots.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex working-directory overrides" "Workcell blocked unsafe Codex override" --cd /state --version
 
-if run_entrypoint codex codex --config shell_environment_policy.set.BAD=1 --version >/tmp/workcell-entrypoint-codex-config-shell.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex shell environment overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-shell.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex profile config overrides" "Workcell blocked unsafe Codex config override" --config profile=breakglass --version
 
-if run_entrypoint codex codex --config 'plugins."evil@rogue".enabled=true' --version >/tmp/workcell-entrypoint-codex-config-plugins.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex plugin config overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-plugins.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex network_access config overrides" "Workcell blocked unsafe Codex config override" --config sandbox_workspace_write.network_access=true --version
 
-if run_entrypoint codex codex --config 'marketplaces.rogue.source=/tmp/evil' --version >/tmp/workcell-entrypoint-codex-config-marketplaces.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex marketplace config overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-marketplaces.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex writable_roots config overrides" "Workcell blocked unsafe Codex config override" --config sandbox_workspace_write.writable_roots=/state --version
+
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex shell environment overrides" "Workcell blocked unsafe Codex config override" --config shell_environment_policy.set.BAD=1 --version
+
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex plugin config overrides" "Workcell blocked unsafe Codex config override" --config 'plugins."evil@rogue".enabled=true' --version
+
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex marketplace config overrides" "Workcell blocked unsafe Codex config override" --config 'marketplaces.rogue.source=/tmp/evil' --version
 
 # Quoted/whitespace TOML key spellings must not bypass config-override blocking.
-if run_entrypoint codex codex --config 'features."remote_plugin"=true' --version >/tmp/workcell-entrypoint-codex-config-quoted-feature.out 2>&1; then
-  echo "expected Workcell entrypoint to reject quoted-segment Codex feature config overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-quoted-feature.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject quoted-segment Codex feature config overrides" "Workcell blocked unsafe Codex config override" --config 'features."remote_plugin"=true' --version
 
-if run_entrypoint codex codex --config '"mcp_servers".rogue.command=/bin/sh' --version >/tmp/workcell-entrypoint-codex-config-quoted-mcp.out 2>&1; then
-  echo "expected Workcell entrypoint to reject quoted-segment Codex mcp config overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-quoted-mcp.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject quoted-segment Codex mcp config overrides" "Workcell blocked unsafe Codex config override" --config '"mcp_servers".rogue.command=/bin/sh' --version
 
-if run_entrypoint codex codex --config 'features . plugins=true' --version >/tmp/workcell-entrypoint-codex-config-spaced-feature.out 2>&1; then
-  echo "expected Workcell entrypoint to reject whitespace-padded Codex feature config overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-spaced-feature.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject whitespace-padded Codex feature config overrides" "Workcell blocked unsafe Codex config override" --config 'features . plugins=true' --version
 
-if run_entrypoint codex codex --config 'features."remote_plugin=true' --version >/tmp/workcell-entrypoint-codex-config-malformed-quote.out 2>&1; then
-  echo "expected Workcell entrypoint to fail closed on malformed-quote Codex config overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-malformed-quote.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to fail closed on malformed-quote Codex config overrides" "Workcell blocked unsafe Codex config override" --config 'features."remote_plugin=true' --version
 
-# TOML basic-string escapes decode to blocked keys under a spec-compliant parser
-# (the \u0072 escape below is 'r', so features."\u0072emote_plugin" decodes to
-# features.remote_plugin, and "\u0061pproval_policy" decodes to approval_policy).
-# We refuse to decode escapes in bash and fail closed on any backslash in a key
-# segment.
-if run_entrypoint codex codex --config 'features."\u0072emote_plugin"=true' --version >/tmp/workcell-entrypoint-codex-config-escape-feature.out 2>&1; then
-  echo "expected Workcell entrypoint to fail closed on backslash-escaped Codex feature config overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-escape-feature.out
+# TOML basic-string escapes decode to blocked keys under a spec parser (the escape
+# below is 'r', so features."...emote_plugin" decodes to features.remote_plugin). We
+# refuse to decode escapes in bash and fail closed on any backslash in a key segment.
+assert_codex_entrypoint_denied "expected Workcell entrypoint to fail closed on backslash-escaped Codex feature config overrides" "Workcell blocked unsafe Codex config override" --config 'features."\u0072emote_plugin"=true' --version
 
-if run_entrypoint codex codex --config '"\u0061pproval_policy"="never"' --version >/tmp/workcell-entrypoint-codex-config-escape-approval.out 2>&1; then
-  echo "expected Workcell entrypoint to fail closed on backslash-escaped Codex approval-policy config overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-escape-approval.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to fail closed on backslash-escaped Codex approval-policy config overrides" "Workcell blocked unsafe Codex config override" --config '"\u0061pproval_policy"="never"' --version
 
-# Codex parses -c values as TOML, so an inline TABLE value can smuggle blocked
-# child keys under a parent that is not itself blocked (features, profiles). Any
-# inline-table value on a guarded namespace parent must be rejected.
-if run_entrypoint codex codex --config 'features={remote_plugin=true}' --version >/tmp/workcell-entrypoint-codex-config-table-features.out 2>&1; then
-  echo "expected Workcell entrypoint to reject an inline-table override of the features namespace" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-table-features.out
+# Codex parses -c values as TOML, so an inline TABLE value can smuggle blocked child
+# keys under a parent that is not itself blocked (features, profiles). Any inline-table
+# value on a guarded namespace parent must be rejected.
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject an inline-table override of the features namespace" "Workcell blocked unsafe Codex config override" --config 'features={remote_plugin=true}' --version
 
-if run_entrypoint codex codex --config 'profiles={foo={sandbox_mode="danger-full-access"}}' --version >/tmp/workcell-entrypoint-codex-config-table-profiles.out 2>&1; then
-  echo "expected Workcell entrypoint to reject an inline-table override of the profiles namespace" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-table-profiles.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject an inline-table override of the profiles namespace" "Workcell blocked unsafe Codex config override" --config 'profiles={foo={sandbox_mode="danger-full-access"}}' --version
 
-if run_entrypoint codex codex --config 'mcp_servers={evil={command="/bin/sh"}}' --version >/tmp/workcell-entrypoint-codex-config-table-mcp.out 2>&1; then
-  echo "expected Workcell entrypoint to reject an inline-table override of the mcp_servers namespace" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-table-mcp.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject an inline-table override of the mcp_servers namespace" "Workcell blocked unsafe Codex config override" --config 'mcp_servers={evil={command="/bin/sh"}}' --version
 
-# The hooks namespace is a code-execution/trust surface (see the dangerous
-# --dangerously-bypass-hook-trust flag); no legitimate managed -c override sets
-# it, so any hooks.* scalar or inline-table override is blocked.
-if run_entrypoint codex codex --config 'hooks.trust=false' --version >/tmp/workcell-entrypoint-codex-config-hooks-scalar.out 2>&1; then
-  echo "expected Workcell entrypoint to reject a hooks.* config override" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-hooks-scalar.out
+# The hooks namespace is a code-execution/trust surface; no legitimate managed -c
+# override sets it, so any hooks.* scalar or inline-table override is blocked.
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject a hooks.* config override" "Workcell blocked unsafe Codex config override" --config 'hooks.trust=false' --version
 
-if run_entrypoint codex codex --config 'hooks={trust=false}' --version >/tmp/workcell-entrypoint-codex-config-hooks-table.out 2>&1; then
-  echo "expected Workcell entrypoint to reject an inline-table override of the hooks namespace" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-hooks-table.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject an inline-table override of the hooks namespace" "Workcell blocked unsafe Codex config override" --config 'hooks={trust=false}' --version
 
-# PROFILE-SCOPED CONFIG OVERRIDES (Codex P1 review). A Codex profile-v2 layer
-# `[profiles.<name>.…]` can set ANY config key, and the wrapper injects the
-# active managed profile, so `-c profiles.<name>.features.remote_plugin=true`
-# re-enables the SAME surface the bare `features.remote_plugin` block rejects.
-# The gate strips the `profiles.<name>.` prefix and re-tests the remainder
-# against the same top-level blocklist, so every guarded key is blocked
-# profile-scoped too (features/plugins/marketplaces/mcp/hooks/sandbox_*/…).
-if run_entrypoint codex codex --config profiles.strict.features.remote_plugin=true --version >/tmp/workcell-entrypoint-codex-config-profile-remote-plugin.out 2>&1; then
-  echo "expected Workcell entrypoint to reject a profile-scoped features.remote_plugin override" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-remote-plugin.out
+# PROFILE-SCOPED CONFIG OVERRIDES (Codex P1 review). A `[profiles.<name>.…]` layer can
+# set ANY config key, so `-c profiles.<name>.features.remote_plugin=true` re-enables the
+# SAME surface the bare block rejects. The gate strips the `profiles.<name>.` prefix and
+# re-tests the remainder against the same top-level blocklist, so every guarded key is
+# blocked profile-scoped too (features/plugins/marketplaces/mcp/hooks/sandbox_*/…).
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject a profile-scoped features.remote_plugin override" "Workcell blocked unsafe Codex config override" --config profiles.strict.features.remote_plugin=true --version
 
-if run_entrypoint codex codex --config profiles.development.features.plugins=true --version >/tmp/workcell-entrypoint-codex-config-profile-plugins.out 2>&1; then
-  echo "expected Workcell entrypoint to reject a profile-scoped features.plugins override" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-plugins.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject a profile-scoped features.plugins override" "Workcell blocked unsafe Codex config override" --config profiles.development.features.plugins=true --version
 
-if run_entrypoint codex codex --config profiles.x.plugins.y=1 --version >/tmp/workcell-entrypoint-codex-config-profile-plugins-tree.out 2>&1; then
-  echo "expected Workcell entrypoint to reject a profile-scoped plugins.* override" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-plugins-tree.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject a profile-scoped plugins.* override" "Workcell blocked unsafe Codex config override" --config profiles.x.plugins.y=1 --version
 
-if run_entrypoint codex codex --config profiles.x.marketplaces.z=1 --version >/tmp/workcell-entrypoint-codex-config-profile-marketplaces.out 2>&1; then
-  echo "expected Workcell entrypoint to reject a profile-scoped marketplaces.* override" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-marketplaces.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject a profile-scoped marketplaces.* override" "Workcell blocked unsafe Codex config override" --config profiles.x.marketplaces.z=1 --version
 
-# Inline TABLE smuggled under a profile-scoped mcp namespace must also die: the
-# prefix-strip yields `mcp_servers.e`, which matches the `mcp*` guard.
-if run_entrypoint codex codex --config 'profiles.x.mcp_servers.e={command="/bin/sh"}' --version >/tmp/workcell-entrypoint-codex-config-profile-mcp-table.out 2>&1; then
-  echo "expected Workcell entrypoint to reject a profile-scoped mcp inline-table override" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-mcp-table.out
+# Inline TABLE under a profile-scoped mcp namespace must also die: the prefix-strip
+# yields `mcp_servers.e`, which matches the `mcp*` guard.
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject a profile-scoped mcp inline-table override" "Workcell blocked unsafe Codex config override" --config 'profiles.x.mcp_servers.e={command="/bin/sh"}' --version
 
-# Quoted profile name (`profiles."my env"...`) normalizes to a single `my env`
-# segment; the prefix-strip runs after quote normalization, so the remainder is
-# still re-tested and blocked. (A `.` INSIDE a quoted profile name splits the
-# key and fails closed as malformed — covered by the malformed-quote test above.)
-if run_entrypoint codex codex --config 'profiles."my env".features.plugins=true' --version >/tmp/workcell-entrypoint-codex-config-profile-quoted-name.out 2>&1; then
-  echo "expected Workcell entrypoint to reject a quoted-profile-name features.plugins override" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-quoted-name.out
+# Quoted profile name (`profiles."my env"...`) normalizes to a single `my env` segment;
+# the prefix-strip runs after quote normalization, so the remainder is still re-tested
+# and blocked. (A `.` inside a quoted name splits the key and fails closed as malformed
+# — covered by the malformed-quote test above.)
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject a quoted-profile-name features.plugins override" "Workcell blocked unsafe Codex config override" --config 'profiles."my env".features.plugins=true' --version
 
 # REGRESSION: the previously-explicit profiles.*.sandbox_mode block is now
 # covered by the general prefix-strip mechanism and must still reject.
-if run_entrypoint codex codex --config profiles.strict.sandbox_mode=danger-full-access --version >/tmp/workcell-entrypoint-codex-config-profile-sandbox-mode.out 2>&1; then
-  echo "expected Workcell entrypoint to reject a profile-scoped sandbox_mode override" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-sandbox-mode.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject a profile-scoped sandbox_mode override" "Workcell blocked unsafe Codex config override" --config profiles.strict.sandbox_mode=danger-full-access --version
 
-# PERMIT a genuinely benign profile-scoped override: `model` is not on the
-# security-boundary blocklist, so the prefix-strip remainder (`model`) is not
-# guarded and the override passes.
+# PERMIT a genuinely benign profile-scoped override: `model` is not on the blocklist,
+# so the prefix-strip remainder (`model`) is not guarded and the override passes.
 run_entrypoint codex codex --config profiles.strict.model=gpt-5-codex --version >/dev/null
 
-# ATTACHED SHORT `-c` CONFIG OVERRIDES (Codex P1 review). Codex accepts the short
-# config flag glued to its value (`-cKEY=VALUE`) and with clap's `=` separator
-# (`-c=KEY=VALUE`); before the fix only separate `-c <value>` and `--config=…`
-# were routed through the blocklist, so a glued form re-enabled the pinned-off
-# surfaces. The gate must run the SAME config blocker on the attached remainder.
-if run_entrypoint codex codex -cfeatures.remote_plugin=true --version >/tmp/workcell-entrypoint-codex-attached-c-scalar.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the glued -cfeatures.remote_plugin override" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-attached-c-scalar.out
+# ATTACHED SHORT `-c` CONFIG OVERRIDES (Codex P1 review). Codex accepts the short config
+# flag glued to its value (`-cKEY=VALUE`) and with clap's `=` separator (`-c=KEY=VALUE`);
+# before the fix only separate `-c <value>` and `--config=…` were routed, so a glued
+# form re-enabled the pinned-off surfaces. Run the SAME blocker on the attached remainder.
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the glued -cfeatures.remote_plugin override" "Workcell blocked unsafe Codex config override" -cfeatures.remote_plugin=true --version
 
-if run_entrypoint codex codex '-cfeatures={remote_plugin=true}' --version >/tmp/workcell-entrypoint-codex-attached-c-table.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the glued -cfeatures={...} inline-table override" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-attached-c-table.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the glued -cfeatures={...} inline-table override" "Workcell blocked unsafe Codex config override" '-cfeatures={remote_plugin=true}' --version
 
-if run_entrypoint codex codex -c=features.plugins=true --version >/tmp/workcell-entrypoint-codex-attached-c-eq.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the -c=KEY=VALUE (clap separator) plugins override" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-attached-c-eq.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the -c=KEY=VALUE (clap separator) plugins override" "Workcell blocked unsafe Codex config override" -c=features.plugins=true --version
 
-if run_entrypoint codex codex --config=features.plugins=true --version >/tmp/workcell-entrypoint-codex-config-eq-plugins.out 2>&1; then
-  echo "expected Workcell entrypoint to reject the --config=features.plugins override" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-eq-plugins.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the --config=features.plugins override" "Workcell blocked unsafe Codex config override" --config=features.plugins=true --version
 
 # A benign, genuinely-permitted -c override must still pass (model is not on the
 # security-boundary blocklist); a scalar value on a non-guarded key is not an
@@ -2906,29 +2705,13 @@ run_entrypoint codex codex --config 'history.persistence="none"' --version >/dev
 # key is normalized, values pass through untouched.
 run_entrypoint codex codex --config 'model=c:\bin\codex' --version >/dev/null
 
-if run_entrypoint codex codex --add-dir=/tmp --version >/tmp/workcell-entrypoint-codex-add-dir.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex add-dir overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-add-dir.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex add-dir overrides" "Workcell blocked unsafe Codex override" --add-dir=/tmp --version
 
-if run_entrypoint codex codex --enable danger-mode --version >/tmp/workcell-entrypoint-codex-enable.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex feature enables" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-enable.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex feature enables" "Workcell blocked unsafe Codex override" --enable danger-mode --version
 
-if run_entrypoint codex codex --disable safe-guards --version >/tmp/workcell-entrypoint-codex-disable.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex feature disables" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-disable.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex feature disables" "Workcell blocked unsafe Codex override" --disable safe-guards --version
 
-if run_entrypoint codex codex --remote=ssh://example.invalid/workcell --version >/tmp/workcell-entrypoint-codex-remote.out 2>&1; then
-  echo "expected Workcell entrypoint to reject Codex remote overrides" >&2
-  exit 1
-fi
-grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-remote.out
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex remote overrides" "Workcell blocked unsafe Codex override" --remote=ssh://example.invalid/workcell --version
 
 run_entrypoint claude claude --version >/dev/null
 run_entrypoint copilot copilot --version >/dev/null
@@ -3621,10 +3404,10 @@ test -f "$CODEX_HOME/config.toml"
     fi
     grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-local-provider-plugin.out
     if codex --remote-auth-token-env FOO mcp list >/tmp/codex-nested-remote-auth-mcp.out 2>&1; then
-      echo "expected the mcp surface behind the --remote-auth-token-env global to be rejected" >&2
+      echo "expected the --remote-auth-token-env remote-auth surface to be rejected" >&2
       exit 1
     fi
-    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-remote-auth-mcp.out
+    grep -q "Workcell blocked unsafe Codex override" /tmp/codex-nested-remote-auth-mcp.out
     # BARE-PROMPT PRESERVATION (Codex P2 review): a first bare token that is NOT
     # a known Codex subcommand is PROMPT text and must pass the gate, not die.
     # `--version` short-circuits Codex after the gate so the run exits 0.

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2606,6 +2606,48 @@ assert_codex_entrypoint_denied "expected Workcell entrypoint to reject operator-
 
 assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex working-directory overrides" "Workcell blocked unsafe Codex override" --cd /state --version
 
+# Space-separated sandbox danger-full-access deny (regression lock for the reused check).
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex sandbox danger-full-access overrides" "Workcell blocked unsafe Codex override: remove danger-full-access outside breakglass." -s danger-full-access --version
+
+# ATTACHED/GLUED SHORT VALUE-FLAGS (Codex P1 review). Codex (clap) accepts short flags
+# glued to their value (`-pval`/`-sval`/`-Cval`/`-aval`); before the fix only glued `-c`
+# was routed through the guard, so these fell through as unrecognized tokens and were
+# FORWARDED. Each now applies the SAME check (and message) as its space-separated form.
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the glued -pbreakglass profile override" "Workcell blocked unsafe Codex override: --profile" -pbreakglass --version
+
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the glued -sdanger-full-access sandbox override" "Workcell blocked unsafe Codex override: remove danger-full-access outside breakglass." -sdanger-full-access --version
+
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the glued -anever approval override" "Workcell blocked unsafe Codex override: -anever" -anever --version
+
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the glued -C/state working-directory override" "Workcell blocked unsafe Codex override: --cd" -C/state --version
+
+# Long `--flag=value` glued forms of the same guarded flags are denied too.
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the --profile=breakglass override" "Workcell blocked unsafe Codex override: --profile" --profile=breakglass --version
+
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the --sandbox=danger-full-access override" "Workcell blocked unsafe Codex override: --sandbox=danger-full-access" --sandbox=danger-full-access --version
+
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the --cd=/x working-directory override" "Workcell blocked unsafe Codex override: --cd" --cd=/x --version
+
+# PERMIT the in-mode glued profile at the GUARD: run_entrypoint pins strict, so glued
+# `-pstrict`/`--profile=strict` equals the allowed profile and the guard does NOT die
+# (like space-separated `--profile strict`). Codex then exits nonzero on the DUPLICATE
+# --profile (the wrapper also injects managed `--profile strict`), so assert the guard
+# verdict by the ABSENCE of the block message, not a clean exit.
+for codex_profile_permit in -pstrict --profile=strict; do
+  codex_profile_permit_out="/tmp/workcell-entrypoint-codex-profile-permit.out"
+  run_entrypoint codex codex "${codex_profile_permit}" --version >"${codex_profile_permit_out}" 2>&1 || true
+  if grep -q "Workcell blocked" "${codex_profile_permit_out}"; then
+    echo "expected the in-mode glued profile ${codex_profile_permit} to pass the guard" >&2
+    cat "${codex_profile_permit_out}" >&2
+    exit 1
+  fi
+done
+
+# PERMIT glued model/image: a glued `-mgpt-5-codex`/`-iImage` is a single safe flag token
+# with no separate value to consume, so it is harmless and forwarded (must not block).
+run_entrypoint codex codex -mgpt-5-codex --version >/dev/null
+run_entrypoint codex codex -iImage --version >/dev/null
+
 assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex profile config overrides" "Workcell blocked unsafe Codex config override" --config profile=breakglass --version
 
 assert_codex_entrypoint_denied "expected Workcell entrypoint to reject Codex network_access config overrides" "Workcell blocked unsafe Codex config override" --config sandbox_workspace_write.network_access=true --version

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2176,6 +2176,25 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ -x /bin/echo ]]; then
     exit 1
   fi
 
+  # P2 (managed-profile scan must stop at bare `--`). `codex -- --profile
+  # breakglass` puts "--profile breakglass" AFTER `--`, so it is PROMPT text,
+  # never an operator flag. codex_args_include_profile must therefore NOT treat
+  # it as an operator-supplied profile, so the managed `--profile strict` stays
+  # injected and the sandbox/approval contract is preserved. The post-`--` tokens
+  # are forwarded verbatim after the managed args.
+  CODEX_POSTDASH_PROFILE_ARGS="$(
+    run_entrypoint_with_autonomy_and_bind \
+      codex \
+      yolo \
+      /bin/echo \
+      /usr/local/libexec/workcell/real/codex \
+      codex -- --profile breakglass
+  )"
+  if [[ "${CODEX_POSTDASH_PROFILE_ARGS}" != "--profile strict --ask-for-approval never -- --profile breakglass" ]]; then
+    echo "expected managed --profile strict to stay injected when --profile follows a bare --: ${CODEX_POSTDASH_PROFILE_ARGS}" >&2
+    exit 1
+  fi
+
   cat <<'EOF' >"${ROOT_DIR}/tmp/workcell-codex-env-check.sh"
 #!/bin/sh
 printf '{"claude_config":"%s","aws":"%s","gh":"%s","ssh":"%s"}\n' \
@@ -2551,7 +2570,7 @@ fi
 # exact token on the CLI path — deny-by-default over the classified subcommand
 # namespace. These are real pinned-Codex subcommands (not prompt text), so the
 # gate must reject them.
-for codex_denied_sub in cloud sandbox mcp plugin remote-control exec-server mcp-server update; do
+for codex_denied_sub in cloud cloud-tasks responses-api-proxy stdio-to-uds sandbox mcp plugin remote-control exec-server mcp-server update; do
   codex_deny_out="/tmp/workcell-entrypoint-codex-denydefault-${codex_denied_sub}.out"
   if run_entrypoint codex codex "${codex_denied_sub}" >"${codex_deny_out}" 2>&1; then
     echo "expected the deny-set gate to reject the dangerous subcommand: ${codex_denied_sub}" >&2

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2522,9 +2522,14 @@ run_entrypoint codex codex features list >/dev/null
 # permitted AND reached Codex. `help` does not accept `--help`, so it uses the block-
 # message-absent pattern below. execpolicy is a hidden but real read-only classifier
 # the managed autonomy path invokes; it must stay on the allowlist.
-for codex_allowed_sub in e review login logout completion doctor apply a resume fork archive unarchive delete debug execpolicy; do
+for codex_allowed_sub in e review login logout completion doctor apply a resume fork archive unarchive delete execpolicy; do
   run_entrypoint codex codex "${codex_allowed_sub}" --help >/dev/null
 done
+# `debug` is denied on every UI: its second-level subcommands are not read-only
+# (`debug app-server` reaches the app-server test client, `debug clear-memories`
+# mutates local memory), so the deny-by-default gate rejects the whole subcommand.
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex debug subcommand" "Workcell blocked unsupported Codex CLI subcommand" debug
+assert_codex_entrypoint_denied "expected Workcell entrypoint to reject the Codex debug app-server test-client surface" "Workcell blocked unsupported Codex CLI subcommand" debug app-server send-message-v2
 codex_help_permit_out="/tmp/workcell-entrypoint-codex-help-permit.out"
 run_entrypoint codex codex help >"${codex_help_permit_out}" 2>&1 || true
 if grep -q "Workcell blocked" "${codex_help_permit_out}"; then

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2436,6 +2436,27 @@ if run_entrypoint codex codex --dangerously-bypass-approvals-and-sandbox >/tmp/w
 fi
 grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-danger.out
 
+# The whole --dangerously-* family is blocked (0.143 adds hook-trust); the glob
+# also future-proofs against new dangerously-flags.
+if run_entrypoint codex codex --dangerously-bypass-hook-trust --version >/tmp/workcell-entrypoint-codex-danger-hook-trust.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the Codex dangerous hook-trust bypass" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-danger-hook-trust.out
+
+if run_entrypoint codex codex --dangerously-bypass-future-badness --version >/tmp/workcell-entrypoint-codex-danger-future.out 2>&1; then
+  echo "expected Workcell entrypoint to reject any Codex --dangerously-bypass-* flag via the glob" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-danger-future.out
+
+# --yolo is Codex's hidden alias for --dangerously-bypass-approvals-and-sandbox.
+if run_entrypoint codex codex --yolo --version >/tmp/workcell-entrypoint-codex-yolo.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the Codex --yolo bypass alias" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-codex-yolo.out
+
 if run_entrypoint codex codex -a never --version >/tmp/workcell-entrypoint-codex-approval.out 2>&1; then
   echo "expected Workcell entrypoint to reject Codex approval overrides" >&2
   exit 1
@@ -2453,6 +2474,135 @@ if run_entrypoint codex codex app-server >/tmp/workcell-entrypoint-codex-app-ser
   exit 1
 fi
 grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-app-server.out
+
+if run_entrypoint codex codex plugin list >/tmp/workcell-entrypoint-codex-plugin.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the Codex plugin marketplace/install surface" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-plugin.out
+
+if run_entrypoint codex codex remote-control pair >/tmp/workcell-entrypoint-codex-remote-control.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the Codex remote-control app-server pairing surface" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-remote-control.out
+
+# exec-server is the experimental standalone exec daemon, not the managed GUI
+# backend, so it is blocked unconditionally. The exact-token match must not catch
+# the legitimate `exec` subcommand.
+if run_entrypoint codex codex exec-server >/tmp/workcell-entrypoint-codex-exec-server.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the Codex exec-server daemon subcommand" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-exec-server.out
+
+# mcp-server (Codex-as-an-MCP-server daemon) and update (self-update that would
+# defeat the pinned image) are blocked unconditionally, same class as exec-server.
+if run_entrypoint codex codex mcp-server >/tmp/workcell-entrypoint-codex-mcp-server.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the Codex mcp-server daemon subcommand" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-mcp-server.out
+
+if run_entrypoint codex codex update >/tmp/workcell-entrypoint-codex-update.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the Codex self-update subcommand" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-update.out
+
+# features enable/disable persistently write config.toml; both are blocked while
+# the read-only `features list` and the `exec` subcommand stay permitted.
+if run_entrypoint codex codex features enable plugins >/tmp/workcell-entrypoint-codex-features-enable.out 2>&1; then
+  echo "expected Workcell entrypoint to reject persistent Codex feature enable" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-features-enable.out
+
+if run_entrypoint codex codex features disable unified_exec >/tmp/workcell-entrypoint-codex-features-disable.out 2>&1; then
+  echo "expected Workcell entrypoint to reject persistent Codex feature disable" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-features-disable.out
+
+# The exec-server/features exact-token blocks must not catch the legitimate
+# `exec` runtime subcommand or the read-only `features list`.
+run_entrypoint codex codex exec --help >/dev/null
+run_entrypoint codex codex features list >/dev/null
+
+# ALLOWLIST PERMIT COVERAGE. Every classified-safe read-only/session subcommand
+# on the deny-by-default allowlist (verified against real `codex --help` 0.144)
+# must pass the gate. `<sub> --help` prints Codex's own help and exits 0, so a
+# clean exit proves the token was permitted AND reached Codex. `help` does not
+# accept `--help`, so it is proven via the block-message-absent pattern below.
+# execpolicy is a hidden (not in top-level `--help`) but real read-only command
+# classifier the managed autonomy path invokes; it must stay on the allowlist.
+for codex_allowed_sub in e review login logout completion doctor apply a resume fork archive unarchive delete debug execpolicy; do
+  run_entrypoint codex codex "${codex_allowed_sub}" --help >/dev/null
+done
+codex_help_permit_out="/tmp/workcell-entrypoint-codex-help-permit.out"
+run_entrypoint codex codex help >"${codex_help_permit_out}" 2>&1 || true
+if grep -q "Workcell blocked" "${codex_help_permit_out}"; then
+  echo "expected the allowlisted 'help' subcommand to pass the deny-by-default gate" >&2
+  cat "${codex_help_permit_out}" >&2
+  exit 1
+fi
+
+# DENY-BY-DEFAULT REGRESSION LOCK. The whole point of the allowlist refactor:
+# a subcommand that is not on the permit set is denied even if it is unknown to
+# this policy — including MADE-UP future tokens a later CLI bump might add. A
+# blocklist would have silently permitted these; the allowlist denies them.
+for codex_denied_sub in frobnicate some-new-daemon cloud sandbox mcp; do
+  codex_deny_out="/tmp/workcell-entrypoint-codex-denydefault-${codex_denied_sub}.out"
+  if run_entrypoint codex codex "${codex_denied_sub}" >"${codex_deny_out}" 2>&1; then
+    echo "expected the deny-by-default gate to reject the non-allowlisted subcommand: ${codex_denied_sub}" >&2
+    exit 1
+  fi
+  grep -q "Workcell blocked unsupported Codex CLI subcommand" "${codex_deny_out}"
+done
+
+# A permitted subcommand behind a value-taking global still passes the gate
+# (the global's value is consumed, not mistaken for the command token), while a
+# denied one behind the same global is still denied (covered above for plugin).
+run_entrypoint codex codex --model gpt-5 exec --help >/dev/null
+# app/app-server are GUI-gated: denied on the CLI path (run_entrypoint pins
+# AGENT_UI=cli), so the CLI-path deny is covered here; the AGENT_UI=gui PERMIT
+# path is exercised in the nested-container block below, where AGENT_UI is not
+# pinned at the wrapper boundary.
+if run_entrypoint codex codex app >/tmp/workcell-entrypoint-codex-app-cli.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the Codex app subcommand on the CLI path" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand outside the managed GUI path" /tmp/workcell-entrypoint-codex-app-cli.out
+
+# Value-taking global flags must not desynchronize first-subcommand detection:
+# the flag's value is not a command token, so the blocklist still applies.
+if run_entrypoint codex codex --model gpt-5 plugin list >/tmp/workcell-entrypoint-codex-model-plugin.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the Codex plugin surface behind value-taking globals" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-model-plugin.out
+
+if run_entrypoint codex codex --model gpt-5 remote-control pair >/tmp/workcell-entrypoint-codex-model-remote-control.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the Codex remote-control surface behind value-taking globals" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-model-remote-control.out
+
+if run_entrypoint codex codex --model gpt-5 mcp list >/tmp/workcell-entrypoint-codex-model-mcp.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the Codex mcp surface behind value-taking globals" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-model-mcp.out
+
+# --local-provider is another value-taking global; its value must not be
+# mistaken for the subcommand token.
+if run_entrypoint codex codex --local-provider ollama plugin list >/tmp/workcell-entrypoint-codex-local-provider-plugin.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the plugin surface behind the --local-provider global" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-local-provider-plugin.out
+
+run_entrypoint codex codex --model gpt-5 --version >/dev/null
 
 if run_entrypoint codex codex --profile breakglass --version >/tmp/workcell-entrypoint-codex-profile.out 2>&1; then
   echo "expected Workcell entrypoint to reject operator-supplied Codex profiles" >&2
@@ -2489,6 +2639,106 @@ if run_entrypoint codex codex --config shell_environment_policy.set.BAD=1 --vers
   exit 1
 fi
 grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-shell.out
+
+if run_entrypoint codex codex --config 'plugins."evil@rogue".enabled=true' --version >/tmp/workcell-entrypoint-codex-config-plugins.out 2>&1; then
+  echo "expected Workcell entrypoint to reject Codex plugin config overrides" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-plugins.out
+
+if run_entrypoint codex codex --config 'marketplaces.rogue.source=/tmp/evil' --version >/tmp/workcell-entrypoint-codex-config-marketplaces.out 2>&1; then
+  echo "expected Workcell entrypoint to reject Codex marketplace config overrides" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-marketplaces.out
+
+# Quoted/whitespace TOML key spellings must not bypass config-override blocking.
+if run_entrypoint codex codex --config 'features."remote_plugin"=true' --version >/tmp/workcell-entrypoint-codex-config-quoted-feature.out 2>&1; then
+  echo "expected Workcell entrypoint to reject quoted-segment Codex feature config overrides" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-quoted-feature.out
+
+if run_entrypoint codex codex --config '"mcp_servers".rogue.command=/bin/sh' --version >/tmp/workcell-entrypoint-codex-config-quoted-mcp.out 2>&1; then
+  echo "expected Workcell entrypoint to reject quoted-segment Codex mcp config overrides" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-quoted-mcp.out
+
+if run_entrypoint codex codex --config 'features . plugins=true' --version >/tmp/workcell-entrypoint-codex-config-spaced-feature.out 2>&1; then
+  echo "expected Workcell entrypoint to reject whitespace-padded Codex feature config overrides" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-spaced-feature.out
+
+if run_entrypoint codex codex --config 'features."remote_plugin=true' --version >/tmp/workcell-entrypoint-codex-config-malformed-quote.out 2>&1; then
+  echo "expected Workcell entrypoint to fail closed on malformed-quote Codex config overrides" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-malformed-quote.out
+
+# TOML basic-string escapes decode to blocked keys under a spec-compliant parser
+# (the \u0072 escape below is 'r', so features."\u0072emote_plugin" decodes to
+# features.remote_plugin, and "\u0061pproval_policy" decodes to approval_policy).
+# We refuse to decode escapes in bash and fail closed on any backslash in a key
+# segment.
+if run_entrypoint codex codex --config 'features."\u0072emote_plugin"=true' --version >/tmp/workcell-entrypoint-codex-config-escape-feature.out 2>&1; then
+  echo "expected Workcell entrypoint to fail closed on backslash-escaped Codex feature config overrides" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-escape-feature.out
+
+if run_entrypoint codex codex --config '"\u0061pproval_policy"="never"' --version >/tmp/workcell-entrypoint-codex-config-escape-approval.out 2>&1; then
+  echo "expected Workcell entrypoint to fail closed on backslash-escaped Codex approval-policy config overrides" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-escape-approval.out
+
+# Codex parses -c values as TOML, so an inline TABLE value can smuggle blocked
+# child keys under a parent that is not itself blocked (features, profiles). Any
+# inline-table value on a guarded namespace parent must be rejected.
+if run_entrypoint codex codex --config 'features={remote_plugin=true}' --version >/tmp/workcell-entrypoint-codex-config-table-features.out 2>&1; then
+  echo "expected Workcell entrypoint to reject an inline-table override of the features namespace" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-table-features.out
+
+if run_entrypoint codex codex --config 'profiles={foo={sandbox_mode="danger-full-access"}}' --version >/tmp/workcell-entrypoint-codex-config-table-profiles.out 2>&1; then
+  echo "expected Workcell entrypoint to reject an inline-table override of the profiles namespace" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-table-profiles.out
+
+if run_entrypoint codex codex --config 'mcp_servers={evil={command="/bin/sh"}}' --version >/tmp/workcell-entrypoint-codex-config-table-mcp.out 2>&1; then
+  echo "expected Workcell entrypoint to reject an inline-table override of the mcp_servers namespace" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-table-mcp.out
+
+# The hooks namespace is a code-execution/trust surface (see the dangerous
+# --dangerously-bypass-hook-trust flag); no legitimate managed -c override sets
+# it, so any hooks.* scalar or inline-table override is blocked.
+if run_entrypoint codex codex --config 'hooks.trust=false' --version >/tmp/workcell-entrypoint-codex-config-hooks-scalar.out 2>&1; then
+  echo "expected Workcell entrypoint to reject a hooks.* config override" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-hooks-scalar.out
+
+if run_entrypoint codex codex --config 'hooks={trust=false}' --version >/tmp/workcell-entrypoint-codex-config-hooks-table.out 2>&1; then
+  echo "expected Workcell entrypoint to reject an inline-table override of the hooks namespace" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-hooks-table.out
+
+# A benign, genuinely-permitted -c override must still pass (model is not on the
+# security-boundary blocklist); a scalar value on a non-guarded key is not an
+# inline table, so the table guard leaves it untouched.
+run_entrypoint codex codex --config 'model=gpt-5-codex' --version >/dev/null
+run_entrypoint codex codex --config 'history.persistence="none"' --version >/dev/null
+
+# A backslash in the VALUE (not the key) must not trip the escape guard: only the
+# key is normalized, values pass through untouched.
+run_entrypoint codex codex --config 'model=c:\bin\codex' --version >/dev/null
 
 if run_entrypoint codex codex --add-dir=/tmp --version >/tmp/workcell-entrypoint-codex-add-dir.out 2>&1; then
   echo "expected Workcell entrypoint to reject Codex add-dir overrides" >&2
@@ -3169,6 +3419,119 @@ test -f "$CODEX_HOME/config.toml"
       exit 1
     fi
     grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-app-server.out
+    if codex plugin list >/tmp/codex-nested-plugin.out 2>&1; then
+      echo "expected nested Codex invocation to reject the plugin marketplace/install surface" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-plugin.out
+    if codex remote-control pair >/tmp/codex-nested-remote-control.out 2>&1; then
+      echo "expected nested Codex invocation to reject the remote-control app-server pairing surface" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-remote-control.out
+    if AGENT_UI=gui codex plugin list >/tmp/codex-nested-gui-plugin.out 2>&1; then
+      echo "expected an in-container AGENT_UI=gui override to still reject the plugin surface" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-gui-plugin.out
+    if AGENT_UI=gui codex remote-control pair >/tmp/codex-nested-gui-remote-control.out 2>&1; then
+      echo "expected an in-container AGENT_UI=gui override to still reject the remote-control surface" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-gui-remote-control.out
+    if codex exec-server >/tmp/codex-nested-exec-server.out 2>&1; then
+      echo "expected nested Codex invocation to reject the exec-server daemon subcommand" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-exec-server.out
+    if AGENT_UI=gui codex exec-server >/tmp/codex-nested-gui-exec-server.out 2>&1; then
+      echo "expected an in-container AGENT_UI=gui override to still reject the exec-server daemon subcommand" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-gui-exec-server.out
+    if codex --local-provider ollama plugin list >/tmp/codex-nested-local-provider-plugin.out 2>&1; then
+      echo "expected the plugin surface behind the --local-provider global to be rejected" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-local-provider-plugin.out
+    if codex --remote-auth-token-env FOO mcp list >/tmp/codex-nested-remote-auth-mcp.out 2>&1; then
+      echo "expected the mcp surface behind the --remote-auth-token-env global to be rejected" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-remote-auth-mcp.out
+    # DENY-BY-DEFAULT regression lock: a MADE-UP future subcommand that this
+    # policy has never heard of must be denied — the allowlist rejects anything
+    # off the permit set, so a later CLI bump cannot silently reopen a hole.
+    if codex frobnicate >/tmp/codex-nested-frobnicate.out 2>&1; then
+      echo "expected the deny-by-default gate to reject the unknown future subcommand frobnicate" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-frobnicate.out
+    if codex some-new-daemon >/tmp/codex-nested-newdaemon.out 2>&1; then
+      echo "expected the deny-by-default gate to reject the unknown future subcommand some-new-daemon" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-newdaemon.out
+    # cloud/sandbox are no longer GUI-gated: they are off the allowlist, so they
+    # are denied on every UI (including AGENT_UI=gui).
+    if AGENT_UI=gui codex cloud >/tmp/codex-nested-gui-cloud.out 2>&1; then
+      echo "expected AGENT_UI=gui to still reject the non-allowlisted cloud subcommand" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-gui-cloud.out
+    # app/app-server are the managed GUI backend: denied on cli, PERMITTED under
+    # AGENT_UI=gui. `app-server --help` prints Codex help and exits 0, proving the
+    # gui gate lets the token through (no workcell block message).
+    if codex app-server >/tmp/codex-nested-cli-app-server.out 2>&1; then
+      echo "expected the app-server GUI backend to be denied on the CLI path" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand outside the managed GUI path" /tmp/codex-nested-cli-app-server.out
+    AGENT_UI=gui codex app-server --help </dev/null >/tmp/codex-nested-gui-app-server-permit.out 2>&1 || true
+    if grep -q "Workcell blocked" /tmp/codex-nested-gui-app-server-permit.out; then
+      echo "expected AGENT_UI=gui to permit the managed app-server GUI backend" >&2
+      cat /tmp/codex-nested-gui-app-server-permit.out >&2
+      exit 1
+    fi
+    # A permitted read-only subcommand from the allowlist passes the gate; the
+    # block message must be ABSENT (review may exit non-zero without a repo, but
+    # it is never blocked by workcell).
+    codex review --help </dev/null >/tmp/codex-nested-review-permit.out 2>&1 || true
+    if grep -q "Workcell blocked" /tmp/codex-nested-review-permit.out; then
+      echo "expected the allowlisted review subcommand to pass the deny-by-default gate" >&2
+      cat /tmp/codex-nested-review-permit.out >&2
+      exit 1
+    fi
+    # A post-`--` prompt whose first word is a MADE-UP subcommand is literal
+    # prompt text, not a command token, so it must NOT be denied by the allowlist.
+    codex -- frobnicate </dev/null >/tmp/codex-nested-doubledash-frobnicate.out 2>&1 || true
+    if grep -q "Workcell blocked" /tmp/codex-nested-doubledash-frobnicate.out; then
+      echo "expected a post-'--' prompt starting with an unknown word to skip the subcommand allowlist" >&2
+      cat /tmp/codex-nested-doubledash-frobnicate.out >&2
+      exit 1
+    fi
+    # A bare `--` makes every following token literal prompt text, so a prompt
+    # beginning with `plugin`/`remote-control`/`mcp` must NOT be blocked as a
+    # subcommand. Codex may still exit non-zero (the TUI needs a terminal), but
+    # the workcell subcommand block must be ABSENT.
+    codex -- plugin list </dev/null >/tmp/codex-nested-doubledash-plugin.out 2>&1 || true
+    if grep -q "Workcell blocked" /tmp/codex-nested-doubledash-plugin.out; then
+      echo "expected a post-'--' prompt starting with 'plugin' to skip the subcommand blocklist" >&2
+      cat /tmp/codex-nested-doubledash-plugin.out >&2
+      exit 1
+    fi
+    codex -- remote-control pair </dev/null >/tmp/codex-nested-doubledash-remote-control.out 2>&1 || true
+    if grep -q "Workcell blocked" /tmp/codex-nested-doubledash-remote-control.out; then
+      echo "expected a post-'--' prompt starting with 'remote-control' to skip the subcommand blocklist" >&2
+      cat /tmp/codex-nested-doubledash-remote-control.out >&2
+      exit 1
+    fi
+    codex -- mcp </dev/null >/tmp/codex-nested-doubledash-mcp.out 2>&1 || true
+    if grep -q "Workcell blocked" /tmp/codex-nested-doubledash-mcp.out; then
+      echo "expected a post-'--' prompt starting with 'mcp' to skip the subcommand blocklist" >&2
+      cat /tmp/codex-nested-doubledash-mcp.out >&2
+      exit 1
+    fi
     rm -f "$CODEX_HOME/config.toml"
     printf "web_search = \"enabled\"\n" >"$CODEX_HOME/config.toml"
     codex --version >/tmp/codex-version-after-tamper.out 2>/tmp/codex-version-after-tamper.err
@@ -3177,14 +3540,30 @@ test -f "$CODEX_HOME/config.toml"
     test ! -L "$CODEX_HOME/config.toml"
     test -w "$CODEX_HOME/config.toml"
     cmp "$CODEX_HOME/config.toml" /opt/workcell/adapters/codex/.codex/config.toml
-    codex features disable unified_exec >/tmp/codex-features-disable.out 2>/tmp/codex-features-disable.err
-    assert_codex_stderr_clean /tmp/codex-features-disable.err
-    test ! -L "$CODEX_HOME/config.toml"
+    # `codex features enable/disable` persistently writes features.<name> into the
+    # writable config.toml (equivalent to the blocked `-c features.<name>=…`), so
+    # both mutating actions are rejected on the managed path; the block must also
+    # prevent the config mutation (unified_exec stays at its declared false).
+    if codex features enable unified_exec >/tmp/codex-features-enable.out 2>&1; then
+      echo "expected nested Codex invocation to reject persistent feature enable" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-features-enable.out
     test -w "$CODEX_HOME/config.toml"
     assert_codex_feature_value false
-    codex features enable unified_exec >/tmp/codex-features-enable.out 2>/tmp/codex-features-enable.err
-    assert_codex_stderr_clean /tmp/codex-features-enable.err
-    assert_codex_feature_value true
+    if codex features enable plugins >/tmp/codex-features-enable-plugins.out 2>&1; then
+      echo "expected nested Codex invocation to reject the plugin feature re-enable" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-features-enable-plugins.out
+    if codex features disable unified_exec >/tmp/codex-features-disable.out 2>&1; then
+      echo "expected nested Codex invocation to reject persistent feature disable" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-features-disable.out
+    # features list is a read-only inspect and stays permitted.
+    codex features list >/tmp/codex-features-list-permit.out 2>&1
+    grep -q "unified_exec" /tmp/codex-features-list-permit.out
   '
   if /usr/local/libexec/workcell/real/codex --version >/tmp/codex-real-path.out 2>&1; then
     echo "expected direct real Codex payload execution to fail" >&2

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2786,6 +2786,68 @@ if run_entrypoint codex codex --config 'hooks={trust=false}' --version >/tmp/wor
 fi
 grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-hooks-table.out
 
+# PROFILE-SCOPED CONFIG OVERRIDES (Codex P1 review). A Codex profile-v2 layer
+# `[profiles.<name>.…]` can set ANY config key, and the wrapper injects the
+# active managed profile, so `-c profiles.<name>.features.remote_plugin=true`
+# re-enables the SAME surface the bare `features.remote_plugin` block rejects.
+# The gate strips the `profiles.<name>.` prefix and re-tests the remainder
+# against the same top-level blocklist, so every guarded key is blocked
+# profile-scoped too (features/plugins/marketplaces/mcp/hooks/sandbox_*/…).
+if run_entrypoint codex codex --config profiles.strict.features.remote_plugin=true --version >/tmp/workcell-entrypoint-codex-config-profile-remote-plugin.out 2>&1; then
+  echo "expected Workcell entrypoint to reject a profile-scoped features.remote_plugin override" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-remote-plugin.out
+
+if run_entrypoint codex codex --config profiles.development.features.plugins=true --version >/tmp/workcell-entrypoint-codex-config-profile-plugins.out 2>&1; then
+  echo "expected Workcell entrypoint to reject a profile-scoped features.plugins override" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-plugins.out
+
+if run_entrypoint codex codex --config profiles.x.plugins.y=1 --version >/tmp/workcell-entrypoint-codex-config-profile-plugins-tree.out 2>&1; then
+  echo "expected Workcell entrypoint to reject a profile-scoped plugins.* override" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-plugins-tree.out
+
+if run_entrypoint codex codex --config profiles.x.marketplaces.z=1 --version >/tmp/workcell-entrypoint-codex-config-profile-marketplaces.out 2>&1; then
+  echo "expected Workcell entrypoint to reject a profile-scoped marketplaces.* override" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-marketplaces.out
+
+# Inline TABLE smuggled under a profile-scoped mcp namespace must also die: the
+# prefix-strip yields `mcp_servers.e`, which matches the `mcp*` guard.
+if run_entrypoint codex codex --config 'profiles.x.mcp_servers.e={command="/bin/sh"}' --version >/tmp/workcell-entrypoint-codex-config-profile-mcp-table.out 2>&1; then
+  echo "expected Workcell entrypoint to reject a profile-scoped mcp inline-table override" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-mcp-table.out
+
+# Quoted profile name (`profiles."my env"...`) normalizes to a single `my env`
+# segment; the prefix-strip runs after quote normalization, so the remainder is
+# still re-tested and blocked. (A `.` INSIDE a quoted profile name splits the
+# key and fails closed as malformed — covered by the malformed-quote test above.)
+if run_entrypoint codex codex --config 'profiles."my env".features.plugins=true' --version >/tmp/workcell-entrypoint-codex-config-profile-quoted-name.out 2>&1; then
+  echo "expected Workcell entrypoint to reject a quoted-profile-name features.plugins override" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-quoted-name.out
+
+# REGRESSION: the previously-explicit profiles.*.sandbox_mode block is now
+# covered by the general prefix-strip mechanism and must still reject.
+if run_entrypoint codex codex --config profiles.strict.sandbox_mode=danger-full-access --version >/tmp/workcell-entrypoint-codex-config-profile-sandbox-mode.out 2>&1; then
+  echo "expected Workcell entrypoint to reject a profile-scoped sandbox_mode override" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Codex config override" /tmp/workcell-entrypoint-codex-config-profile-sandbox-mode.out
+
+# PERMIT a genuinely benign profile-scoped override: `model` is not on the
+# security-boundary blocklist, so the prefix-strip remainder (`model`) is not
+# guarded and the override passes.
+run_entrypoint codex codex --config profiles.strict.model=gpt-5-codex --version >/dev/null
+
 # ATTACHED SHORT `-c` CONFIG OVERRIDES (Codex P1 review). Codex accepts the short
 # config flag glued to its value (`-cKEY=VALUE`) and with clap's `=` separator
 # (`-c=KEY=VALUE`); before the fix only separate `-c <value>` and `--config=…`

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2494,6 +2494,15 @@ if run_entrypoint codex codex app-server >/tmp/workcell-entrypoint-codex-app-ser
 fi
 grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-app-server.out
 
+# The app-server remote-control surface is denied on the CLI path too (bare
+# app-server is already denied outside the managed GUI path, so the daemon
+# enable-remote-control action never even reaches its own scan here).
+if run_entrypoint codex codex app-server daemon enable-remote-control >/tmp/workcell-entrypoint-codex-app-server-daemon.out 2>&1; then
+  echo "expected Workcell entrypoint to reject the Codex app-server daemon remote-control surface on the CLI path" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-app-server-daemon.out
+
 if run_entrypoint codex codex plugin list >/tmp/workcell-entrypoint-codex-plugin.out 2>&1; then
   echo "expected Workcell entrypoint to reject the Codex plugin marketplace/install surface" >&2
   exit 1
@@ -3580,6 +3589,36 @@ test -f "$CODEX_HOME/config.toml"
       cat /tmp/codex-nested-gui-app-server-permit.out >&2
       exit 1
     fi
+    # The managed GUI allowance for `app-server` permits ONLY the bare launch (plus
+    # the sandbox/approval flags provider-wrapper.sh prepends, never in user argv).
+    # Pinned Codex 0.142.4 hides a `--remote-control` flag on AppServerCommand and
+    # dispatches an AppServerSubcommand (daemon/proxy/generate-*) plus an
+    # AppServerDaemonSubcommand (bootstrap/enable-remote-control/…), so
+    # `codex app-server --remote-control`, `codex app-server daemon`, and
+    # `codex app-server daemon enable-remote-control` reach the remote-control
+    # surface the standalone `remote-control` deny blocks. Under AGENT_UI=gui these
+    # app-server control tokens MUST be denied even though the bare app-server
+    # token is permitted.
+    # NOTE: this whole block runs inside a single-quoted `bash -lc '…'` above, so
+    # it must contain NO single quotes. Each case is asserted explicitly (no loop,
+    # no printf/tr) to stay single-quote-free.
+    assert_gui_appserver_denied() {
+      local out="$1"
+      shift
+      if AGENT_UI=gui codex app-server "$@" </dev/null >"${out}" 2>&1; then
+        echo "expected AGENT_UI=gui to reject the app-server control surface: app-server $*" >&2
+        cat "${out}" >&2
+        exit 1
+      fi
+      grep -q "Workcell blocked" "${out}"
+    }
+    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-remote-control.out --remote-control
+    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-daemon.out daemon
+    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-daemon-erc.out daemon enable-remote-control
+    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-bootstrap-rc.out bootstrap --remote-control
+    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-daemon-bootstrap-rc.out daemon bootstrap --remote-control
+    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-proxy.out proxy
+    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-generate-ts.out generate-ts
     # A permitted read-only subcommand from the allowlist passes the gate; the
     # block message must be ABSENT (review may exit non-zero without a repo, but
     # it is never blocked by workcell).

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -3631,29 +3631,33 @@ test -f "$CODEX_HOME/config.toml"
     fi
     grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-nested-gui-cloud.out
     # app/app-server are the managed GUI backend: denied on cli, PERMITTED under
-    # AGENT_UI=gui. `app-server --help` prints Codex help and exits 0, proving the
-    # gui gate lets the token through (no workcell block message).
+    # AGENT_UI=gui. The gate now permits ONLY the bare managed launch `codex
+    # app-server` with NO trailing args (see reject_unsafe_codex_args). The bare
+    # launch passes the workcell check, then execs real codex app-server which opens
+    # its stdio transport; </dev/null delivers EOF so it exits without hanging. The
+    # PERMIT proof is the ABSENCE of any workcell block message (NOT --help: --help
+    # is a trailing token and is now correctly DENIED — asserted below).
     if codex app-server >/tmp/codex-nested-cli-app-server.out 2>&1; then
       echo "expected the app-server GUI backend to be denied on the CLI path" >&2
       exit 1
     fi
     grep -q "Workcell blocked unsupported Codex CLI subcommand outside the managed GUI path" /tmp/codex-nested-cli-app-server.out
-    AGENT_UI=gui codex app-server --help </dev/null >/tmp/codex-nested-gui-app-server-permit.out 2>&1 || true
+    AGENT_UI=gui timeout 20 codex app-server </dev/null >/tmp/codex-nested-gui-app-server-permit.out 2>&1 || true
     if grep -q "Workcell blocked" /tmp/codex-nested-gui-app-server-permit.out; then
-      echo "expected AGENT_UI=gui to permit the managed app-server GUI backend" >&2
+      echo "expected AGENT_UI=gui to permit the bare managed app-server GUI launch" >&2
       cat /tmp/codex-nested-gui-app-server-permit.out >&2
       exit 1
     fi
     # The managed GUI allowance for `app-server` permits ONLY the bare launch (plus
     # the sandbox/approval flags provider-wrapper.sh prepends, never in user argv).
-    # Pinned Codex 0.142.4 hides a `--remote-control` flag on AppServerCommand and
-    # dispatches an AppServerSubcommand (daemon/proxy/generate-*) plus an
-    # AppServerDaemonSubcommand (bootstrap/enable-remote-control/…), so
-    # `codex app-server --remote-control`, `codex app-server daemon`, and
-    # `codex app-server daemon enable-remote-control` reach the remote-control
-    # surface the standalone `remote-control` deny blocks. Under AGENT_UI=gui these
-    # app-server control tokens MUST be denied even though the bare app-server
-    # token is permitted.
+    # reject_unsafe_codex_args is DENY-BY-DEFAULT here: ANY user token after
+    # `app-server` (before or after `--`) dies. Pinned Codex 0.142.4 exposes not
+    # just the control tokens (`--remote-control`, daemon/proxy/generate-*,
+    # bootstrap/enable-remote-control/…) but network-listening/config flags on
+    # AppServerCommand — `--listen ws://IP:PORT` opens a listening socket, `--stdio`,
+    # `--strict-config`, `--analytics-default-enabled`, `-c …` — none of which the
+    # managed launch passes. Asserting a representative control token AND the
+    # network-listening/config flags proves the general rule, not a token denylist.
     # NOTE: this whole block runs inside a single-quoted `bash -lc '…'` above, so
     # it must contain NO single quotes. Each case is asserted explicitly (no loop,
     # no printf/tr) to stay single-quote-free.
@@ -3667,13 +3671,16 @@ test -f "$CODEX_HOME/config.toml"
       fi
       grep -q "Workcell blocked" "${out}"
     }
+    # Representative control tokens (regression: the old denylist targeted these).
     assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-remote-control.out --remote-control
-    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-daemon.out daemon
     assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-daemon-erc.out daemon enable-remote-control
-    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-bootstrap-rc.out bootstrap --remote-control
-    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-daemon-bootstrap-rc.out daemon bootstrap --remote-control
-    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-proxy.out proxy
-    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-generate-ts.out generate-ts
+    # Network-listening / config surface the old denylist LET THROUGH (P1 finding).
+    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-listen.out --listen ws://0.0.0.0:4500
+    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-stdio.out --stdio
+    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-strict-config.out --strict-config
+    # Deny-by-default: even a benign trailing flag (--help) dies — only the bare
+    # no-arg launch is the managed shape.
+    assert_gui_appserver_denied /tmp/codex-nested-gui-appserver-help.out --help
     # A permitted read-only subcommand from the allowlist passes the gate; the
     # block message must be ABSENT (review may exit non-zero without a repo, but
     # it is never blocked by workcell).

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2550,8 +2550,31 @@ if run_entrypoint codex codex features disable unified_exec >/tmp/workcell-entry
 fi
 grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-features-disable.out
 
+# A `--` before the features action must not let the mutating action slip past
+# the deny (P1 review finding): the pending features-action check takes
+# precedence over the general `--` break, so both orderings are still denied.
+if run_entrypoint codex codex features -- enable plugins >/tmp/workcell-entrypoint-codex-features-dd-enable.out 2>&1; then
+  echo "expected Workcell entrypoint to reject features -- enable plugins across the --" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-features-dd-enable.out
+
+if run_entrypoint codex codex features -- disable unified_exec >/tmp/workcell-entrypoint-codex-features-dd-disable.out 2>&1; then
+  echo "expected Workcell entrypoint to reject features -- disable unified_exec across the --" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-features-dd-disable.out
+
+if run_entrypoint codex codex features enable -- plugins >/tmp/workcell-entrypoint-codex-features-enable-dd.out 2>&1; then
+  echo "expected Workcell entrypoint to reject features enable -- plugins" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/workcell-entrypoint-codex-features-enable-dd.out
+
 # The exec-server/features exact-token blocks must not catch the legitimate
-# `exec` runtime subcommand or the read-only `features list`.
+# `exec` runtime subcommand or the read-only `features list`. The normal prompt
+# `--` break (when NOT expecting a features action) is exercised by the nested
+# `codex -- plugin`/`codex -- frobnicate` permit cases below.
 run_entrypoint codex codex exec --help >/dev/null
 run_entrypoint codex codex features list >/dev/null
 
@@ -3749,9 +3772,41 @@ test -f "$CODEX_HOME/config.toml"
       exit 1
     fi
     grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-features-disable.out
-    # features list is a read-only inspect and stays permitted.
+    # A `--` between `features` and its action MUST NOT let the mutating action
+    # slip past the deny: the pending features-action check now takes precedence
+    # over the general `--` break while armed (P1 review finding). The mutating
+    # action is denied across the `--` and the config stays unmutated.
+    if codex features -- enable plugins >/tmp/codex-features-dd-enable.out 2>&1; then
+      echo "expected nested Codex invocation to reject features -- enable plugins across the --" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-features-dd-enable.out
+    assert_codex_feature_value false
+    if codex features -- disable unified_exec >/tmp/codex-features-dd-disable.out 2>&1; then
+      echo "expected nested Codex invocation to reject features -- disable unified_exec across the --" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-features-dd-disable.out
+    assert_codex_feature_value false
+    # The action can also precede the `--` (features enable -- plugins): the arm
+    # catches enable before the -- is ever reached, so it is denied too.
+    if codex features enable -- plugins >/tmp/codex-features-enable-dd.out 2>&1; then
+      echo "expected nested Codex invocation to reject features enable -- plugins" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked unsupported Codex CLI subcommand" /tmp/codex-features-enable-dd.out
+    assert_codex_feature_value false
+    # features list is a read-only inspect and stays permitted, with or without a
+    # `--` before the action (the normal prompt `--` break is unchanged: a bare
+    # prompt still stops parsing — see the codex -- plugin cases above).
     codex features list >/tmp/codex-features-list-permit.out 2>&1
     grep -q "unified_exec" /tmp/codex-features-list-permit.out
+    codex features -- list >/tmp/codex-features-dd-list-permit.out 2>&1 || true
+    if grep -q "Workcell blocked" /tmp/codex-features-dd-list-permit.out; then
+      echo "expected features -- list to stay permitted (read-only) after honoring the pending action" >&2
+      cat /tmp/codex-features-dd-list-permit.out >&2
+      exit 1
+    fi
   '
   if /usr/local/libexec/workcell/real/codex --version >/tmp/codex-real-path.out 2>&1; then
     echo "expected direct real Codex payload execution to fail" >&2

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1460,14 +1460,56 @@ rm -rf "${codex_managed_config_tmpdir}"
 # unclassified new subcommand would fall through and be permitted as if it were a
 # prompt. This check enforces that invariant against the pinned runtime Codex:
 # it asserts every name in the checked-in fixture (tests/fixtures/
-# codex-subcommands.txt, the full pinned `codex --help` subcommand list) appears
-# as an EXACT case label in the ALLOW, GUI-gated, `features`, or DENY branch of
-# the gate. A pin bump that adds a subcommand must regenerate the fixture from
-# the new `codex --help` and classify the new name in provider-policy.sh, or this
-# fails CI (the fixture cannot be enumerated in-container during a host-side
-# static verify, so it is a checked-in fixture the refresh review updates).
+# codex-subcommands.txt, the full pinned Codex subcommand list derived from the
+# clap `enum Subcommand` source) appears as an EXACT case label in the ALLOW,
+# GUI-gated, `features`, or DENY branch of the gate. A pin bump that adds a
+# subcommand must regenerate the fixture from the new pinned clap Subcommand
+# source and classify the new name in provider-policy.sh, or this fails CI (the
+# fixture cannot be enumerated in-container during a host-side static verify, so
+# it is a checked-in fixture the refresh review updates).
+#
+# The `fixture subset-of classified` assertion below is VACUOUS on a STALE
+# fixture: if a CODEX_VERSION bump adds an upstream subcommand but the fixture is
+# not regenerated, the new name is simply absent from the fixture, is never
+# compared, and falls through the gate as prompt text. To close that meta-gap the
+# fixture carries a `# codex-version:` stamp and this check FIRST asserts the
+# stamp EQUALS `ARG CODEX_VERSION` in the Dockerfile, so a bump that skips fixture
+# regeneration fails here before the subset check can pass vacuously.
 CODEX_POLICY_FILE="${ROOT_DIR}/runtime/container/provider-policy.sh"
 CODEX_SUBCOMMAND_FIXTURE="${ROOT_DIR}/tests/fixtures/codex-subcommands.txt"
+CODEX_DOCKERFILE="${ROOT_DIR}/runtime/container/Dockerfile"
+
+# Bind the fixture to the pinned Codex version so a CODEX_VERSION bump forces
+# fixture regeneration. Parse `ARG CODEX_VERSION=<v>` from the Dockerfile and the
+# `# codex-version: <v>` stamp from the fixture, then assert they are EQUAL. On
+# mismatch the subset check below could pass vacuously against a stale fixture, so
+# fail closed here with regeneration instructions.
+codex_dockerfile_version="$(
+  sed -n 's/^ARG CODEX_VERSION=\([^ ]*\).*/\1/p' "${CODEX_DOCKERFILE}" | head -n 1
+)"
+codex_fixture_version="$(
+  sed -n 's/^#[[:space:]]*codex-version:[[:space:]]*\([^[:space:]]*\).*/\1/p' "${CODEX_SUBCOMMAND_FIXTURE}" | head -n 1
+)"
+if [[ -z "${codex_dockerfile_version}" ]]; then
+  echo 'Codex subcommand completeness check FAILED: could not parse ARG CODEX_VERSION from runtime/container/Dockerfile.' >&2
+  exit 1
+fi
+if [[ -z "${codex_fixture_version}" ]]; then
+  echo 'Codex subcommand completeness check FAILED: tests/fixtures/codex-subcommands.txt is missing the "# codex-version: <v>" stamp.' >&2
+  echo 'Add a "# codex-version: <CODEX_VERSION>" header line matching runtime/container/Dockerfile ARG CODEX_VERSION.' >&2
+  exit 1
+fi
+if [[ "${codex_dockerfile_version}" != "${codex_fixture_version}" ]]; then
+  echo "Codex subcommand completeness check FAILED: fixture is stale versus the pinned Codex version." >&2
+  echo "  Dockerfile ARG CODEX_VERSION: ${codex_dockerfile_version}" >&2
+  echo "  fixture # codex-version:      ${codex_fixture_version}" >&2
+  echo 'A CODEX_VERSION bump MUST regenerate tests/fixtures/codex-subcommands.txt from the new pinned' >&2
+  echo 'codex-rs/cli/src/main.rs clap "enum Subcommand" source (include paren-less unit variants, aliases,' >&2
+  echo 'and hidden "#[clap(hide = true)]" tokens), reclassify any new name in runtime/container/provider-policy.sh,' >&2
+  echo "and bump the fixture's \"# codex-version:\" stamp to ${codex_dockerfile_version}. Otherwise a new upstream" >&2
+  echo 'subcommand falls through the deny-by-default gate as prompt text.' >&2
+  exit 1
+fi
 
 # Extract the exact case-label tokens the gate classifies. The classification
 # case statement lives strictly between the unique `DENY-BY-DEFAULT over the
@@ -1518,7 +1560,7 @@ if [[ -n "${codex_unclassified}" ]]; then
   echo 'Codex subcommand completeness check FAILED: the pinned Codex exposes subcommand(s) that reject_unsafe_codex_args does not classify as ALLOW or DENY.' >&2
   echo 'Unclassified (would leak through the deny-by-default gate as prompt text):' >&2
   printf '  %s\n' "${codex_unclassified}" >&2
-  echo 'Classify each in runtime/container/provider-policy.sh (ALLOW or DENY set) or, if a pin bump removed it, regenerate tests/fixtures/codex-subcommands.txt from the pinned codex --help.' >&2
+  echo 'Classify each in runtime/container/provider-policy.sh (ALLOW or DENY set) or, if a pin bump removed it, regenerate tests/fixtures/codex-subcommands.txt from the pinned clap enum Subcommand source.' >&2
   exit 1
 fi
 

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1450,6 +1450,78 @@ fi
 
 rm -rf "${codex_managed_config_tmpdir}"
 
+# Codex subcommand-namespace COMPLETENESS check.
+#
+# reject_unsafe_codex_args (runtime/container/provider-policy.sh) is
+# deny-by-default over the SUBCOMMAND NAMESPACE, not over all first tokens: a
+# first bare token that is NOT a known Codex subcommand is permitted as [PROMPT]
+# text (so `codex "fix tests"` works). That safety-critical design only holds if
+# EVERY real Codex subcommand is explicitly classified ALLOW or DENY — an
+# unclassified new subcommand would fall through and be permitted as if it were a
+# prompt. This check enforces that invariant against the pinned runtime Codex:
+# it asserts every name in the checked-in fixture (tests/fixtures/
+# codex-subcommands.txt, the full pinned `codex --help` subcommand list) appears
+# as an EXACT case label in the ALLOW, GUI-gated, `features`, or DENY branch of
+# the gate. A pin bump that adds a subcommand must regenerate the fixture from
+# the new `codex --help` and classify the new name in provider-policy.sh, or this
+# fails CI (the fixture cannot be enumerated in-container during a host-side
+# static verify, so it is a checked-in fixture the refresh review updates).
+CODEX_POLICY_FILE="${ROOT_DIR}/runtime/container/provider-policy.sh"
+CODEX_SUBCOMMAND_FIXTURE="${ROOT_DIR}/tests/fixtures/codex-subcommands.txt"
+
+# Extract the exact case-label tokens the gate classifies. The classification
+# case statement lives strictly between the unique `DENY-BY-DEFAULT over the
+# SUBCOMMAND NAMESPACE` comment (its opening) and the unique `Not a known
+# subcommand` fall-through comment (its close). Inside that window, only
+# case-LABEL lines are parsed — a case label is `<tok>[ | <tok> ...])` possibly
+# continued with a trailing `\`. Comment lines (`#…`) and the case body/actions
+# are skipped, so prose words cannot be mistaken for subcommand classifications.
+codex_classified_tokens="$(
+  awk '
+    /DENY-BY-DEFAULT over the SUBCOMMAND NAMESPACE/ { inblock = 1; next }
+    inblock && /Not a known subcommand/ { inblock = 0 }
+    !inblock { next }
+    /^[[:space:]]*#/ { next }
+    {
+      label = $0
+      # A case label either ends the pattern with `)` or is a `\`-continued
+      # multi-line pattern (the ALLOW and DENY sets span two lines). Keep only
+      # the pattern portion up to `)`; for a continuation line there is no `)`
+      # yet, so keep the whole line. Lines with neither `)` nor a trailing `\`
+      # are case bodies/actions and are skipped.
+      if (label ~ /\)/) {
+        sub(/\).*/, "", label)
+      } else if (label !~ /\\[[:space:]]*$/) {
+        next
+      }
+      gsub(/[|\\]/, " ", label)
+      m = split(label, toks, /[ \t]+/)
+      for (i = 1; i <= m; i++) {
+        t = toks[i]
+        if (t ~ /^[a-z][a-z-]*$/) {
+          print t
+        }
+      }
+    }
+  ' "${CODEX_POLICY_FILE}" | sort -u
+)"
+
+codex_fixture_tokens="$(
+  grep -vE '^[[:space:]]*(#|$)' "${CODEX_SUBCOMMAND_FIXTURE}" | sort -u
+)"
+
+# Every fixture (pinned real) subcommand must be classified. `comm -23` prints
+# fixture names absent from the classified set: any output => an unclassified
+# subcommand that would leak through as prompt text.
+codex_unclassified="$(comm -23 <(printf '%s\n' "${codex_fixture_tokens}") <(printf '%s\n' "${codex_classified_tokens}"))"
+if [[ -n "${codex_unclassified}" ]]; then
+  echo 'Codex subcommand completeness check FAILED: the pinned Codex exposes subcommand(s) that reject_unsafe_codex_args does not classify as ALLOW or DENY.' >&2
+  echo 'Unclassified (would leak through the deny-by-default gate as prompt text):' >&2
+  printf '  %s\n' "${codex_unclassified}" >&2
+  echo 'Classify each in runtime/container/provider-policy.sh (ALLOW or DENY set) or, if a pin bump removed it, regenerate tests/fixtures/codex-subcommands.txt from the pinned codex --help.' >&2
+  exit 1
+fi
+
 # scripts/workcell host-launcher hardening invariants: run_host_colima
 # restores the real host HOME, the shebang clears the host environment,
 # the process/Perl/DYLD/Docker environment scrubbers are present,

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1308,8 +1308,15 @@ verify_codex_managed_config_invariants() {
   require_toml_assignment "${file}" "sandbox_workspace_write" "exclude_tmpdir_env_var" "false" || return 1
   require_toml_assignment "${file}" "sandbox_workspace_write" "network_access" "false" || return 1
 
-  require_toml_exact_keys "${file}" "features" "unified_exec" || return 1
+  require_toml_exact_keys "${file}" "features" \
+    "unified_exec" \
+    "plugins" \
+    "plugin_sharing" \
+    "remote_plugin" || return 1
   require_toml_assignment "${file}" "features" "unified_exec" "false" || return 1
+  require_toml_assignment "${file}" "features" "plugins" "false" || return 1
+  require_toml_assignment "${file}" "features" "plugin_sharing" "false" || return 1
+  require_toml_assignment "${file}" "features" "remote_plugin" "false" || return 1
 
   # The base config must carry no inline `[profiles...]` tables (dotted-path
   # form). Quoted single-segment section names with literal dots normalize to a
@@ -1373,6 +1380,20 @@ require_toml_assignment \
   echo 'Expected adapters/codex/requirements.toml to allow workspace-write for managed sessions and danger-full-access only for breakglass' >&2
   exit 1
 }
+
+# The adapter AGENTS.md requires config.toml, managed_config.toml, and
+# requirements.toml to stay aligned on security-boundary config. Lock the
+# requirements [features] bans in lockstep with the managed baseline so the
+# plugin/marketplace surface cannot be re-enabled from the requirements contract.
+require_toml_exact_keys "${ROOT_DIR}/adapters/codex/requirements.toml" "features" \
+  "unified_exec" \
+  "plugins" \
+  "plugin_sharing" \
+  "remote_plugin" || exit 1
+require_toml_assignment "${ROOT_DIR}/adapters/codex/requirements.toml" "features" "unified_exec" "false" || exit 1
+require_toml_assignment "${ROOT_DIR}/adapters/codex/requirements.toml" "features" "plugins" "false" || exit 1
+require_toml_assignment "${ROOT_DIR}/adapters/codex/requirements.toml" "features" "plugin_sharing" "false" || exit 1
+require_toml_assignment "${ROOT_DIR}/adapters/codex/requirements.toml" "features" "remote_plugin" "false" || exit 1
 
 codex_managed_config_tmpdir="$(mktemp -d)"
 

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1452,26 +1452,22 @@ rm -rf "${codex_managed_config_tmpdir}"
 
 # Codex subcommand-namespace COMPLETENESS check.
 #
-# reject_unsafe_codex_args (runtime/container/provider-policy.sh) is deny-by-
-# default over the SUBCOMMAND NAMESPACE, not over all first tokens: a first bare
-# token that is NOT a known subcommand is permitted as [PROMPT] text. That design
-# only holds if EVERY real subcommand is explicitly classified ALLOW or DENY, or
-# an unclassified new one leaks through as a prompt. This check asserts every name
-# in the checked-in fixture (tests/fixtures/codex-subcommands.txt, derived from
-# the clap `enum Subcommand` source) appears as an EXACT case label in the gate.
-#
-# The `fixture subset-of classified` assertion is VACUOUS on a STALE fixture: a
-# CODEX_VERSION bump that adds an upstream subcommand but skips fixture regen
-# leaves the new name absent, never compared, leaking through as prompt text. So
-# the fixture carries a `# codex-version:` stamp and this check FIRST asserts it
-# EQUALS the Dockerfile `ARG CODEX_VERSION` before the (else-vacuous) subset check.
+# reject_unsafe_codex_args (runtime/container/provider-policy.sh) is deny-by-default
+# over the SUBCOMMAND NAMESPACE: a first bare token that is NOT a known subcommand is
+# permitted as [PROMPT] text, so the design only holds if EVERY real subcommand is
+# classified ALLOW or DENY. This asserts every name in the checked-in fixture
+# (tests/fixtures/codex-subcommands.txt, derived from the clap `enum Subcommand`
+# source) appears as an EXACT case label in the gate. That subset check is VACUOUS on
+# a STALE fixture (a CODEX_VERSION bump that skips fixture regen leaves the new name
+# absent and uncompared), so the fixture carries a `# codex-version:` stamp this check
+# FIRST asserts EQUALS the Dockerfile `ARG CODEX_VERSION` before the subset check.
 CODEX_POLICY_FILE="${ROOT_DIR}/runtime/container/provider-policy.sh"
 CODEX_SUBCOMMAND_FIXTURE="${ROOT_DIR}/tests/fixtures/codex-subcommands.txt"
 CODEX_DOCKERFILE="${ROOT_DIR}/runtime/container/Dockerfile"
 
-# Bind the fixture to the pinned Codex version: parse `ARG CODEX_VERSION=<v>` from
-# the Dockerfile and the `# codex-version: <v>` stamp from the fixture, assert
-# EQUAL, and fail closed with regeneration instructions on mismatch.
+# Bind the fixture to the pinned Codex version: parse `ARG CODEX_VERSION=<v>` from the
+# Dockerfile and the `# codex-version: <v>` stamp from the fixture, assert EQUAL, and
+# fail closed with regeneration instructions on mismatch.
 codex_dockerfile_version="$(
   sed -n 's/^ARG CODEX_VERSION=\([^ ]*\).*/\1/p' "${CODEX_DOCKERFILE}" | head -n 1
 )"
@@ -1499,12 +1495,11 @@ if [[ "${codex_dockerfile_version}" != "${codex_fixture_version}" ]]; then
   exit 1
 fi
 
-# Extract the exact case-label tokens the gate classifies. The case statement
-# lives strictly between the unique `DENY-BY-DEFAULT over the SUBCOMMAND
-# NAMESPACE` comment and the unique `Not a known subcommand` fall-through comment.
-# Inside that window only case-LABEL lines (`<tok>[ | <tok> ...])`, possibly `\`-
-# continued) are parsed; comments and case bodies are skipped, so prose cannot be
-# mistaken for a classification.
+# Extract the exact case-label tokens the gate classifies. The case statement lives
+# strictly between the unique `DENY-BY-DEFAULT over the SUBCOMMAND NAMESPACE` comment
+# and the unique `Not a known subcommand` fall-through comment. Inside that window
+# only case-LABEL lines (`<tok>[ | <tok> ...])`, possibly `\`-continued) are parsed;
+# comments and case bodies are skipped, so prose cannot be mistaken for a match.
 codex_classified_tokens="$(
   awk '
     /DENY-BY-DEFAULT over the SUBCOMMAND NAMESPACE/ { inblock = 1; next }

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1452,38 +1452,26 @@ rm -rf "${codex_managed_config_tmpdir}"
 
 # Codex subcommand-namespace COMPLETENESS check.
 #
-# reject_unsafe_codex_args (runtime/container/provider-policy.sh) is
-# deny-by-default over the SUBCOMMAND NAMESPACE, not over all first tokens: a
-# first bare token that is NOT a known Codex subcommand is permitted as [PROMPT]
-# text (so `codex "fix tests"` works). That safety-critical design only holds if
-# EVERY real Codex subcommand is explicitly classified ALLOW or DENY — an
-# unclassified new subcommand would fall through and be permitted as if it were a
-# prompt. This check enforces that invariant against the pinned runtime Codex:
-# it asserts every name in the checked-in fixture (tests/fixtures/
-# codex-subcommands.txt, the full pinned Codex subcommand list derived from the
-# clap `enum Subcommand` source) appears as an EXACT case label in the ALLOW,
-# GUI-gated, `features`, or DENY branch of the gate. A pin bump that adds a
-# subcommand must regenerate the fixture from the new pinned clap Subcommand
-# source and classify the new name in provider-policy.sh, or this fails CI (the
-# fixture cannot be enumerated in-container during a host-side static verify, so
-# it is a checked-in fixture the refresh review updates).
+# reject_unsafe_codex_args (runtime/container/provider-policy.sh) is deny-by-
+# default over the SUBCOMMAND NAMESPACE, not over all first tokens: a first bare
+# token that is NOT a known subcommand is permitted as [PROMPT] text. That design
+# only holds if EVERY real subcommand is explicitly classified ALLOW or DENY, or
+# an unclassified new one leaks through as a prompt. This check asserts every name
+# in the checked-in fixture (tests/fixtures/codex-subcommands.txt, derived from
+# the clap `enum Subcommand` source) appears as an EXACT case label in the gate.
 #
-# The `fixture subset-of classified` assertion below is VACUOUS on a STALE
-# fixture: if a CODEX_VERSION bump adds an upstream subcommand but the fixture is
-# not regenerated, the new name is simply absent from the fixture, is never
-# compared, and falls through the gate as prompt text. To close that meta-gap the
-# fixture carries a `# codex-version:` stamp and this check FIRST asserts the
-# stamp EQUALS `ARG CODEX_VERSION` in the Dockerfile, so a bump that skips fixture
-# regeneration fails here before the subset check can pass vacuously.
+# The `fixture subset-of classified` assertion is VACUOUS on a STALE fixture: a
+# CODEX_VERSION bump that adds an upstream subcommand but skips fixture regen
+# leaves the new name absent, never compared, leaking through as prompt text. So
+# the fixture carries a `# codex-version:` stamp and this check FIRST asserts it
+# EQUALS the Dockerfile `ARG CODEX_VERSION` before the (else-vacuous) subset check.
 CODEX_POLICY_FILE="${ROOT_DIR}/runtime/container/provider-policy.sh"
 CODEX_SUBCOMMAND_FIXTURE="${ROOT_DIR}/tests/fixtures/codex-subcommands.txt"
 CODEX_DOCKERFILE="${ROOT_DIR}/runtime/container/Dockerfile"
 
-# Bind the fixture to the pinned Codex version so a CODEX_VERSION bump forces
-# fixture regeneration. Parse `ARG CODEX_VERSION=<v>` from the Dockerfile and the
-# `# codex-version: <v>` stamp from the fixture, then assert they are EQUAL. On
-# mismatch the subset check below could pass vacuously against a stale fixture, so
-# fail closed here with regeneration instructions.
+# Bind the fixture to the pinned Codex version: parse `ARG CODEX_VERSION=<v>` from
+# the Dockerfile and the `# codex-version: <v>` stamp from the fixture, assert
+# EQUAL, and fail closed with regeneration instructions on mismatch.
 codex_dockerfile_version="$(
   sed -n 's/^ARG CODEX_VERSION=\([^ ]*\).*/\1/p' "${CODEX_DOCKERFILE}" | head -n 1
 )"
@@ -1511,13 +1499,12 @@ if [[ "${codex_dockerfile_version}" != "${codex_fixture_version}" ]]; then
   exit 1
 fi
 
-# Extract the exact case-label tokens the gate classifies. The classification
-# case statement lives strictly between the unique `DENY-BY-DEFAULT over the
-# SUBCOMMAND NAMESPACE` comment (its opening) and the unique `Not a known
-# subcommand` fall-through comment (its close). Inside that window, only
-# case-LABEL lines are parsed — a case label is `<tok>[ | <tok> ...])` possibly
-# continued with a trailing `\`. Comment lines (`#…`) and the case body/actions
-# are skipped, so prose words cannot be mistaken for subcommand classifications.
+# Extract the exact case-label tokens the gate classifies. The case statement
+# lives strictly between the unique `DENY-BY-DEFAULT over the SUBCOMMAND
+# NAMESPACE` comment and the unique `Not a known subcommand` fall-through comment.
+# Inside that window only case-LABEL lines (`<tok>[ | <tok> ...])`, possibly `\`-
+# continued) are parsed; comments and case bodies are skipped, so prose cannot be
+# mistaken for a classification.
 codex_classified_tokens="$(
   awk '
     /DENY-BY-DEFAULT over the SUBCOMMAND NAMESPACE/ { inblock = 1; next }

--- a/tests/fixtures/codex-subcommands.txt
+++ b/tests/fixtures/codex-subcommands.txt
@@ -1,0 +1,50 @@
+# Complete Codex subcommand namespace for the PINNED runtime Codex.
+#
+# Pinned version: 0.142.4 (runtime/container/Dockerfile CODEX_VERSION). This is
+# the EXACT set of first-token subcommand names Codex dispatches on — everything
+# in `codex --help` "Commands:" plus the hidden `execpolicy` subcommand and the
+# `e`/`a` aliases. It does NOT include prompt text: a first bare token not on
+# this list is treated by Codex as the [PROMPT] argument, not a command.
+#
+# The completeness check in scripts/verify-invariants.sh asserts that EVERY name
+# below is classified by reject_unsafe_codex_args
+# (runtime/container/provider-policy.sh) as either ALLOW (permitted),
+# GUI-gated (app-server, permitted only under AGENT_UI=gui), or DENY (rejected).
+# Because a token off this list is permitted as prompt text, an unclassified NEW
+# subcommand introduced by a future pin bump would otherwise silently leak
+# through as a "prompt". This fixture makes that fail CI: when the pin is bumped,
+# the refresh review MUST regenerate this list from the new pinned
+# `codex --help` and classify any new name in provider-policy.sh, or the build
+# stays red.
+#
+# Aliases (e -> exec, a -> apply) are listed because they are dispatchable
+# first-token names in their own right and must be classified too.
+#
+# One subcommand name per line; blank lines and `#` comments are ignored.
+exec
+e
+review
+login
+logout
+mcp
+plugin
+mcp-server
+app-server
+remote-control
+completion
+update
+doctor
+sandbox
+debug
+apply
+a
+resume
+archive
+delete
+unarchive
+fork
+cloud
+exec-server
+features
+help
+execpolicy

--- a/tests/fixtures/codex-subcommands.txt
+++ b/tests/fixtures/codex-subcommands.txt
@@ -1,10 +1,21 @@
 # Complete Codex subcommand namespace for the PINNED runtime Codex.
 #
 # Pinned version: 0.142.4 (runtime/container/Dockerfile CODEX_VERSION). This is
-# the EXACT set of first-token subcommand names Codex dispatches on — everything
-# in `codex --help` "Commands:" plus the hidden `execpolicy` subcommand and the
-# `e`/`a` aliases. It does NOT include prompt text: a first bare token not on
-# this list is treated by Codex as the [PROMPT] argument, not a command.
+# the EXACT set of first-token subcommand names Codex dispatches on. It is
+# derived from the AUTHORITATIVE clap `enum Subcommand` in the pinned source
+# (openai/codex tag rust-v0.142.4, codex-rs/cli/src/main.rs), NOT from
+# `codex --help`: clap kebab-cases each variant name and dispatches on aliases
+# and `#[command(hide = true)]` HIDDEN variants too, none of which `--help`
+# prints. The hidden/alias tokens that `--help` omits but Codex still dispatches
+# on are: the `e` alias (exec), the `a` alias (apply), `mcp-server`, `app`,
+# `execpolicy`, `cloud-tasks` (alias of cloud), `responses-api-proxy` (hidden
+# proxy daemon), `stdio-to-uds` (hidden socket bridge), and `exec-server`.
+# Deriving from `--help` alone silently omitted cloud-tasks/responses-api-proxy/
+# stdio-to-uds, which then fell through the gate as "prompt" text and let the
+# real Codex dispatch them — the fence bypass this fixture now closes.
+#
+# It does NOT include prompt text: a first bare token not on this list is
+# treated by Codex as the [PROMPT] argument, not a command.
 #
 # The completeness check in scripts/verify-invariants.sh asserts that EVERY name
 # below is classified by reject_unsafe_codex_args
@@ -13,12 +24,13 @@
 # Because a token off this list is permitted as prompt text, an unclassified NEW
 # subcommand introduced by a future pin bump would otherwise silently leak
 # through as a "prompt". This fixture makes that fail CI: when the pin is bumped,
-# the refresh review MUST regenerate this list from the new pinned
-# `codex --help` and classify any new name in provider-policy.sh, or the build
-# stays red.
+# the refresh review MUST regenerate this list from the new pinned clap
+# Subcommand enum source and classify any new name in provider-policy.sh, or the
+# build stays red.
 #
-# Aliases (e -> exec, a -> apply) are listed because they are dispatchable
-# first-token names in their own right and must be classified too.
+# NOTE: 0.142.4 has NO `update` variant (that arrived in 0.143), so it is NOT
+# listed here even though provider-policy.sh keeps it in the DENY set as
+# harmless forward-compat.
 #
 # One subcommand name per line; blank lines and `#` comments are ignored.
 exec
@@ -31,11 +43,12 @@ plugin
 mcp-server
 app-server
 remote-control
+app
 completion
-update
 doctor
 sandbox
 debug
+execpolicy
 apply
 a
 resume
@@ -44,7 +57,9 @@ delete
 unarchive
 fork
 cloud
+cloud-tasks
+responses-api-proxy
+stdio-to-uds
 exec-server
 features
 help
-execpolicy

--- a/tests/fixtures/codex-subcommands.txt
+++ b/tests/fixtures/codex-subcommands.txt
@@ -1,5 +1,17 @@
 # Complete Codex subcommand namespace for the PINNED runtime Codex.
 #
+# codex-version: 0.142.4
+#
+# The `# codex-version:` stamp above is MACHINE-READABLE and load-bearing.
+# scripts/verify-invariants.sh parses it and asserts it EQUALS `ARG
+# CODEX_VERSION` in runtime/container/Dockerfile. A CODEX_VERSION bump (e.g. via
+# scripts/update-provider-pins.sh) that does NOT regenerate this fixture and
+# bump this stamp FAILS CI. This closes a completeness-check meta-gap: without
+# the stamp, `fixture subset-of classified` passes VACUOUSLY on a stale fixture,
+# so a NEW upstream subcommand absent from the stale list is never compared and
+# falls through the gate as prompt text. Format: exactly `# codex-version: X.Y.Z`
+# on its own line (leading `# `, single space after the colon).
+#
 # Pinned version: 0.142.4 (runtime/container/Dockerfile CODEX_VERSION). This is
 # the EXACT set of first-token subcommand names Codex dispatches on. It is
 # derived from the AUTHORITATIVE clap `enum Subcommand` in the pinned source
@@ -25,8 +37,10 @@
 # subcommand introduced by a future pin bump would otherwise silently leak
 # through as a "prompt". This fixture makes that fail CI: when the pin is bumped,
 # the refresh review MUST regenerate this list from the new pinned clap
-# Subcommand enum source and classify any new name in provider-policy.sh, or the
-# build stays red.
+# Subcommand enum source (including paren-less unit variants, aliases, and hidden
+# `#[clap(hide = true)]` tokens), classify any new name in provider-policy.sh,
+# AND bump the `# codex-version:` stamp above to the new CODEX_VERSION, or the
+# build stays red (the stamp-vs-Dockerfile equality check fails first).
 #
 # One subcommand name per line; blank lines and `#` comments are ignored.
 exec

--- a/tests/fixtures/codex-subcommands.txt
+++ b/tests/fixtures/codex-subcommands.txt
@@ -2,47 +2,29 @@
 #
 # codex-version: 0.142.4
 #
-# The `# codex-version:` stamp above is MACHINE-READABLE and load-bearing.
-# scripts/verify-invariants.sh parses it and asserts it EQUALS `ARG
-# CODEX_VERSION` in runtime/container/Dockerfile. A CODEX_VERSION bump (e.g. via
-# scripts/update-provider-pins.sh) that does NOT regenerate this fixture and
-# bump this stamp FAILS CI. This closes a completeness-check meta-gap: without
-# the stamp, `fixture subset-of classified` passes VACUOUSLY on a stale fixture,
-# so a NEW upstream subcommand absent from the stale list is never compared and
-# falls through the gate as prompt text. Format: exactly `# codex-version: X.Y.Z`
-# on its own line (leading `# `, single space after the colon).
+# The `# codex-version:` stamp above is MACHINE-READABLE and load-bearing:
+# scripts/verify-invariants.sh parses it and asserts it EQUALS `ARG CODEX_VERSION`
+# in runtime/container/Dockerfile, so a bump that does NOT regenerate this fixture
+# fails CI. Without it, `fixture subset-of classified` passes VACUOUSLY on a stale
+# fixture and a new upstream subcommand leaks through the gate as prompt text.
+# Format: exactly `# codex-version: X.Y.Z` on its own line (`# `, single space
+# after the colon).
 #
-# Pinned version: 0.142.4 (runtime/container/Dockerfile CODEX_VERSION). This is
-# the EXACT set of first-token subcommand names Codex dispatches on. It is
+# The tokens below are the EXACT first-token subcommand names Codex dispatches on,
 # derived from the AUTHORITATIVE clap `enum Subcommand` in the pinned source
-# (openai/codex tag rust-v0.142.4, codex-rs/cli/src/main.rs), NOT from
-# `codex --help`: clap kebab-cases each variant name and dispatches on aliases
-# and `#[command(hide = true)]` HIDDEN variants too, none of which `--help`
-# prints. The hidden/alias tokens that `--help` omits but Codex still dispatches
-# on are: the `e` alias (exec), the `a` alias (apply), `mcp-server`, `app`,
-# `execpolicy`, `cloud-tasks` (alias of cloud), `responses-api-proxy` (hidden
-# proxy daemon), `stdio-to-uds` (hidden socket bridge), and `exec-server`.
-# Deriving from `--help` alone silently omitted cloud-tasks/responses-api-proxy/
-# stdio-to-uds, which then fell through the gate as "prompt" text and let the
-# real Codex dispatch them — the fence bypass this fixture now closes.
+# (openai/codex tag rust-v0.142.4, codex-rs/cli/src/main.rs), NOT `codex --help`:
+# clap also dispatches on aliases and `#[command(hide = true)]` HIDDEN variants
+# that `--help` omits (e/a aliases, mcp-server, app, execpolicy, cloud-tasks,
+# responses-api-proxy, stdio-to-uds, exec-server). Deriving from `--help` alone
+# omitted several, which then leaked through as prompt text. A first bare token
+# NOT on this list is Codex's [PROMPT] argument, not a command.
 #
-# It does NOT include prompt text: a first bare token not on this list is
-# treated by Codex as the [PROMPT] argument, not a command.
-#
-# The completeness check in scripts/verify-invariants.sh asserts that EVERY name
-# below is classified by reject_unsafe_codex_args
-# (runtime/container/provider-policy.sh) as either ALLOW (permitted),
-# GUI-gated (app-server, permitted only under AGENT_UI=gui), or DENY (rejected).
-# Because a token off this list is permitted as prompt text, an unclassified NEW
-# subcommand introduced by a future pin bump would otherwise silently leak
-# through as a "prompt". This fixture makes that fail CI: when the pin is bumped,
-# the refresh review MUST regenerate this list from the new pinned clap
-# Subcommand enum source (including paren-less unit variants, aliases, and hidden
-# `#[clap(hide = true)]` tokens), classify any new name in provider-policy.sh,
-# AND bump the `# codex-version:` stamp above to the new CODEX_VERSION, or the
-# build stays red (the stamp-vs-Dockerfile equality check fails first).
-#
-# One subcommand name per line; blank lines and `#` comments are ignored.
+# The completeness check asserts EVERY name below is classified by
+# reject_unsafe_codex_args (runtime/container/provider-policy.sh) as ALLOW,
+# GUI-gated (app-server, AGENT_UI=gui only), or DENY. A pin bump MUST regenerate
+# this list from the new clap Subcommand enum (unit variants, aliases, hidden
+# tokens), classify any new name in provider-policy.sh, AND bump the stamp above,
+# or the build stays red. One name per line; blank/`#` lines are ignored.
 exec
 e
 review

--- a/tests/fixtures/codex-subcommands.txt
+++ b/tests/fixtures/codex-subcommands.txt
@@ -3,28 +3,26 @@
 # codex-version: 0.142.4
 #
 # The `# codex-version:` stamp above is MACHINE-READABLE and load-bearing:
-# scripts/verify-invariants.sh parses it and asserts it EQUALS `ARG CODEX_VERSION`
-# in runtime/container/Dockerfile, so a bump that does NOT regenerate this fixture
-# fails CI. Without it, `fixture subset-of classified` passes VACUOUSLY on a stale
-# fixture and a new upstream subcommand leaks through the gate as prompt text.
-# Format: exactly `# codex-version: X.Y.Z` on its own line (`# `, single space
-# after the colon).
+# scripts/verify-invariants.sh asserts it EQUALS `ARG CODEX_VERSION` in
+# runtime/container/Dockerfile, so a bump that does NOT regenerate this fixture fails
+# CI (else `fixture subset-of classified` passes VACUOUSLY on a stale fixture and a new
+# upstream subcommand leaks through as prompt text). Format: exactly
+# `# codex-version: X.Y.Z` on its own line (`# `, single space after the colon).
 #
 # The tokens below are the EXACT first-token subcommand names Codex dispatches on,
 # derived from the AUTHORITATIVE clap `enum Subcommand` in the pinned source
-# (openai/codex tag rust-v0.142.4, codex-rs/cli/src/main.rs), NOT `codex --help`:
-# clap also dispatches on aliases and `#[command(hide = true)]` HIDDEN variants
-# that `--help` omits (e/a aliases, mcp-server, app, execpolicy, cloud-tasks,
-# responses-api-proxy, stdio-to-uds, exec-server). Deriving from `--help` alone
-# omitted several, which then leaked through as prompt text. A first bare token
-# NOT on this list is Codex's [PROMPT] argument, not a command.
+# (openai/codex tag rust-v0.142.4, codex-rs/cli/src/main.rs), NOT `codex --help`: clap
+# also dispatches on aliases and `#[command(hide = true)]` HIDDEN variants `--help`
+# omits (e/a aliases, mcp-server, app, execpolicy, cloud-tasks, responses-api-proxy,
+# stdio-to-uds, exec-server), which then leaked through as prompt text. A first bare
+# token NOT on this list is Codex's [PROMPT] argument, not a command.
 #
 # The completeness check asserts EVERY name below is classified by
-# reject_unsafe_codex_args (runtime/container/provider-policy.sh) as ALLOW,
-# GUI-gated (app-server, AGENT_UI=gui only), or DENY. A pin bump MUST regenerate
-# this list from the new clap Subcommand enum (unit variants, aliases, hidden
-# tokens), classify any new name in provider-policy.sh, AND bump the stamp above,
-# or the build stays red. One name per line; blank/`#` lines are ignored.
+# reject_unsafe_codex_args (runtime/container/provider-policy.sh) as ALLOW, GUI-gated
+# (app-server, AGENT_UI=gui only), or DENY. A pin bump MUST regenerate this list from
+# the new clap Subcommand enum (unit variants, aliases, hidden tokens), classify any
+# new name in provider-policy.sh, AND bump the stamp above, or the build stays red.
+# One name per line; blank/`#` lines are ignored.
 exec
 e
 review

--- a/tests/fixtures/codex-subcommands.txt
+++ b/tests/fixtures/codex-subcommands.txt
@@ -28,10 +28,6 @@
 # Subcommand enum source and classify any new name in provider-policy.sh, or the
 # build stays red.
 #
-# NOTE: 0.142.4 has NO `update` variant (that arrived in 0.143), so it is NOT
-# listed here even though provider-policy.sh keeps it in the DENY set as
-# harmless forward-compat.
-#
 # One subcommand name per line; blank lines and `#` comments are ignored.
 exec
 e
@@ -45,6 +41,7 @@ app-server
 remote-control
 app
 completion
+update
 doctor
 sandbox
 debug


### PR DESCRIPTION
## Summary
- Refactor the Codex adapter subcommand gate from a blocklist to an **allowlist (deny-by-default)**. The historical blocklist reopened on every codex CLI version bump — a review of the 0.143 bump surfaced 15 real bypasses (new subcommands `plugin`/`remote-control`/`exec-server`/`mcp-server`/`update`, `features enable`, the `--yolo` alias, inline-TOML/quoted/escaped config-key evasions, `AGENT_UI=gui` env override). Deny-by-default closes the whole class: any new or unknown subcommand is denied until explicitly vetted.
- Permit set (classified read-only/session surface, verified against real `codex --help`): `exec/e, review, login, logout, completion, doctor, apply/a, resume, fork, archive, unarchive, delete, help, debug, execpolicy`; `features`/`features list` (read-only) with `features enable|disable` denied; `app`/`app-server` permitted only under `AGENT_UI=gui` (the managed GUI backend). Bare `codex`, `codex --version`, and `codex -- <prompt>` are permitted (default session/prompt path).
- Retains all config-override and dangerous-flag hardening for permitted subcommands (they still take `-c`/flags): `--yolo` + `--dangerously-bypass-*` glob, value-taking-global consumption, `-c` key normalization (quoted/single-quoted/whitespace/backslash-escape fail-closed), inline-table blocking (`features={…}`/`profiles={…}`/`mcp*`/`hooks`), and the `plugins/plugin_sharing/remote_plugin` feature pins across `.codex/config.toml`, `managed_config.toml`, `requirements.toml`.
- No upstream pin change in this PR — the codex version bump to the latest stable ships separately, riding on top of this allowlist so its new surface is auto-covered.

## Validation
- ./scripts/pre-merge.sh --profile pr-parity
- Sourced-function permit/deny harness 60/60; deny-by-default regression-locked (`codex frobnicate`/`some-new-daemon` denied; `codex -- frobnicate` permitted as prompt text).
- Real colima `scripts/container-smoke.sh` (SMOKE_EXIT=0) and `tests/scenarios/shared/test-session-commands.sh` (SCENARIO_EXIT=0) — the colima run empirically caught the hidden runtime `execpolicy` subcommand and added it to the permit set.
- Full go test ./..., shellcheck/shfmt clean, control-plane manifest regenerated + verified on the committed tree.

## Review
- Draft for the Codex review loop. Supersedes the blocklist hardening on the upstream-refresh PR.
