### PR TITLE
Bound Colima host inputs

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -31,6 +31,8 @@ import (
 	"github.com/omkhar/workcell/internal/transcript"
 )
 
+const maxHelperStdinBytes int64 = 4 << 20
+
 func main() {
 	if err := run(os.Args[1:]); err != nil {
 		// All Go CLI translations (authpolicy, publishpr, sessionctl,
@@ -438,7 +440,7 @@ func cmdHelperSessionSuffix(_ []string) error {
 }
 
 func cmdHelperSessionContainerAbsentForDelete(args []string) error {
-	inventory, err := io.ReadAll(os.Stdin)
+	inventory, err := readHelperInput("container inventory", os.Stdin)
 	if err != nil {
 		return err
 	}
@@ -446,7 +448,7 @@ func cmdHelperSessionContainerAbsentForDelete(args []string) error {
 }
 
 func cmdHelperColimaStatus(args []string) error {
-	input, err := io.ReadAll(os.Stdin)
+	input, err := readHelperInput("Colima profile inventory", os.Stdin)
 	if err != nil {
 		return err
 	}
@@ -466,11 +468,22 @@ func cmdHelperReapColimaProfileProcesses(args []string) error {
 }
 
 func cmdHelperValidateColimaStatus(args []string) error {
-	statusBytes, err := io.ReadAll(os.Stdin)
+	statusBytes, err := readHelperInput("Colima status output", os.Stdin)
 	if err != nil {
 		return err
 	}
 	return launcher.ValidateColimaStatusOutput(string(statusBytes), args[0])
+}
+
+func readHelperInput(subject string, inputReader io.Reader) ([]byte, error) {
+	input, err := io.ReadAll(io.LimitReader(inputReader, maxHelperStdinBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(input)) > maxHelperStdinBytes {
+		return nil, fmt.Errorf("%s exceeds %d-byte limit", subject, maxHelperStdinBytes)
+	}
+	return input, nil
 }
 
 func cmdHelperRunHostColimaWithTimeout(args []string) error {

--- a/cmd/workcell-hostutil/main_test.go
+++ b/cmd/workcell-hostutil/main_test.go
@@ -577,8 +577,12 @@ func TestHostInputSourceContractRejectsMutants(t *testing.T) {
 			workcell:   strings.Replace(workcell, "    pipe_status=(\"${PIPESTATUS[@]}\")", "    pipe_status=(0 0)", 1),
 			invariants: invariants, hostutil: hostutil, colima: colima,
 		},
-		"unquarantined profile status": {
+		"unquarantined profile stdout": {
 			workcell:   strings.Replace(workcell, " helper colima-status \"${profile}\" >\"${status_output}\"", " helper colima-status \"${profile}\"", 1),
+			invariants: invariants, hostutil: hostutil, colima: colima,
+		},
+		"unquarantined profile stderr": {
+			workcell:   strings.Replace(workcell, " >\"${status_output}\" 2>\"${status_error}\"", " >\"${status_output}\"", 1),
 			invariants: invariants, hostutil: hostutil, colima: colima,
 		},
 		"early profile status publish": {
@@ -586,7 +590,7 @@ func TestHostInputSourceContractRejectsMutants(t *testing.T) {
 			invariants: invariants, hostutil: hostutil, colima: colima,
 		},
 		"late-bound cleanup": {
-			workcell:   strings.Replace(workcell, "    printf -v cleanup_command 'rm -f -- %q' \"${status_output}\"\n    # Expand the escaped path before Bash unwinds this local scope.\n    # shellcheck disable=SC2064\n    trap \"${cleanup_command}\" EXIT", "    trap 'rm -f -- \"${status_output}\"' EXIT", 1),
+			workcell:   strings.Replace(workcell, "    printf -v cleanup_command 'rm -rf -- %q' \"${status_dir}\"\n    # Expand the escaped path before Bash unwinds this local scope.\n    # shellcheck disable=SC2064\n    trap \"${cleanup_command}\" EXIT", "    trap 'rm -rf -- \"${status_dir}\"' EXIT", 1),
 			invariants: invariants, hostutil: hostutil, colima: colima,
 		},
 		"pre-captured Colima status": {
@@ -634,9 +638,9 @@ func TestHostInputSourceContractRejectsMutants(t *testing.T) {
 func validateHostInputSource(workcell, invariants, hostutil, colima string) error {
 	requiredWorkcell := []string{
 		"run_profile_docker_command \"${profile}\" ps -a --format '{{.Names}}' 2>&1 |\n    go_hostutil helper session-container-absent-for-delete",
-		"run_host_colima list --json 2>/dev/null |\n      run_go_hostutil_preserve_exit helper colima-status \"${profile}\" >\"${status_output}\"\n    pipe_status=(\"${PIPESTATUS[@]}\")",
-		"printf -v cleanup_command 'rm -f -- %q' \"${status_output}\"\n    # Expand the escaped path before Bash unwinds this local scope.\n    # shellcheck disable=SC2064\n    trap \"${cleanup_command}\" EXIT",
-		"if ((pipe_status[0] != 0)); then\n      exit 1\n    fi\n    if ((pipe_status[1] != 0)); then\n      exit \"${pipe_status[1]}\"\n    fi\n    cat -- \"${status_output}\"",
+		"run_host_colima list --json 2>/dev/null |\n      run_go_hostutil_preserve_exit helper colima-status \"${profile}\" >\"${status_output}\" 2>\"${status_error}\"\n    pipe_status=(\"${PIPESTATUS[@]}\")",
+		"printf -v cleanup_command 'rm -rf -- %q' \"${status_dir}\"\n    # Expand the escaped path before Bash unwinds this local scope.\n    # shellcheck disable=SC2064\n    trap \"${cleanup_command}\" EXIT",
+		"if ((pipe_status[0] != 0)); then\n      exit 1\n    fi\n    if ((pipe_status[1] == 3)); then\n      exit 3\n    fi\n    if ((pipe_status[1] != 0)); then\n      cat -- \"${status_error}\" >&2\n      exit \"${pipe_status[1]}\"\n    fi\n    cat -- \"${status_error}\" >&2\n    cat -- \"${status_output}\"",
 		"run_host_colima status --profile \"${profile}\" 2>&1 |\n      run_go_hostutil_preserve_exit helper validate-colima-status \"${profile}\"\n    pipe_status=(\"${PIPESTATUS[@]}\")",
 	}
 	for _, required := range requiredWorkcell {

--- a/cmd/workcell-hostutil/main_test.go
+++ b/cmd/workcell-hostutil/main_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -536,4 +537,145 @@ func TestHelperUsageListsDirectoryCandidateResolver(t *testing.T) {
 	} else if !strings.Contains(err.Error(), "resolve-host-output-directory-candidate") {
 		t.Fatalf("helperUsage error = %q, want resolve-host-output-directory-candidate", err)
 	}
+}
+
+func TestHelperInputLimit(t *testing.T) {
+	exact := bytes.Repeat([]byte{'x'}, int(maxHelperStdinBytes))
+	got, err := readHelperInput("fixture", bytes.NewReader(exact))
+	if err != nil || len(got) != len(exact) {
+		t.Fatalf("readHelperInput(exact) = %d bytes, %v", len(got), err)
+	}
+	for _, subject := range []string{"container inventory", "Colima profile inventory", "Colima status output"} {
+		_, err := readHelperInput(subject, bytes.NewReader(append(exact, 'x')))
+		if err == nil || !strings.Contains(err.Error(), subject+" exceeds 4194304-byte limit") {
+			t.Fatalf("readHelperInput(%q) err = %v", subject, err)
+		}
+	}
+}
+
+func TestHostInputSourceContractRejectsMutants(t *testing.T) {
+	workcell := mustReadTestFile(t, filepath.Join("..", "..", "scripts", "workcell"))
+	invariants := mustReadTestFile(t, filepath.Join("..", "..", "scripts", "verify-invariants.sh"))
+	hostutil := mustReadTestFile(t, "main.go")
+	colima := mustReadTestFile(t, filepath.Join("..", "..", "internal", "host", "launcher", "colima.go"))
+	if err := validateHostInputSource(workcell, invariants, hostutil, colima); err != nil {
+		t.Fatal(err)
+	}
+
+	type sources struct {
+		workcell   string
+		invariants string
+		hostutil   string
+		colima     string
+	}
+	mutants := map[string]sources{
+		"pre-captured profile inventory": {
+			workcell:   strings.Replace(workcell, "run_host_colima list --json 2>/dev/null |", "list_output=\"$(run_host_colima list --json 2>/dev/null)\"", 1),
+			invariants: invariants, hostutil: hostutil, colima: colima,
+		},
+		"missing profile PIPESTATUS": {
+			workcell:   strings.Replace(workcell, "    pipe_status=(\"${PIPESTATUS[@]}\")", "    pipe_status=(0 0)", 1),
+			invariants: invariants, hostutil: hostutil, colima: colima,
+		},
+		"unquarantined profile status": {
+			workcell:   strings.Replace(workcell, " helper colima-status \"${profile}\" >\"${status_output}\"", " helper colima-status \"${profile}\"", 1),
+			invariants: invariants, hostutil: hostutil, colima: colima,
+		},
+		"early profile status publish": {
+			workcell:   strings.Replace(workcell, "    pipe_status=(\"${PIPESTATUS[@]}\")\n    set -e", "    cat -- \"${status_output}\"\n    pipe_status=(\"${PIPESTATUS[@]}\")\n    set -e", 1),
+			invariants: invariants, hostutil: hostutil, colima: colima,
+		},
+		"late-bound cleanup": {
+			workcell:   strings.Replace(workcell, "    printf -v cleanup_command 'rm -f -- %q' \"${status_output}\"\n    # Expand the escaped path before Bash unwinds this local scope.\n    # shellcheck disable=SC2064\n    trap \"${cleanup_command}\" EXIT", "    trap 'rm -f -- \"${status_output}\"' EXIT", 1),
+			invariants: invariants, hostutil: hostutil, colima: colima,
+		},
+		"pre-captured Colima status": {
+			workcell:   strings.Replace(workcell, "run_host_colima status --profile \"${profile}\" 2>&1 |", "status=\"$(run_host_colima status --profile \"${profile}\" 2>&1)\"", 1),
+			invariants: invariants, hostutil: hostutil, colima: colima,
+		},
+		"pre-captured container inventory": {
+			workcell:   strings.Replace(workcell, "run_profile_docker_command \"${profile}\" ps -a --format '{{.Names}}' 2>&1 |", "inventory=\"$(run_profile_docker_command \"${profile}\" ps -a --format '{{.Names}}' 2>&1)\"", 1),
+			invariants: invariants, hostutil: hostutil, colima: colima,
+		},
+		"stale exit adapter": {
+			workcell:   workcell,
+			invariants: strings.Replace(invariants, "scripts/lib/launcher/go-hostutil.sh\" run_go_hostutil_preserve_exit", "scripts/workcell\" go_hostutil", 1),
+			hostutil:   hostutil, colima: colima,
+		},
+		"unbounded container handler": {
+			workcell: workcell, invariants: invariants,
+			hostutil: strings.Replace(hostutil, "readHelperInput(\"container inventory\", os.Stdin)", "io.ReadAll(os.Stdin)", 1), colima: colima,
+		},
+		"unbounded inventory handler": {
+			workcell: workcell, invariants: invariants,
+			hostutil: strings.Replace(hostutil, "readHelperInput(\"Colima profile inventory\", os.Stdin)", "io.ReadAll(os.Stdin)", 1), colima: colima,
+		},
+		"unbounded status handler": {
+			workcell: workcell, invariants: invariants,
+			hostutil: strings.Replace(hostutil, "readHelperInput(\"Colima status output\", os.Stdin)", "io.ReadAll(os.Stdin)", 1), colima: colima,
+		},
+		"missing absolute-path validation": {
+			workcell: workcell, invariants: invariants, hostutil: hostutil,
+			colima: strings.Replace(colima, "validateColimaBinary(inv.ColimaBin)", "error(nil)", 1),
+		},
+	}
+	for name, mutant := range mutants {
+		t.Run(name, func(t *testing.T) {
+			if mutant.workcell == workcell && mutant.invariants == invariants && mutant.hostutil == hostutil && mutant.colima == colima {
+				t.Fatal("mutant did not change its target source")
+			}
+			if err := validateHostInputSource(mutant.workcell, mutant.invariants, mutant.hostutil, mutant.colima); err == nil {
+				t.Fatal("mutant passed source contract")
+			}
+		})
+	}
+}
+
+func validateHostInputSource(workcell, invariants, hostutil, colima string) error {
+	requiredWorkcell := []string{
+		"run_profile_docker_command \"${profile}\" ps -a --format '{{.Names}}' 2>&1 |\n    go_hostutil helper session-container-absent-for-delete",
+		"run_host_colima list --json 2>/dev/null |\n      run_go_hostutil_preserve_exit helper colima-status \"${profile}\" >\"${status_output}\"\n    pipe_status=(\"${PIPESTATUS[@]}\")",
+		"printf -v cleanup_command 'rm -f -- %q' \"${status_output}\"\n    # Expand the escaped path before Bash unwinds this local scope.\n    # shellcheck disable=SC2064\n    trap \"${cleanup_command}\" EXIT",
+		"if ((pipe_status[0] != 0)); then\n      exit 1\n    fi\n    if ((pipe_status[1] != 0)); then\n      exit \"${pipe_status[1]}\"\n    fi\n    cat -- \"${status_output}\"",
+		"run_host_colima status --profile \"${profile}\" 2>&1 |\n      run_go_hostutil_preserve_exit helper validate-colima-status \"${profile}\"\n    pipe_status=(\"${PIPESTATUS[@]}\")",
+	}
+	for _, required := range requiredWorkcell {
+		if !strings.Contains(workcell, required) {
+			return fmt.Errorf("scripts/workcell lacks %q", required)
+		}
+	}
+	for _, obsolete := range []string{
+		"list_output=\"$(run_host_colima list --json",
+		"status=\"$(run_host_colima status --profile",
+		"inventory=\"$(run_profile_docker_command",
+	} {
+		if strings.Contains(workcell, obsolete) {
+			return fmt.Errorf("pre-captured host input remains: %s", obsolete)
+		}
+	}
+	if strings.Count(invariants, "scripts/lib/launcher/go-hostutil.sh\" run_go_hostutil_preserve_exit") != 2 {
+		return fmt.Errorf("verify-invariants must extract the exit-preserving stream adapter for both harnesses")
+	}
+	for _, call := range []string{
+		"readHelperInput(\"container inventory\", os.Stdin)",
+		"readHelperInput(\"Colima profile inventory\", os.Stdin)",
+		"readHelperInput(\"Colima status output\", os.Stdin)",
+	} {
+		if !strings.Contains(hostutil, call) {
+			return fmt.Errorf("hostutil lacks bounded read %q", call)
+		}
+	}
+	if strings.Count(colima, "validateColimaBinary(inv.ColimaBin)") != 2 {
+		return fmt.Errorf("Colima direct and timeout entries must validate the executable path")
+	}
+	return nil
+}
+
+func mustReadTestFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }

--- a/docs/launcher-contract.md
+++ b/docs/launcher-contract.md
@@ -193,6 +193,14 @@ GPG, SSH, XDG, and GitHub variables.
 
 This function runs `cmd/workcell-colimautil` with the selected arguments.
 
+### Colima host input controls
+
+The launcher streams Colima inventory and status output directly to the host utility.
+The container inventory, Colima inventory, and Colima status inputs each have a 4 MiB limit.
+The launcher publishes a profile status only after the inventory producer and parser succeed.
+Workcell accepts only an absolute path for the selected Colima executable.
+Runtime DNS resolution uses a five-second deadline. The resolver cancels the lookup context when resolution finishes.
+
 The publication function is a deliberate host-side exception. It can receive
 the ambient operator publication and signing environment. The Tier 1 runtime
 does not receive this ambient state. Reviewed injection can stage selected

--- a/internal/host/launcher/colima.go
+++ b/internal/host/launcher/colima.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -47,8 +48,8 @@ func RunHostColima(inv HostColimaInvocation) (int, error) {
 	if len(inv.Args) == 0 {
 		return 0, nil
 	}
-	if inv.ColimaBin == "" {
-		return 0, errors.New("RunHostColima: colima binary path is required")
+	if err := validateColimaBinary(inv.ColimaBin); err != nil {
+		return 0, fmt.Errorf("RunHostColima: %w", err)
 	}
 	cmd, err := newColimaCommand(context.Background(), inv)
 	if err != nil {
@@ -69,8 +70,8 @@ func RunHostColimaWithTimeout(timeoutSeconds int, inv HostColimaInvocation) (int
 	if timeoutSeconds <= 0 {
 		return RunHostColima(inv)
 	}
-	if inv.ColimaBin == "" {
-		return 0, errors.New("RunHostColimaWithTimeout: colima binary path is required")
+	if err := validateColimaBinary(inv.ColimaBin); err != nil {
+		return 0, fmt.Errorf("RunHostColimaWithTimeout: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds)*time.Second)
@@ -185,6 +186,16 @@ func colimaExitCode(exitErr *exec.ExitError) int {
 		return 128 + int(status.Signal())
 	}
 	return exitErr.ExitCode()
+}
+
+func validateColimaBinary(path string) error {
+	if path == "" {
+		return errors.New("colima binary path is required")
+	}
+	if !filepath.IsAbs(path) {
+		return errors.New("colima binary path must be absolute")
+	}
+	return nil
 }
 
 func killColimaProcessGroup(cmd *exec.Cmd) error {

--- a/internal/host/launcher/colima_test.go
+++ b/internal/host/launcher/colima_test.go
@@ -93,6 +93,22 @@ func TestRunHostColimaRequiresColimaBin(t *testing.T) {
 	}
 }
 
+func TestRunHostColimaRequiresAbsoluteColimaBin(t *testing.T) {
+	dir := t.TempDir()
+	fake := writeFakeColima(t, dir, "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	relative := filepath.Base(fake)
+
+	_, err := RunHostColima(HostColimaInvocation{ColimaBin: relative, Args: []string{"list"}})
+	if err == nil || !strings.Contains(err.Error(), "must be absolute") {
+		t.Fatalf("RunHostColima() err = %v, want absolute-path rejection", err)
+	}
+	_, err = RunHostColimaWithTimeout(1, HostColimaInvocation{ColimaBin: relative, Args: []string{"start"}})
+	if err == nil || !strings.Contains(err.Error(), "must be absolute") {
+		t.Fatalf("RunHostColimaWithTimeout() err = %v, want absolute-path rejection", err)
+	}
+}
+
 func TestRunHostColimaForwardsArgsAndPropagatesExitCode(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("relies on POSIX /bin/sh helpers")

--- a/internal/runtimeutil/runtimeutil.go
+++ b/internal/runtimeutil/runtimeutil.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/omkhar/workcell/internal/pathutil"
 	"github.com/omkhar/workcell/internal/rootio"
@@ -21,7 +22,10 @@ import (
 const (
 	maxRuntimeManifestBytes  = rootio.MaxManifestBytes
 	maxRuntimeMountSpecBytes = rootio.MaxDirectMountSpecBytes
+	resolveIPTimeout         = 5 * time.Second
 )
+
+type lookupIPAddrFunc func(context.Context, string) ([]net.IPAddr, error)
 
 type DirectMount struct {
 	Source    string `json:"source"`
@@ -37,13 +41,19 @@ func CanonicalizePath(raw string) (string, error) {
 }
 
 func ResolveIPs(host string) ([]string, error) {
+	return resolveIPs(host, net.DefaultResolver.LookupIPAddr)
+}
+
+func resolveIPs(host string, lookup lookupIPAddrFunc) ([]string, error) {
 	host = strings.TrimSpace(host)
 	host = strings.TrimPrefix(host, "[")
 	host = strings.TrimSuffix(host, "]")
 	if host == "" {
 		return nil, errors.New("host is required")
 	}
-	addrs, err := net.DefaultResolver.LookupIPAddr(context.Background(), host)
+	ctx, cancel := context.WithTimeout(context.Background(), resolveIPTimeout)
+	defer cancel()
+	addrs, err := lookup(ctx, host)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtimeutil/runtimeutil_test.go
+++ b/internal/runtimeutil/runtimeutil_test.go
@@ -5,12 +5,15 @@ package runtimeutil
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -53,6 +56,35 @@ func TestResolveIPs(t *testing.T) {
 	}
 	if !reflect.DeepEqual(ips, []string{"127.0.0.1"}) {
 		t.Fatalf("ResolveIPs = %#v", ips)
+	}
+}
+
+func TestResolveIPsUsesBoundedCancelledContext(t *testing.T) {
+	var observed context.Context
+	var observedDeadline time.Time
+	before := time.Now()
+	ips, err := resolveIPs(" example.test ", func(ctx context.Context, host string) ([]net.IPAddr, error) {
+		observed = ctx
+		if host != "example.test" {
+			t.Fatalf("lookup host = %q", host)
+		}
+		observedDeadline, _ = ctx.Deadline()
+		if observedDeadline.IsZero() {
+			t.Fatal("lookup context has no deadline")
+		}
+		return []net.IPAddr{{IP: net.ParseIP("192.0.2.1")}}, nil
+	})
+	after := time.Now()
+	if err != nil || !reflect.DeepEqual(ips, []string{"192.0.2.1"}) {
+		t.Fatalf("resolveIPs = %#v, %v", ips, err)
+	}
+	if observedDeadline.Before(before.Add(5*time.Second)) || observedDeadline.After(after.Add(5*time.Second)) {
+		t.Fatalf("lookup deadline = %s, want five seconds", observedDeadline)
+	}
+	select {
+	case <-observed.Done():
+	default:
+		t.Fatal("resolveIPs did not cancel its lookup context")
 	}
 }
 

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "1479c9d048a3d6a51e15032ea8fd69900ed911dc3ed561d6097bf083110a1518"
+      "sha256": "be512146bc5ae08b9be70bbc582e970e54d6cdada181069ec8093931d226f616"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "be512146bc5ae08b9be70bbc582e970e54d6cdada181069ec8093931d226f616"
+      "sha256": "3ad0354f6b3506c15851e75edcb0885512e8440b7eee311c5dfbd69d744ef170"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -5064,6 +5064,8 @@ VERIFY_PROFILE_DELETE_REAPER_HARNESS="$(mktemp)"
 rm -f "${VERIFY_PROFILE_DELETE_REAPER_HARNESS}"
 COLIMA_PROFILE_STATUS_HARNESS="$(mktemp)"
 {
+  extract_top_level_bash_function "${ROOT_DIR}/scripts/lib/launcher/go-hostutil.sh" run_go_hostutil_preserve_exit
+  printf '\n'
   extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" colima_profile_status
   extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" maybe_reap_stale_profile_processes
   cat "${ROOT_DIR}/verify/invariants/harnesses/process-colima/colima-profile-status.sh"

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -735,23 +735,32 @@ colima_profile_status() {
   (
     local -a pipe_status=()
     local cleanup_command=""
+    local status_dir=""
+    local status_error=""
     local status_output=""
-    status_output="$(mktemp "${TMPDIR:-/tmp}/workcell-colima-profile-status.XXXXXX")" || exit 1
-    printf -v cleanup_command 'rm -f -- %q' "${status_output}"
+    status_dir="$(mktemp -d "${TMPDIR:-/tmp}/workcell-colima-profile-status.XXXXXX")" || exit 1
+    status_error="${status_dir}/stderr"
+    status_output="${status_dir}/stdout"
+    printf -v cleanup_command 'rm -rf -- %q' "${status_dir}"
     # Expand the escaped path before Bash unwinds this local scope.
     # shellcheck disable=SC2064
     trap "${cleanup_command}" EXIT
     set +e
     run_host_colima list --json 2>/dev/null |
-      run_go_hostutil_preserve_exit helper colima-status "${profile}" >"${status_output}"
+      run_go_hostutil_preserve_exit helper colima-status "${profile}" >"${status_output}" 2>"${status_error}"
     pipe_status=("${PIPESTATUS[@]}")
     set -e
     if ((pipe_status[0] != 0)); then
       exit 1
     fi
+    if ((pipe_status[1] == 3)); then
+      exit 3
+    fi
     if ((pipe_status[1] != 0)); then
+      cat -- "${status_error}" >&2
       exit "${pipe_status[1]}"
     fi
+    cat -- "${status_error}" >&2
     cat -- "${status_output}"
   )
 }

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -731,36 +731,29 @@ run_host_colima_with_timeout() {
 
 colima_profile_status() {
   local profile="$1"
-  local list_output=""
 
-  if ! list_output="$(run_host_colima list --json 2>/dev/null)"; then
-    return 1
-  fi
-  [[ -n "${list_output}" ]] || return 3
-
-  # The colima-status subcommand exits 0 with the profile status on
-  # stdout, 3 when the profile is absent from the list, and 1 for any
-  # other parse error.  go run wraps the child binary's non-zero exit
-  # status as "exit status N\n" on its own stderr while itself exiting
-  # 1, so the bash side reconstructs the original exit code from that
-  # trailer to preserve the contract verify-invariants depends on.
-  local stderr_capture status_output rc trailer
-  stderr_capture="$(mktemp "${TMPDIR:-/tmp}/workcell-colima-status-stderr.XXXXXX")"
-  status_output="$(printf '%s' "${list_output}" | go_hostutil helper colima-status "${profile}" 2>"${stderr_capture}")"
-  rc=$?
-  if ((rc != 0)); then
-    trailer="$(tail -n1 "${stderr_capture}" 2>/dev/null || true)"
-    case "${trailer}" in
-      "exit status "[0-9]*)
-        rc="${trailer##* }"
-        ;;
-    esac
-  fi
-  rm -f "${stderr_capture}"
-  if ((rc == 0)) && [[ -n "${status_output}" ]]; then
-    printf '%s\n' "${status_output}"
-  fi
-  return "${rc}"
+  (
+    local -a pipe_status=()
+    local cleanup_command=""
+    local status_output=""
+    status_output="$(mktemp "${TMPDIR:-/tmp}/workcell-colima-profile-status.XXXXXX")" || exit 1
+    printf -v cleanup_command 'rm -f -- %q' "${status_output}"
+    # Expand the escaped path before Bash unwinds this local scope.
+    # shellcheck disable=SC2064
+    trap "${cleanup_command}" EXIT
+    set +e
+    run_host_colima list --json 2>/dev/null |
+      run_go_hostutil_preserve_exit helper colima-status "${profile}" >"${status_output}"
+    pipe_status=("${PIPESTATUS[@]}")
+    set -e
+    if ((pipe_status[0] != 0)); then
+      exit 1
+    fi
+    if ((pipe_status[1] != 0)); then
+      exit "${pipe_status[1]}"
+    fi
+    cat -- "${status_output}"
+  )
 }
 
 profile_process_pids() {
@@ -6987,10 +6980,15 @@ validate_colima_profile_config() {
 validate_colima_profile() {
   local profile="$1"
   local workspace="$2"
-  local status=""
 
-  status="$(run_host_colima status --profile "${profile}" 2>&1)"
-  if ! printf '%s' "${status}" | go_hostutil helper validate-colima-status "${profile}"; then
+  if ! (
+    local -a pipe_status=()
+    set +e
+    run_host_colima status --profile "${profile}" 2>&1 |
+      run_go_hostutil_preserve_exit helper validate-colima-status "${profile}"
+    pipe_status=("${PIPESTATUS[@]}")
+    ((pipe_status[0] == 0 && pipe_status[1] == 0))
+  ); then
     return 1
   fi
 

--- a/verify/invariants/harnesses/process-colima/colima-profile-status.sh
+++ b/verify/invariants/harnesses/process-colima/colima-profile-status.sh
@@ -2,6 +2,9 @@ set -euo pipefail
 
 ROOT_DIR="__ROOT_DIR__"
 TRUSTED_HOST_PATH="${PATH}"
+PROFILE_STATUS_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-colima-profile-status-harness.XXXXXX")"
+trap 'rm -rf -- "${PROFILE_STATUS_TMPDIR}"' EXIT
+export TMPDIR="${PROFILE_STATUS_TMPDIR}"
 
 # Match scripts/workcell's scrubbed repo-root go_hostutil invocation.
 source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
@@ -23,6 +26,16 @@ go_hostutil() {
         GOCACHE="${GOCACHE}" \
         "${host_go_bin}" run ./cmd/workcell-hostutil "$@"
   )
+}
+
+assert_no_profile_status_temp_files() {
+  local residue=""
+
+  residue="$(find "${PROFILE_STATUS_TMPDIR}" -type f -name 'workcell-colima-profile-status.*' -print -quit)"
+  if [[ -n "${residue}" ]]; then
+    echo "Expected colima_profile_status to remove its temporary output: ${residue}" >&2
+    exit 1
+  fi
 }
 
 run_host_colima() {
@@ -56,15 +69,17 @@ if [[ "${status}" != "Stopped" ]]; then
   echo "Expected colima_profile_status to return Stopped for the matching profile, got: ${status}" >&2
   exit 1
 fi
+assert_no_profile_status_temp_files
 
 status="$(colima_profile_status workcell-other)"
 if [[ "${status}" != "Running" ]]; then
   echo "Expected colima_profile_status to return Running for the matching profile, got: ${status}" >&2
   exit 1
 fi
+assert_no_profile_status_temp_files
 
 missing_status_rc=0
-if colima_profile_status does-not-exist >/tmp/workcell-colima-profile-status-missing.out 2>&1; then
+if colima_profile_status does-not-exist >"${PROFILE_STATUS_TMPDIR}/missing.out" 2>&1; then
   echo "Expected colima_profile_status to fail for a missing profile" >&2
   exit 1
 else
@@ -74,6 +89,7 @@ if ((missing_status_rc != 3)); then
   echo "Expected colima_profile_status to return exit status 3 for a missing profile, got: ${missing_status_rc}" >&2
   exit 1
 fi
+assert_no_profile_status_temp_files
 
 reaped="$(maybe_reap_stale_profile_processes workcell-workcell-ac42b1dc)"
 if [[ "${reaped}" != "reaped:workcell-workcell-ac42b1dc" ]]; then
@@ -123,3 +139,40 @@ if [[ -n "$(maybe_reap_stale_profile_processes workcell-parse-failure)" ]]; then
   echo "Expected maybe_reap_stale_profile_processes to ignore parse failures instead of reaping live profiles blindly" >&2
   exit 1
 fi
+assert_no_profile_status_temp_files
+
+FAILED_INVENTORY_STATUS=""
+FAILED_INVENTORY_REAP_LOG="$(mktemp "${PROFILE_STATUS_TMPDIR}/reap-log.XXXXXX")"
+run_host_colima() {
+  printf '{"name":"workcell-fail-after-output","status":"%s"}\n' "${FAILED_INVENTORY_STATUS}"
+  return 17
+}
+reap_stale_profile_processes() {
+  printf 'reaped:%s\n' "$1" >>"${FAILED_INVENTORY_REAP_LOG}"
+}
+
+for FAILED_INVENTORY_STATUS in Running Stopped; do
+  status=""
+  status_rc=0
+  if status="$(colima_profile_status workcell-fail-after-output)"; then
+    echo "Expected failed ${FAILED_INVENTORY_STATUS} inventory to fail closed" >&2
+    exit 1
+  else
+    status_rc=$?
+  fi
+  if ((status_rc != 1)); then
+    echo "Expected failed ${FAILED_INVENTORY_STATUS} inventory status 1, got: ${status_rc}" >&2
+    exit 1
+  fi
+  if [[ -n "${status}" ]]; then
+    echo "Expected failed ${FAILED_INVENTORY_STATUS} inventory stdout to be empty, got: ${status}" >&2
+    exit 1
+  fi
+  : >"${FAILED_INVENTORY_REAP_LOG}"
+  maybe_reap_stale_profile_processes workcell-fail-after-output
+  if [[ -s "${FAILED_INVENTORY_REAP_LOG}" ]]; then
+    echo "Expected failed ${FAILED_INVENTORY_STATUS} inventory not to trigger reaping" >&2
+    exit 1
+  fi
+  assert_no_profile_status_temp_files
+done

--- a/verify/invariants/harnesses/process-colima/colima-profile-status.sh
+++ b/verify/invariants/harnesses/process-colima/colima-profile-status.sh
@@ -31,9 +31,11 @@ go_hostutil() {
 assert_no_profile_status_temp_files() {
   local residue=""
 
-  residue="$(find "${PROFILE_STATUS_TMPDIR}" -type f -name 'workcell-colima-profile-status.*' -print -quit)"
+  residue="$(find "${PROFILE_STATUS_TMPDIR}" \
+    \( -name 'workcell-colima-profile-status.*' -o -name 'workcell-hostutil-stderr.*' \) \
+    -print -quit)"
   if [[ -n "${residue}" ]]; then
-    echo "Expected colima_profile_status to remove its temporary output: ${residue}" >&2
+    echo "Expected colima_profile_status to remove its temporary streams: ${residue}" >&2
     exit 1
   fi
 }
@@ -79,14 +81,18 @@ fi
 assert_no_profile_status_temp_files
 
 missing_status_rc=0
-if colima_profile_status does-not-exist >"${PROFILE_STATUS_TMPDIR}/missing.out" 2>&1; then
-  echo "Expected colima_profile_status to fail for a missing profile" >&2
-  exit 1
-else
-  missing_status_rc=$?
-fi
+set +e
+colima_profile_status does-not-exist \
+  >"${PROFILE_STATUS_TMPDIR}/missing.stdout" \
+  2>"${PROFILE_STATUS_TMPDIR}/missing.stderr"
+missing_status_rc=$?
+set -e
 if ((missing_status_rc != 3)); then
   echo "Expected colima_profile_status to return exit status 3 for a missing profile, got: ${missing_status_rc}" >&2
+  exit 1
+fi
+if [[ -s "${PROFILE_STATUS_TMPDIR}/missing.stdout" ]] || [[ -s "${PROFILE_STATUS_TMPDIR}/missing.stderr" ]]; then
+  echo "Expected a missing profile to keep stdout and stderr empty" >&2
   exit 1
 fi
 assert_no_profile_status_temp_files
@@ -135,7 +141,26 @@ run_host_colima() {
   printf '%s\n' '{not-json'
 }
 
-if [[ -n "$(maybe_reap_stale_profile_processes workcell-parse-failure)" ]]; then
+malformed_status_rc=0
+set +e
+colima_profile_status workcell-parse-failure \
+  >"${PROFILE_STATUS_TMPDIR}/malformed.stdout" \
+  2>"${PROFILE_STATUS_TMPDIR}/malformed.stderr"
+malformed_status_rc=$?
+set -e
+if ((malformed_status_rc != 1)); then
+  echo "Expected malformed profile inventory status 1, got: ${malformed_status_rc}" >&2
+  exit 1
+fi
+if [[ -s "${PROFILE_STATUS_TMPDIR}/malformed.stdout" ]]; then
+  echo "Expected malformed profile inventory stdout to stay empty" >&2
+  exit 1
+fi
+if ! grep -Fq "invalid character 'n'" "${PROFILE_STATUS_TMPDIR}/malformed.stderr"; then
+  echo "Expected malformed profile inventory diagnostic" >&2
+  exit 1
+fi
+if [[ -n "$(maybe_reap_stale_profile_processes workcell-parse-failure 2>/dev/null)" ]]; then
   echo "Expected maybe_reap_stale_profile_processes to ignore parse failures instead of reaping live profiles blindly" >&2
   exit 1
 fi
@@ -144,6 +169,10 @@ assert_no_profile_status_temp_files
 FAILED_INVENTORY_STATUS=""
 FAILED_INVENTORY_REAP_LOG="$(mktemp "${PROFILE_STATUS_TMPDIR}/reap-log.XXXXXX")"
 run_host_colima() {
+  if [[ "${FAILED_INVENTORY_STATUS}" == Malformed ]]; then
+    printf '%s\n' '{not-json'
+    return 17
+  fi
   printf '{"name":"workcell-fail-after-output","status":"%s"}\n' "${FAILED_INVENTORY_STATUS}"
   return 17
 }
@@ -151,21 +180,22 @@ reap_stale_profile_processes() {
   printf 'reaped:%s\n' "$1" >>"${FAILED_INVENTORY_REAP_LOG}"
 }
 
-for FAILED_INVENTORY_STATUS in Running Stopped; do
-  status=""
+for FAILED_INVENTORY_STATUS in Running Stopped Malformed; do
   status_rc=0
-  if status="$(colima_profile_status workcell-fail-after-output)"; then
-    echo "Expected failed ${FAILED_INVENTORY_STATUS} inventory to fail closed" >&2
-    exit 1
-  else
-    status_rc=$?
-  fi
+  : >"${PROFILE_STATUS_TMPDIR}/failed.stdout"
+  : >"${PROFILE_STATUS_TMPDIR}/failed.stderr"
+  set +e
+  colima_profile_status workcell-fail-after-output \
+    >"${PROFILE_STATUS_TMPDIR}/failed.stdout" \
+    2>"${PROFILE_STATUS_TMPDIR}/failed.stderr"
+  status_rc=$?
+  set -e
   if ((status_rc != 1)); then
     echo "Expected failed ${FAILED_INVENTORY_STATUS} inventory status 1, got: ${status_rc}" >&2
     exit 1
   fi
-  if [[ -n "${status}" ]]; then
-    echo "Expected failed ${FAILED_INVENTORY_STATUS} inventory stdout to be empty, got: ${status}" >&2
+  if [[ -s "${PROFILE_STATUS_TMPDIR}/failed.stdout" ]] || [[ -s "${PROFILE_STATUS_TMPDIR}/failed.stderr" ]]; then
+    echo "Expected failed ${FAILED_INVENTORY_STATUS} inventory streams to be empty" >&2
     exit 1
   fi
   : >"${FAILED_INVENTORY_REAP_LOG}"


### PR DESCRIPTION
## Summary

- Limit container inventory, Colima inventory, and Colima status input to 4 MiB.
- Stream Colima data to the host utility without an unbounded shell capture.
- Publish profile status only after the producer and parser succeed.
- Keep an absent managed profile quiet while preserving status 3.
- Preserve diagnostics for other parser failures.
- Limit runtime DNS resolution to five seconds and cancel completed lookups.
- Reject a Colima executable path that is not absolute.

This PR contains the F-009 host-input slice only. It does not include or claim F-013 process-lifecycle changes.

This smaller review unit supersedes #615 for F-009.

## Validation

- Fresh exact-head `pr-parity` passed, including repository validation, invariants, documentation, and container smoke.
- Six-role source review returned CLEAN.
- Exact live Colima input probes, smoke, and the strict provider scenario passed.
- The signed review fix passed focused tests and independent review.
- The PR has 11 files, 424 changed lines, six validator areas, and no binary files.
