### PR TITLE
Rewrite launcher and session guidance

### DIFF
--- a/docs/launcher-contract.md
+++ b/docs/launcher-contract.md
@@ -1,425 +1,221 @@
-# Launcher contract
-
-`scripts/workcell` is the host-side launcher. Historically it was a single
-monolithic script; roadmap item D4 decomposes it into small, sourced,
-behaviour-preserving modules under `scripts/lib/launcher/`. The launcher
-sources each module from its `source "${ROOT_DIR}/scripts/lib/..."` block
-(after `ROOT_DIR` is resolved) so every extracted helper is defined before its
-first call site.
-
-This document records the contract of each extracted module. It will grow as
-further modules are pulled out of the launcher.
-
-## Launcher reference
-
-The sections below record the cross-cutting launcher contract that the module
-sections then refine: the trusted host tools it requires, the environment it
-pins and scrubs, the exit codes it uses, and the harness-only override flags it
-recognises. Every claim here is derived from `scripts/workcell`,
-`scripts/lib/launcher/*.sh`, and `scripts/lib/*.sh`.
-
-### Required host tools
-
-The launcher avoids bare, unpinned `PATH` lookups for host binaries: every host
-tool is either absolute-resolved or run by name on the pinned `TRUSTED_HOST_PATH`
-(never an inherited `PATH`). Most tools (`go`, `colima`, `docker`, and `git`'s
-`HOST_GIT_BIN`) are absolute-resolved through one of two resolvers, both of which
-abort the launch (printing `Missing trusted host tool: <name>` to stderr and
-exiting `1`) when no trusted candidate is executable; a couple (`git` and `curl`
-via `run_clean_host_command`) are instead run by name on `TRUSTED_HOST_PATH`, as
-the rows and notes below detail. The two resolvers are:
-
-- `resolve_fixed_host_tool <name> <candidate>...`
-  (`scripts/lib/launcher/host-exec.sh`) returns the first caller-supplied candidate
-  that is executable (`-x`) — no `PATH` fallback, but also **no canonicalisation**:
-  it trusts the literal candidate path as written, so a fixed candidate that is a
-  symlink is followed by the kernel without re-validating the target. Trust here
-  rests on those hard-coded paths not being attacker-writable.
-- `resolve_host_tool <name> <candidate>...` (`scripts/workcell`) tries the fixed
-  candidates first, then falls back to `type -P <name>`, but every path **and its
-  canonicalised form** must pass `is_trusted_host_tool_path` before it is accepted
-  (`workcell:6660-6661`), so it cannot resolve to a target outside the trusted
-  prefixes. Its `resolve_host_tool_optional` sibling is identical but returns `1`
-  instead of aborting, so it is used for non-fatal capability probes.
-
-| Tool | Resolver | Candidate paths | Purpose |
-| --- | --- | --- | --- |
-| `go` | `resolve_fixed_host_tool` (`go-hostutil.sh:29`) | `/opt/homebrew/bin/go`, `/usr/local/go/bin/go`, `/usr/local/bin/go`, `/usr/bin/go` | Runs the `workcell-hostutil` and `workcell-colimautil` Go programs via `go run` (see `HOST_GO_BIN`). |
-| `colima` | `resolve_host_tool` (`workcell:625,670,5492`); `resolve_host_tool_optional` probe (`workcell:6713`) | `/opt/homebrew/bin/colima`, `/usr/local/bin/colima` | Manages the Colima VM profile that backs the container runtime (`HOST_COLIMA_BIN`). |
-| `docker` | Fail-closed `resolve_host_tool`: a transient `HOST_DOCKER_BIN="docker"` default (`workcell:8136`) is **overridden** by `prepare_current_target_docker_client` (called in the main launch path at `workcell:8352`), which resolves it to an absolute, canonical-validated path (`resolve_host_tool docker`, `workcell:866`) before any Docker use; other sub-paths probe with `resolve_host_tool_optional` (`workcell:850,1663,6721`) | `/opt/homebrew/bin/docker`, `/usr/local/bin/docker`, `/Applications/Docker.app/Contents/Resources/bin/docker` | Drives the container runtime (`HOST_DOCKER_BIN`), run via `run_workcell_docker_client_command` (`trusted-docker-client.sh:151`). |
-| `git` | `resolve_host_tool` → absolute `HOST_GIT_BIN` (`workcell:4462,8135`); **also** invoked by name via `run_clean_host_command` (`workcell:7092,7163,7190,7213,7232,7372`) | `/usr/bin/git`, `/opt/homebrew/bin/git`, `/usr/local/bin/git` | Inspects and extracts the launch workspace repository. |
-| `curl` | **sanitised-PATH by name only** (no absolute resolve) via `run_clean_host_command` (`workcell:6241,6270`) | found on `TRUSTED_HOST_PATH` inside the sanitised `env -i` | Best-effort `HEAD` preflight for release URLs; **optional** — absence is swallowed (`\|\| true`), not fatal. |
-
-A resolver-backed tool that is absent aborts the launch rather than falling back
-to an attacker-controlled binary — but the resolvers differ in strength, as above:
-`resolve_host_tool` (`colima`, `docker`, and `git`'s `HOST_GIT_BIN`) validates the
-canonical target, while `resolve_fixed_host_tool` (`go`) trusts its literal fixed
-paths. Two tools are instead run **by name on the sanitised `TRUSTED_HOST_PATH`**
-rather than absolute-resolved: `git` (in its `run_clean_host_command` uses) and
-`curl`. These stay confined to the trusted `PATH` but are **not**
-canonical-target-validated and **not** fail-closed — e.g. a missing `curl` leaves
-the preflight URL empty rather than raising `Missing trusted host tool`, so `curl`
-is optional, not required.
-
-`go` additionally has a **second, differently-scoped** resolution path: the
-`--audit-transcript` PTY helper (`scripts/lib/pty_transcript`, `workcell:8778`)
-sources `go-run-env.sh`, whose Go-binary resolver honours a pre-set
-`WORKCELL_GO_BIN`, then `command -v go`, then the fixed candidates
-(`go-run-env.sh:47-71`). Like the fixed resolver it is **fail-closed** — it exits
-`1` with `Missing required tool: go` when none is found (`go-run-env.sh:66-68`) —
-but it is **not confined to fixed trusted paths** (a `command -v go` hit is
-accepted) and `WORKCELL_GO_BIN` is not in the scrub list, so on the
-shebang-bypassed `bash` path an inherited `WORKCELL_GO_BIN` can select the `go`
-used for the transcript.
-
-This table covers the host tools a **local** launch may resolve; the exact set
-depends on the target backend — `missing_launch_host_tools_csv` probes `colima`
-only when `TARGET_BACKEND == "colima"`, whereas a Docker Desktop target
-(`--target docker-desktop`) probes Docker/its context instead, and `curl` is used
-only by the best-effort release-URL preflight. Beyond per-launch resolution, a few
-prerequisites sit outside this table entirely. Remote-preview backends probe extra tools via
-`missing_launch_host_tools_csv` (`scripts/workcell:6708`) — `aws` and
-`session-manager-plugin` for the `aws-ec2-ssm` backend, `gcloud` for `gcp-vm`.
-Image builds require a system `docker-buildx` plugin binary
-(`ensure_workcell_trusted_buildx`, `scripts/lib/trusted-docker-client.sh`), which
-aborts with `Missing trusted docker-buildx binary` when none is found. A
-pre-set, executable `WORKCELL_TRUSTED_BUILDX_BIN` short-circuits that search and
-is honored as-is; the launcher's `env -i` shebang (line 1) clears it on any
-normal invocation, so this override survives only for shebang-bypassed
-invocations (`/bin/bash -p scripts/workcell`) that inherit an
-attacker-controlled value. Such invocations already run outside the pinned
-entrypoint and are out of the launcher's trust boundary. And the
-`workcell publish-pr` subcommand resolves `gh` on its non-dry-run path (required;
-via the Go publish helper `internal/publishpr`, `ResolveHostTool(ctx, "gh", true,
-…)`), failing with `Missing trusted host tool: gh` at publication time if it is
-absent.
-
-### Environment expectations
-
-The launcher pins its own process environment before doing any work, then
-derives a small set of host-context variables.
-
-**Pinned `PATH`.** On direct execution the launcher re-execs itself with a
-**cleared** environment: the shebang (`scripts/workcell:1`) is
-`#!/usr/bin/env -S -i PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin BASH_ENV= ENV= /bin/bash`,
-so `env -i` discards the inherited environment and starts `bash` with only the
-fixed `PATH` and cleared `BASH_ENV`/`ENV`. **This wholesale clear only happens
-when the shebang is honored.** When the launcher is instead invoked directly by an
-interpreter the shebang is bypassed, `env -i` never runs, and only the explicit
-`scrub_host_process_env` list (below) plus the `PATH` reset apply — and the two
-such forms differ on startup-file vectors:
-
-- `/bin/bash -p scripts/workcell` (the privileged form the repo's own
-  verify-invariants and publish-pr harnesses use) ignores `BASH_ENV`/`ENV`, so
-  those vectors are inert even before the scrub.
-- plain `bash scripts/workcell` (no `-p`) **processes `BASH_ENV` before the script
-  body runs**, so a `BASH_ENV` startup-file injection has already executed by the
-  time `scrub_host_process_env` unsets the variable — the scrub is *not* a defence
-  against it on that path.
-
-Either way, security reasoning must not assume unlisted variables are absent on a
-shebang-bypassed launch. In both cases the `PATH` string is frozen as
-`readonly TRUSTED_HOST_PATH` and
-re-exported as `PATH` (`scripts/workcell:5-6`), and it is the `PATH` handed to
-every sanitised host command via `env -i PATH="${TRUSTED_HOST_PATH}"`
-(`host-exec.sh:49,77`).
-
-**Scrubbed variables.** `scrub_host_process_env` (`scripts/workcell:7-30`, called
-at `scripts/workcell:32`) unsets, in order:
-
-- `BASH_ENV`, `ENV` — startup-file injection vectors;
-- `WORKCELL_TEST_FAIL_AFTER_PROFILE_REFRESH` — always unset (the fault-injection
-  hook is reachable only through a CLI flag, below);
-- `WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS`, `_ARCH`, `_DISTRO`, `_DISTRO_VERSION` —
-  unset **unless** `WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT` is `1`;
-- `PYTHONPATH`, `PYTHONHOME`, `PYTHONSAFEPATH`, `PYTHONSTARTUP`;
-- `RUBYOPT`, `RUBYLIB`, `GEM_HOME`, `GEM_PATH`;
-- `PERL5OPT`, `PERL5LIB`, `PERLLIB`, `PERL_MB_OPT`, `PERL_MM_OPT`;
-- `LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT`, `LD_DEBUG`, `LD_DEBUG_OUTPUT`,
-  `LD_BIND_NOW`, `LD_ASSUME_KERNEL`;
-- every `DYLD_*` variable found via `compgen -v`.
-
-**Derived / exported variables.** After scrubbing, the launcher establishes:
-
-| Variable | Value | Mechanism |
-| --- | --- | --- |
-| `REAL_HOME` | resolved host home | `resolve_workcell_real_home` (`workcell:71`, from `trusted-docker-client.sh`) |
-| `WORKCELL_GO_CACHE_ROOT` (exported) | `${REAL_HOME}/Library/Caches/workcell/go` on Darwin, else `${XDG_CACHE_HOME:-${REAL_HOME}/.cache}/workcell/go` | `workcell:73-79` |
-| `COLIMA_STATE_ROOT` | `${REAL_HOME}/.colima` | `workcell:90`; passed to `colima` as `COLIMA_HOME` (`workcell:632`) |
-| `GOPATH` / `GOMODCACHE` / `GOCACHE` (exported) | `${cache_root}/gopath`, `/mod-cache`, `/build-cache` under `WORKCELL_GO_CACHE_ROOT` | `ensure_go_run_env` in `go-run-env.sh:30-44` (honours pre-set values) |
-
-`REAL_HOME` and `WORKCELL_GO_CACHE_ROOT` are deliberately established *before*
-`go-hostutil.sh` is sourced (`workcell:80-85`), so the wrappers never run before
-the host home and default Go cache root are fixed. This is an **ordering**
-guarantee, not full confinement: `ensure_go_run_env` **honours a pre-set**
-`GOPATH`/`GOMODCACHE`/`GOCACHE` (`go-run-env.sh:33-35`), and those three are not in
-the `scrub_host_process_env` list, so on the shebang-bypassed
-`bash scripts/workcell` path (above) a caller-supplied Go cache can persist — the
-wrappers are guaranteed a *defined* cache root, not necessarily the default one.
-
-### Exit codes
-
-The launcher's **own** exit codes — those it originates for its own
-skip/failure conditions — are:
-
-| Code | Meaning | Representative sources |
-| --- | --- | --- |
-| `0` | Success, or an intentional clean skip (no work to do). | `workcell:3651` (no session id → skip), `workcell:8147` (logs shown) |
-| `1` | General failure. In particular, the trusted-tool resolvers abort here when a required host tool is missing. | `host-exec.sh` `resolve_fixed_host_tool`, `workcell:6676` `resolve_host_tool` |
-| `2` | Usage / validation / precondition guard failure — by far the most common code. Covers invalid CLI arguments, mode-requirement violations, reserved-variable rejection, a missing host working directory, and Colima profile validation failures. | `workcell:8151,8155` (reserved vars), `workcell:8614-8616` (profile validation), `run_clean_host_command_in_dir` missing-dir (`host-exec.sh`) |
-| `88` | Test-only fault injection: a simulated crash immediately after a managed-profile refresh, used by harness recovery tests. Reached only through the hidden CLI flag below. | `maybe_fail_after_profile_refresh_for_tests` (`workcell:2625`) |
-| `124` | A managed operation timed out — e.g. `colima start` exceeding `WORKCELL_COLIMA_START_TIMEOUT_SECONDS`. The timeout wrapper returns `124` and `set -e` propagates it, so the launcher itself exits `124` (matching `stability-contract.md`). | `run_command_with_debug_log` / `start_managed_profile` timeout path |
-
-`0`/`1`/`2`/`88` are the *literal* `exit` codes in `scripts/workcell`
-(`grep -nE 'exit [0-9]'`); `124` is originated indirectly, via `set -e`
-propagating a timeout wrapper's non-zero return. Beyond the codes it originates,
-a normal end-to-end invocation also **passes the supervised child's exit status
-through unchanged** — a completed session exits with the container's status
-(`exit "${DOCKER_STATUS}"`, `workcell:8797`), a build failure with
-`${BUILD_STATUS}` (`workcell:8698`), and session subcommands propagate their
-helper's status (`exit $?`, e.g. `workcell:4182,4188`). So an end-to-end run can
-surface any status in `0`–`255` (including `128+N` for a signalled child);
-[`stability-contract.md`](stability-contract.md) is the authoritative exit-code
-reference.
-
-### Test override flags
-
-These variables exist for the validation harness / CI, not for operators. Each is
-gated — hard-rejected, unconditionally unset, or ignored unless its harness
-conditions hold — so a normal launch cannot *act* on one. Note the gate that
-decides whether a value is **scrubbed** is, for the support-matrix vars, weaker
-than the gate that decides whether it is **honoured** (see their rows).
-
-| Flag | Overrides | Gating |
-| --- | --- | --- |
-| `WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT` | Two distinct effects: (a) at startup its presence (`=1`) makes `scrub_host_process_env` **skip unsetting** the four support-matrix vars; (b) it is one condition the detectors check before honouring those overrides. | Effect (a) is gated **only** on the `=1` marker (`workcell:12-17`) — *not* parent-verified. Effect (b) additionally requires `support_matrix_host_override_allowed` to confirm a recognised validation-harness parent (`host-detect.sh`). |
-| `WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS` / `_ARCH` / `_DISTRO` / `_DISTRO_VERSION` | Forces the detected host OS / arch / distro / distro version. | **Unset at startup only when the `SANITIZED_ENTRYPOINT` marker is absent** (`workcell:12-17`); with the marker set they survive startup even under a non-harness parent, but the detectors **honour** them only when `support_matrix_host_override_allowed` returns `0` (marker **and** recognised parent). So on the shebang-bypassed `bash scripts/workcell` path they can be *present but ignored*, not guaranteed absent. |
-| `WORKCELL_TEST_CODEX_AUTH_FILE` | Reserved harness variable name — **rejected legacy input**, not a credential override: no launcher resolver consumes it (the Codex resolver no longer recognises it; see `docs/security/`). | If non-empty in the launcher's own environment the launcher **refuses to run**: `exit 2`, "reserved for the Workcell test harness" (`workcell:8150-8152`). |
-| `WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE` | **Dual role.** An *operator-supplied* value is rejected; but the launcher's own self-staging probe (`--synthetic-claude-export`, `workcell:4804`) sets this var **internally** so the Claude credential resolver materialises the synthetic export (`internal/injection/prepare_bundle.go:434`, `internal/authresolve/resolve_provider_credentials.go:16`). | Reject-on-presence guard for *inherited* operator input: `exit 2` if set in the launcher's own env (`workcell:8154-8156`). The internal staging happens later, inside bundle prep, after that guard. |
-| `WORKCELL_TEST_FAIL_AFTER_PROFILE_REFRESH` | Would request the mid-refresh fault injection. | The env variable is **unconditionally unset** at startup (`workcell:11`). The fault is reachable only through the hidden CLI flag `--test-fail-after-profile-refresh`, which sets the internal `TEST_FAIL_AFTER_PROFILE_REFRESH=1` (`workcell:7883-7884`) and triggers `exit 88`. |
-
-These gates are **harness conventions, not a security boundary against a local
-operator**. The support-matrix "parent" check is a *substring match* on the parent
-process command line (below), not a verified process identity, so a caller who
-controls their own process tree can construct a matching command line. It deters
-accidental leakage from an ordinary launch; it is not a defence against deliberate
-spoofing by someone who already runs the launcher (who, being local, controls that
-environment anyway). The credential-fixture variables are stricter — they force an
-`exit 2` abort whenever present. The authoritative host/credential threat model
-lives in the security docs under `docs/security/`, not here.
-
-## Host detection (`host-detect.sh`)
-
-`scripts/lib/launcher/host-detect.sh` normalises the host environment into the
-lowercased values the launcher's support-matrix logic consumes. Every helper
-depends only on `uname`/`ps`/`PPID`/environment variables and each other — no
-other launcher function — which makes the module self-contained.
-
-All emitted values are lowercased and newline-terminated. Values are normalised
-to canonical tokens where recognised, and otherwise passed through lowercased.
-
-### `support_matrix_host_override_allowed()`
-
-Gate that decides whether the harness-only host overrides (below) are honoured.
-Returns `0` (allowed) only when **both** hold:
-
-- `WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT` is `1`; and
-- the parent process command line (read from `/proc/${PPID}/cmdline`, falling
-  back to `ps -p "${PPID}"`) matches one of the recognised validation harness
-  entrypoints (`scripts/verify-invariants.sh` or the shared dry-run scenario
-  scripts).
-
-Returns non-zero otherwise. This keeps the overrides usable by Linux
-validation runners exercising launch assembly without weakening the real,
-operator-facing support boundary.
-
-### `detected_host_os()`
-
-Prints the normalised host operating system: `macos` (Darwin), `linux`
-(Linux), or `windows` (MINGW/MSYS/CYGWIN/`Windows_NT`). Any other `uname -s`
-value is passed through lowercased.
-
-### `detected_host_arch()`
-
-Prints the normalised host architecture: `arm64` (`arm64`/`aarch64`) or `amd64`
-(`x86_64`/`amd64`). Any other `uname -m` value is passed through lowercased.
-
-### `detected_host_distro()`
-
-On non-Linux hosts prints `none`. On Linux, prints the lowercased `ID` from
-`/etc/os-release`, or `unknown` when it cannot be determined.
-
-### `detected_host_distro_version()`
-
-On non-Linux hosts prints `none`. On Linux, prints the lowercased `VERSION_ID`
-(falling back to `VERSION_CODENAME`) from `/etc/os-release`, or `unknown` when
-it cannot be determined.
-
-### Harness-only overrides
-
-When `support_matrix_host_override_allowed` returns `0`, each detector first
-honours a reserved override environment variable if it is non-empty, printing
-its value verbatim:
-
-- `WORKCELL_TEST_SUPPORT_MATRIX_HOST_OS`
-- `WORKCELL_TEST_SUPPORT_MATRIX_HOST_ARCH`
-- `WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO`
-- `WORKCELL_TEST_SUPPORT_MATRIX_HOST_DISTRO_VERSION`
-
-These variables are reserved for the validation harness. The launcher scrubs
-them from the host process environment unless the sanitized-entrypoint marker
-is set, so they cannot be smuggled in by an operator to spoof the detected host.
-
-## Trusted host-command execution (`host-exec.sh`)
-
-`scripts/lib/launcher/host-exec.sh` resolves fixed, trusted host tools and runs
-host commands under a sanitised environment. Every helper depends only on
-`env`/`cd` builtins, the readonly `TRUSTED_HOST_PATH`, `REAL_HOME` (used with a
-fallback), and `resolve_workcell_real_home` (from
-`scripts/lib/trusted-docker-client.sh`) — no other launcher function — which
-makes the module self-contained.
-
-### `resolve_fixed_host_tool()`
-
-Resolves a trusted host tool from an allowlist of absolute candidate paths.
-Called as `resolve_fixed_host_tool <name> <candidate>...`; prints the first
-candidate that is executable (`-x`) and returns `0`. If no candidate is
-executable it prints `Missing trusted host tool: <name>` to stderr and exits
-`1`. Only fixed, caller-supplied absolute paths are considered, so the resolved
-binary never depends on a `PATH` search.
-
-### `run_clean_host_command()`
-
-Runs a host command under a sanitised environment. With no arguments it is a
-no-op returning `0`. Otherwise it resolves the host home (`REAL_HOME`, falling
-back to `resolve_workcell_real_home`, then `/` if neither is a directory),
-`cd`s into that home, and execs the command via `env -i` with only
-`PATH="${TRUSTED_HOST_PATH}"`, `HOME`, and `LC_ALL=C`/`LANG=C` set. The command
-runs in a subshell so the launcher's own working directory and environment are
-unaffected, and the command's exit status is propagated.
-
-### `run_clean_host_command_in_dir()`
-
-Same sanitised `env -i` execution as `run_clean_host_command()`, but runs the
-command from a caller-supplied working directory. Called as
-`run_clean_host_command_in_dir <dir> <cmd>...`. If `<dir>` is not a directory it
-prints `Missing host working directory: <dir>` to stderr and exits `2`. With no
-command arguments it is a no-op returning `0`. `HOME` resolution and the pinned
-`PATH`/locale are identical to `run_clean_host_command()`.
-
-## Go/Colima host-utility wrappers (`go-hostutil.sh`)
-
-`scripts/lib/launcher/go-hostutil.sh` invokes the `workcell-hostutil` and
-`workcell-colimautil` Go programs on the host via `go run`, always routed
-through `run_clean_host_command_in_dir` (from `host-exec.sh`) so the child
-executes from `${ROOT_DIR}` under the sanitised `env -i` host environment. Every
-helper depends only on `ensure_go_run_env` plus the `GOPATH`/`GOMODCACHE`/
-`GOCACHE` it exports (`scripts/lib/go-run-env.sh`),
-`run_clean_host_command_in_dir` (`scripts/lib/launcher/host-exec.sh`), and the
-`ROOT_DIR` global set in `scripts/workcell`. `HOST_GO_BIN` is resolved by this
-module itself (via `resolve_fixed_host_tool` from `host-exec.sh`, sourced
-immediately before), since these wrappers are its sole consumer — so every
-dependency is sourced or assigned before the first wrapper call, which makes the
-module self-contained.
-
-### `go_hostutil()`
-
-Runs `workcell-hostutil` on the host. Calls `ensure_go_run_env`, then executes
-`"${HOST_GO_BIN}" run ./cmd/workcell-hostutil "$@"` from `${ROOT_DIR}` via
-`run_clean_host_command_in_dir`, forwarding only `GOPATH`/`GOMODCACHE`/`GOCACHE`
-into the sanitised environment. All other host context must be passed on argv
-because the `env -i` boundary strips inherited environment variables.
-
-### `run_go_hostutil_preserve_exit()`
-
-Wraps `go_hostutil()` and recovers the Go child's real exit code. It captures
-the child's stderr to a temp file (cleaned up via a `RETURN` trap and
-explicitly), and if the stderr ends in an `exit status N` trailer emitted by
-`go run`, it substitutes `N` for the generic exit code `1` and strips the
-trailer from the forwarded stderr. Non-trailer stderr is re-emitted unchanged
-and the resolved exit code is returned.
-
-### `go_hostutil_publish_pr()`
-
-Same `go run ./cmd/workcell-hostutil` invocation as `go_hostutil()`, but forwards
-an explicit allowlist of terminal, GnuPG, SSH, XDG, and GitHub environment
-variables (for example `TERM`, `GPG_TTY`, `GNUPGHOME`, `SSH_AUTH_SOCK`,
-`GIT_ASKPASS`, the `XDG_*` dirs, `GH_TOKEN`/`GITHUB_TOKEN`, `GH_HOST`,
-`GH_CONFIG_DIR`) — each added only when non-empty — so host-side PR publication
-can reach the operator's credentials and interactive signing agents while the
-rest of the environment stays sanitised.
-
-### `go_colimautil()`
-
-Runs `workcell-colimautil` on the host. Identical structure to `go_hostutil()`
-(`ensure_go_run_env`, forwarding `GOPATH`/`GOMODCACHE`/`GOCACHE` from
-`${ROOT_DIR}` via `run_clean_host_command_in_dir`), targeting
-`./cmd/workcell-colimautil` instead.
-
-## Egress-endpoint assembly (`egress-endpoints.sh`)
-
-`scripts/lib/launcher/egress-endpoints.sh` computes the per-session network
-egress allowlist and translates it into the container runtime's `--add-host`
-arguments. It maps each provider, remote-VM broker, and injected credential to
-its fixed `host:port` endpoint set, deduplicates and deny-subtracts the combined
-list through the `workcell-hostutil` Go helper, fails closed when a deny rule
-empties the allowlist, labels whether the launch actually enforces the
-allowlist, and resolves the surviving endpoints into `--add-host` runtime args.
-Every helper depends only on `csv_contains_value` (defined in
-`scripts/workcell`), `go_hostutil` (`scripts/lib/launcher/go-hostutil.sh`, sourced
-before this module), the read-only launch-state globals `AGENT`,
-`INJECTION_CREDENTIAL_KEYS`, `NETWORK_POLICY`, and `TARGET_BACKEND`, and the
-`RUNTIME_NETWORK_ARGS` array `build_runtime_host_aliases` populates — all defined
-before the first call site in the main launch path — which makes the module
-self-contained.
-
-### `provider_endpoints()`
-
-Prints the space-separated `host:port` egress set a provider requires
-(`codex`, `claude`, `copilot`, `gemini`). Returns `1` for any unrecognised
-provider so the caller sees no endpoints.
-
-### `target_broker_endpoints()`
-
-Prints the space-separated `host:port` control-plane endpoints a remote-VM
-broker backend requires (`aws-ec2-ssm`, `gcp-vm`). Returns `0` (empty) for every
-other target, including the local `colima` and `docker-desktop` backends.
-
-### `credential_extra_endpoints()`
-
-Prints additional endpoints implied by the injected credential set
-(`INJECTION_CREDENTIAL_KEYS`): GitHub host/config credentials add the GitHub web
-and raw-content hosts, and — only when `AGENT` is `gemini` — Google OAuth/ADC
-credentials add the Google identity and AI-platform hosts. Prints nothing when
-no credential implies extra egress.
-
-### `dedupe_endpoint_list()` / `subtract_endpoint_list()`
-
-Thin wrappers over the `workcell-hostutil helper` sub-commands
-`dedupe-endpoints` and `subtract-endpoints`. `dedupe_endpoint_list` collapses the
-combined allow set to unique endpoints preserving order; `subtract_endpoint_list`
-removes every endpoint in the deny list from the allow list, preserving allow
-order. Deny always wins over allow, and the subtraction only ever tightens the
-allowlist — it can never add an endpoint or change `NETWORK_POLICY`.
-
-### `fail_empty_egress_after_deny()`
-
-Aborts fail-closed (`exit 1`) with an actionable diagnostic when
-`[network].deny_endpoints` has removed every computed endpoint on the enforced
-colima allowlist path, so a zero-egress session never launches. Called for both
-the `bootstrap` and `session` phases.
-
-### `egress_enforcement_label()`
-
-Prints `allowlist` only when the launch actually enforces the per-session
-default-deny allowlist — `TARGET_BACKEND` is `colima` **and** `NETWORK_POLICY` is
-`allowlist` — and `none` for every other target, making the parity gap explicit
-on the launch summary.
-
-### `build_runtime_host_aliases()`
-
-Resets and repopulates the `RUNTIME_NETWORK_ARGS` array. On the `allowlist`
-policy it resolves the supplied endpoint list to IPs via
-`workcell-hostutil helper resolve-endpoints` and appends one `--add-host
-host:ip` argument per resolved address (bracketing IPv6 literals); on any other
-policy it leaves `RUNTIME_NETWORK_ARGS` empty and returns.
+# Launcher Contract
+
+[`scripts/workcell`](../scripts/workcell) is the host launcher. It sources small
+modules from `scripts/lib/launcher/`. This page records the current contract of
+those modules.
+
+## Launcher Reference
+
+Direct execution uses the launcher shebang. The shebang starts Bash with an
+empty environment, a fixed `PATH`, and empty `BASH_ENV` and `ENV` values. The
+launcher also scrubs language startup and dynamic-loader variables.
+
+Do not use `bash scripts/workcell` as a trusted entry point. That command skips
+the shebang. Bash can process `BASH_ENV` before the script can scrub it.
+Repository test harnesses can use `/bin/bash -p scripts/workcell`. Privileged
+Bash does not process those startup files, but it still skips the empty shebang
+environment.
+
+The launcher gives clean host commands these values:
+
+- The fixed trusted `PATH`.
+- The resolved host home, or `/` if no valid home exists.
+- `LC_ALL=C` and `LANG=C`.
+- Only the additional variables that the applicable helper permits.
+
+## Host Tools
+
+The launcher does not use an inherited `PATH`. It uses fixed candidates or a
+fixed trusted path.
+
+| Tool | Resolution and use |
+|---|---|
+| Go | `resolve_fixed_host_tool` selects the first executable fixed candidate. Go runs the host utility commands. |
+| Colima | `resolve_host_tool` selects and checks a trusted candidate for the Colima target. |
+| Docker | Target preparation selects and checks the Docker client before Docker use. |
+| Git | The launcher can use a checked absolute Git path. Clean host commands also call Git by name on the fixed path. |
+| curl | A best-effort release URL check calls curl by name on the fixed path. curl is optional for that check. |
+| AWS tools | The AWS preview probe checks `aws` and `session-manager-plugin`. |
+| gcloud | The GCP preview probe checks `gcloud`. |
+| gh | The host publication helper requires a trusted GitHub CLI path for a real publication. |
+
+`resolve_fixed_host_tool` tests only whether a literal candidate path is
+executable. It does not resolve and check a symlink target. Trust requires fixed
+directories that an attacker cannot write to.
+
+The main `resolve_host_tool` path also checks the canonical path against trusted
+prefixes. Clean host commands that call a tool by name use the fixed path but do
+not check the canonical target.
+
+Image builds require a trusted Docker Buildx plug-in. A direct launch
+clears a caller-supplied `WORKCELL_TRUSTED_BUILDX_BIN` value. A shebang-bypass
+test process can keep caller-supplied environment values and is outside the
+direct entry point contract.
+
+The PTY transcript helper has its own Go resolver. It accepts
+`WORKCELL_GO_BIN`, then a Go binary on its current path, then fixed candidates.
+This resolver stops if it finds no Go binary. A direct launcher execution clears
+the inherited environment. A shebang-bypass process can supply a different
+value.
+
+## Host Environment
+
+The launcher removes these environment values at startup:
+
+- `BASH_ENV` and `ENV`.
+- `WORKCELL_TEST_FAIL_AFTER_PROFILE_REFRESH` in all cases.
+- The four support-matrix test values unless the sanitized-entry marker is `1`.
+- Python, Ruby, and Perl startup or library values.
+- Linux loader values such as `LD_PRELOAD` and `LD_LIBRARY_PATH`.
+- Each `DYLD_*` value.
+
+The launcher resolves the real host home before it sources Go host wrappers. It
+sets a default cache root for Workcell Go tools. The Go environment helper supplies
+`GOPATH`, `GOMODCACHE`, and `GOCACHE` when they have no value.
+
+On a shebang-bypass path, a caller can preserve unlisted variables and existing
+Go cache values. Thus, the direct shebang is part of the trusted launcher
+contract.
+
+## Exit Status
+
+The launcher uses these status values:
+
+| Status | Meaning |
+|---|---|
+| `0` | Success or an intentional no-work result |
+| `1` | General failure, such as a missing required trusted tool |
+| `2` | Usage, validation, or precondition failure |
+| `88` | Hidden CLI test fault after a managed profile refresh |
+| `124` | Managed operation timeout |
+
+The launcher can also return the provider, container, build, or session-helper
+status without change. Use [Stability Contract](stability-contract.md) for the
+authoritative public exit behavior.
+
+## Test-Only Inputs
+
+The test inputs for host support can replace detected host fields only when both of
+these conditions are true:
+
+1. `WORKCELL_VERIFY_INVARIANTS_SANITIZED_ENTRYPOINT=1` is present.
+2. The parent command line matches one of the listed repository validation
+   harnesses.
+
+This parent check searches for a substring in the command line. It prevents
+accidental operator use. It is not a security boundary against a local operator
+who controls the process tree.
+
+The launcher rejects inherited `WORKCELL_TEST_CODEX_AUTH_FILE` and
+`WORKCELL_TEST_CLAUDE_KEYCHAIN_EXPORT_FILE` values. The synthetic Claude probe
+can set its internal fixture value only after the inherited-value check.
+
+The launcher always removes an inherited
+`WORKCELL_TEST_FAIL_AFTER_PROFILE_REFRESH` value. The hidden CLI test option has
+no parent-process gate. It exits with status `88` only after a managed profile
+refresh.
+
+## Host Detection Module
+
+[`host-detect.sh`](../scripts/lib/launcher/host-detect.sh) returns normalized,
+lowercase host fields during detection without a test override. An allowed test
+override passes through without a case change.
+
+| Function | Result |
+|---|---|
+| `detected_host_os` | `macos`, `linux`, `windows`, or a lowercase unknown value |
+| `detected_host_arch` | `arm64`, `amd64`, or a lowercase unknown value |
+| `detected_host_distro` | Linux `ID`, `unknown`, or `none` on a non-Linux host |
+| `detected_host_distro_version` | Linux `VERSION_ID`, then `VERSION_CODENAME`, `unknown`, or `none` |
+
+`support_matrix_host_override_allowed` applies the two-part test gate described
+above. The module uses `uname`, `ps`, `tr`, `PPID`, environment values,
+`/etc/os-release`, and its own functions.
+
+## Clean Host Execution Module
+
+[`host-exec.sh`](../scripts/lib/launcher/host-exec.sh) supplies three functions.
+
+### `resolve_fixed_host_tool`
+
+This function receives a tool name and fixed absolute candidates. It prints the
+first executable candidate. If it finds none, it prints
+`Missing trusted host tool: <name>` and exits with status `1`.
+
+### `run_clean_host_command`
+
+This function changes to the resolved host home and starts a command with an
+empty environment. It supplies only the fixed path, home, and C locale. With no
+command, it returns success.
+
+### `run_clean_host_command_in_dir`
+
+This function uses the same clean environment in a caller-selected directory.
+If the directory does not exist, it prints a diagnostic and exits with status
+`2`. With no command after the directory, it returns success.
+
+## Go Host Utility Module
+
+[`go-hostutil.sh`](../scripts/lib/launcher/go-hostutil.sh) resolves the fixed Go
+binary and runs Go commands from the repository root in the clean host
+environment.
+
+| Function | Contract |
+|---|---|
+| `go_hostutil` | Run `cmd/workcell-hostutil` with the selected arguments. |
+| `run_go_hostutil_preserve_exit` | Recover the child status from Go's final `exit status N` diagnostic and return it. |
+| `go_hostutil_publish_pr` | Run host publication with an explicit allowlist of terminal, GPG, SSH, XDG, and GitHub variables. |
+| `go_colimautil` | Run `cmd/workcell-colimautil` with the selected arguments. |
+
+The publication function is a deliberate host-side exception. It can receive
+the ambient operator publication and signing environment. The Tier 1 runtime
+does not receive this ambient state. Reviewed injection can stage selected
+GitHub CLI files and SSH identities. The supported pull-request publication
+workflow stays on the host.
+
+## Egress Endpoint Module
+
+[`egress-endpoints.sh`](../scripts/lib/launcher/egress-endpoints.sh) supplies
+helpers for fixed provider, target broker, and credential endpoint values. It
+also supplies list and host-alias helpers.
+
+### Endpoint sources
+
+`provider_endpoints` returns the fixed service endpoints for Codex, Claude,
+Copilot, or Gemini. `target_broker_endpoints` adds the fixed AWS SSM or GCP IAP
+broker endpoints. `credential_extra_endpoints` adds fixed GitHub or Google
+authentication endpoints when the selected staged inputs need them.
+
+The main launcher combines these values with authentication-recovery,
+injection-policy, profile-extra, and conditional Debian endpoints.
+
+Use [Outbound Endpoints](outbound-endpoints.md) for the full endpoint inventory.
+
+### List operations
+
+`dedupe_endpoint_list` preserves the first occurrence of each endpoint.
+`subtract_endpoint_list` removes each denied endpoint and preserves the allow
+order. A deny value cannot add an endpoint.
+
+If deny values remove every session endpoint, the check stops an enforced
+Colima allowlist session with status `1`. This session check does not apply to
+`--prepare-only`. If deny values remove every bootstrap endpoint, the check
+stops only when a rebuild must use that bootstrap set. A prepared image can
+still launch when the session endpoint set is not empty.
+
+### Enforcement label and host aliases
+
+`egress_enforcement_label` returns `allowlist` only for a Colima target with the
+allowlist policy. It returns `none` for Docker Desktop and the blocked remote
+preview targets.
+
+`build_runtime_host_aliases` resolves the effective endpoint hosts and builds
+Docker `--add-host` arguments. It does nothing when the network policy is not
+`allowlist`. These aliases support deterministic resolution. The rule set in
+the Colima VM supplies the actual managed egress enforcement.
+
+## Change Rule
+
+Keep each extracted module behavior-compatible with its call sites. When a
+module contract changes, update its tests, this page, and the applicable
+operator or security document. Make the updates in the same change.

