### PR TITLE
Rewrite adapter contributor and security records

### DIFF
--- a/docs/extending-adapters.md
+++ b/docs/extending-adapters.md
@@ -1,219 +1,171 @@
-# Extending Adapters: Worked Contributor Examples
+# Extend a Provider Adapter
 
-Two step-by-step examples for the most common adapter-contributor tasks. Each
-step names the file it touches and the security invariant or threat-model item
-it must satisfy, so a change either preserves the boundary or fails a gate.
+Use this page for a new credential type or provider adapter. Read
+[Invariants](invariants.md), [Threat Model](threat-model.md), and the
+[Adapter Porting Workflow](../workflows/adapter-porting.md) first.
 
-Read [invariants.md](invariants.md) and [threat-model.md](threat-model.md)
-first. For the higher-level porting checklist see
-[../workflows/adapter-porting.md](../workflows/adapter-porting.md). For the
-per-adapter reference see [adapter-control-planes.md](adapter-control-planes.md)
-and each adapter's `README.md` under [`../adapters/`](../adapters/README.md).
+The provider registry is data in `internal/adapters/data.go`. A registry change
+is only one part of an adapter change. Runtime dispatch, policy, seed logic,
+validation, and documents must change together.
 
-The per-adapter registry is data, not code: adding a credential type or a
-provider is a table edit in `internal/adapters/data.go` plus the runtime seeding
-and docs, not a new Go package (`internal/adapters/adapters.go`).
+## Add a Credential Type
 
-## Example 1: Add a credential type
+### 1. Register the credential
 
-Goal: add a new provider-native credential key (for an existing adapter) that an
-operator can stage through injection policy. This walkthrough uses a
-hypothetical `gemini_settings` key for the Gemini adapter as a concrete shape;
-substitute your real key and target.
+In `internal/adapters/data.go`:
 
-### Steps (add a credential type)
+1. Add the key to the provider credential list.
+2. Add its mount path under `/opt/workcell/host-inputs/credentials/`.
+3. Add its provider-home destination to the reserved targets.
 
