### PR TITLE
^d Serialize PR policy events after branch pushes

### DIFF
--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -89,6 +89,9 @@ If the task is release-bound, also read:
   end-to-end certification.
 - Open the PR as a draft first. Mark it ready only after the review and check
   gates below are satisfied.
+- Every PR must complete the Codex bot loop required by `AGENTS.md`. Workflow
+  step 9 defines the repository procedure; use the Codex PR review loop skill
+  when it is available.
 - Do not stop at PR creation. Follow repo-owned checks until they are green,
   fix failures, and rerun the relevant local validation before pushing more
   commits.
@@ -111,6 +114,9 @@ If the task is release-bound, also read:
   merge, then follow merged `main` workflows until all repo-owned lanes are
   green. Scope hosted polling to the PR head SHA or merge SHA; historical
   scheduled failures are triage inputs, not blockers for an unrelated SHA.
+- A single-maintainer admin merge may bypass only a missing independent
+  approval. It never bypasses required checks, commit-signature or base policy,
+  the current-head Codex clean marker, comment sweeps, or unresolved threads.
 - Do not accept failing repo-owned tests, checks, or workflows as acceptable
   residue. Fix them or explicitly change the claimed guarantee in the same
   review unit.
@@ -145,19 +151,23 @@ If the task is release-bound, also read:
      settled; require success unless the next change is the single corrective
      draft transition or base edit needed to restore a permitted PR state
    - continue following checks until green
-9. Sweep top-level comments, inline comments, unresolved threads, and async
+9. Run the Codex bot loop after the branch is at its intended head. Post the
+   standalone trigger, check every response channel, react to and resolve or
+   disposition findings, resolve Codex threads, and confirm the clean marker's
+   reviewed SHA matches the current head. Repeat this step after every push.
+10. Sweep top-level comments, inline comments, unresolved threads, and async
    reviewer feedback.
-10. When checks are green and no actionable findings remain, mark the PR ready
+11. When checks are green and no actionable findings remain, mark the PR ready
    unless the user explicitly asked to keep it draft. Do not mark non-`main`
    base PRs ready; they stay lower-assurance draft-only review units.
-11. After marking ready, re-check checks and review surfaces again.
-12. If merge is part of the task, repeat the review sweep immediately before
+12. After marking ready, re-check checks and review surfaces again.
+13. If merge is part of the task, repeat the review sweep immediately before
     merge, merge, then follow merged `main` workflows until repo-owned lanes
     are green.
-13. After merge follow-up, run the aggregate repository readiness gate:
+14. After merge follow-up, run the aggregate repository readiness gate:
     `./scripts/check-repo-readiness.sh --repo <owner/repo> --base main`. Use
     `--watch` when CI or maintenance workflows are still active.
-14. If the task exposed a reusable PR-lifecycle or hosted-validation lesson,
+15. If the task exposed a reusable PR-lifecycle or hosted-validation lesson,
     update the relevant repo-local instructions in the same change stream or a
     separate follow-on PR.
 

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -92,6 +92,12 @@ If the task is release-bound, also read:
 - Do not stop at PR creation. Follow repo-owned checks until they are green,
   fix failures, and rerun the relevant local validation before pushing more
   commits.
+- Serialize follow-up branch pushes and PR-base-policy-triggering mutations,
+  including title, body, or base edits and draft/ready transitions. Do not run
+  them concurrently or while `Allowed PR base` is in progress: finish the
+  push, confirm the PR's `headRefOid`, and wait for the push-triggered policy
+  run to pass before mutating metadata. If the mutation triggers a replacement
+  policy run, follow it to success before another triggering mutation or merge.
 - Sweep top-level comments, inline comments, unresolved review threads, and
   configured async reviewers in `policy/reviewer-identities.toml`.
 - Mark the PR ready only after repo-owned checks are green and the review
@@ -132,6 +138,8 @@ If the task is release-bound, also read:
    - fix the underlying issue locally
    - rerun the smallest local validation that proves the fix
    - push the signed follow-up commit host-side to the existing branch
+   - confirm `headRefOid` matches the pushed head and its `Allowed PR base` run
+     passed before a PR-base-policy-triggering metadata change
    - continue following checks until green
 9. Sweep top-level comments, inline comments, unresolved threads, and async
    reviewer feedback.

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -96,8 +96,11 @@ If the task is release-bound, also read:
   including title, body, or base edits and draft/ready transitions. Do not run
   them concurrently or while `Allowed PR base` is in progress: finish the
   push, confirm the PR's `headRefOid`, and wait for the push-triggered policy