--- a/docs/launcher-contract.md
+++ b/docs/launcher-contract.md
@@ -23,7 +23,7 @@ The launcher gives clean host commands these values:
 - `LC_ALL=C` and `LANG=C`.
 - Only the additional variables that the applicable helper permits.
 
-## Host Tools
+### Required host tools
 
 The launcher does not use an inherited `PATH`. It uses fixed candidates or a
 fixed trusted path.
@@ -58,7 +58,7 @@ This resolver stops if it finds no Go binary. A direct launcher execution clears
 the inherited environment. A shebang-bypass process can supply a different
 value.
 
-## Host Environment
+### Environment expectations
 
 The launcher removes these environment values at startup:
 
@@ -77,7 +77,7 @@ On a shebang-bypass path, a caller can preserve unlisted variables and existing
 Go cache values. Thus, the direct shebang is part of the trusted launcher
 contract.
 
-## Exit Status
+### Exit codes
 
 The launcher uses these status values:
 
@@ -93,7 +93,7 @@ The launcher can also return the provider, container, build, or session-helper
 status without change. Use [Stability Contract](stability-contract.md) for the
 authoritative public exit behavior.
 
-## Test-Only Inputs
+### Test override flags
 
 The test inputs for host support can replace detected host fields only when both of
 these conditions are true:
