### PR TITLE
Preserve complete local parity dispatch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,10 +183,14 @@ Helpful flags:
 ./scripts/pre-merge.sh --allow-dirty
 ./scripts/pre-merge.sh --profile repo-core
 ./scripts/pre-merge.sh --profile release-preflight
-./scripts/pre-merge.sh --skip-repro
-./scripts/pre-merge.sh --skip-release-bundle
+./scripts/pre-merge.sh --profile repo-core --skip-repro
+./scripts/pre-merge.sh --profile release-preflight --skip-release-bundle
 ./scripts/pre-merge.sh --rebuild-validator
 ```
+
+`--skip-repro` is diagnostic-only for the non-publication profiles;
+publication-grade `pr-parity` rejects it so emitted evidence cannot certify a
+selected but unexecuted reproducibility lane.
 
 For `main`-based PRs, `./scripts/repo-publish-pr.sh` consumes the fresh
 `pr-parity` evidence emitted by `./scripts/pre-merge.sh` and refuses to publish

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -19,7 +19,11 @@ GitHub-only behavior do not drift silently:
 - its fail-closed resident Git discovery rejects hidden/split-index state, shallow graphs, unsafe ancestry, mutable ignores, and present gitlinks; it neutralizes cached stats, ignores `.git/info/exclude`, and bypasses built-in conversions with raw bytes
 
 That inventory underpins the local `./scripts/pre-merge.sh` profiles and the
-repo-local `./scripts/repo-publish-pr.sh` publication gate.
+repo-local `./scripts/repo-publish-pr.sh` publication gate. For
+publication-grade `pr-parity`, `pre-merge.sh` buffers the complete local
+dispatch list before execution, then runs each selected local script once in
+declared `local_order`; a lane that reads standard input cannot consume or skip
+later dispatcher records, and `--skip-repro` is rejected.
 For the narrow certified-adapter exception, local parity evidence must be
 generated with `./scripts/pre-merge.sh --profile pr-parity --label
 approved-large-certified-adapter`; host publication must use `workcell

--- a/scripts/pre-merge.sh
+++ b/scripts/pre-merge.sh
@@ -44,6 +44,7 @@ Options:
   --rebuild-validator       Rebuild the local validator image before validation
   --skip-release-bundle     Skip verify-release-bundle.sh in shared validate runs
   --skip-repro              Skip verify-reproducible-build.sh when selected
+                            (not allowed with pr-parity evidence)
   -h, --help                Show this help
 EOF
 }
