### PR TITLE
Bound Apple manifest consumers

### DIFF
--- a/docs/apple-container-evaluation.md
+++ b/docs/apple-container-evaluation.md
@@ -57,6 +57,11 @@ The target prepares a private `0700` stage under `.materialization-staging`.
 After stage creation, a preparation failure leaves the stage in place without pathname cleanup.
 An operator can inspect and remove the stage after they understand the failure.
 
+The conformance check reads workspace trees through stable descriptors.
+It does not create mirror copies.
+Persisted manifests use the same 64 MiB limit as workspace publication.
+The manifest reader rejects noncanonical JSON and trailing data.
+
 ## Decision
 
 The technical evaluation result was `GO`. Workcell deferred operator

--- a/internal/applecontainer/conformance.go
+++ b/internal/applecontainer/conformance.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -20,77 +19,6 @@ import (
 	"github.com/omkhar/workcell/internal/host/sessions"
 	"github.com/omkhar/workcell/internal/providerid"
 )
-
-// rejectDuplicateJSONKeys walks the token stream and rejects any object with a duplicate key.
-// encoding/json is LAST-WINS on duplicates, so a persisted record/manifest could smuggle an extra
-// `"target_id":"evil"` past field validation; this closes that (like the audit-line dup-key check).
-func rejectDuplicateJSONKeys(raw []byte) error {
-	return scanJSONValue(json.NewDecoder(bytes.NewReader(raw)))
-}
-
-// scanJSONValue consumes exactly one JSON value from dec and checks nested objects for dup keys.
-func scanJSONValue(dec *json.Decoder) error {
-	tok, err := dec.Token()
-	if err != nil {
-		return err
-	}
-	delim, ok := tok.(json.Delim)
-	if !ok {
-		return nil // scalar
-	}
-	if delim == '{' {
-		seen := map[string]struct{}{}
-		for dec.More() {
-			key, err := dec.Token()
-			if err != nil {
-				return err
-			}
-			name := key.(string)
-			if _, dup := seen[name]; dup {
-				return fmt.Errorf("duplicate JSON key %q", name)
-			}
-			seen[name] = struct{}{}
-			if err := scanJSONValue(dec); err != nil {
-				return err
-			}
-		}
-	} else { // '['
-		for dec.More() {
-			if err := scanJSONValue(dec); err != nil {
-				return err
-			}
-		}
-	}
-	_, err = dec.Token() // consume the closing } or ]
-	return err
-}
-
-// readPersistedManifest decodes the manifest PERSISTED at the derived canonical path via the
-// production no-follow reader (readFileSafe: openat O_NOFOLLOW per component, Fstat S_IFREG +
-// Nlink==1), so a symlink/hardlink at the canonical path pointing at a decoy outside StateRoot —
-// or a missing/stale/divergent file — is rejected rather than followed. Duplicate JSON keys too.
-// The decode is STRICT (DisallowUnknownFields + no trailing content): a conformant target must
-// emit exactly the v1 schema, so an extra/unknown key in the persisted manifest is rejected.
-func readPersistedManifest(stateRoot, path string, into any) error {
-	data, err := readFileSafe(stateRoot, path, "manifest")
-	if err != nil {
-		return err
-	}
-	if err := rejectDuplicateJSONKeys(data); err != nil {
-		return fmt.Errorf("manifest at %q: %w", path, err)
-	}
-	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(into); err != nil {
-		return fmt.Errorf("manifest at %q: %w", path, err)
-	}
-	// Require a strict io.EOF after the value: a trailing object, token, OR unmatched delimiter
-	// (a lone `}`/`]`, which dec.More() would miss) is rejected as trailing data.
-	if _, err := dec.Token(); err != io.EOF {
-		return fmt.Errorf("manifest at %q: trailing data after manifest", path)
-	}
-	return nil
-}
 
 // requireNoSymlink verifies path (under stateRoot) is reached without traversing any symlink and
 // is the expected kind (regular file, or directory when wantDir), via the production no-follow
