### PR TITLE
Enforce Claude stable publication cool-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ immutable-release check. The failed tag and draft remain untouched.
   publisher explicitly; retain the publisher's direct check when its default
   token can read the endpoint, and accept only GitHub's exact
   integration-permission denial when the fresh precheck is present.
+- gate Claude refreshes on the later of stable-registry publication and native
+  manifest build times so delayed channel publication cannot shorten the
+  provider cool-off.
 
 ## v1.0.0 - 2026-08-04
 

--- a/internal/metadatautil/provider_bumps.go
+++ b/internal/metadatautil/provider_bumps.go
@@ -687,9 +687,10 @@ func selectGeminiStable(currentVersion string, cutoff time.Time, sources Provide
 }
 
 // claudeSelectionForCandidate fetches and validates the Claude release manifest
-// for a candidate version and assembles its ProviderBumpSelection, returning the
-// parsed build time so callers can apply the cool-off cutoff. Shared by the
-// approved-version and newest-stable resolution paths in selectClaudeStable.
+// for a candidate version and assembles its ProviderBumpSelection. It returns
+// the later of the registry publication and native build times so a delayed
+// stable-channel publication cannot shorten the configured cool-off. Shared by
+// the approved-version and newest-stable resolution paths in selectClaudeStable.
 func claudeSelectionForCandidate(candidate stableVersion, currentVersion string, sources ProviderBumpSources, client *http.Client) (ProviderBumpSelection, time.Time, error) {
 	manifestURL := fmt.Sprintf("%s/%s/manifest.json", sources.ClaudeReleaseRootURL, candidate.Raw)
 	var manifest claudeManifest
@@ -703,6 +704,10 @@ func claudeSelectionForCandidate(candidate stableVersion, currentVersion string,
 	if err != nil {
 		return ProviderBumpSelection{}, time.Time{}, fmt.Errorf("parse Claude manifest buildDate for %s: %w", candidate.Raw, err)
 	}
+	availableAt := buildTime.UTC()
+	if candidate.Source.After(availableAt) {
+		availableAt = candidate.Source.UTC()
+	}
 	armChecksum := manifest.Platforms["linux-arm64"].Checksum
 	amdChecksum := manifest.Platforms["linux-x64"].Checksum
 	if armChecksum == "" || amdChecksum == "" {
@@ -712,13 +717,13 @@ func claudeSelectionForCandidate(candidate stableVersion, currentVersion string,
 		Channel:        "stable",
 		CurrentVersion: currentVersion,
 		TargetVersion:  candidate.Raw,
-		PublishedAt:    buildTime.UTC().Format(time.RFC3339),
+		PublishedAt:    availableAt.Format(time.RFC3339),
 		Changed:        candidate.Raw != currentVersion,
 		Checksums: map[string]string{
 			"arm64": armChecksum,
 			"amd64": amdChecksum,
 		},
-	}, buildTime, nil
+	}, availableAt, nil
 }
 
 func selectClaudeStable(currentVersion string, cutoff time.Time, maxVersion string, approvedVersion string, sources ProviderBumpSources, client *http.Client) (ProviderBumpSelection, error) {

--- a/internal/metadatautil/provider_bumps_test.go
+++ b/internal/metadatautil/provider_bumps_test.go
@@ -1516,6 +1516,78 @@ func TestPlanProviderBumpsDoesNotDowngradeWhenCurrentClaudeVersionIsStillCooling
 	}
 }
 
