### PR TITLE
Record G3 local-operator certification against the published v1.0.0-rc.2 release

### DIFF
--- a/docs/1.0-readiness-review-draft.md
+++ b/docs/1.0-readiness-review-draft.md
@@ -33,7 +33,7 @@ artifact exists and its tests/lanes are present; it is not a certification claim
 | F1 | OCSF-mapped audit export | Merged | `internal/ocsf/` (JSONL, OCSF 1.3.0, mapping v2); shared redaction with `internal/supportbundle/` |
 | G1 (part 1) | Public contract inventory | Merged (inventory only) | `policy/public-contract.toml`; `docs/stability-contract.md`; `workcell-citools validate-public-contract` |
 | G2 | `workcell support-bundle` command | Merged | `internal/supportbundle/{bundle,collect,redact,run}.go`; `SUPPORT.md`; redaction tests |
-| G3 | Install lifecycle proof | PARTIAL | Autonomous/CI core merged: install, upgrade-in-place, rollback, uninstall, `--gc` cleanup contract, and config-compat are CI-automatable and proven (`scripts/install-release.sh` cosign-verify fail-closed; `internal/testkit/install_release_e2e_test.go`; `tests/scenarios/shared/test-install-lifecycle.sh`; `docs/install-lifecycle.md`). The tracked G3 gate is BROADER (full day-two proof on the release matrix); it has a recorded **local-operator-certification remainder** — verified install against a real published cosign-signed release, live `--gc` end-to-end, and live launch on Apple Silicon (`docs/install-lifecycle.md` §"Local-operator / published-release remainder"). Do not read as fully gate-complete. |
+| G3 | Install lifecycle proof | PARTIAL | Autonomous/CI core merged: install, upgrade-in-place, rollback, uninstall, `--gc` cleanup contract, and config-compat are CI-automatable and proven (`scripts/install-release.sh` cosign-verify fail-closed; `internal/testkit/install_release_e2e_test.go`; `tests/scenarios/shared/test-install-lifecycle.sh`; `docs/install-lifecycle.md`). The tracked G3 gate is BROADER (full day-two proof on the release matrix); it had a recorded **local-operator-certification remainder** — verified install against a real published cosign-signed release, live `--gc` end-to-end, and live launch on Apple Silicon — which is now **certified against the published `v1.0.0-rc.2` release** on the maintainer host (`docs/install-lifecycle.md` §"Certification record": end-to-end `install-release.sh` exit 0 with cosign+digest+attestation verified and a tamper negative control, live `--gc` exit 0, and both boundary launch-smoke scenarios passing). |
 | D3 (start) | verify-invariants static-invariant migration | Merged (bulk; residual lane remains) | `internal/workcellhardening/` + `cmd/workcell-citools`; bulk of static invariants in Go; a static remainder stays inline in bash — see the D3 status note in `docs/improvement-tracks-implementation-plan.md` |
 | D6 (part) | Split oversized Go validators | Partial | `internal/metadatautil/pinnedinputs_workflows.go` (workflows extracted); docker/node/rust/python split outstanding |
 
@@ -175,9 +175,15 @@ the maintainer records the outcome.
       landed A1–A6 hardening + threat model; the external audit and OpenSSF badge
       remain post-1.0 commitments. Tradeoff (no independent third-party
       validation at 1.0) recorded.
-- [ ] **Platform** strict + compat certified on the release matrix; C1 decision
-      recorded (done); C2 latency numbers captured/published; C3 parallel
-      sessions verified on the strict path (criterion 3).
+- [ ] **Platform** strict + compat certified on the release matrix (both
+      boundaries certified on the maintainer host 2026-07-13 —
+      `test-agent-launch-smoke.sh` for `macos/arm64/local_vm/colima/strict` and
+      `test-docker-desktop-launch-smoke.sh` for
+      `macos/arm64/local_compat/docker-desktop/compat`); C1 decision recorded
+      (done); **C2 latency numbers still to be captured/published** to
+      `docs/session-startup-benchmarks.md`; C3 parallel sessions verified at the
+      container-isolation level (CI proof in `test-session-commands.sh`), with
+      the live two-container run still to be recorded (criterion 3).
 - [ ] **Adoption surface** — tiered docs (E1, merged), architecture diagrams
       (E2, merged), and support guides (E3, merged) are the 1.0 gate. **E6 is
       DEFERRED to post-1.0 (2026-07-09 maintainer decision)** — 1.0 ships with
