### PR TITLE
Revise incident and audit documentation

### DIFF
--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -1,403 +1,321 @@
 # Operator Boundary-Incident Response Runbook
 
-This runbook is for an **operator** who suspects a **runtime boundary breach**
-on a Workcell host: an agent escaping the session boundary, host credential
-exposure, or workspace/control-plane tampering. It is the operational companion
-to the [runtime-boundary threat model](threat-model.md); the
-[CI/CD threat model](ci-threat-model.md) covers the separate
-signing-compromise case (build and release pipeline), not a live session.
+Use this runbook when you suspect a Workcell runtime boundary breach.
 
-This runbook **stitches together shipped tooling** — it introduces no new
-commands. Every command below exists today unless it is explicitly marked as
-roadmapped. Work top to bottom: **detect, contain, preserve, collect, verify,
-report, recover.** When time is short, the order that matters most is
-**contain, then preserve before collect** — never clean or garbage-collect
-before evidence is off the box.
+First, contain the session. Then preserve evidence before you collect or inspect
+it.
 
-## 0. Scope
+Do not run `workcell gc`. Do not run `workcell session delete` before you
+preserve and report the evidence.
 
-Use this runbook for a suspected violation of a runtime trust boundary defined
-in the [threat model](threat-model.md#trust-boundaries), for example:
+For a build or release incident, use the
+[CI/CD threat model](ci-threat-model.md#signing-compromise-incident-response).
 
-- reads of host secrets outside the documented boundary (credential exposure)
-- writes outside the intended workspace without explicit `breakglass`, or
-  unmanaged host socket/credential passthrough (agent escape)
-- repo-local control-plane files replacing reviewed provider baselines, or
-  silent trust widening through repo content (workspace/control-plane tamper)
+## 1. Scope and severity
 
-These mirror the **in-scope** reports in [`SECURITY.md`](../SECURITY.md#in-scope).
-For anything in the build/release pipeline, use the
-[signing-compromise runbook](ci-threat-model.md#signing-compromise-incident-response)
-instead.
+Use this runbook for these events:
 
-## 1. Detect and triage
+- A session reads a host secret outside the documented boundary.
+- A session writes outside the workspace without explicit `breakglass`.
+- A session receives an unmanaged host socket or credential store.
+- Workspace content changes provider controls or mutable Git controls.
+- A session has unexpected outbound access.
 
-Signals that a session may have crossed a boundary:
+These events match the runtime scope in [`SECURITY.md`](../SECURITY.md#in-scope).
 
-- **Assurance downgrade.** Each session record carries an initial, current, and
-  final assurance state (see the
-  [session supervisor design](workcell-session-supervisor-design.md#data-model)).
-  A session that *ended lower-assurance* (for example a warning that
-  package-manager mutations ran as root inside the container) is a triage signal,
-  not proof, but it warrants review.
-- **Unexpected workspace changes.** `workcell session diff --id SESSION_ID`
-  renders the current workspace against the clean git base recorded at launch. It
-  is read-only and fails closed if it cannot trust the comparison. Unexpected
-  edits — especially to control-plane files (agent config, MCP config, git
-  config) — are a tamper signal.
-- **Boundary/egress anomalies.** Unexpected outbound behavior on the managed
-  Colima path, or host secrets/sockets that should never have been reachable
-  (see the [threat model controls](threat-model.md#controls)).
-- **Live host state.** `workcell --agent <provider> --doctor` and
-  `workcell --agent <provider> --inspect` report resolved profile, target, and
-  launch/assurance state; use
-  [diagnostics-and-support-matrix.md](diagnostics-and-support-matrix.md) to read
-  the fields.
+Treat host-secret exposure or a confirmed sandbox escape as critical. Treat
+workspace control-plane changes as high severity.
 
-**Severity.** Treat host **secret exposure** and confirmed **sandbox escape**
-(a write outside the workspace without `breakglass`, or host socket/credential
-passthrough) as **critical** — these are the cases
-[`SECURITY.md`](../SECURITY.md#response) prioritizes. Treat workspace/control-plane
-tamper without confirmed host reach as **high**. If in doubt, escalate at the
-higher severity and let the assessment downgrade it.
+## 2. Immediate safety rules
 
-## 2. Contain
+- Do not delete a session, profile, VM, container, or state file.
+- Do not run `workcell gc` before evidence collection is complete.
+- Do not publish raw audit data, workspace data, or credentials.
+- Use the session record to identify the target. Do not use `--inspect` for this
+  purpose.
+- Stop active execution immediately when continued execution creates more risk.
 
-Stop the affected session(s) and halt further agent execution before you
-investigate.
+An immediate VM stop can destroy volatile network evidence. Stop immediately
+when active execution increases host exposure.
 
-1. **Inventory sessions.** `workcell session list` (add `--verbose` for target
-   and workspace transport, or `--json` to script it) shows every recorded
-   session with its live status, profile, and id.
-2. **Stop a detached session.** `workcell session stop --id SESSION_ID` performs
-   a graceful stop (`docker stop`); add `--force` to kill it immediately
-   (`docker kill`) instead. Stop itself does not remove the container, but do
-   **not** rely on the container as evidence: for a detached session the live
-   session monitor reacts to the container exit by capturing its in-container
-   audit/file-trace state, finalizing the durable session record and audit log,
-   and then removing the container (`docker rm -f`) —
-   `session_monitor_main` at `scripts/workcell:4225-4228`. The evidence that
-   survives is the **durable state-root** (record, profile audit log, captured
-   logs), which you collect in step 4 — not the container. This works only for
-   **detached** sessions started with `workcell session start`.
-3. **Stop a foreground session.** An interactive `workcell` launch has no
-   `session stop` handle. Terminate the launcher process; the runtime container
-   is ephemeral by default (`--container-mutability ephemeral`) and does not
-   persist after the launch exits.
-4. **Halt the target's isolation boundary (defense in depth).** Stopping the
-   session (steps 2-3) stops its container; the general principle for a fuller
-   halt is then to bring down the target's isolation boundary.
+## 3. Containment
 
-   **First, wait for the session to finalize (detached sessions).** For a
-   detached session, `workcell session stop` returns as soon as it issues the
-   stop — it writes `status=stopping` and does **not** wait
-   (`scripts/workcell:3894-3897`). The session monitor then finalizes the durable
-   record and audit log (and only then removes the container) asynchronously
-   (`session_monitor_main`, `scripts/workcell:4222-4228`). If you halt the Colima
-   VM (or stop Docker Desktop) while the status is still `stopping`, you interrupt
-   the monitor mid-finalization and the durable evidence may be captured
-   incompletely. So after `session stop`, **poll `workcell session show --id
-   SESSION_ID` (or `session list --verbose`) until the status is terminal**
-   (`stopped`, `exited`, `failed`, or `aborted` — `session_is_terminal_status`,
-   `scripts/workcell:3909-3918`), which confirms the monitor has finalized the
-   durable record and audit, **before** halting the boundary below.
+1. Run `workcell session list --verbose`.
+2. Run `workcell session show --id SESSION_ID`.
+3. Record the profile, container name, target kind, and target provider.
+4. Create a new owner-only evidence directory at an absolute path.
+5. Capture network evidence if this action does not delay containment.
+6. Stop the affected session.
+7. Wait for a terminal session status.
+8. Capture the final Colima firewall rules.
+9. Stop the target boundary.
 
-   The boundary-halt command is **target-specific**, so confirm which target the
-   **suspect session** used. Read it from that session's record — `workcell
-   session show --id SESSION_ID` (or `workcell session list --verbose`) reports
-   the record's `target_kind` and `target_provider`. Do not use `--inspect` for
-   this: it prints your *current* launch options, not the suspect session's
-   target. At 1.0 the operator-reachable targets on the supported macOS arm64 host
-   are the two `launch=allowed` rows in
-   [`policy/host-support-matrix.tsv`](../policy/host-support-matrix.tsv):
-   - **`local_vm` / Colima (the default, strict target).** All sessions for a
-     profile run inside one dedicated Colima VM. Take the profile from the session
-     record (`workcell session show --id SESSION_ID`), then stop that VM through
-     Colima directly. Pin the Colima home so you hit the same VM the launcher
-     created — the launcher always invokes Colima with `COLIMA_HOME=~/.colima`
-     (`scripts/workcell:620-632`, `run_host_colima`) — so run
-     `COLIMA_HOME=~/.colima colima stop -p <profile>` to halt all execution on it.
-     Note: stopping the VM removes the profile's Docker socket, so a later
-     `workcell session delete` cannot clean container artifacts until the VM is
-     running again (see step 7). Host-side collection in step 4 does not need the
-     VM, so this halt is safe to do before collecting.
-   - **`local_compat` / Docker Desktop (compat, lower assurance).** The isolation
-     boundary is the Docker Desktop container/context, not a Workcell-dedicated
-     VM, so there is no `colima stop` to run. `workcell session stop --id
-     SESSION_ID --force` force-**stops** the session by killing its container
-     (`--force` selects `docker kill` over the graceful `docker stop` —
-     `internal/sessionctl/stop.go:33,116-117`), which contains the breach. As in
-     step 2, `stop` itself does not `docker rm` the container, but the live
-     monitor finalizes the durable record/audit and then removes it, so treat the
-     durable state-root artifacts (collected in step 4) as the evidence rather
-     than the container.
-   Do **not** delete the profile, VM, or container yet — teardown is step 7,
-   after evidence is collected. The `remote_vm` preview targets (`aws-ec2-ssm`,
-   `gcp-vm`) are `preview-only` with `launch=blocked` in the matrix, so no live
-   operator session runs on them at 1.0 and they are out of scope here; if you
-   ever tear down a preview broker, follow that target's own teardown, not
-   `colima stop`.
+Set the evidence path before any capture command. Use operator-controlled
+storage outside the affected profile.
 
-## 3. Preserve evidence
+```sh
+EVIDENCE_DIRECTORY=/absolute/operator-controlled/path
+umask 077
+mkdir -m 700 "$EVIDENCE_DIRECTORY"
+```
 
-Durable session state lives on the host under the Workcell-owned target-state
-root, and the path is **target-aware**. Identify the target first — the same
-`target_kind` and `target_provider` from the suspect session's record
-(`workcell session show --id SESSION_ID`, or `workcell session list --verbose`)
-you read in step 2 — then preserve that target's tree.
+`mkdir` must create the directory. Stop if the path exists.
 
-The general layout (`internal/host/hoststate/profilepaths.go`
-`ProfileTargetStateDir` /`ProfileSessionsDirPath` / `ProfileAuditLogPath`) is
-`<target-state-root>/<target_kind>/<target_provider>/<profile>/`, where the
-target-state root is `${WORKCELL_STATE_ROOT}/targets` and `WORKCELL_STATE_ROOT`
-defaults to `${XDG_STATE_HOME:-~/.local/state}/workcell` (`scripts/workcell:91-92`):
+Use this command for a normal detached-session stop:
 
-- session records:
-  `.../<target_kind>/<target_provider>/<profile>/sessions/<session_id>.json`
-- audit log (profile-wide, shared by all sessions in the profile):
-  `.../<target_kind>/<target_provider>/<profile>/workcell.audit.log`
+```sh
+workcell session stop --id SESSION_ID
+```
 
-For the two operator-reachable targets at 1.0 this resolves to:
+Use `--force` if a graceful stop increases host exposure or can change more
+evidence:
 
-- **`local_vm` / Colima (default, strict):**
-  `~/.local/state/workcell/targets/local_vm/colima/<profile>/{sessions/,workcell.audit.log}`
-- **`local_compat` / Docker Desktop (compat):**
-  `~/.local/state/workcell/targets/local_compat/docker-desktop/<profile>/{sessions/,workcell.audit.log}`
+```sh
+workcell session stop --id SESSION_ID --force
+```
 
-The Colima target additionally has a **legacy** tree that compatibility reads
-still accept, and Docker Desktop does **not** (`LegacyProfileSessionsDirPath` /
-`LegacyProfileAuditLogPath` are keyed on the Colima state root):
+After you stop a detached session, poll this command:
 
-- legacy records: `~/.colima/<profile>/sessions/<session_id>.json`
-- legacy profile-wide audit log (a profile-level file **outside** `sessions/`):
-  `~/.colima/<profile>/workcell.audit.log`
+```sh
+workcell session show --id SESSION_ID
+```
 
-`WORKCELL_STATE_ROOT` is operator-overridable, so if it is set in your
-environment the `targets/...` tree lives under that root instead of
-`~/.local/state/workcell`. The Colima legacy tree is **not** overridable: the
-launcher unconditionally resets `COLIMA_STATE_ROOT` to `~/.colima`
-(`scripts/workcell:90`, `COLIMA_STATE_ROOT="${REAL_HOME}/.colima"`), so the
-legacy Colima path is always `~/.colima/<profile>/` regardless of any
-`COLIMA_STATE_ROOT` you export.
+Wait until the status is `stopped`, `exited`, `failed`, or `aborted`.
 
-- **Do not garbage-collect before you collect.** `workcell --gc` (alias
-  `workcell gc`) deliberately deletes transient `session-audit.*` scratch, temp
-  scratch, and runtime-image cache residue. Durable session records survive gc,
-  but the transient audit scratch does not — running gc during an incident
-  destroys evidence. Do not run it until collection is complete.
-- **Do not `session delete`.** `workcell session delete` removes the durable
-  record and stopped-session artifacts. Defer it to recovery (step 7).
-- **Snapshot the state root.** Copy your target's profile directory
-  (`.../<target_kind>/<target_provider>/<profile>/`) whole — session records plus
-  the profile-wide `workcell.audit.log`. For the **Colima** target, also copy the
-  legacy tree under `~/.colima/<profile>/` — both the legacy `sessions/` records
-  and the legacy profile-level `~/.colima/<profile>/workcell.audit.log`, since a
-  legacy record can point its `audit_log_path` at that profile-level file outside
-  `sessions/` (the Docker Desktop target has no legacy tree). Copy all of them to
-  read-only storage before further action, so the on-disk evidence is preserved
-  even if later steps mutate host state.
+Do not stop the target boundary while the status is `stopping`. The session
+monitor can still write the durable record and audit data.
 
-Note: workflow-artifact retention in
-[retention-policy.md](retention-policy.md) governs **CI/release** artifacts, not
-these host-side session state roots; host evidence is preserved by the operator,
-not by a retention timer.
+Stop the boundary if the monitor stalls or continued execution increases host
+exposure. Record the last status. The durable evidence can be incomplete.
 
-## 4. Collect
+An interactive foreground launch has no session stop handle. Terminate its
+launcher process.
 
-Capture a redacted, shareable diagnostics snapshot with the support bundle
-(roadmap item G2, shipped):
+### Colima network evidence
+
+The `local_vm` target uses one Colima VM for each Workcell profile. All
+containers in that profile share the egress rules.
+
+Capture the container state only if this action does not delay containment or
+increase exposure:
+
+```sh
+DOCKER_HOST="unix://$HOME/.colima/PROFILE/docker.sock" \
+  docker inspect CONTAINER_NAME > "$EVIDENCE_DIRECTORY/container-inspect.json"
+```
+
+Capture the IPv4 and IPv6 firewall state before the VM stop:
+
+```sh
+COLIMA_HOME="$HOME/.colima" colima ssh --profile PROFILE -- \
+  sudo iptables-save > "$EVIDENCE_DIRECTORY/colima-iptables-before.txt"
+COLIMA_HOME="$HOME/.colima" colima ssh --profile PROFILE -- \
+  sudo ip6tables-save > "$EVIDENCE_DIRECTORY/colima-ip6tables-before.txt"
+```
+
+After the session reaches a terminal status, capture both rule sets again:
+
+```sh
+COLIMA_HOME="$HOME/.colima" colima ssh --profile PROFILE -- \
+  sudo iptables-save > "$EVIDENCE_DIRECTORY/colima-iptables-after.txt"
+COLIMA_HOME="$HOME/.colima" colima ssh --profile PROFILE -- \
+  sudo ip6tables-save > "$EVIDENCE_DIRECTORY/colima-ip6tables-after.txt"
+```
+
+The monitor can remove the stopped container. Thus, the pre-stop inspection
+can be the only container-network record.
+
+Then stop the Colima boundary:
+
+```sh
+COLIMA_HOME="$HOME/.colima" colima stop --profile PROFILE
+```
+
+### Docker Desktop containment
+
+The `local_compat` target uses Docker Desktop. It does not have a dedicated
+Workcell VM or a Workcell egress allowlist.
+
+Force-stop the suspect session if a graceful stop increases exposure. Stop
+Docker Desktop only if a force-stop fails or other Docker workloads are
+suspect.
+
+## 4. Evidence preservation
+
+The durable profile state has this layout:
+
+```text
+${WORKCELL_STATE_ROOT}/targets/<target-kind>/<provider>/<profile>/
+```
+
+The default root is `~/.local/state/workcell`. The profile directory contains
+session records and the shared `workcell.audit.log`.
+
+Use these paths for the two supported launch targets:
+
+| Target | Profile state path |
+|---|---|
+| `local_vm` / `colima` | `${WORKCELL_STATE_ROOT}/targets/local_vm/colima/PROFILE/` |
+| `local_compat` / `docker-desktop` | `${WORKCELL_STATE_ROOT}/targets/local_compat/docker-desktop/PROFILE/` |
+
+The Colima target can also read legacy state from `~/.colima/PROFILE/`. Preserve
+that complete directory when it exists.
+
+Use the owner-only evidence directory from section 3. It must be outside the
+affected profile. Copy the complete profile directory into it.
+
+For example:
+
+```sh
+cp -pR PROFILE_STATE_DIRECTORY "$EVIDENCE_DIRECTORY/"
+```
+
+Replace each uppercase placeholder before you run the commands.
+
+Resolve the state root. Then preserve the public key that the seal names.
+
+```sh
+WORKCELL_INCIDENT_STATE_ROOT="${WORKCELL_STATE_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/workcell}"
+cp -p "$WORKCELL_INCIDENT_STATE_ROOT/signing/KEY_ID.pub" "$EVIDENCE_DIRECTORY/"
+```
+
+Record a fingerprint in the evidence directory:
+
+```sh
+shasum -a 256 "$EVIDENCE_DIRECTORY/KEY_ID.pub" \
+  > "$EVIDENCE_DIRECTORY/KEY_ID.pub.sha256"
+```
+
+CAUTION: Do not copy the private key into the evidence directory, support
+bundle, or report.
+
+After you preserve essential evidence, use a separate trusted system to revoke
+each exposed credential at its source. Record the revocation time. Do not stage
+a replacement on the affected operator host.
+
+## 5. Evidence collection
+
+Create a redacted host diagnostics bundle:
 
 ```sh
 workcell support-bundle --output ~/workcell-support-bundle.json
 ```
 
-It runs entirely host-side and never starts the runtime. It collects install
-state, the policy-file inventory, target/state-root layout, per-provider adapter
-presence and credential **key names** (never values), durable session-record
-summaries, and **audit pointers** (audit-log path, presence, size, and mtime —
-never log contents). See [`SUPPORT.md`](../SUPPORT.md#what-it-collects) for the
-full field list.
+See [`SUPPORT.md`](../SUPPORT.md) for the field list and redaction rules.
 
-**Redaction guarantees** (also embedded in each bundle under `redaction`, and
-documented in [`SUPPORT.md`](../SUPPORT.md#redaction-guarantees)): credential
-file contents are never read; workspace and agent output are never collected;
-token/key/password/secret/credential material is masked by pattern and by
-secret-named `key=value` pairs; and the operator home-directory prefix is
-rewritten to `~`. The output shape is deterministic, so two bundles diff cleanly.
+Collect the applicable session artifacts:
 
-Per-session evidence, for the specific `SESSION_ID`(s) from step 2:
+| Artifact | Command | Content | Sensitivity |
+|---|---|---|---|
+| Durable record | `workcell session show --id SESSION_ID` | Session metadata and final state | Review before you share. |
+| Session timeline | `workcell session timeline --id SESSION_ID` | Audit events for one session | Can contain raw `session send` text. |
+| Session export | `workcell session export --id SESSION_ID --output PATH` | Record and audit events for the session | Can contain raw message text. |
+| Workspace status and diff | `workcell session diff --id SESSION_ID --output PATH` | File status and raw changed content | Can contain secrets and private source. |
+| Profile audit log | `workcell session logs --id SESSION_ID --kind audit` | Events for all sessions in the profile | Can contain raw message text from other sessions. |
+| Optional runtime logs | `workcell session logs --id SESSION_ID --kind KIND` | Debug, file-trace, or transcript data | Can contain workspace and agent output. |
 
-- `workcell session show --id SESSION_ID [--text]` — the full durable record.
-- `workcell session timeline --id SESSION_ID` — the session-specific audit
-  trail. Audit records can include raw `session send` message text, so treat this
-  as sensitive (see step 6).
-- `workcell session export --id SESSION_ID --output PATH` — the record plus all
-  matching audit records as one JSON bundle (written `0600`). The bundled audit
-  records carry the same raw message text (see step 6).
-- `workcell session diff --id SESSION_ID --output PATH` — the workspace change
-  set against the clean launch base: a `[status]` file list plus a `[diff]`
-  section of raw file contents. The raw contents are sensitive (see step 6).
-- `workcell session logs --id SESSION_ID --kind audit` — prints the **entire
-  profile-wide** `workcell.audit.log` resolved from the session's record, not a
-  per-session slice: it is shared by every session in the profile, so you see all
-  sessions' events, which is useful for cross-session correlation around the
-  suspect session. Use `session timeline` (above) when you want only the suspect
-  session's entries. The `debug`, `file-trace`, and `transcript` kinds exist only
-  when those lower-assurance host logs were explicitly enabled at launch, and may
-  contain workspace or agent output — treat them as sensitive (see step 6).
+## 6. Integrity verification
 
-## 5. Verify evidence integrity
+Run the verification command against the durable profile log:
 
-**What exists today.** Session audit records are host-owned records in the
-target audit log; the launcher, not the agent, writes them (the host owns the
-trusted control plane — see the
-[session supervisor design](workcell-session-supervisor-design.md#why-this-shape)).
-`workcell session export` bundles the records that match a session id, and the
-support bundle records the audit log's size and mtime under `audit_pointers`, so
-you can detect truncation or replacement of the durable log against a preserved
-snapshot (step 3). Cross-check the exported records, the timeline, and the
-preserved `workcell.audit.log` for consistency.
+```sh
+workcell session verify --id SESSION_ID
+```
 
-**Cryptographic verification (A5).** Session audit records now form a signed,
-tamper-evident hash chain, and `workcell session verify --id SESSION_ID`
-recomputes that chain from the **authoritative** durable profile log and verifies
-the host-side signature over the chain head against the per-host signing key
-(["Signed Session Audit Records"](../ROADMAP.md#track-a-boundary-depth-and-agent-threat-defenses)).
-As a responder, run it against the suspect session: a `session_verify=verified`
-result means the audit chain is intact and its head is signed by this host's key,
-so the recorded events have not been altered offline. It fails closed (non-zero,
-no `verified`) on any tamper the chain detects — a flipped byte, a reordered,
-dropped, or duplicated record, an appended container-side line, an
-exported/copied log substituted for the real one, or a missing/mismatched seal.
-It does **not** defend against an attacker with host root who re-signs a rewritten
-chain with the host key (out of scope per the A5 threat model), so pair a
-`verified` result with the host-preservation and consistency cross-checks above
-rather than treating it as proof the host itself was not compromised.
+Workcell attempts to sign the audit head. If this operation fails, the terminal
+session has no seal.
 
-**What still relies on preservation.** For providers whose audit records carry no
-digest chain (e.g. the preview-only apple-container target), `session verify`
-fails closed as unsupported rather than asserting integrity; there, and for the
-host-root case above, integrity is host-preservation plus consistency
-cross-checks, not signature verification. Do not represent current audit records
-as cryptographically tamper-proof.
+Require `session_verify=verified` before you rely on signed integrity. The
+command fails closed when the chain, seal, or public key is invalid or missing.
 
-## 6. Report
+A verified result detects offline changes at or before that session head. A
+later valid record for another session does not change the earlier head.
 
-Escalate through the private channel in [`SECURITY.md`](../SECURITY.md#reporting):
-open a [GitHub Private Vulnerability Report][pvr]. **Do not** disclose a
-suspected boundary breach in a public issue. Expect acknowledgment within
-**5 business days** and an initial assessment within **10 business days**;
-sandbox escapes and secret exposure are prioritized
-([`SECURITY.md`](../SECURITY.md#response)).
+The result does not protect against a host-root attacker who can use the
+private key. Use the preserved files and fingerprints as additional evidence.
 
-Include (redaction-safe by default):
+Apple container records have no digest chain. Verification reports that these
+records have no signable chain.
 
-- the redacted `workcell-support-bundle.json` from step 4;
-- the durable session record(s) for the affected `SESSION_ID`(s) — the
-  structured metadata from `workcell session show`;
-- from `workcell session diff`, the **`[status]` summary only** — the list of
-  changed and untracked files (`git status --short`) — plus, if useful, file
-  counts and hashes. This is metadata about *which* files changed, not their
-  contents;
-- the observed signal, severity, provider, mode, host OS, and the exact commands
-  run.
+See [Signed Session Audit Records](signed-session-audit-records.md) for the
+format, coverage, and trust limits.
 
-Review and redact before sharing (may contain secrets/proprietary content):
+## 7. Private report
 
-- The `[diff]` section of `workcell session diff` output. It is a full
-  `git diff` of raw workspace file contents (`render_session_diff_bundle` in
-  `scripts/workcell` runs `git diff --no-ext-diff --no-textconv` against the
-  launch base), so a compromised session that wrote secrets or changed
-  proprietary files puts that content directly into the diff.
-- The **audit log and anything that reads it** — `workcell session timeline`,
-  `workcell session logs --id SESSION_ID --kind audit`, and the audit records
-  bundled by `workcell session export`. When a detached session was steered with
-  `workcell session send`, the launcher writes the **raw message text** into the
-  audit log as `argv=<message>` (`scripts/workcell:3739-3742`), so the timeline,
-  the audit log, and the exported audit records can contain raw operator/agent
-  message content — including secrets or sensitive data an operator typed.
+Use a [GitHub Private Vulnerability Report][pvr]. Do not use a public issue for
+a suspected boundary breach.
 
-Treat all of these like the `debug`/`file-trace`/`transcript` logs: raw content
-that must be reviewed and redacted by the operator before it crosses the trust
-boundary into a report.
+Include these items when they are safe to share:
 
-Do **not** include:
+- The redacted support bundle.
+- The durable session record.
+- The `[status]` section from the session diff.
+- Hashes and file counts for preserved evidence.
+- The signal, severity, provider, mode, host OS, and commands used.
+- The `session verify` result.
 
-- secrets, credential values, or `.env`-style material;
-- raw workspace content, raw audit/timeline message text, or full agent
-  transcripts unless specifically requested — the `session diff` `[diff]` body,
-  the audit log / timeline / `session logs --kind audit` (raw `session send`
-  messages), and the `debug`/`file-trace`/`transcript` logs are the ones most
-  likely to carry it.
+Review and redact these items before you share them:
 
-The support bundle is redacted by construction, but **skim it once before
-sharing** ([`SUPPORT.md`](../SUPPORT.md#sharing-it-safely)). The session diff,
-the audit log / timeline / exported audit records, and the lower-assurance logs
-are **not** redacted — review them yourself first. If any artifact you were about
-to attach looks like it exposed a secret, keep it out of the report body and
-describe it to the maintainer over the private advisory instead.
+- The `[diff]` section from `workcell session diff`.
+- The audit log, timeline, and session export.
+- Debug, file-trace, and transcript logs.
+- Container inspection and network state.
+
+Do not include credential values, `.env` data, raw workspace files, or the host
+private signing key.
+
+The support bundle applies fixed redaction rules. Review it once before you
+share it. The other incident artifacts do not receive the same guarantee.
 
 [pvr]: https://github.com/omkhar/workcell/security/advisories/new
 
-## 7. Recover
+## 8. Recovery
 
-Only after evidence is collected and reported:
+Start recovery only after you complete evidence collection and the private
+report.
 
-- **Rotate exposed credentials.** If any host secret could have been read,
-  rotate it at the source, then re-stage it with `workcell auth unset` /
-  `workcell auth set` and confirm with `workcell auth status --agent <provider>`.
-- **Tear down the compromised session.** `workcell session delete --id
-  SESSION_ID` removes the durable record and stopped-session artifacts (use
-  `--dry-run` first to preview the cleanup). It has two preconditions: the
-  session must be in a terminal status — `stopped`, `exited`, `failed`, or
-  `aborted` (`session_is_terminal_status`, `scripts/workcell:3909-3918`); stop it
-  first, per step 2. (A foreground/attached session that exited before it
-  finalized is recorded as `aborted` (`scripts/workcell:975-978`) and is
-  delete-able.) The second precondition is that cleaning the session
-  **container** needs the target's Docker socket available
-  (`profile_docker_transport_available`, `scripts/workcell:1649-1675`). Where that
-  socket comes from is target-specific:
-  - **`local_vm` / Colima:** the socket is the Colima VM's Docker socket
-    (`scripts/workcell:1657-1660`), so it is available only while the VM is
-    running. If you halted the VM in step 2.4, restart it with
-    `COLIMA_HOME=~/.colima colima start -p <profile>`, then delete.
-  - **`local_compat` / Docker Desktop:** the socket is a healthy Docker Desktop
-    context reached through the host `docker` binary (`scripts/workcell:1661-1670`),
-    so it is available only while **Docker Desktop itself is running** — ensure
-    the Docker Desktop app/daemon is up, then delete. Do not run `colima start`
-    for this target; Docker Desktop does not use Colima.
+Decide whether the operator host and Docker Desktop remain trusted. Rebuild an
+untrusted system before service recovery. Then use `workcell auth unset` and
+`workcell auth set`. Confirm the replacements with `workcell auth status`.
 
-  Until the socket is available, normal `session delete` refuses container
-  cleanup and tells you to retry with the socket available; in that state either
-  bring the socket up as above, or pass `--record-only` to remove just the
-  durable record (keeping container/log artifacts), or remove the preserved
-  state-root files by hand after evidence collection.
-- **Reset a suspect Colima profile.** `--repair-profile` is **not** a reset for a
-  compromised VM: it only deletes an *unmanaged* profile (one that pre-exists
-  without Workcell ownership metadata) as a launch-time conflict repair, and does
-  nothing to a Workcell-managed profile. To fully reset a suspect profile, delete
-  it through Colima's own CLI, pinning the same home the launcher uses so you hit
-  the Workcell VM — `COLIMA_HOME=~/.colima colima delete -p <profile> --force`
-  (`scripts/workcell:620-632`) — then a fresh `workcell` launch recreates a clean
-  managed profile from the
-  reviewed image. Because the strict runtime container is ephemeral, a clean
-  relaunch otherwise starts from the reviewed image already.
-- **Close the loop.** If the incident revealed a genuine boundary weakness (not
-  just an expected lower-assurance mode), it belongs in the private advisory so a
-  fix and regression test can follow — see the coordinated-disclosure model in
-  [`SECURITY.md`](../SECURITY.md#disclosure).
+### Delete the session record
 
-## References
+CAUTION: `workcell session delete` removes the durable session record. Confirm
+that you completed evidence collection and the private report.
 
-- [Runtime-boundary threat model](threat-model.md) — assets, trust boundaries,
-  and controls this runbook responds to
-- [`SECURITY.md`](../SECURITY.md) — reporting channel, SLAs, and scope
-- [`SUPPORT.md`](../SUPPORT.md) — the `workcell support-bundle` field list and
-  redaction guarantees
-- [Session supervisor design](workcell-session-supervisor-design.md) — durable
-  session records, state-root paths, and the host-owned audit model
-- [Support tiers and status vocabulary](support-tiers.md) and
-  [diagnostics and the support matrix](diagnostics-and-support-matrix.md)
-- [CI/CD threat model](ci-threat-model.md) — the separate signing-compromise
-  incident runbook
-- [`ROADMAP.md`](../ROADMAP.md) — A5 signed session audit records (roadmapped)
+Run a dry run first:
+
+```sh
+workcell session delete --dry-run --id SESSION_ID
+```
+
+Review the result. Then run the command without `--dry-run`.
+
+The session must have a terminal status. Container cleanup also requires the
+target Docker transport.
+
+For Colima, restart the preserved profile when cleanup needs its socket:
+
+```sh
+COLIMA_HOME="$HOME/.colima" colima start --profile PROFILE
+```
+
+For Docker Desktop, start Docker Desktop and use its configured context.
+
+Do not use `--record-only` when you must remove residual container artifacts.
+Do not manually remove state files.
+
+### Reset a Colima profile
+
+CAUTION: This command deletes the complete Colima profile. Confirm the
+profile name and preserved evidence first.
+
+```sh
+COLIMA_HOME="$HOME/.colima" colima delete --profile PROFILE --force
+```
+
+`--repair-profile` does not reset a managed profile. It only repairs an
+unmanaged profile conflict during launch.
+
+Report each confirmed boundary weakness through the private advisory. Add a
+fix and a regression check before you close the incident.

--- a/docs/signed-session-audit-records.md
+++ b/docs/signed-session-audit-records.md
@@ -1,175 +1,167 @@
 # Signed Session Audit Records
 
-Workcell session audit records form a tamper-evident hash chain whose head is
-signed host-side. `workcell session verify --id SESSION_ID` recomputes the chain
-from the authoritative durable log and verifies that signature, so a reviewer
-outside the agent can detect tampering. This document specifies the record
-format, the signing and verification model, and — explicitly — what the model
-does and does not protect.
+For launched Colima and Docker Desktop sessions, Workcell writes chained audit
+records to a host-owned profile log. Each later chained record contains the
+prior digest.
 
-## Hash-chain format
+At finalization, Workcell attempts to sign the final session digest.
+`workcell session verify` checks the digest chain and the host signature.
 
-Every audit record is appended to a per-profile log under Workcell-owned target
-state, for example:
+This control detects offline record changes. It does not protect against a
+host-root attacker who has the signing key.
+
+## Security purpose
+
+The operator host owns the audit log and the signing key. The agent does not
+receive the signing key. Thus, an agent cannot create a valid host seal.
+
+The seal gives boundary integrity. It does not attest the identity of a remote
+signer. For release identity, see [Provenance](provenance.md).
+
+## Record format
+
+Workcell appends records to this target-aware path:
 
 ```text
-~/.local/state/workcell/targets/<target-kind>/<provider>/<profile>/workcell.audit.log
+${WORKCELL_STATE_ROOT}/targets/<target-kind>/<provider>/<profile>/workcell.audit.log
 ```
 
-`scripts/workcell`'s `append_audit_record_to_path` writes each record as
-whitespace-delimited `key=value` tokens:
+The default `WORKCELL_STATE_ROOT` is `~/.local/state/workcell`.
+
+Each line contains space-separated `key=value` fields:
 
 ```text
-timestamp=<ts> <event fields...> [prev_digest=<hex>] record_digest=<hex>
+timestamp=<time> <event-fields> [prev_digest=<hex>] record_digest=<hex>
 ```
 
-- `timestamp` is a UTC RFC 3339 second-resolution stamp.
-- The event fields are the record payload (for example
-  `event=exit session_id=<id> exit_status=0 ...`). Every session record carries
-  `session_id=<id>`.
-- `record_digest` chains the record to its predecessor:
+| Field | Writer | Required state | Meaning |
+|---|---|---|---|
+| `timestamp` | Host launcher | All records | UTC time in RFC 3339 format |
+| Event fields | Host launcher | All records | Event data in write order |
+| `session_id` | Host launcher | Session records | Session that owns the event |
+| `prev_digest` | Host launcher | Chained records after the chain root | Digest of the prior chained record |
+| `record_digest` | Host launcher | Chained records | Digest of this record and the prior digest |
 
-  ```text
-  record_digest = SHA-256( prev_digest \x00 timestamp \x00 arg0 \x00 arg1 ... )
-  ```
+Workcell calculates the record digest as follows:
 
-  computed by `hoststate.AuditRecordDigest`, where the args are the event-field
-  tokens in write order and `prev_digest` is the previous record's
-  `record_digest` (empty for the first record in the log).
-- `prev_digest` is omitted on the first record and present on every subsequent
-  record.
+```text
+SHA-256(prev_digest \x00 timestamp \x00 event_field_0 \x00 event_field_1 ...)
+```
 
-Because each digest folds in the previous digest, altering, reordering, or
-dropping any record changes every downstream digest — a standard tamper-evident
-chain. The **head** of a session is the `record_digest` of the last log record
-carrying that session's `session_id`.
+The first record with a digest has no `prev_digest`. A changed, missing, or
+reordered chained record breaks the chain.
 
-### Append serialization invariant
+A profile log can start with unchained legacy records. Digest-chain verification
+excludes this initial legacy prefix. Those records are outside signed integrity.
 
-The chain is linear only if appends are serialized: an appender reads the
-current tail's `record_digest` as the new record's `prev_digest`, so two
-concurrent detached-session control paths (`start`/`send`/`stop`) that read the
-same tail and both append would fork the chain and make verification reject a
-legitimate later record. `append_audit_record_to_path` therefore holds an
-exclusive per-log lock across the read-tail-plus-append critical section. The
-lock is the repo's atomic, crash-safe `acquire-profile-lock` primitive (an
-atomic `mkdir`+`rename` whose owner PID lets a crashed holder be reclaimed)
-applied to a `<audit-log>.lock` directory, so no external `flock(1)` is required
-— it is absent on the macOS host. The critical section is short but includes a
-cold `go` digest computation, so a waiter uses a bounded ~30s backoff (1500 ×
-20ms) to reliably outlast an in-progress append; on exhaustion (a genuinely
-stuck holder) the appender fails closed (skips the record) rather than fork the
-chain. Single-writer behavior is unchanged.
+The session head is the last `record_digest` for that `session_id`.
 
-## Seal (host-side signature)
+## Append lock
 
-When the runtime boundary finalizes a session (`finalize_session_audit`, after
-the terminal audit record is appended and the durable record is written),
-Workcell signs the session head:
+Workcell locks the profile audit log before it reads the tail and appends a
+record. The lock covers both operations.
 
-- **Key.** A per-host ECDSA P-256 key (the curve cosign uses by default) is
-  generated on first use under `~/.local/state/workcell/signing/` — directory
-  mode `0700`, private key `signing.key` mode `0600`. If that directory cannot
-  be created and confined to owner-only access, signing fails closed rather than
-  sign with an insecurely stored key.
-- **Signed message.** A domain-separated message binding the session id to the
-  recomputed head is signed, so a signature cannot be replayed onto a different
-  session or a different chain state.
-- **Seal file.** The signature is stored beside the durable session record as
-  `<session-id>.audit-sig` (host-owned, mode `0600`). It records the seal
-  version, session id, head digest, signing key id, algorithm, and the
-  base64 signature. Only the version, session id, key id, algorithm, and
-  signature are load-bearing; the head digest is informational because
-  verification always recomputes the head from the authoritative log.
-- **Public key.** The public half is written to
-  `~/.local/state/workcell/signing/<key-id>.pub` (PKIX PEM), where `<key-id>` is
-  a SHA-256 fingerprint prefix of the public key. `session verify` pins the
-  signature to the key id named in the seal.
+The lock uses the repository `acquire-profile-lock` operation. It does not
+require `flock` on macOS.
 
-This is a boundary/host signature, **not** an agent signature: the operator host
-signs on the trusted side of the runtime boundary, so the agent inside the
-sandbox never holds the signing key and cannot forge a seal.
+The appender uses approximately 30 seconds of sleep backoff. Helper execution
+can make the total wait longer. If the lock remains unavailable, the append
+operation fails.
 
-## Verification
+## Host seal
 
-`workcell session verify --id SESSION_ID` is read-only and fail-closed:
+Workcell attempts to sign the session head. If this operation fails, Workcell
+finalizes the session without a seal.
 
-1. Locate the durable session record and its authoritative audit log.
-2. Read the seal beside the record. A session with no seal fails closed.
-3. Recompute the hash chain over the authoritative log from the first record up
-   to and including the session head, rejecting any record that carries a
-   duplicate key (the same fail-closed rule the OCSF export applies).
-4. Verify the seal signature over the **recomputed** head using the pinned
-   public key named by the seal.
+Workcell uses these seal items:
 
-Exit codes: `0` verified, `1` verification failed (tamper, or a missing or
-invalid seal), `2` usage error. Output is passed through the shared support
-bundle redactor (the [G2](../SUPPORT.md) rule-set), so no secret leaks.
+| Item | Location | Content |
+|---|---|---|
+| Private key | `${WORKCELL_STATE_ROOT}/signing/signing.key` | ECDSA P-256 private key |
+| Public key | `${WORKCELL_STATE_ROOT}/signing/<key-id>.pub` | PKIX PEM public key |
+| Seal | Beside the session record as `<session-id>.audit-sig` | Session ID, key ID, algorithm, signature, and recorded head |
 
-### Corrupt (untokenizable) records
+Workcell creates the signing directory with mode `0700`. It creates the private
+key and seal with mode `0600`.
 
-The writer emits `event=` before `session_id=`, so a malformed field can make a
-record untokenizable before its `session_id` is reachable — and such a line
-cannot be attributed to a session at all. The genuine writer never emits an
-untokenizable record (it closes every bash ANSI-C `$'…'` block), so verification
-treats any untokenizable line as corruption or tamper and **fails closed**,
-rather than silently dropping an unreadable, appended same-session record as an
-unrelated non-member. A legitimate other-session record — even a torn/legacy
-line missing `record_digest` — still tokenizes and is attributed by its
-`session_id`, so it does not fail an unrelated session. The one accepted
-tradeoff is that a rare crash-truncation inside an ANSI-C block anywhere in the
-shared profile log fails verification for sessions reading it; that is the
-correct fail-closed posture for tamper-evident audit (a reviewer must
-investigate a log that cannot be parsed).
+The key ID is a prefix of the SHA-256 public-key fingerprint. The signed message
+binds the session ID to the calculated head. Therefore, a seal cannot apply to
+another session or chain state.
 
-### Key rotation
+The head value in the seal is information only. Verification calculates the
+head from the authoritative audit log.
 
-To rotate, an operator removes (or moves aside) `signing.key`; the next signing
-run generates a fresh key with a new key id. Old public keys are retained under
-the signing directory, so seals produced by an earlier key still verify against
-their recorded key id.
+If key storage is not owner-only, Workcell does not sign. If the lock or signer
+fails, Workcell reports a warning and lets finalization continue.
 
-## Trust model
+CAUTION: Preserve the old public key before you replace `signing.key`. Old seals
+require their recorded public keys.
 
-**Detected.** Any modification to the persisted audit records at or before a
-session's signed head:
+Do not put `signing.key` in a support bundle or incident report.
 
-- a flipped byte in any record field or digest;
-- a reordered or dropped record (chain linkage breaks or the head changes);
-- a forged duplicate key on a record;
-- an exported or copied log presented in place of the authoritative one (the
-  copy is not the persisted record the seal was computed over);
-- any session presented without a valid host seal.
+## Verification procedure
 
-**Not defended.** This is boundary integrity, not host compromise resistance:
+Run this read-only command:
 
-- A host-root attacker who can read `signing.key` can re-sign a tampered chain.
-  The seal proves the records were signed by a holder of the per-host key, not
-  that the host itself was never compromised.
-- The signing key protects records against parties **without** that key
-  (the sandboxed agent, a lower-privilege process, offline tampering of the log
-  or an exported copy) — not against the key holder.
-- Verification confirms integrity and host-side provenance; it is not an
-  identity attestation of a remote signer (contrast the release-artifact keyless
-  Sigstore flow in [provenance.md](provenance.md), whose trust anchor is a CI
-  workflow identity that does not exist at session runtime).
+```sh
+workcell session verify --id SESSION_ID
+```
 
-## Provider coverage
+The command does these steps:
 
-Signing covers providers whose audit records form a digest chain — the
-bash-launcher backends (colima, docker-desktop, aws-ec2-ssm, gcp-vm) whose
-session lifecycle is finalized by `finalize_session_audit`. The preview-only,
-launch-blocked `apple-container` target writes plain lifecycle audit lines
-without `prev_digest`/`record_digest`, so there is no chain to seal: such
-sessions are **unsigned**, and `workcell session verify` reports them
-fail-closed with a clear "no signable digest chain" reason. Signing the
-apple-container lifecycle (its own finalize path) is a documented follow-up; it
-is intentionally out of scope here rather than sealed with an unverifiable
-signature.
+1. It finds the durable session record and its authoritative profile log.
+2. It reads the seal beside the record.
+3. It recalculates the chain from the first record with a digest through the session head.
+4. It rejects each strictly checked record that contains a duplicate key.
+5. It loads the public key that the seal identifies.
+6. It checks the signature against the calculated head.
 
-## Coordination with OCSF export
+The command returns these exit codes:
 
-Signing adds a sidecar file and does not modify the audit log or the durable
-session record, so `workcell session export --format ocsf` is unchanged: signed
-sessions export exactly as before, and the export's own duplicate-key and
-cross-session fail-closed rules continue to apply.
+| Exit code | Result |
+|---|---|
+| `0` | Verification succeeded. |
+| `1` | Verification failed. The chain, seal, or key is missing or invalid. |
+| `2` | The command usage is invalid. |
+
+Every log line must tokenize. Each line for the selected session must also pass
+strict field validation. The last such line defines the session head.
+
+Workcell strictly validates all records through that head. It verifies the
+digest chain from the first record with a digest through the head. A later
+tokenizable record for another session stays outside strict validation.
+
+Require `session_verify=verified` before you rely on signed integrity. A
+terminal session without a seal does not meet this requirement.
+
+## Limits and provider coverage
+
+Verification detects these conditions:
+
+- A chained record changed from the first record with a digest through the signed head.
+- A chained record through the signed head is missing or in a different position.
+- A strictly checked record contains a duplicate key.
+- A different log replaces the authoritative log and changes signed content.
+- The seal or named public key is missing or invalid.
+
+Verification does not protect the initial unchained legacy prefix. It also does
+not detect a rewrite by a host-root attacker who can use the private key.
+
+The seal shows that the key holder signed the chain. It does not show whether an
+attacker compromised the operator host.
+
+Launched sessions have signed-chain support on these providers:
+
+- `colima`
+- `docker-desktop`
+
+The `aws-ec2-ssm` and `gcp-vm` targets are preview-only and launch-blocked.
+Workcell does not provide remote-session signatures because it cannot launch
+these targets.
+
+The preview-only `apple-container` target writes unchained lifecycle records.
+It has no operator launch path. Workcell cannot seal those records, and
+`session verify` fails with a `no signable digest chain` reason.
+
+`workcell session export --format ocsf` does not include the seal. It rejects
+duplicate keys and excludes records for another session.

--- a/docs/unsafe-code-audit-checklist.md
+++ b/docs/unsafe-code-audit-checklist.md
@@ -1,73 +1,107 @@
 # Unsafe-Code Pre-Audit Checklist
 
-Workcell's security boundary depends on a small, deliberately contained body of
-Rust `unsafe` code: the container-side exec/syscall interception shim
-(`runtime/container/rust/src/lib.rs`) and the launcher binaries
-(`runtime/container/rust/src/bin/`). This checklist is the pre-audit reference
-for reviewing that surface — before a release, a dependency bump that touches
-libc, or an external security audit.
+This checklist covers Rust `unsafe` code in the syscall shim and launcher
+binaries.
 
-## Enforcement in place
+Use it before a release, a relevant `libc` update, or an external audit.
 
-- Every `unsafe {}` block carries a `// SAFETY:` comment stating the invariant
-  that makes it sound. This is enforced by
-  `undocumented_unsafe_blocks = "deny"` in
-  `runtime/container/rust/Cargo.toml`, checked by
-  `cargo clippy --all-targets --locked --offline -- -D warnings` in
-  `scripts/validate-repo.sh`. A new undocumented `unsafe` block fails CI.
-- That clippy lint does not cover `unsafe extern "C" {` blocks, so
-  `scripts/validate-repo.sh` additionally requires a preceding `// SAFETY:`
-  comment on every `unsafe extern` block. A new undocumented FFI declaration
-  fails CI too.
-- `#![deny(unsafe_op_in_unsafe_fn)]` (`lib.rs`) forces every operation inside an
-  `unsafe fn` into an explicit `unsafe {}` block, so no unsafe operation is
-  implicitly covered by the function signature.
+## Scope
 
-## Unsafe surface inventory
+The first-party Rust surface is in these paths:
 
-The unsafe code falls into a few invariant classes. An auditor should confirm
-each block still belongs to its class and that the class invariant holds.
+- `runtime/container/rust/src/lib.rs`
+- `runtime/container/rust/src/bin/`
 
-| Class | What it does | Invariant to confirm |
+Each `unsafe {}` block and `unsafe extern` block must have a safety comment.
+The manual audit must map every unsafe site to one class below.
+
+## Automated checks
+
+Run the locked offline Clippy command:
+
+```sh
+cargo clippy --manifest-path runtime/container/rust/Cargo.toml \
+  --all-targets --locked --offline -- -D warnings
+```
+
+`runtime/container/rust/Cargo.toml` sets
+`undocumented_unsafe_blocks = "deny"`. Thus, Clippy rejects an `unsafe {}` block
+that has no `// SAFETY:` comment.
+
+Clippy does not check `unsafe extern "C"` blocks. `scripts/validate-repo.sh`
+requires a `// SAFETY:` comment immediately before each block.
+
+`lib.rs` also sets `#![deny(unsafe_op_in_unsafe_fn)]`. Each unsafe operation in
+an unsafe function must use an explicit unsafe block.
+
+These checks do not confirm that the inventory is complete. The manual review
+must map each first-party unsafe site to one class below.
+
+## Unsafe classes
+
+| Class | Operations | Required invariant |
 |---|---|---|
-| Niladic syscalls (`getpid`, `getppid`, `fork`) | no-argument syscalls | no preconditions; return value handled |
-| C-string ABI reads (`CStr::from_ptr`, `*ptr.add`) | reading intercepted `argv`/`envp`/path pointers | pointer is null-checked and points to a NUL-terminated string / NUL-sentinel array per the exec ABI |
-| `static mut environ` reads | reading libc's global env when no `envp` given | read in the calling thread with no concurrent `setenv`/`putenv` |
-| `dlsym(RTLD_NEXT)` + `transmute_copy` | resolving the next-chain libc symbol into a fn pointer | `T` is a pointer-sized `extern "C"` fn whose ABI matches the named symbol |
-| Syscall trampoline (`workcell_syscall_shim`) | entered from hand-written `global_asm!` | asm preserves the `syscall(long, ...)` ABI; per-number arg meanings |
-| LD_PRELOAD interposers + tail forwards | intercept then forward original args to real libc | args obey the interposed function's C ABI; forwarded unmodified |
-| Env mutation (`env::set_var`/`remove_var`) | Rust 2024 unsafe env writes | runs single-threaded before any thread/child spawns |
-| Signal-handler `kill` / `sigaction` setup | async-signal-safe teardown | only async-signal-safe calls; PID read via atomic |
+| Niladic system call | `getpid`, `getppid` | The call has no pointer input. The code handles its result. |
+| C pointer and string | `CStr::from_ptr`, pointer offsets, `getauxval` result | The code checks required pointers. Each string ends with NUL. Each array has a NUL sentinel. |
+| Path access | `access` | The path is a live NUL-terminated string. The code handles the result. |
+| FFI output buffer | `fstatat`, `MaybeUninit::assume_init` | The C call succeeds before Rust reads initialized output. |
+| File-descriptor lifecycle | `openat`, `close` | The code checks the new descriptor and closes it exactly once. |
+| Process lifecycle FFI | `execve`, `fork`, `_exit`, `waitpid` | The launcher is single-threaded at `fork`. Arguments match the C ABI. Parent and child paths handle ownership correctly. |
+| Error report FFI | `write`, `__errno_location`, `__error` | The buffer is valid. The code sets the thread-local error value to `EPERM`. |
+| Global environment read | `static mut environ` | No concurrent code changes the process environment. |
+| Dynamic symbol load | `dlsym(RTLD_NEXT)`, `transmute_copy` | The function type has pointer size and matches the named C symbol. |
+| Unsafe export | `#[unsafe(no_mangle)]` | The symbol has an intended export or interposition target. Its ABI matches that target. No unintended collision exists. |
+| System-call trampoline | `workcell_syscall_shim`, `global_asm!` | Assembly preserves the Linux `syscall(long, ...)` ABI. Each system-call number uses the correct arguments. |
+| Preload interposer | LD_PRELOAD wrappers and tail calls | The wrapper matches the C ABI. It passes the original arguments to libc. |
+| Environment change | `env::set_var`, `env::remove_var` | The launcher changes the environment before it creates a thread or child process. |
+| Test environment change | Test-only `env::remove_var` | The test has no concurrent environment access. |
+| Signal setup and teardown | `kill`, `sigaction`, `sigemptyset`, `std::mem::zeroed` | The handler uses async-signal-safe calls. Structures and handlers match the C ABI. |
 
-## High-scrutiny items (subtle invariants — review these first)
+This map assigns each first-party site group to an inventory class:
 
-1. **`workcell_syscall_shim` (`lib.rs`)** — safety is upheld by the
-   `global_asm!` trampoline, not by any Rust caller, and it reads all six
-   register args regardless of the variadic count. A change to the asm or to the
-   per-syscall arg handling must be re-audited against the kernel ABI.
-2. **`load_symbol` `transmute_copy` (`lib.rs`)** — `transmute_copy` skips the
-   size check; soundness rests on every instantiation of `T` being a
-   pointer-sized `extern "C"` fn pointer matching the named C symbol. Adding a
-   new interposer means adding a matching `Fn` type alias + `c"name"` pair.
-3. **`static mut environ` reads** — a shared mutable global; sound only absent
-   concurrent `setenv`/`putenv`, consistent with libc `getenv` semantics.
-4. **`env::set_var`/`remove_var` in the launchers** — the "no data race"
-   invariant holds only if these run before any thread is spawned. Confirm caller
-   ordering; note the default multithreaded test runner is the weak spot for the
-   `#[cfg(test)]` uses.
+| File and function group | Inventory class |
+|---|---|
+| `lib.rs`: process path and file-descriptor helpers | Niladic system call, path access, C pointer and string, FFI output buffer |
+| `lib.rs`: `report` and `errno_location` | Error report FFI |
+| `lib.rs`: `load_symbol` and symbol accessors | Dynamic symbol load |
+| `lib.rs`: `workcell_syscall_shim` | Unsafe export, system-call trampoline |
+| `lib.rs`: exported `exec*` and `posix_spawn*` functions | Unsafe export, preload interposer, C pointer and string, global environment read, FFI output buffer, file-descriptor lifecycle |
+| `bin/common/launcher_common.rs`: environment helpers | Environment change, global environment read |
+| `bin/common/launcher_common.rs`: `exec_request` | Process lifecycle FFI, global environment read |
+| `bin/common/launcher_common.rs`: signal helpers | Signal setup and teardown |
+| `bin/common/launcher_common.rs`: `spawn_and_wait_request` | Process lifecycle FFI, global environment read, signal setup and teardown |
+| `bin/workcell-launcher.rs`: `current_execfn` | C pointer and string |
+| `bin/workcell-launcher.rs`: environment cleanup test | Test environment change |
 
-## Pre-audit checklist
+Give special attention to these sites:
 
-- [ ] `cargo clippy … -D warnings` is green (zero `undocumented_unsafe_blocks`).
-- [ ] `#![deny(unsafe_op_in_unsafe_fn)]` is still present in `lib.rs`.
-- [ ] Every `unsafe {}` block's `// SAFETY:` comment still matches the code it
-      guards (no block was edited without updating its invariant).
-- [ ] No new `unsafe` construct falls outside the classes above; if it does, it
-      is documented and added to this inventory.
-- [ ] The high-scrutiny items are unchanged, or their changes were re-audited
-      against the relevant ABI (kernel syscall, libc symbol, signal-safety).
-- [ ] Any new LD_PRELOAD interposer pairs a `c"symbol"` literal with a matching
-      `extern "C" fn` type alias, and forwards the caller's original arguments
-      unmodified.
-- [ ] `libc` crate version bumps are reviewed for changed signatures on the
-      intercepted symbols.
+- `workcell_syscall_shim` reads all six register arguments. Review the assembly
+  and system-call behavior together.
+- `load_symbol` uses `transmute_copy`. Each type must have pointer size and
+  match the named C function signature.
+- `static mut environ` is shared mutable state. Confirm that no concurrent code
+  calls `setenv` or `putenv`.
+- Launcher environment changes must occur before thread or child creation.
+- `fstatat` output stays uninitialized until the C call succeeds.
+- `fork` creates two control paths. Confirm all `_exit`, `execve`, and `waitpid`
+  results and ownership rules.
+- The post-`fork` child formats errors before `_exit`. Confirm the launcher stays
+  single-threaded and no unsafe shared state is active at `fork`.
+
+## Manual release checklist
+
+- [ ] Run the locked offline Clippy command. Confirm exit code 0.
+- [ ] Confirm that each `unsafe {}` block has an accurate `// SAFETY:` comment.
+- [ ] Confirm that each `unsafe extern` block has a `// SAFETY:` comment immediately before it.
+- [ ] Confirm that `#![deny(unsafe_op_in_unsafe_fn)]` remains in `lib.rs`.
+- [ ] List each first-party unsafe site with `rg -n '\bunsafe\b' runtime/container/rust/src`.
+- [ ] Map each unsafe site to one class in this inventory.
+- [ ] Add each new unsafe class to this inventory.
+- [ ] Compare each changed interposer signature with the libc signature for that symbol.
+- [ ] Confirm that each interposer passes the original arguments to libc.
+- [ ] Review changes to the system-call trampoline against the Linux ABI.
+- [ ] Review each `libc` version change for affected signatures.
+- [ ] Confirm that each launcher changes environment variables before it creates a thread.
+- [ ] Confirm that each environment test has no concurrent environment access.
+- [ ] Confirm that Rust reads FFI output buffers only after the C call initializes them successfully.
+- [ ] Confirm that each process lifecycle path handles errors and child ownership.


### PR DESCRIPTION
## Summary

- Revise incident and audit documentation.
- Match shipped behavior.
- Use ASD-STE100 Simplified Technical English.

## Validation

- Exact source, security, and STE reviews accepted the final patch.
- `./scripts/ci/job-docs.sh`
- `./scripts/pre-merge.sh --profile pr-parity`