### PR TITLE
Rewrite Workcell system design guidance

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -177,7 +177,7 @@ claim.
 
 Exit gates:
 
-- architecture and data-flow diagrams exist
+- architecture and data-flow documentation exists
 - threat model, known gaps, support boundaries, and non-protections are public
 - SBOM, provenance, reproducibility, release signing, and vulnerability
   handling are summarized
@@ -499,7 +499,7 @@ Use generated, checked metrics before you add a numeric inventory here.
 ### Track E: Documentation And Adoption
 
 - **E1 (complete, M):** tiered documentation entry points and a slimmer README
-- **E2 (complete, M):** maintained architecture diagrams in the system design doc
+- **E2 (complete, M):** maintained architecture in the system design document
 - **E3 (complete, S):** support-tier legend and a `--doctor`/`--inspect`
   diagnostics interpretation guide
 - **E4 (complete, S):** documentation CI checks links, orphans, spelling, man

--- a/docs/1.0-readiness-review.md
+++ b/docs/1.0-readiness-review.md
@@ -250,7 +250,7 @@ docs/contract, and release lenses completed this checklist on 2026-08-04.
       launches no containers. Historical preliminary and certified evidence is
       committed at
       [`docs/benchmark-evidence/c3-two-container-isolation-2026-07-15.md`](benchmark-evidence/c3-two-container-isolation-2026-07-15.md).
-- [x] **Adoption surface** — tiered docs (E1, merged), architecture diagrams
+- [x] **Adoption surface** — tiered docs (E1, merged), architecture documentation
       (E2, merged), and support guides (E3, merged) are the 1.0 gate. **E6 is
       DEFERRED to post-1.0 (2026-07-09 maintainer decision)** — 1.0 ships with
       in-repo markdown docs; a **preliminary** C2 capture was published to

