### PR TITLE
Align assurance and operator documentation

### DIFF
--- a/docs/diagnostics-and-support-matrix.md
+++ b/docs/diagnostics-and-support-matrix.md
@@ -1,49 +1,50 @@
-# Diagnostics and the support matrix
+# Diagnostics and the Support Matrix
 
-`workcell --doctor` and `workcell --inspect` emit host and
-`support_matrix_*` key=value lines derived from
-[`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv). This
-page explains each field and how an operator should act on the resolved row.
+`workcell --doctor` and `workcell --inspect` print host and
+`support_matrix_*` fields. Workcell gets these fields from
+[`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv).
 
-## Emitted fields
+## Fields
 
 <!-- support-matrix-fields:begin -->
 | Field | Meaning |
 |---|---|
-| `host_os` | Detected host operating system (for example `macos`, `linux`). |
-| `host_arch` | Detected host CPU architecture (for example `arm64`, `amd64`). |
-| `host_distro` | Detected Linux distribution ID, or `none` off Linux. |
-| `host_distro_version` | Detected Linux distribution version, or `none` off Linux. |
-| `support_matrix_status` | Row status for the resolved host and target: `supported`, `preview-only`, `validation-host-only`, or `unsupported`. |
-| `support_matrix_launch` | Whether operator launch is `allowed` or `blocked` for the resolved combination. |
-| `support_matrix_evidence` | Evidence tier backing the row: `certification-only`, `repo-required`, `manual-only`, or `none`. |
-| `support_matrix_validation_lane` | Named validation lane for the row, or `none`. |
-| `support_matrix_reason` | Human-readable reason string for the resolved status. |
+| `host_os` | Detected host operating system, such as `macos` or `linux`. |
+| `host_arch` | Detected host CPU architecture, such as `arm64` or `amd64`. |
+| `host_distro` | Detected Linux distribution ID. The value is `none` on other systems. |
+| `host_distro_version` | Detected Linux distribution version. The value is `none` on other systems. |
+| `support_matrix_status` | Status of the matching row: `supported`, `preview-only`, `validation-host-only`, or `unsupported`. |
+| `support_matrix_launch` | Launch decision for the matching row: `allowed` or `blocked`. |
+| `support_matrix_evidence` | Evidence class for the row: `certification-only`, `repo-required`, `manual-only`, or `none`. |
+| `support_matrix_validation_lane` | Name of the validation lane, or `none`. |
+| `support_matrix_reason` | Reason for the status and launch decision. |
 <!-- support-matrix-fields:end -->
 
-`--inspect` and `--doctor` also print additional launch-state fields,
-including `target_kind`, `target_provider`, and `target_assurance_class` for
-the selected target. Use those to confirm which non-default target was
-resolved.
+The commands also print launch-state fields. These fields include
+`target_kind`, `target_provider`, and `target_assurance_class`. Use them to
+confirm the selected target.
 
-## Triage decision tree
+## Operator decision
 
-1. If `support_matrix_launch=allowed`:
-   - With `support_matrix_status=supported`, proceed only for the resolved row and only with the evidence its `support_matrix_evidence` names (for current supported rows this is `certification-only`) as recorded in `policy/host-support-matrix.tsv`.
-   - With any other status, treat the row as inconsistent for operator launch, stop, and follow `support_matrix_reason`.
-2. If `support_matrix_launch=blocked`:
-   - With `support_matrix_status=preview-only`, treat the row as preview or certification-only. It is not an operator launch host.
-   - With `support_matrix_status=validation-host-only`, use the host only for the named validation lane, such as `trusted-linux-amd64-validator`.
-   - With `support_matrix_status=unsupported`, do not launch. Read `support_matrix_reason` for the unsupported boundary.
-   - With any other status, follow the blocked launch decision first and do not treat the row as supported.
+First, read `support_matrix_launch`.
 
-## No implicit support claim
+- If the value is `allowed`, continue only when
+  `support_matrix_status=supported`. Use only the evidence that
+  `support_matrix_evidence` specifies.
+- If the value is `blocked`, do not start an operator session.
 
-No tier, assurance class, or status confers a support claim on its own.
-Supported launch paths still require the live certification evidence recorded in
-[`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv).
+If `support_matrix_launch=blocked`, read `support_matrix_status`:
 
-For the vocabulary behind each value, see
-[`docs/support-tiers.md`](support-tiers.md). The canonical source for the
-resolved matrix row is
-[`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv).
+- `preview-only`: Use the row only for its documented preview or certification
+  work.
+- `validation-host-only`: Use the host only for
+  `support_matrix_validation_lane`.
+- `unsupported`: Do not launch. Read `support_matrix_reason`.
+- `supported` or any unexpected value: Stop. The blocked decision has
+  priority.
+
+No field gives support by itself. A supported launch requires one matching row
+with `status=supported`, `launch=allowed`, and the required evidence.
+
+See [support-tiers.md](support-tiers.md) for all values. For a possible runtime
+boundary breach, use [incident-response.md](incident-response.md).

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -1,151 +1,162 @@
 # Security Invariants
 
-These invariants define the safe path. The priority order in the repository
-only applies after these constraints are satisfied.
+These invariants define the safe path. Repository priorities apply only after
+Workcell satisfies these constraints.
 
 ## 1. Host secrets stay outside the default trust boundary
 
-On the managed path, Workcell does not pass through:
+The managed path does not pass these host resources to the runtime:
 
-- host home directories
-- keychains or browser profiles
-- git credential helpers
+- home directories
+- keychains and browser profiles
+- Git credential helpers
 - `docker.sock`
-- SSH, GPG, or provider agent sockets
-- host provider-home state such as `~/.codex`, `~/.claude`, `~/.copilot`,
-  `~/.config/github-copilot`, `~/.cache/github-copilot`, or `~/.gemini`
+- SSH, GPG, and provider agent sockets
+- provider state such as `~/.codex`, `~/.claude`, `~/.copilot`,
+  `~/.config/github-copilot`, `~/.cache/github-copilot`, and `~/.gemini`
 
