### PR TITLE
Align provider and install documentation

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -11,26 +11,23 @@ and behavior):
 - [`copilot/`](copilot/README.md)
 - [`gemini/`](gemini/README.md)
 
-Planned fail-closed scaffolds:
+Unsupported fail-closed scaffolds:
 
 - [`antigravity/`](antigravity/README.md)
 
 ## Common adapter contract
 
-Every supported adapter follows the same shape:
+Every supported adapter has these properties:
 
-- one shared runtime VM-plus-container boundary; the adapter is thin and its
-  provider config is defense in depth, not the boundary
-- a session-local provider home rebuilt each launch from immutable baselines
-  under `adapters/<name>/`, explicit injection-policy inputs, and masked
-  workspace imports (`runtime/container/home-control-plane.sh`)
-- explicit credential keys only — no host home, keychain, socket, or ambient CLI
-  auth passthrough (see [`../docs/injection-policy.md`](../docs/injection-policy.md)
-  and [`../docs/invariants.md`](../docs/invariants.md))
-- provider-native unsafe-flag rejection in the wrapper
-  (`runtime/container/provider-policy.sh`), enforced in **every** mode — the
-  wrapper re-checks arguments (`WORKCELL_WRAPPER_CONTEXT=1`) so even `breakglass`
-  cannot pass them; breakglass raises the sandbox floor, not the unsafe-flag policy
+- One VM and container runtime boundary is common to all adapters.
+- The adapter is thin. Provider configuration is not the runtime boundary.
+- Each start builds a session-local provider home from immutable baselines and
+  explicit inputs.
+- Each adapter accepts only explicit credential keys.
+- It does not pass host homes, keychains, sockets, or ambient CLI auth.
+- The wrapper rejects provider unsafe flags in every mode.
+- Breakglass changes the container posture. It does not change the provider
+  unsafe-flag policy.
 
 The cross-adapter mapping tables live in
 [`../docs/adapter-control-planes.md`](../docs/adapter-control-planes.md).
@@ -44,16 +41,19 @@ Adapter rules:
 
 ## Adding a new provider
 
-Per-provider Go tables (credential keys, container paths, reserved
-targets) live in `internal/adapters/data.go` — promoting a planned provider is
-a single row append to the `providers` slice plus the per-provider config tree
-under `adapters/<name>/`. There is no longer a per-provider Go sub-package; see
-`internal/adapters/adapters.go` for the public API that the injection, policy,
-and runtime paths consume. A provider directory without a registry row is only a
-fail-closed scaffold.
+Per-provider Go tables contain credential keys, container paths, and reserved
+targets. These tables are in `internal/adapters/data.go`. Add a row when you
+implement an adapter. The row must match `providerid.CredentialMetadataProviders`
+order. Also add the provider configuration tree under `adapters/<name>/`.
 
-For step-by-step worked examples — adding a credential type and extending or
-adding an adapter, each annotated with the invariants and threat-model items it
-touches — see [`../docs/extending-adapters.md`](../docs/extending-adapters.md).
+These registry changes do not make a provider supported. Support also requires
+launcher, auth, policy, tests, documents, and live certification. A provider
+directory without a registry row is a fail-closed scaffold.
+
+The file `internal/adapters/adapters.go` contains the public API. Injection,
+policy, and runtime code use this API.
+
+See [`../docs/extending-adapters.md`](../docs/extending-adapters.md) for worked
+examples. Each example identifies its related invariants and threats.
 The porting checklist is in
 [`../workflows/adapter-porting.md`](../workflows/adapter-porting.md).

--- a/adapters/antigravity/README.md
+++ b/adapters/antigravity/README.md
@@ -1,16 +1,15 @@
 # Google Antigravity CLI Adapter
 
-This adapter directory is a fail-closed planning scaffold. Workcell recognizes
-`antigravity` as a planned Google Antigravity CLI provider id
-(`internal/providerid/providerid.go`), but it does not install, prepare,
-authenticate, or launch Antigravity yet. It is not in the supported-provider
-registry (`internal/adapters/data.go`) and `providerid.IsValid("antigravity")`
-returns false.
+This adapter directory is a fail-closed scaffold. Workcell recognizes
+`antigravity` as a provider name in `internal/providerid/providerid.go`.
+Workcell does not install, prepare, authenticate, or start Antigravity. The
+supported-provider registry does not include it. The function
+`providerid.IsValid("antigravity")` returns false.
 
 ## Auth methods
 
-None today. A future path must first pin official install and auth provenance,
-then stage only reviewed Google auth material into session-local provider state.
+None. A supported path must pin official install and auth provenance. It must
+stage only reviewed Google auth material in session-local provider state.
 Host Google account caches, browser profiles, keychains, host homes, and
 provider caches are not acceptable implicit safe-path inputs
 (`docs/injection-policy.md`, `docs/invariants.md` §1). No Antigravity credential
@@ -19,26 +18,23 @@ the matching adapter, validation, and docs land.
 
 ## Managed control-plane files
 
-None today. Before support is claimed the adapter must own session-local
-provider home/cache/settings state under `/state/agent-home` and explicitly map
-or block Antigravity's subagent, plugin, MCP, sandbox, permission, hook, and
-instruction surfaces (`docs/adapter-control-planes.md`).
+None. Before support, the adapter must own session-local provider state under
+`/state/agent-home`. It must map or block each Antigravity control surface. See
+`docs/adapter-control-planes.md`.
 
 ## Adapter behavior
 
-`workcell --agent antigravity` exits before runtime preparation with a
-"planned Workcell provider adapter, but it is not supported yet" diagnostic and
-a non-zero status (`scripts/workcell`). Support promotion requires the same
-review unit to add:
+`workcell --agent antigravity` exits before runtime preparation. It gives a
+"planned Workcell provider adapter, but it is not supported yet" diagnostic.
+One review unit must add all these controls before support:
 
-- an official pinned Antigravity CLI install path with provenance evidence
-- explicit Antigravity home and cache-state handling under `/state/agent-home`
-- a staged Google auth handoff that does not mount host Google account state,
-  browser profiles, keychains, host homes, or provider caches
-- provider-native unsafe-flag rejection in the Workcell wrapper
-  (`runtime/container/provider-policy.sh`)
-- deterministic dry-run and scenario coverage
-- a live provider certification run before any supported Tier 1 matrix claim
+- Pin the official Antigravity CLI install path and provenance.
+- Own Antigravity home and cache state under `/state/agent-home`.
+- Stage Google auth without a host account, browser, keychain, home, or cache
+  mount.
+- Reject provider unsafe flags in `runtime/container/provider-policy.sh`.
+- Add deterministic dry-run and scenario tests.
+- Pass live provider certification before a Tier 1 claim.
 
 ## See also
 

--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -1,25 +1,17 @@
 # Claude Adapter
 
-The Claude adapter maps the shared Workcell runtime into Claude Code's native
-files and guardrails. Hooks and settings are defense in depth; the runtime
-VM-plus-container boundary stays primary.
+The Claude adapter maps the Workcell runtime to Claude Code controls. The VM
+and container runtime boundary is the primary control. Hooks and settings give
+additional protection.
 
 ## Auth methods
 
-- `claude_auth` credential key — a direct staged auth file mirrored into the
-  Claude auth locations under `~/.claude/`, `~/.claude.json`, and
-  `~/.config/claude-code/` (`internal/adapters/data.go`,
-  `runtime/container/home-control-plane.sh`).
-- `claude_api_key` credential key — wired through an `apiKeyHelper` script at
-  `~/.claude/workcell/api-key-helper.sh` that reads the mounted key file, so a
-  second plaintext key copy is not seeded into the session
-  (`runtime/container/home-control-plane.sh`).
-- `claude_mcp` credential key — reviewed Claude MCP config seeded to `~/.mcp.json`.
-- `claude-macos-keychain` resolver — a fail-closed scaffold: it records the
-  intended host-side auth source in policy but Workcell still aborts launch
-  until a supported export path exists
-  (`internal/authresolve/resolve_credential_sources.go`,
-  `docs/injection-policy.md`).
+- `claude_auth` stages the auth file at the reviewed Claude auth paths.
+- `claude_api_key` uses `~/.claude/workcell/api-key-helper.sh`. The helper reads
+  the mounted key file. It does not make a second plaintext key copy.
+- `claude_mcp` stages reviewed Claude MCP configuration at `~/.mcp.json`.
+- `claude-macos-keychain` is a fail-closed scaffold. Workcell stops until a
+  supported export path exists.
 - Shared GitHub CLI (`github_hosts`, `github_config`) and SSH inputs apply
   (`sharedCredentialsEnabled: true` in `internal/adapters/data.go`).
 
@@ -43,38 +35,32 @@ Repo baselines under `adapters/claude/`:
 In-container reserved session targets include `~/.claude`,
 `~/.claude/settings.json`, `~/.claude/CLAUDE.md`, the auth mirrors
 (`~/.claude/.credentials.json`, `~/.claude.json`,
-`~/.config/claude-code/auth.json`), the API-key helper dir `~/.claude/workcell`,
+`~/.config/claude-code/auth.json`), the API key helper dir `~/.claude/workcell`,
 and `~/.mcp.json` (`ReservedTargets` in `internal/adapters/data.go`).
 
 ## Adapter behavior
 