-1. **Register the key and its mount path.** In `internal/adapters/data.go`, add
-   the key to the provider's `credentialKeys` and add a
-   `credentialContainerPaths[key]` entry under
-   `/opt/workcell/host-inputs/credentials/`. Add the in-container destination to
-   that provider's `reservedTargets`.
-   - Invariant [§2 writes stay inside the intended workspace](invariants.md#2-writes-stay-inside-the-intended-workspace):
-     the reserved target makes the destination Workcell-owned so a `[[copies]]`
-     entry cannot clobber it (see the "no writes into Workcell-managed
-     control-plane paths" limit in
-     [injection-policy.md](injection-policy.md#explicit-limits)).
-   - Guardrail: `TestScopedCredentialKeysHaveContainerPaths` and
-     `TestCredentialContainerPathsRootedAtHostInputs` in
-     `internal/adapters/adapters_test.go` fail if the mount path is missing or
-     not rooted at the host-inputs credentials dir.
+The reserved target stops a general copy rule that tries to replace a Workcell
+control file. See [Injection Policy explicit limits](injection-policy.md#explicit-limits).
+Adapter tests must confirm that each key has a credential mount path. They must
+confirm that the path is under the credential input root.
 
-2. **(Optional) Register a host resolver.** Only if the key is resolver-backed,
-   add it to `allowedResolvers` in
-   `internal/authresolve/resolve_credential_sources.go`, and add the matching
-   `resolveCredential` and `ProbeResolverReadiness` cases in
-   `resolve_provider_credentials.go` — the `allowedResolvers` entry only makes
-   policy validation accept the name; without the resolution/probe cases, launch
-   returns `unsupported credential resolver`. Resolvers materialize to
-   ordinary files under the per-launch injection bundle host-side; they never
-   pass Keychain or host-agent access into the runtime.
-   - Invariant [§1 host secrets stay outside the default trust boundary](invariants.md#1-host-secrets-stay-outside-the-default-trust-boundary):
-     resolver-backed auth is host-side preprocessing only
-     ([Provider Bootstrap Matrix](provider-bootstrap-matrix.md#current-matrix)).
+### 2. Add a resolver for a host-owned source
 
-3. **Confirm rendering picks up the key.** Rendering is table-driven off
-   `adapters.CredentialContainerPaths()` in
-   `internal/injection/render_credentials.go`, so a registered key flows without
-   editing the renderer. It validates that direct credential sources live
-   outside the mounted workspace and are owner-only.
-   - Invariant [§1](invariants.md#1-host-secrets-stay-outside-the-default-trust-boundary):
-     a source under the workspace is rejected so the original secret path is not
-     also exposed through the workspace mount
-     ([injection-policy.md](injection-policy.md#security-boundary)).
+For a host resolver, add the name to the resolver allowlist. Then add both the
+resolution and readiness cases. An allowlist value without those cases passes
+the policy parser but stops at launch with an unsupported-resolver error.
 
-4. **Seed the credential into the provider home.** In
-   `runtime/container/home-control-plane.sh`, copy the mounted credential into
-   its provider-home target with
-   `workcell_copy_manifest_credential_file <key> "${HOME}/<target>"` (the Gemini
-   block near the other `gemini_*` seeds is the pattern). Validate the file shape
-   if the provider requires it.
-   - If the credential is optional or mode-filtered, guard the copy so an absent
-     credential does not abort the whole seed path: `home-control-plane.sh` runs
-     under `set -e` and `workcell_copy_manifest_credential_file` returns non-zero
-     when the key has no mount path, so follow the existing seeds' `|| true` or
-     `if ! ...` pattern rather than a bare call.
-   - Invariant [§1](invariants.md#1-host-secrets-stay-outside-the-default-trust-boundary):
-     the credential is copied from a read-only mount into session-local state and
-     the direct mount is not persisted back into the baseline.
+A resolver must create a regular file in the per-launch host bundle. Do not
+pass a keychain, agent, socket, or host credential store into the runtime.
+See the [Provider Bootstrap Matrix](provider-bootstrap-matrix.md#current-matrix)
+for the supported resolver states.
 
-5. **Document the key.** Add a row to the
-   [credential keys](injection-policy.md#credential-keys) table.
-   Add a row to the
-   [Provider Bootstrap Matrix](provider-bootstrap-matrix.md#current-matrix).
-   Update [adapter-control-planes.md](adapter-control-planes.md) if the managed
-   file set changes. Add the key to the adapter's `README.md` auth section.
-   - Also update the operator status surface: `print_injection_status` in
-     `scripts/workcell` prints a hard-coded `supported_credential_keys=...` list
-     when no policy is loaded, so a new key is accepted by the table-driven Go
-     paths but missing from `workcell --auth-status` guidance until that list is
-     updated too.
-   - Threat-model note: an undocumented credential path is exactly the "trust
-     widened without review" case CONTRIBUTING flags — keep the docs in the same
-     change.
+### 3. Check the renderer
 
-6. **Test.** Extend `internal/adapters/adapters_test.go` and the injection render
-   tests, then run `go test ./internal/adapters/... ./internal/injection/...`.
+The credential renderer uses the adapter registry. A registered key does not
+need a new renderer branch. After the renderer creates the bundle, bundle
+preparation must reject a direct source in the mounted workspace. It must also
+require the documented owner-only source mode.
+See the [Injection Policy security boundary](injection-policy.md#security-boundary).
 
-> **The registration spans layers — grep to find them all.** A credential key is
-> also referenced by the host auth-management surfaces: `workcell auth set`
-> staging destinations (`canonicalCredentialDestinations`, declared in
-> `internal/authpolicy/manage.go` and consumed by `staging.go`) and
-> `--auth-status` ordering/summaries
-> (`statusOrder`, `bootstrapSummaryForCredential` in `internal/authpolicy/`),
-> plus the hard-coded `supported_credential_keys` list in `scripts/workcell`.
-> These sites are intentionally spread across the validation, resolution,
-> staging, and status layers, so grep the tree for an existing key (for example
-> `codex_auth`) and mirror every hit — a key that lands only in the registry
-> renders from hand-written TOML but fails `workcell auth set` or reports
-> `provider_auth_mode=none`.
+### 4. Seed the provider home
 
-### Checklist touched (add a credential type)
+In `runtime/container/home-control-plane.sh`, copy the mounted credential to its
+reserved provider-home target. Validate the file shape when the provider has a
+format requirement.
 
-- [§1 host secrets stay outside the boundary](invariants.md#1-host-secrets-stay-outside-the-default-trust-boundary)
-  (steps 2, 3, 4)
-- [§2 writes stay inside the intended workspace](invariants.md#2-writes-stay-inside-the-intended-workspace)
-  (step 1: reserved target ownership)
-- Injection-policy [explicit limits](injection-policy.md#explicit-limits):
-  no arbitrary env-var secret injection, no `[[copies]]` into managed paths
-  (steps 1, 3)
+An optional or mode-filtered key must not stop provider-home creation when it is
+absent. Follow the current guarded copy patterns. Do not add a bare copy call
+that fails under `set -e` for an optional key.
 
-## Example 2: Extend an adapter (or add a new one)
+### 5. Update all host surfaces
 
-Goal: change an adapter's provider-native surface — for instance add a blocked
-unsafe flag, or promote a planned adapter such as `antigravity`.
+Find a current credential key. Use its occurrences to update each applicable
+layer:
 
-### Steps (extend an adapter)
+- Adapter registry and reserved targets.
+- Destinations for staged authentication.
+- Status order and bootstrap summaries.
+- Resolver allowlist, resolution, and readiness.
+- Launcher `supported_credential_keys` output for the no-policy state.
+- Provider-home seed logic for the runtime.
+- [Credential keys](injection-policy.md#credential-keys).
+- [Provider Bootstrap Matrix](provider-bootstrap-matrix.md#current-matrix).
+- [Adapter Control Planes](adapter-control-planes.md) and the adapter README.
 
-1. **Lock the shared boundary first.** Do not add host mounts, sockets, or
-   ambient credential passthrough. Confirm the VM profile, inner container,
-   narrow mount set, and network posture are unchanged
-   ([../workflows/adapter-porting.md](../workflows/adapter-porting.md), step 1).
-   - Invariant [§1](invariants.md#1-host-secrets-stay-outside-the-default-trust-boundary)
-     and [§2](invariants.md#2-writes-stay-inside-the-intended-workspace).
+A partial change can accept hand-written policy but fail `workcell auth set` or
+report the wrong provider authentication mode.
 
-2. **Register the provider (new adapter only).** Add the id to
-   `internal/providerid/providerid.go` and the supported set, and add a row to
-   `providers` in `internal/adapters/data.go` with its credential keys, container
-   paths, and reserved targets. A directory without a registry row stays a
-   fail-closed scaffold (see the `antigravity` README).
-   - Also wire the host launcher and runtime dispatch: `scripts/workcell`
-     validates the agent name against a fixed set (which also backs `--help`,
-     `workcell why`, and `--auth-status`), and `runtime/container/entrypoint.sh`,
-     the Rust core-launcher, and the Dockerfile core-wrapper symlinks map default
-     launches and managed-wrapper routing for the same fixed
-     `codex|claude|copilot|gemini` set. Until all of these accept the id,
-     `workcell --agent <new>` fails before or during runtime prep (rejected as an
-     `Unsupported agent/ui combination`, or not routed through the managed
-     provider wrapper), so the registry edits alone are not enough.
-   - Exec-guard the binary (security): a provider that installs a direct runtime
-     binary must also be added to `PROTECTED_RUNTIME_PATHS`
-     (`runtime/container/rust/src/lib.rs`) and the development-mode blocklist
-     (`development_wrapper_protected_runtime_match` and the provider
-     command-name case in `runtime/container/development-wrapper.sh`). Otherwise
-     `/usr/local/libexec/workcell/real/<new>` can be executed directly, bypassing
-     the managed wrapper and its unsafe-argument rejection.
-   - Guardrail: `internal/providerid/providerid_test.go` asserts a planned
-     provider stays out of the supported set until support lands.
+### 6. Test the change
 
-3. **Add or extend unsafe-argument rejection.** Edit the provider's
-   `reject_unsafe_<name>_args` in `runtime/container/provider-policy.sh` (and wire
-   a new provider into `validate_command_args` and
-   `runtime/container/provider-wrapper.sh`). Block provider-native flags and
-   subcommands that widen trust. The only code-level exemption is
-   `provider_policy_allows_breakglass`, but it is false inside
-   `provider-wrapper.sh` (which always sets `WORKCELL_WRAPPER_CONTEXT=1`), so the
-   wrapper re-check rejects these flags even in a `breakglass` session —
-   `container-smoke.sh` asserts breakglass overrides still fail.
-   - Invariant [§3 repo policy must not silently widen trust](invariants.md#3-repo-policy-must-not-silently-widen-trust)
-     and [§5 destructive or trust-widening actions need defense in depth](invariants.md#5-destructive-or-trust-widening-actions-need-defense-in-depth).
+At minimum, extend adapter and injection tests. Run:
 
-4. **Seed the control plane.** Rebuild the provider home in
-   `runtime/container/home-control-plane.sh` from the immutable baseline under
-   `adapters/<name>/`, explicit injection inputs, and masked workspace imports.
-   Mask any repo-local provider control-plane files the provider reads.
-   - Wire the manifest: `runtime/container/control-plane-manifest.json` (generated
-     from `internal/metadatautil/core.go`) is the inventory of adapter baseline
-     files; `workcell_verify_control_plane_prefix` only checks the entries it
-     already lists, so it will not by itself catch a baseline file you forgot to
-     register. The required gate is `scripts/verify-control-plane-manifest.sh`,
-     which regenerates the manifest and diffs it against the committed file — so
-     add the new baseline files to the manifest source, regenerate, and run that
-     check, or an unlisted baseline file slips through.
-   - Invariant [§3](invariants.md#3-repo-policy-must-not-silently-widen-trust):
-     repo content must not retake the control plane.
+```sh
+go test ./internal/adapters/... ./internal/injection/...
+```
 
-5. **Map autonomy and label lower-assurance paths.** Map
-   `workcell --agent-autonomy` to the provider's native flags in the wrapper and
-   record the mapping in
-   [adapter-control-planes.md](adapter-control-planes.md#autonomy-mapping).
-   Scrub provider telemetry env by default; any opt-in is lower assurance.
-   - Invariant [§4 network posture is explicit](invariants.md#4-network-posture-is-explicit)
-     and [§6 lower-assurance paths are labeled](invariants.md#6-lower-assurance-paths-are-labeled).
+Also run each focused authentication or runtime test for the new key.
 
-6. **Ship validation with the change.** Add or extend deterministic tests
-   (`internal/adapters/adapters_test.go`, provider-policy coverage) and a
-   scenario/smoke path. No adapter change is complete without matching invariant
-   coverage ([../workflows/adapter-porting.md](../workflows/adapter-porting.md),
-   step 6).
-   - Promotion gate: before `provider-matrix.md` claims a supported Tier 1, run
-     the live provider certification (`provider-e2e`) — deterministic tests and a
-     smoke path are necessary but not sufficient. A supported-tier claim without
-     that live-certification evidence is exactly what the release gate forbids.
+## Add or Extend a Provider
 
-7. **Update the docs in the same change.** Update
-   [provider-matrix.md](provider-matrix.md),
-   [adapter-control-planes.md](adapter-control-planes.md), and the adapter's
-   `README.md`.
+### 1. Preserve the shared boundary
 
-### Checklist touched (extend an adapter)
+Do not add an ambient host credential, broad mount, or host socket. Keep the
+selected target, container controls, managed provider home, and explicit
+network posture.
 
-- [§1](invariants.md#1-host-secrets-stay-outside-the-default-trust-boundary),
-  [§2](invariants.md#2-writes-stay-inside-the-intended-workspace) (step 1: no new
-  host exposure)
-- [§3 no silent trust widening](invariants.md#3-repo-policy-must-not-silently-widen-trust)
-  (steps 3, 4)
-- [§4 explicit network posture](invariants.md#4-network-posture-is-explicit) and
-  [§6 labeled lower-assurance paths](invariants.md#6-lower-assurance-paths-are-labeled)
-  (step 5)
-- [§5 defense in depth](invariants.md#5-destructive-or-trust-widening-actions-need-defense-in-depth)
-  (step 3: wrapper-side rejection is defense in depth, not the boundary)
+### 2. Register a new provider
+
+For a new provider:
+
+1. Define the identifier in `internal/providerid`. A planned identifier can stay
+   outside `AllProviders` and fail closed during implementation.
+2. Add the identifier to `CredentialMetadataProviders` when the adapter registry
+   supplies its credential metadata. A planned provider can stay outside
+   `AllProviders` during this step.
+3. Add the adapter registry row with credential keys, paths, and reserved
+   targets.
+4. Add launcher validation and help output.
+5. Add runtime entry-point and wrapper dispatch.
+6. Add the provider binary to each applicable exec-guard and protected-runtime
+   list for development mode.
+7. Add the provider binary and wrapper links to the runtime image.
+8. Add the provider allowlist, credential setup, and probe cases to
+   `scripts/provider-e2e.sh`.
+9. Add the identifier to `AllProviders` so that validation can select it.
+10. Run the deterministic tests for the final supported-provider set.
+11. Complete live provider certification before you sign the support-claim
+   commit.
+
+A directory and registry row do not make a provider supported. Until each
+dispatch and protection layer accepts the identifier, the provider must fail
+closed.
+
+### 3. Reject unsafe provider options
+
+Add or extend the provider checks in
+`runtime/container/provider-policy.sh`. Reject flags and subcommands that can
+change instructions, tools, MCP configuration, or permissions. Also reject
+options that change sandbox posture or remote control outside Workcell policy.
+
+Wire a new provider into both argument validation and the provider wrapper. The
+wrapper checks the arguments again. Current provider wrappers do not accept an
+unsafe-argument exception in a `breakglass` session.
+
+### 4. Build the managed control plane
+
+In non-breakglass modes, build the provider home from these sources:
+
+- The immutable adapter baseline.
+- Explicit staged inputs.
+- Imported workspace instructions that the provider supports.
+
+On the default safe path, mask each mutable repository control path that the
+provider can read. Require explicit acknowledgement and label every supported
+exception lower assurance. The operator must give that acknowledgement for each
+supported exception. Add each baseline file to the source for the control-plane
+manifest. Regenerate the manifest. Run
+`scripts/verify-control-plane-manifest.sh`. A runtime prefix check examines only
+files that the manifest already lists.
+
+### 5. Map autonomy and network needs
+
+Map `--agent-autonomy` to the provider's native surface. Add only fixed endpoint
+literals that the supported provider path needs. Scrub environment values for
+provider telemetry by default. Label each permitted lower-assurance option.
+
+### 6. Add evidence before a support claim
+
+Add deterministic adapter, policy, invariant, scenario, and smoke tests. Before
+you sign a commit with a new Tier 1 support claim, complete the live
+`provider-e2e` certification for that provider.
+
+Repository tests do not replace a live provider certification. Keep the
+provider unsupported until the implementation, evidence, support matrix, and
+operator documents have the same claim.
+
+### 7. Update the contract
+
+Update these sources in the same change:
+
+- [Provider Matrix](provider-matrix.md).
+- [Adapter Control Planes](adapter-control-planes.md).
+- The adapter README.
+- Injection policy and bootstrap status when authentication changes.
+- Operator contract and requirements when the public workflow changes.
+
+Complete the Codex review loop before merge.

--- a/docs/requirements-validation.md
+++ b/docs/requirements-validation.md
@@ -1,99 +1,72 @@
-# Requirements Validation
+# Requirements and Validation
 
-Workcell now keeps:
+Workcell keeps two machine-readable contract files:
 
-- a normative operator workflow contract in
-  [`policy/operator-contract.toml`](../policy/operator-contract.toml)
-- a requirement-to-doc-and-evidence mapping in
-  [`policy/requirements.toml`](../policy/requirements.toml)
+- [`policy/operator-contract.toml`](../policy/operator-contract.toml) defines
+  supported public workflows.
+- [`policy/requirements.toml`](../policy/requirements.toml) maps requirements to
+  documents and automated evidence.
 
-## Purpose
+## Operator Contract
 
 The operator contract defines:
 
-- which public workflows are supported
-- their canonical syntax and compatibility aliases
-- where those workflows must be discoverable
-- which docs and automated evidence currently back each public workflow
+- A stable identifier for each public workflow.
+- Canonical syntax and compatibility aliases.
+- Help, README, manpage, and document locations.
+- Automated evidence for the workflow.
+- Required remediation text and alias probes when applicable.
 
-The requirements matrix does three things:
+It is the command inventory source. The requirements matrix is not a command
+inventory.
 
-- names the current functional and nonfunctional requirements that the repo is
-  claiming as implemented
-- links functional requirements to stable workflow ids from the operator
-  contract
-- points each requirement at concrete automated evidence and supporting
-  documentation
+## Requirements Matrix
 
-This is meant to reduce drift between:
+The requirements matrix:
 
-- what the docs say Workcell does
-- what the tests and validation scripts actually prove
-- what maintainers treat as the supported contract
+- Lists current functional and nonfunctional requirements.
+- Links functional requirements to operator workflow identifiers.
+- Links each requirement to current evidence and documents.
 
-## Validation Rule
+Do not add planned behavior as an implemented requirement.
 
-`./scripts/verify-requirements-coverage.sh` validates that:
+## Validators
 
-- the matrix is syntactically valid
-- functional and nonfunctional requirement sections are both present
-- requirement ids and titles are unique
-- every requirement cites at least one automated evidence file
-- every evidence and documentation path is repo-relative and exists in the repo
-- every release-facing Markdown example and the current release-evaluation docs
-  (`docs/provider-matrix.md`, `docs/validation-scenarios.md`, and
-  `docs/enterprise-rollout.md` when present) appear in at least one requirement
-  `docs` array
+`./scripts/verify-requirements-coverage.sh` checks these conditions:
 
-`./scripts/verify-operator-contract.sh` validates that:
+- TOML syntax is valid.
+- Functional and nonfunctional sections exist.
+- Requirement identifiers and titles are unique.
+- Each requirement has at least one automated evidence file.
+- Each evidence and document path is repository-relative and exists.
+- Release examples occur in a requirement document list. The list also
+  includes `docs/provider-matrix.md`, `docs/validation-scenarios.md`, and
+  `docs/enterprise-rollout.md` when those files exist.
 
-- every public workflow in `policy/operator-contract.toml` is mapped to at
-  least one requirement
-- every requirement workflow reference resolves to a declared workflow id
-- every workflow-cited doc and evidence path exists and is also cited by the
-  referenced requirements
-- required help, README, and manpage surfaces contain the contract-declared
-  workflow syntax
-- compatibility aliases still pass their contract-declared alias probes
-- contract-declared remediation copy still exists in the launcher source
+`./scripts/verify-operator-contract.sh` checks these conditions:
 
-Both checks run through the normal validation entrypoints, including
-`./scripts/dev-quick-check.sh` and `./scripts/validate-repo.sh`.
+- Each public workflow maps to at least one requirement.
+- Each requirement workflow reference exists.
+- Workflow evidence and documents also occur in the linked requirements.
+- Each declared discovery surface contains the canonical syntax.
+- Compatibility aliases pass their declared probes.
+- Required remediation text remains in the launcher.
 
-## Scope
+Both validators run in the quick and full repository validation paths.
 
-The requirements matrix is intentionally not the command-inventory source of
-truth. It is about traceability for the supported repo contract, not every
-possible implementation detail.
-
-It should cover:
-
-- the main managed launch path
-- host-side operator commands
-- supported install and uninstall surfaces
-- auth and injection behavior
-- assurance and audit behavior
-- release and reproducibility guarantees
-- newly added product capabilities such as session inventory
-
-It should not be used to smuggle in speculative roadmap items that are not yet
-implemented.
-
-## Maintenance Rules
+## Maintenance Rule
 
 When a supported requirement changes:
 
-1. update `policy/operator-contract.toml` when the public workflow surface,
-   canonical syntax, discoverability, compatibility status, docs, or evidence
-   changes
-2. update `policy/requirements.toml`
-3. update or add the automated evidence
-4. update the docs that explain the requirement
-5. rerun both validators
+1. Update the operator contract if the public workflow, syntax, alias,
+   discovery surface, document, or evidence changes.
+2. Update the requirements matrix.
+3. Add or update automated evidence.
+4. Update the explanatory documents.
+5. Run both validators.
 
-If a requirement cannot point to real automated evidence, it is not ready to be
-claimed as part of the canonical supported contract.
+If a requirement has no automated evidence, do not claim it as part of the
+canonical supported contract.
 
-When adding a new Markdown file under `docs/examples/`, update
-`policy/requirements.toml` in the same change so the release-facing example
-docs remain machine-checked.
+When you add a Markdown file under `docs/examples/`, add it to an applicable
+requirement in the same change.

--- a/docs/security/security-findings-2026-04-24-mutation-results.md
+++ b/docs/security/security-findings-2026-04-24-mutation-results.md
@@ -1,16 +1,14 @@
-# Security Findings Mutation Results - 2026-04-24
+# Mutation Results for Security Findings, 2026-04-24
 
-Scope: sink-level mutations for the four validated security findings. This is not repo-wide mutation coverage.
-
-## Results
+This test covered one sink mutation for each validated finding. It was not a
+repository-wide mutation test.
 
 | Mutant | Finding | Command | Result |
-| --- | --- | --- | --- |
-| Disable YAML AST job-permissions rejection | F2 | `go test ./internal/metadatautil -run TestSafePullRequestTargetWorkflowRejectsInlineJobLevelPermissions -count=1` | killed |
-| Reintroduce `WORKCELL_TEST_CODEX_AUTH_FILE` override in Codex resolver | F3 | `go test ./internal/authresolve -run TestRunCodexHomeResolverIgnoresLegacyTestOverrideEnv -count=1` | killed |
-| Disable path-separator rejection in `statePathSegment` | F4 | `go test ./internal/remotevm -run TestFakeTargetRejectsPathTraversal -count=1` | killed |
-| Restore pre-hardened `repo-publish-pr.sh` entrypoint | F1 | `bash ./tests/scenarios/shared/test-publish-pr-dry-run.sh` | killed |
+|---|---|---|---|
+| Disable the YAML AST check for job permissions | F2 | `go test ./internal/metadatautil -run TestSafePullRequestTargetWorkflowRejectsInlineJobLevelPermissions -count=1` | Killed |
+| Restore the legacy Codex resolver environment override | F3 | `go test ./internal/authresolve -run TestRunCodexHomeResolverIgnoresLegacyTestOverrideEnv -count=1` | Killed |
+| Disable the path-separator check in `statePathSegment` | F4 | `go test ./internal/remotevm -run TestFakeTargetRejectsPathTraversal -count=1` | Killed |
+| Restore the publication wrapper before hardening | F1 | `bash ./tests/scenarios/shared/test-publish-pr-dry-run.sh` | Killed |
 
-Mutation score: 4 / 4 targeted mutants killed.
-
-The full repository validation also ran the existing Workcell mutation suite through `bash ./scripts/validate-repo.sh`; it completed successfully as part of the final validation gate.
+The targeted mutation result was 4 of 4 killed mutants. Full repository
+validation also ran the current Workcell mutation suite and passed.

--- a/docs/security/security-findings-2026-04-24-mutation-results.md
+++ b/docs/security/security-findings-2026-04-24-mutation-results.md
@@ -11,4 +11,4 @@ repository-wide mutation test.
 | Restore the publication wrapper before hardening | F1 | `bash ./tests/scenarios/shared/test-publish-pr-dry-run.sh` | Killed |
 
 The targeted mutation result was 4 of 4 killed mutants. Full repository
-validation also ran the current Workcell mutation suite and passed.
+validation also ran the then-current Workcell mutation suite and passed.

--- a/docs/security/security-findings-2026-04-24-poc-matrix.md
+++ b/docs/security/security-findings-2026-04-24-poc-matrix.md
@@ -1,15 +1,15 @@
-# Security Findings PoC Matrix - 2026-04-24
+# PoC Matrix for Security Findings, 2026-04-24
 
-| PoC or regression | Type | Findings | Positive control | Negative control |
-| --- | --- | --- | --- | --- |
-| `test-publish-pr-dry-run.sh` poisoned PATH wrapper check | Runtime regression | F1 | Fake `bash`, `dirname`, `git`, and `jq` are first in `PATH`. | Wrapper still produces the expected dry-run plan and the poison marker is not created. |
-| `TestSafePullRequestTargetWorkflowRejectsInlineJobLevelPermissions` | Unit regression | F2 | Inline `permissions: { contents: write }` under a job. | Existing trusted metadata-only workflow remains accepted. |
-| `TestSafePullRequestTargetWorkflowRejectsInlineReusableWorkflowCalls` | Unit regression | F2 | Inline job-level `uses`. | Existing block-style rejection tests and accepted workflow still pass. |
-| `TestSafePullRequestTargetWorkflowRejectsInlineStepUses` | Unit regression | F2 | Inline step-level external action. | Existing allowed `run`-only workflow still passes. |
-| `TestSafePullRequestTargetWorkflowRejectsInlineCheckout` | Unit regression | F2 | Inline `actions/checkout` step. | Existing checkout rejection remains specific. |
-| `TestRunCodexHomeResolverIgnoresLegacyTestOverrideEnv` | Unit regression | F3 | Legacy `WORKCELL_TEST_CODEX_AUTH_FILE` points at a readable secret. | Empty synthetic `HOME` produces `configured-only` placeholder, not attacker file materialization. |
-| `TestWorkcellRejectsHarnessOnlyCredentialResolverEnvBeforeBundlePreparation` | Static boundary regression | F3 | Caller-controlled harness-only resolver env appears in launcher source. | Internal self-staging probe may still synthesize resolver inputs without forwarding caller env. |
-| `test-codex-resolver-launcher.sh` self-staging probe | Runtime regression | F3 | Launcher proves Codex resolver staging with an internal synthetic `HOME`. | No external `WORKCELL_TEST_CODEX_AUTH_FILE` is required or forwarded. |
-| `TestFakeTargetRejectsPathTraversalIdentifiers` | Unit regression | F4 | Target and materialization IDs contain `../`. | Valid fake target materialization tests still pass. |
-| `TestFakeTargetRejectsPathTraversalProvider` | Unit regression | F4 | Contract provider contains `../`. | Provider-specific AWS state-root test still passes. |
-| `TestFakeTargetRejectsPathTraversalSessionID` | Unit regression | F4 | Session ID contains `../`. | Valid materialize/bootstrap setup still succeeds before rejected session start. |
+| Test | Type | Finding | Positive control | Negative control |
+|---|---|---|---|---|
+| `test-publish-pr-dry-run.sh` poisoned-path check | Runtime | F1 | Fake Bash, dirname, Git, and jq tools occur first in `PATH`. | The dry-run plan is correct, and no poison marker exists. |
+| `TestSafePullRequestTargetWorkflowRejectsInlineJobLevelPermissions` | Unit | F2 | A job has inline write permissions. | Trusted metadata-only workflow remains valid. |
+| `TestSafePullRequestTargetWorkflowRejectsInlineReusableWorkflowCalls` | Unit | F2 | A job has inline reusable-workflow `uses`. | Block-form checks and the valid workflow pass. |
+| `TestSafePullRequestTargetWorkflowRejectsInlineStepUses` | Unit | F2 | A step has inline external-action `uses`. | A run-only workflow passes. |
+| `TestSafePullRequestTargetWorkflowRejectsInlineCheckout` | Unit | F2 | A step has inline checkout. | The specific checkout rejection and valid workflow pass. |
+| `TestRunCodexHomeResolverIgnoresLegacyTestOverrideEnv` | Unit | F3 | The legacy variable points to a readable secret. | An empty synthetic home produces a placeholder, not the attacker file. |
+| `TestWorkcellRejectsHarnessOnlyCredentialResolverEnvBeforeBundlePreparation` | Static | F3 | A caller-controlled harness value occurs in launcher source. | An internal probe can create its own synthetic input. |
+| `test-codex-resolver-launcher.sh` | Runtime | F3 | The launcher stages Codex auth from an internal synthetic home. | It does not need or forward the legacy variable. |
+| `TestFakeTargetRejectsPathTraversalIdentifiers` | Unit | F4 | Target and materialization identifiers contain `../`. | Valid materialization tests pass. |
+| `TestFakeTargetRejectsPathTraversalProvider` | Unit | F4 | The provider contains `../`. | Valid AWS state-root tests pass. |
+| `TestFakeTargetRejectsPathTraversalSessionID` | Unit | F4 | The session identifier contains `../`. | Valid setup completes before the invalid session start stops. |

--- a/docs/security/security-findings-2026-04-24-validation.md
+++ b/docs/security/security-findings-2026-04-24-validation.md
@@ -1,88 +1,75 @@
-# Security Findings Validation - 2026-04-24
+# Security Finding Validation, 2026-04-24
 
 Repository: `omkhar/workcell`
+
 Validation branch: `codex/security-findings-remediation`
+
 Baseline commit: `e0268f7711ad3cb61102eb313c2f5b3715188a39`
-Patch state: main-based signed PR patch.
-Scope: four Codex scanner findings from the 2026-04-24 CSV export, validated against the PR #157 head.
 
-## Summary
+Scope: Four Codex scanner findings from the 2026-04-24 CSV export, validated
+against the PR 157 head.
 
-All four reported findings were genuine in the validated branch. The fixes are prepared as a separate security follow-up after PR #157 and should not be merged until #157 is on `main`.
+## Result
+
+All four findings were genuine. The [signed remediation commit](https://github.com/omkhar/workcell/commit/860e21f6dae310aafb14956c33fdc462faa5ee72) later merged to `main`.
 
 | ID | Component | Original severity | Result | Retriaged severity |
-| --- | --- | --- | --- | --- |
-| F1 | `scripts/repo-publish-pr.sh` | high | fixed | high |
-| F2 | `internal/metadatautil/validate.go` | medium | fixed | medium |
-| F3 | `internal/authresolve`, `scripts/workcell` | medium | fixed | high |
-| F4 | `internal/remotevm/fake_target.go` | informational | fixed | low |
+|---|---|---|---|---|
+| F1 | `scripts/repo-publish-pr.sh` | High | Fixed | High |
+| F2 | `internal/metadatautil/validate.go` | Medium | Fixed | Medium |
+| F3 | `internal/authresolve`, `scripts/workcell` | Medium | Fixed | High |
+| F4 | `internal/remotevm/fake_target.go` | Informational | Fixed | Low |
 
-## Findings
+## F1: Publication Tool Resolution
 
-### F1: Publication wrapper trusted tool resolution
+The publication wrapper used Git and jq from a caller-controlled path before it
+checked `pr-parity` evidence. This was a host code-execution and publication
+integrity risk.
 
-Original claim: the repo-local publication wrapper ran `git` and `jq` through caller-controlled `PATH` before enforcing PR-parity evidence.
+The fix gave the wrapper a sanitized trusted entry point and trusted absolute
+Git and jq paths. The regression test puts fake Bash, dirname, Git, and jq tools
+first in `PATH`. The wrapper creates the correct dry-run plan, and no fake tool
+runs.
 
-Verification result: genuine. The wrapper is host-side publication control-plane code, so hostile interpreter/tool resolution before parity enforcement is a host code execution and publication-integrity risk.
+## F2: `pull_request_target` YAML Bypass
 
-Fix: `scripts/repo-publish-pr.sh` now enters through the sanitized trusted entrypoint and resolves trusted absolute `git` and `jq` paths before parity checks.
+Line-pattern checks accepted inline YAML that hid job permissions, reusable
+workflow calls, or external actions.
 
-Evidence: `tests/scenarios/shared/test-publish-pr-dry-run.sh` includes a poisoned `PATH` with fake `bash`, `dirname`, `git`, and `jq`; the wrapper still publishes a dry-run plan and none of the fake tools execute.
+The fix parses the YAML AST. It rejects non-empty top-level permissions,
+job-level permissions, reusable workflow calls, action steps, and checkout in
+block or flow form. Unit tests cover each inline form.
 
-### F2: `pull_request_target` YAML parser bypass
+## F3: Codex Resolver Test Variable
 
-Original claim: line-oriented regex checks accepted inline YAML mappings that could hide job permissions, reusable workflows, or external action use.
+The launcher forwarded `WORKCELL_TEST_CODEX_AUTH_FILE`. The resolver could use
+that value instead of the fixed `~/.codex/auth.json` path. A caller could direct
+the resolver to another readable file.
 
-Verification result: genuine. Flow-style YAML bypassed the line regex shape while preserving the same workflow semantics.
+The fix removed the resolver support for that variable. The launcher rejects
+inherited harness-only resolver values before bundle preparation. Tests use a
+synthetic home or an internal probe that stages data.
 
-Fix: `isSafePullRequestTargetWorkflow` now parses the workflow YAML AST and rejects non-empty top-level permissions, job-level permissions, reusable workflow `uses`, step `uses`, and checkout regardless of block or flow style.
+Regression tests prove that the resolver ignores the legacy value, the launcher
+rejects it, and neither component forwards it.
 
-Evidence: `internal/metadatautil/workflow_validation_test.go` covers inline job permissions, inline job `uses`, inline step `uses`, and inline checkout.
+## F4: Fake Remote Target Path Traversal
 
-### F3: Codex resolver harness env disclosure
+The fake remote target joined target and session identifiers to state paths
+without a complete segment check. Public AWS target identifiers had a separate
+check, but the reusable fake target did not.
 
-Original claim: `WORKCELL_TEST_CODEX_AUTH_FILE` could redirect the Codex host-auth resolver to an arbitrary operator-readable file.
-
-Verification result: genuine. The launcher forwarded the test env var into resolver execution, and the resolver honored it as a replacement for the fixed `~/.codex/auth.json` contract.
-
-Fix: the resolver no longer recognizes `WORKCELL_TEST_CODEX_AUTH_FILE`; `scripts/workcell` rejects harness-only resolver env vars before bundle preparation and no longer forwards caller-controlled test resolver env. Tests use synthetic `HOME` fixtures or self-staging probe internals instead.
-
-Evidence: `internal/authresolve` includes a regression test proving the legacy env var is ignored. `internal/testkit` statically checks that the launcher rejects harness-only resolver env before bundle preparation and does not forward caller-controlled values.
-
-### F4: Fake remote VM path traversal
-
-Original claim: fake remote VM target IDs were joined directly into filesystem paths used by materialization removal and session record writes.
-
-Verification result: genuine, currently low severity. Public AWS CLI target IDs are separately constrained, but the internal fake target and conformance harness must be safe before reuse by later remote VM provider code.
-
-Fix: `FakeTarget` validates target provider, target ID, materialization ID, and session ID as single path segments before any state-root path join.
-
-Evidence: `internal/remotevm/fake_target_test.go` rejects traversal in target, provider, materialization, and session identifiers.
-
-## Review Lenses
-
-Applied review lenses: security exploitability, SWE fixability/regression risk, and engineering-management sequencing/scope. The review outcome is that all four findings are genuine and should be remediated. This patch is based on the merged Phase 7 mainline after PR #157. If reviewers want smaller review units, split by commit into publication/workflow hardening, credential resolver boundary, and remote VM confinement.
+The fix validates provider, target, materialization, and session identifiers as
+single path segments before a state-root join. Unit tests reject traversal in
+each identifier class.
 
 ## Validation
 
-Focused validation:
+The remediation passed focused authentication, metadata, remote-target, and
+test-kit Go tests. It also passed resolver, publication, manifest, operator
+contract, requirements, dead-code, repository-hygiene, and full repository
+validation.
 
-```sh
-go test ./internal/authresolve ./internal/authpolicy ./internal/metadatautil ./internal/remotevm ./internal/testkit
-bash ./tests/scenarios/shared/test-codex-resolver-launcher.sh
-bash ./tests/scenarios/shared/test-publish-pr-dry-run.sh
-bash ./scripts/verify-control-plane-manifest.sh
-```
-
-Contract and repo validation:
-
-```sh
-bash ./scripts/verify-operator-contract.sh
-bash ./scripts/verify-requirements-coverage.sh
-bash ./scripts/check-dead-code.sh
-bash ./scripts/check-public-repo-hygiene.sh
-/usr/bin/env -u GIT_PAGER ./scripts/validate-repo.sh
-./scripts/workcell --gc
-```
-
-Result: all commands passed on the patched worktree.
+See the [PoC matrix](security-findings-2026-04-24-poc-matrix.md) and
+[mutation results](security-findings-2026-04-24-mutation-results.md) for the
+replayable evidence.


### PR DESCRIPTION
## Summary

- Rewrite adapter contributor guidance around the existing shared runtime boundary.
- Clarify declared discovery-surface validation and credential lifecycle requirements.
- Condense the April 24 security evidence records without changing their historical conclusions.

## Security and support

- Preserve non-breakglass masking and explicit breakglass acknowledgements.
- Preserve provider certification requirements and lower-assurance labels.
- Do not add a provider, backend, support tier, or runtime behavior.

## Validation

- `./scripts/check-doc-links.sh`
- `./scripts/verify-operator-contract.sh`
- `./scripts/verify-requirements-coverage.sh`
- `./scripts/verify-control-plane-manifest.sh`
- `./scripts/ci/job-docs.sh`
- `/usr/bin/env -u GIT_PAGER ./scripts/dev-quick-check.sh`
- `/usr/bin/env -u GIT_PAGER ./scripts/validate-repo.sh`
- `/usr/bin/env -u GIT_PAGER ./scripts/pre-merge.sh --profile pr-parity`

Two adversarial review passes found no remaining actionable issue.
