### PR TITLE
Activate strict parallel-session certification

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -534,8 +534,11 @@ security-boundary product to prove.
 - **C2 (post-1.0, M):** session start latency program with cached images, an
   optional kept-warm lane, and a certification design that does not broaden the
   launcher with destructive controls; generic output remains benchmark-only
-- **C3 (next, L):** native parallel sessions — one agent per worktree,
-  branch, and isolated runtime, with session-record linkage
+- **C3 (implemented; locally certified 2026-08-03, L):** native parallel
+  sessions — one agent per worktree, branch, and isolated runtime, with
+  session-record linkage. The exact-tree pre-merge certification is bound to
+  signed activation commit `a26b750f`; shipped status depends on that commit
+  being reachable from `main`
 - **C4 (later, L):** container tooling inside the boundary as an explicit
   labeled lane that never weakens the outer boundary
 - **C5 (now, S):** syscall-shim performance baselines for the hooked

--- a/cmd/workcell-c3-certify/main.go
+++ b/cmd/workcell-c3-certify/main.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/omkhar/workcell/internal/host/c3certify"
+)
+
+func main() {
+	root := flag.String("root", "", "Workcell control-plane root")
+	workspace := flag.String("workspace", "", "clean workload git workspace")
+	tree := flag.String("precommit-control-tree", "", "full indexed control-tree SHA")
+	flag.Parse()
+	if flag.NArg() != 0 || *root == "" || *workspace == "" {
+		fmt.Fprintln(os.Stderr, "Usage: workcell-c3-certify --root PATH --workspace PATH [--precommit-control-tree SHA]")
+		os.Exit(2)
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	options := c3certify.Options{Root: *root, Workspace: *workspace, PrecommitControlTree: *tree}
+	if err := c3certify.Run(ctx, options, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/docs/1.0-readiness-review-draft.md
+++ b/docs/1.0-readiness-review-draft.md
@@ -153,12 +153,15 @@ Grounded in `ROADMAP.md` Non-Goals plus verification of what is on `main`:
   post-1.0. The generic driver remains benchmark-only because caller-provided
   hooks cannot prove lifecycle state; the reviewed dedicated-certifier design
   was rejected rather than broaden the launcher with destructive controls.
-- **C3 parallel sessions:** the live two-container run is recorded (2026-07-15,
-  §6 Platform row) — distinct containers, worktrees, and branches. That
-  establishes *structural* isolation; the **runtime non-interference check**
-  required by `docs/safe-path-expectations.md` (a write inside session A's
-  container is not visible inside session B) is **still to be performed** before
-  criterion 3 is signed off.
+- **C3 parallel sessions:** the preliminary 2026-07-15 run established only
+  structural isolation. A live 2026-08-03 certification on
+  `macos/arm64/local_vm/colima/strict` proved overlapping same-repo sessions,
+  distinct containers/worktrees/branches, symmetric runtime
+  write-invisibility, independent stop behavior, and bounded cleanup. The
+  exact-tree pre-merge certification is bound to signed activation commit
+  `a26b750f`; treat C3 as shipped only when that commit is reachable from
+  `main`. See
+  `docs/benchmark-evidence/c3-two-container-isolation-2026-07-15.md`.
 - **No CI-runner egress hardening (accepted for 1.0):** GitHub-hosted CI runners
   have no `step-security/harden-runner` or equivalent egress allowlist, so a
   compromised build step has open network egress (the runtime *product* sandbox's
@@ -230,21 +233,17 @@ the maintainer records the outcome.
       `cache-hit` anomaly; `cold` is a tarball restore not a first build; teardown
       never ran); **G4 decision recorded 2026-08-01: C2 certification and its
       1.0 latency target are deferred to post-1.0; generic benchmark output is
-      not certification evidence**; **C3 two-session run recorded
-      2026-07-15**
-      — two same-repo `--session-workspace isolated` sessions (started 33 s apart,
-      each short-lived — **not concurrent**, see the evidence file) on
-      `macos/arm64/local_vm/colima/strict` produced distinct containers
-      (`workcell-codex-strict-repo-557c91b5` / `…-0e6b0d64`), distinct worktrees,
-      and distinct branches under one `workspace_root` — *structural*
-      worktree-per-agent isolation, on top of the CI **clone-level host-side**
-      proof in `test-session-commands.sh` (that scenario creates two git clones and
-      checks file invisibility between their host paths — it launches no containers;
-      see `docs/safe-path-expectations.md`). The **runtime non-interference check**
-      required by
-      `docs/safe-path-expectations.md` (a write inside session A's container is not
-      visible inside session B) is **still to be performed** before criterion 3 is
-      signed off. Raw `session show` evidence for both sessions is committed at
+      not certification evidence**; **C3 certified locally 2026-08-03** on
+      `macos/arm64/local_vm/colima/strict` with two overlapping same-repo
+      isolated sessions. The run proved distinct containers, worktrees, and
+      branches; symmetric container/host-worktree marker visibility and
+      cross-session invisibility; independent stop behavior; and bounded
+      removal of sessions, containers, worktrees, the certifier-owned profile,
+      target state, and runtime cache. The exact-tree run is bound to signed
+      activation commit `a26b750f`; treat it as shipped only when that commit is
+      reachable from `main`. The CI clone-level proof remains complementary and
+      launches no containers. Historical preliminary and certified evidence is
+      committed at
       [`docs/benchmark-evidence/c3-two-container-isolation-2026-07-15.md`](benchmark-evidence/c3-two-container-isolation-2026-07-15.md).
 - [ ] **Adoption surface** — tiered docs (E1, merged), architecture diagrams
       (E2, merged), and support guides (E3, merged) are the 1.0 gate. **E6 is

--- a/docs/benchmark-evidence/c3-two-container-isolation-2026-07-15.md
+++ b/docs/benchmark-evidence/c3-two-container-isolation-2026-07-15.md
@@ -1,4 +1,4 @@
-# C3 — two-session isolation, raw capture (2026-07-15, PRELIMINARY)
+# C3 — two-session isolation evidence
 
 Auditable evidence for the C3 isolation run recorded in
 [`../1.0-readiness-review-draft.md`](../1.0-readiness-review-draft.md) §6 Platform
@@ -11,8 +11,9 @@ then `session show` was captured for each.
 > session A had already exited before session B started — they did **not** overlap
 > in time. This evidence therefore shows that the isolation *scheme* assigns
 > **distinct** containers/worktrees/branches to two sessions, but it does **not**
-> establish a live **concurrent** two-container run. A concurrent capture needs
-> sessions that stay alive (e.g. a long-running task) and is left for Batch-3.
+> establish a live **concurrent** two-container run. This was the historical
+> 2026-07-15 conclusion. The 2026-08-03 certification below closes that
+> evidence gap with overlapping keepalive sessions.
 
 ## Invocation
 
@@ -61,8 +62,69 @@ Session B — `20260715T193705Z-2ae8e294`:
 - `status: failed` is expected here: a detached `codex` started with no task exits
   non-zero within seconds. It does not affect the isolation attributes above, which
   are assigned at session-start time.
-- This is **structural** evidence only. It does **not** perform the runtime
+- This preliminary capture is **structural** evidence only. It does **not**
+  perform the runtime
   non-interference check required by
-  [`../safe-path-expectations.md`](../safe-path-expectations.md) — that a write
-  inside session A's running container is not visible inside session B — which
-  remains to be done before criterion 3 is signed off.
+  [`../safe-path-expectations.md`](../safe-path-expectations.md). The certified
+  2026-08-03 run below performs that check.
+
+## Certified concurrent run (2026-08-03)
+
+This local-operator certification ran on
+`macos/arm64/local_vm/colima/strict`. It is bound to signed activation commit
+`a26b750f8d8c7957fc15a3f5c164c2df28f25b46` and its exact control-plane tree
+`726f485a609b88edcee7ee5ad88692d7aafdd501`. The certification was performed
+before merge. This evidence record is not itself a shipped-status claim; verify
+that the activation commit is reachable from `main` before treating it as
+shipped.
+
+The exact-tree run used the new maintainer entrypoint:
+
+```sh
+./scripts/certify-c3-parallel-sessions.sh \
+  --workspace /path/to/clean/workload \
+  --precommit-control-tree 726f485a609b88edcee7ee5ad88692d7aafdd501
+```
+
+The certifier used clean workload commit
+`cc6bc6f8310d1f65ef03007024d4ec2e3f57fe7b` and recorded:
+
+```text
+date (UTC): 2026-08-03T18:17:15Z
+Workcell launcher SHA-256: e414864af41a89527582c891bb777f513816b2cccbfd63a48106e0f8fab0126d
+Docker client SHA-256: 49d98ab806e8678cd6341b09dad6389e5bcd8a46513de7651053bee3d8366e8d
+target: local_vm/colima/strict
+profile: wcl-c3-2305439552
+session A: 20260803T181448Z-82c58950
+container A: workcell-codex-strict-repo-e90ea0c8
+branch A: workcell/session-20260803T181448Z-82c58950
+session B: 20260803T181648Z-57e2dd25
+container B: workcell-codex-strict-repo-8b984979
+branch B: workcell/session-20260803T181648Z-57e2dd25
+```
+
+The exact worktree paths were certifier-owned isolated paths under the temporary
+workload clone. They are intentionally generalized here rather than publishing
+the maintainer host's private temporary-directory prefix.
+
+The certifier proved all of the following in one run:
+
+- sessions A and B overlapped and had distinct containers, isolated worktrees,
+  and branches;
+- a marker written through container A's `/workspace` was present in A's
+  recorded host worktree and absent from both container B and B's host
+  worktree; the symmetric B-to-A check also passed;
+- each container's `/workspace` matched its recorded host worktree;
+- session A stopped independently while session B remained running;
+- both session records, containers, and isolated worktrees were removed; and
+- the certifier-owned Colima profile, target state, and runtime-image-cache
+  entries were removed.
+
+An independent post-run audit then found no exact profile process or Colima
+inventory entry, no exact Colima/profile/target/cache path, and no state-root
+name matching either session or the profile. It also confirmed the certified
+control-plane tree was unchanged.
+
+Scope limitation: the sessions used Workcell's explicitly acknowledged
+arbitrary-command keepalive path. This certifies the parallel strict runtime
+boundaries and lifecycle behavior; it does not certify provider interaction.

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -530,16 +530,24 @@ here for continuity of the B6 track.
 
 ### C3: Native Parallel Sessions
 
-- Steps: design review (may start during v0.14) for worktree-aware workspace
-  handling (one agent per worktree/branch/isolated runtime); extend session
-  records with linkage across parallel sessions; define per-session resource
-  and identity boundaries; implement launch/inventory/diff flows for N
-  concurrent sessions per repo.
-- Exit gates: two concurrent sessions on one repo cannot interfere
-  (deterministic tests); session tooling renders parallel topology; docs
-  updated; works on the strict path.
-- Validation: scenario coverage including conflict cases; live exercise.
-- Size: L. Dependencies: C1 decision helps (per-session VMs).
+- Status: implemented and locally certified on 2026-08-03. The exact-tree
+  pre-merge certification is bound to signed activation commit `a26b750f`;
+  shipped status depends on that commit being reachable from `main`.
+- Delivered: worktree-aware session handling with one branch, isolated
+  worktree, and container per session; linked origin-repository metadata;
+  per-session resource and identity boundaries; and launch, inventory, and
+  diff flows for concurrent same-repository sessions.
+- Exit gates: deterministic tests prove clone/branch separation and
+  write-invisibility; session tooling renders the parallel topology; the live
+  strict-path certification proved two overlapping sessions could not observe
+  each other's markers and that one stopped independently while the other
+  remained live.
+- Validation: `test-session-commands.sh`, `internal/host/c3certify` tests, and
+  the live evidence in
+  `docs/benchmark-evidence/c3-two-container-isolation-2026-07-15.md`.
+- Size: L. Sequencing note: C3 was implemented and certified independently of
+  C2. C2 can improve parallel-session startup latency but does not gate C3; the
+  C1 decision can inform future per-session-VM isolation.
 
 ### D5: Modularize The Rust Interception Library
 
@@ -738,7 +746,8 @@ does not gate 1.0.
 
 - D1 → D2 → D3/D4; A3 + A4 → D5; D2 → D7 (shell portion)
 - B9 → B6; B1 → B2; B3 baseline before D3/D5 refactors land
-- C5 informs the post-1.0 C2 program; C1 decision informs C2/C3/C4
+- C5 informs the post-1.0 C2 program; C2 can improve C3 latency but does not
+  gate the completed C3; the C1 decision informs C2/C3/C4
 - E4 → E1 → E6; A2 → E5; D8 → G1 (inventory) → G1 (freeze); E5 → G1 (freeze)
 - G1 (inventory) → G3; A5 ↔ F1 coordinated; F1 → F2; G2 ↔ F1 redaction rules
 - A3/A4/D5 → B7 (part 2); everything → G4

--- a/docs/safe-path-expectations.md
+++ b/docs/safe-path-expectations.md
@@ -125,20 +125,22 @@ always resolve to distinct clone paths and distinct branches. The live container
 name is NOT session-id-derived: it is assigned a random suffix at launch
 (`workcell-<agent>-<mode>-repo-<random>`), which makes concurrent containers
 distinct without depending on the session id.
-Proven vs deferred, kept honest:
+Evidence boundaries:
 
-- CI-PROVEN (this PR, host-side, no Colima): for two distinct session ids on the
+- CI-PROVEN (host-side, no Colima): for two distinct session ids on the
   same repo, the derivations produce distinct isolated clone paths and distinct
   branches, and clone-level write-invisibility holds (a write in clone A does not
   appear in clone B). The session-commands scenario runs the real clone/branch
   derivations directly and asserts both, needing only git—no live runtime.
-- LOCAL-OPERATOR-CERTIFICATION (deferred, needs Apple Silicon + Colima): the LIVE
-  two-container concurrent launch plus runtime cross-container non-interference (a
-  write inside session A's running container is invisible inside session B's).
-  This runtime container isolation is the boundary Workcell relies on generally,
-  but this PR's automated evidence covers only the clone/branch layer; the live
-  layer is certified locally because hosted CI has no Colima VM to launch
-  containers in.
+- LOCAL-OPERATOR-CERTIFIED (2026-08-03, Apple Silicon + Colima): the
+  maintainer-only `scripts/certify-c3-parallel-sessions.sh` workflow proved a
+  live overlapping two-container launch, symmetric runtime cross-container
+  write-invisibility, independent stop behavior, and bounded cleanup. The
+  exact-tree pre-merge certification is bound to signed activation commit
+  `a26b750f`; shipped status depends on that commit being reachable from
+  `main`. See
+  [`benchmark-evidence/c3-two-container-isolation-2026-07-15.md`](benchmark-evidence/c3-two-container-isolation-2026-07-15.md).
+  Hosted CI still cannot repeat the live Colima layer.
 
 The shared VM/kernel is not proven distinct here; pass a distinct
 `--colima-profile` to place a session on its own VM.

--- a/internal/host/c3certify/certify_test.go
+++ b/internal/host/c3certify/certify_test.go
@@ -8,15 +8,145 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/omkhar/workcell/internal/host/sessions"
 )
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
+
+func TestWriteReportReturnsWriterError(t *testing.T) {
+	item := &evidence{}
+	if err := writeReport(failingWriter{}, snapshot{}, item, item, time.Time{}); err == nil {
+		t.Fatal("writeReport hid writer failure")
+	}
+}
+
+func TestParseStartSessionID(t *testing.T) {
+	got, err := parseStartSessionID([]byte("session_id=session-a\nstatus=running\n"))
+	if err != nil || got != "session-a" {
+		t.Fatalf("parseStartSessionID = %q, %v", got, err)
+	}
+	for _, output := range []string{
+		"status=running\n", "session_id=a\nsession_id=b\n", "session_id=--all\n",
+	} {
+		if _, err := parseStartSessionID([]byte(output)); err == nil {
+			t.Fatalf("parseStartSessionID accepted %q", output)
+		}
+	}
+}
+
+func TestValidatePairPinsStrictIsolationIdentity(t *testing.T) {
+	workspace, commit := newGitRepo(t)
+	a := newIsolatedRecord(t, workspace, commit, "session-a", "workcell-a")
+	b := newIsolatedRecord(t, workspace, commit, "session-b", "workcell-b")
+	c := testCertifier(t, workspace)
+	if err := c.validatePair(context.Background(), a, b, commit); err != nil {
+		t.Fatalf("validatePair error = %v", err)
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*sessions.SessionRecord, *sessions.SessionRecord)
+		want   string
+	}{
+		{"provider", func(a, _ *sessions.SessionRecord) { a.TargetProvider = "docker-desktop" }, "target_provider"},
+		{"target assurance", func(_, b *sessions.SessionRecord) { b.TargetAssuranceClass = "compat" }, "target_assurance_class"},
+		{"effective assurance", func(a, _ *sessions.SessionRecord) { a.CurrentAssurance = "lower-assurance-package-mutation" }, "assurance"},
+		{"mode", func(a, _ *sessions.SessionRecord) { a.Mode = "development" }, "mode"},
+		{"transport", func(a, _ *sessions.SessionRecord) { a.WorkspaceTransport = "virtiofs" }, "workspace_transport"},
+		{"execution path", func(_, b *sessions.SessionRecord) { b.ExecutionPath = "managed-tier1" }, "execution_path"},
+		{"shared container", func(a, b *sessions.SessionRecord) { b.ContainerName = a.ContainerName }, "containers"},
+		{"shared worktree", func(a, b *sessions.SessionRecord) { b.WorktreePath = a.WorktreePath }, "recorded worktree"},
+		{"shared branch", func(a, b *sessions.SessionRecord) { b.GitBranch = a.GitBranch }, "isolated branch"},
+		{"different profile", func(_, b *sessions.SessionRecord) { b.Profile = "other" }, "profile"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotA, gotB := a, b
+			tc.mutate(&gotA, &gotB)
+			err := c.validatePair(context.Background(), gotA, gotB, commit)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validatePair error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestStartTimeoutAdoptsOwnedRecord(t *testing.T) {
+	workspace, commit := newGitRepo(t)
+	c := testCertifier(t, workspace)
+	c.workcell = "/fake/workcell"
+	c.options.CommandTimeout = time.Millisecond
+	c.deps.command = func(startCtx context.Context, env []string, name string, args ...string) ([]byte, error) {
+		if name == c.git {
+			return runCommand(startCtx, env, name, args...)
+		}
+		<-startCtx.Done()
+		c.options.CommandTimeout = 10 * time.Second
+		record := newIsolatedRecord(t, workspace, commit, "session-a", "workcell-a")
+		writeTestRecord(t, c, record)
+		return nil, startCtx.Err()
+	}
+	if _, err := c.start(context.Background()); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("start error = %v, want deadline", err)
+	}
+	if len(c.sessions) != 1 || c.sessions[0].record.SessionID != "session-a" {
+		t.Fatalf("adopted sessions = %+v, want timed-out launch evidence", c.sessions)
+	}
+}
+
+func TestCaptureSnapshotPinsPrecommitTree(t *testing.T) {
+	control, _ := newGitRepo(t)
+	workload, _ := newGitRepo(t)
+	c := testCertifier(t, workload)
+	c.options.Root, c.workcell, c.docker = control, filepath.Join(control, "tracked"), filepath.Join(control, "tracked")
+	mustNoError(t, os.WriteFile(c.workcell, []byte("indexed\n"), 0o600))
+	runGit(t, control, "add", "tracked")
+	c.options.PrecommitControlTree = strings.TrimSpace(string(runGit(t, control, "write-tree")))
+	if _, err := c.captureSnapshot(context.Background()); err != nil {
+		t.Fatalf("captureSnapshot error = %v", err)
+	}
+	c.options.PrecommitControlTree = strings.Repeat("0", 40)
+	if _, err := c.captureSnapshot(context.Background()); err == nil {
+		t.Fatal("captureSnapshot accepted mismatched tree")
+	}
+	c.options.PrecommitControlTree = strings.TrimSpace(string(runGit(t, control, "write-tree")))
+	mustNoError(t, os.WriteFile(filepath.Join(control, "untracked"), nil, 0o600))
+	if _, err := c.captureSnapshot(context.Background()); err == nil {
+		t.Fatal("captureSnapshot accepted untracked residue")
+	}
+	mustNoError(t, os.Remove(filepath.Join(control, "untracked")))
+	mustNoError(t, os.WriteFile(c.workcell, []byte("dirty\n"), 0o600))
+	if _, err := c.captureSnapshot(context.Background()); err == nil {
+		t.Fatal("captureSnapshot accepted tracked worktree changes")
+	}
+}
+
+func TestExecuteJoinsPrimaryAndCleanupErrors(t *testing.T) {
+	c := testCertifier(t, t.TempDir())
+	c.dockerConfig = filepath.Join("/dev/null", "child")
+	c.deps.command = func(context.Context, []string, string, ...string) ([]byte, error) {
+		return nil, errors.New("primary failure")
+	}
+	err := c.execute(context.Background(), new(strings.Builder))
+	if err == nil || !strings.Contains(err.Error(), "primary failure") ||
+		!strings.Contains(err.Error(), "cleanup verification failed") {
+		t.Fatalf("execute error = %v, want joined primary and cleanup failures", err)
+	}
+	if _, err := os.Stat(c.scratchRoot); err != nil {
+		t.Fatalf("cleanup failure removed owned evidence: %v", err)
+	}
+}
 
 func TestExecuteProvesAndCleansTwoSessions(t *testing.T) {
 	control, _ := newGitRepo(t)
@@ -53,6 +183,7 @@ func TestExecuteProvesAndCleansTwoSessions(t *testing.T) {
 	}
 	records, paths := map[string]sessions.SessionRecord{}, map[string]string{}
 	stopped, deleted := map[string]bool{}, map[string]bool{}
+	var markerCommands []string
 	var reapedProfile string
 	c.deps.reapProfileProcesses = func(_ context.Context, profile string) error { reapedProfile = profile; return nil }
 	c.deps.command = func(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
@@ -87,6 +218,7 @@ func TestExecuteProvesAndCleansTwoSessions(t *testing.T) {
 		}
 		if name == c.docker {
 			if args[0] == "exec" {
+				markerCommands = append(markerCommands, strings.Join(args, "\x00"))
 				if strings.Contains(args[4], "printf") {
 					for _, record := range records {
 						if record.ContainerName == args[1] {
@@ -129,12 +261,314 @@ func TestExecuteProvesAndCleansTwoSessions(t *testing.T) {
 	if len(records) != 2 || !deleted["session-1"] || !deleted["session-2"] || reapedProfile != c.profile {
 		t.Fatalf("incomplete certification: deleted=%v reaped=%s", deleted, reapedProfile)
 	}
+	wantMarkerCommands := []string{
+		strings.Join([]string{"exec", "workcell-session-1", "/bin/sh", "-lc",
+			`printf "%s\n" "$1" >"/workspace/$2"`, "sh", "session-a-only", ".workcell-c3-session-1"}, "\x00"),
+		strings.Join([]string{"exec", "workcell-session-2", "/bin/sh", "-lc",
+			`test ! -e "/workspace/$1"`, "sh", ".workcell-c3-session-1"}, "\x00"),
+		strings.Join([]string{"exec", "workcell-session-2", "/bin/sh", "-lc",
+			`printf "%s\n" "$1" >"/workspace/$2"`, "sh", "session-b-only", ".workcell-c3-session-2"}, "\x00"),
+		strings.Join([]string{"exec", "workcell-session-1", "/bin/sh", "-lc",
+			`test ! -e "/workspace/$1"`, "sh", ".workcell-c3-session-2"}, "\x00"),
+	}
+	if !slices.Equal(markerCommands, wantMarkerCommands) {
+		t.Fatalf("marker commands = %q, want symmetric A/B proof %q", markerCommands, wantMarkerCommands)
+	}
 	for _, path := range ownedPaths {
 		if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("owned profile residue %s: %v", path, err)
 		}
 	}
 }
+
+func TestProveMarkerRejectsWrongContainerMount(t *testing.T) {
+	c := testCertifier(t, t.TempDir())
+	c.docker = "/fake/docker"
+	present := sessions.SessionRecord{
+		SessionID: "session-b", Profile: c.profile, ContainerName: "workcell-b", WorktreePath: t.TempDir(),
+	}
+	absent := sessions.SessionRecord{
+		SessionID: "session-a", Profile: c.profile, ContainerName: "workcell-a", WorktreePath: t.TempDir(),
+	}
+	wrongMount := t.TempDir()
+	c.deps.command = func(_ context.Context, _ []string, _ string, args ...string) ([]byte, error) {
+		if args[0] == "exec" && strings.Contains(args[4], "printf") {
+			mustNoError(t, os.WriteFile(filepath.Join(wrongMount, args[len(args)-1]),
+				[]byte(args[len(args)-2]+"\n"), 0o600))
+		}
+		return nil, nil
+	}
+	if err := c.proveMarker(context.Background(), present, absent, ".marker-b", "session-b-only"); err == nil {
+		t.Fatal("proveMarker accepted a container mounted to an unrelated empty directory")
+	}
+}
+
+func TestCleanupDoesNotStopUnvalidatedSessionID(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		write bool
+	}{
+		{name: "absent record"},
+		{name: "mismatched record", write: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workspace, commit := newGitRepo(t)
+			c := testCertifier(t, workspace)
+			c.workcell = "/fake/workcell"
+			c.sessions = []*evidence{{record: sessions.SessionRecord{SessionID: "foreign"}}}
+			if test.write {
+				record := newIsolatedRecord(t, workspace, commit, "foreign", "workcell-foreign")
+				record.Profile, record.TargetID = "other-profile", "other-profile"
+				writeTestRecord(t, c, record)
+			}
+			var workcellCalls int
+			c.deps.command = func(_ context.Context, _ []string, name string, _ ...string) ([]byte, error) {
+				if name == c.workcell {
+					workcellCalls++
+				}
+				return nil, errors.New("unexpected command")
+			}
+			_ = c.cleanup(context.Background())
+			if workcellCalls != 0 {
+				t.Fatalf("cleanup issued %d Workcell calls for an unvalidated id", workcellCalls)
+			}
+		})
+	}
+}
+
+func TestDockerCommandRejectsSymlinkedSocketPaths(t *testing.T) {
+	t.Run("profile parent", func(t *testing.T) {
+		c := testCertifier(t, t.TempDir())
+		c.docker = "/fake/docker"
+		mustNoError(t, os.Symlink(t.TempDir(), filepath.Join(c.colimaRoot, c.profile)))
+		if _, err := c.dockerCommand(context.Background(), c.profile, "ps"); err == nil {
+			t.Fatal("dockerCommand accepted a symlinked profile directory")
+		}
+	})
+	t.Run("socket", func(t *testing.T) {
+		c := testCertifier(t, t.TempDir())
+		c.docker = "/fake/docker"
+		profileRoot := filepath.Join(c.colimaRoot, c.profile)
+		mustNoError(t, os.Mkdir(profileRoot, 0o700))
+		socketRoot, err := os.MkdirTemp("/tmp", "c3sock.")
+		mustNoError(t, err)
+		t.Cleanup(func() { _ = os.RemoveAll(socketRoot) })
+		socketTarget := filepath.Join(socketRoot, "docker.sock")
+		listener, err := net.Listen("unix", socketTarget)
+		mustNoError(t, err)
+		t.Cleanup(func() { _ = listener.Close() })
+		requireSocket := func(path string) error {
+			info, err := os.Lstat(path)
+			if err == nil && info.Mode()&os.ModeSocket == 0 {
+				return errors.New("not a socket")
+			}
+			return err
+		}
+		mustNoError(t, requireSocket(socketTarget))
+		mustNoError(t, os.Symlink(socketTarget, filepath.Join(profileRoot, "docker.sock")))
+		c.deps.socketExists = requireSocket
+		if _, err := c.dockerCommand(context.Background(), c.profile, "ps"); err == nil {
+			t.Fatal("dockerCommand accepted a symlinked socket")
+		}
+	})
+}
+
+func TestRuntimeImageCachePathsTreatsStateRootLiterally(t *testing.T) {
+	stateRoot := filepath.Join(t.TempDir(), "state[meta]*?")
+	cacheRoot := filepath.Join(stateRoot, "runtime-image-cache", "local_vm", "colima")
+	mustNoError(t, os.MkdirAll(cacheRoot, 0o700))
+	profile := "wcl-c3-test"
+	tempCache := filepath.Join(cacheRoot, profile+".pending.tar")
+	unrelated := filepath.Join(cacheRoot, "other.pending.tar")
+	mustNoError(t, os.WriteFile(tempCache, nil, 0o600))
+	mustNoError(t, os.WriteFile(unrelated, nil, 0o600))
+	paths, err := runtimeImageCachePaths(stateRoot, profile)
+	mustNoError(t, err)
+	if !slices.Contains(paths, tempCache) || slices.Contains(paths, unrelated) {
+		t.Fatalf("runtime cache paths = %q", paths)
+	}
+}
+
+func TestNewCertifierCreatesMissingColimaRoot(t *testing.T) {
+	home, root, workspace := t.TempDir(), t.TempDir(), t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WORKCELL_STATE_ROOT", t.TempDir())
+	mustNoError(t, os.MkdirAll(filepath.Join(root, "scripts"), 0o700))
+	mustNoError(t, os.WriteFile(filepath.Join(root, "scripts", "workcell"), nil, 0o700))
+	c, err := newCertifier(Options{Root: root, Workspace: workspace}, dependencies{})
+	if err == nil {
+		t.Cleanup(func() {
+			_ = os.RemoveAll(c.dockerConfig)
+			_ = os.RemoveAll(c.scratchRoot)
+		})
+	}
+	info, err := os.Lstat(filepath.Join(home, ".colima"))
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("created Colima root = %v, %v", info, err)
+	}
+}
+
+func TestRunRejectsInvalidOptions(t *testing.T) {
+	if err := Run(context.Background(), Options{PollAttempts: -1}, io.Discard); err == nil {
+		t.Fatal("Run accepted invalid polling options")
+	}
+}
+
+func TestCleanupPathProofsFailClosed(t *testing.T) {
+	workspace, commit := newGitRepo(t)
+	record := newIsolatedRecord(t, workspace, commit, "session-a", "workcell-a")
+	c := testCertifier(t, workspace)
+	record.WorktreePath = ""
+	if err := c.validateCleanupRecord(context.Background(), record); err == nil {
+		t.Fatal("cleanup accepted empty recorded path")
+	}
+	record = newIsolatedRecord(t, workspace, commit, "session-b", "workcell-b")
+	parent := filepath.Dir(filepath.Dir(record.WorktreePath))
+	realParent := parent + "-real"
+	mustNoError(t, os.Rename(parent, realParent))
+	mustNoError(t, os.Symlink(realParent, parent))
+	if err := c.validateCleanupRecord(context.Background(), record); err == nil {
+		t.Fatal("cleanup accepted symlinked ancestor")
+	}
+}
+
+func TestRecordAbsenceRequiresDirectFilesystemProof(t *testing.T) {
+	workspace, commit := newGitRepo(t)
+	c := testCertifier(t, workspace)
+	record := newIsolatedRecord(t, workspace, commit, "session-a", "workcell-a")
+	item := &evidence{record: record, recordPath: writeTestRecord(t, c, record)}
+	if err := c.proveRecordAbsent(item); err == nil {
+		t.Fatal("proveRecordAbsent accepted an existing durable record")
+	}
+	mustNoError(t, os.Remove(item.recordPath))
+	if err := c.proveRecordAbsent(item); err != nil {
+		t.Fatalf("proveRecordAbsent error = %v", err)
+	}
+}
+
+func TestKeepaliveHandlesSignals(t *testing.T) {
+	for _, signal := range []os.Signal{os.Interrupt, syscall.SIGTERM} {
+		t.Run(signal.String(), func(t *testing.T) {
+			bin := t.TempDir()
+			ready := filepath.Join(bin, "ready")
+			sleep := filepath.Join(bin, "sleep")
+			mustNoError(t, os.WriteFile(sleep,
+				[]byte("#!/bin/sh\nprintf ready >\"$READY\"\nexec /bin/sleep \"$@\"\n"), 0o700))
+			cmd := exec.Command("/bin/sh", "-c", keepalive)
+			cmd.Env = append(os.Environ(), "PATH="+bin+":/usr/bin:/bin", "READY="+ready)
+			mustNoError(t, cmd.Start())
+			done := make(chan error, 1)
+			go func() { done <- cmd.Wait() }()
+			waited := false
+			t.Cleanup(func() {
+				if waited {
+					return
+				}
+				_ = cmd.Process.Kill()
+				select {
+				case <-done:
+				case <-time.After(3 * time.Second):
+				}
+			})
+			deadline := time.Now().Add(3 * time.Second)
+			for {
+				if output, err := os.ReadFile(ready); err == nil && string(output) == "ready" {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("keepalive did not report readiness")
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			mustNoError(t, cmd.Process.Signal(signal))
+			select {
+			case err := <-done:
+				waited = true
+				mustNoError(t, err)
+			case <-time.After(3 * time.Second):
+				_ = cmd.Process.Kill()
+				<-done
+				waited = true
+				t.Fatalf("keepalive did not handle %s", signal)
+			}
+		})
+	}
+}
+
+func TestRunCommandReapsCancelledProcessGroup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	root := t.TempDir()
+	ready, marker := filepath.Join(root, "ready"), filepath.Join(root, "cleanup")
+	script := `trap 'printf done >"$2"; exit 0' TERM; /bin/sh -c 'trap "" TERM; while :; do sleep 1; done' & printf '%s\n' "$$" >"$1"; wait`
+	type result struct {
+		output []byte
+		err    error
+	}
+	resultCh := make(chan result, 1)
+	resultReceived := false
+	var group int
+	go func() {
+		output, err := runCommandWithDelay(ctx, os.Environ(), 2*time.Second,
+			"/bin/sh", "-c", script, "sh", ready, marker)
+		resultCh <- result{output: output, err: err}
+	}()
+	t.Cleanup(func() {
+		cancel()
+		if group > 0 {
+			_ = syscall.Kill(-group, syscall.SIGKILL)
+		}
+		if !resultReceived {
+			select {
+			case <-resultCh:
+			case <-time.After(3 * time.Second):
+			}
+		}
+	})
+	deadline := time.Now().Add(3 * time.Second)
+	var lastReadyErr error
+	for {
+		output, err := os.ReadFile(ready)
+		if err == nil {
+			var candidate int
+			if _, scanErr := fmt.Sscan(string(output), &candidate); scanErr == nil &&
+				candidate > 0 && strings.HasSuffix(string(output), "\n") {
+				group = candidate
+				break
+			}
+			lastReadyErr = fmt.Errorf("parse process group %q", output)
+		} else {
+			lastReadyErr = err
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("command did not report readiness: %v", lastReadyErr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	var commandResult result
+	select {
+	case commandResult = <-resultCh:
+		resultReceived = true
+	case <-time.After(4 * time.Second):
+		t.Fatal("cancelled command did not return")
+	}
+	if commandResult.err == nil {
+		t.Fatal("runCommandWithDelay succeeded after timeout")
+	}
+	if markerOutput, err := os.ReadFile(marker); err != nil || string(markerOutput) != "done" {
+		t.Fatalf("graceful cleanup = %q, %v", markerOutput, err)
+	}
+	deadline = time.Now().Add(2 * time.Second)
+	for syscall.Kill(-group, 0) == nil {
+		if time.Now().After(deadline) {
+			_ = syscall.Kill(-group, syscall.SIGKILL)
+			t.Fatalf("cancelled process group %d survived: %v", group, commandResult.err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestGitCommandDisablesRepositoryExecution(t *testing.T) {
 	workspace, _ := newGitRepo(t)
 	marker, hook := filepath.Join(t.TempDir(), "hook-ran"), filepath.Join(t.TempDir(), "hook.sh")
@@ -167,6 +601,7 @@ func TestGitCommandDisablesRepositoryExecution(t *testing.T) {
 		t.Fatal("gitCommand accepted hidden index state")
 	}
 }
+
 func TestGitCommandRejectsForgedTrackedState(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -212,6 +647,7 @@ func TestGitCommandRejectsForgedTrackedState(t *testing.T) {
 		})
 	}
 }
+
 func testCertifier(t *testing.T, workspace string) *certifier {
 	git, err := exec.LookPath("git")
 	mustNoError(t, err)

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -11,6 +11,71 @@ import (
 	"testing"
 )
 
+func TestC3CertificationEntrypointSanitizesBuildControl(t *testing.T) {
+	t.Parallel()
+
+	script := filepath.Join(repoRoot(t), "scripts", "certify-c3-parallel-sessions.sh")
+	bashEnvMarker := filepath.Join(t.TempDir(), "bash-env-ran")
+	functionMarker := filepath.Join(t.TempDir(), "function-ran")
+	bashEnv := filepath.Join(t.TempDir(), "bash-env")
+	if err := os.WriteFile(bashEnv, []byte(`printf injected >"`+bashEnvMarker+`"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	injectedFunction := `() { printf injected >"` + functionMarker + `"; }`
+	cmd := exec.Command(script, "--self-entrypoint-probe")
+	cmd.Env = canonicalBuildEnv(map[string]string{
+		"BASH_ENV":                         bashEnv,
+		"BASH_FUNC_exec%%":                 injectedFunction,
+		"BASH_FUNC_source%%":               injectedFunction,
+		"GOENV":                            filepath.Join(t.TempDir(), "go-env"),
+		"GOFLAGS":                          "-overlay=/tmp/workcell-hostile-overlay.json",
+		"GOTOOLCHAIN":                      "auto",
+		"GOWORK":                           filepath.Join(t.TempDir(), "go.work"),
+		"WORKCELL_C3_SANITIZED_ENTRYPOINT": "1",
+		"WORKCELL_GO_BIN":                  "/definitely-not-go",
+	})
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("entrypoint probe: %v: %s", err, output)
+	}
+	// Go reports an empty GOENV path when GOENV=off, then the other exact
+	// process-level controls.
+	if string(output) != "\noff\n-mod=readonly\nlocal\n" {
+		t.Fatalf("Go build control = %q", output)
+	}
+	for _, marker := range []string{bashEnvMarker, functionMarker} {
+		if _, err := os.Stat(marker); !os.IsNotExist(err) {
+			t.Fatalf("hostile shell control executed: %s: %v", marker, err)
+		}
+	}
+
+	const usage = "Usage: certify-c3-parallel-sessions.sh --workspace PATH [--precommit-control-tree SHA]\n"
+	cmd = exec.Command(script, "--help")
+	cmd.Env = canonicalBuildEnv(nil)
+	output, err = cmd.CombinedOutput()
+	if err != nil || string(output) != usage {
+		t.Fatalf("wrapper help = %q, %v", output, err)
+	}
+	cmd = exec.Command(script)
+	cmd.Env = canonicalBuildEnv(nil)
+	output, err = cmd.CombinedOutput()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok || exitErr.ExitCode() != 2 || string(output) != usage {
+		t.Fatalf("wrapper usage failure = %q, %v", output, err)
+	}
+
+	cmd = exec.Command(script,
+		"--workspace", "/definitely-not-a-workcell-workspace",
+		"--root", "/definitely-not-workcell")
+	cmd.Env = canonicalBuildEnv(nil)
+	output, err = cmd.CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "/definitely-not-a-workcell-workspace") ||
+		strings.Contains(string(output), "resolve control-plane root") {
+		t.Fatalf("wrapper-owned root was not pinned: %v: %s", err, output)
+	}
+}
+
 func TestVerifyInvariantsUsesDedicatedSanitizedEntrypoint(t *testing.T) {
 	t.Parallel()
 
@@ -125,6 +190,7 @@ func TestValidationGatesLintAllScenarioShellScripts(t *testing.T) {
 			"scripts/check-dead-code.sh",
 			"scripts/check-public-repo-hygiene.sh",
 			"scripts/check-pr-shape.sh",
+			"scripts/certify-c3-parallel-sessions.sh",
 			"scripts/generate-homebrew-formula.sh",
 			"scripts/install-workcell.sh",
 			"scripts/install.sh",

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -285,6 +285,19 @@ docs = [
   "docs/ci-threat-model.md",
 ]
 
+[functional.FR-015]
+title = "Native parallel strict sessions"
+summary = "Workcell supports overlapping same-repository strict sessions in distinct containers, isolated worktrees, and branches, with runtime cross-session write-invisibility, independent stop behavior, and bounded certifier cleanup."
+evidence = [
+  "scripts/certify-c3-parallel-sessions.sh",
+  "internal/host/c3certify/certify_test.go",
+  "tests/scenarios/shared/test-session-commands.sh",
+]
+docs = [
+  "docs/safe-path-expectations.md",
+  "docs/benchmark-evidence/c3-two-container-isolation-2026-07-15.md",
+]
+
 [nonfunctional.NFR-001]
 title = "Bounded VM-plus-container execution"
 summary = "The safe path preserves a dedicated Colima VM plus a hardened container rather than depending on provider config as the security boundary."

--- a/scripts/certify-c3-parallel-sessions.sh
+++ b/scripts/certify-c3-parallel-sessions.sh
@@ -1,0 +1,94 @@
+#!/bin/bash -p
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Omkhar Arasaratnam
+#
+# Thin host entrypoint for the Go-owned C3 strict-path certifier.
+set -euo pipefail
+set +C +f +v +x
+shopt -u failglob nullglob nocaseglob nocasematch
+unset CDPATH GLOBIGNORE
+
+readonly TRUSTED_HOST_PATH="/opt/homebrew/bin:/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
+[[ "${HOME:-}" == /* ]] || {
+  echo "certify-c3: HOME must be an absolute path" >&2
+  exit 2
+}
+ROOT_DIR="$(CDPATH='' cd -P -- "${BASH_SOURCE[0]%/*}/.." && pwd -P)"
+
+# shellcheck disable=SC2016
+exec /usr/bin/env -i \
+  PATH="${TRUSTED_HOST_PATH}" \
+  HOME="${HOME}" \
+  TMPDIR="${TMPDIR:-/tmp}" \
+  LC_ALL=C \
+  LANG=C \
+  GOENV=off \
+  GOWORK=off \
+  GOTOOLCHAIN=local \
+  GOFLAGS=-mod=readonly \
+  /bin/bash -p -c '
+    set -euo pipefail
+    readonly ROOT_DIR="$1"
+    shift
+    # shellcheck source=/dev/null
+    source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
+    if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
+      [[ "$#" -eq 1 ]] || exit 2
+      go_bin="$(resolve_go_bin)"
+      exec "${go_bin}" env GOENV GOWORK GOFLAGS GOTOOLCHAIN
+    fi
+    usage() {
+      echo "Usage: certify-c3-parallel-sessions.sh --workspace PATH [--precommit-control-tree SHA]"
+    }
+    arguments=("$@")
+    workspace_seen=0
+    while (($# > 0)); do
+      case "$1" in
+        -h | --help)
+          usage
+          exit 0
+          ;;
+        --workspace)
+          [[ "$#" -ge 2 && -n "$2" ]] || {
+            usage >&2
+            exit 2
+          }
+          workspace_seen=1
+          shift 2
+          ;;
+        --workspace=*)
+          [[ -n "${1#*=}" ]] || {
+            usage >&2
+            exit 2
+          }
+          workspace_seen=1
+          shift
+          ;;
+        --precommit-control-tree | --root)
+          [[ "$#" -ge 2 && -n "$2" ]] || {
+            usage >&2
+            exit 2
+          }
+          shift 2
+          ;;
+        --precommit-control-tree=* | --root=*)
+          [[ -n "${1#*=}" ]] || {
+            usage >&2
+            exit 2
+          }
+          shift
+          ;;
+        *)
+          echo "certify-c3: unknown argument: $1" >&2
+          usage >&2
+          exit 2
+          ;;
+      esac
+    done
+    ((workspace_seen == 1)) || {
+      usage >&2
+      exit 2
+    }
+    set -- "${arguments[@]}"
+    exec_go_run_in_repo "${ROOT_DIR}" ./cmd/workcell-c3-certify "$@" --root "${ROOT_DIR}"
+  ' workcell-c3-sanitized "${ROOT_DIR}" "$@"

--- a/scripts/dev-quick-check.sh
+++ b/scripts/dev-quick-check.sh
@@ -35,6 +35,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/check-dead-code.sh"
   "${ROOT_DIR}/scripts/check-public-repo-hygiene.sh"
   "${ROOT_DIR}/scripts/check-pr-shape.sh"
+  "${ROOT_DIR}/scripts/certify-c3-parallel-sessions.sh"
   "${ROOT_DIR}/scripts/ci-plan.sh"
   "${ROOT_DIR}/scripts/dev-quick-check.sh"
   "${ROOT_DIR}/scripts/go-port-validate.sh"

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -156,6 +156,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/check-repo-readiness.sh"
   "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
   "${ROOT_DIR}/scripts/check-public-contract.sh"
+  "${ROOT_DIR}/scripts/certify-c3-parallel-sessions.sh"
   "${ROOT_DIR}/scripts/build-and-test.sh"
   "${ROOT_DIR}/scripts/ci-plan.sh"
   "${ROOT_DIR}/scripts/bench/run-exec-guard-bench.sh"


### PR DESCRIPTION
## Summary

- activate the hardened C3 strict-path certifier through a sanitized Go-backed host entrypoint
- add failure-path and entrypoint controls for cleanup, identity, sockets, cancellation, and hostile build state
- record exact-tree Apple-Silicon/Colima evidence for overlapping same-repository sessions and align roadmap, readiness, safe-path, and requirements contracts

## Live certification

- certified activation commit: `a26b750f8d8c7957fc15a3f5c164c2df28f25b46`
- certified tree: `726f485a609b88edcee7ee5ad88692d7aafdd501`
- target: `macos/arm64/local_vm/colima/strict`
- result: overlapping sessions, distinct containers/worktrees/branches, symmetric cross-session write invisibility, independent stop, and complete owned-state cleanup

Merge with a merge commit. Squash or rebase merging would discard the certified
activation commit and invalidate the documented reachability condition.

## Validation

- `go test -count=1 ./...`
- `go test -race -count=1 ./internal/host/c3certify`
- `go vet ./...`
- focused shellcheck, entrypoint, contract-parity, requirements, markdown, and spelling checks
- two complete `./scripts/pre-merge.sh --profile pr-parity` passes; final evidence binds current `main` (`e491e5cf`) to head `9cfb07fd`
