### PR TITLE
Add descriptor-safe session state primitives

### DIFF
--- a/internal/host/sessions/owner_file.go
+++ b/internal/host/sessions/owner_file.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessions
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+type ownerFile struct {
+	data []byte
+	stat unix.Stat_t
+}
+
+func safeDescriptorBasename(name string) error {
+	if name == "" || name == "." || name == ".." || filepath.IsAbs(name) || strings.ContainsRune(name, filepath.Separator) || strings.ContainsRune(name, 0) || name != strings.TrimSpace(name) {
+		return errors.New("descriptor-relative file name must be one safe basename")
+	}
+	return nil
+}
+
+type descriptorReader struct {
+	fs descriptorFS
+	fd int
+}
+
+func (reader descriptorReader) Read(buffer []byte) (int, error) {
+	for {
+		count, err := reader.fs.read(reader.fd, buffer)
+		if count > 0 {
+			return count, nil
+		}
+		if err == nil {
+			return 0, io.EOF
+		}
+		if !errors.Is(err, unix.EINTR) {
+			return count, err
+		}
+	}
+}
+
+// readOwnerFileAt verifies and closes one owner-only regular file beneath
+// dirFD. The caller must obtain dirFD from a trusted descriptor walk. A caller
+// that correlates this snapshot with another file or later mutates state based
+// on it must also hold the enclosing state lock through that decision. Because
+// the file descriptor is not retained, same-UID mutations that preserve the
+// checked identity and metadata remain outside this helper's guarantee.
+func readOwnerFileAt(dirFD int, name, path, subject string, limit int64, writable bool, allowedLinks ...uint64) (ownerFile, error) {
+	return readOwnerFileAtFS(defaultDescriptorFS(), dirFD, name, path, subject, limit, writable, allowedLinks...)
+}
+
+func readOwnerFileAtFS(fs descriptorFS, dirFD int, name, path, subject string, limit int64, writable bool, allowedLinks ...uint64) (result ownerFile, err error) {
+	if err := safeDescriptorBasename(name); err != nil {
+		return ownerFile{}, err
+	}
+	if limit <= 0 || limit > math.MaxInt64-1 {
+		return ownerFile{}, errors.New("owner-file read limit must be positive and permit a one-byte overflow probe")
+	}
+	var expected unix.Stat_t
+	if err := fs.fstatat(dirFD, name, &expected, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return ownerFile{}, err
+	}
+	if expected.Mode&unix.S_IFMT != unix.S_IFREG || expected.Ino == 0 {
+		return ownerFile{}, fmt.Errorf("%s: %s is not a regular file", path, subject)
+	}
+	flags := unix.O_RDONLY
+	if writable {
+		flags = unix.O_RDWR
+	}
+	fd, err := fs.openat(dirFD, name, flags|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		if fd >= 0 {
+			err = closeOwnedDescriptors(err, ownDescriptor(fs, fd))
+		}
+		if errors.Is(err, unix.ELOOP) {
+			return ownerFile{}, fmt.Errorf("%s: %s is not a regular file: %w", path, subject, err)
+		}
+		return ownerFile{}, err
+	}
+	if fd < 0 {
+		return ownerFile{}, errors.New("owner-file open returned an invalid descriptor")
+	}
+	owned := ownDescriptor(fs, fd)
+	defer func() {
+		err = errors.Join(err, owned.close())
+		if err != nil {
+			result = ownerFile{}
+		}
+	}()
+
+	var before unix.Stat_t
+	if err := fs.fstat(fd, &before); err != nil {
+		return ownerFile{}, err
+	}
+	if !sameFileIdentity(expected, before) || before.Mode&unix.S_IFMT != unix.S_IFREG {
+		return ownerFile{}, fmt.Errorf("%s: %s changed between inspection and open", path, subject)
+	}
+	if err := validateOwnerFileStat(path, subject, before, limit, allowedLinks...); err != nil {
+		return ownerFile{}, err
+	}
+	data, err := io.ReadAll(io.LimitReader(descriptorReader{fs: fs, fd: fd}, limit+1))
+	if err != nil {
+		return ownerFile{}, err
+	}
+	var after unix.Stat_t
+	if err := fs.fstat(fd, &after); err != nil {
+		return ownerFile{}, err
+	}
+	if err := validateOwnerFileStat(path, subject, after, limit, allowedLinks...); err != nil {
+		return ownerFile{}, err
+	}
+	if int64(len(data)) > limit {
+		return ownerFile{}, fmt.Errorf("%s: %s exceeds %d bytes", path, subject, limit)
+	}
+	if !sameFileIdentity(before, after) || before.Uid != after.Uid || before.Gid != after.Gid || before.Mode != after.Mode || before.Nlink != after.Nlink || before.Size != after.Size || int64(len(data)) != after.Size {
+		return ownerFile{}, fmt.Errorf("%s: %s changed while it was read", path, subject)
+	}
+	return ownerFile{data: data, stat: after}, nil
+}
+
+func validateOwnerFileStat(path, subject string, stat unix.Stat_t, limit int64, allowedLinks ...uint64) error {
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG || stat.Ino == 0 {
+		return fmt.Errorf("%s: %s is not a regular file", path, subject)
+	}
+	if !ownedByCurrentUser(stat) || stat.Mode&0o077 != 0 {
+		return fmt.Errorf("%s: %s must be owned by the current user and owner-only", path, subject)
+	}
+	linkAllowed := false
+	for _, count := range allowedLinks {
+		if count > 0 && uint64(stat.Nlink) == count {
+			linkAllowed = true
+		}
+	}
+	if !linkAllowed {
+		return fmt.Errorf("%s: %s link count is unsafe", path, subject)
+	}
+	if stat.Size < 0 || stat.Size > limit {
+		return fmt.Errorf("%s: %s exceeds %d bytes", path, subject, limit)
+	}
+	return nil
+}
+
+func sameFileIdentity(left, right unix.Stat_t) bool {
+	return left.Dev == right.Dev && left.Ino == right.Ino
+}

