### PR TITLE
Make session deletion prove container absence

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -269,6 +269,7 @@ func helperSubcommands() []helperSubcommand {
 		{"session-export", 0, -1, runHelperSessionExport},
 		{"session-diff-metadata", 0, -1, runHelperSessionDiffMetadata},
 		{"session-runtime-metadata", 0, -1, runHelperSessionRuntimeMetadata},
+		{"session-container-absent-for-delete", 1, 1, cmdHelperSessionContainerAbsentForDelete},
 		{"session-timeline", 0, -1, runHelperSessionTimeline},
 		{"audit-digest", 2, -1, cmdHelperAuditDigest},
 		{"direct-mount-cache-key", 2, 2, cmdHelperDirectMountCacheKey},
@@ -415,6 +416,14 @@ func cmdHelperSessionSuffix(_ []string) error {
 	}
 	fmt.Println(value)
 	return nil
+}
+
+func cmdHelperSessionContainerAbsentForDelete(args []string) error {
+	inventory, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return err
+	}
+	return sessions.ProveContainerAbsentForDelete(args[0], string(inventory))
 }
 
 func cmdHelperColimaStatus(args []string) error {

--- a/internal/host/sessions/container_absence.go
+++ b/internal/host/sessions/container_absence.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessions
+
+import (
+	"bufio"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	dockerContainerNamePattern   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]+$`)
+	workcellContainerNamePattern = regexp.MustCompile(`^workcell-[A-Za-z0-9][A-Za-z0-9_.-]*$`)
+)
+
+// ProveContainerAbsentForDelete validates a successful `docker ps -a
+// --format {{.Names}}` inventory and proves that it does not contain the
+// Workcell-managed container name. Unsupported record identifiers and
+// malformed inventories fail closed.
+func ProveContainerAbsentForDelete(containerName, inventory string) error {
+	normalizedName := strings.TrimPrefix(containerName, "/")
+	if !workcellContainerNamePattern.MatchString(normalizedName) {
+		return fmt.Errorf("unsupported Workcell container name: %q", containerName)
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(inventory))
+	for scanner.Scan() {
+		observedName := scanner.Text()
+		if !dockerContainerNamePattern.MatchString(observedName) {
+			return fmt.Errorf("malformed Docker container inventory")
+		}
+		if observedName == normalizedName {
+			return fmt.Errorf("container is still present: %s", normalizedName)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read Docker container inventory: %w", err)
+	}
+	return nil
+}

--- a/internal/host/sessions/container_absence_test.go
+++ b/internal/host/sessions/container_absence_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package sessions
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProveContainerAbsentForDelete(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		containerName string
+		inventory     string
+		wantErr       bool
+	}{
+		{
+			name:          "empty inventory",
+			containerName: "workcell-session-fixture",
+		},
+		{
+			name:          "unrelated and near names",
+			containerName: "workcell-session-fixture",
+			inventory:     "unrelated-container\nworkcell-session-fixture-neighbor",
+		},
+		{
+			name:          "slash-prefixed target",
+			containerName: "/workcell-session-fixture",
+			inventory:     "unrelated-container",
+		},
+		{
+			name:          "CRLF inventory",
+			containerName: "workcell-session-fixture",
+			inventory:     "unrelated-container\r\nneighbor-container\r\n",
+		},
+		{
+			name:          "exact name",
+			containerName: "workcell-session-fixture",
+			inventory:     "workcell-session-fixture",
+			wantErr:       true,
+		},
+		{
+			name:          "exact name among near names",
+			containerName: "workcell-session-fixture",
+			inventory:     "workcell-session-fixture-neighbor\nworkcell-session-fixture",
+			wantErr:       true,
+		},
+		{
+			name:          "whitespace line",
+			containerName: "workcell-session-fixture",
+			inventory:     " ",
+			wantErr:       true,
+		},
+		{
+			name:          "one-character line",
+			containerName: "workcell-session-fixture",
+			inventory:     "a",
+			wantErr:       true,
+		},
+		{
+			name:          "slash in observed name",
+			containerName: "workcell-session-fixture",
+			inventory:     "valid-name\ninvalid/name",
+			wantErr:       true,
+		},
+		{
+			name:          "blank interior line",
+			containerName: "workcell-session-fixture",
+			inventory:     "unrelated-container\n\nneighbor-container",
+			wantErr:       true,
+		},
+		{
+			name:          "container ID target",
+			containerName: strings.Repeat("a", 64),
+			wantErr:       true,
+		},
+		{
+			name:          "non-Workcell target",
+			containerName: "unrelated-container",
+			wantErr:       true,
+		},
+		{
+			name:          "double slash target",
+			containerName: "//workcell-session-fixture",
+			wantErr:       true,
+		},
+		{
+			name:          "oversized inventory line",
+			containerName: "workcell-session-fixture",
+			inventory:     strings.Repeat("a", 64*1024),
+			wantErr:       true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := ProveContainerAbsentForDelete(test.containerName, test.inventory)
+			if test.wantErr && err == nil {
+				t.Fatal("ProveContainerAbsentForDelete unexpectedly proved absence")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("ProveContainerAbsentForDelete() error = %v", err)
+			}
+		})
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "c12ccb4f5ed8a67dbb428985897f1d7ab14c3cda02adac50bd02dc095f5b5a55"
+      "sha256": "536020f8bd0b4930ed25defe5e3ff5f868ac5022e80b0d99d96d9561a5b07485"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "30d332b7792c86cd28dd8927d206760f348f79548e784e46e712a40fa57ba505"
+      "sha256": "c12ccb4f5ed8a67dbb428985897f1d7ab14c3cda02adac50bd02dc095f5b5a55"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -2211,6 +2211,36 @@ session_container_exit_code() {
   printf '%s\n' "${exit_code}"
 }
 
+session_container_absent_for_delete() {
+  local profile="$1"
+  local container_name="$2"
+  local normalized_name=""
+  local inventory_output=""
+  local observed_name=""
+
+  case "${container_name}" in
+    /workcell-*) normalized_name="${container_name#/}" ;;
+    workcell-*) normalized_name="${container_name}" ;;
+    *) return 1 ;;
+  esac
+  [[ "${normalized_name}" =~ ^workcell-[A-Za-z0-9][A-Za-z0-9_.-]*$ ]] || return 1
+
+  if ! inventory_output="$(run_profile_docker_command "${profile}" ps -a --format '{{.Names}}' 2>&1)"; then
+    return 1
+  fi
+  inventory_output="$(printf '%s\n' "${inventory_output}" | tr -d '\r')"
+  [[ -n "${inventory_output}" ]] || return 0
+
+  # Compare the complete inventory client-side. This avoids Docker filter
+  # normalization differences and makes every accepted absence proof depend on
+  # a well-formed, successful inventory that does not contain the exact name.
+  while IFS= read -r observed_name; do
+    [[ "${observed_name}" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]+$ ]] || return 1
+    [[ "${observed_name}" != "${normalized_name}" ]] || return 1
+  done <<<"${inventory_output}"
+  return 0
+}
+
 session_container_state_for_delete() {
   local profile="$1"
   local container_name="$2"
@@ -2233,12 +2263,15 @@ session_container_state_for_delete() {
     esac
     return 1
   fi
-  case "${inspect_output}" in
-    *"No such object"* | *"No such container"*)
-      printf 'missing\n'
-      return 0
-      ;;
-  esac
+
+  # Docker's missing-object diagnostic is not a stable API: capitalization
+  # and wording differ across client releases. Prove absence through a second,
+  # exact-name inventory query instead of interpreting human-readable stderr.
+  # A failed or malformed inventory remains an inspection failure.
+  if session_container_absent_for_delete "${profile}" "${container_name}"; then
+    printf 'missing\n'
+    return 0
+  fi
   return 1
 }
 
