### PR TITLE
Bound and anchor injection policy reads

### DIFF
--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -394,7 +394,7 @@ It rejects group or other write permission below that anchor.
 The reader rejects other foreign-owned ancestors and non-sticky writable ancestors.
 On Darwin, it canonicalizes `/var`, `/etc`, and `/tmp` below `/private` before the walk.
 
-The reader records metadata before and after each bounded read.
+The reader checks metadata before the first read and after the first and last bounded reads.
 It rejects identity, owner, group, mode, link-count, and size changes.
 It rejects byte-count and modification changes.
 It reads the descriptor again to reject same-length in-place changes.

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -368,6 +368,38 @@ credentials, and copies.
 
 ## Explicit limits
 
+### Policy reader trust boundary
+
+The policy reader accepts at most 16 MiB for one policy file.
+The reader accepts at most 64 MiB and 4,096 files for one include bundle.
+The limits include the entrypoint and each included policy file.
+The reader accepts a regular file only.
+The current user must own the file.
+Group and other users must not have write permission.
+
+The file must have exactly one hard link.
+Group and other users can read a policy file.
+The reader rejects grant-capable and unrecognized extended ACLs.
+On Darwin, it accepts only `group:everyone deny delete` with no ACL flags.
+On Linux, it rejects CIFS and SMB descriptor filesystems because it cannot prove that ACLs are absent.
+
+The reader opens each path component by descriptor.
+The descriptor walk rejects symbolic links that reach the reader.
+Some entrypoint callers resolve a selected symbolic link before this walk.
+It accepts non-writable, root-owned system ancestors before the user anchor.
+It accepts root-owned sticky transit directories, such as `/tmp`, before the user anchor.
+It requires current-user ownership below the user anchor.
+
+It rejects group or other write permission below that anchor.
+The reader rejects other foreign-owned ancestors and non-sticky writable ancestors.
+On Darwin, it canonicalizes `/var`, `/etc`, and `/tmp` below `/private` before the walk.
+
+The reader records metadata before and after each bounded read.
+It rejects identity, owner, group, mode, link-count, and size changes.
+It rejects byte-count and modification changes.
+It reads the descriptor again to reject same-length in-place changes.
+The parser and SHA-256 source record use the accepted descriptor snapshot.
+
 - The safe path does not accept arbitrary environment variables that contain
   secrets.
 - The safe path does not pass a complete host home.

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -379,15 +379,18 @@ Group and other users must not have write permission.
 
 The file must have exactly one hard link.
 Group and other users can read a policy file.
-The reader rejects grant-capable and unrecognized extended ACLs.
 On Darwin, it accepts only `group:everyone deny delete` with no ACL flags.
-On Linux, it rejects CIFS and SMB descriptor filesystems because it cannot prove that ACLs are absent.
+On Linux, it rejects unproved ACL types and NFS, CIFS, and SMB descriptor filesystems.
+On Linux, it accepts POSIX ACLs on root-owned system ancestors only on ext2, ext3, ext4, XFS, Btrfs, tmpfs, and OverlayFS filesystems.
+The directory mode proves that the access ACL gives no non-owner write permission.
+A default ACL cannot change access to that existing ancestor.
+The reader checks each descendant separately.
+The reader rejects POSIX ACLs on policy files, current-user directories, and sticky transit directories.
 
 The reader opens each path component by descriptor.
 The descriptor walk rejects symbolic links that reach the reader.
 Some entrypoint callers resolve a selected symbolic link before this walk.
-It accepts non-writable, root-owned system ancestors before the user anchor.
-It accepts root-owned sticky transit directories, such as `/tmp`, before the user anchor.
+It accepts non-writable root-owned ancestors and root-owned sticky transit directories before the user anchor.
 It requires current-user ownership below the user anchor.
 
 It rejects group or other write permission below that anchor.

--- a/internal/authpolicy/manage_inspect.go
+++ b/internal/authpolicy/manage_inspect.go
@@ -6,10 +6,13 @@ package authpolicy
 import (
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/omkhar/workcell/internal/injectionpolicy"
 )
