### PR TITLE
Enforce release environment tag policy

### DIFF
--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -183,7 +183,8 @@ reviewed inputs:
 - tag rulesets for `refs/tags/v*`
 - the `release` environment, with reviewer protection when the GitHub plan
   supports it and an explicitly documented lower-assurance fallback when it
-  does not
+  does not; it permits only `v*` deployment tags, no deployment branches, no
+  environment variables or secrets, and no administrator bypass
 - the `hosted-controls-audit` and `upstream-refresh` environments, including
   their exact secret and variable contents plus their disabled admin bypass
   posture

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -55,6 +55,9 @@ honestly in docs, status reports, and release commentary.
   `workcell-pr-lifecycle` skill in addition to this release runbook.
 - Wait for `main` to be green before pushing the release tag.
 - Follow the tag-triggered `Release` workflow through completion.
+- Before pushing the tag, verify the hosted-controls audit confirms that the
+  `release` environment permits only `v*` deployment tags, with no deployment
+  branches, variables, secrets, or administrator bypass.
 - Approve the `release` environment only after release preflight and install
   verification are green.
 - Verify that the repository-level immutable-release control is enabled before

--- a/internal/metadatautil/hostedcontrols.go
+++ b/internal/metadatautil/hostedcontrols.go
@@ -227,6 +227,26 @@ func ValidateCanonicalWorkflowEnvironments(policy map[string]any, policyPath str
 		return err
 	}
 
+	release, ok := environments["release"]
+	if !ok {
+		return errors.New("policy/github-hosted-controls.toml must declare workflow_environment.release")
+	}
+	if len(release.RequiredSecrets) != 0 {
+		return errors.New("policy/github-hosted-controls.toml must not declare secrets for workflow_environment.release")
+	}
+	if len(release.Variables) != 0 {
+		return errors.New("policy/github-hosted-controls.toml must not declare public variables for workflow_environment.release")
+	}
+	if !release.HasAllowAdminBypass || release.AllowAdminBypass {
+		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.release.allow_admin_bypass = false")
+	}
+	if release.HasDeploymentBranches || len(release.DeploymentBranches) != 0 {
+		return errors.New("policy/github-hosted-controls.toml must not set workflow_environment.release.deployment_branches")
+	}
+	if !release.HasDeploymentTags || len(release.DeploymentTags) != 1 || release.DeploymentTags[0] != "v*" {
+		return errors.New("policy/github-hosted-controls.toml must set workflow_environment.release.deployment_tags = [\"v*\"]")
+	}
+
 	hostedControlsAudit, ok := environments["hosted-controls-audit"]
 	if !ok {
 		return errors.New("policy/github-hosted-controls.toml must declare workflow_environment.hosted-controls-audit")

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -206,6 +206,10 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 		`WORKCELL_RELEASE_NO_ATTEST = "false"`,
 		`WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = "false"`,
 		"",
+		"[workflow_environment.release]",
+		"allow_admin_bypass = false",
+		`deployment_tags = ["v*"]`,
+		"",
 		"[workflow_environment.hosted-controls-audit]",
 		`required_secrets = ["WORKCELL_HOSTED_CONTROLS_TOKEN"]`,
 		"allow_admin_bypass = false",
@@ -375,6 +379,10 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 	}
 	releaseEnv := map[string]any{
 		"name": "release",
+		"deployment_branch_policy": map[string]any{
+			"custom_branch_policies": true,
+			"protected_branches":     false,
+		},
 		"protection_rules": []map[string]any{
 			releaseReviewRule,
 			{
@@ -383,6 +391,12 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 			},
 		},
 		"can_admins_bypass": false,
+	}
+	releaseVariables := map[string]any{
+		"variables": []map[string]any{},
+	}
+	releaseSecrets := map[string]any{
+		"secrets": []map[string]any{},
 	}
 	hostedControlsAuditEnv := map[string]any{
 		"name": "hosted-controls-audit",
@@ -420,6 +434,11 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 			{"name": "v*", "type": "tag"},
 		},
 	}
