### PR TITLE
Defer C2 certification to post-1.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,8 +134,12 @@ improvement tracks below; `G` items are the 1.0 contract-and-operations track.
    resourcing (no audit sponsor/funding).
 3. Platform: `macos/arm64` strict (Colima) and compat (Docker Desktop) are
    certified on the release matrix; the Apple `container` backend decision
-   (C1) is recorded either way; session start latency targets (C2) are met
-   and published; native parallel sessions (C3) work on the strict path.
+   (C1) is recorded either way; native parallel sessions (C3) work on the
+   strict path. **[Amended 2026-08-01, recorded maintainer decision:]** C2
+   certification and its 1.0 latency target are deferred to post-1.0. The
+   generic startup driver remains benchmark-only because caller-provided hooks
+   cannot prove lifecycle state; the reviewed dedicated-certifier design was
+   rejected rather than broaden the launcher with destructive controls.
 4. Providers: the Tier 1 set covers the current agent ecosystem — Codex,
    Claude Code, GitHub Copilot CLI, Gemini, and Google Antigravity CLI —
    each through the same Tier 1 evidence bar. If upstream instability blocks
@@ -168,11 +172,10 @@ improvement tracks below; `G` items are the 1.0 contract-and-operations track.
    support-tier and diagnostics guides (E3) are live. **[Amended 2026-07-09,
    recorded maintainer decision:]** the rendered docs site with demos and
    externally published reproducible benchmarks (E6) is **deferred to post-1.0**.
-   1.0 ships with in-repo markdown docs; C2 benchmark numbers are still captured
-   and published in
-   [`docs/session-startup-benchmarks.md`](docs/session-startup-benchmarks.md)
-   during Batch 3 local-operator certification. Tradeoff recorded honestly:
-   1.0 ships without the external rendered site or demo package.
+   1.0 ships with in-repo markdown docs. C2 is deferred to post-1.0 and the
+   generic benchmark is not certification evidence. Tradeoff recorded honestly:
+   1.0 ships without the external rendered site, demo package, or a certified
+   latency claim.
 8. Readiness review: a cross-lens 1.0 gate review (G4) — product,
    enterprise/security, adapter-maintainer, validation, docs/contract, and
    release lenses — records no unresolved P0/P1 findings, and every support
@@ -189,10 +192,10 @@ amended above). B6 — defer the automated Apple-Silicon runner (no funding);
 certify both boundaries by the local-operator discipline on the maintainer's
 host (criterion 6, amended above). B7 — defer the third-party boundary audit and
 OpenSSF badge to post-1.0 (criterion 2, amended above). E6 — defer the rendered
-docs site, demos, and external benchmark publication; 1.0 ships with in-repo
-markdown docs while C2 benchmark numbers are captured and published through
-Batch 3 local-operator certification (criterion 7, amended above). See the
-readiness review for the recorded G4 checklist state.
+docs site, demos, and external benchmark publication. C2 — defer certification
+and its latency target to post-1.0; preserve the generic driver as benchmark-only
+after rejecting the broader dedicated-certifier design (criteria 3 and 7 amended
+above). See the readiness review for the recorded G4 checklist state.
 
 ### Milestone Train
 
@@ -205,10 +208,10 @@ live in
 |---|---|---|
 | v0.12 | Containment and hygiene | A2, A7, B3, B4, B5, D1, D2, E3, E4 |
 | v0.13 | Boundary depth and stability | A1, A3, A4, B1, C5, D8, E1, E2, F3, G1 (inventory) |
-| v0.14 | Platform, speed, and adoption | C1, C2, B8, B9, D3 (start), D4, E5, E7, G2, Antigravity Tier 1 adapter track |
+| v0.14 | Platform, speed, and adoption | C1, B8, B9, D3 (start), D4, E5, E7, G2, Antigravity Tier 1 adapter track |
 | v0.15 | Enterprise evidence and release assurance | A5, A6, C3, D5, D7, F1, G3 |
 | v1.0-rc | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
-| post-1.0 | Reach expansion | Phases 13–19 remainder, C4, B2 (dual-control releases), B6 (automated real-boundary lane), B7 (badge + audit completion), E6 (rendered docs site + external demos), F2 |
+| post-1.0 | Reach expansion | Phases 13–19 remainder, C2, C4, B2 (dual-control releases), B6 (automated real-boundary lane), B7 (badge + audit completion), E6 (rendered docs site + external demos), F2 |
 
 Phase 13 (Linux `amd64` `local_compat` certification candidate) may land
 before or after 1.0 depending on certification evidence; it does not gate