+
+var afterDiffEntrypointRead func()
 
 func commandShow(policyPath string, stdout io.Writer) error {
 	policy, _, err := loadPolicyBundle(policyPath)
@@ -60,11 +63,19 @@ func commandValidate(policyPath string, stdout io.Writer) error {
 }
 
 func commandDiff(policyPath string, stdout io.Writer) error {
-	source, err := os.ReadFile(policyPath)
+	resolvedPolicyPath, err := filepath.Abs(policyPath)
 	if err != nil {
 		return err
 	}
-	policy, _, err := loadPolicyBundle(policyPath)
+	reader := injectionpolicy.NewBundleReader()
+	entrypoint, err := reader.ReadAndPin(resolvedPolicyPath)
+	if err != nil {
+		return err
+	}
+	if afterDiffEntrypointRead != nil {
+		afterDiffEntrypointRead()
+	}
+	policy, _, err := loadPolicyBundleWithReader(resolvedPolicyPath, reader)
 	if err != nil {
 		return err
 	}
@@ -72,7 +83,7 @@ func commandDiff(policyPath string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	sourceText := string(source)
+	sourceText := string(entrypoint.Bytes)
 	if sourceText == rendered {
 		fmt.Fprintln(stdout, "diff_status=clean")
 		return nil

--- a/internal/authpolicy/manage_mutate.go
+++ b/internal/authpolicy/manage_mutate.go
@@ -328,6 +328,8 @@ func loadMutablePolicy(policyPath string) (map[string]any, error) {
 	return policy, nil
 }
 
+var afterCredentialBundleRead func()
+
 func ensureCredentialNotOnlyInIncludes(policyPath string, credentials map[string]any, credential string, command string) error {
 	if _, ok := credentials[credential]; ok || policyPath == "" {
 		return nil
@@ -335,6 +337,9 @@ func ensureCredentialNotOnlyInIncludes(policyPath string, credentials map[string
 	mergedPolicy, policySources, err := loadPolicyBundle(policyPath)
 	if err != nil {
 		return err
+	}
+	if afterCredentialBundleRead != nil {
+		afterCredentialBundleRead()
 	}
 	mergedCredentials, _ := mergedPolicy["credentials"].(map[string]any)
 	if mergedCredentials == nil {
@@ -345,11 +350,7 @@ func ensureCredentialNotOnlyInIncludes(policyPath string, credentials map[string
 	}
 	fragmentPath := ""
 	for _, source := range policySources {
-		sourcePolicy, err := loadRawPolicy(source.Path)
-		if err != nil {
-			return err
-		}
-		sourceCredentials, _ := sourcePolicy["credentials"].(map[string]any)
+		sourceCredentials, _ := source.Fragment["credentials"].(map[string]any)
 		if sourceCredentials != nil {
 			if _, ok := sourceCredentials[credential]; ok {
 				fragmentPath = source.Path

--- a/internal/authpolicy/manage_test.go
+++ b/internal/authpolicy/manage_test.go
@@ -697,6 +697,19 @@ func TestGeminiProjectsOnlyStatusIsSupplemental(t *testing.T) {
 	mustContain(t, got.stdout, "provider_bootstrap_next_step=stage-reviewed-gemini-env-or-oauth")
 }
 
+func TestIncludedCredentialUsesAcceptedSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	policy, fragment := filepath.Join(dir, "policy.toml"), filepath.Join(dir, "fragment.toml")
+	writeFile(t, policy, "version = 1\nincludes = [\"fragment.toml\"]\n", 0o600)
+	writeFile(t, fragment, "version = 1\n[credentials.codex_auth]\nsource = \"/tmp/auth\"\n", 0o600)
+	afterCredentialBundleRead = func() { writeFile(t, fragment, "version = 1\n", 0o600) }
+	t.Cleanup(func() { afterCredentialBundleRead = nil })
+	err := ensureCredentialNotOnlyInIncludes(policy, map[string]any{}, "codex_auth", "set")
+	if err == nil || !strings.Contains(err.Error(), ": fragment.toml") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestSharedCredentialsAreScopedToRequestedAgent(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/internal/authpolicy/policy.go
+++ b/internal/authpolicy/policy.go
@@ -405,15 +405,6 @@ func documentToPolicyMap(doc *tomlsubset.Document, policyPath string) (map[strin
 	return root, nil
 }
 
-func policySHA256(policyPath string) (string, error) {
-	data, err := os.ReadFile(policyPath)
-	if err != nil {
-		return "", err
-	}
-	sum := sha256.Sum256(data)
-	return "sha256:" + hex.EncodeToString(sum[:]), nil
-}
-
 func compositePolicySHA256(policySources []PolicySource) string {
 	sortedSources := append([]PolicySource(nil), policySources...)
 	sort.Slice(sortedSources, func(i, j int) bool {
@@ -632,10 +623,14 @@ func loadPolicyBundle(policyPath string) (map[string]any, []PolicySource, error)
 	if err != nil {
 		return nil, nil, err
 	}
-	return loadPolicyBundleWithState(resolvedPolicyPath, "", nil, map[string]struct{}{})
+	return loadPolicyBundleWithReader(resolvedPolicyPath, injectionpolicy.NewBundleReader())
 }
 
-func loadPolicyBundleWithState(policyPath string, entrypointRoot string, activeStack []string, loadedPaths map[string]struct{}) (map[string]any, []PolicySource, error) {
+func loadPolicyBundleWithReader(policyPath string, reader *injectionpolicy.BundleReader) (map[string]any, []PolicySource, error) {
+	return loadPolicyBundleWithState(policyPath, "", nil, map[string]struct{}{}, reader)
+}
+
+func loadPolicyBundleWithState(policyPath string, entrypointRoot string, activeStack []string, loadedPaths map[string]struct{}, reader *injectionpolicy.BundleReader) (map[string]any, []PolicySource, error) {
 	resolvedPolicyPath, err := filepath.Abs(policyPath)
 	if err != nil {
 		return nil, nil, err
@@ -658,11 +653,11 @@ func loadPolicyBundleWithState(policyPath string, entrypointRoot string, activeS
 	}
 	loadedPaths[resolvedPolicyPath] = struct{}{}
 
-	content, err := os.ReadFile(resolvedPolicyPath)
+	file, err := reader.Read(resolvedPolicyPath)
 	if err != nil {
 		return nil, nil, err
 	}
-	loaded, err := parseTOMLSubset(string(content), resolvedPolicyPath)
+	loaded, err := parseTOMLSubset(string(file.Bytes), resolvedPolicyPath)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -694,7 +689,7 @@ func loadPolicyBundleWithState(policyPath string, entrypointRoot string, activeS
 		if err != nil {
 			return nil, nil, err
 		}
-		includedPolicy, includedSources, err := loadPolicyBundleWithState(includePath, entrypointRoot, nextStack, loadedPaths)
+		includedPolicy, includedSources, err := loadPolicyBundleWithState(includePath, entrypointRoot, nextStack, loadedPaths, reader)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -718,26 +713,23 @@ func loadPolicyBundleWithState(policyPath string, entrypointRoot string, activeS
 	if err := validatePolicyNetwork(merged); err != nil {
 		return nil, nil, err
 	}
-	sourceSHA, err := policySHA256(resolvedPolicyPath)
-	if err != nil {
-		return nil, nil, err
-	}
 	logicalPath, err := logicalPolicyPath(resolvedPolicyPath, entrypointRoot)
 	if err != nil {
 		return nil, nil, err
 	}
 	policySources = append(policySources, PolicySource{
-		Path:   logicalPath,
-		Sha256: sourceSHA,
+		Path:     logicalPath,
+		Sha256:   file.Sha256,
+		Fragment: loaded,
 	})
 	return merged, policySources, nil
 }
 
 func loadRawPolicy(policyPath string) (map[string]any, error) {
-	if _, err := os.Stat(policyPath); os.IsNotExist(err) {
+	content, err := injectionpolicy.ReadFile(policyPath)
+	if os.IsNotExist(err) {
 		return map[string]any{"version": 1}, nil
 	}
-	content, err := os.ReadFile(policyPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/authpolicy/policy_main_test.go
+++ b/internal/authpolicy/policy_main_test.go
@@ -139,6 +139,27 @@ func TestPolicyMainShowRendersPolicy(t *testing.T) {
 	}
 }
 
+func TestPolicyMainDiffPinsEntrypointSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.toml")
+	if err := os.WriteFile(path, []byte("version = 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	afterDiffEntrypointRead = func() {
+		if err := os.WriteFile(path, []byte("version = 1\n\n[network]\nallow_endpoints = [\"registry.example.test:443\"]\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() { afterDiffEntrypointRead = nil })
+	var stdout, stderr bytes.Buffer
+	if err := runPolicyMain([]string{"diff", "--injection-policy", path}, &stdout, &stderr); err != nil {
+		t.Fatalf("diff: %v stderr=%q", err, stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "diff_status=clean") {
+		t.Fatalf("diff output = %q, want pinned clean result", got)
+	}
+}
+
 func TestPolicyMainResolvesRelativePolicyFromBase(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "policy.toml"), []byte(minimalPolicy), 0o600); err != nil {

--- a/internal/authresolve/resolve_policy_load.go
+++ b/internal/authresolve/resolve_policy_load.go
@@ -4,7 +4,6 @@
 package authresolve
 
 import (
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"maps"
@@ -13,16 +12,21 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/omkhar/workcell/internal/injectionpolicy"
 	"github.com/omkhar/workcell/internal/tomlsubset"
 )
 
 func loadPolicyBundle(policyPath string) (map[string]any, []PolicySource, error) {
-	resolvedPolicyPath := filepath.Clean(policyPath)
-	entrypointRoot := filepath.Dir(resolvedPolicyPath)
-	return loadPolicyBundleRecursive(resolvedPolicyPath, entrypointRoot, nil, map[string]struct{}{})
+	return loadPolicyBundleWithReader(policyPath, injectionpolicy.NewBundleReader())
 }
 
-func loadPolicyBundleRecursive(policyPath, entrypointRoot string, activeStack []string, loadedPaths map[string]struct{}) (map[string]any, []PolicySource, error) {
+func loadPolicyBundleWithReader(policyPath string, reader *injectionpolicy.BundleReader) (map[string]any, []PolicySource, error) {
+	resolvedPolicyPath := filepath.Clean(policyPath)
+	entrypointRoot := filepath.Dir(resolvedPolicyPath)
+	return loadPolicyBundleRecursive(resolvedPolicyPath, entrypointRoot, nil, map[string]struct{}{}, reader)
+}
+
+func loadPolicyBundleRecursive(policyPath, entrypointRoot string, activeStack []string, loadedPaths map[string]struct{}, reader *injectionpolicy.BundleReader) (map[string]any, []PolicySource, error) {
 	if slices.Contains(activeStack, policyPath) {
 		cycle := append(append([]string{}, activeStack...), policyPath)
 		return nil, nil, fmt.Errorf("injection policy include cycle detected: %s", strings.Join(cycle, " -> "))
@@ -32,11 +36,11 @@ func loadPolicyBundleRecursive(policyPath, entrypointRoot string, activeStack []
 	}
 	loadedPaths[policyPath] = struct{}{}
 
-	content, err := os.ReadFile(policyPath)
+	file, err := reader.Read(policyPath)
 	if err != nil {
 		return nil, nil, err
 	}
-	loaded, err := parseTOMLSubset(string(content), policyPath)
+	loaded, err := parseTOMLSubset(string(file.Bytes), policyPath)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,7 +79,7 @@ func loadPolicyBundleRecursive(policyPath, entrypointRoot string, activeStack []
 		if err != nil {
 			return nil, nil, err
 		}
-		includedPolicy, includedSources, err := loadPolicyBundleRecursive(includePath, entrypointRoot, nextStack, loadedPaths)
+		includedPolicy, includedSources, err := loadPolicyBundleRecursive(includePath, entrypointRoot, nextStack, loadedPaths, reader)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -96,24 +100,12 @@ func loadPolicyBundleRecursive(policyPath, entrypointRoot string, activeStack []
 	if err := validatePolicyCredentials(merged); err != nil {
 		return nil, nil, err
 	}
-	sourceSHA, err := policySHA256(policyPath)
-	if err != nil {
-		return nil, nil, err
-	}
 	policySources = append(policySources, PolicySource{
-		Path:   logicalPolicyPath(policyPath, entrypointRoot),
-		Sha256: sourceSHA,
+		Path:     logicalPolicyPath(policyPath, entrypointRoot),
+		Sha256:   file.Sha256,
+		Fragment: loaded,
 	})
 	return merged, policySources, nil
-}
-
-func policySHA256(policyPath string) (string, error) {
-	data, err := os.ReadFile(policyPath)
-	if err != nil {
-		return "", fmt.Errorf("read policy %s: %w", policyPath, err)
-	}
-	sum := sha256.Sum256(data)
-	return "sha256:" + fmt.Sprintf("%x", sum[:]), nil
 }
 
 func validatePolicyInclude(raw any, label, base, entrypointRoot string) (string, error) {

--- a/internal/injection/render_policy_load.go
+++ b/internal/injection/render_policy_load.go
@@ -4,8 +4,6 @@
 package injection
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -15,6 +13,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/omkhar/workcell/internal/injectionpolicy"
 	"github.com/omkhar/workcell/internal/tomlsubset"
 )
 
@@ -24,38 +23,37 @@ func loadPolicyBundle(policyPath Path) (map[string]any, []PolicySource, error) {
 		return nil, nil, err
 	}
 	resolvedPolicy := Path(resolvedPolicyPath)
+	return loadPolicyBundleWithReader(resolvedPolicy, injectionpolicy.NewBundleReader())
+}
+
+func loadPolicyBundleWithReader(policyPath Path, reader *injectionpolicy.BundleReader) (map[string]any, []PolicySource, error) {
 	loadedPaths := map[string]struct{}{}
-	merged, sources, err := loadPolicyBundleRecursive(resolvedPolicy, resolvedPolicy.Parent(), nil, loadedPaths)
+	merged, sources, err := loadPolicyBundleRecursive(policyPath, policyPath.Parent(), nil, loadedPaths, reader)
 	if err != nil {
 		return nil, nil, err
 	}
 	return merged, sources, nil
 }
 
-func loadPolicyBundleRecursive(policyPath, entrypointRoot Path, activeStack []Path, loadedPaths map[string]struct{}) (map[string]any, []PolicySource, error) {
-	resolvedPolicyPath, err := resolveAbsPath(policyPath.String())
-	if err != nil {
-		return nil, nil, err
-	}
-	resolved := Path(resolvedPolicyPath)
-	if slices.Contains(activeStack, resolved) {
-		cycle := append(append([]Path{}, activeStack...), resolved)
+func loadPolicyBundleRecursive(policyPath, entrypointRoot Path, activeStack []Path, loadedPaths map[string]struct{}, reader *injectionpolicy.BundleReader) (map[string]any, []PolicySource, error) {
+	if slices.Contains(activeStack, policyPath) {
+		cycle := append(append([]Path{}, activeStack...), policyPath)
 		parts := make([]string, 0, len(cycle))
 		for _, p := range cycle {
 			parts = append(parts, p.String())
 		}
 		return nil, nil, fmt.Errorf("injection policy include cycle detected: %s", strings.Join(parts, " -> "))
 	}
-	if _, ok := loadedPaths[resolved.String()]; ok {
-		return nil, nil, fmt.Errorf("injection policy includes the same file more than once: %s", resolved)
+	if _, ok := loadedPaths[policyPath.String()]; ok {
+		return nil, nil, fmt.Errorf("injection policy includes the same file more than once: %s", policyPath)
 	}
-	loadedPaths[resolved.String()] = struct{}{}
+	loadedPaths[policyPath.String()] = struct{}{}
 
-	raw, err := os.ReadFile(resolved.String())
+	file, err := reader.Read(policyPath.String())
 	if err != nil {
 		return nil, nil, err
 	}
-	loaded, err := parseTOMLSubset(string(raw), resolved)
+	loaded, err := parseTOMLSubset(string(file.Bytes), policyPath)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -88,13 +86,13 @@ func loadPolicyBundleRecursive(policyPath, entrypointRoot Path, activeStack []Pa
 	}
 	merged := map[string]any{"version": 1}
 	sources := make([]PolicySource, 0)
-	nextStack := append(append([]Path{}, activeStack...), resolved)
+	nextStack := append(append([]Path{}, activeStack...), policyPath)
 	for index, include := range includes {
-		includePath, err := validatePolicyInclude(include, fmt.Sprintf("includes[%d]", index), resolved.Parent(), entrypointRoot)
+		includePath, err := validatePolicyInclude(include, fmt.Sprintf("includes[%d]", index), policyPath.Parent(), entrypointRoot)
 		if err != nil {
 			return nil, nil, err
 		}
-		included, includedSources, err := loadPolicyBundleRecursive(includePath, entrypointRoot, nextStack, loadedPaths)
+		included, includedSources, err := loadPolicyBundleRecursive(includePath, entrypointRoot, nextStack, loadedPaths, reader)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -107,18 +105,15 @@ func loadPolicyBundleRecursive(policyPath, entrypointRoot Path, activeStack []Pa
 	currentPolicy := maps.Clone(loaded)
 	delete(currentPolicy, "includes")
 	if len(activeStack) > 0 {
-		currentPolicy = rebasePolicyFragment(currentPolicy, resolved.Parent())
+		currentPolicy = rebasePolicyFragment(currentPolicy, policyPath.Parent())
 	}
-	if err := mergePolicyFragment(merged, currentPolicy, resolved); err != nil {
-		return nil, nil, err
-	}
-	sourceSHA, err := policySHA256(resolved.String())
-	if err != nil {
+	if err := mergePolicyFragment(merged, currentPolicy, policyPath); err != nil {
 		return nil, nil, err
 	}
 	sources = append(sources, PolicySource{
-		Path:   logicalPolicyPath(resolved, entrypointRoot),
-		Sha256: sourceSHA,
+		Path:     logicalPolicyPath(policyPath, entrypointRoot),
+		Sha256:   file.Sha256,
+		Fragment: loaded,
 	})
 	return merged, sources, nil
 }
@@ -325,15 +320,6 @@ func documentToInjectionMap(doc *tomlsubset.Document, policyPath string) (map[st
 	return root, nil
 }
 
-func policySHA256(policyPath string) (string, error) {
-	data, err := os.ReadFile(policyPath)
-	if err != nil {
-		return "", fmt.Errorf("read policy %s: %w", policyPath, err)
-	}
-	sum := sha256.Sum256(data)
-	return "sha256:" + hex.EncodeToString(sum[:]), nil
-}
-
 func logicalPolicyPath(policyPath, entrypointRoot Path) string {
 	relative, err := filepath.Rel(entrypointRoot.String(), policyPath.String())
 	if err != nil {
@@ -426,17 +412,35 @@ func rebasePolicyFragment(policy map[string]any, fragmentDir Path) map[string]an
 }
 
 func validatePolicyInclude(raw any, label string, base, entrypointRoot Path) (Path, error) {
-	source, err := validateSourcePath(raw, label, base)
+	rawPath, ok := raw.(string)
+	if !ok || rawPath == "" {
+		return Path(""), fmt.Errorf("%s must be a non-empty string path", label)
+	}
+	if err := validateManifestPathField(rawPath, label); err != nil {
+		return Path(""), err
+	}
+	source, err := expandHostPath(rawPath, base)
 	if err != nil {
 		return Path(""), err
 	}
-	if err := ensureIsFile(source, label); err != nil {
+	if err := validateManifestPathField(source.String(), label); err != nil {
 		return Path(""), err
 	}
-	if err := requirePathWithin(entrypointRoot, source, label); err != nil {
+	if err := requirePolicyIncludePathWithin(entrypointRoot, source, label); err != nil {
 		return Path(""), err
 	}
 	return source, nil
+}
+
+func requirePolicyIncludePathWithin(root, candidate Path, label string) error {
+	relative, err := filepath.Rel(root.String(), candidate.String())
+	if err != nil {
+		return err
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return fmt.Errorf("%s must stay within %s: %s", label, root, candidate)
+	}
+	return nil
 }
 
 func mergePolicyFragment(base, addition map[string]any, sourcePath Path) error {

--- a/internal/injection/render_policy_reader_limits_test.go
+++ b/internal/injection/render_policy_reader_limits_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injection
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/injectionpolicy"
+)
+
+func TestLoadPolicyBundleReaderLimits(t *testing.T) {
+	dir := t.TempDir()
+	entry := filepath.Join(dir, "policy.toml")
+	fragment := filepath.Join(dir, "fragment.toml")
+	entryText := "version = 1\nincludes = [\"fragment.toml\"]\n"
+	fragmentText := "version = 1\n"
+	writeReaderPolicy(t, entry, entryText)
+	writeReaderPolicy(t, fragment, fragmentText)
+	size := int64(len(entryText) + len(fragmentText))
+	for _, tc := range []struct {
+		want  string
+		bytes int64
+		files int
+	}{
+		{"", size, 2}, {"aggregate bundle limit", size - 1, 2}, {"include/file count limit", size, 1},
+	} {
+		_, _, err := loadPolicyBundleWithReader(Path(entry), injectionpolicy.NewBundleReaderWithLimits(128, tc.bytes, tc.files))
+		if tc.want == "" && err != nil || tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
+			t.Fatalf("load policy bundle error = %v, want %q", err, tc.want)
+		}
+	}
+}
+
+func TestLoadPolicyBundleBindsSnapshotAndDigest(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.toml")
+	original := "version = 1\n[documents]\noriginal = \"original.md\"\n"
+	writeReaderPolicy(t, path, original)
+	reader := injectionpolicy.NewBundleReader()
+	if _, err := reader.ReadAndPin(path); err != nil {
+		t.Fatal(err)
+	}
+	writeReaderPolicy(t, path, "version = 1\n")
+	policy, sources, err := loadPolicyBundleWithReader(Path(path), reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := policy["documents"].(map[string]any)["original"]; !ok {
+		t.Fatalf("policy = %#v", policy)
+	}
+	sum := sha256.Sum256([]byte(original))
+	if len(sources) != 1 || sources[0].Sha256 != "sha256:"+hex.EncodeToString(sum[:]) {
+		t.Fatalf("sources = %#v", sources)
+	}
+}
+
+func TestLoadPolicyBundleRejectsUnsafeInclude(t *testing.T) {
+	root, target := t.TempDir(), t.TempDir()
+	writeReaderPolicy(t, filepath.Join(target, "fragment.toml"), "version = 1\n")
+	if err := os.Symlink(filepath.Join(target, "fragment.toml"), filepath.Join(root, "fragment.toml")); err != nil {
+		t.Fatal(err)
+	}
+	writeReaderPolicy(t, filepath.Join(root, "policy.toml"), "version = 1\nincludes = [\"fragment.toml\"]\n")
+	if _, _, err := loadPolicyBundle(Path(filepath.Join(root, "policy.toml"))); err == nil || !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("load error = %v", err)
+	}
+}
+
+func TestLoadPolicyBundleRejectsInvalidUTF8(t *testing.T) {
+	for _, include := range []bool{false, true} {
+		dir, path := t.TempDir(), ""
+		path = filepath.Join(dir, "policy.toml")
+		content := string([]byte{'\xff'})
+		if include {
+			content = "version = 1\nincludes = [\"fragment.toml\"]\n"
+			writeReaderPolicy(t, filepath.Join(dir, "fragment.toml"), string([]byte{'\xff'}))
+		}
+		writeReaderPolicy(t, path, content)
+		if _, _, err := loadPolicyBundle(Path(path)); err == nil || !strings.Contains(err.Error(), "valid UTF-8") {
+			t.Fatalf("load error = %v", err)
+		}
+	}
+}
+
+func writeReaderPolicy(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/injection/render_validation.go
+++ b/internal/injection/render_validation.go
@@ -184,21 +184,6 @@ func expandHostPath(raw string, base Path) (Path, error) {
 	return Path(abs), nil
 }
 
-func requirePathWithin(root, candidate Path, label string) error {
-	resolvedRoot, err := filepath.EvalSymlinks(root.String())
-	if err != nil {
-		return err
-	}
-	resolvedCandidate, err := filepath.EvalSymlinks(candidate.String())
-	if err != nil {
-		return err
-	}
-	if resolvedCandidate != resolvedRoot && !strings.HasPrefix(resolvedCandidate, resolvedRoot+string(filepath.Separator)) {
-		return fmt.Errorf("%s must stay within %s: %s", label, resolvedRoot, resolvedCandidate)
-	}
-	return nil
-}
-
 func requireNoSymlink(path Path, label string) error {
 	if info, err := os.Lstat(path.String()); err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("%s must not be a symlink: %s", label, path)

--- a/internal/injectionpolicy/reader.go
+++ b/internal/injectionpolicy/reader.go
@@ -190,7 +190,7 @@ func statTrustedPolicyFile(file *os.File, path string) (policyFileStat, error) {
 	if stat.Uid != policyCurrentEUID() || mode&0o022 != 0 {
 		return policyFileStat{}, fmt.Errorf("injection policy %s must be owned by the current user and not writable by group or other users", path)
 	}
-	if err := rejectPolicyACL(int(file.Fd())); err != nil {
+	if err := rejectPolicyACL(int(file.Fd()), false); err != nil {
 		return policyFileStat{}, fmt.Errorf("injection policy file has an extended ACL: %s: %w", path, err)
 	}
 	modTime, changeTime := policyFileTimes(stat)
@@ -308,11 +308,12 @@ func validatePolicyDirectory(fd int, path string, stat unix.Stat_t, anchored boo
 		return false, fmt.Errorf("injection policy path contains a non-directory component: %s", path)
 	}
 	ownedAndControlled := stat.Uid == policyCurrentEUID() && mode&0o022 == 0
+	systemAncestor := !anchored && stat.Uid == 0 && stat.Uid != policyCurrentEUID() && mode&0o022 == 0
 	if anchored {
 		if !ownedAndControlled {
 			return false, fmt.Errorf("injection policy directory below the current-user-controlled anchor is unsafe: %s", path)
 		}
-		if err := rejectPolicyACL(fd); err != nil {
+		if err := rejectPolicyACL(fd, false); err != nil {
 			return false, fmt.Errorf("injection policy directory has an extended ACL: %s: %w", path, err)
 		}
 		return true, nil
@@ -324,7 +325,7 @@ func validatePolicyDirectory(fd int, path string, stat unix.Stat_t, anchored boo
 	} else {
 		return false, fmt.Errorf("injection policy directory ancestor is not trusted: %s", path)
 	}
-	if err := rejectPolicyACL(fd); err != nil {
+	if err := rejectPolicyACL(fd, systemAncestor); err != nil {
 		return false, fmt.Errorf("injection policy directory has an extended ACL: %s: %w", path, err)
 	}
 	return anchored, nil

--- a/internal/injectionpolicy/reader.go
+++ b/internal/injectionpolicy/reader.go
@@ -35,16 +35,14 @@ type PolicyFile struct {
 
 // BundleReader bounds one policy bundle.
 type BundleReader struct {
-	bytes             int64
-	files             int
-	fileLimit         int64
-	bundleLimit       int64
-	fileLimitCount    int
-	beforeOpenLeaf    func()
-	beforeFinalStat   func()
-	beforeConfirmRead func(*os.File)
-	beforeConfirmStat func()
-	snapshots         map[string]PolicyFile
+	bytes                             int64
+	files                             int
+	fileLimit, bundleLimit            int64
+	fileLimitCount                    int
+	beforeOpenLeaf                    func()
+	beforeFinalStat, afterConfirmRead func()
+	beforeConfirmRead                 func(*os.File)
+	snapshots                         map[string]PolicyFile
 }
 
 // NewBundleReader returns a reader with a fresh bundle budget.
@@ -96,9 +94,6 @@ func (r *BundleReader) Read(path string) (PolicyFile, error) {
 	if err != nil {
 		return PolicyFile{}, closePolicyFile(fmt.Errorf("read injection policy %s: %w", path, err), file, path)
 	}
-	if r.beforeFinalStat != nil {
-		r.beforeFinalStat()
-	}
 	after, err := statTrustedPolicyFile(file, path)
 	if err != nil {
 		return PolicyFile{}, closePolicyFile(err, file, path)
@@ -132,31 +127,42 @@ func (r *BundleReader) Read(path string) (PolicyFile, error) {
 	if len(confirmed) != len(data) || sha256.Sum256(confirmed) != sha256.Sum256(data) {
 		return PolicyFile{}, closePolicyFile(fmt.Errorf("injection policy changed while it was read: %s", path), file, path)
 	}
-	if r.beforeConfirmStat != nil {
-		r.beforeConfirmStat()
+	if r.afterConfirmRead != nil {
+		r.afterConfirmRead()
 	}
-	confirmedStat, err := statTrustedPolicyFile(file, path)
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return PolicyFile{}, closePolicyFile(fmt.Errorf("rewind accepted injection policy %s: %w", path, err), file, path)
+	}
+	accepted, err := io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil {
+		return PolicyFile{}, closePolicyFile(fmt.Errorf("read accepted injection policy %s: %w", path, err), file, path)
+	}
+	if len(accepted) != len(data) || sha256.Sum256(accepted) != sha256.Sum256(data) {
+		return PolicyFile{}, closePolicyFile(fmt.Errorf("injection policy changed while it was read: %s", path), file, path)
+	}
+	if r.beforeFinalStat != nil {
+		r.beforeFinalStat()
+	}
+	acceptedStat, err := statTrustedPolicyFile(file, path)
 	if err != nil {
 		return PolicyFile{}, closePolicyFile(err, file, path)
 	}
-	if !samePolicyFile(before, confirmedStat) {
+	if !samePolicyFile(before, acceptedStat) {
 		return PolicyFile{}, closePolicyFile(fmt.Errorf("injection policy changed while it was read: %s", path), file, path)
 	}
 	if err := file.Close(); err != nil {
 		return PolicyFile{}, fmt.Errorf("close injection policy %s: %w", path, err)
 	}
 
-	r.bytes += int64(len(data))
+	r.bytes += int64(len(accepted))
 	r.files++
-	sum := sha256.Sum256(data)
-	return PolicyFile{Bytes: data, Sha256: "sha256:" + hex.EncodeToString(sum[:])}, nil
+	sum := sha256.Sum256(accepted)
+	return PolicyFile{Bytes: accepted, Sha256: "sha256:" + hex.EncodeToString(sum[:])}, nil
 }
 
 type policyFileStat struct {
 	dev, ino, mode, uid, gid, nlink uint64
-	size                            int64
-	modTime                         int64
-	changeTime                      int64
+	size, modTime, changeTime       int64
 }
 
 // ReadAndPin pins a file snapshot for one following Read.
@@ -189,8 +195,8 @@ func statTrustedPolicyFile(file *os.File, path string) (policyFileStat, error) {
 	}
 	modTime, changeTime := policyFileTimes(stat)
 	return policyFileStat{
-		dev: uint64(stat.Dev), ino: uint64(stat.Ino), mode: mode, uid: uint64(stat.Uid), gid: uint64(stat.Gid), nlink: uint64(stat.Nlink), size: stat.Size,
-		modTime: modTime, changeTime: changeTime,
+		dev: uint64(stat.Dev), ino: uint64(stat.Ino), mode: mode, uid: uint64(stat.Uid), gid: uint64(stat.Gid),
+		nlink: uint64(stat.Nlink), size: stat.Size, modTime: modTime, changeTime: changeTime,
 	}, nil
 }
 

--- a/internal/injectionpolicy/reader.go
+++ b/internal/injectionpolicy/reader.go
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injectionpolicy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/sys/unix"
+)
+
+// PolicyFileMaxBytes is the maximum size of one policy file read.
+const PolicyFileMaxBytes int64 = 16 << 20
+
+// PolicyBundleMaxBytes is the maximum size of one policy bundle.
+const PolicyBundleMaxBytes int64 = 64 << 20
+
+// PolicyBundleMaxFiles is the maximum files in one policy bundle.
+const PolicyBundleMaxFiles = 4096
+
+// PolicyFile contains one accepted descriptor snapshot.
+type PolicyFile struct {
+	Bytes  []byte
+	Sha256 string
+}
+
+// BundleReader bounds one policy bundle.
+type BundleReader struct {
+	bytes             int64
+	files             int
+	fileLimit         int64
+	bundleLimit       int64
+	fileLimitCount    int
+	beforeOpenLeaf    func()
+	beforeFinalStat   func()
+	beforeConfirmRead func(*os.File)
+	beforeConfirmStat func()
+	snapshots         map[string]PolicyFile
+}
+
+// NewBundleReader returns a reader with a fresh bundle budget.
+func NewBundleReader() *BundleReader {
+	return NewBundleReaderWithLimits(PolicyFileMaxBytes, PolicyBundleMaxBytes, PolicyBundleMaxFiles)
+}
+
+// NewBundleReaderWithLimits creates a reader for test limits.
+func NewBundleReaderWithLimits(fileLimit, bundleLimit int64, fileLimitCount int) *BundleReader {
+	return &BundleReader{fileLimit: fileLimit, bundleLimit: bundleLimit, fileLimitCount: fileLimitCount}
+}
+
+// Read reads one policy file and accounts for its bundle limits.
+func (r *BundleReader) Read(path string) (PolicyFile, error) {
+	if r == nil {
+		return PolicyFile{}, fmt.Errorf("injection policy reader is nil")
+	}
+	if snapshot, ok := r.snapshots[path]; ok {
+		delete(r.snapshots, path)
+		return snapshot, nil
+	}
+	if r.fileLimit <= 0 || r.bundleLimit <= 0 || r.fileLimitCount <= 0 || r.fileLimit > PolicyFileMaxBytes || r.bundleLimit > PolicyBundleMaxBytes || r.fileLimitCount > PolicyBundleMaxFiles {
+		return PolicyFile{}, errors.New("injection policy reader has invalid limits")
+	}
+	if r.files >= r.fileLimitCount {
+		return PolicyFile{}, fmt.Errorf("injection policy bundle exceeds the include/file count limit of %d: %s", r.fileLimitCount, path)
+	}
+	remaining := r.bundleLimit - r.bytes
+	if remaining < 0 {
+		remaining = 0
+	}
+	limit := r.fileLimit
+	limitName := "per-file limit"
+	if remaining < limit {
+		limit = remaining
+		limitName = "aggregate bundle limit"
+	}
+
+	file, err := openPolicyFileNoFollow(path, r.beforeOpenLeaf)
+	if err != nil {
+		return PolicyFile{}, err
+	}
+	before, err := statTrustedPolicyFile(file, path)
+	if err != nil {
+		return PolicyFile{}, closePolicyFile(err, file, path)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil {
+		return PolicyFile{}, closePolicyFile(fmt.Errorf("read injection policy %s: %w", path, err), file, path)
+	}
+	if r.beforeFinalStat != nil {
+		r.beforeFinalStat()
+	}
+	after, err := statTrustedPolicyFile(file, path)
+	if err != nil {
+		return PolicyFile{}, closePolicyFile(err, file, path)
+	}
+	if !samePolicyFile(before, after) {
+		return PolicyFile{}, closePolicyFile(fmt.Errorf("injection policy changed while it was read: %s", path), file, path)
+	}
+	if int64(len(data)) > limit {
+		max := limit
+		if limitName == "aggregate bundle limit" {
+			max = r.bundleLimit
+		}
+		return PolicyFile{}, closePolicyFile(fmt.Errorf("injection policy %s exceeds the %s of %d bytes", path, limitName, max), file, path)
+	}
+	if after.size != int64(len(data)) {
+		return PolicyFile{}, closePolicyFile(fmt.Errorf("injection policy byte count changed while it was read: %s", path), file, path)
+	}
+	if !utf8.Valid(data) {
+		return PolicyFile{}, closePolicyFile(fmt.Errorf("injection policy must contain valid UTF-8: %s", path), file, path)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return PolicyFile{}, closePolicyFile(fmt.Errorf("rewind injection policy %s: %w", path, err), file, path)
+	}
+	if r.beforeConfirmRead != nil {
+		r.beforeConfirmRead(file)
+	}
+	confirmed, err := io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil {
+		return PolicyFile{}, closePolicyFile(fmt.Errorf("confirm injection policy %s: %w", path, err), file, path)
+	}
+	if len(confirmed) != len(data) || sha256.Sum256(confirmed) != sha256.Sum256(data) {
+		return PolicyFile{}, closePolicyFile(fmt.Errorf("injection policy changed while it was read: %s", path), file, path)
+	}
+	if r.beforeConfirmStat != nil {
+		r.beforeConfirmStat()
+	}
+	confirmedStat, err := statTrustedPolicyFile(file, path)
+	if err != nil {
+		return PolicyFile{}, closePolicyFile(err, file, path)
+	}
+	if !samePolicyFile(before, confirmedStat) {
+		return PolicyFile{}, closePolicyFile(fmt.Errorf("injection policy changed while it was read: %s", path), file, path)
+	}
+	if err := file.Close(); err != nil {
+		return PolicyFile{}, fmt.Errorf("close injection policy %s: %w", path, err)
+	}
+
+	r.bytes += int64(len(data))
+	r.files++
+	sum := sha256.Sum256(data)
+	return PolicyFile{Bytes: data, Sha256: "sha256:" + hex.EncodeToString(sum[:])}, nil
+}
+
+type policyFileStat struct {
+	dev, ino, mode, uid, gid, nlink uint64
+	size                            int64
+	modTime                         int64
+	changeTime                      int64
+}
+
+// ReadAndPin pins a file snapshot for one following Read.
+func (r *BundleReader) ReadAndPin(path string) (PolicyFile, error) {
+	file, err := r.Read(path)
+	if err != nil {
+		return PolicyFile{}, err
+	}
+	if r.snapshots == nil {
+		r.snapshots = make(map[string]PolicyFile)
+	}
+	r.snapshots[path] = file
+	return file, nil
+}
+
+func statTrustedPolicyFile(file *os.File, path string) (policyFileStat, error) {
+	var stat unix.Stat_t
+	if err := unix.Fstat(int(file.Fd()), &stat); err != nil {
+		return policyFileStat{}, fmt.Errorf("fstat injection policy %s: %w", path, err)
+	}
+	mode := uint64(stat.Mode)
+	if mode&unix.S_IFMT != unix.S_IFREG || stat.Ino == 0 || stat.Nlink != 1 {
+		return policyFileStat{}, fmt.Errorf("injection policy %s must be a regular file with exactly one link", path)
+	}
+	if stat.Uid != policyCurrentEUID() || mode&0o022 != 0 {
+		return policyFileStat{}, fmt.Errorf("injection policy %s must be owned by the current user and not writable by group or other users", path)
+	}
+	if err := rejectPolicyACL(int(file.Fd())); err != nil {
+		return policyFileStat{}, fmt.Errorf("injection policy file has an extended ACL: %s: %w", path, err)
+	}
+	modTime, changeTime := policyFileTimes(stat)
+	return policyFileStat{
+		dev: uint64(stat.Dev), ino: uint64(stat.Ino), mode: mode, uid: uint64(stat.Uid), gid: uint64(stat.Gid), nlink: uint64(stat.Nlink), size: stat.Size,
+		modTime: modTime, changeTime: changeTime,
+	}, nil
+}
+
+func samePolicyFile(before, after policyFileStat) bool {
+	return before.dev == after.dev && before.ino == after.ino && before.mode == after.mode && before.uid == after.uid && before.gid == after.gid && before.nlink == after.nlink && before.size == after.size && before.modTime == after.modTime && before.changeTime == after.changeTime
+}
+
+func closePolicyFile(cause error, file *os.File, path string) error {
+	if err := file.Close(); err != nil {
+		return errors.Join(cause, fmt.Errorf("close injection policy %s: %w", path, err))
+	}
+	return cause
+}
+
+// ReadFile reads one policy file with default limits.
+func ReadFile(path string) ([]byte, error) {
+	reader := NewBundleReader()
+	file, err := reader.Read(path)
+	if err != nil {
+		return nil, err
+	}
+	return file.Bytes, nil
+}
+
+func openPolicyFileNoFollow(path string, beforeOpenLeaf func()) (*os.File, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("make injection policy path absolute %s: %w", path, err)
+	}
+	abs = canonicalPolicySystemPath(filepath.Clean(abs))
+	if !filepath.IsAbs(abs) || abs == string(filepath.Separator) {
+		return nil, fmt.Errorf("injection policy path must name a file: %s", path)
+	}
+
+	components := strings.Split(strings.TrimPrefix(abs, string(filepath.Separator)), string(filepath.Separator))
+	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open injection policy root for %s: %w", path, err)
+	}
+	var rootStat unix.Stat_t
+	if err := unix.Fstat(fd, &rootStat); err != nil {
+		return nil, errors.Join(fmt.Errorf("stat injection policy root for %s: %w", path, err), closeUnixError(unix.Close(fd), "root", path))
+	}
+	anchored, err := validatePolicyDirectory(fd, string(filepath.Separator), rootStat, false)
+	if err != nil {
+		return nil, errors.Join(fmt.Errorf("validate injection policy root for %s: %w", path, err), closeUnixError(unix.Close(fd), "root", path))
+	}
+	for index, component := range components {
+		if component == "" || component == "." || component == ".." {
+			return nil, errors.Join(fmt.Errorf("injection policy path has an unsafe component: %s", path), closeUnixError(unix.Close(fd), "parent", path))
+		}
+		leaf := index == len(components)-1
+		if leaf && beforeOpenLeaf != nil {
+			beforeOpenLeaf()
+		}
+		flags := unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_CLOEXEC | unix.O_NONBLOCK
+		if !leaf {
+			flags |= unix.O_DIRECTORY
+		}
+		nextFD, openErr := unix.Openat(fd, component, flags, 0)
+		closeErr := unix.Close(fd)
+		if openErr != nil {
+			if errors.Is(openErr, unix.ELOOP) || errors.Is(openErr, unix.ENOTDIR) {
+				return nil, errors.Join(fmt.Errorf("injection policy path contains a symbolic link or non-directory component: %s", path), closeUnixError(closeErr, "parent", path))
+			}
+			return nil, errors.Join(fmt.Errorf("open injection policy component %q in %s: %w", component, abs, openErr), closeUnixError(closeErr, "parent", path))
+		}
+		if closeErr != nil {
+			return nil, errors.Join(fmt.Errorf("close injection policy parent for %s: %w", path, closeErr), closeUnixError(unix.Close(nextFD), "component", path))
+		}
+		if !leaf {
+			var stat unix.Stat_t
+			if err := unix.Fstat(nextFD, &stat); err != nil {
+				return nil, errors.Join(fmt.Errorf("stat injection policy directory %s: %w", path, err), closeUnixError(unix.Close(nextFD), "directory", path))
+			}
+			currentPath := string(filepath.Separator) + strings.Join(components[:index+1], string(filepath.Separator))
+			nextAnchored, err := validatePolicyDirectory(nextFD, currentPath, stat, anchored)
+			if err != nil {
+				return nil, errors.Join(err, closeUnixError(unix.Close(nextFD), "directory", path))
+			}
+			anchored = nextAnchored
+		} else if !anchored {
+			return nil, errors.Join(fmt.Errorf("injection policy must be beneath a current-user-controlled directory: %s", path), closeUnixError(unix.Close(nextFD), "file", path))
+		}
+		fd = nextFD
+	}
+
+	if fd < 0 {
+		return nil, fmt.Errorf("open injection policy returned an invalid descriptor: %s", path)
+	}
+	// #nosec G115 -- successful unix.Openat calls return a nonnegative int file descriptor.
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		return nil, errors.Join(fmt.Errorf("open injection policy: %s", path), closeUnixError(unix.Close(fd), "file", path))
+	}
+	return file, nil
+}
+
+func closeUnixError(err error, label, path string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("close injection policy %s for %s: %w", label, path, err)
+}
+
+func validatePolicyDirectory(fd int, path string, stat unix.Stat_t, anchored bool) (bool, error) {
+	mode := uint64(stat.Mode)
+	if mode&unix.S_IFMT != unix.S_IFDIR || stat.Ino == 0 {
+		return false, fmt.Errorf("injection policy path contains a non-directory component: %s", path)
+	}
+	ownedAndControlled := stat.Uid == policyCurrentEUID() && mode&0o022 == 0
+	if anchored {
+		if !ownedAndControlled {
+			return false, fmt.Errorf("injection policy directory below the current-user-controlled anchor is unsafe: %s", path)
+		}
+		if err := rejectPolicyACL(fd); err != nil {
+			return false, fmt.Errorf("injection policy directory has an extended ACL: %s: %w", path, err)
+		}
+		return true, nil
+	}
+	if stat.Uid == 0 && (mode&0o022 == 0 || mode&unix.S_ISVTX != 0) {
+		anchored = policyCurrentEUID() == 0 && mode&0o077 == 0 && mode&unix.S_ISVTX == 0
+	} else if ownedAndControlled {
+		anchored = true
+	} else {
+		return false, fmt.Errorf("injection policy directory ancestor is not trusted: %s", path)
+	}
+	if err := rejectPolicyACL(fd); err != nil {
+		return false, fmt.Errorf("injection policy directory has an extended ACL: %s: %w", path, err)
+	}
+	return anchored, nil
+}
+
+var policyCurrentEUID = func() uint32 { return uint32(os.Geteuid()) }
+
+func canonicalPolicySystemPath(path string) string {
+	if runtime.GOOS != "darwin" {
+		return path
+	}
+	for _, prefix := range []string{"/var", "/etc", "/tmp"} {
+		if path == prefix || strings.HasPrefix(path, prefix+string(filepath.Separator)) {
+			return filepath.Join("/private", strings.TrimPrefix(path, string(filepath.Separator)))
+		}
+	}
+	return path
+}

--- a/internal/injectionpolicy/reader_acl.go
+++ b/internal/injectionpolicy/reader_acl.go
@@ -7,9 +7,11 @@ import "strings"
 
 var rejectPolicyACL = rejectPolicyExtendedACL
 
-func isPolicyACLName(name string) bool {
+func isPolicyACLName(name string, allowPOSIX bool) bool {
 	switch name {
-	case "system.nfs4_acl", "system.posix_acl_access", "system.posix_acl_default", "system.richacl", "system.cifs_acl", "system.cifs_ntsd", "system.cifs_ntsd_full", "security.NTACL":
+	case "system.posix_acl_access", "system.posix_acl_default":
+		return !allowPOSIX
+	case "system.nfs4_acl", "system.richacl", "system.cifs_acl", "system.cifs_ntsd", "system.cifs_ntsd_full", "security.NTACL":
 		return true
 	default:
 		return strings.HasPrefix(name, "system.smb3_")

--- a/internal/injectionpolicy/reader_acl.go
+++ b/internal/injectionpolicy/reader_acl.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injectionpolicy
+
+import "strings"
+
+var rejectPolicyACL = rejectPolicyExtendedACL
+
+func isPolicyACLName(name string) bool {
+	switch name {
+	case "system.nfs4_acl", "system.posix_acl_access", "system.posix_acl_default", "system.richacl", "system.cifs_acl", "system.cifs_ntsd", "system.cifs_ntsd_full", "security.NTACL":
+		return true
+	default:
+		return strings.HasPrefix(name, "system.smb3_")
+	}
+}

--- a/internal/injectionpolicy/reader_acl_darwin.go
+++ b/internal/injectionpolicy/reader_acl_darwin.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin && cgo
+
+package injectionpolicy
+
+/*
+#include <errno.h>
+#include <grp.h>
+#include <membership.h>
+#include <string.h>
+#include <sys/acl.h>
+static int policy_no_acl_flags(acl_entry_t entry) {
+	acl_flagset_t flags;
+	if (acl_get_flagset_np(entry, &flags) != 0) {
+		return 0;
+	}
+	for (unsigned int bit = 1; bit <= (1U << 30); bit <<= 1)
+		if (acl_get_flag_np(flags, (acl_flag_t)bit) != 0) {
+			return 0;
+		}
+	return 1;
+}
+static int policy_standard_deny_acl(int fd) {
+	struct group group, *found = NULL;
+	char buffer[4096]; uuid_t everyone;
+	if (getgrnam_r("everyone", &group, buffer, sizeof(buffer), &found) != 0 || !found || mbr_gid_to_uuid(group.gr_gid, everyone) != 0) {
+		return 0;
+	}
+	acl_t acl = acl_get_fd_np(fd, ACL_TYPE_EXTENDED);
+	acl_entry_t entry; acl_tag_t tag; acl_permset_mask_t perms; guid_t *qualifier;
+	if (!acl || acl_valid(acl) != 0 || acl_get_entry(acl, ACL_FIRST_ENTRY, &entry) != 0 || acl_get_tag_type(entry, &tag) != 0 || acl_get_permset_mask_np(entry, &perms) != 0 || !(qualifier = acl_get_qualifier(entry))) {
+		if (acl) acl_free(acl);
+		return 0;
+	}
+	int safe = tag == ACL_EXTENDED_DENY && perms == ACL_DELETE && policy_no_acl_flags(entry) && memcmp(qualifier, everyone, sizeof(everyone)) == 0;
+	acl_free(qualifier);
+	if (!safe) {
+		acl_free(acl);
+		return 0;
+	}
+	errno = 0;
+	safe = acl_get_entry(acl, ACL_NEXT_ENTRY, &entry) == -1 && errno == EINVAL;
+	acl_free(acl);
+	return safe;
+}
+*/
+import "C"
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func rejectPolicyExtendedACL(fd int) error {
+	attributes := unix.Attrlist{Bitmapcount: unix.ATTR_BIT_MAP_COUNT, Commonattr: unix.ATTR_CMN_EXTENDED_SECURITY}
+	var buffer [12]byte
+	_, _, errno := unix.Syscall6(unix.SYS_FGETATTRLIST, uintptr(fd), uintptr(unsafe.Pointer(&attributes)), uintptr(unsafe.Pointer(&buffer[0])), uintptr(len(buffer)), unix.FSOPT_REPORT_FULLSIZE, 0)
+	if errno != 0 {
+		return fmt.Errorf("inspect extended ACL: %w", errno)
+	}
+	if binary.LittleEndian.Uint32(buffer[:4]) < uint32(len(buffer)) {
+		return errors.New("inspect extended ACL: malformed attribute response")
+	}
+	if binary.LittleEndian.Uint32(buffer[8:]) == 0 {
+		return nil
+	}
+	if C.policy_standard_deny_acl(C.int(fd)) != 1 {
+		return errors.New("extended ACL is not the permitted deny-only form")
+	}
+	return nil
+}

--- a/internal/injectionpolicy/reader_acl_darwin.go
+++ b/internal/injectionpolicy/reader_acl_darwin.go
@@ -57,7 +57,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func rejectPolicyExtendedACL(fd int) error {
+func rejectPolicyExtendedACL(fd int, _ bool) error {
 	attributes := unix.Attrlist{Bitmapcount: unix.ATTR_BIT_MAP_COUNT, Commonattr: unix.ATTR_CMN_EXTENDED_SECURITY}
 	var buffer [12]byte
 	_, _, errno := unix.Syscall6(unix.SYS_FGETATTRLIST, uintptr(fd), uintptr(unsafe.Pointer(&attributes)), uintptr(unsafe.Pointer(&buffer[0])), uintptr(len(buffer)), unix.FSOPT_REPORT_FULLSIZE, 0)

--- a/internal/injectionpolicy/reader_acl_darwin_nocgo.go
+++ b/internal/injectionpolicy/reader_acl_darwin_nocgo.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin && !cgo
+
+package injectionpolicy
+
+import "errors"
+
+func rejectPolicyExtendedACL(int) error { return errors.New("cannot inspect extended ACL without cgo") }

--- a/internal/injectionpolicy/reader_acl_darwin_nocgo.go
+++ b/internal/injectionpolicy/reader_acl_darwin_nocgo.go
@@ -7,4 +7,6 @@ package injectionpolicy
 
 import "errors"
 
-func rejectPolicyExtendedACL(int) error { return errors.New("cannot inspect extended ACL without cgo") }
+func rejectPolicyExtendedACL(int, bool) error {
+	return errors.New("cannot inspect extended ACL without cgo")
+}

--- a/internal/injectionpolicy/reader_acl_darwin_test.go
+++ b/internal/injectionpolicy/reader_acl_darwin_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin && cgo
+
+package injectionpolicy
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestBundleReaderDarwinACL(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		entries []string
+		wantOK  bool
+	}{
+		{"standard deny", []string{"group:everyone deny delete"}, true},
+		{"grant", []string{"group:everyone allow read"}, false},
+		{"other deny", []string{"group:staff deny delete"}, false},
+		{"other permission", []string{"group:everyone deny write"}, false},
+		{"inherited", []string{"group:everyone deny delete,file_inherit"}, false},
+		{"additional entry", []string{"group:staff deny delete", "group:everyone deny delete"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), "policy")
+			if err := os.Mkdir(dir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			path := writePolicyFile(t, dir, "policy.toml", []byte("version = 1\n"))
+			t.Cleanup(func() { _ = exec.Command("/bin/chmod", "-N", dir).Run() })
+			for _, entry := range tc.entries {
+				if output, err := exec.Command("/bin/chmod", "+a", entry, dir).CombinedOutput(); err != nil {
+					t.Fatalf("chmod: %v: %s", err, output)
+				}
+			}
+			_, err := NewBundleReader().Read(path)
+			if (err == nil) != tc.wantOK {
+				t.Fatalf("Read error = %v, want success=%t", err, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/injectionpolicy/reader_acl_linux.go
+++ b/internal/injectionpolicy/reader_acl_linux.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux
+
+package injectionpolicy
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const cifsSuperMagic = 0xff534d42
+
+var (
+	policyFstatfs    = unix.Fstatfs
+	policyFlistxattr = unix.Flistxattr
+)
+
+func rejectPolicyExtendedACL(fd int) error {
+	var filesystem unix.Statfs_t
+	if err := policyFstatfs(fd, &filesystem); err != nil {
+		return fmt.Errorf("identify filesystem for ACL proof: %w", err)
+	}
+	if isSMBFilesystem(int64(filesystem.Type)) {
+		return errors.New("cannot prove absence of SMB ACL descriptors")
+	}
+	for attempt := 0; attempt < 3; attempt++ {
+		size, err := policyFlistxattr(fd, nil)
+		if err != nil {
+			return fmt.Errorf("list extended attributes: %w", err)
+		}
+		if size == 0 {
+			return nil
+		}
+		if size > 64*1024 {
+			return errors.New("list extended attributes: oversized response")
+		}
+		buffer := make([]byte, size)
+		read, err := policyFlistxattr(fd, buffer)
+		if err == unix.ERANGE {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("read extended attributes: %w", err)
+		}
+		for _, name := range strings.Split(string(buffer[:read]), "\x00") {
+			if isPolicyACLName(name) {
+				return errors.New("extended ACLs are not permitted")
+			}
+		}
+		return nil
+	}
+	return errors.New("read extended attributes: attribute list changed repeatedly")
+}
+
+func isSMBFilesystem(filesystemType int64) bool {
+	return filesystemType == cifsSuperMagic || filesystemType == int64(unix.SMB_SUPER_MAGIC) || filesystemType == int64(unix.SMB2_SUPER_MAGIC)
+}

--- a/internal/injectionpolicy/reader_acl_linux.go
+++ b/internal/injectionpolicy/reader_acl_linux.go
@@ -20,14 +20,17 @@ var (
 	policyFlistxattr = unix.Flistxattr
 )
 
-func rejectPolicyExtendedACL(fd int) error {
+func rejectPolicyExtendedACL(fd int, allowPOSIX bool) error {
 	var filesystem unix.Statfs_t
 	if err := policyFstatfs(fd, &filesystem); err != nil {
 		return fmt.Errorf("identify filesystem for ACL proof: %w", err)
 	}
-	if isSMBFilesystem(int64(filesystem.Type)) {
-		return errors.New("cannot prove absence of SMB ACL descriptors")
+	if int64(filesystem.Type) == int64(unix.NFS_SUPER_MAGIC) || isSMBFilesystem(int64(filesystem.Type)) {
+		return errors.New("cannot prove absence of NFS, CIFS, or SMB ACL descriptors")
 	}
+	// Linux synchronizes access masks with group mode bits.
+	// EXT2_SUPER_MAGIC covers ext2, ext3, and ext4. Default ACLs do not grant current access.
+	allowPOSIX = allowPOSIX && isLocalPOSIXACLFilesystem(int64(filesystem.Type))
 	for attempt := 0; attempt < 3; attempt++ {
 		size, err := policyFlistxattr(fd, nil)
 		if err != nil {
@@ -48,7 +51,7 @@ func rejectPolicyExtendedACL(fd int) error {
 			return fmt.Errorf("read extended attributes: %w", err)
 		}
 		for _, name := range strings.Split(string(buffer[:read]), "\x00") {
-			if isPolicyACLName(name) {
+			if isPolicyACLName(name, allowPOSIX) {
 				return errors.New("extended ACLs are not permitted")
 			}
 		}
@@ -59,4 +62,12 @@ func rejectPolicyExtendedACL(fd int) error {
 
 func isSMBFilesystem(filesystemType int64) bool {
 	return filesystemType == cifsSuperMagic || filesystemType == int64(unix.SMB_SUPER_MAGIC) || filesystemType == int64(unix.SMB2_SUPER_MAGIC)
+}
+
+func isLocalPOSIXACLFilesystem(filesystemType int64) bool {
+	switch filesystemType {
+	case int64(unix.EXT2_SUPER_MAGIC), int64(unix.XFS_SUPER_MAGIC), int64(unix.BTRFS_SUPER_MAGIC), int64(unix.TMPFS_MAGIC), int64(unix.OVERLAYFS_SUPER_MAGIC):
+		return true
+	}
+	return false
 }

--- a/internal/injectionpolicy/reader_acl_linux_test.go
+++ b/internal/injectionpolicy/reader_acl_linux_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux
+
+package injectionpolicy
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestPolicyACLReaderRejectsUnprovableFilesystem(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.toml")
+	if err := os.WriteFile(path, []byte("version = 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	old := policyFstatfs
+	policyFstatfs = func(int, *unix.Statfs_t) error { return errors.New("no filesystem proof") }
+	t.Cleanup(func() { policyFstatfs = old })
+	if err := rejectPolicyExtendedACL(int(file.Fd())); err == nil || !strings.Contains(err.Error(), "ACL proof") {
+		t.Fatalf("rejectPolicyExtendedACL() = %v, want proof rejection", err)
+	}
+}
+
+func TestPolicyACLReaderRejectsSMBFilesystem(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.toml")
+	if err := os.WriteFile(path, []byte("version = 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	for _, filesystemType := range []int64{cifsSuperMagic, int64(unix.SMB_SUPER_MAGIC), int64(unix.SMB2_SUPER_MAGIC)} {
+		old := policyFstatfs
+		policyFstatfs = func(_ int, stat *unix.Statfs_t) error {
+			stat.Type = filesystemType
+			return nil
+		}
+		err := rejectPolicyExtendedACL(int(file.Fd()))
+		policyFstatfs = old
+		if err == nil || !strings.Contains(err.Error(), "SMB ACL") {
+			t.Fatalf("rejectPolicyExtendedACL() = %v, want SMB ACL rejection", err)
+		}
+	}
+}
+
+func TestPolicyACLReaderRejectsDescriptorXattrs(t *testing.T) {
+	path := writePolicyFile(t, t.TempDir(), "policy.toml", []byte("version = 1\n"))
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	oldStat, oldList := policyFstatfs, policyFlistxattr
+	policyFstatfs = func(int, *unix.Statfs_t) error { return nil }
+	t.Cleanup(func() { policyFstatfs, policyFlistxattr = oldStat, oldList })
+	for _, name := range []string{"system.cifs_acl", "system.cifs_ntsd", "system.cifs_ntsd_full", "system.smb3_acl", "security.NTACL"} {
+		policyFlistxattr = func(_ int, buffer []byte) (int, error) {
+			if buffer == nil {
+				return len(name) + 1, nil
+			}
+			copy(buffer, name+"\x00")
+			return len(name) + 1, nil
+		}
+		if err := rejectPolicyExtendedACL(int(file.Fd())); err == nil || !strings.Contains(err.Error(), "extended ACL") {
+			t.Fatalf("rejectPolicyExtendedACL(%q) = %v, want descriptor rejection", name, err)
+		}
+	}
+}
+
+func TestPolicyACLReaderAllowsNonACLXattr(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.toml")
+	if err := os.WriteFile(path, []byte("version = 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if err := unix.Fsetxattr(int(file.Fd()), "user.workcell", []byte("test"), 0); err != nil {
+		t.Skipf("user xattrs are unavailable: %v", err)
+	}
+	if err := rejectPolicyExtendedACL(int(file.Fd())); err != nil {
+		t.Fatalf("rejectPolicyExtendedACL() = %v, want nil", err)
+	}
+}

--- a/internal/injectionpolicy/reader_acl_linux_test.go
+++ b/internal/injectionpolicy/reader_acl_linux_test.go
@@ -8,93 +8,76 @@ package injectionpolicy
 import (
 	"errors"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"golang.org/x/sys/unix"
 )
 
-func TestPolicyACLReaderRejectsUnprovableFilesystem(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "policy.toml")
-	if err := os.WriteFile(path, []byte("version = 1\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	file, err := os.Open(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer file.Close()
-	old := policyFstatfs
-	policyFstatfs = func(int, *unix.Statfs_t) error { return errors.New("no filesystem proof") }
-	t.Cleanup(func() { policyFstatfs = old })
-	if err := rejectPolicyExtendedACL(int(file.Fd())); err == nil || !strings.Contains(err.Error(), "ACL proof") {
-		t.Fatalf("rejectPolicyExtendedACL() = %v, want proof rejection", err)
-	}
-}
-
-func TestPolicyACLReaderRejectsSMBFilesystem(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "policy.toml")
-	if err := os.WriteFile(path, []byte("version = 1\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	file, err := os.Open(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer file.Close()
-	for _, filesystemType := range []int64{cifsSuperMagic, int64(unix.SMB_SUPER_MAGIC), int64(unix.SMB2_SUPER_MAGIC)} {
-		old := policyFstatfs
-		policyFstatfs = func(_ int, stat *unix.Statfs_t) error {
-			stat.Type = filesystemType
-			return nil
-		}
-		err := rejectPolicyExtendedACL(int(file.Fd()))
-		policyFstatfs = old
-		if err == nil || !strings.Contains(err.Error(), "SMB ACL") {
-			t.Fatalf("rejectPolicyExtendedACL() = %v, want SMB ACL rejection", err)
-		}
-	}
-}
-
-func TestPolicyACLReaderRejectsDescriptorXattrs(t *testing.T) {
+func TestPolicyACLReaderACLProof(t *testing.T) {
 	path := writePolicyFile(t, t.TempDir(), "policy.toml", []byte("version = 1\n"))
 	file, err := os.Open(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer file.Close()
-	oldStat, oldList := policyFstatfs, policyFlistxattr
-	policyFstatfs = func(int, *unix.Statfs_t) error { return nil }
-	t.Cleanup(func() { policyFstatfs, policyFlistxattr = oldStat, oldList })
-	for _, name := range []string{"system.cifs_acl", "system.cifs_ntsd", "system.cifs_ntsd_full", "system.smb3_acl", "security.NTACL"} {
+	oldUser, oldStat, oldList := policyCurrentEUID, policyFstatfs, policyFlistxattr
+	policyCurrentEUID = func() uint32 { return 1000 }
+	policyFstatfs = func(_ int, stat *unix.Statfs_t) error { stat.Type = unix.OVERLAYFS_SUPER_MAGIC; return nil }
+	t.Cleanup(func() { policyCurrentEUID, policyFstatfs, policyFlistxattr = oldUser, oldStat, oldList })
+	fixture := func(name string) {
 		policyFlistxattr = func(_ int, buffer []byte) (int, error) {
-			if buffer == nil {
-				return len(name) + 1, nil
+			if buffer != nil {
+				copy(buffer, name+"\x00")
 			}
-			copy(buffer, name+"\x00")
 			return len(name) + 1, nil
 		}
-		if err := rejectPolicyExtendedACL(int(file.Fd())); err == nil || !strings.Contains(err.Error(), "extended ACL") {
-			t.Fatalf("rejectPolicyExtendedACL(%q) = %v, want descriptor rejection", name, err)
+	}
+	for _, test := range []struct {
+		name, attribute string
+		stat            unix.Stat_t
+		reject          bool
+	}{
+		{"home access ACL", "system.posix_acl_access", unix.Stat_t{Mode: unix.S_IFDIR | 0o755, Uid: 0, Ino: 1}, false},
+		{"home default ACL", "system.posix_acl_default", unix.Stat_t{Mode: unix.S_IFDIR | 0o755, Uid: 0, Ino: 1}, false},
+		{"normal xattr", "user.workcell", unix.Stat_t{Mode: unix.S_IFDIR | 0o755, Uid: 0, Ino: 1}, false},
+		{"effective write", "system.posix_acl_access", unix.Stat_t{Mode: unix.S_IFDIR | 0o775, Uid: 0, Ino: 1}, true},
+		{"NFS descriptor", "system.nfs4_acl", unix.Stat_t{Mode: unix.S_IFDIR | 0o755, Uid: 0, Ino: 1}, true},
+		{"Rich ACL", "system.richacl", unix.Stat_t{Mode: unix.S_IFDIR | 0o755, Uid: 0, Ino: 1}, true},
+		{"CIFS descriptor", "system.cifs_acl", unix.Stat_t{Mode: unix.S_IFDIR | 0o755, Uid: 0, Ino: 1}, true},
+		{"CIFS NTSD", "system.cifs_ntsd", unix.Stat_t{Mode: unix.S_IFDIR | 0o755, Uid: 0, Ino: 1}, true},
+		{"CIFS security descriptor", "system.cifs_ntsd_full", unix.Stat_t{Mode: unix.S_IFDIR | 0o755, Uid: 0, Ino: 1}, true},
+		{"SMB descriptor", "security.NTACL", unix.Stat_t{Mode: unix.S_IFDIR | 0o755, Uid: 0, Ino: 1}, true},
+		{"SMB3 descriptor", "system.smb3_acl", unix.Stat_t{Mode: unix.S_IFDIR | 0o755, Uid: 0, Ino: 1}, true},
+		{"current-user ancestor", "system.posix_acl_access", unix.Stat_t{Mode: unix.S_IFDIR | 0o700, Uid: 1000, Ino: 1}, true},
+		{"sticky transit", "system.posix_acl_access", unix.Stat_t{Mode: unix.S_IFDIR | unix.S_ISVTX | 0o777, Uid: 0, Ino: 1}, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture(test.attribute)
+			_, err := validatePolicyDirectory(int(file.Fd()), "/home", test.stat, false)
+			if (err != nil) != test.reject {
+				t.Fatalf("validatePolicyDirectory() = %v, want rejection=%t", err, test.reject)
+			}
+		})
+	}
+	policyFstatfs = func(_ int, stat *unix.Statfs_t) error { stat.Type = unix.FUSE_SUPER_MAGIC; return nil }
+	fixture("system.posix_acl_access")
+	if _, err := validatePolicyDirectory(int(file.Fd()), "/home", unix.Stat_t{Mode: unix.S_IFDIR | 0o755, Uid: 0, Ino: 1}, false); err == nil {
+		t.Fatal("validatePolicyDirectory accepted a POSIX ACL on FUSE")
+	}
+	for _, filesystemType := range []int64{int64(unix.EXT2_SUPER_MAGIC), int64(unix.XFS_SUPER_MAGIC), int64(unix.BTRFS_SUPER_MAGIC), int64(unix.TMPFS_MAGIC), int64(unix.OVERLAYFS_SUPER_MAGIC)} {
+		if !isLocalPOSIXACLFilesystem(filesystemType) {
+			t.Fatal("local POSIX ACL filesystem was rejected")
 		}
 	}
-}
-
-func TestPolicyACLReaderAllowsNonACLXattr(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "policy.toml")
-	if err := os.WriteFile(path, []byte("version = 1\n"), 0o600); err != nil {
-		t.Fatal(err)
+	policyFstatfs = func(int, *unix.Statfs_t) error { return errors.New("no filesystem proof") }
+	if err := rejectPolicyExtendedACL(int(file.Fd()), false); err == nil || !strings.Contains(err.Error(), "ACL proof") {
+		t.Fatalf("rejectPolicyExtendedACL() = %v, want proof rejection", err)
 	}
-	file, err := os.Open(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer file.Close()
-	if err := unix.Fsetxattr(int(file.Fd()), "user.workcell", []byte("test"), 0); err != nil {
-		t.Skipf("user xattrs are unavailable: %v", err)
-	}
-	if err := rejectPolicyExtendedACL(int(file.Fd())); err != nil {
-		t.Fatalf("rejectPolicyExtendedACL() = %v, want nil", err)
+	for _, filesystemType := range []int64{int64(unix.NFS_SUPER_MAGIC), cifsSuperMagic, int64(unix.SMB_SUPER_MAGIC), int64(unix.SMB2_SUPER_MAGIC)} {
+		policyFstatfs = func(_ int, stat *unix.Statfs_t) error { stat.Type = filesystemType; return nil }
+		if err := rejectPolicyExtendedACL(int(file.Fd()), false); err == nil || !strings.Contains(err.Error(), "ACL descriptors") {
+			t.Fatalf("rejectPolicyExtendedACL() = %v, want filesystem ACL rejection", err)
+		}
 	}
 }

--- a/internal/injectionpolicy/reader_test.go
+++ b/internal/injectionpolicy/reader_test.go
@@ -17,9 +17,9 @@ import (
 func TestBundleReaderRejectsFileACL(t *testing.T) {
 	path := writePolicyFile(t, t.TempDir(), "policy.toml", []byte("version = 1\n"))
 	old := rejectPolicyACL
-	rejectPolicyACL = func(fd int) error {
+	rejectPolicyACL = func(fd int, allowPOSIX bool) error {
 		var stat unix.Stat_t
-		if unix.Fstat(fd, &stat) != nil || stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		if allowPOSIX || unix.Fstat(fd, &stat) != nil || stat.Mode&unix.S_IFMT != unix.S_IFREG {
 			return nil
 		}
 		return errors.New("extended ACLs are not permitted")

--- a/internal/injectionpolicy/reader_test.go
+++ b/internal/injectionpolicy/reader_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injectionpolicy
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestBundleReaderRejectsFileACL(t *testing.T) {
+	path := writePolicyFile(t, t.TempDir(), "policy.toml", []byte("version = 1\n"))
+	old := rejectPolicyACL
+	rejectPolicyACL = func(fd int) error {
+		var stat unix.Stat_t
+		if unix.Fstat(fd, &stat) != nil || stat.Mode&unix.S_IFMT != unix.S_IFREG {
+			return nil
+		}
+		return errors.New("extended ACLs are not permitted")
+	}
+	t.Cleanup(func() { rejectPolicyACL = old })
+	if _, err := NewBundleReader().Read(path); err == nil || !strings.Contains(err.Error(), "extended ACL") {
+		t.Fatalf("Read error = %v, want ACL rejection", err)
+	}
+}
+
+func TestBundleReaderRejectsMutation(t *testing.T) {
+	for _, final := range []bool{false, true} {
+		t.Run(fmt.Sprintf("after confirmation=%t", final), func(t *testing.T) {
+			path := writePolicyFile(t, t.TempDir(), "policy.toml", []byte("version = 1\n"))
+			reader := NewBundleReader()
+			mutate := func() {
+				if err := os.WriteFile(path, []byte("version = 2\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if final {
+				reader.beforeConfirmStat = mutate
+			} else {
+				reader.beforeFinalStat = mutate
+			}
+			if _, err := reader.Read(path); err == nil || !strings.Contains(err.Error(), "changed while it was read") {
+				t.Fatalf("Read error = %v, want mutation rejection", err)
+			}
+		})
+	}
+}
+
+func TestBundleReaderConfirmsSecondRead(t *testing.T) {
+	path := writePolicyFile(t, t.TempDir(), "policy.toml", []byte("version = 1\n"))
+	reader := NewBundleReader()
+	reader.beforeConfirmRead = func(file *os.File) { _, _ = file.Seek(1, io.SeekStart) }
+	if _, err := reader.Read(path); err == nil || !strings.Contains(err.Error(), "changed while it was read") {
+		t.Fatalf("Read error = %v, want confirmation rejection", err)
+	}
+}
+
+func writePolicyFile(t *testing.T, dir, name string, content []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestBundleReaderRejectsInvalidUTF8(t *testing.T) {
+	path := writePolicyFile(t, t.TempDir(), "policy.toml", []byte{'\xff'})
+	if _, err := NewBundleReader().Read(path); err == nil || !strings.Contains(err.Error(), "valid UTF-8") {
+		t.Fatalf("Read error = %v, want UTF-8 rejection", err)
+	}
+}
+
+func TestBundleReaderReportsCurrentDirectory(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "policy")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := writePolicyFile(t, dir, "policy.toml", []byte("version = 1\n"))
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewBundleReader().Read(path); err == nil || !strings.Contains(err.Error(), dir) || strings.Contains(err.Error(), path) {
+		t.Fatalf("Read error = %v, want current directory %s", err, dir)
+	}
+}

--- a/internal/injectionpolicy/reader_test.go
+++ b/internal/injectionpolicy/reader_test.go
@@ -5,7 +5,6 @@ package injectionpolicy
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -32,8 +31,14 @@ func TestBundleReaderRejectsFileACL(t *testing.T) {
 }
 
 func TestBundleReaderRejectsMutation(t *testing.T) {
-	for _, final := range []bool{false, true} {
-		t.Run(fmt.Sprintf("after confirmation=%t", final), func(t *testing.T) {
+	for _, test := range []struct {
+		name              string
+		afterConfirmation bool
+	}{
+		{name: "after confirmation", afterConfirmation: true},
+		{name: "after accepted read"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
 			path := writePolicyFile(t, t.TempDir(), "policy.toml", []byte("version = 1\n"))
 			reader := NewBundleReader()
 			mutate := func() {
@@ -41,10 +46,14 @@ func TestBundleReaderRejectsMutation(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			if final {
-				reader.beforeConfirmStat = mutate
+			if test.afterConfirmation {
+				reader.afterConfirmRead = mutate
 			} else {
-				reader.beforeFinalStat = mutate
+				reader.beforeFinalStat = func() {
+					if err := os.Chmod(path, 0o400); err != nil {
+						t.Fatal(err)
+					}
+				}
 			}
 			if _, err := reader.Read(path); err == nil || !strings.Contains(err.Error(), "changed while it was read") {
 				t.Fatalf("Read error = %v, want mutation rejection", err)

--- a/internal/injectionpolicy/reader_times_darwin.go
+++ b/internal/injectionpolicy/reader_times_darwin.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin
+
+package injectionpolicy
+
+import "golang.org/x/sys/unix"
+
+func policyFileTimes(stat unix.Stat_t) (int64, int64) {
+	return stat.Mtim.Sec*1_000_000_000 + stat.Mtim.Nsec, stat.Ctim.Sec*1_000_000_000 + stat.Ctim.Nsec
+}

--- a/internal/injectionpolicy/reader_times_linux.go
+++ b/internal/injectionpolicy/reader_times_linux.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux
+
+package injectionpolicy
+
+import "golang.org/x/sys/unix"
+
+func policyFileTimes(stat unix.Stat_t) (int64, int64) {
+	return stat.Mtim.Sec*1_000_000_000 + stat.Mtim.Nsec, stat.Ctim.Sec*1_000_000_000 + stat.Ctim.Nsec
+}

--- a/internal/injectionpolicy/types.go
+++ b/internal/injectionpolicy/types.go
@@ -30,4 +30,7 @@ type PolicySource struct {
 	// rely on the prefix to distinguish the digest from a bare hex
 	// string.
 	Sha256 string `json:"sha256"`
+	// Fragment is the parsed file from the accepted descriptor snapshot.
+	// It is internal bundle state and never appears in source metadata.
+	Fragment map[string]any `json:"-"`
 }

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -94,6 +94,55 @@ var goHelperMutations = []mutationCase{
 		command:      goCmd("test", "./internal/injection"),
 	},
 	{
+		relativePath: "internal/injectionpolicy/reader.go",
+		original:     "flags := unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_CLOEXEC | unix.O_NONBLOCK",
+		replacement:  "flags := unix.O_RDONLY | unix.O_CLOEXEC | unix.O_NONBLOCK",
+		label:        "injection policy no-follow open",
+		command:      goCmd("test", "./internal/injection"),
+	},
+	{
+		relativePath: "internal/injectionpolicy/reader.go",
+		original:     "if err := rejectPolicyACL(int(file.Fd())); err != nil {",
+		replacement:  "if err := rejectPolicyACL(int(file.Fd())); false && err != nil {",
+		label:        "injection policy ACL proof",
+		command:      goCmd("test", "./internal/injectionpolicy"),
+	},
+	{
+		relativePath: "internal/injectionpolicy/reader.go",
+		original:     "if r.files >= r.fileLimitCount {",
+		replacement:  "if false {",
+		label:        "injection policy file limit",
+		command:      goCmd("test", "./internal/injection"),
+	},
+	{
+		relativePath: "internal/injectionpolicy/reader.go",
+		original:     "if snapshot, ok := r.snapshots[path]; ok {",
+		replacement:  "if snapshot, ok := r.snapshots[path]; false && ok {",
+		label:        "injection policy snapshot reuse",
+		command:      goCmd("test", "./internal/injection"),
+	},
+	{
+		relativePath: "internal/injection/render_policy_load.go",
+		original:     "Sha256:   file.Sha256,",
+		replacement:  "Sha256: \"\",",
+		label:        "injection policy digest binding",
+		command:      goCmd("test", "./internal/injection"),
+	},
+	{
+		relativePath: "internal/injectionpolicy/reader.go",
+		original:     "confirmed, err := io.ReadAll(io.LimitReader(file, limit+1))",
+		replacement:  "confirmed := data",
+		label:        "injection policy confirmation read",
+		command:      goCmd("test", "./internal/injectionpolicy"),
+	},
+	{
+		relativePath: "internal/injectionpolicy/reader.go",
+		original:     "return before.dev == after.dev && before.ino == after.ino && before.mode == after.mode && before.uid == after.uid && before.gid == after.gid && before.nlink == after.nlink && before.size == after.size && before.modTime == after.modTime && before.changeTime == after.changeTime",
+		replacement:  "return true",
+		label:        "injection policy metadata comparison",
+		command:      goCmd("test", "./internal/injectionpolicy"),
+	},
+	{
 		relativePath: "internal/injection/render_injection_bundle.go",
 		original:     `"sendenv":             {},`,
 		replacement:  `// "sendenv":             {},`,
@@ -224,7 +273,7 @@ func runGoHelperMutations(repoRoot string) (killed, total int, survivors []strin
 			}
 			defer os.RemoveAll(tempRoot)
 
-			for _, relativePath := range []string{"cmd", "internal", "go.mod", "go.sum"} {
+			for _, relativePath := range []string{"adapters", "cmd", "docs", "internal", "policy", "go.mod", "go.sum"} {
 				if err := copyIntoTempRoot(repoRoot, tempRoot, relativePath); err != nil {
 					results <- result{label: tc.label, err: err}
 					return

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -102,8 +102,8 @@ var goHelperMutations = []mutationCase{
 	},
 	{
 		relativePath: "internal/injectionpolicy/reader.go",
-		original:     "if err := rejectPolicyACL(int(file.Fd())); err != nil {",
-		replacement:  "if err := rejectPolicyACL(int(file.Fd())); false && err != nil {",
+		original:     "if err := rejectPolicyACL(int(file.Fd()), false); err != nil {",
+		replacement:  "if err := rejectPolicyACL(int(file.Fd()), false); false && err != nil {",
 		label:        "injection policy ACL proof",
 		command:      goCmd("test", "./internal/injectionpolicy"),
 	},

--- a/policy/mutation-score-policy.json
+++ b/policy/mutation-score-policy.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "baseline_score": 100.0,
-  "expected_mutants": 14
+  "expected_mutants": 21
 }


### PR DESCRIPTION
## Summary

- Bound injection-policy reads to trusted file descriptors.
- Enforce file, bundle, owner, mode, link, ancestor, and ACL limits.
- Use one accepted snapshot for parsing, source records, and SHA-256 digests.
- Apply the shared reader to renderer, resolver, policy, and inspection paths.

## Security evidence

- Sol review found no actionable issue after the final race correction.
- Twenty-one mutation tests fail when required controls are removed.
- Repeated race tests reject same-size content changes.
- Live policy, authentication, resolver, and assurance scenarios passed.

## Validation

- `./scripts/pre-merge.sh --profile pr-parity`
- Focused Go tests and race tests
- Full Go vet
- Cross-platform compile checks
- Contract, document, format, and diff checks
