### PR TITLE
Harden canonical build environments for validation roots

### DIFF
--- a/.agents/skills/workcell-contract-parity/SKILL.md
+++ b/.agents/skills/workcell-contract-parity/SKILL.md
@@ -177,7 +177,7 @@ If `scripts/workcell` changed, also run:
 If contract or release-facing docs changed broadly, finish with:
 
 ```sh
-bash ./scripts/validate-repo.sh
+/usr/bin/env -u GIT_PAGER ./scripts/validate-repo.sh
 ```
 
 ## Blocking rule

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -155,7 +155,7 @@ Always run the smallest local validation that proves the actual change. When
 the work updates repo-wide instructions or multiple docs/skills, finish with:
 
 ```sh
-bash ./scripts/validate-repo.sh
+/usr/bin/env -u GIT_PAGER ./scripts/validate-repo.sh
 ```
 
 Use the GitHub plugin helpers when they fit the task:

--- a/docs/security/security-findings-2026-04-24-validation.md
+++ b/docs/security/security-findings-2026-04-24-validation.md
@@ -81,7 +81,7 @@ bash ./scripts/verify-operator-contract.sh
 bash ./scripts/verify-requirements-coverage.sh
 bash ./scripts/check-dead-code.sh
 bash ./scripts/check-public-repo-hygiene.sh
