### PR TITLE
Constrain upstream release asset downloads and improve tests

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -78,8 +78,9 @@ func subcommands() []subcommand {
 		{"extract-claude-sha", "DOCKERFILE_PATH TARGET_ARCH", 2, 2, cmdExtractClaudeSHA},
 		{"extract-codex-sha", "DOCKERFILE_PATH TARGET_ARCH", 2, 2, cmdExtractCodexSHA},
 		{"extract-copilot-sha", "DOCKERFILE_PATH TARGET_ARCH", 2, 2, cmdExtractCopilotSHA},
+		{"github-api-get", "URL", 1, 1, cmdGitHubAPIGet},
+		{"github-release-asset", "REPOSITORY ASSET_NAME CLASS", 3, 3, cmdGitHubReleaseAsset},
 		{"hadolint-manifest-checksum", "ASSET_NAME", 1, 1, cmdHadolintManifestChecksum},
-		{"github-release-asset", "REPOSITORY ASSET_NAME", 2, 2, cmdGitHubReleaseAsset},
 		{"select-buildx-version", "CURRENT_VERSION CANDIDATE_VERSION", 2, 2, cmdSelectBuildxVersion},
 		{"manifest-checksum", "MANIFEST_PATH PLATFORM", 2, 2, cmdManifestChecksum},
 		{"manifest-version", "MANIFEST_PATH EXPECTED_VERSION", 2, 2, cmdManifestVersion},
@@ -111,6 +112,7 @@ func subcommands() []subcommand {
 		{"run-mutation-tests", "", 0, 0, cmdRunMutationTests},
 		{"mutation-score", "POLICY_PATH", 1, 1, cmdMutationScore},
 		{"tree-compare", "LEFT_ROOT RIGHT_ROOT", 2, 2, cmdTreeCompare},
+		{"upstream-get", "PROFILE [VERSION TARGET]", 1, 3, cmdUpstreamGet},
 		{"git-config-blocklist-parity", "ROOT_DIR", 1, 1, cmdGitConfigBlocklistParity},
 		{"workcell-hardening-invariants", "ROOT_DIR", 1, 1, cmdWorkcellHardeningInvariants},
 		{"workcell-config-safety", "ROOT_DIR", 1, 1, cmdWorkcellConfigSafety},
@@ -353,7 +355,29 @@ func cmdHadolintManifestChecksum(args []string) error {
 func cmdGitHubReleaseAsset(args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	content, err := metadatautil.FetchGitHubReleaseAsset(ctx, os.Stdin, args[0], args[1])
+	content, err := metadatautil.FetchGitHubReleaseAssetClass(ctx, os.Stdin, args[0], args[1], args[2])
+	if err != nil {
+		return err
+	}
+	_, err = os.Stdout.Write(content)
+	return err
+}
+
+func cmdGitHubAPIGet(args []string) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	content, err := metadatautil.FetchGitHubAPI(ctx, args[0])
+	if err != nil {
+		return err
+	}
+	_, err = os.Stdout.Write(content)
+	return err
+}
+
+func cmdUpstreamGet(args []string) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	content, err := metadatautil.FetchUpstream(ctx, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -79,6 +79,7 @@ func subcommands() []subcommand {
 		{"extract-codex-sha", "DOCKERFILE_PATH TARGET_ARCH", 2, 2, cmdExtractCodexSHA},
 		{"extract-copilot-sha", "DOCKERFILE_PATH TARGET_ARCH", 2, 2, cmdExtractCopilotSHA},
 		{"hadolint-manifest-checksum", "ASSET_NAME", 1, 1, cmdHadolintManifestChecksum},
+		{"github-release-asset", "REPOSITORY ASSET_NAME", 2, 2, cmdGitHubReleaseAsset},
 		{"select-buildx-version", "CURRENT_VERSION CANDIDATE_VERSION", 2, 2, cmdSelectBuildxVersion},
 		{"manifest-checksum", "MANIFEST_PATH PLATFORM", 2, 2, cmdManifestChecksum},
 		{"manifest-version", "MANIFEST_PATH EXPECTED_VERSION", 2, 2, cmdManifestVersion},
@@ -347,6 +348,17 @@ func cmdHadolintManifestChecksum(args []string) error {
 	}
 	fmt.Println(value)
 	return nil
+}
+
+func cmdGitHubReleaseAsset(args []string) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	content, err := metadatautil.FetchGitHubReleaseAsset(ctx, os.Stdin, args[0], args[1])
+	if err != nil {
+		return err
+	}
+	_, err = os.Stdout.Write(content)
+	return err
 }
 
 func cmdResolveDebianBootstrap(args []string) error {

--- a/cmd/workcell-citools/main_test.go
+++ b/cmd/workcell-citools/main_test.go
@@ -40,6 +40,12 @@ func TestUnknownCommandExitsWithUsageCode(t *testing.T) {
 	assertCitoolsUsageExit(t, "definitely-not-a-subcommand")
 }
 
+func TestUpstreamFetchCommandsRejectWrongArity(t *testing.T) {
+	assertCitoolsUsageExit(t, "github-api-get")
+	assertCitoolsUsageExit(t, "github-release-asset", "owner/repository", "asset")
+	assertCitoolsUsageExit(t, "upstream-get", "profile", "one", "two", "three")
+}
+
 // assertCitoolsUsageExit runs the binary (via the helper-process trick) with
 // the given argv tail and asserts a usage exit (code 2 + "usage:" on stderr).
 func assertCitoolsUsageExit(t *testing.T, argv ...string) {

--- a/internal/metadatautil/github_release_asset.go
+++ b/internal/metadatautil/github_release_asset.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -19,12 +18,7 @@ import (
 )
 
 const (
-	githubReleaseAssetMaxMetadataBytes = 200 << 20
-	githubReleaseAssetMaxBytes         = 64 << 10
-	githubReleaseAssetMaxTokenBytes    = 16 << 10
-	githubReleaseAssetTimeout          = 60 * time.Second
-	githubReleaseAssetConnectTimeout   = 15 * time.Second
-	githubReleaseAssetUserAgent        = "workcell-upstream-pins/1.0"
+	githubReleaseAssetTimeout = 60 * time.Second
 )
 
 var (
@@ -40,29 +34,31 @@ type githubReleaseAssetDocument struct {
 	} `json:"assets"`
 }
 
-type githubReleaseAssetDoer interface {
-	Do(*http.Request) (*http.Response, error)
-}
-
 // FetchGitHubReleaseAsset selects one asset from releaseJSON and downloads it.
 // The authenticated API request cannot redirect automatically. A validated
 // release-assets URL gets one separate request without credentials.
 func FetchGitHubReleaseAsset(ctx context.Context, releaseJSON io.Reader, repository, assetName string) ([]byte, error) {
-	token, err := githubReleaseAssetToken()
+	return FetchGitHubReleaseAssetClass(ctx, releaseJSON, repository, assetName, "checksum")
+}
+
+// FetchGitHubReleaseAssetClass selects one release asset in a reviewed size
+// class. Checksums stay small while release archives use the updater's bounded
+// metadata-size ceiling.
+func FetchGitHubReleaseAssetClass(ctx context.Context, releaseJSON io.Reader, repository, assetName, assetClass string) ([]byte, error) {
+	maxBytes, err := githubReleaseAssetLimit(assetClass)
 	if err != nil {
 		return nil, err
 	}
-	return fetchGitHubReleaseAsset(ctx, newGitHubReleaseAssetClient(), releaseJSON, repository, assetName, token)
+	token, err := githubAPIToken()
+	if err != nil {
+		return nil, err
+	}
+	return fetchGitHubReleaseAsset(ctx, newGitHubReleaseAssetClient(), releaseJSON, repository, assetName, token, maxBytes)
 }
 
 func newGitHubReleaseAssetClient() *http.Client {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.DialContext = (&net.Dialer{
-		Timeout:   githubReleaseAssetConnectTimeout,
-		KeepAlive: 30 * time.Second,
-	}).DialContext
 	return &http.Client{
-		Transport: transport,
+		Transport: newUpstreamHTTPTransport(),
 		Timeout:   githubReleaseAssetTimeout,
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			return http.ErrUseLastResponse
@@ -70,7 +66,7 @@ func newGitHubReleaseAssetClient() *http.Client {
 	}
 }
 
-func fetchGitHubReleaseAsset(ctx context.Context, client githubReleaseAssetDoer, releaseJSON io.Reader, repository, assetName, token string) ([]byte, error) {
+func fetchGitHubReleaseAsset(ctx context.Context, client upstreamHTTPDoer, releaseJSON io.Reader, repository, assetName, token string, maxBytes int64) ([]byte, error) {
 	apiURL, err := githubReleaseAssetAPIURL(releaseJSON, repository, assetName)
 	if err != nil {
 		return nil, err
@@ -88,7 +84,7 @@ func fetchGitHubReleaseAsset(ctx context.Context, client githubReleaseAssetDoer,
 
 	switch initial.StatusCode {
 	case http.StatusOK:
-		return readGitHubReleaseAssetBody(initial)
+		return readGitHubReleaseAssetBody(initial, maxBytes)
 	case http.StatusFound:
 		locations := initial.Header.Values("Location")
 		if len(locations) != 1 || locations[0] == "" {
@@ -110,7 +106,7 @@ func fetchGitHubReleaseAsset(ctx context.Context, client githubReleaseAssetDoer,
 		if redirect.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("unexpected GitHub release asset redirect response %d", redirect.StatusCode)
 		}
-		return readGitHubReleaseAssetBody(redirect)
+		return readGitHubReleaseAssetBody(redirect, maxBytes)
 	default:
 		return nil, fmt.Errorf("unexpected GitHub release asset response %d", initial.StatusCode)
 	}
@@ -123,11 +119,11 @@ func githubReleaseAssetAPIURL(releaseJSON io.Reader, repository, assetName strin
 	if assetName == "" || strings.ContainsAny(assetName, "\r\n") {
 		return "", errors.New("GitHub release asset name must be one line")
 	}
-	content, err := io.ReadAll(io.LimitReader(releaseJSON, githubReleaseAssetMaxMetadataBytes+1))
+	content, err := io.ReadAll(io.LimitReader(releaseJSON, upstreamMetadataMaxBytes+1))
 	if err != nil {
 		return "", fmt.Errorf("read GitHub release metadata: %w", err)
 	}
-	if len(content) > githubReleaseAssetMaxMetadataBytes {
+	if len(content) > upstreamMetadataMaxBytes {
 		return "", errors.New("GitHub release metadata exceeds the size limit")
 	}
 	var document githubReleaseAssetDocument
@@ -155,12 +151,13 @@ func githubReleaseAssetAPIURL(releaseJSON io.Reader, repository, assetName strin
 	return fmt.Sprintf("https://api.github.com/repos/%s/releases/assets/%s", repository, assetID), nil
 }
 
-func githubReleaseAssetRequest(ctx context.Context, client githubReleaseAssetDoer, rawURL, token string, initial bool) (*http.Response, error) {
+func githubReleaseAssetRequest(ctx context.Context, client upstreamHTTPDoer, rawURL, token string, initial bool) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", githubReleaseAssetUserAgent)
+	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set("User-Agent", upstreamUserAgent)
 	if initial {
 		req.Header.Set("Accept", "application/octet-stream")
 	}
@@ -187,43 +184,52 @@ func validGitHubReleaseAssetRedirectURL(rawURL string) bool {
 		githubReleaseRedirectPath.MatchString(parsed.Path)
 }
 
-func readGitHubReleaseAssetBody(response *http.Response) ([]byte, error) {
-	if response.Body == nil {
-		return nil, errors.New("GitHub release asset response has no body")
-	}
-	if response.ContentLength > githubReleaseAssetMaxBytes {
-		return nil, errors.New("GitHub release asset exceeds the size limit")
-	}
-	content, err := io.ReadAll(io.LimitReader(response.Body, githubReleaseAssetMaxBytes+1))
-	if err != nil {
-		return nil, fmt.Errorf("read GitHub release asset: %w", err)
-	}
-	if len(content) > githubReleaseAssetMaxBytes {
-		return nil, errors.New("GitHub release asset exceeds the size limit")
-	}
-	return content, nil
+func readGitHubReleaseAssetBody(response *http.Response, maxBytes int64) ([]byte, error) {
+	return readBoundedHTTPBody(response, maxBytes, "GitHub release asset")
 }
 
-func githubReleaseAssetToken() (string, error) {
+func githubReleaseAssetLimit(assetClass string) (int64, error) {
+	switch assetClass {
+	case "checksum":
+		return upstreamChecksumMaxBytes, nil
+	case "archive":
+		return upstreamMetadataMaxBytes, nil
+	default:
+		return 0, fmt.Errorf("unknown GitHub release asset class %q", assetClass)
+	}
+}
+
+func githubAPIToken() (string, error) {
 	raw := os.Getenv("WORKCELL_GITHUB_API_TOKEN")
-	if tokenFile := os.Getenv("WORKCELL_GITHUB_API_TOKEN_FILE"); tokenFile != "" {
+	fromFile := false
+	if raw == "" {
+		raw = os.Getenv("GITHUB_TOKEN")
+	}
+	if raw == "" {
+		raw = os.Getenv("GH_TOKEN")
+	}
+	if raw == "" && os.Getenv("WORKCELL_GITHUB_API_TOKEN_FILE") != "" {
+		fromFile = true
+		tokenFile := os.Getenv("WORKCELL_GITHUB_API_TOKEN_FILE")
 		file, err := os.Open(tokenFile)
 		if err != nil {
 			return "", fmt.Errorf("read WORKCELL_GITHUB_API_TOKEN_FILE: %w", err)
 		}
 		defer file.Close()
-		content, err := io.ReadAll(io.LimitReader(file, githubReleaseAssetMaxTokenBytes+1))
+		content, err := io.ReadAll(io.LimitReader(file, githubAPIMaxTokenBytes+1))
 		if err != nil {
 			return "", fmt.Errorf("read WORKCELL_GITHUB_API_TOKEN_FILE: %w", err)
 		}
-		if len(content) > githubReleaseAssetMaxTokenBytes {
+		if len(content) > githubAPIMaxTokenBytes {
 			return "", errors.New("WORKCELL_GITHUB_API_TOKEN_FILE exceeds the size limit")
 		}
 		raw = string(content)
 	}
-	raw = strings.TrimRight(raw, "\n")
+	if fromFile {
+		raw = strings.TrimRight(raw, "\n")
+	}
 	if strings.ContainsAny(raw, "\r\n") {
-		return "", errors.New("WORKCELL_GITHUB_API_TOKEN_FILE and WORKCELL_GITHUB_API_TOKEN must contain exactly one token line")
+		return "", errors.New("GitHub API token must contain exactly one token line")
 	}
 	return raw, nil
 }

--- a/internal/metadatautil/github_release_asset.go
+++ b/internal/metadatautil/github_release_asset.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	githubReleaseAssetMaxMetadataBytes = 200 << 20
+	githubReleaseAssetMaxBytes         = 64 << 10
+	githubReleaseAssetMaxTokenBytes    = 16 << 10
+	githubReleaseAssetTimeout          = 60 * time.Second
+	githubReleaseAssetConnectTimeout   = 15 * time.Second
+	githubReleaseAssetUserAgent        = "workcell-upstream-pins/1.0"
+)
+
+var (
+	githubReleaseRepositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+	githubReleaseAssetIDPattern    = regexp.MustCompile(`^[1-9][0-9]*$`)
+	githubReleaseRedirectPath      = regexp.MustCompile(`^/github-production-release-asset/[1-9][0-9]*/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+)
+
+type githubReleaseAssetDocument struct {
+	Assets []struct {
+		ID   json.RawMessage `json:"id"`
+		Name string          `json:"name"`
+	} `json:"assets"`
+}
+
+type githubReleaseAssetDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// FetchGitHubReleaseAsset selects one asset from releaseJSON and downloads it.
+// The authenticated API request cannot redirect automatically. A validated
+// release-assets URL gets one separate request without credentials.
+func FetchGitHubReleaseAsset(ctx context.Context, releaseJSON io.Reader, repository, assetName string) ([]byte, error) {
+	token, err := githubReleaseAssetToken()
+	if err != nil {
+		return nil, err
+	}
+	return fetchGitHubReleaseAsset(ctx, newGitHubReleaseAssetClient(), releaseJSON, repository, assetName, token)
+}
+
+func newGitHubReleaseAssetClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{
+		Timeout:   githubReleaseAssetConnectTimeout,
+		KeepAlive: 30 * time.Second,
+	}).DialContext
+	return &http.Client{
+		Transport: transport,
+		Timeout:   githubReleaseAssetTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func fetchGitHubReleaseAsset(ctx context.Context, client githubReleaseAssetDoer, releaseJSON io.Reader, repository, assetName, token string) ([]byte, error) {
+	apiURL, err := githubReleaseAssetAPIURL(releaseJSON, repository, assetName)
+	if err != nil {
+		return nil, err
+	}
+	initial, err := githubReleaseAssetRequest(ctx, client, apiURL, token, true)
+	if err != nil {
+		return nil, fmt.Errorf("unable to download the GitHub release asset")
+	}
+	if initial == nil {
+		return nil, errors.New("GitHub release asset request returned no response")
+	}
+	if initial.Body != nil {
+		defer initial.Body.Close()
+	}
+
+	switch initial.StatusCode {
+	case http.StatusOK:
+		return readGitHubReleaseAssetBody(initial)
+	case http.StatusFound:
+		locations := initial.Header.Values("Location")
+		if len(locations) != 1 || locations[0] == "" {
+			return nil, errors.New("GitHub release asset redirect must include one Location header")
+		}
+		if !validGitHubReleaseAssetRedirectURL(locations[0]) {
+			return nil, errors.New("GitHub release asset redirect is outside the allowed endpoint")
+		}
+		redirect, requestErr := githubReleaseAssetRequest(ctx, client, locations[0], "", false)
+		if requestErr != nil {
+			return nil, errors.New("unable to download the GitHub release asset redirect")
+		}
+		if redirect == nil {
+			return nil, errors.New("GitHub release asset redirect returned no response")
+		}
+		if redirect.Body != nil {
+			defer redirect.Body.Close()
+		}
+		if redirect.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("unexpected GitHub release asset redirect response %d", redirect.StatusCode)
+		}
+		return readGitHubReleaseAssetBody(redirect)
+	default:
+		return nil, fmt.Errorf("unexpected GitHub release asset response %d", initial.StatusCode)
+	}
+}
+
+func githubReleaseAssetAPIURL(releaseJSON io.Reader, repository, assetName string) (string, error) {
+	if !githubReleaseRepositoryPattern.MatchString(repository) {
+		return "", fmt.Errorf("invalid GitHub release asset repository: %s", repository)
+	}
+	if assetName == "" || strings.ContainsAny(assetName, "\r\n") {
+		return "", errors.New("GitHub release asset name must be one line")
+	}
+	content, err := io.ReadAll(io.LimitReader(releaseJSON, githubReleaseAssetMaxMetadataBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("read GitHub release metadata: %w", err)
+	}
+	if len(content) > githubReleaseAssetMaxMetadataBytes {
+		return "", errors.New("GitHub release metadata exceeds the size limit")
+	}
+	var document githubReleaseAssetDocument
+	if err := json.Unmarshal(content, &document); err != nil {
+		return "", fmt.Errorf("parse GitHub release metadata: %w", err)
+	}
+	var assetID string
+	matches := 0
+	for _, asset := range document.Assets {
+		if asset.Name != assetName {
+			continue
+		}
+		matches++
+		candidate := string(asset.ID)
+		if githubReleaseAssetIDPattern.MatchString(candidate) {
+			assetID = candidate
+		}
+	}
+	if matches != 1 {
+		return "", fmt.Errorf("unable to resolve one release asset named %s", assetName)
+	}
+	if assetID == "" {
+		return "", fmt.Errorf("unable to resolve a numeric release asset ID for %s", assetName)
+	}
+	return fmt.Sprintf("https://api.github.com/repos/%s/releases/assets/%s", repository, assetID), nil
+}
+
+func githubReleaseAssetRequest(ctx context.Context, client githubReleaseAssetDoer, rawURL, token string, initial bool) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", githubReleaseAssetUserAgent)
+	if initial {
+		req.Header.Set("Accept", "application/octet-stream")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return client.Do(req)
+}
+
+func validGitHubReleaseAssetRedirectURL(rawURL string) bool {
+	if rawURL == "" || strings.ContainsAny(rawURL, " \t\r\n#") {
+		return false
+	}
+	parsed, err := url.ParseRequestURI(rawURL)
+	if err != nil {
+		return false
+	}
+	return parsed.Scheme == "https" &&
+		parsed.Host == "release-assets.githubusercontent.com" &&
+		parsed.User == nil &&
+		parsed.Fragment == "" &&
+		parsed.RawPath == "" &&
+		parsed.RawQuery != "" &&
+		githubReleaseRedirectPath.MatchString(parsed.Path)
+}
+
+func readGitHubReleaseAssetBody(response *http.Response) ([]byte, error) {
+	if response.Body == nil {
+		return nil, errors.New("GitHub release asset response has no body")
+	}
+	if response.ContentLength > githubReleaseAssetMaxBytes {
+		return nil, errors.New("GitHub release asset exceeds the size limit")
+	}
+	content, err := io.ReadAll(io.LimitReader(response.Body, githubReleaseAssetMaxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read GitHub release asset: %w", err)
+	}
+	if len(content) > githubReleaseAssetMaxBytes {
+		return nil, errors.New("GitHub release asset exceeds the size limit")
+	}
+	return content, nil
+}
+
+func githubReleaseAssetToken() (string, error) {
+	raw := os.Getenv("WORKCELL_GITHUB_API_TOKEN")
+	if tokenFile := os.Getenv("WORKCELL_GITHUB_API_TOKEN_FILE"); tokenFile != "" {
+		file, err := os.Open(tokenFile)
+		if err != nil {
+			return "", fmt.Errorf("read WORKCELL_GITHUB_API_TOKEN_FILE: %w", err)
+		}
+		defer file.Close()
+		content, err := io.ReadAll(io.LimitReader(file, githubReleaseAssetMaxTokenBytes+1))
+		if err != nil {
+			return "", fmt.Errorf("read WORKCELL_GITHUB_API_TOKEN_FILE: %w", err)
+		}
+		if len(content) > githubReleaseAssetMaxTokenBytes {
+			return "", errors.New("WORKCELL_GITHUB_API_TOKEN_FILE exceeds the size limit")
+		}
+		raw = string(content)
+	}
+	raw = strings.TrimRight(raw, "\n")
+	if strings.ContainsAny(raw, "\r\n") {
+		return "", errors.New("WORKCELL_GITHUB_API_TOKEN_FILE and WORKCELL_GITHUB_API_TOKEN must contain exactly one token line")
+	}
+	return raw, nil
+}

--- a/internal/metadatautil/github_release_asset_test.go
+++ b/internal/metadatautil/github_release_asset_test.go
@@ -111,13 +111,16 @@ func TestFetchGitHubReleaseAssetDirect(t *testing.T) {
 		if got := req.Header.Get("Accept"); got != "application/octet-stream" {
 			t.Fatalf("Accept = %q", got)
 		}
+		if got := req.Header.Get("Accept-Encoding"); got != "identity" {
+			t.Fatalf("Accept-Encoding = %q", got)
+		}
 		if got := req.Header.Get("Authorization"); got != "Bearer "+token {
 			t.Fatalf("Authorization = %q", got)
 		}
 		return githubReleaseAssetResponse(http.StatusOK, nil, body), nil
 	})
 
-	got, err := fetchGitHubReleaseAsset(context.Background(), client, testGitHubReleaseDocument("424242"), "rhysd/actionlint", testGitHubReleaseAssetName, token)
+	got, err := fetchGitHubReleaseAsset(context.Background(), client, testGitHubReleaseDocument("424242"), "rhysd/actionlint", testGitHubReleaseAssetName, token, upstreamChecksumMaxBytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +143,7 @@ func TestFetchGitHubReleaseAssetRedirectDropsCredentials(t *testing.T) {
 		return githubReleaseAssetResponse(http.StatusOK, nil, body), nil
 	})
 
-	got, err := fetchGitHubReleaseAsset(context.Background(), client, testGitHubReleaseDocument("424242"), "rhysd/actionlint", testGitHubReleaseAssetName, token)
+	got, err := fetchGitHubReleaseAsset(context.Background(), client, testGitHubReleaseDocument("424242"), "rhysd/actionlint", testGitHubReleaseAssetName, token, upstreamChecksumMaxBytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +156,7 @@ func TestFetchGitHubReleaseAssetRedirectDropsCredentials(t *testing.T) {
 	if requests[1].URL.String() != testGitHubReleaseRedirect {
 		t.Fatalf("redirect URL = %q", requests[1].URL)
 	}
-	if requests[1].Header.Get("Authorization") != "" || requests[1].Header.Get("Accept") != "" {
+	if requests[1].Header.Get("Authorization") != "" || requests[1].Header.Get("Accept") != "" || requests[1].Header.Get("Accept-Encoding") != "identity" {
 		t.Fatalf("redirect retained initial headers: %#v", requests[1].Header)
 	}
 }
@@ -171,8 +174,8 @@ func TestFetchGitHubReleaseAssetRejectsResponses(t *testing.T) {
 		{name: "duplicate location", responses: []*http.Response{githubReleaseAssetResponse(http.StatusFound, http.Header{"Location": []string{testGitHubReleaseRedirect, testGitHubReleaseRedirect}}, "")}, wantError: "must include one Location header"},
 		{name: "hostile location", responses: []*http.Response{githubReleaseAssetResponse(http.StatusFound, http.Header{"Location": []string{"https://attacker.invalid/file"}}, "")}, wantError: "outside the allowed endpoint"},
 		{name: "second redirect", responses: []*http.Response{githubReleaseAssetResponse(http.StatusFound, http.Header{"Location": []string{testGitHubReleaseRedirect}}, ""), githubReleaseAssetResponse(http.StatusFound, http.Header{"Location": []string{testGitHubReleaseRedirect}}, "")}, wantError: "unexpected GitHub release asset redirect response 302"},
-		{name: "declared oversized", responses: []*http.Response{{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader("small")), ContentLength: githubReleaseAssetMaxBytes + 1}}, wantError: "exceeds the size limit"},
-		{name: "streamed oversized", responses: []*http.Response{githubReleaseAssetResponse(http.StatusOK, nil, strings.Repeat("x", githubReleaseAssetMaxBytes+1))}, wantError: "exceeds the size limit"},
+		{name: "declared oversized", responses: []*http.Response{{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader("small")), ContentLength: upstreamChecksumMaxBytes + 1}}, wantError: "exceeds the size limit"},
+		{name: "streamed oversized", responses: []*http.Response{githubReleaseAssetResponse(http.StatusOK, nil, strings.Repeat("x", upstreamChecksumMaxBytes+1))}, wantError: "exceeds the size limit"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -185,7 +188,7 @@ func TestFetchGitHubReleaseAssetRejectsResponses(t *testing.T) {
 				index++
 				return response, nil
 			})
-			_, err := fetchGitHubReleaseAsset(context.Background(), client, testGitHubReleaseDocument("424242"), "rhysd/actionlint", testGitHubReleaseAssetName, "fixture-token")
+			_, err := fetchGitHubReleaseAsset(context.Background(), client, testGitHubReleaseDocument("424242"), "rhysd/actionlint", testGitHubReleaseAssetName, "fixture-token", upstreamChecksumMaxBytes)
 			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
 				t.Fatalf("fetchGitHubReleaseAsset() error = %v, want text %q", err, tc.wantError)
 			}
@@ -193,27 +196,82 @@ func TestFetchGitHubReleaseAssetRejectsResponses(t *testing.T) {
 	}
 }
 
-func TestGitHubReleaseAssetToken(t *testing.T) {
-	t.Setenv("WORKCELL_GITHUB_API_TOKEN", "")
+func TestGitHubAPITokenPrecedenceAndLinePolicy(t *testing.T) {
 	tokenFile := filepath.Join(t.TempDir(), "token")
-	if err := os.WriteFile(tokenFile, []byte("fixture-token"), 0o600); err != nil {
+	if err := os.WriteFile(tokenFile, []byte("file-token\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("WORKCELL_GITHUB_API_TOKEN_FILE", tokenFile)
-	if got, err := githubReleaseAssetToken(); err != nil || got != "fixture-token" {
-		t.Fatalf("githubReleaseAssetToken() = %q, %v", got, err)
+
+	for _, tc := range []struct {
+		name         string
+		workcell     string
+		github       string
+		gh           string
+		file         string
+		fileContents string
+		want         string
+		wantErr      string
+	}{
+		{name: "workcell wins", workcell: "workcell-token", github: "github-token", gh: "gh-token", file: tokenFile, want: "workcell-token"},
+		{name: "github wins", github: "github-token", gh: "gh-token", file: tokenFile, want: "github-token"},
+		{name: "gh wins", gh: "gh-token", file: tokenFile, want: "gh-token"},
+		{name: "file fallback", file: tokenFile, want: "file-token"},
+		{name: "trailing newline file", file: tokenFile, fileContents: "fixture-token\n", want: "fixture-token"},
+		{name: "trailing newline environment", workcell: "fixture-token\n", file: tokenFile, wantErr: "exactly one token line"},
+		{name: "internal newline file", file: tokenFile, fileContents: "fixture\ntoken\n", wantErr: "exactly one token line"},
+		{name: "environment bypasses unreadable file", workcell: "workcell-token", file: filepath.Join(t.TempDir(), "missing"), want: "workcell-token"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.fileContents != "" {
+				if err := os.WriteFile(tokenFile, []byte(tc.fileContents), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.WriteFile(tokenFile, []byte("file-token\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("WORKCELL_GITHUB_API_TOKEN", tc.workcell)
+			t.Setenv("GITHUB_TOKEN", tc.github)
+			t.Setenv("GH_TOKEN", tc.gh)
+			t.Setenv("WORKCELL_GITHUB_API_TOKEN_FILE", tc.file)
+			got, err := githubAPIToken()
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("githubAPIToken() error = %v, want text %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil || got != tc.want {
+				t.Fatalf("githubAPIToken() = %q, %v, want %q", got, err, tc.want)
+			}
+		})
 	}
-	if err := os.WriteFile(tokenFile, []byte("fixture-token\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if got, err := githubReleaseAssetToken(); err != nil || got != "fixture-token" {
-		t.Fatalf("newline-terminated githubReleaseAssetToken() = %q, %v", got, err)
-	}
-	if err := os.WriteFile(tokenFile, []byte("fixture\ntoken\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := githubReleaseAssetToken(); err == nil || !strings.Contains(err.Error(), "exactly one token line") {
-		t.Fatalf("githubReleaseAssetToken() error = %v", err)
+}
+
+func TestGitHubReleaseAssetLimit(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		assetClass string
+		want       int64
+		wantErr    string
+	}{
+		{assetClass: "checksum", want: upstreamChecksumMaxBytes},
+		{assetClass: "archive", want: upstreamMetadataMaxBytes},
+		{assetClass: "unknown", wantErr: "unknown GitHub release asset class"},
+	} {
+		t.Run(tc.assetClass, func(t *testing.T) {
+			t.Parallel()
+			got, err := githubReleaseAssetLimit(tc.assetClass)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("githubReleaseAssetLimit(%q) error = %v, want text %q", tc.assetClass, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil || got != tc.want {
+				t.Fatalf("githubReleaseAssetLimit(%q) = %d, %v, want %d", tc.assetClass, got, err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/metadatautil/github_release_asset_test.go
+++ b/internal/metadatautil/github_release_asset_test.go
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	testGitHubReleaseAssetName = "actionlint_1.2.3_checksums.txt"
+	testGitHubReleaseAssetURL  = "https://api.github.com/repos/rhysd/actionlint/releases/assets/424242"
+	testGitHubReleaseRedirect  = "https://release-assets.githubusercontent.com/github-production-release-asset/12345678/01234567-89ab-cdef-0123-456789abcdef?sp=r&sv=fixture"
+)
+
+type githubReleaseAssetRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn githubReleaseAssetRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestGitHubReleaseAssetAPIURL(t *testing.T) {
+	t.Parallel()
+
+	validRelease := `{"assets":[{"id":424242,"name":"` + testGitHubReleaseAssetName + `","url":"https://attacker.invalid/ignored"}]}`
+	for _, tc := range []struct {
+		name       string
+		repository string
+		assetName  string
+		document   string
+		want       string
+		wantError  string
+	}{
+		{name: "valid", repository: "rhysd/actionlint", assetName: testGitHubReleaseAssetName, document: validRelease, want: testGitHubReleaseAssetURL},
+		{name: "invalid repository", repository: "rhysd/actionlint/extra", assetName: testGitHubReleaseAssetName, document: validRelease, wantError: "invalid GitHub release asset repository"},
+		{name: "missing asset", repository: "rhysd/actionlint", assetName: "missing", document: validRelease, wantError: "unable to resolve one release asset"},
+		{name: "duplicate asset", repository: "rhysd/actionlint", assetName: testGitHubReleaseAssetName, document: `{"assets":[{"id":1,"name":"` + testGitHubReleaseAssetName + `"},{"id":2,"name":"` + testGitHubReleaseAssetName + `"}]}`, wantError: "unable to resolve one release asset"},
+		{name: "string asset ID", repository: "rhysd/actionlint", assetName: testGitHubReleaseAssetName, document: `{"assets":[{"id":"424242","name":"` + testGitHubReleaseAssetName + `"}]}`, wantError: "numeric release asset ID"},
+		{name: "zero asset ID", repository: "rhysd/actionlint", assetName: testGitHubReleaseAssetName, document: `{"assets":[{"id":0,"name":"` + testGitHubReleaseAssetName + `"}]}`, wantError: "numeric release asset ID"},
+		{name: "fractional asset ID", repository: "rhysd/actionlint", assetName: testGitHubReleaseAssetName, document: `{"assets":[{"id":1.5,"name":"` + testGitHubReleaseAssetName + `"}]}`, wantError: "numeric release asset ID"},
+		{name: "malformed document", repository: "rhysd/actionlint", assetName: testGitHubReleaseAssetName, document: `{`, wantError: "parse GitHub release metadata"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := githubReleaseAssetAPIURL(strings.NewReader(tc.document), tc.repository, tc.assetName)
+			if tc.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+					t.Fatalf("githubReleaseAssetAPIURL() error = %v, want text %q", err, tc.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("githubReleaseAssetAPIURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidGitHubReleaseAssetRedirectURL(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "valid", url: testGitHubReleaseRedirect, want: true},
+		{name: "http", url: strings.Replace(testGitHubReleaseRedirect, "https://", "http://", 1)},
+		{name: "userinfo", url: strings.Replace(testGitHubReleaseRedirect, "release-assets.githubusercontent.com", "user@release-assets.githubusercontent.com", 1)},
+		{name: "port", url: strings.Replace(testGitHubReleaseRedirect, "release-assets.githubusercontent.com", "release-assets.githubusercontent.com:443", 1)},
+		{name: "different host", url: strings.Replace(testGitHubReleaseRedirect, "release-assets.githubusercontent.com", "objects.githubusercontent.com", 1)},
+		{name: "uppercase UUID", url: strings.Replace(testGitHubReleaseRedirect, "01234567-89ab", "01234567-89AB", 1)},
+		{name: "zero repository ID", url: strings.Replace(testGitHubReleaseRedirect, "/12345678/", "/0/", 1)},
+		{name: "extra path", url: strings.Replace(testGitHubReleaseRedirect, "?sp=", "/extra?sp=", 1)},
+		{name: "escaped path", url: strings.Replace(testGitHubReleaseRedirect, "/12345678/", "/12345678%2F", 1)},
+		{name: "no query", url: strings.Split(testGitHubReleaseRedirect, "?")[0]},
+		{name: "empty query", url: strings.Split(testGitHubReleaseRedirect, "?")[0] + "?"},
+		{name: "fragment", url: testGitHubReleaseRedirect + "#fragment"},
+		{name: "space", url: testGitHubReleaseRedirect + " "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := validGitHubReleaseAssetRedirectURL(tc.url); got != tc.want {
+				t.Fatalf("validGitHubReleaseAssetRedirectURL(%q) = %t, want %t", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFetchGitHubReleaseAssetDirect(t *testing.T) {
+	t.Parallel()
+
+	const token = "fixture-token"
+	const body = "abc  actionlint_1.2.3_linux_amd64.tar.gz\n"
+	requests := 0
+	client := githubReleaseAssetTestClient(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.URL.String() != testGitHubReleaseAssetURL {
+			t.Fatalf("request URL = %q, want %q", req.URL, testGitHubReleaseAssetURL)
+		}
+		if got := req.Header.Get("Accept"); got != "application/octet-stream" {
+			t.Fatalf("Accept = %q", got)
+		}
+		if got := req.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Fatalf("Authorization = %q", got)
+		}
+		return githubReleaseAssetResponse(http.StatusOK, nil, body), nil
+	})
+
+	got, err := fetchGitHubReleaseAsset(context.Background(), client, testGitHubReleaseDocument("424242"), "rhysd/actionlint", testGitHubReleaseAssetName, token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != body || requests != 1 {
+		t.Fatalf("content = %q, requests = %d", got, requests)
+	}
+}
+
+func TestFetchGitHubReleaseAssetRedirectDropsCredentials(t *testing.T) {
+	t.Parallel()
+
+	const token = "fixture-token"
+	const body = "abc  actionlint_1.2.3_linux_amd64.tar.gz\n"
+	var requests []*http.Request
+	client := githubReleaseAssetTestClient(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Clone(req.Context()))
+		if len(requests) == 1 {
+			return githubReleaseAssetResponse(http.StatusFound, http.Header{"Location": []string{testGitHubReleaseRedirect}}, ""), nil
+		}
+		return githubReleaseAssetResponse(http.StatusOK, nil, body), nil
+	})
+
+	got, err := fetchGitHubReleaseAsset(context.Background(), client, testGitHubReleaseDocument("424242"), "rhysd/actionlint", testGitHubReleaseAssetName, token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != body || len(requests) != 2 {
+		t.Fatalf("content = %q, requests = %d", got, len(requests))
+	}
+	if requests[0].URL.String() != testGitHubReleaseAssetURL || requests[0].Header.Get("Authorization") != "Bearer "+token {
+		t.Fatalf("initial request = %#v", requests[0])
+	}
+	if requests[1].URL.String() != testGitHubReleaseRedirect {
+		t.Fatalf("redirect URL = %q", requests[1].URL)
+	}
+	if requests[1].Header.Get("Authorization") != "" || requests[1].Header.Get("Accept") != "" {
+		t.Fatalf("redirect retained initial headers: %#v", requests[1].Header)
+	}
+}
+
+func TestFetchGitHubReleaseAssetRejectsResponses(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		responses []*http.Response
+		wantError string
+	}{
+		{name: "initial 301", responses: []*http.Response{githubReleaseAssetResponse(http.StatusMovedPermanently, nil, "")}, wantError: "unexpected GitHub release asset response 301"},
+		{name: "missing location", responses: []*http.Response{githubReleaseAssetResponse(http.StatusFound, nil, "")}, wantError: "must include one Location header"},
+		{name: "duplicate location", responses: []*http.Response{githubReleaseAssetResponse(http.StatusFound, http.Header{"Location": []string{testGitHubReleaseRedirect, testGitHubReleaseRedirect}}, "")}, wantError: "must include one Location header"},
+		{name: "hostile location", responses: []*http.Response{githubReleaseAssetResponse(http.StatusFound, http.Header{"Location": []string{"https://attacker.invalid/file"}}, "")}, wantError: "outside the allowed endpoint"},
+		{name: "second redirect", responses: []*http.Response{githubReleaseAssetResponse(http.StatusFound, http.Header{"Location": []string{testGitHubReleaseRedirect}}, ""), githubReleaseAssetResponse(http.StatusFound, http.Header{"Location": []string{testGitHubReleaseRedirect}}, "")}, wantError: "unexpected GitHub release asset redirect response 302"},
+		{name: "declared oversized", responses: []*http.Response{{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader("small")), ContentLength: githubReleaseAssetMaxBytes + 1}}, wantError: "exceeds the size limit"},
+		{name: "streamed oversized", responses: []*http.Response{githubReleaseAssetResponse(http.StatusOK, nil, strings.Repeat("x", githubReleaseAssetMaxBytes+1))}, wantError: "exceeds the size limit"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			index := 0
+			client := githubReleaseAssetTestClient(func(*http.Request) (*http.Response, error) {
+				if index >= len(tc.responses) {
+					t.Fatal("unexpected extra request")
+				}
+				response := tc.responses[index]
+				index++
+				return response, nil
+			})
+			_, err := fetchGitHubReleaseAsset(context.Background(), client, testGitHubReleaseDocument("424242"), "rhysd/actionlint", testGitHubReleaseAssetName, "fixture-token")
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("fetchGitHubReleaseAsset() error = %v, want text %q", err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestGitHubReleaseAssetToken(t *testing.T) {
+	t.Setenv("WORKCELL_GITHUB_API_TOKEN", "")
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenFile, []byte("fixture-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WORKCELL_GITHUB_API_TOKEN_FILE", tokenFile)
+	if got, err := githubReleaseAssetToken(); err != nil || got != "fixture-token" {
+		t.Fatalf("githubReleaseAssetToken() = %q, %v", got, err)
+	}
+	if err := os.WriteFile(tokenFile, []byte("fixture-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := githubReleaseAssetToken(); err != nil || got != "fixture-token" {
+		t.Fatalf("newline-terminated githubReleaseAssetToken() = %q, %v", got, err)
+	}
+	if err := os.WriteFile(tokenFile, []byte("fixture\ntoken\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := githubReleaseAssetToken(); err == nil || !strings.Contains(err.Error(), "exactly one token line") {
+		t.Fatalf("githubReleaseAssetToken() error = %v", err)
+	}
+}
+
+func TestGitHubReleaseAssetClientRejectsAutomaticRedirects(t *testing.T) {
+	t.Parallel()
+
+	client := newGitHubReleaseAssetClient()
+	err := client.CheckRedirect(&http.Request{}, []*http.Request{{}})
+	if !errors.Is(err, http.ErrUseLastResponse) {
+		t.Fatalf("CheckRedirect() error = %v, want http.ErrUseLastResponse", err)
+	}
+	if client.Timeout != githubReleaseAssetTimeout {
+		t.Fatalf("client timeout = %s, want %s", client.Timeout, githubReleaseAssetTimeout)
+	}
+}
+
+func testGitHubReleaseDocument(assetID string) io.Reader {
+	return strings.NewReader(`{"assets":[{"id":` + assetID + `,"name":"` + testGitHubReleaseAssetName + `"}]}`)
+}
+
+func githubReleaseAssetResponse(status int, header http.Header, body string) *http.Response {
+	if header == nil {
+		header = make(http.Header)
+	}
+	return &http.Response{
+		StatusCode:    status,
+		Header:        header,
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: -1,
+	}
+}
+
+func githubReleaseAssetTestClient(roundTrip githubReleaseAssetRoundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: roundTrip,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}

--- a/internal/metadatautil/upstream_fetch.go
+++ b/internal/metadatautil/upstream_fetch.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	upstreamMetadataMaxBytes = 200 << 20
+	upstreamChecksumMaxBytes = 64 << 10
+	githubAPIMaxTokenBytes   = 16 << 10
+	upstreamHTTPTimeout      = 120 * time.Second
+	upstreamChecksumTimeout  = 60 * time.Second
+	upstreamConnectTimeout   = 15 * time.Second
+	upstreamUserAgent        = "workcell-upstream-pins/1.0"
+)
+
+var upstreamRustVersionPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
+
+type upstreamHTTPDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type upstreamFetchRequest struct {
+	url                 string
+	redirectHost        string
+	maxBytes            int64
+	timeout             time.Duration
+	responseDescription string
+}
+
+// FetchGitHubAPI gets one bounded GitHub API document. It sends a GitHub token
+// only to the reviewed GitHub API origin and refuses all redirects.
+func FetchGitHubAPI(ctx context.Context, rawURL string) ([]byte, error) {
+	token, err := githubAPIToken()
+	if err != nil {
+		return nil, err
+	}
+	return fetchGitHubAPI(ctx, newGitHubAPIClient(), rawURL, token)
+}
+
+func fetchGitHubAPI(ctx context.Context, client upstreamHTTPDoer, rawURL, token string) ([]byte, error) {
+	return fetchGitHubAPIWithLimit(ctx, client, rawURL, token, upstreamMetadataMaxBytes)
+}
+
+func fetchGitHubAPIWithLimit(ctx context.Context, client upstreamHTTPDoer, rawURL, token string, maxBytes int64) ([]byte, error) {
+	if err := validateGitHubAPIURL(rawURL); err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set("User-Agent", upstreamUserAgent)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.New("unable to download GitHub API metadata")
+	}
+	if resp == nil {
+		return nil, errors.New("GitHub API request returned no response")
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected GitHub API response %d", resp.StatusCode)
+	}
+	return readBoundedHTTPBody(resp, maxBytes, "GitHub API metadata")
+}
+
+func newGitHubAPIClient() *http.Client {
+	return &http.Client{
+		Transport: newUpstreamHTTPTransport(),
+		Timeout:   upstreamHTTPTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func validateGitHubAPIURL(rawURL string) error {
+	parsed, err := url.ParseRequestURI(rawURL)
+	if err != nil {
+		return errors.New("invalid GitHub API URL")
+	}
+	if parsed.Scheme != "https" ||
+		parsed.Host != "api.github.com" ||
+		parsed.User != nil ||
+		parsed.Fragment != "" ||
+		parsed.RawPath != "" ||
+		parsed.Opaque != "" ||
+		!strings.HasPrefix(parsed.Path, "/repos/") {
+		return errors.New("GitHub API URL is outside the allowed endpoint")
+	}
+	return nil
+}
+
+// FetchUpstream gets a bounded document from one reviewed public endpoint.
+// The profile names deliberately form a closed set so the updater cannot turn
+// release metadata into an arbitrary network destination.
+func FetchUpstream(ctx context.Context, args []string) ([]byte, error) {
+	request, err := upstreamFetchRequestFor(args)
+	if err != nil {
+		return nil, err
+	}
+	return fetchUpstream(ctx, newUpstreamFetchClient(request), request)
+}
+
+func fetchUpstream(ctx context.Context, client upstreamHTTPDoer, request upstreamFetchRequest) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, request.url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set("User-Agent", upstreamUserAgent)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to download %s", request.responseDescription)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("%s request returned no response", request.responseDescription)
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected %s response %d", request.responseDescription, resp.StatusCode)
+	}
+	return readBoundedHTTPBody(resp, request.maxBytes, request.responseDescription)
+}
+
+func upstreamFetchRequestFor(args []string) (upstreamFetchRequest, error) {
+	if len(args) == 0 {
+		return upstreamFetchRequest{}, errors.New("missing upstream fetch profile")
+	}
+	switch args[0] {
+	case "go-releases":
+		if len(args) != 1 {
+			return upstreamFetchRequest{}, errors.New("go-releases does not accept arguments")
+		}
+		return fixedUpstreamFetchRequest("https://go.dev/dl/?mode=json", "go.dev", upstreamMetadataMaxBytes, upstreamHTTPTimeout, "Go release metadata"), nil
+	case "rust-channel":
+		if len(args) != 1 {
+			return upstreamFetchRequest{}, errors.New("rust-channel does not accept arguments")
+		}
+		return fixedUpstreamFetchRequest("https://static.rust-lang.org/dist/channel-rust-stable.toml", "static.rust-lang.org", upstreamMetadataMaxBytes, upstreamHTTPTimeout, "Rust channel metadata"), nil
+	case "rustup-release":
+		if len(args) != 1 {
+			return upstreamFetchRequest{}, errors.New("rustup-release does not accept arguments")
+		}
+		return fixedUpstreamFetchRequest("https://static.rust-lang.org/rustup/release-stable.toml", "static.rust-lang.org", upstreamMetadataMaxBytes, upstreamHTTPTimeout, "rustup release metadata"), nil
+	case "rustup-checksum":
+		if len(args) != 3 {
+			return upstreamFetchRequest{}, errors.New("rustup-checksum requires VERSION and TARGET")
+		}
+		version := args[1]
+		if !upstreamRustVersionPattern.MatchString(version) {
+			return upstreamFetchRequest{}, fmt.Errorf("invalid rustup version %q", version)
+		}
+		target := args[2]
+		switch target {
+		case "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu":
+		default:
+			return upstreamFetchRequest{}, fmt.Errorf("unsupported rustup target %q", target)
+		}
+		return fixedUpstreamFetchRequest(fmt.Sprintf("https://static.rust-lang.org/rustup/archive/%s/%s/rustup-init.sha256", version, target), "static.rust-lang.org", upstreamChecksumMaxBytes, upstreamChecksumTimeout, "rustup checksum"), nil
+	case "dockerhub-binfmt-tags":
+		if len(args) != 1 {
+			return upstreamFetchRequest{}, errors.New("dockerhub-binfmt-tags does not accept arguments")
+		}
+		return fixedUpstreamFetchRequest("https://hub.docker.com/v2/repositories/tonistiigi/binfmt/tags?page_size=100", "hub.docker.com", upstreamMetadataMaxBytes, upstreamHTTPTimeout, "Docker Hub binfmt tags"), nil
+	default:
+		return upstreamFetchRequest{}, fmt.Errorf("unknown upstream fetch profile %q", args[0])
+	}
+}
+
+func fixedUpstreamFetchRequest(rawURL, redirectHost string, maxBytes int64, timeout time.Duration, responseDescription string) upstreamFetchRequest {
+	return upstreamFetchRequest{
+		url:                 rawURL,
+		redirectHost:        redirectHost,
+		maxBytes:            maxBytes,
+		timeout:             timeout,
+		responseDescription: responseDescription,
+	}
+}
+
+func newUpstreamFetchClient(request upstreamFetchRequest) *http.Client {
+	return &http.Client{
+		Transport: newUpstreamHTTPTransport(),
+		Timeout:   request.timeout,
+		CheckRedirect: func(next *http.Request, via []*http.Request) error {
+			if len(via) >= 3 {
+				return errors.New("stopped after 3 upstream redirects")
+			}
+			if next.URL.Scheme != "https" ||
+				next.URL.Host != request.redirectHost ||
+				next.URL.User != nil ||
+				next.URL.Fragment != "" ||
+				next.URL.RawPath != "" ||
+				next.URL.Opaque != "" {
+				return errors.New("upstream redirect is outside the reviewed HTTPS origin")
+			}
+			return nil
+		},
+	}
+}
+
+func newUpstreamHTTPTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{
+		Timeout:   upstreamConnectTimeout,
+		KeepAlive: 30 * time.Second,
+	}).DialContext
+	return transport
+}
+
+func readBoundedHTTPBody(response *http.Response, maxBytes int64, description string) ([]byte, error) {
+	if response.Body == nil {
+		return nil, fmt.Errorf("%s response has no body", description)
+	}
+	if response.ContentLength > maxBytes {
+		return nil, fmt.Errorf("%s exceeds the size limit", description)
+	}
+	content, err := io.ReadAll(io.LimitReader(response.Body, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", description, err)
+	}
+	if int64(len(content)) > maxBytes {
+		return nil, fmt.Errorf("%s exceeds the size limit", description)
+	}
+	return content, nil
+}

--- a/internal/metadatautil/upstream_fetch_test.go
+++ b/internal/metadatautil/upstream_fetch_test.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type upstreamHTTPDoerFunc func(*http.Request) (*http.Response, error)
+
+func (fn upstreamHTTPDoerFunc) Do(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+type upstreamRepeatedReader struct {
+	remaining int64
+}
+
+func (r *upstreamRepeatedReader) Read(content []byte) (int, error) {
+	if r.remaining == 0 {
+		return 0, io.EOF
+	}
+	if int64(len(content)) > r.remaining {
+		content = content[:r.remaining]
+	}
+	for index := range content {
+		content[index] = 'x'
+	}
+	r.remaining -= int64(len(content))
+	return len(content), nil
+}
+
+func TestValidateGitHubAPIURL(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "valid", url: "https://api.github.com/repos/hadolint/hadolint/releases/latest", want: true},
+		{name: "valid query", url: "https://api.github.com/repos/docker/actions-toolkit/contents/.github/buildx-releases.json?ref=main", want: true},
+		{name: "http", url: "http://api.github.com/repos/hadolint/hadolint/releases/latest"},
+		{name: "userinfo", url: "https://token@api.github.com/repos/hadolint/hadolint/releases/latest"},
+		{name: "port", url: "https://api.github.com:443/repos/hadolint/hadolint/releases/latest"},
+		{name: "different host", url: "https://attacker.invalid/repos/hadolint/hadolint/releases/latest"},
+		{name: "fragment", url: "https://api.github.com/repos/hadolint/hadolint/releases/latest#fragment"},
+		{name: "escaped path", url: "https://api.github.com/repos/hadolint%2Fhadolint/releases/latest"},
+		{name: "outside repos", url: "https://api.github.com/user"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateGitHubAPIURL(tc.url)
+			if (err == nil) != tc.want {
+				t.Fatalf("validateGitHubAPIURL(%q) error = %v, want valid=%t", tc.url, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestFetchGitHubAPI(t *testing.T) {
+	t.Parallel()
+
+	const token = "fixture-token"
+	content, err := fetchGitHubAPI(context.Background(), upstreamHTTPDoerFunc(func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodGet || request.URL.String() != "https://api.github.com/repos/hadolint/hadolint/releases/latest" {
+			t.Fatalf("request = %s %s", request.Method, request.URL)
+		}
+		if got := request.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Fatalf("Authorization = %q", got)
+		}
+		if got := request.Header.Get("Accept"); got != "application/vnd.github+json" {
+			t.Fatalf("Accept = %q", got)
+		}
+		if got := request.Header.Get("Accept-Encoding"); got != "identity" {
+			t.Fatalf("Accept-Encoding = %q", got)
+		}
+		return upstreamHTTPResponse(http.StatusOK, "{\"tag_name\":\"v1\"}"), nil
+	}), "https://api.github.com/repos/hadolint/hadolint/releases/latest", token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(content), `{"tag_name":"v1"}`; got != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+}
+
+func TestFetchGitHubAPIRejectsBadResponses(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		response *http.Response
+		err      error
+		want     string
+	}{
+		{name: "transport", err: errors.New("network"), want: "unable to download GitHub API metadata"},
+		{name: "nil response", want: "returned no response"},
+		{name: "redirect", response: upstreamHTTPResponse(http.StatusFound, ""), want: "unexpected GitHub API response 302"},
+		{name: "missing body", response: &http.Response{StatusCode: http.StatusOK, Header: make(http.Header)}, want: "has no body"},
+		{name: "declared oversized", response: &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader("small")), ContentLength: 5}, want: "exceeds the size limit"},
+		{name: "streamed oversized", response: &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(&upstreamRepeatedReader{remaining: 5}), ContentLength: -1}, want: "exceeds the size limit"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := fetchGitHubAPIWithLimit(context.Background(), upstreamHTTPDoerFunc(func(*http.Request) (*http.Response, error) {
+				return tc.response, tc.err
+			}), "https://api.github.com/repos/hadolint/hadolint/releases/latest", "", 4)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("fetchGitHubAPI() error = %v, want text %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestGitHubAPIClientRejectsAutomaticRedirects(t *testing.T) {
+	t.Parallel()
+
+	client := newGitHubAPIClient()
+	if err := client.CheckRedirect(&http.Request{}, []*http.Request{{}}); !errors.Is(err, http.ErrUseLastResponse) {
+		t.Fatalf("CheckRedirect() error = %v, want http.ErrUseLastResponse", err)
+	}
+	if client.Timeout != upstreamHTTPTimeout {
+		t.Fatalf("client timeout = %s, want %s", client.Timeout, upstreamHTTPTimeout)
+	}
+}
+
+func TestUpstreamFetchRequestFor(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		url     string
+		host    string
+		max     int64
+		timeout int64
+		wantErr string
+	}{
+		{name: "go", args: []string{"go-releases"}, url: "https://go.dev/dl/?mode=json", host: "go.dev", max: upstreamMetadataMaxBytes, timeout: int64(upstreamHTTPTimeout)},
+		{name: "rust channel", args: []string{"rust-channel"}, url: "https://static.rust-lang.org/dist/channel-rust-stable.toml", host: "static.rust-lang.org", max: upstreamMetadataMaxBytes, timeout: int64(upstreamHTTPTimeout)},
+		{name: "rustup release", args: []string{"rustup-release"}, url: "https://static.rust-lang.org/rustup/release-stable.toml", host: "static.rust-lang.org", max: upstreamMetadataMaxBytes, timeout: int64(upstreamHTTPTimeout)},
+		{name: "rustup checksum", args: []string{"rustup-checksum", "1.2.3", "x86_64-unknown-linux-gnu"}, url: "https://static.rust-lang.org/rustup/archive/1.2.3/x86_64-unknown-linux-gnu/rustup-init.sha256", host: "static.rust-lang.org", max: upstreamChecksumMaxBytes, timeout: int64(upstreamChecksumTimeout)},
+		{name: "docker hub", args: []string{"dockerhub-binfmt-tags"}, url: "https://hub.docker.com/v2/repositories/tonistiigi/binfmt/tags?page_size=100", host: "hub.docker.com", max: upstreamMetadataMaxBytes, timeout: int64(upstreamHTTPTimeout)},
+		{name: "unknown", args: []string{"https://attacker.invalid"}, wantErr: "unknown upstream fetch profile"},
+		{name: "bad rust version", args: []string{"rustup-checksum", "1.2.3?redirect", "x86_64-unknown-linux-gnu"}, wantErr: "invalid rustup version"},
+		{name: "bad target", args: []string{"rustup-checksum", "1.2.3", "attacker"}, wantErr: "unsupported rustup target"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			request, err := upstreamFetchRequestFor(tc.args)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("upstreamFetchRequestFor(%q) error = %v, want text %q", tc.args, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if request.url != tc.url || request.redirectHost != tc.host || request.maxBytes != tc.max || int64(request.timeout) != tc.timeout {
+				t.Fatalf("request = %#v", request)
+			}
+		})
+	}
+}
+
+func TestFetchUpstreamAndRedirectPolicy(t *testing.T) {
+	t.Parallel()
+
+	request := fixedUpstreamFetchRequest("https://go.dev/dl/?mode=json", "go.dev", 4, upstreamHTTPTimeout, "fixture metadata")
+	content, err := fetchUpstream(context.Background(), upstreamHTTPDoerFunc(func(got *http.Request) (*http.Response, error) {
+		if got.URL.String() != request.url || got.Header.Get("Accept-Encoding") != "identity" || got.Header.Get("Authorization") != "" {
+			t.Fatalf("request = %#v", got)
+		}
+		return upstreamHTTPResponse(http.StatusOK, "body"), nil
+	}), request)
+	if err != nil || string(content) != "body" {
+		t.Fatalf("fetchUpstream() = %q, %v", content, err)
+	}
+
+	client := newUpstreamFetchClient(request)
+	good, err := http.NewRequest(http.MethodGet, "https://go.dev/next", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.CheckRedirect(good, nil); err != nil {
+		t.Fatalf("same-origin HTTPS redirect rejected: %v", err)
+	}
+	bad, err := url.Parse("http://go.dev/next")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.CheckRedirect(&http.Request{URL: bad}, nil); err == nil || !strings.Contains(err.Error(), "outside the reviewed HTTPS origin") {
+		t.Fatalf("insecure redirect error = %v", err)
+	}
+	otherHost, err := url.Parse("https://attacker.invalid/next")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.CheckRedirect(&http.Request{URL: otherHost}, nil); err == nil || !strings.Contains(err.Error(), "outside the reviewed HTTPS origin") {
+		t.Fatalf("different-host redirect error = %v", err)
+	}
+	if err := client.CheckRedirect(good, []*http.Request{{}, {}, {}}); err == nil || !strings.Contains(err.Error(), "stopped after 3") {
+		t.Fatalf("redirect-count error = %v", err)
+	}
+}
+
+func TestReadBoundedHTTPBodyRejectsUnknownLengthOverflow(t *testing.T) {
+	t.Parallel()
+
+	response := upstreamHTTPResponse(http.StatusOK, "12345")
+	if _, err := readBoundedHTTPBody(response, 4, "fixture"); err == nil || !strings.Contains(err.Error(), "exceeds the size limit") {
+		t.Fatalf("readBoundedHTTPBody() error = %v", err)
+	}
+}
+
+func upstreamHTTPResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode:    status,
+		Header:        make(http.Header),
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: -1,
+	}
+}

--- a/internal/testkit/update_upstream_pins_check_test.go
+++ b/internal/testkit/update_upstream_pins_check_test.go
@@ -20,7 +20,6 @@ import (
 
 const (
 	updaterFixtureActionlintAssetID = "424242"
-	updaterFixtureCurlVersion       = "8.7.1"
 )
 
 type updaterFixturePins struct {
@@ -103,14 +102,12 @@ type updaterFixtureCurlCall struct {
 }
 
 type updaterFixtureOptions struct {
-	Token       string
-	CurlVersion string
+	Token             string
+	RelativeTokenFile bool
 }
 
 func defaultUpdaterFixtureOptions() updaterFixtureOptions {
-	return updaterFixtureOptions{
-		CurlVersion: updaterFixtureCurlVersion,
-	}
+	return updaterFixtureOptions{}
 }
 
 func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
@@ -131,12 +128,14 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 	checkRun := runUpdaterFixture(t, fixtureRoot, checkScratch, citoolsPath, goWrapperPath, pins, targetPlan, "--check")
 	assertUpdaterFixtureRun(t, checkRun, 1, updaterFixtureSummary(pins, driftedManifest, targetManifest), targetPlan.Snapshot)
 	assertUpdaterCommandCounts(t, checkRun.CIToolsLog, map[string]int{
-		"github-release-asset":       1,
+		"github-api-get":             7,
+		"github-release-asset":       3,
 		"hadolint-manifest-checksum": 2,
 		"select-buildx-version":      1,
 		"inspect-debian-bootstrap":   1,
 		"apply-debian-bootstrap":     0,
 		"check-pinned-inputs":        0,
+		"upstream-get":               6,
 	})
 	if want := []string{"summary", "check"}; !reflect.DeepEqual(checkRun.ProviderLog, want) {
 		t.Fatalf("provider updater command log = %q, want %q", checkRun.ProviderLog, want)
@@ -157,12 +156,14 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 	applyRun := runUpdaterFixture(t, fixtureRoot, applyScratch, citoolsPath, goWrapperPath, pins, targetPlan, "--apply")
 	assertUpdaterFixtureRun(t, applyRun, 0, updaterFixtureSummary(pins, driftedManifest, targetManifest), targetPlan.Snapshot)
 	assertUpdaterCommandCounts(t, applyRun.CIToolsLog, map[string]int{
-		"github-release-asset":       1,
+		"github-api-get":             7,
+		"github-release-asset":       3,
 		"hadolint-manifest-checksum": 2,
 		"select-buildx-version":      1,
 		"inspect-debian-bootstrap":   1,
 		"apply-debian-bootstrap":     1,
 		"check-pinned-inputs":        1,
+		"upstream-get":               6,
 	})
 	if want := []string{"summary", "check", "apply"}; !reflect.DeepEqual(applyRun.ProviderLog, want) {
 		t.Fatalf("provider updater command log = %q, want %q", applyRun.ProviderLog, want)
@@ -193,12 +194,14 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 	cleanRun := runUpdaterFixture(t, fixtureRoot, cleanScratch, citoolsPath, goWrapperPath, pins, targetPlan, "--check")
 	assertUpdaterFixtureRun(t, cleanRun, 0, updaterFixtureSummary(pins, targetManifest, targetManifest), targetPlan.Snapshot)
 	assertUpdaterCommandCounts(t, cleanRun.CIToolsLog, map[string]int{
-		"github-release-asset":       1,
+		"github-api-get":             7,
+		"github-release-asset":       3,
 		"hadolint-manifest-checksum": 2,
 		"select-buildx-version":      1,
 		"inspect-debian-bootstrap":   1,
 		"apply-debian-bootstrap":     0,
 		"check-pinned-inputs":        0,
+		"upstream-get":               6,
 	})
 	assertUpdaterScratchHasOnlyLogs(t, cleanScratch)
 	afterCleanCheck := snapshotUpdaterFixtureTree(t, fixtureRoot)
@@ -222,13 +225,17 @@ func TestUpdateUpstreamPinsCredentialedRequestsKeepTokensOffArgv(t *testing.T) {
 
 	options := defaultUpdaterFixtureOptions()
 	options.Token = token
+	options.RelativeTokenFile = true
 	run := runUpdaterFixtureWithOptions(t, fixtureRoot, t.TempDir(), citoolsPath, goWrapperPath, pins, targetPlan, "--check", options)
 	assertUpdaterFixtureRun(t, run, 1, updaterFixtureSummary(pins, driftedManifest, targetManifest), targetPlan.Snapshot)
-	assertCredentialedUpdaterCurlCalls(t, run.CurlCalls, token)
-	assertUpdaterCommandCounts(t, run.CIToolsLog, map[string]int{"github-release-asset": 1})
+	assertUpdaterCommandCounts(t, run.CIToolsLog, map[string]int{
+		"github-api-get":       7,
+		"github-release-asset": 3,
+		"upstream-get":         6,
+	})
 }
 
-func TestUpdateUpstreamPinsRequiresBoundedCurl(t *testing.T) {
+func TestUpdateUpstreamPinsDoesNotRequireCurlVersion(t *testing.T) {
 	t.Parallel()
 
 	pins := readUpdaterFixturePins(t)
@@ -240,31 +247,12 @@ func TestUpdateUpstreamPinsRequiresBoundedCurl(t *testing.T) {
 	goWrapperPath := writeUpdaterFixtureGoWrapper(t, toolsRoot)
 	fixtureRoot := writeUpdaterFixture(t, driftedManifest, 0o640)
 
-	for _, tc := range []struct {
-		name        string
-		version     string
-		wantCode    int
-		wantMessage string
-	}{
-		{name: "minimum", version: "8.4.0", wantCode: 1, wantMessage: updaterFixtureSummary(pins, driftedManifest, targetManifest)},
-		{name: "older", version: "8.3.0", wantCode: 1, wantMessage: "curl 8.4.0 or newer is required"},
-		{name: "malformed", version: "not-a-version", wantCode: 1, wantMessage: "Unable to parse the curl version"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			options := defaultUpdaterFixtureOptions()
-			options.CurlVersion = tc.version
-			run := runUpdaterFixtureWithOptions(t, fixtureRoot, t.TempDir(), citoolsPath, goWrapperPath, pins, targetPlan, "--check", options)
-			if run.Code != tc.wantCode {
-				t.Fatalf("update-upstream-pins exit code = %d, want %d\n%s", run.Code, tc.wantCode, run.Output)
-			}
-			if !strings.Contains(run.Output, tc.wantMessage) {
-				t.Fatalf("update-upstream-pins output = %q, want text %q", run.Output, tc.wantMessage)
-			}
-			assertUpdaterFixtureCurlVersionProbe(t, run.CurlCalls, tc.version)
-			if tc.version != "8.4.0" && updaterFixtureCurlKindCount(run.CurlCalls, "curl") != 0 {
-				t.Fatalf("unsupported curl version made HTTP requests: %#v", run.CurlCalls)
-			}
-		})
+	run := runUpdaterFixture(t, fixtureRoot, t.TempDir(), citoolsPath, goWrapperPath, pins, targetPlan, "--check")
+	assertUpdaterFixtureRun(t, run, 1, updaterFixtureSummary(pins, driftedManifest, targetManifest), targetPlan.Snapshot)
+	for _, call := range run.CurlCalls {
+		if call.Kind != "curl" || strings.Contains(call.Args, "--version") || strings.Contains(call.Args, "--max-filesize") {
+			t.Fatalf("updater used unsupported curl capability: %#v", call)
+		}
 	}
 }
 
@@ -291,12 +279,14 @@ func TestUpdateUpstreamPinsApplyFailureLeavesFixtureUnchanged(t *testing.T) {
 	}
 	assertUpdaterResolutionLog(t, run.ResolutionLog, invalidPlan.Snapshot)
 	assertUpdaterCommandCounts(t, run.CIToolsLog, map[string]int{
-		"github-release-asset":       1,
+		"github-api-get":             7,
+		"github-release-asset":       3,
 		"hadolint-manifest-checksum": 2,
 		"select-buildx-version":      1,
 		"inspect-debian-bootstrap":   1,
 		"apply-debian-bootstrap":     1,
 		"check-pinned-inputs":        0,
+		"upstream-get":               6,
 	})
 	if want := []string{"summary", "check"}; !reflect.DeepEqual(run.ProviderLog, want) {
 		t.Fatalf("provider updater command log = %q, want %q", run.ProviderLog, want)
@@ -331,11 +321,11 @@ func TestUpdaterFixtureCurlRejectsUnexpectedReleaseProbeArguments(t *testing.T) 
 			name string
 			args string
 		}{
-			{name: "missing-curlrc-disable", args: "-fsSI --max-time 120 --connect-timeout 15 --max-filesize 209715200"},
-			{name: "late-curlrc-disable", args: "-fsSI -q --max-time 120 --connect-timeout 15 --max-filesize 209715200"},
-			{name: "wrong-method", args: "-q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200"},
-			{name: "missing-size-bound", args: "-q -fsSI --max-time 120 --connect-timeout 15"},
-			{name: "extra-arguments", args: "-q -fsSI --max-time 120 --connect-timeout 15 --max-filesize 209715200 --retry 1"},
+			{name: "missing-curlrc-disable", args: "-fsSI --max-time 120 --connect-timeout 15"},
+			{name: "late-curlrc-disable", args: "-fsSI -q --max-time 120 --connect-timeout 15"},
+			{name: "wrong-method", args: "-q -fsSL --max-time 120 --connect-timeout 15"},
+			{name: "stale-size-bound", args: "-q -fsSI --max-time 120 --connect-timeout 15 --max-filesize 209715200"},
+			{name: "extra-arguments", args: "-q -fsSI --max-time 120 --connect-timeout 15 --retry 1"},
 		} {
 			malformed := malformed
 			t.Run(endpoint.name+"/"+malformed.name, func(t *testing.T) {
@@ -598,9 +588,14 @@ func runUpdaterFixtureWithOptions(t *testing.T, fixtureRoot, scratchRoot, citool
 		t.Fatal(err)
 	}
 	if options.Token != "" {
-		credentialDir := t.TempDir()
-		tokenFile = filepath.Join(credentialDir, "github-token")
-		if err := os.WriteFile(tokenFile, []byte(options.Token), 0o600); err != nil {
+		credentialPath := filepath.Join(t.TempDir(), "github-token")
+		if options.RelativeTokenFile {
+			tokenFile = "github-token"
+			credentialPath = filepath.Join(scratchRoot, tokenFile)
+		} else {
+			tokenFile = credentialPath
+		}
+		if err := os.WriteFile(credentialPath, []byte(options.Token), 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -637,7 +632,6 @@ func runUpdaterFixtureWithOptions(t *testing.T, fixtureRoot, scratchRoot, citool
 		"WORKCELL_FIXTURE_CITOOLS_LOG=" + citoolsLogPath,
 		"WORKCELL_FIXTURE_COSIGN_VERSION=" + pins.CosignVersion,
 		"WORKCELL_FIXTURE_CURL_LOG=" + curlLogPath,
-		"WORKCELL_FIXTURE_CURL_VERSION=" + options.CurlVersion,
 		"WORKCELL_FIXTURE_GITHUB_TOKEN=" + options.Token,
 		"WORKCELL_FIXTURE_REQUIRE_HOSTILE_CURLRC=1",
 		"WORKCELL_FIXTURE_DEBIAN_PLAN=" + string(planJSON),
@@ -742,58 +736,6 @@ func readUpdaterFixtureCurlCalls(t *testing.T, path string) []updaterFixtureCurl
 	return calls
 }
 
-func updaterFixtureCurlKindCount(calls []updaterFixtureCurlCall, kind string) int {
-	count := 0
-	for _, call := range calls {
-		if call.Kind == kind {
-			count++
-		}
-	}
-	return count
-}
-
-func assertUpdaterFixtureCurlVersionProbe(t *testing.T, calls []updaterFixtureCurlCall, version string) {
-	t.Helper()
-
-	count := 0
-	for _, call := range calls {
-		if call.Kind != "curl-version" {
-			continue
-		}
-		count++
-		if call.URL != version || call.Config != "" || call.Args != "-q --version" {
-			t.Fatalf("curl version probe = %#v, want version %q with -q first", call, version)
-		}
-	}
-	if count != 1 {
-		t.Fatalf("curl version probes = %d, want 1; calls=%#v", count, calls)
-	}
-}
-
-func assertCredentialedUpdaterCurlCalls(t *testing.T, calls []updaterFixtureCurlCall, token string) {
-	t.Helper()
-
-	githubConfig := "header = \"Accept: application/vnd.github+json\"\nheader = \"Authorization: Bearer " + token + "\""
-	githubCalls := 0
-	for _, call := range calls {
-		if call.Kind != "curl" {
-			continue
-		}
-		if strings.Contains(call.Args, token) || strings.Contains(call.Args, "Authorization:") || strings.Contains(call.Args, "--oauth2-bearer") {
-			t.Fatalf("credential leaked through curl argv: %#v", call)
-		}
-		if strings.HasPrefix(call.URL, "https://api.github.com/") {
-			githubCalls++
-			if call.Config != githubConfig || !strings.Contains(call.Args, "--config -") || strings.Contains(call.Args, "-fsSL") {
-				t.Fatalf("GitHub API curl capture = %#v, want config %q through stdin", call, githubConfig)
-			}
-		}
-	}
-	if githubCalls == 0 {
-		t.Fatalf("credentialed updater made no GitHub API calls: %#v", calls)
-	}
-}
-
 func assertUpdaterFixtureRun(t *testing.T, run updaterFixtureRun, wantCode int, wantOutput, snapshot string) {
 	t.Helper()
 
@@ -835,7 +777,7 @@ func assertUpdaterCommandCounts(t *testing.T, commands []string, expected map[st
 	}
 	for command := range counts {
 		switch command {
-		case "extract-dockerfile-arg", "github-release-asset", "hadolint-manifest-checksum", "select-buildx-version", "inspect-debian-bootstrap", "apply-debian-bootstrap", "check-pinned-inputs":
+		case "extract-dockerfile-arg", "github-api-get", "github-release-asset", "hadolint-manifest-checksum", "select-buildx-version", "inspect-debian-bootstrap", "apply-debian-bootstrap", "check-pinned-inputs", "upstream-get":
 		default:
 			t.Fatalf("unexpected real workcell-citools command %q; log=%q", command, commands)
 		}
@@ -1146,24 +1088,6 @@ expect_fixture_curl_argv() {
   fi
   shift
   expected=("$@")
-  if [[ "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" != "" && "${label}" == https://api.github.com/* ]]; then
-    local -a credentialed=()
-    for ((index = 0; index < ${#expected[@]}; index++)); do
-      if [[ "${expected[index]}" == "-H" && "${expected[index + 1]:-}" == "Accept: application/vnd.github+json" ]]; then
-        ((index++))
-        continue
-      fi
-      if [[ "${expected[index]}" == "-fsSL" ]]; then
-        credentialed+=(-fsS)
-        continue
-      fi
-      if [[ "${expected[index]}" == "${label}" ]]; then
-        credentialed+=(--config -)
-      fi
-      credentialed+=("${expected[index]}")
-    done
-    expected=("${credentialed[@]}")
-  fi
   if [[ "${#actual[@]}" -ne "${#expected[@]}" ]]; then
     unexpected_fixture curl "${label}: argv=${actual[*]}"
     return
@@ -1197,111 +1121,13 @@ curl() {
       return
     fi
   fi
-  if [[ "$#" -eq 2 && "$1" == "-q" && "$2" == "--version" ]]; then
-    record_fixture_http_request curl-version "${WORKCELL_FIXTURE_CURL_VERSION}" "" "$*"
-    printf 'curl %s (fixture) libcurl/%s\n' "${WORKCELL_FIXTURE_CURL_VERSION}" "${WORKCELL_FIXTURE_CURL_VERSION}"
-    return
-  fi
   local url="${!#}"
-  local fixture_curl_config=""
-  local index=0
-  for ((index = 1; index <= $#; index++)); do
-    if [[ "${!index}" != "--config" ]]; then
-      continue
-    fi
-    local next_index=$((index + 1))
-    local config_source="${!next_index}"
-    if [[ "${config_source}" != "-" ]]; then
-      unexpected_fixture curl "${url}: unexpected curl config source ${config_source:-<missing>}"
-      return
-    fi
-    fixture_curl_config="$(cat)"
-    break
-  done
-  if [[ "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" != "" && "${url}" == https://api.github.com/repos/rhysd/actionlint/releases/assets/* ]]; then
-    local expected_asset_config="header = \"Authorization: Bearer ${WORKCELL_FIXTURE_GITHUB_TOKEN}\""
-    if [[ "${fixture_curl_config}" != "${expected_asset_config}" ]]; then
-      unexpected_fixture curl "${url}: credential config=${fixture_curl_config}"
-      return
-    fi
-  elif [[ "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" != "" && "${url}" == https://api.github.com/* ]]; then
-    local expected_config="header = \"Accept: application/vnd.github+json\"
-header = \"Authorization: Bearer ${WORKCELL_FIXTURE_GITHUB_TOKEN}\""
-    if [[ "${fixture_curl_config}" != "${expected_config}" ]]; then
-      unexpected_fixture curl "${url}: credential config=${fixture_curl_config}"
-      return
-    fi
-  fi
-  record_fixture_http_request curl "${url}" "${fixture_curl_config}" "$*"
+  record_fixture_http_request curl "${url}" "" "$*"
   case "${url}" in
-    'https://go.dev/dl/?mode=json')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 "${url}" || return
-      printf '[{"stable":true,"version":"go%s","files":[{"os":"linux","arch":"amd64","kind":"archive","sha256":"%s"},{"os":"linux","arch":"arm64","kind":"archive","sha256":"%s"}]}]\n' \
-        "${WORKCELL_FIXTURE_GO_VERSION}" "${WORKCELL_FIXTURE_GO_AMD64_SHA}" "${WORKCELL_FIXTURE_GO_ARM64_SHA}"
-      ;;
-    'https://static.rust-lang.org/dist/channel-rust-stable.toml')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 "${url}" || return
-      printf '[pkg.rust]\nversion = "%s (fixture)"\n' "${WORKCELL_FIXTURE_RUST_VERSION}"
-      ;;
-    'https://static.rust-lang.org/rustup/release-stable.toml')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 "${url}" || return
-      printf "version = '%s'\n" "${WORKCELL_FIXTURE_RUSTUP_VERSION}"
-      ;;
-    */x86_64-unknown-linux-gnu/rustup-init.sha256)
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 60 --connect-timeout 15 --max-filesize 65536 "${url}" || return
-      printf '%s  rustup-init\n' "${WORKCELL_FIXTURE_RUSTUP_AMD64_SHA}"
-      ;;
-    */aarch64-unknown-linux-gnu/rustup-init.sha256)
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 60 --connect-timeout 15 --max-filesize 65536 "${url}" || return
-      printf '%s  rustup-init\n' "${WORKCELL_FIXTURE_RUSTUP_ARM64_SHA}"
-      ;;
-    'https://api.github.com/repos/hadolint/hadolint/releases/latest')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 -H 'Accept: application/vnd.github+json' "${url}" || return
-      printf '{"tag_name":"%s","assets":[{"name":"checksums.sha256","browser_download_url":"https://fixture.invalid/hadolint-checksums.sha256"}]}\n' "${WORKCELL_FIXTURE_HADOLINT_VERSION}"
-      ;;
-    'https://fixture.invalid/hadolint-checksums.sha256')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 60 --connect-timeout 15 --max-filesize 65536 "${url}" || return
-      printf '%s' "${WORKCELL_FIXTURE_HADOLINT_CHECKSUMS}"
-      ;;
-    'https://api.github.com/repos/docker/buildx/releases/latest')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 -H 'Accept: application/vnd.github+json' "${url}" || return
-      printf '{"tag_name":"%s","assets":[]}\n' "${WORKCELL_FIXTURE_BUILDX_VERSION}"
-      ;;
-    'https://api.github.com/repos/docker/actions-toolkit/contents/.github/buildx-releases.json?ref=main')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 -H 'Accept: application/vnd.github+json' "${url}" || return
-      local catalog
-      catalog="$(printf '{"%s":{"tag_name":"%s"}}' "${WORKCELL_FIXTURE_BUILDX_VERSION}" "${WORKCELL_FIXTURE_BUILDX_VERSION}" | base64 | tr -d '\n')"
-      printf '{"encoding":"base64","content":"%s"}\n' "${catalog}"
-      ;;
-    'https://api.github.com/repos/sigstore/cosign/releases/latest')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 -H 'Accept: application/vnd.github+json' "${url}" || return
-      printf '{"tag_name":"%s","assets":[]}\n' "${WORKCELL_FIXTURE_COSIGN_VERSION}"
-      ;;
-    'https://api.github.com/repos/anchore/syft/releases/latest')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 -H 'Accept: application/vnd.github+json' "${url}" || return
-      printf '{"tag_name":"%s","assets":[]}\n' "${WORKCELL_FIXTURE_SYFT_VERSION}"
-      ;;
-    'https://api.github.com/repos/rhysd/actionlint/releases/latest')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 -H 'Accept: application/vnd.github+json' "${url}" || return
-      printf '{"tag_name":"v%s","assets":[{"id":%s,"name":"actionlint_%s_checksums.txt","url":"https://attacker.invalid/actionlint-checksums"}]}\n' \
-        "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}" "${WORKCELL_FIXTURE_ACTIONLINT_ASSET_ID}" "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}"
-      ;;
-    'https://api.github.com/repos/zizmorcore/zizmor/releases/latest')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 -H 'Accept: application/vnd.github+json' "${url}" || return
-      printf '{"tag_name":"v%s","assets":[{"name":"zizmor-x86_64-unknown-linux-gnu.tar.gz","browser_download_url":"https://fixture.invalid/zizmor.tar.gz"}]}\n' "${WORKCELL_FIXTURE_ZIZMOR_VERSION}"
-      ;;
-    'https://fixture.invalid/zizmor.tar.gz')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 60 --connect-timeout 15 --max-filesize 209715200 "${url}" || return
-      printf 'fixture-zizmor-archive'
-      ;;
-    'https://hub.docker.com/v2/repositories/tonistiigi/binfmt/tags?page_size=100')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 "${url}" || return
-      printf '{"results":[{"name":"%s"}]}\n' "${WORKCELL_FIXTURE_QEMU_TAG}"
-      ;;
     https://snapshot.debian.org/archive/debian/*/dists/trixie/Release|\
     https://snapshot.debian.org/archive/debian/*/dists/trixie-updates/Release|\
     https://snapshot.debian.org/archive/debian-security/*/dists/trixie-security/Release)
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSI --max-time 120 --connect-timeout 15 --max-filesize 209715200 "${url}" || return
+      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSI --max-time 120 --connect-timeout 15 "${url}" || return
       printf 'release %s\n' "${url}" >>"${WORKCELL_FIXTURE_RESOLUTION_LOG}"
       ;;
     *)
@@ -1334,6 +1160,29 @@ docker() {
   printf 'Name: %s\nDigest: sha256:%s\n' "${ref}" "${digest}"
 }
 
+fixture_require_citools_root() {
+  [[ "${PWD}" == "${WORKCELL_FIXTURE_ROOT}" ]] || {
+    unexpected_fixture go "workcell-citools cwd=${PWD}"
+    return
+  }
+}
+
+fixture_require_github_token_boundary() {
+  [[ "$*" != *"${WORKCELL_FIXTURE_GITHUB_TOKEN:-}"* || -z "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" ]] || {
+    unexpected_fixture go "GitHub token leaked through argv"
+    return
+  }
+  if [[ -n "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" ]]; then
+    [[ -r "${WORKCELL_GITHUB_API_TOKEN_FILE:-}" && "$(<"${WORKCELL_GITHUB_API_TOKEN_FILE}")" == "${WORKCELL_FIXTURE_GITHUB_TOKEN}" ]] || {
+      unexpected_fixture go "invalid GitHub token file"
+      return
+    }
+  elif [[ -n "${WORKCELL_GITHUB_API_TOKEN_FILE:-}" ]]; then
+    unexpected_fixture go "unexpected GitHub token file"
+    return
+  fi
+}
+
 go() {
   local command="${3:-}"
   if [[ "${1:-}" != "run" || "${2:-}" != "./cmd/workcell-citools" || "$#" -lt 3 ]]; then
@@ -1349,34 +1198,129 @@ go() {
     printf '%s\n' "${WORKCELL_FIXTURE_DEBIAN_PLAN}"
     return
   fi
-  if [[ "${command}" == "github-release-asset" ]]; then
-    [[ "${PWD}" == "${WORKCELL_FIXTURE_ROOT}" ]] || {
-      unexpected_fixture go "github-release-asset cwd=${PWD}"
+  if [[ "${command}" == "github-api-get" ]]; then
+    fixture_require_citools_root || return
+    fixture_require_github_token_boundary "$@" || return
+    [[ "$#" -eq 4 ]] || {
+      unexpected_fixture go "$*"
       return
     }
-    [[ "$#" -eq 5 && "$4" == "rhysd/actionlint" && "$5" == "actionlint_${WORKCELL_FIXTURE_ACTIONLINT_VERSION}_checksums.txt" ]] || {
+    printf '%s\n' "${command}" >>"${WORKCELL_FIXTURE_CITOOLS_LOG}"
+    case "$4" in
+      'https://api.github.com/repos/hadolint/hadolint/releases/latest')
+        printf '{"tag_name":"%s","assets":[{"id":424243,"name":"checksums.sha256"}]}\n' "${WORKCELL_FIXTURE_HADOLINT_VERSION}"
+        ;;
+      'https://api.github.com/repos/docker/buildx/releases/latest')
+        printf '{"tag_name":"%s","assets":[]}\n' "${WORKCELL_FIXTURE_BUILDX_VERSION}"
+        ;;
+      'https://api.github.com/repos/docker/actions-toolkit/contents/.github/buildx-releases.json?ref=main')
+        local catalog
+        catalog="$(printf '{"%s":{"tag_name":"%s"}}' "${WORKCELL_FIXTURE_BUILDX_VERSION}" "${WORKCELL_FIXTURE_BUILDX_VERSION}" | base64 | tr -d '\n')"
+        printf '{"encoding":"base64","content":"%s"}\n' "${catalog}"
+        ;;
+      'https://api.github.com/repos/sigstore/cosign/releases/latest')
+        printf '{"tag_name":"%s","assets":[]}\n' "${WORKCELL_FIXTURE_COSIGN_VERSION}"
+        ;;
+      'https://api.github.com/repos/anchore/syft/releases/latest')
+        printf '{"tag_name":"%s","assets":[]}\n' "${WORKCELL_FIXTURE_SYFT_VERSION}"
+        ;;
+      'https://api.github.com/repos/rhysd/actionlint/releases/latest')
+        printf '{"tag_name":"v%s","assets":[{"id":%s,"name":"actionlint_%s_checksums.txt"}]}\n' \
+          "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}" "${WORKCELL_FIXTURE_ACTIONLINT_ASSET_ID}" "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}"
+        ;;
+      'https://api.github.com/repos/zizmorcore/zizmor/releases/latest')
+        printf '{"tag_name":"v%s","assets":[{"id":424244,"name":"zizmor-x86_64-unknown-linux-gnu.tar.gz"}]}\n' "${WORKCELL_FIXTURE_ZIZMOR_VERSION}"
+        ;;
+      *)
+        unexpected_fixture go "$*"
+        ;;
+    esac
+    return
+  fi
+  if [[ "${command}" == "upstream-get" ]]; then
+    fixture_require_citools_root || return
+    printf '%s\n' "${command}" >>"${WORKCELL_FIXTURE_CITOOLS_LOG}"
+    case "$4" in
+      go-releases)
+        [[ "$#" -eq 4 ]] || {
+          unexpected_fixture go "$*"
+          return
+        }
+        printf '[{"stable":true,"version":"go%s","files":[{"os":"linux","arch":"amd64","kind":"archive","sha256":"%s"},{"os":"linux","arch":"arm64","kind":"archive","sha256":"%s"}]}]\n' \
+          "${WORKCELL_FIXTURE_GO_VERSION}" "${WORKCELL_FIXTURE_GO_AMD64_SHA}" "${WORKCELL_FIXTURE_GO_ARM64_SHA}"
+        ;;
+      rust-channel)
+        [[ "$#" -eq 4 ]] || {
+          unexpected_fixture go "$*"
+          return
+        }
+        printf '[pkg.rust]\nversion = "%s (fixture)"\n' "${WORKCELL_FIXTURE_RUST_VERSION}"
+        ;;
+      rustup-release)
+        [[ "$#" -eq 4 ]] || {
+          unexpected_fixture go "$*"
+          return
+        }
+        printf "version = '%s'\n" "${WORKCELL_FIXTURE_RUSTUP_VERSION}"
+        ;;
+      rustup-checksum)
+        [[ "$#" -eq 6 && "$5" == "${WORKCELL_FIXTURE_RUSTUP_VERSION}" ]] || {
+          unexpected_fixture go "$*"
+          return
+        }
+        case "$6" in
+          x86_64-unknown-linux-gnu)
+            printf '%s  rustup-init\n' "${WORKCELL_FIXTURE_RUSTUP_AMD64_SHA}"
+            ;;
+          aarch64-unknown-linux-gnu)
+            printf '%s  rustup-init\n' "${WORKCELL_FIXTURE_RUSTUP_ARM64_SHA}"
+            ;;
+          *)
+            unexpected_fixture go "$*"
+            ;;
+        esac
+        ;;
+      dockerhub-binfmt-tags)
+        [[ "$#" -eq 4 ]] || {
+          unexpected_fixture go "$*"
+          return
+        }
+        printf '{"results":[{"name":"%s"}]}\n' "${WORKCELL_FIXTURE_QEMU_TAG}"
+        ;;
+      *)
+        unexpected_fixture go "$*"
+        ;;
+    esac
+    return
+  fi
+  if [[ "${command}" == "github-release-asset" ]]; then
+    fixture_require_citools_root || return
+    fixture_require_github_token_boundary "$@" || return
+    [[ "$#" -eq 6 ]] || {
       unexpected_fixture go "$*"
       return
     }
     local release_json=""
     release_json="$(cat)"
-    jq -e --arg name "$5" --argjson id "${WORKCELL_FIXTURE_ACTIONLINT_ASSET_ID}" \
-      '[.assets[] | select(.name == $name and .id == $id)] | length == 1' \
-      <<<"${release_json}" >/dev/null || {
+    jq -e --arg name "$5" '[.assets[] | select(.name == $name and (.id | type) == "number")] | length == 1' <<<"${release_json}" >/dev/null || {
       unexpected_fixture go "invalid release metadata"
       return
     }
-    if [[ -n "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" ]]; then
-      [[ -r "${WORKCELL_GITHUB_API_TOKEN_FILE:-}" && "$(<"${WORKCELL_GITHUB_API_TOKEN_FILE}")" == "${WORKCELL_FIXTURE_GITHUB_TOKEN}" ]] || {
-        unexpected_fixture go "invalid GitHub token file"
-        return
-      }
-    elif [[ -n "${WORKCELL_GITHUB_API_TOKEN_FILE:-}" ]]; then
-      unexpected_fixture go "unexpected GitHub token file"
-      return
-    fi
     printf '%s\n' "${command}" >>"${WORKCELL_FIXTURE_CITOOLS_LOG}"
-    printf '%s  actionlint_%s_linux_amd64.tar.gz\n' "${WORKCELL_FIXTURE_ACTIONLINT_SHA}" "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}"
+    case "$4:$5:$6" in
+      rhysd/actionlint:actionlint_"${WORKCELL_FIXTURE_ACTIONLINT_VERSION}"_checksums.txt:checksum)
+        printf '%s  actionlint_%s_linux_amd64.tar.gz\n' "${WORKCELL_FIXTURE_ACTIONLINT_SHA}" "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}"
+        ;;
+      hadolint/hadolint:checksums.sha256:checksum)
+        printf '%s' "${WORKCELL_FIXTURE_HADOLINT_CHECKSUMS}"
+        ;;
+      zizmorcore/zizmor:zizmor-x86_64-unknown-linux-gnu.tar.gz:archive)
+        printf 'fixture-zizmor-archive'
+        ;;
+      *)
+        unexpected_fixture go "$*"
+        ;;
+    esac
     return
   fi
   printf '%s\n' "${command}" >>"${WORKCELL_FIXTURE_CITOOLS_LOG}"

--- a/internal/testkit/update_upstream_pins_check_test.go
+++ b/internal/testkit/update_upstream_pins_check_test.go
@@ -21,7 +21,6 @@ import (
 const (
 	updaterFixtureActionlintAssetID = "424242"
 	updaterFixtureCurlVersion       = "8.7.1"
-	updaterFixtureRedirectURL       = "https://release-assets.githubusercontent.com/github-production-release-asset/12345678/01234567-89ab-cdef-0123-456789abcdef?sp=r&sv=fixture"
 )
 
 type updaterFixturePins struct {
@@ -104,19 +103,13 @@ type updaterFixtureCurlCall struct {
 }
 
 type updaterFixtureOptions struct {
-	Token                 string
-	CurlVersion           string
-	AssetID               string
-	AssetAPIResponse      string
-	AssetRedirectResponse string
+	Token       string
+	CurlVersion string
 }
 
 func defaultUpdaterFixtureOptions() updaterFixtureOptions {
 	return updaterFixtureOptions{
-		CurlVersion:           updaterFixtureCurlVersion,
-		AssetID:               updaterFixtureActionlintAssetID,
-		AssetAPIResponse:      "redirect",
-		AssetRedirectResponse: "body",
+		CurlVersion: updaterFixtureCurlVersion,
 	}
 }
 
@@ -138,6 +131,7 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 	checkRun := runUpdaterFixture(t, fixtureRoot, checkScratch, citoolsPath, goWrapperPath, pins, targetPlan, "--check")
 	assertUpdaterFixtureRun(t, checkRun, 1, updaterFixtureSummary(pins, driftedManifest, targetManifest), targetPlan.Snapshot)
 	assertUpdaterCommandCounts(t, checkRun.CIToolsLog, map[string]int{
+		"github-release-asset":       1,
 		"hadolint-manifest-checksum": 2,
 		"select-buildx-version":      1,
 		"inspect-debian-bootstrap":   1,
@@ -163,6 +157,7 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 	applyRun := runUpdaterFixture(t, fixtureRoot, applyScratch, citoolsPath, goWrapperPath, pins, targetPlan, "--apply")
 	assertUpdaterFixtureRun(t, applyRun, 0, updaterFixtureSummary(pins, driftedManifest, targetManifest), targetPlan.Snapshot)
 	assertUpdaterCommandCounts(t, applyRun.CIToolsLog, map[string]int{
+		"github-release-asset":       1,
 		"hadolint-manifest-checksum": 2,
 		"select-buildx-version":      1,
 		"inspect-debian-bootstrap":   1,
@@ -198,6 +193,7 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 	cleanRun := runUpdaterFixture(t, fixtureRoot, cleanScratch, citoolsPath, goWrapperPath, pins, targetPlan, "--check")
 	assertUpdaterFixtureRun(t, cleanRun, 0, updaterFixtureSummary(pins, targetManifest, targetManifest), targetPlan.Snapshot)
 	assertUpdaterCommandCounts(t, cleanRun.CIToolsLog, map[string]int{
+		"github-release-asset":       1,
 		"hadolint-manifest-checksum": 2,
 		"select-buildx-version":      1,
 		"inspect-debian-bootstrap":   1,
@@ -211,7 +207,7 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 	}
 }
 
-func TestUpdateUpstreamPinsCredentialedRequestsKeepTokensOffArgvAndRedirects(t *testing.T) {
+func TestUpdateUpstreamPinsCredentialedRequestsKeepTokensOffArgv(t *testing.T) {
 	t.Parallel()
 
 	pins := readUpdaterFixturePins(t)
@@ -229,6 +225,7 @@ func TestUpdateUpstreamPinsCredentialedRequestsKeepTokensOffArgvAndRedirects(t *
 	run := runUpdaterFixtureWithOptions(t, fixtureRoot, t.TempDir(), citoolsPath, goWrapperPath, pins, targetPlan, "--check", options)
 	assertUpdaterFixtureRun(t, run, 1, updaterFixtureSummary(pins, driftedManifest, targetManifest), targetPlan.Snapshot)
 	assertCredentialedUpdaterCurlCalls(t, run.CurlCalls, token)
+	assertUpdaterCommandCounts(t, run.CIToolsLog, map[string]int{"github-release-asset": 1})
 }
 
 func TestUpdateUpstreamPinsRequiresBoundedCurl(t *testing.T) {
@@ -271,107 +268,6 @@ func TestUpdateUpstreamPinsRequiresBoundedCurl(t *testing.T) {
 	}
 }
 
-func TestUpdateUpstreamPinsConstrainsReleaseAssetRedirects(t *testing.T) {
-	t.Parallel()
-
-	pins := readUpdaterFixturePins(t)
-	targetPlan := updaterTargetDebianPlan()
-	targetManifest := updaterManifestFromPlan(targetPlan)
-	driftedManifest := updaterDriftedManifest(t, targetPlan.Snapshot)
-	toolsRoot := t.TempDir()
-	citoolsPath := buildUpdaterFixtureCITools(t, toolsRoot)
-	goWrapperPath := writeUpdaterFixtureGoWrapper(t, toolsRoot)
-	fixtureRoot := writeUpdaterFixture(t, driftedManifest, 0o640)
-
-	for _, tc := range []struct {
-		name             string
-		assetID          string
-		apiResponse      string
-		redirectResponse string
-		wantMessage      string
-		wantRedirects    int
-	}{
-		{name: "direct-body", apiResponse: "direct", wantMessage: updaterFixtureSummary(pins, driftedManifest, targetManifest)},
-		{name: "wrong-status", apiResponse: "status-301", wantMessage: "Unexpected GitHub release asset response 301"},
-		{name: "missing-location", apiResponse: "missing-location", wantMessage: "must include one Location header"},
-		{name: "duplicate-location", apiResponse: "duplicate-location", wantMessage: "must include one Location header"},
-		{name: "hostile-location", apiResponse: "hostile-location", wantMessage: "outside the allowed endpoint"},
-		{name: "second-hop", apiResponse: "redirect", redirectResponse: "redirect", wantMessage: "Unexpected GitHub release asset redirect response 302", wantRedirects: 1},
-		{name: "invalid-asset-id", assetID: `"invalid"`, apiResponse: "redirect", wantMessage: "Unable to resolve a numeric release asset ID"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			options := defaultUpdaterFixtureOptions()
-			options.Token = "fixture-github-token"
-			if tc.assetID != "" {
-				options.AssetID = tc.assetID
-			}
-			if tc.apiResponse != "" {
-				options.AssetAPIResponse = tc.apiResponse
-			}
-			if tc.redirectResponse != "" {
-				options.AssetRedirectResponse = tc.redirectResponse
-			}
-			run := runUpdaterFixtureWithOptions(t, fixtureRoot, t.TempDir(), citoolsPath, goWrapperPath, pins, targetPlan, "--check", options)
-			if run.Code != 1 {
-				t.Fatalf("update-upstream-pins exit code = %d, want 1\n%s", run.Code, run.Output)
-			}
-			if !strings.Contains(run.Output, tc.wantMessage) {
-				t.Fatalf("update-upstream-pins output = %q, want text %q", run.Output, tc.wantMessage)
-			}
-			if got := updaterFixtureCurlURLCount(run.CurlCalls, updaterFixtureRedirectURL); got != tc.wantRedirects {
-				t.Fatalf("release asset redirect calls = %d, want %d; calls=%#v", got, tc.wantRedirects, run.CurlCalls)
-			}
-			if updaterFixtureCurlURLCount(run.CurlCalls, "https://attacker.invalid/actionlint-checksums") != 0 {
-				t.Fatalf("hostile release metadata URL was requested: %#v", run.CurlCalls)
-			}
-		})
-	}
-}
-
-func TestGitHubReleaseAssetURLValidators(t *testing.T) {
-	t.Parallel()
-
-	scriptPath := filepath.Join(repoRoot(t), "scripts", "update-upstream-pins.sh")
-	content, err := os.ReadFile(scriptPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	validators := extractShellFunction(t, string(content), "valid_github_release_asset_api_url") + "\n" +
-		extractShellFunction(t, string(content), "valid_github_release_asset_redirect_url") + "\n"
-
-	for _, tc := range []struct {
-		name      string
-		function  string
-		url       string
-		wantValid bool
-	}{
-		{name: "api-valid", function: "valid_github_release_asset_api_url", url: "https://api.github.com/repos/rhysd/actionlint/releases/assets/424242", wantValid: true},
-		{name: "api-http", function: "valid_github_release_asset_api_url", url: "http://api.github.com/repos/rhysd/actionlint/releases/assets/424242"},
-		{name: "api-userinfo", function: "valid_github_release_asset_api_url", url: "https://api.github.com@attacker.invalid/repos/rhysd/actionlint/releases/assets/424242"},
-		{name: "api-port", function: "valid_github_release_asset_api_url", url: "https://api.github.com:443/repos/rhysd/actionlint/releases/assets/424242"},
-		{name: "api-query", function: "valid_github_release_asset_api_url", url: "https://api.github.com/repos/rhysd/actionlint/releases/assets/424242?x=1"},
-		{name: "redirect-valid", function: "valid_github_release_asset_redirect_url", url: updaterFixtureRedirectURL, wantValid: true},
-		{name: "redirect-http", function: "valid_github_release_asset_redirect_url", url: strings.Replace(updaterFixtureRedirectURL, "https://", "http://", 1)},
-		{name: "redirect-userinfo", function: "valid_github_release_asset_redirect_url", url: strings.Replace(updaterFixtureRedirectURL, "release-assets.githubusercontent.com", "release-assets.githubusercontent.com@attacker.invalid", 1)},
-		{name: "redirect-port", function: "valid_github_release_asset_redirect_url", url: strings.Replace(updaterFixtureRedirectURL, "release-assets.githubusercontent.com", "release-assets.githubusercontent.com:443", 1)},
-		{name: "redirect-host", function: "valid_github_release_asset_redirect_url", url: strings.Replace(updaterFixtureRedirectURL, "release-assets.githubusercontent.com", "objects.githubusercontent.com", 1)},
-		{name: "redirect-extra-path", function: "valid_github_release_asset_redirect_url", url: strings.Replace(updaterFixtureRedirectURL, "?sp=", "/extra?sp=", 1)},
-		{name: "redirect-no-query", function: "valid_github_release_asset_redirect_url", url: strings.Split(updaterFixtureRedirectURL, "?")[0]},
-		{name: "redirect-fragment", function: "valid_github_release_asset_redirect_url", url: updaterFixtureRedirectURL + "#fragment"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			cmd := exec.Command("/bin/bash", "-p", "-c", validators+tc.function+` "$1"`, "asset-url-validator", tc.url)
-			err := cmd.Run()
-			if tc.wantValid && err != nil {
-				t.Fatalf("%s rejected %q: %v", tc.function, tc.url, err)
-			}
-			if !tc.wantValid && err == nil {
-				t.Fatalf("%s accepted %q", tc.function, tc.url)
-			}
-		})
-	}
-}
-
 func TestUpdateUpstreamPinsApplyFailureLeavesFixtureUnchanged(t *testing.T) {
 	t.Parallel()
 
@@ -395,6 +291,7 @@ func TestUpdateUpstreamPinsApplyFailureLeavesFixtureUnchanged(t *testing.T) {
 	}
 	assertUpdaterResolutionLog(t, run.ResolutionLog, invalidPlan.Snapshot)
 	assertUpdaterCommandCounts(t, run.CIToolsLog, map[string]int{
+		"github-release-asset":       1,
 		"hadolint-manifest-checksum": 2,
 		"select-buildx-version":      1,
 		"inspect-debian-bootstrap":   1,
@@ -731,11 +628,8 @@ func runUpdaterFixtureWithOptions(t *testing.T, fixtureRoot, scratchRoot, citool
 		"TZ=UTC",
 		"WORKCELL_DEBIAN_SNAPSHOT_LOOKBACK_DAYS=0",
 		"WORKCELL_FIXTURE_ACTIONLINT_SHA=" + pins.ActionlintSHA,
-		"WORKCELL_FIXTURE_ACTIONLINT_ASSET_ID=" + options.AssetID,
+		"WORKCELL_FIXTURE_ACTIONLINT_ASSET_ID=" + updaterFixtureActionlintAssetID,
 		"WORKCELL_FIXTURE_ACTIONLINT_VERSION=" + pins.ActionlintVersion,
-		"WORKCELL_FIXTURE_ASSET_API_RESPONSE=" + options.AssetAPIResponse,
-		"WORKCELL_FIXTURE_ASSET_REDIRECT_URL=" + updaterFixtureRedirectURL,
-		"WORKCELL_FIXTURE_ASSET_REDIRECT_RESPONSE=" + options.AssetRedirectResponse,
 		"WORKCELL_FIXTURE_BUILDKIT_DIGEST=" + buildkitDigest,
 		"WORKCELL_FIXTURE_BUILDKIT_TRACK=" + buildkitTrack,
 		"WORKCELL_FIXTURE_BUILDX_VERSION=" + pins.BuildxVersion,
@@ -756,6 +650,7 @@ func runUpdaterFixtureWithOptions(t *testing.T, fixtureRoot, scratchRoot, citool
 		"WORKCELL_FIXTURE_HADOLINT_CHECKSUMS=" + pins.HadolintChecksums,
 		"WORKCELL_FIXTURE_HADOLINT_VERSION=" + pins.HadolintVersion,
 		"WORKCELL_FIXTURE_PROVIDER_LOG=" + providerLogPath,
+		"WORKCELL_FIXTURE_ROOT=" + fixtureRoot,
 		"WORKCELL_FIXTURE_QEMU_DIGEST=" + qemuDigest,
 		"WORKCELL_FIXTURE_QEMU_TAG=" + qemuTag,
 		"WORKCELL_FIXTURE_RESOLUTION_LOG=" + resolutionLogPath,
@@ -875,24 +770,11 @@ func assertUpdaterFixtureCurlVersionProbe(t *testing.T, calls []updaterFixtureCu
 	}
 }
 
-func updaterFixtureCurlURLCount(calls []updaterFixtureCurlCall, url string) int {
-	count := 0
-	for _, call := range calls {
-		if call.Kind == "curl" && call.URL == url {
-			count++
-		}
-	}
-	return count
-}
-
 func assertCredentialedUpdaterCurlCalls(t *testing.T, calls []updaterFixtureCurlCall, token string) {
 	t.Helper()
 
 	githubConfig := "header = \"Accept: application/vnd.github+json\"\nheader = \"Authorization: Bearer " + token + "\""
-	assetConfig := "header = \"Authorization: Bearer " + token + "\""
-	assetCalls := 0
-	redirectCalls := 0
-	assetURL := "https://api.github.com/repos/rhysd/actionlint/releases/assets/" + updaterFixtureActionlintAssetID
+	githubCalls := 0
 	for _, call := range calls {
 		if call.Kind != "curl" {
 			continue
@@ -900,25 +782,15 @@ func assertCredentialedUpdaterCurlCalls(t *testing.T, calls []updaterFixtureCurl
 		if strings.Contains(call.Args, token) || strings.Contains(call.Args, "Authorization:") || strings.Contains(call.Args, "--oauth2-bearer") {
 			t.Fatalf("credential leaked through curl argv: %#v", call)
 		}
-		switch {
-		case call.URL == assetURL:
-			assetCalls++
-			if call.Config != assetConfig || !strings.Contains(call.Args, "--config -") || strings.Contains(call.Args, "-fsSL") {
-				t.Fatalf("release asset curl capture = %#v, want config %q through stdin without redirects", call, assetConfig)
-			}
-		case call.URL == updaterFixtureRedirectURL:
-			redirectCalls++
-			if call.Config != "" || strings.Contains(call.Args, "--config") || strings.Contains(call.Args, "-fsSL") {
-				t.Fatalf("release asset redirect curl capture = %#v, want one uncredentialed request", call)
-			}
-		case strings.HasPrefix(call.URL, "https://api.github.com/"):
+		if strings.HasPrefix(call.URL, "https://api.github.com/") {
+			githubCalls++
 			if call.Config != githubConfig || !strings.Contains(call.Args, "--config -") || strings.Contains(call.Args, "-fsSL") {
 				t.Fatalf("GitHub API curl capture = %#v, want config %q through stdin", call, githubConfig)
 			}
 		}
 	}
-	if assetCalls != 1 || redirectCalls != 1 {
-		t.Fatalf("credentialed curl captures release-asset=%d release-asset-redirect=%d, want 1, 1; calls=%#v", assetCalls, redirectCalls, calls)
+	if githubCalls == 0 {
+		t.Fatalf("credentialed updater made no GitHub API calls: %#v", calls)
 	}
 }
 
@@ -963,7 +835,7 @@ func assertUpdaterCommandCounts(t *testing.T, commands []string, expected map[st
 	}
 	for command := range counts {
 		switch command {
-		case "extract-dockerfile-arg", "hadolint-manifest-checksum", "select-buildx-version", "inspect-debian-bootstrap", "apply-debian-bootstrap", "check-pinned-inputs":
+		case "extract-dockerfile-arg", "github-release-asset", "hadolint-manifest-checksum", "select-buildx-version", "inspect-debian-bootstrap", "apply-debian-bootstrap", "check-pinned-inputs":
 		default:
 			t.Fatalf("unexpected real workcell-citools command %q; log=%q", command, commands)
 		}
@@ -1310,34 +1182,6 @@ record_fixture_http_request() {
   printf '%s\t%s\t%s\t%s\n' "$1" "$2" "${escaped_config}" "$4" >>"${WORKCELL_FIXTURE_CURL_LOG}"
 }
 
-expect_fixture_authenticated_asset_argv() {
-  local url="$1"
-  shift
-  if [[ "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" != "" ]]; then
-    if [[ "$#" -ne 21 || "$1" != "-q" || "$2" != "-fsS" || "$3" != "--max-time" || "$4" != "60" || "$5" != "--connect-timeout" || "$6" != "15" || "$7" != "--max-filesize" || "$8" != "65536" || "$9" != "--proto" || "${10}" != "=https" || "${11}" != "-D" || -z "${12}" || "${13}" != "-o" || -z "${14}" || "${15}" != "-w" || "${16}" != "%{http_code}" || "${17}" != "-H" || "${18}" != "Accept: application/octet-stream" || "${19}" != "--config" || "${20}" != "-" || "${21}" != "${url}" ]]; then
-      unexpected_fixture curl "${url}: argv=$*"
-      return
-    fi
-    printf '%s\n%s\n' "${12}" "${14}"
-    return
-  fi
-  if [[ "$#" -ne 19 || "$1" != "-q" || "$2" != "-fsS" || "$3" != "--max-time" || "$4" != "60" || "$5" != "--connect-timeout" || "$6" != "15" || "$7" != "--max-filesize" || "$8" != "65536" || "$9" != "--proto" || "${10}" != "=https" || "${11}" != "-D" || -z "${12}" || "${13}" != "-o" || -z "${14}" || "${15}" != "-w" || "${16}" != "%{http_code}" || "${17}" != "-H" || "${18}" != "Accept: application/octet-stream" || "${19}" != "${url}" ]]; then
-    unexpected_fixture curl "${url}: argv=$*"
-    return
-  fi
-  printf '%s\n%s\n' "${12}" "${14}"
-}
-
-expect_fixture_asset_redirect_argv() {
-  local url="$1"
-  shift
-  if [[ "$#" -ne 17 || "$1" != "-q" || "$2" != "-fsS" || "$3" != "--max-time" || "$4" != "60" || "$5" != "--connect-timeout" || "$6" != "15" || "$7" != "--max-filesize" || "$8" != "65536" || "$9" != "--proto" || "${10}" != "=https" || "${11}" != "-D" || -z "${12}" || "${13}" != "-o" || -z "${14}" || "${15}" != "-w" || "${16}" != "%{http_code}" || "${17}" != "${url}" ]]; then
-    unexpected_fixture curl "${url}: argv=$*"
-    return
-  fi
-  printf '%s\n%s\n' "${12}" "${14}"
-}
-
 curl() {
   if [[ "$#" -eq 0 ]]; then
     unexpected_fixture curl '<missing-argv>'
@@ -1442,84 +1286,6 @@ header = \"Authorization: Bearer ${WORKCELL_FIXTURE_GITHUB_TOKEN}\""
       printf '{"tag_name":"v%s","assets":[{"id":%s,"name":"actionlint_%s_checksums.txt","url":"https://attacker.invalid/actionlint-checksums"}]}\n' \
         "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}" "${WORKCELL_FIXTURE_ACTIONLINT_ASSET_ID}" "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}"
       ;;
-    https://api.github.com/repos/rhysd/actionlint/releases/assets/*)
-      if [[ "${url}" != "https://api.github.com/repos/rhysd/actionlint/releases/assets/${WORKCELL_FIXTURE_ACTIONLINT_ASSET_ID}" ]]; then
-        unexpected_fixture curl "${url}: unexpected release asset ID"
-        return
-      fi
-      local asset_paths
-      asset_paths="$(expect_fixture_authenticated_asset_argv "${url}" "$@")" || return
-      if [[ "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" != "" && "${fixture_curl_config}" != "header = \"Authorization: Bearer ${WORKCELL_FIXTURE_GITHUB_TOKEN}\"" ]]; then
-        unexpected_fixture curl "${url}: release asset credential config=${fixture_curl_config}"
-        return
-      fi
-      if [[ "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" == "" && "${fixture_curl_config}" != "" ]]; then
-        unexpected_fixture curl "${url}: unexpected release asset credential config=${fixture_curl_config}"
-        return
-      fi
-      local headers_file="${asset_paths%%$'\n'*}"
-      local body_file="${asset_paths#*$'\n'}"
-      case "${WORKCELL_FIXTURE_ASSET_API_RESPONSE}" in
-        direct)
-          : >"${headers_file}"
-          printf '%s  actionlint_%s_linux_amd64.tar.gz\n' "${WORKCELL_FIXTURE_ACTIONLINT_SHA}" "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}" >"${body_file}"
-          printf '200'
-          ;;
-        redirect)
-          printf 'Location: %s\r\n' "${WORKCELL_FIXTURE_ASSET_REDIRECT_URL}" >"${headers_file}"
-          : >"${body_file}"
-          printf '302'
-          ;;
-        status-301)
-          printf 'Location: %s\r\n' "${WORKCELL_FIXTURE_ASSET_REDIRECT_URL}" >"${headers_file}"
-          : >"${body_file}"
-          printf '301'
-          ;;
-        missing-location)
-          : >"${headers_file}"
-          : >"${body_file}"
-          printf '302'
-          ;;
-        duplicate-location)
-          printf 'Location: %s\r\nLocation: %s\r\n' "${WORKCELL_FIXTURE_ASSET_REDIRECT_URL}" "${WORKCELL_FIXTURE_ASSET_REDIRECT_URL}" >"${headers_file}"
-          : >"${body_file}"
-          printf '302'
-          ;;
-        hostile-location)
-          printf 'Location: https://attacker.invalid/actionlint-checksums\r\n' >"${headers_file}"
-          : >"${body_file}"
-          printf '302'
-          ;;
-        *)
-          unexpected_fixture curl "${url}: asset API response=${WORKCELL_FIXTURE_ASSET_API_RESPONSE}"
-          ;;
-      esac
-      ;;
-    "${WORKCELL_FIXTURE_ASSET_REDIRECT_URL:-https://release-assets.githubusercontent.com/github-production-release-asset/12345678/01234567-89ab-cdef-0123-456789abcdef?sp=r&sv=fixture}")
-      local redirect_paths
-      redirect_paths="$(expect_fixture_asset_redirect_argv "${url}" "$@")" || return
-      if [[ "${fixture_curl_config}" != "" ]]; then
-        unexpected_fixture curl "${url}: redirect retained credential config=${fixture_curl_config}"
-        return
-      fi
-      local redirect_headers_file="${redirect_paths%%$'\n'*}"
-      local redirect_body_file="${redirect_paths#*$'\n'}"
-      case "${WORKCELL_FIXTURE_ASSET_REDIRECT_RESPONSE}" in
-        body)
-          : >"${redirect_headers_file}"
-          printf '%s  actionlint_%s_linux_amd64.tar.gz\n' "${WORKCELL_FIXTURE_ACTIONLINT_SHA}" "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}" >"${redirect_body_file}"
-          printf '200'
-          ;;
-        redirect)
-          printf 'Location: %s\r\n' "${WORKCELL_FIXTURE_ASSET_REDIRECT_URL}" >"${redirect_headers_file}"
-          : >"${redirect_body_file}"
-          printf '302'
-          ;;
-        *)
-          unexpected_fixture curl "${url}: asset redirect response=${WORKCELL_FIXTURE_ASSET_REDIRECT_RESPONSE}"
-          ;;
-      esac
-      ;;
     'https://api.github.com/repos/zizmorcore/zizmor/releases/latest')
       expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 -H 'Accept: application/vnd.github+json' "${url}" || return
       printf '{"tag_name":"v%s","assets":[{"name":"zizmor-x86_64-unknown-linux-gnu.tar.gz","browser_download_url":"https://fixture.invalid/zizmor.tar.gz"}]}\n' "${WORKCELL_FIXTURE_ZIZMOR_VERSION}"
@@ -1581,6 +1347,36 @@ go() {
     }
     printf 'resolve %s\n' "$4" >>"${WORKCELL_FIXTURE_RESOLUTION_LOG}"
     printf '%s\n' "${WORKCELL_FIXTURE_DEBIAN_PLAN}"
+    return
+  fi
+  if [[ "${command}" == "github-release-asset" ]]; then
+    [[ "${PWD}" == "${WORKCELL_FIXTURE_ROOT}" ]] || {
+      unexpected_fixture go "github-release-asset cwd=${PWD}"
+      return
+    }
+    [[ "$#" -eq 5 && "$4" == "rhysd/actionlint" && "$5" == "actionlint_${WORKCELL_FIXTURE_ACTIONLINT_VERSION}_checksums.txt" ]] || {
+      unexpected_fixture go "$*"
+      return
+    }
+    local release_json=""
+    release_json="$(cat)"
+    jq -e --arg name "$5" --argjson id "${WORKCELL_FIXTURE_ACTIONLINT_ASSET_ID}" \
+      '[.assets[] | select(.name == $name and .id == $id)] | length == 1' \
+      <<<"${release_json}" >/dev/null || {
+      unexpected_fixture go "invalid release metadata"
+      return
+    }
+    if [[ -n "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" ]]; then
+      [[ -r "${WORKCELL_GITHUB_API_TOKEN_FILE:-}" && "$(<"${WORKCELL_GITHUB_API_TOKEN_FILE}")" == "${WORKCELL_FIXTURE_GITHUB_TOKEN}" ]] || {
+        unexpected_fixture go "invalid GitHub token file"
+        return
+      }
+    elif [[ -n "${WORKCELL_GITHUB_API_TOKEN_FILE:-}" ]]; then
+      unexpected_fixture go "unexpected GitHub token file"
+      return
+    fi
+    printf '%s\n' "${command}" >>"${WORKCELL_FIXTURE_CITOOLS_LOG}"
+    printf '%s  actionlint_%s_linux_amd64.tar.gz\n' "${WORKCELL_FIXTURE_ACTIONLINT_SHA}" "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}"
     return
   fi
   printf '%s\n' "${command}" >>"${WORKCELL_FIXTURE_CITOOLS_LOG}"

--- a/internal/testkit/update_upstream_pins_check_test.go
+++ b/internal/testkit/update_upstream_pins_check_test.go
@@ -18,6 +18,12 @@ import (
 	"time"
 )
 
+const (
+	updaterFixtureActionlintAssetID = "424242"
+	updaterFixtureCurlVersion       = "8.7.1"
+	updaterFixtureRedirectURL       = "https://release-assets.githubusercontent.com/github-production-release-asset/12345678/01234567-89ab-cdef-0123-456789abcdef?sp=r&sv=fixture"
+)
+
 type updaterFixturePins struct {
 	RuntimeBase                  string
 	ValidatorBase                string
@@ -87,6 +93,31 @@ type updaterFixtureRun struct {
 	ResolutionLog string
 	CIToolsLog    []string
 	ProviderLog   []string
+	CurlCalls     []updaterFixtureCurlCall
+}
+
+type updaterFixtureCurlCall struct {
+	Kind   string
+	URL    string
+	Config string
+	Args   string
+}
+
+type updaterFixtureOptions struct {
+	Token                 string
+	CurlVersion           string
+	AssetID               string
+	AssetAPIResponse      string
+	AssetRedirectResponse string
+}
+
+func defaultUpdaterFixtureOptions() updaterFixtureOptions {
+	return updaterFixtureOptions{
+		CurlVersion:           updaterFixtureCurlVersion,
+		AssetID:               updaterFixtureActionlintAssetID,
+		AssetAPIResponse:      "redirect",
+		AssetRedirectResponse: "body",
+	}
 }
 
 func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
@@ -180,6 +211,167 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 	}
 }
 
+func TestUpdateUpstreamPinsCredentialedRequestsKeepTokensOffArgvAndRedirects(t *testing.T) {
+	t.Parallel()
+
+	pins := readUpdaterFixturePins(t)
+	targetPlan := updaterTargetDebianPlan()
+	targetManifest := updaterManifestFromPlan(targetPlan)
+	driftedManifest := updaterDriftedManifest(t, targetPlan.Snapshot)
+	toolsRoot := t.TempDir()
+	citoolsPath := buildUpdaterFixtureCITools(t, toolsRoot)
+	goWrapperPath := writeUpdaterFixtureGoWrapper(t, toolsRoot)
+	fixtureRoot := writeUpdaterFixture(t, driftedManifest, 0o640)
+	const token = "fixture-github-token"
+
+	options := defaultUpdaterFixtureOptions()
+	options.Token = token
+	run := runUpdaterFixtureWithOptions(t, fixtureRoot, t.TempDir(), citoolsPath, goWrapperPath, pins, targetPlan, "--check", options)
+	assertUpdaterFixtureRun(t, run, 1, updaterFixtureSummary(pins, driftedManifest, targetManifest), targetPlan.Snapshot)
+	assertCredentialedUpdaterCurlCalls(t, run.CurlCalls, token)
+}
+
+func TestUpdateUpstreamPinsRequiresBoundedCurl(t *testing.T) {
+	t.Parallel()
+
+	pins := readUpdaterFixturePins(t)
+	targetPlan := updaterTargetDebianPlan()
+	targetManifest := updaterManifestFromPlan(targetPlan)
+	driftedManifest := updaterDriftedManifest(t, targetPlan.Snapshot)
+	toolsRoot := t.TempDir()
+	citoolsPath := buildUpdaterFixtureCITools(t, toolsRoot)
+	goWrapperPath := writeUpdaterFixtureGoWrapper(t, toolsRoot)
+	fixtureRoot := writeUpdaterFixture(t, driftedManifest, 0o640)
+
+	for _, tc := range []struct {
+		name        string
+		version     string
+		wantCode    int
+		wantMessage string
+	}{
+		{name: "minimum", version: "8.4.0", wantCode: 1, wantMessage: updaterFixtureSummary(pins, driftedManifest, targetManifest)},
+		{name: "older", version: "8.3.0", wantCode: 1, wantMessage: "curl 8.4.0 or newer is required"},
+		{name: "malformed", version: "not-a-version", wantCode: 1, wantMessage: "Unable to parse the curl version"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			options := defaultUpdaterFixtureOptions()
+			options.CurlVersion = tc.version
+			run := runUpdaterFixtureWithOptions(t, fixtureRoot, t.TempDir(), citoolsPath, goWrapperPath, pins, targetPlan, "--check", options)
+			if run.Code != tc.wantCode {
+				t.Fatalf("update-upstream-pins exit code = %d, want %d\n%s", run.Code, tc.wantCode, run.Output)
+			}
+			if !strings.Contains(run.Output, tc.wantMessage) {
+				t.Fatalf("update-upstream-pins output = %q, want text %q", run.Output, tc.wantMessage)
+			}
+			assertUpdaterFixtureCurlVersionProbe(t, run.CurlCalls, tc.version)
+			if tc.version != "8.4.0" && updaterFixtureCurlKindCount(run.CurlCalls, "curl") != 0 {
+				t.Fatalf("unsupported curl version made HTTP requests: %#v", run.CurlCalls)
+			}
+		})
+	}
+}
+
+func TestUpdateUpstreamPinsConstrainsReleaseAssetRedirects(t *testing.T) {
+	t.Parallel()
+
+	pins := readUpdaterFixturePins(t)
+	targetPlan := updaterTargetDebianPlan()
+	targetManifest := updaterManifestFromPlan(targetPlan)
+	driftedManifest := updaterDriftedManifest(t, targetPlan.Snapshot)
+	toolsRoot := t.TempDir()
+	citoolsPath := buildUpdaterFixtureCITools(t, toolsRoot)
+	goWrapperPath := writeUpdaterFixtureGoWrapper(t, toolsRoot)
+	fixtureRoot := writeUpdaterFixture(t, driftedManifest, 0o640)
+
+	for _, tc := range []struct {
+		name             string
+		assetID          string
+		apiResponse      string
+		redirectResponse string
+		wantMessage      string
+		wantRedirects    int
+	}{
+		{name: "direct-body", apiResponse: "direct", wantMessage: updaterFixtureSummary(pins, driftedManifest, targetManifest)},
+		{name: "wrong-status", apiResponse: "status-301", wantMessage: "Unexpected GitHub release asset response 301"},
+		{name: "missing-location", apiResponse: "missing-location", wantMessage: "must include one Location header"},
+		{name: "duplicate-location", apiResponse: "duplicate-location", wantMessage: "must include one Location header"},
+		{name: "hostile-location", apiResponse: "hostile-location", wantMessage: "outside the allowed endpoint"},
+		{name: "second-hop", apiResponse: "redirect", redirectResponse: "redirect", wantMessage: "Unexpected GitHub release asset redirect response 302", wantRedirects: 1},
+		{name: "invalid-asset-id", assetID: `"invalid"`, apiResponse: "redirect", wantMessage: "Unable to resolve a numeric release asset ID"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			options := defaultUpdaterFixtureOptions()
+			options.Token = "fixture-github-token"
+			if tc.assetID != "" {
+				options.AssetID = tc.assetID
+			}
+			if tc.apiResponse != "" {
+				options.AssetAPIResponse = tc.apiResponse
+			}
+			if tc.redirectResponse != "" {
+				options.AssetRedirectResponse = tc.redirectResponse
+			}
+			run := runUpdaterFixtureWithOptions(t, fixtureRoot, t.TempDir(), citoolsPath, goWrapperPath, pins, targetPlan, "--check", options)
+			if run.Code != 1 {
+				t.Fatalf("update-upstream-pins exit code = %d, want 1\n%s", run.Code, run.Output)
+			}
+			if !strings.Contains(run.Output, tc.wantMessage) {
+				t.Fatalf("update-upstream-pins output = %q, want text %q", run.Output, tc.wantMessage)
+			}
+			if got := updaterFixtureCurlURLCount(run.CurlCalls, updaterFixtureRedirectURL); got != tc.wantRedirects {
+				t.Fatalf("release asset redirect calls = %d, want %d; calls=%#v", got, tc.wantRedirects, run.CurlCalls)
+			}
+			if updaterFixtureCurlURLCount(run.CurlCalls, "https://attacker.invalid/actionlint-checksums") != 0 {
+				t.Fatalf("hostile release metadata URL was requested: %#v", run.CurlCalls)
+			}
+		})
+	}
+}
+
+func TestGitHubReleaseAssetURLValidators(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "update-upstream-pins.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validators := extractShellFunction(t, string(content), "valid_github_release_asset_api_url") + "\n" +
+		extractShellFunction(t, string(content), "valid_github_release_asset_redirect_url") + "\n"
+
+	for _, tc := range []struct {
+		name      string
+		function  string
+		url       string
+		wantValid bool
+	}{
+		{name: "api-valid", function: "valid_github_release_asset_api_url", url: "https://api.github.com/repos/rhysd/actionlint/releases/assets/424242", wantValid: true},
+		{name: "api-http", function: "valid_github_release_asset_api_url", url: "http://api.github.com/repos/rhysd/actionlint/releases/assets/424242"},
+		{name: "api-userinfo", function: "valid_github_release_asset_api_url", url: "https://api.github.com@attacker.invalid/repos/rhysd/actionlint/releases/assets/424242"},
+		{name: "api-port", function: "valid_github_release_asset_api_url", url: "https://api.github.com:443/repos/rhysd/actionlint/releases/assets/424242"},
+		{name: "api-query", function: "valid_github_release_asset_api_url", url: "https://api.github.com/repos/rhysd/actionlint/releases/assets/424242?x=1"},
+		{name: "redirect-valid", function: "valid_github_release_asset_redirect_url", url: updaterFixtureRedirectURL, wantValid: true},
+		{name: "redirect-http", function: "valid_github_release_asset_redirect_url", url: strings.Replace(updaterFixtureRedirectURL, "https://", "http://", 1)},
+		{name: "redirect-userinfo", function: "valid_github_release_asset_redirect_url", url: strings.Replace(updaterFixtureRedirectURL, "release-assets.githubusercontent.com", "release-assets.githubusercontent.com@attacker.invalid", 1)},
+		{name: "redirect-port", function: "valid_github_release_asset_redirect_url", url: strings.Replace(updaterFixtureRedirectURL, "release-assets.githubusercontent.com", "release-assets.githubusercontent.com:443", 1)},
+		{name: "redirect-host", function: "valid_github_release_asset_redirect_url", url: strings.Replace(updaterFixtureRedirectURL, "release-assets.githubusercontent.com", "objects.githubusercontent.com", 1)},
+		{name: "redirect-extra-path", function: "valid_github_release_asset_redirect_url", url: strings.Replace(updaterFixtureRedirectURL, "?sp=", "/extra?sp=", 1)},
+		{name: "redirect-no-query", function: "valid_github_release_asset_redirect_url", url: strings.Split(updaterFixtureRedirectURL, "?")[0]},
+		{name: "redirect-fragment", function: "valid_github_release_asset_redirect_url", url: updaterFixtureRedirectURL + "#fragment"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command("/bin/bash", "-p", "-c", validators+tc.function+` "$1"`, "asset-url-validator", tc.url)
+			err := cmd.Run()
+			if tc.wantValid && err != nil {
+				t.Fatalf("%s rejected %q: %v", tc.function, tc.url, err)
+			}
+			if !tc.wantValid && err == nil {
+				t.Fatalf("%s accepted %q", tc.function, tc.url)
+			}
+		})
+	}
+}
+
 func TestUpdateUpstreamPinsApplyFailureLeavesFixtureUnchanged(t *testing.T) {
 	t.Parallel()
 
@@ -226,6 +418,7 @@ func TestUpdaterFixtureCurlRejectsUnexpectedReleaseProbeArguments(t *testing.T) 
 	probePrefix := "set -euo pipefail\n" +
 		extractShellFunction(t, updaterFixtureHarness, "unexpected_fixture") + "\n" +
 		extractShellFunction(t, updaterFixtureHarness, "expect_fixture_curl_argv") + "\n" +
+		extractShellFunction(t, updaterFixtureHarness, "record_fixture_http_request") + "\n" +
 		extractShellFunction(t, updaterFixtureHarness, "curl") + "\n"
 	endpoints := []struct {
 		name string
@@ -475,6 +668,10 @@ func writeUpdaterFixtureFile(t *testing.T, root, rel, content string, mode fs.Fi
 }
 
 func runUpdaterFixture(t *testing.T, fixtureRoot, scratchRoot, citoolsPath, goWrapperPath string, pins updaterFixturePins, plan updaterFixtureDebianPlan, mode string) updaterFixtureRun {
+	return runUpdaterFixtureWithOptions(t, fixtureRoot, scratchRoot, citoolsPath, goWrapperPath, pins, plan, mode, defaultUpdaterFixtureOptions())
+}
+
+func runUpdaterFixtureWithOptions(t *testing.T, fixtureRoot, scratchRoot, citoolsPath, goWrapperPath string, pins updaterFixturePins, plan updaterFixtureDebianPlan, mode string, options updaterFixtureOptions) updaterFixtureRun {
 	t.Helper()
 
 	planJSON, err := json.Marshal(plan)
@@ -495,6 +692,18 @@ func runUpdaterFixture(t *testing.T, fixtureRoot, scratchRoot, citoolsPath, goWr
 	providerLogPath := filepath.Join(scratchRoot, "provider.log")
 	for _, logPath := range []string{resolutionLogPath, citoolsLogPath, providerLogPath} {
 		if err := os.WriteFile(logPath, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	curlLogPath := filepath.Join(t.TempDir(), "curl.log")
+	tokenFile := ""
+	if err := os.WriteFile(curlLogPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if options.Token != "" {
+		credentialDir := t.TempDir()
+		tokenFile = filepath.Join(credentialDir, "github-token")
+		if err := os.WriteFile(tokenFile, []byte(options.Token), 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -522,13 +731,20 @@ func runUpdaterFixture(t *testing.T, fixtureRoot, scratchRoot, citoolsPath, goWr
 		"TZ=UTC",
 		"WORKCELL_DEBIAN_SNAPSHOT_LOOKBACK_DAYS=0",
 		"WORKCELL_FIXTURE_ACTIONLINT_SHA=" + pins.ActionlintSHA,
+		"WORKCELL_FIXTURE_ACTIONLINT_ASSET_ID=" + options.AssetID,
 		"WORKCELL_FIXTURE_ACTIONLINT_VERSION=" + pins.ActionlintVersion,
+		"WORKCELL_FIXTURE_ASSET_API_RESPONSE=" + options.AssetAPIResponse,
+		"WORKCELL_FIXTURE_ASSET_REDIRECT_URL=" + updaterFixtureRedirectURL,
+		"WORKCELL_FIXTURE_ASSET_REDIRECT_RESPONSE=" + options.AssetRedirectResponse,
 		"WORKCELL_FIXTURE_BUILDKIT_DIGEST=" + buildkitDigest,
 		"WORKCELL_FIXTURE_BUILDKIT_TRACK=" + buildkitTrack,
 		"WORKCELL_FIXTURE_BUILDX_VERSION=" + pins.BuildxVersion,
 		"WORKCELL_FIXTURE_CITOOLS=" + citoolsPath,
 		"WORKCELL_FIXTURE_CITOOLS_LOG=" + citoolsLogPath,
 		"WORKCELL_FIXTURE_COSIGN_VERSION=" + pins.CosignVersion,
+		"WORKCELL_FIXTURE_CURL_LOG=" + curlLogPath,
+		"WORKCELL_FIXTURE_CURL_VERSION=" + options.CurlVersion,
+		"WORKCELL_FIXTURE_GITHUB_TOKEN=" + options.Token,
 		"WORKCELL_FIXTURE_REQUIRE_HOSTILE_CURLRC=1",
 		"WORKCELL_FIXTURE_DEBIAN_PLAN=" + string(planJSON),
 		"WORKCELL_FIXTURE_DEBIAN_SNAPSHOT=" + plan.Snapshot,
@@ -565,6 +781,9 @@ func runUpdaterFixture(t *testing.T, fixtureRoot, scratchRoot, citoolsPath, goWr
 		"https_proxy=http://127.0.0.1:1",
 		"no_proxy=",
 	}
+	if tokenFile != "" {
+		cmd.Env = append(cmd.Env, "WORKCELL_GITHUB_API_TOKEN_FILE="+tokenFile)
+	}
 	output, runErr := cmd.CombinedOutput()
 	curlConfig, err := os.ReadFile(filepath.Join(hostileHome, ".curlrc"))
 	if err != nil {
@@ -581,13 +800,15 @@ func runUpdaterFixture(t *testing.T, fixtureRoot, scratchRoot, citoolsPath, goWr
 		}
 		code = exitErr.ExitCode()
 	}
-	return updaterFixtureRun{
+	run := updaterFixtureRun{
 		Code:          code,
 		Output:        string(output),
 		ResolutionLog: readUpdaterFixtureLog(t, resolutionLogPath),
 		CIToolsLog:    splitUpdaterFixtureLog(readUpdaterFixtureLog(t, citoolsLogPath)),
 		ProviderLog:   splitUpdaterFixtureLog(readUpdaterFixtureLog(t, providerLogPath)),
 	}
+	run.CurlCalls = readUpdaterFixtureCurlCalls(t, curlLogPath)
+	return run
 }
 
 func readUpdaterFixtureLog(t *testing.T, path string) string {
@@ -605,6 +826,100 @@ func splitUpdaterFixtureLog(content string) []string {
 		return nil
 	}
 	return strings.Split(strings.TrimSuffix(content, "\n"), "\n")
+}
+
+func readUpdaterFixtureCurlCalls(t *testing.T, path string) []updaterFixtureCurlCall {
+	t.Helper()
+
+	var calls []updaterFixtureCurlCall
+	for _, line := range splitUpdaterFixtureLog(readUpdaterFixtureLog(t, path)) {
+		fields := strings.SplitN(line, "\t", 4)
+		if len(fields) != 4 {
+			t.Fatalf("malformed fixture curl record %q", line)
+		}
+		calls = append(calls, updaterFixtureCurlCall{
+			Kind:   fields[0],
+			URL:    fields[1],
+			Config: strings.ReplaceAll(fields[2], `\n`, "\n"),
+			Args:   fields[3],
+		})
+	}
+	return calls
+}
+
+func updaterFixtureCurlKindCount(calls []updaterFixtureCurlCall, kind string) int {
+	count := 0
+	for _, call := range calls {
+		if call.Kind == kind {
+			count++
+		}
+	}
+	return count
+}
+
+func assertUpdaterFixtureCurlVersionProbe(t *testing.T, calls []updaterFixtureCurlCall, version string) {
+	t.Helper()
+
+	count := 0
+	for _, call := range calls {
+		if call.Kind != "curl-version" {
+			continue
+		}
+		count++
+		if call.URL != version || call.Config != "" || call.Args != "-q --version" {
+			t.Fatalf("curl version probe = %#v, want version %q with -q first", call, version)
+		}
+	}
+	if count != 1 {
+		t.Fatalf("curl version probes = %d, want 1; calls=%#v", count, calls)
+	}
+}
+
+func updaterFixtureCurlURLCount(calls []updaterFixtureCurlCall, url string) int {
+	count := 0
+	for _, call := range calls {
+		if call.Kind == "curl" && call.URL == url {
+			count++
+		}
+	}
+	return count
+}
+
+func assertCredentialedUpdaterCurlCalls(t *testing.T, calls []updaterFixtureCurlCall, token string) {
+	t.Helper()
+
+	githubConfig := "header = \"Accept: application/vnd.github+json\"\nheader = \"Authorization: Bearer " + token + "\""
+	assetConfig := "header = \"Authorization: Bearer " + token + "\""
+	assetCalls := 0
+	redirectCalls := 0
+	assetURL := "https://api.github.com/repos/rhysd/actionlint/releases/assets/" + updaterFixtureActionlintAssetID
+	for _, call := range calls {
+		if call.Kind != "curl" {
+			continue
+		}
+		if strings.Contains(call.Args, token) || strings.Contains(call.Args, "Authorization:") || strings.Contains(call.Args, "--oauth2-bearer") {
+			t.Fatalf("credential leaked through curl argv: %#v", call)
+		}
+		switch {
+		case call.URL == assetURL:
+			assetCalls++
+			if call.Config != assetConfig || !strings.Contains(call.Args, "--config -") || strings.Contains(call.Args, "-fsSL") {
+				t.Fatalf("release asset curl capture = %#v, want config %q through stdin without redirects", call, assetConfig)
+			}
+		case call.URL == updaterFixtureRedirectURL:
+			redirectCalls++
+			if call.Config != "" || strings.Contains(call.Args, "--config") || strings.Contains(call.Args, "-fsSL") {
+				t.Fatalf("release asset redirect curl capture = %#v, want one uncredentialed request", call)
+			}
+		case strings.HasPrefix(call.URL, "https://api.github.com/"):
+			if call.Config != githubConfig || !strings.Contains(call.Args, "--config -") || strings.Contains(call.Args, "-fsSL") {
+				t.Fatalf("GitHub API curl capture = %#v, want config %q through stdin", call, githubConfig)
+			}
+		}
+	}
+	if assetCalls != 1 || redirectCalls != 1 {
+		t.Fatalf("credentialed curl captures release-asset=%d release-asset-redirect=%d, want 1, 1; calls=%#v", assetCalls, redirectCalls, calls)
+	}
 }
 
 func assertUpdaterFixtureRun(t *testing.T, run updaterFixtureRun, wantCode int, wantOutput, snapshot string) {
@@ -959,6 +1274,24 @@ expect_fixture_curl_argv() {
   fi
   shift
   expected=("$@")
+  if [[ "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" != "" && "${label}" == https://api.github.com/* ]]; then
+    local -a credentialed=()
+    for ((index = 0; index < ${#expected[@]}; index++)); do
+      if [[ "${expected[index]}" == "-H" && "${expected[index + 1]:-}" == "Accept: application/vnd.github+json" ]]; then
+        ((index++))
+        continue
+      fi
+      if [[ "${expected[index]}" == "-fsSL" ]]; then
+        credentialed+=(-fsS)
+        continue
+      fi
+      if [[ "${expected[index]}" == "${label}" ]]; then
+        credentialed+=(--config -)
+      fi
+      credentialed+=("${expected[index]}")
+    done
+    expected=("${credentialed[@]}")
+  fi
   if [[ "${#actual[@]}" -ne "${#expected[@]}" ]]; then
     unexpected_fixture curl "${label}: argv=${actual[*]}"
     return
@@ -969,6 +1302,40 @@ expect_fixture_curl_argv() {
       return
     fi
   done
+}
+
+record_fixture_http_request() {
+  [[ -n "${WORKCELL_FIXTURE_CURL_LOG:-}" ]] || return 0
+  local escaped_config="${3//$'\n'/\\n}"
+  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "${escaped_config}" "$4" >>"${WORKCELL_FIXTURE_CURL_LOG}"
+}
+
+expect_fixture_authenticated_asset_argv() {
+  local url="$1"
+  shift
+  if [[ "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" != "" ]]; then
+    if [[ "$#" -ne 21 || "$1" != "-q" || "$2" != "-fsS" || "$3" != "--max-time" || "$4" != "60" || "$5" != "--connect-timeout" || "$6" != "15" || "$7" != "--max-filesize" || "$8" != "65536" || "$9" != "--proto" || "${10}" != "=https" || "${11}" != "-D" || -z "${12}" || "${13}" != "-o" || -z "${14}" || "${15}" != "-w" || "${16}" != "%{http_code}" || "${17}" != "-H" || "${18}" != "Accept: application/octet-stream" || "${19}" != "--config" || "${20}" != "-" || "${21}" != "${url}" ]]; then
+      unexpected_fixture curl "${url}: argv=$*"
+      return
+    fi
+    printf '%s\n%s\n' "${12}" "${14}"
+    return
+  fi
+  if [[ "$#" -ne 19 || "$1" != "-q" || "$2" != "-fsS" || "$3" != "--max-time" || "$4" != "60" || "$5" != "--connect-timeout" || "$6" != "15" || "$7" != "--max-filesize" || "$8" != "65536" || "$9" != "--proto" || "${10}" != "=https" || "${11}" != "-D" || -z "${12}" || "${13}" != "-o" || -z "${14}" || "${15}" != "-w" || "${16}" != "%{http_code}" || "${17}" != "-H" || "${18}" != "Accept: application/octet-stream" || "${19}" != "${url}" ]]; then
+    unexpected_fixture curl "${url}: argv=$*"
+    return
+  fi
+  printf '%s\n%s\n' "${12}" "${14}"
+}
+
+expect_fixture_asset_redirect_argv() {
+  local url="$1"
+  shift
+  if [[ "$#" -ne 17 || "$1" != "-q" || "$2" != "-fsS" || "$3" != "--max-time" || "$4" != "60" || "$5" != "--connect-timeout" || "$6" != "15" || "$7" != "--max-filesize" || "$8" != "65536" || "$9" != "--proto" || "${10}" != "=https" || "${11}" != "-D" || -z "${12}" || "${13}" != "-o" || -z "${14}" || "${15}" != "-w" || "${16}" != "%{http_code}" || "${17}" != "${url}" ]]; then
+    unexpected_fixture curl "${url}: argv=$*"
+    return
+  fi
+  printf '%s\n%s\n' "${12}" "${14}"
 }
 
 curl() {
@@ -986,7 +1353,42 @@ curl() {
       return
     fi
   fi
+  if [[ "$#" -eq 2 && "$1" == "-q" && "$2" == "--version" ]]; then
+    record_fixture_http_request curl-version "${WORKCELL_FIXTURE_CURL_VERSION}" "" "$*"
+    printf 'curl %s (fixture) libcurl/%s\n' "${WORKCELL_FIXTURE_CURL_VERSION}" "${WORKCELL_FIXTURE_CURL_VERSION}"
+    return
+  fi
   local url="${!#}"
+  local fixture_curl_config=""
+  local index=0
+  for ((index = 1; index <= $#; index++)); do
+    if [[ "${!index}" != "--config" ]]; then
+      continue
+    fi
+    local next_index=$((index + 1))
+    local config_source="${!next_index}"
+    if [[ "${config_source}" != "-" ]]; then
+      unexpected_fixture curl "${url}: unexpected curl config source ${config_source:-<missing>}"
+      return
+    fi
+    fixture_curl_config="$(cat)"
+    break
+  done
+  if [[ "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" != "" && "${url}" == https://api.github.com/repos/rhysd/actionlint/releases/assets/* ]]; then
+    local expected_asset_config="header = \"Authorization: Bearer ${WORKCELL_FIXTURE_GITHUB_TOKEN}\""
+    if [[ "${fixture_curl_config}" != "${expected_asset_config}" ]]; then
+      unexpected_fixture curl "${url}: credential config=${fixture_curl_config}"
+      return
+    fi
+  elif [[ "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" != "" && "${url}" == https://api.github.com/* ]]; then
+    local expected_config="header = \"Accept: application/vnd.github+json\"
+header = \"Authorization: Bearer ${WORKCELL_FIXTURE_GITHUB_TOKEN}\""
+    if [[ "${fixture_curl_config}" != "${expected_config}" ]]; then
+      unexpected_fixture curl "${url}: credential config=${fixture_curl_config}"
+      return
+    fi
+  fi
+  record_fixture_http_request curl "${url}" "${fixture_curl_config}" "$*"
   case "${url}" in
     'https://go.dev/dl/?mode=json')
       expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 "${url}" || return
@@ -1037,12 +1439,86 @@ curl() {
       ;;
     'https://api.github.com/repos/rhysd/actionlint/releases/latest')
       expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 -H 'Accept: application/vnd.github+json' "${url}" || return
-      printf '{"tag_name":"v%s","assets":[{"name":"actionlint_%s_checksums.txt","url":"https://fixture.invalid/actionlint-checksums"}]}\n' \
-        "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}" "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}"
+      printf '{"tag_name":"v%s","assets":[{"id":%s,"name":"actionlint_%s_checksums.txt","url":"https://attacker.invalid/actionlint-checksums"}]}\n' \
+        "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}" "${WORKCELL_FIXTURE_ACTIONLINT_ASSET_ID}" "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}"
       ;;
-    'https://fixture.invalid/actionlint-checksums')
-      expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 60 --connect-timeout 15 --max-filesize 65536 -H 'Accept: application/octet-stream' "${url}" || return
-      printf '%s  actionlint_%s_linux_amd64.tar.gz\n' "${WORKCELL_FIXTURE_ACTIONLINT_SHA}" "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}"
+    https://api.github.com/repos/rhysd/actionlint/releases/assets/*)
+      if [[ "${url}" != "https://api.github.com/repos/rhysd/actionlint/releases/assets/${WORKCELL_FIXTURE_ACTIONLINT_ASSET_ID}" ]]; then
+        unexpected_fixture curl "${url}: unexpected release asset ID"
+        return
+      fi
+      local asset_paths
+      asset_paths="$(expect_fixture_authenticated_asset_argv "${url}" "$@")" || return
+      if [[ "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" != "" && "${fixture_curl_config}" != "header = \"Authorization: Bearer ${WORKCELL_FIXTURE_GITHUB_TOKEN}\"" ]]; then
+        unexpected_fixture curl "${url}: release asset credential config=${fixture_curl_config}"
+        return
+      fi
+      if [[ "${WORKCELL_FIXTURE_GITHUB_TOKEN:-}" == "" && "${fixture_curl_config}" != "" ]]; then
+        unexpected_fixture curl "${url}: unexpected release asset credential config=${fixture_curl_config}"
+        return
+      fi
+      local headers_file="${asset_paths%%$'\n'*}"
+      local body_file="${asset_paths#*$'\n'}"
+      case "${WORKCELL_FIXTURE_ASSET_API_RESPONSE}" in
+        direct)
+          : >"${headers_file}"
+          printf '%s  actionlint_%s_linux_amd64.tar.gz\n' "${WORKCELL_FIXTURE_ACTIONLINT_SHA}" "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}" >"${body_file}"
+          printf '200'
+          ;;
+        redirect)
+          printf 'Location: %s\r\n' "${WORKCELL_FIXTURE_ASSET_REDIRECT_URL}" >"${headers_file}"
+          : >"${body_file}"
+          printf '302'
+          ;;
+        status-301)
+          printf 'Location: %s\r\n' "${WORKCELL_FIXTURE_ASSET_REDIRECT_URL}" >"${headers_file}"
+          : >"${body_file}"
+          printf '301'
+          ;;
+        missing-location)
+          : >"${headers_file}"
+          : >"${body_file}"
+          printf '302'
+          ;;
+        duplicate-location)
+          printf 'Location: %s\r\nLocation: %s\r\n' "${WORKCELL_FIXTURE_ASSET_REDIRECT_URL}" "${WORKCELL_FIXTURE_ASSET_REDIRECT_URL}" >"${headers_file}"
+          : >"${body_file}"
+          printf '302'
+          ;;
+        hostile-location)
+          printf 'Location: https://attacker.invalid/actionlint-checksums\r\n' >"${headers_file}"
+          : >"${body_file}"
+          printf '302'
+          ;;
+        *)
+          unexpected_fixture curl "${url}: asset API response=${WORKCELL_FIXTURE_ASSET_API_RESPONSE}"
+          ;;
+      esac
+      ;;
+    "${WORKCELL_FIXTURE_ASSET_REDIRECT_URL:-https://release-assets.githubusercontent.com/github-production-release-asset/12345678/01234567-89ab-cdef-0123-456789abcdef?sp=r&sv=fixture}")
+      local redirect_paths
+      redirect_paths="$(expect_fixture_asset_redirect_argv "${url}" "$@")" || return
+      if [[ "${fixture_curl_config}" != "" ]]; then
+        unexpected_fixture curl "${url}: redirect retained credential config=${fixture_curl_config}"
+        return
+      fi
+      local redirect_headers_file="${redirect_paths%%$'\n'*}"
+      local redirect_body_file="${redirect_paths#*$'\n'}"
+      case "${WORKCELL_FIXTURE_ASSET_REDIRECT_RESPONSE}" in
+        body)
+          : >"${redirect_headers_file}"
+          printf '%s  actionlint_%s_linux_amd64.tar.gz\n' "${WORKCELL_FIXTURE_ACTIONLINT_SHA}" "${WORKCELL_FIXTURE_ACTIONLINT_VERSION}" >"${redirect_body_file}"
+          printf '200'
+          ;;
+        redirect)
+          printf 'Location: %s\r\n' "${WORKCELL_FIXTURE_ASSET_REDIRECT_URL}" >"${redirect_headers_file}"
+          : >"${redirect_body_file}"
+          printf '302'
+          ;;
+        *)
+          unexpected_fixture curl "${url}: asset redirect response=${WORKCELL_FIXTURE_ASSET_REDIRECT_RESPONSE}"
+          ;;
+      esac
       ;;
     'https://api.github.com/repos/zizmorcore/zizmor/releases/latest')
       expect_fixture_curl_argv "${url}" "$@" -- -q -fsSL --max-time 120 --connect-timeout 15 --max-filesize 209715200 -H 'Accept: application/vnd.github+json' "${url}" || return

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -321,14 +321,22 @@ func TestVerifyOperatorContractIgnoresAmbientHelpOverride(t *testing.T) {
 	t.Parallel()
 
 	scriptPath := filepath.Join(repoRoot(t), "scripts", "verify-operator-contract.sh")
-	content, err := os.ReadFile(scriptPath)
-	if err != nil {
+	marker := filepath.Join(t.TempDir(), "hostile-help-ran")
+	helpBin := filepath.Join(t.TempDir(), "hostile-workcell")
+	if err := os.WriteFile(helpBin, []byte("#!/bin/sh\n: >\"${WORKCELL_HELP_MARKER:?}\"\nexit 97\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	script := string(content)
 
-	if !strings.Contains(script, "env -u WORKCELL_HELP_BIN") {
-		t.Fatalf("%s must clear WORKCELL_HELP_BIN so normal validation probes the repo script", scriptPath)
+	cmd := exec.Command(scriptPath)
+	cmd.Env = canonicalBuildEnv(map[string]string{
+		"WORKCELL_HELP_BIN":    helpBin,
+		"WORKCELL_HELP_MARKER": marker,
+	})
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("verify operator contract with hostile help override: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("hostile help override executed: %v", err)
 	}
 }
 
@@ -560,19 +568,28 @@ func TestGenerateHomebrewFormulaPinsExplicitVersion(t *testing.T) {
 	t.Parallel()
 
 	scriptPath := filepath.Join(repoRoot(t), "scripts", "generate-homebrew-formula.sh")
-	content, err := os.ReadFile(scriptPath)
+	formulaPath := filepath.Join(t.TempDir(), "Formula", "workcell.rb")
+	const version = "v1.2.3"
+	const checksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	cmd := exec.Command(scriptPath, version, checksum, formulaPath, "--repository", "omkhar/workcell")
+	cmd.Env = canonicalBuildEnv(map[string]string{
+		"GITHUB_REPOSITORY": "hostile/example",
+	})
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("generate Homebrew formula: %v\n%s", err, output)
+	}
+	formula, err := os.ReadFile(formulaPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	script := string(content)
-
 	for _, want := range []string{
-		`FORMULA_VERSION="${VERSION}"`,
-		`FORMULA_VERSION="${FORMULA_VERSION#v}"`,
-		`version "${FORMULA_VERSION}"`,
+		`url "https://github.com/omkhar/workcell/releases/download/v1.2.3/workcell-v1.2.3.tar.gz"`,
+		`version "1.2.3"`,
+		`sha256 "` + checksum + `"`,
 	} {
-		if !strings.Contains(script, want) {
-			t.Fatalf("%s does not contain %q", scriptPath, want)
+		if !strings.Contains(string(formula), want) {
+			t.Fatalf("generated formula does not contain %q\n%s", want, formula)
 		}
 	}
 }
@@ -1002,85 +1019,6 @@ func TestPublishUpstreamRefreshPRRequiresCleanWorktree(t *testing.T) {
 ^F Refresh pinned upstreams (pr-parity passed; runtime/provider maintenance)`
 	if !strings.Contains(script, commitTemplateStart) {
 		t.Fatalf("%s must generate the reviewed Risk-Aware upstream-refresh commit subject", scriptPath)
-	}
-}
-
-func TestUpdateUpstreamPinsRefreshesReviewedSources(t *testing.T) {
-	t.Parallel()
-
-	scriptPath := filepath.Join(repoRoot(t), "scripts", "update-upstream-pins.sh")
-	content, err := os.ReadFile(scriptPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	script := string(content)
-
-	for _, want := range []string{
-		"--apply",
-		"--check",
-		"scripts/update-provider-pins.sh",
-		"https://go.dev/dl/?mode=json",
-		"https://static.rust-lang.org/dist/channel-rust-stable.toml",
-		"https://static.rust-lang.org/rustup/release-stable.toml",
-		"https://api.github.com/repos/docker/buildx/releases/latest",
-		"https://api.github.com/repos/sigstore/cosign/releases/latest",
-		"https://api.github.com/repos/anchore/syft/releases/latest",
-		"https://api.github.com/repos/rhysd/actionlint/releases/latest",
-		"--config -",
-		`header = "Authorization: Bearer ${token}"`,
-		"Accept: application/octet-stream",
-		"github_release_asset_api_url",
-		`-D "${headers_file}"`,
-		`curl -q -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "${location}"`,
-		"https://api.github.com/repos/hadolint/hadolint/releases/latest",
-		"hub.docker.com/v2/repositories/tonistiigi/binfmt/tags",
-		"docker buildx imagetools inspect",
-		"https://snapshot.debian.org/archive/debian/",
-		"https://snapshot.debian.org/archive/debian-security/",
-		"latest_debian_bootstrap_plan",
-		"resolve-debian-bootstrap",
-		"apply-debian-bootstrap",
-		"inspect-debian-bootstrap",
-		"runtime/container/debian-bootstrap.env",
-		"scripts/check-pinned-inputs.sh",
-		"UPSTREAM_REFRESH_WORKFLOW_PATH",
-		"current_upstream_refresh_cosign_version",
-		"upstream-refresh-cosign-version",
-	} {
-		if !strings.Contains(script, want) {
-			t.Fatalf("%s does not contain %q", scriptPath, want)
-		}
-	}
-	if strings.Contains(script, "--oauth2-bearer") {
-		t.Fatalf("%s still passes GitHub tokens through curl argv", scriptPath)
-	}
-	curlCalls := 0
-	for lineNumber, line := range strings.Split(script, "\n") {
-		index := strings.Index(line, "curl ")
-		if index < 0 {
-			continue
-		}
-		curlCalls++
-		if strings.Count(line, "curl ") != 1 || !strings.HasPrefix(line[index:], "curl -q ") {
-			t.Fatalf("%s:%d must disable HOME/.curlrc with curl's first option", scriptPath, lineNumber+1)
-		}
-	}
-	if curlCalls == 0 {
-		t.Fatalf("%s contains no curl calls", scriptPath)
-	}
-
-	for _, want := range []string{
-		`actionlint_checksums_url="$(github_release_asset_api_url "${actionlint_release_json}" "actionlint_${target_actionlint_version}_checksums.txt")"`,
-		`github_release_asset_get "${actionlint_checksums_url}" |`,
-	} {
-		if !strings.Contains(script, want) {
-			t.Fatalf("actionlint checksum path in %s does not contain %q", scriptPath, want)
-		}
-	}
-
-	githubAPIGet := extractShellFunction(t, script, "github_api_get")
-	if strings.Contains(githubAPIGet, `-H "Authorization: Bearer ${token}"`) {
-		t.Fatalf("github_api_get in %s must not follow redirects with a custom GitHub Authorization header", scriptPath)
 	}
 }
 

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -106,6 +106,31 @@ require_tool jq
 require_tool mktemp
 require_tool shasum
 
+# curl 8.4.0 began enforcing --max-filesize for responses without a known size.
+require_curl_max_filesize_support() {
+  local curl_version=""
+  local curl_version_output=""
+  local curl_major=""
+  local curl_minor=""
+
+  if ! curl_version_output="$(curl -q --version)"; then
+    echo "Unable to read the curl version" >&2
+    return 1
+  fi
+  curl_version="$(awk 'NR == 1 { print $2 }' <<<"${curl_version_output}")"
+  if [[ ! "${curl_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Unable to parse the curl version: ${curl_version:-unknown}" >&2
+    return 1
+  fi
+  IFS='.' read -r curl_major curl_minor _ <<<"${curl_version}"
+  if ((10#${curl_major} < 8 || (10#${curl_major} == 8 && 10#${curl_minor} < 4))); then
+    echo "curl 8.4.0 or newer is required for bounded upstream downloads: ${curl_version}" >&2
+    return 1
+  fi
+}
+
+require_curl_max_filesize_support
+
 # API response bodies are JSON/TOML; 200 MiB cap is well above realistic
 # upstream sizes (e.g. the Rust channel TOML is ~13 MiB and growing,
 # GitHub release lists are at most a few MiB) while still rejecting a
@@ -135,7 +160,9 @@ github_api_get() {
   local token
   token="$(github_api_token)"
   if [[ -n "${token}" ]]; then
-    curl -q -fsSL "${CURL_API_GUARDS[@]}" --config - "${url}" <<EOF
+    # Do not follow redirects while a custom Authorization header is active.
+    # curl sends custom headers to redirect targets when --location is used.
+    curl -q -fsS "${CURL_API_GUARDS[@]}" --config - "${url}" <<EOF
 header = "Accept: application/vnd.github+json"
 header = "Authorization: Bearer ${token}"
 EOF
@@ -161,33 +188,79 @@ github_release_asset_url() {
 }
 
 github_release_asset_api_url() {
-  local release_json="$1"
-  local asset_name="$2"
-  local asset_url
-  asset_url="$(jq -r --arg asset_name "${asset_name}" '.assets[] | select(.name == $asset_name) | .url' <<<"${release_json}")"
-  if [[ -z "${asset_url}" || "${asset_url}" == "null" ]]; then
-    echo "Unable to resolve release asset ${asset_name}" >&2
-    exit 1
+  local repo="$1"
+  local release_json="$2"
+  local asset_name="$3"
+  local asset_id=""
+
+  if [[ ! "${repo}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+    echo "Invalid GitHub release asset repository: ${repo}" >&2
+    return 1
   fi
-  printf '%s\n' "${asset_url}"
+  asset_id="$(jq -r --arg asset_name "${asset_name}" '.assets[] | select(.name == $asset_name) | .id | select(type == "number")' <<<"${release_json}")"
+  if [[ ! "${asset_id}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Unable to resolve a numeric release asset ID for ${asset_name}" >&2
+    return 1
+  fi
+  printf 'https://api.github.com/repos/%s/releases/assets/%s\n' "${repo}" "${asset_id}"
 }
 
-github_release_asset_get() {
+valid_github_release_asset_api_url() {
+  [[ "$1" =~ ^https://api\.github\.com/repos/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/releases/assets/[1-9][0-9]*$ ]]
+}
+
+valid_github_release_asset_redirect_url() {
+  local url="$1"
+  local remainder=""
+  local redirect_path=""
+  local redirect_query=""
+  local repository_id=""
+  local object_id=""
+
+  remainder="${url#https://release-assets.githubusercontent.com/github-production-release-asset/}"
+  if [[ "${remainder}" == "${url}" || "${remainder}" != *\?* ]]; then
+    return 1
+  fi
+  redirect_path="${remainder%%\?*}"
+  redirect_query="${remainder#*\?}"
+  IFS='/' read -r repository_id object_id <<<"${redirect_path}"
+  if [[ "${redirect_path}" != "${repository_id}/${object_id}" ]]; then
+    return 1
+  fi
+  if [[ ! "${repository_id}" =~ ^[1-9][0-9]*$ ]]; then
+    return 1
+  fi
+  if [[ ! "${object_id}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+    return 1
+  fi
+  if [[ -z "${redirect_query}" || "${redirect_query}" == *'#'* || "${redirect_query}" == *[[:space:]]* ]]; then
+    return 1
+  fi
+}
+
+github_release_asset_get() (
   local url="$1"
   local token
   local body_file=""
   local headers_file=""
   local location=""
+  local location_lines=""
+  local redirect_status=""
   local status=""
 
+  if ! valid_github_release_asset_api_url "${url}"; then
+    echo "Invalid GitHub release asset API URL: ${url}" >&2
+    exit 1
+  fi
   token="$(github_api_token)"
-  if [[ -n "${token}" ]]; then
-    headers_file="$(mktemp "${TMPDIR:-/tmp}/workcell-release-asset-headers.XXXXXX")"
-    body_file="$(mktemp "${TMPDIR:-/tmp}/workcell-release-asset-body.XXXXXX")"
-    trap 'rm -f "${headers_file}" "${body_file}"' RETURN
+  headers_file="$(mktemp "${TMPDIR:-/tmp}/workcell-release-asset-headers.XXXXXX")"
+  body_file="$(mktemp "${TMPDIR:-/tmp}/workcell-release-asset-body.XXXXXX")"
+  trap 'rm -f "${headers_file}" "${body_file}"' EXIT
 
-    status="$(
+  if [[ -n "${token}" ]]; then
+    if ! status="$(
       curl -q -fsS "${CURL_CHECKSUM_GUARDS[@]}" \
+        --proto '=https' \
         -D "${headers_file}" \
         -o "${body_file}" \
         -w '%{http_code}' \
@@ -196,30 +269,62 @@ github_release_asset_get() {
         "${url}" <<EOF
 header = "Authorization: Bearer ${token}"
 EOF
-    )"
-    case "${status}" in
-      200)
-        cat "${body_file}"
-        ;;
-      3??)
-        location="$(sed -n 's/^[Ll][Oo][Cc][Aa][Tt][Ii][Oo][Nn]:[[:space:]]*//p' "${headers_file}" | tail -n 1 | tr -d '\r')"
-        if [[ -z "${location}" ]]; then
-          echo "GitHub release asset redirect did not include a Location header: ${url}" >&2
-          exit 1
-        fi
-        curl -q -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "${location}"
-        ;;
-      *)
-        echo "Unexpected GitHub release asset response ${status}: ${url}" >&2
-        exit 1
-        ;;
-    esac
-    rm -f "${headers_file}" "${body_file}"
-    trap - RETURN
-    return 0
+    )"; then
+      echo "Unable to download the GitHub release asset: ${url}" >&2
+      exit 1
+    fi
+  elif ! status="$(
+    curl -q -fsS "${CURL_CHECKSUM_GUARDS[@]}" \
+      --proto '=https' \
+      -D "${headers_file}" \
+      -o "${body_file}" \
+      -w '%{http_code}' \
+      -H "Accept: application/octet-stream" \
+      "${url}"
+  )"; then
+    echo "Unable to download the GitHub release asset: ${url}" >&2
+    exit 1
   fi
-  curl -q -fsSL "${CURL_CHECKSUM_GUARDS[@]}" -H "Accept: application/octet-stream" "${url}"
-}
+
+  case "${status}" in
+    200) ;;
+    302)
+      location_lines="$(sed -n 's/^[Ll][Oo][Cc][Aa][Tt][Ii][Oo][Nn]:[[:space:]]*//p' "${headers_file}" | tr -d '\r')"
+      if [[ -z "${location_lines}" || "${location_lines}" == *$'\n'* ]]; then
+        echo "GitHub release asset redirect must include one Location header: ${url}" >&2
+        exit 1
+      fi
+      location="${location_lines}"
+      if ! valid_github_release_asset_redirect_url "${location}"; then
+        echo "GitHub release asset redirect is outside the allowed endpoint: ${location}" >&2
+        exit 1
+      fi
+      : >"${headers_file}"
+      : >"${body_file}"
+      if ! redirect_status="$(
+        curl -q -fsS "${CURL_CHECKSUM_GUARDS[@]}" \
+          --proto '=https' \
+          -D "${headers_file}" \
+          -o "${body_file}" \
+          -w '%{http_code}' \
+          "${location}"
+      )"; then
+        echo "Unable to download the GitHub release asset redirect: ${location}" >&2
+        exit 1
+      fi
+      if [[ "${redirect_status}" != "200" ]]; then
+        echo "Unexpected GitHub release asset redirect response ${redirect_status}: ${location}" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "Unexpected GitHub release asset response ${status}: ${url}" >&2
+      exit 1
+      ;;
+  esac
+
+  cat "${body_file}"
+)
 
 github_tag_commit_sha() {
   local repo="$1"
@@ -606,7 +711,7 @@ target_syft_version="$(jq -r '.tag_name' <<<"${syft_release_json}")"
 
 actionlint_release_json="$(github_api_get 'https://api.github.com/repos/rhysd/actionlint/releases/latest')"
 target_actionlint_version="$(jq -r '.tag_name | sub("^v"; "")' <<<"${actionlint_release_json}")"
-actionlint_checksums_url="$(github_release_asset_api_url "${actionlint_release_json}" "actionlint_${target_actionlint_version}_checksums.txt")"
+actionlint_checksums_url="$(github_release_asset_api_url 'rhysd/actionlint' "${actionlint_release_json}" "actionlint_${target_actionlint_version}_checksums.txt")"
 target_actionlint_sha="$(
   github_release_asset_get "${actionlint_checksums_url}" |
     awk '/actionlint_'"${target_actionlint_version}"'_linux_amd64\.tar\.gz$/ { print $1; exit }'

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -187,145 +187,6 @@ github_release_asset_url() {
   printf '%s\n' "${asset_url}"
 }
 
-github_release_asset_api_url() {
-  local repo="$1"
-  local release_json="$2"
-  local asset_name="$3"
-  local asset_id=""
-
-  if [[ ! "${repo}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
-    echo "Invalid GitHub release asset repository: ${repo}" >&2
-    return 1
-  fi
-  asset_id="$(jq -r --arg asset_name "${asset_name}" '.assets[] | select(.name == $asset_name) | .id | select(type == "number")' <<<"${release_json}")"
-  if [[ ! "${asset_id}" =~ ^[1-9][0-9]*$ ]]; then
-    echo "Unable to resolve a numeric release asset ID for ${asset_name}" >&2
-    return 1
-  fi
-  printf 'https://api.github.com/repos/%s/releases/assets/%s\n' "${repo}" "${asset_id}"
-}
-
-valid_github_release_asset_api_url() {
-  [[ "$1" =~ ^https://api\.github\.com/repos/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/releases/assets/[1-9][0-9]*$ ]]
-}
-
-valid_github_release_asset_redirect_url() {
-  local url="$1"
-  local remainder=""
-  local redirect_path=""
-  local redirect_query=""
-  local repository_id=""
-  local object_id=""
-
-  remainder="${url#https://release-assets.githubusercontent.com/github-production-release-asset/}"
-  if [[ "${remainder}" == "${url}" || "${remainder}" != *\?* ]]; then
-    return 1
-  fi
-  redirect_path="${remainder%%\?*}"
-  redirect_query="${remainder#*\?}"
-  IFS='/' read -r repository_id object_id <<<"${redirect_path}"
-  if [[ "${redirect_path}" != "${repository_id}/${object_id}" ]]; then
-    return 1
-  fi
-  if [[ ! "${repository_id}" =~ ^[1-9][0-9]*$ ]]; then
-    return 1
-  fi
-  if [[ ! "${object_id}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
-    return 1
-  fi
-  if [[ -z "${redirect_query}" || "${redirect_query}" == *'#'* || "${redirect_query}" == *[[:space:]]* ]]; then
-    return 1
-  fi
-}
-
-github_release_asset_get() (
-  local url="$1"
-  local token
-  local body_file=""
-  local headers_file=""
-  local location=""
-  local location_lines=""
-  local redirect_status=""
-  local status=""
-
-  if ! valid_github_release_asset_api_url "${url}"; then
-    echo "Invalid GitHub release asset API URL: ${url}" >&2
-    exit 1
-  fi
-  token="$(github_api_token)"
-  headers_file="$(mktemp "${TMPDIR:-/tmp}/workcell-release-asset-headers.XXXXXX")"
-  body_file="$(mktemp "${TMPDIR:-/tmp}/workcell-release-asset-body.XXXXXX")"
-  trap 'rm -f "${headers_file}" "${body_file}"' EXIT
-
-  if [[ -n "${token}" ]]; then
-    if ! status="$(
-      curl -q -fsS "${CURL_CHECKSUM_GUARDS[@]}" \
-        --proto '=https' \
-        -D "${headers_file}" \
-        -o "${body_file}" \
-        -w '%{http_code}' \
-        -H "Accept: application/octet-stream" \
-        --config - \
-        "${url}" <<EOF
-header = "Authorization: Bearer ${token}"
-EOF
-    )"; then
-      echo "Unable to download the GitHub release asset: ${url}" >&2
-      exit 1
-    fi
-  elif ! status="$(
-    curl -q -fsS "${CURL_CHECKSUM_GUARDS[@]}" \
-      --proto '=https' \
-      -D "${headers_file}" \
-      -o "${body_file}" \
-      -w '%{http_code}' \
-      -H "Accept: application/octet-stream" \
-      "${url}"
-  )"; then
-    echo "Unable to download the GitHub release asset: ${url}" >&2
-    exit 1
-  fi
-
-  case "${status}" in
-    200) ;;
-    302)
-      location_lines="$(sed -n 's/^[Ll][Oo][Cc][Aa][Tt][Ii][Oo][Nn]:[[:space:]]*//p' "${headers_file}" | tr -d '\r')"
-      if [[ -z "${location_lines}" || "${location_lines}" == *$'\n'* ]]; then
-        echo "GitHub release asset redirect must include one Location header: ${url}" >&2
-        exit 1
-      fi
-      location="${location_lines}"
-      if ! valid_github_release_asset_redirect_url "${location}"; then
-        echo "GitHub release asset redirect is outside the allowed endpoint: ${location}" >&2
-        exit 1
-      fi
-      : >"${headers_file}"
-      : >"${body_file}"
-      if ! redirect_status="$(
-        curl -q -fsS "${CURL_CHECKSUM_GUARDS[@]}" \
-          --proto '=https' \
-          -D "${headers_file}" \
-          -o "${body_file}" \
-          -w '%{http_code}' \
-          "${location}"
-      )"; then
-        echo "Unable to download the GitHub release asset redirect: ${location}" >&2
-        exit 1
-      fi
-      if [[ "${redirect_status}" != "200" ]]; then
-        echo "Unexpected GitHub release asset redirect response ${redirect_status}: ${location}" >&2
-        exit 1
-      fi
-      ;;
-    *)
-      echo "Unexpected GitHub release asset response ${status}: ${url}" >&2
-      exit 1
-      ;;
-  esac
-
-  cat "${body_file}"
-)
-
 github_tag_commit_sha() {
   local repo="$1"
   local tag="$2"
@@ -711,9 +572,11 @@ target_syft_version="$(jq -r '.tag_name' <<<"${syft_release_json}")"
 
 actionlint_release_json="$(github_api_get 'https://api.github.com/repos/rhysd/actionlint/releases/latest')"
 target_actionlint_version="$(jq -r '.tag_name | sub("^v"; "")' <<<"${actionlint_release_json}")"
-actionlint_checksums_url="$(github_release_asset_api_url 'rhysd/actionlint' "${actionlint_release_json}" "actionlint_${target_actionlint_version}_checksums.txt")"
 target_actionlint_sha="$(
-  github_release_asset_get "${actionlint_checksums_url}" |
+  cd "${ROOT_DIR}" || exit
+  printf '%s' "${actionlint_release_json}" |
+    go run ./cmd/workcell-citools github-release-asset \
+      'rhysd/actionlint' "actionlint_${target_actionlint_version}_checksums.txt" |
     awk '/actionlint_'"${target_actionlint_version}"'_linux_amd64\.tar\.gz$/ { print $1; exit }'
 )"
 

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -p
 workcell_upstream_pins_token_file_created=""
+if [[ -n "${WORKCELL_GITHUB_API_TOKEN_FILE:-}" && "${WORKCELL_GITHUB_API_TOKEN_FILE}" != /* ]]; then
+  workcell_upstream_pins_invocation_dir="$(pwd -P)" || {
+    echo "Cannot resolve the updater invocation directory." >&2
+    exit 1
+  }
+  export WORKCELL_GITHUB_API_TOKEN_FILE="${workcell_upstream_pins_invocation_dir}/${WORKCELL_GITHUB_API_TOKEN_FILE}"
+  unset workcell_upstream_pins_invocation_dir
+fi
 if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
   unset WORKCELL_UPSTREAM_PINS_TOKEN_FILE_CREATED
   if [[ -z "${WORKCELL_GITHUB_API_TOKEN_FILE:-}" ]]; then
@@ -106,85 +114,38 @@ require_tool jq
 require_tool mktemp
 require_tool shasum
 
-# curl 8.4.0 began enforcing --max-filesize for responses without a known size.
-require_curl_max_filesize_support() {
-  local curl_version=""
-  local curl_version_output=""
-  local curl_major=""
-  local curl_minor=""
-
-  if ! curl_version_output="$(curl -q --version)"; then
-    echo "Unable to read the curl version" >&2
-    return 1
-  fi
-  curl_version="$(awk 'NR == 1 { print $2 }' <<<"${curl_version_output}")"
-  if [[ ! "${curl_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Unable to parse the curl version: ${curl_version:-unknown}" >&2
-    return 1
-  fi
-  IFS='.' read -r curl_major curl_minor _ <<<"${curl_version}"
-  if ((10#${curl_major} < 8 || (10#${curl_major} == 8 && 10#${curl_minor} < 4))); then
-    echo "curl 8.4.0 or newer is required for bounded upstream downloads: ${curl_version}" >&2
-    return 1
-  fi
-}
-
-require_curl_max_filesize_support
-
-# API response bodies are JSON/TOML; 200 MiB cap is well above realistic
-# upstream sizes (e.g. the Rust channel TOML is ~13 MiB and growing,
-# GitHub release lists are at most a few MiB) while still rejecting a
-# multi-GB body from a misbehaving or compromised endpoint.
-CURL_API_GUARDS=(--max-time 120 --connect-timeout 15 --max-filesize 209715200)
+# Response-body download policy lives in workcell-citools. curl remains only
+# for bodyless Debian Release probes, which need no curl size-cap capability.
+CURL_HEAD_GUARDS=(--max-time 120 --connect-timeout 15)
 DEBIAN_SNAPSHOT_LOOKBACK_DAYS="${WORKCELL_DEBIAN_SNAPSHOT_LOOKBACK_DAYS:-60}"
 MAX_DEBIAN_SNAPSHOT_AGE_DAYS="${WORKCELL_MAX_DEBIAN_SNAPSHOT_AGE_DAYS:-60}"
 
-github_api_token() {
-  local token="${WORKCELL_GITHUB_API_TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}"
-  if [[ -z "${token}" && -n "${WORKCELL_GITHUB_API_TOKEN_FILE:-}" ]]; then
-    if [[ ! -r "${WORKCELL_GITHUB_API_TOKEN_FILE}" ]]; then
-      echo "GitHub API token file is not readable: ${WORKCELL_GITHUB_API_TOKEN_FILE}" >&2
-      exit 1
-    fi
-    token="$(<"${WORKCELL_GITHUB_API_TOKEN_FILE}")"
-  fi
-  if [[ -n "${token}" && ("${token}" == *$'\n'* || "${token}" == *$'\r'*) ]]; then
-    echo "GitHub API token must be a single line" >&2
-    exit 1
-  fi
-  printf '%s' "${token}"
+run_upstream_citools() {
+  (
+    cd "${ROOT_DIR}" || exit
+    go run ./cmd/workcell-citools "$@"
+  )
 }
 
 github_api_get() {
-  local url="$1"
-  local token
-  token="$(github_api_token)"
-  if [[ -n "${token}" ]]; then
-    # Do not follow redirects while a custom Authorization header is active.
-    # curl sends custom headers to redirect targets when --location is used.
-    curl -q -fsS "${CURL_API_GUARDS[@]}" --config - "${url}" <<EOF
-header = "Accept: application/vnd.github+json"
-header = "Authorization: Bearer ${token}"
-EOF
-    return
-  fi
-  curl -q -fsSL "${CURL_API_GUARDS[@]}" -H "Accept: application/vnd.github+json" "${url}"
+  run_upstream_citools github-api-get "$1"
 }
 
-dockerhub_api_get() {
-  curl -q -fsSL "${CURL_API_GUARDS[@]}" "$1"
+upstream_get() {
+  run_upstream_citools upstream-get "$@"
 }
 
-github_release_asset_url() {
+github_release_asset() {
   local release_json="$1"
-  local asset_name="$2"
-  local asset_url
-  asset_url="$(jq -r --arg asset_name "${asset_name}" '.assets[] | select(.name == $asset_name) | .browser_download_url' <<<"${release_json}")"
-  if [[ -z "${asset_url}" || "${asset_url}" == "null" ]]; then
-    echo "Unable to resolve release asset ${asset_name}" >&2
-    exit 1
-  fi
-  printf '%s\n' "${asset_url}"
+  local repository="$2"
+  local asset_name="$3"
+  local asset_class="$4"
+
+  (
+    cd "${ROOT_DIR}" || exit
+    printf '%s' "${release_json}" |
+      go run ./cmd/workcell-citools github-release-asset "${repository}" "${asset_name}" "${asset_class}"
+  )
 }
 
 github_tag_commit_sha() {
@@ -441,9 +402,9 @@ latest_debian_bootstrap_plan() {
   resolution_error_path="$(mktemp "${TMPDIR:-/tmp}/workcell-debian-bootstrap.XXXXXX")"
   for offset in $(seq 0 "${lookback_days}"); do
     stamp="$(date_stamp_for_offset "${offset}")"
-    if curl -q -fsSI "${CURL_API_GUARDS[@]}" "https://snapshot.debian.org/archive/debian/${stamp}/dists/trixie/Release" >/dev/null &&
-      curl -q -fsSI "${CURL_API_GUARDS[@]}" "https://snapshot.debian.org/archive/debian/${stamp}/dists/trixie-updates/Release" >/dev/null &&
-      curl -q -fsSI "${CURL_API_GUARDS[@]}" "https://snapshot.debian.org/archive/debian-security/${stamp}/dists/trixie-security/Release" >/dev/null &&
+    if curl -q -fsSI "${CURL_HEAD_GUARDS[@]}" "https://snapshot.debian.org/archive/debian/${stamp}/dists/trixie/Release" >/dev/null &&
+      curl -q -fsSI "${CURL_HEAD_GUARDS[@]}" "https://snapshot.debian.org/archive/debian/${stamp}/dists/trixie-updates/Release" >/dev/null &&
+      curl -q -fsSI "${CURL_HEAD_GUARDS[@]}" "https://snapshot.debian.org/archive/debian-security/${stamp}/dists/trixie-security/Release" >/dev/null &&
       resolution="$(resolve_debian_bootstrap_pins "${stamp}" 2>"${resolution_error_path}")"; then
       rm -f "${resolution_error_path}"
       printf '%s\n' "${resolution}"
@@ -488,7 +449,7 @@ semver_major_minor() {
 }
 
 latest_qemu_tag() {
-  dockerhub_api_get "https://hub.docker.com/v2/repositories/tonistiigi/binfmt/tags?page_size=100" |
+  upstream_get dockerhub-binfmt-tags |
     jq -r '
         [
           .results[].name
@@ -511,13 +472,13 @@ latest_qemu_tag() {
       '
 }
 
-latest_go_json="$(curl -q -fsSL "${CURL_API_GUARDS[@]}" 'https://go.dev/dl/?mode=json' | jq 'map(select(.stable == true)) | .[0]')"
+latest_go_json="$(upstream_get go-releases | jq 'map(select(.stable == true)) | .[0]')"
 target_go_toolchain="$(jq -r '.version | sub("^go"; "")' <<<"${latest_go_json}")"
 target_go_language="$(semver_patch_zero "${target_go_toolchain}")"
 target_go_sha_amd64="$(jq -r '.files[] | select(.os == "linux" and .arch == "amd64" and .kind == "archive") | .sha256' <<<"${latest_go_json}")"
 target_go_sha_arm64="$(jq -r '.files[] | select(.os == "linux" and .arch == "arm64" and .kind == "archive") | .sha256' <<<"${latest_go_json}")"
 
-rust_stable_toml="$(curl -q -fsSL "${CURL_API_GUARDS[@]}" 'https://static.rust-lang.org/dist/channel-rust-stable.toml')"
+rust_stable_toml="$(upstream_get rust-channel)"
 target_rust_version="$(
   awk -F'"' '
     /^\[pkg\.rust\]$/ {
@@ -535,22 +496,14 @@ target_rust_version="$(
   ' <<<"${rust_stable_toml}"
 )"
 target_cargo_rust_version="$(semver_major_minor "${target_rust_version}")"
-rustup_stable_toml="$(curl -q -fsSL "${CURL_API_GUARDS[@]}" 'https://static.rust-lang.org/rustup/release-stable.toml')"
+rustup_stable_toml="$(upstream_get rustup-release)"
 target_rustup_version="$(awk -F"'" '$1 == "version = " { print $2; exit }' <<<"${rustup_stable_toml}")"
-# SHA256 checksum files and small manifests are bounded so a misbehaving CDN
-# or compromised release host cannot serve a multi-GB body that OOMs the
-# maintainer's shell. Mirrors the discipline applied to the zizmor download
-# below.
-CURL_CHECKSUM_GUARDS=(--max-time 60 --connect-timeout 15 --max-filesize 65536)
-target_rustup_sha_amd64="$(curl -q -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "https://static.rust-lang.org/rustup/archive/${target_rustup_version}/x86_64-unknown-linux-gnu/rustup-init.sha256" | awk '{print $1}')"
-target_rustup_sha_arm64="$(curl -q -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "https://static.rust-lang.org/rustup/archive/${target_rustup_version}/aarch64-unknown-linux-gnu/rustup-init.sha256" | awk '{print $1}')"
+target_rustup_sha_amd64="$(upstream_get rustup-checksum "${target_rustup_version}" x86_64-unknown-linux-gnu | awk '{print $1}')"
+target_rustup_sha_arm64="$(upstream_get rustup-checksum "${target_rustup_version}" aarch64-unknown-linux-gnu | awk '{print $1}')"
 
 hadolint_release_json="$(github_api_get 'https://api.github.com/repos/hadolint/hadolint/releases/latest')"
 target_hadolint_version="$(jq -r '.tag_name' <<<"${hadolint_release_json}")"
-hadolint_checksums_url="$(github_release_asset_url "${hadolint_release_json}" 'checksums.sha256')"
-hadolint_checksums="$(
-  curl -q -fsSL "${CURL_CHECKSUM_GUARDS[@]}" "${hadolint_checksums_url}"
-)"
+hadolint_checksums="$(github_release_asset "${hadolint_release_json}" 'hadolint/hadolint' 'checksums.sha256' checksum)"
 target_hadolint_sha_amd64="$(
   cd "${ROOT_DIR}" || exit
   printf '%s' "${hadolint_checksums}" | go run ./cmd/workcell-citools hadolint-manifest-checksum 'hadolint-linux-x86_64'
@@ -573,22 +526,14 @@ target_syft_version="$(jq -r '.tag_name' <<<"${syft_release_json}")"
 actionlint_release_json="$(github_api_get 'https://api.github.com/repos/rhysd/actionlint/releases/latest')"
 target_actionlint_version="$(jq -r '.tag_name | sub("^v"; "")' <<<"${actionlint_release_json}")"
 target_actionlint_sha="$(
-  cd "${ROOT_DIR}" || exit
-  printf '%s' "${actionlint_release_json}" |
-    go run ./cmd/workcell-citools github-release-asset \
-      'rhysd/actionlint' "actionlint_${target_actionlint_version}_checksums.txt" |
+  github_release_asset "${actionlint_release_json}" 'rhysd/actionlint' "actionlint_${target_actionlint_version}_checksums.txt" checksum |
     awk '/actionlint_'"${target_actionlint_version}"'_linux_amd64\.tar\.gz$/ { print $1; exit }'
 )"
 
 zizmor_release_json="$(github_api_get 'https://api.github.com/repos/zizmorcore/zizmor/releases/latest')"
 target_zizmor_version="$(jq -r '.tag_name | sub("^v"; "")' <<<"${zizmor_release_json}")"
-target_zizmor_url="$(github_release_asset_url "${zizmor_release_json}" 'zizmor-x86_64-unknown-linux-gnu.tar.gz')"
 target_zizmor_sha="$(
-  curl -q -fsSL \
-    --max-time 60 \
-    --connect-timeout 15 \
-    --max-filesize 209715200 \
-    "${target_zizmor_url}" |
+  github_release_asset "${zizmor_release_json}" 'zizmorcore/zizmor' 'zizmor-x86_64-unknown-linux-gnu.tar.gz' archive |
     shasum -a 256 |
     awk '{ print $1 }'
 )"


### PR DESCRIPTION
## Summary\n\n- Download GitHub release assets through a bounded Go policy path.\n- Validate numeric asset identifiers and one exact release redirect.\n- Strip credentials before the release asset body request.\n- Keep curl only for bodyless Debian snapshot probes.\n- Replace brittle source inventories with behavioral and hermetic tests.\n\n## Validation\n\n- Full repository validation: 17 passed, 0 failed, 5 certification-only skips.\n- Exact-head pr-parity, including container smoke.\n- Focused Go package tests and race detection.\n- Go vet, Bash syntax, gofmt, and diff checks.\n- Six-role adversarial review reached a dry result.\n\nThe updater found normal upstream drift during live validation. This PR excludes that unrelated refresh.