### PR TITLE
Rewrite validation evidence guidance

### DIFF
--- a/docs/benchmark-evidence/exec-guard-bench-2026-07-05.md
+++ b/docs/benchmark-evidence/exec-guard-bench-2026-07-05.md
@@ -1,0 +1,49 @@
+# Exec-Guard Benchmark Raw Capture: 2026-07-05
+
+This file preserves the report from the
+[2026-07-05 Bench workflow run](https://github.com/omkhar/workcell/actions/runs/28729189802).
+The interpreted result is in
+[Syscall-Shim Benchmarks](../syscall-shim-benchmarks.md#results).
+
+- Pull-request head: `18bbcf26390a92c863476495e447bc981fd6b873`
+- Checked-out merge commit: `c1112cc1f50ccb5f9c4dbc1114e6f891b4b1f5c4`
+- Artifact digest: `sha256:59968e78b3c3dbf58536de1df9f861dd3dd4ff188c5e38c5ea85a3195982beaf`
+
+## Generated report
+
+The data below preserves the generated report labels and values. It replaces
+the runner workspace prefix with `$GITHUB_WORKSPACE`.
+
+- date (UTC): 2026-07-05T04:14:51Z
+- host: Linux 6.17.0-1018-azure x86_64
+- online CPUs: 4
+- target: /bin/true
+- iterations: 5000 (warmup 500) x 2 run(s)
+- cdylib: $GITHUB_WORKSPACE/runtime/container/rust/target/release/libworkcell_exec_guard.so
+
+### Run 1
+
+| Mode | Unhooked median (ns) | Hooked median (ns) | Delta (ns) | Delta (%) | Unhooked stddev (ns) | Hooked stddev (ns) |
+|---|---|---|---|---|---|---|
+| execve | 553855 | 818320 | 264465 | 47.7 | 66171 | 45594 |
+| execv | 551629 | 818568 | 266939 | 48.4 | 37468 | 46129 |
+| execvp | 565185 | 827073 | 261888 | 46.3 | 53482 | 42094 |
+| posix_spawn | 467863 | 524429 | 56566 | 12.1 | 34718 | 30218 |
+
+### Run 2
+
+| Mode | Unhooked median (ns) | Hooked median (ns) | Delta (ns) | Delta (%) | Unhooked stddev (ns) | Hooked stddev (ns) |
+|---|---|---|---|---|---|---|
+| execve | 549696 | 826893 | 277197 | 50.4 | 40175 | 38619 |
+| execv | 550807 | 815793 | 264986 | 48.1 | 38915 | 37926 |
+| execvp | 567039 | 824098 | 257059 | 45.3 | 35583 | 37278 |
+| posix_spawn | 469546 | 524850 | 55304 | 11.8 | 35119 | 32251 |
+
+### Cross-run stability (hooked median)
+
+| Mode | Min (ns) | Max (ns) | Spread (ns) | Spread (%) |
+|---|---|---|---|---|
+| execve | 818320 | 826893 | 8573 | 1.0 |
+| execv | 815793 | 818568 | 2775 | 0.3 |
+| execvp | 824098 | 827073 | 2975 | 0.4 |
+| posix_spawn | 524429 | 524850 | 421 | 0.1 |

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -1,165 +1,115 @@
 # Fuzzing
 
-Workcell fuzzes the hand-rolled parsers that sit on attacker- or
-contributor-influenceable input. Each target asserts a single invariant: for any
-input, the parser must not panic. An error return for malformed input is the
-expected, correct outcome; only a crash is a finding.
+Workcell fuzzes parsers and classifiers that process repository or
+attacker-controlled input. A target must not panic. A target must preserve its
+harness invariant.
 
 ## Where the targets live
 
-Fuzz targets are ordinary Go `Fuzz*` functions in `_test.go` files, each in the
-same package as the parser it exercises:
+### Go targets
 
-- `internal/metadatautil/fuzz_test.go`
-  - `FuzzExtractWorkflowUses` — the workflow-YAML `uses:` extractor that feeds
-    the default-deny GitHub Actions allowlist scan.
-  - `FuzzParseToolPins` — the `[tool_pins]` TOML parser behind
-    `policy/tool-pins.toml`.
-  - `FuzzValidateControlPlaneManifest` — the control-plane manifest JSON
-    validator.
-- `internal/tomlsubset/fuzz_test.go`
-  - `FuzzParse` — the TOML-subset parser that gates auth and injection policy.
-- `internal/injection/fuzz_test.go`
-  - `FuzzIsAllowedSystemSymlink` — the direct-mount source-chain oracle.
-  - `FuzzParseSSHDirective` — the SSH config directive parser.
+| Package | Target | Surface |
+|---|---|---|
+| `internal/metadatautil` | `FuzzExtractWorkflowUses` | GitHub Actions `uses` values |
+| `internal/metadatautil` | `FuzzParseToolPins` | Tool-pin TOML |
+| `internal/metadatautil` | `FuzzValidateControlPlaneManifest` | Control-plane manifest JSON |
+| `internal/tomlsubset` | `FuzzParse` | Policy TOML subset |
+| `internal/injection` | `FuzzIsAllowedSystemSymlink` | Direct-mount source chains |
+| `internal/injection` | `FuzzParseSSHDirective` | SSH configuration directives |
 
-Seed corpora are drawn from real repository configs (actual workflow files, the
-real `policy/tool-pins.toml`, and the committed control-plane manifest) plus
-enumerated malformed shapes, so the checked-in corpus reflects the inputs these
-parsers actually see.
+The seed corpus includes repository configuration and invalid forms. The
+`go test ./...` pull-request lane replays each saved seed.
 
 ### Rust exec-guard classifiers (cargo-fuzz)
 
-The `workcell_exec_guard` LD_PRELOAD guard (`runtime/container/rust/`) is fuzzed
-with [cargo-fuzz]/libFuzzer. Targets live in
-`runtime/container/rust/fuzz/fuzz_targets/`, one per A3 parser surface:
+The Rust targets use `cargo-fuzz` and libFuzzer.
 
-- `path_classification` — `classify_protected_runtime_path`,
-  `path_points_to_dynamic_loader`, and `classify_loader_target` (the path
-  validation / dynamic-loader classification surface).
-- `env_filtering` — `path_from_env_entries`, `env_has_unsafe_git_override`, and
-  `resolve_command_via_path_value` (the environment-filtering surface).
-- `git_config_parsing` — `git_config_spec_is_blocked`,
-  `git_config_key_is_blocked`, and `git_config_spec_value_is_explicit_safe` (the
-  git-config spec parsing surface).
+| Target | Surface |
+|---|---|
+| `path_classification` | Protected runtime paths and dynamic loaders |
+| `env_filtering` | Path lookup and unsafe Git environment values |
+| `git_config_parsing` | Git configuration keys and values |
 
-These classifiers are private in the shipped `cdylib`. They are exposed to the
-fuzz targets only through the `fuzz_api` module in `src/lib.rs`, which is gated
-`#[cfg(fuzzing)]` — cargo-fuzz sets `--cfg fuzzing`, so the widened surface never
-exists in the normal `cargo build`/`cargo test` or the released library. The
-crate adds `rlib` to `crate-type` purely so cargo-fuzz can link the lib; the
-`cdylib` artifact is unchanged. Seed corpora
-(`runtime/container/rust/fuzz/corpus/<target>/`) are real loader paths, environ
-entries, and git-config specs taken from the guard's own constants.
+The targets are in `runtime/container/rust/fuzz/fuzz_targets/`. Their seed data
+is in `runtime/container/rust/fuzz/corpus/`.
 
-[cargo-fuzz]: https://github.com/rust-fuzz/cargo-fuzz
+The release library does not export the private classifiers. Fuzz builds enable
+`fuzz_api` through `cfg(fuzzing)`.
 
 ## Running a target locally
 
-The seed corpus runs as a normal regression test on every PR:
+Run the Go seed tests:
 
 ```sh
 go test ./internal/metadatautil/ ./internal/tomlsubset/ ./internal/injection/
 ```
 
-To spend a bounded budget mutating the seeds for one target, name the target and
-its package:
+Run one target for one minute:
 
 ```sh
-go test ./internal/metadatautil/ -run '^$' -fuzz='^FuzzParseToolPins$' -fuzztime=1m
+go test ./internal/metadatautil/ -run '^$' \
+  -fuzz='^FuzzParseToolPins$' -fuzztime=1m
 ```
-
-`-fuzz` runs exactly one target in one package at a time; `-run '^$'` skips the
-ordinary unit tests so only the fuzzer runs.
 
 ### Rust targets
 
-The Rust targets need the nightly toolchain (libFuzzer's sanitizer/coverage
-codegen) and `cargo-fuzz`:
+Install the pinned tools:
 
 ```sh
-# Use the same dated nightly the scheduled lane pins
-# (WORKCELL_RUST_FUZZ_NIGHTLY in .github/workflows/fuzz.yml) so local runs match
-# CI; bump both together and refresh fuzz/Cargo.lock when moving it.
 rustup toolchain install nightly-2026-07-02
 cargo install cargo-fuzz --version 0.13.2 --locked
 ```
 
-The exec-guard crate pins crates.io to a vendored directory for its reproducible
-shipping build (`runtime/container/rust/.cargo/config.toml`), and the
-non-shipping fuzz crate's extra dependency (`libfuzzer-sys`) is not vendored. A
-local fuzz build therefore needs crates.io access for that one dependency, so
-`cargo +nightly-2026-07-02 fuzz build` will fail dependency resolution against the vendored
-config unless you first override it. Apply the same override the scheduled lane
-uses (see the `Rust fuzz` job in [`.github/workflows/fuzz.yml`](../.github/workflows/fuzz.yml)):
-in `runtime/container/rust/.cargo/config.toml`, temporarily **remove** (or comment
-out) the `replace-with = "vendored-sources"` line so `crates.io` resolves from its
-built-in default registry. Do not add a second source pointed at the crates.io
-index — Cargo rejects that as a duplicate of the built-in `crates-io` source. Do
-this locally only and **do not commit it** — the committed vendored config is what
-release builds use.
+The release crate uses vendored sources. The fuzz crate also needs
+`libfuzzer-sys` from crates.io.
 
-Then, from `runtime/container/rust/`, build all targets or run one on its seed
-corpus for a bounded budget:
+For a local fuzz build, temporarily remove the `replace-with =
+"vendored-sources"` line from `runtime/container/rust/.cargo/config.toml`.
+Do not commit that change.
+
+Then run these commands from `runtime/container/rust/`:
 
 ```sh
 cargo +nightly-2026-07-02 fuzz build
-cargo +nightly-2026-07-02 fuzz run path_classification -- -max_total_time=25
+cargo +nightly-2026-07-02 fuzz run path_classification -- \
+  -max_total_time=25
 ```
 
 ## Scheduled lane
 
-`.github/workflows/fuzz.yml` runs weekly and on demand. It gives each target a
-few minutes of fuzzing, exercising every target above. The `Go fuzz` job runs
-the Go targets inside the validator image (via `scripts/ci/job-fuzz.sh` →
-`scripts/ci/run-fuzz-in-validator.sh`) so it uses the reviewed, pinned Go
-toolchain rather than the runner's ambient Go. The `Rust fuzz` job installs the
-nightly toolchain plus `cargo-fuzz` and runs each Rust target for a bounded
-`-max_total_time` budget. Neither job is on the PR path — the Go seed corpus
-already gates PRs through the normal `go test` lanes, and the Rust seed corpora
-are checked in — so the lane stays a scheduled, heavy sweep. Both jobs are
-registered in `policy/workflow-lane-policy.json` and reflected in
-`policy/workflow-lanes.json`; their crash-artifact retention is in
-`policy/retention-policy.json`.
+`.github/workflows/fuzz.yml` runs each target each week and on demand.
+
+The Go job uses the pinned validator image. The Rust job installs the pinned
+nightly toolchain and `cargo-fuzz` version.
+
+The workflow is not a pull request gate. The `go test ./...` pull-request lane
+replays the saved Go seed corpus. The scheduled or on-demand Rust job replays
+the saved Rust corpus.
+
+Workflow lane policy and retention policy record both jobs and their crash
+artifacts.
 
 ## Crash triage
 
 ### Go
 
-When the fuzzer finds a crash it writes a reproducer file at
-`testdata/fuzz/<Target>/<hash>` next to the target's package and fails the run.
-On the scheduled lane the failing job uploads those files as the
-`fuzz-reproducers` artifact before the runner workspace is discarded, so the
-exact input survives the run.
-To triage:
+For a Go crash:
 
-1. Retrieve the reproducer — from the failing run's `fuzz-reproducers` artifact
-   for a scheduled-lane crash, or from your working tree for a local one — and
-   commit it. It becomes a permanent regression seed and, once fixed, guards
-   against the crash returning.
-2. Reproduce it directly: `go test ./<package>/ -run='^<Target>$/<hash>$'`.
-3. Fix the parser so the input returns an error instead of panicking.
-4. Re-run the target with `-fuzz` to confirm the crash is gone and no new one
-   appears.
+1. Download the `fuzz-reproducers` artifact.
+2. Put the input in `PACKAGE/testdata/fuzz/TARGET/HASH`.
+3. Reproduce it with `go test ./PACKAGE -run='^TARGET$/HASH$'`.
+4. Fix the parser or classifier so the harness invariant holds.
+5. Commit the input as a regression seed.
+6. Run the target again.
 
 ### Rust
 
-When a Rust target crashes, libFuzzer prints the panic and writes the minimized
-failing input under `runtime/container/rust/fuzz/artifacts/<target>/`. The
-scheduled `Rust fuzz` job uploads that directory as the `rust-fuzz-reproducers`
-artifact on failure, so the exact input survives the run.
-To triage, from `runtime/container/rust/`:
+For a Rust crash:
 
-1. Retrieve the reproducer — from the failing run's `rust-fuzz-reproducers`
-   artifact for a scheduled-lane crash, or from `fuzz/artifacts/<target>/` for a
-   local one.
-2. Reproduce it directly by replaying the single input:
-   `cargo +nightly-2026-07-02 fuzz run <target> fuzz/artifacts/<target>/<crash-file>`.
-3. Optionally minimize it further: `cargo +nightly-2026-07-02 fuzz tmin <target>
-   fuzz/artifacts/<target>/<crash-file>`.
-4. Decide whether the crash is a real classifier bug (fix `src/lib.rs` so the
-   input is handled instead of panicking) or an over-aggressive target (fix the
-   harness). Add the minimized input to `fuzz/corpus/<target>/` as a permanent
-   regression seed.
-5. Re-run the target (`cargo +nightly-2026-07-02 fuzz run <target> -- -max_total_time=60`)
-   to confirm the crash is gone and no new one appears.
+1. Download the `rust-fuzz-reproducers` artifact.
+2. Put the input in `fuzz/artifacts/TARGET/`.
+3. Replay it with `cargo +nightly-2026-07-02 fuzz run TARGET PATH`.
+4. Minimize it with `cargo +nightly-2026-07-02 fuzz tmin TARGET PATH`.
+5. Fix the classifier or the harness.
+6. Put the minimized input in `fuzz/corpus/TARGET/`.
+7. Run the target again.

--- a/docs/session-startup-benchmarks.md
+++ b/docs/session-startup-benchmarks.md
@@ -1,209 +1,141 @@
 # Session-start latency baselines
 
-Workcell starts an isolated session by resolving the runtime image, booting the
-container runtime (Colima today, Apple `container` under evaluation in C1), and
-completing the supervisor handshake. The post-1.0 **C2** program measures that
-latency and drives it down with cached images and an optional kept-warm lane — the sibling of
-[syscall-shim-benchmarks.md](syscall-shim-benchmarks.md) (C5). Numbers are captured
-on a host with a live runtime, not in PR CI (a real start needs a booted VM); the
-[results tables below](#results) hold a **preliminary live capture from 2026-07-15**
-— recorded with its raw evidence, but confounded by four methodology issues
-(documented there) and therefore not a certified C2 result.
+## Where this fits
+
+Workcell does not publish a certified session-start target. The C2 performance
+claim remains deferred.
+
+This page describes the benchmark driver and a preliminary 2026-07-15 capture.
+The capture has known confounds and is not certification evidence.
 
 ## What is measured
 
-A **sample** is one full session start: the wall-clock time from invoking the
-session-start command to the point the session is ready. The benchmark times
-three modes that span the latency shapes C2 targets:
+One sample measures wall-clock time from `session start` invocation until the
+session monitor reports ready.
 
-| Mode | Runtime state before the sample | What it isolates |
+| Mode | Intended state | Purpose |
 |---|---|---|
-| `cold` | image tag absent; Workcell tarball retained; profile stopped | tarball restore + full boot |
-| `warm` | image cached and a kept-warm session available | best-case start off the kept-warm lane |
-| `cache-hit` | image cached, no kept-warm session | the image-cache win alone, without the warm lane |
+| `cold` | Image absent and profile stopped | Image restore and runtime boot |
+| `cache-hit` | Image present and no warm session | Image-cache effect |
+| `warm` | Image present and verified warm session | Warm-session effect |
 
-These modes establish no performance guarantee or C2 certification.
+The Go driver uses a monotonic clock. It includes target launch and output
+capture. It excludes driver setup and cleanup.
+
+The report contains median, p90, mean, population standard deviation, minimum,
+and maximum values.
 
 ## Methodology
 
-The Go driver behind `scripts/bench/run-startup-bench.sh` times each launch on a
-monotonic clock. Driver startup, output validation, and cleanup are outside the
-interval; target launch and stdout capture are inside it. Stats conventions match C5:
+`scripts/bench/run-startup-bench.sh` applies these rules:
 
-- **median** (`sorted[floor(n/2)]`, the outlier-robust headline), **p90**
-  (`sorted[floor(n*9/10)]` clamped, the tail a slow start shows), **mean/stddev**
-  (population, to expose a skewed distribution), and **min/max** (observed range).
-
-The driver (`scripts/bench/run-startup-bench.sh`) establishes each mode's runtime
-state through a per-mode prep hook (`WORKCELL_STARTUP_COLD_PREP` /
-`WORKCELL_STARTUP_CACHE_HIT_PREP` / `WORKCELL_STARTUP_WARM_PREP` — e.g. evicting
-the cached image and stopping the kept-warm session for `cold`, pre-pulling the
-image but leaving the warm lane down for `cache-hit`, or pre-pulling and priming
-the warm lane for `warm`), then times the exact argv after `--`. The target emits
-exactly `session_id=...` and `sample_token=...`, echoing the random token. Teardown
-receives the token with an empty session ID; the absence operation receives both
-and must echo matching fields. These hooks cannot prove resource ownership,
-cleanup, or lifecycle state. The measurement repeats for `WORKCELL_STARTUP_RUNS`
-passes.
-
-Live runs are guarded so a misconfigured capture cannot look publishable:
-
-- **Every driven mode's prep hook is required** (`*_COLD_PREP` /
-  `*_CACHE_HIT_PREP` / `*_WARM_PREP`); an unset hook fails fast rather than
-  measuring whatever state happened to be present.
-- **Teardown and absence operations are required** after every launch. Live `warm`
-  is opt-in and also requires `WORKCELL_STARTUP_WARM_VERIFY`; default modes are
-  `cold cache-hit`.
-- **The runtime must be usable, not just installed** — a cheap read-only probe
-  (`docker info` / `colima status` / `container system status`) sends a
-  client-only host to the clean CI-safe skip. `WORKCELL_STARTUP_RUNTIME` overrides
-  and skips the probe.
-- **`WORKCELL_STARTUP_RUNS >= 2`** — the stability gate needs cross-run evidence,
-  so a single-run capture is rejected.
-
-For `cold` **and `cache-hit`** the driver re-runs the mode's prep hook before
-**every** measured sample (warmup `0`) and aggregates the per-sample timings — a
-start warms the cache/lane the next start would spend, so prepping once per pass
-would leave only the first sample genuine; those hooks must be **repeatable**.
-Only `warm` shares one prep per pass; its warmups are also torn down.
-
-Measured argv follows `--`, preserving each argument without shell parsing. Every
-state operation names one executable path. Canned dry runs execute no operations.
+- Each selected mode requires its preparation command.
+- Cold and cache-hit preparation runs before each measured sample.
+- Each launch requires teardown and an absence check.
+- Warm mode also requires `WORKCELL_STARTUP_WARM_VERIFY`.
+- A live run requires a usable runtime.
+- A live run requires at least two passes.
+- Each target must return the expected session ID and sample token.
 
 ### The cross-run stability gate
 
-The driver enforces a reproducibility guard: after all
-runs it computes, per mode, the run-to-run **median** spread as a percentage of
-the smallest run's median, and **fails** (non-zero exit) if any mode exceeds
-`WORKCELL_STARTUP_STABILITY_PCT` (default 15%) — the evidence a published number
-repeats. A zero median fails the gate outright: a 0 ns start is impossible, so it
-signals a broken clock rather than a 0% spread that would read as `STABLE`.
+The driver checks the spread between run medians. The default maximum spread is
+15% of the smallest run median. A zero median or larger spread fails the run.
 
 ### Runner caveats
 
-Numbers are **relative** to the host's hardware and runtime backend. A warm delta
-is meaningful only when a kept-warm lane is present and verified.
+These guards check command results. They do not prove resource ownership or a
+correct runtime state. A dedicated certifier is necessary for a C2 claim.
 
 ## Results
 
-**Status: PRELIMINARY capture 2026-07-15 — benchmark-only, not C2 certification.**
-Captured on the maintainer host (Darwin 25.5.0 arm64, 12 online
-CPUs, `colima` runtime, profile `wcl-workcell-006e49ec`), 5 iterations × 2 runs,
-`codex` provider; the cross-run stability gate passed (exit 0) — its overall max
-cross-run median spread was **4.1%**, from the unpromoted `cache-hit` mode; the two
-promoted tiers below were each ≤0.6%. The **exact
-invocation (`WORKCELL_STARTUP_CMD` + all three prep hooks) and the complete raw
-report** are preserved verbatim in
-[`benchmark-evidence/session-startup-2026-07-15.md`](benchmark-evidence/session-startup-2026-07-15.md).
-Four methodology confounds (below) mean these numbers are a useful preliminary
-signal, **not** a certified C2 result or a 1.0 latency target.
-
 ### Measured start latency (5 samples per run, both runs shown)
 
-The two reported tiers are named for the **image state they actually exercise**, not
-for a kept-warm session lane (see caveat 1). Both runs are shown verbatim — the p90,
-mean, and stddev differ materially between runs (e.g. cold p90 21.9 s in Run 1 vs
-16.0 s in Run 2), so no single run's non-median statistics are representative; only
-the medians are stable cross-run (≤0.6%, see the stability table):
+Status: preliminary capture from 2026-07-15.
 
-| Tier (harness mode) | Run | Median (ns) | p90 (ns) | Mean (ns) | Stddev (ns) | median ≈ |
-|---|---|---|---|---|---|---|
-| image-evicted → tarball restore (`cold`) | 1 | 15863271000 | 21907998000 | 17088363200 | 2410769883 | 15.9 s |
-| image-evicted → tarball restore (`cold`) | 2 | 15958072000 | 15980669000 | 15888017600 | 149981479 | 16.0 s |
-| image-resident (`warm`) | 1 | 13457187000 | 13685462000 | 13497043600 | 99040400 | 13.5 s |
-| image-resident (`warm`) | 2 | 13543427000 | 13659044000 | 13489852400 | 139001557 | 13.5 s |
+| Capture item | Value |
+|---|---|
+| Host | `Darwin 25.5.0 arm64` |
+| Online CPUs | `12` |
+| Runtime | `colima` |
+| Provider | `codex` |
+| Samples per run | `5` |
+| Runs | `2` |
+| Maximum median spread | `4.1%` |
 
-The ~2.4 s median difference between the tiers is the **Docker-image
-restore-from-tarball cost**, not a kept-warm-session win.
+The capture measured the image archive-restore state and the image-resident
+state. It did not measure a warm-session lane.
+
+| Actual tier | Run | Median (ns) | p90 (ns) | Mean (ns) | Standard deviation (ns) |
+|---|---|---|---|---|---|
+| Image archive restore | 1 | 15863271000 | 21907998000 | 17088363200 | 2410769883 |
+| Image archive restore | 2 | 15958072000 | 15980669000 | 15888017600 | 149981479 |
+| Image resident | 1 | 13457187000 | 13685462000 | 13497043600 | 99040400 |
+| Image resident | 2 | 13543427000 | 13659044000 | 13489852400 | 139001557 |
 
 ### Cross-run stability (median)
 
-| Tier | Min median (ns) | Max median (ns) | Spread (ns) | Spread (%) | Verdict |
-|---|---|---|---|---|---|
-| `cold` | 15863271000 | 15958072000 | 94801000 | 0.6 | STABLE |
-| `warm` | 13457187000 | 13543427000 | 86240000 | 0.6 | STABLE |
+| Tier | Minimum median (ns) | Maximum median (ns) | Spread |
+|---|---|---|---|
+| Image archive restore | 15863271000 | 15958072000 | 0.6% |
+| Image resident | 13457187000 | 13543427000 | 0.6% |
+
+The median difference is approximately 2.4 seconds. It represents image archive
+restore cost. It is not a warm-session improvement.
 
 ### Methodology confounds (why this is preliminary, not certified)
 
-1. **No kept-warm session was exercised.** The `warm` prep only prepares the image;
-   a detached `codex` session started with no task exits within seconds, so no
-   persistent kept-warm session existed during the `warm` samples. The `warm` tier
-   therefore measures an **image-resident start**, not the documented kept-warm lane,
-   and the delta above must **not** be read as a warm-lane win.
-2. **`cache-hit` shows a real, unexplained anomaly — not noise.** In the raw report
-   `cache-hit` medians are 23.75 s / 24.73 s versus 15.86 s / 15.96 s for `cold` —
-   roughly **50–55% slower with no overlapping sample range**. Running `--prepare-only`
-   before each sample (the `cache-hit` prep) demonstrably makes the subsequent start
-   *slower* than evicting the image, which is counter-intuitive and **unresolved**. It
-   is preserved in the raw report and flagged here for investigation; it is not dropped
-   as noise.
-3. **`cold` is a tarball restore, not a first-ever build.** The `cold` prep evicts only
-   the Docker image while Workcell's local image tarball remains, so `cold` reloads from
-   that tarball. A genuinely fresh host (no tarball) additionally runs the one-time
-   `buildx` build of `workcell:local` (minutes) — a provisioning cost excluded here.
-4. **Per-sample teardown never ran.** The teardown was a shell function exported via
-   `export -f` under zsh (a no-op there), so it did not reach the driver and no session
-   teardown ran between samples (see the raw evidence). Detached no-task sessions
-   self-terminate within seconds, so live sessions did not accumulate across the ~15 s
-   gaps — but the samples did not begin in the harness's intended clean state, and this
-   is a candidate contributor to the `cache-hit` anomaly.
+1. The taskless warm session exited before the samples.
+2. The cold mode kept the local image archive.
+3. A Zsh function export did not run per-sample cleanup.
+4. Cache-hit medians were 50% to 55% slower than cold medians.
 
-A future C2 certification should prove **working per-sample teardown**, resolve the
-`cache-hit` anomaly, and decide whether to capture a no-tarball first-start tier.
+The cause of the cache-hit result remains unknown. Do not use it for a
+performance claim.
 
 ## Filling in the numbers
 
-On a host with a live runtime, run the driver (see [Rerunning](#rerunning)) with
-`WORKCELL_STARTUP_OUTPUT` set. A `0` exit means the benchmark stability gate
-passed; non-zero can also mean configuration, launch, or cleanup failure. Generic
-driver output cannot certify or promote C2; the `certify` command is rejected.
+The [raw capture](benchmark-evidence/session-startup-2026-07-15.md) contains the
+exact command, all samples, and the complete confound record.
 
 ## Rerunning
 
-From the repository root on a host with a container runtime:
+On a host with a live runtime, set repeatable state commands:
 
 ```sh
-export WORKCELL_STARTUP_COLD_PREP=/absolute/path/to/repeatable-cold-operation
-export WORKCELL_STARTUP_CACHE_HIT_PREP=/absolute/path/to/repeatable-cache-operation
-export WORKCELL_STARTUP_TEARDOWN=/absolute/path/to/exact-session-teardown
-export WORKCELL_STARTUP_TEARDOWN_VERIFY=/absolute/path/to/absence-verifier
+export WORKCELL_STARTUP_COLD_PREP=/absolute/path/to/cold-preparation
+export WORKCELL_STARTUP_CACHE_HIT_PREP=/absolute/path/to/cache-preparation
+export WORKCELL_STARTUP_TEARDOWN=/absolute/path/to/session-teardown
+export WORKCELL_STARTUP_TEARDOWN_VERIFY=/absolute/path/to/absence-check
 export WORKCELL_STARTUP_OUTPUT=session-startup-results.md
 
-# Defaults: 5 iterations, 1 warmup, 2 runs, 15% stability threshold.
-./scripts/bench/run-startup-bench.sh -- /absolute/path/to/measured-wrapper arg1
+./scripts/bench/run-startup-bench.sh -- \
+  /absolute/path/to/measured-wrapper ARGUMENT
 ```
 
-Operations receive `WORKCELL_STARTUP_SAMPLE_MODE`, `WORKCELL_STARTUP_SAMPLE_RUN`,
-and `WORKCELL_STARTUP_SAMPLE_INDEX`; target, teardown, and verifier also receive
-`WORKCELL_STARTUP_SAMPLE_TOKEN`, while the verifier receives
-`WORKCELL_STARTUP_SESSION_ID`.
+The driver passes sample mode, run, index, and token through `WORKCELL_STARTUP_*`
+variables. It passes an empty session ID to teardown. It passes the parsed
+session ID only to the absence check.
 
-Other controls select iterations, warmup (forced to `0` for `cold`/`cache-hit`),
-runs, stability threshold, modes, operations, and output. Numeric controls are validated
-(`ITERATIONS`/`RUNS` `>= 1`, `WARMUP`/`STABILITY_PCT` `>= 0`); anything else fails
-fast rather than silently misreporting.
+The default modes are `cold cache-hit`. If a persistent warm session exists,
+set `WORKCELL_STARTUP_MODES='cold cache-hit warm'`. Then set the warm
+preparation and verification commands.
 
 ### Dry run without a runtime
 
-The driver is CI-safe: with no runtime it exits `0` with a clear skip message. To
-rehearse the full report and stability gate on any host, feed canned samples — the
-dry run runs no prep hooks (any exported `*_PREP` is ignored) and times nothing:
+The driver exits with a skip result when no runtime is usable. Synthetic test
+values can exercise report generation without a runtime:
 
 ```sh
-# One stable run set (gate passes, exit 0):
-WORKCELL_STARTUP_SAMPLES_NS='10 20 30 40 50' ./scripts/bench/run-startup-bench.sh
-
-# Two ';'-separated per-run groups with divergent medians (gate fails non-zero):
-WORKCELL_STARTUP_SAMPLES_NS='10 20 30;100 200 300' ./scripts/bench/run-startup-bench.sh
+WORKCELL_STARTUP_SAMPLES_NS='10 20 30 40 50' \
+  ./scripts/bench/run-startup-bench.sh
 ```
 
-The unit tests in `internal/startupbench` use this canned path (plus benign live
-targets) to pin the stats math, the gate, and the guards without a container.
+Use two semicolon-separated run groups to test the stability failure:
 
-## Where this fits
+```sh
+WORKCELL_STARTUP_SAMPLES_NS='10 20 30;100 200 300' \
+  ./scripts/bench/run-startup-bench.sh
+```
 
-The thin `scripts/bench/run-startup-bench.sh` wrapper invokes the Go
-implementation in `internal/startupbench`; its wrapper remains alongside the C5
-exec-guard benchmark ([syscall-shim-benchmarks.md](syscall-shim-benchmarks.md)).
-A scheduled, non-PR-blocking lane that captures the live numbers on a
-runtime-capable runner is **deferred** until the image build is unblocked.
+The synthetic test path runs no state command and measures no launch.

--- a/docs/standards-watchlist.md
+++ b/docs/standards-watchlist.md
@@ -1,32 +1,28 @@
 # Standards Watchlist
 
-Workcell tracks a small set of external standards that shape how coding agents
-are configured, secured, and identified. This is a living reference: it records
-each standard's current status and what to watch, so the project's controls and
-docs stay aligned as the standards move.
+The maintainer reviews this list each quarter. Review it sooner when a tracked
+body publishes a new version.
 
-- **Owner:** the maintainer (see [MAINTAINERS.md](../MAINTAINERS.md)).
-- **Review cadence:** quarterly, or sooner when a tracked standard publishes a
-  new version.
-- **Last reviewed:** 2026-07-04.
-- **Next review due:** 2026-10-04.
+- Last review: 2026-08-06.
+- Next planned review: 2026-11-06.
 
 ## Watchlist
 
-| Standard | Body | Status at last review | Canonical source | Why it matters to Workcell | What to watch |
-|---|---|---|---|---|---|
-| Model Context Protocol (MCP) | Agentic AI Foundation (Linux Foundation); originated at Anthropic | Date-revisioned spec (e.g. `2025-11-25`); donated to the Linux Foundation's Agentic AI Foundation in December 2025 | <https://modelcontextprotocol.io/specification> | Workcell injects MCP server/config surfaces for providers; auth and transport changes affect what the runtime must contain and validate | new spec revisions; OAuth/OIDC auth alignment; transport changes; the SEP (Specification Enhancement Proposal) process and any working-group split |
-| OWASP Top 10 for Agentic Applications | OWASP GenAI Security Initiative | 2026 edition (ASI01–ASI10), released December 2025 | <https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/> | Workcell's control coverage is mapped against it in [owasp-agentic-mapping.md](owasp-agentic-mapping.md); a new edition would change that mapping | the next edition and its cadence; changes to ASI03 (agent identity); divergence from the separate LLM Top 10 |
-| Agent identity and authentication | IETF WIMSE working group, plus individual drafts | Active work in the IETF **WIMSE** WG (Workload Identity in Multi-System Environments), which covers workload/agent identity and carries agent-specific drafts (e.g. WIMSE applicability to AI agents, cross-organizational delegation); complemented by individual drafts building on OAuth 2.0, SPIFFE, and WIMSE. A dedicated agent-identity protocol is still emerging. | <https://datatracker.ietf.org/wg/wimse/> | Bears on how Workcell would attest and authenticate an agent's actions beyond human OAuth; informs ASI03 posture | WIMSE WG documents (esp. the AI-agent applicability and delegation drafts) advancing toward RFC; adoption of OAuth extensions for agent-to-service auth |
+| Work | Status at review | Workcell effect | Next check |
+|---|---|---|---|
+| [Model Context Protocol 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28) | Current dated specification | MCP transport, authorization, and extension changes can affect injected configuration and runtime controls. | Check adapter support for the stateless protocol and authorization changes. |
+| [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) | Published 2026 edition | Workcell maps its controls to ASI01 through ASI10. | Check for a new edition. If OWASP publishes one, update the mapping. |
+| [IETF WIMSE documents](https://datatracker.ietf.org/wg/wimse/documents/) | Active working-group and individual drafts | Workload identity can affect future agent authentication and delegation. | Check architecture, credential, proof-token, and AI-agent drafts. |
 
 ## Notes
 
-- The OWASP entry is the authoritative input to Workcell's agentic-security
-  control mapping; keep it and [owasp-agentic-mapping.md](owasp-agentic-mapping.md)
-  in step when the edition changes.
-- The agent-identity line is deliberately conservative: the active venue is the
-  IETF WIMSE working group, but a dedicated agent-identity protocol is still
-  emerging (multiple drafts building on OAuth 2.0, SPIFFE, and WIMSE), so
-  Workcell tracks WIMSE without committing to any one draft.
-- Version numbers and dates above reflect the last-reviewed date; confirm the
-  canonical sources at each review rather than trusting this snapshot.
+The MCP 2026-07-28 version changes the core protocol to stateless requests. It
+also adds new authorization and extension rules.
+
+The OWASP item is the source for the
+[agentic application mapping](owasp-agentic-mapping.md). Update both documents
+together when OWASP publishes a new edition.
+
+WIMSE work is not a Workcell implementation commitment. The AI-agent identity
+documents remain Internet-Drafts. Do not describe them as an IETF standard or
+an approved agent identity protocol.

--- a/docs/syscall-shim-benchmarks.md
+++ b/docs/syscall-shim-benchmarks.md
@@ -60,9 +60,9 @@ complete runs for each mode.
 
 ### Allow-path overhead (median of 5000 samples, 2 runs)
 
-The [2026-07-05 Bench workflow run](https://github.com/omkhar/workcell/actions/runs/28729189802)
-measured these values on a GitHub-hosted Linux runner. It used the release
-library with glibc.
+The [raw two-run report](benchmark-evidence/exec-guard-bench-2026-07-05.md)
+comes from the [2026-07-05 Bench workflow run](https://github.com/omkhar/workcell/actions/runs/28729189802).
+The run used a GitHub-hosted Linux runner and the release library with glibc.
 
 | Mode | Plain median (ns) | Guard median (ns) | Delta (ns) | Delta |
 |---|---|---|---|---|
@@ -123,3 +123,5 @@ not apply to macOS.
 
 To refresh this page, run the scheduled workflow. Copy the two-run medians and
 spreads from its artifact. Do not use one run as a published result.
+Preserve the complete report in `docs/benchmark-evidence/` before you publish
+new values.

--- a/docs/syscall-shim-benchmarks.md
+++ b/docs/syscall-shim-benchmarks.md
@@ -1,158 +1,125 @@
 # Syscall-shim performance baselines
 
-The `workcell_exec_guard` LD_PRELOAD shim (`runtime/container/rust/src/lib.rs`)
-interposes the libc exec/spawn family and classifies every launch before
-forwarding it to the real entry point. This page records the added latency that
-classification costs on the **allow path** -- a launch the guard permits and
-forwards -- and the methodology and rerun steps behind those numbers. Its
-sibling page, [session-startup-benchmarks.md](session-startup-benchmarks.md),
-records historical, benchmark-only C2 session-start measurements; it makes no
-1.0 performance claim.
+The Linux `workcell_exec_guard` library checks each intercepted process launch.
+This page records the added classification latency on the allow path.
 
-The numbers are produced by the optional `bench.yml` GitHub lane on Linux, not
-on the macOS development host: the shim reads `/proc` and interposes the
-glibc/musl symbols, so its overhead only exists on Linux. The results table
-below holds the measured values from that lane; rerun it to refresh them (see
-[Filling in the numbers](#filling-in-the-numbers)).
+The result is a relative Linux CI measurement. It is not an absolute performance
+guarantee for an operator host.
 
 ## What the guard hooks, and what the harness measures
 
-The shim exports and interposes these libc symbols (`#[no_mangle]` entries in
-`runtime/container/rust/src/lib.rs`):
+The library interposes these functions:
 
-- `execve`, `execv`, `execvp`, `execvpe`
-- `execveat`, `fexecve`
-- `posix_spawn`, `posix_spawnp`
-- `syscall` (via an assembly trampoline that re-dispatches `SYS_execve` /
-  `SYS_execveat` back through the hooked `execve` / `execveat`)
+- `execve`
+- `execv`
+- `execvp`
+- `execvpe`
+- `execveat`
+- `fexecve`
+- `posix_spawn`
+- `posix_spawnp`
+- `syscall` for `SYS_execve` and `SYS_execveat`
 
-The microbenchmark exercises four representative entry points that span the two
-distinct overhead shapes:
+The benchmark samples four representative functions:
 
-| Harness mode | Interposed symbol | Overhead shape |
-|---|---|---|
-| `execve` | `execve` | classification runs in the forked child (cold per launch) |
-| `execv` | `execv` | as above; reads `environ` rather than an explicit `envp` |
-| `execvp` | `execvp` | as above, plus `PATH` search resolution |
-| `posix_spawn` | `posix_spawn` | classification runs in the calling process (warm, cached signatures) |
+| Mode | Additional behavior |
+|---|---|
+| `execve` | Reads explicit argument and environment arrays. |
+| `execv` | Reads the process environment. |
+| `execvp` | Resolves a bare command through a controlled `PATH`. |
+| `posix_spawn` | Uses classifier caches in the long-lived driver. |
 
-`execveat` / `fexecve` / `posix_spawnp` share the same classifier code paths as
-the sampled entry points, so they are covered transitively rather than sampled
-separately.
+The other interposed functions reuse these classifier paths, except for
+`execveat` and `fexecve`. The benchmark does not measure their file-descriptor
+paths. It does not sample the other hooks separately.
 
 ## Methodology
 
-The harness (`scripts/bench/exec-guard-bench.c`) launches a benign target
-(`/bin/true`) that the guard classifies as "not protected" and forwards, so
-every sample runs the classifier to completion on the allow path -- it measures
-classification cost, not a blocked-exec early return. Each sample is one
-`fork` + exec + `wait` (for the `exec*` modes) or one `posix_spawn` + `wait`.
+`scripts/bench/exec-guard-bench.c` launches `/bin/true`. The guard permits this
+target and completes all allow-path classification.
 
-The driver (`scripts/bench/run-exec-guard-bench.sh`) runs the harness twice per
-mode -- once unhooked (plain libc) and once with `LD_PRELOAD` set to the built
-`libworkcell_exec_guard.so` -- and reports the delta. The same fork/exec/wait
-structure is on both sides, so the delta isolates the guard's added latency.
+`scripts/bench/run-exec-guard-bench.sh` measures each mode twice:
 
-The harness removes `LD_PRELOAD` from the environment (via `unsetenv`) before the
-measured launches. The guard is already resident in the harness from its own
-startup, so its hooks still fire and classify every launch; scrubbing the
-variable only stops each measured child from **re-loading** the `.so`. Without
-this, every hooked sample would also charge the dynamic loader's one-time cost of
-mapping the preload into the short-lived `/bin/true` child, and the delta would
-be a mix of classifier cost and per-child loader cost. The published numbers are
-therefore the guard's **classification** overhead; a real container additionally
-pays that per-launch loader cost, amortized over each child's lifetime. The
-`execvp` mode launches a **bare** command name against a controlled `PATH` (the
-driver sets `PATH` so the target's directory resolves it) so it exercises the
-guard's `PATH`-search resolution rather than an absolute-path fast path.
+1. Plain libc without the guard.
+2. The same operation with the guard preloaded.
 
-Variance is controlled by:
-
-- **Warmup.** `WORKCELL_BENCH_WARMUP` samples run and are discarded before
-  measurement, so first-touch loader and page-cache costs are excluded.
-- **Volume.** `WORKCELL_BENCH_ITERATIONS` measured samples per mode (5000 in the
-  lane), reported as **median** (robust to scheduler outliers) alongside mean,
-  p90, and standard deviation.
-- **Repetition.** `WORKCELL_BENCH_RUNS` full passes (2 in the lane). The driver
-  prints a cross-run stability table so the run-to-run spread of the hooked
-  median is visible -- this is the C5 validation gate.
+The reported delta is the added classification time.
 
 ### Runner caveats
 
-- Numbers are **relative overheads on a shared CI runner**, not absolute
-  hardware figures; treat the delta (and its percentage), not the absolute
-  medians, as the portable signal.
-- For the `exec*` modes the classifier runs in the freshly forked child, so its
-  `OnceLock` signature caches start cold each launch; for `posix_spawn` it runs
-  in the long-lived driver process, so the caches are warm after the first call.
-  The two overhead columns are expected to differ for this reason.
-- On a stock runner `/proc/1/environ` is not readable, so the guard fails closed
-  to the strict profile (`current_mode_blocks_mutable_native_exec` returns
-  `true`). This matches the container's strict-profile default.
+The harness removes `LD_PRELOAD` before it starts each measured child. The guard
+stays loaded in the harness, so its hooks still run.
+
+This method excludes the child cost to load the shared library. Each guarded
+child process also pays that cost.
+
+The scheduled workflow uses 5,000 measured samples, 500 warm-up samples, and two
+complete runs for each mode.
 
 ## Results
 
-**Status: measured on the `bench.yml` lane** (`ubuntu-latest` GitHub-hosted
-runner, release cdylib, glibc). Numbers are shared-runner relative overheads, not
-absolute guarantees; re-measure on the target host for absolute figures. On the
-allow path the guard's classification adds ~265us (~48%) per `exec*` launch and
-~57us (~12%) per `posix_spawn`; a real container additionally pays the amortized
-per-child cost of loading the preloaded `.so` into each launched process.
-
 ### Allow-path overhead (median of 5000 samples, 2 runs)
 
-| Mode | Unhooked median (ns) | Hooked median (ns) | Delta (ns) | Delta (%) |
+The [2026-07-05 Bench workflow run](https://github.com/omkhar/workcell/actions/runs/28729189802)
+measured these values on a GitHub-hosted Linux runner. It used the release
+library with glibc.
+
+| Mode | Plain median (ns) | Guard median (ns) | Delta (ns) | Delta |
 |---|---|---|---|---|
-| `execve` | 553855 | 818320 | 264465 | 47.7 |
-| `execv` | 551629 | 818568 | 266939 | 48.4 |
-| `execvp` | 565185 | 827073 | 261888 | 46.3 |
-| `posix_spawn` | 467863 | 524429 | 56566 | 12.1 |
+| `execve` | 553855 | 818320 | 264465 | 47.7% |
+| `execv` | 551629 | 818568 | 266939 | 48.4% |
+| `execvp` | 565185 | 827073 | 261888 | 46.3% |
+| `posix_spawn` | 467863 | 524429 | 56566 | 12.1% |
 
 ### Cross-run stability (hooked median)
 
-| Mode | Min (ns) | Max (ns) | Spread (ns) | Spread (%) |
-|---|---|---|---|---|
-| `execve` | 818320 | 826893 | 8573 | 1.0 |
-| `execv` | 815793 | 818568 | 2775 | 0.3 |
-| `execvp` | 824098 | 827073 | 2975 | 0.4 |
-| `posix_spawn` | 524429 | 524850 | 421 | 0.1 |
+| Mode | Minimum guard median (ns) | Maximum guard median (ns) | Spread |
+|---|---|---|---|
+| `execve` | 818320 | 826893 | 1.0% |
+| `execv` | 815793 | 818568 | 0.3% |
+| `execvp` | 824098 | 827073 | 0.4% |
+| `posix_spawn` | 524429 | 524850 | 0.1% |
 
-## Filling in the numbers
+The `exec*` modes add approximately 265 microseconds in this capture.
+`posix_spawn` adds approximately 57 microseconds.
 
-1. Trigger the lane: run the **Bench** workflow (`bench.yml`) via
-   `workflow_dispatch`, or wait for its weekly schedule.
-2. Download the `exec-guard-bench-results` artifact (or read the job log): it is
-   the Markdown report the driver emits, including both per-run tables and the
-   cross-run stability table.
-3. Transcribe the two runs' medians into the tables above, and confirm the
-   stability spread stays small (single-digit percent) -- that is the evidence
-   the lane produces stable numbers across two runs.
-
-## Rerunning locally (Linux only)
-
-From the repository root on a Linux host:
-
-```sh
-# Build the exec-guard cdylib (offline, from vendored sources).
-(cd runtime/container/rust && cargo build --release --locked --offline --lib)
-
-# Run the benchmark (defaults: 3000 iterations, 300 warmup, 2 runs, /bin/true).
-./scripts/bench/run-exec-guard-bench.sh
-```
-
-Tunable via environment: `WORKCELL_BENCH_ITERATIONS`, `WORKCELL_BENCH_WARMUP`,
-`WORKCELL_BENCH_RUNS`, `WORKCELL_BENCH_TARGET`, `WORKCELL_EXEC_GUARD_SO`, and
-`WORKCELL_BENCH_OUTPUT` (write the Markdown report to a file).
-
-On macOS the driver compiles and runs the **unhooked baseline only** and says
-so: `DYLD_INSERT_LIBRARIES` semantics differ and the Linux-only guard logic does
-not apply, so hooked numbers must come from Linux.
+Each `exec*` sample uses a new child, so its classifier caches start cold. The
+`posix_spawn` samples use warm caches in the driver process.
 
 ## Where this fits
 
-The lane is registered in `policy/workflow-lane-policy.json` and reflected in
-`policy/workflow-lanes.json`; the artifact retention is in
-`policy/retention-policy.json` and mirrored in
-[retention-policy.md](retention-policy.md). See
-[github-workflows.md](github-workflows.md) for the full workflow inventory and
-[fuzzing.md](fuzzing.md) for the sibling scheduled exec-guard lane.
+### Scheduled workflow
+
+`.github/workflows/bench.yml` runs each week and on demand. It uploads
+`exec-guard-bench-results`.
+
+Repository policy records the workflow lane and artifact retention.
+See [GitHub Workflows](github-workflows.md) and
+[Retention Policy](retention-policy.md).
+
+## Rerunning locally (Linux only)
+
+Run this benchmark only on Linux:
+
+```sh
+(cd runtime/container/rust && \
+  cargo build --release --locked --offline --lib)
+./scripts/bench/run-exec-guard-bench.sh
+```
+
+The driver uses these optional variables:
+
+- `WORKCELL_BENCH_ITERATIONS`
+- `WORKCELL_BENCH_WARMUP`
+- `WORKCELL_BENCH_RUNS`
+- `WORKCELL_BENCH_TARGET`
+- `WORKCELL_EXEC_GUARD_SO`
+- `WORKCELL_BENCH_OUTPUT`
+
+On macOS, the driver runs only the plain baseline. The Linux preload guard does
+not apply to macOS.
+
+## Filling in the numbers
+
+To refresh this page, run the scheduled workflow. Copy the two-run medians and
+spreads from its artifact. Do not use one run as a published result.


### PR DESCRIPTION
## Summary

- Rewrite fuzzing, session-startup benchmark, standards watchlist, and syscall-shim benchmark guidance.
- Preserve the existing public Markdown fragments.
- Correct the live-run pass rule and identify the dated syscall benchmark evidence.

## Validation

- Focused source-parity and benchmark-evidence review
- Documentation validation and link checks
- Full repository validation
- Exact-head `pr-parity` gate, host invariants, and container smoke
- Adversarial review to a dry result