### PR TITLE
Rewrite benchmark evidence records

### DIFF
--- a/docs/b6-disposition-options-draft.md
+++ b/docs/b6-disposition-options-draft.md
@@ -1,197 +1,90 @@
-# B6 Real-Boundary Certification Lane — Disposition Options
+# B6 Apple Silicon Boundary Lane Decision
 
-**DECISION RECORDED (2026-07-09):** the maintainer chose to **defer the automated
-Apple-Silicon certification lane to post-1.0** — no funding or hosting for a
-self-hosted runner is available (the only Apple-Silicon host is the maintainer's
-own MacBook). In its place, 1.0 requires **local-operator certification of both
-launch boundaries (strict Colima + compat Docker Desktop) on that host**, and
-`ROADMAP.md` criterion 6 is amended accordingly. The assurance tradeoff — the
-live Colima/Apple-Silicon boundary is exercised locally by the maintainer rather
-than continuously in hosted CI (which runs only a Docker smoke lane on a
-`ubuntu-latest` runner) — is recorded in the amended criterion and the readiness
-review. The options and tradeoffs that informed this decision follow.
+## Decision
 
-B6 (a real-boundary certification lane on Apple Silicon runner infrastructure)
-was a human/funding decision, not an autonomous one. This document lays out the
-options, their tradeoffs against the merged evidence, and the recommendation the
-maintainer acted on.
+On 2026-07-09, the maintainer deferred the automated boundary lane for Apple
+Silicon until after 1.0.
 
