### PR TITLE
Refresh eligible GitHub Actions pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           sudo install -m 0755 "$(command -v cosign)" /usr/local/bin/cosign
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           cache-binary: true
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
@@ -262,7 +262,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           cache-binary: true
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,12 +52,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - if: ${{ matrix.build-mode == 'autobuild' }}
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
 
-      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           cache-binary: true
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           version: ${{ env.WORKCELL_BUILDX_VERSION }}
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           cache-binary: true
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,16 +60,16 @@ jobs:
           persist-credentials: false
 
       - if: ${{ !github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_CODE_SCANNING == 'true' }}
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - if: ${{ (!github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_CODE_SCANNING == 'true') && matrix.build-mode == 'autobuild' }}
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
 
       - if: ${{ !github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_CODE_SCANNING == 'true' }}
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
 
   preflight-arm64-repro:
     name: Release reproducible image (arm64)
@@ -96,7 +96,7 @@ jobs:
         name: Compute source date epoch
         run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           cache-binary: false
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
@@ -153,7 +153,7 @@ jobs:
         name: Compute source date epoch
         run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           cache-binary: false
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
@@ -190,7 +190,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           cache-binary: false
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
@@ -225,7 +225,7 @@ jobs:
         name: Compute source date epoch
         run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           cache-binary: false
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
@@ -462,7 +462,7 @@ jobs:
             -t "workcell-validator:${GITHUB_SHA}" \
             .
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           cache-binary: false
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
@@ -756,20 +756,20 @@ jobs:
         name: Compute source date epoch
         run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           cache-binary: false
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
           version: ${{ env.WORKCELL_BUILDX_VERSION }}
 
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
 
       - id: build_arm64
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         env:
           SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
         with:
@@ -832,7 +832,7 @@ jobs:
         name: Compute source date epoch
         run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           cache-binary: false
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
@@ -866,7 +866,7 @@ jobs:
           sudo install -m 0755 "$(command -v cosign)" /usr/local/bin/cosign
           sudo install -m 0755 "$(command -v syft)" /usr/local/bin/syft
 
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           # Use repository_owner instead of github.actor: any maintainer
@@ -999,7 +999,7 @@ jobs:
             dist/preflight/workcell-control-plane-preflight.json
 
       - id: build_amd64
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         env:
           SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -50,7 +50,7 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      - uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         if: ${{ !github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_SCORECARD_SARIF == 'true' }}
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- update `docker/setup-buildx-action` from v4.1.0 to v4.2.0 at `bb05f3f5519dd87d3ba754cc423b652a5edd6d2c`
- update `github/codeql-action` from v4.36.2 to v4.37.0 at `99df26d4f13ea111d4ec1a7dddef6063f76b97e9`
- update `docker/login-action` from v4.2.0 to v4.4.0 at `af1e73f918a031802d376d3c8bbc3fe56130a9b0`
- update `docker/build-push-action` from v7.2.0 to v7.3.0 at `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a`
- reproduce the still-applicable Dependabot PR #502 as one maintainer-signed review unit on current `main`

## Eligibility and supply-chain review

- re-resolved immediately before implementation against official GitHub releases and the repository's seven-day cooldown
- CodeQL v4.37.1, v4.37.2, and v4.37.3 remain inside the cooldown and are intentionally excluded; v4.37.0 is the newest eligible CodeQL release
- all four exact target commits are GitHub-verified and match their official release tags; CodeQL's annotated v4.37.0 tag is unsigned, while its peeled target commit is GitHub-verified
- the root Docker action interface and all four used CodeQL sub-action interfaces are byte-identical to the previous pins
- the seven changed workflow files exactly match PR #502's intended patch

## Validation

- `./scripts/check-workflows.sh`
- `./scripts/check-pinned-inputs.sh`
- `./scripts/verify-github-hosted-controls.sh`
- `./scripts/dev-quick-check.sh`
- pre-sign `./scripts/pre-merge.sh --profile pr-parity --allow-dirty` on tree `3b28a08fea939074c80ecf4ab1913cf7f779db74`
- exact signed-head `./scripts/pre-merge.sh --profile pr-parity`

Hosted heavy CI, CodeQL, Security, Mutation, reproducibility, and macOS install lanes remain required before merge.
