### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ This project follows a lightweight Keep a Changelog style.
 Historical release details before this file existed remain available in GitHub
 Releases.
 
-## Unreleased
+## v1.0.0 - 2026-08-04
+
+Workcell 1.0 freezes the supported operator contract and records a final GO
+decision for the Apple-Silicon macOS release boundary. Supported launch remains
+limited to strict Colima and lower-assurance Docker Desktop compatibility;
+remote macOS targets stay preview-only, and Linux and Windows remain blocked as
+operator hosts.
 
 ### Changed
 
@@ -16,6 +22,11 @@ Releases.
 
 ### Fixed
 
+- give detached provider sessions a real pseudoterminal while preserving the
+  controlled host send/attach channel, so interactive Tier 1 CLIs do not exit
+  immediately with a non-terminal stdin error; keep interactive attach portable
+  to the system Bash shipped by macOS; and keep graceful stop signal forwarding
+  inside the managed supervisor after the runtime drops privileges.
 - remove temporary Buildx resources after every runtime-image build attempt,
   with exact target, random identity, ownership, and inventory checks.
 - stage and hash the exact GitHub release asset inventory before the first

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,7 @@
 # Roadmap
 
-Workcell is still pre-1.0. The roadmap must expand adoption without weakening
+Workcell 1.0 freezes the reviewed local boundary and operator contract. The
+roadmap must expand adoption without weakening
 the core promise: coding agents run behind explicit runtime boundaries,
 support tiers, diagnostics, and evidence. Delivered features belong in the
 changelog and user docs. This file records direction and sequencing, not a
@@ -181,8 +182,8 @@ improvement tracks below; `G` items are the 1.0 contract-and-operations track.
    release lenses — records no unresolved P0/P1 findings, and every support
    matrix row matches shipped behavior.
 
-The G4 evidence package and its go/no-go checklist live in
-[`docs/1.0-readiness-review-draft.md`](docs/1.0-readiness-review-draft.md); the
+The completed G4 evidence package and its GO checklist live in
+[`docs/1.0-readiness-review.md`](docs/1.0-readiness-review.md); the
 B6 (item 6) real-boundary certification lane disposition options are in
 [`docs/b6-disposition-options-draft.md`](docs/b6-disposition-options-draft.md).
 **Recorded maintainer decisions (2026-07-09):** B2 — defer dual-control
@@ -195,7 +196,8 @@ OpenSSF badge to post-1.0 (criterion 2, amended above). E6 — defer the rendere
 docs site, demos, and external benchmark publication. C2 — defer certification
 and its latency target to post-1.0; preserve the generic driver as benchmark-only
 after rejecting the broader dedicated-certifier design (criteria 3 and 7 amended
-above). See the readiness review for the recorded G4 checklist state.
+above). The 2026-08-04 readiness review records the completed checklist, exact
+evidence identities, scope decisions, and zero unresolved P0/P1 findings.
 
 ### Milestone Train
 
@@ -210,7 +212,7 @@ live in
 | v0.13 | Boundary depth and stability | A1, A3, A4, B1, C5, D8, E1, E2, F3, G1 (inventory) |
 | v0.14 | Platform, speed, and adoption | C1, B8, B9, D3 (start), D4, E5, E7, G2, Antigravity Tier 1 adapter track |
 | v0.15 | Enterprise evidence and release assurance | A5, A6, C3, D5, D7, F1, G3 |
-| v1.0-rc | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
+| v1.0 | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
 | post-1.0 | Reach expansion | Phases 13–19 remainder, C2, C4, B2 (dual-control releases), B6 (automated real-boundary lane), B7 (badge + audit completion), E6 (rendered docs site + external demos), F2 |
 
 Phase 13 (Linux `amd64` `local_compat` certification candidate) may land
@@ -476,20 +478,20 @@ OS-level sandboxes (Seatbelt/bubblewrap). Workcell's VM-plus-container
 boundary and staged-credential model match the containment doctrine the
 strongest vendors now publish; these items deepen that lead.
 
-- **A1 (now, M):** egress policy depth and target parity — document, extend,
+- **A1 (complete, M):** egress policy depth and target parity — document, extend,
   and parity-label the shipped strict default-deny allowlist rather than
   build a duplicate lane
-- **A2 (now, M):** repo-defined MCP and agent-config containment,
+- **A2 (complete, M):** repo-defined MCP and agent-config containment,
   deny-by-default in `strict` with acknowledged, audited exceptions
-- **A3 (now, M):** fuzzing expansion across the Rust shim and Go parsers,
+- **A3 (complete, M):** fuzzing expansion across the Rust shim and Go parsers,
   wired into continuous fuzzing
-- **A4 (now, S):** `SAFETY:` documentation for every unsafe Rust block plus a
+- **A4 (complete, S):** `SAFETY:` documentation for every unsafe Rust block plus a
   pre-audit checklist
-- **A5 (next, M):** signed, tamper-evident session audit records verifiable
+- **A5 (complete, M):** signed, tamper-evident session audit records verifiable
   from outside the agent
-- **A6 (next, M):** documented syscall/filesystem hardening profile with a
+- **A6 (complete, M):** documented syscall/filesystem hardening profile with a
   deterministic conformance check
-- **A7 (now, S):** OWASP Agentic Top 10 control mapping feeding the Phase 11
+- **A7 (complete, S):** OWASP Agentic Top 10 control mapping feeding the Phase 11
   evidence packet
 
 ### Track B: Supply Chain And Release Assurance
@@ -500,15 +502,15 @@ keyless Sigstore signing, SBOMs, and GitHub attestations. These items close
 the remaining gaps between that posture and the level enterprises will ask a
 security-boundary product to prove.
 
-- **B1 (now, M):** SLSA v1.0 gap analysis published in the provenance docs
+- **B1 (complete, M):** SLSA v1.0 gap analysis published in the provenance docs
 - **B2 (post-1.0, M):** dual-control release approval — deferred by the
   2026-07-09 criterion-6 amendment because no second trusted maintainer exists;
   1.0 uses the documented single-maintainer controls in `docs/releasing.md`
-- **B3 (now, M):** scheduled mutation-score lane with published score and
+- **B3 (complete, M):** scheduled mutation-score lane with published score and
   baseline regression gate, beyond today's release-preflight-only run
-- **B4 (now, S):** centralized tool pins and a permitted-GitHub-actions
+- **B4 (complete, S):** centralized tool pins and a permitted-GitHub-actions
   allowlist check
-- **B5 (now, S):** audit-trail retention policy with extended
+- **B5 (complete, S):** audit-trail retention policy with extended
   release-evidence retention and post-expiry attestation/Rekor guidance
 - **B6 (post-1.0, L):** real-boundary certification lane on Apple Silicon runner
   infrastructure, gated on the CI threat model — deferred to post-1.0 by the
@@ -517,9 +519,9 @@ security-boundary product to prove.
 - **B7 (post-1.0, S + L):** OpenSSF Best Practices badge and funded
   third-party boundary audit — both deferred to post-1.0 by the 2026-07-09
   criterion-2/6 amendment
-- **B8 (next, M):** CI efficiency and reliability program — nightly
+- **B8 (complete, M):** CI efficiency and reliability program — nightly
   reproducibility split, retries, flake tracking, cost visibility
-- **B9 (next, M):** CI/CD threat model covering secrets, runner trust tiers,
+- **B9 (complete, M):** CI/CD threat model covering secrets, runner trust tiers,
   attestation assumptions, and signing-compromise response
 
 ### Track C: Runtime Platform Evolution
@@ -537,11 +539,10 @@ security-boundary product to prove.
 - **C3 (implemented; locally certified 2026-08-03, L):** native parallel
   sessions — one agent per worktree, branch, and isolated runtime, with
   session-record linkage. The exact-tree pre-merge certification is bound to
-  signed activation commit `a26b750f`; shipped status depends on that commit
-  being reachable from `main`
+  signed activation commit `a26b750f`, which is reachable from reviewed `main`
 - **C4 (later, L):** container tooling inside the boundary as an explicit
   labeled lane that never weakens the outer boundary
-- **C5 (now, S):** syscall-shim performance baselines for the hooked
+- **C5 (complete, S):** syscall-shim performance baselines for the hooked
   exec/spawn paths
 
 ### Track D: Code Health And Consolidation
@@ -552,43 +553,47 @@ monolithic Rust interception library, a 8,910-line launcher script, a
 9,131-line `verify-invariants.sh`, and widespread helper duplication across
 120 shell scripts (for example, 25 separate `cleanup()` definitions).
 
-- **D1 (now, S):** language-boundary doctrine — Rust for the shim, Go for
+- **D1 (complete, S):** language-boundary doctrine — Rust for the shim, Go for
   logic, shell as thin glue
-- **D2 (now, M):** shared shell helper library plus a shellcheck lane over
+- **D2 (complete, M):** shared shell helper library plus a shellcheck lane over
   all scripts
-- **D3 (next, L):** migrate the `verify-invariants` and `container-smoke`
-  orchestration from bash to Go, keeping scenario parity
-- **D4 (next, M):** modularize the launcher and document its contract
-- **D5 (next, L):** modularize the Rust interception library into focused
-  modules
-- **D6 (later, M):** split oversized Go validators per format
-- **D7 (next, M):** property-based session-lifecycle tests, Go benchmarks,
-  and a shell unit-test lane
-- **D8 (now, S):** stability contracts for internal APIs, CLI surfaces, and
+- **D3 (complete, L):** migrate the static `verify-invariants` scope to Go;
+  retain the documented static residual, dynamic tail, and container-smoke
+  orchestration in bash by the recorded G4 narrowing
+- **D4 (complete, M):** modularize the launcher and document its contract
+- **D5 (partial; post-1.0 remainder, L):** the git-policy module is extracted;
+  carry the remaining Rust interception-library module splits post-1.0
+- **D6 (complete for 1.0, M):** split the oversized Go validators by major
+  format; retain the small inline validators and dispatcher-main refactor as
+  post-1.0 code-health work by the recorded G4 scope decision
+- **D7 (partial; post-1.0 remainder, M):** property-based session-lifecycle
+  tests and shell-protocol coverage shipped; carry Go benchmarks and the broader
+  shell unit-test lane post-1.0
+- **D8 (complete, S):** stability contracts for internal APIs, CLI surfaces, and
   a unified exit-code contract
 
 ### Track E: Documentation And Adoption
 
