### PR TITLE
Revise shipped release evidence in STE

### DIFF
--- a/docs/install-lifecycle.md
+++ b/docs/install-lifecycle.md
@@ -100,8 +100,9 @@ That run completed these install jobs:
 - `Release install verification (macos-15)`
 - `Release install verification (macos-26)`
 
-GitHub published an immutable release with 18 assets.
-Each asset has a GitHub SHA-256 digest.
+The workflow uploaded 18 assets to the immutable release.
+Each uploaded asset has a GitHub SHA-256 digest.
+The release page lists 21 entries because GitHub adds two source-code archives and one release-attestation entry.
 
 On 2026-08-05, the maintainer ran the shipped verified installer against `v1.0.2`.
 The installer source matched the `v1.0.2` tag.

--- a/docs/install-lifecycle.md
+++ b/docs/install-lifecycle.md
@@ -80,8 +80,10 @@ The uninstaller removes these Workcell-owned items:
 - Workcell caches and token handoff data
 - Workcell temporary files
 
-The uninstaller preserves `~/.config/workcell` and user-specified log files.
-It also preserves shared host packages and unrelated Colima profiles.
+The uninstaller preserves `~/.config/workcell`, shared host packages, and unrelated Colima profiles.
+The uninstaller removes a user-selected log if the log is inside a removal target.
+The uninstaller removes a log directly under `/tmp` or `$TMPDIR` if the current user owns the log and its name matches a Workcell cleanup pattern.
+Copy required evidence outside each removal path that the dry run reports.
 
 `workcell --gc` removes stale cache, temporary, session-audit, and runtime state.
 It does not provide a dry-run option.

--- a/docs/install-lifecycle.md
+++ b/docs/install-lifecycle.md
@@ -1,145 +1,135 @@
-# Install lifecycle proof
+# Install lifecycle evidence
 
-Workcell's day-two operations — install, upgrade-in-place, rollback, uninstall,
-and `workcell --gc` — each need repeatable evidence that they behave correctly
-and leave no orphaned Workcell-owned state. This page enumerates that evidence
-set and, for each item, states plainly whether it is **CI-automatable** (proven
-by GitHub-hosted runners or `go test`, with no special hardware or secrets) or
-**local-operator certification** (needs real Apple Silicon hardware or a
-genuinely published, cosign-signed release, and is recorded as operator
-evidence rather than faked in CI).
+Workcell checks install, update, rollback, uninstall, and cleanup operations.
+This page separates automated evidence from live operator evidence.
 
-The split is deliberate and honest: hosted runners can prove the non-container
-install-lifecycle mechanics — download, verify, extract, link, PATH, uninstall,
-the `--gc` cleanup contract, upgrade/rollback repointing, and config
-compatibility — but they cannot prove a live containerized launch (that needs
-Apple Silicon with nested virtualization for Colima/Docker), a unit test cannot
-exercise a real keyless Sigstore signature (that needs GitHub OIDC and a
-published release), and a live host-wide `--gc` is not safe to run in an
-automated lane (it reaps the real host's `/tmp` and home cache roots — see the
-remainder note).
+Automated evidence runs without special hardware or repository secrets.
+Live operator evidence needs a published release, Apple Silicon, or a local runtime.
 
-## Release matrix
+## Test matrix
 
-- Non-container mechanics run on the standard `validate` lane
-  (`ubuntu-latest`) via `go test ./...` and `scripts/run-scenario-tests.sh
-  --repo-required`.
-- The `install-verification` lane
-  ([`.github/workflows/ci.yml`](../.github/workflows/ci.yml)) exercises the
-  bundle installer and Homebrew formula on the GitHub-hosted macOS matrix
-  (`macos-26`, `macos-15`), mirrored at release time in
-  [`.github/workflows/release.yml`](../.github/workflows/release.yml).
+The standard validation lane runs on `ubuntu-latest`.
+It checks Go tests and the required repository scenarios.
 
-## Day-two evidence set
+The CI workflow also runs install checks on these GitHub-hosted Apple Silicon runners:
 
-| Operation | What is proven | Evidence | Class |
-| --- | --- | --- | --- |
-| Install (plain bundle) | `install.sh` links the launcher and man page, the launcher runs, and the Homebrew formula installs/uninstalls | `install-verification` lane | CI-automatable |
-| Verified install (`install-release.sh`) | download → `cosign`-verify fail-closed → extract → handoff to the bundle installer; a bad signature or a digest mismatch aborts **before** any bundle code runs | [`internal/testkit/install_release_e2e_test.go`](../internal/testkit/install_release_e2e_test.go) (offline fixture, stubbed `curl`/`cosign`) | CI-automatable for the orchestration + fail-closed logic; verification against a real published, cosign-signed release is the release/local remainder |
-| Verifier internals | `verify-release-artifact.sh` rejects a tampered artifact, a bad signature, absent material, and absent `cosign`; an acknowledged `--skip-verify` returns a distinct unverified code | [`internal/testkit/release_verify_test.go`](../internal/testkit/release_verify_test.go) | CI-automatable |
-| Upgrade-in-place | re-running the installer from a newer tree repoints the single launcher entry with no duplicate and no orphaned old link, and the new launcher runs | [`tests/scenarios/shared/test-install-lifecycle.sh`](../tests/scenarios/shared/test-install-lifecycle.sh) | CI-automatable |
-| Rollback | re-installing the prior tree repoints the launcher back, proving the operation is symmetric and pins no state forward | same scenario | CI-automatable |
-| Uninstall | the launcher and man symlinks are removed (no orphaned Workcell-owned install links); `~/.config/workcell` is preserved | `install-verification` lane (end to end on a hosted runner) | CI-automatable |
-| `workcell --gc` cleanup contract | the reap logic removes Workcell-owned, pattern-matching stale scratch in a **given** root and preserves unrelated files | [`tests/scenarios/shared/test-install-lifecycle.sh`](../tests/scenarios/shared/test-install-lifecycle.sh) exercises `cleanup_workcell_temp_root` at the function level against an **injected sandbox root**; [`internal/workcellhardening`](../internal/workcellhardening) covers the surfaces `--gc` must reap | CI-automatable |
-| `workcell --gc` end to end | a full live `--gc` cleans stale runtime/cache/temp state without harming user data | recorded operator run | local-operator certification (see safety note below) |
-| Config/schema compatibility | the current binary reads a persisted version-1 session record, and fails closed on an unrecognized future version | [`internal/host/sessions/sessions_test.go`](../internal/host/sessions/sessions_test.go) | CI-automatable |
-| Live launch | a containerized agent session actually launches on the release matrix | recorded launch evidence | local-operator certification (Apple Silicon) |
+- `macos-15`
+- `macos-26`
 
-## Config and schema compatibility
+The release workflow uses the same macOS runner matrix.
+Each macOS job checks the bundle installer, the uninstaller, and the Homebrew formula.
 
-An in-place upgrade only crosses a compatibility boundary if the newer binary
-must read an on-disk format an older install wrote in an older shape. Workcell's
-two runtime-persisted versioned formats are:
+## Evidence by operation
 
-- **Session records** (`~/.local/state/workcell/.../sessions/*.json`) —
-  `version` field, currently `1`
-  ([`internal/host/sessions/sessions.go`](../internal/host/sessions/sessions.go)).
-- **Injection policy** (`~/.config/workcell/injection-policy.toml`) — `version`
-  field, currently `1`.
+| Operation | Evidence | Limit |
+| --- | --- | --- |
+| Install from a local bundle | The macOS jobs check the launcher link, man-page link, Homebrew install, and Homebrew uninstall. | These jobs do not verify a downloaded release signature. |
+| Install a verified release | [`install_release_e2e_test.go`](../internal/testkit/install_release_e2e_test.go) checks download, verification, extraction, and installer handoff. | The test uses local `curl` and `cosign` fixtures. |
+| Verify a release asset | [`release_verify_test.go`](../internal/testkit/release_verify_test.go) checks missing tools, missing files, invalid signatures, and digest mismatches. | A live release check still needs published Sigstore data. |
+| Update an install | [`test-install-lifecycle.sh`](../tests/scenarios/shared/test-install-lifecycle.sh) checks that a new install replaces the launcher link. | The test uses local source trees. |
+| Roll back an install | The same scenario installs the earlier tree again and checks the launcher link. | The test uses local source trees. |
+| Uninstall | The macOS install jobs check the complete uninstall command. | The command removes managed state, profiles, caches, token handoff, and temporary files. |
+| Check cleanup rules | The install scenario checks `cleanup_workcell_temp_root` with an isolated root. | This check does not run host-wide cleanup. |
+| Run host-wide cleanup | A live `workcell --gc` run checks real Workcell state roots. | First, preserve all Workcell state and evidence that must remain. |
+| Read stored data | Session tests read version 1 records and reject an unknown version. | Workcell has not shipped a data migration. |
+| Start a runtime session | The strict and compatibility launch-smoke scenarios check real containers. | GitHub-hosted macOS runners do not provide the required nested virtualization. |
 
