### PR TITLE
Align core documentation with Workcell v1.0.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,19 @@ the runtime boundary or explicit security guarantees in the name of convenience.
   instruction, runbook, or validator in a reviewable change rather than relying
   on conversational memory.
 
+## Documentation language
+
+- Use ASD-STE100 Simplified Technical English Issue 9 for public documents.
+- Use active voice and simple verb forms.
+- Limit an instruction to 20 words.
+- Limit a descriptive sentence to 25 words.
+- Put one instruction in each sentence.
+- Put no more than six sentences in one paragraph.
+- Keep commands, paths, identifiers, proper names, and quoted output exact.
+- Use the approved project technical nouns and technical verbs.
+- Review each new project term before use.
+- Check changed documents for current support and release facts.
+
 ## Mandatory rules
 
 - Sign every commit. Do not create or rewrite commits in this repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,34 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
-This project follows a lightweight Keep a Changelog style.
+This project uses a simple Keep a Changelog format.
 
-Historical release details before this file existed remain available in GitHub
-Releases.
+The GitHub Releases page contains old details that are not in this file.
+
+## v1.0.2 - 2026-08-05
+
+This release is the first published 1.0 release. The `v1.0.0` and
+`v1.0.1` tags did not produce published releases. Workcell preserves both
+failed tags.
+
+### Changed
+
+- Workcell updated the Debian snapshot after the release check found an
+  upstream change.
+- Workcell updated the pinned Rust toolchain image after the release check
+  found a new
+  image digest.
+- Workcell updated the pinned Node.js base image after the release check found
+  a new
+  image digest.
 
 ## v1.0.1 - 2026-08-04
 
-Supersedes v1.0.0, which was tagged but never published: its release workflow
-uploaded the complete asset inventory to a draft, then the default Actions
-token could not read the repository-administration endpoint used for the final
-immutable-release check. The failed tag and draft remain untouched.
+The `v1.0.1` attempt did not produce a published release. It replaced the
+`v1.0.0` attempt, which also did not produce a published release. The
+`v1.0.0` workflow uploaded all assets to a draft release. The default Actions
+token could not read the final immutable-release control. Workcell preserves
+the failed tags and draft release.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,10 @@ ergonomics second.
 - document lower-assurance paths instead of implying parity
 - sign every commit
 - use feature branches and pull requests; do not push directly to `main`
+- use ASD-STE100 Simplified Technical English Issue 9 for public prose
+
+See [docs/documentation-language.md](docs/documentation-language.md) for the
+project language rules.
 
 ## First-time setup
 
