### PR TITLE
Align validation and stability documentation with v1

### DIFF
--- a/docs/scenario-gaps.md
+++ b/docs/scenario-gaps.md
@@ -1,15 +1,14 @@
-# Scenario Test Coverage Gaps
+# Scenario test coverage gaps
 
-This page lists shipped surfaces that have less test coverage than the core
-secretless path.
+This page lists shipped interfaces that have less test coverage than the core secretless path.
 
 ## Highest-priority gaps
 
 ### Full macOS boundary proof
 
-The macOS Colima runtime boundary depends on Colima and
-Virtualization.framework. GitHub-hosted runners cannot prove this boundary.
-The local certification lane provides the current evidence:
+The macOS Colima runtime boundary uses Colima and Virtualization.framework.
+GitHub-hosted runners cannot prove this boundary.
+The local certification lane supplies the current evidence:
 
 ```bash
 ./scripts/run-scenario-tests.sh --secretless-only --certification-only
@@ -17,52 +16,56 @@ The local certification lane provides the current evidence:
 
 ### Authenticated tests for each provider
 
-`scripts/provider-e2e.sh` runs authenticated provider tests. It requires an
-Apple Silicon macOS host, Colima, and live provider credentials. CI does not run
-this path. Some documented authentication paths do not have complete live tests.
+`scripts/provider-e2e.sh` runs authenticated provider tests.
+It requires an Apple Silicon macOS host, Colima, and live provider credentials.
+CI does not run this path.
+Some documented authentication paths do not have complete live tests.
 
 ### Lower-assurance transitions
 
-No end-to-end scenario completes these checks:
+No end-to-end scenario does these checks:
 
-- Start a prompt-autonomy session and verify its audit fields through session
-  finalization.
+- Start a prompt-autonomy session and verify its final audit fields.
 - Change packages in a mutable container and verify the final assurance record.
 - Start a `breakglass` session and verify its posture and audit output.
+
+### Changed-file planner
+
+The changed-file planner has these open hardening tasks:
+
+- Harden JSON temporary state.
+- Move the later `go run` cache path into the controlled run root.
 
 ## Provider gaps
 
 ### Codex
 
-- No end-to-end scenario changes rule mutability and verifies the final audit
-  record.
-- No live scenario completes the host-side publication handoff from a managed
-  session.
+- No end-to-end scenario changes rule mutability and verifies the final audit record.
+- No live scenario completes host publication from a managed session.
 
 ### Claude
 
-- No authenticated scenario imports MCP state and verifies the runtime state.
+- No authenticated scenario imports MCP state and verifies runtime state.
 - No end-to-end scenario changes prompt autonomy and verifies its audit label.
 
 ### Gemini
 
-- No end-to-end scenario reuses cached Gemini OAuth and completes a provider
-  request.
-- No end-to-end scenario combines Vertex credentials with `gcloud_adc` and
-  completes a provider request.
+- No end-to-end scenario reuses cached Gemini OAuth and completes a provider request.
+- No end-to-end scenario combines Vertex credentials with `gcloud_adc` and completes a provider request.
 - No end-to-end scenario verifies folder-trust restoration after `breakglass`.
 
 ### Copilot and Antigravity
 
-- Copilot live staged-token certification stays outside repo-required CI.
+- Copilot live staged-token certification remains outside repo-required CI.
 - Antigravity has no supported adapter, authentication input, bootstrap path,
   control plane, scenario evidence, or live certification.
 - Complete Antigravity live certification before any support claim.
 
 ## Current evidence boundary
 
-Repository invariants, smoke tests, deterministic scenarios, reproducibility
-checks, and release preflight cover the core path. The remaining gaps apply to
-live provider authentication, local macOS proof, and lower-assurance changes.
+Repository invariants, smoke tests, deterministic scenarios, reproducibility checks,
+and release preflight cover the core path.
+The remaining gaps apply to live provider authentication, local macOS proof,
+lower-assurance changes, and planner hardening.
 Copilot has deterministic adapter evidence and a live certification gate.
 Antigravity remains unsupported.

--- a/docs/stability-contract.md
+++ b/docs/stability-contract.md
@@ -1,194 +1,192 @@
-# Stability Contract
+# Stability contract
 
-This document defines Workcell's versioned v1 compatibility surface for the
-1.0 release-candidate gate, including the exit-code contract shared across the
-Rust launcher, the Go binaries, and the shell entrypoint. Candidate and release
-identity remain recorded separately in the readiness review; this contract does
-not imply that live 1.0 certification is complete.
+This page defines the public compatibility contract for Workcell v1.
+Workcell published `v1.0.2` on 2026-08-05 as its first 1.0 release.
 
-**Contract version: 1.** The machine-checkable companion to this document is
-`policy/public-contract.toml`, enforced by `workcell-citools
-validate-public-contract` (`internal/metadatautil.CheckPublicContract`). It
-asserts that every exit code and output-line prefix documented below is
-actually emitted somewhere in the source tree, and that the session-record
-field list and injection-policy table list below exactly match the
-`SessionRecord`/`SessionExport` JSON shape and the injection-policy table
-whitelist in code.
+These files contain the machine-readable contract:
 
-"Stable" means the shape follows the deprecation policy below. "Experimental"
-means it may change or be removed. For v1, every workflow declared
-`support = "supported"` and `target_state = "retain"` in
-`policy/operator-contract.toml` is stable at its canonical syntax unless this
-document explicitly classifies part of it as experimental. Absence from this
-document and the operator contract is not a stability promise.
+- [`policy/public-contract.toml`](../policy/public-contract.toml) lists the public primitives.
+- [`policy/operator-contract.toml`](../policy/operator-contract.toml) lists the stable operator workflows.
+- [`policy/v1-contract-freeze.toml`](../policy/v1-contract-freeze.toml) contains the v1 compatibility floor.
+
+`workcell-citools validate-public-contract` checks the public primitives.
+`verify-operator-contract.sh` checks the operator workflows.
+Release preflight compares the v1 floor with each earlier version in Git history.
+
+The contract version is `1`.
+
+`Stable` means that this deprecation policy applies.
+`Experimental` interfaces have no compatibility guarantee.
+Workcell makes no compatibility promise for an unlisted public interface.
 
 ## Deprecation policy
 
-From the first release candidate that contains this freeze through the final
-1.0 release and subsequent v1 releases, Workcell follows
-[semantic versioning](https://semver.org). The stable surfaces enumerated in
-this document carry a compatibility guarantee within the major version: the
-exit-code contract, the machine-readable output-line prefixes, the
-session-record/export field set, and the injection-policy table (enforced by
-`policy/public-contract.toml` and the immutable
-[`policy/v1-contract-freeze.toml`](../policy/v1-contract-freeze.toml) baseline),
-together with the stable `scripts/workcell` CLI flags and subcommands documented
-under [CLI stability](#cli-stability) (enforced via
-`policy/operator-contract.toml` and the same baseline). Release preflight
-compares that floor with every prior version in Git history, so a coordinated
-edit of the live inventory and current floor cannot erase an earlier v1
-commitment. The guarantee:
+Workcell follows semantic versioning for stable v1 interfaces.
+These rules apply:
 
-- **No breaking change to a stable surface ships in a patch or minor release.**
-  A new field or prefix may be *added*; an existing one is not renamed, removed,
-  or given a changed meaning except across a major version bump.
-- **Deprecations are announced before removal.** A stable surface slated for
-  removal is first marked deprecated in [`CHANGELOG.md`](../CHANGELOG.md) and,
-  where it has a runtime presence, emits a documented deprecation notice. It
-  keeps working for at least one subsequent minor release, and its removal lands
-  only in a major version bump.
-- **Experimental surfaces** (labeled "Experimental" here, and anything absent
-  from this document) carry no such guarantee and may change or be removed in any
-  release.
-- **A security fix may override this policy** when a stable surface is itself the
-  vulnerability; any such change is called out in [`CHANGELOG.md`](../CHANGELOG.md)
-  and [`SECURITY.md`](../SECURITY.md).
+- A patch or minor release must not break a stable interface.
+- Workcell permits compatible additions to fields, prefixes, flags, and commands.
+- Workcell must announce a deprecation in [`CHANGELOG.md`](../CHANGELOG.md).
+- A deprecated runtime interface must show a documented deprecation notice.
+- The interface must work for at least one later minor release.
+- Workcell removes the interface only in a new major release.
 
-Workcell is currently in single-maintainer release mode
-([`SECURITY.md`](../SECURITY.md#supported-versions)), so only the latest release
-receives fixes; track it and read [`CHANGELOG.md`](../CHANGELOG.md) for
-deprecations before upgrading.
+Workcell permits an exception only when a stable interface causes a security vulnerability.
+Workcell must record that exception in `CHANGELOG.md` and [`SECURITY.md`](../SECURITY.md).
+
+Workcell uses a single-maintainer release process.
+Only the latest release gets security fixes.
+Read `CHANGELOG.md` before you upgrade.
 
 ## Exit-code contract
 
-The canonical convention across every entrypoint:
-
 | Code | Meaning |
-|------|---------|
-| 0 | success |
-| 2 | usage / precondition error (missing or unknown command, wrong arity, bad option, unmet precondition) |
-| 1 | runtime error (an operation attempted and failed) |
-| 3 | colima profile status: no matching profile (`workcell-hostutil colima-status`) |
-| 124 | colima operation timed out (mirrors GNU `timeout`) |
-| 126 | launcher: fail-closed policy block, or target not executable (`EACCES`) |
-| 127 | launcher: target not found (`ENOENT`) |
-| 128+N | launcher: supervised child terminated by signal N |
-| 0–255 | launcher: passthrough of the supervised child's own exit status |
+| ---: | --- |
+| `0` | The operation succeeded or made a documented clean skip. |
+| `1` | The operation started and failed at runtime. |
+| `2` | The command, option, argument, or precondition is not valid. |
+| `3` | `workcell-hostutil colima-status` did not find the requested profile. |
+| `124` | A Colima operation timed out. |
+| `126` | The launcher blocked execution or the target is not executable. |
+| `127` | The launcher did not find the target. |
+| `128+N` | Signal `N` terminated the supervised child process. |
 
-Per surface:
+The launcher returns the supervised child exit status without a change.
+That child status can equal a launcher-owned code.
+Use the diagnostic and command context to identify the source.
 
-- **Go binaries** (`workcell-citools`, `workcell-hostutil`, `workcell-colimautil`,
-  `workcell-runtimeutil`): usage/precondition errors exit **2**, runtime errors
-  exit **1**. The exit code is carried through the error chain by
-  `internal/cliexit.ExitCodeError{Code}`. Deterministic exit-code tests live in
-  each binary's `main_test.go`.
-- **Shell entrypoint** (`scripts/workcell`): usage/precondition failures exit
-  **2** (the dominant convention); a small set of host-precondition failures
-  exit **1** (see the recorded exception below). Runs under `set -euo pipefail`.
-- **Rust launcher** (`workcell-launcher`): fail-closed authorization refusals and
-  non-executable targets exit **126**; missing targets exit **127**; a supervised
-  child's exit status or signal (`128+N`) is passed through unchanged.
+The Go command tools use exit code `2` for usage and precondition errors.
+They use exit code `1` for runtime errors.
+`internal/cliexit.ExitCodeError` carries the code through the error chain.
+
+The `scripts/workcell` command uses exit code `2` for most precondition errors.
+It runs with `set -euo pipefail`.
 
 ### Recorded intentional exceptions
 
-These are deliberate and are documented rather than "fixed", because changing
-them would break existing shell↔Go parity or the launcher's fail-closed
-posture:
+Exit code `126` has two documented meanings.
+It can report a policy block or an `EACCES` execution error.
+Read the launcher diagnostic to identify the cause.
 
-- **Launcher 126 is overloaded** — it covers both a fail-closed policy block and
-  an exec `EACCES` (not executable). Both match the shell convention that 126
-  means "command found but not runnable". A caller distinguishes them by the
-  launcher's stderr diagnostic, not the code.
-- **Shell 1-vs-2 split for host preconditions** — "missing trusted host tool"
-  exits **1** while "missing host working directory" exits **2**. This split is
-  frozen for byte-for-byte parity with the Go translations
-  (`internal/publishpr/host_exec.go`) and is guarded by `internal/testkit`'s
-  bash↔Go parity harness.
+The shell uses two codes for host preconditions.
+If Workcell cannot find a trusted host tool, it returns exit code `1`.
+If Workcell cannot find the specified host working directory, it returns exit code `2`.
+
+This split preserves shell and Go parity.
+The parity tests in `internal/testkit` enforce it.
 
 ## CLI stability
 
-The user-facing CLI is `scripts/workcell`. The canonical inventory is
-`policy/operator-contract.toml`; in summary, the stable surface includes:
+`policy/operator-contract.toml` is the exact stable workflow inventory.
+`policy/v1-contract-freeze.toml` stores each frozen canonical command.
 
-- Core flags: `--agent`, `--target`, `--mode`, `--workspace`, `--agent-autonomy`,
-  `--dry-run`, `--prepare` / `--prepare-only`, and the introspection flags
-  `--doctor` / `--inspect` / `--logs` / `--auth-status` / `--gc`, plus
-  `--repair-profile`, `--cache-profile`, `--session-workspace`, and `--version`.
-- Subcommands: `publish-pr`; `support-bundle`;
-  `session <start|attach|send|stop|list|show|delete|logs|timeline|diff|export|verify>`;
-  `auth <init|set|unset|status>`; `policy <show|validate|diff>`; and `why`.
+The stable inventory includes these command groups:
 
-Stable syntax does not promote a target's support tier. The `aws-ec2-ssm` and
-`gcp-vm` target names remain stable inputs to preview-only, launch-blocked
-workflows as defined by the host support matrix.
+- managed Codex, Claude, Copilot, and Gemini launch commands
+- strict, development, and build modes
+- autonomy, target, workspace, prepare, repair, dry-run, and cache options
+- `publish-pr` and `support-bundle`
+- `auth`, `policy`, and `why`
+- `session` start, control, inspection, export, verification, and deletion commands
+- doctor, inspect, log, authentication-status, cleanup, and version options
 
-Experimental or explicitly gated (may change; already marked in `--help`):
+Use the policy file for the exact syntax.
+Do not infer stable syntax from this summary.
 
-- `--agent antigravity` (recognized as planned but unsupported).
-- `--ui gui` (not implemented; fails closed).
-- backend behavior and support status for the preview targets selected by
-  `aws-ec2-ssm` and `gcp-vm`; the selector spellings themselves are stable.
-- `--mode breakglass` (gated behind a dated `--ack-breakglass`),
-  `--allow-arbitrary-command` (behind `--ack-arbitrary-command`),
-  `--allow-control-plane-vcs` (behind `--ack-control-plane-vcs`), and
-  `--allow-repo-mcp` (behind a dated `--ack-repo-mcp`).
+Stable selector syntax does not change a target support tier.
+The host support matrix controls target support.
+Workcell supports strict Colima only on macOS arm64.
+Workcell supports Docker Desktop compatibility only on macOS arm64.
+The `aws-ec2-ssm` and `gcp-vm` selector names are stable.
+These remote targets remain preview-only and launch-blocked.
+
+The `--version` syntax is stable.
+The `v1.0.2` bundle reports `workcell v1.0.1`.
+The command reads the first changelog entry in that bundle.
+Do not use this output to authenticate the release tag.
+Verify the signed release tag, signed checksum, and bundle digest.
+
+Workcell does not guarantee compatibility for these preview interfaces:
+
+- Workcell does not implement `--ui gui`. The value fails closed.
+- Workcell does not guarantee backend behavior for `aws-ec2-ssm` or `gcp-vm`.
+
+`--agent antigravity` is a recognized but unsupported value.
+It fails closed.
+
+These higher-trust options require explicit acknowledgement:
+
+- `--mode breakglass` requires a dated `--ack-breakglass` value.
+- `--allow-arbitrary-command` requires a dated `--ack-arbitrary-command` value.
+- `--allow-control-plane-vcs` requires `--ack-control-plane-vcs`.
+- `--allow-repo-mcp` requires a dated `--ack-repo-mcp` value.
+
+Workcell rejects each option without its acknowledgement.
+These options reduce assurance or expose an additional control surface.
+Use an option only for its documented exception.
 
 ## Stable machine-readable output
 
-These lines are consumed by tests, CI, or other tooling and are treated as
-contract-like `key=value` / structured output:
+The public contract freezes these output prefixes:
 
-- session `show` metadata: `target_kind=`, `target_provider=`, `workspace=`,
-  `assurance=`, and peers.
-- support matrix: `host_os=`, `host_arch=`, `support_matrix_status=`.
-- `publish_pr_url=` (from `publish-pr`).
-- `mutation score: NN.NN% (k/t killed)` and `surviving mutants: …`.
-- audit digest lines: `record_digest=`, `prev_digest=`.
-- `scenario-manifest` TSV rows (tab-delimited), with ordered columns `id`,
-  `test_file`, `requires_credentials`, `lane`, `platform`,
-  `validation_tier`, and `manual`.
+| Prefix | Source |
+| --- | --- |
+| `host_os=` | Host support matrix and `scripts/workcell` |
+| `host_arch=` | Host support matrix and `scripts/workcell` |
+| `support_matrix_status=` | Host support matrix and `scripts/workcell` |
+| `provider_bootstrap_` | Authentication policy and `scripts/workcell` |
+| `target_kind=` | Session records and `scripts/workcell` |
+| `target_provider=` | Session records and `scripts/workcell` |
+| `workspace=` | Session records and `scripts/workcell` |
+| `assurance=` | Session records and `scripts/workcell` |
+| `publish_pr_url=` | PR publication output |
+| `mutation score:` | Mutation result output |
+| `surviving mutants:` | Mutation result output |
+| `record_digest=` | Audit output from `scripts/workcell` |
+| `prev_digest=` | Audit output from `scripts/workcell` |
+| `egress_enforcement=` | Egress output from `scripts/workcell` |
+| `session_verify=` | `session verify` output |
+| `key_id=` | `session verify` output |
+| `head_digest=` | `session verify` output |
 
-The full stable output-line prefix set enforced by `policy/public-contract.toml`
-`[output_lines].prefixes`:
+The `scenario-manifest` TSV schema also has a stable column order:
 
-| Prefix | Emitted by |
-|--------|------------|
-| `host_os=` | `internal/host/supportmatrix`, `scripts/workcell` |
-| `host_arch=` | `internal/host/supportmatrix`, `scripts/workcell` |
-| `support_matrix_status=` | `internal/host/supportmatrix`, `scripts/workcell` |
-| `provider_bootstrap_` | `internal/authpolicy`, `scripts/workcell` |
-| `target_kind=` | `internal/host/sessions`, `scripts/workcell` |
-| `target_provider=` | `internal/host/sessions`, `scripts/workcell` |
-| `workspace=` | `internal/host/sessions`, `scripts/workcell` |
-| `assurance=` | `internal/host/sessions`, `scripts/workcell` |
-| `publish_pr_url=` | `internal/publishpr` (via `internal/shellproto`) |
-| `mutation score:` | `cmd/workcell-citools` |
-| `surviving mutants:` | `cmd/workcell-citools` |
-| `record_digest=` | `scripts/workcell` |
-| `prev_digest=` | `scripts/workcell` |
-| `egress_enforcement=` | `scripts/workcell` |
-| `session_verify=` | `internal/sessionctl` (`session verify`) |
-| `key_id=` | `internal/sessionctl` (`session verify`) |
-| `head_digest=` | `internal/sessionctl` (`session verify`) |
+1. `id`
+2. `test_file`
+3. `requires_credentials`
+4. `lane`
+5. `platform`
+6. `validation_tier`
+7. `manual`
 
-The complete set of `key=` prefixes in the `session show --text` summary is
-enforced separately, by set-equality against `SessionShowLines`
-(`policy/public-contract.toml` `[session_show_prefixes]`).
+`policy/public-contract.toml` also freezes the complete `session show --text` prefix set.
+The validator compares that set with `SessionShowLines`.
 
 ## Injection-policy supported tables
 
-`internal/injection` accepts exactly five top-level tables in an injection
-policy TOML document: `documents`, `ssh`, `credentials`, `network`
-(single-bracket tables), and `copies` (the one supported `[[array-of-table]]`).
-Any other top-level table name is rejected. `[network]` carries only the egress
-`allow_endpoints`/`deny_endpoints` lists and cannot change the network-policy
-mode; see `docs/injection-policy.md` for the per-table schema and the egress
-mechanism.
+An injection policy accepts these five top-level tables:
+
+- `documents`
+- `ssh`
+- `credentials`
+- `copies`
+- `network`
+
+`copies` is the only supported array-of-table.
+The other four names use single tables.
+
+The policy root also accepts these scalar keys:
+
+- `version`
+- `includes`
+
+The `[network]` table accepts `allow_endpoints` and `deny_endpoints`.
+It cannot change the network-policy mode.
+See [Injection policy](injection-policy.md) for each table schema.
 
 ## Durable session-record fields
 
-`internal/host/sessions.SessionRecord`'s JSON field set (`session show`,
-`session export`, and the on-disk session record file):
+`SessionRecord` uses these stable JSON fields:
 
 `version`, `session_id`, `profile`, `target_kind`, `target_provider`,
 `target_id`, `target_assurance_class`, `runtime_api`, `workspace_transport`,
@@ -201,13 +199,13 @@ mechanism.
 `final_assurance`, `workspace_control_plane`, `workspace_repo_mcp`,
 `bootstrap_id`, `image_ref`.
 
-`SessionExport` (`session export`) wraps this in `session` and adds
-`audit_records`.
+`SessionExport` contains these stable fields:
+
+- `session`
+- `audit_records`
 
 ## Internal Go APIs
 
-All Go code lives under `internal/`, so it is not importable outside the module;
-"stable" here means a stable intra-module contract. The most depended-upon is
-`internal/cliexit` (the exit-code carrier used by every CLI). Treat other
-`internal/` package APIs as implementation detail that may change with their
-callers.
+Internal Go APIs are not part of the public v1 contract.
+Code outside this module cannot import packages under `internal/`.
+Workcell does not guarantee compatibility for those APIs.

--- a/docs/validation-scenarios.md
+++ b/docs/validation-scenarios.md
@@ -1,286 +1,297 @@
-# Validation Scenarios
+# Validation scenarios
 
-Workcell uses several validation layers. No single test proves the full
-boundary or release story by itself.
+Workcell uses more than one validation layer.
+No single test proves the complete runtime boundary or release process.
 
-Use this page with:
+Use these files as the sources of truth:
 
-- [`policy/operator-contract.toml`](../policy/operator-contract.toml) for the
-  normative operator workflow inventory
-- [docs/use-case-matrix.md](use-case-matrix.md) for what is currently covered
-- [docs/requirements-validation.md](requirements-validation.md) for the
-  machine-checked requirement-to-evidence mapping
-- [docs/scenario-gaps.md](scenario-gaps.md) for what is still missing
+- [`policy/operator-contract.toml`](../policy/operator-contract.toml) defines the supported operator workflows.
+- [`policy/requirements.toml`](../policy/requirements.toml) maps requirements to evidence.
+- [`tests/scenarios/manifest.json`](../tests/scenarios/manifest.json) lists the scenarios.
+- [Use-case matrix](use-case-matrix.md) shows the tested use cases.
+- [Scenario gaps](scenario-gaps.md) lists known evidence gaps.
 
-## Traceability anchors
+## Validation layers
 
-[`tests/scenarios/manifest.json`](../tests/scenarios/manifest.json) is the
-canonical scenario index.
+The main local commands have different purposes.
 
-Use these anchors when checking release-facing claims:
+| Command | Purpose |
+| --- | --- |
+| `./scripts/dev-quick-check.sh` | Run the fast format, lint, contract, and unit checks. |
+| `./scripts/build-and-test.sh` | Run host-native tests. Use `--docker` for the pinned validator image. |
+| `./scripts/container-smoke.sh` | Build the runtime image and test the container boundary. |
+| `./scripts/verify-invariants.sh` | Test launcher, policy, profile, and host-boundary invariants. |
+| `./scripts/verify-reproducible-build.sh` | Compare two runtime builds. |
+| `./scripts/validate-repo.sh` | Run the selected repository validation profile. |
+| `./scripts/pre-merge.sh` | Plan and run a local validation profile. |
+| `./scripts/verify-release-bundle.sh` | Rebuild and compare the release bundle during release preflight. |
 
-- auth and resolver posture:
-  `shared/auth-commands`, `shared/auth-status`,
-  `shared/claude-resolver-launcher`, `shared/codex-resolver-launcher`
-- lower-assurance mode claims: `shared/assurance-dry-run`
-- compat target selection and fail-closed diagnostics: `shared/compat-target-dry-run`
-- preview AWS remote VM diagnostics and certification gate:
-  `shared/aws-remote-vm-dry-run`, `shared/aws-ec2-ssm-launch-smoke`
-- preview GCP remote VM diagnostics and certification gate:
-  `shared/gcp-remote-vm-dry-run`, `shared/gcp-vm-launch-smoke`
-- local runtime certification smoke: `shared/agent-launch-smoke`
-- host publication handoff and main-only PR-base safeguards: `shared/publish-pr`
-- host-side session inventory and control plus detached workspace-mode
-  remediation: `shared/session-commands`
-- persistent cache-plane contract checks: `shared/assurance-dry-run`
-- canonical preview-only remote VM contract:
-  `internal/remotevm/contract_test.go`,
-  `internal/remotevm/fake_target_test.go`,
-  `internal/remotevm/conformance_test.go`
-- roadmap gate and evidence-map traceability for managed workstations,
-  enterprise evidence, and host expansion:
-  `scripts/verify-requirements-coverage.sh`,
-  `scripts/verify-operator-contract.sh`
-- planned provider-parity roadmap traceability:
-  `ROADMAP.md`, `docs/provider-matrix.md`,
-  `docs/provider-bootstrap-matrix.md`
-- Claude hook coverage: `claude-swe/hook-parametric`
-- supported GitHub-hosted macOS release window:
-  `scripts/verify-github-macos-release-test-runners.sh`
-- Gemini Vertex supplemental `gcloud_adc` and allowlist behavior:
-  `scripts/verify-invariants.sh`
+`pre-merge.sh` has these profiles:
 
-## Repo-required deterministic checks
+- `repo-core` runs deterministic repository validation.
+- `pr-parity` mirrors the required checks for a PR that targets `main`.
+- `release-preflight` adds the release checks.
 
-These are the checks that must stay green for normal repo validation. They run
-without provider credentials and must not depend on live Colima or cloud
-state:
+The full release-bundle comparison runs only in `release-preflight` and the
+`Release` workflow.
+The invariant checks still inspect the release-bundle entrypoint in other profiles.
 
-- `./scripts/dev-quick-check.sh`
-- `./scripts/build-and-test.sh` (host-native by default; `--docker` reruns repo validation inside the pinned CI validator container from a disposable snapshot)
-- `./scripts/container-smoke.sh`
-- `./scripts/verify-invariants.sh`
-- `./scripts/verify-release-bundle.sh` (release-preflight only: it runs in
-  the `release-preflight` validate profile and in `release.yml`, not in the
-  standard PR lane)
-- `./scripts/verify-reproducible-build.sh`
-- `./scripts/pre-merge.sh` profiles:
-  - `repo-core` for deterministic repo-required validation
-  - `pr-parity` for the local mirror of required `main`-based PR checks
-  - `release-preflight` for the additional mirrored release-facing lanes
-- `./scripts/repo-publish-pr.sh` for `main`-based PR publication after fresh
-  local `pr-parity` evidence exists
-  - reviewed, live-certified adapter support PRs that cannot be split use
-    `--label approved-large-certified-adapter` for local parity and
-    `--approved-large-certified-adapter` during host publication
+Use `./scripts/repo-publish-pr.sh` to publish a PR that targets `main`.
+The wrapper requires fresh `pr-parity` evidence.
+For an approved large adapter PR, use both approved adapter flags:
 
-They cover repo shape, runtime contracts, smoke behavior, and reproducibility.
-The G0a1a1 canonical-build-environment unit covers `validate-repo`,
-`dev-quick-check`, and the hosted-controls verifier. These three roots
-explicitly source `scripts/lib/canonical-build-env.sh`.
+- Use `--label approved-large-certified-adapter` during local parity.
+- Use `--approved-large-certified-adapter` during host publication.
 
-The gate rejects every nonempty ambient shell-identifier `GO*` and `CGO*`
-variable except exact `GOENV=off`, exact `GOWORK=off`, empty `GOFLAGS`, and
-caller-selected `GOPATH`, `GOCACHE`, and `GOMODCACHE` storage paths. Passive
-hosted-runner tool-cache aliases matching exact
-`GOROOT_<major>_<minor>_{X64,ARM64}` grammar are not Go tool inputs and are
-removed before any descendant runs; near-matches still fail closed. The gate also
-rejects ambient external compiler/tool selectors, `NETRC`, `GCM_INTERACTIVE`,
-nonempty `BASH_ENV` or `ENV`, every retained `BASH_FUNC_*` entry,
-noncanonical shell-identifier `GIT_*` overrides, and system/global Git config
-and attributes. Invalid identifiers exposed by the shell fail generically
-before indirect expansion; raw invalid names hidden by the shell and not
-recognized as tool variables are outside this unit. Set-empty `BASH_ENV` and
-`ENV` are removed so ordinary Bash descendants cannot consume them. The three
-allowed storage paths and their contents are explicitly lower assurance; exact
-tool and build-input identity remains a separate certification dependency.
-Production/default graph checks remain untagged.
+## Scenario inventory
 
-G0a1a1 does not yet claim complete CI/release workflow-root closure. G0a1a2
-must close canonical-state propagation through trusted-entrypoint children,
-including forged-sentinel behavior. G0a1b must close the shared validate job's
-containerized archive boundary and early token lifecycle. G0a1c must close
-`ci-plan` and its direct `pre-merge` caller with resident-only base selection,
-no implicit network or authentication, and fail-closed changed-file
-collection. G0a2 must wire and test the remaining build/release helpers,
-including `build-and-test`, pin checks and updates, smoke and manifest
-generation, invariant/release-bundle/reproducibility checks, and
-upstream-release and `verify-build-input-manifest` verification. After G0a2,
-the direct `job-pr-shape`, `job-docs`, `job-mutation`, `job-fuzz`,
-`check-workflows`, and `check-release-tag-signature` roots remain for G0b.
-Release certification stays blocked until these dependencies land.
+The manifest contains 22 scenarios:
 
-The gate begins only after the shell process starts. Its startup-state claim
-therefore requires the reviewed privileged shebang, which ignores `BASH_ENV`,
-`ENV`, and imported functions, and clears `CDPATH` during root discovery.
-Launching a root through an arbitrary interpreter is outside this unit. The
-gate also does not constrain arbitrary direct `go` invocations, authenticate
-the local repository's Git administrative metadata, or make
-candidate-controlled scripts trusted. The whole local administrative plane,
-including repository config, refs, index and worktree state, hooks, object and
-alternates storage, replace/graft/shallow data, and `.git/info/attributes`,
-remains an immutable-tree, controller, and scan dependency. It also does not
-authenticate later `PATH` resolution, tool binaries, or the three allowed
-storage roots and their module/build-cache contents. Ambient Go selector
-variables for module proxy, checksum, and auth behavior are rejected, but
-G0a1a does not authenticate the resulting network policy or credential files
-selected through `HOME` (including `.netrc`). General process networking
-variables and the contents reachable through the three allowed storage paths
-also remain outside this unit. Beyond arbitrary-interpreter startup-code surfaces,
-shell semantic and tracing state such as `SHELLOPTS`, `BASHOPTS`,
-`BASH_XTRACEFD`, and descendant `CDPATH` remain a G0a2a hygiene dependency.
+- 17 secretless, repo-required scenarios
+- two secretless certification scenarios
+- three credentialed certification scenarios
 
-They also now cover canonical requirement traceability, host-side policy
-inspection and explainability, host-side detached session inventory, control,
-logs/timeline, clean-base diff/export behavior, and operator-contract parity.
-They also now carry the canonical preview-only `remote_vm` contract through the
-deterministic `internal/remotevm` fake target and shared conformance harness,
-the explicit `docker-desktop` compat target through deterministic
-backend-selection, state-root-routing, and fail-closed diagnostics, and the
-preview-only `aws-ec2-ssm` and `gcp-vm` remote VM targets through deterministic
-broker-plan diagnostics and fail-closed live gating. Planning gates for managed
-workstations, enterprise evidence, and host expansion are covered as
-requirements and documentation traceability, not as runtime support scenarios.
+The repo-required runner uses this command:
 
-`./scripts/validate-repo.sh` runs the repo-required scenario tier through:
+```bash
+./scripts/run-scenario-tests.sh --repo-required
+```
 
-- `./scripts/run-scenario-tests.sh --repo-required`
+The runner uses one job by default.
+This setting prevents races on shared host state.
+Set `WORKCELL_SCENARIO_JOBS` above `1` only when lower determinism is acceptable.
 
-That scenario runner executes serially by default so repo-required checks do
-not race on shared host-side state. Set `WORKCELL_SCENARIO_JOBS` above `1`
-only for explicit local debugging where you accept lower determinism.
+### Main traceability anchors
 
-## Local certification smoke
+Use these scenario identifiers for release claims:
 
-These checks are still valuable, but they are intentionally not part of the
-repo-required validation path because they depend on a live runtime boundary.
+- `shared/auth-commands` and `shared/auth-status` test authentication.
+- `shared/codex-resolver-launcher` tests the Codex resolver.
+- `shared/claude-resolver-launcher` tests the Claude resolver.
+- `shared/policy-commands` tests policy commands.
+- `shared/assurance-dry-run` tests assurance labels.
+- `shared/compat-target-dry-run` tests Docker Desktop selection.
+- `shared/aws-remote-vm-dry-run` tests AWS preview plans.
+- `shared/gcp-remote-vm-dry-run` tests GCP preview plans.
+- `shared/agent-launch-smoke` tests the local runtime launch.
+- `shared/docker-desktop-launch-smoke` tests the Docker Desktop launch.
+- `shared/publish-pr` tests PR publication.
+- `shared/publish-github-release` tests the release entrypoint and signed-tag gate.
+- `shared/home-control-plane-manifest` tests home control-plane files.
+- `shared/session-commands` tests session operations.
+- `shared/copilot-session-dry-run` tests the Copilot token handoff.
+- `shared/shellproto-lib` tests shell protocol inputs.
+- `shared/install-lifecycle` tests install, update, rollback, and isolated cleanup logic.
+- `claude-swe/hook-parametric` tests the Claude command hook.
 
-- `./scripts/run-scenario-tests.sh --secretless-only --certification-only`
+The remote VM contract also has deterministic Go tests:
 
-Today that secretless certification tier includes:
+- `internal/remotevm/contract_test.go`
+- `internal/remotevm/fake_target_test.go`
+- `internal/remotevm/conformance_test.go`
 
-- `shared/agent-launch-smoke` for local macOS Colima prepare-only and
-  provider-version smoke on the managed path
-- `shared/docker-desktop-launch-smoke` for the explicit
-  `local_compat/docker-desktop/compat` path on healthy macOS Docker Desktop
-  hosts with Docker seccomp available; this is lower assurance than the strict
-  Colima path and does not assert AppArmor/SELinux daemon parity
+Requirements checks cover planned managed workstations, enterprise evidence,
+and host expansion.
+These checks prove traceability only.
+They do not make these paths supported runtime targets.
 
-Credentialed certification smoke is in the `provider-e2e` lane and requires
-`--all` plus the relevant live credentials:
+## Canonical build environment
 
-- `./scripts/run-scenario-tests.sh --all --certification-only`
+Four reviewed scripts source `scripts/lib/canonical-build-env.sh`:
 
-That credentialed tier includes:
+- `scripts/dev-quick-check.sh`
+- `scripts/validate-repo.sh`
+- `scripts/verify-github-hosted-controls.sh`
+- `scripts/check-public-contract.sh`
 
-- `shared/aws-ec2-ssm-launch-smoke` for the credentialed
-  `remote_vm/aws-ec2-ssm/compat` preview boundary against a reviewed
-  SSM-managed EC2 target
-- `shared/gcp-vm-launch-smoke` for the credentialed
-  `remote_vm/gcp-vm/compat` preview boundary against a reviewed
-  IAP-reachable Compute Engine target without an external NAT IP
-- `shared/copilot-provider-e2e` for the credentialed Copilot CLI adapter path:
-  explicit `copilot_github_token` staging, managed development shell, and a
-  non-destructive authenticated `copilot -p` probe
+The direct-entrypoint mutation test covers the first three scripts.
+The validation-entrypoint tests cover the public-contract script and its caller.
 
-Copilot CLI has deterministic adapter, auth, bootstrap, policy, and smoke
-coverage in the repo-required lane. Live provider-authenticated certification
-of a non-destructive `copilot -p` launch with staged credentials remains a
-maintainer pre-signing gate for changes that promote or materially alter the
-Copilot support claim, and stays separate from repo-required validation because
-it needs live provider credentials. Antigravity remains planned/fail-closed and
-must add the same deterministic and live evidence before claiming support.
+The helper rejects nonempty shell-visible ambient `GO*` and `CGO*` variables.
+It permits only these Go values and storage paths:
 
-Remote VM live smoke remains certification-only as well, but it is currently a
-provider-e2e preview gate documented in
-[`docs/aws-ec2-ssm-preview.md`](aws-ec2-ssm-preview.md) and
-[`docs/gcp-vm-preview.md`](gcp-vm-preview.md) rather than a repo-required
-scenario. Set `WORKCELL_AWS_EC2_SSM_TARGET_ID` and
-`WORKCELL_AWS_EC2_SSM_REGION` before running the AWS smoke. Set
-`WORKCELL_GCP_VM_TARGET_ID`, `WORKCELL_GCP_VM_ZONE`, and
-`WORKCELL_GCP_VM_PROJECT` before running the GCP smoke.
+- exact `GOENV=off`
+- exact `GOWORK=off`
+- empty `GOFLAGS`
+- caller-selected `GOPATH`, `GOCACHE`, and `GOMODCACHE`
 
-Certification smoke is where local boundary proof belongs. It should stay
-available and documented, but it must not be the reason repo validation fails
-on a machine that lacks the live runtime prerequisites.
+GitHub runners can set passive tool-cache aliases.
+The helper accepts only `GOROOT_<major>_<minor>_{X64,ARM64}` names.
+It removes each accepted alias before a child process starts.
+It rejects a near-match.
 
-When a change introduces or materially changes a supported end-to-end
-workflow, backend, support-tier claim, or certification-only validation path,
-this certification tier becomes a pre-signing gate: complete the relevant live
-smoke successfully before signing the commit that claims the new support.
+The helper also rejects these ambient inputs:
 
-## Documentation example coverage
+- external compiler and package-tool selectors
+- `NETRC` and `GCM_INTERACTIVE`
+- nonempty `BASH_ENV` and `ENV`
+- each retained `BASH_FUNC_*` entry
+- noncanonical `GIT_*` overrides
+- system and global Git configuration
+- system and global Git attributes
 
-Release-facing examples are expected to map to existing automated evidence even
-when the repo does not add a dedicated new scenario for each page.
+The privileged shebang ignores Bash startup files and imported functions.
+The entrypoints also clear `CDPATH` during root discovery.
+Run each entrypoint directly.
+This guarantee does not cover an arbitrary interpreter.
 
-| Guide | Primary evidence |
-|---|---|
-| `README.md` install, launch, and session snippets | `scripts/verify-invariants.sh`, `scripts/container-smoke.sh`, `tests/scenarios/shared/test-session-commands.sh`, `cmd/workcell-hostutil/main_test.go` |
-| `docs/getting-started.md` | `scripts/verify-invariants.sh`, `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh` |
-| `docs/examples/quickstart-codex.md` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-codex-resolver-launcher.sh`, `tests/scenarios/shared/test-publish-pr-dry-run.sh` |
-| `docs/examples/quickstart-claude.md` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-claude-resolver-launcher.sh`, `tests/scenarios/shared/test-publish-pr-dry-run.sh` |
-| `docs/examples/quickstart-copilot.md` | `tests/scenarios/shared/test-agent-launch-smoke.sh`, `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-policy-commands.sh`, `scripts/container-smoke.sh`; live `scripts/provider-e2e.sh --agent copilot` remains certification-only |
-| `docs/examples/quickstart-gemini.md` | `tests/scenarios/shared/test-auth-status.sh` for the staged `gemini_env` path and `tests/scenarios/shared/test-publish-pr-dry-run.sh` for the host-side publication steps; OAuth plus supplemental `gemini_projects` and `gcloud_adc` remain manual provider-e2e validation paths |
-| `docs/provider-bootstrap-matrix.md` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-policy-commands.sh`, `tests/scenarios/shared/test-codex-resolver-launcher.sh`, `tests/scenarios/shared/test-claude-resolver-launcher.sh`, `scripts/container-smoke.sh` |
-| `workcell session start --agent copilot` | `tests/scenarios/shared/test-copilot-session-dry-run.sh` for detached-session launch metadata, dry-run token redaction, and non-dry-run Copilot token handoff assembly/consumption cleanup; live provider-authenticated Copilot CLI certification remains covered by certification-only provider-e2e |
-| `docs/examples/enterprise-claude-setup.md` | `tests/scenarios/shared/test-auth-commands.sh`, `tests/scenarios/shared/test-auth-status.sh`, `tests/scenarios/shared/test-policy-commands.sh`, `tests/scenarios/shared/test-publish-pr-dry-run.sh` |
+The gate does not scrub `SHELLOPTS`, `BASHOPTS`, or `BASH_XTRACEFD`.
+It also does not scrub descendant `CDPATH`.
+A child shell can consume this state.
 