-**No versioned on-disk format crosses a boundary yet:** only version 1 has ever
-shipped, so an in-place upgrade to a newer binary reads the same version-1
-records it writes — there is no older-shape-to-newer-binary migration to
-perform today. Both formats validate strictly against their known version and
-reject anything else, so the boundary is *fail-closed*, not silently
-misinterpreted. Two tests pin this state as a contract:
+## Stored-format compatibility evidence
 
-- The current binary reads a persisted version-1 session record correctly (the
-  forward-read baseline for upgrade).
-- The current binary rejects a version-2 record with an explicit
-  `unsupported session record version` error.
+The install and update evidence on this page covers two versioned host formats:
 
-Together these ensure any future format bump must be a **deliberate, migrated,
-and tested** step — a silent break or an accidental version bump fails CI. The
-build-time-only formats (control-plane manifest, workflow-lane and provider-bump
-manifests) are validated at build/CI time and are not read across a runtime
-upgrade, so they are out of scope for day-two compatibility.
+- Session records use `version = 1`.
+- The injection policy uses `version = 1`.
 
-## Local-operator / published-release remainder
+Only version 1 has shipped.
+The current binary reads version 1 and rejects an unknown version.
+No released Workcell version needs a format migration.
 
-These are intentionally **not** faked in CI and are certified by the operator
-with recorded evidence:
+This list is not a complete inventory of versioned Workcell state.
+For example, signed audit records use a separate version 1 seal sidecar.
+Session verification checks that sidecar.
+See [signed session audit records](signed-session-audit-records.md).
 
-- **End-to-end `install-release.sh` against a genuinely published, cosign-signed
-  release** over the network (Sigstore/Fulcio/Rekor). The fixture test proves
-  the orchestration and fail-closed decisions offline; the real keyless
-  signature check against a real release tag is certified at release time.
-- **A live containerized launch** on Apple Silicon macOS (hosted runners lack
-  the nested virtualization Colima/Docker needs).
-- **A full live `workcell --gc`** across real host cache layouts. A live `--gc`
-  cannot be safely automated in the repo-required scenario: it reaps the
-  hard-coded `/tmp` scratch root and the passwd-derived real-home cache roots,
-  and neither can be redirected to a sandbox — `resolve_workcell_real_home`
-  prefers the passwd identity over `$HOME` (and rejects a mismatched
-  `WORKCELL_DOCKER_REAL_HOME` override), and the `/tmp` root has no override. So
-  a live `--gc` in CI could delete a developer's or runner's real Workcell
-  temp/cache state. The scenario therefore proves the reap **contract** at the
-  function level against an injected sandbox root, and the full live run is
-  operator-certified. (`scripts/uninstall.sh` reaps `/tmp` the same way, which
-  is why its end-to-end coverage lives in the hosted `install-verification`
-  lane, not the repo-required scenario.)
-- **A real cross-minor-version data migration**, which only becomes testable
-  once a second on-disk format version ships.
+Installed updates do not read build manifests.
+Validation reads those manifests during builds and repository checks.
 
-### Certification record
+## Cleanup safety
 
-Recorded local-operator certification on the maintainer host
-(macOS 26.5.2, `arm64`; Colima Docker 29.2.1; Docker Desktop 29.5.3):
+Preserve incident evidence before you run `workcell --gc` or the uninstaller.
+Follow the [incident response runbook](incident-response.md) for a suspected boundary failure.
 
-- **Verified install against the published, cosign-signed `v1.0.0-rc.2`
-  release** (2026-07-13): `install-release.sh --version v1.0.0-rc.2
-  --attestation` run end-to-end into an isolated `HOME` completed exit `0` — a
-  single command that downloaded the real release bundle, keyless-verified it
-  against the release signing identity (`Verified OK`, bundle
-  `sha256:d1cc3bba197ab09b195ad6a98b674d79299d6c9eca2a151798127a9f0a83dba9`),
-  passed the GitHub attestation gate that `--attestation` requires
-  (`GitHub attestation verified`), then extracted and installed a `workcell`
-  that reports `workcell v1.0.0-rc.2`. A **negative control** — the same bundle
-  with appended bytes, checked via `verify-release-artifact.sh` — was rejected
-  fail-closed with `digest mismatch` (the cosign signature on `SHA256SUMS`
-  still verified; the tampered tarball digest did not match the signed value),
-  confirming a tampered bundle cannot reach the installer.
-- **Live `workcell --gc`** from the verified `v1.0.0-rc.2` bundle completed
-  exit `0`, reporting the stale injection/session-audit/runtime-cache/
-  build-cache/temp state it cleaned.
-- **Live containerized launch on Apple Silicon** is certified by the two
-  boundary launch-smoke scenarios run on this host in the same session:
-  `tests/scenarios/shared/test-agent-launch-smoke.sh`
-  (`macos/arm64/local_vm/colima/strict`) and
-  `tests/scenarios/shared/test-docker-desktop-launch-smoke.sh`
-  (`macos/arm64/local_compat/docker-desktop/compat`), both passing against the
-  real runtime image on this hardware.
+For a Homebrew formula install, remove the formula first:
 
-## Relationship to forced consumer verification (CI threat model gap 1)
+```bash
+brew uninstall workcell
+```
 
-[ci-threat-model.md](ci-threat-model.md) tracks, as known gap 1, that verified
-install — now the *documented default* — is not yet *forced* across all
-documented install paths. The end-to-end fixture proof above closes the
-CI-automatable half of that gap's "exercise `install-release.sh` end to end"
-requirement — a tampered or unsigned bundle cannot reach the bundle installer —
-and the "against a real published release" half is now done (the Certification
-record above: `install-release.sh --attestation` against the published
-`v1.0.0-rc.2`). Fully closing the gap now requires only making verification the
-*forced* default across all flows and shipping a standalone verified installer
-bootstrap (so consumers need not clone the repo to obtain a trusted
-`install-release.sh`).
+Then use an extracted release bundle or a source checkout.
+From its root, preview every runtime-state removal target:
+
+```bash
+./scripts/uninstall.sh --dry-run
+```
+
+Review each path before you run `./scripts/uninstall.sh` without `--dry-run`.
+The uninstaller removes these Workcell-owned items:
+
+- launcher and man-page links
+- `~/.local/state/workcell`
+- managed Colima profiles and related data
+- Workcell caches and token handoff data
+- Workcell temporary files
+
+The uninstaller preserves `~/.config/workcell` and user-specified log files.
+It also preserves shared host packages and unrelated Colima profiles.
+
+`workcell --gc` removes stale cache, temporary, session-audit, and runtime state.
+It does not provide a dry-run option.
+It can remove Workcell state from another local run.
+Do not run host-wide cleanup as a repository scenario.
+
+An install, update, or rollback does not restore deleted state.
+
+## Published v1.0.2 record
+
+Release `v1.0.2` is the first published stable Workcell 1.0 release.
+The `Release` workflow run `30974305124` completed successfully on 2026-08-05.
+
+That run completed these install jobs:
+
+- `Release install verification (macos-15)`
+- `Release install verification (macos-26)`
+
+GitHub published an immutable release with 18 assets.
+Each asset has a GitHub SHA-256 digest.
+
+On 2026-08-05, the maintainer ran the shipped verified installer against `v1.0.2`.
+The installer source matched the `v1.0.2` tag.
+The run used an isolated home and `--no-install-deps`.
+
+The live run proved these results:
+
+- Cosign verified `SHA256SUMS` against the release workflow identity.
+- The bundle digest matched the signed value `c2a34aa1cf2c2119633cd0f04fc0470520ac44d1e22e1d74f409ff696fc38d1f`.
+- `gh attestation verify` accepted the source-bundle attestation.
+- The installer created the launcher and man-page links.
+
+The installed launcher reported `workcell v1.0.1`.
+This output does not match the `v1.0.2` release tag.
+The `v1.0.2` source bundle starts its changelog at `v1.0.1`.
+The launcher reads its version from that first changelog entry.
+
+Treat this result as a shipped version output defect.
+Do not use `workcell --version` to prove the `v1.0.2` bundle tag.
+Use the release tag, signed checksum, and verified bundle digest for that proof.
+
+## Consumer-verification gap
+
+The recommended release install verifies the bundle before extraction.
+Verification is not mandatory for every install path.
+
+An operator can run `install.sh` from a source tree or a manually downloaded bundle without signature verification.
+Also, the release does not publish `install-release.sh` as a separate asset.
+The operator must get that script from the repository.
+
+See [CI/CD threat model](ci-threat-model.md) for the tracked risk.