@@ -85,17 +89,30 @@ See [GitHub's docs on signing commits][sign-docs] for setup details.
    ./scripts/dev-quick-check.sh
    ```
 
-5. Before opening a PR, run the full local gate:
+5. Create a signed commit. Use Risk-Aware Commit Notation.
+6. Before publication, run the full local gate:
 
    ```bash
-   ./scripts/pre-merge.sh
+   ./scripts/pre-merge.sh --profile pr-parity
    ```
 
-6. Publish against `main` with the repo-local parity wrapper:
+7. Publish a draft PR against `main` with the repository wrapper:
 
    ```bash
-   ./scripts/repo-publish-pr.sh
+   ./scripts/repo-publish-pr.sh \
+     --branch feature-name \
+     --title "PR title" \
+     --body "Explain the change and its evidence." \
+     --commit-message "^D Describe the change (validation passes; user-visible documentation)"
    ```
+
+8. Post the standalone PR comment `@codex review`.
+9. Fix or disposition each finding.
+10. Resolve each review thread.
+11. Repeat the Codex review after each push.
+12. Require a clean Codex marker for the current head.
+13. Mark the PR ready only after all required checks and reviews pass.
+14. Check comments and review threads again immediately before merge.
 
 The pre-commit hook blocks unrelated commits when stable provider pin bumps are
 pending and points you at `./scripts/publish-provider-bump-pr.sh`.
@@ -119,18 +136,25 @@ concrete feature requests.
 
 ## Commit messages
 
-Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+Use Risk-Aware Commit Notation:
 
 ```text
-<type>: <description>
-
-[optional body]
+<risk><intention> <description> (risk reason; case reason)
 ```
 
-Common types: `feat`, `fix`, `docs`, `chore`, `test`, `refactor`.
+Risk symbols are `.`, `^`, `!`, and `@`. They mean safe, validated, risky,
+and broken.
 
-Keep the subject line under 72 characters. If the change touches the runtime
-boundary, trust model, or provider adapters, mention it in the body.
+Intention letters are `F`, `B`, `R`, and `D`. They mean feature, bug fix,
+refactor, and documentation. Use an uppercase letter for a user-visible change.
+
+Example:
+
+```text
+^D Update release status (validation passes; user-visible documentation)
+```
+
+See [the commit skill](.agents/skills/commit/SKILL.md) for the complete rules.
 
 ## Validation levels
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,8 +1,7 @@
 # Governance
 
-Workcell is a maintainer-led open source project with an explicit bias toward
-auditable security boundaries, small reviewable changes, and clear operator
-contracts.
+The Workcell project has one maintainer. The project uses clear security
+boundaries, small changes, and clear operator contracts.
 
 ## Goals
 
@@ -70,9 +69,10 @@ problem, alternatives, and invariants that must remain intact.
 
 ## Stability and releases
 
-Workcell is currently pre-1.0. Breaking changes may happen, but they should be
-called out in [CHANGELOG.md](CHANGELOG.md), reflected in the docs, and kept
-deliberate rather than incidental.
+Workcell has a stable v1 public contract. Follow the
+[published deprecation policy](docs/stability-contract.md) for a breaking
+change. Record the change in
+[CHANGELOG.md](CHANGELOG.md), and update the applicable documents.
 
 Releases normally land through a short-lived release PR, followed by green
 post-merge `main` CI, a signed tag, the tagged `Release` workflow, and final

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 [![Docs](https://github.com/omkhar/workcell/actions/workflows/docs.yml/badge.svg)](https://github.com/omkhar/workcell/actions/workflows/docs.yml)
 [![Security](https://github.com/omkhar/workcell/actions/workflows/security.yml/badge.svg)](https://github.com/omkhar/workcell/actions/workflows/security.yml)
 
-Workcell runs coding agents inside a bounded local runtime on Apple Silicon
-macOS: a dedicated Colima VM plus a hardened container inside that VM. It ships
-Tier 1 adapters for Codex, Claude Code, GitHub Copilot CLI, and Gemini that
-seed each provider's native control plane without pretending provider config is
-the security boundary. Google Antigravity CLI remains a queued fail-closed
-follow-on; current releases do not support `--agent antigravity`.
+Workcell runs coding agents in a bounded local runtime on Apple Silicon macOS.
+The strict runtime uses a hardened container in a dedicated Colima VM.
+Workcell supports Tier 1 adapters for Codex, Claude Code, GitHub Copilot CLI,
+and Gemini. Each adapter uses the native provider control plane. Provider
+configuration is not the security boundary. Workcell does not support
+`--agent antigravity`.
 
-This project is for teams that want local agent velocity without turning the
-host home directory, keychain, provider state, or local sockets into the trust
-boundary.
+Use Workcell when a team needs local agents and an explicit runtime boundary.
+The safe path does not pass through the host home, keychain, provider state,
+or local sockets.
 
 ## Why Workcell
 
@@ -41,9 +41,8 @@ boundary.
 
 ## Project status
 
-- in the 1.0 release-candidate phase, with the v1 public contract frozen under
-  the published deprecation policy; exact candidate binding and final 1.0
-  readiness are still evidence-gated
+- `v1.0.2` is the first published 1.0 release.
+- the published deprecation policy governs the frozen v1 public contract
 - Apple Silicon macOS hosts only today; Linux and Windows are not currently
   supported as launch hosts
 - local host-launched runtime first; cloud-facing paths today are the
@@ -77,8 +76,8 @@ boundary.
   analytics plane; team rollout today relies on distributing reviewed
   host-side files
 
-Breaking changes should be called out in [CHANGELOG.md](CHANGELOG.md) and
-tracked in [ROADMAP.md](ROADMAP.md).
+The changelog identifies each breaking change. The roadmap identifies future
+work.
 
 ## Community
 
@@ -294,6 +293,7 @@ options.
 | Security reporting | [SECURITY.md](SECURITY.md) |
 | Stability and exit-code contract | [docs/stability-contract.md](docs/stability-contract.md) |
 | Standards watchlist | [docs/standards-watchlist.md](docs/standards-watchlist.md) |
+| Documentation language | [docs/documentation-language.md](docs/documentation-language.md) |
 
 ## Repository layout
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,8 +31,8 @@ The deterministic phase breakdown lives in
 Cross-cutting engineering, security-depth, and adoption improvements from the
 2026-07 repository review live in
 [Engineering And Ecosystem Improvement Tracks](#engineering-and-ecosystem-improvement-tracks)
-below. The release program that sequences those tracks, the remaining feature
-work, and the 1.0 criteria lives in [Path To 1.0](#path-to-10) below.
+below. The [1.0 Program Record](#10-program-record) contains the historical
+release criteria and deferred work.
 
 ## Product Direction
 
@@ -88,122 +88,47 @@ work, and the 1.0 criteria lives in [Path To 1.0](#path-to-10) below.
   adapter is a committed follow-on provider-parity track behind the same
   Tier 1 evidence bar (see [docs/provider-matrix.md](docs/provider-matrix.md)).
 
-## Path To 1.0
+## 1.0 Program Record
 
-Workcell 1.0 is a contract-stability and assurance claim, not a
-platform-reach claim. 1.0 means: the public operator contract is frozen under
-semantic versioning, the reviewed macOS boundary is certified and audit-ready,
-the supported provider set covers the current agent ecosystem, day-two
-operations are proven, and the release path meets the supply-chain bar
-enterprise buyers require. Platform expansion — Linux operator hosts, Windows,
-managed workstations — continues after 1.0 through the phase gates below and
-does not gate 1.0.
+Workcell published `v1.0.2` on 2026-08-05. This release completed the 1.0
+program. The `v1.0.0` and `v1.0.1` tags did not produce published releases.
 
-The competitive context shaping this bar: microVM-per-session runtimes with
-warm starts and per-session egress allowlists are now the mainstream
-comparison point; OS-level sandbox competitors have shipped bypass CVEs;
-repo-defined MCP servers are a proven one-keypress RCE class across three of
-the four currently supported provider CLIs; and enterprises evaluate agent
-runtimes
-against OWASP agentic guidance, SIEM-ready audit export, and SLSA supply-chain
-levels. Workcell's 1.0 bar leans into its differentiators — the strongest
-local boundary, staged credentials, host-side signing, signed evidence, and
-honest support labels — while closing the speed and parallelism gaps
-competitors treat as table stakes and surfacing controls it already ships,
-such as per-session egress allowlisting.
+The 1.0 program froze the public operator contract. It certified the reviewed
+macOS boundary and completed the reviewed release process. It did not add
+Linux, Windows, or managed workstation support.
 
 ### 1.0 Release Criteria
 
-1.0 ships when all of the following hold. Item identifiers refer to the
-improvement tracks below; `G` items are the 1.0 contract-and-operations track.
+The final review confirmed these results:
 
-1. Contract stability: CLI flags and stable output lines, exit codes, the
-   injection-policy schema, and session-record and export formats are
-   versioned, frozen, and covered by a published deprecation policy (G1); the
-   manpage and CLI reference are complete for the frozen surface.
-2. Boundary assurance: egress policy depth and target parity (A1),
-   repo-defined MCP and
-   agent-config containment (A2), hardening-profile conformance (A6),
-   expanded fuzzing (A3), documented unsafe-code invariants (A4), and signed
-   session audit records (A5) are landed. **[Amended 2026-07-09, recorded
-   maintainer decision:]** the third-party boundary audit (B7) is **deferred to
-   post-1.0** rather than required to be scheduled at 1.0. 1.0 boundary
-   assurance rests on the landed A1–A6 hardening plus the documented threat
-   model and invariants; the external audit remains a post-1.0 commitment (see
-   the phase table). Tradeoff recorded honestly: 1.0 ships without independent
-   third-party validation of the boundary, reflecting current maintainer
-   resourcing (no audit sponsor/funding).
-3. Platform: `macos/arm64` strict (Colima) and compat (Docker Desktop) are
-   certified on the release matrix; the Apple `container` backend decision
-   (C1) is recorded either way; native parallel sessions (C3) work on the
-   strict path. **[Amended 2026-08-01, recorded maintainer decision:]** C2
-   certification and its 1.0 latency target are deferred to post-1.0. The
-   generic startup driver remains benchmark-only because caller-provided hooks
-   cannot prove lifecycle state; the reviewed dedicated-certifier design was
-   rejected rather than broaden the launcher with destructive controls.
-4. Providers: the Tier 1 set covers the current agent ecosystem — Codex,
-   Claude Code, GitHub Copilot CLI, Gemini, and Google Antigravity CLI —
-   each through the same Tier 1 evidence bar. If upstream instability blocks
-   Antigravity live certification, 1.0 may ship with the fail-closed scaffold
-   plus an explicit recorded scope decision instead of a support claim.
-5. Operations: install, upgrade, uninstall, rollback, `--gc`, and support
-   bundles (G2) are proven end to end on the release matrix (G3).
-6. Release assurance: mutation-score gating (B3) and SLSA L3 gaps closed or
-   explicitly dispositioned (B1) are in place. **[Amended 2026-07-09, recorded
-   maintainer decision:]** dual-control releases (B2) are **deferred to
-   post-1.0** because Workcell has no second trusted maintainer today. For
-   1.0, the documented single-maintainer controls in
-   [`docs/releasing.md`](docs/releasing.md) are the compensating release
-   control: signed commits, protected `main` with strict CI, required release
-   approval, admin-merge audit trail, and public single-maintainer release
-   comments recording the version, exact head SHA, timestamp, and merge path.
-   Tradeoff recorded honestly: 1.0 has no independent second approver.
-   **[Amended 2026-07-09, recorded maintainer decision:]** the automated
-   real-boundary certification lane (B6, a self-hosted Apple-Silicon CI runner)
-   and the OpenSSF Best Practices badge (B7 part 1) are **deferred to post-1.0**
-   — no funding or hosting for a self-hosted runner is available, and the B7
-   track is deferred with the audit (criterion 2). In place of the automated B6
-   lane, 1.0 requires **local-operator certification of both launch boundaries
-   (strict Colima + compat Docker Desktop) on the maintainer's Apple-Silicon
-   host**, recorded in the readiness review. Tradeoff recorded honestly: the
-   live Colima/Apple-Silicon boundary is exercised by the maintainer locally,
-   not continuously in hosted CI (which runs only a Docker smoke lane on a
-   `ubuntu-latest` runner).
-7. Adoption surface: tiered docs (E1), architecture diagrams (E2), and the
-   support-tier and diagnostics guides (E3) are live. **[Amended 2026-07-09,
-   recorded maintainer decision:]** the rendered docs site with demos and
-   externally published reproducible benchmarks (E6) is **deferred to post-1.0**.
-   1.0 ships with in-repo markdown docs. C2 is deferred to post-1.0 and the
-   generic benchmark is not certification evidence. Tradeoff recorded honestly:
-   1.0 ships without the external rendered site, demo package, or a certified
-   latency claim.
-8. Readiness review: a cross-lens 1.0 gate review (G4) — product,
-   enterprise/security, adapter-maintainer, validation, docs/contract, and
-   release lenses — records no unresolved P0/P1 findings, and every support
-   matrix row matches shipped behavior.
+1. Workcell froze the v1 command and data contracts.
+2. Workcell shipped the A1 through A6 boundary controls.
+3. Workcell certified strict Colima and Docker Desktop compatibility on macOS.
+4. Workcell supported Codex, Claude Code, Copilot CLI, and Gemini.
+5. Workcell proved install, upgrade-in-place, rollback, uninstall,
+   `workcell --gc`, and support bundle operations.
+6. Workcell used mutation tests, signed history, provenance, and immutable
+   release controls.
+7. Workcell shipped the in-repository user and assurance documents.
+8. The G4 review had no open P0 or P1 findings.
 
-The completed G4 evidence package and its GO checklist live in
-[`docs/1.0-readiness-review.md`](docs/1.0-readiness-review.md); the
-B6 (item 6) real-boundary certification lane disposition options are in
-[`docs/b6-disposition-options-draft.md`](docs/b6-disposition-options-draft.md).
-**Recorded maintainer decisions (2026-07-09):** B2 — defer dual-control
-releases because no second trusted maintainer exists; use the single-maintainer
-controls in [`docs/releasing.md`](docs/releasing.md) for 1.0 (criterion 6,
-amended above). B6 — defer the automated Apple-Silicon runner (no funding);
-certify both boundaries by the local-operator discipline on the maintainer's
-host (criterion 6, amended above). B7 — defer the third-party boundary audit and
-OpenSSF badge to post-1.0 (criterion 2, amended above). E6 — defer the rendered
-docs site, demos, and external benchmark publication. C2 — defer certification
-and its latency target to post-1.0; preserve the generic driver as benchmark-only
-after rejecting the broader dedicated-certifier design (criteria 3 and 7 amended
-above). The 2026-08-04 readiness review records the completed checklist, exact
-evidence identities, scope decisions, and zero unresolved P0/P1 findings.
+The final G4 record is in
+[`docs/1.0-readiness-review.md`](docs/1.0-readiness-review.md). It contains the
+exact evidence and each deferred item.
+
+The maintainer deferred these items to work after 1.0:
+
+- a second release approver
+- an automated Apple Silicon boundary lane; see the
+  [B6 decision record](docs/b6-disposition-options-draft.md)
+- a third-party boundary audit and an OpenSSF badge
+- a rendered document site and external demos
+- a certified session start time claim
+- Google Antigravity CLI support
 
 ### Milestone Train
 
-Milestones are sequencing buckets on the existing release cadence; versions
-are indicative and may split. Per-item steps, exit gates, and dependencies
-live in
+These historical milestones led to 1.0. The detailed record is in
 [`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md).
 
 | Milestone | Theme | Contents |
