### PR TITLE
Secure Apple workspace publication

### DIFF
--- a/docs/apple-container-evaluation.md
+++ b/docs/apple-container-evaluation.md
@@ -48,6 +48,15 @@ use this guard because it has no `apple-container` operator target.
 The deterministic target writes lifecycle audit records without a signed
 digest chain. Session verification fails closed for this target.
 
+## Workspace Materialization Safety
+
+The deterministic target pins a trusted, pre-existing `StateRoot` before it writes target state.
+It rejects a source workspace that overlaps `StateRoot`.
+Each materialization ID is create-once, and native exclusive publication does not replace an existing materialization.
+The target prepares a private `0700` stage under `.materialization-staging`.
+After stage creation, a preparation failure leaves the stage in place without pathname cleanup.
+An operator can inspect and remove the stage after they understand the failure.
+
 ## Decision
 
 The technical evaluation result was `GO`. Workcell deferred operator

--- a/internal/applecontainer/audit.go
+++ b/internal/applecontainer/audit.go
@@ -517,13 +517,11 @@ func stageRecordTemp(parentFD int, base string, data []byte) (string, error) {
 // (Nlink==1) defense.
 //
 // This is atomic-PUBLISH, NOT atomically create-once: Renameat replaces an
-// existing final name. Primitive-level atomic create-once on Darwin would require
-// linkat, which transiently exposes a SECOND hard link (temp+final) that the
-// Nlink==1 read guard would reject — the two are mutually exclusive on Darwin
-// (no RENAME_NOREPLACE). So create-once is the CALLER's responsibility via
-// serialization: the applecontainer session lifecycle holds a per-session flock
-// and performs an under-lock record-exists check before creating. The per-session
-// lock is the correct layer for that guarantee.
+// existing final name. This helper does not use Darwin's RENAME_EXCL because
+// record replacement is required for rewrites. So create-once is the CALLER's
+// responsibility via serialization: the applecontainer session lifecycle holds
+// a per-session flock and performs an under-lock record-exists check before
+// creating. Workspace materialization uses a separate exclusive-rename helper.
 //
 // mustExist=true (rewrite) additionally requires an existing single-linked regular
 // file (refuse symlink/FIFO/hard-link). mustExist=false (create) keeps a cheap

--- a/internal/applecontainer/target.go
+++ b/internal/applecontainer/target.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -108,6 +107,10 @@ func NewAppleContainerTarget(contract Contract) (AppleContainerTarget, error) {
 }
 
 func (t AppleContainerTarget) MaterializeWorkspace(_ context.Context, req MaterializeRequest) (MaterializeResult, error) {
+	return t.materializeWorkspaceWithOps(req, systemWorkspaceMaterializeOps())
+}
+
+func (t AppleContainerTarget) materializeWorkspaceWithOps(req MaterializeRequest, ops workspaceMaterializeOps) (MaterializeResult, error) {
 	if strings.TrimSpace(req.StateRoot) == "" {
 		return MaterializeResult{}, fmt.Errorf("state root is required")
 	}
@@ -126,27 +129,10 @@ func (t AppleContainerTarget) MaterializeWorkspace(_ context.Context, req Materi
 	if strings.TrimSpace(req.SourceWorkspace) == "" {
 		return MaterializeResult{}, fmt.Errorf("source workspace is required")
 	}
-	// Writing generated state into (or as, or around) the tree being copied is a
-	// degenerate configuration; reject it before creating any state.
-	if overlap, err := stateRootOverlapsSource(req.StateRoot, req.SourceWorkspace); err != nil {
-		return MaterializeResult{}, err
-	} else if overlap {
-		return MaterializeResult{}, fmt.Errorf("state root %q must not overlap source workspace %q", req.StateRoot, req.SourceWorkspace)
-	}
 	root := targetRoot(req.StateRoot, t.Contract.TargetKind, targetProvider, targetID)
 	materializationRoot := filepath.Join(root, "materializations", materializationID)
 	workspaceRoot := filepath.Join(materializationRoot, t.Contract.WorkspaceMaterialization.WorkspaceDir)
 	manifestPath := filepath.Join(materializationRoot, t.Contract.WorkspaceMaterialization.ManifestName)
-	if err := os.RemoveAll(materializationRoot); err != nil {
-		return MaterializeResult{}, err
-	}
-	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
-		return MaterializeResult{}, err
-	}
-	entries, err := copyWorkspaceTree(req.SourceWorkspace, workspaceRoot, t.Contract.WorkspaceMaterialization.ExcludedPaths)
-	if err != nil {
-		return MaterializeResult{}, err
-	}
 	manifest := WorkspaceManifest{
 		Version:               1,
 		TargetKind:            t.Contract.TargetKind,
@@ -157,9 +143,20 @@ func (t AppleContainerTarget) MaterializeWorkspace(_ context.Context, req Materi
 		MaterializationID:     materializationID,
 		MaterializedWorkspace: workspaceRoot,
 		ExcludedPaths:         append([]string(nil), t.Contract.WorkspaceMaterialization.ExcludedPaths...),
-		Entries:               entries,
+		Entries:               nil,
 	}
-	if err := writeJSON(manifestPath, manifest); err != nil {
+	manifest, err = publishWorkspaceMaterialization(
+		req.StateRoot,
+		[]string{"targets", t.Contract.TargetKind, targetProvider, targetID},
+		materializationID,
+		t.Contract.WorkspaceMaterialization.WorkspaceDir,
+		t.Contract.WorkspaceMaterialization.ManifestName,
+		req.SourceWorkspace,
+		t.Contract.WorkspaceMaterialization.ExcludedPaths,
+		manifest,
+		ops,
+	)
+	if err != nil {
 		return MaterializeResult{}, err
 	}
 	return MaterializeResult{
@@ -258,20 +255,6 @@ func validateAuditToken(label, value string) error {
 	return nil
 }
 
-// stateRootOverlapsSource reports whether the state root equals, is inside, or is
-// a parent of the source workspace, comparing absolute symlink-resolved paths.
-func stateRootOverlapsSource(stateRoot, source string) (bool, error) {
-	s, err := resolveExistingPrefix(source)
-	if err != nil {
-		return false, err
-	}
-	r, err := resolveExistingPrefix(stateRoot)
-	if err != nil {
-		return false, err
-	}
-	return strings.EqualFold(s, r) || pathWithin(s, r) || pathWithin(r, s), nil
-}
-
 // pathWithin reports whether child is inside parent (component-aware via
 // filepath.Rel, so /foobar is not inside /foo). Comparison is case-insensitive
 // because on a case-insensitive volume (APFS default) /Foo and /foo are the same
@@ -282,26 +265,6 @@ func pathWithin(parent, child string) bool {
 		return false
 	}
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-}
-
-// resolveExistingPrefix makes path absolute and resolves symlinks on its longest
-// existing prefix, appending any not-yet-created tail lexically.
-func resolveExistingPrefix(path string) (string, error) {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return "", err
-	}
-	current, tail := filepath.Clean(abs), ""
-	for {
-		if resolved, err := filepath.EvalSymlinks(current); err == nil {
-			return filepath.Join(resolved, tail), nil
-		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			return abs, nil
-		}
-		current, tail = parent, filepath.Join(filepath.Base(current), tail)
-	}
 }
 
 // copyWorkspaceTree copies sourceRoot into destRoot, excluding the configured
@@ -442,11 +405,10 @@ func isExcludedPath(rel string, excluded []string) bool {
 }
 
 func writeJSON(path string, value any) error {
-	content, err := json.MarshalIndent(value, "", "  ")
+	content, err := marshalManifestBytes(value)
 	if err != nil {
 		return err
 	}
-	content = append(content, '\n')
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}

--- a/internal/applecontainer/target_session.go
+++ b/internal/applecontainer/target_session.go
@@ -6,7 +6,6 @@ package applecontainer
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -516,8 +515,8 @@ func (t AppleContainerTarget) FinishSession(_ context.Context, req FinishSession
 }
 
 // verifyPersistedManifest requires the on-disk manifest at path to serialize
-// identically to the in-memory manifest (writeJSON emits MarshalIndent + "\n"),
-// so every field — not just the path — is certified against persisted state. The
+// identically to the in-memory manifest through the shared format helper, so
+// every field — not just the path — is certified against persisted state. The
 // manifest is read through the hardened path so a manifest FILE swapped for a
 // symlink/FIFO is refused, not followed, even though its parent chain was checked.
 func verifyPersistedManifest(stateRoot, path string, manifest any) error {
@@ -525,11 +524,11 @@ func verifyPersistedManifest(stateRoot, path string, manifest any) error {
 	if err != nil {
 		return err
 	}
-	want, err := json.MarshalIndent(manifest, "", "  ")
+	want, err := marshalManifestBytes(manifest)
 	if err != nil {
 		return err
 	}
-	if !bytes.Equal(onDisk, append(want, '\n')) {
+	if !bytes.Equal(onDisk, want) {
 		return fmt.Errorf("persisted manifest %q does not match the in-memory manifest", path)
 	}
 	return nil

--- a/internal/applecontainer/target_session_recovery_test.go
+++ b/internal/applecontainer/target_session_recovery_test.go
@@ -20,14 +20,13 @@ func targetRootOf(started SessionResult) string {
 	return filepath.Dir(filepath.Dir(started.RecordPath))
 }
 
-// rewriteManifest re-persists v at path in writeJSON's on-disk format
-// (MarshalIndent + trailing newline, 0o600) so a self-consistent tamper — the
-// Result and the on-disk bytes edited to agree — still passes the byte-compare.
+// rewriteManifest re-persists v in writeJSON's format so a self-consistent
+// tamper still passes the exact byte comparison.
 func rewriteManifest(t *testing.T, path string, v any) {
 	t.Helper()
-	data, err := json.MarshalIndent(v, "", "  ")
+	data, err := marshalManifestBytes(v)
 	mustNil(t, err)
-	mustNil(t, os.WriteFile(path, append(data, '\n'), 0o600))
+	mustNil(t, os.WriteFile(path, data, 0o600))
 }
 
 // TestStartSessionRejectsAuditLogOutsideTargetRoot: an AuditLogPath outside the

--- a/internal/applecontainer/target_session_test.go
+++ b/internal/applecontainer/target_session_test.go
@@ -457,6 +457,7 @@ func TestAuditPathValuesRoundTrip(t *testing.T) {
 	mustNil(t, os.MkdirAll(filepath.Join(src, "src"), 0o755))
 	mustNil(t, os.WriteFile(filepath.Join(src, "src", "main.go"), []byte("package main\n"), 0o644))
 	state := filepath.Join(t.TempDir(), "My State Dir")
+	mustNil(t, os.Mkdir(state, 0o700))
 
 	mat, log := runToStart(t, src, state)
 
@@ -474,7 +475,7 @@ func TestAuditPathValuesRoundTrip(t *testing.T) {
 }
 
 // TestAuditPathNewlineRejectedBeforeAudit: a newline in a source path is rejected
-// at the record write (records forbid newlines) before any audit line is emitted.
+// before any audit line is emitted. Materialization can reject it first.
 func TestAuditPathNewlineRejectedBeforeAudit(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -486,7 +487,15 @@ func TestAuditPathNewlineRejectedBeforeAudit(t *testing.T) {
 	state := t.TempDir()
 
 	mat, err := target.MaterializeWorkspace(ctx, MaterializeRequest{StateRoot: state, TargetID: "tid", MaterializationID: "mid", SourceWorkspace: src})
-	mustNil(t, err)
+	if err != nil {
+		if workspaceMaterializationSupported && !strings.Contains(err.Error(), "unsafe control character") {
+			t.Fatalf("materialization returned the wrong rejection: %v", err)
+		}
+		if _, statErr := os.Lstat(filepath.Join(state, "targets")); !os.IsNotExist(statErr) {
+			t.Fatalf("rejected materialization wrote target state: %v", statErr)
+		}
+		return
+	}
 	boot, err := target.BootstrapTarget(ctx, BootstrapRequest{StateRoot: state, TargetID: "tid", BootstrapID: "bid", ImageRef: "img:1"})
 	mustNil(t, err)
 	if _, e := target.StartSession(ctx, StartSessionRequest{SessionID: "sid", Agent: "codex", Mode: "strict", StartedAt: "2026", Materialization: mat, Bootstrap: boot}); e == nil {

--- a/internal/applecontainer/workspace_copy.go
+++ b/internal/applecontainer/workspace_copy.go
@@ -52,6 +52,7 @@ type workspaceSnapshot struct {
 
 type workspaceObjectID struct{ dev, ino uint64 }
 type workspaceOps struct {
+	stat      func(string, *unix.Stat_t) error
 	openat    func(int, string, int, uint32) (int, error)
 	fstat     func(int, *unix.Stat_t) error
 	fstatat   func(int, string, *unix.Stat_t, int) error
@@ -62,7 +63,7 @@ type workspaceOps struct {
 }
 
 func systemWorkspaceOps() workspaceOps {
-	return workspaceOps{unix.Openat, unix.Fstat, unix.Fstatat, unix.Mkdirat, unix.Fchmod, workspaceReadlink, unix.Symlinkat}
+	return workspaceOps{unix.Stat, unix.Openat, unix.Fstat, unix.Fstatat, unix.Mkdirat, unix.Fchmod, workspaceReadlink, unix.Symlinkat}
 }
 
 type workspaceWalk struct {
@@ -99,6 +100,17 @@ func copyWorkspaceTreeWithOps(sourceRoot string, parentFD int, name string, excl
 	if err != nil {
 		return nil, err
 	}
+	return copyWorkspaceTreeFromDescriptor(sourceFD, sourceSnapshot, parentFD, name, excluded, limits, ops)
+}
+
+// copyWorkspaceTreeFromDescriptor consumes sourceFD, including on failure.
+func copyWorkspaceTreeFromDescriptor(sourceFD int, sourceSnapshot workspaceSnapshot, parentFD int, name string, excluded []string, limits workspaceCopyLimits, ops workspaceOps) ([]WorkspaceEntry, error) {
+	if !workspaceCopySupported {
+		return abortWorkspaceCopy(sourceFD, errWorkspaceCopyUnsupported)
+	}
+	if err := validateWorkspaceLeaf("workspace destination", name); err != nil {
+		return abortWorkspaceCopy(sourceFD, err)
+	}
 	if err := requireWorkspaceNameAbsent(parentFD, name, ops); err != nil {
 		return abortWorkspaceCopy(sourceFD, err)
 	}
@@ -106,7 +118,7 @@ func copyWorkspaceTreeWithOps(sourceRoot string, parentFD int, name string, excl
 	if err != nil {
 		return abortWorkspaceCopy(sourceFD, err)
 	}
-	walk := &workspaceWalk{excluded: excluded, limits: limits, fileSizes: make(map[string]int64), reserved: make(map[string]WorkspaceEntry), directories: make(map[workspaceObjectID]string), ops: ops}
+	walk := &workspaceWalk{entries: make([]WorkspaceEntry, 0), excluded: excluded, limits: limits, fileSizes: make(map[string]int64), reserved: make(map[string]WorkspaceEntry), directories: make(map[workspaceObjectID]string), ops: ops}
 	err = walk.directory(sourceFD, destFD, "", 0, sourceSnapshot)
 	if err == nil {
 		err = validateWorkspaceLinks(walk.entries)
@@ -648,10 +660,14 @@ func readWorkspaceLink(parentFD int, name string, ops workspaceOps) (string, err
 }
 
 func openWorkspaceSourceRoot(sourceRoot string, ops workspaceOps) (int, workspaceSnapshot, error) {
-	if _, err := pathutil.CollisionKey(sourceRoot); err != nil {
+	return openPinnedWorkspaceDirectory("source workspace", sourceRoot, true, ops)
+}
+
+func openPinnedWorkspaceDirectory(label, directory string, stable bool, ops workspaceOps) (int, workspaceSnapshot, error) {
+	if _, err := pathutil.CollisionKey(directory); err != nil {
 		return -1, workspaceSnapshot{}, err
 	}
-	resolved, err := filepath.EvalSymlinks(sourceRoot)
+	resolved, err := filepath.EvalSymlinks(directory)
 	if err != nil {
 		return -1, workspaceSnapshot{}, err
 	}
@@ -660,22 +676,22 @@ func openWorkspaceSourceRoot(sourceRoot string, ops workspaceOps) (int, workspac
 		return -1, workspaceSnapshot{}, err
 	}
 	var before unix.Stat_t
-	if err := unix.Stat(resolved, &before); err != nil {
+	if err := ops.stat(resolved, &before); err != nil {
 		return -1, workspaceSnapshot{}, err
 	}
 	beforeSnapshot := workspaceSnapshotFromUnix(before)
 	if beforeSnapshot.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFDIR) {
-		return -1, workspaceSnapshot{}, fmt.Errorf("source workspace is not a directory: %s", sourceRoot)
+		return -1, workspaceSnapshot{}, fmt.Errorf("%s is not a directory: %s", label, directory)
 	}
 	fd, err := openAbsoluteWorkspaceDir(resolved, ops)
 	if err != nil {
-		return -1, workspaceSnapshot{}, fmt.Errorf("open source workspace %q: %w", sourceRoot, err)
+		return -1, workspaceSnapshot{}, fmt.Errorf("open %s %q: %w", label, directory, err)
 	}
 	var opened unix.Stat_t
-	if err := ops.fstat(fd, &opened); err != nil || workspaceSnapshotFromUnix(opened) != beforeSnapshot {
-		return -1, workspaceSnapshot{}, closeFDError(fd, "source workspace changed while opening")
+	if err := ops.fstat(fd, &opened); err != nil || opened.Dev != before.Dev || opened.Ino != before.Ino || stable && workspaceSnapshotFromUnix(opened) != beforeSnapshot {
+		return -1, workspaceSnapshot{}, closeFDError(fd, "%s changed while opening", label)
 	}
-	return fd, beforeSnapshot, nil
+	return fd, workspaceSnapshotFromUnix(opened), nil
 }
 
 func openAbsoluteWorkspaceDir(directory string, ops workspaceOps) (int, error) {
@@ -705,7 +721,7 @@ func requireWorkspaceNameAbsent(parentFD int, name string, ops workspaceOps) err
 	var stat unix.Stat_t
 	err := ops.fstatat(parentFD, name, &stat, unix.AT_SYMLINK_NOFOLLOW)
 	if err == nil {
-		return fmt.Errorf("workspace destination %q already exists", name)
+		return fmt.Errorf("workspace destination %q already exists: %w", name, unix.EEXIST)
 	}
 	if !errors.Is(err, unix.ENOENT) {
 		return fmt.Errorf("inspect workspace destination %q: %w", name, err)
@@ -729,6 +745,10 @@ func createWorkspaceDirectory(parentFD int, name string, ops workspaceOps) (int,
 	if err := ops.mkdirat(parentFD, name, 0o700); err != nil {
 		return -1, err
 	}
+	return openCreatedWorkspaceDirectory(parentFD, name, ops)
+}
+
+func openCreatedWorkspaceDirectory(parentFD int, name string, ops workspaceOps) (int, error) {
 	var before unix.Stat_t
 	if err := ops.fstatat(parentFD, name, &before, unix.AT_SYMLINK_NOFOLLOW); err != nil {
 		return -1, err

--- a/internal/applecontainer/workspace_copy.go
+++ b/internal/applecontainer/workspace_copy.go
@@ -58,12 +58,13 @@ type workspaceOps struct {
 	fstatat   func(int, string, *unix.Stat_t, int) error
 	mkdirat   func(int, string, uint32) error
 	fchmod    func(int, uint32) error
+	fsync     func(int) error
 	readlink  func(int, string, []byte) (int, error)
 	symlinkat func(string, int, string) error
 }
 
 func systemWorkspaceOps() workspaceOps {
-	return workspaceOps{unix.Stat, unix.Openat, unix.Fstat, unix.Fstatat, unix.Mkdirat, unix.Fchmod, workspaceReadlink, unix.Symlinkat}
+	return workspaceOps{unix.Stat, unix.Openat, unix.Fstat, unix.Fstatat, unix.Mkdirat, unix.Fchmod, unix.Fsync, workspaceReadlink, unix.Symlinkat}
 }
 
 type workspaceWalk struct {
@@ -128,6 +129,11 @@ func copyWorkspaceTreeFromDescriptor(sourceFD int, sourceSnapshot workspaceSnaps
 	}
 	if err == nil {
 		err = walk.validateDestination(destFD)
+	}
+	if err == nil {
+		if syncErr := ops.fsync(destFD); syncErr != nil {
+			err = fmt.Errorf("sync workspace root: %w", syncErr)
+		}
 	}
 	if err == nil {
 		_, err = verifyWorkspaceNameAt(parentFD, name, destFD, ops)
@@ -234,6 +240,9 @@ func (walk *workspaceWalk) copyDirectory(sourceParent, destParent int, name, rel
 	if err := walk.ops.fchmod(destChild, uint32(mode.Perm())); err != nil {
 		return err
 	}
+	if err := walk.ops.fsync(destChild); err != nil {
+		return fmt.Errorf("sync workspace directory %q: %w", rel, err)
+	}
 	if _, err := verifyWorkspaceNameAt(destParent, name, destChild, walk.ops); err != nil {
 		return err
 	}
@@ -290,6 +299,9 @@ func (walk *workspaceWalk) copyFile(sourceParent, destParent int, name, rel stri
 	if err := walk.ops.fchmod(destFD, uint32(mode.Perm())); err != nil {
 		return err
 	}
+	if err := walk.ops.fsync(destFD); err != nil {
+		return fmt.Errorf("sync workspace file %q: %w", rel, err)
+	}
 	copiedSnapshot, err := verifyWorkspaceNameAt(destParent, name, destFD, walk.ops)
 	if err != nil {
 		return err
@@ -303,6 +315,7 @@ func (walk *workspaceWalk) copyFile(sourceParent, destParent int, name, rel stri
 }
 
 func (walk *workspaceWalk) copySymlink(sourceParent, destParent int, name, rel string, before workspaceSnapshot) error {
+	// The postorder parent-directory sync persists the verified symlink metadata.
 	sourceLinkFD, err := walk.ops.openat(sourceParent, name, workspaceSymlinkOpenFlags, 0)
 	if err != nil {
 		return fmt.Errorf("pin workspace symlink %q: %w", rel, err)

--- a/internal/applecontainer/workspace_copy_test.go
+++ b/internal/applecontainer/workspace_copy_test.go
@@ -50,7 +50,7 @@ func TestWorkspaceCopyUsesPinnedParent(t *testing.T) {
 }
 
 func TestWorkspaceCopyRejectsSourceRaces(t *testing.T) {
-	for _, kind := range []string{"replacement", "symlink-follow", "special", "in-place-file", "ctime-only", "nlink-only", "in-place-directory"} {
+	for _, kind := range []string{"replacement", "symlink-follow", "special", "root-open", "in-place-file", "ctime-only", "nlink-only", "in-place-directory"} {
 		t.Run(kind, func(t *testing.T) {
 			source := t.TempDir()
 			victim := filepath.Join(source, "victim")
@@ -87,7 +87,11 @@ func TestWorkspaceCopyRejectsSourceRaces(t *testing.T) {
 					}
 					if stat.Ino == watchedStat.Ino && uint64(stat.Dev) == uint64(watchedStat.Dev) {
 						observations++
-						if observations == 2 {
+						if observations == map[bool]int{false: 2, true: 1}[kind == "root-open"] {
+							if kind == "root-open" {
+								mustNil(t, os.Mkdir(filepath.Join(source, "early"), 0o700))
+								return original(fd, stat)
+							}
 							if kind == "ctime-only" {
 								stat.Ctim.Nsec++
 							} else if kind == "nlink-only" {

--- a/internal/applecontainer/workspace_publish.go
+++ b/internal/applecontainer/workspace_publish.go
@@ -1,0 +1,471 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/omkhar/workcell/internal/rootio"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	workspaceStageAttempts = 16
+	workspaceStagingName   = ".materialization-staging"
+)
+
+var errWorkspaceMaterializationUnsupported = errors.New("secure workspace materialization is unsupported on this platform")
+
+type workspaceMaterializeOps struct {
+	workspace workspaceOps
+	random    func([]byte) (int, error)
+	write     func(int, []byte) (int, error)
+	fsync     func(int) error
+	publish   func(int, string, int, string) error
+	manifest  int64
+}
+
+func systemWorkspaceMaterializeOps() workspaceMaterializeOps {
+	return workspaceMaterializeOps{systemWorkspaceOps(), rand.Read, unix.Write, unix.Fsync, workspacePublish, workspaceManifestMaxBytes}
+}
+
+// publishWorkspaceMaterialization creates one materialization without replacement.
+// StateRoot must be a pre-existing, trusted, caller-owned directory.
+func publishWorkspaceMaterialization(stateRoot string, targetChain []string, finalName, workspaceName, manifestName, sourceRoot string, excluded []string, manifest WorkspaceManifest, ops workspaceMaterializeOps) (_ WorkspaceManifest, retErr error) {
+	if !workspaceMaterializationSupported || !workspaceCopySupported {
+		return WorkspaceManifest{}, errWorkspaceMaterializationUnsupported
+	}
+	if len(targetChain) == 0 || ops.manifest <= 0 {
+		return WorkspaceManifest{}, fmt.Errorf("workspace materialization configuration is invalid")
+	}
+	for label, value := range map[string]string{"materialization id": finalName, "workspace directory": workspaceName, "manifest name": manifestName} {
+		if err := validateWorkspaceLeaf(label, value); err != nil {
+			return WorkspaceManifest{}, err
+		}
+	}
+	for _, name := range targetChain {
+		if err := validateWorkspaceLeaf("managed directory", name); err != nil {
+			return WorkspaceManifest{}, err
+		}
+	}
+	stateFD, stateSnapshot, err := openPinnedWorkspaceDirectory("state root", stateRoot, false, ops.workspace)
+	if err != nil {
+		return WorkspaceManifest{}, err
+	}
+	defer unix.Close(stateFD)
+	if stateSnapshot.uid != uint32(os.Geteuid()) || stateSnapshot.mode&0o022 != 0 || stateSnapshot.mode&0o7000 != 0 {
+		return WorkspaceManifest{}, fmt.Errorf("state root must be caller-owned and must not be group-writable or world-writable")
+	}
+	sourceFD, sourceSnapshot, err := openWorkspaceSourceRoot(sourceRoot, ops.workspace)
+	if err != nil {
+		return WorkspaceManifest{}, err
+	}
+	defer unix.Close(sourceFD)
+	if err := rejectWorkspaceDescriptorOverlap(stateFD, stateSnapshot, sourceFD, sourceSnapshot, ops.workspace); err != nil {
+		return WorkspaceManifest{}, err
+	}
+	targetFD, targetID, err := openManagedWorkspaceChain(stateFD, targetChain, true, ops.workspace)
+	if err != nil {
+		return WorkspaceManifest{}, err
+	}
+	defer unix.Close(targetFD)
+	finalParentFD, finalParentID, err := openManagedWorkspaceDirectory(targetFD, "materializations", 0o700, false, true, ops.workspace)
+	if err != nil {
+		return WorkspaceManifest{}, err
+	}
+	defer unix.Close(finalParentFD)
+	if err := requireWorkspaceNameAbsent(finalParentFD, finalName, ops.workspace); err != nil {
+		return WorkspaceManifest{}, err
+	}
+	stagingParentFD, stagingParentID, err := openManagedWorkspaceDirectory(targetFD, workspaceStagingName, 0o700, true, true, ops.workspace)
+	if err != nil {
+		return WorkspaceManifest{}, err
+	}
+	defer unix.Close(stagingParentFD)
+	stageName, stageFD, err := createPrivateWorkspaceStage(stagingParentFD, ops)
+	if err != nil {
+		if stageName != "" {
+			return WorkspaceManifest{}, fmt.Errorf("materialization failed after private stage %q was created; no pathname cleanup was attempted: %w", stageName, err)
+		}
+		return WorkspaceManifest{}, err
+	}
+	published := false
+	defer func() {
+		if retErr != nil && !published {
+			modeErr := ops.workspace.fchmod(stageFD, 0o700)
+			bound, bindErr := workspaceNameBindsFD(stagingParentFD, stageName, stageFD, ops.workspace)
+			if modeErr == nil && bindErr == nil && bound {
+				retErr = fmt.Errorf("materialization failed; private stage %q was retained without pathname cleanup: %w", stageName, retErr)
+			} else if modeErr == nil && bindErr == nil {
+				retErr = fmt.Errorf("materialization publication outcome is ambiguous; the owned object was returned to mode 0700, but private stage %q no longer binds it; no pathname cleanup was attempted: %w", stageName, retErr)
+			} else {
+				retErr = fmt.Errorf("materialization failed after stage creation; no pathname cleanup was attempted and stage retention could not be confirmed: %w", errors.Join(retErr, modeErr, bindErr))
+			}
+		}
+		_ = unix.Close(stageFD)
+	}()
+	copyFD, err := ops.workspace.openat(sourceFD, ".", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return WorkspaceManifest{}, err
+	}
+	var copyStat unix.Stat_t
+	if err := ops.workspace.fstat(copyFD, &copyStat); err != nil || workspaceSnapshotFromUnix(copyStat) != sourceSnapshot {
+		return WorkspaceManifest{}, closeFDError(copyFD, "source workspace changed before copying")
+	}
+	entries, err := copyWorkspaceTreeFromDescriptor(copyFD, sourceSnapshot, stageFD, workspaceName, excluded, defaultWorkspaceCopyLimits(), ops.workspace)
+	if err != nil {
+		return WorkspaceManifest{}, err
+	}
+	manifest.Entries = entries
+	want, err := marshalManifestBytes(manifest)
+	if err != nil {
+		return WorkspaceManifest{}, err
+	}
+	if int64(len(want)) > ops.manifest {
+		return WorkspaceManifest{}, fmt.Errorf("workspace manifest exceeds %d bytes", ops.manifest)
+	}
+	if err := writeWorkspaceManifestAt(stageFD, manifestName, want, ops); err != nil {
+		return WorkspaceManifest{}, err
+	}
+	if err := validateWorkspaceManifestAt(stageFD, manifestName, want, ops); err != nil {
+		return WorkspaceManifest{}, err
+	}
+	if err := requireWorkspaceStageEntries(stageFD, workspaceName, manifestName); err != nil {
+		return WorkspaceManifest{}, err
+	}
+	if err := ops.workspace.fchmod(stageFD, 0o755); err != nil {
+		return WorkspaceManifest{}, fmt.Errorf("set final materialization mode: %w", err)
+	}
+	if err := ops.fsync(stageFD); err != nil {
+		return WorkspaceManifest{}, fmt.Errorf("sync private workspace stage: %w", err)
+	}
+	if err := ops.fsync(stagingParentFD); err != nil {
+		return WorkspaceManifest{}, fmt.Errorf("sync staging parent: %w", err)
+	}
+	if err := ops.fsync(finalParentFD); err != nil {
+		return WorkspaceManifest{}, fmt.Errorf("sync materializations parent: %w", err)
+	}
+	if err := verifyWorkspaceSource(sourceFD, sourceSnapshot, stateFD, stateSnapshot, ops.workspace); err != nil {
+		return WorkspaceManifest{}, err
+	}
+	if err := verifyWorkspacePublishAnchors(stateRoot, stateSnapshot, stateFD, targetChain, targetID, targetFD, finalParentID, finalParentFD, stagingParentID, stagingParentFD, ops.workspace); err != nil {
+		return WorkspaceManifest{}, err
+	}
+	if err := requireWorkspaceNameAbsent(finalParentFD, finalName, ops.workspace); err != nil {
+		return WorkspaceManifest{}, err
+	}
+	stageSnapshot, err := verifyWorkspaceNameAt(stagingParentFD, stageName, stageFD, ops.workspace)
+	if err != nil || stageSnapshot.mode&0o7777 != 0o755 {
+		return WorkspaceManifest{}, fmt.Errorf("private workspace stage changed before publication")
+	}
+	publishErr := ops.publish(stagingParentFD, stageName, finalParentFD, finalName)
+	stageBound, stageBindErr := workspaceNameBindsFD(stagingParentFD, stageName, stageFD, ops.workspace)
+	finalBound, finalBindErr := workspaceNameBindsFD(finalParentFD, finalName, stageFD, ops.workspace)
+	if finalBound {
+		published = true
+		if stageBound {
+			return WorkspaceManifest{}, fmt.Errorf("materialization was published, but the private stage name still exists")
+		}
+	} else if publishErr == nil {
+		return WorkspaceManifest{}, fmt.Errorf("publication returned success but final binding is invalid: %w", errors.Join(stageBindErr, finalBindErr))
+	} else {
+		return WorkspaceManifest{}, fmt.Errorf("publish materialization %q without replacement: %w", finalName, errors.Join(publishErr, stageBindErr, finalBindErr))
+	}
+	if err := ops.fsync(stagingParentFD); err != nil {
+		return WorkspaceManifest{}, fmt.Errorf("materialization was published, but staging parent sync failed: %w", err)
+	}
+	if err := ops.fsync(finalParentFD); err != nil {
+		return WorkspaceManifest{}, fmt.Errorf("materialization was published, but materializations parent sync failed: %w", err)
+	}
+	if err := verifyWorkspacePublishAnchors(stateRoot, stateSnapshot, stateFD, targetChain, targetID, targetFD, finalParentID, finalParentFD, stagingParentID, stagingParentFD, ops.workspace); err != nil {
+		return WorkspaceManifest{}, fmt.Errorf("materialization was published, but its anchor changed: %w", err)
+	}
+	if bound, err := workspaceNameBindsFD(finalParentFD, finalName, stageFD, ops.workspace); err != nil || !bound {
+		return WorkspaceManifest{}, fmt.Errorf("materialization was published, but final binding changed")
+	}
+	return manifest, nil
+}
+
+func rejectWorkspaceDescriptorOverlap(stateFD int, state workspaceSnapshot, sourceFD int, source workspaceSnapshot, ops workspaceOps) error {
+	stateID, sourceID := workspaceObjectID{state.dev, state.ino}, workspaceObjectID{source.dev, source.ino}
+	stateWithinSource, err := workspaceDescriptorWithin(sourceID, stateFD, ops)
+	if err != nil {
+		return err
+	}
+	sourceWithinState, err := workspaceDescriptorWithin(stateID, sourceFD, ops)
+	if err != nil {
+		return err
+	}
+	if stateWithinSource || sourceWithinState {
+		return fmt.Errorf("state root must not overlap the source workspace")
+	}
+	return nil
+}
+
+func workspaceDescriptorWithin(ancestor workspaceObjectID, childFD int, ops workspaceOps) (bool, error) {
+	current, err := ops.openat(childFD, ".", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = unix.Close(current) }()
+	for hop := 0; hop < workspaceMaxPathBytes; hop++ {
+		var currentStat unix.Stat_t
+		if err := ops.fstat(current, &currentStat); err != nil {
+			return false, err
+		}
+		currentID := snapshotObjectID(workspaceSnapshotFromUnix(currentStat))
+		if currentID == ancestor {
+			return true, nil
+		}
+		parent, err := ops.openat(current, "..", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return false, err
+		}
+		var parentStat unix.Stat_t
+		if err := ops.fstat(parent, &parentStat); err != nil {
+			unix.Close(parent)
+			return false, err
+		}
+		parentID := snapshotObjectID(workspaceSnapshotFromUnix(parentStat))
+		if parentID == currentID {
+			unix.Close(parent)
+			return false, nil
+		}
+		unix.Close(current)
+		current = parent
+	}
+	return false, fmt.Errorf("filesystem ancestry exceeds %d components", workspaceMaxPathBytes)
+}
+
+func openManagedWorkspaceChain(stateFD int, names []string, create bool, ops workspaceOps) (int, workspaceObjectID, error) {
+	current, err := ops.openat(stateFD, ".", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, workspaceObjectID{}, err
+	}
+	var id workspaceObjectID
+	for _, name := range names {
+		next, nextID, err := openManagedWorkspaceDirectory(current, name, 0o700, false, create, ops)
+		unix.Close(current)
+		if err != nil {
+			return -1, workspaceObjectID{}, err
+		}
+		current, id = next, nextID
+	}
+	return current, id, nil
+}
+
+func openManagedWorkspaceDirectory(parentFD int, name string, createMode uint32, requirePrivate, create bool, ops workspaceOps) (int, workspaceObjectID, error) {
+	created := false
+	if create {
+		if err := ops.mkdirat(parentFD, name, createMode); err == nil {
+			created = true
+		} else if !errors.Is(err, unix.EEXIST) {
+			return -1, workspaceObjectID{}, fmt.Errorf("create managed directory %q: %w", name, err)
+		}
+	}
+	var before unix.Stat_t
+	if err := ops.fstatat(parentFD, name, &before, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return -1, workspaceObjectID{}, fmt.Errorf("inspect managed directory %q: %w", name, err)
+	}
+	want := workspaceSnapshotFromUnix(before)
+	if want.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFDIR) || want.uid != uint32(os.Geteuid()) || want.mode&0o022 != 0 || want.mode&0o7000 != 0 {
+		return -1, workspaceObjectID{}, fmt.Errorf("managed directory %q is not a secure caller-owned directory", name)
+	}
+	fd, err := ops.openat(parentFD, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, workspaceObjectID{}, fmt.Errorf("open managed directory %q: %w", name, err)
+	}
+	opened, err := verifyWorkspaceDirectoryNameAt(parentFD, name, fd, ops)
+	if err != nil || snapshotObjectID(opened) != snapshotObjectID(want) {
+		return -1, workspaceObjectID{}, closeFDError(fd, "managed directory %q changed while opening", name)
+	}
+	if created {
+		if err := ops.fchmod(fd, createMode); err != nil {
+			return -1, workspaceObjectID{}, closeFDError(fd, "set managed directory %q mode: %w", name, err)
+		}
+		opened, err = verifyWorkspaceDirectoryNameAt(parentFD, name, fd, ops)
+		if err != nil || opened.mode&0o7777 != createMode {
+			return -1, workspaceObjectID{}, closeFDError(fd, "managed directory %q changed after mode update", name)
+		}
+	}
+	if requirePrivate && opened.mode&0o7777 != 0o700 {
+		return -1, workspaceObjectID{}, closeFDError(fd, "managed directory %q must have mode 0700", name)
+	}
+	return fd, snapshotObjectID(opened), nil
+}
+
+func createPrivateWorkspaceStage(parentFD int, ops workspaceMaterializeOps) (string, int, error) {
+	for attempt := 0; attempt < workspaceStageAttempts; attempt++ {
+		var token [16]byte
+		n, err := ops.random(token[:])
+		if err != nil || n != len(token) {
+			return "", -1, errors.Join(err, io.ErrUnexpectedEOF)
+		}
+		name := ".workcell-stage-" + hex.EncodeToString(token[:])
+		if err := ops.workspace.mkdirat(parentFD, name, 0o700); errors.Is(err, unix.EEXIST) {
+			continue
+		} else if err != nil {
+			return "", -1, fmt.Errorf("create private workspace stage: %w", err)
+		}
+		fd, err := openCreatedWorkspaceDirectory(parentFD, name, ops.workspace)
+		if err != nil {
+			return name, -1, err
+		}
+		if err := ops.workspace.fchmod(fd, 0o700); err != nil {
+			return name, -1, closeFDError(fd, "set private workspace stage mode: %w", err)
+		}
+		snapshot, err := verifyWorkspaceNameAt(parentFD, name, fd, ops.workspace)
+		if err != nil || snapshot.mode&0o7777 != 0o700 {
+			return name, -1, closeFDError(fd, "private workspace stage changed after mode update")
+		}
+		return name, fd, nil
+	}
+	return "", -1, fmt.Errorf("could not allocate a private workspace stage")
+}
+
+func marshalManifestBytes(value any) ([]byte, error) {
+	switch value.(type) {
+	case WorkspaceManifest, *WorkspaceManifest:
+		return rootio.MarshalCompactJSON(value, "workspace manifest", workspaceManifestMaxBytes)
+	}
+	content, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(content, '\n'), nil
+}
+
+func writeWorkspaceManifestAt(stageFD int, name string, content []byte, ops workspaceMaterializeOps) error {
+	fd, err := ops.workspace.openat(stageFD, name, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0o600)
+	if err != nil {
+		return fmt.Errorf("create workspace manifest: %w", err)
+	}
+	defer unix.Close(fd)
+	if err := ops.workspace.fchmod(fd, 0o600); err != nil {
+		return err
+	}
+	if n, err := ops.write(fd, content); err != nil {
+		return err
+	} else if n != len(content) {
+		return io.ErrShortWrite
+	}
+	if err := ops.fsync(fd); err != nil {
+		return err
+	}
+	snapshot, err := verifyWorkspaceNameAt(stageFD, name, fd, ops.workspace)
+	if err != nil || snapshot.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFREG) || snapshot.mode&0o7777 != 0o600 || snapshot.uid != uint32(os.Geteuid()) || snapshot.nlink != 1 || snapshot.size != int64(len(content)) {
+		return fmt.Errorf("workspace manifest changed while writing")
+	}
+	return nil
+}
+
+func validateWorkspaceManifestAt(stageFD int, name string, want []byte, ops workspaceMaterializeOps) error {
+	fd, err := ops.workspace.openat(stageFD, name, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("open workspace manifest: %w", err)
+	}
+	handle := os.NewFile(uintptr(fd), name)
+	defer handle.Close()
+	var before unix.Stat_t
+	if err := ops.workspace.fstat(fd, &before); err != nil {
+		return err
+	}
+	snapshot := workspaceSnapshotFromUnix(before)
+	if snapshot.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFREG) || snapshot.mode&0o7777 != 0o600 || snapshot.uid != uint32(os.Geteuid()) || snapshot.nlink != 1 || snapshot.size < 0 || snapshot.size > ops.manifest {
+		return fmt.Errorf("workspace manifest is not a bounded private regular file")
+	}
+	content, err := io.ReadAll(io.LimitReader(handle, ops.manifest+1))
+	if err != nil {
+		return fmt.Errorf("read bounded workspace manifest: %w", err)
+	}
+	if int64(len(content)) > ops.manifest {
+		return fmt.Errorf("workspace manifest exceeds %d bytes", ops.manifest)
+	}
+	stable, err := verifyWorkspaceNameAt(stageFD, name, fd, ops.workspace)
+	if err != nil || stable != snapshot || !bytes.Equal(content, want) {
+		return fmt.Errorf("workspace manifest changed during validation")
+	}
+	return nil
+}
+
+func requireWorkspaceStageEntries(stageFD int, workspaceName, manifestName string) error {
+	names, err := workspaceDirectoryNames(stageFD, 3)
+	if err != nil {
+		return err
+	}
+	if workspaceName == manifestName || len(names) != 2 || names[0] != workspaceName && names[1] != workspaceName || names[0] != manifestName && names[1] != manifestName {
+		return fmt.Errorf("private workspace stage has unexpected entries")
+	}
+	return nil
+}
+
+func workspaceNameBindsFD(parentFD int, name string, fd int, ops workspaceOps) (bool, error) {
+	var opened, named unix.Stat_t
+	if err := ops.fstat(fd, &opened); err != nil {
+		return false, err
+	}
+	err := ops.fstatat(parentFD, name, &named, unix.AT_SYMLINK_NOFOLLOW)
+	if errors.Is(err, unix.ENOENT) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return workspaceSnapshotFromUnix(opened) == workspaceSnapshotFromUnix(named), nil
+}
+
+func verifyWorkspaceDirectoryNameAt(parentFD int, name string, fd int, ops workspaceOps) (workspaceSnapshot, error) {
+	var opened, named unix.Stat_t
+	if err := ops.fstat(fd, &opened); err != nil {
+		return workspaceSnapshot{}, err
+	}
+	snapshot := workspaceSnapshotFromUnix(opened)
+	if err := ops.fstatat(parentFD, name, &named, unix.AT_SYMLINK_NOFOLLOW); err != nil || snapshotObjectID(workspaceSnapshotFromUnix(named)) != snapshotObjectID(snapshot) {
+		return workspaceSnapshot{}, fmt.Errorf("managed directory %q changed", name)
+	}
+	return snapshot, nil
+}
+
+func verifyWorkspaceSource(sourceFD int, source workspaceSnapshot, stateFD int, state workspaceSnapshot, ops workspaceOps) error {
+	var current unix.Stat_t
+	if err := ops.fstat(sourceFD, &current); err != nil || workspaceSnapshotFromUnix(current) != source {
+		return fmt.Errorf("source workspace changed before publication")
+	}
+	return rejectWorkspaceDescriptorOverlap(stateFD, state, sourceFD, source, ops)
+}
+
+func verifyWorkspacePublishAnchors(stateRoot string, state workspaceSnapshot, stateFD int, chain []string, targetID workspaceObjectID, targetFD int, finalParentID workspaceObjectID, finalParentFD int, stagingParentID workspaceObjectID, stagingParentFD int, ops workspaceOps) error {
+	var visible unix.Stat_t
+	if err := ops.stat(stateRoot, &visible); err != nil || snapshotObjectID(workspaceSnapshotFromUnix(visible)) != snapshotObjectID(state) {
+		return fmt.Errorf("state root identity changed")
+	}
+	openedTarget, openedTargetID, err := openManagedWorkspaceChain(stateFD, chain, false, ops)
+	if err != nil {
+		return err
+	}
+	defer unix.Close(openedTarget)
+	if openedTargetID != targetID {
+		return fmt.Errorf("target directory identity changed")
+	}
+	for _, check := range []struct {
+		parent int
+		name   string
+		fd     int
+		id     workspaceObjectID
+	}{{targetFD, "materializations", finalParentFD, finalParentID}, {targetFD, workspaceStagingName, stagingParentFD, stagingParentID}} {
+		if opened, err := verifyWorkspaceDirectoryNameAt(check.parent, check.name, check.fd, ops); err != nil || snapshotObjectID(opened) != check.id {
+			return fmt.Errorf("managed directory %q changed", check.name)
+		}
+	}
+	return nil
+}
+
+func snapshotObjectID(s workspaceSnapshot) workspaceObjectID { return workspaceObjectID{s.dev, s.ino} }

--- a/internal/applecontainer/workspace_publish.go
+++ b/internal/applecontainer/workspace_publish.go
@@ -17,10 +17,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const (
-	workspaceStageAttempts = 16
-	workspaceStagingName   = ".materialization-staging"
-)
+const workspaceStageAttempts, workspaceStagingName = 16, ".materialization-staging"
 
 var errWorkspaceMaterializationUnsupported = errors.New("secure workspace materialization is unsupported on this platform")
 
@@ -443,9 +440,11 @@ func verifyWorkspaceSource(sourceFD int, source workspaceSnapshot, stateFD int, 
 }
 
 func verifyWorkspacePublishAnchors(stateRoot string, state workspaceSnapshot, stateFD int, chain []string, targetID workspaceObjectID, targetFD int, finalParentID workspaceObjectID, finalParentFD int, stagingParentID workspaceObjectID, stagingParentFD int, ops workspaceOps) error {
-	var visible unix.Stat_t
-	if err := ops.stat(stateRoot, &visible); err != nil || snapshotObjectID(workspaceSnapshotFromUnix(visible)) != snapshotObjectID(state) {
-		return fmt.Errorf("state root identity changed")
+	var opened, visible unix.Stat_t
+	openedErr, visibleErr := ops.fstat(stateFD, &opened), ops.stat(stateRoot, &visible)
+	openedState, visibleState, stateID := workspaceSnapshotFromUnix(opened), workspaceSnapshotFromUnix(visible), snapshotObjectID(state)
+	if openedErr != nil || visibleErr != nil || snapshotObjectID(openedState) != stateID || snapshotObjectID(visibleState) != stateID || openedState.uid != uint32(os.Geteuid()) || visibleState.uid != uint32(os.Geteuid()) || openedState.mode&0o7022 != 0 || visibleState.mode&0o7022 != 0 {
+		return fmt.Errorf("state root identity or security policy changed")
 	}
 	openedTarget, openedTargetID, err := openManagedWorkspaceChain(stateFD, chain, false, ops)
 	if err != nil {

--- a/internal/applecontainer/workspace_publish.go
+++ b/internal/applecontainer/workspace_publish.go
@@ -72,7 +72,7 @@ func publishWorkspaceMaterialization(stateRoot string, targetChain []string, fin
 		return WorkspaceManifest{}, err
 	}
 	defer unix.Close(targetFD)
-	finalParentFD, finalParentID, err := openManagedWorkspaceDirectory(targetFD, "materializations", 0o700, false, true, ops.workspace)
+	finalParentFD, finalParentID, err := openManagedWorkspaceDirectory(targetFD, "materializations", 0o700, true, true, ops.workspace)
 	if err != nil {
 		return WorkspaceManifest{}, err
 	}
@@ -139,14 +139,10 @@ func publishWorkspaceMaterialization(stateRoot string, targetChain []string, fin
 	if err := ops.workspace.fchmod(stageFD, 0o755); err != nil {
 		return WorkspaceManifest{}, fmt.Errorf("set final materialization mode: %w", err)
 	}
-	if err := ops.workspace.fsync(stageFD); err != nil {
-		return WorkspaceManifest{}, fmt.Errorf("sync private workspace stage: %w", err)
-	}
-	if err := ops.workspace.fsync(stagingParentFD); err != nil {
-		return WorkspaceManifest{}, fmt.Errorf("sync staging parent: %w", err)
-	}
-	if err := ops.workspace.fsync(finalParentFD); err != nil {
-		return WorkspaceManifest{}, fmt.Errorf("sync materializations parent: %w", err)
+	for index, fd := range []int{stageFD, stagingParentFD, finalParentFD} {
+		if err := ops.workspace.fsync(fd); err != nil {
+			return WorkspaceManifest{}, fmt.Errorf("sync %s: %w", []string{"private workspace stage", "staging parent", "materializations parent"}[index], err)
+		}
 	}
 	if err := verifyWorkspaceSource(sourceFD, sourceSnapshot, stateFD, stateSnapshot, ops.workspace); err != nil {
 		return WorkspaceManifest{}, err
@@ -174,11 +170,10 @@ func publishWorkspaceMaterialization(stateRoot string, targetChain []string, fin
 	} else {
 		return WorkspaceManifest{}, fmt.Errorf("publish materialization %q without replacement: %w", finalName, errors.Join(publishErr, stageBindErr, finalBindErr))
 	}
-	if err := ops.workspace.fsync(stagingParentFD); err != nil {
-		return WorkspaceManifest{}, fmt.Errorf("materialization was published, but staging parent sync failed: %w", err)
-	}
-	if err := ops.workspace.fsync(finalParentFD); err != nil {
-		return WorkspaceManifest{}, fmt.Errorf("materialization was published, but materializations parent sync failed: %w", err)
+	for index, fd := range []int{stagingParentFD, finalParentFD} {
+		if err := ops.workspace.fsync(fd); err != nil {
+			return WorkspaceManifest{}, fmt.Errorf("materialization was published, but %s sync failed: %w", []string{"staging parent", "materializations parent"}[index], err)
+		}
 	}
 	if err := verifyWorkspacePublishAnchors(stateRoot, stateSnapshot, stateFD, targetChain, targetID, targetFD, finalParentID, finalParentFD, stagingParentID, stagingParentFD, ops.workspace); err != nil {
 		return WorkspaceManifest{}, fmt.Errorf("materialization was published, but its anchor changed: %w", err)
@@ -289,6 +284,11 @@ func openManagedWorkspaceDirectory(parentFD int, name string, createMode uint32,
 	}
 	if requirePrivate && opened.mode&0o7777 != 0o700 {
 		return -1, workspaceObjectID{}, closeFDError(fd, "managed directory %q must have mode 0700", name)
+	}
+	if create {
+		if err := ops.fsync(parentFD); err != nil {
+			return -1, workspaceObjectID{}, closeFDError(fd, "sync managed directory parent for %q: %w", name, err)
+		}
 	}
 	return fd, snapshotObjectID(opened), nil
 }

--- a/internal/applecontainer/workspace_publish.go
+++ b/internal/applecontainer/workspace_publish.go
@@ -269,21 +269,18 @@ func openManagedWorkspaceDirectory(parentFD int, name string, createMode uint32,
 	if err != nil {
 		return -1, workspaceObjectID{}, fmt.Errorf("open managed directory %q: %w", name, err)
 	}
-	opened, err := verifyWorkspaceDirectoryNameAt(parentFD, name, fd, snapshotObjectID(want), ops)
+	opened, err := verifyWorkspaceDirectoryNameAt(parentFD, name, fd, snapshotObjectID(want), requirePrivate && !created, ops)
 	if err != nil {
-		return -1, workspaceObjectID{}, closeFDError(fd, "managed directory %q changed while opening", name)
+		return -1, workspaceObjectID{}, closeFDError(fd, "managed directory %q changed while opening: %w", name, err)
 	}
 	if created {
 		if err := ops.fchmod(fd, createMode); err != nil {
 			return -1, workspaceObjectID{}, closeFDError(fd, "set managed directory %q mode: %w", name, err)
 		}
-		opened, err = verifyWorkspaceDirectoryNameAt(parentFD, name, fd, snapshotObjectID(want), ops)
+		opened, err = verifyWorkspaceDirectoryNameAt(parentFD, name, fd, snapshotObjectID(want), requirePrivate, ops)
 		if err != nil || opened.mode&0o7777 != createMode {
 			return -1, workspaceObjectID{}, closeFDError(fd, "managed directory %q changed after mode update", name)
 		}
-	}
-	if requirePrivate && opened.mode&0o7777 != 0o700 {
-		return -1, workspaceObjectID{}, closeFDError(fd, "managed directory %q must have mode 0700", name)
 	}
 	if create {
 		if err := ops.fsync(parentFD); err != nil {
@@ -406,7 +403,7 @@ func workspaceNameBindsFD(parentFD int, name string, fd int, ops workspaceOps) (
 	}
 	return workspaceSnapshotFromUnix(opened) == workspaceSnapshotFromUnix(named), nil
 }
-func verifyWorkspaceDirectoryNameAt(parentFD int, name string, fd int, expected workspaceObjectID, ops workspaceOps) (workspaceSnapshot, error) {
+func verifyWorkspaceDirectoryNameAt(parentFD int, name string, fd int, expected workspaceObjectID, requirePrivate bool, ops workspaceOps) (workspaceSnapshot, error) {
 	var opened, named unix.Stat_t
 	if err := ops.fstat(fd, &opened); err != nil {
 		return workspaceSnapshot{}, err
@@ -416,6 +413,9 @@ func verifyWorkspaceDirectoryNameAt(parentFD int, name string, fd int, expected 
 	namedSnapshot := workspaceSnapshotFromUnix(named)
 	if namedErr != nil || snapshotObjectID(snapshot) != expected || snapshotObjectID(namedSnapshot) != expected || snapshot.uid != uint32(os.Geteuid()) || namedSnapshot.uid != uint32(os.Geteuid()) || snapshot.mode&0o7022 != 0 || namedSnapshot.mode&0o7022 != 0 {
 		return workspaceSnapshot{}, fmt.Errorf("managed directory %q changed", name)
+	}
+	if requirePrivate && (snapshot.mode&0o7777 != 0o700 || namedSnapshot.mode&0o7777 != 0o700) {
+		return workspaceSnapshot{}, fmt.Errorf("managed directory %q must have mode 0700", name)
 	}
 	return snapshot, nil
 }
@@ -441,10 +441,10 @@ func verifyWorkspacePublishAnchors(stateRoot string, state workspaceSnapshot, st
 	if openedTargetID != targetID {
 		return fmt.Errorf("target directory identity changed")
 	}
-	if _, err := verifyWorkspaceDirectoryNameAt(targetFD, "materializations", finalParentFD, finalParentID, ops); err != nil {
+	if _, err := verifyWorkspaceDirectoryNameAt(targetFD, "materializations", finalParentFD, finalParentID, true, ops); err != nil {
 		return err
 	}
-	if _, err := verifyWorkspaceDirectoryNameAt(targetFD, workspaceStagingName, stagingParentFD, stagingParentID, ops); err != nil {
+	if _, err := verifyWorkspaceDirectoryNameAt(targetFD, workspaceStagingName, stagingParentFD, stagingParentID, true, ops); err != nil {
 		return err
 	}
 	return nil

--- a/internal/applecontainer/workspace_publish.go
+++ b/internal/applecontainer/workspace_publish.go
@@ -25,17 +25,15 @@ type workspaceMaterializeOps struct {
 	workspace workspaceOps
 	random    func([]byte) (int, error)
 	write     func(int, []byte) (int, error)
-	fsync     func(int) error
 	publish   func(int, string, int, string) error
 	manifest  int64
 }
 
 func systemWorkspaceMaterializeOps() workspaceMaterializeOps {
-	return workspaceMaterializeOps{systemWorkspaceOps(), rand.Read, unix.Write, unix.Fsync, workspacePublish, workspaceManifestMaxBytes}
+	return workspaceMaterializeOps{systemWorkspaceOps(), rand.Read, unix.Write, workspacePublish, workspaceManifestMaxBytes}
 }
 
-// publishWorkspaceMaterialization creates one materialization without replacement.
-// StateRoot must be a pre-existing, trusted, caller-owned directory.
+// publishWorkspaceMaterialization creates one materialization without replacement; StateRoot must be a pre-existing, trusted, caller-owned directory.
 func publishWorkspaceMaterialization(stateRoot string, targetChain []string, finalName, workspaceName, manifestName, sourceRoot string, excluded []string, manifest WorkspaceManifest, ops workspaceMaterializeOps) (_ WorkspaceManifest, retErr error) {
 	if !workspaceMaterializationSupported || !workspaceCopySupported {
 		return WorkspaceManifest{}, errWorkspaceMaterializationUnsupported
@@ -141,13 +139,13 @@ func publishWorkspaceMaterialization(stateRoot string, targetChain []string, fin
 	if err := ops.workspace.fchmod(stageFD, 0o755); err != nil {
 		return WorkspaceManifest{}, fmt.Errorf("set final materialization mode: %w", err)
 	}
-	if err := ops.fsync(stageFD); err != nil {
+	if err := ops.workspace.fsync(stageFD); err != nil {
 		return WorkspaceManifest{}, fmt.Errorf("sync private workspace stage: %w", err)
 	}
-	if err := ops.fsync(stagingParentFD); err != nil {
+	if err := ops.workspace.fsync(stagingParentFD); err != nil {
 		return WorkspaceManifest{}, fmt.Errorf("sync staging parent: %w", err)
 	}
-	if err := ops.fsync(finalParentFD); err != nil {
+	if err := ops.workspace.fsync(finalParentFD); err != nil {
 		return WorkspaceManifest{}, fmt.Errorf("sync materializations parent: %w", err)
 	}
 	if err := verifyWorkspaceSource(sourceFD, sourceSnapshot, stateFD, stateSnapshot, ops.workspace); err != nil {
@@ -176,10 +174,10 @@ func publishWorkspaceMaterialization(stateRoot string, targetChain []string, fin
 	} else {
 		return WorkspaceManifest{}, fmt.Errorf("publish materialization %q without replacement: %w", finalName, errors.Join(publishErr, stageBindErr, finalBindErr))
 	}
-	if err := ops.fsync(stagingParentFD); err != nil {
+	if err := ops.workspace.fsync(stagingParentFD); err != nil {
 		return WorkspaceManifest{}, fmt.Errorf("materialization was published, but staging parent sync failed: %w", err)
 	}
-	if err := ops.fsync(finalParentFD); err != nil {
+	if err := ops.workspace.fsync(finalParentFD); err != nil {
 		return WorkspaceManifest{}, fmt.Errorf("materialization was published, but materializations parent sync failed: %w", err)
 	}
 	if err := verifyWorkspacePublishAnchors(stateRoot, stateSnapshot, stateFD, targetChain, targetID, targetFD, finalParentID, finalParentFD, stagingParentID, stagingParentFD, ops.workspace); err != nil {
@@ -190,7 +188,6 @@ func publishWorkspaceMaterialization(stateRoot string, targetChain []string, fin
 	}
 	return manifest, nil
 }
-
 func rejectWorkspaceDescriptorOverlap(stateFD int, state workspaceSnapshot, sourceFD int, source workspaceSnapshot, ops workspaceOps) error {
 	stateID, sourceID := workspaceObjectID{state.dev, state.ino}, workspaceObjectID{source.dev, source.ino}
 	stateWithinSource, err := workspaceDescriptorWithin(sourceID, stateFD, ops)
@@ -206,7 +203,6 @@ func rejectWorkspaceDescriptorOverlap(stateFD int, state workspaceSnapshot, sour
 	}
 	return nil
 }
-
 func workspaceDescriptorWithin(ancestor workspaceObjectID, childFD int, ops workspaceOps) (bool, error) {
 	current, err := ops.openat(childFD, ".", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
 	if err != nil {
@@ -241,7 +237,6 @@ func workspaceDescriptorWithin(ancestor workspaceObjectID, childFD int, ops work
 	}
 	return false, fmt.Errorf("filesystem ancestry exceeds %d components", workspaceMaxPathBytes)
 }
-
 func openManagedWorkspaceChain(stateFD int, names []string, create bool, ops workspaceOps) (int, workspaceObjectID, error) {
 	current, err := ops.openat(stateFD, ".", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
 	if err != nil {
@@ -258,7 +253,6 @@ func openManagedWorkspaceChain(stateFD int, names []string, create bool, ops wor
 	}
 	return current, id, nil
 }
-
 func openManagedWorkspaceDirectory(parentFD int, name string, createMode uint32, requirePrivate, create bool, ops workspaceOps) (int, workspaceObjectID, error) {
 	created := false
 	if create {
@@ -298,7 +292,6 @@ func openManagedWorkspaceDirectory(parentFD int, name string, createMode uint32,
 	}
 	return fd, snapshotObjectID(opened), nil
 }
-
 func createPrivateWorkspaceStage(parentFD int, ops workspaceMaterializeOps) (string, int, error) {
 	for attempt := 0; attempt < workspaceStageAttempts; attempt++ {
 		var token [16]byte
@@ -327,7 +320,6 @@ func createPrivateWorkspaceStage(parentFD int, ops workspaceMaterializeOps) (str
 	}
 	return "", -1, fmt.Errorf("could not allocate a private workspace stage")
 }
-
 func marshalManifestBytes(value any) ([]byte, error) {
 	switch value.(type) {
 	case WorkspaceManifest, *WorkspaceManifest:
@@ -339,7 +331,6 @@ func marshalManifestBytes(value any) ([]byte, error) {
 	}
 	return append(content, '\n'), nil
 }
-
 func writeWorkspaceManifestAt(stageFD int, name string, content []byte, ops workspaceMaterializeOps) error {
 	fd, err := ops.workspace.openat(stageFD, name, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0o600)
 	if err != nil {
@@ -354,7 +345,7 @@ func writeWorkspaceManifestAt(stageFD int, name string, content []byte, ops work
 	} else if n != len(content) {
 		return io.ErrShortWrite
 	}
-	if err := ops.fsync(fd); err != nil {
+	if err := ops.workspace.fsync(fd); err != nil {
 		return err
 	}
 	snapshot, err := verifyWorkspaceNameAt(stageFD, name, fd, ops.workspace)
@@ -363,7 +354,6 @@ func writeWorkspaceManifestAt(stageFD int, name string, content []byte, ops work
 	}
 	return nil
 }
-
 func validateWorkspaceManifestAt(stageFD int, name string, want []byte, ops workspaceMaterializeOps) error {
 	fd, err := ops.workspace.openat(stageFD, name, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
 	if err != nil {
@@ -392,7 +382,6 @@ func validateWorkspaceManifestAt(stageFD int, name string, want []byte, ops work
 	}
 	return nil
 }
-
 func requireWorkspaceStageEntries(stageFD int, workspaceName, manifestName string) error {
 	names, err := workspaceDirectoryNames(stageFD, 3)
 	if err != nil {
@@ -403,7 +392,6 @@ func requireWorkspaceStageEntries(stageFD int, workspaceName, manifestName strin
 	}
 	return nil
 }
-
 func workspaceNameBindsFD(parentFD int, name string, fd int, ops workspaceOps) (bool, error) {
 	var opened, named unix.Stat_t
 	if err := ops.fstat(fd, &opened); err != nil {
@@ -418,7 +406,6 @@ func workspaceNameBindsFD(parentFD int, name string, fd int, ops workspaceOps) (
 	}
 	return workspaceSnapshotFromUnix(opened) == workspaceSnapshotFromUnix(named), nil
 }
-
 func verifyWorkspaceDirectoryNameAt(parentFD int, name string, fd int, expected workspaceObjectID, ops workspaceOps) (workspaceSnapshot, error) {
 	var opened, named unix.Stat_t
 	if err := ops.fstat(fd, &opened); err != nil {
@@ -432,7 +419,6 @@ func verifyWorkspaceDirectoryNameAt(parentFD int, name string, fd int, expected 
 	}
 	return snapshot, nil
 }
-
 func verifyWorkspaceSource(sourceFD int, source workspaceSnapshot, stateFD int, state workspaceSnapshot, ops workspaceOps) error {
 	var current unix.Stat_t
 	if err := ops.fstat(sourceFD, &current); err != nil || workspaceSnapshotFromUnix(current) != source {
@@ -440,7 +426,6 @@ func verifyWorkspaceSource(sourceFD int, source workspaceSnapshot, stateFD int, 
 	}
 	return rejectWorkspaceDescriptorOverlap(stateFD, state, sourceFD, source, ops)
 }
-
 func verifyWorkspacePublishAnchors(stateRoot string, state workspaceSnapshot, stateFD int, chain []string, targetID workspaceObjectID, targetFD int, finalParentID workspaceObjectID, finalParentFD int, stagingParentID workspaceObjectID, stagingParentFD int, ops workspaceOps) error {
 	var opened, visible unix.Stat_t
 	openedErr, visibleErr := ops.fstat(stateFD, &opened), ops.stat(stateRoot, &visible)
@@ -464,5 +449,4 @@ func verifyWorkspacePublishAnchors(stateRoot string, state workspaceSnapshot, st
 	}
 	return nil
 }
-
 func snapshotObjectID(s workspaceSnapshot) workspaceObjectID { return workspaceObjectID{s.dev, s.ino} }

--- a/internal/applecontainer/workspace_publish.go
+++ b/internal/applecontainer/workspace_publish.go
@@ -280,15 +280,15 @@ func openManagedWorkspaceDirectory(parentFD int, name string, createMode uint32,
 	if err != nil {
 		return -1, workspaceObjectID{}, fmt.Errorf("open managed directory %q: %w", name, err)
 	}
-	opened, err := verifyWorkspaceDirectoryNameAt(parentFD, name, fd, ops)
-	if err != nil || snapshotObjectID(opened) != snapshotObjectID(want) {
+	opened, err := verifyWorkspaceDirectoryNameAt(parentFD, name, fd, snapshotObjectID(want), ops)
+	if err != nil {
 		return -1, workspaceObjectID{}, closeFDError(fd, "managed directory %q changed while opening", name)
 	}
 	if created {
 		if err := ops.fchmod(fd, createMode); err != nil {
 			return -1, workspaceObjectID{}, closeFDError(fd, "set managed directory %q mode: %w", name, err)
 		}
-		opened, err = verifyWorkspaceDirectoryNameAt(parentFD, name, fd, ops)
+		opened, err = verifyWorkspaceDirectoryNameAt(parentFD, name, fd, snapshotObjectID(want), ops)
 		if err != nil || opened.mode&0o7777 != createMode {
 			return -1, workspaceObjectID{}, closeFDError(fd, "managed directory %q changed after mode update", name)
 		}
@@ -419,13 +419,15 @@ func workspaceNameBindsFD(parentFD int, name string, fd int, ops workspaceOps) (
 	return workspaceSnapshotFromUnix(opened) == workspaceSnapshotFromUnix(named), nil
 }
 
-func verifyWorkspaceDirectoryNameAt(parentFD int, name string, fd int, ops workspaceOps) (workspaceSnapshot, error) {
+func verifyWorkspaceDirectoryNameAt(parentFD int, name string, fd int, expected workspaceObjectID, ops workspaceOps) (workspaceSnapshot, error) {
 	var opened, named unix.Stat_t
 	if err := ops.fstat(fd, &opened); err != nil {
 		return workspaceSnapshot{}, err
 	}
 	snapshot := workspaceSnapshotFromUnix(opened)
-	if err := ops.fstatat(parentFD, name, &named, unix.AT_SYMLINK_NOFOLLOW); err != nil || snapshotObjectID(workspaceSnapshotFromUnix(named)) != snapshotObjectID(snapshot) {
+	namedErr := ops.fstatat(parentFD, name, &named, unix.AT_SYMLINK_NOFOLLOW)
+	namedSnapshot := workspaceSnapshotFromUnix(named)
+	if namedErr != nil || snapshotObjectID(snapshot) != expected || snapshotObjectID(namedSnapshot) != expected || snapshot.uid != uint32(os.Geteuid()) || namedSnapshot.uid != uint32(os.Geteuid()) || snapshot.mode&0o7022 != 0 || namedSnapshot.mode&0o7022 != 0 {
 		return workspaceSnapshot{}, fmt.Errorf("managed directory %q changed", name)
 	}
 	return snapshot, nil
@@ -454,15 +456,11 @@ func verifyWorkspacePublishAnchors(stateRoot string, state workspaceSnapshot, st
 	if openedTargetID != targetID {
 		return fmt.Errorf("target directory identity changed")
 	}
-	for _, check := range []struct {
-		parent int
-		name   string
-		fd     int
-		id     workspaceObjectID
-	}{{targetFD, "materializations", finalParentFD, finalParentID}, {targetFD, workspaceStagingName, stagingParentFD, stagingParentID}} {
-		if opened, err := verifyWorkspaceDirectoryNameAt(check.parent, check.name, check.fd, ops); err != nil || snapshotObjectID(opened) != check.id {
-			return fmt.Errorf("managed directory %q changed", check.name)
-		}
+	if _, err := verifyWorkspaceDirectoryNameAt(targetFD, "materializations", finalParentFD, finalParentID, ops); err != nil {
+		return err
+	}
+	if _, err := verifyWorkspaceDirectoryNameAt(targetFD, workspaceStagingName, stagingParentFD, stagingParentID, ops); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/applecontainer/workspace_publish_darwin.go
+++ b/internal/applecontainer/workspace_publish_darwin.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin && !ios
+
+package applecontainer
+
+import "golang.org/x/sys/unix"
+
+const workspaceMaterializationSupported = true
+
+func workspacePublish(fromFD int, from string, toFD int, to string) error {
+	return unix.RenameatxNp(fromFD, from, toFD, to, unix.RENAME_EXCL)
+}

--- a/internal/applecontainer/workspace_publish_linux.go
+++ b/internal/applecontainer/workspace_publish_linux.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux && !android
+
+package applecontainer
+
+import "golang.org/x/sys/unix"
+
+const workspaceMaterializationSupported = true
+
+func workspacePublish(fromFD int, from string, toFD int, to string) error {
+	return unix.Renameat2(fromFD, from, toFD, to, unix.RENAME_NOREPLACE)
+}

--- a/internal/applecontainer/workspace_publish_other.go
+++ b/internal/applecontainer/workspace_publish_other.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build (!darwin && !linux) || ios || android
+
+package applecontainer
+
+const workspaceMaterializationSupported = false
+
+func workspacePublish(int, string, int, string) error { return errWorkspaceMaterializationUnsupported }

--- a/internal/applecontainer/workspace_publish_test.go
+++ b/internal/applecontainer/workspace_publish_test.go
@@ -32,12 +32,7 @@ func newWorkspacePublishFixture(t *testing.T) workspacePublishFixture {
 	state, source := t.TempDir(), t.TempDir()
 	mustNil(t, os.WriteFile(filepath.Join(source, "file"), []byte("original"), 0o600))
 	root := targetRoot(state, target.Contract.TargetKind, target.Contract.TargetProvider, "tid")
-	return workspacePublishFixture{
-		target:      target,
-		request:     MaterializeRequest{StateRoot: state, TargetID: "tid", MaterializationID: "mid", SourceWorkspace: source},
-		finalParent: filepath.Join(root, "materializations"),
-		final:       filepath.Join(root, "materializations", "mid"), stageParent: filepath.Join(root, workspaceStagingName),
-	}
+	return workspacePublishFixture{target, MaterializeRequest{StateRoot: state, TargetID: "tid", MaterializationID: "mid", SourceWorkspace: source}, filepath.Join(root, "materializations"), filepath.Join(root, "materializations", "mid"), filepath.Join(root, workspaceStagingName)}
 }
 
 func workspaceTestMaterializeOps() workspaceMaterializeOps {
@@ -54,6 +49,23 @@ func workspacePathMatchesFD(path string, fd int) bool {
 	return unix.Stat(path, &named) == nil && unix.Fstat(fd, &opened) == nil && named.Dev == opened.Dev && named.Ino == opened.Ino
 }
 
+func TestWorkspaceManagedDirectoryPolicyRequiresBothViews(t *testing.T) {
+	for _, kind := range []string{"secure", "opened-uid", "named-uid", "opened-write", "named-special"} {
+		base := unix.Stat_t{Dev: 1, Ino: 2, Mode: unix.S_IFDIR | 0o700, Uid: uint32(os.Geteuid())}
+		opened, named := base, base
+		changed := map[bool]*unix.Stat_t{true: &opened, false: &named}[strings.HasPrefix(kind, "opened")]
+		changed.Uid += map[bool]uint32{true: 1}[strings.HasSuffix(kind, "uid")]
+		changed.Mode |= map[string]unix.Stat_t{"opened-write": {Mode: 0o022}, "named-special": {Mode: 0o7000}}[kind].Mode
+		ops := systemWorkspaceOps()
+		ops.fstat = func(_ int, stat *unix.Stat_t) error { *stat = opened; return nil }
+		ops.fstatat = func(_ int, _ string, stat *unix.Stat_t, _ int) error { *stat = named; return nil }
+		_, err := verifyWorkspaceDirectoryNameAt(1, "materializations", 2, workspaceObjectID{1, 2}, ops)
+		if rejected := err != nil; rejected != (kind != "secure") {
+			t.Fatalf("%s rejected=%t error=%v", kind, rejected, err)
+		}
+	}
+}
+
 func TestWorkspacePublicationSuccessAndManifestFormat(t *testing.T) {
 	fixture := newWorkspacePublishFixture(t)
 	mustNil(t, os.Remove(filepath.Join(fixture.request.SourceWorkspace, "file")))
@@ -67,31 +79,22 @@ func TestWorkspacePublicationSuccessAndManifestFormat(t *testing.T) {
 	}
 	result, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
 	mustNil(t, err)
-	if !manifestFlags {
-		t.Fatal("manifest create flags are incomplete")
-	}
 	content, err := os.ReadFile(result.ManifestPath)
 	mustNil(t, err)
 	want, err := marshalManifestBytes(result.Manifest)
 	mustNil(t, err)
-	if result.Manifest.Entries == nil || !bytes.Contains(content, []byte(`"entries":[]`)) || !bytes.Equal(content, want) || bytes.Contains(content, []byte("\n  \"")) {
-		t.Fatalf("workspace manifest is not exact compact JSON: %q", content)
+	if !manifestFlags || result.Manifest.Entries == nil || !bytes.Contains(content, []byte(`"entries":[]`)) || !bytes.Equal(content, want) || bytes.Contains(content, []byte("\n  \"")) {
+		t.Fatalf("workspace manifest or create flags are invalid: flags=%t content=%q", manifestFlags, content)
 	}
-	pointer, err := marshalManifestBytes(&result.Manifest)
-	mustNil(t, err)
-	if !bytes.Equal(pointer, want) {
-		t.Fatal("workspace manifest pointer uses a different format")
+	pointer, pointerErr := marshalManifestBytes(&result.Manifest)
+	bootstrap, bootstrapErr := marshalManifestBytes(BootstrapManifest{Version: 1, BootstrapID: "bid"})
+	if pointerErr != nil || bootstrapErr != nil || !bytes.Equal(pointer, want) || !bytes.Contains(bootstrap, []byte("\n  \"")) {
+		t.Fatalf("manifest encoding parity: pointer=%q bootstrap=%q error=%v", pointer, bootstrap, errors.Join(pointerErr, bootstrapErr))
 	}
-	bootstrap, err := marshalManifestBytes(BootstrapManifest{Version: 1, BootstrapID: "bid"})
-	mustNil(t, err)
-	if !bytes.Contains(bootstrap, []byte("\n  \"")) {
-		t.Fatalf("bootstrap manifest lost indented format: %q", bootstrap)
-	}
-	if info, err := os.Stat(result.MaterializationRoot); err != nil || info.Mode().Perm() != 0o755 {
-		t.Fatalf("final materialization mode: info=%v error=%v", info, err)
-	}
-	if names, err := os.ReadDir(fixture.stageParent); err != nil || len(names) != 0 {
-		t.Fatalf("successful publication left a stage: names=%v error=%v", names, err)
+	info, statErr := os.Stat(result.MaterializationRoot)
+	names, readErr := os.ReadDir(fixture.stageParent)
+	if statErr != nil || info.Mode().Perm() != 0o755 || readErr != nil || len(names) != 0 {
+		t.Fatalf("successful publication state: final=%v/%v stages=%v/%v", info, statErr, names, readErr)
 	}
 }
 
@@ -319,7 +322,7 @@ func TestWorkspacePublicationRetriesStageCollision(t *testing.T) {
 }
 
 func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
-	for _, kind := range []string{"state-root", "state-policy", "managed-parent", "stage-name", "final-name", "final-late"} {
+	for _, kind := range []string{"state-root", "state-policy", "managed-parent", "parent-final-pre", "parent-stage-pre", "parent-final-post", "parent-stage-post", "stage-name", "final-name", "final-late"} {
 		t.Run(kind, func(t *testing.T) {
 			fixture := newWorkspacePublishFixture(t)
 			ops, reached, publishCalled := workspaceTestMaterializeOps(), false, false
@@ -338,7 +341,7 @@ func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 					}
 					return original(fd, name, mode)
 				}
-			case "state-policy", "managed-parent":
+			case "state-policy", "managed-parent", "parent-final-pre", "parent-stage-pre":
 				original := ops.fsync
 				ops.fsync = func(fd int) error {
 					err := original(fd)
@@ -347,6 +350,11 @@ func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 						reached = true
 						if kind == "state-policy" {
 							mustNil(t, os.Chmod(fixture.request.StateRoot, 0o777))
+							return err
+						}
+						if strings.HasPrefix(kind, "parent-") {
+							parent := map[bool]string{true: fixture.stageParent, false: fixture.finalParent}[strings.Contains(kind, "stage")]
+							mustNil(t, os.Chmod(parent, 0o777))
 							return err
 						}
 						mustNil(t, errors.Join(os.Rename(fixture.finalParent, fixture.finalParent+".moved"), os.Mkdir(fixture.finalParent, 0o700)))
@@ -364,14 +372,18 @@ func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 					}
 					return err
 				}
-			case "final-name":
+			case "final-name", "parent-final-post", "parent-stage-post":
 				original := ops.publish
 				ops.publish = func(fromFD int, from string, toFD int, to string) error {
 					if err := original(fromFD, from, toFD, to); err != nil {
 						return err
 					}
 					reached = true
-					mustNil(t, errors.Join(os.Rename(fixture.final, fixture.final+".moved"), os.Mkdir(fixture.final, 0o700)))
+					if kind == "final-name" {
+						mustNil(t, errors.Join(os.Rename(fixture.final, fixture.final+".moved"), os.Mkdir(fixture.final, 0o700)))
+					} else {
+						mustNil(t, os.Chmod(map[bool]string{true: fixture.stageParent, false: fixture.finalParent}[strings.Contains(kind, "stage")], 0o777))
+					}
 					return nil
 				}
 			case "final-late":
@@ -395,8 +407,8 @@ func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 			if err == nil || !reached {
 				t.Fatalf("%s race: reached=%t error=%v", kind, reached, err)
 			}
-			if !strings.HasPrefix(kind, "final-") && publishCalled {
-				t.Fatalf("%s race reached publication", kind)
+			if wantPublish := strings.HasPrefix(kind, "final-") || strings.HasSuffix(kind, "-post"); publishCalled != wantPublish {
+				t.Fatalf("%s race publication=%t, want %t", kind, publishCalled, wantPublish)
 			}
 			if kind == "stage-name" {
 				if info, statErr := os.Stat(filepath.Join(fixture.stageParent, workspaceTestStage+".moved")); statErr != nil || info.Mode().Perm() != 0o700 {
@@ -404,18 +416,12 @@ func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 				}
 			}
 			if strings.HasPrefix(kind, "final-") {
-				wantError, wantMode := "ambiguous", os.FileMode(0o700)
-				if kind == "final-late" {
-					wantError, wantMode = "final binding changed", 0o755
-				}
-				if !strings.Contains(err.Error(), wantError) {
-					t.Fatalf("post-publish error is not distinct: %v", err)
-				}
-				if info, statErr := os.Stat(fixture.final); statErr != nil || info.Mode().Perm() != 0o700 {
-					t.Fatalf("replacement final was chmodded: info=%v error=%v", info, statErr)
-				}
-				if info, statErr := os.Stat(fixture.final + ".moved"); statErr != nil || info.Mode().Perm() != wantMode {
-					t.Fatalf("ambiguous owned object mode: info=%v error=%v", info, statErr)
+				wantError := map[bool]string{true: "final binding changed", false: "ambiguous"}[kind == "final-late"]
+				wantMode := map[bool]os.FileMode{true: 0o755, false: 0o700}[kind == "final-late"]
+				finalInfo, finalErr := os.Stat(fixture.final)
+				movedInfo, movedErr := os.Stat(fixture.final + ".moved")
+				if !strings.Contains(err.Error(), wantError) || finalErr != nil || movedErr != nil || finalInfo.Mode().Perm() != 0o700 || movedInfo.Mode().Perm() != wantMode {
+					t.Fatalf("post-publish state: final=%v/%v moved=%v/%v error=%v", finalInfo, finalErr, movedInfo, movedErr, err)
 				}
 			}
 		})
@@ -468,8 +474,7 @@ func TestWorkspacePublicationManagedOpenDoesNotFollowSwap(t *testing.T) {
 
 func TestWorkspacePublicationConcurrentCreateOnce(t *testing.T) {
 	fixture := newWorkspacePublishFixture(t)
-	start := make(chan struct{})
-	errs := make(chan error, 2)
+	start, errs := make(chan struct{}), make(chan error, 2)
 	for range 2 {
 		go func() {
 			<-start
@@ -496,18 +501,16 @@ func TestWorkspacePublicationConcurrentCreateOnce(t *testing.T) {
 
 func TestWorkspaceManifestLimitExactAndOver(t *testing.T) {
 	for _, delta := range []int64{0, -1} {
-		t.Run(map[int64]string{0: "exact", -1: "over"}[delta], func(t *testing.T) {
-			fixture := newWorkspacePublishFixture(t)
-			mustNil(t, os.Remove(filepath.Join(fixture.request.SourceWorkspace, "file")))
-			manifest := WorkspaceManifest{Version: 1, TargetKind: fixture.target.Contract.TargetKind, TargetProvider: fixture.target.Contract.TargetProvider, TargetID: "tid", WorkspaceTransport: fixture.target.Contract.WorkspaceTransport, SourceWorkspace: fixture.request.SourceWorkspace, MaterializationID: "mid", MaterializedWorkspace: filepath.Join(fixture.final, fixture.target.Contract.WorkspaceMaterialization.WorkspaceDir), ExcludedPaths: append([]string(nil), fixture.target.Contract.WorkspaceMaterialization.ExcludedPaths...), Entries: []WorkspaceEntry{}}
-			content, err := json.Marshal(manifest)
-			mustNil(t, err)
-			ops := workspaceTestMaterializeOps()
-			ops.manifest = int64(len(content)+1) + delta
-			_, err = fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
-			if (delta == 0) != (err == nil) {
-				t.Fatalf("manifest limit delta %d: %v", delta, err)
-			}
-		})
+		fixture := newWorkspacePublishFixture(t)
+		mustNil(t, os.Remove(filepath.Join(fixture.request.SourceWorkspace, "file")))
+		manifest := WorkspaceManifest{Version: 1, TargetKind: fixture.target.Contract.TargetKind, TargetProvider: fixture.target.Contract.TargetProvider, TargetID: "tid", WorkspaceTransport: fixture.target.Contract.WorkspaceTransport, SourceWorkspace: fixture.request.SourceWorkspace, MaterializationID: "mid", MaterializedWorkspace: filepath.Join(fixture.final, fixture.target.Contract.WorkspaceMaterialization.WorkspaceDir), ExcludedPaths: append([]string(nil), fixture.target.Contract.WorkspaceMaterialization.ExcludedPaths...), Entries: []WorkspaceEntry{}}
+		content, err := json.Marshal(manifest)
+		mustNil(t, err)
+		ops := workspaceTestMaterializeOps()
+		ops.manifest = int64(len(content)+1) + delta
+		_, err = fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+		if (delta == 0) != (err == nil) {
+			t.Fatalf("manifest limit delta %d: %v", delta, err)
+		}
 	}
 }

--- a/internal/applecontainer/workspace_publish_test.go
+++ b/internal/applecontainer/workspace_publish_test.go
@@ -35,18 +35,20 @@ func newWorkspacePublishFixture(t *testing.T) workspacePublishFixture {
 	return workspacePublishFixture{target, MaterializeRequest{StateRoot: state, TargetID: "tid", MaterializationID: "mid", SourceWorkspace: source}, filepath.Join(root, "materializations"), filepath.Join(root, "materializations", "mid"), filepath.Join(root, workspaceStagingName)}
 }
 func workspaceTestMaterializeOps() workspaceMaterializeOps {
-	ops := systemWorkspaceMaterializeOps()
-	ops.random = bytes.NewReader(bytes.Repeat([]byte{0x11}, 16)).Read
-	return ops
+	return workspaceMaterializeOps{systemWorkspaceOps(), bytes.NewReader(bytes.Repeat([]byte{0x11}, 16)).Read, unix.Write, workspacePublish, workspaceManifestMaxBytes}
 }
 func workspacePathMatchesFD(path string, fd int) bool {
 	var named, opened unix.Stat_t
 	return unix.Lstat(path, &named) == nil && unix.Fstat(fd, &opened) == nil && named.Dev == opened.Dev && named.Ino == opened.Ino
 }
 func workspaceMustNotExist(t *testing.T, label, path string) {
+	_, err := os.Lstat(path)
+	workspaceRequire(t, os.IsNotExist(err), "%s exists or failed inspection: %v", label, err)
+}
+func workspaceRequire(t *testing.T, ok bool, format string, args ...any) {
 	t.Helper()
-	if _, err := os.Lstat(path); !os.IsNotExist(err) {
-		t.Fatalf("%s exists or failed inspection: %v", label, err)
+	if !ok {
+		t.Fatalf(format, args...)
 	}
 }
 func TestWorkspaceManagedDirectoryPolicyRequiresBothViews(t *testing.T) {
@@ -60,9 +62,7 @@ func TestWorkspaceManagedDirectoryPolicyRequiresBothViews(t *testing.T) {
 		ops.fstat = func(_ int, stat *unix.Stat_t) error { *stat = opened; return nil }
 		ops.fstatat = func(_ int, _ string, stat *unix.Stat_t, _ int) error { *stat = named; return nil }
 		_, err := verifyWorkspaceDirectoryNameAt(1, "materializations", 2, workspaceObjectID{1, 2}, ops)
-		if rejected := err != nil; rejected != (kind != "secure") {
-			t.Fatalf("%s rejected=%t error=%v", kind, rejected, err)
-		}
+		workspaceRequire(t, (err != nil) == (kind != "secure"), "%s rejected=%t error=%v", kind, err != nil, err)
 	}
 }
 func TestWorkspacePublicationSuccessAndManifestFormat(t *testing.T) {
@@ -82,19 +82,13 @@ func TestWorkspacePublicationSuccessAndManifestFormat(t *testing.T) {
 	mustNil(t, err)
 	want, err := marshalManifestBytes(result.Manifest)
 	mustNil(t, err)
-	if !manifestFlags || result.Manifest.Entries == nil || !bytes.Contains(content, []byte(`"entries":[]`)) || !bytes.Equal(content, want) || bytes.Contains(content, []byte("\n  \"")) {
-		t.Fatalf("workspace manifest or create flags are invalid: flags=%t content=%q", manifestFlags, content)
-	}
+	workspaceRequire(t, manifestFlags && result.Manifest.Entries != nil && bytes.Contains(content, []byte(`"entries":[]`)) && bytes.Equal(content, want) && !bytes.Contains(content, []byte("\n  \"")), "workspace manifest or create flags are invalid: flags=%t content=%q", manifestFlags, content)
 	pointer, pointerErr := marshalManifestBytes(&result.Manifest)
 	bootstrap, bootstrapErr := marshalManifestBytes(BootstrapManifest{Version: 1, BootstrapID: "bid"})
-	if pointerErr != nil || bootstrapErr != nil || !bytes.Equal(pointer, want) || !bytes.Contains(bootstrap, []byte("\n  \"")) {
-		t.Fatalf("manifest encoding parity: pointer=%q bootstrap=%q error=%v", pointer, bootstrap, errors.Join(pointerErr, bootstrapErr))
-	}
+	workspaceRequire(t, pointerErr == nil && bootstrapErr == nil && bytes.Equal(pointer, want) && bytes.Contains(bootstrap, []byte("\n  \"")), "manifest encoding parity: pointer=%q bootstrap=%q error=%v", pointer, bootstrap, errors.Join(pointerErr, bootstrapErr))
 	info, statErr := os.Stat(result.MaterializationRoot)
 	names, readErr := os.ReadDir(fixture.stageParent)
-	if statErr != nil || info.Mode().Perm() != 0o755 || readErr != nil || len(names) != 0 {
-		t.Fatalf("successful publication state: final=%v/%v stages=%v/%v", info, statErr, names, readErr)
-	}
+	workspaceRequire(t, statErr == nil && info.Mode().Perm() == 0o755 && readErr == nil && len(names) == 0, "successful publication state: final=%v/%v stages=%v/%v", info, statErr, names, readErr)
 }
 func TestWorkspacePublicationRejectsPhysicalOverlap(t *testing.T) {
 	for _, kind := range []string{"equal", "state-inside-source", "source-inside-state"} {
@@ -109,9 +103,8 @@ func TestWorkspacePublicationRejectsPhysicalOverlap(t *testing.T) {
 			fixture.request.SourceWorkspace = filepath.Join(fixture.request.StateRoot, "source")
 			mustNil(t, os.Mkdir(fixture.request.SourceWorkspace, 0o700))
 		}
-		if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps()); err == nil || !strings.Contains(err.Error(), "overlap") {
-			t.Fatalf("%s overlap result: %v", kind, err)
-		}
+		_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps())
+		workspaceRequire(t, err != nil && strings.Contains(err.Error(), "overlap"), "%s overlap result: %v", kind, err)
 		workspaceMustNotExist(t, kind+" overlap target state", filepath.Join(fixture.request.StateRoot, "targets"))
 	}
 }
@@ -130,9 +123,8 @@ func TestWorkspacePublicationRequiresPinnedStateRoot(t *testing.T) {
 			}
 			return original(fd, name, flags, mode)
 		}
-		if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); !changed || reject != (err != nil) {
-			t.Fatalf("state-root change: reject=%t changed=%t error=%v", reject, changed, err)
-		}
+		_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+		workspaceRequire(t, changed && reject == (err != nil), "state-root change: reject=%t changed=%t error=%v", reject, changed, err)
 		if reject {
 			for _, root := range []string{fixture.request.StateRoot, moved} {
 				workspaceMustNotExist(t, "state-root swap target state", filepath.Join(root, "targets"))
@@ -141,9 +133,8 @@ func TestWorkspacePublicationRequiresPinnedStateRoot(t *testing.T) {
 	}
 	fixture := newWorkspacePublishFixture(t)
 	fixture.request.StateRoot = filepath.Join(t.TempDir(), "missing")
-	if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps()); err == nil {
-		t.Fatal("missing state root succeeded")
-	}
+	_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps())
+	workspaceRequire(t, err != nil, "missing state root succeeded")
 	workspaceMustNotExist(t, "missing state root", fixture.request.StateRoot)
 	fixture = newWorkspacePublishFixture(t)
 	originalState, replacementState, link := t.TempDir(), t.TempDir(), filepath.Join(t.TempDir(), "state")
@@ -158,17 +149,15 @@ func TestWorkspacePublicationRequiresPinnedStateRoot(t *testing.T) {
 		}
 		return original(fd, name, mode)
 	}
-	if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); err == nil || !swapped {
-		t.Fatalf("visible StateRoot swap: reached=%t error=%v", swapped, err)
-	}
-	if names, err := os.ReadDir(replacementState); err != nil || len(names) != 0 {
-		t.Fatalf("visible StateRoot replacement changed: names=%v error=%v", names, err)
-	}
+	_, err = fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+	workspaceRequire(t, err != nil && swapped, "visible StateRoot swap: reached=%t error=%v", swapped, err)
+	names, err := os.ReadDir(replacementState)
+	workspaceRequire(t, err == nil && len(names) == 0, "visible StateRoot replacement changed: names=%v error=%v", names, err)
 }
 func TestWorkspacePublicationExistingFinalUntouched(t *testing.T) {
 	for _, kind := range []string{"directory", "file", "symlink"} {
 		fixture := newWorkspacePublishFixture(t)
-		mustNil(t, os.MkdirAll(fixture.finalParent, 0o755))
+		mustNil(t, os.MkdirAll(fixture.finalParent, 0o700))
 		mustNil(t, map[string]func() error{
 			"directory": func() error { return os.Mkdir(fixture.final, 0o700) },
 			"file":      func() error { return os.WriteFile(fixture.final, []byte("keep"), 0o600) },
@@ -178,11 +167,15 @@ func TestWorkspacePublicationExistingFinalUntouched(t *testing.T) {
 		mustNil(t, err)
 		_, err = fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps())
 		after, statErr := os.Lstat(fixture.final)
-		if !errors.Is(err, unix.EEXIST) || statErr != nil || !os.SameFile(before, after) || before.Mode() != after.Mode() || before.Size() != after.Size() || !before.ModTime().Equal(after.ModTime()) {
-			t.Fatalf("existing %s changed: before=%v after=%v materialize=%v stat=%v", kind, before, after, err, statErr)
-		}
+		workspaceRequire(t, errors.Is(err, unix.EEXIST) && statErr == nil && os.SameFile(before, after) && before.Mode() == after.Mode() && before.Size() == after.Size() && before.ModTime().Equal(after.ModTime()), "existing %s changed: before=%v after=%v materialize=%v stat=%v", kind, before, after, err, statErr)
 		workspaceMustNotExist(t, "existing-final staging parent", fixture.stageParent)
 	}
+	fixture := newWorkspacePublishFixture(t)
+	mustNil(t, errors.Join(os.Chmod(fixture.request.SourceWorkspace, 0o755), os.Chmod(filepath.Join(fixture.request.SourceWorkspace, "file"), 0o644), os.MkdirAll(fixture.finalParent, 0o700), os.Chmod(fixture.finalParent, 0o755)))
+	_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps())
+	workspaceRequire(t, err != nil && strings.Contains(err.Error(), "materializations") && strings.Contains(err.Error(), "mode 0700"), "public materializations accepted: %v", err)
+	workspaceMustNotExist(t, "public materializations stage", fixture.stageParent)
+	workspaceMustNotExist(t, "public materializations final", fixture.final)
 }
 func TestWorkspaceNativePublishNeverReplaces(t *testing.T) {
 	if !workspaceMaterializationSupported {
@@ -193,29 +186,54 @@ func TestWorkspaceNativePublishNeverReplaces(t *testing.T) {
 	mustNil(t, err)
 	defer unix.Close(fd)
 	mustNil(t, errors.Join(os.WriteFile(filepath.Join(parent, "stage"), []byte("stage"), 0o600), os.WriteFile(filepath.Join(parent, "final"), []byte("final"), 0o600)))
-	if err := workspacePublish(fd, "stage", fd, "final"); !errors.Is(err, unix.EEXIST) {
-		t.Fatalf("native no-replace returned %v, want EEXIST", err)
-	}
+	err = workspacePublish(fd, "stage", fd, "final")
+	workspaceRequire(t, errors.Is(err, unix.EEXIST), "native no-replace returned %v, want EEXIST", err)
 	stage, stageErr := os.ReadFile(filepath.Join(parent, "stage"))
 	final, finalErr := os.ReadFile(filepath.Join(parent, "final"))
-	if stageErr != nil || finalErr != nil || string(stage) != "stage" || string(final) != "final" {
-		t.Fatalf("files after exclusive rename: stage=%q/%v final=%q/%v", stage, stageErr, final, finalErr)
-	}
+	workspaceRequire(t, stageErr == nil && finalErr == nil && string(stage) == "stage" && string(final) == "final", "files after exclusive rename: stage=%q/%v final=%q/%v", stage, stageErr, final, finalErr)
 }
 func TestWorkspacePublicationDurability(t *testing.T) {
-	for _, fail := range []string{"", "nested-file", "nested", "workspace"} {
+	for _, fail := range []string{"", "parent-targets", "parent-local_vm", "parent-apple-container", "parent-tid", "parent-materializations", "parent-" + workspaceStagingName, "existing-parent-targets", "nested-file", "nested", "workspace"} {
 		fixture, ops, events := newWorkspacePublishFixture(t), workspaceTestMaterializeOps(), []string{}
-		nested := filepath.Join(fixture.request.SourceWorkspace, "nested")
-		mustNil(t, errors.Join(os.Remove(filepath.Join(fixture.request.SourceWorkspace, "file")), os.Mkdir(nested, 0o700), os.WriteFile(filepath.Join(nested, "file"), []byte("data"), 0o600), os.Symlink("file", filepath.Join(nested, "link"))))
+		mustNil(t, errors.Join(os.Remove(filepath.Join(fixture.request.SourceWorkspace, "file")), os.Mkdir(filepath.Join(fixture.request.SourceWorkspace, "nested"), 0o700), os.WriteFile(filepath.Join(fixture.request.SourceWorkspace, "nested", "file"), []byte("data"), 0o600), os.Symlink("file", filepath.Join(fixture.request.SourceWorkspace, "nested", "link"))))
 		stage := filepath.Join(fixture.stageParent, workspaceTestStage)
 		workspace := filepath.Join(stage, fixture.target.Contract.WorkspaceMaterialization.WorkspaceDir)
+		target := filepath.Dir(fixture.finalParent)
+		managed := []struct{ name, parent, child string }{{"targets", fixture.request.StateRoot, filepath.Join(fixture.request.StateRoot, "targets")}, {fixture.target.Contract.TargetKind, filepath.Join(fixture.request.StateRoot, "targets"), filepath.Join(fixture.request.StateRoot, "targets", fixture.target.Contract.TargetKind)}, {fixture.target.Contract.TargetProvider, filepath.Join(fixture.request.StateRoot, "targets", fixture.target.Contract.TargetKind), filepath.Join(fixture.request.StateRoot, "targets", fixture.target.Contract.TargetKind, fixture.target.Contract.TargetProvider)}, {"tid", filepath.Dir(target), target}, {"materializations", target, fixture.finalParent}, {workspaceStagingName, target, fixture.stageParent}}
+		existing := strings.HasPrefix(fail, "existing-")
+		failEvent := strings.TrimPrefix(fail, "existing-")
+		if existing {
+			mustNil(t, os.Mkdir(filepath.Join(fixture.request.StateRoot, "targets"), 0o700))
+		}
 		paths := []struct{ label, path string }{{"nested-file", filepath.Join(workspace, "nested", "file")}, {"link", filepath.Join(workspace, "nested", "link")}, {"nested", filepath.Join(workspace, "nested")}, {"workspace", workspace}, {"manifest", filepath.Join(stage, fixture.target.Contract.WorkspaceMaterialization.ManifestName)}, {"stage", stage}, {"staging", fixture.stageParent}, {"final", fixture.finalParent}}
-		ready, sync, publish, chmod, symlink := map[string]bool{}, ops.workspace.fsync, ops.publish, ops.workspace.fchmod, ops.workspace.symlinkat
+		ready, sync, publish, chmod, symlink, mkdir, statat := map[string]bool{}, ops.workspace.fsync, ops.publish, ops.workspace.fchmod, ops.workspace.symlinkat, ops.workspace.mkdirat, ops.workspace.fstatat
+		managedIndex, made, modeReady, verified := 0, existing, existing, existing
+		ops.workspace.mkdirat = func(fd int, name string, mode uint32) error {
+			err := mkdir(fd, name, mode)
+			if err == nil && managedIndex < len(managed) && name == managed[managedIndex].name && workspacePathMatchesFD(managed[managedIndex].parent, fd) {
+				made = true
+				events = append(events, "mkdir-"+name)
+				mustNil(t, os.Chmod(managed[managedIndex].child, 0o755))
+			}
+			return err
+		}
 		ops.workspace.fchmod = func(fd int, mode uint32) error {
+			err := chmod(fd, mode)
+			if err == nil && managedIndex < len(managed) && mode == 0o700 && workspacePathMatchesFD(managed[managedIndex].child, fd) {
+				modeReady = true
+			}
 			ready["nested-file"] = ready["nested-file"] || workspacePathMatchesFD(paths[0].path, fd)
 			ready["nested"] = ready["nested"] || workspacePathMatchesFD(paths[2].path, fd)
 			ready["workspace"] = ready["workspace"] || workspacePathMatchesFD(paths[3].path, fd)
-			return chmod(fd, mode)
+			return err
+		}
+		ops.workspace.fstatat = func(fd int, name string, stat *unix.Stat_t, flags int) error {
+			err := statat(fd, name, stat, flags)
+			if err == nil && managedIndex < len(managed) && made && modeReady && !verified && name == managed[managedIndex].name && workspacePathMatchesFD(managed[managedIndex].parent, fd) && stat.Mode&0o7777 == 0o700 {
+				verified = true
+				events = append(events, "ready-"+name)
+			}
+			return err
 		}
 		ops.workspace.symlinkat = func(target string, fd int, name string) error {
 			err := symlink(target, fd, name)
@@ -223,6 +241,16 @@ func TestWorkspacePublicationDurability(t *testing.T) {
 			return err
 		}
 		ops.workspace.fsync = func(fd int) error {
+			if managedIndex < len(managed) && workspacePathMatchesFD(managed[managedIndex].parent, fd) {
+				workspaceRequire(t, made && modeReady && verified, "%s parent synced before creation and final-mode verification", managed[managedIndex].name)
+				event := "parent-" + managed[managedIndex].name
+				events = append(events, event)
+				managedIndex++
+				made, modeReady, verified = false, false, false
+				if event == failEvent {
+					return unix.EIO
+				}
+			}
 			for _, item := range paths {
 				if workspacePathMatchesFD(item.path, fd) {
 					if item.label == "nested" && !ready["link"] || (item.label == "nested-file" || item.label == "nested" || item.label == "workspace") && !ready[item.label] {
@@ -242,22 +270,22 @@ func TestWorkspacePublicationDurability(t *testing.T) {
 			return publish(fromFD, from, toFD, to)
 		}
 		_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
-		got, want := strings.Join(events, ","), "nested-file,nested,workspace,manifest,stage,staging,final,publish,staging,final"
-		if fail == "" && (err != nil || got != want) {
-			t.Fatalf("durability order: got=%q want=%q error=%v", got, want, err)
-		}
+		got := strings.Join(events, ",")
+		want := "mkdir-targets,ready-targets,parent-targets,mkdir-local_vm,ready-local_vm,parent-local_vm,mkdir-apple-container,ready-apple-container,parent-apple-container,mkdir-tid,ready-tid,parent-tid,mkdir-materializations,ready-materializations,parent-materializations,mkdir-" + workspaceStagingName + ",ready-" + workspaceStagingName + ",parent-" + workspaceStagingName + ",nested-file,nested,workspace,manifest,stage,staging,final,publish,staging,final"
+		workspaceRequire(t, fail != "" || err == nil && got == want, "durability order: got=%q want=%q error=%v", got, want, err)
 		stageInfo, stageErr := os.Stat(stage)
 		_, manifestErr := os.Lstat(filepath.Join(stage, fixture.target.Contract.WorkspaceMaterialization.ManifestName))
 		_, finalErr := os.Lstat(fixture.final)
-		if fail != "" && (err == nil || !strings.Contains(err.Error(), "sync workspace") || !strings.Contains(err.Error(), "pathname cleanup") || !strings.HasSuffix(got, fail) || strings.Contains(got, "publish") || !os.IsNotExist(manifestErr) || !os.IsNotExist(finalErr) || stageErr != nil || stageInfo.Mode().Perm() != 0o700) {
-			t.Fatalf("%s durability failure: events=%q stage=%v/%v manifest=%v final=%v error=%v", fail, got, stageInfo, stageErr, manifestErr, finalErr, err)
+		if strings.Contains(fail, "parent-") {
+			workspaceRequire(t, errors.Is(err, unix.EIO) && strings.Contains(err.Error(), "sync managed directory parent") && !strings.Contains(err.Error(), "pathname cleanup") && got == map[bool]string{true: failEvent, false: want[:strings.Index(want, failEvent)+len(failEvent)]}[existing] && !strings.Contains(got, "publish") && os.IsNotExist(stageErr) && os.IsNotExist(manifestErr) && os.IsNotExist(finalErr), "%s managed durability failure: events=%q stage=%v manifest=%v final=%v error=%v", fail, got, stageErr, manifestErr, finalErr, err)
+		} else if fail != "" {
+			workspaceRequire(t, err != nil && strings.Contains(err.Error(), "sync workspace") && strings.Contains(err.Error(), "pathname cleanup") && strings.HasSuffix(got, fail) && !strings.Contains(got, "publish") && os.IsNotExist(manifestErr) && os.IsNotExist(finalErr) && stageErr == nil && stageInfo.Mode().Perm() == 0o700, "%s durability failure: events=%q stage=%v/%v manifest=%v final=%v error=%v", fail, got, stageInfo, stageErr, manifestErr, finalErr, err)
 		}
 	}
 }
 func TestWorkspacePublicationFailureRetainsPrivateStage(t *testing.T) {
 	for _, kind := range []string{"post-mkdir", "manifest-limit", "short-write", "manifest-validation", "publish-race", "source-change"} {
-		fixture := newWorkspacePublishFixture(t)
-		ops, reached := workspaceTestMaterializeOps(), false
+		fixture, ops, reached := newWorkspacePublishFixture(t), workspaceTestMaterializeOps(), false
 		switch kind {
 		case "post-mkdir":
 			original := ops.workspace.fstatat
@@ -269,8 +297,7 @@ func TestWorkspacePublicationFailureRetainsPrivateStage(t *testing.T) {
 				return original(fd, name, stat, flags)
 			}
 		case "manifest-limit":
-			ops.manifest = 1
-			reached = true
+			ops.manifest, reached = 1, true
 		case "short-write":
 			original := ops.write
 			ops.write = func(fd int, data []byte) (int, error) {
@@ -308,20 +335,16 @@ func TestWorkspacePublicationFailureRetainsPrivateStage(t *testing.T) {
 			}
 		}
 		_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
-		if err == nil || !reached || !strings.Contains(err.Error(), "pathname cleanup") {
-			t.Fatalf("%s failure: reached=%t error=%v", kind, reached, err)
-		}
+		workspaceRequire(t, err != nil && reached && strings.Contains(err.Error(), "pathname cleanup"), "%s failure: reached=%t error=%v", kind, reached, err)
 		if kind == "publish-race" {
-			if info, statErr := os.Stat(fixture.final); statErr != nil || !info.IsDir() {
-				t.Fatalf("publish-race final changed: info=%v error=%v", info, statErr)
-			}
+			info, statErr := os.Stat(fixture.final)
+			workspaceRequire(t, statErr == nil && info.IsDir(), "publish-race final changed: info=%v error=%v", info, statErr)
 		} else if _, statErr := os.Lstat(fixture.final); !os.IsNotExist(statErr) {
 			t.Fatalf("%s published a final: %v", kind, statErr)
 		}
 		stage := filepath.Join(fixture.stageParent, workspaceTestStage)
-		if info, statErr := os.Stat(stage); statErr != nil || info.Mode().Perm() != 0o700 {
-			t.Fatalf("%s retained stage: info=%v error=%v", kind, info, statErr)
-		}
+		info, statErr := os.Stat(stage)
+		workspaceRequire(t, statErr == nil && info.Mode().Perm() == 0o700, "%s retained stage: info=%v error=%v", kind, info, statErr)
 	}
 }
 func TestWorkspacePublicationRetriesStageCollision(t *testing.T) {
@@ -330,12 +353,10 @@ func TestWorkspacePublicationRetriesStageCollision(t *testing.T) {
 	mustNil(t, os.Mkdir(filepath.Join(fixture.stageParent, workspaceTestStage), 0o700))
 	ops := systemWorkspaceMaterializeOps()
 	ops.random = bytes.NewReader(append(bytes.Repeat([]byte{0x11}, 16), bytes.Repeat([]byte{0x22}, 16)...)).Read
-	if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); err != nil {
-		t.Fatalf("stage collision retry: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(fixture.stageParent, workspaceTestStage)); err != nil {
-		t.Fatalf("colliding private stage changed: %v", err)
-	}
+	_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+	workspaceRequire(t, err == nil, "stage collision retry: %v", err)
+	_, err = os.Stat(filepath.Join(fixture.stageParent, workspaceTestStage))
+	workspaceRequire(t, err == nil, "colliding private stage changed: %v", err)
 }
 func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 	for _, kind := range []string{"state-root", "state-policy", "managed-parent", "parent-final-pre", "parent-stage-pre", "parent-final-post", "parent-stage-post", "stage-name", "final-name", "final-late"} {
@@ -363,12 +384,8 @@ func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 				stage := filepath.Join(fixture.stageParent, workspaceTestStage)
 				if err == nil && !reached && workspacePathMatchesFD(stage, fd) {
 					reached = true
-					if kind == "state-policy" {
-						mustNil(t, os.Chmod(fixture.request.StateRoot, 0o777))
-						return err
-					}
-					if strings.HasPrefix(kind, "parent-") {
-						parent := map[bool]string{true: fixture.stageParent, false: fixture.finalParent}[strings.Contains(kind, "stage")]
+					if kind != "managed-parent" {
+						parent := map[bool]string{true: map[bool]string{true: fixture.stageParent, false: fixture.finalParent}[strings.Contains(kind, "stage")], false: fixture.request.StateRoot}[strings.HasPrefix(kind, "parent-")]
 						mustNil(t, os.Chmod(parent, 0o777))
 						return err
 					}
@@ -419,25 +436,19 @@ func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 			}
 		}
 		_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
-		if err == nil || !reached {
-			t.Fatalf("%s race: reached=%t error=%v", kind, reached, err)
-		}
-		if wantPublish := strings.HasPrefix(kind, "final-") || strings.HasSuffix(kind, "-post"); publishCalled != wantPublish {
-			t.Fatalf("%s race publication=%t, want %t", kind, publishCalled, wantPublish)
-		}
+		workspaceRequire(t, err != nil && reached, "%s race: reached=%t error=%v", kind, reached, err)
+		wantPublish := strings.HasPrefix(kind, "final-") || strings.HasSuffix(kind, "-post")
+		workspaceRequire(t, publishCalled == wantPublish, "%s race publication=%t, want %t", kind, publishCalled, wantPublish)
 		if kind == "stage-name" {
-			if info, statErr := os.Stat(filepath.Join(fixture.stageParent, workspaceTestStage+".moved")); statErr != nil || info.Mode().Perm() != 0o700 {
-				t.Fatalf("owned swapped stage mode: info=%v error=%v", info, statErr)
-			}
+			info, statErr := os.Stat(filepath.Join(fixture.stageParent, workspaceTestStage+".moved"))
+			workspaceRequire(t, statErr == nil && info.Mode().Perm() == 0o700, "owned swapped stage mode: info=%v error=%v", info, statErr)
 		}
 		if strings.HasPrefix(kind, "final-") {
 			wantError := map[bool]string{true: "final binding changed", false: "ambiguous"}[kind == "final-late"]
 			wantMode := map[bool]os.FileMode{true: 0o755, false: 0o700}[kind == "final-late"]
 			finalInfo, finalErr := os.Stat(fixture.final)
 			movedInfo, movedErr := os.Stat(fixture.final + ".moved")
-			if !strings.Contains(err.Error(), wantError) || finalErr != nil || movedErr != nil || finalInfo.Mode().Perm() != 0o700 || movedInfo.Mode().Perm() != wantMode {
-				t.Fatalf("post-publish state: final=%v/%v moved=%v/%v error=%v", finalInfo, finalErr, movedInfo, movedErr, err)
-			}
+			workspaceRequire(t, strings.Contains(err.Error(), wantError) && finalErr == nil && movedErr == nil && finalInfo.Mode().Perm() == 0o700 && movedInfo.Mode().Perm() == wantMode, "post-publish state: final=%v/%v moved=%v/%v error=%v", finalInfo, finalErr, movedInfo, movedErr, err)
 		}
 	}
 }
@@ -459,9 +470,7 @@ func TestWorkspacePublicationCopiesFromPinnedSource(t *testing.T) {
 	result, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
 	mustNil(t, err)
 	data, err := os.ReadFile(filepath.Join(result.MaterializedWorkspace, "file"))
-	if err != nil || string(data) != "original" || !swapped {
-		t.Fatalf("pinned source result: data=%q swapped=%t error=%v", data, swapped, err)
-	}
+	workspaceRequire(t, err == nil && string(data) == "original" && swapped, "pinned source result: data=%q swapped=%t error=%v", data, swapped, err)
 }
 func TestWorkspacePublicationManagedOpenDoesNotFollowSwap(t *testing.T) {
 	fixture := newWorkspacePublishFixture(t)
@@ -476,12 +485,10 @@ func TestWorkspacePublicationManagedOpenDoesNotFollowSwap(t *testing.T) {
 		}
 		return original(fd, name, flags, mode)
 	}
-	if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); err == nil || !reached || !flagsOK {
-		t.Fatalf("managed open swap: reached=%t flagsOK=%t error=%v", reached, flagsOK, err)
-	}
-	if names, err := os.ReadDir(out); err != nil || len(names) != 0 {
-		t.Fatalf("managed open followed replacement: names=%v error=%v", names, err)
-	}
+	_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+	workspaceRequire(t, err != nil && reached && flagsOK, "managed open swap: reached=%t flagsOK=%t error=%v", reached, flagsOK, err)
+	names, err := os.ReadDir(out)
+	workspaceRequire(t, err == nil && len(names) == 0, "managed open followed replacement: names=%v error=%v", names, err)
 }
 func TestWorkspacePublicationConcurrentCreateOnce(t *testing.T) {
 	fixture := newWorkspacePublishFixture(t)
@@ -495,9 +502,7 @@ func TestWorkspacePublicationConcurrentCreateOnce(t *testing.T) {
 	}
 	close(start)
 	first, second := <-errs, <-errs
-	if !(first == nil && errors.Is(second, unix.EEXIST) || second == nil && errors.Is(first, unix.EEXIST)) {
-		t.Fatalf("concurrent results: first=%v second=%v", first, second)
-	}
+	workspaceRequire(t, first == nil && errors.Is(second, unix.EEXIST) || second == nil && errors.Is(first, unix.EEXIST), "concurrent results: first=%v second=%v", first, second)
 }
 func TestWorkspaceManifestLimitExactAndOver(t *testing.T) {
 	for _, delta := range []int64{0, -1} {
@@ -509,8 +514,6 @@ func TestWorkspaceManifestLimitExactAndOver(t *testing.T) {
 		ops := workspaceTestMaterializeOps()
 		ops.manifest = int64(len(content)+1) + delta
 		_, err = fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
-		if (delta == 0) != (err == nil) {
-			t.Fatalf("manifest limit delta %d: %v", delta, err)
-		}
+		workspaceRequire(t, (delta == 0) == (err == nil), "manifest limit delta %d: %v", delta, err)
 	}
 }

--- a/internal/applecontainer/workspace_publish_test.go
+++ b/internal/applecontainer/workspace_publish_test.go
@@ -30,7 +30,7 @@ func newWorkspacePublishFixture(t *testing.T) workspacePublishFixture {
 	target, err := NewAppleContainerTarget(Contract{})
 	mustNil(t, err)
 	state, source := t.TempDir(), t.TempDir()
-	mustNil(t, os.WriteFile(filepath.Join(source, "file"), []byte("original"), 0o600))
+	mustNil(t, errors.Join(os.Chmod(source, 0o755), os.WriteFile(filepath.Join(source, "file"), []byte("original"), 0o644)))
 	root := targetRoot(state, target.Contract.TargetKind, target.Contract.TargetProvider, "tid")
 	return workspacePublishFixture{target, MaterializeRequest{StateRoot: state, TargetID: "tid", MaterializationID: "mid", SourceWorkspace: source}, filepath.Join(root, "materializations"), filepath.Join(root, "materializations", "mid"), filepath.Join(root, workspaceStagingName)}
 }
@@ -52,17 +52,22 @@ func workspaceRequire(t *testing.T, ok bool, format string, args ...any) {
 	}
 }
 func TestWorkspaceManagedDirectoryPolicyRequiresBothViews(t *testing.T) {
-	for _, kind := range []string{"secure", "opened-uid", "named-uid", "opened-write", "named-special"} {
-		base := unix.Stat_t{Dev: 1, Ino: 2, Mode: unix.S_IFDIR | 0o700, Uid: uint32(os.Geteuid())}
-		opened, named := base, base
-		changed := map[bool]*unix.Stat_t{true: &opened, false: &named}[strings.HasPrefix(kind, "opened")]
+	for _, kind := range []string{"private-secure", "public-0755", "private-opened-0755", "private-named-0755", "private-created-named-0755", "opened-uid", "named-uid", "opened-write", "named-special"} {
+		base := unix.Stat_t{Dev: 1, Ino: 2, Mode: unix.S_IFDIR | 0o700 | map[string]unix.Stat_t{"public-0755": {Mode: 0o055}}[kind].Mode, Uid: uint32(os.Geteuid())}
+		opened, named, created, ops := base, base, kind == "private-created-named-0755", systemWorkspaceOps()
+		changed := map[bool]*unix.Stat_t{true: &opened, false: &named}[strings.Contains(kind, "opened")]
 		changed.Uid += map[bool]uint32{true: 1}[strings.HasSuffix(kind, "uid")]
-		changed.Mode |= map[string]unix.Stat_t{"opened-write": {Mode: 0o022}, "named-special": {Mode: 0o7000}}[kind].Mode
-		ops := systemWorkspaceOps()
+		changed.Mode |= map[string]unix.Stat_t{"private-opened-0755": {Mode: 0o055}, "private-named-0755": {Mode: 0o055}, "opened-write": {Mode: 0o022}, "named-special": {Mode: 0o7000}}[kind].Mode
 		ops.fstat = func(_ int, stat *unix.Stat_t) error { *stat = opened; return nil }
 		ops.fstatat = func(_ int, _ string, stat *unix.Stat_t, _ int) error { *stat = named; return nil }
-		_, err := verifyWorkspaceDirectoryNameAt(1, "materializations", 2, workspaceObjectID{1, 2}, ops)
-		workspaceRequire(t, (err != nil) == (kind != "secure"), "%s rejected=%t error=%v", kind, err != nil, err)
+		ops.mkdirat, ops.openat, ops.fchmod, ops.fsync = func(int, string, uint32) error { return nil }, func(int, string, int, uint32) (int, error) { return -1, nil }, func(int, uint32) error {
+			named.Mode |= 0o055
+			return nil
+		}, func(int) error { return nil }
+		_, directErr := verifyWorkspaceDirectoryNameAt(1, "materializations", -1, workspaceObjectID{1, 2}, strings.HasPrefix(kind, "private-"), ops)
+		_, _, createdErr := openManagedWorkspaceDirectory(1, "materializations", 0o700, true, created, ops)
+		err := map[bool]error{false: directErr, true: createdErr}[created]
+		workspaceRequire(t, (err != nil) == (kind != "private-secure" && kind != "public-0755"), "%s rejected=%t error=%v", kind, err != nil, err)
 	}
 }
 func TestWorkspacePublicationSuccessAndManifestFormat(t *testing.T) {
@@ -78,10 +83,9 @@ func TestWorkspacePublicationSuccessAndManifestFormat(t *testing.T) {
 	}
 	result, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
 	mustNil(t, err)
-	content, err := os.ReadFile(result.ManifestPath)
-	mustNil(t, err)
-	want, err := marshalManifestBytes(result.Manifest)
-	mustNil(t, err)
+	content, readErr := os.ReadFile(result.ManifestPath)
+	want, marshalErr := marshalManifestBytes(result.Manifest)
+	mustNil(t, errors.Join(readErr, marshalErr))
 	workspaceRequire(t, manifestFlags && result.Manifest.Entries != nil && bytes.Contains(content, []byte(`"entries":[]`)) && bytes.Equal(content, want) && !bytes.Contains(content, []byte("\n  \"")), "workspace manifest or create flags are invalid: flags=%t content=%q", manifestFlags, content)
 	pointer, pointerErr := marshalManifestBytes(&result.Manifest)
 	bootstrap, bootstrapErr := marshalManifestBytes(BootstrapManifest{Version: 1, BootstrapID: "bid"})
@@ -170,23 +174,22 @@ func TestWorkspacePublicationExistingFinalUntouched(t *testing.T) {
 		workspaceRequire(t, errors.Is(err, unix.EEXIST) && statErr == nil && os.SameFile(before, after) && before.Mode() == after.Mode() && before.Size() == after.Size() && before.ModTime().Equal(after.ModTime()), "existing %s changed: before=%v after=%v materialize=%v stat=%v", kind, before, after, err, statErr)
 		workspaceMustNotExist(t, "existing-final staging parent", fixture.stageParent)
 	}
-	fixture := newWorkspacePublishFixture(t)
-	mustNil(t, errors.Join(os.Chmod(fixture.request.SourceWorkspace, 0o755), os.Chmod(filepath.Join(fixture.request.SourceWorkspace, "file"), 0o644), os.MkdirAll(fixture.finalParent, 0o700), os.Chmod(fixture.finalParent, 0o755)))
-	_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps())
-	workspaceRequire(t, err != nil && strings.Contains(err.Error(), "materializations") && strings.Contains(err.Error(), "mode 0700"), "public materializations accepted: %v", err)
-	workspaceMustNotExist(t, "public materializations stage", fixture.stageParent)
-	workspaceMustNotExist(t, "public materializations final", fixture.final)
+	for _, staging := range []bool{false, true} {
+		fixture := newWorkspacePublishFixture(t)
+		mustNil(t, errors.Join(os.Chmod(fixture.request.SourceWorkspace, 0o755), os.Chmod(filepath.Join(fixture.request.SourceWorkspace, "file"), 0o644), os.MkdirAll(map[bool]string{true: fixture.stageParent, false: fixture.finalParent}[staging], 0o700), os.Chmod(map[bool]string{true: fixture.stageParent, false: fixture.finalParent}[staging], 0o755)))
+		_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps())
+		workspaceRequire(t, err != nil && strings.Contains(err.Error(), map[bool]string{true: workspaceStagingName, false: "materializations"}[staging]) && strings.Contains(err.Error(), "mode 0700"), "public managed parent accepted: staging=%t error=%v", staging, err)
+		workspaceMustNotExist(t, "public parent stage", map[bool]string{true: filepath.Join(fixture.stageParent, workspaceTestStage), false: fixture.stageParent}[staging])
+		workspaceMustNotExist(t, "public parent final", fixture.final)
+	}
 }
 func TestWorkspaceNativePublishNeverReplaces(t *testing.T) {
 	if !workspaceMaterializationSupported {
 		t.Skip("native workspace publication is unsupported")
 	}
-	parent := t.TempDir()
-	fd, err := unix.Open(parent, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
-	mustNil(t, err)
-	defer unix.Close(fd)
+	parent, fd := workspaceTestParent(t)
 	mustNil(t, errors.Join(os.WriteFile(filepath.Join(parent, "stage"), []byte("stage"), 0o600), os.WriteFile(filepath.Join(parent, "final"), []byte("final"), 0o600)))
-	err = workspacePublish(fd, "stage", fd, "final")
+	err := workspacePublish(fd, "stage", fd, "final")
 	workspaceRequire(t, errors.Is(err, unix.EEXIST), "native no-replace returned %v, want EEXIST", err)
 	stage, stageErr := os.ReadFile(filepath.Join(parent, "stage"))
 	final, finalErr := os.ReadFile(filepath.Join(parent, "final"))
@@ -349,14 +352,12 @@ func TestWorkspacePublicationFailureRetainsPrivateStage(t *testing.T) {
 }
 func TestWorkspacePublicationRetriesStageCollision(t *testing.T) {
 	fixture := newWorkspacePublishFixture(t)
-	mustNil(t, os.MkdirAll(fixture.stageParent, 0o700))
-	mustNil(t, os.Mkdir(filepath.Join(fixture.stageParent, workspaceTestStage), 0o700))
+	mustNil(t, errors.Join(os.MkdirAll(fixture.stageParent, 0o700), os.Mkdir(filepath.Join(fixture.stageParent, workspaceTestStage), 0o700)))
 	ops := systemWorkspaceMaterializeOps()
 	ops.random = bytes.NewReader(append(bytes.Repeat([]byte{0x11}, 16), bytes.Repeat([]byte{0x22}, 16)...)).Read
-	_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
-	workspaceRequire(t, err == nil, "stage collision retry: %v", err)
-	_, err = os.Stat(filepath.Join(fixture.stageParent, workspaceTestStage))
-	workspaceRequire(t, err == nil, "colliding private stage changed: %v", err)
+	_, materializeErr := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+	_, statErr := os.Stat(filepath.Join(fixture.stageParent, workspaceTestStage))
+	workspaceRequire(t, materializeErr == nil && statErr == nil, "stage collision retry: materialize=%v stage=%v", materializeErr, statErr)
 }
 func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 	for _, kind := range []string{"state-root", "state-policy", "managed-parent", "parent-final-pre", "parent-stage-pre", "parent-final-post", "parent-stage-post", "stage-name", "final-name", "final-late"} {
@@ -386,7 +387,7 @@ func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 					reached = true
 					if kind != "managed-parent" {
 						parent := map[bool]string{true: map[bool]string{true: fixture.stageParent, false: fixture.finalParent}[strings.Contains(kind, "stage")], false: fixture.request.StateRoot}[strings.HasPrefix(kind, "parent-")]
-						mustNil(t, os.Chmod(parent, 0o777))
+						mustNil(t, os.Chmod(parent, map[bool]os.FileMode{true: 0o777, false: 0o755}[kind == "state-policy"]))
 						return err
 					}
 					mustNil(t, errors.Join(os.Rename(fixture.finalParent, fixture.finalParent+".moved"), os.Mkdir(fixture.finalParent, 0o700)))
@@ -414,7 +415,7 @@ func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 				if kind == "final-name" {
 					mustNil(t, errors.Join(os.Rename(fixture.final, fixture.final+".moved"), os.Mkdir(fixture.final, 0o700)))
 				} else {
-					mustNil(t, os.Chmod(map[bool]string{true: fixture.stageParent, false: fixture.finalParent}[strings.Contains(kind, "stage")], 0o777))
+					mustNil(t, os.Chmod(map[bool]string{true: fixture.stageParent, false: fixture.finalParent}[strings.Contains(kind, "stage")], 0o755))
 				}
 				return nil
 			}
@@ -467,10 +468,9 @@ func TestWorkspacePublicationCopiesFromPinnedSource(t *testing.T) {
 		}
 		return original(fd, name, mode)
 	}
-	result, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
-	mustNil(t, err)
-	data, err := os.ReadFile(filepath.Join(result.MaterializedWorkspace, "file"))
-	workspaceRequire(t, err == nil && string(data) == "original" && swapped, "pinned source result: data=%q swapped=%t error=%v", data, swapped, err)
+	result, materializeErr := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+	data, readErr := os.ReadFile(filepath.Join(result.MaterializedWorkspace, "file"))
+	workspaceRequire(t, materializeErr == nil && readErr == nil && string(data) == "original" && swapped, "pinned source result: data=%q swapped=%t error=%v", data, swapped, errors.Join(materializeErr, readErr))
 }
 func TestWorkspacePublicationManagedOpenDoesNotFollowSwap(t *testing.T) {
 	fixture := newWorkspacePublishFixture(t)

--- a/internal/applecontainer/workspace_publish_test.go
+++ b/internal/applecontainer/workspace_publish_test.go
@@ -34,21 +34,21 @@ func newWorkspacePublishFixture(t *testing.T) workspacePublishFixture {
 	root := targetRoot(state, target.Contract.TargetKind, target.Contract.TargetProvider, "tid")
 	return workspacePublishFixture{target, MaterializeRequest{StateRoot: state, TargetID: "tid", MaterializationID: "mid", SourceWorkspace: source}, filepath.Join(root, "materializations"), filepath.Join(root, "materializations", "mid"), filepath.Join(root, workspaceStagingName)}
 }
-
 func workspaceTestMaterializeOps() workspaceMaterializeOps {
 	ops := systemWorkspaceMaterializeOps()
-	ops.random = func(buffer []byte) (int, error) {
-		copy(buffer, bytes.Repeat([]byte{0x11}, len(buffer)))
-		return len(buffer), nil
-	}
+	ops.random = bytes.NewReader(bytes.Repeat([]byte{0x11}, 16)).Read
 	return ops
 }
-
 func workspacePathMatchesFD(path string, fd int) bool {
 	var named, opened unix.Stat_t
-	return unix.Stat(path, &named) == nil && unix.Fstat(fd, &opened) == nil && named.Dev == opened.Dev && named.Ino == opened.Ino
+	return unix.Lstat(path, &named) == nil && unix.Fstat(fd, &opened) == nil && named.Dev == opened.Dev && named.Ino == opened.Ino
 }
-
+func workspaceMustNotExist(t *testing.T, label, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		t.Fatalf("%s exists or failed inspection: %v", label, err)
+	}
+}
 func TestWorkspaceManagedDirectoryPolicyRequiresBothViews(t *testing.T) {
 	for _, kind := range []string{"secure", "opened-uid", "named-uid", "opened-write", "named-special"} {
 		base := unix.Stat_t{Dev: 1, Ino: 2, Mode: unix.S_IFDIR | 0o700, Uid: uint32(os.Geteuid())}
@@ -65,7 +65,6 @@ func TestWorkspaceManagedDirectoryPolicyRequiresBothViews(t *testing.T) {
 		}
 	}
 }
-
 func TestWorkspacePublicationSuccessAndManifestFormat(t *testing.T) {
 	fixture := newWorkspacePublishFixture(t)
 	mustNil(t, os.Remove(filepath.Join(fixture.request.SourceWorkspace, "file")))
@@ -97,119 +96,94 @@ func TestWorkspacePublicationSuccessAndManifestFormat(t *testing.T) {
 		t.Fatalf("successful publication state: final=%v/%v stages=%v/%v", info, statErr, names, readErr)
 	}
 }
-
 func TestWorkspacePublicationRejectsPhysicalOverlap(t *testing.T) {
 	for _, kind := range []string{"equal", "state-inside-source", "source-inside-state"} {
-		t.Run(kind, func(t *testing.T) {
-			fixture := newWorkspacePublishFixture(t)
-			switch kind {
-			case "equal":
-				fixture.request.StateRoot = fixture.request.SourceWorkspace
-			case "state-inside-source":
-				fixture.request.StateRoot = filepath.Join(fixture.request.SourceWorkspace, "state")
-				mustNil(t, os.Mkdir(fixture.request.StateRoot, 0o700))
-			case "source-inside-state":
-				fixture.request.SourceWorkspace = filepath.Join(fixture.request.StateRoot, "source")
-				mustNil(t, os.Mkdir(fixture.request.SourceWorkspace, 0o700))
-			}
-			if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps()); err == nil || !strings.Contains(err.Error(), "overlap") {
-				t.Fatalf("%s overlap result: %v", kind, err)
-			}
-			if _, err := os.Lstat(filepath.Join(fixture.request.StateRoot, "targets")); !os.IsNotExist(err) {
-				t.Fatalf("%s overlap created target state: %v", kind, err)
-			}
-		})
+		fixture := newWorkspacePublishFixture(t)
+		switch kind {
+		case "equal":
+			fixture.request.StateRoot = fixture.request.SourceWorkspace
+		case "state-inside-source":
+			fixture.request.StateRoot = filepath.Join(fixture.request.SourceWorkspace, "state")
+			mustNil(t, os.Mkdir(fixture.request.StateRoot, 0o700))
+		case "source-inside-state":
+			fixture.request.SourceWorkspace = filepath.Join(fixture.request.StateRoot, "source")
+			mustNil(t, os.Mkdir(fixture.request.SourceWorkspace, 0o700))
+		}
+		if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps()); err == nil || !strings.Contains(err.Error(), "overlap") {
+			t.Fatalf("%s overlap result: %v", kind, err)
+		}
+		workspaceMustNotExist(t, kind+" overlap target state", filepath.Join(fixture.request.StateRoot, "targets"))
 	}
 }
-
 func TestWorkspacePublicationRequiresPinnedStateRoot(t *testing.T) {
 	for _, reject := range []bool{false, true} {
-		t.Run(map[bool]string{false: "concurrent-child", true: "pre-open-swap"}[reject], func(t *testing.T) {
-			fixture, ops, changed := newWorkspacePublishFixture(t), workspaceTestMaterializeOps(), false
-			moved, original := fixture.request.StateRoot+".moved", ops.workspace.openat
-			ops.workspace.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
-				if name == filepath.Base(fixture.request.StateRoot) && !changed {
-					changed = true
-					if reject {
-						mustNil(t, errors.Join(os.Rename(fixture.request.StateRoot, moved), os.Mkdir(fixture.request.StateRoot, 0o700)))
-					} else {
-						mustNil(t, os.Mkdir(filepath.Join(fixture.request.StateRoot, "peer"), 0o700))
-					}
-				}
-				return original(fd, name, flags, mode)
-			}
-			if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); !changed || reject != (err != nil) {
-				t.Fatalf("state-root change: reject=%t changed=%t error=%v", reject, changed, err)
-			}
-			if reject {
-				for _, root := range []string{fixture.request.StateRoot, moved} {
-					if _, err := os.Lstat(filepath.Join(root, "targets")); !os.IsNotExist(err) {
-						t.Fatalf("state-root swap wrote to %q: %v", root, err)
-					}
+		fixture, ops, changed := newWorkspacePublishFixture(t), workspaceTestMaterializeOps(), false
+		moved, original := fixture.request.StateRoot+".moved", ops.workspace.openat
+		ops.workspace.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
+			if name == filepath.Base(fixture.request.StateRoot) && !changed {
+				changed = true
+				if reject {
+					mustNil(t, errors.Join(os.Rename(fixture.request.StateRoot, moved), os.Mkdir(fixture.request.StateRoot, 0o700)))
+				} else {
+					mustNil(t, os.Mkdir(filepath.Join(fixture.request.StateRoot, "peer"), 0o700))
 				}
 			}
-		})
+			return original(fd, name, flags, mode)
+		}
+		if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); !changed || reject != (err != nil) {
+			t.Fatalf("state-root change: reject=%t changed=%t error=%v", reject, changed, err)
+		}
+		if reject {
+			for _, root := range []string{fixture.request.StateRoot, moved} {
+				workspaceMustNotExist(t, "state-root swap target state", filepath.Join(root, "targets"))
+			}
+		}
 	}
-	t.Run("missing", func(t *testing.T) {
-		fixture := newWorkspacePublishFixture(t)
-		fixture.request.StateRoot = filepath.Join(t.TempDir(), "missing")
-		if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps()); err == nil {
-			t.Fatal("missing state root succeeded")
+	fixture := newWorkspacePublishFixture(t)
+	fixture.request.StateRoot = filepath.Join(t.TempDir(), "missing")
+	if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps()); err == nil {
+		t.Fatal("missing state root succeeded")
+	}
+	workspaceMustNotExist(t, "missing state root", fixture.request.StateRoot)
+	fixture = newWorkspacePublishFixture(t)
+	originalState, replacementState, link := t.TempDir(), t.TempDir(), filepath.Join(t.TempDir(), "state")
+	mustNil(t, os.Symlink(originalState, link))
+	fixture.request.StateRoot = link
+	ops, swapped := workspaceTestMaterializeOps(), false
+	original := ops.workspace.mkdirat
+	ops.workspace.mkdirat = func(fd int, name string, mode uint32) error {
+		if name == "targets" && !swapped {
+			swapped = true
+			mustNil(t, errors.Join(os.Remove(link), os.Symlink(replacementState, link)))
 		}
-		if _, err := os.Lstat(fixture.request.StateRoot); !os.IsNotExist(err) {
-			t.Fatalf("missing state root was created: %v", err)
-		}
-	})
-	t.Run("visible-symlink-swap", func(t *testing.T) {
-		fixture := newWorkspacePublishFixture(t)
-		originalState, replacementState, link := t.TempDir(), t.TempDir(), filepath.Join(t.TempDir(), "state")
-		mustNil(t, os.Symlink(originalState, link))
-		fixture.request.StateRoot = link
-		ops, swapped := workspaceTestMaterializeOps(), false
-		original := ops.workspace.mkdirat
-		ops.workspace.mkdirat = func(fd int, name string, mode uint32) error {
-			if name == "targets" && !swapped {
-				swapped = true
-				mustNil(t, errors.Join(os.Remove(link), os.Symlink(replacementState, link)))
-			}
-			return original(fd, name, mode)
-		}
-		if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); err == nil || !swapped {
-			t.Fatalf("visible StateRoot swap: reached=%t error=%v", swapped, err)
-		}
-		if names, err := os.ReadDir(replacementState); err != nil || len(names) != 0 {
-			t.Fatalf("visible StateRoot replacement changed: names=%v error=%v", names, err)
-		}
-	})
+		return original(fd, name, mode)
+	}
+	if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); err == nil || !swapped {
+		t.Fatalf("visible StateRoot swap: reached=%t error=%v", swapped, err)
+	}
+	if names, err := os.ReadDir(replacementState); err != nil || len(names) != 0 {
+		t.Fatalf("visible StateRoot replacement changed: names=%v error=%v", names, err)
+	}
 }
-
 func TestWorkspacePublicationExistingFinalUntouched(t *testing.T) {
 	for _, kind := range []string{"directory", "file", "symlink"} {
-		t.Run(kind, func(t *testing.T) {
-			fixture := newWorkspacePublishFixture(t)
-			mustNil(t, os.MkdirAll(fixture.finalParent, 0o755))
-			switch kind {
-			case "directory":
-				mustNil(t, os.Mkdir(fixture.final, 0o700))
-			case "file":
-				mustNil(t, os.WriteFile(fixture.final, []byte("keep"), 0o600))
-			case "symlink":
-				mustNil(t, os.Symlink("sentinel-target", fixture.final))
-			}
-			before, err := os.Lstat(fixture.final)
-			mustNil(t, err)
-			_, err = fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps())
-			after, statErr := os.Lstat(fixture.final)
-			if !errors.Is(err, unix.EEXIST) || statErr != nil || !os.SameFile(before, after) || before.Mode() != after.Mode() || before.Size() != after.Size() || !before.ModTime().Equal(after.ModTime()) {
-				t.Fatalf("existing %s changed: before=%v after=%v materialize=%v stat=%v", kind, before, after, err, statErr)
-			}
-			if _, err := os.Lstat(fixture.stageParent); !os.IsNotExist(err) {
-				t.Fatalf("existing final created a staging parent: %v", err)
-			}
-		})
+		fixture := newWorkspacePublishFixture(t)
+		mustNil(t, os.MkdirAll(fixture.finalParent, 0o755))
+		mustNil(t, map[string]func() error{
+			"directory": func() error { return os.Mkdir(fixture.final, 0o700) },
+			"file":      func() error { return os.WriteFile(fixture.final, []byte("keep"), 0o600) },
+			"symlink":   func() error { return os.Symlink("sentinel-target", fixture.final) },
+		}[kind]())
+		before, err := os.Lstat(fixture.final)
+		mustNil(t, err)
+		_, err = fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps())
+		after, statErr := os.Lstat(fixture.final)
+		if !errors.Is(err, unix.EEXIST) || statErr != nil || !os.SameFile(before, after) || before.Mode() != after.Mode() || before.Size() != after.Size() || !before.ModTime().Equal(after.ModTime()) {
+			t.Fatalf("existing %s changed: before=%v after=%v materialize=%v stat=%v", kind, before, after, err, statErr)
+		}
+		workspaceMustNotExist(t, "existing-final staging parent", fixture.stageParent)
 	}
 }
-
 func TestWorkspaceNativePublishNeverReplaces(t *testing.T) {
 	if !workspaceMaterializationSupported {
 		t.Skip("native workspace publication is unsupported")
@@ -222,212 +196,251 @@ func TestWorkspaceNativePublishNeverReplaces(t *testing.T) {
 	if err := workspacePublish(fd, "stage", fd, "final"); !errors.Is(err, unix.EEXIST) {
 		t.Fatalf("native no-replace returned %v, want EEXIST", err)
 	}
-	for name, want := range map[string]string{"stage": "stage", "final": "final"} {
-		data, err := os.ReadFile(filepath.Join(parent, name))
-		if err != nil || string(data) != want {
-			t.Fatalf("%s after exclusive rename: %q %v", name, data, err)
+	stage, stageErr := os.ReadFile(filepath.Join(parent, "stage"))
+	final, finalErr := os.ReadFile(filepath.Join(parent, "final"))
+	if stageErr != nil || finalErr != nil || string(stage) != "stage" || string(final) != "final" {
+		t.Fatalf("files after exclusive rename: stage=%q/%v final=%q/%v", stage, stageErr, final, finalErr)
+	}
+}
+func TestWorkspacePublicationDurability(t *testing.T) {
+	for _, fail := range []string{"", "nested-file", "nested", "workspace"} {
+		fixture, ops, events := newWorkspacePublishFixture(t), workspaceTestMaterializeOps(), []string{}
+		nested := filepath.Join(fixture.request.SourceWorkspace, "nested")
+		mustNil(t, errors.Join(os.Remove(filepath.Join(fixture.request.SourceWorkspace, "file")), os.Mkdir(nested, 0o700), os.WriteFile(filepath.Join(nested, "file"), []byte("data"), 0o600), os.Symlink("file", filepath.Join(nested, "link"))))
+		stage := filepath.Join(fixture.stageParent, workspaceTestStage)
+		workspace := filepath.Join(stage, fixture.target.Contract.WorkspaceMaterialization.WorkspaceDir)
+		paths := []struct{ label, path string }{{"nested-file", filepath.Join(workspace, "nested", "file")}, {"link", filepath.Join(workspace, "nested", "link")}, {"nested", filepath.Join(workspace, "nested")}, {"workspace", workspace}, {"manifest", filepath.Join(stage, fixture.target.Contract.WorkspaceMaterialization.ManifestName)}, {"stage", stage}, {"staging", fixture.stageParent}, {"final", fixture.finalParent}}
+		ready, sync, publish, chmod, symlink := map[string]bool{}, ops.workspace.fsync, ops.publish, ops.workspace.fchmod, ops.workspace.symlinkat
+		ops.workspace.fchmod = func(fd int, mode uint32) error {
+			ready["nested-file"] = ready["nested-file"] || workspacePathMatchesFD(paths[0].path, fd)
+			ready["nested"] = ready["nested"] || workspacePathMatchesFD(paths[2].path, fd)
+			ready["workspace"] = ready["workspace"] || workspacePathMatchesFD(paths[3].path, fd)
+			return chmod(fd, mode)
+		}
+		ops.workspace.symlinkat = func(target string, fd int, name string) error {
+			err := symlink(target, fd, name)
+			ready["link"] = ready["link"] || err == nil
+			return err
+		}
+		ops.workspace.fsync = func(fd int) error {
+			for _, item := range paths {
+				if workspacePathMatchesFD(item.path, fd) {
+					if item.label == "nested" && !ready["link"] || (item.label == "nested-file" || item.label == "nested" || item.label == "workspace") && !ready[item.label] {
+						t.Fatalf("%s synced before its required mode or symlink update", item.label)
+					}
+					events = append(events, item.label)
+					if item.label == fail {
+						return unix.EIO
+					}
+					break
+				}
+			}
+			return sync(fd)
+		}
+		ops.publish = func(fromFD int, from string, toFD int, to string) error {
+			events = append(events, "publish")
+			return publish(fromFD, from, toFD, to)
+		}
+		_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+		got, want := strings.Join(events, ","), "nested-file,nested,workspace,manifest,stage,staging,final,publish,staging,final"
+		if fail == "" && (err != nil || got != want) {
+			t.Fatalf("durability order: got=%q want=%q error=%v", got, want, err)
+		}
+		stageInfo, stageErr := os.Stat(stage)
+		_, manifestErr := os.Lstat(filepath.Join(stage, fixture.target.Contract.WorkspaceMaterialization.ManifestName))
+		_, finalErr := os.Lstat(fixture.final)
+		if fail != "" && (err == nil || !strings.Contains(err.Error(), "sync workspace") || !strings.Contains(err.Error(), "pathname cleanup") || !strings.HasSuffix(got, fail) || strings.Contains(got, "publish") || !os.IsNotExist(manifestErr) || !os.IsNotExist(finalErr) || stageErr != nil || stageInfo.Mode().Perm() != 0o700) {
+			t.Fatalf("%s durability failure: events=%q stage=%v/%v manifest=%v final=%v error=%v", fail, got, stageInfo, stageErr, manifestErr, finalErr, err)
 		}
 	}
 }
-
 func TestWorkspacePublicationFailureRetainsPrivateStage(t *testing.T) {
 	for _, kind := range []string{"post-mkdir", "manifest-limit", "short-write", "manifest-validation", "publish-race", "source-change"} {
-		t.Run(kind, func(t *testing.T) {
-			fixture := newWorkspacePublishFixture(t)
-			ops, reached := workspaceTestMaterializeOps(), false
-			switch kind {
-			case "post-mkdir":
-				original := ops.workspace.fstatat
-				ops.workspace.fstatat = func(fd int, name string, stat *unix.Stat_t, flags int) error {
-					if name == workspaceTestStage && !reached {
-						reached = true
-						return unix.EIO
-					}
-					return original(fd, name, stat, flags)
+		fixture := newWorkspacePublishFixture(t)
+		ops, reached := workspaceTestMaterializeOps(), false
+		switch kind {
+		case "post-mkdir":
+			original := ops.workspace.fstatat
+			ops.workspace.fstatat = func(fd int, name string, stat *unix.Stat_t, flags int) error {
+				if name == workspaceTestStage && !reached {
+					reached = true
+					return unix.EIO
 				}
-			case "manifest-limit":
-				ops.manifest = 1
+				return original(fd, name, stat, flags)
+			}
+		case "manifest-limit":
+			ops.manifest = 1
+			reached = true
+		case "short-write":
+			original := ops.write
+			ops.write = func(fd int, data []byte) (int, error) {
 				reached = true
-			case "short-write":
-				original := ops.write
-				ops.write = func(fd int, data []byte) (int, error) {
+				n, err := original(fd, data)
+				return n - 1, err
+			}
+		case "manifest-validation":
+			original := ops.write
+			ops.write = func(fd int, data []byte) (int, error) {
+				n, err := original(fd, data)
+				if err == nil {
 					reached = true
-					n, err := original(fd, data)
-					return n - 1, err
+					_, err = unix.Pwrite(fd, []byte("X"), 0)
 				}
-			case "manifest-validation":
-				original := ops.write
-				ops.write = func(fd int, data []byte) (int, error) {
-					n, err := original(fd, data)
-					if err == nil {
-						reached = true
-						_, err = unix.Pwrite(fd, []byte("X"), 0)
-					}
-					return n, err
-				}
-			case "publish-race":
-				original := ops.publish
-				ops.publish = func(fromFD int, from string, toFD int, to string) error {
+				return n, err
+			}
+		case "publish-race":
+			original := ops.publish
+			ops.publish = func(fromFD int, from string, toFD int, to string) error {
+				reached = true
+				mustNil(t, unix.Mkdirat(toFD, to, 0o700))
+				return original(fromFD, from, toFD, to)
+			}
+		case "source-change":
+			original := ops.workspace.fsync
+			ops.workspace.fsync = func(fd int) error {
+				err := original(fd)
+				stage := filepath.Join(fixture.stageParent, workspaceTestStage)
+				if err == nil && !reached && workspacePathMatchesFD(stage, fd) {
 					reached = true
-					mustNil(t, unix.Mkdirat(toFD, to, 0o700))
-					return original(fromFD, from, toFD, to)
+					mustNil(t, os.WriteFile(filepath.Join(fixture.request.SourceWorkspace, "late"), []byte("x"), 0o600))
 				}
-			case "source-change":
-				original := ops.fsync
-				ops.fsync = func(fd int) error {
-					err := original(fd)
-					stage := filepath.Join(fixture.stageParent, workspaceTestStage)
-					if err == nil && !reached && workspacePathMatchesFD(stage, fd) {
-						reached = true
-						mustNil(t, os.WriteFile(filepath.Join(fixture.request.SourceWorkspace, "late"), []byte("x"), 0o600))
-					}
-					return err
-				}
+				return err
 			}
-			_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
-			if err == nil || !reached || !strings.Contains(err.Error(), "pathname cleanup") {
-				t.Fatalf("%s failure: reached=%t error=%v", kind, reached, err)
+		}
+		_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+		if err == nil || !reached || !strings.Contains(err.Error(), "pathname cleanup") {
+			t.Fatalf("%s failure: reached=%t error=%v", kind, reached, err)
+		}
+		if kind == "publish-race" {
+			if info, statErr := os.Stat(fixture.final); statErr != nil || !info.IsDir() {
+				t.Fatalf("publish-race final changed: info=%v error=%v", info, statErr)
 			}
-			if kind == "publish-race" {
-				if info, statErr := os.Stat(fixture.final); statErr != nil || !info.IsDir() {
-					t.Fatalf("publish-race final changed: info=%v error=%v", info, statErr)
-				}
-			} else if _, statErr := os.Lstat(fixture.final); !os.IsNotExist(statErr) {
-				t.Fatalf("%s published a final: %v", kind, statErr)
-			}
-			stage := filepath.Join(fixture.stageParent, workspaceTestStage)
-			if info, statErr := os.Stat(stage); statErr != nil || info.Mode().Perm() != 0o700 {
-				t.Fatalf("%s retained stage: info=%v error=%v", kind, info, statErr)
-			}
-		})
+		} else if _, statErr := os.Lstat(fixture.final); !os.IsNotExist(statErr) {
+			t.Fatalf("%s published a final: %v", kind, statErr)
+		}
+		stage := filepath.Join(fixture.stageParent, workspaceTestStage)
+		if info, statErr := os.Stat(stage); statErr != nil || info.Mode().Perm() != 0o700 {
+			t.Fatalf("%s retained stage: info=%v error=%v", kind, info, statErr)
+		}
 	}
 }
-
 func TestWorkspacePublicationRetriesStageCollision(t *testing.T) {
 	fixture := newWorkspacePublishFixture(t)
 	mustNil(t, os.MkdirAll(fixture.stageParent, 0o700))
 	mustNil(t, os.Mkdir(filepath.Join(fixture.stageParent, workspaceTestStage), 0o700))
-	ops, attempts := systemWorkspaceMaterializeOps(), 0
-	ops.random = func(buffer []byte) (int, error) {
-		attempts++
-		copy(buffer, bytes.Repeat([]byte{byte(attempts * 0x11)}, len(buffer)))
-		return len(buffer), nil
-	}
-	if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); err != nil || attempts != 2 {
-		t.Fatalf("stage collision retry: attempts=%d error=%v", attempts, err)
+	ops := systemWorkspaceMaterializeOps()
+	ops.random = bytes.NewReader(append(bytes.Repeat([]byte{0x11}, 16), bytes.Repeat([]byte{0x22}, 16)...)).Read
+	if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); err != nil {
+		t.Fatalf("stage collision retry: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(fixture.stageParent, workspaceTestStage)); err != nil {
 		t.Fatalf("colliding private stage changed: %v", err)
 	}
 }
-
 func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 	for _, kind := range []string{"state-root", "state-policy", "managed-parent", "parent-final-pre", "parent-stage-pre", "parent-final-post", "parent-stage-post", "stage-name", "final-name", "final-late"} {
-		t.Run(kind, func(t *testing.T) {
-			fixture := newWorkspacePublishFixture(t)
-			ops, reached, publishCalled := workspaceTestMaterializeOps(), false, false
-			publish := ops.publish
-			ops.publish = func(fromFD int, from string, toFD int, to string) error {
-				publishCalled = true
-				return publish(fromFD, from, toFD, to)
-			}
-			switch kind {
-			case "state-root":
-				moved, original := fixture.request.StateRoot+".moved", ops.workspace.mkdirat
-				ops.workspace.mkdirat = func(fd int, name string, mode uint32) error {
-					if name == "targets" && !reached {
-						reached = true
-						mustNil(t, errors.Join(os.Rename(fixture.request.StateRoot, moved), os.Mkdir(fixture.request.StateRoot, 0o700)))
-					}
-					return original(fd, name, mode)
-				}
-			case "state-policy", "managed-parent", "parent-final-pre", "parent-stage-pre":
-				original := ops.fsync
-				ops.fsync = func(fd int) error {
-					err := original(fd)
-					stage := filepath.Join(fixture.stageParent, workspaceTestStage)
-					if err == nil && !reached && workspacePathMatchesFD(stage, fd) {
-						reached = true
-						if kind == "state-policy" {
-							mustNil(t, os.Chmod(fixture.request.StateRoot, 0o777))
-							return err
-						}
-						if strings.HasPrefix(kind, "parent-") {
-							parent := map[bool]string{true: fixture.stageParent, false: fixture.finalParent}[strings.Contains(kind, "stage")]
-							mustNil(t, os.Chmod(parent, 0o777))
-							return err
-						}
-						mustNil(t, errors.Join(os.Rename(fixture.finalParent, fixture.finalParent+".moved"), os.Mkdir(fixture.finalParent, 0o700)))
-					}
-					return err
-				}
-			case "stage-name":
-				original := ops.workspace.fchmod
-				ops.workspace.fchmod = func(fd int, mode uint32) error {
-					err := original(fd, mode)
-					stage := filepath.Join(fixture.stageParent, workspaceTestStage)
-					if err == nil && mode == 0o755 && !reached && workspacePathMatchesFD(stage, fd) {
-						reached = true
-						mustNil(t, errors.Join(os.Rename(stage, stage+".moved"), os.Mkdir(stage, 0o700)))
-					}
-					return err
-				}
-			case "final-name", "parent-final-post", "parent-stage-post":
-				original := ops.publish
-				ops.publish = func(fromFD int, from string, toFD int, to string) error {
-					if err := original(fromFD, from, toFD, to); err != nil {
-						return err
-					}
+		fixture := newWorkspacePublishFixture(t)
+		ops, reached, publishCalled := workspaceTestMaterializeOps(), false, false
+		publish := ops.publish
+		ops.publish = func(fromFD int, from string, toFD int, to string) error {
+			publishCalled = true
+			return publish(fromFD, from, toFD, to)
+		}
+		switch kind {
+		case "state-root":
+			moved, original := fixture.request.StateRoot+".moved", ops.workspace.mkdirat
+			ops.workspace.mkdirat = func(fd int, name string, mode uint32) error {
+				if name == "targets" && !reached {
 					reached = true
-					if kind == "final-name" {
-						mustNil(t, errors.Join(os.Rename(fixture.final, fixture.final+".moved"), os.Mkdir(fixture.final, 0o700)))
-					} else {
-						mustNil(t, os.Chmod(map[bool]string{true: fixture.stageParent, false: fixture.finalParent}[strings.Contains(kind, "stage")], 0o777))
-					}
-					return nil
+					mustNil(t, errors.Join(os.Rename(fixture.request.StateRoot, moved), os.Mkdir(fixture.request.StateRoot, 0o700)))
 				}
-			case "final-late":
-				originalPublish, originalSync, renamed := ops.publish, ops.fsync, false
-				ops.publish = func(fromFD int, from string, toFD int, to string) error {
-					if err := originalPublish(fromFD, from, toFD, to); err != nil {
+				return original(fd, name, mode)
+			}
+		case "state-policy", "managed-parent", "parent-final-pre", "parent-stage-pre":
+			original := ops.workspace.fsync
+			ops.workspace.fsync = func(fd int) error {
+				err := original(fd)
+				stage := filepath.Join(fixture.stageParent, workspaceTestStage)
+				if err == nil && !reached && workspacePathMatchesFD(stage, fd) {
+					reached = true
+					if kind == "state-policy" {
+						mustNil(t, os.Chmod(fixture.request.StateRoot, 0o777))
 						return err
 					}
-					renamed = true
-					return io.ErrUnexpectedEOF
-				}
-				ops.fsync = func(fd int) error {
-					if renamed && !reached {
-						reached = true
-						mustNil(t, errors.Join(os.Rename(fixture.final, fixture.final+".moved"), os.Mkdir(fixture.final, 0o700)))
+					if strings.HasPrefix(kind, "parent-") {
+						parent := map[bool]string{true: fixture.stageParent, false: fixture.finalParent}[strings.Contains(kind, "stage")]
+						mustNil(t, os.Chmod(parent, 0o777))
+						return err
 					}
-					return originalSync(fd)
+					mustNil(t, errors.Join(os.Rename(fixture.finalParent, fixture.finalParent+".moved"), os.Mkdir(fixture.finalParent, 0o700)))
 				}
+				return err
 			}
-			_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
-			if err == nil || !reached {
-				t.Fatalf("%s race: reached=%t error=%v", kind, reached, err)
-			}
-			if wantPublish := strings.HasPrefix(kind, "final-") || strings.HasSuffix(kind, "-post"); publishCalled != wantPublish {
-				t.Fatalf("%s race publication=%t, want %t", kind, publishCalled, wantPublish)
-			}
-			if kind == "stage-name" {
-				if info, statErr := os.Stat(filepath.Join(fixture.stageParent, workspaceTestStage+".moved")); statErr != nil || info.Mode().Perm() != 0o700 {
-					t.Fatalf("owned swapped stage mode: info=%v error=%v", info, statErr)
+		case "stage-name":
+			original := ops.workspace.fchmod
+			ops.workspace.fchmod = func(fd int, mode uint32) error {
+				err := original(fd, mode)
+				stage := filepath.Join(fixture.stageParent, workspaceTestStage)
+				if err == nil && mode == 0o755 && !reached && workspacePathMatchesFD(stage, fd) {
+					reached = true
+					mustNil(t, errors.Join(os.Rename(stage, stage+".moved"), os.Mkdir(stage, 0o700)))
 				}
+				return err
 			}
-			if strings.HasPrefix(kind, "final-") {
-				wantError := map[bool]string{true: "final binding changed", false: "ambiguous"}[kind == "final-late"]
-				wantMode := map[bool]os.FileMode{true: 0o755, false: 0o700}[kind == "final-late"]
-				finalInfo, finalErr := os.Stat(fixture.final)
-				movedInfo, movedErr := os.Stat(fixture.final + ".moved")
-				if !strings.Contains(err.Error(), wantError) || finalErr != nil || movedErr != nil || finalInfo.Mode().Perm() != 0o700 || movedInfo.Mode().Perm() != wantMode {
-					t.Fatalf("post-publish state: final=%v/%v moved=%v/%v error=%v", finalInfo, finalErr, movedInfo, movedErr, err)
+		case "final-name", "parent-final-post", "parent-stage-post":
+			original := ops.publish
+			ops.publish = func(fromFD int, from string, toFD int, to string) error {
+				if err := original(fromFD, from, toFD, to); err != nil {
+					return err
 				}
+				reached = true
+				if kind == "final-name" {
+					mustNil(t, errors.Join(os.Rename(fixture.final, fixture.final+".moved"), os.Mkdir(fixture.final, 0o700)))
+				} else {
+					mustNil(t, os.Chmod(map[bool]string{true: fixture.stageParent, false: fixture.finalParent}[strings.Contains(kind, "stage")], 0o777))
+				}
+				return nil
 			}
-		})
+		case "final-late":
+			originalPublish, originalSync, renamed := ops.publish, ops.workspace.fsync, false
+			ops.publish = func(fromFD int, from string, toFD int, to string) error {
+				if err := originalPublish(fromFD, from, toFD, to); err != nil {
+					return err
+				}
+				renamed = true
+				return io.ErrUnexpectedEOF
+			}
+			ops.workspace.fsync = func(fd int) error {
+				if renamed && !reached {
+					reached = true
+					mustNil(t, errors.Join(os.Rename(fixture.final, fixture.final+".moved"), os.Mkdir(fixture.final, 0o700)))
+				}
+				return originalSync(fd)
+			}
+		}
+		_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+		if err == nil || !reached {
+			t.Fatalf("%s race: reached=%t error=%v", kind, reached, err)
+		}
+		if wantPublish := strings.HasPrefix(kind, "final-") || strings.HasSuffix(kind, "-post"); publishCalled != wantPublish {
+			t.Fatalf("%s race publication=%t, want %t", kind, publishCalled, wantPublish)
+		}
+		if kind == "stage-name" {
+			if info, statErr := os.Stat(filepath.Join(fixture.stageParent, workspaceTestStage+".moved")); statErr != nil || info.Mode().Perm() != 0o700 {
+				t.Fatalf("owned swapped stage mode: info=%v error=%v", info, statErr)
+			}
+		}
+		if strings.HasPrefix(kind, "final-") {
+			wantError := map[bool]string{true: "final binding changed", false: "ambiguous"}[kind == "final-late"]
+			wantMode := map[bool]os.FileMode{true: 0o755, false: 0o700}[kind == "final-late"]
+			finalInfo, finalErr := os.Stat(fixture.final)
+			movedInfo, movedErr := os.Stat(fixture.final + ".moved")
+			if !strings.Contains(err.Error(), wantError) || finalErr != nil || movedErr != nil || finalInfo.Mode().Perm() != 0o700 || movedInfo.Mode().Perm() != wantMode {
+				t.Fatalf("post-publish state: final=%v/%v moved=%v/%v error=%v", finalInfo, finalErr, movedInfo, movedErr, err)
+			}
+		}
 	}
 }
-
 func TestWorkspacePublicationCopiesFromPinnedSource(t *testing.T) {
 	fixture := newWorkspacePublishFixture(t)
 	real, decoy, link := fixture.request.SourceWorkspace, t.TempDir(), filepath.Join(t.TempDir(), "source")
@@ -450,7 +463,6 @@ func TestWorkspacePublicationCopiesFromPinnedSource(t *testing.T) {
 		t.Fatalf("pinned source result: data=%q swapped=%t error=%v", data, swapped, err)
 	}
 }
-
 func TestWorkspacePublicationManagedOpenDoesNotFollowSwap(t *testing.T) {
 	fixture := newWorkspacePublishFixture(t)
 	out, originalTargets := t.TempDir(), filepath.Join(fixture.request.StateRoot, "targets")
@@ -471,7 +483,6 @@ func TestWorkspacePublicationManagedOpenDoesNotFollowSwap(t *testing.T) {
 		t.Fatalf("managed open followed replacement: names=%v error=%v", names, err)
 	}
 }
-
 func TestWorkspacePublicationConcurrentCreateOnce(t *testing.T) {
 	fixture := newWorkspacePublishFixture(t)
 	start, errs := make(chan struct{}), make(chan error, 2)
@@ -483,22 +494,11 @@ func TestWorkspacePublicationConcurrentCreateOnce(t *testing.T) {
 		}()
 	}
 	close(start)
-	successes, exists := 0, 0
-	for range 2 {
-		err := <-errs
-		if err == nil {
-			successes++
-		} else if errors.Is(err, unix.EEXIST) {
-			exists++
-		} else {
-			t.Fatalf("concurrent materialization returned %v", err)
-		}
-	}
-	if successes != 1 || exists != 1 {
-		t.Fatalf("concurrent results: success=%d EEXIST=%d", successes, exists)
+	first, second := <-errs, <-errs
+	if !(first == nil && errors.Is(second, unix.EEXIST) || second == nil && errors.Is(first, unix.EEXIST)) {
+		t.Fatalf("concurrent results: first=%v second=%v", first, second)
 	}
 }
-
 func TestWorkspaceManifestLimitExactAndOver(t *testing.T) {
 	for _, delta := range []int64{0, -1} {
 		fixture := newWorkspacePublishFixture(t)

--- a/internal/applecontainer/workspace_publish_test.go
+++ b/internal/applecontainer/workspace_publish_test.go
@@ -43,9 +43,7 @@ func newWorkspacePublishFixture(t *testing.T) workspacePublishFixture {
 func workspaceTestMaterializeOps() workspaceMaterializeOps {
 	ops := systemWorkspaceMaterializeOps()
 	ops.random = func(buffer []byte) (int, error) {
-		for i := range buffer {
-			buffer[i] = 0x11
-		}
+		copy(buffer, bytes.Repeat([]byte{0x11}, len(buffer)))
 		return len(buffer), nil
 	}
 	return ops
@@ -309,9 +307,7 @@ func TestWorkspacePublicationRetriesStageCollision(t *testing.T) {
 	ops, attempts := systemWorkspaceMaterializeOps(), 0
 	ops.random = func(buffer []byte) (int, error) {
 		attempts++
-		for i := range buffer {
-			buffer[i] = byte(attempts * 0x11)
-		}
+		copy(buffer, bytes.Repeat([]byte{byte(attempts * 0x11)}, len(buffer)))
 		return len(buffer), nil
 	}
 	if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); err != nil || attempts != 2 {
@@ -323,7 +319,7 @@ func TestWorkspacePublicationRetriesStageCollision(t *testing.T) {
 }
 
 func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
-	for _, kind := range []string{"state-root", "managed-parent", "stage-name", "final-name", "final-late"} {
+	for _, kind := range []string{"state-root", "state-policy", "managed-parent", "stage-name", "final-name", "final-late"} {
 		t.Run(kind, func(t *testing.T) {
 			fixture := newWorkspacePublishFixture(t)
 			ops, reached, publishCalled := workspaceTestMaterializeOps(), false, false
@@ -342,13 +338,17 @@ func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 					}
 					return original(fd, name, mode)
 				}
-			case "managed-parent":
+			case "state-policy", "managed-parent":
 				original := ops.fsync
 				ops.fsync = func(fd int) error {
 					err := original(fd)
 					stage := filepath.Join(fixture.stageParent, workspaceTestStage)
 					if err == nil && !reached && workspacePathMatchesFD(stage, fd) {
 						reached = true
+						if kind == "state-policy" {
+							mustNil(t, os.Chmod(fixture.request.StateRoot, 0o777))
+							return err
+						}
 						mustNil(t, errors.Join(os.Rename(fixture.finalParent, fixture.finalParent+".moved"), os.Mkdir(fixture.finalParent, 0o700)))
 					}
 					return err
@@ -395,10 +395,10 @@ func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
 			if err == nil || !reached {
 				t.Fatalf("%s race: reached=%t error=%v", kind, reached, err)
 			}
+			if !strings.HasPrefix(kind, "final-") && publishCalled {
+				t.Fatalf("%s race reached publication", kind)
+			}
 			if kind == "stage-name" {
-				if publishCalled {
-					t.Fatal("stage-name race reached publication")
-				}
 				if info, statErr := os.Stat(filepath.Join(fixture.stageParent, workspaceTestStage+".moved")); statErr != nil || info.Mode().Perm() != 0o700 {
 					t.Fatalf("owned swapped stage mode: info=%v error=%v", info, statErr)
 				}

--- a/internal/applecontainer/workspace_publish_test.go
+++ b/internal/applecontainer/workspace_publish_test.go
@@ -1,0 +1,513 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+const workspaceTestStage = ".workcell-stage-11111111111111111111111111111111"
+
+type workspacePublishFixture struct {
+	target                          AppleContainerTarget
+	request                         MaterializeRequest
+	finalParent, final, stageParent string
+}
+
+func newWorkspacePublishFixture(t *testing.T) workspacePublishFixture {
+	t.Helper()
+	target, err := NewAppleContainerTarget(Contract{})
+	mustNil(t, err)
+	state, source := t.TempDir(), t.TempDir()
+	mustNil(t, os.WriteFile(filepath.Join(source, "file"), []byte("original"), 0o600))
+	root := targetRoot(state, target.Contract.TargetKind, target.Contract.TargetProvider, "tid")
+	return workspacePublishFixture{
+		target:      target,
+		request:     MaterializeRequest{StateRoot: state, TargetID: "tid", MaterializationID: "mid", SourceWorkspace: source},
+		finalParent: filepath.Join(root, "materializations"),
+		final:       filepath.Join(root, "materializations", "mid"), stageParent: filepath.Join(root, workspaceStagingName),
+	}
+}
+
+func workspaceTestMaterializeOps() workspaceMaterializeOps {
+	ops := systemWorkspaceMaterializeOps()
+	ops.random = func(buffer []byte) (int, error) {
+		for i := range buffer {
+			buffer[i] = 0x11
+		}
+		return len(buffer), nil
+	}
+	return ops
+}
+
+func workspacePathMatchesFD(path string, fd int) bool {
+	var named, opened unix.Stat_t
+	return unix.Stat(path, &named) == nil && unix.Fstat(fd, &opened) == nil && named.Dev == opened.Dev && named.Ino == opened.Ino
+}
+
+func TestWorkspacePublicationSuccessAndManifestFormat(t *testing.T) {
+	fixture := newWorkspacePublishFixture(t)
+	mustNil(t, os.Remove(filepath.Join(fixture.request.SourceWorkspace, "file")))
+	ops, manifestFlags := workspaceTestMaterializeOps(), false
+	originalOpen := ops.workspace.openat
+	ops.workspace.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
+		if name == fixture.target.Contract.WorkspaceMaterialization.ManifestName && flags&unix.O_CREAT != 0 {
+			manifestFlags = flags&(unix.O_EXCL|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC) == unix.O_EXCL|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC
+		}
+		return originalOpen(fd, name, flags, mode)
+	}
+	result, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+	mustNil(t, err)
+	if !manifestFlags {
+		t.Fatal("manifest create flags are incomplete")
+	}
+	content, err := os.ReadFile(result.ManifestPath)
+	mustNil(t, err)
+	want, err := marshalManifestBytes(result.Manifest)
+	mustNil(t, err)
+	if result.Manifest.Entries == nil || !bytes.Contains(content, []byte(`"entries":[]`)) || !bytes.Equal(content, want) || bytes.Contains(content, []byte("\n  \"")) {
+		t.Fatalf("workspace manifest is not exact compact JSON: %q", content)
+	}
+	pointer, err := marshalManifestBytes(&result.Manifest)
+	mustNil(t, err)
+	if !bytes.Equal(pointer, want) {
+		t.Fatal("workspace manifest pointer uses a different format")
+	}
+	bootstrap, err := marshalManifestBytes(BootstrapManifest{Version: 1, BootstrapID: "bid"})
+	mustNil(t, err)
+	if !bytes.Contains(bootstrap, []byte("\n  \"")) {
+		t.Fatalf("bootstrap manifest lost indented format: %q", bootstrap)
+	}
+	if info, err := os.Stat(result.MaterializationRoot); err != nil || info.Mode().Perm() != 0o755 {
+		t.Fatalf("final materialization mode: info=%v error=%v", info, err)
+	}
+	if names, err := os.ReadDir(fixture.stageParent); err != nil || len(names) != 0 {
+		t.Fatalf("successful publication left a stage: names=%v error=%v", names, err)
+	}
+}
+
+func TestWorkspacePublicationRejectsPhysicalOverlap(t *testing.T) {
+	for _, kind := range []string{"equal", "state-inside-source", "source-inside-state"} {
+		t.Run(kind, func(t *testing.T) {
+			fixture := newWorkspacePublishFixture(t)
+			switch kind {
+			case "equal":
+				fixture.request.StateRoot = fixture.request.SourceWorkspace
+			case "state-inside-source":
+				fixture.request.StateRoot = filepath.Join(fixture.request.SourceWorkspace, "state")
+				mustNil(t, os.Mkdir(fixture.request.StateRoot, 0o700))
+			case "source-inside-state":
+				fixture.request.SourceWorkspace = filepath.Join(fixture.request.StateRoot, "source")
+				mustNil(t, os.Mkdir(fixture.request.SourceWorkspace, 0o700))
+			}
+			if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps()); err == nil || !strings.Contains(err.Error(), "overlap") {
+				t.Fatalf("%s overlap result: %v", kind, err)
+			}
+			if _, err := os.Lstat(filepath.Join(fixture.request.StateRoot, "targets")); !os.IsNotExist(err) {
+				t.Fatalf("%s overlap created target state: %v", kind, err)
+			}
+		})
+	}
+}
+
+func TestWorkspacePublicationRequiresPinnedStateRoot(t *testing.T) {
+	for _, reject := range []bool{false, true} {
+		t.Run(map[bool]string{false: "concurrent-child", true: "pre-open-swap"}[reject], func(t *testing.T) {
+			fixture, ops, changed := newWorkspacePublishFixture(t), workspaceTestMaterializeOps(), false
+			moved, original := fixture.request.StateRoot+".moved", ops.workspace.openat
+			ops.workspace.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
+				if name == filepath.Base(fixture.request.StateRoot) && !changed {
+					changed = true
+					if reject {
+						mustNil(t, errors.Join(os.Rename(fixture.request.StateRoot, moved), os.Mkdir(fixture.request.StateRoot, 0o700)))
+					} else {
+						mustNil(t, os.Mkdir(filepath.Join(fixture.request.StateRoot, "peer"), 0o700))
+					}
+				}
+				return original(fd, name, flags, mode)
+			}
+			if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); !changed || reject != (err != nil) {
+				t.Fatalf("state-root change: reject=%t changed=%t error=%v", reject, changed, err)
+			}
+			if reject {
+				for _, root := range []string{fixture.request.StateRoot, moved} {
+					if _, err := os.Lstat(filepath.Join(root, "targets")); !os.IsNotExist(err) {
+						t.Fatalf("state-root swap wrote to %q: %v", root, err)
+					}
+				}
+			}
+		})
+	}
+	t.Run("missing", func(t *testing.T) {
+		fixture := newWorkspacePublishFixture(t)
+		fixture.request.StateRoot = filepath.Join(t.TempDir(), "missing")
+		if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps()); err == nil {
+			t.Fatal("missing state root succeeded")
+		}
+		if _, err := os.Lstat(fixture.request.StateRoot); !os.IsNotExist(err) {
+			t.Fatalf("missing state root was created: %v", err)
+		}
+	})
+	t.Run("visible-symlink-swap", func(t *testing.T) {
+		fixture := newWorkspacePublishFixture(t)
+		originalState, replacementState, link := t.TempDir(), t.TempDir(), filepath.Join(t.TempDir(), "state")
+		mustNil(t, os.Symlink(originalState, link))
+		fixture.request.StateRoot = link
+		ops, swapped := workspaceTestMaterializeOps(), false
+		original := ops.workspace.mkdirat
+		ops.workspace.mkdirat = func(fd int, name string, mode uint32) error {
+			if name == "targets" && !swapped {
+				swapped = true
+				mustNil(t, errors.Join(os.Remove(link), os.Symlink(replacementState, link)))
+			}
+			return original(fd, name, mode)
+		}
+		if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); err == nil || !swapped {
+			t.Fatalf("visible StateRoot swap: reached=%t error=%v", swapped, err)
+		}
+		if names, err := os.ReadDir(replacementState); err != nil || len(names) != 0 {
+			t.Fatalf("visible StateRoot replacement changed: names=%v error=%v", names, err)
+		}
+	})
+}
+
+func TestWorkspacePublicationExistingFinalUntouched(t *testing.T) {
+	for _, kind := range []string{"directory", "file", "symlink"} {
+		t.Run(kind, func(t *testing.T) {
+			fixture := newWorkspacePublishFixture(t)
+			mustNil(t, os.MkdirAll(fixture.finalParent, 0o755))
+			switch kind {
+			case "directory":
+				mustNil(t, os.Mkdir(fixture.final, 0o700))
+			case "file":
+				mustNil(t, os.WriteFile(fixture.final, []byte("keep"), 0o600))
+			case "symlink":
+				mustNil(t, os.Symlink("sentinel-target", fixture.final))
+			}
+			before, err := os.Lstat(fixture.final)
+			mustNil(t, err)
+			_, err = fixture.target.materializeWorkspaceWithOps(fixture.request, workspaceTestMaterializeOps())
+			after, statErr := os.Lstat(fixture.final)
+			if !errors.Is(err, unix.EEXIST) || statErr != nil || !os.SameFile(before, after) || before.Mode() != after.Mode() || before.Size() != after.Size() || !before.ModTime().Equal(after.ModTime()) {
+				t.Fatalf("existing %s changed: before=%v after=%v materialize=%v stat=%v", kind, before, after, err, statErr)
+			}
+			if _, err := os.Lstat(fixture.stageParent); !os.IsNotExist(err) {
+				t.Fatalf("existing final created a staging parent: %v", err)
+			}
+		})
+	}
+}
+
+func TestWorkspaceNativePublishNeverReplaces(t *testing.T) {
+	if !workspaceMaterializationSupported {
+		t.Skip("native workspace publication is unsupported")
+	}
+	parent := t.TempDir()
+	fd, err := unix.Open(parent, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	mustNil(t, err)
+	defer unix.Close(fd)
+	mustNil(t, errors.Join(os.WriteFile(filepath.Join(parent, "stage"), []byte("stage"), 0o600), os.WriteFile(filepath.Join(parent, "final"), []byte("final"), 0o600)))
+	if err := workspacePublish(fd, "stage", fd, "final"); !errors.Is(err, unix.EEXIST) {
+		t.Fatalf("native no-replace returned %v, want EEXIST", err)
+	}
+	for name, want := range map[string]string{"stage": "stage", "final": "final"} {
+		data, err := os.ReadFile(filepath.Join(parent, name))
+		if err != nil || string(data) != want {
+			t.Fatalf("%s after exclusive rename: %q %v", name, data, err)
+		}
+	}
+}
+
+func TestWorkspacePublicationFailureRetainsPrivateStage(t *testing.T) {
+	for _, kind := range []string{"post-mkdir", "manifest-limit", "short-write", "manifest-validation", "publish-race", "source-change"} {
+		t.Run(kind, func(t *testing.T) {
+			fixture := newWorkspacePublishFixture(t)
+			ops, reached := workspaceTestMaterializeOps(), false
+			switch kind {
+			case "post-mkdir":
+				original := ops.workspace.fstatat
+				ops.workspace.fstatat = func(fd int, name string, stat *unix.Stat_t, flags int) error {
+					if name == workspaceTestStage && !reached {
+						reached = true
+						return unix.EIO
+					}
+					return original(fd, name, stat, flags)
+				}
+			case "manifest-limit":
+				ops.manifest = 1
+				reached = true
+			case "short-write":
+				original := ops.write
+				ops.write = func(fd int, data []byte) (int, error) {
+					reached = true
+					n, err := original(fd, data)
+					return n - 1, err
+				}
+			case "manifest-validation":
+				original := ops.write
+				ops.write = func(fd int, data []byte) (int, error) {
+					n, err := original(fd, data)
+					if err == nil {
+						reached = true
+						_, err = unix.Pwrite(fd, []byte("X"), 0)
+					}
+					return n, err
+				}
+			case "publish-race":
+				original := ops.publish
+				ops.publish = func(fromFD int, from string, toFD int, to string) error {
+					reached = true
+					mustNil(t, unix.Mkdirat(toFD, to, 0o700))
+					return original(fromFD, from, toFD, to)
+				}
+			case "source-change":
+				original := ops.fsync
+				ops.fsync = func(fd int) error {
+					err := original(fd)
+					stage := filepath.Join(fixture.stageParent, workspaceTestStage)
+					if err == nil && !reached && workspacePathMatchesFD(stage, fd) {
+						reached = true
+						mustNil(t, os.WriteFile(filepath.Join(fixture.request.SourceWorkspace, "late"), []byte("x"), 0o600))
+					}
+					return err
+				}
+			}
+			_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+			if err == nil || !reached || !strings.Contains(err.Error(), "pathname cleanup") {
+				t.Fatalf("%s failure: reached=%t error=%v", kind, reached, err)
+			}
+			if kind == "publish-race" {
+				if info, statErr := os.Stat(fixture.final); statErr != nil || !info.IsDir() {
+					t.Fatalf("publish-race final changed: info=%v error=%v", info, statErr)
+				}
+			} else if _, statErr := os.Lstat(fixture.final); !os.IsNotExist(statErr) {
+				t.Fatalf("%s published a final: %v", kind, statErr)
+			}
+			stage := filepath.Join(fixture.stageParent, workspaceTestStage)
+			if info, statErr := os.Stat(stage); statErr != nil || info.Mode().Perm() != 0o700 {
+				t.Fatalf("%s retained stage: info=%v error=%v", kind, info, statErr)
+			}
+		})
+	}
+}
+
+func TestWorkspacePublicationRetriesStageCollision(t *testing.T) {
+	fixture := newWorkspacePublishFixture(t)
+	mustNil(t, os.MkdirAll(fixture.stageParent, 0o700))
+	mustNil(t, os.Mkdir(filepath.Join(fixture.stageParent, workspaceTestStage), 0o700))
+	ops, attempts := systemWorkspaceMaterializeOps(), 0
+	ops.random = func(buffer []byte) (int, error) {
+		attempts++
+		for i := range buffer {
+			buffer[i] = byte(attempts * 0x11)
+		}
+		return len(buffer), nil
+	}
+	if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); err != nil || attempts != 2 {
+		t.Fatalf("stage collision retry: attempts=%d error=%v", attempts, err)
+	}
+	if _, err := os.Stat(filepath.Join(fixture.stageParent, workspaceTestStage)); err != nil {
+		t.Fatalf("colliding private stage changed: %v", err)
+	}
+}
+
+func TestWorkspacePublicationRejectsDescriptorRaces(t *testing.T) {
+	for _, kind := range []string{"state-root", "managed-parent", "stage-name", "final-name", "final-late"} {
+		t.Run(kind, func(t *testing.T) {
+			fixture := newWorkspacePublishFixture(t)
+			ops, reached, publishCalled := workspaceTestMaterializeOps(), false, false
+			publish := ops.publish
+			ops.publish = func(fromFD int, from string, toFD int, to string) error {
+				publishCalled = true
+				return publish(fromFD, from, toFD, to)
+			}
+			switch kind {
+			case "state-root":
+				moved, original := fixture.request.StateRoot+".moved", ops.workspace.mkdirat
+				ops.workspace.mkdirat = func(fd int, name string, mode uint32) error {
+					if name == "targets" && !reached {
+						reached = true
+						mustNil(t, errors.Join(os.Rename(fixture.request.StateRoot, moved), os.Mkdir(fixture.request.StateRoot, 0o700)))
+					}
+					return original(fd, name, mode)
+				}
+			case "managed-parent":
+				original := ops.fsync
+				ops.fsync = func(fd int) error {
+					err := original(fd)
+					stage := filepath.Join(fixture.stageParent, workspaceTestStage)
+					if err == nil && !reached && workspacePathMatchesFD(stage, fd) {
+						reached = true
+						mustNil(t, errors.Join(os.Rename(fixture.finalParent, fixture.finalParent+".moved"), os.Mkdir(fixture.finalParent, 0o700)))
+					}
+					return err
+				}
+			case "stage-name":
+				original := ops.workspace.fchmod
+				ops.workspace.fchmod = func(fd int, mode uint32) error {
+					err := original(fd, mode)
+					stage := filepath.Join(fixture.stageParent, workspaceTestStage)
+					if err == nil && mode == 0o755 && !reached && workspacePathMatchesFD(stage, fd) {
+						reached = true
+						mustNil(t, errors.Join(os.Rename(stage, stage+".moved"), os.Mkdir(stage, 0o700)))
+					}
+					return err
+				}
+			case "final-name":
+				original := ops.publish
+				ops.publish = func(fromFD int, from string, toFD int, to string) error {
+					if err := original(fromFD, from, toFD, to); err != nil {
+						return err
+					}
+					reached = true
+					mustNil(t, errors.Join(os.Rename(fixture.final, fixture.final+".moved"), os.Mkdir(fixture.final, 0o700)))
+					return nil
+				}
+			case "final-late":
+				originalPublish, originalSync, renamed := ops.publish, ops.fsync, false
+				ops.publish = func(fromFD int, from string, toFD int, to string) error {
+					if err := originalPublish(fromFD, from, toFD, to); err != nil {
+						return err
+					}
+					renamed = true
+					return io.ErrUnexpectedEOF
+				}
+				ops.fsync = func(fd int) error {
+					if renamed && !reached {
+						reached = true
+						mustNil(t, errors.Join(os.Rename(fixture.final, fixture.final+".moved"), os.Mkdir(fixture.final, 0o700)))
+					}
+					return originalSync(fd)
+				}
+			}
+			_, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+			if err == nil || !reached {
+				t.Fatalf("%s race: reached=%t error=%v", kind, reached, err)
+			}
+			if kind == "stage-name" {
+				if publishCalled {
+					t.Fatal("stage-name race reached publication")
+				}
+				if info, statErr := os.Stat(filepath.Join(fixture.stageParent, workspaceTestStage+".moved")); statErr != nil || info.Mode().Perm() != 0o700 {
+					t.Fatalf("owned swapped stage mode: info=%v error=%v", info, statErr)
+				}
+			}
+			if strings.HasPrefix(kind, "final-") {
+				wantError, wantMode := "ambiguous", os.FileMode(0o700)
+				if kind == "final-late" {
+					wantError, wantMode = "final binding changed", 0o755
+				}
+				if !strings.Contains(err.Error(), wantError) {
+					t.Fatalf("post-publish error is not distinct: %v", err)
+				}
+				if info, statErr := os.Stat(fixture.final); statErr != nil || info.Mode().Perm() != 0o700 {
+					t.Fatalf("replacement final was chmodded: info=%v error=%v", info, statErr)
+				}
+				if info, statErr := os.Stat(fixture.final + ".moved"); statErr != nil || info.Mode().Perm() != wantMode {
+					t.Fatalf("ambiguous owned object mode: info=%v error=%v", info, statErr)
+				}
+			}
+		})
+	}
+}
+
+func TestWorkspacePublicationCopiesFromPinnedSource(t *testing.T) {
+	fixture := newWorkspacePublishFixture(t)
+	real, decoy, link := fixture.request.SourceWorkspace, t.TempDir(), filepath.Join(t.TempDir(), "source")
+	mustNil(t, os.WriteFile(filepath.Join(decoy, "file"), []byte("decoy"), 0o600))
+	mustNil(t, os.Symlink(real, link))
+	fixture.request.SourceWorkspace = link
+	ops, swapped := workspaceTestMaterializeOps(), false
+	original := ops.workspace.mkdirat
+	ops.workspace.mkdirat = func(fd int, name string, mode uint32) error {
+		if name == "targets" && !swapped {
+			swapped = true
+			mustNil(t, errors.Join(os.Remove(link), os.Symlink(decoy, link)))
+		}
+		return original(fd, name, mode)
+	}
+	result, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+	mustNil(t, err)
+	data, err := os.ReadFile(filepath.Join(result.MaterializedWorkspace, "file"))
+	if err != nil || string(data) != "original" || !swapped {
+		t.Fatalf("pinned source result: data=%q swapped=%t error=%v", data, swapped, err)
+	}
+}
+
+func TestWorkspacePublicationManagedOpenDoesNotFollowSwap(t *testing.T) {
+	fixture := newWorkspacePublishFixture(t)
+	out, originalTargets := t.TempDir(), filepath.Join(fixture.request.StateRoot, "targets")
+	mustNil(t, os.Mkdir(originalTargets, 0o700))
+	ops, reached, flagsOK := workspaceTestMaterializeOps(), false, false
+	original := ops.workspace.openat
+	ops.workspace.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
+		if name == "targets" && !reached {
+			reached, flagsOK = true, flags&unix.O_NOFOLLOW != 0
+			mustNil(t, errors.Join(os.Rename(originalTargets, originalTargets+".moved"), os.Symlink(out, originalTargets)))
+		}
+		return original(fd, name, flags, mode)
+	}
+	if _, err := fixture.target.materializeWorkspaceWithOps(fixture.request, ops); err == nil || !reached || !flagsOK {
+		t.Fatalf("managed open swap: reached=%t flagsOK=%t error=%v", reached, flagsOK, err)
+	}
+	if names, err := os.ReadDir(out); err != nil || len(names) != 0 {
+		t.Fatalf("managed open followed replacement: names=%v error=%v", names, err)
+	}
+}
+
+func TestWorkspacePublicationConcurrentCreateOnce(t *testing.T) {
+	fixture := newWorkspacePublishFixture(t)
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			<-start
+			_, err := fixture.target.MaterializeWorkspace(context.Background(), fixture.request)
+			errs <- err
+		}()
+	}
+	close(start)
+	successes, exists := 0, 0
+	for range 2 {
+		err := <-errs
+		if err == nil {
+			successes++
+		} else if errors.Is(err, unix.EEXIST) {
+			exists++
+		} else {
+			t.Fatalf("concurrent materialization returned %v", err)
+		}
+	}
+	if successes != 1 || exists != 1 {
+		t.Fatalf("concurrent results: success=%d EEXIST=%d", successes, exists)
+	}
+}
+
+func TestWorkspaceManifestLimitExactAndOver(t *testing.T) {
+	for _, delta := range []int64{0, -1} {
+		t.Run(map[int64]string{0: "exact", -1: "over"}[delta], func(t *testing.T) {
+			fixture := newWorkspacePublishFixture(t)
+			mustNil(t, os.Remove(filepath.Join(fixture.request.SourceWorkspace, "file")))
+			manifest := WorkspaceManifest{Version: 1, TargetKind: fixture.target.Contract.TargetKind, TargetProvider: fixture.target.Contract.TargetProvider, TargetID: "tid", WorkspaceTransport: fixture.target.Contract.WorkspaceTransport, SourceWorkspace: fixture.request.SourceWorkspace, MaterializationID: "mid", MaterializedWorkspace: filepath.Join(fixture.final, fixture.target.Contract.WorkspaceMaterialization.WorkspaceDir), ExcludedPaths: append([]string(nil), fixture.target.Contract.WorkspaceMaterialization.ExcludedPaths...), Entries: []WorkspaceEntry{}}
+			content, err := json.Marshal(manifest)
+			mustNil(t, err)
+			ops := workspaceTestMaterializeOps()
+			ops.manifest = int64(len(content)+1) + delta
+			_, err = fixture.target.materializeWorkspaceWithOps(fixture.request, ops)
+			if (delta == 0) != (err == nil) {
+				t.Fatalf("manifest limit delta %d: %v", delta, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Publish Apple workspace copies through private staging and descriptor-bound paths.
- Reject overlapping state roots and existing materialization identifiers.
- Recheck StateRoot and managed-parent policy at publication boundaries.
- Require exact mode `0700` for both views of each private managed parent.
- Synchronize each new managed-directory entry after final-mode and binding checks.
- Synchronize each copied regular file and directory before stage publication.
- Preserve failed stages for explicit operator inspection.
- Add recovery, race, hard-link, durability, and platform behavior tests.
- Document workspace materialization safety.

## Evidence

- Base: `e7cf9c05fd69136241fd05743bbad569590d65a8`
- Head: `160d0861d832ebb4cfc39d40cbae78684545e488`
- Tree: `096729ee56e6fcf45885041c16653e22d307e235`
- Full-index aggregate diff SHA-256: `e48fe2ef5738f9c529e57f6fe48d01de6ed48d8c1438f5147ef88f9dfdf38d8e`
- PR parity evidence SHA-256: `2390241a55a1aa33f61bc0ab5b542cde7a88b0576efc5c8b43cee6200a9e1b2e`

## Checks

- [x] Fresh exact-head PR parity passed.
- [x] Live Apple certification passed for the exact tree.
- [x] All six publication commits have valid maintainer signatures.
- [x] The shape is 13 paths, 1,200 changed lines, two areas, and zero binaries.
- [x] Private-parent `0755` races fail before successful publication.
- [x] The fail-open mutants failed as expected.
- [x] The certification supply closure passed.
- [x] No special label is required.