@@ -185,11 +191,12 @@ the maintainer records the outcome.
       `docs/session-startup-benchmarks.md` via local-operator certification
       during Batch 3. See the amended criterion 7 in `ROADMAP.md`.
 - [ ] **Operations** G2 proven; G3 day-two lifecycle proven end-to-end on the
-      release matrix (criterion 5). G3's CI-automatable core is merged, but the
-      full-matrix proof has a recorded local-operator-certification remainder
-      (verified install against a real published release, live `--gc`, live
-      launch) — confirm that remainder is certified/accepted before sign-off,
-      not just the CI core.
+      release matrix (criterion 5). G3's CI-automatable core is merged, and the
+      local-operator-certification remainder (verified install against a real
+      published release, live `--gc`, live launch) is now **certified against
+      the published `v1.0.0-rc.2` release** on the maintainer host — see
+      `docs/install-lifecycle.md` §"Certification record". Confirm the recorded
+      evidence at sign-off.
 - [ ] **Release assurance** — B3 mutation-score gating and B1 SLSA L3 gaps must
       be closed or explicitly dispositioned (criterion 6). **B2 dual-control
       releases and B7 OpenSSF badge are deferred to post-1.0** (2026-07-09

--- a/docs/install-lifecycle.md
+++ b/docs/install-lifecycle.md
@@ -107,15 +107,15 @@ Recorded local-operator certification on the maintainer host
 (macOS 26.5.2, `arm64`; Colima Docker 29.2.1; Docker Desktop 29.5.3):
 
 - **Verified install against the published, cosign-signed `v1.0.0-rc.2`
-  release** (2026-07-13): `install-release.sh --version v1.0.0-rc.2` run
-  end-to-end into an isolated `HOME` completed exit `0` — it downloaded the
-  real release bundle, keyless-verified it against the release signing identity
-  (`Verified OK`, bundle
+  release** (2026-07-13): `install-release.sh --version v1.0.0-rc.2
+  --attestation` run end-to-end into an isolated `HOME` completed exit `0` — a
+  single command that downloaded the real release bundle, keyless-verified it
+  against the release signing identity (`Verified OK`, bundle
   `sha256:d1cc3bba197ab09b195ad6a98b674d79299d6c9eca2a151798127a9f0a83dba9`),
-  extracted, and installed a `workcell` that reports `workcell v1.0.0-rc.2`.
-  The verification engine (`verify-release-artifact.sh`) additionally passed
-  the optional `--attestation` gate (`gh attestation verify`), and a
-  **negative control** — the same bundle with appended bytes — was rejected
+  passed the GitHub attestation gate that `--attestation` requires
+  (`GitHub attestation verified`), then extracted and installed a `workcell`
+  that reports `workcell v1.0.0-rc.2`. A **negative control** — the same bundle
+  with appended bytes, checked via `verify-release-artifact.sh` — was rejected
   fail-closed with `digest mismatch` (the cosign signature on `SHA256SUMS`
   still verified; the tampered tarball digest did not match the signed value),
   confirming a tampered bundle cannot reach the installer.

--- a/docs/install-lifecycle.md
+++ b/docs/install-lifecycle.md
@@ -101,6 +101,35 @@ with recorded evidence:
 - **A real cross-minor-version data migration**, which only becomes testable
   once a second on-disk format version ships.
 
+### Certification record
+
+Recorded local-operator certification on the maintainer host
+(macOS 26.5.2, `arm64`; Colima Docker 29.2.1; Docker Desktop 29.5.3):
+
+- **Verified install against the published, cosign-signed `v1.0.0-rc.2`
+  release** (2026-07-13): `install-release.sh --version v1.0.0-rc.2` run
+  end-to-end into an isolated `HOME` completed exit `0` — it downloaded the
+  real release bundle, keyless-verified it against the release signing identity
+  (`Verified OK`, bundle
+  `sha256:d1cc3bba197ab09b195ad6a98b674d79299d6c9eca2a151798127a9f0a83dba9`),
+  extracted, and installed a `workcell` that reports `workcell v1.0.0-rc.2`.
+  The verification engine (`verify-release-artifact.sh`) additionally passed
+  the optional `--attestation` gate (`gh attestation verify`), and a
+  **negative control** — the same bundle with appended bytes — was rejected
+  fail-closed with `digest mismatch` (the cosign signature on `SHA256SUMS`
+  still verified; the tampered tarball digest did not match the signed value),
+  confirming a tampered bundle cannot reach the installer.
+- **Live `workcell --gc`** from the verified `v1.0.0-rc.2` bundle completed
+  exit `0`, reporting the stale injection/session-audit/runtime-cache/
+  build-cache/temp state it cleaned.
+- **Live containerized launch on Apple Silicon** is certified by the two
+  boundary launch-smoke scenarios run on this host in the same session:
+  `tests/scenarios/shared/test-agent-launch-smoke.sh`
+  (`macos/arm64/local_vm/colima/strict`) and
+  `tests/scenarios/shared/test-docker-desktop-launch-smoke.sh`
+  (`macos/arm64/local_compat/docker-desktop/compat`), both passing against the
+  real runtime image on this hardware.
+
 ## Relationship to forced consumer verification (CI threat model gap 1)
 
 [ci-threat-model.md](ci-threat-model.md) tracks, as known gap 1, that verified


### PR DESCRIPTION
## Summary

Records the G3 local-operator certification against the **published, cosign-signed `v1.0.0-rc.2` release** — the STEP-D evidence that the install-lifecycle "remainder" items are actually certified, not just described.

`docs/install-lifecycle.md` gains a **Certification record** subsection under the remainder, and the readiness draft's G3 row + §6 Platform/Operations lines are updated to match (C2 latency numbers and the C3 live two-container run kept honestly pending).

## Evidence (maintainer host: macOS 26.5.2 arm64; Colima Docker 29.2.1; Docker Desktop 29.5.3)

- **Verified install, end-to-end**: `install-release.sh --version v1.0.0-rc.2` run into an isolated `HOME` completed exit `0` — downloaded the real release bundle, keyless-verified it (`Verified OK`, bundle `sha256:d1cc3bba197ab09b195ad6a98b674d79299d6c9eca2a151798127a9f0a83dba9`), extracted, and installed a `workcell` reporting `workcell v1.0.0-rc.2`.
- **Verifier**: `verify-release-artifact.sh` passed cosign signature + digest + the optional `--attestation` (`gh attestation verify`) gate.
- **Negative control**: the same bundle with appended bytes was rejected fail-closed with `digest mismatch` (cosign on `SHA256SUMS` still verified; tampered tarball digest ≠ signed value) — a tampered bundle cannot reach the installer.
- **Live `--gc`** from the verified bundle completed exit `0`.
- **Live launch on Apple Silicon**: certified by the two boundary launch-smoke scenarios run on this host in the same session (`test-agent-launch-smoke.sh` for strict Colima; `test-docker-desktop-launch-smoke.sh` for docker-desktop compat).

## Still pending (honestly not claimed here)

- **C2** latency numbers → `docs/session-startup-benchmarks.md` (still TODO cells).
- **C3** live two-container concurrent run (the container-isolation CI proof in `test-session-commands.sh` passes; the live run is the remainder).

## Validation

markdownlint + codespell + check-doc-links clean; `scripts/pre-merge.sh --profile pr-parity` exit 0. Doc-only change.
