### PR TITLE
Preserve live injection bundles during cleanup

### DIFF
--- a/internal/host/hoststate/hoststate.go
+++ b/internal/host/hoststate/hoststate.go
@@ -487,14 +487,12 @@ func injectionBundleIsLive(bundlePath string, cutoff time.Time) (bool, error) {
 		return true, fmt.Errorf("parse owner.json at %s: %w", ownerMetaPath, err)
 	}
 	if owner.PID <= 0 || owner.Started == "" {
-		return false, nil
+		return true, fmt.Errorf("owner metadata is incomplete: %s", ownerMetaPath)
 	}
-	started, err := launcher.ProcessStartTime(owner.PID)
+	started, err := launcher.ObserveProcessGeneration(owner.PID, owner.Started)
 	if err != nil {
-		// launcher.ProcessStartTime distinguishes ESRCH ("process gone")
-		// from other errors via launcher.IsProcessGone. If the process
-		// is definitively gone, the bundle is dead. Anything else is a
-		// transient lookup failure - keep the bundle.
+		// launcher.ObserveProcessGeneration distinguishes an absent process
+		// from other errors. Keep the bundle on lookup errors.
 		if launcher.IsProcessGone(err) {
 			return false, nil
 		}

--- a/internal/host/hoststate/hoststate_test.go
+++ b/internal/host/hoststate/hoststate_test.go
@@ -6,10 +6,17 @@ package hoststate
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/omkhar/workcell/internal/host/launcher"
 )
 
 func TestDirectMountCacheKeyMatchesNULTerminatedHash(t *testing.T) {
@@ -158,6 +165,268 @@ func TestCleanupStaleInjectionBundlesRemovesCopilotTokenSidecar(t *testing.T) {
 			t.Fatalf("stale injection artifact should be removed: %s err=%v", path, err)
 		}
 	}
