### PR TITLE
Restore host certification record fields

### DIFF
--- a/docs/host-expansion-readiness.md
+++ b/docs/host-expansion-readiness.md
@@ -95,8 +95,8 @@ One promotion change must include all these items:
 
 The certification record must identify the exact matrix row and Docker Desktop
 version. It must record the Workcell commit SHA, worktree dirty state, host
-kernel, cgroup mode, Docker security features, command, UTC timestamp, and
-cleanup status.
+kernel, and cgroup mode. It must also record Docker security features, the
+command, the UTC timestamp, and cleanup status.
 
 The live certification must test the host and target that the exact matrix row
 names. It must also test the selected Docker Desktop version. The rollback must

--- a/docs/host-expansion-readiness.md
+++ b/docs/host-expansion-readiness.md
@@ -93,6 +93,11 @@ One promotion change must include all these items:
 - Complete live certification on a real operator host.
 - Update operator, support, and validation documents with the same claim.
 
+The certification record must identify the exact matrix row and Docker Desktop
+version. It must record the Workcell commit SHA, worktree dirty state, host
+kernel, cgroup mode, Docker security features, command, UTC timestamp, and
+cleanup status.
+
 The live certification must test the host and target that the exact matrix row
 names. It must also test the selected Docker Desktop version. The rollback must
 disable or remove the new path. Regression tests must protect the current


### PR DESCRIPTION
## Summary

- Restore auditable Phase 13 certification record fields.
- Bind evidence to the exact matrix row, Docker Desktop version, Workcell commit, host posture, command, timestamp, and cleanup.

## Validation

- `./scripts/ci/job-docs.sh`
- `./scripts/verify-operator-contract.sh`
- `./scripts/verify-requirements-coverage.sh`
- `./scripts/pre-merge.sh --profile pr-parity`

## Review

- Addresses the late Codex P2 on PR #574.
- Adversarial review reached dry consensus.