-There is no Antigravity quickstart row until the matching adapter, credential
-path, scenario evidence, and live certification land.
+This gate starts after the shell process starts.
+It does not authenticate these inputs:
 
-## Manual authenticated smoke
+- an arbitrary direct `go` command
+- the local Git administrative plane
+- the worktree, index, refs, hooks, or object storage
+- `.git/info/attributes`
+- later `PATH` resolution or tool binaries
+- caller-selected Go storage paths and their contents
+- network policy or credential files under `HOME`, including `.netrc`
+- general process-network variables
 
-`./scripts/provider-e2e.sh` is the reviewed path for provider-authenticated
-checks. It is deliberately separate from default CI and from the repo-required
-scenario tier so the default path stays deterministic and secretless.
+The three caller-selected Go storage paths are explicitly lower assurance.
+The gate does not prove tool identity or build-input identity.
+Release preflight uses separate checks for those properties.
 
-Use it when you need to verify:
+## Local certification
 
-- real provider login reuse
-- provider-specific auth selection
-- injected MCP or project-registry behavior
-- provider UX that only shows up with a live account
-- Copilot or future Antigravity CLI behavior that depends on live staged
-  provider credentials
+Local certification uses a live runtime boundary.
+It is not part of the repo-required lane.
 
-## GitHub CI vs local boundary proof
+Run the secretless certification scenarios with:
 