--- a/docs/install-lifecycle.md
+++ b/docs/install-lifecycle.md
@@ -126,6 +126,36 @@ Treat this result as a shipped version output defect.
 Do not use `workcell --version` to prove the `v1.0.2` bundle tag.
 Use the release tag, signed checksum, and verified bundle digest for that proof.
 
+## Certification record
+
+On 2026-07-13, the maintainer completed these checks for the published
+`v1.0.0-rc.2` release on an Apple Silicon host with macOS 26.5.2.
+The Colima scenario used Docker 29.2.1.
+The Docker Desktop scenario used Docker 29.5.3.
+
+The certification completed these checks:
+
+- `install-release.sh --version v1.0.0-rc.2 --attestation` completed with
+  exit code 0 in an isolated home.
+- Cosign verified the published `SHA256SUMS` signature against the release
+  workflow identity and reported `Verified OK`.
+- The verified bundle digest was
+  `d1cc3bba197ab09b195ad6a98b674d79299d6c9eca2a151798127a9f0a83dba9`.
+- `gh attestation verify` accepted the source-bundle attestation.
+- The installed launcher reported `workcell v1.0.0-rc.2`.
+- A negative control appended data to the bundle.
+  The verifier rejected that bundle with `digest mismatch` before installation.
+- A live `workcell --gc` command completed with exit code 0 and reported the
+  Workcell state that it removed.
+- `tests/scenarios/shared/test-agent-launch-smoke.sh` passed for
+  `macos/arm64/local_vm/colima/strict`.
+- `tests/scenarios/shared/test-docker-desktop-launch-smoke.sh` passed for
+  `macos/arm64/local_compat/docker-desktop/compat`.
+
+This record is historical release evidence.
+It does not certify release `v1.0.2`.
+Use the published `v1.0.2` record for current release evidence.
+
 ## Consumer-verification gap
 
 The recommended release install verifies the bundle before extraction.

--- a/docs/install-lifecycle.md
+++ b/docs/install-lifecycle.md
@@ -28,7 +28,7 @@ Each macOS job checks the bundle installer, the uninstaller, and the Homebrew fo
 | Verify a release asset | [`release_verify_test.go`](../internal/testkit/release_verify_test.go) checks missing tools, missing files, invalid signatures, and digest mismatches. | A live release check still needs published Sigstore data. |
 | Update an install | [`test-install-lifecycle.sh`](../tests/scenarios/shared/test-install-lifecycle.sh) checks that a new install replaces the launcher link. | The test uses local source trees. |
 | Roll back an install | The same scenario installs the earlier tree again and checks the launcher link. | The test uses local source trees. |
-| Uninstall | The macOS install jobs check the complete uninstall command. | The command removes managed state, profiles, caches, token handoff, and temporary files. |
+| Uninstall | The CI and release macOS matrices run the uninstaller without options. They confirm removal of the launcher and man-page links. | The jobs do not seed other Workcell cleanup targets or confirm their removal. These targets include state, profiles, caches, token handoff files, and cleanup scratch. |
 | Check cleanup rules | The install scenario checks `cleanup_workcell_temp_root` with an isolated root. | This check does not run host-wide cleanup. |
 | Run host-wide cleanup | A live `workcell --gc` run checks real Workcell state roots. | First, preserve all Workcell state and evidence that must remain. |
 | Read stored data | Session tests read version 1 records and reject an unknown version. | Workcell has not shipped a data migration. |

--- a/docs/install.md
+++ b/docs/install.md
@@ -33,7 +33,7 @@ it. Do not use the installer from an arbitrary source checkout.
 The script checks the release-workflow OIDC identity and issuer. It checks the
 Sigstore bundle and Rekor entry. Then it checks the bundle digest in the
 verified `SHA256SUMS` file. These checks automate the manual steps in
