### PR TITLE
Refresh Rust toolchain image digest

### DIFF
--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -7,7 +7,7 @@ ARG NODE_BASE_IMAGE=node:24-trixie-slim@sha256:85498d7fd8e2bc0b02abb1792ef273415
 # Set to 0 to use epoch; set to a specific date for release builds.
 ARG SOURCE_DATE_EPOCH=0
 
-ARG RUST_TOOLCHAIN_IMAGE=rust:1.97.1-slim-trixie@sha256:5c6f46a6e4472ab1ca7ba7d494e6677f2f219ebc02f32025d3986f057635ec9c
+ARG RUST_TOOLCHAIN_IMAGE=rust:1.97.1-slim-trixie@sha256:69153971349358535be9821190190f026a761f690c6b58c68a914d14ab2d610a
 
 FROM ${RUST_TOOLCHAIN_IMAGE} AS rust-toolchain
 


### PR DESCRIPTION
## Summary

- refresh the immutable digest for `rust:1.97.1-slim-trixie`
- retain the reviewed Rust version and all provider pins unchanged
- keep release preflight aligned with the latest reviewed upstream track

## Candidate

- run: https://github.com/omkhar/workcell/actions/runs/30968213554
- tracking issue: https://github.com/omkhar/workcell/issues/282
- base sha: `addb58521f11a98ce9e5fe139e5173c826f9673a`
- patch sha256: `1d2330f40195583fbf822514007f2938f6cf0089e3cfd2f626aae92e8405ac85`
- tree oid: `f951a607c7055fd9f6e34ccdded6338c652fb829`

## Validation

- exact candidate patch and tree identity reproduced locally
- all four provider release checks passed; no provider version changed
- rebuilt and validated the repository with the refreshed digest
- Dockerfile lint, Go and Rust tests, scenarios, contract parity, and host invariants passed through the live VM boundary attempt
- exact VM parity attempted twice with profile `workcell-live-debug-41883`; both attempts reached the VZ `running` state but Lima's host DHCP lease service timed out before guest SSH (`Get "http://lima/services/dhcp/leases": context deadline exceeded`)
- hosted CI and exact-head Codex review remain required before merge

## Release recovery

This pin must merge before the next v1.0.2 release attempt so release preflight sees the latest reviewed upstream track. Failed v1.0.0 and v1.0.1 tags and drafts remain untouched.