-GitHub-hosted CI proves:
+```bash
+./scripts/run-scenario-tests.sh --secretless-only --certification-only
+```
 
-- repo validation and workflow hygiene
-- smoke behavior in the reviewed runtime image
-- reproducibility and release-preflight logic
-- bundle install/uninstall and Homebrew install/uninstall on GitHub-hosted
-  Apple Silicon `macos-26` and `macos-15`
-- signing and attestation logic on tagged releases
+This tier contains:
 
-GitHub-hosted CI does not prove the full macOS Colima boundary. That remains a
-local exercise.
+- `shared/agent-launch-smoke` for `macos/arm64/local_vm/colima/strict`
+- `shared/docker-desktop-launch-smoke` for `macos/arm64/local_compat/docker-desktop/compat`
 
-Workcell now also keeps a machine-checked local parity inventory in:
+The Docker Desktop path has lower assurance.
+Its test requires a healthy Apple Silicon macOS Docker Desktop host.
+It also requires Docker seccomp support.
+It does not prove AppArmor or SELinux parity with Colima.
+
+Run credentialed certification with:
+
+```bash
+./scripts/run-scenario-tests.sh --all --certification-only
+```
+
+This command runs all five certification scenarios.
+Three scenarios require credentials:
+
+- `shared/aws-ec2-ssm-launch-smoke`
+- `shared/gcp-vm-launch-smoke`
+- `shared/copilot-provider-e2e`
+
+The AWS test requires a reviewed SSM-managed EC2 target.
+Set `WORKCELL_AWS_EC2_SSM_TARGET_ID` and `WORKCELL_AWS_EC2_SSM_REGION`.
+
+The GCP test requires a reviewed IAP-reachable Compute Engine target.
+Set `WORKCELL_GCP_VM_TARGET_ID`, `WORKCELL_GCP_VM_ZONE`, and
+`WORKCELL_GCP_VM_PROJECT`.
+
+The AWS and GCP targets remain preview-only and launch-blocked.
+Their certification tests do not promote them to supported targets.
+
+The Copilot test stages `copilot_github_token`.
+Set `WORKCELL_E2E_COPILOT_GITHUB_TOKEN` for this test.
+It starts a managed development shell.
+It then runs a non-destructive authenticated `copilot -p` request.
+
+Complete the applicable live test before you sign a commit that changes a support claim.
+This rule applies to a new or materially changed end-to-end workflow or backend.
+It also applies to a materially changed certification-only validation path.
+
+Antigravity remains unsupported and fails closed.
+Do not claim support before deterministic evidence and live certification exist.
+
+## Manual authenticated tests
+
+Use `./scripts/provider-e2e.sh` for authenticated provider tests.
+This path is separate from deterministic CI.
+
+Use it to test:
+
+- provider login reuse
+- provider-specific authentication selection
+- injected MCP state
+- project-registry behavior
+- provider behavior that requires a live account
+
+Do not put provider credentials in the workspace or repository configuration.
+Use the injection policy or the reviewed provider test path.
+
+## Documentation evidence
+
+`policy/operator-contract.toml` maps each supported workflow to its documents and evidence.
+`./scripts/verify-operator-contract.sh` checks those mappings.
+[Requirements validation](requirements-validation.md) describes the requirement checks.
+
+Live Copilot certification remains outside the repo-required lane.
+Gemini OAuth, `gemini_projects`, and `gcloud_adc` remain manual provider tests.
+Antigravity has no quickstart because Workcell does not support it.
+
+## GitHub and local proof
+
+GitHub-hosted CI proves these properties:
+
+- repository validation and workflow hygiene
+- runtime-image smoke behavior
+- reproducible builds and release-preflight logic
+- bundle installation and launcher-link removal on `macos-26` and `macos-15`
+- Homebrew installation and removal on `macos-26` and `macos-15`
+- signing and attestation logic for a release tag
+
+GitHub-hosted CI does not prove the strict macOS Colima boundary.
+Use local certification for that proof.
+
+These files define local and hosted lane parity:
 
 - [`policy/workflow-lane-policy.json`](../policy/workflow-lane-policy.json)
 - [`policy/workflow-lanes.json`](../policy/workflow-lanes.json)
 
