### PR TITLE
Make docker-desktop compat cert diagnostics credential-free (runs on hosts with real provider auth)

### DIFF
--- a/tests/scenarios/shared/test-docker-desktop-launch-smoke.sh
+++ b/tests/scenarios/shared/test-docker-desktop-launch-smoke.sh
@@ -100,6 +100,7 @@ inspect_target_state() {
     --target docker-desktop \
     --agent codex \
     --inspect \
+    --no-default-injection-policy \
     --workspace "${WORKSPACE}" \
     >"${TMP_DIR}/inspect.stdout" 2>"${TMP_DIR}/inspect.stderr"
 }
@@ -109,6 +110,7 @@ doctor_target() {
     --target docker-desktop \
     --agent codex \
     --doctor \
+    --no-default-injection-policy \
     --workspace "${WORKSPACE}" \
     >"${TMP_DIR}/doctor.stdout" 2>"${TMP_DIR}/doctor.stderr"
 }


### PR DESCRIPTION
## Summary

The `docker-desktop-launch-smoke` certification scenario (the `macos/arm64` `local_compat/docker-desktop/compat` boundary cert) fails on any host that has real Codex auth staged at `~/.codex` — i.e. every real local-operator-certification machine, which is the exact target for a compat-boundary certification.

Root cause: the scenario's `inspect_target_state` and `doctor_target` functions invoked `scripts/workcell --inspect` / `--doctor` with **neither** `--injection-policy` **nor** `--no-default-injection-policy`, so they fell back to the default injection policy. That resolves `codex_auth` to the host `~/.codex`, and `resolve_credential_sources` then fails closed:

```
credentials.codex_auth must not point inside host provider/auth state: /Users/.../.codex
resolve_credential_sources exited 1
```

The guard is correct — it refuses to use host provider auth as a session credential source. The bug is that the diagnostic pre-checks resolve credentials at all. The scenario's own launch steps already exercise real credential injection with the fixture policy; the `--inspect`/`--doctor` steps only assert **target-state** fields (`profile`, `target_state_dir`, `target_kind`, assurance class, support-matrix rows) — nothing about credentials.

Fix: add `--no-default-injection-policy` to the two diagnostic calls, matching the sibling `aws-ec2-ssm-launch-smoke` and `gcp-vm-launch-smoke` certification scenarios, which already use exactly that flag on their `--doctor` pre-check. This keeps the diagnostics credential-free and makes the cert runnable on any host regardless of staged provider auth, with no assertion coverage loss.

## Validation

- **Reproduced** the failure on this MacBook (real `~/.codex` present), then confirmed `--no-default-injection-policy` on `--inspect`/`--doctor` returns `rc=0` and still emits every asserted target-state field.
- **Certified the compat boundary end-to-end**: `tests/scenarios/shared/test-docker-desktop-launch-smoke.sh` now passes against real Docker Desktop (`29.5.3`) on `macos/arm64` — `Docker Desktop provider launch smoke scenario passed`.
- `go test ./...`, shellcheck, and `scripts/pre-merge.sh --profile pr-parity` all green.

This is a STEP-D compat-boundary certification deliverable: the `local_compat/docker-desktop/compat` boundary is now empirically certified on the maintainer host (the `local_vm/colima/strict` boundary was certified separately via `agent-launch-smoke`).
