### PR TITLE
Reap verifier Colima profile processes

### DIFF
--- a/internal/host/launcher/colima_process_reaper_test.go
+++ b/internal/host/launcher/colima_process_reaper_test.go
@@ -165,6 +165,26 @@ func TestReapColimaProfileProcessesSignalsBoundIdentity(t *testing.T) {
 	}
 }
 
+func TestReapColimaProfileProcessesReapsDetachedMux(t *testing.T) {
+	fake := newReaperFake()
+	fake.profile = "wcl-live-det-test"
+	fake.processes = map[int]string{
+		42: "/opt/homebrew/bin/limactl hostagent /tmp/colima-wcl-live-det-test/ha.pid",
+		43: "ssh: /tmp/colima-wcl-live-det-test/ssh.sock [mux]",
+	}
+	fake.started = map[int]string{42: "started-42", 43: "started-43"}
+	fake.states = map[int]string{42: "R", 43: "R"}
+	fake.termRemoves = true
+
+	if err := reapColimaProfileProcesses(context.Background(), fake.profile, fake.dependencies()); err != nil {
+		t.Fatalf("reap error = %v", err)
+	}
+	want := []reaperSignal{{pid: 42, signal: syscall.SIGTERM}, {pid: 43, signal: syscall.SIGTERM}}
+	if !slices.Equal(fake.signals, want) {
+		t.Fatalf("signals = %#v, want %#v", fake.signals, want)
+	}
+}
+
 func TestReapColimaProfileProcessesPreservesGracefulShutdownWindow(t *testing.T) {
 	fake := newReaperFake()
 	deps := fake.dependencies()

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -481,6 +481,9 @@ delete_verify_colima_profile() {
   elif [[ -x /usr/local/bin/colima ]]; then
     /usr/local/bin/colima delete --profile "${profile_name}" --force >/dev/null 2>&1 || true
   fi
+  if ! go_verify_hostutil helper reap-colima-profile-processes "${profile_name}"; then
+    return 1
+  fi
   rm -rf \
     "${REAL_HOME}/.colima/${profile_name}" \
     "${REAL_HOME}/.local/state/workcell/targets/local_vm/colima/${profile_name}" \
@@ -5052,6 +5055,13 @@ PROFILE_PROCESS_REAPER_HARNESS="$(mktemp)"
 } >"${PROFILE_PROCESS_REAPER_HARNESS}"
 /bin/bash "${PROFILE_PROCESS_REAPER_HARNESS}"
 rm -f "${PROFILE_PROCESS_REAPER_HARNESS}"
+VERIFY_PROFILE_DELETE_REAPER_HARNESS="$(mktemp)"
+{
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/verify-invariants.sh" delete_verify_colima_profile
+  cat "${ROOT_DIR}/verify/invariants/harnesses/process-colima/verify-profile-delete-reaper.sh"
+} >"${VERIFY_PROFILE_DELETE_REAPER_HARNESS}"
+/bin/bash "${VERIFY_PROFILE_DELETE_REAPER_HARNESS}"
+rm -f "${VERIFY_PROFILE_DELETE_REAPER_HARNESS}"
 COLIMA_PROFILE_STATUS_HARNESS="$(mktemp)"
 {
   extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" colima_profile_status

--- a/verify/invariants/harnesses/process-colima/verify-profile-delete-reaper.sh
+++ b/verify/invariants/harnesses/process-colima/verify-profile-delete-reaper.sh
@@ -1,0 +1,78 @@
+set -euo pipefail
+
+function_body="$(declare -f delete_verify_colima_profile)"
+function_body="$(printf '%s\n' "${function_body}" | sed \
+  -e 's|if \[\[ -x /opt/homebrew/bin/colima \]\]; then|if [[ "${COLIMA_VARIANT}" == "homebrew" ]]; then|' \
+  -e 's|if \[\[ -x /usr/local/bin/colima \]\]; then|if [[ "${COLIMA_VARIANT}" == "local" ]]; then|' \
+  -e 's|/opt/homebrew/bin/colima delete|fake_colima delete|' \
+  -e 's|/usr/local/bin/colima delete|fake_colima delete|')"
+eval "${function_body}"
+
+profile_name="wcl-live-det-test"
+REAL_HOME="/tmp/workcell-verify-profile-delete-reaper"
+event_log=""
+reaper_calls=0
+remove_calls=0
+REAPER_STATUS=0
+
+fake_colima() {
+  [[ "$*" == "delete --profile ${profile_name} --force" ]] || {
+    echo "Unexpected Colima delete invocation: $*" >&2
+    return 1
+  }
+  event_log="${event_log}D"
+}
+
+go_verify_hostutil() {
+  [[ "$*" == "helper reap-colima-profile-processes ${profile_name}" ]] || {
+    echo "Unexpected profile reaper invocation: $*" >&2
+    return 1
+  }
+  reaper_calls=$((reaper_calls + 1))
+  event_log="${event_log}R"
+  return "${REAPER_STATUS}"
+}
+
+rm() {
+  remove_calls=$((remove_calls + 1))
+  event_log="${event_log}M"
+}
+
+assert_success() {
+  local variant="$1"
+
+  COLIMA_VARIANT="${variant}"
+  event_log=""
+  reaper_calls=0
+  remove_calls=0
+  REAPER_STATUS=0
+  delete_verify_colima_profile "${profile_name}"
+  [[ "${event_log}" == "DRMM" && "${reaper_calls}" -eq 1 && "${remove_calls}" -eq 2 ]] || {
+    echo "Expected delete, one reaper call, and state removal for ${variant}, got ${event_log}" >&2
+    exit 1
+  }
+}
+
+assert_reaper_failure() {
+  local status=0
+
+  COLIMA_VARIANT="homebrew"
+  event_log=""
+  reaper_calls=0
+  remove_calls=0
+  REAPER_STATUS=23
+  if delete_verify_colima_profile "${profile_name}"; then
+    echo "Expected profile reaper failure to stop cleanup" >&2
+    exit 1
+  else
+    status=$?
+  fi
+  [[ "${status}" -ne 0 && "${event_log}" == "DR" && "${reaper_calls}" -eq 1 && "${remove_calls}" -eq 0 ]] || {
+    echo "Expected failed reaper to prevent state removal, got ${event_log}" >&2
+    exit 1
+  }
+}
+
+assert_success homebrew
+assert_success local
+assert_reaper_failure


### PR DESCRIPTION
## Summary

- Reap profile-owned Colima processes after verifier profile deletion.
- Stop before state removal when process cleanup cannot prove success.
- Add regression coverage for detached SSH muxes and cleanup ordering.

## Validation

- `bash ./scripts/verify-invariants.sh` on Darwin with live Colima lanes
- `go test ./...`
- `go vet ./internal/host/launcher ./cmd/workcell-hostutil`
- `./scripts/verify-operator-contract.sh`
- `./scripts/verify-requirements-coverage.sh`
- `./scripts/check-dead-code.sh`
- `./scripts/check-public-repo-hygiene.sh`
- `env -u GIT_PAGER ./scripts/pre-merge.sh --profile pr-parity --allow-dirty`
- `git diff --check`

## Review

- Six-role adversarial review reached dry consensus after one fail-closed repair.
- The live detached-session lane created and removed the exact temporary mux.
