### PR TITLE
Revise maintainer and runtime documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,38 +1,36 @@
 # Code of Conduct
 
-Workcell is a security-focused engineering project. We expect discussion and
-review to stay direct, technical, and respectful.
+Workcell is a security-focused engineering project. Keep each discussion
+direct, technical, and respectful.
 
-## Expected behavior
+## Required behavior
 
-- assume good intent and argue from evidence
-- critique ideas, code, and tradeoffs without attacking people
-- make space for newcomers, operators, and maintainers with different levels of
-  context
-- be clear when a claim is a requirement, an inference, or a preference
-- respect the project's security boundaries and disclosure process
+- Assume good intent. Use evidence.
+- Critique work. Do not attack a person.
+- Give new contributors the context that they need.
+- Identify each requirement, inference, and preference.
+- Follow the security boundary and private disclosure process.
 
-## Unacceptable behavior
+## Prohibited behavior
 
-- harassment, intimidation, or personal attacks
-- discriminatory or demeaning language
-- repeated bad-faith arguing, dogpiling, or deliberate thread derailment
-- publishing private information without permission
-- pressuring contributors to disclose security-sensitive details publicly
+- Do not harass a person. Do not threaten a person. Do not attack a person.
+- Do not use discriminatory language. Do not insult a person.
+- Do not intentionally disrupt a discussion.
+- Do not publish private information without permission.
+- Do not request public disclosure of security-sensitive details.
 
 ## Scope
 
-This applies to repository discussions, issues, pull requests, releases, and
-other project spaces.
+This code applies to repository discussions, issues, pull requests, releases,
+and other project spaces.
 
-## Reporting
+## Reports
 
-For conduct concerns, contact the maintainer privately through GitHub. For
-security-sensitive behavior or disclosures, use the process in
-[SECURITY.md](SECURITY.md).
+Report a conduct concern to the maintainer at `omkhar@gmail.com`.
+For a security report, follow [`SECURITY.md`](SECURITY.md).
 
 ## Enforcement
 
-Maintainers may edit, hide, lock, or remove content that violates this code of
-conduct and may limit participation when needed to protect the project and its
-contributors.
+The maintainer can edit, hide, lock, or remove content that violates this code.
+The maintainer can also limit participation to protect contributors or the
+project.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,44 +1,58 @@
 # Maintainers
 
-## Current maintainers
+## Maintainer
 
-| GitHub | Role | Areas |
+| GitHub account | Role | Areas |
 |---|---|---|
-| `@omkhar` | Lead maintainer | runtime boundary, adapters, release posture, policy, docs |
+| `@omkhar` | Lead maintainer | Runtime, adapters, policy, releases, and documentation |
 
-## Current release mode
+## Single-maintainer operation
 
-- Workcell currently operates in single-maintainer release mode.
-- `@omkhar` may merge release PRs, approve the `release` environment, and cut
-  signed tags after required checks and comment sweeps succeed.
-- Asynchronous review from humans and configured async reviewers is expected
-  input but is not a substitute for an independent maintainer.
-- Release status should describe this honestly as single-maintainer operation,
-  not as multi-party approval.
+Workcell uses a single-maintainer release process. `@omkhar` can merge a pull
+request, approve the `release` environment, and create a signed tag.
 
-## Review expectations
+The maintainer must first complete all required checks and comment sweeps.
+Administrative merge authority can satisfy only the independent-approval
+requirement. It cannot override a commit-signature gate or the base-branch
+policy. It cannot override a failed repository check, an unresolved actionable
+comment, or a missing clean Codex review of the current head commit. It cannot
+override an unresolved review thread.
 
-- boundary- or policy-affecting changes should not merge without maintainer
-  review
-- contributor-facing docs should stay aligned with shipped behavior
-- release and provenance changes should include verification updates
-- every PR should be checked for top-level comments, inline review comments,
-  and unresolved review threads before merge
-- actionable comments from human or asynchronous reviewers should be addressed
-  or explicitly dispositioned before merge
-- comments should be checked again after CI turns green and immediately before
-  merge
+Do not describe this process as independent or multi-party approval.
 
-## Growth plan
+## Pull request review
 
-The project intends to add reviewers and maintainers over time, starting with:
+Apply these rules to every pull request:
 
-- runtime and policy review capacity
-- provider adapter review capacity
-- docs and onboarding review capacity
-- release and supply-chain review capacity
-- at least one backup release approver who can independently review or approve
-  security-sensitive release work when available
+1. Keep the pull request open for review.
+2. After every push, post a standalone issue comment with only
+   `@codex review`.
+3. Inspect issue comments, inline comments, formal reviews, and the trigger
+   reaction.
+4. React to each Codex finding.
+5. Fix or disposition each actionable finding.
+6. Run the required validation again.
+7. If a fix changes the branch, push a signed commit.
+8. After each new push, request another review.
+9. Resolve each addressed Codex thread.
+10. Require a fresh clean result for the current head commit.
+11. Continue until Codex reports no actionable finding for the current head.
+12. Check top-level comments, inline comments, formal reviews, and unresolved
+    threads.
+13. Check configured asynchronous reviewers.
+14. Repeat the comment sweep after CI succeeds and before merge.
 
