### PR TITLE
Fix the release arm64 Copilot probe: single-platform image so --load works (v1.0.0-rc.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,9 +234,13 @@ jobs:
       - name: Build arm64 runtime image for Copilot help probe
         env:
           SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
+        # No BUILDKIT_MULTI_PLATFORM here: it forces a manifest-list output,
+        # which `--load` (the docker exporter) rejects on buildx v0.35.0+.
+        # This probe only runs the loaded image; it does not compare digests
+        # against the reproducible-build manifest, so list packaging is not
+        # needed.
         run: |
           docker buildx build \
-            --build-arg "BUILDKIT_MULTI_PLATFORM=1" \
             --build-arg "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}" \
             --load \
             --platform linux/arm64 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Releases.
 
 ## Unreleased
 
+## v1.0.0-rc.2 - 2026-07-12
+
+Supersedes v1.0.0-rc.1, which was tagged but never published: its release
+workflow failed in the new arm64 Copilot runtime-image probe, whose build
+requested a manifest-list output (`BUILDKIT_MULTI_PLATFORM=1`) that the
+`--load` docker exporter rejects on the buildx `v0.35.0` pin, and release
+preflight then failed closed on that check. This release fixes the probe and
+carries the full v1.0.0-rc.1 content below.
+
+### Fixed
+
+- build the release-time arm64 Copilot help-probe image as a plain
+  single-platform image so it can be loaded and probed; the probe never
+  compared digests against the reproducible-build manifest, so manifest-list
+  packaging was never needed there.
+
 ## v1.0.0-rc.1 - 2026-07-09
 
 This entry reconstructs the v0.12 through v0.15 milestone train plus the 1.0


### PR DESCRIPTION
## Summary

Fixes the v1.0.0-rc.1 release blocker. The tag-triggered Release run failed in the new **arm64 Copilot runtime-image probe** job:

```
ERROR: failed to build: failed to solve: docker exporter does not currently support exporting manifest lists
```

The probe build passed `BUILDKIT_MULTI_PLATFORM=1` (which forces manifest-list packaging even for a single platform) together with `--load` (the docker exporter, which cannot import manifest lists). The buildx pin bump `v0.34.1` → `v0.35.0` (#490) surfaced the conflict: v0.34.1 tolerated the combination (reproduced locally on v0.34.1-desktop — it loads fine), v0.35.0 rejects it. **Release preflight** then failed closed on the failed check-run, so the tag was never published (correct fail-closed behavior).

Fix: drop `BUILDKIT_MULTI_PLATFORM=1` from the probe build only. The probe runs the loaded image to verify the pinned Copilot release's help surface; it never compares digests against the reproducible-build manifest, so manifest-list packaging was never needed there. The reproducible-build and publish jobs (which do need `BUILDKIT_MULTI_PLATFORM=1`) export to OCI/registry and are untouched.

Also adds the superseding `## v1.0.0-rc.2 - 2026-07-12` changelog entry per the v0.11.1/v0.11.2 tagged-but-never-published precedent (rc.1 content carries below it).

Per `docs/releasing.md` recovery notes: the failed `v1.0.0-rc.1` tag stays; `v1.0.0-rc.2` is cut after this merges.

## Validation

- Built the probe image without the build-arg against the pinned buildkit image (`moby/buildkit:buildx-stable-1@sha256:0168…`) on real arm64 and ran `verify-upstream-copilot-release.sh` in docker mode against it — `Workcell upstream Copilot release verification passed`, exit 0.
- zizmor on the edited workflow: no findings. markdownlint + codespell clean.
- `scripts/pre-merge.sh --profile pr-parity` — exit 0.
