### PR TITLE
Keep Codex command inventory current during pin refresh

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -77,6 +77,7 @@ func subcommands() []subcommand {
 		{"check-provider-bump-policy", "POLICY_PATH DOCKERFILE PROVIDERS_PACKAGE_JSON", 3, 3, cmdCheckProviderBumpPolicy},
 		{"provider-bump-plan", "POLICY_PATH DOCKERFILE PROVIDERS_PACKAGE_JSON [NOW_RFC3339]", 3, 4, cmdProviderBumpPlan},
 		{"apply-provider-bump-plan", "PLAN_PATH POLICY_PATH DOCKERFILE PROVIDERS_PACKAGE_JSON", 4, 4, cmdApplyProviderBumpPlan},
+		{"prepare-codex-subcommand-fixture", "VERSION FIXTURE_PATH OUTPUT_PATH", 3, 3, cmdPrepareCodexSubcommandFixture},
 		{"resolve-debian-bootstrap", "SNAPSHOT", 1, 1, cmdResolveDebianBootstrap},
 		{"inspect-debian-bootstrap", "MANIFEST_PATH", 1, 1, cmdInspectDebianBootstrap},
 		{"apply-debian-bootstrap", "PLAN_PATH REPO_ROOT", 2, 2, cmdApplyDebianBootstrap},
@@ -388,6 +389,10 @@ func cmdProviderBumpPlan(args []string) error {
 
 func cmdApplyProviderBumpPlan(args []string) error {
 	return metadatautil.ApplyProviderBumpPlan(args[0], args[1], args[2], args[3])
+}
+
+func cmdPrepareCodexSubcommandFixture(args []string) error {
+	return metadatautil.PrepareCodexSubcommandFixture(args[0], args[1], args[2])
 }
 
 func cmdGenerateBuildInputManifest(args []string) error {

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -91,6 +91,9 @@ Other macOS versions are not install-gated today.
   pin-hygiene before provider release verification paths run
 - it refreshes provider pins, the Linux runtime and validator base images,
   Debian snapshot, Go/Rust/Hadolint toolchains, and release-build helper pins
+- a Codex pin change fetches the exact tagged CLI source and advances the
+  command-inventory fixture only when the classified subcommand set is
+  unchanged; additions or removals stop refresh before pin mutation
 - it binds to the empty `upstream-refresh` GitHub environment as an out-of-tree
   `main`-only gate with no hosted signing inputs
 - it uploads an advisory candidate bundle containing `patch`, `diffstat`, and

--- a/internal/metadatautil/codex_subcommands.go
+++ b/internal/metadatautil/codex_subcommands.go
@@ -1,0 +1,542 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const (
+	defaultCodexCLISourceAPIURLFormat = "https://api.github.com/repos/openai/codex/contents/codex-rs/cli/src/main.rs?ref=rust-v%s"
+	maxCodexCLISourceBytes            = 2 << 20
+)
+
+var (
+	codexSubcommandEnumStartPattern = regexp.MustCompile(`^\s*(?:pub(?:\([^)]*\))?\s+)?enum\s+Subcommand\s*\{\s*$`)
+	codexVariantIdentifierPattern   = regexp.MustCompile(`^[A-Z][A-Za-z0-9_]*$`)
+	codexClapScalarPattern          = regexp.MustCompile(`^(name|alias|visible_alias)\s*=\s*"([a-z0-9][a-z0-9-]*)"$`)
+	codexClapListPattern            = regexp.MustCompile(`^(aliases|visible_aliases)\s*=\s*\[(.*)\]$`)
+	codexQuotedTokenPattern         = regexp.MustCompile(`^"([a-z0-9][a-z0-9-]*)"$`)
+	codexDeriveAttributePattern     = regexp.MustCompile(`^#\[derive\(([^()]*)\)\]$`)
+	codexRustPathPattern            = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*$`)
+	codexFixtureStampPattern        = regexp.MustCompile(`(?m)^# codex-version: ([0-9]+\.[0-9]+\.[0-9]+)$`)
+	codexFixtureSourceTagPattern    = regexp.MustCompile(`openai/codex tag rust-v([0-9]+\.[0-9]+\.[0-9]+)`)
+	codexSubcommandTokenPattern     = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+	codexGitBlobSHAPattern          = regexp.MustCompile(`^[0-9a-f]{40}$`)
+)
+
+type githubContentsFile struct {
+	Type     string `json:"type"`
+	Encoding string `json:"encoding"`
+	Content  string `json:"content"`
+	SHA      string `json:"sha"`
+}
+
+// PrepareCodexSubcommandFixture fetches the authoritative CLI source at the
+// exact pinned release tag and prepares a replacement fixture. It only advances
+// the version stamp when the complete command namespace is unchanged. A new or
+// removed command therefore stops automated provider refresh before any pin is
+// applied and requires an explicit policy classification review.
+func PrepareCodexSubcommandFixture(version, fixturePath, outputPath string) error {
+	if !stableVersionPattern.MatchString(version) {
+		return fmt.Errorf("Codex fixture version must be an exact stable version, got %q", version)
+	}
+	sourceURL := fmt.Sprintf(defaultCodexCLISourceAPIURLFormat, version)
+	return prepareCodexSubcommandFixture(version, fixturePath, outputPath, sourceURL, &http.Client{Timeout: providerBumpHTTPTimeout})
+}
+
+func prepareCodexSubcommandFixture(version, fixturePath, outputPath, sourceURL string, client *http.Client) error {
+	if fixturePath == outputPath {
+		return errors.New("Codex fixture output must be a separate prepared file")
+	}
+	var sourceFile githubContentsFile
+	if err := fetchJSON(client, sourceURL, &sourceFile); err != nil {
+		return fmt.Errorf("fetch authoritative Codex CLI source for %s: %w", version, err)
+	}
+	if sourceFile.Type != "file" || sourceFile.Encoding != "base64" || !codexGitBlobSHAPattern.MatchString(sourceFile.SHA) {
+		return fmt.Errorf("authoritative Codex CLI source for %s has malformed GitHub content metadata", version)
+	}
+	encoded := strings.ReplaceAll(sourceFile.Content, "\n", "")
+	source, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return fmt.Errorf("decode authoritative Codex CLI source for %s: %w", version, err)
+	}
+	if len(source) == 0 || len(source) > maxCodexCLISourceBytes {
+		return fmt.Errorf("authoritative Codex CLI source for %s has %d decoded bytes, want 1..%d", version, len(source), maxCodexCLISourceBytes)
+	}
+	if actualSHA := codexGitBlobObjectID(source); sourceFile.SHA != actualSHA {
+		return fmt.Errorf("authoritative Codex CLI source for %s disagrees with its Git blob SHA: metadata=%s actual=%s", version, sourceFile.SHA, actualSHA)
+	}
+	subcommands, err := parseCodexSubcommands(source)
+	if err != nil {
+		return fmt.Errorf("parse authoritative Codex CLI source for %s: %w", version, err)
+	}
+	fixtureInfo, err := os.Lstat(fixturePath)
+	if err != nil {
+		return err
+	}
+	if !fixtureInfo.Mode().IsRegular() || fixtureInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("Codex subcommand fixture must be a regular file: %s", fixturePath)
+	}
+	if outputInfo, statErr := os.Lstat(outputPath); statErr == nil && os.SameFile(fixtureInfo, outputInfo) {
+		return errors.New("Codex fixture output must not alias the source fixture")
+	} else if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return statErr
+	}
+	fixture, err := os.ReadFile(fixturePath)
+	if err != nil {
+		return err
+	}
+	updated, err := updateCodexSubcommandFixture(version, fixture, subcommands)
+	if err != nil {
+		return err
+	}
+	return writePreparedCodexFixture(outputPath, updated)
+}
+
+// codexGitBlobObjectID computes the SHA-1 object ID mandated by Git's current
+// blob format. This is a metadata/content consistency check; release assets
+// remain independently bound by SHA-256 digests.
+func codexGitBlobObjectID(content []byte) string {
+	// #nosec G401 -- Git object IDs require SHA-1; this is not a cryptographic
+	// trust decision and the trusted API transport remains separately enforced.
+	digest := sha1.New()
+	_, _ = digest.Write([]byte(fmt.Sprintf("blob %d\x00", len(content))))
+	_, _ = digest.Write(content)
+	return hex.EncodeToString(digest.Sum(nil))
+}
+
+func parseCodexSubcommands(source []byte) ([]string, error) {
+	if strings.Contains(string(source), "\r") {
+		return nil, errors.New("source must use LF line endings")
+	}
+	lines := strings.Split(string(source), "\n")
+	inEnum := false
+	closed := false
+	seenEnum := false
+	inPreludeMultilineAttribute := false
+	enumAttributes := make([]string, 0, 2)
+	attributes := make([]string, 0, 2)
+	commands := make([]string, 0, 32)
+	seen := make(map[string]bool)
+	for lineNumber, line := range lines {
+		if !inEnum {
+			trimmed := strings.TrimSpace(line)
+			if inPreludeMultilineAttribute {
+				if strings.HasSuffix(trimmed, "]") {
+					inPreludeMultilineAttribute = false
+				}
+				continue
+			}
+			if codexSubcommandEnumStartPattern.MatchString(line) {
+				if seenEnum {
+					return nil, errors.New("source contains more than one enum Subcommand")
+				}
+				if err := validateCodexSubcommandEnumAttributes(enumAttributes); err != nil {
+					return nil, fmt.Errorf("Subcommand enum attributes: %w", err)
+				}
+				enumAttributes = enumAttributes[:0]
+				seenEnum = true
+				inEnum = true
+				continue
+			}
+			if strings.HasPrefix(trimmed, "#[") {
+				if !strings.HasSuffix(trimmed, "]") {
+					enumAttributes = []string{fmt.Sprintf("<multiline attribute at line %d>", lineNumber+1)}
+					inPreludeMultilineAttribute = true
+					continue
+				}
+				enumAttributes = append(enumAttributes, trimmed)
+				continue
+			}
+			if trimmed != "" && !strings.HasPrefix(trimmed, "///") && !strings.HasPrefix(trimmed, "//") {
+				enumAttributes = enumAttributes[:0]
+			}
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "}" {
+			if len(attributes) != 0 {
+				return nil, fmt.Errorf("dangling Subcommand attribute before line %d", lineNumber+1)
+			}
+			inEnum = false
+			closed = true
+			continue
+		}
+		if trimmed == "" || strings.HasPrefix(trimmed, "///") || strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#[") {
+			if !strings.HasSuffix(trimmed, "]") {
+				return nil, fmt.Errorf("multiline Subcommand attribute at line %d is unsupported", lineNumber+1)
+			}
+			attributes = append(attributes, trimmed)
+			continue
+		}
+		variant, err := parseCodexSubcommandVariant(line)
+		if err != nil {
+			return nil, fmt.Errorf("unrecognized Subcommand variant at line %d: %s", lineNumber+1, trimmed)
+		}
+		variantNames, err := codexVariantCommandNames(variant, attributes)
+		if err != nil {
+			return nil, fmt.Errorf("Subcommand variant %s: %w", variant, err)
+		}
+		attributes = attributes[:0]
+		for _, name := range variantNames {
+			if seen[name] {
+				return nil, fmt.Errorf("duplicate Codex subcommand token %q", name)
+			}
+			seen[name] = true
+			commands = append(commands, name)
+		}
+	}
+	if !seenEnum || !closed || inEnum {
+		return nil, errors.New("source does not contain one complete enum Subcommand")
+	}
+	if seen["help"] {
+		return nil, errors.New("source declares help explicitly; implicit Clap help token would be ambiguous")
+	}
+	commands = append(commands, "help")
+	if len(commands) < 2 {
+		return nil, errors.New("source contains no Codex subcommands")
+	}
+	return commands, nil
+}
+
+func parseCodexSubcommandVariant(line string) (string, error) {
+	trimmedRight := strings.TrimRight(line, " \t")
+	if !strings.HasPrefix(trimmedRight, "    ") || len(trimmedRight) <= 4 || trimmedRight[4] == ' ' || trimmedRight[4] == '\t' {
+		return "", errors.New("variant must use exactly four spaces of indentation")
+	}
+	declaration := strings.TrimSuffix(trimmedRight[4:], ",")
+	if declaration == trimmedRight[4:] || declaration == "" {
+		return "", errors.New("variant must end with one comma")
+	}
+	if codexVariantIdentifierPattern.MatchString(declaration) {
+		return declaration, nil
+	}
+	open := strings.IndexByte(declaration, '(')
+	if open <= 0 || !codexVariantIdentifierPattern.MatchString(declaration[:open]) || !strings.HasSuffix(declaration, ")") {
+		return "", errors.New("variant must be one unit or tuple declaration")
+	}
+	payload := declaration[open+1 : len(declaration)-1]
+	if !codexRustPathPattern.MatchString(payload) {
+		return "", errors.New("tuple variant must contain exactly one reviewed Rust type path")
+	}
+	return declaration[:open], nil
+}
+
+func codexVariantCommandNames(variant string, attributes []string) ([]string, error) {
+	primary := rustVariantKebabCase(variant)
+	hasExplicitName := false
+	aliases := make([]string, 0, 2)
+	for _, attribute := range attributes {
+		if isCodexCfgAttribute(attribute) {
+			continue
+		}
+		items, err := codexCommandAttributeItems(attribute)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range items {
+			if item == "hide = true" {
+				continue
+			}
+			if match := codexClapScalarPattern.FindStringSubmatch(item); len(match) == 3 {
+				switch match[1] {
+				case "name":
+					if hasExplicitName {
+						return nil, fmt.Errorf("multiple explicit command names in %s", attribute)
+					}
+					hasExplicitName = true
+					primary = match[2]
+				case "alias", "visible_alias":
+					aliases = append(aliases, match[2])
+				}
+				continue
+			}
+			if match := codexClapListPattern.FindStringSubmatch(item); len(match) == 3 {
+				listItems, splitErr := splitCodexAttributeItems(match[2])
+				if splitErr != nil || len(listItems) == 0 {
+					return nil, fmt.Errorf("%s has an empty or malformed alias list", attribute)
+				}
+				for _, rawAlias := range listItems {
+					alias := codexQuotedTokenPattern.FindStringSubmatch(rawAlias)
+					if len(alias) != 2 {
+						return nil, fmt.Errorf("%s has an empty or malformed alias list", attribute)
+					}
+					aliases = append(aliases, alias[1])
+				}
+				continue
+			}
+			return nil, fmt.Errorf("unsupported dispatch-affecting Clap item %q in %s", item, attribute)
+		}
+	}
+	names := append([]string{primary}, aliases...)
+	for _, name := range names {
+		if !codexSubcommandTokenPattern.MatchString(name) {
+			return nil, fmt.Errorf("invalid command token %q", name)
+		}
+	}
+	return names, nil
+}
+
+func isCodexCfgAttribute(attribute string) bool {
+	const prefix = "#[cfg("
+	if !strings.HasPrefix(attribute, prefix) {
+		return false
+	}
+	depth := 1
+	inString := false
+	escaped := false
+	for index := len(prefix); index < len(attribute); index++ {
+		current := attribute[index]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch current {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch current {
+		case '"':
+			inString = true
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return index > len(prefix) && attribute[index:] == ")]"
+			}
+			if depth < 0 {
+				return false
+			}
+		}
+	}
+	return false
+}
+
+func validateCodexSubcommandEnumAttributes(attributes []string) error {
+	if len(attributes) != 1 {
+		for _, attribute := range attributes {
+			if !codexDeriveAttributePattern.MatchString(attribute) {
+				return fmt.Errorf("unsupported enum-level attribute %s", attribute)
+			}
+		}
+		return fmt.Errorf("want exactly one clap::Subcommand derive, got %v", attributes)
+	}
+	match := codexDeriveAttributePattern.FindStringSubmatch(attributes[0])
+	if len(match) != 2 {
+		return fmt.Errorf("unsupported enum-level attribute %s", attributes[0])
+	}
+	foundSubcommand := false
+	for _, rawDerive := range strings.Split(match[1], ",") {
+		derive := strings.TrimSpace(rawDerive)
+		if !codexRustPathPattern.MatchString(derive) {
+			return fmt.Errorf("unsupported derive %q", derive)
+		}
+		if derive == "clap::Subcommand" {
+			foundSubcommand = true
+		}
+	}
+	if !foundSubcommand {
+		return errors.New("missing clap::Subcommand derive")
+	}
+	return nil
+}
+
+func codexCommandAttributeItems(attribute string) ([]string, error) {
+	var body string
+	switch {
+	case strings.HasPrefix(attribute, "#[clap(") && strings.HasSuffix(attribute, ")]"):
+		body = strings.TrimSuffix(strings.TrimPrefix(attribute, "#[clap("), ")]")
+	case strings.HasPrefix(attribute, "#[command(") && strings.HasSuffix(attribute, ")]"):
+		body = strings.TrimSuffix(strings.TrimPrefix(attribute, "#[command("), ")]")
+	default:
+		return nil, fmt.Errorf("unsupported Subcommand attribute %s", attribute)
+	}
+	return splitCodexAttributeItems(body)
+}
+
+func splitCodexAttributeItems(value string) ([]string, error) {
+	items := make([]string, 0, 2)
+	start := 0
+	depth := 0
+	inString := false
+	escaped := false
+	for index := 0; index < len(value); index++ {
+		current := value[index]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch current {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch current {
+		case '"':
+			inString = true
+		case '[', '(', '{':
+			depth++
+		case ']', ')', '}':
+			depth--
+			if depth < 0 {
+				return nil, errors.New("unbalanced Clap attribute delimiters")
+			}
+		case ',':
+			if depth == 0 {
+				item := strings.TrimSpace(value[start:index])
+				if item == "" {
+					return nil, errors.New("empty Clap attribute item")
+				}
+				items = append(items, item)
+				start = index + 1
+			}
+		}
+	}
+	if inString || escaped || depth != 0 {
+		return nil, errors.New("unterminated Clap attribute item")
+	}
+	last := strings.TrimSpace(value[start:])
+	if last == "" {
+		return nil, errors.New("empty Clap attribute item")
+	}
+	return append(items, last), nil
+}
+
+func rustVariantKebabCase(variant string) string {
+	var out strings.Builder
+	for i := 0; i < len(variant); i++ {
+		current := variant[i]
+		if current >= 'A' && current <= 'Z' {
+			if i > 0 {
+				previous := variant[i-1]
+				nextIsLower := i+1 < len(variant) && variant[i+1] >= 'a' && variant[i+1] <= 'z'
+				if (previous >= 'a' && previous <= 'z') || (previous >= '0' && previous <= '9') || ((previous >= 'A' && previous <= 'Z') && nextIsLower) {
+					out.WriteByte('-')
+				}
+			}
+			out.WriteByte(current + ('a' - 'A'))
+			continue
+		}
+		out.WriteByte(current)
+	}
+	return out.String()
+}
+
+func updateCodexSubcommandFixture(version string, fixture []byte, authoritative []string) ([]byte, error) {
+	text := string(fixture)
+	if strings.Contains(text, "\r") {
+		return nil, errors.New("Codex subcommand fixture must use LF line endings")
+	}
+	stampMatches := codexFixtureStampPattern.FindAllStringSubmatch(text, -1)
+	if len(stampMatches) != 1 {
+		return nil, errors.New("Codex subcommand fixture must contain exactly one version stamp")
+	}
+	sourceMatches := codexFixtureSourceTagPattern.FindAllStringSubmatch(text, -1)
+	if len(sourceMatches) != 1 || sourceMatches[0][1] != stampMatches[0][1] {
+		return nil, errors.New("Codex subcommand fixture source tag must occur once and match its version stamp")
+	}
+	lines := strings.Split(text, "\n")
+	firstToken := -1
+	existing := make([]string, 0, len(authoritative))
+	seenExisting := make(map[string]bool, len(authoritative))
+	for index, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			if firstToken >= 0 && trimmed != "" {
+				return nil, errors.New("Codex subcommand fixture comments must precede every token")
+			}
+			continue
+		}
+		if !codexSubcommandTokenPattern.MatchString(trimmed) {
+			return nil, fmt.Errorf("Codex subcommand fixture contains invalid token %q", trimmed)
+		}
+		if firstToken < 0 {
+			firstToken = index
+		}
+		if seenExisting[trimmed] {
+			return nil, fmt.Errorf("Codex subcommand fixture contains duplicate token %q", trimmed)
+		}
+		seenExisting[trimmed] = true
+		existing = append(existing, trimmed)
+	}
+	if firstToken < 0 {
+		return nil, errors.New("Codex subcommand fixture contains no tokens")
+	}
+	added, removed := stringSetDifference(authoritative, existing), stringSetDifference(existing, authoritative)
+	if len(added) != 0 || len(removed) != 0 {
+		return nil, fmt.Errorf("Codex %s changes the classified subcommand namespace (added=%v removed=%v); review and classify the new authoritative enum before updating the fixture", version, added, removed)
+	}
+	header := strings.Join(lines[:firstToken], "\n")
+	header = codexFixtureStampPattern.ReplaceAllString(header, "# codex-version: "+version)
+	header = codexFixtureSourceTagPattern.ReplaceAllString(header, "openai/codex tag rust-v"+version)
+	return []byte(strings.TrimRight(header, "\n") + "\n" + strings.Join(authoritative, "\n") + "\n"), nil
+}
+
+func stringSetDifference(left, right []string) []string {
+	rightSet := make(map[string]bool, len(right))
+	for _, item := range right {
+		rightSet[item] = true
+	}
+	var difference []string
+	for _, item := range left {
+		if !rightSet[item] {
+			difference = append(difference, item)
+		}
+	}
+	sort.Strings(difference)
+	return difference
+}
+
+func writePreparedCodexFixture(path string, content []byte) error {
+	flags := os.O_WRONLY | os.O_TRUNC
+	if info, err := os.Lstat(path); err == nil {
+		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("Codex fixture output must be a regular file: %s", path)
+		}
+	} else if errors.Is(err, os.ErrNotExist) {
+		flags |= os.O_CREATE | os.O_EXCL
+	} else {
+		return err
+	}
+	file, err := os.OpenFile(path, flags, 0o644)
+	if err != nil {
+		return err
+	}
+	if err := file.Chmod(0o644); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if _, err := file.Write(content); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}

