### PR TITLE
Bound validator workspace bind probe

### DIFF
--- a/internal/host/validatorbind/validatorbind.go
+++ b/internal/host/validatorbind/validatorbind.go
@@ -18,7 +18,15 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+const (
+	validatorBindProbeTimeout   = 30 * time.Second
+	validatorBindCleanupTimeout = 5 * time.Second
+)
+
+var errValidatorBindProbeTimeout = errors.New("validator workspace bind probe timed out")
 
 const probeScript = `
 set -euo pipefail
@@ -45,6 +53,10 @@ func Require(ctx context.Context, options Options) error {
 }
 
 func require(ctx context.Context, options Options, command commandFunc) (result error) {
+	return requireWithProbeTimeout(ctx, options, command, validatorBindProbeTimeout)
+}
+
+func requireWithProbeTimeout(ctx context.Context, options Options, command commandFunc, timeout time.Duration) (result error) {
 	if !filepath.IsAbs(options.DockerBinary) {
 		return fmt.Errorf("validator Docker binary must be an absolute path")
 	}
@@ -77,6 +89,7 @@ func require(ctx context.Context, options Options, command commandFunc) (result 
 	if err != nil {
 		return fmt.Errorf("write validator workspace bind challenge: %w", err)
 	}
+	containerName := "workcell-validator-bind-" + value
 	// The challenge is a random non-secret freshness token. It must be readable
 	// when a rootless or userns-remapped daemon changes bind-mount ownership.
 	if err := os.Chmod(challengePath, 0o644); err != nil {
@@ -87,12 +100,12 @@ func require(ctx context.Context, options Options, command commandFunc) (result 
 		return err
 	}
 
-	args := make([]string, 0, 22)
+	args := make([]string, 0, 24)
 	if options.Context != "" {
 		args = append(args, "--context", options.Context)
 	}
 	args = append(args,
-		"run", "--rm",
+		"run", "--rm", "--name", containerName,
 		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 		"--entrypoint", "/bin/bash",
 		"--mount", mount,
@@ -101,10 +114,17 @@ func require(ctx context.Context, options Options, command commandFunc) (result 
 		options.Image,
 		"-c", probeScript,
 	)
-	if err := command(ctx, workspace, options.DockerBinary, args); err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
-		}
+	probeCtx, cancel := context.WithTimeoutCause(ctx, timeout, errValidatorBindProbeTimeout)
+	defer cancel()
+	commandErr := command(probeCtx, workspace, options.DockerBinary, args)
+	if parentErr := ctx.Err(); parentErr != nil {
+		return withProbeCleanup(parentErr, command, workspace, options, containerName)
+	}
+	if errors.Is(context.Cause(probeCtx), errValidatorBindProbeTimeout) {
+		probeErr := fmt.Errorf("validator workspace bind probe after %s: %w", timeout, errValidatorBindProbeTimeout)
+		return withProbeCleanup(probeErr, command, workspace, options, containerName)
+	}
+	if commandErr != nil {
 		contextLabel := options.Context
 		if contextLabel == "" {
 			contextLabel = "default"
@@ -125,6 +145,20 @@ func require(ctx context.Context, options Options, command commandFunc) (result 
 		return fmt.Errorf("%s", message)
 	}
 	return nil
+}
+
+func withProbeCleanup(primary error, command commandFunc, workspace string, options Options, containerName string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), validatorBindCleanupTimeout)
+	defer cancel()
+	args := make([]string, 0, 5)
+	if options.Context != "" {
+		args = append(args, "--context", options.Context)
+	}
+	args = append(args, "rm", "--force", containerName)
+	if err := command(cleanupCtx, workspace, options.DockerBinary, args); err != nil {
+		return errors.Join(primary, fmt.Errorf("remove timed-out validator workspace bind probe: %w", err))
+	}
+	return primary
 }
 
 // MountSpec returns a Docker --mount CSV record for the workspace bind.

--- a/internal/host/validatorbind/validatorbind_test.go
+++ b/internal/host/validatorbind/validatorbind_test.go
@@ -5,14 +5,19 @@ package validatorbind
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
+
+var errInvalidCleanupContext = errors.New("cleanup context is canceled or unbounded")
 
 func TestRequireProvesExactWorkspaceAndCleansChallenge(t *testing.T) {
 	t.Parallel()
@@ -79,6 +84,14 @@ func TestRequireProvesExactWorkspaceAndCleansChallenge(t *testing.T) {
 	if slices.Contains(captured, "--volume") {
 		t.Fatalf("Docker args use source-creating --volume syntax: %q", captured)
 	}
+	runIndex := slices.Index(captured, "run")
+	if runIndex < 0 || runIndex+1 == len(captured) || captured[runIndex+1] != "--rm" {
+		t.Fatalf("Docker args omit run --rm: %q", captured)
+	}
+	nameIndex := slices.Index(captured, "--name")
+	if nameIndex < 0 || nameIndex+1 == len(captured) || !validProbeName(captured[nameIndex+1]) {
+		t.Fatalf("Docker args omit a valid probe name: %q", captured)
+	}
 	assertNoChallenges(t, canonical)
 }
 
@@ -124,20 +137,30 @@ func TestRequireRejectsStaleWorkspaceAndCleansChallenge(t *testing.T) {
 	assertNoChallenges(t, workspace)
 }
 
-func TestRequireCancellationCleansChallenge(t *testing.T) {
+func TestRequireCancellationCleansChallengeAndContainer(t *testing.T) {
 	t.Parallel()
 	workspace := createWorkspace(t, "workspace")
 	docker := executableFixture(t, "docker")
 	ctx, cancel := context.WithCancel(context.Background())
 	started := make(chan struct{})
 	result := make(chan error, 1)
+	runArgs := make(chan []string, 1)
+	cleanupArgs := make(chan []string, 1)
 
 	go func() {
 		result <- require(ctx, Options{
 			DockerBinary: docker,
 			Image:        "validator:fixture",
 			Workspace:    workspace,
-		}, func(ctx context.Context, _ string, _ string, _ []string) error {
+		}, func(ctx context.Context, _ string, _ string, args []string) error {
+			if isProbeCleanup(args) {
+				if err := cleanupContextError(ctx); err != nil {
+					return err
+				}
+				cleanupArgs <- append([]string(nil), args...)
+				return nil
+			}
+			runArgs <- append([]string(nil), args...)
 			close(started)
 			<-ctx.Done()
 			return ctx.Err()
@@ -148,6 +171,149 @@ func TestRequireCancellationCleansChallenge(t *testing.T) {
 	if err := <-result; !errors.Is(err, context.Canceled) {
 		t.Fatalf("canceled workspace proof error = %v, want context.Canceled", err)
 	}
+	assertProbeCleanupArgs(t, receiveArgs(t, cleanupArgs), "", probeContainerName(t, receiveArgs(t, runArgs)))
+	assertNoChallenges(t, workspace)
+}
+
+func TestRequireLocalDeadlineFailsClosedAndCleansChallengeAndContainer(t *testing.T) {
+	t.Parallel()
+	workspace := createWorkspace(t, "workspace")
+	docker := executableFixture(t, "docker")
+
+	var cleanupArgs []string
+	var probeName string
+	err := requireWithProbeTimeout(context.Background(), Options{
+		DockerBinary: docker,
+		Image:        "validator:fixture",
+		Workspace:    workspace,
+		Context:      "fixture-context",
+	}, func(ctx context.Context, _ string, _ string, args []string) error {
+		if isProbeCleanup(args) {
+			if err := cleanupContextError(ctx); err != nil {
+				return err
+			}
+			cleanupArgs = append([]string(nil), args...)
+			return nil
+		}
+		probeName = probeContainerName(t, args)
+		<-ctx.Done()
+		return nil
+	}, 0)
+	if !errors.Is(err, errValidatorBindProbeTimeout) {
+		t.Fatalf("local deadline error = %v, want %v", err, errValidatorBindProbeTimeout)
+	}
+	assertProbeCleanupArgs(t, cleanupArgs, "fixture-context", probeName)
+	assertNoChallenges(t, workspace)
+}
+
+func TestRequireParentCancellationTakesPrecedenceAndCleansChallengeAndContainer(t *testing.T) {
+	t.Parallel()
+	workspace := createWorkspace(t, "workspace")
+	docker := executableFixture(t, "docker")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	parentCause := errors.New("parent canceled validator proof")
+	probeExpired := make(chan struct{})
+	returnCommand := make(chan struct{})
+	result := make(chan error, 1)
+	cleanup := make(chan []string, 1)
+	runArgs := make(chan []string, 1)
+
+	go func() {
+		result <- requireWithProbeTimeout(ctx, Options{
+			DockerBinary: docker,
+			Image:        "validator:fixture",
+			Workspace:    workspace,
+		}, func(probeCtx context.Context, _ string, _ string, args []string) error {
+			if isProbeCleanup(args) {
+				if err := cleanupContextError(probeCtx); err != nil {
+					return err
+				}
+				cleanup <- append([]string(nil), args...)
+				return nil
+			}
+			runArgs <- append([]string(nil), args...)
+			<-probeCtx.Done()
+			close(probeExpired)
+			<-returnCommand
+			return nil
+		}, 0)
+	}()
+	<-probeExpired
+	cancel(parentCause)
+	close(returnCommand)
+	err := <-result
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("parent cancellation error = %v, want context.Canceled", err)
+	}
+	if errors.Is(err, parentCause) {
+		t.Fatalf("parent cancellation error = %v, unexpectedly matches %v", err, parentCause)
+	}
+	if errors.Is(err, errValidatorBindProbeTimeout) {
+		t.Fatalf("parent cancellation error = %v, unexpectedly matches %v", err, errValidatorBindProbeTimeout)
+	}
+	assertProbeCleanupArgs(t, receiveArgs(t, cleanup), "", probeContainerName(t, receiveArgs(t, runArgs)))
+	assertNoChallenges(t, workspace)
+}
+
+func TestRequireLocalDeadlineJoinsCleanupFailure(t *testing.T) {
+	t.Parallel()
+	workspace := createWorkspace(t, "workspace")
+	docker := executableFixture(t, "docker")
+	cleanupErr := errors.New("cleanup daemon rejected removal")
+	var cleanupArgs []string
+	var probeName string
+
+	err := requireWithProbeTimeout(context.Background(), Options{
+		DockerBinary: docker,
+		Image:        "validator:fixture",
+		Workspace:    workspace,
+	}, func(ctx context.Context, _ string, _ string, args []string) error {
+		if isProbeCleanup(args) {
+			if err := cleanupContextError(ctx); err != nil {
+				return err
+			}
+			cleanupArgs = append([]string(nil), args...)
+			return cleanupErr
+		}
+		probeName = probeContainerName(t, args)
+		<-ctx.Done()
+		return nil
+	}, 0)
+	if !errors.Is(err, errValidatorBindProbeTimeout) {
+		t.Fatalf("local deadline error = %v, want %v", err, errValidatorBindProbeTimeout)
+	}
+	if !errors.Is(err, cleanupErr) {
+		t.Fatalf("local deadline error = %v, want cleanup error %v", err, cleanupErr)
+	}
+	assertProbeCleanupArgs(t, cleanupArgs, "", probeName)
+	assertNoChallenges(t, workspace)
+}
+
+func TestRequireLocalDeadlineStopsBlockingExecutable(t *testing.T) {
+	t.Parallel()
+	workspace := createWorkspace(t, "workspace")
+	docker, commandLog := blockingDockerFixture(t)
+	result := make(chan error, 1)
+
+	go func() {
+		result <- requireWithProbeTimeout(context.Background(), Options{
+			DockerBinary: docker,
+			Image:        "validator:fixture",
+			Workspace:    workspace,
+			Context:      "fixture-context",
+		}, runCommand, time.Second)
+	}()
+	waitForLoggedProbeStart(t, commandLog)
+	select {
+	case err := <-result:
+		if !errors.Is(err, errValidatorBindProbeTimeout) {
+			t.Fatalf("blocking executable error = %v, want %v", err, errValidatorBindProbeTimeout)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocking executable did not stop after the local deadline")
+	}
+	assertLoggedProbeCleanup(t, commandLog, "fixture-context")
 	assertNoChallenges(t, workspace)
 }
 
@@ -257,6 +423,26 @@ func executableFixture(t *testing.T, name string) string {
 	return path
 }
 
+func blockingDockerFixture(t *testing.T) (string, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "docker")
+	commandLog := path + ".log"
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$@" >> %q
+if [ "$1" = "--context" ]; then
+	shift 2
+fi
+if [ "$1" = "rm" ]; then
+	exit 0
+fi
+exec /bin/sleep 60
+`, commandLog)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path, commandLog
+}
+
 func argumentValue(t *testing.T, args []string, prefix string) string {
 	t.Helper()
 	for _, arg := range args {
@@ -297,6 +483,108 @@ func argumentValueFromArgs(args []string, prefix string) string {
 		}
 	}
 	return ""
+}
+
+func probeContainerName(t *testing.T, args []string) string {
+	t.Helper()
+	index := slices.Index(args, "--name")
+	if index < 0 || index+1 == len(args) {
+		t.Fatalf("Docker args omit probe name: %q", args)
+	}
+	name := args[index+1]
+	if !validProbeName(name) {
+		t.Fatalf("Docker probe name = %q, want workcell-validator-bind-<hex>", name)
+	}
+	return name
+}
+
+func validProbeName(name string) bool {
+	const prefix = "workcell-validator-bind-"
+	value, ok := strings.CutPrefix(name, prefix)
+	if !ok || len(value) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func isProbeCleanup(args []string) bool {
+	if len(args) >= 1 && args[0] == "rm" {
+		return true
+	}
+	return len(args) >= 3 && args[0] == "--context" && args[2] == "rm"
+}
+
+func cleanupContextError(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return errInvalidCleanupContext
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		return errInvalidCleanupContext
+	}
+	return nil
+}
+
+func assertLoggedProbeCleanup(t *testing.T, commandLog, dockerContext string) {
+	t.Helper()
+	data, err := os.ReadFile(commandLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+	if len(args) < 5 {
+		t.Fatalf("Docker command log is too short: %q", args)
+	}
+	nameIndex := slices.Index(args, "--name")
+	if nameIndex < 0 || nameIndex+1 == len(args) || !validProbeName(args[nameIndex+1]) {
+		t.Fatalf("Docker command log omits a valid probe name: %q", args)
+	}
+	cleanupArgs := args[len(args)-5:]
+	want := []string{"--context", dockerContext, "rm", "--force", args[nameIndex+1]}
+	if !slices.Equal(cleanupArgs, want) {
+		t.Fatalf("logged cleanup args = %q, want %q", cleanupArgs, want)
+	}
+}
+
+func waitForLoggedProbeStart(t *testing.T, commandLog string) {
+	t.Helper()
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if data, err := os.ReadFile(commandLog); err == nil && slices.Contains(strings.Split(string(data), "\n"), "run") {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatal("blocking Docker executable did not record the probe command")
+		case <-ticker.C:
+		}
+	}
+}
+
+func assertProbeCleanupArgs(t *testing.T, args []string, dockerContext, wantName string) {
+	t.Helper()
+	want := make([]string, 0, 5)
+	if dockerContext != "" {
+		want = append(want, "--context", dockerContext)
+	}
+	want = append(want, "rm", "--force", wantName)
+	if !slices.Equal(args, want) {
+		t.Fatalf("cleanup args = %q, want %q", args, want)
+	}
+}
+
+func receiveArgs(t *testing.T, result <-chan []string) []string {
+	t.Helper()
+	select {
+	case args := <-result:
+		return args
+	case <-time.After(2 * time.Second):
+		t.Fatal("Docker command was not recorded")
+		return nil
+	}
 }
 
 func assertNoChallenges(t *testing.T, workspace string) {


### PR DESCRIPTION
## Summary

- Bound Docker workspace visibility probes to 30 seconds.
- Give each probe a unique container name.
- Force-remove timed-out probes through an independent cleanup context.
- Preserve caller cancellation behavior.
- Add real executable lifecycle regressions.

## Tests

- `go test -count=10 ./internal/host/validatorbind`
- `go test -count=1 -race ./internal/host/validatorbind`
- `go vet ./internal/host/validatorbind`
- `./scripts/dev-quick-check.sh`
- `./scripts/validate-repo.sh`
- `./scripts/pre-merge.sh --profile pr-parity`