-Use `./scripts/ci-plan.sh` to see which mirrored lanes a given local
-`pre-merge` profile will execute and which selected lanes remain GitHub-only.
+Use `./scripts/ci-plan.sh` to show the selected local and hosted lanes.
 
-### G0a1c resident changed-file planning
+### Changed-file planning limits
 
-`ci-plan.sh` never fetches. It prefers exact resident `origin/<base>` state, accepts local fallback only after two absence checks, and requires exactly one resident merge base. The collector requires a root `.git` directory and rejects common-directory redirection. It binds the physical worktree and Git directory, scrubs inherited shell/index/glob authority, and rejects nonregular or split-index state, shallow graphs, hidden flags, conversion filters, present gitlinks, and unsafe tracked ancestry. It builds a zero-stat flat index under its run root before worktree inspection, so cached stats are not trusted and the real index is not mutated. Every present stage-0 regular tracked file is raw-hashed with conversions disabled; `text`, `eol`, `ident`, and `working-tree-encoding` cannot hide byte mismatches. Worktree/config behavior, replacement objects, grafts, lazy fetch, and local/base attributes are pinned or inspected explicitly; valid UTF-8 changed paths remain NUL-framed until JSON encoding, while other path bytes fail closed. Worktree, index, or untracked `.gitignore` case variants stop planning. Only `HEAD` rules are honored, never `.git/info/exclude`. Tracked, staged, deleted, and ordinary untracked paths remain visible. Only absent gitlinks are accepted. This scoped guarantee assumes static repository state; the planner is not wholly hermetic. `pr-parity` binds the publishable tree/status after planning and rechecks before evidence, but does not lock Git administration. JSON/temp-state hardening and the later `go run` cache path remain follow-ups. Explicit paths still bypass automatic discovery.
+`ci-plan.sh` does not fetch.
+It uses resident `origin/<base>` state when that state exists.
+It uses a local base only after two absence checks.
+It requires one resident merge base.
 
