### PR TITLE
Fix upstream refresh commit notation

### DIFF
--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -621,6 +621,12 @@ func TestPublishUpstreamRefreshPRRequiresCleanWorktree(t *testing.T) {
 			t.Fatalf("%s does not contain %q", scriptPath, want)
 		}
 	}
+
+	const commitTemplateStart = `cat >"${commit_file}" <<'EOF'
+^F Refresh pinned upstreams (pr-parity passed; runtime/provider maintenance)`
+	if !strings.Contains(script, commitTemplateStart) {
+		t.Fatalf("%s must generate the reviewed Risk-Aware upstream-refresh commit subject", scriptPath)
+	}
 }
 
 func TestUpdateUpstreamPinsRefreshesReviewedSources(t *testing.T) {

--- a/scripts/publish-upstream-refresh-pr.sh
+++ b/scripts/publish-upstream-refresh-pr.sh
@@ -322,7 +322,7 @@ $(cat "${diffstat_path}")
 EOF
 
 cat >"${commit_file}" <<'EOF'
-Refresh pinned upstreams
+^F Refresh pinned upstreams (pr-parity passed; runtime/provider maintenance)
 
 - refresh provider pins and Linux base/toolchain inputs
 - refresh release-build helper versions and image digests


### PR DESCRIPTION
## Summary

- make automatically generated upstream-refresh commits use the mandatory Risk-Aware Commit Notation
- lock the exact reviewed commit subject with a deterministic regression test

## Why

The first current upstream-refresh publication had a valid maintainer signature but omitted the required notation in its generated subject. That forced a replacement PR without rewriting published history. This fixes the generator so future refreshes carry the required classification by construction.

## Validation

- focused and full `internal/testkit` tests
- `bash -n scripts/publish-upstream-refresh-pr.sh`
- `shellcheck -x scripts/publish-upstream-refresh-pr.sh`
- `gofmt -d internal/testkit/validation_entrypoints_test.go`
- fresh local `pr-parity` against the exact published index
- independent frozen-tree review

No runtime, provider pin, policy, or release payload changes are included.