+func TestSelectClaudeStableUsesLaterRegistryPublicationForCooloff(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/claude-registry":
+			writeRegistryMetadata(w, "2.1.222", map[string]string{
+				"2.1.222": "2026-08-04T20:37:17Z",
+				"2.1.221": "2026-08-03T20:00:00Z",
+			})
+		case "/claude-release/2.1.222/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "version": "2.1.222",
+  "buildDate": "2026-08-04T01:46:04Z",
+  "platforms": {
+    "linux-arm64": {"checksum": "222-arm64"},
+    "linux-x64": {"checksum": "222-amd64"}
+  }
+}`))
+		case "/claude-release/2.1.221/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+  "version": "2.1.221",
+  "buildDate": "2026-08-03T19:00:00Z",
+  "platforms": {
+    "linux-arm64": {"checksum": "221-arm64"},
+    "linux-x64": {"checksum": "221-amd64"}
+  }
+}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	sources := ProviderBumpSources{
+		ClaudeRegistryURL:    server.URL + "/claude-registry",
+		ClaudeReleaseRootURL: server.URL + "/claude-release",
+	}
+	selection, err := selectClaudeStable(
+		"2.1.221",
+		time.Date(2026, time.August, 4, 11, 48, 0, 0, time.UTC),
+		"",
+		"",
+		sources,
+		server.Client(),
+	)
+	if err != nil {
+		t.Fatalf("selectClaudeStable() during registry cool-off error = %v", err)
+	}
+	if selection.TargetVersion != "2.1.221" || selection.Changed {
+		t.Fatalf("Claude selection during registry cool-off = %#v, want current version", selection)
+	}
+
+	selection, err = selectClaudeStable(
+		"2.1.221",
+		time.Date(2026, time.August, 4, 21, 0, 0, 0, time.UTC),
+		"",
+		"",
+		sources,
+		server.Client(),
+	)
+	if err != nil {
+		t.Fatalf("selectClaudeStable() after registry cool-off error = %v", err)
+	}
+	if selection.TargetVersion != "2.1.222" || !selection.Changed {
+		t.Fatalf("Claude selection after registry cool-off = %#v, want 2.1.222", selection)
+	}
+	if selection.PublishedAt != "2026-08-04T20:37:17Z" {
+		t.Fatalf("Claude PublishedAt = %q, want later registry publication", selection.PublishedAt)
+	}
+}
+
 func TestPlanProviderBumpsRejectsCurrentClaudeVersionAboveMaxVersion(t *testing.T) {
 	root := t.TempDir()
 	dockerfilePath := filepath.Join(root, "Dockerfile")

--- a/policy/provider-bumps.toml
+++ b/policy/provider-bumps.toml
@@ -11,6 +11,8 @@ channel = "stable"
 
 [provider.claude]
 channel = "stable"
+# Cool-off eligibility uses the later of the stable registry publication and
+# native release manifest build times.
 
 [provider.copilot]
 channel = "stable"

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -222,7 +222,7 @@ FROM runtime-base AS runtime-builder
 # from the public release bucket, verify the per-platform checksums in the
 # corresponding manifest.json, update CLAUDE_VERSION, and refresh the
 # CLAUDE_SHA256 values below.
-ARG CLAUDE_VERSION=2.1.221
+ARG CLAUDE_VERSION=2.1.222
 # OpenAI Codex CLI version and SHA256 checksums for each architecture.
 # Workcell follows the stable npm channel and matching non-prerelease Rust
 # release after the cool-off in policy/provider-bumps.toml. The runtime
@@ -311,11 +311,11 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
   && case "${TARGET_ARCH}" in \
     arm64) \
       CLAUDE_PLATFORM="linux-arm64"; \
-      CLAUDE_SHA256="d3c59d6bcc4adcf4cd85abca3bc13fa1131a34cb32f982bdf030d83a3b11e700"; \
+      CLAUDE_SHA256="a04be0a8d7fe0259571ab7411d51d85658d71a4a26ce62b60c908290372e6016"; \
       ;; \
     amd64) \
       CLAUDE_PLATFORM="linux-x64"; \
-      CLAUDE_SHA256="60db8e88d42c24b5199c92cfd56ec88370c510c3789c6f364af748354f087ada"; \
+      CLAUDE_SHA256="10caae8f22b915c26bfff0e013a4d45608c4f1ae287583626569156f447730e5"; \
       ;; \
     *) \
       echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; \

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -222,7 +222,7 @@ FROM runtime-base AS runtime-builder
 # from the public release bucket, verify the per-platform checksums in the
 # corresponding manifest.json, update CLAUDE_VERSION, and refresh the
 # CLAUDE_SHA256 values below.
-ARG CLAUDE_VERSION=2.1.222
+ARG CLAUDE_VERSION=2.1.221
 # OpenAI Codex CLI version and SHA256 checksums for each architecture.
 # Workcell follows the stable npm channel and matching non-prerelease Rust
 # release after the cool-off in policy/provider-bumps.toml. The runtime
@@ -311,11 +311,11 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
   && case "${TARGET_ARCH}" in \
     arm64) \
       CLAUDE_PLATFORM="linux-arm64"; \
-      CLAUDE_SHA256="a04be0a8d7fe0259571ab7411d51d85658d71a4a26ce62b60c908290372e6016"; \
+      CLAUDE_SHA256="d3c59d6bcc4adcf4cd85abca3bc13fa1131a34cb32f982bdf030d83a3b11e700"; \
       ;; \
     amd64) \
       CLAUDE_PLATFORM="linux-x64"; \
-      CLAUDE_SHA256="10caae8f22b915c26bfff0e013a4d45608c4f1ae287583626569156f447730e5"; \
+      CLAUDE_SHA256="60db8e88d42c24b5199c92cfd56ec88370c510c3789c6f364af748354f087ada"; \
       ;; \
     *) \
       echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; \


### PR DESCRIPTION
## Summary

- gate Claude refreshes on the later of stable npm-registry publication and native manifest build time
- keep Claude 2.1.221 while 2.1.222 completes the reviewed 12-hour cool-off
- add regression coverage for delayed stable-channel publication
- record the fix in the v1.0.1 changelog and provider policy

## Review finding addressed

Codex correctly identified that the original generated refresh used the native manifest build time (01:46Z) even though the stable registry did not publish 2.1.222 until 20:37Z. The first commit reproduced candidate run 30958757262 exactly; the signed follow-up reverts that premature pin and fixes the generator policy so the release preflight remains green without consuming a newly published stable version.

## Validation

- go test ./...
- ./scripts/update-upstream-pins.sh --check
- ./scripts/check-pinned-inputs.sh
- ./scripts/verify-requirements-coverage.sh
- ./scripts/check-doc-links.sh
- git diff --check

## Publication exception

The initial generated candidate used the repository wrapper parity override because the official helper passed all non-VM parity and provider release verification, but both disposable Colima VZ starts timed out at host DHCP/SSH before repository code. Hosted CI and exact-head Codex review remain mandatory.