### PR TITLE
Update brace-expansion to 5.0.7

### DIFF
--- a/tools/markdownlint/package-lock.json
+++ b/tools/markdownlint/package-lock.json
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary

- update the Markdown tooling lockfile from `brace-expansion` 5.0.6 to 5.0.7
- close GHSA-3jxr-9vmj-r5cp / CVE-2026-13149 without changing the direct dependency surface
- preserve the unrelated linkify-it and js-yaml remediation as separate review units

## Scope

- exact replacement for Dependabot PR #505, which remains open until this change merges
- `tools/markdownlint/package.json` is unchanged
- the regenerated lockfile matches npm registry integrity metadata and Dependabot's reviewed patch byte-for-byte

## Validation

- clean nested `npm ci --ignore-scripts`
- `npm ls brace-expansion --all`
- lockfile-only `npm audit` confirms the brace-expansion finding is absent
- repository Markdown lint with the pinned local CLI
- `./scripts/pre-merge.sh --profile pr-parity --allow-dirty`
- independent peer review: CLEAN