@@ -213,11 +138,10 @@ live in
 | v0.14 | Platform, speed, and adoption | C1, B8, B9, D3 (start), D4, E5, E7, G2, Antigravity Tier 1 adapter track |
 | v0.15 | Enterprise evidence and release assurance | A5, A6, C3, D5, D7, F1, G3 |
 | v1.0 | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
-| post-1.0 | Reach expansion | Phases 13–19 remainder, C2, C4, B2 (dual-control releases), B6 (automated real-boundary lane), B7 (badge + audit completion), E6 (rendered docs site + external demos), F2 |
+| post-1.0 | Reach expansion | Phases 13–19, C2, C4, B2, B6, B7, E6, F2 |
 
-Phase 13 (Linux `amd64` `local_compat` certification candidate) may land
-before or after 1.0 depending on certification evidence; it does not gate
-1.0 and 1.0 creates no Linux claim.
+Phase 13 is the next host support candidate. It does not create a Linux
+support claim.
 
 ## Next Provider And Target Phases
 
@@ -285,11 +209,9 @@ Exit gates:
 
 ### Provider Parity Phase: GitHub Copilot CLI Tier 1 Adapter Parity
 
-Status: documentation and contract surfaces now describe GitHub Copilot CLI as
-a Tier 1 provider adapter. Live provider-authenticated certification of a
-non-destructive `copilot -p` launch with staged credentials remains required
-before signing or publishing changes that promote or materially alter the
-Copilot support claim.
+Status: complete. Workcell supports GitHub Copilot CLI as a Tier 1 provider.
+The release process requires live provider certification before a material
+support claim change.
 
 Exit gates:
 
