### PR TITLE
Validate repository-bound GitHub release state

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -214,6 +214,41 @@ func runRelease(args []string) error {
 			return releaseUsage()
 		}
 		return release.WriteGitHubReleasePublishPayload(args[1], args[2])
+	case "validate-repository":
+		if len(args) != 2 {
+			return releaseUsage()
+		}
+		return release.ValidateGitHubRepository(args[1])
+	case "validate-draft-release":
+		if len(args) != 4 {
+			return releaseUsage()
+		}
+		return release.ValidateGitHubDraftRelease(args[1], args[2], args[3])
+	case "validate-published-state":
+		if len(args) != 4 {
+			return releaseUsage()
+		}
+		return release.ValidateGitHubPublishedReleaseState(args[1], args[2], args[3])
+	case "validate-latest-response":
+		if len(args) != 5 {
+			return releaseUsage()
+		}
+		return release.ValidateGitHubLatestReleaseResponse(args[1], args[2], args[3], args[4])
+	case "list-page-size":
+		if len(args) != 2 {
+			return releaseUsage()
+		}
+		size, err := release.GitHubReleaseListPageSize(args[1])
+		if err != nil {
+			return err
+		}
+		fmt.Println(size)
+		return nil
+	case "select-listed-release":
+		if len(args) < 4 {
+			return releaseUsage()
+		}
+		return release.WriteGitHubListedRelease(args[1], args[3:], args[2])
 	case "metadata":
 		if len(args) < 4 {
 			return releaseUsage()
@@ -1047,7 +1082,20 @@ func pathUsage() error {
 }
 
 func releaseUsage() error {
-	return &cliexit.ExitCodeError{Code: 2, Message: "usage: workcell-hostutil release <classify-tag|create-payload|publish-payload|metadata|encode-name|bundle-manifest> [args...]"}
+	return &cliexit.ExitCodeError{Code: 2, Message: `usage: workcell-hostutil release COMMAND [args...]
+commands:
+  classify-tag TAG
+  create-payload TAG OUTPUT
+  publish-payload TAG OUTPUT
+  validate-repository OWNER/REPO
+  validate-draft-release OWNER/REPO TAG RESPONSE_JSON
+  validate-published-state OWNER/REPO TAG RESPONSE_JSON
+  validate-latest-response OWNER/REPO TAG HTTP_STATUS RESPONSE_JSON
+  list-page-size PAGE_JSON
+  select-listed-release TAG OUTPUT PAGE_JSON...
+  metadata RESPONSE_JSON OUTPUT ASSET...
+  encode-name NAME
+  bundle-manifest OUTPUT ARCHIVE_REF BUNDLE_NAME BUNDLE_PREFIX SOURCE_DATE_EPOCH BUNDLE_SHA256 CHECKSUMS_SHA256`}
 }
 
 func helperUsage() error {

--- a/cmd/workcell-hostutil/release_test.go
+++ b/cmd/workcell-hostutil/release_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/cliexit"
+)
+
+func TestReleaseStateCommandDispatch(t *testing.T) {
+	tmp := t.TempDir()
+	draft := writeHostutilReleaseFixture(t, tmp, "draft.json", hostutilReleaseJSON("example/workcell", "v1.2.3", true, false, false))
+	published := writeHostutilReleaseFixture(t, tmp, "published.json", hostutilReleaseJSON("example/workcell", "v1.2.3", false, false, true))
+	page := writeHostutilReleaseFixture(t, tmp, "page.json", "["+hostutilReleaseJSON("example/workcell", "v1.2.3", true, false, false)+"]")
+	selected := filepath.Join(tmp, "selected.json")
+
+	for name, args := range map[string][]string{
+		"repository":       {"validate-repository", "example/workcell"},
+		"draft":            {"validate-draft-release", "example/workcell", "v1.2.3", draft},
+		"published":        {"validate-published-state", "example/workcell", "v1.2.3", published},
+		"latest":           {"validate-latest-response", "example/workcell", "v1.2.3", "200", published},
+		"select exact tag": {"select-listed-release", "v1.2.3", selected, page},
+	} {
+		if err := runRelease(args); err != nil {
+			t.Errorf("%s dispatch error = %v", name, err)
+		}
+	}
+	if info, err := os.Stat(selected); err != nil || info.Size() == 0 {
+		t.Fatalf("selected release info = %#v, error = %v; want nonempty output", info, err)
+	}
+
+	output, err := captureHostutilStdout(t, func() error {
+		return runRelease([]string{"list-page-size", page})
+	})
+	if err != nil || output != "1\n" {
+		t.Fatalf("list-page-size output = %q, error = %v; want %q", output, err, "1\n")
+	}
+}
+
+func TestReleaseStateCommandUsageIsActionable(t *testing.T) {
+	for _, args := range [][]string{
+		nil,
+		{"validate-repository"},
+		{"validate-draft-release", "owner/repo", "v1.2.3"},
+		{"validate-published-state", "owner/repo", "v1.2.3"},
+		{"validate-latest-response", "owner/repo", "v1.2.3", "200"},
+		{"select-listed-release", "v1.2.3", "output.json"},
+	} {
+		err := runRelease(args)
+		var exitErr *cliexit.ExitCodeError
+		if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+			t.Fatalf("runRelease(%q) error = %v, want exit code 2", args, err)
+		}
+		for _, required := range []string{
+			"validate-draft-release OWNER/REPO TAG RESPONSE_JSON",
+			"validate-latest-response OWNER/REPO TAG HTTP_STATUS RESPONSE_JSON",
+			"select-listed-release TAG OUTPUT PAGE_JSON...",
+		} {
+			if !strings.Contains(exitErr.Message, required) {
+				t.Fatalf("usage missing %q:\n%s", required, exitErr.Message)
+			}
+		}
+	}
+}
+
+func hostutilReleaseJSON(repository, tag string, draft, prerelease, immutable bool) string {
+	return `{"id":1,"upload_url":"https://uploads.github.com/repos/` + repository +
+		`/releases/1/assets{?name,label}","tag_name":"` + tag +
+		`","draft":` + strconv.FormatBool(draft) + `,"prerelease":` + strconv.FormatBool(prerelease) +
+		`,"immutable":` + strconv.FormatBool(immutable) + `,"assets":[]}`
+}
+
+func writeHostutilReleaseFixture(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func captureHostutilStdout(t *testing.T, run func() error) (string, error) {
+	t.Helper()
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = original
+	}()
+	runErr := run()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(data), runErr
+}