-- Each launch rebuilds the provider home from the immutable baseline plus
-  explicit injection inputs; repo-local `.claude/` and `CLAUDE.md` are masked and
-  imported only as reviewed layers
-  (`runtime/container/home-control-plane.sh`, `docs/invariants.md` §3).
+- Each start rebuilds the provider home from the immutable baseline and explicit
+  inputs. Workcell masks repo-local `.claude/` and `CLAUDE.md`. It imports them
+  only as reviewed layers.
 - The reviewed `PreToolUse` Bash hook blocks common trust-widening shell
   patterns. It is defense in depth: it does not replace the runtime boundary and
   does not cover non-Bash Claude tools
   (`docs/adapter-control-planes.md#claude-hook-coverage`).
 - Autonomy is set host-side via `workcell --agent-autonomy` (mapped to
   `--permission-mode`); the wrapper does not honor provider-native overrides.
-- Unsafe-argument policy (`reject_unsafe_claude_args` in
-  `runtime/container/provider-policy.sh`): the wrapper blocks
-  `--dangerously-skip-permissions`, `--add-dir`, `--allowedTools`,
-  `--mcp-config`, `--plugin-dir`, `--settings`, `--setting-sources`,
-  `--system-prompt`, `--append-system-prompt`, in-session `--permission-mode`
-  overrides, and the `install`/`update` lifecycle commands. These are rejected in
-  **every** mode including `breakglass`: `provider-wrapper.sh` re-checks arguments
-  (it sets `WORKCELL_WRAPPER_CONTEXT=1`, which makes the breakglass exemption
-  inapplicable), so `container-smoke.sh` confirms breakglass overrides still fail.
-  Breakglass raises the container sandbox floor, not the provider unsafe-flag
-  policy.
+- `reject_unsafe_claude_args` blocks permission bypass, extra directories,
+  custom tools, MCP, plugins, settings, and prompt overrides.
+- It also blocks provider install and update commands. These rules apply in all
+  modes, including `breakglass`.
+- Breakglass changes the container posture. It does not change the provider
+  unsafe-flag policy.
 - The wrapper scrubs provider env such as `CLAUDE_CONFIG_DIR`, `GH_TOKEN`,
   `GITHUB_TOKEN`, and the OpenTelemetry variables before launch
   (`runtime/container/provider-wrapper.sh`).
 
-GUI or IDE use is lower assurance unless it is only a client to the same bounded
-runtime.
+GUI or IDE use has lower assurance. It can be Tier 2 only as a client of the
+same bounded runtime.
 
 ## See also
 

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,20 +1,17 @@
 # Codex Adapter
 
-The Codex adapter maps the shared Workcell boundary into Codex-native controls.
-It re-seeds a session-local Codex home from reviewed baselines on every launch;
-the runtime VM-plus-container boundary stays primary and Codex config is defense
-in depth, not the boundary.
+The Codex adapter maps the Workcell runtime to Codex controls. At each start,
+it builds a session-local Codex home from reviewed baselines. The VM and
+container runtime boundary is the primary control. Codex configuration gives
+additional protection.
 
 ## Auth methods
 
-- `codex_auth` credential key — a direct staged `auth.json` seeded to
-  `~/.codex/auth.json` (`internal/adapters/data.go`).
-- `codex-home-auth-file` resolver — a reviewed host-side Codex auth-file reuse
-  path; still host-side preprocessing only, not Keychain passthrough
-  (`internal/authresolve/resolve_credential_sources.go`).
-- Shared GitHub CLI (`github_hosts`, `github_config`) and SSH inputs apply
-  because Codex opts into shared credentials
-  (`sharedCredentialsEnabled: true` in `internal/adapters/data.go`).
+- `codex_auth` stages `auth.json` at `~/.codex/auth.json`. See
+  `internal/adapters/data.go`.
+- `codex-home-auth-file` reads the reviewed host Codex auth file. It does not
+  pass a keychain to the runtime.
+- Codex accepts the shared `github_hosts`, `github_config`, and SSH inputs.
 
 See [../../docs/injection-policy.md](../../docs/injection-policy.md) and
 [../../docs/provider-bootstrap-matrix.md](../../docs/provider-bootstrap-matrix.md).
@@ -48,40 +45,30 @@ In-container reserved session targets: `~/.codex/{config.toml,auth.json,`
   session-local Codex home, and imports repo-local control-plane files only as
   masked, reviewed layers (`runtime/container/provider-wrapper.sh`,
   `runtime/container/home-control-plane.sh`).