@@ -528,8 +531,9 @@ security-boundary product to prove.
   default (and the only option below macOS 26); promotion to a supported
   backend deferred post-1.0 pending the B6 certification lane.** See
   [docs/apple-container-evaluation.md](docs/apple-container-evaluation.md)
-- **C2 (next, M):** session start latency program with cached images, an
-  optional kept-warm lane, and published reproducible benchmarks
+- **C2 (post-1.0, M):** session start latency program with cached images, an
+  optional kept-warm lane, and a certification design that does not broaden the
+  launcher with destructive controls; generic output remains benchmark-only
 - **C3 (next, L):** native parallel sessions — one agent per worktree,
   branch, and isolated runtime, with session-record linkage
 - **C4 (later, L):** container tooling inside the boundary as an explicit

--- a/docs/1.0-readiness-review-draft.md
+++ b/docs/1.0-readiness-review-draft.md
@@ -148,8 +148,11 @@ Grounded in `ROADMAP.md` Non-Goals plus verification of what is on `main`:
   no persistent kept-warm session was exercised (so the delta is an image-restore
   cost, not a warm-lane win), `cache-hit` shows an unresolved ~50% anomaly, `cold`
   is a tarball restore not a no-tarball first build, and per-sample teardown never
-  ran (the `export -f` under zsh was a no-op). A clean C2 cert (working teardown +
-  persistent warm session + resolved `cache-hit` anomaly) remains for Batch-3.
+  ran (the `export -f` under zsh was a no-op). **G4 decision recorded
+  2026-08-01:** C2 certification and its 1.0 latency target are deferred to
+  post-1.0. The generic driver remains benchmark-only because caller-provided
+  hooks cannot prove lifecycle state; the reviewed dedicated-certifier design
+  was rejected rather than broaden the launcher with destructive controls.
 - **C3 parallel sessions:** the live two-container run is recorded (2026-07-15,
   §6 Platform row) — distinct containers, worktrees, and branches. That
   establishes *structural* isolation; the **runtime non-interference check**
@@ -206,6 +209,14 @@ the maintainer records the outcome.
       landed A1–A6 hardening + threat model; the external audit and OpenSSF badge
       remain post-1.0 commitments. Tradeoff (no independent third-party
       validation at 1.0) recorded.
+- [x] **C2 scope decision — criterion 3 AMENDED (2026-08-01).** C2
+      certification and any latency target are deferred to post-1.0 because the
+      generic driver uses caller-provided hooks that cannot prove lifecycle state,
+      while the reviewed dedicated-certifier design would broaden the launcher
+      with destructive controls. The rationale is recorded in `ROADMAP.md` and
+      the G4 plan; 1.0 makes no C2 performance claim. This records only the
+      narrow C2 scope decision: it does not mark Platform or overall readiness
+      complete.
 - [ ] **Platform** strict + compat certified on the release matrix (both
       boundaries certified on the maintainer host 2026-07-13 —
       `test-agent-launch-smoke.sh` for `macos/arm64/local_vm/colima/strict` and
@@ -217,7 +228,9 @@ the maintainer records the outcome.
       4.1% from cache-hit; promoted tiers ≤0.6%) — but **not a clean C2 cert**
       (no persistent kept-warm session → not a warm-lane win; unresolved ~50%
       `cache-hit` anomaly; `cold` is a tarball restore not a first build; teardown
-      never ran); clean C2 cert pending Batch-3; **C3 two-session run recorded
+      never ran); **G4 decision recorded 2026-08-01: C2 certification and its
+      1.0 latency target are deferred to post-1.0; generic benchmark output is
+      not certification evidence**; **C3 two-session run recorded
       2026-07-15**
       — two same-repo `--session-workspace isolated` sessions (started 33 s apart,
       each short-lived — **not concurrent**, see the evidence file) on
