### PR TITLE
Gate release publication on canonical tag policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,25 @@ env:
   WORKCELL_SYFT_VERSION: v1.49.0
 
 jobs:
+  tag-policy:
+    name: Release tag policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Classify release tag
+        run: go run ./cmd/workcell-hostutil release classify-tag "${GITHUB_REF_NAME}" >/dev/null
+
   codeql-preflight:
     name: Release CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    needs: tag-policy
     permissions:
       actions: read # Read workflow metadata required by CodeQL helper actions.
       contents: read
@@ -81,6 +96,7 @@ jobs:
     # mirrors the already-reviewed native arm64 lane in ci.yml.
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
+    needs: tag-policy
     permissions:
       contents: read
     outputs:
@@ -138,6 +154,7 @@ jobs:
     # combined runtime manifest that publish checks against.
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    needs: tag-policy
     permissions:
       contents: read
     outputs:
@@ -183,6 +200,7 @@ jobs:
     # `needs` of build-arm64-image and release below.
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: tag-policy
     permissions:
       contents: read
     steps:
@@ -214,6 +232,7 @@ jobs:
     name: Release Copilot runtime image probe (arm64)
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
+    needs: tag-policy
     permissions:
       contents: read
     steps:
@@ -264,6 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs:
+      - tag-policy
       - preflight-amd64-repro
       - preflight-arm64-repro
     environment:
@@ -353,10 +373,6 @@ jobs:
             echo "Wait for main checks to finish before re-running this release." >&2
             exit 1
           fi
-
-      - name: Validate release tag name
-        run: |
-          [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]
 
       - name: Verify release tag signature
         env:
@@ -644,6 +660,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     needs:
+      - tag-policy
       - preflight
     permissions:
       contents: read
@@ -733,6 +750,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     needs:
+      - tag-policy
       - codeql-preflight
       - preflight
       - preflight-arm64-copilot-runtime
@@ -792,6 +810,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs:
+      - tag-policy
       - codeql-preflight
       - preflight
       - preflight-arm64-copilot-runtime
@@ -818,10 +837,6 @@ jobs:
         with:
           name: workcell-release-preflight
           path: dist/preflight
-
-      - name: Validate release tag name
-        run: |
-          [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]
 
       - name: Verify release tag signature
         env:

