### PR TITLE
Complete the readiness known-gaps surface: CI-runner egress (GAP-4) + D5/D7 post-1.0 scope

### DIFF
--- a/docs/1.0-readiness-review-draft.md
+++ b/docs/1.0-readiness-review-draft.md
@@ -158,6 +158,14 @@ Grounded in `ROADMAP.md` Non-Goals plus verification of what is on `main`:
 - **D3 (complete) / D6:** see the D3 and D6 status notes in
   `docs/improvement-tracks-implementation-plan.md` — both have literal-exit-gate
   scope decisions pending for this review.
+- **D5 / D7 shell-unit lane — carried to post-1.0 (accepted):** D5 (Rust
+  interception-library modularization) is partial — the git-policy module is
+  extracted (`runtime/container/rust/src/gitpolicy.rs`), but `lib.rs` (~2.2k
+  lines) is not yet split into the full focused-module set; the remaining splits
+  are deferred post-1.0 (the exported ABI and A3/A4 safety nets are intact). D7's
+  property-based session tests and Go benchmarks shipped, but its **shell
+  unit-test lane** (bats-style coverage of the D2 shared shell helpers) is not
+  shipped and is deferred post-1.0. Neither blocks 1.0.
 
 ## 6. Go / no-go checklist for the maintainer (G4)
 

--- a/docs/1.0-readiness-review-draft.md
+++ b/docs/1.0-readiness-review-draft.md
@@ -162,10 +162,12 @@ Grounded in `ROADMAP.md` Non-Goals plus verification of what is on `main`:
   interception-library modularization) is partial — the git-policy module is
   extracted (`runtime/container/rust/src/gitpolicy.rs`), but `lib.rs` (~2.2k
   lines) is not yet split into the full focused-module set; the remaining splits
-  are deferred post-1.0 (the exported ABI and A3/A4 safety nets are intact). D7's
-  property-based session tests and Go benchmarks shipped, but its **shell
-  unit-test lane** (bats-style coverage of the D2 shared shell helpers) is not
-  shipped and is deferred post-1.0. Neither blocks 1.0.
+  are deferred post-1.0 (the exported ABI and A3/A4 safety nets are intact). For
+  D7, the property-based session-lifecycle tests shipped
+  (`internal/host/sessions/lifecycle_property_test.go`), but its **Go benchmarks**
+  (no `func Benchmark*` exists in the tree) and its **shell unit-test lane**
+  (bats-style coverage of the D2 shared shell helpers) are not shipped and are
+  deferred post-1.0. Neither blocks 1.0.
 
 ## 6. Go / no-go checklist for the maintainer (G4)
 

--- a/docs/1.0-readiness-review-draft.md
+++ b/docs/1.0-readiness-review-draft.md
@@ -145,6 +145,13 @@ Grounded in `ROADMAP.md` Non-Goals plus verification of what is on `main`:
 - **C3 parallel sessions:** 1.0 delivers container-level isolation on the strict
   path; full worktree-per-agent isolation should be verified against the
   criterion before sign-off.
+- **No CI-runner egress hardening (accepted for 1.0):** GitHub-hosted CI runners
+  have no `step-security/harden-runner` or equivalent egress allowlist, so a
+  compromised build step has open network egress (the runtime *product* sandbox's
+  default-deny egress is a separate control). This is a re-affirmed accepted risk
+  for 1.0, mitigated by all-GitHub-hosted ephemeral single-use runners,
+  least-privilege per-job tokens, `persist-credentials: false`, and pinned
+  actions/tools — see `docs/ci-threat-model.md` threat 4 / known gap 4.
 - **G1 freeze (part 2):** the contract *inventory* exists; the *freeze* +
   deprecation policy is the v1.0-rc G1 step and is intentionally LAST (after A5
   and the contract surface settle). Do not run the freeze before then.

--- a/docs/1.0-readiness-review-draft.md
+++ b/docs/1.0-readiness-review-draft.md
@@ -164,10 +164,13 @@ Grounded in `ROADMAP.md` Non-Goals plus verification of what is on `main`:
   lines) is not yet split into the full focused-module set; the remaining splits
   are deferred post-1.0 (the exported ABI and A3/A4 safety nets are intact). For
   D7, the property-based session-lifecycle tests shipped
-  (`internal/host/sessions/lifecycle_property_test.go`), but its **Go benchmarks**
-  (no `func Benchmark*` exists in the tree) and its **shell unit-test lane**
-  (bats-style coverage of the D2 shared shell helpers) are not shipped and are
-  deferred post-1.0. Neither blocks 1.0.
+  (`internal/host/sessions/lifecycle_property_test.go`) and the shared shell
+  helpers have unit coverage via the repo-required `shared/shellproto-lib`
+  scenario (`tests/scenarios/shared/test-shellproto-lib.sh` exercises
+  `scripts/lib/shellproto.sh`). What remains deferred post-1.0 is D7's **Go
+  benchmarks** (no `func Benchmark*` exists in the tree) and a **broader
+  bats-style unit lane** over the full set of D2 shared shell helpers. Neither
+  blocks 1.0.
 
 ## 6. Go / no-go checklist for the maintainer (G4)
 


### PR DESCRIPTION
Two STEP-E readiness additions to `docs/1.0-readiness-review-draft.md` §5:

- **GAP-4**: re-affirm the CI-runner egress-hardening gap (ci-threat-model.md threat 4 / known gap 4 — no harden-runner allowlist on GitHub-hosted runners) as an accepted 1.0 risk, with its mitigations (all-GitHub-hosted ephemeral runners, least-privilege tokens, persist-credentials:false, pinned actions/tools).
- **D5 / D7 shell-lane**: record the post-1.0 scope decisions — D5 Rust-library modularization is partial (gitpolicy.rs extracted, lib.rs still ~2.2k lines), and D7's bats-style shell unit-test lane does not exist; both deferred, verified against source.

markdownlint + codespell + check-doc-links clean; pre-merge pr-parity exit 0. Doc-only.