### PR TITLE
^D Add engineering practices baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,11 @@ the runtime boundary or explicit security guarantees in the name of convenience.
 - If validation or review exposes a recurring quality gap, fix the repo-local
   instruction, runbook, or validator in a reviewable change rather than relying
   on conversational memory.
+- Before broad engineering changes, read
+  `docs/software-engineering-practices.md`.
+- Preserve its evidence rules.
+- Measure repository health before adding a numeric quality target.
+- Use the smallest evidence-preserving review unit.
 
 ## Documentation language
 
@@ -104,10 +109,10 @@ the runtime boundary or explicit security guarantees in the name of convenience.
   conflict-free subset (`docker.sock`, `SSH_AUTH_SOCK`, `/.ssh`,
   `/.aws`, `Library/Keychains`, `.gnupg`, `.git-credentials`) lives in
   `policy/forbidden-host-paths.toml` and is enforced by
-  `scripts/verify-invariants.sh` against the dry-run docker invocation;
-  the provider-state directories above (host `~/.codex`, etc.) need a
-  host-side `-v` mount-source check that the policy file deliberately
-  omits today.
+  `scripts/verify-invariants.sh` against the dry-run Docker invocation.
+  The same verifier checks host-side mount sources for the provider-state
+  directories above. The policy file omits their conflicting in-container
+  substrings.
 - Keep `breakglass` paths explicit, narrow, and separately documented.
 - Require explicit operator acknowledgement for `breakglass` or equivalent
   higher-trust paths.

--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ options.
 | Changelog | [CHANGELOG.md](CHANGELOG.md) |
 | Security reporting | [SECURITY.md](SECURITY.md) |
 | Stability and exit-code contract | [docs/stability-contract.md](docs/stability-contract.md) |