-- **E1 (now, M):** tiered documentation entry points and a slimmer README
-- **E2 (now, M):** maintained architecture diagrams in the system design doc
-- **E3 (now, S):** support-tier legend and a `--doctor`/`--inspect`
+- **E1 (complete, M):** tiered documentation entry points and a slimmer README
+- **E2 (complete, M):** maintained architecture diagrams in the system design doc
+- **E3 (complete, S):** support-tier legend and a `--doctor`/`--inspect`
   diagnostics interpretation guide
-- **E4 (now, S):** docs CI depth — link checking, orphan detection, status
+- **E4 (complete, S):** docs CI depth — link checking, orphan detection, status
   labels, freshness markers
-- **E5 (next, M):** injection-policy annotated schema with complete
+- **E5 (complete, M):** injection-policy annotated schema with complete
   per-provider examples
 - **E6 (post-1.0, M):** adoption growth kit — docs site, terminal demos,
   Homebrew tap, isolation-model architecture post backed by benchmarks;
   deferred by the 2026-07-09 criterion-7 amendment
-- **E7 (next, S):** contributor runbook depth and substantive adapter READMEs
+- **E7 (complete, S):** contributor runbook depth and substantive adapter READMEs
 
 ### Track F: Enterprise And Standards Alignment
 
-- **F1 (next, M):** OCSF-mapped audit export — the concrete Phase 17 format
+- **F1 (complete, M):** OCSF-mapped audit export — the concrete Phase 17 format
   decision
 - **F2 (later, M):** SPIFFE-style per-session identity groundwork feeding
   Phase 15
-- **F3 (now, S):** standards watchlist (MCP spec line, OWASP agentic
+- **F3 (complete, S):** standards watchlist (MCP spec line, OWASP agentic
   guidance, agent-identity drafts) with a review cadence
 
 ### Track G: 1.0 Contract And Operations
@@ -597,16 +602,15 @@ These items exist specifically to make 1.0 a truthful claim: a frozen public
 contract and proven day-two operations.
 
 - **G1 (complete, M):** the public contract inventory, v1 stability
-  classification, deprecation policy, and release-preflight drift gate are
-  versioned; the candidate-scoped G4 readiness record will supply exact
-  identities
-- **G2 (implemented, M):** `workcell support-bundle` ships with documented
+  classification, deprecation policy, release-preflight drift gate, and exact
+  G4 evidence identities are versioned
+- **G2 (complete, M):** `workcell support-bundle` ships with documented
   redaction rules
-- **G3 (candidate freshness pending, M):** install, upgrade, uninstall,
-  rollback, and `--gc` have repeatable evidence; the readiness register keeps
-  historical release-candidate evidence separate from the final candidate
-- **G4 (pending, S):** the cross-lens 1.0 readiness gate records fixed statuses,
-  exact candidate/evidence identities, and every explicit scope decision
+- **G3 (complete, M):** install, upgrade, uninstall, rollback, and `--gc` have
+  repeatable CI evidence plus published-release local certification
+- **G4 (complete, S):** the cross-lens 1.0 readiness gate records fixed
+  statuses, exact candidate/evidence identities, every explicit scope decision,
+  and no unresolved P0/P1 findings
 
 ### Sequencing Summary
 

--- a/docs/1.0-readiness-review.md
+++ b/docs/1.0-readiness-review.md
@@ -1,19 +1,19 @@
-# Workcell 1.0 Readiness Review (DRAFT — maintainer sign-off required)
+# Workcell 1.0 Readiness Review — GO
 
-**Status: DRAFT for the G4 gate. This document does NOT itself decide 1.0
-readiness.** It is the evidence package a maintainer needs to run the cross-lens
-G4 review defined in
+**Status: GO for the v1.0.0 release boundary.** This is the completed
+cross-lens G4 review defined in
 [ROADMAP.md → 1.0 Release Criteria item 8](../ROADMAP.md#10-release-criteria)
 and
 [improvement-tracks-implementation-plan.md → G4](improvement-tracks-implementation-plan.md).
-Every claim below is grounded in code, policy, or docs merged to `main` and is
-marked with its verification basis. Claims about work still in review are
-labelled as such and MUST NOT be read as shipped.
+Every claim below is grounded in code, policy, docs, hosted checks, or live
+certification reachable from the reviewed `main` commit.
 
-Prepared 2026-07-08 against `main`; refreshed 2026-07-30 for the G1 contract
-freeze. The signed-audit contract surface (A5) is on `main`. Exact candidate
-and evidence identities remain intentionally unset until the G4 review;
-re-verify every remaining row before sign-off.
+Finalized 2026-08-04 against signed `main` merge
+`786c6140d51d67fb19cd6884b63e49affccf90a0`. Its tree
+`6fc94341222284e201795c99490abfc3da46031a` is identical to signed reviewed
+head `5288d5fd4e3047545b9952bd140aea2a61dc8cd4`; all 18 exact-merge checks
+were non-failing, no workflow remained active, and the repository readiness
+gate reported `ready` before the release branch was created.
 
 ## 1. What v0.13 → v0.15 delivered (merged, verified)
 
@@ -34,9 +34,9 @@ artifact exists and its tests/lanes are present; it is not a certification claim
 | F1 | OCSF-mapped audit export | Merged | `internal/ocsf/` (JSONL, OCSF 1.3.0, mapping v2); shared redaction with `internal/supportbundle/` |
 | G1 | Public contract inventory and v1 freeze | Complete | `policy/public-contract.toml`; `policy/operator-contract.toml`; `docs/stability-contract.md`; `workcell-citools validate-public-contract`; release-preflight validation |
 | G2 | `workcell support-bundle` command | Merged | `internal/supportbundle/{bundle,collect,redact,run}.go`; `SUPPORT.md`; redaction tests |
-| G3 | Install lifecycle proof | PARTIAL | Autonomous/CI core merged: install, upgrade-in-place, rollback, uninstall, `--gc` cleanup contract, and config-compat are CI-automatable and proven (`scripts/install-release.sh` cosign-verify fail-closed; `internal/testkit/install_release_e2e_test.go`; `tests/scenarios/shared/test-install-lifecycle.sh`; `docs/install-lifecycle.md`). The tracked G3 gate is BROADER (full day-two proof on the release matrix); it had a recorded **local-operator-certification remainder** — verified install against a real published cosign-signed release, live `--gc` end-to-end, and live launch on Apple Silicon — which is now **certified against the published `v1.0.0-rc.2` release** on the maintainer host (`docs/install-lifecycle.md` §"Certification record": end-to-end `install-release.sh` exit 0 with cosign+digest+attestation verified and a tamper negative control, live `--gc` exit 0, and both boundary launch-smoke scenarios passing). |
-| D3 (complete) | verify-invariants static-invariant migration | Work complete; residual acceptance is a G4 scope decision (§6) | `internal/workcellhardening/` + `cmd/workcell-citools`; the bulk of static invariants is in Go, with a documented narrow static residual accepted (not a completed migration) and a genuinely non-static tail that stays in bash by design — see the D3 (complete) status note in `docs/improvement-tracks-implementation-plan.md`. The literal-exit-gate scope decision (carry the remainder vs. record an explicit narrowing) is pending in §5/§6, not decided here. |
-| D6 | Split oversized Go validators | De-oversizing goal met; whether D6-complete gates 1.0-rc is a G4 scope decision (§6) | `internal/metadatautil/pinnedinputs_workflows.go`, `pinnedinputs_node.go`, and `pinnedinputs_docker.go` split out; the small Rust (~129 lines) and Python (~7 lines) validators remain inline as an accepted, non-oversized remainder (recorded 2026-07-09 in `docs/improvement-tracks-implementation-plan.md`). The gating decision is pending in §5/§6, not decided here. |
+| G3 | Install lifecycle proof | Complete | Autonomous/CI core merged: install, upgrade-in-place, rollback, uninstall, `--gc` cleanup contract, and config-compat are CI-automatable and proven (`scripts/install-release.sh` cosign-verify fail-closed; `internal/testkit/install_release_e2e_test.go`; `tests/scenarios/shared/test-install-lifecycle.sh`; `docs/install-lifecycle.md`). The local-operator remainder is certified against the published `v1.0.0-rc.2` release on the maintainer host: verified install with cosign, digest, and attestation checks plus a tamper negative control; live `--gc`; and both launch boundaries. |
+| D3 (complete) | verify-invariants static-invariant migration | Complete under recorded narrowing | `internal/workcellhardening/` + `cmd/workcell-citools` serve the bulk static scope. G4 accepts the documented narrow static residual, dynamic tail, and `container-smoke` orchestration in bash by design; further migration is post-1.0 code health. |
+| D6 | Split oversized Go validators | Complete for 1.0 | Major formats are split into `pinnedinputs_workflows.go`, `pinnedinputs_node.go`, and `pinnedinputs_docker.go`. G4 accepts the small inline Rust/Python validators and remaining dispatcher-main refactor as post-1.0 code health. |
 
 ## 2. Recently merged (2026-07-09) — formerly in review, now on `main`
 
@@ -96,15 +96,15 @@ supplemental); Google — not Workcell — retires personal-account OAuth login 
 - **Hardening profile (A6):** `policy/hardening-profile.toml` documents the
   reviewed seccomp/capability/rootfs/tmpfs/pids posture with a machine-checkable
   conformance check wired into `verify-invariants`.
-- **Install-lifecycle proof (G3, PARTIAL):** `scripts/install-release.sh`
+- **Install-lifecycle proof (G3, complete):** `scripts/install-release.sh`
   verifies the signed `SHA256SUMS` with cosign fail-closed before extraction by
   default (a documented `--skip-verify` opt-out exists, gated behind an explicit
   `--i-understand-unverified-install` acknowledgment, so verification is the
   default rather than unconditionally forced),
   and the CI-automatable day-two set (install/upgrade/rollback/uninstall/`--gc`
-  contract/config-compat) is proven; the full release-matrix day-two proof has a
-  recorded local-operator-certification remainder (verified install against a
-  real published release, live `--gc`, live launch) — see `docs/install-lifecycle.md`.
+  contract/config-compat) is proven. The former local-operator remainder is also
+  certified: verified install against a real published release, live `--gc`,
+  and both live launch boundaries — see `docs/install-lifecycle.md`.
 - **MCP containment (A2):** repo-defined MCP/agent-config surfaces are
   deny-by-default in `strict` with acknowledged, audited exceptions.
 - **Provenance/SLSA (B1):** `docs/provenance.md` records the SLSA Build-track
