### PR TITLE
Align hosted installation evidence with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,11 +191,21 @@ jobs:
             echo "Unable to locate extracted bundle root" >&2
             exit 1
           fi
+          test ! -e "${HOME}/.local/bin/workcell"
+          test ! -L "${HOME}/.local/bin/workcell"
+          test ! -e "${HOME}/.local/share/man/man1/workcell.1"
+          test ! -L "${HOME}/.local/share/man/man1/workcell.1"
           "${bundle_dir}/scripts/install.sh"
           "${HOME}/.local/bin/workcell" --help >/dev/null
+          test -e "${HOME}/.local/bin/workcell"
+          test -L "${HOME}/.local/bin/workcell"
+          test -e "${HOME}/.local/share/man/man1/workcell.1"
+          test -L "${HOME}/.local/share/man/man1/workcell.1"
           HOME="${HOME}" "${bundle_dir}/scripts/uninstall.sh"
           test ! -e "${HOME}/.local/bin/workcell"
+          test ! -L "${HOME}/.local/bin/workcell"
           test ! -e "${HOME}/.local/share/man/man1/workcell.1"
+          test ! -L "${HOME}/.local/share/man/man1/workcell.1"
 
       - name: Verify Homebrew formula install
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -700,11 +700,21 @@ jobs:
             echo "Unable to locate extracted bundle root" >&2
             exit 1
           fi
+          test ! -e "${HOME}/.local/bin/workcell"
+          test ! -L "${HOME}/.local/bin/workcell"
+          test ! -e "${HOME}/.local/share/man/man1/workcell.1"
+          test ! -L "${HOME}/.local/share/man/man1/workcell.1"
           "${bundle_dir}/scripts/install.sh"
           "${HOME}/.local/bin/workcell" --help >/dev/null
+          test -e "${HOME}/.local/bin/workcell"
+          test -L "${HOME}/.local/bin/workcell"
+          test -e "${HOME}/.local/share/man/man1/workcell.1"
+          test -L "${HOME}/.local/share/man/man1/workcell.1"
           HOME="${HOME}" "${bundle_dir}/scripts/uninstall.sh"
           test ! -e "${HOME}/.local/bin/workcell"
+          test ! -L "${HOME}/.local/bin/workcell"
           test ! -e "${HOME}/.local/share/man/man1/workcell.1"
+          test ! -L "${HOME}/.local/share/man/man1/workcell.1"
 
       - name: Verify Homebrew formula install
         env:

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ or local sockets.
   deterministic evidence, and live certification together
 - GitHub-hosted CI verifies repo shape, reproducibility, release posture, and
   secretless runtime behavior
-- GitHub-hosted CI verifies bundle install/uninstall and Homebrew
-  install/uninstall on Apple Silicon `macos-26` and `macos-15` on pushes to
-  `main`, manual dispatch, and PRs labeled `approved-heavy-ci`
+- On Apple Silicon `macos-26` and `macos-15`, hosted CI verifies bundle
+  installation, launcher-link removal, and man-page-link removal. It also
+  verifies Homebrew installation and formula removal.
 - the real macOS Colima boundary is still a local operator exercise because
   GitHub-hosted Linux runners cannot prove it
 - the canonical host support boundary lives in

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,8 +105,8 @@ The final review confirmed these results:
 2. Workcell shipped the A1 through A6 boundary controls.
 3. Workcell certified strict Colima and Docker Desktop compatibility on macOS.
 4. Workcell supported Codex, Claude Code, Copilot CLI, and Gemini.
-5. Workcell proved install, upgrade-in-place, rollback, uninstall,
-   `workcell --gc`, and support bundle operations.
+5. Workcell shipped install, update, rollback, uninstall, `workcell --gc`, and
+   support-bundle workflows with documented evidence limits.
 6. Workcell used mutation tests, signed history, provenance, and immutable
    release controls.
 7. Workcell shipped the in-repository user and assurance documents.
@@ -418,11 +418,10 @@ strongest vendors now publish; these items deepen that lead.
 
 ### Track B: Supply Chain And Release Assurance
 
-CI is already strong: all 72 action references SHA-pinned, workflows start
-from `permissions: {}`, reproducible builds verified on amd64 and arm64,
-keyless Sigstore signing, SBOMs, and GitHub attestations. These items close
-the remaining gaps between that posture and the level enterprises will ask a
-security-boundary product to prove.
+CI requires a full commit SHA for each action reference.
+Workflows start from `permissions: {}`.
+CI also verifies reproducible amd64 and arm64 builds.
+Releases use keyless Sigstore signatures, SBOMs, and GitHub attestations.
 
 - **B1 (complete, M):** SLSA v1.0 gap analysis published in the provenance docs
 - **B2 (post-1.0, M):** dual-control release approval — deferred by the
@@ -469,11 +468,8 @@ security-boundary product to prove.
 
 ### Track D: Code Health And Consolidation
 
-The Go tree is in good shape (28.8k source lines, 82% test-to-code ratio,
-three direct dependencies). The concentration risks are a 2,288-line
-monolithic Rust interception library, a 8,910-line launcher script, a
-9,131-line `verify-invariants.sh`, and widespread helper duplication across
-120 shell scripts (for example, 25 separate `cleanup()` definitions).
+The main code-health risks are large implementation files and repeated shell helpers.
+Use generated, checked metrics before you add a numeric inventory here.
 
 - **D1 (complete, S):** language-boundary doctrine — Rust for the shim, Go for
   logic, shell as thin glue
@@ -528,8 +524,9 @@ contract and proven day-two operations.
   G4 evidence identities are versioned
 - **G2 (complete, M):** `workcell support-bundle` ships with documented
   redaction rules
-- **G3 (complete, M):** install, upgrade, uninstall, rollback, and `--gc` have
-  repeatable CI evidence plus published-release local certification
+- **G3 (complete, M):** install, update, uninstall, rollback, and `--gc` ship
+  with documented evidence limits. Hosted bundle checks prove installation
+  and link removal, not complete uninstall behavior.
 - **G4 (complete, S):** the cross-lens 1.0 readiness gate records fixed
   statuses, exact candidate/evidence identities, every explicit scope decision,
   and no unresolved P0/P1 findings

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -104,8 +104,11 @@ uses this support bundle to collect evidence and escalates through
 - active development happens on `main`
 - the latest tagged release is the primary install target
 - security fixes land on `main`; there are no long-lived release branches
-- CI and tagged-release install/uninstall verification currently run only on
+- hosted install checks in CI and tagged-release workflows currently run only on
   GitHub-hosted Apple Silicon `macos-26` and `macos-15`
+- these checks prove bundle installation, launcher-link removal,
+  man-page-link removal, Homebrew installation, and formula removal
+- they do not prove complete bundle uninstall behavior
 - other macOS versions are outside the current install verification matrix
 
 For major behavior changes, check [CHANGELOG.md](CHANGELOG.md) and

--- a/docs/enterprise-rollout.md
+++ b/docs/enterprise-rollout.md
@@ -1,169 +1,169 @@
-# Enterprise Rollout Today
+# Enterprise rollout
 
 This page describes the current Workcell rollout model for teams.
 
-Workcell is local-first today:
+Workcell uses a local-first model.
+It supports Apple Silicon macOS hosts only.
+The primary product interface starts a local runtime from the host.
+Workcell does not supply a managed cloud worker or remote worker.
+It also does not supply a central policy, inventory, or analytics service.
 
-- supported hosts are Apple Silicon macOS only
-- the primary product surface is a host-launched local runtime
-- there is no Workcell-managed cloud or remote worker plane yet
-- there is no centralized Workcell policy, inventory, or analytics service yet
+Use [Enterprise evidence baseline](enterprise-evidence-baseline.md) for the current evidence map.
 
