### PR TITLE
Publish the G1 deprecation policy in the stability contract

### DIFF
--- a/docs/stability-contract.md
+++ b/docs/stability-contract.md
@@ -21,10 +21,13 @@ not a stability promise.
 ## Deprecation policy
 
 From 1.0 onward Workcell follows [semantic versioning](https://semver.org). The
-stable surfaces enumerated in this document and enforced by
-`policy/public-contract.toml` — the exit-code contract, the machine-readable
-output-line prefixes, the session-record/export field set, and the
-injection-policy table — carry a compatibility guarantee within a major version:
+stable surfaces enumerated in this document carry a compatibility guarantee
+within a major version: the exit-code contract, the machine-readable output-line
+prefixes, the session-record/export field set, and the injection-policy table
+(enforced by `policy/public-contract.toml`), together with the stable
+`scripts/workcell` CLI flags and subcommands documented under
+[CLI stability](#cli-stability) (enforced via `policy/operator-contract.toml`).
+The guarantee:
 
 - **No breaking change to a stable surface ships in a patch or minor release.**
   A new field or prefix may be *added*; an existing one is not renamed, removed,

--- a/docs/stability-contract.md
+++ b/docs/stability-contract.md
@@ -18,6 +18,34 @@ whitelist in code.
 "Experimental" means it may change or be removed. Absence from this document is
 not a stability promise.
 
+## Deprecation policy
+
+From 1.0 onward Workcell follows [semantic versioning](https://semver.org). The
+stable surfaces enumerated in this document and enforced by
+`policy/public-contract.toml` — the exit-code contract, the machine-readable
+output-line prefixes, the session-record/export field set, and the
+injection-policy table — carry a compatibility guarantee within a major version:
+
+- **No breaking change to a stable surface ships in a patch or minor release.**
+  A new field or prefix may be *added*; an existing one is not renamed, removed,
+  or given a changed meaning except across a major version bump.
+- **Deprecations are announced before removal.** A stable surface slated for
+  removal is first marked deprecated in [`CHANGELOG.md`](../CHANGELOG.md) and,
+  where it has a runtime presence, emits a documented deprecation notice. It
+  keeps working for at least one subsequent minor release, and its removal lands
+  only in a major version bump.
+- **Experimental surfaces** (labeled "Experimental" here, and anything absent
+  from this document) carry no such guarantee and may change or be removed in any
+  release.
+- **A security fix may override this policy** when a stable surface is itself the
+  vulnerability; any such change is called out in [`CHANGELOG.md`](../CHANGELOG.md)
+  and [`SECURITY.md`](../SECURITY.md).
+
+Workcell is currently in single-maintainer release mode
+([`SECURITY.md`](../SECURITY.md#supported-versions)), so only the latest release
+receives fixes; track it and read [`CHANGELOG.md`](../CHANGELOG.md) for
+deprecations before upgrading.
+
 ## Exit-code contract
 
 The canonical convention across every entrypoint:


### PR DESCRIPTION
G1 freeze prep (no version bump — that stays with the maintainer's release cut).

`docs/stability-contract.md` referenced deprecation notes and said 'G1 extends it into the versioned 1.0 contract', but never defined the policy. Adds a **Deprecation policy** section stating the 1.0-onward semver compatibility guarantee for the stable surfaces enforced by `policy/public-contract.toml`:

- no breaking change to a stable surface in a patch/minor release (additive-only);
- deprecations announced in CHANGELOG + a runtime notice, kept working ≥1 subsequent minor, removed only in a major bump;
- experimental surfaces excluded; a security fix may override with a CHANGELOG/SECURITY.md callout;
- cross-references SECURITY.md's single-maintainer supported-versions posture.

markdownlint + codespell + check-doc-links clean; pre-merge pr-parity exit 0. Doc-only.