### PR TITLE
Bound Colima host orchestration

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -31,6 +31,8 @@ import (
 	"github.com/omkhar/workcell/internal/transcript"
 )
 
+const maxHelperStdinBytes int64 = 4 << 20
+
 func main() {
 	if err := run(os.Args[1:]); err != nil {
 		// All Go CLI translations (authpolicy, publishpr, sessionctl,
@@ -438,7 +440,7 @@ func cmdHelperSessionSuffix(_ []string) error {
 }
 
 func cmdHelperSessionContainerAbsentForDelete(args []string) error {
-	inventory, err := io.ReadAll(os.Stdin)
+	inventory, err := readHelperInput("container inventory", os.Stdin)
 	if err != nil {
 		return err
 	}
@@ -446,7 +448,7 @@ func cmdHelperSessionContainerAbsentForDelete(args []string) error {
 }
 
 func cmdHelperColimaStatus(args []string) error {
-	input, err := io.ReadAll(os.Stdin)
+	input, err := readHelperInput("Colima profile inventory", os.Stdin)
 	if err != nil {
 		return err
 	}
@@ -466,11 +468,22 @@ func cmdHelperReapColimaProfileProcesses(args []string) error {
 }
 
 func cmdHelperValidateColimaStatus(args []string) error {
-	statusBytes, err := io.ReadAll(os.Stdin)
+	statusBytes, err := readHelperInput("Colima status output", os.Stdin)
 	if err != nil {
 		return err
 	}
 	return launcher.ValidateColimaStatusOutput(string(statusBytes), args[0])
+}
+
+func readHelperInput(subject string, inputReader io.Reader) ([]byte, error) {
+	input, err := io.ReadAll(io.LimitReader(inputReader, maxHelperStdinBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(input)) > maxHelperStdinBytes {
+		return nil, fmt.Errorf("%s exceeds %d-byte limit", subject, maxHelperStdinBytes)
+	}
+	return input, nil
 }
 
 func cmdHelperRunHostColimaWithTimeout(args []string) error {
@@ -505,6 +518,9 @@ func parseColimaInvocationArgs(args []string) (int, launcher.HostColimaInvocatio
 	timeoutSeconds, err := strconv.Atoi(args[0])
 	if err != nil {
 		return 0, launcher.HostColimaInvocation{}, nil, fmt.Errorf("parse timeout seconds: %w", err)
+	}
+	if timeoutSeconds > launcher.MaxColimaTimeoutSeconds {
+		return 0, launcher.HostColimaInvocation{}, nil, fmt.Errorf("timeout seconds must not exceed %d", launcher.MaxColimaTimeoutSeconds)
 	}
 	rest := args[1:]
 	inv := launcher.HostColimaInvocation{

--- a/cmd/workcell-hostutil/main_test.go
+++ b/cmd/workcell-hostutil/main_test.go
@@ -5,6 +5,8 @@ package main
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -536,4 +538,90 @@ func TestHelperUsageListsDirectoryCandidateResolver(t *testing.T) {
 	} else if !strings.Contains(err.Error(), "resolve-host-output-directory-candidate") {
 		t.Fatalf("helperUsage error = %q, want resolve-host-output-directory-candidate", err)
 	}
+}
+
+func TestHelperInputLimit(t *testing.T) {
+	exact := bytes.Repeat([]byte{'x'}, int(maxHelperStdinBytes))
+	got, err := readHelperInput("fixture", bytes.NewReader(exact))
+	if err != nil || len(got) != len(exact) {
+		t.Fatalf("readHelperInput(exact) = %d bytes, %v", len(got), err)
+	}
+	for _, subject := range []string{"container inventory", "Colima profile inventory", "Colima status output"} {
+		_, err := readHelperInput(subject, bytes.NewReader(append(exact, 'x')))
+		if err == nil || !strings.Contains(err.Error(), subject+" exceeds 4194304-byte limit") {
+			t.Fatalf("readHelperInput(%q) err = %v", subject, err)
+		}
+	}
+}
+
+func TestParseColimaInvocationCapsTimeout(t *testing.T) {
+	seconds, _, _, err := parseColimaInvocationArgs([]string{"86400", "--", "start"})
+	if err != nil || seconds != 86400 {
+		t.Fatalf("parse exact timeout = %d, %v", seconds, err)
+	}
+	if _, _, _, err := parseColimaInvocationArgs([]string{"86401", "--", "start"}); err == nil {
+		t.Fatal("parseColimaInvocationArgs accepted more than 24 hours")
+	}
+}
+
+func TestManagedColimaSourceContractRejectsMutants(t *testing.T) {
+	workcell := mustReadTestFile(t, filepath.Join("..", "..", "scripts", "workcell"))
+	invariants := mustReadTestFile(t, filepath.Join("..", "..", "scripts", "verify-invariants.sh"))
+	hostutil := mustReadTestFile(t, "main.go")
+	if err := validateManagedColimaSource(workcell, invariants, hostutil); err != nil {
+		t.Fatal(err)
+	}
+	mutants := map[string][3]string{
+		"pre-captured list":   {strings.Replace(workcell, "run_host_colima list --json 2>/dev/null |", "list_output=\"$(run_host_colima list --json 2>/dev/null)\"", 1), invariants, hostutil},
+		"missing PIPESTATUS":  {strings.Replace(workcell, "run_host_colima list --json 2>/dev/null |\n      run_go_hostutil_preserve_exit helper colima-status \"${profile}\"\n    pipe_status=(\"${PIPESTATUS[@]}\")", "run_host_colima list --json 2>/dev/null |\n      run_go_hostutil_preserve_exit helper colima-status \"${profile}\"\n    pipe_status=(0 0)", 1), invariants, hostutil},
+		"shell-managed start": {strings.Replace(workcell, "run_host_colima_with_timeout \"${WORKCELL_COLIMA_START_TIMEOUT_SECONDS:-180}\" start", "run_host_colima start", 1), invariants, hostutil},
+		"stale extraction":    {workcell, invariants + "\nextract_top_level_bash_function \"${ROOT_DIR}/scripts/workcell\" terminate_process_tree_by_pid\n", hostutil},
+		"unbounded handler":   {workcell, invariants, strings.Replace(hostutil, "readHelperInput(\"Colima status output\", os.Stdin)", "io.ReadAll(os.Stdin)", 1)},
+	}
+	for name, mutant := range mutants {
+		t.Run(name, func(t *testing.T) {
+			if err := validateManagedColimaSource(mutant[0], mutant[1], mutant[2]); err == nil {
+				t.Fatal("mutant passed source contract")
+			}
+		})
+	}
+}
+
+func validateManagedColimaSource(workcell, invariants, hostutil string) error {
+	for _, required := range []string{
+		"run_host_colima list --json 2>/dev/null |\n      run_go_hostutil_preserve_exit helper colima-status \"${profile}\"\n    pipe_status=(\"${PIPESTATUS[@]}\")",
+		"run_host_colima status --profile \"${profile}\" 2>&1 |\n      run_go_hostutil_preserve_exit helper validate-colima-status \"${profile}\"\n    pipe_status=(\"${PIPESTATUS[@]}\")",
+		"run_host_colima_with_timeout \"${WORKCELL_COLIMA_START_TIMEOUT_SECONDS:-180}\" start",
+	} {
+		if !strings.Contains(workcell, required) {
+			return fmt.Errorf("scripts/workcell lacks %q", required)
+		}
+	}
+	if !strings.Contains(invariants, "scripts/lib/launcher/go-hostutil.sh\" run_go_hostutil_preserve_exit") {
+		return errors.New("verify-invariants does not extract the exit-preserving stream helper")
+	}
+	for _, obsolete := range []string{"list_output=\"$(run_host_colima list --json", "status=\"$(run_host_colima status --profile", "kill_process_tree_by_pid", "terminate_process_tree_by_pid"} {
+		if strings.Contains(workcell, obsolete) || strings.Contains(invariants, "scripts/workcell\" "+obsolete) {
+			return fmt.Errorf("obsolete launcher path remains: %s", obsolete)
+		}
+	}
+	for _, call := range []string{
+		"readHelperInput(\"container inventory\", os.Stdin)",
+		"readHelperInput(\"Colima profile inventory\", os.Stdin)",
+		"readHelperInput(\"Colima status output\", os.Stdin)",
+	} {
+		if !strings.Contains(hostutil, call) {
+			return fmt.Errorf("hostutil lacks bounded read %q", call)
+		}
+	}
+	return nil
+}
+
+func mustReadTestFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }

--- a/docs/launcher-contract.md
+++ b/docs/launcher-contract.md
@@ -193,6 +193,22 @@ GPG, SSH, XDG, and GitHub variables.
 
 This function runs `cmd/workcell-colimautil` with the selected arguments.
 
+### Colima stream and timeout controls
+
+The launcher streams Colima inventory and status output directly to the host utility.
+The container inventory, Colima inventory, and Colima status inputs each have a 4 MiB limit.
+
+Managed Colima start uses the checked absolute Colima path. A positive timeout cannot exceed 24 hours.
+For a positive timeout, the Go helper starts Colima in a dedicated process group.
+
+On timeout, the helper sends `SIGTERM` and polls for group absence.
+It sends `SIGKILL` if the group remains. It polls again and fails if the group remains.
+
+After cancellation, the helper converts only expected termination outcomes to status `124` when cleanup succeeds.
+It preserves ordinary exit statuses and unrelated signal statuses. It reports start, input/output, and cleanup errors.
+
+Runtime DNS resolution uses a five-second deadline. The resolver cancels the lookup context when resolution finishes.
+
 The publication function is a deliberate host-side exception. It can receive
 the ambient operator publication and signing environment. The Tier 1 runtime
 does not receive this ambient state. Reviewed injection can stage selected

--- a/internal/host/launcher/colima.go
+++ b/internal/host/launcher/colima.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -17,7 +18,13 @@ import (
 // ColimaTimeoutExitCode mirrors GNU coreutils `timeout`'s exit code for a
 // process that was killed because its deadline elapsed.  Bash callers
 // rely on this value to distinguish a timeout from a colima failure.
-const ColimaTimeoutExitCode = 124
+const (
+	ColimaTimeoutExitCode       = 124
+	MaxColimaTimeoutSeconds     = 24 * 60 * 60
+	colimaTerminationGrace      = 5 * time.Second
+	colimaTerminationProofLimit = 5 * time.Second
+	colimaTerminationPoll       = 25 * time.Millisecond
+)
 
 // HostColimaInvocation captures the environment used to invoke a
 // trusted host `colima` binary on behalf of scripts/workcell.  The
@@ -47,8 +54,8 @@ func RunHostColima(inv HostColimaInvocation) (int, error) {
 	if len(inv.Args) == 0 {
 		return 0, nil
 	}
-	if inv.ColimaBin == "" {
-		return 0, errors.New("RunHostColima: colima binary path is required")
+	if err := validateColimaBinary(inv.ColimaBin); err != nil {
+		return 0, fmt.Errorf("RunHostColima: %w", err)
 	}
 	cmd, err := newColimaCommand(context.Background(), inv)
 	if err != nil {
@@ -63,37 +70,46 @@ func RunHostColima(inv HostColimaInvocation) (int, error) {
 // returns ColimaTimeoutExitCode (124) after killing the colima process
 // group, matching the bash run_host_colima_with_timeout helper.
 func RunHostColimaWithTimeout(timeoutSeconds int, inv HostColimaInvocation) (int, error) {
+	if timeoutSeconds > MaxColimaTimeoutSeconds {
+		return 0, fmt.Errorf("RunHostColimaWithTimeout: timeout must not exceed %d seconds", MaxColimaTimeoutSeconds)
+	}
 	if len(inv.Args) == 0 {
 		return 0, nil
 	}
 	if timeoutSeconds <= 0 {
 		return RunHostColima(inv)
 	}
-	if inv.ColimaBin == "" {
-		return 0, errors.New("RunHostColimaWithTimeout: colima binary path is required")
+	if err := validateColimaBinary(inv.ColimaBin); err != nil {
+		return 0, fmt.Errorf("RunHostColimaWithTimeout: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
+	return runHostColimaWithContext(ctx, inv)
+}
 
+func runHostColimaWithContext(ctx context.Context, inv HostColimaInvocation) (int, error) {
 	cmd, err := newColimaCommand(ctx, inv)
 	if err != nil {
 		return 0, err
 	}
-	// Place the child in its own process group so we can deliver
-	// SIGKILL to the whole tree on timeout (mirroring the bash
-	// helper's kill_process_tree_by_pid behaviour).
+	// Place the child in its own process group so cancellation can
+	// terminate and prove the absence of every descendant.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cleanupResult := make(chan error, 1)
 	cmd.Cancel = func() error {
-		return killColimaProcessGroup(cmd)
+		err := terminateColimaProcessGroup(cmd)
+		cleanupResult <- err
+		return err
 	}
-	cmd.WaitDelay = 5 * time.Second
 
-	code, runErr := runColimaCommand(cmd)
-	if ctx.Err() == context.DeadlineExceeded {
-		return ColimaTimeoutExitCode, nil
+	runErr := cmd.Run()
+	select {
+	case cleanupErr := <-cleanupResult:
+		return colimaCancellationResult(runErr, cleanupErr)
+	default:
+		return colimaRunResult(runErr)
 	}
-	return code, runErr
 }
 
 // ValidateColimaStatusOutput checks that the textual output of
@@ -166,7 +182,10 @@ func colimaChildEnv(inv HostColimaInvocation) []string {
 }
 
 func runColimaCommand(cmd *exec.Cmd) (int, error) {
-	err := cmd.Run()
+	return colimaRunResult(cmd.Run())
+}
+
+func colimaRunResult(err error) (int, error) {
 	if err == nil {
 		return 0, nil
 	}
@@ -175,6 +194,32 @@ func runColimaCommand(cmd *exec.Cmd) (int, error) {
 		return colimaExitCode(exitErr), nil
 	}
 	return 0, fmt.Errorf("colima invocation failed: %w", err)
+}
+
+func colimaCancellationResult(runErr, cleanupErr error) (int, error) {
+	if cleanupErr != nil {
+		cleanupErr = fmt.Errorf("colima process-group cleanup failed: %w", cleanupErr)
+		if runErr != nil {
+			return 0, errors.Join(fmt.Errorf("colima invocation failed: %w", runErr), cleanupErr)
+		}
+		return 0, cleanupErr
+	}
+	if expectedColimaCancellationError(runErr) {
+		return ColimaTimeoutExitCode, nil
+	}
+	return colimaRunResult(runErr)
+}
+
+func expectedColimaCancellationError(err error) bool {
+	if err == nil || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	return ok && status.Signaled() && (status.Signal() == syscall.SIGTERM || status.Signal() == syscall.SIGKILL)
 }
 
 func colimaExitCode(exitErr *exec.ExitError) int {
@@ -187,16 +232,63 @@ func colimaExitCode(exitErr *exec.ExitError) int {
 	return exitErr.ExitCode()
 }
 
-func killColimaProcessGroup(cmd *exec.Cmd) error {
+func validateColimaBinary(path string) error {
+	if path == "" {
+		return errors.New("colima binary path is required")
+	}
+	if !filepath.IsAbs(path) {
+		return errors.New("colima binary path must be absolute")
+	}
+	return nil
+}
+
+func terminateColimaProcessGroup(cmd *exec.Cmd) error {
 	if cmd == nil || cmd.Process == nil {
 		return nil
 	}
-	pid := cmd.Process.Pid
-	// Negative pid targets the whole process group.  Ignore the
-	// "no such process" error that arises if the child already exited
-	// between the deadline firing and our kill call.
-	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+	groupID := cmd.Process.Pid
+	if err := signalColimaProcessGroup(groupID, syscall.SIGTERM); err != nil {
+		return err
+	}
+	absent, err := waitForColimaProcessGroupExit(groupID, colimaTerminationGrace)
+	if err != nil || absent {
+		return err
+	}
+	if err := signalColimaProcessGroup(groupID, syscall.SIGKILL); err != nil {
+		return err
+	}
+	absent, err = waitForColimaProcessGroupExit(groupID, colimaTerminationProofLimit)
+	if err != nil {
+		return err
+	}
+	if !absent {
+		return fmt.Errorf("process group %d remains after SIGKILL", groupID)
+	}
+	return nil
+}
+
+func signalColimaProcessGroup(groupID int, signal syscall.Signal) error {
+	if err := syscall.Kill(-groupID, signal); err != nil && !errors.Is(err, syscall.ESRCH) {
 		return err
 	}
 	return nil
+}
+
+func waitForColimaProcessGroupExit(groupID int, limit time.Duration) (bool, error) {
+	deadline := time.Now().Add(limit)
+	for {
+		err := syscall.Kill(-groupID, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return true, nil
+		}
+		// EPERM proves presence, not absence. Keep polling for ESRCH;
+		// a later TERM or KILL still fails closed if it cannot signal.
+		if err != nil && !errors.Is(err, syscall.EPERM) {
+			return false, err
+		}
+		if !time.Now().Before(deadline) {
+			return false, nil
+		}
+		time.Sleep(colimaTerminationPoll)
+	}
 }

--- a/internal/host/launcher/colima_test.go
+++ b/internal/host/launcher/colima_test.go
@@ -4,9 +4,13 @@
 package launcher
 
 import (
+	"context"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -90,6 +94,18 @@ func TestRunHostColimaRequiresColimaBin(t *testing.T) {
 	_, err := RunHostColima(HostColimaInvocation{Args: []string{"list"}})
 	if err == nil {
 		t.Fatal("RunHostColima() err = nil, want colima-bin-required error")
+	}
+}
+
+func TestRunHostColimaRequiresAbsoluteColimaBin(t *testing.T) {
+	t.Parallel()
+	_, err := RunHostColima(HostColimaInvocation{ColimaBin: "colima", Args: []string{"list"}})
+	if err == nil || !strings.Contains(err.Error(), "must be absolute") {
+		t.Fatalf("RunHostColima() err = %v, want absolute-path rejection", err)
+	}
+	_, err = RunHostColimaWithTimeout(1, HostColimaInvocation{ColimaBin: "colima", Args: []string{"start"}})
+	if err == nil || !strings.Contains(err.Error(), "must be absolute") {
+		t.Fatalf("RunHostColimaWithTimeout() err = %v, want absolute-path rejection", err)
 	}
 }
 
@@ -194,31 +210,105 @@ exit 11
 	}
 }
 
+func TestRunHostColimaWithTimeoutRejectsMoreThanOneDay(t *testing.T) {
+	t.Parallel()
+	_, err := RunHostColimaWithTimeout(24*60*60+1, HostColimaInvocation{
+		ColimaBin: "/bin/true",
+		Args:      []string{"list"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "must not exceed") {
+		t.Fatalf("RunHostColimaWithTimeout() err = %v, want timeout-cap rejection", err)
+	}
+}
+
 func TestRunHostColimaWithTimeoutKillsRunawayChild(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("relies on POSIX /bin/sh helpers")
 	}
 	// Serial — see ETXTBSY note on TestRunHostColimaForwardsArgsAndPropagatesExitCode.
-	dir := t.TempDir()
-	fake := writeFakeColima(t, dir, `#!/bin/sh
-# Sleep well past the test deadline to force the timeout path.
-sleep 30
-exit 0
+	for _, tc := range []struct {
+		name   string
+		setup  string
+		minRun time.Duration
+		maxRun time.Duration
+	}{
+		{"TERM-responsive", ":", 0, 4 * time.Second},
+		{"TERM-resistant", "trap '' TERM", 4750 * time.Millisecond, 10 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			marker := filepath.Join(dir, "processes")
+			fake := writeFakeColima(t, dir, "#!/bin/sh\n"+tc.setup+`
+sh -c "`+tc.setup+`; while :; do sleep 1; done" &
+child=$!
+pgid=$(ps -o pgid= -p $$ | tr -d ' ')
+printf '%s %s\n' "$pgid" "$child" >"$2"
+wait "$child"
 `)
-	start := time.Now()
-	code, err := RunHostColimaWithTimeout(1, HostColimaInvocation{
-		ColimaBin: fake,
-		RealHome:  dir,
-		Args:      []string{"start"},
-	})
-	if err != nil {
-		t.Fatalf("RunHostColimaWithTimeout() err = %v", err)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			go cancelWhenFileExists(ctx, cancel, marker)
+			start := time.Now()
+			code, err := runHostColimaWithContext(ctx, HostColimaInvocation{
+				ColimaBin: fake,
+				RealHome:  dir,
+				Args:      []string{"start", marker},
+			})
+			if err != nil || code != ColimaTimeoutExitCode {
+				t.Fatalf("runHostColimaWithContext() = %d, %v", code, err)
+			}
+			if elapsed := time.Since(start); elapsed < tc.minRun || elapsed > tc.maxRun {
+				t.Fatalf("process-group cleanup completed in %s", elapsed)
+			}
+			fields := strings.Fields(string(mustReadFile(t, marker)))
+			if len(fields) != 2 {
+				t.Fatalf("process marker = %q", fields)
+			}
+			groupID, err := strconv.Atoi(fields[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := syscall.Kill(-groupID, 0); !errors.Is(err, syscall.ESRCH) {
+				t.Fatalf("process group %d still exists: %v", groupID, err)
+			}
+		})
 	}
-	if code != ColimaTimeoutExitCode {
-		t.Fatalf("RunHostColimaWithTimeout() code = %d, want %d", code, ColimaTimeoutExitCode)
-	}
-	if elapsed := time.Since(start); elapsed > 10*time.Second {
-		t.Fatalf("RunHostColimaWithTimeout() took %s, expected to honour 1s deadline", elapsed)
+}
+
+func TestColimaCancellationResultPreservesOutcomes(t *testing.T) {
+	termErr := processSignalError(t, syscall.SIGTERM)
+	killErr := processSignalError(t, syscall.SIGKILL)
+	interruptErr := processSignalError(t, syscall.SIGINT)
+	exitErr := exec.Command("/bin/sh", "-c", "exit 7").Run()
+	plainErr := errors.New("write failed")
+	cleanupErr := errors.New("group remains")
+	for _, tc := range []struct {
+		name       string
+		runErr     error
+		cleanupErr error
+		wantCode   int
+		wantErrors []error
+	}{
+		{"nil", nil, nil, 124, nil},
+		{"deadline", context.DeadlineExceeded, nil, 124, nil},
+		{"TERM", termErr, nil, 124, nil},
+		{"KILL", killErr, nil, 124, nil},
+		{"exit 7", exitErr, nil, 7, nil},
+		{"SIGINT", interruptErr, nil, 128 + int(syscall.SIGINT), nil},
+		{"I/O error", plainErr, nil, 0, []error{plainErr}},
+		{"cleanup", termErr, cleanupErr, 0, []error{termErr, cleanupErr}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code, err := colimaCancellationResult(tc.runErr, tc.cleanupErr)
+			if code != tc.wantCode || (len(tc.wantErrors) == 0 && err != nil) {
+				t.Fatalf("colimaCancellationResult() = %d, %v", code, err)
+			}
+			for _, wantErr := range tc.wantErrors {
+				if !errors.Is(err, wantErr) {
+					t.Fatalf("colimaCancellationResult() err = %v, want %v", err, wantErr)
+				}
+			}
+		})
 	}
 }
 
@@ -242,6 +332,19 @@ exit 0
 	if code != 0 {
 		t.Fatalf("RunHostColimaWithTimeout() code = %d, want 0", code)
 	}
+	runaway := writeFakeColima(t, dir, "#!/bin/sh\nsleep 30\n")
+	start := time.Now()
+	code, err = RunHostColimaWithTimeout(1, HostColimaInvocation{
+		ColimaBin: runaway,
+		RealHome:  dir,
+		Args:      []string{"start"},
+	})
+	if err != nil || code != ColimaTimeoutExitCode {
+		t.Fatalf("RunHostColimaWithTimeout(runaway) = %d, %v", code, err)
+	}
+	if elapsed := time.Since(start); elapsed < 750*time.Millisecond || elapsed > 10*time.Second {
+		t.Fatalf("one-second timeout completed in %s", elapsed)
+	}
 }
 
 func writeFakeColima(t *testing.T, dir, script string) string {
@@ -254,4 +357,39 @@ func writeFakeColima(t *testing.T, dir, script string) string {
 		t.Fatalf("chmod fake colima: %v", err)
 	}
 	return path
+}
+
+func processSignalError(t *testing.T, signal syscall.Signal) error {
+	t.Helper()
+	cmd := exec.Command("/bin/sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Process.Signal(signal); err != nil {
+		t.Fatal(err)
+	}
+	err := cmd.Wait()
+	if err == nil {
+		t.Fatalf("signal %s produced no error", signal)
+	}
+	return err
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func cancelWhenFileExists(ctx context.Context, cancel context.CancelFunc, path string) {
+	for ctx.Err() == nil {
+		if data, err := os.ReadFile(path); err == nil && len(strings.Fields(string(data))) == 2 {
+			cancel()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }

--- a/internal/runtimeutil/runtimeutil.go
+++ b/internal/runtimeutil/runtimeutil.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/omkhar/workcell/internal/pathutil"
 	"github.com/omkhar/workcell/internal/rootio"
@@ -21,7 +22,10 @@ import (
 const (
 	maxRuntimeManifestBytes  = rootio.MaxManifestBytes
 	maxRuntimeMountSpecBytes = rootio.MaxDirectMountSpecBytes
+	resolveIPTimeout         = 5 * time.Second
 )
+
+type lookupIPAddrFunc func(context.Context, string) ([]net.IPAddr, error)
 
 type DirectMount struct {
 	Source    string `json:"source"`
@@ -37,13 +41,19 @@ func CanonicalizePath(raw string) (string, error) {
 }
 
 func ResolveIPs(host string) ([]string, error) {
+	return resolveIPs(host, net.DefaultResolver.LookupIPAddr)
+}
+
+func resolveIPs(host string, lookup lookupIPAddrFunc) ([]string, error) {
 	host = strings.TrimSpace(host)
 	host = strings.TrimPrefix(host, "[")
 	host = strings.TrimSuffix(host, "]")
 	if host == "" {
 		return nil, errors.New("host is required")
 	}
-	addrs, err := net.DefaultResolver.LookupIPAddr(context.Background(), host)
+	ctx, cancel := context.WithTimeout(context.Background(), resolveIPTimeout)
+	defer cancel()
+	addrs, err := lookup(ctx, host)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtimeutil/runtimeutil_test.go
+++ b/internal/runtimeutil/runtimeutil_test.go
@@ -5,12 +5,15 @@ package runtimeutil
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -53,6 +56,35 @@ func TestResolveIPs(t *testing.T) {
 	}
 	if !reflect.DeepEqual(ips, []string{"127.0.0.1"}) {
 		t.Fatalf("ResolveIPs = %#v", ips)
+	}
+}
+
+func TestResolveIPsUsesBoundedCancelledContext(t *testing.T) {
+	var observed context.Context
+	var observedDeadline time.Time
+	before := time.Now()
+	ips, err := resolveIPs(" example.test ", func(ctx context.Context, host string) ([]net.IPAddr, error) {
+		observed = ctx
+		if host != "example.test" {
+			t.Fatalf("lookup host = %q", host)
+		}
+		observedDeadline, _ = ctx.Deadline()
+		if observedDeadline.IsZero() {
+			t.Fatal("lookup context has no deadline")
+		}
+		return []net.IPAddr{{IP: net.ParseIP("192.0.2.1")}}, nil
+	})
+	after := time.Now()
+	if err != nil || !reflect.DeepEqual(ips, []string{"192.0.2.1"}) {
+		t.Fatalf("resolveIPs = %#v, %v", ips, err)
+	}
+	if observedDeadline.Before(before.Add(5*time.Second)) || observedDeadline.After(after.Add(5*time.Second)) {
+		t.Fatalf("lookup deadline = %s, want five seconds", observedDeadline)
+	}
+	select {
+	case <-observed.Done():
+	default:
+		t.Fatal("resolveIPs did not cancel its lookup context")
 	}
 }
 

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "1479c9d048a3d6a51e15032ea8fd69900ed911dc3ed561d6097bf083110a1518"
+      "sha256": "3a18d749ff3f86314b86f5ed0900a4ffdd2c72c2801e1e52006dd488133c9c26"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2766,10 +2766,6 @@ go_verify_citools workcell-managed-profile-staging "${ROOT_DIR}" || exit 1
 WORKCELL_COLIMA_TIMEOUT_HARNESS="${BARRIER_VERIFY_ROOT}/workcell-colima-timeout-harness.sh"
 {
   printf 'set -euo pipefail\n'
-  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" kill_process_tree_by_pid
-  printf '\n'
-  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" terminate_process_tree_by_pid
-  printf '\n'
   extract_top_level_bash_function "${ROOT_DIR}/scripts/lib/launcher/go-hostutil.sh" run_go_hostutil_preserve_exit
   printf '\n'
   extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" run_host_colima_with_timeout
@@ -5064,6 +5060,8 @@ VERIFY_PROFILE_DELETE_REAPER_HARNESS="$(mktemp)"
 rm -f "${VERIFY_PROFILE_DELETE_REAPER_HARNESS}"
 COLIMA_PROFILE_STATUS_HARNESS="$(mktemp)"
 {
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/lib/launcher/go-hostutil.sh" run_go_hostutil_preserve_exit
+  printf '\n'
   extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" colima_profile_status
   extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" maybe_reap_stale_profile_processes
   cat "${ROOT_DIR}/verify/invariants/harnesses/process-colima/colima-profile-status.sh"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -685,34 +685,6 @@ run_host_colima() {
   )
 }
 
-kill_process_tree_by_pid() {
-  local target_pid="$1"
-  local child_pid=""
-
-  [[ -n "${target_pid}" ]] || return 0
-  while IFS= read -r child_pid; do
-    [[ -n "${child_pid}" ]] || continue
-    kill_process_tree_by_pid "${child_pid}"
-  done < <(pgrep -P "${target_pid}" 2>/dev/null || true)
-  kill "${target_pid}" >/dev/null 2>&1 || true
-}
-
-terminate_process_tree_by_pid() {
-  local target_pid="$1"
-  local deadline=0
-
-  [[ -n "${target_pid}" ]] || return 0
-  kill_process_tree_by_pid "${target_pid}"
-  deadline=$((SECONDS + 5))
-  while kill -0 "${target_pid}" >/dev/null 2>&1; do
-    if ((SECONDS >= deadline)); then
-      kill -9 "${target_pid}" >/dev/null 2>&1 || true
-      break
-    fi
-    sleep 1
-  done
-}
-
 run_host_colima_with_timeout() {
   local timeout_seconds="$1"
   shift
@@ -731,36 +703,18 @@ run_host_colima_with_timeout() {
 
 colima_profile_status() {
   local profile="$1"
-  local list_output=""
 
-  if ! list_output="$(run_host_colima list --json 2>/dev/null)"; then
-    return 1
-  fi
-  [[ -n "${list_output}" ]] || return 3
-
-  # The colima-status subcommand exits 0 with the profile status on
-  # stdout, 3 when the profile is absent from the list, and 1 for any
-  # other parse error.  go run wraps the child binary's non-zero exit
-  # status as "exit status N\n" on its own stderr while itself exiting
-  # 1, so the bash side reconstructs the original exit code from that
-  # trailer to preserve the contract verify-invariants depends on.
-  local stderr_capture status_output rc trailer
-  stderr_capture="$(mktemp "${TMPDIR:-/tmp}/workcell-colima-status-stderr.XXXXXX")"
-  status_output="$(printf '%s' "${list_output}" | go_hostutil helper colima-status "${profile}" 2>"${stderr_capture}")"
-  rc=$?
-  if ((rc != 0)); then
-    trailer="$(tail -n1 "${stderr_capture}" 2>/dev/null || true)"
-    case "${trailer}" in
-      "exit status "[0-9]*)
-        rc="${trailer##* }"
-        ;;
-    esac
-  fi
-  rm -f "${stderr_capture}"
-  if ((rc == 0)) && [[ -n "${status_output}" ]]; then
-    printf '%s\n' "${status_output}"
-  fi
-  return "${rc}"
+  (
+    local -a pipe_status=()
+    set +e
+    run_host_colima list --json 2>/dev/null |
+      run_go_hostutil_preserve_exit helper colima-status "${profile}"
+    pipe_status=("${PIPESTATUS[@]}")
+    if ((pipe_status[0] != 0)); then
+      exit 1
+    fi
+    exit "${pipe_status[1]}"
+  )
 }
 
 profile_process_pids() {
@@ -6387,14 +6341,11 @@ run_command_with_debug_log() {
   local heartbeat_pid=""
   local spinner_pid=""
   local spinner_enabled=0
-  local tail_pid=""
   local start_seconds=0
   local pid=""
   local status=0
-  local timed_out=0
-  local timeout_seconds=0
+  local managed_timeout_status=124
   local heartbeat_interval_seconds=30
-  local next_heartbeat=0
   local failed_capture_path=""
 
   format_elapsed_compact() {
@@ -6522,58 +6473,8 @@ run_command_with_debug_log() {
       fi
     fi
   fi
-  case "${label}" in
-    colima-start)
-      timeout_seconds="${WORKCELL_COLIMA_START_TIMEOUT_SECONDS:-180}"
-      ;;
-  esac
   maybe_print_progress_update start "0s"
-  if ((timeout_seconds > 0)); then
-    "$@" >"${log_path}" 2>&1 &
-    pid=$!
-    if [[ "${spinner_enabled}" -eq 1 ]]; then
-      start_progress_spinner "${pid}"
-    elif [[ "${LOG_LEVEL}" != "debug" ]]; then
-      next_heartbeat=$((SECONDS + heartbeat_interval_seconds))
-    fi
-    if [[ "${LOG_LEVEL}" == "debug" ]]; then
-      tail -n +1 -f "${log_path}" >&2 &
-      tail_pid=$!
-    fi
-    while kill -0 "${pid}" >/dev/null 2>&1; do
-      sleep 1
-      if ! kill -0 "${pid}" >/dev/null 2>&1; then
-        break
-      fi
-      if [[ "${spinner_enabled}" -eq 0 ]] && [[ "${LOG_LEVEL}" != "debug" ]] && ((SECONDS >= next_heartbeat)); then
-        maybe_print_progress_update heartbeat "$(format_elapsed_compact "$((SECONDS - start_seconds))")"
-        next_heartbeat=$((SECONDS + heartbeat_interval_seconds))
-      fi
-      if ((SECONDS - start_seconds >= timeout_seconds)); then
-        timed_out=1
-        terminate_process_tree_by_pid "${pid}"
-        break
-      fi
-    done
-    if wait "${pid}"; then
-      :
-    else
-      status=$?
-    fi
-    if ((timed_out == 1)); then
-      status=124
-    fi
-    stop_progress_spinner
-    if [[ -n "${tail_pid}" ]]; then
-      kill "${tail_pid}" >/dev/null 2>&1 || true
-      wait "${tail_pid}" 2>/dev/null || true
-    fi
-    if [[ -n "${DEBUG_LOG_PATH}" ]] && [[ -f "${log_path}" ]]; then
-      if debug_log_path="$(revalidate_recorded_host_output_path "${DEBUG_LOG_PATH}")"; then
-        cat "${log_path}" >>"${debug_log_path}"
-      fi
-    fi
-  elif [[ "${LOG_LEVEL}" == "debug" ]]; then
+  if [[ "${LOG_LEVEL}" == "debug" ]]; then
     set +e
     "$@" 2>&1 | tee "${log_path}" >&2
     debug_pipe_status=("${PIPESTATUS[@]}")
@@ -6619,7 +6520,7 @@ run_command_with_debug_log() {
   if [[ "${status}" -eq 0 ]]; then
     maybe_print_progress_update success "$(format_elapsed_compact "$((SECONDS - start_seconds))")"
   else
-    if ((timed_out == 1)); then
+    if [[ "${label}" == "colima-start" ]] && [[ "${status}" -eq "${managed_timeout_status}" ]]; then
       echo "Workcell timed out waiting for managed Colima profile ${COLIMA_PROFILE} to start ($(format_elapsed_compact "$((SECONDS - start_seconds))"))." >&2
     fi
     echo "Workcell ${label} failed." >&2
@@ -6987,10 +6888,15 @@ validate_colima_profile_config() {
 validate_colima_profile() {
   local profile="$1"
   local workspace="$2"
-  local status=""
 
-  status="$(run_host_colima status --profile "${profile}" 2>&1)"
-  if ! printf '%s' "${status}" | go_hostutil helper validate-colima-status "${profile}"; then
+  if ! (
+    local -a pipe_status=()
+    set +e
+    run_host_colima status --profile "${profile}" 2>&1 |
+      run_go_hostutil_preserve_exit helper validate-colima-status "${profile}"
+    pipe_status=("${PIPESTATUS[@]}")
+    ((pipe_status[0] == 0 && pipe_status[1] == 0))
+  ); then
     return 1
   fi
 
@@ -7018,7 +6924,7 @@ start_managed_profile() {
   while :; do
     maybe_reap_stale_profile_processes "${COLIMA_PROFILE}" || return 2
     if run_command_with_debug_log colima-start \
-      run_host_colima start \
+      run_host_colima_with_timeout "${WORKCELL_COLIMA_START_TIMEOUT_SECONDS:-180}" start \
       --profile "${COLIMA_PROFILE}" \
       --vm-type vz \
       --mount "${workspace_mount}:w" \


### PR DESCRIPTION
## Summary

- Stream Colima inventory and status output directly into bounded Go helpers.
- Limit three host utility inputs to 4 MiB.
- Apply a five-second DNS lookup deadline.
- Enforce an absolute Colima path and a 24-hour timeout limit.
- Terminate the managed process group with `SIGTERM`, then `SIGKILL` when necessary.
- Preserve ordinary exit and signal results.
- Update the launcher contract, control-plane manifest, and invariant checks.

This change completes the F-009 host slice and the F-013 remainder.

## Validation

- Fresh `pr-parity` passed for the exact base, head, tree, and clean status.
- Repository validation passed: 17 scenarios, zero failures, and five skips.
- All 21 reviewed mutation cases passed.
- Focused, race, full, vet, static, contract, and invariant checks passed.
- Live Colima smoke and Darwin TERM-resistant cleanup proof passed.
- Strict Colima and Docker Desktop secretless certification passed: two passes, zero failures, and 20 checks.
- Residue cleanup passed.

## Scope

- 10 changed files
- 626 changed lines
- Five validator areas
- No binaries
- No special CI label
