### PR TITLE
Record 1.0 delivery results

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ or local sockets.
   mounts
 - keep provider adapters native: one shared boundary, thin provider-specific
   control-plane mapping
-- keep publication on the host: signed commits, signed-range verification, and
-  GitHub publication stay out of Tier 1
+- keep the normal publication workflow on the host: signed commits,
+  signed-range verification, and GitHub publication stay out of Tier 1
+- keep publication authority explicit: credential injection can give a
+  session publication authority
 - keep verification paths nonroot by default: runtime and validator images
   default to a named unprivileged `workcell` user, while repo-mounted
   validation lanes pass explicit caller UID/GID and isolated writable state,
@@ -33,11 +35,11 @@ or local sockets.
 
 ## How it compares
 
-| Approach | Primary boundary | Provider-native control plane | Host-side signed publication | Lower-assurance paths called out |
+| Approach | Primary boundary | Provider-native control plane | Publication outside runtime | Lower-assurance paths called out |
 |---|---|---|---|---|
 | Host-native provider CLI | host user session | yes | no | rarely |
 | Generic container wrapper | container only, often mixed with host state | often partial | varies | often unclear |
-| Workcell | dedicated Colima VM plus hardened container | yes | yes | yes |
+| Workcell strict | dedicated Colima VM plus hardened container | yes | yes | yes |
 
 ## Project status
 