-See [GOVERNANCE.md](GOVERNANCE.md) for the role model and
-[ROADMAP.md](ROADMAP.md) for the near-term priorities.
+An asynchronous review is advisory input. It is not an independent maintainer
+approval.
+
+## Future growth
+
+The project can add maintainers for these areas:
+
+- Runtime and policy.
+- Provider adapters.
+- Documentation and support for new contributors.
+- Release and supply chain.
+
+See [Governance](GOVERNANCE.md) for the role model. See the
+[Roadmap](ROADMAP.md) for planned work.

--- a/adapters/claude/CLAUDE.md
+++ b/adapters/claude/CLAUDE.md
@@ -1,9 +1,8 @@
 # Claude Adapter Instructions
 
-- The runtime boundary is the primary control. Do not assume hooks or prompt
-  text protect the host.
-- Stay inside the mounted workspace.
-- Do not attempt to read host credentials, shell state, browser state, or
-  keychains.
-- Use feature branches. Do not push directly to `main` or rewrite history.
-- Treat `breakglass` as explicit operator intent, not a convenience path.
+- Treat the runtime boundary as the primary control.
+- Do not treat hooks or instructions as a host security boundary.
+- Stay in the mounted workspace.
+- Do not read host credentials, shell state, browser state, or keychains.
+- Use a feature branch. Do not push to `main`. Do not rewrite history.
+- Use `breakglass` only when the operator explicitly selects it.

--- a/adapters/gemini/GEMINI.md
+++ b/adapters/gemini/GEMINI.md
@@ -1,8 +1,8 @@
 # Gemini Adapter Instructions
 
-- The shared VM plus container runtime is the primary boundary.
-- Do not widen trust by enabling host-native tools, sockets, or credentials.
-- Stay inside the mounted workspace.
-- Treat network access as profile-scoped and explicit.
-- Use lower-assurance GUI paths only when the operator has accepted the
-  downgrade.
+- Treat the VM and container as the primary runtime boundary.
+- Do not add host-native tools, sockets, or credentials to the safe path.
+- Stay in the mounted workspace.
+- Treat network access as explicit. Colima enforcement applies to one profile.
+- The supported interface is the CLI. The launcher stops if an operator selects
+  the GUI interface.

--- a/policy/README.md
+++ b/policy/README.md
@@ -1,20 +1,23 @@
 # Policy Core
 
-`policy/` holds the shared contract layer for Workcell.
+The `policy/` directory contains the shared Workcell contracts.
 
-It exists to define what every adapter and workflow must preserve:
+Each adapter and workflow must preserve these rules:
 
-- the runtime boundary is primary
-- host secrets and control sockets stay out by default
-- network modes are explicit
-- `breakglass` is narrow and visibly lower assurance
-- hosted controls outside git still require explicit policy
+- The runtime boundary is the primary control.
+- The safe path excludes control sockets, unapproved secrets, ambient
+  authentication state, and direct provider-state mounts. It permits only an
+  approved staged credential handoff.
+- Each network mode is explicit.
+- `breakglass` is narrow and has lower assurance.
+- Hosted controls outside Git need an explicit policy record.
 
-Provider-native config does not live here. That belongs in `adapters/`.
+Provider-native configuration belongs in `adapters/`, not in this directory.
 
-`hardening-profile.toml` captures the runtime's reviewed container-hardening
-posture (dropped capabilities, `no-new-privileges`, read-only rootfs, hardened
-tmpfs mounts, PID limit, mapped non-root user) and the outbound-endpoint
-inventory. The `hardening-profile-conformance` invariant
-(`scripts/verify-invariants.sh`) fails closed when the launcher drifts from it.
-See [docs/outbound-endpoints.md](../docs/outbound-endpoints.md).
+`hardening-profile.toml` records container controls and fixed endpoint literals.
+The controls include dropped capabilities, `no-new-privileges`, a read-only root
+file system, hardened temporary mounts, a PID limit, and a mapped non-root user.
+
+The `hardening-profile-conformance` check compares the policy artifact with
+launcher source functions. See the [outbound endpoint inventory](../docs/outbound-endpoints.md)
+for the human-readable fixed sets and their limits.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -8,8 +8,8 @@ The strict local target uses two isolation layers:
 The VM is the main local boundary. The container supplies a reproducible
 provider runtime.
 
