### PR TITLE
^S Reject release assets with extended ACLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,21 @@ jobs:
       - name: Run Workcell container smoke
         run: ./scripts/container-smoke.sh
 
+  release-asset-acl:
+    name: Release asset ACL (Darwin)
+    needs: pr-shape
+    runs-on: macos-15
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Verify release asset ACL handling
+        run: ./scripts/ci/job-release-asset-acl.sh
+
   install-verification:
     name: Install verification (${{ matrix.runner_label }})
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'approved-heavy-ci') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -673,6 +673,13 @@ jobs:
           - runner: macos-15
             runner_label: macos-15
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Verify release asset ACL handling
+        run: ./scripts/ci/job-release-asset-acl.sh
+
       - name: Download preflight release install artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/docs/ci-threat-model.md
+++ b/docs/ci-threat-model.md
@@ -107,6 +107,11 @@ The final publisher downloads that current-run artifact and publishes its files.
 The publisher trusts this handoff.
 It does not verify the new signatures or attestations after the handoff.
 
+The release publisher rejects extended ACLs on source and staging file handles.
+The required Darwin lane checks the native macOS ACL interface on every PR and `main` push.
+The Linux validator fixture checks POSIX ACL handling before a release can publish.
+The release install matrix repeats the Darwin proof before it uses release artifacts.
+
 ### Untrusted pull requests
 
 The PR workflows use the `pull_request` event.

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -58,6 +58,8 @@ For an approved large adapter PR, use both required options:
 ## CI routing
 
 Normal PRs run the required deterministic lanes.
+The `Release asset ACL (Darwin)` lane runs on every PR and `main` push.
+It uses `macos-15` and checks the exact Go toolchain.
 The `approved-heavy-ci` label enables these expensive PR lanes:
 
 - native amd64 and arm64 reproducible builds
@@ -90,6 +92,8 @@ The Homebrew job verifies that `brew uninstall` removes the formula.
 
 GitHub-hosted macOS does not prove the strict Colima boundary.
 Local certification supplies that proof.
+
+The release install matrix runs the same ACL script before it uses release artifacts.
 
 ## Release workflow
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -532,10 +532,14 @@ In immutable-release mode, the release publisher must create or reuse a draft
 release, stage and validate the full artifact set before the first GitHub
 mutation, upload only from the sealed staging handles, revalidate the exact
 uploaded inventory, and only then publish the final release record. Source-path
-changes after staging cannot change the uploaded bytes. The entrypoint also
-binds publication to the locally checked-out annotated tag object and its peeled
-commit; the Go publisher verifies that exact binding against GitHub before and
-after publication. Release preflight verifies repository release immutability
+changes after staging cannot change the uploaded bytes. The entrypoint rejects
+extended ACLs on source and staging handles. Before publication, require the
+native Darwin ACL lane. Require the validator Linux ACL fixture to pass. The
+entrypoint also binds publication to the locally checked-out annotated tag
+object and its peeled commit.
+
+The Go publisher verifies that exact binding against GitHub before and after
+publication. Release preflight verifies repository release immutability
 with the environment-scoped `WORKCELL_HOSTED_CONTROLS_TOKEN`. After the
 release-approved job seals and uploads its workflow artifact, a minimal final
 job in `hosted-controls-audit` refreshes that check immediately before
@@ -543,8 +547,9 @@ publication and removes the admin-metadata credential before invoking the
 publisher. The publisher still attempts the direct check with its default
 Actions token and accepts only GitHub's exact
 `Resource not accessible by integration` denial when the fresh preverification
-is present. A disabled control or any other response still fails closed. If
-publication instead tries to upload assets into an
+is present. A disabled control or any other response still fails closed.
+
+If publication instead tries to upload assets into an
 already-published immutable release, treat that as a release-process bug, patch
 `main`, and cut the next patch release rather than rewriting the failed tag.
 If a create, delete, upload, or publish request fails after it starts, treat the