-## Credential placement rule
+The planner requires a root `.git` directory.
+It rejects common-directory redirection and shallow graphs.
+The planner rejects nonregular or split-index state.
+It also rejects hidden flags, conversion filters, present gitlinks, and unsafe ancestry.
 
-Provider credentials belong in the injection policy or the reviewed manual
-provider-e2e path. They do not belong in the workspace, repo config, or
-ambient host passthrough.
+The planner creates a separate zero-stat index.
+It does not change the real index.
+It hashes each present stage-0 regular file with conversions disabled.
+It keeps valid UTF-8 paths in NUL-framed data until JSON encoding.
+It rejects other path bytes.
+
+The planner honors only the `HEAD` version of `.gitignore`.
+It rejects worktree, index, and untracked case variants of that file.
+It keeps tracked, staged, deleted, and normal untracked paths visible.
+
+This guarantee assumes that repository state does not change during planning.
+The planner is not fully hermetic.
+Explicit paths bypass automatic changed-file discovery.
+`pr-parity` rechecks the tree and status before it writes evidence.
+It does not lock Git administrative state.
 
 ## Out of scope
 
-These are not treated as equivalent to the default path:
+Do not treat these paths as equal to the default path:
 
 - host-native GUI execution
-- arbitrary container commands outside the explicit managed `development` or `--allow-arbitrary-command` paths
+- arbitrary container commands outside the managed development path
 - `breakglass`
