### PR TITLE
Make verified one-command release install the default in README + getting-started (gap 1a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ links; the full index is in the [Docs map](#docs-map) below.
 ## 5-minute path
 
 Install Workcell, create the host-side auth policy, inspect the derived
-posture, then launch:
+posture, then launch. `./scripts/install.sh` below assumes you are in a
+verified or source tree; to install a tagged release instead, use the verified
+one-command path `./scripts/install-release.sh --version vX.Y.Z --attestation`
+(see [Install](#install)).
 
 ```bash
 ./scripts/install.sh
@@ -147,17 +150,21 @@ host support boundary that `--doctor` and `--inspect` report.
 
 ## Install
 
-On Apple Silicon macOS, download a tagged release bundle, unpack it, and run the
-supported installer:
+On Apple Silicon macOS, the recommended path is the one-command **verified
+release install**, which downloads a tagged release, verifies its cosign
+signature and digest fail-closed **before any bundle code runs**, and only then
+installs:
 
 ```bash
-tar -xzf workcell-vX.Y.Z.tar.gz
-cd workcell-vX.Y.Z
-./scripts/install.sh
+./scripts/install-release.sh --version vX.Y.Z --attestation
 ```
 
-`./scripts/install.sh` installs only the missing required Homebrew formulas
-(`colima`, `docker`, `gh`, `git`, `go`) before it links the launcher.
+Both `install-release.sh` and the bundle's own `./scripts/install.sh` install
+only the missing required Homebrew formulas (`colima`, `docker`, `gh`, `git`,
+`go`) before linking the launcher; pass `-- --no-install-deps` for a
+launcher-only install. If you already have a verified, unpacked release tree
+(see the manual steps in [docs/getting-started.md](docs/getting-started.md)),
+run `./scripts/install.sh` from inside it.
 
 For the Homebrew formula asset, the source checkout path, and the full host
 requirements, see [docs/install.md](docs/install.md).

--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ links; the full index is in the [Docs map](#docs-map) below.
 Install Workcell, create the host-side auth policy, inspect the derived
 posture, then launch. `./scripts/install.sh` below assumes you are in a
 verified or source tree; to install a tagged release instead, use the verified
-one-command path `./scripts/install-release.sh --version vX.Y.Z --attestation`
-(see [Install](#install)).
+one-command path `./scripts/install-release.sh --version vX.Y.Z` (see
+[Install](#install) for the tag clone, signature checks, and the optional
+`--attestation` gate).
 
 ```bash
 ./scripts/install.sh

--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ from the repository over TLS (a trusted source) rather than the unverified
 bundle — clone the repo, then run it:
 
 ```bash
-brew install cosign gh git gnupg   # verifier tools must exist before verification runs (macOS ships neither gnupg nor, on a clean host, git)
+brew install cosign git gnupg   # verifier tools must exist before verification runs (macOS ships neither gnupg nor, on a clean host, git)
 git clone --branch vX.Y.Z --depth 1 https://github.com/omkhar/workcell.git
 cd workcell
 git tag -v vX.Y.Z        # verify the tag signature before running the installer
-./scripts/install-release.sh --version vX.Y.Z --attestation
+./scripts/install-release.sh --version vX.Y.Z
 ```
 
 Clone the **tag** (`--branch vX.Y.Z`), not the mutable default branch: the
@@ -172,14 +172,16 @@ holds. `git tag -v` authenticates that commit against the maintainer signing
 key **before** you execute the installer — import and confirm the key
 fingerprint from [SECURITY.md](SECURITY.md#signing-key) first.
 
-`cosign` (and `gh` for `--attestation`) must already be installed, because
-verification runs **before** the bundle installer that provides the other host
-packages. The bundle installer then installs only the remaining missing required
-formulas (`colima`, `docker`, `git`, `go`) before linking the launcher; pass
-`-- --no-install-deps` for a launcher-only install. To verify and install
-straight from the release page without a clone, use the manual cosign flow in
-[docs/getting-started.md](docs/getting-started.md); if you already have a
-verified, unpacked release tree, run `./scripts/install.sh` from inside it.
+The verifier tools (`cosign`, and `git`/`gnupg` for the clone and tag check)
+must already be installed, because verification runs **before** the bundle
+installer that provides the other host packages (`colima`, `docker`, `go`); pass
+`-- --no-install-deps` for a launcher-only install. For an **additional** GitHub
+attestation check, append `--attestation` — that step needs `gh` installed and
+authenticated (`brew install gh && gh auth login`) and network access. To verify
+and install straight from the release page without a clone, use the manual
+cosign flow in [docs/getting-started.md](docs/getting-started.md); if you already
+have a verified, unpacked release tree, run `./scripts/install.sh` from inside
+it.
 
 For the Homebrew formula asset, the source checkout path, and the full host
 requirements, see [docs/install.md](docs/install.md).

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ from the repository over TLS (a trusted source) rather than the unverified
 bundle — clone the repo, then run it:
 
 ```bash
-brew install cosign gh   # verifier tools must exist before verification runs
+brew install cosign gh git gnupg   # verifier tools must exist before verification runs (macOS ships neither gnupg nor, on a clean host, git)
 git clone --branch vX.Y.Z --depth 1 https://github.com/omkhar/workcell.git
 cd workcell
 git tag -v vX.Y.Z        # verify the tag signature before running the installer

--- a/README.md
+++ b/README.md
@@ -159,10 +159,15 @@ bundle — clone the repo, then run it:
 
 ```bash
 brew install cosign gh   # verifier tools must exist before verification runs
-git clone https://github.com/omkhar/workcell.git
+git clone --branch vX.Y.Z --depth 1 https://github.com/omkhar/workcell.git
 cd workcell
 ./scripts/install-release.sh --version vX.Y.Z --attestation
 ```
+
+Clone the **tag** (`--branch vX.Y.Z`), not the mutable default branch: the
+pre-trust installer runs before any release verification, so it must come from
+the signed, immutable release commit rather than whatever `main` currently
+holds.
 
 `cosign` (and `gh` for `--attestation`) must already be installed, because
 verification runs **before** the bundle installer that provides the other host

--- a/README.md
+++ b/README.md
@@ -161,13 +161,16 @@ bundle — clone the repo, then run it:
 brew install cosign gh   # verifier tools must exist before verification runs
 git clone --branch vX.Y.Z --depth 1 https://github.com/omkhar/workcell.git
 cd workcell
+git tag -v vX.Y.Z        # verify the tag signature before running the installer
 ./scripts/install-release.sh --version vX.Y.Z --attestation
 ```
 
 Clone the **tag** (`--branch vX.Y.Z`), not the mutable default branch: the
 pre-trust installer runs before any release verification, so it must come from
 the signed, immutable release commit rather than whatever `main` currently
-holds.
+holds. `git tag -v` authenticates that commit against the maintainer signing
+key **before** you execute the installer — import and confirm the key
+fingerprint from [SECURITY.md](SECURITY.md#signing-key) first.
 
 `cosign` (and `gh` for `--attestation`) must already be installed, because
 verification runs **before** the bundle installer that provides the other host

--- a/README.md
+++ b/README.md
@@ -153,18 +153,23 @@ host support boundary that `--doctor` and `--inspect` report.
 On Apple Silicon macOS, the recommended path is the one-command **verified
 release install**, which downloads a tagged release, verifies its cosign
 signature and digest fail-closed **before any bundle code runs**, and only then
-installs:
+installs. `install-release.sh` is not a standalone release asset, so get it
+from the repository over TLS (a trusted source) rather than the unverified
+bundle — clone the repo, then run it:
 
 ```bash
+git clone https://github.com/omkhar/workcell.git
+cd workcell
 ./scripts/install-release.sh --version vX.Y.Z --attestation
 ```
 
 Both `install-release.sh` and the bundle's own `./scripts/install.sh` install
 only the missing required Homebrew formulas (`colima`, `docker`, `gh`, `git`,
 `go`) before linking the launcher; pass `-- --no-install-deps` for a
-launcher-only install. If you already have a verified, unpacked release tree
-(see the manual steps in [docs/getting-started.md](docs/getting-started.md)),
-run `./scripts/install.sh` from inside it.
+launcher-only install. To verify and install straight from the release page
+without a clone, use the manual cosign flow in
+[docs/getting-started.md](docs/getting-started.md); if you already have a
+verified, unpacked release tree, run `./scripts/install.sh` from inside it.
 
 For the Homebrew formula asset, the source checkout path, and the full host
 requirements, see [docs/install.md](docs/install.md).

--- a/README.md
+++ b/README.md
@@ -158,16 +158,18 @@ from the repository over TLS (a trusted source) rather than the unverified
 bundle — clone the repo, then run it:
 
 ```bash
+brew install cosign gh   # verifier tools must exist before verification runs
 git clone https://github.com/omkhar/workcell.git
 cd workcell
 ./scripts/install-release.sh --version vX.Y.Z --attestation
 ```
 
-Both `install-release.sh` and the bundle's own `./scripts/install.sh` install
-only the missing required Homebrew formulas (`colima`, `docker`, `gh`, `git`,
-`go`) before linking the launcher; pass `-- --no-install-deps` for a
-launcher-only install. To verify and install straight from the release page
-without a clone, use the manual cosign flow in
+`cosign` (and `gh` for `--attestation`) must already be installed, because
+verification runs **before** the bundle installer that provides the other host
+packages. The bundle installer then installs only the remaining missing required
+formulas (`colima`, `docker`, `git`, `go`) before linking the launcher; pass
+`-- --no-install-deps` for a launcher-only install. To verify and install
+straight from the release page without a clone, use the manual cosign flow in
 [docs/getting-started.md](docs/getting-started.md); if you already have a
 verified, unpacked release tree, run `./scripts/install.sh` from inside it.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,29 @@ Always verify a release before installing it: `scripts/install-release.sh`
 checks the release's cosign signature and digest fail-closed before any bundle
 code runs (see [`docs/install-lifecycle.md`](docs/install-lifecycle.md)).
 
+## Signing key
+
+Release tags and commits are GPG-signed by the maintainer. Confirm any key you
+import against this fingerprint before trusting a signature:
+
+```text
+Omkhar Arasaratnam <omkhar@gmail.com>
+ed25519  9055 4248 C4F7 CC08 6BB7  45D0 DA5A 8E9F 536C 42FD
+```
+
+When you obtain the installer from a checkout of a release tag (the verified
+install path in [`docs/getting-started.md`](docs/getting-started.md)), verify
+that tag's signature against this key **before** running any code from it:
+
+```bash
+# import the maintainer key (e.g. from a keyserver) and confirm the fingerprint above, then:
+git tag -v vX.Y.Z
+```
+
+This authenticates the installer source; the release *artifacts* are
+independently verified with keyless cosign signatures (no long-lived signing
+key), documented in [`docs/provenance.md`](docs/provenance.md).
+
 ## Reporting
 
 Do not disclose new sandbox escapes, credential leaks, signing bypasses, or

--- a/docs/ci-threat-model.md
+++ b/docs/ci-threat-model.md
@@ -276,12 +276,14 @@ digest fail-closed (via `scripts/verify-release-artifact.sh`) before installing,
 so on that path the guarantee no longer depends on a user remembering the manual
 `cosign verify` / `gh attestation verify` commands in
 [provenance.md](provenance.md). As of the 1.0 docs this verified path is the
-**documented default** install — the README and getting-started lead with
-`install-release.sh` (obtained via a repo clone over TLS, since the installer is
-not itself a standalone release asset) or, from the release page, the manual
-`cosign verify` flow. Verification is not yet *forced*, however: a user can
-still choose an unverified install (`tar … && ./scripts/install.sh`, the plain
-`install.sh`, or a hand-fetched bundle), and no standalone verified installer is
+**documented default for installing a tagged release** — the README Install
+section and getting-started recommend `install-release.sh` (obtained via a repo
+clone over TLS, since the installer is not itself a standalone release asset) or,
+from the release page, the manual `cosign verify` flow. Verification is not yet
+*forced*, however: the README's 5-minute quickstart still runs the plain
+`./scripts/install.sh` from an assumed local checkout, a user can otherwise
+choose an unverified install (`tar … && ./scripts/install.sh` or a hand-fetched
+bundle), and no standalone verified installer is
 published as a release asset — so the residual is a defaulting/bootstrap gap,
 not an absent capability (threat 8,
 [known gap 1](#known-gaps-and-future-work)). The verification identity that a consumer (or the installer) pins is the

--- a/docs/ci-threat-model.md
+++ b/docs/ci-threat-model.md
@@ -270,15 +270,20 @@ the release workflow.) The plain installers (`install.sh` →
 `install-workcell.sh`) install from a local checkout and do **not** download or
 verify a signed release artifact — that is what `install-release.sh` adds.
 
-On the consumer side, `scripts/install-release.sh` now automates the
-trust-establishing step for consumers who **choose** it: it verifies the signed
-`SHA256SUMS` and the bundle digest fail-closed (via
-`scripts/verify-release-artifact.sh`) before installing, so on that path the
-guarantee no longer depends on a user remembering the manual `cosign verify` /
-`gh attestation verify` commands in [provenance.md](provenance.md). It is opt-in,
-not the default: a user who runs the documented default install (`tar … &&
-./scripts/install.sh`, the plain `install.sh`, or a hand-fetched bundle) still
-gets none — so verification is not yet *forced* (threat 8,
+On the consumer side, `scripts/install-release.sh` automates the
+trust-establishing step: it verifies the signed `SHA256SUMS` and the bundle
+digest fail-closed (via `scripts/verify-release-artifact.sh`) before installing,
+so on that path the guarantee no longer depends on a user remembering the manual
+`cosign verify` / `gh attestation verify` commands in
+[provenance.md](provenance.md). As of the 1.0 docs this verified path is the
+**documented default** install — the README and getting-started lead with
+`install-release.sh` (obtained via a repo clone over TLS, since the installer is
+not itself a standalone release asset) or, from the release page, the manual
+`cosign verify` flow. Verification is not yet *forced*, however: a user can
+still choose an unverified install (`tar … && ./scripts/install.sh`, the plain
+`install.sh`, or a hand-fetched bundle), and no standalone verified installer is
+published as a release asset — so the residual is a defaulting/bootstrap gap,
+not an absent capability (threat 8,
 [known gap 1](#known-gaps-and-future-work)). The verification identity that a consumer (or the installer) pins is the
 release workflow at a tag ref (`.../release.yml@refs/tags/.+`) with issuer
 `https://token.actions.githubusercontent.com`. What remains asymmetric is CI:
@@ -305,7 +310,7 @@ Residual risk is rated after the existing mitigation.
 | 5 | **Signing-key compromise** | **No long-lived cosign key exists** (keyless OIDC/Fulcio); the git tag/commit key lives off-CI on the maintainer host; releases are immutable (`immutable_github_releases = true`) | Low for cosign; see [incident response](#signing-compromise-incident-response) for the OIDC-identity and GPG-key cases |
 | 6 | **Provenance / attestation forgery** | Attestations bound to the release workflow identity via OIDC; consumers pin `--certificate-identity` / `--signer-workflow`; Rekor transparency; fail-closed attestation pinned by policy | Medium: **Build L2, not L3** — a compromised build step in the same job could get a genuine attestation over a forged digest; and no consumer is *forced* to verify (threat 8) |
 | 7 | **Cache poisoning** from a fork PR into trusted builds | PR-keyed buildx cache scope distinct from `validator-main`; `mode=max` writes gated to `push` events | Low |
-| 8 | **Unverified consumer install** — user runs an artifact that was never verified | An **opt-in** fail-closed verified path exists: `scripts/install-release.sh` downloads, verifies via `verify-release-artifact.sh` (`cosign verify-blob` of the signed `SHA256SUMS` against the pinned release-workflow identity, plus optional `gh attestation verify`), and only then installs; verification commands also documented in [provenance.md](provenance.md); immutable releases; `SHA256SUMS` signed | Medium: the verified path is fail-closed **but opt-in, not the default** — the documented default install (`tar … && ./scripts/install.sh`, the plain `install.sh`, or any hand-fetched bundle) still does not verify, so a consumer is not *forced* to verify. Reduced from High, not eliminated, until installer verification is the default across all install paths (see [known gap 1](#known-gaps-and-future-work)) |
+| 8 | **Unverified consumer install** — user runs an artifact that was never verified | A fail-closed verified path is the **documented default**: `scripts/install-release.sh` downloads, verifies via `verify-release-artifact.sh` (`cosign verify-blob` of the signed `SHA256SUMS` against the pinned release-workflow identity, plus optional `gh attestation verify`), and only then installs; the README and getting-started lead with it (or the manual `cosign verify` flow from the release page); verification commands also documented in [provenance.md](provenance.md); immutable releases; `SHA256SUMS` signed | Medium: verified install is the documented default and fail-closed, **but not *forced*** — a user can still choose an unverified install (`tar … && ./scripts/install.sh`, the plain `install.sh`, or any hand-fetched bundle), and the installer is obtained via a repo clone rather than a standalone signed release asset. Reduced from High, not eliminated, until verification is forced across all paths and a verified installer bootstrap ships (see [known gap 1](#known-gaps-and-future-work)) |
 | 9 | **Malicious change reaches a release** without review | Signed-commits + anti-rewrite branch ruleset; tag ruleset on `refs/tags/v*`; required status checks; `pr-base-policy.yml` forces `main` base; publish gated on tag-on-green-main and the `release` environment approval; the amd64 image is rebuilt from the archived source bundle (`context: dist/release-source`) | Medium: **single-maintainer** — the tag signer and the release approver are the same identity; no two-person review (a SLSA Source-track control, out of scope for v1.0 Build). The **arm64** image is built from the checked-out release tag (`context: .`), not the repackaged source archive, so only amd64 gets the archive-rebuild property; both platforms still derive from the same signed, immutable tag |
 | 10 | **Oversized/obfuscated PR** hides a malicious diff | `scripts/check-pr-shape.sh` caps PRs at ≤25 files, ≤1200 changed lines, ≤8 areas, 0 binaries (reviewed override raises limits for certified-adapter PRs only) | Low |
 | 11 | **Stored token leaks via script logging** | Token is environment-scoped read-only metadata; passed by env, never echoed by the workflow | Low: depends on `run-hosted-controls-audit.sh` never running `set -x` over the token |
@@ -382,8 +387,9 @@ restored. This is a residual risk, not a mitigated one.
 These are real weaknesses in the current CI/CD posture, stated so they can be
 tracked or accepted deliberately:
 
-1. **Forced consumer verification — PARTIALLY addressed (opt-in verified path
-   exists; not yet the default).** A fail-closed verified install path now
+1. **Forced consumer verification — PARTIALLY addressed (verified install is now
+   the documented default; not yet *forced*, and the installer bootstraps via a
+   repo clone).** A fail-closed verified install path now
    exists: `scripts/install-release.sh` downloads, verifies, and only then
    installs a tagged release via `scripts/verify-release-artifact.sh`, which by
    default `cosign verify-blob`s the signed `SHA256SUMS` against the pinned
@@ -395,22 +401,30 @@ tracked or accepted deliberately:
    acknowledged `--skip-verify` for documented air-gapped installs (see
    [install.md](install.md#verified-release-install-recommended)). The published
    SBOMs are for downstream SCA and are deliberately **not** an install-time gate
-   (the installer does not verify them). **This provides consumer signature
-   verification for the signed checksums and bundle, but does not yet fully close
-   the gap:** it is a separate, opt-in entrypoint — the documented default
+   (the installer does not verify them). The README and getting-started now lead
+   with this verified path (`install-release.sh`, obtained via a repo clone over
+   TLS, or the manual `cosign verify` flow from the release page). **This makes
+   verified install the documented default, but does not yet fully close the
+   gap:** verification is not *forced* — a user can still choose an unverified
    install (`tar … && ./scripts/install.sh`, the plain `install.sh`, or a
-   hand-fetched bundle) still does not verify, so verification is not *forced*.
+   hand-fetched bundle) — and the installer is bootstrapped from a repo clone
+   rather than a standalone signed release asset.
    Homebrew installs verify at checksum level via the pinned `sha256` in
    `workcell.rb`. **G3 progress:** `install-release.sh` is now exercised end to
    end in CI against a locally built fixture release with stubbed `curl`/`cosign`
    (`internal/testkit/install_release_e2e_test.go`), proving the full
    download → verify → extract → handoff chain is fail-closed — a bad signature
-   or a digest mismatch aborts before the bundle installer runs. **Fully closing
-   gap 1** still requires (a) making installer verification the default/forced
-   path across all documented install flows, and (b) exercising the verified
-   path against a genuinely published, cosign-signed release (the offline fixture
-   proves the orchestration and fail-closed logic, not a real keyless Sigstore
-   signature). Both are tracked under **G3**, install-lifecycle proof; see
+   or a digest mismatch aborts before the bundle installer runs. Part (b) below
+   is now done: the verified path has been exercised end-to-end against the
+   genuinely published, cosign-signed `v1.0.0-rc.2` release (`install-release.sh
+   --attestation` exit 0 with cosign + digest + attestation verified, plus a
+   tamper negative control — see
+   [install-lifecycle.md](install-lifecycle.md) §"Certification record"), so the
+   real keyless Sigstore signature path is proven, not just the offline fixture.
+   **Fully closing gap 1** now requires only (a) making verification *forced*
+   across all documented install flows and shipping a standalone verified
+   installer bootstrap (so consumers need not clone the repo to get a trusted
+   `install-release.sh`); tracked under **G3**, install-lifecycle proof; see
    [install-lifecycle.md](install-lifecycle.md).
 2. **SLSA Build L3 not met (threat 6).** Build and provenance generation share a
    job/runner, so provenance is forgeable by a compromised build step. Closing

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,8 +33,13 @@ run it:
 ```bash
 git clone --branch vX.Y.Z --depth 1 https://github.com/omkhar/workcell.git
 cd workcell
+git tag -v vX.Y.Z        # verify the tag signature before running the installer
 ./scripts/install-release.sh --version vX.Y.Z --attestation
 ```
+
+`git tag -v` authenticates the checked-out installer against the maintainer
+signing key **before** you run it — import and confirm the key fingerprint from
+[SECURITY.md](../SECURITY.md#signing-key) first.
 
 `--attestation` additionally requires `gh attestation verify` to pass (hence
 `gh` above). Arguments after `--` are forwarded to the bundle installer (e.g.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,10 +26,12 @@ brew install cosign gh
 
 `install-release.sh` is not published as a standalone release asset, so obtain
 it from the repository over TLS (a trusted source for the installer) rather than
-from the not-yet-verified bundle — clone the repo, then run it:
+from the not-yet-verified bundle — clone the **release tag** (not the mutable
+default branch, since the pre-trust installer runs before any verification), then
+run it:
 
 ```bash
-git clone https://github.com/omkhar/workcell.git
+git clone --branch vX.Y.Z --depth 1 https://github.com/omkhar/workcell.git
 cd workcell
 ./scripts/install-release.sh --version vX.Y.Z --attestation
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,12 +18,12 @@ before any bundle code runs**, and only then extracts and installs.
 
 The verifier tools must already be on the host, because verification runs
 **before** the bundle installer (which is what installs the other host packages)
-gets to run. Install `cosign`, `gh` (for `--attestation`), and `gnupg` plus
-`git` (for the `git clone` + `git tag -v` below — macOS ships neither `gnupg`
-nor, on a clean host, `git`) first:
+gets to run. Install `cosign` plus `gnupg` and `git` (for the `git clone` +
+`git tag -v` below — macOS ships neither `gnupg` nor, on a clean host, `git`)
+first:
 
 ```bash
-brew install cosign gh git gnupg
+brew install cosign git gnupg
 ```
 
 `install-release.sh` is not published as a standalone release asset, so obtain
@@ -36,18 +36,25 @@ run it:
 git clone --branch vX.Y.Z --depth 1 https://github.com/omkhar/workcell.git
 cd workcell
 git tag -v vX.Y.Z        # verify the tag signature before running the installer
-./scripts/install-release.sh --version vX.Y.Z --attestation
+./scripts/install-release.sh --version vX.Y.Z
 ```
 
 `git tag -v` authenticates the checked-out installer against the maintainer
 signing key **before** you run it — import and confirm the key fingerprint from
-[SECURITY.md](../SECURITY.md#signing-key) first.
+[SECURITY.md](../SECURITY.md#signing-key) first. Arguments after `--` are
+forwarded to the bundle installer (e.g. `-- --no-install-deps` for a
+launcher-only install). A tampered or unsigned bundle is refused before its
+(also-tampered) installer could run — this is why verifying before extraction is
+sound.
 
-`--attestation` additionally requires `gh attestation verify` to pass (hence
-`gh` above). Arguments after `--` are forwarded to the bundle installer (e.g.
-`-- --no-install-deps` for a launcher-only install). A tampered or unsigned
-bundle is refused before its (also-tampered) installer could run — this is why
-verifying before extraction is sound.
+For an **additional** GitHub attestation check, append `--attestation`. That
+step runs `gh attestation verify`, which queries the GitHub API, so it also
+needs `gh` **installed and authenticated** (`brew install gh && gh auth login`)
+and network access:
+
+```bash
+./scripts/install-release.sh --version vX.Y.Z --attestation
+```
 
 **Manual equivalent** (from the release page directly, or to inspect each step):
 download the bundle plus `SHA256SUMS` and `SHA256SUMS.sigstore.json` from GitHub

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,8 +56,11 @@ cosign verify-blob SHA256SUMS \
   --certificate-identity-regexp 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 shasum -a 256 --ignore-missing -c SHA256SUMS
+# needs network; pins the same anchored identity regex + OIDC issuer that
+# install-release.sh --attestation uses (not --signer-workflow, which can over-match).
 gh attestation verify workcell-vX.Y.Z.tar.gz --repo omkhar/workcell \
-  --signer-workflow omkhar/workcell/.github/workflows/release.yml  # needs network
+  --cert-identity-regex 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
+  --cert-oidc-issuer https://token.actions.githubusercontent.com
 tar -xzf workcell-vX.Y.Z.tar.gz
 cd workcell-vX.Y.Z
 ./scripts/install.sh

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,14 @@ one-command verified path: it downloads the tagged release bundle plus its
 signed `SHA256SUMS`, verifies the cosign signature and digest **fail-closed
 before any bundle code runs**, and only then extracts and installs.
 
+The verifier tools must already be on the host, because verification runs
+**before** the bundle installer (which is what installs the other host packages)
+gets to run. Install `cosign`, and `gh` for `--attestation`, first:
+
+```bash
+brew install cosign gh
+```
+
 `install-release.sh` is not published as a standalone release asset, so obtain
 it from the repository over TLS (a trusted source for the installer) rather than
 from the not-yet-verified bundle — clone the repo, then run it:
@@ -26,15 +34,16 @@ cd workcell
 ./scripts/install-release.sh --version vX.Y.Z --attestation
 ```
 
-`--attestation` additionally requires `gh attestation verify` to pass. Arguments
-after `--` are forwarded to the bundle installer (e.g.
+`--attestation` additionally requires `gh attestation verify` to pass (hence
+`gh` above). Arguments after `--` are forwarded to the bundle installer (e.g.
 `-- --no-install-deps` for a launcher-only install). A tampered or unsigned
 bundle is refused before its (also-tampered) installer could run — this is why
 verifying before extraction is sound.
 
 **Manual equivalent** (from the release page directly, air-gapped, or to inspect
 each step): download the bundle plus `SHA256SUMS` and `SHA256SUMS.sigstore.json`
-from GitHub Releases and verify before unpacking:
+from GitHub Releases and verify before unpacking. This mirrors the
+`--attestation` flow, so it includes the `gh attestation verify` gate:
 
 ```bash
 cosign verify-blob SHA256SUMS \
@@ -42,6 +51,8 @@ cosign verify-blob SHA256SUMS \
   --certificate-identity-regexp 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 shasum -a 256 --ignore-missing -c SHA256SUMS
+gh attestation verify workcell-vX.Y.Z.tar.gz --repo omkhar/workcell \
+  --signer-workflow omkhar/workcell/.github/workflows/release.yml
 tar -xzf workcell-vX.Y.Z.tar.gz
 cd workcell-vX.Y.Z
 ./scripts/install.sh

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,10 +18,12 @@ before any bundle code runs**, and only then extracts and installs.
 
 The verifier tools must already be on the host, because verification runs
 **before** the bundle installer (which is what installs the other host packages)
-gets to run. Install `cosign`, and `gh` for `--attestation`, first:
+gets to run. Install `cosign`, `gh` (for `--attestation`), and `gnupg` plus
+`git` (for the `git clone` + `git tag -v` below — macOS ships neither `gnupg`
+nor, on a clean host, `git`) first:
 
 ```bash
-brew install cosign gh
+brew install cosign gh git gnupg
 ```
 
 `install-release.sh` is not published as a standalone release asset, so obtain

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,12 +11,18 @@ GitHub-hosted Apple Silicon `macos-26` and `macos-15`.
 
 ### Option A: verified release install (recommended)
 
-Use `install-release.sh`, the one-command verified path. It downloads the
-tagged release bundle plus its signed `SHA256SUMS`, verifies the cosign
-signature and digest **fail-closed before any bundle code runs**, and only then
-extracts and installs:
+Always verify a release before installing it. `install-release.sh` is the
+one-command verified path: it downloads the tagged release bundle plus its
+signed `SHA256SUMS`, verifies the cosign signature and digest **fail-closed
+before any bundle code runs**, and only then extracts and installs.
+
+`install-release.sh` is not published as a standalone release asset, so obtain
+it from the repository over TLS (a trusted source for the installer) rather than
+from the not-yet-verified bundle — clone the repo, then run it:
 
 ```bash
+git clone https://github.com/omkhar/workcell.git
+cd workcell
 ./scripts/install-release.sh --version vX.Y.Z --attestation
 ```
 
@@ -26,9 +32,9 @@ after `--` are forwarded to the bundle installer (e.g.
 bundle is refused before its (also-tampered) installer could run — this is why
 verifying before extraction is sound.
 
-**Manual equivalent** (air-gapped, or to inspect each step): download the bundle
-plus `SHA256SUMS` and `SHA256SUMS.sigstore.json` from GitHub Releases and verify
-before unpacking:
+**Manual equivalent** (from the release page directly, air-gapped, or to inspect
+each step): download the bundle plus `SHA256SUMS` and `SHA256SUMS.sigstore.json`
+from GitHub Releases and verify before unpacking:
 
 ```bash
 cosign verify-blob SHA256SUMS \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,11 +9,26 @@ GitHub-hosted Apple Silicon `macos-26` and `macos-15`.
 
 ## 1. Install Workcell
 
-### Option A: verified release bundle
+### Option A: verified release install (recommended)
 
-Download a tagged release bundle plus `SHA256SUMS` and
-`SHA256SUMS.sigstore.json` from GitHub Releases, verify the bundle, then
-unpack it and run the installer:
+Use `install-release.sh`, the one-command verified path. It downloads the
+tagged release bundle plus its signed `SHA256SUMS`, verifies the cosign
+signature and digest **fail-closed before any bundle code runs**, and only then
+extracts and installs:
+
+```bash
+./scripts/install-release.sh --version vX.Y.Z --attestation
+```
+
+`--attestation` additionally requires `gh attestation verify` to pass. Arguments
+after `--` are forwarded to the bundle installer (e.g.
+`-- --no-install-deps` for a launcher-only install). A tampered or unsigned
+bundle is refused before its (also-tampered) installer could run — this is why
+verifying before extraction is sound.
+
+**Manual equivalent** (air-gapped, or to inspect each step): download the bundle
+plus `SHA256SUMS` and `SHA256SUMS.sigstore.json` from GitHub Releases and verify
+before unpacking:
 
 ```bash
 cosign verify-blob SHA256SUMS \
@@ -26,7 +41,8 @@ cd workcell-vX.Y.Z
 ./scripts/install.sh
 ```
 
-See [docs/provenance.md](provenance.md) for the full verification contract.
+See [docs/provenance.md](provenance.md) for the full verification contract and
+[docs/install-lifecycle.md](install-lifecycle.md) for the day-two lifecycle.
 
 On supported macOS hosts, the installer uses Homebrew to install only the
 missing required packages (`colima`, `docker`, `gh`, `git`, `go`). Use

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,16 +50,21 @@ default). For a strictly offline/air-gapped install, omit that step — the cosi
 signature over `SHA256SUMS` plus the digest check is the offline-capable core
 guarantee — or pass a locally downloaded attestation with `--bundle`:
 
+The identity regex below is **anchored and escaped** (`^…\.…$`) so only the
+release tag is a wildcard — the exact pin `verify-release-artifact.sh` uses, not
+the illustrative unescaped form elsewhere in the docs (an unescaped `.` matches
+any character and can over-match the identity):
+
 ```bash
 cosign verify-blob SHA256SUMS \
   --bundle SHA256SUMS.sigstore.json \
-  --certificate-identity-regexp 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
+  --certificate-identity-regexp '^https://github\.com/omkhar/workcell/\.github/workflows/release\.yml@refs/tags/.+$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 shasum -a 256 --ignore-missing -c SHA256SUMS
-# needs network; pins the same anchored identity regex + OIDC issuer that
+# needs network; pins the same anchored/escaped identity regex + OIDC issuer that
 # install-release.sh --attestation uses (not --signer-workflow, which can over-match).
 gh attestation verify workcell-vX.Y.Z.tar.gz --repo omkhar/workcell \
-  --cert-identity-regex 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
+  --cert-identity-regex '^https://github\.com/omkhar/workcell/\.github/workflows/release\.yml@refs/tags/.+$' \
   --cert-oidc-issuer https://token.actions.githubusercontent.com
 tar -xzf workcell-vX.Y.Z.tar.gz
 cd workcell-vX.Y.Z

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,10 +40,15 @@ cd workcell
 bundle is refused before its (also-tampered) installer could run — this is why
 verifying before extraction is sound.
 
-**Manual equivalent** (from the release page directly, air-gapped, or to inspect
-each step): download the bundle plus `SHA256SUMS` and `SHA256SUMS.sigstore.json`
-from GitHub Releases and verify before unpacking. This mirrors the
-`--attestation` flow, so it includes the `gh attestation verify` gate:
+**Manual equivalent** (from the release page directly, or to inspect each step):
+download the bundle plus `SHA256SUMS` and `SHA256SUMS.sigstore.json` from GitHub
+Releases and verify before unpacking. The `cosign verify-blob` and `shasum`
+steps verify offline against the downloaded Sigstore bundle; the
+`gh attestation verify` step below mirrors the `--attestation` gate but
+**requires network access** (it fetches the attestation from the GitHub API by
+default). For a strictly offline/air-gapped install, omit that step — the cosign
+signature over `SHA256SUMS` plus the digest check is the offline-capable core
+guarantee — or pass a locally downloaded attestation with `--bundle`:
 
 ```bash
 cosign verify-blob SHA256SUMS \
@@ -52,7 +57,7 @@ cosign verify-blob SHA256SUMS \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 shasum -a 256 --ignore-missing -c SHA256SUMS
 gh attestation verify workcell-vX.Y.Z.tar.gz --repo omkhar/workcell \
-  --signer-workflow omkhar/workcell/.github/workflows/release.yml
+  --signer-workflow omkhar/workcell/.github/workflows/release.yml  # needs network
 tar -xzf workcell-vX.Y.Z.tar.gz
 cd workcell-vX.Y.Z
 ./scripts/install.sh

--- a/docs/install-lifecycle.md
+++ b/docs/install-lifecycle.md
@@ -133,10 +133,13 @@ Recorded local-operator certification on the maintainer host
 ## Relationship to forced consumer verification (CI threat model gap 1)
 
 [ci-threat-model.md](ci-threat-model.md) tracks, as known gap 1, that verified
-install is not yet the *forced* default across all documented install paths. The
-end-to-end fixture proof above closes the CI-automatable half of that gap's
-"exercise `install-release.sh` end to end" requirement — a tampered or
-unsigned bundle cannot reach the bundle installer. Fully closing the gap still
-requires making verification the forced default across all documented flows and
-exercising the verified path against a real published release; both are recorded
-in the remainder above.
+install — now the *documented default* — is not yet *forced* across all
+documented install paths. The end-to-end fixture proof above closes the
+CI-automatable half of that gap's "exercise `install-release.sh` end to end"
+requirement — a tampered or unsigned bundle cannot reach the bundle installer —
+and the "against a real published release" half is now done (the Certification
+record above: `install-release.sh --attestation` against the published
+`v1.0.0-rc.2`). Fully closing the gap now requires only making verification the
+*forced* default across all flows and shipping a standalone verified installer
+bootstrap (so consumers need not clone the repo to obtain a trusted
+`install-release.sh`).

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -276,6 +276,8 @@ evidence = [
   "internal/testkit/release_verify_test.go",
 ]
 docs = [
+  "README.md",
+  "docs/getting-started.md",
   "docs/install.md",
   "docs/provenance.md",
   "docs/ci-threat-model.md",


### PR DESCRIPTION
## Summary

Closes ci-threat-model **gap 1a**: verified install is now the *default* recommended path across the documented install flows, instead of leading with the unverified manual unpack + `install.sh` (or a hand-run cosign dance a user could skip).

`install-release.sh --version vX.Y.Z --attestation` — which downloads a tagged release, verifies its cosign signature + digest (+ attestation) **fail-closed before any bundle code runs**, then installs — now leads:

- the README **5-minute path** (a one-line pointer),
- the README **## Install** section (as the recommended command), and
- **getting-started.md Option A** (recommended, with the manual step-by-step kept as the air-gapped / inspect-each-step alternative).

This is well-motivated now that `install-release.sh` is certified end-to-end against the published `v1.0.0-rc.2` release (see `docs/install-lifecycle.md` §"Certification record").

## Validation

Verified the documented flags (`--attestation`, `-- INSTALLER_ARGS` forwarding) exist in `scripts/install-release.sh`. markdownlint + codespell + check-doc-links clean; `scripts/pre-merge.sh --profile pr-parity` exit 0. Doc-only.