-Docker Desktop is a supported compatibility target. It does not provide a
-dedicated Workcell VM or Workcell egress enforcement.
+Docker Desktop is a supported compatibility target on Apple Silicon macOS. It
+does not provide a dedicated Workcell VM or Workcell egress enforcement.
 
 ## Runtime goals
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,56 +1,55 @@
 # Runtime Boundary
 
-Tier 1 is a two-layer boundary:
+The strict local target uses two isolation layers:
 
-1. a dedicated Colima VM profile on macOS
-2. a hardened inner container inside that VM
+1. A dedicated Colima VM profile on macOS.
+2. A hardened runtime container in that VM.
 
-The VM is the main local isolation boundary. The container provides a reviewed,
-reproducible runtime for the supported providers.
+The VM is the main local boundary. The container supplies a reproducible
+provider runtime.
 
-## Goals
+Docker Desktop is a supported compatibility target. It does not provide a
+dedicated Workcell VM or Workcell egress enforcement.
 
-- keep the safe path one command away
-- run the provider inside the boundary, not on the host
-- mount only the selected workspace as durable host state, with explicit
-  narrow per-session handoff directories only where a reviewed provider auth
-  path requires them
-- keep the container unprivileged by default, with a named nonroot `workcell`
-  user in the shipped runtime and validator images
-- enforce network posture at the VM layer
-- block common control-plane escape hatches on the managed path
+## Runtime goals
 
-The host launcher still starts the managed runtime with explicit `--user 0:0`
-only long enough for PID 1 to seed runtime state and then drop privileges.
-Repo-mounted validator and release-helper paths instead run under explicit
-caller UID/GID mappings with isolated writable home, cache, and tmp roots so
-the mounted checkout never depends on ambient container-root defaults. When an
-explicit caller UID has no passwd entry inside the image, the launcher
-synthesizes an isolated writable home for that lane. The local
-`scripts/build-and-test.sh --docker` validator snapshot uses that same
-contract.
+- Keep the safe path available through one command.
+- Run the provider inside the runtime boundary.
+- Mount only the selected workspace and the approved persistent-cache paths as
+  durable host data.
+- Use only narrow, approved credential handoffs.
+- Run provider processes with the mapped host UID and GID.
+- Block common control-plane escape paths.
+
+Mutable sessions start PID 1 as root to prepare runtime state. PID 1 then changes
+to the mapped UID and GID before it starts the provider. Read-only sessions start
+PID 1 with the mapped UID and GID.
+
+Validator and release-helper containers use the caller UID and GID. They use
+separate writable home, cache, and temporary directories.
 
 ## Runtime profiles
 
-- `strict`: default provider lane
-- `development`: managed interactive development lane
-- `build`: explicit build and image-preparation lane
-- `breakglass`: explicit higher-trust lane
+| Profile | Use |
+|---|---|
+| `strict` | Default provider session from the prepared image |
+| `development` | Managed interactive development |
+| `build` | Image preparation and build work |
+| `breakglass` | Explicit higher-trust work with lower assurance |
 
-`strict` runs from the reviewed prepared runtime image and auto-prepares it when
-missing or stale. Interactive repo work and dependency egress belong to
-`development` or `build`.
+Strict mode prepares a missing or stale image. Development and build profiles
+permit the dependency access that their documented plans require.
 
-## Main entrypoints
+## Main entry points
 
-- `scripts/workcell`: host launcher and operator entrypoint
-- `scripts/colima-egress-allowlist.sh`: VM-level network posture helper
-- `scripts/container-smoke.sh`: direct container smoke coverage
-- `scripts/verify-invariants.sh`: invariant checks
-- `scripts/build-and-test.sh`: repo-wide validation and local check entry point
-- `scripts/pre-merge.sh`: pinned validator-container pre-merge harness with optional disposable snapshots
+- `scripts/workcell` provides the operator CLI and host launcher.
+- `scripts/colima-egress-allowlist.sh` manages profile-wide Colima rules.
+- `scripts/container-smoke.sh` runs direct container checks.
+- `scripts/verify-invariants.sh` verifies security invariants.
+- `scripts/build-and-test.sh` runs repository validation.
+- `scripts/pre-merge.sh` runs the pinned pre-merge validator.
 
-## GUI status
+## Interface scope
 
-CLI is the implemented Tier 1 path today. GUI or IDE surfaces are lower
-assurance unless they become clients of the same bounded runtime.
+The supported Tier 1 interface is the CLI. GUI and IDE paths have lower
+assurance unless they use the same runtime boundary.

--- a/runtime/colima/README.md
+++ b/runtime/colima/README.md
@@ -30,4 +30,4 @@ socket, keychain, or general credential store.
 
 All containers in one Colima profile share the Workcell egress rules. The last
 launch replaces those rules. Do not run concurrent sessions with different
-network policies in one profile.
+complete endpoint sets in one profile.

