### PR TITLE
Activate sealed GitHub release publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -830,6 +830,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Download preflight binding manifests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Releases.
 
 - remove temporary Buildx resources after every runtime-image build attempt,
   with exact target, random identity, ownership, and inventory checks.
+- stage and hash the exact GitHub release asset inventory before the first
+  hosted mutation, upload only from unlinked read-only handles, and verify each
+  uploaded SHA-256 before publishing the immutable release.
 
 ## v1.0.0-rc.2 - 2026-07-12
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -61,8 +61,9 @@ honestly in docs, status reports, and release commentary.
   pushing a release tag.
 - Publish release assets through a draft GitHub release first, then publish
   the final release record only after the asset set is complete. The release
-  workflow handles that draft creation and final publication automatically; the
-  operator verifies the finished published release state.
+  workflow stages the exact asset inventory into private, unlinked, read-only
+  handles before its first GitHub mutation and uploads only those staged bytes.
+  The operator verifies the finished published release state.
 - Verify the published GitHub release, attached assets, and immutable-release
   state before concluding.
 - Do not rewrite or delete a failed release tag. Recover by patching `main` and
@@ -515,21 +516,40 @@ If the workflow enters a waiting state for the `release` environment:
 In `review-gated` mode, stop with the fourth checkpoint packet before approving
 the environment.
 
-The workflow starts with a read-only tag-policy gate. The gate uses the same
-`workcell-hostutil release classify-tag` implementation as the host-side
-publisher, and every later release job depends on it directly. The publisher
-also classifies the tag before its first GitHub release-API request.
+The workflow starts with a read-only tag-policy gate. The gate and host-side
+publisher use the same Go tag-classification policy, and every later release
+job depends on the gate directly. The publisher also classifies the tag before
+its first GitHub release-API request.
 Unsupported tags therefore fail before a write-capable job or API mutation can
 run. Release candidates are published as prereleases and never become latest;
 final tags are non-prereleases and become latest only when their populated
 draft is published.
 
 In immutable-release mode, the release publisher must create or reuse a draft
-release, upload the full artifact set into that draft, and only then publish
-the final release record. If publication instead tries to upload assets into an
-already-published immutable release, treat that as a release-process bug,
-patch `main`, and cut the next patch release rather than rewriting the failed
-tag.
+release, stage and validate the full artifact set before the first GitHub
+mutation, upload only from the sealed staging handles, revalidate the exact
+uploaded inventory, and only then publish the final release record. Source-path
+changes after staging cannot change the uploaded bytes. The entrypoint also
+binds publication to the locally checked-out annotated tag object and its peeled
+commit; the Go publisher verifies that exact binding against GitHub before and
+after publication. If publication instead tries to upload assets into an
+already-published immutable release, treat that as a release-process bug, patch
+`main`, and cut the next patch release rather than rewriting the failed tag.
+If a create, delete, upload, or publish request fails after it starts, treat the
+hosted mutation outcome as ambiguous and inspect the exact-tag draft and asset
+inventory before recovery. Never retry a tag whose publication might have
+completed; recover with the next patch release.
+
+### Sealed publisher activation certification
+
+The sealed publisher was live-certified on 2026-08-02 in a maintainer-controlled
+private fixture repository with repository release immutability enabled. One
+run invoked the Go publisher directly and a second used the production
+`scripts/publish-github-release.sh` entrypoint. Each run used a distinct signed
+annotated release-candidate tag, verified the exact tag-object and peeled-commit
+binding, and published the exact 18-asset manifest. GitHub reported every asset
+as uploaded with a `sha256:` digest, both releases as immutable prereleases, and
+both tag signatures as verified with reason `valid`.
 
 After approving the environment in single-maintainer mode, leave a public PR
 follow-up comment so the self-review is visible in the same release thread. Use

