### PR TITLE
Fix provider execution in the container smoke harness

### DIFF
--- a/internal/testkit/container_smoke_harness_test.go
+++ b/internal/testkit/container_smoke_harness_test.go
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const containerSmokeInputCommand = "bash -c 'exec 3<&0; exec </dev/null; source /dev/fd/3' <<'SCRIPT'"
+
+type containerSmokeProvider struct {
+	name  string
+	label string
+}
+
+var containerSmokeProviders = []containerSmokeProvider{
+	{name: "codex", label: "Codex"},
+	{name: "claude", label: "Claude"},
+	{name: "gemini", label: "Gemini"},
+}
+
+func containerSmokeFailureTrap(label string) string {
+	return "trap 'failure_status=$?; if [[ $- == *e* ]]; then trap - ERR; echo \"" + label + " smoke block failed at input line ${LINENO}.\" >&2; exit \"${failure_status}\"; fi' ERR"
+}
+
+func containerSmokeProviderBody(source string, provider containerSmokeProvider) (string, error) {
+	marker := "run_container_stdin " + provider.name + " " + containerSmokeInputCommand
+	if count := strings.Count(source, marker); count != 1 {
+		return "", fmt.Errorf("%s direct-stdin block count = %d, want 1", provider.name, count)
+	}
+
+	remainder := strings.SplitN(source, marker, 2)[1]
+	remainder = strings.TrimPrefix(remainder, "\n")
+	end := strings.Index(remainder, "\nSCRIPT\n")
+	if end < 0 {
+		return "", fmt.Errorf("%s direct-stdin block has no closing SCRIPT delimiter", provider.name)
+	}
+	return remainder[:end] + "\n", nil
+}
+
+func containerSmokeLiteralHeredoc(source string, delimiter string) (string, error) {
+	opener := "<<'" + delimiter + "'\n"
+	if count := strings.Count(source, opener); count != 1 {
+		return "", fmt.Errorf("%s heredoc opener count = %d, want 1", delimiter, count)
+	}
+
+	remainder := strings.SplitN(source, opener, 2)[1]
+	end := strings.Index(remainder, "\n"+delimiter+"\n")
+	if end < 0 {
+		return "", fmt.Errorf("%s heredoc has no closing delimiter", delimiter)
+	}
+	return remainder[:end] + "\n", nil
+}
+
+func containerSmokeBashSyntax(body string) error {
+	return containerSmokeBashSyntaxWithPath("/bin/bash", body)
+}
+
+func containerSmokeBashSyntaxWithPath(bashPath string, body string) error {
+	cmd := exec.Command(bashPath, "--noprofile", "--norc", "-n")
+	cmd.Stdin = strings.NewReader(body)
+	output, err := cmd.CombinedOutput()
+	return containerSmokeBashParseResult(err, output)
+}
+
+func containerSmokeBashParseResult(err error, output []byte) error {
+	if err != nil {
+		return fmt.Errorf("bash -n failed: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	if warning := strings.TrimSpace(string(output)); warning != "" {
+		return fmt.Errorf("bash -n emitted parser output: %s", warning)
+	}
+	return nil
+}
+
+func validateContainerSmokeHarness(source string) error {
+	var problems []string
+	require := func(scope string, source string, fragments ...string) {
+		for _, fragment := range fragments {
+			if !strings.Contains(source, fragment) {
+				problems = append(problems, scope+" is missing "+fmt.Sprintf("%q", fragment))
+			}
+		}
+	}
+
+	for _, provider := range containerSmokeProviders {
+		legacy := "run_container " + provider.name + " bash -lc \"$("
+		if strings.Contains(source, legacy) {
+			problems = append(problems, provider.name+" still generates its smoke block through command substitution")
+		}
+
+		body, err := containerSmokeProviderBody(source, provider)
+		if err != nil {
+			problems = append(problems, err.Error())
+			continue
+		}
+		require(provider.name, body,
+			"set -Eeuo pipefail",
+			containerSmokeFailureTrap(provider.label),
+		)
+		if err := containerSmokeBashSyntax(body); err != nil {
+			problems = append(problems, provider.name+" block "+err.Error())
+		}
+	}
+
+	codex, err := containerSmokeProviderBody(source, containerSmokeProviders[0])
+	if err == nil {
+		require("codex", codex,
+			`codex_user_script=/run/workcell/container-smoke-codex-user.sh`,
+			"cat >\"${codex_user_script}\" <<'CODEX_USER_SCRIPT'\n    set -Eeuo pipefail",
+			`trap 'failure_status=$?; if [[ $- == *e* ]]; then trap - ERR; echo "Codex user smoke block failed at input line ${LINENO}." >&2; exit "${failure_status}"; fi' ERR`,
+			"\nCODEX_USER_SCRIPT\n  chmod 0444",
+			`chmod 0444 "${codex_user_script}"`,
+			"setpriv --reuid \"$WORKCELL_HOST_UID\" --regid \"$WORKCELL_HOST_GID\" --init-groups \\\n    bash -c 'source \"$1\"' workcell-codex-user-smoke \"${codex_user_script}\" </dev/null",
+		)
+		staged, stageErr := containerSmokeLiteralHeredoc(codex, "CODEX_USER_SCRIPT")
+		if stageErr != nil {
+			problems = append(problems, stageErr.Error())
+		} else {
+			require("staged mapped-user codex", staged,
+				`test "$(id -u)" = "$WORKCELL_HOST_UID"`,
+				`test "$(id -u)" != 0`,
+				`raw_execveat_number=322`,
+				`raw_execveat_number=281`,
+				`raw_execveat_empty_path_flag=4096`,
+				`$n=0+shift`,
+				`$flags=0+shift`,
+				`syscall($n, $fd, $empty, $zero, $env, $flags)`,
+				`"$raw_execveat_number" "$EXEC_TMP/workcell-raw-execveat-script" "$raw_execveat_empty_path_flag"`,
+				`grep -qx "raw-execveat-fd-script-allowed" /tmp/workcell-raw-execveat-fd.out`,
+			)
+			if count := strings.Count(staged, "raw-execveat-fd-script-allowed"); count != 2 {
+				problems = append(problems, fmt.Sprintf("staged mapped-user codex exact raw execveat marker count = %d, want 2", count))
+			}
+			if syntaxErr := containerSmokeBashSyntax(staged); syntaxErr != nil {
+				problems = append(problems, "staged codex user block "+syntaxErr.Error())
+			}
+		}
+	}
+
+	for _, provider := range containerSmokeProviders[1:] {
+		body, bodyErr := containerSmokeProviderBody(source, provider)
+		if bodyErr != nil {
+			continue
+		}
+		require(provider.name, body,
+			`run_as_runtime_user() {`,
+			`setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups "$@"`,
+			`runtime_uid="$(run_as_runtime_user id -u)"`,
+			`test "${runtime_uid}" = "$WORKCELL_HOST_UID"`,
+			`test "${runtime_uid}" != 0`,
+		)
+		expectedCalls := map[string]int{"claude": 6, "gemini": 9}[provider.name]
+		if count := strings.Count(body, "run_as_runtime_user "+provider.name); count != expectedCalls {
+			problems = append(problems, fmt.Sprintf("%s mapped provider policy call count = %d, want %d", provider.name, count, expectedCalls))
+		}
+	}
+
+	if len(problems) != 0 {
+		return fmt.Errorf("container smoke harness validation failed:\n- %s", strings.Join(problems, "\n- "))
+	}
+	return nil
+}
+
+func readContainerSmokeHarness(tb testing.TB) string {
+	tb.Helper()
+	path := filepath.Join(repoRoot(tb), "scripts", "container-smoke.sh")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return string(content)
+}
+
+func mutateContainerSmokeHarness(tb testing.TB, source string, old string, replacement string) string {
+	tb.Helper()
+	if count := strings.Count(source, old); count != 1 {
+		tb.Fatalf("container smoke mutation anchor count = %d, want 1: %q", count, old)
+	}
+	return strings.Replace(source, old, replacement, 1)
+}
+
+func TestContainerSmokeHarness(t *testing.T) {
+	t.Parallel()
+	if err := validateContainerSmokeHarness(readContainerSmokeHarness(t)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestContainerSmokeBashSyntaxRejectsStatusZeroParserWarnings(t *testing.T) {
+	t.Parallel()
+	parserPath := filepath.Join(t.TempDir(), "bash")
+	parser := []byte("#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' 'warning: here-document delimited by end-of-file' >&2\n")
+	if err := os.WriteFile(parserPath, parser, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := containerSmokeBashSyntaxWithPath(parserPath, "cat <<'EOF'\n"); err == nil {
+		t.Fatal("bash parser warning passed validation with a successful status")
+	}
+}
+
+func TestContainerSmokeFailureTrapHonorsErrexitState(t *testing.T) {
+	t.Parallel()
+	trap := containerSmokeFailureTrap("Probe")
+	script := strings.Join([]string{
+		"set -Eeuo pipefail",
+		trap,
+		"set +e",
+		"/bin/bash -c 'exit 126'",
+		"status=$?",
+		"set -e",
+		`test "${status}" -eq 126`,
+		`printf 'expected-status=%s\n' "${status}"`,
+		"/bin/bash -c 'exit 7'",
+	}, "\n")
+	cmd := exec.Command("/bin/bash", "--noprofile", "--norc", "-c", "exec 3<&0; exec </dev/null; source /dev/fd/3")
+	cmd.Stdin = strings.NewReader(script)
+	output, err := cmd.CombinedOutput()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok || exitErr.ExitCode() != 7 {
+		t.Fatalf("failure sequence exit = %v, want status 7: %s", err, output)
+	}
+	if !strings.Contains(string(output), "expected-status=126\n") {
+		t.Fatalf("expected failure status was not preserved: %s", output)
+	}
+	if !strings.Contains(string(output), "Probe smoke block failed at input line ") {
+		t.Fatalf("unexpected failure did not report its input line: %s", output)
+	}
+}
+
+func TestContainerSmokeHarnessRejectsMutations(t *testing.T) {
+	t.Parallel()
+	source := readContainerSmokeHarness(t)
+	cases := []struct {
+		name        string
+		anchor      string
+		replacement string
+	}{
+		{
+			name:        "generated-command-substitution",
+			anchor:      "run_container_stdin codex " + containerSmokeInputCommand,
+			replacement: `run_container codex bash -lc "$(cat <<'SCRIPT'`,
+		},
+		{
+			name:        "stdin-descriptor-not-preserved",
+			anchor:      "run_container_stdin claude " + containerSmokeInputCommand,
+			replacement: "run_container_stdin claude bash -c 'exec </dev/null; source /dev/fd/3' <<'SCRIPT'",
+		},
+		{
+			name:        "provider-stdin-not-closed",
+			anchor:      "run_container_stdin gemini " + containerSmokeInputCommand,
+			replacement: "run_container_stdin gemini bash -c 'exec 3<&0; source /dev/fd/3' <<'SCRIPT'",
+		},
+		{
+			name:        "failure-trap-removed",
+			anchor:      "  " + containerSmokeFailureTrap("Gemini") + "\n",
+			replacement: "",
+		},
+		{
+			name:        "failure-trap-errexit-guard-removed",
+			anchor:      "  " + containerSmokeFailureTrap("Codex") + "\n",
+			replacement: `  trap 'failure_status=$?; trap - ERR; echo "Codex smoke block failed at input line ${LINENO}." >&2; exit "${failure_status}"' ERR` + "\n",
+		},
+		{
+			name:        "failure-status-not-preserved",
+			anchor:      `exit "${failure_status}"; fi' ERR` + "\n  /usr/local/bin/workcell-entrypoint claude",
+			replacement: `true; fi' ERR` + "\n  /usr/local/bin/workcell-entrypoint claude",
+		},
+		{
+			name:        "late-syntax-error",
+			anchor:      `    codex features -- list >/tmp/codex-features-dd-list-permit.out 2>&1 || true`,
+			replacement: "    if then",
+		},
+		{
+			name:        "unterminated-staged-heredoc-warning",
+			anchor:      "CODEX_USER_SCRIPT\n  chmod 0444",
+			replacement: "CODEX_USER_SCRIP\n  chmod 0444",
+		},
+		{
+			name:        "mapped-user-invariant-removed",
+			anchor:      "  runtime_uid=\"$(run_as_runtime_user id -u)\"\n  test \"${runtime_uid}\" = \"$WORKCELL_HOST_UID\"\n  test \"${runtime_uid}\" != 0\n  if run_as_runtime_user claude",
+			replacement: "  if run_as_runtime_user claude",
+		},
+		{
+			name:        "codex-setpriv-mapping-changed",
+			anchor:      `setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups \` + "\n    bash -c 'source \"$1\"' workcell-codex-user-smoke",
+			replacement: `setpriv --reuid 65534 --regid "$WORKCELL_HOST_GID" --init-groups \` + "\n    bash -c 'source \"$1\"' workcell-codex-user-smoke",
+		},
+		{
+			name:        "execveat-mapped-uid-equality-removed",
+			anchor:      `    test "$(id -u)" = "$WORKCELL_HOST_UID"` + "\n",
+			replacement: "",
+		},
+		{
+			name:        "execveat-mapped-user-invariant-removed",
+			anchor:      `    test "$(id -u)" != 0` + "\n    test \"$WORKCELL_RUNTIME\" = \"1\"",
+			replacement: `    test "$WORKCELL_RUNTIME" = "1"`,
+		},
+		{
+			name:        "provider-policy-command-runs-as-root",
+			anchor:      `if run_as_runtime_user claude update`,
+			replacement: `if claude update`,
+		},
+		{
+			name:        "execveat-flags-left-as-string",
+			anchor:      `$flags=0+shift`,
+			replacement: `$flags=shift`,
+		},
+		{
+			name:        "execveat-syscall-removed",
+			anchor:      `syscall($n, $fd, $empty, $zero, $env, $flags)`,
+			replacement: `$zero`,
+		},
+		{
+			name:        "execveat-empty-path-flag-not-passed",
+			anchor:      `"$raw_execveat_number" "$EXEC_TMP/workcell-raw-execveat-script" "$raw_execveat_empty_path_flag"`,
+			replacement: `"$raw_execveat_number" "$EXEC_TMP/workcell-raw-execveat-script" 0`,
+		},
+		{
+			name:        "exact-success-marker-removed",
+			anchor:      `printf 'raw-execveat-fd-script-allowed\n'`,
+			replacement: `printf 'raw-execveat-fd-script-ran\n'`,
+		},
+		{
+			name:        "generic-einval-accepted",
+			anchor:      `grep -qx "raw-execveat-fd-script-allowed" /tmp/workcell-raw-execveat-fd.out`,
+			replacement: `grep -Eq "raw-execveat-fd-script-allowed|Invalid argument" /tmp/workcell-raw-execveat-fd.out`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mutated := mutateContainerSmokeHarness(t, source, tc.anchor, tc.replacement)
+			if err := validateContainerSmokeHarness(mutated); err == nil {
+				t.Fatal("container smoke harness mutation passed validation")
+			}
+		})
+	}
+}

--- a/internal/testkit/container_smoke_harness_test.go
+++ b/internal/testkit/container_smoke_harness_test.go
@@ -160,6 +160,21 @@ func validateContainerSmokeHarness(source string) error {
 		if count := strings.Count(body, "run_as_runtime_user "+provider.name); count != expectedCalls {
 			problems = append(problems, fmt.Sprintf("%s mapped provider policy call count = %d, want %d", provider.name, count, expectedCalls))
 		}
+		if provider.name == "claude" {
+			require("claude writable glob fixture", body,
+				`claude_glob_fixture="$(mktemp -d /tmp/workcell-claude-hook-glob.XXXXXX)"`,
+				`trap 'rm -rf -- "${claude_glob_fixture}"' EXIT`,
+				`test -O "${claude_glob_fixture}"`,
+				`test -w "${claude_glob_fixture}"`,
+				`touch "${claude_glob_fixture}/claude"`,
+				`claude_glob_previous_dir="${PWD}"`,
+				"\n  cd \"${claude_glob_fixture}\"\n",
+				"\n  cd \"${claude_glob_previous_dir}\"\n",
+			)
+			if strings.Contains(body, "touch ./claude") {
+				problems = append(problems, "claude glob fixture still depends on a writable workspace")
+			}
+		}
 	}
 
 	if len(problems) != 0 {
@@ -206,7 +221,6 @@ func TestContainerSmokeBashSyntaxRejectsStatusZeroParserWarnings(t *testing.T) {
 }
 
 func TestContainerSmokeFailureTrapHonorsErrexitState(t *testing.T) {
-	t.Parallel()
 	trap := containerSmokeFailureTrap("Probe")
 	script := strings.Join([]string{
 		"set -Eeuo pipefail",
@@ -231,6 +245,23 @@ func TestContainerSmokeFailureTrapHonorsErrexitState(t *testing.T) {
 	}
 	if !strings.Contains(string(output), "Probe smoke block failed at input line ") {
 		t.Fatalf("unexpected failure did not report its input line: %s", output)
+	}
+}
+
+func TestContainerSmokeHarnessRejectsNonWritableClaudeWorkspaceDependency(t *testing.T) {
+	t.Parallel()
+	source := readContainerSmokeHarness(t)
+	mutated := mutateContainerSmokeHarness(t, source,
+		"  touch \"${claude_glob_fixture}/claude\"\n  claude_glob_previous_dir=\"${PWD}\"\n  cd \"${claude_glob_fixture}\"",
+		"  touch ./claude\n  claude_glob_previous_dir=\"${PWD}\"\n  :",
+	)
+	err := validateContainerSmokeHarness(mutated)
+	if err == nil {
+		t.Fatal("non-writable Claude workspace dependency passed validation")
+	}
+	if !strings.Contains(err.Error(), "claude writable glob fixture") ||
+		!strings.Contains(err.Error(), "writable workspace") {
+		t.Fatalf("non-writable workspace mutation error = %q, want fixture and workspace diagnostics", err)
 	}
 }
 
@@ -306,6 +337,16 @@ func TestContainerSmokeHarnessRejectsMutations(t *testing.T) {
 			name:        "provider-policy-command-runs-as-root",
 			anchor:      `if run_as_runtime_user claude update`,
 			replacement: `if claude update`,
+		},
+		{
+			name:        "claude-glob-fixture-cleanup-trap-removed",
+			anchor:      `  trap 'rm -rf -- "${claude_glob_fixture}"' EXIT` + "\n",
+			replacement: "",
+		},
+		{
+			name:        "claude-glob-fixture-cd-check-bypassed",
+			anchor:      `  cd "${claude_glob_fixture}"` + "\n",
+			replacement: `  cd "${claude_glob_fixture}" || true` + "\n",
 		},
 		{
 			name:        "execveat-flags-left-as-string",

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -5107,14 +5107,20 @@ EOF
       exit 1
     }
   grep -q "BLOCKED:" /tmp/claude-hook-quote-split.out
-  touch ./claude
+  claude_glob_fixture="$(mktemp -d /tmp/workcell-claude-hook-glob.XXXXXX)"
+  trap 'rm -rf -- "${claude_glob_fixture}"' EXIT
+  test -O "${claude_glob_fixture}"
+  test -w "${claude_glob_fixture}"
+  touch "${claude_glob_fixture}/claude"
+  claude_glob_previous_dir="${PWD}"
+  cd "${claude_glob_fixture}"
   printf "%s" "{\"tool_input\":{\"command\":\"c* --dangerously-skip-permissions\"}}" \
     | /opt/workcell/adapters/claude/hooks/guard-bash.sh >/tmp/claude-hook-glob.out 2>&1 && {
       echo "expected Claude guard hook to reject glob-expanded command names" >&2
       exit 1
     }
   grep -q "BLOCKED:" /tmp/claude-hook-glob.out
-  rm -f ./claude
+  cd "${claude_glob_previous_dir}"
   cat >/tmp/claude-hook-positional.json <<'EOF'
 {"tool_input":{"command":"set -- cl aude; \"$1$2\" --dangerously-skip-permissions"}}
 EOF

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -3470,13 +3470,16 @@ run_container gemini bash -lc '
   grep -q "Workcell control-plane manifest mismatch for /opt/workcell/adapters/gemini/.gemini/settings.json" /tmp/workcell-control-plane-gemini-tamper.out
 '
 
-run_container codex bash -lc "$(
-  cat <<'SCRIPT'
-	  set -euo pipefail
-	  /usr/local/bin/workcell-entrypoint codex --version >/dev/null
-  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '
-    set -euo pipefail
+run_container_stdin codex bash -c 'exec 3<&0; exec </dev/null; source /dev/fd/3' <<'SCRIPT'
+  set -Eeuo pipefail
+  trap 'failure_status=$?; if [[ $- == *e* ]]; then trap - ERR; echo "Codex smoke block failed at input line ${LINENO}." >&2; exit "${failure_status}"; fi' ERR
+  /usr/local/bin/workcell-entrypoint codex --version >/dev/null
+  codex_user_script=/run/workcell/container-smoke-codex-user.sh
+  cat >"${codex_user_script}" <<'CODEX_USER_SCRIPT'
+    set -Eeuo pipefail
+    trap 'failure_status=$?; if [[ $- == *e* ]]; then trap - ERR; echo "Codex user smoke block failed at input line ${LINENO}." >&2; exit "${failure_status}"; fi' ERR
     CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
+    test "$(id -u)" = "$WORKCELL_HOST_UID"
     test "$(id -u)" != 0
     test "$WORKCELL_RUNTIME" = "1"
     test "$TMPDIR" = "/state/tmp"
@@ -3716,9 +3719,8 @@ test -f "$CODEX_HOME/config.toml"
     # `--strict-config`, `--analytics-default-enabled`, `-c …` — none of which the
     # managed launch passes. Asserting a representative control token AND the
     # network-listening/config flags proves the general rule, not a token denylist.
-    # NOTE: this whole block runs inside a single-quoted `bash -lc '…'` above, so
-    # it must contain NO single quotes. Each case is asserted explicitly (no loop,
-    # no printf/tr) to stay single-quote-free.
+    # Keep each managed app-server case explicit so failures identify the rejected
+    # control surface without parsing a generated command string.
     assert_gui_appserver_denied() {
       local out="$1"
       shift
@@ -3842,7 +3844,37 @@ test -f "$CODEX_HOME/config.toml"
       cat /tmp/codex-features-dd-list-permit.out >&2
       exit 1
     fi
-  '
+    case "$(uname -m)" in
+      x86_64)
+        raw_execveat_number=322
+        ;;
+      aarch64)
+        raw_execveat_number=281
+        ;;
+      *)
+        echo "unsupported architecture for raw execveat smoke" >&2
+        exit 1
+        ;;
+    esac
+    raw_execveat_empty_path_flag=4096
+    cat >"$EXEC_TMP/workcell-raw-execveat-script" <<'EOF'
+#!/bin/sh
+printf 'raw-execveat-fd-script-allowed\n'
+EOF
+    chmod 0700 "$EXEC_TMP/workcell-raw-execveat-script"
+    if ! perl -e '$n=0+shift; $path=shift; sysopen(my $fh, $path, 0) or die "$!\n"; fcntl($fh, 2, 0) or die "$!\n"; $fd=fileno($fh); $empty=pack("C", 0); $zero=0; $flags=0+shift; $guard="LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so"; $env=pack("p*", $guard, undef); syscall($n, $fd, $empty, $zero, $env, $flags); die "$!\n"' \
+      "$raw_execveat_number" "$EXEC_TMP/workcell-raw-execveat-script" "$raw_execveat_empty_path_flag" \
+      >/tmp/workcell-raw-execveat-fd.out 2>&1; then
+      echo "expected numeric AT_EMPTY_PATH execveat to allow a mapped-user mutable script" >&2
+      cat /tmp/workcell-raw-execveat-fd.out >&2
+      exit 1
+    fi
+    grep -qx "raw-execveat-fd-script-allowed" /tmp/workcell-raw-execveat-fd.out
+CODEX_USER_SCRIPT
+  chmod 0444 "${codex_user_script}"
+  setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups \
+    bash -c 'source "$1"' workcell-codex-user-smoke "${codex_user_script}" </dev/null
+  rm -f "${codex_user_script}"
   if /usr/local/libexec/workcell/real/codex --version >/tmp/codex-real-path.out 2>&1; then
     echo "expected direct real Codex payload execution to fail" >&2
     exit 1
@@ -4964,10 +4996,10 @@ EOF
   fi
   grep -Eq "hook ran|pre-commit" /tmp/git-guard-xdg-config.out
 SCRIPT
-)"
 
-run_container claude bash -lc "$(
-  cat <<'SCRIPT'
+run_container_stdin claude bash -c 'exec 3<&0; exec </dev/null; source /dev/fd/3' <<'SCRIPT'
+  set -Eeuo pipefail
+  trap 'failure_status=$?; if [[ $- == *e* ]]; then trap - ERR; echo "Claude smoke block failed at input line ${LINENO}." >&2; exit "${failure_status}"; fi' ERR
   /usr/local/bin/workcell-entrypoint claude --version >/dev/null
   setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '
     set -euo pipefail
@@ -4981,32 +5013,38 @@ run_container claude bash -lc "$(
     jq -r ".disableBypassPermissionsMode" /etc/claude-code/managed-settings.json | grep -q "^allow$"
     jq -r ".hooks.PreToolUse[0].hooks[0].command" "$HOME/.claude/settings.json" | grep -q "guard-bash.sh"
   '
-  if claude --dangerously-skip-permissions >/tmp/claude-nested-danger.out 2>&1; then
+  run_as_runtime_user() {
+    setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups "$@"
+  }
+  runtime_uid="$(run_as_runtime_user id -u)"
+  test "${runtime_uid}" = "$WORKCELL_HOST_UID"
+  test "${runtime_uid}" != 0
+  if run_as_runtime_user claude --dangerously-skip-permissions >/tmp/claude-nested-danger.out 2>&1; then
     echo "expected nested Claude invocation to reject unsafe overrides" >&2
     exit 1
   fi
   grep -q "Workcell blocked unsafe Claude override" /tmp/claude-nested-danger.out
-  if claude --add-dir=/state --version >/tmp/claude-nested-add-dir.out 2>&1; then
+  if run_as_runtime_user claude --add-dir=/state --version >/tmp/claude-nested-add-dir.out 2>&1; then
     echo "expected nested Claude invocation to reject add-dir overrides" >&2
     exit 1
   fi
   grep -q "Workcell blocked unsafe Claude override" /tmp/claude-nested-add-dir.out
-  if claude --permission-mode default --version >/tmp/claude-nested-permission-mode.out 2>&1; then
+  if run_as_runtime_user claude --permission-mode default --version >/tmp/claude-nested-permission-mode.out 2>&1; then
     echo "expected nested Claude invocation to reject autonomy overrides" >&2
     exit 1
   fi
   grep -q "Workcell blocked Claude autonomy override" /tmp/claude-nested-permission-mode.out
-  if claude update >/tmp/claude-nested-update.out 2>&1; then
+  if run_as_runtime_user claude update >/tmp/claude-nested-update.out 2>&1; then
     echo "expected nested Claude invocation to reject lifecycle updates" >&2
     exit 1
   fi
   grep -q "Workcell blocked Claude lifecycle command: update" /tmp/claude-nested-update.out
-  if claude install >/tmp/claude-nested-install.out 2>&1; then
+  if run_as_runtime_user claude install >/tmp/claude-nested-install.out 2>&1; then
     echo "expected nested Claude invocation to reject lifecycle installs" >&2
     exit 1
   fi
   grep -q "Workcell blocked Claude lifecycle command: install" /tmp/claude-nested-install.out
-  if WORKCELL_MODE=breakglass claude --dangerously-skip-permissions >/tmp/claude-nested-breakglass.out 2>&1; then
+  if WORKCELL_MODE=breakglass run_as_runtime_user claude --dangerously-skip-permissions >/tmp/claude-nested-breakglass.out 2>&1; then
     echo "expected nested Claude invocation to ignore caller-supplied breakglass env" >&2
     exit 1
   fi
@@ -5146,10 +5184,10 @@ EOF
     }
   grep -q "BLOCKED:" /tmp/claude-hook-home-control-plane.out
 SCRIPT
-)"
 
-run_container gemini bash -lc "$(
-  cat <<'SCRIPT'
+run_container_stdin gemini bash -c 'exec 3<&0; exec </dev/null; source /dev/fd/3' <<'SCRIPT'
+  set -Eeuo pipefail
+  trap 'failure_status=$?; if [[ $- == *e* ]]; then trap - ERR; echo "Gemini smoke block failed at input line ${LINENO}." >&2; exit "${failure_status}"; fi' ERR
   /usr/local/bin/workcell-entrypoint gemini --version >/dev/null
   setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '
     set -euo pipefail
@@ -5168,49 +5206,55 @@ run_container gemini bash -lc "$(
     test -f "$HOME/.gemini/GEMINI.md"
     test -f "$HOME/.gemini/projects.json"
   '
-  if gemini --yolo >/tmp/gemini-nested-yolo.out 2>&1; then
+  run_as_runtime_user() {
+    setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups "$@"
+  }
+  runtime_uid="$(run_as_runtime_user id -u)"
+  test "${runtime_uid}" = "$WORKCELL_HOST_UID"
+  test "${runtime_uid}" != 0
+  if run_as_runtime_user gemini --yolo >/tmp/gemini-nested-yolo.out 2>&1; then
     echo "expected nested Gemini invocation to reject unsafe overrides" >&2
     exit 1
   fi
   grep -q "Workcell blocked unsafe Gemini override" /tmp/gemini-nested-yolo.out
-  if gemini -y >/tmp/gemini-nested-yolo-short.out 2>&1; then
+  if run_as_runtime_user gemini -y >/tmp/gemini-nested-yolo-short.out 2>&1; then
     echo "expected nested Gemini invocation to reject short yolo overrides" >&2
     exit 1
   fi
   grep -q "Workcell blocked unsafe Gemini override" /tmp/gemini-nested-yolo-short.out
-  if gemini --bypassPermissions --version >/tmp/gemini-nested-bypass-camel.out 2>&1; then
+  if run_as_runtime_user gemini --bypassPermissions --version >/tmp/gemini-nested-bypass-camel.out 2>&1; then
     echo "expected nested Gemini invocation to reject bypassPermissions-style overrides" >&2
     exit 1
   fi
   grep -q "Workcell blocked unsafe Gemini override" /tmp/gemini-nested-bypass-camel.out
-  if gemini --bypass-permissions --version >/tmp/gemini-nested-bypass-dashed.out 2>&1; then
+  if run_as_runtime_user gemini --bypass-permissions --version >/tmp/gemini-nested-bypass-dashed.out 2>&1; then
     echo "expected nested Gemini invocation to reject bypass-permissions-style overrides" >&2
     exit 1
   fi
   grep -q "Workcell blocked unsafe Gemini override" /tmp/gemini-nested-bypass-dashed.out
-  if gemini --add-dir=/state --version >/tmp/gemini-nested-add-dir.out 2>&1; then
+  if run_as_runtime_user gemini --add-dir=/state --version >/tmp/gemini-nested-add-dir.out 2>&1; then
     echo "expected nested Gemini invocation to reject add-dir overrides" >&2
     exit 1
   fi
   grep -q "Workcell blocked unsafe Gemini override" /tmp/gemini-nested-add-dir.out
-  if gemini --approval-mode default --version >/tmp/gemini-nested-approval-mode.out 2>&1; then
+  if run_as_runtime_user gemini --approval-mode default --version >/tmp/gemini-nested-approval-mode.out 2>&1; then
     echo "expected nested Gemini invocation to reject autonomy overrides" >&2
     exit 1
   fi
   grep -q "Workcell blocked Gemini autonomy override" /tmp/gemini-nested-approval-mode.out
-  if WORKCELL_MODE=breakglass gemini --yolo >/tmp/gemini-nested-breakglass.out 2>&1; then
+  if WORKCELL_MODE=breakglass run_as_runtime_user gemini --yolo >/tmp/gemini-nested-breakglass.out 2>&1; then
     echo "expected nested Gemini invocation to ignore caller-supplied breakglass env" >&2
     exit 1
   fi
   grep -q "Workcell blocked unsafe Gemini override" /tmp/gemini-nested-breakglass.out
-  NODE_EXTRA_CA_CERTS=/workspace/does-not-exist.pem gemini --version >/tmp/gemini-extra-ca.out 2>&1
+  NODE_EXTRA_CA_CERTS=/workspace/does-not-exist.pem run_as_runtime_user gemini --version >/tmp/gemini-extra-ca.out 2>&1
   if grep -qi "extra cert" /tmp/gemini-extra-ca.out; then
     echo "expected provider wrapper to scrub NODE_EXTRA_CA_CERTS" >&2
     cat /tmp/gemini-extra-ca.out >&2
     exit 1
   fi
   rm -rf /workspace/.gemini
-  HOME=/workspace gemini --version >/dev/null 2>&1
+  HOME=/workspace run_as_runtime_user gemini --version >/dev/null 2>&1
   test ! -e /workspace/.gemini/settings.json
   test ! -e /workspace/.gemini/projects.json
   setpriv --reuid "$WORKCELL_HOST_UID" --regid "$WORKCELL_HOST_GID" --init-groups bash -lc '
@@ -5222,6 +5266,5 @@ run_container gemini bash -lc "$(
     jq -r ".general.enableAutoUpdateNotification" "$HOME/.gemini/settings.json" | grep -q "^false$"
   '
 SCRIPT
-)"
 
 echo "Workcell container smoke passed."


### PR DESCRIPTION
## Summary

- Preserve provider smoke programs on file descriptor 3.
- Close provider standard input before script execution.
- Run nested provider policy probes as the mapped runtime user.
- Add a raw numeric `execveat` success fixture for `AT_EMPTY_PATH`.
- Use an owned temporary directory for the Claude glob fixture.
- Restore the original directory and clean the fixture on exit.
- Add harness validation and 21 mutation cases.

## Validation

- Fresh `pr-parity` passed for the exact base, head, and tree.
- Repository validation passed with 17 scenarios, zero failures, and five planned skips.
- Container smoke passed after the hosted workspace correction.
- Invariant and documentation checks passed.
- Live certification passed on the exact signed tree before signing.
- Six-role source and post-certification reviews were clean.
- Workcell-owned residue cleanup passed.

## Scope

- The change contains two files and 504 changed lines.
- The change adds no binary file.
- The change adds no public operator contract.
- The change requires no special CI label.