--- a/runtime/colima/README.md
+++ b/runtime/colima/README.md
@@ -1,33 +1,33 @@
 # Colima Design
 
-Workcell uses a dedicated Colima VM profile because that is the strongest
-practical local boundary available in the current macOS stack.
+Workcell uses a dedicated Colima profile for each workspace by default. The VM
+is the primary boundary for the strict macOS target.
 
 ## Boundary rules
 
-- use a dedicated profile per workspace by default
-- do not rely on Colima's shared `default` profile for Tier 1
-- mount only the selected workspace as writable host state, except for
-  explicit narrow per-session handoff directories such as the Copilot token
-  handoff mount
-- do not mount host homes, sockets, or broad source trees
-- enforce network posture at the VM layer
+- Do not use the shared Colima `default` profile for the strict target.
+- Mount only the selected workspace as writable durable host data.
+- Use only narrow, per-session credential handoff directories.
+- Do not mount a host home, socket, keychain, or broad source tree.
+- Apply the Workcell network policy at the VM layer.
 
-## Operational stance
+## Profile and mounts
 
-The host launcher derives a profile name from the workspace path unless the
-operator overrides it. The managed path validates the resulting Lima config and
-expects exactly one writable host mount for durable host state: the selected
-workspace. Auth handoffs that must cross the VM boundary, such as the Copilot
-token handoff, use a two-level shape: Workcell mounts a guarded parent staging
-root into Colima, then mounts only the per-session token handoff subdirectory
-into the container. These handoff directories stay outside provider state and
-must not become host homes, sockets, keychains, or broad credential stores.
+The launcher derives the profile name from the workspace path. The operator can
+select another profile.
 
-## What stays out
+The managed Lima configuration has one writable workspace mount: the selected
+workspace. A reviewed credential path can add a narrow handoff mount.
 
-- host home directories
-- host auth and agent sockets
-- keychain and browser-profile passthrough
-- host Docker control sockets
-- unrelated source trees
+The Copilot token path uses two mount levels. Workcell first mounts a guarded
+parent staging directory into the VM. It then mounts only the session token
+directory into the container.
+
+The handoff stays outside provider state. It must not become a host home,
+socket, keychain, or general credential store.
+
+## Network limit
+
+All containers in one Colima profile share the Workcell egress rules. The last
+launch replaces those rules. Do not run concurrent sessions with different
+network policies in one profile.

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -56,7 +56,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/claude/CLAUDE.md",
       "runtime_path": "/opt/workcell/adapters/claude/CLAUDE.md",