@@ -222,6 +223,7 @@ collect_selected_scripts() {
     | map(select(.status == "local"))
     | sort_by(.local_order, .local_script, .id)
     | unique_by(.local_script)
+    | sort_by(.local_order, .local_script, .id)
     | .[]
     | [.local_order, .local_script]
     | @tsv
@@ -290,11 +292,22 @@ write_pr_parity_evidence() {
 
 execute_plan() {
   local plan_json="$1"
+  local selected_script_records=""
+  local -a selected_scripts=()
   local script=""
   local repro_platforms=""
 
-  while IFS=$'\t' read -r _ script; do
+  if ! selected_script_records="$(collect_selected_scripts "${plan_json}")"; then
+    echo "Unable to collect selected local parity scripts." >&2
+    return 2
+  fi
+  while IFS=$'\t' read -r _ script <&3; do
     [[ -n "${script}" ]] || continue
+    selected_scripts[${#selected_scripts[@]}]="${script}"
+  done 3<<<"${selected_script_records}"
+  ((${#selected_scripts[@]} > 0)) || return 0
+
+  for script in "${selected_scripts[@]}"; do
     case "${script}" in
       scripts/check-workflows.sh)
         echo "[pre-merge] workflow lint and policy analysis"
@@ -347,7 +360,7 @@ execute_plan() {
         exit 2
         ;;
     esac
-  done < <(collect_selected_scripts "${plan_json}")
+  done
 }
 
 build_plan_args() {
@@ -463,6 +476,11 @@ case "${PROFILE}" in
     exit 2
     ;;
 esac
+
+if [[ "${PROFILE}" == "pr-parity" && "${RUN_REPRO}" -eq 0 ]]; then
+  echo "--skip-repro cannot be used with pr-parity because publication evidence requires every selected local lane." >&2
+  exit 2
+fi
 
 case "${PARITY_SNAPSHOT}" in
   index | worktree) ;;

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -5106,6 +5106,7 @@ fi
 PREMERGE_HARNESS_ROOT="${BARRIER_VERIFY_ROOT}/premerge-harness"
 PREMERGE_FAKEBIN="${PREMERGE_HARNESS_ROOT}/fakebin"
 PREMERGE_LOG="${PREMERGE_HARNESS_ROOT}/premerge.log"
+PREMERGE_DISPATCH_LOG="${PREMERGE_HARNESS_ROOT}/dispatch.log"
 PREMERGE_DEFAULT_HOME="${PREMERGE_HARNESS_ROOT}/home"
 if [[ "${OSTYPE:-}" == darwin* ]]; then
   PREMERGE_DEFAULT_SNAPSHOT_PARENT="${PREMERGE_DEFAULT_HOME}/Library/Caches/workcell-validation-snapshots"
@@ -5145,6 +5146,9 @@ for stub in check-workflows.sh container-smoke.sh; do
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s %s\n' "$(basename "$0")" "$*" >>"${PREMERGE_LOG}"
+if [[ -n "${PREMERGE_DISPATCH_LOG:-}" ]]; then
+  printf 'scripts/%s\n' "$(basename "$0")" >>"${PREMERGE_DISPATCH_LOG}"
+fi
 EOF
   chmod 0755 "${PREMERGE_HARNESS_ROOT}/scripts/${stub}"
 done
@@ -5153,6 +5157,12 @@ for stub in job-validate.sh job-docs.sh job-pin-hygiene.sh job-pr-shape.sh; do
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'ci/%s %s\n' "$(basename "$0")" "$*" >>"${PREMERGE_LOG}"
+if [[ -n "${PREMERGE_DISPATCH_LOG:-}" ]]; then
+  printf 'scripts/ci/%s\n' "$(basename "$0")" >>"${PREMERGE_DISPATCH_LOG}"
+fi
+if [[ "$(basename "$0")" == "job-validate.sh" && "${WORKCELL_PREMERGE_TEST_CONSUME_STDIN:-0}" == "1" ]]; then
+  cat >/dev/null
+fi
 EOF
   chmod 0755 "${PREMERGE_HARNESS_ROOT}/scripts/ci/${stub}"
 done
@@ -5161,6 +5171,9 @@ cat >"${PREMERGE_HARNESS_ROOT}/scripts/verify-reproducible-build.sh" <<'EOF'
 set -euo pipefail
 printf '%s %s\n' "$(basename "$0")" "$*" >>"${PREMERGE_LOG}"
 printf 'verify-reproducible-build.sh env WORKCELL_REPRO_PLATFORMS=%s\n' "${WORKCELL_REPRO_PLATFORMS-}" >>"${PREMERGE_LOG}"
+if [[ -n "${PREMERGE_DISPATCH_LOG:-}" ]]; then
+  printf 'scripts/%s\n' "$(basename "$0")" >>"${PREMERGE_DISPATCH_LOG}"
+fi
 EOF
 chmod 0755 "${PREMERGE_HARNESS_ROOT}/scripts/verify-reproducible-build.sh"
 cat >"${PREMERGE_HARNESS_ROOT}/scripts/ci-plan.sh" <<'EOF'
@@ -5220,10 +5233,12 @@ JSON
   "profile": "pr-parity",
   "lanes": [
     {"id": "security.yml/actionlint", "status": "local", "local_script": "scripts/check-workflows.sh", "local_order": 10},
+    {"id": "security.yml/zizmor", "status": "local", "local_script": "scripts/check-workflows.sh", "local_order": 10},
     {"id": "ci.yml/pr-shape", "status": "local", "local_script": "scripts/ci/job-pr-shape.sh", "local_order": 15},
     {"id": "ci.yml/validate", "status": "local", "local_script": "scripts/ci/job-validate.sh", "local_order": 20},
     {"id": "docs.yml/spelling-and-manpage", "status": "local", "local_script": "scripts/ci/job-docs.sh", "local_order": 30},
     {"id": "ci.yml/container-smoke", "status": "local", "local_script": "scripts/container-smoke.sh", "local_order": 40},
+    {"id": "ci.yml/reproducible-build-platform[platform=linux/amd64]", "status": "local", "local_script": "scripts/verify-reproducible-build.sh", "local_order": 45, "matrix": {"platform": "linux/amd64"}},
     {"id": "ci.yml/reproducible-build-platform[platform=linux/arm64]", "status": "local", "local_script": "scripts/verify-reproducible-build.sh", "local_order": 45, "matrix": {"platform": "linux/arm64"}}
   ]
 }
@@ -5365,16 +5380,19 @@ fi
 grep -q -- '--local-include-untracked requires --local-snapshot worktree.' /tmp/workcell-premerge-local-include.out
 
 : >"${PREMERGE_LOG}"
+: >"${PREMERGE_DISPATCH_LOG}"
 if ! PATH="${PREMERGE_FAKEBIN}:${PATH}" \
   HOME="${PREMERGE_DEFAULT_HOME}" \
   XDG_CACHE_HOME='' \
   PREMERGE_LOG="${PREMERGE_LOG}" \
+  PREMERGE_DISPATCH_LOG="${PREMERGE_DISPATCH_LOG}" \
+  WORKCELL_PREMERGE_TEST_CONSUME_STDIN=1 \
   WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
   WORKCELL_FAKE_GIT_STATUS_OUTPUT=$' M README.md\n?? stray.txt\n' \
   WORKCELL_FAKE_GIT_TREE_OID='1111111111111111111111111111111111111111' \
   WORKCELL_VALIDATION_SNAPSHOT_PARENT='' \
   "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
-  --local-snapshot head >/tmp/workcell-premerge-local-snapshot.out 2>&1; then
+  --local-snapshot head </dev/null >/tmp/workcell-premerge-local-snapshot.out 2>&1; then
   echo "Expected --local-snapshot head pre-merge harness to succeed on a dirty worktree" >&2
   cat /tmp/workcell-premerge-local-snapshot.out >&2
   exit 1
@@ -5388,9 +5406,15 @@ for expected in \
   'ci/job-validate.sh --profile pr-parity' \
   'ci/job-docs.sh ' \
   'container-smoke.sh ' \
-  'verify-reproducible-build.sh env WORKCELL_REPRO_PLATFORMS=linux/arm64'; do
+  'verify-reproducible-build.sh env WORKCELL_REPRO_PLATFORMS=linux/amd64,linux/arm64'; do
   grep -q "${expected}" "${PREMERGE_LOG}"
 done
+PREMERGE_EXPECTED_DISPATCH=$'scripts/check-workflows.sh\nscripts/ci/job-pr-shape.sh\nscripts/ci/job-validate.sh\nscripts/ci/job-docs.sh\nscripts/container-smoke.sh\nscripts/verify-reproducible-build.sh'
+if [[ "$(cat "${PREMERGE_DISPATCH_LOG}")" != "${PREMERGE_EXPECTED_DISPATCH}" ]]; then
+  echo "Expected pre-merge to execute each selected local script once in local_order without sharing dispatcher stdin" >&2
+  cat "${PREMERGE_DISPATCH_LOG}" >&2
+  exit 1
+fi
 for expected in \
   '"profile": "pr-parity"' \
   '"base_branch": "main"' \
@@ -5405,6 +5429,17 @@ done
 
 rm -f "${PREMERGE_HARNESS_ROOT}/.git/workcell-parity/pr-parity.json" \
   "${PREMERGE_HARNESS_ROOT}/.git/workcell-fake-tree-sequence-index"
+if PATH="${PREMERGE_FAKEBIN}:${PATH}" \
+  PREMERGE_LOG="${PREMERGE_LOG}" \
+  WORKCELL_FAKE_GIT_ROOT="${PREMERGE_HARNESS_ROOT}" \
+  "${PREMERGE_HARNESS_ROOT}/scripts/pre-merge.sh" \
+  --skip-repro >/tmp/workcell-premerge-skip-repro.out 2>&1; then
+  echo "Expected pr-parity to reject --skip-repro before writing publication evidence" >&2
+  exit 1
+fi
+grep -q -- '--skip-repro cannot be used with pr-parity because publication evidence requires every selected local lane.' /tmp/workcell-premerge-skip-repro.out
+test ! -f "${PREMERGE_HARNESS_ROOT}/.git/workcell-parity/pr-parity.json"
+
 : >"${PREMERGE_LOG}"
 if PATH="${PREMERGE_FAKEBIN}:${PATH}" \
   PREMERGE_LOG="${PREMERGE_LOG}" \


### PR DESCRIPTION
## Summary

- materialize the local validation dispatch list before any child lane can consume dispatcher stdin
- preserve canonical local execution order after lane deduplication
- reject `pr-parity --skip-repro` before publication evidence can be written
- document the strengthened parity contract

## Validation

- `bash ./scripts/verify-invariants.sh`
- `go test ./...`
- `bash tests/scenarios/shared/test-session-commands.sh` on Colima
- `./scripts/pre-merge.sh --profile pr-parity`
- six-role adversarial review: no actionable findings

## Risk

Supporting publication-evidence bugfix. No runtime-boundary or provider behavior changes.