### PR TITLE
Reject Unicode path aliases before filesystem writes

### DIFF
--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -15,6 +15,9 @@ in launcher-owned state.
 Workcell mounts the staged source read-only. A crash can leave staged plaintext
 until cleanup.
 
+Workcell rejects destination names that collide after NFC normalization and Unicode case folding.
+Workcell writes no content at a destination path it rejects for invalid UTF-8 data.
+
 Store each credential source outside the mounted workspace. Workcell rejects a
 credential source inside the workspace.
 

--- a/docs/remote-vm-contract.md
+++ b/docs/remote-vm-contract.md
@@ -31,6 +31,9 @@ AWS and GCP conformance fixtures also use this fake target.
 The fake target copies the source workspace into its local target root. It
 excludes `.git` and records each copied entry in `materialization.json`.
 
+The fake target rejects destination names that collide after NFC normalization and Unicode case folding.
+It writes no content at a destination path it rejects for invalid UTF-8 data.
+
 This process is contract evidence only. It does not copy data to AWS or GCP.
 It does not start a Workcell remote session.
 

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,6 @@ require github.com/BurntSushi/toml v1.6.0
 
 require golang.org/x/sys v0.47.0
 
+require golang.org/x/text v0.41.0
+
 require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
+golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/host/authstate/authstate.go
+++ b/internal/host/authstate/authstate.go
@@ -8,7 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
+
+	"github.com/omkhar/workcell/internal/pathutil"
 )
 
 var forbiddenCredentialSourceRoots = []string{
@@ -36,77 +37,95 @@ var forbiddenCredentialSourceRoots = []string{
 }
 
 func RejectCredentialSource(source string, label string) error {
-	if root, ok := ForbiddenCredentialSourceRoot(source); ok {
+	if root, ok, err := ForbiddenCredentialSourceRoot(source); err != nil {
+		return fmt.Errorf("cannot check host provider/auth state: %w", err)
+	} else if ok {
 		return fmt.Errorf("%s must not point inside host provider/auth state: %s", label, root)
 	}
 	return nil
 }
 
 func RejectCredentialDirectorySource(source string, label string) error {
-	if root, ok := ForbiddenCredentialDirectorySourceRoot(source); ok {
+	if root, ok, err := ForbiddenCredentialDirectorySourceRoot(source); err != nil {
+		return fmt.Errorf("cannot check host provider/auth state: %w", err)
+	} else if ok {
 		return fmt.Errorf("%s must not include host provider/auth state: %s", label, root)
 	}
 	return nil
 }
 
-func ForbiddenCredentialSourceRoot(source string) (string, bool) {
+func ForbiddenCredentialSourceRoot(source string) (string, bool, error) {
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
-		return "", false
+		if err != nil {
+			return "", false, fmt.Errorf("get user home: %w", err)
+		}
+		return "", false, fmt.Errorf("get user home: empty path")
 	}
 	return forbiddenCredentialSourceRoot(source, home, hostPathComparisonCaseInsensitive())
 }
 
-func ForbiddenCredentialDirectorySourceRoot(source string) (string, bool) {
+func ForbiddenCredentialDirectorySourceRoot(source string) (string, bool, error) {
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
-		return "", false
+		if err != nil {
+			return "", false, fmt.Errorf("get user home: %w", err)
+		}
+		return "", false, fmt.Errorf("get user home: empty path")
 	}
 	return forbiddenCredentialDirectorySourceRoot(source, home, hostPathComparisonCaseInsensitive())
 }
 
-func forbiddenCredentialSourceRoot(source, home string, caseInsensitive bool) (string, bool) {
+func forbiddenCredentialSourceRoot(source, home string, caseInsensitive bool) (string, bool, error) {
 	var err error
 
 	home, err = filepath.Abs(home)
 	if err != nil {
-		return "", false
+		return "", false, fmt.Errorf("resolve user home: %w", err)
 	}
 	source, err = filepath.Abs(source)
 	if err != nil {
-		return "", false
+		return "", false, fmt.Errorf("resolve source path: %w", err)
 	}
 	source = filepath.Clean(source)
 
 	for _, rel := range forbiddenCredentialSourceRoots {
 		root := filepath.Clean(filepath.Join(home, filepath.FromSlash(rel)))
-		if pathWithinRoot(root, source, caseInsensitive) {
-			return root, true
+		inside, err := pathutil.WithinOrEqual(root, source, caseInsensitive)
+		if err != nil {
+			return "", false, err
+		}
+		if inside {
+			return root, true, nil
 		}
 	}
-	return "", false
+	return "", false, nil
 }
 
-func forbiddenCredentialDirectorySourceRoot(source, home string, caseInsensitive bool) (string, bool) {
+func forbiddenCredentialDirectorySourceRoot(source, home string, caseInsensitive bool) (string, bool, error) {
 	var err error
 
 	home, err = filepath.Abs(home)
 	if err != nil {
-		return "", false
+		return "", false, fmt.Errorf("resolve user home: %w", err)
 	}
 	source, err = filepath.Abs(source)
 	if err != nil {
-		return "", false
+		return "", false, fmt.Errorf("resolve source path: %w", err)
 	}
 	source = filepath.Clean(source)
 
 	for _, rel := range forbiddenCredentialSourceRoots {
 		root := filepath.Clean(filepath.Join(home, filepath.FromSlash(rel)))
-		if pathWithinRoot(source, root, caseInsensitive) {
-			return root, true
+		inside, err := pathutil.WithinOrEqual(source, root, caseInsensitive)
+		if err != nil {
+			return "", false, err
+		}
+		if inside {
+			return root, true, nil
 		}
 	}
-	return "", false
+	return "", false, nil
 }
 
 func hostPathComparisonCaseInsensitive() bool {
@@ -116,21 +135,4 @@ func hostPathComparisonCaseInsensitive() bool {
 	default:
 		return false
 	}
-}
-
-func pathWithinRoot(root, candidate string, caseInsensitive bool) bool {
-	root = filepath.Clean(root)
-	candidate = filepath.Clean(candidate)
-	if caseInsensitive {
-		root = strings.ToLower(root)
-		candidate = strings.ToLower(candidate)
-	}
-	if candidate == root {
-		return true
-	}
-	rel, err := filepath.Rel(root, candidate)
-	if err != nil {
-		return false
-	}
-	return rel != "." && rel != ".." && !filepath.IsAbs(rel) && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/internal/host/authstate/authstate_test.go
+++ b/internal/host/authstate/authstate_test.go
@@ -4,16 +4,69 @@
 package authstate
 
 import (
+	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/pathutil"
 )
+
+func TestRejectCredentialSourceFailsClosedWhenHomeIsUnavailable(t *testing.T) {
+	t.Setenv("HOME", "")
+	err := RejectCredentialSource("/tmp/source", "credential")
+	if err == nil || !strings.Contains(err.Error(), "cannot check") {
+		t.Fatalf("RejectCredentialSource error = %v", err)
+	}
+	err = RejectCredentialDirectorySource("/tmp/source", "credential")
+	if err == nil || !strings.Contains(err.Error(), "cannot check") {
+		t.Fatalf("RejectCredentialDirectorySource error = %v", err)
+	}
+}
+
+func TestForbiddenCredentialSourceRootRejectsInvalidUTF8WithoutDisclosure(t *testing.T) {
+	home := t.TempDir()
+	invalid := "secret-prefix-" + string([]byte{0xff})
+	_, _, err := forbiddenCredentialSourceRoot(invalid, home, true)
+	if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("forbiddenCredentialSourceRoot error = %v", err)
+	}
+	_, _, err = forbiddenCredentialDirectorySourceRoot(invalid, home, true)
+	if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("forbiddenCredentialDirectorySourceRoot error = %v", err)
+	}
+}
+
+func TestForbiddenCredentialRootsRejectUnicodeAliasesAndSiblings(t *testing.T) {
+	for _, pair := range [][2]string{{"café", "cafe\u0301"}, {"straße", "STRASSE"}, {"Σ", "ς"}, {"ﬀ", "ff"}, {"µ", "Μ"}, {"ś", "ſ\u0301"}} {
+		home := filepath.Join(t.TempDir(), pair[0])
+		sourceHome := filepath.Join(filepath.Dir(home), pair[1])
+		file := filepath.Join(sourceHome, ".codex", "auth.json")
+		if _, ok, err := forbiddenCredentialSourceRoot(file, home, true); err != nil || !ok {
+			t.Fatalf("file alias %q/%q = %v, %v", pair[0], pair[1], ok, err)
+		}
+		if _, ok, err := forbiddenCredentialDirectorySourceRoot(sourceHome, home, true); err != nil || !ok {
+			t.Fatalf("directory alias %q/%q = %v, %v", pair[0], pair[1], ok, err)
+		}
+		sibling := sourceHome + "-sibling"
+		if _, ok, err := forbiddenCredentialSourceRoot(filepath.Join(sibling, ".codex", "auth.json"), home, true); err != nil || ok {
+			t.Fatalf("file sibling %q = %v, %v", sibling, ok, err)
+		}
+		if _, ok, err := forbiddenCredentialDirectorySourceRoot(sibling, home, true); err != nil || ok {
+			t.Fatalf("directory sibling %q = %v, %v", sibling, ok, err)
+		}
+	}
+}
 
 func TestForbiddenCredentialSourceRootRejectsProviderState(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
 	source := filepath.Join(home, ".config", "gh", "hosts.yml")
-	root, ok := ForbiddenCredentialSourceRoot(source)
+	root, ok, err := ForbiddenCredentialSourceRoot(source)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !ok {
 		t.Fatalf("ForbiddenCredentialSourceRoot(%q) did not reject provider state", source)
 	}
@@ -87,7 +140,10 @@ func TestForbiddenCredentialSourceRootRejectsCaseVariedProviderState(t *testing.
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			root, ok := forbiddenCredentialSourceRoot(tc.source, home, true)
+			root, ok, err := forbiddenCredentialSourceRoot(tc.source, home, true)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if !ok {
 				t.Fatalf("forbiddenCredentialSourceRoot(%q) did not reject case-varied provider state", tc.source)
 			}
@@ -106,7 +162,9 @@ func TestForbiddenCredentialSourceRootAllowsSiblingAndManagedState(t *testing.T)
 		filepath.Join(home, ".config", "github-copilot-export", "token.txt"),
 		filepath.Join(home, ".local", "state", "workcell", "credentials", "copilot", "github-token.txt"),
 	} {
-		if root, ok := ForbiddenCredentialSourceRoot(source); ok {
+		if root, ok, err := ForbiddenCredentialSourceRoot(source); err != nil {
+			t.Fatal(err)
+		} else if ok {
 			t.Fatalf("ForbiddenCredentialSourceRoot(%q) rejected allowed source under %q", source, root)
 		}
 	}
@@ -137,7 +195,10 @@ func TestForbiddenCredentialDirectorySourceRootRejectsAncestorProviderState(t *t
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			root, ok := forbiddenCredentialDirectorySourceRoot(tc.source, home, true)
+			root, ok, err := forbiddenCredentialDirectorySourceRoot(tc.source, home, true)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if !ok {
 				t.Fatalf("forbiddenCredentialDirectorySourceRoot(%q) did not reject directory containing provider state", tc.source)
 			}
@@ -155,7 +216,9 @@ func TestForbiddenCredentialDirectorySourceRootAllowsSibling(t *testing.T) {
 		filepath.Join(home, ".config", "github-copilot-export"),
 		filepath.Join(home, ".local", "state", "workcell"),
 	} {
-		if root, ok := forbiddenCredentialDirectorySourceRoot(source, home, true); ok {
+		if root, ok, err := forbiddenCredentialDirectorySourceRoot(source, home, true); err != nil {
+			t.Fatal(err)
+		} else if ok {
 			t.Fatalf("forbiddenCredentialDirectorySourceRoot(%q) rejected allowed directory under %q", source, root)
 		}
 	}

--- a/internal/injection/prepare_bundle.go
+++ b/internal/injection/prepare_bundle.go
@@ -17,6 +17,7 @@ import (
 	"github.com/omkhar/workcell/internal/cliexit"
 	"github.com/omkhar/workcell/internal/host/hoststate"
 	"github.com/omkhar/workcell/internal/host/launcher"
+	"github.com/omkhar/workcell/internal/pathutil"
 	"github.com/omkhar/workcell/internal/shellproto"
 )
 
@@ -305,6 +306,10 @@ func PrepareBundle(opts PrepareBundleOptions) (*PrepareBundleResult, error) {
 }
 
 func rejectWorkspaceCredentialSources(manifestPath, workspacePath string, requireWorkspaceDirectory bool) error {
+	return rejectWorkspaceCredentialSourcesWith(manifestPath, workspacePath, requireWorkspaceDirectory, pathWithin)
+}
+
+func rejectWorkspaceCredentialSourcesWith(manifestPath, workspacePath string, requireWorkspaceDirectory bool, within func(string, string) (bool, error)) error {
 	if strings.TrimSpace(workspacePath) == "" {
 		return nil
 	}
@@ -346,14 +351,18 @@ func rejectWorkspaceCredentialSources(manifestPath, workspacePath string, requir
 			return fmt.Errorf("resolve credentials.%s source for workspace validation: %w", key, err)
 		}
 		source = filepath.Clean(source)
-		if pathWithin(workspace, source) {
+		inside, err := within(workspace, source)
+		if err != nil {
+			return fmt.Errorf("compare credentials.%s source with workspace: %w", key, err)
+		}
+		if inside {
 			return fmt.Errorf("credentials.%s source must be outside the mounted workspace: %s", key, source)
 		}
 	}
 	return nil
 }
 
-func pathWithin(root, candidate string) bool {
+func pathWithin(root, candidate string) (bool, error) {
 	return pathWithinWithCase(root, candidate, hostPathComparisonCaseInsensitive())
 }
 
@@ -366,21 +375,8 @@ func hostPathComparisonCaseInsensitive() bool {
 	}
 }
 
-func pathWithinWithCase(root, candidate string, caseInsensitive bool) bool {
-	if root == "" || candidate == "" {
-		return false
-	}
-	root = filepath.Clean(root)
-	candidate = filepath.Clean(candidate)
-	if caseInsensitive {
-		root = strings.ToLower(root)
-		candidate = strings.ToLower(candidate)
-	}
-	rel, err := filepath.Rel(root, candidate)
-	if err != nil {
-		return false
-	}
-	return rel == "." || (rel != ".." && !filepath.IsAbs(rel) && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+func pathWithinWithCase(root, candidate string, caseInsensitive bool) (bool, error) {
+	return pathutil.WithinOrEqual(root, candidate, caseInsensitive)
 }
 
 // installSyntheticProbeEnv mirrors the bash branches that stage synthetic

--- a/internal/injection/prepare_bundle_test.go
+++ b/internal/injection/prepare_bundle_test.go
@@ -5,10 +5,13 @@ package injection
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/pathutil"
 )
 
 func TestPrepareBundleNoPolicyClearsState(t *testing.T) {
@@ -147,14 +150,59 @@ func TestPathWithinCaseInsensitiveHostComparison(t *testing.T) {
 	root := filepath.Join(string(filepath.Separator), "Users", "maintainer", "Repo")
 	candidate := filepath.Join(string(filepath.Separator), "users", "maintainer", "repo", "copilot-token.txt")
 
-	if !pathWithinWithCase(root, candidate, true) {
+	inside, err := pathWithinWithCase(root, candidate, true)
+	if err != nil || !inside {
 		t.Fatalf("expected case-insensitive host comparison to treat %q as inside %q", candidate, root)
 	}
-	if pathWithinWithCase(root, candidate, false) {
+	inside, err = pathWithinWithCase(root, candidate, false)
+	if err != nil || inside {
 		t.Fatalf("expected case-sensitive comparison to preserve exact-case path boundaries")
 	}
-	if pathWithinWithCase(root, filepath.Join(string(filepath.Separator), "users", "maintainer", "repo-other", "token.txt"), true) {
+	inside, err = pathWithinWithCase(root, filepath.Join(string(filepath.Separator), "users", "maintainer", "repo-other", "token.txt"), true)
+	if err != nil || inside {
 		t.Fatalf("expected sibling case-variant path to stay outside workspace")
+	}
+}
+
+func TestPathWithinWithCaseRejectsUnicodeAliases(t *testing.T) {
+	inside, err := pathWithinWithCase("/tmp/café", "/tmp/cafe\u0301/file", false)
+	if err != nil || !inside {
+		t.Fatal("NFC child was outside")
+	}
+	inside, err = pathWithinWithCase("/tmp/straße", "/tmp/STRASSE/file", true)
+	if err != nil || !inside {
+		t.Fatal("case-fold child was outside")
+	}
+}
+
+func TestPathWithinRejectsInvalidInputs(t *testing.T) {
+	invalid := "secret-prefix-" + string([]byte{0xff})
+	if _, err := pathWithin(invalid, "/tmp/source"); !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("invalid root error = %v", err)
+	}
+	if _, err := pathWithin("/tmp/root", invalid); !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("invalid candidate error = %v", err)
+	}
+}
+
+func TestRejectWorkspaceCredentialSourcesPropagatesComparisonError(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	if err := os.Mkdir(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	credential := filepath.Join(root, "credential")
+	if err := os.WriteFile(credential, []byte("token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifest := filepath.Join(root, "manifest.json")
+	if err := os.WriteFile(manifest, []byte(`{"credentials":{"x":{"source":"`+credential+`"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	comparisonErr := errors.New("comparison failed")
+	err := rejectWorkspaceCredentialSourcesWith(manifest, workspace, true, func(string, string) (bool, error) { return false, comparisonErr })
+	if !errors.Is(err, comparisonErr) {
+		t.Fatalf("error = %v, want comparison error", err)
 	}
 }
 

--- a/internal/injection/render_documents_copies.go
+++ b/internal/injection/render_documents_copies.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/omkhar/workcell/internal/pathutil"
 	"github.com/omkhar/workcell/internal/providerid"
 	"golang.org/x/sys/unix"
 )
@@ -152,6 +153,9 @@ func copySource(source, destination Path) (string, error) {
 	}
 	defer sourceFile.Close()
 	if kind == directMountSourceDir {
+		if err := validateInjectionDirectoryDescendants(sourceFile); err != nil {
+			return "", err
+		}
 		if err := os.MkdirAll(destination.Parent().String(), 0o755); err != nil {
 			return "", err
 		}
@@ -218,18 +222,22 @@ func copyOpenDirectoryToRootWithState(
 		return err
 	}
 	for _, entry := range entries {
-		displayPath := filepath.Join(sourceDisplay, entry.Name())
-		if entry.Type()&os.ModeSymlink != 0 {
-			return fmt.Errorf("injection source must not contain a symbolic link: %s", displayPath)
+		name := entry.Name()
+		if err := validateInjectionDescendantName(name); err != nil {
+			return err
 		}
-		child, _, kind, err := openChild(source, entry.Name(), displayPath)
+		displayPath := filepath.Join(sourceDisplay, name)
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("injection source must not contain a symbolic link: %q", displayPath)
+		}
+		child, _, kind, err := openChild(source, name, displayPath)
 		if err != nil {
 			if errors.Is(err, unix.ELOOP) {
-				return fmt.Errorf("injection source must not contain a symbolic link: %s", displayPath)
+				return fmt.Errorf("injection source must not contain a symbolic link: %q", displayPath)
 			}
-			return fmt.Errorf("open injection source entry %s: %w", displayPath, err)
+			return fmt.Errorf("open injection source entry %q: %w", displayPath, err)
 		}
-		childRelative := filepath.Join(relative, entry.Name())
+		childRelative := filepath.Join(relative, name)
 		switch kind {
 		case directMountSourceDir:
 			err = state.reserve(childRelative, "directory")
@@ -249,7 +257,7 @@ func copyOpenDirectoryToRootWithState(
 				err = writeFileExclusive(destination, childRelative, data, 0o600)
 			}
 		default:
-			err = fmt.Errorf("injection source contains an unsupported entry: %s", displayPath)
+			err = fmt.Errorf("injection source contains an unsupported entry: %q", displayPath)
 		}
 		closeErr := child.Close()
 		if err != nil {
@@ -262,9 +270,15 @@ func copyOpenDirectoryToRootWithState(
 	return nil
 }
 
+func validateInjectionDescendantName(name string) error {
+	if _, err := pathutil.CollisionKey(name); err != nil {
+		return fmt.Errorf("invalid injection source entry: %w", err)
+	}
+	return nil
+}
+
 // injectionDestinationState reserves each target path before it is created.
-// The key is case-insensitive because the standard Apple filesystem treats
-// `A` and `a` as the same destination. Unicode normalization is separate work.
+// The key uses NFC normalization and Unicode full case folding.
 type injectionDestinationState struct {
 	paths map[string]string
 }
@@ -274,11 +288,14 @@ func newInjectionDestinationState() *injectionDestinationState {
 }
 
 func (s *injectionDestinationState) reserve(path, kind string) error {
-	key := strings.ToLower(filepath.Clean(path))
-	if previous, exists := s.paths[key]; exists {
-		return fmt.Errorf("injection destination path collision between %s and %s", previous, path)
+	key, err := pathutil.CollisionKey(path)
+	if err != nil {
+		return fmt.Errorf("invalid injection destination path: %w", err)
 	}
-	s.paths[key] = fmt.Sprintf("%s (%s)", path, kind)
+	if previous, exists := s.paths[key]; exists {
+		return fmt.Errorf("injection destination path collision between %s and %q", previous, path)
+	}
+	s.paths[key] = fmt.Sprintf("%q (%s)", path, kind)
 	return nil
 }
 

--- a/internal/injection/render_documents_copies_security_test.go
+++ b/internal/injection/render_documents_copies_security_test.go
@@ -4,11 +4,159 @@
 package injection
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/pathutil"
 )
+
+func TestValidateInjectionDescendantNameRejectsInvalidUTF8WithoutDisclosure(t *testing.T) {
+	invalid := "secret-prefix-" + string([]byte{0xff})
+	err := validateInjectionDescendantName(invalid)
+	if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("entry-name error = %v", err)
+	}
+}
+
+func TestCopySourceRejectsUnsafeDescendantBeforeReadOnlyDestination(t *testing.T) {
+	for _, testCase := range unsafeInjectionDescendantNames {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := t.TempDir()
+			source := filepath.Join(root, "source")
+			if err := os.Mkdir(source, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(source, testCase.value), []byte("approved"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			destinationParent := filepath.Join(root, "read-only")
+			if err := os.Mkdir(destinationParent, 0o500); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chmod(destinationParent, 0o700) })
+			_, err := copySource(Path(source), Path(filepath.Join(destinationParent, "output")))
+			assertUnsafeInjectionDescendantError(t, err)
+		})
+	}
+}
+
+var unsafeInjectionDescendantNames = []struct {
+	name  string
+	value string
+}{
+	{name: "newline", value: "secret-prefix-\n"},
+	{name: "escape", value: "secret-prefix-\x1b"},
+	{name: "line separator", value: "secret-prefix-\u2028"},
+	{name: "paragraph separator", value: "secret-prefix-\u2029"},
+}
+
+func assertUnsafeInjectionDescendantError(t *testing.T, err error) {
+	t.Helper()
+	if !errors.Is(err, pathutil.ErrUnsafePathControl) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("unsafe descendant error = %v", err)
+	}
+}
+
+func TestCopyOpenDirectoryToRootWithStateRejectsLinuxInvalidUTF8Symlink(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux permits invalid UTF-8 descendant names")
+	}
+	sourcePath := t.TempDir()
+	invalid := "secret-prefix-" + string([]byte{0xff})
+	if err := os.Symlink("target", filepath.Join(sourcePath, invalid)); err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	destinationPath := t.TempDir()
+	destination, err := os.OpenRoot(destinationPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destination.Close()
+	err = copyOpenDirectoryToRootWithState(source, destination, sourcePath, ".", openDirectMountChild, newInjectionDestinationState())
+	if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("copy error = %v", err)
+	}
+	entries, err := os.ReadDir(destinationPath)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("destination entries = %#v, %v", entries, err)
+	}
+}
+
+func TestInjectionDestinationStateRejectsUnsafeControlNames(t *testing.T) {
+	for _, testCase := range unsafeInjectionDescendantNames {
+		t.Run(testCase.name, func(t *testing.T) {
+			assertUnsafeInjectionDescendantError(t, newInjectionDestinationState().reserve(testCase.value, "regular file"))
+		})
+	}
+}
+
+func TestCopyOpenDirectoryToRootWithStateRejectsPreReservedUnicodeAlias(t *testing.T) {
+	sourceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceRoot, "cafe\u0301"), []byte("approved"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.Open(sourceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	destinationPath := t.TempDir()
+	destination, err := os.OpenRoot(destinationPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destination.Close()
+	state := newInjectionDestinationState()
+	if err := state.reserve("café", "reserved"); err != nil {
+		t.Fatal(err)
+	}
+	err = copyOpenDirectoryToRootWithState(source, destination, sourceRoot, ".", openDirectMountChild, state)
+	if err == nil || !strings.Contains(err.Error(), "destination path collision") {
+		t.Fatalf("copy error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destinationPath, "cafe\u0301")); !os.IsNotExist(err) {
+		t.Fatalf("destination was written: %v", err)
+	}
+}
+
+func TestCopyOpenDirectoryToRootWithStateRejectsInvalidUTF8(t *testing.T) {
+	sourceRoot := t.TempDir()
+	invalid := "secret-prefix-" + string([]byte{0xff})
+	if err := os.WriteFile(filepath.Join(sourceRoot, invalid), []byte("approved"), 0o600); err != nil {
+		err = newInjectionDestinationState().reserve(invalid, "regular file")
+		if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+			t.Fatalf("reservation error = %v", err)
+		}
+		return
+	}
+	source, err := os.Open(sourceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	destinationPath := t.TempDir()
+	destination, err := os.OpenRoot(destinationPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destination.Close()
+	err = copyOpenDirectoryToRootWithState(source, destination, sourceRoot, "target", openDirectMountChild, newInjectionDestinationState())
+	if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("copy error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destinationPath, "target", invalid)); !os.IsNotExist(err) {
+		t.Fatalf("destination was written: %v", err)
+	}
+}
 
 func TestStageFileRejectsValidatedSourcePathReplacement(t *testing.T) {
 	root := t.TempDir()
@@ -363,6 +511,22 @@ func TestStageDirectMountsRejectsCaseInsensitiveDestinationCollision(t *testing.
 	_, err := StageDirectMounts(filepath.Join(root, "bundle"), specPath)
 	if err == nil || !strings.Contains(err.Error(), "destination path collision") {
 		t.Fatalf("StageDirectMounts error = %v, want destination collision", err)
+	}
+}
+
+func TestInjectionDestinationStateRejectsUnicodeAliases(t *testing.T) {
+	state := newInjectionDestinationState()
+	if err := state.reserve("credentials/café", "directory"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.reserve("credentials/cafe\u0301", "regular file"); err == nil {
+		t.Fatal("NFC collision accepted")
+	}
+	if err := state.reserve("credentials/straße", "directory"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.reserve("credentials/STRASSE", "regular file"); err == nil {
+		t.Fatal("case-fold collision accepted")
 	}
 }
 

--- a/internal/injection/stage_direct_mounts.go
+++ b/internal/injection/stage_direct_mounts.go
@@ -156,6 +156,9 @@ func stageDirectMountEntry(hostSource, stagedSource string) error {
 
 	switch kind {
 	case directMountSourceDir:
+		if err := validateInjectionDirectoryDescendants(source); err != nil {
+			return err
+		}
 		if err := os.Mkdir(stagedSource, 0o700); err != nil {
 			return err
 		}
@@ -189,30 +192,99 @@ func copyDirContents(src *os.File, srcDisplay, dst string) error {
 	return copyDirContentsWithState(src, srcDisplay, dst, newInjectionDestinationState())
 }
 
-func copyDirContentsWithState(src *os.File, srcDisplay, dst string, state *injectionDestinationState) error {
-	entries, err := src.ReadDir(-1)
+// validateInjectionDirectoryDescendants checks each descendant through an
+// opened directory descriptor. It never builds a path from an unchecked name.
+func validateInjectionDirectoryDescendants(source *os.File) error {
+	fd, err := unix.Openat(int(source.Fd()), ".", unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return err
+	}
+	copy := os.NewFile(uintptr(fd), "")
+	if copy == nil {
+		_ = unix.Close(fd)
+		return errors.New("cannot inspect injection source directory")
+	}
+	defer copy.Close()
+	return validateInjectionDirectoryEntries(copy)
+}
+
+func validateInjectionDirectoryEntries(source *os.File) error {
+	return validateInjectionDirectoryEntriesWith(source, classifyDirectMountChild, openDirectMountChild)
+}
+
+func validateInjectionDirectoryEntriesWith(
+	source *os.File,
+	classifyChild func(*os.File, string) (os.FileMode, directMountSourceKind, error),
+	openChild func(*os.File, string, string) (*os.File, os.FileMode, directMountSourceKind, error),
+) error {
+	entries, err := source.ReadDir(-1)
 	if err != nil {
 		return err
 	}
 	for _, entry := range entries {
-		mode := entry.Type()
-		displayPath := filepath.Join(srcDisplay, entry.Name())
-		if mode&fs.ModeSymlink != 0 {
-			log.Printf("workcell injection: skipping symlink under host-input source: %s", displayPath)
+		name := entry.Name()
+		if err := validateInjectionDescendantName(name); err != nil {
+			return err
+		}
+		if entry.Type()&fs.ModeSymlink != 0 {
 			continue
 		}
-		childMode, kind, err := classifyDirectMountChild(src, entry.Name())
+		_, kind, err := classifyChild(source, name)
 		if err != nil {
 			return err
 		}
 		if kind == directMountSourceOther {
 			continue
 		}
-		target := filepath.Join(dst, entry.Name())
-		child, childMode, kind, err := openDirectMountChild(src, entry.Name(), displayPath)
+		child, _, kind, err := openChild(source, name, "")
+		if errors.Is(err, unix.ELOOP) || isSkippableDirectMountOpenError(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if kind == directMountSourceDir {
+			err = validateInjectionDirectoryEntriesWith(child, classifyChild, openChild)
+		}
+		closeErr := child.Close()
+		if err != nil {
+			return err
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+	}
+	return nil
+}
+
+func copyDirContentsWithState(src *os.File, srcDisplay, dst string, state *injectionDestinationState) error {
+	entries, err := src.ReadDir(-1)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if err := validateInjectionDescendantName(name); err != nil {
+			return err
+		}
+		mode := entry.Type()
+		displayPath := filepath.Join(srcDisplay, name)
+		if mode&fs.ModeSymlink != 0 {
+			log.Printf("workcell injection: skipping symlink under host-input source: %q", displayPath)
+			continue
+		}
+		childMode, kind, err := classifyDirectMountChild(src, name)
+		if err != nil {
+			return err
+		}
+		if kind == directMountSourceOther {
+			continue
+		}
+		target := filepath.Join(dst, name)
+		child, childMode, kind, err := openDirectMountChild(src, name, displayPath)
 		if err != nil {
 			if errors.Is(err, unix.ELOOP) || isSkippableDirectMountOpenError(err) {
-				log.Printf("workcell injection: skipping non-regular entry under host-input source: %s", displayPath)
+				log.Printf("workcell injection: skipping non-regular entry under host-input source: %q", displayPath)
 				continue
 			}
 			return err
@@ -353,7 +425,7 @@ func openDirectMountChild(parent *os.File, name, displayPath string) (*os.File, 
 	file := os.NewFile(uintptr(fd), displayPath)
 	if file == nil {
 		_ = unix.Close(fd)
-		return nil, 0, directMountSourceOther, fmt.Errorf("Direct input source is missing, not absolute, or not a regular file/directory: %s", displayPath)
+		return nil, 0, directMountSourceOther, fmt.Errorf("Direct input source is missing, not absolute, or not a regular file/directory: %q", displayPath)
 	}
 	kind, mode, err := classifyDirectMountFD(fd)
 	if err != nil {

--- a/internal/injection/stage_direct_mounts_test.go
+++ b/internal/injection/stage_direct_mounts_test.go
@@ -4,16 +4,227 @@
 package injection
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"log"
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
 
 	"github.com/omkhar/workcell/internal/host/hoststate"
+	"github.com/omkhar/workcell/internal/pathutil"
+	"golang.org/x/sys/unix"
 )
+
+func TestCopyDirContentsWithStateRejectsPreReservedUnicodeAlias(t *testing.T) {
+	sourcePath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourcePath, "STRASSE"), []byte("approved"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	destination := t.TempDir()
+	state := newInjectionDestinationState()
+	if err := state.reserve(filepath.Join(destination, "straße"), "reserved"); err != nil {
+		t.Fatal(err)
+	}
+	err = copyDirContentsWithState(source, sourcePath, destination, state)
+	if err == nil || !strings.Contains(err.Error(), "destination path collision") {
+		t.Fatalf("copy error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destination, "STRASSE")); !os.IsNotExist(err) {
+		t.Fatalf("destination was written: %v", err)
+	}
+}
+
+func TestCopyDirContentsWithStateRejectsInvalidUTF8Reservation(t *testing.T) {
+	sourcePath := t.TempDir()
+	invalid := "secret-prefix-" + string([]byte{0xff})
+	if err := os.WriteFile(filepath.Join(sourcePath, invalid), []byte("approved"), 0o600); err != nil {
+		err = newInjectionDestinationState().reserve(invalid, "regular file")
+		if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+			t.Fatalf("reservation error = %v", err)
+		}
+		return
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	destination := t.TempDir()
+	err = copyDirContentsWithState(source, sourcePath, destination, newInjectionDestinationState())
+	if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("copy error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destination, invalid)); !os.IsNotExist(err) {
+		t.Fatalf("destination was written: %v", err)
+	}
+}
+
+func TestStageDirectMountsRejectsUnsafeDescendantBeforeReadOnlyDestination(t *testing.T) {
+	for _, testCase := range unsafeInjectionDescendantNames {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := t.TempDir()
+			source := filepath.Join(root, "source")
+			if err := os.Mkdir(source, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(source, testCase.value), []byte("approved"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			bundleRoot := filepath.Join(root, "bundle")
+			stagedRoot := filepath.Join(bundleRoot, "direct-mounts")
+			if err := os.MkdirAll(bundleRoot, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Mkdir(stagedRoot, 0o500); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chmod(stagedRoot, 0o700) })
+			specPath := filepath.Join(root, "spec.json")
+			writeMountSpec(t, specPath, []map[string]any{{"source": source, "mount_path": "/opt/workcell/host-inputs/source"}})
+			_, err := StageDirectMounts(bundleRoot, specPath)
+			assertUnsafeInjectionDescendantError(t, err)
+		})
+	}
+}
+
+func TestCopyDirContentsWithStateRejectsLinuxInvalidUTF8SpecialFile(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux permits invalid UTF-8 descendant names")
+	}
+	sourcePath := t.TempDir()
+	invalid := "secret-prefix-" + string([]byte{0xff})
+	if err := unix.Mkfifo(filepath.Join(sourcePath, invalid), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	destination := t.TempDir()
+	err = copyDirContentsWithState(source, sourcePath, destination, newInjectionDestinationState())
+	if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("copy error = %v", err)
+	}
+	entries, err := os.ReadDir(destination)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("destination entries = %#v, %v", entries, err)
+	}
+}
+
+func TestCopyDirContentsRejectsControlCharactersBeforeLogging(t *testing.T) {
+	for _, testCase := range unsafeInjectionDescendantNames {
+		t.Run(testCase.name, func(t *testing.T) {
+			sourcePath := t.TempDir()
+			if err := os.Symlink("target", filepath.Join(sourcePath, testCase.value)); err != nil {
+				t.Fatal(err)
+			}
+			source, err := os.Open(sourcePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer source.Close()
+			var output bytes.Buffer
+			previousOutput := log.Writer()
+			log.SetOutput(&output)
+			t.Cleanup(func() { log.SetOutput(previousOutput) })
+			err = copyDirContentsWithState(source, sourcePath, t.TempDir(), newInjectionDestinationState())
+			assertUnsafeInjectionDescendantError(t, err)
+			if output.Len() != 0 {
+				t.Fatalf("control name reached the log: %q", output.String())
+			}
+		})
+	}
+}
+
+func TestValidateInjectionDirectoryEntriesWith(t *testing.T) {
+	newSource := func(t *testing.T) *os.File {
+		t.Helper()
+		path := t.TempDir()
+		if err := os.WriteFile(filepath.Join(path, "entry"), []byte("data"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		source, err := os.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = source.Close() })
+		return source
+	}
+
+	t.Run("other skips opener", func(t *testing.T) {
+		opened := false
+		err := validateInjectionDirectoryEntriesWith(newSource(t),
+			func(*os.File, string) (os.FileMode, directMountSourceKind, error) {
+				return 0, directMountSourceOther, nil
+			},
+			func(*os.File, string, string) (*os.File, os.FileMode, directMountSourceKind, error) {
+				opened = true
+				return newSource(t), 0, directMountSourceOther, nil
+			},
+		)
+		if err != nil {
+			t.Fatalf("validate entries: %v", err)
+		}
+		if opened {
+			t.Fatal("opener was called for an unsupported entry")
+		}
+	})
+
+	t.Run("classifier error propagates", func(t *testing.T) {
+		sentinel := errors.New("classify sentinel")
+		err := validateInjectionDirectoryEntriesWith(newSource(t),
+			func(*os.File, string) (os.FileMode, directMountSourceKind, error) {
+				return 0, directMountSourceOther, sentinel
+			},
+			func(*os.File, string, string) (*os.File, os.FileMode, directMountSourceKind, error) {
+				return nil, 0, directMountSourceOther, nil
+			},
+		)
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("validate entries error = %v, want classifier sentinel", err)
+		}
+	})
+
+	for _, testCase := range []struct {
+		name string
+		err  error
+		skip bool
+	}{
+		{name: "ENXIO skips", err: unix.ENXIO, skip: true},
+		{name: "ENODEV skips", err: unix.ENODEV, skip: true},
+		{name: "EACCES propagates", err: unix.EACCES},
+		{name: "EIO propagates", err: unix.EIO},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := validateInjectionDirectoryEntriesWith(newSource(t),
+				func(*os.File, string) (os.FileMode, directMountSourceKind, error) {
+					return 0, directMountSourceRegular, nil
+				},
+				func(*os.File, string, string) (*os.File, os.FileMode, directMountSourceKind, error) {
+					return nil, 0, directMountSourceOther, testCase.err
+				},
+			)
+			if testCase.skip && err != nil {
+				t.Fatalf("validate entries error = %v, want nil", err)
+			}
+			if !testCase.skip && !errors.Is(err, testCase.err) {
+				t.Fatalf("validate entries error = %v, want %v", err, testCase.err)
+			}
+		})
+	}
+}
 
 func writeMountSpec(t *testing.T, path string, entries []map[string]any) {
 	t.Helper()
@@ -46,6 +257,25 @@ func TestStageDirectMountsRejectsDanglingSpecSymlink(t *testing.T) {
 
 	if _, err := StageDirectMounts(bundleRoot, specPath); err == nil {
 		t.Fatal("expected dangling mount-spec symlink to be rejected")
+	}
+}
+
+func TestStageDirectMountsRejectsUnicodeDestinationCollision(t *testing.T) {
+	bundleRoot := t.TempDir()
+	source := filepath.Join(bundleRoot, "source")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(source, "café"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(source, "cafe\u0301"), 0o755); err != nil {
+		t.Skipf("filesystem does not permit distinct normalization aliases: %v", err)
+	}
+	specPath := filepath.Join(bundleRoot, "spec.json")
+	writeMountSpec(t, specPath, []map[string]any{{"source": source, "mount_path": "/opt/workcell/host-inputs/source"}})
+	if _, err := StageDirectMounts(bundleRoot, specPath); err == nil || !strings.Contains(err.Error(), "destination path collision") {
+		t.Fatalf("StageDirectMounts error = %v, want destination collision", err)
 	}
 }
 

--- a/internal/pathutil/identity.go
+++ b/internal/pathutil/identity.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package pathutil
+
+import (
+	"path/filepath"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/unicode/norm"
+)
+
+// CollisionKey returns a Unicode-normalized, case-insensitive path identity.
+func CollisionKey(path string) (string, error) {
+	normalized, err := normalizePath(path, true)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(normalized), nil
+}
+
+// WithinOrEqual reports if candidate is root or is below root.
+func WithinOrEqual(root, candidate string, caseInsensitive bool) (bool, error) {
+	root, err := normalizePath(root, caseInsensitive)
+	if err != nil {
+		return false, err
+	}
+	candidate, err = normalizePath(candidate, caseInsensitive)
+	if err != nil {
+		return false, err
+	}
+	rel, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return false, err
+	}
+	return rel == "." || (rel != ".." && !filepath.IsAbs(rel) && !strings.HasPrefix(rel, ".."+string(filepath.Separator))), nil
+}
+
+func normalizePath(path string, caseInsensitive bool) (string, error) {
+	if path == "" {
+		return "", ErrEmptyPath
+	}
+	if !utf8.ValidString(path) {
+		return "", ErrInvalidUTF8Path
+	}
+	for _, runeValue := range path {
+		if unicode.IsControl(runeValue) || unicode.Is(unicode.Zl, runeValue) || unicode.Is(unicode.Zp, runeValue) {
+			return "", ErrUnsafePathControl
+		}
+	}
+	normalized := norm.NFC.String(filepath.Clean(path))
+	if caseInsensitive {
+		normalized = norm.NFC.String(cases.Fold().String(normalized))
+	}
+	return normalized, nil
+}

--- a/internal/pathutil/identity_test.go
+++ b/internal/pathutil/identity_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package pathutil
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCollisionKeyUnicodeAliases(t *testing.T) {
+	for _, pair := range [][2]string{{"café", "cafe\u0301"}, {"straße", "STRASSE"}, {"Σ", "ς"}, {"ﬀ", "ff"}, {"µ", "Μ"}, {"ś", "ſ\u0301"}} {
+		left, err := CollisionKey(pair[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		right, err := CollisionKey(pair[1])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if left != right {
+			t.Fatalf("keys differ: %q and %q", pair[0], pair[1])
+		}
+	}
+}
+
+func TestPathIdentityRejectsEmptyAndInvalidUTF8(t *testing.T) {
+	invalid := "secret-prefix-" + string([]byte{0xff})
+	if _, err := CollisionKey(invalid); !errors.Is(err, ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("CollisionKey invalid error = %v", err)
+	}
+	if _, err := WithinOrEqual("root", invalid, false); !errors.Is(err, ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("WithinOrEqual invalid candidate error = %v", err)
+	}
+	if _, err := CollisionKey(""); !errors.Is(err, ErrEmptyPath) {
+		t.Fatalf("empty error = %v, want ErrEmptyPath", err)
+	}
+}
+
+func TestPathIdentityRejectsUnsafeControlRunes(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		path string
+		want error
+	}{
+		{name: "newline", path: "secret-prefix-\n", want: ErrUnsafePathControl},
+		{name: "escape", path: "secret-prefix-\x1b", want: ErrUnsafePathControl},
+		{name: "line separator", path: "secret-prefix-\u2028", want: ErrUnsafePathControl},
+		{name: "paragraph separator", path: "secret-prefix-\u2029", want: ErrUnsafePathControl},
+		{name: "valid", path: "secret-prefix-safe"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := CollisionKey(testCase.path)
+			if testCase.want == nil {
+				if err != nil {
+					t.Fatalf("CollisionKey() error = %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, testCase.want) || strings.Contains(err.Error(), "secret-prefix") {
+				t.Fatalf("CollisionKey() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestWithinOrEqualUnicodeAndBoundaries(t *testing.T) {
+	inside, err := WithinOrEqual("/tmp/café", "/tmp/cafe\u0301/file", false)
+	if err != nil || !inside {
+		t.Fatalf("NFC containment = %v, %v", inside, err)
+	}
+	inside, err = WithinOrEqual("/tmp/straße", "/tmp/STRASSE/file", true)
+	if err != nil || !inside {
+		t.Fatalf("fold containment = %v, %v", inside, err)
+	}
+	inside, err = WithinOrEqual("/tmp/ś", "/tmp/ſ\u0301/file", true)
+	if err != nil || !inside {
+		t.Fatalf("post-fold NFC containment = %v, %v", inside, err)
+	}
+	inside, err = WithinOrEqual("/tmp/root", "/tmp/root-other/file", true)
+	if err != nil || inside {
+		t.Fatalf("sibling containment = %v, %v", inside, err)
+	}
+}
+
+func TestCollisionKeyConcurrent(t *testing.T) {
+	values := []string{"café", "cafe\u0301", "straße", "STRASSE", "Σ", "ς"}
+	done := make(chan struct{})
+	for range 32 {
+		go func() {
+			for _, value := range values {
+				if _, err := CollisionKey(value); err != nil {
+					t.Error(err)
+				}
+			}
+			done <- struct{}{}
+		}()
+	}
+	for range 32 {
+		<-done
+	}
+}

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -19,6 +19,14 @@ import (
 // domain-specific message.
 var ErrEmptyPath = errors.New("pathutil: path is empty")
 
+// ErrInvalidUTF8Path is returned when a path contains invalid UTF-8 bytes.
+// Callers can match it with errors.Is without exposing the rejected bytes.
+var ErrInvalidUTF8Path = errors.New("pathutil: path contains invalid UTF-8")
+
+// ErrUnsafePathControl is returned when a path contains a control or line
+// separator rune. Callers can match it without exposing the rejected bytes.
+var ErrUnsafePathControl = errors.New("pathutil: path contains an unsafe control character")
+
 // ExpandUserPathBestEffort expands `~`, `~/...`, and `~user`/`~user/...`
 // references via os.UserHomeDir or user.Lookup.  When a `~user` lookup
 // fails (unknown user or empty home), it returns the input verbatim

--- a/internal/remotevm/fake_target.go
+++ b/internal/remotevm/fake_target.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/omkhar/workcell/internal/host/sessions"
+	"github.com/omkhar/workcell/internal/pathutil"
 )
 
 type WorkspaceEntry struct {
@@ -366,7 +367,14 @@ func statePathSegment(label, value string) (string, error) {
 }
 
 func copyWorkspaceTree(sourceRoot, destRoot string, excluded []string) ([]WorkspaceEntry, error) {
+	return copyWorkspaceTreeWithReservation(sourceRoot, destRoot, excluded, newWorkspaceDestinationState())
+}
+
+func copyWorkspaceTreeWithReservation(sourceRoot, destRoot string, excluded []string, destinations workspaceDestinationReservation) ([]WorkspaceEntry, error) {
 	entries := make([]WorkspaceEntry, 0)
+	if destinations == nil {
+		return nil, fmt.Errorf("workspace destination reservation is required")
+	}
 	resolvedRoot, err := filepath.EvalSymlinks(sourceRoot)
 	if err != nil {
 		return nil, err
@@ -378,12 +386,19 @@ func copyWorkspaceTree(sourceRoot, destRoot string, excluded []string) ([]Worksp
 		if path == sourceRoot {
 			return nil
 		}
+		if _, err := pathutil.CollisionKey(d.Name()); err != nil {
+			return fmt.Errorf("invalid workspace entry: %w", err)
+		}
 		rel, err := filepath.Rel(sourceRoot, path)
 		if err != nil {
 			return err
 		}
 		rel = filepath.ToSlash(rel)
-		if isExcludedPath(rel, excluded) {
+		excludedPath, err := isExcludedPath(rel, excluded)
+		if err != nil {
+			return err
+		}
+		if excludedPath {
 			if d.IsDir() {
 				return filepath.SkipDir
 			}
@@ -394,21 +409,24 @@ func copyWorkspaceTree(sourceRoot, destRoot string, excluded []string) ([]Worksp
 			return err
 		}
 		destPath := filepath.Join(destRoot, filepath.FromSlash(rel))
+		if err := destinations.reserve(rel); err != nil {
+			return err
+		}
 		switch {
 		case info.Mode()&os.ModeSymlink != 0:
 			target, err := os.Readlink(path)
 			if err != nil {
-				return err
+				return fmt.Errorf("read workspace symlink %q: %q", rel, err.Error())
 			}
 			// The remote-vm contract promises host-auditable materialization:
 			// a symlink that resolves outside the materialized workspace would
 			// smuggle non-workspace content past that audit, so fail closed.
 			if filepath.IsAbs(target) {
-				return fmt.Errorf("workspace symlink %s targets an absolute path: %s", rel, target)
+				return fmt.Errorf("workspace symlink %q targets an absolute path: %q", rel, target)
 			}
 			resolved := filepath.ToSlash(filepath.Clean(filepath.Join(filepath.Dir(filepath.FromSlash(rel)), target)))
 			if resolved == ".." || strings.HasPrefix(resolved, "../") {
-				return fmt.Errorf("workspace symlink %s escapes the workspace: %s", rel, target)
+				return fmt.Errorf("workspace symlink %q escapes the workspace: %q", rel, target)
 			}
 			// The lexical check above is evadable through symlink chains
 			// (an in-workspace link to a parent directory re-routes a later
@@ -417,10 +435,10 @@ func copyWorkspaceTree(sourceRoot, destRoot string, excluded []string) ([]Worksp
 			// links fail closed.
 			physical, err := filepath.EvalSymlinks(path)
 			if err != nil {
-				return fmt.Errorf("workspace symlink %s does not resolve inside the workspace: %v", rel, err)
+				return fmt.Errorf("workspace symlink %q does not resolve inside the workspace: %q", rel, err.Error())
 			}
 			if physical != resolvedRoot && !strings.HasPrefix(physical, resolvedRoot+string(filepath.Separator)) {
-				return fmt.Errorf("workspace symlink %s escapes the workspace: %s", rel, target)
+				return fmt.Errorf("workspace symlink %q escapes the workspace: %q", rel, target)
 			}
 			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 				return err
@@ -453,7 +471,7 @@ func copyWorkspaceTree(sourceRoot, destRoot string, excluded []string) ([]Worksp
 				SHA256: hex.EncodeToString(sum[:]),
 			})
 		default:
-			return fmt.Errorf("unsupported workspace entry kind for %s", rel)
+			return fmt.Errorf("unsupported workspace entry kind for %q", rel)
 		}
 		return nil
 	})
@@ -466,13 +484,44 @@ func copyWorkspaceTree(sourceRoot, destRoot string, excluded []string) ([]Worksp
 	return entries, nil
 }
 
-func isExcludedPath(rel string, excluded []string) bool {
+func isExcludedPath(rel string, excluded []string) (bool, error) {
+	if _, err := pathutil.CollisionKey(rel); err != nil {
+		return false, err
+	}
 	for _, item := range excluded {
-		if rel == item || strings.HasPrefix(rel, item+"/") {
-			return true
+		inside, err := pathutil.WithinOrEqual(item, rel, true)
+		if err != nil {
+			return false, err
+		}
+		if inside {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
+}
+
+type workspaceDestinationReservation interface {
+	reserve(string) error
+}
+
+type workspaceDestinationState struct {
+	paths map[string]string
+}
+
+func newWorkspaceDestinationState() *workspaceDestinationState {
+	return &workspaceDestinationState{paths: make(map[string]string)}
+}
+
+func (s *workspaceDestinationState) reserve(path string) error {
+	key, err := pathutil.CollisionKey(path)
+	if err != nil {
+		return fmt.Errorf("invalid workspace destination path: %w", err)
+	}
+	if previous, exists := s.paths[key]; exists {
+		return fmt.Errorf("workspace destination path collision between %s and %q", previous, path)
+	}
+	s.paths[key] = fmt.Sprintf("%q", path)
+	return nil
 }
 
 func writeJSON(path string, value any) error {

--- a/internal/remotevm/fake_target_test.go
+++ b/internal/remotevm/fake_target_test.go
@@ -5,11 +5,25 @@ package remotevm
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omkhar/workcell/internal/pathutil"
+	"golang.org/x/sys/unix"
 )
+
+type failingWorkspaceReservation struct {
+	calls []string
+	err   error
+}
+
+func (r *failingWorkspaceReservation) reserve(path string) error {
+	r.calls = append(r.calls, path)
+	return r.err
+}
 
 func TestFakeTargetMaterializeWorkspaceCopiesFixtureAndExcludesDotGit(t *testing.T) {
 	t.Parallel()
@@ -45,6 +59,178 @@ func TestFakeTargetMaterializeWorkspaceCopiesFixtureAndExcludesDotGit(t *testing
 	}
 	if got, want := len(result.Manifest.Entries), 3; got != want {
 		t.Fatalf("len(result.Manifest.Entries) = %d, want %d", got, want)
+	}
+}
+
+func TestCopyWorkspaceTreeRejectsUnicodeDestinationCollision(t *testing.T) {
+	for _, pair := range [][2]string{{"café", "cafe\u0301"}, {"straße", "STRASSE"}, {"Σ", "ς"}, {"ﬀ", "ff"}, {"µ", "Μ"}, {"ś", "ſ\u0301"}} {
+		state := newWorkspaceDestinationState()
+		if err := state.reserve(pair[0]); err != nil {
+			t.Fatal(err)
+		}
+		if err := state.reserve(pair[1]); err == nil {
+			t.Fatalf("Unicode collision accepted: %q and %q", pair[0], pair[1])
+		}
+	}
+}
+
+func TestRemoteWorkspaceExclusionsUseUnicodePathIdentity(t *testing.T) {
+	for _, pair := range [][2]string{{".git", ".GIT"}, {"café", "cafe\u0301"}, {"straße", "STRASSE"}, {"Σ", "ς"}, {"ﬀ", "ff"}, {"µ", "Μ"}, {"ś", "ſ\u0301"}} {
+		excluded, err := isExcludedPath(filepath.Join(pair[1], "child"), []string{pair[0]})
+		if err != nil || !excluded {
+			t.Fatalf("excluded %q by %q = %v, %v", pair[1], pair[0], excluded, err)
+		}
+		excluded, err = isExcludedPath(pair[1]+"-sibling", []string{pair[0]})
+		if err != nil || excluded {
+			t.Fatalf("sibling %q excluded by %q = %v, %v", pair[1], pair[0], excluded, err)
+		}
+	}
+}
+
+func TestRemoteWorkspaceIdentityRejectsInvalidUTF8(t *testing.T) {
+	invalid := "secret-prefix-" + string([]byte{0xff})
+	if _, err := isExcludedPath(invalid, nil); !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("exclusion error = %v", err)
+	}
+	if err := newWorkspaceDestinationState().reserve(invalid); !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("reservation error = %v", err)
+	}
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, invalid), []byte("approved"), 0o600); err != nil {
+		return
+	}
+	destination := t.TempDir()
+	if _, err := copyWorkspaceTree(source, destination, nil); !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("copy error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destination, invalid)); !os.IsNotExist(err) {
+		t.Fatalf("destination was written: %v", err)
+	}
+	stateRoot := t.TempDir()
+	target, err := NewFakeTarget(DefaultContract())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = target.MaterializeWorkspace(context.Background(), MaterializeRequest{StateRoot: stateRoot, TargetID: "target", MaterializationID: "invalid", SourceWorkspace: source})
+	if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
+		t.Fatalf("materialize error = %v", err)
+	}
+	manifest := filepath.Join(targetRoot(stateRoot, CanonicalProvider, "target"), "materializations", "invalid", MaterializationFile)
+	if _, err := os.Lstat(manifest); !os.IsNotExist(err) {
+		t.Fatalf("manifest exists after invalid input: %v", err)
+	}
+}
+
+func TestCopyWorkspaceTreeRejectsUnsafeDescendantBeforeReadOnlyDestination(t *testing.T) {
+	for _, testCase := range []struct {
+		name  string
+		value string
+	}{
+		{name: "newline", value: "secret-prefix-\n"},
+		{name: "escape", value: "secret-prefix-\x1b"},
+		{name: "line separator", value: "secret-prefix-\u2028"},
+		{name: "paragraph separator", value: "secret-prefix-\u2029"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			source := t.TempDir()
+			if err := os.WriteFile(filepath.Join(source, testCase.value), []byte("approved"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			destination := t.TempDir()
+			if err := os.Chmod(destination, 0o500); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chmod(destination, 0o700) })
+			_, err := copyWorkspaceTree(source, destination, nil)
+			if !errors.Is(err, pathutil.ErrUnsafePathControl) || strings.Contains(err.Error(), "secret-prefix") {
+				t.Fatalf("unsafe descendant error = %v", err)
+			}
+		})
+	}
+}
+
+func TestRemoteWorkspaceExclusionRejectsUnsafeControls(t *testing.T) {
+	for _, path := range []string{"secret-prefix-\n", "secret-prefix-\x1b", "secret-prefix-\u2028", "secret-prefix-\u2029"} {
+		if _, err := isExcludedPath(path, nil); !errors.Is(err, pathutil.ErrUnsafePathControl) || strings.Contains(err.Error(), "secret-prefix") {
+			t.Fatalf("unsafe exclusion error = %v", err)
+		}
+	}
+}
+
+func TestRemoteWorkspaceDiagnosticsQuoteControlCharacters(t *testing.T) {
+	source := t.TempDir()
+	target := "/tmp/target\n\x1b"
+	if err := os.Symlink(target, filepath.Join(source, "link")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := copyWorkspaceTree(source, t.TempDir(), nil)
+	if err == nil {
+		t.Fatal("absolute control-character symlink was accepted")
+	}
+	assertQuotedWorkspaceDiagnostic(t, err.Error())
+}
+
+func assertQuotedWorkspaceDiagnostic(t *testing.T, message string) {
+	t.Helper()
+	if strings.Contains(message, "\n") || strings.Contains(message, "\x1b") {
+		t.Fatalf("diagnostic contains a raw control character: %q", message)
+	}
+	if !strings.Contains(message, `\n`) || !strings.Contains(message, `\x1b`) {
+		t.Fatalf("diagnostic does not quote control characters: %q", message)
+	}
+}
+
+func TestCopyWorkspaceTreeReservesBeforeWrite(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "first"), []byte("approved"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(t.TempDir(), "destination")
+	reservation := &failingWorkspaceReservation{err: errors.New("reserve failed")}
+	if _, err := copyWorkspaceTreeWithReservation(source, destination, nil, reservation); !errors.Is(err, reservation.err) {
+		t.Fatalf("copy error = %v", err)
+	}
+	if len(reservation.calls) != 1 || reservation.calls[0] != "first" {
+		t.Fatalf("reservation calls = %#v", reservation.calls)
+	}
+	if _, err := os.Stat(filepath.Join(destination, "first")); !os.IsNotExist(err) {
+		t.Fatalf("destination was written before reservation: %v", err)
+	}
+}
+
+func TestCopyWorkspaceTreePreservesFirstContentAfterReservation(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "first"), []byte("approved"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	destination := t.TempDir()
+	entries, err := copyWorkspaceTree(source, destination, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(destination, "first"))
+	if err != nil || string(data) != "approved" || len(entries) != 1 || entries[0].SHA256 == "" {
+		t.Fatalf("copy result = %q, %#v, %v", data, entries, err)
+	}
+}
+
+func TestFakeTargetDoesNotWriteManifestAfterWorkspaceFailure(t *testing.T) {
+	source := t.TempDir()
+	if err := unix.Mkfifo(filepath.Join(source, "pipe"), 0o600); err != nil {
+		t.Skipf("cannot create FIFO: %v", err)
+	}
+	state := t.TempDir()
+	target, err := NewFakeTarget(DefaultContract())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = target.MaterializeWorkspace(context.Background(), MaterializeRequest{StateRoot: state, TargetID: "target", MaterializationID: "failure", SourceWorkspace: source})
+	if err == nil {
+		t.Fatal("unsafe workspace entry was accepted")
+	}
+	manifest := filepath.Join(targetRoot(state, CanonicalProvider, "target"), "materializations", "failure", MaterializationFile)
+	if _, err := os.Lstat(manifest); !os.IsNotExist(err) {
+		t.Fatalf("manifest exists after failure: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Normalize path identity with NFC and full Unicode case folding.
- Reject invalid UTF-8 and unsafe control characters before filesystem use.
- Reserve injection and remote workspace destinations before writes.
- Apply fail-closed containment checks to host authentication paths.
- Classify direct-mount descendants before access.
- Skip only unsupported entries and known special-file races.

## Security effect

This change prevents different Unicode aliases from using one destination.
It also stops invalid or unsafe path names before filesystem operations.
Diagnostics do not expose rejected path bytes.

## Validation

- Fresh `pr-parity` passed for the exact base, head, tree, and clean worktree.
- Focused, full, race, vet, cross-build, contract, `govulncheck`, Linux arm64, and mutation checks passed.
- The final adversarial review was clean.
- `shared/agent-launch-smoke` passed.
- `shared/docker-desktop-launch-smoke` passed.
- The scenario result was 2 passed, 0 failed, and 20 skipped.
- The certification cleanup check passed.

## Scope

- Base: `2d9e905b1badcf98a00c2065f06f2946a4fc4302`
- Head: `481ac51f6fff3615bcfc4679ed474ad4ec177885`
- Tree: `668f1166da94986e5e9eb492127dbc30cceb457d`
- Canonical diff SHA-256: `ea582040cc2b0184408d53f2113045980558661ac24688052a08707a6ff8964a`
- Shape: 17 files, 1,189 lines, 3 validator areas, and 0 binary files.
- Publication range: one signed commit.