### PR TITLE
^B Verify validator workspace binds before certification

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -14,19 +14,23 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/gitconfigblocklist"
 	"github.com/omkhar/workcell/internal/hardeningprofile"
+	"github.com/omkhar/workcell/internal/host/validatorbind"
 	"github.com/omkhar/workcell/internal/metadatautil"
 	"github.com/omkhar/workcell/internal/mutation"
 	"github.com/omkhar/workcell/internal/paritytree"
@@ -88,6 +92,8 @@ func subcommands() []subcommand {
 		{"generate-reproducible-build-manifest", "OCI_EXPORT REPRO_PLATFORMS OUTPUT_PATH SOURCE_DATE_EPOCH", 4, 4, cmdGenerateReproducibleBuildManifest},
 		{"verify-reproducible-build-manifest", "OCI_EXPORT REPRO_PLATFORMS MANIFEST_PATH", 3, 3, cmdVerifyReproducibleBuildManifest},
 		{"canonicalize-path", "PATH", 1, 1, cmdCanonicalizePath},
+		{"validate-docker-workspace-bind", "DOCKER_BIN IMAGE WORKSPACE CONTEXT CONTEXT_EXPLICIT", 5, 5, cmdValidateDockerWorkspaceBind},
+		{"docker-workspace-bind-mount", "WORKSPACE READONLY", 2, 2, cmdDockerWorkspaceBindMount},
 		{"coverage-percent", "REPORT_PATH MINIMUM LABEL", 3, 3, cmdCoveragePercent},
 		{"coverage-executables", "MESSAGE_PATH", 1, 1, cmdCoverageExecutables},
 		{"validate-json", "FILE [FILE...]", 1, -1, cmdValidateJSON},
@@ -453,6 +459,35 @@ func cmdGenerateReproducibleBuildManifest(args []string) error {
 
 func cmdVerifyReproducibleBuildManifest(args []string) error {
 	return metadatautil.VerifyReproducibleBuildManifest(args[0], args[1], args[2])
+}
+
+func cmdValidateDockerWorkspaceBind(args []string) error {
+	contextExplicit, err := strconv.ParseBool(args[4])
+	if err != nil {
+		return fmt.Errorf("CONTEXT_EXPLICIT must be true or false")
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return validatorbind.Require(ctx, validatorbind.Options{
+		DockerBinary:    args[0],
+		Image:           args[1],
+		Workspace:       args[2],
+		Context:         args[3],
+		ContextExplicit: contextExplicit,
+	})
+}
+
+func cmdDockerWorkspaceBindMount(args []string) error {
+	readOnly, err := strconv.ParseBool(args[1])
+	if err != nil {
+		return fmt.Errorf("READONLY must be true or false")
+	}
+	mount, err := validatorbind.MountSpec(args[0], readOnly)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, mount)
+	return nil
 }
 
 func cmdCanonicalizePath(args []string) error {

--- a/internal/host/validatorbind/validatorbind.go
+++ b/internal/host/validatorbind/validatorbind.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package validatorbind proves that a selected Docker daemon sees the exact
+// checkout a validator-backed lane intends to mount.
+package validatorbind
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/csv"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const probeScript = `
+set -euo pipefail
+test -f /workspace/go.mod
+test -x /workspace/scripts/validate-repo.sh
+test "$(cat "/workspace/${WORKCELL_VALIDATOR_BIND_CHALLENGE_NAME}")" = "${WORKCELL_VALIDATOR_BIND_CHALLENGE_VALUE}"
+`
+
+// Options describes one validator workspace visibility proof.
+type Options struct {
+	DockerBinary    string
+	Image           string
+	Workspace       string
+	Context         string
+	ContextExplicit bool
+}
+
+type commandFunc func(context.Context, string, string, []string) error
+
+// Require proves that the selected Docker daemon sees the exact canonical
+// workspace and its per-invocation challenge.
+func Require(ctx context.Context, options Options) error {
+	return require(ctx, options, runCommand)
+}
+
+func require(ctx context.Context, options Options, command commandFunc) (result error) {
+	if !filepath.IsAbs(options.DockerBinary) {
+		return fmt.Errorf("validator Docker binary must be an absolute path")
+	}
+	if options.Image == "" {
+		return fmt.Errorf("validator image is required")
+	}
+	workspace, err := canonicalWorkspace(options.Workspace)
+	if err != nil {
+		return err
+	}
+
+	challenge, err := os.CreateTemp(workspace, ".workcell-validator-bind.")
+	if err != nil {
+		return fmt.Errorf("cannot create the validator workspace bind challenge: %s: %w", workspace, err)
+	}
+	challengePath := challenge.Name()
+	defer func() {
+		if err := os.Remove(challengePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			result = errors.Join(result, fmt.Errorf("remove validator workspace bind challenge: %w", err))
+		}
+	}()
+
+	value, err := randomValue()
+	if err == nil {
+		_, err = fmt.Fprintln(challenge, value)
+	}
+	if closeErr := challenge.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return fmt.Errorf("write validator workspace bind challenge: %w", err)
+	}
+	// The challenge is a random non-secret freshness token. It must be readable
+	// when a rootless or userns-remapped daemon changes bind-mount ownership.
+	if err := os.Chmod(challengePath, 0o644); err != nil {
+		return fmt.Errorf("make validator workspace bind challenge readable: %w", err)
+	}
+	mount, err := MountSpec(workspace, true)
+	if err != nil {
+		return err
+	}
+
+	args := make([]string, 0, 22)
+	if options.Context != "" {
+		args = append(args, "--context", options.Context)
+	}
+	args = append(args,
+		"run", "--rm",
+		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
+		"--entrypoint", "/bin/bash",
+		"--mount", mount,
+		"-e", "WORKCELL_VALIDATOR_BIND_CHALLENGE_NAME="+filepath.Base(challengePath),
+		"-e", "WORKCELL_VALIDATOR_BIND_CHALLENGE_VALUE="+value,
+		options.Image,
+		"-c", probeScript,
+	)
+	if err := command(ctx, workspace, options.DockerBinary, args); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		contextLabel := options.Context
+		if contextLabel == "" {
+			contextLabel = "default"
+		}
+		message := fmt.Sprintf(
+			"Validator workspace is not visible through Docker context %s: %s",
+			contextLabel,
+			workspace,
+		)
+		if options.ContextExplicit {
+			message += fmt.Sprintf(
+				"\nConfigured WORKCELL_DOCKER_CONTEXT=%s cannot bind this checkout; choose a context that can.",
+				options.Context,
+			)
+		} else {
+			message += "\nSelect a Docker context whose daemon can bind this checkout, or set WORKCELL_DOCKER_CONTEXT explicitly."
+		}
+		return fmt.Errorf("%s", message)
+	}
+	return nil
+}
+
+// MountSpec returns a Docker --mount CSV record for the workspace bind.
+func MountSpec(workspace string, readOnly bool) (string, error) {
+	if !filepath.IsAbs(workspace) {
+		return "", fmt.Errorf("validator workspace must be an absolute path")
+	}
+	fields := []string{"type=bind", "src=" + workspace, "dst=/workspace"}
+	if readOnly {
+		fields = append(fields, "readonly")
+	}
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+	if err := writer.Write(fields); err != nil {
+		return "", fmt.Errorf("encode validator workspace mount: %w", err)
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return "", fmt.Errorf("encode validator workspace mount: %w", err)
+	}
+	return strings.TrimSuffix(buffer.String(), "\n"), nil
+}
+
+func canonicalWorkspace(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve validator workspace: %w", err)
+	}
+	workspace, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("Validator workspace does not exist: %s", path)
+	}
+	info, err := os.Stat(workspace)
+	if err != nil || !info.IsDir() {
+		return "", fmt.Errorf("Validator workspace does not exist: %s", path)
+	}
+	goMod, goModErr := os.Stat(filepath.Join(workspace, "go.mod"))
+	validator, validatorErr := os.Stat(filepath.Join(workspace, "scripts", "validate-repo.sh"))
+	if goModErr != nil || !goMod.Mode().IsRegular() ||
+		validatorErr != nil || !validator.Mode().IsRegular() || validator.Mode().Perm()&0o111 == 0 {
+		return "", fmt.Errorf("Validator workspace is missing required validation inputs: %s", workspace)
+	}
+	return workspace, nil
+}
+
+func randomValue() (string, error) {
+	value := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, value); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value), nil
+}
+
+func runCommand(ctx context.Context, dir, binary string, args []string) error {
+	command := exec.CommandContext(ctx, binary, args...)
+	command.Dir = dir
+	command.Stdout = io.Discard
+	command.Stderr = io.Discard
+	return command.Run()
+}

--- a/internal/host/validatorbind/validatorbind_test.go
+++ b/internal/host/validatorbind/validatorbind_test.go
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package validatorbind
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestRequireProvesExactWorkspaceAndCleansChallenge(t *testing.T) {
+	t.Parallel()
+	workspace := createWorkspace(t, "workspace,with-comma")
+	canonical, err := filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	docker := executableFixture(t, "docker")
+	var captured []string
+
+	err = require(context.Background(), Options{
+		DockerBinary:    docker,
+		Image:           "validator:fixture",
+		Workspace:       workspace,
+		Context:         "fixture-context",
+		ContextExplicit: true,
+	}, func(_ context.Context, dir, binary string, args []string) error {
+		if dir != canonical {
+			t.Fatalf("command dir = %q, want %q", dir, canonical)
+		}
+		if binary != docker {
+			t.Fatalf("Docker binary = %q, want %q", binary, docker)
+		}
+		captured = append([]string(nil), args...)
+		name := argumentValue(t, args, "WORKCELL_VALIDATOR_BIND_CHALLENGE_NAME=")
+		value := argumentValue(t, args, "WORKCELL_VALIDATOR_BIND_CHALLENGE_VALUE=")
+		if len(value) != 64 {
+			t.Fatalf("challenge value length = %d, want 64", len(value))
+		}
+		challenge := filepath.Join(canonical, name)
+		info, err := os.Stat(challenge)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o644 {
+			t.Fatalf("challenge mode = %o, want 644", info.Mode().Perm())
+		}
+		data, err := os.ReadFile(challenge)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != value+"\n" {
+			t.Fatalf("challenge content = %q, want %q", data, value+"\\n")
+		}
+		return runProbe(context.Background(), args, canonical)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mount, err := MountSpec(canonical, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"--context", "fixture-context",
+		"--mount", mount,
+		"validator:fixture",
+	} {
+		if !slices.Contains(captured, want) {
+			t.Fatalf("Docker args missing %q: %q", want, captured)
+		}
+	}
+	if slices.Contains(captured, "--volume") {
+		t.Fatalf("Docker args use source-creating --volume syntax: %q", captured)
+	}
+	assertNoChallenges(t, canonical)
+}
+
+func TestMountSpecCSVEncodesWorkspaceAndReadonlyMode(t *testing.T) {
+	t.Parallel()
+	workspace := `/tmp/workspace,with"quote`
+	readOnly, err := MountSpec(workspace, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `type=bind,"src=/tmp/workspace,with""quote",dst=/workspace,readonly`; readOnly != want {
+		t.Fatalf("readonly mount = %q, want %q", readOnly, want)
+	}
+	readWrite, err := MountSpec(workspace, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `type=bind,"src=/tmp/workspace,with""quote",dst=/workspace`; readWrite != want {
+		t.Fatalf("read-write mount = %q, want %q", readWrite, want)
+	}
+	if _, err := MountSpec("relative", false); err == nil {
+		t.Fatal("relative workspace mount accepted")
+	}
+}
+
+func TestRequireRejectsStaleWorkspaceAndCleansChallenge(t *testing.T) {
+	t.Parallel()
+	workspace := createWorkspace(t, "workspace")
+	staleWorkspace := createWorkspace(t, "stale-workspace")
+	docker := executableFixture(t, "docker")
+
+	err := require(context.Background(), Options{
+		DockerBinary: docker,
+		Image:        "validator:fixture",
+		Workspace:    workspace,
+		Context:      "fixture-context",
+	}, func(ctx context.Context, _ string, _ string, args []string) error {
+		return runProbe(ctx, args, staleWorkspace)
+	})
+	if err == nil || !strings.Contains(err.Error(), "Validator workspace is not visible") {
+		t.Fatalf("stale workspace error = %v", err)
+	}
+	assertNoChallenges(t, workspace)
+}
+
+func TestRequireCancellationCleansChallenge(t *testing.T) {
+	t.Parallel()
+	workspace := createWorkspace(t, "workspace")
+	docker := executableFixture(t, "docker")
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	result := make(chan error, 1)
+
+	go func() {
+		result <- require(ctx, Options{
+			DockerBinary: docker,
+			Image:        "validator:fixture",
+			Workspace:    workspace,
+		}, func(ctx context.Context, _ string, _ string, _ []string) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+	<-started
+	cancel()
+	if err := <-result; !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled workspace proof error = %v, want context.Canceled", err)
+	}
+	assertNoChallenges(t, workspace)
+}
+
+func TestRequireFailsClosedAndCleansChallenge(t *testing.T) {
+	t.Parallel()
+	workspace := createWorkspace(t, "workspace")
+	docker := executableFixture(t, "docker")
+	for _, tc := range []struct {
+		name     string
+		explicit bool
+		want     string
+	}{
+		{
+			name:     "explicit context",
+			explicit: true,
+			want:     "Configured WORKCELL_DOCKER_CONTEXT=fixture-context cannot bind this checkout",
+		},
+		{
+			name: "selected context",
+			want: "Select a Docker context whose daemon can bind this checkout",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := require(context.Background(), Options{
+				DockerBinary:    docker,
+				Image:           "validator:fixture",
+				Workspace:       workspace,
+				Context:         "fixture-context",
+				ContextExplicit: tc.explicit,
+			}, func(context.Context, string, string, []string) error {
+				return errors.New("daemon rejected bind")
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+			assertNoChallenges(t, workspace)
+		})
+	}
+}
+
+func TestRequireRejectsInvalidInputsBeforeDocker(t *testing.T) {
+	t.Parallel()
+	workspace := createWorkspace(t, "workspace")
+	docker := executableFixture(t, "docker")
+	for _, tc := range []struct {
+		name    string
+		options Options
+		want    string
+	}{
+		{
+			name:    "relative Docker binary",
+			options: Options{DockerBinary: "docker", Image: "validator:fixture", Workspace: workspace},
+			want:    "Docker binary must be an absolute path",
+		},
+		{
+			name:    "missing image",
+			options: Options{DockerBinary: docker, Workspace: workspace},
+			want:    "validator image is required",
+		},
+		{
+			name:    "missing workspace",
+			options: Options{DockerBinary: docker, Image: "validator:fixture", Workspace: filepath.Join(t.TempDir(), "missing")},
+			want:    "Validator workspace does not exist",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			err := require(context.Background(), tc.options, func(context.Context, string, string, []string) error {
+				called = true
+				return nil
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+			if called {
+				t.Fatal("Docker command ran after invalid input")
+			}
+		})
+	}
+}
+
+func createWorkspace(t *testing.T, name string) string {
+	t.Helper()
+	workspace := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(workspace, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "go.mod"), []byte("module example.com/workcell\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(workspace, "scripts", "validate-repo.sh"),
+		[]byte("#!/bin/bash\nexit 0\n"),
+		0o755,
+	); err != nil {
+		t.Fatal(err)
+	}
+	return workspace
+}
+
+func executableFixture(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func argumentValue(t *testing.T, args []string, prefix string) string {
+	t.Helper()
+	for _, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
+			return strings.TrimPrefix(arg, prefix)
+		}
+	}
+	t.Fatalf("Docker args missing %q: %q", prefix, args)
+	return ""
+}
+
+func runProbe(ctx context.Context, args []string, mountedWorkspace string) error {
+	var script string
+	for i := range args {
+		if args[i] == "-c" && i+1 < len(args) {
+			script = args[i+1]
+			break
+		}
+	}
+	if script == "" {
+		return errors.New("Docker args omit probe script")
+	}
+	script = strings.ReplaceAll(script, "/workspace", "${WORKCELL_TEST_MOUNT}")
+	command := exec.CommandContext(ctx, "/bin/bash", "-c", script)
+	command.Env = append(
+		os.Environ(),
+		"WORKCELL_TEST_MOUNT="+mountedWorkspace,
+		"WORKCELL_VALIDATOR_BIND_CHALLENGE_NAME="+argumentValueFromArgs(args, "WORKCELL_VALIDATOR_BIND_CHALLENGE_NAME="),
+		"WORKCELL_VALIDATOR_BIND_CHALLENGE_VALUE="+argumentValueFromArgs(args, "WORKCELL_VALIDATOR_BIND_CHALLENGE_VALUE="),
+	)
+	return command.Run()
+}
+
+func argumentValueFromArgs(args []string, prefix string) string {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
+			return strings.TrimPrefix(arg, prefix)
+		}
+	}
+	return ""
+}
+
+func assertNoChallenges(t *testing.T, workspace string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(workspace, ".workcell-validator-bind.*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("validator bind challenge residue remains: %v", matches)
+	}
+}

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidatorRunnersRequireWorkspaceMountPreflight(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	for _, tc := range []struct {
+		rel       string
+		workspace string
+	}{
+		{rel: "scripts/ci/job-validate.sh", workspace: "ROOT_DIR"},
+		{rel: "scripts/ci/run-docs-in-validator.sh", workspace: "WORKSPACE"},
+		{rel: "scripts/ci/run-fuzz-in-validator.sh", workspace: "WORKSPACE"},
+		{rel: "scripts/ci/run-mutation-in-validator.sh", workspace: "WORKSPACE"},
+		{rel: "scripts/ci/run-validate-in-validator.sh", workspace: "WORKSPACE"},
+	} {
+		tc := tc
+		t.Run(tc.rel, func(t *testing.T) {
+			t.Parallel()
+
+			content, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(tc.rel)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			call := `require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${` + tc.workspace + `}"`
+			if strings.Count(string(content), call) != 1 {
+				t.Fatalf("%s must invoke the shared workspace mount preflight exactly once", tc.rel)
+			}
+			setup := strings.Index(string(content), "setup_workcell_ci_docker")
+			preflight := strings.Index(string(content), call)
+			workload := strings.Index(string(content)[preflight+len(call):], "workcell_ci_docker run --rm")
+			if setup < 0 || preflight < setup || workload < 0 {
+				t.Fatalf("%s must order Docker setup, workspace preflight, then validator workload", tc.rel)
+			}
+			mount := `--mount "type=bind,src=${` + tc.workspace + `},dst=/workspace"`
+			if !strings.Contains(string(content)[preflight+len(call):], mount) {
+				t.Fatalf("%s must use the same canonical bind mechanism for its validator workload", tc.rel)
+			}
+			if tc.workspace == "ROOT_DIR" &&
+				!strings.Contains(string(content), `ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"`) {
+				t.Fatalf("%s must canonicalize ROOT_DIR before both preflight and workload binds", tc.rel)
+			}
+		})
+	}
+}
+
+func TestRequireWorkcellCIWorkspaceMount(t *testing.T) {
+	t.Parallel()
+
+	workspace := createValidatorWorkspaceFixture(t)
+	staleWorkspace := createValidatorWorkspaceFixture(t)
+	visibleMount := filepath.Join(t.TempDir(), "visible")
+	staleMount := filepath.Join(t.TempDir(), "stale")
+	if err := os.Symlink(workspace, visibleMount); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(staleWorkspace, staleMount); err != nil {
+		t.Fatal(err)
+	}
+	helper := filepath.Join(repoRoot(t), "scripts", "ci", "lib", "local-docker-parity.sh")
+	probe := filepath.Join(t.TempDir(), "workspace-mount-probe.sh")
+	probeScript := `#!/bin/bash
+set -euo pipefail
+source "$1"
+workspace="$(cd "$2" && pwd -P)"
+mode="$3"
+stale_workspace="$(cd "$4" && pwd -P)"
+visible_mount="$5"
+stale_mount="$6"
+WORKCELL_DOCKER_CONTEXT="fixture-context"
+setup_workcell_trusted_docker_client() {
+  :
+}
+select_workcell_docker_context() {
+  [[ "${DOCKER_CONTEXT_NAME}" == "fixture-context" ]]
+}
+workcell_ci_docker() {
+  mount_spec=""
+  challenge_name=""
+  challenge_value=""
+  payload=""
+  image_seen=0
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --mount)
+        mount_spec="${2:-}"
+        shift 2
+        ;;
+      -e)
+        case "${2:-}" in
+          WORKCELL_VALIDATOR_BIND_CHALLENGE_NAME=*)
+            challenge_name="${2#*=}"
+            ;;
+          WORKCELL_VALIDATOR_BIND_CHALLENGE_VALUE=*)
+            challenge_value="${2#*=}"
+            ;;
+        esac
+        shift 2
+        ;;
+      -c)
+        payload="${2:-}"
+        shift 2
+        ;;
+      fixture-image)
+        image_seen=1
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  [[ "${mount_spec}" == "type=bind,src=${workspace},dst=/workspace,readonly" ]] || return 64
+  [[ "${image_seen}" -eq 1 ]] || return 64
+  [[ "${challenge_name}" == .workcell-validator-bind.* ]] || return 64
+  [[ -n "${challenge_value}" ]] || return 64
+  [[ -n "${payload}" ]] || return 64
+  case "${mode}" in
+    visible)
+      daemon_workspace="${visible_mount}"
+      ;;
+    missing)
+      return 125
+      ;;
+    stale)
+      daemon_workspace="${stale_mount}"
+      ;;
+  esac
+  translated_payload="${payload//\/workspace/${daemon_workspace}}"
+  env \
+    "WORKCELL_VALIDATOR_BIND_CHALLENGE_NAME=${challenge_name}" \
+    "WORKCELL_VALIDATOR_BIND_CHALLENGE_VALUE=${challenge_value}" \
+    /bin/bash -c "${translated_payload}"
+}
+setup_workcell_ci_docker
+require_workcell_ci_workspace_mount fixture-image "${workspace}"
+`
+	if err := os.WriteFile(probe, []byte(probeScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("visible", func(t *testing.T) {
+		output, err := exec.Command("/bin/bash", probe, helper, workspace, "visible", staleWorkspace, visibleMount, staleMount).CombinedOutput()
+		if err != nil {
+			t.Fatalf("visible workspace rejected: %v\n%s", err, output)
+		}
+		assertNoValidatorBindChallenges(t, workspace)
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		output, err := exec.Command("/bin/bash", probe, helper, workspace, "missing", staleWorkspace, visibleMount, staleMount).CombinedOutput()
+		if err == nil {
+			t.Fatalf("missing workspace accepted: %s", output)
+		}
+		for _, want := range []string{
+			"Validator workspace is not visible through Docker context fixture-context",
+			"Configured WORKCELL_DOCKER_CONTEXT=fixture-context cannot bind this checkout",
+		} {
+			if !strings.Contains(string(output), want) {
+				t.Fatalf("missing-workspace output does not contain %q:\n%s", want, output)
+			}
+		}
+		assertNoValidatorBindChallenges(t, workspace)
+	})
+
+	t.Run("stale", func(t *testing.T) {
+		output, err := exec.Command("/bin/bash", probe, helper, workspace, "stale", staleWorkspace, visibleMount, staleMount).CombinedOutput()
+		if err == nil {
+			t.Fatalf("stale workspace accepted: %s", output)
+		}
+		if !strings.Contains(string(output), "Validator workspace is not visible through Docker context fixture-context") {
+			t.Fatalf("stale-workspace output is not actionable:\n%s", output)
+		}
+		assertNoValidatorBindChallenges(t, workspace)
+	})
+}
+
+func createValidatorWorkspaceFixture(t *testing.T) string {
+	t.Helper()
+
+	workspace := filepath.Join(t.TempDir(), "workspace with spaces")
+	if err := os.MkdirAll(filepath.Join(workspace, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for path, content := range map[string]string{
+		"go.mod":                   "module example.com/workcell-fixture\n",
+		"scripts/validate-repo.sh": "#!/bin/bash\nexit 0\n",
+	} {
+		if err := os.WriteFile(filepath.Join(workspace, filepath.FromSlash(path)), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chmod(filepath.Join(workspace, "scripts", "validate-repo.sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return workspace
+}
+
+func assertNoValidatorBindChallenges(t *testing.T, workspace string) {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(workspace, ".workcell-validator-bind.*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("validator bind challenge residue remains: %v", matches)
+	}
+}

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -4,9 +4,11 @@
 package testkit
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -43,9 +45,11 @@ func TestValidatorRunnersRequireWorkspaceMountPreflight(t *testing.T) {
 			if setup < 0 || preflight < setup || workload < 0 {
 				t.Fatalf("%s must order Docker setup, workspace preflight, then validator workload", tc.rel)
 			}
-			mount := `--mount "type=bind,src=${` + tc.workspace + `},dst=/workspace"`
-			if !strings.Contains(string(content)[preflight+len(call):], mount) {
-				t.Fatalf("%s must use the same canonical bind mechanism for its validator workload", tc.rel)
+			mountSpec := `validator_workspace_mount="$(workcell_ci_workspace_mount_spec "${` + tc.workspace + `}" false)"`
+			mount := `--mount "${validator_workspace_mount}"`
+			afterPreflight := string(content)[preflight+len(call):]
+			if !strings.Contains(afterPreflight, mountSpec) || !strings.Contains(afterPreflight, mount) {
+				t.Fatalf("%s must use the non-creating comma-safe bind mechanism for its validator workload", tc.rel)
 			}
 			if tc.workspace == "ROOT_DIR" &&
 				!strings.Contains(string(content), `ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"`) {
@@ -55,166 +59,76 @@ func TestValidatorRunnersRequireWorkspaceMountPreflight(t *testing.T) {
 	}
 }
 
-func TestRequireWorkcellCIWorkspaceMount(t *testing.T) {
+func TestRequireWorkcellCIWorkspaceMountDispatchesGoPolicy(t *testing.T) {
 	t.Parallel()
 
-	workspace := createValidatorWorkspaceFixture(t)
-	staleWorkspace := createValidatorWorkspaceFixture(t)
-	visibleMount := filepath.Join(t.TempDir(), "visible")
-	staleMount := filepath.Join(t.TempDir(), "stale")
-	if err := os.Symlink(workspace, visibleMount); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Symlink(staleWorkspace, staleMount); err != nil {
-		t.Fatal(err)
-	}
-	helper := filepath.Join(repoRoot(t), "scripts", "ci", "lib", "local-docker-parity.sh")
-	probe := filepath.Join(t.TempDir(), "workspace-mount-probe.sh")
-	probeScript := `#!/bin/bash
+	root := repoRoot(t)
+	binDir := t.TempDir()
+	docker := writeExecutable(t, binDir, "docker", "#!/bin/bash\nexit 0\n")
+	goBin := writeExecutable(t, binDir, "go", `#!/bin/bash
 set -euo pipefail
-source "$1"
-workspace="$(cd "$2" && pwd -P)"
-mode="$3"
-stale_workspace="$(cd "$4" && pwd -P)"
-visible_mount="$5"
-stale_mount="$6"
+printf '%s\0' "$@" >"${WORKCELL_TEST_GO_ARGS}"
+`)
+	argsLog := filepath.Join(t.TempDir(), "go.args")
+	workspace := filepath.Join(t.TempDir(), "workspace, with spaces")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	helper := filepath.Join(root, "scripts", "ci", "lib", "local-docker-parity.sh")
+	probe := writeExecutable(t, t.TempDir(), "probe", `#!/bin/bash
+set -euo pipefail
+ROOT_DIR="$1"
+WORKCELL_GO_BIN="$2"
+PATH="$3:${PATH}"
+DOCKER_CONTEXT_NAME="fixture-context"
 WORKCELL_DOCKER_CONTEXT="fixture-context"
-setup_workcell_trusted_docker_client() {
-  :
-}
-select_workcell_docker_context() {
-  [[ "${DOCKER_CONTEXT_NAME}" == "fixture-context" ]]
-}
-workcell_ci_docker() {
-  mount_spec=""
-  challenge_name=""
-  challenge_value=""
-  payload=""
-  image_seen=0
-  while [[ "$#" -gt 0 ]]; do
-    case "$1" in
-      --mount)
-        mount_spec="${2:-}"
-        shift 2
-        ;;
-      -e)
-        case "${2:-}" in
-          WORKCELL_VALIDATOR_BIND_CHALLENGE_NAME=*)
-            challenge_name="${2#*=}"
-            ;;
-          WORKCELL_VALIDATOR_BIND_CHALLENGE_VALUE=*)
-            challenge_value="${2#*=}"
-            ;;
-        esac
-        shift 2
-        ;;
-      -c)
-        payload="${2:-}"
-        shift 2
-        ;;
-      fixture-image)
-        image_seen=1
-        shift
-        ;;
-      *)
-        shift
-        ;;
-    esac
-  done
-  [[ "${mount_spec}" == "type=bind,src=${workspace},dst=/workspace,readonly" ]] || return 64
-  [[ "${image_seen}" -eq 1 ]] || return 64
-  [[ "${challenge_name}" == .workcell-validator-bind.* ]] || return 64
-  [[ -n "${challenge_value}" ]] || return 64
-  [[ -n "${payload}" ]] || return 64
-  case "${mode}" in
-    visible)
-      daemon_workspace="${visible_mount}"
-      ;;
-    missing)
-      return 125
-      ;;
-    stale)
-      daemon_workspace="${stale_mount}"
-      ;;
-  esac
-  translated_payload="${payload//\/workspace/${daemon_workspace}}"
-  env \
-    "WORKCELL_VALIDATOR_BIND_CHALLENGE_NAME=${challenge_name}" \
-    "WORKCELL_VALIDATOR_BIND_CHALLENGE_VALUE=${challenge_value}" \
-    /bin/bash -c "${translated_payload}"
-}
-setup_workcell_ci_docker
-require_workcell_ci_workspace_mount fixture-image "${workspace}"
-`
-	if err := os.WriteFile(probe, []byte(probeScript), 0o700); err != nil {
-		t.Fatal(err)
+export ROOT_DIR WORKCELL_GO_BIN PATH DOCKER_CONTEXT_NAME WORKCELL_DOCKER_CONTEXT
+source "$4"
+require_workcell_ci_workspace_mount fixture-image "$5"
+`)
+	command := exec.Command("/bin/bash", probe, root, goBin, binDir, helper, workspace)
+	command.Env = append(os.Environ(), "WORKCELL_TEST_GO_ARGS="+argsLog)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Go policy dispatch failed: %v\n%s", err, output)
 	}
-
-	t.Run("visible", func(t *testing.T) {
-		output, err := exec.Command("/bin/bash", probe, helper, workspace, "visible", staleWorkspace, visibleMount, staleMount).CombinedOutput()
-		if err != nil {
-			t.Fatalf("visible workspace rejected: %v\n%s", err, output)
-		}
-		assertNoValidatorBindChallenges(t, workspace)
-	})
-
-	t.Run("missing", func(t *testing.T) {
-		output, err := exec.Command("/bin/bash", probe, helper, workspace, "missing", staleWorkspace, visibleMount, staleMount).CombinedOutput()
-		if err == nil {
-			t.Fatalf("missing workspace accepted: %s", output)
-		}
-		for _, want := range []string{
-			"Validator workspace is not visible through Docker context fixture-context",
-			"Configured WORKCELL_DOCKER_CONTEXT=fixture-context cannot bind this checkout",
-		} {
-			if !strings.Contains(string(output), want) {
-				t.Fatalf("missing-workspace output does not contain %q:\n%s", want, output)
-			}
-		}
-		assertNoValidatorBindChallenges(t, workspace)
-	})
-
-	t.Run("stale", func(t *testing.T) {
-		output, err := exec.Command("/bin/bash", probe, helper, workspace, "stale", staleWorkspace, visibleMount, staleMount).CombinedOutput()
-		if err == nil {
-			t.Fatalf("stale workspace accepted: %s", output)
-		}
-		if !strings.Contains(string(output), "Validator workspace is not visible through Docker context fixture-context") {
-			t.Fatalf("stale-workspace output is not actionable:\n%s", output)
-		}
-		assertNoValidatorBindChallenges(t, workspace)
-	})
-}
-
-func createValidatorWorkspaceFixture(t *testing.T) string {
-	t.Helper()
-
-	workspace := filepath.Join(t.TempDir(), "workspace with spaces")
-	if err := os.MkdirAll(filepath.Join(workspace, "scripts"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	for path, content := range map[string]string{
-		"go.mod":                   "module example.com/workcell-fixture\n",
-		"scripts/validate-repo.sh": "#!/bin/bash\nexit 0\n",
-	} {
-		if err := os.WriteFile(filepath.Join(workspace, filepath.FromSlash(path)), []byte(content), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := os.Chmod(filepath.Join(workspace, "scripts", "validate-repo.sh"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	return workspace
-}
-
-func assertNoValidatorBindChallenges(t *testing.T, workspace string) {
-	t.Helper()
-
-	matches, err := filepath.Glob(filepath.Join(workspace, ".workcell-validator-bind.*"))
+	data, err := os.ReadFile(argsLog)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(matches) != 0 {
-		t.Fatalf("validator bind challenge residue remains: %v", matches)
+	got := stringsFromNUL(data)
+	want := []string{
+		"run",
+		"./cmd/workcell-citools",
+		"validate-docker-workspace-bind",
+		docker,
+		"fixture-image",
+		workspace,
+		"fixture-context",
+		"true",
 	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("Go policy args = %q, want %q", got, want)
+	}
+}
+
+func writeExecutable(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func stringsFromNUL(data []byte) []string {
+	records := bytes.Split(data, []byte{0})
+	if len(records) > 0 && len(records[len(records)-1]) == 0 {
+		records = records[:len(records)-1]
+	}
+	result := make([]string, len(records))
+	for i, record := range records {
+		result[i] = string(record)
+	}
+	return result
 }

--- a/scripts/ci/job-validate.sh
+++ b/scripts/ci/job-validate.sh
@@ -144,6 +144,7 @@ if [[ "${PROFILE}" != "repo-core" ]]; then
   # TOCTOU surface that motivates mktemp in scripts/build-and-test.sh is
   # not reachable here.  Keep the predictable path for CI.
   require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${ROOT_DIR}"
+  validator_workspace_mount="$(workcell_ci_workspace_mount_spec "${ROOT_DIR}" false)"
   validator_home="/tmp/workcell-home-${validator_uid}"
   validator_cache="${validator_home}/.cache"
   validator_tmp="${validator_home}/.tmp"
@@ -154,7 +155,7 @@ if [[ "${PROFILE}" != "repo-core" ]]; then
   workcell_ci_docker run --rm \
     --user "${validator_uid}:${validator_gid}" \
     --entrypoint /bin/bash \
-    --mount "type=bind,src=${ROOT_DIR},dst=/workspace" \
+    --mount "${validator_workspace_mount}" \
     -w /workspace \
     -e HOME="${validator_home}" \
     -e XDG_CACHE_HOME="${validator_cache}" \

--- a/scripts/ci/job-validate.sh
+++ b/scripts/ci/job-validate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 workcell_validate_token_file_created=""
 if [[ -z "${WORKCELL_GITHUB_API_TOKEN_FILE:-}" ]]; then
   workcell_validate_token="${WORKCELL_GITHUB_API_TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}"
@@ -143,6 +143,7 @@ if [[ "${PROFILE}" != "repo-core" ]]; then
   # GitHub-hosted runners are exclusive per-job, so the planted-symlink
   # TOCTOU surface that motivates mktemp in scripts/build-and-test.sh is
   # not reachable here.  Keep the predictable path for CI.
+  require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${ROOT_DIR}"
   validator_home="/tmp/workcell-home-${validator_uid}"
   validator_cache="${validator_home}/.cache"
   validator_tmp="${validator_home}/.tmp"
@@ -153,7 +154,7 @@ if [[ "${PROFILE}" != "repo-core" ]]; then
   workcell_ci_docker run --rm \
     --user "${validator_uid}:${validator_gid}" \
     --entrypoint /bin/bash \
-    -v "${ROOT_DIR}:/workspace" \
+    --mount "type=bind,src=${ROOT_DIR},dst=/workspace" \
     -w /workspace \
     -e HOME="${validator_home}" \
     -e XDG_CACHE_HOME="${validator_cache}" \

--- a/scripts/ci/lib/local-docker-parity.sh
+++ b/scripts/ci/lib/local-docker-parity.sh
@@ -34,3 +34,52 @@ workcell_ci_docker() {
     docker "$@"
   fi
 }
+
+require_workcell_ci_workspace_mount() (
+  local image="$1"
+  local workspace="$2"
+  local challenge_path="" challenge_name="" challenge_value=""
+  local context_label="${DOCKER_CONTEXT_NAME:-default}"
+
+  workspace="$(cd "${workspace}" && pwd -P)" || {
+    echo "Validator workspace does not exist: ${workspace}" >&2
+    return 2
+  }
+  [[ -f "${workspace}/go.mod" ]] && [[ -x "${workspace}/scripts/validate-repo.sh" ]] || {
+    echo "Validator workspace is missing required validation inputs: ${workspace}" >&2
+    return 2
+  }
+
+  challenge_path="$(mktemp "${workspace}/.workcell-validator-bind.XXXXXX")" || {
+    echo "Cannot create the validator workspace bind challenge: ${workspace}" >&2
+    return 2
+  }
+  trap 'rm -f "${challenge_path}"' EXIT
+  challenge_name="${challenge_path##*/}"
+  challenge_value="${challenge_name}.$$.${RANDOM}.${RANDOM}"
+  printf '%s\n' "${challenge_value}" >"${challenge_path}"
+  chmod 0600 "${challenge_path}"
+
+  # shellcheck disable=SC2016
+  if ! workcell_ci_docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    --entrypoint /bin/bash \
+    --mount "type=bind,src=${workspace},dst=/workspace,readonly" \
+    -e "WORKCELL_VALIDATOR_BIND_CHALLENGE_NAME=${challenge_name}" \
+    -e "WORKCELL_VALIDATOR_BIND_CHALLENGE_VALUE=${challenge_value}" \
+    "${image}" \
+    -c '
+      set -euo pipefail
+      test -f /workspace/go.mod
+      test -x /workspace/scripts/validate-repo.sh
+      test "$(cat "/workspace/${WORKCELL_VALIDATOR_BIND_CHALLENGE_NAME}")" = "${WORKCELL_VALIDATOR_BIND_CHALLENGE_VALUE}"
+    ' 2>/dev/null; then
+    echo "Validator workspace is not visible through Docker context ${context_label}: ${workspace}" >&2
+    if [[ -n "${WORKCELL_DOCKER_CONTEXT:-}" ]]; then
+      echo "Configured WORKCELL_DOCKER_CONTEXT=${WORKCELL_DOCKER_CONTEXT} cannot bind this checkout; choose a context that can." >&2
+    else
+      echo "Select a Docker context whose daemon can bind this checkout, or set WORKCELL_DOCKER_CONTEXT explicitly." >&2
+    fi
+    return 2
+  fi
+)

--- a/scripts/ci/lib/local-docker-parity.sh
+++ b/scripts/ci/lib/local-docker-parity.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
 # shellcheck shell=bash
+source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
 
 setup_workcell_ci_docker() {
   setup_workcell_trusted_docker_client
@@ -35,51 +36,33 @@ workcell_ci_docker() {
   fi
 }
 
-require_workcell_ci_workspace_mount() (
+require_workcell_ci_workspace_mount() {
   local image="$1"
   local workspace="$2"
-  local challenge_path="" challenge_name="" challenge_value=""
-  local context_label="${DOCKER_CONTEXT_NAME:-default}"
+  local docker_bin=""
+  local context_explicit="false"
 
-  workspace="$(cd "${workspace}" && pwd -P)" || {
-    echo "Validator workspace does not exist: ${workspace}" >&2
+  docker_bin="$(command -v docker 2>/dev/null || true)"
+  [[ -n "${docker_bin}" && "${docker_bin}" == /* ]] || {
+    echo "Missing required tool: docker" >&2
     return 2
   }
-  [[ -f "${workspace}/go.mod" ]] && [[ -x "${workspace}/scripts/validate-repo.sh" ]] || {
-    echo "Validator workspace is missing required validation inputs: ${workspace}" >&2
-    return 2
-  }
-
-  challenge_path="$(mktemp "${workspace}/.workcell-validator-bind.XXXXXX")" || {
-    echo "Cannot create the validator workspace bind challenge: ${workspace}" >&2
-    return 2
-  }
-  trap 'rm -f "${challenge_path}"' EXIT
-  challenge_name="${challenge_path##*/}"
-  challenge_value="${challenge_name}.$$.${RANDOM}.${RANDOM}"
-  printf '%s\n' "${challenge_value}" >"${challenge_path}"
-  chmod 0600 "${challenge_path}"
-
-  # shellcheck disable=SC2016
-  if ! workcell_ci_docker run --rm \
-    --user "$(id -u):$(id -g)" \
-    --entrypoint /bin/bash \
-    --mount "type=bind,src=${workspace},dst=/workspace,readonly" \
-    -e "WORKCELL_VALIDATOR_BIND_CHALLENGE_NAME=${challenge_name}" \
-    -e "WORKCELL_VALIDATOR_BIND_CHALLENGE_VALUE=${challenge_value}" \
+  [[ -z "${WORKCELL_DOCKER_CONTEXT:-}" ]] || context_explicit="true"
+  run_go_in_repo "${ROOT_DIR}" run ./cmd/workcell-citools \
+    validate-docker-workspace-bind \
+    "${docker_bin}" \
     "${image}" \
-    -c '
-      set -euo pipefail
-      test -f /workspace/go.mod
-      test -x /workspace/scripts/validate-repo.sh
-      test "$(cat "/workspace/${WORKCELL_VALIDATOR_BIND_CHALLENGE_NAME}")" = "${WORKCELL_VALIDATOR_BIND_CHALLENGE_VALUE}"
-    ' 2>/dev/null; then
-    echo "Validator workspace is not visible through Docker context ${context_label}: ${workspace}" >&2
-    if [[ -n "${WORKCELL_DOCKER_CONTEXT:-}" ]]; then
-      echo "Configured WORKCELL_DOCKER_CONTEXT=${WORKCELL_DOCKER_CONTEXT} cannot bind this checkout; choose a context that can." >&2
-    else
-      echo "Select a Docker context whose daemon can bind this checkout, or set WORKCELL_DOCKER_CONTEXT explicitly." >&2
-    fi
-    return 2
-  fi
-)
+    "${workspace}" \
+    "${DOCKER_CONTEXT_NAME:-}" \
+    "${context_explicit}"
+}
+
+workcell_ci_workspace_mount_spec() {
+  local workspace="$1"
+  local readonly="$2"
+
+  run_go_in_repo "${ROOT_DIR}" run ./cmd/workcell-citools \
+    docker-workspace-bind-mount \
+    "${workspace}" \
+    "${readonly}"
+}

--- a/scripts/ci/run-docs-in-validator.sh
+++ b/scripts/ci/run-docs-in-validator.sh
@@ -20,6 +20,7 @@ if [[ ! -d "${WORKSPACE}" ]]; then
   echo "Validator workspace does not exist: ${WORKSPACE}" >&2
   exit 2
 fi
+WORKSPACE="$(cd "${WORKSPACE}" && pwd -P)"
 
 validator_uid="$(id -u)"
 validator_gid="$(id -g)"
@@ -32,12 +33,13 @@ validator_cache="${validator_home}/.cache"
 validator_tmp="${validator_home}/.tmp"
 
 setup_workcell_ci_docker
+require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${WORKSPACE}"
 
 # shellcheck disable=SC2016
 workcell_ci_docker run --rm \
   --user "${validator_uid}:${validator_gid}" \
   --entrypoint /bin/bash \
-  -v "${WORKSPACE}:/workspace" \
+  --mount "type=bind,src=${WORKSPACE},dst=/workspace" \
   -w /workspace \
   -e HOME="${validator_home}" \
   -e XDG_CACHE_HOME="${validator_cache}" \

--- a/scripts/ci/run-docs-in-validator.sh
+++ b/scripts/ci/run-docs-in-validator.sh
@@ -34,12 +34,13 @@ validator_tmp="${validator_home}/.tmp"
 
 setup_workcell_ci_docker
 require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${WORKSPACE}"
+validator_workspace_mount="$(workcell_ci_workspace_mount_spec "${WORKSPACE}" false)"
 
 # shellcheck disable=SC2016
 workcell_ci_docker run --rm \
   --user "${validator_uid}:${validator_gid}" \
   --entrypoint /bin/bash \
-  --mount "type=bind,src=${WORKSPACE},dst=/workspace" \
+  --mount "${validator_workspace_mount}" \
   -w /workspace \
   -e HOME="${validator_home}" \
   -e XDG_CACHE_HOME="${validator_cache}" \

--- a/scripts/ci/run-fuzz-in-validator.sh
+++ b/scripts/ci/run-fuzz-in-validator.sh
@@ -27,6 +27,7 @@ if [[ ! -d "${WORKSPACE}" ]]; then
   echo "Validator workspace does not exist: ${WORKSPACE}" >&2
   exit 2
 fi
+WORKSPACE="$(cd "${WORKSPACE}" && pwd -P)"
 
 validator_uid="$(id -u)"
 validator_gid="$(id -g)"
@@ -35,6 +36,7 @@ validator_cache="${validator_home}/.cache"
 validator_tmp="${validator_home}/.tmp"
 
 setup_workcell_ci_docker
+require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${WORKSPACE}"
 
 # shellcheck disable=SC2016
 workcell_ci_docker run --rm \
@@ -46,7 +48,7 @@ workcell_ci_docker run --rm \
   -e GOMODCACHE="${validator_cache}/go-mod" \
   -e TMPDIR="${validator_tmp}" \
   -e WORKCELL_FUZZTIME="${FUZZTIME}" \
-  -v "${WORKSPACE}:/workspace" \
+  --mount "type=bind,src=${WORKSPACE},dst=/workspace" \
   -w /workspace \
   "${VALIDATOR_IMAGE}" \
   -lc '

--- a/scripts/ci/run-fuzz-in-validator.sh
+++ b/scripts/ci/run-fuzz-in-validator.sh
@@ -37,6 +37,7 @@ validator_tmp="${validator_home}/.tmp"
 
 setup_workcell_ci_docker
 require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${WORKSPACE}"
+validator_workspace_mount="$(workcell_ci_workspace_mount_spec "${WORKSPACE}" false)"
 
 # shellcheck disable=SC2016
 workcell_ci_docker run --rm \
@@ -48,7 +49,7 @@ workcell_ci_docker run --rm \
   -e GOMODCACHE="${validator_cache}/go-mod" \
   -e TMPDIR="${validator_tmp}" \
   -e WORKCELL_FUZZTIME="${FUZZTIME}" \
-  --mount "type=bind,src=${WORKSPACE},dst=/workspace" \
+  --mount "${validator_workspace_mount}" \
   -w /workspace \
   "${VALIDATOR_IMAGE}" \
   -lc '

--- a/scripts/ci/run-mutation-in-validator.sh
+++ b/scripts/ci/run-mutation-in-validator.sh
@@ -23,6 +23,7 @@ if [[ ! -d "${WORKSPACE}" ]]; then
   echo "Validator workspace does not exist: ${WORKSPACE}" >&2
   exit 2
 fi
+WORKSPACE="$(cd "${WORKSPACE}" && pwd -P)"
 
 validator_uid="$(id -u)"
 validator_gid="$(id -g)"
@@ -31,6 +32,7 @@ validator_cache="${validator_home}/.cache"
 validator_tmp="${validator_home}/.tmp"
 
 setup_workcell_ci_docker
+require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${WORKSPACE}"
 
 # shellcheck disable=SC2016
 workcell_ci_docker run --rm \
@@ -42,7 +44,7 @@ workcell_ci_docker run --rm \
   -e GOMODCACHE="${validator_cache}/go-mod" \
   -e CARGO_TARGET_DIR="${validator_cache}/cargo-target" \
   -e TMPDIR="${validator_tmp}" \
-  -v "${WORKSPACE}:/workspace" \
+  --mount "type=bind,src=${WORKSPACE},dst=/workspace" \
   -w /workspace \
   "${VALIDATOR_IMAGE}" \
   -lc '

--- a/scripts/ci/run-mutation-in-validator.sh
+++ b/scripts/ci/run-mutation-in-validator.sh
@@ -33,6 +33,7 @@ validator_tmp="${validator_home}/.tmp"
 
 setup_workcell_ci_docker
 require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${WORKSPACE}"
+validator_workspace_mount="$(workcell_ci_workspace_mount_spec "${WORKSPACE}" false)"
 
 # shellcheck disable=SC2016
 workcell_ci_docker run --rm \
@@ -44,7 +45,7 @@ workcell_ci_docker run --rm \
   -e GOMODCACHE="${validator_cache}/go-mod" \
   -e CARGO_TARGET_DIR="${validator_cache}/cargo-target" \
   -e TMPDIR="${validator_tmp}" \
-  --mount "type=bind,src=${WORKSPACE},dst=/workspace" \
+  --mount "${validator_workspace_mount}" \
   -w /workspace \
   "${VALIDATOR_IMAGE}" \
   -lc '

--- a/scripts/ci/run-validate-in-validator.sh
+++ b/scripts/ci/run-validate-in-validator.sh
@@ -22,6 +22,7 @@ if [[ ! -d "${WORKSPACE}" ]]; then
   echo "Validator workspace does not exist: ${WORKSPACE}" >&2
   exit 2
 fi
+WORKSPACE="$(cd "${WORKSPACE}" && pwd -P)"
 
 validator_uid="$(id -u)"
 validator_gid="$(id -g)"
@@ -37,6 +38,7 @@ validator_cache="${validator_home}/.cache"
 validator_tmp="${validator_home}/.tmp"
 
 setup_workcell_ci_docker
+require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${WORKSPACE}"
 
 # shellcheck disable=SC2016
 workcell_ci_docker run --rm \
@@ -50,7 +52,7 @@ workcell_ci_docker run --rm \
   -e GOMODCACHE="${validator_cache}/go-mod" \
   -e CARGO_TARGET_DIR="${validator_cache}/cargo-target" \
   -e TMPDIR="${validator_tmp}" \
-  -v "${WORKSPACE}:/workspace" \
+  --mount "type=bind,src=${WORKSPACE},dst=/workspace" \
   -w /workspace \
   "${VALIDATOR_IMAGE}" \
   -lc '

--- a/scripts/ci/run-validate-in-validator.sh
+++ b/scripts/ci/run-validate-in-validator.sh
@@ -39,6 +39,7 @@ validator_tmp="${validator_home}/.tmp"
 
 setup_workcell_ci_docker
 require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${WORKSPACE}"
+validator_workspace_mount="$(workcell_ci_workspace_mount_spec "${WORKSPACE}" false)"
 
 # shellcheck disable=SC2016
 workcell_ci_docker run --rm \
@@ -52,7 +53,7 @@ workcell_ci_docker run --rm \
   -e GOMODCACHE="${validator_cache}/go-mod" \
   -e CARGO_TARGET_DIR="${validator_cache}/cargo-target" \
   -e TMPDIR="${validator_tmp}" \
-  --mount "type=bind,src=${WORKSPACE},dst=/workspace" \
+  --mount "${validator_workspace_mount}" \
   -w /workspace \
   "${VALIDATOR_IMAGE}" \
   -lc '


### PR DESCRIPTION
## Summary

- fail validator-backed lanes before certification when the selected Docker daemon cannot see the requested checkout
- keep canonicalization, challenge lifecycle, probe policy, cancellation, diagnostics, and mount encoding in Go while shell remains thin dispatch
- use a rootless-readable random non-secret challenge and exact stale-workspace comparison
- use CSV-encoded, non-creating `--mount` records for the readonly probe and all five read-write validator workloads

## Validation

- three independent peer-review lenses CLEAN after iterative fixes
- focused Go tests, race tests, vet, Bash syntax, ShellCheck, and 20x repeat controls
- live comma-bearing checkout passed preflight and workload mounting
- live unshared host checkout failed without creating its source path inside Colima
- `./scripts/validate-repo.sh`
- exact-HEAD `./scripts/pre-merge.sh --profile pr-parity --base main --parity-snapshot worktree`

Signed commits: `f26971b17ffd2862fcce7262e7dd48e820866bb7`, `dfd1eda6761e71e7707adda24c551f4df6e40eb6`
