### PR TITLE
Harden injection copy staging

### DIFF
--- a/internal/injection/render_documents_copies.go
+++ b/internal/injection/render_documents_copies.go
@@ -6,6 +6,7 @@ package injection
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/omkhar/workcell/internal/providerid"
+	"golang.org/x/sys/unix"
 )
 
 // allowedCopyEntryKeys is the parser-accepted key set for a single `[[copies]]`
@@ -144,15 +146,16 @@ func renderCopies(policy map[string]any, outputRoot, policyDir Path, agent, mode
 }
 
 func copySource(source, destination Path) (string, error) {
-	info, err := os.Stat(source.String())
+	sourceFile, _, kind, err := openDirectMountSource(source.String())
 	if err != nil {
 		return "", err
 	}
-	if info.IsDir() {
-		if err := ensureNoSymlinksWithin(source); err != nil {
+	defer sourceFile.Close()
+	if kind == directMountSourceDir {
+		if err := os.MkdirAll(destination.Parent().String(), 0o755); err != nil {
 			return "", err
 		}
-		if err := os.MkdirAll(destination.String(), 0o700); err != nil {
+		if err := os.Mkdir(destination.String(), 0o700); err != nil {
 			return "", err
 		}
 		destinationRoot, err := os.OpenRoot(destination.String())
@@ -160,38 +163,7 @@ func copySource(source, destination Path) (string, error) {
 			return "", err
 		}
 		defer destinationRoot.Close()
-		if err := filepath.Walk(source.String(), func(current string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			rel, err := filepath.Rel(source.String(), current)
-			if err != nil {
-				return err
-			}
-			if rel == "." {
-				return nil
-			}
-			rel = filepath.Clean(rel)
-			if info.IsDir() {
-				if err := destinationRoot.MkdirAll(rel, 0o755); err != nil {
-					return err
-				}
-				return destinationRoot.Chmod(rel, 0o700)
-			}
-			data, err := os.ReadFile(current)
-			if err != nil {
-				return err
-			}
-			if parent := filepath.Dir(rel); parent != "." {
-				if err := destinationRoot.MkdirAll(parent, 0o755); err != nil {
-					return err
-				}
-			}
-			if err := destinationRoot.WriteFile(rel, data, 0o600); err != nil {
-				return err
-			}
-			return destinationRoot.Chmod(rel, 0o600)
-		}); err != nil {
+		if err := copyOpenDirectoryToRoot(sourceFile, destinationRoot, source.String(), ".", openDirectMountChild); err != nil {
 			return "", err
 		}
 		if err := os.Chmod(destination.String(), 0o700); err != nil {
@@ -199,7 +171,7 @@ func copySource(source, destination Path) (string, error) {
 		}
 		return "dir", nil
 	}
-	if !info.Mode().IsRegular() {
+	if kind != directMountSourceRegular {
 		return "", fmt.Errorf("injection source must be a file or directory: %s", source)
 	}
 	if err := os.MkdirAll(destination.Parent().String(), 0o755); err != nil {
@@ -210,17 +182,124 @@ func copySource(source, destination Path) (string, error) {
 		return "", err
 	}
 	defer parentRoot.Close()
-	data, err := os.ReadFile(source.String())
+	data, err := io.ReadAll(sourceFile)
 	if err != nil {
 		return "", err
 	}
-	if err := parentRoot.WriteFile(destination.Base(), data, 0o600); err != nil {
+	if err := writeFileExclusive(parentRoot, destination.Base(), data, 0o600); err != nil {
 		return "", err
 	}
 	if err := parentRoot.Chmod(destination.Base(), 0o600); err != nil {
 		return "", err
 	}
 	return "file", nil
+}
+
+// copyOpenDirectoryToRoot copies an already-open source directory. Each
+// descendant is opened from its parent descriptor without following links.
+func copyOpenDirectoryToRoot(
+	source *os.File,
+	destination *os.Root,
+	sourceDisplay, relative string,
+	openChild func(*os.File, string, string) (*os.File, os.FileMode, directMountSourceKind, error),
+) error {
+	return copyOpenDirectoryToRootWithState(source, destination, sourceDisplay, relative, openChild, newInjectionDestinationState())
+}
+
+func copyOpenDirectoryToRootWithState(
+	source *os.File,
+	destination *os.Root,
+	sourceDisplay, relative string,
+	openChild func(*os.File, string, string) (*os.File, os.FileMode, directMountSourceKind, error),
+	state *injectionDestinationState,
+) error {
+	entries, err := source.ReadDir(-1)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		displayPath := filepath.Join(sourceDisplay, entry.Name())
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("injection source must not contain a symbolic link: %s", displayPath)
+		}
+		child, _, kind, err := openChild(source, entry.Name(), displayPath)
+		if err != nil {
+			if errors.Is(err, unix.ELOOP) {
+				return fmt.Errorf("injection source must not contain a symbolic link: %s", displayPath)
+			}
+			return fmt.Errorf("open injection source entry %s: %w", displayPath, err)
+		}
+		childRelative := filepath.Join(relative, entry.Name())
+		switch kind {
+		case directMountSourceDir:
+			err = state.reserve(childRelative, "directory")
+			if err == nil {
+				err = destination.Mkdir(childRelative, 0o700)
+			}
+			if err == nil {
+				err = copyOpenDirectoryToRootWithState(child, destination, displayPath, childRelative, openChild, state)
+			}
+		case directMountSourceRegular:
+			var data []byte
+			data, err = io.ReadAll(child)
+			if err == nil {
+				err = state.reserve(childRelative, "regular file")
+			}
+			if err == nil {
+				err = writeFileExclusive(destination, childRelative, data, 0o600)
+			}
+		default:
+			err = fmt.Errorf("injection source contains an unsupported entry: %s", displayPath)
+		}
+		closeErr := child.Close()
+		if err != nil {
+			return err
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+	}
+	return nil
+}
+
+// injectionDestinationState reserves each target path before it is created.
+// The key is case-insensitive because the standard Apple filesystem treats
+// `A` and `a` as the same destination. Unicode normalization is separate work.
+type injectionDestinationState struct {
+	paths map[string]string
+}
+
+func newInjectionDestinationState() *injectionDestinationState {
+	return &injectionDestinationState{paths: make(map[string]string)}
+}
+
+func (s *injectionDestinationState) reserve(path, kind string) error {
+	key := strings.ToLower(filepath.Clean(path))
+	if previous, exists := s.paths[key]; exists {
+		return fmt.Errorf("injection destination path collision between %s and %s", previous, path)
+	}
+	s.paths[key] = fmt.Sprintf("%s (%s)", path, kind)
+	return nil
+}
+
+func writeFileExclusive(root *os.Root, path string, data []byte, perm os.FileMode) (retErr error) {
+	file, err := root.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			retErr = errors.Join(retErr, closeErr)
+		}
+	}()
+	written, err := file.Write(data)
+	if err != nil {
+		return err
+	}
+	if written != len(data) {
+		return io.ErrShortWrite
+	}
+	return nil
 }
 
 func stageFile(source, outputRoot Path, relpath string) error {
@@ -235,17 +314,28 @@ func stageFile(source, outputRoot Path, relpath string) error {
 			return err
 		}
 	}
-	data, err := os.ReadFile(source.String())
+	sourceFile, _, kind, err := openDirectMountSource(source.String())
 	if err != nil {
 		return err
 	}
-	if err := root.WriteFile(relpath, data, 0o600); err != nil {
+	defer sourceFile.Close()
+	if kind != directMountSourceRegular {
+		return fmt.Errorf("injection source must be a file: %s", source)
+	}
+	data, err := io.ReadAll(sourceFile)
+	if err != nil {
+		return err
+	}
+	if err := writeFileExclusive(root, relpath, data, 0o600); err != nil {
 		return err
 	}
 	return root.Chmod(relpath, 0o600)
 }
 
 func validateContainerTarget(candidate string) (string, error) {
+	if err := validateManifestPathField(candidate, "injection target"); err != nil {
+		return "", err
+	}
 	if containsParentPathSegment(candidate) {
 		return "", fmt.Errorf("injection target must not contain parent path segments: %s", candidate)
 	}

--- a/internal/injection/render_documents_copies_security_test.go
+++ b/internal/injection/render_documents_copies_security_test.go
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injection
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStageFileRejectsValidatedSourcePathReplacement(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.txt")
+	secret := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(source, []byte("approved"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(secret, []byte("host secret"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	validated, err := validateSourcePath(source, "documents.common", Path(root))
+	if err != nil {
+		t.Fatalf("validate source: %v", err)
+	}
+	if err := os.Rename(source, source+".original"); err != nil {
+		t.Fatalf("rename source: %v", err)
+	}
+	if err := os.Symlink(secret, source); err != nil {
+		t.Skipf("symlink is not available: %v", err)
+	}
+
+	output := t.TempDir()
+	err = stageFile(validated, Path(output), "documents/common.md")
+	if err == nil || !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("stageFile error = %v, want symbolic-link rejection", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(output, "documents", "common.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("stageFile created output after source replacement, stat error = %v", statErr)
+	}
+}
+
+func TestCopySourceRejectsValidatedSourcePathReplacement(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.txt")
+	secret := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(source, []byte("approved"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(secret, []byte("host secret"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	validated, err := validateSourcePath(source, "copies.source", Path(root))
+	if err != nil {
+		t.Fatalf("validate source: %v", err)
+	}
+	if err := os.Rename(source, source+".original"); err != nil {
+		t.Fatalf("rename source: %v", err)
+	}
+	if err := os.Symlink(secret, source); err != nil {
+		t.Skipf("symlink is not available: %v", err)
+	}
+
+	output := filepath.Join(root, "output")
+	_, err = copySource(validated, Path(output))
+	if err == nil || !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("copySource error = %v, want symbolic-link rejection", err)
+	}
+	if _, statErr := os.Lstat(output); !os.IsNotExist(statErr) {
+		t.Fatalf("copySource created output after source replacement, stat error = %v", statErr)
+	}
+}
+
+func TestCopySourceRefusesExistingDestination(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.txt")
+	destination := filepath.Join(root, "destination.txt")
+	if err := os.WriteFile(source, []byte("approved"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(destination, []byte("preserve"), 0o600); err != nil {
+		t.Fatalf("write destination: %v", err)
+	}
+	if _, err := copySource(Path(source), Path(destination)); err == nil {
+		t.Fatal("copySource accepted an existing destination")
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if string(data) != "preserve" {
+		t.Fatalf("destination content = %q, want preserve", data)
+	}
+}
+
+func TestStageDirectMountEntryRefusesExistingDestination(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.txt")
+	destination := filepath.Join(root, "staged.txt")
+	if err := os.WriteFile(source, []byte("approved"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(destination, []byte("preserve"), 0o600); err != nil {
+		t.Fatalf("write destination: %v", err)
+	}
+	if err := stageDirectMountEntry(source, destination); err == nil {
+		t.Fatal("stageDirectMountEntry accepted an existing destination")
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if string(data) != "preserve" {
+		t.Fatalf("destination content = %q, want preserve", data)
+	}
+}
+
+func TestCopyOpenDirectoryRejectsChildReplacementAfterReadDir(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "source")
+	childPath := filepath.Join(sourcePath, "child.txt")
+	secretPath := filepath.Join(root, "secret.txt")
+	if err := os.Mkdir(sourcePath, 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(childPath, []byte("approved"), 0o600); err != nil {
+		t.Fatalf("write child: %v", err)
+	}
+	if err := os.WriteFile(secretPath, []byte("host secret"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	source, _, kind, err := openDirectMountSource(sourcePath)
+	if err != nil {
+		t.Fatalf("open source: %v", err)
+	}
+	defer source.Close()
+	if kind != directMountSourceDir {
+		t.Fatalf("source kind = %v, want directory", kind)
+	}
+	outputPath := filepath.Join(root, "output")
+	if err := os.Mkdir(outputPath, 0o700); err != nil {
+		t.Fatalf("mkdir output: %v", err)
+	}
+	destination, err := os.OpenRoot(outputPath)
+	if err != nil {
+		t.Fatalf("open output root: %v", err)
+	}
+	defer destination.Close()
+
+	swapped := false
+	openChild := func(parent *os.File, name, displayPath string) (*os.File, os.FileMode, directMountSourceKind, error) {
+		if !swapped {
+			swapped = true
+			if err := os.Rename(childPath, childPath+".original"); err != nil {
+				t.Fatalf("rename child: %v", err)
+			}
+			if err := os.Symlink(secretPath, childPath); err != nil {
+				t.Skipf("symlink is not available: %v", err)
+			}
+		}
+		return openDirectMountChild(parent, name, displayPath)
+	}
+
+	err = copyOpenDirectoryToRoot(source, destination, sourcePath, ".", openChild)
+	if err == nil || !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("copy directory error = %v, want symbolic-link rejection", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(outputPath, "child.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("copy directory created raced child, stat error = %v", statErr)
+	}
+}
+
+type manifestFramingValue struct {
+	name string
+	raw  string
+}
+
+var manifestFramingValues = []manifestFramingValue{
+	{name: "newline", raw: `\n`},
+	{name: "unit separator", raw: `\x1f`},
+	{name: "line separator", raw: `\u2028`},
+	{name: "invalid UTF-8", raw: string([]byte{0xff})},
+}
+
+func assertRejectedBundleIsEmpty(t *testing.T, output string) {
+	t.Helper()
+	entries, err := os.ReadDir(output)
+	if err != nil {
+		t.Fatalf("read rejected bundle: %v", err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+		t.Fatalf("rejected bundle left partial output: %v", names)
+	}
+}
+
+func TestRunRenderInjectionBundleRejectsFramedCopyTargets(t *testing.T) {
+	for _, framing := range manifestFramingValues {
+		t.Run(framing.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeText(t, filepath.Join(root, "copy.txt"), "approved\n", 0o600)
+			policyPath := filepath.Join(root, "policy.toml")
+			output := filepath.Join(root, "bundle")
+			writeText(t, policyPath, strings.Join([]string{
+				"version = 1",
+				"[[copies]]",
+				`source = "copy.txt"`,
+				`target = "/state/injected/value` + framing.raw + `next"`,
+				`classification = "public"`,
+			}, "\n"), 0o600)
+
+			if err := RunRenderInjectionBundle(policyPath, "codex", "strict", output, ""); err == nil {
+				t.Fatal("RunRenderInjectionBundle accepted a framed target")
+			}
+			assertRejectedBundleIsEmpty(t, output)
+		})
+	}
+}
+
+func TestRunRenderInjectionBundleRejectsFramedDirectMountSources(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		policy []string
+	}{
+		{
+			name: "secret copy",
+			policy: []string{
+				"[[copies]]",
+				`target = "/state/injected/secret"`,
+				`classification = "secret"`,
+			},
+		},
+		{
+			name: "ssh config",
+			policy: []string{
+				"[ssh]",
+			},
+		},
+		{
+			name: "ssh known hosts",
+			policy: []string{
+				"[ssh]",
+			},
+		},
+		{
+			name: "ssh identity",
+			policy: []string{
+				"[ssh]",
+			},
+		},
+	} {
+		for _, framing := range manifestFramingValues {
+			t.Run(test.name+"/"+framing.name, func(t *testing.T) {
+				root := t.TempDir()
+				policyPath := filepath.Join(root, "policy.toml")
+				output := filepath.Join(root, "bundle")
+				policy := append([]string{"version = 1"}, test.policy...)
+				source := `"unsafe` + framing.raw + `parent/source"`
+				switch test.name {
+				case "secret copy":
+					policy = append(policy[:2], append([]string{`source = ` + source}, policy[2:]...)...)
+				case "ssh config":
+					policy = append(policy, `config = `+source)
+				case "ssh known hosts":
+					policy = append(policy, `known_hosts = `+source)
+				case "ssh identity":
+					policy = append(policy, `identities = [`+source+`]`)
+				}
+				writeText(t, policyPath, strings.Join(policy, "\n"), 0o600)
+
+				if err := RunRenderInjectionBundle(policyPath, "codex", "strict", output, ""); err == nil {
+					t.Fatal("RunRenderInjectionBundle accepted a framed source")
+				}
+				assertRejectedBundleIsEmpty(t, output)
+			})
+		}
+	}
+}
+
+func TestRunRenderInjectionBundleRejectsDelimitedSourceParentAfterExpansion(t *testing.T) {
+	root := t.TempDir()
+	policyRoot := filepath.Join(root, "unsafe\x1fparent")
+	writeText(t, filepath.Join(policyRoot, "source"), "secret\n", 0o600)
+	policyPath := filepath.Join(policyRoot, "policy.toml")
+	output := filepath.Join(root, "bundle")
+	writeText(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[[copies]]",
+		`source = "source"`,
+		`target = "/state/injected/secret"`,
+		`classification = "secret"`,
+	}, "\n"), 0o600)
+
+	err := RunRenderInjectionBundle(policyPath, "codex", "strict", output, "")
+	if err == nil {
+		t.Fatal("RunRenderInjectionBundle accepted an expanded framed source")
+	}
+	assertRejectedBundleIsEmpty(t, output)
+}
+
+func TestInjectionDestinationStateRejectsCaseInsensitiveCollision(t *testing.T) {
+	state := newInjectionDestinationState()
+	if err := state.reserve("A", "directory"); err != nil {
+		t.Fatalf("reserve first destination: %v", err)
+	}
+	if err := state.reserve("a", "regular file"); err == nil {
+		t.Fatal("case-colliding destination was accepted")
+	}
+}
+
+func TestRunRenderInjectionBundleRejectsCaseInsensitivePublicCopyCollision(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(source, "A"), 0o755); err != nil {
+		t.Fatalf("mkdir A: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(source, "a"), 0o755); err != nil {
+		t.Skipf("filesystem does not permit distinct case aliases: %v", err)
+	}
+	policyPath := filepath.Join(root, "policy.toml")
+	output := filepath.Join(root, "bundle")
+	writeText(t, policyPath, strings.Join([]string{
+		"version = 1",
+		"[[copies]]",
+		`source = "source"`,
+		`target = "/state/injected/source"`,
+		`classification = "public"`,
+	}, "\n"), 0o600)
+
+	err := RunRenderInjectionBundle(policyPath, "codex", "strict", output, "")
+	if err == nil || !strings.Contains(err.Error(), "destination path collision") {
+		t.Fatalf("RunRenderInjectionBundle error = %v, want destination collision", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(output, "manifest.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("manifest exists after public-copy collision: %v", statErr)
+	}
+}
+
+func TestStageDirectMountsRejectsCaseInsensitiveDestinationCollision(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(source, "A"), 0o755); err != nil {
+		t.Fatalf("mkdir A: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(source, "a"), 0o755); err != nil {
+		t.Skipf("filesystem does not permit distinct case aliases: %v", err)
+	}
+	specPath := filepath.Join(root, "mounts.json")
+	writeMountSpec(t, specPath, []map[string]any{{
+		"source": source, "mount_path": "/opt/workcell/host-inputs/source",
+	}})
+
+	_, err := StageDirectMounts(filepath.Join(root, "bundle"), specPath)
+	if err == nil || !strings.Contains(err.Error(), "destination path collision") {
+		t.Fatalf("StageDirectMounts error = %v, want destination collision", err)
+	}
+}
+
+func TestRenderSSHAcceptsSafeIdentityBasename(t *testing.T) {
+	root := t.TempDir()
+	identity := filepath.Join(root, "id_workcell-safe")
+	if err := os.WriteFile(identity, []byte("private key"), 0o600); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+	ssh, err := renderSSH(map[string]any{
+		"ssh": map[string]any{"identities": []any{identity}},
+	}, Path(t.TempDir()), Path(root), "codex", "strict")
+	if err != nil {
+		t.Fatalf("renderSSH: %v", err)
+	}
+	identities := ssh["identities"].([]map[string]any)
+	if len(identities) != 1 || identities[0]["target_name"] != "id_workcell-safe" {
+		t.Fatalf("rendered identities = %#v", identities)
+	}
+}
+
+func TestRenderSSHRejectsUnsafeIdentityBasename(t *testing.T) {
+	root := t.TempDir()
+	identity := filepath.Join(root, "id\nunsafe")
+	if err := os.WriteFile(identity, []byte("private key"), 0o600); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+	_, err := renderSSH(map[string]any{
+		"ssh": map[string]any{"identities": []any{identity}},
+	}, Path(t.TempDir()), Path(root), "codex", "strict")
+	if err == nil || !strings.Contains(err.Error(), "control or line-separator") {
+		t.Fatalf("renderSSH error = %v, want manifest field rejection", err)
+	}
+}

--- a/internal/injection/render_policy_load.go
+++ b/internal/injection/render_policy_load.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/omkhar/workcell/internal/tomlsubset"
 )
@@ -175,6 +176,9 @@ func loadPolicyMetadataOverride(rawPath string) (string, []PolicySource, error) 
 // table whitelist (documents/ssh/credentials).
 func parseTOMLSubset(content string, policyPath Path) (map[string]any, error) {
 	policy := policyPath.String()
+	if !utf8.ValidString(content) {
+		return nil, fmt.Errorf("%s must contain valid UTF-8", policy)
+	}
 	subsetContent, copiesEntries, err := extractCopiesBlocks(content, policy)
 	if err != nil {
 		return nil, err

--- a/internal/injection/render_ssh.go
+++ b/internal/injection/render_ssh.go
@@ -130,6 +130,9 @@ func renderSSH(policy map[string]any, outputRoot, policyDir Path, agent, mode st
 		if _, reserved := reservedSSHFilnames[source.Base()]; reserved {
 			return nil, fmt.Errorf("ssh.identities[%d] basename collides with a reserved SSH file: %s", index, source.Base())
 		}
+		if err := validateManifestPathField(source.Base(), fmt.Sprintf("ssh.identities[%d] basename", index)); err != nil {
+			return nil, err
+		}
 		if _, exists := seenIdentityTargets[source.Base()]; exists {
 			return nil, fmt.Errorf("ssh.identities contains duplicate target basename: %s", source.Base())
 		}

--- a/internal/injection/render_validation.go
+++ b/internal/injection/render_validation.go
@@ -12,6 +12,8 @@ import (
 	"slices"
 	"strings"
 	"syscall"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/omkhar/workcell/internal/host/authstate"
 	"github.com/omkhar/workcell/internal/pathutil"
@@ -118,8 +120,14 @@ func validateSourcePath(raw any, label string, base Path) (Path, error) {
 	if !ok || rawStr == "" {
 		return Path(""), fmt.Errorf("%s must be a non-empty string path", label)
 	}
+	if err := validateManifestPathField(rawStr, label); err != nil {
+		return Path(""), err
+	}
 	source, err := expandHostPath(rawStr, base)
 	if err != nil {
+		return Path(""), err
+	}
+	if err := validateManifestPathField(source.String(), label); err != nil {
 		return Path(""), err
 	}
 	info, err := os.Stat(source.String())
@@ -145,6 +153,20 @@ func validateSourcePath(raw any, label string, base Path) (Path, error) {
 		}
 	}
 	return source, nil
+}
+
+// validateManifestPathField rejects values that cannot safely pass through the
+// line- and unit-separator-delimited manifest readers in the runtime.
+func validateManifestPathField(value, label string) error {
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%s must contain valid UTF-8", label)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) || unicode.Is(unicode.Zl, r) || unicode.Is(unicode.Zp, r) {
+			return fmt.Errorf("%s must not contain control or line-separator characters", label)
+		}
+	}
+	return nil
 }
 
 func expandHostPath(raw string, base Path) (Path, error) {

--- a/internal/injection/stage_direct_mounts.go
+++ b/internal/injection/stage_direct_mounts.go
@@ -61,9 +61,6 @@ func StageDirectMounts(bundleRoot, mountSpecPath string) ([]string, error) {
 		}
 		entryHash := hoststate.DirectMountCacheKey(mount.Source, mount.MountPath)
 		stagedSource := filepath.Join(stagedRoot, entryHash)
-		if err := os.RemoveAll(stagedSource); err != nil {
-			return nil, err
-		}
 		if err := stageDirectMountEntry(mount.Source, stagedSource); err != nil {
 			return nil, err
 		}
@@ -163,7 +160,7 @@ func stageDirectMountEntry(hostSource, stagedSource string) error {
 
 	switch kind {
 	case directMountSourceDir:
-		if err := os.MkdirAll(stagedSource, 0o755); err != nil {
+		if err := os.Mkdir(stagedSource, 0o700); err != nil {
 			return err
 		}
 		return copyDirContents(source, filepath.Clean(hostSource), stagedSource)
@@ -193,6 +190,10 @@ func stageDirectMountEntry(hostSource, stagedSource string) error {
 // opened with openat(O_NOFOLLOW), so a parent path swapped after validation
 // cannot redirect staging to a different host tree.
 func copyDirContents(src *os.File, srcDisplay, dst string) error {
+	return copyDirContentsWithState(src, srcDisplay, dst, newInjectionDestinationState())
+}
+
+func copyDirContentsWithState(src *os.File, srcDisplay, dst string, state *injectionDestinationState) error {
 	entries, err := src.ReadDir(-1)
 	if err != nil {
 		return err
@@ -222,11 +223,15 @@ func copyDirContents(src *os.File, srcDisplay, dst string) error {
 		}
 		switch kind {
 		case directMountSourceDir:
-			if err := os.MkdirAll(target, childMode); err != nil {
+			if err := state.reserve(target, "directory"); err != nil {
 				child.Close()
 				return err
 			}
-			if err := copyDirContents(child, displayPath, target); err != nil {
+			if err := os.Mkdir(target, childMode); err != nil {
+				child.Close()
+				return err
+			}
+			if err := copyDirContentsWithState(child, displayPath, target, state); err != nil {
 				child.Close()
 				return err
 			}
@@ -234,6 +239,10 @@ func copyDirContents(src *os.File, srcDisplay, dst string) error {
 				return err
 			}
 		case directMountSourceRegular:
+			if err := state.reserve(target, "regular file"); err != nil {
+				child.Close()
+				return err
+			}
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				child.Close()
 				return err
@@ -267,7 +276,7 @@ func copyFileWithMode(src, dst string, _ os.FileMode) error {
 }
 
 func copyOpenFileWithMode(in *os.File, dst string, mode os.FileMode) error {
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL|unix.O_NOFOLLOW, mode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Harden copy staging for F-003, F-023, and F-026.
- Use descriptor-safe traversal for source files and directories.
- Reject replacement races and preserve existing destination targets.
- Reject case-insensitive destination collisions.
- Validate copy and SSH manifest fields before staging.
- Keep the runtime boundary and host policy unchanged.

## Security evidence

- Directory traversal uses opened descriptors and rejects symlink replacement.
- Destination creation uses exclusive operations and rejects collisions.
- Manifest paths use the repository path grammar and basename rules.
- Security tests cover races, symlinks, collisions, malformed fields, and valid cases.

## Validation

- `go test ./internal/injection`
- `go test ./...`
- `go vet ./internal/injection`
- `git diff --check`
- `./scripts/pre-merge.sh --profile pr-parity`

Sol reviewed the security design and found no actionable issue.