@@ -110,7 +112,7 @@ links; the full index is in the [Docs map](#docs-map) below.
 - **Contributors — work on Workcell**: [repository layout](#repository-layout) ·
   [contributor workflow](CONTRIBUTING.md) ·
   [agent guidelines](AGENTS.md) ·
-  [improvement-tracks plan](docs/improvement-tracks-implementation-plan.md)
+  [1.0 delivery record](docs/improvement-tracks-implementation-plan.md)
 
 ## 5-minute path
 
@@ -163,9 +165,9 @@ host support boundary that `--doctor` and `--inspect` report.
 On Apple Silicon macOS, the recommended path is the one-command **verified
 release install**, which downloads a tagged release, verifies its cosign
 signature and digest fail-closed **before any bundle code runs**, and only then
-installs. `install-release.sh` is not a standalone release asset, so get it
-from the repository over TLS (a trusted source) rather than the unverified
-bundle — clone the repo, then run it:
+installs. `install-release.sh` is not a standalone release asset. Get it from
+the repository through TLS transport, not from the unverified bundle. Then
+authenticate the selected revision with the signed-tag check:
 
 ```bash
 brew install cosign git gnupg   # verifier tools must exist before verification runs (macOS ships neither gnupg nor, on a clean host, git)
@@ -196,18 +198,30 @@ it.
 For the Homebrew formula asset, the source checkout path, and the full host
 requirements, see [docs/install.md](docs/install.md).
 
-To reclaim stale runtime/cache/temp state without uninstalling, run
-`workcell --gc` (it reaps aged `session-audit` records, so do not run it before
-preserving evidence for a suspected incident — see
-[docs/incident-response.md](docs/incident-response.md)).
-`./scripts/uninstall.sh` (run `--dry-run` first — its output is the
-authoritative list) removes the launcher link, the managed state under the
-default state root (`~/.local/state/workcell`), and the Workcell-managed Colima
-profiles/caches (legacy `workcell-*` and current `wcl-*` names), leaving shared
-packages and unrelated profiles alone; it does not reach a custom
-`WORKCELL_STATE_ROOT`/`XDG_STATE_HOME` (remove that yourself). After a Homebrew
-formula install, `brew uninstall workcell` removes only the formula, so also run
-`./scripts/uninstall.sh` (from a bundle or checkout) to clear the runtime state.
+If you suspect an incident, preserve all available evidence before you run
+`workcell --gc`. See
+[docs/incident-response.md](docs/incident-response.md).
+To reclaim stale runtime, cache, and temporary state without an uninstall, run
+`workcell --gc`.
+It removes aged transient `session-audit.*` scratch, not durable session
+records.
+
+Run `./scripts/uninstall.sh --dry-run` before you uninstall Workcell.
+Its output is the authoritative list.
+The uninstall command removes the launcher link and the managed state under
+`~/.local/state/workcell`.
+It also removes Workcell-managed Colima profiles and caches.
+Workcell-managed profiles and caches use legacy `workcell-*` names or current
+`wcl-*` names.
+The command does not remove shared packages or unrelated profiles.
+
+The uninstall command does not reach a custom `WORKCELL_STATE_ROOT` or
+`XDG_STATE_HOME`.
+Remove that custom state separately.
+After a Homebrew formula install, `brew uninstall workcell` removes only the
+formula.
+Also run `./scripts/uninstall.sh` from a bundle or checkout to remove the
+runtime state.
 See [docs/install-lifecycle.md](docs/install-lifecycle.md).
 
 ## Command reference

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ or local sockets.
 
 ## How it compares
 
-| Approach | Primary boundary | Provider-native control plane | Publication outside runtime | Lower-assurance paths called out |
+| Approach | Primary boundary | Provider-native control plane | Normal publication path | Lower-assurance paths called out |
 |---|---|---|---|---|
-| Host-native provider CLI | host user session | yes | no | rarely |
+| Host-native provider CLI | host user session | yes | host user session | rarely |
 | Generic container wrapper | container only, often mixed with host state | often partial | varies | often unclear |
-| Workcell strict | dedicated Colima VM plus hardened container | yes | yes | yes |
+| Workcell strict | dedicated Colima VM plus hardened container | yes | separate host workflow | yes |
 
 ## Project status
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,15 +78,15 @@ release criteria and deferred work.
   Antigravity CLI is queued as the
   follow-on track; current releases do not support `--agent antigravity`, its
   credential keys, or a matching quickstart.
-- Upstream retires Gemini CLI for the free, Pro, and Ultra personal-account
-  login tiers on June 18, 2026 in favor of the closed-source Antigravity
-  CLI; Gemini Code Assist Standard/Enterprise licenses and paid Gemini API
-  keys keep access. Reviewed posture: the Gemini Tier 1 adapter stays
+- Google stopped Gemini CLI service for the free, Pro, and Ultra
+  personal-account login tiers on June 18, 2026. Google moved these users to
+  the closed-source Antigravity CLI. Gemini Code Assist Standard or Enterprise
+  licenses and paid Gemini API keys keep access. The Gemini Tier 1 adapter stays
   supported for the auth inputs Google keeps serving (licensed Code Assist
   or a paid Gemini API key, with `gcloud_adc` as the supplemental Vertex
-  input to those modes rather than a standalone path), and an Antigravity
-  adapter is a committed follow-on provider-parity track behind the same
-  Tier 1 evidence bar (see [docs/provider-matrix.md](docs/provider-matrix.md)).
+  input to those modes rather than a standalone path). The Antigravity adapter
+  remains a follow-on provider-parity track behind the same Tier 1 evidence bar.
+  See [docs/provider-matrix.md](docs/provider-matrix.md).
 
 ## 1.0 Program Record
 
@@ -321,19 +321,19 @@ Exit gates:
 - bundles can be distributed through MDM, Git, or future admin tooling without
   implying centralized remote execution
 
-### Phase 17: Fleet Inventory And Audit Export
+### Phase 17: Fleet Inventory And Centralized Audit Ingestion
 
-Make host-local Workcell records consumable by enterprise inventory and SIEM
-systems.
+Workcell already exports OCSF 1.3.0 JSON Lines for SIEM ingestion.
+The support bundle already supplies local install, policy, target, provider,
+and runtime evidence.
+This phase adds fleet inventory and centralized ingestion.
 
 Exit gates:
 
-- machine-readable session, target, policy, runtime, provider, assurance,
-  downgrade, and support-status metadata can be exported
-- redaction rules and privacy boundaries are documented
-- JSONL/SIEM-friendly export formats are stable enough for pilot use
-- support bundles include the evidence needed to diagnose install, policy,
-  target, provider, and runtime failures
+- fleet inventory can collect records from reviewed hosts
+- centralized ingestion preserves the documented redaction and privacy rules
+- exports include the missing support-status metadata
+- organizations can apply their retention policy to collected records
 
 ### Phase 18: Regulated-Team Proof Harness And Windows Investigation
 
@@ -380,12 +380,13 @@ tracks are direction and sequencing, not support claims. Every item lands
 under the same evidence bar as the phases above: docs, deterministic tests,
 diagnostics, and (where applicable) live certification travel with the change.
 
-Horizons: `now` (next one to three releases), `next` (after the current
-provider and target phases stabilize), `later` (post-1.0 or gated on earlier
-items). Sizes: S/M/L. Milestone assignment for every item lives in the
-[Milestone Train](#milestone-train) under the 1.0 Program Record, and the per-item
-implementation plan — steps, exit gates, dependencies, and validation
-expectations — lives in
+The `now` horizon means the next one to three releases.
+The `next` horizon starts after the current provider and target phases stabilize.
+The `later` horizon is post-1.0 or depends on earlier items.
+Items use S, M, and L size labels.
+Historical milestone assignment for every item lives in the
+[Milestone Train](#milestone-train) under the 1.0 Program Record. The final
+per-item delivery result lives in
 [`docs/improvement-tracks-implementation-plan.md`](docs/improvement-tracks-implementation-plan.md).
 
 ### Track A: Boundary Depth And Agent-Threat Defenses
@@ -396,9 +397,10 @@ Claude Code, Gemini CLI, and Copilot CLI (the TrustFall disclosure; Codex CLI
 was not in the disclosed set), prompt injection through PR titles and
 comments against agent PR-review integrations, recurring
 npm worm campaigns (Shai-Hulud and successors), and sandbox-bypass CVEs in
-OS-level sandboxes (Seatbelt/bubblewrap). Workcell's VM-plus-container
-boundary and staged-credential model match the containment doctrine the
-strongest vendors now publish; these items deepen that lead.
+OS-level sandboxes (Seatbelt/bubblewrap). These threats can act through
+repository control files, review text, dependencies, or sandbox bypasses.
+Workcell uses its VM-plus-container boundary and staged credentials to limit
+the effect of these threats. These tracks strengthen those controls.
 
 - **A1 (complete, M):** egress policy depth and target parity — document, extend,
   and parity-label the shipped strict default-deny allowlist rather than
@@ -428,7 +430,7 @@ Releases use keyless Sigstore signatures, SBOMs, and GitHub attestations.
   2026-07-09 criterion-6 amendment because no second trusted maintainer exists;
   1.0 uses the documented single-maintainer controls in `docs/releasing.md`
 - **B3 (complete, M):** scheduled mutation-score lane with published score and
-  baseline regression gate, beyond today's release-preflight-only run
+  baseline regression gate, beyond the former release-preflight-only run
 - **B4 (complete, S):** centralized tool pins and a permitted-GitHub-actions
   allowlist check
 - **B5 (complete, S):** audit-trail retention policy with extended
@@ -440,20 +442,24 @@ Releases use keyless Sigstore signatures, SBOMs, and GitHub attestations.
 - **B7 (post-1.0, S + L):** OpenSSF Best Practices badge and funded
   third-party boundary audit — both deferred to post-1.0 by the 2026-07-09
   criterion-2/6 amendment
-- **B8 (complete, M):** CI efficiency and reliability program — nightly
-  reproducibility split, retries, flake tracking, cost visibility
+- **B8 (complete, M):** CI efficiency and reliability program — the
+  `approved-heavy-ci` pull request label, main-push and release
+  reproducibility, retries, flake candidates, and workflow wall-clock reports
 - **B9 (complete, M):** CI/CD threat model covering secrets, runner trust tiers,
   attestation assumptions, and signing-compromise response
 
 ### Track C: Runtime Platform Evolution
 
-- **C1 (evaluated, L):** Apple `container` backend evaluation (macOS 26+) as
-  `local_vm/apple-container` — **recorded go/no-go: GO on the evaluation
-  (per-session VM, sub-second boot, confirmed on macOS 26.5.1);
-  `preview-only`/`blocked` and support-invisible; Colima stays the reviewed
-  default (and the only option below macOS 26); promotion to a supported
-  backend deferred post-1.0 pending the B6 certification lane.** See
-  [docs/apple-container-evaluation.md](docs/apple-container-evaluation.md)
+- **C1 (evaluated, L):** Workcell evaluated the Apple `container` backend on
+  macOS 26 as `local_vm/apple-container`. The result was GO for technical
+  feasibility. Three starts on an idle host took less than one second on macOS
+  26.5.1. Starts on a saturated host took 2–7 seconds.
+
+  The target remains `preview-only` and `blocked`. It has no support claim.
+  Workcell blocks operator launch. Colima remains the reviewed default and the
+  only supported `local_vm` option below macOS 26. Workcell can promote the
+  target only after the post-1.0 certification in B6. See
+  [docs/apple-container-evaluation.md](docs/apple-container-evaluation.md).
 - **C2 (post-1.0, M):** session start latency program with cached images, an
   optional kept-warm lane, and a certification design that does not broaden the
   launcher with destructive controls; generic output remains benchmark-only
@@ -496,8 +502,8 @@ Use generated, checked metrics before you add a numeric inventory here.
 - **E2 (complete, M):** maintained architecture diagrams in the system design doc
 - **E3 (complete, S):** support-tier legend and a `--doctor`/`--inspect`
   diagnostics interpretation guide
-- **E4 (complete, S):** docs CI depth — link checking, orphan detection, status
-  labels, freshness markers
+- **E4 (complete, S):** documentation CI checks links, orphans, spelling, man
+  pages, support-field parity, and public-contract drift
 - **E5 (complete, M):** injection-policy annotated schema with complete
   per-provider examples
 - **E6 (post-1.0, M):** adoption growth kit — docs site, terminal demos,

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -1,783 +1,140 @@
-# Improvement Tracks Implementation Plan
-
-This document turns the
-[1.0 Program Record](../ROADMAP.md#10-program-record) and its
-[Engineering And Ecosystem Improvement Tracks](../ROADMAP.md#engineering-and-ecosystem-improvement-tracks)
-into a concrete, milestone-based implementation plan. The tracks came from
-the 2026-07 repository review (documentation, Rust/Go/shell source, tests,
-CI, release workflows) plus external research on the 2025–2026
-agent-sandboxing ecosystem. This plan records sequencing, per-item
-implementation shape, exit gates, and validation expectations. It creates no
-support claims; every support-visible change still lands through the
-host-support matrix, provider matrix, and certification gates.
-
-Track and item identifiers (`A1`, `B3`, `G1`, ...) refer to the roadmap
-tracks and stay stable across both documents. Milestones match the roadmap's
-Milestone Train; versions are indicative and may split.
-
-## Principles
-
-- tests first: every code-bearing item starts by writing the failing
-  deterministic test or check that defines done
-- one review unit per item or sub-item; no bundling unrelated tracks into one
-  PR
-- docs, contract surfaces, and validation evidence land in the same change as
-  the behavior they describe
-- refactors (Track D) must be behavior-preserving and proven by the existing
-  test surface before and after
-- security-depth items (Track A) fail closed by default; any relaxation is an
-  explicit labeled lower-assurance path
-- nothing in this plan weakens the VM-plus-container boundary, staged
-  credential model, or host-side publication rules
-- 1.0 is a truth claim: no milestone content ships a support label ahead of
-  its evidence
-
-## Competitive Drivers
-
-The milestone ordering answers the current landscape directly:
-
-- repo-defined MCP servers are a proven one-keypress RCE class across three
-  of the four supported provider CLIs (Claude Code, Gemini CLI, Copilot CLI
-  per the TrustFall disclosure) → A2 lands first (v0.12)
-- per-session egress allowlists are table stakes in every adjacent runtime
-  and in national-agency MCP guidance; strict Colima launches already enforce
-  default-deny allowlisting → A1 (v0.13) documents, extends, and brings
-  target parity to that shipped control instead of building a duplicate lane
-- microVM-per-session backends with warm starts are the mainstream
-  comparison point → C1 anchors v0.14; C2 is a post-1.0 program
-- parallel worktree-per-agent sessions are the 2026 unit of agent work →
-  C3 is in 1.0 scope (v0.15), not a post-1.0 idea
-- upstream retires Gemini CLI personal-account tiers in June 2026 →
-  the Antigravity Tier 1 adapter track runs inside the 1.0 window (v0.14)
-- enterprises evaluate against OWASP agentic guidance, SIEM-ready export,
-  and SLSA levels → A7, F1, and B1 sit on the 1.0 critical path; B2 is
-  deferred post-1.0 under the 2026-07-09 criterion-6 amendment
-- container-in-sandbox (C4) stays post-1.0: it is a differentiator response,
-  not a 1.0 gate, and must not risk the outer boundary
-
-## Delivery Model
-
-| Milestone | Theme | Contents |
-|---|---|---|
-| v0.12 | Containment and hygiene | A2, A7, B3, B4, B5, D1, D2, E3, E4 |
-| v0.13 | Boundary depth and stability | A1, A3, A4, B1, C5, D8, E1, E2, F3, G1 (inventory) |
-| v0.14 | Platform, speed, and adoption | C1, B8, B9, D3 (start), D4, E5, E7, G2, Antigravity Tier 1 adapter track |
-| v0.15 | Enterprise evidence and release assurance | A5, A6, C3, D5, D7, F1, G3 |
-| v1.0 | Freeze and gate | G1 (freeze), G4, D3 (complete), D6 |
-| post-1.0 | Reach expansion | Phases 13–19 remainder, C2, C4, B2 (dual-control releases), B6 (automated real-boundary lane), B7 (badge + audit completion), E6 (rendered docs site + external demos), F2 |
-
-Items inside a milestone are independently shippable and individually
-reviewable. Later-milestone items may start early when nothing earlier gates
-them.
-
-## Milestone v0.12: Containment And Hygiene
-
-### A2: Repo-Defined MCP And Agent-Config Containment
-
-- Steps: inventory repo-local MCP/tool-config/instruction surfaces per
-  provider (Codex, Claude, Copilot, Gemini) from the adapter control-plane
-  docs; extend workspace control-plane masking policy to classify each
-  surface as `deny`, `mask`, or `ack-required`; implement `strict`-mode
-  deny-by-default for repo-defined MCP server definitions; add an explicit
-  per-path acknowledgement input on the reviewed policy path; record the
-  decision in the session record.
-- Exit gates: deterministic tests prove repo-local MCP config cannot reach
-  the provider process in `strict` without acknowledgement; masking tables in
-  [`adapter-control-planes.md`](adapter-control-planes.md) updated; scenario
-  manifest parity holds; injection-policy docs describe the new keys.
-- Validation: unit tests per adapter surface, one scenario per provider,
-  mutation coverage over the new policy branch points.
-- Size: M. Dependencies: none.
-
-### A7: OWASP Agentic Top 10 Control Mapping
-
-- Steps: write `docs/owasp-agentic-mapping.md` mapping each Workcell control
-  to ASI01–ASI10 (staged credentials → ASI03, control-plane masking → ASI04,
-  VM boundary → ASI05, session records → observability), including explicit
-  non-coverage rows; link from the threat model and the enterprise evidence
-  baseline.
-- Exit gates: every ASI row states covered/partial/not-covered with the
-  enforcing mechanism or gap named; docs lint and link checks pass.
-- Validation: docs lanes; review lens from the threat-model owner.
-- Size: S. Dependencies: none.
-
-### B3: Mutation Testing Gated In CI
-
-- Steps: add a scheduled and `approved-heavy-ci` mutation lane invoking the
-  existing `scripts/run-mutation-tests.sh` path (today mutation tests run
-  only inside the release-preflight `validate-repo.sh` profile); record the
-  current score as the baseline in a reviewed policy file; fail the lane when
-  the score drops below baseline; surface the score in the job summary.
-- Exit gates: lane green on `main`; baseline file reviewed; release preflight
-  refuses when the recorded baseline regresses.
-- Validation: deliberate mutant-survival dry run proves the gate trips.
-- Size: M. Dependencies: none. Land before the Track D refactors so the
-  refactors inherit a scored safety net.
-
-### B4: Centralized Tool Pins And Action Allowlist
-
-- Steps: create a reviewed policy file holding tool pins (actionlint, zizmor,
-  syft, cosign, buildx, buildkit, QEMU) with integrity hashes; refactor
-  workflows to consume the central values; add a permitted-actions allowlist
-  and a checker that every workflow `uses:` entry matches it; wire both into
-  pre-commit and release preflight.
-- Exit gates: no workflow carries an inline unpinned or off-allowlist tool;
-  checker fails on a seeded violation; pin-hygiene lane covers the new file.
-- Validation: negative-test the checker; full CI pass.
-- Size: S. Dependencies: none.
-
-### B5: Audit-Trail Retention Policy
-
-- Steps: write `docs/retention-policy.md` recording artifact retention per
-  workflow with justification; extend release-evidence artifact retention to
-  90 days; document how to query GitHub attestations and the Rekor
-  transparency log after artifact expiry.
-- Exit gates: retention values in workflows match the documented policy; a
-  drift check compares them.
-- Validation: docs lanes plus the drift check.
-- Size: S. Dependencies: none.
-
-### D1: Language-Boundary Doctrine
-
-- Steps: add a language-boundary section to `AGENTS.md` (or a referenced
-  standalone doc): Rust only for syscall interception and exec guards, Go for
-  policy/state/orchestration logic, shell only as thin glue; new logic
-  defaults to Go; shell growth beyond glue requires stated justification.
-- Exit gates: doctrine reviewed and linked from contributor docs.
-- Validation: docs lanes.
-- Size: S. Dependencies: none. Gates D2–D6 direction.
-
-### D2: Shared Shell Library And Shellcheck Lane
-
-- Steps: extract duplicated `cleanup`, `require_tool`, `die`, JSON, and
-  resolver helpers into `scripts/lib/` shared sources; convert call sites
-  incrementally (one reviewable batch per PR); add a shellcheck lane at
-  warning severity (including SC2154) over `scripts/`.
-- Exit gates: duplicate helper definitions reduced to the shared sources;
-  shellcheck lane green; scenario suite unchanged before/after each batch.
-- Validation: existing scenario and smoke suites per batch; shellcheck in CI.
-- Size: M. Dependencies: D1.
-
-### E3: Support-Tier Legend And Diagnostics Guide
-
-- Steps: write `docs/support-tiers.md` defining `strict`, `compat`,
-  `preview`, `certification candidate`, `experimental`, and `unsupported`
-  with current examples from the host-support matrix; write
-  `docs/diagnostics-and-support-matrix.md` explaining `--doctor`/`--inspect`
-  fields (`support_matrix_*`) with a triage decision tree; link both from
-  README and SUPPORT.
-- Exit gates: every tier word used in README/ROADMAP resolves to one
-  definition; diagnostics fields in the guide match the emitting code.
-- Validation: docs lanes; a deterministic check that documented
-  `support_matrix_*` field names match the code-emitted set.
-- Size: S. Dependencies: none.
-
-### E4: Docs CI Depth
-
-- Steps: add intra-repo markdown link checking and orphan detection to the
-  docs workflow; add status labels (active/planning/historical) to planning
-  docs; add last-verified release markers to the threat model, invariants,
-  and provider matrix; document the local docs-validation command in
-  CONTRIBUTING.
-- Exit gates: link checker fails on a seeded broken link; every `docs/*.md`
-  is either linked from an index/README or explicitly labeled.
-- Validation: docs workflow green with the new checks.
-- Size: S. Dependencies: none. Unblocks confidence for E1 restructuring.
-
-## Milestone v0.13: Boundary Depth And Stability
-
-### A1: Egress Policy Depth And Target Parity
-
-Strict Colima launches already enforce default-deny, per-session egress
-allowlisting (`runtime/profiles/strict.env` sets `NETWORK_POLICY=allowlist`;
-the launcher computes per-session `ALLOW_ENDPOINTS`, applies them through the
-VM-level egress helper, and prints and audits the endpoint set). A1 is the
-delta on that shipped control, not a new lane.
-
-- Steps: document the shipped mechanism as a reviewed policy artifact
-  alongside A6; design review for the delta — an operator-facing
-  injection-policy surface for reviewed per-session allowlist extensions and
-  tightenings, domain/DNS-level and proxy-based filtering options for
-  finer-grained control, and enforcement-parity labeling for targets where
-  the allowlist helper does not apply; implement the reviewed delta with
-  fail-closed diagnostics.
-- Exit gates: the shipped mechanism is documented and covered by
-  deterministic tests (blocked/allowed flows, audited endpoint recording);
-  operator extensions flow through the reviewed policy path; targets without
-  allowlist enforcement are explicitly labeled; docs (injection policy,
-  invariants, threat model) updated; no weakening of the shipped default.
-- Validation: unit plus scenario tests; live boundary exercise on the strict
-  path for the delta before any support-visible claim.
-- Size: M. Dependencies: design review; coordinates with A6 artifacts.
-
-### A3: Fuzzing Expansion And Continuous Fuzzing
-
-- Steps: add Rust fuzz targets (path validation, environment filtering,
-  Git-config parsing) using `cargo-fuzz`; add Go fuzz targets
-  (workflow-YAML, provider-manifest, pinned-inputs parsing); seed corpora
-  from real repo configs; add a scheduled CI fuzz lane with time budget;
-  evaluate OSS-Fuzz onboarding once targets are stable.
-- Exit gates: each named parser has a fuzz target and checked-in corpus; the
-  scheduled lane runs green; crash triage workflow documented.
-- Validation: seeded-crash dry run proves the lane reports failures.
-- Size: M. Dependencies: none (D5 later refactors keep targets intact).
-
-### A4: Unsafe-Code Safety Documentation
-
-- Steps: add `SAFETY:` comments to every `unsafe` block in
-  `runtime/container/rust/src/lib.rs` and binaries, stating the invariant
-  that makes the block sound; add a lint/check that rejects new undocumented
-  unsafe blocks; write the pre-audit checklist.
-- Exit gates: zero undocumented unsafe blocks; check enforced in CI.
-- Validation: Rust build and test lanes; negative-test the check.
-- Size: S. Dependencies: none. Pairs with D5.
-
-### B1: SLSA v1.0 Gap Analysis
-
-- Steps: audit the release path against SLSA Build L1–L3; publish the gap
-  matrix in [`provenance.md`](provenance.md) (hermeticity, builder hardening,
-  two-person review), marking which gaps are structural to single-maintainer
-  mode and what closes each.
-- Exit gates: every SLSA L3 requirement has a status and, where unmet, a
-  named path or explicit non-goal.
-- Validation: docs lanes; release-owner review lens.
-- Size: M. Dependencies: none. Feeds B2 and Phase 11 evidence.
-
-### B7 (part 1): OpenSSF Best Practices Badge
-
-**Deferred to post-1.0 (2026-07-09 criterion-2/6 amendment).** Originally
-sequenced in v0.13; no longer a 1.0 gate. Listed under post-1.0 in the milestone
-train above; this detail section stays here for continuity of the B7 track.
-
-- Steps: register the project, complete the passing-level questionnaire,
-  remediate any unmet criteria, add the badge plus the existing Scorecard
-  badge to README.
-- Exit gates: passing badge live; criteria answers recorded.
-- Validation: badge status page.
-- Size: S. Dependencies: none.
-
-### C5: Syscall-Shim Performance Baselines
-
-- Steps: add microbenchmarks for hooked exec/spawn/posix_spawn paths versus
-  unhooked baseline; record results in a reviewed benchmarks doc; wire an
-  optional benchmark lane.
-- Exit gates: baseline numbers published with methodology; rerun instructions
-  documented.
-- Validation: benchmark lane produces stable numbers across two runs.
-- Size: S. Dependencies: none. Feeds C2 and E6 benchmarking claims.
-
-### D8: Stability Contracts
-
-- Steps: document which internal Go APIs and CLI flags/output lines are
-  stable versus experimental ahead of 1.0; unify and document the exit-code
-  contract across the Rust launcher, Go binaries, and shell entrypoints.
-- Exit gates: contract doc reviewed; any exit-code mismatches found during
-  the audit are fixed or explicitly recorded.
-- Validation: deterministic exit-code tests for documented paths.
-- Size: S. Dependencies: none. Direct input to G1.
-
-### E1: Tiered Documentation Entry Points
-
-- Steps: restructure README around three labeled paths (open-source
-  operator, enterprise evaluator, contributor); extract the operator command
-  reference and long tables into dedicated docs; keep README as orientation
-  plus the 5-minute path.
-- Exit gates: README materially shorter; no content lost (moved, not
-  deleted); link checks pass; quickstart path unchanged or improved.
-- Validation: docs lanes with E4 checks.
-- Size: M. Dependencies: E4 (link checking) strongly preferred first.
-
-### E2: Architecture Diagrams
-
-- Steps: add maintained Mermaid diagrams to
-  [`workcell-system-design.md`](workcell-system-design.md): boundary stack
-  (host/VM/container/provider), policy-to-injection trust flow, control-plane
-  seeding/masking; reference from the enterprise evidence baseline.
-- Exit gates: diagrams render on GitHub; sources live in the repo; evidence
-  baseline links them.
-- Validation: docs lanes; visual review.
-- Size: M. Dependencies: none.
-
-### F3: Standards Watchlist
-
-- Steps: write a short reviewed doc tracking the MCP spec line, OWASP
-  agentic guidance, and agent-identity drafts, with owner and review cadence.
-- Exit gates: doc exists with current entries and next-review date.
-- Validation: docs lanes.
-- Size: S. Dependencies: none.
-
-### G1 (part 1): Public Contract Inventory
-
-- Steps: enumerate the public operator surface — CLI flags, stable output
-  lines (`support_matrix_*`, `provider_bootstrap_*`, session key=value
-  summaries), exit codes, injection-policy schema keys, session-record and
-  export formats — into a versioned contract document; classify each entry
-  stable/experimental/deprecated; reconcile the manpage and CLI reference
-  against the inventory.
-- Exit gates: inventory complete and reviewed; every documented surface has
-  a deterministic test or check referencing it; manpage gaps filed or fixed.
-- Validation: contract-to-code drift check in CI.
-- Size: M. Dependencies: D8. The freeze itself is G1 part 2 at v1.0-rc.
-
-## Milestone v0.14: Platform, Speed, And Adoption
-
-### C1: Apple `container` Backend Evaluation (macOS 26+)
-
-Context: Apple's Containerization framework reached 1.0.0 in June 2026 — one
-lightweight VM per container on Virtualization.framework, sub-second boot, a
-frozen 1.0 API, Apple Silicon only, macOS 26 baseline. Per-session VM
-isolation would be a stronger and lighter boundary than one shared Colima VM.
-
-- Steps: spike behind the existing target-kind contract as
-  `local_vm/apple-container`; map lifecycle, mounts, networking, and
-  diagnostics onto the shared conformance harness; measure boundary
-  properties versus Colima (per-session VM, boot latency); record the
-  evaluation and a go/no-go promotion decision; ship nothing support-visible
-  until the full support-matrix gates pass.
-- Exit gates: written evaluation with conformance results; explicit
-  fail-closed behavior on macOS below 26; promotion decision recorded in the
-  roadmap.
-- Validation: deterministic conformance harness; live local exercise.
-- Size: L. Dependencies: none technically; C2 benefits from it. The 1.0 gate
-  is the recorded decision, not a shipped backend.
-
-### C2: Session Start Latency Program
-
-**Deferred to post-1.0 (recorded 2026-08-01).** The generic startup driver is
-benchmark-only: its caller-provided lifecycle hooks cannot prove the image,
-profile, session, or cleanup facts required for certification. A reviewed
-dedicated-certifier design was rejected because the required state controls would
-broaden the launcher with destructive maintainer operations. The preliminary
-2026-07-15 capture remains historical measurement evidence only; it does not meet
-or gate a 1.0 latency target.
-
-- Post-1.0 steps: measure and publish the current cold/warm start breakdown;
-  add prebaked per-project image caching under the existing cache-profile
-  labeling; evaluate a kept-warm VM lane as an explicit labeled mode; publish
-  reproducible startup benchmarks; and set any resulting latency target.
-- Post-1.0 exit gates: a certification design must prove lifecycle state without
-  widening the supported launcher surface before any performance claim or target.
-- 1.0 exit gate: recorded rationale in ROADMAP/G4; no C2 performance claim.
-- Validation: benchmark lane for non-certifying measurements; a future dedicated
-  certification review before any support or performance claim.
-- Size: M. Dependencies: C5 methodology; C1 informs the ceiling.
-
-### B8: CI Efficiency And Reliability Program
-
-- Steps: move expensive reproducibility checks to a nightly lane on `main`
-  with release preflight consuming the recorded result; add retry policy for
-  transient artifact/network steps; add flaky-test tracking (label plus
-  weekly report); add CI cost visibility reporting.
-- Exit gates: PR wall-clock reduced without losing release-time assurance;
-  flake report exists; cost report exists.
-- Validation: before/after CI timing evidence.
-- Size: M. Dependencies: none.
-
-### B9: CI/CD Threat Model
-
-- Steps: write `docs/ci-threat-model.md`: secrets handling and rotation,
-  runner trust tiers (GitHub-hosted versus self-hosted), attestation
-  verification assumptions, signing-compromise incident response.
-- Exit gates: doc reviewed; SECURITY.md links it.
-- Validation: docs lanes; security review lens.
-- Size: M. Dependencies: none. Gated B6, now deferred to post-1.0 (2026-07-09
-  criterion-6 amendment).
-
-### D3 (start): Migrate Largest Orchestration Scripts To Go
-
-- Steps: reimplement `verify-invariants.sh` (9,131 lines) and
-  `container-smoke.sh` (4,570 lines) incrementally as Go commands under
-  `cmd/`, one check-group per PR, keeping scenario parity via existing
-  manifests; retire shell paths only when their Go replacements have equal or
-  better coverage.
-- Exit gates: per batch — identical pass/fail behavior on the scenario
-  corpus; final (v1.0-rc) — shell originals removed or reduced to thin
-  shims.
-- Validation: side-by-side runs during migration; mutation coverage on the
-  Go replacements.
-- Size: L. Dependencies: D1; D2 reduces churn first; B3 baseline in place.
-
-### D4: Modularize The Launcher
-
-- Steps: split `scripts/workcell` (8,910 lines) into sourced modules (host
-  detection, environment scrubbing, wrapper assembly, dispatch); write
-  [`launcher-contract.md`](launcher-contract.md) (required tools, environment
-  expectations, exit codes, test override flags).
-- Exit gates: behavior-identical on the scenario suite; contract doc matches
-  implementation.
-- Validation: scenario suite before/after; bats coverage for extracted
-  modules (D7).
-- Size: M. Dependencies: D1, D2.
-
-### E5: Injection-Policy Schema Documentation
-
-- Steps: expand [`injection-policy.md`](injection-policy.md) with an
-  annotated schema (each key: type, required/optional, provider
-  applicability) and complete per-provider example policies including the
-  multi-provider single-host pattern; add a check that documented keys match
-  the parser's accepted set.
-- Exit gates: schema doc complete; drift check green.
-- Validation: docs lanes plus the drift check.
-- Size: M. Dependencies: A2 adds keys — document them together; feeds G1.
-
-### E6: Adoption Growth Kit
-
-**Deferred to post-1.0 (2026-07-09 criterion-7 amendment).** 1.0 ships with
-in-repo markdown docs. C2 remains post-1.0 and its generic benchmark output is
-not a certification substitute. This detail section stays here for continuity of
-the E6 track.
-
-- Steps: publish a rendered docs site from the existing markdown; record
-  asciinema demos for the 5-minute path and one provider quickstart; ship a
-  Homebrew tap alongside the formula asset; write the "why a VM boundary"
-  architecture post backed by C5/C2 benchmark numbers.
-- Exit gates: site live; demos embedded; tap installable; post published
-  with reproducible benchmark methodology.
-- Validation: install-from-tap verification lane; docs lanes.
-- Size: M. Dependencies: C5 (numbers), E1 (structure) first.
-
-### E7: Contributor Runbook Depth
-
-- Steps: give adapter READMEs real content (auth methods, managed
-  control-plane files, adapter behavior summary); add worked contributor
-  examples (add a credential type, extend an adapter) with the
-  invariants/threat-model checklist each touches.
-- Exit gates: no stub adapter README remains; examples verified by following
-  them.
-- Validation: docs lanes; dry-run of one worked example.
-- Size: S. Dependencies: none.
-
-### G2: Support Bundle Command
-
-- Steps: design the `workcell support-bundle` collection set (install state,
-  policy view, target diagnostics, provider bootstrap summaries, session
-  metadata, recent audit pointers) with documented redaction rules; implement
-  host-side with deterministic output shape; document the operator flow in
-  SUPPORT.md.
-- Exit gates: bundle contains the evidence needed to diagnose install,
-  policy, target, provider, and runtime failures; redaction tests prove no
-  credential material or workspace content leaks; docs updated.
-- Validation: unit tests over collection and redaction; golden-file bundle
-  shape; one scenario per failure class.
-- Size: M. Dependencies: none; coordinates with F1 field naming.
-
-### Provider Parity: Google Antigravity CLI Tier 1 Adapter
-
-Runs as the already-committed provider-parity track under its existing exit
-gates (adapter, pinned install/auth provenance, explicit Google auth staging,
-session-local provider home/cache, unsafe-argument policy, quickstart,
-deterministic tests, live provider certification). This plan adds only
-sequencing: the track runs inside the 1.0 window starting v0.14, and its
-outcome — support claim or explicitly recorded deferral — is a G4 input. No
-shortcut to the Tier 1 evidence bar.
-
-## Milestone v0.15: Enterprise Evidence And Release Assurance
-
-### A5: Signed Session Audit Records
-
-- Steps: design the hash-chain format for session audit logs; sign chain
-  heads host-side with existing Sigstore tooling; add verification tooling
-  (`workcell session verify` shape decided at design review); document the
-  trust model (boundary-signed, not agent-signed).
-- Exit gates: tamper on any record breaks verification in tests; export
-  format versioned; docs updated.
-- Validation: unit tests over chain/verify; scenario for tamper detection.
-- Size: M. Dependencies: F1 format decisions coordinated.
-
-### A6: Documented Syscall And Filesystem Hardening Profile
-
-- Steps: extract the runtime container's effective seccomp posture,
-  capability set, and rootfs expectations into reviewed policy artifacts;
-  publish the outbound-endpoint inventory; add a deterministic conformance
-  check comparing artifacts to the built image.
-- Exit gates: conformance check green in CI and release preflight; docs
-  reference the artifacts.
-- Validation: negative-test the conformance check.
-- Size: M. Dependencies: A1 design informs the endpoint inventory.
-
-### B2: Dual-Control Release Approval
-
-**Deferred to post-1.0 (2026-07-09 criterion-6 amendment).** Workcell has no
-second trusted maintainer today; 1.0 uses the single-maintainer compensating
-controls documented in `docs/releasing.md` instead. This detail section stays
-here for continuity of the B2 track.
-
-- Steps: add a second release approver identity; require two approvals on
-  the release environment; update `docs/releasing.md` including the
-  emergency bypass and its audit trail.
-- Exit gates: hosted controls enforce two approvals; releasing doc updated;
-  hosted-controls audit lane verifies the setting.
-- Validation: hosted-controls workflow assertions.
-- Size: M. Dependencies: a second trusted maintainer; B1 recommended first.
-
-### B6: Real-Boundary Certification Lane In CI
-
-**Deferred to post-1.0 (2026-07-09 criterion-6 amendment, no runner funding).**
-Originally sequenced in v0.15; no longer a 1.0 gate — listed under post-1.0 in
-the milestone train. 1.0 uses local-operator certification of both boundaries
-instead (see `docs/b6-disposition-options-draft.md`). This detail section stays
-here for continuity of the B6 track.
-
-- Steps: with B9 landed, evaluate self-hosted Apple Silicon runner options
-  versus macOS CI services; treat the runner as lower-trust per the threat
-  model (no repo secrets beyond scoped runner registration); implement a
-  scheduled lane that launches the strict Colima path and runs the
-  certification smoke; document runner lifecycle.
-- Exit gates: scheduled lane exercises a real strict launch; failure alerts
-  actionable; threat model covers the runner.
-- Validation: the lane itself plus induced-failure drill.
-- Size: L. Dependencies: B9.
-
-### C3: Native Parallel Sessions
-
-- Status: implemented and locally certified on 2026-08-03. The exact-tree
-  pre-merge certification is bound to signed activation commit `a26b750f`;
-  shipped status depends on that commit being reachable from `main`.
-- Delivered: worktree-aware session handling with one branch, isolated
-  worktree, and container per session; linked origin-repository metadata;
-  per-session resource and identity boundaries; and launch, inventory, and
-  diff flows for concurrent same-repository sessions.
-- Exit gates: deterministic tests prove clone/branch separation and
-  write-invisibility; session tooling renders the parallel topology; the live
-  strict-path certification proved two overlapping sessions could not observe
-  each other's markers and that one stopped independently while the other
-  remained live.
-- Validation: `test-session-commands.sh`, `internal/host/c3certify` tests, and
-  the live evidence in
-  `docs/benchmark-evidence/c3-two-container-isolation-2026-07-15.md`.
-- Size: L. Sequencing note: C3 was implemented and certified independently of
-  C2. C2 can improve parallel-session startup latency but does not gate C3; the
-  C1 decision can inform future per-session-VM isolation.
-
-### D5: Modularize The Rust Interception Library
-
-- Steps: split `lib.rs` (2,288 lines) into focused modules (syscall shim,
-  git policy, runtime protection, path validation) preserving the exported
-  ABI; keep A3 fuzz targets and A4 safety docs green through the refactor.
-- Exit gates: no behavior change on runtime test surface; module boundaries
-  documented; unsafe-block documentation preserved.
-- Validation: full runtime test suite plus fuzz corpus replay before/after.
-- Size: L. Dependencies: A3, A4 first (safety net before refactor).
-
-### D7: Deepen Test Kinds
-
-- Steps: add property-based tests for the session lifecycle state machine
-  (attach/detach/timeout idempotency, signal races); add Go benchmarks for
-  validation and session hot paths; add a bats (or equivalent) unit lane for
-  shared shell helpers from D2.
-- Exit gates: new lanes green in CI; at least one previously untested
-  interleaving covered.
-- Validation: the lanes themselves; mutation score movement (B3).
-- Size: M. Dependencies: D2 for the shell portion; extends to C3's parallel
-  session states.
-
-### F1: OCSF-Mapped Audit Export
-
-- Steps: map session-record fields to OCSF classes per the OWASP Agent
-  Observability Standard; add an OCSF JSONL export mode to
-  `workcell session export`; document redaction rules and privacy
-  boundaries; version the mapping.
-- Exit gates: exported events validate against the OCSF schema; redaction
-  tests pass; Phase 17 docs reference the format.
-- Validation: schema-validation tests; golden-file exports.
-- Size: M. Dependencies: A5 coordinated (signed records should export
-  cleanly); shares redaction rules with G2.
-
-### G3: Install Lifecycle Proof
-
-- Steps: define the day-two evidence set — install, upgrade-in-place across
-  one minor version, uninstall, rollback, `--gc` — on the release matrix;
-  add config/schema compatibility reads where upgrades cross versioned
-  formats; automate what GitHub-hosted macOS runners can prove and record
-  the local-operator remainder as certification evidence. The install step
-  must exercise the verified path (`scripts/install-release.sh`, which
-  downloads and `cosign`-verifies the signed `SHA256SUMS` fail-closed before
-  installing) end-to-end against a published release, not just the bundle's
-  own `install.sh`, and make that verified path the default install flow.
-  Together — verification as the forced default across documented install
-  paths plus an end-to-end CI proof — these fully close ci-threat-model known
-  gap 1, which today is only partially addressed (the verified path exists but
-  is opt-in).
-- Exit gates: each lifecycle operation has repeatable evidence; upgrade and
-  rollback leave no orphaned Workcell-owned state; docs match behavior.
-- Validation: CI install-matrix lanes extended with upgrade/rollback;
-  scenario coverage for state cleanup.
-- Size: M. Dependencies: G1 inventory (formats must be versioned to prove
-  compatibility).
-
-## Milestone v1.0: Freeze And Gate
-
-### G1 (part 2): Contract Freeze And Deprecation Policy
-
-- Steps: publish the semantic-versioning and deprecation policy; mark the
-  inventoried surface frozen; convert the contract-to-code drift check into
-  a release gate; declare experimental surfaces explicitly.
-- Exit gates: every stable surface is versioned, tested, and documented in
-  the manpage/CLI reference; deprecation policy published; drift gate
-  enforced in release preflight.
-- Validation: contract drift gate; release preflight dry run.
-- Size: M. Dependencies: G1 part 1, D8, E5.
-
-### G4: 1.0 Readiness Gate Review
-
-- Steps: run the cross-lens review (product, enterprise/security,
-  adapter-maintainer, validation, docs/contract, release) against the 1.0
-  release criteria in the roadmap; verify every host-support and provider
-  matrix row against shipped behavior; record all scope decisions (for
-  example an Antigravity certification deferral) explicitly; file and burn
-  down any P0/P1 findings.
-- Decision (recorded 2026-08-01): C2's 1.0 latency target and certification are
-  deferred to post-1.0. The generic benchmark remains benchmark-only; the
-  rejected dedicated-certifier design does not create a launcher control surface.
-- Exit gates: no unresolved P0/P1 findings; matrices verified; scope
-  decisions recorded; criteria checklist complete with evidence links.
-- Validation: the recorded review itself.
-- Size: S (review) over the rc period. Dependencies: everything above.
-- Status (recorded 2026-08-04): COMPLETE. The six-lens review verified the
-  support and provider matrices, recorded every scope decision, closed its two
-  initial P1 findings and one subsequent Codex review finding, and finished
-  with no unresolved P0/P1 findings. Exact identities and evidence links are in
-  `docs/1.0-readiness-review.md`.
-
-### D3 (complete): Orchestration Migration Finished
-
-- Exit gates: `verify-invariants` and `container-smoke` fully served by Go
-  implementations with equal or better coverage; shell originals removed or
-  reduced to thin shims.
-
-- Status (recorded 2026-07-09, evidence-based, scope narrowed): the bulk of the
-  `verify-invariants` **static-invariant** scope is migrated to Go. Most static
-  file-content, regex, function-block, filesystem (`-d`/`-x`/`-f`), and
-  JSON-expression (`jq -e` scalar/array/index/truthiness/type) invariants live in
-  `internal/workcellhardening` behind `cmd/workcell-citools` subcommands (50
-  delegations from `scripts/verify-invariants.sh`). A documented narrow residual
-  of static repo-file assertions still runs inline in `scripts/verify-invariants.sh`
-  using `sed`/`awk` (e.g. the `run_in_vm` order check in
-  `scripts/colima-egress-allowlist.sh`); this is an accepted static residual,
-  not a completed migration. A genuinely non-static tail also stays in bash by
-  design (`jq -r` guards over runtime `mktemp`-generated manifests, `jq -e`
-  stdin guards, awk/sed helpers, and
-  `HOST_GATE_SCRIPTS` runtime harnesses). Scope narrowing decision (2026-07-09):
-  D3 (complete) is satisfied by this recorded narrowing — "bulk of `verify-invariants`
-  static invariants in Go; the static remainder, non-static tail, and
-  `container-smoke` orchestration stay in bash by design, with the residual
-  documented and accepted". Container-smoke.sh migration is a post-1.0 code-health
-  item, not a D3-complete gate. This narrowing is evidence-based, not a gap.
-
-### D6: Split Oversized Go Validators
-
-- Steps: split `pinnedinputs.go` (1,546 lines) into per-format packages
-  (docker, node, rust, workflows, python) with focused tests; apply the same
-  pattern to the largest dispatcher mains.
-- Exit gates: behavior-identical validation results on the existing corpus;
-  per-package tests.
-- Validation: existing pin-hygiene lanes before/after; mutation coverage.
-- Size: M. Dependencies: none; scheduled late to avoid churn against B4.
-
-- Historical status (recorded 2026-07-08, evidence-based): PARTIAL. The GitHub Actions
-  workflow format is already extracted into
-  `internal/metadatautil/pinnedinputs_workflows.go` (PR #453). The remaining
-  split is a real behavior-preserving refactor lane, not a doc finalization:
-  `internal/metadatautil/pinnedinputs.go` still holds a single 1,458-line
-  `CheckPinnedInputs` function (lines 51–1509) in which the docker, node, rust,
-  go-toolchain, and provider-version checks are **interleaved**, not contiguous —
-  they share ~43 uses of locals computed once at the top (`runtimeDockerfile`,
-  `repoRoot`, `cargoManifestText`, `rustToolchainText`) and depend on a fixed
-  first-failure order. A clean per-format-package split must first extract
-  cohesive helpers, thread that shared state, and preserve byte-exact error
-  messages and check ordering (the same first-failure-order hazard D3 hit), so it
-  is an L-effort lane best carried as one or more dedicated behavior-preserving
-  PRs (one format per PR: rust, then node/docker/provider, then go-toolchain),
-  each proven identical on the existing pin-hygiene corpus before and after. The
-  D6 "largest dispatcher mains" clause (`cmd/workcell-hostutil/main.go` at 1,300
-  lines) is likewise a separate refactor slice. This does not gate 1.0
-  correctness — the validators already pass — it is a code-health split; the
-  G4 therefore had to decide whether D6 (complete) was required for the 1.0
-  gate or could carry into post-1.0 as a code-health item.
-- Update (recorded 2026-07-09): the largest pinned-input ecosystems are split
-  into their own files (GitHub Actions workflows in `pinnedinputs_workflows.go`,
-  Node/npm in `pinnedinputs_node.go`, and Docker in `pinnedinputs_docker.go`); the
-  small Rust (~129 lines) and Python (~7 lines) validators remain inline as an
-  accepted, non-oversized remainder. The D6 de-oversizing goal is met —
-  `pinnedinputs.go` is no longer oversized. G4 accepted the small inline
-  validators and remaining dispatcher-main refactor as post-1.0 code-health
-  work, so D6 is complete for the 1.0 gate.
-
-## Post-1.0
-
-### B7 (part 2): Third-Party Boundary Audit
-
-- Steps: scope an external audit of the runtime boundary (Rust shim, VM and
-  container configuration, credential staging); pursue funding (OSTIF or
-  sponsor); remediate and publish results. Scheduling the audit was originally a
-  1.0 criterion but is **deferred to post-1.0 by the 2026-07-09 criterion-2
-  amendment** (no audit sponsor/funding); completing it remains post-1.0 work.
-- Exit gates: audit report published; findings triaged to closure or
-  explicit acceptance.
-- Size: L. Dependencies: A3, A4, D5 (audit-ready code).
-
-### C4: Container Tooling Inside The Boundary
-
-- Steps: investigate rootless or nested container execution inside the
-  bounded runtime; document the assurance impact; if viable, ship as an
-  explicit labeled lane, never as a silent capability of `strict`.
-- Exit gates: written investigation with a go/no-go; any shipped lane has
-  its own tier label, diagnostics, and scenario evidence.
-- Validation: boundary tests proving the outer VM/container posture is
-  unchanged when the lane is off.
-- Size: L. Dependencies: C1 evaluation informs the mechanism.
-
-### F2: Per-Session Identity Groundwork
-
-- Steps: define a stable trust-domain session identifier (SPIFFE-style URI
-  shape) and stamp it into session records and exports; keep it local-first
-  (no hosted control plane); document how Phase 15 identity work consumes
-  it.
-- Exit gates: identifier present and stable across session lifecycle;
-  export formats (F1) carry it; docs updated.
-- Validation: unit tests over identifier stability; export golden files.
-- Size: M. Dependencies: F1.
-
-### Roadmap Phases 13–19
-
-Linux `amd64` promotion (Phase 13), Linux `arm64`/Raspberry Pi (Phase 14),
-identity and access (Phase 15), signed policy bundles (Phase 16), fleet
-inventory and audit export beyond F1 (Phase 17), the regulated-team proof
-harness and Windows investigation (Phase 18), and the managed-workstation
-preview plus Azure (Phase 19) continue under their existing exit gates.
-Phase 13 is work after 1.0. It creates no Linux support claim.
-
-## Dependency Summary
-
-- D1 → D2 → D3/D4; A3 + A4 → D5; D2 → D7 (shell portion)
-- B9 → B6; B1 → B2; B3 baseline before D3/D5 refactors land
-- C5 informs the post-1.0 C2 program; C2 can improve C3 latency but does not
-  gate the completed C3; the C1 decision informs C2/C3/C4
-- E4 → E1 → E6; A2 → E5; D8 → G1 (inventory) → G1 (freeze); E5 → G1 (freeze)
-- G1 (inventory) → G3; A5 ↔ F1 coordinated; F1 → F2; G2 ↔ F1 redaction rules
-- A3/A4/D5 → B7 (part 2); everything → G4
-
-## Verification Model
-
-- every code-bearing item lands tests-first with unit, integration, and —
-  where the touched packages already carry it — mutation coverage
-- refactor items (D2–D6) require identical behavior on the existing scenario
-  corpus before and after, per batch
-- security items (A1, A2, A5, A6) require fail-closed negative tests and
-  threat-model/invariants updates in the same change
-- CI items (B3, B4, B6, B8) require a seeded-failure drill proving the gate
-  actually trips
-- operations items (G2, G3) require redaction/negative tests and repeatable
-  lifecycle evidence, not one-off manual runs
-- support-visible changes (C1 promotion, C3, C4 lanes, Antigravity support)
-  additionally require the standard support-matrix, diagnostics, docs,
-  rollback, and live certification package before any claim
-- the 1.0 claim itself requires the G4 gate review with recorded evidence
-
-## Status Tracking
-
-Track progress by item identifier in PR titles and the changelog. When an
-item completes, record the delivered evidence next to its roadmap entry;
-when an item is dropped or reshaped, update both this plan and the roadmap
-section in the same change. Milestone reassignment is a normal, recorded
-event; silently skipping a 1.0 criterion is not.
+# 1.0 improvement-track delivery record
+
+Status: historical record.
+
+Workcell published `v1.0.2` on 2026-08-05.
+This release completed the 1.0 program.
+The `v1.0.0` and `v1.0.1` tags did not produce published releases.
+
+This page records the result of the improvement plan that started in July 2026.
+It is not the plan for new work.
+See the [roadmap](../ROADMAP.md) for current work and sequencing.
+See the [1.0 readiness review](1.0-readiness-review.md) for the final evidence.
+
+## Status terms
+
+- **Complete**: The reviewed 1.0 scope shipped.
+- **Evaluated**: The evaluation finished, but the result did not create support.
+- **Implemented and locally certified**: The feature shipped, and local live certification passed.
+- **Complete for 1.0**: The G4 review accepted the shipped scope and named the remaining work.
+- **Partial**: Part of the original scope shipped, and named work remains.
+- **Post-1.0**: The maintainer explicitly deferred the item.
+- **Later**: The item remains an idea and has no delivery commitment.
+
+These terms do not create a support claim.
+The [support tiers](support-tiers.md) define the supported targets and assurance classes.
+
+The [roadmap milestone train](../ROADMAP.md#milestone-train) records the historical sequence.
+
+## Track A: boundary and agent-threat controls
+
+| ID | Result | Shipped record |
+| --- | --- | --- |
+| A1 | Complete | Strict Colima uses default-deny egress rules. The injection policy can add reviewed endpoints. Other targets have explicit assurance labels. See [outbound endpoints](outbound-endpoints.md) and [injection policy](injection-policy.md). |
+| A2 | Complete | Workcell denies repository MCP files by default. The lower-assurance exception requires `--allow-repo-mcp` and a dated `--ack-repo-mcp` value. Workcell masks provider and Git control paths by default. See [adapter control planes](adapter-control-planes.md). |
+| A3 | Complete | Rust and Go fuzz targets run in the fuzz workflow. See [fuzzing](fuzzing.md) and the `Fuzz` workflow. |
+| A4 | Complete | Rust unsafe blocks have `SAFETY:` records. The repository includes an [unsafe-code audit checklist](unsafe-code-audit-checklist.md). |
+| A5 | Complete | On chain-capable targets, verification covers records through the signed session head. Workcell seals this head with a per-host ECDSA P-256 key that has no external trust anchor. See [signed session audit records](signed-session-audit-records.md). |
+| A6 | Complete | The repository versions the hardening profile and its deterministic checks. See [hardening profile](../policy/hardening-profile.toml) and [invariants](invariants.md). |
+| A7 | Complete | The [OWASP agentic mapping](owasp-agentic-mapping.md) records containment, partial coverage, and gaps. |
+
+## Track B: supply chain and release assurance
+
+| ID | Result | Shipped record |
+| --- | --- | --- |
+| B1 | Complete | The [provenance record](provenance.md) maps the release path to SLSA v1.0 and records unmet levels. |
+| B2 | Post-1.0 | Workcell has no second trusted maintainer. The [release process](releasing.md) records single-maintainer controls and does not claim separation of duties. |
+| B3 | Complete | The mutation workflow runs weekly and with the `approved-heavy-ci` label. The versioned mutation policy enforces the score. See [mutation policy](../policy/mutation-score-policy.json). Mutation testing is not limited to release preflight. |
+| B4 | Complete | Workcell keeps tool pins and the GitHub Actions allowlist in reviewed policy files. See [tool pins](../policy/tool-pins.toml) and [allowed actions](../policy/allowed-actions.toml). |
+| B5 | Complete | The [retention policy](retention-policy.md) records workflow retention and post-expiry evidence sources. |
+| B6 | Post-1.0 | Certification on hosted Apple Silicon did not ship. The [B6 decision record](b6-disposition-options-draft.md) records the funding and trust limits. Local certification supplies the 1.0 evidence. |
+| B7 | Post-1.0 | The OpenSSF Best Practices badge and a funded third-party boundary audit did not ship. |
+| B8 | Complete | Heavy pull-request builds require the `approved-heavy-ci` label. Reproducibility runs on each main push and during release preflight. Weekly reports show flake candidates and workflow durations. |
+| B9 | Complete | The [CI threat model](ci-threat-model.md) records runner tiers, permissions, secrets, attestations, and incident actions. |
+
+## Track C: runtime platform
+
+| ID | Result | Shipped record |
+| --- | --- | --- |
+| C1 | Evaluated | The Apple container evaluation returned GO for technical feasibility. The preview writes audit lifecycle records without signatures. Workcell blocks operator launch. Colima remains the reviewed default. See [Apple container evaluation](apple-container-evaluation.md). |
+| C2 | Post-1.0 | Workcell has benchmark evidence, but it has no certified claim for session start time. See [session startup benchmarks](session-startup-benchmarks.md). |
+| C3 | Implemented and locally certified | Native parallel sessions use separate worktrees, branches, runtimes, and linked session records. Local certification passed on 2026-08-03. |
+| C4 | Later | A nested container-tooling lane did not ship. Any future lane must keep the outer VM and container boundary. |
+| C5 | Complete | The benchmark lane reports syscall-shim exec and spawn measurements and run-to-run stability. |
+
+## Track D: code health
+
+| ID | Result | Shipped record |
+| --- | --- | --- |
+| D1 | Complete | The repository agreement assigns Rust to the shim, Go to policy and orchestration, and shell to glue. |
+| D2 | Complete | Shared shell helpers and the shellcheck lane shipped. |
+| D3 | Complete | Go owns most of the static invariant scope. Bash keeps an accepted static residual, the dynamic tail, and smoke orchestration. The G4 review accepted this boundary. |
+| D4 | Complete | Launcher modules and the [launcher contract](launcher-contract.md) shipped. |
+| D5 | Partial | Workcell extracted the Rust git-policy module. More interception-library splits remain after 1.0. |
+| D6 | Complete for 1.0 | Workcell split the large Go validators by major format. Small inline validators and a dispatcher refactor remain code-health work. |
+| D7 | Partial | Property-based session tests and shell-protocol coverage shipped. More Go benchmarks and shell unit tests remain. |
+| D8 | Complete | The [stability contract](stability-contract.md) records public, internal, and exit-code rules. |
+
+## Track E: documentation and adoption
+
+| ID | Result | Shipped record |
+| --- | --- | --- |
+| E1 | Complete | README entry points and the documentation map serve operators, evaluators, and contributors. |
+| E2 | Complete | The [system design](workcell-system-design.md) contains maintained architecture diagrams. |
+| E3 | Complete | The [support tiers](support-tiers.md) and [diagnostics guide](diagnostics-and-support-matrix.md) define the emitted support fields. |
+| E4 | Complete | Documentation CI checks links, orphans, spelling, man pages, support-field parity, and public-contract drift. |
+| E5 | Complete | The [injection policy](injection-policy.md) has an annotated schema and provider examples. |
+| E6 | Post-1.0 | A rendered documentation site, external demos, a Homebrew tap, and an architecture article did not ship. |
+| E7 | Complete | Contributor procedures and adapter-specific README files shipped. |
+
+## Track F: enterprise and standards
+
+| ID | Result | Shipped record |
+| --- | --- | --- |
+| F1 | Complete | `workcell session export` produces JSON bundles and OCSF 1.3.0 JSON Lines streams. |
+| F2 | Later | SPIFFE-style session identity did not ship. |
+| F3 | Complete | The [standards watchlist](standards-watchlist.md) records sources, owners, and review cadence. |
+
+## Track G: 1.0 contract and operations
+
+| ID | Result | Shipped record |
+| --- | --- | --- |
+| G1 | Complete | The repository versions the public contract inventory, v1 stability classes, deprecation policy, and drift checks. |
+| G2 | Complete | `workcell support-bundle` ships with documented collection and redaction rules. This command is not future work. |
+| G3 | Complete | The tagged-release installer verifies by default and has an acknowledged bypass. Direct `install.sh` runs from a source tree or downloaded bundle do not perform the tagged-release verification. Hosted checks prove installation and link removal, not complete uninstall behavior. See [install lifecycle](install-lifecycle.md). |
+| G4 | Complete | The [1.0 readiness review](1.0-readiness-review.md) records fixed evidence identities, scope decisions, and no unresolved P0 or P1 findings. |
+
+## Provider item: Google Antigravity
+
+Google Antigravity support did not ship in the 1.0 program.
+The v0.14 work delivered a fail-closed adapter scaffold.
+It does not install, authenticate, or launch Antigravity.
+
+### Current status
+
+The [provider matrix](provider-matrix.md) lists Antigravity as unsupported.
+The `Current support` table and supported-provider set exclude it.
+The roadmap keeps it as post-1.0 provider work.
+Do not use the old milestone assignment as a support claim.
+
+## Recorded scope decisions
+
+- On 2026-07-09, the maintainer deferred B2, B6, B7, and E6.
+- On 2026-08-01, the G4 review deferred C2 and its certified start time target.
+- On 2026-08-04, the G4 review completed with no unresolved P0 or P1 finding.
+- On 2026-08-05, Workcell published `v1.0.2` and completed the 1.0 program.
+
+## Evidence index
+
+- The [1.0 readiness review](1.0-readiness-review.md) gives the final item status and exact evidence identities.
+- The [roadmap program record](../ROADMAP.md#10-program-record) records the release result and deferred work.
+- The [release process](releasing.md) records the single-maintainer controls.
+- The [support tiers](support-tiers.md) record the current support boundary.
+
+The repository does not claim independent approval or hosted real-boundary certification for 1.0.
+
+## Current work
+
+Do not add new planned work to this historical record.
+Add current work to the [roadmap](../ROADMAP.md) or to a focused design record.
+If a shipped fact changes, update this record and the roadmap in the same review unit.


### PR DESCRIPTION
## Summary

- Replace the old implementation plan with the historical 1.0 delivery record.
- Align README and roadmap statements with shipped behavior.
- Use Simplified Technical English in the changed text.

## Validation

- Three exact-hash adversarial reviews accepted source truth, security, and STE.
- `./scripts/check-doc-links.sh`
- `./scripts/verify-operator-contract.sh`
- `./scripts/verify-requirements-coverage.sh`
- `./scripts/check-dead-code.sh`
- `./scripts/check-public-repo-hygiene.sh`
- `./scripts/ci/job-docs.sh`
- `./scripts/pre-merge.sh --profile pr-parity`
