### PR TITLE
Add sealed GitHub release publisher core

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -207,6 +208,23 @@ func runRelease(args []string) error {
 			return err
 		}
 		return json.NewEncoder(os.Stdout).Encode(policy)
+	case "publish":
+		if len(args) < 5 {
+			return releaseUsage()
+		}
+		releaseID, err := release.PublishGitHubRelease(
+			context.Background(),
+			os.Getenv("GITHUB_REPOSITORY"),
+			os.Getenv("GITHUB_TOKEN"),
+			args[1],
+			release.TagExpectation{ObjectSHA: args[2], PeeledCommitSHA: args[3]},
+			args[4:],
+		)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Uploaded sealed GitHub release assets and published %s (release id %d)\n", args[1], releaseID)
+		return nil
 	case "create-payload":
 		if len(args) != 3 {
 			return releaseUsage()
@@ -1097,6 +1115,7 @@ func releaseUsage() error {
 	return &cliexit.ExitCodeError{Code: 2, Message: `usage: workcell-hostutil release COMMAND [args...]
 commands:
   classify-tag TAG
+  publish TAG TAG_OBJECT_SHA PEELED_COMMIT_SHA ASSET...
   create-payload TAG OUTPUT
   publish-payload TAG OUTPUT
   validate-repository OWNER/REPO

--- a/internal/host/release/publisher.go
+++ b/internal/host/release/publisher.go
@@ -1,0 +1,689 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin || linux
+
+package release
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	githubAPIOrigin, githubUploadsOrigin         = "https://api.github.com", "https://uploads.github.com"
+	githubAPIVersion                             = "2022-11-28"
+	maxGitHubResponseBytes                       = 4 * 1024 * 1024
+	maxGitHubReleasePages, githubReleasePageSize = 100, 25
+	maxGitHubCredentialBytes                     = 4096
+)
+
+type githubHTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type githubReleasePublisher struct {
+	client     githubHTTPClient
+	afterStage func([]localAsset)
+}
+
+type githubReleaseAsset struct {
+	ID     *int64  `json:"id"`
+	Name   *string `json:"name"`
+	Size   *int64  `json:"size"`
+	State  *string `json:"state"`
+	Digest *string `json:"digest"`
+}
+
+type githubTagRecord struct {
+	Ref    string `json:"ref"`
+	SHA    string `json:"sha"`
+	Tag    string `json:"tag"`
+	Object struct {
+		Type string `json:"type"`
+		SHA  string `json:"sha"`
+	} `json:"object"`
+}
+
+// PublishGitHubRelease publishes the exact Workcell asset inventory through a
+// draft GitHub release. Every source is copied into an unlinked read-only stage
+// before the first API mutation, and uploads read only from those staged
+// handles.
+func PublishGitHubRelease(ctx context.Context, repository, token, tag string, expectedTag TagExpectation, paths []string) (releaseID int64, retErr error) {
+	client := &http.Client{
+		Timeout: 15 * time.Minute,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return errors.New("GitHub release publisher refuses HTTP redirects")
+		},
+	}
+	publisher := githubReleasePublisher{client: client}
+	return publisher.publish(ctx, repository, token, tag, expectedTag, paths)
+}
+
+func (publisher githubReleasePublisher) publish(ctx context.Context, repository, token, tag string, expectedTag TagExpectation, paths []string) (releaseID int64, retErr error) {
+	if ctx == nil {
+		return 0, inputErrorf("release publication context must not be nil")
+	}
+	if publisher.client == nil {
+		return 0, errors.New("GitHub release publisher HTTP client must not be nil")
+	}
+	if err := validateRepository(repository); err != nil {
+		return 0, err
+	}
+	if err := validateGitHubCredential(token); err != nil {
+		return 0, err
+	}
+	policy, err := ClassifyTag(tag)
+	if err != nil {
+		return 0, err
+	}
+	if err := validateTagExpectation(expectedTag); err != nil {
+		return 0, err
+	}
+
+	assets, err := inspectWorkcellAssets(tag, paths)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		retErr = errors.Join(retErr, closeLocalAssets(assets))
+	}()
+	if publisher.afterStage != nil {
+		publisher.afterStage(assets)
+	}
+	if err := publisher.verifyTagBinding(ctx, repository, token, tag, expectedTag); err != nil {
+		return 0, err
+	}
+
+	releaseRecord, found, err := publisher.findRelease(ctx, repository, token, tag)
+	if err != nil {
+		return 0, err
+	}
+	if !found {
+		releaseRecord, err = publisher.createDraft(ctx, repository, token, tag, policy)
+		if err != nil {
+			return 0, err
+		}
+	}
+	if err := validateMutableDraft(repository, tag, policy, releaseRecord); err != nil {
+		return 0, err
+	}
+	releaseID = *releaseRecord.ID
+
+	existingAssets, err := decodeReleaseAssets(releaseRecord)
+	if err != nil {
+		return 0, err
+	}
+	if err := validateExistingDraftAssets(tag, existingAssets); err != nil {
+		return 0, err
+	}
+	for _, existing := range existingAssets {
+		if err := publisher.deleteAsset(ctx, repository, token, *existing.ID); err != nil {
+			return 0, err
+		}
+	}
+	for index := range assets {
+		if err := publisher.uploadAsset(ctx, repository, token, releaseID, &assets[index]); err != nil {
+			return 0, err
+		}
+	}
+
+	beforePublish, err := publisher.getReleaseByID(ctx, repository, token, releaseID)
+	if err != nil {
+		return 0, err
+	}
+	if err := validateMutableDraft(repository, tag, policy, beforePublish); err != nil {
+		return 0, err
+	}
+	if err := validateExactUploadedAssets(beforePublish, assets); err != nil {
+		return 0, err
+	}
+	if err := publisher.verifyTagBinding(ctx, repository, token, tag, expectedTag); err != nil {
+		return 0, fmt.Errorf("reverify release tag before publication: %w", err)
+	}
+	if err := closeLocalAssets(assets); err != nil {
+		return 0, fmt.Errorf("close sealed release assets before publishing draft: %w", err)
+	}
+
+	published, err := publisher.publishDraft(ctx, repository, token, tag, policy, releaseID)
+	if err != nil {
+		return releaseID, fmt.Errorf(
+			"GitHub release %q publication state is ambiguous after the publish request for id %d; inspect the hosted release before any recovery action: %w",
+			tag,
+			releaseID,
+			err,
+		)
+	}
+	if err := validatePublishedRelease(repository, tag, policy, releaseID, published, assets); err != nil {
+		return releaseID, postPublicationVerificationError(tag, releaseID, err)
+	}
+
+	observed, err := publisher.getReleaseByID(ctx, repository, token, releaseID)
+	if err != nil {
+		return releaseID, postPublicationVerificationError(tag, releaseID, err)
+	}
+	if err := validatePublishedRelease(repository, tag, policy, releaseID, observed, assets); err != nil {
+		return releaseID, postPublicationVerificationError(tag, releaseID, err)
+	}
+	if err := publisher.validateLatest(ctx, repository, token, tag, policy, releaseID, assets); err != nil {
+		return releaseID, postPublicationVerificationError(tag, releaseID, err)
+	}
+	return releaseID, nil
+}
+
+func postPublicationVerificationError(tag string, releaseID int64, err error) error {
+	return fmt.Errorf(
+		"GitHub release %q was published as id %d, but final verification failed; do not rewrite or retry this tag, inspect the hosted state and recover with the next patch release if needed: %w",
+		tag,
+		releaseID,
+		err,
+	)
+}
+
+func validateGitHubCredential(token string) error {
+	if token == "" || len(token) > maxGitHubCredentialBytes || strings.TrimSpace(token) != token {
+		return inputErrorf("GITHUB_TOKEN must be a non-empty credential without surrounding whitespace")
+	}
+	for _, character := range token {
+		if character <= 0x20 || character == 0x7f {
+			return inputErrorf("GITHUB_TOKEN must not contain whitespace or control characters")
+		}
+	}
+	return nil
+}
+
+func (publisher githubReleasePublisher) verifyTagBinding(
+	ctx context.Context,
+	repository, token, tag string,
+	expected TagExpectation,
+) error {
+	tagBody, err := publisher.get(ctx, token, fmt.Sprintf(
+		"%s/repos/%s/git/tags/%s", githubAPIOrigin, repository, expected.ObjectSHA,
+	))
+	if err != nil {
+		return fmt.Errorf("read GitHub annotated tag %q: %w", tag, err)
+	}
+	var annotated githubTagRecord
+	if err := json.Unmarshal(tagBody, &annotated); err != nil {
+		return fmt.Errorf("decode GitHub annotated tag %q: %w", tag, err)
+	}
+	if annotated.SHA != expected.ObjectSHA || annotated.Tag != tag || annotated.Object.Type != "commit" {
+		return fmt.Errorf("GitHub annotated tag %q does not bind the expected tag object, tag name, and one commit", tag)
+	}
+	refBody, err := publisher.get(ctx, token, fmt.Sprintf(
+		"%s/repos/%s/git/ref/tags/%s", githubAPIOrigin, repository, url.PathEscape(tag),
+	))
+	if err != nil {
+		return fmt.Errorf("read GitHub release tag ref %q: %w", tag, err)
+	}
+	var reference githubTagRecord
+	if err := json.Unmarshal(refBody, &reference); err != nil {
+		return fmt.Errorf("decode GitHub release tag ref %q: %w", tag, err)
+	}
+	return validateTagBinding(tag, expected, GitHubTagBinding{
+		Ref:             reference.Ref,
+		ObjectType:      reference.Object.Type,
+		ObjectSHA:       reference.Object.SHA,
+		PeeledCommitSHA: annotated.Object.SHA,
+	})
+}
+
+func (publisher githubReleasePublisher) findRelease(ctx context.Context, repository, token, tag string) (listedRelease, bool, error) {
+	var match listedRelease
+	found := false
+	for page := 1; page <= maxGitHubReleasePages; page++ {
+		endpoint := fmt.Sprintf(
+			"%s/repos/%s/releases?per_page=%d&page=%d",
+			githubAPIOrigin,
+			repository,
+			githubReleasePageSize,
+			page,
+		)
+		body, err := publisher.get(ctx, token, endpoint)
+		if err != nil {
+			return listedRelease{}, false, fmt.Errorf("list GitHub releases page %d: %w", page, err)
+		}
+		var rawItems []json.RawMessage
+		if err := json.Unmarshal(body, &rawItems); err != nil {
+			return listedRelease{}, false, fmt.Errorf("decode GitHub releases page %d: %w", page, err)
+		}
+		if rawItems == nil {
+			return listedRelease{}, false, fmt.Errorf("decode GitHub releases page %d: expected JSON array, got null", page)
+		}
+		for index, raw := range rawItems {
+			var item listedRelease
+			if err := json.Unmarshal(raw, &item); err != nil {
+				return listedRelease{}, false, fmt.Errorf("decode GitHub release page %d item %d: %w", page, index, err)
+			}
+			if err := validateListedRelease(item); err != nil {
+				return listedRelease{}, false, fmt.Errorf("malformed GitHub release page %d item %d: %w", page, index, err)
+			}
+			if *item.TagName != tag {
+				continue
+			}
+			if found {
+				return listedRelease{}, false, fmt.Errorf("GitHub releases contain duplicate exact tag %q", tag)
+			}
+			match = item
+			found = true
+		}
+		if len(rawItems) < githubReleasePageSize {
+			return match, found, nil
+		}
+	}
+	return listedRelease{}, false, fmt.Errorf("GitHub release list exceeded the fail-closed limit of %d pages", maxGitHubReleasePages)
+}
+
+func (publisher githubReleasePublisher) createDraft(ctx context.Context, repository, token, tag string, policy TagPolicy) (listedRelease, error) {
+	payload := createPayload{
+		TagName:              tag,
+		Draft:                true,
+		Prerelease:           policy.Prerelease,
+		MakeLatest:           "false",
+		GenerateReleaseNotes: true,
+	}
+	body, err := publisher.requestJSON(
+		ctx,
+		token,
+		http.MethodPost,
+		fmt.Sprintf("%s/repos/%s/releases", githubAPIOrigin, repository),
+		payload,
+		http.StatusCreated,
+	)
+	if err != nil {
+		return listedRelease{}, fmt.Errorf("create GitHub draft release %q: %w", tag, err)
+	}
+	return decodeReleaseRecord(body, "created draft")
+}
+
+func (publisher githubReleasePublisher) deleteAsset(ctx context.Context, repository, token string, assetID int64) error {
+	endpoint := fmt.Sprintf("%s/repos/%s/releases/assets/%d", githubAPIOrigin, repository, assetID)
+	if _, err := publisher.request(ctx, token, http.MethodDelete, endpoint, "", nil, 0, http.StatusNoContent); err != nil {
+		return fmt.Errorf("delete existing GitHub release asset %d: %w", assetID, err)
+	}
+	return nil
+}
+
+func (publisher githubReleasePublisher) uploadAsset(ctx context.Context, repository, token string, releaseID int64, asset *localAsset) error {
+	if asset == nil {
+		return errors.New("release asset must not be nil")
+	}
+	reader, err := rewindLocalAssetReader(asset)
+	if err != nil {
+		return err
+	}
+	query := url.Values{"name": []string{asset.name}}
+	endpoint := fmt.Sprintf(
+		"%s/repos/%s/releases/%d/assets?%s",
+		githubUploadsOrigin,
+		repository,
+		releaseID,
+		query.Encode(),
+	)
+	body, err := publisher.request(
+		ctx,
+		token,
+		http.MethodPost,
+		endpoint,
+		"application/octet-stream",
+		reader,
+		asset.size,
+		http.StatusCreated,
+	)
+	if err != nil {
+		return fmt.Errorf("upload GitHub release asset %q: %w", asset.name, err)
+	}
+	var uploaded githubReleaseAsset
+	if err := json.Unmarshal(body, &uploaded); err != nil {
+		return fmt.Errorf("decode uploaded GitHub release asset %q: %w", asset.name, err)
+	}
+	return validateUploadedAsset(uploaded, asset)
+}
+
+func (publisher githubReleasePublisher) getReleaseByID(ctx context.Context, repository, token string, releaseID int64) (listedRelease, error) {
+	endpoint := fmt.Sprintf("%s/repos/%s/releases/%d", githubAPIOrigin, repository, releaseID)
+	body, err := publisher.get(ctx, token, endpoint)
+	if err != nil {
+		return listedRelease{}, fmt.Errorf("read GitHub release %d: %w", releaseID, err)
+	}
+	return decodeReleaseRecord(body, "release")
+}
+
+func (publisher githubReleasePublisher) publishDraft(ctx context.Context, repository, token, tag string, policy TagPolicy, releaseID int64) (listedRelease, error) {
+	makeLatest := "false"
+	if policy.MakeLatest {
+		makeLatest = "true"
+	}
+	payload := publishPayload{
+		Prerelease: policy.Prerelease,
+		MakeLatest: makeLatest,
+	}
+	body, err := publisher.requestJSON(
+		ctx,
+		token,
+		http.MethodPatch,
+		fmt.Sprintf("%s/repos/%s/releases/%d", githubAPIOrigin, repository, releaseID),
+		payload,
+		http.StatusOK,
+	)
+	if err != nil {
+		return listedRelease{}, fmt.Errorf("publish GitHub release %q: %w", tag, err)
+	}
+	return decodeReleaseRecord(body, "published release")
+}
+
+func (publisher githubReleasePublisher) validateLatest(
+	ctx context.Context,
+	repository, token, tag string,
+	policy TagPolicy,
+	releaseID int64,
+	assets []localAsset,
+) error {
+	endpoint := fmt.Sprintf("%s/repos/%s/releases/latest", githubAPIOrigin, repository)
+	expectedStatuses := []int{http.StatusOK}
+	if !policy.MakeLatest {
+		expectedStatuses = append(expectedStatuses, http.StatusNotFound)
+	}
+	body, status, err := publisher.requestOneOf(ctx, token, http.MethodGet, endpoint, "", nil, 0, expectedStatuses...)
+	if err != nil {
+		return fmt.Errorf("read GitHub latest release after publishing %q: %w", tag, err)
+	}
+	if status == http.StatusNotFound {
+		return nil
+	}
+	latest, err := decodeReleaseRecord(body, "latest release")
+	if err != nil {
+		return err
+	}
+	if policy.MakeLatest {
+		return validatePublishedRelease(repository, tag, policy, releaseID, latest, assets)
+	}
+	latestPolicy, err := ClassifyTag(*latest.TagName)
+	if err != nil || !latestPolicy.MakeLatest || *latest.Draft || *latest.Prerelease || !*latest.Immutable {
+		return fmt.Errorf("GitHub latest release tag %q is not an immutable published final release after release-candidate publication", *latest.TagName)
+	}
+	return validateReleaseUploadURL(repository, latest)
+}
+
+func (publisher githubReleasePublisher) requestJSON(ctx context.Context, token, method, endpoint string, payload any, expectedStatus int) ([]byte, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("encode GitHub release request: %w", err)
+	}
+	return publisher.request(ctx, token, method, endpoint, "application/json", bytes.NewReader(body), int64(len(body)), expectedStatus)
+}
+
+func (publisher githubReleasePublisher) get(ctx context.Context, token, endpoint string) ([]byte, error) {
+	return publisher.request(ctx, token, http.MethodGet, endpoint, "", nil, 0, http.StatusOK)
+}
+
+func (publisher githubReleasePublisher) request(
+	ctx context.Context,
+	token, method, endpoint, contentType string,
+	body io.Reader,
+	contentLength int64,
+	expectedStatus int,
+) ([]byte, error) {
+	responseBody, _, err := publisher.requestOneOf(ctx, token, method, endpoint, contentType, body, contentLength, expectedStatus)
+	return responseBody, err
+}
+
+func (publisher githubReleasePublisher) requestOneOf(
+	ctx context.Context,
+	token, method, endpoint, contentType string,
+	body io.Reader,
+	contentLength int64,
+	expectedStatuses ...int,
+) ([]byte, int, error) {
+	if err := validateGitHubRequestURL(endpoint); err != nil {
+		return nil, 0, err
+	}
+	request, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("create GitHub API request: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
+	if contentType != "" {
+		request.Header.Set("Content-Type", contentType)
+		request.ContentLength = contentLength
+	}
+	response, err := publisher.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("perform GitHub API request: %w", err)
+	}
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(response.Body, maxGitHubResponseBytes+1))
+	if err != nil {
+		return nil, response.StatusCode, fmt.Errorf("read GitHub API response: %w", err)
+	}
+	if len(responseBody) > maxGitHubResponseBytes {
+		return nil, response.StatusCode, fmt.Errorf("GitHub API response exceeds %d bytes", maxGitHubResponseBytes)
+	}
+	for _, expectedStatus := range expectedStatuses {
+		if response.StatusCode == expectedStatus {
+			return responseBody, response.StatusCode, nil
+		}
+	}
+	statusError := fmt.Sprintf("GitHub API returned HTTP %d, want %s", response.StatusCode, formatHTTPStatuses(expectedStatuses))
+	if message := githubAPIErrorMessage(responseBody); message != "" {
+		statusError += ": " + message
+	}
+	return nil, response.StatusCode, errors.New(statusError)
+}
+
+func validateGitHubRequestURL(endpoint string) error {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("parse GitHub API endpoint: %w", err)
+	}
+	if parsed.Scheme != "https" || parsed.User != nil || parsed.Fragment != "" {
+		return errors.New("GitHub API endpoint must be an HTTPS URL without userinfo or fragment")
+	}
+	if parsed.Host != "api.github.com" && parsed.Host != "uploads.github.com" {
+		return fmt.Errorf("GitHub API endpoint host %q is not trusted", parsed.Host)
+	}
+	return nil
+}
+
+func formatHTTPStatuses(statuses []int) string {
+	formatted := make([]string, 0, len(statuses))
+	for _, status := range statuses {
+		formatted = append(formatted, strconv.Itoa(status))
+	}
+	return strings.Join(formatted, " or ")
+}
+
+func githubAPIErrorMessage(body []byte) string {
+	var response struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return ""
+	}
+	message := strings.TrimSpace(response.Message)
+	message = strings.Map(func(character rune) rune {
+		if unicode.IsControl(character) {
+			return ' '
+		}
+		return character
+	}, message)
+	const maxMessageRunes = 512
+	runes := []rune(message)
+	if len(runes) > maxMessageRunes {
+		message = string(runes[:maxMessageRunes]) + "…"
+	}
+	return strings.Join(strings.Fields(message), " ")
+}
+
+func decodeReleaseRecord(body []byte, state string) (listedRelease, error) {
+	var record listedRelease
+	if err := json.Unmarshal(body, &record); err != nil {
+		return listedRelease{}, fmt.Errorf("decode GitHub %s response: %w", state, err)
+	}
+	if err := validateListedRelease(record); err != nil {
+		return listedRelease{}, fmt.Errorf("malformed GitHub %s response: %w", state, err)
+	}
+	return record, nil
+}
+
+func validateMutableDraft(repository, tag string, policy TagPolicy, record listedRelease) error {
+	if err := validateListedRelease(record); err != nil {
+		return err
+	}
+	if *record.TagName != tag {
+		return fmt.Errorf("GitHub draft release tag_name = %q, want %q", *record.TagName, tag)
+	}
+	if !*record.Draft {
+		if *record.Immutable {
+			return fmt.Errorf("GitHub release %q is already published and immutable; patch main and cut the next patch release instead", tag)
+		}
+		return fmt.Errorf("GitHub release %q is already published; Workcell only uploads assets to draft releases, so patch main and cut the next patch release instead", tag)
+	}
+	if *record.Immutable {
+		return fmt.Errorf("GitHub draft release %q unexpectedly reports immutable = true", tag)
+	}
+	if *record.Prerelease != policy.Prerelease {
+		return fmt.Errorf("GitHub draft release prerelease = %t, want %t for %s tag %q", *record.Prerelease, policy.Prerelease, policy.Kind, tag)
+	}
+	return validateReleaseUploadURL(repository, record)
+}
+
+func decodeReleaseAssets(record listedRelease) ([]githubReleaseAsset, error) {
+	if record.Assets == nil {
+		return nil, errors.New("GitHub release response is missing assets")
+	}
+	assets := make([]githubReleaseAsset, 0, len(*record.Assets))
+	for index, raw := range *record.Assets {
+		var asset githubReleaseAsset
+		if err := json.Unmarshal(raw, &asset); err != nil {
+			return nil, fmt.Errorf("decode GitHub release asset %d: %w", index, err)
+		}
+		if asset.ID == nil || *asset.ID <= 0 || asset.Name == nil || *asset.Name == "" {
+			return nil, fmt.Errorf("GitHub release asset %d is missing a valid id or name", index)
+		}
+		assets = append(assets, asset)
+	}
+	return assets, nil
+}
+
+func validateExistingDraftAssets(tag string, assets []githubReleaseAsset) error {
+	expected := make(map[string]struct{}, maxReleaseAssetCount)
+	for _, name := range expectedWorkcellAssetNames(tag) {
+		expected[name] = struct{}{}
+	}
+	seenNames := make(map[string]struct{}, len(assets))
+	seenIDs := make(map[int64]struct{}, len(assets))
+	for _, asset := range assets {
+		if _, ok := expected[*asset.Name]; !ok {
+			return fmt.Errorf("GitHub draft release contains unexpected asset %q; remove or disposition it before publication", *asset.Name)
+		}
+		if _, duplicate := seenNames[*asset.Name]; duplicate {
+			return fmt.Errorf("GitHub draft release contains duplicate asset name %q", *asset.Name)
+		}
+		if _, duplicate := seenIDs[*asset.ID]; duplicate {
+			return fmt.Errorf("GitHub draft release contains duplicate asset id %d", *asset.ID)
+		}
+		seenNames[*asset.Name] = struct{}{}
+		seenIDs[*asset.ID] = struct{}{}
+	}
+	return nil
+}
+
+func validateUploadedAsset(uploaded githubReleaseAsset, expected *localAsset) error {
+	if uploaded.ID == nil || *uploaded.ID <= 0 {
+		return fmt.Errorf("uploaded GitHub release asset %q is missing a valid id", expected.name)
+	}
+	if uploaded.Name == nil {
+		return fmt.Errorf("uploaded GitHub release asset is missing name, want %q", expected.name)
+	}
+	if *uploaded.Name != expected.name {
+		return fmt.Errorf("uploaded GitHub release asset name = %q, want %q", *uploaded.Name, expected.name)
+	}
+	if uploaded.Size == nil {
+		return fmt.Errorf("uploaded GitHub release asset %q is missing size, want %d", expected.name, expected.size)
+	}
+	if *uploaded.Size != expected.size {
+		return fmt.Errorf("uploaded GitHub release asset %q size = %d, want %d", expected.name, *uploaded.Size, expected.size)
+	}
+	if uploaded.State == nil {
+		return fmt.Errorf("uploaded GitHub release asset %q is missing state, want uploaded", expected.name)
+	}
+	if *uploaded.State != "uploaded" {
+		return fmt.Errorf("uploaded GitHub release asset %q state = %q, want uploaded", expected.name, *uploaded.State)
+	}
+	wantDigest := "sha256:" + expected.sha256
+	if uploaded.Digest == nil {
+		return fmt.Errorf("uploaded GitHub release asset %q is missing digest, want %q", expected.name, wantDigest)
+	}
+	if *uploaded.Digest != wantDigest {
+		return fmt.Errorf("uploaded GitHub release asset %q digest = %q, want %q", expected.name, *uploaded.Digest, wantDigest)
+	}
+	return nil
+}
+
+func validateExactUploadedAssets(record listedRelease, expected []localAsset) error {
+	observed, err := decodeReleaseAssets(record)
+	if err != nil {
+		return err
+	}
+	if len(observed) != len(expected) {
+		return fmt.Errorf("GitHub release contains %d assets, want exact staged inventory of %d", len(observed), len(expected))
+	}
+	byName := make(map[string]githubReleaseAsset, len(observed))
+	for _, asset := range observed {
+		if _, duplicate := byName[*asset.Name]; duplicate {
+			return fmt.Errorf("GitHub release contains duplicate asset name %q", *asset.Name)
+		}
+		byName[*asset.Name] = asset
+	}
+	for index := range expected {
+		asset, ok := byName[expected[index].name]
+		if !ok {
+			return fmt.Errorf("GitHub release is missing staged asset %q", expected[index].name)
+		}
+		if err := validateUploadedAsset(asset, &expected[index]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validatePublishedRelease(
+	repository, tag string,
+	policy TagPolicy,
+	releaseID int64,
+	record listedRelease,
+	assets []localAsset,
+) error {
+	if err := validateListedRelease(record); err != nil {
+		return err
+	}
+	if *record.ID != releaseID || *record.TagName != tag {
+		return fmt.Errorf("published GitHub release identity is id %d tag %q, want id %d tag %q", *record.ID, *record.TagName, releaseID, tag)
+	}
+	if *record.Draft {
+		return fmt.Errorf("published GitHub release %q still reports draft = true", tag)
+	}
+	if *record.Prerelease != policy.Prerelease {
+		return fmt.Errorf("published GitHub release prerelease = %t, want %t for %s tag %q", *record.Prerelease, policy.Prerelease, policy.Kind, tag)
+	}
+	if !*record.Immutable {
+		return fmt.Errorf("published GitHub release %q is not immutable", tag)
+	}
+	if err := validateReleaseUploadURL(repository, record); err != nil {
+		return fmt.Errorf("published %w", err)
+	}
+	return validateExactUploadedAssets(record, assets)
+}

--- a/internal/host/release/publisher.go
+++ b/internal/host/release/publisher.go
@@ -151,9 +151,18 @@ func (publisher githubReleasePublisher) publish(ctx context.Context, repository,
 	if err := publisher.verifyTagBinding(ctx, repository, token, tag, expectedTag); err != nil {
 		return 0, fmt.Errorf("reverify release tag before publication: %w", err)
 	}
-	immutableReleasesEndpoint := fmt.Sprintf("%s/repos/%s/immutable-releases", githubAPIOrigin, repository)
-	if _, _, err := publisher.requestOneOf(ctx, token, http.MethodGet, immutableReleasesEndpoint, "", nil, 0, http.StatusOK); err != nil {
+	immutableReleasesBody, _, err := publisher.requestOneOf(ctx, token, http.MethodGet, fmt.Sprintf("%s/repos/%s/immutable-releases", githubAPIOrigin, repository), "", nil, 0, http.StatusOK)
+	if err != nil {
 		return 0, fmt.Errorf("verify immutable releases before publication: %w", err)
+	}
+	var immutableReleases struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.Unmarshal(immutableReleasesBody, &immutableReleases); err != nil {
+		return 0, fmt.Errorf("decode GitHub immutable releases response: %w", err)
+	}
+	if !immutableReleases.Enabled {
+		return 0, errors.New("GitHub immutable releases response did not report enabled = true")
 	}
 	if err := closeLocalAssets(assets); err != nil {
 		return 0, fmt.Errorf("close sealed release assets before publishing draft: %w", err)

--- a/internal/host/release/publisher.go
+++ b/internal/host/release/publisher.go
@@ -177,6 +177,9 @@ func (publisher githubReleasePublisher) publish(ctx context.Context, repository,
 			err,
 		)
 	}
+	if err := publisher.verifyTagBinding(ctx, repository, token, tag, expectedTag); err != nil {
+		return releaseID, postPublicationVerificationError(tag, releaseID, err)
+	}
 	if err := validatePublishedRelease(repository, tag, policy, releaseID, published, assets); err != nil {
 		return releaseID, postPublicationVerificationError(tag, releaseID, err)
 	}

--- a/internal/host/release/publisher.go
+++ b/internal/host/release/publisher.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	githubAPIOrigin, githubUploadsOrigin         = "https://api.github.com", "https://uploads.github.com"
-	githubAPIVersion                             = "2022-11-28"
+	githubAPIVersion                             = "2026-03-10"
 	maxGitHubResponseBytes                       = 4 * 1024 * 1024
 	maxGitHubReleasePages, githubReleasePageSize = 100, 25
 	maxGitHubCredentialBytes                     = 4096
@@ -150,6 +150,10 @@ func (publisher githubReleasePublisher) publish(ctx context.Context, repository,
 	}
 	if err := publisher.verifyTagBinding(ctx, repository, token, tag, expectedTag); err != nil {
 		return 0, fmt.Errorf("reverify release tag before publication: %w", err)
+	}
+	immutableReleasesEndpoint := fmt.Sprintf("%s/repos/%s/immutable-releases", githubAPIOrigin, repository)
+	if _, _, err := publisher.requestOneOf(ctx, token, http.MethodGet, immutableReleasesEndpoint, "", nil, 0, http.StatusOK); err != nil {
+		return 0, fmt.Errorf("verify immutable releases before publication: %w", err)
 	}
 	if err := closeLocalAssets(assets); err != nil {
 		return 0, fmt.Errorf("close sealed release assets before publishing draft: %w", err)
@@ -673,14 +677,8 @@ func validatePublishedRelease(
 	if *record.ID != releaseID || *record.TagName != tag {
 		return fmt.Errorf("published GitHub release identity is id %d tag %q, want id %d tag %q", *record.ID, *record.TagName, releaseID, tag)
 	}
-	if *record.Draft {
-		return fmt.Errorf("published GitHub release %q still reports draft = true", tag)
-	}
-	if *record.Prerelease != policy.Prerelease {
-		return fmt.Errorf("published GitHub release prerelease = %t, want %t for %s tag %q", *record.Prerelease, policy.Prerelease, policy.Kind, tag)
-	}
-	if !*record.Immutable {
-		return fmt.Errorf("published GitHub release %q is not immutable", tag)
+	if err := validatePublishedReleaseItem(tag, record); err != nil {
+		return err
 	}
 	if err := validateReleaseUploadURL(repository, record); err != nil {
 		return fmt.Errorf("published %w", err)

--- a/internal/host/release/publisher.go
+++ b/internal/host/release/publisher.go
@@ -177,9 +177,6 @@ func (publisher githubReleasePublisher) publish(ctx context.Context, repository,
 			err,
 		)
 	}
-	if err := publisher.verifyTagBinding(ctx, repository, token, tag, expectedTag); err != nil {
-		return releaseID, postPublicationVerificationError(tag, releaseID, err)
-	}
 	if err := validatePublishedRelease(repository, tag, policy, releaseID, published, assets); err != nil {
 		return releaseID, postPublicationVerificationError(tag, releaseID, err)
 	}
@@ -192,6 +189,9 @@ func (publisher githubReleasePublisher) publish(ctx context.Context, repository,
 		return releaseID, postPublicationVerificationError(tag, releaseID, err)
 	}
 	if err := publisher.validateLatest(ctx, repository, token, tag, policy, releaseID, assets); err != nil {
+		return releaseID, postPublicationVerificationError(tag, releaseID, err)
+	}
+	if err := publisher.verifyTagBinding(ctx, repository, token, tag, expectedTag); err != nil {
 		return releaseID, postPublicationVerificationError(tag, releaseID, err)
 	}
 	return releaseID, nil

--- a/internal/host/release/publisher_test.go
+++ b/internal/host/release/publisher_test.go
@@ -23,19 +23,19 @@ import (
 )
 
 type publisherClient struct {
-	t                                                              *testing.T
-	tag, repository, token                                         string
-	releaseID                                                      int64
-	stagingDone                                                    *bool
-	draft, immutable, existing                                     bool
-	assets                                                         []githubReleaseAsset
-	uploaded                                                       map[string][]byte
-	latestStatus                                                   int
-	latestBody                                                     any
-	beforePublish                                                  func()
-	failFinalVerification, failTagRebind, disableImmutableReleases bool
-	bindingReads                                                   int
-	requests                                                       []string
+	t                                *testing.T
+	tag, repository, token           string
+	releaseID                        int64
+	stagingDone                      *bool
+	draft, immutable, existing       bool
+	assets                           []githubReleaseAsset
+	uploaded                         map[string][]byte
+	latestStatus                     int
+	latestBody                       any
+	beforePublish                    func()
+	disableImmutableReleases         bool
+	failTagRebindAfter, bindingReads int
+	requests                         []string
 }
 
 func (client *publisherClient) Do(request *http.Request) (*http.Response, error) {
@@ -65,7 +65,7 @@ func (client *publisherClient) Do(request *http.Request) (*http.Response, error)
 	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == tagRefPath:
 		client.bindingReads++
 		objectSHA := testTagObjectSHA
-		if client.failTagRebind && client.bindingReads > 1 {
+		if client.failTagRebindAfter > 0 && client.bindingReads > client.failTagRebindAfter {
 			objectSHA = strings.Repeat("c", 40)
 		}
 		return jsonResponse(http.StatusOK, map[string]any{"ref": "refs/tags/" + client.tag, "object": map[string]any{"type": "tag", "sha": objectSHA}}), nil
@@ -113,9 +113,6 @@ func (client *publisherClient) Do(request *http.Request) (*http.Response, error)
 		client.assets = append(client.assets, asset)
 		return jsonResponse(http.StatusCreated, asset), nil
 	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == releasePath:
-		if client.failFinalVerification && !client.draft {
-			client.immutable = false
-		}
 		return jsonResponse(http.StatusOK, client.record()), nil
 	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == immutableReleasesPath:
 		if client.disableImmutableReleases {
@@ -239,7 +236,7 @@ func TestPublisherSealsFinalAndReleaseCandidateAssets(t *testing.T) {
 			wantSuffix := "GET api.github.com/repos/example/workcell/git/tags/" + testTagObjectSHA +
 				"\nGET api.github.com/repos/example/workcell/git/ref/tags/" + tc.tag +
 				"\nGET api.github.com/repos/example/workcell/immutable-releases" +
-				"\nPATCH api.github.com/repos/example/workcell/releases/42\nGET api.github.com/repos/example/workcell/releases/42\nGET api.github.com/repos/example/workcell/releases/latest"
+				"\nPATCH api.github.com/repos/example/workcell/releases/42\nGET api.github.com/repos/example/workcell/git/tags/" + testTagObjectSHA + "\nGET api.github.com/repos/example/workcell/git/ref/tags/" + tc.tag + "\nGET api.github.com/repos/example/workcell/releases/42\nGET api.github.com/repos/example/workcell/releases/latest"
 			if !strings.HasSuffix(strings.Join(client.requests, "\n"), wantSuffix) {
 				t.Fatalf("requests = %q, want final verification suffix %q", client.requests, wantSuffix)
 			}
@@ -247,15 +244,15 @@ func TestPublisherSealsFinalAndReleaseCandidateAssets(t *testing.T) {
 	}
 }
 
-func TestPublisherPostPublicationFailureRequiresNextPatchRecovery(t *testing.T) {
+func TestPublisherMovedTagAfterPublicationRequiresNextPatchRecovery(t *testing.T) {
 	paths, _ := writeAssets(t, "v1.0.0")
 	client := &publisherClient{
 		t: t, tag: "v1.0.0", repository: "example/workcell", token: "token", releaseID: 42,
-		assets: []githubReleaseAsset{}, uploaded: make(map[string][]byte), failFinalVerification: true,
+		assets: []githubReleaseAsset{}, uploaded: make(map[string][]byte), failTagRebindAfter: 2,
 	}
-	_, err := (githubReleasePublisher{client: client}).publish(context.Background(), client.repository, client.token, client.tag, TagExpectation{ObjectSHA: testTagObjectSHA, PeeledCommitSHA: testTagCommitSHA}, paths)
-	for _, fragment := range []string{"was published", "do not rewrite or retry this tag", "next patch release"} {
-		if err == nil || !strings.Contains(err.Error(), fragment) {
+	id, err := (githubReleasePublisher{client: client}).publish(context.Background(), client.repository, client.token, client.tag, TagExpectation{ObjectSHA: testTagObjectSHA, PeeledCommitSHA: testTagCommitSHA}, paths)
+	for _, fragment := range []string{"was published", "do not rewrite or retry this tag", "next patch release", "annotated tag object SHA"} {
+		if id != 42 || err == nil || !strings.Contains(err.Error(), fragment) {
 			t.Fatalf("publish() error = %v, want %q", err, fragment)
 		}
 	}
@@ -264,7 +261,7 @@ func TestPublisherPostPublicationFailureRequiresNextPatchRecovery(t *testing.T) 
 func TestPublisherRejectsMovedTagBeforePublication(t *testing.T) {
 	paths, _ := writeAssets(t, "v1.0.0")
 	client := &publisherClient{t: t, tag: "v1.0.0", repository: "example/workcell", token: "token", releaseID: 42,
-		assets: []githubReleaseAsset{}, uploaded: make(map[string][]byte), failTagRebind: true}
+		assets: []githubReleaseAsset{}, uploaded: make(map[string][]byte), failTagRebindAfter: 1}
 	_, err := (githubReleasePublisher{client: client}).publish(context.Background(), client.repository, client.token, client.tag, TagExpectation{ObjectSHA: testTagObjectSHA, PeeledCommitSHA: testTagCommitSHA}, paths)
 	if err == nil || !strings.Contains(err.Error(), "reverify release tag") || slices.Contains(client.requests, "PATCH api.github.com/repos/example/workcell/releases/42") {
 		t.Fatalf("publish() error=%v requests=%q", err, client.requests)

--- a/internal/host/release/publisher_test.go
+++ b/internal/host/release/publisher_test.go
@@ -1,0 +1,484 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin || linux
+
+package release
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type publisherClient struct {
+	t                          *testing.T
+	tag, repository, token     string
+	releaseID                  int64
+	stagingDone                *bool
+	draft, immutable, existing bool
+	assets                     []githubReleaseAsset
+	uploaded                   map[string][]byte
+	latestStatus               int
+	latestBody                 any
+	beforePublish              func()
+	failFinalVerification      bool
+	failTagRebind              bool
+	bindingReads               int
+	requests                   []string
+}
+
+func (client *publisherClient) Do(request *http.Request) (*http.Response, error) {
+	client.t.Helper()
+	if client.stagingDone != nil && !*client.stagingDone {
+		client.t.Fatal("GitHub request started before every asset was staged")
+	}
+	if request.Header.Get("Authorization") != "Bearer "+client.token {
+		client.t.Fatalf("unexpected authorization header")
+	}
+	client.requests = append(client.requests, request.Method+" "+request.URL.Host+request.URL.Path)
+	policy, err := ClassifyTag(client.tag)
+	if err != nil {
+		client.t.Fatal(err)
+	}
+	makeLatest := "false"
+	if policy.MakeLatest {
+		makeLatest = "true"
+	}
+	listPath := "/repos/" + client.repository + "/releases"
+	releasePath := fmt.Sprintf("%s/%d", listPath, client.releaseID)
+	tagRefPath := "/repos/" + client.repository + "/git/ref/tags/" + client.tag
+	switch {
+	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == "/repos/"+client.repository+"/git/tags/"+testTagObjectSHA:
+		return tagObjectResponse(client.tag, testTagObjectSHA, testTagCommitSHA), nil
+	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == tagRefPath:
+		client.bindingReads++
+		objectSHA := testTagObjectSHA
+		if client.failTagRebind && client.bindingReads > 1 {
+			objectSHA = strings.Repeat("c", 40)
+		}
+		return tagRefResponse(client.tag, objectSHA), nil
+	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == listPath:
+		if request.URL.Query().Get("per_page") != strconv.Itoa(githubReleasePageSize) || request.URL.Query().Get("page") != "1" {
+			client.t.Fatalf("unexpected release-list query %q", request.URL.RawQuery)
+		}
+		if client.existing {
+			return jsonResponse(http.StatusOK, []any{client.record()}), nil
+		}
+		return jsonResponse(http.StatusOK, []any{}), nil
+	case request.Method == http.MethodPost && request.URL.Host == "api.github.com" && request.URL.Path == listPath:
+		var payload createPayload
+		decodeJSONRequest(client.t, request, &payload)
+		if payload.TagName != client.tag || !payload.Draft || payload.Prerelease != policy.Prerelease || payload.MakeLatest != "false" || !payload.GenerateReleaseNotes {
+			client.t.Fatalf("unexpected create payload %#v", payload)
+		}
+		client.draft, client.immutable = true, false
+		return jsonResponse(http.StatusCreated, client.record()), nil
+	case request.Method == http.MethodDelete && request.URL.Host == "api.github.com" && strings.HasPrefix(request.URL.Path, listPath+"/assets/"):
+		id, parseErr := strconv.ParseInt(strings.TrimPrefix(request.URL.Path, listPath+"/assets/"), 10, 64)
+		if parseErr != nil {
+			client.t.Fatal(parseErr)
+		}
+		for index := range client.assets {
+			if *client.assets[index].ID == id {
+				client.assets = append(client.assets[:index], client.assets[index+1:]...)
+				return jsonResponse(http.StatusNoContent, nil), nil
+			}
+		}
+		client.t.Fatalf("delete requested unknown asset %d", id)
+	case request.Method == http.MethodPost && request.URL.Host == "uploads.github.com" && request.URL.Path == releasePath+"/assets":
+		name := request.URL.Query().Get("name")
+		content, readErr := io.ReadAll(request.Body)
+		if readErr != nil {
+			return nil, readErr
+		}
+		if name == "" || request.ContentLength != int64(len(content)) {
+			client.t.Fatalf("invalid upload name=%q length=%d", name, request.ContentLength)
+		}
+		client.uploaded[name] = append([]byte(nil), content...)
+		digest := sha256.Sum256(content)
+		id, size, state, digestText := int64(len(client.assets)+100), int64(len(content)), "uploaded", "sha256:"+hex.EncodeToString(digest[:])
+		asset := githubReleaseAsset{ID: &id, Name: &name, Size: &size, State: &state, Digest: &digestText}
+		client.assets = append(client.assets, asset)
+		return jsonResponse(http.StatusCreated, asset), nil
+	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == releasePath:
+		if client.failFinalVerification && !client.draft {
+			client.immutable = false
+		}
+		return jsonResponse(http.StatusOK, client.record()), nil
+	case request.Method == http.MethodPatch && request.URL.Host == "api.github.com" && request.URL.Path == releasePath:
+		if client.beforePublish != nil {
+			client.beforePublish()
+		}
+		var payload publishPayload
+		decodeJSONRequest(client.t, request, &payload)
+		if payload.Draft || payload.Prerelease != policy.Prerelease || payload.MakeLatest != makeLatest {
+			client.t.Fatalf("unexpected publish payload %#v", payload)
+		}
+		client.draft, client.immutable = false, true
+		return jsonResponse(http.StatusOK, client.record()), nil
+	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == listPath+"/latest":
+		if client.latestStatus != 0 {
+			return jsonResponse(client.latestStatus, client.latestBody), nil
+		}
+		return jsonResponse(http.StatusOK, client.record()), nil
+	default:
+		client.t.Fatalf("unexpected GitHub request %s %s", request.Method, request.URL)
+	}
+	return nil, nil
+}
+
+func (client *publisherClient) record() map[string]any {
+	policy, err := ClassifyTag(client.tag)
+	if err != nil {
+		client.t.Fatal(err)
+	}
+	return releaseRecord(client.repository, client.tag, client.releaseID, client.draft, policy.Prerelease, client.immutable, client.assets)
+}
+
+func releaseRecord(repository, tag string, id int64, draft, prerelease, immutable bool, assets any) map[string]any {
+	return map[string]any{
+		"id": id, "upload_url": fmt.Sprintf("%s/repos/%s/releases/%d/assets{?name,label}", githubUploadsOrigin, repository, id),
+		"tag_name": tag, "draft": draft, "prerelease": prerelease, "immutable": immutable, "assets": assets,
+	}
+}
+
+func jsonResponse(status int, value any) *http.Response {
+	body, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return &http.Response{StatusCode: status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(string(body)))}
+}
+
+func tagRefResponse(tag, objectSHA string) *http.Response {
+	return jsonResponse(http.StatusOK, map[string]any{"ref": "refs/tags/" + tag, "object": map[string]any{"type": "tag", "sha": objectSHA}})
+}
+
+func tagObjectResponse(tag, objectSHA, commitSHA string) *http.Response {
+	return jsonResponse(http.StatusOK, map[string]any{"sha": objectSHA, "tag": tag, "object": map[string]any{"type": "commit", "sha": commitSHA}})
+}
+
+func decodeJSONRequest(t *testing.T, request *http.Request, destination any) {
+	t.Helper()
+	if request.Header.Get("Content-Type") != "application/json" {
+		t.Fatalf("unexpected content type %q", request.Header.Get("Content-Type"))
+	}
+	if err := json.NewDecoder(request.Body).Decode(destination); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeAssets(t *testing.T, tag string) ([]string, map[string][]byte) {
+	t.Helper()
+	paths, content := make([]string, 0, maxReleaseAssetCount), make(map[string][]byte, maxReleaseAssetCount)
+	root := t.TempDir()
+	for index, name := range expectedWorkcellAssetNames(tag) {
+		value := []byte(fmt.Sprintf("sealed asset %02d: %s\n", index, name))
+		path := filepath.Join(root, name)
+		if err := os.WriteFile(path, value, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		paths, content[name] = append(paths, path), value
+	}
+	return paths, content
+}
+
+func publisherTagExpectation() TagExpectation {
+	return TagExpectation{ObjectSHA: testTagObjectSHA, PeeledCommitSHA: testTagCommitSHA}
+}
+
+func TestPublisherSealsFinalAndReleaseCandidateAssets(t *testing.T) {
+	const repository, token = "example/workcell", "github_pat_test"
+	for _, tc := range []struct {
+		name, tag  string
+		latestCode int
+		latestBody any
+	}{
+		{name: "final", tag: "v1.0.0"},
+		{name: "rc without final", tag: "v1.0.0-rc.3", latestCode: http.StatusNotFound, latestBody: map[string]string{"message": "Not Found"}},
+		{name: "rc preserves final", tag: "v1.0.0-rc.3", latestCode: http.StatusOK, latestBody: releaseRecord(repository, "v0.9.0", 41, false, false, true, []any{})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paths, original := writeAssets(t, tc.tag)
+			staged := false
+			client := &publisherClient{
+				t: t, tag: tc.tag, repository: repository, token: token, releaseID: 42,
+				stagingDone: &staged, assets: []githubReleaseAsset{}, uploaded: make(map[string][]byte),
+				latestStatus: tc.latestCode, latestBody: tc.latestBody,
+			}
+			var handles []localAsset
+			client.beforePublish = func() {
+				for index := range handles {
+					if _, err := handles[index].content.Seek(0, io.SeekStart); err == nil {
+						t.Fatalf("sealed asset %q remains open before publication", handles[index].name)
+					}
+				}
+			}
+			publisher := githubReleasePublisher{client: client, afterStage: func(assets []localAsset) {
+				handles = append([]localAsset(nil), assets...)
+				for _, path := range paths {
+					if err := os.WriteFile(path, []byte("MUTATED SOURCE\n"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				staged = true
+			}}
+			if id, err := publisher.publish(context.Background(), repository, token, tc.tag, publisherTagExpectation(), paths); err != nil || id != 42 {
+				t.Fatalf("publish() = id %d error %v", id, err)
+			}
+			for name, want := range original {
+				if got := client.uploaded[name]; string(got) != string(want) {
+					t.Fatalf("uploaded %q = %q, want sealed bytes %q", name, got, want)
+				}
+			}
+			if client.draft || !client.immutable {
+				t.Fatalf("finished draft=%t immutable=%t", client.draft, client.immutable)
+			}
+			wantSuffix := "GET api.github.com/repos/example/workcell/git/tags/" + testTagObjectSHA +
+				"\nGET api.github.com/repos/example/workcell/git/ref/tags/" + tc.tag +
+				"\nPATCH api.github.com/repos/example/workcell/releases/42\nGET api.github.com/repos/example/workcell/releases/42\nGET api.github.com/repos/example/workcell/releases/latest"
+			if !strings.HasSuffix(strings.Join(client.requests, "\n"), wantSuffix) {
+				t.Fatalf("requests = %q, want final verification suffix %q", client.requests, wantSuffix)
+			}
+		})
+	}
+}
+
+func TestPublisherPostPublicationFailureRequiresNextPatchRecovery(t *testing.T) {
+	paths, _ := writeAssets(t, "v1.0.0")
+	client := &publisherClient{
+		t: t, tag: "v1.0.0", repository: "example/workcell", token: "token", releaseID: 42,
+		assets: []githubReleaseAsset{}, uploaded: make(map[string][]byte), failFinalVerification: true,
+	}
+	_, err := (githubReleasePublisher{client: client}).publish(context.Background(), client.repository, client.token, client.tag, publisherTagExpectation(), paths)
+	for _, fragment := range []string{"was published", "do not rewrite or retry this tag", "next patch release"} {
+		if err == nil || !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("publish() error = %v, want %q", err, fragment)
+		}
+	}
+}
+
+func TestPublisherRejectsMovedTagBeforePublication(t *testing.T) {
+	paths, _ := writeAssets(t, "v1.0.0")
+	client := &publisherClient{t: t, tag: "v1.0.0", repository: "example/workcell", token: "token", releaseID: 42,
+		assets: []githubReleaseAsset{}, uploaded: make(map[string][]byte), failTagRebind: true}
+	_, err := (githubReleasePublisher{client: client}).publish(context.Background(), client.repository, client.token, client.tag, publisherTagExpectation(), paths)
+	if err == nil || !strings.Contains(err.Error(), "reverify release tag") || slices.Contains(client.requests, "PATCH api.github.com/repos/example/workcell/releases/42") {
+		t.Fatalf("publish() error=%v requests=%q", err, client.requests)
+	}
+}
+
+func TestPublisherReplacesExpectedStaleDraftAsset(t *testing.T) {
+	const tag, repository = "v1.0.0", "example/workcell"
+	paths, _ := writeAssets(t, tag)
+	id, name, size, state := int64(99), expectedWorkcellAssetNames(tag)[0], int64(0), "starter"
+	client := &publisherClient{
+		t: t, tag: tag, repository: repository, token: "token", releaseID: 42, draft: true, existing: true,
+		assets: []githubReleaseAsset{{ID: &id, Name: &name, Size: &size, State: &state}}, uploaded: make(map[string][]byte),
+	}
+	if _, err := (githubReleasePublisher{client: client}).publish(context.Background(), repository, "token", tag, publisherTagExpectation(), paths); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(client.requests, "DELETE api.github.com/repos/example/workcell/releases/assets/99") {
+		t.Fatalf("requests = %q, want stale asset deletion", client.requests)
+	}
+}
+
+type staticClient struct {
+	requests int
+	status   int
+	body     any
+}
+
+func (client *staticClient) Do(request *http.Request) (*http.Response, error) {
+	client.requests++
+	if marker := "/git/ref/tags/"; strings.Contains(request.URL.Path, marker) {
+		tag := strings.TrimPrefix(request.URL.Path[strings.Index(request.URL.Path, marker):], marker)
+		return tagRefResponse(tag, testTagObjectSHA), nil
+	}
+	if strings.HasSuffix(request.URL.Path, "/git/tags/"+testTagObjectSHA) {
+		tag := "v1.0.0"
+		return tagObjectResponse(tag, testTagObjectSHA, testTagCommitSHA), nil
+	}
+	return jsonResponse(client.status, client.body), nil
+}
+
+type listClient struct {
+	t     *testing.T
+	pages map[int][]any
+}
+
+func (client *listClient) Do(request *http.Request) (*http.Response, error) {
+	client.t.Helper()
+	page, err := strconv.Atoi(request.URL.Query().Get("page"))
+	if err != nil || request.Method != http.MethodGet || request.URL.Query().Get("per_page") != strconv.Itoa(githubReleasePageSize) {
+		client.t.Fatalf("unexpected list request %s", request.URL)
+	}
+	return jsonResponse(http.StatusOK, client.pages[page]), nil
+}
+
+func fullPage(repository string) []any {
+	page := make([]any, githubReleasePageSize)
+	for index := range page {
+		page[index] = releaseRecord(repository, fmt.Sprintf("unrelated-%d", index), int64(index+1), true, false, false, []any{})
+	}
+	return page
+}
+
+func TestFindReleasePaginationAndDuplicateTags(t *testing.T) {
+	const repository, tag = "example/workcell", "v1.0.0"
+	t.Run("second page match", func(t *testing.T) {
+		client := &listClient{t: t, pages: map[int][]any{1: fullPage(repository), 2: {releaseRecord(repository, tag, 4242, true, false, false, []any{})}}}
+		record, found, err := (githubReleasePublisher{client: client}).findRelease(context.Background(), repository, "token", tag)
+		if err != nil || !found || record.ID == nil || *record.ID != 4242 {
+			t.Fatalf("findRelease() = found %t record %#v error %v", found, record, err)
+		}
+	})
+	t.Run("duplicate across pages", func(t *testing.T) {
+		first := fullPage(repository)
+		first[0] = releaseRecord(repository, tag, 41, true, false, false, []any{})
+		client := &listClient{t: t, pages: map[int][]any{1: first, 2: {releaseRecord(repository, tag, 42, true, false, false, []any{})}}}
+		if _, _, err := (githubReleasePublisher{client: client}).findRelease(context.Background(), repository, "token", tag); err == nil || !strings.Contains(err.Error(), "duplicate exact tag") {
+			t.Fatalf("findRelease() error = %v, want duplicate rejection", err)
+		}
+	})
+}
+
+func TestPublisherRejectsUnsafeStateBeforeMutation(t *testing.T) {
+	const repository, tag = "example/workcell", "v1.0.0"
+	paths, _ := writeAssets(t, tag)
+	for _, tc := range []struct {
+		name   string
+		record map[string]any
+		want   string
+	}{
+		{name: "unexpected asset", record: releaseRecord(repository, tag, 42, true, false, false, []any{map[string]any{"id": 100, "name": "unreviewed.bin"}}), want: "unexpected asset"},
+		{name: "published mutable", record: releaseRecord(repository, tag, 42, false, false, false, []any{}), want: "already published"},
+		{name: "published immutable", record: releaseRecord(repository, tag, 42, false, false, true, []any{}), want: "already published"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &staticClient{status: http.StatusOK, body: []any{tc.record}}
+			_, err := (githubReleasePublisher{client: client}).publish(context.Background(), repository, "token", tag, publisherTagExpectation(), paths)
+			if err == nil || !strings.Contains(err.Error(), tc.want) || client.requests != 3 {
+				t.Fatalf("publish() error=%v requests=%d", err, client.requests)
+			}
+		})
+	}
+}
+
+func TestPublisherRejectsInputsBeforeNetwork(t *testing.T) {
+	paths, _ := writeAssets(t, "v1.0.0")
+	for _, tc := range []struct {
+		name, tag string
+		paths     []string
+		want      string
+	}{
+		{name: "missing asset", tag: "v1.0.0", paths: paths[:len(paths)-1], want: "missing required basename"},
+		{name: "unsupported tag", tag: "v1.0.0-beta.1", want: "unsupported release tag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &staticClient{status: http.StatusInternalServerError}
+			_, err := (githubReleasePublisher{client: client}).publish(context.Background(), "example/workcell", "token", tc.tag, publisherTagExpectation(), tc.paths)
+			if err == nil || !strings.Contains(err.Error(), tc.want) || client.requests != 0 {
+				t.Fatalf("publish() error=%v requests=%d", err, client.requests)
+			}
+		})
+	}
+}
+
+func TestGitHubRequestURLTrust(t *testing.T) {
+	for _, endpoint := range []string{"http://api.github.com/x", "https://api.github.com.evil.test/x", "https://user@api.github.com/x", "https://api.github.com/x#fragment", "://bad"} {
+		if err := validateGitHubRequestURL(endpoint); err == nil {
+			t.Fatalf("validateGitHubRequestURL(%q) succeeded", endpoint)
+		}
+	}
+	for _, endpoint := range []string{"https://api.github.com/x", "https://uploads.github.com/x"} {
+		if err := validateGitHubRequestURL(endpoint); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestGitHubCredentialPolicy(t *testing.T) {
+	for _, credential := range []string{"", " token", "token ", "token\nvalue", strings.Repeat("x", maxGitHubCredentialBytes+1)} {
+		if err := validateGitHubCredential(credential); !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("validateGitHubCredential(%q) error = %v, want invalid input", credential, err)
+		}
+	}
+}
+
+func TestMutableDraftBindsRepositoryUploadURL(t *testing.T) {
+	record := releaseRecord("attacker/workcell", "v1.0.0", 42, true, false, false, []any{})
+	body, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := decodeReleaseRecord(body, "test draft")
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy, err := ClassifyTag("v1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateReleaseUploadURL("ATTACKER/WORKCELL", decoded); err != nil {
+		t.Fatal(err)
+	}
+	confusable := strings.Replace(*decoded.UploadURL, "uploads", "uploadſ", 1)
+	decoded.UploadURL = &confusable
+	if err := validateReleaseUploadURL("ATTACKER/WORKCELL", decoded); err == nil {
+		t.Fatal("Unicode-confusable upload host accepted")
+	}
+	if err := validateMutableDraft("example/workcell", "v1.0.0", policy, decoded); err == nil || !strings.Contains(err.Error(), "upload_url") {
+		t.Fatalf("validateMutableDraft() error = %v, want repository-bound upload URL rejection", err)
+	}
+}
+
+func TestUploadedAssetRequiresExactDigest(t *testing.T) {
+	content := []byte("sealed bytes")
+	digest := sha256.Sum256(content)
+	expected := localAsset{name: "asset.bin", size: int64(len(content)), sha256: hex.EncodeToString(digest[:])}
+	id, name, size, state := int64(1), expected.name, expected.size, "uploaded"
+	for _, digest := range []*string{nil, pointer(""), pointer("sha256:" + strings.Repeat("0", 64))} {
+		if err := validateUploadedAsset(githubReleaseAsset{ID: &id, Name: &name, Size: &size, State: &state, Digest: digest}, &expected); err == nil || !strings.Contains(err.Error(), "digest") {
+			t.Fatalf("validateUploadedAsset() error = %v", err)
+		}
+	}
+}
+
+func TestGitHubErrorsAreBoundedAndSanitized(t *testing.T) {
+	message := strings.Repeat("unsafe\n", 100)
+	body, err := json.Marshal(map[string]string{"message": message})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := githubAPIErrorMessage(body); got == "" || strings.ContainsAny(got, "\r\n\t") || len([]rune(got)) > 513 {
+		t.Fatalf("githubAPIErrorMessage() = %q", got)
+	}
+	client := &staticClient{status: http.StatusForbidden, body: map[string]string{"message": "release permission denied"}}
+	_, err = (githubReleasePublisher{client: client}).request(context.Background(), "token", http.MethodGet, githubAPIOrigin+"/repos/example/workcell/releases", "", nil, 0, http.StatusOK)
+	if err == nil || !strings.Contains(err.Error(), "HTTP 403") || !strings.Contains(err.Error(), "release permission denied") {
+		t.Fatalf("request() error = %v", err)
+	}
+}
+
+func TestUnsupportedTagIsInvalidInput(t *testing.T) {
+	_, err := (githubReleasePublisher{client: &staticClient{}}).publish(context.Background(), "example/workcell", "token", "beta", TagExpectation{}, nil)
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("publish() error = %v, want invalid input", err)
+	}
+}
+
+func pointer(value string) *string { return &value }

--- a/internal/host/release/publisher_test.go
+++ b/internal/host/release/publisher_test.go
@@ -23,20 +23,19 @@ import (
 )
 
 type publisherClient struct {
-	t                          *testing.T
-	tag, repository, token     string
-	releaseID                  int64
-	stagingDone                *bool
-	draft, immutable, existing bool
-	assets                     []githubReleaseAsset
-	uploaded                   map[string][]byte
-	latestStatus               int
-	latestBody                 any
-	beforePublish              func()
-	failFinalVerification      bool
-	failTagRebind              bool
-	bindingReads               int
-	requests                   []string
+	t                                                              *testing.T
+	tag, repository, token                                         string
+	releaseID                                                      int64
+	stagingDone                                                    *bool
+	draft, immutable, existing                                     bool
+	assets                                                         []githubReleaseAsset
+	uploaded                                                       map[string][]byte
+	latestStatus                                                   int
+	latestBody                                                     any
+	beforePublish                                                  func()
+	failFinalVerification, failTagRebind, disableImmutableReleases bool
+	bindingReads                                                   int
+	requests                                                       []string
 }
 
 func (client *publisherClient) Do(request *http.Request) (*http.Response, error) {
@@ -44,8 +43,8 @@ func (client *publisherClient) Do(request *http.Request) (*http.Response, error)
 	if client.stagingDone != nil && !*client.stagingDone {
 		client.t.Fatal("GitHub request started before every asset was staged")
 	}
-	if request.Header.Get("Authorization") != "Bearer "+client.token {
-		client.t.Fatalf("unexpected authorization header")
+	if request.Header.Get("Authorization") != "Bearer "+client.token || request.Header.Get("X-GitHub-Api-Version") != githubAPIVersion {
+		client.t.Fatalf("unexpected GitHub request headers")
 	}
 	client.requests = append(client.requests, request.Method+" "+request.URL.Host+request.URL.Path)
 	policy, err := ClassifyTag(client.tag)
@@ -59,6 +58,7 @@ func (client *publisherClient) Do(request *http.Request) (*http.Response, error)
 	listPath := "/repos/" + client.repository + "/releases"
 	releasePath := fmt.Sprintf("%s/%d", listPath, client.releaseID)
 	tagRefPath := "/repos/" + client.repository + "/git/ref/tags/" + client.tag
+	immutableReleasesPath := "/repos/" + client.repository + "/immutable-releases"
 	switch {
 	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == "/repos/"+client.repository+"/git/tags/"+testTagObjectSHA:
 		return tagObjectResponse(client.tag, testTagObjectSHA, testTagCommitSHA), nil
@@ -117,6 +117,11 @@ func (client *publisherClient) Do(request *http.Request) (*http.Response, error)
 			client.immutable = false
 		}
 		return jsonResponse(http.StatusOK, client.record()), nil
+	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == immutableReleasesPath:
+		if client.disableImmutableReleases {
+			return jsonResponse(http.StatusNotFound, map[string]string{"message": "Not Found"}), nil
+		}
+		return jsonResponse(http.StatusOK, map[string]bool{"enabled": true}), nil
 	case request.Method == http.MethodPatch && request.URL.Host == "api.github.com" && request.URL.Path == releasePath:
 		if client.beforePublish != nil {
 			client.beforePublish()
@@ -148,10 +153,7 @@ func (client *publisherClient) record() map[string]any {
 }
 
 func releaseRecord(repository, tag string, id int64, draft, prerelease, immutable bool, assets any) map[string]any {
-	return map[string]any{
-		"id": id, "upload_url": fmt.Sprintf("%s/repos/%s/releases/%d/assets{?name,label}", githubUploadsOrigin, repository, id),
-		"tag_name": tag, "draft": draft, "prerelease": prerelease, "immutable": immutable, "assets": assets,
-	}
+	return map[string]any{"id": id, "upload_url": fmt.Sprintf("%s/repos/%s/releases/%d/assets{?name,label}", githubUploadsOrigin, repository, id), "tag_name": tag, "draft": draft, "prerelease": prerelease, "immutable": immutable, "assets": assets}
 }
 
 func jsonResponse(status int, value any) *http.Response {
@@ -195,10 +197,6 @@ func writeAssets(t *testing.T, tag string) ([]string, map[string][]byte) {
 	return paths, content
 }
 
-func publisherTagExpectation() TagExpectation {
-	return TagExpectation{ObjectSHA: testTagObjectSHA, PeeledCommitSHA: testTagCommitSHA}
-}
-
 func TestPublisherSealsFinalAndReleaseCandidateAssets(t *testing.T) {
 	const repository, token = "example/workcell", "github_pat_test"
 	for _, tc := range []struct {
@@ -235,7 +233,7 @@ func TestPublisherSealsFinalAndReleaseCandidateAssets(t *testing.T) {
 				}
 				staged = true
 			}}
-			if id, err := publisher.publish(context.Background(), repository, token, tc.tag, publisherTagExpectation(), paths); err != nil || id != 42 {
+			if id, err := publisher.publish(context.Background(), repository, token, tc.tag, TagExpectation{ObjectSHA: testTagObjectSHA, PeeledCommitSHA: testTagCommitSHA}, paths); err != nil || id != 42 {
 				t.Fatalf("publish() = id %d error %v", id, err)
 			}
 			for name, want := range original {
@@ -248,6 +246,7 @@ func TestPublisherSealsFinalAndReleaseCandidateAssets(t *testing.T) {
 			}
 			wantSuffix := "GET api.github.com/repos/example/workcell/git/tags/" + testTagObjectSHA +
 				"\nGET api.github.com/repos/example/workcell/git/ref/tags/" + tc.tag +
+				"\nGET api.github.com/repos/example/workcell/immutable-releases" +
 				"\nPATCH api.github.com/repos/example/workcell/releases/42\nGET api.github.com/repos/example/workcell/releases/42\nGET api.github.com/repos/example/workcell/releases/latest"
 			if !strings.HasSuffix(strings.Join(client.requests, "\n"), wantSuffix) {
 				t.Fatalf("requests = %q, want final verification suffix %q", client.requests, wantSuffix)
@@ -262,7 +261,7 @@ func TestPublisherPostPublicationFailureRequiresNextPatchRecovery(t *testing.T) 
 		t: t, tag: "v1.0.0", repository: "example/workcell", token: "token", releaseID: 42,
 		assets: []githubReleaseAsset{}, uploaded: make(map[string][]byte), failFinalVerification: true,
 	}
-	_, err := (githubReleasePublisher{client: client}).publish(context.Background(), client.repository, client.token, client.tag, publisherTagExpectation(), paths)
+	_, err := (githubReleasePublisher{client: client}).publish(context.Background(), client.repository, client.token, client.tag, TagExpectation{ObjectSHA: testTagObjectSHA, PeeledCommitSHA: testTagCommitSHA}, paths)
 	for _, fragment := range []string{"was published", "do not rewrite or retry this tag", "next patch release"} {
 		if err == nil || !strings.Contains(err.Error(), fragment) {
 			t.Fatalf("publish() error = %v, want %q", err, fragment)
@@ -274,8 +273,18 @@ func TestPublisherRejectsMovedTagBeforePublication(t *testing.T) {
 	paths, _ := writeAssets(t, "v1.0.0")
 	client := &publisherClient{t: t, tag: "v1.0.0", repository: "example/workcell", token: "token", releaseID: 42,
 		assets: []githubReleaseAsset{}, uploaded: make(map[string][]byte), failTagRebind: true}
-	_, err := (githubReleasePublisher{client: client}).publish(context.Background(), client.repository, client.token, client.tag, publisherTagExpectation(), paths)
+	_, err := (githubReleasePublisher{client: client}).publish(context.Background(), client.repository, client.token, client.tag, TagExpectation{ObjectSHA: testTagObjectSHA, PeeledCommitSHA: testTagCommitSHA}, paths)
 	if err == nil || !strings.Contains(err.Error(), "reverify release tag") || slices.Contains(client.requests, "PATCH api.github.com/repos/example/workcell/releases/42") {
+		t.Fatalf("publish() error=%v requests=%q", err, client.requests)
+	}
+}
+
+func TestPublisherRejectsDisabledImmutableReleasesBeforePublication(t *testing.T) {
+	paths, _ := writeAssets(t, "v1.0.0")
+	client := &publisherClient{t: t, tag: "v1.0.0", repository: "example/workcell", token: "token", releaseID: 42,
+		assets: []githubReleaseAsset{}, uploaded: make(map[string][]byte), disableImmutableReleases: true}
+	_, err := (githubReleasePublisher{client: client}).publish(context.Background(), client.repository, client.token, client.tag, TagExpectation{ObjectSHA: testTagObjectSHA, PeeledCommitSHA: testTagCommitSHA}, paths)
+	if err == nil || !strings.Contains(err.Error(), "HTTP 404") || slices.Contains(client.requests, "PATCH api.github.com/repos/example/workcell/releases/42") {
 		t.Fatalf("publish() error=%v requests=%q", err, client.requests)
 	}
 }
@@ -288,7 +297,7 @@ func TestPublisherReplacesExpectedStaleDraftAsset(t *testing.T) {
 		t: t, tag: tag, repository: repository, token: "token", releaseID: 42, draft: true, existing: true,
 		assets: []githubReleaseAsset{{ID: &id, Name: &name, Size: &size, State: &state}}, uploaded: make(map[string][]byte),
 	}
-	if _, err := (githubReleasePublisher{client: client}).publish(context.Background(), repository, "token", tag, publisherTagExpectation(), paths); err != nil {
+	if _, err := (githubReleasePublisher{client: client}).publish(context.Background(), repository, "token", tag, TagExpectation{ObjectSHA: testTagObjectSHA, PeeledCommitSHA: testTagCommitSHA}, paths); err != nil {
 		t.Fatal(err)
 	}
 	if !slices.Contains(client.requests, "DELETE api.github.com/repos/example/workcell/releases/assets/99") {
@@ -297,9 +306,8 @@ func TestPublisherReplacesExpectedStaleDraftAsset(t *testing.T) {
 }
 
 type staticClient struct {
-	requests int
-	status   int
-	body     any
+	requests, status int
+	body             any
 }
 
 func (client *staticClient) Do(request *http.Request) (*http.Response, error) {
@@ -309,8 +317,7 @@ func (client *staticClient) Do(request *http.Request) (*http.Response, error) {
 		return tagRefResponse(tag, testTagObjectSHA), nil
 	}
 	if strings.HasSuffix(request.URL.Path, "/git/tags/"+testTagObjectSHA) {
-		tag := "v1.0.0"
-		return tagObjectResponse(tag, testTagObjectSHA, testTagCommitSHA), nil
+		return tagObjectResponse("v1.0.0", testTagObjectSHA, testTagCommitSHA), nil
 	}
 	return jsonResponse(client.status, client.body), nil
 }
@@ -370,7 +377,7 @@ func TestPublisherRejectsUnsafeStateBeforeMutation(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			client := &staticClient{status: http.StatusOK, body: []any{tc.record}}
-			_, err := (githubReleasePublisher{client: client}).publish(context.Background(), repository, "token", tag, publisherTagExpectation(), paths)
+			_, err := (githubReleasePublisher{client: client}).publish(context.Background(), repository, "token", tag, TagExpectation{ObjectSHA: testTagObjectSHA, PeeledCommitSHA: testTagCommitSHA}, paths)
 			if err == nil || !strings.Contains(err.Error(), tc.want) || client.requests != 3 {
 				t.Fatalf("publish() error=%v requests=%d", err, client.requests)
 			}
@@ -390,7 +397,7 @@ func TestPublisherRejectsInputsBeforeNetwork(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			client := &staticClient{status: http.StatusInternalServerError}
-			_, err := (githubReleasePublisher{client: client}).publish(context.Background(), "example/workcell", "token", tc.tag, publisherTagExpectation(), tc.paths)
+			_, err := (githubReleasePublisher{client: client}).publish(context.Background(), "example/workcell", "token", tc.tag, TagExpectation{ObjectSHA: testTagObjectSHA, PeeledCommitSHA: testTagCommitSHA}, tc.paths)
 			if err == nil || !strings.Contains(err.Error(), tc.want) || client.requests != 0 {
 				t.Fatalf("publish() error=%v requests=%d", err, client.requests)
 			}
@@ -471,13 +478,6 @@ func TestGitHubErrorsAreBoundedAndSanitized(t *testing.T) {
 	_, err = (githubReleasePublisher{client: client}).request(context.Background(), "token", http.MethodGet, githubAPIOrigin+"/repos/example/workcell/releases", "", nil, 0, http.StatusOK)
 	if err == nil || !strings.Contains(err.Error(), "HTTP 403") || !strings.Contains(err.Error(), "release permission denied") {
 		t.Fatalf("request() error = %v", err)
-	}
-}
-
-func TestUnsupportedTagIsInvalidInput(t *testing.T) {
-	_, err := (githubReleasePublisher{client: &staticClient{}}).publish(context.Background(), "example/workcell", "token", "beta", TagExpectation{}, nil)
-	if !errors.Is(err, ErrInvalidInput) {
-		t.Fatalf("publish() error = %v, want invalid input", err)
 	}
 }
 

--- a/internal/host/release/publisher_test.go
+++ b/internal/host/release/publisher_test.go
@@ -61,14 +61,14 @@ func (client *publisherClient) Do(request *http.Request) (*http.Response, error)
 	immutableReleasesPath := "/repos/" + client.repository + "/immutable-releases"
 	switch {
 	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == "/repos/"+client.repository+"/git/tags/"+testTagObjectSHA:
-		return tagObjectResponse(client.tag, testTagObjectSHA, testTagCommitSHA), nil
+		return jsonResponse(http.StatusOK, map[string]any{"sha": testTagObjectSHA, "tag": client.tag, "object": map[string]any{"type": "commit", "sha": testTagCommitSHA}}), nil
 	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == tagRefPath:
 		client.bindingReads++
 		objectSHA := testTagObjectSHA
 		if client.failTagRebind && client.bindingReads > 1 {
 			objectSHA = strings.Repeat("c", 40)
 		}
-		return tagRefResponse(client.tag, objectSHA), nil
+		return jsonResponse(http.StatusOK, map[string]any{"ref": "refs/tags/" + client.tag, "object": map[string]any{"type": "tag", "sha": objectSHA}}), nil
 	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == listPath:
 		if request.URL.Query().Get("per_page") != strconv.Itoa(githubReleasePageSize) || request.URL.Query().Get("page") != "1" {
 			client.t.Fatalf("unexpected release-list query %q", request.URL.RawQuery)
@@ -119,7 +119,7 @@ func (client *publisherClient) Do(request *http.Request) (*http.Response, error)
 		return jsonResponse(http.StatusOK, client.record()), nil
 	case request.Method == http.MethodGet && request.URL.Host == "api.github.com" && request.URL.Path == immutableReleasesPath:
 		if client.disableImmutableReleases {
-			return jsonResponse(http.StatusNotFound, map[string]string{"message": "Not Found"}), nil
+			return jsonResponse(http.StatusOK, map[string]bool{"enabled": false}), nil
 		}
 		return jsonResponse(http.StatusOK, map[string]bool{"enabled": true}), nil
 	case request.Method == http.MethodPatch && request.URL.Host == "api.github.com" && request.URL.Path == releasePath:
@@ -162,14 +162,6 @@ func jsonResponse(status int, value any) *http.Response {
 		panic(err)
 	}
 	return &http.Response{StatusCode: status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(string(body)))}
-}
-
-func tagRefResponse(tag, objectSHA string) *http.Response {
-	return jsonResponse(http.StatusOK, map[string]any{"ref": "refs/tags/" + tag, "object": map[string]any{"type": "tag", "sha": objectSHA}})
-}
-
-func tagObjectResponse(tag, objectSHA, commitSHA string) *http.Response {
-	return jsonResponse(http.StatusOK, map[string]any{"sha": objectSHA, "tag": tag, "object": map[string]any{"type": "commit", "sha": commitSHA}})
 }
 
 func decodeJSONRequest(t *testing.T, request *http.Request, destination any) {
@@ -284,7 +276,7 @@ func TestPublisherRejectsDisabledImmutableReleasesBeforePublication(t *testing.T
 	client := &publisherClient{t: t, tag: "v1.0.0", repository: "example/workcell", token: "token", releaseID: 42,
 		assets: []githubReleaseAsset{}, uploaded: make(map[string][]byte), disableImmutableReleases: true}
 	_, err := (githubReleasePublisher{client: client}).publish(context.Background(), client.repository, client.token, client.tag, TagExpectation{ObjectSHA: testTagObjectSHA, PeeledCommitSHA: testTagCommitSHA}, paths)
-	if err == nil || !strings.Contains(err.Error(), "HTTP 404") || slices.Contains(client.requests, "PATCH api.github.com/repos/example/workcell/releases/42") {
+	if err == nil || !strings.Contains(err.Error(), "enabled = true") || slices.Contains(client.requests, "PATCH api.github.com/repos/example/workcell/releases/42") {
 		t.Fatalf("publish() error=%v requests=%q", err, client.requests)
 	}
 }
@@ -314,10 +306,10 @@ func (client *staticClient) Do(request *http.Request) (*http.Response, error) {
 	client.requests++
 	if marker := "/git/ref/tags/"; strings.Contains(request.URL.Path, marker) {
 		tag := strings.TrimPrefix(request.URL.Path[strings.Index(request.URL.Path, marker):], marker)
-		return tagRefResponse(tag, testTagObjectSHA), nil
+		return jsonResponse(http.StatusOK, map[string]any{"ref": "refs/tags/" + tag, "object": map[string]any{"type": "tag", "sha": testTagObjectSHA}}), nil
 	}
 	if strings.HasSuffix(request.URL.Path, "/git/tags/"+testTagObjectSHA) {
-		return tagObjectResponse("v1.0.0", testTagObjectSHA, testTagCommitSHA), nil
+		return jsonResponse(http.StatusOK, map[string]any{"sha": testTagObjectSHA, "tag": "v1.0.0", "object": map[string]any{"type": "commit", "sha": testTagCommitSHA}}), nil
 	}
 	return jsonResponse(client.status, client.body), nil
 }

--- a/internal/host/release/publisher_test.go
+++ b/internal/host/release/publisher_test.go
@@ -236,7 +236,7 @@ func TestPublisherSealsFinalAndReleaseCandidateAssets(t *testing.T) {
 			wantSuffix := "GET api.github.com/repos/example/workcell/git/tags/" + testTagObjectSHA +
 				"\nGET api.github.com/repos/example/workcell/git/ref/tags/" + tc.tag +
 				"\nGET api.github.com/repos/example/workcell/immutable-releases" +
-				"\nPATCH api.github.com/repos/example/workcell/releases/42\nGET api.github.com/repos/example/workcell/git/tags/" + testTagObjectSHA + "\nGET api.github.com/repos/example/workcell/git/ref/tags/" + tc.tag + "\nGET api.github.com/repos/example/workcell/releases/42\nGET api.github.com/repos/example/workcell/releases/latest"
+				"\nPATCH api.github.com/repos/example/workcell/releases/42\nGET api.github.com/repos/example/workcell/releases/42\nGET api.github.com/repos/example/workcell/releases/latest\nGET api.github.com/repos/example/workcell/git/tags/" + testTagObjectSHA + "\nGET api.github.com/repos/example/workcell/git/ref/tags/" + tc.tag
 			if !strings.HasSuffix(strings.Join(client.requests, "\n"), wantSuffix) {
 				t.Fatalf("requests = %q, want final verification suffix %q", client.requests, wantSuffix)
 			}

--- a/internal/host/release/release.go
+++ b/internal/host/release/release.go
@@ -203,10 +203,16 @@ func validateReleaseUploadURL(repository string, item listedRelease) error {
 		repository,
 		*item.ID,
 	)
-	if *item.UploadURL != want {
+	if !equalASCIIFold(*item.UploadURL, want) {
 		return fmt.Errorf("GitHub release upload_url = %q, want %q", *item.UploadURL, want)
 	}
 	return nil
+}
+
+func equalASCIIFold(left, right string) bool {
+	nonASCII := func(character rune) bool { return character > 0x7f }
+	return strings.IndexFunc(left, nonASCII) < 0 &&
+		strings.IndexFunc(right, nonASCII) < 0 && strings.EqualFold(left, right)
 }
 
 // ValidateGitHubDraftRelease validates an exact-tag mutable draft and its


### PR DESCRIPTION
## Summary

- add a dormant, sealed GitHub release publisher core with immutable tag-object and peeled-commit binding
- seal release assets before the first API mutation and verify exact inventory, digest, size, and release state
- keep the production release shell and workflow unchanged in this review unit

## Validation

- exact signed-head `pr-parity` passed
- `go test -race ./...` and `go vet ./...` passed
- focused release publisher tests, contract checks, hygiene checks, and six-role adversarial consensus review passed

## Activation boundary

This PR does not activate the publisher or make a public support claim. A separate activation PR must wire the production release workflow, complete live end-to-end certification, and add mutation-boundary fault tests for ambiguous create, upload, delete, and publish outcomes.