### PR TITLE
Preserve Bash dialect across Docker environment declarations

### DIFF
--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -18,13 +18,13 @@ ARG SOURCE_DATE_EPOCH
 # One canonical, atomically replaced tuple feeds both shipped Dockerfiles.
 COPY --chmod=0444 runtime/container/debian-bootstrap.env /usr/local/share/workcell/debian-bootstrap.env
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
 ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 ENV TZ=UTC
 ENV npm_config_audit=false
 ENV npm_config_fund=false
 ENV npm_config_update_notifier=false
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
 RUN mapfile -t debian_bootstrap_pins < /usr/local/share/workcell/debian-bootstrap.env \
@@ -243,12 +243,13 @@ ARG TARGETARCH
 ARG BUILDKIT_MULTI_PLATFORM=1
 ARG SOURCE_DATE_EPOCH
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /workcell-rust
 
 ENV CARGO_HOME=/usr/local/cargo
 ENV PATH=/usr/local/cargo/bin:${PATH}
 ENV RUSTUP_HOME=/usr/local/rustup
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo
 COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup

--- a/tools/validator/Dockerfile
+++ b/tools/validator/Dockerfile
@@ -30,11 +30,11 @@ ARG RUSTUP_VERSION
 ARG RUSTUP_INIT_LINUX_X86_64_SHA256
 ARG RUSTUP_INIT_LINUX_ARM64_SHA256
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
 ENV CARGO_HOME=/usr/local/cargo
 ENV PATH=/usr/local/cargo/bin:/usr/local/go/bin:${PATH}
 ENV RUSTUP_HOME=/usr/local/rustup
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
 RUN mapfile -t debian_bootstrap_pins < /usr/local/share/workcell/debian-bootstrap.env \


### PR DESCRIPTION
## Summary

- place each stage's Bash `SHELL` declaration after its `ENV` declarations
- preserve Docker build behavior while allowing Hadolint 2.15.1 to retain the correct shell dialect
- unblock the reviewed upstream-pin refresh without suppressing new linter findings

## Validation

- `/tmp/hadolint-v2.15.1/hadolint-macos-arm64 --failure-threshold warning runtime/container/Dockerfile tools/validator/Dockerfile`
- `./scripts/check-pinned-inputs.sh`
- `go test ./internal/metadatautil ./internal/testkit`
- `./scripts/pre-merge.sh --profile pr-parity --allow-dirty`

## Context

The exact `main` upstream-refresh candidate from run 30858375257 advanced Hadolint to 2.15.1. Its independently reproduced PR-parity run stopped on SC3010 because Hadolint resets the inferred shell dialect when an `ENV` instruction follows `SHELL`. Moving `SHELL` after `ENV` makes the declared Bash execution model explicit at each affected `RUN` instruction.