--- a/internal/host/release/publisher_input.go
+++ b/internal/host/release/publisher_input.go
@@ -70,6 +70,12 @@ func validateRepository(repository string) error {
 	return nil
 }
 
+// ValidateGitHubRepository requires one safe OWNER/REPO identifier before a
+// caller interpolates it into a GitHub release API URL.
+func ValidateGitHubRepository(repository string) error {
+	return validateRepository(repository)
+}
+
 func validateToolchain(toolchain string) error {
 	if !toolchainPattern.MatchString(toolchain) {
 		return inputErrorf("toolchain must be exact goX.Y.Z, got %q", toolchain)

--- a/internal/host/release/release.go
+++ b/internal/host/release/release.go
@@ -47,6 +47,16 @@ type response struct {
 	Assets    []asset `json:"assets"`
 }
 
+type listedRelease struct {
+	ID         *int64             `json:"id"`
+	UploadURL  *string            `json:"upload_url"`
+	TagName    *string            `json:"tag_name"`
+	Draft      *bool              `json:"draft"`
+	Prerelease *bool              `json:"prerelease"`
+	Immutable  *bool              `json:"immutable"`
+	Assets     *[]json.RawMessage `json:"assets"`
+}
+
 type bundleManifest struct {
 	ArchiveRef      string `json:"archive_ref"`
 	BundleName      string `json:"bundle_name"`
@@ -97,6 +107,236 @@ func WriteGitHubReleasePublishPayload(tagName, outputPath string) error {
 		return err
 	}
 	return os.WriteFile(outputPath, data, 0o644)
+}
+
+// GitHubReleaseListPageSize validates that path contains one List releases
+// response page and returns its item count.
+func GitHubReleaseListPageSize(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	var page []json.RawMessage
+	if err := json.Unmarshal(data, &page); err != nil {
+		return 0, fmt.Errorf("decode GitHub releases list page: %w", err)
+	}
+	if page == nil {
+		return 0, fmt.Errorf("decode GitHub releases list page: expected JSON array, got null")
+	}
+	return len(page), nil
+}
+
+// WriteGitHubListedRelease selects exactly one authenticated List releases item
+// with tagName across every supplied page. An absent tag produces an empty
+// output file. Duplicate matches or malformed release objects fail closed.
+func WriteGitHubListedRelease(tagName string, pagePaths []string, outputPath string) error {
+	if _, err := ClassifyTag(tagName); err != nil {
+		return err
+	}
+	if len(pagePaths) == 0 {
+		return inputErrorf("at least one GitHub releases list page is required")
+	}
+	var match json.RawMessage
+	for _, pagePath := range pagePaths {
+		data, err := os.ReadFile(pagePath)
+		if err != nil {
+			return err
+		}
+		var page []json.RawMessage
+		if err := json.Unmarshal(data, &page); err != nil {
+			return fmt.Errorf("decode GitHub releases list page %q: %w", pagePath, err)
+		}
+		if page == nil {
+			return fmt.Errorf("decode GitHub releases list page %q: expected JSON array, got null", pagePath)
+		}
+		for index, raw := range page {
+			var item listedRelease
+			if err := json.Unmarshal(raw, &item); err != nil {
+				return fmt.Errorf("decode GitHub release list item %d in %q: %w", index, pagePath, err)
+			}
+			if err := validateListedRelease(item); err != nil {
+				return fmt.Errorf("malformed GitHub release list item %d in %q: %w", index, pagePath, err)
+			}
+			if *item.TagName != tagName {
+				continue
+			}
+			if match != nil {
+				return fmt.Errorf("GitHub releases list contains duplicate exact tag %q", tagName)
+			}
+			match = append(json.RawMessage(nil), raw...)
+		}
+	}
+	if match == nil {
+		return os.WriteFile(outputPath, nil, 0o600)
+	}
+	return os.WriteFile(outputPath, match, 0o600)
+}
+
+func validateListedRelease(item listedRelease) error {
+	if item.ID == nil || *item.ID <= 0 {
+		return fmt.Errorf("missing or invalid id")
+	}
+	if item.UploadURL == nil || *item.UploadURL == "" {
+		return fmt.Errorf("missing upload_url")
+	}
+	if item.TagName == nil || *item.TagName == "" {
+		return fmt.Errorf("missing tag_name")
+	}
+	if item.Draft == nil {
+		return fmt.Errorf("missing draft")
+	}
+	if item.Prerelease == nil {
+		return fmt.Errorf("missing prerelease")
+	}
+	if item.Immutable == nil {
+		return fmt.Errorf("missing immutable")
+	}
+	if item.Assets == nil {
+		return fmt.Errorf("missing assets")
+	}
+	return nil
+}
+
+func validateReleaseUploadURL(repository string, item listedRelease) error {
+	want := fmt.Sprintf(
+		"https://uploads.github.com/repos/%s/releases/%d/assets{?name,label}",
+		repository,
+		*item.ID,
+	)
+	if *item.UploadURL != want {
+		return fmt.Errorf("GitHub release upload_url = %q, want %q", *item.UploadURL, want)
+	}
+	return nil
+}
+
+// ValidateGitHubDraftRelease validates an exact-tag mutable draft and its
+// repository-derived upload URL. Asset content authorization is intentionally
+// owned by the staged-content publisher, not this metadata-only validator.
+func ValidateGitHubDraftRelease(repository, tagName, responsePath string) error {
+	if err := validateRepository(repository); err != nil {
+		return err
+	}
+	policy, err := ClassifyTag(tagName)
+	if err != nil {
+		return err
+	}
+	item, err := readListedRelease(responsePath, "draft")
+	if err != nil {
+		return err
+	}
+	if *item.TagName != tagName {
+		return fmt.Errorf("GitHub draft release tag_name = %q, want %q", *item.TagName, tagName)
+	}
+	if !*item.Draft {
+		return fmt.Errorf("GitHub draft release draft = false, want true")
+	}
+	if *item.Prerelease != policy.Prerelease {
+		return fmt.Errorf("GitHub draft release prerelease = %t, want %t for %s tag %q", *item.Prerelease, policy.Prerelease, policy.Kind, tagName)
+	}
+	if *item.Immutable {
+		return fmt.Errorf("GitHub draft release immutable = true, want false")
+	}
+	if err := validateReleaseUploadURL(repository, item); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateGitHubPublishedReleaseState verifies immutable published metadata and
+// repository binding. It does not authorize asset bytes.
+func ValidateGitHubPublishedReleaseState(repository, tagName, responsePath string) error {
+	if err := validateRepository(repository); err != nil {
+		return err
+	}
+	if _, err := ClassifyTag(tagName); err != nil {
+		return err
+	}
+	item, err := readListedRelease(responsePath, "published")
+	if err != nil {
+		return err
+	}
+	if *item.TagName != tagName {
+		return fmt.Errorf("GitHub published release tag_name = %q, want %q", *item.TagName, tagName)
+	}
+	if err := validateReleaseUploadURL(repository, item); err != nil {
+		return err
+	}
+	return validatePublishedReleaseItem(tagName, item)
+}
+
+func readListedRelease(path, state string) (listedRelease, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return listedRelease{}, err
+	}
+	var item listedRelease
+	if err := json.Unmarshal(data, &item); err != nil {
+		return listedRelease{}, fmt.Errorf("decode GitHub %s release response: %w", state, err)
+	}
+	if err := validateListedRelease(item); err != nil {
+		return listedRelease{}, fmt.Errorf("malformed GitHub %s release response: %w", state, err)
+	}
+	return item, nil
+}
+
+// ValidateGitHubLatestReleaseResponse verifies GitHub's repository-wide latest
+// pointer after publication. Final tags must become latest. Release candidates
+// must leave a final release latest; a 404 is valid when none exists.
+func ValidateGitHubLatestReleaseResponse(repository, tagName, httpStatus, responsePath string) error {
+	if err := validateRepository(repository); err != nil {
+		return err
+	}
+	policy, err := ClassifyTag(tagName)
+	if err != nil {
+		return err
+	}
+	if policy.MakeLatest {
+		if httpStatus != "200" {
+			return fmt.Errorf("GitHub latest release lookup returned HTTP %s after final tag %q; want 200", httpStatus, tagName)
+		}
+	} else {
+		if httpStatus == "404" {
+			return nil
+		}
+		if httpStatus != "200" {
+			return fmt.Errorf("GitHub latest release lookup returned HTTP %s after release-candidate tag %q; want 200 or 404", httpStatus, tagName)
+		}
+	}
+	item, err := readListedRelease(responsePath, "latest")
+	if err != nil {
+		return err
+	}
+	if err := validateReleaseUploadURL(repository, item); err != nil {
+		return err
+	}
+	if policy.MakeLatest {
+		if *item.TagName != tagName {
+			return fmt.Errorf("GitHub latest release tag_name = %q, want final tag %q", *item.TagName, tagName)
+		}
+		return validatePublishedReleaseItem(tagName, item)
+	}
+	latestPolicy, err := ClassifyTag(*item.TagName)
+	if err != nil || !latestPolicy.MakeLatest {
+		return fmt.Errorf("GitHub latest release tag_name = %q after release-candidate tag %q; want a final release tag", *item.TagName, tagName)
+	}
+	return validatePublishedReleaseItem(*item.TagName, item)
+}
+
+func validatePublishedReleaseItem(tagName string, item listedRelease) error {
+	if *item.Draft {
+		return fmt.Errorf("GitHub published release draft = true, want false")
+	}
+	policy, err := ClassifyTag(tagName)
+	if err != nil {
+		return err
+	}
+	if *item.Prerelease != policy.Prerelease {
+		return fmt.Errorf("GitHub published release prerelease = %t, want %t for %s tag %q", *item.Prerelease, policy.Prerelease, policy.Kind, tagName)
+	}
+	if !*item.Immutable {
+		return fmt.Errorf("GitHub published release immutable = false, want true")
+	}
+	return nil
 }
 
 // WriteGitHubReleaseMetadata reads a GitHub release response JSON file

--- a/internal/host/release/release_state_test.go
+++ b/internal/host/release/release_state_test.go
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin || linux
+
+package release
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGitHubReleaseListPageSize(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		body    string
+		want    int
+		wantErr string
+	}{
+		{name: "empty", body: `[]`},
+		{name: "two", body: `[{},{}]`, want: 2},
+		{name: "null", body: `null`, wantErr: "expected JSON array"},
+		{name: "object", body: `{}`, wantErr: "decode GitHub releases list page"},
+		{name: "malformed", body: `[`, wantErr: "decode GitHub releases list page"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := GitHubReleaseListPageSize(writeReleaseStateFixture(t, tc.body))
+			assertReleaseStateResult(t, err, tc.wantErr)
+			if err == nil && got != tc.want {
+				t.Fatalf("page size = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteGitHubListedRelease(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	other := releaseStateJSON(t, "example/workcell", "v1.2.30", true, false, false, 0)
+	match := releaseStateJSON(t, "example/workcell", "v1.2.3", true, false, false, 0)
+	first := filepath.Join(tmp, "first.json")
+	second := filepath.Join(tmp, "second.json")
+	output := filepath.Join(tmp, "selected.json")
+	writeReleaseStatePage(t, first, other)
+	writeReleaseStatePage(t, second, match)
+
+	if err := WriteGitHubListedRelease("v1.2.3", []string{first, second}, output); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != match {
+		t.Fatalf("selected release = %s, want %s", got, match)
+	}
+
+	if err := WriteGitHubListedRelease("v1.2.4", []string{first, second}, output); err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Stat(output); err != nil || info.Size() != 0 {
+		t.Fatalf("absent exact tag output info = %#v, error = %v; want empty file", info, err)
+	}
+}
+
+func TestWriteGitHubListedReleaseFailsClosed(t *testing.T) {
+	t.Parallel()
+	valid := releaseStateJSON(t, "example/workcell", "v1.2.3", true, false, false, 0)
+	for _, tc := range []struct {
+		name    string
+		pages   []string
+		wantErr string
+	}{
+		{name: "duplicate exact tag", pages: []string{"[" + valid + "]", "[" + valid + "]"}, wantErr: "duplicate exact tag"},
+		{name: "null page", pages: []string{"null"}, wantErr: "expected JSON array"},
+		{name: "malformed page", pages: []string{"["}, wantErr: "decode GitHub releases list page"},
+		{
+			name:    "missing upload URL",
+			pages:   []string{`[{"id":2,"tag_name":"v1.2.4","draft":true,"prerelease":false,"immutable":false,"assets":[]}]`},
+			wantErr: "missing upload_url",
+		},
+		{
+			name:    "missing assets",
+			pages:   []string{`[{"id":2,"upload_url":"https://uploads.example/2","tag_name":"v1.2.4","draft":true,"prerelease":false,"immutable":false}]`},
+			wantErr: "missing assets",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmp := t.TempDir()
+			paths := make([]string, 0, len(tc.pages))
+			for index, body := range tc.pages {
+				path := filepath.Join(tmp, fmt.Sprintf("page-%d.json", index))
+				if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				paths = append(paths, path)
+			}
+			err := WriteGitHubListedRelease("v1.2.3", paths, filepath.Join(tmp, "selected.json"))
+			assertReleaseStateResult(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestValidateGitHubDraftRelease(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		repository string
+		tag        string
+		body       string
+		wantErr    string
+	}{
+		{name: "final", repository: "example/workcell", tag: "v1.2.3", body: releaseStateJSON(t, "example/workcell", "v1.2.3", true, false, false, 1)},
+		{name: "release candidate", repository: "example/workcell", tag: "v1.2.3-rc.4", body: releaseStateJSON(t, "example/workcell", "v1.2.3-rc.4", true, true, false, 0)},
+		{name: "wrong tag", repository: "example/workcell", tag: "v1.2.3", body: releaseStateJSON(t, "example/workcell", "v1.2.4", true, false, false, 0), wantErr: `tag_name = "v1.2.4"`},
+		{name: "published", repository: "example/workcell", tag: "v1.2.3", body: releaseStateJSON(t, "example/workcell", "v1.2.3", false, false, false, 0), wantErr: "draft = false"},
+		{name: "wrong class", repository: "example/workcell", tag: "v1.2.3", body: releaseStateJSON(t, "example/workcell", "v1.2.3", true, true, false, 0), wantErr: "prerelease = true"},
+		{name: "immutable", repository: "example/workcell", tag: "v1.2.3", body: releaseStateJSON(t, "example/workcell", "v1.2.3", true, false, true, 0), wantErr: "immutable = true"},
+		{name: "wrong repository", repository: "example/workcell", tag: "v1.2.3", body: releaseStateJSON(t, "other/workcell", "v1.2.3", true, false, false, 0), wantErr: "upload_url"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateGitHubDraftRelease(tc.repository, tc.tag, writeReleaseStateFixture(t, tc.body))
+			assertReleaseStateResult(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestValidateGitHubPublishedReleaseState(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		repository string
+		tag        string
+		body       string
+		wantErr    string
+	}{
+		{name: "final", repository: "example/workcell", tag: "v1.2.3", body: releaseStateJSON(t, "example/workcell", "v1.2.3", false, false, true, 1)},
+		{name: "release candidate", repository: "example/workcell", tag: "v1.2.3-rc.4", body: releaseStateJSON(t, "example/workcell", "v1.2.3-rc.4", false, true, true, 0)},
+		{name: "mutable", repository: "example/workcell", tag: "v1.2.3", body: releaseStateJSON(t, "example/workcell", "v1.2.3", false, false, false, 0), wantErr: "immutable = false"},
+		{name: "draft", repository: "example/workcell", tag: "v1.2.3", body: releaseStateJSON(t, "example/workcell", "v1.2.3", true, false, true, 0), wantErr: "draft = true"},
+		{name: "wrong class", repository: "example/workcell", tag: "v1.2.3", body: releaseStateJSON(t, "example/workcell", "v1.2.3", false, true, true, 0), wantErr: "prerelease = true"},
+		{name: "wrong repository", repository: "example/workcell", tag: "v1.2.3", body: releaseStateJSON(t, "other/workcell", "v1.2.3", false, false, true, 0), wantErr: "upload_url"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateGitHubPublishedReleaseState(tc.repository, tc.tag, writeReleaseStateFixture(t, tc.body))
+			assertReleaseStateResult(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestValidateGitHubLatestReleaseResponse(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		repository string
+		tag        string
+		status     string
+		body       string
+		wantErr    string
+	}{
+		{name: "final points to itself", repository: "example/workcell", tag: "v1.2.3", status: "200", body: releaseStateJSON(t, "example/workcell", "v1.2.3", false, false, true, 0)},
+		{name: "release candidate leaves final latest", repository: "example/workcell", tag: "v1.2.3-rc.4", status: "200", body: releaseStateJSON(t, "example/workcell", "v1.2.2", false, false, true, 0)},
+		{name: "release candidate with no final", repository: "example/workcell", tag: "v1.2.3-rc.4", status: "404", body: `{}`},
+		{name: "final is not latest", repository: "example/workcell", tag: "v1.2.3", status: "200", body: releaseStateJSON(t, "example/workcell", "v1.2.2", false, false, true, 0), wantErr: "want final tag"},
+		{name: "final latest is missing", repository: "example/workcell", tag: "v1.2.3", status: "404", body: `{}`, wantErr: "want 200"},
+		{name: "release candidate lookup fails", repository: "example/workcell", tag: "v1.2.3-rc.4", status: "500", body: `{}`, wantErr: "want 200 or 404"},
+		{name: "release candidate became latest", repository: "example/workcell", tag: "v1.2.3-rc.4", status: "200", body: releaseStateJSON(t, "example/workcell", "v1.2.3-rc.4", false, true, true, 0), wantErr: "want a final release tag"},
+		{name: "another release candidate is latest", repository: "example/workcell", tag: "v1.2.3-rc.4", status: "200", body: releaseStateJSON(t, "example/workcell", "v1.2.2-rc.9", false, true, true, 0), wantErr: "want a final release tag"},
+		{name: "wrong repository", repository: "example/workcell", tag: "v1.2.3", status: "200", body: releaseStateJSON(t, "other/workcell", "v1.2.3", false, false, true, 0), wantErr: "upload_url"},
+		{name: "latest is mutable", repository: "example/workcell", tag: "v1.2.3", status: "200", body: releaseStateJSON(t, "example/workcell", "v1.2.3", false, false, false, 0), wantErr: "immutable = false"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateGitHubLatestReleaseResponse(tc.repository, tc.tag, tc.status, writeReleaseStateFixture(t, tc.body))
+			assertReleaseStateResult(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestReleaseStateValidatorsRejectInvalidInputsBeforeFileReads(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "missing.json")
+	for name, err := range map[string]error{
+		"draft repository":  ValidateGitHubDraftRelease("../repo", "v1.2.3", missing),
+		"draft tag":         ValidateGitHubDraftRelease("example/workcell", "v1.2.3-beta.1", missing),
+		"published repo":    ValidateGitHubPublishedReleaseState("../repo", "v1.2.3", missing),
+		"published tag":     ValidateGitHubPublishedReleaseState("example/workcell", "v1.2.3-beta.1", missing),
+		"latest repository": ValidateGitHubLatestReleaseResponse("../repo", "v1.2.3", "200", missing),
+		"latest tag":        ValidateGitHubLatestReleaseResponse("example/workcell", "v1.2.3-beta.1", "200", missing),
+		"listed exact tag":  WriteGitHubListedRelease("v1.2.3-beta.1", []string{missing}, filepath.Join(t.TempDir(), "out")),
+		"no list pages":     WriteGitHubListedRelease("v1.2.3", nil, filepath.Join(t.TempDir(), "out")),
+		"repository export": ValidateGitHubRepository("../repo"),
+	} {
+		if !errors.Is(err, ErrInvalidInput) {
+			t.Errorf("%s error = %v, want ErrInvalidInput", name, err)
+		}
+	}
+}
+
+func releaseStateJSON(t *testing.T, repository, tag string, draft, prerelease, immutable bool, assetCount int) string {
+	t.Helper()
+	assets := make([]json.RawMessage, 0, assetCount)
+	for index := 0; index < assetCount; index++ {
+		assets = append(assets, json.RawMessage(fmt.Sprintf(`{"opaque_asset_index":%d}`, index)))
+	}
+	id := int64(1)
+	uploadURL := "https://uploads.github.com/repos/" + repository + "/releases/1/assets{?name,label}"
+	item := listedRelease{
+		ID:         &id,
+		UploadURL:  &uploadURL,
+		TagName:    &tag,
+		Draft:      &draft,
+		Prerelease: &prerelease,
+		Immutable:  &immutable,
+		Assets:     &assets,
+	}
+	data, err := json.Marshal(item)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func writeReleaseStateFixture(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "response.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeReleaseStatePage(t *testing.T, path string, items ...string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("["+strings.Join(items, ",")+"]"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertReleaseStateResult(t *testing.T, err error, wantErr string) {
+	t.Helper()
+	if wantErr == "" {
+		if err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	if err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("error = %v, want substring %q", err, wantErr)
+	}
+}


### PR DESCRIPTION
## Summary

- add fail-closed GitHub release list, draft, published, and latest-state validators
- bind release metadata to the expected OWNER/REPO and exact supported tag class
- expose tested hostutil commands for the release publisher workflow

## Scope boundary

This unit validates release metadata only. It does not authorize asset bytes, names, sizes, digests, symlinks, or staged paths. A secure staged-content publisher remains mandatory before v1.0.0 publication.

## Integration dependency

PR #532 is a hard dependency. After it merges, this branch must be rebased and the shared cmd/workcell-hostutil/main.go command surface must preserve both the canonical tag-policy commands and these state validators, followed by full revalidation and review.

## Evidence

- verified signed commit b3b9b21c63142ea633e69c550cccf206bbe6e479
- exact clean pr-parity passed for HEAD and current main, including host invariants, docs, and container smoke
- go test -race ./internal/host/release ./cmd/workcell-hostutil
- go test ./...
- go vet ./...
- live positive validation against immutable v0.11.2 release metadata
- live negative validation rejected historically misclassified immutable v1.0.0-rc.2 metadata
- three-lens peer review loop clean after fixes