### PR TITLE
Rewrite CI and enterprise evidence guidance

### DIFF
--- a/docs/ci-efficiency-and-reliability.md
+++ b/docs/ci-efficiency-and-reliability.md
@@ -1,149 +1,92 @@
 # CI Efficiency and Reliability
 
-This documents the B8 program: reducing pull-request CI wall-clock without
-weakening release-time assurance, plus the reliability and visibility tooling
-that keeps CI health observable. It complements
-[github-workflows.md](github-workflows.md), which is the authoritative workflow
-inventory.
+This page records the shipped B8 changes. Use
+[GitHub Workflows](github-workflows.md) for the current workflow inventory.
 
-The prime directive throughout: **no release-gating assurance is lost.** Every
-*deterministic* check moved off the PR-blocking path still runs before release
-(on the post-merge `main` push and/or re-verified in `release.yml` preflight);
-each change below names that mechanism. The one exception is **active fuzzing**,
-which is a nondeterministic discovery hunt, not a release gate — its release-time
-assurance is the deterministic seed-corpus regression (still run on every PR and
-at preflight via `go test`), while the extended active budget runs on the
-scheduled `fuzz.yml` lane and is intentionally *not* a `release.yml` dependency.
+## Assurance Rule
 
-## PR wall-clock reductions
+A change to pull-request CI must preserve each deterministic release gate.
+Scheduled fuzzing is a discovery activity. It is not a release gate. The seed
+corpus is deterministic and stays in `go test ./...`.
 
-### Active fuzzing moved off the PR-blocking validate lane
+## Pull Request Changes
 
-The `Validate repository` lane in [`ci.yml`](../.github/workflows/ci.yml) used
-to spend a nondeterministic active-fuzzing time budget on every PR (and every
-release preflight) via `scripts/validate-repo.sh`. Active fuzzing is a
-time-bounded *discovery hunt*, not a deterministic gate: it hit a spurious
-per-input timeout (0 execs/sec at ~16s, no reproducer) that failed a PR while
-`main` stayed green, forcing a full validate-lane re-run.
+### Active fuzzing
 
-What changed:
+The pull-request validation path runs the deterministic fuzz seed corpus through
+`go test ./...`. It does not run a time-bounded active fuzz campaign.
 
-- The deterministic fuzz **seed corpora still run on every PR** via
-  `go test ./...`. That is the release-relevant regression assurance and it is
-  unchanged.
-- The extended **active-fuzzing budget runs only on the scheduled fuzz lane**
-  ([`fuzz.yml`](../.github/workflows/fuzz.yml) →
-  `scripts/ci/job-fuzz.sh` → `scripts/ci/run-fuzz-in-validator.sh`), which
-  mutates the same seeds for a longer budget on a weekly cadence and on
-  `workflow_dispatch`.
+The scheduled `fuzz.yml` workflow runs the active Go and Rust fuzz targets. An
+operator can also start this workflow with `workflow_dispatch`. This design
+removes a nondeterministic time budget from the pull-request critical path and
+keeps the seed regression gate.
 
-Coverage preservation: the scheduled Go fuzz lane exercises `FuzzParse`
-(`internal/tomlsubset`), `FuzzParseSSHDirective` and
-`FuzzIsAllowedSystemSymlink` (`internal/injection`), and the
-`internal/metadatautil` parser targets. The PR path previously fuzzed
-`FuzzParse` and `FuzzParseSSHDirective` (both covered by the scheduled lane) plus
-a stale reference to `FuzzIsSafeRelativeSymlinkTarget`, a target that no longer
-exists and silently no-op'd. So **no active-fuzz coverage is lost** at
-nightly/release by this move; the seed-corpus regression that does gate release
-still runs everywhere `go test` runs.
+Use [Fuzzing](fuzzing.md) for the current target list and artifact behavior.
 
-### Heavy reproducible-build rebuilds gated behind `approved-heavy-ci`
+### Reproducible builds
 
-`ci.yml`'s `reproducible-build-platform` matrix runs two ~45-minute no-cache
-double-builds (amd64 + native arm64). It was the only heavy `ci.yml` lane not
-behind the `approved-heavy-ci` label gate that install verification, CodeQL, and
-mutation already use, so an unreviewed fork PR could trigger that compute on
-demand.
+The native amd64 and arm64 reproducible-build matrix is a heavy lane. A pull
+request needs the `approved-heavy-ci` label to start this matrix. The aggregate
+required check accepts the documented skip result for an unlabeled pull
+request.
 
