### PR TITLE
Bound session audit reads

### DIFF
--- a/internal/host/auditlog/open_unix.go
+++ b/internal/host/auditlog/open_unix.go
@@ -1,0 +1,151 @@
+//go:build unix
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package auditlog
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// openRegularSingleLink opens an audit log without following its leaf path.
+// The nonblocking flag prevents a swapped FIFO from stalling the host command.
+func openRegularSingleLink(path string) (*os.File, error) {
+	parentFD, leaf, err := openAuditLogParent(path)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(parentFD)
+	fd, err := unix.Openat(parentFD, leaf, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, fmt.Errorf("auditlog: %s must not be a symlink: %w", path, err)
+		}
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("auditlog: %s could not be opened", path)
+	}
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		_ = file.Close()
+		return nil, &os.PathError{Op: "stat", Path: path, Err: err}
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		_ = file.Close()
+		return nil, fmt.Errorf("auditlog: %s is not a regular file", path)
+	}
+	if stat.Nlink != 1 {
+		_ = file.Close()
+		return nil, fmt.Errorf("auditlog: %s has %d links; expected one", path, stat.Nlink)
+	}
+	if stat.Uid != uint32(os.Geteuid()) || stat.Mode&0o077 != 0 {
+		_ = file.Close()
+		return nil, fmt.Errorf("auditlog: %s must be owned by the current user and owner-only", path)
+	}
+	return file, nil
+}
+
+func openAuditLogParent(path string) (int, string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return -1, "", err
+	}
+	clean := canonicalSystemPath(filepath.Clean(abs))
+	if clean == string(filepath.Separator) {
+		return -1, "", fmt.Errorf("auditlog: %s is not a file", path)
+	}
+	parent := filepath.Dir(clean)
+	leaf := filepath.Base(clean)
+	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, "", err
+	}
+	var rootStat unix.Stat_t
+	if err := unix.Fstat(fd, &rootStat); err != nil {
+		_ = unix.Close(fd)
+		return -1, "", err
+	}
+	anchored, err := validateAuditDirectory(string(filepath.Separator), rootStat, false)
+	if err != nil {
+		_ = unix.Close(fd)
+		return -1, "", err
+	}
+	currentPath := string(filepath.Separator)
+	for _, component := range strings.Split(strings.TrimPrefix(parent, string(filepath.Separator)), string(filepath.Separator)) {
+		if component == "" {
+			continue
+		}
+		next, openErr := unix.Openat(fd, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if openErr != nil {
+			_ = unix.Close(fd)
+			return -1, "", openErr
+		}
+		var stat unix.Stat_t
+		if statErr := unix.Fstat(next, &stat); statErr != nil {
+			_ = unix.Close(next)
+			_ = unix.Close(fd)
+			return -1, "", statErr
+		}
+		currentPath = filepath.Join(currentPath, component)
+		nextAnchored, validateErr := validateAuditDirectory(currentPath, stat, anchored)
+		if validateErr != nil {
+			_ = unix.Close(next)
+			_ = unix.Close(fd)
+			return -1, "", validateErr
+		}
+		_ = unix.Close(fd)
+		fd = next
+		anchored = nextAnchored
+	}
+	return fd, leaf, nil
+}
+
+// validateAuditDirectory uses the host state-path policy. Before the walk
+// reaches a current-user directory, only root-owned non-writable ancestors and
+// sticky transit directories are trusted. Each directory below that anchor must
+// be controlled by the current user.
+func validateAuditDirectory(path string, stat unix.Stat_t, anchored bool) (bool, error) {
+	if stat.Mode&unix.S_IFMT != unix.S_IFDIR || stat.Ino == 0 {
+		return false, fmt.Errorf("auditlog: %s is not a directory", path)
+	}
+	euid := uint32(os.Geteuid())
+	ownerControlled := stat.Uid == euid && stat.Mode&0o022 == 0
+	if anchored {
+		if !ownerControlled {
+			return false, fmt.Errorf("auditlog: %s is unsafe below the owner-controlled directory", path)
+		}
+		return true, nil
+	}
+	if stat.Uid == 0 && (stat.Mode&0o022 == 0 || stat.Mode&unix.S_ISVTX != 0) {
+		return euid == 0 && stat.Mode&0o077 == 0 && stat.Mode&unix.S_ISVTX == 0, nil
+	}
+	if ownerControlled {
+		return true, nil
+	}
+	return false, fmt.Errorf("auditlog: %s is not a trusted directory ancestor", path)
+}
+
+// canonicalSystemPath removes platform aliases such as macOS /var and /tmp.
+// It does not resolve arbitrary descendants, so a mutable state-directory
+// symlink remains visible to the no-follow descriptor walk below.
+func canonicalSystemPath(path string) string {
+	for _, alias := range []string{"/var", "/tmp"} {
+		physical, err := filepath.EvalSymlinks(alias)
+		if err != nil || physical == alias || (path != alias && !strings.HasPrefix(path, alias+string(filepath.Separator))) {
+			continue
+		}
+		return physical + strings.TrimPrefix(path, alias)
+	}
+	return path
+}

