### PR TITLE
Update linkify-it to 5.0.2

### DIFF
--- a/tools/markdownlint/package-lock.json
+++ b/tools/markdownlint/package-lock.json
@@ -344,9 +344,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- update the Markdown tooling lockfile from `linkify-it` 5.0.1 to 5.0.2
- close GHSA-v245-v573-v5vm / CVE-2026-59887 without changing the direct dependency surface
- preserve the unrelated js-yaml remediation as a separate review unit

## Scope

- exact signed replacement for Dependabot PR #508, which remains open until this change merges
- `tools/markdownlint/package.json` is unchanged
- the lockfile tuple matches npm registry integrity metadata and Dependabot's reviewed patch

## Validation

- clean nested `npm ci --ignore-scripts`
- `npm ls linkify-it`
- `npm audit` confirms the linkify-it finding is absent; only the separately queued js-yaml finding remains
- repository Markdown lint with the pinned local CLI
- `./scripts/pre-merge.sh --profile pr-parity --allow-dirty`
- `./scripts/pre-merge.sh --profile pr-parity` on the signed commit
- independent peer review: CLEAN
