### PR TITLE
Refresh Debian bootstrap pins safely

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -77,6 +77,7 @@ func subcommands() []subcommand {
 		{"check-provider-bump-policy", "POLICY_PATH DOCKERFILE PROVIDERS_PACKAGE_JSON", 3, 3, cmdCheckProviderBumpPolicy},
 		{"provider-bump-plan", "POLICY_PATH DOCKERFILE PROVIDERS_PACKAGE_JSON [NOW_RFC3339]", 3, 4, cmdProviderBumpPlan},
 		{"apply-provider-bump-plan", "PLAN_PATH POLICY_PATH DOCKERFILE PROVIDERS_PACKAGE_JSON", 4, 4, cmdApplyProviderBumpPlan},
+		{"resolve-debian-bootstrap", "SNAPSHOT", 1, 1, cmdResolveDebianBootstrap},
 		{"generate-build-input-manifest", "DOCKERFILE PACKAGE_JSON PACKAGE_LOCK OUTPUT BUILD_REF SOURCE_DATE_EPOCH REQUIRE_TRACKED", 7, 7, cmdGenerateBuildInputManifest},
 		{"generate-builder-environment-manifest", "OUTPUT BUILDKIT_IMAGE BUILDX_VERSION_TARGET COSIGN_VERSION_TARGET QEMU_IMAGE SYFT_VERSION_TARGET BUILDX_VERSION BUILDX_INSPECT DOCKER_VERSION_JSON QEMU_VERSION COSIGN_VERSION CURL_VERSION GIT_VERSION GZIP_VERSION SYFT_VERSION TAR_VERSION", 16, 16, cmdGenerateBuilderEnvironmentManifest},
 		{"check-pinned-inputs", "DOCKERFILE VALIDATOR_DOCKERFILE PROVIDERS_PACKAGE_JSON PROVIDERS_PACKAGE_LOCK WORKFLOWS_DIR CI_WORKFLOW RELEASE_WORKFLOW PIN_HYGIENE_WORKFLOW CODEOWNERS CODEX_REQUIREMENTS CODEX_MCP_CONFIG HOSTED_CONTROLS_POLICY HOSTED_CONTROLS_SCRIPT PROVIDER_BUMP_POLICY MAX_DEBIAN_SNAPSHOT_AGE_DAYS", 15, 15, cmdCheckPinnedInputs},
@@ -316,6 +317,16 @@ func cmdExtractCopilotSHA(args []string) error {
 	}
 	fmt.Println(value)
 	return nil
+}
+
+func cmdResolveDebianBootstrap(args []string) error {
+	pins, err := metadatautil.ResolveDefaultDebianBootstrapPins(args[0])
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(pins)
 }
 
 func cmdManifestChecksum(args []string) error {

--- a/internal/metadatautil/debian_bootstrap.go
+++ b/internal/metadatautil/debian_bootstrap.go
@@ -1,0 +1,430 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"bufio"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	debianSnapshotArchiveBase = "https://snapshot.debian.org/archive/debian"
+	maxPackagesGzipBytes      = 64 << 20
+	maxPackagesDecodedBytes   = 512 << 20
+	maxPackagesLineBytes      = 1 << 20
+	maxPackagesStanzaBytes    = 4 << 20
+	maxPackagesStanzaFields   = 256
+	maxPackagesStanzaLines    = 4096
+	maxBootstrapPackageBytes  = 128 << 20
+)
+
+var (
+	debianSnapshotPattern       = regexp.MustCompile(`^[0-9]{8}T[0-9]{6}Z$`)
+	debianDigestPattern         = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	debianSafeFilenamePattern   = regexp.MustCompile(`^pool/[A-Za-z0-9.+~_/-]+\.deb$`)
+	debianOpenSSLAMD64Pattern   = regexp.MustCompile(`^pool/main/o/openssl/openssl_[A-Za-z0-9.+~_-]+_amd64\.deb$`)
+	debianOpenSSLARM64Pattern   = regexp.MustCompile(`^pool/main/o/openssl/openssl_[A-Za-z0-9.+~_-]+_arm64\.deb$`)
+	debianCACertificatesPattern = regexp.MustCompile(`^pool/main/c/ca-certificates/ca-certificates_[A-Za-z0-9.+~_-]+_all\.deb$`)
+)
+
+// DebianBootstrapPackage is the immutable package record taken from a Debian
+// snapshot Packages.gz index and verified against the referenced .deb bytes.
+type DebianBootstrapPackage struct {
+	Version      string `json:"version"`
+	Architecture string `json:"architecture"`
+	Filename     string `json:"filename"`
+	SHA256       string `json:"sha256"`
+	Size         int64  `json:"size"`
+}
+
+// DebianBootstrapPins is the complete resolved snapshot TLS bootstrap tuple.
+type DebianBootstrapPins struct {
+	Snapshot       string                 `json:"snapshot"`
+	OpenSSLAMD64   DebianBootstrapPackage `json:"openssl_amd64"`
+	OpenSSLARM64   DebianBootstrapPackage `json:"openssl_arm64"`
+	CACertificates DebianBootstrapPackage `json:"ca_certificates"`
+}
+
+type debianPackageIndex struct {
+	OpenSSL        DebianBootstrapPackage
+	CACertificates DebianBootstrapPackage
+}
+
+// ResolveDebianBootstrapPins resolves and byte-verifies the package tuple for
+// one snapshot. A snapshot is unsuitable unless both architecture indexes
+// contain the same OpenSSL version and agree on the architecture-independent
+// CA package. Packages.gz is trusted through authenticated HTTPS from the
+// configured snapshot endpoint; this resolver does not claim independent
+// Debian OpenPGP verification of that metadata.
+func ResolveDebianBootstrapPins(ctx context.Context, client *http.Client, archiveBaseURL, snapshot string) (DebianBootstrapPins, error) {
+	var zero DebianBootstrapPins
+	if err := validateDebianSnapshot(snapshot); err != nil {
+		return zero, err
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 120 * time.Second}
+	}
+	archiveBaseURL = strings.TrimRight(archiveBaseURL, "/")
+	if err := validateHTTPBaseURL(archiveBaseURL); err != nil {
+		return zero, err
+	}
+	parsedBaseURL, _ := url.Parse(archiveBaseURL)
+	client = restrictDebianRedirects(client, parsedBaseURL)
+
+	amd64, err := fetchDebianPackageIndex(ctx, client, archiveBaseURL, snapshot, "amd64")
+	if err != nil {
+		return zero, fmt.Errorf("resolve amd64 bootstrap packages: %w", err)
+	}
+	arm64, err := fetchDebianPackageIndex(ctx, client, archiveBaseURL, snapshot, "arm64")
+	if err != nil {
+		return zero, fmt.Errorf("resolve arm64 bootstrap packages: %w", err)
+	}
+	if amd64.OpenSSL.Version != arm64.OpenSSL.Version {
+		return zero, fmt.Errorf("OpenSSL version disagreement between amd64 (%s) and arm64 (%s)", amd64.OpenSSL.Version, arm64.OpenSSL.Version)
+	}
+	if amd64.CACertificates != arm64.CACertificates {
+		return zero, errors.New("ca-certificates metadata disagreement between amd64 and arm64 Packages.gz indexes")
+	}
+
+	pins := DebianBootstrapPins{
+		Snapshot:       snapshot,
+		OpenSSLAMD64:   amd64.OpenSSL,
+		OpenSSLARM64:   arm64.OpenSSL,
+		CACertificates: amd64.CACertificates,
+	}
+	if err := validateDebianBootstrapPins(pins); err != nil {
+		return zero, err
+	}
+	for _, pkg := range []DebianBootstrapPackage{pins.OpenSSLAMD64, pins.OpenSSLARM64, pins.CACertificates} {
+		if err := verifyDebianPackageBytes(ctx, client, archiveBaseURL, snapshot, pkg); err != nil {
+			return zero, err
+		}
+	}
+	return pins, nil
+}
+
+// ResolveDefaultDebianBootstrapPins uses the reviewed snapshot.debian.org
+// archive endpoint for the resolver command.
+func ResolveDefaultDebianBootstrapPins(snapshot string) (DebianBootstrapPins, error) {
+	return ResolveDebianBootstrapPins(context.Background(), nil, debianSnapshotArchiveBase, snapshot)
+}
+
+func validateHTTPBaseURL(raw string) error {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("invalid Debian archive base URL %q", raw)
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("Debian archive base URL must use HTTPS: %q", raw)
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("Debian archive base URL must not contain userinfo, a query, or a fragment: %q", raw)
+	}
+	return nil
+}
+
+func restrictDebianRedirects(client *http.Client, baseURL *url.URL) *http.Client {
+	restricted := *client
+	original := restricted.CheckRedirect
+	restricted.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req.URL.Scheme != "https" || !strings.EqualFold(req.URL.Host, baseURL.Host) || req.URL.User != nil {
+			return fmt.Errorf("refuse Debian archive redirect outside reviewed HTTPS origin: %s", req.URL.Redacted())
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 Debian archive redirects")
+		}
+		if original != nil {
+			return original(req, via)
+		}
+		return nil
+	}
+	return &restricted
+}
+
+func fetchDebianPackageIndex(ctx context.Context, client *http.Client, archiveBaseURL, snapshot, architecture string) (debianPackageIndex, error) {
+	var zero debianPackageIndex
+	indexURL := fmt.Sprintf("%s/%s/dists/trixie/main/binary-%s/Packages.gz", archiveBaseURL, snapshot, architecture)
+	body, err := fetchBounded(ctx, client, indexURL, maxPackagesGzipBytes)
+	if err != nil {
+		return zero, err
+	}
+	defer body.Close()
+
+	gz, err := gzip.NewReader(body)
+	if err != nil {
+		return zero, fmt.Errorf("open %s as gzip: %w", indexURL, err)
+	}
+	defer gz.Close()
+
+	var opensslMatches []DebianBootstrapPackage
+	var caMatches []DebianBootstrapPackage
+	err = scanDebianPackageStanzas(io.LimitReader(gz, maxPackagesDecodedBytes+1), func(stanza map[string]string) error {
+		switch {
+		case stanza["Package"] == "openssl" && stanza["Architecture"] == architecture:
+			pkg, err := debianPackageFromStanza(stanza)
+			if err != nil {
+				return fmt.Errorf("openssl/%s: %w", architecture, err)
+			}
+			opensslMatches = append(opensslMatches, pkg)
+		case stanza["Package"] == "ca-certificates" && stanza["Architecture"] == "all":
+			pkg, err := debianPackageFromStanza(stanza)
+			if err != nil {
+				return fmt.Errorf("ca-certificates/all: %w", err)
+			}
+			caMatches = append(caMatches, pkg)
+		}
+		return nil
+	})
+	if err != nil {
+		return zero, fmt.Errorf("parse %s: %w", indexURL, err)
+	}
+	opensslPackage, err := uniqueDebianPackage(opensslMatches, "openssl", architecture)
+	if err != nil {
+		return zero, err
+	}
+	caPackage, err := uniqueDebianPackage(caMatches, "ca-certificates", "all")
+	if err != nil {
+		return zero, err
+	}
+	return debianPackageIndex{OpenSSL: opensslPackage, CACertificates: caPackage}, nil
+}
+
+func fetchBounded(ctx context.Context, client *http.Client, rawURL string, maxBytes int64) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept-Encoding", "identity")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", rawURL, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("GET %s: unexpected status %s", rawURL, resp.Status)
+	}
+	if resp.ContentLength > maxBytes {
+		resp.Body.Close()
+		return nil, fmt.Errorf("GET %s: response exceeds %d-byte limit", rawURL, maxBytes)
+	}
+	return &boundedReadCloser{Reader: io.LimitReader(resp.Body, maxBytes+1), Closer: resp.Body, max: maxBytes}, nil
+}
+
+type boundedReadCloser struct {
+	io.Reader
+	io.Closer
+	max  int64
+	read int64
+}
+
+func (r *boundedReadCloser) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	r.read += int64(n)
+	if r.read > r.max {
+		return n, fmt.Errorf("response exceeds %d-byte limit", r.max)
+	}
+	return n, err
+}
+
+func scanDebianPackageStanzas(reader io.Reader, visit func(map[string]string) error) error {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64<<10), maxPackagesLineBytes)
+	current := make(map[string]string)
+	lineNumber := 0
+	decodedBytes := int64(0)
+	stanzaBytes := int64(0)
+	stanzaLines := 0
+	lastField := ""
+	flush := func() error {
+		if len(current) > 0 {
+			if err := visit(current); err != nil {
+				return err
+			}
+			current = make(map[string]string)
+		}
+		stanzaBytes = 0
+		stanzaLines = 0
+		return nil
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		lineNumber++
+		decodedBytes += int64(len(line)) + 1
+		stanzaBytes += int64(len(line)) + 1
+		stanzaLines++
+		if decodedBytes > maxPackagesDecodedBytes {
+			return fmt.Errorf("decoded Packages metadata exceeds %d-byte limit", maxPackagesDecodedBytes)
+		}
+		if stanzaBytes > maxPackagesStanzaBytes {
+			return fmt.Errorf("line %d: package stanza exceeds %d-byte limit", lineNumber, maxPackagesStanzaBytes)
+		}
+		if stanzaLines > maxPackagesStanzaLines {
+			return fmt.Errorf("line %d: package stanza exceeds %d-line limit", lineNumber, maxPackagesStanzaLines)
+		}
+		line = strings.TrimSuffix(line, "\r")
+		switch {
+		case line == "":
+			if err := flush(); err != nil {
+				return err
+			}
+			lastField = ""
+		case strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t"):
+			if lastField == "" {
+				return fmt.Errorf("line %d: continuation without a field", lineNumber)
+			}
+			// Folded fields are legal Debian control syntax, but all fields used
+			// for the bootstrap security decision are scalar. Ignore bounded
+			// continuation bytes for unrelated fields because none are consumed.
+			if isDebianBootstrapScalarField(lastField) {
+				return fmt.Errorf("line %d: continuation is not allowed for scalar field %s", lineNumber, lastField)
+			}
+		default:
+			name, value, ok := strings.Cut(line, ":")
+			if !ok || name == "" || strings.TrimSpace(name) != name {
+				return fmt.Errorf("line %d: malformed field", lineNumber)
+			}
+			if _, duplicate := current[name]; duplicate {
+				return fmt.Errorf("line %d: duplicate field %s", lineNumber, name)
+			}
+			if len(current) >= maxPackagesStanzaFields {
+				return fmt.Errorf("line %d: package stanza exceeds %d-field limit", lineNumber, maxPackagesStanzaFields)
+			}
+			current[name] = strings.TrimSpace(value)
+			lastField = name
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan Packages metadata: %w", err)
+	}
+	return flush()
+}
+
+func isDebianBootstrapScalarField(name string) bool {
+	switch name {
+	case "Package", "Version", "Architecture", "Filename", "Size", "SHA256":
+		return true
+	default:
+		return false
+	}
+}
+
+func uniqueDebianPackage(matches []DebianBootstrapPackage, packageName, architecture string) (DebianBootstrapPackage, error) {
+	if len(matches) != 1 {
+		return DebianBootstrapPackage{}, fmt.Errorf("expected exactly one %s/%s package, found %d", packageName, architecture, len(matches))
+	}
+	return matches[0], nil
+}
+
+func debianPackageFromStanza(stanza map[string]string) (DebianBootstrapPackage, error) {
+	pkg := DebianBootstrapPackage{
+		Version:      stanza["Version"],
+		Architecture: stanza["Architecture"],
+		Filename:     stanza["Filename"],
+		SHA256:       stanza["SHA256"],
+	}
+	if pkg.Version == "" || pkg.Architecture == "" || pkg.Filename == "" || pkg.SHA256 == "" || stanza["Size"] == "" {
+		return DebianBootstrapPackage{}, errors.New("missing Version, Architecture, Filename, SHA256, or Size")
+	}
+	clean := path.Clean(pkg.Filename)
+	if clean != pkg.Filename || strings.HasPrefix(clean, "/") || strings.HasPrefix(clean, "../") || !debianSafeFilenamePattern.MatchString(clean) {
+		return DebianBootstrapPackage{}, fmt.Errorf("unsafe package filename %q", pkg.Filename)
+	}
+	if !debianDigestPattern.MatchString(pkg.SHA256) {
+		return DebianBootstrapPackage{}, fmt.Errorf("malformed SHA256 %q", pkg.SHA256)
+	}
+	size, err := strconv.ParseInt(stanza["Size"], 10, 64)
+	if err != nil || size <= 0 || size > maxBootstrapPackageBytes {
+		return DebianBootstrapPackage{}, fmt.Errorf("invalid package Size %q", stanza["Size"])
+	}
+	pkg.Size = size
+	return pkg, nil
+}
+
+func verifyDebianPackageBytes(ctx context.Context, client *http.Client, archiveBaseURL, snapshot string, pkg DebianBootstrapPackage) error {
+	rawURL := fmt.Sprintf("%s/%s/%s", archiveBaseURL, snapshot, pkg.Filename)
+	body, err := fetchBounded(ctx, client, rawURL, pkg.Size)
+	if err != nil {
+		return fmt.Errorf("verify %s: %w", pkg.Filename, err)
+	}
+	defer body.Close()
+	hash := sha256.New()
+	written, err := io.Copy(hash, body)
+	if err != nil {
+		return fmt.Errorf("verify %s: %w", pkg.Filename, err)
+	}
+	if written != pkg.Size {
+		return fmt.Errorf("verify %s: size mismatch: metadata=%d downloaded=%d", pkg.Filename, pkg.Size, written)
+	}
+	got := hex.EncodeToString(hash.Sum(nil))
+	if got != pkg.SHA256 {
+		return fmt.Errorf("verify %s: SHA256 mismatch: metadata=%s downloaded=%s", pkg.Filename, pkg.SHA256, got)
+	}
+	return nil
+}
+
+func validateDebianBootstrapPins(pins DebianBootstrapPins) error {
+	if err := validateDebianSnapshot(pins.Snapshot); err != nil {
+		return err
+	}
+	checks := []struct {
+		pkg  DebianBootstrapPackage
+		name string
+		arch string
+		path *regexp.Regexp
+	}{
+		{pins.OpenSSLAMD64, "openssl", "amd64", debianOpenSSLAMD64Pattern},
+		{pins.OpenSSLARM64, "openssl", "arm64", debianOpenSSLARM64Pattern},
+		{pins.CACertificates, "ca-certificates", "all", debianCACertificatesPattern},
+	}
+	for _, check := range checks {
+		if check.pkg.Version == "" || len(check.pkg.Version) > 256 {
+			return fmt.Errorf("invalid %s/%s Version", check.name, check.arch)
+		}
+		if check.pkg.Architecture != check.arch {
+			return fmt.Errorf("invalid %s/%s Architecture %q", check.name, check.arch, check.pkg.Architecture)
+		}
+		if !check.path.MatchString(check.pkg.Filename) || path.Clean(check.pkg.Filename) != check.pkg.Filename {
+			return fmt.Errorf("invalid %s/%s Filename %q", check.name, check.arch, check.pkg.Filename)
+		}
+		if !debianDigestPattern.MatchString(check.pkg.SHA256) {
+			return fmt.Errorf("invalid %s/%s SHA256", check.name, check.arch)
+		}
+		if check.pkg.Size <= 0 || check.pkg.Size > maxBootstrapPackageBytes {
+			return fmt.Errorf("invalid %s/%s Size %d", check.name, check.arch, check.pkg.Size)
+		}
+	}
+	if pins.OpenSSLAMD64.Version != pins.OpenSSLARM64.Version {
+		return errors.New("OpenSSL versions must agree across architectures")
+	}
+	amd64Stem := strings.TrimSuffix(pins.OpenSSLAMD64.Filename, "_amd64.deb")
+	arm64Stem := strings.TrimSuffix(pins.OpenSSLARM64.Filename, "_arm64.deb")
+	if amd64Stem != arm64Stem {
+		return errors.New("OpenSSL package filename versions must agree across architectures")
+	}
+	return nil
+}
+
+func validateDebianSnapshot(snapshot string) error {
+	if !debianSnapshotPattern.MatchString(snapshot) {
+		return fmt.Errorf("invalid Debian snapshot timestamp %q", snapshot)
+	}
+	if _, err := time.Parse("20060102T150405Z", snapshot); err != nil {
+		return fmt.Errorf("invalid Debian snapshot timestamp %q", snapshot)
+	}
+	return nil
+}