@@ -481,56 +409,25 @@ func validateMaterialization(contract Contract, layout canonicalLayout, result M
 	if !slices.Equal(m.ExcludedPaths, contract.WorkspaceMaterialization.ExcludedPaths) {
 		return fmt.Errorf("materialization excluded_paths = %v, want %v", m.ExcludedPaths, contract.WorkspaceMaterialization.ExcludedPaths)
 	}
-	// Reject a SYMLINKED workspace root before any tree read: copyWorkspaceTree EvalSymlinks-es its
-	// root, so a symlinked canonical path would let a target certify a decoy tree outside StateRoot.
-	if err := requireNoSymlink(c.StateRoot, layout.materializedWorkspace, "materialized workspace", true); err != nil {
-		return err
-	}
-	if _, err := os.Stat(filepath.Join(layout.materializedWorkspace, ".git")); !os.IsNotExist(err) {
-		return fmt.Errorf("materialized workspace must not contain .git")
-	}
-	mirrorRoot, err := os.MkdirTemp("", "workcell-applecontainer-compare.")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(mirrorRoot)
-	// Certify the manifest against the actual destination on disk AND the source.
-	for i, tree := range []struct {
-		label    string
-		root     string
-		excluded []string
+	// Inspect both trees through stable descriptors. The conformance check does not
+	// create mirror trees or write to either workspace.
+	for _, tree := range []struct {
+		label   string
+		inspect func() ([]WorkspaceEntry, error)
 	}{
-		{"the destination workspace on disk", layout.materializedWorkspace, nil},
-		{"copied workspace", c.SourceWorkspace, contract.WorkspaceMaterialization.ExcludedPaths},
+		{"the destination workspace on disk", func() ([]WorkspaceEntry, error) {
+			return inspectMaterializedWorkspace(c.StateRoot, layout.materializedWorkspace)
+		}},
+		{"the source workspace", func() ([]WorkspaceEntry, error) {
+			return inspectSourceWorkspace(c.SourceWorkspace, contract.WorkspaceMaterialization.ExcludedPaths)
+		}},
 	} {
-		got, err := copyWorkspaceTree(tree.root, filepath.Join(mirrorRoot, fmt.Sprintf("cmp%d", i)), tree.excluded)
+		got, err := tree.inspect()
 		if err != nil {
 			return err
 		}
 		if !slices.Equal(got, m.Entries) {
 			return fmt.Errorf("materialization manifest entries do not match %s", tree.label)
-		}
-	}
-	// Every certified regular file must be single-linked (Nlink==1): a conformant materialization
-	// produces ISOLATED copies, not hardlinks sharing an inode with a path (possibly outside the
-	// workspace). Extends the hardlink defense already applied to manifests/record/audit.
-	return requireSingleLinkedWorkspace(c.StateRoot, layout.materializedWorkspace, m.Entries)
-}
-
-// requireSingleLinkedWorkspace asserts every regular file in the certified workspace tree has
-// Nlink==1, using the no-follow statPathSafe (consistent with the manifest/record/audit reads).
-func requireSingleLinkedWorkspace(stateRoot, workspaceRoot string, entries []WorkspaceEntry) error {
-	for _, e := range entries {
-		if e.Kind != "file" {
-			continue
-		}
-		p := filepath.Join(workspaceRoot, filepath.FromSlash(e.Path))
-		st, err := statPathSafe(stateRoot, p)
-		if err != nil {
-			return fmt.Errorf("workspace file %q: %w", p, err)
-		}
-		if st.Nlink != 1 {
-			return fmt.Errorf("workspace file %q is multiply linked (%d links) — a conformant materialization uses isolated copies", p, st.Nlink)
 		}
 	}
 	return nil

--- a/internal/applecontainer/conformance_test.go
+++ b/internal/applecontainer/conformance_test.go
@@ -36,9 +36,9 @@ func rejectsEachPersistedManifestField[M any](t *testing.T, label, path string, 
 	for i, mut := range muts {
 		bad := base
 		mut(&bad)
-		data, err := json.MarshalIndent(bad, "", "  ")
+		data, err := marshalManifestBytes(bad)
 		mustNil(t, err)
-		mustNil(t, os.WriteFile(path, append(data, '\n'), 0o600))
+		mustNil(t, os.WriteFile(path, data, 0o600))
 		if validate() == nil {
 			t.Fatalf("%s persisted field %d: tampered on-disk value accepted (not pinned)", label, i)
 		}
@@ -58,9 +58,9 @@ func rejectsEachManifestFieldPin[R any, M any](t *testing.T, label, path string,
 		bad := base
 		m := manifest(&bad)
 		mut(m)
-		data, err := json.MarshalIndent(*m, "", "  ")
+		data, err := marshalManifestBytes(*m)
 		mustNil(t, err)
-		mustNil(t, os.WriteFile(path, append(data, '\n'), 0o600))
+		mustNil(t, os.WriteFile(path, data, 0o600))
 		if validate(bad) == nil {
 			t.Fatalf("%s field pin %d: consistently-tampered value accepted (pin not exercised)", label, i)
 		}
@@ -632,9 +632,8 @@ func TestConformanceRejectsSymlinkedManifest(t *testing.T) {
 }
 
 // TestConformanceRejectsSymlinkedWorkspaceRoot: a symlinked materialized-workspace root (→ VALID
-// decoy tree outside StateRoot) must be rejected, else copyWorkspaceTree EvalSymlinks-es it and
-// certifies the decoy. The manifest stays real, isolating the workspace-root guard. Neutralize →
-// decoy walked → FAIL.
+// decoy tree outside StateRoot) must be rejected by descriptor inspection. The manifest stays
+// real, which isolates the workspace-root guard. Neutralize the guard and the test fails.
 func TestConformanceRejectsSymlinkedWorkspaceRoot(t *testing.T) {
 	t.Parallel()
 	_, _, contract, c, layout, mat, _ := symlinkLifecycle(t)

--- a/internal/applecontainer/manifest_read.go
+++ b/internal/applecontainer/manifest_read.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/pathutil"
+	"golang.org/x/sys/unix"
+)
+
+func rejectDuplicateJSONKeys(raw []byte) error {
+	return scanJSONValue(json.NewDecoder(bytes.NewReader(raw)))
+}
+
+func scanJSONValue(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		return nil
+	}
+	if delim == '{' {
+		seen := make(map[string]struct{})
+		for dec.More() {
+			key, err := dec.Token()
+			if err != nil {
+				return err
+			}
+			name, ok := key.(string)
+			if !ok {
+				return fmt.Errorf("JSON object key is not a string")
+			}
+			if _, found := seen[name]; found {
+				return fmt.Errorf("duplicate JSON key %q", name)
+			}
+			seen[name] = struct{}{}
+			if err := scanJSONValue(dec); err != nil {
+				return err
+			}
+		}
+	} else {
+		for dec.More() {
+			if err := scanJSONValue(dec); err != nil {
+				return err
+			}
+		}
+	}
+	_, err = dec.Token()
+	return err
+}
+
+// readFileSafeBounded reads a stable, single-linked regular file through a
+// pinned parent. It accepts files up to limit bytes and verifies the final name.
+func readFileSafeBounded(trustedRoot, filePath, label string, limit int64) ([]byte, error) {
+	return readFileSafeBoundedWithParent(trustedRoot, filePath, label, limit, openParentDirNoCreate, nil)
+}
+
+func readFileSafeBoundedWithParent(trustedRoot, filePath, label string, limit int64, openParent func(string, string) (int, error), validate func([]byte) error) ([]byte, error) {
+	if limit < 0 {
+		return nil, fmt.Errorf("%s has an invalid byte limit", label)
+	}
+	parentFD, err := openParent(trustedRoot, filepath.Dir(filePath))
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(parentFD)
+	name := filepath.Base(filePath)
+	fd, err := unix.Openat(parentFD, name, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %s %q: %w", label, filePath, err)
+	}
+	handle := os.NewFile(uintptr(fd), filePath)
+	defer handle.Close()
+
+	var before unix.Stat_t
+	if err := unix.Fstat(fd, &before); err != nil {
+		return nil, fmt.Errorf("stat %s %q: %w", label, filePath, err)
+	}
+	want := workspaceSnapshotFromUnix(before)
+	if want.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFREG) {
+		return nil, fmt.Errorf("%s %q is not a regular file", label, filePath)
+	}
+	if want.nlink != 1 {
+		return nil, fmt.Errorf("%s %q is multiply linked (%d links)", label, filePath, want.nlink)
+	}
+	if want.size < 0 || want.size > limit {
+		return nil, fmt.Errorf("%s exceeds the byte limit of %d: %s", label, limit, name)
+	}
+	data, err := io.ReadAll(io.LimitReader(handle, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s %q: %w", label, filePath, err)
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("%s exceeds the byte limit of %d: %s", label, limit, name)
+	}
+	if int64(len(data)) != want.size {
+		return nil, fmt.Errorf("%s %q changed while reading", label, filePath)
+	}
+
+	if _, err := handle.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seek %s %q: %w", label, filePath, err)
+	}
+	digest := sha256.Sum256(data)
+	check := sha256.New()
+	read, err := io.Copy(check, io.LimitReader(handle, limit+1))
+	if err != nil || read != int64(len(data)) || !bytes.Equal(check.Sum(nil), digest[:]) {
+		return nil, fmt.Errorf("%s %q changed during verification", label, filePath)
+	}
+	// Keep both original descriptors open through decoding and caller validation.
+	// Reopen the full path only after all semantic work completes.
+	if validate != nil {
+		if err := validate(data); err != nil {
+			return nil, err
+		}
+	}
+	reopenedParent, err := openParent(trustedRoot, filepath.Dir(filePath))
+	if err != nil {
+		return nil, fmt.Errorf("%s %q changed during verification", label, filePath)
+	}
+	defer unix.Close(reopenedParent)
+	var opened, named, pinnedParent, reboundParent, reboundLeaf unix.Stat_t
+	if err := unix.Fstat(fd, &opened); err != nil {
+		return nil, fmt.Errorf("restat %s %q: %w", label, filePath, err)
+	}
+	if err := unix.Fstatat(parentFD, name, &named, unix.AT_SYMLINK_NOFOLLOW); err != nil ||
+		unix.Fstat(parentFD, &pinnedParent) != nil || unix.Fstat(reopenedParent, &reboundParent) != nil ||
+		unix.Fstatat(reopenedParent, name, &reboundLeaf, unix.AT_SYMLINK_NOFOLLOW) != nil ||
+		workspaceSnapshotFromUnix(opened) != want || workspaceSnapshotFromUnix(named) != want ||
+		workspaceSnapshotFromUnix(pinnedParent) != workspaceSnapshotFromUnix(reboundParent) ||
+		workspaceSnapshotFromUnix(reboundLeaf) != want {
+		return nil, fmt.Errorf("%s %q changed during verification", label, filePath)
+	}
+	return data, nil
+}
+
+func readPersistedManifest(stateRoot, manifestPath string, into any) error {
+	return readPersistedManifestWithParent(stateRoot, manifestPath, into, openParentDirNoCreate, nil)
+}
+
+func readPersistedManifestWithParent(stateRoot, manifestPath string, into any, openParent func(string, string) (int, error), validate func([]byte) error) error {
+	_, err := readFileSafeBoundedWithParent(stateRoot, manifestPath, "manifest", workspaceManifestMaxBytes, openParent, func(data []byte) error {
+		if err := rejectDuplicateJSONKeys(data); err != nil {
+			return fmt.Errorf("manifest at %q: %w", manifestPath, err)
+		}
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(into); err != nil {
+			return fmt.Errorf("manifest at %q: %w", manifestPath, err)
+		}
+		if _, err := dec.Token(); err != io.EOF {
+			return fmt.Errorf("manifest at %q: trailing data after manifest", manifestPath)
+		}
+		if manifest, ok := into.(*WorkspaceManifest); ok {
+			if err := validateWorkspaceManifestStructure(*manifest); err != nil {
+				return fmt.Errorf("manifest at %q: %w", manifestPath, err)
+			}
+		}
+		want, err := marshalManifestBytes(into)
+		if err != nil {
+			return fmt.Errorf("manifest at %q: %w", manifestPath, err)
+		}
+		if !bytes.Equal(data, want) {
+			return fmt.Errorf("manifest at %q is not canonical", manifestPath)
+		}
+		if validate != nil {
+			return validate(data)
+		}
+		return nil
+	})
+	return err
+}
+
+func validateWorkspaceManifestStructure(manifest WorkspaceManifest) error {
+	for label, value := range map[string]string{
+		"source_workspace":       manifest.SourceWorkspace,
+		"materialized_workspace": manifest.MaterializedWorkspace,
+	} {
+		if _, err := pathutil.CollisionKey(value); err != nil {
+			return fmt.Errorf("invalid %s: %w", label, err)
+		}
+	}
+	if manifest.ExcludedPaths == nil {
+		return fmt.Errorf("excluded_paths must not be null")
+	}
+	for _, excluded := range manifest.ExcludedPaths {
+		if _, err := pathutil.CollisionKey(excluded); err != nil {
+			return fmt.Errorf("invalid excluded path: %w", err)
+		}
+	}
+	if manifest.Entries == nil {
+		return fmt.Errorf("entries must not be null")
+	}
+	if len(manifest.Entries) > workspaceMaxEntries {
+		return fmt.Errorf("entries exceeds %d items", workspaceMaxEntries)
+	}
+	seen := make(map[string]string, len(manifest.Entries))
+	for index, entry := range manifest.Entries {
+		if entry.Path == "" || path.IsAbs(entry.Path) || path.Clean(entry.Path) != entry.Path {
+			return fmt.Errorf("entry %d has an invalid path", index)
+		}
+		components := strings.Split(entry.Path, "/")
+		if err := validateWorkspacePath(entry.Path, len(components)); err != nil {
+			return err
+		}
+		for _, component := range components {
+			if err := validateWorkspaceLeaf("workspace manifest entry", component); err != nil {
+				return err
+			}
+		}
+		key, err := pathutil.CollisionKey(entry.Path)
+		if err != nil {
+			return err
+		}
+		if previous, found := seen[key]; found {
+			return fmt.Errorf("workspace manifest entry collision between %q and %q", previous, entry.Path)
+		}
+		seen[key] = entry.Path
+		if index > 0 && manifest.Entries[index-1].Path >= entry.Path {
+			return fmt.Errorf("workspace manifest entries are not in canonical order")
+		}
+		if err := validateWorkspaceManifestEntry(entry); err != nil {
+			return fmt.Errorf("entry %q: %w", entry.Path, err)
+		}
+	}
+	if err := validateWorkspaceLinks(manifest.Entries); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateWorkspaceManifestEntry(entry WorkspaceEntry) error {
+	allowedMode := fs.ModePerm
+	switch entry.Kind {
+	case "dir":
+		allowedMode |= fs.ModeDir
+		if entry.Mode.Type() != fs.ModeDir || entry.SHA256 != "" || entry.LinkTarget != "" {
+			return fmt.Errorf("directory metadata is invalid")
+		}
+	case "file":
+		if entry.Mode.Type() != 0 || entry.LinkTarget != "" || len(entry.SHA256) != sha256.Size*2 || entry.SHA256 != strings.ToLower(entry.SHA256) {
+			return fmt.Errorf("file metadata is invalid")
+		}
+		if _, err := hex.DecodeString(entry.SHA256); err != nil {
+			return fmt.Errorf("file digest is invalid")
+		}
+	case "symlink":
+		allowedMode |= fs.ModeSymlink
+		if entry.Mode.Type() != fs.ModeSymlink || entry.SHA256 != "" || entry.LinkTarget == "" || path.IsAbs(entry.LinkTarget) {
+			return fmt.Errorf("symlink metadata is invalid")
+		}
+		if len(entry.LinkTarget) > workspaceMaxLinkBytes {
+			return fmt.Errorf("symlink target exceeds %d bytes", workspaceMaxLinkBytes)
+		}
+		if _, err := pathutil.CollisionKey(entry.LinkTarget); err != nil {
+			return fmt.Errorf("symlink target is invalid: %w", err)
+		}
+	default:
+		return fmt.Errorf("kind is invalid")
+	}
+	if entry.Mode&^allowedMode != 0 {
+		return fmt.Errorf("mode has unsupported bits")
+	}
+	return nil
+}
+
+func sortedWorkspaceEntries(entries []WorkspaceEntry) []WorkspaceEntry {
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	return entries
+}

--- a/internal/applecontainer/manifest_read_test.go
+++ b/internal/applecontainer/manifest_read_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func testWorkspaceManifest() WorkspaceManifest {
+	return WorkspaceManifest{
+		Version:               1,
+		TargetKind:            TargetKind,
+		TargetProvider:        Provider,
+		TargetID:              "tid",
+		WorkspaceTransport:    WorkspaceTransport,
+		SourceWorkspace:       "/source",
+		MaterializationID:     "mid",
+		MaterializedWorkspace: "/state/targets/local_vm/apple-container/tid/materializations/mid/workspace",
+		ExcludedPaths:         []string{".git"},
+		Entries:               []WorkspaceEntry{},
+	}
+}
+
+func canonicalManifestForTest(t *testing.T, manifest WorkspaceManifest) []byte {
+	t.Helper()
+	data, err := json.Marshal(manifest)
+	mustNil(t, err)
+	return append(data, '\n')
+}
+
+func TestPersistedWorkspaceManifestRejectsNonExactData(t *testing.T) {
+	stateRoot := t.TempDir()
+	manifestPath := filepath.Join(stateRoot, "materialization.json")
+	valid := canonicalManifestForTest(t, testWorkspaceManifest())
+	mustNil(t, os.WriteFile(manifestPath, valid, 0o600))
+	var decoded WorkspaceManifest
+	mustNil(t, readPersistedManifest(stateRoot, manifestPath, &decoded))
+
+	duplicateEntries := testWorkspaceManifest()
+	duplicateEntries.Entries = []WorkspaceEntry{
+		{Path: "same", Kind: "dir", Mode: fs.ModeDir | 0o755},
+		{Path: "same", Kind: "dir", Mode: fs.ModeDir | 0o755},
+	}
+	unicodeAliases := testWorkspaceManifest()
+	unicodeAliases.Entries = []WorkspaceEntry{
+		{Path: "Cafe\u0301", Kind: "dir", Mode: fs.ModeDir | 0o755},
+		{Path: "Caf\u00e9", Kind: "dir", Mode: fs.ModeDir | 0o755},
+	}
+	emptyEntry := testWorkspaceManifest()
+	emptyEntry.Entries = []WorkspaceEntry{{}}
+	nullEntries := bytes.Replace(valid, []byte(`"entries":[]`), []byte(`"entries":null`), 1)
+	duplicateKey := bytes.Replace(valid, []byte(`"version":1`), []byte(`"version":1,"version":1`), 1)
+	unknownKey := bytes.Replace(valid, []byte(`{"version":1`), []byte(`{"unknown":true,"version":1`), 1)
+
+	for _, testCase := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty", data: nil},
+		{name: "short", data: valid[:len(valid)/2]},
+		{name: "trailing-object", data: append(append([]byte(nil), valid...), []byte("{}\n")...)},
+		{name: "trailing-delimiter", data: append(append([]byte(nil), valid...), '}')},
+		{name: "unknown-key", data: unknownKey},
+		{name: "duplicate-key", data: duplicateKey},
+		{name: "null-entries", data: nullEntries},
+		{name: "duplicate-entry", data: canonicalManifestForTest(t, duplicateEntries)},
+		{name: "unicode-entry-alias", data: canonicalManifestForTest(t, unicodeAliases)},
+		{name: "empty-entry", data: canonicalManifestForTest(t, emptyEntry)},
+		{name: "noncanonical-whitespace", data: append([]byte(" \n"), valid...)},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			mustNil(t, os.WriteFile(manifestPath, testCase.data, 0o600))
+			var got WorkspaceManifest
+			if err := readPersistedManifest(stateRoot, manifestPath, &got); err == nil {
+				t.Fatal("invalid persisted workspace manifest was accepted")
+			}
+		})
+	}
+}
+
+func TestReadFileSafeBoundedAcceptsExactAndRejectsOverLimit(t *testing.T) {
+	const limit = int64(4096)
+	stateRoot := t.TempDir()
+	path := filepath.Join(stateRoot, "manifest.json")
+	for _, testCase := range []struct {
+		name    string
+		size    int64
+		wantErr bool
+	}{
+		{name: "exact", size: limit},
+		{name: "over", size: limit + 1, wantErr: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			mustNil(t, os.WriteFile(path, []byte(strings.Repeat("x", int(testCase.size))), 0o600))
+			got, err := readFileSafeBounded(stateRoot, path, "manifest", limit)
+			if (err != nil) != testCase.wantErr {
+				t.Fatalf("readFileSafeBounded() error = %v, wantErr %t", err, testCase.wantErr)
+			}
+			if !testCase.wantErr && int64(len(got)) != limit {
+				t.Fatalf("read size = %d, want %d", len(got), limit)
+			}
+		})
+	}
+}
+
+func TestPersistedManifestRejectsHardlinkAndSpecialLeaf(t *testing.T) {
+	stateRoot := t.TempDir()
+	manifestPath := filepath.Join(stateRoot, "materialization.json")
+	outside := filepath.Join(t.TempDir(), "outside.json")
+	mustNil(t, os.WriteFile(outside, canonicalManifestForTest(t, testWorkspaceManifest()), 0o600))
+	mustNil(t, os.Link(outside, manifestPath))
+	var manifest WorkspaceManifest
+	if err := readPersistedManifest(stateRoot, manifestPath, &manifest); err == nil || !strings.Contains(err.Error(), "multiply linked") {
+		t.Fatalf("hardlinked manifest error = %v", err)
+	}
+
+	mustNil(t, os.Remove(manifestPath))
+	mustNil(t, unix.Mkfifo(manifestPath, 0o600))
+	result := make(chan error, 1)
+	go func() { result <- readPersistedManifest(stateRoot, manifestPath, &manifest) }()
+	select {
+	case err := <-result:
+		if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+			t.Fatalf("FIFO manifest error = %v", err)
+		}
+	case <-time.After(time.Second):
+		fd, _ := unix.Open(manifestPath, unix.O_RDWR|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+		if fd >= 0 {
+			defer unix.Close(fd)
+		}
+		select {
+		case <-result:
+		case <-time.After(time.Second):
+		}
+		t.Fatal("FIFO manifest read blocked")
+	}
+}
+
+func TestPersistedManifestRejectsPostValidationParentRebinding(t *testing.T) {
+	root := t.TempDir()
+	parent, replacement := filepath.Join(root, "parent"), filepath.Join(root, "replacement")
+	manifest := testWorkspaceManifest()
+	for _, dir := range []string{parent, replacement} {
+		mustNil(t, os.Mkdir(dir, 0o700))
+		mustNil(t, os.WriteFile(filepath.Join(dir, "manifest.json"), canonicalManifestForTest(t, manifest), 0o600))
+	}
+	validated := false
+	calls := 0
+	openParent := func(root, path string) (int, error) {
+		calls++
+		if calls == 2 && validated {
+			mustNil(t, os.Rename(parent, parent+".saved"))
+			mustNil(t, os.Rename(replacement, parent))
+		}
+		return openParentDirNoCreate(root, path)
+	}
+	var got WorkspaceManifest
+	if err := readPersistedManifestWithParent(root, filepath.Join(parent, "manifest.json"), &got, openParent, func([]byte) error {
+		validated = true
+		return nil
+	}); err == nil || calls != 2 {
+		t.Fatalf("parent rebind result: opens=%d error=%v", calls, err)
+	}
+}
+
+func TestPersistedManifestUsesWorkspaceByteLimit(t *testing.T) {
+	stateRoot := t.TempDir()
+	manifestPath := filepath.Join(stateRoot, "materialization.json")
+	mustNil(t, os.WriteFile(manifestPath, nil, 0o600))
+	mustNil(t, os.Truncate(manifestPath, workspaceManifestMaxBytes+1))
+	var manifest WorkspaceManifest
+	err := readPersistedManifest(stateRoot, manifestPath, &manifest)
+	if err == nil || !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("over-limit persisted manifest error = %v", err)
+	}
+}
+
+func TestPersistedWorkspaceManifestRejectsPathAndMetadataConfusion(t *testing.T) {
+	base := testWorkspaceManifest()
+	validDigest := strings.Repeat("a", 64)
+	mutations := []func(*WorkspaceManifest){
+		func(m *WorkspaceManifest) { m.SourceWorkspace = "source\nevent=forged" },
+		func(m *WorkspaceManifest) { m.MaterializedWorkspace = string([]byte{'/', 'x', 0xff}) },
+		func(m *WorkspaceManifest) {
+			m.Entries = []WorkspaceEntry{{Path: "../escape", Kind: "file", Mode: 0o600, SHA256: validDigest}}
+		},
+		func(m *WorkspaceManifest) {
+			m.Entries = []WorkspaceEntry{{Path: "file", Kind: "file", Mode: 0o600, SHA256: "ABC" + strings.Repeat("a", 61)}}
+		},
+		func(m *WorkspaceManifest) {
+			m.Entries = []WorkspaceEntry{{Path: "link", Kind: "symlink", Mode: fs.ModeSymlink | 0o777, LinkTarget: "/outside"}}
+		},
+		func(m *WorkspaceManifest) {
+			m.Entries = []WorkspaceEntry{
+				{Path: "file", Kind: "file", Mode: 0o600, SHA256: validDigest},
+				{Path: "link", Kind: "symlink", Mode: fs.ModeSymlink | 0o777, LinkTarget: strings.Repeat("./", workspaceMaxLinkBytes/2) + "file"},
+			}
+		},
+	}
+	for index, mutate := range mutations {
+		manifest := base
+		mutate(&manifest)
+		if err := validateWorkspaceManifestStructure(manifest); err == nil {
+			t.Fatalf("mutation %d was accepted", index)
+		}
+	}
+}