@@ -115,24 +115,39 @@ The launcher always removes an inherited
 no parent-process gate. It exits with status `88` only after a managed profile
 refresh.
 
-## Host Detection Module
+## Host detection (`host-detect.sh`)
 
 [`host-detect.sh`](../scripts/lib/launcher/host-detect.sh) returns normalized,
-lowercase host fields during detection without a test override. An allowed test
-override passes through without a case change.
+lowercase host fields during detection without a test override. The module uses
+`uname`, `ps`, `tr`, `PPID`, environment values, `/etc/os-release`, and its own
+functions.
 
-| Function | Result |
-|---|---|
-| `detected_host_os` | `macos`, `linux`, `windows`, or a lowercase unknown value |
-| `detected_host_arch` | `arm64`, `amd64`, or a lowercase unknown value |
-| `detected_host_distro` | Linux `ID`, `unknown`, or `none` on a non-Linux host |
-| `detected_host_distro_version` | Linux `VERSION_ID`, then `VERSION_CODENAME`, `unknown`, or `none` |
+### `support_matrix_host_override_allowed()`
 
-`support_matrix_host_override_allowed` applies the two-part test gate described
-above. The module uses `uname`, `ps`, `tr`, `PPID`, environment values,
-`/etc/os-release`, and its own functions.
+This function applies the two-part test gate described above.
 