--- a/internal/metadatautil/codex_subcommands_test.go
+++ b/internal/metadatautil/codex_subcommands_test.go
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const codexSubcommandSourceFixture = `#[derive(Debug, Parser)]
+#[clap(
+    author,
+    version
+)]
+struct UnrelatedRoot {}
+
+#[derive(Debug, clap::Subcommand)]
+enum Subcommand {
+    /// Run Codex non-interactively.
+    #[clap(visible_alias = "e")]
+    Exec(ExecCli),
+
+    /// Launch the Desktop app on supported hosts.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    App(app_cmd::AppCommand),
+
+    /// Update Codex.
+    Update,
+
+    /// Browse cloud tasks.
+    #[clap(name = "cloud", alias = "cloud-tasks")]
+    Cloud(CloudTasksCli),
+
+    /// Internal relay.
+    #[clap(hide = true, name = "stdio-to-uds")]
+    StdioToUds(StdioToUdsCommand),
+}
+`
+
+func TestParseCodexSubcommandsIncludesAliasesHiddenAndUnitVariants(t *testing.T) {
+	want := []string{"exec", "e", "app", "update", "cloud", "cloud-tasks", "stdio-to-uds", "help"}
+	got, err := parseCodexSubcommands([]byte(codexSubcommandSourceFixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseCodexSubcommands() = %q, want %q", got, want)
+	}
+}
+
+func TestParseCodexSubcommandsFailsClosedOnUnsupportedShapes(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{name: "missing-enum", source: "enum Other { Exec, }\n", want: "one complete enum"},
+		{name: "multiline-attribute", source: codexTestEnum("    #[clap(\n    Exec(ExecCli),\n"), want: "multiline Subcommand attribute"},
+		{name: "unsupported-alias", source: codexTestEnum("    #[clap(alias(\"e\"))]\n    Exec(ExecCli),\n"), want: "unsupported dispatch-affecting Clap item"},
+		{name: "dynamic-alias", source: codexTestEnum("    #[clap(alias = make_alias())]\n    Exec(ExecCli),\n"), want: "unsupported dispatch-affecting Clap item"},
+		{name: "multiple-names", source: codexTestEnum("    #[clap(name = \"first\", name = \"second\")]\n    Exec(ExecCli),\n"), want: "multiple explicit command names"},
+		{name: "malformed-alias-list", source: codexTestEnum("    #[clap(aliases = [\"e\", make_alias()])]\n    Exec(ExecCli),\n"), want: "empty or malformed alias list"},
+		{name: "duplicate", source: codexTestEnum("    Exec(ExecCli),\n    #[clap(name = \"exec\")]\n    Other(OtherCli),\n"), want: "duplicate Codex subcommand"},
+		{name: "long-flag", source: codexTestEnum("    #[command(long_flag = \"danger\")]\n    Exec(ExecCli),\n"), want: "unsupported dispatch-affecting Clap item"},
+		{name: "short-flag", source: codexTestEnum("    #[command(short_flag = 'd')]\n    Exec(ExecCli),\n"), want: "unsupported dispatch-affecting Clap item"},
+		{name: "external-subcommand", source: codexTestEnum("    #[command(external_subcommand)]\n    Exec(ExecCli),\n"), want: "unsupported dispatch-affecting Clap item"},
+		{name: "flatten", source: codexTestEnum("    #[command(flatten)]\n    Exec(ExecCli),\n"), want: "unsupported dispatch-affecting Clap item"},
+		{name: "skip", source: codexTestEnum("    #[command(skip)]\n    Exec(ExecCli),\n"), want: "unsupported dispatch-affecting Clap item"},
+		{name: "nested-subcommand", source: codexTestEnum("    #[command(subcommand)]\n    Exec(ExecCli),\n"), want: "unsupported dispatch-affecting Clap item"},
+		{name: "indirect-command", source: codexTestEnum("    #[cfg_attr(unix, command(long_flag = \"danger\"))]\n    Exec(ExecCli),\n"), want: "unsupported Subcommand attribute"},
+		{name: "cfg-then-command-same-line", source: codexTestEnum("    #[cfg(unix)] #[command(long_flag = \"danger\")]\n    Exec(ExecCli),\n"), want: "unsupported Subcommand attribute"},
+		{name: "spaced-command", source: codexTestEnum("    # [command(long_flag = \"danger\")]\n    Exec(ExecCli),\n"), want: "unrecognized Subcommand variant"},
+		{name: "enum-rename-all", source: strings.Replace(codexTestEnum("    Exec(ExecCli),\n"), "enum Subcommand", "#[command(rename_all = \"snake_case\")]\nenum Subcommand", 1), want: "unsupported enum-level attribute"},
+		{name: "enum-multiline-attribute", source: strings.Replace(codexTestEnum("    Exec(ExecCli),\n"), "enum Subcommand", "#[command(\n    rename_all = \"snake_case\"\n)]\nenum Subcommand", 1), want: "unsupported enum-level attribute"},
+		{name: "multiple-variants-one-line", source: codexTestEnum("    Exec(ExecCli), Danger(DangerCli),\n"), want: "unrecognized Subcommand variant"},
+		{name: "multiple-tuple-fields", source: codexTestEnum("    Exec(ExecCli, DangerCli),\n"), want: "unrecognized Subcommand variant"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseCodexSubcommands([]byte(test.source))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("parseCodexSubcommands() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestPrepareCodexSubcommandFixtureAdvancesUnchangedNamespace(t *testing.T) {
+	server := codexSourceServer(t, codexSubcommandSourceFixture)
+	fixturePath := filepath.Join(t.TempDir(), "codex-subcommands.txt")
+	outputPath := filepath.Join(t.TempDir(), "prepared.txt")
+	fixture := codexFixtureText("0.144.1", []string{"update", "exec", "e", "app", "cloud", "cloud-tasks", "stdio-to-uds", "help"})
+	if err := os.WriteFile(fixturePath, []byte(fixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := prepareCodexSubcommandFixture("0.145.0", fixturePath, outputPath, server.URL, server.Client()); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "# codex-version: 0.145.0\n") || !strings.Contains(text, "openai/codex tag rust-v0.145.0") {
+		t.Fatalf("prepared fixture did not advance both version bindings:\n%s", text)
+	}
+	wantSuffix := "exec\ne\napp\nupdate\ncloud\ncloud-tasks\nstdio-to-uds\nhelp\n"
+	if !strings.HasSuffix(text, wantSuffix) {
+		t.Fatalf("prepared fixture token order mismatch:\n%s", text)
+	}
+	info, err := os.Stat(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("prepared fixture mode = %04o, want 0644", info.Mode().Perm())
+	}
+}
+
+func TestPrepareCodexSubcommandFixtureRejectsNamespaceDriftWithoutMutation(t *testing.T) {
+	server := codexSourceServer(t, strings.Replace(codexSubcommandSourceFixture, "    Update,\n", "    Update,\n    Danger(DangerCli),\n", 1))
+	root := t.TempDir()
+	fixturePath := filepath.Join(root, "codex-subcommands.txt")
+	outputPath := filepath.Join(root, "prepared.txt")
+	fixture := codexFixtureText("0.144.1", []string{"exec", "e", "app", "update", "cloud", "cloud-tasks", "stdio-to-uds", "help"})
+	if err := os.WriteFile(fixturePath, []byte(fixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outputPath, []byte("sentinel\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := prepareCodexSubcommandFixture("0.145.0", fixturePath, outputPath, server.URL, server.Client())
+	if err == nil || !strings.Contains(err.Error(), "added=[danger]") {
+		t.Fatalf("namespace drift error = %v", err)
+	}
+	content, readErr := os.ReadFile(outputPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(content) != "sentinel\n" {
+		t.Fatalf("failed preparation mutated output: %q", content)
+	}
+}
+
+func TestPrepareCodexSubcommandFixtureRejectsAliasedSourceAndDuplicateFixture(t *testing.T) {
+	server := codexSourceServer(t, codexSubcommandSourceFixture)
+	t.Run("hard-linked-output", func(t *testing.T) {
+		root := t.TempDir()
+		fixturePath := filepath.Join(root, "fixture")
+		fixture := codexFixtureText("0.144.1", []string{"exec", "e", "app", "update", "cloud", "cloud-tasks", "stdio-to-uds", "help"})
+		if err := os.WriteFile(fixturePath, []byte(fixture), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		outputPath := filepath.Join(root, "output")
+		if err := os.Link(fixturePath, outputPath); err != nil {
+			t.Fatal(err)
+		}
+		err := prepareCodexSubcommandFixture("0.145.0", fixturePath, outputPath, server.URL, server.Client())
+		if err == nil || !strings.Contains(err.Error(), "must not alias") {
+			t.Fatalf("aliased output error = %v", err)
+		}
+	})
+	t.Run("duplicate-token", func(t *testing.T) {
+		root := t.TempDir()
+		fixturePath := filepath.Join(root, "fixture")
+		commands := []string{"exec", "exec", "e", "app", "update", "cloud", "cloud-tasks", "stdio-to-uds", "help"}
+		if err := os.WriteFile(fixturePath, []byte(codexFixtureText("0.144.1", commands)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		err := prepareCodexSubcommandFixture("0.145.0", fixturePath, filepath.Join(root, "output"), server.URL, server.Client())
+		if err == nil || !strings.Contains(err.Error(), `duplicate token "exec"`) {
+			t.Fatalf("duplicate fixture error = %v", err)
+		}
+	})
+}
+
+func TestPrepareCodexSubcommandFixtureRejectsMalformedContentMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(githubContentsFile{Type: "symlink", Encoding: "base64", Content: "eA==", SHA: strings.Repeat("a", 40)})
+	}))
+	t.Cleanup(server.Close)
+	root := t.TempDir()
+	fixturePath := filepath.Join(root, "fixture")
+	if err := os.WriteFile(fixturePath, []byte(codexFixtureText("0.144.1", []string{"exec", "help"})), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := prepareCodexSubcommandFixture("0.145.0", fixturePath, filepath.Join(root, "output"), server.URL, server.Client())
+	if err == nil || !strings.Contains(err.Error(), "malformed GitHub content metadata") {
+		t.Fatalf("malformed metadata error = %v", err)
+	}
+}
+
+func TestPrepareCodexSubcommandFixtureRejectsGitBlobSHADisagreement(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(githubContentsFile{
+			Type:     "file",
+			Encoding: "base64",
+			Content:  base64.StdEncoding.EncodeToString([]byte(codexSubcommandSourceFixture)),
+			SHA:      strings.Repeat("a", 40),
+		})
+	}))
+	t.Cleanup(server.Close)
+	root := t.TempDir()
+	fixturePath := filepath.Join(root, "fixture")
+	if err := os.WriteFile(fixturePath, []byte(codexFixtureText("0.144.1", []string{"exec", "help"})), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := prepareCodexSubcommandFixture("0.145.0", fixturePath, filepath.Join(root, "output"), server.URL, server.Client())
+	if err == nil || !strings.Contains(err.Error(), "disagrees with its Git blob SHA") {
+		t.Fatalf("Git blob SHA disagreement error = %v", err)
+	}
+}
+
+func codexSourceServer(t *testing.T, source string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		response := githubContentsFile{
+			Type:     "file",
+			Encoding: "base64",
+			Content:  base64.StdEncoding.EncodeToString([]byte(source)),
+			SHA:      codexGitBlobObjectID([]byte(source)),
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Error(err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func codexFixtureText(version string, commands []string) string {
+	return "# Complete fixture.\n#\n# codex-version: " + version + "\n#\n# derived from the AUTHORITATIVE source (openai/codex tag rust-v" + version + ", codex-rs/cli/src/main.rs).\n# One name per line.\n" + strings.Join(commands, "\n") + "\n"
+}
+
+func codexTestEnum(body string) string {
+	return "#[derive(Debug, clap::Subcommand)]\nenum Subcommand {\n" + body + "}\n"
+}

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -688,6 +688,36 @@ func TestUpdateUpstreamPinsRefreshesReviewedSources(t *testing.T) {
 	}
 }
 
+func TestUpdateProviderPinsPreparesCodexNamespaceBeforeApplyingBump(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(repoRoot(t), "scripts", "update-provider-pins.sh")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(content)
+	prepare := strings.Index(script, "prepare-codex-subcommand-fixture")
+	apply := strings.Index(script, "apply-provider-bump-plan")
+	publish := strings.Index(script, `mv -f -- "${codex_fixture_candidate}" "${CODEX_SUBCOMMAND_FIXTURE_PATH}"`)
+	verify := strings.Index(script, `"${ROOT_DIR}/scripts/verify-upstream-codex-release.sh"`)
+	if prepare < 0 || apply < 0 || publish < 0 || verify < 0 {
+		t.Fatalf("%s must prepare, apply, publish, and verify the Codex fixture update", path)
+	}
+	if !(prepare < apply && apply < publish && publish < verify) {
+		t.Fatalf("%s must validate the authoritative namespace before pin mutation, then publish the prepared fixture before release verification", path)
+	}
+	for _, want := range []string{
+		`CODEX_SUBCOMMAND_FIXTURE_PATH="${ROOT_DIR}/tests/fixtures/codex-subcommands.txt"`,
+		`codex_fixture_candidate="$(mktemp "${CODEX_SUBCOMMAND_FIXTURE_PATH}.XXXXXX")"`,
+		`[[ -z "${codex_fixture_candidate}" ]] || rm -f "${codex_fixture_candidate}"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("%s is missing fail-closed Codex fixture handling %q", path, want)
+		}
+	}
+}
+
 func TestLatestDebianSnapshotFallsBackWhenNewestBootstrapPlanIsUnsuitable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -688,7 +688,7 @@ func TestUpdateUpstreamPinsRefreshesReviewedSources(t *testing.T) {
 	}
 }
 
-func TestUpdateProviderPinsPreparesCodexNamespaceBeforeApplyingBump(t *testing.T) {
+func TestUpdateProviderPinsStagesCodexNamespaceAndLockfileBeforePublishingBump(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.Join(repoRoot(t), "scripts", "update-provider-pins.sh")
@@ -699,18 +699,37 @@ func TestUpdateProviderPinsPreparesCodexNamespaceBeforeApplyingBump(t *testing.T
 	script := string(content)
 	prepare := strings.Index(script, "prepare-codex-subcommand-fixture")
 	apply := strings.Index(script, "apply-provider-bump-plan")
-	publish := strings.Index(script, `mv -f -- "${codex_fixture_candidate}" "${CODEX_SUBCOMMAND_FIXTURE_PATH}"`)
-	verify := strings.Index(script, `"${ROOT_DIR}/scripts/verify-upstream-codex-release.sh"`)
-	if prepare < 0 || apply < 0 || publish < 0 || verify < 0 {
-		t.Fatalf("%s must prepare, apply, publish, and verify the Codex fixture update", path)
+	publishDockerfile := strings.Index(script, `mv -f -- "${dockerfile_candidate}" "${DOCKERFILE_PATH}"`)
+	publishPackageJSON := strings.Index(script, `mv -f -- "${providers_candidate_dir}/package.json" "${PROVIDERS_PACKAGE_JSON_PATH}"`)
+	publishPackageLock := strings.Index(script, `mv -f -- "${providers_candidate_dir}/package-lock.json" "${PROVIDERS_DIR}/package-lock.json"`)
+	publishCodexFixture := strings.Index(script, `mv -f -- "${codex_fixture_candidate}" "${CODEX_SUBCOMMAND_FIXTURE_PATH}"`)
+	lockfile := strings.Index(script, `"${NPM_BIN}" install --package-lock-only`)
+	verify := strings.LastIndex(script, "\nverify_provider_releases\n")
+	if prepare < 0 || apply < 0 || publishDockerfile < 0 || publishPackageJSON < 0 || publishPackageLock < 0 || publishCodexFixture < 0 || lockfile < 0 || verify < 0 {
+		t.Fatalf("%s must prepare, apply, publish, refresh the lockfile, and verify the Codex fixture update", path)
 	}
-	if !(prepare < apply && apply < publish && publish < verify) {
-		t.Fatalf("%s must validate the authoritative namespace before pin mutation, then publish the prepared fixture before release verification", path)
+	if !(prepare < apply && apply < lockfile &&
+		lockfile < publishDockerfile && lockfile < publishPackageJSON && lockfile < publishPackageLock && lockfile < publishCodexFixture &&
+		publishPackageLock < publishPackageJSON && publishCodexFixture < publishDockerfile &&
+		publishDockerfile < verify && publishPackageJSON < verify && publishPackageLock < verify && publishCodexFixture < verify) {
+		t.Fatalf("%s must stage every fallible refresh and publish dependent artifacts before their plan-driving pins", path)
 	}
 	for _, want := range []string{
 		`CODEX_SUBCOMMAND_FIXTURE_PATH="${ROOT_DIR}/tests/fixtures/codex-subcommands.txt"`,
 		`codex_fixture_candidate="$(mktemp "${CODEX_SUBCOMMAND_FIXTURE_PATH}.XXXXXX")"`,
 		`[[ -z "${codex_fixture_candidate}" ]] || rm -f "${codex_fixture_candidate}"`,
+		`[[ -z "${dockerfile_candidate}" ]] || rm -f "${dockerfile_candidate}"`,
+		`"${PROVIDERS_DIR}"/.workcell-provider-bump.*) rm -rf -- "${providers_candidate_dir}" ;;`,
+		`dockerfile_candidate="$(mktemp "${DOCKERFILE_PATH}.XXXXXX")"`,
+		`providers_candidate_dir="$(mktemp -d "${PROVIDERS_DIR}/.workcell-provider-bump.XXXXXX")"`,
+		`"${dockerfile_candidate}"`,
+		`"${providers_candidate_dir}/package.json"`,
+		`cd "${providers_candidate_dir}"`,
+		`if [[ ! -f "${providers_candidate_dir}/package.json" || -L "${providers_candidate_dir}/package.json" ||`,
+		`! -f "${providers_candidate_dir}/package-lock.json" || -L "${providers_candidate_dir}/package-lock.json" ]]`,
+		`unexpected_provider_candidate="$(find "${providers_candidate_dir}"`,
+		"verify_provider_releases() {",
+		"  verify_provider_releases\n  print_summary\n  echo \"No eligible stable provider pin updates found.\"",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("%s is missing fail-closed Codex fixture handling %q", path, want)

--- a/scripts/update-provider-pins.sh
+++ b/scripts/update-provider-pins.sh
@@ -32,6 +32,7 @@ POLICY_PATH="${ROOT_DIR}/policy/provider-bumps.toml"
 DOCKERFILE_PATH="${ROOT_DIR}/runtime/container/Dockerfile"
 PROVIDERS_PACKAGE_JSON_PATH="${ROOT_DIR}/runtime/container/providers/package.json"
 PROVIDERS_DIR="${ROOT_DIR}/runtime/container/providers"
+CODEX_SUBCOMMAND_FIXTURE_PATH="${ROOT_DIR}/tests/fixtures/codex-subcommands.txt"
 
 mode="summary"
 now_override=""
@@ -46,7 +47,7 @@ usage() {
 Usage: scripts/update-provider-pins.sh [--apply | --check | --json] [--now RFC3339]
 
 Modes:
-  --apply   Update pinned provider versions to the newest stable releases older than the configured cool-off and refresh package-lock.json.
+  --apply   Update pinned provider versions to the newest stable releases older than the configured cool-off, refresh package-lock.json, and advance an unchanged Codex command inventory.
   --check   Exit non-zero when an eligible stable provider update is available.
   --json    Print the resolved provider bump plan as JSON.
 
@@ -190,12 +191,26 @@ else
 fi
 
 plan_path="$(mktemp "${TMPDIR:-/tmp}/workcell-provider-bump-plan.XXXXXX.json")"
+codex_fixture_candidate=""
 cleanup_apply() {
   cleanup
   rm -f "${plan_path}"
+  [[ -z "${codex_fixture_candidate}" ]] || rm -f "${codex_fixture_candidate}"
 }
 trap cleanup_apply EXIT
 printf '%s\n' "${plan_json}" >"${plan_path}"
+
+if [[ "$(jq -r '.providers.codex.changed' <<<"${plan_json}")" == "true" ]]; then
+  codex_target_version="$(jq -r '.providers.codex.target_version' <<<"${plan_json}")"
+  codex_fixture_candidate="$(mktemp "${CODEX_SUBCOMMAND_FIXTURE_PATH}.XXXXXX")"
+  (
+    cd "${ROOT_DIR}"
+    go run ./cmd/workcell-citools prepare-codex-subcommand-fixture \
+      "${codex_target_version}" \
+      "${CODEX_SUBCOMMAND_FIXTURE_PATH}" \
+      "${codex_fixture_candidate}"
+  )
+fi
 
 (
   cd "${ROOT_DIR}"
@@ -206,6 +221,11 @@ printf '%s\n' "${plan_json}" >"${plan_path}"
   cd "${PROVIDERS_DIR}"
   "${NPM_BIN}" install --package-lock-only --ignore-scripts --no-audit --no-fund
 )
+
+if [[ -n "${codex_fixture_candidate}" ]]; then
+  mv -f -- "${codex_fixture_candidate}" "${CODEX_SUBCOMMAND_FIXTURE_PATH}"
+  codex_fixture_candidate=""
+fi
 
 "${ROOT_DIR}/scripts/verify-upstream-codex-release.sh"
 "${ROOT_DIR}/scripts/verify-upstream-claude-release.sh"

--- a/scripts/update-provider-pins.sh
+++ b/scripts/update-provider-pins.sh
@@ -170,6 +170,13 @@ print_summary() {
   ' <<<"${plan_json}"
 }
 
+verify_provider_releases() {
+  "${ROOT_DIR}/scripts/verify-upstream-codex-release.sh"
+  "${ROOT_DIR}/scripts/verify-upstream-claude-release.sh"
+  WORKCELL_COPILOT_RELEASE_HELP_MODE=checksum "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh"
+  "${ROOT_DIR}/scripts/verify-upstream-gemini-release.sh"
+}
+
 if [[ "${mode}" == "summary" ]]; then
   print_summary
   exit 0
@@ -185,6 +192,7 @@ else
     print_summary
     exit 0
   fi
+  verify_provider_releases
   print_summary
   echo "No eligible stable provider pin updates found."
   exit 0
@@ -192,10 +200,19 @@ fi
 
 plan_path="$(mktemp "${TMPDIR:-/tmp}/workcell-provider-bump-plan.XXXXXX.json")"
 codex_fixture_candidate=""
+dockerfile_candidate=""
+providers_candidate_dir=""
 cleanup_apply() {
   cleanup
   rm -f "${plan_path}"
   [[ -z "${codex_fixture_candidate}" ]] || rm -f "${codex_fixture_candidate}"
+  [[ -z "${dockerfile_candidate}" ]] || rm -f "${dockerfile_candidate}"
+  if [[ -n "${providers_candidate_dir}" ]]; then
+    case "${providers_candidate_dir}" in
+      "${PROVIDERS_DIR}"/.workcell-provider-bump.*) rm -rf -- "${providers_candidate_dir}" ;;
+      *) echo "Refusing to clean unexpected provider bump candidate path: ${providers_candidate_dir}" >&2 ;;
+    esac
+  fi
 }
 trap cleanup_apply EXIT
 printf '%s\n' "${plan_json}" >"${plan_path}"
@@ -212,24 +229,49 @@ if [[ "$(jq -r '.providers.codex.changed' <<<"${plan_json}")" == "true" ]]; then
   )
 fi
 
+dockerfile_candidate="$(mktemp "${DOCKERFILE_PATH}.XXXXXX")"
+cp -p -- "${DOCKERFILE_PATH}" "${dockerfile_candidate}"
+providers_candidate_dir="$(mktemp -d "${PROVIDERS_DIR}/.workcell-provider-bump.XXXXXX")"
+cp -p -- "${PROVIDERS_DIR}/package.json" "${providers_candidate_dir}/package.json"
+cp -p -- "${PROVIDERS_DIR}/package-lock.json" "${providers_candidate_dir}/package-lock.json"
+
 (
   cd "${ROOT_DIR}"
-  go run ./cmd/workcell-citools apply-provider-bump-plan "${plan_path}" "${POLICY_PATH}" "${DOCKERFILE_PATH}" "${PROVIDERS_PACKAGE_JSON_PATH}"
+  go run ./cmd/workcell-citools apply-provider-bump-plan \
+    "${plan_path}" \
+    "${POLICY_PATH}" \
+    "${dockerfile_candidate}" \
+    "${providers_candidate_dir}/package.json"
 )
 
 (
-  cd "${PROVIDERS_DIR}"
+  cd "${providers_candidate_dir}"
   "${NPM_BIN}" install --package-lock-only --ignore-scripts --no-audit --no-fund
 )
 
+if [[ ! -f "${providers_candidate_dir}/package.json" || -L "${providers_candidate_dir}/package.json" ||
+  ! -f "${providers_candidate_dir}/package-lock.json" || -L "${providers_candidate_dir}/package-lock.json" ]]; then
+  echo "Provider bump staging must produce regular package.json and package-lock.json files." >&2
+  exit 1
+fi
+unexpected_provider_candidate="$(find "${providers_candidate_dir}" -mindepth 1 -maxdepth 1 \
+  ! -name package.json ! -name package-lock.json -print -quit)"
+if [[ -n "${unexpected_provider_candidate}" ]]; then
+  echo "Provider bump staging produced an unexpected path: ${unexpected_provider_candidate}" >&2
+  exit 1
+fi
+
+mv -f -- "${providers_candidate_dir}/package-lock.json" "${PROVIDERS_DIR}/package-lock.json"
+mv -f -- "${providers_candidate_dir}/package.json" "${PROVIDERS_PACKAGE_JSON_PATH}"
+rmdir -- "${providers_candidate_dir}"
+providers_candidate_dir=""
 if [[ -n "${codex_fixture_candidate}" ]]; then
   mv -f -- "${codex_fixture_candidate}" "${CODEX_SUBCOMMAND_FIXTURE_PATH}"
   codex_fixture_candidate=""
 fi
+mv -f -- "${dockerfile_candidate}" "${DOCKERFILE_PATH}"
+dockerfile_candidate=""
 
-"${ROOT_DIR}/scripts/verify-upstream-codex-release.sh"
-"${ROOT_DIR}/scripts/verify-upstream-claude-release.sh"
-WORKCELL_COPILOT_RELEASE_HELP_MODE=checksum "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh"
-"${ROOT_DIR}/scripts/verify-upstream-gemini-release.sh"
+verify_provider_releases
 
 print_summary

--- a/tests/fixtures/codex-subcommands.txt
+++ b/tests/fixtures/codex-subcommands.txt
@@ -22,6 +22,9 @@
 # (app-server, AGENT_UI=gui only), or DENY. A pin bump MUST regenerate this list from
 # the new clap Subcommand enum (unit variants, aliases, hidden tokens), classify any
 # new name in provider-policy.sh, AND bump the stamp above, or the build stays red.
+# The reviewed provider updater advances the stamp automatically only when the exact
+# authoritative token set is unchanged; any addition or removal fails before pin
+# mutation and requires an explicit classification change.
 # One name per line; blank/`#` lines are ignored.
 exec
 e


### PR DESCRIPTION
## Summary

- fetch the exact official tagged Codex CLI source before applying an eligible provider pin bump
- verify the decoded source against its Git blob object ID and derive the full top-level command and alias namespace, including hidden and platform-gated variants
- advance the version-bound command fixture only when that classified namespace is unchanged
- stop before provider pin mutation on additions, removals, unclassified Clap dispatch attributes, unsupported source shapes, malformed metadata or blob disagreement, duplicate fixture tokens, or source/output aliasing
- stage the Dockerfile, provider manifest/lockfile, and Codex fixture before publishing tracked inputs; reject special files or unexpected staging output

## Motivation

Fresh upstream-refresh run 29905786249 correctly discovered Codex 0.145.0, but replay stopped because the provider updater advanced `CODEX_VERSION` without the version-bound command inventory. This change makes those two reviewed inputs move together without silently classifying new provider surface.

## Validation

- focused Go tests, race detector, and vet for `internal/metadatautil`, `internal/testkit`, and `cmd/workcell-citools`
- forced-npm-failure replay on exact staged tree `229603c8`, proving byte-identical tracked inputs and zero candidate residue
- real official-source apply/no-op/check round trip from Codex 0.144.1 to 0.145.0 on the same tree, changing exactly the four expected files
- `scripts/check-pinned-inputs.sh`
- `scripts/check-workflows.sh`
- `scripts/check-doc-links.sh`
- `scripts/dev-quick-check.sh`
- `scripts/verify-invariants.sh`, including owned live-profile cleanup
- pre-sign dirty-tree `pr-parity` bound to tree `229603c83a416031d786faa472c94a217223ba6f`

Hosted heavy CI and the repeated review/comment sweep remain required before merge.