-[provenance.md](provenance.md#verifying-release-assets).
+[provenance.md](provenance.md#verify-release-assets).
 
 The script fails closed. It stops for a missing tool or verification file. It
 also stops for an invalid signature or digest. Use `--attestation` to require a
@@ -66,7 +66,7 @@ run — the default is always verify-and-fail-closed.
 ### Tagged release bundle
 
 For manual verification, download the selected release bundle. Use the steps in
-[provenance.md](provenance.md#verifying-release-assets). Then unpack the bundle.
+[provenance.md](provenance.md#verify-release-assets). Then unpack the bundle.
 Run the supported installer:
 
 ```bash
@@ -95,7 +95,7 @@ The formula declares the same required host dependencies: `colima`, `docker`,
 so Homebrew fails the install if the downloaded bundle's digest does not match —
 a checksum-level integrity check. For the full signed-provenance guarantee
 (keyless cosign signature over `SHA256SUMS`), verify `workcell.rb` and the
-bundle following [provenance.md](provenance.md#verifying-release-assets) before
+bundle following [provenance.md](provenance.md#verify-release-assets) before
 `brew install`, or use the verified release install above.
 
 ### Source checkout

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -12,7 +12,11 @@ GitHub attestations add a second verification surface.
 ## What tagged releases publish
 
 The release publishes a multi-platform runtime image to GHCR.
-It also publishes 18 downloadable assets.
+The workflow also uploads 18 release assets.
+
+The GitHub release page lists 21 entries for `v1.0.2`.
+GitHub adds two source-code archives and one release-attestation entry to the 18 uploaded assets.
+Those three GitHub entries are not part of the sealed workflow artifact set.
 
 Nine assets contain release data:
 
@@ -46,11 +50,11 @@ Cosign signs each SBOM file as a release asset.
 
 [`v1.0.2`](https://github.com/omkhar/workcell/releases/tag/v1.0.2) is the first published stable Workcell 1.0 release.
 GitHub reports this release as final and immutable.
-GitHub also reports a SHA-256 digest for each of its 18 assets.
+GitHub also reports a SHA-256 digest for each of the 18 workflow-uploaded assets.
 
 The [`Release` workflow](https://github.com/omkhar/workcell/actions/runs/30974305124) completed successfully on 2026-08-05.
 Both Apple Silicon install-verification jobs passed.
-The final publisher uploaded the exact 18-asset publication set.
+The final publisher uploaded the exact 18-asset workflow publication set.
 
 The 2026-08-05 live install record verified the `v1.0.2` source bundle.
 Cosign verified `SHA256SUMS` against the release workflow identity.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -1,247 +1,319 @@
-# Provenance, Signing, and SBOMs
+# Provenance, signatures, and SBOMs
 
-Workcell releases publish verifiable artifacts, not just opaque downloads.
-The canonical release posture uses two verification surfaces:
+Workcell publishes signed release data for each successful tagged release.
+The release uses two verification systems:
 
-1. always-on keyless Sigstore/Cosign signing
-2. GitHub-native attestations as an additional publication surface
+1. Keyless Sigstore and Cosign signatures
+2. GitHub artifact attestations
 
-Sigstore is the portable baseline. GitHub attestations are additive.
+Sigstore is the required release signature system.
+GitHub attestations add a second verification surface.
 
 ## What tagged releases publish
 
-Tagged releases publish:
+The release publishes a multi-platform runtime image to GHCR.
+It also publishes 18 downloadable assets.
 
-- a multi-architecture runtime image to GHCR
-- a source bundle tarball
-- a versioned Homebrew formula asset (`workcell.rb`)
+Nine assets contain release data:
+
+- the source bundle
+- the Homebrew formula
+- the image digest
+- the build-input manifest
+- the control-plane manifest
+- the builder-environment manifest
+- the source SBOM
+- the image SBOM
 - `SHA256SUMS`
-- a published image digest file
-- a deterministic build-input manifest
-- a deterministic control-plane manifest
-- a deterministic builder-environment manifest
-- source and image SBOMs in SPDX JSON
-- a Sigstore bundle for the Homebrew formula asset
-- Sigstore bundles for the source bundle, published image digest file,
-  checksums, build-input manifest, control-plane manifest,
-  builder-environment manifest, and both SBOMs
-- keyless Sigstore signatures for the published image
-- GitHub attestations for the published image, image SBOM, source bundle,
-  source SBOM, Homebrew formula, published image digest file, checksums,
-  build-input manifest, control-plane manifest, and builder-environment
-  manifest when the reviewed hosted controls say the repository visibility and
-  GitHub plan support that publication path
+
+The other nine assets contain one Sigstore bundle for each release-data asset.
+The release also signs the runtime image in the container registry.
+
+By default, the release creates GitHub build-provenance attestations for these subjects:
+
+- the runtime image
+- the source bundle
+- the Homebrew formula
+- the image digest
+- the three JSON manifests
+- `SHA256SUMS`
+
+The release also attaches an SBOM predicate to the image and source-bundle subjects.
+The SBOM files are not attestation subjects.
+Cosign signs each SBOM file as a release asset.
+
+## Published v1.0.2 evidence
+
+[`v1.0.2`](https://github.com/omkhar/workcell/releases/tag/v1.0.2) is the first published stable Workcell 1.0 release.
+GitHub reports this release as final and immutable.
+GitHub also reports a SHA-256 digest for each of its 18 assets.
+
+The [`Release` workflow](https://github.com/omkhar/workcell/actions/runs/30974305124) completed successfully on 2026-08-05.
+Both Apple Silicon install-verification jobs passed.
+The final publisher uploaded the exact 18-asset publication set.
+
+The 2026-08-05 live install record verified the `v1.0.2` source bundle.
+Cosign verified `SHA256SUMS` against the release workflow identity.
+GitHub accepted its source-bundle attestation.
+The signed source-bundle digest is:
+
+```text
+c2a34aa1cf2c2119633cd0f04fc0470520ac44d1e22e1d74f409ff696fc38d1f
+```
 
 ## What the release workflow proves
 
-Before publish, release preflight reruns:
+Release preflight checks these items before publication:
 
 - repository validation
-- container smoke
-- release-bundle reproducibility
+- container smoke tests
+- source-bundle reproducibility
 - runtime-image reproducibility
-- explicit nonroot validator and release-helper execution when the archived or
-  live repository is bind-mounted into verification containers
-- hosted-control auditing
-- authoritative-source verification of the GitHub-hosted Apple Silicon macOS
-  release install runner labels
-- upstream pinned Codex, Claude, Copilot, and Gemini release verification
-- fail-closed Google Antigravity provider promotion checks before any future
-  support claim
-- reviewed upstream pin verification across providers, Linux base images,
-  Linux toolchains, and release-build helper pins
-- release-bundle install/uninstall and Homebrew install/uninstall verification
-  on GitHub-hosted Apple Silicon `macos-26` and `macos-15`
+- nonroot validator and release-helper execution
+- hosted repository controls
+- Apple Silicon runner metadata
+- pinned provider releases
+- pinned base images and toolchains
+- bundle install and uninstall on `macos-15` and `macos-26`
+- Homebrew install and uninstall on the same runners
 
-The publish job then rebuilds from the archived source bundle, not the live
-checkout, and re-verifies upstream provider releases plus the reviewed upstream
-pin set from that archived source tree. It binds the published per-platform
-image digests, source bundle, build-input manifest, and control-plane manifest
-back to preflight results before signing and publication.
+The amd64 image job rebuilds from the archived source bundle.
+A separate native arm64 job builds from the checked-out signed tag.
+The amd64 job checks the archived provider pins again.
+The workflow binds both platform digests and the image manifests to the preflight results.
+It then signs and stages the release asset set.
+
+The final job checks hosted controls again.
+It removes the administration token before publication.
+It publishes only the sealed workflow artifact.
 
 ## Sigstore path
 
-The always-on path is:
+The Sigstore path uses these parts:
 
-- GitHub OIDC identity
-- keyless Cosign signing
-- Rekor-backed Sigstore bundles published with the release assets
+- the GitHub OIDC identity
+- short-lived Fulcio certificates
+- keyless Cosign signatures
+- Rekor transparency data in Sigstore bundles
 
-This path is the recommended verifier for consumers who want a portable,
-GitHub-independent check.
+This check does not need the GitHub attestation service.
+It still trusts the named GitHub release workflow identity.
 
 ## GitHub attestation path
 
-The canonical upstream repo publishes GitHub attestations fail-closed: every
-release attests its artifacts unless the opt-out is set. That posture is
-tracked through two repository variables:
+The canonical public repository creates GitHub attestations.
+Its hosted-control policy requires both repository variables below to be `false`:
 
-- `WORKCELL_RELEASE_NO_ATTEST=true` is the explicit opt-out; when unset,
-  releases attest (the earlier `WORKCELL_ENABLE_GITHUB_ATTESTATIONS` opt-in
-  was removed because a missing toggle silently produced unattested releases)
-- `WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS=true` is only allowed when the
-  repository is private/internal and the GitHub plan actually supports private
-  artifact attestations
+- `WORKCELL_RELEASE_NO_ATTEST`
+- `WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS`
 
-This does not replace Sigstore. It adds:
+Do not set either variable to `true` in the canonical repository.
+The hosted-control check fails if a variable has a different value.
+Thus, a variable change alone cannot create an upstream release without attestations.
 
-- GitHub-native attestation UX and policy integration
-- subject-linked attestations for the image and selected release artifacts
+Do not use the old `WORKCELL_ENABLE_GITHUB_ATTESTATIONS` variable.
+The release workflow no longer uses that opt-in variable.
 
-Because GitHub attestations can add extra OCI attestation manifests next to the
-published image, Workcell validates multi-arch platform ordering separately
-from those attestation entries.
+A fork cannot enable an exception with a variable or policy-file change alone.
+It must first change and review both the hosted-control policy and its validator.
+This is a code-and-policy change, not an operator exception.
+A fork release without GitHub attestations has lower assurance.
+It must still create all Sigstore signatures.
 
-## Verifying the image
+GitHub attestations do not replace Sigstore signatures.
+They add GitHub policy data and subject lookup.
 
-Verify the image with Cosign:
+## Verify the image
+
+Select the exact release tag.
+Download these three files from that release:
+
+- `workcell-image.digest`
+- `SHA256SUMS`
+- `SHA256SUMS.sigstore.json`
+
+The `v1.0.2` GHCR package denied anonymous access during the 2026-08-05 check.
+Authenticate to GHCR with `read:packages` access before you verify that image.
+See [GitHub container registry authentication](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
+
+Run the complete procedure in one Bash subshell.
+The subshell does not replace the current Docker configuration or exit trap.
+When the prompt appears, enter a token that has package access.
 
 ```bash
-cosign verify ghcr.io/omkhar/workcell@sha256:DIGEST \
-  --certificate-identity-regexp 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+(
+  set -euo pipefail
+
+  workcell_docker_config="$(mktemp -d)"
+  export DOCKER_CONFIG="${workcell_docker_config}"
+  trap 'rm -rf -- "${workcell_docker_config}"' EXIT
+
+  read -r -p 'GitHub user: ' workcell_github_user
+  read -r -s -p 'GHCR token: ' workcell_ghcr_token
+  printf '\n'
+  printf '%s' "${workcell_ghcr_token}" | docker login ghcr.io \
+    --username "${workcell_github_user}" --password-stdin
+  unset workcell_github_user
+
+  tag=v1.0.2
+  identity="https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/${tag}"
+
+  cosign verify-blob SHA256SUMS \
+    --bundle SHA256SUMS.sigstore.json \
+    --certificate-identity "${identity}" \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+  expected="$(awk '$2 == "workcell-image.digest" {print $1}' SHA256SUMS)"
+  actual="$(shasum -a 256 workcell-image.digest | awk '{print $1}')"
+  test -n "${expected}" && test "${actual}" = "${expected}"
+
+  image_ref="$(cat workcell-image.digest)"
+  cosign verify "${image_ref}" \
+    --certificate-identity "${identity}" \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+  GH_TOKEN="${workcell_ghcr_token}" gh attestation verify "oci://${image_ref}" \
+    --repo omkhar/workcell \
+    --cert-identity "${identity}" \
+    --source-ref "refs/tags/${tag}" \
+    --cert-oidc-issuer https://token.actions.githubusercontent.com
+
+  unset workcell_ghcr_token
+  docker logout ghcr.io
+)
 ```
 
-If the canonical repo published GitHub attestations for that release, verify
-the same image with GitHub attestation tooling:
+`docker login` stores the credential only in the temporary configuration.
+The exit trap deletes that configuration after success or failure.
+For a fork release without GitHub attestations, omit the `gh attestation verify` command.
+
+## Verify release assets
+
+Select the exact release tag and asset.
+Download the asset and these two files from that release:
+
+- `SHA256SUMS`
+- `SHA256SUMS.sigstore.json`
+
+Verify the checksum signature first:
 
 ```bash
-gh attestation verify oci://ghcr.io/omkhar/workcell@sha256:DIGEST \
-  --repo omkhar/workcell \
-  --signer-workflow omkhar/workcell/.github/workflows/release.yml
-```
+tag=v1.0.2
+asset=workcell-v1.0.2.tar.gz
+identity="https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/${tag}"
 
-## Verifying release assets
-
-1. Download `SHA256SUMS`, `SHA256SUMS.sigstore.json`, and the assets you want
-   to verify, including `workcell.rb` if you plan to install through Homebrew.
-2. Verify the signed checksum file with Cosign.
-3. Verify the asset digests against `SHA256SUMS`.
-4. Optionally verify the directly signed Homebrew formula, JSON manifests, or
-   SBOMs with their own Sigstore bundles.
-
-Example:
-
-```bash
 cosign verify-blob SHA256SUMS \
   --bundle SHA256SUMS.sigstore.json \
-  --certificate-identity-regexp 'https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/tags/.+' \
+  --certificate-identity "${identity}" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
-
-sha256sum -c SHA256SUMS
 ```
 
-If you want GitHub's attestation view for the source bundle and the canonical
-repo published GitHub attestations for that release:
+On Linux, check the downloaded asset digest with `sha256sum`:
 
 ```bash
-gh attestation verify workcell-VERSION.tar.gz --repo omkhar/workcell \
-  --signer-workflow omkhar/workcell/.github/workflows/release.yml
+expected="$(awk -v name="${asset}" '$2 == name {print $1}' SHA256SUMS)"
+actual="$(sha256sum "${asset}" | awk '{print $1}')"
+test -n "${expected}" && test "${actual}" = "${expected}"
 ```
 
-## Host-side PR publication
+On macOS, check one asset with `shasum`:
 
-Release and publication changes enter review through host-side PR publication,
-not from inside the Tier 1 runtime. The supported `main`-based path uses
-`./scripts/repo-publish-pr.sh`, which verifies fresh local PR-parity evidence
-before delegating to `workcell publish-pr`.
+```bash
+expected="$(awk -v name="${asset}" '$2 == name {print $1}' SHA256SUMS)"
+actual="$(shasum -a 256 "${asset}" | awk '{print $1}')"
+test -n "${expected}" && test "${actual}" = "${expected}"
+```
 
-`workcell publish-pr` signs any new commit it creates and verifies every
-commit in the branch range being published before push or PR creation. The
-signature check uses host Git signing trust and ignores workspace-local signer
-configuration, stale tracking refs, and replacement refs as trust shortcuts.
+The command fails if the asset has no signed checksum entry.
+It also fails if the computed digest does not match.
+
+Use this optional GitHub check for a downloaded source bundle:
+
+```bash
+gh attestation verify "${asset}" \
+  --repo omkhar/workcell \
+  --cert-identity "${identity}" \
+  --source-ref "refs/tags/${tag}" \
+  --cert-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+The verified installer runs the Cosign and digest checks before extraction.
+Add `--attestation` to require the GitHub check.
+
+The shipped installer pins the repository workflow but accepts any release tag identity.
+Use the manual procedure above when you require exact-tag certificate binding.
 
 ## SLSA v1.0 Build-track gap analysis
 
-SLSA v1.0 defines only the **Build track** (levels L1-L3); it has no Source
-track. Source-integrity controls such as two-person review belong to SLSA's
-Source track, which was added in a later version (v1.2, as Source L4 two-party
-review). This analysis is scoped to the v1.0 Build track, so the current Source
-track is out of scope and not claimed; source-integrity posture is noted
-separately below.
+[SLSA v1.0](https://slsa.dev/spec/v1.0/levels) defines Build levels L1 through L3.
+It does not define a Source track.
 
-Reproducibility and hermeticity are *not* Build L1-L3 requirements in v1.0; they
-are additive properties. Workcell's reproducibility work is credit beyond the
-required levels and does not by itself raise the Build-track level.
+For releases with GitHub attestations, Workcell claims Build L2 for the eight build-provenance subjects.
+Workcell does not claim a Build level for other release files or for releases that disable GitHub attestations.
+Workcell does not claim Build L3.
 
-**Current posture: Build L2 (met). Build L3 is partial — Workcell does not claim
-L3.**
+Reproducibility and hermeticity do not set a SLSA v1.0 Build level.
+They are separate build properties.
 
 ### Build L1 — provenance exists
 
-| Requirement | Status | Mechanism |
-|---|---|---|
-| Provenance describes the platform, process, and top-level inputs | Met | BuildKit SLSA provenance (`provenance: mode=max`) on both image builds; bare `actions/attest` SLSA build-provenance predicates for the image digest and seven release blobs (source bundle, Homebrew formula, image-digest file, the deterministic `workcell-build-inputs.json` / `workcell-control-plane.json` / `workcell-builder-environment.json` manifests, and `SHA256SUMS`); the image and source bundle additionally carry SBOM attestations (the SPDX SBOMs are the attested content, not themselves attested subjects — the `.spdx.json` files are Cosign-signed, not GitHub-attested); Cosign also signs the `.sigstore.json`-bundled assets |
-| Consistent build process | Met | one tag-triggered workflow builds a SHA-pinned Dockerfile with digest-pinned base images and toolchains |
-| Provenance distributed to consumers | Met | Cosign `.sigstore.json` bundles are published as downloadable release assets; the image SLSA/SBOM attestations are pushed to the registry (OCI), and the file attestations are held in GitHub's attestation store and retrieved with `gh attestation verify` (not as downloadable assets); verification is documented above |
+| Requirement | Status | Workcell evidence |
+| --- | --- | --- |
+| Provenance describes the build | Met | BuildKit creates image provenance. GitHub creates build-provenance predicates for eight subjects. |
+| The build process is consistent | Met | One tag workflow uses pinned actions, images, toolchains, and provider inputs. |
+| Consumers can get provenance | Met | GHCR stores image attestations. GitHub stores artifact attestations for release files. |
 
 ### Build L2 — hosted platform, authentic provenance
 
-| Requirement | Status | Mechanism |
-|---|---|---|
-| Build runs on hosted, dedicated infrastructure | Met | all build and publish jobs run on GitHub-hosted runners; the release path uses no self-hosted runners |
-| Provenance tied to the platform by signature | Met | keyless cosign signing and GitHub attestations, both via GitHub OIDC and Fulcio short-lived certificates (no long-lived signing key) |
-| Downstream verification validates authenticity | Met | the documented cosign commands pin the certificate identity to the release workflow at a tag ref and the GitHub OIDC issuer; the `gh attestation verify` examples pin the signer workflow with `--signer-workflow` |
+| Requirement | Status | Workcell evidence |
+| --- | --- | --- |
+| A hosted platform runs the build | Met | [GitHub-hosted runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) run all release build and publish jobs. |
+| A signature ties provenance to that platform | Met | GitHub OIDC and Fulcio bind signatures to the release workflow. |
+| Downstream checks validate provenance authenticity | Met | [GitHub artifact attestations](https://docs.github.com/en/enterprise-cloud@latest/actions/concepts/security/artifact-attestations) and documented commands pin the workflow identity. |
 
-Build L2 is the highest level Workcell claims today.
+Build L2 is the highest level that Workcell claims for those eight subjects.
 
-### Build L3 — hardened builds, non-forgeable provenance
+### Build L3 — hardened builds
 
-| Requirement | Status | Path to close / non-goal |
-|---|---|---|
-| Isolated, ephemeral environment; runs cannot influence one another | Met | GitHub-hosted runners are single-use ephemeral VMs; the reproducibility harness additionally rebuilds with no cache and byte-compares independent builds |
-| Signing material inaccessible to build steps | Partial | there is no long-lived signing key to exfiltrate (ephemeral Fulcio certs), but the image build and the signing/attestation steps run in the same job on the same runner. Close by moving the build itself into an isolated reusable workflow so the build and provenance generation share one trusted context |
-| Provenance strongly resistant to tenant forgery | Partial | the provenance predicate is generated by `actions/attest` in the same job that ran the build. GitHub documents this exact configuration as Build L2; L3 requires the build to run inside the trusted reusable workflow. Merely attesting artifact digests handed up from the current build job does not suffice — a compromised build job could pass any digest. Close by the same build-in-reusable-workflow (or `slsa-framework/slsa-github-generator`) change |
+SLSA v1.0 adds two build-platform controls at L3.
 
-The L2-to-L3 gap is a closeable change: move the build itself into an isolated
-reusable workflow (or the SLSA GitHub generator) so the build and provenance
-generation run together in the trusted context. Attesting digests handed up from
-the current build job is not enough — the caller could supply any digest, and the
-trusted workflow would faithfully attest it. Until the build runs inside the
-trusted workflow, Workcell claims Build L2.
+| Requirement | Status | Workcell evidence or gap |
+| --- | --- | --- |
+| One run cannot influence another run | Not established | GitHub documents a new virtual machine for each standard hosted job. This fact does not prove every SLSA isolation condition. |
+| Build steps cannot access provenance signature material | Not met | Build and attestation steps share one job and its OIDC authority. |
+
+These gaps prevent a Build L3 claim.
+Move provenance authority outside user-defined build steps to close this gap.
+Use a trusted builder that enforces this separation.
 
 ### Hermeticity
 
-The image build is **pinned, integrity-checked, reproducible, and
-network-dependent — not hermetic**. It performs live network fetches: `apt`
-packages from a pinned Debian snapshot (verified by apt's signed repository
-metadata, not a repo-hardcoded checksum), `npm ci`, and provider-binary
-downloads. The TLS-bootstrap `.deb`s and provider tarballs are additionally
-verified against repo-hardcoded `sha256sum` values. Only the Rust compile stage
-is hermetic (vendored crates, `cargo build --locked --offline`).
-Hermeticity is not a Build L1-L3 requirement; closing it (vendoring the remaining
-inputs and building with the network disabled) is optional hardening.
+The image build is reproducible, pinned, and network-dependent.
+It is not hermetic.
+
+The build downloads these inputs:
+
+- Debian packages from a pinned snapshot
+- Node packages through `npm ci`
+- provider archives
+
+Repository checks validate provider archives with fixed digests.
+They also validate the OpenSSL and CA certificate bootstrap packages.
+APT validates Debian repository metadata.
+Only the vendored Rust compile stage runs offline.
 
 ### Source-integrity note (two-person review, outside SLSA v1.0)
 
-Two-person review is a source-integrity control outside SLSA v1.0's Build track.
-It belongs to SLSA's Source track (added in v1.2 as Source L4 two-party review),
-which this v1.0 Build-track analysis does not claim. It is a
-structural non-goal in single-maintainer mode. The release path nonetheless
-raises source-integrity
-assurance through signed annotated release tags (verified via GitHub's API and
-locally), a tag-ancestry check requiring the tag commit to be on `main`, a
-"main checks green" gate before publish, signed publish commits verified across
-the branch range, and a gated `release` deployment environment. These do not
-satisfy, and are not claimed to satisfy, two-person review.
+[SLSA v1.2 Source L4](https://slsa.dev/spec/v1.2/source-requirements#level-4-two-party-review) requires two-party review.
+Workcell operates in single-maintainer mode and does not claim Source L4.
 
-### Caveats
-
-- Claim **Build L2**, not L3: the runner is isolated, but provenance generation
-  is not isolated from the build job.
-- Reproducible and hermetic are distinct properties, and neither is a Build-track
-  level; the reproducibility story does not discharge the L3 isolation gap.
-- The default posture is fail-closed attestation. A release built with
-  `WORKCELL_RELEASE_NO_ATTEST=true` ships without GitHub SLSA attestations
-  (cosign bundles remain), which drops the provenance guarantee for that release.
+Workcell uses signed commits, signed tags, required checks, and public PR records.
+These controls do not replace two-party review.
 
 ## Scope note
 
-Release provenance proves how the published artifacts were built and signed. It
-does not, by itself, prove the entire local macOS runtime boundary. That still
-depends on Workcell's local runtime controls, local validation, and operator
-discipline.
+Release provenance describes published artifacts and their release workflow.
+It does not prove the local macOS runtime boundary.
 
-Continuous CI and tagged-release install verification are also intentionally
-narrow: they currently prove package installability only on GitHub-hosted
-Apple Silicon `macos-26` and `macos-15`.
+Local runtime assurance depends on the Workcell VM, container controls, validation, and operator actions.
+The hosted install matrix covers only Apple Silicon `macos-15` and `macos-26`.

--- a/docs/retention-policy.md
+++ b/docs/retention-policy.md
@@ -1,98 +1,109 @@
-# CI and Release Artifact Retention Policy
+# CI and release artifact retention policy
 
-This page records how long each GitHub Actions workflow keeps its uploaded
-artifacts and why, and how to verify a release after those artifacts expire.
+GitHub Actions keeps each workflow artifact for a fixed time.
+This page lists those times and their purpose.
 
-The machine-enforced source of truth is
-[`policy/retention-policy.json`](../policy/retention-policy.json), which binds
-each artifact name to its required `retention-days`. The
-`workcell-citools check-retention-policy` validator (run by
-`scripts/check-workflows.sh` in both local `pre-merge`/`pr-parity` and the
-`security.yml` lane) asserts that every `actions/upload-artifact` step sets an
-explicit `retention-days` (so no artifact silently inherits the repository
-default) and that each uploaded artifact's retention matches the policy exactly.
-Binding per artifact name — rather than per workflow — means moving a retention
-value from one artifact to another is still caught. The table below mirrors that
-policy for readability.
+[`policy/retention-policy.json`](../policy/retention-policy.json) is the source of truth.
+`workcell-citools check-retention-policy` checks the policy against all workflow files.
+
+The check requires an explicit `retention-days` value for each upload.
+It also requires the exact policy value for each artifact name.
+The local `pr-parity` gate and the `Security` workflow run this check.
 
 ## Retention by artifact
 
-| Workflow | Artifact | retention-days |
-|---|---|---|
-| bench.yml | exec-guard-bench-results | 14 |
-| ci.yml | workcell-ci-install-candidate | 7 |
-| fuzz.yml | fuzz-reproducers | 14 |
-| fuzz.yml | rust-fuzz-reproducers | 14 |
-| fuzz.yml | rust-fuzz-lockfile | 14 |
-| release.yml | workcell-release-preflight | 90 |
-| release.yml | workcell-release-install-candidate | 90 |
-| release.yml | workcell-release-artifacts | 7 |
-| security.yml | zizmor-sarif | 5 |
-| scorecard.yml | scorecard-sarif | 5 |
-| upstream-refresh.yml | upstream-refresh-candidate | 7 |
+| Workflow | Artifact | Days |
+| --- | --- | ---: |
+| `bench.yml` | `exec-guard-bench-results` | 14 |
+| `ci.yml` | `workcell-ci-install-candidate` | 7 |
+| `fuzz.yml` | `fuzz-reproducers` | 14 |
+| `fuzz.yml` | `rust-fuzz-reproducers` | 14 |
+| `fuzz.yml` | `rust-fuzz-lockfile` | 14 |
+| `release.yml` | `workcell-release-preflight` | 90 |
+| `release.yml` | `workcell-release-install-candidate` | 90 |
+| `release.yml` | `workcell-release-artifacts` | 7 |
+| `security.yml` | `zizmor-sarif` | 5 |
+| `scorecard.yml` | `scorecard-sarif` | 5 |
+| `upstream-refresh.yml` | `upstream-refresh-candidate` | 7 |
 
 ## Rationale
 
-- **`release.yml` — 90 and 7 days.** The release-preflight and
-  release-install-candidate artifacts are the buyer- and incident-facing
-  evidence for a tagged release (build inputs, install candidates, manifests);
-  they are kept **90 days** to give incident response and post-release audits a
-  usable window. The `workcell-release-artifacts` upload is kept at **7 days**
-  because every file in it is also published as a permanent GitHub Release
-  asset in the next step, so a long-lived workflow-artifact copy would be pure
-  redundant storage.
-- **`bench.yml` — 14 days.** The `exec-guard-bench-results` upload is the
-  Markdown report from a scheduled or on-demand microbenchmark run (the
-  exec-guard allow-path overhead and its cross-run stability). It is triage and
-  transcription evidence, not integrity provenance: the durable copy is the
-  reviewed baseline in [syscall-shim-benchmarks.md](syscall-shim-benchmarks.md).
-  Fourteen days spans the weekly cadence with margin, matching the sibling
-  `fuzz.yml` evidence artifacts.
-- **`ci.yml` — 7 days.** The CI install candidate is a transient
-  per-PR/per-push build; it is only useful while the change is in flight, and
-  the durable release evidence is produced by `release.yml`.
-- **`fuzz.yml` — 14 days.** Two crash artifacts are uploaded only when a
-  scheduled fuzz run finds a crash: `fuzz-reproducers` carries the Go failing
-  inputs (`testdata/fuzz/<Target>/<hash>`), and `rust-fuzz-reproducers` carries
-  the Rust cargo-fuzz crash inputs (`fuzz/artifacts/<target>/<hash>`), each
-  needed to reproduce and fix the defect. Fourteen days spans the weekly cadence
-  with margin, so a crash from one run is still retrievable for triage after the
-  next run; the durable copy is the reproducer once committed as a regression
-  seed (see [fuzzing.md](fuzzing.md)). The `rust-fuzz-lockfile` artifact carries the
-resolved `fuzz/Cargo.lock` from each run; it is the committed lock's drift
-evidence and is kept the same **14 days** as the reproducers.
-- **`security.yml` — 5 days.** The `zizmor` audit job itself is the enforcement
-  gate: it fails the workflow on any finding. The `zizmor-sarif` upload is a
-  short-lived supplementary export of that run and is **not** ingested into
-  GitHub code scanning, so there is no durable copy after it expires — 5 days is
-  enough to inspect a specific run's SARIF; the durable signal is the pass/fail
-  gate and the workflow logs.
-- **`scorecard.yml` — 5 days.** The Scorecard SARIF is uploaded to GitHub code
-  scanning (`github/codeql-action/upload-sarif`), which is the authoritative,
-  durable copy; the 5-day `scorecard-sarif` artifact is only a short-lived
-  convenience copy of the same data.
-- **`upstream-refresh.yml` — 7 days.** The `upstream-refresh-candidate` bundle
-  (`patch`, `diffstat`, `metadata.json`) is an advisory operator signal for a
-  reviewed upstream-pin refresh, not integrity evidence; the authoritative
-  refresh PR is created later on the host. Seven days covers the review window
-  for a candidate before it is regenerated.
+### Release artifacts
 
-## Verifying a release after artifacts expire
+`workcell-release-preflight` contains four preflight manifests.
+The manifests bind build inputs, the control plane, the source bundle, and runtime images.
 
-Uploaded workflow artifacts are not the durable provenance record. After they
-expire, a release can still be verified from permanent sources:
+`workcell-release-install-candidate` contains the source bundle and Homebrew formula used by the macOS install jobs.
+Workcell keeps both artifacts for 90 days to support release review and incident checks.
 
-- **GitHub attestations.** When the reviewed hosted controls enable them,
-  release artifacts carry GitHub-native build provenance attestations. Verify a
-  downloaded artifact with `gh attestation verify <file> --repo omkhar/workcell`
-  (or the equivalent API), independent of whether the workflow artifact still
-  exists.
-- **Sigstore / Rekor transparency log.** The image, source bundle, Homebrew
-  formula asset, published image digest, checksums, build-input manifest,
-  control-plane manifest, builder-environment manifest, and both SBOMs are
-  signed with keyless Sigstore/Cosign. Those signatures are recorded in the
-  public Rekor transparency log, which is permanent — `cosign verify` and Rekor
-  lookups remain available long after any workflow artifact has aged out.
+`workcell-release-artifacts` contains the sealed 18-asset publication set.
+The final job publishes the same files as immutable GitHub release assets.
+Workcell keeps the workflow copy for seven days.
 
-See [provenance.md](provenance.md) and [github-workflows.md](github-workflows.md)
-for the full signing and attestation surface.
+### CI install artifact
+
+`workcell-ci-install-candidate` contains a temporary bundle, formula, and checksum data.
+The Apple Silicon install jobs use it during one CI run.
+Workcell keeps it for seven days.
+
+### Benchmark artifact
+
+`exec-guard-bench-results` contains the benchmark report.
+Workcell keeps it for 14 days, which covers the weekly schedule.
+
+The reviewed benchmark page is the durable baseline.
+See [syscall shim benchmarks](syscall-shim-benchmarks.md).
+
+### Fuzz artifacts
+
+The Go and Rust reproducer artifacts exist only after a crash.
+They contain inputs that reproduce that crash.
+
+`rust-fuzz-lockfile` contains the resolved fuzz lock file.
+Workcell keeps all three artifacts for 14 days.
+
+First, examine each crash in a private workspace.
+Remove credentials, personal data, and unrelated private content.
+Follow [`SECURITY.md`](../SECURITY.md#reporting) if the crash can affect security.
+Do not commit a sensitive reproducer before the fix or approved disclosure.
+
+See [fuzzing](fuzzing.md) for the triage process.
+
+### Security artifacts
+
+`zizmor-sarif` is a short-term copy of the workflow audit result.
+The `zizmor` job fails on each finding.
+GitHub code scanning does not receive this SARIF file.
+
+`scorecard-sarif` is a short-term copy of the Scorecard result.
+The workflow also sends that result to GitHub code scanning.
+
+Workcell keeps both convenience copies for five days.
+
+### Upstream refresh artifact
+
+`upstream-refresh-candidate` contains a patch, a diffstat, and metadata.
+It is advisory input for a host-side refresh PR.
+It is not release provenance.
+
+Workcell keeps the candidate for seven days.
+The scheduled workflow can publish a new candidate.
+The earlier artifact remains until GitHub deletes it or its retention time ends.
+
+## Verify a release after workflow artifacts expire
+
+Workflow artifacts are not the durable release record.
+Use these sources after a workflow artifact expires:
+
+- Download the immutable release assets and their Sigstore bundles.
+- Verify `SHA256SUMS` against its pinned release workflow identity.
+- Verify each downloaded release asset against the signed checksum list.
+- Use `gh attestation verify` for a subject that has a GitHub attestation.
+- Use `cosign verify` for the runtime image in GHCR.
+
+GitHub stores artifact attestations separately from workflow artifacts.
+GHCR stores the image signature and image attestations with the image.
+The public Rekor log records the Cosign signature entries.
+
+See [provenance](provenance.md) for exact verification commands.
+See [GitHub workflow design](github-workflows.md) for the workflow controls.

--- a/docs/retention-policy.md
+++ b/docs/retention-policy.md
@@ -96,9 +96,12 @@ The earlier artifact remains until GitHub deletes it or its retention time ends.
 Workflow artifacts are not the durable release record.
 Use these sources after a workflow artifact expires:
 
-- Download the immutable release assets and their Sigstore bundles.
-- Verify `SHA256SUMS` against its pinned release workflow identity.
-- Verify each downloaded release asset against the signed checksum list.
+- Download the required release-data assets and their matching Sigstore bundles.
+- Use Cosign and the matching bundle to verify each release-data asset against
+  the pinned release workflow identity.
+- Use the signed `SHA256SUMS` file to verify only the eight other release-data
+  assets that it names.
+- Do not check `SHA256SUMS` or a `.sigstore.json` file against that list.
 - Use `gh attestation verify` for a subject that has a GitHub attestation.
 - Use `cosign verify` for the runtime image in GHCR.
 

--- a/docs/retention-policy.md
+++ b/docs/retention-policy.md
@@ -96,14 +96,20 @@ The earlier artifact remains until GitHub deletes it or its retention time ends.
 Workflow artifacts are not the durable release record.
 Use these sources after a workflow artifact expires:
 
-- Download the required release-data assets and their matching Sigstore bundles.
-- Use Cosign and the matching bundle to verify each release-data asset against
-  the pinned release workflow identity.
+Reject the release if a required signature, identity, or digest check fails.
+
+- Download the required release-data assets, `SHA256SUMS`, and
+  `SHA256SUMS.sigstore.json`.
+- Use Cosign and `SHA256SUMS.sigstore.json` to verify `SHA256SUMS` against the
+  pinned release workflow identity.
 - Use the signed `SHA256SUMS` file to verify only the eight other release-data
   assets that it names.
 - Do not check `SHA256SUMS` or a `.sigstore.json` file against that list.
 - Use `gh attestation verify` for a subject that has a GitHub attestation.
 - Use `cosign verify` for the runtime image in GHCR.
+
+Use the exact tag, workflow identity, OIDC issuer, and source reference that
+the [provenance guide](provenance.md) specifies for each applicable check.
 
 GitHub stores artifact attestations separately from workflow artifacts.
 GHCR stores the image signature and image attestations with the image.

--- a/docs/retention-policy.md
+++ b/docs/retention-policy.md
@@ -36,8 +36,9 @@ The manifests bind build inputs, the control plane, the source bundle, and runti
 `workcell-release-install-candidate` contains the source bundle and Homebrew formula used by the macOS install jobs.
 Workcell keeps both artifacts for 90 days to support release review and incident checks.
 
-`workcell-release-artifacts` contains the sealed 18-asset publication set.
-The final job publishes the same files as immutable GitHub release assets.
+`workcell-release-artifacts` contains the sealed 18-asset workflow publication set.
+The final job publishes the same 18 files as immutable GitHub release assets.
+GitHub adds its own source-code and release-attestation entries to the release page.
 Workcell keeps the workflow copy for seven days.
 
 ### CI install artifact

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -641,7 +641,8 @@ func TestUninstallRemovesWorkcellStateWithoutRequiringGo(t *testing.T) {
 
 	for _, want := range []string{
 		"resolve_real_home",
-		"Preserved shared host packages installed outside Workcell.",
+		"Preserved ~/.config/workcell, shared host packages, and unrelated Colima profiles.",
+		"The uninstaller removes logs directly under /tmp or \\$TMPDIR if the current user owns them and their names match Workcell cleanup patterns.",
 		"shared host packages such as colima, docker, gh, git, and go",
 	} {
 		if !strings.Contains(script, want) {

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -23,9 +23,13 @@ Remove Workcell-owned local install links and managed host state:
 
 Preserved on purpose:
   - ~/.config/workcell/*
-  - user-specified debug log, file trace log, and transcript files
   - shared host packages such as colima, docker, gh, git, and go
   - unrelated Colima profiles and caches
+
+Log safety:
+  - A user-selected log path is not exempt from removal targets.
+  - The uninstaller removes a log directly under /tmp or $TMPDIR if the current user owns the log and its name matches a Workcell cleanup pattern.
+  - Use --dry-run, then copy required evidence outside each reported removal path.
 EOF
 }
 
@@ -455,5 +459,6 @@ else
   fi
 fi
 
-echo "Preserved ~/.config/workcell and any user-specified debug/file-trace/transcript files."
-echo "Preserved shared host packages installed outside Workcell."
+echo "Preserved ~/.config/workcell, shared host packages, and unrelated Colima profiles."
+echo "User-selected log paths are not exempt from removal targets."
+echo "The uninstaller removes logs directly under /tmp or \$TMPDIR if the current user owns them and their names match Workcell cleanup patterns."

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1754,6 +1754,8 @@ if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" "${ROOT_DI
   exit 1
 fi
 grep -q 'matching _store metadata' /tmp/workcell-uninstall-help.out
+grep -q 'A user-selected log path is not exempt from removal targets.' /tmp/workcell-uninstall-help.out
+grep -Fq "The uninstaller removes a log directly under /tmp or \$TMPDIR if the current user owns the log and its name matches a Workcell cleanup pattern." /tmp/workcell-uninstall-help.out
 
 if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" "${ROOT_DIR}/scripts/uninstall.sh" >/tmp/workcell-uninstall.out 2>&1; then
   echo "Expected scripts/uninstall.sh to succeed in a clean temporary HOME" >&2
@@ -1775,8 +1777,9 @@ test ! -e "${INSTALL_VERIFY_HOME}/Library/Caches/colima/workcell-token-handoff"
 test -e "${INSTALL_VERIFY_HOME}/.config/workcell/injection-policy.toml"
 test ! -e "/tmp/workcell-uninstall-verify.log.$$"
 test ! -e "/tmp/workcell-docker.verify-uninstall.$$"
-grep -q 'Preserved ~/.config/workcell and any user-specified debug/file-trace/transcript files.' /tmp/workcell-uninstall.out
-grep -q 'Preserved shared host packages installed outside Workcell.' /tmp/workcell-uninstall.out
+grep -q 'Preserved ~/.config/workcell, shared host packages, and unrelated Colima profiles.' /tmp/workcell-uninstall.out
+grep -q 'User-selected log paths are not exempt from removal targets.' /tmp/workcell-uninstall.out
+grep -Fq "The uninstaller removes logs directly under /tmp or \$TMPDIR if the current user owns them and their names match Workcell cleanup patterns." /tmp/workcell-uninstall.out
 
 if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" "${ROOT_DIR}/scripts/install.sh" --debug >/tmp/workcell-install-debug.out 2>&1; then
   echo "Expected scripts/install.sh --debug to succeed in a clean temporary HOME" >&2
@@ -1897,8 +1900,9 @@ fi
 
 test ! -e "${INSTALL_VERIFY_HOME}/.local/bin/workcell"
 test ! -e "${INSTALL_VERIFY_HOME}/.local/share/man/man1/workcell.1"
-grep -q 'Preserved ~/.config/workcell and any user-specified debug/file-trace/transcript files.' /tmp/workcell-uninstall-debug.out
-grep -q 'Preserved shared host packages installed outside Workcell.' /tmp/workcell-uninstall-debug.out
+grep -q 'Preserved ~/.config/workcell, shared host packages, and unrelated Colima profiles.' /tmp/workcell-uninstall-debug.out
+grep -q 'User-selected log paths are not exempt from removal targets.' /tmp/workcell-uninstall-debug.out
+grep -Fq "The uninstaller removes logs directly under /tmp or \$TMPDIR if the current user owns them and their names match Workcell cleanup patterns." /tmp/workcell-uninstall-debug.out
 
 CUSTOM_DEBUG_DIR="${INSTALL_VERIFY_HOME}/custom-workcell-debug"
 CUSTOM_DEBUG_DIR_REAL="$(go_verify_citools canonicalize-path "${CUSTOM_DEBUG_DIR}")"
@@ -1937,7 +1941,7 @@ if ! env -i HOME="${INSTALL_VERIFY_HOME}" PATH="${TRUSTED_HOST_PATH}" "${ROOT_DI
   cat /tmp/workcell-uninstall-custom-debug.out >&2
   exit 1
 fi
-grep -q 'Preserved shared host packages installed outside Workcell.' /tmp/workcell-uninstall-custom-debug.out
+grep -q 'Preserved ~/.config/workcell, shared host packages, and unrelated Colima profiles.' /tmp/workcell-uninstall-custom-debug.out
 
 INJECTION_POLICY_FIXTURE_ROOT="${BARRIER_VERIFY_ROOT}/injection-policy"
 INJECTION_STATE_ROOT="${INJECTION_POLICY_FIXTURE_ROOT}/xdg-state"


### PR DESCRIPTION
## Summary

- Rewrite install lifecycle, provenance, and retention guidance in ASD-STE100 Simplified Technical English.
- Record the published `v1.0.2` release evidence and the shipped version output defect.
- Preserve the historical `v1.0.0-rc.2` certification record that other audit documents cite.
- Clarify cleanup safety, exact-tag verification, GHCR authentication, attestation scope, and artifact retention.
- Correct the uninstaller log-safety messages and matching contract tests.
- Update incoming links to the generated release-asset verification heading.

## Review

- The Safety Reviewer, ASD-STE100 Editor, and Source Auditor accepted the exact diff.
- The independent Builder, Operator, and Minimalist review roles accepted the exact diff.
- The required exact-head Codex bot review will run before merge.

## Validation

- `./scripts/pre-merge.sh --profile pr-parity --allow-dirty`
- `bash ./scripts/check-doc-links.sh`
- `bash ./scripts/check-doc-support-matrix-fields.sh`
- `bash ./scripts/verify-operator-contract.sh`
- `bash ./scripts/verify-requirements-coverage.sh`
- `bash ./scripts/ci/job-docs.sh`
- Focused install, release, retention, and workflow tests