-## Clean Host Execution Module
+### `detected_host_os()`
+
+This function returns `macos`, `linux`, `windows`, or a lowercase unknown value.
+
+### `detected_host_arch()`
+
+This function returns `arm64`, `amd64`, or a lowercase unknown value.
+
+### `detected_host_distro()`
+
+This function returns the Linux `ID`, `unknown`, or `none` on a non-Linux host.
+
+### `detected_host_distro_version()`
+
+This function returns Linux `VERSION_ID`, then `VERSION_CODENAME`, `unknown`, or
+`none`.
+
+### Harness-only overrides
+
+An allowed test override passes through without a case change.
+
+## Trusted host-command execution (`host-exec.sh`)
 
 [`host-exec.sh`](../scripts/lib/launcher/host-exec.sh) supplies three functions.
 
@@ -154,18 +169,29 @@ This function uses the same clean environment in a caller-selected directory.
 If the directory does not exist, it prints a diagnostic and exits with status
 `2`. With no command after the directory, it returns success.
 
-## Go Host Utility Module
+## Go/Colima host-utility wrappers (`go-hostutil.sh`)
 
 [`go-hostutil.sh`](../scripts/lib/launcher/go-hostutil.sh) resolves the fixed Go
 binary and runs Go commands from the repository root in the clean host
 environment.
 