-  run to pass before mutating metadata. If the mutation triggers a replacement
-  policy run, follow it to success before another triggering mutation or merge.
+  run to settle. Require success before a non-corrective metadata mutation. If
+  it fails because the current PR state violates base policy, make only the
+  draft transition or base edit needed to restore a permitted state, then
+  follow the replacement policy run to success before another triggering
+  mutation or merge.
 - Sweep top-level comments, inline comments, unresolved review threads, and
   configured async reviewers in `policy/reviewer-identities.toml`.
 - Mark the PR ready only after repo-owned checks are green and the review
@@ -139,7 +142,8 @@ If the task is release-bound, also read:
    - rerun the smallest local validation that proves the fix
    - push the signed follow-up commit host-side to the existing branch
    - confirm `headRefOid` matches the pushed head and its `Allowed PR base` run
-     passed before a PR-base-policy-triggering metadata change
+     settled; require success unless the next change is the single corrective
+     draft transition or base edit needed to restore a permitted PR state
    - continue following checks until green
 9. Sweep top-level comments, inline comments, unresolved threads, and async
    reviewer feedback.

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -97,10 +97,11 @@ If the task is release-bound, also read:
   commits.
 - Serialize follow-up branch pushes and PR-base-policy-triggering mutations,
   including title, body, or base edits and draft/ready transitions. Do not run
-  them concurrently or while `Allowed PR base` is in progress: finish the
-  push, confirm the PR's `headRefOid`, and wait for the push-triggered policy
-  run to settle. Require success before a non-corrective metadata mutation. If
-  it fails because the current PR state violates base policy, make only the
+  them concurrently or while `Allowed PR base` is in progress. For each push or
+  mutation, wait for that event's own policy run to appear, identify it against
+  the current PR state, and require it to settle successfully before another
+  push, mutation, or merge; after a push, also confirm the PR's `headRefOid`.
+  If it fails because the current PR state violates base policy, make only the
   draft transition or base edit needed to restore a permitted state, then
   follow the replacement policy run to success before another triggering
   mutation or merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,12 @@ the runtime boundary or explicit security guarantees in the name of convenience.
   - unresolved review threads
   - asynchronous review comments from configured async reviewers listed in
     `policy/reviewer-identities.toml`
+- Every PR must complete the Codex bot loop: post a standalone `@codex review`,
+  sweep its issue comments, inline comments, formal reviews, and trigger
+  reactions; react to and fix or explicitly disposition its findings; resolve
+  its addressed threads; and require a clean marker for the current head before
+  merge. Repeat the loop after every push. When available, use the Codex PR
+  review loop skill for the exact response and SHA checks.
 - Actionable comments must be addressed or explicitly dispositioned before
   merge.
 - Re-check comments and review threads after CI turns green and immediately
@@ -136,6 +142,10 @@ the runtime boundary or explicit security guarantees in the name of convenience.
   acceptable post-merge residue.
 - Async reviewer feedback is advisory input, not a substitute for an
   independent human approval.
+- A single-maintainer admin merge may bypass only a missing independent
+  approval. It must never bypass required checks, commit-signature or base
+  policy, the current-head Codex clean marker, comment sweeps, or unresolved
+  threads.
 
 ## Release workflow
 


### PR DESCRIPTION
## Summary

- serialize push-triggered `Allowed PR base` checks before PR metadata mutations
- permit only a corrective draft transition or base edit after a settled base-policy failure
- require the replacement policy run to succeed before any further triggering mutation or merge

## Validation

- three independent peer-review lenses CLEAN
- `./scripts/ci/job-docs.sh`
- `env -u GIT_PAGER ./scripts/dev-quick-check.sh`
- `env -u GIT_PAGER ./scripts/ci/job-validate.sh --profile pr-parity`
- fresh exact-head `./scripts/pre-merge.sh --profile pr-parity --base main --parity-snapshot worktree`

Signed commits: `db880d68706e6937787595034fb67a84f2bdadb3`, `152c538e2f48db8324edf32a8b2a7c7e6970339b`