--- a/internal/host/sessions/owner_file_test.go
+++ b/internal/host/sessions/owner_file_test.go
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessions
+
+import (
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func openTestDirectory(t testing.TB, path string) int {
+	t.Helper()
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := unix.Close(fd); err != nil {
+			t.Errorf("close test directory: %v", err)
+		}
+	})
+	return fd
+}
+
+func writeOwnerTestFile(t testing.TB, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReadOwnerFileAtRejectsUnsafeBasenamesBeforeIO(t *testing.T) {
+	names := []string{"", ".", "..", "/absolute", "../leaf", "nested/leaf", "nested//leaf", "leaf/", " leaf", "leaf ", "leaf\x00suffix"}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			fs := defaultDescriptorFS()
+			opens := 0
+			fs.openat = func(int, string, int, uint32) (int, error) {
+				opens++
+				return -1, errors.New("unexpected open")
+			}
+			if _, err := readOwnerFileAtFS(fs, -1, name, name, "test file", 8, false, 1); err == nil {
+				t.Fatal("unsafe basename was accepted")
+			}
+			if opens != 0 {
+				t.Fatalf("unsafe basename performed %d opens", opens)
+			}
+		})
+	}
+}
+
+func TestReadOwnerFileAtBoundariesAndPositiveRead(t *testing.T) {
+	root := physicalTempDir(t)
+	dirFD := openTestDirectory(t, root)
+	path := filepath.Join(root, "record")
+	writeOwnerTestFile(t, path, []byte("four"))
+
+	for _, limit := range []int64{4, math.MaxInt64 - 1} {
+		file, err := readOwnerFileAt(dirFD, "record", path, "record", limit, false, 1)
+		if err != nil {
+			t.Fatalf("limit %d rejected exact file: %v", limit, err)
+		}
+		if string(file.data) != "four" || file.stat.Size != 4 {
+			t.Fatalf("read result = %q, size = %d", file.data, file.stat.Size)
+		}
+	}
+	if _, err := readOwnerFileAt(dirFD, "record", path, "record", 3, false, 1); err == nil {
+		t.Fatal("file larger than limit was accepted")
+	}
+	for _, limit := range []int64{-1, 0, math.MaxInt64} {
+		fs := defaultDescriptorFS()
+		opens := 0
+		fs.openat = func(int, string, int, uint32) (int, error) {
+			opens++
+			return -1, errors.New("unexpected open")
+		}
+		if _, err := readOwnerFileAtFS(fs, dirFD, "record", path, "record", limit, false, 1); err == nil || opens != 0 {
+			t.Fatalf("limit %d: error = %v, opens = %d", limit, err, opens)
+		}
+	}
+
+	emptyPath := filepath.Join(root, "empty")
+	writeOwnerTestFile(t, emptyPath, nil)
+	if file, err := readOwnerFileAt(dirFD, "empty", emptyPath, "empty file", 1, true, 1); err != nil || len(file.data) != 0 {
+		t.Fatalf("empty writable read = %#v, %v", file, err)
+	}
+}
+
+func TestReadOwnerFileAtRejectsSymlinkFIFODeviceAndDirectory(t *testing.T) {
+	root := physicalTempDir(t)
+	dirFD := openTestDirectory(t, root)
+	regular := filepath.Join(root, "regular")
+	writeOwnerTestFile(t, regular, []byte("data"))
+	if err := os.Symlink(regular, filepath.Join(root, "symlink")); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Mkfifo(filepath.Join(root, "fifo"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "directory"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"symlink", "fifo", "directory"} {
+		fs := defaultDescriptorFS()
+		opens := 0
+		fs.openat = func(int, string, int, uint32) (int, error) {
+			opens++
+			return -1, errors.New("unexpected open")
+		}
+		if _, err := readOwnerFileAtFS(fs, dirFD, name, filepath.Join(root, name), name, 16, false, 1); err == nil {
+			t.Fatalf("%s was accepted as a regular file", name)
+		}
+		if opens != 0 {
+			t.Fatalf("%s performed %d opens before type rejection", name, opens)
+		}
+	}
+
+	deviceDirFD := openTestDirectory(t, "/dev")
+	fs := defaultDescriptorFS()
+	opens := 0
+	fs.openat = func(int, string, int, uint32) (int, error) {
+		opens++
+		return -1, errors.New("unexpected open")
+	}
+	if _, err := readOwnerFileAtFS(fs, deviceDirFD, "null", "/dev/null", "device", 1, false, 1); err == nil {
+		t.Fatal("device was accepted as a regular file")
+	}
+	if opens != 0 {
+		t.Fatalf("device performed %d opens before type rejection", opens)
+	}
+}
+
+func TestReadOwnerFileAtRejectsIdentitySwapBetweenInspectionAndOpen(t *testing.T) {
+	root := physicalTempDir(t)
+	dirFD := openTestDirectory(t, root)
+	path := filepath.Join(root, "record")
+	oldPath := filepath.Join(root, "record-opened")
+	writeOwnerTestFile(t, path, []byte("old!"))
+
+	fs := defaultDescriptorFS()
+	originalOpen := fs.openat
+	var swapErr error
+	fs.openat = func(dirFD int, name string, flags int, mode uint32) (int, error) {
+		if swapErr == nil {
+			if err := os.Rename(path, oldPath); err != nil {
+				swapErr = err
+			} else if err := os.WriteFile(path, []byte("new!"), 0o600); err != nil {
+				swapErr = err
+			} else if err := os.Chmod(path, 0o600); err != nil {
+				swapErr = err
+			}
+		}
+		return originalOpen(dirFD, name, flags, mode)
+	}
+	if _, err := readOwnerFileAtFS(fs, dirFD, "record", path, "record", 4, false, 1); err == nil || !strings.Contains(err.Error(), "changed between inspection and open") {
+		t.Fatalf("identity swap error = %v", err)
+	}
+	if swapErr != nil {
+		t.Fatal(swapErr)
+	}
+}
+
+func TestReadOwnerFileAtRejectsUnsafeModeOwnerAndLinkCount(t *testing.T) {
+	root := physicalTempDir(t)
+	dirFD := openTestDirectory(t, root)
+	path := filepath.Join(root, "record")
+	writeOwnerTestFile(t, path, []byte("data"))
+	if err := os.Chmod(path, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readOwnerFileAt(dirFD, "record", path, "record", 4, false, 1); err == nil {
+		t.Fatal("group-readable file was accepted")
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	linkPath := filepath.Join(root, "record-link")
+	if err := os.Link(path, linkPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readOwnerFileAt(dirFD, "record", path, "record", 4, false, 1); err == nil {
+		t.Fatal("unexpected two-link file was accepted")
+	}
+	if file, err := readOwnerFileAt(dirFD, "record", path, "record", 4, false, 2); err != nil || string(file.data) != "data" {
+		t.Fatalf("explicit two-link read = %q, %v", file.data, err)
+	}
+
+	fs := defaultDescriptorFS()
+	originalFstat := fs.fstat
+	fs.fstat = func(fd int, stat *unix.Stat_t) error {
+		if err := originalFstat(fd, stat); err != nil {
+			return err
+		}
+		stat.Uid = uint32(os.Geteuid()) + 1
+		return nil
+	}
+	if _, err := readOwnerFileAtFS(fs, dirFD, "record", path, "record", 4, false, 2); err == nil {
+		t.Fatal("foreign-owned file was accepted")
+	}
+}
+
+func TestValidateOwnerFileStatRejectsMetadataBoundaries(t *testing.T) {
+	valid := unix.Stat_t{Mode: unix.S_IFREG | 0o600, Uid: uint32(os.Geteuid()), Nlink: 1, Size: 4, Ino: 1}
+	tests := []struct {
+		name   string
+		mutate func(*unix.Stat_t)
+		links  []uint64
+	}{
+		{name: "zero inode", mutate: func(stat *unix.Stat_t) { stat.Ino = 0 }, links: []uint64{1}},
+		{name: "special", mutate: func(stat *unix.Stat_t) { stat.Mode = unix.S_IFIFO | 0o600 }, links: []uint64{1}},
+		{name: "owner", mutate: func(stat *unix.Stat_t) { stat.Uid++ }, links: []uint64{1}},
+		{name: "mode", mutate: func(stat *unix.Stat_t) { stat.Mode |= 0o004 }, links: []uint64{1}},
+		{name: "no allowed links", mutate: func(*unix.Stat_t) {}},
+		{name: "zero allowed link", mutate: func(*unix.Stat_t) {}, links: []uint64{0}},
+		{name: "wrong link", mutate: func(stat *unix.Stat_t) { stat.Nlink = 2 }, links: []uint64{1}},
+		{name: "negative size", mutate: func(stat *unix.Stat_t) { stat.Size = -1 }, links: []uint64{1}},
+		{name: "over size", mutate: func(stat *unix.Stat_t) { stat.Size = 5 }, links: []uint64{1}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stat := valid
+			test.mutate(&stat)
+			if err := validateOwnerFileStat("record", "record", stat, 4, test.links...); err == nil {
+				t.Fatal("unsafe metadata was accepted")
+			}
+		})
+	}
+}
+
+func TestReadOwnerFileAtDetectsPostReadMutation(t *testing.T) {
+	root := physicalTempDir(t)
+	dirFD := openTestDirectory(t, root)
+	path := filepath.Join(root, "record")
+	writeOwnerTestFile(t, path, []byte("four"))
+	fs := defaultDescriptorFS()
+	originalRead := fs.read
+	mutated := false
+	var mutationErr error
+	fs.read = func(fd int, buffer []byte) (int, error) {
+		count, err := originalRead(fd, buffer)
+		if count > 0 && !mutated {
+			mutated = true
+			mutationErr = os.WriteFile(path, []byte("expanded"), 0o600)
+		}
+		return count, err
+	}
+	if _, err := readOwnerFileAtFS(fs, dirFD, "record", path, "record", 16, false, 1); err == nil {
+		t.Fatal("post-read size mutation was accepted")
+	}
+	if mutationErr != nil {
+		t.Fatal(mutationErr)
+	}
+
+	writeOwnerTestFile(t, path, []byte("four"))
+	fs = defaultDescriptorFS()
+	originalFstat := fs.fstat
+	fstatCalls := 0
+	fs.fstat = func(fd int, stat *unix.Stat_t) error {
+		if err := originalFstat(fd, stat); err != nil {
+			return err
+		}
+		fstatCalls++
+		if fstatCalls == 2 {
+			stat.Ino++
+		}
+		return nil
+	}
+	if _, err := readOwnerFileAtFS(fs, dirFD, "record", path, "record", 4, false, 1); err == nil {
+		t.Fatal("post-read identity mutation was accepted")
+	}
+}
+
+func TestReadOwnerFileAtJoinsOperationAndCloseFailuresWithoutRetry(t *testing.T) {
+	for _, operation := range []string{"first fstat", "second fstat", "read", "close"} {
+		t.Run(operation, func(t *testing.T) {
+			root := physicalTempDir(t)
+			dirFD := openTestDirectory(t, root)
+			path := filepath.Join(root, "record")
+			writeOwnerTestFile(t, path, []byte("data"))
+			operationFailure := errors.New("operation failure")
+			closeFailure := errors.New("close failure")
+			fs := defaultDescriptorFS()
+			originalFstat, originalRead, originalClose := fs.fstat, fs.read, fs.close
+			fstatCalls, closeCalls := 0, 0
+			fs.fstat = func(fd int, stat *unix.Stat_t) error {
+				fstatCalls++
+				if (operation == "first fstat" && fstatCalls == 1) || (operation == "second fstat" && fstatCalls == 2) {
+					return operationFailure
+				}
+				return originalFstat(fd, stat)
+			}
+			fs.read = func(fd int, buffer []byte) (int, error) {
+				if operation == "read" {
+					return 0, operationFailure
+				}
+				return originalRead(fd, buffer)
+			}
+			fs.close = func(fd int) error {
+				closeCalls++
+				return errors.Join(originalClose(fd), closeFailure)
+			}
+			file, err := readOwnerFileAtFS(fs, dirFD, "record", path, "record", 4, false, 1)
+			if operation != "close" && !errors.Is(err, operationFailure) {
+				t.Fatalf("operation error = %v", err)
+			}
+			if !errors.Is(err, closeFailure) || closeCalls != 1 {
+				t.Fatalf("close error = %v, calls = %d", err, closeCalls)
+			}
+			if len(file.data) != 0 {
+				t.Fatalf("data returned after failure: %q", file.data)
+			}
+		})
+	}
+}

--- a/internal/host/sessions/secure_path.go
+++ b/internal/host/sessions/secure_path.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessions
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+type descriptorFS struct {
+	openat   func(int, string, int, uint32) (int, error)
+	fstatat  func(int, string, *unix.Stat_t, int) error
+	mkdirat  func(int, string, uint32) error
+	linkat   func(int, string, int, string, int) error
+	unlinkat func(int, string, int) error
+	fchmod   func(int, uint32) error
+	fstat    func(int, *unix.Stat_t) error
+	fsync    func(int) error
+	flock    func(int, int) error
+	read     func(int, []byte) (int, error)
+	close    func(int) error
+}
+
+func defaultDescriptorFS() descriptorFS {
+	return descriptorFS{
+		openat: unix.Openat, fstatat: unix.Fstatat, mkdirat: unix.Mkdirat, linkat: unix.Linkat,
+		unlinkat: unix.Unlinkat, fchmod: unix.Fchmod, fstat: unix.Fstat,
+		fsync: unix.Fsync, flock: unix.Flock, read: unix.Read, close: unix.Close,
+	}
+}
+
+// ownedDescriptor records exactly one close obligation. close consumes that
+// obligation before invoking the seam, so even a reported close failure is
+// never retried against a descriptor number the kernel may already have reused.
+type ownedDescriptor struct {
+	fs descriptorFS
+	fd int
+}
+
+func ownDescriptor(fs descriptorFS, fd int) *ownedDescriptor {
+	return &ownedDescriptor{fs: fs, fd: fd}
+}
+
+func (descriptor *ownedDescriptor) close() error {
+	if descriptor == nil || descriptor.fd < 0 {
+		return nil
+	}
+	fd := descriptor.fd
+	descriptor.fd = -1
+	return descriptor.fs.close(fd)
+}
+
+func (descriptor *ownedDescriptor) release() int {
+	fd := descriptor.fd
+	descriptor.fd = -1
+	return fd
+}
+
+func closeOwnedDescriptors(cause error, descriptors ...*ownedDescriptor) error {
+	result := cause
+	for _, descriptor := range descriptors {
+		result = errors.Join(result, descriptor.close())
+	}
+	return result
+}
+
+type directoryPolicy func(string, unix.Stat_t) error
+
+// absoluteDirectoryComponents deliberately rejects non-canonical raw input
+// instead of normalizing it. The accepted spelling has one leading separator,
+// no trailing or duplicate separators, no dot components, and no component
+// whose leading or trailing whitespace would be changed by trimming.
+func absoluteDirectoryComponents(path string) ([]string, error) {
+	separator := string(filepath.Separator)
+	if path == "" || path != strings.TrimSpace(path) || !filepath.IsAbs(path) || path == separator || strings.ContainsRune(path, 0) {
+		return nil, errors.New("secure directory walk requires a canonical absolute non-root path")
+	}
+	components := strings.Split(strings.TrimPrefix(path, separator), separator)
+	for _, component := range components {
+		if component == "" || component == "." || component == ".." || component != strings.TrimSpace(component) {
+			return nil, errors.New("secure directory walk contains an unsafe raw component")
+		}
+	}
+	return components, nil
+}
+
+func ownedByCurrentUser(stat unix.Stat_t) bool {
+	return ownedByUser(stat, uint32(os.Geteuid()))
+}
+
+func ownedByUser(stat unix.Stat_t, euid uint32) bool {
+	return stat.Uid == euid
+}
+
+func ownerControlsDirectory(stat unix.Stat_t) bool {
+	return ownerControlsDirectoryForUser(stat, uint32(os.Geteuid()))
+}
+
+func ownerControlsDirectoryForUser(stat unix.Stat_t, euid uint32) bool {
+	return stat.Mode&unix.S_IFMT == unix.S_IFDIR && stat.Ino != 0 && ownedByUser(stat, euid) && stat.Mode&0o022 == 0
+}
+
+// validateWalkDirectory permits only root-owned non-writable system ancestors
+// (plus root-owned sticky transit directories such as /tmp) until it reaches a
+// directory controlled by the current user. Below that anchor, every component
+// must remain controlled by the current user. This constrains replacement races
+// to the same-UID actor that already controls the selected state tree.
+func validateWalkDirectory(path string, stat unix.Stat_t, anchored bool) (bool, error) {
+	return validateWalkDirectoryForUser(path, stat, anchored, uint32(os.Geteuid()))
+}
+
+func validateWalkDirectoryForUser(path string, stat unix.Stat_t, anchored bool, euid uint32) (bool, error) {
+	if stat.Mode&unix.S_IFMT != unix.S_IFDIR || stat.Ino == 0 {
+		return false, fmt.Errorf("%s: path contains a non-directory component", path)
+	}
+	ownedAndControlled := ownerControlsDirectoryForUser(stat, euid)
+	if anchored {
+		if !ownedAndControlled {
+			return false, fmt.Errorf("%s: directory below the owner-controlled anchor is unsafe", path)
+		}
+		return true, nil
+	}
+	if stat.Uid == 0 && (stat.Mode&0o022 == 0 || stat.Mode&unix.S_ISVTX != 0) {
+		return euid == 0 && stat.Mode&0o077 == 0 && stat.Mode&unix.S_ISVTX == 0, nil
+	}
+	if ownedAndControlled {
+		return true, nil
+	}
+	return false, fmt.Errorf("%s: directory ancestor is not trusted", path)
+}
+
+// openAbsoluteDirectory walks an already-canonical absolute path from a
+// descriptor for /. Each component is opened with O_DIRECTORY|O_NOFOLLOW. The
+// returned descriptor belongs to the caller. The walk prevents symlink
+// redirection and rejects writable or foreign-owned ancestors according to
+// validateWalkDirectory; it does not defend against a same-UID actor that can
+// mutate the anchored tree concurrently.
+func openAbsoluteDirectory(path string, create bool, fs descriptorFS, policy directoryPolicy) (int, error) {
+	components, err := absoluteDirectoryComponents(path)
+	if err != nil {
+		return -1, err
+	}
+	rootFD, err := fs.openat(unix.AT_FDCWD, string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		if rootFD >= 0 {
+			err = closeOwnedDescriptors(err, ownDescriptor(fs, rootFD))
+		}
+		return -1, err
+	}
+	if rootFD < 0 {
+		return -1, errors.New("root open returned an invalid descriptor")
+	}
+	current := ownDescriptor(fs, rootFD)
+	var rootStat unix.Stat_t
+	if err := fs.fstat(current.fd, &rootStat); err != nil {
+		return -1, closeOwnedDescriptors(err, current)
+	}
+	anchored, err := validateWalkDirectory(string(filepath.Separator), rootStat, false)
+	if err != nil {
+		return -1, closeOwnedDescriptors(err, current)
+	}
+
+	for index, component := range components {
+		nextFD, openErr := fs.openat(current.fd, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if openErr != nil && nextFD >= 0 {
+			return -1, closeOwnedDescriptors(openErr, ownDescriptor(fs, nextFD), current)
+		}
+		created := false
+		if errors.Is(openErr, unix.ENOENT) && create {
+			mkdirErr := fs.mkdirat(current.fd, component, 0o700)
+			if mkdirErr != nil && !errors.Is(mkdirErr, unix.EEXIST) {
+				return -1, closeOwnedDescriptors(mkdirErr, current)
+			}
+			created = mkdirErr == nil
+			nextFD, openErr = fs.openat(current.fd, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+			if openErr != nil && nextFD >= 0 {
+				return -1, closeOwnedDescriptors(openErr, ownDescriptor(fs, nextFD), current)
+			}
+		}
+		if openErr != nil {
+			if errors.Is(openErr, unix.ELOOP) || errors.Is(openErr, unix.ENOTDIR) {
+				openErr = fmt.Errorf("%s: directory path contains a symlink or non-directory component: %w", path, openErr)
+			}
+			return -1, closeOwnedDescriptors(openErr, current)
+		}
+		if nextFD < 0 {
+			return -1, closeOwnedDescriptors(errors.New("component open returned an invalid descriptor"), current)
+		}
+		next := ownDescriptor(fs, nextFD)
+		if created {
+			if err := fs.fchmod(next.fd, 0o700); err != nil {
+				return -1, closeOwnedDescriptors(err, next, current)
+			}
+		}
+		var stat unix.Stat_t
+		if err := fs.fstat(next.fd, &stat); err != nil {
+			return -1, closeOwnedDescriptors(err, next, current)
+		}
+		nextAnchored, err := validateWalkDirectory(path, stat, anchored)
+		if err != nil {
+			return -1, closeOwnedDescriptors(err, next, current)
+		}
+		final := index == len(components)-1
+		if final && policy != nil {
+			if err := policy(path, stat); err != nil {
+				return -1, closeOwnedDescriptors(err, next, current)
+			}
+		}
+		// A retry after an ambiguous mkdir/fsync result must resync the
+		// containing directory even when this invocation found the child.
+		if create && (created || ownerControlsDirectory(stat)) {
+			if err := fs.fsync(current.fd); err != nil {
+				return -1, closeOwnedDescriptors(err, next, current)
+			}
+		}
+		if err := current.close(); err != nil {
+			return -1, closeOwnedDescriptors(err, next, current)
+		}
+		current = next
+		anchored = nextAnchored
+	}
+	return current.release(), nil
+}
+
+func requireOwnerOnlyDirectory(path string, stat unix.Stat_t) error {
+	if !ownerControlsDirectory(stat) || stat.Mode&0o077 != 0 {
+		return fmt.Errorf("%s: directory must be owned by the current user and owner-only", path)
+	}
+	return nil
+}
+
+func requireOwnerControlledDirectory(path string, stat unix.Stat_t) error {
+	if !ownerControlsDirectory(stat) {
+		return fmt.Errorf("%s: directory must be owner-controlled", path)
+	}
+	return nil
+}

--- a/internal/host/sessions/secure_path_test.go
+++ b/internal/host/sessions/secure_path_test.go
@@ -1,0 +1,437 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessions
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestOpenAbsoluteDirectoryPositiveNestedExistingAndCreate(t *testing.T) {
+	root := physicalTempDir(t)
+	existing := filepath.Join(root, "existing", "leaf")
+	if err := os.MkdirAll(existing, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(existing, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	fd, err := openAbsoluteDirectory(existing, false, defaultDescriptorFS(), requireOwnerOnlyDirectory)
+	if err != nil {
+		t.Fatalf("open existing nested directory: %v", err)
+	}
+	if err := unix.Close(fd); err != nil {
+		t.Fatal(err)
+	}
+
+	created := filepath.Join(root, "created", "leaf")
+	fd, err = openAbsoluteDirectory(created, true, defaultDescriptorFS(), requireOwnerOnlyDirectory)
+	if err != nil {
+		t.Fatalf("create nested directory: %v", err)
+	}
+	if err := unix.Close(fd); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{filepath.Dir(created), created} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o700 {
+			t.Fatalf("%s mode = %o", path, info.Mode().Perm())
+		}
+	}
+}
+
+func TestOpenAbsoluteDirectoryRejectsNonCanonicalRawPathsBeforeIO(t *testing.T) {
+	root := physicalTempDir(t)
+	paths := []string{
+		"relative/path",
+		string(filepath.Separator),
+		" " + filepath.Join(root, "leaf"),
+		filepath.Join(root, "leaf") + " ",
+		root + "//leaf",
+		root + "/./leaf",
+		root + "/../leaf",
+		root + "/leaf/",
+		root + "/ leaf",
+		root + "/leaf\x00suffix",
+		"//tmp/leaf",
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			fs := defaultDescriptorFS()
+			opens := 0
+			fs.openat = func(int, string, int, uint32) (int, error) {
+				opens++
+				return -1, errors.New("unexpected open")
+			}
+			if fd, err := openAbsoluteDirectory(path, true, fs, requireOwnerOnlyDirectory); err == nil {
+				unix.Close(fd)
+				t.Fatal("unsafe raw path was accepted")
+			}
+			if opens != 0 {
+				t.Fatalf("unsafe raw path performed %d opens", opens)
+			}
+		})
+	}
+}
+
+func TestOpenAbsoluteDirectoryRejectsSymlinkAncestorAndLeaf(t *testing.T) {
+	for _, create := range []bool{false, true} {
+		t.Run(map[bool]string{false: "existing", true: "missing"}[create], func(t *testing.T) {
+			root := physicalTempDir(t)
+			realParent := filepath.Join(root, "real")
+			if err := os.Mkdir(realParent, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if !create {
+				if err := os.Mkdir(filepath.Join(realParent, "target"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.Symlink(realParent, filepath.Join(root, "redirect")); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(root, "redirect", "target")
+			if fd, err := openAbsoluteDirectory(path, create, defaultDescriptorFS(), requireOwnerOnlyDirectory); err == nil {
+				unix.Close(fd)
+				t.Fatal("symlink ancestor was accepted")
+			}
+			if create {
+				if _, err := os.Lstat(filepath.Join(realParent, "target")); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("walker created through symlink ancestor: %v", err)
+				}
+			}
+		})
+	}
+
+	root := physicalTempDir(t)
+	realLeaf := filepath.Join(root, "real-leaf")
+	if err := os.Mkdir(realLeaf, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	symlinkLeaf := filepath.Join(root, "leaf")
+	if err := os.Symlink(realLeaf, symlinkLeaf); err != nil {
+		t.Fatal(err)
+	}
+	if fd, err := openAbsoluteDirectory(symlinkLeaf, false, defaultDescriptorFS(), requireOwnerOnlyDirectory); err == nil {
+		unix.Close(fd)
+		t.Fatal("symlink leaf was accepted")
+	}
+}
+
+func TestOpenAbsoluteDirectoryRejectsUnsafeDirectoryBelowAnchor(t *testing.T) {
+	root := physicalTempDir(t)
+	unsafe := filepath.Join(root, "writable")
+	leaf := filepath.Join(unsafe, "leaf")
+	if err := os.MkdirAll(leaf, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(unsafe, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if fd, err := openAbsoluteDirectory(leaf, false, defaultDescriptorFS(), requireOwnerOnlyDirectory); err == nil {
+		unix.Close(fd)
+		t.Fatal("writable directory below owner-controlled anchor was accepted")
+	}
+	if err := os.Chmod(unsafe, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var unsafeStat unix.Stat_t
+	if err := unix.Stat(unsafe, &unsafeStat); err != nil {
+		t.Fatal(err)
+	}
+	fs := defaultDescriptorFS()
+	originalFstat := fs.fstat
+	fs.fstat = func(fd int, stat *unix.Stat_t) error {
+		if err := originalFstat(fd, stat); err != nil {
+			return err
+		}
+		if sameFileIdentity(*stat, unsafeStat) {
+			stat.Uid = uint32(os.Geteuid()) + 1
+		}
+		return nil
+	}
+	if fd, err := openAbsoluteDirectory(leaf, false, fs, requireOwnerOnlyDirectory); err == nil {
+		unix.Close(fd)
+		t.Fatal("foreign-owned directory below owner-controlled anchor was accepted")
+	}
+}
+
+func TestValidateWalkDirectoryEstablishesRootOnlyAnchor(t *testing.T) {
+	rootSystem := unix.Stat_t{Mode: unix.S_IFDIR | 0o755, Uid: 0, Ino: 1}
+	rootSticky := unix.Stat_t{Mode: unix.S_IFDIR | unix.S_ISVTX | 0o777, Uid: 0, Ino: 1}
+	rootOnly := unix.Stat_t{Mode: unix.S_IFDIR | 0o700, Uid: 0, Ino: 1}
+
+	anchored, err := validateWalkDirectoryForUser("/", rootSystem, false, 0)
+	if err != nil || anchored {
+		t.Fatalf("root system directory: anchored = %v, error = %v", anchored, err)
+	}
+	anchored, err = validateWalkDirectoryForUser("/tmp", rootSticky, false, 0)
+	if err != nil || anchored {
+		t.Fatalf("root sticky transit directory: anchored = %v, error = %v", anchored, err)
+	}
+	anchored, err = validateWalkDirectoryForUser("/root", rootOnly, false, 0)
+	if err != nil || !anchored {
+		t.Fatalf("root-only directory: anchored = %v, error = %v", anchored, err)
+	}
+	if _, err := validateWalkDirectoryForUser("/root/writable", rootSticky, anchored, 0); err == nil {
+		t.Fatal("root-owned sticky writable directory below the anchor was accepted")
+	}
+	if stillAnchored, err := validateWalkDirectoryForUser("/root/private", rootOnly, anchored, 0); err != nil || !stillAnchored {
+		t.Fatalf("root-only directory below anchor: anchored = %v, error = %v", stillAnchored, err)
+	}
+}
+
+func TestOpenAbsoluteDirectoryHandlesMkdirEEXISTRaces(t *testing.T) {
+	tests := []struct {
+		name    string
+		install func(string) error
+		wantOK  bool
+	}{
+		{name: "owner-only directory", install: func(path string) error { return os.Mkdir(path, 0o700) }, wantOK: true},
+		{name: "symlink", install: func(path string) error { return os.Symlink(filepath.Dir(path), path) }},
+		{name: "writable directory", install: func(path string) error {
+			if err := os.Mkdir(path, 0o700); err != nil {
+				return err
+			}
+			return os.Chmod(path, 0o777)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := physicalTempDir(t)
+			path := filepath.Join(root, "target")
+			fs := defaultDescriptorFS()
+			mkdirCalls, chmodCalls := 0, 0
+			fs.mkdirat = func(int, string, uint32) error {
+				mkdirCalls++
+				if err := test.install(path); err != nil {
+					return err
+				}
+				return unix.EEXIST
+			}
+			originalChmod := fs.fchmod
+			fs.fchmod = func(fd int, mode uint32) error {
+				chmodCalls++
+				return originalChmod(fd, mode)
+			}
+			fd, err := openAbsoluteDirectory(path, true, fs, requireOwnerOnlyDirectory)
+			if test.wantOK {
+				if err != nil {
+					t.Fatalf("benign EEXIST race failed: %v", err)
+				}
+				unix.Close(fd)
+			} else if err == nil {
+				unix.Close(fd)
+				t.Fatal("unsafe EEXIST race was accepted")
+			}
+			if mkdirCalls != 1 || chmodCalls != 0 {
+				t.Fatalf("mkdir calls = %d, chmod calls = %d", mkdirCalls, chmodCalls)
+			}
+		})
+	}
+}
+
+func TestOpenAbsoluteDirectoryCreateRetryRepairsSkippedParentSync(t *testing.T) {
+	parent := physicalTempDir(t)
+	path := filepath.Join(parent, "created")
+	injected := errors.New("injected parent sync failure")
+	fs := defaultDescriptorFS()
+	originalOpen, originalMkdir, originalSync, originalClose := fs.openat, fs.mkdirat, fs.fsync, fs.close
+	created, failed, targetFD, targetCloses := false, false, -1, 0
+	fs.openat = func(dirFD int, name string, flags int, mode uint32) (int, error) {
+		fd, err := originalOpen(dirFD, name, flags, mode)
+		if err == nil && name == filepath.Base(path) {
+			targetFD = fd
+		}
+		return fd, err
+	}
+	fs.mkdirat = func(fd int, name string, mode uint32) error {
+		err := originalMkdir(fd, name, mode)
+		if err == nil && name == filepath.Base(path) {
+			created = true
+		}
+		return err
+	}
+	fs.fsync = func(fd int) error {
+		if created && !failed {
+			failed = true
+			return injected // Deliberately skip the real fsync.
+		}
+		return originalSync(fd)
+	}
+	fs.close = func(fd int) error {
+		if fd == targetFD {
+			targetCloses++
+		}
+		return originalClose(fd)
+	}
+	if fd, err := openAbsoluteDirectory(path, true, fs, requireOwnerOnlyDirectory); !errors.Is(err, injected) {
+		if fd >= 0 {
+			unix.Close(fd)
+		}
+		t.Fatalf("first create error = %v", err)
+	}
+	if targetCloses != 1 {
+		t.Fatalf("target closes after fsync failure = %d", targetCloses)
+	}
+
+	var parentStat unix.Stat_t
+	if err := unix.Stat(parent, &parentStat); err != nil {
+		t.Fatal(err)
+	}
+	retryFS := defaultDescriptorFS()
+	originalRetrySync := retryFS.fsync
+	parentSyncs := 0
+	retryFS.fsync = func(fd int) error {
+		var stat unix.Stat_t
+		if err := unix.Fstat(fd, &stat); err != nil {
+			return err
+		}
+		if sameFileIdentity(parentStat, stat) {
+			parentSyncs++
+		}
+		return originalRetrySync(fd)
+	}
+	fd, err := openAbsoluteDirectory(path, true, retryFS, requireOwnerOnlyDirectory)
+	if err != nil {
+		t.Fatalf("create retry failed: %v", err)
+	}
+	unix.Close(fd)
+	if parentSyncs == 0 {
+		t.Fatal("create retry did not repair the containing-directory sync")
+	}
+}
+
+func TestOpenAbsoluteDirectoryCleansUpAfterFchmodAndFstatFailures(t *testing.T) {
+	for _, operation := range []string{"fchmod", "fstat"} {
+		t.Run(operation, func(t *testing.T) {
+			root := physicalTempDir(t)
+			path := filepath.Join(root, "target")
+			injected := errors.New("injected " + operation + " failure")
+			fs := defaultDescriptorFS()
+			originalOpen, originalClose := fs.openat, fs.close
+			targetFD, targetCloses := -1, 0
+			fs.openat = func(dirFD int, name string, flags int, mode uint32) (int, error) {
+				fd, err := originalOpen(dirFD, name, flags, mode)
+				if err == nil && name == "target" {
+					targetFD = fd
+				}
+				return fd, err
+			}
+			if operation == "fchmod" {
+				fs.fchmod = func(int, uint32) error { return injected }
+			} else {
+				originalFstat := fs.fstat
+				fs.fstat = func(fd int, stat *unix.Stat_t) error {
+					if fd == targetFD {
+						return injected
+					}
+					return originalFstat(fd, stat)
+				}
+			}
+			fs.close = func(fd int) error {
+				if fd == targetFD {
+					targetCloses++
+				}
+				return originalClose(fd)
+			}
+			if fd, err := openAbsoluteDirectory(path, true, fs, requireOwnerOnlyDirectory); !errors.Is(err, injected) {
+				if fd >= 0 {
+					unix.Close(fd)
+				}
+				t.Fatalf("error = %v", err)
+			}
+			if targetCloses != 1 {
+				t.Fatalf("target closes = %d", targetCloses)
+			}
+		})
+	}
+}
+
+func TestOpenAbsoluteDirectoryJoinsCloseFailuresWithoutRetry(t *testing.T) {
+	root := physicalTempDir(t)
+	path := filepath.Join(root, "target")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	parentFailure := errors.New("parent close failure")
+	targetFailure := errors.New("target cleanup failure")
+	fs := defaultDescriptorFS()
+	originalOpen, originalClose := fs.openat, fs.close
+	parentFD, targetFD := -1, -1
+	parentCloses, targetCloses := 0, 0
+	fs.openat = func(dirFD int, name string, flags int, mode uint32) (int, error) {
+		fd, err := originalOpen(dirFD, name, flags, mode)
+		if err == nil && name == "target" {
+			parentFD, targetFD = dirFD, fd
+		}
+		return fd, err
+	}
+	fs.close = func(fd int) error {
+		realErr := originalClose(fd)
+		switch fd {
+		case parentFD:
+			parentCloses++
+			return errors.Join(realErr, parentFailure)
+		case targetFD:
+			targetCloses++
+			return errors.Join(realErr, targetFailure)
+		default:
+			return realErr
+		}
+	}
+	fd, err := openAbsoluteDirectory(path, false, fs, requireOwnerOnlyDirectory)
+	if fd >= 0 {
+		unix.Close(fd)
+	}
+	if !errors.Is(err, parentFailure) || !errors.Is(err, targetFailure) {
+		t.Fatalf("joined close error = %v", err)
+	}
+	if parentCloses != 1 || targetCloses != 1 {
+		t.Fatalf("parent closes = %d, target closes = %d", parentCloses, targetCloses)
+	}
+}
+
+func TestOpenAbsoluteDirectoryAppliesFinalRootPolicies(t *testing.T) {
+	root := physicalTempDir(t)
+	tests := []struct {
+		name   string
+		mode   os.FileMode
+		policy directoryPolicy
+		wantOK bool
+	}{
+		{name: "owner-only accepted", mode: 0o700, policy: requireOwnerOnlyDirectory, wantOK: true},
+		{name: "owner-controlled accepted", mode: 0o750, policy: requireOwnerControlledDirectory, wantOK: true},
+		{name: "owner-only rejects read bits", mode: 0o750, policy: requireOwnerOnlyDirectory},
+		{name: "owner-controlled rejects writes", mode: 0o770, policy: requireOwnerControlledDirectory},
+	}
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(root, "policy-"+string(rune('a'+index)))
+			if err := os.Mkdir(path, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(path, test.mode); err != nil {
+				t.Fatal(err)
+			}
+			fd, err := openAbsoluteDirectory(path, false, defaultDescriptorFS(), test.policy)
+			if test.wantOK {
+				if err != nil {
+					t.Fatalf("valid root rejected: %v", err)
+				}
+				unix.Close(fd)
+			} else if err == nil {
+				unix.Close(fd)
+				t.Fatal("invalid root accepted")
+			}
+		})
+	}
+}

--- a/internal/host/sessions/test_helpers_test.go
+++ b/internal/host/sessions/test_helpers_test.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessions
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// physicalTempDir removes platform aliases such as macOS /var -> /private/var
+// so raw-path tests exercise the descriptor walker rather than an OS symlink.
+func physicalTempDir(t testing.TB) string {
+	t.Helper()
+	dir := t.TempDir()
+	physical, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return physical
+}


### PR DESCRIPTION
## Summary

- add descriptor-relative, symlink-resistant directory walking for owner-controlled session state
- add bounded owner-only regular-file reads with identity and metadata revalidation
- add deterministic syscall seams and adversarial race, ownership, mode, link-count, close, and platform tests

This is a dormant package-private foundation for the sequenced C3 shared-profile work. It does not activate parallel sessions, change the CLI or public contract, or make a new support claim.

## Risk and assurance

- the implementation is Unix-only and unreachable from shipped runtime paths in this unit
- directory traversal is rooted at a trusted descriptor and fails closed on noncanonical paths, symlinks, unsafe ancestors, and same-read mutations
- same-UID mutation outside the enclosing state lock is explicitly outside these helpers' guarantee

## Validation

- independent adversarial review reached clean consensus on the exact rebased tree
- focused/full Go tests, race detector, vet, staticcheck, and 20 shuffled runs passed
- Darwin and Linux `amd64`/`arm64` compilation passed
- hardened read-only Linux execution passed as root and UID 65532
- full `pr-parity` passed on the exact staged tree, including live Colima invariants and release-payload checks

No live C3 support certification is required for this dormant, unreachable foundation; later behavior-changing units remain fail closed until their exact-tree live gates pass.