-- Codex's own Linux `workspace-write` sandbox is pinned off on the managed path:
-  the current Codex Linux sandbox needs unprivileged user namespaces that are
-  unavailable inside the Tier 1 container.
+- Workcell turns off the Codex Linux `workspace-write` sandbox on the managed
+  path. That sandbox needs unprivileged user namespaces. The Tier 1 container
+  does not provide them.
 - `~/.codex/rules/` is read-only by default; it becomes a session-local writable
   copy only in explicit lower-assurance cases (see
   [../../docs/adapter-control-planes.md](../../docs/adapter-control-planes.md#codex-rules-mutability)).
-- Unsafe-argument policy (`reject_unsafe_codex_args` in
-  `runtime/container/provider-policy.sh`): **subcommands are deny-by-default**
-  over the pinned Codex subcommand namespace — only the read-only/session
-  surface is permitted (exec, review, login/logout, completion, doctor, apply,
-  resume, fork, archive/unarchive/delete, help, execpolicy, `features
-  list`); everything else is rejected (plugin, remote-control, exec-server,
-  mcp*, cloud*, responses-api-proxy, stdio-to-uds, update, sandbox, debug,
-  `features enable`/`disable`, and any unclassified/new subcommand). `app-server` is the
-  managed GUI backend and is permitted only as the bare no-arg launch; an
-  unknown first token is Codex prompt text. The classified set is pinned to the
-  version by
-  [`tests/fixtures/codex-subcommands.txt`](../../tests/fixtures/codex-subcommands.txt)
-  (a `CODEX_VERSION` bump fails CI until it is regenerated). The wrapper also
-  blocks `--yolo`/`--dangerously-bypass-*`, autonomy/network flags
-  (`--full-auto`, `-a`, `--add-dir`, `--search`, `--remote`,
-  `--remote-auth-token-env`, `--enable`, `--disable`, `--cd`,
-  `--sandbox danger-full-access`), off-mode `--profile`
-  values, and reserved `-c`/`--config` overrides of guarded namespaces
-  (features/plugins/marketplaces/mcp/hooks/sandbox/approval, incl. glued,
-  quoted/escaped, inline-table, and `profiles.<name>.<key>` spellings). All are
-  rejected in **every** mode including `breakglass` (`provider-wrapper.sh`
-  re-checks with `WORKCELL_WRAPPER_CONTEXT=1`); breakglass raises the sandbox
-  floor, not the unsafe-argument policy.
+- `reject_unsafe_codex_args` denies unapproved subcommands by default. See
+  `runtime/container/provider-policy.sh`.
+- The allowed set contains the reviewed read-only and session commands. The
+  fixture `tests/fixtures/codex-subcommands.txt` binds this set to the Codex
+  version.
+- The wrapper blocks plugin, cloud, remote-control, `exec-server`, update,
+  sandbox, debug, and unclassified subcommands.
+- It also blocks MCP servers, `responses-api-proxy`, and `stdio-to-uds`.
+- The wrapper permits `app-server` only as a bare start without arguments.
+- The wrapper also blocks unsafe autonomy, network, profile, and configuration
+  flags. This includes changes to guarded configuration namespaces.
+- These rules apply in all modes, including `breakglass`. Breakglass changes
+  the container posture. It does not change the provider unsafe-flag policy.
 - Final branch publication stays on the host through `workcell publish-pr`, not
   from inside the container session.
 
-Codex CLI is Tier 1 when it runs fully inside the bounded runtime. App support is
-only valid once it becomes a client of the same bounded executor.
+Codex CLI is Tier 1 when it runs fully in the bounded runtime. An app can be
+Tier 2 only when it is a client of the same bounded runtime.
 
 ## See also
 

--- a/adapters/copilot/README.md
+++ b/adapters/copilot/README.md
@@ -1,28 +1,25 @@
 # GitHub Copilot CLI Adapter
 
-This adapter owns the Workcell-managed GitHub Copilot CLI baseline. It runs a
-pinned Copilot CLI binary against session-local provider state; the runtime
-VM-plus-container boundary stays primary.
+This adapter owns the Workcell GitHub Copilot CLI baseline. It runs the pinned
+CLI with session-local provider state. The VM and container runtime boundary is
+the primary control.
 
 ## Auth methods
 
 - `copilot_github_token` credential key — the only Copilot auth input
   (`internal/adapters/data.go`; Copilot sets `sharedCredentialsEnabled: false`,
   so shared GitHub CLI state is deliberately excluded).
-- For auth-required launches the staged token is not seeded into provider state.
-  Instead it flows through a scrubbing handoff
-  (`runtime/container/entrypoint.sh`, `runtime/container/provider-wrapper.sh`):
-  the entrypoint moves the token into a transient runtime handoff file, unlinks
-  the mounted file, and re-execs without the token in its environment while
-  staying PID 1 (no Docker `--init`) so `/proc/1/environ` is scrubbed; the
-  provider wrapper then unlinks the handoff file and exports the value as
-  `COPILOT_GITHUB_TOKEN` only for the managed Copilot child process. The original
-  staged token file and its direct-mount copy are removed from direct runtime
-  mounts and are not copied into `COPILOT_HOME`.
-- The adapter does not use host GitHub CLI state, host Copilot provider state
-  (`~/.copilot`, `~/.config/github-copilot`, `~/.cache/github-copilot`), host
-  keychains, `GH_TOKEN`, `GITHUB_TOKEN`, or ambient `gh auth token` as auth or
-  readiness inputs (`docs/invariants.md` §1).
+- An authenticated start does not copy the staged token to provider state. The
+  entrypoint moves it to a temporary runtime file and unlinks the mounted file.
+- The entrypoint uses `exec` to replace itself without the token environment.
+  It stays PID 1 without Docker `--init`. Thus, `/proc/1/environ` does not
+  contain the token.
+- The provider wrapper unlinks the runtime file. It exports the token only to
+  the managed Copilot child as `COPILOT_GITHUB_TOKEN`.
+- Workcell removes the original staged token and its direct-mount copy. It does
+  not copy the token to `COPILOT_HOME`.
+- The adapter does not use host GitHub CLI state or host Copilot state. It does
+  not use host keychains, `GH_TOKEN`, `GITHUB_TOKEN`, or ambient `gh auth token`.
 
 See [../../docs/injection-policy.md](../../docs/injection-policy.md).
 
@@ -47,20 +44,14 @@ directories. In-container reserved session targets: `~/.copilot`,
   `.github/instructions/**`, `.github/mcp.json`, `.github/copilot/settings*.json`,
   repo-local skill/hook dirs) are masked on the safe path (`docs/invariants.md`
   §3).
-- Unsafe-argument policy (`reject_unsafe_copilot_args` in
-  `runtime/container/provider-policy.sh`): the wrapper blocks the
-  `init`/`login`/`logout`/`mcp`/`plugin`/`skill`/`update` lifecycle and
-  control-plane subcommands and a broad set of trust-widening flags (MCP toolset/config,
-  `--allow-all*`, `--allow-tool`/`--allow-url`, `--add-dir`, `--dynamic-retrieval`,
-  `--no-custom-instructions`, `--remote`/`--share*`/`--worktree`, `--yolo`,
-  bundled short options, and more). These are rejected in **every** mode
-  including `breakglass`: `provider-wrapper.sh` re-checks arguments
-  (`WORKCELL_WRAPPER_CONTEXT=1`), so `container-smoke.sh` confirms breakglass
-  overrides still fail. Breakglass raises the sandbox floor, not the unsafe-flag
-  policy.
-- Plugin, MCP, custom-agent, hook, skill, dynamic-retrieval, and remote-session
-  expansion each stay blocked on the default path until a separate Workcell
-  review unit and validation evidence land.
+- `reject_unsafe_copilot_args` blocks `init`, `login`, `logout`, MCP, plugin,
+  skill, update, and other control-plane subcommands.
+- It also blocks unsafe tool, URL, directory, instruction, remote, share,
+  worktree, and autonomy flags.
+- These rules apply in all modes, including `breakglass`. Breakglass changes
+  the container posture. It does not change the provider unsafe-flag policy.
+- The default path blocks plugins, MCP, custom agents, hooks, skills, dynamic
+  retrieval, and remote sessions. A separate review unit must add each surface.
 - Any Copilot telemetry, OpenTelemetry, or content-capture enablement is a
   lower-assurance, acknowledged path, not a default (`docs/invariants.md` §6).
 

--- a/adapters/gemini/README.md
+++ b/adapters/gemini/README.md
@@ -1,13 +1,13 @@
 # Gemini Adapter
 
-The Gemini adapter seeds Gemini CLI's session-local home from reviewed baselines
-and explicit injection inputs. Workcell's external VM-plus-container boundary is
-primary; Gemini's own sandbox is optional and not the Tier 1 boundary here.
+The Gemini adapter builds a session-local Gemini CLI home from reviewed
+baselines and explicit inputs. The Workcell VM and container runtime boundary
+is the primary control. The Gemini sandbox is not the Tier 1 boundary.
 
 ## Auth methods
 
-- `gemini_env` credential key — API key, GCA, or Vertex configuration seeded to
-  `~/.gemini/.env` (`internal/adapters/data.go`).
+- `gemini_env` credential key — API key, Gemini Code Assist (GCA), or Vertex
+  configuration seeded to `~/.gemini/.env` (`internal/adapters/data.go`).
 - `gemini_oauth` credential key — cached Gemini OAuth state seeded to
   `~/.gemini/oauth_creds.json`.
 - `gemini_projects` credential key — persisted project registry seeded to
@@ -51,14 +51,10 @@ Additional in-container session targets: `~/.gemini/.env`,
   `runtime/container/provider-wrapper.sh`).
 - Autonomy is set host-side via `workcell --agent-autonomy` (mapped to
   `--approval-mode`); provider-native overrides are not honored.
-- Unsafe-argument policy (`reject_unsafe_gemini_args` in
-  `runtime/container/provider-policy.sh`): the wrapper blocks
-  `--*dangerously*`, `--*bypass*permission*`, `--sandbox`, `--add-dir`,
-  `-y`/`--yolo`, and in-session `--approval-mode` overrides. These are rejected in
-  **every** mode including `breakglass`: `provider-wrapper.sh` re-checks arguments
-  (`WORKCELL_WRAPPER_CONTEXT=1`), so `container-smoke.sh` confirms breakglass
-  overrides still fail. Breakglass raises the sandbox floor, not the unsafe-flag
-  policy.
+- `reject_unsafe_gemini_args` blocks permission bypass, sandbox, extra
+  directory, yolo, and approval-mode flags.
+- These rules apply in all modes, including `breakglass`. Breakglass changes
+  the container posture. It does not change the provider unsafe-flag policy.
 
 ## See also
 

--- a/docs/adapter-control-planes.md
+++ b/docs/adapter-control-planes.md
@@ -26,16 +26,14 @@ adapter baseline.
 | GitHub Copilot CLI | session-local `COPILOT_HOME`, `COPILOT_CACHE_HOME`, host-mounted token handoff plus transient runtime handoff, logs, and `~/.config/github-copilot` | supported Copilot token credential: `copilot_github_token`, staged through reviewed host-side inputs, removed from direct runtime mounts including the staged direct-mount copy, passed through a temporary handoff mount outside provider state, scrubbed from PID 1 by running the Workcell entrypoint without Docker `--init` for token handoff launches, and exported as `COPILOT_GITHUB_TOKEN` only to the managed child after unlinking the runtime handoff file; host `gh` auth, host keychains, host Copilot provider state (`~/.copilot`, `~/.config/github-copilot`, `~/.cache/github-copilot`), custom instructions, and skill/dynamic-retrieval surfaces are not safe-path inputs |
 | Gemini | `settings.json`, rendered `GEMINI.md`, `.env`, `oauth_creds.json`, `projects.json`, `trustedFolders.json` | `breakglass` restores Gemini's own folder-trust prompt; `gcloud_adc` is supplemental to Vertex config in `gemini_env` |
 
-## Current and planned provider control planes
+## Current and unsupported provider control planes
 
 GitHub Copilot CLI is seeded as a Tier 1 provider adapter. The adapter owns a
 session-local `COPILOT_HOME`, `COPILOT_CACHE_HOME`, token handoff, logs, and
-cache/config directories. It rejects host `~/.copilot`, keychain access,
-host `~/.config/github-copilot`, host `~/.cache/github-copilot`, `GH_TOKEN`,
-`GITHUB_TOKEN`, ambient GitHub CLI fallback, custom instructions, repo-local
-skill/dynamic-retrieval expansion, unreviewed plugin or MCP expansion,
-remote-control sharing, and provider auto-update state as implicit Tier 1
-inputs.
+cache/config directories. It rejects host Copilot state, keychain access, and
+ambient GitHub CLI auth. It also rejects custom instructions and unreviewed
+control-plane expansion. It does not permit remote control or provider
+auto-update state.
 
 Shared cross-provider state can also seed the current supported adapters:
 
@@ -46,12 +44,11 @@ Shared cross-provider state can also seed the current supported adapters:
 That GitHub CLI state must not become a Copilot safe-path auth input unless a
 separate reviewed Copilot path explicitly allows it.
 
-Google Antigravity CLI is also a planned fail-closed adapter. Before support is
-claimed, the Antigravity adapter must pin official CLI provenance, own
-session-local provider home/cache/settings state, and explicitly map or block
-subagents, plugins, MCP, sandbox settings, permissions, hooks, and any shared
-desktop/IDE state. Host Google account caches, browser profiles, keychains,
-host homes, and provider caches must not become implicit Tier 1 inputs.
+Google Antigravity CLI is an unsupported fail-closed scaffold. Before support,
+the adapter must pin official CLI provenance. It must own session-local provider
+state. It must map or block each provider control surface. Host account state,
+browser profiles, keychains, home directories, and provider caches must stay
+excluded.
 
 ## Instruction layering
 