-bash ./scripts/validate-repo.sh
+/usr/bin/env -u GIT_PAGER ./scripts/validate-repo.sh
 ./scripts/workcell --gc
 ```
 

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -75,6 +75,58 @@ state:
     `--approved-large-certified-adapter` during host publication
 
 They cover repo shape, runtime contracts, smoke behavior, and reproducibility.
+The G0a1a1 canonical-build-environment unit covers `validate-repo`,
+`dev-quick-check`, and the hosted-controls verifier. These three roots
+explicitly source `scripts/lib/canonical-build-env.sh`.
+
+The gate rejects every nonempty ambient shell-identifier `GO*` and `CGO*`
+variable except exact `GOENV=off`, exact `GOWORK=off`, empty `GOFLAGS`, and
+caller-selected `GOPATH`, `GOCACHE`, and `GOMODCACHE` storage paths. It also
+rejects ambient external compiler/tool selectors, `NETRC`, `GCM_INTERACTIVE`,
+nonempty `BASH_ENV` or `ENV`, every retained `BASH_FUNC_*` entry,
+noncanonical shell-identifier `GIT_*` overrides, and system/global Git config
+and attributes. Invalid identifiers exposed by the shell fail generically
+before indirect expansion; raw invalid names hidden by the shell and not
+recognized as tool variables are outside this unit. Set-empty `BASH_ENV` and
+`ENV` are removed so ordinary Bash descendants cannot consume them. The three
+allowed storage paths and their contents are explicitly lower assurance; exact
+tool and build-input identity remains a separate certification dependency.
+Production/default graph checks remain untagged.
+
+G0a1a1 does not yet claim complete CI/release workflow-root closure. G0a1a2
+must close canonical-state propagation through trusted-entrypoint children,
+including forged-sentinel behavior. G0a1b must close the shared validate job's
+containerized archive boundary and early token lifecycle. G0a1c must close
+`ci-plan` and its direct `pre-merge` caller with resident-only base selection,
+no implicit network or authentication, and fail-closed changed-file
+collection. G0a2 must wire and test the remaining build/release helpers,
+including `build-and-test`, pin checks and updates, smoke and manifest
+generation, invariant/release-bundle/reproducibility checks, and
+upstream-release and `verify-build-input-manifest` verification. After G0a2,
+the direct `job-pr-shape`, `job-docs`, `job-mutation`, `job-fuzz`,
+`check-workflows`, and `check-release-tag-signature` roots remain for G0b.
+Release certification stays blocked until these dependencies land.
+
+The gate begins only after the shell process starts. Its startup-state claim
+therefore requires the reviewed privileged shebang, which ignores `BASH_ENV`,
+`ENV`, and imported functions, and clears `CDPATH` during root discovery.
+Launching a root through an arbitrary interpreter is outside this unit. The
+gate also does not constrain arbitrary direct `go` invocations, authenticate
+the local repository's Git administrative metadata, or make
+candidate-controlled scripts trusted. The whole local administrative plane,
+including repository config, refs, index and worktree state, hooks, object and
+alternates storage, replace/graft/shallow data, and `.git/info/attributes`,
+remains an immutable-tree, controller, and scan dependency. It also does not
+authenticate later `PATH` resolution, tool binaries, or the three allowed
+storage roots and their module/build-cache contents. Ambient Go selector
+variables for module proxy, checksum, and auth behavior are rejected, but
+G0a1a does not authenticate the resulting network policy or credential files
+selected through `HOME` (including `.netrc`). General process networking
+variables and the contents reachable through the three allowed storage paths
+also remain outside this unit. Beyond the direct startup-code surfaces above,
+shell semantic and tracing state such as `SHELLOPTS`, `BASHOPTS`,
+`BASH_XTRACEFD`, and descendant `CDPATH` remain a G0a2a hygiene dependency.
+
 They also now cover canonical requirement traceability, host-side policy
 inspection and explainability, host-side detached session inventory, control,
 logs/timeline, clean-base diff/export behavior, and operator-contract parity.

--- a/internal/testkit/canonical_build_env_test.go
+++ b/internal/testkit/canonical_build_env_test.go
@@ -1,0 +1,853 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const canonicalGuardBlock = `# shellcheck source=scripts/lib/canonical-build-env.sh
+source "${ROOT_DIR}/scripts/lib/canonical-build-env.sh"
+workcell_require_modern_privileged_bash "$@"
+workcell_require_canonical_build_environment
+`
+
+var canonicalEntrypoints = []struct {
+	relative       string
+	firstOperation string
+	variable       string
+	value          string
+}{
+	{"scripts/dev-quick-check.sh", "require_tool()", "GOAUTH", "workcell-entrypoint-auth"},
+	{"scripts/validate-repo.sh", "SKIP_HEAVY_HOST_SHELLCHECK=", "CGO_CFLAGS", "-DWORKCELL_ENTRYPOINT"},
+	{"scripts/verify-github-hosted-controls.sh", "POLICY_PATH=", "CC", "/tmp/workcell-entrypoint-cc"},
+}
+
+func canonicalBuildEnvVariable(name string) bool {
+	if strings.HasPrefix(name, "GO") ||
+		strings.HasPrefix(name, "CGO") ||
+		strings.HasPrefix(name, "GIT_") ||
+		strings.HasPrefix(name, "BASH_FUNC_") {
+		return true
+	}
+	switch name {
+	case "CC", "CXX", "FC", "AR", "GCCGO", "GCCGOTOOLDIR", "PKG_CONFIG",
+		"NETRC", "GCM_INTERACTIVE", "BASH_ENV", "ENV",
+		"WORKCELL_CANONICAL_BUILD_ENV", "WORKCELL_SANITIZED_ENTRYPOINT":
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalBuildEnvProbe(
+	tb testing.TB,
+	script string,
+	extraEnv map[string]string,
+	args ...string,
+) (int, string) {
+	tb.Helper()
+
+	helper := filepath.Join(repoRoot(tb), "scripts", "lib", "canonical-build-env.sh")
+	return canonicalBuildEnvProbeWithHelper(tb, helper, script, extraEnv, args...)
+}
+
+func canonicalBuildEnvProbeWithHelper(
+	tb testing.TB,
+	helper string,
+	script string,
+	extraEnv map[string]string,
+	args ...string,
+) (int, string) {
+	tb.Helper()
+
+	argv := []string{"--noprofile", "--norc", "-p", "-c", script, "canonical-build-env-probe", helper}
+	argv = append(argv, args...)
+	cmd := exec.Command("/bin/bash", argv...)
+	cmd.Env = canonicalBuildEnv(extraEnv)
+
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return 0, string(output)
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode(), string(output)
+	}
+	tb.Fatalf("canonical build environment probe failed: %v", err)
+	return 0, ""
+}
+
+func canonicalBuildEnv(extraEnv map[string]string) []string {
+	env := make([]string, 0, len(os.Environ())+len(extraEnv)+2)
+	for _, entry := range os.Environ() {
+		name := strings.SplitN(entry, "=", 2)[0]
+		_, overridden := extraEnv[name]
+		if !canonicalBuildEnvVariable(name) && !overridden {
+			env = append(env, entry)
+		}
+	}
+	for _, name := range []string{"BASH_ENV", "ENV"} {
+		if _, overridden := extraEnv[name]; !overridden {
+			env = append(env, name+"=")
+		}
+	}
+	for name, value := range extraEnv {
+		env = append(env, name+"="+value)
+	}
+	return env
+}
+
+func writeCanonicalFixture(tb testing.TB, path string, content []byte, mode os.FileMode) {
+	tb.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.WriteFile(path, content, mode); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+func copyCanonicalFixture(tb testing.TB, source string, destination string) {
+	tb.Helper()
+	content, err := os.ReadFile(source)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	writeCanonicalFixture(tb, destination, content, 0o755)
+}
+
+func writeCanonicalMutation(
+	tb testing.TB,
+	source string,
+	destination string,
+	original string,
+	replacement string,
+) {
+	tb.Helper()
+	content, err := os.ReadFile(source)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if count := strings.Count(string(content), original); count != 1 {
+		tb.Fatalf("mutation anchor count in %s = %d, want 1: %q", source, count, original)
+	}
+	mutated := strings.Replace(string(content), original, replacement, 1)
+	writeCanonicalFixture(tb, destination, []byte(mutated), 0o755)
+}
+
+func TestCanonicalBuildEnvironmentRejectsBuildAndShellInputs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		variable string
+		value    string
+	}{
+		{"bash-startup", "BASH_ENV", "/tmp/workcell-bash-env"},
+		{"posix-shell-startup", "ENV", "/tmp/workcell-env"},
+		{"exported-bash-function", "BASH_FUNC_workcell_probe%%", "() { printf workcell-hostile; }"},
+		{"flags-tags-equals", "GOFLAGS", "-tags=workcell_dormant"},
+		{"flags-tags-split", "GOFLAGS", "-tags workcell_dormant"},
+		{"flags-overlay-equals", "GOFLAGS", "-overlay=/tmp/workcell-overlay.json"},
+		{"flags-overlay-split", "GOFLAGS", "-overlay /tmp/workcell-overlay.json"},
+		{"persisted-env", "GOENV", "/tmp/workcell-goenv"},
+		{"workspace", "GOWORK", "/tmp/workcell.work"},
+		{"target-os", "GOOS", "linux"},
+		{"target-architecture", "GOARCH", "amd64"},
+		{"experiment", "GOEXPERIMENT", "workcell-hostile"},
+		{"module-mode", "GO111MODULE", "off"},
+		{"toolchain", "GOTOOLCHAIN", "local"},
+		{"toolchain-root", "GOROOT", "/tmp/workcell-goroot"},
+		{"debug-semantics", "GODEBUG", "gotypesalias=0"},
+		{"fips-selection", "GOFIPS140", "off"},
+		{"external-link-selection", "GO_EXTLINK_ENABLED", "0"},
+		{"auth-command", "GOAUTH", "workcell-hostile"},
+		{"vcs-policy", "GOVCS", "*:all"},
+		{"module-proxy", "GOPROXY", "direct"},
+		{"checksum-policy", "GOSUMDB", "off"},
+		{"internal-version", "GOTOOLCHAIN_INTERNAL_SWITCH_VERSION", "go999.0"},
+		{"internal-count", "GOTOOLCHAIN_INTERNAL_SWITCH_COUNT", "1"},
+		{"cache-program", "GOCACHEPROG", "/tmp/workcell-cacheprog"},
+		{"future-go-input", "GO_WORKCELL_FUTURE", "workcell-hostile"},
+		{"runtime-scheduling", "GOMAXPROCS", "1"},
+		{"cgo-enabled", "CGO_ENABLED", "0"},
+		{"cgo-cflags", "CGO_CFLAGS", "-DWORKCELL_HOSTILE"},
+		{"cgo-cppflags", "CGO_CPPFLAGS", "-I/tmp/workcell-hostile"},
+		{"cgo-cxxflags", "CGO_CXXFLAGS", "-DWORKCELL_HOSTILE"},
+		{"cgo-fflags", "CGO_FFLAGS", "-fworkcell-hostile"},
+		{"cgo-ldflags", "CGO_LDFLAGS", "-L/tmp/workcell-hostile"},
+		{"cgo-allow", "CGO_CFLAGS_ALLOW", ".*"},
+		{"cgo-disallow", "CGO_LDFLAGS_DISALLOW", "^$"},
+		{"future-cgo-input", "CGO_WORKCELL_FUTURE", "workcell-hostile"},
+		{"future-cgo-input-no-separator", "CGOWORKCELL_FUTURE", "workcell-hostile"},
+		{"c-compiler", "CC", "/tmp/workcell-cc"},
+		{"cxx-compiler", "CXX", "/tmp/workcell-cxx"},
+		{"fortran-compiler", "FC", "/tmp/workcell-fc"},
+		{"archiver", "AR", "/tmp/workcell-ar"},
+		{"gccgo", "GCCGO", "/tmp/workcell-gccgo"},
+		{"gccgo-tool-dir", "GCCGOTOOLDIR", "/tmp/workcell-gccgo-tools"},
+		{"pkg-config", "PKG_CONFIG", "/tmp/workcell-pkg-config"},
+		{"netrc-path", "NETRC", "/tmp/workcell-netrc"},
+		{"credential-manager-interactive", "GCM_INTERACTIVE", "always"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			code, output := canonicalBuildEnvProbe(t, `
+set -euo pipefail
+source "$1"
+workcell_require_canonical_build_environment
+echo should-not-run
+`, map[string]string{tc.variable: tc.value})
+			if code != 2 {
+				t.Fatalf("exit code = %d, want 2; output=%q", code, output)
+			}
+			if strings.HasPrefix(tc.variable, "BASH_FUNC_") {
+				if !strings.Contains(output, "rejects ambient exported Bash functions") ||
+					strings.Contains(output, tc.variable) {
+					t.Fatalf("output disclosed or did not classify an exported Bash function: %q", output)
+				}
+			} else if !strings.Contains(output, tc.variable) {
+				t.Fatalf("output %q does not name rejected variable %s", output, tc.variable)
+			}
+			if strings.Contains(output, tc.value) {
+				t.Fatalf("output leaked rejected %s value: %q", tc.variable, output)
+			}
+		})
+	}
+}
+
+func TestCanonicalBuildEnvironmentRejectsUnsafeIdentifierBeforeExpansion(t *testing.T) {
+	t.Parallel()
+
+	marker := filepath.Join(t.TempDir(), "identifier-expanded")
+	variable := "GO[$(: >'" + marker + "')]"
+	directProbe := `
+set -euo pipefail
+source "$1"
+_workcell_canonical_env_reject_nonempty "$2"
+`
+	env := map[string]string{variable: "workcell-unsafe-name"}
+	code, output := canonicalBuildEnvProbe(t, directProbe, env, variable)
+	if code != 2 ||
+		!strings.Contains(output, "unsafe identifier") ||
+		strings.Contains(output, variable) ||
+		strings.Contains(output, env[variable]) {
+		t.Fatalf("unsafe identifier was not rejected generically: code=%d output=%q", code, output)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("unsafe identifier executed before rejection; stat error=%v", err)
+	}
+	if exec.Command("/bin/bash", "-c", "((BASH_VERSINFO[0] < 4))").Run() == nil {
+		code, output = canonicalBuildEnvProbe(t, `
+set -euo pipefail
+source "$1"
+workcell_require_canonical_build_environment
+`, env)
+		if code != 2 || !strings.Contains(output, "unsafe identifier") {
+			t.Fatalf("Bash 3 prefix discovery did not reject unsafe identifier: code=%d output=%q", code, output)
+		}
+	}
+
+	realHelper := filepath.Join(repoRoot(t), "scripts", "lib", "canonical-build-env.sh")
+	mutant := filepath.Join(t.TempDir(), "canonical-build-env.sh")
+	writeCanonicalMutation(
+		t,
+		realHelper,
+		mutant,
+		"_workcell_canonical_env_reject_nonempty() {\n  local name=\"$1\"\n\n  case \"${name}\" in\n",
+		"_workcell_canonical_env_reject_nonempty() {\n  local name=\"$1\"\n\n  case WORKCELL_SAFE_NAME in\n",
+	)
+	_, _ = canonicalBuildEnvProbeWithHelper(t, mutant, directProbe, env, variable)
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("identifier-validation mutant was not killed: %v", err)
+	}
+}
+
+func TestCanonicalBuildEnvironmentFailsClosedWhenFunctionDetectorFails(t *testing.T) {
+	t.Parallel()
+
+	realHelper := filepath.Join(repoRoot(t), "scripts", "lib", "canonical-build-env.sh")
+	mutant := filepath.Join(t.TempDir(), "canonical-build-env.sh")
+	writeCanonicalMutation(
+		t,
+		realHelper,
+		mutant,
+		"  if /usr/bin/env | /usr/bin/env -i LC_ALL=C /usr/bin/grep '^BASH_FUNC_' >/dev/null; then\n",
+		"  if /usr/bin/false | /usr/bin/env -i LC_ALL=C /usr/bin/grep '^BASH_FUNC_' >/dev/null; then\n",
+	)
+	code, output := canonicalBuildEnvProbeWithHelper(t, mutant, `
+set -euo pipefail
+source "$1"
+workcell_require_canonical_build_environment
+`, nil)
+	if code != 2 || !strings.Contains(output, "could not inspect ambient exported Bash functions") {
+		t.Fatalf("function-detector failure did not fail closed: code=%d output=%q", code, output)
+	}
+}
+
+func TestCanonicalBuildEnvironmentAllowsOnlyGoStoragePaths(t *testing.T) {
+	t.Parallel()
+
+	goCache := filepath.Join(t.TempDir(), "go-build")
+	moduleCache := filepath.Join(t.TempDir(), "go-mod")
+	goPath := filepath.Join(t.TempDir(), "go-path")
+	safeEnv := map[string]string{
+		"GOFLAGS":                "",
+		"GOENV":                  "off",
+		"GOWORK":                 "off",
+		"GOPATH":                 goPath,
+		"GOCACHE":                goCache,
+		"GOMODCACHE":             moduleCache,
+		"GIT_NO_REPLACE_OBJECTS": "1",
+		"GIT_CONFIG_NOSYSTEM":    "1",
+		"GIT_CONFIG_SYSTEM":      "/dev/null",
+		"GIT_CONFIG_GLOBAL":      "/dev/null",
+		"GIT_CONFIG_COUNT":       "1",
+		"GIT_CONFIG_KEY_0":       "core.attributesFile",
+		"GIT_CONFIG_VALUE_0":     "/dev/null",
+		"GIT_ATTR_NOSYSTEM":      "1",
+		"GIT_ATTR_SYSTEM":        "/dev/null",
+		"GIT_ATTR_GLOBAL":        "/dev/null",
+	}
+	code, output := canonicalBuildEnvProbe(t, `
+set -euo pipefail
+source "$1"
+workcell_require_canonical_build_environment
+workcell_require_canonical_build_environment
+printf 'GOFLAGS=<%s>\n' "$GOFLAGS"
+printf 'GOENV=%s\n' "$GOENV"
+printf 'GOWORK=%s\n' "$GOWORK"
+printf 'GOPATH=%s\n' "$GOPATH"
+printf 'GOCACHE=%s\n' "$GOCACHE"
+printf 'GOMODCACHE=%s\n' "$GOMODCACHE"
+printf 'GIT_CONFIG_GLOBAL=%s\n' "$GIT_CONFIG_GLOBAL"
+printf 'GIT_ATTR_GLOBAL=%s\n' "$GIT_ATTR_GLOBAL"
+printf 'BASH_ENV_SET=%s\n' "${BASH_ENV+x}"
+printf 'ENV_SET=%s\n' "${ENV+x}"
+`, safeEnv)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; output=%q", code, output)
+	}
+	for _, want := range []string{
+		"GOFLAGS=<>",
+		"GOENV=off",
+		"GOWORK=off",
+		"GOPATH=" + goPath,
+		"GOCACHE=" + goCache,
+		"GOMODCACHE=" + moduleCache,
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_ATTR_GLOBAL=/dev/null",
+		"BASH_ENV_SET=",
+		"ENV_SET=",
+	} {
+		if !strings.Contains(output, want+"\n") {
+			t.Fatalf("canonical output %q does not contain %q", output, want)
+		}
+	}
+}
+
+func TestCanonicalBuildEnvironmentRejectsGitInputs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		variable string
+		value    string
+	}{
+		{"GIT_INDEX_FILE", "/tmp/workcell-index"},
+		{"GIT_DIR", "/tmp/workcell-git-dir"},
+		{"GIT_WORK_TREE", "/tmp/workcell-worktree"},
+		{"GIT_COMMON_DIR", "/tmp/workcell-common-dir"},
+		{"GIT_OBJECT_DIRECTORY", "/tmp/workcell-objects"},
+		{"GIT_ALTERNATE_OBJECT_DIRECTORIES", "/tmp/workcell-alternates"},
+		{"GIT_REPLACE_REF_BASE", "refs/workcell/replace"},
+		{"GIT_GRAFT_FILE", "/tmp/workcell-grafts"},
+		{"GIT_SHALLOW_FILE", "/tmp/workcell-shallow"},
+		{"GIT_EXEC_PATH", "/tmp/workcell-exec"},
+		{"GIT_CONFIG", "/tmp/workcell-config"},
+		{"GIT_CONFIG_PARAMETERS", "'core.worktree'='/tmp/workcell'"},
+		{"GIT_CONFIG_COUNT", "2"},
+		{"GIT_CONFIG_KEY_0", "core.worktree"},
+		{"GIT_CONFIG_VALUE_0", "/tmp/workcell"},
+		{"GIT_ATTR_SOURCE", "HEAD"},
+		{"GIT_EXTERNAL_DIFF", "/tmp/workcell-diff"},
+		{"GIT_TEMPLATE_DIR", "/tmp/workcell-template"},
+		{"GIT_TEST_ASSUME_DIFFERENT_OWNER", "1"},
+		{"GIT_WORKCELL_FUTURE", "workcell-hostile"},
+		{"GIT_NO_REPLACE_OBJECTS", "0"},
+		{"GIT_CONFIG_NOSYSTEM", "0"},
+		{"GIT_CONFIG_SYSTEM", "/tmp/workcell-system-config"},
+		{"GIT_CONFIG_GLOBAL", "/tmp/workcell-global-config"},
+		{"GIT_ATTR_NOSYSTEM", "0"},
+		{"GIT_ATTR_SYSTEM", "/tmp/workcell-system-attributes"},
+		{"GIT_ATTR_GLOBAL", "/tmp/workcell-global-attributes"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(strings.ToLower(tc.variable), func(t *testing.T) {
+			t.Parallel()
+			code, output := canonicalBuildEnvProbe(t, `
+set -euo pipefail
+source "$1"
+workcell_require_canonical_build_environment
+echo should-not-run
+`, map[string]string{tc.variable: tc.value})
+			if code != 2 {
+				t.Fatalf("exit code = %d, want 2; output=%q", code, output)
+			}
+			if !strings.Contains(output, tc.variable) {
+				t.Fatalf("output %q does not name rejected variable %s", output, tc.variable)
+			}
+			if strings.Contains(output, tc.value) {
+				t.Fatalf("output leaked rejected %s value: %q", tc.variable, output)
+			}
+		})
+	}
+}
+
+func TestCanonicalBuildEnvironmentGitAttributeBoundary(t *testing.T) {
+	t.Parallel()
+
+	fixtureRoot := t.TempDir()
+	fakeHome := filepath.Join(fixtureRoot, "home")
+	globalAttributes := filepath.Join(fakeHome, ".config", "git", "attributes")
+	writeCanonicalFixture(t, globalAttributes, []byte("*.txt export-ignore\n"), 0o600)
+	writeCanonicalFixture(
+		t,
+		filepath.Join(fakeHome, ".gitconfig"),
+		[]byte("[credential]\n\thelper = !exit 97\n"),
+		0o600,
+	)
+	repo := createSnapshotFixtureRepo(t, fixtureRoot)
+	probePath := filepath.Join(repo, "attribute-probe.txt")
+	writeCanonicalFixture(t, probePath, []byte("probe\n"), 0o600)
+
+	checkAttribute := func() (int, string) {
+		return canonicalBuildEnvProbe(t, `
+set -euo pipefail
+source "$1"
+workcell_require_canonical_build_environment
+if git config --global --get credential.helper >/dev/null 2>&1; then
+  echo unexpected-global-credential-helper
+  exit 1
+fi
+git -C "$2" check-attr export-ignore -- attribute-probe.txt
+`, map[string]string{"HOME": fakeHome}, repo)
+	}
+
+	code, output := checkAttribute()
+	if code != 0 || output != "attribute-probe.txt: export-ignore: unspecified\n" {
+		t.Fatalf("global Git state affected canonical attributes: code=%d output=%q", code, output)
+	}
+
+	writeCanonicalFixture(
+		t,
+		filepath.Join(repo, ".git", "info", "attributes"),
+		[]byte("attribute-probe.txt export-ignore\n"),
+		0o600,
+	)
+	code, output = checkAttribute()
+	if code != 0 || output != "attribute-probe.txt: export-ignore: set\n" {
+		t.Fatalf("local administrative attributes limitation not observed: code=%d output=%q", code, output)
+	}
+}
+
+func TestCanonicalBuildEnvironmentBlocksCacheProgramExecution(t *testing.T) {
+	t.Parallel()
+
+	fixtureRoot := t.TempDir()
+	marker := filepath.Join(fixtureRoot, "cache-program-ran")
+	cacheProgram := filepath.Join(fixtureRoot, "cache-program")
+	writeCanonicalFixture(t, cacheProgram, []byte(`#!/bin/sh
+: >"${WORKCELL_CACHEPROG_MARKER:?}"
+exit 1
+`), 0o755)
+
+	runGo := exec.Command("go", "list", "./internal/testkit")
+	runGo.Dir = repoRoot(t)
+	runGo.Env = canonicalBuildEnv(map[string]string{
+		"GOENV":                     "off",
+		"GOWORK":                    "off",
+		"GOFLAGS":                   "",
+		"GOCACHE":                   filepath.Join(fixtureRoot, "go-cache"),
+		"GOCACHEPROG":               cacheProgram,
+		"WORKCELL_CACHEPROG_MARKER": marker,
+	})
+	_ = runGo.Run()
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("control did not prove GOCACHEPROG execution: %v", err)
+	}
+	if err := os.Remove(marker); err != nil {
+		t.Fatal(err)
+	}
+
+	probe := `
+set -euo pipefail
+source "$1"
+workcell_require_canonical_build_environment
+cd "$2"
+go list ./internal/testkit
+`
+	hostileEnv := map[string]string{
+		"GOCACHE":                   filepath.Join(fixtureRoot, "guarded-cache"),
+		"GOCACHEPROG":               cacheProgram,
+		"WORKCELL_CACHEPROG_MARKER": marker,
+	}
+	code, output := canonicalBuildEnvProbe(t, probe, hostileEnv, repoRoot(t))
+	if code != 2 || !strings.Contains(output, "GOCACHEPROG") {
+		t.Fatalf("guard did not reject GOCACHEPROG: code=%d output=%q", code, output)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("guarded GOCACHEPROG executed; stat error=%v", err)
+	}
+
+	realHelper := filepath.Join(repoRoot(t), "scripts", "lib", "canonical-build-env.sh")
+	mutant := filepath.Join(fixtureRoot, "canonical-build-env-mutant.sh")
+	writeCanonicalMutation(
+		t,
+		realHelper,
+		mutant,
+		"      GOENV | GOWORK | GOPATH | GOCACHE | GOMODCACHE)\n",
+		"      GOENV | GOWORK | GOPATH | GOCACHE | GOMODCACHE | GOCACHEPROG)\n",
+	)
+	_, _ = canonicalBuildEnvProbeWithHelper(t, mutant, probe, hostileEnv, repoRoot(t))
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("GOCACHEPROG allowlist mutant was not killed: %v", err)
+	}
+}
+
+func TestCanonicalBuildEnvironmentKillsGuardMutations(t *testing.T) {
+	t.Parallel()
+
+	realHelper := filepath.Join(repoRoot(t), "scripts", "lib", "canonical-build-env.sh")
+	cases := []struct {
+		name        string
+		original    string
+		replacement string
+		variable    string
+		value       string
+	}{
+		{
+			"future-go-allowlist",
+			"      GOENV | GOWORK | GOPATH | GOCACHE | GOMODCACHE)\n",
+			"      GOENV | GOWORK | GOPATH | GOCACHE | GOMODCACHE | GO_WORKCELL_FUTURE)\n",
+			"GO_WORKCELL_FUTURE",
+			"workcell-mutant",
+		},
+		{
+			"cgo-loop-removal",
+			"  for name in \"${!CGO@}\"; do\n",
+			"  for name in WORKCELL_NO_CGO_INPUTS; do\n",
+			"CGOWORKCELL_FUTURE",
+			"workcell-mutant",
+		},
+		{
+			"external-tool-removal",
+			"  for name in CC CXX FC AR GCCGO GCCGOTOOLDIR PKG_CONFIG NETRC GCM_INTERACTIVE; do\n",
+			"  for name in CXX FC AR GCCGO GCCGOTOOLDIR PKG_CONFIG NETRC GCM_INTERACTIVE; do\n",
+			"CC",
+			"/tmp/workcell-mutant-cc",
+		},
+		{
+			"git-index-allowlist",
+			"      GIT_NO_REPLACE_OBJECTS | \\\n",
+			"      GIT_INDEX_FILE | \\\n        GIT_NO_REPLACE_OBJECTS | \\\n",
+			"GIT_INDEX_FILE",
+			"/tmp/workcell-mutant-index",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mutant := filepath.Join(t.TempDir(), "canonical-build-env.sh")
+			writeCanonicalMutation(t, realHelper, mutant, tc.original, tc.replacement)
+			probe := `
+set -euo pipefail
+source "$1"
+workcell_require_canonical_build_environment
+`
+			env := map[string]string{tc.variable: tc.value}
+			if code, output := canonicalBuildEnvProbeWithHelper(t, realHelper, probe, env); code != 2 {
+				t.Fatalf("control did not reject %s: code=%d output=%q", tc.variable, code, output)
+			}
+			if code, output := canonicalBuildEnvProbeWithHelper(t, mutant, probe, env); code == 2 {
+				t.Fatalf("mutant still rejected %s: code=%d output=%q", tc.variable, code, output)
+			}
+		})
+	}
+}
+
+func stagedCanonicalEntrypoint(
+	tb testing.TB,
+	relative string,
+	removeGuard bool,
+) string {
+	tb.Helper()
+
+	root := tb.TempDir()
+	realRoot := repoRoot(tb)
+	realHelper := filepath.Join(realRoot, "scripts", "lib", "canonical-build-env.sh")
+	copyCanonicalFixture(tb, realHelper, filepath.Join(root, "scripts", "lib", "canonical-build-env.sh"))
+
+	content, err := os.ReadFile(filepath.Join(realRoot, filepath.FromSlash(relative)))
+	if err != nil {
+		tb.Fatal(err)
+	}
+	text := string(content)
+	guardEnd := strings.Index(text, canonicalGuardBlock)
+	if guardEnd < 0 {
+		tb.Fatalf("%s does not contain the canonical guard block", relative)
+	}
+	header := text[:guardEnd+len(canonicalGuardBlock)]
+	if removeGuard {
+		header = strings.Replace(
+			header,
+			"workcell_require_canonical_build_environment\n",
+			"",
+			1,
+		)
+	}
+	header += "/bin/bash -c 'if declare -F workcell_descendant >/dev/null; then workcell_descendant; fi'\n"
+	header += "printf 'canonical-entrypoint-reached\\n'\n"
+	staged := filepath.Join(root, filepath.FromSlash(relative))
+	writeCanonicalFixture(tb, staged, []byte(header), 0o755)
+	return staged
+}
+
+func TestCanonicalBuildEnvironmentDirectEntrypoints(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	realHelper := filepath.Join(root, "scripts", "lib", "canonical-build-env.sh")
+	functionDetectorMutant := filepath.Join(t.TempDir(), "canonical-build-env.sh")
+	writeCanonicalMutation(
+		t,
+		realHelper,
+		functionDetectorMutant,
+		"  if /usr/bin/env | /usr/bin/env -i LC_ALL=C /usr/bin/grep '^BASH_FUNC_' >/dev/null; then\n",
+		"  if /usr/bin/true | /usr/bin/false; then\n",
+	)
+	for _, tc := range canonicalEntrypoints {
+		tc := tc
+		t.Run(filepath.Base(tc.relative), func(t *testing.T) {
+			t.Parallel()
+			content, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(tc.relative)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			text := string(content)
+			rootAt := strings.Index(text, `ROOT_DIR="$(CDPATH='' cd -- `)
+			guardAt := strings.Index(text, canonicalGuardBlock)
+			riskAt := strings.Index(text, tc.firstOperation)
+			if !strings.HasPrefix(text, "#!/bin/bash -p\n") ||
+				rootAt < 0 ||
+				guardAt < rootAt ||
+				riskAt < guardAt+len(canonicalGuardBlock) {
+				t.Fatalf("%s must run the privileged canonical guard before %q", tc.relative, tc.firstOperation)
+			}
+
+			control := stagedCanonicalEntrypoint(t, tc.relative, false)
+			mutant := stagedCanonicalEntrypoint(t, tc.relative, true)
+			env := map[string]string{tc.variable: tc.value}
+			probe := `exec "$2"`
+			code, output := canonicalBuildEnvProbe(t, probe, env, control)
+			if code != 2 ||
+				!strings.Contains(output, tc.variable) ||
+				strings.Contains(output, "canonical-entrypoint-reached") {
+				t.Fatalf("control %s did not reject %s: code=%d output=%q", tc.relative, tc.variable, code, output)
+			}
+			code, output = canonicalBuildEnvProbe(t, probe, env, mutant)
+			if code != 0 || !strings.Contains(output, "canonical-entrypoint-reached") {
+				t.Fatalf("guard-removal mutant for %s was not killed: code=%d output=%q", tc.relative, code, output)
+			}
+
+			startupMarker := filepath.Join(t.TempDir(), "startup-ran")
+			functionMarker := filepath.Join(t.TempDir(), "function-ran")
+			startupFile := filepath.Join(t.TempDir(), "bash-env")
+			writeCanonicalFixture(t, startupFile, []byte(`: >"${WORKCELL_DESCENDANT_STARTUP_MARKER:?}"
+`), 0o600)
+			descendantEnv := map[string]string{
+				"BASH_ENV":                            startupFile,
+				"ENV":                                 startupFile,
+				"BASH_FUNC_workcell_descendant%%":     `() { : >"${WORKCELL_DESCENDANT_FUNCTION_MARKER:?}"; }`,
+				"WORKCELL_DESCENDANT_FUNCTION_MARKER": functionMarker,
+				"WORKCELL_DESCENDANT_STARTUP_MARKER":  startupMarker,
+			}
+			if code, output = canonicalBuildEnvProbe(t, probe, descendantEnv, control); code != 2 {
+				t.Fatalf("control %s admitted descendant startup code: code=%d output=%q", tc.relative, code, output)
+			}
+			for _, marker := range []string{startupMarker, functionMarker} {
+				if _, err := os.Stat(marker); !os.IsNotExist(err) {
+					t.Fatalf("control %s executed descendant marker: %s", tc.relative, marker)
+				}
+			}
+			if code, output = canonicalBuildEnvProbe(t, probe, descendantEnv, mutant); code != 0 {
+				t.Fatalf("guard mutant %s did not reach descendant: code=%d output=%q", tc.relative, code, output)
+			}
+			for _, marker := range []string{startupMarker, functionMarker} {
+				if _, err := os.Stat(marker); err != nil {
+					t.Fatalf("guard mutant %s did not execute descendant marker: %v", tc.relative, err)
+				}
+			}
+
+			if err := os.Remove(functionMarker); err != nil {
+				t.Fatal(err)
+			}
+			functionEnv := map[string]string{
+				"BASH_FUNC_workcell_descendant%%":     descendantEnv["BASH_FUNC_workcell_descendant%%"],
+				"WORKCELL_DESCENDANT_FUNCTION_MARKER": functionMarker,
+			}
+			if code, output = canonicalBuildEnvProbe(t, probe, functionEnv, control); code != 2 {
+				t.Fatalf("control %s admitted a raw exported function: code=%d output=%q", tc.relative, code, output)
+			}
+			if _, err := os.Stat(functionMarker); !os.IsNotExist(err) {
+				t.Fatalf("control %s executed a raw exported function; stat error=%v", tc.relative, err)
+			}
+			detectorMutant := stagedCanonicalEntrypoint(t, tc.relative, false)
+			copyCanonicalFixture(t, functionDetectorMutant, filepath.Join(filepath.Dir(detectorMutant), "lib", "canonical-build-env.sh"))
+			if code, output = canonicalBuildEnvProbe(t, probe, functionEnv, detectorMutant); code != 0 {
+				t.Fatalf("function-detector mutant %s did not reach descendant: code=%d output=%q", tc.relative, code, output)
+			}
+			if _, err := os.Stat(functionMarker); err != nil {
+				t.Fatalf("function-detector mutant %s was not killed: %v", tc.relative, err)
+			}
+		})
+	}
+
+	for _, relative := range []string{"scripts/dev-quick-check.sh", "scripts/validate-repo.sh"} {
+		content, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(relative)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(content), `${ROOT_DIR}/scripts/lib/canonical-build-env.sh`) {
+			t.Fatalf("%s must lint and format the canonical helper", relative)
+		}
+	}
+
+	// A direct bare-name invocation goes through PATH resolution before the
+	// kernel applies the privileged shebang. Reaching the guard with the helper
+	// found at the staged root proves BASH_SOURCE retained that resolved path.
+	staged := stagedCanonicalEntrypoint(t, "scripts/dev-quick-check.sh", false)
+	path := filepath.Dir(staged) + string(os.PathListSeparator) + os.Getenv("PATH")
+	code, output := canonicalBuildEnvProbe(
+		t,
+		`exec dev-quick-check.sh`,
+		map[string]string{
+			"PATH":    path,
+			"GOFLAGS": "-overlay=/tmp/workcell-bare-name-overlay.json",
+		},
+	)
+	if code != 2 || !strings.Contains(output, "GOFLAGS") {
+		t.Fatalf("bare-name direct entrypoint did not resolve the canonical root: code=%d output=%q", code, output)
+	}
+}
+
+func TestCanonicalBuildEnvironmentPrivilegedEntrypoint(t *testing.T) {
+	t.Parallel()
+
+	script := filepath.Join(repoRoot(t), "scripts", "validate-repo.sh")
+	bashEnvMarker := filepath.Join(t.TempDir(), "bash-env-ran")
+	bashEnv := filepath.Join(t.TempDir(), "bash-env")
+	writeCanonicalFixture(t, bashEnv, []byte(`: >"${WORKCELL_BASH_ENV_MARKER:?}"
+`), 0o600)
+
+	code, output := canonicalBuildEnvProbe(
+		t,
+		`exec "$2" --help`,
+		map[string]string{
+			"BASH_ENV":                 bashEnv,
+			"WORKCELL_BASH_ENV_MARKER": bashEnvMarker,
+			"GIT_INDEX_FILE":           "/tmp/workcell-hostile-index",
+			"BASH_FUNC_source%%":       "() { :; }",
+			"BASH_FUNC_workcell_require_canonical_build_environment%%": "() { :; }",
+		},
+		script,
+	)
+	if code != 2 || !strings.Contains(output, "BASH_ENV") {
+		t.Fatalf("privileged entrypoint did not reject before help: code=%d output=%q", code, output)
+	}
+	if _, err := os.Stat(bashEnvMarker); !os.IsNotExist(err) {
+		t.Fatalf("privileged entrypoint executed BASH_ENV; stat error=%v", err)
+	}
+
+	if code, output := canonicalBuildEnvProbe(t, `exec /bin/bash "$2" --help`, nil, script); code != 2 ||
+		!strings.Contains(output, "execute the script directly") {
+		t.Fatalf("nonprivileged interpreter did not fail closed: code=%d output=%q", code, output)
+	}
+}
+
+func TestCanonicalBuildEnvironmentScopeAndReachability(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	checks := map[string][]string{
+		".github/workflows/release.yml": {"./scripts/validate-repo.sh"},
+		"scripts/bootstrap-dev.sh":      {`"${ROOT_DIR}/scripts/dev-quick-check.sh"`},
+		"scripts/run-hosted-controls-audit.sh": {
+			`"${ROOT_DIR}/scripts/verify-github-hosted-controls.sh"`,
+		},
+	}
+	for relative, needles := range checks {
+		content, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(relative)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, needle := range needles {
+			if !strings.Contains(string(content), needle) {
+				t.Fatalf("%s must reach the canonical root through %q", relative, needle)
+			}
+		}
+	}
+
+	content, err := os.ReadFile(filepath.Join(root, "docs", "validation-scenarios.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	for _, want := range []string{
+		"G0a1a1 canonical-build-environment",
+		"three roots",
+		"`scripts/lib/canonical-build-env.sh`",
+		"exact `GOENV=off`",
+		"exact `GOWORK=off`",
+		"`GOPATH`, `GOCACHE`, and `GOMODCACHE`",
+		"explicitly lower assurance",
+		"G0a1a2",
+		"G0a1b",
+		"G0a1c",
+		"G0a2a",
+		"G0a2",
+		"G0b",
+		"arbitrary direct `go` invocations",
+		"whole local administrative plane",
+		"`.git/info/attributes`",
+		"credential files",
+		"`HOME` (including `.netrc`)",
+		"`PATH`",
+		"tool binaries",
+		"`BASH_ENV`",
+		"clears `CDPATH`",
+		"`CGO*`",
+		"`BASH_FUNC_*`",
+		"`SHELLOPTS`",
+		"`BASHOPTS`",
+		"`BASH_XTRACEFD`",
+		"descendant `CDPATH`",
+		"resident-only base selection",
+		"Release certification stays blocked",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("validation scenario documentation must contain %q", want)
+		}
+	}
+}

