### PR TITLE
^B Reject ambiguous Hadolint checksum entries

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -77,6 +78,7 @@ func subcommands() []subcommand {
 		{"extract-claude-sha", "DOCKERFILE_PATH TARGET_ARCH", 2, 2, cmdExtractClaudeSHA},
 		{"extract-codex-sha", "DOCKERFILE_PATH TARGET_ARCH", 2, 2, cmdExtractCodexSHA},
 		{"extract-copilot-sha", "DOCKERFILE_PATH TARGET_ARCH", 2, 2, cmdExtractCopilotSHA},
+		{"hadolint-manifest-checksum", "ASSET_NAME", 1, 1, cmdHadolintManifestChecksum},
 		{"manifest-checksum", "MANIFEST_PATH PLATFORM", 2, 2, cmdManifestChecksum},
 		{"manifest-version", "MANIFEST_PATH EXPECTED_VERSION", 2, 2, cmdManifestVersion},
 		{"check-provider-bump-policy", "POLICY_PATH DOCKERFILE PROVIDERS_PACKAGE_JSON", 3, 3, cmdCheckProviderBumpPolicy},
@@ -325,6 +327,19 @@ func cmdExtractCodexSHA(args []string) error {
 
 func cmdExtractCopilotSHA(args []string) error {
 	value, err := metadatautil.ExtractCopilotSHA(args[0], args[1])
+	if err != nil {
+		return err
+	}
+	fmt.Println(value)
+	return nil
+}
+
+func cmdHadolintManifestChecksum(args []string) error {
+	manifest, err := io.ReadAll(io.LimitReader(os.Stdin, metadatautil.HadolintChecksumManifestMaxBytes+1))
+	if err != nil {
+		return err
+	}
+	value, err := metadatautil.HadolintManifestChecksum(manifest, args[0])
 	if err != nil {
 		return err
 	}

--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -20,11 +20,13 @@ import (
 	"github.com/omkhar/workcell/internal/providerid"
 )
 
-var (
-	hexDigestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
-)
+var hexDigestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
 
 const missingTrackedInputMsg = "tracked release input is missing from the working tree; stage the deletion or restore the file before generating a verified build input manifest: %s"
+
+// HadolintChecksumManifestMaxBytes bounds release-manifest input accepted by
+// the updater parser.
+const HadolintChecksumManifestMaxBytes = 64 * 1024
 
 type ControlPlaneArtifact struct {
 	Kind        string
@@ -424,6 +426,34 @@ func ExtractCopilotSHA(dockerfilePath, targetArch string) (string, error) {
 		return "", fmt.Errorf("unable to extract COPILOT_SHA256 for %s", targetArch)
 	}
 	return match[1], nil
+}
+
+func HadolintManifestChecksum(manifest []byte, assetName string) (string, error) {
+	invalidManifest := func() error {
+		return fmt.Errorf("Hadolint checksum manifest must contain exactly one 64-hex digest for %s", assetName)
+	}
+	if len(manifest) > HadolintChecksumManifestMaxBytes || assetName == "" || strings.ContainsAny(assetName, "*\t\r\n ") {
+		return "", invalidManifest()
+	}
+
+	candidates := 0
+	digest := ""
+	for line := range strings.SplitSeq(string(manifest), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || (fields[1] != assetName && fields[1] != "*"+assetName) {
+			continue
+		}
+		candidates++
+		normalizedDigest := strings.ToLower(fields[0])
+		if len(fields) != 2 || fields[1] != "*"+assetName || !hexDigestPattern.MatchString(normalizedDigest) {
+			return "", invalidManifest()
+		}
+		digest = normalizedDigest
+	}
+	if candidates != 1 {
+		return "", invalidManifest()
+	}
+	return digest, nil
 }
 
 func ManifestChecksum(manifestPath, platform string) (string, error) {

--- a/internal/metadatautil/core_test.go
+++ b/internal/metadatautil/core_test.go
@@ -40,6 +40,51 @@ func TestWalkFilesSkipsExcludedPaths(t *testing.T) {
 	}
 }
 
+func TestHadolintManifestChecksum(t *testing.T) {
+	t.Parallel()
+
+	amd64Digest := strings.Repeat("A", 64)
+	arm64Digest := strings.Repeat("b", 64)
+	validManifest := amd64Digest + "  *hadolint-linux-x86_64\n" + arm64Digest + "  *hadolint-linux-arm64\n"
+	tests := []struct {
+		name      string
+		manifest  string
+		assetName string
+		want      string
+		wantErr   bool
+	}{
+		{name: "binary marker", manifest: validManifest, assetName: "hadolint-linux-x86_64", want: strings.ToLower(amd64Digest)},
+		{name: "near match", manifest: amd64Digest + "  *hadolint-linux-x86_64-extra\n", assetName: "hadolint-linux-x86_64", wantErr: true},
+		{name: "duplicate", manifest: amd64Digest + "  *hadolint-linux-x86_64\n" + amd64Digest + "  *hadolint-linux-x86_64\n", assetName: "hadolint-linux-x86_64", wantErr: true},
+		{name: "mixed marker duplicate", manifest: amd64Digest + "  *hadolint-linux-x86_64\n" + amd64Digest + "  hadolint-linux-x86_64\n", assetName: "hadolint-linux-x86_64", wantErr: true},
+		{name: "unmarked", manifest: amd64Digest + "  hadolint-linux-x86_64\n", assetName: "hadolint-linux-x86_64", wantErr: true},
+		{name: "short digest", manifest: amd64Digest[:63] + "  *hadolint-linux-x86_64\n", assetName: "hadolint-linux-x86_64", wantErr: true},
+		{name: "non hexadecimal digest", manifest: strings.Repeat("g", 64) + "  *hadolint-linux-x86_64\n", assetName: "hadolint-linux-x86_64", wantErr: true},
+		{name: "extra field", manifest: amd64Digest + "  *hadolint-linux-x86_64 extra\n", assetName: "hadolint-linux-x86_64", wantErr: true},
+		{name: "invalid asset name", manifest: validManifest, assetName: "hadolint linux x86_64", wantErr: true},
+		{name: "oversized manifest", manifest: strings.Repeat("x", HadolintChecksumManifestMaxBytes+1), assetName: "hadolint-linux-x86_64", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := HadolintManifestChecksum([]byte(test.manifest), test.assetName)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("HadolintManifestChecksum() = %q, want error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("HadolintManifestChecksum() error = %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("HadolintManifestChecksum() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestWalkRepoFilesSkipsExcludedPaths(t *testing.T) {
 	root := t.TempDir()
 	for _, dir := range []string{".git", "dist", "tmp", "node_modules", "target", "pkg"} {

--- a/internal/testkit/update_upstream_pins_check_test.go
+++ b/internal/testkit/update_upstream_pins_check_test.go
@@ -498,7 +498,9 @@ func runUpdaterFixture(t *testing.T, fixtureRoot, scratchRoot, citoolsPath, goWr
 	const hostileCurlConfig = "output = \"/dev/null\"\n"
 	writeUpdaterFixtureFile(t, hostileHome, ".curlrc", hostileCurlConfig, 0o600)
 	cmd := exec.Command("/bin/bash", "-p", "-c", updaterFixtureHarness, "workcell-updater-fixture", filepath.Join(fixtureRoot, "scripts", "update-upstream-pins.sh"), mode)
-	cmd.Dir = fixtureRoot
+	// Invoke the absolute updater path from outside the fixture repository so
+	// every repo-local tool dispatch must anchor itself to ROOT_DIR.
+	cmd.Dir = scratchRoot
 	cmd.Env = []string{
 		"ALL_PROXY=http://127.0.0.1:1",
 		"BASH_ENV=",

--- a/internal/testkit/update_upstream_pins_check_test.go
+++ b/internal/testkit/update_upstream_pins_check_test.go
@@ -33,6 +33,7 @@ type updaterFixturePins struct {
 	HadolintVersion              string
 	HadolintAMD64SHA             string
 	HadolintARM64SHA             string
+	HadolintChecksums            string
 	BuildkitImage                string
 	BuildxVersion                string
 	CosignVersion                string
@@ -208,6 +209,86 @@ func TestUpdateUpstreamPinsApplyFailureLeavesFixtureUnchanged(t *testing.T) {
 	after := snapshotUpdaterFixtureTree(t, fixtureRoot)
 	if !reflect.DeepEqual(after, before) {
 		t.Fatalf("failed update-upstream-pins.sh --apply mutated its fixture tree\nbefore: %#v\nafter:  %#v", before, after)
+	}
+}
+
+func TestUpdateUpstreamPinsRejectsMalformedHadolintChecksumManifest(t *testing.T) {
+	t.Parallel()
+
+	pins := readUpdaterFixturePins(t)
+	targetPlan := updaterTargetDebianPlan()
+	toolsRoot := t.TempDir()
+	citoolsPath := buildUpdaterFixtureCITools(t, toolsRoot)
+	goWrapperPath := writeUpdaterFixtureGoWrapper(t, toolsRoot)
+
+	testCases := []struct {
+		name      string
+		checksums string
+		assetName string
+	}{
+		{
+			name: "near match AMD64 asset name",
+			checksums: fmt.Sprintf(
+				"%s  *hadolint-linux-x86_64-extra\n%s  *hadolint-linux-arm64\n",
+				pins.HadolintAMD64SHA,
+				pins.HadolintARM64SHA,
+			),
+			assetName: "hadolint-linux-x86_64",
+		},
+		{
+			name: "duplicate asset name",
+			checksums: fmt.Sprintf(
+				"%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-arm64\n",
+				pins.HadolintAMD64SHA,
+				pins.HadolintAMD64SHA,
+				pins.HadolintARM64SHA,
+			),
+			assetName: "hadolint-linux-x86_64",
+		},
+		{
+			name: "short digest",
+			checksums: fmt.Sprintf(
+				"%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-arm64\n",
+				pins.HadolintAMD64SHA[:63],
+				pins.HadolintARM64SHA,
+			),
+			assetName: "hadolint-linux-x86_64",
+		},
+		{
+			name: "non hexadecimal digest",
+			checksums: fmt.Sprintf(
+				"%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-arm64\n",
+				strings.Repeat("g", 64),
+				pins.HadolintARM64SHA,
+			),
+			assetName: "hadolint-linux-x86_64",
+		},
+		{
+			name: "near match ARM64 asset name",
+			checksums: fmt.Sprintf(
+				"%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-arm64-extra\n",
+				pins.HadolintAMD64SHA,
+				pins.HadolintARM64SHA,
+			),
+			assetName: "hadolint-linux-arm64",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixtureRoot := writeUpdaterFixture(t, updaterManifestFromPlan(targetPlan), 0o640)
+			fixturePins := pins
+			fixturePins.HadolintChecksums = testCase.checksums
+
+			run := runUpdaterFixture(t, fixtureRoot, t.TempDir(), citoolsPath, goWrapperPath, fixturePins, targetPlan, "--check")
+			if run.Code != 1 {
+				t.Fatalf("updater exit code = %d, want 1\noutput:\n%s", run.Code, run.Output)
+			}
+			want := "Hadolint checksum manifest must contain exactly one 64-hex digest for " + testCase.assetName
+			if !strings.Contains(run.Output, want) {
+				t.Fatalf("updater output did not reject malformed Hadolint manifest:\n%s", run.Output)
+			}
+		})
 	}
 }
 
@@ -526,6 +607,7 @@ func runUpdaterFixture(t *testing.T, fixtureRoot, scratchRoot, citoolsPath, goWr
 		"WORKCELL_FIXTURE_GO_VERSION=" + pins.GoToolchain,
 		"WORKCELL_FIXTURE_HADOLINT_AMD64_SHA=" + pins.HadolintAMD64SHA,
 		"WORKCELL_FIXTURE_HADOLINT_ARM64_SHA=" + pins.HadolintARM64SHA,
+		"WORKCELL_FIXTURE_HADOLINT_CHECKSUMS=" + pins.HadolintChecksums,
 		"WORKCELL_FIXTURE_HADOLINT_VERSION=" + pins.HadolintVersion,
 		"WORKCELL_FIXTURE_PROVIDER_LOG=" + providerLogPath,
 		"WORKCELL_FIXTURE_QEMU_DIGEST=" + qemuDigest,
@@ -820,21 +902,29 @@ func readUpdaterFixturePins(t *testing.T) updaterFixturePins {
 	releaseWorkflow := readUpdaterFixtureSource(t, filepath.Join(root, ".github", "workflows", "release.yml"))
 	securityWorkflow := readUpdaterFixtureSource(t, filepath.Join(root, ".github", "workflows", "security.yml"))
 	upstreamWorkflow := readUpdaterFixtureSource(t, filepath.Join(root, ".github", "workflows", "upstream-refresh.yml"))
+	hadolintAMD64SHA := updaterFixtureUniqueValue(t, validatorDockerfile, "ARG HADOLINT_LINUX_X86_64_SHA256=")
+	hadolintARM64SHA := updaterFixtureUniqueValue(t, validatorDockerfile, "ARG HADOLINT_LINUX_ARM64_SHA256=")
+
 	return updaterFixturePins{
-		RuntimeBase:                  updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG NODE_BASE_IMAGE="),
-		ValidatorBase:                updaterFixtureUniqueValue(t, validatorDockerfile, "ARG VALIDATOR_BASE_IMAGE="),
-		GoToolchain:                  updaterFixtureUniqueValue(t, goMod, "toolchain go"),
-		GoLanguage:                   updaterFixtureUniqueValue(t, goMod, "go "),
-		GoAMD64SHA:                   updaterFixtureUniqueValue(t, validatorDockerfile, "ARG GO_LINUX_X86_64_SHA256="),
-		GoARM64SHA:                   updaterFixtureUniqueValue(t, validatorDockerfile, "ARG GO_LINUX_ARM64_SHA256="),
-		RustVersion:                  updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG RUST_VERSION="),
-		RuntimeRustImage:             updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG RUST_TOOLCHAIN_IMAGE="),
-		RustupVersion:                updaterFixtureUniqueValue(t, validatorDockerfile, "ARG RUSTUP_VERSION="),
-		RustupAMD64SHA:               updaterFixtureUniqueValue(t, validatorDockerfile, "ARG RUSTUP_INIT_LINUX_X86_64_SHA256="),
-		RustupARM64SHA:               updaterFixtureUniqueValue(t, validatorDockerfile, "ARG RUSTUP_INIT_LINUX_ARM64_SHA256="),
-		HadolintVersion:              updaterFixtureUniqueValue(t, validatorDockerfile, "ARG HADOLINT_VERSION="),
-		HadolintAMD64SHA:             updaterFixtureUniqueValue(t, validatorDockerfile, "ARG HADOLINT_LINUX_X86_64_SHA256="),
-		HadolintARM64SHA:             updaterFixtureUniqueValue(t, validatorDockerfile, "ARG HADOLINT_LINUX_ARM64_SHA256="),
+		RuntimeBase:      updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG NODE_BASE_IMAGE="),
+		ValidatorBase:    updaterFixtureUniqueValue(t, validatorDockerfile, "ARG VALIDATOR_BASE_IMAGE="),
+		GoToolchain:      updaterFixtureUniqueValue(t, goMod, "toolchain go"),
+		GoLanguage:       updaterFixtureUniqueValue(t, goMod, "go "),
+		GoAMD64SHA:       updaterFixtureUniqueValue(t, validatorDockerfile, "ARG GO_LINUX_X86_64_SHA256="),
+		GoARM64SHA:       updaterFixtureUniqueValue(t, validatorDockerfile, "ARG GO_LINUX_ARM64_SHA256="),
+		RustVersion:      updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG RUST_VERSION="),
+		RuntimeRustImage: updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG RUST_TOOLCHAIN_IMAGE="),
+		RustupVersion:    updaterFixtureUniqueValue(t, validatorDockerfile, "ARG RUSTUP_VERSION="),
+		RustupAMD64SHA:   updaterFixtureUniqueValue(t, validatorDockerfile, "ARG RUSTUP_INIT_LINUX_X86_64_SHA256="),
+		RustupARM64SHA:   updaterFixtureUniqueValue(t, validatorDockerfile, "ARG RUSTUP_INIT_LINUX_ARM64_SHA256="),
+		HadolintVersion:  updaterFixtureUniqueValue(t, validatorDockerfile, "ARG HADOLINT_VERSION="),
+		HadolintAMD64SHA: hadolintAMD64SHA,
+		HadolintARM64SHA: hadolintARM64SHA,
+		HadolintChecksums: fmt.Sprintf(
+			"%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-arm64\n",
+			hadolintAMD64SHA,
+			hadolintARM64SHA,
+		),
 		BuildkitImage:                updaterFixtureUniqueValue(t, ciWorkflow, "  WORKCELL_BUILDKIT_IMAGE: "),
 		BuildxVersion:                updaterFixtureUniqueValue(t, ciWorkflow, "  WORKCELL_BUILDX_VERSION: "),
 		CosignVersion:                updaterFixtureUniqueValue(t, ciWorkflow, "  WORKCELL_COSIGN_VERSION: "),
@@ -991,15 +1081,11 @@ curl() {
       ;;
     'https://api.github.com/repos/hadolint/hadolint/releases/latest')
       expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 -H 'Accept: application/vnd.github+json' "${url}" || return
-      printf '{"tag_name":"%s","assets":[{"name":"hadolint-linux-x86_64.sha256","browser_download_url":"https://fixture.invalid/hadolint-amd64.sha256"},{"name":"hadolint-linux-arm64.sha256","browser_download_url":"https://fixture.invalid/hadolint-arm64.sha256"}]}\n' "${WORKCELL_FIXTURE_HADOLINT_VERSION}"
+      printf '{"tag_name":"%s","assets":[{"name":"checksums.sha256","browser_download_url":"https://fixture.invalid/hadolint-checksums.sha256"}]}\n' "${WORKCELL_FIXTURE_HADOLINT_VERSION}"
       ;;
-    'https://fixture.invalid/hadolint-amd64.sha256')
+    'https://fixture.invalid/hadolint-checksums.sha256')
       expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 60 --connect-timeout 15 --max-filesize 65536 "${url}" || return
-      printf '%s  hadolint-linux-x86_64\n' "${WORKCELL_FIXTURE_HADOLINT_AMD64_SHA}"
-      ;;
-    'https://fixture.invalid/hadolint-arm64.sha256')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 60 --connect-timeout 15 --max-filesize 65536 "${url}" || return
-      printf '%s  hadolint-linux-arm64\n' "${WORKCELL_FIXTURE_HADOLINT_ARM64_SHA}"
+      printf '%s' "${WORKCELL_FIXTURE_HADOLINT_CHECKSUMS}"
       ;;
     'https://api.github.com/repos/docker/buildx/releases/latest')
       expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 -H 'Accept: application/vnd.github+json' "${url}" || return

--- a/internal/testkit/update_upstream_pins_check_test.go
+++ b/internal/testkit/update_upstream_pins_check_test.go
@@ -107,9 +107,10 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 	checkRun := runUpdaterFixture(t, fixtureRoot, checkScratch, citoolsPath, goWrapperPath, pins, targetPlan, "--check")
 	assertUpdaterFixtureRun(t, checkRun, 1, updaterFixtureSummary(pins, driftedManifest, targetManifest), targetPlan.Snapshot)
 	assertUpdaterCommandCounts(t, checkRun.CIToolsLog, map[string]int{
-		"inspect-debian-bootstrap": 1,
-		"apply-debian-bootstrap":   0,
-		"check-pinned-inputs":      0,
+		"hadolint-manifest-checksum": 2,
+		"inspect-debian-bootstrap":   1,
+		"apply-debian-bootstrap":     0,
+		"check-pinned-inputs":        0,
 	})
 	if want := []string{"summary", "check"}; !reflect.DeepEqual(checkRun.ProviderLog, want) {
 		t.Fatalf("provider updater command log = %q, want %q", checkRun.ProviderLog, want)
@@ -130,9 +131,10 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 	applyRun := runUpdaterFixture(t, fixtureRoot, applyScratch, citoolsPath, goWrapperPath, pins, targetPlan, "--apply")
 	assertUpdaterFixtureRun(t, applyRun, 0, updaterFixtureSummary(pins, driftedManifest, targetManifest), targetPlan.Snapshot)
 	assertUpdaterCommandCounts(t, applyRun.CIToolsLog, map[string]int{
-		"inspect-debian-bootstrap": 1,
-		"apply-debian-bootstrap":   1,
-		"check-pinned-inputs":      1,
+		"hadolint-manifest-checksum": 2,
+		"inspect-debian-bootstrap":   1,
+		"apply-debian-bootstrap":     1,
+		"check-pinned-inputs":        1,
 	})
 	if want := []string{"summary", "check", "apply"}; !reflect.DeepEqual(applyRun.ProviderLog, want) {
 		t.Fatalf("provider updater command log = %q, want %q", applyRun.ProviderLog, want)
@@ -163,9 +165,10 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 	cleanRun := runUpdaterFixture(t, fixtureRoot, cleanScratch, citoolsPath, goWrapperPath, pins, targetPlan, "--check")
 	assertUpdaterFixtureRun(t, cleanRun, 0, updaterFixtureSummary(pins, targetManifest, targetManifest), targetPlan.Snapshot)
 	assertUpdaterCommandCounts(t, cleanRun.CIToolsLog, map[string]int{
-		"inspect-debian-bootstrap": 1,
-		"apply-debian-bootstrap":   0,
-		"check-pinned-inputs":      0,
+		"hadolint-manifest-checksum": 2,
+		"inspect-debian-bootstrap":   1,
+		"apply-debian-bootstrap":     0,
+		"check-pinned-inputs":        0,
 	})
 	assertUpdaterScratchHasOnlyLogs(t, cleanScratch)
 	afterCleanCheck := snapshotUpdaterFixtureTree(t, fixtureRoot)
@@ -197,9 +200,10 @@ func TestUpdateUpstreamPinsApplyFailureLeavesFixtureUnchanged(t *testing.T) {
 	}
 	assertUpdaterResolutionLog(t, run.ResolutionLog, invalidPlan.Snapshot)
 	assertUpdaterCommandCounts(t, run.CIToolsLog, map[string]int{
-		"inspect-debian-bootstrap": 1,
-		"apply-debian-bootstrap":   1,
-		"check-pinned-inputs":      0,
+		"hadolint-manifest-checksum": 2,
+		"inspect-debian-bootstrap":   1,
+		"apply-debian-bootstrap":     1,
+		"check-pinned-inputs":        0,
 	})
 	if want := []string{"summary", "check"}; !reflect.DeepEqual(run.ProviderLog, want) {
 		t.Fatalf("provider updater command log = %q, want %q", run.ProviderLog, want)
@@ -209,105 +213,6 @@ func TestUpdateUpstreamPinsApplyFailureLeavesFixtureUnchanged(t *testing.T) {
 	after := snapshotUpdaterFixtureTree(t, fixtureRoot)
 	if !reflect.DeepEqual(after, before) {
 		t.Fatalf("failed update-upstream-pins.sh --apply mutated its fixture tree\nbefore: %#v\nafter:  %#v", before, after)
-	}
-}
-
-func TestUpdateUpstreamPinsRejectsMalformedHadolintChecksumManifest(t *testing.T) {
-	t.Parallel()
-
-	pins := readUpdaterFixturePins(t)
-	targetPlan := updaterTargetDebianPlan()
-	toolsRoot := t.TempDir()
-	citoolsPath := buildUpdaterFixtureCITools(t, toolsRoot)
-	goWrapperPath := writeUpdaterFixtureGoWrapper(t, toolsRoot)
-
-	testCases := []struct {
-		name      string
-		checksums string
-		assetName string
-	}{
-		{
-			name: "near match AMD64 asset name",
-			checksums: fmt.Sprintf(
-				"%s  *hadolint-linux-x86_64-extra\n%s  *hadolint-linux-arm64\n",
-				pins.HadolintAMD64SHA,
-				pins.HadolintARM64SHA,
-			),
-			assetName: "hadolint-linux-x86_64",
-		},
-		{
-			name: "duplicate binary marker asset name",
-			checksums: fmt.Sprintf(
-				"%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-arm64\n",
-				pins.HadolintAMD64SHA,
-				pins.HadolintAMD64SHA,
-				pins.HadolintARM64SHA,
-			),
-			assetName: "hadolint-linux-x86_64",
-		},
-		{
-			name: "mixed marker duplicate asset name",
-			checksums: fmt.Sprintf(
-				"%s  *hadolint-linux-x86_64\n%s  hadolint-linux-x86_64\n%s  *hadolint-linux-arm64\n",
-				pins.HadolintAMD64SHA,
-				pins.HadolintAMD64SHA,
-				pins.HadolintARM64SHA,
-			),
-			assetName: "hadolint-linux-x86_64",
-		},
-		{
-			name: "unmarked asset name",
-			checksums: fmt.Sprintf(
-				"%s  hadolint-linux-x86_64\n%s  *hadolint-linux-arm64\n",
-				pins.HadolintAMD64SHA,
-				pins.HadolintARM64SHA,
-			),
-			assetName: "hadolint-linux-x86_64",
-		},
-		{
-			name: "short digest",
-			checksums: fmt.Sprintf(
-				"%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-arm64\n",
-				pins.HadolintAMD64SHA[:63],
-				pins.HadolintARM64SHA,
-			),
-			assetName: "hadolint-linux-x86_64",
-		},
-		{
-			name: "non hexadecimal digest",
-			checksums: fmt.Sprintf(
-				"%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-arm64\n",
-				strings.Repeat("g", 64),
-				pins.HadolintARM64SHA,
-			),
-			assetName: "hadolint-linux-x86_64",
-		},
-		{
-			name: "near match ARM64 asset name",
-			checksums: fmt.Sprintf(
-				"%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-arm64-extra\n",
-				pins.HadolintAMD64SHA,
-				pins.HadolintARM64SHA,
-			),
-			assetName: "hadolint-linux-arm64",
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			fixtureRoot := writeUpdaterFixture(t, updaterManifestFromPlan(targetPlan), 0o640)
-			fixturePins := pins
-			fixturePins.HadolintChecksums = testCase.checksums
-
-			run := runUpdaterFixture(t, fixtureRoot, t.TempDir(), citoolsPath, goWrapperPath, fixturePins, targetPlan, "--check")
-			if run.Code != 1 {
-				t.Fatalf("updater exit code = %d, want 1\noutput:\n%s", run.Code, run.Output)
-			}
-			want := "Hadolint checksum manifest must contain exactly one 64-hex digest for " + testCase.assetName
-			if !strings.Contains(run.Output, want) {
-				t.Fatalf("updater output did not reject malformed Hadolint manifest:\n%s", run.Output)
-			}
-		})
 	}
 }
 
@@ -737,7 +642,7 @@ func assertUpdaterCommandCounts(t *testing.T, commands []string, expected map[st
 	}
 	for command := range counts {
 		switch command {
-		case "extract-dockerfile-arg", "inspect-debian-bootstrap", "apply-debian-bootstrap", "check-pinned-inputs":
+		case "extract-dockerfile-arg", "hadolint-manifest-checksum", "inspect-debian-bootstrap", "apply-debian-bootstrap", "check-pinned-inputs":
 		default:
 			t.Fatalf("unexpected real workcell-citools command %q; log=%q", command, commands)
 		}

--- a/internal/testkit/update_upstream_pins_check_test.go
+++ b/internal/testkit/update_upstream_pins_check_test.go
@@ -236,10 +236,29 @@ func TestUpdateUpstreamPinsRejectsMalformedHadolintChecksumManifest(t *testing.T
 			assetName: "hadolint-linux-x86_64",
 		},
 		{
-			name: "duplicate asset name",
+			name: "duplicate binary marker asset name",
 			checksums: fmt.Sprintf(
 				"%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-arm64\n",
 				pins.HadolintAMD64SHA,
+				pins.HadolintAMD64SHA,
+				pins.HadolintARM64SHA,
+			),
+			assetName: "hadolint-linux-x86_64",
+		},
+		{
+			name: "mixed marker duplicate asset name",
+			checksums: fmt.Sprintf(
+				"%s  *hadolint-linux-x86_64\n%s  hadolint-linux-x86_64\n%s  *hadolint-linux-arm64\n",
+				pins.HadolintAMD64SHA,
+				pins.HadolintAMD64SHA,
+				pins.HadolintARM64SHA,
+			),
+			assetName: "hadolint-linux-x86_64",
+		},
+		{
+			name: "unmarked asset name",
+			checksums: fmt.Sprintf(
+				"%s  hadolint-linux-x86_64\n%s  *hadolint-linux-arm64\n",
 				pins.HadolintAMD64SHA,
 				pins.HadolintARM64SHA,
 			),

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -160,6 +160,35 @@ github_release_asset_url() {
   printf '%s\n' "${asset_url}"
 }
 
+hadolint_checksum_from_manifest() {
+  local manifest="$1"
+  local asset_name="$2"
+  local checksum
+
+  if ! checksum="$(
+    awk -v asset_name="${asset_name}" '
+      $2 == "*" asset_name {
+        matches++
+        if (NF != 2 || length($1) != 64 || $1 !~ /^[[:xdigit:]]+$/) {
+          invalid = 1
+        }
+        digest = tolower($1)
+      }
+      END {
+        if (matches != 1 || invalid) {
+          exit 1
+        }
+        print digest
+      }
+    ' <<<"${manifest}"
+  )"; then
+    echo "Hadolint checksum manifest must contain exactly one 64-hex digest for ${asset_name}" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "${checksum}"
+}
+
 github_release_asset_api_url() {
   local release_json="$1"
   local asset_name="$2"
@@ -571,23 +600,25 @@ target_rust_version="$(
 target_cargo_rust_version="$(semver_major_minor "${target_rust_version}")"
 rustup_stable_toml="$(curl -q -fsSL "${CURL_API_GUARDS[@]}" 'https://static.rust-lang.org/rustup/release-stable.toml')"
 target_rustup_version="$(awk -F"'" '$1 == "version = " { print $2; exit }' <<<"${rustup_stable_toml}")"
-# SHA256 checksum bodies are at most ~80 bytes; cap the response so a
-# misbehaving CDN or compromised release host cannot serve a multi-GB
-# body that OOMs the maintainer's shell.  Mirrors the discipline applied
-# to the zizmor download below.
+# SHA256 checksum files and small manifests are bounded so a misbehaving CDN
+# or compromised release host cannot serve a multi-GB body that OOMs the
+# maintainer's shell. Mirrors the discipline applied to the zizmor download
+# below.
 CURL_CHECKSUM_GUARDS=(--max-time 60 --connect-timeout 15 --max-filesize 65536)
 target_rustup_sha_amd64="$(curl -q -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "https://static.rust-lang.org/rustup/archive/${target_rustup_version}/x86_64-unknown-linux-gnu/rustup-init.sha256" | awk '{print $1}')"
 target_rustup_sha_arm64="$(curl -q -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "https://static.rust-lang.org/rustup/archive/${target_rustup_version}/aarch64-unknown-linux-gnu/rustup-init.sha256" | awk '{print $1}')"
 
 hadolint_release_json="$(github_api_get 'https://api.github.com/repos/hadolint/hadolint/releases/latest')"
 target_hadolint_version="$(jq -r '.tag_name' <<<"${hadolint_release_json}")"
-hadolint_sha_amd64_url="$(github_release_asset_url "${hadolint_release_json}" 'hadolint-linux-x86_64.sha256')"
-hadolint_sha_arm64_url="$(github_release_asset_url "${hadolint_release_json}" 'hadolint-linux-arm64.sha256')"
+hadolint_checksums_url="$(github_release_asset_url "${hadolint_release_json}" 'checksums.sha256')"
+hadolint_checksums="$(
+  curl -q -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "${hadolint_checksums_url}"
+)"
 target_hadolint_sha_amd64="$(
-  curl -q -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "${hadolint_sha_amd64_url}" | awk '{print $1}'
+  hadolint_checksum_from_manifest "${hadolint_checksums}" 'hadolint-linux-x86_64'
 )"
 target_hadolint_sha_arm64="$(
-  curl -q -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "${hadolint_sha_arm64_url}" | awk '{print $1}'
+  hadolint_checksum_from_manifest "${hadolint_checksums}" 'hadolint-linux-arm64'
 )"
 
 buildx_release_json="$(github_api_get 'https://api.github.com/repos/docker/buildx/releases/latest')"

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -586,9 +586,11 @@ hadolint_checksums="$(
   curl -q -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "${hadolint_checksums_url}"
 )"
 target_hadolint_sha_amd64="$(
+  cd "${ROOT_DIR}" || exit
   printf '%s' "${hadolint_checksums}" | go run ./cmd/workcell-citools hadolint-manifest-checksum 'hadolint-linux-x86_64'
 )"
 target_hadolint_sha_arm64="$(
+  cd "${ROOT_DIR}" || exit
   printf '%s' "${hadolint_checksums}" | go run ./cmd/workcell-citools hadolint-manifest-checksum 'hadolint-linux-arm64'
 )"
 

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -160,38 +160,6 @@ github_release_asset_url() {
   printf '%s\n' "${asset_url}"
 }
 
-hadolint_checksum_from_manifest() {
-  local manifest="$1"
-  local asset_name="$2"
-  local checksum
-
-  if ! checksum="$(
-    awk -v asset_name="${asset_name}" '
-      ($2 == asset_name || $2 == "*" asset_name) {
-        candidates++
-        if (NF != 2 || length($1) != 64 || $1 !~ /^[0-9A-Fa-f]+$/) {
-          invalid = 1
-        }
-        if ($2 != "*" asset_name) {
-          invalid_marker = 1
-        }
-        digest = tolower($1)
-      }
-      END {
-        if (candidates != 1 || invalid || invalid_marker) {
-          exit 1
-        }
-        print digest
-      }
-    ' <<<"${manifest}"
-  )"; then
-    echo "Hadolint checksum manifest must contain exactly one 64-hex digest for ${asset_name}" >&2
-    exit 1
-  fi
-
-  printf '%s\n' "${checksum}"
-}
-
 github_release_asset_api_url() {
   local release_json="$1"
   local asset_name="$2"
@@ -618,10 +586,10 @@ hadolint_checksums="$(
   curl -q -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "${hadolint_checksums_url}"
 )"
 target_hadolint_sha_amd64="$(
-  hadolint_checksum_from_manifest "${hadolint_checksums}" 'hadolint-linux-x86_64'
+  printf '%s' "${hadolint_checksums}" | go run ./cmd/workcell-citools hadolint-manifest-checksum 'hadolint-linux-x86_64'
 )"
 target_hadolint_sha_arm64="$(
-  hadolint_checksum_from_manifest "${hadolint_checksums}" 'hadolint-linux-arm64'
+  printf '%s' "${hadolint_checksums}" | go run ./cmd/workcell-citools hadolint-manifest-checksum 'hadolint-linux-arm64'
 )"
 
 buildx_release_json="$(github_api_get 'https://api.github.com/repos/docker/buildx/releases/latest')"

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -167,15 +167,18 @@ hadolint_checksum_from_manifest() {
 
   if ! checksum="$(
     awk -v asset_name="${asset_name}" '
-      $2 == "*" asset_name {
-        matches++
-        if (NF != 2 || length($1) != 64 || $1 !~ /^[[:xdigit:]]+$/) {
+      ($2 == asset_name || $2 == "*" asset_name) {
+        candidates++
+        if (NF != 2 || length($1) != 64 || $1 !~ /^[0-9A-Fa-f]+$/) {
           invalid = 1
+        }
+        if ($2 != "*" asset_name) {
+          invalid_marker = 1
         }
         digest = tolower($1)
       }
       END {
-        if (matches != 1 || invalid) {
+        if (candidates != 1 || invalid || invalid_marker) {
           exit 1
         }
         print digest


### PR DESCRIPTION
## Summary

- switch the Hadolint updater to the aggregate checksums.sha256 manifest
- parse and validate the manifest in workcell-citools so shell remains thin dispatch glue
- require exactly one binary-marked 64-hex digest for each Linux asset
- anchor tool dispatch to the selected updater worktree even when invoked externally
- add Go regression coverage for malformed, ambiguous, oversized, near-match, and outside-repository invocation cases

## Validation

- exact pr-parity for head 774cebf2b19b397990d0d6a93d90dd5c1a992826 against main 1e7700aa25ecde949c1cda49244258589aba7533
- focused race tests and Go vet for metadatautil, workcell-citools, and updater fixtures
- bash syntax and shellcheck for scripts/update-upstream-pins.sh
- live updater check invoked from /private/tmp reached the full summary against Hadolint v2.15.1; it returned nonzero only because genuine upstream refreshes are available

## Review notes

The Go parser is fail closed, bounds manifest input to 64 KiB, and executes from ROOT_DIR.