@@ -75,9 +72,8 @@ control plane masked on the safe path.
 | `--agent-autonomy prompt` | `--ask-for-approval on-request` | `--permission-mode default` | `--available-tools=view,create,edit,apply_patch,grep,glob` | `--approval-mode default` |
 
 Copilot maps prompt and yolo modes through the reviewed provider wrapper,
-blocks shell access by omission from `--available-tools`, and rejects
-user-supplied flags that silently widen trust. Antigravity autonomy mappings
-are intentionally absent until its adapter lands.
+blocks shell access by omission from `--available-tools`, and rejects unsafe
+user flags. Antigravity has no autonomy mapping because it is unsupported.
 
 Unsafe provider-native attempts to override those managed flags are blocked on
 the managed path.
@@ -105,10 +101,10 @@ copy only when:
 
 ### Codex native sandbox
 
-Workcell pins Codex's own Linux shell sandbox off on the managed path.
-Workcell's outer VM-plus-container boundary remains the primary isolation
-control, and the current Codex Linux sandbox requires unprivileged user
-namespaces that are not available inside the Tier 1 container.
+Workcell turns off the Codex Linux shell sandbox on the managed path. The
+Workcell VM and container boundary remains the primary isolation control. The
+Codex sandbox needs unprivileged user namespaces. The Tier 1 container does not
+provide them.
 
 ### Claude hook coverage
 
@@ -124,12 +120,10 @@ path so masked ephemeral sessions do not force a restart-based trust prompt.
 
 ### Provider trust and permissions
 
-Copilot support treats permissive CLI options, saved permissions, remote
-control, plugins, hooks, skills, MCP/LSP config, custom instructions,
-repository-local Copilot settings, and dynamic retrieval as managed
-control-plane inputs. Current releases stage only the reviewed session-local
-Copilot home/cache and explicit token input mount, not host Copilot or ambient
-GitHub CLI state.
+Workcell controls permissive CLI options, saved permissions, and remote control.
+It also controls plugins, hooks, skills, MCP, LSP, instructions, and dynamic
+retrieval. The current release stages only reviewed session-local state and the
+explicit token input.
 
 Antigravity support must do the same once official CLI provenance identifies
 its settings, permission, plugin, MCP, hook, and instruction surfaces. Current
@@ -146,15 +140,13 @@ Workcell ships no live MCP defaults in the adapter baselines. Reviewed MCP
 state must arrive through explicit operator inputs, not ambient workspace
 content.
 
-Repo-defined MCP server-definition surfaces (`.mcp.json`, `.github/mcp.json`)
-are classified `deny` in every non-breakglass mode: an untrusted workspace can
-otherwise wire the agent to arbitrary MCP servers, a boundary/exfil risk. The
-launcher overlays a neutralized, schema-valid empty config (`{"mcpServers": {}}`,
-matching the shipped `adapters/claude/mcp-template.json` baseline) over each
-surface so the repo-defined servers never reach the provider process while the
-config stays parseable, and it fails closed — an unparsable or malformed
-workspace config is replaced wholesale rather than honored. This deny is independent of `--allow-control-plane-vcs`: acknowledging
-control-plane Git visibility does not lift it.
+Workcell classifies repo MCP files as `deny` outside breakglass. An untrusted
+workspace can otherwise configure an arbitrary MCP server.
+
+The launcher masks each file with a valid empty configuration. Thus, repo MCP
+servers do not reach the provider. Workcell replaces an invalid configuration
+and fails closed. The `--allow-control-plane-vcs` option does not lift this
+deny.
 
 An operator opts a workspace's MCP configs back in with the explicit,
 `ack-required` pair `--allow-repo-mcp` plus a dated `--ack-repo-mcp=YYYY-MM-DD`.

--- a/docs/examples/enterprise-claude-setup.md
+++ b/docs/examples/enterprise-claude-setup.md
@@ -1,19 +1,18 @@
 # Enterprise Claude Setup with Workcell
 
-This pattern is for teams that want a shared Claude baseline without mounting
-whole host homes into the runtime.
+Use this pattern for a shared Claude baseline. It does not mount host home
+directories in the runtime.
 
-It assumes supported Apple Silicon macOS hosts and the current local-first
-Workcell product shape. Workcell does not yet ship a centralized enterprise
-policy or session-administration plane; teams distribute reviewed host-side
-files through their existing host configuration workflow today.
+This pattern requires supported Apple Silicon macOS hosts. Workcell has no
+central enterprise policy or session administration service. Use your host
+configuration process to distribute reviewed files.
 
 ## Recommended split
 
 Keep these concerns separate:
 
 - org-wide instructions in `documents.common` or `documents.claude`
-- reviewed Claude API-key access in `credentials.claude_api_key`
+- reviewed Claude API key access in `credentials.claude_api_key`
 - reviewed MCP state in `credentials.claude_mcp`
 - optional fail-closed macOS resolver scaffold in `credentials.claude_auth`
 

--- a/docs/examples/gemini-vertex-setup.md
+++ b/docs/examples/gemini-vertex-setup.md
@@ -11,8 +11,8 @@ GOOGLE_CLOUD_PROJECT=my-project
 GOOGLE_CLOUD_LOCATION=us-central1
 ```
 
-If your flow also needs ADC, export a reviewed copy and keep it as a separate
-credential file under Workcell-managed operator state.
+If you need ADC, export a reviewed copy. Keep it as a separate credential file
+in Workcell operator state.
 
 ## 2. Create the injection policy
 

--- a/docs/examples/quickstart-claude.md
+++ b/docs/examples/quickstart-claude.md
@@ -44,10 +44,9 @@ workcell auth set \
   --ack-host-resolver
 ```
 
-That resolver records the intended host-side auth source in policy, but the
-current Workcell implementation still aborts `--prepare-only` and launch flows
-unless a supported export path exists. Use it only to record intent for a
-future supported export and verify the configured-only state with
+The resolver records the intended host auth source. Workcell stops preparation
+and launch because no supported export path exists. Use this scaffold only to
+record policy intent. Check its state with
 `workcell auth status --agent claude`.
 
 ## 2. Optional explicit prepare

--- a/docs/examples/quickstart-codex.md
+++ b/docs/examples/quickstart-codex.md
@@ -1,7 +1,6 @@
 # Quickstart: Codex in Workcell
 
-This guide walks through the normal Codex path inside Workcell's bounded
-runtime.
+Use this guide to start Codex in the bounded Workcell runtime.
 
 It assumes a supported Apple Silicon macOS host. GitHub-hosted CI and
 tagged-release install verification currently cover `macos-26` and `macos-15`;
@@ -17,9 +16,8 @@ the strongest local boundary claim still depends on local Colima validation.
 
 ## 1. Create or update the injection policy
 
-Workcell does not pass host provider homes through to the session. Use the
-host-side auth helpers to create the policy and copy the reviewed auth file
-into Workcell's managed credential store:
+Workcell does not pass host provider homes to the session. Use the host auth
+commands to stage the reviewed auth file:
 
 ```bash
 workcell auth init
@@ -39,9 +37,9 @@ workcell auth set \
   --ack-host-resolver
 ```
 
-That resolver reuses the reviewed `~/.codex/auth.json` file on the host
-through the same staged bundle flow. It does not pass the host home through to
-the runtime.
+The resolver reads the reviewed host `~/.codex/auth.json` file. It stages the
+file through the same bundle flow. It does not pass the host home to the
+runtime.
 
 ## 2. Optional explicit prepare
 

--- a/docs/examples/quickstart-copilot.md
+++ b/docs/examples/quickstart-copilot.md
@@ -1,14 +1,13 @@
 # Quickstart: GitHub Copilot CLI
 