--- a/internal/metadatautil/debian_bootstrap_test.go
+++ b/internal/metadatautil/debian_bootstrap_test.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const testDebianSnapshot = "20260720T000000Z"
+
+type debianFixturePackage struct {
+	name         string
+	version      string
+	architecture string
+	filename     string
+	content      []byte
+	digest       string
+	size         int64
+}
+
+func (p debianFixturePackage) sha256() string {
+	if p.digest != "" {
+		return p.digest
+	}
+	sum := sha256.Sum256(p.content)
+	return hex.EncodeToString(sum[:])
+}
+
+func (p debianFixturePackage) metadataSize() int64 {
+	if p.size != 0 {
+		return p.size
+	}
+	return int64(len(p.content))
+}
+
+func TestResolveDebianBootstrapPinsHandlesPackageRotation(t *testing.T) {
+	amd64 := debianFixturePackage{
+		name: "openssl", version: "3.5.9-1~deb13u2", architecture: "amd64",
+		filename: "pool/main/o/openssl/openssl_3.5.9-1~deb13u2_amd64.deb", content: []byte("openssl-amd64-rotated"),
+	}
+	arm64 := debianFixturePackage{
+		name: "openssl", version: "3.5.9-1~deb13u2", architecture: "arm64",
+		filename: "pool/main/o/openssl/openssl_3.5.9-1~deb13u2_arm64.deb", content: []byte("openssl-arm64-rotated"),
+	}
+	ca := debianFixturePackage{
+		name: "ca-certificates", version: "20260701", architecture: "all",
+		filename: "pool/main/c/ca-certificates/ca-certificates_20260701_all.deb", content: []byte("ca-certificates-rotated"),
+	}
+	client := newDebianFixtureClient(t, []debianFixturePackage{amd64, ca}, []debianFixturePackage{arm64, ca})
+
+	pins, err := ResolveDebianBootstrapPins(context.Background(), client, "https://snapshot.test/archive/debian", testDebianSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pins.OpenSSLAMD64.Filename != amd64.filename || pins.OpenSSLARM64.Filename != arm64.filename || pins.CACertificates.Filename != ca.filename {
+		t.Fatalf("resolved package rotation incorrectly: %#v", pins)
+	}
+	if pins.OpenSSLAMD64.SHA256 != amd64.sha256() || pins.OpenSSLARM64.SHA256 != arm64.sha256() || pins.CACertificates.SHA256 != ca.sha256() {
+		t.Fatalf("resolved package digests incorrectly: %#v", pins)
+	}
+}
+
+func TestResolveDebianBootstrapPinsRejectsMissingArchitecture(t *testing.T) {
+	ca := debianFixturePackage{name: "ca-certificates", version: "1", architecture: "all", filename: "pool/main/c/ca-certificates/ca-certificates_1_all.deb", content: []byte("ca")}
+	amd64 := debianFixturePackage{name: "openssl", version: "1", architecture: "amd64", filename: "pool/main/o/openssl/openssl_1_amd64.deb", content: []byte("amd64")}
+	client := newDebianFixtureClient(t, []debianFixturePackage{amd64, ca}, []debianFixturePackage{ca})
+
+	_, err := ResolveDebianBootstrapPins(context.Background(), client, "https://snapshot.test/archive/debian", testDebianSnapshot)
+	if err == nil || !strings.Contains(err.Error(), "expected exactly one openssl/arm64 package") {
+		t.Fatalf("missing arm64 package error = %v", err)
+	}
+}
+
+func TestResolveDebianBootstrapPinsRejectsCADigestDisagreement(t *testing.T) {
+	amd64 := debianFixturePackage{name: "openssl", version: "1", architecture: "amd64", filename: "pool/main/o/openssl/openssl_1_amd64.deb", content: []byte("amd64")}
+	arm64 := debianFixturePackage{name: "openssl", version: "1", architecture: "arm64", filename: "pool/main/o/openssl/openssl_1_arm64.deb", content: []byte("arm64")}
+	caAMD64 := debianFixturePackage{name: "ca-certificates", version: "1", architecture: "all", filename: "pool/main/c/ca-certificates/ca-certificates_1_all.deb", content: []byte("ca")}
+	caARM64 := caAMD64
+	caARM64.digest = strings.Repeat("f", 64)
+	client := newDebianFixtureClient(t, []debianFixturePackage{amd64, caAMD64}, []debianFixturePackage{arm64, caARM64})
+
+	_, err := ResolveDebianBootstrapPins(context.Background(), client, "https://snapshot.test/archive/debian", testDebianSnapshot)
+	if err == nil || !strings.Contains(err.Error(), "metadata disagreement") {
+		t.Fatalf("CA digest disagreement error = %v", err)
+	}
+}
+
+func TestResolveDebianBootstrapPinsRejectsDownloadedDigestMismatch(t *testing.T) {
+	badDigest := strings.Repeat("0", 64)
+	amd64 := debianFixturePackage{name: "openssl", version: "1", architecture: "amd64", filename: "pool/main/o/openssl/openssl_1_amd64.deb", content: []byte("amd64"), digest: badDigest}
+	arm64 := debianFixturePackage{name: "openssl", version: "1", architecture: "arm64", filename: "pool/main/o/openssl/openssl_1_arm64.deb", content: []byte("arm64")}
+	ca := debianFixturePackage{name: "ca-certificates", version: "1", architecture: "all", filename: "pool/main/c/ca-certificates/ca-certificates_1_all.deb", content: []byte("ca")}
+	client := newDebianFixtureClient(t, []debianFixturePackage{amd64, ca}, []debianFixturePackage{arm64, ca})
+
+	_, err := ResolveDebianBootstrapPins(context.Background(), client, "https://snapshot.test/archive/debian", testDebianSnapshot)
+	if err == nil || !strings.Contains(err.Error(), "SHA256 mismatch") {
+		t.Fatalf("downloaded digest mismatch error = %v", err)
+	}
+}
+
+func TestResolveDebianBootstrapPinsRejectsMalformedMetadata(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if strings.HasSuffix(r.URL.Path, "/Packages.gz") {
+			var body bytes.Buffer
+			gz := gzip.NewWriter(&body)
+			_, _ = gz.Write([]byte("Package openssl\n"))
+			_ = gz.Close()
+			return httpFixtureResponse(http.StatusOK, body.Bytes()), nil
+		}
+		return httpFixtureResponse(http.StatusNotFound, nil), nil
+	})}
+
+	_, err := ResolveDebianBootstrapPins(context.Background(), client, "https://snapshot.test/archive/debian", testDebianSnapshot)
+	if err == nil || !strings.Contains(err.Error(), "malformed field") {
+		t.Fatalf("malformed Packages.gz error = %v", err)
+	}
+}
+
+func TestResolveDebianBootstrapPinsRejectsUntrustedTransport(t *testing.T) {
+	for _, base := range []string{
+		"http://snapshot.test/archive/debian",
+		"https://user@snapshot.test/archive/debian",
+		"https://snapshot.test/archive/debian?query=1",
+		"https://snapshot.test/archive/debian#fragment",
+	} {
+		if _, err := ResolveDebianBootstrapPins(context.Background(), &http.Client{}, base, testDebianSnapshot); err == nil {
+			t.Fatalf("accepted untrusted archive URL %q", base)
+		}
+	}
+	for _, location := range []string{"http://snapshot.test/file/index", "https://other.test/file/index"} {
+		client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			response := httpFixtureResponse(http.StatusFound, nil)
+			response.Header.Set("Location", location)
+			return response, nil
+		})}
+		_, err := ResolveDebianBootstrapPins(context.Background(), client, "https://snapshot.test/archive/debian", testDebianSnapshot)
+		if err == nil || !strings.Contains(err.Error(), "redirect outside reviewed HTTPS origin") {
+			t.Fatalf("redirect %q error = %v", location, err)
+		}
+	}
+}
+
+func TestResolveDebianBootstrapPinsRejectsShortPackage(t *testing.T) {
+	amd64 := debianFixturePackage{name: "openssl", version: "1", architecture: "amd64", filename: "pool/main/o/openssl/openssl_1_amd64.deb", content: []byte("amd64"), size: 7}
+	arm64 := debianFixturePackage{name: "openssl", version: "1", architecture: "arm64", filename: "pool/main/o/openssl/openssl_1_arm64.deb", content: []byte("arm64")}
+	ca := debianFixturePackage{name: "ca-certificates", version: "1", architecture: "all", filename: "pool/main/c/ca-certificates/ca-certificates_1_all.deb", content: []byte("ca")}
+	_, err := ResolveDebianBootstrapPins(context.Background(), newDebianFixtureClient(t, []debianFixturePackage{amd64, ca}, []debianFixturePackage{arm64, ca}), "https://snapshot.test/archive/debian", testDebianSnapshot)
+	if err == nil || !strings.Contains(err.Error(), "size mismatch") {
+		t.Fatalf("short package error = %v", err)
+	}
+}
+
+func TestFetchBoundedRejectsBadResponses(t *testing.T) {
+	responses := []*http.Response{
+		httpFixtureResponse(http.StatusServiceUnavailable, nil),
+		httpFixtureResponse(http.StatusOK, []byte("12345")),
+		httpFixtureResponse(http.StatusOK, []byte("12345")),
+	}
+	responses[2].ContentLength = -1
+	for _, response := range responses {
+		response := response
+		client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) { return response, nil })}
+		body, err := fetchBounded(context.Background(), client, "https://snapshot.test/file", 4)
+		if err == nil {
+			_, err = io.ReadAll(body)
+			_ = body.Close()
+		}
+		if err == nil {
+			t.Fatal("bounded fetch accepted a bad response")
+		}
+	}
+}
+
+func TestScanDebianPackageStanzasRejectsScalarContinuations(t *testing.T) {
+	for _, field := range []string{"Package", "Version", "Architecture", "Filename", "Size", "SHA256"} {
+		t.Run(field, func(t *testing.T) {
+			metadata := fmt.Sprintf("%s: value\n continuation\n\n", field)
+			err := scanDebianPackageStanzas(strings.NewReader(metadata), func(map[string]string) error { return nil })
+			if err == nil || !strings.Contains(err.Error(), "continuation is not allowed for scalar field "+field) {
+				t.Fatalf("scalar continuation error = %v", err)
+			}
+		})
+	}
+}
+
+func TestScanDebianPackageStanzasEnforcesResourceBounds(t *testing.T) {
+	var fields strings.Builder
+	for i := 0; i <= maxPackagesStanzaFields; i++ {
+		fmt.Fprintf(&fields, "X%d: value\n", i)
+	}
+	for name, metadata := range map[string]string{
+		"line":   "Description: " + strings.Repeat("x", maxPackagesLineBytes) + "\n",
+		"lines":  "Description: x\n" + strings.Repeat(" x\n", maxPackagesStanzaLines),
+		"stanza": "Description: x\n" + strings.Repeat(" "+strings.Repeat("x", 900000)+"\n", 5),
+		"fields": fields.String(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := scanDebianPackageStanzas(strings.NewReader(metadata), func(map[string]string) error { return nil }); err == nil {
+				t.Fatal("oversized package metadata was accepted")
+			}
+		})
+	}
+}
+
+func newDebianFixtureClient(t *testing.T, amd64Packages, arm64Packages []debianFixturePackage) *http.Client {
+	t.Helper()
+	artifacts := make(map[string][]byte)
+	for _, pkg := range append(append([]debianFixturePackage{}, amd64Packages...), arm64Packages...) {
+		artifacts["/archive/debian/"+testDebianSnapshot+"/"+pkg.filename] = pkg.content
+	}
+	indexes := map[string][]byte{
+		"amd64": gzipDebianPackages(t, amd64Packages),
+		"arm64": gzipDebianPackages(t, arm64Packages),
+	}
+	return &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodGet || r.URL.Scheme != "https" || r.URL.Host != "snapshot.test" || r.Header.Get("Accept-Encoding") != "identity" {
+			t.Fatalf("unexpected Debian request: %s %s Accept-Encoding=%q", r.Method, r.URL, r.Header.Get("Accept-Encoding"))
+		}
+		for architecture, body := range indexes {
+			if r.URL.Path == "/archive/debian/"+testDebianSnapshot+"/dists/trixie/main/binary-"+architecture+"/Packages.gz" {
+				return httpFixtureResponse(http.StatusOK, body), nil
+			}
+		}
+		if body, ok := artifacts[r.URL.Path]; ok {
+			return httpFixtureResponse(http.StatusOK, body), nil
+		}
+		return httpFixtureResponse(http.StatusNotFound, nil), nil
+	})}
+}
+
+func httpFixtureResponse(status int, body []byte) *http.Response {
+	return &http.Response{
+		StatusCode:    status,
+		Status:        fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Header:        make(http.Header),
+	}
+}
+
+func gzipDebianPackages(t *testing.T, packages []debianFixturePackage) []byte {
+	t.Helper()
+	var body bytes.Buffer
+	gz := gzip.NewWriter(&body)
+	for _, pkg := range packages {
+		_, err := fmt.Fprintf(gz, "Package: %s\nVersion: %s\nArchitecture: %s\nFilename: %s\nSize: %d\nSHA256: %s\n\n", pkg.name, pkg.version, pkg.architecture, pkg.filename, pkg.metadataSize(), pkg.sha256())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return body.Bytes()
+}

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -600,8 +600,8 @@ func TestUpdateUpstreamPinsRefreshesReviewedSources(t *testing.T) {
 		"https://snapshot.debian.org/archive/debian/",
 		"https://snapshot.debian.org/archive/debian-security/",
 		"debian_snapshot_has_bootstrap_packages",
-		"openssl_3.5.5-1~deb13u1_amd64.deb",
-		"openssl_3.5.5-1~deb13u1_arm64.deb",
+		"openssl_3.5.6-1~deb13u2_amd64.deb",
+		"openssl_3.5.6-1~deb13u2_arm64.deb",
 		"ca-certificates_20250419_all.deb",
 		"scripts/check-pinned-inputs.sh",
 		"UPSTREAM_REFRESH_WORKFLOW_PATH",
@@ -668,13 +668,13 @@ curl() {
     */dists/trixie/Release | */dists/trixie-updates/Release | */dists/trixie-security/Release)
       return 0
       ;;
-    */20260518T000000Z/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb | \
-    */20260518T000000Z/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_arm64.deb | \
+    */20260518T000000Z/pool/main/o/openssl/openssl_3.5.6-1~deb13u2_amd64.deb | \
+    */20260518T000000Z/pool/main/o/openssl/openssl_3.5.6-1~deb13u2_arm64.deb | \
     */20260518T000000Z/pool/main/c/ca-certificates/ca-certificates_20250419_all.deb)
       return 0
       ;;
-    */pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb | \
-    */pool/main/o/openssl/openssl_3.5.5-1~deb13u1_arm64.deb | \
+    */pool/main/o/openssl/openssl_3.5.6-1~deb13u2_amd64.deb | \
+    */pool/main/o/openssl/openssl_3.5.6-1~deb13u2_arm64.deb | \
     */pool/main/c/ca-certificates/ca-certificates_20250419_all.deb)
       return 22
       ;;