-Reusable auth enters the session only through explicit injection-policy inputs.
-The GitHub Copilot CLI adapter preserves the same invariant for host Copilot
-provider state (`~/.copilot`, `~/.config/github-copilot`,
-`~/.cache/github-copilot`), host keychains, `GH_TOKEN`, `GITHUB_TOKEN`, and
-ambient `gh auth token` fallback by accepting only `copilot_github_token`
-through the reviewed host-side staging path, removing the original token file
-from direct runtime mounts, moving it through a temporary handoff mount outside
-provider state and a transient runtime handoff file, re-execing the entrypoint
-without the token in its environment, and exporting it as
-`COPILOT_GITHUB_TOKEN` only for the managed child after the wrapper unlinks the
-handoff file. The
-planned Google Antigravity CLI adapter must preserve it for host Google account
-caches, browser profiles, keychains, host homes, and provider caches. Current
-releases do not support `--agent antigravity`.
+Reusable authentication enters a session only through reviewed injection-policy
+inputs.
+
+The Copilot adapter accepts only `copilot_github_token`. It does not use host
+Copilot state, `GH_TOKEN`, `GITHUB_TOKEN`, a host keychain, or `gh auth token`.
+Workcell gives the token only to the managed Copilot child through the reviewed
+temporary handoff. It does not retain the token in mounted provider state or in
+the entrypoint environment. See
+[Onboarding and Authentication](onboarding-and-auth.md#copilot-token-handoff).
+
+Workcell does not support Antigravity. A future adapter must not use host Google
+account state, browser profiles, keychains, home directories, or provider
+caches.
 
 ## 2. Writes stay inside the intended workspace
 
 The selected workspace is the durable writable mount. Provider homes are
-session-local state inside the runtime. Workcell's host-side staging roots under
-`~/Library/Caches/colima/workcell-host-inputs` and
-`~/Library/Caches/colima/workcell-shadow` are mounted into the managed Colima VM
-read-only so the runtime can consume reviewed injection bundles and masked
-workspace control-plane snapshots without widening durable write access.
-Host-side publication remains a separate action.
+session-local runtime state.
+
+Workcell uses these host staging roots:
+
+- `~/Library/Caches/colima/workcell-host-inputs`
+- `~/Library/Caches/colima/workcell-shadow`
+
+The managed Colima VM mounts these roots as read-only. These mounts do not give
+the runtime durable write access outside the selected workspace. GitHub
+publication remains a separate host action.
 
 ## 3. Repo policy must not silently widen trust
 
-Repo-local control-plane files are masked on the safe path and imported into
-provider homes as reviewed inputs. The masked set is the provider files
-`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.mcp.json`,
-`.github/mcp.json`, and `.github/copilot-instructions.md`; the provider,
-Copilot, and IDE directories `.codex/`, `.claude/`, `.copilot/`,
-`.gemini/`, `.github/instructions/`, `.github/copilot/`,
-`.github/hooks/`, `.github/agents/`, `.github/skills/`, `.agents/skills/`,
-`.vscode/`, `.idea/`, `.cursor/`, and `.zed/`; and git execution-control paths (`hooks`, `config`,
-`config.worktree`, and `worktrees` for the workspace repo and its
-submodules). The workspace should not be able to quietly take over the
-runtime control plane.
+Workcell masks repository control-plane files on the safe path. It imports only
+reviewed inputs into provider homes.
 
-The Copilot adapter explicitly accounts for Copilot-specific repo control-plane
-files such as `.github/copilot-instructions.md`, `.github/instructions/**`,
-`.github/mcp.json`, `.github/copilot/settings*.json`, and repo-local skill
-and hook directories by masking them on the safe path and launching Copilot with custom
-instructions disabled while blocking skill/dynamic-retrieval overrides. The
-planned Antigravity adapter must do the same for Antigravity-specific settings,
-plugin, MCP, hook, and instruction files before it can claim support.
+The mask includes these files:
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `.mcp.json`
+- `.github/mcp.json` and `.github/copilot-instructions.md`
+
+The mask includes these directories:
+
+- `.codex/`, `.claude/`, `.copilot/`, and `.gemini/`
+- `.github/instructions/`, `.github/copilot/`, `.github/hooks/`,
+  `.github/agents/`, and `.github/skills/`
+- `.agents/skills/`
+- `.vscode/`, `.idea/`, `.cursor/`, and `.zed/`
+
+Workcell also masks Git execution-control paths for the workspace repository and
+its submodules. These paths are `hooks`, `config`, `config.worktree`, and
+`worktrees`.
+
+The Copilot adapter also masks Copilot settings, instructions, MCP files,
+skills, and hooks. It disables custom instructions and blocks skill and dynamic
+retrieval overrides.
+
+A future Antigravity adapter must mask its settings, plugins, MCP files, hooks,
+and instructions before it can claim support.
 
 ## 4. Network posture is explicit
 
-`strict`, `development`, `build`, and `breakglass` are distinct runtime
-profiles. Workcell
-does not rely on provider prompts to describe network posture after the fact.
+`strict`, `development`, `build`, and `breakglass` are separate modes. Workcell
+does not use a provider prompt as a network control.
 
-`strict` sets `NETWORK_POLICY=allowlist`, and on the `colima` target the launcher
-enforces it as a fail-closed, dual-stack, default-deny egress firewall:
-`iptables`/`ip6tables` rules in the VM's `DOCKER-USER` chain ACCEPT only the
-reviewed `host:port` allowlist and `DROP` the rest, aborting rather than run
-without IPv6 containment. Only the colima target applies this per-session
-allowlist (the launch summary states which with an `egress_enforcement=` label);
-other targets rely on their own controls. Operators may extend or tighten the
-allowlist only through the reviewed injection-policy `[network]` surface
-(`allow_endpoints`/`deny_endpoints`), which can never disable the default or
-change `NETWORK_POLICY`. See the [`[network]` egress section](injection-policy.md#network-egress-network).
+The `strict` mode sets `NETWORK_POLICY=allowlist`. On Colima, Workcell applies a
+fail-closed dual-stack firewall in the VM `DOCKER-USER` chain. It permits only
+reviewed `host:port` entries and drops other egress. It stops the launch if it
+cannot contain IPv6.
 
-The full set of outbound `host:port` endpoints the allowlist may resolve is the
-reviewed [outbound-endpoint inventory](outbound-endpoints.md), captured in
-`policy/hardening-profile.toml` and cross-checked against the launcher by the
-`hardening-profile-conformance` invariant.
+Only Colima applies the per-session allowlist. Other targets use their own
+network controls. The launch summary states the result in
+`egress_enforcement=`.
+
+The injection policy can add or deny endpoints through `[network]`. It cannot
+disable the default policy or change `NETWORK_POLICY`. See
+[Network egress](injection-policy.md#network-egress-network).
+
+The reviewed endpoint inventory is in
+[outbound-endpoints.md](outbound-endpoints.md). The machine-readable source is
+`policy/hardening-profile.toml`.
 
 ## 4a. Container hardening posture is captured and drift-checked
 
-The runtime container's syscall/filesystem hardening posture — dropped
-capabilities (`--cap-drop ALL`, with only `SETUID`/`SETGID` re-added for the
-mutable-mode mapped-user re-exec), `--security-opt no-new-privileges:true`,
-`--read-only` rootfs, the hardened `nosuid,nodev`(`,noexec`) tmpfs mounts,
-`--pids-limit`, and the mapped non-root `--user` — is captured as the reviewed
-`policy/hardening-profile.toml` artifact. The `hardening-profile-conformance`
-invariant asserts scripts/workcell still applies every declared literal and
-contains none of the forbidden ones (`--privileged`, `seccomp=unconfined`), so a
-posture weakening fails CI.
+The runtime container uses these controls:
+
+- drops all capabilities
+- adds only `SETUID` and `SETGID` for the mutable-mode mapped-user step
+- uses `no-new-privileges`
+- uses a read-only root file system in `readonly` sessions
+- uses hardened `nosuid`, `nodev`, and applicable `noexec` temporary mounts
+- sets a process limit
+- runs as a mapped nonroot user
+
+`policy/hardening-profile.toml` records this posture. The
+`hardening-profile-conformance` invariant checks the launcher. It also rejects
+`--privileged` and `seccomp=unconfined`.
 
 ## 5. Destructive or trust-widening actions need defense in depth
 
-The runtime boundary is primary, but Workcell also uses provider-side defenses
-where they help:
+The runtime boundary is the primary control. Provider controls add defense in
+depth:
 
 - Codex requirements and rules
-- Claude reviewed settings and Bash hook
-- Gemini managed settings and trusted-folder seeding
+- Claude managed settings and Bash hook
+- Gemini managed settings and trusted-folder seed
 
-These are guardrails, not substitutes for the runtime boundary.
+These controls do not replace the runtime boundary.
 
 ## 6. Lower-assurance paths are labeled
 
-Examples:
+Examples include:
 
 - `--agent-autonomy prompt`
 - `--cache-profile standard`
 - `development`
-- package mutation inside a mutable container
+- package changes in a mutable container
 - `--allow-control-plane-vcs`
 - `--allow-repo-mcp`
 - `--allow-arbitrary-command`
 - `breakglass`
-- host-side debug or transcript capture
-- any Copilot or future Antigravity telemetry, OpenTelemetry, or content-capture
-  enablement
+- host debug logs or transcript capture
+- Copilot or future Antigravity telemetry and content capture
 
-Workcell records those choices in launch or runtime state instead of implying
-they are equivalent to the default path.
+Workcell records these choices in launch or runtime state.
 
 ## 7. Autonomous runs remain auditable
 
-The launcher keeps durable host-side audit metadata for real sessions. Full
-debug logs, file traces, and transcripts are separate explicit choices rather
-than ambient defaults.
+The launcher keeps durable host session metadata. Full debug logs, file traces,
+and transcripts require separate operator options.
 
 ## Profile expectations
 
 | Profile | Expected posture |
 |---|---|
-| `strict` | default provider lane; reviewed mounts, explicit network posture, repo control-plane masking |
-| `strict --container-mutability readonly` | strongest managed lane; package-manager writes blocked |
-| `development` | managed interactive lane; same boundary and masking as `strict` with managed non-provider command execution and broader dependency egress |
-| `build` | broader egress for image preparation and dependency refresh |
-| `breakglass` | explicit higher-trust lane requiring acknowledgement |
+| `strict` | Default provider path with reviewed mounts, explicit network controls, and control-plane masks |
+| `strict --container-mutability readonly` | Strongest managed path with package-manager writes blocked |
+| `development` | Managed interactive path with the same boundary and masks, non-provider commands, and more dependency endpoints |
+| `build` | Image preparation path with broader build endpoints |
+| `breakglass` | Explicit higher-trust path with dated acknowledgement |
 
 ## Non-goals
 
-Workcell does not claim:
+Workcell does not claim that:
 
-- that provider hooks or rules are the primary boundary
-- that host-native GUIs are equivalent to Tier 1
-- that release provenance proves the full local macOS boundary on its own
+- provider hooks or rules are the primary boundary
+- host-native graphical applications are equal to Tier 1
+- release provenance proves the local macOS runtime boundary

--- a/docs/mode-map.md
+++ b/docs/mode-map.md
@@ -1,36 +1,44 @@
 # Mode Map
 
-Workcell uses two terms throughout the docs:
+Workcell uses these terms:
 
-- `Tier 1`: a provider CLI running fully inside the bounded Workcell runtime
-- `strict`: the default managed Tier 1 runtime mode
+- `Tier 1`: A provider CLI runs fully inside the bounded Workcell runtime.
+- `strict`: This term identifies the default managed Tier 1 mode.
 
-`--mode` selects one of four lanes:
+The `--mode` option selects one of four modes.
 
-| `--mode` | Intended use | Key properties |
+| Mode | Use | Main properties |
 |---|---|---|
-| `strict` | default provider lane | bounded VM plus container, reviewed network posture, repo control-plane masking, provider-focused entrypoint, `--agent-autonomy yolo` by default |
-| `development` | managed interactive development lane | same boundary and masking as `strict`, managed non-provider command execution, broader dependency egress, visibly lower assurance than `strict` |
-| `build` | image preparation and dependency refresh | broader egress for rebuild and preparation work |
-| `breakglass` | explicit higher-trust debugging path | requires `--ack-breakglass=YYYY-MM-DD` using today's UTC date; visibly lower assurance |
+| `strict` | Default provider work | Workcell uses the VM and container boundary, reviewed network controls, repository control-plane masks, the provider entrypoint, and default `--agent-autonomy yolo`. |
+| `development` | Managed interactive development | Workcell uses the same boundary and masks as `strict`. This mode permits managed non-provider commands and more dependency endpoints. It has lower assurance than `strict`. |
+| `build` | Image preparation and dependency updates | This mode permits the broader network access that the build path needs. |
+| `breakglass` | Higher-trust debugging | This mode requires `--ack-breakglass=YYYY-MM-DD` with the current UTC date. It has lower assurance than the managed modes. |
 
-`--container-mutability` is orthogonal to `--mode`: `ephemeral` (the
-default) allows package-manager mutations and labels the session
-`managed-mutable`, while `readonly` blocks package-manager writes and
-gives the strongest managed posture available — `--mode strict
---container-mutability readonly` is the lane to pick when no
-lower-assurance downgrade is acceptable.
+## Container mutability
 
-Other defaults that matter:
+The `--container-mutability` option is independent of `--mode`.
 
-- `--agent` is always required; there is no default provider
-- `--agent-autonomy yolo` is the default; `--agent-autonomy prompt` is the
-  explicit lower-assurance opt-out
-- `--cache-profile off` is the default
-- `--cache-profile standard` keeps a workspace-scoped persistent non-secret
-  cache plane for package and compiler caches, but it is an explicit
-  lower-assurance path
-- strict launches prepare the reviewed runtime image automatically when needed
-- interactive launches show a spinner with elapsed time by default; use
-  `--no-spinner` to force plain heartbeat updates instead
-- `--prepare` and `--prepare-only` remain useful when you want to make that step explicit
+- `ephemeral` is the default. It permits package-manager changes in the
+  disposable container and labels the session `managed-mutable`.
+- `readonly` blocks package-manager writes. Use `--mode strict
+  --container-mutability readonly` for the strongest managed posture.
+
+## Other defaults
+
+- You must select an agent with `--agent`.
+- `--agent-autonomy yolo` is the default. `--agent-autonomy prompt` is an
+  explicit lower-assurance choice.
+- `--cache-profile off` is the default.
+- `--cache-profile standard` keeps workspace-scoped package and compiler
+  caches. It does not keep secret provider state. It is an explicit
+  lower-assurance choice.
+- A strict launch prepares the reviewed runtime image when the image is missing
+  or stale.
+- An interactive launch shows a spinner and elapsed time. Use `--no-spinner`
+  for plain status updates.
+- Use `--prepare` or `--prepare-only` when you must prepare the image as a
+  separate step.
+
+See [invariants.md](invariants.md) for the controls that apply to each mode.
+See [safe-path-expectations.md](safe-path-expectations.md) for operator
+examples.

--- a/docs/onboarding-and-auth.md
+++ b/docs/onboarding-and-auth.md
@@ -1,65 +1,78 @@
-# Onboarding and Auth
+# Onboarding and Authentication
 
-The supported way to feed stable inputs into sessions is an explicit injection
-policy, usually at `~/.config/workcell/injection-policy.toml`.
+Use an injection policy to give stable inputs to a session. The usual path is
+`~/.config/workcell/injection-policy.toml`.
 
-Use the host-side auth helpers instead of hand-editing the common case:
+## Host commands
+
+Use the host authentication commands for common operations:
 
 ```bash
 workcell auth init
 workcell auth set --agent codex --credential codex_auth --source /path/to/auth.json
 workcell auth status --agent codex
-workcell auth unset --agent codex --credential codex_auth
 workcell policy validate
 workcell why --agent codex --mode strict --credential codex_auth
 workcell --agent codex --auth-status --workspace /path/to/repo
 ```
 
-`workcell auth status` shows the host policy view. `--auth-status` shows the
-derived launch view after selector evaluation and preprocessing.
-`workcell policy show|validate|diff` inspects the merged host policy, and
-`workcell why` explains why one credential is selected, out of scope, filtered,
-or still only configured on the host side.
+- `workcell auth status` shows the host policy view.
+- `workcell --auth-status` shows the launch view after selector evaluation and
+  preprocessing.
+- `workcell policy show`, `validate`, and `diff` inspect the merged host policy.
+- `workcell why` explains why Workcell selected or filtered one credential. It
+  also reports when the policy does not configure a credential and the exact
+  `out-of-scope` and `configured-only` states.
 
-Direct staged credentials are the primary supported auth path today. Built-in
-resolver coverage now includes Codex host-auth reuse through
-`codex-home-auth-file`, while the Claude macOS resolver remains a fail-closed
-scaffold until a supported export path exists.
+To remove the managed copy of a credential, use:
 
-`workcell auth status` and `workcell --auth-status` print
-`provider_bootstrap_*` lines, and `workcell why` prints `bootstrap_*` lines for
-the selected credential. Use those fields with
-[provider-bootstrap-matrix.md](provider-bootstrap-matrix.md) to see
-whether a path is repo-required, certification-only, or manual.
+```bash
+workcell auth unset --credential codex_auth
+```
+
+This command removes the managed credential copy from the selected injection
+policy state. It does not remove the original source file.
+
+Direct staged credentials are the primary supported path. Workcell can also
+reuse Codex host authentication through `codex-home-auth-file`. The Claude
+macOS resolver is a fail-closed scaffold. It does not provide a supported
+export path.
+
+The status commands print `provider_bootstrap_*` fields. The `why` command
+prints `bootstrap_*` fields. Use these fields with
+[provider-bootstrap-matrix.md](provider-bootstrap-matrix.md).
+
+## Supported staged inputs
 
 Workcell can stage:
 
-- common or provider-specific instruction fragments
-- provider-native credentials such as `codex_auth`, `claude_auth`,
-  `claude_api_key`, `claude_mcp`, `copilot_github_token`, `gemini_env`,
-  `gemini_oauth`, `gemini_projects`, and `gcloud_adc`
-- scoped GitHub CLI credentials through `github_hosts` and `github_config`
-- SSH config, known hosts, and identities
-- explicit copied files or directories for non-reserved paths
+- common or provider-specific instruction files
+- `codex_auth`
+- `claude_auth`, `claude_api_key`, and `claude_mcp`
+- `copilot_github_token`
+- `gemini_env`, `gemini_oauth`, `gemini_projects`, and `gcloud_adc`
+- scoped GitHub CLI state through `github_hosts` and `github_config`
+- SSH configuration, known hosts, and identities
+- explicit files or directories for non-reserved paths
 
-It does not support whole-home passthrough, arbitrary environment-variable
-secret injection, or host socket forwarding on the safe path.
+The safe path does not support a host home mount, arbitrary secret environment
+variables, or host socket forwarding.
 
-Copilot auth is intentionally narrow: configure `copilot_github_token` and let
-Workcell stage it through reviewed host-side inputs. For an auth-required
-Copilot launch, the launcher removes the original staged token file from direct
-runtime mounts, passes a temporary host-mounted token handoff outside mounted
-provider state, the runtime entrypoint consumes it into a transient handoff
-file, unlinks the mounted file, and re-execs without the token in its
-environment. The wrapper unlinks that runtime file before exporting the value
-as `COPILOT_GITHUB_TOKEN` only to the managed Copilot child process.
-Workcell does not copy or pre-stage the token into `COPILOT_HOME`. Host `gh`
-auth, `GH_TOKEN`, `GITHUB_TOKEN`, host Copilot provider state (`~/.copilot`,
-`~/.config/github-copilot`, `~/.cache/github-copilot`), keychains, and
-whole-home state are not readiness or auth sources. Antigravity credentials and
-provider-home state are not supported inputs yet.
+## Copilot token handoff
 
-See [injection-policy.md](injection-policy.md) and
-[examples/injection-policy.toml](examples/injection-policy.toml).
-The by-provider bootstrap tiers and handoffs live in
-[provider-bootstrap-matrix.md](provider-bootstrap-matrix.md).
+Configure only `copilot_github_token` for Copilot authentication. The launcher
+removes the original staged token from direct runtime mounts. It uses a
+temporary handoff mount outside provider state. The entrypoint moves the token
+to a temporary runtime file, removes the mounted copy, and replaces itself
+without the token in its environment. The wrapper removes the runtime file and gives
+`COPILOT_GITHUB_TOKEN` only to the managed Copilot child.
+
+Workcell does not put the token in `COPILOT_HOME`. It does not use host `gh`
+auth, `GH_TOKEN`, `GITHUB_TOKEN`, host Copilot state, a host keychain, or a host
+home as a Copilot authentication source.
+
+Workcell does not support Antigravity credentials or provider state.
+
+See [injection-policy.md](injection-policy.md) for the complete schema. See
+[examples/injection-policy.toml](examples/injection-policy.toml) for an
+example.

--- a/docs/safe-path-expectations.md
+++ b/docs/safe-path-expectations.md
@@ -123,9 +123,10 @@ workcell session delete --id SESSION_ID --dry-run
 workcell session delete --id SESSION_ID
 ```
 
-`workcell session delete` requires a terminal session and refuses a running
-container. It removes the durable session record and only the recorded
-session-owned artifacts. It does not rewrite the shared profile audit log.
+`workcell session delete` requires a session with terminal status. It refuses a
+running session or container. It removes the durable session record and only
+the recorded session-owned artifacts. It does not rewrite the shared profile
+audit log.
 
 `workcell session list --verbose` adds target, workspace transport, Git branch,
 and worktree fields. `workcell session list --parallel` groups sessions by

--- a/docs/safe-path-expectations.md
+++ b/docs/safe-path-expectations.md
@@ -1,39 +1,27 @@
 # Safe-path Expectations
 
-- Workcell launches the selected provider directly inside the bounded runtime
-- there is no separate "start a container, then attach the agent" step
-- `publish-pr` runs on the host so signed commits, signed-range verification,
-  and GitHub publication stay outside the Tier 1 container, and it blocks
-  unsigned publish ranges and over-broad branch diffs before push so published
-  PRs stay reviewable; `main` is the only supported PR base by default, and
-  non-`main` bases remain an explicit lower-assurance draft-only escape hatch
-  with an explicit preflight warning that repo-owned PR checks are not expected
-  for that base; reviewed, live-certified adapter support PRs may use the
-  bounded `approved-large-certified-adapter` label plus
-  `--approved-large-certified-adapter` publication flag when they cannot be
-  split without invalidating certification evidence; after a verified push,
-  publication reuses a matching open PR for the selected base and branch
-  in the pushed `origin` repository without changing its existing title, body,
-  labels, or draft state, and fails closed if that preserved state violates the
-  non-`main` draft-only or certified-adapter label requirements
-  (`origin` must resolve to exactly one push destination, and GitHub operations
-  use a credential-free selector derived from that push destination)
-- completed and aborted launches are recorded as durable host-side session
-  records that you can inspect with `workcell session ...`
-- `workcell session diff` compares the current workspace against the clean git
-  base recorded at launch and fails closed when the launch started dirty, when
-  no launch git base was recorded, or when the workspace is not a self-contained
-  git worktree
-- `--debug-log`, `--file-trace-log`, and `--audit-transcript` are explicit
-  lower-assurance operator choices and are off by default
+The safe path has these properties:
 
-Useful operator flows:
+- Workcell starts the selected provider inside the bounded runtime. You do not
+  start a container and then attach the provider.
+- `publish-pr` runs on the host. It enforces signed ranges, the pull request
+  shape gate, the `main` base, and explicit exceptions. Thus, GitHub publication
+  stays outside the Tier 1 container.
+- Completed and aborted launches produce durable host session records.
+- `workcell session diff` compares the current workspace with the clean Git
+  base at launch. It stops if the launch was dirty, had no recorded Git base,
+  or did not use a self-contained Git worktree.
+- Debug logs, file traces, and audit transcripts are off by default. Their
+  options are explicit lower-assurance choices.
 
-For changes to this repository, publish main-based PRs through the repo wrapper
-after fresh local parity evidence:
+## Publish a Workcell pull request
+
+For this repository, first create fresh `pr-parity` evidence. The
+`--allow-dirty` option validates live worktree changes before the wrapper
+creates their signed commit. Then use the repository wrapper:
 
 ```bash
-./scripts/pre-merge.sh --profile pr-parity
+./scripts/pre-merge.sh --profile pr-parity --allow-dirty
 ./scripts/repo-publish-pr.sh --workspace /path/to/repo --branch feature/name \
   --title-file /tmp/pr-title.txt \
   --body-file /tmp/pr-body.md \
@@ -44,53 +32,37 @@ after fresh local parity evidence:
 operator repositories that do not carry Workcell's repo-local parity wrapper,
 or for the explicitly lower-assurance non-`main` draft path.
 
-Use `--target colima|docker-desktop|aws-ec2-ssm|gcp-vm` to select the managed
-runtime backend.
-
 ```bash
-workcell --agent codex --prepare --workspace /path/to/repo
-workcell --agent codex --prepare-only --workspace /path/to/repo
-workcell --target docker-desktop --agent codex --workspace /path/to/repo
-workcell --target aws-ec2-ssm --target-id i-1234567890abcdef0 --agent codex --workspace /path/to/repo --dry-run
-workcell --target gcp-vm --target-id workcell-phase8-cert --agent codex --workspace /path/to/repo --dry-run
-workcell --agent codex --mode development --workspace /path/to/repo -- bash -lc 'git status'
-workcell session list
-workcell session list --verbose
-workcell session list --parallel
-workcell session start --agent codex --workspace /path/to/repo
-workcell session delete --id SESSION_ID
-workcell session attach --id 20260408T120000Z-1a2b3c4d
-workcell session send --id 20260408T120000Z-1a2b3c4d --message "continue with tests"
-workcell session stop --id 20260408T120000Z-1a2b3c4d
-workcell session show --id 20260408T120000Z-1a2b3c4d
-workcell session show --id 20260408T120000Z-1a2b3c4d --text
-workcell session logs --id 20260408T120000Z-1a2b3c4d --kind audit
-workcell session timeline --id 20260408T120000Z-1a2b3c4d
-workcell session diff --id 20260408T120000Z-1a2b3c4d
-workcell session export --id 20260408T120000Z-1a2b3c4d --output /tmp/workcell-session.json
-workcell session verify --id 20260408T120000Z-1a2b3c4d
-workcell policy show
-workcell policy diff
-workcell why --agent codex --mode strict --credential codex_auth
-workcell --agent codex --doctor --workspace /path/to/repo
-workcell --agent codex --inspect --workspace /path/to/repo
-workcell --agent codex --auth-status --workspace /path/to/repo
-workcell --gc
-./scripts/update-upstream-pins.sh --check
-./scripts/publish-provider-bump-pr.sh
-workcell --logs audit --colima-profile wcl-...
-# Lower-level host publication helper for repositories without a repo wrapper.
 workcell publish-pr --workspace /path/to/repo --branch feature/name \
   --title-file /tmp/pr-title.txt \
   --body-file /tmp/pr-body.md \
   --commit-message-file /tmp/commit-message.txt
-# Reviewed exception: live-certified adapter PRs that cannot be split.
-workcell publish-pr --workspace /path/to/repo --branch feature/name \
+```
+
+After a verified push, publication can reuse an open pull request with the same
+repository, base, and branch. It preserves the title, body, labels, and draft
+state. It stops if that state violates the base or shape gate. `origin` must
+have exactly one push destination. GitHub commands use a credential-free
+repository selector from that destination.
+
+For a certified adapter exception in this repository, first create parity
+evidence with the matching label. Then publish through the repository wrapper:
+
+```bash
+# Certified adapter change that cannot keep valid evidence after a split.
+./scripts/pre-merge.sh --profile pr-parity \
+  --allow-dirty --label approved-large-certified-adapter
+./scripts/repo-publish-pr.sh --workspace /path/to/repo --branch feature/name \
   --approved-large-certified-adapter \
   --title-file /tmp/pr-title.txt \
   --body-file /tmp/pr-body.md \
   --commit-message-file /tmp/commit-message.txt
-# Lower-assurance exception: non-main bases stay draft-only.
+```
+
+Use the non-`main` exception only for lower-assurance review stacks:
+
+```bash
+# Lower-assurance review stack. The pull request must stay draft.
 workcell publish-pr --workspace /path/to/repo --branch feature/name \
   --base feature/review-stack --allow-non-main-base \
   --title-file /tmp/pr-title.txt \
@@ -98,56 +70,97 @@ workcell publish-pr --workspace /path/to/repo --branch feature/name \
   --commit-message-file /tmp/commit-message.txt
 ```
 
-For the preview-only AWS and GCP remote VM broker paths and their certification
-gates, see [aws-ec2-ssm-preview.md](aws-ec2-ssm-preview.md) and
+## Common operator commands
+
+During a suspected incident, do not use `workcell session delete` or
+`workcell --gc`. These commands can remove evidence. First, preserve the
+evidence as specified in [incident-response.md](incident-response.md).
+
+```bash
+workcell --agent codex --prepare --workspace /path/to/repo
+workcell --agent codex --prepare-only --workspace /path/to/repo
+workcell --target docker-desktop --agent codex --workspace /path/to/repo
+workcell --target aws-ec2-ssm --target-id i-1234567890abcdef0 \
+  --agent codex --workspace /path/to/repo --dry-run
+workcell --target gcp-vm --target-id workcell-phase8-cert \
+  --agent codex --workspace /path/to/repo --dry-run
+workcell --agent codex --mode development --workspace /path/to/repo \
+  -- bash -lc 'git status'
+workcell --agent codex --doctor --workspace /path/to/repo
+workcell --agent codex --inspect --workspace /path/to/repo
+workcell --agent codex --auth-status --workspace /path/to/repo
+workcell policy show
+workcell policy diff
+workcell why --agent codex --mode strict --credential codex_auth
+workcell --gc
+```
+
+AWS EC2 SSM and GCP VM are preview-only broker paths. Workcell blocks operator
+launch. See [aws-ec2-ssm-preview.md](aws-ec2-ssm-preview.md) and
 [gcp-vm-preview.md](gcp-vm-preview.md).
 
-`workcell session list --verbose` adds target, workspace transport, git branch,
-and worktree columns without changing the default compact inventory view.
-`workcell session list --parallel` groups sessions by their origin repository so
-concurrent sessions launched against one repo (each started with
-`--session-workspace isolated`, which clones a clean workspace into its own git
-branch and container) render as a single parallel topology with each sibling's
-isolated worktree, git branch, and container. Note that same-repo isolated
-siblings share one Colima VM: the profile is derived from the original workspace
-path, so they resolve to the same profile and VM (distinct clones, branches, and
-containers, but a shared VM/kernel). Pass a distinct `--colima-profile` to place
-a session on its own VM. The `--parallel` inventory emits one stable `key=value`
-field per line (the same space-safe idiom as `workcell session show --text`), so
-a parser recovers each value—including a workspace path containing spaces—as the
-remainder of its line after the first `=`.
-The 1.0 parallel-session isolation model is container-level: two same-repo
-isolated sessions run as distinct containers sharing one Colima VM. The session
-id deterministically derives two of the per-session boundaries—the isolated clone
-path (`<repo>/.git/workcell-sessions/<session-id>/repo`) and the git branch
-(`workcell/session-<session-id>`)—so two distinct session ids on one source repo
-always resolve to distinct clone paths and distinct branches. The live container
-name is NOT session-id-derived: it is assigned a random suffix at launch
-(`workcell-<agent>-<mode>-repo-<random>`), which makes concurrent containers
-distinct without depending on the session id.
-Evidence boundaries:
+## Session commands
 
-- CI-PROVEN (host-side, no Colima): for two distinct session ids on the
-  same repo, the derivations produce distinct isolated clone paths and distinct
-  branches, and clone-level write-invisibility holds (a write in clone A does not
-  appear in clone B). The session-commands scenario runs the real clone/branch
-  derivations directly and asserts both, needing only git—no live runtime.
-- LOCAL-OPERATOR-CERTIFIED (2026-08-03, Apple Silicon + Colima): the
-  maintainer-only `scripts/certify-c3-parallel-sessions.sh` workflow proved a
-  live overlapping two-container launch, symmetric runtime cross-container
-  write-invisibility, independent stop behavior, and bounded cleanup. The
-  exact-tree pre-merge certification is bound to signed activation commit
-  `a26b750f`; shipped status depends on that commit being reachable from
-  `main`. See
-  [`benchmark-evidence/c3-two-container-isolation-2026-07-15.md`](benchmark-evidence/c3-two-container-isolation-2026-07-15.md).
-  Hosted CI still cannot repeat the live Colima layer.
+For deletion, always inspect the `--dry-run` result before you run the command
+without `--dry-run`.
 
-The shared VM/kernel is not proven distinct here; pass a distinct
-`--colima-profile` to place a session on its own VM.
-`workcell session show --text` renders stable key=value lines for the same
-target-aware record, and `workcell session start|send|stop` emit stable
-key=value summaries so host-side detached control stays scriptable.
-`workcell --gc` removes stale Workcell-owned temp scratch, disposable
-session-audit directories, broken latest-log pointers, and over-budget runtime
-image cache entries without deleting durable session records. It also removes
-stale regenerateable Workcell build cache entries.
+```bash
+workcell session start --agent codex --workspace /path/to/repo
+workcell session list
+workcell session list --verbose
+workcell session list --parallel
+workcell session attach --id SESSION_ID
+workcell session send --id SESSION_ID --message "continue with tests"
+workcell session stop --id SESSION_ID
+workcell session show --id SESSION_ID
+workcell session show --id SESSION_ID --text
+workcell session logs --id SESSION_ID --kind audit
+workcell session timeline --id SESSION_ID
+workcell session diff --id SESSION_ID
+workcell session export --id SESSION_ID --output /tmp/workcell-session.json
+workcell session verify --id SESSION_ID
+workcell session delete --id SESSION_ID --dry-run
+workcell session delete --id SESSION_ID
+```
+
+`workcell session delete` requires a terminal session and refuses a running
+container. It removes the durable session record and only the recorded
+session-owned artifacts. It does not rewrite the shared profile audit log.
+
+`workcell session list --verbose` adds target, workspace transport, Git branch,
+and worktree fields. `workcell session list --parallel` groups sessions by
+origin repository. It prints one stable `key=value` field per line.
+
+## Parallel-session boundary
+
+Use `--session-workspace isolated` to create a clean clone and branch for one
+session. Two isolated sessions for one repository have different clone paths,
+branches, and containers.
+
+By default, these sessions share one Colima VM and kernel. Their profile comes
+from the original workspace path. Use a different `--colima-profile` for each
+session when each session needs a different VM.
+
+The session ID defines these values:
+
+- clone path: `<repo>/.git/workcell-sessions/<session-id>/repo`
+- branch: `workcell/session-<session-id>`
+
+Workcell gives the container name a random suffix. The session ID does not
+define the name.
+
+Repository tests prove distinct clone paths, distinct branches, and clone-level
+write invisibility without Colima. Local certification on 2026-08-03 proved two
+simultaneous containers, cross-container write isolation, independent stop
+behavior, and bounded cleanup. This evidence applies only to signed commit
+`a26b750f` and exact tree `726f485a609b88edcee7ee5ad88692d7aafdd501`.
+The commit is reachable from `main`. See
+[the C3 evidence record](benchmark-evidence/c3-two-container-isolation-2026-07-15.md).
+
+Hosted CI does not prove the shared-VM runtime boundary.
+
+## Garbage collection
+
+`workcell --gc` removes stale Workcell scratch data, stale transient audit
+directories, broken latest-log links, excess image-cache entries, and stale
+regenerable build-cache entries. It does not delete durable session records.

--- a/docs/scenario-gaps.md
+++ b/docs/scenario-gaps.md
@@ -1,64 +1,68 @@
 # Scenario Test Coverage Gaps
 
-This file tracks the main places where Workcell is documented or designed but
-not yet covered as deeply as the core secretless validation path.
+This page lists shipped surfaces that have less test coverage than the core
+secretless path.
 
-## Highest-value gaps
+## Highest-priority gaps
 
 ### Full macOS boundary proof
 
-The strongest local claim depends on the actual Colima plus
-Virtualization.Framework boundary. GitHub-hosted runners cannot prove that, so
-the best evidence today is still the local macOS certification lane:
-`./scripts/run-scenario-tests.sh --secretless-only --certification-only`.
+The macOS Colima runtime boundary depends on Colima and
+Virtualization.framework. GitHub-hosted runners cannot prove this boundary.
+The local certification lane provides the current evidence:
 
-### End-to-end authenticated coverage for every provider
+```bash
+./scripts/run-scenario-tests.sh --secretless-only --certification-only
+```
 
-Provider-authenticated smoke (`scripts/provider-e2e.sh`) is available for
-local use, but it requires a real macOS+Colima environment and live provider
-credentials and is not run in CI. Not every documented auth path has full
-automated end-to-end coverage across all providers.
+### Authenticated tests for each provider
 
-### Lower-assurance transition coverage
+`scripts/provider-e2e.sh` runs authenticated provider tests. It requires an
+Apple Silicon macOS host, Colima, and live provider credentials. CI does not run
+this path. Some documented authentication paths do not have complete live tests.
 
-Some downgrade paths are validated statically or by smoke tests but still need
-more explicit end-to-end scenarios, especially:
+### Lower-assurance transitions
 
-- prompt autonomy audit fields
-- package-mutation downgrade behavior
-- `breakglass` posture and audit output
+No end-to-end scenario completes these checks:
 
-## Provider-specific gaps
+- Start a prompt-autonomy session and verify its audit fields through session
+  finalization.
+- Change packages in a mutable container and verify the final assurance record.
+- Start a `breakglass` session and verify its posture and audit output.
+
+## Provider gaps
 
 ### Codex
 
-- more end-to-end coverage around rule mutability transitions
-- more explicit live coverage of host-side publication handoff
+- No end-to-end scenario changes rule mutability and verifies the final audit
+  record.
+- No live scenario completes the host-side publication handoff from a managed
+  session.
 
 ### Claude
 
-- deeper authenticated coverage for imported MCP state and prompt-autonomy
-  downgrade labeling
+- No authenticated scenario imports MCP state and verifies the runtime state.
+- No end-to-end scenario changes prompt autonomy and verifies its audit label.
 
 ### Gemini
 
-- more end-to-end coverage for Gemini OAuth reuse
-- more end-to-end coverage for Vertex plus `gcloud_adc`
-- more coverage for `breakglass` folder-trust restoration
+- No end-to-end scenario reuses cached Gemini OAuth and completes a provider
+  request.
+- No end-to-end scenario combines Vertex credentials with `gcloud_adc` and
+  completes a provider request.
+- No end-to-end scenario verifies folder-trust restoration after `breakglass`.
 
-### Planned and certification-only provider coverage
+### Copilot and Antigravity
 
-- Copilot live staged-credential certification remains certification-only and
-  outside repo-required CI
-- Antigravity adapter, auth, bootstrap, unsafe-argument, and control-plane
-  seeding coverage after implementation starts
-- Antigravity live staged-credential certification before any support claim
+- Copilot live staged-token certification stays outside repo-required CI.
+- Antigravity has no supported adapter, authentication input, bootstrap path,
+  control plane, scenario evidence, or live certification.
+- Complete Antigravity live certification before any support claim.
 
-## Why these gaps remain acceptable for now
+## Current evidence boundary
 
-The core repo-required path is covered by invariants, smoke tests, deterministic
-repo validation, reproducibility checks, and tagged release preflight. The open
-gaps are mostly at the edges: live-provider auth, local macOS proof, and
-explicit lower-assurance transitions. Copilot deterministic adapter evidence is
-covered; Antigravity remains a planned provider-parity track and unsupported
-until its adapter evidence lands.
+Repository invariants, smoke tests, deterministic scenarios, reproducibility
+checks, and release preflight cover the core path. The remaining gaps apply to
+live provider authentication, local macOS proof, and lower-assurance changes.
+Copilot has deterministic adapter evidence and a live certification gate.
+Antigravity remains unsupported.

--- a/docs/support-tiers.md
+++ b/docs/support-tiers.md
@@ -1,58 +1,64 @@
-# Support tiers and status vocabulary
+# Support Tiers and Status Terms
 
-This page defines the support vocabulary used across the README, ROADMAP,
-`--doctor`, and `--inspect`. The canonical source for host, target, provider,
-launch, evidence, and validation-lane claims is
+This page defines the terms that Workcell uses for host and target support. The
+canonical source is
 [`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv).
+
+Read a complete matrix row before you make a support decision. No one field
+gives support by itself.
 
 ## Status
 
 | Value | Meaning |
 |---|---|
-| `supported` | The matrix row is reviewed for an operator launch path when paired with the row's launch and evidence fields. This value does not create a support claim by itself. |
-| `preview-only` | The row is documented for preview or certification-only work. It is not a supported operator launch claim, and the row's launch field still controls whether Workcell may start anything. |
-| `validation-host-only` | The row is usable only for the named validation lane. It is not an operator launch host. |
-| `unsupported` | The host and target combination is not a supported Workcell combination. Operators should follow the row reason instead of launching. |
+| `supported` | The row can be an operator launch path when `launch=allowed` and the required evidence exists. |
+| `preview-only` | The row is for documented preview or certification work. It is not a supported operator launch path. |
+| `validation-host-only` | The row is only for its named validation lane. It is not an operator launch path. |
+| `unsupported` | Workcell does not support this host and target combination. |
 
 ## Target assurance class
 
 | Value | Meaning |
 |---|---|
-| `strict` | The target is intended for the stricter Workcell runtime boundary, such as the dedicated local VM path. The assurance class alone does not confer support. |
-| `compat` | The target is a compatibility or lower-assurance path. It must stay explicitly labeled and still depends on the matrix row for launch and evidence. |
+| `strict` | The target uses the stricter Workcell boundary, such as the dedicated local VM path. This value does not give support by itself. |
+| `compat` | The target is a compatibility path with lower assurance. The matrix row still controls launch and evidence. |
+| `per-session-vm` | The target design gives each session a VM. The shipped Apple container row is still preview-only and blocked. |
 
 ## Launch
 
 | Value | Meaning |
 |---|---|
-| `allowed` | Workcell may proceed with operator launch for the resolved row, subject to the row's status and required evidence. |
-| `blocked` | Workcell must not proceed with operator launch for the resolved row. The row reason explains the boundary. |
+| `allowed` | Workcell can start an operator session when the row is also `supported` and has the required evidence. |
+| `blocked` | Workcell must not start an operator session. Read the row reason. |
 
 ## Evidence
 
 | Value | Meaning |
 |---|---|
-| `certification-only` | The row depends on live certification evidence recorded for that matrix entry. This is not replaced by the status or assurance class. |
-| `repo-required` | The row depends on repository-owned validation evidence rather than an operator launch claim. |
-| `manual-only` | The row depends on manual verification recorded for that matrix entry rather than automated or repository-owned evidence. |
-| `none` | The row has no supporting evidence claim. It must not be treated as supported. |
+| `certification-only` | The row depends on its recorded live certification evidence. |
+| `repo-required` | The row depends on repository-owned validation. This does not make it an operator launch path. |
+| `manual-only` | The row depends on recorded manual verification. |
+| `none` | The row has no evidence claim. Do not treat it as supported. |
 
 ## Validation lane
 
 | Value | Meaning |
 |---|---|
-| `none` | The row is not assigned to a named validation lane. |
-| `trusted-linux-amd64-validator` | The row is assigned to the trusted Linux amd64 validation lane and is not an operator launch host unless another matrix row says so. |
+| `none` | The row has no named validation lane. |
+| `trusted-linux-amd64-validator` | The row is for the trusted Linux amd64 validation lane. It is not an operator launch host. |
 
 ## Target kind
 
 | Value | Meaning |
 |---|---|
-| `local_vm` | A local VM target kind. The current examples include the Colima strict path. |
-| `local_compat` | A local compatibility target kind. The current examples include the Docker Desktop compat path. |
-| `remote_vm` | A remote VM target kind. The current macOS examples for AWS EC2 SSM and GCP VM are `preview-only`; the same providers resolve to other statuses on other hosts per the matrix. |
+| `local_vm` | A local VM target, such as Colima or the Apple container preview. |
+| `local_compat` | A local compatibility target, such as Docker Desktop. |
+| `remote_vm` | Workcell reaches a remote VM through reviewed broker access. The AWS and GCP paths are preview or validation paths. |
 
-## Current matrix examples
+## Current representative rows
+
+The canonical matrix contains more unsupported host and architecture rows. The
+table below shows every shipped macOS arm64 row and every Linux amd64 row.
 
 | host_os | host_arch | target_kind | target_provider | target_assurance_class | status | launch | evidence | validation_lane |
 |---|---|---|---|---|---|---|---|---|
@@ -60,23 +66,16 @@ launch, evidence, and validation-lane claims is
 | `macos` | `arm64` | `local_compat` | `docker-desktop` | `compat` | `supported` | `allowed` | `certification-only` | `none` |
 | `macos` | `arm64` | `remote_vm` | `aws-ec2-ssm` | `compat` | `preview-only` | `blocked` | `certification-only` | `none` |
 | `macos` | `arm64` | `remote_vm` | `gcp-vm` | `compat` | `preview-only` | `blocked` | `certification-only` | `none` |
+| `macos` | `arm64` | `local_vm` | `apple-container` | `per-session-vm` | `preview-only` | `blocked` | `certification-only` | `none` |
 | `linux` | `amd64` | `local_vm` | `colima` | `strict` | `validation-host-only` | `blocked` | `repo-required` | `trusted-linux-amd64-validator` |
 | `linux` | `amd64` | `local_compat` | `docker-desktop` | `compat` | `unsupported` | `blocked` | `none` | `none` |
+| `linux` | `amd64` | `remote_vm` | `aws-ec2-ssm` | `compat` | `validation-host-only` | `blocked` | `repo-required` | `trusted-linux-amd64-validator` |
+| `linux` | `amd64` | `remote_vm` | `gcp-vm` | `compat` | `validation-host-only` | `blocked` | `repo-required` | `trusted-linux-amd64-validator` |
 
-- On macOS arm64 with the Colima `local_vm` strict target, the operator sees an allowed, certification-only launch path for the reviewed local VM row.
-- On macOS arm64 with the Docker Desktop `local_compat` compat target, the operator sees an allowed, certification-only launch path for the reviewed compatibility row.
-- On macOS arm64 with the AWS EC2 SSM `remote_vm` compat target, the operator sees a preview-only row with launch blocked for certification-only preview work.
-- On macOS arm64 with the GCP VM `remote_vm` compat target, the operator sees a preview-only row with launch blocked for certification-only preview work.
-- On Linux amd64 with the Colima `local_vm` strict target, the operator sees a validation-host-only row for the trusted Linux amd64 validator with launch blocked.
-- On Linux amd64 with the Docker Desktop `local_compat` compat target, the operator sees an unsupported row with launch blocked and no evidence claim.
+Linux arm64 and Windows rows are `unsupported`, `blocked`, and have no evidence
+claim. The `apple-container` target also requires macOS 26, but its matrix row
+is still preview-only and blocked. See the canonical matrix for the exact
+reason in each row.
 
-## No implicit support claim
-
-No tier, assurance class, or status confers a support claim on its own.
-Supported launch paths still require the live certification evidence recorded in
-[`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv).
-
-For the emitted `--doctor` and `--inspect` lines, see
-[`docs/diagnostics-and-support-matrix.md`](diagnostics-and-support-matrix.md).
-For a suspected runtime boundary breach rather than a support question, follow
-the [operator boundary-incident response runbook](incident-response.md).
+See [diagnostics-and-support-matrix.md](diagnostics-and-support-matrix.md) for
+the fields from `--doctor` and `--inspect`.

--- a/docs/use-case-matrix.md
+++ b/docs/use-case-matrix.md
@@ -1,47 +1,43 @@
 # Use Case Coverage Matrix
 
-This matrix summarizes how well the current repo validates the most important
-Workcell workflows.
+This matrix shows the current validation level for important Workcell
+workflows.
 
-## Coverage scale
+## Status terms
 
-- `tested`: covered by repo validation, invariants, smoke, or scenario tests
-- `doc-only`: documented and intentionally supported, but not deeply automated
-- `gap`: recognized coverage gap tracked in `docs/scenario-gaps.md`
-- `planned gap`: roadmap target with no current implementation, tracked in `docs/scenario-gaps.md`
+- `tested`: Repository validation, invariants, smoke tests, or scenarios cover
+  the use case.
+- `partial`: Some deterministic evidence exists, but live or provider-specific
+  coverage is incomplete.
+- `gap`: The implementation exists, but an important coverage gap remains.
+- `planned gap`: The roadmap names the work, but the implementation does not
+  exist.
 
 ## Matrix
 
-| Use case | Status | Primary evidence |
+| Use case | Status | Main evidence |
 |---|---|---|
-| secretless provider launch on the managed path | tested | `scripts/container-smoke.sh`, `scripts/verify-invariants.sh` |
-| provider auth injected through the reviewed policy model | tested for direct staged inputs plus Codex host-auth reuse; the Claude macOS resolver remains fail-closed scaffold only | container smoke, auth-status tests, policy tests, provider-specific helpers |
-| host-side policy inspection and credential explainability | tested | `tests/scenarios/shared/test-policy-commands.sh`, `internal/authpolicy/manage_test.go` |
-| host-side signed `publish-pr` handoff | tested | shared scenario tests and invariant checks |
-| repo control-plane masking and provider-home re-seeding | tested | invariants and smoke |
-| repo-mounted validator and release-helper runs stay nonroot with explicit caller identity and isolated writable state | tested | CI, release preflight, `scripts/pre-merge.sh`, and invariant checks |
-| prompt-autonomy downgrade labeling | tested for Codex, partial elsewhere | invariants plus provider-specific coverage |
-| host-side session inventory, detached session control, delete, log and timeline views, clean-base diff, and audit export | tested | `tests/scenarios/shared/test-session-commands.sh`, `internal/host/sessions/sessions_test.go`, `cmd/workcell-hostutil/main_test.go` |
-| detached-session isolated workspace preflight and direct-workspace remediation | tested | `tests/scenarios/shared/test-session-commands.sh` |
-| opt-in persistent cache plane (`--cache-profile standard`) | tested | `tests/scenarios/shared/test-assurance-dry-run.sh`, `scripts/verify-invariants.sh` |
-| bundle installer plus uninstall helper on the supported GitHub-hosted macOS matrix | tested | `scripts/verify-invariants.sh`, CI, tagged release install verification |
-| Homebrew formula install plus uninstall on the supported GitHub-hosted macOS matrix | tested | CI and tagged release install verification |
-| release-bundle reproducibility | tested | `scripts/verify-release-bundle.sh`, tagged release preflight |
-| runtime-image reproducibility | tested | `scripts/verify-reproducible-build.sh`, CI, tagged release preflight |
-| Sigstore signing and SBOM publication | tested | successful tagged release workflow |
-| GitHub attestations on tagged releases | tested at release time | `release.yml` publish job |
-| full macOS Colima boundary proof | gap | local certification lane exists, but it is still not repo-required proof |
-| exhaustive live-provider auth UX across all providers | gap | manual provider-e2e path exists, but automation is partial |
-| GitHub Copilot CLI provider parity | tested for deterministic adapter path; live certification-only gate | adapter, auth key, docs, deterministic scenario evidence, smoke coverage, and release pin checks exist; live staged-token `copilot -p` certification is required before signing or publishing changes that promote or materially alter the Copilot support claim |
-| Google Antigravity CLI provider parity | planned gap | roadmap and provider docs record the target support bar; no adapter, auth key, quickstart, scenario evidence, or live certification exists yet |
+| Secretless provider launch on the managed path | `tested` | `scripts/container-smoke.sh`, `scripts/verify-invariants.sh` |
+| Credential injection through the reviewed policy | `partial` | `tests/scenarios/shared/test-auth-status.sh`, `internal/authpolicy/manage_test.go`; the Claude macOS resolver is a fail-closed scaffold |
+| Host policy inspection and credential explanations | `tested` | `tests/scenarios/shared/test-policy-commands.sh`, `internal/authpolicy/manage_test.go` |
+| Signed host-side `publish-pr` handoff | `tested` | `tests/scenarios/shared/test-publish-pr-dry-run.sh`, `scripts/verify-invariants.sh` |
+| Repository control-plane masks and provider-home seeding | `tested` | `tests/scenarios/shared/test-home-control-plane-manifest.sh`, `scripts/container-smoke.sh`, `scripts/verify-invariants.sh` |
+| Nonroot repository validation and release helpers | `tested` | `scripts/ci/job-validate.sh`, `scripts/pre-merge.sh`, `scripts/verify-invariants.sh` |
+| Prompt-autonomy downgrade labels | `partial` | `scripts/verify-invariants.sh`; other providers have less coverage |
+| Session inventory, control, delete, logs, timeline, diff, and export | `tested` | `tests/scenarios/shared/test-session-commands.sh`, `internal/host/sessions/sessions_test.go` |
+| Isolated-session workspace preflight and direct-workspace remediation | `tested` | `tests/scenarios/shared/test-session-commands.sh` |
+| Persistent non-secret cache with `--cache-profile standard` | `tested` | `tests/scenarios/shared/test-assurance-dry-run.sh`, `scripts/verify-invariants.sh` |
+| Bundle install and uninstall on the hosted macOS matrix | `tested` | `tests/scenarios/shared/test-install-lifecycle.sh`, `internal/testkit/install_release_e2e_test.go`, `.github/workflows/ci.yml` `Install verification` jobs |
+| Homebrew install and uninstall on the hosted macOS matrix | `tested` | `.github/workflows/ci.yml` and `.github/workflows/release.yml` install-verification jobs |
+| Release-bundle reproducibility | `tested` | `scripts/verify-release-bundle.sh`, `scripts/ci/job-validate.sh --profile release-preflight` |
+| Runtime-image reproducibility | `tested` | `scripts/verify-reproducible-build.sh`, `.github/workflows/ci.yml` `Reproducible build` jobs |
+| Sigstore signatures, SBOMs, and GitHub attestations | `tested` | Successful v1.0.2 `Release` workflow |
+| Full local macOS and Colima boundary proof | `gap` | A local certification lane exists. It is not repo-required proof. |
+| Live authentication for every provider path | `gap` | Operators run `scripts/provider-e2e.sh` manually, and coverage is incomplete. |
+| Copilot deterministic provider path | `tested` | `tests/scenarios/shared/test-copilot-session-dry-run.sh`, `scripts/container-smoke.sh`, `scripts/verify-upstream-copilot-release.sh` |
+| Copilot live staged-token path | `partial` | Work that promotes or materially alters the Copilot support claim requires live `copilot -p` certification. |
+| Antigravity provider path | `planned gap` | No supported adapter, authentication input, quickstart, scenario evidence, or certification exists. |
 
-## Notes
-
-The most heavily tested paths are the repo-required secretless runtime
-boundary, explicit nonroot repo validation and release preflight,
-reproducibility, signed publication, and the host-side operator plane. The
-most mature host-side operator surfaces are auth/policy inspection plus
-session inventory, detached control, delete, timeline, export, and
-isolated-workspace remediation. The biggest remaining gaps are local macOS
-boundary proof, deeper end-to-end live-provider coverage, and the planned
-Antigravity adapter parity phase.
+The core secretless boundary, signed publication, reproducibility, release
+provenance, and host operator commands have the most test evidence. See
+[scenario-gaps.md](scenario-gaps.md) for the remaining work.


### PR DESCRIPTION
## Summary

- Align the support, mode, authentication, and scenario documents with the shipped v1.0.2 behavior.
- Apply ASD-STE100 Simplified Technical English to the current assurance documents.
- Preserve the security invariant anchors and exact support-matrix terms.
- Add exact incident warnings, publication steps, credential cleanup, and session deletion guidance.

## Validation

- The shared documentation job passes.
- Operator-contract, requirements, link, support-matrix, control-plane, dead-code, and public-repository checks pass.
- Focused authentication, session, and operator-contract tests pass.
- Fresh `pr-parity` passed all repository, Rust, Go, scenario, contract, and control-plane gates.
- The final host-only VZ fixture could not obtain a guest SSH address after two three-minute attempts. The temporary profile was removed.

## Review

The source auditor, safety reviewer, STE editor, builder, operator, and minimalist roles accept the final diff after repair rounds.