-      "sha256": "57ebc2c1f55c1e537f14db0a843f24e1273a016c184d4fae5e5ff5c6e673c8a5"
+      "sha256": "e74c5a705371f97125c36e9b8281f6b6b4476175211754cfabeb6089fae4c115"
     },
     {
       "kind": "adapter-baseline",
@@ -176,7 +176,7 @@
       "kind": "adapter-baseline",
       "repo_path": "adapters/gemini/GEMINI.md",
       "runtime_path": "/opt/workcell/adapters/gemini/GEMINI.md",
-      "sha256": "a06f4999ace204e3a1f1236c98a777d18e9eba24df8fbe0ddd623bd0fccc8cb9"
+      "sha256": "371f44f99b4a080286086493b470a6bf12d63bd6a9ce94e835f2a0a24b9a1c56"
     },
     {
       "kind": "runtime-control-plane",

--- a/verify/invariants/README.md
+++ b/verify/invariants/README.md
@@ -1,28 +1,34 @@
 # Invariant Test Plan
 
-The invariant suite answers one question: does the current implementation still
-match the documented security and control-plane contract?
+The invariant suite checks the documented runtime and control-plane contract.
 
-## Minimum checks
+## Positive checks
 
-The suite should keep verifying that:
+The suite verifies these conditions:
 
-1. the provider launches inside the container, not on the host
-2. the runtime receives only the reviewed host mounts
-3. host auth state and sockets stay out by default
-4. the selected workspace is the only writable host mount
-5. network posture is applied for the managed modes
-6. `breakglass` is explicit and visibly different
-7. provider control-plane files are present and loadable
-8. unsafe broad workspaces are rejected
+1. The provider starts in the container.
+2. The runtime receives only approved host mounts.
+3. The safe path rejects direct mounts of host authentication roots and all
+   host sockets. It permits only approved staged credential files.
+4. The selected workspace is the only general writable host mount. An approved
+   temporary credential handoff is one narrow exception. An approved non-secret
+   persistent-cache plane is another exception.
+5. Managed Colima modes apply the selected profile network policy.
+6. The launch output labels `breakglass` as lower assurance.
+7. Provider control-plane files are present and usable.
+8. Workcell rejects unsafe broad workspaces.
+
+The dry-run mount checks cover the fixed forbidden-path subset in
+`policy/forbidden-host-paths.toml`. Checks for provider-state sources also require a
+host-side validation lane.
 
 ## Negative checks
 
-The suite should fail if it finds:
+The suite fails when it detects these conditions:
 
-- `docker.sock` passthrough
-- host home passthrough
-- host provider-state passthrough
-- SSH or GPG agent socket passthrough
-- missing egress controls on the managed path
-- silent defaulting into `breakglass`
+- A Docker socket passes into the runtime.
+- A host home passes into the runtime.
+- A direct host provider-state mount passes into the runtime.
+- An SSH or GPG agent socket passes into the runtime.
+- A managed Colima allowlist mode has no egress rules.
+- A launch selects `breakglass` without explicit operator input.

--- a/verify/invariants/README.md
+++ b/verify/invariants/README.md
@@ -13,7 +13,7 @@ The suite verifies these conditions:
 4. The selected workspace is the only general writable host mount. An approved
    temporary credential handoff is one narrow exception. An approved non-secret
    persistent-cache plane is another exception.
-5. Managed Colima modes apply the selected profile network policy.
+5. Managed Colima modes generate the network-policy plan for the selected profile.
 6. The launch output labels `breakglass` as lower assurance.
 7. Provider control-plane files are present and usable.
 8. Workcell rejects unsafe broad workspaces.
@@ -30,5 +30,5 @@ The suite fails when it detects these conditions:
 - A host home passes into the runtime.
 - A direct host provider-state mount passes into the runtime.
 - An SSH or GPG agent socket passes into the runtime.
-- A managed Colima allowlist mode has no egress rules.
+- A generated allowlist plan for a managed Colima mode has no egress rules.
 - A launch selects `breakglass` without explicit operator input.

--- a/verify/invariants/expected-controls.md
+++ b/verify/invariants/expected-controls.md
@@ -1,47 +1,45 @@
 # Expected Controls
 
-## Workspace and mount controls
+## Workspace and mounts
 
-- exactly one task workspace mount is writable
-- no host home mount is present
-- no host credential or agent socket mounts are present
-- `/` and `$HOME` are rejected as default workspaces
-- `/tmp` is mounted `noexec`
-- `TMPDIR` points at `/state/tmp`
-- `strict` blocks direct native ELF launches from mutable `/workspace` and
-  `/state` paths
-- `strict` blocks mutable shebang scripts that point at protected real
-  runtimes or loaders targeting them
+- Exactly one task workspace mount is writable.
+- The runtime mounts no host home, credential store, or agent socket.
+- Workcell rejects `/` and the operator home as default workspaces.
+- The runtime mounts `/tmp` with `noexec`.
+- `TMPDIR` points to `/state/tmp`.
+- Strict mode blocks native ELF files from mutable workspace and state paths.
+- Strict mode blocks mutable scripts that select protected runtimes or loaders.
 
-## Codex controls
+## Codex
 
-- `strict` uses `workspace-write`
-- `development` uses `workspace-write`
-- `build` uses `workspace-write`
-- `breakglass` uses `danger-full-access`
-- web search stays disabled in all shipped profiles
+- Strict, development, and build profile files set `workspace-write`.
+- `breakglass` uses `danger-full-access`.
+- All shipped profiles disable web search.
+- The launcher reports the Codex native sandbox as disabled. The VM, container,
+  and syscall shim supply the effective boundary.
 
-## Network controls
+## Network
 
-- `strict` applies the base egress allowlist
-- `development` applies the expanded development egress allowlist
-- `build` applies the expanded egress allowlist
-- allowlist modes program reviewed IPv4 and, when available, IPv6 destination
-  allowlists; if IPv6 enforcement is unavailable, Workcell fails closed instead
-  of leaving an unmanaged parallel egress path
-- `breakglass` clears the allowlist and documents the loss
+- Strict mode uses the base allowlist.
+- Development and build modes add their versioned endpoint sets.
+- Colima allowlist modes program IPv4 and IPv6 `DOCKER-USER` rules.
+- Workcell stops the operation if it cannot apply IPv6 rules.
+- `breakglass` clears the profile-wide allowlist and reports the loss.
+- Docker Desktop reports `egress_enforcement=none`.
 
-## Audit and operator controls
+## Audit and operator output
 
-- the wrapper prints the selected Colima profile, runtime profile, and
-  workspace path
-- the wrapper prints the selected network policy and allowlist
-- `strict` auto-prepares the reviewed runtime image when missing or stale, while
-  explicit rebuild requests must be paired with `--prepare` so refresh remains
-  operator-visible
-- `build` prints any temporary bootstrap allowlist before rebuilding the
-  runtime image
-- the wrapper prints the execution path and durable host audit-log location
-- each real run appends a durable host-side audit record under the managed
-  Colima profile directory, including whether bootstrap egress was applied
-- lower-assurance modes are named explicitly
+- The launcher prints the profile, runtime mode, workspace, and target.
+- The launcher prints the network policy, endpoint list, and enforcement.
+- Strict mode prepares a missing or stale runtime image.
+- An explicit rebuild also requires `--prepare`.
+- When a rebuild uses bootstrap egress, build mode prints the temporary
+  bootstrap endpoint set.
+- The launcher prints the execution path and audit-log path.
+- When Workcell starts a non-dry-run session, it appends a host-owned audit
+  record.
+- Finalization attempts to sign a chained session head.
+- `session verify` fails closed when the chain, seal, or public key is invalid.
+- Operator output identifies each lower-assurance mode.
+
+The Colima egress rules apply to one profile, not one session.

--- a/workflows/adapter-porting.md
+++ b/workflows/adapter-porting.md
@@ -1,78 +1,49 @@
 # Adapter Porting Workflow
 
-Use this checklist when adding or refactoring a provider adapter.
+Use this workflow when you add or change a provider adapter.
 
 ## Goal
 
-Preserve the shared Workcell boundary while mapping into the provider's native
-control plane. Do not blur the boundary and the adapter into one layer.
+Keep one shared runtime boundary and one thin provider adapter. Use the native
+provider control plane. Do not treat it as the security boundary.
 
-## Design order
+## Work sequence
 
-Optimize in this order:
+1. Confirm the supported target boundary and assurance status.
+2. List each provider file that Workcell owns, masks, seeds, or links.
+3. Use the smallest provider-native configuration surface.
+4. Add the seed path for the provider home.
+5. Block flags and paths that lower assurance without operator acknowledgment.
+6. Add invariant, scenario, and adapter tests.
+7. Run live certification for each new support claim.
+8. Update the provider matrix and operator documents.
+9. If host or target support changes, update the host-support matrix.
+10. Complete adversarial and Codex review loops.
 
-1. Developer experience
-2. Simplicity
-3. Security invariant preservation
-4. Performance
-5. Idiomatic correctness
+The seed path can use these ordered sources:
 
-That order only applies after the runtime boundary is fixed.
+1. Immutable adapter baseline.
+2. Supported repository instruction files.
+3. Explicit injection-policy documents.
 
-## Porting sequence
+Do not let repository content replace immutable adapter controls.
 
-### 1. Lock the shared boundary first
+## Required documentation
 
-Before touching provider specifics, confirm that the shared runtime still
-guarantees:
-
-- dedicated VM profile
-- hardened inner container
-- narrow mount set
-- explicit network posture
-- no host home, sockets, or ambient credential passthrough
-
-### 2. Define the native control plane
-
-Document exactly which provider files Workcell owns, seeds, links, or masks.
-Keep the list small and auditable.
-
-### 3. Keep the adapter thin
-
-Use the provider's native config surfaces where possible. Do not invent a fake
-universal provider config layer.
-
-### 4. Add the runtime seeding path
-
-Update the home-control-plane logic so the provider-facing home is rebuilt from:
-
-- the immutable adapter baseline
-- imported workspace docs
-- explicit injection-policy input
-
-### 5. Add deny-list and downgrade logic
-
-Block provider-native flags or workflows that would silently widen trust, and
-document any lower-assurance paths explicitly.
-
-### 6. Add validation with the adapter
-
-No adapter change is complete without matching invariant or smoke coverage.
-
-### 7. Update the docs in the same change
-
-At minimum, update:
+Update each document that the adapter change affects in the same change:
 
 - `docs/provider-matrix.md`
 - `docs/adapter-control-planes.md`
-- provider-specific quickstart or adapter README material if behavior changed
+- Provider quickstart.
+- Adapter README.
+- Injection policy.
+- Support and certification evidence.
 
 ## Review questions
 
-Before merging an adapter change, ask:
-
-1. Did this improve the workflow, or just add indirection?
-2. Is the provider config being mistaken for the primary boundary?
-3. Can repo content retake the control plane after this change?
-4. Are any lower-assurance paths clearly labeled?
-5. Is the new behavior covered by validation?
+1. Does the adapter preserve the runtime boundary?
+2. Can repository content replace a trusted control?
+3. Does each lower-assurance path have an explicit label?
+4. Do tests exercise the shipped path?
+5. Does live evidence support each new claim?
+6. Did the change add unnecessary abstraction?

--- a/workflows/go-porting.md
+++ b/workflows/go-porting.md
@@ -1,94 +1,37 @@
-# Go Porting Workflow
+# Go Porting Record
 
-Status: this migration is complete and no repo-owned Python remains. The
-workflow is retained as the reference pattern for future language ports.
+The repository migration from Python helper files to Go is complete. Some shell
+tests use inline Python for test data and assertions.
 
-This workflow defines the compatibility-first migration path for replacing
-repo-owned Python with Go on the experimental branch.
+This record keeps the method for a future language port. It does not describe
+planned Workcell work.
 
-## Scope
+## Preserved method
 
-Tranche 1 covers the bounded helper surface under `scripts/lib/` plus the
-repo-owned Python tests and mutation harness that define current behavior.
+1. Record the old CLI, file, permission, and error contracts.
+2. Add differential tests that use the same fixtures.
+3. Port low-coupling tools before shared policy code.
+4. Put shared parser and validation code in one library.
+5. Change callers only after parity tests pass.
+6. Remove the old runtime and validation code last.
 
-Tranche 2 covers the remaining launcher- and invariant-side host utilities that
-still need Go-backed replacements. Track those separately so the shared helper
-migration does not stall on unrelated one-off host-side probes.
+Each port must preserve these properties:
 
-## Dependencies
+- CLI flags and exit codes.
+- JSON and TOML shapes.
+- Deterministic order.
+- Secret file modes.
+- Path checks and symlink rejection.
+- Mutation resistance for security decisions.
 
-Prefer the Go standard library by default. Treat every non-stdlib dependency
-as a policy exception that needs an explicit written rationale covering:
+Use the Go standard library by default. A new dependency needs a written
+supply-chain rationale.
 
-- why the gap is not practical to solve with stdlib and small local code
-- why the dependency improves safety or compatibility more than it increases
-  supply-chain surface
-- how widely the dependency would spread through the repo
+The validation entry point is:
 
-Until a dependency clears that bar, do not add it.
-
-## Team
-
-Use parallel workstreams with explicit ownership:
-
-1. Contract and fixtures
-   Capture CLI contracts, file formats, permissions, and error-path behavior.
-2. Low-coupling tools
-   Port `scenario_manifest`, `extract_direct_mounts`, and `pty_transcript`
-   first to prove the Go CLI and parity harness with minimal blast radius.
-3. Shared policy core
-   Port duplicated parsing, include-merging, path validation, and TOML rendering
-   logic into one Go library before touching the highest-coupling helpers.
-4. Injection pipeline
-   Port `render_injection_bundle` and `resolve_credential_sources` against the
-   shared library rather than independently.
-5. Host auth management
-   Port `manage_injection_policy` only after the shared policy primitives are
-   stable, because it depends on the same selector and validation semantics.
-6. Verification and benchmarks
-   Keep parity gates green, then compare Python and Go implementations for
-   runtime, filesystem behavior, and operator-facing output.
-
-## Order Of Operations
-
-1. Freeze the Python baseline with unit, mutation, and coverage checks.
-2. Add Go parity tests that compare future Go helpers against the current
-   Python outputs on the same fixtures.
-3. Port the low-coupling helpers first to validate the Go module layout and
-   the parity harness on small surfaces.
-4. Port the shared policy and injection cluster as a unit to avoid duplicated
-   parsing drift.
-5. Replace call sites only after the Go entrypoint has parity coverage and the
-   current Python tests pass against the new implementation.
-6. Remove Python from validation scripts last, after the helper cutover is
-   complete and remaining inline snippets are either ported or explicitly
-   deferred.
-
-## Compatibility Gates
-
-Every helper cutover should preserve:
-
-- CLI flags and exit status semantics
-- JSON and TOML output shape
-- deterministic ordering where current tests rely on it
-- file modes for secrets and staged outputs
-- path validation and symlink rejection behavior
-- mutation-test resistance for security-sensitive branches
-
-## Local Validation
-
-Use the bounded baseline script before and after each porting step:
-
-```bash
+```sh
 ./scripts/go-port-validate.sh
 ```
 
-For non-functional comparison, benchmark only fixture-driven helpers with stable
-inputs and compare:
-
-- wall-clock runtime
-- peak memory where practical
-- bytes written and file mode outcomes
-
-Do not switch shell entrypoints to Go until the compatibility harness proves the
-new helper is a drop-in replacement.
+Do not use this record as evidence for a new port. Add fresh parity tests and
+validation for the new source and destination languages.

--- a/workflows/python-to-go-migration.md
+++ b/workflows/python-to-go-migration.md
@@ -1,121 +1,42 @@
-# Python To Go Migration Workflow
+# Python-to-Go Migration Record
 
-Status: this migration is complete and no repo-owned Python remains. The
-workflow is retained as the reference pattern for future language ports.
+The repository migration from Python helper files to Go is complete. Some shell
+tests use inline Python for test data and assertions.
 
-Use this workflow when porting repo-owned Python helpers to Go.
+This page records the completed compatibility method. It is not an active
+migration plan.
 
-## Goal
+## Completed sequence
 
-Replace Python helper implementations without weakening the Workcell runtime
-boundary, broadening parser behavior, or creating compatibility drift at the
-shell/runtime boundary.
+1. The project recorded the Python behavior and security checks.
+2. Differential tests compared Python and Go with the same fixtures.
+3. Low-coupling tools moved before the policy and injection tools.
+4. Shared Go libraries replaced duplicate parser logic and path checks.
+5. Callers changed only after their parity tests passed.
+6. Validation moved after helper parity.
+7. The project removed the residual repo-owned Python helper files.
 
-## Design order
+The sequence covered these helper groups:
 
-Optimize in this order:
+- Scenario manifest tools.
+- Direct mount extraction.
+- PTY transcript tools.
+- Policy parser and renderer.
+- Credential source resolution.
+- Authentication policy management.
 
-1. Compatibility with current Python behavior
-2. Simplicity
-3. Security invariant preservation
-4. Performance
-5. Idiomatic correctness
+## Preserved gates
 
-That order applies only after the current boundary and assurance model stay
-intact.
+Each cutover compared these results:
 
-## Dependencies
+- Exit code.
+- Standard output and standard error.
+- JSON or TOML output.
+- File tree and content.
+- File modes.
+- Security error paths.
 
-Default to the Go standard library. Any non-stdlib dependency needs an explicit
-written rationale that explains why it is unavoidable, why a small local
-implementation is worse, and why the added supply-chain surface is justified.
+The migration kept shell entry points stable until the Go tools had parity.
 
-## Migration sequence
-
-### 1. Freeze the legacy baseline first
-
-Before porting anything, capture a passing baseline for:
-
-- `./scripts/verify-coverage.sh`
-- `./scripts/run-mutation-tests.sh`
-- `./scripts/run-scenario-tests.sh --repo-required`
-- `./scripts/verify-scenario-coverage.sh`
-- `./scripts/verify-control-plane-parity.sh`
-
-If the helper touches the live runtime boundary, also capture the local
-certification lane separately:
-
-- `./scripts/run-scenario-tests.sh --secretless-only --certification-only`
-
-### 2. Keep the shell contract stable
-
-Do not churn shell call sites more than once. Prefer stable Go binaries under
-`cmd/` plus extensionless wrappers when cutover begins. Keep Python as the
-oracle until parity is proven.
-
-### 3. Port leaf tools before the policy cluster
-
-Port in this order:
-
-1. `scenario_manifest`
-2. `extract_direct_mounts`
-3. `pty_transcript`
-4. shared policy library replacing `policy_bundle.py`
-5. `resolve_credential_sources`
-6. `manage_injection_policy`
-7. `render_injection_bundle`
-
-The policy and rendering cluster should move only after the shared parser and
-validation behavior exist in one Go library.
-
-### 4. Add parity gates before cutover
-
-For each helper, run Python and Go against the same fixtures and compare:
-
-- exit code
-- stdout/stderr
-- rewritten JSON or TOML
-- output file layout
-- file contents
-- file modes
-
-Normalize only fields that are inherently unstable, such as PTY transcript
-timestamps.
-
-### 5. Cut over call sites in batches
-
-After parity is green for a helper, switch all direct consumers of that helper
-in one change. Keep control-plane manifests, invariant checks, and validation
-scripts in sync with the new entrypoints.
-
-### 6. Replace validation plumbing after helper parity
-
-Only after the helper ports are stable should the repo remove:
-
-- Python mutation coverage for helper paths
-- residual helper-specific host-language invocations in shell validation
-
-### 7. Treat inline shell Python as a second migration wave
-
-Porting the helper entrypoints does not remove the remaining host-side utility
-logic embedded in shell scripts. Handle that second wave by domain rather than
-file-by-file.
-
-## Local validation matrix
-
-- Functional: differential Python-vs-Go fixture tests plus existing unit,
-  invariant, scenario, and smoke coverage.
-- Non-functional: startup time, max RSS, binary size, and output tree size on
-  fixed local fixtures.
-- Avoid hard performance thresholds for Docker, Colima, networked auth, or
-  TTY-scheduling-heavy paths.
-
-## Review questions
-
-Before merging any migration slice, ask:
-
-1. Did this preserve current Python behavior at the CLI and filesystem level?
-2. Did this keep the runtime boundary and control-plane masking rules intact?
-3. Did this reduce future cutover work, or only move code around?
-4. Are validation and invariant checks still exercising the migrated path?
-5. Is any remaining Python dependency explicit and temporary?
+For a future language port, create a new plan. Use fresh baseline evidence and
+tests for that change.


### PR DESCRIPTION
## Summary

- Revise maintainer and runtime documentation.
- Match shipped behavior.
- Use ASD-STE100 Simplified Technical English.

## Validation

- Exact source, security, and STE reviews accepted the final patch.
- `./scripts/ci/job-docs.sh`
- `./scripts/pre-merge.sh --profile pr-parity`