### PR TITLE
Activate exact runtime-image builder cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Releases.
 
 ## Unreleased
 
+### Fixed
+
+- remove temporary Buildx resources after every runtime-image build attempt,
+  with exact target, random identity, ownership, and inventory checks.
+
 ## v1.0.0-rc.2 - 2026-07-12
 
 Supersedes v1.0.0-rc.1, which was tagged but never published: its release

--- a/internal/workcellhardening/workcellhardening.go
+++ b/internal/workcellhardening/workcellhardening.go
@@ -831,6 +831,12 @@ var runtimeInvariantChecks = []check{
 		message: "Expected scripts/workcell to invoke buildx through the trusted absolute plugin path",
 	},
 	{
+		kind:         kindFunctionBlock,
+		functionName: "cleanup",
+		pattern:      "cleanup_runtime_builder || true",
+		message:      "Expected launcher exit cleanup to reap an active owned runtime-image builder",
+	},
+	{
 		// kindFunctionBlock (musl aarch64 asset must be present).
 		kind:         kindFunctionBlock,
 		functionName: "runtime_build_codex_arch",
@@ -893,7 +899,7 @@ var runtimeInvariantChecks = []check{
 	},
 }
 
-// CheckRuntimeInvariants runs the ten scripts/workcell runtime/gc
+// CheckRuntimeInvariants runs the scripts/workcell runtime/gc
 // invariants against the repo rooted at rootDir, in the shell's original
 // order.  It returns nil when every invariant holds (the shell's exit 0),
 // or an error whose message equals the shell's stderr for the first

--- a/internal/workcellhardening/workcellhardening_test.go
+++ b/internal/workcellhardening/workcellhardening_test.go
@@ -298,7 +298,7 @@ func TestCheckConfigSafetyRealRepo(t *testing.T) {
 }
 
 // runtimeHappyLauncher is a minimal scripts/workcell that satisfies all
-// ten runtime/gc invariants: the trusted Docker client seed, no
+// runtime/gc invariants: the trusted Docker client seed, no
 // DOCKER_CONFIG pin to the real host home, the buildx_cmd invocation, a
 // runtime_build_codex_arch body resolving both musl assets (and no gnu
 // asset), both hidden probes, both --gc cleanup helpers, the strict-mode