@@ -120,8 +120,8 @@ Grounded in `ROADMAP.md` Non-Goals plus verification of what is on `main`:
   Linux `amd64` is a trusted validation host only.
 - **Apple `container` is preview-only/launch-blocked** for 1.0; promotion is
   deferred post-1.0 pending the B6 certification lane.
-- **Antigravity is fail-closed scaffold**, not a support claim. 1.0 may ship
-  with the scaffold plus a recorded scope decision (ROADMAP criterion 4).
+- **Antigravity is a fail-closed scaffold**, not a support claim. 1.0 ships
+  with the scaffold and its recorded post-1.0 deferral (ROADMAP criterion 4).
 - **B2 dual-control releases:** deferred to post-1.0 by recorded maintainer
   decision (2026-07-09) — single-maintainer releases are the current mode.
   Compensating controls (signed commits, protected main, admin-merge audit
@@ -170,12 +170,11 @@ Grounded in `ROADMAP.md` Non-Goals plus verification of what is on `main`:
   for 1.0, mitigated by all-GitHub-hosted ephemeral single-use runners,
   least-privilege per-job tokens, `persist-credentials: false`, and pinned
   actions/tools — see `docs/ci-threat-model.md` threat 4 / known gap 4.
-- **G1 freeze:** complete after A5 and the contract surface settled. Candidate
-  certification and the G4 readiness decision remain separate gates; the
-  freeze does not claim that either is complete.
-- **D3 (complete) / D6:** see the D3 and D6 status notes in
-  `docs/improvement-tracks-implementation-plan.md` — both have literal-exit-gate
-  scope decisions pending for this review.
+- **G1 freeze:** complete after A5 and the contract surface settled. G4 is also
+  complete; the signed release tag and published artifacts remain separate
+  release steps.
+- **D3 (complete) / D6:** G4 accepts the documented narrow D3 residual and the
+  small D6 inline/dispatcher remainder as post-1.0 code-health work.
 - **D5 / D7 shell-unit lane — carried to post-1.0 (accepted):** D5 (Rust
   interception-library modularization) is partial — the git-policy module is
   extracted (`runtime/container/rust/src/gitpolicy.rs`), but `lib.rs` (~2.2k
@@ -190,23 +189,22 @@ Grounded in `ROADMAP.md` Non-Goals plus verification of what is on `main`:
   bats-style unit lane** over the full set of D2 shared shell helpers. Neither
   blocks 1.0.
 
-## 6. Go / no-go checklist for the maintainer (G4)
+## 6. Final GO checklist (G4)
 
-Run the cross-lens review (product, enterprise/security, adapter-maintainer,
-validation, docs/contract, release). This checklist is unchecked on purpose —
-the maintainer records the outcome.
+The product, enterprise/security, adapter-maintainer, validation,
+docs/contract, and release lenses completed this checklist on 2026-08-04.
 
 - [x] **A5 merged to `main`** (2026-07-09) and its tamper/verify tests green;
       audit surface settled before freeze (release-criteria item 2). DONE.
-- [ ] **Every support-matrix row matches shipped behavior** — walk
+- [x] **Every support-matrix row matches shipped behavior** — verified
       `policy/host-support-matrix.tsv` against real launch/blocked behavior
       (criterion 8).
-- [ ] **Every provider-matrix row matches shipped behavior**, and the Antigravity
-      scope decision (support claim vs recorded deferral) is recorded
-      (criterion 4).
+- [x] **Every provider-matrix row matches shipped behavior.** Codex, Claude
+      Code, GitHub Copilot CLI, and Gemini are Tier 1. Antigravity remains a
+      fail-closed scaffold deferred to post-1.0 (criterion 4).
 - [x] **Contract surface frozen (G1)** — inventory frozen, deprecation policy
       published, drift gate enforced in release preflight.
-- [ ] **Boundary assurance items** A1/A2/A3/A4/A5/A6 landed (criterion 2).
+- [x] **Boundary assurance items** A1/A2/A3/A4/A5/A6 landed (criterion 2).
 - [x] **Third-party boundary audit (B7)** — **DEFERRED to post-1.0 by recorded
       maintainer decision (2026-07-09)**; criterion 2 amended in `ROADMAP.md`
       accordingly (no audit sponsor/funding). 1.0 boundary assurance rests on the
@@ -221,8 +219,10 @@ the maintainer records the outcome.
       the G4 plan; 1.0 makes no C2 performance claim. This records only the
       narrow C2 scope decision: it does not mark Platform or overall readiness
       complete.
-- [ ] **Platform** strict + compat certified on the release matrix (both
-      boundaries certified on the maintainer host 2026-07-13 —
+- [x] **Platform** strict + compat certified on the release matrix. Historical
+      boundary certification was recorded on 2026-07-13. On 2026-08-04, all
+      four supported agents passed both boundary smokes on the exact reviewed
+      tree —
       `test-agent-launch-smoke.sh` for `macos/arm64/local_vm/colima/strict` and
       `test-docker-desktop-launch-smoke.sh` for
       `macos/arm64/local_compat/docker-desktop/compat`); C1 decision recorded
@@ -241,27 +241,27 @@ the maintainer records the outcome.
       cross-session invisibility; independent stop behavior; and bounded
       removal of sessions, containers, worktrees, the certifier-owned profile,
       target state, and runtime cache. The exact-tree run is bound to signed
-      activation commit `a26b750f`; treat it as shipped only when that commit is
-      reachable from `main`. The CI clone-level proof remains complementary and
+      activation commit `a26b750f`, which is reachable from reviewed `main`.
+      The CI clone-level proof remains complementary and
       launches no containers. Historical preliminary and certified evidence is
       committed at
       [`docs/benchmark-evidence/c3-two-container-isolation-2026-07-15.md`](benchmark-evidence/c3-two-container-isolation-2026-07-15.md).
-- [ ] **Adoption surface** — tiered docs (E1, merged), architecture diagrams
+- [x] **Adoption surface** — tiered docs (E1, merged), architecture diagrams
       (E2, merged), and support guides (E3, merged) are the 1.0 gate. **E6 is
       DEFERRED to post-1.0 (2026-07-09 maintainer decision)** — 1.0 ships with
       in-repo markdown docs; a **preliminary** C2 capture was published to
       `docs/session-startup-benchmarks.md` on 2026-07-15 (not a certification —
       C2 certification and its 1.0 target are deferred post-1.0 by the recorded
       G4 decision). See the amended criterion 7 in `ROADMAP.md`.
-- [ ] **Operations** G2 proven; G3 day-two lifecycle proven end-to-end on the
+- [x] **Operations** G2 proven; G3 day-two lifecycle proven end-to-end on the
       release matrix (criterion 5). G3's CI-automatable core is merged, and the
       local-operator-certification remainder (verified install against a real
       published release, live `--gc`, live launch) is now **certified against
       the published `v1.0.0-rc.2` release** on the maintainer host — see
       `docs/install-lifecycle.md` §"Certification record". Confirm the recorded
       evidence at sign-off.
-- [ ] **Release assurance** — B3 mutation-score gating and B1 SLSA L3 gaps must
-      be closed or explicitly dispositioned (criterion 6). **B2 dual-control
+- [x] **Release assurance** — B3 mutation-score gating is green and B1 SLSA L3
+      gaps are explicitly dispositioned (criterion 6). **B2 dual-control
       releases and B7 OpenSSF badge are deferred to post-1.0** (2026-07-09
       amendments): B2 because single-maintainer is the current reality
       (compensating controls documented in `docs/releasing.md`), and B7 with the
@@ -277,21 +277,22 @@ the maintainer records the outcome.
       boundary is exercised locally, not continuously in hosted CI (only a Docker
       smoke lane is). The local certification itself is tracked under the
       Platform/Operations items below and `docs/b6-disposition-options-draft.md`.
-- [ ] **D3 (complete) and D6 scope decisions recorded** — for D3, either carry
-      the remaining static remainder (e.g. the run_in_vm colima-egress-allowlist
-      order check) + container-smoke migration, or record an explicit narrowing
-      of the D3 (complete) gate; the bulk of static invariants are already in Go.
-      For D6, decide whether D6 (complete) gates 1.0-rc.
-- [ ] **No unresolved P0/P1 findings** across all lenses; all scope decisions
-      recorded with evidence links (criterion 8).
+- [x] **D3 (complete) and D6 scope decisions recorded.** G4 accepts D3's narrow
+      static residual, dynamic tail, and container-smoke orchestration in bash;
+      it accepts D6's small inline validators and dispatcher-main refactor as
+      post-1.0 code-health work.
+- [x] **No unresolved P0/P1 findings** across all lenses. The adversarial review
+      found two P1 validation gaps; both were fixed before publication. Codex
+      later found one P1 scenario-manifest TSV-order gap; it was fixed on signed
+      head `5288d5fd4e3047545b9952bd140aea2a61dc8cd4`, the thread was resolved,
+      and exact-head Codex review was clean both after the fix and after CI.
 
 ## 7. Verification basis and caveats
 
-- Rows in §1 were verified by file existence + presence of tests/lanes on
-  `main`; they are NOT independent certification results.
+- Rows in §1 were verified by file existence and tests/lanes on reviewed
+  `main`; live-certification claims are separately identified.
 - §2 (A5) was verified by confirming `internal/host/auditseal` and
   `internal/host/keystore` plus the `workcell session verify` surface are present
   on `main` (merged 2026-07-09), with their tamper/verify tests green.
-- This draft deliberately does not assert pass/fail on any criterion — that is
-  the maintainer's G4 decision. Where a subagent census and direct inspection
-  disagreed (A5), direct inspection of `main` won.
+- Final GO applies only to the support boundary in §3. It does not promote any
+  preview, validation-only, unsupported, deferred, or non-claim surface.

--- a/docs/b6-disposition-options-draft.md
+++ b/docs/b6-disposition-options-draft.md
@@ -194,4 +194,4 @@ local-operator cert) to meet buyer expectations, and funding/ops for a
 lower-trust Apple Silicon runner is available before the freeze.
 
 Either way, the decision and its evidence basis must be recorded in the G4
-readiness review (see `docs/1.0-readiness-review-draft.md` §6).
+readiness review (see `docs/1.0-readiness-review.md` §6).

--- a/docs/benchmark-evidence/c3-two-container-isolation-2026-07-15.md
+++ b/docs/benchmark-evidence/c3-two-container-isolation-2026-07-15.md
@@ -1,7 +1,7 @@
 # C3 — two-session isolation evidence
 
 Auditable evidence for the C3 isolation run recorded in
-[`../1.0-readiness-review-draft.md`](../1.0-readiness-review-draft.md) §6 Platform
+[`../1.0-readiness-review.md`](../1.0-readiness-review.md) §6 Platform
 row. Two same-repo detached sessions were started with `--session-workspace
 isolated` on `macos/arm64/local_vm/colima/strict` (profile `wcl-workcell-006e49ec`),
 then `session show` was captured for each.

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -63,7 +63,7 @@ The milestone ordering answers the current landscape directly:
 | v0.13 | Boundary depth and stability | A1, A3, A4, B1, C5, D8, E1, E2, F3, G1 (inventory) |
 | v0.14 | Platform, speed, and adoption | C1, B8, B9, D3 (start), D4, E5, E7, G2, Antigravity Tier 1 adapter track |
 | v0.15 | Enterprise evidence and release assurance | A5, A6, C3, D5, D7, F1, G3 |
-| v1.0-rc | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
+| v1.0 | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
 | post-1.0 | Reach expansion | Phases 13–19 remainder, C2, C4, B2 (dual-control releases), B6 (automated real-boundary lane), B7 (badge + audit completion), E6 (rendered docs site + external demos), F2 |
 
 Items inside a milestone are independently shippable and individually
@@ -605,7 +605,7 @@ here for continuity of the B6 track.
 - Size: M. Dependencies: G1 inventory (formats must be versioned to prove
   compatibility).
 
-## Milestone v1.0-rc: Freeze And Gate
+## Milestone v1.0: Freeze And Gate
 
 ### G1 (part 2): Contract Freeze And Deprecation Policy
 
@@ -633,6 +633,11 @@ here for continuity of the B6 track.
   decisions recorded; criteria checklist complete with evidence links.
 - Validation: the recorded review itself.
 - Size: S (review) over the rc period. Dependencies: everything above.
+- Status (recorded 2026-08-04): COMPLETE. The six-lens review verified the
+  support and provider matrices, recorded every scope decision, closed its two
+  initial P1 findings and one subsequent Codex review finding, and finished
+  with no unresolved P0/P1 findings. Exact identities and evidence links are in
+  `docs/1.0-readiness-review.md`.
 
 ### D3 (complete): Orchestration Migration Finished
 
@@ -669,7 +674,7 @@ here for continuity of the B6 track.
 - Validation: existing pin-hygiene lanes before/after; mutation coverage.
 - Size: M. Dependencies: none; scheduled late to avoid churn against B4.
 
-- Status (recorded 2026-07-08, evidence-based): PARTIAL. The GitHub Actions
+- Historical status (recorded 2026-07-08, evidence-based): PARTIAL. The GitHub Actions
   workflow format is already extracted into
   `internal/metadatautil/pinnedinputs_workflows.go` (PR #453). The remaining
   split is a real behavior-preserving refactor lane, not a doc finalization:
@@ -687,15 +692,16 @@ here for continuity of the B6 track.
   D6 "largest dispatcher mains" clause (`cmd/workcell-hostutil/main.go` at 1,300
   lines) is likewise a separate refactor slice. This does not gate 1.0
   correctness — the validators already pass — it is a code-health split; the
-  maintainer should decide whether D6 (complete) is required for the 1.0-rc gate
-  or can carry into the rc window / post-1.0 as a code-health item.
+  G4 therefore had to decide whether D6 (complete) was required for the 1.0
+  gate or could carry into post-1.0 as a code-health item.
 - Update (recorded 2026-07-09): the largest pinned-input ecosystems are split
   into their own files (GitHub Actions workflows in `pinnedinputs_workflows.go`,
   Node/npm in `pinnedinputs_node.go`, and Docker in `pinnedinputs_docker.go`); the
   small Rust (~129 lines) and Python (~7 lines) validators remain inline as an
   accepted, non-oversized remainder. The D6 de-oversizing goal is met —
-  `pinnedinputs.go` is no longer oversized; the D6 gate closes once the G4
-  review records any accepted dispatcher-main remainder.
+  `pinnedinputs.go` is no longer oversized. G4 accepted the small inline
+  validators and remaining dispatcher-main refactor as post-1.0 code-health
+  work, so D6 is complete for the 1.0 gate.
 
 ## Post-1.0
 

--- a/docs/workcell-session-supervisor-design.md
+++ b/docs/workcell-session-supervisor-design.md
@@ -138,6 +138,25 @@ trust.
 emit stable key=value summaries so detached-session control stays scriptable on
 the host.
 
+## Runtime Language Boundary
+
+The host-side session policy, durable state, and orchestration remain in the Go
+session tooling. `runtime/container/detached-stdin-wrapper.sh` is a deliberate,
+bounded exception to the default Go language boundary: it is the container
+entrypoint's process-local adapter around `/usr/bin/script`, and must run as the
+detached container's PID 1 after the entrypoint drops privileges. Its only
+responsibilities are to keep the provider attached to a pseudo-terminal, relay
+the Workcell-owned input FIFO, forward container signals to that provider, reap
+the process tree, and return the provider's exit status.
+
+Keeping that adapter in shell avoids adding another trusted runtime binary
+and build artifact solely to supervise commands that the entrypoint already
+executes. The wrapper does not select policy, write durable session state, or
+implement host orchestration; additions in any of those areas belong in Go.
+If its process-local lifecycle responsibilities grow beyond this bounded list,
+move the supervisor to a dedicated Go runtime tool instead of extending the
+shell exception.
+
 ## Current Non-Goals
 
 The current slice does not yet attempt to implement:

--- a/docs/workcell-session-supervisor-design.md
+++ b/docs/workcell-session-supervisor-design.md
@@ -146,8 +146,9 @@ bounded exception to the default Go language boundary: it is the container
 entrypoint's process-local adapter around `/usr/bin/script`, and must run as the
 detached container's PID 1 after the entrypoint drops privileges. Its only
 responsibilities are to keep the provider attached to a pseudo-terminal, relay
-the Workcell-owned input FIFO, forward container signals to that provider, reap
-the process tree, and return the provider's exit status.
+the Workcell-owned input FIFO in key-at-a-time terminal mode, synchronize
+terminal dimensions, forward container signals to that provider, reap the
+process tree, restore terminal state, and return the provider's exit status.
 
 Keeping that adapter in shell avoids adding another trusted runtime binary
 and build artifact solely to supervise commands that the entrypoint already

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -212,7 +212,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/detached-stdin-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/detached-stdin-wrapper.sh",
-      "sha256": "d715de1a87695aac871700b0b33b3845b176db5d73f4c285cb2922ca43660c03"
+      "sha256": "9802a89717992353b5ddee76fdf64ca678705c2b19efa1cb757eb2071b3259e8"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -212,7 +212,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/detached-stdin-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/detached-stdin-wrapper.sh",
-      "sha256": "9802a89717992353b5ddee76fdf64ca678705c2b19efa1cb757eb2071b3259e8"
+      "sha256": "8abf7c68352a6133b03bd3b7bd3e308b0d9cfeddc45e4fa5df05a12dc95ef3f3"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -212,7 +212,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/detached-stdin-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/detached-stdin-wrapper.sh",
-      "sha256": "5c22095abfe9bcd858b5174b54e1af2d3e244b86034d4c4794ff64679c894d3a"
+      "sha256": "d715de1a87695aac871700b0b33b3845b176db5d73f4c285cb2922ca43660c03"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "e414864af41a89527582c891bb777f513816b2cccbfd63a48106e0f8fab0126d"
+      "sha256": "98a7b04fbd880f74b3a3725536efb963212c5bc10c1c604c13e03f8ffd4f1e5e"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",
@@ -212,7 +212,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/detached-stdin-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/detached-stdin-wrapper.sh",
-      "sha256": "55b23923d5e22ad5559c1aa598301f98899ac0bf473c591dbeb42f91660b8c98"
+      "sha256": "5c22095abfe9bcd858b5174b54e1af2d3e244b86034d4c4794ff64679c894d3a"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/detached-stdin-wrapper.sh
+++ b/runtime/container/detached-stdin-wrapper.sh
@@ -54,20 +54,28 @@ forward_child_signal() {
   fi
 }
 
+first_child_of() {
+  local parent_pid="$1"
+  local candidate_pid=""
+
+  while read -r candidate_pid; do
+    if [[ "${candidate_pid}" =~ ^[1-9][0-9]*$ ]]; then
+      printf '%s\n' "${candidate_pid}"
+      return 0
+    fi
+  done < <(/usr/bin/ps -o pid= --ppid "${parent_pid}" 2>/dev/null)
+  return 1
+}
+
 discover_provider() {
   local attempt=0
   local pty_shell_pid=""
   local candidate_provider_pid=""
 
   for ((attempt = 0; attempt < 50; attempt++)); do
-    pty_shell_pid=""
-    if [[ -r "/proc/${child_pid}/task/${child_pid}/children" ]]; then
-      read -r pty_shell_pid _ <"/proc/${child_pid}/task/${child_pid}/children" || true
-    fi
-    if [[ "${pty_shell_pid}" =~ ^[1-9][0-9]*$ ]] &&
-      [[ -r "/proc/${pty_shell_pid}/task/${pty_shell_pid}/children" ]]; then
-      candidate_provider_pid=""
-      read -r candidate_provider_pid _ <"/proc/${pty_shell_pid}/task/${pty_shell_pid}/children" || true
+    pty_shell_pid="$(first_child_of "${child_pid}" || true)"
+    if [[ -n "${pty_shell_pid}" ]]; then
+      candidate_provider_pid="$(first_child_of "${pty_shell_pid}" || true)"
       if [[ "${candidate_provider_pid}" =~ ^[1-9][0-9]*$ ]] &&
         kill -0 "${candidate_provider_pid}" >/dev/null 2>&1; then
         provider_pid="${candidate_provider_pid}"

--- a/runtime/container/detached-stdin-wrapper.sh
+++ b/runtime/container/detached-stdin-wrapper.sh
@@ -8,6 +8,13 @@ chmod 0700 "$(dirname "${stdin_path}")"
 mkfifo "${stdin_path}"
 chmod 0600 "${stdin_path}"
 exec 3<>"${stdin_path}"
+exec_path="$(mktemp "$(dirname "${stdin_path}")/session-exec.XXXXXX")"
+{
+  printf '#!/usr/bin/env bash\nexec'
+  printf ' %q' "$@"
+  printf '\n'
+} >"${exec_path}"
+chmod 0700 "${exec_path}"
 child_pid=""
 child_done=0
 child_status=0
@@ -24,7 +31,7 @@ forwarder_pid=$!
 cleanup() {
   kill "${forwarder_pid}" >/dev/null 2>&1 || true
   wait "${forwarder_pid}" >/dev/null 2>&1 || true
-  rm -f "${stdin_path}"
+  rm -f "${stdin_path}" "${exec_path}"
 }
 
 forward_child_signal() {
@@ -67,7 +74,7 @@ handle_signal() {
 trap cleanup EXIT
 trap 'handle_signal INT' INT
 trap 'handle_signal TERM' TERM
-"$@" <&3 &
+/usr/bin/script -qefc "${exec_path}" /dev/null <&3 &
 child_pid="$!"
 set +e
 wait "${child_pid}"

--- a/runtime/container/detached-stdin-wrapper.sh
+++ b/runtime/container/detached-stdin-wrapper.sh
@@ -18,6 +18,7 @@ chmod 0700 "${exec_path}"
 child_pid=""
 child_done=0
 child_status=0
+provider_pid=""
 
 forward_container_tty_input() {
   while :; do
@@ -37,11 +38,46 @@ cleanup() {
 forward_child_signal() {
   local signal="$1"
 
+  if [[ -z "${provider_pid}" ]] &&
+    [[ -n "${child_pid}" ]] &&
+    kill -0 "${child_pid}" >/dev/null 2>&1; then
+    discover_provider || true
+  fi
+  if [[ -n "${provider_pid}" ]] &&
+    kill -0 "${provider_pid}" >/dev/null 2>&1; then
+    kill "-${signal}" "${provider_pid}" >/dev/null 2>&1 || true
+    return
+  fi
   if [[ -n "${child_pid}" ]] &&
     kill -0 "${child_pid}" >/dev/null 2>&1; then
-    kill "-${signal}" "${child_pid}" >/dev/null 2>&1 ||
-      kill "${child_pid}" >/dev/null 2>&1 || true
+    kill "-${signal}" "${child_pid}" >/dev/null 2>&1 || true
   fi
+}
+
+discover_provider() {
+  local attempt=0
+  local pty_shell_pid=""
+  local candidate_provider_pid=""
+
+  for ((attempt = 0; attempt < 50; attempt++)); do
+    pty_shell_pid=""
+    if [[ -r "/proc/${child_pid}/task/${child_pid}/children" ]]; then
+      read -r pty_shell_pid _ <"/proc/${child_pid}/task/${child_pid}/children" || true
+    fi
+    if [[ "${pty_shell_pid}" =~ ^[1-9][0-9]*$ ]] &&
+      [[ -r "/proc/${pty_shell_pid}/task/${pty_shell_pid}/children" ]]; then
+      candidate_provider_pid=""
+      read -r candidate_provider_pid _ <"/proc/${pty_shell_pid}/task/${pty_shell_pid}/children" || true
+      if [[ "${candidate_provider_pid}" =~ ^[1-9][0-9]*$ ]] &&
+        kill -0 "${candidate_provider_pid}" >/dev/null 2>&1; then
+        provider_pid="${candidate_provider_pid}"
+        return 0
+      fi
+    fi
+    kill -0 "${child_pid}" >/dev/null 2>&1 || return 1
+    sleep 0.02
+  done
+  return 1
 }
 
 handle_signal() {
@@ -76,6 +112,12 @@ trap 'handle_signal INT' INT
 trap 'handle_signal TERM' TERM
 /usr/bin/script -qefc "${exec_path}" /dev/null <&3 &
 child_pid="$!"
+if ! discover_provider && kill -0 "${child_pid}" >/dev/null 2>&1; then
+  echo "Workcell could not identify the detached provider process." >&2
+  kill "${child_pid}" >/dev/null 2>&1 || true
+  wait "${child_pid}" >/dev/null 2>&1 || true
+  exit 1
+fi
 set +e
 wait "${child_pid}"
 status="$?"

--- a/runtime/container/detached-stdin-wrapper.sh
+++ b/runtime/container/detached-stdin-wrapper.sh
@@ -19,6 +19,24 @@ child_pid=""
 child_done=0
 child_status=0
 provider_pid=""
+container_tty_state=""
+container_tty_configured=0
+
+restore_container_tty() {
+  if [[ "${container_tty_configured}" == "1" ]] &&
+    [[ -n "${container_tty_state}" ]]; then
+    /usr/bin/stty "${container_tty_state}" </dev/tty >/dev/null 2>&1 || true
+  fi
+  container_tty_configured=0
+  container_tty_state=""
+}
+
+configure_container_tty() {
+  container_tty_state="$(/usr/bin/stty -g </dev/tty 2>/dev/null || true)"
+  [[ -n "${container_tty_state}" ]] || return 1
+  /usr/bin/stty raw -echo </dev/tty
+  container_tty_configured=1
+}
 
 forward_container_tty_input() {
   while :; do
@@ -32,6 +50,7 @@ forwarder_pid=$!
 cleanup() {
   kill "${forwarder_pid}" >/dev/null 2>&1 || true
   wait "${forwarder_pid}" >/dev/null 2>&1 || true
+  restore_container_tty
   rm -f "${stdin_path}" "${exec_path}"
 }
 
@@ -88,21 +107,58 @@ discover_provider() {
   return 1
 }
 
+sync_terminal_size() {
+  local rows=""
+  local columns=""
+
+  [[ -n "${provider_pid}" ]] || return 0
+  kill -0 "${provider_pid}" >/dev/null 2>&1 || return 0
+  read -r rows columns < <(/usr/bin/stty size </dev/tty 2>/dev/null || true)
+  if [[ "${rows}" =~ ^[1-9][0-9]*$ ]] &&
+    [[ "${columns}" =~ ^[1-9][0-9]*$ ]]; then
+    /usr/bin/stty rows "${rows}" cols "${columns}" \
+      <"/proc/${provider_pid}/fd/0" >/dev/null 2>&1 || true
+  fi
+}
+
+handle_terminal_resize() {
+  # Docker Desktop can emit a burst of SIGWINCH events while the container
+  # terminal settles. Let the burst coalesce before copying its final size to
+  # the provider PTY so a signal handled mid-burst cannot leave it stale.
+  /usr/bin/sleep 0.1
+  sync_terminal_size
+}
+
+wait_for_child() {
+  local status=0
+
+  while :; do
+    set +e
+    wait "${child_pid}"
+    status="$?"
+    set -e
+    if kill -0 "${child_pid}" >/dev/null 2>&1; then
+      continue
+    fi
+    child_status="${status}"
+    child_done=1
+    return 0
+  done
+}
+
 handle_signal() {
   local signal="$1"
   local status=0
 
   if [[ "${child_done}" == "1" ]]; then
-    trap - EXIT INT TERM
+    trap - EXIT INT TERM WINCH
     cleanup
     exit "${child_status}"
   fi
   forward_child_signal "${signal}"
   if [[ -n "${child_pid}" ]]; then
-    set +e
-    wait "${child_pid}" >/dev/null 2>&1
-    status="$?"
-    set -e
+    wait_for_child >/dev/null 2>&1
+    status="${child_status}"
   else
     case "${signal}" in
       INT) status=130 ;;
@@ -110,7 +166,7 @@ handle_signal() {
       *) status=128 ;;
     esac
   fi
-  trap - EXIT INT TERM
+  trap - EXIT INT TERM WINCH
   cleanup
   exit "${status}"
 }
@@ -118,6 +174,10 @@ handle_signal() {
 trap cleanup EXIT
 trap 'handle_signal INT' INT
 trap 'handle_signal TERM' TERM
+if ! configure_container_tty; then
+  echo "Workcell could not configure the detached container terminal." >&2
+  exit 1
+fi
 /usr/bin/script -qefc "${exec_path}" /dev/null <&3 &
 child_pid="$!"
 if ! discover_provider && kill -0 "${child_pid}" >/dev/null 2>&1; then
@@ -126,12 +186,10 @@ if ! discover_provider && kill -0 "${child_pid}" >/dev/null 2>&1; then
   wait "${child_pid}" >/dev/null 2>&1 || true
   exit 1
 fi
-set +e
-wait "${child_pid}"
-status="$?"
-child_status="${status}"
-child_done=1
-trap - EXIT INT TERM
-set -e
+trap handle_terminal_resize WINCH
+sync_terminal_size
+wait_for_child
+status="${child_status}"
+trap - EXIT INT TERM WINCH
 cleanup
 exit "${status}"

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -38,6 +38,7 @@ INJECTION_BUNDLE_ROOT=""
 WORKSPACE_IMPORT_ROOT=""
 DETACHED_TTY_SMOKE_CONTAINER=""
 DETACHED_TTY_SMOKE_SENTINEL=""
+DETACHED_TTY_ATTACH_PID=""
 declare -a WORKSPACE_IMPORT_ARGS=()
 declare -a RUNTIME_SECURITY_ARGS=()
 declare -a COPILOT_SMOKE_TOKEN_HANDOFF_DIRS=()
@@ -472,6 +473,10 @@ cleanup() {
   if [[ -n "${DETACHED_TTY_SMOKE_CONTAINER}" ]]; then
     docker_cmd rm -f "${DETACHED_TTY_SMOKE_CONTAINER}" >/dev/null 2>&1 || true
   fi
+  if [[ -n "${DETACHED_TTY_ATTACH_PID}" ]]; then
+    kill "${DETACHED_TTY_ATTACH_PID}" >/dev/null 2>&1 || true
+    wait "${DETACHED_TTY_ATTACH_PID}" >/dev/null 2>&1 || true
+  fi
   cleanup_workcell_trusted_docker_client
   cleanup_workspace_scratch "${ROOT_DIR}" || true
   if [[ -n "${SMOKE_WORKSPACE}" ]]; then
@@ -504,6 +509,21 @@ docker_cmd() {
   else
     docker "$@"
   fi
+}
+
+run_detached_tty_attach_probe() {
+  local transcript_path="$1"
+  shift
+  local -a command_args=("$@")
+  local command_string=""
+
+  if script --help 2>&1 | grep -q -- ' -c, --command '; then
+    printf -v command_string '%q ' "${command_args[@]}"
+    script -qef -c "${command_string% }" "${transcript_path}"
+    return
+  fi
+
+  script -qeF "${transcript_path}" "${command_args[@]}"
 }
 
 populate_runtime_security_args() {
@@ -1043,6 +1063,7 @@ run_container_with_injection_bundle_stdin() {
 
 if [[ "${1:-}" == "--self-docker-probe" ]]; then
   require_tool docker
+  require_tool script
   setup_workcell_trusted_docker_client
   if [[ -n "${DOCKER_CONTEXT_NAME:-}" ]]; then
     select_docker_context
@@ -1058,6 +1079,7 @@ if [[ "${1:-}" == "--self-test-host-path-hardening" ]]; then
 fi
 
 require_tool docker
+require_tool script
 trap cleanup EXIT
 cleanup_workspace_scratch "${ROOT_DIR}"
 prepare_smoke_workspace
@@ -3241,6 +3263,7 @@ grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-direct
 
 DETACHED_TTY_SMOKE_CONTAINER="workcell-detached-tty-smoke-$$"
 DETACHED_TTY_SMOKE_SENTINEL="${SMOKE_WORKSPACE}/detached-tty-stop-sentinel"
+DETACHED_TTY_ATTACH_TRANSCRIPT="${SMOKE_WORKSPACE}/detached-tty-attach.typescript"
 rm -f "${DETACHED_TTY_SMOKE_SENTINEL}"
 docker_cmd rm -f "${DETACHED_TTY_SMOKE_CONTAINER}" >/dev/null 2>&1 || true
 # The nested shell expressions stay literal to verify exact argv transport.
@@ -3251,7 +3274,7 @@ if ! docker_cmd create \
   --entrypoint /bin/bash \
   "${IMAGE_TAG}" \
   /usr/local/libexec/workcell/detached-stdin-wrapper.sh \
-  /bin/bash -lc 'test -t 0 && test -t 1 && test -t 2 && test "$1" = "space value" && test "$2" = "single'\''quote" && test "$3" = '\''$(not-run)'\'' && printf "detached-tty-ok\\n"; trap '\''printf "detached-term-ok\\n" >/tmp/detached-term-ok; exit 0'\'' TERM; while :; do sleep 1; done' \
+  /bin/bash -lc 'test -t 0 && test -t 1 && test -t 2 && test "$1" = "space value" && test "$2" = "single'\''quote" && test "$3" = '\''$(not-run)'\'' && printf "detached-tty-ok\\n"; trap '\''stty size >/tmp/detached-size'\'' WINCH; trap '\''printf "detached-term-ok\\n" >/tmp/detached-term-ok; exit 0'\'' TERM; tty_state="$(stty -g)"; stty raw -echo; IFS= read -r -n 1 key; stty "${tty_state}"; printf "%s" "${key}" >/tmp/detached-key; while :; do sleep 1; done' \
   bash \
   'space value' \
   "single'quote" \
@@ -3274,7 +3297,58 @@ if [[ "${DETACHED_TTY_SMOKE_READY}" != "1" ]]; then
   docker_cmd logs "${DETACHED_TTY_SMOKE_CONTAINER}" >&2 || true
   exit 1
 fi
+DETACHED_TTY_INITIAL_SIZE="$(docker_cmd exec "${DETACHED_TTY_SMOKE_CONTAINER}" \
+  /bin/bash -lc 'stty size </proc/1/fd/0' 2>/dev/null || true)"
+DETACHED_TTY_ATTACH_COMMAND=(docker)
+if [[ -n "${DOCKER_CONTEXT_NAME}" ]]; then
+  DETACHED_TTY_ATTACH_COMMAND+=(--context "${DOCKER_CONTEXT_NAME}")
+fi
+DETACHED_TTY_ATTACH_COMMAND+=(attach --sig-proxy=false "${DETACHED_TTY_SMOKE_CONTAINER}")
+(
+  (
+    sleep 1
+    printf x
+    sleep 5
+  ) |
+    run_detached_tty_attach_probe \
+      "${DETACHED_TTY_ATTACH_TRANSCRIPT}" \
+      /bin/bash -lc 'stty rows 41 cols 123; exec "$@"' -- \
+      "${DETACHED_TTY_ATTACH_COMMAND[@]}"
+) >/dev/null 2>&1 &
+DETACHED_TTY_ATTACH_PID=$!
+DETACHED_TTY_KEY=""
+DETACHED_TTY_SIZE=""
+DETACHED_TTY_OUTER_SIZE=""
+for _ in $(seq 1 100); do
+  DETACHED_TTY_KEY="$(docker_cmd exec "${DETACHED_TTY_SMOKE_CONTAINER}" cat /tmp/detached-key 2>/dev/null || true)"
+  DETACHED_TTY_SIZE="$(docker_cmd exec "${DETACHED_TTY_SMOKE_CONTAINER}" cat /tmp/detached-size 2>/dev/null || true)"
+  DETACHED_TTY_OUTER_SIZE="$(docker_cmd exec "${DETACHED_TTY_SMOKE_CONTAINER}" \
+    /bin/bash -lc 'stty size </proc/1/fd/0' 2>/dev/null || true)"
+  if [[ "${DETACHED_TTY_KEY}" == "x" ]] &&
+    [[ "${DETACHED_TTY_SIZE}" =~ ^[1-9][0-9]*\ [1-9][0-9]*$ ]] &&
+    [[ "${DETACHED_TTY_SIZE}" == "${DETACHED_TTY_OUTER_SIZE}" ]] &&
+    [[ "${DETACHED_TTY_SIZE}" != "${DETACHED_TTY_INITIAL_SIZE}" ]]; then
+    break
+  fi
+  sleep 0.1
+done
+if [[ "${DETACHED_TTY_KEY}" != "x" ]] ||
+  [[ ! "${DETACHED_TTY_SIZE}" =~ ^[1-9][0-9]*\ [1-9][0-9]*$ ]] ||
+  [[ "${DETACHED_TTY_SIZE}" != "${DETACHED_TTY_OUTER_SIZE}" ]] ||
+  [[ "${DETACHED_TTY_SIZE}" == "${DETACHED_TTY_INITIAL_SIZE}" ]]; then
+  echo "Detached stdin wrapper did not relay key-at-a-time input and terminal size" >&2
+  printf 'key=%q initial_size=%q outer_size=%q provider_size=%q\n' \
+    "${DETACHED_TTY_KEY}" \
+    "${DETACHED_TTY_INITIAL_SIZE}" \
+    "${DETACHED_TTY_OUTER_SIZE}" \
+    "${DETACHED_TTY_SIZE}" >&2
+  cat "${DETACHED_TTY_ATTACH_TRANSCRIPT}" >&2 || true
+  exit 1
+fi
 docker_cmd stop -t 10 "${DETACHED_TTY_SMOKE_CONTAINER}" >/dev/null
+kill "${DETACHED_TTY_ATTACH_PID}" >/dev/null 2>&1 || true
+wait "${DETACHED_TTY_ATTACH_PID}" >/dev/null 2>&1 || true
+DETACHED_TTY_ATTACH_PID=""
 DETACHED_TTY_SMOKE_OUTPUT="$(docker_cmd logs "${DETACHED_TTY_SMOKE_CONTAINER}" 2>&1 | tr -d '\r')"
 DETACHED_TTY_SMOKE_STATUS="$(docker_cmd inspect --format '{{.State.ExitCode}}' "${DETACHED_TTY_SMOKE_CONTAINER}")"
 docker_cmd cp "${DETACHED_TTY_SMOKE_CONTAINER}:/tmp/detached-term-ok" "${DETACHED_TTY_SMOKE_SENTINEL}" >/dev/null

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -37,6 +37,7 @@ INJECTION_FIXTURE_ROOT=""
 INJECTION_BUNDLE_ROOT=""
 WORKSPACE_IMPORT_ROOT=""
 DETACHED_TTY_SMOKE_CONTAINER=""
+DETACHED_TTY_SMOKE_SENTINEL=""
 declare -a WORKSPACE_IMPORT_ARGS=()
 declare -a RUNTIME_SECURITY_ARGS=()
 declare -a COPILOT_SMOKE_TOKEN_HANDOFF_DIRS=()
@@ -3239,6 +3240,8 @@ fi
 grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-direct-codex-breakglass.out
 
 DETACHED_TTY_SMOKE_CONTAINER="workcell-detached-tty-smoke-$$"
+DETACHED_TTY_SMOKE_SENTINEL="${SMOKE_WORKSPACE}/detached-tty-stop-sentinel"
+rm -f "${DETACHED_TTY_SMOKE_SENTINEL}"
 docker_cmd rm -f "${DETACHED_TTY_SMOKE_CONTAINER}" >/dev/null 2>&1 || true
 # The nested shell expressions stay literal to verify exact argv transport.
 # shellcheck disable=SC2016
@@ -3248,7 +3251,7 @@ if ! docker_cmd create \
   --entrypoint /bin/bash \
   "${IMAGE_TAG}" \
   /usr/local/libexec/workcell/detached-stdin-wrapper.sh \
-  /bin/bash -lc 'test -t 0 && test -t 1 && test -t 2 && test "$1" = "space value" && test "$2" = "single'\''quote" && test "$3" = '\''$(not-run)'\'' && printf "detached-tty-ok\\n"' \
+  /bin/bash -lc 'test -t 0 && test -t 1 && test -t 2 && test "$1" = "space value" && test "$2" = "single'\''quote" && test "$3" = '\''$(not-run)'\'' && printf "detached-tty-ok\\n"; trap '\''printf "detached-term-ok\\n" >/tmp/detached-term-ok; exit 0'\'' TERM; while :; do sleep 1; done' \
   bash \
   'space value' \
   "single'quote" \
@@ -3257,14 +3260,30 @@ if ! docker_cmd create \
   echo "Could not create the detached terminal smoke container" >&2
   exit 1
 fi
-set +e
-DETACHED_TTY_SMOKE_OUTPUT="$(docker_cmd start -a "${DETACHED_TTY_SMOKE_CONTAINER}" | tr -d '\r')"
-DETACHED_TTY_SMOKE_STATUS="$?"
-set -e
+docker_cmd start "${DETACHED_TTY_SMOKE_CONTAINER}" >/dev/null
+DETACHED_TTY_SMOKE_READY=0
+for _ in $(seq 1 50); do
+  if docker_cmd logs "${DETACHED_TTY_SMOKE_CONTAINER}" 2>&1 | tr -d '\r' | grep -qx 'detached-tty-ok'; then
+    DETACHED_TTY_SMOKE_READY=1
+    break
+  fi
+  sleep 0.1
+done
+if [[ "${DETACHED_TTY_SMOKE_READY}" != "1" ]]; then
+  echo "Detached stdin wrapper did not give its managed child a terminal" >&2
+  docker_cmd logs "${DETACHED_TTY_SMOKE_CONTAINER}" >&2 || true
+  exit 1
+fi
+docker_cmd stop -t 10 "${DETACHED_TTY_SMOKE_CONTAINER}" >/dev/null
+DETACHED_TTY_SMOKE_OUTPUT="$(docker_cmd logs "${DETACHED_TTY_SMOKE_CONTAINER}" 2>&1 | tr -d '\r')"
+DETACHED_TTY_SMOKE_STATUS="$(docker_cmd inspect --format '{{.State.ExitCode}}' "${DETACHED_TTY_SMOKE_CONTAINER}")"
+docker_cmd cp "${DETACHED_TTY_SMOKE_CONTAINER}:/tmp/detached-term-ok" "${DETACHED_TTY_SMOKE_SENTINEL}" >/dev/null
 docker_cmd rm -f "${DETACHED_TTY_SMOKE_CONTAINER}" >/dev/null 2>&1 || true
 DETACHED_TTY_SMOKE_CONTAINER=""
-if [[ "${DETACHED_TTY_SMOKE_STATUS}" -ne 0 ]] || [[ "${DETACHED_TTY_SMOKE_OUTPUT}" != "detached-tty-ok" ]]; then
-  echo "Detached stdin wrapper did not give its managed child a terminal" >&2
+if [[ "${DETACHED_TTY_SMOKE_STATUS}" != "0" ]] ||
+  ! grep -qx 'detached-tty-ok' <<<"${DETACHED_TTY_SMOKE_OUTPUT}" ||
+  ! grep -qx 'detached-term-ok' "${DETACHED_TTY_SMOKE_SENTINEL}"; then
+  echo "Detached stdin wrapper did not preserve terminal or graceful-stop behavior" >&2
   printf '%s\n' "${DETACHED_TTY_SMOKE_OUTPUT}" >&2
   exit 1
 fi

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -36,6 +36,7 @@ SMOKE_WORKSPACE=""
 INJECTION_FIXTURE_ROOT=""
 INJECTION_BUNDLE_ROOT=""
 WORKSPACE_IMPORT_ROOT=""
+DETACHED_TTY_SMOKE_CONTAINER=""
 declare -a WORKSPACE_IMPORT_ARGS=()
 declare -a RUNTIME_SECURITY_ARGS=()
 declare -a COPILOT_SMOKE_TOKEN_HANDOFF_DIRS=()
@@ -467,6 +468,9 @@ prepare_smoke_workspace() {
 }
 
 cleanup() {
+  if [[ -n "${DETACHED_TTY_SMOKE_CONTAINER}" ]]; then
+    docker_cmd rm -f "${DETACHED_TTY_SMOKE_CONTAINER}" >/dev/null 2>&1 || true
+  fi
   cleanup_workcell_trusted_docker_client
   cleanup_workspace_scratch "${ROOT_DIR}" || true
   if [[ -n "${SMOKE_WORKSPACE}" ]]; then
@@ -3233,6 +3237,35 @@ if run_container codex bash -lc 'AGENT_NAME=codex WORKCELL_MODE=breakglass CODEX
   exit 1
 fi
 grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-direct-codex-breakglass.out
+
+DETACHED_TTY_SMOKE_CONTAINER="workcell-detached-tty-smoke-$$"
+docker_cmd rm -f "${DETACHED_TTY_SMOKE_CONTAINER}" >/dev/null 2>&1 || true
+if ! docker_cmd create \
+  --name "${DETACHED_TTY_SMOKE_CONTAINER}" \
+  -i -t \
+  --entrypoint /bin/bash \
+  "${IMAGE_TAG}" \
+  /usr/local/libexec/workcell/detached-stdin-wrapper.sh \
+  /bin/bash -lc 'test -t 0 && test -t 1 && test -t 2 && test "$1" = "space value" && test "$2" = "single'\''quote" && test "$3" = '\''$(not-run)'\'' && printf "detached-tty-ok\\n"' \
+  bash \
+  'space value' \
+  "single'quote" \
+  '$(not-run)' \
+  >/dev/null; then
+  echo "Could not create the detached terminal smoke container" >&2
+  exit 1
+fi
+set +e
+DETACHED_TTY_SMOKE_OUTPUT="$(docker_cmd start -a "${DETACHED_TTY_SMOKE_CONTAINER}" | tr -d '\r')"
+DETACHED_TTY_SMOKE_STATUS="$?"
+set -e
+docker_cmd rm -f "${DETACHED_TTY_SMOKE_CONTAINER}" >/dev/null 2>&1 || true
+DETACHED_TTY_SMOKE_CONTAINER=""
+if [[ "${DETACHED_TTY_SMOKE_STATUS}" -ne 0 ]] || [[ "${DETACHED_TTY_SMOKE_OUTPUT}" != "detached-tty-ok" ]]; then
+  echo "Detached stdin wrapper did not give its managed child a terminal" >&2
+  printf '%s\n' "${DETACHED_TTY_SMOKE_OUTPUT}" >&2
+  exit 1
+fi
 
 populate_runtime_security_args ephemeral
 if docker_cmd run --rm \

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -3240,6 +3240,8 @@ grep -q "Workcell blocked unsafe Codex override" /tmp/workcell-entrypoint-direct
 
 DETACHED_TTY_SMOKE_CONTAINER="workcell-detached-tty-smoke-$$"
 docker_cmd rm -f "${DETACHED_TTY_SMOKE_CONTAINER}" >/dev/null 2>&1 || true
+# The nested shell expressions stay literal to verify exact argv transport.
+# shellcheck disable=SC2016
 if ! docker_cmd create \
   --name "${DETACHED_TTY_SMOKE_CONTAINER}" \
   -i -t \

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -7548,7 +7548,7 @@ EOF
     grep -q "\"session_id\": \"${DETACHED_SESSION_ID}\"" "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     grep -q '"status": "exited"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     grep -q '"live_status": "stopped"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
-    grep -q '"exit_status": 0' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
+    grep -q '"exit_status": "0"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     grep -q '"current_assurance": "managed-mutable"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     grep -q '"final_assurance": "managed-mutable"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     DETACHED_SESSION_MONITOR_COMMAND="$(ps -o command= -p "${DETACHED_SESSION_MONITOR_PID}" 2>/dev/null | head -n1 || true)"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -7286,7 +7286,7 @@ test -d /opt/workcell/host-inputs
 [[ -z "$(find /opt/workcell/host-inputs -mindepth 1 -print -quit)" ]]
 printf 'SESSION_MASKS_OK\n'
 printf 'SESSION_MASKS_OK\n' >>"/workspace/${WORKER_SENTINEL_REL}"
-trap 'printf "SESSION_STOPPING\n"; exit 0' TERM INT
+trap 'printf "SESSION_STOPPING\n"; printf "SESSION_STOPPING\n" >>"/workspace/${WORKER_SENTINEL_REL}"; exit 0' TERM INT
 while IFS= read -r line; do
   printf 'SESSION_RECV:%s\n' "${line}"
   printf 'SESSION_RECV:%s\n' "${line}" >>"/workspace/${WORKER_SENTINEL_REL}"
@@ -7549,6 +7549,7 @@ EOF
     grep -q '"status": "exited"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     grep -q '"live_status": "stopped"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     grep -q '"exit_status": "0"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
+    grep -q '^SESSION_STOPPING$' "${DETACHED_SESSION_SENTINEL_PATH}"
     grep -q '"current_assurance": "managed-mutable"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     grep -q '"final_assurance": "managed-mutable"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     DETACHED_SESSION_MONITOR_COMMAND="$(ps -o command= -p "${DETACHED_SESSION_MONITOR_PID}" 2>/dev/null | head -n1 || true)"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -7271,6 +7271,11 @@ if [[ "$(uname -s)" == "Darwin" ]] &&
 set -euo pipefail
 WORKER_SENTINEL_REL="${1:?missing detached-session sentinel path}"
 : >"/workspace/${WORKER_SENTINEL_REL}"
+test -t 0
+test -t 1
+test -t 2
+printf 'SESSION_TTY_OK\n'
+printf 'SESSION_TTY_OK\n' >>"/workspace/${WORKER_SENTINEL_REL}"
 printf 'SESSION_READY\n'
 printf 'SESSION_READY\n' >>"/workspace/${WORKER_SENTINEL_REL}"
 test -r /workspace/AGENTS.md
@@ -7386,6 +7391,7 @@ EOF
     fi
     grep -q '^SESSION_READY$' "${DETACHED_SESSION_SENTINEL_PATH}"
     grep -q '^SESSION_MASKS_OK$' "${DETACHED_SESSION_SENTINEL_PATH}"
+    grep -q '^SESSION_TTY_OK$' "${DETACHED_SESSION_SENTINEL_PATH}"
     DETACHED_ATTACH_STATUS=0
     DETACHED_ATTACH_READY=0
     DETACHED_ATTACH_READY_MESSAGE="attach-ready"
@@ -7542,6 +7548,7 @@ EOF
     grep -q "\"session_id\": \"${DETACHED_SESSION_ID}\"" "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     grep -q '"status": "exited"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     grep -q '"live_status": "stopped"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
+    grep -q '"exit_status": 0' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     grep -q '"current_assurance": "managed-mutable"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     grep -q '"final_assurance": "managed-mutable"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     DETACHED_SESSION_MONITOR_COMMAND="$(ps -o command= -p "${DETACHED_SESSION_MONITOR_PID}" 2>/dev/null | head -n1 || true)"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -3954,7 +3954,9 @@ session_attach_main() {
     "stdin_mode=${stdin_mode}" \
     "container_name=${container_name}"
   set +e
-  run_profile_docker_command "${profile}" attach "${attach_args[@]}" "${container_name}"
+  run_profile_docker_command "${profile}" attach \
+    ${attach_args[@]+"${attach_args[@]}"} \
+    "${container_name}"
   attach_status="$?"
   set -e
   if [[ "${attach_status}" -ne 0 ]]; then
@@ -9090,12 +9092,12 @@ fi
 DOCKER_RUN_ARGS=("${DOCKER_RUN[@]:${DOCKER_RUN_PREFIX_LEN}}")
 
 if [[ "${SESSION_DETACHED}" -eq 1 ]]; then
+  # The managed detached-stdin wrapper supervises and reaps the provider as
+  # container PID 1. Docker's init cannot signal that unprivileged process
+  # after the entrypoint drops privileges.
   DOCKER_RUN=(
     "${HOST_DOCKER_BIN}" run
   )
-  if [[ -z "${COPILOT_TOKEN_HANDOFF_DIR}" ]]; then
-    DOCKER_RUN+=(--init)
-  fi
   DOCKER_RUN+=(-d -i -t "${DOCKER_RUN_ARGS[@]}")
 elif [[ -t 0 ]] && [[ -t 1 ]]; then
   mark_interactive_host_terminal_dirty

--- a/tests/scenarios/shared/test-copilot-session-dry-run.sh
+++ b/tests/scenarios/shared/test-copilot-session-dry-run.sh
@@ -47,7 +47,11 @@ grep -q '^profile=.* mode=strict agent=copilot ' "${TMP_DIR}/session.stderr"
 grep -q '^target_kind=local_vm target_provider=colima ' "${TMP_DIR}/session.stderr"
 grep -q '^execution_path=managed-tier1 audit_log=' "${TMP_DIR}/session.stderr"
 grep -q '^session_assurance_initial=managed-mutable$' "${TMP_DIR}/session.stderr"
-grep -Fq -- "docker run --init -d -i -t" "${TMP_DIR}/session.stdout"
+grep -Fq -- "docker run -d -i -t" "${TMP_DIR}/session.stdout"
+if grep -Fq -- "docker run --init -d -i -t" "${TMP_DIR}/session.stdout"; then
+  echo "Copilot detached session kept Docker's init ahead of the managed session supervisor" >&2
+  exit 1
+fi
 grep -Fq -- "-e WORKCELL_DETACHED_STDIN_PATH=/state/tmp/workcell/session-stdin" "${TMP_DIR}/session.stdout"
 grep -Fq -- "workcell:local" "${TMP_DIR}/session.stdout"
 

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -493,7 +493,11 @@ if [[ "${detached_launch_blocked}" -eq 1 ]]; then
   grep -q 'Supported launch hosts today remain Apple Silicon macOS' <<<"${detached_start_blocked_output}"
 else
   detached_start_default_output="$(run_detached_start_dry_run direct "${DETACHED_START_WORKSPACE}")"
-  grep -Fq -- "docker run --init -d -i -t" <<<"${detached_start_default_output}"
+  grep -Fq -- "docker run -d -i -t" <<<"${detached_start_default_output}"
+  if grep -Fq -- "docker run --init -d -i -t" <<<"${detached_start_default_output}"; then
+    echo "Detached session start kept Docker's init ahead of the managed session supervisor" >&2
+    exit 1
+  fi
   grep -Eq -- "-v ${DETACHED_START_WORKSPACE}/\\.git/workcell-sessions/.+/repo:/workspace($| )" <<<"${detached_start_default_output}"
   grep -Fq -- "-e WORKCELL_DETACHED_STDIN_PATH=/state/tmp/workcell/session-stdin" <<<"${detached_start_default_output}"
   if grep -Fq -- "-v ${DETACHED_START_WORKSPACE}:/workspace" <<<"${detached_start_default_output}"; then
@@ -3109,7 +3113,7 @@ EOF_JSON
       esac
     }
 
-    attach_output="$(session_attach_main --id "${SESSION_ID}" --no-stdin)"
+    attach_output="$(session_attach_main --id "${SESSION_ID}")"
     send_output="$(session_send_main --id "${SESSION_ID}" --message resume)"
     stop_output="$(session_stop_main --id "${SESSION_ID}")"
     delete_output="$(session_delete_main --id "${SESSION_ID}")"
@@ -3131,7 +3135,7 @@ grep -q '^send_output=session_id=detached-lifecycle|sent_bytes=7|status=running|
 grep -q '^stop_output=session_id=detached-lifecycle|stop_requested=1|status=exited|live_status=stopped|control_mode=detached|target_kind=local_vm|target_provider=colima|target_id=wcl-detached-lifecycle|target_summary=local_vm/colima/wcl-detached-lifecycle|target_assurance_class=strict|runtime_api=docker|workspace_transport=workspace-mount|workspace='"${WORKSPACE_A}"'|display_workspace='"${WORKSPACE_A}"'|workspace_origin='"${WORKSPACE_A}"'|display_worktree='"${WORKSPACE_A}"'|worktree_path='"${WORKSPACE_A}"'|display_git_branch=none|git_branch=|assurance=managed-mutable|$' <<<"${session_lifecycle_output}"
 grep -q '^delete_output=session_id=detached-lifecycle|deleted=1|record_only=0|dry_run=0|removed=record,container,session_audit_dir,debug_log,file_trace_log,transcript_log,audit_seal|kept=none|missing=none|unavailable=none|$' <<<"${session_lifecycle_output}"
 test -f "${SESSION_LIFECYCLE_AUDIT_LOG}"
-grep -q '^transport|wcl-detached-lifecycle|attach --no-stdin workcell-session-fixture$' "${SESSION_LIFECYCLE_RECORD}"
+grep -q '^transport|wcl-detached-lifecycle|attach workcell-session-fixture$' "${SESSION_LIFECYCLE_RECORD}"
 grep -q '^transport|wcl-detached-lifecycle|exec --user ' "${SESSION_LIFECYCLE_RECORD}"
 grep -q '/state/tmp/workcell/session-stdin' "${SESSION_LIFECYCLE_RECORD}"
 grep -q '^transport|wcl-detached-lifecycle|stop workcell-session-fixture$' "${SESSION_LIFECYCLE_RECORD}"


### PR DESCRIPTION
Prepare the Workcell v1.0.0 release.

- finalize the reviewed Apple Silicon macOS support boundary and G4 GO record
- fix detached provider TTY, interactive attach, and graceful-stop behavior
- add exact lifecycle, argv, and live invariant regression coverage
- retain remote macOS as preview-only and Linux/Windows as unsupported operator hosts

Local exact-head `pr-parity`, strict Colima certification, and Docker Desktop compatibility certification passed before publication.