--- a/scripts/dev-quick-check.sh
+++ b/scripts/dev-quick-check.sh
@@ -1,7 +1,11 @@
-#!/usr/bin/env -S BASH_ENV= ENV= bash
+#!/bin/bash -p
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "${BASH_SOURCE[0]%/*}/.." && pwd -P)"
+# shellcheck source=scripts/lib/canonical-build-env.sh
+source "${ROOT_DIR}/scripts/lib/canonical-build-env.sh"
+workcell_require_modern_privileged_bash "$@"
+workcell_require_canonical_build_environment
 
 require_tool() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -49,6 +53,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/ci/run-docs-in-validator.sh"
   "${ROOT_DIR}/scripts/ci/run-validate-in-validator.sh"
   "${ROOT_DIR}/scripts/lib/extract_direct_mounts"
+  "${ROOT_DIR}/scripts/lib/canonical-build-env.sh"
   "${ROOT_DIR}/scripts/lib/go-run-env.sh"
   "${ROOT_DIR}/scripts/lib/launcher/host-detect.sh"
   "${ROOT_DIR}/scripts/lib/launcher/host-exec.sh"

--- a/scripts/lib/canonical-build-env.sh
+++ b/scripts/lib/canonical-build-env.sh
@@ -1,0 +1,165 @@
+# shellcheck shell=bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Omkhar Arasaratnam
+#
+# Establish the Go and Git process environment for each reviewed entrypoint
+# that explicitly sources this helper. This is intentionally not a claim about
+# ungated workflow roots, arbitrary direct compiler invocations, tool identity,
+# or the contents of caller-selected storage paths.
+
+_workcell_canonical_env_reject_nonempty() {
+  local name="$1"
+
+  case "${name}" in
+    "" | [0123456789]* | *[!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_]*)
+      echo "Canonical build environment rejects an ambient variable with an unsafe identifier." >&2
+      return 2
+      ;;
+  esac
+  if [[ -n "${!name-}" ]]; then
+    printf 'Canonical build environment rejects ambient %s; rerun with the variable unset.\n' "${name}" >&2
+    return 2
+  fi
+  unset "${name}"
+}
+
+_workcell_canonical_env_require_value() {
+  local name="$1"
+  local expected="$2"
+  local actual="${!name-}"
+
+  if [[ -n "${actual}" && "${actual}" != "${expected}" ]]; then
+    printf 'Canonical build environment rejects ambient %s; rerun with the variable unset.\n' "${name}" >&2
+    return 2
+  fi
+}
+
+workcell_require_modern_privileged_bash() {
+  local candidate=""
+
+  if [[ "$-" != *p* ]]; then
+    echo "Canonical entrypoint requires privileged Bash mode; execute the script directly." >&2
+    return 2
+  fi
+  ((BASH_VERSINFO[0] >= 4)) && return 0
+  for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [[ -x "${candidate}" ]] || continue
+    if "${candidate}" -p -c '((BASH_VERSINFO[0] >= 4))'; then
+      exec "${candidate}" -p "$0" "$@"
+    fi
+  done
+  echo "Canonical entrypoint requires Bash 4 or newer at a trusted absolute path." >&2
+  return 2
+}
+
+workcell_require_canonical_build_environment() {
+  local name=""
+  local -a raw_environment_status=()
+
+  # Privileged Bash ignores these startup inputs for this shell but retains
+  # them in the exported environment. Reject executable values and remove
+  # empty startup variables so an ordinary Bash descendant cannot consume
+  # them later. Bash versions disagree about whether retained BASH_FUNC_*%%
+  # entries appear in shell variable expansion, so inspect the raw environment
+  # through fixed absolute tools and a scrubbed grep environment.
+  _workcell_canonical_env_reject_nonempty BASH_ENV || return 2
+  _workcell_canonical_env_reject_nonempty ENV || return 2
+  if /usr/bin/env | /usr/bin/env -i LC_ALL=C /usr/bin/grep '^BASH_FUNC_' >/dev/null; then
+    echo "Canonical build environment rejects ambient exported Bash functions." >&2
+    return 2
+  else
+    raw_environment_status=("${PIPESTATUS[@]}")
+    if ((raw_environment_status[0] != 0 || raw_environment_status[1] != 1)); then
+      echo "Canonical build environment could not inspect ambient exported Bash functions." >&2
+      return 2
+    fi
+  fi
+
+  # GOFLAGS is rejected wholesale so tags, overlays, and other flag spellings
+  # cannot select a different package graph. GOENV=off and GOWORK=off prevent
+  # persisted Go configuration and an ambient workspace from restoring inputs.
+  _workcell_canonical_env_reject_nonempty GOFLAGS || return 2
+  _workcell_canonical_env_require_value GOENV off || return 2
+  _workcell_canonical_env_require_value GOWORK off || return 2
+
+  # Fail closed on current, internal, and future Go environment inputs. Only
+  # the three storage locations below remain caller-selectable; their contents
+  # are a separately documented, lower-assurance dependency.
+  for name in "${!GO@}"; do
+    [[ -n "${name}" ]] || continue
+    case "${name}" in
+      GOENV | GOWORK | GOPATH | GOCACHE | GOMODCACHE)
+        continue
+        ;;
+    esac
+    _workcell_canonical_env_reject_nonempty "${name}" || return 2
+  done
+  for name in "${!CGO@}"; do
+    [[ -n "${name}" ]] || continue
+    _workcell_canonical_env_reject_nonempty "${name}" || return 2
+  done
+  for name in CC CXX FC AR GCCGO GCCGOTOOLDIR PKG_CONFIG NETRC GCM_INTERACTIVE; do
+    _workcell_canonical_env_reject_nonempty "${name}" || return 2
+  done
+
+  # Fail closed on every ambient Git override except the exact canonical
+  # values established below. This avoids a version-sensitive denylist:
+  # attributes, external helpers, repository/object selection, config,
+  # templates, test hooks, and future GIT_* inputs all stay outside the
+  # canonical view. Callers may still use a narrowly scoped assignment after
+  # this gate (for example, pre-merge's temporary GIT_INDEX_FILE).
+  for name in "${!GIT_@}"; do
+    [[ -n "${name}" ]] || continue
+    case "${name}" in
+      GIT_NO_REPLACE_OBJECTS | \
+        GIT_CONFIG_NOSYSTEM | \
+        GIT_CONFIG_SYSTEM | \
+        GIT_CONFIG_GLOBAL | \
+        GIT_CONFIG_COUNT | \
+        GIT_CONFIG_KEY_0 | \
+        GIT_CONFIG_VALUE_0 | \
+        GIT_ATTR_NOSYSTEM | \
+        GIT_ATTR_SYSTEM | \
+        GIT_ATTR_GLOBAL)
+        continue
+        ;;
+    esac
+    _workcell_canonical_env_reject_nonempty "${name}" || return 2
+  done
+
+  # These exact values are safe and idempotent when one canonical entrypoint
+  # invokes another. They suppress ambient system/global config, global
+  # attributes, and replacement objects without preventing later trusted,
+  # child-scoped fixture assignments.
+  _workcell_canonical_env_require_value GIT_NO_REPLACE_OBJECTS 1 || return 2
+  _workcell_canonical_env_require_value GIT_CONFIG_NOSYSTEM 1 || return 2
+  _workcell_canonical_env_require_value GIT_CONFIG_SYSTEM /dev/null || return 2
+  _workcell_canonical_env_require_value GIT_CONFIG_GLOBAL /dev/null || return 2
+  _workcell_canonical_env_require_value GIT_CONFIG_COUNT 1 || return 2
+  _workcell_canonical_env_require_value GIT_CONFIG_KEY_0 core.attributesFile || return 2
+  _workcell_canonical_env_require_value GIT_CONFIG_VALUE_0 /dev/null || return 2
+  _workcell_canonical_env_require_value GIT_ATTR_NOSYSTEM 1 || return 2
+  _workcell_canonical_env_require_value GIT_ATTR_SYSTEM /dev/null || return 2
+  _workcell_canonical_env_require_value GIT_ATTR_GLOBAL /dev/null || return 2
+
+  GOFLAGS=""
+  GOENV=off
+  GOWORK=off
+  GIT_NO_REPLACE_OBJECTS=1
+  GIT_CONFIG_NOSYSTEM=1
+  GIT_CONFIG_SYSTEM=/dev/null
+  GIT_CONFIG_GLOBAL=/dev/null
+  GIT_CONFIG_COUNT=1
+  GIT_CONFIG_KEY_0=core.attributesFile
+  GIT_CONFIG_VALUE_0=/dev/null
+  GIT_ATTR_NOSYSTEM=1
+  GIT_ATTR_SYSTEM=/dev/null
+  GIT_ATTR_GLOBAL=/dev/null
+  WORKCELL_CANONICAL_BUILD_ENV=1
+  export GOFLAGS GOENV GOWORK
+  export GIT_NO_REPLACE_OBJECTS GIT_CONFIG_NOSYSTEM
+  export GIT_CONFIG_SYSTEM GIT_CONFIG_GLOBAL GIT_ATTR_NOSYSTEM
+  export GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+  export GIT_ATTR_SYSTEM GIT_ATTR_GLOBAL
+  export WORKCELL_CANONICAL_BUILD_ENV
+}

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -1,7 +1,11 @@
-#!/usr/bin/env -S BASH_ENV= ENV= bash
+#!/bin/bash -p
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "${BASH_SOURCE[0]%/*}/.." && pwd -P)"
+# shellcheck source=scripts/lib/canonical-build-env.sh
+source "${ROOT_DIR}/scripts/lib/canonical-build-env.sh"
+workcell_require_modern_privileged_bash "$@"
+workcell_require_canonical_build_environment
 SKIP_HEAVY_HOST_SHELLCHECK="${WORKCELL_SKIP_HEAVY_HOST_SHELLCHECK:-0}"
 VALIDATION_PROFILE="${WORKCELL_VALIDATE_REPO_PROFILE:-release-preflight}"
 