@@ -4401,8 +4434,14 @@ session_delete_main() {
 
   if [[ "${remove_container}" -eq 1 ]]; then
     if ! run_profile_docker_command "${SESSION_META_PROFILE}" rm -f "${SESSION_META_CONTAINER_NAME}" >/dev/null 2>&1; then
-      echo "session delete failed to remove the stopped session container: ${session_id}" >&2
-      exit 1
+      # The detached monitor can remove a stopped container between the
+      # inspection above and this rm. Accept only a new exact-name absence
+      # proof; a live object or unavailable inventory still fails closed and
+      # preserves the durable record and artifacts for a safe retry.
+      if ! session_container_absent_for_delete "${SESSION_META_PROFILE}" "${SESSION_META_CONTAINER_NAME}"; then
+        echo "session delete failed to remove the stopped session container: ${session_id}" >&2
+        exit 1
+      fi
     fi
   fi
   if [[ "${remove_debug_log}" -eq 1 ]]; then

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -2214,31 +2214,13 @@ session_container_exit_code() {
 session_container_absent_for_delete() {
   local profile="$1"
   local container_name="$2"
-  local normalized_name=""
-  local inventory_output=""
-  local observed_name=""
 
-  case "${container_name}" in
-    /workcell-*) normalized_name="${container_name#/}" ;;
-    workcell-*) normalized_name="${container_name}" ;;
-    *) return 1 ;;
-  esac
-  [[ "${normalized_name}" =~ ^workcell-[A-Za-z0-9][A-Za-z0-9_.-]*$ ]] || return 1
-
-  if ! inventory_output="$(run_profile_docker_command "${profile}" ps -a --format '{{.Names}}' 2>&1)"; then
-    return 1
-  fi
-  inventory_output="$(printf '%s\n' "${inventory_output}" | tr -d '\r')"
-  [[ -n "${inventory_output}" ]] || return 0
-
-  # Compare the complete inventory client-side. This avoids Docker filter
-  # normalization differences and makes every accepted absence proof depend on
-  # a well-formed, successful inventory that does not contain the exact name.
-  while IFS= read -r observed_name; do
-    [[ "${observed_name}" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]+$ ]] || return 1
-    [[ "${observed_name}" != "${normalized_name}" ]] || return 1
-  done <<<"${inventory_output}"
-  return 0
+  # Preserve the inventory byte-for-byte: Go owns identifier normalization,
+  # inventory validation, and the fail-closed absence decision. Pipefail makes
+  # either the same-profile Docker query or Go policy failure reject the proof.
+  run_profile_docker_command "${profile}" ps -a --format '{{.Names}}' 2>&1 |
+    go_hostutil helper session-container-absent-for-delete "${container_name}" \
+      >/dev/null 2>&1
 }
 
 session_container_state_for_delete() {

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -2534,12 +2534,14 @@ bash -lc '
   set -euo pipefail
   source "$1"
   trap - EXIT
-  for inventory_case in exact exact_and_near whitespace one_character malformed; do
+  for inventory_case in exact exact_and_near whitespace empty_record trailing_blank one_character malformed; do
     run_profile_docker_command() {
       case "${inventory_case}" in
         exact) printf "workcell-session-fixture\n" ;;
         exact_and_near) printf "workcell-session-fixture\nworkcell-session-fixture-neighbor\n" ;;
         whitespace) printf " \n" ;;