@@ -696,9 +696,9 @@ latest_debian_snapshot
 		t.Fatal(err)
 	}
 	for _, want := range []string{
-		"https://snapshot.debian.org/archive/debian/20260526T000000Z/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb",
-		"https://snapshot.debian.org/archive/debian/20260518T000000Z/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb",
-		"https://snapshot.debian.org/archive/debian/20260518T000000Z/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_arm64.deb",
+		"https://snapshot.debian.org/archive/debian/20260526T000000Z/pool/main/o/openssl/openssl_3.5.6-1~deb13u2_amd64.deb",
+		"https://snapshot.debian.org/archive/debian/20260518T000000Z/pool/main/o/openssl/openssl_3.5.6-1~deb13u2_amd64.deb",
+		"https://snapshot.debian.org/archive/debian/20260518T000000Z/pool/main/o/openssl/openssl_3.5.6-1~deb13u2_arm64.deb",
 		"https://snapshot.debian.org/archive/debian/20260518T000000Z/pool/main/c/ca-certificates/ca-certificates_20250419_all.deb",
 	} {
 		if !strings.Contains(string(curlLog), want) {
@@ -735,13 +735,13 @@ curl() {
     */dists/trixie/Release | */dists/trixie-updates/Release | */dists/trixie-security/Release)
       return 0
       ;;
-    */20260518T000000Z/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb | \
-    */20260518T000000Z/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_arm64.deb | \
+    */20260518T000000Z/pool/main/o/openssl/openssl_3.5.6-1~deb13u2_amd64.deb | \
+    */20260518T000000Z/pool/main/o/openssl/openssl_3.5.6-1~deb13u2_arm64.deb | \
     */20260518T000000Z/pool/main/c/ca-certificates/ca-certificates_20250419_all.deb)
       return 0
       ;;
-    */pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb | \
-    */pool/main/o/openssl/openssl_3.5.5-1~deb13u1_arm64.deb | \
+    */pool/main/o/openssl/openssl_3.5.6-1~deb13u2_amd64.deb | \
+    */pool/main/o/openssl/openssl_3.5.6-1~deb13u2_arm64.deb | \
     */pool/main/c/ca-certificates/ca-certificates_20250419_all.deb)
       return 22
       ;;

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -3425,8 +3425,8 @@ type dockerfilePinSpec struct {
 // download/checksum/dpkg probes sharing another.
 var dockerfilePinSpecs = []dockerfilePinSpec{
 	{`ca-certificates_20250419_all\.deb`, "to pin a snapshot CA bundle bootstrap package before HTTPS apt"},
-	{`openssl_3\.5\.5-1~deb13u1_amd64\.deb`, "to pin the amd64 snapshot OpenSSL bootstrap package before HTTPS apt"},
-	{`openssl_3\.5\.5-1~deb13u1_arm64\.deb`, "to pin the arm64 snapshot OpenSSL bootstrap package before HTTPS apt"},
+	{`openssl_3\.5\.6-1~deb13u2_amd64\.deb`, "to pin the amd64 snapshot OpenSSL bootstrap package before HTTPS apt"},
+	{`openssl_3\.5\.6-1~deb13u2_arm64\.deb`, "to pin the arm64 snapshot OpenSSL bootstrap package before HTTPS apt"},
 	{`Acquire::Retries "5";`, "to pin apt retry count for snapshot fetch resilience"},
 	{`Acquire::http::Timeout "30";`, "to pin apt HTTP timeout for snapshot fetch resilience"},
 	{`Acquire::https::Timeout "30";`, "to pin apt HTTPS timeout for snapshot fetch resilience"},

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -4509,8 +4509,8 @@ func TestCheckHostutilEgressRgRealRepo(t *testing.T) {
 // property of one file.
 const dockerfilePinsHappyBody = `FROM debian:trixie-slim
 ARG CA_DEB=ca-certificates_20250419_all.deb
-ARG OPENSSL_AMD64=openssl_3.5.5-1~deb13u1_amd64.deb
-ARG OPENSSL_ARM64=openssl_3.5.5-1~deb13u1_arm64.deb
+ARG OPENSSL_AMD64=openssl_3.5.6-1~deb13u2_amd64.deb
+ARG OPENSSL_ARM64=openssl_3.5.6-1~deb13u2_arm64.deb
 RUN echo 'Acquire::Retries "5";' >>/etc/apt/apt.conf
 RUN echo 'Acquire::http::Timeout "30";' >>/etc/apt/apt.conf
 RUN echo 'Acquire::https::Timeout "30";' >>/etc/apt/apt.conf
@@ -4574,7 +4574,7 @@ func TestCheckDockerfilePins(t *testing.T) {
 			// fires, proving the Dockerfile-outer order.
 			name:        "validator missing arm64 OpenSSL pin",
 			runtimeDF:   dockerfilePinsHappyBody,
-			validatorDF: strings.Replace(dockerfilePinsHappyBody, "openssl_3.5.5-1~deb13u1_arm64.deb", "openssl_OLD_arm64.deb", 1),
+			validatorDF: strings.Replace(dockerfilePinsHappyBody, "openssl_3.5.6-1~deb13u2_arm64.deb", "openssl_OLD_arm64.deb", 1),
 			wantRel:     validatorDockerfileRelPath,
 			wantSuffix:  "to pin the arm64 snapshot OpenSSL bootstrap package before HTTPS apt",
 		},

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -7,10 +7,10 @@ ARG NODE_BASE_IMAGE=node:24-trixie-slim@sha256:366fdef91728b1b7fa18c84fba63b6e79
 # Set to 0 to use epoch; set to a specific date for release builds.
 ARG SOURCE_DATE_EPOCH=0
 
-# Debian snapshot date for apt sources. Pinned for reproducibility.
-# To update: choose a newer snapshot date at https://snapshot.debian.org/,
-# verify packages are available, update this value, and re-run verify-reproducible-build.sh.
-ARG DEBIAN_SNAPSHOT=20260518T000000Z
+# Debian snapshot date and TLS-bootstrap packages are one reproducibility tuple.
+# Resolve the snapshot plus both architecture paths and all digests together,
+# update both Dockerfiles, and then re-run verify-reproducible-build.sh.
+ARG DEBIAN_SNAPSHOT=20260721T000000Z
 ARG RUST_TOOLCHAIN_IMAGE=rust:1.97.0-slim-trixie@sha256:14c4fe50ea427dc42381a1a09a9a839c1d2346a2e508cd491bf02c659dbc0ed7
 
 FROM ${RUST_TOOLCHAIN_IMAGE} AS rust-toolchain
@@ -49,12 +49,12 @@ RUN fetch_snapshot_bootstrap_package() { \
        local openssl_url="" openssl_sha256="" ca_url="" ca_sha256=""; \
        case "$(dpkg --print-architecture)" in \
          amd64) \
-           openssl_url="archive/debian/${DEBIAN_SNAPSHOT}/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb"; \
-           openssl_sha256="233d6d1f6ff00509cba554365e7cfb3be36db1dea57291eeb248f2c04d62719d"; \
+           openssl_url="archive/debian/${DEBIAN_SNAPSHOT}/pool/main/o/openssl/openssl_3.5.6-1~deb13u2_amd64.deb"; \
+           openssl_sha256="7b4270966255f0bad468ac889f4b090a6e10eb6ccbc2be0fa418560b24bdef5a"; \
            ;; \
          arm64) \
-           openssl_url="archive/debian/${DEBIAN_SNAPSHOT}/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_arm64.deb"; \
-           openssl_sha256="92dfcdc213cd7a5e6aa34a1ac9660a59e56838d12876f4b34599f8fea39cb432"; \
+           openssl_url="archive/debian/${DEBIAN_SNAPSHOT}/pool/main/o/openssl/openssl_3.5.6-1~deb13u2_arm64.deb"; \
+           openssl_sha256="1ee735e2480519bd1fd5f6576a879243bc81b9773059e1fa1ec8b8943c84e77c"; \
            ;; \
          *) \
            echo "Unsupported dpkg architecture for snapshot TLS bootstrap: $(dpkg --print-architecture)" >&2; \

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -465,8 +465,8 @@ debian_snapshot_has_bootstrap_packages() {
   local path
 
   for path in \
-    "pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb" \
-    "pool/main/o/openssl/openssl_3.5.5-1~deb13u1_arm64.deb" \
+    "pool/main/o/openssl/openssl_3.5.6-1~deb13u2_amd64.deb" \
+    "pool/main/o/openssl/openssl_3.5.6-1~deb13u2_arm64.deb" \
     "pool/main/c/ca-certificates/ca-certificates_20250419_all.deb"; do
     if ! curl -fsSI "${base}/${path}" >/dev/null 2>&1; then
       return 1

--- a/tools/validator/Dockerfile
+++ b/tools/validator/Dockerfile
@@ -1,5 +1,5 @@
 ARG VALIDATOR_BASE_IMAGE=node:24-trixie-slim@sha256:366fdef91728b1b7fa18c84fba63b6e79ed77b7e10cc206878e9705da4d7b169
-ARG DEBIAN_SNAPSHOT=20260518T000000Z
+ARG DEBIAN_SNAPSHOT=20260721T000000Z
 ARG GO_VERSION=1.26.5
 ARG GO_LINUX_X86_64_SHA256=5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053
 ARG GO_LINUX_ARM64_SHA256=fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49
@@ -58,12 +58,12 @@ RUN fetch_snapshot_bootstrap_package() { \
        local openssl_url="" openssl_sha256="" ca_url="" ca_sha256=""; \
        case "$(dpkg --print-architecture)" in \
          amd64) \
-           openssl_url="archive/debian/${DEBIAN_SNAPSHOT}/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_amd64.deb"; \
-           openssl_sha256="233d6d1f6ff00509cba554365e7cfb3be36db1dea57291eeb248f2c04d62719d"; \
+           openssl_url="archive/debian/${DEBIAN_SNAPSHOT}/pool/main/o/openssl/openssl_3.5.6-1~deb13u2_amd64.deb"; \
+           openssl_sha256="7b4270966255f0bad468ac889f4b090a6e10eb6ccbc2be0fa418560b24bdef5a"; \
            ;; \
          arm64) \
-           openssl_url="archive/debian/${DEBIAN_SNAPSHOT}/pool/main/o/openssl/openssl_3.5.5-1~deb13u1_arm64.deb"; \
-           openssl_sha256="92dfcdc213cd7a5e6aa34a1ac9660a59e56838d12876f4b34599f8fea39cb432"; \
+           openssl_url="archive/debian/${DEBIAN_SNAPSHOT}/pool/main/o/openssl/openssl_3.5.6-1~deb13u2_arm64.deb"; \
+           openssl_sha256="1ee735e2480519bd1fd5f6576a879243bc81b9773059e1fa1ec8b8943c84e77c"; \
            ;; \
          *) \
            echo "Unsupported dpkg architecture for snapshot TLS bootstrap: $(dpkg --print-architecture)" >&2; \


### PR DESCRIPTION
## Summary

- add a bounded resolver for current Debian OpenSSL and CA package metadata across `amd64`, `arm64`, and architecture-independent packages
- refresh both runtime Dockerfiles to the same live snapshot tuple and align the transitional updater and hardening fixtures
- fail closed on malformed or inconsistent metadata, unsafe URLs or redirects, oversized inputs, missing architectures, path/version disagreement, and package byte mismatches

## Trust boundary

The selected packages are fetched over HTTPS and byte-verified against the snapshot `Packages.gz` metadata. This unit does not claim independent Debian OpenPGP metadata verification.

## Validation

- `go test ./...`
- `go test -race ./internal/metadatautil ./cmd/workcell-citools`
- focused `go vet`
- `bash -n scripts/update-upstream-pins.sh`
- `./scripts/check-pinned-inputs.sh`
- live resolver and non-mutating updater `--check`
- full runtime and validator Dockerfile builds for `linux/amd64` and `linux/arm64`, including installed package-version checks
- fresh canonical `pr-parity` on the exact signed tree
- two independent peer-review passes with no actionable findings

The durable atomic shared-manifest integration and its full updater round-trip harness follow immediately as separate review units.