-- whole-home or socket passthrough
+- whole-home mounts
+- host socket or credential-state passthrough

--- a/internal/testkit/canonical_build_env_test.go
+++ b/internal/testkit/canonical_build_env_test.go
@@ -911,42 +911,53 @@ func TestCanonicalBuildEnvironmentScopeAndReachability(t *testing.T) {
 	}
 	text := string(content)
 	for _, want := range []string{
-		"G0a1a1 canonical-build-environment",
-		"three roots",
+		"Four reviewed scripts",
 		"`scripts/lib/canonical-build-env.sh`",
+		"`scripts/check-public-contract.sh`",
+		"direct-entrypoint mutation test",
+		"validation-entrypoint tests",
 		"exact `GOENV=off`",
 		"exact `GOWORK=off`",
 		"`GOPATH`, `GOCACHE`, and `GOMODCACHE`",
 		"`GOROOT_<major>_<minor>_{X64,ARM64}`",
-		"removed before any descendant runs",
-		"near-matches still fail closed",
+		"child process starts",
+		"rejects a near-match",
 		"explicitly lower assurance",
-		"G0a1a2",
-		"G0a1b",
-		"G0a1c",
-		"G0a2a",
-		"G0a2",
-		"G0b",
-		"arbitrary direct `go` invocations",
-		"whole local administrative plane",
+		"arbitrary direct `go` command",
+		"local Git administrative plane",
 		"`.git/info/attributes`",
 		"credential files",
-		"`HOME` (including `.netrc`)",
+		"under `HOME`, including `.netrc`",
 		"`PATH`",
 		"tool binaries",
 		"`BASH_ENV`",
-		"clears `CDPATH`",
+		"clear `CDPATH`",
 		"`CGO*`",
 		"`BASH_FUNC_*`",
 		"`SHELLOPTS`",
 		"`BASHOPTS`",
 		"`BASH_XTRACEFD`",
 		"descendant `CDPATH`",
-		"resident-only base selection",
-		"Release certification stays blocked",
+		"does not fetch",
+		"resident `origin/<base>`",
+		"separate zero-stat index",
+		"does not lock Git administrative state",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("validation scenario documentation must contain %q", want)
+		}
+	}
+	for _, stale := range []string{
+		"G0a1a1",
+		"G0a1a2",
+		"G0a1b",
+		"G0a1c",
+		"G0a2",
+		"G0b",
+		"Release certification stays blocked",
+	} {
+		if strings.Contains(text, stale) {
+			t.Fatalf("validation scenario documentation contains stale milestone text %q", stale)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Rewrite the validation, stability, and scenario-gap documents in Simplified Technical English.
- Align support, certification, release, and planner claims with shipped behavior.
- Replace stale milestone assertions with durable documentation checks.

## Validation

- `./scripts/pre-merge.sh --profile pr-parity --allow-dirty`
- Adversarial review: STE editor, source auditor, and assurance reviewer accepted the exact diff.

## Notes

- The first parity run found a transient Colima file-mode race in a bind-mounted Copilot test stub.
- A direct container-smoke rerun passed.
- A fresh full parity run also passed and wrote the publication evidence.