+        empty_record) printf "\n" ;;
+        trailing_blank) printf "unrelated-container\n\n" ;;
         one_character) printf "a\n" ;;
         malformed) printf "valid-name\ninvalid/name\n" ;;
       esac
@@ -2747,7 +2749,7 @@ EOF_JSON
   test -f "${SESSION_DELETE_RM_RACE_ROOT}/wcl-detached-fixture/sessions/detached-fixture.json"
   test -f "${SESSION_DELETE_RM_RACE_ROOT}/wcl-detached-fixture/sessions/detached-fixture.audit-sig"
   if [[ "${inventory_outcome}" == "identifier" ]]; then
-    test ! -e "${SESSION_DELETE_RM_RACE_ROOT}/ps-called"
+    test -f "${SESSION_DELETE_RM_RACE_ROOT}/ps-called"
   fi
 done
 

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -2463,6 +2463,11 @@ EOF_JSON
           printf "stopped\n"
           ;;
         rm)
+          # Model the detached monitor removing the stopped container between
+          # the delete inspection and rm.
+          return 1
+          ;;
+        ps)
           return 0
           ;;
         *)
@@ -2487,6 +2492,264 @@ grep -q '^missing=none$' <<<"${session_delete_cleanup_output}"
 grep -q '^unavailable=none$' <<<"${session_delete_cleanup_output}"
 grep -q '^transport|wcl-detached-fixture|inspect --format ' "${SESSION_DELETE_CLEANUP_RECORD}"
 grep -q '^transport|wcl-detached-fixture|rm -f workcell-session-fixture$' "${SESSION_DELETE_CLEANUP_RECORD}"
