### PR TITLE
Make detached attach readiness deterministic

### DIFF
--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -270,6 +270,7 @@ UNMANAGED_PROFILE_NAME=""
 DETACHED_SESSION_ID=""
 DETACHED_SESSION_WORKSPACE=""
 DETACHED_SESSION_SOURCE_SENTINEL_PATH=""
+DETACHED_ATTACH_PID=""
 VERIFY_INVARIANTS_CLEANUP_ACTIVE=0
 ROOT_STRICT_SUPPORT_OUTPUT="$(
   go_verify_hostutil helper support-matrix-eval \
@@ -494,6 +495,25 @@ verify_profile_target_state_dir() {
   printf '%s/.local/state/workcell/targets/local_vm/colima/%s\n' "${REAL_HOME}" "${profile_name}"
 }
 
+terminate_verify_process_tree_by_pid() {
+  local target_pid="$1"
+  local child_pid=""
+
+  [[ -n "${target_pid}" ]] || return 0
+  while IFS= read -r child_pid; do
+    [[ -n "${child_pid}" ]] || continue
+    terminate_verify_process_tree_by_pid "${child_pid}"
+  done < <(pgrep -P "${target_pid}" 2>/dev/null || true)
+  kill "${target_pid}" >/dev/null 2>&1 || true
+}
+
+cleanup_detached_attach_probe() {
+  [[ -n "${DETACHED_ATTACH_PID}" ]] || return 0
+  terminate_verify_process_tree_by_pid "${DETACHED_ATTACH_PID}"
+  wait "${DETACHED_ATTACH_PID}" >/dev/null 2>&1 || true
+  DETACHED_ATTACH_PID=""
+}
+
 cleanup_detached_session_runtime() {
   local session_parent=""
 
@@ -613,6 +633,7 @@ cleanup() {
   trap - EXIT ERR
   set +e
 
+  cleanup_detached_attach_probe
   cleanup_detached_session_runtime
   delete_verify_colima_profile "${LIVE_DEBUG_PROFILE_NAME:-}"
   delete_verify_colima_profile "${LIVE_DETACHED_PROFILE_NAME:-}"
@@ -7208,6 +7229,7 @@ if [[ "$(uname -s)" == "Darwin" ]] &&
     DETACHED_SESSION_START_OUT="${BARRIER_VERIFY_ROOT}/debug/live-detached-session.start.out"
     DETACHED_SESSION_SHOW_RUNNING_OUT="${BARRIER_VERIFY_ROOT}/debug/live-detached-session.show-running.out"
     DETACHED_SESSION_ATTACH_TYPESCRIPT="${BARRIER_VERIFY_ROOT}/debug/live-detached-session.attach.typescript"
+    DETACHED_SESSION_ATTACH_READY_SEND_OUT="${BARRIER_VERIFY_ROOT}/debug/live-detached-session.send-attach-ready.out"
     DETACHED_SESSION_SEND_ALPHA_OUT="${BARRIER_VERIFY_ROOT}/debug/live-detached-session.send-alpha.out"
     DETACHED_SESSION_SEND_BETA_OUT="${BARRIER_VERIFY_ROOT}/debug/live-detached-session.send-beta.out"
     DETACHED_SESSION_DIFF_OUT="${BARRIER_VERIFY_ROOT}/debug/live-detached-session.diff.out"
@@ -7358,9 +7380,14 @@ EOF
     grep -q '^SESSION_READY$' "${DETACHED_SESSION_SENTINEL_PATH}"
     grep -q '^SESSION_MASKS_OK$' "${DETACHED_SESSION_SENTINEL_PATH}"
     DETACHED_ATTACH_STATUS=0
+    DETACHED_ATTACH_READY=0
+    DETACHED_ATTACH_READY_MESSAGE="attach-ready"
+    DETACHED_ATTACH_READY_SEND_COUNT=0
+    DETACHED_ATTACH_EARLY_STATUS=""
+    DETACHED_ATTACH_MESSAGES_RECEIVED=0
     (
       VERIFY_INVARIANTS_EXPECTED_FAILURE=1
-      run_typescript_probe_with_timeout 10 \
+      run_typescript_probe_with_timeout 30 \
         "${DETACHED_SESSION_ATTACH_TYPESCRIPT}" \
         "${ROOT_DIR}/scripts/workcell" \
         session attach \
@@ -7368,7 +7395,43 @@ EOF
         --no-stdin
     ) &
     DETACHED_ATTACH_PID=$!
-    sleep 1
+    for ((ready_send_attempt = 0; ready_send_attempt < 5; ready_send_attempt++)); do
+      if ! run_workcell_verify session send \
+        --id "${DETACHED_SESSION_ID}" \
+        --message "${DETACHED_ATTACH_READY_MESSAGE}" >"${DETACHED_SESSION_ATTACH_READY_SEND_OUT}" 2>&1; then
+        echo "Expected detached session attach-readiness send to succeed" >&2
+        cat "${DETACHED_SESSION_ATTACH_READY_SEND_OUT}" >&2
+        exit 1
+      fi
+      DETACHED_ATTACH_READY_SEND_COUNT=$((DETACHED_ATTACH_READY_SEND_COUNT + 1))
+      for ((ready_poll_attempt = 0; ready_poll_attempt < 3; ready_poll_attempt++)); do
+        if grep -Fq "SESSION_RECV:${DETACHED_ATTACH_READY_MESSAGE}" "${DETACHED_SESSION_ATTACH_TYPESCRIPT}" 2>/dev/null; then
+          DETACHED_ATTACH_READY=1
+          break 2
+        fi
+        if ! kill -0 "${DETACHED_ATTACH_PID}" >/dev/null 2>&1; then
+          if wait "${DETACHED_ATTACH_PID}"; then
+            DETACHED_ATTACH_EARLY_STATUS=0
+          else
+            DETACHED_ATTACH_EARLY_STATUS=$?
+          fi
+          DETACHED_ATTACH_PID=""
+          break 2
+        fi
+        if ((ready_poll_attempt < 2)); then
+          sleep 1
+        fi
+      done
+    done
+    if [[ "${DETACHED_ATTACH_READY}" != "1" ]]; then
+      echo "Detached session attach did not become ready before live send assertions" >&2
+      if [[ -n "${DETACHED_ATTACH_EARLY_STATUS}" ]]; then
+        echo "Detached session attach exited early with status ${DETACHED_ATTACH_EARLY_STATUS}" >&2
+      fi
+      cat "${DETACHED_SESSION_ATTACH_TYPESCRIPT}" >&2 || true
+      cat "${DETACHED_SESSION_ATTACH_READY_SEND_OUT}" >&2 || true
+      exit 1
+    fi
     if ! run_workcell_verify session send --id "${DETACHED_SESSION_ID}" --message alpha >"${DETACHED_SESSION_SEND_ALPHA_OUT}" 2>&1; then
       echo "Expected detached session send(alpha) to succeed" >&2
       cat "${DETACHED_SESSION_SEND_ALPHA_OUT}" >&2
@@ -7382,13 +7445,42 @@ EOF
     grep -q "^session_id=${DETACHED_SESSION_ID}$" "${DETACHED_SESSION_SEND_ALPHA_OUT}"
     grep -q '^sent_bytes=6$' "${DETACHED_SESSION_SEND_ALPHA_OUT}"
     grep -q '^sent_bytes=5$' "${DETACHED_SESSION_SEND_BETA_OUT}"
+    for ((message_poll_attempt = 0; message_poll_attempt < 10; message_poll_attempt++)); do
+      if grep -Fq 'SESSION_RECV:alpha' "${DETACHED_SESSION_ATTACH_TYPESCRIPT}" 2>/dev/null &&
+        grep -Fq 'SESSION_RECV:beta' "${DETACHED_SESSION_ATTACH_TYPESCRIPT}" 2>/dev/null; then
+        DETACHED_ATTACH_MESSAGES_RECEIVED=1
+        break
+      fi
+      if ! kill -0 "${DETACHED_ATTACH_PID}" >/dev/null 2>&1; then
+        if wait "${DETACHED_ATTACH_PID}"; then
+          DETACHED_ATTACH_EARLY_STATUS=0
+        else
+          DETACHED_ATTACH_EARLY_STATUS=$?
+        fi
+        DETACHED_ATTACH_PID=""
+        break
+      fi
+      if ((message_poll_attempt < 9)); then
+        sleep 1
+      fi
+    done
+    if [[ "${DETACHED_ATTACH_MESSAGES_RECEIVED}" != "1" ]]; then
+      echo "Detached session attach did not stream the live send assertions" >&2
+      if [[ -n "${DETACHED_ATTACH_EARLY_STATUS}" ]]; then
+        echo "Detached session attach exited early with status ${DETACHED_ATTACH_EARLY_STATUS}" >&2
+      fi
+      cat "${DETACHED_SESSION_ATTACH_TYPESCRIPT}" >&2 || true
+      exit 1
+    fi
     if wait "${DETACHED_ATTACH_PID}"; then
       DETACHED_ATTACH_STATUS=0
     else
       DETACHED_ATTACH_STATUS=$?
     fi
+    DETACHED_ATTACH_PID=""
     if [[ "${DETACHED_ATTACH_STATUS}" != "0" ]] && [[ "${DETACHED_ATTACH_STATUS}" != "124" ]]; then
       echo "Expected detached session attach to stream live output or timeout cleanly" >&2
+      echo "Detached session attach exited with status ${DETACHED_ATTACH_STATUS}" >&2
       cat "${DETACHED_SESSION_ATTACH_TYPESCRIPT}" >&2 || true
       exit 1
     fi
@@ -7462,7 +7554,7 @@ EOF
     fi
     grep -q "event=launch session_id=${DETACHED_SESSION_ID}" "${DETACHED_SESSION_TIMELINE_OUT}"
     grep -q "event=attach-attempt session_id=${DETACHED_SESSION_ID}" "${DETACHED_SESSION_TIMELINE_OUT}"
-    test "$(grep -c "event=command session_id=${DETACHED_SESSION_ID}" "${DETACHED_SESSION_TIMELINE_OUT}")" = "2"
+    test "$(grep -c "event=command session_id=${DETACHED_SESSION_ID}" "${DETACHED_SESSION_TIMELINE_OUT}")" = "$((DETACHED_ATTACH_READY_SEND_COUNT + 2))"
     grep -q "event=stop-request session_id=${DETACHED_SESSION_ID}" "${DETACHED_SESSION_TIMELINE_OUT}"
     grep -q "event=exit session_id=${DETACHED_SESSION_ID}" "${DETACHED_SESSION_TIMELINE_OUT}"
     if ! run_workcell_verify session logs --id "${DETACHED_SESSION_ID}" --kind audit >"${DETACHED_SESSION_LOGS_AUDIT_OUT}" 2>&1; then


### PR DESCRIPTION
## Summary

- replace the detached-session invariant's fixed attach delay with a transcript-proven readiness barrier
- wait for the live `alpha` and `beta` messages before evaluating the attach process
- account for readiness sends in the audit timeline and reap the attach process tree on every exit path

## Validation

- `./scripts/verify-invariants.sh`
- `./scripts/dev-quick-check.sh`
- `./scripts/validate-repo.sh`
- `./scripts/pre-merge.sh --profile pr-parity`
- `bash -n scripts/verify-invariants.sh`
- `shellcheck -e SC1091 scripts/verify-invariants.sh`
- `shfmt -ln=bash -i 2 -ci -d scripts/verify-invariants.sh`
- three peer-review lenses, all clean after fixes and re-review

## Contract and scope

- test/certification harness only; no public operator-contract change
- PR shape: 1 file, 98 lines, 1 area, 0 binaries