@@ -582,6 +587,18 @@ integration denial, and invoked the production publisher. [Workflow run
 published release id `365188077`; GitHub reports it as an immutable prerelease
 with the exact 18 digest-bearing assets and a valid signed tag. The temporary
 fixture environment secret was deleted immediately after the run.
+
+Release asset ACL rejection was live-certified on 2026-08-11 with signed tag
+`v0.0.0-rc.5` in the same fixture. Before tag creation, an ACL-bearing source
+failed during local asset inspection. The negative run created no tag or
+release. The corrected run published [release id
+`368796851`](https://github.com/omkhar/workcell-release-publisher-certification/releases/tag/v0.0.0-rc.5)
+with 18 digest-bearing assets. GitHub reports the prerelease as immutable and
+the signed tag as verified with reason `valid`.
+
+The certified non-document candidate fingerprint is
+`sha256:078903a66b1e3fc30e06a9c2d82152a999aac34f0ab71bc470d06ad4c77486c3`.
+The fingerprint covers the 19 changed non-document paths.
 
 After approving the environment in single-maintainer mode, leave a public PR
 follow-up comment so the self-review is visible in the same release thread. Use

--- a/internal/host/release/asset_acl.go
+++ b/internal/host/release/asset_acl.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package release
+
+func isExtendedACLName(name string) bool {
+	switch name {
+	case "system.nfs4_acl", "system.posix_acl_access", "system.posix_acl_default", "system.richacl":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/host/release/asset_acl_darwin.go
+++ b/internal/host/release/asset_acl_darwin.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin
+
+package release
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func rejectExtendedACL(fd int) error {
+	attributes := unix.Attrlist{Bitmapcount: unix.ATTR_BIT_MAP_COUNT, Commonattr: unix.ATTR_CMN_EXTENDED_SECURITY}
+	var buffer [12]byte
+	_, _, errno := unix.Syscall6(unix.SYS_FGETATTRLIST, uintptr(fd), uintptr(unsafe.Pointer(&attributes)), uintptr(unsafe.Pointer(&buffer[0])), uintptr(len(buffer)), unix.FSOPT_REPORT_FULLSIZE, 0)
+	if errno != 0 {
+		return fmt.Errorf("inspect extended ACL: %w", errno)
+	}
+	if binary.LittleEndian.Uint32(buffer[:4]) < uint32(len(buffer)) {
+		return errors.New("inspect extended ACL: malformed attribute response")
+	}
+	if binary.LittleEndian.Uint32(buffer[8:]) != 0 {
+		return inputErrorf("extended ACLs are not permitted")
+	}
+	return nil
+}

--- a/internal/host/release/asset_acl_darwin_test.go
+++ b/internal/host/release/asset_acl_darwin_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin
+
+package release
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestReleaseAssetACLDarwin(t *testing.T) {
+	t.Run("source file", func(t *testing.T) {
+		path := writeAssetFile(t, "asset", []byte("asset"))
+		addDarwinACL(t, path)
+		fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = unix.Close(fd) })
+		if err := rejectExtendedACL(fd); !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("rejectExtendedACL() = %v, want ErrInvalidInput", err)
+		}
+		if _, err := inspectLocalAssets([]string{path}); !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("inspectLocalAssets() = %v, want ErrInvalidInput", err)
+		}
+	})
+	t.Run("source ancestor", func(t *testing.T) {
+		directory := t.TempDir()
+		path := directory + "/asset"
+		if err := os.WriteFile(path, []byte("asset"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		addDarwinACL(t, directory)
+		if _, err := inspectLocalAssets([]string{path}); !errors.Is(err, ErrInvalidInput) || !strings.Contains(err.Error(), "directory") {
+			t.Fatalf("inspectLocalAssets() = %v, want directory ErrInvalidInput", err)
+		}
+	})
+	t.Run("ACL mutation during read", func(t *testing.T) {
+		path := writeAssetFile(t, "asset", []byte("asset"))
+		base := openatAssetSourceOpener{}
+		opener := foundationOpenerFunc(func(candidate string) (assetSource, error) {
+			source, err := base.Open(candidate)
+			if err != nil {
+				return nil, err
+			}
+			return &aclMutationSource{
+				assetSource: source,
+				mutate: func() error {
+					return addDarwinACLError(candidate)
+				},
+			}, nil
+		})
+		if _, err := inspectLocalAssetsWithOpener([]string{path}, opener); !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("inspectLocalAssetsWithOpener() = %v, want ErrInvalidInput", err)
+		}
+	})
+	t.Run("staging directory inheritance", func(t *testing.T) {
+		tempRoot := t.TempDir()
+		addDarwinInheritedACL(t, tempRoot)
+		t.Setenv("TMPDIR", tempRoot)
+		if stage, err := createStagedAssetContent(); !errors.Is(err, ErrInvalidInput) {
+			if stage != nil {
+				_ = discardStagedAssetContent(stage, "asset")
+			}
+			t.Fatalf("createStagedAssetContent() = %v, want ErrInvalidInput", err)
+		}
+	})
+	t.Run("linked staging handle", func(t *testing.T) {
+		stage, err := createStagedAssetContent()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = discardStagedAssetContent(stage, "asset") })
+		if _, err := stage.Write([]byte("asset")); err != nil {
+			t.Fatal(err)
+		}
+		if err := stage.Sync(); err != nil {
+			t.Fatal(err)
+		}
+		addDarwinACL(t, stage.file.Name())
+		if reader, err := sealStagedAssetContent(stage, "asset", 5); !errors.Is(err, ErrInvalidInput) {
+			if reader != nil {
+				_ = reader.Close()
+			}
+			t.Fatalf("sealStagedAssetContent() = %v, want ErrInvalidInput", err)
+		}
+	})
+}
+
+func addDarwinACL(t *testing.T, path string) {
+	t.Helper()
+	if err := addDarwinACLCall(path, "everyone deny write"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func addDarwinACLError(path string) error { return addDarwinACLCall(path, "everyone deny write") }
+
+func addDarwinInheritedACL(t *testing.T, path string) {
+	t.Helper()
+	if err := addDarwinACLCall(path, "everyone deny write,file_inherit,directory_inherit"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func addDarwinACLCall(path, acl string) error {
+	output, err := exec.Command("/bin/chmod", "+a", acl, path).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("add Darwin ACL: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}

--- a/internal/host/release/asset_acl_linux.go
+++ b/internal/host/release/asset_acl_linux.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux
+
+package release
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+func rejectExtendedACL(fd int) error {
+	for attempt := 0; attempt < 3; attempt++ {
+		size, err := unix.Flistxattr(fd, nil)
+		if err != nil {
+			return fmt.Errorf("list extended attributes for ACL validation: %w", err)
+		}
+		if size == 0 {
+			return nil
+		}
+		if size > 64*1024 {
+			return errors.New("list extended attributes for ACL validation: oversized response")
+		}
+		buffer := make([]byte, size)
+		read, err := unix.Flistxattr(fd, buffer)
+		if err == unix.ERANGE {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("read extended attributes for ACL validation: %w", err)
+		}
+		for _, name := range strings.Split(string(buffer[:read]), "\x00") {
+			if isExtendedACLName(name) {
+				return inputErrorf("extended ACLs are not permitted")
+			}
+		}
+		return nil
+	}
+	return errors.New("read extended attributes for ACL validation: attribute list changed repeatedly")
+}

--- a/internal/host/release/asset_acl_linux_test.go
+++ b/internal/host/release/asset_acl_linux_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux
+
+package release
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestReleaseAssetACLLinux(t *testing.T) {
+	requireLinuxACL(t)
+	foreignUID := strconv.FormatUint(uint64(os.Geteuid())+1, 10)
+
+	t.Run("source file", func(t *testing.T) {
+		path := writeAssetFile(t, "asset", []byte("asset"))
+		addLinuxACL(t, path, "u:"+foreignUID+":r--")
+		assertLinuxMode(t, path, 0o600)
+		fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = unix.Close(fd) })
+		if err := rejectExtendedACL(fd); !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("rejectExtendedACL() = %v, want ErrInvalidInput", err)
+		}
+		if _, err := inspectLocalAssets([]string{path}); !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("inspectLocalAssets() = %v, want ErrInvalidInput", err)
+		}
+	})
+
+	t.Run("source ancestor", func(t *testing.T) {
+		directory := t.TempDir()
+		if err := os.Chmod(directory, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		path := directory + "/asset"
+		if err := os.WriteFile(path, []byte("asset"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		addLinuxACL(t, directory, "u:"+foreignUID+":rwx")
+		assertLinuxMode(t, directory, 0o700)
+		if _, err := inspectLocalAssets([]string{path}); !errors.Is(err, ErrInvalidInput) || !strings.Contains(err.Error(), "directory") {
+			t.Fatalf("inspectLocalAssets() = %v, want directory ErrInvalidInput", err)
+		}
+	})
+
+	t.Run("ACL mutation during read", func(t *testing.T) {
+		path := writeAssetFile(t, "asset", []byte("asset"))
+		base := openatAssetSourceOpener{}
+		opener := foundationOpenerFunc(func(candidate string) (assetSource, error) {
+			source, err := base.Open(candidate)
+			if err != nil {
+				return nil, err
+			}
+			return &aclMutationSource{
+				assetSource: source,
+				mutate: func() error {
+					return addLinuxACLError(candidate, "u:"+foreignUID+":r--")
+				},
+			}, nil
+		})
+		if _, err := inspectLocalAssetsWithOpener([]string{path}, opener); !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("inspectLocalAssetsWithOpener() = %v, want ErrInvalidInput", err)
+		}
+		assertLinuxMode(t, path, 0o600)
+	})
+
+	t.Run("staging directory inheritance", func(t *testing.T) {
+		tempRoot := t.TempDir()
+		if err := os.Chmod(tempRoot, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		addLinuxACL(t, tempRoot, "d:u:"+foreignUID+":rwx")
+		assertLinuxMode(t, tempRoot, 0o700)
+		t.Setenv("TMPDIR", tempRoot)
+		if stage, err := createStagedAssetContent(); !errors.Is(err, ErrInvalidInput) {
+			if stage != nil {
+				_ = discardStagedAssetContent(stage, "asset")
+			}
+			t.Fatalf("createStagedAssetContent() = %v, want ErrInvalidInput", err)
+		}
+		assertLinuxMode(t, tempRoot, 0o700)
+	})
+
+	t.Run("linked staging handle", func(t *testing.T) {
+		stage, err := createStagedAssetContent()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = discardStagedAssetContent(stage, "asset") })
+		if _, err := stage.Write([]byte("asset")); err != nil {
+			t.Fatal(err)
+		}
+		if err := stage.Sync(); err != nil {
+			t.Fatal(err)
+		}
+		addLinuxACL(t, stage.file.Name(), "u:"+foreignUID+":r--")
+		assertLinuxMode(t, stage.file.Name(), 0o600)
+		if reader, err := sealStagedAssetContent(stage, "asset", 5); !errors.Is(err, ErrInvalidInput) {
+			if reader != nil {
+				_ = reader.Close()
+			}
+			t.Fatalf("sealStagedAssetContent() = %v, want ErrInvalidInput", err)
+		}
+	})
+}
+
+func requireLinuxACL(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("setfacl"); err == nil {
+		return
+	} else if os.Getenv("WORKCELL_REQUIRE_NATIVE_ACL_TESTS") == "1" {
+		t.Fatalf("setfacl is required for native Linux ACL tests: %v", err)
+	}
+	t.Skip("setfacl is not installed")
+}
+
+func addLinuxACL(t *testing.T, path, entry string) {
+	t.Helper()
+	if err := addLinuxACLError(path, entry); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func addLinuxACLError(path, entry string) error {
+	output, err := exec.Command("setfacl", "-n", "-m", entry, path).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("add Linux ACL: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func assertLinuxMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode for %q = %o, want %o", path, got, want)
+	}
+}

--- a/internal/host/release/asset_acl_test.go
+++ b/internal/host/release/asset_acl_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package release
+
+import "testing"
+
+func TestExtendedACLNamePolicy(t *testing.T) {
+	for _, name := range []string{"system.nfs4_acl", "system.posix_acl_access", "system.posix_acl_default", "system.richacl"} {
+		if !isExtendedACLName(name) {
+			t.Fatalf("isExtendedACLName(%q) = false", name)
+		}
+	}
+	if isExtendedACLName("user.workcell") {
+		t.Fatal("isExtendedACLName(user.workcell) = true")
+	}
+}

--- a/internal/host/release/asset_content.go
+++ b/internal/host/release/asset_content.go
@@ -67,6 +67,10 @@ type assetSource interface {
 	Close() error
 }
 
+type extendedACLSource interface {
+	rejectExtendedACL() error
+}
+
 type assetSourceOpener interface {
 	Open(string) (assetSource, error)
 }
@@ -108,7 +112,7 @@ func (openatAssetSourceOpener) Open(path string) (assetSource, error) {
 	if err := unix.Fstat(currentFD, &rootStat); err != nil {
 		return nil, errors.Join(fmt.Errorf("stat filesystem root for release asset %q: %w", path, err), closeUnixFD(currentFD, "release asset path parent"))
 	}
-	anchored, err := validateAssetDirectory(string(filepath.Separator), rootStat, false)
+	anchored, err := validateAssetDirectory(currentFD, string(filepath.Separator), rootStat, false)
 	if err != nil {
 		return nil, errors.Join(err, closeUnixFD(currentFD, "release asset path parent"))
 	}
@@ -145,6 +149,9 @@ func (openatAssetSourceOpener) Open(path string) (assetSource, error) {
 			if opened.Dev != expected.Dev || opened.Ino != expected.Ino || uint32(opened.Mode)&uint32(unix.S_IFMT) != uint32(unix.S_IFREG) {
 				return nil, errors.Join(inputErrorf("release asset %q changed between inspection and open", path), closeUnixFD(nextFD, "release asset"), closeUnixFD(currentFD, "release asset path parent"))
 			}
+			if err := rejectExtendedACL(nextFD); err != nil {
+				return nil, errors.Join(fmt.Errorf("validate extended ACL for release asset %q: %w", path, err), closeUnixFD(nextFD, "release asset"), closeUnixFD(currentFD, "release asset path parent"))
+			}
 			if closeErr := closeUnixFD(currentFD, "release asset path parent"); closeErr != nil {
 				return nil, errors.Join(closeErr, closeUnixFD(nextFD, "release asset"))
 			}
@@ -158,7 +165,7 @@ func (openatAssetSourceOpener) Open(path string) (assetSource, error) {
 		if err := unix.Fstat(nextFD, &directoryStat); err != nil {
 			return nil, errors.Join(fmt.Errorf("stat release asset %q directory component %q: %w", path, component, err), closeUnixFD(nextFD, "release asset path component"), closeUnixFD(currentFD, "release asset path parent"))
 		}
-		nextAnchored, err := validateAssetDirectory(cleanPath, directoryStat, anchored)
+		nextAnchored, err := validateAssetDirectory(nextFD, cleanPath, directoryStat, anchored)
 		if err != nil {
 			return nil, errors.Join(err, closeUnixFD(nextFD, "release asset path component"), closeUnixFD(currentFD, "release asset path parent"))
 		}
@@ -171,7 +178,7 @@ func (openatAssetSourceOpener) Open(path string) (assetSource, error) {
 	return nil, errors.Join(errors.New("release asset path traversal ended without a file"), closeUnixFD(currentFD, "release asset path parent"))
 }
 
-func validateAssetDirectory(path string, stat unix.Stat_t, anchored bool) (bool, error) {
+func validateAssetDirectory(fd int, path string, stat unix.Stat_t, anchored bool) (bool, error) {
 	mode := uint32(stat.Mode)
 	if mode&uint32(unix.S_IFMT) != uint32(unix.S_IFDIR) || stat.Ino == 0 {
 		return false, inputErrorf("release asset %q contains a non-directory component", path)
@@ -181,15 +188,34 @@ func validateAssetDirectory(path string, stat unix.Stat_t, anchored bool) (bool,
 		if !ownedAndControlled {
 			return false, inputErrorf("release asset %q contains a directory below its owner-controlled anchor that is foreign-owned or writable by another user", path)
 		}
+		if err := validateAssetDirectoryACL(fd, path); err != nil {
+			return false, err
+		}
 		return true, nil
 	}
 	if stat.Uid == 0 && (mode&0o022 == 0 || mode&uint32(unix.S_ISVTX) != 0) {
-		return os.Geteuid() == 0 && mode&0o077 == 0 && mode&uint32(unix.S_ISVTX) == 0, nil
+		if os.Geteuid() != 0 || mode&0o077 != 0 || mode&uint32(unix.S_ISVTX) != 0 {
+			return false, nil
+		}
+		if err := validateAssetDirectoryACL(fd, path); err != nil {
+			return false, err
+		}
+		return true, nil
 	}
 	if ownedAndControlled {
+		if err := validateAssetDirectoryACL(fd, path); err != nil {
+			return false, err
+		}
 		return true, nil
 	}
 	return false, inputErrorf("release asset %q contains an untrusted directory ancestor", path)
+}
+
+func validateAssetDirectoryACL(fd int, path string) error {
+	if err := rejectExtendedACL(fd); err != nil {
+		return fmt.Errorf("validate extended ACL for release asset directory %q: %w", path, err)
+	}
+	return nil
 }
 
 func canonicalAssetSourcePath(path, goos string) (string, error) {
@@ -277,7 +303,19 @@ func (source *openatAssetSource) Stat() (assetSourceStat, error) {
 	return assetSourceStatFromUnix(stat), nil
 }
 
+func (source *openatAssetSource) rejectExtendedACL() error {
+	return rejectExtendedACL(int(source.file.Fd()))
+}
+
 func (source *openatAssetSource) Close() error { return source.file.Close() }
+
+func validateAssetSourceACL(source assetSource) error {
+	aclSource, ok := source.(extendedACLSource)
+	if !ok {
+		return nil
+	}
+	return aclSource.rejectExtendedACL()
+}
 
 func inspectLocalAssets(paths []string) ([]localAsset, error) {
 	return inspectLocalAssetsWithOpener(paths, openatAssetSourceOpener{})
@@ -317,6 +355,9 @@ func inspectLocalAssetsWithOpener(paths []string, opener assetSourceOpener) ([]l
 		if stat.UID != uint32(os.Geteuid()) || stat.Mode&0o022 != 0 {
 			return nil, abortAssetInspection(assets, errors.Join(inputErrorf("release asset %q must be owned by the current user and not writable by another user", path), closeAssetSource(source, name)))
 		}
+		if err := validateAssetSourceACL(source); err != nil {
+			return nil, abortAssetInspection(assets, errors.Join(fmt.Errorf("validate extended ACL for release asset %q before staging: %w", path, err), closeAssetSource(source, name)))
+		}
 		stagedBytes, err = reserveReleaseAssetBytes(stagedBytes, stat.Size)
 		if err != nil {
 			return nil, abortAssetInspection(assets, errors.Join(fmt.Errorf("release asset %q: %w", path, err), closeAssetSource(source, name)))
@@ -333,8 +374,9 @@ func inspectLocalAssetsWithOpener(paths []string, opener assetSourceOpener) ([]l
 			written += probed
 		}
 		after, afterStatErr := source.Stat()
+		sourceACLErr := validateAssetSourceACL(source)
 		sourceCloseErr := closeAssetSource(source, name)
-		if copyErr != nil || afterStatErr != nil || sourceCloseErr != nil {
+		if copyErr != nil || afterStatErr != nil || sourceACLErr != nil || sourceCloseErr != nil {
 			var wrappedCopyErr error
 			if copyErr != nil {
 				wrappedCopyErr = fmt.Errorf("stage release asset %q content: %w", name, copyErr)
@@ -343,7 +385,11 @@ func inspectLocalAssetsWithOpener(paths []string, opener assetSourceOpener) ([]l
 			if afterStatErr != nil {
 				wrappedStatErr = fmt.Errorf("restat staged release asset %q source: %w", name, afterStatErr)
 			}
-			return nil, abortAssetInspection(assets, errors.Join(wrappedCopyErr, wrappedStatErr, sourceCloseErr, discardStagedAssetContent(stage, name)))
+			var wrappedACLErr error
+			if sourceACLErr != nil {
+				wrappedACLErr = fmt.Errorf("validate extended ACL for release asset %q after staging: %w", path, sourceACLErr)
+			}
+			return nil, abortAssetInspection(assets, errors.Join(wrappedCopyErr, wrappedStatErr, wrappedACLErr, sourceCloseErr, discardStagedAssetContent(stage, name)))
 		}
 		if stat != after {
 			return nil, abortAssetInspection(assets, errors.Join(inputErrorf("release asset %q changed while its content was staged", path), discardStagedAssetContent(stage, name)))
@@ -394,7 +440,7 @@ func createStagedAssetContent() (*stagedAssetWriter, error) {
 	if err := unix.Fstat(directoryFD, &directoryStat); err != nil {
 		return nil, errors.Join(fmt.Errorf("stat private release asset staging directory: %w", err), closeAssetContent(directory, "staging directory"), removeStagedAssetDirectoryPath(directoryPath))
 	}
-	if err := validateStagedAssetDirectoryStat(directoryStat); err != nil {
+	if err := validateStagedAssetDirectory(int(directory.Fd()), directoryStat); err != nil {
 		return nil, errors.Join(err, closeAssetContent(directory, "staging directory"), removeStagedAssetDirectoryPath(directoryPath))
 	}
 	stage := &stagedAssetWriter{
@@ -431,7 +477,7 @@ func createStagedAssetContent() (*stagedAssetWriter, error) {
 	if err := unix.Fstat(int(stage.file.Fd()), &stat); err != nil {
 		return nil, errors.Join(fmt.Errorf("stat release asset content stage: %w", err), discardStagedAssetContent(stage, "staging file"))
 	}
-	if err := validateStagedAssetStat(stat, 0, 1); err != nil {
+	if err := validateStagedAsset(int(stage.file.Fd()), stat, 0, 1); err != nil {
 		return nil, errors.Join(err, discardStagedAssetContent(stage, "staging file"))
 	}
 	return stage, nil
@@ -445,7 +491,7 @@ func sealStagedAssetContent(stage *stagedAssetWriter, name string, size int64) (
 	if err := unix.Fstat(int(stage.file.Fd()), &writerStat); err != nil {
 		return nil, errors.Join(fmt.Errorf("stat completed release asset %q content stage: %w", name, err), discardStagedAssetContent(stage, name))
 	}
-	if err := validateStagedAssetStat(writerStat, size, 1); err != nil {
+	if err := validateStagedAsset(int(stage.file.Fd()), writerStat, size, 1); err != nil {
 		return nil, errors.Join(err, discardStagedAssetContent(stage, name))
 	}
 
@@ -461,7 +507,7 @@ func sealStagedAssetContent(stage *stagedAssetWriter, name string, size int64) (
 	if err := unix.Fstat(readerFD, &readerStat); err != nil {
 		return nil, errors.Join(fmt.Errorf("stat release asset %q read-only content stage: %w", name, err), closeAssetContent(reader, name), discardStagedAssetContent(stage, name))
 	}
-	if err := validateStagedAssetStat(readerStat, size, 1); err != nil {
+	if err := validateStagedAsset(readerFD, readerStat, size, 1); err != nil {
 		return nil, errors.Join(err, closeAssetContent(reader, name), discardStagedAssetContent(stage, name))
 	}
 	if writerStat.Dev != readerStat.Dev || writerStat.Ino != readerStat.Ino {
@@ -482,7 +528,7 @@ func sealStagedAssetContent(stage *stagedAssetWriter, name string, size int64) (
 	if err := unix.Fstat(readerFD, &sealedStat); err != nil {
 		return nil, errors.Join(fmt.Errorf("stat sealed release asset %q content: %w", name, err), closeAssetContent(reader, name), discardStagedAssetContent(stage, name))
 	}
-	if err := validateStagedAssetStat(sealedStat, size, 0); err != nil {
+	if err := validateStagedAsset(readerFD, sealedStat, size, 0); err != nil {
 		return nil, errors.Join(err, closeAssetContent(reader, name), discardStagedAssetContent(stage, name))
 	}
 	if writerStat.Dev != sealedStat.Dev || writerStat.Ino != sealedStat.Ino {
@@ -502,7 +548,7 @@ func hashStagedAssetContent(reader *os.File, name string, size int64) (string, e
 	if err := unix.Fstat(int(reader.Fd()), &before); err != nil {
 		return "", fmt.Errorf("stat sealed release asset %q before hashing: %w", name, err)
 	}
-	if err := validateStagedAssetStat(before, size, 0); err != nil {
+	if err := validateStagedAsset(int(reader.Fd()), before, size, 0); err != nil {
 		return "", err
 	}
 	hash := sha256.New()
@@ -531,16 +577,22 @@ func hashStagedAssetContent(reader *os.File, name string, size int64) (string, e
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-func validateStagedAssetDirectoryStat(stat unix.Stat_t) error {
+func validateStagedAssetDirectory(fd int, stat unix.Stat_t) error {
 	if uint32(stat.Mode)&uint32(unix.S_IFMT) != uint32(unix.S_IFDIR) || uint32(stat.Mode)&0o777 != 0o700 || stat.Uid != uint32(os.Geteuid()) || stat.Ino == 0 {
 		return errors.New("release asset staging directory failed owner, mode, directory, or identity validation")
+	}
+	if err := rejectExtendedACL(fd); err != nil {
+		return fmt.Errorf("release asset staging directory has an extended ACL: %w", err)
 	}
 	return nil
 }
 
-func validateStagedAssetStat(stat unix.Stat_t, size int64, links uint64) error {
+func validateStagedAsset(fd int, stat unix.Stat_t, size int64, links uint64) error {
 	if uint32(stat.Mode)&uint32(unix.S_IFMT) != uint32(unix.S_IFREG) || uint32(stat.Mode)&0o777 != 0o600 || stat.Uid != uint32(os.Geteuid()) || stat.Size != size || uint64(stat.Nlink) != links || stat.Ino == 0 {
 		return errors.New("release asset content stage failed owner, mode, size, regular-file, identity, or link-count validation")
+	}
+	if err := rejectExtendedACL(fd); err != nil {
+		return fmt.Errorf("release asset content stage has an extended ACL: %w", err)
 	}
 	return nil
 }

--- a/internal/host/release/asset_content_test.go
+++ b/internal/host/release/asset_content_test.go
@@ -84,6 +84,9 @@ func TestInspectLocalAssetsStagesStableUnlinkedContent(t *testing.T) {
 	if stat.Mode&unix.S_IFMT != unix.S_IFREG || stat.Mode&0o777 != 0o600 || int(stat.Uid) != os.Geteuid() || stat.Nlink != 0 {
 		t.Fatalf("staged fd mode=%o uid=%d nlink=%d", stat.Mode, stat.Uid, stat.Nlink)
 	}
+	if err := rejectExtendedACL(int(stage.Fd())); err != nil {
+		t.Fatalf("rejectExtendedACL(sealed stage) = %v", err)
+	}
 	flags, err := unix.FcntlInt(stage.Fd(), unix.F_GETFL, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -294,6 +297,45 @@ func TestStagedContentSurvivesSameMetadataMutationAndPathSwap(t *testing.T) {
 			t.Fatalf("path swap changed opened stream: got %q, want %q", got, original)
 		}
 	})
+}
+
+func TestInspectLocalAssetsRejectsModeMutationAfterOpen(t *testing.T) {
+	path := writeAssetFile(t, "asset.bin", []byte("asset"))
+	base := openatAssetSourceOpener{}
+	opener := foundationOpenerFunc(func(candidate string) (assetSource, error) {
+		source, err := base.Open(candidate)
+		if err != nil {
+			return nil, err
+		}
+		if err := os.Chmod(candidate, 0o622); err != nil {
+			return nil, errors.Join(err, source.Close())
+		}
+		return source, nil
+	})
+	if _, err := inspectLocalAssetsWithOpener([]string{path}, opener); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("inspectLocalAssetsWithOpener() = %v, want ErrInvalidInput", err)
+	}
+}
+
+type aclMutationSource struct {
+	assetSource
+	mutate  func() error
+	mutated bool
+}
+
+func (source *aclMutationSource) Read(buffer []byte) (int, error) {
+	read, err := source.assetSource.Read(buffer)
+	if read > 0 && !source.mutated {
+		source.mutated = true
+		if mutationErr := source.mutate(); mutationErr != nil {
+			return read, mutationErr
+		}
+	}
+	return read, err
+}
+
+func (source *aclMutationSource) rejectExtendedACL() error {
+	return source.assetSource.(extendedACLSource).rejectExtendedACL()
 }
 
 func TestInspectionPreservesOperationalStatReadAndSourceCloseErrors(t *testing.T) {

--- a/internal/metadatautil/pinnedinputs_docker.go
+++ b/internal/metadatautil/pinnedinputs_docker.go
@@ -131,7 +131,7 @@ func validateDockerPinnedInputs(cfg PinnedInputsConfig, repoRoot, runtimeDockerf
 	if err := requireExactPackages(runtimeInstallBlocks[1], []string{"gcc", "libc6-dev"}, "Runtime builder", cfg.RuntimeDockerfilePath); err != nil {
 		return err
 	}
-	if err := requireExactPackages(validatorInstallBlocks[0], []string{"ca-certificates", "codespell", "curl", "gcc", "git", "groff-base", "jq", "libc6-dev", "llvm", "mandoc", "openssh-client", "procps", "shellcheck", "shfmt", "yamllint"}, "Validator", cfg.ValidatorDockerfilePath); err != nil {
+	if err := requireExactPackages(validatorInstallBlocks[0], []string{"acl", "ca-certificates", "codespell", "curl", "gcc", "git", "groff-base", "jq", "libc6-dev", "llvm", "mandoc", "openssh-client", "procps", "shellcheck", "shfmt", "yamllint"}, "Validator", cfg.ValidatorDockerfilePath); err != nil {
 		return err
 	}
 	goLanguageVersion, err := requireGoDirective(goModText, "go", goModPath)

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -232,6 +232,7 @@ func TestValidationGatesLintAllScenarioShellScripts(t *testing.T) {
 		`${ROOT_DIR}/scripts/check-dead-code.sh`,
 		`${ROOT_DIR}/scripts/check-public-repo-hygiene.sh`,
 		`${ROOT_DIR}/scripts/check-pr-shape.sh`,
+		`${ROOT_DIR}/scripts/ci/job-release-asset-acl.sh`,
 		`${ROOT_DIR}/scripts/install.sh`,
 		`${ROOT_DIR}/scripts/build-and-test.sh`,
 		`${ROOT_DIR}/scripts/install-dev-tools.sh`,

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -7,11 +7,99 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 )
+
+func TestReleaseAssetACLValidationFindsRunnerToolcacheGo(t *testing.T) {
+	t.Parallel()
+
+	arch := map[string]string{"amd64": "x64", "arm64": "arm64"}[runtime.GOARCH]
+	if arch == "" {
+		t.Skipf("runner toolcache architecture is not covered: %s", runtime.GOARCH)
+	}
+	goMod, err := os.ReadFile(filepath.Join(repoRoot(t), "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedToolchain := ""
+	for _, line := range strings.Split(string(goMod), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[0] == "toolchain" {
+			expectedToolchain = fields[1]
+			break
+		}
+	}
+	if expectedToolchain == "" {
+		t.Fatal("go.mod has no toolchain directive")
+	}
+
+	tempDir := t.TempDir()
+	toolBin := filepath.Join(tempDir, "toolcache", "go", strings.TrimPrefix(expectedToolchain, "go"), arch, "bin")
+	if err := os.MkdirAll(toolBin, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(tempDir, "go-test-ran")
+	fakeGo := filepath.Join(toolBin, "go")
+	fakeGoScript := `#!/bin/sh
+case "$*" in
+  "env GOVERSION") printf '%s\n' "${WORKCELL_TEST_EXPECTED_GO}" ;;
+  "env GOOS") printf '%s\n' darwin ;;
+  "test ./internal/host/release -run ^TestReleaseAssetACLDarwin$")
+    : >"${WORKCELL_TEST_GO_MARKER}"
+    ;;
+  *) exit 64 ;;
+esac
+`
+	if err := os.WriteFile(fakeGo, []byte(fakeGoScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	pathDir := filepath.Join(tempDir, "path")
+	if err := os.Mkdir(pathDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"awk", "dirname", "uname"} {
+		path, err := exec.LookPath(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(path, filepath.Join(pathDir, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	staleGo := filepath.Join(pathDir, "go")
+	staleGoScript := `#!/bin/sh
+if [ "$*" = "env GOVERSION" ]; then
+  printf '%s\n' go0.0.0
+  exit 0
+fi
+exit 64
+`
+	if err := os.WriteFile(staleGo, []byte(staleGoScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	script := filepath.Join(repoRoot(t), "scripts", "ci", "job-release-asset-acl.sh")
+	cmd := exec.Command("/bin/bash", script)
+	cmd.Env = canonicalBuildEnv(map[string]string{
+		"AGENT_TOOLSDIRECTORY":      "",
+		"PATH":                      pathDir,
+		"RUNNER_TOOL_CACHE":         filepath.Join(tempDir, "toolcache"),
+		"WORKCELL_TEST_EXPECTED_GO": expectedToolchain,
+		"WORKCELL_TEST_GO_MARKER":   marker,
+	})
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("release ACL validation: %v: %s", err, output)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("runner toolcache Go did not run the Darwin ACL test: %v", err)
+	}
+}
 
 func TestC3CertificationEntrypointSanitizesBuildControl(t *testing.T) {
 	t.Parallel()

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -44,6 +44,7 @@ contexts = [
   "Pull request shape",
   "Validate repository",
   "Container smoke",
+  "Release asset ACL (Darwin)",
   "Reproducible build",
   "Dependency review",
   "GitHub Actions lint",
@@ -51,6 +52,8 @@ contexts = [
 ]
 
 [actions_policy]
+# The unlabelled macOS-15 release-asset ACL lane runs for every pull request and
+# main push. Release install verification repeats the same native proof before publication.
 # Release and CI workflows should run with the narrowest practical default
 # token posture and only permit pinned actions from GitHub or explicitly
 # trusted publishers.

--- a/policy/requirements.toml
+++ b/policy/requirements.toml
@@ -345,9 +345,12 @@ docs = [
 
 [nonfunctional.NFR-004]
 title = "Release provenance validation"
-summary = "Release artifacts, control-plane manifests, and signing metadata must remain validated and reproducible before publication, with the exact asset inventory sealed before any GitHub mutation and uploaded only from its staged read-only content."
+summary = "Release artifacts, control-plane manifests, signing metadata, and source and staging ACL state must remain validated before publication. The exact asset inventory must be sealed before any GitHub mutation and uploaded only from staged read-only content."
 evidence = [
+  "internal/host/release/asset_acl_darwin_test.go",
+  "internal/host/release/asset_acl_linux_test.go",
   "internal/host/release/publisher_test.go",
+  "scripts/ci/job-release-asset-acl.sh",
   "scripts/verify-release-bundle.sh",
   "scripts/verify-control-plane-manifest.sh",
   "scripts/verify-upstream-claude-release.sh",
@@ -359,6 +362,7 @@ docs = [
   "docs/releasing.md",
   "docs/provenance.md",
   "docs/github-workflows.md",
+  "docs/ci-threat-model.md",
 ]
 
 [nonfunctional.NFR-005]

--- a/policy/workflow-lane-policy.json
+++ b/policy/workflow-lane-policy.json
@@ -42,6 +42,12 @@
       "local_script": "scripts/ci/job-pr-shape.sh",
       "local_order": 5
     },
+    "ci.yml/release-asset-acl": {
+      "profiles": ["pr-parity"],
+      "authority": "pr-parity",
+      "local_mode": "none",
+      "github_only_reason": "native Darwin release-asset ACL proof requires the hosted macOS filesystem and the exact Go toolchain"
+    },
     "ci.yml/reproducible-build": {
       "profiles": ["pr-parity"],
       "authority": "pr-parity",

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -136,6 +136,24 @@
       "local_order": 5
     },
     {
+      "id": "ci.yml/release-asset-acl",
+      "workflow_path": ".github/workflows/ci.yml",
+      "workflow_name": "CI",
+      "job_id": "release-asset-acl",
+      "job_name": "Release asset ACL (Darwin)",
+      "workflow_events": [
+        "pull_request",
+        "push",
+        "workflow_dispatch"
+      ],
+      "profiles": [
+        "pr-parity"
+      ],
+      "authority": "pr-parity",
+      "local_mode": "none",
+      "github_only_reason": "native Darwin release-asset ACL proof requires the hosted macOS filesystem and the exact Go toolchain"
+    },
+    {
       "id": "ci.yml/reproducible-build",
       "workflow_path": ".github/workflows/ci.yml",
       "workflow_name": "CI",

--- a/scripts/ci/job-release-asset-acl.sh
+++ b/scripts/ci/job-release-asset-acl.sh
@@ -10,15 +10,41 @@ if [[ ! "${expected_toolchain}" =~ ^go[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 export GOTOOLCHAIN=local
-actual_toolchain="$(go env GOVERSION)"
+
+go_bin="$(command -v go 2>/dev/null || true)"
+if [[ -n "${go_bin}" ]] && [[ "$("${go_bin}" env GOVERSION)" != "${expected_toolchain}" ]]; then
+  go_bin=""
+fi
+if [[ -z "${go_bin}" ]]; then
+  case "$(uname -m)" in
+    arm64 | aarch64)
+      toolcache_arch="arm64"
+      ;;
+    x86_64 | amd64)
+      toolcache_arch="x64"
+      ;;
+    *)
+      echo "Unsupported Go toolcache architecture: $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+  toolcache_root="${RUNNER_TOOL_CACHE:-${AGENT_TOOLSDIRECTORY:-}}"
+  go_bin="${toolcache_root%/}/go/${expected_toolchain#go}/${toolcache_arch}/bin/go"
+fi
+if [[ ! -x "${go_bin}" ]]; then
+  echo "Go toolchain ${expected_toolchain} is unavailable" >&2
+  exit 1
+fi
+
+actual_toolchain="$("${go_bin}" env GOVERSION)"
 if [[ "${actual_toolchain}" != "${expected_toolchain}" ]]; then
   echo "Go toolchain ${actual_toolchain} does not match ${expected_toolchain}" >&2
   exit 1
 fi
-if [[ "$(go env GOOS)" != "darwin" ]]; then
+if [[ "$("${go_bin}" env GOOS)" != "darwin" ]]; then
   echo "Release asset ACL proof requires Darwin" >&2
   exit 1
 fi
 
 cd "${ROOT_DIR}"
-go test ./internal/host/release -run '^TestReleaseAssetACLDarwin$'
+"${go_bin}" test ./internal/host/release -run '^TestReleaseAssetACLDarwin$'

--- a/scripts/ci/job-release-asset-acl.sh
+++ b/scripts/ci/job-release-asset-acl.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+expected_toolchain="$(awk '$1 == "toolchain" { print $2; exit }' "${ROOT_DIR}/go.mod")"
+if [[ ! "${expected_toolchain}" =~ ^go[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "go.mod must declare an exact Go toolchain" >&2
+  exit 1
+fi
+
+export GOTOOLCHAIN=local
+actual_toolchain="$(go env GOVERSION)"
+if [[ "${actual_toolchain}" != "${expected_toolchain}" ]]; then
+  echo "Go toolchain ${actual_toolchain} does not match ${expected_toolchain}" >&2
+  exit 1
+fi
+if [[ "$(go env GOOS)" != "darwin" ]]; then
+  echo "Release asset ACL proof requires Darwin" >&2
+  exit 1
+fi
+
+cd "${ROOT_DIR}"
+go test ./internal/host/release -run '^TestReleaseAssetACLDarwin$'

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -169,6 +169,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/ci/job-mutation.sh"
   "${ROOT_DIR}/scripts/ci/job-pin-hygiene.sh"
   "${ROOT_DIR}/scripts/ci/job-pr-shape.sh"
+  "${ROOT_DIR}/scripts/ci/job-release-asset-acl.sh"
   "${ROOT_DIR}/scripts/ci/job-validate.sh"
   "${ROOT_DIR}/scripts/ci/run-docs-in-validator.sh"
   "${ROOT_DIR}/scripts/ci/run-fuzz-in-validator.sh"

--- a/tools/validator/Dockerfile
+++ b/tools/validator/Dockerfile
@@ -33,6 +33,7 @@ ARG RUSTUP_INIT_LINUX_ARM64_SHA256
 ENV CARGO_HOME=/usr/local/cargo
 ENV PATH=/usr/local/cargo/bin:/usr/local/go/bin:${PATH}
 ENV RUSTUP_HOME=/usr/local/rustup
+ENV WORKCELL_REQUIRE_NATIVE_ACL_TESTS=1
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -109,6 +110,7 @@ RUN mapfile -t debian_bootstrap_pins < /usr/local/share/workcell/debian-bootstra
   && printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99workcell-validator-snapshot \
   && install_validator_packages() { \
        DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+         acl \
          ca-certificates \
          codespell \
          curl \


### PR DESCRIPTION
## Summary

- Reject extended ACLs on release sources, trusted ancestors, and staging handles.
- Add required native Darwin and Linux validator proof.
- Keep workflow, hosted-control, requirements, threat-model, and release contracts aligned.

## Validation

- `./scripts/pre-merge.sh --profile pr-parity`
- `./scripts/ci/job-release-asset-acl.sh`
- `go test ./...`
- `go vet ./...`
- Six-role adversarial review reached a dry result.

## Live certification

An ACL-bearing fixture failed before any tag or release existed. The corrected
candidate published [immutable fixture release
`v0.0.0-rc.5`](https://github.com/omkhar/workcell-release-publisher-certification/releases/tag/v0.0.0-rc.5)
with 18 digest-bearing assets. GitHub verified its signed tag with reason
`valid`.