--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -195,11 +195,25 @@ func runRelease(args []string) error {
 	}
 
 	switch args[0] {
+	case "classify-tag":
+		if len(args) != 2 {
+			return releaseUsage()
+		}
+		policy, err := release.ClassifyTag(args[1])
+		if err != nil {
+			return err
+		}
+		return json.NewEncoder(os.Stdout).Encode(policy)
 	case "create-payload":
 		if len(args) != 3 {
 			return releaseUsage()
 		}
 		return release.WriteGitHubReleaseCreatePayload(args[1], args[2])
+	case "publish-payload":
+		if len(args) != 3 {
+			return releaseUsage()
+		}
+		return release.WriteGitHubReleasePublishPayload(args[1], args[2])
 	case "metadata":
 		if len(args) < 4 {
 			return releaseUsage()
@@ -1033,7 +1047,7 @@ func pathUsage() error {
 }
 
 func releaseUsage() error {
-	return &cliexit.ExitCodeError{Code: 2, Message: "usage: workcell-hostutil release <create-payload|metadata|encode-name|bundle-manifest> [args...]"}
+	return &cliexit.ExitCodeError{Code: 2, Message: "usage: workcell-hostutil release <classify-tag|create-payload|publish-payload|metadata|encode-name|bundle-manifest> [args...]"}
 }
 
 func helperUsage() error {

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -515,6 +515,15 @@ If the workflow enters a waiting state for the `release` environment:
 In `review-gated` mode, stop with the fourth checkpoint packet before approving
 the environment.
 
+The workflow starts with a read-only tag-policy gate. The gate uses the same
+`workcell-hostutil release classify-tag` implementation as the host-side
+publisher, and every later release job depends on it directly. The publisher
+also classifies the tag before its first GitHub release-API request.
+Unsupported tags therefore fail before a write-capable job or API mutation can
+run. Release candidates are published as prereleases and never become latest;
+final tags are non-prereleases and become latest only when their populated
+draft is published.
+
 In immutable-release mode, the release publisher must create or reuse a draft
 release, upload the full artifact set into that draft, and only then publish
 the final release record. If publication instead tries to upload assets into an

--- a/internal/host/release/publisher_input_test.go
+++ b/internal/host/release/publisher_input_test.go
@@ -16,6 +16,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -285,6 +287,65 @@ func TestAssetInventoryMatchesBothAuthoritativeWorkflowLists(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowUsesSingleAuthoritativeTagPolicyGate(t *testing.T) {
+	t.Parallel()
+	root := filepath.Join("..", "..", "..")
+	workflowData, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(workflowData)
+	if strings.Count(workflow, "release classify-tag") != 1 {
+		t.Fatalf("release workflow classify-tag invocation count = %d, want 1", strings.Count(workflow, "release classify-tag"))
+	}
+	if strings.Contains(workflow, "=~") || strings.Contains(workflow, `^v[0-9]`) {
+		t.Fatal("release workflow contains a competing release-tag regex")
+	}
+
+	var document struct {
+		Jobs map[string]struct {
+			Needs       yaml.Node         `yaml:"needs"`
+			Permissions map[string]string `yaml:"permissions"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(workflowData, &document); err != nil {
+		t.Fatalf("parse release workflow: %v", err)
+	}
+	tagPolicy, ok := document.Jobs["tag-policy"]
+	if !ok {
+		t.Fatal("release workflow is missing tag-policy job")
+	}
+	if len(tagPolicy.Permissions) != 1 || tagPolicy.Permissions["contents"] != "read" {
+		t.Fatalf("tag-policy permissions = %#v, want only contents: read", tagPolicy.Permissions)
+	}
+	for jobID, job := range document.Jobs {
+		if jobID == "tag-policy" {
+			continue
+		}
+		if !workflowNeedsJob(job.Needs, "tag-policy") {
+			t.Fatalf("release workflow job %q is not directly gated by tag-policy", jobID)
+		}
+	}
+
+	publisherData, err := os.ReadFile(filepath.Join(root, "scripts", "publish-github-release.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	publisher := string(publisherData)
+	firstAPI := strings.Index(publisher, `status="$(api GET`)
+	if firstAPI < 0 {
+		t.Fatal("publisher is missing the GitHub release lookup")
+	}
+	for _, invocation := range []string{`release classify-tag "${TAG_NAME}"`} {
+		if strings.Count(publisher, invocation) != 1 {
+			t.Fatalf("publisher invocation %q count = %d, want 1", invocation, strings.Count(publisher, invocation))
+		}
+		if index := strings.Index(publisher, invocation); index < 0 || index > firstAPI {
+			t.Fatalf("publisher invocation %q must precede the first GitHub release-API call", invocation)
+		}
+	}
+}
+
 func TestWorkflowInventoryParserAcceptsBothBundlePlaceholderForms(t *testing.T) {
 	t.Parallel()
 	data, err := os.ReadFile(filepath.Join("..", "..", "..", ".github", "workflows", "release.yml"))
@@ -322,6 +383,20 @@ func TestWorkflowInventoryParserAcceptsBothBundlePlaceholderForms(t *testing.T) 
 			}
 		})
 	}
+}
+
+func workflowNeedsJob(needs yaml.Node, wanted string) bool {
+	switch needs.Kind {
+	case yaml.ScalarNode:
+		return needs.Value == wanted
+	case yaml.SequenceNode:
+		for _, item := range needs.Content {
+			if item.Kind == yaml.ScalarNode && item.Value == wanted {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func TestWorkflowInventoryParserRejectsMutations(t *testing.T) {

--- a/internal/host/release/release.go
+++ b/internal/host/release/release.go
@@ -23,7 +23,15 @@ import (
 type createPayload struct {
 	TagName              string `json:"tag_name"`
 	Draft                bool   `json:"draft"`
+	Prerelease           bool   `json:"prerelease"`
+	MakeLatest           string `json:"make_latest"`
 	GenerateReleaseNotes bool   `json:"generate_release_notes"`
+}
+
+type publishPayload struct {
+	Draft      bool   `json:"draft"`
+	Prerelease bool   `json:"prerelease"`
+	MakeLatest string `json:"make_latest"`
 }
 
 type asset struct {
@@ -51,10 +59,38 @@ type bundleManifest struct {
 // WriteGitHubReleaseCreatePayload emits the JSON body the GitHub
 // "create a release" REST call needs.
 func WriteGitHubReleaseCreatePayload(tagName, outputPath string) error {
+	policy, err := ClassifyTag(tagName)
+	if err != nil {
+		return err
+	}
 	payload := createPayload{
 		TagName:              tagName,
 		Draft:                true,
+		Prerelease:           policy.Prerelease,
+		MakeLatest:           "false",
 		GenerateReleaseNotes: true,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(outputPath, data, 0o644)
+}
+
+// WriteGitHubReleasePublishPayload emits the final metadata transition for the
+// supported release class.
+func WriteGitHubReleasePublishPayload(tagName, outputPath string) error {
+	policy, err := ClassifyTag(tagName)
+	if err != nil {
+		return err
+	}
+	makeLatest := "false"
+	if policy.MakeLatest {
+		makeLatest = "true"
+	}
+	payload := publishPayload{
+		Prerelease: policy.Prerelease,
+		MakeLatest: makeLatest,
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/host/release/release_test.go
+++ b/internal/host/release/release_test.go
@@ -6,6 +6,7 @@ package release
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,19 +15,76 @@ import (
 
 func TestWriteGitHubReleaseCreatePayload(t *testing.T) {
 	t.Parallel()
-	tmp := t.TempDir()
-	outputPath := filepath.Join(tmp, "create.json")
-	if err := WriteGitHubReleaseCreatePayload("v1.2.3", outputPath); err != nil {
-		t.Fatal(err)
+	for _, tc := range []struct {
+		tag  string
+		want string
+	}{
+		{
+			tag:  "v1.2.3",
+			want: `{"tag_name":"v1.2.3","draft":true,"prerelease":false,"make_latest":"false","generate_release_notes":true}`,
+		},
+		{
+			tag:  "v1.2.3-rc.4",
+			want: `{"tag_name":"v1.2.3-rc.4","draft":true,"prerelease":true,"make_latest":"false","generate_release_notes":true}`,
+		},
+	} {
+		t.Run(tc.tag, func(t *testing.T) {
+			t.Parallel()
+			outputPath := filepath.Join(t.TempDir(), "create.json")
+			if err := WriteGitHubReleaseCreatePayload(tc.tag, outputPath); err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(outputPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != tc.want {
+				t.Fatalf("payload = %s, want %s", data, tc.want)
+			}
+		})
 	}
+}
 
-	data, err := os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatal(err)
+func TestWriteGitHubReleasePublishPayload(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		tag  string
+		want string
+	}{
+		{tag: "v1.2.3", want: `{"draft":false,"prerelease":false,"make_latest":"true"}`},
+		{tag: "v1.2.3-rc.4", want: `{"draft":false,"prerelease":true,"make_latest":"false"}`},
+	} {
+		t.Run(tc.tag, func(t *testing.T) {
+			t.Parallel()
+			outputPath := filepath.Join(t.TempDir(), "publish.json")
+			if err := WriteGitHubReleasePublishPayload(tc.tag, outputPath); err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(outputPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != tc.want {
+				t.Fatalf("payload = %s, want %s", data, tc.want)
+			}
+		})
 	}
+}
 
-	if string(data) != `{"tag_name":"v1.2.3","draft":true,"generate_release_notes":true}` {
-		t.Fatalf("unexpected payload: %s", data)
+func TestReleasePayloadsRejectUnsupportedTags(t *testing.T) {
+	t.Parallel()
+	for _, write := range []func(string, string) error{
+		WriteGitHubReleaseCreatePayload,
+		WriteGitHubReleasePublishPayload,
+	} {
+		outputPath := filepath.Join(t.TempDir(), "payload.json")
+		err := write("v1.2.3-beta.1", outputPath)
+		if !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("write unsupported tag error = %v, want ErrInvalidInput", err)
+		}
+		if _, statErr := os.Stat(outputPath); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("unsupported tag created output file: %v", statErr)
+		}
 	}
 }
 

--- a/policy/workflow-lane-policy.json
+++ b/policy/workflow-lane-policy.json
@@ -201,6 +201,12 @@
       "local_mode": "none",
       "github_only_reason": "release publication remains GitHub-only"
     },
+    "release.yml/tag-policy": {
+      "profiles": ["release-preflight"],
+      "authority": "release-only",
+      "local_mode": "none",
+      "github_only_reason": "the exact pushed-tag event binding exists only in GitHub Actions; the shared tag classifier and negative controls run in local Go tests"
+    },
     "scorecard.yml/analysis": {
       "profiles": ["release-preflight"],
       "authority": "github-only",

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -702,6 +702,22 @@
       "github_only_reason": "release publication remains GitHub-only"
     },
     {
+      "id": "release.yml/tag-policy",
+      "workflow_path": ".github/workflows/release.yml",
+      "workflow_name": "Release",
+      "job_id": "tag-policy",
+      "job_name": "Release tag policy",
+      "workflow_events": [
+        "push"
+      ],
+      "profiles": [
+        "release-preflight"
+      ],
+      "authority": "release-only",
+      "local_mode": "none",
+      "github_only_reason": "the exact pushed-tag event binding exists only in GitHub Actions; the shared tag classifier and negative controls run in local Go tests"
+    },
+    {
       "id": "scorecard.yml/analysis",
       "workflow_path": ".github/workflows/scorecard.yml",
       "workflow_name": "Scorecard",

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -130,6 +130,9 @@ cleanup() {
 trap cleanup EXIT
 build_go_tool_in_repo "${ROOT_DIR}" "${HOSTUTIL_BIN}" ./cmd/workcell-hostutil
 
+# This fail-closed tag gate runs before the first GitHub release-API request.
+"${HOSTUTIL_BIN}" release classify-tag "${TAG_NAME}" >/dev/null
+
 release_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}"
 release_json="${TMP_ROOT}/release.json"
 create_payload="${TMP_ROOT}/create.json"
@@ -205,7 +208,7 @@ for path in "$@"; do
 done
 
 publish_payload="${TMP_ROOT}/publish.json"
-printf '{"draft":false}\n' >"${publish_payload}"
+"${HOSTUTIL_BIN}" release publish-payload "${TAG_NAME}" "${publish_payload}"
 publish_status="$(api PATCH "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/${release_id}" "${publish_payload}" "${TMP_ROOT}/publish-response.json")"
 [[ "${publish_status}" == "200" ]] || {
   echo "Failed to publish GitHub release ${TAG_NAME} after uploading assets" >&2


### PR DESCRIPTION
## Summary

- fail unsupported tags in the first read-only release job and before publisher API access
- distinguish final and release-candidate create/publish metadata
- add dynamic all-job gating, payload negative controls, workflow-lane parity, and scoped runbook updates

## Validation

- `./scripts/pre-merge.sh --profile pr-parity` (exact signed commit)
- `go test -race ./internal/host/release ./cmd/workcell-hostutil`
- `./scripts/check-workflows.sh`
- `./scripts/verify-workflow-lanes.sh`
- `tests/scenarios/shared/test-publish-github-release.sh`
- three-lens peer-review loop clean