@@ -313,6 +313,10 @@ setup_workcell_trusted_docker_client() {
 
 runtime_build_image() {
   buildx_cmd build --tag workcell/runtime .
+}
+
+cleanup() {
+  cleanup_runtime_builder || true
 }
 
 runtime_build_codex_arch() {
@@ -373,6 +377,11 @@ func TestCheckRuntimeInvariants(t *testing.T) {
 			name:    "missing buildx_cmd build",
 			body:    strings.Replace(runtimeHappyLauncher, "buildx_cmd build", "buildx build", 1),
 			wantErr: "Expected scripts/workcell to invoke buildx through the trusted absolute plugin path",
+		},
+		{
+			name:    "exit trap omits builder cleanup",
+			body:    strings.Replace(runtimeHappyLauncher, "cleanup_runtime_builder || true", ":", 1),
+			wantErr: "Expected launcher exit cleanup to reap an active owned runtime-image builder",
 		},
 		{
 			// kindFunctionBlock: aarch64 musl asset removed from the block.

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "bd48ad5ddfda057471c28b55a5fcf159926d8594d06b4db1f210c08f9ed04a08"
+      "sha256": "783e3f18f9c0e69b3d62f30d98249740439707f316443e9e8a6ddce02e53ca51"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "536020f8bd0b4930ed25defe5e3ff5f868ac5022e80b0d99d96d9561a5b07485"
+      "sha256": "bd48ad5ddfda057471c28b55a5fcf159926d8594d06b4db1f210c08f9ed04a08"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1883,7 +1883,7 @@ docker_cmd run -d \
   -v "$(workcell_docker_host_path "${INJECTION_BUNDLE_ROOT}/copilot"):/opt/workcell/host-injections:ro" \
   -v "$(workcell_docker_host_path "${COPILOT_METADATA_STUB}"):/usr/local/libexec/workcell/real/copilot:ro" \
   "${IMAGE_TAG}" copilot -p smoke -s >/dev/null
-for _ in {1..100}; do
+for _ in {1..300}; do
   [[ -e "${COPILOT_METADATA_TOKEN_HANDOFF_DIR}/copilot-token-consumed" ]] && break
   sleep 0.1
 done
@@ -1897,13 +1897,20 @@ if [[ -e "${COPILOT_METADATA_TOKEN_HANDOFF_DIR}/copilot-github-token.txt" ]]; th
   docker_cmd rm -f "${COPILOT_METADATA_CONTAINER}" >/dev/null 2>&1 || true
   exit 32
 fi
-for _ in {1..100}; do
+for _ in {1..300}; do
   [[ -e "${SMOKE_WORKSPACE}/tmp/copilot-metadata-stub.out" ]] && break
+  if [[ "$(docker_cmd inspect --format '{{.State.Status}}' "${COPILOT_METADATA_CONTAINER}" 2>/dev/null || true)" =~ ^(dead|exited)$ ]]; then
+    echo "Copilot metadata smoke container exited before the stub became ready" >&2
+    docker_cmd logs "${COPILOT_METADATA_CONTAINER}" >&2 || true
+    docker_cmd rm -f "${COPILOT_METADATA_CONTAINER}" >/dev/null 2>&1 || true
+    exit 34
+  fi
   sleep 0.1
 done
 if [[ ! -e "${SMOKE_WORKSPACE}/tmp/copilot-metadata-stub.out" ]] ||
   ! grep -q '^copilot-metadata-stub-ok$' "${SMOKE_WORKSPACE}/tmp/copilot-metadata-stub.out"; then
   echo "Copilot metadata smoke stub did not become ready" >&2
+  docker_cmd logs "${COPILOT_METADATA_CONTAINER}" >&2 || true
   docker_cmd rm -f "${COPILOT_METADATA_CONTAINER}" >/dev/null 2>&1 || true
   exit 34
 fi

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1844,8 +1844,8 @@ test -z "${WORKCELL_COPILOT_GITHUB_TOKEN:-}"
 test -z "${WORKCELL_COPILOT_TOKEN_FILE:-}"
 test ! -e /opt/workcell/copilot-token-handoff/copilot-github-token.txt
 test -e /opt/workcell/copilot-token-handoff/copilot-token-consumed
-printf 'copilot-metadata-stub-ok\n' >/workspace/tmp/copilot-metadata-stub.out
 trap 'printf "copilot-metadata-term-ok\n" >/workspace/tmp/copilot-metadata-term.out; exit 0' TERM INT
+printf 'copilot-metadata-stub-ok\n' >/workspace/tmp/copilot-metadata-stub.out
 while :; do
   sleep 1
 done
@@ -1896,6 +1896,16 @@ if [[ -e "${COPILOT_METADATA_TOKEN_HANDOFF_DIR}/copilot-github-token.txt" ]]; th
   echo "Copilot metadata smoke token handoff file was not consumed" >&2
   docker_cmd rm -f "${COPILOT_METADATA_CONTAINER}" >/dev/null 2>&1 || true
   exit 32
+fi
+for _ in {1..100}; do
+  [[ -e "${SMOKE_WORKSPACE}/tmp/copilot-metadata-stub.out" ]] && break
+  sleep 0.1
+done
+if [[ ! -e "${SMOKE_WORKSPACE}/tmp/copilot-metadata-stub.out" ]] ||
+  ! grep -q '^copilot-metadata-stub-ok$' "${SMOKE_WORKSPACE}/tmp/copilot-metadata-stub.out"; then
+  echo "Copilot metadata smoke stub did not become ready" >&2
+  docker_cmd rm -f "${COPILOT_METADATA_CONTAINER}" >/dev/null 2>&1 || true
+  exit 34
 fi
 COPILOT_METADATA_ENV="$(docker_cmd inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "${COPILOT_METADATA_CONTAINER}")"
 COPILOT_METADATA_JSON="$(docker_cmd inspect "${COPILOT_METADATA_CONTAINER}")"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1000,6 +1000,87 @@ declare -a WORKSPACE_IMPORT_MOUNTS=()
 declare -a CACHE_MOUNTS=()
 declare -a RUNTIME_NETWORK_ARGS=()
 INTERACTIVE_HOST_TERMINAL_RESTORE_NEEDED=0
+BUILDX_BUILDER=""
+RUNTIME_BUILDER_CLEANUP_ACTIVE=0
+
+runtime_builder_policy() {
+  local action="$1"
+  local buildkitd_config="${2:-}"
+  local docker_endpoint="${DOCKER_HOST:-}"
+  local target_kind=""
+
+  target_kind="$(current_target_kind)" || return 1
+  if [[ -n "${DOCKER_CONTEXT:-}" ]]; then
+    docker_endpoint="$(run_workcell_docker_client_command \
+      docker context inspect "${DOCKER_CONTEXT}" --format '{{.Endpoints.docker.Host}}')" || return 1
+  fi
+  run_go_hostutil_preserve_exit runtime-builder-cli "${action}" \
+    "--profile=${COLIMA_PROFILE}" \
+    "--backend=${TARGET_BACKEND}" \
+    "--target-kind=${target_kind}" \
+    "--target-state-root=${WORKCELL_TARGET_STATE_ROOT}" \
+    "--colima-state-root=${COLIMA_STATE_ROOT}" \
+    "--workspace=${PROFILE_WORKSPACE_ROOT}" \
+    "--docker-host=${DOCKER_HOST:-}" \
+    "--docker-context=${DOCKER_CONTEXT:-}" \
+    "--docker-endpoint=${docker_endpoint}" \
+    "--docker-bin=${HOST_DOCKER_BIN}" \
+    "--docker-config=${DOCKER_CONFIG}" \
+    "--docker-home=${HOME}" \
+    "--real-home=${REAL_HOME}" \
+    "--docker-cwd=${WORKCELL_DOCKER_CLIENT_CWD:-${HOME:-/}}" \
+    "--buildx-bin=${WORKCELL_TRUSTED_BUILDX_BIN}" \
+    "--buildkitd-config=${buildkitd_config}" \
+    "--tool-path=${TRUSTED_HOST_PATH}"
+}
+
+begin_runtime_builder() {
+  local claim_output=""
+  local key=""
+  local value=""
+
+  [[ "${RUNTIME_BUILDER_CLEANUP_ACTIVE:-0}" -eq 0 ]] || {
+    echo "Workcell refused to claim a second runtime-image builder before cleanup." >&2
+    return 1
+  }
+  ensure_workcell_trusted_buildx
+  claim_output="$(mktemp "${TMPDIR:-/tmp}/workcell-runtime-builder-claim.XXXXXX")" || return 1
+  if ! runtime_builder_policy claim >"${claim_output}"; then
+    rm -f "${claim_output}"
+    echo "Workcell refused to claim runtime-image builder ownership." >&2
+    return 1
+  fi
+  RUNTIME_BUILDER_CLEANUP_ACTIVE=1
+  BUILDX_BUILDER=""
+  while IFS='=' read -r key value; do
+    case "${key}" in
+      builder_name)
+        [[ -z "${BUILDX_BUILDER}" && -n "${value}" ]] || { rm -f "${claim_output}"; return 1; }
+        BUILDX_BUILDER="${value}"
+        ;;
+      *)
+        rm -f "${claim_output}"; return 1
+        ;;
+    esac
+  done <"${claim_output}"
+  rm -f "${claim_output}"
+  [[ -n "${BUILDX_BUILDER}" ]] || return 1
+}
+
+create_runtime_builder() {
+  local buildkitd_config=""
+
+  [[ "${RUNTIME_BUILDER_CLEANUP_ACTIVE:-0}" -eq 1 ]] || return 1
+  buildkitd_config="$(prepare_workcell_buildkitd_config)" || return 1
+  runtime_builder_policy create "${buildkitd_config}"
+}
+
+cleanup_runtime_builder() {
+  [[ "${RUNTIME_BUILDER_CLEANUP_ACTIVE:-0}" -eq 1 ]] || return 0
+  runtime_builder_policy cleanup || return 1
+  RUNTIME_BUILDER_CLEANUP_ACTIVE=0
+  BUILDX_BUILDER=""
+}
 
 mark_interactive_host_terminal_dirty() {
   [[ -t 0 ]] && [[ -t 1 ]] || return 0
@@ -1076,6 +1157,7 @@ cleanup() {
     run_workcell_docker_client_command "${HOST_DOCKER_BIN}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
   fi
 
+  cleanup_runtime_builder || true
   if [[ -n "${PROFILE_LOCK_DIR}" ]] && [[ -d "${PROFILE_LOCK_DIR}" ]]; then
     rm -rf "${PROFILE_LOCK_DIR}"
   fi
@@ -6683,13 +6765,7 @@ run_runtime_image_build_with_retries() {
   local max_attempts=5
   local codex_release_url=""
   local copilot_release_url=""
-  local safe_builder_context=""
   local -a build_cmd=()
-
-  if [[ -z "${BUILDX_BUILDER:-}" ]]; then
-    safe_builder_context="${COLIMA_PROFILE//[^[:alnum:]_.-]/-}"
-    BUILDX_BUILDER="workcell-runtime-${safe_builder_context}"
-  fi
 
   while :; do
     build_status=0
@@ -6732,25 +6808,35 @@ run_runtime_image_build_with_retries() {
         "${EGRESS_HELPER}" apply "${COLIMA_PROFILE}" "${BOOTSTRAP_ENDPOINTS}"
       fi
     fi
-    ensure_workcell_selected_builder
-    build_cmd=(
-      buildx_cmd build
-      --build-arg "SOURCE_DATE_EPOCH=${build_source_date_epoch}"
-      --provenance=false
-      --sbom=false
-      --load
-      -t "${IMAGE_TAG}"
-      -f "${ROOT_DIR}/runtime/container/Dockerfile"
-      "${ROOT_DIR}"
-    )
-    if [[ -n "${codex_release_url}" ]]; then
-      build_cmd+=(--build-arg "CODEX_RELEASE_URL=${codex_release_url}")
+    if ! begin_runtime_builder; then
+      return 2
     fi
-    if [[ -n "${copilot_release_url}" ]]; then
-      build_cmd+=(--build-arg "COPILOT_RELEASE_URL=${copilot_release_url}")
+    if ! create_runtime_builder; then
+      build_status=2
+    else
+      build_cmd=(
+        buildx_cmd build
+        --builder "${BUILDX_BUILDER}"
+        --build-arg "SOURCE_DATE_EPOCH=${build_source_date_epoch}"
+        --provenance=false
+        --sbom=false
+        --load
+        -t "${IMAGE_TAG}"
+        -f "${ROOT_DIR}/runtime/container/Dockerfile"
+        "${ROOT_DIR}"
+      )
+      if [[ -n "${codex_release_url}" ]]; then
+        build_cmd+=(--build-arg "CODEX_RELEASE_URL=${codex_release_url}")
+      fi
+      if [[ -n "${copilot_release_url}" ]]; then
+        build_cmd+=(--build-arg "COPILOT_RELEASE_URL=${copilot_release_url}")
+      fi
+      SOURCE_DATE_EPOCH="${build_source_date_epoch}" run_command_with_debug_log runtime-build \
+        "${build_cmd[@]}" || build_status=$?
     fi
-    SOURCE_DATE_EPOCH="${build_source_date_epoch}" run_command_with_debug_log runtime-build \
-      "${build_cmd[@]}" || build_status=$?
+    if ! cleanup_runtime_builder; then
+      return 2
+    fi
     if [[ "${build_status}" -eq 0 ]]; then
       return 0
     fi

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1036,6 +1036,7 @@ runtime_builder_policy() {
 
 begin_runtime_builder() {
   local claim_output=""
+  local claim_valid=1
   local key=""
   local value=""
 
@@ -1055,16 +1056,20 @@ begin_runtime_builder() {
   while IFS='=' read -r key value; do
     case "${key}" in
       builder_name)
-        [[ -z "${BUILDX_BUILDER}" && -n "${value}" ]] || { rm -f "${claim_output}"; return 1; }
+        if [[ -n "${BUILDX_BUILDER}" || -z "${value}" ]]; then
+          claim_valid=0
+          break
+        fi
         BUILDX_BUILDER="${value}"
         ;;
       *)
-        rm -f "${claim_output}"; return 1
+        claim_valid=0
+        break
         ;;
     esac
   done <"${claim_output}"
   rm -f "${claim_output}"
-  [[ -n "${BUILDX_BUILDER}" ]] || return 1
+  [[ "${claim_valid}" -eq 1 && -n "${BUILDX_BUILDER}" ]] || return 1
 }
 
 create_runtime_builder() {

--- a/tests/scenarios/shared/test-agent-launch-smoke.sh
+++ b/tests/scenarios/shared/test-agent-launch-smoke.sh
@@ -124,6 +124,25 @@ prepare_runtime
 grep -q "^profile=${PROFILE} mode=strict agent=codex " "${TMP_DIR}/prepare.stderr"
 grep -q '^target_kind=local_vm target_provider=colima target_id='"${PROFILE}"' target_assurance_class=strict runtime_api=docker workspace_transport=workspace-mount$' "${TMP_DIR}/prepare.stderr"
 grep -q "Prepared runtime image recorded for profile ${PROFILE}. No session launched because --prepare-only was requested." "${TMP_DIR}/prepare.stderr"
+"${ROOT_DIR}/scripts/workcell" \
+  --inspect \
+  --agent codex \
+  --no-default-injection-policy \
+  --workspace "${WORKSPACE}" \
+  --colima-profile "${PROFILE}" >"${TMP_DIR}/inspect.stdout"
+TARGET_STATE_DIR="$(sed -n 's/^target_state_dir=//p' "${TMP_DIR}/inspect.stdout")"
+[[ -n "${TARGET_STATE_DIR}" ]]
+[[ ! -e "${TARGET_STATE_DIR}/workcell.builder-owned" ]]
+BUILDER_PREFIX="buildx_buildkit_workcell-runtime-${PROFILE}"
+COLIMA_HOME="${REAL_HOME}/.colima" colima start --profile "${PROFILE}" >/dev/null
+{
+  env DOCKER_HOST="unix://${REAL_HOME}/.colima/${PROFILE}/docker.sock" docker ps -a --format '{{.Names}}'
+  env DOCKER_HOST="unix://${REAL_HOME}/.colima/${PROFILE}/docker.sock" docker volume ls --format '{{.Name}}'
+} >"${TMP_DIR}/builder-inventory"
+if grep -Eq "^${BUILDER_PREFIX}-[a-f0-9]{32}(0|0?_state)?$" "${TMP_DIR}/builder-inventory"; then
+  echo "Runtime-image builder resources remain after prepare-only." >&2
+  exit 1
+fi
 
 for agent in codex claude copilot gemini; do
   expected_version="$(expected_runtime_version "${agent}")"

--- a/tests/scenarios/shared/test-docker-desktop-launch-smoke.sh
+++ b/tests/scenarios/shared/test-docker-desktop-launch-smoke.sh
@@ -16,6 +16,7 @@ cleanup() {
   local builder_name=""
   local builder_container_prefix=""
   local builder_resource=""
+  local -a builder_names=()
   local -a builder_containers=()
   local -a builder_volumes=()
 
@@ -34,25 +35,22 @@ cleanup() {
     done
   fi
   if [[ -n "${PROFILE_NAME}" ]]; then
-    builder_name="workcell-runtime-${PROFILE_NAME//[^[:alnum:]_.-]/-}"
+    builder_name="workcell-runtime-${PROFILE_NAME}-"
     builder_container_prefix="buildx_buildkit_${builder_name}"
-    builder_containers=("${builder_container_prefix}" "${builder_container_prefix}0")
-    builder_volumes=("${builder_container_prefix}_state" "${builder_container_prefix}0_state")
+    while IFS= read -r builder_resource; do builder_names+=("${builder_resource}"); done < <(docker --context desktop-linux buildx ls --format '{{.Name}}' 2>/dev/null | grep -E "^${builder_name}[a-f0-9]{32}$" || true)
+    while IFS= read -r builder_resource; do builder_containers+=("${builder_resource}"); done < <(docker --context desktop-linux ps -a --format '{{.Names}}' 2>/dev/null | grep -E "^${builder_container_prefix}[a-f0-9]{32}0?$" || true)
+    while IFS= read -r builder_resource; do builder_volumes+=("${builder_resource}"); done < <(docker --context desktop-linux volume ls --format '{{.Name}}' 2>/dev/null | grep -E "^${builder_container_prefix}[a-f0-9]{32}0?_state$" || true)
     for ((cleanup_attempt = 1; cleanup_attempt <= 5; cleanup_attempt++)); do
-      docker --context desktop-linux buildx rm --force "${builder_name}" >/dev/null 2>&1 || true
+      for builder_resource in "${builder_names[@]}"; do
+        docker --context desktop-linux buildx rm --force "${builder_resource}" >/dev/null 2>&1 || true
+      done
       for builder_resource in "${builder_containers[@]}"; do
         docker --context desktop-linux rm -f "${builder_resource}" >/dev/null 2>&1 || true
       done
       for builder_resource in "${builder_volumes[@]}"; do
         docker --context desktop-linux volume rm "${builder_resource}" >/dev/null 2>&1 || true
       done
-      if ! docker --context desktop-linux ps -a --format '{{.Names}}' | grep -Fxq "${builder_container_prefix}" &&
-        ! docker --context desktop-linux ps -a --format '{{.Names}}' | grep -Fxq "${builder_container_prefix}0" &&
-        ! docker --context desktop-linux volume ls --format '{{.Name}}' | grep -Fxq "${builder_container_prefix}_state" &&
-        ! docker --context desktop-linux volume ls --format '{{.Name}}' | grep -Fxq "${builder_container_prefix}0_state"; then
-        break
-      fi
-      sleep 1
+      [[ "${cleanup_attempt}" -eq 5 ]] || sleep 1
     done
   fi
   if [[ -n "${TARGET_STATE_DIR}" ]] && [[ "${TARGET_STATE_DIR}" == "${REAL_HOME}/.local/state/workcell/targets/local_compat/docker-desktop/"* ]]; then
@@ -193,6 +191,16 @@ grep -q '^target_kind=local_compat target_provider=docker-desktop target_id=desk
 grep -q 'Prepared runtime image recorded for profile ' "${TMP_DIR}/prepare.stderr"
 [[ -f "${TARGET_STATE_DIR}/workcell.image-ready" ]]
 [[ -f "${TARGET_STATE_DIR}/workcell.managed" ]]
+[[ ! -e "${TARGET_STATE_DIR}/workcell.builder-owned" ]]
+BUILDER_PREFIX="buildx_buildkit_workcell-runtime-${PROFILE_NAME}"
+{
+  docker --context desktop-linux ps -a --format '{{.Names}}'
+  docker --context desktop-linux volume ls --format '{{.Name}}'
+} >"${TMP_DIR}/builder-inventory"
+if grep -Eq "^${BUILDER_PREFIX}-[a-f0-9]{32}(0|0?_state)?$" "${TMP_DIR}/builder-inventory"; then
+  echo "Runtime-image builder resources remain after prepare-only." >&2
+  exit 1
+fi
 
 for agent in codex claude copilot gemini; do
   expected_version="$(expected_runtime_version "${agent}")"

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -3142,6 +3142,10 @@ grep -q 'event=command session_id=detached-lifecycle source=host-cli command=ses
 grep -q 'event=stop-request session_id=detached-lifecycle' "${SESSION_LIFECYCLE_AUDIT_LOG}"
 grep -q 'event=exit session_id=detached-lifecycle source=host-stop-fallback exit_status=0 final_assurance=managed-mutable' "${SESSION_LIFECYCLE_AUDIT_LOG}"
 
+runtime_builder_claim_output="$(bash -lc '
+  set -euo pipefail; source "$1"; root="$2"; WORKCELL_DOCKER_SANDBOX_ROOT="${root}/docker"; WORKCELL_DOCKER_HOME="${WORKCELL_DOCKER_SANDBOX_ROOT}/home"; WORKCELL_DOCKER_CLIENT_CWD="${WORKCELL_DOCKER_HOME}"; mkdir -p "${WORKCELL_DOCKER_HOME}"; RUNTIME_BUILDER_CLEANUP_ACTIVE=0; ensure_workcell_trusted_buildx() { :; }; runtime_builder_policy() { [[ "$1" == claim ]] && printf "builder_name=workcell-runtime-test\\n"; }; trap "rm -rf \"${WORKCELL_DOCKER_SANDBOX_ROOT}\"" EXIT; begin_runtime_builder; test -d "${WORKCELL_DOCKER_HOME}"; run_workcell_docker_client_command /bin/pwd
+' _ "${WORKCELL_FUNCTIONS_COPY}" "${TMP_DIR}/runtime-builder-claim")"
+grep -qx "${TMP_DIR}/runtime-builder-claim/docker/home" <<<"${runtime_builder_claim_output}"
 HOST_DOCKER_BIN="$(resolve_host_docker_bin || true)"
 if [[ -n "${HOST_DOCKER_BIN}" ]]; then
   docker_context_candidate=""

--- a/verify/invariants/harnesses/process-colima/workcell-runtime-build-retry.sh
+++ b/verify/invariants/harnesses/process-colima/workcell-runtime-build-retry.sh
@@ -25,6 +25,8 @@ SECURITY_COUNT=0
 SLEEP_COUNT=0
 RESTORE_COUNT=0
 ENSURE_AUDIT_COUNT=0
+CLAIM_COUNT=0 CLEANUP_COUNT=0 CLEANUP_FAIL=0
+CREATE_COUNT=0 CREATE_FAILURES_REMAINING=0 BUILD_FAILURES_REMAINING=1
 
 mkdir -p "$(dirname "${PROFILE_MARKER}")" "${ROOT_DIR}" "${WORKSPACE}" "${SESSION_AUDIT_DIR}"
 printf 'stale\n' >"${PROFILE_MARKER}"
@@ -58,11 +60,18 @@ validate_colima_profile() {
 validate_runtime_security_posture() {
   SECURITY_COUNT=$((SECURITY_COUNT + 1))
 }
-ensure_workcell_selected_builder() { :; }
+begin_runtime_builder() { CLAIM_COUNT=$((CLAIM_COUNT + 1)); BUILDX_BUILDER="workcell-runtime-${COLIMA_PROFILE}"; }
+cleanup_runtime_builder() { CLEANUP_COUNT=$((CLEANUP_COUNT + 1)); [[ "${CLEANUP_FAIL}" -eq 0 ]]; }
+create_runtime_builder() {
+  CREATE_COUNT=$((CREATE_COUNT + 1))
+  [[ "${CREATE_FAILURES_REMAINING}" -eq 0 ]] || { CREATE_FAILURES_REMAINING=$((CREATE_FAILURES_REMAINING - 1)); return 1; }
+}
 buildx_cmd() { :; }
 run_command_with_debug_log() {
   BUILD_COUNT=$((BUILD_COUNT + 1))
-  if [[ "${BUILD_COUNT}" -eq 1 ]]; then
+  BUILD_ARGS="$*"
+  if [[ "${BUILD_FAILURES_REMAINING}" -gt 0 ]]; then
+    BUILD_FAILURES_REMAINING=$((BUILD_FAILURES_REMAINING - 1))
     return 37
   fi
   return 0
@@ -72,16 +81,30 @@ sleep() {
 }
 
 run_runtime_image_build_with_retries "${SOURCE_DATE_EPOCH}"
-[[ "${BUILD_COUNT}" -eq 2 ]]
-[[ "${REFRESH_COUNT}" -eq 1 ]]
-[[ "${START_COUNT}" -eq 1 ]]
-[[ "${VALIDATE_COUNT}" -eq 1 ]]
-[[ "${RESTORE_COUNT}" -eq 1 ]]
-[[ "${ENSURE_AUDIT_COUNT}" -eq 1 ]]
-[[ "${SECURITY_COUNT}" -eq 1 ]]
-[[ "${SLEEP_COUNT}" -eq 1 ]]
+((BUILD_COUNT == 2 && REFRESH_COUNT == 1 && START_COUNT == 1))
+((VALIDATE_COUNT == 1 && RESTORE_COUNT == 1 && ENSURE_AUDIT_COUNT == 1))
+((CLAIM_COUNT == 2 && CREATE_COUNT == 2 && CLEANUP_COUNT == 2))
+((SECURITY_COUNT == 1 && SLEEP_COUNT == 1))
+[[ "${BUILD_ARGS}" == *"buildx_cmd build --builder workcell-runtime-${COLIMA_PROFILE}"* ]]
 [[ "${PROFILE_VALIDATED}" -eq 1 ]]
 [[ "$(cat "${PROFILE_MARKER}")" == "${PROFILE_WORKSPACE_ROOT}" ]]
 [[ -f "${ROOT}/pointers/${COLIMA_PROFILE}-debug" ]]
 [[ -f "${ROOT}/pointers/${COLIMA_PROFILE}-file-trace" ]]
 [[ -f "${ROOT}/pointers/${COLIMA_PROFILE}-transcript" ]]
+
+BUILD_COUNT=0 CLAIM_COUNT=0 CLEANUP_COUNT=0 CLEANUP_FAIL=1
+CREATE_COUNT=0 BUILD_FAILURES_REMAINING=1 REFRESH_COUNT=0 SLEEP_COUNT=0
+if run_runtime_image_build_with_retries "${SOURCE_DATE_EPOCH}"; then
+  echo "Expected runtime build retries to abort when exact builder cleanup fails." >&2
+  exit 1
+else
+  BUILD_STATUS=$?
+fi
+((BUILD_STATUS == 2 && BUILD_COUNT == 1 && CLAIM_COUNT == 1))
+((CREATE_COUNT == 1 && CLEANUP_COUNT == 1 && REFRESH_COUNT == 0 && SLEEP_COUNT == 0))
+
+BUILD_COUNT=0 BUILD_FAILURES_REMAINING=0 CLAIM_COUNT=0 CLEANUP_COUNT=0
+CLEANUP_FAIL=0 CREATE_COUNT=0 CREATE_FAILURES_REMAINING=1 REFRESH_COUNT=0 SLEEP_COUNT=0
+run_runtime_image_build_with_retries "${SOURCE_DATE_EPOCH}"
+((BUILD_COUNT == 1 && CLAIM_COUNT == 2 && CREATE_COUNT == 2))
+((CLEANUP_COUNT == 2 && REFRESH_COUNT == 1 && SLEEP_COUNT == 1))


### PR DESCRIPTION
## Summary

- activate the reviewed runtime-builder ownership core from #531 in launcher image builds
- claim, create, and clean one exact Buildx builder per build attempt, including failure and retry paths
- add hardening coverage and make Copilot TERM smoke readiness explicit under loaded validation

## Validation

- strict Colima live certification passed for all providers
- Docker Desktop compatibility live certification passed for all providers
- committed-head `pr-parity` passed at `f93a1dad419897178597e4ced4d575e4bedab45e`
- focused shared-snapshot container smoke passed