--- a/internal/host/release/publisher.go
+++ b/internal/host/release/publisher.go
@@ -301,6 +301,8 @@ func (publisher githubReleasePublisher) findRelease(ctx context.Context, reposit
 }
 
 func (publisher githubReleasePublisher) createDraft(ctx context.Context, repository, token, tag string, policy TagPolicy) (listedRelease, error) {
+	operation := fmt.Sprintf("create GitHub draft release %q", tag)
+	const recovery = "inspect the exact-tag hosted release state before retrying"
 	payload := createPayload{
 		TagName:              tag,
 		Draft:                true,
@@ -317,15 +319,23 @@ func (publisher githubReleasePublisher) createDraft(ctx context.Context, reposit
 		http.StatusCreated,
 	)
 	if err != nil {
-		return listedRelease{}, fmt.Errorf("create GitHub draft release %q: %w", tag, err)
+		return listedRelease{}, ambiguousMutationError(operation, recovery, err)
 	}
-	return decodeReleaseRecord(body, "created draft")
+	created, err := decodeReleaseRecord(body, "created draft")
+	if err != nil {
+		return listedRelease{}, ambiguousMutationError(operation, recovery, err)
+	}
+	return created, nil
 }
 
 func (publisher githubReleasePublisher) deleteAsset(ctx context.Context, repository, token string, assetID int64) error {
 	endpoint := fmt.Sprintf("%s/repos/%s/releases/assets/%d", githubAPIOrigin, repository, assetID)
 	if _, err := publisher.request(ctx, token, http.MethodDelete, endpoint, "", nil, 0, http.StatusNoContent); err != nil {
-		return fmt.Errorf("delete existing GitHub release asset %d: %w", assetID, err)
+		return ambiguousMutationError(
+			fmt.Sprintf("delete existing GitHub release asset %d", assetID),
+			"inspect the draft asset inventory before retrying",
+			err,
+		)
 	}
 	return nil
 }
@@ -338,6 +348,8 @@ func (publisher githubReleasePublisher) uploadAsset(ctx context.Context, reposit
 	if err != nil {
 		return err
 	}
+	operation := fmt.Sprintf("upload GitHub release asset %q", asset.name)
+	const recovery = "inspect the draft asset inventory before retrying"
 	query := url.Values{"name": []string{asset.name}}
 	endpoint := fmt.Sprintf(
 		"%s/repos/%s/releases/%d/assets?%s",
@@ -357,13 +369,16 @@ func (publisher githubReleasePublisher) uploadAsset(ctx context.Context, reposit
 		http.StatusCreated,
 	)
 	if err != nil {
-		return fmt.Errorf("upload GitHub release asset %q: %w", asset.name, err)
+		return ambiguousMutationError(operation, recovery, err)
 	}
 	var uploaded githubReleaseAsset
 	if err := json.Unmarshal(body, &uploaded); err != nil {
-		return fmt.Errorf("decode uploaded GitHub release asset %q: %w", asset.name, err)
+		return ambiguousMutationError(operation, recovery, fmt.Errorf("decode uploaded asset response: %w", err))
 	}
-	return validateUploadedAsset(uploaded, asset)
+	if err := validateUploadedAsset(uploaded, asset); err != nil {
+		return ambiguousMutationError(operation, recovery, err)
+	}
+	return nil
 }
 
 func (publisher githubReleasePublisher) getReleaseByID(ctx context.Context, repository, token string, releaseID int64) (listedRelease, error) {
@@ -376,6 +391,8 @@ func (publisher githubReleasePublisher) getReleaseByID(ctx context.Context, repo
 }
 
 func (publisher githubReleasePublisher) publishDraft(ctx context.Context, repository, token, tag string, policy TagPolicy, releaseID int64) (listedRelease, error) {
+	operation := fmt.Sprintf("publish GitHub release %q", tag)
+	const recovery = "inspect the hosted release and do not retry or rewrite this tag until its state is known"
 	makeLatest := "false"
 	if policy.MakeLatest {
 		makeLatest = "true"
@@ -393,9 +410,17 @@ func (publisher githubReleasePublisher) publishDraft(ctx context.Context, reposi
 		http.StatusOK,
 	)
 	if err != nil {
-		return listedRelease{}, fmt.Errorf("publish GitHub release %q: %w", tag, err)
+		return listedRelease{}, ambiguousMutationError(operation, recovery, err)
 	}
-	return decodeReleaseRecord(body, "published release")
+	published, err := decodeReleaseRecord(body, "published release")
+	if err != nil {
+		return listedRelease{}, ambiguousMutationError(operation, recovery, err)
+	}
+	return published, nil
+}
+
+func ambiguousMutationError(operation, recovery string, err error) error {
+	return fmt.Errorf("%s outcome is ambiguous; %s: %w", operation, recovery, err)
 }
 
 func (publisher githubReleasePublisher) validateLatest(

--- a/internal/host/release/publisher_input_test.go
+++ b/internal/host/release/publisher_input_test.go
@@ -332,16 +332,16 @@ func TestReleaseWorkflowUsesSingleAuthoritativeTagPolicyGate(t *testing.T) {
 		t.Fatal(err)
 	}
 	publisher := string(publisherData)
-	firstAPI := strings.Index(publisher, `status="$(api GET`)
-	if firstAPI < 0 {
-		t.Fatal("publisher is missing the GitHub release lookup")
+	invocation := `"${HOSTUTIL_BIN}" release publish "${TAG_NAME}" "${TAG_OBJECT_SHA}" "${PEELED_COMMIT_SHA}" "$@"`
+	if strings.Count(publisher, invocation) != 1 {
+		t.Fatalf("publisher invocation %q count = %d, want 1", invocation, strings.Count(publisher, invocation))
 	}
-	for _, invocation := range []string{`release classify-tag "${TAG_NAME}"`} {
-		if strings.Count(publisher, invocation) != 1 {
-			t.Fatalf("publisher invocation %q count = %d, want 1", invocation, strings.Count(publisher, invocation))
-		}
-		if index := strings.Index(publisher, invocation); index < 0 || index > firstAPI {
-			t.Fatalf("publisher invocation %q must precede the first GitHub release-API call", invocation)
+	if strings.Contains(publisher, "curl ") || strings.Contains(publisher, "api GET") {
+		t.Fatal("publisher shell must delegate GitHub release API policy to the Go publisher")
+	}
+	for _, binding := range []string{`"${TAG_REF}^{tag}"`, `"${TAG_REF}^{commit}"`} {
+		if strings.Count(publisher, binding) != 1 {
+			t.Fatalf("publisher tag binding %q count = %d, want 1", binding, strings.Count(publisher, binding))
 		}
 	}
 }

--- a/internal/host/release/publisher_test.go
+++ b/internal/host/release/publisher_test.go
@@ -294,6 +294,135 @@ func TestPublisherReplacesExpectedStaleDraftAsset(t *testing.T) {
 	}
 }
 
+type mutationFaultClient struct {
+	requests int
+	err      error
+	response *http.Response
+}
+
+func (client *mutationFaultClient) Do(*http.Request) (*http.Response, error) {
+	client.requests++
+	return client.response, client.err
+}
+
+func TestMutationFailuresReportAmbiguousHostedState(t *testing.T) {
+	const repository, tag = "example/workcell", "v1.0.0"
+	policy, err := ClassifyTag(tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, _ := writeAssets(t, tag)
+	assets, err := inspectWorkcellAssets(tag, paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := closeLocalAssets(assets); err != nil {
+			t.Error(err)
+		}
+	})
+
+	injected := errors.New("connection reset after request write")
+	for _, tc := range []struct {
+		name, operation, recovery string
+		run                       func(githubReleasePublisher) error
+	}{
+		{
+			name: "create", operation: "create GitHub draft release", recovery: "inspect the exact-tag hosted release state",
+			run: func(publisher githubReleasePublisher) error {
+				_, err := publisher.createDraft(context.Background(), repository, "token", tag, policy)
+				return err
+			},
+		},
+		{
+			name: "delete", operation: "delete existing GitHub release asset", recovery: "inspect the draft asset inventory",
+			run: func(publisher githubReleasePublisher) error {
+				return publisher.deleteAsset(context.Background(), repository, "token", 99)
+			},
+		},
+		{
+			name: "upload", operation: "upload GitHub release asset", recovery: "inspect the draft asset inventory",
+			run: func(publisher githubReleasePublisher) error {
+				return publisher.uploadAsset(context.Background(), repository, "token", 42, &assets[0])
+			},
+		},
+		{
+			name: "publish", operation: "publish GitHub release", recovery: "do not retry or rewrite this tag",
+			run: func(publisher githubReleasePublisher) error {
+				_, err := publisher.publishDraft(context.Background(), repository, "token", tag, policy, 42)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &mutationFaultClient{err: injected}
+			err := tc.run(githubReleasePublisher{client: client})
+			for _, fragment := range []string{tc.operation, "outcome is ambiguous", tc.recovery} {
+				if err == nil || !strings.Contains(err.Error(), fragment) {
+					t.Fatalf("mutation error = %v, want %q", err, fragment)
+				}
+			}
+			if !errors.Is(err, injected) || client.requests != 1 {
+				t.Fatalf("mutation error = %v requests = %d", err, client.requests)
+			}
+		})
+	}
+}
+
+func TestMutationResponseFailuresReportAmbiguousHostedState(t *testing.T) {
+	const repository, tag = "example/workcell", "v1.0.0"
+	policy, err := ClassifyTag(tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, _ := writeAssets(t, tag)
+	assets, err := inspectWorkcellAssets(tag, paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := closeLocalAssets(assets); err != nil {
+			t.Error(err)
+		}
+	})
+
+	for _, tc := range []struct {
+		name      string
+		status    int
+		operation string
+		run       func(githubReleasePublisher) error
+	}{
+		{
+			name: "create", status: http.StatusCreated, operation: "create GitHub draft release",
+			run: func(publisher githubReleasePublisher) error {
+				_, err := publisher.createDraft(context.Background(), repository, "token", tag, policy)
+				return err
+			},
+		},
+		{
+			name: "upload", status: http.StatusCreated, operation: "upload GitHub release asset",
+			run: func(publisher githubReleasePublisher) error {
+				return publisher.uploadAsset(context.Background(), repository, "token", 42, &assets[0])
+			},
+		},
+		{
+			name: "publish", status: http.StatusOK, operation: "publish GitHub release",
+			run: func(publisher githubReleasePublisher) error {
+				_, err := publisher.publishDraft(context.Background(), repository, "token", tag, policy, 42)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &mutationFaultClient{response: jsonResponse(tc.status, map[string]any{})}
+			err := tc.run(githubReleasePublisher{client: client})
+			if err == nil || !strings.Contains(err.Error(), tc.operation) || !strings.Contains(err.Error(), "outcome is ambiguous") || client.requests != 1 {
+				t.Fatalf("mutation response error = %v requests = %d", err, client.requests)
+			}
+		})
+	}
+}
+
 type staticClient struct {
 	requests, status int
 	body             any

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -325,8 +325,9 @@ docs = [
 
 [nonfunctional.NFR-004]
 title = "Release provenance validation"
-summary = "Release artifacts, control-plane manifests, and signing metadata must remain validated and reproducible before publication."
+summary = "Release artifacts, control-plane manifests, and signing metadata must remain validated and reproducible before publication, with the exact asset inventory sealed before any GitHub mutation and uploaded only from its staged read-only content."
 evidence = [
+  "internal/host/release/publisher_test.go",
   "scripts/verify-release-bundle.sh",
   "scripts/verify-control-plane-manifest.sh",
   "scripts/verify-upstream-claude-release.sh",
@@ -335,6 +336,7 @@ evidence = [
   "scripts/verify-upstream-gemini-release.sh",
 ]
 docs = [
+  "docs/releasing.md",
   "docs/provenance.md",
   "docs/github-workflows.md",
 ]

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -16,36 +16,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=/dev/null
 source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
 
-release_upload_policy_error() {
-  local tag_name="$1"
-  local release_draft="$2"
-  local release_immutable="$3"
-
-  if [[ "${release_draft}" == "true" ]]; then
-    return 0
-  fi
-
-  if [[ "${release_immutable}" == "true" ]]; then
-    echo "GitHub release ${tag_name} is already published and immutable; asset uploads are no longer allowed. Patch main and cut the next patch release instead." >&2
-  else
-    echo "GitHub release ${tag_name} is already published; Workcell only uploads assets to draft releases. Patch main and cut the next patch release instead." >&2
-  fi
-  return 1
-}
-
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
   echo "publish-github-release-entrypoint-ok"
-  exit 0
-fi
-
-if [[ "${1:-}" == "--self-release-state-probe" ]]; then
-  [[ $# -eq 4 ]] || {
-    echo "Usage: publish-github-release.sh --self-release-state-probe TAG DRAFT IMMUTABLE" >&2
-    exit 2
-  }
-  release_upload_policy_error "$2" "$3" "$4"
-  echo "publish-github-release-state-ok"
   exit 0
 fi
 
@@ -56,164 +29,28 @@ EOF
   exit 2
 }
 
-require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
-}
-
 [[ $# -ge 2 ]] || usage
 
 TAG_NAME="$1"
 shift
 
-[[ -n "${GITHUB_TOKEN:-}" ]] || {
-  echo "GITHUB_TOKEN is required" >&2
-  exit 1
-}
-
-[[ -n "${GITHUB_REPOSITORY:-}" ]] || {
-  echo "GITHUB_REPOSITORY is required" >&2
-  exit 1
-}
-
-require_tool curl
-
-for path in "$@"; do
-  [[ -f "${path}" && -s "${path}" ]] || {
-    echo "Missing, empty, or non-file release asset: ${path}" >&2
-    exit 1
-  }
-done
-
-api() {
-  local method="$1"
-  local url="$2"
-  local body_path="${3:-}"
-  local response_path="$4"
-  local status
-
-  if [[ -n "${body_path}" ]]; then
-    status="$(curl -sS \
-      -o "${response_path}" \
-      -w '%{http_code}' \
-      -X "${method}" \
-      -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-      -H 'Accept: application/vnd.github+json' \
-      -H 'X-GitHub-Api-Version: 2022-11-28' \
-      -H 'Content-Type: application/json' \
-      --data @"${body_path}" \
-      "${url}")"
-  else
-    status="$(curl -sS \
-      -o "${response_path}" \
-      -w '%{http_code}' \
-      -X "${method}" \
-      -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-      -H 'Accept: application/vnd.github+json' \
-      -H 'X-GitHub-Api-Version: 2022-11-28' \
-      "${url}")"
-  fi
-
-  printf '%s\n' "${status}"
-}
-
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/workcell-release-api.XXXXXX")"
 HOSTUTIL_BIN="$(mktemp "${TMPDIR:-/tmp}/workcell-hostutil.XXXXXX")"
 
 cleanup() {
-  rm -rf "${TMP_ROOT}"
   rm -f "${HOSTUTIL_BIN}"
 }
 
 trap cleanup EXIT
 build_go_tool_in_repo "${ROOT_DIR}" "${HOSTUTIL_BIN}" ./cmd/workcell-hostutil
 
-# This fail-closed tag gate runs before the first GitHub release-API request.
-"${HOSTUTIL_BIN}" release classify-tag "${TAG_NAME}" >/dev/null
-
-release_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}"
-release_json="${TMP_ROOT}/release.json"
-create_payload="${TMP_ROOT}/create.json"
-
-status="$(api GET "${release_url}" "" "${release_json}")"
-case "${status}" in
-  200) ;;
-  404)
-    "${HOSTUTIL_BIN}" release create-payload "${TAG_NAME}" "${create_payload}"
-    status="$(api POST "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases" "${create_payload}" "${release_json}")"
-    [[ "${status}" == "201" ]] || {
-      echo "GitHub release creation failed with status ${status}" >&2
-      cat "${release_json}" >&2
-      exit 1
-    }
-    ;;
-  *)
-    echo "GitHub release lookup failed with status ${status}" >&2
-    cat "${release_json}" >&2
-    exit 1
-    ;;
-esac
-
-"${HOSTUTIL_BIN}" release metadata "${release_json}" "${TMP_ROOT}/release-metadata.txt" "$@"
-
-release_metadata=()
-while IFS= read -r -d '' field; do
-  release_metadata+=("${field}")
-done <"${TMP_ROOT}/release-metadata.txt"
-release_id="${release_metadata[0]}"
-upload_url="${release_metadata[1]}"
-release_draft="${release_metadata[2]}"
-release_immutable="${release_metadata[3]}"
-
-if ! release_upload_policy_error "${TAG_NAME}" "${release_draft}" "${release_immutable}"; then
-  exit 1
-fi
-
-for ((i = 4; i < ${#release_metadata[@]}; i += 2)); do
-  asset_id_index=$((i + 1))
-  asset_name="${release_metadata[i]}"
-  asset_id="${release_metadata[asset_id_index]}"
-
-  if [[ -n "${asset_id}" ]]; then
-    delete_status="$(api DELETE "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" "" "${TMP_ROOT}/delete-${asset_id}.json")"
-    [[ "${delete_status}" == "204" ]] || {
-      echo "Failed to delete existing GitHub release asset ${asset_name} (${asset_id})" >&2
-      cat "${TMP_ROOT}/delete-${asset_id}.json" >&2
-      exit 1
-    }
-  fi
-done
-
-for path in "$@"; do
-  asset_name="$(basename "${path}")"
-  encoded_name="$("${HOSTUTIL_BIN}" release encode-name "${asset_name}")"
-  upload_response="${TMP_ROOT}/upload-${asset_name}.json"
-  upload_status="$(curl -sS \
-    -o "${upload_response}" \
-    -w '%{http_code}' \
-    -X POST \
-    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-    -H 'Accept: application/vnd.github+json' \
-    -H 'X-GitHub-Api-Version: 2022-11-28' \
-    -H 'Content-Type: application/octet-stream' \
-    --data-binary @"${path}" \
-    "${upload_url}?name=${encoded_name}")"
-  [[ "${upload_status}" == "201" ]] || {
-    echo "Failed to upload GitHub release asset ${asset_name}" >&2
-    cat "${upload_response}" >&2
-    exit 1
-  }
-done
-
-publish_payload="${TMP_ROOT}/publish.json"
-"${HOSTUTIL_BIN}" release publish-payload "${TAG_NAME}" "${publish_payload}"
-publish_status="$(api PATCH "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/${release_id}" "${publish_payload}" "${TMP_ROOT}/publish-response.json")"
-[[ "${publish_status}" == "200" ]] || {
-  echo "Failed to publish GitHub release ${TAG_NAME} after uploading assets" >&2
-  cat "${TMP_ROOT}/publish-response.json" >&2
-  exit 1
+TAG_REF="refs/tags/${TAG_NAME}"
+TAG_OBJECT_SHA="$(git -C "${ROOT_DIR}" --no-replace-objects rev-parse --verify "${TAG_REF}^{tag}")" || {
+  echo "Release tag ${TAG_NAME} must resolve locally to an annotated tag object." >&2
+  exit 2
+}
+PEELED_COMMIT_SHA="$(git -C "${ROOT_DIR}" --no-replace-objects rev-parse --verify "${TAG_REF}^{commit}")" || {
+  echo "Release tag ${TAG_NAME} must peel locally to exactly one commit." >&2
+  exit 2
 }
 
-printf 'Uploaded GitHub release assets and published final release for %s (release id %s)\n' "${TAG_NAME}" "${release_id}"
+"${HOSTUTIL_BIN}" release publish "${TAG_NAME}" "${TAG_OBJECT_SHA}" "${PEELED_COMMIT_SHA}" "$@"

--- a/tests/scenarios/manifest.json
+++ b/tests/scenarios/manifest.json
@@ -93,7 +93,7 @@
     },
     {
       "id": "shared/publish-github-release",
-      "description": "Host-side publish-github-release only mutates draft releases and fails closed for already-published mutable or immutable releases",
+      "description": "Host-side release publication sanitizes its shell entrypoint and requires an annotated signed release tag; sealed publisher behavior is covered by Go integration tests",
       "lane": "secretless",
       "platform": "any",
       "manual": false,

--- a/tests/scenarios/shared/test-publish-github-release.sh
+++ b/tests/scenarios/shared/test-publish-github-release.sh
@@ -14,22 +14,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-draft_ok_output="$("${ROOT_DIR}/scripts/publish-github-release.sh" --self-release-state-probe v9.9.9 true false)"
-grep -Fx 'publish-github-release-state-ok' <<<"${draft_ok_output}" >/dev/null
-
-set +e
-published_mutable_output="$("${ROOT_DIR}/scripts/publish-github-release.sh" --self-release-state-probe v9.9.9 false false 2>&1)"
-published_mutable_rc=$?
-set -e
-test "${published_mutable_rc}" -eq 1
-grep -F 'GitHub release v9.9.9 is already published; Workcell only uploads assets to draft releases.' <<<"${published_mutable_output}" >/dev/null
-
-set +e
-published_immutable_output="$("${ROOT_DIR}/scripts/publish-github-release.sh" --self-release-state-probe v9.9.9 false true 2>&1)"
-published_immutable_rc=$?
-set -e
-test "${published_immutable_rc}" -eq 1
-grep -F 'GitHub release v9.9.9 is already published and immutable; asset uploads are no longer allowed.' <<<"${published_immutable_output}" >/dev/null
+entrypoint_output="$("${ROOT_DIR}/scripts/publish-github-release.sh" --self-entrypoint-probe)"
+grep -Fx 'publish-github-release-entrypoint-ok' <<<"${entrypoint_output}" >/dev/null
 
 mkdir -p "${FIXTURE}" "${HOST_HOME}" "${HOST_XDG_CONFIG_HOME}/git"
 export HOME="${HOST_HOME}"
@@ -105,4 +91,4 @@ set -e
 test "${unsigned_tag_rc}" -eq 2
 grep -F 'must be an annotated signed tag object' <<<"${unsigned_tag_output}" >/dev/null
 
-echo "publish-github-release policy scenario passed"
+echo "publish-github-release entrypoint scenario passed"


### PR DESCRIPTION
## Summary
- activate the sealed Go GitHub release publisher in the production release workflow
- bind publication to the checked-out annotated tag object and peeled commit, and fetch full tag history
- fail closed with explicit recovery guidance for ambiguous create/delete/upload/publish outcomes
- update release docs, requirements evidence, and the secretless entrypoint scenario

## Validation
- live-certified direct Go publisher and production shell entrypoint in a maintainer-controlled private immutable-release fixture (two signed annotated RC tags, exact 18-asset manifests, GitHub SHA-256 digests, immutable releases)
- `go test ./internal/host/release ./cmd/workcell-hostutil`
- `env -u GIT_PAGER ./scripts/validate-repo.sh`
- `env -u GIT_PAGER ./scripts/pre-merge.sh --profile pr-parity`
- adversarial consensus and simplify review clean