-This quickstart covers the Workcell Tier 1 Copilot CLI path. It uses one
-explicit credential key, `copilot_github_token`. Workcell stages that token
-through reviewed host-side inputs and removes the token file plus staged
-direct-mount copy from direct runtime mounts for Copilot sessions. For
-auth-required provider launches, Workcell converts the token to a temporary
-host-mounted token handoff outside mounted provider state, moves it through a
-transient runtime handoff file with the Workcell entrypoint as PID 1, unlinks
-the mounted handoff file, and exports it as
-`COPILOT_GITHUB_TOKEN` only for the managed Copilot child process.
+Use this guide for the Tier 1 Copilot CLI path. Copilot accepts one credential,
+`copilot_github_token`. Workcell stages the token from an explicit host input.
+It removes the original token file and its staged copy from direct mounts.
+
+For an authenticated start, Workcell uses a temporary token handoff. This
+handoff is outside provider state. The entrypoint remains PID 1 and removes the
+mounted file. The wrapper exports `COPILOT_GITHUB_TOKEN` only to the managed
+Copilot child.
 
 Do not rely on host `gh` auth, host keychains, `GH_TOKEN`, `GITHUB_TOKEN`,
 host Copilot provider state (`~/.copilot`, `~/.config/github-copilot`,
@@ -52,11 +51,9 @@ workcell --agent copilot --inspect --workspace /path/to/repo
 ```
 
 The managed runtime sets `COPILOT_HOME` and `COPILOT_CACHE_HOME` to
-Workcell-owned session-local paths. It does not mount host Copilot provider
-state (`~/.copilot`, `~/.config/github-copilot`,
-`~/.cache/github-copilot`), host keychains, or host GitHub CLI auth, and it
-does not copy the token into `COPILOT_HOME`. Workcell also disables Copilot
-custom instructions on the managed path.
+session-local paths. It does not mount host Copilot state, keychains, or host
+GitHub CLI auth. It does not copy the token to `COPILOT_HOME`. Workcell also
+disables Copilot custom instructions on the managed path.
 
 ## 4. Launch
 

--- a/docs/examples/quickstart-gemini.md
+++ b/docs/examples/quickstart-gemini.md
@@ -12,7 +12,7 @@ the strongest local boundary claim still depends on local Colima validation.
 
 ## 1. Create or update the injection policy
 
-API key or Vertex env-file path:
+Gemini Code Assist (GCA), API key, or Vertex environment file path:
 
 ```bash
 workcell auth init
@@ -55,11 +55,10 @@ workcell auth status --agent gemini
 workcell --agent gemini --auth-status --workspace /path/to/repo
 ```
 
-The staged `gemini_env` and `gemini_oauth` paths report
-`provider_bootstrap_path=direct-staged`. `gemini_projects` reports
-`provider_bootstrap_state=supplemental-only` because the project registry is a
-reviewed input, not a standalone auth mode. `gcloud_adc` remains a supplemental
-Vertex input for the same reason; see
+The `gemini_env` and `gemini_oauth` paths report
+`provider_bootstrap_path=direct-staged`. The `gemini_projects` path reports
+`provider_bootstrap_state=supplemental-only`. The project registry is not an
+auth mode. The `gcloud_adc` input is also a Vertex supplement. See
 [docs/examples/gemini-vertex-setup.md](gemini-vertex-setup.md) and
 [docs/provider-bootstrap-matrix.md](../provider-bootstrap-matrix.md) for the
 current manual handoff.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,6 @@
 # Getting Started
 
-This guide is the shortest path from "I want to evaluate Workcell" to "I have
-an agent running inside the managed boundary."
+Use this guide to install Workcell and start an agent in the managed runtime.
 
 It assumes an Apple Silicon macOS host.
 Continuous CI and tagged-release install verification currently cover only
@@ -11,41 +10,34 @@ GitHub-hosted Apple Silicon `macos-26` and `macos-15`.
 
 ### Option A: verified release install (recommended)
 
-Always verify a release before installing it. `install-release.sh` is the
-one-command verified path: it downloads the tagged release bundle plus its
-signed `SHA256SUMS`, verifies the cosign signature and digest **fail-closed
-before any bundle code runs**, and only then extracts and installs.
+Always verify a release before you install it. `install-release.sh` is the
+verified install path. It downloads the release bundle and its signed
+`SHA256SUMS` file. It verifies the Cosign signature and digest before it runs
+bundle code. If verification fails, it stops the install.
 
-The verifier tools must already be on the host, because verification runs
-**before** the bundle installer (which is what installs the other host packages)
-gets to run. Install `cosign` plus `gnupg` and `git` (for the `git clone` +
-`git tag -v` below — macOS ships neither `gnupg` nor, on a clean host, `git`)
-first:
+Install the verification tools on the host before you run the installer.
+Install `cosign`, `gnupg`, and `git`:
 
 ```bash
 brew install cosign git gnupg
 ```
 
-`install-release.sh` is not published as a standalone release asset, so obtain
-it from the repository over TLS (a trusted source for the installer) rather than
-from the not-yet-verified bundle — clone the **release tag** (not the mutable
-default branch, since the pre-trust installer runs before any verification), then
-run it:
+The release does not include `install-release.sh` as a separate asset. Get it
+from the signed release tag. Do not get it from the mutable default branch.
+Use [release-posture.md](release-posture.md) to find the current release tag.
+First, import and confirm the maintainer key fingerprint from
+[SECURITY.md](../SECURITY.md#signing-key).
 
 ```bash
 git clone --branch vX.Y.Z --depth 1 https://github.com/omkhar/workcell.git
 cd workcell
-git tag -v vX.Y.Z        # verify the tag signature before running the installer
+git tag -v vX.Y.Z
 ./scripts/install-release.sh --version vX.Y.Z
 ```
 
-`git tag -v` authenticates the checked-out installer against the maintainer
-signing key **before** you run it — import and confirm the key fingerprint from
-[SECURITY.md](../SECURITY.md#signing-key) first. Arguments after `--` are
-forwarded to the bundle installer (e.g. `-- --no-install-deps` for a
-launcher-only install). A tampered or unsigned bundle is refused before its
-(also-tampered) installer could run — this is why verifying before extraction is
-sound.
+`git tag -v` checks the installer against the maintainer signing key. Arguments
+after `--` go to the bundle installer. For example, use
+`-- --no-install-deps` for a launcher-only install.
 
 For an **additional** GitHub attestation check, append `--attestation`. That
 step runs `gh attestation verify`, which queries the GitHub API, so it also
@@ -56,20 +48,16 @@ and network access:
 ./scripts/install-release.sh --version vX.Y.Z --attestation
 ```
 
-**Manual equivalent** (from the release page directly, or to inspect each step):
-download the bundle plus `SHA256SUMS` and `SHA256SUMS.sigstore.json` from GitHub
-Releases and verify before unpacking. The `cosign verify-blob` and `shasum`
-steps verify offline against the downloaded Sigstore bundle; the
-`gh attestation verify` step below mirrors the `--attestation` gate but
-**requires network access** (it fetches the attestation from the GitHub API by
-default). For a strictly offline/air-gapped install, omit that step — the cosign
-signature over `SHA256SUMS` plus the digest check is the offline-capable core
-guarantee — or pass a locally downloaded attestation with `--bundle`:
+For manual verification, download the bundle, `SHA256SUMS`, and
+`SHA256SUMS.sigstore.json`. Verify them before extraction. The Cosign and digest
+steps can run offline with the downloaded Sigstore bundle.
 
-The identity regex below is **anchored and escaped** (`^…\.…$`) so only the
-release tag is a wildcard — the exact pin `verify-release-artifact.sh` uses, not
-the illustrative unescaped form elsewhere in the docs (an unescaped `.` matches
-any character and can over-match the identity):
+The GitHub attestation step requires network access by default. Omit it for an
+offline install. You can also give it a local attestation with `--bundle`.
+
+The regex below anchors and escapes the fixed identity text (`^…\.…$`). Thus,
+only the release tag is variable. `verify-release-artifact.sh` uses the same
+expression.
 
 ```bash
 cosign verify-blob SHA256SUMS \
@@ -97,8 +85,8 @@ plus a final warning summary instead.
 
 ### Option B: Homebrew formula asset from a tagged release
 
-Each tagged release can publish a versioned `workcell.rb` formula asset that
-installs the same reviewed tree into Homebrew-managed `libexec`:
+Each supported release includes a `workcell.rb` formula asset. The formula
+installs the reviewed tree in the Homebrew `libexec` directory.
 
 ```bash
 curl -LO https://github.com/omkhar/workcell/releases/download/vX.Y.Z/workcell.rb
@@ -106,7 +94,7 @@ curl -LO https://github.com/omkhar/workcell/releases/download/vX.Y.Z/SHA256SUMS
 curl -LO https://github.com/omkhar/workcell/releases/download/vX.Y.Z/SHA256SUMS.sigstore.json
 cosign verify-blob SHA256SUMS \
   --bundle SHA256SUMS.sigstore.json \
-  --certificate-identity-regexp 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
+  --certificate-identity-regexp '^https://github\.com/omkhar/workcell/\.github/workflows/release\.yml@refs/tags/.+$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 shasum -a 256 --ignore-missing -c SHA256SUMS
 brew install --formula ./workcell.rb
@@ -177,16 +165,14 @@ workcell auth set \
 Do not use host `gh` auth, `GH_TOKEN`, `GITHUB_TOKEN`, host keychains, or host
 Copilot provider state (`~/.copilot`, `~/.config/github-copilot`,
 `~/.cache/github-copilot`) as Copilot readiness sources. Workcell stages only
-`copilot_github_token` and removes the token file plus staged direct-mount
-copy from direct runtime mounts for Copilot sessions. For auth-required
-provider launches, Workcell converts it to a temporary host-mounted token
-handoff outside mounted provider state, moves it through a transient runtime
-handoff file with the Workcell entrypoint as PID 1, unlinks the mounted handoff
-file, and exports it as `COPILOT_GITHUB_TOKEN` only for the managed Copilot
-child.
+`copilot_github_token`. It removes the original token file and its staged copy
+from direct mounts. For an authenticated start, Workcell uses a temporary token
+handoff. The handoff is outside provider state. The entrypoint remains PID 1
+and unlinks the mounted file. Workcell exports `COPILOT_GITHUB_TOKEN` only to
+the managed Copilot child.
 
 Google Antigravity CLI is not a supported agent yet. Do not configure
-`--agent antigravity`, planned credential keys, or host provider-home state
+`--agent antigravity`, unimplemented credential keys, or host provider state
 until the matching Workcell adapter support phase lands with docs and
 certification.
 
@@ -239,8 +225,8 @@ workcell --agent codex --agent-autonomy prompt --workspace /path/to/repo
 - [Copilot quickstart](examples/quickstart-copilot.md)
 - [Gemini quickstart](examples/quickstart-gemini.md)
 
-There is no Antigravity quickstart in current releases. That planned provider
-will get a quickstart only when Workcell support is implemented and certified.
+There is no Antigravity quickstart. Workcell must implement and certify support
+before it adds a quickstart.
 
 For team rollout patterns on today's local-first product, see
 [Enterprise rollout today](enterprise-rollout.md).
@@ -259,18 +245,14 @@ For team rollout patterns on today's local-first product, see
   older than 12 hours, so do **not** run it before preserving evidence for a
   suspected security incident — see the
   [incident-response runbook](incident-response.md).
-- **Bundle or source install** (Option A or C): `./scripts/uninstall.sh` removes
-  the `~/.local/bin` launcher link and man page, the managed host state under the
-  default state root (`~/.local/state/workcell`), and the Workcell-managed Colima
-  profiles and caches (both the legacy `workcell-*` and the current `wcl-*`
-  names), while leaving shared packages and unrelated profiles alone. Always run
-  `./scripts/uninstall.sh --dry-run` first — its output is the authoritative list
-  of what will be removed. It does **not** reach state written under a custom
-  `WORKCELL_STATE_ROOT`/`XDG_STATE_HOME`; remove that yourself.
-- **Homebrew formula install** (Option B): `brew uninstall workcell` removes the
-  formula tree, but not the runtime state a launched session created — so also
-  run `./scripts/uninstall.sh` (from a release bundle or source checkout) to
-  clear the managed state and Colima profiles.
+- **Bundle or source install**: First run `./scripts/uninstall.sh --dry-run`.
+  Then run `./scripts/uninstall.sh`. It removes Workcell links, state, profiles,
+  and caches. It preserves `~/.config/workcell`, including the injection policy
+  and managed credentials. It also keeps shared packages and unrelated profiles.
+  Remove custom `WORKCELL_STATE_ROOT` or `XDG_STATE_HOME` content separately.
+- **Homebrew formula install**: Run `brew uninstall workcell`. Then run
+  `./scripts/uninstall.sh` from a release bundle or source checkout. The second
+  command removes runtime state and Colima profiles.
 
 These are covered as repeatable day-two operations in
 [docs/install-lifecycle.md](install-lifecycle.md).

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,10 @@ release bundle and its signed `SHA256SUMS` file. It verifies the signature and
 bundle digest before it runs bundle code. It then extracts the bundle and runs
 `scripts/install.sh`.
 
-First, import and confirm the maintainer key from
+Install Git, GnuPG, and [`cosign`](https://github.com/sigstore/cosign) before
+you verify the tag. On macOS, use `brew install cosign git gnupg`.
+
+Import the maintainer signing key. Confirm its fingerprint against
 [`SECURITY.md`](../SECURITY.md#signing-key). Then use the signed release tag:
 
 ```bash
@@ -27,11 +30,9 @@ git tag -v vX.Y.Z
 The `git tag -v` command verifies the pre-verification installer before you run
 it. Do not use the installer from an arbitrary source checkout.
 
-Verification requires [`cosign`](https://github.com/sigstore/cosign) on `PATH`.
-Install it with `brew install cosign`. The script checks the release-workflow
-OIDC identity and issuer. It checks the Sigstore bundle and Rekor entry. Then it
-checks the bundle digest in the verified `SHA256SUMS` file. These checks automate
-the manual steps in
+The script checks the release-workflow OIDC identity and issuer. It checks the
+Sigstore bundle and Rekor entry. Then it checks the bundle digest in the
+verified `SHA256SUMS` file. These checks automate the manual steps in
 [provenance.md](provenance.md#verifying-release-assets).
 
 The script fails closed. It stops for a missing tool or verification file. It

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,7 @@
 # Install
 
-Workcell ships with a supported installer plus a tagged Homebrew formula asset.
+Workcell includes a supported installer and a Homebrew formula asset. Use
+[release-posture.md](release-posture.md) to find the current release tag.
 For the shortest end-to-end path, see the
 [5-minute path](../README.md#5-minute-path) in the README.
 
@@ -8,47 +9,42 @@ For the shortest end-to-end path, see the
 
 ### Verified release install (recommended)
 
-`scripts/install-release.sh` is the fail-closed install path. It downloads a
-tagged release bundle plus its signed `SHA256SUMS`, verifies the signature and
-the bundle digest **before** any bundle code runs, and only then extracts the
-bundle and hands off to its `scripts/install.sh`. Verifying before extraction is
-what makes it sound: a tampered bundle is rejected before its (also-tampered)
-installer could run.
+`scripts/install-release.sh` is the fail-closed install path. It downloads the
+release bundle and its signed `SHA256SUMS` file. It verifies the signature and
+bundle digest before it runs bundle code. It then extracts the bundle and runs
+`scripts/install.sh`.
+
+First, import and confirm the maintainer key from
+[`SECURITY.md`](../SECURITY.md#signing-key). Then use the signed release tag:
 
 ```bash
-# From a source checkout (or after placing install-release.sh and
-# verify-release-artifact.sh together in a scripts/ directory):
+git clone --branch vX.Y.Z --depth 1 https://github.com/omkhar/workcell.git
+cd workcell
+git tag -v vX.Y.Z
 ./scripts/install-release.sh --version vX.Y.Z
 ```
 
-Verification requires [`cosign`](https://github.com/sigstore/cosign) on `PATH`
-(`brew install cosign`). It is keyless: the script checks that the release's
-`SHA256SUMS` was signed by the Workcell release workflow's OIDC identity
-(`.../.github/workflows/release.yml@refs/tags/…`, issuer
-`https://token.actions.githubusercontent.com`) through Sigstore/Fulcio with a
-Rekor transparency entry, then binds the downloaded bundle to its entry in that
-verified `SHA256SUMS`. This automates the manual `cosign verify-blob` and
-`sha256sum -c` steps in
+The `git tag -v` command verifies the pre-verification installer before you run
+it. Do not use the installer from an arbitrary source checkout.
+
+Verification requires [`cosign`](https://github.com/sigstore/cosign) on `PATH`.
+Install it with `brew install cosign`. The script checks the release-workflow
+OIDC identity and issuer. It checks the Sigstore bundle and Rekor entry. Then it
+checks the bundle digest in the verified `SHA256SUMS` file. These checks automate
+the manual steps in
 [provenance.md](provenance.md#verifying-release-assets).
 
-It **fails closed**: a missing `cosign`, absent verification material, a
-signature that does not verify against the pinned identity, or a digest mismatch
-each refuse the install with a non-zero exit and a clear error. Pass
-`--attestation` to additionally require `gh attestation verify` against the
-release workflow, and `--repo OWNER/REPO` to install from a fork or mirror.
+The script fails closed. It stops for a missing tool or verification file. It
+also stops for an invalid signature or digest. Use `--attestation` to require a
+GitHub attestation. Use `--repo OWNER/REPO` for a fork or mirror.
 
-Because this runs before the download is trusted, the installer pins its
-interpreter to the absolute `/bin/bash` (a system bash at `/bin/bash` is
-required — present on macOS and mainstream Linux) so a fake `bash` earlier in
-`PATH` cannot hijack it, and it resolves the tools it calls (`cosign`, `gh`,
-`curl`, `tar`, `sha256sum`) from a fixed trusted `PATH` (the system directories
-plus `/usr/local/bin` and `/opt/homebrew/bin`) rather than your ambient `PATH`,
-so a user-writable directory early in `PATH` cannot shadow them with a fake.
-Invoke it as `./scripts/install-release.sh` (which uses that trusted
-interpreter) — do not run it through an untrusted `bash …`. Install
-`cosign`/`gh` in one of those standard locations (`brew install cosign gh` does
-this). If yours live elsewhere, set `WORKCELL_INSTALL_TRUSTED_PATH` to a trusted
-`PATH` that includes them.
+The installer uses `/bin/bash` before it trusts the download. It finds its tools
+only in a fixed trusted `PATH`. Thus, an earlier user-writable directory cannot
+provide a false tool.
+
+Run `./scripts/install-release.sh` directly. Do not run it with an untrusted
+`bash`. Install `cosign` and `gh` in a standard location. If necessary, set
+`WORKCELL_INSTALL_TRUSTED_PATH` to a trusted path that contains them.
 
 #### Offline / air-gapped installs
 
@@ -68,9 +64,9 @@ run — the default is always verify-and-fail-closed.
 
 ### Tagged release bundle
 
-If you prefer to verify manually, download a tagged release bundle, verify it
-following [provenance.md](provenance.md#verifying-release-assets), unpack it, and
-run the supported installer:
+For manual verification, download the selected release bundle. Use the steps in
+[provenance.md](provenance.md#verifying-release-assets). Then unpack the bundle.
+Run the supported installer:
 
 ```bash
 tar -xzf workcell-vX.Y.Z.tar.gz
@@ -85,8 +81,8 @@ system unchanged and get a warning summary of anything still missing.
 
 ### Tagged Homebrew formula asset
 
-Tagged releases can publish a versioned `workcell.rb` asset. Download it from
-the release page and install it locally with Homebrew:
+Each supported release includes a versioned `workcell.rb` asset. Download it
+from the release page. Then install it with Homebrew:
 
 ```bash
 curl -LO https://github.com/omkhar/workcell/releases/download/vX.Y.Z/workcell.rb

--- a/docs/provider-bootstrap-matrix.md
+++ b/docs/provider-bootstrap-matrix.md
@@ -1,7 +1,6 @@
 # Provider Bootstrap Matrix
 
-This page records the reviewed host-side bootstrap and explainability contract
-for provider auth inputs.
+This page defines the host bootstrap contract for provider auth inputs.
 
 Use it with:
 
@@ -16,22 +15,20 @@ The host-side commands expose the same bootstrap summary on one reviewed path:
   resolver preprocessing
 - `workcell why` prints `bootstrap_*` for one credential decision
 
-Support tiers on this page mean:
+This page uses these support levels:
 
-- `repo-required`: host-side policy, staging, and explainability are proven by
-  deterministic repo validation
-- `certification-only`: the path needs live runtime or provider smoke before
-  Workcell claims it as supported
-- `manual`: the path is operator-driven, supplemental, or intentionally
-  fail-closed rather than fully automated on the reviewed path
+- `repo-required`: Repository tests prove policy, staging, and status output.
+- `certification-only`: A live runtime or provider test must pass before a
+  support claim.
+- `manual`: The path is supplemental, operator-driven, or intentionally
+  fail-closed.
 
-These tiers describe the Workcell bootstrap and staging contract. Live
-provider-authenticated UX remains the separate manual provider-e2e lane unless
-the evidence explicitly says otherwise.
+These levels apply to the Workcell bootstrap and staging contract. Provider
+authentication stays in the manual end-to-end lane unless evidence states a
+different level.
 
-Roadmap-only provider entries are called out separately. They are not accepted
-by `workcell auth`, `workcell --auth-status`, or `workcell why` until the
-matching adapter and evidence land.
+Unsupported providers appear in a separate section. The auth commands do not
+accept them.
 
 ## Current Matrix
 
@@ -43,52 +40,52 @@ matching adapter and evidence land.
 | Claude | direct staged `claude_api_key` | `direct-staged` | `repo-required` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh` | helper-backed API key path |
 | Claude | `[credentials.claude_auth] resolver = "claude-macos-keychain"` | `host-export-scaffold` | `manual` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-policy-commands.sh` | records intent and stays fail-closed until a supported export path exists |
 | GitHub Copilot CLI | direct staged `copilot_github_token` | `direct-staged` | `repo-required` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-policy-commands.sh`, `scripts/container-smoke.sh` | converted to a temporary host-mounted token handoff outside mounted provider state, removed from direct runtime mounts, consumed into a transient runtime handoff file with the Workcell entrypoint as PID 1, and exported to the managed Copilot child as `COPILOT_GITHUB_TOKEN`; host `gh` auth, host keychains, `GH_TOKEN`, `GITHUB_TOKEN`, and host Copilot provider state (`~/.copilot`, `~/.config/github-copilot`, `~/.cache/github-copilot`) are not auth sources |
-| Gemini | direct staged `gemini_env` | `direct-staged` | `repo-required` | `tests/scenarios/shared/test-auth-status.sh` | reviewed API key or Vertex env-file path |
+| Gemini | direct staged `gemini_env` | `direct-staged` | `repo-required` | `tests/scenarios/shared/test-auth-status.sh` | reviewed Gemini Code Assist (GCA), API key, or Vertex environment file path |
 | Gemini | direct staged `gemini_oauth` | `direct-staged` | `repo-required` | `tests/scenarios/shared/test-auth-status.sh` | reviewed cached Gemini OAuth path |
 | Gemini | direct staged `gemini_projects` supplement | `project-registry-supplement` | `manual` | `tests/scenarios/shared/test-auth-status.sh`, `internal/authpolicy/manage_test.go` | reviewed Gemini project registry input; not a standalone auth mode |
 | Gemini | direct staged `gcloud_adc` supplement | `vertex-supplement` | `manual` | `scripts/verify-invariants.sh`, `docs/examples/gemini-vertex-setup.md` | supplemental Vertex input only; not a standalone Gemini auth mode |
 
 ## Copilot CLI Bootstrap Notes
 
-Copilot support is intentionally limited to one direct staged credential:
-`copilot_github_token`. For auth-required launches, Workcell converts that
-file into a temporary host-mounted token handoff outside mounted provider
-state, removes the original token file from direct runtime mounts, deletes the
-staged direct-mount copy from the mounted injection bundle, stages it into a
-transient runtime handoff file, unlinks the mounted handoff file, re-execs the
-entrypoint
-without the token in its environment, keeps that entrypoint as PID 1 instead
-of Docker `--init` so `/proc/1/environ` is scrubbed, and exports its value as
-`COPILOT_GITHUB_TOKEN` only for the managed Copilot child process after the
-wrapper unlinks the handoff file. Copilot development-shell or debug-command
-launches also remove the token file and staged copy from direct runtime mounts
-without creating the handoff mount. It is not copied into `COPILOT_HOME`. Host
-Copilot provider state (`~/.copilot`, `~/.config/github-copilot`,
-`~/.cache/github-copilot`), host keychains, `GH_TOKEN`, `GITHUB_TOKEN`,
-ambient `gh auth token`, and whole-home state are not safe-path inputs.
+Copilot accepts only the staged `copilot_github_token` credential. Workcell
+removes the original token from direct runtime mounts. It also removes the
+staged copy from the mounted injection bundle.
 
-The deterministic bootstrap row is repo-required. Live provider-authenticated
-certification of a non-destructive `copilot -p` launch with staged credentials
-remains a maintainer pre-signing gate for changes that promote or materially
-alter the Copilot support claim.
+For an authenticated start, Workcell uses a temporary host-mounted handoff.
+This mount is outside provider state. The entrypoint moves the token to a
+temporary runtime file. It unlinks the mounted file. Then it uses `exec` to
+replace itself without the token environment.
 
-## Planned Antigravity CLI Bootstrap Track
+The entrypoint remains PID 1, without Docker `--init`. Thus,
+`/proc/1/environ` does not contain the token.
 
-Google Antigravity CLI is a planned fail-closed provider track, but it has no
-supported bootstrap row yet. Before it can join the current matrix, Workcell
-must pin the official install and auth model, add explicit staged Google auth
-material, and prevent host Google account state, browser profiles, keychains,
-host homes, and provider caches from becoming implicit inputs.
+The wrapper reads and unlinks the runtime file. It exports
+`COPILOT_GITHUB_TOKEN` only to the managed Copilot child. It does not copy the
+token to `COPILOT_HOME`. Development and debug commands do not receive a token
+handoff.
 
-The Antigravity bootstrap row is supportable only after deterministic
-auth-status, policy, bootstrap-summary, control-plane seeding, and
-unsafe-argument tests exist, plus live provider certification with staged
-credentials inside the managed runtime.
+Host Copilot state, keychains, ambient tokens, and whole-home state are not
+safe-path inputs.
+
+Repository tests prove the deterministic bootstrap row. The maintainer must run
+a live, authenticated `copilot -p` test before a signed commit changes the
+Copilot support claim.
+
+## Unsupported Antigravity CLI Scaffold
+
+Google Antigravity CLI has no supported bootstrap row. Workcell recognizes the
+provider name and stops before runtime preparation.
+
+Before support, Workcell must pin the official install and auth model. It must
+add explicit Google auth input. Host account state, browser profiles,
+keychains, home directories, and provider caches must stay excluded.
+
+Support also requires deterministic auth, policy, bootstrap, and unsafe-flag
+tests. A live provider test with staged credentials must pass.
 
 ## Remote Target Bootstrap
 
-Preview remote targets also carry an explicit host-side bootstrap contract.
-Today that matrix is:
+Preview remote targets also have a host bootstrap contract:
 
 | Target | Bootstrap path | Support | Evidence | Notes |
 |---|---|---|---|---|
@@ -115,5 +112,5 @@ The bootstrap summary fields also report the remaining operator handoff:
 - [Quickstart: Gemini](examples/quickstart-gemini.md)
 - [Gemini Vertex AI setup](examples/gemini-vertex-setup.md)
 
-There is no Antigravity quickstart until the matching CLI support lands with
-adapter, auth, and certification evidence.
+There is no Antigravity quickstart. Workcell must add the adapter, auth input,
+tests, and certification evidence before support.

--- a/docs/provider-matrix.md
+++ b/docs/provider-matrix.md
@@ -12,29 +12,23 @@ through a native control-plane mapping.
 | GitHub Copilot CLI | CLI | Workcell-owned session-local `COPILOT_HOME`, `COPILOT_CACHE_HOME`, and GitHub Copilot config/cache directories, host-mounted token handoff plus transient runtime handoff, logs, cache state, custom instructions disabled, and skill/dynamic-retrieval overrides blocked | `copilot_github_token` | supported Copilot token credential: a directly staged `copilot_github_token`; Workcell removes the token file and staged direct-mount copy from direct runtime mounts, passes a temporary handoff mount outside provider state, runs the Workcell entrypoint as PID 1 for token handoff launches, exports it as `COPILOT_GITHUB_TOKEN` only to the managed Copilot child after unlinking the runtime handoff file, and does not use host `gh` auth, host keychains, `GH_TOKEN`, `GITHUB_TOKEN`, or host Copilot provider state (`~/.copilot`, `~/.config/github-copilot`, `~/.cache/github-copilot`) |
 | Gemini | Gemini CLI | `~/.gemini/settings.json`, rendered `GEMINI.md`, `.env`, OAuth creds, `projects.json`, trusted folders | `gemini_env`, `gemini_oauth`, `gemini_projects`, `gcloud_adc` | Gemini's own sandbox is not the Tier 1 boundary here; `gcloud_adc` is supplemental to Vertex config |
 
-### Upstream change: Gemini CLI retirement on June 18, 2026
+### Gemini CLI account change
 
-Google has announced that Gemini CLI stops serving requests for the free,
-Pro, and Ultra personal-account login tiers on June 18, 2026, in favor of
-the closed-source Antigravity CLI. Per the announcement, access continues
-for Gemini Code Assist Standard/Enterprise licenses and for paid Gemini /
-Gemini Enterprise Agent Platform API keys
-([announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/)).
-**Reviewed posture: the Gemini Tier 1 adapter stays shipped and supported
-for the auth inputs Google keeps serving — `gemini_env`/`gemini_oauth` with
-a Code Assist Standard/Enterprise license or a paid Gemini API key;
-`gcloud_adc` remains the supplemental Vertex input to those modes, not a
-standalone post-June auth path.** The free, Pro, and Ultra personal-account
-OAuth login is what upstream retires; those accounts are refused by Google,
-not by Workcell, while the adapter, control-plane mapping, and pinned CLI
-remain intact. An Antigravity adapter is
-a committed follow-on provider-parity track with a different binary and
-control-plane surface, following the same Tier 1 evidence bar as every
-provider; sequencing is tracked in [ROADMAP.md](../ROADMAP.md).
+On June 18, 2026, Gemini CLI stopped service for free, Pro, and Ultra personal
+accounts. Gemini CLI access remains available through Gemini Code Assist
+Standard and Enterprise licenses. It also remains available through paid Gemini
+and Gemini Enterprise Agent Platform API keys. See the
+[Google announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/).
 
-## Planned provider parity
+The Gemini Tier 1 adapter remains supported for these active auth paths. Use
+`gemini_oauth` only for reviewed cached OAuth state. Use `gemini_env` for
+Gemini Code Assist (GCA), a paid API key, or Vertex environment configuration.
+Use `gcloud_adc` only as a Vertex supplement. It is not a standalone auth path.
+Google, not Workcell, refuses the retired account types.
 
-| Provider | Planned Tier 1 surface | Planned managed control plane | Planned auth input | Support status |
+## Unsupported provider scaffold
+
+| Provider | Target Tier 1 surface | Required control plane | Required auth input | Support status |
 |---|---|---|---|---|
 | Google Antigravity CLI | `workcell --agent antigravity --workspace ...` | session-local provider home/cache, settings, permissions, subagents, plugins, MCP, sandbox state, hooks, and reviewed instruction imports once official CLI provenance is pinned | explicit staged Google auth material, exact key names still pending official install/auth implementation | fail-closed scaffold; not current support |
 
@@ -44,19 +38,16 @@ is historical planning context; the current support boundary is the table
 above and the quickstart in
 [docs/examples/quickstart-copilot.md](examples/quickstart-copilot.md).
 
-GitHub documents Copilot CLI as a terminal agent with interactive and
-programmatic modes, environment-token auth, configurable `COPILOT_HOME`, and
-permissive tool flags such as `--allow-all` and `--yolo`. Workcell treats
-those product surfaces as implementation inputs that must stay mapped or
-blocked by the Workcell adapter. Live provider-authenticated `copilot -p`
-certification remains a maintainer pre-signing gate for changes that promote
-or materially alter the Copilot support claim.
+GitHub Copilot CLI has interactive and programmatic modes. It accepts an
+environment token and a configurable `COPILOT_HOME`. It also has permissive
+tool flags. The Workcell adapter maps or blocks these surfaces.
 
-Antigravity remains planned/fail-closed. Even where upstream CLI documentation
-exists, Workcell must still pin the supported install/auth path and land the
-same adapter, auth/bootstrap, unsafe-argument, control-plane masking,
-quickstart, scenario, and live-certification evidence before any Tier 1 support
-claim.
+A live, authenticated `copilot -p` test is a pre-signing gate. Run it before a
+signed commit changes the Copilot support claim.
+
+Antigravity remains unsupported and fails closed. Before support, Workcell must
+add a pinned install path, explicit auth, an adapter, tests, and live
+certification.
 
 For provider auth maturity and rollout caveats, see
 [docs/injection-policy.md](injection-policy.md) and
@@ -69,10 +60,9 @@ For provider auth maturity and rollout caveats, see
 - Tier 3: host-native GUI, cloud, or web-only guidance with no claim of
   equivalent local isolation
 
-Copilot cloud agent, Copilot IDE extensions, Antigravity desktop or IDE
-surfaces, and host-native provider CLI execution are Tier 3 unless a future
-integration makes them clients of the same bounded Workcell session plane. The
-planned support target is each local provider CLI adapter running inside Tier 1.
+Copilot cloud agent and Copilot IDE extensions are Tier 3. Antigravity desktop
+and IDE surfaces are also Tier 3. Host-native provider CLIs are Tier 3. Only a
+reviewed client of the bounded runtime can qualify for Tier 2.
 
 Do not force one provider's control model onto another. Keep one shared
 boundary and one thin adapter per product.
@@ -80,10 +70,10 @@ boundary and one thin adapter per product.
 ## Validation traceability
 
 Use [`policy/operator-contract.toml`](../policy/operator-contract.toml) for the
-supported operator workflow surface, [docs/requirements-validation.md](requirements-validation.md)
-for the machine-checked requirement and evidence mapping, and
-[docs/validation-scenarios.md](validation-scenarios.md) for the concrete
-scenario and script anchors behind the auth and control-plane caveats.
+operator workflow. Use
+[requirements-validation.md](requirements-validation.md) for requirement
+evidence. Use [validation-scenarios.md](validation-scenarios.md) for scenario
+and script references.
 
 The Tier 1, 2, and 3 rule is a support classification. It is not a claim that
 GUI, IDE, or cloud paths receive the same validation depth as the Tier 1 CLI

--- a/docs/provider-quickstarts.md
+++ b/docs/provider-quickstarts.md
@@ -7,11 +7,11 @@
 | GitHub Copilot CLI | CLI | session-local `COPILOT_HOME`, `COPILOT_CACHE_HOME`, token handoff, custom instructions disabled, skill/dynamic-retrieval overrides blocked | [examples/quickstart-copilot.md](examples/quickstart-copilot.md) |
 | Gemini | Gemini CLI | `~/.gemini/settings.json`, `GEMINI.md`, `.env`, `projects.json` | [examples/quickstart-gemini.md](examples/quickstart-gemini.md) |
 
-Planned provider parity:
+Unsupported provider scaffold:
 
 | Provider | Target surface | Required before support |
 |---|---|---|
-| Google Antigravity CLI | planned fail-closed Tier 1 CLI adapter; not current support | `--agent antigravity`, pinned official install/auth provenance, explicit Google auth staging, session-local provider home/cache, unsafe-argument policy, quickstart, deterministic tests, and live provider certification |
+| Google Antigravity CLI | fail-closed scaffold; not supported | A supported adapter, explicit auth input, session-local provider state, tests, a quickstart, and live certification |
 
 GUI and IDE surfaces are lower assurance unless they act only as clients to
 the same bounded runtime.

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -164,7 +164,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/copilot/README.md",
       "runtime_path": "/opt/workcell/adapters/copilot/README.md",
-      "sha256": "1f345163f7e3bece0b774b10440af608923e13aca1f2e1c6bf8dae5414ffb7d8"
+      "sha256": "c5c1d8f887850ee5cf86bf08bc6c39727436ba8d7c4b9c5b3a9a8073bcbdd26c"
     },
     {
       "kind": "adapter-baseline",


### PR DESCRIPTION
Summary:
- align provider and install manuals with shipped controls
- apply ASD-STE100 language to current operator guides
- fix release identity, token-handoff, and uninstall guidance
- refresh the generated control-plane manifest

Validation:
- focused documentation and contract checks pass
- six-role adversarial review accepts the final documentation
- local PR parity passed repository validation, then the live VZ fixture failed after two DHCP lease timeouts
- hosted checks will provide the final parity result