### PR TITLE
Bump golang.org/x/sys to 0.47.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ toolchain go1.26.5
 
 require github.com/BurntSushi/toml v1.6.0
 
-require golang.org/x/sys v0.46.0
+require golang.org/x/sys v0.47.0
 
 require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
-golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary

- update `golang.org/x/sys` from 0.46.0 to 0.47.0 after the seven-day Go-module cool-off
- preserve the exact upstream Go proxy and checksum-database values
- keep the dependency unit limited to `go.mod` and `go.sum`

## Risk review

- independently reviewed the five upstream commits and all 40 Workcell-used `x/sys/unix` symbols
- no used declaration or constant changed; Workcell does not call the changed `EpollWait` path
- the module Go floor remains 1.25.0, below Workcell's Go 1.26.5 toolchain
- `govulncheck` found no reachable vulnerability

## Validation

- `go mod verify` and tidy-diff clean
- full Go race suite and `go vet ./...`
- Linux amd64 and arm64 cross-builds
- repository quick validation and pin checks
- independent dependency review clean
- full PR parity before signing
- full PR parity on signed commit `ef7e30cfe5ab4b3847f8657ac407267c357a78ef`