--- a/docs/improvement-tracks-implementation-plan.md
+++ b/docs/improvement-tracks-implementation-plan.md
@@ -80,7 +80,7 @@ The [roadmap milestone train](../ROADMAP.md#milestone-train) records the histori
 | ID | Result | Shipped record |
 | --- | --- | --- |
 | E1 | Complete | README entry points and the documentation map serve operators, evaluators, and contributors. |
-| E2 | Complete | The [system design](workcell-system-design.md) contains maintained architecture diagrams. |
+| E2 | Complete | The [system design](workcell-system-design.md) documents the maintained architecture. |
 | E3 | Complete | The [support tiers](support-tiers.md) and [diagnostics guide](diagnostics-and-support-matrix.md) define the emitted support fields. |
 | E4 | Complete | Documentation CI checks links, orphans, spelling, man pages, support-field parity, and public-contract drift. |
 | E5 | Complete | The [injection policy](injection-policy.md) has an annotated schema and provider examples. |

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -2,500 +2,283 @@
 
 ## Purpose
 
-This document describes the current Workcell architecture as implemented in the
-repository today. Roadmap direction and future product strategy live in
-[`ROADMAP.md`](../ROADMAP.md) and
-[`docs/implement-first-delivery-plan.md`](implement-first-delivery-plan.md)
-rather than in this design doc.
-
-## Executive Summary
-
-Workcell is a host-launched, policy-driven runtime for coding agents. Its
-current architecture is:
-
-1. a trusted host control plane in [`scripts/workcell`](../scripts/workcell)
-   prepares and validates each session
-2. a dedicated Colima VM provides the primary machine boundary on supported
-   Apple Silicon macOS hosts
-3. a hardened container inside that VM provides the agent execution runtime
-4. thin provider adapters seed provider-native homes and configuration without
-   pretending provider config is the security boundary
-5. host-side policy rendering, control-plane masking, and explicit injection
-   determine what material enters the runtime
-6. host-side durable session records, audit logs, and detached session control
-   make the runtime inspectable without introducing a daemonized control plane
-
-The main architectural point is unchanged across providers: Workcell does not
-trust prompt files, provider settings, or repo-local control-plane files as the
-primary boundary. The supported boundary is the host-controlled VM plus
-container path, reinforced by explicit injection, managed provider homes,
-control-plane masking, provider wrappers, and release-time provenance.
-
-## Design Goals
-
-The repository working agreement prioritizes:
-
-1. developer experience
-2. simplicity
-3. security invariants
-4. performance
-5. idiomatic correctness
-
-Within that order, the system is designed to:
-
-- keep the trusted control plane on the host
-- preserve a dedicated VM plus container boundary for supported adapters
-- make lower-assurance paths explicit instead of silently widening trust
-- keep provider-specific behavior visible instead of hiding it behind a fake
-  universal abstraction
-- prefer auditable configuration and invariant checks over hidden magic
-
-## Non-Goals
-
-Workcell is not trying to be:
-
-- a generic shared-kernel container sandbox
-- a provider-agnostic agent framework that erases real CLI differences
-- a repo-local prompt/config convention presented as a security system
-- a remote worker or cloud-agent platform today
-- a centralized enterprise policy or analytics plane today
-
-## System Overview
-
-### 1. Host Control Plane
-
-The main orchestrator is [`scripts/workcell`](../scripts/workcell). The host
-control plane is responsible for:
-
-- scrubbing the host environment before launch
-- resolving trusted host binaries and helper scripts
-- computing and validating the Colima profile for the workspace
-- validating runtime assumptions such as `vz`, mount shape, and the bounded
-  Docker path
-- loading auth policy and injection policy
-- resolving host-side credential sources before launch
-- rendering the staged injection bundle and metadata
-- shadowing repo-local control-plane paths on the safe path
-- applying the VM egress allowlist
-- preparing the runtime image when required
-- launching the runtime container with controlled mounts, tmpfs state, and
-  managed environment variables
-- recording audit metadata, assurance state, and detached session records
-
-Operationally, `scripts/workcell` is the real control plane. Trust-sensitive
-decisions are made before the provider CLI starts.
-
-### 2. Host-Side Structured Helpers
-
-The shell launcher delegates structured policy and metadata work to small Go
-packages under [`internal/`](../internal):
-
-- [`internal/authpolicy`](../internal/authpolicy): host-side auth-policy state
-  and `workcell auth ...`
-- [`internal/authresolve`](../internal/authresolve): host-side credential source
-  resolution and preprocessing
-- [`internal/injection`](../internal/injection): staged injection bundle
-  rendering and validation
-- [`internal/host/launcher`](../internal/host/launcher), [`internal/host/sessions`](../internal/host/sessions),
-  [`internal/host/hoststate`](../internal/host/hoststate), [`internal/host/release`](../internal/host/release),
-  [`internal/host/stateroot`](../internal/host/stateroot),
-  [`internal/host/supportmatrix`](../internal/host/supportmatrix): host-side
-  utility subpackages (path canonicalization, colima/profile-lock, session
-  records, mount/audit state, GitHub release helpers, Workcell-owned
-  target-state roots, support matrix)
-- [`internal/metadatautil`](../internal/metadatautil): metadata and validation
-  helpers used by repo checks and release posture
-- [`internal/runtimeutil`](../internal/runtimeutil): runtime-related utility
-  helpers
-
-This split keeps orchestration visible in shell while moving structured data
-validation and rendering into typed code.
-
-### 3. Runtime Boundary and Profiles
-
-The supported safe path is two-tier:
-
-1. a dedicated Colima VM on the host
-2. a hardened agent container inside that VM
-
-```mermaid
-flowchart TB
-    subgraph host["macOS host — control plane"]
-        cli["workcell CLI + host-side helpers"]
-        subgraph vm["Dedicated Colima VM"]
-            subgraph ctr["Hardened agent container<br/>no-new-privileges · cap-drop ALL · pids-limit<br/>tmpfs /tmp /run /state"]
-                provider["Provider agent<br/>Codex / Claude / Copilot / Gemini"]
-                ws["/workspace<br/>selected mount"]
-                provider --- ws
-            end
-        end
-    end
-    cli --> vm --> ctr
-```
-
-The container launch path applies controls such as:
-
-- Docker `--init` for launches that do not require PID 1 environment scrubbing
-- `--security-opt no-new-privileges:true`
-- `--cap-drop ALL`
-- `--pids-limit 1024`
-- tmpfs mounts for `/tmp`, `/run`, and `/state`
-- a tightly managed environment
-- a selected workspace mount at `/workspace`
-
-Runtime profiles in [`runtime/profiles/`](../runtime/profiles) separate
-posture and expectations:
-
-- `strict`: default managed provider lane
-- `development`: managed interactive lane with broader command flexibility
-- `build`: broader preparation and dependency-refresh lane
-- `breakglass`: explicit higher-trust lane requiring acknowledgement
-
-The system relies on profile-specific guarantees, not on provider prompt text
-that describes those guarantees after the fact.
-
-### 4. Workspace and Control-Plane Isolation
-
-On the safe path, Workcell prevents mutable workspace content from silently
-becoming the live provider control plane.
-
-Repo-local control-plane paths such as:
-
-- `AGENTS.md`
-- `CLAUDE.md`
-- `GEMINI.md`
-- `.mcp.json`
-- `.codex/`
-- `.claude/`
-- `.gemini/`
-- mutable git hook and config paths
-
-are masked or shadowed by Workcell over the workspace. Of these, the provider
-documentation files may additionally be imported into the managed provider home
-as reviewed inputs, and which files are imported depends on the adapter: Codex
-imports `AGENTS.md`; Claude and Gemini import `AGENTS.md` plus their own file
-(`CLAUDE.md` or `GEMINI.md`); Copilot imports none, because its custom-instruction
-surface is intentionally disabled. The remaining control-plane paths are
-neutralized in the workspace but not reseeded into the provider home.
-
-For tracked files, the shadow path can materialize content from the git index
-instead of live mutable workspace state. That narrows the gap between what the
-operator reviewed and what the runtime consumes.
-
-```mermaid
-flowchart LR
-    subgraph repo["Repo-local control plane — mutable workspace"]
-        docs["AGENTS.md · CLAUDE.md · GEMINI.md<br/>provider docs"]
-        other[".mcp.json · .codex/ · .claude/ · .gemini/<br/>mutable git hooks + config"]
-    end
-    idx["git index<br/>tracked files"] -. materialize .-> mask
-    docs --> mask["Masked / shadowed<br/>over /workspace"]
-    other --> mask
-    docs -. "Codex/Claude/Gemini only<br/>(Copilot imports none)" .-> home["Imported into managed provider home<br/>as reviewed inputs"]
-```
-
-### 5. Injection and Credential Flow
-
-Workcell's supported path for credentials, shared GitHub state, SSH material,
-and reviewed documentation fragments is explicit injection policy.
-
-The flow is:
-
-1. load the injection policy on the host
-2. resolve host-side credential sources and selector scope
-3. render a staged injection bundle and manifest
-4. mount the staged bundle into controlled runtime paths
-5. reseed the managed provider home from approved sources
-
-```mermaid
-flowchart TD
-    policy["Injection policy<br/>loaded on host"] --> resolve["Resolve credential sources<br/>+ selector scope"]
-    resolve --> render["Render staged bundle<br/>+ manifest"]
-    render --> mount["Mount bundle into<br/>controlled runtime paths"]
-    mount --> reseed["Reseed managed<br/>provider home"]
-    reseed --> agent["Provider agent"]
-    guard["Secrets classified + staged ·<br/>target paths enumerated ·<br/>reserved provider-home paths protected"] -. governs .-> render
-```
-
-Important properties of the current implementation:
-
-- secrets are staged and classified explicitly
-- supported target paths are tightly enumerated
-- reserved provider-home paths cannot be overwritten arbitrarily
-- shared GitHub and SSH inputs are opt-in and policy-scoped
-- resolver-backed credentials are a host preprocessing step, not live host
-  socket or keychain passthrough
-- direct staged credentials are the primary supported auth path today
-- built-in resolver coverage remains narrow and explicit:
-  `codex-home-auth-file` is the reviewed Codex host-auth reuse path, while
-  `claude-macos-keychain` remains a fail-closed scaffold rather than a launch
-  path
-
-### 6. Container Entry and Provider Launch Chain
-
-Inside the container, the launch chain is deliberately layered:
-
-1. [`runtime/container/entrypoint.sh`](../runtime/container/entrypoint.sh)
-2. [`runtime/container/runtime-user.sh`](../runtime/container/runtime-user.sh)
-3. [`runtime/container/home-control-plane.sh`](../runtime/container/home-control-plane.sh)
-4. [`runtime/container/provider-wrapper.sh`](../runtime/container/provider-wrapper.sh)
-5. provider binary
-
-This chain exists to keep the provider home, runtime state, and policy checks
-under Workcell control.
-
-`entrypoint.sh` validates the managed environment, maps the runtime user for
-mutable sessions, seeds runtime state, and routes lower-assurance development
-commands only through the managed wrapper path.
-
-`home-control-plane.sh` rebuilds the effective provider home under
-`/state/agent-home`, verifies control-plane artifacts, layers baseline and
-imported docs, and seeds auth, MCP, rules, and SSH material.
-
-`provider-wrapper.sh` and
-[`runtime/container/provider-policy.sh`](../runtime/container/provider-policy.sh)
-then sanitize the environment and reject trust-widening provider flags or
-config overrides before launching the provider.
-
-### 7. Runtime Mutability and Assurance
-
-Workcell distinguishes between the default managed path and explicit
-lower-assurance behavior.
-
-Examples already implemented in the runtime:
-
-- `development` is a managed lane, but not equivalent to `strict`
-- mutable package installation is mediated and recorded as a downgrade
-- prompt autonomy, transcript capture, and other widened paths are explicit
-- `breakglass` is separate and acknowledged rather than silently inherited
-
-Assurance is therefore a runtime property that Workcell records and surfaces,
-not a marketing label applied equally to every mode.
-
-### 8. Exec Guard and Wrapper Defense in Depth
-
-The deepest technical enforcement layer is the Rust exec guard under
-[`runtime/container/rust/`](../runtime/container/rust), loaded with
-`LD_PRELOAD`.
-
-Its role is to prevent bypasses beneath shell wrappers, including:
-
-- direct protected-runtime execution outside approved wrappers
-- shebang execution from mutable paths targeting protected runtimes
-- native execution paths that bypass policy on the strict path
-- git hook and config bypass patterns
-
-Workcell reinforces this with command wrappers such as:
-
-- [`runtime/container/bin/git`](../runtime/container/bin/git)
-- [`runtime/container/bin/node`](../runtime/container/bin/node)
-- [`runtime/container/public-node-guard.mjs`](../runtime/container/public-node-guard.mjs)
-
-The result is defense in depth below prompt files, shell aliases, and
-provider-native settings.
-
-The exec guard is a libc interposer registered in `/etc/ld.so.preload` (and
-re-exported as `LD_PRELOAD` by every wrapper), so it is loaded into the
-process that *calls* `exec`, not the process being launched. It therefore
-mediates a launch regardless of whether the launched binary is dynamically
-or statically linked — a wrapper or shell that invokes a static provider
-binary is still guarded, and a static provider invoked as a protected
-runtime is still blocked. The one linkage-dependent residual is a fully
-static process making its *own* `exec` call: such a process never consults
-`/etc/ld.so.preload`, so the interposer is absent inside it and its direct
-`exec` of a mutable `/workspace` or `/state` binary would not be intercepted
-by this layer (the provider's own sandbox and the VM/container boundary
-remain in force). Because providers are now packaged as static musl
-binaries, a fully linkage-independent backstop — kernel-enforced `noexec`
-on `/workspace` for the strict path, extending the existing `/tmp noexec`
-control, optionally paired with a seccomp `execve` filter — is the tracked
-hardening for this layer; it changes the macOS Colima runtime mount set and
-so must land with the host-side live certification rather than as a
-repo-only change.
-
-### 9. Thin Provider Adapters
-
-Provider integration remains intentionally thin and explicit:
-
-- Codex: managed config, requirements, rules, and MCP material under the
-  Workcell boundary
-- Claude Code: reviewed settings, baseline instructions, auth mirrors, MCP
-  config, and shell-hook policy support
-- Gemini CLI: managed settings, trust-state seeding, and explicit auth material
-  such as `.env`, OAuth, project, and optional Vertex supplement files
-
-Workcell keeps one shared boundary and many thin adapters. It does not hide the
-real provider differences behind a fake universal control plane.
-
-### 10. Runtime Target Taxonomy And Remote VM Contract
-
-The current strongest live safe path is still the strict `local_vm/colima`
-boundary. Phase 5 adds a canonical preview-only `remote_vm` contract in
-[`policy/remote-vm-contract.json`](../policy/remote-vm-contract.json) plus a
-shared fake target and conformance harness in
-[`internal/remotevm`](../internal/remotevm).
-
-That contract fixes the control-plane meanings that later remote providers
-must reuse:
-
-- explicit host-owned remote workspace materialization rather than an implicit
-  live host mount
-- brokered access and bootstrap metadata rather than ambient host socket or
-  credential passthrough
-- `target kind`, `assurance class`, `runtime API`, and `workspace transport`
-  as separate recorded concepts in session and audit state
-- a shared fake target plus deterministic conformance harness that later cloud
-  adapters must pass unchanged instead of redefining contract suites per
-  provider
-
-The first provider-specific consumer is the preview-only
-`remote_vm/aws-ec2-ssm/compat` path. The second is the preview-only
-`remote_vm/gcp-vm/compat` path. Their deterministic repo-required evidence
-stays at dry-run diagnostics and shared conformance reuse, while live cloud use
-remains separate certification-only gates with brokered SSM or IAP access and
-no inbound public SSH.
-
-### 11. Host-Side Detached Session Plane
-
-Workcell now includes a host-owned detached session plane. The current CLI
-surface includes:
-
-- `workcell session start`
-- `workcell session attach`
-- `workcell session send`
-- `workcell session stop`
-- `workcell session list`
-- `workcell session show`
-- `workcell session delete`
-- `workcell session logs`
-- `workcell session timeline`
-- `workcell session diff`
-- `workcell session export`
-- `workcell session verify`
-
-The supported operator inventory is maintained in
-[`policy/operator-contract.toml`](../policy/operator-contract.toml). This
-system-design doc explains shape and rationale; it should not be treated as the
-authoritative CLI inventory.
-
-Detached session records are written under the Workcell-owned target-state tree
-as
-`~/.local/state/workcell/targets/local_vm/colima/<profile>/sessions/<session-id>.json`.
-Compatibility reads still accept older legacy records under
-`~/.colima/<profile>/sessions/<session-id>.json`. The current session record
-schema in [`internal/host/sessions/sessions.go`](../internal/host/sessions/sessions.go)
-includes:
-
-- session identity, profile, target kind, target provider, target id,
-  target assurance class, runtime API, agent, mode, and UI
-- workspace path, workspace origin, workspace root, and worktree path
-- workspace transport as a distinct recorded concept alongside workspace paths
-- git branch, head, and clean-base metadata
-- container name, monitor pid, status, and live status
-- audit, debug, file-trace, and transcript log pointers
-- start, observe, and finish timestamps
-- initial, current, and final assurance
-- workspace control-plane state
-
-Detached sessions default to `--session-workspace isolated`, which clones a
-clean per-session git worktree on the host for supported source workspaces.
-
-The current session plane is intentionally file-backed and host-owned. It does
-not require a separate daemon, local socket trust, or centralized service.
-
-### 12. Verification and Release Posture
-
-The repository pairs runtime controls with verification and provenance
-material:
-
-- [`verify/invariants/`](../verify/invariants) and
-  [`docs/invariants.md`](invariants.md) define the safe-path contract
-- [`docs/threat-model.md`](threat-model.md) documents trust boundaries and
-  abuse paths
-- [`docs/validation-scenarios.md`](validation-scenarios.md) tracks scenario
-  coverage and remaining gaps
-- [`docs/provenance.md`](provenance.md) and [`docs/releasing.md`](releasing.md)
-  describe release-time signing, attestation, and publication expectations
-
-Final GitHub publication is intentionally host-side. In this repository the
-supported `main`-based PR path goes through `./scripts/repo-publish-pr.sh`,
-which delegates to `workcell publish-pr` after fresh local parity evidence
-exists. That keeps branch push, commit signing, and PR creation outside the
-bounded Tier 1 runtime.
-
-## End-to-End Flow
-
-### Safe Launch Flow
-
-The normal strict-path launch is:
-
-1. the operator runs `workcell --agent <provider> --workspace <repo>`
-2. the host launcher scrubs the environment and validates workspace and profile
-   assumptions
-3. auth and injection policy are resolved on the host
-4. repo-local control-plane files are shadowed or imported through Workcell
-5. the runtime image and VM egress posture are prepared
-6. the container starts with hardened flags and managed environment variables
-7. the managed provider home is rebuilt under `/state/agent-home`
-8. the provider wrapper validates flags and starts the provider inside the
-   bounded runtime
-
-### Detached Session Flow
-
-The current detached flow adds host-owned lifecycle state:
-
-1. `workcell session start` allocates a durable session id
-2. detached sessions default to an isolated per-session workspace when the
-   source workspace supports it
-3. the launcher writes a durable session record and audit state on the host
-4. the runtime executes in the same bounded environment as foreground launches
-5. the operator can later inspect, attach, steer, stop, diff, or export the
-   session from the host
-
-### Publish Flow
-
-The supported publication path remains:
-
-1. run the provider inside Workcell
-2. review the resulting changes
-3. run local `pr-parity`, then publish from the host with
-   `./scripts/repo-publish-pr.sh`
-
-This keeps commit signing and repository publication outside the in-container
-runtime boundary.
+This page describes the system that is in this repository. Use the
+[Roadmap](../ROADMAP.md) for planned work. Use the
+[host-support matrix](../policy/host-support-matrix.tsv) for current support
+decisions.
+
+## Design Rules
+
+Workcell uses these rules:
+
+- Keep the trusted control plane on the host.
+- Use a dedicated VM and a container for the strict local boundary.
+- Keep each provider adapter small and explicit.
+- Do not use provider configuration or instructions as the security boundary.
+- Require explicit operator input for a lower-assurance path.
+- Record the selected target and assurance class.
+- Stop a live launch if the selected host and target do not have an allowed
+  matrix row.
+
+Workcell is not a generic container sandbox. It is not a cloud agent service.
+It does not provide a central enterprise policy or analytics service.
+
+## System Boundary
+
+The strict local target has these parts:
+
+1. The host launcher validates and prepares the session.
+2. A dedicated Colima VM supplies the main machine boundary.
+3. A hardened container runs the provider in the VM.
+4. A provider adapter creates a managed provider home.
+5. Host-owned records preserve session and audit data.
+
+The macOS arm64 Docker Desktop target uses the same container launch path and
+core hardening flags. It does not have a dedicated Workcell VM. It does not have
+Workcell egress enforcement. It requires seccomp, but it does not require
+AppArmor or SELinux. For these reasons, its assurance class is `compat`, not
+`strict`.
+
+The Colima VM belongs to one workspace-bound Colima profile. It does not belong
+to one runtime mode or session. Concurrent sessions in one profile share the VM
+and kernel.
+
+The command line interface also accepts the AWS EC2 SSM and GCP VM target names.
+Those targets supply reviewed dry-run broker plans. Their operator launch rows
+are blocked. They do not start a Workcell-managed remote session.
+
+The Apple `container` evaluation and the managed-workstation contract do not
+have operator target values.
+
+## Host Control Plane
+
+[`scripts/workcell`](../scripts/workcell) is the main host control plane. It
+does these tasks before it starts a provider:
+
+- Scrub the host environment.
+- Resolve trusted host tools.
+- Validate the workspace, host, target, and support-matrix row.
+- Load authentication and injection policy.
+- Resolve approved credential sources on the host.
+- Create the staged injection bundle.
+- Mask mutable workspace control files on non-`breakglass` paths.
+- Prepare the runtime image when it is missing or stale, or when the operator
+  selects an explicit prepared rebuild.
+- Apply the selected Colima egress policy.
+- Start the container with controlled mounts and environment variables.
+- Write session, audit, and assurance records.
+
+The launcher uses Go packages in [`internal/`](../internal) for structured
+policy, state, and metadata work. The shell file stays as orchestration glue.
+Go code owns authentication policy, credential resolution, injection, host
+state, sessions, target state, release helpers, and support-matrix evaluation.
+
+## Target and Support Model
+
+Durable session records store `target_kind`, `target_provider`,
+`target_assurance_class`, and `workspace_transport`. The launcher reports all
+fields in this table through diagnostics.
+
+| Field | Meaning |
+|---|---|
+| `target_kind` | Execution shape, such as `local_vm` or `local_compat` |
+| `target_provider` | Target implementation, such as `colima` |
+| `target_assurance_class` | Boundary class, such as `strict` or `compat` |
+| `support_matrix_status` | Support status for one host and target row |
+| `support_matrix_launch` | Whether operator launch is allowed |
+| `workspace_transport` | Method that moves the workspace into the target |
+
+An assurance class does not give support by itself. The host-support matrix is
+the only support decision source. Workcell does not select another target when
+the selected target is blocked.
+
+## Runtime Profiles
+
+The profiles under [`runtime/profiles/`](../runtime/profiles) define different
+runtime postures:
+
+| Profile | Purpose |
+|---|---|
+| `strict` | Default managed provider session |
+| `development` | Managed interactive development |
+| `build` | Image preparation and build work |
+| `breakglass` | Explicit higher-trust work with lower assurance |
+
+The launcher records an assurance reduction. It does not present all profiles
+as equivalent. `breakglass` requires operator acknowledgment.
+
+## Workspace and Mounts
+
+The launcher mounts the selected workspace at `/workspace`. It rejects broad
+default workspaces such as `/` and the operator home. Approved persistent-cache
+paths and narrow credential handoffs are separate mount classes.
+
+The safe path does not pass these host resources into the runtime:
+
+- The host home.
+- Docker or agent sockets.
+- Host keychains or credential stores.
+- Provider-state directories from the host.
+- Broad SSH, GPG, cloud, or GitHub authentication state.
+
+The safe path masks repository files that can take control of a provider or
+Git. Examples include provider settings, MCP settings, provider-state
+directories, Git hooks, and mutable Git configuration.
+
+Regular repository instruction files can enter a managed provider home as
+imported workspace input. Workcell does not require Git tracking for these
+imports. Codex imports `AGENTS.md`. Claude and Gemini import `AGENTS.md` and
+their native instruction file. Copilot imports no repository instruction file.
+
+## Authentication and Injection
+
+Workcell does not mount a live host credential store. It uses this host-owned
+sequence:
+
+1. Load the injection policy.
+2. Select the provider and runtime-mode scope.
+3. Resolve an approved source on the host, when a supported resolver exists.
+4. Render a staged bundle and its manifest.
+5. Mount the staged bundle at enumerated runtime paths.
+6. Build the managed provider home from approved material.
+
+Directly staged credentials are the primary supported path. Workcell also
+supports the resolver for Codex host-auth files. The Claude macOS keychain
+resolver is a fail-closed scaffold. It does not supply a launch credential.
+
+The injection schema controls input names, selectors, file modes, source types,
+and target paths. It blocks arbitrary writes to reserved provider-home paths.
+
+## Network Policy
+
+Managed Colima allowlist modes install rules in the VM. These rules apply to the
+whole Colima profile, not to one session. The most recent launch sets the
+profile policy. A `breakglass` launch clears the managed allowlist rules.
+
+The allowlist can include provider, target-broker, credential-derived,
+auth-recovery, validated policy, and profile endpoints. Ephemeral local launches
+can also include build and snapshot endpoints. It does not list all hosts that a
+session can reach. A deny rule can remove an endpoint from the effective session
+or bootstrap set.
+
+Rule replacement is not atomic. A failed replacement can leave the profile
+without the default-deny rule. Existing connections can continue after a more
+restrictive policy replaces the rule set. These are residual risks of the
+current profile-wide control.
+
+Docker Desktop reports `egress_enforcement=none`. Workcell does not claim VM
+egress enforcement for that target.
+
+## Container Start Sequence
+
+The runtime uses this control chain:
+
+1. [`entrypoint.sh`](../runtime/container/entrypoint.sh) validates the managed
+   environment and prepares runtime state.
+2. [`runtime-user.sh`](../runtime/container/runtime-user.sh) manages the mapped
+   host UID and GID.
+3. [`home-control-plane.sh`](../runtime/container/home-control-plane.sh) builds
+   the provider home under `/state/agent-home`.
+4. [`provider-wrapper.sh`](../runtime/container/provider-wrapper.sh) scrubs the
+   provider environment.
+5. [`provider-policy.sh`](../runtime/container/provider-policy.sh) rejects
+   prohibited provider flags and configuration changes.
+6. The selected provider binary starts.
+
+Mutable sessions start the entry point as root so that it can prepare runtime
+state. The entry point then changes to the mapped UID and GID. Read-only
+sessions start with the mapped UID and GID.
+
+The container launch uses capability removal, `no-new-privileges`, a process
+limit, controlled temporary filesystems, and a managed environment. The
+[Invariant Test Plan](../verify/invariants/README.md) and
+[Expected Controls](../verify/invariants/expected-controls.md) are the detailed
+control sources.
+
+## Provider Adapters
+
+Workcell supports Tier 1 command-line adapters for Codex, Claude Code, GitHub
+Copilot CLI, and Gemini CLI. Each adapter maps the provider's native home,
+settings, authentication inputs, and prohibited options.
+
+Workcell does not hide provider differences behind one common provider control
+plane. Use the [Provider Matrix](provider-matrix.md) for the exact mapping and
+current provider notes.
+
+## Exec Guard
+
+The Rust exec guard under [`runtime/container/rust/`](../runtime/container/rust)
+adds checks below the shell wrappers. It uses a libc preload interposer. On the
+strict path, it blocks direct native ELF files from mutable paths. It also
+blocks mutable shebang scripts that select a protected runtime. Workcell
+supplies guarded wrappers for tools such as Git and Node.
+
+The guard is defense in depth. A fully static process does not load the
+interposer for its own later `exec` call. `/workspace` does not have a kernel
+`noexec` mount. Thus, a fully static caller can make a direct `exec` call that
+this layer does not inspect. The container and VM boundaries stay in force. Use
+[Expected Controls](../verify/invariants/expected-controls.md) for the exact
+enforcement scope.
+
+## Detached Sessions
+
+The host owns detached session state. The operator can start, attach, send
+input, stop, list, show, delete, inspect logs, inspect a timeline, inspect a
+diff, export, and verify a session. The
+[operator contract](../policy/operator-contract.toml) is the authoritative
+command inventory.
+
+Detached sessions use a host-owned JSON record. The record includes identity,
+target, workspace, Git, process, log, time, and assurance data. Workcell stores
+new local Colima records in the Workcell-owned target-state tree. Compatibility
+reads accept the old Colima session path.
+
+The default workspace mode for a detached session creates an isolated host
+clone and branch for a supported Git workspace. The session plane uses files
+and host processes.
+It does not require a Workcell daemon or a trusted local socket.
+
+## Audit and Publication
+
+A real launch appends a host-owned audit record. Session finalization tries to
+sign a chained session head. Verification stops when the chain, seal, or public
+key is invalid. The [Signed Session Audit Records](signed-session-audit-records.md)
+page defines the exact guarantees and legacy limits.
+
+Repository publication is a host-side action. This repository uses
+`./scripts/repo-publish-pr.sh` after fresh local `pr-parity` evidence exists.
+The Tier 1 container does not receive ambient maintainer signing or GitHub
+publication state. Injection policy can stage reviewed GitHub authentication
+and configuration for runtime use, but pull-request publication stays a
+host-side workflow.
+
+## Verification Sources
+
+Use these sources for detailed claims:
+
+- [Threat Model](threat-model.md) for assets, attacks, controls, and residual
+  risks.
+- [Injection Policy](injection-policy.md) for the machine-checked injection
+  schema.
+- [Diagnostics and the Support Matrix](diagnostics-and-support-matrix.md) for
+  target decisions and output fields.
+- [Validation Scenarios](validation-scenarios.md) for test coverage.
+- [Provenance](provenance.md) and [Release Process](releasing.md) for release
+  controls.
 
 ## Current Limits
 
-The current architecture is intentionally narrower than the longer-term
-roadmap:
-
-- Apple Silicon macOS hosts only
-- no generally supported Workcell-managed cloud or remote worker plane today;
-  only the preview-only `remote_vm/aws-ec2-ssm/compat` and
-  `remote_vm/gcp-vm/compat` broker plans exist, and their live paths remain
-  certification-only
-- no centralized enterprise policy, session administration, or analytics plane
-- no queue, pause/resume, checkpoint, or fork model yet on the session plane
-- GUI and IDE surfaces are lower assurance unless they act only as clients to
-  the same bounded runtime
-- built-in auth resolver coverage remains narrow, with direct staged inputs as
-  the primary supported auth path plus Codex host-auth reuse and the
-  fail-closed Claude macOS scaffold
-- the strongest macOS boundary claim still depends on local validation rather
-  than GitHub-hosted CI alone
-
-## Light Comparison
-
-Compared with cloud-first or IDE-first agent systems, Workcell currently
-prioritizes:
-
-- explicit local runtime boundaries over remote execution
-- host-owned publication and signing over in-session repository publication
-- reviewed provider-home seeding over trusting repo-local mutable config as the
-  live control plane
-- explicit lower-assurance labeling over flattening all modes into one trust
-  story
-
-Roadmap direction such as broader session orchestration, deployment reach, and
-team-level administration lives in [`ROADMAP.md`](../ROADMAP.md), not in this
-architecture description.
+- Operator launch is supported only for the allowed macOS arm64 matrix rows.
+- Linux amd64 is a validation host, not an operator host.
+- Linux arm64 and Windows targets are unsupported.
+- AWS and GCP remote targets have preview rows on macOS arm64.
+- The Colima, AWS, and GCP Linux amd64 rows are `validation-host-only`.
+- Operator launch remains blocked for all these rows.
+- Apple `container` is preview-only and has no operator target value.
+- Workcell has no managed-workstation backend.
+- The session plane has no queue, pause, resume, checkpoint, or fork model.
+- The supported user interface is the CLI. GUI and IDE paths do not have the
+  Tier 1 claim.
+- The built-in resolvers support Codex host-auth reuse. The Claude macOS
+  keychain resolver stops without a credential.
+- Claims for the strict macOS boundary require live host certification.


### PR DESCRIPTION
## Summary

- Replace the oversized system-design page with a concise record of the current architecture.
- Align completed roadmap gates with maintained architecture documentation.
- Preserve support, security, and assurance limits while linking authoritative detail pages.

This change does not add a supported target, backend, or operator workflow.

## Validation

- `./scripts/ci/job-docs.sh`
- `env -u GIT_PAGER ./scripts/validate-repo.sh`
- `./scripts/pre-merge.sh --profile pr-parity`
- Six-role adversarial review with no remaining findings