+}
+
+func TestCleanupStaleInjectionBundlesPreservesLiveCurrentOwnerAndSidecars(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	bundleName := "workcell-injections.live"
+	bundleDir := filepath.Join(root, bundleName)
+	mountSidecar := filepath.Join(root, bundleName+".mounts.json")
+	tokenSidecar := filepath.Join(root, bundleName+".copilot-token.env.live")
+	tokenHandoffDir := filepath.Join(root, bundleName+".copilot-token-handoff.live")
+	if err := os.MkdirAll(tokenHandoffDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := launcher.WriteProfileOwner(filepath.Join(bundleDir, "owner.json"), os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{mountSidecar, tokenSidecar} {
+		if err := os.WriteFile(path, []byte("test\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-13 * time.Hour)
+	for _, path := range []string{bundleDir, mountSidecar, tokenSidecar, tokenHandoffDir} {
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := CleanupStaleInjectionBundles(root); err != nil {
+		t.Fatalf("CleanupStaleInjectionBundles() error = %v", err)
+	}
+	for _, path := range []string{bundleDir, mountSidecar, tokenSidecar, tokenHandoffDir} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("live injection artifact should remain: %s err=%v", path, err)
+		}
+	}
+}
+
+func TestCleanupStaleInjectionBundlesPreservesInvalidOwners(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name  string
+		owner []byte
+	}{
+		{name: "malformed JSON", owner: []byte("{")},
+		{name: "incomplete", owner: []byte(`{"pid":1}`)},
+		{name: "wrong platform", owner: injectionOwnerJSON(t, os.Getpid(), otherPlatformGeneration())},
+		{name: "malformed darwin seconds", owner: injectionOwnerJSON(t, os.Getpid(), "darwin:0.000000")},
+		{name: "malformed darwin microseconds", owner: injectionOwnerJSON(t, os.Getpid(), "darwin:1.00000")},
+		{name: "overflow darwin seconds", owner: injectionOwnerJSON(t, os.Getpid(), "darwin:9223372036854775808.000000")},
+		{name: "malformed linux zero ticks", owner: injectionOwnerJSON(t, os.Getpid(), "linux:0")},
+		{name: "malformed linux ticks", owner: injectionOwnerJSON(t, os.Getpid(), "linux:01")},
+		{name: "overflow linux ticks", owner: injectionOwnerJSON(t, os.Getpid(), "linux:18446744073709551616")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			bundleDir := filepath.Join(root, "workcell-injections.invalid")
+			writeInjectionOwnerContent(t, bundleDir, test.owner)
+			ageInjectionArtifact(t, bundleDir)
+
+			if err := CleanupStaleInjectionBundles(root); err != nil {
+				t.Fatalf("CleanupStaleInjectionBundles() error = %v", err)
+			}
+			if _, err := os.Stat(bundleDir); err != nil {
+				t.Fatalf("invalid owner bundle should remain: %v", err)
+			}
+		})
+	}
+}
+
+func TestCleanupStaleInjectionBundlesTreatsSimilarPrefixesAsLegacy(t *testing.T) {
+	t.Parallel()
+
+	for _, started := range []string{"darwinish:1.000000", "linuxish:1"} {
+		t.Run(started, func(t *testing.T) {
+			root := t.TempDir()
+			bundleDir := filepath.Join(root, "workcell-injections.similar")
+			writeInjectionOwner(t, bundleDir, os.Getpid(), started)
+			ageInjectionArtifact(t, bundleDir)
+
+			if err := CleanupStaleInjectionBundles(root); err != nil {
+				t.Fatalf("CleanupStaleInjectionBundles() error = %v", err)
+			}
+			if _, err := os.Stat(bundleDir); !os.IsNotExist(err) {
+				t.Fatalf("legacy mismatch bundle should be removed, err = %v", err)
+			}
+		})
+	}
+}
+
+func TestCleanupStaleInjectionBundlesPreservesLiveOwnerDuringConcurrentCleanup(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	bundleDir := filepath.Join(root, "workcell-injections.concurrent")
+	if err := launcher.WriteProfileOwner(filepath.Join(bundleDir, "owner.json"), os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	ageInjectionArtifact(t, bundleDir)
+
+	const cleaners = 32
+	errs := make(chan error, cleaners)
+	var group sync.WaitGroup
+	for range cleaners {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			errs <- CleanupStaleInjectionBundles(root)
+		}()
+	}
+	group.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("CleanupStaleInjectionBundles() error = %v", err)
+		}
+	}
+	if _, err := os.Stat(bundleDir); err != nil {
+		t.Fatalf("live bundle should remain after concurrent cleanup: %v", err)
+	}
+}
+
+func TestInjectionBundleIsLiveSupportsLegacyOwner(t *testing.T) {
+	t.Parallel()
+
+	bundleDir := filepath.Join(t.TempDir(), "workcell-injections.legacy")
+	started, err := launcher.ProcessStartTime(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeInjectionOwner(t, bundleDir, os.Getpid(), started)
+
+	live, err := injectionBundleIsLive(bundleDir, time.Now())
+	if err != nil || !live {
+		t.Fatalf("injectionBundleIsLive() = %v, %v; want true, nil", live, err)
+	}
+}
+
+func TestInjectionBundleIsLiveRejectsDeadAndChangedOwners(t *testing.T) {
+	t.Parallel()
+
+	started := currentProcessGeneration(t)
+	dead := exec.Command("/bin/sh", "-c", "exit 0")
+	if err := dead.Run(); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name    string
+		pid     int
+		started string
+	}{
+		{name: "dead", pid: dead.ProcessState.Pid(), started: started},
+		{name: "changed generation", pid: os.Getpid(), started: differentProcessGeneration(t, started)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			bundleDir := filepath.Join(t.TempDir(), "workcell-injections."+test.name)
+			writeInjectionOwner(t, bundleDir, test.pid, test.started)
+
+			live, err := injectionBundleIsLive(bundleDir, time.Now())
+			if err != nil || live {
+				t.Fatalf("injectionBundleIsLive() = %v, %v; want false, nil", live, err)
+			}
+		})
+	}
+}
+
+func TestInjectionBundleIsLivePreservesMalformedOwner(t *testing.T) {
+	t.Parallel()
+
+	bundleDir := filepath.Join(t.TempDir(), "workcell-injections.malformed")
+	if err := os.MkdirAll(bundleDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "owner.json"), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	live, err := injectionBundleIsLive(bundleDir, time.Now())
+	if err == nil || !live {
+		t.Fatalf("injectionBundleIsLive() = %v, %v; want true, non-nil", live, err)
+	}
+}
+
+func writeInjectionOwner(t *testing.T, bundleDir string, pid int, started string) {
+	t.Helper()
+	writeInjectionOwnerContent(t, bundleDir, injectionOwnerJSON(t, pid, started))
+}
+
+func writeInjectionOwnerContent(t *testing.T, bundleDir string, content []byte) {
+	t.Helper()
+	if err := os.MkdirAll(bundleDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "owner.json"), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func injectionOwnerJSON(t *testing.T, pid int, started string) []byte {
+	t.Helper()
+	payload, err := json.Marshal(struct {
+		PID     int    `json:"pid"`
+		Started string `json:"started"`
+	}{PID: pid, Started: started})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+func ageInjectionArtifact(t *testing.T, path string) {
+	t.Helper()
+	old := time.Now().Add(-13 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func otherPlatformGeneration() string {
+	if runtime.GOOS == "darwin" {
+		return "linux:1"
+	}
+	return "darwin:1.000000"
+}
+
+func currentProcessGeneration(t *testing.T) string {
+	t.Helper()
+	var seed string
+	switch runtime.GOOS {
+	case "darwin":
+		seed = "darwin:1.000000"
+	case "linux":
+		seed = "linux:1"
+	default:
+		started, err := launcher.ProcessStartTime(os.Getpid())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return started
+	}
+	started, err := launcher.ObserveProcessGeneration(os.Getpid(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return started
+}
+
+func differentProcessGeneration(t *testing.T, started string) string {
+	t.Helper()
+	if ticks, ok := strings.CutPrefix(started, "linux:"); ok {
+		return "linux:" + ticks + "0"
+	}
+	seconds, microseconds, ok := strings.Cut(strings.TrimPrefix(started, "darwin:"), ".")
+	if !ok || seconds == "" || len(microseconds) != 6 {
+		return started + " changed"
+	}
+	if microseconds == "000000" {
+		return "darwin:" + seconds + ".000001"
+	}
+	return "darwin:" + seconds + ".000000"
 }
 
 func TestCleanupStaleInjectionBundlesConservativelyHandlesOrphanCopilotTokenSidecars(t *testing.T) {

--- a/internal/host/launcher/launcher.go
+++ b/internal/host/launcher/launcher.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -298,6 +299,63 @@ func WriteProfileOwner(ownerPath string, pid int) error {
 		return err
 	}
 	return os.Chmod(ownerPath, 0o600)
+}
+
+// ObserveProcessGeneration returns the observed generation for a recorded
+// process owner. It preserves support for untagged legacy ps start-time records.
+func ObserveProcessGeneration(pid int, recorded string) (string, error) {
+	switch {
+	case strings.HasPrefix(recorded, "darwin:"):
+		if !validDarwinProcessGeneration(recorded) {
+			return "", errors.New("invalid darwin process generation")
+		}
+		if runtime.GOOS != "darwin" {
+			return "", fmt.Errorf("darwin process generation does not match %s host", runtime.GOOS)
+		}
+		return processGeneration(pid)
+	case strings.HasPrefix(recorded, "linux:"):
+		if !validLinuxProcessGeneration(recorded) {
+			return "", errors.New("invalid linux process generation")
+		}
+		if runtime.GOOS != "linux" {
+			return "", fmt.Errorf("linux process generation does not match %s host", runtime.GOOS)
+		}
+		return processGeneration(pid)
+	default:
+		return ProcessStartTime(pid)
+	}
+}
+
+func validDarwinProcessGeneration(recorded string) bool {
+	seconds, microseconds, ok := strings.Cut(strings.TrimPrefix(recorded, "darwin:"), ".")
+	if !ok || !isPositiveCanonicalInt64(seconds) || len(microseconds) != 6 || !isDecimal(microseconds) {
+		return false
+	}
+	value, err := strconv.ParseUint(microseconds, 10, 32)
+	return err == nil && value <= 999_999
+}
+
+func validLinuxProcessGeneration(recorded string) bool {
+	return isPositiveCanonicalUint64(strings.TrimPrefix(recorded, "linux:"))
+}
+
+func isPositiveCanonicalInt64(value string) bool {
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	return err == nil && parsed > 0 && strconv.FormatInt(parsed, 10) == value
+}
+
+func isPositiveCanonicalUint64(value string) bool {
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	return err == nil && parsed > 0 && strconv.FormatUint(parsed, 10) == value
+}
+
+func isDecimal(value string) bool {
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // ProcessStartTime returns the `ps -o lstart=` value for pid, or an error


### PR DESCRIPTION
Summary:

- Validate exact process generation records before stale-bundle cleanup.
- Keep bundles when owner metadata is malformed or uses another platform.
- Add process reuse, race, sidecar, and cleanup regression tests.

Validation:

- ./scripts/pre-merge.sh --profile pr-parity
- Independent Sol security review: clean.
- Focused tests passed 32 times.
- Race, vet, full Go, Linux cross-build, and mutation checks passed.

Security finding: F-061.