@@ -238,8 +251,8 @@ the maintainer records the outcome.
       DEFERRED to post-1.0 (2026-07-09 maintainer decision)** — 1.0 ships with
       in-repo markdown docs; a **preliminary** C2 capture was published to
       `docs/session-startup-benchmarks.md` on 2026-07-15 (not a certification —
-      see the §6 Platform row for the confounds; a clean C2 cert is pending
-      Batch-3). See the amended criterion 7 in `ROADMAP.md`.
+      C2 certification and its 1.0 target are deferred post-1.0 by the recorded
+      G4 decision). See the amended criterion 7 in `ROADMAP.md`.
 - [ ] **Operations** G2 proven; G3 day-two lifecycle proven end-to-end on the
       release matrix (criterion 5). G3's CI-automatable core is merged, and the
       local-operator-certification remainder (verified install against a real

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -44,7 +44,7 @@ The milestone ordering answers the current landscape directly:
   default-deny allowlisting → A1 (v0.13) documents, extends, and brings
   target parity to that shipped control instead of building a duplicate lane
 - microVM-per-session backends with warm starts are the mainstream
-  comparison point → C1/C2 anchor v0.14
+  comparison point → C1 anchors v0.14; C2 is a post-1.0 program
 - parallel worktree-per-agent sessions are the 2026 unit of agent work →
   C3 is in 1.0 scope (v0.15), not a post-1.0 idea
 - upstream retires Gemini CLI personal-account tiers in June 2026 →
@@ -61,10 +61,10 @@ The milestone ordering answers the current landscape directly:
 |---|---|---|
 | v0.12 | Containment and hygiene | A2, A7, B3, B4, B5, D1, D2, E3, E4 |
 | v0.13 | Boundary depth and stability | A1, A3, A4, B1, C5, D8, E1, E2, F3, G1 (inventory) |
-| v0.14 | Platform, speed, and adoption | C1, C2, B8, B9, D3 (start), D4, E5, E7, G2, Antigravity Tier 1 adapter track |
+| v0.14 | Platform, speed, and adoption | C1, B8, B9, D3 (start), D4, E5, E7, G2, Antigravity Tier 1 adapter track |
 | v0.15 | Enterprise evidence and release assurance | A5, A6, C3, D5, D7, F1, G3 |
 | v1.0-rc | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
-| post-1.0 | Reach expansion | Phases 13–19 remainder, C4, B2 (dual-control releases), B6 (automated real-boundary lane), B7 (badge + audit completion), E6 (rendered docs site + external demos), F2 |
+| post-1.0 | Reach expansion | Phases 13–19 remainder, C2, C4, B2 (dual-control releases), B6 (automated real-boundary lane), B7 (badge + audit completion), E6 (rendered docs site + external demos), F2 |
 
 Items inside a milestone are independently shippable and individually
 reviewable. Later-milestone items may start early when nothing earlier gates
@@ -343,15 +343,23 @@ isolation would be a stronger and lighter boundary than one shared Colima VM.
 
 ### C2: Session Start Latency Program
 
-- Steps: measure and publish the current cold/warm start breakdown; add
-  prebaked per-project image caching under the existing cache-profile
-  labeling; evaluate a kept-warm VM lane as an explicit labeled mode;
-  publish reproducible startup benchmarks; set and record the 1.0 latency
-  target.
-- Exit gates: measured improvement recorded; no new unlabeled assurance
-  downgrade; benchmark methodology published; 1.0 target met or re-scoped
-  with rationale.
-- Validation: benchmark lane; scenario coverage for cache-profile behavior.
+**Deferred to post-1.0 (recorded 2026-08-01).** The generic startup driver is
+benchmark-only: its caller-provided lifecycle hooks cannot prove the image,
+profile, session, or cleanup facts required for certification. A reviewed
+dedicated-certifier design was rejected because the required state controls would
+broaden the launcher with destructive maintainer operations. The preliminary
+2026-07-15 capture remains historical measurement evidence only; it does not meet
+or gate a 1.0 latency target.
+
+- Post-1.0 steps: measure and publish the current cold/warm start breakdown;
+  add prebaked per-project image caching under the existing cache-profile
+  labeling; evaluate a kept-warm VM lane as an explicit labeled mode; publish
+  reproducible startup benchmarks; and set any resulting latency target.
+- Post-1.0 exit gates: a certification design must prove lifecycle state without
+  widening the supported launcher surface before any performance claim or target.
+- 1.0 exit gate: recorded rationale in ROADMAP/G4; no C2 performance claim.
+- Validation: benchmark lane for non-certifying measurements; a future dedicated
+  certification review before any support or performance claim.
 - Size: M. Dependencies: C5 methodology; C1 informs the ceiling.
 
 ### B8: CI Efficiency And Reliability Program
@@ -415,9 +423,9 @@ isolation would be a stronger and lighter boundary than one shared Colima VM.
 ### E6: Adoption Growth Kit
 
 **Deferred to post-1.0 (2026-07-09 criterion-7 amendment).** 1.0 ships with
-in-repo markdown docs; C2 benchmark numbers remain required in
-`docs/session-startup-benchmarks.md` during Batch 3 local-operator
-certification. This detail section stays here for continuity of the E6 track.
+in-repo markdown docs. C2 remains post-1.0 and its generic benchmark output is
+not a certification substitute. This detail section stays here for continuity of
+the E6 track.
 
 - Steps: publish a rendered docs site from the existing markdown; record
   asciinema demos for the 5-minute path and one provider quickstart; ship a
@@ -531,8 +539,7 @@ here for continuity of the B6 track.
   (deterministic tests); session tooling renders parallel topology; docs
   updated; works on the strict path.
 - Validation: scenario coverage including conflict cases; live exercise.
-- Size: L. Dependencies: C2 (latency makes parallel viable); C1 decision
-  helps (per-session VMs).
+- Size: L. Dependencies: C1 decision helps (per-session VMs).
 
 ### D5: Modularize The Rust Interception Library
 
@@ -611,6 +618,9 @@ here for continuity of the B6 track.
   matrix row against shipped behavior; record all scope decisions (for
   example an Antigravity certification deferral) explicitly; file and burn
   down any P0/P1 findings.
+- Decision (recorded 2026-08-01): C2's 1.0 latency target and certification are
+  deferred to post-1.0. The generic benchmark remains benchmark-only; the
+  rejected dedicated-certifier design does not create a launcher control surface.
 - Exit gates: no unresolved P0/P1 findings; matrices verified; scope
   decisions recorded; criteria checklist complete with evidence links.
 - Validation: the recorded review itself.
@@ -728,7 +738,7 @@ does not gate 1.0.
 
 - D1 → D2 → D3/D4; A3 + A4 → D5; D2 → D7 (shell portion)
 - B9 → B6; B1 → B2; B3 baseline before D3/D5 refactors land
-- C5 → C2 → C3; C1 decision informs C2/C3/C4
+- C5 informs the post-1.0 C2 program; C1 decision informs C2/C3/C4
 - E4 → E1 → E6; A2 → E5; D8 → G1 (inventory) → G1 (freeze); E5 → G1 (freeze)
 - G1 (inventory) → G3; A5 ↔ F1 coordinated; F1 → F2; G2 ↔ F1 redaction rules
 - A3/A4/D5 → B7 (part 2); everything → G4

--- a/docs/session-startup-benchmarks.md
+++ b/docs/session-startup-benchmarks.md
@@ -2,13 +2,13 @@
 
 Workcell starts an isolated session by resolving the runtime image, booting the
 container runtime (Colima today, Apple `container` under evaluation in C1), and
-completing the supervisor handshake. **C2** measures that start latency and drives
-it down with cached images and an optional kept-warm lane — the sibling of
+completing the supervisor handshake. The post-1.0 **C2** program measures that
+latency and drives it down with cached images and an optional kept-warm lane — the sibling of
 [syscall-shim-benchmarks.md](syscall-shim-benchmarks.md) (C5). Numbers are captured
 on a host with a live runtime, not in PR CI (a real start needs a booted VM); the
 [results tables below](#results) hold a **preliminary live capture from 2026-07-15**
-— recorded with its raw evidence, but confounded by three methodology issues
-(documented there) and therefore not yet a certified C2 result.
+— recorded with its raw evidence, but confounded by four methodology issues
+(documented there) and therefore not a certified C2 result.
 
 ## What is measured
 
@@ -22,8 +22,7 @@ modes that span the latency shapes C2 targets:
 | `warm` | image cached and a kept-warm session available | best-case start off the kept-warm lane |
 | `cache-hit` | image cached, no kept-warm session | the image-cache win alone, without the warm lane |
 
-The `cold` vs `warm` delta is the headline C2 number; `cache-hit` separates the
-image-cache win from the kept-warm-lane win so each is credited independently.
+These modes establish no performance guarantee or C2 certification.
 
 ## Methodology
 
@@ -72,7 +71,7 @@ hooks — these guards are live-only.
 
 ### The cross-run stability gate
 
-Reproducibility is the C2 acceptance bar, so the driver enforces it: after all
+The driver enforces a reproducibility guard: after all
 runs it computes, per mode, the run-to-run **median** spread as a percentage of
 the smallest run's median, and **fails** (non-zero exit) if any mode exceeds
 `WORKCELL_STARTUP_STABILITY_PCT` (default 15%) — the evidence a published number
@@ -81,14 +80,13 @@ signals a broken clock rather than a 0% spread that would read as `STABLE`.
 
 ### Runner caveats
 
-Numbers are **relative** to the host's hardware and runtime backend, so treat the
-cold-vs-warm delta (not absolute medians) as the portable signal; session start
-includes VM boot, so expect a wider stddev than the C5 exec-guard numbers.
+Numbers are **relative** to the host's hardware and runtime backend. A warm delta
+is meaningful only when a kept-warm lane is present and verified.
 
 ## Results
 
-**Status: PRELIMINARY capture 2026-07-15 — recorded, but not yet a clean C2
-certification.** Captured on the maintainer host (Darwin 25.5.0 arm64, 12 online
+**Status: PRELIMINARY capture 2026-07-15 — benchmark-only, not C2 certification.**
+Captured on the maintainer host (Darwin 25.5.0 arm64, 12 online
 CPUs, `colima` runtime, profile `wcl-workcell-006e49ec`), 5 iterations × 2 runs,
 `codex` provider; the cross-run stability gate passed (exit 0) — its overall max
 cross-run median spread was **4.1%**, from the unpromoted `cache-hit` mode; the two
@@ -97,7 +95,7 @@ invocation (`WORKCELL_STARTUP_CMD` + all three prep hooks) and the complete raw
 report** are preserved verbatim in
 [`benchmark-evidence/session-startup-2026-07-15.md`](benchmark-evidence/session-startup-2026-07-15.md).
 Four methodology confounds (below) mean these numbers are a useful preliminary
-signal, **not** a certified C2 result; a clean capture remains for Batch-3.
+signal, **not** a certified C2 result or a 1.0 latency target.
 
 ### Measured start latency (5 samples per run, both runs shown)
 
@@ -149,17 +147,15 @@ restore-from-tarball cost**, not a kept-warm-session win.
    gaps — but the samples did not begin in the harness's intended clean state, and this
    is a candidate contributor to the `cache-hit` anomaly.
 
-A clean C2 certification should run with **working per-sample teardown**, establish an
-actual persistent kept-warm session, resolve or explain the `cache-hit` anomaly, and
-decide whether to also capture a no-tarball first-start tier.
+A future C2 certification should prove **working per-sample teardown**, resolve the
+`cache-hit` anomaly, and decide whether to capture a no-tarball first-start tier.
 
 ## Filling in the numbers
 
 On a host with a live runtime, run the driver (see [Rerunning](#rerunning)) with
-`WORKCELL_STARTUP_OUTPUT` set. A `0` exit means the stability gate passed and the
-numbers are reproducible (non-zero means the spread was too wide — fix first).
-Transcribe the report's medians, p90s and stability table into the tables above,
-fill `vs cold`, and record the host, runtime backend, and `N`/`R`.
+`WORKCELL_STARTUP_OUTPUT` set. A `0` exit means the benchmark stability gate
+passed; non-zero can also mean configuration, launch, or cleanup failure. Generic
+driver output cannot certify or promote C2.
 
 ## Rerunning
 

--- a/docs/syscall-shim-benchmarks.md
+++ b/docs/syscall-shim-benchmarks.md
@@ -6,7 +6,8 @@ forwarding it to the real entry point. This page records the added latency that
 classification costs on the **allow path** -- a launch the guard permits and
 forwards -- and the methodology and rerun steps behind those numbers. Its
 sibling page, [session-startup-benchmarks.md](session-startup-benchmarks.md),
-records the **C2** session-start latency baselines.
+records historical, benchmark-only C2 session-start measurements; it makes no
+1.0 performance claim.
 
 The numbers are produced by the optional `bench.yml` GitHub lane on Linux, not
 on the macOS development host: the shim reads `/proc` and interposes the


### PR DESCRIPTION
## Summary

- record the maintainer decision to defer C2 certification and its latency target to post-1.0
- keep the generic startup driver benchmark-only because caller-provided hooks cannot prove lifecycle state
- reject the reviewed dedicated-certifier design rather than broaden the launcher with destructive controls

## Validation

- `./scripts/verify-operator-contract.sh`
- `./scripts/verify-requirements-coverage.sh`
- `./scripts/check-dead-code.sh`
- `./scripts/check-public-contract.sh`
- `./scripts/check-public-repo-hygiene.sh`
- `env -u GIT_PAGER ./scripts/validate-repo.sh`
- `./scripts/pre-merge.sh --profile pr-parity --local-snapshot head --keep-local-dir`