### PR TITLE
Bound runtime manifest input and publication

### DIFF
--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -373,6 +373,8 @@ credentials, and copies.
 - The safe path does not pass a complete host home.
 - `[[copies]]` cannot write Workcell control-plane paths.
 - Workcell does not forward `SSH_AUTH_SOCK`.
+- Workcell reads an injection manifest only from one regular file of 16 MiB or less.
+- Workcell reads a direct-mount specification only from one regular file of 1 MiB or less.
 - Processes in one session do not receive isolation from each other.
 - Copilot does not receive host provider homes, keychains, or ambient CLI auth.
 - Strict mode does not set provider telemetry or content-capture variables.

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -408,8 +408,10 @@ The parser and SHA-256 source record use the accepted descriptor snapshot.
 - The safe path does not pass a complete host home.
 - `[[copies]]` cannot write Workcell control-plane paths.
 - Workcell does not forward `SSH_AUTH_SOCK`.
-- Workcell reads an injection manifest only from one regular file of 16 MiB or less.
-- Workcell reads a direct-mount specification only from one regular file of 1 MiB or less.
+- Workcell reads an injection manifest only from a regular file of 16 MiB or less.
+- Workcell writes an injection manifest only to a regular file of 16 MiB or less.
+- Workcell reads a direct-mount specification only from a regular file of 1 MiB or less.
+- Workcell writes a direct-mount specification only to a regular file of 1 MiB or less.
 - Processes in one session do not receive isolation from each other.
 - Copilot does not receive host provider homes, keychains, or ambient CLI auth.
 - Strict mode does not set provider telemetry or content-capture variables.

--- a/internal/host/hoststate/hoststate.go
+++ b/internal/host/hoststate/hoststate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/omkhar/workcell/internal/host/launcher"
 	"github.com/omkhar/workcell/internal/host/sessions"
 	"github.com/omkhar/workcell/internal/pathutil"