--- a/internal/applecontainer/target_session.go
+++ b/internal/applecontainer/target_session.go
@@ -520,18 +520,29 @@ func (t AppleContainerTarget) FinishSession(_ context.Context, req FinishSession
 // manifest is read through the hardened path so a manifest FILE swapped for a
 // symlink/FIFO is refused, not followed, even though its parent chain was checked.
 func verifyPersistedManifest(stateRoot, path string, manifest any) error {
-	onDisk, err := readFileSafe(stateRoot, path, "manifest")
-	if err != nil {
-		return err
+	return verifyPersistedManifestWithParent(stateRoot, path, manifest, openParentDirNoCreate)
+}
+
+func verifyPersistedManifestWithParent(stateRoot, path string, manifest any, openParent func(string, string) (int, error)) error {
+	var into any
+	switch manifest.(type) {
+	case WorkspaceManifest:
+		into = &WorkspaceManifest{}
+	case BootstrapManifest:
+		into = &BootstrapManifest{}
+	default:
+		return fmt.Errorf("unknown manifest type %T", manifest)
 	}
 	want, err := marshalManifestBytes(manifest)
 	if err != nil {
 		return err
 	}
-	if !bytes.Equal(onDisk, want) {
-		return fmt.Errorf("persisted manifest %q does not match the in-memory manifest", path)
-	}
-	return nil
+	return readPersistedManifestWithParent(stateRoot, path, into, openParent, func(data []byte) error {
+		if !bytes.Equal(data, want) {
+			return fmt.Errorf("persisted manifest %q does not match the in-memory manifest", path)
+		}
+		return nil
+	})
 }
 
 // assertManifestContract pins a manifest's contract-sourced identity fields to

--- a/internal/applecontainer/workspace_inspect.go
+++ b/internal/applecontainer/workspace_inspect.go
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"sort"
+
+	"github.com/omkhar/workcell/internal/pathutil"
+	"golang.org/x/sys/unix"
+)
+
+// inspectSourceWorkspace reads a source tree without creating a mirror. It
+// requires the source path to bind the same directory after inspection.
+func inspectSourceWorkspace(sourceRoot string, excluded []string) ([]WorkspaceEntry, error) {
+	return inspectSourceWorkspaceWithOps(sourceRoot, excluded, defaultWorkspaceCopyLimits(), systemWorkspaceOps())
+}
+
+func inspectSourceWorkspaceWithOps(sourceRoot string, excluded []string, limits workspaceCopyLimits, ops workspaceOps) ([]WorkspaceEntry, error) {
+	if !workspaceCopySupported {
+		return nil, errWorkspaceCopyUnsupported
+	}
+	for _, item := range excluded {
+		if _, err := pathutil.CollisionKey(item); err != nil {
+			return nil, fmt.Errorf("invalid excluded path: %w", err)
+		}
+	}
+	rootFD, rootSnapshot, err := openWorkspaceSourceRoot(sourceRoot, ops)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(rootFD)
+	entries, err := inspectWorkspaceDescriptor(rootFD, rootSnapshot, excluded, limits, ops)
+	if err != nil {
+		return nil, err
+	}
+	reopened, rebound, err := openWorkspaceSourceRoot(sourceRoot, ops)
+	if err != nil {
+		return nil, fmt.Errorf("source workspace changed after inspection: %w", err)
+	}
+	defer unix.Close(reopened)
+	if rebound != rootSnapshot {
+		return nil, fmt.Errorf("source workspace changed after inspection")
+	}
+	return entries, nil
+}
+
+// inspectMaterializedWorkspace reads a derived workspace through StateRoot.
+// It rejects parent symlinks and requires the final name to retain its inode.
+func inspectMaterializedWorkspace(stateRoot, workspaceRoot string) ([]WorkspaceEntry, error) {
+	parentFD, err := openParentDirNoCreate(stateRoot, filepath.Dir(workspaceRoot))
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(parentFD)
+	name := filepath.Base(workspaceRoot)
+	var initial unix.Stat_t
+	if err := unix.Fstatat(parentFD, name, &initial, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return nil, err
+	}
+	expected := workspaceSnapshotFromUnix(initial)
+	entries, err := inspectWorkspaceAt(parentFD, name, expected, nil, defaultWorkspaceCopyLimits(), systemWorkspaceOps())
+	if err != nil {
+		return nil, err
+	}
+	finalStat, err := statPathSafe(stateRoot, workspaceRoot)
+	if err != nil || workspaceSnapshotFromUnix(finalStat) != expected {
+		return nil, fmt.Errorf("materialized workspace path changed during inspection")
+	}
+	var pinned unix.Stat_t
+	if err := unix.Fstatat(parentFD, name, &pinned, unix.AT_SYMLINK_NOFOLLOW); err != nil ||
+		workspaceSnapshotFromUnix(pinned) != expected {
+		return nil, fmt.Errorf("materialized workspace path changed during inspection")
+	}
+	return entries, nil
+}
+
+func inspectWorkspaceAt(parentFD int, name string, expected workspaceSnapshot, excluded []string, limits workspaceCopyLimits, ops workspaceOps) ([]WorkspaceEntry, error) {
+	if !workspaceCopySupported {
+		return nil, errWorkspaceCopyUnsupported
+	}
+	if err := validateWorkspaceLeaf("workspace root", name); err != nil {
+		return nil, err
+	}
+	var before unix.Stat_t
+	if err := ops.fstatat(parentFD, name, &before, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return nil, err
+	}
+	if workspaceSnapshotFromUnix(before) != expected {
+		return nil, fmt.Errorf("materialized workspace changed before opening")
+	}
+	if expected.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFDIR) {
+		return nil, fmt.Errorf("materialized workspace is not a directory")
+	}
+	rootFD, err := ops.openat(parentFD, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(rootFD)
+	opened, err := verifyWorkspaceNameAt(parentFD, name, rootFD, ops)
+	if err != nil || opened != expected {
+		return nil, fmt.Errorf("materialized workspace changed while opening")
+	}
+	entries, err := inspectWorkspaceDescriptor(rootFD, opened, excluded, limits, ops)
+	if err != nil {
+		return nil, err
+	}
+	stable, err := verifyWorkspaceNameAt(parentFD, name, rootFD, ops)
+	if err != nil || stable != opened {
+		return nil, fmt.Errorf("materialized workspace binding changed during inspection")
+	}
+	return entries, nil
+}
+
+type workspaceInspector struct {
+	walk *workspaceWalk
+}
+
+func inspectWorkspaceDescriptor(rootFD int, rootSnapshot workspaceSnapshot, excluded []string, limits workspaceCopyLimits, ops workspaceOps) ([]WorkspaceEntry, error) {
+	walk := &workspaceWalk{
+		excluded:    excluded,
+		limits:      limits,
+		entries:     make([]WorkspaceEntry, 0),
+		reserved:    make(map[string]WorkspaceEntry),
+		directories: make(map[workspaceObjectID]string),
+		ops:         ops,
+	}
+	inspector := workspaceInspector{walk: walk}
+	if err := inspector.directory(rootFD, "", 0, rootSnapshot); err != nil {
+		return nil, err
+	}
+	if err := validateWorkspaceLinks(walk.entries); err != nil {
+		return nil, err
+	}
+	return sortedWorkspaceEntries(walk.entries), nil
+}
+
+func (inspector workspaceInspector) directory(fd int, parentRel string, depth int, expected workspaceSnapshot) error {
+	id := workspaceObjectID{expected.dev, expected.ino}
+	if previous, found := inspector.walk.directories[id]; found {
+		return fmt.Errorf("workspace directory identity repeats at %q and %q", previous, parentRel)
+	}
+	inspector.walk.directories[id] = parentRel
+	initialNames, err := workspaceDirectoryNames(fd, workspaceMaxEntries+1)
+	if err != nil {
+		return err
+	}
+	for _, name := range initialNames {
+		if err := validateWorkspaceLeaf("workspace entry", name); err != nil {
+			return err
+		}
+		rel := path.Join(parentRel, name)
+		if err := validateWorkspacePath(rel, depth+1); err != nil {
+			return err
+		}
+		excluded, err := isExcludedPathSafe(rel, inspector.walk.excluded)
+		if err != nil {
+			return err
+		}
+		if inspector.walk.entryCount >= inspector.walk.limits.maxEntries {
+			return fmt.Errorf("workspace has more than %d entries", inspector.walk.limits.maxEntries)
+		}
+		inspector.walk.entryCount++
+		if excluded {
+			continue
+		}
+		var stat unix.Stat_t
+		if err := inspector.walk.ops.fstatat(fd, name, &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			return fmt.Errorf("stat workspace entry %q: %w", rel, err)
+		}
+		before := workspaceSnapshotFromUnix(stat)
+		if err := inspector.walk.reserve(rel); err != nil {
+			return err
+		}
+		var entry WorkspaceEntry
+		switch before.mode & uint32(unix.S_IFMT) {
+		case uint32(unix.S_IFDIR):
+			entry, err = inspector.inspectDirectory(fd, name, rel, depth+1, before)
+		case uint32(unix.S_IFREG):
+			entry, err = inspector.inspectFile(fd, name, rel, before)
+		case uint32(unix.S_IFLNK):
+			entry, err = inspector.inspectSymlink(fd, name, rel, before)
+		default:
+			err = fmt.Errorf("unsupported workspace entry kind for %q", rel)
+		}
+		if err != nil {
+			return err
+		}
+		if err := inspector.walk.retain(entry); err != nil {
+			return err
+		}
+	}
+	var after unix.Stat_t
+	if err := inspector.walk.ops.fstat(fd, &after); err != nil || workspaceSnapshotFromUnix(after) != expected {
+		return fmt.Errorf("workspace directory changed during inspection")
+	}
+	stableNames, err := workspaceDirectoryNames(fd, len(initialNames)+1)
+	if err != nil {
+		return err
+	}
+	sort.Strings(initialNames)
+	sort.Strings(stableNames)
+	if !slices.Equal(initialNames, stableNames) {
+		return fmt.Errorf("workspace directory entries changed during inspection")
+	}
+	return nil
+}
+
+func (inspector workspaceInspector) inspectDirectory(parentFD int, name, rel string, depth int, before workspaceSnapshot) (WorkspaceEntry, error) {
+	fd, err := inspector.walk.ops.openat(parentFD, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return WorkspaceEntry{}, fmt.Errorf("open workspace directory %q: %w", rel, err)
+	}
+	defer unix.Close(fd)
+	opened, err := verifyWorkspaceNameAt(parentFD, name, fd, inspector.walk.ops)
+	if err != nil || opened != before {
+		return WorkspaceEntry{}, fmt.Errorf("workspace directory %q changed while opening", rel)
+	}
+	if err := inspector.directory(fd, rel, depth, opened); err != nil {
+		return WorkspaceEntry{}, err
+	}
+	stable, err := verifyWorkspaceNameAt(parentFD, name, fd, inspector.walk.ops)
+	if err != nil || stable != opened {
+		return WorkspaceEntry{}, fmt.Errorf("workspace directory %q changed during inspection", rel)
+	}
+	return WorkspaceEntry{Path: rel, Kind: "dir", Mode: entryMode(stable, fs.ModeDir)}, nil
+}
+
+func (inspector workspaceInspector) inspectFile(parentFD int, name, rel string, before workspaceSnapshot) (WorkspaceEntry, error) {
+	fd, err := inspector.walk.ops.openat(parentFD, name, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return WorkspaceEntry{}, fmt.Errorf("open workspace file %q: %w", rel, err)
+	}
+	file := os.NewFile(uintptr(fd), rel)
+	defer file.Close()
+	var stat unix.Stat_t
+	if err := inspector.walk.ops.fstat(fd, &stat); err != nil {
+		return WorkspaceEntry{}, err
+	}
+	opened := workspaceSnapshotFromUnix(stat)
+	if opened != before || opened.mode&uint32(unix.S_IFMT) != uint32(unix.S_IFREG) || opened.nlink != 1 {
+		return WorkspaceEntry{}, fmt.Errorf("workspace file %q changed kind or is multiply linked", rel)
+	}
+	if opened.size < 0 || opened.size > inspector.walk.limits.maxFileBytes || opened.size > inspector.walk.limits.maxBytes-inspector.walk.totalBytes {
+		return WorkspaceEntry{}, inspector.walk.sizeError(rel, opened.size)
+	}
+	hash := sha256.New()
+	read, err := io.Copy(hash, io.LimitReader(file, opened.size+1))
+	if err != nil || read != opened.size {
+		return WorkspaceEntry{}, fmt.Errorf("workspace file %q changed while reading", rel)
+	}
+	digest := hash.Sum(nil)
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return WorkspaceEntry{}, err
+	}
+	stableHash := sha256.New()
+	stableRead, err := io.Copy(stableHash, io.LimitReader(file, opened.size+1))
+	if err != nil || stableRead != opened.size || !bytes.Equal(stableHash.Sum(nil), digest) {
+		return WorkspaceEntry{}, fmt.Errorf("workspace file %q content changed during inspection", rel)
+	}
+	stable, err := verifyWorkspaceNameAt(parentFD, name, fd, inspector.walk.ops)
+	if err != nil || stable != opened {
+		return WorkspaceEntry{}, fmt.Errorf("workspace file %q changed during inspection", rel)
+	}
+	inspector.walk.totalBytes += opened.size
+	return WorkspaceEntry{Path: rel, Kind: "file", Mode: entryMode(stable, 0), SHA256: hex.EncodeToString(digest)}, nil
+}
+
+func (inspector workspaceInspector) inspectSymlink(parentFD int, name, rel string, before workspaceSnapshot) (WorkspaceEntry, error) {
+	fd, err := inspector.walk.ops.openat(parentFD, name, workspaceSymlinkOpenFlags, 0)
+	if err != nil {
+		return WorkspaceEntry{}, fmt.Errorf("pin workspace symlink %q: %w", rel, err)
+	}
+	defer unix.Close(fd)
+	opened, err := verifyWorkspaceNameAt(parentFD, name, fd, inspector.walk.ops)
+	if err != nil || opened != before || opened.nlink != 1 {
+		return WorkspaceEntry{}, fmt.Errorf("workspace symlink %q changed or is multiply linked", rel)
+	}
+	target, err := readWorkspaceLink(fd, "", inspector.walk.ops)
+	if err != nil {
+		return WorkspaceEntry{}, err
+	}
+	if target == "" || path.IsAbs(target) {
+		return WorkspaceEntry{}, fmt.Errorf("workspace symlink %q has an invalid target", rel)
+	}
+	if _, err := pathutil.CollisionKey(target); err != nil {
+		return WorkspaceEntry{}, fmt.Errorf("workspace symlink %q has an invalid target: %w", rel, err)
+	}
+	stable, err := verifyWorkspaceNameAt(parentFD, name, fd, inspector.walk.ops)
+	if err != nil || stable != opened {
+		return WorkspaceEntry{}, fmt.Errorf("workspace symlink %q changed during inspection", rel)
+	}
+	return WorkspaceEntry{Path: rel, Kind: "symlink", Mode: entryMode(stable, fs.ModeSymlink), LinkTarget: target}, nil
+}