--- a/internal/host/auditlog/read.go
+++ b/internal/host/auditlog/read.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+// Package auditlog provides bounded streaming reads for the shared host audit
+// log. The limits are intentionally generous for normal session history while
+// preventing an attacker-controlled log from forcing an unbounded allocation.
+package auditlog
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// MaxLineBytes is the maximum physical audit-log line size, including its
+// optional newline terminator. Session audit records are normally far smaller.
+const MaxLineBytes = 1 << 20
+
+// MaxLogBytes is the maximum audit-log size processed by one operation. This
+// preserves the existing complete-log semantics while bounding total work.
+const MaxLogBytes = 64 << 20
+
+// ForEachLine streams a file to fn without reading the whole file into memory.
+// It returns an error when the file exceeds either documented audit-log limit.
+func ForEachLine(path string, fn func(line string, lineNumber int) error) error {
+	file, err := openRegularSingleLink(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	reader := bufio.NewReaderSize(file, 64<<10)
+	var line []byte
+	var total int64
+	lineNumber := 0
+	for {
+		fragment, readErr := reader.ReadSlice('\n')
+		total += int64(len(fragment))
+		if total > MaxLogBytes {
+			return fmt.Errorf("auditlog: %s exceeds maximum size of %d bytes", path, MaxLogBytes)
+		}
+		if len(line)+len(fragment) > MaxLineBytes {
+			return fmt.Errorf("auditlog: %s line %d exceeds maximum size of %d bytes", path, lineNumber+1, MaxLineBytes)
+		}
+		line = append(line, fragment...)
+		if readErr == bufio.ErrBufferFull {
+			continue
+		}
+		if len(line) > 0 {
+			lineNumber++
+			if err := fn(string(line), lineNumber); err != nil {
+				return err
+			}
+			line = nil
+		}
+		if errors.Is(readErr, io.EOF) {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+}

--- a/internal/host/auditlog/read_test.go
+++ b/internal/host/auditlog/read_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package auditlog
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeRepeated(t *testing.T, path string, size int, value string) {
+	t.Helper()
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if err := file.Chmod(0o600); err != nil {
+		t.Fatal(err)
+	}
+	for size > 0 {
+		chunk := value
+		if len(chunk) > size {
+			chunk = chunk[:size]
+		}
+		if _, err := file.WriteString(chunk); err != nil {
+			t.Fatal(err)
+		}
+		size -= len(chunk)
+	}
+}
+
+func TestForEachLineAcceptsExactLineLimit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.log")
+	writeRepeated(t, path, MaxLineBytes, "x")
+	called := false
+	if err := ForEachLine(path, func(line string, lineNumber int) error {
+		called = true
+		if len(line) != MaxLineBytes || lineNumber != 1 {
+			t.Fatalf("callback received line length %d number %d", len(line), lineNumber)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("ForEachLine() exact line limit error = %v", err)
+	}
+	if !called {
+		t.Fatal("ForEachLine() did not report the exact-limit line")
+	}
+}
+
+func TestForEachLineAcceptsExactLogLimit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.log")
+	writeRepeated(t, path, MaxLogBytes, strings.Repeat("x", MaxLineBytes-1)+"\n")
+	if err := ForEachLine(path, func(string, int) error { return nil }); err != nil {
+		t.Fatalf("ForEachLine() exact log limit error = %v", err)
+	}
+}
+
+func TestForEachLineRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.log")
+	path := filepath.Join(dir, "audit.log")
+	if err := os.WriteFile(target, []byte("session_id=attacker\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+	if err := ForEachLine(path, func(string, int) error { return nil }); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("ForEachLine() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestForEachLineRejectsHardLink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.log")
+	path := filepath.Join(dir, "audit.log")
+	if err := os.WriteFile(target, []byte("session_id=attacker\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(target, path); err != nil {
+		t.Fatal(err)
+	}
+	if err := ForEachLine(path, func(string, int) error { return nil }); err == nil || !strings.Contains(err.Error(), "expected one") {
+		t.Fatalf("ForEachLine() error = %v, want hard-link rejection", err)
+	}
+}
+
+func TestForEachLineRejectsNonOwnerOnlyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.log")
+	if err := os.WriteFile(path, []byte("session_id=attacker\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ForEachLine(path, func(string, int) error { return nil }); err == nil || !strings.Contains(err.Error(), "owner-only") {
+		t.Fatalf("ForEachLine() error = %v, want owner-only rejection", err)
+	}
+}
+
+func TestForEachLineRejectsWritableParent(t *testing.T) {
+	root := t.TempDir()
+	parent := filepath.Join(root, "unsafe")
+	if err := os.Mkdir(parent, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parent, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(parent, "audit.log")
+	if err := os.WriteFile(path, []byte("session_id=attacker\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ForEachLine(path, func(string, int) error { return nil }); err == nil || !strings.Contains(err.Error(), "unsafe") {
+		t.Fatalf("ForEachLine() error = %v, want unsafe-parent rejection", err)
+	}
+}
+
+func TestForEachLineRejectsSymlinkedParent(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "parent")
+	outsideDir := filepath.Join(root, "outside")
+	if err := os.Mkdir(realDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "audit.log"), []byte("session_id=real\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(outsideDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideDir, "audit.log"), []byte("session_id=outside\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(realDir, filepath.Join(root, "moved")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideDir, realDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ForEachLine(filepath.Join(realDir, "audit.log"), func(string, int) error { return nil }); err == nil {
+		t.Fatal("ForEachLine() followed a symlinked parent")
+	}
+}

--- a/internal/host/auditseal/auditseal.go
+++ b/internal/host/auditseal/auditseal.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/omkhar/workcell/internal/host/auditlog"
 	"github.com/omkhar/workcell/internal/host/hoststate"
 	"github.com/omkhar/workcell/internal/host/keystore"
 	"github.com/omkhar/workcell/internal/ocsf"
@@ -127,74 +128,12 @@ type chainRecord struct {
 // (a LATER unrelated session's line never affects it); earlier interleaved
 // records ARE verified, each decoded strictly.
 func recomputeSessionHead(auditLogPath, targetProvider, sessionID string) (string, error) {
-	data, err := os.ReadFile(auditLogPath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("auditseal: no audit log for session %s", sessionID)
-		}
-		return "", err
-	}
-
-	raw := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
-	lines := make([]string, 0, len(raw))
-	for _, line := range raw {
-		if line = strings.TrimSpace(line); line != "" {
-			lines = append(lines, line)
-		}
-	}
-
-	// Pass 1: locate the head. A line claims this session iff it has a session_id
-	// TOKEN == sessionID (argv-safe); a claiming line that fails strict decode is
-	// same-session tamper (fail closed), a non-claiming line is skipped (L209/L280).
-	lastMatch := -1
-	for i, line := range lines {
-		// Corruption gate: a malformed field can make a record untokenizable before
-		// its session_id (the writer emits `event=` first). The genuine writer never
-		// emits one, so fail closed rather than drop an unreadable same-session
-		// tamper as a non-member (a legitimate other-session torn line tokenizes).
-		if !ocsf.AuditLineTokenizable(line, targetProvider) {
-			return "", fmt.Errorf("auditseal: audit log has an untokenizable record at line %d (corruption or tamper)", i+1)
-		}
-		if !ocsf.AuditLineClaimsSession(line, targetProvider, sessionID) {
-			continue
-		}
-		if _, err := ocsf.DecodeAuditLineStrict(line, targetProvider); err != nil {
-			return "", fmt.Errorf("auditseal: audit record for session %s is malformed: %w", sessionID, err)
-		}
-		lastMatch = i
-	}
-	if lastMatch < 0 {
-		return "", fmt.Errorf("auditseal: no audit records for session %s", sessionID)
-	}
-
-	// No-chain provider guard: report ErrUnsupportedAuditChain ONLY when NONE of
-	// the session's chain-region records (lines[0..lastMatch]) carries a
-	// record_digest — the genuine no-chain provider (apple-container) emits a
-	// digest on NO record. Checking only the HEAD record would let an attacker on
-	// a chained provider (colima/docker) strip the head's record_digest, or append
-	// a no-digest record claiming the session AFTER a valid chain (making it the
-	// new head), and have real tamper misreported as "unsupported/unsigned"
-	// (HasSignableChain maps ErrUnsupportedAuditChain->false). If ANY record in the
-	// region has a digest the chain exists: fall through to pass 2, which anchors
-	// at the first digest-bearing line and fails "missing record_digest" on any
-	// post-root record (including the head) that lacks one. A decode error here is
-	// genuine tamper and is surfaced as such.
-	anyDigest := false
-	for i := 0; i <= lastMatch; i++ {
-		fields, err := ocsf.DecodeAuditLineStrict(lines[i], targetProvider)
-		if err != nil {
-			return "", fmt.Errorf("auditseal: %w", err)
-		}
-		if auditFieldsHaveKey(fields, "record_digest") {
-			anyDigest = true
-			break
-		}
-	}
-	if !anyDigest {
-		return "", ErrUnsupportedAuditChain
-	}
-
-	// Pass 2: strict chain verification over records 0..lastMatch. On an upgraded
+	// Verify the chain in one bounded stream. Reopening the path for separate
+	// passes could combine records from different file states during an append.
+	// Keep the verdict at each matching record, so unrelated later records retain
+	// the existing behavior and do not affect that session's head.
+	//
+	// On an upgraded
 	// profile the audit log can have legacy entries written BEFORE record_digest
 	// existed; the append path seeds prev_digest from the last existing digest (or
 	// "" if none), so there is exactly ONE chain root = the first physical line
@@ -203,57 +142,92 @@ func recomputeSessionHead(auditLogPath, targetProvider, sessionID string) (strin
 	// at that root with expectedPrev="". After the root, a line missing
 	// record_digest is stripped-digest tamper — only the leading prefix is skippable.
 	expectedPrev := ""
-	head := ""
+	chainHead := ""
 	started := false
-	for i := 0; i <= lastMatch; i++ {
-		fields, err := ocsf.DecodeAuditLineStrict(lines[i], targetProvider)
+	matched := false
+	matchedHead := ""
+	var chainErr error
+	var matchedErr error
+	logicalLine := 0
+	err := auditlog.ForEachLine(auditLogPath, func(rawLine string, _ int) error {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			return nil
+		}
+		i := logicalLine
+		logicalLine++
+		// A malformed field can make a record untokenizable before its session ID.
+		// The writer never emits such a record, so reject it as corruption.
+		if !ocsf.AuditLineTokenizable(line, targetProvider) {
+			return fmt.Errorf("auditseal: audit log has an untokenizable record at line %d (corruption or tamper)", i+1)
+		}
+		claimsSession := ocsf.AuditLineClaimsSession(line, targetProvider, sessionID)
+		fields, err := ocsf.DecodeAuditLineStrict(line, targetProvider)
 		if err != nil {
-			return "", fmt.Errorf("auditseal: %w", err)
+			if claimsSession {
+				return fmt.Errorf("auditseal: audit record for session %s is malformed: %w", sessionID, err)
+			}
+			if chainErr == nil {
+				chainErr = fmt.Errorf("auditseal: %w", err)
+			}
+			return nil
 		}
-		rec := chainRecord{}
-		hasDigest := false
-		for _, f := range fields {
-			switch f.Key {
-			case "timestamp":
-				rec.timestamp = f.Value
-			case "prev_digest":
-				rec.prevDigest = f.Value
-			case "record_digest":
-				rec.recordDigest = f.Value
-				hasDigest = true
-			default:
-				rec.args = append(rec.args, f.Key+"="+f.Value)
+		if chainErr == nil {
+			rec := chainRecord{}
+			hasDigest := false
+			for _, f := range fields {
+				switch f.Key {
+				case "timestamp":
+					rec.timestamp = f.Value
+				case "prev_digest":
+					rec.prevDigest = f.Value
+				case "record_digest":
+					rec.recordDigest = f.Value
+					hasDigest = true
+				default:
+					rec.args = append(rec.args, f.Key+"="+f.Value)
+				}
+			}
+			if !started && hasDigest {
+				started = true
+			}
+			if started {
+				switch {
+				case rec.recordDigest == "":
+					chainErr = fmt.Errorf("auditseal: audit chain broken at record %d: missing record_digest", i)
+				case hoststate.AuditRecordDigest(rec.prevDigest, rec.timestamp, rec.args) != rec.recordDigest:
+					chainErr = fmt.Errorf("auditseal: audit chain broken at record %d: recomputed digest does not match stored record_digest", i)
+				case rec.prevDigest != expectedPrev:
+					chainErr = fmt.Errorf("auditseal: audit chain broken at record %d: prev_digest does not link to the previous record", i)
+				default:
+					expectedPrev = rec.recordDigest
+					chainHead = rec.recordDigest
+				}
 			}
 		}
-		if !started {
-			if !hasDigest {
-				continue // contiguous legacy prefix before the chain root
+		if claimsSession {
+			matched = true
+			matchedHead = chainHead
+			matchedErr = chainErr
+			if matchedErr == nil && !started {
+				matchedErr = ErrUnsupportedAuditChain
 			}
-			started = true // first line carrying a record_digest is the chain root
 		}
-		if rec.recordDigest == "" {
-			return "", fmt.Errorf("auditseal: audit chain broken at record %d: missing record_digest", i)
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("auditseal: no audit log for session %s", sessionID)
 		}
-		want := hoststate.AuditRecordDigest(rec.prevDigest, rec.timestamp, rec.args)
-		if want != rec.recordDigest {
-			return "", fmt.Errorf("auditseal: audit chain broken at record %d: recomputed digest does not match stored record_digest", i)
-		}
-		if rec.prevDigest != expectedPrev {
-			return "", fmt.Errorf("auditseal: audit chain broken at record %d: prev_digest does not link to the previous record", i)
-		}
-		expectedPrev = rec.recordDigest
-		head = rec.recordDigest
+		return "", err
 	}
-	return head, nil
-}
-
-func auditFieldsHaveKey(fields []ocsf.AuditField, key string) bool {
-	for _, f := range fields {
-		if f.Key == key {
-			return true
-		}
+	if !matched {
+		return "", fmt.Errorf("auditseal: no audit records for session %s", sessionID)
 	}
-	return false
+	if matchedErr != nil {
+		return "", matchedErr
+	}
+	return matchedHead, nil
 }
 
 // HasSignableChain reports whether a session's audit records form a signable

--- a/internal/host/auditseal/auditseal_test.go
+++ b/internal/host/auditseal/auditseal_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omkhar/workcell/internal/host/auditlog"
 	"github.com/omkhar/workcell/internal/host/hoststate"
 	"github.com/omkhar/workcell/internal/host/keystore"
 	"github.com/omkhar/workcell/internal/ocsf"
@@ -56,6 +57,45 @@ func writeLog(t *testing.T, dir string, lines []string) string {
 		t.Fatalf("write log: %v", err)
 	}
 	return path
+}
+
+func writeSizedLog(t *testing.T, path string, size int, fill byte) {
+	t.Helper()
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	chunk := strings.Repeat(string(fill), 64<<10)
+	for size > 0 {
+		part := chunk
+		if len(part) > size {
+			part = part[:size]
+		}
+		if _, err := file.WriteString(part); err != nil {
+			t.Fatal(err)
+		}
+		size -= len(part)
+	}
+	if err := file.Chmod(0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSignRejectsOversizedAuditLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "workcell.audit.log")
+	writeSizedLog(t, path, auditlog.MaxLineBytes+1, 'x')
+	if _, err := SignSessionHead(filepath.Join(t.TempDir(), "signing"), path, "colima", "sess-A", "t"); err == nil || !strings.Contains(err.Error(), "line") {
+		t.Fatalf("SignSessionHead() error = %v, want oversized-line rejection", err)
+	}
+}
+
+func TestSignRejectsOversizedAuditLog(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "workcell.audit.log")
+	writeSizedLog(t, path, auditlog.MaxLogBytes+1, '\n')
+	if _, err := SignSessionHead(filepath.Join(t.TempDir(), "signing"), path, "colima", "sess-A", "t"); err == nil || !strings.Contains(err.Error(), "maximum size") {
+		t.Fatalf("SignSessionHead() error = %v, want oversized-log rejection", err)
+	}
 }
 
 func genuineLog(t *testing.T) []record {

--- a/internal/host/sessions/sessions.go
+++ b/internal/host/sessions/sessions.go
@@ -14,6 +14,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/omkhar/workcell/internal/host/auditlog"
+	"golang.org/x/sys/unix"
 )
 
 type SessionRecord struct {
@@ -73,6 +76,9 @@ type SessionRecordLocation struct {
 	Record SessionRecord
 	Path   string
 }
+
+// MaxSessionRecordBytes bounds one persisted session record read.
+const MaxSessionRecordBytes int64 = 1 << 20
 
 func SessionDiffMetadataLines(record SessionRecord) []string {
 	record = normalizeSessionRecord(record)
@@ -378,13 +384,32 @@ func WriteSessionRecord(path string, updates map[string]string) error {
 // own atomic writer while reusing this exact serialization and validation.
 // WriteSessionRecord is a thin wrapper over it, so its behavior is unchanged.
 func EncodeSessionRecord(path string, updates map[string]string) ([]byte, error) {
-	var existing []byte
-	if data, err := os.ReadFile(path); err == nil {
-		existing = data
-	} else if !errors.Is(err, os.ErrNotExist) {
+	existing, err := readSessionRecordBytes(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
 	return encodeSessionRecordFrom(existing, updates, path)
+}
+
+func readSessionRecordBytes(path string) ([]byte, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	abs = canonicalSystemPath(filepath.Clean(abs))
+	parentFD, err := openAbsoluteDirectory(filepath.Dir(abs), false, defaultDescriptorFS(), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(parentFD)
+	// Keep diagnostics on the caller's path. The canonical path is used only
+	// for the descriptor walk, so macOS aliases such as /var do not become
+	// /private paths before the support-bundle redactor sees the error.
+	file, err := readOwnerFileAt(parentFD, filepath.Base(abs), path, "session record", MaxSessionRecordBytes, false, 1)
+	if err != nil {
+		return nil, err
+	}
+	return file.data, nil
 }
 
 // EncodeSessionRecordFrom is EncodeSessionRecord over already-read existing bytes
@@ -507,15 +532,33 @@ func encodeSessionRecordFrom(existing []byte, updates map[string]string, source 
 	if err != nil {
 		return nil, err
 	}
-	return append(data, '\n'), nil
+	data = append(data, '\n')
+	if int64(len(data)) > MaxSessionRecordBytes {
+		return nil, fmt.Errorf("%s exceeds %d bytes", source, MaxSessionRecordBytes)
+	}
+	return data, nil
 }
 
 func ReadSessionRecord(path string) (SessionRecord, error) {
-	data, err := os.ReadFile(path)
+	data, err := readSessionRecordBytes(path)
 	if err != nil {
 		return SessionRecord{}, err
 	}
 	return DecodeSessionRecord(data, path)
+}
+
+// canonicalSystemPath removes platform aliases such as macOS /var and /tmp.
+// It does not resolve arbitrary descendants, so the descriptor walk can still
+// reject mutable state-directory symlinks.
+func canonicalSystemPath(path string) string {
+	for _, alias := range []string{"/var", "/tmp"} {
+		physical, err := filepath.EvalSymlinks(alias)
+		if err != nil || physical == alias || (path != alias && !strings.HasPrefix(path, alias+string(filepath.Separator))) {
+			continue
+		}
+		return physical + strings.TrimPrefix(path, alias)
+	}
+	return path
 }
 
 // DecodeSessionRecord parses, normalizes, and validates a session record from its
@@ -757,6 +800,7 @@ func FindSessionRecordInRoots(roots []string, sessionID string) (SessionRecord, 
 	return record, err
 }
 
+// FindSessionRecordWithPathInRoots finds one session and its canonical record path.
 func FindSessionRecordWithPathInRoots(roots []string, sessionID string) (SessionRecord, string, error) {
 	locations, err := ListSessionRecordLocationsInRoots(roots, SessionListOptions{})
 	if err != nil {
@@ -784,12 +828,16 @@ func ExportSessionRecord(root, sessionID string) (SessionExport, error) {
 }
 
 func ExportSessionRecordInRoots(roots []string, sessionID string) (SessionExport, error) {
-	record, err := FindSessionRecordInRoots(roots, sessionID)
+	record, recordPath, err := FindSessionRecordWithPathInRoots(roots, sessionID)
 	if err != nil {
 		return SessionExport{}, err
 	}
 
-	records, err := SessionAuditRecords(record)
+	auditLogPath, err := canonicalAuditLogPath(record, recordPath)
+	if err != nil {
+		return SessionExport{}, err
+	}
+	records, err := sessionAuditRecords(record, auditLogPath)
 	if err != nil {
 		return SessionExport{}, err
 	}
@@ -801,36 +849,39 @@ func SessionTimelineRecords(root, sessionID string) ([]string, error) {
 }
 
 func SessionTimelineRecordsInRoots(roots []string, sessionID string) ([]string, error) {
-	record, err := FindSessionRecordInRoots(roots, sessionID)
+	record, recordPath, err := FindSessionRecordWithPathInRoots(roots, sessionID)
 	if err != nil {
 		return nil, err
 	}
-	return SessionAuditRecords(record)
+	auditLogPath, err := canonicalAuditLogPath(record, recordPath)
+	if err != nil {
+		return nil, err
+	}
+	return sessionAuditRecords(record, auditLogPath)
 }
 
-func SessionAuditRecords(record SessionRecord) ([]string, error) {
-	if record.AuditLogPath == "" {
-		return []string{}, nil
+func canonicalAuditLogPath(record SessionRecord, recordPath string) (string, error) {
+	canonical := filepath.Join(filepath.Dir(filepath.Dir(recordPath)), "workcell.audit.log")
+	if strings.TrimSpace(record.AuditLogPath) != "" && filepath.Clean(record.AuditLogPath) != filepath.Clean(canonical) {
+		return "", fmt.Errorf("session %q audit log path does not match its canonical location", record.SessionID)
 	}
+	return canonical, nil
+}
 
-	data, err := os.ReadFile(record.AuditLogPath)
+func sessionAuditRecords(record SessionRecord, auditLogPath string) ([]string, error) {
+	records := make([]string, 0)
+	err := auditlog.ForEachLine(auditLogPath, func(rawLine string, _ int) error {
+		line := strings.TrimSpace(rawLine)
+		if line != "" && auditLineHasSessionID(line, record.SessionID) {
+			records = append(records, line)
+		}
+		return nil
+	})
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return []string{}, nil
 		}
 		return nil, err
-	}
-
-	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
-	records := make([]string, 0, len(lines))
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		if auditLineHasSessionID(line, record.SessionID) {
-			records = append(records, line)
-		}
 	}
 	return records, nil
 }

--- a/internal/host/sessions/sessions_test.go
+++ b/internal/host/sessions/sessions_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/host/auditlog"
 )
 
 func TestWriteSessionRecordRoundTrip(t *testing.T) {
@@ -587,6 +589,154 @@ func TestSessionTimelineRecordsIncludesMatchingAuditLines(t *testing.T) {
 	}
 }
 
+func writeSizedAuditLog(t *testing.T, path string, size int, fill byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	chunk := strings.Repeat(string(fill), 64<<10)
+	for size > 0 {
+		part := chunk
+		if len(part) > size {
+			part = part[:size]
+		}
+		if _, err := file.WriteString(part); err != nil {
+			t.Fatal(err)
+		}
+		size -= len(part)
+	}
+	if err := file.Chmod(0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeTimelineFixture(t *testing.T, root, auditLogPath string) {
+	t.Helper()
+	writeSessionFixture(t, filepath.Join(root, "wcl-one", "sessions", "session-1.json"), SessionRecord{
+		Version:        1,
+		SessionID:      "session-1",
+		Profile:        "wcl-one",
+		Agent:          "codex",
+		Mode:           "strict",
+		Status:         "exited",
+		Workspace:      "/tmp/workspace-a",
+		StartedAt:      "2026-04-08T10:00:00Z",
+		FinishedAt:     "2026-04-08T10:05:00Z",
+		ExitStatus:     "0",
+		FinalAssurance: "managed-mutable",
+		AuditLogPath:   auditLogPath,
+	})
+}
+
+func TestSessionTimelineRecordsRejectsOversizedAuditLine(t *testing.T) {
+	root := t.TempDir()
+	auditLogPath := filepath.Join(root, "wcl-one", "workcell.audit.log")
+	writeSizedAuditLog(t, auditLogPath, auditlog.MaxLineBytes+1, 'x')
+	writeTimelineFixture(t, root, auditLogPath)
+	if _, err := SessionTimelineRecords(root, "session-1"); err == nil || !strings.Contains(err.Error(), "line") {
+		t.Fatalf("SessionTimelineRecords() error = %v, want oversized-line rejection", err)
+	}
+}
+
+func TestSessionTimelineRecordsRejectsOversizedAuditLog(t *testing.T) {
+	root := t.TempDir()
+	auditLogPath := filepath.Join(root, "wcl-one", "workcell.audit.log")
+	writeSizedAuditLog(t, auditLogPath, auditlog.MaxLogBytes+1, '\n')
+	writeTimelineFixture(t, root, auditLogPath)
+	if _, err := SessionTimelineRecords(root, "session-1"); err == nil || !strings.Contains(err.Error(), "maximum size") {
+		t.Fatalf("SessionTimelineRecords() error = %v, want oversized-log rejection", err)
+	}
+}
+
+func TestSessionTimelineRecordsDerivesCanonicalPathWhenRecordPathEmpty(t *testing.T) {
+	root := t.TempDir()
+	auditLogPath := filepath.Join(root, "wcl-one", "workcell.audit.log")
+	if err := os.MkdirAll(filepath.Dir(auditLogPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(auditLogPath, []byte("session_id=session-1 event=launch\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeTimelineFixture(t, root, "")
+	timeline, err := SessionTimelineRecords(root, "session-1")
+	if err != nil {
+		t.Fatalf("SessionTimelineRecords() error = %v", err)
+	}
+	if len(timeline) != 1 || timeline[0] != "session_id=session-1 event=launch" {
+		t.Fatalf("SessionTimelineRecords() = %v, want canonical record", timeline)
+	}
+}
+
+func TestSessionExportsRejectRedirectedAuditLogPath(t *testing.T) {
+	root := t.TempDir()
+	redirected := filepath.Join(root, "outside", "workcell.audit.log")
+	if err := os.MkdirAll(filepath.Dir(redirected), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(redirected, []byte("session_id=session-1 event=redirected\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeTimelineFixture(t, root, redirected)
+	for _, name := range []string{"export", "timeline"} {
+		t.Run(name, func(t *testing.T) {
+			if name == "export" {
+				if _, err := ExportSessionRecord(root, "session-1"); err == nil || !strings.Contains(err.Error(), "canonical") {
+					t.Fatalf("ExportSessionRecord() error = %v, want canonical-path rejection", err)
+				}
+				return
+			}
+			if _, err := SessionTimelineRecords(root, "session-1"); err == nil || !strings.Contains(err.Error(), "canonical") {
+				t.Fatalf("SessionTimelineRecords() error = %v, want canonical-path rejection", err)
+			}
+		})
+	}
+}
+
+func TestSessionExportsRejectLinkedCanonicalAuditLog(t *testing.T) {
+	for _, linkType := range []string{"symlink", "hard-link"} {
+		t.Run(linkType, func(t *testing.T) {
+			root := t.TempDir()
+			auditLogPath := filepath.Join(root, "wcl-one", "workcell.audit.log")
+			if err := os.MkdirAll(filepath.Dir(auditLogPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			decoy := filepath.Join(root, "decoy.log")
+			if err := os.WriteFile(decoy, []byte("session_id=session-1 event=decoy\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var err error
+			if linkType == "symlink" {
+				err = os.Symlink(decoy, auditLogPath)
+			} else {
+				err = os.Link(decoy, auditLogPath)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeTimelineFixture(t, root, auditLogPath)
+
+			for _, operation := range []string{"export", "timeline"} {
+				t.Run(operation, func(t *testing.T) {
+					if operation == "export" {
+						if _, err := ExportSessionRecord(root, "session-1"); err == nil {
+							t.Fatal("ExportSessionRecord() accepted a linked audit log")
+						}
+						return
+					}
+					if _, err := SessionTimelineRecords(root, "session-1"); err == nil {
+						t.Fatal("SessionTimelineRecords() accepted a linked audit log")
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestReadSessionRecordRejectsUnknownJSONField(t *testing.T) {
 	t.Parallel()
 
@@ -602,6 +752,7 @@ func TestReadSessionRecordRejectsUnknownJSONField(t *testing.T) {
   "started_at": "2026-04-08T10:00:00Z",
   "unexpected": "value"
 }
+
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -612,6 +763,38 @@ func TestReadSessionRecordRejectsUnknownJSONField(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unknown field") {
 		t.Fatalf("ReadSessionRecord() error = %v, want unknown field failure", err)
+	}
+}
+
+func TestReadSessionRecordRejectsSymlinkAndOversizedFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	realPath := filepath.Join(root, "real.json")
+	if err := os.WriteFile(realPath, []byte(`{"session_id":"outside"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkPath := filepath.Join(root, "link.json")
+	if err := os.Symlink(realPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadSessionRecord(linkPath); err == nil {
+		t.Fatal("ReadSessionRecord() followed a symlink")
+	}
+	if _, err := EncodeSessionRecord(linkPath, nil); err == nil {
+		t.Fatal("EncodeSessionRecord() followed a symlink")
+	}
+
+	largePath := filepath.Join(root, "large.json")
+	large := make([]byte, MaxSessionRecordBytes+1)
+	if err := os.WriteFile(largePath, large, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadSessionRecord(largePath); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("ReadSessionRecord() oversized error = %v, want size rejection", err)
+	}
+	if _, err := EncodeSessionRecord(largePath, nil); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("EncodeSessionRecord() oversized error = %v, want size rejection", err)
 	}
 }
 

--- a/internal/supportbundle/bundle_test.go
+++ b/internal/supportbundle/bundle_test.go
@@ -157,7 +157,9 @@ func writeSessionRecord(t *testing.T, profileDir, name string, rec sessions.Sess
 	if err != nil {
 		t.Fatalf("marshal session record: %v", err)
 	}
-	mustWrite(t, filepath.Join(sessionsDir, name), string(data))
+	if err := os.WriteFile(filepath.Join(sessionsDir, name), data, 0o600); err != nil {
+		t.Fatalf("write session record: %v", err)
+	}
 }
 
 func mustMkdir(t *testing.T, dir string) {

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
 set -euo pipefail
+umask 077
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-session-scenario.XXXXXX")"


### PR DESCRIPTION
## Summary

- Bound session records and audit logs.
- Open audit paths through descriptors without following links.
- Require trusted ancestors and owner-only regular files.
- Bind session records to the canonical audit path.
- Reject oversized records, lines, and logs.

## Security evidence

- Exact limits pass, and the next byte fails.
- Link, hard-link, mode, owner, and writable-parent tests fail closed.
- Rename races keep the accepted descriptor.
- The session command scenario creates owner-only fixtures and passes.

## Validation

- `go test ./... -count=1`
- Focused race tests
- `go vet`
- Exact session command scenario
- `./scripts/pre-merge.sh --profile pr-parity`

Sol reviewed the final patch and found no actionable issue.
