### PR TITLE
Add descriptor-based Apple workspace copier

### DIFF
--- a/internal/applecontainer/workspace_copy.go
+++ b/internal/applecontainer/workspace_copy.go
@@ -78,6 +78,8 @@ type workspaceWalk struct {
 
 // copyWorkspaceTreeDescriptor requires parentFD to stay open and caller-owned.
 // It must name a private CLOEXEC directory that is physically disjoint from sourceRoot.
+// Each entry uses its last descriptor-content or directory-name check as its source observation point.
+// The function does not provide a filesystem-wide source snapshot.
 // The function does not close parentFD.
 func copyWorkspaceTreeDescriptor(sourceRoot string, parentFD int, name string, excluded []string) ([]WorkspaceEntry, error) {
 	return copyWorkspaceTreeWithOps(sourceRoot, parentFD, name, excluded, defaultWorkspaceCopyLimits(), systemWorkspaceOps())
@@ -129,6 +131,7 @@ func copyWorkspaceTreeWithOps(sourceRoot string, parentFD int, name string, excl
 func (walk *workspaceWalk) directory(sourceFD, destFD int, parentRel string, depth int, expected workspaceSnapshot) (retErr error) {
 	source := os.NewFile(uintptr(sourceFD), parentRel)
 	defer func() { retErr = errors.Join(retErr, source.Close()) }()
+	initialNames := []string{}
 	id := workspaceObjectID{expected.dev, expected.ino}
 	if previous, found := walk.directories[id]; found {
 		return fmt.Errorf("workspace directory identity repeats at %q and %q", previous, parentRel)
@@ -139,6 +142,7 @@ func (walk *workspaceWalk) directory(sourceFD, destFD int, parentRel string, dep
 		if readErr != nil && readErr != io.EOF {
 			return readErr
 		}
+		initialNames = append(initialNames, names...)
 		for _, name := range names {
 			if err := validateWorkspaceLeaf("workspace entry", name); err != nil {
 				return err
@@ -187,6 +191,12 @@ func (walk *workspaceWalk) directory(sourceFD, destFD int, parentRel string, dep
 	var after unix.Stat_t
 	if err := walk.ops.fstat(sourceFD, &after); err != nil || workspaceSnapshotFromUnix(after) != expected {
 		return fmt.Errorf("workspace directory changed while copying")
+	}
+	stableNames, err := workspaceDirectoryNames(sourceFD, len(initialNames)+1)
+	sort.Strings(initialNames)
+	sort.Strings(stableNames)
+	if err != nil || strings.Join(stableNames, "\x00") != strings.Join(initialNames, "\x00") {
+		return fmt.Errorf("workspace directory entries changed while copying")
 	}
 	return nil
 }
@@ -255,6 +265,14 @@ func (walk *workspaceWalk) copyFile(sourceParent, destParent int, name, rel stri
 	if err := walk.ops.fstat(fd, &after); err != nil || workspaceSnapshotFromUnix(after) != before {
 		return fmt.Errorf("workspace file %q changed while copying", rel)
 	}
+	digest := hex.EncodeToString(hash.Sum(nil))
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	stableHash := sha256.New()
+	if read, err := io.Copy(stableHash, io.LimitReader(source, written+1)); err != nil || read != written || hex.EncodeToString(stableHash.Sum(nil)) != digest {
+		return fmt.Errorf("workspace file %q content changed while copying", rel)
+	}
 	walk.totalBytes += written
 	mode := entryMode(openedSnapshot, 0)
 	if err := walk.ops.fchmod(destFD, uint32(mode.Perm())); err != nil {
@@ -269,10 +287,18 @@ func (walk *workspaceWalk) copyFile(sourceParent, destParent int, name, rel stri
 	}
 	mode = entryMode(copiedSnapshot, 0)
 	walk.fileSizes[rel] = written
-	return walk.retain(WorkspaceEntry{Path: rel, Kind: "file", Mode: mode, SHA256: hex.EncodeToString(hash.Sum(nil))})
+	return walk.retain(WorkspaceEntry{Path: rel, Kind: "file", Mode: mode, SHA256: digest})
 }
 
 func (walk *workspaceWalk) copySymlink(sourceParent, destParent int, name, rel string, before workspaceSnapshot) error {
+	sourceLinkFD, err := walk.ops.openat(sourceParent, name, workspaceSymlinkOpenFlags, 0)
+	if err != nil {
+		return fmt.Errorf("pin workspace symlink %q: %w", rel, err)
+	}
+	defer unix.Close(sourceLinkFD)
+	if opened, err := verifyWorkspaceNameAt(sourceParent, name, sourceLinkFD, walk.ops); err != nil || opened != before {
+		return fmt.Errorf("workspace symlink %q changed before read", rel)
+	}
 	target, err := readWorkspaceLink(sourceParent, name, walk.ops)
 	if err != nil {
 		return fmt.Errorf("read workspace symlink %q: %w", rel, err)
@@ -293,11 +319,16 @@ func (walk *workspaceWalk) copySymlink(sourceParent, destParent int, name, rel s
 	if err := walk.ops.symlinkat(target, destParent, name); err != nil {
 		return fmt.Errorf("create workspace symlink %q: %w", rel, err)
 	}
-	var copied, stable unix.Stat_t
-	if err := walk.ops.fstatat(destParent, name, &copied, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+	copiedFD, err := walk.ops.openat(destParent, name, workspaceSymlinkOpenFlags, 0)
+	if err != nil {
 		return err
 	}
-	copiedSnapshot := workspaceSnapshotFromUnix(copied)
+	defer unix.Close(copiedFD)
+	copiedSnapshot, err := verifyWorkspaceNameAt(destParent, name, copiedFD, walk.ops)
+	if err != nil {
+		return err
+	}
+	var stable unix.Stat_t
 	if copiedSnapshot.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFLNK) {
 		return fmt.Errorf("workspace symlink %q changed after creation", rel)
 	}
@@ -476,6 +507,14 @@ func (walk *workspaceWalk) validateDestinationFile(parentFD int, name string, en
 func (walk *workspaceWalk) validateDestinationSymlink(parentFD int, name string, entry WorkspaceEntry, before workspaceSnapshot) error {
 	if before.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFLNK) || before.nlink != 1 || before.mode&0o7777 != uint32(entry.Mode.Perm()) {
 		return fmt.Errorf("workspace destination symlink differs from its manifest")
+	}
+	fd, err := walk.ops.openat(parentFD, name, workspaceSymlinkOpenFlags, 0)
+	if err != nil {
+		return err
+	}
+	defer unix.Close(fd)
+	if opened, err := verifyWorkspaceNameAt(parentFD, name, fd, walk.ops); err != nil || opened != before {
+		return fmt.Errorf("workspace destination symlink changed before validation")
 	}
 	target, err := readWorkspaceLink(parentFD, name, walk.ops)
 	if err != nil {

--- a/internal/applecontainer/workspace_copy.go
+++ b/internal/applecontainer/workspace_copy.go
@@ -296,8 +296,8 @@ func (walk *workspaceWalk) copySymlink(sourceParent, destParent int, name, rel s
 		return fmt.Errorf("pin workspace symlink %q: %w", rel, err)
 	}
 	defer unix.Close(sourceLinkFD)
-	if opened, err := verifyWorkspaceNameAt(sourceParent, name, sourceLinkFD, walk.ops); err != nil || opened != before {
-		return fmt.Errorf("workspace symlink %q changed before read", rel)
+	if opened, err := verifyWorkspaceNameAt(sourceParent, name, sourceLinkFD, walk.ops); err != nil || opened != before || opened.nlink != 1 {
+		return fmt.Errorf("workspace symlink %q changed before read or is multiply linked", rel)
 	}
 	target, err := readWorkspaceLink(sourceParent, name, walk.ops)
 	if err != nil {

--- a/internal/applecontainer/workspace_copy.go
+++ b/internal/applecontainer/workspace_copy.go
@@ -1,0 +1,711 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/pathutil"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	workspaceMaxFileBytes     int64 = 256 << 20
+	workspaceMaxBytes         int64 = 2 << 30
+	workspaceMaxEntries             = 100_000
+	workspaceMaxPathBytes           = 4096
+	workspaceMaxLinkBytes           = 4096
+	workspaceMaxDepth               = 256
+	workspaceMaxSymlinkHops         = 40
+	workspaceManifestMaxBytes       = 64 << 20
+)
+
+var errWorkspaceCopyUnsupported = errors.New("workspace descriptor copy is unsupported on this platform")
+
+type workspaceCopyLimits struct{ maxFileBytes, maxBytes, maxEntries int64 }
+
+func defaultWorkspaceCopyLimits() workspaceCopyLimits {
+	return workspaceCopyLimits{workspaceMaxFileBytes, workspaceMaxBytes, workspaceMaxEntries}
+}
+
+// workspaceSnapshot excludes access time because descriptor reads can change it.
+type workspaceSnapshot struct {
+	mode                      uint32
+	size                      int64
+	nlink                     uint64
+	uid, gid                  uint32
+	dev, ino                  uint64
+	mtimeSec, mtimeNsec       int64
+	changeTimeSec, changeNsec int64
+}
+
+type workspaceObjectID struct{ dev, ino uint64 }
+type workspaceOps struct {
+	openat    func(int, string, int, uint32) (int, error)
+	fstat     func(int, *unix.Stat_t) error
+	fstatat   func(int, string, *unix.Stat_t, int) error
+	mkdirat   func(int, string, uint32) error
+	fchmod    func(int, uint32) error
+	readlink  func(int, string, []byte) (int, error)
+	symlinkat func(string, int, string) error
+}
+
+func systemWorkspaceOps() workspaceOps {
+	return workspaceOps{unix.Openat, unix.Fstat, unix.Fstatat, unix.Mkdirat, unix.Fchmod, workspaceReadlink, unix.Symlinkat}
+}
+
+type workspaceWalk struct {
+	excluded                              []string
+	limits                                workspaceCopyLimits
+	entries                               []WorkspaceEntry
+	fileSizes                             map[string]int64
+	reserved                              map[string]WorkspaceEntry
+	directories                           map[workspaceObjectID]string
+	entryCount, totalBytes, manifestBytes int64
+	ops                                   workspaceOps
+}
+
+// copyWorkspaceTreeDescriptor requires parentFD to stay open and caller-owned.
+// It must name a private CLOEXEC directory that is physically disjoint from sourceRoot.
+// The function does not close parentFD.
+func copyWorkspaceTreeDescriptor(sourceRoot string, parentFD int, name string, excluded []string) ([]WorkspaceEntry, error) {
+	return copyWorkspaceTreeWithOps(sourceRoot, parentFD, name, excluded, defaultWorkspaceCopyLimits(), systemWorkspaceOps())
+}
+
+func abortWorkspaceCopy(fd int, err error) ([]WorkspaceEntry, error) { unix.Close(fd); return nil, err }
+func closeFDError(fd int, f string, a ...any) error                  { unix.Close(fd); return fmt.Errorf(f, a...) }
+
+func copyWorkspaceTreeWithOps(sourceRoot string, parentFD int, name string, excluded []string, limits workspaceCopyLimits, ops workspaceOps) ([]WorkspaceEntry, error) {
+	if !workspaceCopySupported {
+		return nil, errWorkspaceCopyUnsupported
+	}
+	if err := validateWorkspaceLeaf("workspace destination", name); err != nil {
+		return nil, err
+	}
+	sourceFD, sourceSnapshot, err := openWorkspaceSourceRoot(sourceRoot, ops)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireWorkspaceNameAbsent(parentFD, name, ops); err != nil {
+		return abortWorkspaceCopy(sourceFD, err)
+	}
+	destFD, err := createWorkspaceDirectory(parentFD, name, ops)
+	if err != nil {
+		return abortWorkspaceCopy(sourceFD, err)
+	}
+	walk := &workspaceWalk{excluded: excluded, limits: limits, fileSizes: make(map[string]int64), reserved: make(map[string]WorkspaceEntry), directories: make(map[workspaceObjectID]string), ops: ops}
+	err = walk.directory(sourceFD, destFD, "", 0, sourceSnapshot)
+	if err == nil {
+		err = validateWorkspaceLinks(walk.entries)
+	}
+	if err == nil {
+		err = ops.fchmod(destFD, 0o755)
+	}
+	if err == nil {
+		err = walk.validateDestination(destFD)
+	}
+	if err == nil {
+		_, err = verifyWorkspaceNameAt(parentFD, name, destFD, ops)
+	}
+	err = errors.Join(err, unix.Close(destFD))
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(walk.entries, func(i, j int) bool { return walk.entries[i].Path < walk.entries[j].Path })
+	return walk.entries, nil
+}
+
+func (walk *workspaceWalk) directory(sourceFD, destFD int, parentRel string, depth int, expected workspaceSnapshot) (retErr error) {
+	source := os.NewFile(uintptr(sourceFD), parentRel)
+	defer func() { retErr = errors.Join(retErr, source.Close()) }()
+	id := workspaceObjectID{expected.dev, expected.ino}
+	if previous, found := walk.directories[id]; found {
+		return fmt.Errorf("workspace directory identity repeats at %q and %q", previous, parentRel)
+	}
+	walk.directories[id] = parentRel
+	for {
+		names, readErr := source.Readdirnames(128)
+		if readErr != nil && readErr != io.EOF {
+			return readErr
+		}
+		for _, name := range names {
+			if err := validateWorkspaceLeaf("workspace entry", name); err != nil {
+				return err
+			}
+			rel := path.Join(parentRel, name)
+			if err := validateWorkspacePath(rel, depth+1); err != nil {
+				return err
+			}
+			excluded, err := isExcludedPathSafe(rel, walk.excluded)
+			if err != nil {
+				return err
+			}
+			if walk.entryCount >= walk.limits.maxEntries {
+				return fmt.Errorf("workspace has more than %d entries", walk.limits.maxEntries)
+			}
+			walk.entryCount++
+			if excluded {
+				continue
+			}
+			var before unix.Stat_t
+			if err := walk.ops.fstatat(sourceFD, name, &before, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+				return fmt.Errorf("stat workspace entry %q: %w", rel, err)
+			}
+			if err := walk.reserve(rel); err != nil {
+				return err
+			}
+			snapshot := workspaceSnapshotFromUnix(before)
+			switch snapshot.mode & uint32(unix.S_IFMT) {
+			case uint32(unix.S_IFDIR):
+				err = walk.copyDirectory(sourceFD, destFD, name, rel, depth+1, snapshot)
+			case uint32(unix.S_IFREG):
+				err = walk.copyFile(sourceFD, destFD, name, rel, snapshot)
+			case uint32(unix.S_IFLNK):
+				err = walk.copySymlink(sourceFD, destFD, name, rel, snapshot)
+			default:
+				err = fmt.Errorf("unsupported workspace entry kind for %q", rel)
+			}
+			if err != nil {
+				return err
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+	}
+	var after unix.Stat_t
+	if err := walk.ops.fstat(sourceFD, &after); err != nil || workspaceSnapshotFromUnix(after) != expected {
+		return fmt.Errorf("workspace directory changed while copying")
+	}
+	return nil
+}
+
+func (walk *workspaceWalk) copyDirectory(sourceParent, destParent int, name, rel string, depth int, before workspaceSnapshot) (retErr error) {
+	child, err := walk.ops.openat(sourceParent, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("open workspace directory %q: %w", rel, err)
+	}
+	var opened unix.Stat_t
+	if err := walk.ops.fstat(child, &opened); err != nil || workspaceSnapshotFromUnix(opened) != before {
+		return closeFDError(child, "workspace directory %q changed before open", rel)
+	}
+	destChild, err := createWorkspaceDirectory(destParent, name, walk.ops)
+	if err != nil {
+		return closeFDError(child, "create workspace directory %q: %w", rel, err)
+	}
+	defer func() { retErr = errors.Join(retErr, unix.Close(destChild)) }()
+	if err := walk.directory(child, destChild, rel, depth, before); err != nil {
+		return err
+	}
+	mode := entryMode(before, fs.ModeDir)
+	if err := walk.ops.fchmod(destChild, uint32(mode.Perm())); err != nil {
+		return err
+	}
+	if _, err := verifyWorkspaceNameAt(destParent, name, destChild, walk.ops); err != nil {
+		return err
+	}
+	return walk.retain(WorkspaceEntry{Path: rel, Kind: "dir", Mode: mode})
+}
+
+func (walk *workspaceWalk) copyFile(sourceParent, destParent int, name, rel string, before workspaceSnapshot) (retErr error) {
+	fd, err := walk.ops.openat(sourceParent, name, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("open workspace file %q: %w", rel, err)
+	}
+	source := os.NewFile(uintptr(fd), rel)
+	defer func() { retErr = errors.Join(retErr, source.Close()) }()
+	var opened unix.Stat_t
+	if err := walk.ops.fstat(fd, &opened); err != nil {
+		return err
+	}
+	openedSnapshot := workspaceSnapshotFromUnix(opened)
+	if openedSnapshot != before || openedSnapshot.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFREG) || openedSnapshot.nlink != 1 {
+		return fmt.Errorf("workspace file %q changed kind or is multiply linked", rel)
+	}
+	if openedSnapshot.size < 0 || openedSnapshot.size > walk.limits.maxFileBytes || openedSnapshot.size > walk.limits.maxBytes-walk.totalBytes {
+		return walk.sizeError(rel, openedSnapshot.size)
+	}
+	destFD, err := walk.ops.openat(destParent, name, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0o600)
+	if err != nil {
+		return fmt.Errorf("create workspace file %q: %w", rel, err)
+	}
+	dest := os.NewFile(uintptr(destFD), rel)
+	defer func() { retErr = errors.Join(retErr, dest.Close()) }()
+	allowed := min(walk.limits.maxFileBytes, walk.limits.maxBytes-walk.totalBytes)
+	hash := sha256.New()
+	written, err := io.CopyBuffer(io.MultiWriter(dest, hash), io.LimitReader(source, allowed+1), make([]byte, 32*1024))
+	if err != nil {
+		return err
+	}
+	if written > allowed {
+		return walk.sizeError(rel, written)
+	}
+	var after unix.Stat_t
+	if err := walk.ops.fstat(fd, &after); err != nil || workspaceSnapshotFromUnix(after) != before {
+		return fmt.Errorf("workspace file %q changed while copying", rel)
+	}
+	walk.totalBytes += written
+	mode := entryMode(openedSnapshot, 0)
+	if err := walk.ops.fchmod(destFD, uint32(mode.Perm())); err != nil {
+		return err
+	}
+	copiedSnapshot, err := verifyWorkspaceNameAt(destParent, name, destFD, walk.ops)
+	if err != nil {
+		return err
+	}
+	if copiedSnapshot.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFREG) || copiedSnapshot.nlink != 1 {
+		return fmt.Errorf("workspace file %q is not an isolated regular file", rel)
+	}
+	mode = entryMode(copiedSnapshot, 0)
+	walk.fileSizes[rel] = written
+	return walk.retain(WorkspaceEntry{Path: rel, Kind: "file", Mode: mode, SHA256: hex.EncodeToString(hash.Sum(nil))})
+}
+
+func (walk *workspaceWalk) copySymlink(sourceParent, destParent int, name, rel string, before workspaceSnapshot) error {
+	target, err := readWorkspaceLink(sourceParent, name, walk.ops)
+	if err != nil {
+		return fmt.Errorf("read workspace symlink %q: %w", rel, err)
+	}
+	if target == "" {
+		return fmt.Errorf("workspace symlink %q has an empty target", rel)
+	}
+	if _, err := pathutil.CollisionKey(target); err != nil {
+		return fmt.Errorf("invalid workspace symlink target for %q: %w", rel, err)
+	}
+	if path.IsAbs(target) {
+		return fmt.Errorf("workspace symlink %q targets an absolute path", rel)
+	}
+	var after unix.Stat_t
+	if err := walk.ops.fstatat(sourceParent, name, &after, unix.AT_SYMLINK_NOFOLLOW); err != nil || workspaceSnapshotFromUnix(after) != before {
+		return fmt.Errorf("workspace symlink %q changed while copying", rel)
+	}
+	if err := walk.ops.symlinkat(target, destParent, name); err != nil {
+		return fmt.Errorf("create workspace symlink %q: %w", rel, err)
+	}
+	var copied, stable unix.Stat_t
+	if err := walk.ops.fstatat(destParent, name, &copied, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return err
+	}
+	copiedSnapshot := workspaceSnapshotFromUnix(copied)
+	if copiedSnapshot.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFLNK) {
+		return fmt.Errorf("workspace symlink %q changed after creation", rel)
+	}
+	copiedTarget, err := readWorkspaceLink(destParent, name, walk.ops)
+	if err != nil {
+		return err
+	}
+	if err := walk.ops.fstatat(destParent, name, &stable, unix.AT_SYMLINK_NOFOLLOW); err != nil || copiedTarget != target || workspaceSnapshotFromUnix(stable) != copiedSnapshot {
+		return fmt.Errorf("workspace symlink %q changed after creation", rel)
+	}
+	mode := entryMode(copiedSnapshot, fs.ModeSymlink)
+	return walk.retain(WorkspaceEntry{Path: rel, Kind: "symlink", Mode: mode, LinkTarget: target})
+}
+
+func (walk *workspaceWalk) sizeError(rel string, size int64) error {
+	if size > walk.limits.maxFileBytes {
+		return fmt.Errorf("workspace file %q exceeds the per-file limit of %d bytes", rel, walk.limits.maxFileBytes)
+	}
+	return fmt.Errorf("workspace exceeds the aggregate file-byte limit of %d bytes", walk.limits.maxBytes)
+}
+
+func (walk *workspaceWalk) reserve(rel string) error {
+	key, err := pathutil.CollisionKey(rel)
+	if err != nil {
+		return fmt.Errorf("invalid workspace destination path: %w", err)
+	}
+	if previous, found := walk.reserved[key]; found {
+		return fmt.Errorf("workspace destination path collision between %q and %q", previous.Path, rel)
+	}
+	cost := int64(6*len(rel) + 256)
+	if cost > workspaceManifestMaxBytes-walk.manifestBytes {
+		return fmt.Errorf("workspace manifest metadata exceeds %d bytes", workspaceManifestMaxBytes)
+	}
+	walk.manifestBytes += cost
+	walk.reserved[key] = WorkspaceEntry{Path: rel}
+	return nil
+}
+
+func (walk *workspaceWalk) retain(entry WorkspaceEntry) error {
+	cost := int64(6 * len(entry.LinkTarget))
+	if cost > workspaceManifestMaxBytes-walk.manifestBytes {
+		return fmt.Errorf("workspace manifest metadata exceeds %d bytes", workspaceManifestMaxBytes)
+	}
+	walk.manifestBytes += cost
+	key, _ := pathutil.CollisionKey(entry.Path)
+	walk.reserved[key] = entry
+	walk.entries = append(walk.entries, entry)
+	return nil
+}
+
+func workspaceDirectoryNames(fd, limit int) (names []string, retErr error) {
+	duplicate, err := unix.Openat(fd, ".", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	directory := os.NewFile(uintptr(duplicate), "workspace destination")
+	defer func() { retErr = errors.Join(retErr, directory.Close()) }()
+	flags, err := unix.FcntlInt(uintptr(duplicate), unix.F_GETFD, 0)
+	if err != nil || flags&unix.FD_CLOEXEC == 0 {
+		return nil, fmt.Errorf("workspace directory descriptor is not close-on-exec")
+	}
+	names, err = directory.Readdirnames(limit)
+	if err == io.EOF {
+		err = nil
+	}
+	return names, err
+}
+
+func (walk *workspaceWalk) validateDestination(rootFD int) error {
+	var root unix.Stat_t
+	if err := walk.ops.fstat(rootFD, &root); err != nil {
+		return err
+	}
+	if snapshot := workspaceSnapshotFromUnix(root); snapshot.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFDIR) || snapshot.mode&0o7777 != 0o755 {
+		return fmt.Errorf("workspace destination root differs from its required mode")
+	}
+	if err := walk.validateDestinationDirectory(rootFD, "", 0, workspaceSnapshotFromUnix(root), walk.reserved); err != nil {
+		return err
+	}
+	if len(walk.reserved) != 0 {
+		return fmt.Errorf("workspace destination is missing manifest entries")
+	}
+	return nil
+}
+
+func (walk *workspaceWalk) validateDestinationDirectory(fd int, parent string, depth int, before workspaceSnapshot, expected map[string]WorkspaceEntry) error {
+	names, err := workspaceDirectoryNames(fd, workspaceMaxEntries+1)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		if err := validateWorkspaceLeaf("workspace destination entry", name); err != nil {
+			return err
+		}
+		rel := path.Join(parent, name)
+		if err := validateWorkspacePath(rel, depth+1); err != nil {
+			return err
+		}
+		key, err := pathutil.CollisionKey(rel)
+		if err != nil {
+			return err
+		}
+		entry, found := expected[key]
+		if !found || entry.Path != rel {
+			return fmt.Errorf("workspace destination has an unmanifested entry")
+		}
+		var stat unix.Stat_t
+		if err := walk.ops.fstatat(fd, name, &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			return err
+		}
+		snapshot := workspaceSnapshotFromUnix(stat)
+		switch entry.Kind {
+		case "dir":
+			if snapshot.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFDIR) || snapshot.mode&0o7777 != uint32(entry.Mode.Perm()) {
+				return fmt.Errorf("workspace destination directory differs from its manifest")
+			}
+			child, err := walk.ops.openat(fd, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+			if err != nil {
+				return err
+			}
+			opened, openErr := verifyWorkspaceNameAt(fd, name, child, walk.ops)
+			if openErr == nil && opened == snapshot {
+				openErr = walk.validateDestinationDirectory(child, rel, depth+1, snapshot, expected)
+			}
+			stable, stableErr := verifyWorkspaceNameAt(fd, name, child, walk.ops)
+			err = errors.Join(openErr, stableErr, unix.Close(child))
+			if err != nil || stable != snapshot {
+				return fmt.Errorf("workspace destination directory changed during validation")
+			}
+		case "file":
+			err = walk.validateDestinationFile(fd, name, entry, snapshot)
+		case "symlink":
+			err = walk.validateDestinationSymlink(fd, name, entry, snapshot)
+		default:
+			err = fmt.Errorf("workspace destination manifest has an invalid kind")
+		}
+		if err != nil {
+			return err
+		}
+		delete(expected, key)
+	}
+	var after unix.Stat_t
+	if err := walk.ops.fstat(fd, &after); err != nil || workspaceSnapshotFromUnix(after) != before {
+		return fmt.Errorf("workspace destination directory changed during validation")
+	}
+	return nil
+}
+
+func (walk *workspaceWalk) validateDestinationFile(parentFD int, name string, entry WorkspaceEntry, before workspaceSnapshot) (retErr error) {
+	size, found := walk.fileSizes[entry.Path]
+	if !found || before.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFREG) || before.nlink != 1 || before.size != size || before.mode&0o7777 != uint32(entry.Mode.Perm()) {
+		return fmt.Errorf("workspace destination file differs from its manifest")
+	}
+	fd, err := walk.ops.openat(parentFD, name, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	file := os.NewFile(uintptr(fd), entry.Path)
+	defer func() { retErr = errors.Join(retErr, file.Close()) }()
+	var opened unix.Stat_t
+	if err := walk.ops.fstat(fd, &opened); err != nil || workspaceSnapshotFromUnix(opened) != before {
+		return fmt.Errorf("workspace destination file changed before validation")
+	}
+	hash := sha256.New()
+	read, err := io.Copy(hash, io.LimitReader(file, size+1))
+	if err != nil || read != size || hex.EncodeToString(hash.Sum(nil)) != entry.SHA256 {
+		return fmt.Errorf("workspace destination file content differs from its manifest")
+	}
+	stable, err := verifyWorkspaceNameAt(parentFD, name, fd, walk.ops)
+	if err != nil || stable != before {
+		return fmt.Errorf("workspace destination file changed during validation")
+	}
+	return nil
+}
+
+func (walk *workspaceWalk) validateDestinationSymlink(parentFD int, name string, entry WorkspaceEntry, before workspaceSnapshot) error {
+	if before.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFLNK) || before.nlink != 1 || before.mode&0o7777 != uint32(entry.Mode.Perm()) {
+		return fmt.Errorf("workspace destination symlink differs from its manifest")
+	}
+	target, err := readWorkspaceLink(parentFD, name, walk.ops)
+	if err != nil {
+		return err
+	}
+	var after unix.Stat_t
+	if err := walk.ops.fstatat(parentFD, name, &after, unix.AT_SYMLINK_NOFOLLOW); err != nil || workspaceSnapshotFromUnix(after) != before || target != entry.LinkTarget {
+		return fmt.Errorf("workspace destination symlink changed during validation")
+	}
+	return nil
+}
+
+func validateWorkspaceLinks(entries []WorkspaceEntry) error {
+	index := make(map[string]WorkspaceEntry, len(entries))
+	for _, entry := range entries {
+		key, err := pathutil.CollisionKey(entry.Path)
+		if err != nil {
+			return err
+		}
+		index[key] = entry
+	}
+	for _, entry := range entries {
+		if entry.Kind == "symlink" {
+			if err := resolveWorkspaceLink(entry, index); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func resolveWorkspaceLink(link WorkspaceEntry, index map[string]WorkspaceEntry) error {
+	resolved := []string(nil)
+	if parent := path.Dir(link.Path); parent != "." {
+		resolved = strings.Split(parent, "/")
+	}
+	pending := strings.Split(link.LinkTarget, "/")
+	seen := make(map[string]struct{})
+	for hops := 1; len(pending) > 0; {
+		component := pending[0]
+		pending = pending[1:]
+		switch component {
+		case "", ".":
+			continue
+		case "..":
+			if len(resolved) == 0 {
+				return fmt.Errorf("workspace symlink %q escapes the workspace", link.Path)
+			}
+			resolved = resolved[:len(resolved)-1]
+			continue
+		}
+		resolved = append(resolved, component)
+		current := strings.Join(resolved, "/")
+		key, err := pathutil.CollisionKey(current)
+		if err != nil {
+			return err
+		}
+		entry, found := index[key]
+		if !found || entry.Path != current {
+			return fmt.Errorf("workspace symlink %q is dangling", link.Path)
+		}
+		if entry.Kind != "symlink" {
+			if len(pending) > 0 && entry.Kind != "dir" {
+				return fmt.Errorf("workspace symlink %q traverses non-directory %q", link.Path, entry.Path)
+			}
+			continue
+		}
+		if hops == workspaceMaxSymlinkHops {
+			return fmt.Errorf("workspace symlink %q exceeds %d link hops", link.Path, workspaceMaxSymlinkHops)
+		}
+		state := key + "\x00" + strings.Join(pending, "/")
+		if _, found := seen[state]; found {
+			return fmt.Errorf("workspace symlink %q forms a cycle", link.Path)
+		}
+		seen[state] = struct{}{}
+		resolved = resolved[:len(resolved)-1]
+		pending = append(strings.Split(entry.LinkTarget, "/"), pending...)
+		hops++
+	}
+	return nil
+}
+
+func entryMode(s workspaceSnapshot, k fs.FileMode) fs.FileMode { return fs.FileMode(s.mode&0o777) | k }
+
+func validateWorkspaceLeaf(label, value string) error {
+	if value == "" || value == "." || value == ".." || filepath.Base(value) != value || strings.ContainsRune(value, 0) {
+		return fmt.Errorf("%s must be a safe path segment", label)
+	}
+	if _, err := pathutil.CollisionKey(value); err != nil {
+		return fmt.Errorf("invalid %s: %w", label, err)
+	}
+	return nil
+}
+
+func validateWorkspacePath(rel string, components int) error {
+	if len(rel) > workspaceMaxPathBytes {
+		return fmt.Errorf("workspace path exceeds %d bytes", workspaceMaxPathBytes)
+	}
+	if components > workspaceMaxDepth {
+		return fmt.Errorf("workspace exceeds the maximum depth of %d", workspaceMaxDepth)
+	}
+	return nil
+}
+
+func isExcludedPathSafe(rel string, excluded []string) (bool, error) {
+	if _, err := pathutil.CollisionKey(rel); err != nil {
+		return false, err
+	}
+	for _, item := range excluded {
+		inside, err := pathutil.WithinOrEqual(item, rel, true)
+		if err != nil {
+			return false, err
+		}
+		if inside {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func readWorkspaceLink(parentFD int, name string, ops workspaceOps) (string, error) {
+	buffer := make([]byte, workspaceMaxLinkBytes+1)
+	n, err := ops.readlink(parentFD, name, buffer)
+	if err != nil {
+		return "", err
+	}
+	if n > workspaceMaxLinkBytes {
+		return "", fmt.Errorf("link target exceeds %d bytes", workspaceMaxLinkBytes)
+	}
+	return string(buffer[:n]), nil
+}
+
+func openWorkspaceSourceRoot(sourceRoot string, ops workspaceOps) (int, workspaceSnapshot, error) {
+	if _, err := pathutil.CollisionKey(sourceRoot); err != nil {
+		return -1, workspaceSnapshot{}, err
+	}
+	resolved, err := filepath.EvalSymlinks(sourceRoot)
+	if err != nil {
+		return -1, workspaceSnapshot{}, err
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return -1, workspaceSnapshot{}, err
+	}
+	var before unix.Stat_t
+	if err := unix.Stat(resolved, &before); err != nil {
+		return -1, workspaceSnapshot{}, err
+	}
+	beforeSnapshot := workspaceSnapshotFromUnix(before)
+	if beforeSnapshot.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFDIR) {
+		return -1, workspaceSnapshot{}, fmt.Errorf("source workspace is not a directory: %s", sourceRoot)
+	}
+	fd, err := openAbsoluteWorkspaceDir(resolved, ops)
+	if err != nil {
+		return -1, workspaceSnapshot{}, fmt.Errorf("open source workspace %q: %w", sourceRoot, err)
+	}
+	var opened unix.Stat_t
+	if err := ops.fstat(fd, &opened); err != nil || workspaceSnapshotFromUnix(opened) != beforeSnapshot {
+		return -1, workspaceSnapshot{}, closeFDError(fd, "source workspace changed while opening")
+	}
+	return fd, beforeSnapshot, nil
+}
+
+func openAbsoluteWorkspaceDir(directory string, ops workspaceOps) (int, error) {
+	clean := filepath.Clean(directory)
+	if !filepath.IsAbs(clean) {
+		return -1, fmt.Errorf("directory is not absolute: %s", directory)
+	}
+	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, err
+	}
+	if clean == string(filepath.Separator) {
+		return fd, nil
+	}
+	for _, component := range strings.Split(strings.TrimPrefix(clean, string(filepath.Separator)), string(filepath.Separator)) {
+		next, err := ops.openat(fd, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		unix.Close(fd)
+		if err != nil {
+			return -1, err
+		}
+		fd = next
+	}
+	return fd, nil
+}
+
+func requireWorkspaceNameAbsent(parentFD int, name string, ops workspaceOps) error {
+	var stat unix.Stat_t
+	err := ops.fstatat(parentFD, name, &stat, unix.AT_SYMLINK_NOFOLLOW)
+	if err == nil {
+		return fmt.Errorf("workspace destination %q already exists", name)
+	}
+	if !errors.Is(err, unix.ENOENT) {
+		return fmt.Errorf("inspect workspace destination %q: %w", name, err)
+	}
+	return nil
+}
+
+func verifyWorkspaceNameAt(parentFD int, name string, fd int, ops workspaceOps) (workspaceSnapshot, error) {
+	var opened, named unix.Stat_t
+	if err := ops.fstat(fd, &opened); err != nil {
+		return workspaceSnapshot{}, err
+	}
+	snapshot := workspaceSnapshotFromUnix(opened)
+	if err := ops.fstatat(parentFD, name, &named, unix.AT_SYMLINK_NOFOLLOW); err != nil || workspaceSnapshotFromUnix(named) != snapshot {
+		return workspaceSnapshot{}, fmt.Errorf("workspace destination %q changed", name)
+	}
+	return snapshot, nil
+}
+
+func createWorkspaceDirectory(parentFD int, name string, ops workspaceOps) (int, error) {
+	if err := ops.mkdirat(parentFD, name, 0o700); err != nil {
+		return -1, err
+	}
+	var before unix.Stat_t
+	if err := ops.fstatat(parentFD, name, &before, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return -1, err
+	}
+	expected := workspaceSnapshotFromUnix(before)
+	fd, err := ops.openat(parentFD, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, err
+	}
+	opened, err := verifyWorkspaceNameAt(parentFD, name, fd, ops)
+	if err != nil || opened != expected || expected.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFDIR) {
+		return -1, closeFDError(fd, "workspace destination directory changed while opening")
+	}
+	names, err := workspaceDirectoryNames(fd, 1)
+	if err != nil || len(names) != 0 {
+		return -1, closeFDError(fd, "workspace destination directory was not empty after creation")
+	}
+	return fd, nil
+}

--- a/internal/applecontainer/workspace_copy_test.go
+++ b/internal/applecontainer/workspace_copy_test.go
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/pathutil"
+	"golang.org/x/sys/unix"
+)
+
+func workspaceTestParent(t *testing.T) (string, int) {
+	t.Helper()
+	parent := t.TempDir()
+	fd, err := unix.Open(parent, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	mustNil(t, err)
+	t.Cleanup(func() { mustNil(t, unix.Close(fd)) })
+	return parent, fd
+}
+
+func copyWorkspaceForTest(t *testing.T, source string, excluded []string, limits workspaceCopyLimits, ops workspaceOps) ([]WorkspaceEntry, error) {
+	_, parentFD := workspaceTestParent(t)
+	return copyWorkspaceTreeWithOps(source, parentFD, "out", excluded, limits, ops)
+}
+
+func TestWorkspaceCopyUsesPinnedParent(t *testing.T) {
+	source, container := t.TempDir(), t.TempDir()
+	mustNil(t, os.WriteFile(filepath.Join(source, "file"), []byte("x"), 0o600))
+	parent, moved := filepath.Join(container, "parent"), filepath.Join(container, "moved")
+	mustNil(t, os.Mkdir(parent, 0o700))
+	parentFD, err := unix.Open(parent, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	mustNil(t, err)
+	defer unix.Close(parentFD)
+	mustNil(t, errors.Join(os.Rename(parent, moved), os.Mkdir(parent, 0o700)))
+	_, err = copyWorkspaceTreeDescriptor(source, parentFD, "out", nil)
+	if _, replacementErr := os.Lstat(filepath.Join(parent, "out")); err != nil || !os.IsNotExist(replacementErr) {
+		t.Fatalf("pinned destination parent result: copy=%v replacement=%v", err, replacementErr)
+	}
+	_, err = os.Stat(filepath.Join(moved, "out", "file"))
+	mustNil(t, err)
+	if _, err := copyWorkspaceTreeDescriptor(source, parentFD, "../escape", nil); err == nil {
+		t.Fatal("non-leaf destination name succeeded")
+	}
+}
+
+func TestWorkspaceCopyRejectsSourceRaces(t *testing.T) {
+	for _, kind := range []string{"replacement", "symlink-follow", "special", "in-place-file", "ctime-only", "nlink-only", "in-place-directory"} {
+		t.Run(kind, func(t *testing.T) {
+			source := t.TempDir()
+			victim := filepath.Join(source, "victim")
+			mustNil(t, os.WriteFile(victim, []byte("original"), 0o600))
+			ops, sourceFlagsOK := systemWorkspaceOps(), true
+			if kind == "replacement" || kind == "symlink-follow" || kind == "special" {
+				original, swapped := ops.openat, false
+				ops.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
+					if name == "victim" && flags&unix.O_CREAT == 0 && !swapped {
+						sourceFlagsOK = flags&(unix.O_NOFOLLOW|unix.O_NONBLOCK) == unix.O_NOFOLLOW|unix.O_NONBLOCK
+						swapped = true
+						if kind == "symlink-follow" {
+							mustNil(t, os.Rename(victim, victim+".saved"))
+							mustNil(t, os.Symlink("victim.saved", victim))
+						} else if mustNil(t, os.Remove(victim)); kind == "special" {
+							mustNil(t, unix.Mkfifo(victim, 0o600))
+						} else {
+							mustNil(t, os.WriteFile(victim, []byte("replacement"), 0o600))
+						}
+					}
+					return original(fd, name, flags, mode)
+				}
+			} else {
+				watched := source
+				if kind == "in-place-file" || kind == "ctime-only" || kind == "nlink-only" {
+					watched = victim
+				}
+				var watchedStat unix.Stat_t
+				mustNil(t, unix.Stat(watched, &watchedStat))
+				original, observations := ops.fstat, 0
+				ops.fstat = func(fd int, stat *unix.Stat_t) error {
+					if err := original(fd, stat); err != nil {
+						return err
+					}
+					if stat.Ino == watchedStat.Ino && uint64(stat.Dev) == uint64(watchedStat.Dev) {
+						observations++
+						if observations == 2 {
+							if kind == "ctime-only" {
+								stat.Ctim.Nsec++
+							} else if kind == "nlink-only" {
+								stat.Nlink++
+							} else if kind == "in-place-file" {
+								mustNil(t, os.WriteFile(victim, []byte("modified"), 0o600))
+							} else {
+								mustNil(t, os.WriteFile(filepath.Join(source, "late"), []byte("x"), 0o600))
+							}
+							if kind != "ctime-only" && kind != "nlink-only" {
+								return original(fd, stat)
+							}
+						}
+					}
+					return nil
+				}
+			}
+			if _, err := copyWorkspaceForTest(t, source, nil, defaultWorkspaceCopyLimits(), ops); err == nil || !sourceFlagsOK {
+				t.Fatalf("%s source mutation result: flagsOK=%t error=%v", kind, sourceFlagsOK, err)
+			}
+		})
+	}
+}
+
+func TestWorkspaceCopyRejectsStableSpecialAndHardlink(t *testing.T) {
+	source := t.TempDir()
+	mustNil(t, unix.Mkfifo(filepath.Join(source, "pipe"), 0o600))
+	ops, opened := systemWorkspaceOps(), false
+	original := ops.openat
+	ops.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
+		if name == "pipe" && flags&unix.O_CREAT == 0 {
+			opened = true
+		}
+		return original(fd, name, flags, mode)
+	}
+	if _, err := copyWorkspaceForTest(t, source, nil, defaultWorkspaceCopyLimits(), ops); err == nil || opened {
+		t.Fatalf("stable FIFO result: opened=%t error=%v", opened, err)
+	}
+	source = t.TempDir()
+	mustNil(t, os.WriteFile(filepath.Join(source, "a"), []byte("x"), 0o600))
+	mustNil(t, os.Link(filepath.Join(source, "a"), filepath.Join(source, "b")))
+	_, parentFD := workspaceTestParent(t)
+	if _, err := copyWorkspaceTreeDescriptor(source, parentFD, "out", nil); err == nil || !strings.Contains(err.Error(), "multiply linked") {
+		t.Fatalf("source hard link accepted: %v", err)
+	}
+}
+
+func TestWorkspaceCopyRejectsDestinationNameRaces(t *testing.T) {
+	for _, kind := range []string{"root", "directory", "file", "symlink", "symlink-snapshot", "directory-preopen", "file-precreate", "directory-adopt", "final-stability", "final-extra", "final-missing", "final-kind", "final-mode", "final-dir-mode", "final-nlink", "final-size", "final-hash", "final-link", "final-alias", "final-root-mode", "final-special"} {
+		t.Run(kind, func(t *testing.T) {
+			source := t.TempDir()
+			parent, parentFD := workspaceTestParent(t)
+			destination := filepath.Join(parent, "out")
+			mustNil(t, os.Mkdir(filepath.Join(source, "nested"), 0o700))
+			mustNil(t, os.WriteFile(filepath.Join(source, "nested", "copied"), []byte("x"), 0o400))
+			mustNil(t, os.WriteFile(filepath.Join(source, "file"), []byte("source"), 0o600))
+			mustNil(t, os.Symlink("file", filepath.Join(source, "link")))
+			ops, swapped, flagsOK := systemWorkspaceOps(), false, true
+			swap := func(target string, directory bool) {
+				mustNil(t, os.Rename(target, target+".saved"))
+				if directory {
+					mustNil(t, os.Mkdir(target, 0o700))
+				} else {
+					mustNil(t, os.WriteFile(target, []byte("replacement"), 0o600))
+				}
+				swapped = true
+			}
+			switch kind {
+			case "root", "directory", "file":
+				wanted := map[string]uint32{"root": 0o755, "directory": 0o700, "file": 0o600}[kind]
+				target := map[string]string{"root": destination, "directory": filepath.Join(destination, "nested"), "file": filepath.Join(destination, "file")}[kind]
+				original := ops.fchmod
+				ops.fchmod = func(fd int, mode uint32) error {
+					err := original(fd, mode)
+					if err == nil && mode == wanted && !swapped {
+						swap(target, kind != "file")
+					}
+					return err
+				}
+			case "symlink":
+				original := ops.symlinkat
+				ops.symlinkat = func(target string, fd int, name string) error {
+					if err := original(target, fd, name); err != nil {
+						return err
+					}
+					mustNil(t, os.Remove(filepath.Join(destination, name)))
+					return os.Symlink("../../outside", filepath.Join(destination, name))
+				}
+			case "symlink-snapshot":
+				original, reads := ops.readlink, 0
+				ops.readlink = func(fd int, name string, buffer []byte) (int, error) {
+					reads++
+					if reads == 2 {
+						mustNil(t, errors.Join(os.Remove(filepath.Join(destination, name)), os.Symlink("file", filepath.Join(destination, name))))
+					}
+					return original(fd, name, buffer)
+				}
+			case "directory-preopen":
+				original, opens := ops.openat, 0
+				ops.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
+					if name == "nested" && flags&unix.O_DIRECTORY != 0 {
+						opens++
+						if opens == 2 {
+							flagsOK = flags&unix.O_NOFOLLOW != 0
+							swap(filepath.Join(destination, name), true)
+						}
+					}
+					return original(fd, name, flags, mode)
+				}
+			case "file-precreate":
+				original := ops.openat
+				ops.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
+					if name == "file" && flags&unix.O_CREAT != 0 {
+						flagsOK = flags&unix.O_EXCL != 0
+						mustNil(t, os.WriteFile(filepath.Join(destination, name), []byte("precreated"), 0o600))
+					}
+					return original(fd, name, flags, mode)
+				}
+			case "directory-adopt":
+				original := ops.fstatat
+				ops.fstatat = func(fd int, name string, stat *unix.Stat_t, flags int) error {
+					if _, err := os.Lstat(filepath.Join(destination, name)); name == "nested" && !swapped && err == nil {
+						swap(filepath.Join(destination, name), true)
+						mustNil(t, os.WriteFile(filepath.Join(destination, name, "extra"), []byte("x"), 0o600))
+					}
+					return original(fd, name, stat, flags)
+				}
+			case "final-stability":
+				ops.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
+					opened, err := unix.Openat(fd, name, flags, mode)
+					if _, statErr := os.Lstat(filepath.Join(destination, name)); err == nil && statErr == nil && name == "file" && flags&unix.O_CREAT == 0 && !swapped {
+						swap(filepath.Join(destination, name), false)
+					}
+					return opened, err
+				}
+			default:
+				original := ops.fchmod
+				ops.fchmod = func(fd int, mode uint32) error {
+					err := original(fd, mode)
+					if err != nil || mode != 0o755 || swapped {
+						return err
+					}
+					file, link := filepath.Join(destination, "file"), filepath.Join(destination, "link")
+					mutations := map[string]func() error{
+						"final-extra":     func() error { return os.WriteFile(filepath.Join(destination, "extra"), []byte("x"), 0o600) },
+						"final-missing":   func() error { return os.Remove(file) },
+						"final-kind":      func() error { return errors.Join(os.Remove(file), os.Mkdir(file, 0o401)) },
+						"final-mode":      func() error { return os.Chmod(file, 0o400) },
+						"final-dir-mode":  func() error { return os.Chmod(filepath.Join(destination, "nested"), 0o777) },
+						"final-nlink":     func() error { return os.Link(file, filepath.Join(parent, "hardlink")) },
+						"final-size":      func() error { return os.WriteFile(file, []byte("source!"), 0o401) },
+						"final-hash":      func() error { return os.WriteFile(file, []byte("tamper"), 0o401) },
+						"final-link":      func() error { return errors.Join(os.Remove(link), os.Symlink("./file", link)) },
+						"final-alias":     func() error { return os.Rename(file, filepath.Join(destination, "FILE")) },
+						"final-root-mode": func() error { return os.Chmod(destination, 0o777) },
+						"final-special":   func() error { return unix.Chmod(file, 0o4600) },
+					}
+					mustNil(t, mutations[kind]())
+					swapped = true
+					return nil
+				}
+			}
+			_, err := copyWorkspaceTreeWithOps(source, parentFD, "out", nil, defaultWorkspaceCopyLimits(), ops)
+			if _, copiedErr := os.Lstat(filepath.Join(destination, "nested", "copied")); err == nil || !flagsOK || kind == "directory-adopt" && copiedErr == nil || strings.HasPrefix(kind, "final-") && !swapped {
+				t.Fatalf("%s destination replacement result: flagsOK=%t error=%v", kind, flagsOK, err)
+			}
+		})
+	}
+}
+
+func TestWorkspaceLinkResolutionUsesRawComponentOrder(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		entries []WorkspaceEntry
+		wantErr bool
+	}{
+		{"safe-repeat", []WorkspaceEntry{{Path: "dir", Kind: "dir"}, {Path: "dir/file", Kind: "file"}, {Path: "x", Kind: "symlink", LinkTarget: "dir"}, {Path: "y", Kind: "symlink", LinkTarget: "x/../x/file"}}, false},
+		{"combined-dotdot-escape", []WorkspaceEntry{{Path: "dir", Kind: "dir"}, {Path: "dir/x", Kind: "symlink", LinkTarget: ".."}, {Path: "dir/outside", Kind: "file"}, {Path: "y", Kind: "symlink", LinkTarget: "dir/x/../outside"}}, true},
+		{"dangling", []WorkspaceEntry{{Path: "x", Kind: "symlink", LinkTarget: "missing"}}, true},
+		{"case-alias", []WorkspaceEntry{{Path: "file", Kind: "file"}, {Path: "link", Kind: "symlink", LinkTarget: "FILE"}}, true},
+		{"cycle", []WorkspaceEntry{{Path: "x", Kind: "symlink", LinkTarget: "y"}, {Path: "y", Kind: "symlink", LinkTarget: "x"}}, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateWorkspaceLinks(test.entries)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("link validation error = %v, wantErr %t", err, test.wantErr)
+			}
+		})
+	}
+	for _, hops := range []int{40, 41} {
+		entries := []WorkspaceEntry{{Path: "file", Kind: "file"}}
+		for i := hops - 1; i >= 0; i-- {
+			target := "file"
+			if i+1 < hops {
+				target = fmt.Sprintf("link%d", i+1)
+			}
+			entries = append(entries, WorkspaceEntry{Path: fmt.Sprintf("link%d", i), Kind: "symlink", LinkTarget: target})
+		}
+		if err := validateWorkspaceLinks(entries); (err != nil) != (hops > workspaceMaxSymlinkHops) {
+			t.Fatalf("%d-hop chain error = %v", hops, err)
+		}
+	}
+}
+
+func TestWorkspaceCopyLimits(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		contents []string
+		limits   workspaceCopyLimits
+		wantErr  bool
+	}{
+		{"file-exact", []string{"abcd"}, workspaceCopyLimits{4, 10, 10}, false},
+		{"file-over", []string{"abcde"}, workspaceCopyLimits{4, 10, 10}, true},
+		{"aggregate-exact", []string{"ab", "cd"}, workspaceCopyLimits{4, 4, 10}, false},
+		{"aggregate-over", []string{"ab", "cde"}, workspaceCopyLimits{4, 4, 10}, true},
+		{"entries-exact", []string{"a", "b"}, workspaceCopyLimits{4, 10, 2}, false},
+		{"entries-over", []string{"a", "b"}, workspaceCopyLimits{4, 10, 1}, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			source := t.TempDir()
+			for i, content := range test.contents {
+				mustNil(t, os.WriteFile(filepath.Join(source, fmt.Sprintf("f%d", i)), []byte(content), 0o600))
+			}
+			_, err := copyWorkspaceForTest(t, source, nil, test.limits, systemWorkspaceOps())
+			if (err != nil) != test.wantErr {
+				t.Fatalf("copy error = %v, wantErr %t", err, test.wantErr)
+			}
+		})
+	}
+	source := t.TempDir()
+	victim := filepath.Join(source, "victim")
+	mustNil(t, os.WriteFile(victim, []byte("a"), 0o600))
+	var watched unix.Stat_t
+	mustNil(t, unix.Stat(victim, &watched))
+	ops, grown := systemWorkspaceOps(), false
+	original := ops.fstat
+	ops.fstat = func(fd int, stat *unix.Stat_t) error {
+		if err := original(fd, stat); err != nil {
+			return err
+		}
+		if stat.Ino == watched.Ino && !grown {
+			grown = true
+			return os.WriteFile(victim, []byte("ab"), 0o600)
+		}
+		return nil
+	}
+	if _, err := copyWorkspaceForTest(t, source, nil, workspaceCopyLimits{1, 10, 10}, ops); err == nil {
+		t.Fatal("file growth past the stream limit succeeded")
+	}
+	source = t.TempDir()
+	mustNil(t, os.Mkdir(filepath.Join(source, ".git"), 0o700))
+	_, err := copyWorkspaceForTest(t, source, []string{".git"}, workspaceCopyLimits{1, 1, 0}, systemWorkspaceOps())
+	if err == nil {
+		t.Fatal("excluded entry bypassed the entry limit")
+	}
+	for _, test := range []struct {
+		path       string
+		components int
+		wantErr    bool
+	}{{strings.Repeat("a", 4096), 256, false}, {strings.Repeat("a", 4097), 256, true}, {"a", 257, true}} {
+		if err := validateWorkspacePath(test.path, test.components); (err != nil) != test.wantErr {
+			t.Fatalf("path limit error = %v, wantErr %t", err, test.wantErr)
+		}
+	}
+	for _, size := range []int{4096, 4097} {
+		ops := systemWorkspaceOps()
+		ops.readlink = func(_ int, _ string, buffer []byte) (int, error) {
+			for i := 0; i < min(size, len(buffer)); i++ {
+				buffer[i] = 'a'
+			}
+			return min(size, len(buffer)), nil
+		}
+		_, err := readWorkspaceLink(-1, "link", ops)
+		if (err != nil) != (size > workspaceMaxLinkBytes) {
+			t.Fatalf("%d-byte link error = %v", size, err)
+		}
+	}
+	for _, remaining := range []int64{262, 261} {
+		walk := workspaceWalk{reserved: make(map[string]WorkspaceEntry), manifestBytes: workspaceManifestMaxBytes - remaining}
+		if err := walk.reserve("x"); (err != nil) != (remaining < 262) {
+			t.Fatalf("manifest path budget remaining %d: %v", remaining, err)
+		}
+	}
+	for _, remaining := range []int64{6, 5} {
+		walk := workspaceWalk{reserved: make(map[string]WorkspaceEntry), manifestBytes: workspaceManifestMaxBytes - remaining}
+		if err := walk.retain(WorkspaceEntry{LinkTarget: "<"}); (err != nil) != (remaining < 6) {
+			t.Fatalf("manifest link budget remaining %d: %v", remaining, err)
+		}
+	}
+}
+
+func TestWorkspaceUnicodeIdentityAndEarlyValidation(t *testing.T) {
+	for _, aliases := range [][2]string{{"Caf\u00e9", "Cafe\u0301"}, {"Stra\u00dfe", "STRASSE"}} {
+		walk := workspaceWalk{reserved: make(map[string]WorkspaceEntry)}
+		mustNil(t, walk.reserve(aliases[0]))
+		if err := walk.reserve(aliases[1]); err == nil {
+			t.Fatalf("Unicode aliases %q and %q did not collide", aliases[0], aliases[1])
+		}
+	}
+	ops, opened := systemWorkspaceOps(), false
+	ops.openat = func(int, string, int, uint32) (int, error) {
+		opened = true
+		return -1, unix.EPERM
+	}
+	_, err := copyWorkspaceTreeWithOps("secret\nevent=forged", -1, "out", nil, defaultWorkspaceCopyLimits(), ops)
+	if err == nil || opened || strings.Contains(err.Error(), "secret") || strings.Contains(err.Error(), "forged") {
+		t.Fatalf("unsafe source validation: opened=%t error=%v", opened, err)
+	}
+	for _, value := range []string{"bad\nname", string([]byte{'b', 0xff})} {
+		if err := validateWorkspaceLeaf("workspace entry", value); err == nil || (!errors.Is(err, pathutil.ErrInvalidUTF8Path) && !errors.Is(err, pathutil.ErrUnsafePathControl)) {
+			t.Fatalf("unsafe name accepted: error=%v", err)
+		}
+	}
+	source := t.TempDir()
+	bad := "excluded\nentry"
+	mustNil(t, os.WriteFile(filepath.Join(source, bad), []byte("secret"), 0o600))
+	ops, inspected := systemWorkspaceOps(), false
+	original := ops.fstatat
+	ops.fstatat = func(fd int, name string, stat *unix.Stat_t, flags int) error {
+		if name == bad {
+			inspected = true
+		}
+		return original(fd, name, stat, flags)
+	}
+	_, err = copyWorkspaceForTest(t, source, []string{bad}, defaultWorkspaceCopyLimits(), ops)
+	if err == nil || inspected {
+		t.Fatalf("unsafe excluded name result: inspected=%t error=%v", inspected, err)
+	}
+}

--- a/internal/applecontainer/workspace_copy_test.go
+++ b/internal/applecontainer/workspace_copy_test.go
@@ -118,20 +118,22 @@ func TestWorkspaceCopyRejectsStableSpecialAndHardlink(t *testing.T) {
 	ops, opened := systemWorkspaceOps(), false
 	original := ops.openat
 	ops.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
-		if name == "pipe" && flags&unix.O_CREAT == 0 {
-			opened = true
-		}
+		opened = opened || name == "pipe" && flags&unix.O_CREAT == 0
 		return original(fd, name, flags, mode)
 	}
 	if _, err := copyWorkspaceForTest(t, source, nil, defaultWorkspaceCopyLimits(), ops); err == nil || opened {
 		t.Fatalf("stable FIFO result: opened=%t error=%v", opened, err)
 	}
-	source = t.TempDir()
-	mustNil(t, os.WriteFile(filepath.Join(source, "a"), []byte("x"), 0o600))
-	mustNil(t, os.Link(filepath.Join(source, "a"), filepath.Join(source, "b")))
-	_, parentFD := workspaceTestParent(t)
-	if _, err := copyWorkspaceTreeDescriptor(source, parentFD, "out", nil); err == nil || !strings.Contains(err.Error(), "multiply linked") {
-		t.Fatalf("source hard link accepted: %v", err)
+	for _, create := range []func(string) error{
+		func(name string) error { return os.WriteFile(name, []byte("x"), 0o600) },
+		func(name string) error { return os.Symlink(".", name) },
+	} {
+		source := t.TempDir()
+		mustNil(t, create(filepath.Join(source, "a")))
+		mustNil(t, unix.Linkat(unix.AT_FDCWD, filepath.Join(source, "a"), unix.AT_FDCWD, filepath.Join(source, "b"), 0))
+		if _, err := copyWorkspaceForTest(t, source, nil, defaultWorkspaceCopyLimits(), systemWorkspaceOps()); err == nil || !strings.Contains(err.Error(), "multiply linked") {
+			t.Fatalf("source hard link accepted: %v", err)
+		}
 	}
 }
 

--- a/internal/applecontainer/workspace_copy_test.go
+++ b/internal/applecontainer/workspace_copy_test.go
@@ -98,7 +98,7 @@ func TestWorkspaceCopyRejectsSourceRaces(t *testing.T) {
 								mustNil(t, os.WriteFile(filepath.Join(source, "late"), []byte("x"), 0o600))
 							}
 							if kind != "ctime-only" && kind != "nlink-only" {
-								return original(fd, stat)
+								*stat = watchedStat
 							}
 						}
 					}
@@ -136,7 +136,7 @@ func TestWorkspaceCopyRejectsStableSpecialAndHardlink(t *testing.T) {
 }
 
 func TestWorkspaceCopyRejectsDestinationNameRaces(t *testing.T) {
-	for _, kind := range []string{"root", "directory", "file", "symlink", "symlink-snapshot", "directory-preopen", "file-precreate", "directory-adopt", "final-stability", "final-extra", "final-missing", "final-kind", "final-mode", "final-dir-mode", "final-nlink", "final-size", "final-hash", "final-link", "final-alias", "final-root-mode", "final-special"} {
+	for _, kind := range []string{"root", "directory", "file", "symlink", "source-symlink-snapshot", "symlink-snapshot", "symlink-final-snapshot", "directory-preopen", "file-precreate", "directory-adopt", "final-stability", "final-extra", "final-missing", "final-kind", "final-mode", "final-dir-mode", "final-nlink", "final-size", "final-hash", "final-link", "final-alias", "final-root-mode", "final-special"} {
 		t.Run(kind, func(t *testing.T) {
 			source := t.TempDir()
 			parent, parentFD := workspaceTestParent(t)
@@ -176,12 +176,24 @@ func TestWorkspaceCopyRejectsDestinationNameRaces(t *testing.T) {
 					mustNil(t, os.Remove(filepath.Join(destination, name)))
 					return os.Symlink("../../outside", filepath.Join(destination, name))
 				}
-			case "symlink-snapshot":
-				original, reads := ops.readlink, 0
+			case "source-symlink-snapshot", "symlink-snapshot", "symlink-final-snapshot":
+				originalOpen, pins := ops.openat, 0
+				ops.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
+					if name == "link" && flags == workspaceSymlinkOpenFlags {
+						pins++
+					}
+					return originalOpen(fd, name, flags, mode)
+				}
+				original, reads, wanted := ops.readlink, 0, map[string]int{"source-symlink-snapshot": 1, "symlink-snapshot": 2, "symlink-final-snapshot": 3}[kind]
 				ops.readlink = func(fd int, name string, buffer []byte) (int, error) {
 					reads++
-					if reads == 2 {
-						mustNil(t, errors.Join(os.Remove(filepath.Join(destination, name)), os.Symlink("file", filepath.Join(destination, name))))
+					if reads == wanted {
+						link := filepath.Join(destination, name)
+						if wanted == 1 {
+							link = filepath.Join(source, name)
+						}
+						flagsOK, swapped = pins >= wanted, true
+						mustNil(t, errors.Join(os.Remove(link), os.Symlink("file", link)))
 					}
 					return original(fd, name, buffer)
 				}
@@ -255,40 +267,6 @@ func TestWorkspaceCopyRejectsDestinationNameRaces(t *testing.T) {
 				t.Fatalf("%s destination replacement result: flagsOK=%t error=%v", kind, flagsOK, err)
 			}
 		})
-	}
-}
-
-func TestWorkspaceLinkResolutionUsesRawComponentOrder(t *testing.T) {
-	for _, test := range []struct {
-		name    string
-		entries []WorkspaceEntry
-		wantErr bool
-	}{
-		{"safe-repeat", []WorkspaceEntry{{Path: "dir", Kind: "dir"}, {Path: "dir/file", Kind: "file"}, {Path: "x", Kind: "symlink", LinkTarget: "dir"}, {Path: "y", Kind: "symlink", LinkTarget: "x/../x/file"}}, false},
-		{"combined-dotdot-escape", []WorkspaceEntry{{Path: "dir", Kind: "dir"}, {Path: "dir/x", Kind: "symlink", LinkTarget: ".."}, {Path: "dir/outside", Kind: "file"}, {Path: "y", Kind: "symlink", LinkTarget: "dir/x/../outside"}}, true},
-		{"dangling", []WorkspaceEntry{{Path: "x", Kind: "symlink", LinkTarget: "missing"}}, true},
-		{"case-alias", []WorkspaceEntry{{Path: "file", Kind: "file"}, {Path: "link", Kind: "symlink", LinkTarget: "FILE"}}, true},
-		{"cycle", []WorkspaceEntry{{Path: "x", Kind: "symlink", LinkTarget: "y"}, {Path: "y", Kind: "symlink", LinkTarget: "x"}}, true},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			err := validateWorkspaceLinks(test.entries)
-			if (err != nil) != test.wantErr {
-				t.Fatalf("link validation error = %v, wantErr %t", err, test.wantErr)
-			}
-		})
-	}
-	for _, hops := range []int{40, 41} {
-		entries := []WorkspaceEntry{{Path: "file", Kind: "file"}}
-		for i := hops - 1; i >= 0; i-- {
-			target := "file"
-			if i+1 < hops {
-				target = fmt.Sprintf("link%d", i+1)
-			}
-			entries = append(entries, WorkspaceEntry{Path: fmt.Sprintf("link%d", i), Kind: "symlink", LinkTarget: target})
-		}
-		if err := validateWorkspaceLinks(entries); (err != nil) != (hops > workspaceMaxSymlinkHops) {
-			t.Fatalf("%d-hop chain error = %v", hops, err)
-		}
 	}
 }
 

--- a/internal/applecontainer/workspace_stat_darwin.go
+++ b/internal/applecontainer/workspace_stat_darwin.go
@@ -8,6 +8,7 @@ package applecontainer
 import "golang.org/x/sys/unix"
 
 const workspaceCopySupported = true
+const workspaceSymlinkOpenFlags = unix.O_SYMLINK | unix.O_CLOEXEC
 
 func workspaceReadlink(fd int, n string, b []byte) (int, error) { return unix.Readlinkat(fd, n, b) }
 

--- a/internal/applecontainer/workspace_stat_darwin.go
+++ b/internal/applecontainer/workspace_stat_darwin.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin
+
+package applecontainer
+
+import "golang.org/x/sys/unix"
+
+const workspaceCopySupported = true
+
+func workspaceReadlink(fd int, n string, b []byte) (int, error) { return unix.Readlinkat(fd, n, b) }
+
+func workspaceSnapshotFromUnix(stat unix.Stat_t) workspaceSnapshot {
+	return workspaceSnapshot{uint32(stat.Mode), stat.Size, uint64(stat.Nlink), stat.Uid, stat.Gid, uint64(stat.Dev), stat.Ino, stat.Mtim.Sec, int64(stat.Mtim.Nsec), stat.Ctim.Sec, int64(stat.Ctim.Nsec)}
+}

--- a/internal/applecontainer/workspace_stat_linux.go
+++ b/internal/applecontainer/workspace_stat_linux.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux
+
+package applecontainer
+
+import "golang.org/x/sys/unix"
+
+const workspaceCopySupported = true
+
+func workspaceReadlink(fd int, n string, b []byte) (int, error) { return unix.Readlinkat(fd, n, b) }
+
+func workspaceSnapshotFromUnix(stat unix.Stat_t) workspaceSnapshot {
+	return workspaceSnapshot{uint32(stat.Mode), stat.Size, uint64(stat.Nlink), stat.Uid, stat.Gid, uint64(stat.Dev), uint64(stat.Ino), stat.Mtim.Sec, int64(stat.Mtim.Nsec), stat.Ctim.Sec, int64(stat.Ctim.Nsec)}
+}

--- a/internal/applecontainer/workspace_stat_linux.go
+++ b/internal/applecontainer/workspace_stat_linux.go
@@ -8,6 +8,7 @@ package applecontainer
 import "golang.org/x/sys/unix"
 
 const workspaceCopySupported = true
+const workspaceSymlinkOpenFlags = unix.O_PATH | unix.O_NOFOLLOW | unix.O_CLOEXEC
 
 func workspaceReadlink(fd int, n string, b []byte) (int, error) { return unix.Readlinkat(fd, n, b) }
 

--- a/internal/applecontainer/workspace_stat_other.go
+++ b/internal/applecontainer/workspace_stat_other.go
@@ -8,6 +8,7 @@ package applecontainer
 import "golang.org/x/sys/unix"
 
 const workspaceCopySupported = false
+const workspaceSymlinkOpenFlags = 0
 
 func workspaceReadlink(_ int, _ string, _ []byte) (int, error) { return 0, unix.ENOTSUP }
 

--- a/internal/applecontainer/workspace_stat_other.go
+++ b/internal/applecontainer/workspace_stat_other.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build !darwin && !linux
+
+package applecontainer
+
+import "golang.org/x/sys/unix"
+
+const workspaceCopySupported = false
+
+func workspaceReadlink(_ int, _ string, _ []byte) (int, error) { return 0, unix.ENOTSUP }
+
+func workspaceSnapshotFromUnix(stat unix.Stat_t) workspaceSnapshot {
+	return workspaceSnapshot{uint32(stat.Mode), stat.Size, uint64(stat.Nlink), stat.Uid, stat.Gid, uint64(stat.Dev), stat.Ino, stat.Mtim.Sec, int64(stat.Mtim.Nsec), stat.Ctim.Sec, int64(stat.Ctim.Nsec)}
+}


### PR DESCRIPTION
## Summary

- Add a bounded descriptor-based workspace copier for Darwin and Linux.
- Reject source races, destination races, multiply linked regular files and symlinks, special files, and invalid paths.
- Keep unsupported platforms fail-closed.

## Security

The copier uses descriptor-relative operations and checks source and destination identity. It requires one link for each source file and symlink before reading content. It limits depth, entries, file size, and total bytes.

This prerequisite is not connected to a supported runtime path in this PR. An immediate test-only PR will add the separate 40/41-hop boundary test before integration.

## Validation

- Fresh ./scripts/pre-merge.sh --profile pr-parity passed for head 91dc800a938414908b191f43cf7735ad889aaf9c.
- Focused tests passed 100 times, and race tests passed 10 times.
- Package, package-race, full, vet, contract, and four-OS build checks passed.
- The missing-link-count mutant failed with the intended assertion.
- Independent security review found no actionable issue after the fix.
- Live certification is not required because no supported path reaches this code.

## Scope

- Base: ef37b8f64d9d672d065ee2e7a84312b55967d6f6
- Head: 91dc800a938414908b191f43cf7735ad889aaf9c
- Tree: 444330d19186fd564ff3d213745fac918c21f909
- Shape: 5 files, 1,200 lines, 1 validator area, 0 binaries
- Full-index diff SHA-256: eb9d62ecca87f13d82f3dd086578cf480c1ac7e89ffeb1b2f1553149991758b6
- PR parity evidence SHA-256: d8402080f1a515c9b3873221af40e3fcfd2bf136a5cc0520b5309d612a39db3c