--- a/internal/applecontainer/workspace_inspect_test.go
+++ b/internal/applecontainer/workspace_inspect_test.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestWorkspaceInspectionMatchesPublishedManifest(t *testing.T) {
+	target, err := NewAppleContainerTarget(Contract{})
+	mustNil(t, err)
+	stateRoot, sourceRoot := t.TempDir(), writeSampleWorkspace(t)
+	mustNil(t, os.Symlink("README.md", filepath.Join(sourceRoot, "readme-link")))
+	materialized, err := target.MaterializeWorkspace(context.Background(), MaterializeRequest{
+		StateRoot: stateRoot, TargetID: "tid", MaterializationID: "mid", SourceWorkspace: sourceRoot,
+	})
+	mustNil(t, err)
+
+	sourceEntries, err := inspectSourceWorkspace(sourceRoot, target.Contract.WorkspaceMaterialization.ExcludedPaths)
+	mustNil(t, err)
+	finalEntries, err := inspectMaterializedWorkspace(stateRoot, materialized.MaterializedWorkspace)
+	mustNil(t, err)
+	if !slices.Equal(sourceEntries, materialized.Manifest.Entries) || !slices.Equal(finalEntries, materialized.Manifest.Entries) {
+		t.Fatalf("inspection entries differ from the published manifest")
+	}
+}
+
+func TestWorkspaceInspectionReadsPinnedSymlinkDuringABA(t *testing.T) {
+	sourceRoot := t.TempDir()
+	for _, name := range []string{"file", "other"} {
+		mustNil(t, os.WriteFile(filepath.Join(sourceRoot, name), []byte(name), 0o600))
+	}
+	link := filepath.Join(sourceRoot, "link")
+	mustNil(t, os.Symlink("file", link))
+	ops := systemWorkspaceOps()
+	originalReadlink := ops.readlink
+	pinned := false
+	observed := ""
+	ops.readlink = func(fd int, name string, buffer []byte) (int, error) {
+		pinned = name == ""
+		saved := link + ".saved"
+		if err := os.Rename(link, saved); err != nil {
+			return 0, err
+		}
+		if err := os.Symlink("other", link); err != nil {
+			_ = os.Rename(saved, link)
+			return 0, err
+		}
+		count, readErr := originalReadlink(fd, name, buffer)
+		if readErr == nil {
+			observed = string(buffer[:count])
+		}
+		restoreErr := errors.Join(os.Remove(link), os.Rename(saved, link))
+		return count, errors.Join(readErr, restoreErr)
+	}
+	_, err := inspectSourceWorkspaceWithOps(sourceRoot, nil, defaultWorkspaceCopyLimits(), ops)
+	if (err != nil && !strings.Contains(err.Error(), "workspace symlink \"link\" changed during inspection")) || !pinned || observed != "file" {
+		t.Fatalf("symlink ABA result: pinned=%t observed=%q error=%v", pinned, observed, err)
+	}
+}
+
+func TestWorkspaceInspectionRejectsSpecialFileBeforeOpen(t *testing.T) {
+	sourceRoot := t.TempDir()
+	mustNil(t, unix.Mkfifo(filepath.Join(sourceRoot, "pipe"), 0o600))
+	ops := systemWorkspaceOps()
+	originalOpenat := ops.openat
+	openedPipe := false
+	ops.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
+		if name == "pipe" {
+			openedPipe = true
+		}
+		return originalOpenat(fd, name, flags, mode)
+	}
+	if _, err := inspectSourceWorkspaceWithOps(sourceRoot, nil, defaultWorkspaceCopyLimits(), ops); err == nil || openedPipe {
+		t.Fatalf("special file result: opened=%t error=%v", openedPipe, err)
+	}
+}
+
+func TestConformanceWorkspaceInspectionDoesNotCreateMirror(t *testing.T) {
+	ctx, target, contract, c, layout := newFixture(t)
+	materialized, _ := materializeAndBootstrap(t, ctx, target, c)
+	missingTempRoot := filepath.Join(t.TempDir(), "missing")
+	t.Setenv("TMPDIR", missingTempRoot)
+	if temp, err := os.MkdirTemp("", "must-fail."); err == nil {
+		_ = os.RemoveAll(temp)
+		t.Fatal("test temp root unexpectedly permits mirror creation")
+	}
+	if err := validateMaterialization(contract, layout, materialized, c); err != nil {
+		t.Fatalf("read-only materialization validation failed: %v", err)
+	}
+	if _, err := os.Lstat(missingTempRoot); !os.IsNotExist(err) {
+		t.Fatalf("materialization validation created temp state: %v", err)
+	}
+}
+
+func TestWorkspaceInspectionRejectsSourceRootRebinding(t *testing.T) {
+	sourceRoot := t.TempDir()
+	mustNil(t, os.WriteFile(filepath.Join(sourceRoot, "file"), []byte("content"), 0o600))
+	movedRoot := sourceRoot + ".moved"
+	ops := systemWorkspaceOps()
+	originalStat := ops.stat
+	rootStats := 0
+	ops.stat = func(name string, stat *unix.Stat_t) error {
+		rootStats++
+		if rootStats == 2 {
+			if err := errors.Join(os.Rename(sourceRoot, movedRoot), os.Mkdir(sourceRoot, 0o700)); err != nil {
+				return err
+			}
+			if err := os.WriteFile(filepath.Join(sourceRoot, "file"), []byte("content"), 0o600); err != nil {
+				return err
+			}
+		}
+		return originalStat(name, stat)
+	}
+	if _, err := inspectSourceWorkspaceWithOps(sourceRoot, nil, defaultWorkspaceCopyLimits(), ops); err == nil || rootStats != 2 {
+		t.Fatalf("source rebinding result: rootStats=%d error=%v", rootStats, err)
+	}
+}
+
+func TestWorkspaceInspectionRejectsFinalRootRebinding(t *testing.T) {
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "workspace")
+	mustNil(t, os.Mkdir(workspace, 0o755))
+	mustNil(t, os.WriteFile(filepath.Join(workspace, "file"), []byte("content"), 0o600))
+	parentFD, err := unix.Open(parent, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	mustNil(t, err)
+	defer unix.Close(parentFD)
+	var initial unix.Stat_t
+	mustNil(t, unix.Fstatat(parentFD, "workspace", &initial, unix.AT_SYMLINK_NOFOLLOW))
+	expected := workspaceSnapshotFromUnix(initial)
+
+	ops := systemWorkspaceOps()
+	originalFstatat := ops.fstatat
+	rootStats := 0
+	ops.fstatat = func(fd int, name string, stat *unix.Stat_t, flags int) error {
+		if fd == parentFD && name == "workspace" {
+			rootStats++
+			if rootStats == 3 {
+				if err := errors.Join(os.Rename(workspace, workspace+".moved"), os.Mkdir(workspace, 0o755)); err != nil {
+					return err
+				}
+				if err := os.WriteFile(filepath.Join(workspace, "file"), []byte("content"), 0o600); err != nil {
+					return err
+				}
+			}
+		}
+		return originalFstatat(fd, name, stat, flags)
+	}
+	if _, err := inspectWorkspaceAt(parentFD, "workspace", expected, nil, defaultWorkspaceCopyLimits(), ops); err == nil || rootStats != 3 {
+		t.Fatalf("final rebinding result: rootStats=%d error=%v", rootStats, err)
+	}
+}
+
+func TestWorkspaceInspectionRejectsPreopenRootRebinding(t *testing.T) {
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "workspace")
+	mustNil(t, os.Mkdir(workspace, 0o755))
+	mustNil(t, os.WriteFile(filepath.Join(workspace, "file"), []byte("content"), 0o600))
+	parentFD, err := unix.Open(parent, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	mustNil(t, err)
+	defer unix.Close(parentFD)
+	var initial unix.Stat_t
+	mustNil(t, unix.Fstatat(parentFD, "workspace", &initial, unix.AT_SYMLINK_NOFOLLOW))
+	expected := workspaceSnapshotFromUnix(initial)
+
+	mustNil(t, os.Rename(workspace, workspace+".saved"))
+	mustNil(t, os.Mkdir(workspace, 0o755))
+	mustNil(t, os.WriteFile(filepath.Join(workspace, "file"), []byte("content"), 0o600))
+	if _, err := inspectWorkspaceAt(parentFD, "workspace", expected, nil, defaultWorkspaceCopyLimits(), systemWorkspaceOps()); err == nil ||
+		!strings.Contains(err.Error(), "changed before opening") {
+		t.Fatalf("pre-open root rebinding error = %v", err)
+	}
+}
+
+func TestWorkspaceInspectionRejectsUnsafeIdentityBeforeContentRead(t *testing.T) {
+	sourceRoot := t.TempDir()
+	unsafeName := "secret\nevent=forged"
+	mustNil(t, os.WriteFile(filepath.Join(sourceRoot, unsafeName), []byte("secret"), 0o600))
+	ops := systemWorkspaceOps()
+	originalOpenat := ops.openat
+	openedUnsafe := false
+	ops.openat = func(fd int, name string, flags int, mode uint32) (int, error) {
+		if name == unsafeName {
+			openedUnsafe = true
+		}
+		return originalOpenat(fd, name, flags, mode)
+	}
+	_, err := inspectSourceWorkspaceWithOps(sourceRoot, nil, defaultWorkspaceCopyLimits(), ops)
+	if err == nil || openedUnsafe || strings.Contains(err.Error(), "secret") || strings.Contains(err.Error(), "forged") {
+		t.Fatalf("unsafe identity result: opened=%t error=%v", openedUnsafe, err)
+	}
+}