-| Function | Contract |
-|---|---|
-| `go_hostutil` | Run `cmd/workcell-hostutil` with the selected arguments. |
-| `run_go_hostutil_preserve_exit` | Recover the child status from Go's final `exit status N` diagnostic and return it. |
-| `go_hostutil_publish_pr` | Run host publication with an explicit allowlist of terminal, GPG, SSH, XDG, and GitHub variables. |
-| `go_colimautil` | Run `cmd/workcell-colimautil` with the selected arguments. |
+### `go_hostutil()`
+
+This function runs `cmd/workcell-hostutil` with the selected arguments.
+
+### `run_go_hostutil_preserve_exit()`
+
+This function recovers and returns the child status from Go's final
+`exit status N` diagnostic.
+
+### `go_hostutil_publish_pr()`
+
+This function runs host publication with an explicit allowlist of terminal,
+GPG, SSH, XDG, and GitHub variables.
+
+### `go_colimautil()`
+
+This function runs `cmd/workcell-colimautil` with the selected arguments.
 
 The publication function is a deliberate host-side exception. It can receive
 the ambient operator publication and signing environment. The Tier 1 runtime
@@ -173,29 +199,38 @@ does not receive this ambient state. Reviewed injection can stage selected
 GitHub CLI files and SSH identities. The supported pull-request publication
 workflow stays on the host.
 
