### PR TITLE
Close out ambiguous historical Codex findings: deny Copilot logout + document buildx override

### DIFF
--- a/adapters/copilot/README.md
+++ b/adapters/copilot/README.md
@@ -49,8 +49,8 @@ directories. In-container reserved session targets: `~/.copilot`,
   §3).
 - Unsafe-argument policy (`reject_unsafe_copilot_args` in
   `runtime/container/provider-policy.sh`): the wrapper blocks the
-  `init`/`login`/`mcp`/`plugin`/`skill`/`update` lifecycle and control-plane
-  subcommands and a broad set of trust-widening flags (MCP toolset/config,
+  `init`/`login`/`logout`/`mcp`/`plugin`/`skill`/`update` lifecycle and
+  control-plane subcommands and a broad set of trust-widening flags (MCP toolset/config,
   `--allow-all*`, `--allow-tool`/`--allow-url`, `--add-dir`, `--dynamic-retrieval`,
   `--no-custom-instructions`, `--remote`/`--share*`/`--worktree`, `--yolo`,
   bundled short options, and more). These are rejected in **every** mode

--- a/docs/launcher-contract.md
+++ b/docs/launcher-contract.md
@@ -82,7 +82,13 @@ prerequisites sit outside this table entirely. Remote-preview backends probe ext
 `session-manager-plugin` for the `aws-ec2-ssm` backend, `gcloud` for `gcp-vm`.
 Image builds require a system `docker-buildx` plugin binary
 (`ensure_workcell_trusted_buildx`, `scripts/lib/trusted-docker-client.sh`), which
-aborts with `Missing trusted docker-buildx binary` when none is found. And the
+aborts with `Missing trusted docker-buildx binary` when none is found. A
+pre-set, executable `WORKCELL_TRUSTED_BUILDX_BIN` short-circuits that search and
+is honored as-is; the launcher's `env -i` shebang (line 1) clears it on any
+normal invocation, so this override survives only for shebang-bypassed
+invocations (`/bin/bash -p scripts/workcell`) that inherit an
+attacker-controlled value. Such invocations already run outside the pinned
+entrypoint and are out of the launcher's trust boundary. And the
 `workcell publish-pr` subcommand resolves `gh` on its non-dry-run path (required;
 via the Go publish helper `internal/publishpr`, `ResolveHostTool(ctx, "gh", true,
 …)`), failing with `Missing trusted host tool: gh` at publication time if it is

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -164,7 +164,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/copilot/README.md",
       "runtime_path": "/opt/workcell/adapters/copilot/README.md",
-      "sha256": "8152b7c1490787bed3b99b5dd20c072b6cf34e482ea99f3fb968a599c19c9aaa"
+      "sha256": "1f345163f7e3bece0b774b10440af608923e13aca1f2e1c6bf8dae5414ffb7d8"
     },
     {
       "kind": "adapter-baseline",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -248,7 +248,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "c82e4837aaca7095dd01bf4dbcdcb3185eadd5624eb37b157691ce53f40ff3ca"
+      "sha256": "1e8c5e98828890f7c51c58e8f1d486cd8412b5b5b06d5cb55ddd1a910c05e8d1"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -469,7 +469,7 @@ reject_unsafe_copilot_args() {
     if [[ "${saw_command}" -eq 0 ]] && [[ "${arg}" != -* ]]; then
       saw_command=1
       case "${arg}" in
-        init | login | mcp | plugin | skill | update)
+        init | login | logout | mcp | plugin | skill | update)
           workcell_die "Workcell blocked Copilot lifecycle/control-plane command: ${arg}"
           ;;
       esac

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2949,6 +2949,11 @@ if (reject_unsafe_copilot_args mcp) >/tmp/workcell-copilot-policy-mcp.out 2>&1; 
   exit 1
 fi
 grep -q "Workcell blocked Copilot lifecycle/control-plane command: mcp" /tmp/workcell-copilot-policy-mcp.out
+if (reject_unsafe_copilot_args logout) >/tmp/workcell-copilot-policy-logout.out 2>&1; then
+  echo "expected Copilot policy to reject the logout auth-state command" >&2
+  exit 1
+fi
+grep -q "Workcell blocked Copilot lifecycle/control-plane command: logout" /tmp/workcell-copilot-policy-logout.out
 if (reject_unsafe_copilot_args --model gpt-4.1 mcp) >/tmp/workcell-copilot-policy-model-mcp.out 2>&1; then
   echo "expected Copilot policy to reject lifecycle commands after model values" >&2
   exit 1


### PR DESCRIPTION
## Summary

Closes out the six ambiguous historical Codex findings that were left unreacted on PRs #336, #359, #362, and #397. I verified each against the current tree (not the PR-era code) and reacted 👍 on all six. Verdicts:

| Finding | PR | Verdict |
| --- | --- | --- |
| codex `--dangerously-bypass-hook-trust` forwarded | #336 | **Already fixed** — current guard denies `--dangerously-bypass-*` (verified against the pinned codex binary). |
| app-server missing `approval_policy` | #336 | **Handled by design** — app-server gets its approval policy from the injected `--ask-for-approval` flag (documented in the wrapper). |
| copilot help verification skipped in checksum-only mode | #359 | **Addressed** — the default mode is now `auto` (does native/docker help verification), and release callers set `native`/`docker` explicitly; no bare caller selects `checksum`. |
| copilot business/enterprise egress hosts absent | #362 | **Deliberate scoping** — the default strict allowlist intentionally covers only `api.githubcopilot.com` + `api.individual.githubcopilot.com` + github hosts; adding wildcard `*.business.githubcopilot.com` would broaden default egress. Not changed. |
| **copilot `logout` not denied** | #362 | **Live gap — fixed here.** |
| `WORKCELL_TRUSTED_BUILDX_BIN` override undocumented | #397 | **Doc-only — added here.** |

## Changes

1. **`^F` copilot `logout` deny** — `reject_unsafe_copilot_args` blocked `login`/`init`/`mcp`/`plugin`/`skill`/`update` but omitted `logout`, so a managed Copilot session could clear persisted auth state — asymmetric with the denied `login`. Added `logout` to the lifecycle deny list, with a container-smoke denial assertion, and regenerated the control-plane manifest.

2. **`^d` buildx override doc** — documents in `docs/launcher-contract.md` that a pre-set executable `WORKCELL_TRUSTED_BUILDX_BIN` short-circuits the trusted-plugin search but is cleared by the launcher's `env -i` shebang on any normal invocation, surviving only for shebang-bypass `/bin/bash -p scripts/workcell` runs that are already outside the trust boundary.

## Validation

- `go test ./...`, `scripts/container-smoke.sh` (colima rebuild, new `logout` assertion), `scripts/verify-invariants.sh` — all green.
- markdownlint + codespell + check-doc-links clean.
- `scripts/pre-merge.sh --profile pr-parity` — exit 0.