+| Software engineering practices | [docs/software-engineering-practices.md](docs/software-engineering-practices.md) |
 | Standards watchlist | [docs/standards-watchlist.md](docs/standards-watchlist.md) |
 | Documentation language | [docs/documentation-language.md](docs/documentation-language.md) |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,6 +34,9 @@ Cross-cutting engineering, security-depth, and adoption improvements from the
 below. The [1.0 Program Record](#10-program-record) contains the historical
 release criteria and deferred work.
 
+The current engineering baseline and measurable improvement plan live in
+[Software Engineering Practices](docs/software-engineering-practices.md).
+
 ## Product Direction
 
 - Position Workcell as an auditable runtime boundary for coding agents, not as
@@ -536,6 +539,31 @@ contract and proven day-two operations.
 - **G4 (complete, S):** the cross-lens 1.0 readiness gate records fixed
   statuses, exact candidate/evidence identities, every explicit scope decision,
   and no unresolved P0/P1 findings
+
+### Track H: Engineering Health And Delivery Feedback
+
+The canonical practices, evidence safeguards, dependencies, and acceptance
+measures live in
+[Software Engineering Practices](docs/software-engineering-practices.md).
+
+- **H1 (complete, S):** classified primary-source baseline, repository assessment,
+  measurement safeguards, and ordered improvement plan
+- **H2 (next, M):** deterministic engineering-health generator and one dated
+  versioned baseline
+- **H3 (after H2, M):** durable CI distributions, review wait states, and
+  unchanged-head trigger measurement
+- **H4 (after H1, M):** SLSA v1.2 Build and Source reassessment plus read-only
+  release-output verification
+- **H5 (after H2, M):** risk-based race, mutation, and critical-package
+  coverage evidence
+- **H6 (after H2, L):** one measured, behavior-preserving complexity
+  reduction per review unit
+- **H7 (after H2, M):** shared validation inventory and objective-driven
+  benchmarks
+- **H8 (after H1, M):** locked Rust vendor-refresh workflow with offline and
+  reproducibility checks
+- **H9 (external, L):** second maintainer, trusted Apple runner, third-party
+  boundary review, and honest OpenSSF badge assessment
 
 ### Sequencing Summary
 

--- a/docs/engineering-evidence/software-engineering-practices-2026-08-11.json
+++ b/docs/engineering-evidence/software-engineering-practices-2026-08-11.json
@@ -1,0 +1,119 @@
+{
+  "schema_version": 1,
+  "record_type": "software-engineering-practices-assessment",
+  "repository": "omkhar/workcell",
+  "repository_commit": "e38f3036ff11a52aee2b04b10b854c51e4d6baf4",
+  "assessment_date": "2026-08-11",
+  "repository_inventory": {
+    "method": "tracked-file counts, exact text searches, line counts, and current repository configuration",
+    "exclusions": [
+      ".git content",
+      "untracked content",
+      "cached content",
+      "runtime/container/rust/vendor for non-vendor source conclusions"
+    ],
+    "commands": [
+      "git ls-files '*_test.go'",
+      "git ls-files 'tests/scenarios/*.sh' 'tests/scenarios/**/*.sh'",
+      "rg -n '#\\[test\\]' runtime/container/rust/src --glob '*.rs'",
+      "rg -n '^func Benchmark' --glob '*.go' .",
+      "rg -n 'go test.*-race' .github scripts policy",
+      "wc -l scripts/workcell scripts/verify-invariants.sh scripts/container-smoke.sh"
+    ],
+    "go_test_files": 147,
+    "rust_test_attributes": 30,
+    "scenario_scripts": 22,
+    "go_benchmark_functions": 0,
+    "configured_go_race_lanes_found": 0,
+    "selected_file_lines": {
+      "scripts/workcell": 9396,
+      "scripts/verify-invariants.sh": 8722,
+      "scripts/container-smoke.sh": 5227
+    },
+    "coverage_policy": {
+      "rust_launcher_minimum_percent": 90,
+      "internal_metadatautil_minimum_percent": 56,
+      "other_go_package_minimums_configured": 0
+    },
+    "mutation_policy": {
+      "expected_mutants": 14,
+      "required_score_percent": 100
+    }
+  },
+  "github_delivery_history": {
+    "collection_completed_at": "2026-08-11T10:30:30Z",
+    "window_start": "2026-07-11T10:19:10Z",
+    "window_end": "2026-08-11T10:19:10Z",
+    "window_hours": 744,
+    "method": {
+      "pull_requests": "cursor-paginated GraphQL searches for created and merged timestamps",
+      "actions": "31 exact daily REST ranges with pagination",
+      "reviews": "paginated review submissions and review threads",
+      "codex_review_triggers": "issue comments created in the window, from non-bot authors, whose trimmed body was exactly @codex review; every matching comment counted",
+      "release_runs": "paginated Actions and GitHub Release records"
+    },
+    "counts": {
+      "pull_requests_created_in_window": 106,
+      "pull_requests_merged_in_window": 102,
+      "pull_requests_closed_unmerged_in_window": 6,
+      "codex_review_triggers": 490,
+      "submitted_reviews": 470,
+      "review_threads": 305,
+      "pull_request_workflow_runs": 1433,
+      "workflow_success": 790,
+      "workflow_skipped": 539,
+      "workflow_failure": 13,
+      "workflow_cancelled": 91,
+      "workflow_later_attempts": 8
+    },
+    "durations_hours": {
+      "percentile_method": "linear interpolation",
+      "creation_to_merge_population": 102,
+      "creation_to_merge_p50": 0.91,
+      "creation_to_merge_p90": 49.46,
+      "workflow_wait_proxy_population": 101,
+      "workflow_wait_proxy_p50": 0.72,
+      "workflow_wait_proxy_p90": 51.13,
+      "workflow_wait_proxy_max": 120.73
+    },
+    "workflow_wait_proxy_definition": "pull request creation through the last completed branch-matched pull_request workflow before merge",
+    "limitations": [
+      "The workflow-wait proxy is not an individual workflow duration.",
+      "The workflow-wait proxy is not a proven critical path.",
+      "One merged pull request had no completed branch-matched pull_request workflow before merge and was excluded from the workflow-wait proxy.",
+      "Review-thread volume is not an actionable-finding count.",
+      "GitHub history does not identify production deployments.",
+      "GitHub history does not provide production service-level objectives.",
+      "The collection did not preserve raw comment bodies or contributor identities."
+    ]
+  },
+  "hosted_controls": {
+    "collection_completed_at": "2026-08-11T10:40:38Z",
+    "source": "GitHub repository ruleset API",
+    "main_rulesets": [
+      "main-integrity",
+      "main-review",
+      "main-status-checks"
+    ],
+    "required_status_checks": [
+      "Allowed PR base",
+      "Container smoke",
+      "GitHub Actions lint",
+      "GitHub Actions security analysis",
+      "Pull request shape",
+      "Reproducible build",
+      "Validate repository",
+      "Dependency review"
+    ],
+    "required_signatures": true,
+    "required_pull_request": true,
+    "required_thread_resolution": true,
+    "single_maintainer_admin_bypass": "pull_requests_only"
+  },
+  "record_limitations": [
+    "This file contains aggregate evidence, not raw GitHub API responses.",
+    "The repository snapshot will become historical after later commits.",
+    "Counts are risk indicators and do not prove quality.",
+    "This record makes no support, certification, compliance, or SLSA-level change."
+  ]
+}

--- a/docs/software-engineering-practices.md
+++ b/docs/software-engineering-practices.md
@@ -1,0 +1,352 @@
+# Software Engineering Practices
+
+Use this document as Workcell's durable engineering baseline and improvement
+plan. It maps primary sources to repository evidence and bounded work.
+It does not change product support, assurance, certification, compliance, or
+release claims.
+
+- Assessment date: 2026-08-11.
+- Repository commit: `e38f3036ff11a52aee2b04b10b854c51e4d6baf4`.
+- GitHub history window: 2026-07-11 10:19 UTC through 2026-08-11 10:19 UTC.
+- Next planned review: 2026-11-06.
+
+Engineering health means the measurable condition of development, review,
+validation, release, and maintenance work. A risk indicator identifies where
+review can help. It does not prove poor quality.
+
+## Evidence Rules
+
+- Prefer primary standards, official product documents, and official project
+  guidance.
+- Separate observed facts, reasoned inferences, proposals, and external
+  constraints.
+- Bind measurements to a commit, time window, method, exclusions, and sample
+  size.
+- Use language-aware parsers for structural metrics.
+- Omit a metric when its method is unreliable.
+- Use metrics to find constraints and verify improvements.
+- Never rank contributors, agents, or models.
+- Avoid universal line-count, complexity, coverage, velocity, or duration
+  targets.
+- Promote advisory measurements into gates only after reviewed evidence proves
+  value.
+
+## Source Baseline
+
+The baseline uses primary standards and owner-controlled guidance. A source's
+type limits how Workcell applies it.
+
+| Area | Source | Type | Durable Workcell use |
+|---|---|---|---|
+| Secure development | [NIST SSDF 1.1](https://csrc.nist.gov/pubs/sp/800/218/final) | Government framework | Integrate preparation, protection, production, and vulnerability response across the lifecycle. |
+| Trustworthy systems | [NIST SP 800-160 Rev. 1](https://csrc.nist.gov/pubs/sp/800/160/v1/r1/final) | Government engineering guidance | Trace trust objectives through requirements, design, implementation, verification, validation, and operations. |
+| Product quality | [ISO/IEC 25010:2023](https://www.iso.org/standard/78176.html) | International standard | Use relevant quality characteristics for requirements, tests, acceptance criteria, and measures. |
+| Secure defaults | [CISA Secure by Design](https://www.cisa.gov/sites/default/files/2023-10/Shifting-the-Balance-of-Cybersecurity-Risk-Principles-and-Approaches-for-Secure-by-Design-Software.pdf) | Government guidance | Keep the safe path default and place security responsibility in the product. |
+| Supply chain | [SLSA v1.2](https://slsa.dev/spec/v1.2/) and [artifact verification](https://slsa.dev/spec/v1.2/verifying-artifacts) | Approved industry specification | Assess Build and Source tracks separately. Verify artifacts against explicit identities and expectations. |
+| Workflow security | [GitHub Actions secure use](https://docs.github.com/en/actions/reference/security/secure-use) | Platform-owner guidance | Use minimum permissions, immutable action identities, and privilege separation for untrusted content. |
+| Code review | [Google Engineering Practices](https://google.github.io/eng-practices/review/reviewer/standard.html) | Organization guidance | Merge small changes that clearly improve code health. Prefer technical evidence over preference. |
+| Delivery | [DORA metrics](https://dora.dev/guides/dora-metrics/) | Research-based guidance | Use application-level trends to improve throughput and stability. Do not turn metrics into targets. |
+| Operations | [Google SRE monitoring](https://sre.google/sre-book/monitoring-distributed-systems/) | Organization guidance | Prefer simple signals that expose user-visible symptoms and support diagnosis. |
+| Go | [Go documentation](https://go.dev/doc/comment) and [table-driven tests](https://go.dev/wiki/TableDrivenTests) | Language-project guidance | Use official conventions, clear APIs, diagnostic failures, and maintainable tests. |
+| Rust | [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) and [Cargo CI guidance](https://doc.rust-lang.org/cargo/guide/continuous-integration.html) | Language-project guidance | Use idiomatic APIs and balance deterministic coverage with CI cost. |
+| Open source | [OpenSSF Best Practices Badge](https://openssf.org/projects/best-practices-badge/) | Voluntary program | Use the checklist and Scorecard as evidence. Do not treat either as boundary proof. |
+
+Track selected moving source versions in the
+[Standards Watchlist](standards-watchlist.md). A source update does not change a
+Workcell claim until a reviewed repository change maps the effect.
+
+## Assessment Method And Evidence
+
+The [versioned aggregate record](engineering-evidence/software-engineering-practices-2026-08-11.json)
+contains the methods, exclusions, sample sizes, definitions, and collected
+counts. It contains no raw comment body or contributor identity.
+
+Repository facts came from tracked files at the recorded commit. The audit used
+exact searches, policy reads, validators, and line counts. It excluded Git
+metadata, caches, and untracked content.
+
+Hosted facts came from paginated GitHub APIs. The audit used separate timestamp
+queries for created and merged pull requests. It split Actions history into 31
+daily windows.
+
+The aggregate record does not preserve raw GitHub responses. Later repository
+or hosted changes can make its values historical. H2 and H3 define the durable
+collection work.
+
+## Practice Baseline
+
+### Change Design And Review
+
+- Preserve the runtime boundary before optimizing convenience or speed.
+- Solve the demonstrated problem with the smallest coherent change.
+- Keep unrelated formatting, refactoring, behavior, and support changes in
+  separate review units.
+- Review design, functionality, complexity, concurrency, tests, documentation,
+  and system context.
+- Accept a change when it clearly improves code health and all required gates
+  pass.
+- Record a concrete blocker when required evidence is unavailable.
+
+### Verification
+
+- Select tests from changed risks and contracts.
+- Require tests to fail under the defect they claim to detect.
+- Use negative, property, mutation, race, integration, and live evidence where
+  each method adds value.
+- Use coverage as a map of exercised code, not as proof of test quality.
+- Keep deterministic regression checks on pull requests.
+- Run expensive discovery checks on scheduled, approved, main, or release
+  lanes.
+- Preserve live certification for supported workflow and boundary changes.
+
+### Security And Supply Chain
+
+- Keep secure defaults, least privilege, explicit exceptions, and fail-closed
+  behavior.
+- Keep security controls outside provider prompts and configuration.
+- Pin dependencies and workflow actions through reviewed repository policy.
+- Verify published artifacts against expected source, builder, subject, and
+  parameters.
+- Scope every SLSA, provenance, certification, and compliance statement to its
+  exact evidence.
+- Treat signed commits and automated review as controls, not independent human
+  approval.
+
+### Delivery And Operations
+
+- Keep the pull-request critical path deterministic and diagnostic.
+- Measure distributions and outcomes before setting thresholds.
+- Separate queue time, execution time, repair time, and review wait.
+- Show sample size, exclusions, incomplete data, and collection failures.
+- Use repository trends to improve the system.
+- Define a deployment before reporting DORA measures.
+- Prefer actionable issue records over noisy alerts.
+
+### Maintainability
+
+- Use size, churn, boundary criticality, defect history, and review burden
+  together.
+- Extract one behavior-preserving seam in each refactoring review unit.
+- Add characterization or differential evidence before moving boundary logic.
+- Keep shell as detection, scrubbing, dispatch, and launch glue.
+- Put new policy, state, and orchestration logic in Go by default.
+- Keep Rust changes within the syscall-interception boundary.
+- Remove duplicate validation inventories only after tests prove profile parity.
+
+## Current Assessment
+
+| Area | Observed facts | Reasoned assessment |
+|---|---|---|
+| Architecture | [System Design](workcell-system-design.md) documents the host launcher, dedicated VM boundary, hardened container, thin adapters, and host-owned records. | Strong and explicit. |
+| Contract traceability | The [operator contract](../policy/operator-contract.toml), [requirements](../policy/requirements.toml), documents, scenarios, and evidence have repository validators. | Strong and unusually complete. |
+| Verification | At assessment, non-vendored sources had 147 Go test files, 30 Rust test attributes, and 22 scenario scripts. [Validation](validation-scenarios.md) includes fuzz, mutation, smoke, and certification paths. | Broad, but assurance measurement is uneven. |
+| Supply chain | [Workflows](github-workflows.md) use full action SHAs and minimum permissions. They run dependency, CodeQL, Scorecard, reproducibility, signing, SBOM, and attestation controls. | Strong, with documented residual risks. |
+| Delivery feedback | [Weekly reports](ci-efficiency-and-reliability.md) show workflow totals, averages, failures, reruns, and tracked flaky issues. | Useful foundation, but distributions and durable artifacts are missing. |
+| Maintainability | The aggregate record contains exact line counts for three boundary-related shell files. | Concentrated risk signals, not automatic refactoring orders. |
+| Governance | The aggregate record identifies active signed-commit, pull-request, thread-resolution, and status-check rulesets. | Strong hosted controls. Single-maintainer operation limits independent review. |
+| Release evidence | [Provenance](provenance.md) records signatures, checksums, SBOMs, attestations, reproducibility, and the output-verification gap. | Strong production controls with a known verification gap. |
+
+Release coverage enforces 90 percent for the Rust launcher and 56 percent for
+`internal/metadatautil`. It sets no floor for other Go packages. The mutation
+policy requires all 14 reviewed mutants to be killed.
+
+The repository has no Go benchmark function or race-detector lane. These
+absences are planning signals. They do not prove a user-visible performance or
+concurrency defect.
+
+## Delivery History Snapshot
+
+The audit used cursor-paginated pull-request data. It split Actions collection
+into 31 paginated daily windows to avoid GitHub's 1,000-result limit.
+
+Merge-time statistics use the 102 pull requests merged in the window.
+Percentiles use linear interpolation.
+
+- GitHub recorded 106 created pull requests and 102 merges.
+- Median creation-to-merge time was 0.91 hours.
+- The p90 creation-to-merge time was 49.46 hours.
+- GitHub recorded 490 Codex triggers, 470 submitted reviews, and 305 review
+  threads.
+- GitHub recorded 1,433 pull-request workflow runs.
+- Those runs included 790 successes, 539 skips, 13 failures, and 91
+  cancellations.
+- Eight workflow runs used a later attempt.
+- The p90 workflow-wait proxy was 51.13 hours.
+
+The workflow-wait proxy measures PR creation through the last completed
+branch-matched workflow before merge. It is not an individual workflow duration
+or a proven critical path.
+
+GitHub history does not identify production deployments or service-level
+objectives. Therefore, Workcell cannot report the five current DORA measures
+from this data. Release workflow results remain release evidence, not production
+service evidence.
+
+## Improvement Plan
+
+### H1: Durable Baseline
+
+Status: implemented by this document and its repository pointers.
+
+Completion evidence:
+
+- The source baseline classifies each primary or owner-controlled source.
+- The versioned aggregate record preserves the dated assessment evidence.
+- The current assessment separates facts, inferences, plans, and constraints.
+- `AGENTS.md` points broad engineering work to this document.
+- The Roadmap records the ordered work.
+
+### H2: Deterministic Engineering-Health Evidence
+
+Dependency: H1.
+
+Build a tested generator for one dated, versioned repository baseline.
+
+Acceptance evidence:
+
+- Record the source commit, schema, method, exclusions, and collection time.
+- Record file size, 30-day and 90-day churn, tests, requirements, and validation
+  lanes.
+- Exclude vendor, generated, cache, binary, and temporary content explicitly.
+- Use syntax-aware metrics for Go and Rust.
+- Keep shell measurements at file level until a reliable parser exists.
+- Test the generator against small fixture repositories.
+
+Keep the first baseline advisory. Do not refresh a committed snapshot on every
+pull request.
+
+### H3: CI And Review Feedback
+
+Dependencies: H1 and H2.
+
+Extend the weekly CI insight lane with durable JSON and Markdown artifacts.
+
+Acceptance evidence:
+
+- Report count, p50, p95, queue time, execution time, conclusion, and rerun
+  ratio.
+- Group data by stable workflow identity.
+- Add a schema version to each JSON artifact.
+- Upload the bounded reports as GitHub Actions artifacts.
+- Record the reviewed retention period in `policy/retention-policy.json`.
+- Keep `docs/retention-policy.md` consistent with that policy.
+- Exclude comment bodies, identities, credentials, and branch names.
+- Report pagination gaps, API failures, and missing timestamps.
+- Encode absent or partial data instead of reporting a complete result.
+- Test calculations with offline JSON fixtures.
+- Add exact PR wait states for ready, review request, required green, and
+  merge.
+- Measure duplicate review triggers for unchanged heads.
+
+Keep these reports read-only and non-gating until a reviewed baseline exists.
+Treat unchanged-head and Codex-trigger counts as diagnostic data only. Never
+relax the required current-head Codex review loop.
+
+Do not rank people, agents, or models.
+
+### H4: SLSA v1.2 And Release Verification
+
+Dependency: H1.
+
+Reassess provenance against the SLSA v1.2 Build and Source tracks.
+
+Acceptance evidence:
+
+- Use the existing eight-subject SLSA v1.0 Build L2 claim as the comparison
+  baseline.
+- Do not claim a v1.2 level before this reassessment proves it.
+- Record Source-track controls and the single-maintainer constraint.
+- Keep Build L3 and Source L4 unclaimed.
+- Define trusted builder identities and verification expectations.
+- Add read-only post-publication verification for exact-tag release outputs.
+- Verify digests, Cosign identity, provenance subject, builder, and expected
+  parameters.
+
+Do not rewrite a published tag or release after a verification failure. Follow
+the documented next-patch recovery.
+
+### H5: Risk-Based Assurance Expansion
+
+Dependencies: H2 and a reviewed risk or evidence gap.
+
+Add evidence where critical decisions have weak or missing proof.
+
+Acceptance evidence:
+
+- Measure a targeted race-detector lane for concurrency-heavy Go packages.
+- Start the lane as a scheduled or approved trial on named high-risk packages.
+- Record its duration, resource cost, findings, and false signals.
+- Add negative, property, or mutation cases for high-impact decision branches.
+- Report mutation scope explicitly.
+- Produce coverage maps for selected critical Go package groups.
+- Set a ratchet only after reviewed baseline evidence supports it.
+- Keep expensive discovery work outside normal pull-request latency.
+
+Promote the race lane only after reviewed evidence proves useful PR feedback.
+Otherwise, retain scheduled or on-demand execution.
+
+Do not set one repository-wide coverage percentage. Do not describe the
+14-mutant suite as repository-wide mutation testing.
+
+### H6: Measured Complexity Reduction
+
+Dependency: H2.
+
+Select one hotspot with size, churn, boundary, defect, and review evidence.
+
+Acceptance evidence:
+
+- Extract one behavior-preserving seam.
+- Preserve output, exit codes, side effects, and first-failure order.
+- Add characterization or differential tests before extraction.
+- Keep the public contract unchanged.
+- Run live certification when a supported workflow can change.
+
+Stop when a refactor requires a behavior or support change. Create a separate
+feature unit for that change.
+
+### H7: Validation And Benchmark Maintenance
+
+Dependency: H2.
+
+- Define shared validation sets once while preserving quick and full profiles.
+- Prove that each quick profile remains a documented subset of full validation.
+- Add Go benchmarks only for paths with an objective or regression history.
+- Add shell unit tests only for stable glue or protocol helpers.
+
+Do not build a new framework around logic scheduled for removal.
+
+### H8: Rust Vendor Refresh
+
+Dependency: H1.
+
+Add a locked Rust vendor-refresh workflow. Verify `Cargo.lock`, vendored
+sources, offline builds, and reproducibility. Keep dependency updates in
+separate review units.
+
+This work does not depend on the engineering-health generator.
+
+### H9: External Controls
+
+Complete these items only when authority and resources exist:
+
+- Add a second qualified maintainer for real independent review.
+- Fund trusted Apple Silicon boundary automation.
+- Complete a third-party boundary review.
+- Assess the OpenSSF badge honestly after known internal gaps close.
+
+The badge is voluntary self-certification. It does not prove Workcell runtime
+isolation.
+
+## Execution And Review
+
+Use the repo-local pull-request lifecycle for model routing and publication.
+Use representative tasks to compare acceptance success, rework, elapsed time,
+tokens, and cost. Never reduce evidence or correctness to lower model cost.
+
+Permit parallel research, review, and local validation on separate scopes.
+Serialize GitHub mutations through one coordinator. Merge one review unit before
+publishing the next dependent unit.
+
+Review this document each quarter. Update it sooner after a material standard,
+architecture, assurance, or delivery-process change.

--- a/docs/standards-watchlist.md
+++ b/docs/standards-watchlist.md
@@ -3,7 +3,8 @@
 The maintainer reviews this list each quarter. Review it sooner when a tracked
 body publishes a new version.
 
-- Last review: 2026-08-06.
+- Last full agent-standards review: 2026-08-06.
+- Engineering-practice sources reviewed: 2026-08-11.
 - Next planned review: 2026-11-06.
 
 ## Watchlist
@@ -13,6 +14,15 @@ body publishes a new version.
 | [Model Context Protocol 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28) | Current dated specification | MCP transport, authorization, and extension changes can affect injected configuration and runtime controls. | Check adapter support for the stateless protocol and authorization changes. |
 | [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) | Published 2026 edition | Workcell maps its controls to ASI01 through ASI10. | Check for a new edition. If OWASP publishes one, update the mapping. |
 | [IETF WIMSE documents](https://datatracker.ietf.org/wg/wimse/documents/) | Active working-group and individual drafts | Workload identity can affect future agent authentication and delegation. | Check architecture, credential, proof-token, and AI-agent drafts. |
+| [NIST SSDF 1.1](https://csrc.nist.gov/pubs/sp/800/218/final) | Final, published February 2022 | The engineering baseline maps secure development across the lifecycle. | Check for a final revision or supplement. |
+| [NIST SP 800-160 Rev. 1](https://csrc.nist.gov/pubs/sp/800/160/v1/r1/final) | Final, published November 2022 | Trust objectives inform architecture, requirements, verification, and operations. | Check for a final revision. |
+| [ISO/IEC 25010:2023](https://www.iso.org/standard/78176.html) | Published second edition | Relevant product-quality characteristics inform requirements, tests, acceptance, and measures. | Check its systematic-review status. |
+| [SLSA v1.2](https://slsa.dev/spec/v1.2/) | Approved specification | Build and Source tracks affect provenance claims and source-control assessment. | Reassess exact Workcell track and level claims after a new approved version. |
+| [GitHub Actions secure use](https://docs.github.com/en/actions/reference/security/secure-use) | Current official guidance | Token permissions, untrusted checkout, action identity, and secret handling affect workflow controls. | Check after a material Actions security change. |
+| [DORA metrics](https://dora.dev/guides/dora-metrics/) | Current five-measure guidance, updated January 2026 | Repository trends can guide delivery improvement after Workcell defines deployments and recovery. | Check definitions before changing a delivery measure. |
+| [Google Engineering Practices](https://google.github.io/eng-practices/review/reviewer/standard.html) | Current official guidance | Small changes, technical evidence, and code-health improvement inform review practice. | Check for material review-policy changes. |
+| [Go guidance](https://go.dev/doc/comment) and [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) | Current official project guidance | Language conventions inform APIs, documentation, and tests. | Check after a supported language or toolchain change. |
+| [OpenSSF Best Practices Badge](https://openssf.org/projects/best-practices-badge/) | Current voluntary self-certification program | The checklist can support open-source hygiene. It does not prove Workcell isolation. | Check criteria before starting the deferred badge assessment. |
 
 ## Notes
 

--- a/policy/forbidden-host-paths.toml
+++ b/policy/forbidden-host-paths.toml
@@ -6,9 +6,9 @@
 # These are intentionally restricted to substrings that have no legitimate
 # in-container counterpart: a bare `/.codex` would also match the
 # container path `/state/agent-home/.codex`, so provider-specific state
-# directories are deliberately excluded here. A future change can add a
-# host-side `-v` mount-source check to cover those without conflicting
-# with the in-container paths.
+# directories are deliberately excluded here. `scripts/verify-invariants.sh`
+# separately checks host-side mount sources without matching the in-container
+# paths.
 #
 # AGENTS.md sources the canonical narrative ("Keep host mounts minimal";
 # "Never pass through host sockets or auth state"); this file is the


### PR DESCRIPTION
## Summary

- Add a primary-source engineering baseline and a versioned 31-day evidence record.
- Record the H1-H9 improvement plan and durable repository guidance.
- Correct stale mount-source validation comments in repository policy.

## Validation

- Full repository validation passed.
- Fresh exact-head PR parity passed, including container smoke.
- Adversarial, source, parity, and mechanical reviews reached dry results.

No product support, assurance, certification, compliance, or SLSA claim changes.