-What changed: the fork-PR trigger is now gated behind `approved-heavy-ci`
-(identical `if:` to install verification). On an unlabeled PR the per-platform
-matrix is skipped and the aggregate `Reproducible build` required context passes
-on the `skipped` result; on a push to `main`, a labeled PR, or dispatch it fails
-unless the matrix succeeds.
+The matrix runs for each push to `main`. The release workflow also runs native
+reproducibility preflight jobs and compares the release image with the verified
+digests. Thus, an unlabeled fork pull request does not remove the release gate.
 
-Release-time assurance preservation — reproducibility is re-verified **twice**
-independently of the unlabeled-PR path:
+## Network Retry Policy
 
-| Mechanism | Where | Enforces |
-|---|---|---|
-| Post-merge `main` push | `ci.yml` `reproducible-build-platform` (runs on every push to `main`) | Every merged commit's runtime image is reproducibility-verified |
-| Release preflight | `release.yml` `preflight-amd64-repro` / `preflight-arm64-repro` (native, no QEMU) | Publish byte-compares the released image against these verified per-platform digests; a mismatch fails the release |
+[`scripts/retry.sh`](../scripts/retry.sh) supplies a bounded retry for
+idempotent fetch operations. The default is three attempts. The default initial
+delay is five seconds, and the delay doubles after each failure.
 
-Additionally, `release.yml`'s preflight gates on the tagged commit's `main`
-check-runs being green (the "Require main checks green for tagged commit" step),
-so the post-merge reproducibility run is enforced at release time as well.
+Workflows use retries for operations such as a toolchain install or a verified
+tool download. Checksum verification still follows the downloaded tools that
+use recorded checksums.
 
-## Retry policy for transient network steps
+Do not add retries to deterministic tests, linters, or locked dependency
+checks. A retry can hide a repeatable defect and add delay.
 
-Transient registry/network failures were failing otherwise-green lanes.
-[`scripts/retry.sh`](../scripts/retry.sh) is a bounded-retry wrapper
-(`WORKCELL_RETRY_ATTEMPTS`, default 3; doubling `WORKCELL_RETRY_DELAY` backoff,
-default 5s) applied to idempotent fetches:
+## Flaky Test Record
 
-- `fuzz.yml`: rustup nightly toolchain install and `cargo install cargo-fuzz`.
-- `security.yml` / `release.yml`: `curl --retry`/`--retry-connrefused` on the
-  actionlint and zizmor downloads. Checksum verification still runs after the
-  download, so retry only adds robustness and cannot weaken integrity.
+Use the `flaky-test` issue label for a confirmed nondeterministic failure. The
+issue must name the test or lane. The issue must include the observed behavior.
 
-Deterministic steps (linters, tests, `--locked` lock checks) are deliberately
-**not** wrapped: retrying them wastes CI time and hides nothing.
+The `ci-insights.yml` workflow creates a weekly flaky-test report. It combines:
 
-## Flaky-test tracking
+1. Open issues with the `flaky-test` label.
+2. Workflow runs in the selected period that failed or had more than one run
+   attempt.
 
-Convention: when a test or lane fails nondeterministically, open a GitHub issue
-labeled **`flaky-test`** describing the target and the observed nondeterminism.
-That label is the human-curated tracked list.
+The second signal supplies candidates. It does not prove that a failure is
+flaky. [`scripts/ci/flaky-report.sh`](../scripts/ci/flaky-report.sh) creates the
+read-only job summary.
 
-The [`ci-insights.yml`](../.github/workflows/ci-insights.yml) `Flaky-test report`
-job runs weekly (and on demand) and writes a Markdown report to its run's **job
-summary** combining two signals:
+## CI Cost Report
 
-1. Open `flaky-test`-labeled issues (the tracked list).
-2. Workflow runs in the lookback window (default 7 days,
-   `WORKCELL_CI_INSIGHTS_DAYS`) that needed a re-run (`run_attempt > 1`) or
-   concluded in failure — an empirical flake signal from CI history.
+The same workflow creates a weekly cost report. The report shows run count,
+total wall-clock time, and average wall-clock time for each workflow. Queue time
+is part of wall-clock time. [`scripts/ci/cost-report.sh`](../scripts/ci/cost-report.sh)
+creates the read-only job summary.
 