-The current rollout model is to distribute reviewed host-side files and let
-operators launch Workcell locally inside the shared VM-plus-container boundary.
-Use [enterprise-evidence-baseline.md](enterprise-evidence-baseline.md) as the
-current evidence map for architecture, support boundaries, audit retention,
-release provenance, and evaluation-only control mappings.
+## Evidence authority
 
-## Traceability note
+Use these sources for rollout decisions:
 
-- supported-host and release-window claims map to the validated install matrix
-- auth, policy, session, and host-publication claims map to the named anchors
-  in [validation-scenarios.md](validation-scenarios.md)
-- the "not centralized yet" bullets below are support-boundary statements, not
-  claims of automated proof
+- [`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv) defines host support.
+- [`policy/operator-contract.toml`](../policy/operator-contract.toml) defines supported workflows.
+- [Validation scenarios](validation-scenarios.md) identifies test evidence.
+- [Retention policy](retention-policy.md) defines hosted workflow artifact retention.
+- [Provenance](provenance.md) defines release verification.
 
-## What Workcell standardizes today
+A support statement does not prove an automated control.
+Use the named evidence for each claim.
 
-Workcell already gives teams one shared contract for:
+## Current team contract
 
-- the runtime boundary and runtime profiles
-- provider-home seeding and control-plane masking
-- the host-side injection-policy format
-- host-side auth, policy, and explainability commands
-- detached session records and host-side session control
-- host-side publication and release provenance
+Workcell supplies one team contract for these items:
 
-Those pieces are implemented in the product. They do not depend on a separate
-central administration plane.
+- runtime boundaries and runtime profiles
+- provider-state input and control-plane masks
+- host injection policies
+- host authentication and policy commands
+- detached session records and session control
+- host PR publication and release provenance
 
-## What stays host-local today
+These items do not require a central Workcell service.
 
-These parts are still local to each operator host:
+## Host-local state
+
+These items remain on each operator host:
 
 - Workcell installation and updates
-- `~/.config/workcell/` policy files and included fragments
-- managed credential material referenced by `workcell auth`
-- `~/.local/state/workcell/targets/local_vm/colima/<profile>/sessions/`
-  durable session records
-- local launch history, retained debug logs, transcripts, and file traces
+- policy files under `~/.config/workcell/`
+- managed credential files that `workcell auth` uses
+- session records under the selected Workcell state root
+- launch history, debug logs, transcripts, and file traces
 
-If you want team-wide consistency today, distribute reviewed host-side files
-through your existing host configuration workflow rather than expecting
-Workcell to act as a central policy service.
+Use your existing host-configuration system to distribute reviewed files.
+Do not use Workcell as a central policy service.
 
-## Recommended rollout shape
+## Recommended rollout
 
-### 1. Standardize the support boundary
+### 1. Define the support boundary
 
-Roll out Workcell only to supported Apple Silicon macOS hosts and treat the
-current GitHub-hosted install matrix as the tested release window, not as proof
-for all macOS variants.
+Install Workcell only on supported Apple Silicon macOS hosts.
+Treat the hosted macOS matrix as a tested release window.
+Do not use that matrix as proof for all macOS versions.
 
-### 2. Distribute reviewed host-side files
+### 2. Distribute reviewed files
 
-Use your existing device-management, bootstrap, or dotfile workflow to place:
+Use your device-management or bootstrap system to place these files:
 
-- reviewed Workcell policy fragments under `~/.config/workcell/`
-- org-wide instruction docs referenced from `[documents]`
-- reviewed credential files referenced from `[credentials]`
-- reviewed SSH config and identity paths referenced from `[ssh]`
+- Workcell policy fragments under `~/.config/workcell/`
+- organization instructions that `[documents]` entries reference
+- credential files that `[credentials]` entries reference
+- SSH configuration and identity files that `[ssh]` entries reference
 
-Keep repo-local provider control files as imported inputs, not as the live
-control plane.
+Keep repository provider-control files as imported inputs.
+Do not use those files as the live control plane.
 
-### 3. Prefer direct staged auth inputs, with reviewed Codex host reuse when needed
+### 3. Use staged authentication
 
-Direct staged credentials are still the main supported auth path today.
+Use direct staged credentials as the primary authentication path.
 
-- Codex: `codex_auth`
-- Claude: `claude_auth`, `claude_api_key`, and `claude_mcp`
-- Gemini: `gemini_env`, `gemini_oauth`, and `gemini_projects`
-- Gemini Vertex supplement: `gcloud_adc`
+- Codex uses `codex_auth`.
+- Claude uses `claude_auth`, `claude_api_key`, and `claude_mcp`.
+- Gemini uses `gemini_env`, `gemini_oauth`, and `gemini_projects`.
+- Gemini Vertex can also use `gcloud_adc`.
+- Copilot uses `copilot_github_token`.
 
-Reviewed Codex host-auth reuse through `codex-home-auth-file` is also
-supported on the same staged host-owned path when a team wants to reuse the
-existing `~/.codex/auth.json` cache file instead of copying it into a separate
-managed location.
+Codex can reuse the reviewed host file that `codex-home-auth-file` selects.
+This path stages only the selected `auth.json` file.
 
-Current caveats:
+The Claude macOS resolver records operator intent but fails closed.
+No supported export path exists.
 
-- the built-in Claude macOS resolver scaffold can record intent, but it remains
-  fail-closed until a supported export path exists
-- `gcloud_adc` is supplemental to Vertex config, not a standalone Gemini auth
-  mode
-- GitHub Copilot CLI uses explicit `copilot_github_token` staging only; do not
-  distribute host Copilot provider state (`~/.copilot`,
-  `~/.config/github-copilot`, `~/.cache/github-copilot`), host GitHub CLI auth,
-  keychain/browser exports, `GH_TOKEN`, `GITHUB_TOKEN`, or broad provider tokens
-  as Workcell inputs
-- Google Antigravity CLI remains planned and unsupported; do not distribute its
-  host provider home, keychain/browser exports, ambient CLI auth, or broad
-  provider tokens as Workcell inputs
+`gcloud_adc` supplements Gemini Vertex configuration.
+It is not a separate Gemini authentication mode.
 
-See [injection-policy.md](injection-policy.md) for the current by-provider auth
-maturity summary and
-[provider-bootstrap-matrix.md](provider-bootstrap-matrix.md) for the explicit
-repo-required versus manual bootstrap tiers.
+Do not distribute Copilot provider state, GitHub CLI authentication, keychain data, or ambient tokens.
+Antigravity is unsupported and fails closed.
+Do not distribute Antigravity provider state or credentials.
 
-The Copilot enterprise rollout gate must document organization policy and
-license prerequisites, token ownership, audit expectations,
-telemetry/content-capture posture, and the exact staged-token handoff before a
-team adopts it. The Antigravity gate must do the same before that planned
-provider can claim support.
+See [Injection policy](injection-policy.md) for the exact input schema.
+See [Provider bootstrap matrix](provider-bootstrap-matrix.md) for test tiers.
 
-Strict-mode Copilot support default-denies provider telemetry, OpenTelemetry,
-and content-capture environment variables. Future Antigravity support must
-preserve that posture. Any content-capture enablement must be lower assurance,
-explicitly acknowledged, audited, and covered by deterministic tests.
+Before a Copilot enterprise rollout, document these items:
 
-### 4. Scope shared GitHub and SSH inputs deliberately
+- organization policy and license requirements
+- token ownership
+- audit requirements
+- telemetry and content-capture policy
+- the exact staged-token path
 
-When teams want shared GitHub CLI or SSH behavior:
+Strict Copilot mode rejects provider telemetry and content-capture environment variables.
+Mark each exception as lower assurance.
+Document each exception.
+Acknowledge each exception.
+Audit each exception.
+Test each exception.
 
-- scope `github_hosts` and `github_config` with `providers = [...]`
-- keep SSH material in the `[ssh]` section rather than ad hoc copies
-- review MCP state explicitly instead of trusting ambient workspace config
+### 4. Limit shared GitHub and SSH inputs
 
-This keeps shared inputs least-privilege and visible in policy.
+Set `providers = [...]` on shared `github_hosts` and `github_config` inputs.
+Put SSH inputs in the `[ssh]` table.
+Review MCP state before you stage it.
 
-### 5. Keep publication on the host
+These steps keep shared inputs visible and limited.
 
-The supported publication path remains:
+### 5. Publish from the host
 
-1. run the provider inside Workcell
-2. review the resulting changes
-3. run local `pr-parity`, then publish from the host with
-   `./scripts/repo-publish-pr.sh`
+Use this publication sequence:
 
-Do not treat in-session git publication as equivalent to the host-side release
-and signing model.
+1. Run the provider inside Workcell.
+2. Review the changes.
+3. Run local `pr-parity`.
+4. Run `./scripts/repo-publish-pr.sh` on the host.
 
-## What is not centralized yet
+Do not publish from the managed session.
+Host publication preserves the reviewed signature and policy path.
 
-Workcell does not yet provide:
+## Interfaces that are not central
 
-- centralized policy distribution inside the product
-- org-wide RBAC, SSO, or SCIM features
-- centralized session inventory or usage analytics
-- a preserved-boundary GUI or IDE client path
-- remote or cloud-spawned workspaces
+Workcell does not supply these interfaces:
 
-Those are roadmap items, not part of the supported contract today.
+- central policy distribution
+- organization RBAC, SSO, or SCIM
+- central session inventory or usage analytics
+- a supported GUI or IDE client
+- supported remote or cloud workspaces
 
-## Assurance notes for rollout decisions
+These interfaces are outside the current support contract.
 
-- GitHub-hosted CI proves repo shape, smoke behavior, reproducibility, release
-  posture, and install/uninstall behavior on GitHub-hosted Apple Silicon
-  `macos-26` and `macos-15`.
-- GitHub-hosted CI does not prove the full local macOS Colima boundary.
-- The strongest boundary claim still depends on local validation and operator
-  discipline on supported hosts.
-- Lower-assurance paths such as `development`, `breakglass`, prompt autonomy,
-  package mutation, and host-side transcript capture should stay explicit in
-  rollout guidance.
+## Assurance limits
 
-## Related docs
+GitHub CI proves repository validation, smoke behavior, reproducibility, and release posture.
+
+On `macos-26` and `macos-15`, hosted CI proves these install properties:
+
+- bundle installation
+- launcher-link removal
+- man-page-link removal
+- Homebrew installation and formula removal
+
+Hosted CI does not prove complete bundle uninstall behavior.
+It also does not prove the strict local Colima boundary.
+
+Local certification supplies the current strict-boundary evidence.
+Follow the certification procedure.
+Record the result.
+
+Document each lower-assurance path in team instructions.
+These paths include development mode, breakglass, prompt autonomy, package changes, and host transcripts.
+
+## Related documents
 
 - [Getting started](getting-started.md)
 - [Injection policy](injection-policy.md)

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -99,6 +99,7 @@ It then compares the archive digest with the expected digest.
 It creates source-dependent manifests and the amd64 image from the extracted tree.
 It creates the formula from the verified archive digest.
 The native arm64 image job builds from the checked-out release tag.
+
 The workflow also creates the builder-environment manifest, image-digest file, software bills of materials, signatures, and checksums.
 The release job seals the assets in one workflow artifact.
 The final job publishes that sealed artifact.

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -1,233 +1,222 @@
-# GitHub Workflow Design
+# GitHub workflow design
 
-Workcell keeps the workflow set narrow and reviewable. GitHub automation should
-reinforce the runtime boundary and release posture, not replace them. Artifact
-retention for these workflows is documented and drift-checked in
-[retention-policy.md](retention-policy.md).
+Workcell uses a reviewed GitHub workflow set.
+The workflows support the runtime boundary and release process.
+They do not replace the runtime boundary.
 
-Workcell also keeps a machine-checked lane inventory so local parity and
-GitHub-only behavior do not drift silently:
+[Retention policy](retention-policy.md) defines workflow artifact retention.
 
-- [`policy/workflow-lane-policy.json`](../policy/workflow-lane-policy.json)
-  declares each expanded workflow lane's profiles, authority, and local mode
-- [`policy/workflow-lanes.json`](../policy/workflow-lanes.json) is the
-  generated manifest derived from the live workflow YAML plus that policy
-- `./scripts/verify-workflow-lanes.sh` fails if the manifest drifts
-- `./scripts/ci-plan.sh` explains which mirrored lanes apply locally and which
-  selected lanes remain GitHub-only for a given profile, event, labels, and
-  changed files
-- its fail-closed resident Git discovery rejects hidden/split-index state, shallow graphs, unsafe ancestry, mutable ignores, and present gitlinks; it neutralizes cached stats, ignores `.git/info/exclude`, and bypasses built-in conversions with raw bytes
+## Lane inventory
 
-That inventory underpins the local `./scripts/pre-merge.sh` profiles and the
-repo-local `./scripts/repo-publish-pr.sh` publication gate. For
-publication-grade `pr-parity`, `pre-merge.sh` buffers the complete local
-dispatch list before execution, then runs each selected local script once in
-declared `local_order`; a lane that reads standard input cannot consume or skip
-later dispatcher records, and `--skip-repro` is rejected.
-For the narrow certified-adapter exception, local parity evidence must be
-generated with `./scripts/pre-merge.sh --profile pr-parity --label
-approved-large-certified-adapter`; host publication must use `workcell
-publish-pr --approved-large-certified-adapter` through the repo wrapper, which
-adds the matching `approved-large-certified-adapter` PR label.
+These files define the machine-readable lane inventory:
+
+- [`policy/workflow-lane-policy.json`](../policy/workflow-lane-policy.json) defines each lane and its authority.
+- [`policy/workflow-lanes.json`](../policy/workflow-lanes.json) contains the generated lane manifest.
+
+`./scripts/verify-workflow-lanes.sh` rejects manifest drift.
+`./scripts/ci-plan.sh` shows the selected local and hosted lanes.
+
+The changed-file planner fails closed for unsafe Git state.
+It rejects split indexes, shallow graphs, unsafe ancestry, mutable ignore files, and present gitlinks.
+It ignores `.git/info/exclude` and disables Git conversion filters.
+
+`./scripts/pre-merge.sh` runs each selected local lane in `local_order`.
+It reads the complete plan before it starts a lane.
+Thus, a lane cannot consume a later plan record from standard input.
+
+For an approved large adapter PR, use both required options:
+
+```bash
+./scripts/pre-merge.sh \
+  --profile pr-parity \
+  --label approved-large-certified-adapter
+
+./scripts/repo-publish-pr.sh \
+  --approved-large-certified-adapter \
+  ...
+```
 
 ## Workflow inventory
 
 | Workflow | Purpose |
-|---|---|
-| `ci.yml` | repository validation, smoke, reproducibility, pin verification, and upstream release re-verification on pushes and PRs; package install/uninstall verification and the heavy per-platform reproducible-build lanes run only on pushes to `main`, manual dispatch, and PRs labeled `approved-heavy-ci`; the PR-shape job accepts `approved-large-certified-adapter` only for bounded, reviewed, live-certified adapter support PRs |
-| `pr-base-policy.yml` | trusted base-branch guard that keeps `main` as the supported ready-PR base and leaves non-`main` PR bases as draft-only lower-assurance review units |
-| `docs.yml` | fast spelling and manpage feedback for docs-only changes |
-| `security.yml` | repo-owned workflow contract checks, dependency review, and `zizmor` |
-| `codeql.yml` | code scanning for shipped Rust, Go, and JavaScript surfaces |
-| `scorecard.yml` | OpenSSF Scorecard analysis |
-| `pin-hygiene.yml` | scheduled re-validation of pinned inputs plus upstream refresh drift across providers, Linux base images, toolchains, and release-build pins |
-| `mutation.yml` | weekly-cron, manual, and `approved-heavy-ci`-gated lane that runs the mutation-score gate in the validator image via `scripts/ci/job-mutation.sh` and `scripts/ci/run-mutation-in-validator.sh` (GitHub-only; the same gate also runs locally in the release-preflight validate profile) |
-| `fuzz.yml` | weekly-cron and manual lane that spends an extended, time-bounded budget fuzzing the Go parser targets whose seed corpora already run as regression tests on every PR; see [fuzzing.md](fuzzing.md) |
-| `bench.yml` | optional weekly-cron and manual lane that builds the exec-guard cdylib and times the LD_PRELOAD shim's allow-path classification overhead against the unhooked libc baseline across two runs; not on the PR path; see [syscall-shim-benchmarks.md](syscall-shim-benchmarks.md) |
-| `ci-insights.yml` | scheduled, read-only CI observability lane that writes a weekly flaky-test report and CI cost report to each run's job summary; never gates PRs or releases; see [ci-efficiency-and-reliability.md](ci-efficiency-and-reliability.md) |
-| `upstream-refresh.yml` | scheduled and manual candidate generation for reviewed upstream pins, with later signed host-side PR publication |
-| `hosted-controls.yml` | drift detection for GitHub-hosted controls that live outside git |
-| `release.yml` | tagged release preflight, publication, signatures, SBOMs, manifests, and attestations |
+| --- | --- |
+| `bench.yml` | Measures exec-guard performance on a schedule or manual run. |
+| `ci-insights.yml` | Writes weekly flake and cost reports. See [CI reliability](ci-efficiency-and-reliability.md). |
+| `ci.yml` | Runs repository validation, smoke tests, reproducibility, install checks, and PR-shape checks. |
+| `codeql.yml` | Scans the shipped Go, Rust, and JavaScript code. |
+| `docs.yml` | Checks spelling, links, contracts, and the man page. |
+| `fuzz.yml` | Runs extended Go and Rust fuzz tests. |
+| `hosted-controls.yml` | Checks GitHub controls that are outside Git. |
+| `mutation.yml` | Runs the mutation-score gate on a schedule, manual run, or approved heavy PR. |
+| `pin-hygiene.yml` | Checks reviewed upstream and tool pins. |
+| `pr-base-policy.yml` | Requires `main` as the base for a ready PR. |
+| `release.yml` | Builds, verifies, signs, and publishes a release. |
+| `scorecard.yml` | Runs OpenSSF Scorecard analysis. |
+| `security.yml` | Checks workflow policy, dependencies, and GitHub Actions security. |
+| `upstream-refresh.yml` | Creates an advisory upstream-pin candidate and updates the tracking issue. |
 
-## Release workflow posture
+## CI routing
 
-`release.yml` is intentionally strict:
+Normal PRs run the required deterministic lanes.
+The `approved-heavy-ci` label enables these expensive PR lanes:
 
-- it verifies from GitHub-owned sources that the release install matrix still
-  matches the newest two GitHub-hosted Apple Silicon macOS runner labels
-- it publishes from the archived source bundle, not the live checkout
-- it runs repo-mounted validator and release-helper lanes under an explicit
-  caller UID/GID with isolated writable home, cache, and tmp roots rather than
-  relying on ambient container-root defaults; passwd-less caller UIDs get a
-  synthesized isolated home instead of collapsing to `/`
-- it re-verifies upstream provider releases and every reviewed upstream pin from the archived source tree before packaging and signing
-- it gates publication on release-bundle install/uninstall and Homebrew
-  install/uninstall verification on GitHub-hosted Apple Silicon `macos-26`
-  and `macos-15`
-- it runs a release-scoped CodeQL matrix so Go uses `autobuild` while Rust and
-  JavaScript keep buildless scanning
-- it binds publish outputs to preflight results before signing
-- it builds and reproducibility-verifies the `linux/arm64` runtime image on a
-  native `ubuntu-24.04-arm` runner instead of QEMU emulation, matching `ci.yml`;
-  the amd64 image stays native on `ubuntu-latest`, and publish assembles the
-  multi-arch manifest from both native digests after the preflight digest match
-- the native arm64 build/push job is gated on the same `release` environment as
-  publish, so no image reaches GHCR before the release approval
-- it refuses to publish when provider pins, Linux base images, Linux toolchains,
-  or release-build pins lag the latest tracked upstream versions
-- it signs release assets with keyless Sigstore/Cosign
-- it publishes GitHub attestations as an additional surface, not a
-  replacement, but only when the reviewed hosted controls say the repository
-  visibility and plan support them
-- it uses pinned GitHub Actions and pinned Buildx, QEMU, Cosign, and Syft
-  versions
-- it runs with minimal workflow-level permissions, keeps package publication,
-  OIDC, and attestations in the release-approved artifact job, and grants the
-  separate final publication job only artifact read and repository-content
-  write permissions
+- native amd64 and arm64 reproducible builds
+- install verification on `macos-26` and `macos-15`
+- CodeQL language jobs
+- mutation tests
 
-That is also the current tested host-support limit for CI and tagged releases.
-Other macOS versions are not install-gated today.
+Native reproducibility and install verification also run on each push to `main`.
+CodeQL also runs on each push to `main` and its weekly schedule.
+The mutation workflow also runs on its weekly schedule.
+All four lane groups support manual dispatch.
 
-## Upstream refresh workflow
+The aggregate reproducibility check passes on a normal PR when the platform matrix result is `skipped`.
+It requires both platform jobs on `main`, an approved heavy PR, or manual dispatch.
 
-`upstream-refresh.yml` is the dedicated candidate lane for reviewed upstream pins:
+## Hosted install evidence
 
-- it runs on a daily schedule and on manual dispatch
-- it installs the same pinned Cosign verifier release used by CI, release, and
-  pin-hygiene before provider release verification paths run
-- it refreshes provider pins, the Linux runtime and validator base images,
-  Debian snapshot, Go/Rust/Hadolint toolchains, and release-build helper pins
-- a Codex pin change fetches the exact tagged CLI source and advances the
-  command-inventory fixture only when the classified subcommand set is
-  unchanged; additions or removals stop refresh before pin mutation
-- it binds to the empty `upstream-refresh` GitHub environment as an out-of-tree
-  `main`-only gate with no hosted signing inputs
-- it uploads an advisory candidate bundle containing `patch`, `diffstat`, and
-  `metadata.json`
-- it opens or updates one rolling tracking issue instead of pushing a branch or
-  opening a PR from GitHub Actions
-- the authoritative refresh PR is created later on the host through
-  `./scripts/publish-upstream-refresh-pr.sh`, which recreates the refresh
-  locally, requires exact candidate identity matches when a candidate run is
-  cited, runs `pr-parity`, and then delegates to
-  `./scripts/repo-publish-pr.sh`
-- the candidate artifact and tracking issue are operator signals only; they are
-  not integrity evidence and do not replace the later signed host-side review
-  unit
+The hosted macOS jobs test five install properties:
 
-## Required reproducibility
+- bundle installation
+- launcher-link removal
+- man-page-link removal
+- Homebrew installation and formula removal
 
-`ci.yml` keeps the branch-protected `Reproducible build` context tied to the
-actual platform checks. The native amd64 and arm64 reproducible-build lanes are
-heavy (two ~45-minute no-cache double-builds), so they run on pushes to `main`,
-manual dispatch, and pull requests labeled `approved-heavy-ci` — the same
-heavy-lane gate that CodeQL, mutation, and install verification use — rather
-than on every fork PR ungated. On an unlabeled pull request the per-platform
-matrix is skipped and the aggregate `Reproducible build` context passes on that
-`skipped` result; on a push to `main`, a labeled PR, or dispatch it fails unless
-the per-platform matrix succeeds. Release-time reproducibility assurance is
-preserved independently of the PR path: every post-merge push to `main` runs the
-per-platform lanes, and `release.yml` re-verifies reproducibility natively in
-`preflight-amd64-repro` / `preflight-arm64-repro` before publish (see below).
+The jobs run `scripts/uninstall.sh` for the bundle.
+They assert only the two link removals after that command.
+They do not prove complete bundle uninstall behavior.
 
-`release.yml` uses the same native-runner split: the `preflight-arm64-repro`
-job reproducibility-verifies the arm64 runtime image on `ubuntu-24.04-arm` and
-feeds its digests into the preflight manifest, while the amd64 image is verified
-natively in `preflight`. `check-pinned-inputs` rejects any reintroduction of
-`docker/setup-qemu-action` into the release workflow.
+The Homebrew job verifies that `brew uninstall` removes the formula.
 
-`check-pinned-inputs` also gates the GitHub Actions supply chain: every `uses:`
-must be pinned by full commit SHA, and its `owner/repo` must appear in the
-reviewed allowlist
-[`policy/allowed-actions.toml`](../policy/allowed-actions.toml). SHA-pinning
-proves the integrity of a specific ref; the allowlist restricts which action
-publishers may run at all, so introducing a new action — even a correctly
-pinned one — requires a reviewed change to that policy.
+GitHub-hosted macOS does not prove the strict Colima boundary.
+Local certification supplies that proof.
 
-The CI/release tool pins (cosign, buildx, buildkit, QEMU, syft, actionlint,
-zizmor) have a reviewed chokepoint in
-[`policy/tool-pins.toml`](../policy/tool-pins.toml). The values still live inline
-in the workflows; `check-pinned-inputs` asserts every workflow copy equals the
-policy, and `scripts/update-upstream-pins.sh` rewrites the workflows and the
-policy together on a bump. The policy is the human-reviewed record kept in
-lockstep with the workflows, so a pin can never move without a reviewed diff to
-that file.
+## Release workflow
 
-`ci.yml` and `docs.yml` use the same explicit nonroot validator contract when
-they bind-mount the repository: the workflow computes the caller UID/GID,
-passes isolated writable roots, and creates those paths inside the validator
-before repo validation or docs checks run. That contract still holds when the
-caller UID lacks a passwd entry inside the image because the launcher
-synthesizes an isolated writable home for those lanes.
+The preflight job records the expected digest for its source archive.
+The release job independently creates and extracts its own archive from the checked-out release tag.
+It then compares the archive digest with the expected digest.
+It creates source-dependent manifests and the amd64 image from the extracted tree.
+It creates the formula from the verified archive digest.
+The native arm64 image job builds from the checked-out release tag.
+The workflow also creates the builder-environment manifest, image-digest file, software bills of materials, signatures, and checksums.
+The release job seals the assets in one workflow artifact.
+The final job publishes that sealed artifact.
 
-The mirrored local workflow bodies live under `scripts/ci/`:
+Release preflight does these checks:
 
-- `job-pr-shape.sh`
-- `job-validate.sh`
-- `job-docs.sh`
-- `job-pin-hygiene.sh`
-- `build-validator-image.sh`
-- `run-validate-in-validator.sh`
-- `run-docs-in-validator.sh`
+- repository validation and container smoke tests
+- provider and upstream-pin verification
+- source-bundle and runtime-image reproducibility
+- release input and control-plane manifests
+- hosted control verification
+- native amd64 and arm64 image builds
+- the hosted install evidence in this page
+- release CodeQL analysis
 
-GitHub workflow YAML stays responsible for event routing, permissions, runners,
-and hosted-only concerns. The shared scripts keep the mirrorable job logic
-identical between local parity runs and GitHub CI.
+The release uses native `ubuntu-latest` for amd64.
+It uses native `ubuntu-24.04-arm` for arm64.
+The workflow compares both platform digests with preflight data.
+Then it creates one multi-platform manifest.
+
+The `release` environment gates image pushes and sealed-asset construction.
+No image reaches GHCR before that gate.
+The `hosted-controls-audit` environment gates release preflight and final GitHub release publication.
+
+The release uses Cosign to create keyless Sigstore signatures.
+It also creates GitHub attestations when the reviewed hosted controls permit them.
+GitHub attestations do not replace Sigstore signatures.
+
+The final publisher has `actions: read` and `contents: write` permissions.
+It checks hosted controls immediately before publication.
+It removes the administration token before it uses the default publication token.
+
+## Upstream refresh
+
+`upstream-refresh.yml` runs each day and on manual dispatch.
+It checks these pin groups:
+
+- provider releases
+- Linux runtime and validator images
+- Debian snapshot data
+- Go, Rust, Hadolint, and release tools
+
+A Codex change also checks the classified command inventory.
+The workflow stops if the command set changes.
+
+The workflow uploads an advisory candidate bundle.
+That bundle contains `patch`, `diffstat`, and `metadata.json`.
+It also updates one tracking issue.
+
+The workflow does not push a branch or open a PR.
+Use `./scripts/publish-upstream-refresh-pr.sh` for host publication.
+That helper recreates the change, checks candidate identity, runs `pr-parity`, and uses the repository PR wrapper.
+
+The candidate artifact and issue are operator signals.
+They are not integrity evidence.
+
+## Action and tool pins
+
+Use a full commit SHA for each GitHub Action reference.
+List each publisher in [`policy/allowed-actions.toml`](../policy/allowed-actions.toml) before you use its action.
+
+A full commit SHA fixes the selected action version.
+The allowlist limits the action publishers.
+A new publisher requires a reviewed policy change.
+
+[`policy/tool-pins.toml`](../policy/tool-pins.toml) records the reviewed CI and release tools.
+`check-pinned-inputs` compares each workflow copy with that policy.
+`scripts/update-upstream-pins.sh` updates the workflow and policy copies together.
+
+## Validator identity
+
+`ci.yml` and `docs.yml` run the validator as the caller UID and GID.
+They use separate writable home, cache, and temporary roots.
+The launcher creates an isolated home if the caller has no passwd entry.
+
+The mirrored local jobs are under `scripts/ci/`.
+Workflow YAML controls events, permissions, runners, and hosted-only steps.
+The local scripts contain the shared job logic.
 
 ## Hosted controls
 
-Some release-relevant controls live outside git. Workcell still treats them as
-reviewed inputs:
+Some release controls are outside Git:
 
-- branch rulesets for signed commits, anti-rewrite protection, PR gating, and
-  required checks
-- tag rulesets for `refs/tags/v*`
-- the `release` environment, with reviewer protection when the GitHub plan
-  supports it and an explicitly documented lower-assurance fallback when it
-  does not; it permits only `v*` deployment tags, no deployment branches, no
-  environment variables or secrets, and no administrator bypass
-- the `hosted-controls-audit` and `upstream-refresh` environments, including
-  their exact secret and variable contents plus their disabled admin bypass
-  posture
-- `hosted-controls-audit` permits the `main` branch and protected `v*` release
-  tags so scheduled/main audits and tag-triggered release preflight both use a
-  dedicated environment gate for `WORKCELL_HOSTED_CONTROLS_TOKEN`
-- after the release-approved job seals and uploads its workflow artifact, a
-  minimal final job in `hosted-controls-audit` refreshes the immutable-release
-  check immediately before publication; it removes the admin-metadata
-  credential before the publisher uses its default token and accepts only
-  GitHub's exact integration-permission denial with that fresh check
-- GitHub Actions SHA pinning
-- canonical repository variables such as
-  `WORKCELL_RELEASE_NO_ATTEST=false` and
-  `WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS=false`
+- branch and tag rulesets
+- the `release` environment
+- the `hosted-controls-audit` environment
+- the `upstream-refresh` environment
+- repository variables for attestation policy
 
-`scripts/verify-github-hosted-controls.sh` audits those settings against
-`policy/github-hosted-controls.toml`.
+`scripts/verify-github-hosted-controls.sh` compares those controls with
+[`policy/github-hosted-controls.toml`](../policy/github-hosted-controls.toml).
 
-## Public vs private behavior
+The canonical repository requires these variable values:
 
-The workflow set supports both public and private repos, but some features are
-conditional:
+- `WORKCELL_RELEASE_NO_ATTEST=false`
+- `WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS=false`
 
-- private repos may need `WORKCELL_HOSTED_CONTROLS_TOKEN` for hosted-control
-  auditing
-- private code scanning and some SARIF uploads are opt-in because GitHub plan
-  support varies
-- public repos can publish GitHub attestations when enabled
-- private/internal repos only publish GitHub attestations when the reviewed
-  `WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS` variable is explicitly set for
-  a GitHub plan that supports them
+The release environment permits protected `v*` tags only.
+It has no secret or variable content and no administrator bypass.
+
+## Public and private repositories
+
+The `hosted-controls-audit` environment requires `WORKCELL_HOSTED_CONTROLS_TOKEN`.
+This requirement applies to public and private repositories.
+Private code scans and SARIF uploads depend on the GitHub plan.
+
+The public repository creates GitHub attestations.
+A private repository needs reviewed policy and plan support before it creates them.
 
 ## Deliberate omissions
 
-Workcell does not use:
+Workcell does not use these workflow features:
 
-- general-purpose `pull_request_target` workflows; the only exception is
-  `pr-base-policy.yml`, which reads pull-request metadata from trusted
-  base-branch workflow code, keeps top-level `permissions: {}`, and must not
-  check out repository contents or use external actions
-- ambient PAT-style workflow credentials
-- GitHub-hosted macOS claims for the full Colima boundary
-- stale-issue or other bot churn unrelated to the runtime or release posture
+- general-purpose `pull_request_target` automation
+- ambient personal-access-token credentials
+- a hosted claim for the strict Colima boundary
+- unrelated stale-issue automation
+
+`pr-base-policy.yml` is the only `pull_request_target` exception.
+It uses trusted base-branch code and reads PR metadata only.
+It does not check out repository content or use an external action.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -78,8 +78,10 @@ Release preflight checks these items before publication:
 - Apple Silicon runner metadata
 - pinned provider releases
 - pinned base images and toolchains
-- bundle install and uninstall on `macos-15` and `macos-26`
-- Homebrew install and uninstall on the same runners
+- bundle installation, launcher-link removal, and man-page-link removal on `macos-15` and `macos-26`
+- Homebrew installation and formula removal on the same runners
+
+The bundle job does not prove complete bundle uninstall behavior.
 
 The amd64 image job rebuilds from the archived source bundle.
 A separate native arm64 job builds from the checked-out signed tag.

--- a/docs/release-posture.md
+++ b/docs/release-posture.md
@@ -1,39 +1,53 @@
-# Release Posture
+# Release posture
 
 The latest release is [`v1.0.2`](https://github.com/omkhar/workcell/releases/tag/v1.0.2).
-It is the first published 1.0 release. GitHub reports it as immutable. Its
-18-asset inventory has a SHA-256 digest for each asset.
+It is the first published release in the 1.0 series.
+GitHub reports this release as immutable.
+GitHub also provides a SHA-256 digest for each release asset.
 
-Workcell rebuilds and verifies each tagged release before publication. The
-release path does these checks:
+The release workflow rebuilds and verifies each tagged release before publication.
+It does these checks:
 
-- reruns validation, smoke, and reproducibility checks
-- reruns repo-mounted validator and release-helper paths under an explicit
-  caller UID/GID with isolated writable home, cache, and tmp roots instead of
-  relying on ambient container-root defaults, including passwd-less caller UIDs
-- verifies from GitHub-owned sources that the release install matrix still
-  targets the newest two GitHub-hosted Apple Silicon macOS runner labels
-- refuses to publish if any reviewed provider, Linux base image, Linux
-  toolchain, or release-build pin is behind the latest tracked upstream
-- verifies pinned Codex, Claude, Copilot, and Gemini releases against upstream
-  metadata as part of the reviewed provider set; Antigravity gets the same
-  gate before any future support claim
-- publishes from the archived source bundle rather than the live checkout
-- gates publication on bundle and Homebrew install verification on
-  GitHub-hosted Apple Silicon `macos-26` and `macos-15`
-- signs the image, source bundle, Homebrew formula asset, published image
-  digest file, checksums, build-input manifest, control-plane manifest,
-  builder-environment manifest, and both SBOMs with keyless Sigstore/Cosign
-- publishes GitHub-native attestations when the reviewed hosted controls say
-  the repository visibility and GitHub plan support them for every published
-  primary release artifact, as an additional verification surface rather than a
-  replacement for Sigstore
+- It runs repository validation, container smoke tests, and reproducibility tests.
+- It runs repo-mounted validators and release helpers with an explicit caller user ID and group ID.
+- It gives those processes separate writable home, cache, and temporary directories.
+- It supports a caller user ID that has no password-file entry.
+- It verifies the two current GitHub-hosted Apple Silicon macOS runner labels.
+- It blocks publication when a reviewed provider, Linux image, toolchain, or release-build pin is out of date.
+- It verifies the pinned Codex, Claude, Copilot, and Gemini releases against upstream metadata.
+- It keeps Antigravity unsupported until that provider passes the same gate.
 
-That install matrix is the current release-gated support window. Other macOS
-versions may work, but they are not currently proven by tagged-release CI.
+The preflight job records the expected digest for its source archive.
+The release job creates and extracts an independent archive from the checked-out release tag.
+It compares that archive digest with the expected digest.
+It creates source-dependent manifests and the amd64 image from the extracted tree.
+It creates the Homebrew formula from the verified archive digest.
 
-Forks can keep the GitHub attestation gates off. The upstream repo treats
-those settings as hosted control-plane state and audits them accordingly.
+The native arm64 image job builds from the checked-out release tag.
+The workflow compares the published platform digests with the preflight data.
 
-See [provenance.md](provenance.md) and
-[github-workflows.md](github-workflows.md).
+The hosted install jobs prove these properties on Apple Silicon `macos-26` and `macos-15`:
+
+- bundle installation
+- launcher-link removal
+- man-page-link removal
+- Homebrew installation
+- formula removal
+
+The hosted jobs do not prove complete bundle uninstall behavior.
+The release gate tests installation on these two macOS versions only.
+Other macOS versions can work, but tagged-release CI does not prove them.
+
+The `release` environment gates image pushes and sealed-asset construction.
+The `hosted-controls-audit` environment gates release preflight and final GitHub release publication.
+
+The workflow uses Cosign to create keyless Sigstore signatures.
+It signs the image, source archive, Homebrew formula, image-digest file, checksums, manifests, and software bills of materials.
+It also creates GitHub attestations when the reviewed hosted controls permit them.
+GitHub attestations are an additional verification surface.
+They do not replace Sigstore signatures.
+
+Forks can keep the GitHub attestation gates off.
+The upstream repository audits those gates as hosted control-plane state.
+
+See [provenance.md](provenance.md) and [github-workflows.md](github-workflows.md).

--- a/docs/use-case-matrix.md
+++ b/docs/use-case-matrix.md
@@ -27,8 +27,8 @@ workflows.
 | Session inventory, control, delete, logs, timeline, diff, and export | `tested` | `tests/scenarios/shared/test-session-commands.sh`, `internal/host/sessions/sessions_test.go` |
 | Isolated-session workspace preflight and direct-workspace remediation | `tested` | `tests/scenarios/shared/test-session-commands.sh` |
 | Persistent non-secret cache with `--cache-profile standard` | `tested` | `tests/scenarios/shared/test-assurance-dry-run.sh`, `scripts/verify-invariants.sh` |
-| Bundle install and uninstall on the hosted macOS matrix | `tested` | `tests/scenarios/shared/test-install-lifecycle.sh`, `internal/testkit/install_release_e2e_test.go`, `.github/workflows/ci.yml` `Install verification` jobs |
-| Homebrew install and uninstall on the hosted macOS matrix | `tested` | `.github/workflows/ci.yml` and `.github/workflows/release.yml` install-verification jobs |
+| Bundle installation and link removal on the hosted macOS matrix | `tested` | The `Install verification` jobs in `.github/workflows/ci.yml` and the `Release install verification` jobs in `.github/workflows/release.yml` prove bundle installation, launcher-link removal, and man-page-link removal. They do not prove complete bundle uninstall behavior. |
+| Homebrew installation and formula removal on the hosted macOS matrix | `tested` | `.github/workflows/ci.yml` and `.github/workflows/release.yml` install-verification jobs |
 | Release-bundle reproducibility | `tested` | `scripts/verify-release-bundle.sh`, `scripts/ci/job-validate.sh --profile release-preflight` |
 | Runtime-image reproducibility | `tested` | `scripts/verify-reproducible-build.sh`, `.github/workflows/ci.yml` `Reproducible build` jobs |
 | Sigstore signatures, SBOMs, and GitHub attestations | `tested` | Successful v1.0.2 `Release` workflow |

--- a/internal/testkit/ci_plan_git_test.go
+++ b/internal/testkit/ci_plan_git_test.go
@@ -408,7 +408,7 @@ func TestCIPlanGitCollectorRejectsBaseFiltersBeforeExecution(t *testing.T) {
 			marker := fixture.configureFilter(driverName, driver)
 			fixture.writeFile("tracked.txt", []byte("worktree\n"), 0o644)
 			result := fixture.run("--base", "main")
-			if result.code == 0 || docsErr != nil || workflowDocsErr != nil || !bytes.Contains(docs, []byte("rejects nonregular or split-index state")) || !bytes.Contains(docs, []byte("conversion filters")) || !bytes.Contains(workflowDocs, []byte("fail-closed resident Git discovery")) ||
+			if result.code == 0 || docsErr != nil || workflowDocsErr != nil || !bytes.Contains(docs, []byte("rejects nonregular or split-index state")) || !bytes.Contains(docs, []byte("conversion filters")) || !bytes.Contains(workflowDocs, []byte("fails closed for unsafe Git state")) || !bytes.Contains(workflowDocs, []byte("disables Git conversion filters")) ||
 				!strings.Contains(result.stderr, "effective pinned attributes select conversion filter "+driverName+" for tracked.txt") ||
 				strings.Contains(result.stderr, marker) {
 				t.Fatalf("base %s/%s filter or scope docs failed: code=%d stderr=%q docs=%v/%v", driverName, driver, result.code, result.stderr, docsErr, workflowDocsErr)

--- a/internal/testkit/hosted_install_evidence_test.go
+++ b/internal/testkit/hosted_install_evidence_test.go
@@ -1,0 +1,57 @@
+package testkit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHostedInstallEvidenceDocumentation(t *testing.T) {
+	root := repoRoot(t)
+	evidencePaths := []string{
+		"README.md",
+		"SUPPORT.md",
+		"docs/enterprise-rollout.md",
+		"docs/github-workflows.md",
+		"docs/provenance.md",
+		"docs/release-posture.md",
+		"docs/use-case-matrix.md",
+		"policy/requirements.toml",
+	}
+	for _, path := range evidencePaths {
+		content, err := os.ReadFile(filepath.Join(root, path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := strings.Join(strings.Fields(string(content)), " ")
+		for _, want := range []string{
+			"bundle installation",
+			"launcher-link removal",
+			"man-page-link removal",
+			"Homebrew installation",
+			"formula removal",
+		} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("%s must describe hosted %s evidence", path, want)
+			}
+		}
+	}
+	for _, path := range append(evidencePaths, "ROADMAP.md") {
+		content, err := os.ReadFile(filepath.Join(root, path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := strings.ToLower(string(content))
+		for _, stale := range []string{
+			"bundle install/uninstall",
+			"bundle install and uninstall",
+			"bundle installation and removal",
+			"install/uninstall behavior",
+		} {
+			if strings.Contains(text, stale) {
+				t.Fatalf("%s overstates hosted bundle evidence with %q", path, stale)
+			}
+		}
+	}
+}

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestC3CertificationEntrypointSanitizesBuildControl(t *testing.T) {
@@ -715,7 +717,7 @@ func TestAppleSiliconOnlyHostGuardsArePinned(t *testing.T) {
 	}
 }
 
-func TestGitHubWorkflowsContinuouslyVerifyInstallAndUninstall(t *testing.T) {
+func TestGitHubWorkflowsVerifyHostedInstallEvidence(t *testing.T) {
 	t.Parallel()
 
 	for _, workflowName := range []string{"ci.yml", "release.yml"} {
@@ -739,6 +741,140 @@ func TestGitHubWorkflowsContinuouslyVerifyInstallAndUninstall(t *testing.T) {
 			if !strings.Contains(workflow, want) {
 				t.Fatalf("%s does not contain %q", workflowPath, want)
 			}
+		}
+
+		var parsed struct {
+			Defaults struct {
+				Run struct {
+					Shell string `yaml:"shell"`
+				} `yaml:"run"`
+			} `yaml:"defaults"`
+			Jobs map[string]struct {
+				If              string     `yaml:"if"`
+				RunsOn          string     `yaml:"runs-on"`
+				Needs           yaml.Node  `yaml:"needs"`
+				ContinueOnError *yaml.Node `yaml:"continue-on-error"`
+				Defaults        struct {
+					Run struct {
+						Shell string `yaml:"shell"`
+					} `yaml:"run"`
+				} `yaml:"defaults"`
+				Strategy struct {
+					Matrix struct {
+						Include []struct {
+							Runner      string `yaml:"runner"`
+							RunnerLabel string `yaml:"runner_label"`
+						} `yaml:"include"`
+					} `yaml:"matrix"`
+				} `yaml:"strategy"`
+				Steps []struct {
+					Name            string     `yaml:"name"`
+					Run             string     `yaml:"run"`
+					If              string     `yaml:"if"`
+					ContinueOnError *yaml.Node `yaml:"continue-on-error"`
+					Shell           string     `yaml:"shell"`
+				} `yaml:"steps"`
+			} `yaml:"jobs"`
+		}
+		if err := yaml.Unmarshal(content, &parsed); err != nil {
+			t.Fatalf("parse %s: %v", workflowPath, err)
+		}
+		if parsed.Defaults.Run.Shell != "bash --noprofile --norc -euo pipefail {0}" {
+			t.Fatalf("%s must use the strict Bash workflow default", workflowPath)
+		}
+		installJob, ok := parsed.Jobs["install-verification"]
+		if !ok {
+			t.Fatalf("%s must contain jobs.install-verification", workflowPath)
+		}
+		wantJobIf := ""
+		if workflowName == "ci.yml" {
+			wantJobIf = "${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'approved-heavy-ci') }}"
+		}
+		if installJob.If != wantJobIf ||
+			installJob.RunsOn != "${{ matrix.runner }}" ||
+			installJob.ContinueOnError != nil ||
+			installJob.Defaults.Run.Shell != "" {
+			t.Fatalf("%s install-verification job metadata does not match the hosted evidence contract", workflowPath)
+		}
+		if workflowName == "ci.yml" {
+			if installJob.Needs.Kind != yaml.ScalarNode || installJob.Needs.Value != "validate" {
+				t.Fatalf("%s install-verification job must require validate", workflowPath)
+			}
+		} else if installJob.Needs.Kind != yaml.SequenceNode ||
+			len(installJob.Needs.Content) != 2 ||
+			installJob.Needs.Content[0].Value != "tag-policy" ||
+			installJob.Needs.Content[1].Value != "preflight" {
+			t.Fatalf("%s install-verification job must require tag-policy and preflight", workflowPath)
+		}
+		include := installJob.Strategy.Matrix.Include
+		if len(include) != 2 ||
+			include[0].Runner != "macos-26" || include[0].RunnerLabel != "macos-26" ||
+			include[1].Runner != "macos-15" || include[1].RunnerLabel != "macos-15" {
+			t.Fatalf("%s install-verification job must use the macos-26 and macos-15 matrix", workflowPath)
+		}
+		installerRun := ""
+		installerStepCount := 0
+		for _, step := range installJob.Steps {
+			if step.Name == "Verify release bundle installer" {
+				if step.If != "" || step.ContinueOnError != nil || step.Shell != "" {
+					t.Fatalf("%s release bundle installer step must use required default execution", workflowPath)
+				}
+				installerRun = step.Run
+				installerStepCount++
+			}
+		}
+		if installerStepCount != 1 {
+			t.Fatalf("%s must contain one release bundle installer step; got %d", workflowPath, installerStepCount)
+		}
+		executableLines := make([]string, 0)
+		for _, line := range strings.Split(installerRun, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			executableLines = append(executableLines, line)
+		}
+		missingBundleMessage := "Missing CI release bundle artifact"
+		if workflowName == "release.yml" {
+			missingBundleMessage = "Missing preflight release bundle artifact"
+		}
+		wantInstallerLines := []string{
+			`set -euo pipefail`,
+			`mkdir -p "${HOME}"`,
+			`bundle_path="$(find dist/install -maxdepth 1 -type f -name 'workcell-*.tar.gz' -print -quit)"`,
+			`if [[ -z "${bundle_path}" ]]; then`,
+			`echo "` + missingBundleMessage + `" >&2`,
+			`exit 1`,
+			`fi`,
+			`extract_root="${RUNNER_TEMP}/bundle-install"`,
+			`rm -rf "${extract_root}"`,
+			`mkdir -p "${extract_root}"`,
+			`tar -xzf "${bundle_path}" -C "${extract_root}"`,
+			`bundle_dir="$(find "${extract_root}" -mindepth 1 -maxdepth 1 -type d -name 'workcell-*' -print -quit)"`,
+			`if [[ -z "${bundle_dir}" ]]; then`,
+			`echo "Unable to locate extracted bundle root" >&2`,
+			`exit 1`,
+			`fi`,
+			`test ! -e "${HOME}/.local/bin/workcell"`,
+			`test ! -L "${HOME}/.local/bin/workcell"`,
+			`test ! -e "${HOME}/.local/share/man/man1/workcell.1"`,
+			`test ! -L "${HOME}/.local/share/man/man1/workcell.1"`,
+			`"${bundle_dir}/scripts/install.sh"`,
+			`"${HOME}/.local/bin/workcell" --help >/dev/null`,
+			`test -e "${HOME}/.local/bin/workcell"`,
+			`test -L "${HOME}/.local/bin/workcell"`,
+			`test -e "${HOME}/.local/share/man/man1/workcell.1"`,
+			`test -L "${HOME}/.local/share/man/man1/workcell.1"`,
+			`HOME="${HOME}" "${bundle_dir}/scripts/uninstall.sh"`,
+			`test ! -e "${HOME}/.local/bin/workcell"`,
+			`test ! -L "${HOME}/.local/bin/workcell"`,
+			`test ! -e "${HOME}/.local/share/man/man1/workcell.1"`,
+			`test ! -L "${HOME}/.local/share/man/man1/workcell.1"`,
+		}
+		gotInstallerRun := strings.Join(executableLines, "\n")
+		wantInstallerRun := strings.Join(wantInstallerLines, "\n")
+		if gotInstallerRun != wantInstallerRun {
+			t.Fatalf("%s must prove clean install, link creation, and complete link removal\nwant:\n%s\ngot:\n%s", workflowPath, wantInstallerRun, gotInstallerRun)
 		}
 	}
 

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -380,6 +380,7 @@ summary = "CI and tagged-release workflows validate bundle installation, launche
 evidence = [
   "scripts/verify-github-macos-release-test-runners.sh",
   "internal/metadatautil/workflow_validation_test.go",
+  "internal/testkit/validation_entrypoints_test.go",
 ]
 docs = [
   "docs/github-workflows.md",

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -376,7 +376,7 @@ docs = [
 
 [nonfunctional.NFR-006]
 title = "Continuously validated install matrix"
-summary = "CI and tagged release workflows continuously validate package install and uninstall behavior on the documented GitHub-hosted Apple Silicon macOS runners and keep that matrix tied to authoritative runner metadata."
+summary = "CI and tagged-release workflows validate bundle installation, launcher-link removal, man-page-link removal, Homebrew installation, and formula removal on documented GitHub-hosted Apple Silicon macOS runners. The workflows tie that matrix to authoritative runner metadata."
 evidence = [
   "scripts/verify-github-macos-release-test-runners.sh",
   "internal/metadatautil/workflow_validation_test.go",

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1861,9 +1861,10 @@ docker_cmd run --rm \
 grep -q '^copilot-pid1-stub-ok$' /tmp/workcell-copilot-pid1-stub.out
 
 COPILOT_METADATA_STUB="${SMOKE_WORKSPACE}/tmp/copilot-metadata-stub"
+COPILOT_METADATA_STUB_STAGE="${COPILOT_METADATA_STUB}.stage"
 COPILOT_METADATA_TOKEN_HANDOFF_DIR="$(copilot_token_handoff_dir_for_bundle "${INJECTION_BUNDLE_ROOT}/copilot")"
 COPILOT_METADATA_CONTAINER="workcell-copilot-metadata-smoke-$$"
-cat >"${COPILOT_METADATA_STUB}" <<'COPILOT_STUB'
+cat >"${COPILOT_METADATA_STUB_STAGE}" <<'COPILOT_STUB'
 #!/usr/bin/env bash
 set -euo pipefail
 test "${COPILOT_GITHUB_TOKEN:-}" = "copilot-smoke-token"
@@ -1877,7 +1878,9 @@ while :; do
   sleep 1
 done
 COPILOT_STUB
-chmod 0555 "${COPILOT_METADATA_STUB}"
+chmod 0555 "${COPILOT_METADATA_STUB_STAGE}"
+# Publish the executable mode and file contents together for the VM mount.
+mv "${COPILOT_METADATA_STUB_STAGE}" "${COPILOT_METADATA_STUB}"
 docker_cmd rm -f "${COPILOT_METADATA_CONTAINER}" >/dev/null 2>&1 || true
 docker_cmd run -d \
   --name "${COPILOT_METADATA_CONTAINER}" \

--- a/tests/scenarios/shared/test-install-lifecycle.sh
+++ b/tests/scenarios/shared/test-install-lifecycle.sh
@@ -9,7 +9,8 @@
 # passwd identity over $HOME, and `/tmp` is hard-coded), so invoking them live
 # here could delete a developer's or CI runner's real Workcell temp/cache state.
 # They are therefore NOT invoked live in this scenario:
-#   - uninstall is proven end to end by the macOS install-verification CI lane;
+#   - hosted CI proves bundle installation and launcher-link and man-page-link
+#     removal. It does not prove complete bundle uninstall behavior;
 #   - `--gc`'s cleanup contract is asserted below at the FUNCTION level against
 #     an INJECTED sandbox root (never `/tmp`, never real home);
 #   - the live end-to-end `--gc` exercise is local-operator-certification


### PR DESCRIPTION
## Summary

- Rewrite the enterprise rollout, GitHub workflow, and release posture documents in Simplified Technical English.
- State the five installation properties that hosted jobs verify.
- Add a regression test for these evidence statements.
- Publish the Copilot metadata stub atomically after its executable mode is final.

## Verification

- `./scripts/pre-merge.sh --profile pr-parity --allow-dirty`
- Adversarial consensus review: accepted by all three reviewers.
- `git diff --check`

## Risk

Low. Most changes are documentation and contract tests. The smoke-test change removes a file-publication race and does not change the tested policy.