--- a/internal/applecontainer/workspace_publish.go
+++ b/internal/applecontainer/workspace_publish.go
@@ -326,6 +326,9 @@ func marshalManifestBytes(value any) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if int64(len(content)) >= workspaceManifestMaxBytes {
+		return nil, fmt.Errorf("manifest exceeds the byte limit of %d", workspaceManifestMaxBytes)
+	}
 	return append(content, '\n'), nil
 }
 func writeWorkspaceManifestAt(stageFD int, name string, content []byte, ops workspaceMaterializeOps) error {

--- a/internal/applecontainer/workspace_stat_darwin.go
+++ b/internal/applecontainer/workspace_stat_darwin.go
@@ -5,12 +5,29 @@
 
 package applecontainer
 
-import "golang.org/x/sys/unix"
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
 
 const workspaceCopySupported = true
 const workspaceSymlinkOpenFlags = unix.O_SYMLINK | unix.O_CLOEXEC
+const workspaceFreadlinkTrap uintptr = 551 // SYS_freadlink, available since macOS 13.
 
-func workspaceReadlink(fd int, n string, b []byte) (int, error) { return unix.Readlinkat(fd, n, b) }
+func workspaceReadlink(fd int, name string, buffer []byte) (int, error) {
+	if name != "" {
+		return unix.Readlinkat(fd, name, buffer)
+	}
+	if len(buffer) == 0 {
+		return 0, nil
+	}
+	count, _, errno := unix.Syscall(workspaceFreadlinkTrap, uintptr(fd), uintptr(unsafe.Pointer(&buffer[0])), uintptr(len(buffer)))
+	if errno != 0 {
+		return 0, errno
+	}
+	return int(count), nil
+}
 
 func workspaceSnapshotFromUnix(stat unix.Stat_t) workspaceSnapshot {
 	return workspaceSnapshot{uint32(stat.Mode), stat.Size, uint64(stat.Nlink), stat.Uid, stat.Gid, uint64(stat.Dev), stat.Ino, stat.Mtim.Sec, int64(stat.Mtim.Nsec), stat.Ctim.Sec, int64(stat.Ctim.Nsec)}


### PR DESCRIPTION
## Summary

- Read persisted Apple manifests through bounded descriptor paths.
- Reject hard links, special files, trailing data, duplicate keys, and noncanonical JSON.
- Inspect source and materialized workspaces without mirror copies.
- Validate entry order, metadata, limits, and stable file identities.
- Apply the shared readers to conformance, sessions, and workspace publication.
- Document the manifest and workspace inspection limits.

## Evidence

- Base: 77dbe5e28701c186031c9665a735f7808970294f
- Head: 16b109ce942a5cea0cacf6ec82423a0dab59a3ff
- Tree: 1f65a1a4c6e9c4296b2e3090b62d5b671e4d457d
- Full-index diff SHA-256: 556bcabcdc17a8652c952c67c20f278438b903de50a77a6faf54d2f3c54031c9
- PR parity evidence SHA-256: fa25360e46b238c847159f55d997e7162b4ddfd72ea11f04b05abaaa4e6efafc

## Checks

- [x] Fresh exact-head PR parity passed.
- [x] Live Apple certification passed for the exact tree.
- [x] The publication commit has a valid maintainer signature.
- [x] The shape is 10 files, 1,200 changed lines, two areas, and zero binaries.
- [x] The sealed certification manifest passed 246 of 246 checks.
- [x] Post-certification review found no actionable finding.
- [x] No special label is required.