@@ -461,7 +383,7 @@ diagnostics, and (where applicable) live certification travel with the change.
 Horizons: `now` (next one to three releases), `next` (after the current
 provider and target phases stabilize), `later` (post-1.0 or gated on earlier
 items). Sizes: S/M/L. Milestone assignment for every item lives in the
-[Milestone Train](#milestone-train) under Path To 1.0, and the per-item
+[Milestone Train](#milestone-train) under the 1.0 Program Record, and the per-item
 implementation plan — steps, exit gates, dependencies, and validation
 expectations — lives in
 [`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md).
@@ -614,18 +536,15 @@ contract and proven day-two operations.
 
 ### Sequencing Summary
 
-Sequencing for all tracks now lives in the
-[Milestone Train](#milestone-train) under Path To 1.0. The v0.12 milestone
-(A2, A7, B3, B4, B5, D1, D2, E3, E4) is the suggested first slice: high
-impact, small-to-medium effort, no new support claims, and each item is
-independently shippable.
+The [Milestone Train](#milestone-train) records the historical sequence to
+1.0. The provider and target phases define the sequence after 1.0.
 
 ## Adoption Workstreams
 
 ### Open Source
 
-- publish a short supported quickstart for the strict macOS path
-- publish a clearly labeled Docker Desktop compat quickstart
+- maintain the supported quickstart for the strict macOS path
+- maintain the clear Docker Desktop compatibility instructions
 - keep the Copilot CLI quickstart tied to the explicit staged-token auth model
   and keep live certification tied to the staged-token provider-e2e gate
 - explain why Docker, devcontainers, prompt rules, and provider config are not
@@ -639,8 +558,8 @@ independently shippable.
 
 ### Enterprise
 
-- provide an enterprise evaluation guide, control evidence packet, deployment
-  decision tree, and pilot rollout plan
+- maintain the enterprise guide, evidence baseline, deployment choices, and
+  pilot plan
 - keep Copilot enterprise rollout material tied to licensing/policy
   prerequisites, token ownership, audit expectations, and the ban on host
   `~/.copilot`, keychain, and ambient GitHub CLI passthrough

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,22 +2,21 @@
 
 ## Supported Versions
 
-Workcell operates in single-maintainer release mode. Security fixes are applied
-to `main` (there are no long-lived release branches) and shipped only in the
-**latest released version**; there are no backports to earlier tags. A fix is
-delivered as the next release cut from `main` (patch release, or the next
-release candidate while the line is pre-1.0), so any release older than the
-newest one stops receiving fixes as soon as a newer release exists — including
-earlier release candidates, which are superseded in place.
+Workcell uses a single-maintainer release process. The maintainer applies
+security fixes to `main`. The repository has no long-lived release branches.
+Only the latest release gets security fixes. Workcell does not backport fixes
+to old tags. The maintainer ships a fix in the next release. Install the latest
+verified release to get the fix.
 
 | Version | Security fixes |
 | --- | --- |
 | Latest release | Yes |
-| Any earlier release / superseded pre-release | No — upgrade to the latest |
+| Any earlier release or pre-release | No. Install the latest release. |
 
-Always verify a release before installing it: `scripts/install-release.sh`
-checks the release's cosign signature and digest fail-closed before any bundle
-code runs (see [`docs/install-lifecycle.md`](docs/install-lifecycle.md)).
+Always verify a release before installation. `scripts/install-release.sh`
+verifies the signed checksum file and the asset digest. It fails closed before
+any bundle code starts. See
+[`docs/install-lifecycle.md`](docs/install-lifecycle.md).
 
 ## Signing key
 

--- a/docs/1.0-readiness-review.md
+++ b/docs/1.0-readiness-review.md
@@ -1,12 +1,16 @@
 # Workcell 1.0 Readiness Review — GO
 
-**Status: GO for the v1.0.0 release boundary.** This is the completed
-cross-lens G4 review defined in
+**Historical status: GO for the v1.0.0 release boundary.** This document
+records the completed cross-lens G4 review from
 [ROADMAP.md → 1.0 Release Criteria item 8](../ROADMAP.md#10-release-criteria)
 and
 [improvement-tracks-implementation-plan.md → G4](improvement-tracks-implementation-plan.md).
 Every claim below is grounded in code, policy, docs, hosted checks, or live
 certification reachable from the reviewed `main` commit.
+
+This review is a historical gate record. Workcell published `v1.0.2` on
+2026-08-05 as the first published 1.0 release. The `v1.0.0` and `v1.0.1` tags did
+not produce published releases.
 
 Finalized 2026-08-04 against signed `main` merge
 `786c6140d51d67fb19cd6884b63e49affccf90a0`. Its tree

--- a/docs/documentation-language.md
+++ b/docs/documentation-language.md
@@ -1,0 +1,69 @@
+# Documentation Language
+
+Use ASD-STE100 Simplified Technical English Issue 9 for Workcell documents.
+This rule applies to public prose, pull request text, and release notes.
+
+## Source
+
+The ASD Simplified Technical English Maintenance Group publishes the standard.
+Request the current official copy from
+[asd-ste100.org](https://www.asd-ste100.org/STE_downloads.html).
+
+Issue 9 has 53 rules and a controlled dictionary. This page only summarizes
+the rules. It does not replace the standard or its dictionary.
+
+Keep commands, paths, identifiers, proper names, and quoted output exact. Do
+not classify all these items as technical nouns or technical verbs.
+
+## Rule summary
+
+- Use approved dictionary words with their approved meanings.
+- Use active voice.
+- Use simple present, simple past, or simple future verbs.
+- Use the imperative form for an instruction.
+- Limit an instruction to 20 words.
+- Limit a descriptive sentence to 25 words.
+- Put one instruction in each sentence.
+- Put one topic in each paragraph.
+- Put no more than six sentences in one paragraph.
+- Do not use an `-ing` verb form.
+- Use an `-ing` term only as an approved word, a technical noun, or its
+  modifier.
+- Limit a multi-word noun to three words.
+- Write an approved longer technical noun in full at its first use.
+- Then use a shorter form or hyphens to show one unit.
+- Use one term for one meaning.
+- Use an approved technical noun or technical verb when it is necessary.
+
+## Project terms
+
+Use these terms with the specified meaning:
+
+| Term | Class | Meaning |
+|---|---|---|
+| Workcell | proper noun | This project and product. |
+| safe path | technical noun | The supported path that applies the reviewed controls. |
+| runtime boundary | technical noun | The VM and container isolation boundary. |
+| control plane | technical noun | The code, files, and settings that control Workcell or a provider. |
+| provider state | technical noun | The provider files, cache, and session data. |
+| support matrix | technical noun | The policy table that defines host support. |
+| Tier 1 | technical noun | A provider support level in the provider matrix. |
+| fail closed | technical verb | Stop when Workcell cannot prove a required condition. |
+| stage | technical verb | Copy approved data to a controlled path before use. |
+| scrub | technical verb | Remove a prohibited value from an environment or file. |
+| mask | technical verb | Hide a workspace control file from the provider. |
+
+Before you use a new project term, search this page and the applicable
+contract document. Define one meaning for the term. Add only a project-specific
+term that has a controlled meaning in more than one document.
+
+## Review
+
+Read each changed document before a commit. Compare each support claim with
+`policy/host-support-matrix.tsv` and `policy/operator-contract.toml`.
+
+Compare each requirement claim with `policy/requirements.toml`. Compare each
+release claim with the published GitHub release.
+
+Check each sentence against the full standard. Then do the public scrub and
+remove private data.

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -1,7 +1,7 @@
 # Improvement Tracks Implementation Plan
 
 This document turns the
-[Path To 1.0](../ROADMAP.md#path-to-10) program and its
+[1.0 Program Record](../ROADMAP.md#10-program-record) and its
 [Engineering And Ecosystem Improvement Tracks](../ROADMAP.md#engineering-and-ecosystem-improvement-tracks)
 into a concrete, milestone-based implementation plan. The tracks came from
 the 2026-07 repository review (documentation, Rust/Go/shell source, tests,
@@ -745,8 +745,7 @@ identity and access (Phase 15), signed policy bundles (Phase 16), fleet
 inventory and audit export beyond F1 (Phase 17), the regulated-team proof
 harness and Windows investigation (Phase 18), and the managed-workstation
 preview plus Azure (Phase 19) continue under their existing exit gates.
-Phase 13 may land before 1.0 if its certification evidence arrives, but it
-does not gate 1.0.
+Phase 13 is work after 1.0. It creates no Linux support claim.
 
 ## Dependency Summary
 

--- a/docs/release-posture.md
+++ b/docs/release-posture.md
@@ -1,6 +1,11 @@
 # Release Posture
 
-Tagged releases are rebuilt and verified before publication. The release path:
+The latest release is [`v1.0.2`](https://github.com/omkhar/workcell/releases/tag/v1.0.2).
+It is the first published 1.0 release. GitHub reports it as immutable. Its
+18-asset inventory has a SHA-256 digest for each asset.
+
+Workcell rebuilds and verifies each tagged release before publication. The
+release path does these checks:
 
 - reruns validation, smoke, and reproducibility checks
 - reruns repo-mounted validator and release-helper paths under an explicit

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -363,7 +363,7 @@ Create a signed release commit:
 
 ```sh
 git add -A
-git commit -S -m "release: ${VERSION}"
+git commit -S -m "^D Prepare ${VERSION} release (local release checks pass; user-visible release record)"
 ```
 
 ## 5. Publish the release PR from the host
@@ -377,7 +377,7 @@ local parity gate:
   --branch "${RELEASE_BRANCH}" \
   --title "${RELEASE_TITLE}" \
   --body "Prepare ${VERSION} release." \
-  --commit-message "release: ${VERSION}"
+  --commit-message "^D Prepare ${VERSION} release (local release checks pass; user-visible release record)"
 ```
 
 In `review-gated` mode, stop with the first checkpoint packet before running


### PR DESCRIPTION
Summary:
- Record v1.0.2 as the first published 1.0 release.
- Convert the 1.0 roadmap section to a historical record.
- Add the ASD-STE100 Issue 9 language rules and project terms.
- Align the contributor process with the shipped PR workflow.

Evidence:
- The exact documentation and contract checks pass.
- Six adversarial reviewer roles accept the final diff.
- The shared repository validator passes.
- The live VZ fixture could not resolve its guest address after two attempts.