### PR TITLE
Redact credential parser diagnostics

### DIFF
--- a/internal/injection/render_credentials.go
+++ b/internal/injection/render_credentials.go
@@ -128,7 +128,7 @@ func validateGeminiEnvFile(source Path) (map[string]any, error) {
 	}
 	for key, value := range values {
 		if _, ok := geminiSupportedEnvKeys[key]; !ok {
-			return nil, fmt.Errorf("unsupported key in Gemini auth env file %s: %s", source, key)
+			return nil, fmt.Errorf("gemini auth env file %s contains an unsupported key", source)
 		}
 		if key != "GOOGLE_GENAI_USE_GCA" && key != "GOOGLE_GENAI_USE_VERTEXAI" && strings.TrimSpace(value) == "" {
 			return nil, fmt.Errorf("gemini auth env file %s sets %s but leaves it empty", source, key)
@@ -206,7 +206,8 @@ func parseSimpleEnvFile(source Path) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, rawLine := range strings.Split(string(data), "\n") {
+	for lineNumber, rawLine := range strings.Split(string(data), "\n") {
+		lineNumber++
 		line := strings.TrimSpace(rawLine)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -216,32 +217,48 @@ func parseSimpleEnvFile(source Path) (map[string]string, error) {
 		}
 		idx := strings.Index(line, "=")
 		if idx < 0 {
-			return nil, fmt.Errorf("malformed Gemini auth env file %s: %s; use KEY=value assignments", source, strings.TrimSpace(rawLine))
+			return nil, fmt.Errorf("malformed Gemini auth env file %s at line %d: use KEY=value assignments", source, lineNumber)
 		}
 		key := strings.TrimSpace(line[:idx])
+		if !validEnvName(key) {
+			return nil, fmt.Errorf("malformed Gemini auth env file %s at line %d: use a valid environment variable name", source, lineNumber)
+		}
 		value := tomlsubset.StripComment(line[idx+1:])
 		if _, exists := values[key]; exists {
-			return nil, fmt.Errorf("gemini auth env file %s configures %s more than once", source, key)
+			return nil, fmt.Errorf("gemini auth env file %s repeats a key at line %d", source, lineNumber)
 		}
 		if value != "" && (value[0] == '\'' || value[0] == '"') {
 			if len(value) < 2 || value[len(value)-1] != value[0] {
-				return nil, fmt.Errorf("malformed Gemini auth env file %s: %s has an unterminated quoted value", source, key)
+				return nil, fmt.Errorf("malformed Gemini auth env file %s at line %d: quoted value is not terminated", source, lineNumber)
 			}
 			if value[0] == '"' {
 				parsed, err := strconv.Unquote(value)
 				if err != nil {
-					return nil, fmt.Errorf("malformed Gemini auth env file %s: %s has an invalid double-quoted value (%v)", source, key, err)
+					return nil, fmt.Errorf("malformed Gemini auth env file %s at line %d: double-quoted value is invalid", source, lineNumber)
 				}
 				value = parsed
 			} else {
 				value = value[1 : len(value)-1]
 			}
 		} else if value != "" && (strings.HasSuffix(value, "'") || strings.HasSuffix(value, "\"")) {
-			return nil, fmt.Errorf("malformed Gemini auth env file %s: %s has an unmatched trailing quote", source, key)
+			return nil, fmt.Errorf("malformed Gemini auth env file %s at line %d: value has an unmatched trailing quote", source, lineNumber)
 		}
 		values[key] = value
 	}
 	return values, nil
+}
+
+func validEnvName(value string) bool {
+	if value == "" {
+		return false
+	}
+	for index, char := range value {
+		if char == '_' || char >= 'A' && char <= 'Z' || char >= 'a' && char <= 'z' || index > 0 && char >= '0' && char <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func parseEnvBooleanValue(values map[string]string, source Path, key string) (bool, error) {
@@ -251,7 +268,7 @@ func parseEnvBooleanValue(values map[string]string, source Path, key string) (bo
 	}
 	normalized := strings.ToLower(strings.TrimSpace(raw))
 	if normalized != "true" && normalized != "false" {
-		return false, fmt.Errorf("invalid boolean in Gemini auth env file %s: %s=%s; use true or false", source, key, raw)
+		return false, fmt.Errorf("invalid boolean in Gemini auth env file %s: %s must be true or false", source, key)
 	}
 	return normalized == "true", nil
 }

--- a/internal/injection/render_credentials_test.go
+++ b/internal/injection/render_credentials_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injection
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseSimpleEnvFileErrorDoesNotEchoRawLine(t *testing.T) {
+	t.Parallel()
+
+	secret := "gemini-secret-marker"
+	path := filepath.Join(t.TempDir(), "gemini.env")
+	if err := os.WriteFile(path, []byte("BROKEN "+secret+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := parseSimpleEnvFile(Path(path))
+	if err == nil {
+		t.Fatal("parseSimpleEnvFile returned nil error for malformed input")
+	}
+	message := err.Error()
+	if strings.Contains(message, secret) {
+		t.Fatalf("parseSimpleEnvFile error echoed secret marker: %q", message)
+	}
+	if !strings.Contains(message, path) || !strings.Contains(message, "line 1") {
+		t.Fatalf("parseSimpleEnvFile error lost source or line context: %q", message)
+	}
+}
+
+func TestParseEnvBooleanValueErrorDoesNotEchoRawValue(t *testing.T) {
+	t.Parallel()
+
+	secret := "gemini-secret-marker"
+	values := map[string]string{"GOOGLE_GENAI_USE_GCA": secret}
+	_, err := parseEnvBooleanValue(values, Path("gemini.env"), "GOOGLE_GENAI_USE_GCA")
+	if err == nil {
+		t.Fatal("parseEnvBooleanValue returned nil error for invalid input")
+	}
+	message := err.Error()
+	if strings.Contains(message, secret) {
+		t.Fatalf("parseEnvBooleanValue error echoed secret marker: %q", message)
+	}
+	if !strings.Contains(message, "gemini.env") || !strings.Contains(message, "GOOGLE_GENAI_USE_GCA") {
+		t.Fatalf("parseEnvBooleanValue error lost source or key context: %q", message)
+	}
+}
+
+func TestGeminiEnvErrorsDoNotEchoUntrustedKeys(t *testing.T) {
+	t.Parallel()
+
+	secret := "GeminiSecretMarker"
+	for _, content := range []string{
+		secret + "=value\n",
+		secret + "='unterminated\n",
+		secret + "=one\n" + secret + "=two\n",
+		secret + "=\"bad\\q\"\n",
+		secret + "=value'\n",
+	} {
+		path := filepath.Join(t.TempDir(), "gemini.env")
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := validateGeminiEnvFile(Path(path))
+		if err == nil {
+			t.Fatal("validateGeminiEnvFile returned nil error for invalid input")
+		}
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("Gemini env error echoed untrusted key: %q", err)
+		}
+	}
+}
+
+func TestValidateGeminiEnvFileAcceptsSupportedAssignment(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "gemini.env")
+	if err := os.WriteFile(path, []byte("GEMINI_API_KEY=valid-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := validateGeminiEnvFile(Path(path))
+	if err != nil {
+		t.Fatalf("validateGeminiEnvFile returned an error: %v", err)
+	}
+	if got := config["selected_auth_type"]; got != "gemini-api-key" {
+		t.Fatalf("selected_auth_type = %q, want gemini-api-key", got)
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -236,7 +236,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/home-control-plane.sh",
       "runtime_path": "/usr/local/libexec/workcell/home-control-plane.sh",
-      "sha256": "14be1e743aaa9c8bb12501ef8ea2a7eca7c0a7f8ca1da73d19c940c73ee5ebf6"
+      "sha256": "33214b64eab7e7e641608aa3aea4aebf002e2c46df55152cc0cf369dfef25059"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -700,22 +700,166 @@ workcell_trim_trailing_whitespace() {
   printf '%s' "${value%"${value##*[![:space:]]}"}"
 }
 
+# The host Go check runs before credentials cross into this container.
+# No Go policy binary ships here. This immutable script rechecks copied bytes
+# before provider launch. Fixed jq decodes values. The extracted Bash harness
+# checks parity and redaction.
+workcell_gemini_env_strip_comment() {
+  local raw_value="$1"
+  local value=""
+  local character=""
+  local quote=""
+  local backslash="\\"
+  local escaped=0
+  local index=0
+
+  while [[ "${index}" -lt "${#raw_value}" ]]; do
+    character="${raw_value:${index}:1}"
+    if [[ "${escaped}" == "1" ]]; then
+      value+="${character}"
+      escaped=0
+    elif [[ "${character}" == "${backslash}" && "${quote}" == '"' ]]; then
+      value+="${character}"
+      escaped=1
+    elif [[ "${character}" == "'" || "${character}" == '"' ]]; then
+      if [[ -z "${quote}" ]]; then
+        quote="${character}"
+      elif [[ "${quote}" == "${character}" ]]; then
+        quote=""
+      fi
+      value+="${character}"
+    elif [[ "${character}" == "#" && -z "${quote}" ]]; then
+      break
+    else
+      value+="${character}"
+    fi
+    index=$((index + 1))
+  done
+
+  value="$(workcell_trim_trailing_whitespace "$(workcell_trim_leading_whitespace "${value}")")"
+  printf '%s\n' "${value}"
+}
+
+workcell_gemini_env_double_quote_escapes_are_safe() {
+  local value="$1"
+  local value_length="${#value}"
+  local character=""
+  local next_character=""
+  local unicode_escape=""
+  local index=1
+
+  while [[ "${index}" -lt "$((value_length - 1))" ]]; do
+    character="${value:${index}:1}"
+    if [[ "${character}" == "\\" ]]; then
+      index=$((index + 1))
+      [[ "${index}" -lt "$((value_length - 1))" ]] || return 0
+      next_character="${value:${index}:1}"
+      case "${next_character}" in
+        /)
+          return 1
+          ;;
+        u)
+          unicode_escape="${value:$((index + 1)):4}"
+          case "${unicode_escape}" in
+            0000 | [Dd][89A-Fa-f][0-9A-Fa-f][0-9A-Fa-f])
+              return 1
+              ;;
+          esac
+          index=$((index + 4))
+          ;;
+      esac
+    fi
+    index=$((index + 1))
+  done
+
+  return 0
+}
+
+workcell_gemini_env_assignment_value() {
+  local env_path="$1"
+  local line_number="$2"
+  local raw_value="$3"
+  local value=""
+  local value_length=0
+
+  value="$(workcell_gemini_env_strip_comment "${raw_value}")"
+  [[ -n "${value}" ]] || {
+    printf '\n'
+    return 0
+  }
+
+  value_length="${#value}"
+  case "${value:0:1}" in
+    '"')
+      if [[ "${value_length}" -lt "2" ]] || [[ "${value:${value_length}-1:1}" != '"' ]]; then
+        workcell_die "Malformed Gemini auth env file ${env_path} at line ${line_number}. Use KEY=value assignments."
+      fi
+      # Use the common Go and JSON escape grammar. JSON accepts `\/`, but Go
+      # rejects it. Reject other Go-only escapes rather than reinterpret them.
+      # Bash command substitution removes NUL bytes. Reject them before jq
+      # decodes one, or a selector such as tr\\u0000ue becomes true.
+      # Reject JSON-only slash escapes and all surrogate escapes. The scanner
+      # consumes backslash pairs, so valid literal backslash text stays valid.
+      if ! workcell_gemini_env_double_quote_escapes_are_safe "${value}"; then
+        workcell_die "Malformed Gemini auth env file ${env_path} at line ${line_number}. Use KEY=value assignments."
+      fi
+      # Reject jq's invalid-byte replacement before decoding. A literal U+FFFD
+      # is deliberately stricter than the host parser. An escaped U+FFFD works.
+      if ! value="$(printf '%s' "${value}" | jq -Rer 'select((explode | index(65533)) == null) | fromjson' 2>/dev/null)"; then
+        workcell_die "Malformed Gemini auth env file ${env_path} at line ${line_number}. Use KEY=value assignments."
+      fi
+      ;;
+    "'")
+      if [[ "${value_length}" -lt "2" ]] || [[ "${value:${value_length}-1:1}" != "'" ]]; then
+        workcell_die "Malformed Gemini auth env file ${env_path} at line ${line_number}. Use KEY=value assignments."
+      fi
+      value="${value:1:$((value_length - 2))}"
+      ;;
+    *)
+      if [[ "${value:${value_length}-1:1}" == "'" || "${value:${value_length}-1:1}" == '"' ]]; then
+        workcell_die "Malformed Gemini auth env file ${env_path} at line ${line_number}. Use KEY=value assignments."
+      fi
+      ;;
+  esac
+
+  printf '%s\n' "${value}"
+}
+
+workcell_gemini_env_value_is_blank() {
+  local value="$1"
+
+  # Keep this set equal to Go strings.TrimSpace: ASCII whitespace, U+0085,
+  # U+00A0, U+1680, U+2000 through U+200A, U+2028, U+2029, U+202F, U+205F,
+  # and U+3000.
+  printf '%s' "${value}" | jq -Rse '
+    explode | all(
+      . == 9 or . == 10 or . == 11 or . == 12 or . == 13 or . == 32 or
+      . == 133 or . == 160 or . == 5760 or
+      (. >= 8192 and . <= 8202) or
+      . == 8232 or . == 8233 or . == 8239 or . == 8287 or . == 12288
+    )
+  ' >/dev/null
+}
+
 workcell_env_file_assignment_value() {
   local env_path="$1"
   local expected_key="$2"
   local line=""
   local parsed_key=""
   local value=""
+  local line_number=0
 
   [[ -f "${env_path}" ]] || return 1
 
+  # shellcheck disable=SC2094 # The loop never writes the input file.
   while IFS= read -r line || [[ -n "${line}" ]]; do
+    line_number=$((line_number + 1))
     line="${line%$'\r'}"
     line="$(workcell_trim_leading_whitespace "${line}")"
     [[ -n "${line}" ]] || continue
     [[ "${line}" == \#* ]] && continue
 
-    if [[ "${line}" == export[[:space:]]* ]]; then
+    if [[ "${line}" == "export "* ]]; then
       line="${line#export}"
       line="$(workcell_trim_leading_whitespace "${line}")"
     fi
@@ -725,16 +869,8 @@ workcell_env_file_assignment_value() {
       value="${BASH_REMATCH[2]}"
       [[ "${parsed_key}" == "${expected_key}" ]] || continue
 
-      value="$(workcell_trim_trailing_whitespace "$(workcell_trim_leading_whitespace "${value}")")"
-
-      if [[ "${value}" =~ ^\"(.*)\"[[:space:]]*(#.*)?$ ]]; then
-        value="${BASH_REMATCH[1]}"
-      elif [[ "${value}" =~ ^\'(.*)\'[[:space:]]*(#.*)?$ ]]; then
-        value="${BASH_REMATCH[1]}"
-      else
-        value="${value%%#*}"
-        value="$(workcell_trim_trailing_whitespace "$(workcell_trim_leading_whitespace "${value}")")"
-      fi
+      # shellcheck disable=SC2094 # The helper reads arguments and writes only stdout.
+      value="$(workcell_gemini_env_assignment_value "${env_path}" "${line_number}" "${value}")" || return 1
 
       printf '%s\n' "${value}"
       return 0
@@ -758,7 +894,7 @@ workcell_env_file_has_assignment_key() {
     [[ -n "${line}" ]] || continue
     [[ "${line}" == \#* ]] && continue
 
-    if [[ "${line}" == export[[:space:]]* ]]; then
+    if [[ "${line}" == "export "* ]]; then
       line="${line#export}"
       line="$(workcell_trim_leading_whitespace "${line}")"
     fi
@@ -778,8 +914,8 @@ workcell_env_file_boolean_value() {
   local expected_key="$2"
   local value=""
 
-  value="$(workcell_env_file_assignment_value "${env_path}" "${expected_key}" || true)"
-  [[ -n "${value}" ]] || return 1
+  workcell_env_file_has_assignment_key "${env_path}" "${expected_key}" || return 1
+  value="$(workcell_env_file_assignment_value "${env_path}" "${expected_key}")" || return 1
   value="$(printf '%s' "${value}" | tr '[:upper:]' '[:lower:]')"
 
   case "${value}" in
@@ -788,7 +924,7 @@ workcell_env_file_boolean_value() {
       return 0
       ;;
     *)
-      workcell_die "Invalid boolean in Gemini auth env file ${env_path}: ${expected_key}=${value}. Use true or false."
+      workcell_die "Invalid boolean in Gemini auth env file ${env_path} for ${expected_key}. Use true or false."
       ;;
   esac
 }
@@ -835,52 +971,53 @@ workcell_validate_gemini_env_file_syntax() {
   local line=""
   local parsed_key=""
   local value=""
+  local line_number=0
   # Keep duplicate-key tracking compatible with host-side Bash 3.2 invariant runs.
   local seen_keys=$'\n'
 
   [[ -f "${env_path}" ]] || return 0
 
+  # Bash read drops NUL bytes. Reject them before it processes the file.
+  if ! jq -n -e --rawfile env_file "${env_path}" '$env_file | explode | index(0) == null' >/dev/null 2>&1; then
+    workcell_die "Malformed Gemini auth env file ${env_path}. Use KEY=value assignments."
+  fi
+
+  # shellcheck disable=SC2094 # The loop never writes the input file.
   while IFS= read -r line || [[ -n "${line}" ]]; do
+    line_number=$((line_number + 1))
     line="${line%$'\r'}"
     line="$(workcell_trim_leading_whitespace "${line}")"
     [[ -n "${line}" ]] || continue
     [[ "${line}" == \#* ]] && continue
 
-    if [[ "${line}" == export[[:space:]]* ]]; then
+    if [[ "${line}" == "export "* ]]; then
       line="${line#export}"
       line="$(workcell_trim_leading_whitespace "${line}")"
     fi
 
     if ! [[ "${line}" =~ ^([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*(.*)$ ]]; then
-      workcell_die "Malformed Gemini auth env file ${env_path}: ${line}. Use KEY=value assignments."
+      workcell_die "Malformed Gemini auth env file ${env_path} at line ${line_number}. Use KEY=value assignments."
     fi
 
     parsed_key="${BASH_REMATCH[1]}"
     value="${BASH_REMATCH[2]}"
+    if ! workcell_gemini_env_key_is_supported "${parsed_key}"; then
+      workcell_die "Unsupported key in Gemini auth env file ${env_path} at line ${line_number}."
+    fi
+
     case "${seen_keys}" in
       *$'\n'"${parsed_key}"$'\n'*)
-        workcell_die "Gemini auth env file ${env_path} configures ${parsed_key} more than once."
+        workcell_die "Gemini auth env file ${env_path} configures ${parsed_key} more than once at line ${line_number}."
         ;;
     esac
     seen_keys+="${parsed_key}"$'\n'
 
-    if ! workcell_gemini_env_key_is_supported "${parsed_key}"; then
-      workcell_die "Unsupported key in Gemini auth env file ${env_path}: ${parsed_key}."
-    fi
-
-    value="$(workcell_trim_trailing_whitespace "$(workcell_trim_leading_whitespace "${value}")")"
-    if [[ "${value}" =~ ^\"(.*)\"[[:space:]]*(#.*)?$ ]]; then
-      value="${BASH_REMATCH[1]}"
-    elif [[ "${value}" =~ ^\'(.*)\'[[:space:]]*(#.*)?$ ]]; then
-      value="${BASH_REMATCH[1]}"
-    else
-      value="${value%%#*}"
-      value="$(workcell_trim_trailing_whitespace "$(workcell_trim_leading_whitespace "${value}")")"
-    fi
+    # shellcheck disable=SC2094 # The helper reads arguments and writes only stdout.
+    value="$(workcell_gemini_env_assignment_value "${env_path}" "${line_number}" "${value}")" || return 1
 
     case "${parsed_key}" in
       GEMINI_API_KEY | GOOGLE_API_KEY | GOOGLE_CLOUD_PROJECT | GOOGLE_CLOUD_PROJECT_ID | GOOGLE_CLOUD_LOCATION | GOOGLE_CLOUD_REGION | CLOUD_ML_REGION | VERTEX_LOCATION | VERTEX_AI_LOCATION)
-        if [[ -z "${value}" ]]; then
+        if workcell_gemini_env_value_is_blank "${value}"; then
           workcell_die "Gemini auth env file ${env_path} sets ${parsed_key} but leaves it empty."
         fi
         ;;
@@ -899,11 +1036,19 @@ workcell_validate_gemini_env_auth_config() {
 
   [[ -f "${env_path}" ]] || return 0
 
-  workcell_validate_gemini_env_file_syntax "${env_path}"
-  gca_value="$(workcell_env_file_boolean_value "${env_path}" "GOOGLE_GENAI_USE_GCA" || true)"
-  vertex_value="$(workcell_env_file_boolean_value "${env_path}" "GOOGLE_GENAI_USE_VERTEXAI" || true)"
-  gemini_api_key="$(workcell_env_file_assignment_value "${env_path}" "GEMINI_API_KEY" || true)"
-  google_api_key="$(workcell_env_file_assignment_value "${env_path}" "GOOGLE_API_KEY" || true)"
+  workcell_validate_gemini_env_file_syntax "${env_path}" || return 1
+  if workcell_env_file_has_assignment_key "${env_path}" "GOOGLE_GENAI_USE_GCA"; then
+    gca_value="$(workcell_env_file_boolean_value "${env_path}" "GOOGLE_GENAI_USE_GCA")" || return 1
+  fi
+  if workcell_env_file_has_assignment_key "${env_path}" "GOOGLE_GENAI_USE_VERTEXAI"; then
+    vertex_value="$(workcell_env_file_boolean_value "${env_path}" "GOOGLE_GENAI_USE_VERTEXAI")" || return 1
+  fi
+  if workcell_env_file_has_assignment_key "${env_path}" "GEMINI_API_KEY"; then
+    gemini_api_key="$(workcell_env_file_assignment_value "${env_path}" "GEMINI_API_KEY")" || return 1
+  fi
+  if workcell_env_file_has_assignment_key "${env_path}" "GOOGLE_API_KEY"; then
+    google_api_key="$(workcell_env_file_assignment_value "${env_path}" "GOOGLE_API_KEY")" || return 1
+  fi
 
   if [[ "${gca_value}" == "true" ]] && [[ "${vertex_value}" == "true" ]]; then
     workcell_die "Gemini auth env file ${env_path} enables both GOOGLE_GENAI_USE_GCA and GOOGLE_GENAI_USE_VERTEXAI. Choose exactly one auth selector."
@@ -1001,7 +1146,8 @@ workcell_env_file_value_is_true() {
   local expected_key="$2"
   local value=""
 
-  value="$(workcell_env_file_boolean_value "${env_path}" "${expected_key}" || true)"
+  workcell_env_file_has_assignment_key "${env_path}" "${expected_key}" || return 1
+  value="$(workcell_env_file_boolean_value "${env_path}" "${expected_key}")" || return 1
   [[ "${value}" == "true" ]]
 }
 
@@ -1011,6 +1157,8 @@ workcell_gemini_selected_auth_type_from_env_file() {
 
   [[ -f "${env_path}" ]] || return 1
 
+  workcell_validate_gemini_env_auth_config "${env_path}" || return 1
+
   if workcell_env_file_value_is_true "${env_path}" "GOOGLE_GENAI_USE_GCA"; then
     printf 'oauth-personal\n'
     return 0
@@ -1019,7 +1167,9 @@ workcell_gemini_selected_auth_type_from_env_file() {
     printf 'vertex-ai\n'
     return 0
   fi
-  env_value="$(workcell_env_file_assignment_value "${env_path}" "GEMINI_API_KEY" || true)"
+  if workcell_env_file_has_assignment_key "${env_path}" "GEMINI_API_KEY"; then
+    env_value="$(workcell_env_file_assignment_value "${env_path}" "GEMINI_API_KEY")" || return 1
+  fi
   if [[ -n "${env_value}" ]]; then
     printf 'gemini-api-key\n'
     return 0
@@ -1033,7 +1183,9 @@ workcell_gemini_selected_auth_type() {
   local oauth_path="$2"
   local selected_auth_type=""
 
-  selected_auth_type="$(workcell_gemini_selected_auth_type_from_env_file "${env_path}" || true)"
+  if [[ -f "${env_path}" ]]; then
+    selected_auth_type="$(workcell_gemini_selected_auth_type_from_env_file "${env_path}")" || return 1
+  fi
   if [[ -z "${selected_auth_type}" ]] && [[ -f "${oauth_path}" ]]; then
     selected_auth_type="oauth-personal"
   fi

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -8553,7 +8553,17 @@ GEMINI_AUTH_SELECTION_STDERR="$(mktemp)"
   printf '\n'
   extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_trim_trailing_whitespace
   printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_gemini_env_strip_comment
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_gemini_env_double_quote_escapes_are_safe
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_gemini_env_assignment_value
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_gemini_env_value_is_blank
+  printf '\n'
   extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_env_file_assignment_value
+  printf '\n'
+  extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_env_file_has_assignment_key
   printf '\n'
   extract_top_level_bash_function "${ROOT_DIR}/runtime/container/home-control-plane.sh" workcell_gemini_env_key_is_supported
   printf '\n'

--- a/verify/invariants/harnesses/gemini-auth-selection.sh
+++ b/verify/invariants/harnesses/gemini-auth-selection.sh
@@ -20,11 +20,24 @@ expect_fatal_function_failure() {
   local stderr_path="$2"
   shift 2
 
-  if ( "$@" ) >"${stdout_path}" 2>"${stderr_path}"; then
+  if (
+    set +x
+    "$@"
+  ) >"${stdout_path}" 2>"${stderr_path}"; then
     return 0
   fi
 
   return 1
+}
+
+expect_stderr_to_omit() {
+  local stderr_path="$1"
+  local marker="$2"
+
+  if grep -Fq "${marker}" "${stderr_path}"; then
+    echo "Gemini auth error leaked credential-file content" >&2
+    exit 1
+  fi
 }
 
 expect_auth_type() {
@@ -52,12 +65,37 @@ expect_auth_type() {
 
 expect_auth_type 'GEMINI_API_KEY=test-key' 0 'gemini-api-key'
 expect_auth_type ' export GEMINI_API_KEY = "quoted-key" # comment' 0 'gemini-api-key'
+expect_auth_type 'GOOGLE_GENAI_USE_GCA="tr\u0075e"' 0 'oauth-personal'
 expect_auth_type $'GOOGLE_GENAI_USE_GCA=true\nGEMINI_API_KEY=test-key' 0 'oauth-personal'
 expect_auth_type $'GOOGLE_GENAI_USE_GCA="true" # comment\nGOOGLE_CLOUD_PROJECT=my-proj' 0 'oauth-personal'
 expect_auth_type $'GOOGLE_GENAI_USE_VERTEXAI="true" # comment\nGOOGLE_CLOUD_PROJECT=my-proj\nGOOGLE_CLOUD_LOCATION="us-central1" # comment' 0 'vertex-ai'
 expect_auth_type $'GOOGLE_GENAI_USE_VERTEXAI=true\nGOOGLE_API_KEY=vertex-key' 0 'vertex-ai'
 expect_auth_type $'GEMINI_API_KEY=test-key\nGOOGLE_CLOUD_PROJECT=my-proj' 0 'gemini-api-key'
 expect_auth_type '' 1 'oauth-personal'
+
+printf 'GEMINI_API_KEY="decoded\\u002dkey"\n' >"${TMP_DIR}/quoted-escape.env"
+if [[ "$(workcell_env_file_assignment_value "${TMP_DIR}/quoted-escape.env" "GEMINI_API_KEY")" != "decoded-key" ]]; then
+  echo "Expected Gemini double-quoted escapes to decode before auth selection" >&2
+  exit 1
+fi
+
+printf '%s\n' 'GEMINI_API_KEY="literal\\uD800"' >"${TMP_DIR}/literal-surrogate-escape.env"
+if [[ "$(workcell_env_file_assignment_value "${TMP_DIR}/literal-surrogate-escape.env" "GEMINI_API_KEY")" != 'literal\uD800' ]]; then
+  echo "Expected literal Gemini backslash Unicode escapes to remain valid" >&2
+  exit 1
+fi
+
+printf '%s\n' 'GEMINI_API_KEY="literal\\u0000"' >"${TMP_DIR}/literal-nul-escape.env"
+if [[ "$(workcell_env_file_assignment_value "${TMP_DIR}/literal-nul-escape.env" "GEMINI_API_KEY")" != 'literal\u0000' ]]; then
+  echo "Expected literal Gemini backslash NUL escapes to remain valid" >&2
+  exit 1
+fi
+
+printf '%s\n' 'GEMINI_API_KEY="literal\\/"' >"${TMP_DIR}/literal-slash-escape.env"
+if [[ "$(workcell_env_file_assignment_value "${TMP_DIR}/literal-slash-escape.env" "GEMINI_API_KEY")" != 'literal\/' ]]; then
+  echo "Expected literal Gemini backslash slash text to remain valid" >&2
+  exit 1
+fi
 
 printf 'GOOGLE_API_KEY=test-key\n' >"${TMP_DIR}/google-api-key-only.env"
 if workcell_gemini_selected_auth_type "${TMP_DIR}/google-api-key-only.env" "${TMP_DIR}/missing-oauth.json" >/dev/null 2>&1; then
@@ -70,37 +108,228 @@ if workcell_gemini_selected_auth_type "${TMP_DIR}/missing.env" "${TMP_DIR}/missi
   exit 1
 fi
 
-printf 'GOOGLE_GENAI_USE_GCA=maybe\n' >"${TMP_DIR}/invalid-bool.env"
+printf 'GOOGLE_GENAI_USE_GCA=invalid-boolean-secret\n' >"${TMP_DIR}/invalid-bool.env"
 if expect_fatal_function_failure /tmp/gemini-invalid-bool.stdout /tmp/gemini-invalid-bool.stderr \
   workcell_validate_gemini_env_auth_config "${TMP_DIR}/invalid-bool.env"; then
   echo "Expected invalid Gemini auth booleans to be rejected" >&2
   exit 1
 fi
 grep -q 'Invalid boolean in Gemini auth env file' /tmp/gemini-invalid-bool.stderr
+grep -q 'GOOGLE_GENAI_USE_GCA' /tmp/gemini-invalid-bool.stderr
+expect_stderr_to_omit /tmp/gemini-invalid-bool.stderr 'invalid-boolean-secret'
 
-printf 'GOOGLE_GENAI_USE_VERTEXAI true\n' >"${TMP_DIR}/malformed.env"
+printf 'GOOGLE_GENAI_USE_VERTEXAI raw-malformed-secret\n' >"${TMP_DIR}/malformed.env"
 if expect_fatal_function_failure /tmp/gemini-malformed.stdout /tmp/gemini-malformed.stderr \
   workcell_validate_gemini_env_auth_config "${TMP_DIR}/malformed.env"; then
   echo "Expected malformed Gemini auth env syntax to be rejected" >&2
   exit 1
 fi
 grep -q 'Malformed Gemini auth env file' /tmp/gemini-malformed.stderr
+grep -q 'line 1' /tmp/gemini-malformed.stderr
+expect_stderr_to_omit /tmp/gemini-malformed.stderr 'raw-malformed-secret'
 
-printf 'UNSUPPORTED_KEY=test\n' >"${TMP_DIR}/unsupported.env"
+printf 'UNSUPPORTED_SECRET_KEY=unsupported-value-secret\n' >"${TMP_DIR}/unsupported.env"
 if expect_fatal_function_failure /tmp/gemini-unsupported.stdout /tmp/gemini-unsupported.stderr \
   workcell_validate_gemini_env_auth_config "${TMP_DIR}/unsupported.env"; then
   echo "Expected unsupported Gemini auth env keys to be rejected" >&2
   exit 1
 fi
 grep -q 'Unsupported key in Gemini auth env file' /tmp/gemini-unsupported.stderr
+grep -q 'line 1' /tmp/gemini-unsupported.stderr
+expect_stderr_to_omit /tmp/gemini-unsupported.stderr 'UNSUPPORTED_SECRET_KEY'
+expect_stderr_to_omit /tmp/gemini-unsupported.stderr 'unsupported-value-secret'
 
-printf 'GEMINI_API_KEY=one\nGEMINI_API_KEY=two\n' >"${TMP_DIR}/duplicate-api-key.env"
+printf 'GEMINI_API_KEY=duplicate-one-secret\nGEMINI_API_KEY=duplicate-two-secret\n' >"${TMP_DIR}/duplicate-api-key.env"
 if expect_fatal_function_failure /tmp/gemini-duplicate-api-key.stdout /tmp/gemini-duplicate-api-key.stderr \
   workcell_validate_gemini_env_auth_config "${TMP_DIR}/duplicate-api-key.env"; then
   echo "Expected duplicate GEMINI_API_KEY assignments to be rejected" >&2
   exit 1
 fi
 grep -q 'configures GEMINI_API_KEY more than once' /tmp/gemini-duplicate-api-key.stderr
+grep -q 'line 2' /tmp/gemini-duplicate-api-key.stderr
+expect_stderr_to_omit /tmp/gemini-duplicate-api-key.stderr 'duplicate-one-secret'
+expect_stderr_to_omit /tmp/gemini-duplicate-api-key.stderr 'duplicate-two-secret'
+
+printf 'GEMINI_API_KEY="unterminated-quote-secret\n' >"${TMP_DIR}/unterminated-quote.env"
+if expect_fatal_function_failure /tmp/gemini-unterminated-quote.stdout /tmp/gemini-unterminated-quote.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/unterminated-quote.env"; then
+  echo "Expected unterminated Gemini auth quotes to be rejected" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-unterminated-quote.stderr
+grep -q 'line 1' /tmp/gemini-unterminated-quote.stderr
+expect_stderr_to_omit /tmp/gemini-unterminated-quote.stderr 'unterminated-quote-secret'
+
+printf "GEMINI_API_KEY=trailing-quote-secret'\n" >"${TMP_DIR}/trailing-quote.env"
+if expect_fatal_function_failure /tmp/gemini-trailing-quote.stdout /tmp/gemini-trailing-quote.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/trailing-quote.env"; then
+  echo "Expected trailing Gemini auth quotes to be rejected" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-trailing-quote.stderr
+grep -q 'line 1' /tmp/gemini-trailing-quote.stderr
+expect_stderr_to_omit /tmp/gemini-trailing-quote.stderr 'trailing-quote-secret'
+
+printf 'GEMINI_API_KEY="invalid-double-escape-secret\\q"\n' >"${TMP_DIR}/invalid-escape.env"
+if expect_fatal_function_failure /tmp/gemini-invalid-escape.stdout /tmp/gemini-invalid-escape.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/invalid-escape.env"; then
+  echo "Expected invalid Gemini double-quoted escapes to be rejected" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-invalid-escape.stderr
+grep -q 'line 1' /tmp/gemini-invalid-escape.stderr
+expect_stderr_to_omit /tmp/gemini-invalid-escape.stderr 'invalid-double-escape-secret'
+
+printf '%s\n' 'GEMINI_API_KEY="json-only-slash-escape-secret\/"' >"${TMP_DIR}/json-only-slash-escape.env"
+if expect_fatal_function_failure /tmp/gemini-json-only-slash-escape.stdout /tmp/gemini-json-only-slash-escape.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/json-only-slash-escape.env"; then
+  echo "Expected JSON-only Gemini double-quoted slash escapes to be rejected" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-json-only-slash-escape.stderr
+grep -q 'line 1' /tmp/gemini-json-only-slash-escape.stderr
+expect_stderr_to_omit /tmp/gemini-json-only-slash-escape.stderr 'json-only-slash-escape-secret'
+
+printf 'GEMINI_API_KEY="go-only-hex-escape-secret\\x61"\n' >"${TMP_DIR}/go-only-escape.env"
+if expect_fatal_function_failure /tmp/gemini-go-only-escape.stdout /tmp/gemini-go-only-escape.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/go-only-escape.env"; then
+  echo "Expected Go-only Gemini double-quoted escapes to be rejected" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-go-only-escape.stderr
+grep -q 'line 1' /tmp/gemini-go-only-escape.stderr
+expect_stderr_to_omit /tmp/gemini-go-only-escape.stderr 'go-only-hex-escape-secret'
+
+printf 'GEMINI_API_KEY="unpaired-surrogate-secret\\uD800"\n' >"${TMP_DIR}/unpaired-surrogate.env"
+if expect_fatal_function_failure /tmp/gemini-unpaired-surrogate.stdout /tmp/gemini-unpaired-surrogate.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/unpaired-surrogate.env"; then
+  echo "Expected Gemini double-quoted surrogate escapes to be rejected" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-unpaired-surrogate.stderr
+grep -q 'line 1' /tmp/gemini-unpaired-surrogate.stderr
+expect_stderr_to_omit /tmp/gemini-unpaired-surrogate.stderr 'unpaired-surrogate-secret'
+
+printf 'GEMINI_API_KEY="low-surrogate-secret\\uDFFF"\n' >"${TMP_DIR}/low-surrogate.env"
+if expect_fatal_function_failure /tmp/gemini-low-surrogate.stdout /tmp/gemini-low-surrogate.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/low-surrogate.env"; then
+  echo "Expected Gemini low-surrogate escapes to be rejected" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-low-surrogate.stderr
+grep -q 'line 1' /tmp/gemini-low-surrogate.stderr
+expect_stderr_to_omit /tmp/gemini-low-surrogate.stderr 'low-surrogate-secret'
+
+printf 'GEMINI_API_KEY="escaped-ufffd\\uFFFD"\n' >"${TMP_DIR}/escaped-ufffd.env"
+if ! workcell_validate_gemini_env_auth_config "${TMP_DIR}/escaped-ufffd.env" >/tmp/gemini-escaped-ufffd.stdout 2>/tmp/gemini-escaped-ufffd.stderr; then
+  echo "Expected escaped Gemini U+FFFD to remain valid" >&2
+  exit 1
+fi
+
+{
+  printf 'GEMINI_API_KEY="invalid-byte-prefix-secret-'
+  printf '\377'
+  printf '%s\n' '-invalid-byte-suffix-secret"'
+} >"${TMP_DIR}/invalid-utf8.env"
+if expect_fatal_function_failure /tmp/gemini-invalid-utf8.stdout /tmp/gemini-invalid-utf8.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/invalid-utf8.env"; then
+  echo "Expected Gemini env files with invalid UTF-8 to be rejected" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-invalid-utf8.stderr
+grep -q 'line 1' /tmp/gemini-invalid-utf8.stderr
+expect_stderr_to_omit /tmp/gemini-invalid-utf8.stderr 'invalid-byte-prefix-secret'
+expect_stderr_to_omit /tmp/gemini-invalid-utf8.stderr 'invalid-byte-suffix-secret'
+
+printf 'GEMINI_API_KEY="embedded-quote-secret"suffix"\n' >"${TMP_DIR}/embedded-quote.env"
+if expect_fatal_function_failure /tmp/gemini-embedded-quote.stdout /tmp/gemini-embedded-quote.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/embedded-quote.env"; then
+  echo "Expected embedded Gemini double quotes to be rejected" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-embedded-quote.stderr
+grep -q 'line 1' /tmp/gemini-embedded-quote.stderr
+expect_stderr_to_omit /tmp/gemini-embedded-quote.stderr 'embedded-quote-secret'
+
+printf 'export\tGEMINI_API_KEY=export-tab-secret\n' >"${TMP_DIR}/export-tab.env"
+if expect_fatal_function_failure /tmp/gemini-export-tab.stdout /tmp/gemini-export-tab.stderr \
+  workcell_validate_gemini_env_auth_config "${TMP_DIR}/export-tab.env"; then
+  echo "Expected tab-delimited export Gemini env syntax to be rejected" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-export-tab.stderr
+grep -q 'line 1' /tmp/gemini-export-tab.stderr
+expect_stderr_to_omit /tmp/gemini-export-tab.stderr 'export-tab-secret'
+
+printf 'GOOGLE_GENAI_USE_GCA=invalid-gca-fallback-secret\nGEMINI_API_KEY=valid-fallback-key\n' >"${TMP_DIR}/invalid-gca-fallback.env"
+if expect_fatal_function_failure /tmp/gemini-invalid-gca-fallback.stdout /tmp/gemini-invalid-gca-fallback.stderr \
+  workcell_gemini_selected_auth_type "${TMP_DIR}/invalid-gca-fallback.env" "${TMP_DIR}/missing-oauth.json"; then
+  echo "Expected invalid Google Code Assist selector to block Gemini API key fallback" >&2
+  exit 1
+fi
+grep -q 'Invalid boolean in Gemini auth env file' /tmp/gemini-invalid-gca-fallback.stderr
+grep -q 'GOOGLE_GENAI_USE_GCA' /tmp/gemini-invalid-gca-fallback.stderr
+expect_stderr_to_omit /tmp/gemini-invalid-gca-fallback.stderr 'invalid-gca-fallback-secret'
+expect_stderr_to_omit /tmp/gemini-invalid-gca-fallback.stderr 'valid-fallback-key'
+
+printf 'GOOGLE_GENAI_USE_GCA="tr\\u0000ue" # selector-nul-secret\nGEMINI_API_KEY=valid-nul-fallback-key\n' >"${TMP_DIR}/nul-selector-fallback.env"
+if expect_fatal_function_failure /tmp/gemini-nul-selector-fallback.stdout /tmp/gemini-nul-selector-fallback.stderr \
+  workcell_gemini_selected_auth_type "${TMP_DIR}/nul-selector-fallback.env" "${TMP_DIR}/missing-oauth.json"; then
+  echo "Expected Gemini selector NUL escapes to block API key fallback" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-nul-selector-fallback.stderr
+grep -q 'line 1' /tmp/gemini-nul-selector-fallback.stderr
+expect_stderr_to_omit /tmp/gemini-nul-selector-fallback.stderr 'selector-nul-secret'
+expect_stderr_to_omit /tmp/gemini-nul-selector-fallback.stderr 'valid-nul-fallback-key'
+
+{
+  printf 'GOOGLE_GENAI_USE_GCA=tr'
+  printf '\0'
+  printf '%s\n' 'ue # raw-nul-selector-secret'
+  printf '%s\n' 'GEMINI_API_KEY=valid-raw-nul-fallback-key'
+} >"${TMP_DIR}/raw-nul-selector-fallback.env"
+if expect_fatal_function_failure /tmp/gemini-raw-nul-selector-fallback.stdout /tmp/gemini-raw-nul-selector-fallback.stderr \
+  workcell_gemini_selected_auth_type "${TMP_DIR}/raw-nul-selector-fallback.env" "${TMP_DIR}/missing-oauth.json"; then
+  echo "Expected raw Gemini selector NUL bytes to block API key fallback" >&2
+  exit 1
+fi
+grep -q 'Malformed Gemini auth env file' /tmp/gemini-raw-nul-selector-fallback.stderr
+expect_stderr_to_omit /tmp/gemini-raw-nul-selector-fallback.stderr 'raw-nul-selector-secret'
+expect_stderr_to_omit /tmp/gemini-raw-nul-selector-fallback.stderr 'valid-raw-nul-fallback-key'
+
+printf 'GOOGLE_GENAI_USE_VERTEXAI=invalid-vertex-fallback-secret\nGEMINI_API_KEY=valid-fallback-key\n' >"${TMP_DIR}/invalid-vertex-fallback.env"
+if expect_fatal_function_failure /tmp/gemini-invalid-vertex-fallback.stdout /tmp/gemini-invalid-vertex-fallback.stderr \
+  workcell_gemini_selected_auth_type "${TMP_DIR}/invalid-vertex-fallback.env" "${TMP_DIR}/missing-oauth.json"; then
+  echo "Expected invalid Vertex selector to block Gemini API key fallback" >&2
+  exit 1
+fi
+grep -q 'Invalid boolean in Gemini auth env file' /tmp/gemini-invalid-vertex-fallback.stderr
+grep -q 'GOOGLE_GENAI_USE_VERTEXAI' /tmp/gemini-invalid-vertex-fallback.stderr
+expect_stderr_to_omit /tmp/gemini-invalid-vertex-fallback.stderr 'invalid-vertex-fallback-secret'
+expect_stderr_to_omit /tmp/gemini-invalid-vertex-fallback.stderr 'valid-fallback-key'
+
+printf 'GEMINI_API_KEY="   " # whitespace-only-api-secret\n' >"${TMP_DIR}/whitespace-api-key.env"
+printf '{}\n' >"${TMP_DIR}/whitespace-api-key-oauth.json"
+if expect_fatal_function_failure /tmp/gemini-whitespace-api-key.stdout /tmp/gemini-whitespace-api-key.stderr \
+  workcell_gemini_selected_auth_type "${TMP_DIR}/whitespace-api-key.env" "${TMP_DIR}/whitespace-api-key-oauth.json"; then
+  echo "Expected whitespace-only Gemini API keys to block OAuth fallback" >&2
+  exit 1
+fi
+grep -q 'sets GEMINI_API_KEY but leaves it empty' /tmp/gemini-whitespace-api-key.stderr
+expect_stderr_to_omit /tmp/gemini-whitespace-api-key.stderr 'whitespace-only-api-secret'
+
+for unicode_whitespace_escape in '\u0085' '\u00A0' '\u2007' '\u202F'; do
+  printf 'GEMINI_API_KEY="%s" # unicode-whitespace-api-secret\n' "${unicode_whitespace_escape}" >"${TMP_DIR}/unicode-whitespace-api-key.env"
+  printf '{}\n' >"${TMP_DIR}/unicode-whitespace-api-key-oauth.json"
+  if expect_fatal_function_failure /tmp/gemini-unicode-whitespace-api-key.stdout /tmp/gemini-unicode-whitespace-api-key.stderr \
+    workcell_gemini_selected_auth_type "${TMP_DIR}/unicode-whitespace-api-key.env" "${TMP_DIR}/unicode-whitespace-api-key-oauth.json"; then
+    echo "Expected Unicode whitespace-only Gemini API keys to block OAuth fallback" >&2
+    exit 1
+  fi
+done
+grep -q 'sets GEMINI_API_KEY but leaves it empty' /tmp/gemini-unicode-whitespace-api-key.stderr
+expect_stderr_to_omit /tmp/gemini-unicode-whitespace-api-key.stderr 'unicode-whitespace-api-secret'
 
 printf ' export GOOGLE_GENAI_USE_GCA=true\nGOOGLE_GENAI_USE_GCA=false\n' >"${TMP_DIR}/duplicate-exported-bool.env"
 if expect_fatal_function_failure /tmp/gemini-duplicate-exported-bool.stdout /tmp/gemini-duplicate-exported-bool.stderr \


### PR DESCRIPTION
## Summary

- Remove credential file content from Gemini parser errors.
- Keep the source path and line number for diagnosis.
- Reject invalid environment variable names before later validation.

## Security evidence

- Baseline tests reproduced malformed-line and invalid-boolean disclosure.
- Regression tests cover all parser branches that previously exposed input.
- A Sol adversarial review found no remaining issue.

## Validation

- `go test ./... -count=1`
- `go vet ./internal/injection`
- `./scripts/pre-merge.sh --profile pr-parity`