@@ -154,6 +158,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/install-dev-tools.sh"
   "${ROOT_DIR}/scripts/lint-dockerfiles.sh"
   "${ROOT_DIR}/scripts/lib/extract_direct_mounts"
+  "${ROOT_DIR}/scripts/lib/canonical-build-env.sh"
   "${ROOT_DIR}/scripts/lib/go-run-env.sh"
   "${ROOT_DIR}/scripts/lib/launcher/host-detect.sh"
   "${ROOT_DIR}/scripts/lib/launcher/host-exec.sh"

--- a/scripts/verify-github-hosted-controls.sh
+++ b/scripts/verify-github-hosted-controls.sh
@@ -1,9 +1,13 @@
-#!/usr/bin/env -S BASH_ENV= ENV= bash
+#!/bin/bash -p
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "${BASH_SOURCE[0]%/*}/.." && pwd -P)"
+# shellcheck source=scripts/lib/canonical-build-env.sh
+source "${ROOT_DIR}/scripts/lib/canonical-build-env.sh"
+workcell_require_modern_privileged_bash "$@"
+workcell_require_canonical_build_environment
 POLICY_PATH="${WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH:-${ROOT_DIR}/policy/github-hosted-controls.toml}"
-# shellcheck source=/dev/null
+# shellcheck source=scripts/lib/go-run-env.sh
 source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
 
 require_tool() {


### PR DESCRIPTION
## Summary

- add one canonical Go/Git/shell environment gate to the repository validator, developer quick check, and hosted-controls verifier
- reject ambient build selectors and executable tool overrides, scrub Bash startup files and exported functions before descendants, and fail closed on detector errors
- retain only the documented lower-assurance Go storage roots, support the macOS Bash 3 to trusted Bash 4+ transition, and document the remaining release-blocking closure work
- add cross-version entrypoint, descendant, hostile-identifier, and killed-mutation coverage

## Validation

- focused canonical-environment standard and race suites
- Bash 3 through Bash 5 entrypoint and function-only controls
- shellcheck, shfmt, diff checks, and independent exact-tree review
- full staged-tree `pr-parity`, including live Colima invariant coverage
- full clean-HEAD `pr-parity` on the signed commit

## Scope

This is the first bounded G0 canonical-environment unit. Trusted-entrypoint propagation, the validator-container archive boundary, `ci-plan`/`pre-merge`, and the remaining build/release roots stay explicitly blocked for subsequent review units.
