### PR TITLE
Repair brace-expansion security pins

### DIFF
--- a/runtime/container/providers/package.json
+++ b/runtime/container/providers/package.json
@@ -9,7 +9,7 @@
   },
   "overrides": {
     "@tootallnate/once": "3.0.1",
-    "brace-expansion": "5.0.5",
+    "brace-expansion": "5.0.9",
     "picomatch": "4.0.4"
   }
 }

--- a/tools/markdownlint/package-lock.json
+++ b/tools/markdownlint/package-lock.json
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary

- update the runtime provider override from brace-expansion 5.0.5 to 5.0.9
- update the markdownlint lock from brace-expansion 5.0.8 to 5.0.9
- resolve GHSA-rgw5-rvv9-x895 / CVE-2026-69152 without unrelated provider upgrades

## Validation

- npm audit for runtime/container/providers: 0 vulnerabilities
- npm audit for tools/markdownlint: 0 vulnerabilities
- check-pinned-inputs and build-input-manifest verification
- full local pr-parity, including repository invariants, docs, runtime build, and container smoke

## Review

- Codex bot review loop required before merge
- merge only after all hosted checks and review threads are clean