-The report is generated by [`scripts/ci/flaky-report.sh`](../scripts/ci/flaky-report.sh)
-and is read-only (`actions:read` + issues read). Re-runs and failures are
-*candidates*, not confirmed flakes; triage them and, if nondeterministic, file a
-`flaky-test` issue so they persist in signal 1 until fixed.
+## Recorded Timing Estimate
 
-## CI cost visibility
+The 2026-07-05 B8 estimate followed the
+[fuzz change](https://github.com/omkhar/workcell/commit/924c07a37f268afdbf55715ee04952ea6f0edc0b)
+and the
+[reproducible-build change](https://github.com/omkhar/workcell/commit/845b1b0d2c77574afbedb2202799971a9d912286).
+It used configuration and timeout values. A local host cannot run all hosted CI
+jobs. It did not claim an end-to-end measured result.
 
-The `ci-insights.yml` `CI cost report` job runs on the same weekly cadence and
-writes a Markdown table to its job summary aggregating per-workflow wall-clock
-over the lookback window (runs, total wall-clock, average per run), sorted by
-total. It is generated by
-[`scripts/ci/cost-report.sh`](../scripts/ci/cost-report.sh) and is read-only
-(`actions:read`). Wall-clock includes queue time because that is the latency a
-change actually waits on.
+The expected result for an unlabeled pull request was:
 
-## Before/after PR timing estimate and methodology
+- The change removes approximately 30 seconds of active fuzz time from the
+  validation path.
+- The change removes the approximately 45-minute reproducible-build matrix from
+  the required pull-request critical path.
+- The scheduled and on-demand workflow keeps active fuzz campaigns.
+- `go test ./...` keeps the fuzz seed tests.
+- Pushes to `main` and the release workflow keep reproducible builds.
 
-Full CI cannot be run locally (hosted runners, GHCR, macOS runners), so these
-are estimates derived from the configured job timeouts and the fuzz-time
-constants in the scripts, not measured end-to-end runs. The `CI cost report`
-above provides the empirical before/after once it accumulates history across the
-change.
-
-Methodology: read the serial critical path for an **unlabeled** PR (the common
-case — most PRs are not labeled `approved-heavy-ci`) as the max over required
-contexts, and account for the removed work.
-
-- **Active fuzzing:** the validate lane previously ran two effective active-fuzz
-  targets at 15s each (`FuzzParse`, `FuzzParseSSHDirective`) plus one no-op,
-  i.e. ~30s of serial fuzz time on the validate critical path per PR. Removing
-  it drops that ~30s and — more importantly — removes a nondeterministic timeout
-  failure mode whose cost was a full validate-lane re-run (up to the 60-minute
-  lane budget) on a spurious failure.
-- **Reproducible build:** previously the `Reproducible build` required context
-  waited on a ~45-minute per-platform matrix on **every** PR (the two platforms
-  run in parallel, so ~45 minutes, not 90). On an unlabeled PR that context now
-  resolves in under a minute (skipped matrix → aggregator passes), removing a
-  ~45-minute-budget required gate from the unlabeled-PR critical path.
-
-Net expected effect for an unlabeled PR: the all-green critical path is no longer
-gated by the ~45-minute reproducible-build matrix, and the validate lane sheds
-~30s of flaky active-fuzz plus its re-run risk. PRs that genuinely need the heavy
-lanes still get them by applying `approved-heavy-ci`. Exact minutes depend on
-real per-run durations, which the cost report will quantify.
+Use the CI cost report for current measured history. Do not present the recorded
+estimate as a current service-level objective.

--- a/docs/enterprise-evidence-baseline.md
+++ b/docs/enterprise-evidence-baseline.md
@@ -1,114 +1,101 @@
 # Enterprise Evidence Baseline
 
-This page records the Phase 11 evidence baseline for enterprise evaluation. It
-is an evidence map, not a compliance certification or an independent audit
-report.
+This page records the Phase 11 evidence map. It is not a certification or an
+independent audit report.
 
-Workcell currently supports local-first rollout on reviewed Apple Silicon macOS
-hosts. Evidence for broader host support, centralized policy, fleet inventory,
-or managed-workstation execution must land in later phases before those become
-support claims.
+Workcell supports operator launch only on the allowed macOS arm64 matrix rows.
+Broader host support, centralized policy, fleet inventory, and a managed
+workstation need new implementation and evidence.
 
-## Evidence Packet
+## Evidence Map
 
 | Area | Current source |
 |---|---|
-| Architecture and data flow | [workcell-system-design.md](workcell-system-design.md) (with boundary-stack, policy-to-injection, and control-plane masking diagrams), [invariants.md](invariants.md), [adapter-control-planes.md](adapter-control-planes.md) |
-| Runtime and target boundaries | [remote-vm-contract.md](remote-vm-contract.md), [managed-workstation-contract.md](managed-workstation-contract.md), [host-expansion-readiness.md](host-expansion-readiness.md), [policy/host-support-matrix.tsv](../policy/host-support-matrix.tsv) |
-| Threat model and non-protections | [threat-model.md](threat-model.md), [invariants.md](invariants.md), [enterprise-rollout.md](enterprise-rollout.md) |
-| Validation evidence | [validation-scenarios.md](validation-scenarios.md), [requirements-validation.md](requirements-validation.md), [use-case-matrix.md](use-case-matrix.md) |
-| Release provenance, SBOMs, and signing | [provenance.md](provenance.md), [github-workflows.md](github-workflows.md), [releasing.md](releasing.md) |
-| Support boundary and rollout | [enterprise-rollout.md](enterprise-rollout.md), [provider-matrix.md](provider-matrix.md), [../SUPPORT.md](../SUPPORT.md), [../ROADMAP.md](../ROADMAP.md) |
+| Architecture and data flow | [System Design](workcell-system-design.md), [Invariants](invariants.md), [Adapter Control Planes](adapter-control-planes.md) |
+| Runtime and target boundaries | [Remote VM Contract](remote-vm-contract.md), [Managed Workstation Contract](managed-workstation-contract.md), [Host Expansion Readiness](host-expansion-readiness.md), [host-support matrix](../policy/host-support-matrix.tsv) |
+| Threats and non-protections | [Threat Model](threat-model.md), [Invariants](invariants.md), [Enterprise Rollout](enterprise-rollout.md) |
+| Validation | [Validation Scenarios](validation-scenarios.md), [Requirements and Validation](requirements-validation.md), [Use-Case Matrix](use-case-matrix.md) |
+| Release provenance | [Provenance](provenance.md), [GitHub Workflows](github-workflows.md), [Release Process](releasing.md) |
+| Support and rollout | [Enterprise Rollout](enterprise-rollout.md), [Provider Matrix](provider-matrix.md), [Support](../SUPPORT.md), [Roadmap](../ROADMAP.md) |
 
-## Audit Schema And Retention
+## Audit and Session Evidence
 
-Current audit and session evidence is host-local:
+Audit and session evidence is host-local. New state uses the Workcell-owned
+target-state tree. The exact root depends on the target kind, provider, and
+profile.
 
-- profile audit logs live under Workcell-owned target state, for example
-  `~/.local/state/workcell/targets/<target-kind>/<provider>/<profile>/workcell.audit.log`
-- audit records are append-only text records with timestamps, event fields,
-  assurance data, and chained record digests
-- launched sessions write durable JSON records under the same target-state root
-- session audit-chain heads are signed host-side, and
-  `workcell session verify` recomputes the chain from the authoritative log and
-  checks that signature — see
-  [signed-session-audit-records.md](signed-session-audit-records.md) for the
-  format and trust model (boundary/host-signed, not agent-signed)
-- `workcell session timeline` filters audit records for one session
-- `workcell session export` bundles a session record with matching audit records
-- durable session records intentionally survive `workcell --gc`
-- `workcell session delete` removes a stopped session record and recorded
-  session-owned artifacts, but it does not rewrite the shared profile audit log
+A launched session can create these records:
 
-Retention remains operator or organization owned. Workcell does not yet provide
-a centralized retention policy or fleet inventory. SIEM ingestion is served by
-the OCSF-mapped export below (an export format, not a hosted pipeline or
-retention service).
+- An append-only profile audit log with event, time, and assurance fields.
+- A chained digest for each supported audit record.
+- A durable JSON session record.
+- A best-effort host signature for the final session-chain head.
+- Pointers to the debug log, transcript log, file-trace log, session audit
+  directory, and shared audit log when the session record has these paths.
 
-### OCSF-Mapped Export
+`workcell session verify` recomputes the authoritative chain and checks the seal
+and public key. Use [Signed Session Audit Records](signed-session-audit-records.md)
+for its guarantees and legacy limits.
 
-`workcell session export --format ocsf` renders a session and its audit
-lifecycle records as [OCSF](https://schema.ocsf.io/) 1.3.0 JSON Lines — one
-**Application Lifecycle** event (`category_uid` 6, `class_uid` 6002) per line —
-so a SIEM can ingest Workcell session evidence without a bespoke parser. The
-default `--format json` bundle is unchanged.
+`workcell session timeline` selects audit records for one session.
+`workcell session export` creates a session bundle. `workcell --gc` preserves
+durable session records. `workcell session delete` removes a stopped record. A
+full delete also removes the recorded stopped container, debug log, file-trace
+log, transcript log, session audit directory, and audit seal when they exist.
+It does not remove the recorded isolated clone. It does not rewrite the shared
+profile audit log.
 
-- **Events.** One summary event for the session record (finished → `activity_id`
-  4 Stop, live → 3 Start), then one event per audit record (started/launch →
-  Start, finished/exit → Stop, else → 99 Other). `metadata.version` is the OCSF
-  schema version (`1.3.0`); `metadata.mapping_version` is the Workcell
-  field→OCSF mapping version (`2` for this multi-event stream) so consumers can
-  gate parsers on either axis independently.
-- **Redaction.** Every field is passed through the shared support-bundle
-  redactor (the same rule-set as [G2 support bundles](../SUPPORT.md)) before it
-  enters an event; there is no un-redacted output path. That redactor masks
-  credentials and tokens and rewrites the operator home prefix to `~` — it does
-  NOT scrub arbitrary non-home paths, so operational metadata such as
-  `session.workspace` or `session.git_branch` (e.g. `/tmp/project`) is retained
-  as-is beyond the home rewrite. Because that regex redaction cannot sanitize
-  arbitrary prose, any operator/agent FREE-FORM payload — the `argv` session
-  message and any unexpected/tampered audit key or value — is instead
-  HARD-REDACTED to a fixed placeholder rather than emitted, so a credential in
-  prose or split-CLI form cannot reach the export even though it evades the
-  regex rules.
-- **Tamper resistance.** A tampered audit line with a duplicate identity key
-  fails the export closed (no forged event); a record whose decoded `session_id`
-  does not match the exported session is dropped (no cross-session
-  attribution); a torn crash fragment maps to Unknown, not Success.
+The operator or organization owns retention. Workcell has no central retention
+service or fleet inventory.
 
-## Known Gaps
+## OCSF Export
 
-These are intentionally not claimed today:
+`workcell session export --format ocsf` writes OCSF 1.3.0 JSON Lines. Each line
+is an Application Lifecycle event with `category_uid` 6 and `class_uid` 6002.
+The default JSON bundle is unchanged.
 
-- independent SOC 2, ISO 27001, or similar certification
-- centralized Workcell RBAC, SSO, SCIM, analytics, or inventory
-- Linux, Windows, Linux `arm64`, or Raspberry Pi operator-host support
-- managed-workstation provider support
-- automatic backend fallback
-- proof that release provenance alone proves the full local runtime boundary
+The export has these properties:
+
+- It writes one summary event and one event for each audit record that matches
+  the session.
+- It records OCSF schema version `1.3.0` and Workcell mapping version `2`.
+- It applies the shared support-bundle redactor to each dynamic session or
+  audit string value.
+- It replaces free-form session messages and unexpected audit fields with a
+  fixed redaction value.
+- It stops on a duplicate audit identity key.
+- It drops an audit record when the decoded session identifier does not match
+  the exported session.
+- It maps a torn crash fragment to an unknown result, not a success result.
+
+The shared redactor masks credentials and tokens. It replaces the operator home
+prefix with `~`. It can retain any non-home path that does not match another
+redaction rule.
+
+## Claims That Workcell Does Not Make
+
+Workcell does not claim:
+
+- Independent SOC 2, ISO 27001, or equivalent certification.
+- Central Workcell RBAC, SSO, SCIM, analytics, retention, or inventory.
+- Linux or Windows operator-host support.
+- Managed-workstation provider support.
+- Automatic target fallback.
+- That release provenance proves the complete local runtime boundary.
 
 ## Control Mapping Aid
 
-The mappings below are evaluation aids for buyers and reviewers. They are not
-claims that Workcell is certified against those frameworks.
+These mappings help an evaluator find evidence. They are not conformance claims.
 
-| Framework area | Workcell evidence to inspect |
+| Framework area | Evidence to inspect |
 |---|---|
-| SOC 2 logical access and change management | host-side policy commands, signed PR publication, release provenance, hosted-control audits |
-| SOC 2 system operations and monitoring | validation scenarios, session audit records, release workflow evidence |
-| SOC 2 risk mitigation | threat model, invariants, support matrix, lower-assurance mode labeling |
-| ISO 27001 access control | injection policy, provider bootstrap matrix, host-owned credential staging |
-| ISO 27001 configuration and change management | operator contract, requirements traceability, signed commits, PR-parity validation |
-| ISO 27001 logging and monitoring | session records, audit logs, hosted-control audits, release attestations |
-| ISO 27001 secure development and supplier controls | pinned upstream verification, reproducible builds, SBOM publication, vulnerability reporting |
-| OWASP Top 10 for Agentic Applications (2026) | [owasp-agentic-mapping.md](owasp-agentic-mapping.md) — a conservative posture map, not a conformance claim |
+| Access and change management | Host policy commands, signed publication, provenance, and hosted-control audits |
+| Operations and monitoring | Validation scenarios, session audit records, and release workflow evidence |
+| Risk treatment | Threat model, invariants, support matrix, and lower-assurance labels |
+| Configuration management | Operator contract, requirements traceability, signed commits, and `pr-parity` evidence |
+| Logging | Session records, audit logs, hosted-control audits, and release attestations |
+| Secure development and suppliers | Pinned upstream checks, reproducible builds, SBOMs, and vulnerability reporting |
+| OWASP agentic applications | [OWASP Agentic Mapping](owasp-agentic-mapping.md), which is a conservative posture map |
 
-## Quality Gate
-
-Enterprise evidence must stay reviewable and current:
-
-- do not convert roadmap items into support claims
-- keep evidence links repo-local and machine-checked when practical
-- remove duplicated or vague assurance language during peer review
-- update the evidence map in the same change as any support-tier, release,
-  audit, or runtime-boundary change that affects it
+Update this evidence map in the same change as a support, release, audit, or
+runtime-boundary claim that changes the evidence map.

--- a/docs/enterprise-evidence-baseline.md
+++ b/docs/enterprise-evidence-baseline.md
@@ -42,6 +42,7 @@ for its guarantees and legacy limits.
 durable session records. `workcell session delete` removes a stopped record. A
 full delete also removes the recorded stopped container, debug log, file-trace
 log, transcript log, session audit directory, and audit seal when they exist.
+
 It does not remove the recorded isolated clone. It does not rewrite the shared
 profile audit log.
 
@@ -97,5 +98,5 @@ These mappings help an evaluator find evidence. They are not conformance claims.
 | Secure development and suppliers | Pinned upstream checks, reproducible builds, SBOMs, and vulnerability reporting |
 | OWASP agentic applications | [OWASP Agentic Mapping](owasp-agentic-mapping.md), which is a conservative posture map |
 
-Update this evidence map in the same change as a support, release, audit, or
+Update this map in the same change as a support, release, audit, or
 runtime-boundary claim that changes the evidence map.


### PR DESCRIPTION
## Summary

- Rewrite CI guidance for labels, retries, reproducibility, fuzzing, and cost reports.
- Replace the enterprise baseline with a concise map of current repository evidence.
- Add stable sources for the historical CI time estimate.

This change does not alter runtime behavior or support status.

## Validation

- `./scripts/ci/job-docs.sh`
- `/usr/bin/env -u GIT_PAGER ./scripts/dev-quick-check.sh`
- `/usr/bin/env -u GIT_PAGER ./scripts/validate-repo.sh`
- `/usr/bin/env -u GIT_PAGER ./scripts/pre-merge.sh --profile pr-parity`
- Six-role adversarial review, with no remaining finding.