+	"github.com/omkhar/workcell/internal/rootio"
 )
 
 func AuditRecordDigest(prevDigest, timestamp string, args []string) string {
@@ -517,7 +518,7 @@ func canonicalizePath(path string) (string, error) {
 }
 
 func readJSONFile(path string, target any) error {
-	content, err := os.ReadFile(path)
+	content, err := rootio.ReadFileNoFollow(path, "JSON metadata", rootio.MaxManifestBytes)
 	if err != nil {
 		return err
 	}

--- a/internal/host/hoststate/hoststate_test.go
+++ b/internal/host/hoststate/hoststate_test.go
@@ -4,6 +4,7 @@
 package hoststate
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -17,6 +18,8 @@ import (
 	"time"
 
 	"github.com/omkhar/workcell/internal/host/launcher"
+	"github.com/omkhar/workcell/internal/rootio"
+	"golang.org/x/sys/unix"
 )
 
 func TestDirectMountCacheKeyMatchesNULTerminatedHash(t *testing.T) {
@@ -27,6 +30,61 @@ func TestDirectMountCacheKeyMatchesNULTerminatedHash(t *testing.T) {
 	want := hex.EncodeToString(sum[:8])
 	if got != want {
 		t.Fatalf("DirectMountCacheKey() = %q, want %q", got, want)
+	}
+}
+
+func TestManifestMetadataLinesUsesBoundedNoFollowReads(t *testing.T) {
+	root := t.TempDir()
+	exactPath := filepath.Join(root, "manifest.json")
+	exact := append([]byte(`{"metadata":{}}`), bytes.Repeat([]byte{' '}, int(rootio.MaxManifestBytes)-len(`{"metadata":{}}`))...)
+	if err := os.WriteFile(exactPath, exact, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if lines, err := ManifestMetadataLines(exactPath); err != nil || len(lines) != 7 {
+		t.Fatalf("ManifestMetadataLines exact limit = %#v, %v", lines, err)
+	}
+
+	overLimitPath := filepath.Join(root, "over-limit.json")
+	if err := os.WriteFile(overLimitPath, append(exact, ' '), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ManifestMetadataLines(overLimitPath); err == nil || !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("ManifestMetadataLines oversized error = %v, want byte-limit rejection", err)
+	}
+
+	target := filepath.Join(root, "target.json")
+	if err := os.WriteFile(target, []byte(`{"metadata":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	leafLink := filepath.Join(root, "manifest-link.json")
+	if err := os.Symlink(filepath.Base(target), leafLink); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	if _, err := ManifestMetadataLines(leafLink); err == nil {
+		t.Fatal("ManifestMetadataLines accepted a leaf symlink")
+	}
+
+	realParent := filepath.Join(root, "real-parent")
+	if err := os.Mkdir(realParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realParent, "manifest.json"), []byte(`{"metadata":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkedParent := filepath.Join(root, "linked-parent")
+	if err := os.Symlink(filepath.Base(realParent), linkedParent); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	if _, err := ManifestMetadataLines(filepath.Join(linkedParent, "manifest.json")); err == nil {
+		t.Fatal("ManifestMetadataLines accepted a symlinked parent")
+	}
+
+	fifo := filepath.Join(root, "manifest.fifo")
+	if err := unix.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("unix.Mkfifo unavailable: %v", err)
+	}
+	if _, err := ManifestMetadataLines(fifo); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("ManifestMetadataLines FIFO error = %v, want regular-file rejection", err)
 	}
 }
 

--- a/internal/injection/extract_direct_mounts.go
+++ b/internal/injection/extract_direct_mounts.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 
 	"github.com/omkhar/workcell/internal/pathutil"
+	"github.com/omkhar/workcell/internal/rootio"
 )
 
 // DirectMount is the JSON shape this binary emits for each direct mount.
@@ -36,29 +37,43 @@ func RequireDirectMount(entry map[string]any, label string) (DirectMount, error)
 
 // RunExtractDirectMounts reproduces the legacy extract_direct_mounts helper.
 func RunExtractDirectMounts(manifestPath, mountSpecPath string) error {
-	resolvedManifestPath, err := resolveAbsPath(manifestPath)
+	return runExtractDirectMounts(manifestPath, mountSpecPath, nil)
+}
+
+// runExtractDirectMounts retains the descriptor for the manifest parent from
+// the read through the atomic replacement. beforeManifestWrite is a test seam
+// for deterministic leaf mutation checks; production callers pass nil.
+func runExtractDirectMounts(manifestPath, mountSpecPath string, beforeManifestWrite func() error) error {
+	manifestInputPath, err := absoluteInputPath(manifestPath)
 	if err != nil {
 		return err
 	}
-	resolvedMountSpecPath, err := resolveAbsPath(mountSpecPath)
+	mountSpecOutputPath, err := absoluteInputPath(mountSpecPath)
 	if err != nil {
 		return err
 	}
 
-	manifest, err := loadJSONObject(resolvedManifestPath)
+	manifestParent, manifestName, manifest, err := openJSONObjectForRewrite(manifestInputPath)
 	if err != nil {
 		return err
 	}
+	defer manifestParent.Close()
 
 	directMounts, err := collectDirectMounts(manifest)
 	if err != nil {
 		return err
 	}
 
-	if err := writeIndentedJSON(resolvedManifestPath, manifest, 0o600); err != nil {
+	if err := writeIndentedJSONAtNoFollow(manifestParent, manifestName, manifest, 0o600, beforeManifestWrite); err != nil {
 		return err
 	}
-	if err := writeIndentedJSON(resolvedMountSpecPath, directMounts, 0o600); err != nil {
+
+	mountSpecParent, cleanedMountSpecPath, err := rootio.OpenParentDirectoryNoFollow(mountSpecOutputPath)
+	if err != nil {
+		return err
+	}
+	defer mountSpecParent.Close()
+	if err := writeIndentedJSONAtNoFollow(mountSpecParent, filepath.Base(cleanedMountSpecPath), directMounts, 0o600, nil); err != nil {
 		return err
 	}
 	return nil
@@ -159,16 +174,49 @@ func sortDirectMounts(directMounts []DirectMount) []DirectMount {
 	return directMounts
 }
 
-func loadJSONObject(path string) (map[string]any, error) {
-	data, err := os.ReadFile(path)
+func openJSONObjectForRewrite(path string) (*os.File, string, map[string]any, error) {
+	parent, cleaned, err := rootio.OpenParentDirectoryNoFollow(path)
 	if err != nil {
-		return nil, err
+		return nil, "", nil, err
+	}
+	name := filepath.Base(cleaned)
+	data, err := rootio.ReadFileAtNoFollow(parent, name, "injection manifest", maxInjectionManifestBytes)
+	if err != nil {
+		parent.Close()
+		return nil, "", nil, err
 	}
 	var manifest map[string]any
 	if err := json.Unmarshal(data, &manifest); err != nil {
-		return nil, err
+		parent.Close()
+		return nil, "", nil, err
 	}
-	return manifest, nil
+	return parent, name, manifest, nil
+}
+
+func writeIndentedJSONAtNoFollow(parent *os.File, name string, value any, mode os.FileMode, beforeWrite func() error) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if beforeWrite != nil {
+		if err := beforeWrite(); err != nil {
+			return err
+		}
+	}
+	return rootio.WriteFileAtomicAtNoFollow(parent, name, data, mode, ".workcell-manifest-")
+}
+
+func absoluteInputPath(raw string) (string, error) {
+	expanded, err := pathutil.ExpandUserPathStrictRequireNonEmpty(raw)
+	if err != nil {
+		return "", err
+	}
+	absolute, err := filepath.Abs(expanded)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(absolute), nil
 }
 
 func asObjectMap(value any, label string) (map[string]any, error) {

--- a/internal/injection/extract_direct_mounts.go
+++ b/internal/injection/extract_direct_mounts.go
@@ -44,11 +44,11 @@ func RunExtractDirectMounts(manifestPath, mountSpecPath string) error {
 // the read through the atomic replacement. beforeManifestWrite is a test seam
 // for deterministic leaf mutation checks; production callers pass nil.
 func runExtractDirectMounts(manifestPath, mountSpecPath string, beforeManifestWrite func() error) error {
-	manifestInputPath, err := absoluteInputPath(manifestPath)
+	manifestInputPath, err := pathutil.ExpandUserPathStrictRequireNonEmpty(manifestPath)
 	if err != nil {
 		return err
 	}
-	mountSpecOutputPath, err := absoluteInputPath(mountSpecPath)
+	mountSpecOutputPath, err := pathutil.ExpandUserPathStrictRequireNonEmpty(mountSpecPath)
 	if err != nil {
 		return err
 	}
@@ -58,22 +58,42 @@ func runExtractDirectMounts(manifestPath, mountSpecPath string, beforeManifestWr
 		return err
 	}
 	defer manifestParent.Close()
-
-	directMounts, err := collectDirectMounts(manifest)
-	if err != nil {
-		return err
-	}
-
-	if err := writeIndentedJSONAtNoFollow(manifestParent, manifestName, manifest, 0o600, beforeManifestWrite); err != nil {
-		return err
-	}
-
 	mountSpecParent, cleanedMountSpecPath, err := rootio.OpenParentDirectoryNoFollow(mountSpecOutputPath)
 	if err != nil {
 		return err
 	}
 	defer mountSpecParent.Close()
-	if err := writeIndentedJSONAtNoFollow(mountSpecParent, filepath.Base(cleanedMountSpecPath), directMounts, 0o600, nil); err != nil {
+	mountSpecName := filepath.Base(cleanedMountSpecPath)
+	sameFile, err := rootio.SameFileAtNoFollow(manifestParent, manifestName, mountSpecParent, mountSpecName)
+	if err != nil {
+		return err
+	}
+	if sameFile {
+		return fmt.Errorf("direct mount specification must not alias injection manifest")
+	}
+
+	directMounts, err := collectDirectMounts(manifest)
+	if err != nil {
+		return err
+	}
+	manifestData, err := marshalInjectionManifest(manifest)
+	if err != nil {
+		return err
+	}
+	mountSpecData, err := marshalInjectionMountSpec(directMounts)
+	if err != nil {
+		return err
+	}
+
+	if err := writeJSONAtNoFollow(mountSpecParent, mountSpecName, mountSpecData, 0o600); err != nil {
+		return err
+	}
+	if beforeManifestWrite != nil {
+		if err := beforeManifestWrite(); err != nil {
+			return err
+		}
+	}
+	if err := writeJSONAtNoFollow(manifestParent, manifestName, manifestData, 0o600); err != nil {
 		return err
 	}
 	return nil
@@ -193,30 +213,8 @@ func openJSONObjectForRewrite(path string) (*os.File, string, map[string]any, er
 	return parent, name, manifest, nil
 }
 
-func writeIndentedJSONAtNoFollow(parent *os.File, name string, value any, mode os.FileMode, beforeWrite func() error) error {
-	data, err := json.MarshalIndent(value, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	if beforeWrite != nil {
-		if err := beforeWrite(); err != nil {
-			return err
-		}
-	}
+func writeJSONAtNoFollow(parent *os.File, name string, data []byte, mode os.FileMode) error {
 	return rootio.WriteFileAtomicAtNoFollow(parent, name, data, mode, ".workcell-manifest-")
-}
-
-func absoluteInputPath(raw string) (string, error) {
-	expanded, err := pathutil.ExpandUserPathStrictRequireNonEmpty(raw)
-	if err != nil {
-		return "", err
-	}
-	absolute, err := filepath.Abs(expanded)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Clean(absolute), nil
 }
 
 func asObjectMap(value any, label string) (map[string]any, error) {

--- a/internal/injection/extract_direct_mounts_test.go
+++ b/internal/injection/extract_direct_mounts_test.go
@@ -210,28 +210,17 @@ func TestRunExtractDirectMountsWritesMode0600(t *testing.T) {
 }
 
 func TestRunExtractDirectMountsAtomicallyReplacesSwappedManifestLeaf(t *testing.T) {
-	fixture := map[string]any{"copies": []any{}}
-	expectedRoot := t.TempDir()
-	expectedManifest := filepath.Join(expectedRoot, "manifest.json")
-	expectedMounts := filepath.Join(expectedRoot, "mounts.json")
-	writeFixtureManifest(t, expectedManifest, fixture)
-	if err := RunExtractDirectMounts(expectedManifest, expectedMounts); err != nil {
-		t.Fatalf("prepare expected output: %v", err)
-	}
-	wantManifest := readFile(t, expectedManifest)
-	wantMounts := readFile(t, expectedMounts)
-
 	root := t.TempDir()
 	manifestPath := filepath.Join(root, "manifest.json")
 	mountSpecPath := filepath.Join(root, "mounts.json")
-	writeFixtureManifest(t, manifestPath, fixture)
+	writeFixtureManifest(t, manifestPath, map[string]any{"copies": []any{}})
 	outside := filepath.Join(root, "outside.json")
 	originalOutside := []byte(`{"outside":true}` + "\n")
-	if err := os.WriteFile(outside, originalOutside, 0o600); err != nil {
-		t.Fatal(err)
-	}
-
+	writeFile(t, outside, originalOutside)
 	err := runExtractDirectMounts(manifestPath, mountSpecPath, func() error {
+		if _, err := os.Stat(mountSpecPath); err != nil {
+			return err
+		}
 		if err := os.Rename(manifestPath, manifestPath+".original"); err != nil {
 			return err
 		}
@@ -240,15 +229,7 @@ func TestRunExtractDirectMountsAtomicallyReplacesSwappedManifestLeaf(t *testing.
 	if err != nil {
 		t.Fatalf("RunExtractDirectMounts after leaf swap: %v", err)
 	}
-	if got := readFile(t, manifestPath); !bytes.Equal(got, wantManifest) {
-		t.Fatalf("manifest output changed after leaf swap:\n got %q\nwant %q", got, wantManifest)
-	}
-	if got := readFile(t, mountSpecPath); !bytes.Equal(got, wantMounts) {
-		t.Fatalf("mount output changed after leaf swap:\n got %q\nwant %q", got, wantMounts)
-	}
-	if data := readFile(t, outside); !bytes.Equal(data, originalOutside) {
-		t.Fatalf("outside symlink target changed: %q", data)
-	}
+	assertFileBytes(t, outside, originalOutside)
 	if info, err := os.Lstat(manifestPath); err != nil || info.Mode()&os.ModeSymlink != 0 {
 		t.Fatalf("swapped manifest leaf was not atomically replaced: %v, %v", info, err)
 	}
@@ -260,22 +241,12 @@ func TestRunExtractDirectMountsAtomicallyReplacesMountSpecSymlink(t *testing.T) 
 	root := t.TempDir()
 	manifestPath := filepath.Join(root, "manifest.json")
 	writeFixtureManifest(t, manifestPath, map[string]any{"copies": []any{}})
-
-	outside := filepath.Join(root, "outside-mounts.json")
-	originalOutside := []byte(`{"outside":true}` + "\n")
-	if err := os.WriteFile(outside, originalOutside, 0o600); err != nil {
-		t.Fatal(err)
-	}
 	mountSpecPath := filepath.Join(root, "mounts.json")
-	if err := os.Symlink(filepath.Base(outside), mountSpecPath); err != nil {
+	if err := os.Symlink(filepath.Base(manifestPath), mountSpecPath); err != nil {
 		t.Skipf("os.Symlink unavailable: %v", err)
 	}
-
 	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err != nil {
 		t.Fatalf("RunExtractDirectMounts with symlinked mount output: %v", err)
-	}
-	if data := readFile(t, outside); !bytes.Equal(data, originalOutside) {
-		t.Fatalf("outside mount-spec target changed: %q", data)
 	}
 	if info, err := os.Lstat(mountSpecPath); err != nil || info.Mode()&os.ModeSymlink != 0 {
 		t.Fatalf("mount-spec leaf was not atomically replaced: %v, %v", info, err)
@@ -290,34 +261,86 @@ func TestRunExtractDirectMountsRejectsSymlinkedMountSpecParent(t *testing.T) {
 	root := t.TempDir()
 	manifestPath := filepath.Join(root, "manifest.json")
 	writeFixtureManifest(t, manifestPath, map[string]any{"copies": []any{}})
-
 	realParent := filepath.Join(root, "real-parent")
 	if err := os.Mkdir(realParent, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	mountSpecTarget := filepath.Join(realParent, "mounts.json")
 	originalTarget := []byte(`{"outside":true}` + "\n")
-	if err := os.WriteFile(mountSpecTarget, originalTarget, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeFile(t, mountSpecTarget, originalTarget)
 	linkedParent := filepath.Join(root, "linked-parent")
 	if err := os.Symlink(filepath.Base(realParent), linkedParent); err != nil {
 		t.Skipf("os.Symlink unavailable: %v", err)
 	}
-
 	if err := RunExtractDirectMounts(manifestPath, filepath.Join(linkedParent, "mounts.json")); err == nil {
 		t.Fatal("RunExtractDirectMounts accepted a symlinked mount-spec parent")
 	}
-	if data := readFile(t, mountSpecTarget); !bytes.Equal(data, originalTarget) {
-		t.Fatalf("symlinked mount-spec parent changed outside target: %q", data)
+	assertFileBytes(t, mountSpecTarget, originalTarget)
+}
+
+func TestRunExtractDirectMountsRejectsOutputAliasesBeforePublication(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.json")
+	original := []byte(`{"credentials":{"a":{"source":"s","mount_path":"m"}}}` + "\n")
+	writeFile(t, manifestPath, original)
+	hardLink := filepath.Join(root, "hardlink.json")
+	if err := os.Link(manifestPath, hardLink); err != nil {
+		t.Fatal(err)
 	}
+	aliases := []string{manifestPath, root + "/./manifest.json", hardLink}
+	if canonical, err := filepath.EvalSymlinks(root); err != nil {
+		t.Fatal(err)
+	} else if canonical != root {
+		aliases = append(aliases, filepath.Join(canonical, filepath.Base(manifestPath)))
+	}
+	caseAlias := filepath.Join(root, strings.ToUpper(filepath.Base(manifestPath)))
+	if info, err := os.Stat(caseAlias); err == nil {
+		manifestInfo, err := os.Stat(manifestPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if os.SameFile(info, manifestInfo) {
+			aliases = append(aliases, caseAlias)
+		}
+	} else if !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	for _, mountSpecPath := range aliases {
+		if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err == nil || !strings.Contains(err.Error(), "alias") {
+			t.Fatalf("RunExtractDirectMounts alias error = %v", err)
+		}
+		assertFileBytes(t, manifestPath, original)
+	}
+	mountSpecPath := filepath.Join(root, "mounts")
+	if err := os.Mkdir(mountSpecPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err == nil {
+		t.Fatal("RunExtractDirectMounts accepted a directory output")
+	}
+	assertFileBytes(t, manifestPath, original)
+	if info, err := os.Stat(mountSpecPath); err != nil || !info.IsDir() {
+		t.Fatalf("mount specification directory changed: %v, %v", info, err)
+	}
+}
+
+func TestRunExtractDirectMountsKeepsManifestWhenFinalPublicationFails(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.json")
+	mountSpecPath := filepath.Join(root, "mounts.json")
+	original := []byte(`{"credentials":{"a":{"source":"s","mount_path":"m"}}}` + "\n")
+	writeFile(t, manifestPath, original)
+	if err := runExtractDirectMounts(manifestPath, mountSpecPath, func() error { return os.ErrPermission }); err == nil {
+		t.Fatal("RunExtractDirectMounts accepted a final-manifest failure")
+	}
+	assertFileBytes(t, manifestPath, original)
+	assertFileBytes(t, mountSpecPath, []byte(`[{"source":"s","mount_path":"m"}]`+"\n"))
 }
 
 func TestRunExtractDirectMountsLeavesPlainCopySourcesInline(t *testing.T) {
 	root := t.TempDir()
 	manifestPath := filepath.Join(root, "manifest.json")
 	mountSpecPath := filepath.Join(root, "mounts.json")
-
 	writeFixtureManifest(t, manifestPath, map[string]any{
 		"copies": []any{
 			map[string]any{
@@ -330,7 +353,6 @@ func TestRunExtractDirectMountsLeavesPlainCopySourcesInline(t *testing.T) {
 	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err != nil {
 		t.Fatalf("RunExtractDirectMounts returned error: %v", err)
 	}
-
 	var manifest map[string]any
 	if err := json.Unmarshal(readFile(t, manifestPath), &manifest); err != nil {
 		t.Fatalf("json.Unmarshal manifest: %v", err)
@@ -360,9 +382,7 @@ func TestRunExtractDirectMountsRejectsUnsafeManifestPaths(t *testing.T) {
 	root := t.TempDir()
 	original := []byte(`{"copies":[]}` + "\n")
 	target := filepath.Join(root, "target.json")
-	if err := os.WriteFile(target, original, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeFile(t, target, original)
 	leafLink := filepath.Join(root, "leaf-link.json")
 	if err := os.Symlink(filepath.Base(target), leafLink); err != nil {
 		t.Skipf("os.Symlink unavailable: %v", err)
@@ -370,18 +390,14 @@ func TestRunExtractDirectMountsRejectsUnsafeManifestPaths(t *testing.T) {
 	if err := RunExtractDirectMounts(leafLink, filepath.Join(root, "mounts.json")); err == nil {
 		t.Fatal("RunExtractDirectMounts accepted a leaf symlink")
 	}
-	if data, err := os.ReadFile(target); err != nil || !bytes.Equal(data, original) {
-		t.Fatalf("leaf symlink changed target manifest: %q, %v", data, err)
-	}
+	assertFileBytes(t, target, original)
 
 	realParent := filepath.Join(root, "real-parent")
 	if err := os.Mkdir(realParent, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	parentTarget := filepath.Join(realParent, "manifest.json")
-	if err := os.WriteFile(parentTarget, original, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeFile(t, parentTarget, original)
 	linkedParent := filepath.Join(root, "linked-parent")
 	if err := os.Symlink(filepath.Base(realParent), linkedParent); err != nil {
 		t.Skipf("os.Symlink unavailable: %v", err)
@@ -389,9 +405,7 @@ func TestRunExtractDirectMountsRejectsUnsafeManifestPaths(t *testing.T) {
 	if err := RunExtractDirectMounts(filepath.Join(linkedParent, "manifest.json"), filepath.Join(root, "mounts-parent.json")); err == nil {
 		t.Fatal("RunExtractDirectMounts accepted a symlinked parent")
 	}
-	if data, err := os.ReadFile(parentTarget); err != nil || !bytes.Equal(data, original) {
-		t.Fatalf("parent symlink changed target manifest: %q, %v", data, err)
-	}
+	assertFileBytes(t, parentTarget, original)
 
 	fifo := filepath.Join(root, "manifest.fifo")
 	if err := unix.Mkfifo(fifo, 0o600); err != nil {
@@ -407,9 +421,7 @@ func TestRunExtractDirectMountsManifestByteLimit(t *testing.T) {
 	manifestPath := filepath.Join(root, "manifest.json")
 	mountSpecPath := filepath.Join(root, "mounts.json")
 	exact := append([]byte(`{"copies":[]}`), bytes.Repeat([]byte{' '}, int(maxInjectionManifestBytes-int64(len(`{"copies":[]}`))))...)
-	if err := os.WriteFile(manifestPath, exact, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeFile(t, manifestPath, exact)
 	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err != nil {
 		t.Fatalf("RunExtractDirectMounts exact limit: %v", err)
 	}
@@ -418,21 +430,67 @@ func TestRunExtractDirectMountsManifestByteLimit(t *testing.T) {
 	}
 
 	overLimit := append(exact, ' ')
-	if err := os.WriteFile(manifestPath, overLimit, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeFile(t, manifestPath, overLimit)
 	if err := os.Remove(mountSpecPath); err != nil {
 		t.Fatal(err)
 	}
 	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err == nil || !strings.Contains(err.Error(), "byte limit") {
 		t.Fatalf("RunExtractDirectMounts over-limit error = %v, want byte-limit rejection", err)
 	}
-	if got := readFile(t, manifestPath); !bytes.Equal(got, overLimit) {
-		t.Fatal("RunExtractDirectMounts changed an over-limit manifest")
-	}
+	assertFileBytes(t, manifestPath, overLimit)
 	if _, err := os.Stat(mountSpecPath); !os.IsNotExist(err) {
 		t.Fatalf("RunExtractDirectMounts created mount specification after over-limit input: %v", err)
 	}
+}
+
+func TestRunExtractDirectMountsUsesCompactJSONForDeepManifest(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.json")
+	mountSpecPath := filepath.Join(root, "mounts.json")
+	const depth = 3000
+	manifest := []byte(`{"padding":` + strings.Repeat("[", depth) + "null" + strings.Repeat("]", depth) + "}")
+	writeFile(t, manifestPath, manifest)
+	var value any
+	if err := json.Unmarshal(manifest, &value); err != nil {
+		t.Fatal(err)
+	}
+	indented, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(indented)+1) <= maxInjectionManifestBytes {
+		t.Fatalf("indented deep manifest size = %d, want more than %d", len(indented)+1, maxInjectionManifestBytes)
+	}
+	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err != nil {
+		t.Fatalf("RunExtractDirectMounts deep compact manifest: %v", err)
+	}
+	if info, err := os.Stat(manifestPath); err != nil || info.Size() >= maxInjectionManifestBytes {
+		t.Fatalf("compact deep manifest size = %v, %v", info, err)
+	}
+}
+
+func TestRunExtractDirectMountsBoundsDirectMountOutputBeforePublication(t *testing.T) {
+	root := t.TempDir()
+	exactManifest := filepath.Join(root, "exact-manifest.json")
+	exactMountSpec := filepath.Join(root, "exact-mounts.json")
+	writeDirectMountOutputFixture(t, exactManifest, maxInjectionMountSpecBytes)
+	if err := RunExtractDirectMounts(exactManifest, exactMountSpec); err != nil {
+		t.Fatalf("RunExtractDirectMounts exact direct-mount output: %v", err)
+	}
+	if info, err := os.Stat(exactMountSpec); err != nil || info.Size() != maxInjectionMountSpecBytes {
+		t.Fatalf("exact direct-mount output size = %v, %v", info, err)
+	}
+
+	overManifest := filepath.Join(root, "over-manifest.json")
+	overMountSpec := filepath.Join(root, "over-mounts.json")
+	originalManifest := writeDirectMountOutputFixture(t, overManifest, maxInjectionMountSpecBytes+1)
+	mountSpecBefore := []byte(`{"unchanged":true}` + "\n")
+	writeFile(t, overMountSpec, mountSpecBefore)
+	if err := RunExtractDirectMounts(overManifest, overMountSpec); err == nil || !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("RunExtractDirectMounts over-limit direct-mount output error = %v", err)
+	}
+	assertFileBytes(t, overManifest, originalManifest)
+	assertFileBytes(t, overMountSpec, mountSpecBefore)
 }
 
 func runGoExtractDirectMounts(t *testing.T, manifestFixture map[string]any) ([]byte, []byte) {
@@ -457,9 +515,38 @@ func writeFixtureManifest(t *testing.T, path string, fixture map[string]any) {
 		t.Fatalf("marshal fixture: %v", err)
 	}
 	data = append(data, '\n')
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		t.Fatalf("write fixture: %v", err)
+	writeFile(t, path, data)
+}
+
+func writeDirectMountOutputFixture(t *testing.T, manifestPath string, mountSpecSize int64) []byte {
+	t.Helper()
+	base, err := json.Marshal([]DirectMount{{Source: "s"}})
+	if err != nil {
+		t.Fatal(err)
 	}
+	base = append(base, '\n')
+	pathSize := mountSpecSize - int64(len(base))
+	if pathSize < 1 {
+		t.Fatalf("direct-mount output limit %d is too small", mountSpecSize)
+	}
+	mountPath := strings.Repeat("m", int(pathSize))
+	expected, err := json.Marshal([]DirectMount{{Source: "s", MountPath: mountPath}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected = append(expected, '\n')
+	if int64(len(expected)) != mountSpecSize {
+		t.Fatalf("direct-mount fixture size = %d, want %d", len(expected), mountSpecSize)
+	}
+	writeFixtureManifest(t, manifestPath, map[string]any{
+		"credentials": map[string]any{
+			"credential": map[string]any{
+				"source":     "s",
+				"mount_path": mountPath,
+			},
+		},
+	})
+	return readFile(t, manifestPath)
 }
 
 func readFile(t *testing.T, path string) []byte {
@@ -469,6 +556,20 @@ func readFile(t *testing.T, path string) []byte {
 		t.Fatalf("read file %s: %v", path, err)
 	}
 	return data
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertFileBytes(t *testing.T, path string, want []byte) {
+	t.Helper()
+	if got := readFile(t, path); !bytes.Equal(got, want) {
+		t.Fatalf("file changed: %s", path)
+	}
 }
 
 func assertFileMode(t *testing.T, path string, want os.FileMode) {

--- a/internal/injection/extract_direct_mounts_test.go
+++ b/internal/injection/extract_direct_mounts_test.go
@@ -4,10 +4,14 @@
 package injection
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestRequireDirectMountRemovesSourceAndReturnsEntry(t *testing.T) {
@@ -205,6 +209,110 @@ func TestRunExtractDirectMountsWritesMode0600(t *testing.T) {
 	assertFileMode(t, mountSpecPath, 0o600)
 }
 
+func TestRunExtractDirectMountsAtomicallyReplacesSwappedManifestLeaf(t *testing.T) {
+	fixture := map[string]any{"copies": []any{}}
+	expectedRoot := t.TempDir()
+	expectedManifest := filepath.Join(expectedRoot, "manifest.json")
+	expectedMounts := filepath.Join(expectedRoot, "mounts.json")
+	writeFixtureManifest(t, expectedManifest, fixture)
+	if err := RunExtractDirectMounts(expectedManifest, expectedMounts); err != nil {
+		t.Fatalf("prepare expected output: %v", err)
+	}
+	wantManifest := readFile(t, expectedManifest)
+	wantMounts := readFile(t, expectedMounts)
+
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.json")
+	mountSpecPath := filepath.Join(root, "mounts.json")
+	writeFixtureManifest(t, manifestPath, fixture)
+	outside := filepath.Join(root, "outside.json")
+	originalOutside := []byte(`{"outside":true}` + "\n")
+	if err := os.WriteFile(outside, originalOutside, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runExtractDirectMounts(manifestPath, mountSpecPath, func() error {
+		if err := os.Rename(manifestPath, manifestPath+".original"); err != nil {
+			return err
+		}
+		return os.Symlink(filepath.Base(outside), manifestPath)
+	})
+	if err != nil {
+		t.Fatalf("RunExtractDirectMounts after leaf swap: %v", err)
+	}
+	if got := readFile(t, manifestPath); !bytes.Equal(got, wantManifest) {
+		t.Fatalf("manifest output changed after leaf swap:\n got %q\nwant %q", got, wantManifest)
+	}
+	if got := readFile(t, mountSpecPath); !bytes.Equal(got, wantMounts) {
+		t.Fatalf("mount output changed after leaf swap:\n got %q\nwant %q", got, wantMounts)
+	}
+	if data := readFile(t, outside); !bytes.Equal(data, originalOutside) {
+		t.Fatalf("outside symlink target changed: %q", data)
+	}
+	if info, err := os.Lstat(manifestPath); err != nil || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("swapped manifest leaf was not atomically replaced: %v, %v", info, err)
+	}
+	assertFileMode(t, manifestPath, 0o600)
+	assertFileMode(t, mountSpecPath, 0o600)
+}
+
+func TestRunExtractDirectMountsAtomicallyReplacesMountSpecSymlink(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.json")
+	writeFixtureManifest(t, manifestPath, map[string]any{"copies": []any{}})
+
+	outside := filepath.Join(root, "outside-mounts.json")
+	originalOutside := []byte(`{"outside":true}` + "\n")
+	if err := os.WriteFile(outside, originalOutside, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mountSpecPath := filepath.Join(root, "mounts.json")
+	if err := os.Symlink(filepath.Base(outside), mountSpecPath); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+
+	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err != nil {
+		t.Fatalf("RunExtractDirectMounts with symlinked mount output: %v", err)
+	}
+	if data := readFile(t, outside); !bytes.Equal(data, originalOutside) {
+		t.Fatalf("outside mount-spec target changed: %q", data)
+	}
+	if info, err := os.Lstat(mountSpecPath); err != nil || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("mount-spec leaf was not atomically replaced: %v, %v", info, err)
+	}
+	if got := readFile(t, mountSpecPath); !bytes.Equal(bytes.TrimSpace(got), []byte("null")) {
+		t.Fatalf("mount specification = %q, want preserved JSON null", got)
+	}
+	assertFileMode(t, mountSpecPath, 0o600)
+}
+
+func TestRunExtractDirectMountsRejectsSymlinkedMountSpecParent(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.json")
+	writeFixtureManifest(t, manifestPath, map[string]any{"copies": []any{}})
+
+	realParent := filepath.Join(root, "real-parent")
+	if err := os.Mkdir(realParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	mountSpecTarget := filepath.Join(realParent, "mounts.json")
+	originalTarget := []byte(`{"outside":true}` + "\n")
+	if err := os.WriteFile(mountSpecTarget, originalTarget, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkedParent := filepath.Join(root, "linked-parent")
+	if err := os.Symlink(filepath.Base(realParent), linkedParent); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+
+	if err := RunExtractDirectMounts(manifestPath, filepath.Join(linkedParent, "mounts.json")); err == nil {
+		t.Fatal("RunExtractDirectMounts accepted a symlinked mount-spec parent")
+	}
+	if data := readFile(t, mountSpecTarget); !bytes.Equal(data, originalTarget) {
+		t.Fatalf("symlinked mount-spec parent changed outside target: %q", data)
+	}
+}
+
 func TestRunExtractDirectMountsLeavesPlainCopySourcesInline(t *testing.T) {
 	root := t.TempDir()
 	manifestPath := filepath.Join(root, "manifest.json")
@@ -245,6 +353,85 @@ func TestRunExtractDirectMountsLeavesPlainCopySourcesInline(t *testing.T) {
 	}
 	if len(mounts) != 0 {
 		t.Fatalf("expected no direct mounts, got %#v", mounts)
+	}
+}
+
+func TestRunExtractDirectMountsRejectsUnsafeManifestPaths(t *testing.T) {
+	root := t.TempDir()
+	original := []byte(`{"copies":[]}` + "\n")
+	target := filepath.Join(root, "target.json")
+	if err := os.WriteFile(target, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	leafLink := filepath.Join(root, "leaf-link.json")
+	if err := os.Symlink(filepath.Base(target), leafLink); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	if err := RunExtractDirectMounts(leafLink, filepath.Join(root, "mounts.json")); err == nil {
+		t.Fatal("RunExtractDirectMounts accepted a leaf symlink")
+	}
+	if data, err := os.ReadFile(target); err != nil || !bytes.Equal(data, original) {
+		t.Fatalf("leaf symlink changed target manifest: %q, %v", data, err)
+	}
+
+	realParent := filepath.Join(root, "real-parent")
+	if err := os.Mkdir(realParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	parentTarget := filepath.Join(realParent, "manifest.json")
+	if err := os.WriteFile(parentTarget, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkedParent := filepath.Join(root, "linked-parent")
+	if err := os.Symlink(filepath.Base(realParent), linkedParent); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	if err := RunExtractDirectMounts(filepath.Join(linkedParent, "manifest.json"), filepath.Join(root, "mounts-parent.json")); err == nil {
+		t.Fatal("RunExtractDirectMounts accepted a symlinked parent")
+	}
+	if data, err := os.ReadFile(parentTarget); err != nil || !bytes.Equal(data, original) {
+		t.Fatalf("parent symlink changed target manifest: %q, %v", data, err)
+	}
+
+	fifo := filepath.Join(root, "manifest.fifo")
+	if err := unix.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("unix.Mkfifo unavailable: %v", err)
+	}
+	if err := RunExtractDirectMounts(fifo, filepath.Join(root, "mounts-fifo.json")); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("RunExtractDirectMounts FIFO error = %v, want non-regular rejection", err)
+	}
+}
+
+func TestRunExtractDirectMountsManifestByteLimit(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.json")
+	mountSpecPath := filepath.Join(root, "mounts.json")
+	exact := append([]byte(`{"copies":[]}`), bytes.Repeat([]byte{' '}, int(maxInjectionManifestBytes-int64(len(`{"copies":[]}`))))...)
+	if err := os.WriteFile(manifestPath, exact, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err != nil {
+		t.Fatalf("RunExtractDirectMounts exact limit: %v", err)
+	}
+	if got := readFile(t, mountSpecPath); string(got) != "null\n" {
+		t.Fatalf("exact-limit mount specification = %q, want null", got)
+	}
+
+	overLimit := append(exact, ' ')
+	if err := os.WriteFile(manifestPath, overLimit, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(mountSpecPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err == nil || !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("RunExtractDirectMounts over-limit error = %v, want byte-limit rejection", err)
+	}
+	if got := readFile(t, manifestPath); !bytes.Equal(got, overLimit) {
+		t.Fatal("RunExtractDirectMounts changed an over-limit manifest")
+	}
+	if _, err := os.Stat(mountSpecPath); !os.IsNotExist(err) {
+		t.Fatalf("RunExtractDirectMounts created mount specification after over-limit input: %v", err)
 	}
 }
 

--- a/internal/injection/manifest_read.go
+++ b/internal/injection/manifest_read.go
@@ -7,12 +7,23 @@ import (
 	"github.com/omkhar/workcell/internal/rootio"
 )
 
-// maxInjectionManifestBytes bounds each generated manifest read. It matches
-// the maximum selected injection file size.
-const maxInjectionManifestBytes = rootio.MaxManifestBytes
+const (
+	// maxInjectionManifestBytes bounds each generated manifest read and write.
+	maxInjectionManifestBytes = rootio.MaxManifestBytes
+	// maxInjectionMountSpecBytes bounds each generated direct-mount specification.
+	maxInjectionMountSpecBytes = rootio.MaxDirectMountSpecBytes
+)
 
 // readInjectionManifest opens the full path through descriptors. It rejects
 // leaf and parent symlinks before it reads one regular file.
 func readInjectionManifest(path string) ([]byte, error) {
 	return rootio.ReadFileNoFollow(path, "injection manifest", maxInjectionManifestBytes)
+}
+
+func marshalInjectionManifest(value any) ([]byte, error) {
+	return rootio.MarshalCompactJSON(value, "injection manifest", maxInjectionManifestBytes)
+}
+
+func marshalInjectionMountSpec(value any) ([]byte, error) {
+	return rootio.MarshalCompactJSON(value, "direct mount specification", maxInjectionMountSpecBytes)
 }

--- a/internal/injection/manifest_read.go
+++ b/internal/injection/manifest_read.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injection
+
+import (
+	"github.com/omkhar/workcell/internal/rootio"
+)
+
+// maxInjectionManifestBytes bounds each generated manifest read. It matches
+// the maximum selected injection file size.
+const maxInjectionManifestBytes = rootio.MaxManifestBytes
+
+// readInjectionManifest opens the full path through descriptors. It rejects
+// leaf and parent symlinks before it reads one regular file.
+func readInjectionManifest(path string) ([]byte, error) {
+	return rootio.ReadFileNoFollow(path, "injection manifest", maxInjectionManifestBytes)
+}

--- a/internal/injection/prepare_bundle.go
+++ b/internal/injection/prepare_bundle.go
@@ -251,7 +251,7 @@ func PrepareBundle(opts PrepareBundleOptions) (*PrepareBundleResult, error) {
 		return nil, err
 	}
 	manifestPath := filepath.Join(bundleRoot, "manifest.json")
-	if info, err := os.Stat(manifestPath); err != nil || !info.Mode().IsRegular() {
+	if info, err := os.Lstat(manifestPath); err != nil || !info.Mode().IsRegular() {
 		return nil, fmt.Errorf("Injection manifest was not rendered: %s", manifestPath)
 	}
 	requireWorkspaceDirectory := !(opts.AuthStatus || opts.Doctor || opts.Inspect)
@@ -325,9 +325,9 @@ func rejectWorkspaceCredentialSources(manifestPath, workspacePath string, requir
 	}
 	workspace = filepath.Clean(workspace)
 
-	data, err := os.ReadFile(manifestPath)
+	data, err := readInjectionManifest(manifestPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("read manifest for credential-source validation: %w", err)
 	}
 	var manifest struct {
 		Credentials map[string]struct {

--- a/internal/injection/prepare_bundle_test.go
+++ b/internal/injection/prepare_bundle_test.go
@@ -4,6 +4,7 @@
 package injection
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,6 +78,41 @@ func TestPrepareBundleRejectsCredentialSourceUnderWorkspace(t *testing.T) {
 	}
 }
 
+func TestRejectWorkspaceCredentialSourcesRejectsUnsafeManifest(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	if err := os.Mkdir(workspace, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	manifest := filepath.Join(root, "manifest.json")
+	if err := os.WriteFile(manifest, []byte(`{"credentials":{}}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifestLink := filepath.Join(root, "manifest-link.json")
+	if err := os.Symlink(filepath.Base(manifest), manifestLink); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	if err := rejectWorkspaceCredentialSources(manifestLink, workspace, true); err == nil {
+		t.Fatal("rejectWorkspaceCredentialSources accepted a manifest symlink")
+	}
+}
+
+func TestRejectWorkspaceCredentialSourcesRejectsOverLimitManifest(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	if err := os.Mkdir(workspace, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	manifest := filepath.Join(root, "manifest.json")
+	data := append([]byte(`{"credentials":{}}`), bytes.Repeat([]byte{' '}, int(maxInjectionManifestBytes-int64(len(`{"credentials":{}}`))+1))...)
+	if err := os.WriteFile(manifest, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := rejectWorkspaceCredentialSources(manifest, workspace, true); err == nil || !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("rejectWorkspaceCredentialSources over-limit error = %v, want byte-limit rejection", err)
+	}
+}
+
 func TestPrepareBundleRejectsCredentialSourceUnderTildeWorkspace(t *testing.T) {
 	realHome := t.TempDir()
 	t.Setenv("HOME", realHome)
@@ -147,7 +183,7 @@ func TestPrepareBundleRejectsMissingLaunchWorkspaceForCredentialValidation(t *te
 	}
 }
 
-func TestPrepareBundleAuthStatusAllowsMissingWorkspace(t *testing.T) {
+func TestPrepareBundleAuthStatusAllowsMissingWorkspaceAndReadsMetadata(t *testing.T) {
 	realHome := t.TempDir()
 	policyPath := filepath.Join(realHome, "policy.toml")
 	credentialPath := filepath.Join(realHome, "copilot-token.txt")
@@ -158,7 +194,7 @@ func TestPrepareBundleAuthStatusAllowsMissingWorkspace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := PrepareBundle(PrepareBundleOptions{
+	result, err := PrepareBundle(PrepareBundleOptions{
 		Agent:                "copilot",
 		Mode:                 "strict",
 		WorkspacePath:        filepath.Join(realHome, "missing-workspace"),
@@ -170,6 +206,12 @@ func TestPrepareBundleAuthStatusAllowsMissingWorkspace(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("expected auth-status to allow missing workspace, got %v", err)
+	}
+	if result.InjectionPolicySHA256 == "" {
+		t.Fatal("PrepareBundle did not read the rendered manifest metadata")
+	}
+	if result.InjectionCredentialKeys != "copilot_github_token" {
+		t.Fatalf("InjectionCredentialKeys = %q, want copilot_github_token", result.InjectionCredentialKeys)
 	}
 }
 

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -18,6 +18,7 @@ import (
 	"github.com/omkhar/workcell/internal/adapters"
 	"github.com/omkhar/workcell/internal/injectionpolicy"
 	"github.com/omkhar/workcell/internal/providerid"
+	"github.com/omkhar/workcell/internal/rootio"
 )
 
 const (
@@ -117,6 +118,12 @@ func ValidateRenderAgentMode(agent, mode string) error {
 }
 
 func RunRenderInjectionBundle(policyPath, agent, mode, outputRoot, policyMetadata string) error {
+	return runRenderInjectionBundle(policyPath, agent, mode, outputRoot, policyMetadata, nil)
+}
+
+// runRenderInjectionBundle keeps the manifest parent descriptor open through
+// publication. beforeManifestWrite gives tests a deterministic leaf-swap seam.
+func runRenderInjectionBundle(policyPath, agent, mode, outputRoot, policyMetadata string, beforeManifestWrite func() error) error {
 	resolvedPolicyPath, err := resolveAbsPath(policyPath)
 	if err != nil {
 		return err
@@ -211,7 +218,7 @@ func RunRenderInjectionBundle(policyPath, agent, mode, outputRoot, policyMetadat
 	}
 
 	manifestPath := filepath.Join(resolvedOutputRoot, "manifest.json")
-	if err := writeIndentedJSON(manifestPath, manifest, 0o600); err != nil {
+	if err := writeCompactJSON(manifestPath, manifest, 0o600, beforeManifestWrite); err != nil {
 		return err
 	}
 	fmt.Fprintln(os.Stdout, manifestPath)
@@ -461,16 +468,22 @@ func sshMountSource(renderedSSH map[string]any, key string) (source, mountPath s
 	return "", "", false
 }
 
-func writeIndentedJSON(pathname string, value any, mode os.FileMode) error {
-	data, err := json.MarshalIndent(value, "", "  ")
+func writeCompactJSON(pathname string, value any, mode os.FileMode, beforeWrite func() error) error {
+	data, err := marshalInjectionManifest(value)
 	if err != nil {
 		return err
 	}
-	data = append(data, '\n')
-	if err := os.WriteFile(pathname, data, mode); err != nil {
+	parent, cleaned, err := rootio.OpenParentDirectoryNoFollow(pathname)
+	if err != nil {
 		return err
 	}
-	return os.Chmod(pathname, mode)
+	defer parent.Close()
+	if beforeWrite != nil {
+		if err := beforeWrite(); err != nil {
+			return err
+		}
+	}
+	return rootio.WriteFileAtomicAtNoFollow(parent, filepath.Base(cleaned), data, mode, ".workcell-manifest-")
 }
 
 func secretCopyTargets(renderedCopies []map[string]any) []string {

--- a/internal/injection/render_injection_bundle_test.go
+++ b/internal/injection/render_injection_bundle_test.go
@@ -4,6 +4,7 @@
 package injection
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -12,6 +13,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/rootio"
 )
 
 func TestParseTOMLSubsetAndHelperErrors(t *testing.T) {
@@ -870,6 +873,96 @@ func TestRunRenderInjectionBundleWritesManifestAndTracksMaterialChanges(t *testi
 	}
 }
 
+func TestRunRenderInjectionBundleAtomicallyReplacesManifestLeaf(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	writeText(t, policyPath, "version = 1\n", 0o600)
+	for _, test := range []struct {
+		name    string
+		swapped bool
+	}{
+		{name: "pre-existing-leaf-link"},
+		{name: "swapped-leaf-link", swapped: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			output := filepath.Join(root, test.name)
+			manifestPath := filepath.Join(output, "manifest.json")
+			outside := filepath.Join(root, test.name+"-outside.json")
+			outsideBefore := []byte(`{"outside":true}` + "\n")
+			writeText(t, outside, string(outsideBefore), 0o600)
+			writeText(t, manifestPath, "{\"old\":true}\n", 0o600)
+			swap := func() error {
+				if err := os.Remove(manifestPath); err != nil {
+					return err
+				}
+				return os.Symlink(outside, manifestPath)
+			}
+			var err error
+			if test.swapped {
+				err = runRenderInjectionBundle(policyPath, "codex", "strict", output, "", swap)
+			} else {
+				if err := swap(); err != nil {
+					t.Skipf("os.Symlink unavailable: %v", err)
+				}
+				err = RunRenderInjectionBundle(policyPath, "codex", "strict", output, "")
+			}
+			if err != nil {
+				t.Fatalf("RunRenderInjectionBundle %s: %v", test.name, err)
+			}
+			if got := []byte(readText(t, outside)); !bytes.Equal(got, outsideBefore) {
+				t.Fatalf("outside target changed after %s: %q", test.name, got)
+			}
+			if info, err := os.Lstat(manifestPath); err != nil || info.Mode()&os.ModeSymlink != 0 {
+				t.Fatalf("manifest leaf was not atomically replaced after %s: %v, %v", test.name, info, err)
+			}
+			assertRenderFileMode(t, manifestPath, 0o600)
+		})
+	}
+}
+
+func TestRunRenderInjectionBundleBoundsManifestOutputBeforePublication(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, "policy.toml")
+	metadataPath := filepath.Join(root, "policy-metadata.json")
+	writeText(t, policyPath, "version = 1\n", 0o600)
+	probeOutput := filepath.Join(root, "probe")
+	writePolicyMetadataOverride(t, metadataPath, 1)
+	if err := RunRenderInjectionBundle(policyPath, "codex", "strict", probeOutput, metadataPath); err != nil {
+		t.Fatalf("prepare manifest size probe: %v", err)
+	}
+	probeInfo, err := os.Stat(filepath.Join(probeOutput, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pathSize := rootio.MaxManifestBytes - (probeInfo.Size() - 1)
+	if pathSize < 1 {
+		t.Fatalf("manifest output limit %d is too small", rootio.MaxManifestBytes)
+	}
+	exactOutput := filepath.Join(root, "exact")
+	writePolicyMetadataOverride(t, metadataPath, pathSize)
+	if err := RunRenderInjectionBundle(policyPath, "codex", "strict", exactOutput, metadataPath); err != nil {
+		t.Fatalf("RunRenderInjectionBundle exact manifest output: %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(exactOutput, "manifest.json")); err != nil || info.Size() != rootio.MaxManifestBytes {
+		t.Fatalf("exact manifest output size = %v, %v", info, err)
+	}
+
+	overOutput := filepath.Join(root, "over")
+	if err := os.Mkdir(overOutput, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	overManifest := filepath.Join(overOutput, "manifest.json")
+	manifestBefore := []byte(`{"unchanged":true}` + "\n")
+	writeText(t, overManifest, string(manifestBefore), 0o600)
+	writePolicyMetadataOverride(t, metadataPath, pathSize+1)
+	if err := RunRenderInjectionBundle(policyPath, "codex", "strict", overOutput, metadataPath); err == nil || !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("RunRenderInjectionBundle over-limit manifest output error = %v", err)
+	}
+	if got := []byte(readText(t, overManifest)); !bytes.Equal(got, manifestBefore) {
+		t.Fatal("RunRenderInjectionBundle published an over-limit manifest")
+	}
+}
+
 func writeText(t *testing.T, path, content string, mode os.FileMode) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -914,4 +1007,12 @@ func readManifest(t *testing.T, path string) map[string]any {
 		t.Fatal(err)
 	}
 	return manifest
+}
+
+func writePolicyMetadataOverride(t *testing.T, path string, sourcePathSize int64) {
+	t.Helper()
+	if sourcePathSize < 1 {
+		t.Fatalf("policy source path size = %d, want at least one byte", sourcePathSize)
+	}
+	writeText(t, path, `{"policy_entrypoint":"policy.toml","policy_sources":[{"path":"`+strings.Repeat("p", int(sourcePathSize))+`","sha256":"sha256:original"}]}`, 0o600)
 }

--- a/internal/injection/render_policy_load.go
+++ b/internal/injection/render_policy_load.go
@@ -7,13 +7,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/omkhar/workcell/internal/injectionpolicy"
+	"github.com/omkhar/workcell/internal/pathutil"
+	"github.com/omkhar/workcell/internal/rootio"
 	"github.com/omkhar/workcell/internal/tomlsubset"
 )
 
@@ -119,11 +120,11 @@ func loadPolicyBundleRecursive(policyPath, entrypointRoot Path, activeStack []Pa
 }
 
 func loadPolicyMetadataOverride(rawPath string) (string, []PolicySource, error) {
-	resolved, err := resolveAbsPath(rawPath)
+	resolved, err := pathutil.ExpandUserPathStrictRequireNonEmpty(rawPath)
 	if err != nil {
 		return "", nil, err
 	}
-	data, err := os.ReadFile(resolved)
+	data, err := rootio.ReadFileNoFollow(resolved, "policy metadata override", rootio.MaxManifestBytes)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/injection/render_policy_reader_limits_test.go
+++ b/internal/injection/render_policy_reader_limits_test.go
@@ -4,6 +4,7 @@
 package injection
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
@@ -12,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/omkhar/workcell/internal/injectionpolicy"
+	"github.com/omkhar/workcell/internal/rootio"
+	"golang.org/x/sys/unix"
 )
 
 func TestLoadPolicyBundleReaderLimits(t *testing.T) {
@@ -84,6 +87,60 @@ func TestLoadPolicyBundleRejectsInvalidUTF8(t *testing.T) {
 		if _, _, err := loadPolicyBundle(Path(path)); err == nil || !strings.Contains(err.Error(), "valid UTF-8") {
 			t.Fatalf("load error = %v", err)
 		}
+	}
+}
+
+func TestLoadPolicyMetadataOverrideUsesBoundedNoFollowRead(t *testing.T) {
+	root := t.TempDir()
+	valid := []byte(`{"policy_entrypoint":"policy.toml","policy_sources":[{"path":"policy.toml","sha256":"sha256:original"}]}`)
+	exact := append(valid, bytes.Repeat([]byte{' '}, int(rootio.MaxManifestBytes)-len(valid))...)
+	exactPath := filepath.Join(root, "exact.json")
+	if err := os.WriteFile(exactPath, exact, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if entrypoint, sources, err := loadPolicyMetadataOverride(exactPath); err != nil || entrypoint != "policy.toml" || len(sources) != 1 {
+		t.Fatalf("loadPolicyMetadataOverride exact limit = %q, %#v, %v", entrypoint, sources, err)
+	}
+	overLimitPath := filepath.Join(root, "over-limit.json")
+	if err := os.WriteFile(overLimitPath, append(exact, ' '), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := loadPolicyMetadataOverride(overLimitPath); err == nil || !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("loadPolicyMetadataOverride over-limit error = %v", err)
+	}
+	target := filepath.Join(root, "target.json")
+	if err := os.WriteFile(target, valid, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	leafLink := filepath.Join(root, "leaf-link.json")
+	if err := os.Symlink(filepath.Base(target), leafLink); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	if _, _, err := loadPolicyMetadataOverride(leafLink); err == nil {
+		t.Fatal("loadPolicyMetadataOverride accepted a leaf symlink")
+	}
+
+	realParent := filepath.Join(root, "real-parent")
+	if err := os.Mkdir(realParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realParent, "metadata.json"), valid, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkedParent := filepath.Join(root, "linked-parent")
+	if err := os.Symlink(filepath.Base(realParent), linkedParent); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	if _, _, err := loadPolicyMetadataOverride(filepath.Join(linkedParent, "metadata.json")); err == nil {
+		t.Fatal("loadPolicyMetadataOverride accepted a symlinked parent")
+	}
+
+	fifo := filepath.Join(root, "metadata.fifo")
+	if err := unix.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("unix.Mkfifo unavailable: %v", err)
+	}
+	if _, _, err := loadPolicyMetadataOverride(fifo); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("loadPolicyMetadataOverride FIFO error = %v", err)
 	}
 }
 

--- a/internal/injection/stage_direct_mounts.go
+++ b/internal/injection/stage_direct_mounts.go
@@ -31,7 +31,8 @@ const hostInputMountPrefix = "/opt/workcell/host-inputs/"
 // (bash returned 0 in that case).  It returns a usage-style error when the
 // bundle root is empty.
 func StageDirectMounts(bundleRoot, mountSpecPath string) ([]string, error) {
-	if _, err := os.Stat(mountSpecPath); err != nil {
+	mounts, err := runtimeutil.ListDirectMounts(mountSpecPath)
+	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
@@ -43,11 +44,6 @@ func StageDirectMounts(bundleRoot, mountSpecPath string) ([]string, error) {
 
 	stagedRoot := filepath.Join(bundleRoot, "direct-mounts")
 	if err := os.MkdirAll(stagedRoot, 0o755); err != nil {
-		return nil, err
-	}
-
-	mounts, err := runtimeutil.ListDirectMounts(mountSpecPath)
-	if err != nil {
 		return nil, err
 	}
 

--- a/internal/injection/stage_direct_mounts_test.go
+++ b/internal/injection/stage_direct_mounts_test.go
@@ -37,6 +37,18 @@ func TestStageDirectMountsMissingSpecReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestStageDirectMountsRejectsDanglingSpecSymlink(t *testing.T) {
+	bundleRoot := t.TempDir()
+	specPath := filepath.Join(bundleRoot, "spec.json")
+	if err := os.Symlink(filepath.Join(bundleRoot, "does-not-exist"), specPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	if _, err := StageDirectMounts(bundleRoot, specPath); err == nil {
+		t.Fatal("expected dangling mount-spec symlink to be rejected")
+	}
+}
+
 func TestStageDirectMountsEmptyBundleRootRejected(t *testing.T) {
 	specPath := filepath.Join(t.TempDir(), "spec.json")
 	writeMountSpec(t, specPath, []map[string]any{})

--- a/internal/rootio/nofollow.go
+++ b/internal/rootio/nofollow.go
@@ -5,6 +5,7 @@ package rootio
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -17,13 +18,16 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// MaxManifestBytes is the maximum accepted size for one runtime or injection
-// manifest. Callers use it for metadata JSON that describes the same bundle.
-const MaxManifestBytes int64 = 16 * 1024 * 1024
+const (
+	// MaxManifestBytes is the maximum accepted size for one runtime or injection
+	// manifest. Callers use it for metadata JSON that describes the same bundle.
+	MaxManifestBytes int64 = 16 * 1024 * 1024
+	// MaxDirectMountSpecBytes is the maximum accepted size for one direct-mount
+	// specification.
+	MaxDirectMountSpecBytes int64 = 1 * 1024 * 1024
+)
 
-// OpenParentDirectoryNoFollow opens every component of path's parent through
-// directory descriptors. It rejects parent symlinks and returns the cleaned
-// absolute path with the descriptor that names its parent.
+// OpenParentDirectoryNoFollow uses descriptors for the parent and rejects parent symlinks.
 func OpenParentDirectoryNoFollow(path string) (*os.File, string, error) {
 	cleaned, err := filepath.Abs(path)
 	if err != nil {
@@ -35,7 +39,6 @@ func OpenParentDirectoryNoFollow(path string) (*os.File, string, error) {
 	if parent != string(filepath.Separator) {
 		components = strings.Split(strings.TrimPrefix(parent, string(filepath.Separator)), string(filepath.Separator))
 	}
-
 	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, "", err
@@ -48,7 +51,6 @@ func OpenParentDirectoryNoFollow(path string) (*os.File, string, error) {
 		}
 		fd = nextFD
 	}
-
 	parentFile := os.NewFile(uintptr(fd), parent)
 	if parentFile == nil {
 		_ = unix.Close(fd)
@@ -76,7 +78,6 @@ func ReadFileAtNoFollow(parent *os.File, name, label string, limit int64) ([]byt
 	if limit < 0 {
 		return nil, fmt.Errorf("%s has an invalid byte limit", label)
 	}
-
 	fd, err := unix.Openat(int(parent.Fd()), name, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC|unix.O_NONBLOCK, 0)
 	if err != nil {
 		return nil, err
@@ -87,7 +88,6 @@ func ReadFileAtNoFollow(parent *os.File, name, label string, limit int64) ([]byt
 		return nil, fmt.Errorf("open %s: %s", label, name)
 	}
 	defer file.Close()
-
 	info, err := file.Stat()
 	if err != nil {
 		return nil, err
@@ -112,6 +112,42 @@ func ReadFileAtNoFollow(parent *os.File, name, label string, limit int64) ([]byt
 	return data, nil
 }
 
+// SameFileAtNoFollow compares existing leaf inodes without following symlinks.
+func SameFileAtNoFollow(firstParent *os.File, firstName string, secondParent *os.File, secondName string) (bool, error) {
+	if err := validateLeafName(firstName); err != nil {
+		return false, err
+	}
+	if err := validateLeafName(secondName); err != nil {
+		return false, err
+	}
+	var first, second unix.Stat_t
+	if err := unix.Fstatat(int(firstParent.Fd()), firstName, &first, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return false, err
+	}
+	if err := unix.Fstatat(int(secondParent.Fd()), secondName, &second, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return false, nil
+		}
+		return false, err
+	}
+	return first.Dev == second.Dev && first.Ino == second.Ino, nil
+}
+
+// MarshalCompactJSON returns compact newline-terminated JSON when it fits limit.
+func MarshalCompactJSON(value any, label string, limit int64) ([]byte, error) {
+	if limit < 0 {
+		return nil, fmt.Errorf("%s has an invalid byte limit", label)
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) >= limit {
+		return nil, fmt.Errorf("%s exceeds the byte limit of %d", label, limit)
+	}
+	return append(data, '\n'), nil
+}
+
 // WriteFileAtomicAtNoFollow replaces name from an already trusted parent.
 // It writes a unique sibling with O_EXCL, sets mode before publication, then
 // uses renameat. renameat replaces a swapped leaf symlink instead of following it.
@@ -125,7 +161,6 @@ func WriteFileAtomicAtNoFollow(parent *os.File, name string, data []byte, mode o
 	if strings.Contains(tempPrefix, string(filepath.Separator)) {
 		return fmt.Errorf("temporary-file prefix must not contain a path separator: %s", tempPrefix)
 	}
-
 	parentFD := int(parent.Fd())
 	for attempt := 0; attempt < 32; attempt++ {
 		suffix, err := randomSuffix()
@@ -140,14 +175,12 @@ func WriteFileAtomicAtNoFollow(parent *os.File, name string, data []byte, mode o
 		if err != nil {
 			return err
 		}
-
 		file := os.NewFile(uintptr(fd), filepath.Join(parent.Name(), temporaryName))
 		if file == nil {
 			_ = unix.Close(fd)
 			_ = unix.Unlinkat(parentFD, temporaryName, 0)
 			return fmt.Errorf("create temporary file for %s", name)
 		}
-
 		if _, err := io.Copy(file, bytes.NewReader(data)); err != nil {
 			_ = file.Close()
 			_ = unix.Unlinkat(parentFD, temporaryName, 0)

--- a/internal/rootio/nofollow.go
+++ b/internal/rootio/nofollow.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package rootio
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// MaxManifestBytes is the maximum accepted size for one runtime or injection
+// manifest. Callers use it for metadata JSON that describes the same bundle.
+const MaxManifestBytes int64 = 16 * 1024 * 1024
+
+// OpenParentDirectoryNoFollow opens every component of path's parent through
+// directory descriptors. It rejects parent symlinks and returns the cleaned
+// absolute path with the descriptor that names its parent.
+func OpenParentDirectoryNoFollow(path string) (*os.File, string, error) {
+	cleaned, err := filepath.Abs(path)
+	if err != nil {
+		return nil, "", err
+	}
+	cleaned = canonicalizeSystemPath(filepath.Clean(cleaned))
+	parent := filepath.Dir(cleaned)
+	components := []string{}
+	if parent != string(filepath.Separator) {
+		components = strings.Split(strings.TrimPrefix(parent, string(filepath.Separator)), string(filepath.Separator))
+	}
+
+	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, "", err
+	}
+	for _, component := range components {
+		nextFD, openErr := unix.Openat(fd, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		_ = unix.Close(fd)
+		if openErr != nil {
+			return nil, "", openErr
+		}
+		fd = nextFD
+	}
+
+	parentFile := os.NewFile(uintptr(fd), parent)
+	if parentFile == nil {
+		_ = unix.Close(fd)
+		return nil, "", fmt.Errorf("open parent directory: %s", parent)
+	}
+	return parentFile, cleaned, nil
+}
+
+// ReadFileNoFollow reads one regular file through a descriptor-relative,
+// no-follow traversal. It accepts files up to limit bytes.
+func ReadFileNoFollow(path, label string, limit int64) ([]byte, error) {
+	parent, cleaned, err := OpenParentDirectoryNoFollow(path)
+	if err != nil {
+		return nil, err
+	}
+	defer parent.Close()
+	return ReadFileAtNoFollow(parent, filepath.Base(cleaned), label, limit)
+}
+
+// ReadFileAtNoFollow reads one regular leaf from an already trusted parent.
+func ReadFileAtNoFollow(parent *os.File, name, label string, limit int64) ([]byte, error) {
+	if err := validateLeafName(name); err != nil {
+		return nil, err
+	}
+	if limit < 0 {
+		return nil, fmt.Errorf("%s has an invalid byte limit", label)
+	}
+
+	fd, err := unix.Openat(int(parent.Fd()), name, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), filepath.Join(parent.Name(), name))
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("open %s: %s", label, name)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s must be a regular file: %s", label, name)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, limit))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) == limit && limit < math.MaxInt64 {
+		var extra [1]byte
+		n, readErr := file.Read(extra[:])
+		if readErr != nil && readErr != io.EOF {
+			return nil, readErr
+		}
+		if n != 0 {
+			return nil, fmt.Errorf("%s exceeds the byte limit of %d: %s", label, limit, name)
+		}
+	}
+	return data, nil
+}
+
+// WriteFileAtomicAtNoFollow replaces name from an already trusted parent.
+// It writes a unique sibling with O_EXCL, sets mode before publication, then
+// uses renameat. renameat replaces a swapped leaf symlink instead of following it.
+func WriteFileAtomicAtNoFollow(parent *os.File, name string, data []byte, mode os.FileMode, tempPrefix string) error {
+	if err := validateLeafName(name); err != nil {
+		return err
+	}
+	if tempPrefix == "" {
+		tempPrefix = ".workcell-tmp-"
+	}
+	if strings.Contains(tempPrefix, string(filepath.Separator)) {
+		return fmt.Errorf("temporary-file prefix must not contain a path separator: %s", tempPrefix)
+	}
+
+	parentFD := int(parent.Fd())
+	for attempt := 0; attempt < 32; attempt++ {
+		suffix, err := randomSuffix()
+		if err != nil {
+			return err
+		}
+		temporaryName := tempPrefix + suffix + ".tmp"
+		fd, err := unix.Openat(parentFD, temporaryName, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, uint32(mode.Perm()))
+		if errors.Is(err, unix.EEXIST) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		file := os.NewFile(uintptr(fd), filepath.Join(parent.Name(), temporaryName))
+		if file == nil {
+			_ = unix.Close(fd)
+			_ = unix.Unlinkat(parentFD, temporaryName, 0)
+			return fmt.Errorf("create temporary file for %s", name)
+		}
+
+		if _, err := io.Copy(file, bytes.NewReader(data)); err != nil {
+			_ = file.Close()
+			_ = unix.Unlinkat(parentFD, temporaryName, 0)
+			return err
+		}
+		if err := unix.Fchmod(fd, uint32(mode.Perm())); err != nil {
+			_ = file.Close()
+			_ = unix.Unlinkat(parentFD, temporaryName, 0)
+			return err
+		}
+		if err := file.Close(); err != nil {
+			_ = unix.Unlinkat(parentFD, temporaryName, 0)
+			return err
+		}
+		if err := unix.Renameat(parentFD, temporaryName, parentFD, name); err != nil {
+			_ = unix.Unlinkat(parentFD, temporaryName, 0)
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("unable to allocate temporary file under %s", parent.Name())
+}
+
+func validateLeafName(name string) error {
+	if name == "" || name == "." || name == ".." || name == string(filepath.Separator) || name != filepath.Base(name) {
+		return fmt.Errorf("path must name one file within the opened parent: %s", name)
+	}
+	return nil
+}
+
+func canonicalizeSystemPath(path string) string {
+	if runtime.GOOS != "darwin" {
+		return path
+	}
+	for _, prefix := range []string{"/var", "/etc", "/tmp"} {
+		if path == prefix || strings.HasPrefix(path, prefix+"/") {
+			return filepath.Join("/private", strings.TrimPrefix(path, string(filepath.Separator)))
+		}
+	}
+	return path
+}

--- a/internal/rootio/rootio_test.go
+++ b/internal/rootio/rootio_test.go
@@ -5,9 +5,11 @@ package rootio
 
 import (
 	"bytes"
+	"encoding/json"
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -25,6 +27,51 @@ func TestReadFileNoFollowMaxIntLimit(t *testing.T) {
 	}
 	if !bytes.Equal(got, want) {
 		t.Fatalf("content mismatch: got %q, want %q", got, want)
+	}
+}
+
+func TestMarshalCompactJSONBoundsAndPreservesFormat(t *testing.T) {
+	value := map[string]any{"items": []any{"quote \"[]{}:,\\\\", map[string]any{"name": "two"}}}
+	want, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = append(want, '\n')
+	got, err := MarshalCompactJSON(value, "test JSON", int64(len(want)))
+	if err != nil {
+		t.Fatalf("MarshalCompactJSON exact limit: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("MarshalCompactJSON changed output:\n got %q\nwant %q", got, want)
+	}
+	if _, err := MarshalCompactJSON(value, "test JSON", int64(len(want)-1)); err == nil {
+		t.Fatal("MarshalCompactJSON accepted output over the byte limit")
+	}
+}
+
+func TestMarshalCompactJSONAvoidsPrettyPrintAmplification(t *testing.T) {
+	const depth = 3000
+	compact := []byte(strings.Repeat("[", depth) + "null" + strings.Repeat("]", depth))
+	var value any
+	if err := json.Unmarshal(compact, &value); err != nil {
+		t.Fatal(err)
+	}
+	compact, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(compact)) >= MaxManifestBytes {
+		t.Fatalf("compact fixture size = %d, want less than %d", len(compact), MaxManifestBytes)
+	}
+	indented, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(indented)+1) <= MaxManifestBytes {
+		t.Fatalf("indented fixture does not exceed %d bytes", MaxManifestBytes)
+	}
+	if got, err := MarshalCompactJSON(value, "injection manifest", MaxManifestBytes); err != nil || int64(len(got)) >= MaxManifestBytes {
+		t.Fatalf("MarshalCompactJSON amplification result = %d bytes, %v", len(got), err)
 	}
 }
 

--- a/internal/rootio/rootio_test.go
+++ b/internal/rootio/rootio_test.go
@@ -5,10 +5,28 @@ package rootio
 
 import (
 	"bytes"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func TestReadFileNoFollowMaxIntLimit(t *testing.T) {
+	rootDir := t.TempDir()
+	path := filepath.Join(rootDir, "manifest.json")
+	want := []byte(`{"version":1}`)
+	if err := os.WriteFile(path, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadFileNoFollow(path, "manifest", math.MaxInt64)
+	if err != nil {
+		t.Fatalf("ReadFileNoFollow returned error: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("content mismatch: got %q, want %q", got, want)
+	}
+}
 
 func TestWriteFileAtomicWritesContentAndMode(t *testing.T) {
 	rootDir := t.TempDir()

--- a/internal/runtimeutil/runtimeutil.go
+++ b/internal/runtimeutil/runtimeutil.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	maxRuntimeManifestBytes        = rootio.MaxManifestBytes
-	maxRuntimeMountSpecBytes int64 = 1 * 1024 * 1024
+	maxRuntimeManifestBytes  = rootio.MaxManifestBytes
+	maxRuntimeMountSpecBytes = rootio.MaxDirectMountSpecBytes
 )
 
 type DirectMount struct {
@@ -143,10 +143,9 @@ func RewriteBundleCredentialOverride(manifestPath, mountSpecPath, credentialKey,
 	}
 	credential["source"] = overrideSource
 
-	data, err := json.MarshalIndent(manifest, "", "  ")
+	data, err := rootio.MarshalCompactJSON(manifest, "bundle manifest", maxRuntimeManifestBytes)
 	if err != nil {
 		return err
 	}
-	data = append(data, '\n')
 	return rootio.WriteFileAtomicAtNoFollow(manifestParent, manifestName, data, 0o600, ".workcell-manifest-")
 }

--- a/internal/runtimeutil/runtimeutil.go
+++ b/internal/runtimeutil/runtimeutil.go
@@ -18,6 +18,11 @@ import (
 	"github.com/omkhar/workcell/internal/rootio"
 )
 
+const (
+	maxRuntimeManifestBytes        = rootio.MaxManifestBytes
+	maxRuntimeMountSpecBytes int64 = 1 * 1024 * 1024
+)
+
 type DirectMount struct {
 	Source    string `json:"source"`
 	MountPath string `json:"mount_path"`
@@ -59,7 +64,7 @@ func ResolveIPs(host string) ([]string, error) {
 }
 
 func ListDirectMounts(mountSpecPath string) ([]DirectMount, error) {
-	data, err := os.ReadFile(mountSpecPath)
+	data, err := rootio.ReadFileNoFollow(mountSpecPath, "direct mount specification", maxRuntimeMountSpecBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -83,13 +88,14 @@ func ListDirectMounts(mountSpecPath string) ([]DirectMount, error) {
 }
 
 func RewriteBundleCredentialOverride(manifestPath, mountSpecPath, credentialKey, overrideSource string) error {
-	manifestRoot, err := os.OpenRoot(filepath.Dir(manifestPath))
+	manifestParent, cleanedManifestPath, err := rootio.OpenParentDirectoryNoFollow(manifestPath)
 	if err != nil {
 		return err
 	}
-	defer manifestRoot.Close()
-	manifestName := filepath.Base(manifestPath)
-	manifestData, err := manifestRoot.ReadFile(manifestName)
+	defer manifestParent.Close()
+
+	manifestName := filepath.Base(cleanedManifestPath)
+	manifestData, err := rootio.ReadFileAtNoFollow(manifestParent, manifestName, "bundle manifest", maxRuntimeManifestBytes)
 	if err != nil {
 		return err
 	}
@@ -142,5 +148,5 @@ func RewriteBundleCredentialOverride(manifestPath, mountSpecPath, credentialKey,
 		return err
 	}
 	data = append(data, '\n')
-	return rootio.WriteFileAtomic(manifestRoot, manifestName, data, 0o600, ".workcell-manifest-")
+	return rootio.WriteFileAtomicAtNoFollow(manifestParent, manifestName, data, 0o600, ".workcell-manifest-")
 }

--- a/internal/runtimeutil/runtimeutil_test.go
+++ b/internal/runtimeutil/runtimeutil_test.go
@@ -149,30 +149,20 @@ func TestRewriteBundleCredentialOverrideRejectsManifestSymlinkEscape(t *testing.
 }
 
 func TestListDirectMountsRejectsUnsafeInputsAndAcceptsExactLimit(t *testing.T) {
-	t.Parallel()
-
 	root := t.TempDir()
 	valid := filepath.Join(root, "mounts.json")
 	exact := append([]byte("[]"), bytes.Repeat([]byte{' '}, int(maxRuntimeMountSpecBytes-2))...)
-	if err := os.WriteFile(valid, exact, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeRuntimeFile(t, valid, exact)
 	if mounts, err := ListDirectMounts(valid); err != nil || len(mounts) != 0 {
 		t.Fatalf("ListDirectMounts exact limit = %#v, %v", mounts, err)
 	}
-
 	oversized := filepath.Join(root, "oversized.json")
-	if err := os.WriteFile(oversized, append(exact, ' '), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeRuntimeFile(t, oversized, append(exact, ' '))
 	if _, err := ListDirectMounts(oversized); err == nil || !strings.Contains(err.Error(), "byte limit") {
 		t.Fatalf("ListDirectMounts oversized error = %v, want byte-limit rejection", err)
 	}
-
 	target := filepath.Join(root, "target.json")
-	if err := os.WriteFile(target, []byte("[]\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeRuntimeFile(t, target, []byte("[]\n"))
 	leafLink := filepath.Join(root, "leaf-link.json")
 	if err := os.Symlink(filepath.Base(target), leafLink); err != nil {
 		t.Skipf("os.Symlink unavailable: %v", err)
@@ -180,14 +170,11 @@ func TestListDirectMountsRejectsUnsafeInputsAndAcceptsExactLimit(t *testing.T) {
 	if _, err := ListDirectMounts(leafLink); err == nil {
 		t.Fatal("ListDirectMounts accepted a leaf symlink")
 	}
-
 	realParent := filepath.Join(root, "real-parent")
 	if err := os.Mkdir(realParent, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(realParent, "mounts.json"), []byte("[]\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeRuntimeFile(t, filepath.Join(realParent, "mounts.json"), []byte("[]\n"))
 	linkedParent := filepath.Join(root, "linked-parent")
 	if err := os.Symlink(filepath.Base(realParent), linkedParent); err != nil {
 		t.Skipf("os.Symlink unavailable: %v", err)
@@ -195,7 +182,6 @@ func TestListDirectMountsRejectsUnsafeInputsAndAcceptsExactLimit(t *testing.T) {
 	if _, err := ListDirectMounts(filepath.Join(linkedParent, "mounts.json")); err == nil {
 		t.Fatal("ListDirectMounts accepted a symlinked parent")
 	}
-
 	fifo := filepath.Join(root, "mounts.fifo")
 	if err := unix.Mkfifo(fifo, 0o600); err != nil {
 		t.Skipf("unix.Mkfifo unavailable: %v", err)
@@ -206,32 +192,31 @@ func TestListDirectMountsRejectsUnsafeInputsAndAcceptsExactLimit(t *testing.T) {
 }
 
 func TestRewriteBundleCredentialOverrideRejectsUnsafeManifestAndAcceptsExactLimit(t *testing.T) {
-	t.Parallel()
-
 	root := t.TempDir()
-	manifest := []byte(`{"credentials":{"a":{}}}`)
-	exact := append(manifest, bytes.Repeat([]byte{' '}, int(maxRuntimeManifestBytes)-len(manifest))...)
 	manifestPath := filepath.Join(root, "manifest.json")
-	if err := os.WriteFile(manifestPath, exact, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeRuntimeManifestForOutputSize(t, manifestPath, maxRuntimeManifestBytes)
 	if err := RewriteBundleCredentialOverride(manifestPath, "", "a", "override.txt"); err != nil {
 		t.Fatalf("RewriteBundleCredentialOverride exact limit: %v", err)
 	}
-
-	oversized := filepath.Join(root, "oversized.json")
-	if err := os.WriteFile(oversized, append(exact, ' '), 0o600); err != nil {
-		t.Fatal(err)
+	if info, err := os.Stat(manifestPath); err != nil || info.Size() != maxRuntimeManifestBytes {
+		t.Fatalf("RewriteBundleCredentialOverride exact output size = %v, %v", info, err)
 	}
-	if err := RewriteBundleCredentialOverride(oversized, "", "a", "override.txt"); err == nil || !strings.Contains(err.Error(), "byte limit") {
+	overLimit := filepath.Join(root, "over-limit.json")
+	original := writeRuntimeManifestForOutputSize(t, overLimit, maxRuntimeManifestBytes+1)
+	if err := RewriteBundleCredentialOverride(overLimit, "", "a", "override.txt"); err == nil || !strings.Contains(err.Error(), "byte limit") {
 		t.Fatalf("RewriteBundleCredentialOverride oversized error = %v, want byte-limit rejection", err)
 	}
-
-	outside := filepath.Join(root, "outside.json")
-	original := []byte(`{"credentials":{"a":{}}}` + "\n")
-	if err := os.WriteFile(outside, original, 0o600); err != nil {
-		t.Fatal(err)
+	if got, err := os.ReadFile(overLimit); err != nil || !bytes.Equal(got, original) {
+		t.Fatal("RewriteBundleCredentialOverride published an over-limit manifest")
 	}
+	inputOverLimit := filepath.Join(root, "input-over-limit.json")
+	writeRuntimeFile(t, inputOverLimit, append(original, bytes.Repeat([]byte{' '}, int(maxRuntimeManifestBytes)-len(original)+1)...))
+	if err := RewriteBundleCredentialOverride(inputOverLimit, "", "a", "override.txt"); err == nil || !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("RewriteBundleCredentialOverride oversized input error = %v, want byte-limit rejection", err)
+	}
+	outside := filepath.Join(root, "outside.json")
+	outsideOriginal := []byte(`{"credentials":{"a":{}}}` + "\n")
+	writeRuntimeFile(t, outside, outsideOriginal)
 	leafLink := filepath.Join(root, "leaf-link.json")
 	if err := os.Symlink(filepath.Base(outside), leafLink); err != nil {
 		t.Skipf("os.Symlink unavailable: %v", err)
@@ -239,18 +224,41 @@ func TestRewriteBundleCredentialOverrideRejectsUnsafeManifestAndAcceptsExactLimi
 	if err := RewriteBundleCredentialOverride(leafLink, "", "a", "override.txt"); err == nil {
 		t.Fatal("RewriteBundleCredentialOverride accepted a leaf symlink")
 	}
-	if data, err := os.ReadFile(outside); err != nil || !bytes.Equal(data, original) {
+	if data, err := os.ReadFile(outside); err != nil || !bytes.Equal(data, outsideOriginal) {
 		t.Fatalf("leaf symlink changed outside manifest: %q, %v", data, err)
 	}
-
+	hardLinkedManifest := filepath.Join(root, "hardlink-manifest.json")
+	if err := os.Chmod(outside, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(outside, hardLinkedManifest); err != nil {
+		t.Fatal(err)
+	}
+	outsideBefore, outsideErr := os.Stat(outside)
+	manifestBefore, manifestErr := os.Stat(hardLinkedManifest)
+	if outsideErr != nil || manifestErr != nil || !os.SameFile(outsideBefore, manifestBefore) {
+		t.Fatalf("hard-link precondition = %v, %v", outsideErr, manifestErr)
+	}
+	if err := RewriteBundleCredentialOverride(hardLinkedManifest, "", "a", "override.txt"); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(outside); err != nil || !bytes.Equal(data, outsideOriginal) {
+		t.Fatalf("hard-link changed outside manifest: %q, %v", data, err)
+	}
+	outsideAfter, outsideErr := os.Stat(outside)
+	manifestAfter, manifestErr := os.Stat(hardLinkedManifest)
+	if outsideErr != nil || manifestErr != nil || os.SameFile(outsideAfter, manifestAfter) || outsideAfter.Mode().Perm() != 0o640 || manifestAfter.Mode().Perm() != 0o600 {
+		t.Fatalf("hard-link postcondition = %v, %v", outsideErr, manifestErr)
+	}
+	if data, err := os.ReadFile(hardLinkedManifest); err != nil || !bytes.Contains(data, []byte(`"source":"override.txt"`)) {
+		t.Fatalf("hard-link manifest override = %q, %v", data, err)
+	}
 	realParent := filepath.Join(root, "real-parent")
 	if err := os.Mkdir(realParent, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	parentTarget := filepath.Join(realParent, "manifest.json")
-	if err := os.WriteFile(parentTarget, original, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeRuntimeFile(t, parentTarget, outsideOriginal)
 	linkedParent := filepath.Join(root, "linked-parent")
 	if err := os.Symlink(filepath.Base(realParent), linkedParent); err != nil {
 		t.Skipf("os.Symlink unavailable: %v", err)
@@ -258,15 +266,47 @@ func TestRewriteBundleCredentialOverrideRejectsUnsafeManifestAndAcceptsExactLimi
 	if err := RewriteBundleCredentialOverride(filepath.Join(linkedParent, "manifest.json"), "", "a", "override.txt"); err == nil {
 		t.Fatal("RewriteBundleCredentialOverride accepted a symlinked parent")
 	}
-	if data, err := os.ReadFile(parentTarget); err != nil || !bytes.Equal(data, original) {
+	if data, err := os.ReadFile(parentTarget); err != nil || !bytes.Equal(data, outsideOriginal) {
 		t.Fatalf("parent symlink changed target manifest: %q, %v", data, err)
 	}
-
 	fifo := filepath.Join(root, "manifest.fifo")
 	if err := unix.Mkfifo(fifo, 0o600); err != nil {
 		t.Skipf("unix.Mkfifo unavailable: %v", err)
 	}
 	if err := RewriteBundleCredentialOverride(fifo, "", "a", "override.txt"); err == nil || !strings.Contains(err.Error(), "regular file") {
 		t.Fatalf("RewriteBundleCredentialOverride FIFO error = %v, want regular-file rejection", err)
+	}
+}
+
+func writeRuntimeManifestForOutputSize(t *testing.T, path string, outputSize int64) []byte {
+	t.Helper()
+	output := map[string]any{"credentials": map[string]any{"a": map[string]any{"source": "override.txt"}}, "padding": ""}
+	data, err := json.Marshal(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paddingSize := outputSize - int64(len(data)+1)
+	if paddingSize < 0 {
+		t.Fatalf("runtime manifest output limit %d is too small", outputSize)
+	}
+	output["padding"] = strings.Repeat("p", int(paddingSize))
+	expected, err := json.Marshal(output)
+	if err != nil || int64(len(expected)+1) != outputSize {
+		t.Fatalf("runtime manifest fixture size = %d, want %d: %v", len(expected)+1, outputSize, err)
+	}
+	input := map[string]any{"credentials": map[string]any{"a": map[string]any{"source": "x"}}, "padding": output["padding"]}
+	data, err = json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append(data, '\n')
+	writeRuntimeFile(t, path, data)
+	return data
+}
+
+func writeRuntimeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/runtimeutil/runtimeutil_test.go
+++ b/internal/runtimeutil/runtimeutil_test.go
@@ -4,11 +4,15 @@
 package runtimeutil
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestCanonicalizePath(t *testing.T) {
@@ -141,5 +145,128 @@ func TestRewriteBundleCredentialOverrideRejectsManifestSymlinkEscape(t *testing.
 	}
 	if string(data) != `{"credentials":{"a":{"mount_path":"m"}}}`+"\n" {
 		t.Fatalf("outside manifest changed unexpectedly: %s", data)
+	}
+}
+
+func TestListDirectMountsRejectsUnsafeInputsAndAcceptsExactLimit(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	valid := filepath.Join(root, "mounts.json")
+	exact := append([]byte("[]"), bytes.Repeat([]byte{' '}, int(maxRuntimeMountSpecBytes-2))...)
+	if err := os.WriteFile(valid, exact, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if mounts, err := ListDirectMounts(valid); err != nil || len(mounts) != 0 {
+		t.Fatalf("ListDirectMounts exact limit = %#v, %v", mounts, err)
+	}
+
+	oversized := filepath.Join(root, "oversized.json")
+	if err := os.WriteFile(oversized, append(exact, ' '), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ListDirectMounts(oversized); err == nil || !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("ListDirectMounts oversized error = %v, want byte-limit rejection", err)
+	}
+
+	target := filepath.Join(root, "target.json")
+	if err := os.WriteFile(target, []byte("[]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	leafLink := filepath.Join(root, "leaf-link.json")
+	if err := os.Symlink(filepath.Base(target), leafLink); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	if _, err := ListDirectMounts(leafLink); err == nil {
+		t.Fatal("ListDirectMounts accepted a leaf symlink")
+	}
+
+	realParent := filepath.Join(root, "real-parent")
+	if err := os.Mkdir(realParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realParent, "mounts.json"), []byte("[]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkedParent := filepath.Join(root, "linked-parent")
+	if err := os.Symlink(filepath.Base(realParent), linkedParent); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	if _, err := ListDirectMounts(filepath.Join(linkedParent, "mounts.json")); err == nil {
+		t.Fatal("ListDirectMounts accepted a symlinked parent")
+	}
+
+	fifo := filepath.Join(root, "mounts.fifo")
+	if err := unix.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("unix.Mkfifo unavailable: %v", err)
+	}
+	if _, err := ListDirectMounts(fifo); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("ListDirectMounts FIFO error = %v, want regular-file rejection", err)
+	}
+}
+
+func TestRewriteBundleCredentialOverrideRejectsUnsafeManifestAndAcceptsExactLimit(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	manifest := []byte(`{"credentials":{"a":{}}}`)
+	exact := append(manifest, bytes.Repeat([]byte{' '}, int(maxRuntimeManifestBytes)-len(manifest))...)
+	manifestPath := filepath.Join(root, "manifest.json")
+	if err := os.WriteFile(manifestPath, exact, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RewriteBundleCredentialOverride(manifestPath, "", "a", "override.txt"); err != nil {
+		t.Fatalf("RewriteBundleCredentialOverride exact limit: %v", err)
+	}
+
+	oversized := filepath.Join(root, "oversized.json")
+	if err := os.WriteFile(oversized, append(exact, ' '), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RewriteBundleCredentialOverride(oversized, "", "a", "override.txt"); err == nil || !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("RewriteBundleCredentialOverride oversized error = %v, want byte-limit rejection", err)
+	}
+
+	outside := filepath.Join(root, "outside.json")
+	original := []byte(`{"credentials":{"a":{}}}` + "\n")
+	if err := os.WriteFile(outside, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	leafLink := filepath.Join(root, "leaf-link.json")
+	if err := os.Symlink(filepath.Base(outside), leafLink); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	if err := RewriteBundleCredentialOverride(leafLink, "", "a", "override.txt"); err == nil {
+		t.Fatal("RewriteBundleCredentialOverride accepted a leaf symlink")
+	}
+	if data, err := os.ReadFile(outside); err != nil || !bytes.Equal(data, original) {
+		t.Fatalf("leaf symlink changed outside manifest: %q, %v", data, err)
+	}
+
+	realParent := filepath.Join(root, "real-parent")
+	if err := os.Mkdir(realParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	parentTarget := filepath.Join(realParent, "manifest.json")
+	if err := os.WriteFile(parentTarget, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkedParent := filepath.Join(root, "linked-parent")
+	if err := os.Symlink(filepath.Base(realParent), linkedParent); err != nil {
+		t.Skipf("os.Symlink unavailable: %v", err)
+	}
+	if err := RewriteBundleCredentialOverride(filepath.Join(linkedParent, "manifest.json"), "", "a", "override.txt"); err == nil {
+		t.Fatal("RewriteBundleCredentialOverride accepted a symlinked parent")
+	}
+	if data, err := os.ReadFile(parentTarget); err != nil || !bytes.Equal(data, original) {
+		t.Fatalf("parent symlink changed target manifest: %q, %v", data, err)
+	}
+
+	fifo := filepath.Join(root, "manifest.fifo")
+	if err := unix.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("unix.Mkfifo unavailable: %v", err)
+	}
+	if err := RewriteBundleCredentialOverride(fifo, "", "a", "override.txt"); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("RewriteBundleCredentialOverride FIFO error = %v, want regular-file rejection", err)
 	}
 }


### PR DESCRIPTION
## Summary

- This change bounds runtime manifest, policy, and host-state reads.
- It rejects symbolic links at protected paths.
- It checks compact JSON size before atomic publication.
- It preserves the prior manifest if later publication fails.

## Validation

- Fresh PR parity passed for the published tree.
- The change has 18 files and 1,195 lines in two validator areas.
- Seven security mutations failed their focused tests.
- All three published commits have valid maintainer signatures.