### PR TITLE
Fix audit lock reclaim race

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -279,9 +279,8 @@ func helperSubcommands() []helperSubcommand {
 		{"route-profile-docker-command", 1, -1, cmdHelperRouteProfileDockerCommand},
 		{"prepare-current-docker-client-plan", 1, -1, cmdHelperPrepareCurrentDockerClientPlan},
 		{"cleanup-stale-log-pointers", 1, 1, cmdHelperCleanupStaleLogPointers},
-		{"profile-lock-is-stale", 1, 1, cmdHelperProfileLockIsStale},
 		{"acquire-profile-lock", 2, 2, cmdHelperAcquireProfileLock},
-		{"write-profile-owner", 2, 2, cmdHelperWriteProfileOwner},
+		{"release-profile-lock", 2, 2, cmdHelperReleaseProfileLock},
 		{"cleanup-stale-session-audit-dirs", 1, 1, cmdHelperCleanupStaleSessionAuditDirs},
 		{"session-record-write", 2, -1, cmdHelperSessionRecordWrite},
 		{"session-list", 0, -1, runHelperSessionList},
@@ -632,19 +631,6 @@ func cmdHelperCleanupStaleLogPointers(args []string) error {
 	return hoststate.CleanupStaleLatestLogPointers(args[0])
 }
 
-func cmdHelperProfileLockIsStale(args []string) error {
-	stale, err := launcher.ProfileLockIsStale(args[0])
-	if err != nil {
-		return err
-	}
-	if stale {
-		fmt.Println("1")
-	} else {
-		fmt.Println("0")
-	}
-	return nil
-}
-
 func cmdHelperAcquireProfileLock(args []string) error {
 	pid, err := strconv.Atoi(args[1])
 	if err != nil {
@@ -662,12 +648,20 @@ func cmdHelperAcquireProfileLock(args []string) error {
 	return nil
 }
 
-func cmdHelperWriteProfileOwner(args []string) error {
+func cmdHelperReleaseProfileLock(args []string) error {
 	pid, err := strconv.Atoi(args[1])
 	if err != nil {
 		return fmt.Errorf("parse pid: %w", err)
 	}
-	return launcher.WriteProfileOwner(args[0], pid)
+	if err := launcher.ReleaseProfileLock(args[0], pid); err != nil {
+		if errors.Is(err, launcher.ErrProfileLockTransitionBusy) {
+			fmt.Println("0")
+			return nil
+		}
+		return err
+	}
+	fmt.Println("1")
+	return nil
 }
 
 func cmdHelperCleanupStaleSessionAuditDirs(args []string) error {

--- a/docs/signed-session-audit-records.md
+++ b/docs/signed-session-audit-records.md
@@ -61,8 +61,9 @@ The session head is the last `record_digest` for that `session_id`.
 Workcell locks the profile audit log before it reads the tail and appends a
 record. The lock covers both operations.
 
-The lock uses the repository `acquire-profile-lock` operation. It does not
-require `flock` on macOS.
+The lock uses the repository `acquire-profile-lock` operation. A Go-owned
+advisory lock serializes acquisition, stale reclaim, and release. This design
+does not require the external `flock` command on macOS.
 
 The appender uses approximately 30 seconds of sleep backoff. Helper execution
 can make the total wait longer. If the lock remains unavailable, the append

--- a/internal/host/launcher/launcher.go
+++ b/internal/host/launcher/launcher.go
@@ -16,9 +16,15 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
-var errNoMatch = errors.New("not found")
+var (
+	errNoMatch = errors.New("not found")
+	// ErrProfileLockTransitionBusy reports a contended transition guard.
+	ErrProfileLockTransitionBusy = errors.New("profile lock transition guard is busy")
+)
 
 func RandomHex(n int) (string, error) {
 	if n <= 0 {
@@ -101,9 +107,37 @@ func ColimaProfileProcessPIDs(psOutput []byte, profile string) ([]int, error) {
 	return pids, nil
 }
 
-func ProfileLockIsStale(lockDir string) (bool, error) {
+type profileLockOwner struct {
+	PID     int    `json:"pid"`
+	Started string `json:"started"`
+}
+
+func readProfileLockOwner(lockDir string) (profileLockOwner, error) {
 	ownerPath := filepath.Join(lockDir, "owner.json")
 	content, err := os.ReadFile(ownerPath)
+	if err != nil {
+		return profileLockOwner{}, err
+	}
+
+	var owner profileLockOwner
+	if err := json.Unmarshal(content, &owner); err != nil {
+		return profileLockOwner{}, fmt.Errorf("parse profile lock owner metadata: %w", err)
+	}
+	if owner.PID <= 0 || owner.Started == "" {
+		return profileLockOwner{}, fmt.Errorf("profile lock owner metadata is incomplete: %s", ownerPath)
+	}
+	return owner, nil
+}
+
+func observedProfileLockGeneration(owner profileLockOwner) (string, error) {
+	if strings.HasPrefix(owner.Started, "darwin:") || strings.HasPrefix(owner.Started, "linux:") {
+		return processGeneration(owner.PID)
+	}
+	return ProcessStartTime(owner.PID)
+}
+
+func ProfileLockIsStale(lockDir string) (bool, error) {
+	owner, err := readProfileLockOwner(lockDir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return true, nil
@@ -111,32 +145,9 @@ func ProfileLockIsStale(lockDir string) (bool, error) {
 		return false, err
 	}
 
-	var owner struct {
-		PID     int    `json:"pid"`
-		Started string `json:"started"`
-	}
-	if err := json.Unmarshal(content, &owner); err != nil {
-		return false, fmt.Errorf("parse profile lock owner metadata: %w", err)
-	}
-	if owner.PID <= 0 || owner.Started == "" {
-		return false, fmt.Errorf("profile lock owner metadata is incomplete: %s", ownerPath)
-	}
-
-	alive, err := pidAlive(owner.PID)
+	observed, err := observedProfileLockGeneration(owner)
 	if err != nil {
-		return false, err
-	}
-	if !alive {
-		return true, nil
-	}
-
-	observed, err := ProcessStartTime(owner.PID)
-	if err != nil {
-		alive, killErr := pidAlive(owner.PID)
-		if killErr != nil {
-			return false, killErr
-		}
-		if !alive {
+		if IsProcessGone(err) {
 			return true, nil
 		}
 		return false, err
@@ -144,19 +155,43 @@ func ProfileLockIsStale(lockDir string) (bool, error) {
 	return observed != owner.Started, nil
 }
 
-// pidAlive reports whether signal 0 reaches pid. A missing process (ESRCH)
-// returns (false, nil); any other Kill error is surfaced.
-func pidAlive(pid int) (bool, error) {
-	if err := syscall.Kill(pid, 0); err != nil {
-		if errors.Is(err, syscall.ESRCH) {
-			return false, nil
-		}
-		return false, err
+// withProfileLockTransition serializes lock acquisition, stale reclaim, and
+// release. The sibling guard file persists so all callers lock the same inode.
+// The kernel releases the advisory lock if a helper process exits unexpectedly.
+func withProfileLockTransition(lockDir string, fn func() error) error {
+	if lockDir == "" || filepath.Clean(lockDir) == string(filepath.Separator) {
+		return errors.New("profile lock directory is required")
 	}
-	return true, nil
+	if err := os.MkdirAll(filepath.Dir(lockDir), 0o755); err != nil {
+		return err
+	}
+
+	guardPath := lockDir + ".guard"
+	fd, err := unix.Open(guardPath, unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return fmt.Errorf("open profile lock transition guard: %w", err)
+	}
+	defer unix.Close(fd) //nolint:errcheck // the operation result is authoritative
+	if err := unix.Fchmod(fd, 0o600); err != nil {
+		return fmt.Errorf("set profile lock transition guard mode: %w", err)
+	}
+	for {
+		if err := unix.Flock(fd, unix.LOCK_EX|unix.LOCK_NB); err != nil {
+			if errors.Is(err, syscall.EINTR) {
+				continue
+			}
+			if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+				return ErrProfileLockTransitionBusy
+			}
+			return fmt.Errorf("lock profile transition guard: %w", err)
+		}
+		break
+	}
+	defer unix.Flock(fd, unix.LOCK_UN) //nolint:errcheck // closing the descriptor also releases the lock
+	return fn()
 }
 
-func AcquireProfileLock(lockDir string, pid int) (bool, error) {
+func acquireProfileLockUncoordinated(lockDir string, pid int) (bool, error) {
 	parentDir := filepath.Dir(lockDir)
 	if err := os.MkdirAll(parentDir, 0o755); err != nil {
 		return false, err
@@ -187,8 +222,63 @@ func AcquireProfileLock(lockDir string, pid int) (bool, error) {
 	return true, nil
 }
 
+// AcquireProfileLock atomically acquires a free lock or reclaims a stale lock.
+// The transition guard prevents an earlier stale decision from deleting a new
+// holder that acquired the directory after another process released it.
+func AcquireProfileLock(lockDir string, pid int) (bool, error) {
+	var acquired bool
+	err := withProfileLockTransition(lockDir, func() error {
+		var err error
+		acquired, err = acquireProfileLockUncoordinated(lockDir, pid)
+		if err != nil || acquired {
+			return err
+		}
+		stale, err := ProfileLockIsStale(lockDir)
+		if err != nil {
+			return err
+		}
+		if !stale {
+			return nil
+		}
+		if err := os.RemoveAll(lockDir); err != nil {
+			return fmt.Errorf("remove stale profile lock: %w", err)
+		}
+		acquired, err = acquireProfileLockUncoordinated(lockDir, pid)
+		return err
+	})
+	if errors.Is(err, ErrProfileLockTransitionBusy) {
+		return false, nil
+	}
+	return acquired, err
+}
+
+// ReleaseProfileLock removes only the caller's lock while holding the same
+// transition guard used by acquisition and stale reclaim.
+func ReleaseProfileLock(lockDir string, pid int) error {
+	return withProfileLockTransition(lockDir, func() error {
+		owner, err := readProfileLockOwner(lockDir)
+		if err != nil {
+			return err
+		}
+		if owner.PID != pid {
+			return fmt.Errorf("profile lock owner pid is %d, not %d", owner.PID, pid)
+		}
+		started, err := observedProfileLockGeneration(owner)
+		if err != nil {
+			return err
+		}
+		if owner.Started != started {
+			return errors.New("profile lock owner process generation changed")
+		}
+		if err := os.RemoveAll(lockDir); err != nil {
+			return fmt.Errorf("release profile lock: %w", err)
+		}
+		return nil
+	})
+}
+
 func WriteProfileOwner(ownerPath string, pid int) error {
-	started, err := ProcessStartTime(pid)
+	started, err := processGeneration(pid)
 	if err != nil {
 		return err
 	}

--- a/internal/host/launcher/launcher_test.go
+++ b/internal/host/launcher/launcher_test.go
@@ -5,12 +5,17 @@ package launcher
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestColimaProfileStatusMissingProfileReturnsNoMatch(t *testing.T) {
@@ -107,7 +112,7 @@ func TestProfileLockIsStaleReportsIncompleteOwnerMetadata(t *testing.T) {
 func TestProfileLockIsStaleRecognizesLiveOwner(t *testing.T) {
 	t.Parallel()
 	lockDir := t.TempDir()
-	started, err := ProcessStartTime(os.Getpid())
+	started, err := processGeneration(os.Getpid())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,6 +126,44 @@ func TestProfileLockIsStaleRecognizesLiveOwner(t *testing.T) {
 	}
 	if stale {
 		t.Fatal("ProfileLockIsStale() stale = true, want false for live owner")
+	}
+}
+
+func TestProfileLockIsStalePreservesLiveLegacyOwner(t *testing.T) {
+	t.Parallel()
+	lockDir := t.TempDir()
+	started, err := ProcessStartTime(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"pid":` + strconv.Itoa(os.Getpid()) + `,"started":"` + started + `"}` + "\n")
+	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stale, err := ProfileLockIsStale(lockDir)
+	if err != nil {
+		t.Fatalf("ProfileLockIsStale() error = %v", err)
+	}
+	if stale {
+		t.Fatal("ProfileLockIsStale() stale = true, want false for live legacy owner")
+	}
+}
+
+func TestProfileLockIsStaleRecognizesReusedPIDGeneration(t *testing.T) {
+	t.Parallel()
+	lockDir := t.TempDir()
+	payload := []byte(`{"pid":` + strconv.Itoa(os.Getpid()) + `,"started":"darwin:different"}` + "\n")
+	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stale, err := ProfileLockIsStale(lockDir)
+	if err != nil {
+		t.Fatalf("ProfileLockIsStale() error = %v", err)
+	}
+	if !stale {
+		t.Fatal("ProfileLockIsStale() stale = false, want true for reused PID generation")
 	}
 }
 
@@ -151,7 +194,17 @@ func TestAcquireProfileLockCreatesOwnerAtomically(t *testing.T) {
 		t.Fatalf("owner PID = %d, want %d", owner.PID, os.Getpid())
 	}
 	if owner.Started == "" {
-		t.Fatal("owner.Started = empty, want process start time")
+		t.Fatal("owner.Started = empty, want process generation")
+	}
+	wantGeneration, err := processGeneration(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if owner.Started != wantGeneration {
+		t.Fatalf("owner.Started = %q, want %q", owner.Started, wantGeneration)
+	}
+	if err := ReleaseProfileLock(lockDir, os.Getpid()); err != nil {
+		t.Fatalf("ReleaseProfileLock() error = %v", err)
 	}
 }
 
@@ -159,8 +212,9 @@ func TestAcquireProfileLockReturnsFalseWhenLockExists(t *testing.T) {
 	t.Parallel()
 	parent := t.TempDir()
 	lockDir := filepath.Join(parent, "profile.lock")
-	if err := os.MkdirAll(lockDir, 0o755); err != nil {
-		t.Fatal(err)
+	first, err := AcquireProfileLock(lockDir, os.Getpid())
+	if err != nil || !first {
+		t.Fatalf("first AcquireProfileLock() = %v, %v; want true, nil", first, err)
 	}
 
 	acquired, err := AcquireProfileLock(lockDir, os.Getpid())
@@ -179,5 +233,167 @@ func TestAcquireProfileLockReturnsFalseWhenLockExists(t *testing.T) {
 		if strings.Contains(entry.Name(), ".pending.") {
 			t.Fatalf("temporary lock dir leaked: %s", entry.Name())
 		}
+	}
+	if err := ReleaseProfileLock(lockDir, os.Getpid()); err != nil {
+		t.Fatalf("ReleaseProfileLock() error = %v", err)
+	}
+}
+
+func TestAcquireProfileLockSerializesConcurrentStaleReclaim(t *testing.T) {
+	lockDir := filepath.Join(t.TempDir(), "audit.log.lock")
+	holder := exec.Command("/bin/sleep", "60")
+	if err := holder.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteProfileOwner(filepath.Join(lockDir, "owner.json"), holder.Process.Pid); err != nil {
+		_ = holder.Process.Kill()
+		_ = holder.Wait()
+		t.Fatal(err)
+	}
+	if err := holder.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	if err := holder.Wait(); err == nil {
+		t.Fatal("killed stale lock holder exited successfully")
+	}
+
+	type result struct {
+		acquired bool
+		err      error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	for range 2 {
+		go func() {
+			<-start
+			acquired, err := AcquireProfileLock(lockDir, os.Getpid())
+			results <- result{acquired: acquired, err: err}
+		}()
+	}
+	close(start)
+
+	acquiredCount := 0
+	for range 2 {
+		got := <-results
+		if got.err != nil {
+			t.Fatalf("AcquireProfileLock() error = %v", got.err)
+		}
+		if got.acquired {
+			acquiredCount++
+		}
+	}
+	if acquiredCount != 1 {
+		t.Fatalf("concurrent stale reclaim acquired count = %d, want 1", acquiredCount)
+	}
+	stale, err := ProfileLockIsStale(lockDir)
+	if err != nil {
+		t.Fatalf("ProfileLockIsStale() error = %v", err)
+	}
+	if stale {
+		t.Fatal("concurrent stale reclaim removed the live successor lock")
+	}
+	if err := ReleaseProfileLock(lockDir, os.Getpid()); err != nil {
+		t.Fatalf("ReleaseProfileLock() error = %v", err)
+	}
+}
+
+func TestReleaseProfileLockRejectsDifferentOwner(t *testing.T) {
+	lockDir := filepath.Join(t.TempDir(), "profile.lock")
+	acquired, err := AcquireProfileLock(lockDir, os.Getpid())
+	if err != nil || !acquired {
+		t.Fatalf("AcquireProfileLock() = %v, %v; want true, nil", acquired, err)
+	}
+	if err := ReleaseProfileLock(lockDir, os.Getpid()+1); err == nil {
+		t.Fatal("ReleaseProfileLock() accepted a different owner")
+	}
+	if _, err := os.Stat(lockDir); err != nil {
+		t.Fatalf("lock disappeared after rejected release: %v", err)
+	}
+	if err := ReleaseProfileLock(lockDir, os.Getpid()); err != nil {
+		t.Fatalf("ReleaseProfileLock() error = %v", err)
+	}
+	info, err := os.Stat(lockDir + ".guard")
+	if err != nil {
+		t.Fatalf("stat persistent transition guard: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("transition guard mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestReleaseProfileLockRejectsChangedProcessGeneration(t *testing.T) {
+	lockDir := filepath.Join(t.TempDir(), "profile.lock")
+	acquired, err := AcquireProfileLock(lockDir, os.Getpid())
+	if err != nil || !acquired {
+		t.Fatalf("AcquireProfileLock() = %v, %v; want true, nil", acquired, err)
+	}
+	payload := []byte(`{"pid":` + strconv.Itoa(os.Getpid()) + `,"started":"darwin:different"}` + "\n")
+	if err := os.WriteFile(filepath.Join(lockDir, "owner.json"), payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ReleaseProfileLock(lockDir, os.Getpid()); err == nil {
+		t.Fatal("ReleaseProfileLock() accepted a changed process generation")
+	}
+	if _, err := os.Stat(lockDir); err != nil {
+		t.Fatalf("lock disappeared after rejected generation: %v", err)
+	}
+}
+
+func TestProfileLockTransitionGuardFailsFastWhenHeld(t *testing.T) {
+	lockDir := filepath.Join(t.TempDir(), "profile.lock")
+	holder := exec.Command("/bin/sleep", "60")
+	if err := holder.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteProfileOwner(filepath.Join(lockDir, "owner.json"), holder.Process.Pid); err != nil {
+		_ = holder.Process.Kill()
+		_ = holder.Wait()
+		t.Fatal(err)
+	}
+	if err := holder.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	if err := holder.Wait(); err == nil {
+		t.Fatal("killed stale lock holder exited successfully")
+	}
+
+	guardFD, err := unix.Open(lockDir+".guard", unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(guardFD) //nolint:errcheck // test cleanup
+	if err := unix.Flock(guardFD, unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	second, err := AcquireProfileLock(lockDir, os.Getpid())
+	if err != nil {
+		t.Fatalf("AcquireProfileLock() behind held guard error = %v", err)
+	}
+	if second {
+		t.Fatal("AcquireProfileLock() acquired behind a held transition guard")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("AcquireProfileLock() blocked behind guard for %s", elapsed)
+	}
+
+	start = time.Now()
+	if err := ReleaseProfileLock(lockDir, holder.Process.Pid); !errors.Is(err, ErrProfileLockTransitionBusy) {
+		t.Fatalf("ReleaseProfileLock() behind held guard error = %v, want busy", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("ReleaseProfileLock() blocked behind guard for %s", elapsed)
+	}
+
+	if err := unix.Flock(guardFD, unix.LOCK_UN); err != nil {
+		t.Fatal(err)
+	}
+	acquired, err := AcquireProfileLock(lockDir, os.Getpid())
+	if err != nil || !acquired {
+		t.Fatalf("AcquireProfileLock() after guard release = %v, %v; want true, nil", acquired, err)
+	}
+	if err := ReleaseProfileLock(lockDir, os.Getpid()); err != nil {
+		t.Fatalf("ReleaseProfileLock() after guard release error = %v", err)
 	}
 }

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "98a7b04fbd880f74b3a3725536efb963212c5bc10c1c604c13e03f8ffd4f1e5e"
+      "sha256": "1479c9d048a3d6a51e15032ea8fd69900ed911dc3ed561d6097bf083110a1518"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -8626,16 +8626,27 @@ if ! sed -n '/^acquire_profile_lock()/,/^}/p' "${ROOT_DIR}/scripts/workcell" | a
   /^[[:space:]]*fi$/ && state == 4 { state = 5; next }
   /^[[:space:]]*if \[\[ "\$\{acquired_state\}" == "1" \]\]; then$/ && state == 5 { state = 6; next }
   /^[[:space:]]*PROFILE_LOCK_DIR="\$\{lock_dir\}"$/ && state == 6 { state = 7; next }
-  /^[[:space:]]*return 0$/ && state == 7 { state = 8; next }
-  /^[[:space:]]*fi$/ && state == 8 { state = 9; next }
-  /^[[:space:]]*if ! stale_state="\$\(profile_lock_is_stale "\$\{lock_dir\}"\)"; then$/ && state == 9 { state = 10; next }
-  /^[[:space:]]*echo "Failed to inspect managed runtime lock state for profile \$\{profile\}\." >&2$/ && state == 10 { state = 11; next }
-  /^[[:space:]]*return 1$/ && state == 11 { state = 12; next }
-  /^[[:space:]]*fi$/ && state == 12 { state = 13; next }
-  /^[[:space:]]*if \[\[ "\$\{stale_state\}" == "1" \]\]; then$/ && state == 13 { state = 14; exit }
-  END { exit(state == 14 ? 0 : 1) }
+  /^[[:space:]]*return 0$/ && state == 7 { state = 8; exit }
+  END { exit(state == 8 ? 0 : 1) }
 '; then
-  echo "Expected workcell to acquire profile locks atomically and fail fast when lock state cannot be inspected" >&2
+  echo "Expected workcell to use the guarded profile-lock acquisition helper" >&2
+  exit 1
+fi
+
+if sed -n '/^acquire_profile_lock()/,/^}/p' "${ROOT_DIR}/scripts/workcell" |
+  grep -Eq 'profile_lock_is_stale|rm -rf.*lock_dir'; then
+  echo "Profile-lock acquisition must not reclaim lock directories in shell" >&2
+  exit 1
+fi
+
+if ! grep -Fq "release_profile_lock \"\${PROFILE_LOCK_DIR}\" \"\$\$\"" "${ROOT_DIR}/scripts/workcell"; then
+  echo "Expected workcell cleanup to use the guarded profile-lock release helper" >&2
+  exit 1
+fi
+
+if ! sed -n '/^release_profile_lock()/,/^}/p' "${ROOT_DIR}/scripts/workcell" |
+  grep -Fq "go_hostutil helper release-profile-lock \"\${lock_dir}\" \"\${holder_pid}\""; then
+  echo "Expected profile-lock release to use the guarded helper" >&2
   exit 1
 fi
 

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -1131,7 +1131,10 @@ cleanup() {
 
   cleanup_runtime_builder || true
   if [[ -n "${PROFILE_LOCK_DIR}" ]] && [[ -d "${PROFILE_LOCK_DIR}" ]]; then
-    rm -rf "${PROFILE_LOCK_DIR}"
+    if ! release_profile_lock "${PROFILE_LOCK_DIR}" "$$"; then
+      echo "Workcell: warning: could not release the managed runtime lock at ${PROFILE_LOCK_DIR}." >&2
+    fi
+    PROFILE_LOCK_DIR=""
   fi
 
   cleanup_workcell_trusted_docker_client
@@ -2569,18 +2572,11 @@ cleanup_stale_latest_log_pointers() {
   fi
 }
 
-profile_lock_is_stale() {
-  local lock_dir="$1"
-
-  go_hostutil helper profile-lock-is-stale "${lock_dir}"
-}
-
 acquire_profile_lock() {
   local profile="$1"
   local lock_dir=""
   local lock_parent=""
   local acquired_state=""
-  local stale_state=""
   local attempts=0
 
   lock_dir="$(profile_lock_dir_path "${profile}")"
@@ -2596,20 +2592,56 @@ acquire_profile_lock() {
       PROFILE_LOCK_DIR="${lock_dir}"
       return 0
     fi
-    if ! stale_state="$(profile_lock_is_stale "${lock_dir}")"; then
-      echo "Failed to inspect managed runtime lock state for profile ${profile}." >&2
-      return 1
-    fi
-    if [[ "${stale_state}" == "1" ]]; then
-      rm -rf "${lock_dir}"
-      continue
-    fi
     attempts=$((attempts + 1))
     if [[ "${attempts}" -eq 1 ]]; then
       echo "Waiting for the active Workcell session on profile ${profile} to release the managed runtime lock." >&2
     fi
     sleep 1
   done
+}
+
+release_profile_lock() {
+  local lock_dir="$1"
+  local holder_pid="$2"
+  local attempts=0
+  local released_state=""
+
+  while true; do
+    if ! released_state="$(go_hostutil helper release-profile-lock "${lock_dir}" "${holder_pid}")"; then
+      return 1
+    fi
+    if [[ "${released_state}" == "1" ]]; then
+      return 0
+    fi
+    attempts=$((attempts + 1))
+    if [[ "${attempts}" -ge 1500 ]]; then
+      return 1
+    fi
+    sleep 0.02
+  done
+}
+
+capture_current_shell_process_pid() {
+  local physical_pid=""
+
+  WORKCELL_CURRENT_SHELL_PID=""
+  if [[ -n "${BASHPID:-}" ]]; then
+    WORKCELL_CURRENT_SHELL_PID="${BASHPID}"
+    return 0
+  fi
+
+  # Bash 3.2 keeps $$ unchanged in a background subshell. The trailing builtin
+  # keeps the command-substitution shell alive while its child reports that
+  # shell's parent, which is this physical shell process.
+  physical_pid="$(
+    /bin/sh -c '/bin/ps -o ppid= -p "$PPID"'
+    :
+  )"
+  physical_pid="${physical_pid//[[:space:]]/}"
+  if [[ ! "${physical_pid}" =~ ^[1-9][0-9]*$ ]]; then
+    return 1
+  fi
+  WORKCELL_CURRENT_SHELL_PID="${physical_pid}"
 }
 
 cleanup_stale_session_audit_dirs() {
@@ -2712,40 +2744,23 @@ append_audit_record() {
   append_audit_record_to_path "${audit_path}" "$@"
 }
 
-# acquire_audit_log_lock serializes audit-log appends. The hash chain reads the
-# current tail's record_digest as the next record's prev_digest, so two
-# concurrent detached-session control paths (start/send/stop) racing the
-# read+append would fork the chain and make the verifier reject a legitimate
-# later record. This reuses the atomic, crash-safe profile-lock primitive
-# (acquire-profile-lock + profile-lock-is-stale: an atomic mkdir-rename lock
-# whose owner PID lets a crashed holder be reclaimed) on a per-log lock dir, so
-# no external flock(1) is required (it is absent on the macOS host). The lock
-# HOLDER computes the record digest via go_hostutil, which routes through
-# `go run` and can take several seconds to compile the child on a cold/busy host;
-# a waiter must reliably outlast that or it would skip a legitimate terminal
-# audit/signing record and break the chain. So it uses a ~30s bounded backoff
-# (1500 x 20ms). Genuine exhaustion at ~30s means a real anomaly (a stuck
-# holder), not normal cold-start latency; there it fails closed (no append)
-# rather than fork the chain.
+# acquire_audit_log_lock serializes the tail read and append. The Go lock helper
+# serializes acquisition, stale reclaim, and release with a persistent advisory
+# guard. This prevents an earlier stale decision from deleting a new holder. The
+# directory lock remains held while Bash renders the record with printf %q. A
+# waiter uses a bounded ~30-second backoff and fails closed on exhaustion.
 acquire_audit_log_lock() {
   local lock_dir="$1"
   local attempts=0
   local acquired_state=""
-  local stale_state=""
-  # Record the ACTUAL holder process so profile_lock_is_stale can reclaim the lock
-  # when that process dies. append_audit_record_to_path and the signer can take
-  # this lock from inside a backgrounded ( ) subshell, where $$ is still the parent
-  # launcher PID, not the worker that does the cleanup rm -rf. BASHPID is the
-  # current process's own PID on bash 4+; the macOS host runs under /bin/bash 3.2
-  # which lacks BASHPID, so fall back to $$ there (${BASHPID:-$$}) — no unbound
-  # error under set -u, and on the host every audit-lock holder is a top-level
-  # process (launch shell, detached-monitor process, session-stop/-control command)
-  # whose $$ IS the real holder, so reclaim still works. This MUST be captured here
-  # in the holder's own context, NOT inside the go_hostutil "$( )" below: BASHPID
-  # inside a command substitution is that transient subshell's PID (already dead by
-  # the stale check). (acquire_profile_lock deliberately keeps $$: its owner is the
-  # top-level launch shell for the whole session.)
-  local holder_pid="${BASHPID:-$$}"
+  # Record the physical holder process so a later caller can reclaim a crashed
+  # worker's lock. Capture it before go_hostutil command substitution. That
+  # substitution has a transient PID which is dead at the next stale check.
+  # acquire_profile_lock keeps $$ because its owner is the top-level launcher.
+  local holder_pid=""
+
+  capture_current_shell_process_pid || return 1
+  holder_pid="${WORKCELL_CURRENT_SHELL_PID}"
 
   mkdir -p "$(dirname "${lock_dir}")"
   while true; do
@@ -2755,16 +2770,21 @@ acquire_audit_log_lock() {
     if [[ "${acquired_state}" == "1" ]]; then
       return 0
     fi
-    if stale_state="$(profile_lock_is_stale "${lock_dir}")" && [[ "${stale_state}" == "1" ]]; then
-      rm -rf "${lock_dir}"
-      continue
-    fi
     attempts=$((attempts + 1))
     if [[ "${attempts}" -ge 1500 ]]; then
       return 1
     fi
     sleep 0.02
   done
+}
+
+release_audit_log_lock() {
+  local lock_dir="$1"
+  local holder_pid=""
+
+  capture_current_shell_process_pid || return 1
+  holder_pid="${WORKCELL_CURRENT_SHELL_PID}"
+  release_profile_lock "${lock_dir}" "${holder_pid}"
 }
 
 append_audit_record_to_path() {
@@ -2802,7 +2822,10 @@ append_audit_record_to_path() {
       printf '\n'
     } >>"${audit_path}"
   ) || rc=$?
-  rm -rf "${lock_dir}" 2>/dev/null || true
+  if ! release_audit_log_lock "${lock_dir}"; then
+    echo "Workcell: warning: could not release audit-log lock for ${audit_path}." >&2
+    [[ "${rc}" -ne 0 ]] || rc=1
+  fi
   return "${rc}"
 }
 
@@ -3358,7 +3381,9 @@ sign_session_audit_head_explicit() {
     "--provider=${target_provider}" 2>/dev/null; then
     echo "Workcell: warning: could not sign session audit head for ${session_id}; session verify will report it unsigned." >&2
   fi
-  rm -rf "${lock_dir}" 2>/dev/null || true
+  if ! release_audit_log_lock "${lock_dir}"; then
+    echo "Workcell: warning: could not release audit-log lock after signing ${session_id}." >&2
+  fi
 }
 
 write_profile_image_marker() {

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -809,7 +809,7 @@ awk '
 # out and skip.)
 RECLAIM_LOG="${TMP_DIR}/reclaim-audit/workcell.audit.log"
 reclaim_output="$(
-  bash -lc '
+  /bin/bash -lc '
     set -euo pipefail
     source "$1"
     trap - EXIT
@@ -874,8 +874,9 @@ slow_holder_output="$(
         if mkdir "$3" 2>/dev/null; then echo 1; else echo 0; fi
         return 0
       fi
-      if [[ "${1:-} ${2:-}" == "helper profile-lock-is-stale" ]]; then
-        echo 0
+      if [[ "${1:-} ${2:-}" == "helper release-profile-lock" ]]; then
+        rm -rf "$3"
+        echo 1
         return 0
       fi
       real_go_hostutil "$@"
@@ -973,8 +974,9 @@ signer_lock_output="$(
         if mkdir "$3" 2>/dev/null; then echo 1; else echo 0; fi
         return 0
       fi
-      if [[ "${1:-} ${2:-}" == "helper profile-lock-is-stale" ]]; then
-        echo 0
+      if [[ "${1:-} ${2:-}" == "helper release-profile-lock" ]]; then
+        rm -rf "$3"
+        echo 1
         return 0
       fi
       real_go_hostutil "$@"
@@ -999,7 +1001,7 @@ signer_lock_output="$(
       sleep 0.05
     done
     # Signer is provably blocked with no seal yet; release so it acquires and signs.
-    rm -rf "${LOCK_DIR}"
+    go_hostutil helper release-profile-lock "${LOCK_DIR}" "$$" >/dev/null
     wait "${signer_pid}"
     printf "blocked=%s\n" "${blocked}"
     printf "seal=%s\n" "$([[ -s "${RECORD_PATH%.json}.audit-sig" ]] && echo 1 || echo 0)"


### PR DESCRIPTION
## Summary

- Serialize audit lock transitions with a persistent advisory guard.
- Use process-generation identities for new lock owners.
- Preserve live legacy lock records during upgrades.
- Record the physical Bash process for background audit writers.
- Route release through owner-checked Go logic.

## Problem

Concurrent stale observers could delete a new successor lock. Two writers could then append concurrently and fork the audit chain.

This change repairs the merged-main validation failure from PR #581.

## Validation

- `go test -race` passed for the launcher lock tests.
- Repeated stale-reclaim and guard-contention tests passed.
- Linux amd64 and Darwin arm64 compile checks passed.
- The session command scenario passed.
- `scripts/verify-invariants.sh` passed in isolation.
- `scripts/dev-quick-check.sh` passed.
- `scripts/validate-repo.sh` passed.
- Exact-head `pr-parity` passed, including container smoke.
- Two adversarial review rounds found no remaining issue.