-## Egress Endpoint Module
+## Egress-endpoint assembly (`egress-endpoints.sh`)
 
 [`egress-endpoints.sh`](../scripts/lib/launcher/egress-endpoints.sh) supplies
 helpers for fixed provider, target broker, and credential endpoint values. It
 also supplies list and host-alias helpers.
 
-### Endpoint sources
+### `provider_endpoints()`
 
-`provider_endpoints` returns the fixed service endpoints for Codex, Claude,
-Copilot, or Gemini. `target_broker_endpoints` adds the fixed AWS SSM or GCP IAP
-broker endpoints. `credential_extra_endpoints` adds fixed GitHub or Google
-authentication endpoints when the selected staged inputs need them.
+This function returns the fixed service endpoints for Codex, Claude, Copilot,
+or Gemini.
+
+### `target_broker_endpoints()`
+
+This function adds the fixed AWS SSM or GCP IAP broker endpoints.
+
+### `credential_extra_endpoints()`
+
+This function adds fixed GitHub or Google authentication endpoints when the
+selected staged inputs need them.
 
 The main launcher combines these values with authentication-recovery,
 injection-policy, profile-extra, and conditional Debian endpoints.
 
 Use [Outbound Endpoints](outbound-endpoints.md) for the full endpoint inventory.
 
-### List operations
+### `dedupe_endpoint_list()` / `subtract_endpoint_list()`
 
 `dedupe_endpoint_list` preserves the first occurrence of each endpoint.
 `subtract_endpoint_list` removes each denied endpoint and preserves the allow
 order. A deny value cannot add an endpoint.