+grep -Fqx 'transport|wcl-detached-fixture|ps -a --format {{.Names}}' \
+  "${SESSION_DELETE_CLEANUP_RECORD}"
+
+SESSION_DELETE_MISSING_CONTAINER_RECORD="${DETACHED_STATE_DIR}/session-delete.missing-container.record"
+session_delete_missing_container_state="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    RECORD_FILE="$2"
+    : >"${RECORD_FILE}"
+    run_profile_docker_command() {
+      local profile="$1"
+      shift
+      printf "transport|%s|%s\n" "${profile}" "$*" >>"${RECORD_FILE}"
+      case "$1" in
+        inspect)
+          printf "error: no such object: workcell-session-fixture\n" >&2
+          return 1
+          ;;
+        ps)
+          [[ "$*" == "ps -a --format {{.Names}}" ]]
+          return
+          ;;
+        *)
+          return 1
+          ;;
+      esac
+    }
+    session_container_state_for_delete wcl-detached-fixture workcell-session-fixture
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_DELETE_MISSING_CONTAINER_RECORD}"
+)"
+[[ "${session_delete_missing_container_state}" == "missing" ]]
+grep -q '^transport|wcl-detached-fixture|inspect --format ' "${SESSION_DELETE_MISSING_CONTAINER_RECORD}"
+grep -Fqx 'transport|wcl-detached-fixture|ps -a --format {{.Names}}' \
+  "${SESSION_DELETE_MISSING_CONTAINER_RECORD}"
+
+set +e
+bash -lc '
+  set -euo pipefail
+  source "$1"
+  trap - EXIT
+  for inventory_case in exact exact_and_near whitespace one_character malformed; do
+    run_profile_docker_command() {
+      case "${inventory_case}" in
+        exact) printf "workcell-session-fixture\n" ;;
+        exact_and_near) printf "workcell-session-fixture\nworkcell-session-fixture-neighbor\n" ;;
+        whitespace) printf " \n" ;;
+        one_character) printf "a\n" ;;
+        malformed) printf "valid-name\ninvalid/name\n" ;;
+      esac
+    }
+    if session_container_absent_for_delete wcl-detached-fixture workcell-session-fixture; then
+      echo "accepted unexpected inventory case: ${inventory_case}" >&2
+      exit 1
+    fi
+  done
+' _ "${WORKCELL_FUNCTIONS_COPY}"
+session_delete_unexpected_inventory_status=$?
+set -e
+if [[ "${session_delete_unexpected_inventory_status}" -ne 0 ]]; then
+  echo "session delete treated nonempty or malformed container inventory as proof of absence" >&2
+  exit 1
+fi
+
+bash -lc '
+  set -euo pipefail
+  source "$1"
+  trap - EXIT
+  run_profile_docker_command() {
+    printf "unrelated-container\nworkcell-session-fixture-neighbor\n"
+  }
+  session_container_absent_for_delete wcl-detached-fixture workcell-session-fixture
+  session_container_absent_for_delete wcl-detached-fixture /workcell-session-fixture
+' _ "${WORKCELL_FUNCTIONS_COPY}"
+
+bash -lc '
+  set -uo pipefail
+  source "$1"
+  trap - EXIT
+  inventory_available=1
+  run_profile_docker_command() {
+    [[ "${inventory_available}" -eq 1 ]]
+  }
+  set +e
+  session_container_absent_for_delete wcl-detached-fixture workcell-session-fixture
+  inventory_status=$?
+  [[ "${inventory_status}" -eq 0 ]]
+  [[ "$-" != *e* ]]
+  inventory_available=0
+  session_container_absent_for_delete wcl-detached-fixture workcell-session-fixture
+  inventory_status=$?
+  [[ "${inventory_status}" -eq 1 ]]
+  [[ "$-" != *e* ]]
+' _ "${WORKCELL_FUNCTIONS_COPY}"
+
+SESSION_DELETE_UNAVAILABLE_INVENTORY_RECORD="${DETACHED_STATE_DIR}/session-delete.unavailable-inventory.record"
+set +e
+bash -lc '
+  set -euo pipefail
+  source "$1"
+  trap - EXIT
+  RECORD_FILE="$2"
+  : >"${RECORD_FILE}"
+  run_profile_docker_command() {
+    local profile="$1"
+    shift
+    printf "transport|%s|%s\n" "${profile}" "$*" >>"${RECORD_FILE}"
+    case "$1" in
+      inspect)
+        printf "error: no such object: workcell-session-fixture\n" >&2
+        return 1
+        ;;
+      ps)
+        return 1
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  }
+  session_container_state_for_delete wcl-detached-fixture workcell-session-fixture
+' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_DELETE_UNAVAILABLE_INVENTORY_RECORD}" >/dev/null 2>&1
+session_delete_unavailable_inventory_status=$?
+set -e
+if [[ "${session_delete_unavailable_inventory_status}" -eq 0 ]]; then
+  echo "session delete treated an unavailable container inventory as proof of absence" >&2
+  exit 1
+fi
+grep -Fqx 'transport|wcl-detached-fixture|ps -a --format {{.Names}}' \
+  "${SESSION_DELETE_UNAVAILABLE_INVENTORY_RECORD}"
+
+SESSION_DELETE_MISSING_INTEGRATION_ROOT="${DETACHED_STATE_DIR}/session-delete.missing-integration.root"
+session_delete_missing_integration_output="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    COLIMA_STATE_ROOT="$2"
+    PROFILE_DIR="${COLIMA_STATE_ROOT}/wcl-detached-fixture"
+    RECORD_PATH="${PROFILE_DIR}/sessions/detached-fixture.json"
+    AUDIT_SEAL_PATH="${RECORD_PATH%.json}.audit-sig"
+    mkdir -p "${PROFILE_DIR}/sessions"
+    : >"${PROFILE_DIR}/docker.sock"
+    printf "{\"version\":1}\n" >"${AUDIT_SEAL_PATH}"
+    cat >"${RECORD_PATH}" <<EOF_JSON
+{"version":1,"session_id":"detached-fixture","profile":"wcl-detached-fixture","agent":"codex","mode":"strict","status":"exited","live_status":"stopped","workspace":"/tmp/detached-fixture-workspace","container_name":"workcell-session-fixture","started_at":"2026-04-08T14:00:00Z"}
+EOF_JSON
+    resolve_host_tool() { printf "/bin/false\n"; }
+    sanitize_host_docker_env() { :; }
+    revalidate_recorded_host_output_path() { printf "%s\n" "$1"; }
+    load_session_runtime_metadata() {
+      SESSION_META_PROFILE="wcl-detached-fixture"
+      SESSION_META_CONTAINER_NAME="workcell-session-fixture"
+      SESSION_META_STATUS="exited"
+      SESSION_META_LIVE_STATUS="stopped"
+      SESSION_META_SESSION_AUDIT_DIR=""
+      SESSION_META_DEBUG_LOG_PATH=""
+      SESSION_META_FILE_TRACE_LOG_PATH=""
+      SESSION_META_TRANSCRIPT_LOG_PATH=""
+    }
+    run_profile_docker_command() {
+      case "$2" in
+        inspect)
+          printf "error: no such object: workcell-session-fixture\n" >&2
+          return 1
+          ;;
+        ps)
+          return 0
+          ;;
+        *)
+          return 1
+          ;;
+      esac
+    }
+    session_delete_main --id detached-fixture
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_DELETE_MISSING_INTEGRATION_ROOT}"
+)"
+grep -q '^deleted=1$' <<<"${session_delete_missing_integration_output}"
+grep -q '^missing=container$' <<<"${session_delete_missing_integration_output}"
+test ! -e "${SESSION_DELETE_MISSING_INTEGRATION_ROOT}/wcl-detached-fixture/sessions/detached-fixture.json"
+test ! -e "${SESSION_DELETE_MISSING_INTEGRATION_ROOT}/wcl-detached-fixture/sessions/detached-fixture.audit-sig"
+
+for inventory_outcome in exact slash_exact identifier unavailable; do
+  SESSION_DELETE_RM_RACE_ROOT="${DETACHED_STATE_DIR}/session-delete.rm-race-${inventory_outcome}.root"
+  set +e
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    trap - EXIT
+    COLIMA_STATE_ROOT="$2"
+    inventory_outcome="$3"
+    record_container_name="workcell-session-fixture"
+    case "${inventory_outcome}" in
+      slash_exact) record_container_name="/workcell-session-fixture" ;;
+      identifier) record_container_name="60960d42abe11240abc082d91d806be0fdf5986da9dcb9aefb56695bfd45e104" ;;
+    esac
+    PROFILE_DIR="${COLIMA_STATE_ROOT}/wcl-detached-fixture"
+    RECORD_PATH="${PROFILE_DIR}/sessions/detached-fixture.json"
+    AUDIT_SEAL_PATH="${RECORD_PATH%.json}.audit-sig"
+    PS_CALLED_PATH="${COLIMA_STATE_ROOT}/ps-called"
+    mkdir -p "${PROFILE_DIR}/sessions"
+    : >"${PROFILE_DIR}/docker.sock"
+    printf "{\"version\":1}\n" >"${AUDIT_SEAL_PATH}"
+    cat >"${RECORD_PATH}" <<EOF_JSON
+{"version":1,"session_id":"detached-fixture","profile":"wcl-detached-fixture","agent":"codex","mode":"strict","status":"exited","live_status":"stopped","workspace":"/tmp/detached-fixture-workspace","container_name":"${record_container_name}","started_at":"2026-04-08T14:00:00Z"}
+EOF_JSON
+    resolve_host_tool() { printf "/bin/false\n"; }
+    sanitize_host_docker_env() { :; }
+    revalidate_recorded_host_output_path() { printf "%s\n" "$1"; }
+    load_session_runtime_metadata() {
+      SESSION_META_PROFILE="wcl-detached-fixture"
+      SESSION_META_CONTAINER_NAME="${record_container_name}"
+      SESSION_META_STATUS="exited"
+      SESSION_META_LIVE_STATUS="stopped"
+      SESSION_META_SESSION_AUDIT_DIR=""
+      SESSION_META_DEBUG_LOG_PATH=""
+      SESSION_META_FILE_TRACE_LOG_PATH=""
+      SESSION_META_TRANSCRIPT_LOG_PATH=""
+    }
+    run_profile_docker_command() {
+      case "$2" in
+        inspect)
+          printf "stopped\n"
+          ;;
+        rm)
+          return 1
+          ;;
+        ps)
+          if [[ "${inventory_outcome}" == "exact" || "${inventory_outcome}" == "slash_exact" ]]; then
+            printf "workcell-session-fixture\n"
+            return 0
+          fi
+          if [[ "${inventory_outcome}" == "identifier" ]]; then
+            : >"${PS_CALLED_PATH}"
+            return 0
+          fi
+          return 1
+          ;;
+        *)
+          return 1
+          ;;
+      esac
+    }
+    session_delete_main --id detached-fixture
+  ' _ "${WORKCELL_FUNCTIONS_COPY}" "${SESSION_DELETE_RM_RACE_ROOT}" "${inventory_outcome}" >/dev/null 2>&1
+  session_delete_rm_race_status=$?
+  set -e
+  if [[ "${session_delete_rm_race_status}" -eq 0 ]]; then
+    echo "session delete accepted an unproved rm-race absence: ${inventory_outcome}" >&2
+    exit 1
+  fi
+  test -f "${SESSION_DELETE_RM_RACE_ROOT}/wcl-detached-fixture/sessions/detached-fixture.json"
+  test -f "${SESSION_DELETE_RM_RACE_ROOT}/wcl-detached-fixture/sessions/detached-fixture.audit-sig"
+  if [[ "${inventory_outcome}" == "identifier" ]]; then
+    test ! -e "${SESSION_DELETE_RM_RACE_ROOT}/ps-called"
+  fi
+done
 
 SESSION_DELETE_COMPAT_RECORD="${DETACHED_STATE_DIR}/session-delete.compat.record"
 SESSION_DELETE_COMPAT_ROOT="${DETACHED_STATE_DIR}/session-delete.compat.root"


### PR DESCRIPTION
## Summary

- replace Docker error-text matching with a successful full container inventory
  streamed byte-for-byte into a Go-owned policy decision
- fail closed for unsupported identifiers, malformed or unavailable inventory,
  and live exact-name matches
- accept a detached-monitor removal race only after a fresh absence proof,
  preserving the durable record, audit seal, and artifacts otherwise

The public `workcell session delete` contract is unchanged; this hardens its
existing missing-container and concurrent-cleanup behavior.

## Validation

- full live `tests/scenarios/shared/test-session-commands.sh`
- live helper proof against Docker 29.2.1 for present, slash-prefixed, ID, and
  absent targets
- ShellCheck and Bash syntax
- focused Go packages for session control and host sessions
- control-plane manifest and operator-contract verification
- three-lens adversarial peer review, clean after findings were fixed and
  re-reviewed
- fresh exact-tree `./scripts/pre-merge.sh --profile pr-parity`