-Context: B6 is defined in
-[improvement-tracks-implementation-plan.md → B6](improvement-tracks-implementation-plan.md)
-and is 1.0 release-criteria item 6 in
-[ROADMAP.md](../ROADMAP.md#10-release-criteria). Its stated exit gate is a
-scheduled lane that launches the strict Colima path and runs the certification
-smoke on a real Apple Silicon boundary, with the runner treated as lower-trust
-per the CI threat model (no repo secrets beyond scoped runner registration).
-Note a scope gap the maintainer should resolve: B6's *tracked step wording* names
-only the strict Colima path, but ROADMAP criterion 3 requires BOTH supported
-Apple Silicon launch boundaries certified on the release matrix — strict Colima
-AND docker-desktop compat (`policy/host-support-matrix.tsv`). So the
-real-boundary evidence surface B6 must ultimately cover is both boundaries, not
-Colima alone; whichever option is chosen must account for both.
+The project did not fund or operate a self-hosted runner. The only available
+Apple Silicon system was the maintainer workstation.
 
-Prepared 2026-07-08 against `main`. Verified: no self-hosted Apple Silicon
-runner lane exists on `main` today. Do NOT conflate two different backends when
-weighing the B6 go/no-go:
+The maintainer changed release criterion 6 for 1.0. It now requires local
+operator certification of both supported launch targets:
 
-- **There are TWO supported, launch-allowed 1.0 operator boundaries on Apple
-  Silicon macOS** (`policy/host-support-matrix.tsv`; both `supported`/`allowed`),
-  and ROADMAP criterion 3 requires BOTH certified on the release matrix:
-  `macos/arm64/local_vm/colima/strict` (the strict Colima VM+container path) and
-  `macos/arm64/local_compat/docker-desktop/compat` (the lower-assurance Docker
-  Desktop compat path). The real-boundary evidence for both is the
-  **local-operator certification** lane — a live containerized launch on real
-  Apple Silicon hardware (the scenario suite under `tests/scenarios/`, driven by
-  `scripts/run-scenario-tests.sh`, run on real hardware rather than a hosted
-  runner), recorded per `docs/install-lifecycle.md` (§"Local-operator /
-  published-release remainder"). **The B6 lane scope therefore covers BOTH
-  boundaries**, not Colima alone; it is NOT the C1 evaluation.
-- **C1 was the Apple `container` BACKEND evaluation** — a *different* backend
-  that is preview/launch-blocked and NOT one of the two supported launch
-  boundaries above (`docs/apple-container-evaluation.md`). Its macOS 26.5.1
-  capture is evidence about the apple-container preview, not about either
-  supported boundary, and must not be read as strict-Colima or compat
-  certification.
+- `macos/arm64/local_vm/colima/strict`
+- `macos/arm64/local_compat/docker-desktop/compat`
 
-CI today does NOT run either live boundary: the hosted runtime exercise is the
-`container-smoke` job on `ubuntu-latest` running `./scripts/container-smoke.sh`
-under **Docker** (a hosted Docker container-smoke lane), and the
-`trusted-linux-amd64-validator` lane (`policy/host-support-matrix.tsv`) is
-`validation-host-only`/`blocked` — neither is a live macOS VM-plus-container
-boundary. Both the strict-Colima and docker-desktop-compat operator boundaries
-are exercised ONLY by local-operator certification, never in hosted CI.
+The project completed those certifications before 1.0. The current release
+keeps the same boundary evidence model.
 
-## What "real-boundary" means for the supported tier
+## What the decision did not change
 
-The supported, launch-allowed operator boundaries are BOTH
-`macos/arm64/local_vm/colima/strict` and
-`macos/arm64/local_compat/docker-desktop/compat` (both `supported`/`allowed` in
-`policy/host-support-matrix.tsv`; ROADMAP criterion 3 requires both certified).
-Hosted CI cannot exercise either today: GitHub-hosted macOS runners do not offer
-the nested virtualization the Colima VM (or a Docker Desktop VM) needs, and the
-Linux `amd64` validators run a *different* host architecture. What hosted CI does
-run is a Docker container-smoke lane on `ubuntu-latest`, not either macOS
-boundary. So the gap B6 closes is: **a scheduled, real Apple-Silicon-macOS launch
-in CI across both supported boundaries** (strict Colima and docker-desktop
-compat), versus the current local-operator certification of those paths.
+Both targets remain supported and launch-allowed on macOS in
+`policy/host-support-matrix.tsv`.
 
-## Option A — Fund/provision a self-hosted Apple Silicon runner
+The Apple `container` target is a different target. It remains preview-only and
+has no operator launch path. Its evaluation does not certify Colima or Docker
+Desktop.
 
-Stand up self-hosted Apple Silicon macOS runner infrastructure and implement the
-scheduled certification lane B6 describes.
+## Hosted evidence limit
 
-**What 1.0 gains:**
+GitHub-hosted CI does not launch either supported runtime boundary on macOS.
 
-- A recurring, real launch across both supported boundaries (strict Colima and
-  docker-desktop compat) in CI, catching regressions the local-operator cert
-  would only catch out-of-band.
-- Fully satisfies release-criteria item 6's B6 clause as written.
-- Continuous evidence for the Apple `container` promotion path (C1 → B6), which
-  is currently deferred post-1.0 precisely because this lane does not exist.
+| Hosted lane | Evidence | Limit |
+|---|---|---|
+| `container-smoke` on `ubuntu-latest` | Container controls and deterministic invariants | Not a macOS VM boundary |
+| `trusted-linux-amd64-validator` | Repository, policy, and scenario validation | Validation-host-only target |
+| `install-verification` on `macos-15` and `macos-26` | Install and uninstall behavior | No Colima or Docker Desktop VM launch |
 
-**Costs and security tradeoffs:**
+Thus, local operator certification supplies the live boundary evidence. Hosted
+CI supplies deterministic and install evidence.
 
-- **Funding + ops:** dedicated Apple Silicon hardware (or a paid hosted
-  Apple-Silicon runner service), plus lifecycle ownership (patching, runner
-  registration rotation, availability).
-- **Trust tier:** per the CI/CD threat model (B9), a self-hosted runner is
-  **lower-trust** than the hosted control plane. It must carry **no repo secrets
-  beyond scoped, rotatable runner registration**, run untrusted PR code only
-  under the documented isolation, and never gain signing authority (host-side
-  signing stays off the runner). This must be documented in the threat model as
-  part of the exit gate.
-- **Blast radius:** a compromised self-hosted runner is a foothold; the mitigation
-  is ephemerality (fresh VM per job), least privilege, and no long-lived
-  credentials — all of which add ops cost.
+## Options that the maintainer considered
 
-## Option B — Amend criterion 6 to defer the hosted real-boundary lane post-1.0
+### Option A: self-hosted Apple Silicon runner
 
-Option B is NOT an auto-satisfied checkbox. Release-criteria item 6 REQUIRES a
-real-boundary certification lane (B6) *in place*; the roadmap does not list B6
-among the gaps that "explicit disposition" alone can satisfy (that
-explicit-disposition allowance is scoped to the SLSA L3 gaps, separately). So
-choosing Option B means the maintainer must **amend release-criteria item 6** —
-an explicit, recorded criterion change / scope reduction — to defer the hosted
-real-boundary Apple Silicon lane to post-1.0, accepting the reduced assurance
-stated below. This is a real decision the maintainer owns, not a box the draft
-can tick.
+If the project selects this option, the lane will run both supported macOS
+targets on a schedule.
 
-Under the amended criterion, 1.0 would ship with the existing **hosted Docker
-smoke lane** plus **local-operator certification** of both supported Apple
-Silicon boundaries (strict Colima and docker-desktop compat), and B6 (the hosted
-real-boundary Apple Silicon lane) would move to post-1.0.
+The lane will improve regression detection. It will also add runner
+maintenance, availability, and security work.
 
-**What 1.0 keeps:**
+The runner will be a lower-trust system. It must run one job. The workflow must
+then replace it. The workflow must use trusted scheduled triggers and
+`permissions: {}`. It must have no OIDC authority or environment secrets. It
+must not hold release signing authority. A short-lived credential for scoped
+runner registration is the only permitted repository credential.
 
-- Both reviewed boundaries (strict Colima and docker-desktop compat) are still
-  certified — via local-operator certification on real Apple Silicon macOS.
-- Hosted CI still exercises the containment logic and all deterministic
-  invariants: the container-smoke lane runs the runtime image under **Docker on
-  a GitHub-hosted `ubuntu-latest` runner**, and the Linux `amd64` validators run
-  verify-invariants, the Go engine, and the scenario corpus.
-- No new lower-trust runner attack surface is introduced before 1.0.
+### Option B: local certification
 
-**What 1.0 loses / accepts (the assurance tradeoff the amendment accepts):**
+This option keeps live certification on an operator-controlled Apple Silicon
+system. It does not add the attack surface of a self-hosted runner.
 
-- **Neither live macOS boundary (strict Colima or docker-desktop compat) is
-  exercised in hosted CI at all.** The repo does use GitHub-hosted runners of
-  both kinds, but neither exercises a live boundary: the hosted **Linux** runners
-  (`ubuntu-latest`) run the Docker `container-smoke` lane, and the hosted
-  **macOS** runners (`macos-26`, `macos-15`, the `install-verification` matrix in
-  `.github/workflows/ci.yml`) cover install/uninstall mechanics only. Hosted
-  macOS runners cannot run the Colima or Docker Desktop VM either — GitHub-hosted
-  macOS runners do not expose the nested virtualization those VMs need — so they
-  prove install plumbing, not the VM-plus-container boundary. Net: hosted Linux =
-  Docker container-smoke; hosted macOS = install-verification only; both live
-  macOS boundaries = local-operator certification only. Regressions on either
-  supported path are caught by local-operator certification cadence, not by every
-  scheduled CI run.
-- Release-criteria item 6 is met only by a **recorded amendment** that removes
-  the in-place B6 requirement for 1.0 — not by an implemented lane, and not by
-  an auto-permitted deferral. The amendment and its assurance tradeoff MUST be
-  recorded as a scope decision in the G4 review.
-- Apple `container` promotion stays blocked post-1.0 (it already is, per C1).
+It has lower assurance than a continuous hosted lane. A boundary regression can
+remain undetected until the next local certification.
 
-## Recommendation — chosen: Option B (recorded 2026-07-09)
+## Recorded result
 
-**The maintainer chose Option B** (see the DECISION RECORDED banner at the top):
-criterion 6 is amended to defer the hosted real-boundary lane, with B6 (Option A)
-scheduled as the first post-1.0 assurance item; 1.0 relies on local-operator
-certification of both supported boundaries. The recommendation that informed it
-was:
+The maintainer selected Option B. The 1.0 readiness review records the criterion
+change and the completed local certifications.
 
-**Recommended: Option B for 1.0 — amend criterion 6 to defer the hosted
-real-boundary lane, with B6 (Option A) scheduled as the first post-1.0 assurance
-item** — *if and only if* the maintainer is willing to make that recorded
-criterion amendment and judges local-operator certification of both supported
-Apple Silicon boundaries (strict Colima and docker-desktop compat) sufficient
-boundary evidence for the 1.0 claim.
+B6 remains a post-1.0 improvement. It is not a condition of the current support
+claim.
 
-Rationale grounded in the evidence:
+## Future B6 exit gate
 
-1. 1.0 is a contract-stability and assurance claim, not a platform-reach claim
-   (ROADMAP "Path To 1.0"). Both supported boundaries are certified through the
-   local-operator discipline — but that certification is a pending 1.0 checklist
-   item (it must be run and confirmed on the release matrix for both boundaries,
-   not assumed already complete); B6 improves the *cadence and automation* of
-   that signal, not the boundaries' correctness.
-2. Option A introduces a lower-trust runner attack surface. Standing it up
-   *before* 1.0 adds security-ops burden and threat-model work to the exact
-   window where the contract surface is being frozen — the opposite of what the
-   freeze wants.
-3. Criterion 6 as written requires B6 in place, so Option B is a genuine
-   scope-reduction decision, not a free deferral. Recommending it means
-   recommending that the maintainer amend the criterion with the assurance
-   tradeoff recorded — it is honest precisely because it is presented as a
-   criterion change the maintainer owns, not a box the draft ticks.
-4. B6 is genuinely valuable and should be the first post-1.0 assurance lane
-   (it also unblocks the deferred Apple `container` promotion), so Option A is
-   "scheduled," not "dropped."
+A future automated lane must meet these conditions:
 
-**Pick Option A instead if** the maintainer judges that a 1.0 security-boundary
-product must show a *continuous hosted* real-boundary lane (not a periodic
-local-operator cert) to meet buyer expectations, and funding/ops for a
-lower-trust Apple Silicon runner is available before the freeze.
+1. It runs on a physical macOS host with Apple Silicon.
+2. It launches both supported macOS targets.
+3. It uses an isolated and replaceable runner.
+4. It runs one job before replacement.
+5. It uses trusted scheduled triggers and `permissions: {}`.
+6. It has no OIDC authority or environment secrets.
+7. It has no release signing authority.
+8. It has no repository credential except scoped runner registration.
+9. It records the exact commit, control tree, host, and result.
+10. It updates the CI threat model and operator documentation.
 
-Either way, the decision and its evidence basis must be recorded in the G4
-readiness review (see `docs/1.0-readiness-review.md` §6).
+See the [1.0 readiness review](1.0-readiness-review.md) for the release record.
+See the [Roadmap](../ROADMAP.md) for the current B6 status.

--- a/docs/benchmark-evidence/c3-two-container-isolation-2026-07-15.md
+++ b/docs/benchmark-evidence/c3-two-container-isolation-2026-07-15.md
@@ -1,21 +1,18 @@
-# C3 — two-session isolation evidence
+# C3 Two-Session Isolation Evidence
 
-Auditable evidence for the C3 isolation run recorded in
-[`../1.0-readiness-review.md`](../1.0-readiness-review.md) §6 Platform
-row. Two same-repo detached sessions were started with `--session-workspace
-isolated` on `macos/arm64/local_vm/colima/strict` (profile `wcl-workcell-006e49ec`),
-then `session show` was captured for each.
+This record contains a preliminary capture from 2026-07-15 and a certified run
+from 2026-08-03.
 
-> **Not a concurrent run.** The two sessions started **33 s apart** (19:36:40 vs
-> 19:37:13, below) and each taskless `codex` session exits within seconds, so
-> session A had already exited before session B started — they did **not** overlap
-> in time. This evidence therefore shows that the isolation *scheme* assigns
-> **distinct** containers/worktrees/branches to two sessions, but it does **not**
-> establish a live **concurrent** two-container run. This was the historical
-> 2026-07-15 conclusion. The 2026-08-03 certification below closes that
-> evidence gap with overlapping keepalive sessions.
+## Preliminary capture
 
-## Invocation
+The first capture started two isolated detached sessions on
+`macos/arm64/local_vm/colima/strict`.
+
+The sessions started 33 seconds apart. They did not overlap. The capture shows
+different container, worktree, and branch identifiers. It does not show
+concurrent isolation.
+
+### Preliminary command
 
 ```sh
 export REPO="$HOME/src/workcell"   # a clean git worktree
@@ -25,60 +22,59 @@ export REPO="$HOME/src/workcell"   # a clean git worktree
 for id in <ID1> <ID2>; do ./scripts/workcell session show --id "$id"; done
 ```
 
-## Captured `session show` fields (verbatim; home path generalized to `$HOME`)
+### Captured fields
 
-Session A — `20260715T193632Z-f4226b4e`:
+These normalized fields preserve the captured values. They do not preserve the
+command output format.
 
-```text
-"session_id":            "20260715T193632Z-f4226b4e"
-"target_provider":       "colima"
-"target_assurance_class":"strict"
-"status":                "failed"
-"workspace_root":        "$HOME/src/workcell"
-"worktree_path":         "$HOME/src/workcell/.git/workcell-sessions/20260715T193632Z-f4226b4e/repo"
-"git_branch":            "workcell/session-20260715T193632Z-f4226b4e"
-"container_name":        "workcell-codex-strict-repo-557c91b5"
-"started_at":            "2026-07-15T19:36:40Z"
-```
-
-Session B — `20260715T193705Z-2ae8e294`:
+Session A:
 
 ```text
-"session_id":            "20260715T193705Z-2ae8e294"
-"target_provider":       "colima"
-"target_assurance_class":"strict"
-"status":                "failed"
-"workspace_root":        "$HOME/src/workcell"
-"worktree_path":         "$HOME/src/workcell/.git/workcell-sessions/20260715T193705Z-2ae8e294/repo"
-"git_branch":            "workcell/session-20260715T193705Z-2ae8e294"
-"container_name":        "workcell-codex-strict-repo-0e6b0d64"
-"started_at":            "2026-07-15T19:37:13Z"
+session_id=20260715T193632Z-f4226b4e
+target_provider=colima
+target_assurance_class=strict
+status=failed
+workspace_root=$HOME/src/workcell
+worktree_path=$HOME/src/workcell/.git/workcell-sessions/20260715T193632Z-f4226b4e/repo
+git_branch=workcell/session-20260715T193632Z-f4226b4e
+container_name=workcell-codex-strict-repo-557c91b5
+started_at=2026-07-15T19:36:40Z
 ```
 
-## What this establishes — and what it does not
+Session B:
 
-- **Distinct** `container_name`, `worktree_path`, and `git_branch` under one shared
-  `workspace_root` → **structural** worktree-per-agent isolation on the strict path.
-- `status: failed` is expected here: a detached `codex` started with no task exits
-  non-zero within seconds. It does not affect the isolation attributes above, which
-  are assigned at session-start time.
-- This preliminary capture is **structural** evidence only. It does **not**
-  perform the runtime
-  non-interference check required by
-  [`../safe-path-expectations.md`](../safe-path-expectations.md). The certified
-  2026-08-03 run below performs that check.
+```text
+session_id=20260715T193705Z-2ae8e294
+target_provider=colima
+target_assurance_class=strict
+status=failed
+workspace_root=$HOME/src/workcell
+worktree_path=$HOME/src/workcell/.git/workcell-sessions/20260715T193705Z-2ae8e294/repo
+git_branch=workcell/session-20260715T193705Z-2ae8e294
+container_name=workcell-codex-strict-repo-0e6b0d64
+started_at=2026-07-15T19:37:13Z
+```
 
-## Certified concurrent run (2026-08-03)
+In this capture, a detached Codex session without a task exited with a failure
+status. The result did not change the resource identifiers that Workcell
+assigned at session start.
 
-This local-operator certification ran on
-`macos/arm64/local_vm/colima/strict`. It is bound to signed activation commit
-`a26b750f8d8c7957fc15a3f5c164c2df28f25b46` and its exact control-plane tree
-`726f485a609b88edcee7ee5ad88692d7aafdd501`. The certification was performed
-before merge. This evidence record is not itself a shipped-status claim; verify
-that the activation commit is reachable from `main` before treating it as
-shipped.
+## Certified concurrent run
 
-The exact-tree run used the new maintainer entrypoint:
+The maintainer ran the C3 certifier on 2026-08-03. The target was
+`macos/arm64/local_vm/colima/strict`.
+
+The evidence binds to these Git objects:
+
+| Item | Value |
+|---|---|
+| Signed activation commit | `a26b750f8d8c7957fc15a3f5c164c2df28f25b46` |
+| Control-plane tree | `726f485a609b88edcee7ee5ad88692d7aafdd501` |
+| Clean workload commit | `cc6bc6f8310d1f65ef03007024d4ec2e3f57fe7b` |
+
+The activation commit is reachable from `main`.
+
+### Command
 
 ```sh
 ./scripts/certify-c3-parallel-sessions.sh \
@@ -86,45 +82,46 @@ The exact-tree run used the new maintainer entrypoint:
   --precommit-control-tree 726f485a609b88edcee7ee5ad88692d7aafdd501
 ```
 
-The certifier used clean workload commit
-`cc6bc6f8310d1f65ef03007024d4ec2e3f57fe7b` and recorded:
+### Recorded result
 
 ```text
-date (UTC): 2026-08-03T18:17:15Z
-Workcell launcher SHA-256: e414864af41a89527582c891bb777f513816b2cccbfd63a48106e0f8fab0126d
-Docker client SHA-256: 49d98ab806e8678cd6341b09dad6389e5bcd8a46513de7651053bee3d8366e8d
-target: local_vm/colima/strict
-profile: wcl-c3-2305439552
-session A: 20260803T181448Z-82c58950
-container A: workcell-codex-strict-repo-e90ea0c8
-branch A: workcell/session-20260803T181448Z-82c58950
-session B: 20260803T181648Z-57e2dd25
-container B: workcell-codex-strict-repo-8b984979
-branch B: workcell/session-20260803T181648Z-57e2dd25
+date_utc=2026-08-03T18:17:15Z
+launcher_sha256=e414864af41a89527582c891bb777f513816b2cccbfd63a48106e0f8fab0126d
+docker_client_sha256=49d98ab806e8678cd6341b09dad6389e5bcd8a46513de7651053bee3d8366e8d
+target=local_vm/colima/strict
+profile=wcl-c3-2305439552
+session_a=20260803T181448Z-82c58950
+container_a=workcell-codex-strict-repo-e90ea0c8
+branch_a=workcell/session-20260803T181448Z-82c58950
+session_b=20260803T181648Z-57e2dd25
+container_b=workcell-codex-strict-repo-8b984979
+branch_b=workcell/session-20260803T181648Z-57e2dd25
 ```
 
-The exact worktree paths were certifier-owned isolated paths under the temporary
-workload clone. They are intentionally generalized here rather than publishing
-the maintainer host's private temporary-directory prefix.
+The certifier proved these properties:
 
-The certifier proved all of the following in one run:
+- Both sessions ran at the same time.
+- Each session had a different container, worktree, and branch.
+- A marker from session A did not occur in session B.
+- A marker from session B did not occur in session A.
+- Each marker occurred in its own session and host worktree.
+- Each container workspace matched its recorded host worktree.
+- Session A stopped while session B continued to run.
+- Cleanup removed both session records, containers, and isolated worktrees.
+- Cleanup removed the certifier Colima profile, target state, and image cache.
+- The control-plane tree did not change during certification.
 
-- sessions A and B overlapped and had distinct containers, isolated worktrees,
-  and branches;
-- a marker written through container A's `/workspace` was present in A's
-  recorded host worktree and absent from both container B and B's host
-  worktree; the symmetric B-to-A check also passed;
-- each container's `/workspace` matched its recorded host worktree;
-- session A stopped independently while session B remained running;
-- both session records, containers, and isolated worktrees were removed; and
-- the certifier-owned Colima profile, target state, and runtime-image-cache
-  entries were removed.
+An independent audit found no process or inventory entry for the exact profile.
+It found no Colima, profile, target, or cache path for that profile. It found no
+state-root name for either session or the profile. The audit also confirmed
+that the certified control-plane tree did not change.
 
-An independent post-run audit then found no exact profile process or Colima
-inventory entry, no exact Colima/profile/target/cache path, and no state-root
-name matching either session or the profile. It also confirmed the certified
-control-plane tree was unchanged.
+## Limit
 
-Scope limitation: the sessions used Workcell's explicitly acknowledged
-arbitrary-command keepalive path. This certifies the parallel strict runtime
-boundaries and lifecycle behavior; it does not certify provider interaction.
+The sessions used the acknowledged keepalive path for arbitrary commands. The run
+certifies parallel runtime boundaries and lifecycle behavior. It does not
+certify provider interaction. Both containers shared one Colima VM and kernel.
+This run does not certify VM-level separation.
+
+See the [safe-path expectations](../safe-path-expectations.md) for the C3
+requirement.

--- a/docs/benchmark-evidence/session-startup-2026-07-15.md
+++ b/docs/benchmark-evidence/session-startup-2026-07-15.md
@@ -1,36 +1,28 @@
-# C2 session-start latency — raw capture (2026-07-15)
+# C2 Session-Start Raw Capture: 2026-07-15
 
-Raw generated report from the Batch-3 local-operator capture, preserved verbatim
-for reproducibility and audit. The published, interpreted result lives in
-[`../session-startup-benchmarks.md`](../session-startup-benchmarks.md#results);
-this file is the underlying evidence, including the `cache-hit` samples that are
-**not** promoted to a published tier (see that doc for why).
+This file preserves the preliminary Batch 3 capture. The interpreted result is
+in [Session-Start Benchmarks](../session-startup-benchmarks.md#results).
 
-## Exact invocation
+Do not use this capture as C2 certification. The capture has four known
+confounds.
 
-Driver: `scripts/bench/run-startup-bench.sh` (see
-[`../session-startup-benchmarks.md`](../session-startup-benchmarks.md#rerunning)).
-Environment for this capture (paths generalized; `$REPO` = the workspace,
-`$WCL_PROFILE` = `wcl-workcell-006e49ec`):
+## Invocation
 
-Shown **exactly as run** on 2026-07-15 (interactive zsh). The `WORKCELL_*`
-variables were `export`ed; the per-sample teardown was a shell **function**
-exported via `export -f` — a bash builtin that is a **no-op under zsh**, so the
-teardown never reached the driver's sub-shell and did not run between samples
-(recorded as a confound below):
+The operator used `./scripts/bench/run-startup-bench.sh` in an interactive Zsh
+session.
+The paths below use `$HOME` in place of the operator home.
 
 ```sh
-export REPO="$HOME/src/workcell"    # the workspace under test
-export WCL_PROFILE="wcl-workcell-006e49ec"   # the derived managed colima profile
+export REPO="$HOME/src/workcell"
+export WCL_PROFILE="wcl-workcell-006e49ec"
 
-# teardown: intended to run before each cold/cache-hit sample
 cleanup_sessions() {
   ./scripts/workcell session list 2>/dev/null | awk 'NR>1{print $1}' | while read -r id; do
-    ./scripts/workcell session stop   --id "$id" >/dev/null 2>&1 || true
+    ./scripts/workcell session stop --id "$id" >/dev/null 2>&1 || true
     ./scripts/workcell session delete --id "$id" >/dev/null 2>&1 || true
   done
 }
-export -f cleanup_sessions   # <-- silently a no-op under zsh; teardown never reached the driver
+export -f cleanup_sessions
 
 export WORKCELL_STARTUP_CMD='./scripts/workcell session start --agent codex --workspace $REPO --session-workspace direct'
 export WORKCELL_STARTUP_COLD_PREP='cleanup_sessions; DOCKER_HOST="unix://$HOME/.colima/$WCL_PROFILE/docker.sock" docker image rm -f workcell:local'
@@ -41,40 +33,30 @@ export WORKCELL_STARTUP_RUNS=2
 export WORKCELL_STARTUP_STABILITY_PCT=15
 ```
 
-For a clean recapture the teardown must actually run: invoke the driver under
-**bash** (so `export -f` works), or — because the driver `eval`s each prep hook
-once, so pipe/loop operators produced by expanding a nested `$VAR` are **not**
-re-parsed as operators — **inline the teardown pipeline literally in each
-`*_PREP` hook** or call a committed script. A real persistent kept-warm session
-must also be established for the `warm` tier (see confounds).
+The operator then ran the benchmark driver.
 
-## Provenance caveats — this is a PRELIMINARY, confounded capture
+## Known confounds
 
-- The measured command is a detached `session start`, which returns once the
-  session monitor is ready (a no-task `codex` then exits shortly after, in the
-  background — it does not affect the start-to-ready latency the harness times).
-- **No persistent kept-warm session.** `WARM_PREP` starts a detached session, but a
-  no-task `codex` exits within seconds, so no kept-warm session existed during the
-  `warm` samples. The `warm` tier therefore measures an **image-resident start**, not
-  the documented kept-warm lane — the `cold`→`warm` delta is an image-restore cost,
-  not a warm-lane win.
-- **`cold` is a tarball restore, not a first build.** `COLD_PREP` evicts only the
-  Docker image; Workcell's local image tarball remains, so `cold` reloads from the
-  tarball + boots. A no-tarball first-ever start additionally runs the one-time
-  `buildx` build (excluded here).
-- **Per-sample teardown did not actually run.** `$CLEAN` was exported as a shell
-  function via `export -f` under zsh (a bash-only builtin), so it did not reach the
-  harness sub-shell and no session teardown ran between samples. Detached no-task
-  sessions self-terminate within seconds, so live sessions did not accumulate across
-  the ~15 s inter-sample gaps — but this is an additional reason the capture is
-  preliminary, and a candidate contributor to the `cache-hit` anomaly.
-- **`cache-hit` is a real, unresolved anomaly — not noise.** The `cache-hit` medians
-  below (23.75 s / 24.73 s) are ~50–55% **slower** than `cold` (15.86 s / 15.96 s)
-  with no overlapping range. Running `--prepare-only` before each sample makes the
-  next start slower than evicting the image — counter-intuitive and **unexplained**.
-  Preserved here for investigation; not used to draw a published conclusion.
+| Confound | Effect |
+|---|---|
+| Zsh did not export the Bash function. | Per-sample session cleanup did not run. The taskless sessions stopped before the approximately 15-second gaps ended. |
+| The taskless warm session exited. | The warm samples measured an image-resident start, not a kept-warm session. |
+| The cold hook kept the local image archive. | Cold samples measured archive restore and boot, not a first build. |
+| Cache-hit samples were slower than cold samples. | The cause remains unknown, so no performance conclusion uses that tier. |
 
-## Generated report (verbatim)
+The benchmark measures the return from detached `session start`. The command
+returns when the session monitor is ready.
+
+For a new capture, set the preparation variable for each selected mode to an
+executable path. Set `WORKCELL_STARTUP_TEARDOWN` and
+`WORKCELL_STARTUP_TEARDOWN_VERIFY` to executable paths. If you select `warm`,
+also set `WORKCELL_STARTUP_WARM_PREP` and
+`WORKCELL_STARTUP_WARM_VERIFY` to executable paths. Put the measured executable
+and its arguments after `--`.
+
+## Generated report
+
+The data below preserves the generated report labels and values.
 
 - date (UTC): 2026-07-15T12:09:05Z
 - host: Darwin 25.5.0 arm64
@@ -108,3 +90,5 @@ must also be established for the `warm` tier (see confounds).
 | warm | 13457187000 | 13543427000 | 86240000 | 0.6 | STABLE |
 
 Stability gate: STABLE (max cross-run median spread 4.1% <= 15%).
+
+This stability result does not remove the confounds above.


### PR DESCRIPTION
## Summary

- Simplify the B6 disposition to the recorded decision and evidence boundary.
- Rewrite the C3 record to separate captured values from command output format.
- Rewrite the C2 record with the executable benchmark invocation and known limits.

## Validation

- `./scripts/ci/job-docs.sh`
- `env -u GIT_PAGER ./scripts/validate-repo.sh`
- `./scripts/pre-merge.sh --profile pr-parity`
- Independent Terra review: dry