+	releaseDeploymentPolicies := map[string]any{
+		"branch_policies": []map[string]any{
+			{"name": "v*", "type": "tag"},
+		},
+	}
 	upstreamRefreshDeploymentBranches := map[string]any{
 		"branch_policies": []map[string]any{
 			{"name": "main", "type": "branch"},
@@ -444,6 +463,9 @@ func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, d
 		{"environment-hosted-controls-audit-variables.json", hostedControlsAuditVariables},
 		{"environment-hosted-controls-audit-secrets.json", hostedControlsAuditSecrets},
 		{"environment-release.json", releaseEnv},
+		{"environment-release-deployment-branch-policies.json", releaseDeploymentPolicies},
+		{"environment-release-variables.json", releaseVariables},
+		{"environment-release-secrets.json", releaseSecrets},
 		{"environment-upstream-refresh.json", upstreamRefreshEnv},
 		{"environment-upstream-refresh-deployment-branch-policies.json", upstreamRefreshDeploymentBranches},
 		{"environment-upstream-refresh-variables.json", upstreamRefreshVariables},
@@ -1327,5 +1349,30 @@ func TestVerifyGitHubHostedControlsRejectsUnexpectedEnvironmentBranchPolicy(t *t
 	}
 	if !strings.Contains(err.Error(), "must restrict deployment branches to main") {
 		t.Fatalf("metadatautil.VerifyGitHubHostedControls() error = %v, want deployment-branch rejection", err)
+	}
+}
+
+func TestVerifyGitHubHostedControlsRejectsUnexpectedReleaseTagPolicy(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, policyPath := writeHostedControlsFixture(t, "review-gated", "review-gated", []map[string]any{
+		{
+			"login": "omkhar",
+			"permissions": map[string]any{
+				"admin": true,
+			},
+		},
+	})
+
+	rewriteFile(t, filepath.Join(tmpDir, "environment-release-deployment-branch-policies.json"), func(content string) string {
+		return strings.Replace(content, `"v*"`, `"release/*"`, 1)
+	})
+
+	err := metadatautil.VerifyGitHubHostedControls(tmpDir, "omkhar/workcell", policyPath)
+	if err == nil {
+		t.Fatal("metadatautil.VerifyGitHubHostedControls() unexpectedly accepted the wrong release tag policy")
+	}
+	if !strings.Contains(err.Error(), "workflow environment omkhar/workcell/release must restrict deployment tags to v*") {
+		t.Fatalf("metadatautil.VerifyGitHubHostedControls() error = %v, want release tag-policy rejection", err)
 	}
 }

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -1226,6 +1226,10 @@ func TestValidateCanonicalHostedControlsWorkflowEnvironmentsRejectsMissingHosted
 	t.Parallel()
 	policy := map[string]any{
 		"workflow_environment": map[string]any{
+			"release": map[string]any{
+				"allow_admin_bypass": false,
+				"deployment_tags":    []any{"v*"},
+			},
 			"upstream-refresh": map[string]any{
 				"allow_admin_bypass":  false,
 				"deployment_branches": []any{"main"},
@@ -1242,10 +1246,92 @@ func TestValidateCanonicalHostedControlsWorkflowEnvironmentsRejectsMissingHosted
 	}
 }
 
+func TestValidateCanonicalHostedControlsWorkflowEnvironmentsRejectsInvalidReleasePolicy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		release map[string]any
+		want    string
+	}{
+		{
+			name:    "missing admin bypass",
+			release: map[string]any{"deployment_tags": []any{"v*"}},
+			want:    "must set workflow_environment.release.allow_admin_bypass = false",
+		},
+		{
+			name:    "admin bypass enabled",
+			release: map[string]any{"allow_admin_bypass": true, "deployment_tags": []any{"v*"}},
+			want:    "must set workflow_environment.release.allow_admin_bypass = false",
+		},
+		{
+			name:    "unexpected secrets",
+			release: map[string]any{"required_secrets": []any{"RELEASE_TOKEN"}, "allow_admin_bypass": false, "deployment_tags": []any{"v*"}},
+			want:    "must not declare secrets for workflow_environment.release",
+		},
+		{
+			name:    "unexpected variables",
+			release: map[string]any{"variables": map[string]any{"RELEASE_REGION": "north"}, "allow_admin_bypass": false, "deployment_tags": []any{"v*"}},
+			want:    "must not declare public variables for workflow_environment.release",
+		},
+		{
+			name:    "deployment branches",
+			release: map[string]any{"allow_admin_bypass": false, "deployment_branches": []any{"main"}, "deployment_tags": []any{"v*"}},
+			want:    "must not set workflow_environment.release.deployment_branches",
+		},
+		{
+			name:    "missing deployment tags",
+			release: map[string]any{"allow_admin_bypass": false},
+			want:    "must set workflow_environment.release.deployment_tags = [\"v*\"]",
+		},
+		{
+			name:    "wrong deployment tag",
+			release: map[string]any{"allow_admin_bypass": false, "deployment_tags": []any{"release/*"}},
+			want:    "must set workflow_environment.release.deployment_tags = [\"v*\"]",
+		},
+		{
+			name:    "multiple deployment tags",
+			release: map[string]any{"allow_admin_bypass": false, "deployment_tags": []any{"v*", "v1.*"}},
+			want:    "must set workflow_environment.release.deployment_tags = [\"v*\"]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := map[string]any{
+				"workflow_environment": map[string]any{
+					"release": tt.release,
+					"hosted-controls-audit": map[string]any{
+						"required_secrets":    []any{"WORKCELL_HOSTED_CONTROLS_TOKEN"},
+						"allow_admin_bypass":  false,
+						"deployment_branches": []any{"main"},
+						"deployment_tags":     []any{"v*"},
+					},
+					"upstream-refresh": map[string]any{
+						"allow_admin_bypass":  false,
+						"deployment_branches": []any{"main"},
+					},
+				},
+			}
+
+			err := metadatautil.ValidateCanonicalWorkflowEnvironments(policy, "policy/github-hosted-controls.toml")
+			if err == nil {
+				t.Fatal("metadatautil.ValidateCanonicalWorkflowEnvironments() unexpectedly accepted invalid release policy")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("metadatautil.ValidateCanonicalWorkflowEnvironments() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidateCanonicalHostedControlsWorkflowEnvironmentsRejectsUnexpectedUpstreamRefreshSecrets(t *testing.T) {
 	t.Parallel()
 	policy := map[string]any{
 		"workflow_environment": map[string]any{
+			"release": map[string]any{
+				"allow_admin_bypass": false,
+				"deployment_tags":    []any{"v*"},
+			},
 			"hosted-controls-audit": map[string]any{
 				"required_secrets":    []any{"WORKCELL_HOSTED_CONTROLS_TOKEN"},
 				"allow_admin_bypass":  false,
@@ -1273,6 +1359,10 @@ func TestValidateCanonicalHostedControlsWorkflowEnvironmentsAcceptsCanonicalValu
 	t.Parallel()
 	policy := map[string]any{
 		"workflow_environment": map[string]any{
+			"release": map[string]any{
+				"allow_admin_bypass": false,
+				"deployment_tags":    []any{"v*"},
+			},
 			"hosted-controls-audit": map[string]any{
 				"required_secrets":    []any{"WORKCELL_HOSTED_CONTROLS_TOKEN"},
 				"allow_admin_bypass":  false,

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -78,6 +78,13 @@ immutable_github_releases = true
 WORKCELL_RELEASE_NO_ATTEST = "false"
 WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS = "false"
 
+[workflow_environment.release]
+# Publish jobs may deploy only from protected release tags. The environment has
+# no branch eligibility, variables, or secrets; its reviewer gate is defined
+# separately by release_environment above.
+allow_admin_bypass = false
+deployment_tags = ["v*"]
+
 [workflow_environment.hosted-controls-audit]
 required_secrets = ["WORKCELL_HOSTED_CONTROLS_TOKEN"]
 allow_admin_bypass = false


### PR DESCRIPTION
Summary:
- Declare the release environment canonical deployment tag policy as v* only.
- Reject release environment branches, variables, secrets, and administrator bypass in policy and live audits.
- Add negative validator coverage and release runbook guidance.

Validation:
- Full pr-parity profile passed for exact head cb769c90580249e9f6df6f7f4f01d35d283ce159 and tree f77042d83a9bd29cb52d247d3116cbb29da38212.
- Focused metadata tests and contract, dead-code, pinned-input, requirements, and public-hygiene checks passed.
- Pre-rollout live hosted-controls audit fails only because the release environment lacks the required v* tag policy.

Rollout:
- Keep this PR draft through hosted checks and the Codex review loop.
- Add the exact v* live tag policy only after review is clean, rerun the hosted-controls audit, then merge.