+
+### `fail_empty_egress_after_deny()`
 
 If deny values remove every session endpoint, the check stops an enforced
 Colima allowlist session with status `1`. This session check does not apply to
@@ -203,11 +238,13 @@ Colima allowlist session with status `1`. This session check does not apply to
 stops only when a rebuild must use that bootstrap set. A prepared image can
 still launch when the session endpoint set is not empty.
 
-### Enforcement label and host aliases
+### `egress_enforcement_label()`
 
 `egress_enforcement_label` returns `allowlist` only for a Colima target with the
 allowlist policy. It returns `none` for Docker Desktop and the blocked remote
 preview targets.
+
+### `build_runtime_host_aliases()`
 
 `build_runtime_host_aliases` resolves the effective endpoint hosts and builds
 Docker `--add-host` arguments. It does nothing when the network policy is not

--- a/docs/workcell-session-supervisor-design.md
+++ b/docs/workcell-session-supervisor-design.md
@@ -1,12 +1,12 @@
 # Workcell Session Supervisor Design
 
-## Purpose
+## Goal
 
 The session supervisor makes a launch a durable host-owned session. Use the
 [operator contract](../policy/operator-contract.toml) and `workcell --help` for
 the current command inventory. This page explains the design.
 
-## Shipped Scope
+## Current Scope
 
 The session command group supplies these functions:
 
@@ -71,7 +71,7 @@ The command group uses the key as follows:
 The durable JSON record is machine-readable state. The audit log is the event
 history. Neither record replaces the other.
 
-## Operator Behavior
+## User Experience
 
 `session list` prints a compact host inventory. Verbose output adds target,
 workspace transport, Git branch, and worktree fields.
@@ -89,7 +89,7 @@ for host automation.
 The control plane uses host files and processes. It does not add a Workcell
 daemon or a same-user trusted local socket.
 
-## Process-Local Adapter
+## Runtime Language Boundary
 
 The host session plane is a Go and Bash system. Go owns the session-record
 schema and validates the command route. Bash dispatches the session subcommands.
@@ -117,7 +117,7 @@ It does not select policy, write durable host state, or do host
 orchestration. Move this adapter to a Go runtime tool if its responsibility
 expands beyond this list.
 
-## Non-Goals
+## Current Non-Goals
 
 The shipped session plane does not provide:
 
@@ -126,6 +126,21 @@ The shipped session plane does not provide:
 - Central multi-host inventory or analytics.
 - A GUI or IDE client with the Tier 1 boundary claim.
 - A remote worker fleet.
+
+## Remaining Work
+
+This page describes shipped behavior. See [ROADMAP.md](../ROADMAP.md) for future
+work.
+
+## Peer Review
+
+The shipped design retains these review decisions.
+
+### Findings
+
+- Durable records do not use `session-audit.*` directories.
+- Audit records contain a session identifier.
+- The host uses a file-based control plane.
 
 ## Residual Risks
 

--- a/docs/workcell-session-supervisor-design.md
+++ b/docs/workcell-session-supervisor-design.md
@@ -1,209 +1,138 @@
 # Workcell Session Supervisor Design
 
-## Goal
+## Purpose
 
-Workcell needs a session-supervisor layer so operators can reason about
-launches as durable session objects rather than as one-off foreground shell
-commands.
+The session supervisor makes a launch a durable host-owned session. Use the
+[operator contract](../policy/operator-contract.toml) and `workcell --help` for
+the current command inventory. This page explains the design.
 
-This document describes the current shipped session-supervisor slice in the
-repository and the gaps that remain without weakening the existing boundary
-model.
+## Shipped Scope
 
-For the supported operator inventory, treat
-[`policy/operator-contract.toml`](../policy/operator-contract.toml) plus
-`workcell --help` as authoritative. This design note is explanatory.
+The session command group supplies these functions:
 
-## Current Scope
+- Start, attach, send input, stop, and delete a detached session.
+- List sessions and show one durable record.
+- Read retained logs and a session audit timeline.
+- Compare a session workspace with its recorded clean Git base.
+- Export a session and the audit records for that session.
+- Verify the session audit chain and seal.
 
-The current implementation provides durable host-side session records plus
-host-side inventory, observability, and detached-control commands:
-
-- `workcell session list`
-- `workcell session show --id ...`
-- `workcell session logs --id ... --kind ...`
-- `workcell session timeline --id ...`
-- `workcell session diff --id ...`
-- `workcell session export --id ...`
-- `workcell session verify --id ...`
-- `workcell session start`
-- `workcell session attach`
-- `workcell session send`
-- `workcell session stop`
-- `workcell session delete`
-
-Each launched session writes durable metadata under the Workcell-owned
-target-state root instead of relying only on the transient `session-audit.*`
-directory.
-
-Detached sessions default to `--session-workspace isolated`, so the detached
-path already points toward worktree-per-session operation on the safe path. The
-public CLI also supports `--session-workspace direct` when operators
-intentionally want a detached session to reuse the live workspace path.
-
-## Data Model
-
-Each session record stores the durable host-side view of one launch, including:
-
-- session identity and profile metadata
-- agent, mode, and UI
-- workspace root, workspace origin, and worktree path
-- git branch, head, and clean launch base when available
-- runtime container name, monitor PID, and live status
-- retained audit, debug, file-trace, and transcript paths
-- start, observe, and finish timestamps
-- initial, current, and final assurance state
-- workspace control-plane mode
-
-The durable record lives under the target-state root, by default:
-
-- `~/.local/state/workcell/targets/local_vm/colima/<profile>/sessions/<session_id>.json`
-
-Compatibility reads still accept older legacy records under
-`~/.colima/<profile>/sessions/<session_id>.json`. The transient
-`session-audit.*` directory remains separate and disposable.
+Detached sessions use `--session-workspace isolated` by default. This mode
+creates a host clone and branch for a supported Git workspace. The operator can
+select `direct` to reuse the live workspace. This selection is explicit.
 
 ## Why This Shape
 
-This design is intentionally host-owned.
+The host launcher owns session policy, durable state, and orchestration. The
+container is disposable. A transient `session-audit.*` directory does not store
+the session record.
 
-That matters because:
+For local Colima, a new record has this default shape:
 
-- the host launcher already owns the trusted control plane
-- the transient container should stay disposable
-- `--gc` already cleans transient audit dirs, Workcell-owned temp scratch, and
-  bounded runtime-image cache residue
-- durable session inventory should survive the transient session cleanup path
+```text
+~/.local/state/workcell/targets/local_vm/colima/<profile>/sessions/<session-id>.json
+```
 
-Storing records under a Workcell-owned target-state root instead of inside
-`session-audit.*` or the Colima runtime tree avoids confusing durable control
-state with ephemeral runtime scratch state.
+Compatibility reads also accept the legacy path under
+`~/.colima/<profile>/sessions/`. Workcell-owned garbage collection preserves
+durable session records. The operator uses `workcell session delete` to remove
+a stopped session record and selected recorded artifacts. It does not remove the
+recorded isolated clone.
+
+## Data Model
+
+A durable record can include:
+
+- Session, profile, agent, mode, and interface identity.
+- Target kind, provider, identifier, assurance class, and runtime API.
+- Workspace source, transport, root, path, and worktree.
+- Git branch, head, and clean launch base.
+- Container name, monitor process, recorded status, and live status.
+- Audit, debug, file-trace, and transcript paths.
+- Start, observation, and finish times.
+- Initial, current, and final assurance.
+- Control-plane state for the workspace.
+
+Use the Go session schema for the exact machine-readable fields.
 
 ## Audit Relationship
 
-The current implementation adds `session_id` to launch, control, assurance, and
-exit audit records in the target audit log, which by default lives beside the
-session records under
-`~/.local/state/workcell/targets/local_vm/colima/<profile>/workcell.audit.log`.
+Applicable audit records contain the session identifier. This key lets the host
+select records from a cumulative target audit log.
 
-That allows:
+The command group uses the key as follows:
 
-- the durable session record to stay machine-readable
-- `workcell session export` to bundle matching audit records
-- `workcell session timeline` to print the session-specific audit trail
-- `workcell session logs` to resolve one retained log for a recorded session
+- `session timeline` prints audit records for the session.
+- `session export` combines the durable record with audit records for the
+  session.
+- `session logs` resolves one retained file from the durable record.
+- `session verify` checks the authoritative audit chain and host seal.
 
-This is the bridge between human-readable audit history and machine-readable
-session metadata.
+The durable JSON record is machine-readable state. The audit log is the event
+history. Neither record replaces the other.
 
-## User Experience
+## Operator Behavior
 
-`workcell session list` is optimized for a quick host-side inventory:
+`session list` prints a compact host inventory. Verbose output adds target,
+workspace transport, Git branch, and worktree fields.
 
-- session id
-- status and live status
-- agent and mode
-- profile
-- start time
-- assurance
-- workspace
+`session show` prints the full record. Its text form prints stable `key=value`
+lines.
 
-`workcell session list --verbose` adds target identity, target assurance,
-workspace transport, git branch, and worktree metadata without changing the
-default compact table.
+`session diff` compares the current workspace with the clean Git base. It stops
+if the launch workspace is dirty, the record has no clean base, or the host
+path is not a self-contained Git worktree.
 
-`workcell session show` returns the full durable record for one session, and
-`workcell session show --text` renders the same record as stable key=value
-lines, including target metadata, workspace transport, display workspace,
-branch, worktree, and artifact pointers.
+`session start`, `session send`, and `session stop` print stable text summaries
+for host automation.
 
-`workcell session logs` prints one retained audit, debug, file-trace, or
-transcript log for a recorded session.
+The control plane uses host files and processes. It does not add a Workcell
+daemon or a same-user trusted local socket.
 
-`workcell session timeline` prints the audit-log records that match one
-session.
+## Process-Local Adapter
 
-`workcell session diff` renders the current workspace status and diff against
-the clean git base recorded when the session started. It fails closed if the
-workspace was already dirty at launch, if no git base was recorded, or if the
-workspace is no longer a self-contained git worktree on the host.
+The host session plane is a Go and Bash system. Go owns the session-record
+schema and validates the command route. Bash dispatches the session subcommands.
+Go parses and validates inputs for attach, send, stop, delete, monitor,
+timeline, logs, and verify. `scripts/workcell` still owns live container checks,
+terminal state, artifact-path resolution, deletion, monitor lifecycle, and
+controls for send and stop operations.
 
-`workcell session export` returns the full record plus matching audit records,
-either to stdout or a user-selected host file.
+The process-local shell adapter is
+[`detached-stdin-wrapper.sh`](../runtime/container/detached-stdin-wrapper.sh).
+The entry point starts the adapter after any required user change. Without file
+tracing, the adapter runs as container PID 1.
 
-Detached sessions can be started, attached to, steered, and stopped from the
-host without introducing a separate always-on daemon or same-user local socket
-trust.
-`workcell session start`, `workcell session send`, and `workcell session stop`
-emit stable key=value summaries so detached-session control stays scriptable on
-the host.
+The adapter can:
 
-## Runtime Language Boundary
+- Keep the provider on a pseudo-terminal.
+- Relay the Workcell-owned input FIFO in key-at-a-time mode.
+- Synchronize terminal dimensions.
+- Forward container signals to the provider.
+- Reap the process tree.
+- Restore terminal state.
+- Return the provider exit status.
 
-The host-side session policy, durable state, and orchestration remain in the Go
-session tooling. `runtime/container/detached-stdin-wrapper.sh` is a deliberate,
-bounded exception to the default Go language boundary: it is the container
-entrypoint's process-local adapter around `/usr/bin/script`, and must run as the
-detached container's PID 1 after the entrypoint drops privileges. Its only
-responsibilities are to keep the provider attached to a pseudo-terminal, relay
-the Workcell-owned input FIFO in key-at-a-time terminal mode, synchronize
-terminal dimensions, forward container signals to that provider, reap the
-process tree, restore terminal state, and return the provider's exit status.
+It does not select policy, write durable host state, or do host
+orchestration. Move this adapter to a Go runtime tool if its responsibility
+expands beyond this list.
 
-Keeping that adapter in shell avoids adding another trusted runtime binary
-and build artifact solely to supervise commands that the entrypoint already
-executes. The wrapper does not select policy, write durable session state, or
-implement host orchestration; additions in any of those areas belong in Go.
-If its process-local lifecycle responsibilities grow beyond this bounded list,
-move the supervisor to a dedicated Go runtime tool instead of extending the
-shell exception.
+## Non-Goals
 
-## Current Non-Goals
+The shipped session plane does not provide:
 
-The current slice does not yet attempt to implement:
-
-- a session queue or warm-pool system
-- pause or resume
-- checkpoints or forks
-- centralized multi-host inventory or analytics
-- preserved-boundary GUI or IDE clients
-- remote worker fleets
-
-## Remaining Work
-
-The remaining near-term work is to:
-
-- deepen validation coverage for detached-session transitions and
-  lower-assurance paths
-- add richer artifact browsing without weakening the host-owned model
-
-Longer-term product-direction items such as pause/resume, checkpoints, GUI
-clients, and enterprise inventory belong in [ROADMAP.md](../ROADMAP.md).
-
-## Peer Review
-
-### Findings
-
-1. Durable records must not live in `session-audit.*`.
-   Reason: `--gc` already treats those directories as stale runtime scratch and
-   can delete them.
-
-2. Session export needs an explicit session key in the audit log.
-   Reason: profile audit logs are cumulative and otherwise cannot be filtered
-   safely to one launch.
-
-3. The session plane should stay host-side and file-based first.
-   Reason: introducing a daemon, sockets, or background workers before the data
-   model stabilizes would add complexity faster than it adds operator value.
+- A queue or warm pool.
+- Pause, resume, checkpoint, or fork operations.
+- Central multi-host inventory or analytics.
+- A GUI or IDE client with the Tier 1 boundary claim.
+- A remote worker fleet.
 
 ## Residual Risks
 
-- Durable session records intentionally survive `--gc`; operators delete them
-  with `workcell session delete` when their audit value ends.
-- Aborted launches rely on host cleanup logic to mark the record as aborted.
-- Detached-session control exists, but there is still no queue, pause/resume,
-  or centralized session administration plane.
+- Durable records stay until the operator deletes them.
+- An aborted launch depends on host cleanup to record the aborted state.
+- The control plane has no central session administrator.
+- The process-local adapter remains shell code inside the container.
 
-Those are acceptable for the current slice because the main goal here is to
-create durable, auditable session objects and bounded detached-session control
-without weakening the reviewed boundary.
+These limits do not change the host-owned boundary. Add new session functions
+only when their state, audit, cleanup, and assurance behavior are explicit.


### PR DESCRIPTION
## Summary

- Rewrite the launcher contract around trusted execution, host tools, environment handling, and host-only publication.
- Rewrite the session design around host-owned state, durable records, command behavior, and the process-local adapter.
- Preserve public fragment identifiers and correct the Go and Bash dispatch boundary and file-trace process behavior.

## Validation

- Shared documentation lane
- Focused session command scenario
- Full repository validation
- Exact-head PR parity, host invariants, and container smoke
- Adversarial review until no actionable finding remained